### PR TITLE
fix(sota,#3801): SC-18 Vyper real compilation output (was mode-démonstration fallback)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-18-Vyper.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-18-Vyper.ipynb
@@ -121,15 +121,9 @@
      "output_type": "stream",
      "text": [
       "Python 3.13.12 | packaged by Anaconda, Inc. | (main, Feb 24 2026, 16:05:56) [MSC v.1942 64 bit (AMD64)]\n",
-      "Vyper : non installe (mode demonstration)\n",
-      "  -> pip install vyper  (pour compiler les contrats)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "web3.py : installe\n"
+      "Vyper 0.4.3 : installe\n",
+      "web3.py : installe\n",
+      "\n"
      ]
     }
    ],
@@ -762,22 +756,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "COMPILATION VYPER (mode demonstration)\n",
+      "COMPILATION VYPER REUSSIE\n",
       "============================================================\n",
-      "Le compilateur vyper n'est pas installe.\n",
-      "Voici ce que la compilation produirait :\n",
-      "\n",
-      "1. BYTECODE : code machine EVM (identique a un contrat Solidity compile)\n",
-      "2. ABI (Application Binary Interface) :\n",
-      "   - constructor(uint256 initial_value)\n",
-      "   - set_value(uint256 new_value) [external]\n",
-      "   - get_value() -> uint256 [view, external]\n",
-      "   - stored_value() -> uint256 [view, auto-generated]\n",
-      "   - owner() -> address [view, auto-generated]\n",
-      "\n",
-      "-> Le bytecode EVM est le meme format que Solidity.\n",
-      "   Un contrat Vyper deploye est indistinguable d'un contrat Solidity\n",
-      "   du point de vue de l'EVM.\n"
+      "Bytecode : 0x346100255760206101965f395f515f553360015561013761002961000039610137610000f35b5f...\n",
+      "Taille bytecode : 406 octets\n",
+      "ABI : 5 fonctions/evenements\n",
+      "  [function] set_value\n",
+      "  [function] get_value\n",
+      "  [function] stored_value\n",
+      "  [function] owner\n",
+      "  [constructor] constructor\n"
      ]
     }
    ],
@@ -924,22 +912,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DEPLOIEMENT (mode demonstration)\n",
-      "============================================================\n",
-      "Sans vyper et/ou anvil, voici le deroulement du deploiement :\n",
-      "\n",
-      "1. Compilation : vyper source -> bytecode EVM + ABI\n",
-      "2. Transaction de deploiement :\n",
-      "   - from: adresse du deployer\n",
-      "   - data: bytecode + arguments du constructeur encodes\n",
-      "   - to: None (creation de contrat)\n",
-      "3. Le contrat recoit une adresse unique\n",
-      "4. Interaction via ABI :\n",
-      "   - call() pour les fonctions @view (gratuit)\n",
-      "   - transact() pour les fonctions qui modifient l'etat (coute du gas)\n",
-      "\n",
-      "-> Le processus est identique a Solidity car l'EVM ne connait\n",
-      "   que le bytecode, pas le langage source.\n"
+      "Anvil non disponible. Lancez : anvil\n",
+      "Le deploiement sera simule.\n"
      ]
     }
    ],


### PR DESCRIPTION
## What

Closes a Prong-A defect in **SC-18-Vyper** (`05-Alternative-Chains`): cell[2] (env check) + cell[13] (Vyper compilation) + cell[16] (deployment) all committed **degraded "mode démonstration" output** instead of the real Vyper toolchain result, because `vyper` was not installed. EPIC #3801 axe-2 (SOTA, Prong-A). Sibling to #7027 (SC-16 concrete-python FHE) — same SmartContracts audit lane.

## Defect (firsthand, G.1)

| Cell | Source (SOTA-correct) | Committed output (degraded) |
|------|----------------------|------------------------------|
| cell[2] env check | `import vyper` guard → `VYPER_AVAILABLE` | `"Vyper : non installe (mode demonstration)"` |
| cell[13] compile | `vyper.compiler.compile_code(STORAGE_SOURCE, output_formats=["abi","bytecode"])` → real bytecode+ABI | `"COMPILATION VYPER (mode demonstration) ... Voici ce que la compilation produirait"` (prose only, no bytecode) |
| cell[16] deploy | `if VYPER_AVAILABLE and bytecode: w3=Web3(anvil); contract.constructor(42).transact()` | `"DEPLOIEMENT (mode demonstration) ... Sans vyper et/ou anvil"` |

The source is correct in every cell — the defect is purely the `except ImportError` / `if not VYPER_AVAILABLE` fallback output being committed as the notebook's result.

## Fix — Stop & Repair (not a scrub)

**Why clean RECOVERABLE-LOCAL (cleaner than #7027):** Vyper is **pure-Python** (`vyper-0.4.3-py3-none-any.whl`, `requires_python >=3.10`) → installs on the notebook's **declared kernel** (Anaconda 3.13.12 `python3`) directly. No kernelspec change, no WSL, no env mismatch — unlike SC-16 (concrete-python needed WSL py3.12). Installed `vyper==0.4.3` + `web3==7.16.0` into base conda 3.13.12, re-ran the **unchanged** cell logic, captured real stdout, injected surgically.

**Real Vyper compiler output now committed (cell[13]):**
```
COMPILATION VYPER REUSSIE
============================================================
Bytecode : 0x346100255760206101965f395f515f553360015561013761002961000039610137610000f35b5f...
Taille bytecode : 406 octets
ABI : 5 fonctions/evenements
  [function] set_value
  [function] get_value
  [function] stored_value
  [function] owner
  [constructor] constructor
```

Real EVM bytecode (406 bytes) + ABI (5 entries incl. auto-generated `stored_value`/`owner` getters) — the Vyper compiler capability a "describe-the-ABI-in-prose" baseline cannot replicate (**Prong-B non-triviality**). cell[2] now correctly reports `Vyper 0.4.3 : installe`.

**cell[16] re-executed to honest state:** with vyper+web3 available (guard now passes) but `anvil` not running, the cell reaches its honest `else` branch — `"Anvil non disponible. Lancez : anvil"` — instead of the stale `"mode démonstration"` that falsely implied vyper itself was absent. Fixes the C.2 internal contradiction (cell[2] said vyper installed while cell[16] committed output said it wasn't).

## Residual — cell[16] full anvil deployment (RECOVERABLE-MACHINE)

Real on-chain deployment (transaction + gas + contract address + view call) requires Foundry's `anvil` local chain (`foundryup`, Linux/macOS only → WSL). Flagged as a **separate grain** (mirrors how SC-16 cell[7] was residual to the TenSEAL PR #6750). The source already handles it correctly (`if w3.is_connected(): ... real deploy ...`); only the env (anvil daemon) is missing.

## Gates verified firsthand

| Gate | Result |
|------|--------|
| Source unchanged | `git diff \| grep -cE '^\+.*"source"'` = **0** / `-` = **0** |
| Catalogue | **0 diff** (clean) |
| nbformat | `nbformat.validate()` **OK** |
| H.3 validator | OK:1, Warnings:**0**, Errors:**0** (matches origin/main baseline) |
| Real vs fallback | cell[2] `Vyper 0.4.3 : installe`; cell[13] `COMPILATION VYPER REUSSIE` + bytecode; cell[16] `Anvil non disponible` (no "mode démonstration") |
| Collision | `gh pr list --search vyper` / `SC-18` = **0** SOTA-fix PR |
| Verdict | **SOTA-OK** for compilation (real Vyper bytecode+ABI); cell[16] honest-no-anvil + residual flagged |

See #3801 (EPIC axe-2 SOTA). Sibling: #7027 (SC-16 FHE), #6750 (SC-16 TenSEAL CKKS).

🤖 po-2025 (GLM no-vision lane; Vyper output captured via deterministic base-conda exec, not visual QA)
