### PR TITLE
fix(svg-helper): re-exec Sudoku-18 logY cells 39/42/55 (consumer half of #7010)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb
@@ -3,7 +3,16 @@
   {
    "cell_type": "markdown",
    "id": "10722324",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006111,
+     "end_time": "2026-07-17T10:14:32.658090+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:32.651979+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "**Navigation** : [Index](README.md) | [<< Sudoku-17 Python](Sudoku-17-LLM-Python.ipynb) | [Fin de serie >>]\n",
     "\n",
@@ -29,7 +38,16 @@
   {
    "cell_type": "markdown",
    "id": "5ed20fef",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005769,
+     "end_time": "2026-07-17T10:14:32.670789+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:32.665020+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 1. Introduction\n",
     "\n",
@@ -58,39 +76,162 @@
    "id": "24a731fc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T23:28:07.853658Z",
-     "iopub.status.busy": "2026-07-14T23:28:07.837479Z",
-     "iopub.status.idle": "2026-07-14T23:28:15.887052Z",
-     "shell.execute_reply": "2026-07-14T23:28:15.879356Z"
-    }
+     "iopub.execute_input": "2026-07-17T10:14:32.695622Z",
+     "iopub.status.busy": "2026-07-17T10:14:32.688690Z",
+     "iopub.status.idle": "2026-07-17T10:14:36.660672Z",
+     "shell.execute_reply": "2026-07-17T10:14:36.656100Z"
+    },
+    "papermill": {
+     "duration": 3.983932,
+     "end_time": "2026-07-17T10:14:36.660802+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:32.676870+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "display_data",
-     "metadata": {},
      "data": {
       "text/html": [
-       "<div><div></div><div><strong>Installing Packages</strong><ul><li><span>Google.OrTools</span></li></ul></div><div></div></div>"
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%29:2048/\",\"http://172.28.48.1:2048/\",\"http://fe80::818a:531e:963d:fa0%44:2048/\",\"http://172.21.192.1:2048/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2048/\",\"http://2a01:e0a:9d4:f320:247d:c5e2:fe1b:ede8:2048/\",\"http://2a01:e0a:9d4:f320:25d1:1d81:dfec:9cb9:2048/\",\"http://2a01:e0a:9d4:f320:955e:fef7:64b4:d353:2048/\",\"http://fe80::5418:77a8:a4bf:a1ed%15:2048/\",\"http://192.168.0.49:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '827012.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
       ]
-     }
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "output_type": "stream",
+     "data": {
+      "text/html": [
+       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>Google.OrTools, 9.15.6755</span></li></ul></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Environnement charge.\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  .NET 10.0.10\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  Google.OrTools CP-SAT importe\r\n"
      ]
@@ -125,7 +266,16 @@
   {
    "cell_type": "markdown",
    "id": "466f92a0",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005971,
+     "end_time": "2026-07-17T10:14:36.672656+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:36.666685+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Environnement et dependances\n",
     "\n",
@@ -149,7 +299,16 @@
   {
    "cell_type": "markdown",
    "id": "58e50755",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00617,
+     "end_time": "2026-07-17T10:14:36.684661+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:36.678491+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 2. Categories d'approches\n",
     "\n",
@@ -201,7 +360,16 @@
   {
    "cell_type": "markdown",
    "id": "03d53a67",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00651,
+     "end_time": "2026-07-17T10:14:36.697591+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:36.691081+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 3. Implementations Python des solveurs\n",
     "\n",
@@ -225,23 +393,31 @@
    "id": "00f6d107",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T23:28:15.889705Z",
-     "iopub.status.busy": "2026-07-14T23:28:15.889371Z",
-     "iopub.status.idle": "2026-07-14T23:28:16.999544Z",
-     "shell.execute_reply": "2026-07-14T23:28:16.998849Z"
-    }
+     "iopub.execute_input": "2026-07-17T10:14:36.713445Z",
+     "iopub.status.busy": "2026-07-17T10:14:36.713216Z",
+     "iopub.status.idle": "2026-07-17T10:14:37.211881Z",
+     "shell.execute_reply": "2026-07-17T10:14:37.211578Z"
+    },
+    "papermill": {
+     "duration": 0.507278,
+     "end_time": "2026-07-17T10:14:37.211980+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:36.704702+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Grille de test:\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       ". . 3 | . 2 . | 6 . . \n",
       "9 . . | 3 . 5 | . . 1 \n",
@@ -257,8 +433,8 @@
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Cases vides: 49\r\n"
      ]
@@ -360,7 +536,16 @@
   {
    "cell_type": "markdown",
    "id": "10f6daa2",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007947,
+     "end_time": "2026-07-17T10:14:37.227463+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:37.219516+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Classe SudokuGrid - Representation commune\n",
     "\n",
@@ -385,7 +570,16 @@
   {
    "cell_type": "markdown",
    "id": "a0a8833a",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.015367,
+     "end_time": "2026-07-17T10:14:37.252005+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:37.236638+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 3.1 Solveur 1 : Backtracking simple\n",
     "\n",
@@ -400,18 +594,26 @@
    "id": "8da8f9e7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T23:28:17.003210Z",
-     "iopub.status.busy": "2026-07-14T23:28:17.002855Z",
-     "iopub.status.idle": "2026-07-14T23:28:17.143122Z",
-     "shell.execute_reply": "2026-07-14T23:28:17.142892Z"
-    }
+     "iopub.execute_input": "2026-07-17T10:14:37.275739Z",
+     "iopub.status.busy": "2026-07-17T10:14:37.275414Z",
+     "iopub.status.idle": "2026-07-17T10:14:37.368466Z",
+     "shell.execute_reply": "2026-07-17T10:14:37.368280Z"
+    },
+    "papermill": {
+     "duration": 0.106399,
+     "end_time": "2026-07-17T10:14:37.368557+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:37.262158+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "Backtracking simple: resolu=True, 201 appels, 0.80 ms\r\n"
+      "Backtracking simple: resolu=True, 201 appels, 0.85 ms\r\n"
      ]
     }
    ],
@@ -460,7 +662,16 @@
   {
    "cell_type": "markdown",
    "id": "412a107e",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.009036,
+     "end_time": "2026-07-17T10:14:37.385921+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:37.376885+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Solveur Backtracking simple\n",
     "\n",
@@ -486,7 +697,16 @@
   {
    "cell_type": "markdown",
    "id": "405f9279",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00724,
+     "end_time": "2026-07-17T10:14:37.400551+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:37.393311+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Exercice : Propagation des singletons (Naked Singles)\n",
     "\n",
@@ -510,79 +730,87 @@
    "id": "6b9322a1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T23:28:17.145442Z",
-     "iopub.status.busy": "2026-07-14T23:28:17.145157Z",
-     "iopub.status.idle": "2026-07-14T23:28:17.487375Z",
-     "shell.execute_reply": "2026-07-14T23:28:17.486094Z"
-    }
+     "iopub.execute_input": "2026-07-17T10:14:37.419350Z",
+     "iopub.status.busy": "2026-07-17T10:14:37.419064Z",
+     "iopub.status.idle": "2026-07-17T10:14:37.561334Z",
+     "shell.execute_reply": "2026-07-17T10:14:37.561182Z"
+    },
+    "papermill": {
+     "duration": 0.152271,
+     "end_time": "2026-07-17T10:14:37.561411+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:37.409140+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Cases remplies par propagation : 0\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "[0, 0, 0, 2, 6, 0, 7, 0, 1]\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "[6, 8, 0, 0, 7, 0, 0, 9, 0]\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "[1, 9, 0, 0, 0, 4, 5, 0, 0]\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "[8, 2, 0, 1, 0, 0, 0, 4, 0]\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "[0, 0, 4, 6, 0, 2, 9, 0, 0]\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "[0, 5, 0, 0, 0, 3, 0, 2, 8]\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "[0, 0, 9, 3, 0, 0, 0, 7, 4]\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "[0, 4, 0, 0, 5, 0, 0, 3, 6]\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "[7, 0, 3, 0, 1, 8, 0, 0, 0]\r\n"
      ]
@@ -620,7 +848,16 @@
   {
    "cell_type": "markdown",
    "id": "c277aa05",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006902,
+     "end_time": "2026-07-17T10:14:37.574838+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:37.567936+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 3.2 Solveur 2 : Backtracking avec MRV\n",
     "\n",
@@ -635,18 +872,26 @@
    "id": "8b60c557",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T23:28:17.495059Z",
-     "iopub.status.busy": "2026-07-14T23:28:17.493538Z",
-     "iopub.status.idle": "2026-07-14T23:28:17.845258Z",
-     "shell.execute_reply": "2026-07-14T23:28:17.844609Z"
-    }
+     "iopub.execute_input": "2026-07-17T10:14:37.588592Z",
+     "iopub.status.busy": "2026-07-17T10:14:37.588403Z",
+     "iopub.status.idle": "2026-07-17T10:14:37.714280Z",
+     "shell.execute_reply": "2026-07-17T10:14:37.713988Z"
+    },
+    "papermill": {
+     "duration": 0.133029,
+     "end_time": "2026-07-17T10:14:37.714368+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:37.581339+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "Backtracking MRV: resolu=True, 50 appels, 2.75 ms\r\n"
+      "Backtracking MRV: resolu=True, 50 appels, 2.06 ms\r\n"
      ]
     }
    ],
@@ -725,7 +970,16 @@
   {
    "cell_type": "markdown",
    "id": "0085d323",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00579,
+     "end_time": "2026-07-17T10:14:37.726641+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:37.720851+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Solveur Backtracking avec MRV\n",
     "\n",
@@ -752,7 +1006,16 @@
   {
    "cell_type": "markdown",
    "id": "b0693e8f",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.0057,
+     "end_time": "2026-07-17T10:14:37.738041+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:37.732341+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 3.3 Solveur 3 : Propagation de contraintes (Norvig)\n",
     "\n",
@@ -770,18 +1033,26 @@
    "id": "9d2dcedb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T23:28:17.849805Z",
-     "iopub.status.busy": "2026-07-14T23:28:17.849155Z",
-     "iopub.status.idle": "2026-07-14T23:28:18.477453Z",
-     "shell.execute_reply": "2026-07-14T23:28:18.477027Z"
-    }
+     "iopub.execute_input": "2026-07-17T10:14:37.750858Z",
+     "iopub.status.busy": "2026-07-17T10:14:37.750646Z",
+     "iopub.status.idle": "2026-07-17T10:14:37.997346Z",
+     "shell.execute_reply": "2026-07-17T10:14:37.997197Z"
+    },
+    "papermill": {
+     "duration": 0.253539,
+     "end_time": "2026-07-17T10:14:37.997419+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:37.743880+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "Norvig: resolu=True, 1 appels, 3.26 ms\r\n"
+      "Norvig: resolu=True, 1 appels, 3.55 ms\r\n"
      ]
     }
    ],
@@ -904,7 +1175,16 @@
   {
    "cell_type": "markdown",
    "id": "811aaf8a",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.008241,
+     "end_time": "2026-07-17T10:14:38.012655+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:38.004414+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Solveur Norvig (propagation de contraintes)\n",
     "\n",
@@ -932,7 +1212,16 @@
   {
    "cell_type": "markdown",
    "id": "17fc7b2b",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.008094,
+     "end_time": "2026-07-17T10:14:38.028760+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:38.020666+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 3.4 Solveur 4 : OR-Tools CP-SAT\n",
     "\n",
@@ -951,18 +1240,26 @@
    "id": "1724f011",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T23:28:18.480689Z",
-     "iopub.status.busy": "2026-07-14T23:28:18.480300Z",
-     "iopub.status.idle": "2026-07-14T23:28:18.837906Z",
-     "shell.execute_reply": "2026-07-14T23:28:18.837296Z"
-    }
+     "iopub.execute_input": "2026-07-17T10:14:38.046927Z",
+     "iopub.status.busy": "2026-07-17T10:14:38.046661Z",
+     "iopub.status.idle": "2026-07-17T10:14:38.213746Z",
+     "shell.execute_reply": "2026-07-17T10:14:38.213595Z"
+    },
+    "papermill": {
+     "duration": 0.17695,
+     "end_time": "2026-07-17T10:14:38.213819+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:38.036869+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "OR-Tools CP-SAT: resolu=True, 65.55 ms\r\n"
+      "OR-Tools CP-SAT: resolu=True, 70.58 ms\r\n"
      ]
     }
    ],
@@ -1019,7 +1316,16 @@
   {
    "cell_type": "markdown",
    "id": "f929b306",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007324,
+     "end_time": "2026-07-17T10:14:38.227809+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:38.220485+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Solveur OR-Tools CP-SAT\n",
     "\n",
@@ -1044,7 +1350,16 @@
   {
    "cell_type": "markdown",
    "id": "65f5c85d",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00794,
+     "end_time": "2026-07-17T10:14:38.243773+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:38.235833+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Exercice : Verifier l'unicite de la solution avec OR-Tools\n",
     "\n",
@@ -1066,23 +1381,31 @@
    "id": "b756d9ab",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T23:28:18.842247Z",
-     "iopub.status.busy": "2026-07-14T23:28:18.841511Z",
-     "iopub.status.idle": "2026-07-14T23:28:19.060588Z",
-     "shell.execute_reply": "2026-07-14T23:28:19.059869Z"
-    }
+     "iopub.execute_input": "2026-07-17T10:14:38.262637Z",
+     "iopub.status.busy": "2026-07-17T10:14:38.262322Z",
+     "iopub.status.idle": "2026-07-17T10:14:38.337179Z",
+     "shell.execute_reply": "2026-07-17T10:14:38.337046Z"
+    },
+    "papermill": {
+     "duration": 0.084813,
+     "end_time": "2026-07-17T10:14:38.337243+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:38.252430+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "OR-Tools disponible pour le test.\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Solution unique : True\r\n"
      ]
@@ -1117,7 +1440,16 @@
   {
    "cell_type": "markdown",
    "id": "f5e64253",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006072,
+     "end_time": "2026-07-17T10:14:38.349566+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:38.343494+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 4. Benchmark\n",
     "\n",
@@ -1139,79 +1471,87 @@
    "id": "b0ae1603",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T23:28:19.065019Z",
-     "iopub.status.busy": "2026-07-14T23:28:19.064252Z",
-     "iopub.status.idle": "2026-07-14T23:28:19.401526Z",
-     "shell.execute_reply": "2026-07-14T23:28:19.400533Z"
-    }
+     "iopub.execute_input": "2026-07-17T10:14:38.362477Z",
+     "iopub.status.busy": "2026-07-17T10:14:38.362300Z",
+     "iopub.status.idle": "2026-07-17T10:14:38.470401Z",
+     "shell.execute_reply": "2026-07-17T10:14:38.470240Z"
+    },
+    "papermill": {
+     "duration": 0.114993,
+     "end_time": "2026-07-17T10:14:38.470482+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:38.355489+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Puzzles charges :\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  Easy:   10 puzzles\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  Medium: 10 puzzles\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  Hard:   10 puzzles\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  Expert: 1 puzzles\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  Easy: 45-57 cases vides (moy: 51.4)\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  Medium: 64-64 cases vides (moy: 64.0)\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  Hard: 53-59 cases vides (moy: 56.2)\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  Expert: 59-59 cases vides (moy: 59.0)\r\n"
      ]
@@ -1278,7 +1618,16 @@
   {
    "cell_type": "markdown",
    "id": "2d71dd3a",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007376,
+     "end_time": "2026-07-17T10:14:38.485060+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:38.477684+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Jeux de test et profil des puzzles\n",
     "\n",
@@ -1302,7 +1651,16 @@
   {
    "cell_type": "markdown",
    "id": "d664416f",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.008029,
+     "end_time": "2026-07-17T10:14:38.500880+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:38.492851+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Execution du benchmark\n",
     "\n",
@@ -1315,23 +1673,31 @@
    "id": "03ad4f8a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T23:28:19.406233Z",
-     "iopub.status.busy": "2026-07-14T23:28:19.405494Z",
-     "iopub.status.idle": "2026-07-14T23:28:19.720697Z",
-     "shell.execute_reply": "2026-07-14T23:28:19.720165Z"
-    }
+     "iopub.execute_input": "2026-07-17T10:14:38.520191Z",
+     "iopub.status.busy": "2026-07-17T10:14:38.519900Z",
+     "iopub.status.idle": "2026-07-17T10:14:38.671990Z",
+     "shell.execute_reply": "2026-07-17T10:14:38.671862Z"
+    },
+    "papermill": {
+     "duration": 0.163348,
+     "end_time": "2026-07-17T10:14:38.672055+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:38.508707+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Solveurs configures : Backtracking, BT + MRV, Norvig, OR-Tools CP-SAT\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Puzzles disponibles : Easy, Medium, Hard, Expert\r\n"
      ]
@@ -1368,7 +1734,16 @@
   {
    "cell_type": "markdown",
    "id": "f1ac6593",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007407,
+     "end_time": "2026-07-17T10:14:38.686535+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:38.679128+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Configuration du benchmark\n",
     "\n",
@@ -1381,16 +1756,24 @@
    "id": "9d2a4ec5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T23:28:19.724683Z",
-     "iopub.status.busy": "2026-07-14T23:28:19.723938Z",
-     "iopub.status.idle": "2026-07-14T23:28:20.169527Z",
-     "shell.execute_reply": "2026-07-14T23:28:20.168550Z"
-    }
+     "iopub.execute_input": "2026-07-17T10:14:38.705855Z",
+     "iopub.status.busy": "2026-07-17T10:14:38.705631Z",
+     "iopub.status.idle": "2026-07-17T10:14:38.806031Z",
+     "shell.execute_reply": "2026-07-17T10:14:38.805907Z"
+    },
+    "papermill": {
+     "duration": 0.110167,
+     "end_time": "2026-07-17T10:14:38.806093+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:38.695926+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Fonction definie : RunBenchmark\r\n"
      ]
@@ -1454,7 +1837,16 @@
   {
    "cell_type": "markdown",
    "id": "ef267990",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006392,
+     "end_time": "2026-07-17T10:14:38.818772+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:38.812380+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lancement du benchmark\n",
     "\n",
@@ -1467,23 +1859,31 @@
    "id": "b8f463f6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T23:28:20.174954Z",
-     "iopub.status.busy": "2026-07-14T23:28:20.173910Z",
-     "iopub.status.idle": "2026-07-14T23:28:28.996107Z",
-     "shell.execute_reply": "2026-07-14T23:28:28.995838Z"
-    }
+     "iopub.execute_input": "2026-07-17T10:14:38.833708Z",
+     "iopub.status.busy": "2026-07-17T10:14:38.833483Z",
+     "iopub.status.idle": "2026-07-17T10:14:43.011007Z",
+     "shell.execute_reply": "2026-07-17T10:14:43.010875Z"
+    },
+    "papermill": {
+     "duration": 4.185837,
+     "end_time": "2026-07-17T10:14:43.011071+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:38.825234+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Benchmark en cours (1 puzzle par difficulte, timeout 10s)...\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Termine.\r\n"
      ]
@@ -1499,7 +1899,16 @@
   {
    "cell_type": "markdown",
    "id": "17767b6e",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00622,
+     "end_time": "2026-07-17T10:14:43.023641+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:43.017421+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Tableau recapitulatif des resultats\n",
     "\n",
@@ -1514,97 +1923,105 @@
    "id": "a2b96f5e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T23:28:28.998677Z",
-     "iopub.status.busy": "2026-07-14T23:28:28.998072Z",
-     "iopub.status.idle": "2026-07-14T23:28:29.153721Z",
-     "shell.execute_reply": "2026-07-14T23:28:29.152995Z"
-    }
+     "iopub.execute_input": "2026-07-17T10:14:43.037123Z",
+     "iopub.status.busy": "2026-07-17T10:14:43.036957Z",
+     "iopub.status.idle": "2026-07-17T10:14:43.121349Z",
+     "shell.execute_reply": "2026-07-17T10:14:43.121225Z"
+    },
+    "papermill": {
+     "duration": 0.091781,
+     "end_time": "2026-07-17T10:14:43.121411+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:43.029630+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "=== Resultats du benchmark ===\n",
       "\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Solveur            |      Easy (ms)   Taux |    Medium (ms)   Taux |      Hard (ms)   Taux |    Expert (ms)   Taux\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "------------------------------------------------------------------------------------------------------------------\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "Backtracking       |           0.85    1/1 |        4476.84    0/1 |         300.94    1/1 |          77.33    1/1\r\n"
+      "Backtracking       |           0.66    1/1 |        3655.86    0/1 |         230.30    1/1 |          61.51    1/1\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "BT + MRV           |           1.84    1/1 |          18.55    1/1 |          96.08    1/1 |           8.36    1/1\r\n"
+      "BT + MRV           |           1.16    1/1 |          13.22    1/1 |          94.39    1/1 |           7.99    1/1\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "Norvig             |           2.56    1/1 |           2.74    1/1 |           2.03    1/1 |           2.53    1/1\r\n"
+      "Norvig             |           3.53    1/1 |           3.74    1/1 |           2.22    1/1 |           2.32    1/1\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "OR-Tools CP-SAT    |          21.84    1/1 |          15.45    1/1 |          15.72    1/1 |          15.35    1/1\r\n"
+      "OR-Tools CP-SAT    |          15.38    1/1 |          15.76    1/1 |          14.86    1/1 |          15.26    1/1\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "\n",
       "--- Temps moyen global (toutes difficultes confondues) ---\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "  Backtracking      :  1213.99 ms/puzzle, 3/4 resolus\r\n"
+      "  Backtracking      :   987.08 ms/puzzle, 3/4 resolus\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "  BT + MRV          :    31.21 ms/puzzle, 4/4 resolus\r\n"
+      "  BT + MRV          :    29.19 ms/puzzle, 4/4 resolus\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "  Norvig            :     2.46 ms/puzzle, 4/4 resolus\r\n"
+      "  Norvig            :     2.95 ms/puzzle, 4/4 resolus\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "  OR-Tools CP-SAT   :    17.09 ms/puzzle, 4/4 resolus\r\n"
+      "  OR-Tools CP-SAT   :    15.32 ms/puzzle, 4/4 resolus\r\n"
      ]
     }
    ],
@@ -1650,7 +2067,16 @@
   {
    "cell_type": "markdown",
    "id": "f977952e",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00771,
+     "end_time": "2026-07-17T10:14:43.135891+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:43.128181+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Exercice : Analyser la robustesse des solveurs face aux puzzles partiels\n",
     "\n",
@@ -1669,11 +2095,19 @@
    "id": "d3a1fe6c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T23:28:29.156511Z",
-     "iopub.status.busy": "2026-07-14T23:28:29.156107Z",
-     "iopub.status.idle": "2026-07-14T23:28:29.231287Z",
-     "shell.execute_reply": "2026-07-14T23:28:29.230931Z"
-    }
+     "iopub.execute_input": "2026-07-17T10:14:43.154675Z",
+     "iopub.status.busy": "2026-07-17T10:14:43.154442Z",
+     "iopub.status.idle": "2026-07-17T10:14:43.197503Z",
+     "shell.execute_reply": "2026-07-17T10:14:43.197352Z"
+    },
+    "papermill": {
+     "duration": 0.052478,
+     "end_time": "2026-07-17T10:14:43.197571+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:43.145093+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -1691,7 +2125,16 @@
   {
    "cell_type": "markdown",
    "id": "04ab291e",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006995,
+     "end_time": "2026-07-17T10:14:43.212339+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:43.205344+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Resultats du benchmark\n",
     "\n",
@@ -1711,7 +2154,16 @@
   {
    "cell_type": "markdown",
    "id": "5eeab716",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007042,
+     "end_time": "2026-07-17T10:14:43.226476+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:43.219434+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Visualisation : temps moyen par difficulte\n",
     "\n",
@@ -1724,28 +2176,36 @@
    "id": "dc4ecdb4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T23:28:29.235124Z",
-     "iopub.status.busy": "2026-07-14T23:28:29.234404Z",
-     "iopub.status.idle": "2026-07-14T23:28:29.516498Z",
-     "shell.execute_reply": "2026-07-14T23:28:29.515496Z"
-    }
+     "iopub.execute_input": "2026-07-17T10:14:43.241838Z",
+     "iopub.status.busy": "2026-07-17T10:14:43.241645Z",
+     "iopub.status.idle": "2026-07-17T10:14:43.929900Z",
+     "shell.execute_reply": "2026-07-17T10:14:43.929761Z"
+    },
+    "papermill": {
+     "duration": 0.696587,
+     "end_time": "2026-07-17T10:14:43.929969+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:43.233382+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Fonction definie : PlotBenchmarkBarsSvg (SvgChartHelper.GroupedBar logY).\r\n"
      ]
     },
     {
-     "output_type": "display_data",
-     "metadata": {},
      "data": {
       "text/html": [
-       "<svg xmlns='http://www.w3.org/2000/svg' width='720' height='400' viewBox='0 0 720 400' font-family='sans-serif' font-size='12'><rect width='720' height='400' fill='white'/><text x='360' y='20' text-anchor='middle' font-size='14' font-weight='bold' fill='#333333'>Benchmark : temps moyen (ms) par difficulte et solveur (axe Y log)</text><line x1='52' y1='358' x2='704' y2='358' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='362' text-anchor='end' fill='#333333'>0</text><line x1='52' y1='277' x2='704' y2='277' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='281' text-anchor='end' fill='#333333'>1208.747</text><line x1='52' y1='196' x2='704' y2='196' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='200' text-anchor='end' fill='#333333'>2417.495</text><line x1='52' y1='115' x2='704' y2='115' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='119' text-anchor='end' fill='#333333'>3626.242</text><line x1='52' y1='34' x2='704' y2='34' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='38' text-anchor='end' fill='#333333'>4834.99</text><line x1='52' y1='34' x2='52' y2='358' stroke='#888888' stroke-width='1'/><line x1='52' y1='358' x2='704' y2='358' stroke='#888888' stroke-width='1'/><text x='44' y='-183.744' text-anchor='end' fill='#333333'>10^2</text><line x1='48' y1='-187.744' x2='52' y2='-187.744' stroke='#888888' stroke-width='1'/><text x='44' y='140.256' text-anchor='end' fill='#333333'>10^3</text><line x1='48' y1='136.256' x2='52' y2='136.256' stroke='#888888' stroke-width='1'/><text x='44' y='464.256' text-anchor='end' fill='#333333'>10^4</text><line x1='48' y1='460.256' x2='52' y2='460.256' stroke='#888888' stroke-width='1'/><rect x='68.3' y='1251.409' width='32.6' height='-893.409' fill='#4C72B0'/><rect x='100.9' y='1141.622' width='32.6' height='-783.622' fill='#55A868'/><rect x='133.5' y='1095.568' width='32.6' height='-737.568' fill='#DD8452'/><rect x='166.1' y='793.836' width='32.6' height='-435.836' fill='#C44E52'/><text x='133.5' y='374' text-anchor='middle' fill='#333333'>Easy</text><rect x='231.3' y='44.829' width='32.6' height='313.171' fill='#4C72B0'/><rect x='263.9' y='816.795' width='32.6' height='-458.795' fill='#55A868'/><rect x='296.5' y='1085.964' width='32.6' height='-727.964' fill='#DD8452'/><rect x='329.1' y='842.514' width='32.6' height='-484.514' fill='#C44E52'/><text x='296.5' y='374' text-anchor='middle' fill='#333333'>Medium</text><rect x='394.3' y='424.715' width='32.6' height='-66.715' fill='#4C72B0'/><rect x='426.9' y='585.37' width='32.6' height='-227.37' fill='#55A868'/><rect x='459.5' y='1127.977' width='32.6' height='-769.977' fill='#DD8452'/><rect x='492.1' y='840.111' width='32.6' height='-482.111' fill='#C44E52'/><text x='459.5' y='374' text-anchor='middle' fill='#333333'>Hard</text><rect x='557.3' y='615.927' width='32.6' height='-257.927' fill='#4C72B0'/><rect x='589.9' y='928.97' width='32.6' height='-570.97' fill='#55A868'/><rect x='622.5' y='1097.378' width='32.6' height='-739.378' fill='#DD8452'/><rect x='655.1' y='843.418' width='32.6' height='-485.418' fill='#C44E52'/><text x='622.5' y='374' text-anchor='middle' fill='#333333'>Expert</text><rect x='532' y='42' width='168' height='86' fill='white' stroke='#E5E5E5' stroke-width='1'/><rect x='544' y='49' width='12' height='8' fill='#4C72B0'/><text x='562' y='58' fill='#333333'>Backtracking</text><rect x='544' y='67' width='12' height='8' fill='#55A868'/><text x='562' y='76' fill='#333333'>BT + MRV</text><rect x='544' y='85' width='12' height='8' fill='#DD8452'/><text x='562' y='94' fill='#333333'>Norvig</text><rect x='544' y='103' width='12' height='8' fill='#C44E52'/><text x='562' y='112' fill='#333333'>OR-Tools CP-SAT</text></svg>"
+       "<svg xmlns='http://www.w3.org/2000/svg' width='720' height='400' viewBox='0 0 720 400' font-family='sans-serif' font-size='12'><rect width='720' height='400' fill='white'/><text x='360' y='20' text-anchor='middle' font-size='14' font-weight='bold' fill='#333333'>Benchmark : temps moyen (ms) par difficulte et solveur (axe Y log)</text><line x1='52' y1='349.908' x2='704' y2='349.908' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='353.908' text-anchor='end' fill='#333333'>0.5</text><line x1='52' y1='326.649' x2='704' y2='326.649' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='330.649' text-anchor='end' fill='#333333'>1</text><line x1='52' y1='303.39' x2='704' y2='303.39' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='307.39' text-anchor='end' fill='#333333'>2</text><line x1='52' y1='272.644' x2='704' y2='272.644' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='276.644' text-anchor='end' fill='#333333'>5</text><line x1='52' y1='249.385' x2='704' y2='249.385' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='253.385' text-anchor='end' fill='#333333'>10</text><line x1='52' y1='226.126' x2='704' y2='226.126' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='230.126' text-anchor='end' fill='#333333'>20</text><line x1='52' y1='195.379' x2='704' y2='195.379' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='199.379' text-anchor='end' fill='#333333'>50</text><line x1='52' y1='172.12' x2='704' y2='172.12' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='176.12' text-anchor='end' fill='#333333'>100</text><line x1='52' y1='148.862' x2='704' y2='148.862' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='152.862' text-anchor='end' fill='#333333'>200</text><line x1='52' y1='118.115' x2='704' y2='118.115' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='122.115' text-anchor='end' fill='#333333'>500</text><line x1='52' y1='94.856' x2='704' y2='94.856' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='98.856' text-anchor='end' fill='#333333'>1000</text><line x1='52' y1='71.597' x2='704' y2='71.597' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='75.597' text-anchor='end' fill='#333333'>2000</text><line x1='52' y1='40.851' x2='704' y2='40.851' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='44.851' text-anchor='end' fill='#333333'>5000</text><line x1='52' y1='34' x2='52' y2='358' stroke='#888888' stroke-width='1'/><line x1='52' y1='358' x2='704' y2='358' stroke='#888888' stroke-width='1'/><rect x='68.3' y='340.643' width='32.6' height='17.357' fill='#4C72B0'/><rect x='100.9' y='321.701' width='32.6' height='36.299' fill='#55A868'/><rect x='133.5' y='284.291' width='32.6' height='73.709' fill='#DD8452'/><rect x='166.1' y='234.933' width='32.6' height='123.067' fill='#C44E52'/><text x='133.5' y='374' text-anchor='middle' fill='#333333'>Easy</text><rect x='231.3' y='51.357' width='32.6' height='306.643' fill='#4C72B0'/><rect x='263.9' y='240.018' width='32.6' height='117.982' fill='#55A868'/><rect x='296.5' y='282.378' width='32.6' height='75.622' fill='#DD8452'/><rect x='329.1' y='234.125' width='32.6' height='123.875' fill='#C44E52'/><text x='296.5' y='374' text-anchor='middle' fill='#333333'>Medium</text><rect x='394.3' y='144.128' width='32.6' height='213.872' fill='#4C72B0'/><rect x='426.9' y='174.057' width='32.6' height='183.943' fill='#55A868'/><rect x='459.5' y='299.845' width='32.6' height='58.155' fill='#DD8452'/><rect x='492.1' y='236.096' width='32.6' height='121.904' fill='#C44E52'/><text x='459.5' y='374' text-anchor='middle' fill='#333333'>Hard</text><rect x='557.3' y='188.43' width='32.6' height='169.57' fill='#4C72B0'/><rect x='589.9' y='256.933' width='32.6' height='101.067' fill='#55A868'/><rect x='622.5' y='298.453' width='32.6' height='59.547' fill='#DD8452'/><rect x='655.1' y='235.197' width='32.6' height='122.803' fill='#C44E52'/><text x='622.5' y='374' text-anchor='middle' fill='#333333'>Expert</text><rect x='532' y='42' width='168' height='86' fill='white' stroke='#E5E5E5' stroke-width='1'/><rect x='544' y='49' width='12' height='8' fill='#4C72B0'/><text x='562' y='58' fill='#333333'>Backtracking</text><rect x='544' y='67' width='12' height='8' fill='#55A868'/><text x='562' y='76' fill='#333333'>BT + MRV</text><rect x='544' y='85' width='12' height='8' fill='#DD8452'/><text x='562' y='94' fill='#333333'>Norvig</text><rect x='544' y='103' width='12' height='8' fill='#C44E52'/><text x='562' y='112' fill='#333333'>OR-Tools CP-SAT</text></svg>"
       ]
-     }
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -1780,7 +2240,16 @@
   {
    "cell_type": "markdown",
    "id": "d0a4ff6c",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00691,
+     "end_time": "2026-07-17T10:14:43.943701+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:43.936791+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Ecarts de performance entre solveurs\n",
     "\n",
@@ -1798,7 +2267,16 @@
   {
    "cell_type": "markdown",
    "id": "f0ba5897",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007608,
+     "end_time": "2026-07-17T10:14:43.958846+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:43.951238+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Visualisation : distribution des temps par solveur\n",
     "\n",
@@ -1811,25 +2289,33 @@
    "id": "89517112",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T23:28:29.519499Z",
-     "iopub.status.busy": "2026-07-14T23:28:29.519110Z",
-     "iopub.status.idle": "2026-07-14T23:28:29.679578Z",
-     "shell.execute_reply": "2026-07-14T23:28:29.678845Z"
-    }
+     "iopub.execute_input": "2026-07-17T10:14:43.976228Z",
+     "iopub.status.busy": "2026-07-17T10:14:43.976022Z",
+     "iopub.status.idle": "2026-07-17T10:14:44.466821Z",
+     "shell.execute_reply": "2026-07-17T10:14:44.466655Z"
+    },
+    "papermill": {
+     "duration": 0.500176,
+     "end_time": "2026-07-17T10:14:44.466951+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:43.966775+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "display_data",
-     "metadata": {},
      "data": {
       "text/html": [
-       "<svg xmlns='http://www.w3.org/2000/svg' width='820' height='420' viewBox='0 0 820 420' font-family='sans-serif' font-size='12'><rect width='820' height='420' fill='white'/><text x='410' y='20' text-anchor='middle' font-size='14' font-weight='bold' fill='#333333'>Distribution des temps de resolution (ms) -- logY, n=16 observations</text><line x1='52' y1='378' x2='804' y2='378' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='382' text-anchor='end' fill='#333333'>2.651</text><line x1='52' y1='292' x2='804' y2='292' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='296' text-anchor='end' fill='#333333'>2.901</text><line x1='52' y1='206' x2='804' y2='206' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='210' text-anchor='end' fill='#333333'>3.151</text><line x1='52' y1='120' x2='804' y2='120' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='124' text-anchor='end' fill='#333333'>3.401</text><line x1='52' y1='34' x2='804' y2='34' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='38' text-anchor='end' fill='#333333'>3.651</text><line x1='52' y1='34' x2='52' y2='378' stroke='#888888' stroke-width='1'/><line x1='52' y1='378' x2='804' y2='378' stroke='#888888' stroke-width='1'/><text x='44' y='605.934' text-anchor='end' fill='#333333'>10^2</text><text x='44' y='261.934' text-anchor='end' fill='#333333'>10^3</text><text x='44' y='-82.066' text-anchor='end' fill='#333333'>10^4</text><rect x='108.4' y='213.663' width='75.2' height='469.124' fill='#4C72B0' fill-opacity='0.6' stroke='#4C72B0' stroke-width='1.5'/><line x1='108.4' y1='506.725' x2='183.6' y2='506.725' stroke='#333333' stroke-width='2'/><line x1='146' y1='682.787' x2='146' y2='1315.06' stroke='#4C72B0' stroke-width='1.5'/><line x1='146' y1='213.663' x2='146' y2='80.702' stroke='#4C72B0' stroke-width='1.5'/><line x1='127.2' y1='1315.06' x2='164.8' y2='1315.06' stroke='#4C72B0' stroke-width='1.5'/><line x1='127.2' y1='80.702' x2='164.8' y2='80.702' stroke='#4C72B0' stroke-width='1.5'/><circle cx='149.792' cy='1315.06' r='2.5' fill='#4C72B0' fill-opacity='0.5'/><circle cx='137.899' cy='640.351' r='2.5' fill='#4C72B0' fill-opacity='0.5'/><circle cx='137.552' cy='437.335' r='2.5' fill='#4C72B0' fill-opacity='0.5'/><circle cx='146.514' cy='34' r='2.5' fill='#4C72B0' fill-opacity='0.5'/><text x='146' y='394' text-anchor='middle' fill='#333333'>Backtracking</text><rect x='296.4' y='746.751' width='75.2' height='258.343' fill='#55A868' fill-opacity='0.6' stroke='#55A868' stroke-width='1.5'/><line x1='296.4' y1='901.601' x2='371.6' y2='901.601' stroke='#333333' stroke-width='2'/><line x1='334' y1='1005.094' x2='334' y2='1198.496' stroke='#55A868' stroke-width='1.5'/><line x1='334' y1='746.751' x2='334' y2='626.675' stroke='#55A868' stroke-width='1.5'/><line x1='315.2' y1='1198.496' x2='352.8' y2='1198.496' stroke='#55A868' stroke-width='1.5'/><line x1='315.2' y1='626.675' x2='352.8' y2='626.675' stroke='#55A868' stroke-width='1.5'/><circle cx='326.52' cy='1198.496' r='2.5' fill='#55A868' fill-opacity='0.5'/><circle cx='328.644' cy='972.717' r='2.5' fill='#55A868' fill-opacity='0.5'/><circle cx='339.063' cy='853.618' r='2.5' fill='#55A868' fill-opacity='0.5'/><circle cx='334.292' cy='607.907' r='2.5' fill='#55A868' fill-opacity='0.5'/><text x='334' y='394' text-anchor='middle' fill='#333333'>BT + MRV</text><rect x='484.4' y='1146.984' width='75.2' height='12.021' fill='#DD8452' fill-opacity='0.6' stroke='#DD8452' stroke-width='1.5'/><line x1='484.4' y1='1150.557' x2='559.6' y2='1150.557' stroke='#333333' stroke-width='2'/><line x1='522' y1='1159.005' x2='522' y2='1179.07' stroke='#DD8452' stroke-width='1.5'/><line x1='522' y1='1146.984' x2='522' y2='1139.403' stroke='#DD8452' stroke-width='1.5'/><line x1='503.2' y1='1179.07' x2='540.8' y2='1179.07' stroke='#DD8452' stroke-width='1.5'/><line x1='503.2' y1='1139.403' x2='540.8' y2='1139.403' stroke='#DD8452' stroke-width='1.5'/><circle cx='514.638' cy='1184.009' r='2.5' fill='#DD8452' fill-opacity='0.5'/><circle cx='527.894' cy='1151.521' r='2.5' fill='#DD8452' fill-opacity='0.5'/><circle cx='516.012' cy='1149.599' r='2.5' fill='#DD8452' fill-opacity='0.5'/><circle cx='516.525' cy='1139.403' r='2.5' fill='#DD8452' fill-opacity='0.5'/><text x='522' y='394' text-anchor='middle' fill='#333333'>Norvig</text><rect x='672.4' y='864.494' width='75.2' height='16.67' fill='#C44E52' fill-opacity='0.6' stroke='#C44E52' stroke-width='1.5'/><line x1='672.4' y1='879.643' x2='747.6' y2='879.643' stroke='#333333' stroke-width='2'/><line x1='710' y1='881.164' x2='710' y2='881.885' stroke='#C44E52' stroke-width='1.5'/><line x1='710' y1='864.494' x2='710' y2='842.531' stroke='#C44E52' stroke-width='1.5'/><line x1='691.2' y1='881.885' x2='728.8' y2='881.885' stroke='#C44E52' stroke-width='1.5'/><line x1='691.2' y1='842.531' x2='728.8' y2='842.531' stroke='#C44E52' stroke-width='1.5'/><circle cx='710.126' cy='881.885' r='2.5' fill='#C44E52' fill-opacity='0.5'/><circle cx='705.944' cy='880.925' r='2.5' fill='#C44E52' fill-opacity='0.5'/><circle cx='707.315' cy='878.373' r='2.5' fill='#C44E52' fill-opacity='0.5'/><circle cx='704.591' cy='829.242' r='2.5' fill='#C44E52' fill-opacity='0.5'/><text x='710' y='394' text-anchor='middle' fill='#333333'>OR-Tools CP-SAT</text></svg>"
+       "<svg xmlns='http://www.w3.org/2000/svg' width='820' height='420' viewBox='0 0 820 420' font-family='sans-serif' font-size='12'><rect width='820' height='420' fill='white'/><text x='410' y='20' text-anchor='middle' font-size='14' font-weight='bold' fill='#333333'>Distribution des temps de resolution (ms) -- logY, n=16 observations</text><line x1='52' y1='369.409' x2='804' y2='369.409' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='373.409' text-anchor='end' fill='#333333'>0.5</text><line x1='52' y1='344.714' x2='804' y2='344.714' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='348.714' text-anchor='end' fill='#333333'>1</text><line x1='52' y1='320.019' x2='804' y2='320.019' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='324.019' text-anchor='end' fill='#333333'>2</text><line x1='52' y1='287.375' x2='804' y2='287.375' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='291.375' text-anchor='end' fill='#333333'>5</text><line x1='52' y1='262.68' x2='804' y2='262.68' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='266.68' text-anchor='end' fill='#333333'>10</text><line x1='52' y1='237.986' x2='804' y2='237.986' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='241.986' text-anchor='end' fill='#333333'>20</text><line x1='52' y1='205.341' x2='804' y2='205.341' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='209.341' text-anchor='end' fill='#333333'>50</text><line x1='52' y1='180.646' x2='804' y2='180.646' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='184.646' text-anchor='end' fill='#333333'>100</text><line x1='52' y1='155.952' x2='804' y2='155.952' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='159.952' text-anchor='end' fill='#333333'>200</text><line x1='52' y1='123.307' x2='804' y2='123.307' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='127.307' text-anchor='end' fill='#333333'>500</text><line x1='52' y1='98.613' x2='804' y2='98.613' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='102.613' text-anchor='end' fill='#333333'>1000</text><line x1='52' y1='73.918' x2='804' y2='73.918' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='77.918' text-anchor='end' fill='#333333'>2000</text><line x1='52' y1='41.274' x2='804' y2='41.274' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='45.274' text-anchor='end' fill='#333333'>5000</text><line x1='52' y1='34' x2='52' y2='378' stroke='#888888' stroke-width='1'/><line x1='52' y1='378' x2='804' y2='378' stroke='#888888' stroke-width='1'/><rect x='108.4' y='95.651' width='75.2' height='112.434' fill='#4C72B0' fill-opacity='0.6' stroke='#4C72B0' stroke-width='1.5'/><line x1='108.4' y1='167.188' x2='183.6' y2='167.188' stroke='#333333' stroke-width='2'/><line x1='146' y1='208.085' x2='146' y2='359.571' stroke='#4C72B0' stroke-width='1.5'/><line x1='146' y1='95.651' x2='146' y2='63.929' stroke='#4C72B0' stroke-width='1.5'/><line x1='127.2' y1='359.571' x2='164.8' y2='359.571' stroke='#4C72B0' stroke-width='1.5'/><line x1='127.2' y1='63.929' x2='164.8' y2='63.929' stroke='#4C72B0' stroke-width='1.5'/><circle cx='149.792' cy='359.571' r='2.5' fill='#4C72B0' fill-opacity='0.5'/><circle cx='137.899' cy='197.962' r='2.5' fill='#4C72B0' fill-opacity='0.5'/><circle cx='137.552' cy='150.926' r='2.5' fill='#4C72B0' fill-opacity='0.5'/><circle cx='146.514' cy='52.429' r='2.5' fill='#4C72B0' fill-opacity='0.5'/><text x='146' y='394' text-anchor='middle' fill='#333333'>Backtracking</text><rect x='296.4' y='219.595' width='75.2' height='59.666' fill='#55A868' fill-opacity='0.6' stroke='#55A868' stroke-width='1.5'/><line x1='296.4' y1='260.595' x2='371.6' y2='260.595' stroke='#333333' stroke-width='2'/><line x1='334' y1='279.261' x2='334' y2='339.46' stroke='#55A868' stroke-width='1.5'/><line x1='334' y1='219.595' x2='334' y2='191.198' stroke='#55A868' stroke-width='1.5'/><line x1='315.2' y1='339.46' x2='352.8' y2='339.46' stroke='#55A868' stroke-width='1.5'/><line x1='315.2' y1='191.198' x2='352.8' y2='191.198' stroke='#55A868' stroke-width='1.5'/><circle cx='326.52' cy='339.46' r='2.5' fill='#55A868' fill-opacity='0.5'/><circle cx='328.644' cy='270.695' r='2.5' fill='#55A868' fill-opacity='0.5'/><circle cx='339.063' cy='252.735' r='2.5' fill='#55A868' fill-opacity='0.5'/><circle cx='334.292' cy='182.702' r='2.5' fill='#55A868' fill-opacity='0.5'/><text x='334' y='394' text-anchor='middle' fill='#333333'>BT + MRV</text><rect x='484.4' y='299.222' width='75.2' height='15.919' fill='#DD8452' fill-opacity='0.6' stroke='#DD8452' stroke-width='1.5'/><line x1='484.4' y1='306.472' x2='559.6' y2='306.472' stroke='#333333' stroke-width='2'/><line x1='522' y1='315.141' x2='522' y2='316.255' stroke='#DD8452' stroke-width='1.5'/><line x1='522' y1='299.222' x2='522' y2='297.71' stroke='#DD8452' stroke-width='1.5'/><line x1='503.2' y1='316.255' x2='540.8' y2='316.255' stroke='#DD8452' stroke-width='1.5'/><line x1='503.2' y1='297.71' x2='540.8' y2='297.71' stroke='#DD8452' stroke-width='1.5'/><circle cx='514.638' cy='316.255' r='2.5' fill='#DD8452' fill-opacity='0.5'/><circle cx='527.894' cy='314.778' r='2.5' fill='#DD8452' fill-opacity='0.5'/><circle cx='516.012' cy='299.741' r='2.5' fill='#DD8452' fill-opacity='0.5'/><circle cx='516.525' cy='297.71' r='2.5' fill='#DD8452' fill-opacity='0.5'/><text x='522' y='394' text-anchor='middle' fill='#333333'>Norvig</text><rect x='672.4' y='247.12' width='75.2' height='0.733' fill='#C44E52' fill-opacity='0.6' stroke='#C44E52' stroke-width='1.5'/><line x1='672.4' y1='247.476' x2='747.6' y2='247.476' stroke='#333333' stroke-width='2'/><line x1='710' y1='247.853' x2='710' y2='248.571' stroke='#C44E52' stroke-width='1.5'/><line x1='710' y1='247.12' x2='710' y2='246.478' stroke='#C44E52' stroke-width='1.5'/><line x1='691.2' y1='248.571' x2='728.8' y2='248.571' stroke='#C44E52' stroke-width='1.5'/><line x1='691.2' y1='246.478' x2='728.8' y2='246.478' stroke='#C44E52' stroke-width='1.5'/><circle cx='710.126' cy='248.571' r='2.5' fill='#C44E52' fill-opacity='0.5'/><circle cx='705.944' cy='247.616' r='2.5' fill='#C44E52' fill-opacity='0.5'/><circle cx='707.315' cy='247.337' r='2.5' fill='#C44E52' fill-opacity='0.5'/><circle cx='704.591' cy='246.478' r='2.5' fill='#C44E52' fill-opacity='0.5'/><text x='710' y='394' text-anchor='middle' fill='#333333'>OR-Tools CP-SAT</text></svg>"
       ]
-     }
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Distribution des temps (boite = Q1..Q3, moustaches = 1.5*IQR) :\r\n"
      ]
@@ -1870,7 +2356,16 @@
   {
    "cell_type": "markdown",
    "id": "41590dbb",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007646,
+     "end_time": "2026-07-17T10:14:44.482594+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:44.474948+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Variabilite et previsibilite des solveurs\n",
     "\n",
@@ -1889,7 +2384,16 @@
   {
    "cell_type": "markdown",
    "id": "1da65893",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007016,
+     "end_time": "2026-07-17T10:14:44.497257+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:44.490241+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Visualisation : radar multi-criteres\n",
     "\n",
@@ -1907,7 +2411,16 @@
   {
    "cell_type": "markdown",
    "id": "4504da27",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00774,
+     "end_time": "2026-07-17T10:14:44.511934+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:44.504194+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Exemple : Ajouter un Solveur et Etendre le Benchmark\n",
     "\n",
@@ -1931,18 +2444,26 @@
    "id": "4864eb97",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T23:28:29.683104Z",
-     "iopub.status.busy": "2026-07-14T23:28:29.682341Z",
-     "iopub.status.idle": "2026-07-14T23:28:29.828858Z",
-     "shell.execute_reply": "2026-07-14T23:28:29.828533Z"
-    }
+     "iopub.execute_input": "2026-07-17T10:14:44.528330Z",
+     "iopub.status.busy": "2026-07-17T10:14:44.528121Z",
+     "iopub.status.idle": "2026-07-17T10:14:44.602839Z",
+     "shell.execute_reply": "2026-07-17T10:14:44.602708Z"
+    },
+    "papermill": {
+     "duration": 0.08372,
+     "end_time": "2026-07-17T10:14:44.602903+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:44.519183+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "Norvig + Forward Checking: resolu=True, 1 appels, 0 coupes FC, 2.10 ms\r\n"
+      "Norvig + Forward Checking: resolu=True, 1 appels, 0 coupes FC, 1.53 ms\r\n"
      ]
     }
    ],
@@ -2006,7 +2527,16 @@
   {
    "cell_type": "markdown",
    "id": "6546d6fe",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00706,
+     "end_time": "2026-07-17T10:14:44.616951+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:44.609891+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exemple : Solveur metaheuristique (recuit simule)\n",
     "\n",
@@ -2032,18 +2562,26 @@
    "id": "80d91159",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T23:28:29.831572Z",
-     "iopub.status.busy": "2026-07-14T23:28:29.831167Z",
-     "iopub.status.idle": "2026-07-14T23:28:30.124915Z",
-     "shell.execute_reply": "2026-07-14T23:28:30.124421Z"
-    }
+     "iopub.execute_input": "2026-07-17T10:14:44.634789Z",
+     "iopub.status.busy": "2026-07-17T10:14:44.634540Z",
+     "iopub.status.idle": "2026-07-17T10:14:44.751780Z",
+     "shell.execute_reply": "2026-07-17T10:14:44.751657Z"
+    },
+    "papermill": {
+     "duration": 0.126991,
+     "end_time": "2026-07-17T10:14:44.751842+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:44.624851+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "Simulated Annealing: resolu=True, 1275 iterations, 212 acceptees, 60.67 ms\r\n"
+      "Simulated Annealing: resolu=True, 1275 iterations, 212 acceptees, 47.72 ms\r\n"
      ]
     }
    ],
@@ -2166,7 +2704,16 @@
   {
    "cell_type": "markdown",
    "id": "56ca7ea0",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007052,
+     "end_time": "2026-07-17T10:14:44.766070+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:44.759018+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Exercice AC-3 et propagation de contraintes\n",
     "\n",
@@ -2183,7 +2730,16 @@
   {
    "cell_type": "markdown",
    "id": "e3665aa6",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007978,
+     "end_time": "2026-07-17T10:14:44.781704+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:44.773726+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Norvig + Forward Checking (Option B)\n",
     "\n",
@@ -2205,16 +2761,24 @@
    "id": "8642cf81",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T23:28:30.127253Z",
-     "iopub.status.busy": "2026-07-14T23:28:30.126889Z",
-     "iopub.status.idle": "2026-07-14T23:28:30.325941Z",
-     "shell.execute_reply": "2026-07-14T23:28:30.325545Z"
-    }
+     "iopub.execute_input": "2026-07-17T10:14:44.799886Z",
+     "iopub.status.busy": "2026-07-17T10:14:44.799673Z",
+     "iopub.status.idle": "2026-07-17T10:14:44.836815Z",
+     "shell.execute_reply": "2026-07-17T10:14:44.836686Z"
+    },
+    "papermill": {
+     "duration": 0.046669,
+     "end_time": "2026-07-17T10:14:44.836878+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:44.790209+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Solveurs etendus : Backtracking, BT + MRV, Norvig, OR-Tools CP-SAT, Norvig + FC, Simulated Annealing\r\n"
      ]
@@ -2238,7 +2802,16 @@
   {
    "cell_type": "markdown",
    "id": "68349371",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006892,
+     "end_time": "2026-07-17T10:14:44.851005+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:44.844113+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Extension du benchmark\n",
     "\n",
@@ -2251,23 +2824,31 @@
    "id": "e692ea3b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T23:28:30.329319Z",
-     "iopub.status.busy": "2026-07-14T23:28:30.328651Z",
-     "iopub.status.idle": "2026-07-14T23:28:48.230139Z",
-     "shell.execute_reply": "2026-07-14T23:28:48.229704Z"
-    }
+     "iopub.execute_input": "2026-07-17T10:14:44.868310Z",
+     "iopub.status.busy": "2026-07-17T10:14:44.868100Z",
+     "iopub.status.idle": "2026-07-17T10:14:58.850814Z",
+     "shell.execute_reply": "2026-07-17T10:14:58.850678Z"
+    },
+    "papermill": {
+     "duration": 13.992256,
+     "end_time": "2026-07-17T10:14:58.850880+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:44.858624+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Benchmark etendu en cours (1 puzzle par difficulte, timeout 10s)...\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Termine.\n",
       "\r\n"
@@ -2283,7 +2864,16 @@
   {
    "cell_type": "markdown",
    "id": "31926d52",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00667,
+     "end_time": "2026-07-17T10:14:58.865059+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:58.858389+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Execution du benchmark etendu\n",
     "\n",
@@ -2296,25 +2886,33 @@
    "id": "a091a298",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T23:28:48.233719Z",
-     "iopub.status.busy": "2026-07-14T23:28:48.233028Z",
-     "iopub.status.idle": "2026-07-14T23:28:48.289860Z",
-     "shell.execute_reply": "2026-07-14T23:28:48.289590Z"
-    }
+     "iopub.execute_input": "2026-07-17T10:14:58.881388Z",
+     "iopub.status.busy": "2026-07-17T10:14:58.881128Z",
+     "iopub.status.idle": "2026-07-17T10:14:58.909702Z",
+     "shell.execute_reply": "2026-07-17T10:14:58.909573Z"
+    },
+    "papermill": {
+     "duration": 0.037403,
+     "end_time": "2026-07-17T10:14:58.909766+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:58.872363+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "display_data",
-     "metadata": {},
      "data": {
       "text/html": [
-       "<svg xmlns='http://www.w3.org/2000/svg' width='720' height='400' viewBox='0 0 720 400' font-family='sans-serif' font-size='12'><rect width='720' height='400' fill='white'/><text x='360' y='20' text-anchor='middle' font-size='14' font-weight='bold' fill='#333333'>Benchmark etendu : Norvig+FC + recuit simule (Prong B #3801, axe Y log)</text><line x1='52' y1='358' x2='704' y2='358' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='362' text-anchor='end' fill='#333333'>0</text><line x1='52' y1='277' x2='704' y2='277' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='281' text-anchor='end' fill='#333333'>1211.038</text><line x1='52' y1='196' x2='704' y2='196' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='200' text-anchor='end' fill='#333333'>2422.076</text><line x1='52' y1='115' x2='704' y2='115' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='119' text-anchor='end' fill='#333333'>3633.113</text><line x1='52' y1='34' x2='704' y2='34' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='38' text-anchor='end' fill='#333333'>4844.151</text><line x1='52' y1='34' x2='52' y2='358' stroke='#888888' stroke-width='1'/><line x1='52' y1='358' x2='704' y2='358' stroke='#888888' stroke-width='1'/><text x='44' y='-184.011' text-anchor='end' fill='#333333'>10^2</text><line x1='48' y1='-188.011' x2='52' y2='-188.011' stroke='#888888' stroke-width='1'/><text x='44' y='139.989' text-anchor='end' fill='#333333'>10^3</text><line x1='48' y1='135.989' x2='52' y2='135.989' stroke='#888888' stroke-width='1'/><text x='44' y='463.989' text-anchor='end' fill='#333333'>10^4</text><line x1='48' y1='459.989' x2='52' y2='459.989' stroke='#888888' stroke-width='1'/><rect x='68.3' y='1375.331' width='21.733' height='-1017.331' fill='#4C72B0'/><rect x='90.033' y='1234.622' width='21.733' height='-876.622' fill='#55A868'/><rect x='111.767' y='1186.116' width='21.733' height='-828.116' fill='#DD8452'/><rect x='133.5' y='868.1' width='21.733' height='-510.1' fill='#C44E52'/><rect x='155.233' y='1073.325' width='21.733' height='-715.325' fill='#8172B3'/><rect x='176.967' y='879.322' width='21.733' height='-521.322' fill='#937860'/><text x='133.5' y='374' text-anchor='middle' fill='#333333'>Easy</text><rect x='231.3' y='44.829' width='21.733' height='313.171' fill='#4C72B0'/><rect x='253.033' y='892.844' width='21.733' height='-534.844' fill='#55A868'/><rect x='274.767' y='1115.172' width='21.733' height='-757.172' fill='#DD8452'/><rect x='296.5' y='838.973' width='21.733' height='-480.973' fill='#C44E52'/><rect x='318.233' y='1020.34' width='21.733' height='-662.34' fill='#8172B3'/><rect x='339.967' y='101.418' width='21.733' height='256.582' fill='#937860'/><text x='296.5' y='374' text-anchor='middle' fill='#333333'>Medium</text><rect x='394.3' y='430.918' width='21.733' height='-72.918' fill='#4C72B0'/><rect x='416.033' y='619.324' width='21.733' height='-261.324' fill='#55A868'/><rect x='437.767' y='1153.718' width='21.733' height='-795.718' fill='#DD8452'/><rect x='459.5' y='769.128' width='21.733' height='-411.128' fill='#C44E52'/><rect x='481.233' y='1140.145' width='21.733' height='-782.145' fill='#8172B3'/><rect x='502.967' y='101.419' width='21.733' height='256.581' fill='#937860'/><text x='459.5' y='374' text-anchor='middle' fill='#333333'>Hard</text><rect x='557.3' y='599.994' width='21.733' height='-241.994' fill='#4C72B0'/><rect x='579.033' y='952.449' width='21.733' height='-594.449' fill='#55A868'/><rect x='600.767' y='1126.4' width='21.733' height='-768.4' fill='#DD8452'/><rect x='622.5' y='720.016' width='21.733' height='-362.016' fill='#C44E52'/><rect x='644.233' y='1102.496' width='21.733' height='-744.496' fill='#8172B3'/><rect x='665.967' y='101.415' width='21.733' height='256.585' fill='#937860'/><text x='622.5' y='374' text-anchor='middle' fill='#333333'>Expert</text><rect x='532' y='42' width='168' height='122' fill='white' stroke='#E5E5E5' stroke-width='1'/><rect x='544' y='49' width='12' height='8' fill='#4C72B0'/><text x='562' y='58' fill='#333333'>Backtracking</text><rect x='544' y='67' width='12' height='8' fill='#55A868'/><text x='562' y='76' fill='#333333'>BT + MRV</text><rect x='544' y='85' width='12' height='8' fill='#DD8452'/><text x='562' y='94' fill='#333333'>Norvig</text><rect x='544' y='103' width='12' height='8' fill='#C44E52'/><text x='562' y='112' fill='#333333'>OR-Tools CP-SAT</text><rect x='544' y='121' width='12' height='8' fill='#8172B3'/><text x='562' y='130' fill='#333333'>Norvig + FC</text><rect x='544' y='139' width='12' height='8' fill='#937860'/><text x='562' y='148' fill='#333333'>Simulated Annealing</text></svg>"
+       "<svg xmlns='http://www.w3.org/2000/svg' width='720' height='400' viewBox='0 0 720 400' font-family='sans-serif' font-size='12'><rect width='720' height='400' fill='white'/><text x='360' y='20' text-anchor='middle' font-size='14' font-weight='bold' fill='#333333'>Benchmark etendu : Norvig+FC + recuit simule (Prong B #3801, axe Y log)</text><line x1='52' y1='354.459' x2='704' y2='354.459' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='358.459' text-anchor='end' fill='#333333'>0.1</text><line x1='52' y1='334.809' x2='704' y2='334.809' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='338.809' text-anchor='end' fill='#333333'>0.2</text><line x1='52' y1='308.833' x2='704' y2='308.833' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='312.833' text-anchor='end' fill='#333333'>0.5</text><line x1='52' y1='289.184' x2='704' y2='289.184' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='293.184' text-anchor='end' fill='#333333'>1</text><line x1='52' y1='269.534' x2='704' y2='269.534' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='273.534' text-anchor='end' fill='#333333'>2</text><line x1='52' y1='243.559' x2='704' y2='243.559' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='247.559' text-anchor='end' fill='#333333'>5</text><line x1='52' y1='223.909' x2='704' y2='223.909' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='227.909' text-anchor='end' fill='#333333'>10</text><line x1='52' y1='204.26' x2='704' y2='204.26' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='208.26' text-anchor='end' fill='#333333'>20</text><line x1='52' y1='178.284' x2='704' y2='178.284' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='182.284' text-anchor='end' fill='#333333'>50</text><line x1='52' y1='158.634' x2='704' y2='158.634' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='162.634' text-anchor='end' fill='#333333'>100</text><line x1='52' y1='138.985' x2='704' y2='138.985' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='142.985' text-anchor='end' fill='#333333'>200</text><line x1='52' y1='113.009' x2='704' y2='113.009' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='117.009' text-anchor='end' fill='#333333'>500</text><line x1='52' y1='93.36' x2='704' y2='93.36' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='97.36' text-anchor='end' fill='#333333'>1000</text><line x1='52' y1='73.71' x2='704' y2='73.71' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='77.71' text-anchor='end' fill='#333333'>2000</text><line x1='52' y1='47.735' x2='704' y2='47.735' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='51.735' text-anchor='end' fill='#333333'>5000</text><line x1='52' y1='34' x2='52' y2='358' stroke='#888888' stroke-width='1'/><line x1='52' y1='358' x2='704' y2='358' stroke='#888888' stroke-width='1'/><rect x='68.3' y='340.643' width='21.733' height='17.357' fill='#4C72B0'/><rect x='90.033' y='296.733' width='21.733' height='61.267' fill='#55A868'/><rect x='111.767' y='280.697' width='21.733' height='77.303' fill='#DD8452'/><rect x='133.5' y='202.942' width='21.733' height='155.058' fill='#C44E52'/><rect x='155.233' y='267.59' width='21.733' height='90.41' fill='#8172B3'/><rect x='176.967' y='231.444' width='21.733' height='126.556' fill='#937860'/><text x='133.5' y='374' text-anchor='middle' fill='#333333'>Easy</text><rect x='231.3' y='51.357' width='21.733' height='306.643' fill='#4C72B0'/><rect x='253.033' y='225.112' width='21.733' height='132.888' fill='#55A868'/><rect x='274.767' y='267.975' width='21.733' height='90.025' fill='#DD8452'/><rect x='296.5' y='212.691' width='21.733' height='145.309' fill='#C44E52'/><rect x='318.233' y='261.514' width='21.733' height='96.486' fill='#8172B3'/><rect x='339.967' y='62.215' width='21.733' height='295.785' fill='#937860'/><text x='296.5' y='374' text-anchor='middle' fill='#333333'>Medium</text><rect x='394.3' y='128.161' width='21.733' height='229.839' fill='#4C72B0'/><rect x='416.033' y='166.199' width='21.733' height='191.801' fill='#55A868'/><rect x='437.767' y='276.465' width='21.733' height='81.535' fill='#DD8452'/><rect x='459.5' y='209.685' width='21.733' height='148.315' fill='#C44E52'/><rect x='481.233' y='274.965' width='21.733' height='83.035' fill='#8172B3'/><rect x='502.967' y='62.21' width='21.733' height='295.79' fill='#937860'/><text x='459.5' y='374' text-anchor='middle' fill='#333333'>Hard</text><rect x='557.3' y='167.825' width='21.733' height='190.175' fill='#4C72B0'/><rect x='579.033' y='230.674' width='21.733' height='127.326' fill='#55A868'/><rect x='600.767' y='272.144' width='21.733' height='85.856' fill='#DD8452'/><rect x='622.5' y='213.11' width='21.733' height='144.89' fill='#C44E52'/><rect x='644.233' y='268.921' width='21.733' height='89.079' fill='#8172B3'/><rect x='665.967' y='62.215' width='21.733' height='295.785' fill='#937860'/><text x='622.5' y='374' text-anchor='middle' fill='#333333'>Expert</text><rect x='532' y='42' width='168' height='122' fill='white' stroke='#E5E5E5' stroke-width='1'/><rect x='544' y='49' width='12' height='8' fill='#4C72B0'/><text x='562' y='58' fill='#333333'>Backtracking</text><rect x='544' y='67' width='12' height='8' fill='#55A868'/><text x='562' y='76' fill='#333333'>BT + MRV</text><rect x='544' y='85' width='12' height='8' fill='#DD8452'/><text x='562' y='94' fill='#333333'>Norvig</text><rect x='544' y='103' width='12' height='8' fill='#C44E52'/><text x='562' y='112' fill='#333333'>OR-Tools CP-SAT</text><rect x='544' y='121' width='12' height='8' fill='#8172B3'/><text x='562' y='130' fill='#333333'>Norvig + FC</text><rect x='544' y='139' width='12' height='8' fill='#937860'/><text x='562' y='148' fill='#333333'>Simulated Annealing</text></svg>"
       ]
-     }
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "\n",
       "(Prong B #3801 : le recuit simule n'a aucune garantie de convergence)\r\n"
@@ -2332,7 +2930,16 @@
   {
    "cell_type": "markdown",
    "id": "c43989c3",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006997,
+     "end_time": "2026-07-17T10:14:58.923798+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:58.916801+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Analyse : le solveur Norvig + FC est-il competitif ?\n",
     "\n",
@@ -2359,7 +2966,16 @@
   {
    "cell_type": "markdown",
    "id": "9faf42d3",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007174,
+     "end_time": "2026-07-17T10:14:58.937842+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:58.930668+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Exemple guide : Comparaison de Profils de Resolution\n",
     "\n",
@@ -2408,16 +3024,24 @@
    "id": "7c230215",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T23:28:48.292586Z",
-     "iopub.status.busy": "2026-07-14T23:28:48.292120Z",
-     "iopub.status.idle": "2026-07-14T23:28:48.354345Z",
-     "shell.execute_reply": "2026-07-14T23:28:48.353799Z"
-    }
+     "iopub.execute_input": "2026-07-17T10:14:58.954310Z",
+     "iopub.status.busy": "2026-07-17T10:14:58.954131Z",
+     "iopub.status.idle": "2026-07-17T10:14:58.981544Z",
+     "shell.execute_reply": "2026-07-17T10:14:58.981422Z"
+    },
+    "papermill": {
+     "duration": 0.035919,
+     "end_time": "2026-07-17T10:14:58.981607+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:58.945688+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Exercice a completer : profilage d un solveur\r\n"
      ]
@@ -2448,7 +3072,16 @@
   {
    "cell_type": "markdown",
    "id": "1a72ccab",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.008189,
+     "end_time": "2026-07-17T10:14:58.997135+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:58.988946+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "#### Solveur Norvig profile\n",
     "\n",
@@ -2463,16 +3096,24 @@
    "id": "7af6d43b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T23:28:48.356946Z",
-     "iopub.status.busy": "2026-07-14T23:28:48.356584Z",
-     "iopub.status.idle": "2026-07-14T23:28:48.411112Z",
-     "shell.execute_reply": "2026-07-14T23:28:48.411575Z"
-    }
+     "iopub.execute_input": "2026-07-17T10:14:59.016026Z",
+     "iopub.status.busy": "2026-07-17T10:14:59.015810Z",
+     "iopub.status.idle": "2026-07-17T10:14:59.047755Z",
+     "shell.execute_reply": "2026-07-17T10:14:59.047628Z"
+    },
+    "papermill": {
+     "duration": 0.04227,
+     "end_time": "2026-07-17T10:14:59.047818+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:59.005548+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Exercice a completer : ProfiledNorvigSolver instrumente\r\n"
      ]
@@ -2494,7 +3135,16 @@
   {
    "cell_type": "markdown",
    "id": "2d09808f",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007043,
+     "end_time": "2026-07-17T10:14:59.062252+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:59.055209+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Execution du profilage\n",
     "\n",
@@ -2511,16 +3161,24 @@
    "id": "461a17c9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T23:28:48.415163Z",
-     "iopub.status.busy": "2026-07-14T23:28:48.414351Z",
-     "iopub.status.idle": "2026-07-14T23:28:48.496330Z",
-     "shell.execute_reply": "2026-07-14T23:28:48.495827Z"
-    }
+     "iopub.execute_input": "2026-07-17T10:14:59.078251Z",
+     "iopub.status.busy": "2026-07-17T10:14:59.078058Z",
+     "iopub.status.idle": "2026-07-17T10:14:59.126864Z",
+     "shell.execute_reply": "2026-07-17T10:14:59.126724Z"
+    },
+    "papermill": {
+     "duration": 0.057446,
+     "end_time": "2026-07-17T10:14:59.126929+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:59.069483+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Resultats collectes : 0 mesures\r\n"
      ]
@@ -2561,7 +3219,16 @@
   {
    "cell_type": "markdown",
    "id": "bd65ed1a",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.008404,
+     "end_time": "2026-07-17T10:14:59.143269+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:59.134865+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Visualisation : scatter plot temps vs operations\n",
     "\n",
@@ -2576,16 +3243,24 @@
    "id": "2d0e1768",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T23:28:48.498611Z",
-     "iopub.status.busy": "2026-07-14T23:28:48.498347Z",
-     "iopub.status.idle": "2026-07-14T23:28:48.543119Z",
-     "shell.execute_reply": "2026-07-14T23:28:48.542684Z"
-    }
+     "iopub.execute_input": "2026-07-17T10:14:59.163249Z",
+     "iopub.status.busy": "2026-07-17T10:14:59.163022Z",
+     "iopub.status.idle": "2026-07-17T10:14:59.193893Z",
+     "shell.execute_reply": "2026-07-17T10:14:59.193763Z"
+    },
+    "papermill": {
+     "duration": 0.041697,
+     "end_time": "2026-07-17T10:14:59.193957+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:59.152260+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Scatter plot a completer ci-dessus\r\n"
      ]
@@ -2608,7 +3283,16 @@
   {
    "cell_type": "markdown",
    "id": "afa74e18",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00751,
+     "end_time": "2026-07-17T10:14:59.208603+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:59.201093+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Votre analyse\n",
     "\n",
@@ -2629,7 +3313,16 @@
   {
    "cell_type": "markdown",
    "id": "544807af",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.008778,
+     "end_time": "2026-07-17T10:14:59.225751+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:59.216973+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Conclusion\n",
     "\n",
@@ -2656,7 +3349,16 @@
   {
    "cell_type": "markdown",
    "id": "1fabc7b9",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.008305,
+     "end_time": "2026-07-17T10:14:59.243976+00:00",
+     "exception": false,
+     "start_time": "2026-07-17T10:14:59.235671+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -2684,6 +3386,18 @@
    "name": "C#",
    "pygments_lexer": "csharp",
    "version": "13.0"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 29.152754,
+   "end_time": "2026-07-17T10:14:59.484673+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "C:\\dev\\CoursIA-fix-groupedbar-logy\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-18-Comparison-Csharp.ipynb",
+   "output_path": "C:\\dev\\CoursIA-fix-groupedbar-logy\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-18-Comparison-Csharp_output.ipynb",
+   "parameters": {},
+   "start_time": "2026-07-17T10:14:30.331919+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary

Consumer half of the **#7010 grain** (fix `GroupedBar`/`BoxPlot` logY + apply to Sudoku-18). The **helper fix already landed on `main`** as `a860a9575` (#7010 squash-merged), but the Sudoku-18 re-exec was not in that merge — `main`'s Sudoku-18 **still fails** `detect_svg_broken_geometry.py` (cells 39/55 = 15+20 negative-height rects, the #7007 regression committed in `b2befcca5`). This PR regenerates those outputs against the now-fixed helper.

**Pure re-exec** via `notebook_tools.py execute --dotnet-only` (`.net-csharp` kernel, 31s): **0 source-cell changes**, 68 cells structurally identical, only `outputs`/`execution_count` regenerated.

## What changed

- **cell[39]** `GroupedBar(logY:true)` — the previously-invisible "Medium/Backtracking ~8000ms" bar now renders (`height=306`, tallest). This is the wide dynamic range (Norvig ~3ms → BT-Medium ~8000ms) logY exists to show — **Prong B #3801**.
- **cell[42]** `BoxPlot(logY:true)` — 4 boxes (Backtracking/BT+MRV/Norvig/OR-Tools), positive heights, whiskers/medians/jittered points in-bounds.
- **cell[55]** `GroupedBar(logY:true)` (extended benchmark: Norvig+FC + recuit simulé).

Option **(B)** log-space fix per ai-01 design-gate (msg-aybluf), NOT Option (A) drop-to-linear (re-crushes fast solvers = defeats Prong-B).

## Acceptance gates (ai-01 #7008) — all PASS

| Gate | Result |
|------|--------|
| `detect_svg_broken_geometry.py --check` (#7008) | **0** (was 2: cell39 15-neg `height=-893`, cell55 20-neg `height=-1017`) |
| `detect_svg_decimal_commas.py` (#6959) | 0 |
| `detect_svg_empty_display.py` (#6971) | 0 |
| out_len > 0 | 4453 / 6261 / 5658 chars |
| no-cdn | pass (zero-dependency inline SVG) |
| no-banner | pass |

**These mechanical gates are CONCLUSIVE and vision-independent by design** — ai-01's `detect_svg_broken_geometry.py` is zero-FP, transform-immune, validated across 945 notebooks (only the #7007 regression flagged). That is the authoritative correctness proof for this PR.

**On vision-QA (honest):** I rendered all 3 SVG outputs via Playwright→PNG and inspected the **SVG coordinates** — confirming clean log-axis decade ticks (0.5→5000), single label per position, all bars/boxes positive height, no off-screen geometry. Note: this lane's main-loop model is GLM (per project routing, GLM lanes lack reliable vision), so my inspection was coordinate-level, not authoritative pixel-level vision. **For authoritative pixel-level vision sign-off, ai-01 (Opus) or a MiniMax lane should eyeball cells 39/42/55.** The mechanical gates above are sufficient on their own.

## Forensic provenance

Close-the-loop on the #7007 bad-merge: po-2024 forensically identified the broken logY (issuecomment-5001689482), #7007 merged anyway (`b2befcca5`), helper fix delivered (#7010 → `a860a9575`), this PR regenerates the consumer renders. ai-01 owns the bad merge and hardened the gate (#7008, `b39f3a61`).

See #7007 (bad merge), #7008 (ai-01's gate), #6927 (SvgChartHelper EPIC), #3801 (Prong B). Completes the #7010 grain.

Co-Authored-By: Claude <noreply@anthropic.com>