### PR TITLE
test(translation,#6949): round-trip fixture-first tests for T3 fork translate_csv.py (22 tests)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -8,6 +8,7 @@ testpaths =
     MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests
     scripts/tests
     MyIA.AI.Notebooks/QuantConnect/scripts/tests
+    scripts/translation/tests
 pythonpath =
     MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts
 addopts = -v --tb=short --import-mode importlib

--- a/scripts/translation/tests/fixtures/sample.csv
+++ b/scripts/translation/tests/fixtures/sample.csv
@@ -1,0 +1,5 @@
+notebook,cell_id,cell_type,src_lang,src_hash,text_fr,text_en,text_es,text_ar,text_fa,text_zh,text_ru,text_pt,hash_fr,hash_en,hash_es,hash_ar,hash_fa,hash_zh,hash_ru,hash_pt
+Series/Foo.ipynb,abc12345,markdown,fr,ec9615f904e04755,"## Introduction au machine learning",## Introduction to machine learning,,,,,,,,,ec9615f904e04755,6d00fbd33a36b21d,,,,,,,
+Series/Foo.ipynb,def67890,markdown,fr,bf21b6b03c8569ce,"Les reseaux de neurones profonds apprennent des representations hierarchiques.",,,,,,,,,bf21b6b03c8569ce,,,,,,,,
+Series/Foo.ipynb,code1111,code,fr,,# commentaire de code,,,,,,,,,,,,,,,,
+Series/Foo.ipynb,empty222,markdown,fr,,,,,,,,,,,,,,,,,

--- a/scripts/translation/tests/test_translate_csv.py
+++ b/scripts/translation/tests/test_translate_csv.py
@@ -1,0 +1,179 @@
+"""Tests for translate_csv.py (T3 fork, #6949 PR #2 acceptance).
+
+Fixture-first round-trip : un CSV canonique `fixtures/sample.csv` est lu,
+réécrit via write_csv, et la perte doit être nulle. Couvre aussi le hash
+contract T3↔T2 (cell_hash recompute), l'éligibilité du translation_plan,
+la sécurité env-only des clés provider, et le gate ENABLED.
+
+Le moteur n'appelle jamais l'API dans ces tests (ENABLED=False, aucune clé).
+"""
+import csv
+import importlib
+import os
+import sys
+
+import pytest
+
+# Add parent dir so `import translate_csv` resolves (convention scripts/notebook_tools/tests).
+sys.path.insert(0, str(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+import translate_csv as t3
+
+FIXTURE = os.path.join(os.path.dirname(__file__), "fixtures", "sample.csv")
+
+
+# ---------------------------------------------------------------------------
+# Hash contract — T3 doit reproduire exactement le hash de T1/T2 (cell_hash).
+# ---------------------------------------------------------------------------
+class TestHashContract:
+    def test_cell_hash_is_16_hex(self):
+        h = t3.cell_hash("anything")
+        assert len(h) == 16
+        int(h, 16)  # raises if not hex
+
+    def test_normalize_strips_trailing_whitespace_per_line(self):
+        assert t3.normalize("a   \nb\t\n") == "a\nb"
+
+    def test_cell_hash_ignores_trailing_whitespace(self):
+        # Faux-drift cosmétique : trailing space ne change pas le hash.
+        assert t3.cell_hash("hello   ") == t3.cell_hash("hello")
+
+    def test_cell_hash_ignores_crlf_vs_lf(self):
+        assert t3.cell_hash("a\r\nb") == t3.cell_hash("a\nb")
+
+    def test_cell_hash_stable(self):
+        # Valeur ancrée pour bloquer une régression du hash (drift-detection).
+        assert t3.cell_hash("## Introduction au machine learning") == "ec9615f904e04755"
+
+
+# ---------------------------------------------------------------------------
+# CSV round-trip — load_csv -> write_csv lossless (BOM toléré en lecture).
+# ---------------------------------------------------------------------------
+class TestCsvRoundTrip:
+    def test_load_csv_reads_fixture(self):
+        rows = t3.load_csv(FIXTURE)
+        assert len(rows) == 4
+        assert rows[0]["cell_id"] == "abc12345"
+        assert rows[0]["cell_type"] == "markdown"
+
+    def test_load_csv_tolerates_utf8_bom(self, tmp_path):
+        # Un CSV avec BOM ne doit pas fuir le BOM dans le premier champ.
+        p = tmp_path / "bom.csv"
+        p.write_bytes(b"\xef\xbb\xbfnotebook,cell_id\r\nx.ipynb,c1\r\n")
+        rows = t3.load_csv(str(p))
+        assert rows[0]["notebook"] == "x.ipynb"  # PAS '﻿x.ipynb'
+
+    def test_write_then_reload_is_lossless_on_canonical_columns(self, tmp_path):
+        rows = t3.load_csv(FIXTURE)
+        out = tmp_path / "rt.csv"
+        t3.write_csv(str(out), rows)
+        rows2 = t3.load_csv(str(out))
+        assert len(rows2) == len(rows)
+        for a, b in zip(rows, rows2):
+            for col in t3.CSV_COLUMNS:
+                assert a.get(col, "") == b.get(col, ""), f"column {col} diverged"
+
+    def test_write_csv_preserves_column_order(self, tmp_path):
+        rows = t3.load_csv(FIXTURE)
+        out = tmp_path / "order.csv"
+        t3.write_csv(str(out), rows)
+        with open(out, encoding="utf-8") as f:
+            header = next(csv.reader(f))
+        assert header == t3.CSV_COLUMNS
+
+    def test_write_csv_uses_lf_line_endings(self, tmp_path):
+        rows = t3.load_csv(FIXTURE)
+        out = tmp_path / "lf.csv"
+        t3.write_csv(str(out), rows)
+        raw = out.read_bytes()
+        assert b"\r\n" not in raw  # LF uniquement (lineterminator='\n')
+
+
+# ---------------------------------------------------------------------------
+# translation_plan — éligibilité markdown x langue cible vide.
+# ---------------------------------------------------------------------------
+class TestTranslationPlan:
+    def test_plan_excludes_already_translated_language(self):
+        rows = t3.load_csv(FIXTURE)
+        # abc12345 (row 0) a text_en rempli -> 'en' exclu pour cette ligne ;
+        # def67890 (row 1) a text_en vide -> 'en' inclus.
+        plan = list(t3.translation_plan(rows, ["en"]))
+        idxs = {i for i, _ in plan}
+        assert 0 not in idxs
+        assert 1 in idxs
+
+    def test_plan_yields_non_en_targets_for_partially_translated_cell(self):
+        rows = t3.load_csv(FIXTURE)
+        # abc12345 n'est traduit qu'en 'en' -> es/ar/fa/zh/ru/pt toutes vides.
+        plan = list(t3.translation_plan(rows, ["es", "ar", "fa", "zh", "ru", "pt"]))
+        idxs = {i for i, _ in plan}
+        # Les 2 lignes markdown (0 et 1) sont éligibles pour ces 6 langues.
+        assert idxs == {0, 1}
+
+    def test_plan_skips_code_cells_by_default(self):
+        rows = t3.load_csv(FIXTURE)
+        plan = list(t3.translation_plan(rows, t3.TARGETS))
+        idxs = {i for i, _ in plan}
+        assert 2 not in idxs  # code1111 = code, skippé
+
+    def test_plan_includes_code_when_flag_set(self):
+        rows = t3.load_csv(FIXTURE)
+        plan = list(t3.translation_plan(rows, ["en"], include_code=True))
+        assert (2, "en") in plan  # code1111 maintenant éligible
+
+    def test_plan_skips_empty_fr(self):
+        rows = t3.load_csv(FIXTURE)
+        plan = list(t3.translation_plan(rows, t3.TARGETS))
+        idxs = {i for i, _ in plan}
+        assert 3 not in idxs  # empty222 = text_fr vide
+
+
+# ---------------------------------------------------------------------------
+# Sécurité — clés provider depuis l'env uniquement, gate ENABLED.
+# ---------------------------------------------------------------------------
+class TestSecurity:
+    def test_provider_keys_empty_without_env(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        assert t3._provider_keys() == []
+
+    def test_provider_keys_reads_openai_env(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        provs = t3._provider_keys()
+        assert len(provs) == 1
+        model, key, base = provs[0]
+        assert key == "sk-test"
+        assert base == "https://api.openai.com/v1"
+
+    def test_provider_keys_no_literals(self):
+        # La clé ne doit JAMAIS venir d'un littéral dans le module (secrets-hygiene).
+        src = open(t3.__file__, encoding="utf-8").read()
+        # Pas de pattern os.getenv("KEY", "<défaut>") avec littéral inline.
+        assert 'getenv("OPENAI_API_KEY"' in src
+        assert 'getenv("OPENAI_API_KEY", "' not in src  # pas de default littéral
+
+    def test_enabled_gate_is_false_by_default(self):
+        # Module chargé frais (jamais muté par un test précédent).
+        importlib.reload(t3)
+        assert t3.ENABLED is False
+
+    def test_run_translations_raises_without_keys(self, monkeypatch):
+        # Même si ENABLED était True, pas de clé -> erreur claire (pas de fuite).
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="Aucune clé API"):
+            t3.run_translations([], ["en"], False, "/tmp/x.csv", False)
+
+
+# ---------------------------------------------------------------------------
+# Conformité schéma — 7 langues cibles, alignées T1/T2.
+# ---------------------------------------------------------------------------
+class TestSchemaAlignment:
+    def test_targets_are_seven_canonical_languages(self):
+        assert t3.TARGETS == ["en", "ru", "pt", "es", "ar", "fa", "zh"]
+
+    def test_every_target_has_text_and_hash_column(self):
+        for lang in t3.TARGETS:
+            assert f"text_{lang}" in t3.CSV_COLUMNS
+            assert f"hash_{lang}" in t3.CSV_COLUMNS


### PR DESCRIPTION
## Summary — round-trip fixture-first tests for T3 fork translate_csv.py (#6949 acceptance)

Completes issue **#6949** acceptance criterion: **"test round-trip fixture-first"** for PR #2 (the fork `scripts/translation/translate_csv.py` = PR #6976, merged 05:39Z). The fork shipped (285 LOC, `--dry-run`/`--smoke`/`--lang`/`--apply` flags, gated `ENABLED=False`) but had **no test mechanism** — the green CI (`translation-drift.yml`) is the **T2 drift detector**, not a test of the fork itself. This PR adds the missing test layer.

Natural ownership: I authored the fork (#6976) + mapping doc (#6980); the test layer was the open acceptance item.

## Why this is needed (the gap)

| Artifact | Status pre-PR | Evidence |
|----------|---------------|----------|
| Fork `translate_csv.py` (#6976) | MERGED, 285 LOC | `git show origin/main:scripts/translation/translate_csv.py` — has `--dry-run`/`--apply` but **0 `def test_`** |
| CI passing | Yes — but it's T2 drift detection | `.github/workflows/translation-drift.yml` runs `check_translation_sync.py`, NOT the fork |
| `#6949` acceptance "round-trip fixture-first test" | **NOT met** | no `tests/` dir in `scripts/translation/` |

## Changes (test-only, atomic — 3 files, +185)

- **`scripts/translation/tests/test_translate_csv.py`** (+165) — 22 tests, 5 classes
- **`scripts/translation/tests/fixtures/sample.csv`** (+5) — canonical CSV fixture (4 rows: translated markdown, untranslated markdown, code cell, empty-fr markdown)
- **`pytest.ini`** (+1) — add `scripts/translation/tests` to `testpaths` (was missing — fork tests wouldn't collect)

## Test coverage (22 tests, 5 classes — fixture-first, 0 API calls)

| Class | Tests | What it locks |
|-------|-------|---------------|
| `TestHashContract` (5) | `cell_hash` is 16-hex / `normalize` strips trailing ws / hash ignores CRLF vs LF (anti false-drift) / hash ignores trailing ws / **stable anchored value** (`ec9615f904e04755` regression guard) | **T3↔T2 hash contract** (fork must reproduce T1/T2 `cell_hash` exactly) |
| `TestCsvRoundTrip` (5) | load reads fixture / **tolerates UTF-8 BOM** (no leak into first field) / write→load **lossless on canonical columns** / column order preserved / **LF-only line endings** | round-trip integrity (RFC 4180) |
| `TestTranslationPlan` (5) | excludes already-translated lang / yields non-en targets for partially translated cell / skips code cells by default / includes with `--include-code` / skips empty `text_fr` | plan eligibility logic |
| `TestSecurity` (5) | `_provider_keys` empty without env / reads `OPENAI_API_KEY` env / **no literal defaults** (source-grep secrets-hygiene rule 1-3) / `ENABLED=False` by default / `run_translations` raises clear `ValueError` without keys | **secrets-hygiene + triple gate** |
| `TestSchemaAlignment` (2) | 7 canonical targets `[en,ru,pt,es,ar,fa,zh]` / every target has `text_<lang>` + `hash_<lang>` column | T1/T2/T3 schema coherence |

**No API calls**: `ENABLED=False` (verified by `test_enabled_gate_is_false_by_default` via `importlib.reload`), no keys in env (monkeypatch-delenv). The fork's live path (`call_chat`/`translate_markdown`) is network-gated and not unit-tested here — it's exercised at activation time (#6949 moyen-terme, gated on user GO #1650 Phase 1).

## Gates

| Gate | Result |
|------|--------|
| `pytest scripts/translation/tests/` | **22 passed in 0.15s** |
| Atomic (1 subject: T3 fork test layer) | ✓ (3 files, all `scripts/translation/tests/` + pytest.ini) |
| No API calls / no keys | ✓ (ENABLED=False, monkeypatch-delenv) |
| Catalogue byte-identical | ✓ (test-only) |
| Convention matches `scripts/notebook_tools/tests/` | ✓ (`sys.path.insert` + `from module import`) |
| Collision | ✓ (0 open PR touching `translate_csv.py test`) |

**Verdict**: SOTA-OK (test layer completes the fork's acceptance; no workaround, real coverage of the fork's pure functions + security gates).

See #6949 (PR #2 acceptance completion), See #4957, See #1650

🤖 po-2023 · cron c.577
