### PR TITLE
i18n(lean,#4980): lean_game_defs_ext Bayesian root — FR-first sibling pair

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian.lean
@@ -45,49 +45,12 @@
   Voir #2610 (formalisation GT-Lean, phases 1-7 : jeux bayésiens + regret
   + Fictitious Play).
 
-  ---
-  English:
-  Bayesian Games — root module
-  ============================
-
-  Core-Lean-4-only formalization of finite two-player Bayesian games
-  (Harsanyi type spaces, interim expected utility, Bayesian Nash
-  equilibrium). Companion to GameTheory-11-BayesianGames.ipynb.
-
-  Modules:
-  - `Bayesian.Sum`      — finite sums over `Fin n` with the lemmas we need
-  - `Bayesian.Types`    — `BayesGame2`, strategies, interim/ex-ante utility
-  - `Bayesian.BNE`      — decidable `isBNE`, one-shot deviation principle,
-                          prior-rescaling invariance
-  - `Bayesian.Examples` — Battle of the Sexes with incomplete information,
-                          equilibrium certified by `decide`
-  - `Bayesian.Auction`  — first-price sealed-bid auction: truthful bidding
-                          earns zero (general theorem), bid-shading BNE
-                          certified by `decide` (phase 2)
-  - `Bayesian.Vickrey`  — second-price auction: truthful bidding weakly
-                          dominant, BNE for every `n` (phase 3)
-  - `Bayesian.Max`      — finite maxima over `Fin (n + 1)`, max-of-sum
-                          vs sum-of-maxima (phase 4)
-  - `Bayesian.Information` — value of information for a single decision
-                          maker: signals as partitions, Blackwell
-                          monotonicity, no-info ≤ signal ≤ perfect (phase 4)
-  - `Bayesian.InfoGames` — counterexample: in a *game*, more information
-                          can strictly hurt the informed player (unique
-                          BNE payoffs 3 < 5, kernel-checked) (phase 4)
-  - `Bayesian.Reputation` — entry deterrence / chain-store reputation:
-                          unique credible BNE with and without type
-                          uncertainty, reputation pays 5 > 4 (phase 5)
-  - `Bayesian.Regret`   — external regret of a finite play sequence (basis
-                          of regret minimization / CFR): defining bound,
-                          max-characterization, `decide`-certified examples
-                          (phase 6, GT-13 target)
-  - `Bayesian.FictitiousPlay` — foundational no-regret learning algorithm:
-                          born-correct state, empirical beliefs, elementary
-                          step, counting invariant certified by `decide`,
-                          2×2 example (phase 7, GT-17 target)
-
-  See #2610 (GT-Lean formalization, phases 1-7: Bayesian games + regret +
-  Fictitious Play).
+  Convention i18n (EPIC #4980, décision user 2026-07-04) : ce fichier root
+  aggregator est **FR canonique**, avec son miroir anglais dans le fichier
+  sibling `Bayesian_en.lean` (modèle sibling pair ratifié 2026-07-04, cf
+  `code-style.md` §Lean i18n). Les modules substantiels vivent dans des
+  fichiers siblings `_en.lean` séparés (découverts par le `globs` du
+  lakefile).
 -/
 
 import Bayesian.Sum

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian_en.lean
@@ -1,0 +1,66 @@
+import Bayesian.Sum
+import Bayesian.Types
+import Bayesian.BNE
+import Bayesian.Examples
+import Bayesian.Auction
+import Bayesian.Vickrey
+import Bayesian.Max
+import Bayesian.Information
+import Bayesian.InfoGames
+import Bayesian.Reputation
+import Bayesian.Regret
+import Bayesian.FictitiousPlay
+
+/-!
+  Bayesian Games — root module
+  ============================
+
+  English mirror of `Bayesian.lean` (FR-first canonical). This file is a
+  landing-doc mirror: only the module docstring differs from the FR version.
+  Body signatures, proofs, and tactics remain byte-identical between the two
+  files.
+
+  Core-Lean-4-only formalization of finite two-player Bayesian games
+  (Harsanyi type spaces, interim expected utility, Bayesian Nash
+  equilibrium). Companion to GameTheory-11-BayesianGames.ipynb.
+
+  Modules:
+  - `Bayesian.Sum`      — finite sums over `Fin n` with the lemmas we need
+  - `Bayesian.Types`    — `BayesGame2`, strategies, interim/ex-ante utility
+  - `Bayesian.BNE`      — decidable `isBNE`, one-shot deviation principle,
+                          prior-rescaling invariance
+  - `Bayesian.Examples` — Battle of the Sexes with incomplete information,
+                          equilibrium certified by `decide`
+  - `Bayesian.Auction`  — first-price sealed-bid auction: truthful bidding
+                          earns zero (general theorem), bid-shading BNE
+                          certified by `decide` (phase 2)
+  - `Bayesian.Vickrey`  — second-price auction: truthful bidding weakly
+                          dominant, BNE for every `n` (phase 3)
+  - `Bayesian.Max`      — finite maxima over `Fin (n + 1)`, max-of-sum
+                          vs sum-of-maxima (phase 4)
+  - `Bayesian.Information` — value of information for a single decision
+                          maker: signals as partitions, Blackwell
+                          monotonicity, no-info ≤ signal ≤ perfect (phase 4)
+  - `Bayesian.InfoGames` — counterexample: in a *game*, more information
+                          can strictly hurt the informed player (unique
+                          BNE payoffs 3 < 5, kernel-checked) (phase 4)
+  - `Bayesian.Reputation` — entry deterrence / chain-store reputation:
+                          unique credible BNE with and without type
+                          uncertainty, reputation pays 5 > 4 (phase 5)
+  - `Bayesian.Regret`   — external regret of a finite play sequence (basis
+                          of regret minimization / CFR): defining bound,
+                          max-characterization, `decide`-certified examples
+                          (phase 6, GT-13 target)
+  - `Bayesian.FictitiousPlay` — foundational no-regret learning algorithm:
+                          born-correct state, empirical beliefs, elementary
+                          step, counting invariant certified by `decide`,
+                          2×2 example (phase 7, GT-17 target)
+
+  See #2610 (GT-Lean formalization, phases 1-7: Bayesian games + regret +
+  Fictitious Play).
+
+  Convention i18n (EPIC #4980, decision ratified 2026-07-04, see
+  `code-style.md` §Lean i18n): distinct FR+EN sibling files (`Bayesian.lean`
+  / `Bayesian_en.lean`) — no inline bilingual block in a single file
+  (Option B rejected: double cost + FR/EN drift + quality bias).
+-/

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/lakefile.toml
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/lakefile.toml
@@ -1,5 +1,13 @@
 name = "lean_game_defs_ext"
 defaultTargets = ["Bayesian"]
 
+# Convention i18n EPIC #4980 (ratifiée user 04/07, pattern #6585 cf
+# decision_theory_lean/lakefile.lean) : `globs` (et non `roots`) pour que
+# `lake build` auto-découvre le sibling `_en` racine (miroir EN, module
+# `Bayesian_en`). Sans globs, le sibling racine `Bayesian_en.lean` (namespace
+# distinct, hors `Bayesian/`) n'est PAS type-checké par la CI (orphan-trap,
+# faux-green — cf conway #6678). `Bayesian.*` couvre les modules imbriqués,
+# `Bayesian_en` couvre le root aggregator EN doc-only.
 [[lean_lib]]
 name = "Bayesian"
+globs = ["Bayesian.*", "Bayesian_en"]


### PR DESCRIPTION
## Summary

Splits the `Bayesian.lean` root of the `lean_game_defs_ext` lake (Bayesian-games, core-only) from an **Option-B bilingual-inline** file (FR block + `--- English:` EN block in one file) into a proper **FR-first sibling pair** — the canonical i18n pattern ratified in #4980 (Option B rejected; Option A sibling pair canonical). Same pattern already shipped to `Utility`/`Gittins`/`Coherence` (decision_theory_lean), `Knots` (knot_lean), `Sensitivity`, and the game_theory_lean multi-lib roots.

### Changes
- **`Bayesian.lean`** (FR-seul canonical): the EN `--- English:` block is removed, replaced by a one-line convention pointer to the sibling. FR docstring + all imports unchanged.
- **`Bayesian_en.lean`** (new, EN-seul sibling): EN docstring migrated verbatim + the SAME imports (landing-doc mirror; body/proofs/tactics stay byte-identical between the two files).
- **`lakefile.toml`**: added `globs = ["Bayesian.*", "Bayesian_en"]` so `lake build` / CI type-checks the root `_en` sibling. Without globs the distinct-module root sibling is **not built by default = orphan-trap / faux-green CI** (#6585; cf conway #6678 forensic where 8 `_en` targets silently failed behind a green CI). This is the **first in-repo use of TOML globs** (all prior globs live in `lakefile.lean`).

### Why this grain
Surfaced by the i18n-inventory refresh (#7022), which also fixed the inventory's TOML-lakefile blind-spot that had hidden this lake entirely (0/13). The lake is **core-only (no Mathlib)**, so it builds locally without the Mathlib-cold-build OOM that gates the heavier lakes — full local validation is possible here (and was the caveat I'd flagged in #7022; now resolved firsthand).

## Validation (firsthand, po-2024 via WSL elan — Lean 4.31.0-rc1 / Lake 5.0.0)

- **`lake build` BEFORE**: 15 jobs, SUCCESS.
- **`lake build` AFTER** (sibling + globs): **16 jobs, SUCCESS** — `Built Bayesian_en` appears at [15/16], confirming the globs discover and type-check the new root sibling (orphan-trap avoided).
- **Byte-identity** proven: `diff <(grep ^import Bayesian.lean) <(grep ^import Bayesian_en.lean)` = empty — only docstrings differ.
- **`grep -c sorry`** unchanged (lake is 0-sorry core-only).
- CI: `.github/workflows/lean-game-defs-ext.yml` calls the reusable `lean-build.yml@main` (`lake build` + sorry baseline) — now exercises `Bayesian_en`.

## Anti-regression

The EN content **migrates** to the sibling (not deleted). No proof, signature, or tactic is touched — only docstrings + lakefile globs.

## Scope

Root aggregator sibling only (the 12 `Bayesian/*` leaf modules remain FR-only for now — 1/13, future tranches). Partial contribution to the open EPICs.

See #4980
See #2610