### PR TITLE
fix(validate-pr-notebooks): catch .NET display() cell with no render (EXEC_PROVED false positive)

### DIFF
--- a/scripts/notebook_tools/tests/test_validate_pr_notebooks.py
+++ b/scripts/notebook_tools/tests/test_validate_pr_notebooks.py
@@ -505,3 +505,112 @@ class TestValidateNotebookLeanTextErrors:
         ])
         result = validate_notebook(nb)
         assert result["passed"] is True
+
+
+# ---------------------------------------------------------------------------
+# validate_notebook — display() rich-render check (H.3b, #7016)
+# ---------------------------------------------------------------------------
+
+class TestValidateNotebookDisplayRender:
+    """A display(...) / .Display(...) cell whose execution_count is set but that
+    produced NO rich-render output (html/svg/image) is STRUCTURAL_ONLY disguised
+    as EXEC_PROVED. In .NET Interactive display() always emits text/html, so an
+    empty render means the call silently no-op'd (SvgChartHelper not loaded /
+    dead kernel / outputs stripped).
+
+    Regression guard for #7016: ML-5 cell[22] = display(SvgChartHelper.Overlay(
+    ...)) at execution_count=9 with outputs:[] — the validator returned
+    EXEC_PROVED + passed=True, hiding that the SVG migration never rendered.
+    """
+
+    def test_dotnet_display_empty_outputs_fails_7016(self, tmp_path):
+        """The #7016 case: .NET display(...) cell, exec_count set, outputs:[]."""
+        nb = _write_nb(tmp_path / "test.ipynb", [
+            _code('display(SvgChartHelper.Overlay("t", "x", "y", new[] {}));',
+                  exec_count=9, outputs=[]),
+        ], kernelspec={"name": ".net-csharp", "language": "C#"})
+        result = validate_notebook(nb)
+        assert result["passed"] is False
+        assert any("display(...) call produced no rich-render" in e and "#7016" in e
+                   for e in result["errors"])
+        assert result["forensic_verdict"] == "STRUCTURAL_ONLY"
+
+    def test_dotnet_display_with_html_render_passes(self, tmp_path):
+        """display(...) that DID emit a non-empty text/html render is EXEC_PROVED."""
+        html_out = {"output_type": "display_data",
+                    "data": {"text/html": ["<svg xmlns='...'>...</svg>"]}}
+        nb = _write_nb(tmp_path / "test.ipynb", [
+            _code('display(chart);', exec_count=3, outputs=[html_out]),
+        ], kernelspec={"name": ".net-csharp", "language": "C#"})
+        result = validate_notebook(nb)
+        assert result["passed"] is True
+        assert result["forensic_verdict"] == "EXEC_PROVED"
+
+    def test_dotnet_display_with_image_render_passes(self, tmp_path):
+        """An image/* render also satisfies the check."""
+        img_out = {"output_type": "display_data",
+                   "data": {"image/png": ["iVBORw0KGgoAAAANSUhEUg=="]}}
+        nb = _write_nb(tmp_path / "test.ipynb", [
+            _code('img.Display();', exec_count=2, outputs=[img_out]),
+        ], kernelspec={"name": ".net-csharp", "language": "C#"})
+        result = validate_notebook(nb)
+        assert result["passed"] is True
+        assert result["forensic_verdict"] == "EXEC_PROVED"
+
+    def test_dotnet_display_empty_html_mime_fails(self, tmp_path):
+        """display_data present but the text/html payload is empty/whitespace =
+        render produced a broken stub, not a real render. Still STRUCTURAL_ONLY."""
+        empty_html = {"output_type": "display_data", "data": {"text/html": ["  "]}}
+        nb = _write_nb(tmp_path / "test.ipynb", [
+            _code('display(broken);', exec_count=4, outputs=[empty_html]),
+        ], kernelspec={"name": ".net-csharp", "language": "C#"})
+        result = validate_notebook(nb)
+        assert result["passed"] is False
+        assert result["forensic_verdict"] == "STRUCTURAL_ONLY"
+
+    def test_dotnet_display_null_exec_count_reports_null_first(self, tmp_path):
+        """display() + execution_count=None: the H.3 null-exec error takes
+        precedence (elif); the verdict is still STRUCTURAL_ONLY, and the error
+        message is the H.3 null-exec one, not the render one."""
+        nb = _write_nb(tmp_path / "test.ipynb", [
+            _code('display(x);', exec_count=None, outputs=[]),
+        ], kernelspec={"name": ".net-csharp", "language": "C#"})
+        result = validate_notebook(nb)
+        assert result["passed"] is False
+        assert any("execution_count is null" in e for e in result["errors"])
+        assert not any("rich-render" in e for e in result["errors"])
+        assert result["forensic_verdict"] == "STRUCTURAL_ONLY"
+
+    def test_python_display_empty_outputs_not_checked(self, tmp_path):
+        """The display-render check is deliberately .NET-scoped (per #7016 body):
+        Python render paths vary (plt.show() emits display_data without a
+        display() call; display(dict) may emit text/plain only), so a python3
+        display(...) cell with empty outputs is NOT flagged here. Documenting the
+        scope boundary so a future generalization is a conscious decision."""
+        nb = _write_nb(tmp_path / "test.ipynb", [
+            _code('display({"a": 1})', exec_count=1, outputs=[]),
+        ], kernelspec={"name": "python3", "language": "python"})
+        result = validate_notebook(nb)
+        assert result["passed"] is True
+        assert result["forensic_verdict"] == "EXEC_PROVED"
+
+    def test_display_word_boundary_no_false_positive(self, tmp_path):
+        """`mydisplay(` (no word boundary before `display`) and `display_name =`
+        must NOT be treated as a display() call — guards the regex boundary."""
+        nb = _write_nb(tmp_path / "test.ipynb", [
+            _code('mydisplay(42)\ndisplay_name = "chart"\n', exec_count=1),
+        ], kernelspec={"name": ".net-csharp", "language": "C#"})
+        result = validate_notebook(nb)
+        assert result["passed"] is True
+        assert result["forensic_verdict"] == "EXEC_PROVED"
+
+    def test_dotnet_pure_assignment_still_exec_proved(self, tmp_path):
+        """Re-affirm: a .NET cell with NO display() call and empty outputs (e.g.
+        `var x = 5;`) stays EXEC_PROVED — execution_count is the proof, a non-
+        empty outputs list is not required for non-display cells (#5214)."""
+        nb = _write_nb(tmp_path / "test.ipynb", [
+            _code('var x = 5;', exec_count=1),
+        ], kernelspec={"name": ".net-csharp", "language": "C#"})
+        result = validate_notebook(nb)
+        assert result["passed"] is True
+        assert result["forensic_verdict"] == "EXEC_PROVED"

--- a/scripts/notebook_tools/validate_pr_notebooks.py
+++ b/scripts/notebook_tools/validate_pr_notebooks.py
@@ -17,6 +17,7 @@ Exit codes:
 
 import argparse
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -81,6 +82,20 @@ ARCHIVE_NOTEBOOK_SUFFIX = "_archive.ipynb"
 # notebooks). A cell tagged "raises-exception" (the standard Jupyter/nbval
 # marker for an intentionally-erroring teaching cell) is exempt.
 TEXT_RENDERED_ERROR_SIGNATURES = ('"severity": "error"', '"severity":"error"')
+
+# A display(...) / .Display(...) call MUST emit a rich-render output. In .NET
+# Interactive the HTML formatter is registered for every object, so display()
+# always produces a non-empty text/html when it actually renders (SvgChartHelper
+# emits the <svg> markup as text/html). A display() cell with exec_count set but
+# NO rich-render output = the render silently no-op'd (SvgChartHelper not loaded,
+# dead kernel, or outputs stripped) = STRUCTURAL_ONLY disguised as EXEC_PROVED
+# (#7016: ML-5 cell[22] display(SvgChartHelper.Overlay(...)) at exec_count=9 with
+# outputs:[]). Word-boundary on `display` rejects `mydisplay(`; `.Display` is the
+# C# extension-method form.
+DISPLAY_CALL_RE = re.compile(r'(\bdisplay|\.Display)\s*\(')
+RICH_RENDER_MIMES = frozenset({
+    "text/html", "image/svg+xml", "image/png", "image/jpeg", "image/webp",
+})
 
 
 def get_changed_notebooks(base: str, paths: list[str] | None = None) -> list[Path]:
@@ -147,6 +162,37 @@ def _is_qc_cloud(rel_path: str, data: dict) -> bool:
     return data.get("metadata", {}).get("qc_reference") is True
 
 
+def _is_dotnet(kernel: str) -> bool:
+    """True for .NET Interactive kernels (.net-csharp/-fsharp/-powershell).
+    These run locally on every worker (#5214) and use display() as the canonical
+    render primitive (SvgChartHelper emits SVG via text/html)."""
+    return kernel.startswith(".net")
+
+
+def _calls_display(source: str) -> bool:
+    """Source calls display(...) (polyglot/IPython lowercase form) or .Display(...)
+    (C# extension form). Word boundary on `display` rejects `mydisplay(`."""
+    return bool(DISPLAY_CALL_RE.search(source))
+
+
+def _has_rich_render_output(outputs: list) -> bool:
+    """True iff outputs contain a display_data entry with a non-empty rich-render
+    MIME (html/svg/image). display() in .NET Interactive always emits one when it
+    actually renders; absence (with exec_count set) means the render silently
+    no-op'd (#7016)."""
+    for out in outputs:
+        if out.get("output_type") != "display_data":
+            continue
+        data = out.get("data", {})
+        for mime, payload in data.items():
+            if mime not in RICH_RENDER_MIMES:
+                continue
+            text = "".join(payload) if isinstance(payload, list) else str(payload)
+            if text.strip():
+                return True
+    return False
+
+
 def validate_notebook(nb_path: Path) -> dict:
     """Validate a single notebook for H.1/H.3 compliance.
 
@@ -191,6 +237,7 @@ def validate_notebook(nb_path: Path) -> dict:
         any(k in kernel for k in ALLOW_NULL_EXEC_COUNT_KERNELS) or qc_cloud
     )
     saw_null_exec = False  # for the forensic verdict (H.5)
+    saw_display_without_output = False  # display() w/o render = fake EXEC_PROVED (#7016)
 
     for i, cell in enumerate(data.get("cells", [])):
         if cell.get("cell_type") != "code":
@@ -235,6 +282,28 @@ def validate_notebook(nb_path: Path) -> dict:
                     f"cell {i}: execution_count is null "
                     f"(H.3/C.2 violation — {kernel} executes locally; "
                     f"commit execution proof, See #5214)"
+                )
+            elif (
+                _is_dotnet(kernel)
+                and _calls_display(source)
+                and not _has_rich_render_output(cell.get("outputs", []))
+            ):
+                # H.3b (#7016): display(...) / .Display(...) ran (exec_count is
+                # set) but produced no rich-render output (text/html or image/*).
+                # In .NET Interactive display() always emits text/html, so
+                # absence = the render silently no-op'd (SvgChartHelper not
+                # loaded / dead kernel / outputs stripped). This is
+                # STRUCTURAL_ONLY disguised as EXEC_PROVED — exec_count alone is
+                # not proof the render happened. A pure `var x = 5;` cell (no
+                # display call, legitimately empty outputs) is unaffected.
+                saw_display_without_output = True
+                result["passed"] = False
+                result["errors"].append(
+                    f"cell {i}: display(...) call produced no rich-render "
+                    f"output (text/html or image/* with content) — "
+                    f"execution_count is set but the display silently "
+                    f"no-op'd (helper not loaded / dead kernel / outputs "
+                    f"stripped); EXEC_PROVED requires the render, See #7016"
                 )
 
         # H.1 check: no error outputs. Two rendering paths:
@@ -283,7 +352,9 @@ def validate_notebook(nb_path: Path) -> dict:
     # reviewers and bots apply CHANGES_REQUESTED on the second (#5214).
     if allow_null_exec_count:
         result["forensic_verdict"] = "ADVISORY_NON_EXEC"
-    elif saw_null_exec:
+    elif saw_null_exec or saw_display_without_output:
+        # STRUCTURAL_ONLY also covers a display() cell whose exec_count is set
+        # but produced no render — execution not actually proven (#7016).
         result["forensic_verdict"] = "STRUCTURAL_ONLY"
     else:
         result["forensic_verdict"] = "EXEC_PROVED"


### PR DESCRIPTION
## Summary

`validate_pr_notebooks.py` returned a **false-positive `EXEC_PROVED`** for a `.NET Interactive` cell that calls `display(...)` with `execution_count` set but `outputs: []` — hiding that the render silently no-op'd. This is **STRUCTURAL_ONLY disguised as EXEC_PROVED**: `exec_count` alone is not proof the render happened.

Spotted in **#7016**'s body (ML-5-TimeSeries migration): cell[22] = `display(SvgChartHelper.Overlay(...))` at `exec_count=9` with `outputs:[]`. The validator returned `EXEC_PROVED + passed=True`, masking that the SVG migration never rendered (the `#r "nuget:"` kernel dies cluster-wide before SvgChartHelper loads — see `dotnet-headless-nuget-restore-cluster-wide-blocker`).

This PR fixes the **validator bug** that #7016's body flagged as a legitimate separate concern. It is **separate from #7016** per the body's anti-regression §D (`See #7016`, not `Closes` — the ML-5 re-exec itself is env-blocked, tracked elsewhere).

## Root cause

The forensic verdict only distinguished empty outputs via `saw_null_exec`, which fires **solely** on `execution_count is None`. A cell with a non-null `exec_count` but empty outputs fell straight to `EXEC_PROVED`.

## Fix (H.3b, scoped per #7016 body)

For **.NET kernels**, when a cell calls `display(...)` / `.Display(...)` **and** `execution_count` is set, require a `display_data` output with a **non-empty rich-render MIME** (`text/html` | `image/svg+xml` | `image/png` | `image/jpeg` | `image/webp`). On failure: `passed=False`, emit a `See #7016` error, downgrade the verdict to `STRUCTURAL_ONLY`.

In .NET Interactive the HTML formatter is registered for every object, so `display()` always emits `text/html` when it actually renders — absence is a real signal, not a false positive.

### Scope is deliberately tight
- **.NET-only.** Python render paths vary (`plt.show()` emits `display_data` without a `display()` call; `display(dict)` may emit `text/plain` only) — generalizing is a conscious follow-up, not this PR.
- **Only when `exec_count` is set** (null `exec_count` already reports H.3 first via `elif`).
- A pure `var x = 5;` cell (no display call, legitimately empty outputs) is **unaffected** — `test_dotnet_empty_outputs_with_exec_count_passes` still holds.

## Validation

- **Empirical (the real bug):** ML-5 cell[22] (`display(SvgChartHelper.Overlay(...))`, `exec_count=9`, `outputs:[]`) → now returns `STRUCTURAL_ONLY / passed=False` instead of the false-positive `EXEC_PROVED`.
- **Suite:** `pytest scripts/notebook_tools/tests/` → **103 passed** (95 existing + 8 new). Zero regressions.
- New regression tests (`TestValidateNotebookDisplayRender`): empty-outputs fail, html/image render pass, empty-html-mime fail, null-exec precedence, python-not-checked scope boundary, word-boundary no-FP, pure-assignment still EXEC_PROVED.

## Files
- `scripts/notebook_tools/validate_pr_notebooks.py` (+73)
- `scripts/notebook_tools/tests/test_validate_pr_notebooks.py` (+109, 8 new tests)

See #7016

🤖 Generated with [Claude Code](https://claude.com/claude-code)
