### PR TITLE
fix(decinfer-8): portable #load path (../../Infer/) for headless re-exec

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-8-Sequential.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-8-Sequential.ipynb
@@ -317,7 +317,7 @@
    ],
    "source": [
     "// Charger le helper pour visualiser les factor graphs\n",
-    "#load \"FactorGraphHelper.cs\"\n",
+    "#load \"../../Infer/FactorGraphHelper.cs\"\n",
     "\n",
     "// Flag pour activer les visualisations de factor graphs\n",
     "bool ShowFactorGraph = true;\n",


### PR DESCRIPTION
## Summary

`DecInfer-8-Sequential.ipynb` cell[4] used `#load "FactorGraphHelper.cs"`, which resolves relative to the kernel CWD. `FactorGraphHelper.cs` lives in `Probas/Infer/`, but DecInfer-8 is in `Probas/DecisionTheory/DecInfer/` — so the `#load` only resolves when the kernel starts from `Probas/Infer/` (interactive VS Code). The repo's dedicated headless executor ([dotnet_executor.py](scripts/notebook_tools/dotnet_executor.py), sets CWD=notebook-dir) could **not** re-exec the notebook: `CS1504 "Fichier introuvable"` at the `#load` cell.

Same defect as DecInfer-4 (fixed in #7028) and the rest of the DecInfer series. Fixed: `#load "../../Infer/FactorGraphHelper.cs"` (relative from the notebook's own dir).

## Validation (firsthand, po-2024, .net-csharp kernel, Infer.NET cached, Graphviz 14.1.2)

- **BEFORE fix**: cell[4] `#load` fails `CS1504` → notebook broken from the setup cell, cannot re-exec headless.
- **AFTER fix**: cell[4] `#load` resolves, helper loads (`"FactorGraphHelper charge. / Graphviz disponible : True"`). Full re-exec: **13/14 code cells pass** (cell[4] setup now OK).
- The one remaining error is **cell[13]** = the LAST cell, a **student EXERCISE STUB** ("Exercice : MDP et Iteration de Valeur", TODOs + `Console.WriteLine("Exercice a completer")`, C.1-compliant). **VERIFIED PRE-EXISTING**: the baseline (origin/main + temp `#load` fix) produces the **identical** cell[13] error — my fix introduces **zero** new errors. cell[13] is out of scope (student exercise to complete).
- **Surgical diff**: 1 line changed (byte-level string replace, preserving exact file format — no whitespace/normalization churn). Existing outputs retained (all valid: the `#load` fix loads the same helper, cell[4] output byte-identical). **H.3**: 0 null-exec.

## Anti-regression

cell[4] is a semantically-equivalent `#load` (same helper, different resolution path) with unchanged output. No other cell touched.

## Scope

DecInfer-8 only (atomic, per-notebook validated). Series continues from #7028 (DecInfer-4). Remaining: DecInfer-1/3/5/6/7/10 each need the same `../../Infer/` fix in their own PR.

See #6927
See #3801