### PR TITLE
fix(ci,#6927): validator EXEC_PROVED false-positive on blank .NET figure cell

### DIFF
--- a/scripts/notebook_tools/tests/test_validate_pr_notebooks.py
+++ b/scripts/notebook_tools/tests/test_validate_pr_notebooks.py
@@ -505,3 +505,56 @@ class TestValidateNotebookLeanTextErrors:
         ])
         result = validate_notebook(nb)
         assert result["passed"] is True
+
+
+# ---------------------------------------------------------------------------
+# validate_notebook — blank-render forensic verdict (#6971 / L644-L1)
+# ---------------------------------------------------------------------------
+
+class TestBlankRenderVerdict:
+    """A .NET `display(chart)` cell that ran (execution_count set) but committed
+    an EMPTY output renders BLANK on GitHub — the exact #6927 defect. Before this
+    guard the forensic verdict falsely read EXEC_PROVED because H.3 only checks
+    execution_count != null (po-2025, #7009/#7016)."""
+
+    def test_empty_display_downgrades_verdict_and_fails(self, tmp_path):
+        nb = _write_nb(tmp_path / "test.ipynb", [
+            _code("display(SvgChartHelper.Bar(\"t\", xs, ys));", exec_count=9),
+        ], kernelspec={"name": ".net-csharp", "language": "C#"})
+        result = validate_notebook(nb)
+        assert result["passed"] is False
+        assert result["forensic_verdict"] == "STRUCTURAL_ONLY"
+        assert any("output is EMPTY" in e and "#6971" in e
+                   for e in result["errors"])
+
+    def test_display_with_svg_output_stays_exec_proved(self, tmp_path):
+        """The same display(chart) cell WITH a real <svg> output is legitimate —
+        it must stay EXEC_PROVED (guards against over-flagging rendered figures)."""
+        svg_out = {"output_type": "display_data",
+                   "data": {"text/html": ["<svg width='100' height='80'></svg>"]}}
+        nb = _write_nb(tmp_path / "test.ipynb", [
+            _code("display(SvgChartHelper.Bar(\"t\", xs, ys));", exec_count=9,
+                  outputs=[svg_out]),
+        ], kernelspec={"name": ".net-csharp", "language": "C#"})
+        result = validate_notebook(nb)
+        assert result["passed"] is True
+        assert result["forensic_verdict"] == "EXEC_PROVED"
+
+    def test_non_chart_empty_output_unaffected(self, tmp_path):
+        """A plain empty-output cell (no display(chart) source) is NOT the
+        blank-render signature — stays EXEC_PROVED (zero-FP contract of #6971)."""
+        nb = _write_nb(tmp_path / "test.ipynb", [
+            _code("var x = 5;", exec_count=1),
+        ], kernelspec={"name": ".net-csharp", "language": "C#"})
+        result = validate_notebook(nb)
+        assert result["passed"] is True
+        assert result["forensic_verdict"] == "EXEC_PROVED"
+
+    def test_empty_display_advisory_kernel_unaffected(self, tmp_path):
+        """Lean/QC (allow_null_exec_count) stay advisory — the blank-render guard
+        is gated on locally-executable kernels only, matching the H.3 carve-out."""
+        nb = _write_nb(tmp_path / "test.ipynb", [
+            _code("display(SvgChartHelper.Bar(\"t\", xs, ys));", exec_count=None),
+        ], kernelspec={"name": "lean4", "language": "lean4"})
+        result = validate_notebook(nb)
+        assert result["forensic_verdict"] == "ADVISORY_NON_EXEC"

--- a/scripts/notebook_tools/validate_pr_notebooks.py
+++ b/scripts/notebook_tools/validate_pr_notebooks.py
@@ -27,6 +27,7 @@ from pathlib import Path
 # dates like "21/02/2022" because "1/0" is a substring of "1/02").
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from notebook_lint import scan_c1_source
+from detect_svg_empty_display import detect_cell as _is_empty_svg_display
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
@@ -191,6 +192,7 @@ def validate_notebook(nb_path: Path) -> dict:
         any(k in kernel for k in ALLOW_NULL_EXEC_COUNT_KERNELS) or qc_cloud
     )
     saw_null_exec = False  # for the forensic verdict (H.5)
+    saw_empty_display = False  # #6971 blank-render signature (see verdict below)
 
     for i, cell in enumerate(data.get("cells", [])):
         if cell.get("cell_type") != "code":
@@ -236,6 +238,24 @@ def validate_notebook(nb_path: Path) -> dict:
                     f"(H.3/C.2 violation — {kernel} executes locally; "
                     f"commit execution proof, See #5214)"
                 )
+
+        # Blank-render check (#6971): a locally-executable figure cell that
+        # display()s a chart but committed an EMPTY output renders BLANK on
+        # GitHub/nbviewer — the exact #6927 defect. Because execution_count is
+        # non-null, H.3 passes and (without this) the forensic verdict below
+        # falsely reads EXEC_PROVED even though the figure is blank (L644-L1,
+        # po-2025 on #7009/#7016). Reuse the zero-FP detector (3 co-necessary
+        # conditions: exec'd + outputs==[] + display(chart) source) so the
+        # verdict, this validator, and the sibling gate stay consistent.
+        if not allow_null_exec_count and _is_empty_svg_display(cell):
+            saw_empty_display = True
+            result["passed"] = False
+            result["errors"].append(
+                f"cell {i}: display(chart) executed but output is EMPTY — "
+                f"blank render on GitHub (#6927/#6971; helper Formatter.Register "
+                f"did not run in exec, See svg-6927-canon). Re-execute so the "
+                f"<svg> is committed; never hand-edit outputs (Stop&Repair)."
+            )
 
         # H.1 check: no error outputs. Two rendering paths:
         #  (a) output_type == "error" — Python/IPython, .NET Interactive.
@@ -284,6 +304,12 @@ def validate_notebook(nb_path: Path) -> dict:
     if allow_null_exec_count:
         result["forensic_verdict"] = "ADVISORY_NON_EXEC"
     elif saw_null_exec:
+        result["forensic_verdict"] = "STRUCTURAL_ONLY"
+    elif saw_empty_display:
+        # Every cell carries execution_count (H.3 passes), but a figure cell
+        # rendered BLANK (empty output) — structural-only in substance, NOT the
+        # real-output proof EXEC_PROVED asserts. Downgrade so reviewers/bots
+        # apply CHANGES_REQUESTED (#5214/#6971) instead of trusting a blank render.
         result["forensic_verdict"] = "STRUCTURAL_ONLY"
     else:
         result["forensic_verdict"] = "EXEC_PROVED"


### PR DESCRIPTION
## Problem (po-2025 finding L644-L1, on #7009/#7016)

`validate_pr_notebooks.py`'s forensic verdict (H.5) returned **`EXEC_PROVED`** for a `.NET` `display(chart)` cell that executed (`execution_count` set) but committed an **empty output** (`outputs: []`). That cell renders **BLANK** on GitHub/nbviewer — the exact #6927 defect the SVG-inline rollout is meant to eliminate — because the H.3 check only verifies `execution_count != null`, never outputs presence. A blank-render notebook (e.g. #7016 ML-5 `cell[22]`) was thus falsely stamped as real-output-proven.

## Fix

Wire the existing **zero-FP** detector `detect_svg_empty_display.py` (#6971) into the validator's per-cell loop. An empty-output `display(chart)` cell now:
- **fails** validation (`passed=False`) with a specific blank-render error, and
- downgrades the forensic verdict to **`STRUCTURAL_ONLY`**, so reviewers/bots apply `CHANGES_REQUESTED` (#5214) instead of trusting a blank figure.

Reuses the canonical 3-condition signature (`exec'd` + `outputs==[]` + `display(chart)` source) — **no new heuristic**. Gated on locally-executable kernels (matches the H.3 carve-out; Lean/QC stay advisory).

## Evidence (firsthand)

| Notebook | Before | After |
|---|---|---|
| #7016 ML-5 `cell[22]` (empty display) | `EXEC_PROVED` (wrong) | **`STRUCTURAL_ONLY` + fail** |
| Sudoku-18 merged (rendered SVGs) | `EXEC_PROVED` | `EXEC_PROVED` (no regression) |
| `var x = 5;` (plain empty output) | `EXEC_PROVED` | `EXEC_PROVED` (zero-FP contract) |

- Tree-wide `detect_svg_empty_display.py --check` == **0** -> no notebook on main flips verdict.
- **47/47** validator tests pass (+4 new `TestBlankRenderVerdict`).

## Scope

2 files, +79 lines. No notebook / catalog / README touched.

Credit: po-2025 diagnosed the false-positive (L644-L1) while unblocking #7016 and deferred the validator fix to a separate PR to avoid scope-creep — this is that PR.

See #6927 #6971 #7016