### PR TITLE
fix(sota,#3801): SC-16 concrete-python FHE real output (was ImportError fallback)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-16-Homomorphic-Encryption.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-16-Homomorphic-Encryption.ipynb
@@ -1172,22 +1172,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Concrete non installe (pip install concrete-python).\n",
+      "CONCRETE FHE - Addition compilee\n",
+      "======================================================================\n",
+      "Circuit compile avec succes\n",
+      "  addition_secrete(7, 13) = 20  (attendu: 20)\n",
       "\n",
-      "Concrete permet de compiler une fonction Python en circuit FHE.\n",
-      "Exemple conceptuel :\n",
-      "\n",
-      "  @fhe.compiler({'x': 'encrypted', 'y': 'encrypted'})\n",
-      "  def addition_secrete(x, y):\n",
-      "      return x + y\n",
-      "\n",
-      "  # Compilation\n",
-      "  circuit = addition_secrete.compile(inputset)\n",
-      "  circuit.keygen()\n",
-      "\n",
-      "  # Execution sur donnees chiffrees\n",
-      "  result = circuit.encrypt_run_decrypt(7, 13)  # -> 20\n",
-      "  # Le serveur n'a jamais vu 7 ni 13\n"
+      "-> Le serveur a calcule 7 + 13 SANS voir les valeurs !\n"
      ]
     }
    ],


### PR DESCRIPTION
## What

Closes the residual Prong-A defect flagged in my own #3801 SmartContracts audit (c.528, 2026-07-15): **SC-16-Homomorphic-Encryption cell[7] (code cell #8) committed the `except ImportError` fallback** ("Concrete non installe...") instead of the real Zama `concrete-python` FHE output. Sibling fix to #6750 (SC-16 TenSEAL CKKS cells 5-6, MERGED). EPIC #3801 axe-2 (SOTA, Prong-A).

## Defect (firsthand, G.1)

Cell[24] source is SOTA-correct (`fhe.Compiler(addition_secrete, {"x":"encrypted","y":"encrypted"})` → `compile(inputset)` → `keygen` → `encrypt_run_decrypt(7,13)`), but the committed `outputs[0]` was the `except ImportError` conceptual fallback — the real FHE circuit had never been executed.

**Why not fixed in #6750 / why RECOVERABLE-MACHINE was the prior verdict:** `concrete-python` (Zama) publishes **no cp313 wheel AND no Windows wheel at all** (PyPI firsthand, scanned 2.6→2.11: only `manylinux_2_28_x86_64` + `macosx_13_0`). The SC-16 declared kernel is `python3` (Store 3.13, Windows). My c.528 verdict was "RECOVERABLE-MACHINE (needs Py≤3.12)" — **refined this cycle firsthand**: the real constraint is **Linux/macOS-only** (no Windows wheel ever), not just the Python version.

## Fix — Stop & Repair (not a scrub), mirror of #6750

**Environment (RECOVERABLE-LOCAL via WSL):** created a Linux py3.12 venv in WSL Ubuntu (po-2025 has WSL per kernels-runtime), `pip install concrete-python==2.11.0` (manylinux_2_28 wheel) + `setuptools<81` (concrete imports `pkg_resources`, removed in setuptools 81+). Ran the **unchanged** cell[7] try-block logic — real FHE compilation of `addition_secrete(x,y)=x+y`:

```
CONCRETE FHE - Addition compilee
======================================================================
Circuit compile avec succes
  addition_secrete(7, 13) = 20  (attendu: 20)

-> Le serveur a calcule 7 + 13 SANS voir les valeurs !
```

`result = circuit.encrypt_run_decrypt(7, 13) = 20` (correct, matches `7+13`) — the server computed the addition **on encrypted inputs only**, the FHE capability a trivial baseline cannot replicate (Prong-B non-triviality satisfied).

**Injection (surgical, +5/−15):** replaced `outputs[0].text` (18-line ImportError array → 6-line real-output array, house ARRAY style). **Source byte-identical, kernelspec `python3` unchanged, exec_count 8 preserved** (positional). No hand-editing of source; no scrub.

## Gates verified firsthand

| Gate | Result |
|------|--------|
| Source unchanged | `git diff \| grep -cE '^\+\s*"source"'` = **0** |
| Catalogue | **0 diff** (`git status \| grep catalog` = clean) |
| nbformat | `nbformat.validate()` **OK**, nbformat 4.5 |
| H.3 validator | Errors: **0** (Warnings: 1 = **pre-existing**, confirmed identical on origin/main baseline) |
| Real vs fallback | assert `Circuit compile avec succes` + `addition_secrete(7, 13) = 20` present, `Concrete non installe` absent |
| Collision | `gh pr list --search concrete-python` / `SC-16` = **0** cell[7] PR (unclaimed) |
| Verdict | **SOTA-OK** (real Zama FHE circuit executed; RECOVERABLE-MACHINE→LOCAL resolved via WSL) |

## Ledger note

Ledger entry **#016 (PR #5994)** "SmartContracts 27 nb SOTA-OK" remains partially premature for SC-16: cells 5-6 fixed (#6750) + cell[7] fixed (this PR) → SC-16 now genuinely SOTA-OK end-to-end. No ledger file edit in this PR (separate concern).

See #3801 (EPIC axe-2 SOTA). Sibling: #6750.

🤖 po-2025 (GLM no-vision lane; FHE output captured via deterministic WSL exec, not visual QA)
