### PR TITLE
fix(decinfer-4): portable #load (../../Infer/) + remove dead Plotly.NET cell

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-4-Multi-Attribute.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-4-Multi-Attribute.ipynb
@@ -196,7 +196,8 @@
    ],
    "source": [
     "// Chargement du helper pour visualisation des graphes de facteurs\n",
-    "#load \"FactorGraphHelper.cs\"\n",
+    "// (FactorGraphHelper.cs vit dans Probas/Infer/ ; chemin relatif ../../Infer pour re-exec headless CWD=notebook-dir.)\n",
+    "#load \"../../Infer/FactorGraphHelper.cs\"\n",
     "\n",
     "Console.WriteLine(\"FactorGraphHelper charge !\");\n",
     "Console.WriteLine($\"Graphviz disponible : {FactorGraphHelper.IsGraphvizAvailable()}\");"
@@ -611,65 +612,6 @@
     "1. Pour chaque attribut, definir vi(xi) : [xi_min, xi_max] -> [0, 1]\n",
     "2. Determiner les poids wi par comparaison des \"swings\"\n",
     "3. Calculer V(.) pour chaque alternative"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "20467e54",
-   "metadata": {
-    "language_info": {
-     "name": "polyglot-notebook"
-    },
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
-    "polyglot_notebook": {
-     "kernelName": "csharp"
-    },
-    "tags": [],
-    "vscode": {
-     "languageId": "csharp"
-    }
-   },
-   "outputs": [
-    {
-     "output_type": "display_data",
-     "metadata": {},
-     "data": {
-      "text/html": [
-       "<div><div></div><div><strong>Installing Packages</strong><ul><li><span>Plotly.NET.Interactive</span></li></ul></div><div></div></div>"
-      ]
-     }
-    },
-    {
-     "output_type": "display_data",
-     "metadata": {},
-     "data": {
-      "text/plain": [""]
-     }
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Plotly.NET charge pour les visualisations interactives !\r\n"
-     ]
-    }
-   ],
-   "source": [
-    "// Installation Plotly.NET pour les visualisations\n",
-    "#r \"nuget: Plotly.NET.Interactive, 5.0.0\"\n",
-    "using Plotly.NET;\n",
-    "using Plotly.NET.LayoutObjects;\n",
-    "using Plotly.NET.TraceObjects;\n",
-    "using Microsoft.FSharp.Core;\n",
-    "\n",
-    "Console.WriteLine(\"Plotly.NET charge pour les visualisations interactives !\");"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Two defects in `DecInfer-4-Multi-Attribute.ipynb`, found while investigating the **#6927 "intent-no-figure" residual** (DecInfer-3/4, flagged low-confidence in the issue body).

### 1. Dead Plotly.NET install cell (removed)
`cell[12]` ran `#r "nuget: Plotly.NET.Interactive, 5.0.0"` + 3 `using Plotly.NET.*` + printed "Plotly.NET charge !", but **Plotly.NET was never used for any chart**. `cell[34]`'s comment documents the original `Chart.Combine` Plotly call "echoue en CS0103 sur re-execution fraiche" and was replaced by `Console.WriteLine` table output. So `cell[12]` installed a heavy NuGet package (the `#r "nuget:"` form is a known cluster-wide headless-hang risk) + imported 3 namespaces — all dead. **Verified: 0 Plotly API calls anywhere outside cell[12] itself.** Removed.

### 2. Non-portable `#load` path (fixed)
`#load "FactorGraphHelper.cs"` resolves relative to the kernel CWD. `FactorGraphHelper.cs` lives in `Probas/Infer/`, but DecInfer-4 is in `Probas/DecisionTheory/DecInfer/` — so the `#load` only resolves when the kernel starts from `Probas/Infer/` (interactive VS Code). The repo's dedicated headless executor ([dotnet_executor.py](scripts/notebook_tools/dotnet_executor.py), sets CWD=notebook-dir) **could not re-exec the notebook**: `CS1504 "Fichier introuvable"` at the `#load` cell. Fixed: `#load "../../Infer/FactorGraphHelper.cs"` (relative from the notebook's own dir).

## Validation (firsthand, po-2024, .net-csharp kernel, Infer.NET + Plotly.NET cached, Graphviz 14.1.2)

- **Full re-exec AFTER both edits: 22/22 code cells, 0 errors, 12.8s** (was: 2 errors at the `#load` cell + cascade, before the path fix).
- **Surgical diff** (2 insertions, 60 deletions): existing outputs retained (all valid — deterministic seed-42 cells reproduce identical numbers, e.g. Dirichlet posterior `w_Prix = 33,3 %` unchanged; `cell[4]` output byte-identical: `'FactorGraphHelper charge ! / Graphviz disponible : True'`). The full re-exec log proves runnability; outputs retained to keep the diff minimal and avoid Graphviz-layout SVG coordinate churn.
- **H.3**: 0 null-exec code cells. **probeAddresses banner**: none introduced (no output churn). **No machine-path leak**.

## Anti-regression

`cell[12]` was dead code (Plotly.NET installed but never used) — its removal cannot affect any other cell (proven: 0 external references + 0-error re-exec). `cell[4]` is a semantically-equivalent `#load` (same helper, different resolution path) with byte-identical output.

## Scope

**DecInfer-4 only** (atomic). **Series note**: 7 other DecInfer notebooks (`DecInfer-1/3/5/6/7/8/10`) reference `FactorGraphHelper` and likely carry the same `#load` portability issue — each needs the same `../../Infer/` fix in a follow-up (not batched here, to keep per-notebook validation atomic). `DecInfer-3` separately investigated = **FALSE POSITIVE** (intentionally console-table design per its `cell[4]` note; factor-graph renders when Graphviz present).

See #6927
See #3801