### PR TITLE
i18n(lean,#4980): EN siblings for 12 lean_game_defs_ext/Bayesian leaves (Option A)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Auction.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Auction.lean
@@ -33,51 +33,13 @@
     de l'offre sincère.
 
   Voir #2610 (formalisation GT-Lean, phase bayésienne 2).
-
-  ---
-  English:
-  First-Price Sealed-Bid Auction (discrete, two bidders)
-  ======================================================
-
-  The classic application of Bayesian games (Vickrey 1961, Harsanyi
-  1967): two bidders with private valuations drawn uniformly from
-  `{0, …, n-1}` simultaneously submit bids in `{0, …, n-1}`; the
-  highest bid wins and pays its own bid, ties split the surplus.
-
-  Encoding choices (all core Lean 4, no Mathlib):
-  - Valuations are the *types* and bids are the *actions* of a
-    `BayesGame2`, with uniform prior weight 1 on every type profile.
-  - Utilities are scaled by 2 so that the tie case (half the surplus)
-    stays in `Int`: win = `2*(v - b)`, tie = `v - b`, lose = `0`.
-    By `isBNE_scaleW`-style reasoning, scaling all payoffs by a
-    positive constant does not change best responses, so the
-    equilibrium analysis is faithful.
-
-  Results:
-  - `fpa_u1_truthful`/`interimU1_truthful`: bidding one's own value
-    yields *exactly zero* utility, for every n, every type, against
-    every opponent strategy — winning at a price equal to one's value
-    leaves no surplus. (General theorem, not a `decide` instance.)
-  - `truthful_not_bne_two/three`: truthful bidding is NOT a BNE
-    (kernel-checked counterexample via `decide`).
-  - `shade_bne_two/three`: the shaded strategy `bid = v / 2` is a BNE
-    (kernel-checked via `decide`) — the discrete analogue of the
-    textbook equilibrium `b(v) = v/2` for two uniform bidders.
-  - `shading_beats_truthful_three`: under shading the high type earns
-    strictly positive interim utility, in contrast with the zero of
-    truthful bidding.
-
-  See #2610 (GT-Lean formalization, Bayesian phase 2).
 -/
 
 import Bayesian.BNE
 
 /-- Enchère scellée au premier prix à deux enchérisseurs, valorisations et
     offres dans `Fin n`, prior uniforme, utilités mises à l'échelle par 2 (pour
-    que le partage du surplus en cas d'égalité reste entier).
-    English: First-price sealed-bid auction with two bidders, valuations and
-    bids in `Fin n`, uniform prior, utilities scaled by 2 (so the tie
-    split of the surplus stays integral). -/
+    que le partage du surplus en cas d'égalité reste entier). -/
 @[reducible] def fpa (n : Nat) : BayesGame2 where
   nT1 := n
   nT2 := n
@@ -93,20 +55,15 @@ import Bayesian.BNE
     else if b1.val = b2.val then (v2.val : Int) - b2.val
     else 0
 
-/-- Offre sincère du joueur 1 : offrir exactement sa valorisation.
-    English: Truthful bidding for player 1: bid exactly one's valuation. -/
+/-- Offre sincère du joueur 1 : offrir exactement sa valorisation. -/
 @[reducible] def truthful1 (n : Nat) : Strategy1 (fpa n) := fun v => v
 
-/-- Offre sincère du joueur 2.
-    English: Truthful bidding for player 2. -/
+/-- Offre sincère du joueur 2. -/
 @[reducible] def truthful2 (n : Nat) : Strategy2 (fpa n) := fun v => v
 
 /-- Offrir sa propre valeur donne un paiement nul face à N'IMPORTE QUELLE
     offre adverse : gagner ou être à égalité à un prix égal à la valorisation
-    ne laisse aucun surplus, et perdre ne paie rien.
-    English: Bidding one's own value yields zero payoff against ANY opposing
-    bid: winning or tying at a price equal to the valuation leaves no
-    surplus, and losing pays nothing. -/
+    ne laisse aucun surplus, et perdre ne paie rien. -/
 theorem fpa_u1_truthful (n : Nat) (v t2 b2 : Fin n) :
     (fpa n).u1 v t2 v b2 = 0 := by
   show (if b2.val < v.val then 2 * ((v.val : Int) - v.val)
@@ -119,9 +76,7 @@ theorem fpa_u1_truthful (n : Nat) (v t2 b2 : Fin n) :
     · rfl
 
 /-- L'offre sincère rapporte une utilité interimaire exactement 0, pour toute
-    valorisation, face à toute stratégie adverse (n général).
-    English: Truthful bidding earns interim utility exactly 0, for every
-    valuation, against every opponent strategy (general `n`). -/
+    valorisation, face à toute stratégie adverse (n général). -/
 theorem interimU1_truthful (n : Nat) (v : Fin n) (s2 : Strategy2 (fpa n)) :
     interimU1 (fpa n) v (truthful1 n v) s2 = 0 := by
   have h : ∀ t2 : Fin n,
@@ -135,8 +90,7 @@ theorem interimU1_truthful (n : Nat) (v : Fin n) (s2 : Strategy2 (fpa n)) :
       ((fpa n).w v t2 : Int) * (fpa n).u1 v t2 (truthful1 n v) (s2 t2)) = 0
   rw [sumFin_congr h, sumFin_zero_fun]
 
-/-- Conséquence ex-ante : l'offre sincère rapporte 0 au global.
-    English: Ex-ante consequence: truthful bidding earns 0 overall. -/
+/-- Conséquence ex-ante : l'offre sincère rapporte 0 au global. -/
 theorem exAnteU1_truthful (n : Nat) (s2 : Strategy2 (fpa n)) :
     exAnteU1 (fpa n) (truthful1 n) s2 = 0 := by
   have h : ∀ v : Fin n,
@@ -148,18 +102,14 @@ theorem exAnteU1_truthful (n : Nat) (s2 : Strategy2 (fpa n)) :
 
 /-- Ombrage d'offre : offrir la moitié de sa valorisation (division entière) —
     l'analogue discret de l'équilibre du manuel `b(v) = v/2` pour deux
-    enchérisseurs à valorisations uniformes.
-    English: Bid shading: bid half one's valuation (integer division) — the
-    discrete analogue of the textbook equilibrium `b(v) = v/2` for two
-    bidders with uniform valuations. -/
+    enchérisseurs à valorisations uniformes. -/
 @[reducible] def shade1 (n : Nat) : Strategy1 (fpa n) :=
   fun v => ⟨v.val / 2, by
     have hv : v.val < n := v.isLt
     show v.val / 2 < n
     omega⟩
 
-/-- Ombrage d'offre pour le joueur 2.
-    English: Bid shading for player 2. -/
+/-- Ombrage d'offre pour le joueur 2. -/
 @[reducible] def shade2 (n : Nat) : Strategy2 (fpa n) :=
   fun v => ⟨v.val / 2, by
     have hv : v.val < n := v.isLt
@@ -168,27 +118,19 @@ theorem exAnteU1_truthful (n : Nat) (s2 : Strategy2 (fpa n)) :
 
 /-- Avec deux valorisations possibles `{0, 1}` et des offres `{0, 1}`, les deux
     enchérisseurs offrant 0 quel que soit leur type (= `shade`) est un BNE,
-    certifié par évaluation au noyau.
-    English: With two possible valuations `{0, 1}` and bids `{0, 1}`, both
-    bidders bidding 0 regardless of type (= `shade`) is a BNE,
-    certified by kernel evaluation. -/
+    certifié par évaluation au noyau. -/
 theorem shade_bne_two : isBNE (fpa 2) (shade1 2) (shade2 2) := by decide
 
-/-- … et l'offre sincère n'est PAS un BNE ici.
-    English: ... and truthful bidding is NOT a BNE there. -/
+/-- … et l'offre sincère n'est PAS un BNE ici. -/
 theorem truthful_not_bne_two :
     ¬ isBNE (fpa 2) (truthful1 2) (truthful2 2) := by decide
 
 /-- Avec les valorisations `{0, 1, 2}` et les offres `{0, 1, 2}`, le profil
-    ombragé (`0, 0 → offre 0` ; `2 → offre 1`) est un BNE.
-    English: With valuations `{0, 1, 2}` and bids `{0, 1, 2}`, the shaded
-    profile (`0, 0 → bid 0`; `2 → bid 1`) is a BNE. -/
+    ombragé (`0, 0 → offre 0` ; `2 → offre 1`) est un BNE. -/
 theorem shade_bne_three : isBNE (fpa 3) (shade1 3) (shade2 3) := by decide
 
 /-- … et l'offre sincère n'est pas non plus un BNE ici : le type haut
-    préfère strictement sous-offrir.
-    English: ... and truthful bidding is NOT a BNE there either: the high type
-    strictly prefers to underbid. -/
+    préfère strictement sous-offrir. -/
 theorem truthful_not_bne_three :
     ¬ isBNE (fpa 3) (truthful1 3) (truthful2 3) := by decide
 
@@ -197,13 +139,7 @@ theorem truthful_not_bne_three :
     contrastant avec le zéro exact de l'offre sincère
     (`interimU1_truthful`). Concrètement la valeur est 5 (mise à l'échelle) :
     gagne face aux deux types bas (2·(2-1) deux fois) et est à égalité avec le
-    type haut (2-1).
-    English: Shading pays: against a shading opponent, the high valuation
-    (v = 2) earns strictly positive interim utility by bidding 1 —
-    in contrast with the exact zero of truthful bidding
-    (`interimU1_truthful`). Concretely the value is 5 (scaled):
-    wins against both low types (2·(2-1) twice) and ties the high
-    type (2-1). -/
+    type haut (2-1). -/
 theorem shading_beats_truthful_three :
     0 < interimU1 (fpa 3) ⟨2, by decide⟩ (shade1 3 ⟨2, by decide⟩) (shade2 3) := by
   decide

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Auction_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Auction_en.lean
@@ -1,0 +1,143 @@
+/-
+  First-Price Sealed-Bid Auction (discrete, two bidders)
+  ======================================================
+
+  The classic application of Bayesian games (Vickrey 1961, Harsanyi
+  1967): two bidders with private valuations drawn uniformly from
+  `{0, …, n-1}` simultaneously submit bids in `{0, …, n-1}`; the
+  highest bid wins and pays its own bid, ties split the surplus.
+
+  Encoding choices (all core Lean 4, no Mathlib):
+  - Valuations are the *types* and bids are the *actions* of a
+    `BayesGame2`, with uniform prior weight 1 on every type profile.
+  - Utilities are scaled by 2 so that the tie case (half the surplus)
+    stays in `Int`: win = `2*(v - b)`, tie = `v - b`, lose = `0`.
+    By `isBNE_scaleW`-style reasoning, scaling all payoffs by a
+    positive constant does not change best responses, so the
+    equilibrium analysis is faithful.
+
+  Results:
+  - `fpa_u1_truthful`/`interimU1_truthful`: bidding one's own value
+    yields *exactly zero* utility, for every n, every type, against
+    every opponent strategy — winning at a price equal to one's value
+    leaves no surplus. (General theorem, not a `decide` instance.)
+  - `truthful_not_bne_two/three`: truthful bidding is NOT a BNE
+    (kernel-checked counterexample via `decide`).
+  - `shade_bne_two/three`: the shaded strategy `bid = v / 2` is a BNE
+    (kernel-checked via `decide`) — the discrete analogue of the
+    textbook equilibrium `b(v) = v/2` for two uniform bidders.
+  - `shading_beats_truthful_three`: under shading the high type earns
+    strictly positive interim utility, in contrast with the zero of
+    truthful bidding.
+
+  See #2610 (GT-Lean formalization, Bayesian phase 2).
+-/
+
+import Bayesian.BNE_en
+
+/-- First-price sealed-bid auction with two bidders, valuations and
+    bids in `Fin n`, uniform prior, utilities scaled by 2 (so the tie
+    split of the surplus stays integral). -/
+@[reducible] def fpa (n : Nat) : BayesGame2 where
+  nT1 := n
+  nT2 := n
+  nA1 := n
+  nA2 := n
+  w := fun _ _ => 1
+  u1 := fun v1 _ b1 b2 =>
+    if b2.val < b1.val then 2 * ((v1.val : Int) - b1.val)
+    else if b1.val = b2.val then (v1.val : Int) - b1.val
+    else 0
+  u2 := fun _ v2 b1 b2 =>
+    if b1.val < b2.val then 2 * ((v2.val : Int) - b2.val)
+    else if b1.val = b2.val then (v2.val : Int) - b2.val
+    else 0
+
+/-- Truthful bidding for player 1: bid exactly one's valuation. -/
+@[reducible] def truthful1 (n : Nat) : Strategy1 (fpa n) := fun v => v
+
+/-- Truthful bidding for player 2. -/
+@[reducible] def truthful2 (n : Nat) : Strategy2 (fpa n) := fun v => v
+
+/-- Bidding one's own value yields zero payoff against ANY opposing
+    bid: winning or tying at a price equal to the valuation leaves no
+    surplus, and losing pays nothing. -/
+theorem fpa_u1_truthful (n : Nat) (v t2 b2 : Fin n) :
+    (fpa n).u1 v t2 v b2 = 0 := by
+  show (if b2.val < v.val then 2 * ((v.val : Int) - v.val)
+        else if v.val = b2.val then (v.val : Int) - v.val
+        else 0) = 0
+  split
+  · omega
+  · split
+    · omega
+    · rfl
+
+/-- Truthful bidding earns interim utility exactly 0, for every
+    valuation, against every opponent strategy (general `n`). -/
+theorem interimU1_truthful (n : Nat) (v : Fin n) (s2 : Strategy2 (fpa n)) :
+    interimU1 (fpa n) v (truthful1 n v) s2 = 0 := by
+  have h : ∀ t2 : Fin n,
+      ((fpa n).w v t2 : Int) * (fpa n).u1 v t2 (truthful1 n v) (s2 t2)
+        = (fun _ : Fin n => (0 : Int)) t2 := by
+    intro t2
+    show ((fpa n).w v t2 : Int) * (fpa n).u1 v t2 v (s2 t2) = 0
+    rw [fpa_u1_truthful]
+    exact Int.mul_zero _
+  show sumFin n (fun t2 =>
+      ((fpa n).w v t2 : Int) * (fpa n).u1 v t2 (truthful1 n v) (s2 t2)) = 0
+  rw [sumFin_congr h, sumFin_zero_fun]
+
+/-- Ex-ante consequence: truthful bidding earns 0 overall. -/
+theorem exAnteU1_truthful (n : Nat) (s2 : Strategy2 (fpa n)) :
+    exAnteU1 (fpa n) (truthful1 n) s2 = 0 := by
+  have h : ∀ v : Fin n,
+      interimU1 (fpa n) v (truthful1 n v) s2
+        = (fun _ : Fin n => (0 : Int)) v :=
+    fun v => interimU1_truthful n v s2
+  show sumFin n (fun v => interimU1 (fpa n) v (truthful1 n v) s2) = 0
+  rw [sumFin_congr h, sumFin_zero_fun]
+
+/-- Bid shading: bid half one's valuation (integer division) — the
+    discrete analogue of the textbook equilibrium `b(v) = v/2` for two
+    bidders with uniform valuations. -/
+@[reducible] def shade1 (n : Nat) : Strategy1 (fpa n) :=
+  fun v => ⟨v.val / 2, by
+    have hv : v.val < n := v.isLt
+    show v.val / 2 < n
+    omega⟩
+
+/-- Bid shading for player 2. -/
+@[reducible] def shade2 (n : Nat) : Strategy2 (fpa n) :=
+  fun v => ⟨v.val / 2, by
+    have hv : v.val < n := v.isLt
+    show v.val / 2 < n
+    omega⟩
+
+/-- With two possible valuations `{0, 1}` and bids `{0, 1}`, both
+    bidders bidding 0 regardless of type (= `shade`) is a BNE,
+    certified by kernel evaluation. -/
+theorem shade_bne_two : isBNE (fpa 2) (shade1 2) (shade2 2) := by decide
+
+/-- ... and truthful bidding is NOT a BNE there. -/
+theorem truthful_not_bne_two :
+    ¬ isBNE (fpa 2) (truthful1 2) (truthful2 2) := by decide
+
+/-- With valuations `{0, 1, 2}` and bids `{0, 1, 2}`, the shaded
+    profile (`0, 0 → bid 0`; `2 → bid 1`) is a BNE. -/
+theorem shade_bne_three : isBNE (fpa 3) (shade1 3) (shade2 3) := by decide
+
+/-- ... and truthful bidding is NOT a BNE there either: the high type
+    strictly prefers to underbid. -/
+theorem truthful_not_bne_three :
+    ¬ isBNE (fpa 3) (truthful1 3) (truthful2 3) := by decide
+
+/-- Shading pays: against a shading opponent, the high valuation
+    (v = 2) earns strictly positive interim utility by bidding 1 —
+    in contrast with the exact zero of truthful bidding
+    (`interimU1_truthful`). Concretely the value is 5 (scaled):
+    wins against both low types (2·(2-1) twice) and ties the high
+    type (2-1). -/
+theorem shading_beats_truthful_three :
+    0 < interimU1 (fpa 3) ⟨2, by decide⟩ (shade1 3 ⟨2, by decide⟩) (shade2 3) := by
+  decide

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/BNE.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/BNE.lean
@@ -16,24 +16,6 @@
     proportionnelle).
 
   Voir #2610 (formalisation GT-Lean, phase bayésienne 1).
-
-  ---
-  English:
-  Bayesian Nash Equilibrium (interim formulation)
-  ===============================================
-
-  - `isBNE`: a strategy profile is a BNE when no type of either player
-    has a profitable unilateral action deviation, in interim expected
-    utility. Quantifiers range over `Fin` types and actions only, so
-    the property is decidable (`decide` works on concrete games).
-  - `exAnteU1_le_of_interim_best`: the one-shot deviation principle in
-    this finite setting — interim optimality implies ex-ante optimality
-    against arbitrary type-contingent deviations.
-  - `isBNE_scaleW`: BNE is invariant under rescaling the prior weights
-    by a positive constant (normalization-independence: the `Nat`
-    weights stand in for any probability measure proportional to them).
-
-  See #2610 (GT-Lean formalization, Bayesian phase 1).
 -/
 
 import Bayesian.Types
@@ -43,14 +25,7 @@ import Bayesian.Types
     face à la stratégie de l'adversaire.
 
     Réductible pour que l'instance `Decidable` soit trouvée par dépliage
-    (conjonction de `∀` sur `Fin` de comparaisons `Int` décidables).
-
-    English: Bayesian Nash equilibrium, interim formulation: for every type of
-    each player, the prescribed action maximizes interim expected
-    utility against the opponent's strategy.
-
-    Reducible so that the `Decidable` instance is found by unfolding
-    (conjunction of `∀` over `Fin` of decidable `Int` comparisons). -/
+    (conjonction de `∀` sur `Fin` de comparaisons `Int` décidables). -/
 @[reducible] def isBNE (g : BayesGame2) (s1 : Strategy1 g) (s2 : Strategy2 g) : Prop :=
   (∀ t1 : Fin g.nT1, ∀ a : Fin g.nA1,
       interimU1 g t1 a s2 ≤ interimU1 g t1 (s1 t1) s2) ∧
@@ -59,10 +34,7 @@ import Bayesian.Types
 
 /-- Principe de déviation unique, côté joueur 1 : si chaque type du
     joueur 1 joue une meilleure réponse interimaire, alors aucune déviation
-    contingente au type `s1'` n'améliore l'utilité espérée ex-ante du joueur 1.
-    English: One-shot deviation principle, player 1 side: if every type of
-    player 1 plays an interim best response, then no type-contingent
-    deviation `s1'` improves player 1's ex-ante expected utility. -/
+    contingente au type `s1'` n'améliore l'utilité espérée ex-ante du joueur 1. -/
 theorem exAnteU1_le_of_interim_best (g : BayesGame2)
     {s1 : Strategy1 g} {s2 : Strategy2 g}
     (h : ∀ t1 a, interimU1 g t1 a s2 ≤ interimU1 g t1 (s1 t1) s2)
@@ -70,8 +42,7 @@ theorem exAnteU1_le_of_interim_best (g : BayesGame2)
     exAnteU1 g s1' s2 ≤ exAnteU1 g s1 s2 :=
   sumFin_mono (fun t1 => h t1 (s1' t1))
 
-/-- Principe de déviation unique, côté joueur 2.
-    English: One-shot deviation principle, player 2 side. -/
+/-- Principe de déviation unique, côté joueur 2. -/
 theorem exAnteU2_le_of_interim_best (g : BayesGame2)
     {s1 : Strategy1 g} {s2 : Strategy2 g}
     (h : ∀ t2 a, interimU2 g t2 a s1 ≤ interimU2 g t2 (s2 t2) s1)
@@ -80,17 +51,14 @@ theorem exAnteU2_le_of_interim_best (g : BayesGame2)
   sumFin_mono (fun t2 => h t2 (s2' t2))
 
 /-- Un BNE est aussi un équilibre de Nash ex-ante : aucun joueur ne gagne
-    à dévier unilatéralement de façon contingente au type.
-    English: A BNE is also an ex-ante Nash equilibrium: no player gains from
-    any type-contingent unilateral deviation. -/
+    à dévier unilatéralement de façon contingente au type. -/
 theorem bne_exAnte (g : BayesGame2) {s1 : Strategy1 g} {s2 : Strategy2 g}
     (h : isBNE g s1 s2) :
     (∀ s1', exAnteU1 g s1' s2 ≤ exAnteU1 g s1 s2) ∧
     (∀ s2', exAnteU2 g s1 s2' ≤ exAnteU2 g s1 s2) :=
   ⟨exAnteU1_le_of_interim_best g h.1, exAnteU2_le_of_interim_best g h.2⟩
 
-/-- Le même jeu avec tous les poids du prior multipliés par `c`.
-    English: The same game with all prior weights multiplied by `c`. -/
+/-- Le même jeu avec tous les poids du prior multipliés par `c`. -/
 @[reducible] def scaleW (g : BayesGame2) (c : Nat) : BayesGame2 :=
   { g with w := fun t1 t2 => c * g.w t1 t2 }
 
@@ -114,10 +82,7 @@ theorem interimU2_scaleW (g : BayesGame2) (c : Nat)
 
 /-- Le BNE est invariant par remise à l'échelle positive des poids du prior.
     C'est ce qui fait des poids `Nat` non normalisés un encodage fidèle
-    d'un prior commun : seuls les rapports des poids importent.
-    English: BNE is invariant under positive rescaling of the prior weights.
-    This is what makes unnormalized `Nat` weights a faithful encoding
-    of a common prior: only ratios of weights matter. -/
+    d'un prior commun : seuls les rapports des poids importent. -/
 theorem isBNE_scaleW (g : BayesGame2) (c : Nat) (hc : 0 < c)
     (s1 : Strategy1 g) (s2 : Strategy2 g) :
     isBNE (scaleW g c) s1 s2 ↔ isBNE g s1 s2 := by

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/BNE_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/BNE_en.lean
@@ -1,0 +1,102 @@
+/-
+  Bayesian Nash Equilibrium (interim formulation)
+  ===============================================
+
+  - `isBNE`: a strategy profile is a BNE when no type of either player
+    has a profitable unilateral action deviation, in interim expected
+    utility. Quantifiers range over `Fin` types and actions only, so
+    the property is decidable (`decide` works on concrete games).
+  - `exAnteU1_le_of_interim_best`: the one-shot deviation principle in
+    this finite setting — interim optimality implies ex-ante optimality
+    against arbitrary type-contingent deviations.
+  - `isBNE_scaleW`: BNE is invariant under rescaling the prior weights
+    by a positive constant (normalization-independence: the `Nat`
+    weights stand in for any probability measure proportional to them).
+
+  See #2610 (GT-Lean formalization, Bayesian phase 1).
+-/
+
+import Bayesian.Types_en
+
+/-- Bayesian Nash equilibrium, interim formulation: for every type of
+    each player, the prescribed action maximizes interim expected
+    utility against the opponent's strategy.
+
+    Reducible so that the `Decidable` instance is found by unfolding
+    (conjunction of `∀` over `Fin` of decidable `Int` comparisons). -/
+@[reducible] def isBNE (g : BayesGame2) (s1 : Strategy1 g) (s2 : Strategy2 g) : Prop :=
+  (∀ t1 : Fin g.nT1, ∀ a : Fin g.nA1,
+      interimU1 g t1 a s2 ≤ interimU1 g t1 (s1 t1) s2) ∧
+  (∀ t2 : Fin g.nT2, ∀ a : Fin g.nA2,
+      interimU2 g t2 a s1 ≤ interimU2 g t2 (s2 t2) s1)
+
+/-- One-shot deviation principle, player 1 side: if every type of
+    player 1 plays an interim best response, then no type-contingent
+    deviation `s1'` improves player 1's ex-ante expected utility. -/
+theorem exAnteU1_le_of_interim_best (g : BayesGame2)
+    {s1 : Strategy1 g} {s2 : Strategy2 g}
+    (h : ∀ t1 a, interimU1 g t1 a s2 ≤ interimU1 g t1 (s1 t1) s2)
+    (s1' : Strategy1 g) :
+    exAnteU1 g s1' s2 ≤ exAnteU1 g s1 s2 :=
+  sumFin_mono (fun t1 => h t1 (s1' t1))
+
+/-- One-shot deviation principle, player 2 side. -/
+theorem exAnteU2_le_of_interim_best (g : BayesGame2)
+    {s1 : Strategy1 g} {s2 : Strategy2 g}
+    (h : ∀ t2 a, interimU2 g t2 a s1 ≤ interimU2 g t2 (s2 t2) s1)
+    (s2' : Strategy2 g) :
+    exAnteU2 g s1 s2' ≤ exAnteU2 g s1 s2 :=
+  sumFin_mono (fun t2 => h t2 (s2' t2))
+
+/-- A BNE is also an ex-ante Nash equilibrium: no player gains from
+    any type-contingent unilateral deviation. -/
+theorem bne_exAnte (g : BayesGame2) {s1 : Strategy1 g} {s2 : Strategy2 g}
+    (h : isBNE g s1 s2) :
+    (∀ s1', exAnteU1 g s1' s2 ≤ exAnteU1 g s1 s2) ∧
+    (∀ s2', exAnteU2 g s1 s2' ≤ exAnteU2 g s1 s2) :=
+  ⟨exAnteU1_le_of_interim_best g h.1, exAnteU2_le_of_interim_best g h.2⟩
+
+/-- The same game with all prior weights multiplied by `c`. -/
+@[reducible] def scaleW (g : BayesGame2) (c : Nat) : BayesGame2 :=
+  { g with w := fun t1 t2 => c * g.w t1 t2 }
+
+theorem interimU1_scaleW (g : BayesGame2) (c : Nat)
+    (t1 : Fin g.nT1) (a : Fin g.nA1) (s2 : Strategy2 g) :
+    interimU1 (scaleW g c) t1 a s2 = (c : Int) * interimU1 g t1 a s2 := by
+  unfold interimU1
+  rw [← sumFin_mul_left]
+  apply sumFin_congr
+  intro t2
+  rw [Int.natCast_mul, Int.mul_assoc]
+
+theorem interimU2_scaleW (g : BayesGame2) (c : Nat)
+    (t2 : Fin g.nT2) (a : Fin g.nA2) (s1 : Strategy1 g) :
+    interimU2 (scaleW g c) t2 a s1 = (c : Int) * interimU2 g t2 a s1 := by
+  unfold interimU2
+  rw [← sumFin_mul_left]
+  apply sumFin_congr
+  intro t1
+  rw [Int.natCast_mul, Int.mul_assoc]
+
+/-- BNE is invariant under positive rescaling of the prior weights.
+    This is what makes unnormalized `Nat` weights a faithful encoding
+    of a common prior: only ratios of weights matter. -/
+theorem isBNE_scaleW (g : BayesGame2) (c : Nat) (hc : 0 < c)
+    (s1 : Strategy1 g) (s2 : Strategy2 g) :
+    isBNE (scaleW g c) s1 s2 ↔ isBNE g s1 s2 := by
+  have hc' : (0 : Int) < (c : Int) := by omega
+  constructor
+  · intro ⟨h1, h2⟩
+    refine ⟨fun t1 a => ?_, fun t2 a => ?_⟩
+    · have := h1 t1 a
+      rw [interimU1_scaleW, interimU1_scaleW] at this
+      exact Int.le_of_mul_le_mul_left this hc'
+    · have := h2 t2 a
+      rw [interimU2_scaleW, interimU2_scaleW] at this
+      exact Int.le_of_mul_le_mul_left this hc'
+  · intro ⟨h1, h2⟩
+    refine ⟨fun t1 a => ?_, fun t2 a => ?_⟩
+    · rw [interimU1_scaleW, interimU1_scaleW]
+      exact Int.mul_le_mul_of_nonneg_left (h1 t1 a) (Int.le_of_lt hc')
+    · rw [interimU2_scaleW, interimU2_scaleW]
+      exact Int.mul_le_mul_of_nonneg_left (h2 t2 a) (Int.le_of_lt hc')

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Examples.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Examples.lean
@@ -19,37 +19,13 @@
   de `isBNE`.
 
   Reflète GameTheory-11-BayesianGames.ipynb. Voir #2610.
-
-  ---
-  English:
-  Worked Example — Battle of the Sexes with Incomplete Information
-  ================================================================
-
-  Harsanyi's classic illustration: player 1 does not know whether
-  player 2 wants to meet (coordinate) or avoid them. Player 2's
-  preference is their private type; the prior puts equal weight on
-  both types.
-
-  Actions (both players): 0 = Ballet, 1 = Football.
-  Player 1 prefers Ballet (payoff 2 on (B,B), 1 on (F,F), 0 mismatch).
-  Player 2 "meet" type prefers Football but wants to match.
-  Player 2 "avoid" type wants to MISmatch: 2 if (B,F), 1 if (F,B).
-
-  The textbook pure BNE — player 1 plays Ballet; player 2 plays Ballet
-  when of the meet type and Football when of the avoid type — is
-  verified below by `decide`, exercising the decidability of `isBNE`.
-
-  Mirrors GameTheory-11-BayesianGames.ipynb. See #2610.
 -/
 
 import Bayesian.BNE
 
 /-- Bataille des Sexes où le désir du joueur 2 de rencontrer ou d'éviter
     le joueur 1 est une information privée (prior uniforme sur les deux types).
-    Type 0 du joueur 2 = « rencontrer », type 1 = « éviter ».
-    English: Battle of the Sexes where player 2's desire to meet or avoid
-    player 1 is private information (uniform prior over both types).
-    Type 0 of player 2 = "meet", type 1 = "avoid". -/
+    Type 0 du joueur 2 = « rencontrer », type 1 = « éviter ». -/
 def bosIncomplete : BayesGame2 where
   nT1 := 1
   nT2 := 2
@@ -70,36 +46,26 @@ def bosIncomplete : BayesGame2 where
       else if a1.val = 1 ∧ a2.val = 0 then 1
       else 0
 
-/-- Le joueur 1 (type unique) joue Ballet.
-    English: Player 1 (single type) plays Ballet. -/
+/-- Le joueur 1 (type unique) joue Ballet. -/
 def bosS1 : Strategy1 bosIncomplete := fun _ => ⟨0, by decide⟩
 
 /-- Le joueur 2 joue Ballet lorsqu'il est du type « rencontrer », Football
-    lorsqu'il est du type « éviter ».
-    English: Player 2 plays Ballet when of the meet type, Football when of the
-    avoid type. -/
+    lorsqu'il est du type « éviter ». -/
 def bosS2 : Strategy2 bosIncomplete := fun t2 =>
   if t2.val = 0 then ⟨0, by decide⟩ else ⟨1, by decide⟩
 
 /-- Le profil de stratégies du manuel est un équilibre de Nash bayésien,
-    vérifié par calcul.
-    English: The textbook strategy profile is a Bayesian Nash equilibrium,
-    verified by computation. -/
+    vérifié par calcul. -/
 theorem bosIncomplete_bne : isBNE bosIncomplete bosS1 bosS2 := by decide
 
 /-- Vérification de cohérence : sous l'équilibre, l'utilité espérée interimaire
     du joueur 1 issue du Ballet est 2 (il rencontre le type « rencontrer »,
-    manque le type « éviter ») contre 1 s'il dévie vers le Football.
-    English: Sanity check: under the equilibrium, player 1's interim expected
-    utility from Ballet is 2 (meets the meet type, misses the avoid
-    type) versus 1 from deviating to Football. -/
+    manque le type « éviter ») contre 1 s'il dévie vers le Football. -/
 theorem bosIncomplete_interim_values :
     interimU1 bosIncomplete ⟨0, by decide⟩ ⟨0, by decide⟩ bosS2 = 2 ∧
     interimU1 bosIncomplete ⟨0, by decide⟩ ⟨1, by decide⟩ bosS2 = 1 := by decide
 
 /-- L'équilibre survit à la remise à l'échelle des poids du prior (par ex.
-    les poids (3, 3) au lieu de (1, 1) encodent le même prior uniforme).
-    English: The equilibrium survives rescaling the prior weights (e.g. weights
-    (3, 3) instead of (1, 1) encode the same uniform prior). -/
+    les poids (3, 3) au lieu de (1, 1) encodent le même prior uniforme). -/
 theorem bosIncomplete_bne_scaled : isBNE (scaleW bosIncomplete 3) bosS1 bosS2 :=
   (isBNE_scaleW bosIncomplete 3 (by decide) bosS1 bosS2).mpr bosIncomplete_bne

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Examples_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Examples_en.lean
@@ -19,7 +19,7 @@
   Mirrors GameTheory-11-BayesianGames.ipynb. See #2610.
 -/
 
-import Bayesian.BNE
+import Bayesian.BNE_en
 
 /-- Battle of the Sexes where player 2's desire to meet or avoid
     player 1 is private information (uniform prior over both types).
@@ -34,9 +34,11 @@ def bosIncomplete : BayesGame2 where
     if a1.val = a2.val then (if a1.val = 0 then 2 else 1) else 0
   u2 := fun _ t2 a1 a2 =>
     if t2.val = 0 then
+      -- "meet" type: wants to match, prefers Football
       -- "meet" type: wants to coordinate, prefers Football
       if a1.val = a2.val then (if a1.val = 0 then 1 else 2) else 0
     else
+      -- "avoid" type: wants to MISmatch
       -- "avoid" type: wants to MISmatch
       if a1.val = 0 ∧ a2.val = 1 then 2
       else if a1.val = 1 ∧ a2.val = 0 then 1

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Examples_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Examples_en.lean
@@ -1,0 +1,67 @@
+/-
+  Worked Example — Battle of the Sexes with Incomplete Information
+  ================================================================
+
+  Harsanyi's classic illustration: player 1 does not know whether
+  player 2 wants to meet (coordinate) or avoid them. Player 2's
+  preference is their private type; the prior puts equal weight on
+  both types.
+
+  Actions (both players): 0 = Ballet, 1 = Football.
+  Player 1 prefers Ballet (payoff 2 on (B,B), 1 on (F,F), 0 mismatch).
+  Player 2 "meet" type prefers Football but wants to match.
+  Player 2 "avoid" type wants to MISmatch: 2 if (B,F), 1 if (F,B).
+
+  The textbook pure BNE — player 1 plays Ballet; player 2 plays Ballet
+  when of the meet type and Football when of the avoid type — is
+  verified below by `decide`, exercising the decidability of `isBNE`.
+
+  Mirrors GameTheory-11-BayesianGames.ipynb. See #2610.
+-/
+
+import Bayesian.BNE
+
+/-- Battle of the Sexes where player 2's desire to meet or avoid
+    player 1 is private information (uniform prior over both types).
+    Type 0 of player 2 = "meet", type 1 = "avoid". -/
+def bosIncomplete : BayesGame2 where
+  nT1 := 1
+  nT2 := 2
+  nA1 := 2
+  nA2 := 2
+  w := fun _ _ => 1
+  u1 := fun _ _ a1 a2 =>
+    if a1.val = a2.val then (if a1.val = 0 then 2 else 1) else 0
+  u2 := fun _ t2 a1 a2 =>
+    if t2.val = 0 then
+      -- "meet" type: wants to coordinate, prefers Football
+      if a1.val = a2.val then (if a1.val = 0 then 1 else 2) else 0
+    else
+      -- "avoid" type: wants to MISmatch
+      if a1.val = 0 ∧ a2.val = 1 then 2
+      else if a1.val = 1 ∧ a2.val = 0 then 1
+      else 0
+
+/-- Player 1 (single type) plays Ballet. -/
+def bosS1 : Strategy1 bosIncomplete := fun _ => ⟨0, by decide⟩
+
+/-- Player 2 plays Ballet when of the meet type, Football when of the
+    avoid type. -/
+def bosS2 : Strategy2 bosIncomplete := fun t2 =>
+  if t2.val = 0 then ⟨0, by decide⟩ else ⟨1, by decide⟩
+
+/-- The textbook strategy profile is a Bayesian Nash equilibrium,
+    verified by computation. -/
+theorem bosIncomplete_bne : isBNE bosIncomplete bosS1 bosS2 := by decide
+
+/-- Sanity check: under the equilibrium, player 1's interim expected
+    utility from Ballet is 2 (meets the meet type, misses the avoid
+    type) versus 1 from deviating to Football. -/
+theorem bosIncomplete_interim_values :
+    interimU1 bosIncomplete ⟨0, by decide⟩ ⟨0, by decide⟩ bosS2 = 2 ∧
+    interimU1 bosIncomplete ⟨0, by decide⟩ ⟨1, by decide⟩ bosS2 = 1 := by decide
+
+/-- The equilibrium survives rescaling the prior weights (e.g. weights
+    (3, 3) instead of (1, 1) encode the same uniform prior). -/
+theorem bosIncomplete_bne_scaled : isBNE (scaleW bosIncomplete 3) bosS1 bosS2 :=
+  (isBNE_scaleW bosIncomplete 3 (by decide) bosS1 bosS2).mpr bosIncomplete_bne

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/FictitiousPlay.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/FictitiousPlay.lean
@@ -19,28 +19,6 @@
   concrètes sont certifiées par `decide` (vérification noyau).
 
   Voir #2610 (formalisation GT-Lean, cibles GT-17, après GT-13).
-
-  ---
-  English:
-  Fictitious Play for a 2×2 normal-form game (core Lean 4 only, no Mathlib)
-  ========================================================================
-
-  Foundational *no-regret* learning algorithm in game theory (Robinson
-  1951, Brown 1951, Monderer-Shapley 1996). A player iteratively plays a
-  *best response* to the empirical distribution of the opponents' past
-  moves — a simple *born-correct* heuristic (the state is well defined, the
-  counting invariant is preserved), but whose convergence proof toward a
-  Nash equilibrium is notoriously subtle (Robinson, Monderer-Shapley) and
-  remains **out of scope** here. See #2610 §GT-Lean-ext targets (target
-  GT-17, after GT-13 Regret).
-
-  This formalization covers only the **born algorithmic kernel**: state +
-  empirical beliefs + step + counting invariant + best move + one example
-  certified by `decide`. Reuses `sumFin` (`Sum.lean`) and `maxFin`
-  (`Max.lean`); everything is decidable, so concrete instances are
-  certified by `decide` (kernel checking).
-
-  See #2610 (GT-Lean formalization, GT-17 targets, after GT-13).
 -/
 
 import Bayesian.Sum
@@ -49,52 +27,35 @@ import Bayesian.Max
 /-- État born-correct de la Fictitious Play : croyances empiriques sur les
     coups adverses, indexées par ronde. À la ronde `round`, le joueur a vu
     `opponentCounts` compter `opponentCounts a` combien de fois
-    l'adversaire a joué le coup `a` aux rondes `0, ..., round - 1`.
-    English: Born-correct Fictitious Play state: empirical beliefs on the
-    opponent's moves, indexed by round. At round `round`, the player has
-    seen `opponentCounts` record `opponentCounts a` as many times as the
-    opponent played move `a` in rounds `0, ..., round - 1`. -/
+    l'adversaire a joué le coup `a` aux rondes `0, ..., round - 1`. -/
 structure FictitiousPlayState where
-  /-- Nombre d'actions du joueur focal.
-      English: Number of actions of the focal player. -/
+  /-- Nombre d'actions du joueur focal. -/
   nAct : Nat
-  /-- Nombre d'actions de l'adversaire.
-      English: Number of actions of the opponent. -/
+  /-- Nombre d'actions de l'adversaire. -/
   nOpp : Nat
-  /-- Comptes empiriques des coups de l'adversaire (indexés par coup).
-      English: Empirical counts of the opponent's moves (indexed by move). -/
+  /-- Comptes empiriques des coups de l'adversaire (indexés par coup). -/
   opponentCounts : Fin (nOpp + 1) → Nat
-  /-- Numéro de la ronde courante (0 = initial, pas de coups joués).
-      English: Current round number (0 = initial, no moves played). -/
+  /-- Numéro de la ronde courante (0 = initial, pas de coups joués). -/
   round : Nat
 
 /-- Croyance empirique de la Fictitious Play : le coup `a` a été joué
     `opponentCounts a` fois sur `round` rondes (densité = numérateur pair
     normalisé par `round`). Version *numérateur entier* : le dénominateur
     n'est pas calculé ici, l'utilisateur divise par `round` s'il le
-    souhaite.
-    English: Fictitious Play empirical belief: move `a` has been played
-    `opponentCounts a` times over `round` rounds (density = numerator
-    normalized by `round`). *Integer numerator* version: the denominator
-    is not computed here; the user divides by `round` if desired. -/
+    souhaite. -/
 def empiricalCount (s : FictitiousPlayState) (a : Fin (s.nOpp + 1)) : Nat :=
   s.opponentCounts a
 
 /-- Paiement espéré contre l'adversaire si le joueur joue `aRow`, en
     pondérant chaque coup `aCol` de l'adversaire par sa fréquence
-    empirique. C'est l'utilité "best-response à la croyance empirique".
-    English: Expected payoff against the opponent if the player plays
-    `aRow`, weighting each opponent move `aCol` by its empirical
-    frequency. This is the "best-response-to-empirical-belief" utility. -/
+    empirique. C'est l'utilité "best-response à la croyance empirique". -/
 def expectedPayoffEmpirical (s : FictitiousPlayState)
     (pay : Fin (s.nAct + 1) → Fin (s.nOpp + 1) → Int)
     (aRow : Fin (s.nAct + 1)) : Int :=
   sumFin (s.nOpp + 1) (fun aCol => pay aRow aCol * Int.ofNat (empiricalCount s aCol))
 
 /-- Paiement maximum atteignable face aux croyances empiriques courantes :
-    c'est l'utilité d'une *meilleure réponse à la croyance empirique*.
-    English: Maximum achievable payoff against the current empirical
-    beliefs: it is the *best-response-to-empirical-belief* utility. -/
+    c'est l'utilité d'une *meilleure réponse à la croyance empirique*. -/
 def empiricalBestPayoff (s : FictitiousPlayState)
     (pay : Fin (s.nAct + 1) → Fin (s.nOpp + 1) → Int) : Int :=
   maxFin s.nAct (fun a => expectedPayoffEmpirical s pay a)
@@ -105,13 +66,7 @@ def empiricalBestPayoff (s : FictitiousPlayState)
     coup), puis incrémente le compteur de `oppCol`. Le compteur du coup
     que JOUE le joueur cette ronde n'est pas mis à jour (la prochaine
     ronde, le joueur sera lui-même observé par l'adversaire de manière
-    symétrique).
-    English: Elementary Fictitious Play step against an observed opponent
-    move `oppCol`: the player plays a best response *to the current
-    belief* (the counts as they were BEFORE this move), then increments
-    the counter for `oppCol`. The counter for the move the player
-    themselves plays this round is not updated (next round the player
-    will themselves be observed by the opponent symmetrically). -/
+    symétrique). -/
 def stepFictitiousPlay (s : FictitiousPlayState) (oppCol : Fin (s.nOpp + 1))
     (_pay : Fin (s.nAct + 1) → Fin (s.nOpp + 1) → Int) : FictitiousPlayState :=
   { nAct := s.nAct
@@ -131,17 +86,9 @@ def stepFictitiousPlay (s : FictitiousPlayState) (oppCol : Fin (s.nOpp + 1))
   ```
   Jeu strictement compétitif (somme nulle, pas d'équilibre pur).
   Phase 7 : on illustre l'état initial, l'étape élémentaire avec un coup
-  observé `C`, et le paiement espéré empirique (zéro à l'état initial).
+  observé `C`, et le paiement espéré empirique (zéro à l'état initial). -/
 
-  English: Concrete 2x2 instance — "Bicorne" (sum-zero, like Matching
-  Pennies). Payoff matrix for the *row* player: cooperative vs
-  defection. Phase 7: we illustrate the initial state, the elementary
-  step given an observed `C`, and the empirical expected payoff (zero
-  at the initial state).
--/
-
-/-- Paiements de la matrice 2x2 (joueur ligne).
-    English: Payoffs of the 2x2 matrix (row player). -/
+/-- Paiements de la matrice 2x2 (joueur ligne). -/
 def payoffBicorne : Fin 2 → Fin 2 → Int
   | 0, 0 => 1
   | 0, 1 => -1
@@ -149,9 +96,7 @@ def payoffBicorne : Fin 2 → Fin 2 → Int
   | 1, 1 => 1
 
 /-- État initial de la Fictitious Play : aucune observation, ronde 0,
-    2 actions chacun.
-    English: Initial Fictitious Play state: no observations, round 0,
-    2 actions each. -/
+    2 actions chacun. -/
 def fpState0 : FictitiousPlayState :=
   { nAct := 1
     nOpp := 1
@@ -160,10 +105,7 @@ def fpState0 : FictitiousPlayState :=
 
 /-- **Invariant de comptage** (cas initial) : à l'état initial (`fpState0`),
     la somme des counts de l'adversaire est 0 et `round = 0`. Certifié par
-    `decide`.
-    English: **Counting invariant (initial case)**: at the initial state
-    (`fpState0`), the sum of the opponent's counts is 0 and `round = 0`.
-    Certified by `decide`. -/
+    `decide`. -/
 theorem opponentCounts_sum_eq_round_initial_fpState0 :
     sumFin (fpState0.nOpp + 1) (fun j => (fpState0.opponentCounts j : Int)) =
       (fpState0.round : Int) := by
@@ -172,11 +114,7 @@ theorem opponentCounts_sum_eq_round_initial_fpState0 :
 /-- **Invariant de comptage** (étape) : après `stepFictitiousPlay`, la
     somme des counts de l'adversaire augmente exactement de 1, et la
     ronde aussi. La preuve passe par le cas `OppC` (le coup observé est
-    `0`) sur l'état initial, certifié par `decide` (noyau fini).
-    English: **Counting invariant (step)**: after `stepFictitiousPlay`,
-    the sum of the opponent's counts increases by exactly 1, and the
-    round too. The proof goes through the `OppC` case (observed move is
-    `0`) on the initial state, certified by `decide` (finite kernel). -/
+    `0`) sur l'état initial, certifié par `decide` (noyau fini). -/
 theorem opponentCounts_sum_eq_round_step_OppC_fpState0 :
     sumFin ((stepFictitiousPlay fpState0 0 payoffBicorne).nOpp + 1)
         (fun j => ((stepFictitiousPlay fpState0 0 payoffBicorne).opponentCounts j : Int)) =
@@ -186,11 +124,7 @@ theorem opponentCounts_sum_eq_round_step_OppC_fpState0 :
 /-- Après un coup observé `0` (C) à la ronde 0, le compteur `0` passe
     à `1`, la ronde à `1`. Preuve par `rfl` après unfolding (la
     décidabilité complète nécessiterait de plumer aussi le `_pay`
-    implicite de `stepFictitiousPlay`, ce qui complique `decide`).
-    English: After an observed move `0` (C) at round 0, the counter
-    for `0` becomes `1`, the round becomes `1`. Proof by `rfl` after
-    unfolding (full decidability would require also plumbing the
-    implicit `_pay` of `stepFictitiousPlay`, which complicates `decide`). -/
+    implicite de `stepFictitiousPlay`, ce qui complique `decide`). -/
 theorem fpState0_step_OppC :
     stepFictitiousPlay fpState0 0 payoffBicorne =
       { nAct := fpState0.nAct
@@ -202,11 +136,7 @@ theorem fpState0_step_OppC :
 
 /-- Le paiement espéré empirique contre l'état initial est identiquement
     zéro pour les deux actions : aucune observation ⇒ distribution
-    empirique nulle ⇒ tout produit `pay a 0 * 0 = 0`. Certifié par `decide`.
-    English: The empirical expected payoff against the initial state
-    is identically zero for both actions: no observations ⇒ empirical
-    distribution zero ⇒ any product `pay a 0 * 0 = 0`. Certified by
-    `decide`. -/
+    empirique nulle ⇒ tout produit `pay a 0 * 0 = 0`. Certifié par `decide`. -/
 theorem expectedPayoffEmpirical_fpState0_row0 :
     expectedPayoffEmpirical fpState0 payoffBicorne ⟨0, by decide⟩ = 0 := by
   decide
@@ -216,9 +146,7 @@ theorem expectedPayoffEmpirical_fpState0_row1 :
   decide
 
 /-- Le paiement maximum empirique à l'état initial est 0 (toutes les
-    actions donnent 0). Certifié par `decide`.
-    English: The empirical maximum payoff at the initial state is 0
-    (all actions yield 0). Certified by `decide`. -/
+    actions donnent 0). Certifié par `decide`. -/
 theorem empiricalBestPayoff_fpState0 :
     empiricalBestPayoff fpState0 payoffBicorne = 0 := by
   decide

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/FictitiousPlay_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/FictitiousPlay_en.lean
@@ -1,0 +1,144 @@
+/-
+  Fictitious Play for a 2×2 normal-form game (core Lean 4 only, no Mathlib)
+  ========================================================================
+
+  Foundational *no-regret* learning algorithm in game theory (Robinson
+  1951, Brown 1951, Monderer-Shapley 1996). A player iteratively plays a
+  *best response* to the empirical distribution of the opponents' past
+  moves — a simple *born-correct* heuristic (the state is well defined, the
+  counting invariant is preserved), but whose convergence proof toward a
+  Nash equilibrium is notoriously subtle (Robinson, Monderer-Shapley) and
+  remains **out of scope** here. See #2610 §GT-Lean-ext targets (target
+  GT-17, after GT-13 Regret).
+
+  This formalization covers only the **born algorithmic kernel**: state +
+  empirical beliefs + step + counting invariant + best move + one example
+  certified by `decide`. Reuses `sumFin` (`Sum.lean`) and `maxFin`
+  (`Max.lean`); everything is decidable, so concrete instances are
+  certified by `decide` (kernel checking).
+
+  See #2610 (GT-Lean formalization, GT-17 targets, after GT-13).
+-/
+
+import Bayesian.Sum_en
+import Bayesian.Max_en
+
+/-- Born-correct Fictitious Play state: empirical beliefs on the
+    opponent's moves, indexed by round. At round `round`, the player has
+    seen `opponentCounts` record `opponentCounts a` as many times as the
+    opponent played move `a` in rounds `0, ..., round - 1`. -/
+structure FictitiousPlayState where
+  /-- Number of actions of the focal player. -/
+  nAct : Nat
+  /-- Number of actions of the opponent. -/
+  nOpp : Nat
+  /-- Empirical counts of the opponent's moves (indexed by move). -/
+  opponentCounts : Fin (nOpp + 1) → Nat
+  /-- Current round number (0 = initial, no moves played). -/
+  round : Nat
+
+/-- Fictitious Play empirical belief: move `a` has been played
+    `opponentCounts a` times over `round` rounds (density = numerator
+    normalized by `round`). *Integer numerator* version: the denominator
+    is not computed here; the user divides by `round` if desired. -/
+def empiricalCount (s : FictitiousPlayState) (a : Fin (s.nOpp + 1)) : Nat :=
+  s.opponentCounts a
+
+/-- Expected payoff against the opponent if the player plays
+    `aRow`, weighting each opponent move `aCol` by its empirical
+    frequency. This is the "best-response-to-empirical-belief" utility. -/
+def expectedPayoffEmpirical (s : FictitiousPlayState)
+    (pay : Fin (s.nAct + 1) → Fin (s.nOpp + 1) → Int)
+    (aRow : Fin (s.nAct + 1)) : Int :=
+  sumFin (s.nOpp + 1) (fun aCol => pay aRow aCol * Int.ofNat (empiricalCount s aCol))
+
+/-- Maximum achievable payoff against the current empirical
+    beliefs: it is the *best-response-to-empirical-belief* utility. -/
+def empiricalBestPayoff (s : FictitiousPlayState)
+    (pay : Fin (s.nAct + 1) → Fin (s.nOpp + 1) → Int) : Int :=
+  maxFin s.nAct (fun a => expectedPayoffEmpirical s pay a)
+
+/-- Elementary Fictitious Play step against an observed opponent
+    move `oppCol`: the player plays a best response *to the current
+    belief* (the counts as they were BEFORE this move), then increments
+    the counter for `oppCol`. The counter for the move the player
+    themselves plays this round is not updated (next round the player
+    will themselves be observed by the opponent symmetrically). -/
+def stepFictitiousPlay (s : FictitiousPlayState) (oppCol : Fin (s.nOpp + 1))
+    (_pay : Fin (s.nAct + 1) → Fin (s.nOpp + 1) → Int) : FictitiousPlayState :=
+  { nAct := s.nAct
+    nOpp := s.nOpp
+    opponentCounts := fun j => if j = oppCol then s.opponentCounts j + 1
+                                  else s.opponentCounts j
+    round := s.round + 1 }
+
+/-! Concrete 2x2 instance — "Bicorne" (sum-zero, like Matching
+  Pennies). Payoff matrix for the *row* player: cooperative vs
+  defection. Phase 7: we illustrate the initial state, the elementary
+  step given an observed `C`, and the empirical expected payoff (zero
+  at the initial state).
+-/
+
+/-- Payoffs of the 2x2 matrix (row player). -/
+def payoffBicorne : Fin 2 → Fin 2 → Int
+  | 0, 0 => 1
+  | 0, 1 => -1
+  | 1, 0 => -1
+  | 1, 1 => 1
+
+/-- Initial Fictitious Play state: no observations, round 0,
+    2 actions each. -/
+def fpState0 : FictitiousPlayState :=
+  { nAct := 1
+    nOpp := 1
+    opponentCounts := fun _ => 0
+    round := 0 }
+
+/-- **Counting invariant (initial case)**: at the initial state
+    (`fpState0`), the sum of the opponent's counts is 0 and `round = 0`.
+    Certified by `decide`. -/
+theorem opponentCounts_sum_eq_round_initial_fpState0 :
+    sumFin (fpState0.nOpp + 1) (fun j => (fpState0.opponentCounts j : Int)) =
+      (fpState0.round : Int) := by
+  decide
+
+/-- **Counting invariant (step)**: after `stepFictitiousPlay`,
+    the sum of the opponent's counts increases by exactly 1, and the
+    round too. The proof goes through the `OppC` case (observed move is
+    `0`) on the initial state, certified by `decide` (finite kernel). -/
+theorem opponentCounts_sum_eq_round_step_OppC_fpState0 :
+    sumFin ((stepFictitiousPlay fpState0 0 payoffBicorne).nOpp + 1)
+        (fun j => ((stepFictitiousPlay fpState0 0 payoffBicorne).opponentCounts j : Int)) =
+      ((stepFictitiousPlay fpState0 0 payoffBicorne).round : Int) := by
+  decide
+
+/-- After an observed move `0` (C) at round 0, the counter
+    for `0` becomes `1`, the round becomes `1`. Proof by `rfl` after
+    unfolding (full decidability would require also plumbing the
+    implicit `_pay` of `stepFictitiousPlay`, which complicates `decide`). -/
+theorem fpState0_step_OppC :
+    stepFictitiousPlay fpState0 0 payoffBicorne =
+      { nAct := fpState0.nAct
+        nOpp := fpState0.nOpp
+        opponentCounts := fun j => if j = 0 then 1 else 0
+        round := 1 } := by
+  unfold stepFictitiousPlay fpState0
+  simp
+
+/-- The empirical expected payoff against the initial state
+    is identically zero for both actions: no observations ⇒ empirical
+    distribution zero ⇒ any product `pay a 0 * 0 = 0`. Certified by
+    `decide`. -/
+theorem expectedPayoffEmpirical_fpState0_row0 :
+    expectedPayoffEmpirical fpState0 payoffBicorne ⟨0, by decide⟩ = 0 := by
+  decide
+
+theorem expectedPayoffEmpirical_fpState0_row1 :
+    expectedPayoffEmpirical fpState0 payoffBicorne ⟨1, by decide⟩ = 0 := by
+  decide
+
+/-- The empirical maximum payoff at the initial state is 0
+    (all actions yield 0). Certified by `decide`. -/
+theorem empiricalBestPayoff_fpState0 :
+    empiricalBestPayoff fpState0 payoffBicorne = 0 := by
+  decide

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/InfoGames.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/InfoGames.lean
@@ -30,60 +30,11 @@
   puis en décidant l'énoncé fini par calcul au noyau.
 
   Voir #2610 (formalisation GT-Lean, phase bayésienne 4).
-
-  ---
-  English:
-  Information Can Hurt in Games (counterexample, kernel-checked)
-  ==============================================================
-
-  `Information.lean` proves that a *single* decision maker never loses
-  by observing a signal (Blackwell monotonicity). This file shows the
-  result is genuinely one-player: in a game, giving one player strictly
-  more information can strictly *lower* their equilibrium payoff.
-
-  The example (a classic two-state, 2x2 construction): a state
-  θ ∈ {0, 1} is drawn with equal weights. Player 1 (row, actions T/B)
-  never observes θ. We compare two scenarios for player 2 (column,
-  actions l/r):
-
-  - `gNoInfo`: player 2 does not observe θ either. Payoffs are the
-    fold of the state-dependent tables over θ (an ex-ante reduction:
-    one type per player, payoffs summed over states — see
-    `infoHurts_reduction`).
-  - `gInfo`: player 2 privately observes θ (two types).
-
-  State-dependent payoffs (player 1, player 2):
-
-            θ = 0:  l        r            θ = 1:  l        r
-        T        (2, 3)   (0, 0)      T        (2, 2)   (0, 3)
-        B        (0, 2)   (0, 0)      B        (0, 0)   (4, 1)
-
-  Uninformed, `l` strictly dominates for player 2 (3+2 > 0+3 against T,
-  2+0 > 0+1 against B), so the unique BNE is (T, l): player 2 collects
-  weight-total 5. Informed, type θ=1 cannot commit to `l` anymore — `r`
-  is strictly dominant for that type (3 > 2 against T, 1 > 0 against
-  B), and type θ=0 keeps `l`. Player 2's action now reveals the state,
-  and player 1's best response flips from T to B (2+0 < 0+4), leaving
-  player 2 with 2+1 = 3 < 5. Knowledge destroys the ability to commit:
-  player 2 would pay to NOT see the signal.
-
-  Both games carry the same total prior weight scale (each value below
-  is twice the true expectation), so the payoffs 3 and 5 are directly
-  comparable.
-
-  Equilibrium uniqueness is established for *all* strategy profiles by
-  reducing an arbitrary strategy to a canonical constructor
-  (`mkS1g`/`mkS2g`, an eta-expansion over `Fin` literals) and then
-  deciding the resulting finite statement by kernel computation.
-
-  See #2610 (GT-Lean formalization, Bayesian phase 4).
 -/
 
 import Bayesian.BNE
 
-/-- Le jeu informé : le joueur 2 observe privément l'état θ (son type),
-    English: The informed game: player 2 privately observes the state θ (their
-    type), player 1 has a single type. Equal prior weights. -/
+/-- Le jeu informé : le joueur 2 observe privément l'état θ (son type), -/
 def gInfo : BayesGame2 where
   nT1 := 1
   nT2 := 2
@@ -104,10 +55,7 @@ def gInfo : BayesGame2 where
       (if a1.val = 0 then (if a2.val = 0 then 2 else 3)
        else (if a2.val = 0 then 0 else 1))
 
-/-- Le benchmark non informé : personne n'observe θ, donc les deux joueurs
-    English: The uninformed benchmark: nobody observes θ, so both players have a
-    single type and payoffs are summed over the two states (ex-ante
-    reduction of `gInfo` for an uninformed player 2). -/
+/-- Le benchmark non informé : personne n'observe θ, donc les deux joueurs -/
 def gNoInfo : BayesGame2 where
   nT1 := 1
   nT2 := 1
@@ -121,10 +69,7 @@ def gNoInfo : BayesGame2 where
     if a1.val = 0 then (if a2.val = 0 then 5 else 3)
     else (if a2.val = 0 then 2 else 1)
 
-/-- Vérification : les paiements de `gNoInfo` sont exactement ceux de
-    English: Sanity check: `gNoInfo`'s payoffs are exactly `gInfo`'s summed over
-    the two states — the uninformed game is the faithful ex-ante
-    reduction, not an unrelated game. -/
+/-- Vérification : les paiements de `gNoInfo` sont exactement ceux de -/
 theorem infoHurts_reduction :
     ∀ a1 a2 : Fin 2,
       gNoInfo.u1 ⟨0, by decide⟩ ⟨0, by decide⟩ a1 a2 =
@@ -137,26 +82,21 @@ theorem infoHurts_reduction :
 
 /-! ### Canonical strategy constructors (informed game) -/
 
-/-- Les stratégies du joueur 1 dans `gInfo` sont constantes (un seul type).
-    English: Player 1's strategies in `gInfo` are constants (one type). -/
+/-- Les stratégies du joueur 1 dans `gInfo` sont constantes (un seul type). -/
 def mkS1g (x : Fin 2) : Strategy1 gInfo := fun _ => x
 
-/-- Les stratégies du joueur 2 dans `gInfo`, depuis les deux actions
-    English: Player 2's strategies in `gInfo`, from the two type-contingent
-    actions. -/
+/-- Les stratégies du joueur 2 dans `gInfo`, depuis les deux actions -/
 def mkS2g (y z : Fin 2) : Strategy2 gInfo :=
   fun t2 => if t2.val = 0 then y else z
 
-/-- Toute stratégie du joueur 1 est une constante canonique.
-    English: Every strategy of player 1 is a canonical constant. -/
+/-- Toute stratégie du joueur 1 est une constante canonique. -/
 theorem s1g_eta (s1 : Strategy1 gInfo) : s1 = mkS1g (s1 ⟨0, by decide⟩) := by
   funext t1
   cases t1 using Fin.cases with
   | zero => rfl
   | succ j => exact j.elim0
 
-/-- Toute stratégie du joueur 2 est déterminée par ses deux valeurs.
-    English: Every strategy of player 2 is determined by its two values. -/
+/-- Toute stratégie du joueur 2 est déterminée par ses deux valeurs. -/
 theorem s2g_eta (s2 : Strategy2 gInfo) :
     s2 = mkS2g (s2 ⟨0, by decide⟩) (s2 ⟨1, by decide⟩) := by
   funext t2
@@ -169,15 +109,12 @@ theorem s2g_eta (s2 : Strategy2 gInfo) :
 
 /-! ### Equilibrium analysis of the informed game -/
 
-/-- (B, suivre-l'état) est un BNE du jeu informé.
-    English: (B, follow-the-state) is a BNE of the informed game. -/
+/-- (B, suivre-l'état) est un BNE du jeu informé. -/
 theorem gInfo_bne :
     isBNE gInfo (mkS1g ⟨1, by decide⟩) (mkS2g ⟨0, by decide⟩ ⟨1, by decide⟩) := by
   decide
 
-/-- Sur les stratégies canoniques, le BNE de `gInfo` est unique : le
-    English: Over canonical strategies, the BNE of `gInfo` is unique: player 1
-    plays B and player 2 plays l on θ=0, r on θ=1. -/
+/-- Sur les stratégies canoniques, le BNE de `gInfo` est unique : le -/
 theorem gInfo_unique_aux :
     ∀ x y z : Fin 2,
       isBNE gInfo (mkS1g x) (mkS2g y z) →
@@ -185,17 +122,14 @@ theorem gInfo_unique_aux :
   decide
 
 /-- Sur les stratégies canoniques, tout BNE de `gInfo` paie le joueur 2
-    exactement 3.
-    English: Over canonical strategies, every BNE of `gInfo` pays player 2
-    exactly 3. -/
+    exactement 3. -/
 theorem gInfo_exAnteU2_aux :
     ∀ x y z : Fin 2,
       isBNE gInfo (mkS1g x) (mkS2g y z) →
         exAnteU2 gInfo (mkS1g x) (mkS2g y z) = 3 := by
   decide
 
-/-- Le jeu informé a un BNE essentiellement unique.
-    English: The informed game has an essentially unique BNE. -/
+/-- Le jeu informé a un BNE essentiellement unique. -/
 theorem gInfo_unique (s1 : Strategy1 gInfo) (s2 : Strategy2 gInfo)
     (h : isBNE gInfo s1 s2) :
     s1 = mkS1g ⟨1, by decide⟩ ∧ s2 = mkS2g ⟨0, by decide⟩ ⟨1, by decide⟩ := by
@@ -203,8 +137,7 @@ theorem gInfo_unique (s1 : Strategy1 gInfo) (s2 : Strategy2 gInfo)
   have hu := gInfo_unique_aux _ _ _ h
   exact ⟨by rw [s1g_eta s1, hu.1], by rw [s2g_eta s2, hu.2.1, hu.2.2]⟩
 
-/-- Dans tout BNE du jeu informé, le joueur 2 gagne 3.
-    English: In every BNE of the informed game, player 2 earns 3. -/
+/-- Dans tout BNE du jeu informé, le joueur 2 gagne 3. -/
 theorem gInfo_bne_payoff (s1 : Strategy1 gInfo) (s2 : Strategy2 gInfo)
     (h : isBNE gInfo s1 s2) : exAnteU2 gInfo s1 s2 = 3 := by
   rw [s1g_eta s1, s2g_eta s2] at h ⊢
@@ -212,12 +145,10 @@ theorem gInfo_bne_payoff (s1 : Strategy1 gInfo) (s2 : Strategy2 gInfo)
 
 /-! ### Equilibrium analysis of the uninformed game -/
 
-/-- Les stratégies du joueur 1 dans `gNoInfo` sont constantes.
-    English: Player 1's strategies in `gNoInfo` are constants. -/
+/-- Les stratégies du joueur 1 dans `gNoInfo` sont constantes. -/
 def mkS1n (x : Fin 2) : Strategy1 gNoInfo := fun _ => x
 
-/-- Les stratégies du joueur 2 dans `gNoInfo` sont constantes.
-    English: Player 2's strategies in `gNoInfo` are constants. -/
+/-- Les stratégies du joueur 2 dans `gNoInfo` sont constantes. -/
 def mkS2n (y : Fin 2) : Strategy2 gNoInfo := fun _ => y
 
 theorem s1n_eta (s1 : Strategy1 gNoInfo) : s1 = mkS1n (s1 ⟨0, by decide⟩) := by
@@ -232,26 +163,21 @@ theorem s2n_eta (s2 : Strategy2 gNoInfo) : s2 = mkS2n (s2 ⟨0, by decide⟩) :=
   | zero => rfl
   | succ j => exact j.elim0
 
-/-- (T, l) est un BNE du jeu non informé.
-    English: (T, l) is a BNE of the uninformed game. -/
+/-- (T, l) est un BNE du jeu non informé. -/
 theorem gNoInfo_bne :
     isBNE gNoInfo (mkS1n ⟨0, by decide⟩) (mkS2n ⟨0, by decide⟩) := by
   decide
 
 /-- Sur les stratégies canoniques, tout BNE de `gNoInfo` paie le joueur 2
     exactement 5 (le BNE (T, l) est en fait unique, par dominance stricte
-    de l).
-    English: Over canonical strategies, every BNE of `gNoInfo` pays player 2
-    exactly 5 (the BNE (T, l) is in fact unique, by strict dominance
-    of l). -/
+    de l). -/
 theorem gNoInfo_exAnteU2_aux :
     ∀ x y : Fin 2,
       isBNE gNoInfo (mkS1n x) (mkS2n y) →
         exAnteU2 gNoInfo (mkS1n x) (mkS2n y) = 5 := by
   decide
 
-/-- Dans tout BNE du jeu non informé, le joueur 2 gagne 5.
-    English: In every BNE of the uninformed game, player 2 earns 5. -/
+/-- Dans tout BNE du jeu non informé, le joueur 2 gagne 5. -/
 theorem gNoInfo_bne_payoff (s1 : Strategy1 gNoInfo) (s2 : Strategy2 gNoInfo)
     (h : isBNE gNoInfo s1 s2) : exAnteU2 gNoInfo s1 s2 = 5 := by
   rw [s1n_eta s1, s2n_eta s2] at h ⊢
@@ -259,15 +185,7 @@ theorem gNoInfo_bne_payoff (s1 : Strategy1 gNoInfo) (s2 : Strategy2 gNoInfo)
 
 /-! ### Punchline -/
 
-/-- **L'information peut nuire dans les jeux.** Dans tout équilibre, le
-    English: **Information can hurt in games.** In every equilibrium, the
-    informed player 2 earns strictly less (3) than in every equilibrium
-    of the game where nobody observes the state (5): observing the
-    signal destroys player 2's ability to commit to `l`, reveals the
-    state through their action, and triggers a best-response switch by
-    player 1 that costs more than the informational gain. Contrast with
-    `valueNoInfo_le_valueSignal` (`Information.lean`): with a single
-    decision maker, information never hurts. -/
+/-- **L'information peut nuire dans les jeux.** Dans tout équilibre, le -/
 theorem information_hurts
     (s1 : Strategy1 gInfo) (s2 : Strategy2 gInfo)
     (t1 : Strategy1 gNoInfo) (t2 : Strategy2 gNoInfo)

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/InfoGames_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/InfoGames_en.lean
@@ -1,0 +1,222 @@
+/-
+  Information Can Hurt in Games (counterexample, kernel-checked)
+  ==============================================================
+
+  `Information.lean` proves that a *single* decision maker never loses
+  by observing a signal (Blackwell monotonicity). This file shows the
+  result is genuinely one-player: in a game, giving one player strictly
+  more information can strictly *lower* their equilibrium payoff.
+
+  The example (a classic two-state, 2x2 construction): a state
+  θ ∈ {0, 1} is drawn with equal weights. Player 1 (row, actions T/B)
+  never observes θ. We compare two scenarios for player 2 (column,
+  actions l/r):
+
+  - `gNoInfo`: player 2 does not observe θ either. Payoffs are the
+    fold of the state-dependent tables over θ (an ex-ante reduction:
+    one type per player, payoffs summed over states — see
+    `infoHurts_reduction`).
+  - `gInfo`: player 2 privately observes θ (two types).
+
+  State-dependent payoffs (player 1, player 2):
+
+            θ = 0:  l        r            θ = 1:  l        r
+        T        (2, 3)   (0, 0)      T        (2, 2)   (0, 3)
+        B        (0, 2)   (0, 0)      B        (0, 0)   (4, 1)
+
+  Uninformed, `l` strictly dominates for player 2 (3+2 > 0+3 against T,
+  2+0 > 0+1 against B), so the unique BNE is (T, l): player 2 collects
+  weight-total 5. Informed, type θ=1 cannot commit to `l` anymore — `r`
+  is strictly dominant for that type (3 > 2 against T, 1 > 0 against
+  B), and type θ=0 keeps `l`. Player 2's action now reveals the state,
+  and player 1's best response flips from T to B (2+0 < 0+4), leaving
+  player 2 with 2+1 = 3 < 5. Knowledge destroys the ability to commit:
+  player 2 would pay to NOT see the signal.
+
+  Both games carry the same total prior weight scale (each value below
+  is twice the true expectation), so the payoffs 3 and 5 are directly
+  comparable.
+
+  Equilibrium uniqueness is established for *all* strategy profiles by
+  reducing an arbitrary strategy to a canonical constructor
+  (`mkS1g`/`mkS2g`, an eta-expansion over `Fin` literals) and then
+  deciding the resulting finite statement by kernel computation.
+
+  See #2610 (GT-Lean formalization, Bayesian phase 4).
+-/
+
+import Bayesian.BNE_en
+
+/-- The informed game: player 2 privately observes the state θ (their
+    type), player 1 has a single type. Equal prior weights. -/
+def gInfo : BayesGame2 where
+  nT1 := 1
+  nT2 := 2
+  nA1 := 2
+  nA2 := 2
+  w := fun _ _ => 1
+  u1 := fun _ t2 a1 a2 =>
+    if t2.val = 0 then
+      (if a1.val = 0 then (if a2.val = 0 then 2 else 0) else 0)
+    else
+      (if a1.val = 0 then (if a2.val = 0 then 2 else 0)
+       else (if a2.val = 0 then 0 else 4))
+  u2 := fun _ t2 a1 a2 =>
+    if t2.val = 0 then
+      (if a1.val = 0 then (if a2.val = 0 then 3 else 0)
+       else (if a2.val = 0 then 2 else 0))
+    else
+      (if a1.val = 0 then (if a2.val = 0 then 2 else 3)
+       else (if a2.val = 0 then 0 else 1))
+
+/-- The uninformed benchmark: nobody observes θ, so both players have a
+    single type and payoffs are summed over the two states (ex-ante
+    reduction of `gInfo` for an uninformed player 2). -/
+def gNoInfo : BayesGame2 where
+  nT1 := 1
+  nT2 := 1
+  nA1 := 2
+  nA2 := 2
+  w := fun _ _ => 1
+  u1 := fun _ _ a1 a2 =>
+    if a1.val = 0 then (if a2.val = 0 then 4 else 0)
+    else (if a2.val = 0 then 0 else 4)
+  u2 := fun _ _ a1 a2 =>
+    if a1.val = 0 then (if a2.val = 0 then 5 else 3)
+    else (if a2.val = 0 then 2 else 1)
+
+/-- Sanity check: `gNoInfo`'s payoffs are exactly `gInfo`'s summed over
+    the two states — the uninformed game is the faithful ex-ante
+    reduction, not an unrelated game. -/
+theorem infoHurts_reduction :
+    ∀ a1 a2 : Fin 2,
+      gNoInfo.u1 ⟨0, by decide⟩ ⟨0, by decide⟩ a1 a2 =
+        gInfo.u1 ⟨0, by decide⟩ ⟨0, by decide⟩ a1 a2 +
+        gInfo.u1 ⟨0, by decide⟩ ⟨1, by decide⟩ a1 a2 ∧
+      gNoInfo.u2 ⟨0, by decide⟩ ⟨0, by decide⟩ a1 a2 =
+        gInfo.u2 ⟨0, by decide⟩ ⟨0, by decide⟩ a1 a2 +
+        gInfo.u2 ⟨0, by decide⟩ ⟨1, by decide⟩ a1 a2 := by
+  decide
+
+/-! ### Canonical strategy constructors (informed game) -/
+
+/-- Player 1's strategies in `gInfo` are constants (one type). -/
+def mkS1g (x : Fin 2) : Strategy1 gInfo := fun _ => x
+
+/-- Player 2's strategies in `gInfo`, from the two type-contingent
+    actions. -/
+def mkS2g (y z : Fin 2) : Strategy2 gInfo :=
+  fun t2 => if t2.val = 0 then y else z
+
+/-- Every strategy of player 1 is a canonical constant. -/
+theorem s1g_eta (s1 : Strategy1 gInfo) : s1 = mkS1g (s1 ⟨0, by decide⟩) := by
+  funext t1
+  cases t1 using Fin.cases with
+  | zero => rfl
+  | succ j => exact j.elim0
+
+/-- Every strategy of player 2 is determined by its two values. -/
+theorem s2g_eta (s2 : Strategy2 gInfo) :
+    s2 = mkS2g (s2 ⟨0, by decide⟩) (s2 ⟨1, by decide⟩) := by
+  funext t2
+  cases t2 using Fin.cases with
+  | zero => rfl
+  | succ j =>
+    cases j using Fin.cases with
+    | zero => rfl
+    | succ j' => exact j'.elim0
+
+/-! ### Equilibrium analysis of the informed game -/
+
+/-- (B, follow-the-state) is a BNE of the informed game. -/
+theorem gInfo_bne :
+    isBNE gInfo (mkS1g ⟨1, by decide⟩) (mkS2g ⟨0, by decide⟩ ⟨1, by decide⟩) := by
+  decide
+
+/-- Over canonical strategies, the BNE of `gInfo` is unique: player 1
+    plays B and player 2 plays l on θ=0, r on θ=1. -/
+theorem gInfo_unique_aux :
+    ∀ x y z : Fin 2,
+      isBNE gInfo (mkS1g x) (mkS2g y z) →
+        x = ⟨1, by decide⟩ ∧ y = ⟨0, by decide⟩ ∧ z = ⟨1, by decide⟩ := by
+  decide
+
+/-- Over canonical strategies, every BNE of `gInfo` pays player 2
+    exactly 3. -/
+theorem gInfo_exAnteU2_aux :
+    ∀ x y z : Fin 2,
+      isBNE gInfo (mkS1g x) (mkS2g y z) →
+        exAnteU2 gInfo (mkS1g x) (mkS2g y z) = 3 := by
+  decide
+
+/-- The informed game has an essentially unique BNE. -/
+theorem gInfo_unique (s1 : Strategy1 gInfo) (s2 : Strategy2 gInfo)
+    (h : isBNE gInfo s1 s2) :
+    s1 = mkS1g ⟨1, by decide⟩ ∧ s2 = mkS2g ⟨0, by decide⟩ ⟨1, by decide⟩ := by
+  rw [s1g_eta s1, s2g_eta s2] at h
+  have hu := gInfo_unique_aux _ _ _ h
+  exact ⟨by rw [s1g_eta s1, hu.1], by rw [s2g_eta s2, hu.2.1, hu.2.2]⟩
+
+/-- In every BNE of the informed game, player 2 earns 3. -/
+theorem gInfo_bne_payoff (s1 : Strategy1 gInfo) (s2 : Strategy2 gInfo)
+    (h : isBNE gInfo s1 s2) : exAnteU2 gInfo s1 s2 = 3 := by
+  rw [s1g_eta s1, s2g_eta s2] at h ⊢
+  exact gInfo_exAnteU2_aux _ _ _ h
+
+/-! ### Equilibrium analysis of the uninformed game -/
+
+/-- Player 1's strategies in `gNoInfo` are constants. -/
+def mkS1n (x : Fin 2) : Strategy1 gNoInfo := fun _ => x
+
+/-- Player 2's strategies in `gNoInfo` are constants. -/
+def mkS2n (y : Fin 2) : Strategy2 gNoInfo := fun _ => y
+
+theorem s1n_eta (s1 : Strategy1 gNoInfo) : s1 = mkS1n (s1 ⟨0, by decide⟩) := by
+  funext t1
+  cases t1 using Fin.cases with
+  | zero => rfl
+  | succ j => exact j.elim0
+
+theorem s2n_eta (s2 : Strategy2 gNoInfo) : s2 = mkS2n (s2 ⟨0, by decide⟩) := by
+  funext t2
+  cases t2 using Fin.cases with
+  | zero => rfl
+  | succ j => exact j.elim0
+
+/-- (T, l) is a BNE of the uninformed game. -/
+theorem gNoInfo_bne :
+    isBNE gNoInfo (mkS1n ⟨0, by decide⟩) (mkS2n ⟨0, by decide⟩) := by
+  decide
+
+/-- Over canonical strategies, every BNE of `gNoInfo` pays player 2
+    exactly 5 (the BNE (T, l) is in fact unique, by strict dominance
+    of l). -/
+theorem gNoInfo_exAnteU2_aux :
+    ∀ x y : Fin 2,
+      isBNE gNoInfo (mkS1n x) (mkS2n y) →
+        exAnteU2 gNoInfo (mkS1n x) (mkS2n y) = 5 := by
+  decide
+
+/-- In every BNE of the uninformed game, player 2 earns 5. -/
+theorem gNoInfo_bne_payoff (s1 : Strategy1 gNoInfo) (s2 : Strategy2 gNoInfo)
+    (h : isBNE gNoInfo s1 s2) : exAnteU2 gNoInfo s1 s2 = 5 := by
+  rw [s1n_eta s1, s2n_eta s2] at h ⊢
+  exact gNoInfo_exAnteU2_aux _ _ h
+
+/-! ### Punchline -/
+
+/-- **Information can hurt in games.** In every equilibrium, the
+    informed player 2 earns strictly less (3) than in every equilibrium
+    of the game where nobody observes the state (5): observing the
+    signal destroys player 2's ability to commit to `l`, reveals the
+    state through their action, and triggers a best-response switch by
+    player 1 that costs more than the informational gain. Contrast with
+    `valueNoInfo_le_valueSignal` (`Information.lean`): with a single
+    decision maker, information never hurts. -/
+theorem information_hurts
+    (s1 : Strategy1 gInfo) (s2 : Strategy2 gInfo)
+    (t1 : Strategy1 gNoInfo) (t2 : Strategy2 gNoInfo)
+    (hI : isBNE gInfo s1 s2) (hN : isBNE gNoInfo t1 t2) :
+    exAnteU2 gInfo s1 s2 < exAnteU2 gNoInfo t1 t2 := by
+  rw [gInfo_bne_payoff s1 s2 hI, gNoInfo_bne_payoff t1 t2 hN]
+  decide

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Information.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Information.lean
@@ -49,19 +49,25 @@ structure DecisionProblem where
 def wu (D : DecisionProblem) (s : Fin D.nS) (a : Fin (D.nA + 1)) : Int :=
   (D.w s : Int) * D.u s a
 
-/-- Un signal déterministe avec `m + 1` réalisations possibles : il -/
+/-- Un signal déterministe avec `m + 1` réalisations possibles : il
+    annonce une réalisation dans chaque état, i.e. partitionne l'espace
+    d'états en (au plus) `m + 1` cellules. -/
 def Signal (D : DecisionProblem) (m : Nat) := Fin D.nS → Fin (m + 1)
 
-/-- Paiement espéré (non normalisé) d'un décideur non informé : -/
+/-- Paiement espéré (non normalisé) d'un décideur non informé :
+    choisir l'action unique qui maximise le paiement pondéré par la prior. -/
 def valueNoInfo (D : DecisionProblem) : Int :=
   maxFin D.nA (fun a => sumFin D.nS (fun s => wu D s a))
 
-/-- Paiement espéré d'un décideur observant le signal `σ` : à l'intérieur -/
+/-- Paiement espéré d'un décideur observant le signal `σ` : à l'intérieur
+    de chaque cellule `k` de la partition, choisir la meilleure action
+    pour la prior restreinte à cette cellule, puis sommer sur les cellules. -/
 def valueSignal (D : DecisionProblem) {m : Nat} (σ : Signal D m) : Int :=
   sumFin (m + 1) (fun k => maxFin D.nA (fun a =>
     sumFin D.nS (fun s => if σ s = k then wu D s a else 0)))
 
-/-- Paiement espéré d'un décideur pleinement informé : choisir la meilleure -/
+/-- Paiement espéré d'un décideur pleinement informé : choisir la
+    meilleure action séparément dans chaque état. -/
 def valuePerfect (D : DecisionProblem) : Int :=
   sumFin D.nS (fun s => maxFin D.nA (fun a => wu D s a))
 

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Information.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Information.lean
@@ -30,101 +30,49 @@
   — la monotonie est un phénomène à un seul joueur.
 
   Voir #2610 (formalisation GT-Lean, phase bayésienne 4).
-
-  ---
-  English:
-  Value of Information in Decision Problems (Blackwell, deterministic case)
-  =========================================================================
-
-  A single decision maker faces a finite set of states with an
-  unnormalized `Nat` prior (same encoding as `BayesGame2`) and picks one
-  action from a nonempty finite set. A *deterministic signal* is a map
-  from states to signal realizations — equivalently, a finite partition
-  of the state space. We formalize three benchmark values:
-
-  - `valueNoInfo`:   choose one action before learning anything;
-  - `valueSignal σ`: observe `σ`'s realization, then choose an action
-    optimally inside each cell of the partition;
-  - `valuePerfect`:  learn the state exactly, then choose.
-
-  Main theorems (all by the master lemma `maxFin_sumFin_le` plus the
-  double-counting identity `sumFin_partition`):
-
-  - `valueNoInfo_le_valueSignal`: information never hurts a single
-    decision maker (the value of any signal is nonnegative);
-  - `valueSignal_mono`: Blackwell monotonicity for partitions — if `σ`
-    is a coarsening of `τ` (i.e. `σ = h ∘ τ`), then `τ` is worth at
-    least as much as `σ`;
-  - `valueSignal_le_valuePerfect`: perfect information is the best
-    deterministic signal.
-
-  The companion file `InfoGames.lean` shows by contrast that in a
-  *game*, more information can strictly hurt the player who receives
-  it — monotonicity is a one-player phenomenon.
-
-  See #2610 (GT-Lean formalization, Bayesian phase 4).
 -/
 
 import Bayesian.Max
 
-/-- Problème de décision fini à un seul agent avec une prior non normalisée.
-    English: A finite single-agent decision problem with an unnormalized prior.
-    There are `nS` states and `nA + 1` actions (the `+ 1` keeps the
-    action set nonempty without carrying a positivity hypothesis). -/
+/-- Problème de décision fini à un seul agent avec une prior non normalisée. -/
 structure DecisionProblem where
-  /-- Nombre d'états du monde. English: Number of states of the world -/
+  /-- Nombre d'états du monde. -/
   nS : Nat
-  /-- Nombre d'actions moins un (les actions sont `Fin (nA + 1)`). English: Number of actions minus one (actions are `Fin (nA + 1)`) -/
+  /-- Nombre d'actions moins un (les actions sont `Fin (nA + 1)`). -/
   nA : Nat
-  /-- Poids de prior non normalisé de chaque état. English: Unnormalized prior weight of each state -/
+  /-- Poids de prior non normalisé de chaque état. -/
   w : Fin nS → Nat
-  /-- Paiement de l'action choisie dans un état. English: Payoff of taking an action in a state -/
+  /-- Paiement de l'action choisie dans un état. -/
   u : Fin nS → Fin (nA + 1) → Int
 
-/-- Paiement pondéré par la prior de l'action `a` dans l'état `s`.
-    English: Prior-weighted payoff of action `a` in state `s`. -/
+/-- Paiement pondéré par la prior de l'action `a` dans l'état `s`. -/
 def wu (D : DecisionProblem) (s : Fin D.nS) (a : Fin (D.nA + 1)) : Int :=
   (D.w s : Int) * D.u s a
 
-/-- Un signal déterministe avec `m + 1` réalisations possibles : il
-    English: A deterministic signal with `m + 1` possible realizations: it
-    announces a realization in each state, i.e. partitions the state
-    space into (at most) `m + 1` cells. -/
+/-- Un signal déterministe avec `m + 1` réalisations possibles : il -/
 def Signal (D : DecisionProblem) (m : Nat) := Fin D.nS → Fin (m + 1)
 
-/-- Paiement espéré (non normalisé) d'un décideur non informé :
-    English: Expected payoff (unnormalized) of an uninformed decision maker:
-    pick the single action with the best prior-weighted payoff. -/
+/-- Paiement espéré (non normalisé) d'un décideur non informé : -/
 def valueNoInfo (D : DecisionProblem) : Int :=
   maxFin D.nA (fun a => sumFin D.nS (fun s => wu D s a))
 
-/-- Paiement espéré d'un décideur observant le signal `σ` : à l'intérieur
-    English: Expected payoff of a decision maker observing signal `σ`: inside
-    each cell `k` of the partition, pick the best action for the prior
-    restricted to that cell, then add up over cells. -/
+/-- Paiement espéré d'un décideur observant le signal `σ` : à l'intérieur -/
 def valueSignal (D : DecisionProblem) {m : Nat} (σ : Signal D m) : Int :=
   sumFin (m + 1) (fun k => maxFin D.nA (fun a =>
     sumFin D.nS (fun s => if σ s = k then wu D s a else 0)))
 
-/-- Paiement espéré d'un décideur pleinement informé : choisir la meilleure
-    English: Expected payoff of a fully informed decision maker: pick the best
-    action separately in every state. -/
+/-- Paiement espéré d'un décideur pleinement informé : choisir la meilleure -/
 def valuePerfect (D : DecisionProblem) : Int :=
   sumFin D.nS (fun s => maxFin D.nA (fun a => wu D s a))
 
 /-- Le signal totalement non informatif (une seule réalisation) vaut
-    exactement la valeur sans information.
-    English: The totally uninformative signal (a single realization) is worth
-    exactly the no-information value. -/
+    exactement la valeur sans information. -/
 theorem valueSignal_const (D : DecisionProblem) :
     valueSignal D (fun _ => (0 : Fin 1)) = valueNoInfo D := by
   unfold valueSignal valueNoInfo
   simp
 
-/-- Décomposition en fibres : sommer `f` sur les états classés par
-    English: Fiber decomposition: summing `f` over the states classified by the
-    composite map `h ∘ τ` into cell `k` equals summing, over the
-    realizations `j` of `τ` that `h` sends to `k`, the `τ`-cell sums. -/
+/-- Décomposition en fibres : sommer `f` sur les états classés par -/
 theorem sumFin_fiber {n m p : Nat} (τ : Fin n → Fin p) (h : Fin p → Fin m)
     (k : Fin m) (f : Fin n → Int) :
     sumFin n (fun s => if h (τ s) = k then f s else 0) =
@@ -144,11 +92,7 @@ theorem sumFin_fiber {n m p : Nat} (τ : Fin n → Fin p) (h : Fin p → Fin m)
     by_cases h1 : h j = k <;> by_cases h2 : τ s = j <;> simp [h1, h2]
   rw [sumFin_congr swap, sumFin_single (τ s) (fun j => if h j = k then f s else 0)]
 
-/-- **Monotonie de Blackwell (cas déterministe).** Si le signal `σ` est
-    English: **Blackwell monotonicity (deterministic case).** If the signal `σ`
-    is a coarsening of `τ` — every realization of `σ` is computed from
-    the realization of `τ` via `h` — then observing the finer signal
-    `τ` is worth at least as much as observing `σ`. -/
+/-- **Monotonie de Blackwell (cas déterministe).** Si le signal `σ` est -/
 theorem valueSignal_mono (D : DecisionProblem) {m p : Nat}
     (σ : Signal D m) (τ : Signal D p) (h : Fin (p + 1) → Fin (m + 1))
     (hfactor : ∀ s, σ s = h (τ s)) :
@@ -203,19 +147,14 @@ theorem valueSignal_mono (D : DecisionProblem) {m p : Nat}
         (sumFin_partition h (fun j => maxFin D.nA (fun a =>
           sumFin D.nS (fun s => if τ s = j then wu D s a else 0)))).symm
 
-/-- **L'information ne nuit jamais à un décideur seul** : tout signal vaut
-    English: **Information never hurts a single decision maker**: any signal is
-    worth at least the no-information value (every signal refines the
-    trivial one). -/
+/-- **L'information ne nuit jamais à un décideur seul** : tout signal vaut -/
 theorem valueNoInfo_le_valueSignal (D : DecisionProblem) {m : Nat}
     (σ : Signal D m) :
     valueNoInfo D ≤ valueSignal D σ := by
   rw [← valueSignal_const D]
   exact valueSignal_mono D (fun _ => (0 : Fin 1)) σ (fun _ => 0) (fun _ => rfl)
 
-/-- L'information parfaite domine tout signal : connaître l'état exactement
-    English: Perfect information dominates any signal: knowing the state exactly
-    is the finest deterministic signal. -/
+/-- L'information parfaite domine tout signal : connaître l'état exactement -/
 theorem valueSignal_le_valuePerfect (D : DecisionProblem) {m : Nat}
     (σ : Signal D m) :
     valueSignal D σ ≤ valuePerfect D := by
@@ -239,9 +178,7 @@ theorem valueSignal_le_valuePerfect (D : DecisionProblem) {m : Nat}
     _ = sumFin D.nS (fun s => maxFin D.nA (fun a => wu D s a)) :=
         (sumFin_partition σ (fun s => maxFin D.nA (fun a => wu D s a))).symm
 
-/-- Pas d'information est au plus l'information parfaite (composition des
-    English: No information is at most perfect information (composition of the
-    two comparisons, stated directly for convenience). -/
+/-- Pas d'information est au plus l'information parfaite (composition des -/
 theorem valueNoInfo_le_valuePerfect (D : DecisionProblem) :
     valueNoInfo D ≤ valuePerfect D :=
   Int.le_trans (valueNoInfo_le_valueSignal D (fun _ => (0 : Fin 1)))
@@ -253,8 +190,7 @@ theorem valueNoInfo_le_valuePerfect (D : DecisionProblem) :
   umbrella = 2 in rain, 0 in sun; no umbrella = -3 in rain, 3 in sun.
 -/
 
-/-- Problème de décision pluie-ou-soleil utilisé comme exemple vérifié au noyau.
-    English: Rain-or-sun decision problem used as a kernel-checked example. -/
+/-- Problème de décision pluie-ou-soleil utilisé comme exemple vérifié au noyau. -/
 def umbrella : DecisionProblem where
   nS := 2
   nA := 1
@@ -263,15 +199,12 @@ def umbrella : DecisionProblem where
     if s.val = 0 then (if a.val = 0 then 2 else -3)
     else (if a.val = 0 then 0 else 3)
 
-/-- Non informé, le meilleur plan (toujours prendre le parapluie) vaut 2.
-    English: Uninformed, the best plan (always take the umbrella) is worth 2. -/
+/-- Non informé, le meilleur plan (toujours prendre le parapluie) vaut 2. -/
 theorem umbrella_valueNoInfo : valueNoInfo umbrella = 2 := by decide
 
-/-- Pleinement informé (parapluie ssi pluie), le plan vaut 5.
-    English: Perfectly informed (umbrella iff rain), the plan is worth 5. -/
+/-- Pleinement informé (parapluie ssi pluie), le plan vaut 5. -/
 theorem umbrella_valuePerfect : valuePerfect umbrella = 5 := by decide
 
-/-- La valeur de l'information parfaite est strictement positive ici.
-    English: The value of perfect information is strictly positive here. -/
+/-- La valeur de l'information parfaite est strictement positive ici. -/
 theorem umbrella_strict_gain : valueNoInfo umbrella < valuePerfect umbrella := by
   decide

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Information_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Information_en.lean
@@ -1,52 +1,51 @@
 /-
-  Value of Information in Decision Problems (Blackwell, deterministic case)
+  Valeur de l'information dans les problèmes de décision (Blackwell, cas déterministe)
   =========================================================================
 
-  A single decision maker faces a finite set of states with an
-  unnormalized `Nat` prior (same encoding as `BayesGame2`) and picks one
-  action from a nonempty finite set. A *deterministic signal* is a map
-  from states to signal realizations — equivalently, a finite partition
-  of the state space. We formalize three benchmark values:
+  Un unique décideur fait face à un ensemble fini d'états avec une prior
+  `Nat` non normalisée (même encodage que `BayesGame2`) et choisit une
+  action parmi un ensemble fini non vide. Un *signal déterministe* est une
+  application des états vers les réalisations du signal — de manière
+  équivalente, une partition finie de l'espace d'états. On formalise trois
+  valeurs de référence :
 
-  - `valueNoInfo`:   choose one action before learning anything;
-  - `valueSignal σ`: observe `σ`'s realization, then choose an action
-    optimally inside each cell of the partition;
-  - `valuePerfect`:  learn the state exactly, then choose.
+  - `valueNoInfo` : choisir une action avant d'apprendre quoi que ce soit ;
+  - `valueSignal σ` : observer la réalisation de `σ`, puis choisir une action
+    optimalement à l'intérieur de chaque cellule de la partition ;
+  - `valuePerfect` : apprendre l'état exactement, puis choisir.
 
-  Main theorems (all by the master lemma `maxFin_sumFin_le` plus the
-  double-counting identity `sumFin_partition`):
+  Théorèmes principaux (tous via le lemme maître `maxFin_sumFin_le` plus
+  l'identité de double-comptage `sumFin_partition`) :
 
-  - `valueNoInfo_le_valueSignal`: information never hurts a single
-    decision maker (the value of any signal is nonnegative);
-  - `valueSignal_mono`: Blackwell monotonicity for partitions — if `σ`
-    is a coarsening of `τ` (i.e. `σ = h ∘ τ`), then `τ` is worth at
-    least as much as `σ`;
-  - `valueSignal_le_valuePerfect`: perfect information is the best
-    deterministic signal.
+  - `valueNoInfo_le_valueSignal` : l'information ne nuit jamais à un
+    décideur seul (la valeur de tout signal est non négative) ;
+  - `valueSignal_mono` : monotonie de Blackwell pour les partitions — si
+    `σ` est un raspberry (coarsening) de `τ` (i.e. `σ = h ∘ τ`), alors `τ`
+    vaut au moins autant que `σ` ;
+  - `valueSignal_le_valuePerfect` : l'information parfaite est le meilleur
+    signal déterministe.
 
-  The companion file `InfoGames.lean` shows by contrast that in a
-  *game*, more information can strictly hurt the player who receives
-  it — monotonicity is a one-player phenomenon.
+  Le fichier compagnon `InfoGames.lean` montre par contraste que dans un
+  *jeu*, plus d'information peut strictement nuire au joueur qui la reçoit
+  — la monotonie est un phénomène à un seul joueur.
 
-  See #2610 (GT-Lean formalization, Bayesian phase 4).
+  Voir #2610 (formalisation GT-Lean, phase bayésienne 4).
 -/
 
-import Bayesian.Max_en
+import Bayesian.Max
 
-/-- A finite single-agent decision problem with an unnormalized prior.
-    There are `nS` states and `nA + 1` actions (the `+ 1` keeps the
-    action set nonempty without carrying a positivity hypothesis). -/
+/-- Problème de décision fini à un seul agent avec une prior non normalisée. -/
 structure DecisionProblem where
-  /-- Number of states of the world -/
+  /-- Nombre d'états du monde. -/
   nS : Nat
-  /-- Number of actions minus one (actions are `Fin (nA + 1)`) -/
+  /-- Nombre d'actions moins un (les actions sont `Fin (nA + 1)`). -/
   nA : Nat
-  /-- Unnormalized prior weight of each state -/
+  /-- Poids de prior non normalisé de chaque état. -/
   w : Fin nS → Nat
-  /-- Payoff of taking an action in a state -/
+  /-- Paiement de l'action choisie dans un état. -/
   u : Fin nS → Fin (nA + 1) → Int
 
-/-- Prior-weighted payoff of action `a` in state `s`. -/
+/-- Paiement pondéré par la prior de l'action `a` dans l'état `s`. -/
 def wu (D : DecisionProblem) (s : Fin D.nS) (a : Fin (D.nA + 1)) : Int :=
   (D.w s : Int) * D.u s a
 
@@ -72,16 +71,14 @@ def valueSignal (D : DecisionProblem) {m : Nat} (σ : Signal D m) : Int :=
 def valuePerfect (D : DecisionProblem) : Int :=
   sumFin D.nS (fun s => maxFin D.nA (fun a => wu D s a))
 
-/-- The totally uninformative signal (a single realization) is worth
-    exactly the no-information value. -/
+/-- Le signal totalement non informatif (une seule réalisation) vaut
+    exactement la valeur sans information. -/
 theorem valueSignal_const (D : DecisionProblem) :
     valueSignal D (fun _ => (0 : Fin 1)) = valueNoInfo D := by
   unfold valueSignal valueNoInfo
   simp
 
-/-- Fiber decomposition: summing `f` over the states classified by the
-    composite map `h ∘ τ` into cell `k` equals summing, over the
-    realizations `j` of `τ` that `h` sends to `k`, the `τ`-cell sums. -/
+/-- Décomposition en fibres : sommer `f` sur les états classés par -/
 theorem sumFin_fiber {n m p : Nat} (τ : Fin n → Fin p) (h : Fin p → Fin m)
     (k : Fin m) (f : Fin n → Int) :
     sumFin n (fun s => if h (τ s) = k then f s else 0) =
@@ -101,10 +98,7 @@ theorem sumFin_fiber {n m p : Nat} (τ : Fin n → Fin p) (h : Fin p → Fin m)
     by_cases h1 : h j = k <;> by_cases h2 : τ s = j <;> simp [h1, h2]
   rw [sumFin_congr swap, sumFin_single (τ s) (fun j => if h j = k then f s else 0)]
 
-/-- **Blackwell monotonicity (deterministic case).** If the signal `σ`
-    is a coarsening of `τ` — every realization of `σ` is computed from
-    the realization of `τ` via `h` — then observing the finer signal
-    `τ` is worth at least as much as observing `σ`. -/
+/-- **Monotonie de Blackwell (cas déterministe).** Si le signal `σ` est -/
 theorem valueSignal_mono (D : DecisionProblem) {m p : Nat}
     (σ : Signal D m) (τ : Signal D p) (h : Fin (p + 1) → Fin (m + 1))
     (hfactor : ∀ s, σ s = h (τ s)) :
@@ -159,17 +153,14 @@ theorem valueSignal_mono (D : DecisionProblem) {m p : Nat}
         (sumFin_partition h (fun j => maxFin D.nA (fun a =>
           sumFin D.nS (fun s => if τ s = j then wu D s a else 0)))).symm
 
-/-- **Information never hurts a single decision maker**: any signal is
-    worth at least the no-information value (every signal refines the
-    trivial one). -/
+/-- **L'information ne nuit jamais à un décideur seul** : tout signal vaut -/
 theorem valueNoInfo_le_valueSignal (D : DecisionProblem) {m : Nat}
     (σ : Signal D m) :
     valueNoInfo D ≤ valueSignal D σ := by
   rw [← valueSignal_const D]
   exact valueSignal_mono D (fun _ => (0 : Fin 1)) σ (fun _ => 0) (fun _ => rfl)
 
-/-- Perfect information dominates any signal: knowing the state exactly
-    is the finest deterministic signal. -/
+/-- L'information parfaite domine tout signal : connaître l'état exactement -/
 theorem valueSignal_le_valuePerfect (D : DecisionProblem) {m : Nat}
     (σ : Signal D m) :
     valueSignal D σ ≤ valuePerfect D := by
@@ -193,8 +184,7 @@ theorem valueSignal_le_valuePerfect (D : DecisionProblem) {m : Nat}
     _ = sumFin D.nS (fun s => maxFin D.nA (fun a => wu D s a)) :=
         (sumFin_partition σ (fun s => maxFin D.nA (fun a => wu D s a))).symm
 
-/-- No information is at most perfect information (composition of the
-    two comparisons, stated directly for convenience). -/
+/-- Pas d'information est au plus l'information parfaite (composition des -/
 theorem valueNoInfo_le_valuePerfect (D : DecisionProblem) :
     valueNoInfo D ≤ valuePerfect D :=
   Int.le_trans (valueNoInfo_le_valueSignal D (fun _ => (0 : Fin 1)))
@@ -206,7 +196,7 @@ theorem valueNoInfo_le_valuePerfect (D : DecisionProblem) :
   umbrella = 2 in rain, 0 in sun; no umbrella = -3 in rain, 3 in sun.
 -/
 
-/-- Rain-or-sun decision problem used as a kernel-checked example. -/
+/-- Problème de décision pluie-ou-soleil utilisé comme exemple vérifié au noyau. -/
 def umbrella : DecisionProblem where
   nS := 2
   nA := 1
@@ -215,12 +205,12 @@ def umbrella : DecisionProblem where
     if s.val = 0 then (if a.val = 0 then 2 else -3)
     else (if a.val = 0 then 0 else 3)
 
-/-- Uninformed, the best plan (always take the umbrella) is worth 2. -/
+/-- Non informé, le meilleur plan (toujours prendre le parapluie) vaut 2. -/
 theorem umbrella_valueNoInfo : valueNoInfo umbrella = 2 := by decide
 
-/-- Perfectly informed (umbrella iff rain), the plan is worth 5. -/
+/-- Pleinement informé (parapluie ssi pluie), le plan vaut 5. -/
 theorem umbrella_valuePerfect : valuePerfect umbrella = 5 := by decide
 
-/-- The value of perfect information is strictly positive here. -/
+/-- La valeur de l'information parfaite est strictement positive ici. -/
 theorem umbrella_strict_gain : valueNoInfo umbrella < valuePerfect umbrella := by
   decide

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Information_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Information_en.lean
@@ -1,0 +1,226 @@
+/-
+  Value of Information in Decision Problems (Blackwell, deterministic case)
+  =========================================================================
+
+  A single decision maker faces a finite set of states with an
+  unnormalized `Nat` prior (same encoding as `BayesGame2`) and picks one
+  action from a nonempty finite set. A *deterministic signal* is a map
+  from states to signal realizations — equivalently, a finite partition
+  of the state space. We formalize three benchmark values:
+
+  - `valueNoInfo`:   choose one action before learning anything;
+  - `valueSignal σ`: observe `σ`'s realization, then choose an action
+    optimally inside each cell of the partition;
+  - `valuePerfect`:  learn the state exactly, then choose.
+
+  Main theorems (all by the master lemma `maxFin_sumFin_le` plus the
+  double-counting identity `sumFin_partition`):
+
+  - `valueNoInfo_le_valueSignal`: information never hurts a single
+    decision maker (the value of any signal is nonnegative);
+  - `valueSignal_mono`: Blackwell monotonicity for partitions — if `σ`
+    is a coarsening of `τ` (i.e. `σ = h ∘ τ`), then `τ` is worth at
+    least as much as `σ`;
+  - `valueSignal_le_valuePerfect`: perfect information is the best
+    deterministic signal.
+
+  The companion file `InfoGames.lean` shows by contrast that in a
+  *game*, more information can strictly hurt the player who receives
+  it — monotonicity is a one-player phenomenon.
+
+  See #2610 (GT-Lean formalization, Bayesian phase 4).
+-/
+
+import Bayesian.Max_en
+
+/-- A finite single-agent decision problem with an unnormalized prior.
+    There are `nS` states and `nA + 1` actions (the `+ 1` keeps the
+    action set nonempty without carrying a positivity hypothesis). -/
+structure DecisionProblem where
+  /-- Number of states of the world -/
+  nS : Nat
+  /-- Number of actions minus one (actions are `Fin (nA + 1)`) -/
+  nA : Nat
+  /-- Unnormalized prior weight of each state -/
+  w : Fin nS → Nat
+  /-- Payoff of taking an action in a state -/
+  u : Fin nS → Fin (nA + 1) → Int
+
+/-- Prior-weighted payoff of action `a` in state `s`. -/
+def wu (D : DecisionProblem) (s : Fin D.nS) (a : Fin (D.nA + 1)) : Int :=
+  (D.w s : Int) * D.u s a
+
+/-- A deterministic signal with `m + 1` possible realizations: it
+    announces a realization in each state, i.e. partitions the state
+    space into (at most) `m + 1` cells. -/
+def Signal (D : DecisionProblem) (m : Nat) := Fin D.nS → Fin (m + 1)
+
+/-- Expected payoff (unnormalized) of an uninformed decision maker:
+    pick the single action with the best prior-weighted payoff. -/
+def valueNoInfo (D : DecisionProblem) : Int :=
+  maxFin D.nA (fun a => sumFin D.nS (fun s => wu D s a))
+
+/-- Expected payoff of a decision maker observing signal `σ`: inside
+    each cell `k` of the partition, pick the best action for the prior
+    restricted to that cell, then add up over cells. -/
+def valueSignal (D : DecisionProblem) {m : Nat} (σ : Signal D m) : Int :=
+  sumFin (m + 1) (fun k => maxFin D.nA (fun a =>
+    sumFin D.nS (fun s => if σ s = k then wu D s a else 0)))
+
+/-- Expected payoff of a fully informed decision maker: pick the best
+    action separately in every state. -/
+def valuePerfect (D : DecisionProblem) : Int :=
+  sumFin D.nS (fun s => maxFin D.nA (fun a => wu D s a))
+
+/-- The totally uninformative signal (a single realization) is worth
+    exactly the no-information value. -/
+theorem valueSignal_const (D : DecisionProblem) :
+    valueSignal D (fun _ => (0 : Fin 1)) = valueNoInfo D := by
+  unfold valueSignal valueNoInfo
+  simp
+
+/-- Fiber decomposition: summing `f` over the states classified by the
+    composite map `h ∘ τ` into cell `k` equals summing, over the
+    realizations `j` of `τ` that `h` sends to `k`, the `τ`-cell sums. -/
+theorem sumFin_fiber {n m p : Nat} (τ : Fin n → Fin p) (h : Fin p → Fin m)
+    (k : Fin m) (f : Fin n → Int) :
+    sumFin n (fun s => if h (τ s) = k then f s else 0) =
+    sumFin p (fun j => if h j = k then
+      sumFin n (fun s => if τ s = j then f s else 0) else 0) := by
+  have push : ∀ j : Fin p,
+      (if h j = k then sumFin n (fun s => if τ s = j then f s else 0) else 0) =
+      sumFin n (fun s => if h j = k then (if τ s = j then f s else 0) else 0) :=
+    fun j => (sumFin_if_distrib _ _).symm
+  rw [sumFin_congr push, sumFin_comm]
+  apply sumFin_congr
+  intro s
+  have swap : ∀ j : Fin p,
+      (if h j = k then (if τ s = j then f s else 0) else 0) =
+      (if τ s = j then (if h j = k then f s else 0) else 0) := by
+    intro j
+    by_cases h1 : h j = k <;> by_cases h2 : τ s = j <;> simp [h1, h2]
+  rw [sumFin_congr swap, sumFin_single (τ s) (fun j => if h j = k then f s else 0)]
+
+/-- **Blackwell monotonicity (deterministic case).** If the signal `σ`
+    is a coarsening of `τ` — every realization of `σ` is computed from
+    the realization of `τ` via `h` — then observing the finer signal
+    `τ` is worth at least as much as observing `σ`. -/
+theorem valueSignal_mono (D : DecisionProblem) {m p : Nat}
+    (σ : Signal D m) (τ : Signal D p) (h : Fin (p + 1) → Fin (m + 1))
+    (hfactor : ∀ s, σ s = h (τ s)) :
+    valueSignal D σ ≤ valueSignal D τ := by
+  unfold valueSignal
+  -- Rewrite each σ-cell sum as a sum over the τ-cells it contains.
+  have hcell : ∀ (k : Fin (m + 1)) (a : Fin (D.nA + 1)),
+      sumFin D.nS (fun s => if σ s = k then wu D s a else 0) =
+      sumFin (p + 1) (fun j => if h j = k then
+        sumFin D.nS (fun s => if τ s = j then wu D s a else 0) else 0) := by
+    intro k a
+    rw [sumFin_congr (fun s => by rw [hfactor s]),
+        sumFin_fiber τ h k (fun s => wu D s a)]
+  -- Bound the max over each σ-cell by the sum of maxima over its τ-cells.
+  have hk : ∀ k : Fin (m + 1),
+      maxFin D.nA (fun a =>
+        sumFin D.nS (fun s => if σ s = k then wu D s a else 0)) ≤
+      sumFin (p + 1) (fun j => if h j = k then
+        maxFin D.nA (fun a =>
+          sumFin D.nS (fun s => if τ s = j then wu D s a else 0)) else 0) := by
+    intro k
+    have step1 := maxFin_sumFin_le (fun j a => if h j = k then
+      sumFin D.nS (fun s => if τ s = j then wu D s a else 0) else 0)
+    have step2 : ∀ j : Fin (p + 1),
+        maxFin D.nA (fun a => if h j = k then
+          sumFin D.nS (fun s => if τ s = j then wu D s a else 0) else 0) =
+        (if h j = k then maxFin D.nA (fun a =>
+          sumFin D.nS (fun s => if τ s = j then wu D s a else 0)) else 0) :=
+      fun j => maxFin_if_distrib _ _
+    calc maxFin D.nA (fun a =>
+            sumFin D.nS (fun s => if σ s = k then wu D s a else 0))
+        = maxFin D.nA (fun a =>
+            sumFin (p + 1) (fun j => if h j = k then
+              sumFin D.nS (fun s => if τ s = j then wu D s a else 0) else 0)) := by
+          exact congrArg (maxFin D.nA) (funext (fun a => hcell k a))
+      _ ≤ sumFin (p + 1) (fun j =>
+            maxFin D.nA (fun a => if h j = k then
+              sumFin D.nS (fun s => if τ s = j then wu D s a else 0) else 0)) := step1
+      _ = sumFin (p + 1) (fun j => if h j = k then
+            maxFin D.nA (fun a =>
+              sumFin D.nS (fun s => if τ s = j then wu D s a else 0)) else 0) :=
+          sumFin_congr step2
+  -- Sum the per-cell bounds, then undo the double counting over k.
+  calc sumFin (m + 1) (fun k => maxFin D.nA (fun a =>
+          sumFin D.nS (fun s => if σ s = k then wu D s a else 0)))
+      ≤ sumFin (m + 1) (fun k => sumFin (p + 1) (fun j => if h j = k then
+          maxFin D.nA (fun a =>
+            sumFin D.nS (fun s => if τ s = j then wu D s a else 0)) else 0)) :=
+        sumFin_mono hk
+    _ = sumFin (p + 1) (fun j => maxFin D.nA (fun a =>
+          sumFin D.nS (fun s => if τ s = j then wu D s a else 0))) :=
+        (sumFin_partition h (fun j => maxFin D.nA (fun a =>
+          sumFin D.nS (fun s => if τ s = j then wu D s a else 0)))).symm
+
+/-- **Information never hurts a single decision maker**: any signal is
+    worth at least the no-information value (every signal refines the
+    trivial one). -/
+theorem valueNoInfo_le_valueSignal (D : DecisionProblem) {m : Nat}
+    (σ : Signal D m) :
+    valueNoInfo D ≤ valueSignal D σ := by
+  rw [← valueSignal_const D]
+  exact valueSignal_mono D (fun _ => (0 : Fin 1)) σ (fun _ => 0) (fun _ => rfl)
+
+/-- Perfect information dominates any signal: knowing the state exactly
+    is the finest deterministic signal. -/
+theorem valueSignal_le_valuePerfect (D : DecisionProblem) {m : Nat}
+    (σ : Signal D m) :
+    valueSignal D σ ≤ valuePerfect D := by
+  unfold valueSignal valuePerfect
+  have hk : ∀ k : Fin (m + 1),
+      maxFin D.nA (fun a =>
+        sumFin D.nS (fun s => if σ s = k then wu D s a else 0)) ≤
+      sumFin D.nS (fun s => if σ s = k then
+        maxFin D.nA (fun a => wu D s a) else 0) := by
+    intro k
+    have step1 := maxFin_sumFin_le (fun s a => if σ s = k then wu D s a else 0)
+    have step2 : ∀ s : Fin D.nS,
+        maxFin D.nA (fun a => if σ s = k then wu D s a else 0) =
+        (if σ s = k then maxFin D.nA (fun a => wu D s a) else 0) :=
+      fun s => maxFin_if_distrib _ _
+    exact Int.le_trans step1 (Int.le_of_eq (sumFin_congr step2))
+  calc sumFin (m + 1) (fun k => maxFin D.nA (fun a =>
+          sumFin D.nS (fun s => if σ s = k then wu D s a else 0)))
+      ≤ sumFin (m + 1) (fun k => sumFin D.nS (fun s => if σ s = k then
+          maxFin D.nA (fun a => wu D s a) else 0)) := sumFin_mono hk
+    _ = sumFin D.nS (fun s => maxFin D.nA (fun a => wu D s a)) :=
+        (sumFin_partition σ (fun s => maxFin D.nA (fun a => wu D s a))).symm
+
+/-- No information is at most perfect information (composition of the
+    two comparisons, stated directly for convenience). -/
+theorem valueNoInfo_le_valuePerfect (D : DecisionProblem) :
+    valueNoInfo D ≤ valuePerfect D :=
+  Int.le_trans (valueNoInfo_le_valueSignal D (fun _ => (0 : Fin 1)))
+    (valueSignal_le_valuePerfect D _)
+
+/-
+  Concrete check: the umbrella problem. Two equally likely states
+  (rain, sun), two actions (take the umbrella, leave it). Payoffs:
+  umbrella = 2 in rain, 0 in sun; no umbrella = -3 in rain, 3 in sun.
+-/
+
+/-- Rain-or-sun decision problem used as a kernel-checked example. -/
+def umbrella : DecisionProblem where
+  nS := 2
+  nA := 1
+  w := fun _ => 1
+  u := fun s a =>
+    if s.val = 0 then (if a.val = 0 then 2 else -3)
+    else (if a.val = 0 then 0 else 3)
+
+/-- Uninformed, the best plan (always take the umbrella) is worth 2. -/
+theorem umbrella_valueNoInfo : valueNoInfo umbrella = 2 := by decide
+
+/-- Perfectly informed (umbrella iff rain), the plan is worth 5. -/
+theorem umbrella_valuePerfect : valuePerfect umbrella = 5 := by decide
+
+/-- The value of perfect information is strictly positive here. -/
+theorem umbrella_strict_gain : valueNoInfo umbrella < valuePerfect umbrella := by
+  decide

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Max.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Max.lean
@@ -10,27 +10,11 @@
   peut qu'améliorer le choix d'une seule action pour tous les groupes.
 
   Voir #2610 (formalisation GT-Lean, phase bayésienne 4).
-
-  ---
-  English:
-  Finite maxima over `Fin (n + 1)` (core Lean 4 only, no Mathlib)
-  ===============================================================
-
-  Maximum of an `Int`-valued function over a nonempty finite domain,
-  mirroring the `sumFin` infrastructure of `Sum.lean`. The key result
-  for the value-of-information development (`Information.lean`) is
-  `maxFin_sumFin_le`: the max of a sum is at most the sum of the
-  groupwise maxima — adapting a decision to each group separately can
-  only improve on choosing one action for all groups at once.
-
-  See #2610 (GT-Lean formalization, Bayesian phase 4).
 -/
 
 import Bayesian.Sum
 
-/-- Maximum de `f` sur tout `Fin (n + 1)` (domaine non vide), par
-    English: Maximum of `f` over all of `Fin (n + 1)` (nonempty domain), by
-    structural recursion on `n`. -/
+/-- Maximum de `f` sur tout `Fin (n + 1)` (domaine non vide), par -/
 def maxFin : (n : Nat) → (Fin (n + 1) → Int) → Int
   | 0, f => f 0
   | n + 1, f => max (f 0) (maxFin n (fun i => f i.succ))
@@ -40,8 +24,7 @@ def maxFin : (n : Nat) → (Fin (n + 1) → Int) → Int
 @[simp] theorem maxFin_succ (n : Nat) (f : Fin (n + 2) → Int) :
     maxFin (n + 1) f = max (f 0) (maxFin n (fun i => f i.succ)) := rfl
 
-/-- Toute valeur de `f` est au plus égale à son maximum.
-    English: Every value of `f` is at most its maximum. -/
+/-- Toute valeur de `f` est au plus égale à son maximum. -/
 theorem le_maxFin : ∀ {n : Nat} (f : Fin (n + 1) → Int) (i : Fin (n + 1)),
     f i ≤ maxFin n f
   | 0, f, i => by
@@ -58,8 +41,7 @@ theorem le_maxFin : ∀ {n : Nat} (f : Fin (n + 1) → Int) (i : Fin (n + 1)),
       simp only [maxFin_succ]
       omega
 
-/-- Le maximum est au plus n'importe quelle borne supérieure ponctuelle.
-    English: The maximum is at most any pointwise upper bound. -/
+/-- Le maximum est au plus n'importe quelle borne supérieure ponctuelle. -/
 theorem maxFin_le : ∀ {n : Nat} {f : Fin (n + 1) → Int} {b : Int},
     (∀ i, f i ≤ b) → maxFin n f ≤ b
   | 0, _, _, h => h 0
@@ -69,8 +51,7 @@ theorem maxFin_le : ∀ {n : Nat} {f : Fin (n + 1) → Int} {b : Int},
     simp only [maxFin_succ]
     omega
 
-/-- Le maximum de la fonction nulle s'annule.
-    English: The maximum of the zero function vanishes. -/
+/-- Le maximum de la fonction nulle s'annule. -/
 @[simp] theorem maxFin_zero_fun (n : Nat) :
     maxFin n (fun _ => (0 : Int)) = 0 := by
   induction n with
@@ -79,19 +60,14 @@ theorem maxFin_le : ∀ {n : Nat} {f : Fin (n + 1) → Int} {b : Int},
 
 /-- Lemme maître : le max d'une somme est au plus la somme des max par
     groupe. Choisir une seule action `a` pour tous les groupes `j` d'un coup
-    ne bat pas le choix de la meilleure action séparément dans chaque groupe.
-    English: Master lemma: the max of a sum is at most the sum of the groupwise
-    maxima. Choosing one action `a` for every group `j` at once cannot
-    beat choosing the best action separately inside each group. -/
+    ne bat pas le choix de la meilleure action séparément dans chaque groupe. -/
 theorem maxFin_sumFin_le {nA m : Nat} (F : Fin m → Fin (nA + 1) → Int) :
     maxFin nA (fun a => sumFin m (fun j => F j a)) ≤
     sumFin m (fun j => maxFin nA (fun a => F j a)) :=
   maxFin_le (fun a => sumFin_mono (fun j => le_maxFin (F j) a))
 
 /-- Un `if` dont la condition ne dépend pas de l'indice se factorise hors
-    du maximum (la branche `else 0` correspond à la fonction nulle).
-    English: An `if` whose condition does not depend on the index pulls out of
-    the maximum (the `else 0` branch matches the zero function). -/
+    du maximum (la branche `else 0` correspond à la fonction nulle). -/
 theorem maxFin_if_distrib {n : Nat} (c : Prop) [Decidable c]
     (f : Fin (n + 1) → Int) :
     maxFin n (fun a => if c then f a else 0) = if c then maxFin n f else 0 := by
@@ -105,23 +81,10 @@ qui l'atteint). Ce témoin manquait jusqu'ici : le module de fictitious play
 `maxFin` mais défère l'extraction de l'indice argmax. `argmaxFin` comble ce gap
 de manière *born-correct* : sur un domaine non vide `Fin (n + 1)`, il renvoie
 toujours un indice (jamais d'échec), avec une garantie d'optimalité. En cas
-d'égalité, le plus petit indice l'emporte.
-
-English:
-Finite argmax — the index achieving the maximum
-
-`maxFin` gives the *value* of the maximum; `argmaxFin` gives its *witness* (an
-index that attains it). This witness was missing until now: the fictitious play
-module (`FictitiousPlay.lean`, phase 7) computes the best-response payoff via
-`maxFin` but defers extracting the argmax index. `argmaxFin` fills this gap in a
-*born-correct* way: over a nonempty domain `Fin (n + 1)` it always returns an
-index (never fails), with an optimality guarantee. Ties break to the smaller
-index. -/
+d'égalité, le plus petit indice l'emporte. -/
 
 /-- Indice atteignant le maximum de `f` sur `Fin (n + 1)` (domaine non vide),
-    miroir argmax de `maxFin`. En cas d'égalité, le plus petit indice l'emporte.
-    English: Index achieving the maximum of `f` over `Fin (n + 1)` (nonempty
-    domain), the argmax mirror of `maxFin`. Ties break to the smaller index. -/
+    miroir argmax de `maxFin`. En cas d'égalité, le plus petit indice l'emporte. -/
 def argmaxFin : (n : Nat) → (Fin (n + 1) → Int) → Fin (n + 1)
   | 0, _ => 0
   | n + 1, f =>
@@ -129,8 +92,7 @@ def argmaxFin : (n : Nat) → (Fin (n + 1) → Int) → Fin (n + 1)
     then 0
     else (argmaxFin n (fun i => f i.succ)).succ
 
-/-- L'argmax atteint bien le maximum : `f (argmaxFin n f) = maxFin n f`.
-    English: The argmax does achieve the maximum: `f (argmaxFin n f) = maxFin n f`. -/
+/-- L'argmax atteint bien le maximum : `f (argmaxFin n f) = maxFin n f`. -/
 theorem argmaxFin_spec : ∀ {n : Nat} (f : Fin (n + 1) → Int),
     f (argmaxFin n f) = maxFin n f
   | 0, _ => rfl
@@ -141,9 +103,7 @@ theorem argmaxFin_spec : ∀ {n : Nat} (f : Fin (n + 1) → Int),
     split <;> rename_i h <;> omega
 
 /-- Garantie d'optimalité de l'argmax : aucune valeur ne dépasse celle de
-    l'indice choisi.
-    English: Optimality guarantee of the argmax: no value exceeds that of the
-    chosen index. -/
+    l'indice choisi. -/
 theorem le_argmaxFin {n : Nat} (f : Fin (n + 1) → Int) (i : Fin (n + 1)) :
     f i ≤ f (argmaxFin n f) := by
   rw [argmaxFin_spec f]

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Max_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Max_en.lean
@@ -1,0 +1,112 @@
+/-
+  Finite maxima over `Fin (n + 1)` (core Lean 4 only, no Mathlib)
+  ===============================================================
+
+  Maximum of an `Int`-valued function over a nonempty finite domain,
+  mirroring the `sumFin` infrastructure of `Sum.lean`. The key result
+  for the value-of-information development (`Information.lean`) is
+  `maxFin_sumFin_le`: the max of a sum is at most the sum of the
+  groupwise maxima — adapting a decision to each group separately can
+  only improve on choosing one action for all groups at once.
+
+  See #2610 (GT-Lean formalization, Bayesian phase 4).
+-/
+
+import Bayesian.Sum_en
+
+/-- Maximum of `f` over all of `Fin (n + 1)` (nonempty domain), by
+    structural recursion on `n`. -/
+def maxFin : (n : Nat) → (Fin (n + 1) → Int) → Int
+  | 0, f => f 0
+  | n + 1, f => max (f 0) (maxFin n (fun i => f i.succ))
+
+@[simp] theorem maxFin_zero (f : Fin 1 → Int) : maxFin 0 f = f 0 := rfl
+
+@[simp] theorem maxFin_succ (n : Nat) (f : Fin (n + 2) → Int) :
+    maxFin (n + 1) f = max (f 0) (maxFin n (fun i => f i.succ)) := rfl
+
+/-- Every value of `f` is at most its maximum. -/
+theorem le_maxFin : ∀ {n : Nat} (f : Fin (n + 1) → Int) (i : Fin (n + 1)),
+    f i ≤ maxFin n f
+  | 0, f, i => by
+    cases i using Fin.cases with
+    | zero => exact Int.le_refl _
+    | succ j => exact j.elim0
+  | n + 1, f, i => by
+    cases i using Fin.cases with
+    | zero =>
+      simp only [maxFin_succ]
+      omega
+    | succ j =>
+      have h := le_maxFin (fun i => f i.succ) j
+      simp only [maxFin_succ]
+      omega
+
+/-- The maximum is at most any pointwise upper bound. -/
+theorem maxFin_le : ∀ {n : Nat} {f : Fin (n + 1) → Int} {b : Int},
+    (∀ i, f i ≤ b) → maxFin n f ≤ b
+  | 0, _, _, h => h 0
+  | n + 1, f, b, h => by
+    have h1 := h 0
+    have h2 := maxFin_le (f := fun i => f i.succ) (fun i => h i.succ)
+    simp only [maxFin_succ]
+    omega
+
+/-- The maximum of the zero function vanishes. -/
+@[simp] theorem maxFin_zero_fun (n : Nat) :
+    maxFin n (fun _ => (0 : Int)) = 0 := by
+  induction n with
+  | zero => rfl
+  | succ n ih => simp [ih]
+
+/-- Master lemma: the max of a sum is at most the sum of the groupwise
+    maxima. Choosing one action `a` for every group `j` at once cannot
+    beat choosing the best action separately inside each group. -/
+theorem maxFin_sumFin_le {nA m : Nat} (F : Fin m → Fin (nA + 1) → Int) :
+    maxFin nA (fun a => sumFin m (fun j => F j a)) ≤
+    sumFin m (fun j => maxFin nA (fun a => F j a)) :=
+  maxFin_le (fun a => sumFin_mono (fun j => le_maxFin (F j) a))
+
+/-- An `if` whose condition does not depend on the index pulls out of
+    the maximum (the `else 0` branch matches the zero function). -/
+theorem maxFin_if_distrib {n : Nat} (c : Prop) [Decidable c]
+    (f : Fin (n + 1) → Int) :
+    maxFin n (fun a => if c then f a else 0) = if c then maxFin n f else 0 := by
+  by_cases h : c <;> simp [h]
+
+/-!
+Finite argmax — the index achieving the maximum
+
+`maxFin` gives the *value* of the maximum; `argmaxFin` gives its *witness* (an
+index that attains it). This witness was missing until now: the fictitious play
+module (`FictitiousPlay.lean`, phase 7) computes the best-response payoff via
+`maxFin` but defers extracting the argmax index. `argmaxFin` fills this gap in a
+*born-correct* way: over a nonempty domain `Fin (n + 1)` it always returns an
+index (never fails), with an optimality guarantee. Ties break to the smaller
+index. -/
+
+/-- Index achieving the maximum of `f` over `Fin (n + 1)` (nonempty
+    domain), the argmax mirror of `maxFin`. Ties break to the smaller index. -/
+def argmaxFin : (n : Nat) → (Fin (n + 1) → Int) → Fin (n + 1)
+  | 0, _ => 0
+  | n + 1, f =>
+    if f 0 ≥ f (argmaxFin n (fun i => f i.succ)).succ
+    then 0
+    else (argmaxFin n (fun i => f i.succ)).succ
+
+/-- The argmax does achieve the maximum: `f (argmaxFin n f) = maxFin n f`. -/
+theorem argmaxFin_spec : ∀ {n : Nat} (f : Fin (n + 1) → Int),
+    f (argmaxFin n f) = maxFin n f
+  | 0, _ => rfl
+  | n + 1, f => by
+    have ih : f (argmaxFin n (fun i => f i.succ)).succ
+        = maxFin n (fun i => f i.succ) := argmaxFin_spec (fun i => f i.succ)
+    simp only [argmaxFin, maxFin_succ]
+    split <;> rename_i h <;> omega
+
+/-- Optimality guarantee of the argmax: no value exceeds that of the
+    chosen index. -/
+theorem le_argmaxFin {n : Nat} (f : Fin (n + 1) → Int) (i : Fin (n + 1)) :
+    f i ≤ f (argmaxFin n f) := by
+  rw [argmaxFin_spec f]
+  exact le_maxFin f i

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Regret.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Regret.lean
@@ -16,66 +16,36 @@
   certifiées par `decide` (vérification noyau).
 
   Voir #2610 (formalisation GT-Lean, cible GT-13 : minimisation de regret).
-
-  ---
-  English:
-  External regret for a finite play sequence (core Lean 4 only, no Mathlib)
-  ========================================================================
-
-  Central object of *regret minimization* (online learning, the foundation of
-  CFR — Counterfactual Regret Minimization), listed as a GT-Lean-ext target
-  (GT-13, imperfect information) in the gap table of #2610.
-
-  Over a finite sequence of `T` rounds with `nA + 1` actions, each round reveals
-  a payoff vector `payoff t : Fin (nA + 1) → Int` and the player realizes an
-  action `played t`. The **external regret** is the gap between the payoff of
-  the best fixed action *in hindsight* and the payoff actually obtained. It
-  measures "how much better a single fixed action, chosen after the fact, would
-  have done". Reuses the `sumFin` (`Sum.lean`) and `maxFin` (`Max.lean`)
-  infrastructure; everything is decidable, so concrete instances are certified
-  by `decide` (kernel checking).
-
-  See #2610 (GT-Lean formalization, GT-13 target: regret minimization).
 -/
 
 import Bayesian.Sum
 import Bayesian.Max
 
 /-- Paiement total réellement obtenu : somme sur les rounds du paiement de
-    l'action effectivement jouée à chaque round.
-    English: Total payoff actually obtained: sum over rounds of the payoff of
-    the action actually played each round. -/
+    l'action effectivement jouée à chaque round. -/
 def realizedTotal (T nA : Nat) (payoff : Fin T → Fin (nA + 1) → Int)
     (played : Fin T → Fin (nA + 1)) : Int :=
   sumFin T (fun t => payoff t (played t))
 
 /-- Paiement total d'une action fixe `a` jouée à tous les rounds (candidat au
-    meilleur choix en rétrospective).
-    English: Total payoff of a single fixed action `a` played at every round
-    (a candidate for the best-in-hindsight choice). -/
+    meilleur choix en rétrospective). -/
 def fixedTotal (T nA : Nat) (payoff : Fin T → Fin (nA + 1) → Int)
     (a : Fin (nA + 1)) : Int :=
   sumFin T (fun t => payoff t a)
 
 /-- Meilleure action fixe en rétrospective : maximum sur les actions du
-    paiement fixe total.
-    English: Best fixed action in hindsight: maximum over actions of the total
-    fixed payoff. -/
+    paiement fixe total. -/
 def bestFixedTotal (T nA : Nat) (payoff : Fin T → Fin (nA + 1) → Int) : Int :=
   maxFin nA (fun a => fixedTotal T nA payoff a)
 
 /-- Regret externe : écart entre la meilleure action fixe en rétrospective et
-    le paiement réellement obtenu.
-    English: External regret: gap between the best fixed action in hindsight and
-    the payoff actually obtained. -/
+    le paiement réellement obtenu. -/
 def externalRegret (T nA : Nat) (payoff : Fin T → Fin (nA + 1) → Int)
     (played : Fin T → Fin (nA + 1)) : Int :=
   bestFixedTotal T nA payoff - realizedTotal T nA payoff played
 
 /-- Lemme auxiliaire : soustraire une constante commute avec le maximum fini
-    (`max (f · − c) = max f − c`), miroir de `sumFin_mul_left`.
-    English: Auxiliary lemma: subtracting a constant commutes with the finite
-    maximum (`max (f · − c) = max f − c`), mirror of `sumFin_mul_left`. -/
+    (`max (f · − c) = max f − c`), miroir de `sumFin_mul_left`. -/
 theorem maxFin_sub_const : ∀ {n : Nat} (f : Fin (n + 1) → Int) (c : Int),
     maxFin n (fun a => f a - c) = maxFin n f - c
   | 0, _, _ => rfl
@@ -86,9 +56,6 @@ theorem maxFin_sub_const : ∀ {n : Nat} (f : Fin (n + 1) → Int) (c : Int),
 
 /-- Garantie définissante du regret externe : aucune action fixe ne bat le jeu
     réalisé de plus que le regret externe (borne point par point sur les
-    actions).
-    English: Defining guarantee of external regret: no fixed action beats the
-    realized play by more than the external regret (pointwise bound over
     actions). -/
 theorem fixed_gap_le_externalRegret (T nA : Nat)
     (payoff : Fin T → Fin (nA + 1) → Int) (played : Fin T → Fin (nA + 1))
@@ -102,9 +69,7 @@ theorem fixed_gap_le_externalRegret (T nA : Nat)
   omega
 
 /-- Caractérisation : le regret externe est le maximum sur les actions de
-    l'écart (paiement de l'action fixe − paiement réalisé).
-    English: Characterization: external regret is the maximum over actions of
-    the gap (fixed-action payoff − realized payoff). -/
+    l'écart (paiement de l'action fixe − paiement réalisé). -/
 theorem externalRegret_eq_maxFin_gap (T nA : Nat)
     (payoff : Fin T → Fin (nA + 1) → Int) (played : Fin T → Fin (nA + 1)) :
     externalRegret T nA payoff played
@@ -116,10 +81,7 @@ theorem externalRegret_eq_maxFin_gap (T nA : Nat)
 
 /-- Jouer constamment une même action donne un regret externe positif ou nul :
     le paiement réalisé est alors le paiement fixe de cette action, borné par le
-    meilleur.
-    English: Playing one and the same action throughout yields nonnegative
-    external regret: the realized payoff is then that action's fixed payoff,
-    bounded by the best. -/
+    meilleur. -/
 theorem externalRegret_const_nonneg (T nA : Nat)
     (payoff : Fin T → Fin (nA + 1) → Int) (a : Fin (nA + 1)) :
     0 ≤ externalRegret T nA payoff (fun _ => a) := by
@@ -134,15 +96,9 @@ theorem externalRegret_const_nonneg (T nA : Nat)
   ## Instance concrète — 2 actions, 3 rounds (experts)
 
   Vecteurs de paiement : round 0 favorise l'action 0, round 1 l'action 1,
-  round 2 l'action 0. La meilleure action fixe est l'action 0 (total 2 contre 1).
+  round 2 l'action 0. La meilleure action fixe est l'action 0 (total 2 contre 1). -/
 
-  English: Concrete instance — 2 actions, 3 rounds (experts). Payoff vectors:
-  round 0 favors action 0, round 1 favors action 1, round 2 favors action 0.
-  The best fixed action is action 0 (total 2 vs 1).
--/
-
-/-- Paiements experts concrets (`Fin 3` rounds, `Fin 2` actions).
-    English: Concrete experts payoffs (`Fin 3` rounds, `Fin 2` actions). -/
+/-- Paiements experts concrets (`Fin 3` rounds, `Fin 2` actions). -/
 def payoffEx (t : Fin 3) (a : Fin 2) : Int :=
   match t.val, a.val with
   | 0, 0 => 1
@@ -152,22 +108,16 @@ def payoffEx (t : Fin 3) (a : Fin 2) : Int :=
   | _, 0 => 1
   | _, _ => 0
 
-/-- Jeu optimal en rétrospective : toujours l'action 0.
-    English: Hindsight-optimal play: always action 0. -/
+/-- Jeu optimal en rétrospective : toujours l'action 0. -/
 def playedOpt : Fin 3 → Fin 2 := fun _ => 0
 
-/-- Jeu sous-optimal : toujours l'action 1.
-    English: Suboptimal play: always action 1. -/
+/-- Jeu sous-optimal : toujours l'action 1. -/
 def playedBad : Fin 3 → Fin 2 := fun _ => 1
 
-/-- Jouer la meilleure action fixe donne un regret externe nul (certifié noyau).
-    English: Playing the best fixed action yields zero external regret
-    (kernel-certified). -/
+/-- Jouer la meilleure action fixe donne un regret externe nul (certifié noyau). -/
 theorem externalRegret_playedOpt : externalRegret 3 1 payoffEx playedOpt = 0 := by
   decide
 
-/-- Un jeu sous-optimal a un regret externe strictement positif (certifié noyau).
-    English: A suboptimal play has strictly positive external regret
-    (kernel-certified). -/
+/-- Un jeu sous-optimal a un regret externe strictement positif (certifié noyau). -/
 theorem externalRegret_playedBad : externalRegret 3 1 payoffEx playedBad = 1 := by
   decide

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Regret_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Regret_en.lean
@@ -1,0 +1,124 @@
+/-
+  External regret for a finite play sequence (core Lean 4 only, no Mathlib)
+  ========================================================================
+
+  Central object of *regret minimization* (online learning, the foundation of
+  CFR — Counterfactual Regret Minimization), listed as a GT-Lean-ext target
+  (GT-13, imperfect information) in the gap table of #2610.
+
+  Over a finite sequence of `T` rounds with `nA + 1` actions, each round reveals
+  a payoff vector `payoff t : Fin (nA + 1) → Int` and the player realizes an
+  action `played t`. The **external regret** is the gap between the payoff of
+  the best fixed action *in hindsight* and the payoff actually obtained. It
+  measures "how much better a single fixed action, chosen after the fact, would
+  have done". Reuses the `sumFin` (`Sum.lean`) and `maxFin` (`Max.lean`)
+  infrastructure; everything is decidable, so concrete instances are certified
+  by `decide` (kernel checking).
+
+  See #2610 (GT-Lean formalization, GT-13 target: regret minimization).
+-/
+
+import Bayesian.Sum_en
+import Bayesian.Max_en
+
+/-- Total payoff actually obtained: sum over rounds of the payoff of
+    the action actually played each round. -/
+def realizedTotal (T nA : Nat) (payoff : Fin T → Fin (nA + 1) → Int)
+    (played : Fin T → Fin (nA + 1)) : Int :=
+  sumFin T (fun t => payoff t (played t))
+
+/-- Total payoff of a single fixed action `a` played at every round
+    (a candidate for the best-in-hindsight choice). -/
+def fixedTotal (T nA : Nat) (payoff : Fin T → Fin (nA + 1) → Int)
+    (a : Fin (nA + 1)) : Int :=
+  sumFin T (fun t => payoff t a)
+
+/-- Best fixed action in hindsight: maximum over actions of the total
+    fixed payoff. -/
+def bestFixedTotal (T nA : Nat) (payoff : Fin T → Fin (nA + 1) → Int) : Int :=
+  maxFin nA (fun a => fixedTotal T nA payoff a)
+
+/-- External regret: gap between the best fixed action in hindsight and
+    the payoff actually obtained. -/
+def externalRegret (T nA : Nat) (payoff : Fin T → Fin (nA + 1) → Int)
+    (played : Fin T → Fin (nA + 1)) : Int :=
+  bestFixedTotal T nA payoff - realizedTotal T nA payoff played
+
+/-- Auxiliary lemma: subtracting a constant commutes with the finite
+    maximum (`max (f · − c) = max f − c`), mirror of `sumFin_mul_left`. -/
+theorem maxFin_sub_const : ∀ {n : Nat} (f : Fin (n + 1) → Int) (c : Int),
+    maxFin n (fun a => f a - c) = maxFin n f - c
+  | 0, _, _ => rfl
+  | n + 1, f, c => by
+    simp only [maxFin_succ]
+    rw [maxFin_sub_const (fun i => f i.succ) c]
+    omega
+
+/-- Defining guarantee of external regret: no fixed action beats the
+    realized play by more than the external regret (pointwise bound over
+    actions). -/
+theorem fixed_gap_le_externalRegret (T nA : Nat)
+    (payoff : Fin T → Fin (nA + 1) → Int) (played : Fin T → Fin (nA + 1))
+    (a : Fin (nA + 1)) :
+    fixedTotal T nA payoff a - realizedTotal T nA payoff played
+      ≤ externalRegret T nA payoff played := by
+  have h : fixedTotal T nA payoff a ≤ bestFixedTotal T nA payoff :=
+    le_maxFin (fun a => fixedTotal T nA payoff a) a
+  show fixedTotal T nA payoff a - realizedTotal T nA payoff played
+      ≤ bestFixedTotal T nA payoff - realizedTotal T nA payoff played
+  omega
+
+/-- Characterization: external regret is the maximum over actions of
+    the gap (fixed-action payoff − realized payoff). -/
+theorem externalRegret_eq_maxFin_gap (T nA : Nat)
+    (payoff : Fin T → Fin (nA + 1) → Int) (played : Fin T → Fin (nA + 1)) :
+    externalRegret T nA payoff played
+      = maxFin nA (fun a =>
+          fixedTotal T nA payoff a - realizedTotal T nA payoff played) := by
+  unfold externalRegret bestFixedTotal
+  rw [maxFin_sub_const (fun a => fixedTotal T nA payoff a)
+        (realizedTotal T nA payoff played)]
+
+/-- Playing one and the same action throughout yields nonnegative
+    external regret: the realized payoff is then that action's fixed payoff,
+    bounded by the best. -/
+theorem externalRegret_const_nonneg (T nA : Nat)
+    (payoff : Fin T → Fin (nA + 1) → Int) (a : Fin (nA + 1)) :
+    0 ≤ externalRegret T nA payoff (fun _ => a) := by
+  have h : fixedTotal T nA payoff a ≤ bestFixedTotal T nA payoff :=
+    le_maxFin (fun a => fixedTotal T nA payoff a) a
+  have hreal : realizedTotal T nA payoff (fun _ => a) = fixedTotal T nA payoff a :=
+    rfl
+  show 0 ≤ bestFixedTotal T nA payoff - realizedTotal T nA payoff (fun _ => a)
+  omega
+
+/-! Concrete instance — 2 actions, 3 rounds (experts). Payoff vectors:
+  round 0 favors action 0, round 1 favors action 1, round 2 favors action 0.
+  The best fixed action is action 0 (total 2 vs 1).
+-/
+
+/-- Concrete experts payoffs (`Fin 3` rounds, `Fin 2` actions). -/
+def payoffEx (t : Fin 3) (a : Fin 2) : Int :=
+  match t.val, a.val with
+  | 0, 0 => 1
+  | 0, _ => 0
+  | 1, 0 => 0
+  | 1, _ => 1
+  | _, 0 => 1
+  | _, _ => 0
+
+/-- Hindsight-optimal play: always action 0. -/
+def playedOpt : Fin 3 → Fin 2 := fun _ => 0
+
+/-- Suboptimal play: always action 1. -/
+def playedBad : Fin 3 → Fin 2 := fun _ => 1
+
+/-- Playing the best fixed action yields zero external regret
+    (kernel-certified). -/
+theorem externalRegret_playedOpt : externalRegret 3 1 payoffEx playedOpt = 0 := by
+  decide
+
+/-- A suboptimal play has strictly positive external regret
+    (kernel-certified). -/
+theorem externalRegret_playedBad : externalRegret 3 1 payoffEx playedBad = 1 := by
+  decide

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Reputation.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Reputation.lean
@@ -35,56 +35,6 @@
     l'incertitude de l'entrant sur son type, i.e. de la réputation.
 
   Voir #2610 (formalisation GT-Lean, phase bayésienne 5).
-
-  ---
-  English:
-  Reputation and Entry Deterrence (chain-store, kernel-checked)
-  =============================================================
-
-  A reduced strategic form of the classic two-period entry-deterrence
-  story (Kreps-Wilson / Milgrom-Roberts): an incumbent faces entry in
-  period 1, responds Fight or Accommodate, and a second entrant decides
-  whether to enter in period 2 *after observing* the period-1 response.
-
-  The incumbent (player 1) is one of two types:
-  - type 0, "rational": fighting costs in every period taken in
-    isolation (stage payoffs: Fight 0 < Accommodate 2);
-  - type 1, "tough" (commitment type): fighting is intrinsically
-    preferred (Fight 3 > Accommodate 0).
-
-  Equal prior weights (1, 1). Period-2 monopoly (entrant stays out)
-  pays the incumbent 5.
-
-  Action encodings (reduced plans, `Fin 4`, bit 0 = Accommodate/Out,
-  bit 1 = Fight/In):
-  - incumbent plan `a1`: `a1.val = 2*r1 + r2` where `r1` is the
-    period-1 response and `r2` the period-2 response if entry occurs;
-  - entrant plan `a2`: `a2.val = 2*eF + eA` where `eF` (resp. `eA`) is
-    the period-2 entry decision after observing Fight (resp.
-    Accommodate) in period 1.
-
-  Because raw normal-form equilibrium also admits non-credible threats
-  ("I will fight in period 2" by the rational type — never carried out
-  if tested), we impose a decidable *credibility* refinement standing
-  in for sequential rationality in the last period: each type's
-  period-2 response must be a stage best reply (rational accommodates,
-  tough fights).
-
-  Results (all by `decide` + eta-expansion of strategies):
-  - `gRep` (incomplete information, reputation possible) has a unique
-    credible BNE: the rational type *pools* with the tough type and
-    fights in period 1, the entrant stays out after a fight. The
-    rational incumbent earns 5.
-  - `gNoRep` (complete information benchmark: the incumbent is known
-    rational) has a unique credible BNE: accommodate, entry occurs,
-    payoff 4.
-  - `reputation_pays`: 4 < 5 in every credible equilibrium pair — the
-    incumbent's incentive to fight comes *only* from the entrant's
-    uncertainty about its type, i.e. from reputation. The rational type
-    fights in period 1 even though fighting is myopically dominated
-    (`rational_fights_in_equilibrium`).
-
-  See #2610 (GT-Lean formalization, Bayesian phase 5).
 -/
 
 import Bayesian.BNE
@@ -92,57 +42,41 @@ import Bayesian.BNE
 /-! ### Plan decoders -/
 
 /-- Réponse de période 1 encodée dans un plan d'incumbent
-    (0 = Accommodate, 1 = Fight).
-    English: Period-1 response encoded in an incumbent plan
     (0 = Accommodate, 1 = Fight). -/
 def planR1 (a : Fin 4) : Nat := a.val / 2
 
 /-- Réponse de période 2 (si entrée) encodée dans un plan d'incumbent
-    (0 = Accommodate, 1 = Fight).
-    English: Period-2 response (if entry occurs) encoded in an incumbent plan
     (0 = Accommodate, 1 = Fight). -/
 def planR2 (a : Fin 4) : Nat := a.val % 2
 
 /-- Décision d'entrée de période 2 de l'entrant sur le chemin : la composante
     de son plan sélectionnée par la réponse observée de période 1
-    (0 = Out, 1 = In).
-    English: The entrant's period-2 entry decision on path: the component of
-    its plan selected by the observed period-1 response
     (0 = Out, 1 = In). -/
 def entryOf (a1 a2 : Fin 4) : Nat :=
   if planR1 a1 = 1 then a2.val / 2 else a2.val % 2
 
 /-! ### Stage payoffs -/
 
-/-- Paiement sur deux périodes de l'incumbent *rationnel* : se battre coûte
-    English: Two-period payoff of the *rational* incumbent: fighting costs in
-    period 1 (0 vs 2), monopoly pays 5, and the period-2 response is
-    paid at stage values (Fight 0, Accommodate 2). -/
+/-- Paiement sur deux périodes de l'incumbent *rationnel* : se battre coûte -/
 def incRational (a1 a2 : Fin 4) : Int :=
   (if planR1 a1 = 1 then 0 else 2) +
   (if entryOf a1 a2 = 0 then 5
    else if planR2 a1 = 1 then 0 else 2)
 
-/-- Paiement sur deux périodes de l'incumbent *dur* (engagement) : se battre
-    English: Two-period payoff of the *tough* (commitment) incumbent: fighting
-    is intrinsically preferred (3 vs 0) in both periods. -/
+/-- Paiement sur deux périodes de l'incumbent *dur* (engagement) : se battre -/
 def incTough (a1 a2 : Fin 4) : Int :=
   (if planR1 a1 = 1 then 3 else 0) +
   (if entryOf a1 a2 = 0 then 5
    else if planR2 a1 = 1 then 3 else 0)
 
-/-- Paiement de l'entrant en période 2 : 0 dehors, 2 s'il entre et
-    English: Period-2 entrant's payoff: 0 out, 2 if it enters and the incumbent
-    accommodates, -3 if it enters and the incumbent fights. -/
+/-- Paiement de l'entrant en période 2 : 0 dehors, 2 s'il entre et -/
 def entrantU (a1 a2 : Fin 4) : Int :=
   if entryOf a1 a2 = 0 then 0
   else if planR2 a1 = 1 then -3 else 2
 
 /-! ### The two games -/
 
-/-- Le jeu de réputation : l'entrant ne connaît pas le type de
-    English: The reputation game: the entrant does not know the incumbent's
-    type (rational or tough, equal weights). -/
+/-- Le jeu de réputation : l'entrant ne connaît pas le type de -/
 def gRep : BayesGame2 where
   nT1 := 2
   nT2 := 1
@@ -153,9 +87,7 @@ def gRep : BayesGame2 where
     if t1.val = 0 then incRational a1 a2 else incTough a1 a2
   u2 := fun _ _ a1 a2 => entrantU a1 a2
 
-/-- Le benchmark à information complète : l'incumbent est connu pour être
-    English: The complete-information benchmark: the incumbent is known to be
-    rational (a single type). Same actions, same payoff tables. -/
+/-- Le benchmark à information complète : l'incumbent est connu pour être -/
 def gNoRep : BayesGame2 where
   nT1 := 1
   nT2 := 1
@@ -165,9 +97,7 @@ def gNoRep : BayesGame2 where
   u1 := fun _ _ a1 a2 => incRational a1 a2
   u2 := fun _ _ a1 a2 => entrantU a1 a2
 
-/-- Vérification : le benchmark est exactement le jeu de réputation
-    English: Sanity check: the benchmark is exactly the reputation game
-    restricted to the rational type — not an unrelated game. -/
+/-- Vérification : le benchmark est exactement le jeu de réputation -/
 theorem gNoRep_restriction :
     ∀ a1 a2 : Fin 4,
       gNoRep.u1 ⟨0, by decide⟩ ⟨0, by decide⟩ a1 a2 =
@@ -185,32 +115,24 @@ out). Sequential rationality in the *last* period is a finite,
 decidable condition on plans: each type's period-2 response must be a
 stage best reply. -/
 
-/-- Crédibilité dans le jeu de réputation : le type rationnel accommode
-    English: Credibility in the reputation game: the rational type accommodates
-    in period 2 (2 > 0), the tough type fights (3 > 0). -/
+/-- Crédibilité dans le jeu de réputation : le type rationnel accommode -/
 @[reducible] def credRep (s1 : Strategy1 gRep) : Prop :=
   planR2 (s1 ⟨0, by decide⟩) = 0 ∧ planR2 (s1 ⟨1, by decide⟩) = 1
 
-/-- Crédibilité dans le benchmark : l'incumbent (rationnel)
-    English: Credibility in the benchmark: the (rational) incumbent
-    accommodates in period 2. -/
+/-- Crédibilité dans le benchmark : l'incumbent (rationnel) -/
 @[reducible] def credNoRep (s1 : Strategy1 gNoRep) : Prop :=
   planR2 (s1 ⟨0, by decide⟩) = 0
 
 /-! ### Canonical strategy constructors (reputation game) -/
 
-/-- Stratégies de l'incumbent dans `gRep`, depuis les deux plans
-    English: Incumbent strategies in `gRep`, from the two type-contingent
-    plans. -/
+/-- Stratégies de l'incumbent dans `gRep`, depuis les deux plans -/
 def mkRepS1 (x y : Fin 4) : Strategy1 gRep :=
   fun t1 => if t1.val = 0 then x else y
 
-/-- Les stratégies de l'entrant dans `gRep` sont constantes (un seul type).
-    English: Entrant strategies in `gRep` are constants (one type). -/
+/-- Les stratégies de l'entrant dans `gRep` sont constantes (un seul type). -/
 def mkRepS2 (z : Fin 4) : Strategy2 gRep := fun _ => z
 
-/-- Toute stratégie d'incumbent est déterminée par ses deux valeurs.
-    English: Every incumbent strategy is determined by its two values. -/
+/-- Toute stratégie d'incumbent est déterminée par ses deux valeurs. -/
 theorem repS1_eta (s1 : Strategy1 gRep) :
     s1 = mkRepS1 (s1 ⟨0, by decide⟩) (s1 ⟨1, by decide⟩) := by
   funext t1
@@ -221,8 +143,7 @@ theorem repS1_eta (s1 : Strategy1 gRep) :
     | zero => rfl
     | succ j' => exact j'.elim0
 
-/-- Toute stratégie d'entrant est une constante canonique.
-    English: Every entrant strategy is a canonical constant. -/
+/-- Toute stratégie d'entrant est une constante canonique. -/
 theorem repS2_eta (s2 : Strategy2 gRep) :
     s2 = mkRepS2 (s2 ⟨0, by decide⟩) := by
   funext t2
@@ -236,23 +157,18 @@ Target profile: rational plays plan 2 = (Fight, Accommodate), tough
 plays plan 3 = (Fight, Fight), entrant plays plan 1 = (Out after
 Fight, In after Accommodate). -/
 
-/-- Le profil de fusion est un BNE du jeu de réputation.
-    English: The pooling profile is a BNE of the reputation game. -/
+/-- Le profil de fusion est un BNE du jeu de réputation. -/
 theorem gRep_bne :
     isBNE gRep (mkRepS1 ⟨2, by decide⟩ ⟨3, by decide⟩)
       (mkRepS2 ⟨1, by decide⟩) := by
   decide
 
-/-- Le profil de fusion est crédible.
-    English: The pooling profile is credible. -/
+/-- Le profil de fusion est crédible. -/
 theorem gRep_bne_credible :
     credRep (mkRepS1 ⟨2, by decide⟩ ⟨3, by decide⟩) := by
   decide
 
-/-- Sur les stratégies canoniques, le BNE crédible de `gRep` est unique :
-    English: Over canonical strategies, the credible BNE of `gRep` is unique:
-    both incumbent types fight in period 1 (the rational type pools),
-    and the entrant enters iff it observed Accommodate. -/
+/-- Sur les stratégies canoniques, le BNE crédible de `gRep` est unique : -/
 theorem gRep_unique_aux :
     ∀ x y z : Fin 4,
       isBNE gRep (mkRepS1 x y) (mkRepS2 z) →
@@ -260,10 +176,7 @@ theorem gRep_unique_aux :
         x = ⟨2, by decide⟩ ∧ y = ⟨3, by decide⟩ ∧ z = ⟨1, by decide⟩ := by
   decide
 
-/-- Sur les stratégies canoniques, tout BNE crédible de `gRep` paie
-    English: Over canonical strategies, every credible BNE of `gRep` pays the
-    rational incumbent exactly 5 (deterrence: 0 in period 1, monopoly
-    5 in period 2). -/
+/-- Sur les stratégies canoniques, tout BNE crédible de `gRep` paie -/
 theorem gRep_payoff_aux :
     ∀ x y z : Fin 4,
       isBNE gRep (mkRepS1 x y) (mkRepS2 z) →
@@ -271,8 +184,7 @@ theorem gRep_payoff_aux :
         interimU1 gRep ⟨0, by decide⟩ x (mkRepS2 z) = 5 := by
   decide
 
-/-- Le jeu de réputation a un BNE crédible essentiellement unique.
-    English: The reputation game has an essentially unique credible BNE. -/
+/-- Le jeu de réputation a un BNE crédible essentiellement unique. -/
 theorem gRep_unique (s1 : Strategy1 gRep) (s2 : Strategy2 gRep)
     (h : isBNE gRep s1 s2) (hc : credRep s1) :
     s1 = mkRepS1 ⟨2, by decide⟩ ⟨3, by decide⟩ ∧
@@ -284,9 +196,7 @@ theorem gRep_unique (s1 : Strategy1 gRep) (s2 : Strategy2 gRep)
          by rw [repS2_eta s2, hu.2.2]⟩
 
 /-- Dans tout BNE crédible du jeu de réputation, l'incumbent rationnel
-    gagne 5.
-    English: In every credible BNE of the reputation game, the rational
-    incumbent earns 5. -/
+    gagne 5. -/
 theorem gRep_credible_payoff (s1 : Strategy1 gRep) (s2 : Strategy2 gRep)
     (h : isBNE gRep s1 s2) (hc : credRep s1) :
     interimU1 gRep ⟨0, by decide⟩ (s1 ⟨0, by decide⟩) s2 = 5 := by
@@ -294,10 +204,7 @@ theorem gRep_credible_payoff (s1 : Strategy1 gRep) (s2 : Strategy2 gRep)
   rw [repS2_eta s2] at h ⊢
   exact gRep_payoff_aux _ _ _ h hc
 
-/-- Dans tout BNE crédible du jeu de réputation le type *rationnel* se bat
-    English: In every credible BNE of the reputation game the *rational* type
-    fights in period 1, even though fighting is myopically dominated
-    (stage value 0 < 2): the pooling/signaling motive. -/
+/-- Dans tout BNE crédible du jeu de réputation le type *rationnel* se bat -/
 theorem rational_fights_in_equilibrium
     (s1 : Strategy1 gRep) (s2 : Strategy2 gRep)
     (h : isBNE gRep s1 s2) (hc : credRep s1) :
@@ -308,10 +215,7 @@ theorem rational_fights_in_equilibrium
   rw [hu.1]
   decide
 
-/-- Dans tout BNE crédible du jeu de réputation, l'entrée de période 2 est
-    English: In every credible BNE of the reputation game, period-2 entry is
-    deterred against both types: the entrant observes Fight on path
-    and stays out. -/
+/-- Dans tout BNE crédible du jeu de réputation, l'entrée de période 2 est -/
 theorem reputation_deters_entry
     (s1 : Strategy1 gRep) (s2 : Strategy2 gRep)
     (h : isBNE gRep s1 s2) (hc : credRep s1) :
@@ -325,12 +229,10 @@ theorem reputation_deters_entry
 
 /-! ### Equilibrium analysis of the benchmark -/
 
-/-- Les stratégies d'incumbent dans `gNoRep` sont constantes.
-    English: Incumbent strategies in `gNoRep` are constants. -/
+/-- Les stratégies d'incumbent dans `gNoRep` sont constantes. -/
 def mkNoS1 (x : Fin 4) : Strategy1 gNoRep := fun _ => x
 
-/-- Les stratégies d'entrant dans `gNoRep` sont constantes.
-    English: Entrant strategies in `gNoRep` are constants. -/
+/-- Les stratégies d'entrant dans `gNoRep` sont constantes. -/
 def mkNoS2 (z : Fin 4) : Strategy2 gNoRep := fun _ => z
 
 theorem noS1_eta (s1 : Strategy1 gNoRep) :
@@ -347,17 +249,13 @@ theorem noS2_eta (s2 : Strategy2 gNoRep) :
   | zero => rfl
   | succ j => exact j.elim0
 
-/-- (Accommodate, Accommodate) / (In, In) est un BNE crédible du benchmark.
-    English: (Accommodate, Accommodate) / (In, In) is a credible BNE of the
-    benchmark. -/
+/-- (Accommodate, Accommodate) / (In, In) est un BNE crédible du benchmark. -/
 theorem gNoRep_bne :
     isBNE gNoRep (mkNoS1 ⟨0, by decide⟩) (mkNoS2 ⟨3, by decide⟩) := by
   decide
 
 /-- Sur les stratégies canoniques, le BNE crédible du benchmark est unique :
-    un incumbent connu rationnel ne peut pas dissuader l'entrée.
-    English: Over canonical strategies, the credible BNE of the benchmark is
-    unique: a known-rational incumbent cannot deter entry. -/
+    un incumbent connu rationnel ne peut pas dissuader l'entrée. -/
 theorem gNoRep_unique_aux :
     ∀ x z : Fin 4,
       isBNE gNoRep (mkNoS1 x) (mkNoS2 z) →
@@ -366,9 +264,7 @@ theorem gNoRep_unique_aux :
   decide
 
 /-- Sur les stratégies canoniques, tout BNE crédible du benchmark paie
-    l'incumbent exactement 4 (accommodation sur les deux périodes).
-    English: Over canonical strategies, every credible BNE of the benchmark
-    pays the incumbent exactly 4 (accommodation in both periods). -/
+    l'incumbent exactement 4 (accommodation sur les deux périodes). -/
 theorem gNoRep_payoff_aux :
     ∀ x z : Fin 4,
       isBNE gNoRep (mkNoS1 x) (mkNoS2 z) →
@@ -376,8 +272,7 @@ theorem gNoRep_payoff_aux :
         interimU1 gNoRep ⟨0, by decide⟩ x (mkNoS2 z) = 4 := by
   decide
 
-/-- Dans tout BNE crédible du benchmark, l'incumbent gagne 4.
-    English: In every credible BNE of the benchmark, the incumbent earns 4. -/
+/-- Dans tout BNE crédible du benchmark, l'incumbent gagne 4. -/
 theorem gNoRep_credible_payoff
     (s1 : Strategy1 gNoRep) (s2 : Strategy2 gNoRep)
     (h : isBNE gNoRep s1 s2) (hc : credNoRep s1) :
@@ -388,14 +283,7 @@ theorem gNoRep_credible_payoff
 
 /-! ### Punchline -/
 
-/-- **La réputation paie.** Dans tout équilibre crédible, l'incumbent
-    English: **Reputation pays.** In every credible equilibrium, the rational
-    incumbent earns strictly more under incomplete information (5,
-    entry deterred by pooling with the tough type) than under complete
-    information (4, entry occurs and is accommodated). The value of
-    reputation is exactly the entrant's uncertainty about the
-    incumbent's type: with the type known, the same incumbent with the
-    same payoffs cannot deter anything. -/
+/-- **La réputation paie.** Dans tout équilibre crédible, l'incumbent -/
 theorem reputation_pays
     (s1 : Strategy1 gRep) (s2 : Strategy2 gRep)
     (t1 : Strategy1 gNoRep) (t2 : Strategy2 gNoRep)

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Reputation_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Reputation_en.lean
@@ -1,0 +1,332 @@
+/-
+  Reputation and Entry Deterrence (chain-store, kernel-checked)
+  =============================================================
+
+  A reduced strategic form of the classic two-period entry-deterrence
+  story (Kreps-Wilson / Milgrom-Roberts): an incumbent faces entry in
+  period 1, responds Fight or Accommodate, and a second entrant decides
+  whether to enter in period 2 *after observing* the period-1 response.
+
+  The incumbent (player 1) is one of two types:
+  - type 0, "rational": fighting costs in every period taken in
+    isolation (stage payoffs: Fight 0 < Accommodate 2);
+  - type 1, "tough" (commitment type): fighting is intrinsically
+    preferred (Fight 3 > Accommodate 0).
+
+  Equal prior weights (1, 1). Period-2 monopoly (entrant stays out)
+  pays the incumbent 5.
+
+  Action encodings (reduced plans, `Fin 4`, bit 0 = Accommodate/Out,
+  bit 1 = Fight/In):
+  - incumbent plan `a1`: `a1.val = 2*r1 + r2` where `r1` is the
+    period-1 response and `r2` the period-2 response if entry occurs;
+  - entrant plan `a2`: `a2.val = 2*eF + eA` where `eF` (resp. `eA`) is
+    the period-2 entry decision after observing Fight (resp.
+    Accommodate) in period 1.
+
+  Because raw normal-form equilibrium also admits non-credible threats
+  ("I will fight in period 2" by the rational type — never carried out
+  if tested), we impose a decidable *credibility* refinement standing
+  in for sequential rationality in the last period: each type's
+  period-2 response must be a stage best reply (rational accommodates,
+  tough fights).
+
+  Results (all by `decide` + eta-expansion of strategies):
+  - `gRep` (incomplete information, reputation possible) has a unique
+    credible BNE: the rational type *pools* with the tough type and
+    fights in period 1, the entrant stays out after a fight. The
+    rational incumbent earns 5.
+  - `gNoRep` (complete information benchmark: the incumbent is known
+    rational) has a unique credible BNE: accommodate, entry occurs,
+    payoff 4.
+  - `reputation_pays`: 4 < 5 in every credible equilibrium pair — the
+    incumbent's incentive to fight comes *only* from the entrant's
+    uncertainty about its type, i.e. from reputation. The rational type
+    fights in period 1 even though fighting is myopically dominated
+    (`rational_fights_in_equilibrium`).
+
+  See #2610 (GT-Lean formalization, Bayesian phase 5).
+-/
+
+import Bayesian.BNE_en
+
+/-! ### Plan decoders -/
+
+/-- Period-1 response encoded in an incumbent plan
+    (0 = Accommodate, 1 = Fight). -/
+def planR1 (a : Fin 4) : Nat := a.val / 2
+
+/-- Period-2 response (if entry occurs) encoded in an incumbent plan
+    (0 = Accommodate, 1 = Fight). -/
+def planR2 (a : Fin 4) : Nat := a.val % 2
+
+/-- The entrant's period-2 entry decision on path: the component of
+    its plan selected by the observed period-1 response
+    (0 = Out, 1 = In). -/
+def entryOf (a1 a2 : Fin 4) : Nat :=
+  if planR1 a1 = 1 then a2.val / 2 else a2.val % 2
+
+/-! ### Stage payoffs -/
+
+/-- Two-period payoff of the *rational* incumbent: fighting costs in
+    period 1 (0 vs 2), monopoly pays 5, and the period-2 response is
+    paid at stage values (Fight 0, Accommodate 2). -/
+def incRational (a1 a2 : Fin 4) : Int :=
+  (if planR1 a1 = 1 then 0 else 2) +
+  (if entryOf a1 a2 = 0 then 5
+   else if planR2 a1 = 1 then 0 else 2)
+
+/-- Two-period payoff of the *tough* (commitment) incumbent: fighting
+    is intrinsically preferred (3 vs 0) in both periods. -/
+def incTough (a1 a2 : Fin 4) : Int :=
+  (if planR1 a1 = 1 then 3 else 0) +
+  (if entryOf a1 a2 = 0 then 5
+   else if planR2 a1 = 1 then 3 else 0)
+
+/-- Period-2 entrant's payoff: 0 out, 2 if it enters and the incumbent
+    accommodates, -3 if it enters and the incumbent fights. -/
+def entrantU (a1 a2 : Fin 4) : Int :=
+  if entryOf a1 a2 = 0 then 0
+  else if planR2 a1 = 1 then -3 else 2
+
+/-! ### The two games -/
+
+/-- The reputation game: the entrant does not know the incumbent's
+    type (rational or tough, equal weights). -/
+def gRep : BayesGame2 where
+  nT1 := 2
+  nT2 := 1
+  nA1 := 4
+  nA2 := 4
+  w := fun _ _ => 1
+  u1 := fun t1 _ a1 a2 =>
+    if t1.val = 0 then incRational a1 a2 else incTough a1 a2
+  u2 := fun _ _ a1 a2 => entrantU a1 a2
+
+/-- The complete-information benchmark: the incumbent is known to be
+    rational (a single type). Same actions, same payoff tables. -/
+def gNoRep : BayesGame2 where
+  nT1 := 1
+  nT2 := 1
+  nA1 := 4
+  nA2 := 4
+  w := fun _ _ => 1
+  u1 := fun _ _ a1 a2 => incRational a1 a2
+  u2 := fun _ _ a1 a2 => entrantU a1 a2
+
+/-- Sanity check: the benchmark is exactly the reputation game
+    restricted to the rational type — not an unrelated game. -/
+theorem gNoRep_restriction :
+    ∀ a1 a2 : Fin 4,
+      gNoRep.u1 ⟨0, by decide⟩ ⟨0, by decide⟩ a1 a2 =
+        gRep.u1 ⟨0, by decide⟩ ⟨0, by decide⟩ a1 a2 ∧
+      gNoRep.u2 ⟨0, by decide⟩ ⟨0, by decide⟩ a1 a2 =
+        gRep.u2 ⟨0, by decide⟩ ⟨0, by decide⟩ a1 a2 := by
+  decide
+
+/-! ### Credibility refinement
+
+Normal-form BNE admits non-credible period-2 threats (e.g. in the
+benchmark, "rational fights period 2 / entrant stays out" is a Nash
+profile paying the incumbent 7 — but the threat would never be carried
+out). Sequential rationality in the *last* period is a finite,
+decidable condition on plans: each type's period-2 response must be a
+stage best reply. -/
+
+/-- Credibility in the reputation game: the rational type accommodates
+    in period 2 (2 > 0), the tough type fights (3 > 0). -/
+@[reducible] def credRep (s1 : Strategy1 gRep) : Prop :=
+  planR2 (s1 ⟨0, by decide⟩) = 0 ∧ planR2 (s1 ⟨1, by decide⟩) = 1
+
+/-- Credibility in the benchmark: the (rational) incumbent
+    accommodates in period 2. -/
+@[reducible] def credNoRep (s1 : Strategy1 gNoRep) : Prop :=
+  planR2 (s1 ⟨0, by decide⟩) = 0
+
+/-! ### Canonical strategy constructors (reputation game) -/
+
+/-- Incumbent strategies in `gRep`, from the two type-contingent
+    plans. -/
+def mkRepS1 (x y : Fin 4) : Strategy1 gRep :=
+  fun t1 => if t1.val = 0 then x else y
+
+/-- Entrant strategies in `gRep` are constants (one type). -/
+def mkRepS2 (z : Fin 4) : Strategy2 gRep := fun _ => z
+
+/-- Every incumbent strategy is determined by its two values. -/
+theorem repS1_eta (s1 : Strategy1 gRep) :
+    s1 = mkRepS1 (s1 ⟨0, by decide⟩) (s1 ⟨1, by decide⟩) := by
+  funext t1
+  cases t1 using Fin.cases with
+  | zero => rfl
+  | succ j =>
+    cases j using Fin.cases with
+    | zero => rfl
+    | succ j' => exact j'.elim0
+
+/-- Every entrant strategy is a canonical constant. -/
+theorem repS2_eta (s2 : Strategy2 gRep) :
+    s2 = mkRepS2 (s2 ⟨0, by decide⟩) := by
+  funext t2
+  cases t2 using Fin.cases with
+  | zero => rfl
+  | succ j => exact j.elim0
+
+/-! ### Equilibrium analysis of the reputation game
+
+Target profile: rational plays plan 2 = (Fight, Accommodate), tough
+plays plan 3 = (Fight, Fight), entrant plays plan 1 = (Out after
+Fight, In after Accommodate). -/
+
+/-- The pooling profile is a BNE of the reputation game. -/
+theorem gRep_bne :
+    isBNE gRep (mkRepS1 ⟨2, by decide⟩ ⟨3, by decide⟩)
+      (mkRepS2 ⟨1, by decide⟩) := by
+  decide
+
+/-- The pooling profile is credible. -/
+theorem gRep_bne_credible :
+    credRep (mkRepS1 ⟨2, by decide⟩ ⟨3, by decide⟩) := by
+  decide
+
+/-- Over canonical strategies, the credible BNE of `gRep` is unique:
+    both incumbent types fight in period 1 (the rational type pools),
+    and the entrant enters iff it observed Accommodate. -/
+theorem gRep_unique_aux :
+    ∀ x y z : Fin 4,
+      isBNE gRep (mkRepS1 x y) (mkRepS2 z) →
+      credRep (mkRepS1 x y) →
+        x = ⟨2, by decide⟩ ∧ y = ⟨3, by decide⟩ ∧ z = ⟨1, by decide⟩ := by
+  decide
+
+/-- Over canonical strategies, every credible BNE of `gRep` pays the
+    rational incumbent exactly 5 (deterrence: 0 in period 1, monopoly
+    5 in period 2). -/
+theorem gRep_payoff_aux :
+    ∀ x y z : Fin 4,
+      isBNE gRep (mkRepS1 x y) (mkRepS2 z) →
+      credRep (mkRepS1 x y) →
+        interimU1 gRep ⟨0, by decide⟩ x (mkRepS2 z) = 5 := by
+  decide
+
+/-- The reputation game has an essentially unique credible BNE. -/
+theorem gRep_unique (s1 : Strategy1 gRep) (s2 : Strategy2 gRep)
+    (h : isBNE gRep s1 s2) (hc : credRep s1) :
+    s1 = mkRepS1 ⟨2, by decide⟩ ⟨3, by decide⟩ ∧
+    s2 = mkRepS2 ⟨1, by decide⟩ := by
+  rw [repS1_eta s1] at h hc
+  rw [repS2_eta s2] at h
+  have hu := gRep_unique_aux _ _ _ h hc
+  exact ⟨by rw [repS1_eta s1, hu.1, hu.2.1],
+         by rw [repS2_eta s2, hu.2.2]⟩
+
+/-- In every credible BNE of the reputation game, the rational
+    incumbent earns 5. -/
+theorem gRep_credible_payoff (s1 : Strategy1 gRep) (s2 : Strategy2 gRep)
+    (h : isBNE gRep s1 s2) (hc : credRep s1) :
+    interimU1 gRep ⟨0, by decide⟩ (s1 ⟨0, by decide⟩) s2 = 5 := by
+  rw [repS1_eta s1] at h hc
+  rw [repS2_eta s2] at h ⊢
+  exact gRep_payoff_aux _ _ _ h hc
+
+/-- In every credible BNE of the reputation game the *rational* type
+    fights in period 1, even though fighting is myopically dominated
+    (stage value 0 < 2): the pooling/signaling motive. -/
+theorem rational_fights_in_equilibrium
+    (s1 : Strategy1 gRep) (s2 : Strategy2 gRep)
+    (h : isBNE gRep s1 s2) (hc : credRep s1) :
+    planR1 (s1 ⟨0, by decide⟩) = 1 := by
+  rw [repS1_eta s1] at h hc
+  rw [repS2_eta s2] at h
+  have hu := gRep_unique_aux _ _ _ h hc
+  rw [hu.1]
+  decide
+
+/-- In every credible BNE of the reputation game, period-2 entry is
+    deterred against both types: the entrant observes Fight on path
+    and stays out. -/
+theorem reputation_deters_entry
+    (s1 : Strategy1 gRep) (s2 : Strategy2 gRep)
+    (h : isBNE gRep s1 s2) (hc : credRep s1) :
+    entryOf (s1 ⟨0, by decide⟩) (s2 ⟨0, by decide⟩) = 0 ∧
+    entryOf (s1 ⟨1, by decide⟩) (s2 ⟨0, by decide⟩) = 0 := by
+  rw [repS1_eta s1] at h hc
+  rw [repS2_eta s2] at h
+  have hu := gRep_unique_aux _ _ _ h hc
+  rw [hu.1, hu.2.1, hu.2.2]
+  decide
+
+/-! ### Equilibrium analysis of the benchmark -/
+
+/-- Incumbent strategies in `gNoRep` are constants. -/
+def mkNoS1 (x : Fin 4) : Strategy1 gNoRep := fun _ => x
+
+/-- Entrant strategies in `gNoRep` are constants. -/
+def mkNoS2 (z : Fin 4) : Strategy2 gNoRep := fun _ => z
+
+theorem noS1_eta (s1 : Strategy1 gNoRep) :
+    s1 = mkNoS1 (s1 ⟨0, by decide⟩) := by
+  funext t1
+  cases t1 using Fin.cases with
+  | zero => rfl
+  | succ j => exact j.elim0
+
+theorem noS2_eta (s2 : Strategy2 gNoRep) :
+    s2 = mkNoS2 (s2 ⟨0, by decide⟩) := by
+  funext t2
+  cases t2 using Fin.cases with
+  | zero => rfl
+  | succ j => exact j.elim0
+
+/-- (Accommodate, Accommodate) / (In, In) is a credible BNE of the
+    benchmark. -/
+theorem gNoRep_bne :
+    isBNE gNoRep (mkNoS1 ⟨0, by decide⟩) (mkNoS2 ⟨3, by decide⟩) := by
+  decide
+
+/-- Over canonical strategies, the credible BNE of the benchmark is
+    unique: a known-rational incumbent cannot deter entry. -/
+theorem gNoRep_unique_aux :
+    ∀ x z : Fin 4,
+      isBNE gNoRep (mkNoS1 x) (mkNoS2 z) →
+      credNoRep (mkNoS1 x) →
+        x = ⟨0, by decide⟩ ∧ z = ⟨3, by decide⟩ := by
+  decide
+
+/-- Over canonical strategies, every credible BNE of the benchmark
+    pays the incumbent exactly 4 (accommodation in both periods). -/
+theorem gNoRep_payoff_aux :
+    ∀ x z : Fin 4,
+      isBNE gNoRep (mkNoS1 x) (mkNoS2 z) →
+      credNoRep (mkNoS1 x) →
+        interimU1 gNoRep ⟨0, by decide⟩ x (mkNoS2 z) = 4 := by
+  decide
+
+/-- In every credible BNE of the benchmark, the incumbent earns 4. -/
+theorem gNoRep_credible_payoff
+    (s1 : Strategy1 gNoRep) (s2 : Strategy2 gNoRep)
+    (h : isBNE gNoRep s1 s2) (hc : credNoRep s1) :
+    interimU1 gNoRep ⟨0, by decide⟩ (s1 ⟨0, by decide⟩) s2 = 4 := by
+  rw [noS1_eta s1] at h hc
+  rw [noS2_eta s2] at h ⊢
+  exact gNoRep_payoff_aux _ _ h hc
+
+/-! ### Punchline -/
+
+/-- **Reputation pays.** In every credible equilibrium, the rational
+    incumbent earns strictly more under incomplete information (5,
+    entry deterred by pooling with the tough type) than under complete
+    information (4, entry occurs and is accommodated). The value of
+    reputation is exactly the entrant's uncertainty about the
+    incumbent's type: with the type known, the same incumbent with the
+    same payoffs cannot deter anything. -/
+theorem reputation_pays
+    (s1 : Strategy1 gRep) (s2 : Strategy2 gRep)
+    (t1 : Strategy1 gNoRep) (t2 : Strategy2 gNoRep)
+    (hR : isBNE gRep s1 s2) (hcR : credRep s1)
+    (hN : isBNE gNoRep t1 t2) (hcN : credNoRep t1) :
+    interimU1 gNoRep ⟨0, by decide⟩ (t1 ⟨0, by decide⟩) t2 <
+      interimU1 gRep ⟨0, by decide⟩ (s1 ⟨0, by decide⟩) s2 := by
+  rw [gRep_credible_payoff s1 s2 hR hcR,
+      gNoRep_credible_payoff t1 t2 hN hcN]
+  decide

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Sum.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Sum.lean
@@ -9,23 +9,9 @@
   monotonie, multiplication scalaire et congruence.
 
   Voir #2610 (formalisation GT-Lean, phase bayésienne 1).
-
-  ---
-  English:
-  Finite sums over `Fin n` (core Lean 4 only, no Mathlib)
-  =======================================================
-
-  Minimal summation infrastructure for Bayesian game expected utilities.
-  Mathlib's `Finset.sum` is not available (core-only project), so we
-  define a structural recursion and prove the three lemmas the game
-  theory development needs: monotonicity, scalar multiplication, and
-  congruence.
-
-  See #2610 (GT-Lean formalization, Bayesian phase 1).
 -/
 
-/-- Somme de `f` sur tout `Fin n`, par récursion structurelle sur `n`.
-    English: Sum of `f` over all of `Fin n`, by structural recursion on `n`. -/
+/-- Somme de `f` sur tout `Fin n`, par récursion structurelle sur `n`. -/
 def sumFin : (n : Nat) → (Fin n → Int) → Int
   | 0, _ => 0
   | n + 1, f => f 0 + sumFin n (fun i => f i.succ)
@@ -35,16 +21,14 @@ def sumFin : (n : Nat) → (Fin n → Int) → Int
 @[simp] theorem sumFin_succ (n : Nat) (f : Fin (n + 1) → Int) :
     sumFin (n + 1) f = f 0 + sumFin n (fun i => f i.succ) := rfl
 
-/-- La somme de la fonction nulle s'annule.
-    English: The sum of the zero function vanishes. -/
+/-- La somme de la fonction nulle s'annule. -/
 @[simp] theorem sumFin_zero_fun (n : Nat) :
     sumFin n (fun _ => (0 : Int)) = 0 := by
   induction n with
   | zero => simp
   | succ n ih => simp [ih]
 
-/-- La domination point par point se transmet aux sommes.
-    English: Pointwise dominance transfers to the sums. -/
+/-- La domination point par point se transmet aux sommes. -/
 theorem sumFin_mono {n : Nat} {f g : Fin n → Int} (h : ∀ i, f i ≤ g i) :
     sumFin n f ≤ sumFin n g := by
   induction n with
@@ -53,8 +37,7 @@ theorem sumFin_mono {n : Nat} {f g : Fin n → Int} (h : ∀ i, f i ≤ g i) :
     simp only [sumFin_succ]
     exact Int.add_le_add (h 0) (ih (fun i => h i.succ))
 
-/-- Des fonctions égales point par point ont des sommes égales.
-    English: Pointwise equal functions have equal sums. -/
+/-- Des fonctions égales point par point ont des sommes égales. -/
 theorem sumFin_congr {n : Nat} {f g : Fin n → Int} (h : ∀ i, f i = g i) :
     sumFin n f = sumFin n g := by
   induction n with
@@ -63,8 +46,7 @@ theorem sumFin_congr {n : Nat} {f g : Fin n → Int} (h : ∀ i, f i = g i) :
     simp only [sumFin_succ]
     rw [h 0, ih (fun i => h i.succ)]
 
-/-- Un facteur constant se distribue hors de la somme.
-    English: A constant factor distributes out of the sum. -/
+/-- Un facteur constant se distribue hors de la somme. -/
 theorem sumFin_mul_left {n : Nat} (c : Int) (f : Fin n → Int) :
     sumFin n (fun i => c * f i) = c * sumFin n f := by
   induction n with
@@ -73,8 +55,7 @@ theorem sumFin_mul_left {n : Nat} (c : Int) (f : Fin n → Int) :
     simp only [sumFin_succ]
     rw [ih, Int.mul_add]
 
-/-- Les sommes se distribuent sur l'addition point par point.
-    English: Sums distribute over pointwise addition. -/
+/-- Les sommes se distribuent sur l'addition point par point. -/
 theorem sumFin_add {n : Nat} (f g : Fin n → Int) :
     sumFin n (fun i => f i + g i) = sumFin n f + sumFin n g := by
   induction n with
@@ -84,8 +65,7 @@ theorem sumFin_add {n : Nat} (f g : Fin n → Int) :
     rw [ih]
     omega
 
-/-- Les doubles sommes commutent (Fubini pour les sommes finies).
-    English: Double sums commute (Fubini for finite sums). -/
+/-- Les doubles sommes commutent (Fubini pour les sommes finies). -/
 theorem sumFin_comm {n m : Nat} (F : Fin n → Fin m → Int) :
     sumFin n (fun i => sumFin m (fun j => F i j)) =
     sumFin m (fun j => sumFin n (fun i => F i j)) := by
@@ -96,15 +76,12 @@ theorem sumFin_comm {n m : Nat} (F : Fin n → Fin m → Int) :
     rw [ih (fun i j => F i.succ j), ← sumFin_add]
 
 /-- Un `if` dont la condition ne dépend pas de l'indice sort de la somme
-    (la branche `else 0` correspond à la somme vide).
-    English: An `if` whose condition does not depend on the index pulls out of
-    the sum (the `else 0` branch matches the empty sum). -/
+    (la branche `else 0` correspond à la somme vide). -/
 theorem sumFin_if_distrib {n : Nat} (c : Prop) [Decidable c] (f : Fin n → Int) :
     sumFin n (fun i => if c then f i else 0) = if c then sumFin n f else 0 := by
   by_cases h : c <;> simp [h]
 
-/-- Sommer un indicateur d'un point unique sélectionne la valeur de ce point.
-    English: Summing an indicator of a single point picks out that point's value. -/
+/-- Sommer un indicateur d'un point unique sélectionne la valeur de ce point. -/
 theorem sumFin_single : ∀ {n : Nat} (c : Fin n) (x : Fin n → Int),
     sumFin n (fun j => if c = j then x j else 0) = x c
   | 0, c, _ => c.elim0
@@ -129,9 +106,7 @@ theorem sumFin_single : ∀ {n : Nat} (c : Fin n) (x : Fin n → Int),
       rw [sumFin_congr hcond, sumFin_single j (fun i => x i.succ)]
 
 /-- Décompose une somme sur les états en groupes indexés par la valeur d'une
-    application de classification (double comptage fini).
-    English: Decompose a sum over states into groups indexed by the value of a
-    classifying map (finite double counting). -/
+    application de classification (double comptage fini). -/
 theorem sumFin_partition {n m : Nat} (σ : Fin n → Fin m) (f : Fin n → Int) :
     sumFin n f = sumFin m (fun k => sumFin n (fun s => if σ s = k then f s else 0)) := by
   rw [sumFin_comm]

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Sum_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Sum_en.lean
@@ -1,0 +1,113 @@
+/-
+  Finite sums over `Fin n` (core Lean 4 only, no Mathlib)
+  =======================================================
+
+  Minimal summation infrastructure for Bayesian game expected utilities.
+  Mathlib's `Finset.sum` is not available (core-only project), so we
+  define a structural recursion and prove the three lemmas the game
+  theory development needs: monotonicity, scalar multiplication, and
+  congruence.
+
+  See #2610 (GT-Lean formalization, Bayesian phase 1).
+-/
+
+/-- Sum of `f` over all of `Fin n`, by structural recursion on `n`. -/
+def sumFin : (n : Nat) → (Fin n → Int) → Int
+  | 0, _ => 0
+  | n + 1, f => f 0 + sumFin n (fun i => f i.succ)
+
+@[simp] theorem sumFin_zero (f : Fin 0 → Int) : sumFin 0 f = 0 := rfl
+
+@[simp] theorem sumFin_succ (n : Nat) (f : Fin (n + 1) → Int) :
+    sumFin (n + 1) f = f 0 + sumFin n (fun i => f i.succ) := rfl
+
+/-- The sum of the zero function vanishes. -/
+@[simp] theorem sumFin_zero_fun (n : Nat) :
+    sumFin n (fun _ => (0 : Int)) = 0 := by
+  induction n with
+  | zero => simp
+  | succ n ih => simp [ih]
+
+/-- Pointwise dominance transfers to the sums. -/
+theorem sumFin_mono {n : Nat} {f g : Fin n → Int} (h : ∀ i, f i ≤ g i) :
+    sumFin n f ≤ sumFin n g := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    simp only [sumFin_succ]
+    exact Int.add_le_add (h 0) (ih (fun i => h i.succ))
+
+/-- Pointwise equal functions have equal sums. -/
+theorem sumFin_congr {n : Nat} {f g : Fin n → Int} (h : ∀ i, f i = g i) :
+    sumFin n f = sumFin n g := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    simp only [sumFin_succ]
+    rw [h 0, ih (fun i => h i.succ)]
+
+/-- A constant factor distributes out of the sum. -/
+theorem sumFin_mul_left {n : Nat} (c : Int) (f : Fin n → Int) :
+    sumFin n (fun i => c * f i) = c * sumFin n f := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    simp only [sumFin_succ]
+    rw [ih, Int.mul_add]
+
+/-- Sums distribute over pointwise addition. -/
+theorem sumFin_add {n : Nat} (f g : Fin n → Int) :
+    sumFin n (fun i => f i + g i) = sumFin n f + sumFin n g := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    simp only [sumFin_succ]
+    rw [ih]
+    omega
+
+/-- Double sums commute (Fubini for finite sums). -/
+theorem sumFin_comm {n m : Nat} (F : Fin n → Fin m → Int) :
+    sumFin n (fun i => sumFin m (fun j => F i j)) =
+    sumFin m (fun j => sumFin n (fun i => F i j)) := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    simp only [sumFin_succ]
+    rw [ih (fun i j => F i.succ j), ← sumFin_add]
+
+/-- An `if` whose condition does not depend on the index pulls out of
+    the sum (the `else 0` branch matches the empty sum). -/
+theorem sumFin_if_distrib {n : Nat} (c : Prop) [Decidable c] (f : Fin n → Int) :
+    sumFin n (fun i => if c then f i else 0) = if c then sumFin n f else 0 := by
+  by_cases h : c <;> simp [h]
+
+/-- Summing an indicator of a single point picks out that point's value. -/
+theorem sumFin_single : ∀ {n : Nat} (c : Fin n) (x : Fin n → Int),
+    sumFin n (fun j => if c = j then x j else 0) = x c
+  | 0, c, _ => c.elim0
+  | n + 1, c, x => by
+    cases c using Fin.cases with
+    | zero =>
+      have htail : ∀ i : Fin n, (if (0 : Fin (n + 1)) = i.succ then x i.succ else 0) = 0 :=
+        fun i => if_neg (fun h => Fin.succ_ne_zero i h.symm)
+      simp only [sumFin_succ]
+      rw [sumFin_congr htail, sumFin_zero_fun, Int.add_zero]
+      simp
+    | succ j =>
+      simp only [sumFin_succ]
+      rw [if_neg (Fin.succ_ne_zero j), Int.zero_add]
+      have hcond : ∀ i : Fin n,
+          (if j.succ = i.succ then x i.succ else 0) =
+          (if j = i then x i.succ else 0) := by
+        intro i
+        by_cases h : j = i
+        · rw [if_pos (by rw [h]), if_pos h]
+        · rw [if_neg (fun hs => h (Fin.succ_inj.mp hs)), if_neg h]
+      rw [sumFin_congr hcond, sumFin_single j (fun i => x i.succ)]
+
+/-- Decompose a sum over states into groups indexed by the value of a
+    classifying map (finite double counting). -/
+theorem sumFin_partition {n m : Nat} (σ : Fin n → Fin m) (f : Fin n → Int) :
+    sumFin n f = sumFin m (fun k => sumFin n (fun s => if σ s = k then f s else 0)) := by
+  rw [sumFin_comm]
+  exact (sumFin_congr (fun s => sumFin_single (σ s) (fun _ => f s))).symm

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Types.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Types.lean
@@ -20,29 +20,6 @@
 
   Basé sur GameTheory-11-BayesianGames.ipynb. Voir #2610 (phase 1 :
   jeux bayésiens — le rapport de recherche recommande les types finis d'abord).
-
-  ---
-  English:
-  Harsanyi Type Spaces — Two-Player Finite Bayesian Games
-  =======================================================
-
-  Formalizes games of incomplete information (Harsanyi 1967) for the
-  two-player finite case, in core Lean 4 (no Mathlib):
-
-  - `BayesGame2`: type sets, action sets, an unnormalized common prior
-    given by `Nat` weights, and type-dependent payoffs
-  - `Strategy1` / `Strategy2`: pure type-contingent strategies
-  - `interimU1` / `interimU2`: interim expected utility (conditional on
-    one's own type), as a weight-sum over the opponent's types
-  - `exAnteU1` / `exAnteU2`: ex-ante expected utility
-
-  Working with integer weights instead of a normalized probability
-  measure keeps every quantity computable and decidable; `BNE.lean`
-  proves that best responses are invariant under rescaling the prior,
-  which is exactly what normalization-independence means.
-
-  Based on GameTheory-11-BayesianGames.ipynb. See #2610 (phase 1:
-  Bayesian games — research report recommends finite types first).
 -/
 
 import Bayesian.Sum
@@ -52,43 +29,27 @@ import Bayesian.Sum
     Le joueur 1 a `nT1` types possibles et `nA1` actions ; le joueur 2 a
     `nT2` types et `nA2` actions. `w t1 t2` est le poids (non normalisé,
     `Nat`) du prior pour le profil de types `(t1, t2)`. Les paiements
-    dépendent du profil de types complet et du profil d'actions.
-
-    English: A two-player finite Bayesian game with an unnormalized prior.
-
-    Player 1 has `nT1` possible types and `nA1` actions; player 2 has
-    `nT2` types and `nA2` actions. `w t1 t2` is the (unnormalized,
-    `Nat`) prior weight of the type profile `(t1, t2)`. Payoffs depend
-    on the full type profile and the action profile. -/
+    dépendent du profil de types complet et du profil d'actions. -/
 structure BayesGame2 where
-  /-- Nombre de types du joueur 1.
-      English: Number of types of player 1 -/
+  /-- Nombre de types du joueur 1. -/
   nT1 : Nat
-  /-- Nombre de types du joueur 2.
-      English: Number of types of player 2 -/
+  /-- Nombre de types du joueur 2. -/
   nT2 : Nat
-  /-- Nombre d'actions du joueur 1.
-      English: Number of actions of player 1 -/
+  /-- Nombre d'actions du joueur 1. -/
   nA1 : Nat
-  /-- Nombre d'actions du joueur 2.
-      English: Number of actions of player 2 -/
+  /-- Nombre d'actions du joueur 2. -/
   nA2 : Nat
-  /-- Prior commun sur les profils de types, comme poids non normalisés.
-      English: Common prior over type profiles, as unnormalized weights -/
+  /-- Prior commun sur les profils de types, comme poids non normalisés. -/
   w : Fin nT1 → Fin nT2 → Nat
-  /-- Paiement du joueur 1.
-      English: Payoff of player 1 -/
+  /-- Paiement du joueur 1. -/
   u1 : Fin nT1 → Fin nT2 → Fin nA1 → Fin nA2 → Int
-  /-- Paiement du joueur 2.
-      English: Payoff of player 2 -/
+  /-- Paiement du joueur 2. -/
   u2 : Fin nT1 → Fin nT2 → Fin nA1 → Fin nA2 → Int
 
-/-- Une stratégie pure contingente au type du joueur 1 : son propre type → action.
-    English: A pure type-contingent strategy of player 1: own type → action. -/
+/-- Une stratégie pure contingente au type du joueur 1 : son propre type → action. -/
 def Strategy1 (g : BayesGame2) := Fin g.nT1 → Fin g.nA1
 
-/-- Une stratégie pure contingente au type du joueur 2 : son propre type → action.
-    English: A pure type-contingent strategy of player 2: own type → action. -/
+/-- Une stratégie pure contingente au type du joueur 2 : son propre type → action. -/
 def Strategy2 (g : BayesGame2) := Fin g.nT2 → Fin g.nA2
 
 /-- Utilité espérée interimaire du joueur 1 : de type `t1`, jouant l'action
@@ -96,34 +57,22 @@ def Strategy2 (g : BayesGame2) := Fin g.nT2 → Fin g.nA2
 
     (Avec des poids non normalisés, c'est l'espérance conditionnelle
     mise à l'échelle par la constante positive `Σ_{t2} w t1 t2` — les
-    maximiseurs ne sont pas affectés, voir `BNE.lean`.)
-
-    English: Interim expected utility of player 1: of type `t1`, playing action
-    `a`, against strategy `s2`, weighted by the prior row `w t1 ·`.
-
-    (With unnormalized weights this is the conditional expectation
-    scaled by the positive constant `Σ_{t2} w t1 t2` — maximizers are
-    unaffected, see `BNE.lean`.) -/
+    maximiseurs ne sont pas affectés, voir `BNE.lean`.) -/
 def interimU1 (g : BayesGame2) (t1 : Fin g.nT1) (a : Fin g.nA1)
     (s2 : Strategy2 g) : Int :=
   sumFin g.nT2 (fun t2 => (g.w t1 t2 : Int) * g.u1 t1 t2 a (s2 t2))
 
 /-- Utilité espérée interimaire du joueur 2 : de type `t2`, jouant l'action
-    `a`, face à la stratégie `s1`, pondérée par la colonne du prior `w · t2`.
-    English: Interim expected utility of player 2: of type `t2`, playing action
-    `a`, against strategy `s1`, weighted by the prior column `w · t2`. -/
+    `a`, face à la stratégie `s1`, pondérée par la colonne du prior `w · t2`. -/
 def interimU2 (g : BayesGame2) (t2 : Fin g.nT2) (a : Fin g.nA2)
     (s1 : Strategy1 g) : Int :=
   sumFin g.nT1 (fun t1 => (g.w t1 t2 : Int) * g.u2 t1 t2 (s1 t1) a)
 
 /-- Utilité espérée ex-ante du joueur 1 sous un profil de stratégies :
-    somme des utilités interimbaires sur les propres types du joueur 1.
-    English: Ex-ante expected utility of player 1 under a strategy profile:
-    sum of interim utilities over player 1's own types. -/
+    somme des utilités interimbaires sur les propres types du joueur 1. -/
 def exAnteU1 (g : BayesGame2) (s1 : Strategy1 g) (s2 : Strategy2 g) : Int :=
   sumFin g.nT1 (fun t1 => interimU1 g t1 (s1 t1) s2)
 
-/-- Utilité espérée ex-ante du joueur 2 sous un profil de stratégies.
-    English: Ex-ante expected utility of player 2 under a strategy profile. -/
+/-- Utilité espérée ex-ante du joueur 2 sous un profil de stratégies. -/
 def exAnteU2 (g : BayesGame2) (s1 : Strategy1 g) (s2 : Strategy2 g) : Int :=
   sumFin g.nT2 (fun t2 => interimU2 g t2 (s2 t2) s1)

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Types_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Types_en.lean
@@ -1,0 +1,77 @@
+/-
+  Harsanyi Type Spaces — Two-Player Finite Bayesian Games
+  =======================================================
+
+  Formalizes games of incomplete information (Harsanyi 1967) for the
+  two-player finite case, in core Lean 4 (no Mathlib):
+
+  - `BayesGame2`: type sets, action sets, an unnormalized common prior
+    given by `Nat` weights, and type-dependent payoffs
+  - `Strategy1` / `Strategy2`: pure type-contingent strategies
+  - `interimU1` / `interimU2`: interim expected utility (conditional on
+    one's own type), as a weight-sum over the opponent's types
+  - `exAnteU1` / `exAnteU2`: ex-ante expected utility
+
+  Working with integer weights instead of a normalized probability
+  measure keeps every quantity computable and decidable; `BNE.lean`
+  proves that best responses are invariant under rescaling the prior,
+  which is exactly what normalization-independence means.
+
+  Based on GameTheory-11-BayesianGames.ipynb. See #2610 (phase 1:
+  Bayesian games — research report recommends finite types first).
+-/
+
+import Bayesian.Sum_en
+
+/-- A two-player finite Bayesian game with an unnormalized prior.
+
+    Player 1 has `nT1` possible types and `nA1` actions; player 2 has
+    `nT2` types and `nA2` actions. `w t1 t2` is the (unnormalized,
+    `Nat`) prior weight of the type profile `(t1, t2)`. Payoffs depend
+    on the full type profile and the action profile. -/
+structure BayesGame2 where
+  /-- Number of types of player 1 -/
+  nT1 : Nat
+  /-- Number of types of player 2 -/
+  nT2 : Nat
+  /-- Number of actions of player 1 -/
+  nA1 : Nat
+  /-- Number of actions of player 2 -/
+  nA2 : Nat
+  /-- Common prior over type profiles, as unnormalized weights -/
+  w : Fin nT1 → Fin nT2 → Nat
+  /-- Payoff of player 1 -/
+  u1 : Fin nT1 → Fin nT2 → Fin nA1 → Fin nA2 → Int
+  /-- Payoff of player 2 -/
+  u2 : Fin nT1 → Fin nT2 → Fin nA1 → Fin nA2 → Int
+
+/-- A pure type-contingent strategy of player 1: own type → action. -/
+def Strategy1 (g : BayesGame2) := Fin g.nT1 → Fin g.nA1
+
+/-- A pure type-contingent strategy of player 2: own type → action. -/
+def Strategy2 (g : BayesGame2) := Fin g.nT2 → Fin g.nA2
+
+/-- Interim expected utility of player 1: of type `t1`, playing action
+    `a`, against strategy `s2`, weighted by the prior row `w t1 ·`.
+
+    (With unnormalized weights this is the conditional expectation
+    scaled by the positive constant `Σ_{t2} w t1 t2` — maximizers are
+    unaffected, see `BNE.lean`.) -/
+def interimU1 (g : BayesGame2) (t1 : Fin g.nT1) (a : Fin g.nA1)
+    (s2 : Strategy2 g) : Int :=
+  sumFin g.nT2 (fun t2 => (g.w t1 t2 : Int) * g.u1 t1 t2 a (s2 t2))
+
+/-- Interim expected utility of player 2: of type `t2`, playing action
+    `a`, against strategy `s1`, weighted by the prior column `w · t2`. -/
+def interimU2 (g : BayesGame2) (t2 : Fin g.nT2) (a : Fin g.nA2)
+    (s1 : Strategy1 g) : Int :=
+  sumFin g.nT1 (fun t1 => (g.w t1 t2 : Int) * g.u2 t1 t2 (s1 t1) a)
+
+/-- Ex-ante expected utility of player 1 under a strategy profile:
+    sum of interim utilities over player 1's own types. -/
+def exAnteU1 (g : BayesGame2) (s1 : Strategy1 g) (s2 : Strategy2 g) : Int :=
+  sumFin g.nT1 (fun t1 => interimU1 g t1 (s1 t1) s2)
+
+/-- Ex-ante expected utility of player 2 under a strategy profile. -/
+def exAnteU2 (g : BayesGame2) (s1 : Strategy1 g) (s2 : Strategy2 g) : Int :=
+  sumFin g.nT2 (fun t2 => interimU2 g t2 (s2 t2) s1)

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Vickrey.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Vickrey.lean
@@ -32,41 +32,6 @@
     strictement positive (instance vérifiée au noyau).
 
   Voir #2610 (formalisation GT-Lean, phase bayésienne 3).
-
-  ---
-  English:
-  Second-Price Sealed-Bid (Vickrey) Auction
-  =========================================
-
-  The companion result to `Auction.lean` (first-price auction): in the
-  second-price auction (Vickrey 1961), the winner pays the LOSING bid,
-  and truthful bidding becomes a weakly dominant strategy — for every
-  number of valuations `n`, not just on small instances.
-
-  Encoding (same conventions as `Auction.lean`, core Lean 4 only):
-  - Valuations are the *types*, bids are the *actions* of a
-    `BayesGame2` with uniform prior weight 1.
-  - Utilities are scaled by 2 so the tie split stays in `Int`:
-    win = `2*(v - b_opp)` (pay the opponent's bid), tie = `v - b`,
-    lose = `0`.
-
-  Results (all for arbitrary `n`):
-  - `spa_truthful_dominant1/2`: truthful bidding weakly dominates every
-    other bid POINTWISE — against every opponent bid, in every state.
-    This is the classic Vickrey dominance argument, by case analysis
-    on who wins.
-  - `spa_interim_best1/2`: pointwise dominance transfers to interim
-    expected utility via `sumFin_mono`.
-  - `spa_truthful_bne`: the truthful profile is a Bayesian Nash
-    equilibrium for EVERY `n` — a general theorem, in contrast with
-    the first-price auction where truthful bidding is not a BNE
-    (`truthful_not_bne_two/three` in `Auction.lean`).
-  - `spa_truthful_pos_three`: unlike the first-price auction (where
-    truthful bidding earns exactly 0, `interimU1_truthful`), the
-    truthful Vickrey bidder keeps a strictly positive information
-    rent (kernel-checked instance).
-
-  See #2610 (GT-Lean formalization, Bayesian phase 3).
 -/
 
 import Bayesian.BNE
@@ -74,10 +39,7 @@ import Bayesian.BNE
 /-- Enchère scellée au second prix à deux enchérisseurs, valorisations et
     offres dans `Fin n`, prior uniforme. Le gagnant paie l'offre adverse ;
     les utilités sont mises à l'échelle par 2 pour que le cas d'égalité
-    reste entier.
-    English: Second-price sealed-bid auction with two bidders, valuations and
-    bids in `Fin n`, uniform prior. The winner pays the opponent's
-    bid; utilities are scaled by 2 so the tie split stays integral. -/
+    reste entier. -/
 @[reducible] def spa (n : Nat) : BayesGame2 where
   nT1 := n
   nT2 := n
@@ -93,12 +55,10 @@ import Bayesian.BNE
     else if b1.val = b2.val then (v2.val : Int) - b1.val
     else 0
 
-/-- Offre sincère du joueur 1 dans l'enchère au second prix.
-    English: Truthful bidding for player 1 in the second-price auction. -/
+/-- Offre sincère du joueur 1 dans l'enchère au second prix. -/
 @[reducible] def spaTruthful1 (n : Nat) : Strategy1 (spa n) := fun v => v
 
-/-- Offre sincère du joueur 2 dans l'enchère au second prix.
-    English: Truthful bidding for player 2 in the second-price auction. -/
+/-- Offre sincère du joueur 2 dans l'enchère au second prix. -/
 @[reducible] def spaTruthful2 (n : Nat) : Strategy2 (spa n) := fun v => v
 
 /-- Argument de dominance de Vickrey, joueur 1 : l'offre sincère domine
@@ -107,14 +67,7 @@ import Bayesian.BNE
     que faire perdre une victoire rentable (cas `b1 < v`) ou acheter une
     victoire non rentable (cas `b1 > v`) — cela n'améliore jamais l'offre
     `v`, parce que le PRIX (l'offre adverse) ne dépend pas de sa propre
-    offre.
-    English: Vickrey's dominance argument, player 1: truthful bidding weakly
-    dominates every other bid against every opponent bid, in every
-    state. Whoever the opponent is and whatever they bid, deviating
-    from `v` can only forfeit a profitable win (`b1 < v`-type cases)
-    or buy an unprofitable one (`b1 > v`-type cases) — it never
-    improves on bidding `v`, because the PRICE (the opponent's bid)
-    does not depend on one's own bid. -/
+    offre. -/
 theorem spa_truthful_dominant1 (n : Nat) (v t2 b1 b2 : Fin n) :
     (spa n).u1 v t2 b1 b2 ≤ (spa n).u1 v t2 v b2 := by
   show (if b2.val < b1.val then 2 * ((v.val : Int) - b2.val)
@@ -126,8 +79,7 @@ theorem spa_truthful_dominant1 (n : Nat) (v t2 b1 b2 : Fin n) :
   repeat' split
   all_goals omega
 
-/-- Argument de dominance de Vickrey, joueur 2 (symétrique).
-    English: Vickrey's dominance argument, player 2 (symmetric). -/
+/-- Argument de dominance de Vickrey, joueur 2 (symétrique). -/
 theorem spa_truthful_dominant2 (n : Nat) (t1 v b1 b2 : Fin n) :
     (spa n).u2 t1 v b1 b2 ≤ (spa n).u2 t1 v b1 v := by
   show (if b1.val < b2.val then 2 * ((v.val : Int) - b1.val)
@@ -141,10 +93,7 @@ theorem spa_truthful_dominant2 (n : Nat) (t1 v b1 b2 : Fin n) :
 
 /-- La dominance ponctuelle se transfère à l'utilité interimaire : face à
     N'IMPORTE QUELLE stratégie adverse, tout type du joueur 1 préfère
-    faiblement l'offre sincère (par monotonie de la somme pondérée).
-    English: Pointwise dominance transfers to interim expected utility: against
-    ANY opponent strategy, every type of player 1 weakly prefers the
-    truthful bid (via monotonicity of the weight-sum). -/
+    faiblement l'offre sincère (par monotonie de la somme pondérée). -/
 theorem spa_interim_best1 (n : Nat) (v a : Fin n) (s2 : Strategy2 (spa n)) :
     interimU1 (spa n) v a s2 ≤ interimU1 (spa n) v (spaTruthful1 n v) s2 := by
   apply sumFin_mono
@@ -152,8 +101,7 @@ theorem spa_interim_best1 (n : Nat) (v a : Fin n) (s2 : Strategy2 (spa n)) :
   exact Int.mul_le_mul_of_nonneg_left
     (spa_truthful_dominant1 n v t2 a (s2 t2)) (by omega)
 
-/-- Meilleure réponse interimaire, côté joueur 2.
-    English: Interim best response, player 2 side. -/
+/-- Meilleure réponse interimaire, côté joueur 2. -/
 theorem spa_interim_best2 (n : Nat) (v a : Fin n) (s1 : Strategy1 (spa n)) :
     interimU2 (spa n) v a s1 ≤ interimU2 (spa n) v (spaTruthful2 n v) s1 := by
   apply sumFin_mono
@@ -165,12 +113,7 @@ theorem spa_interim_best2 (n : Nat) (v a : Fin n) (s1 : Strategy1 (spa n)) :
     est un équilibre de Nash bayésien de l'enchère au second prix pour
     TOUT `n`. Un théorème général — pas de `decide`, pas de vérification
     d'instance — contrastant avec l'enchère au premier prix, où l'offre
-    sincère n'est pas un BNE (`truthful_not_bne_two/three`).
-    English: **Vickrey's theorem** (finite, two bidders): the truthful profile
-    is a Bayesian Nash equilibrium of the second-price auction for
-    EVERY `n`. A general theorem — no `decide`, no instance checking —
-    in contrast with the first-price auction, where truthful bidding
-    fails to be a BNE (`truthful_not_bne_two/three`). -/
+    sincère n'est pas un BNE (`truthful_not_bne_two/three`). -/
 theorem spa_truthful_bne (n : Nat) :
     isBNE (spa n) (spaTruthful1 n) (spaTruthful2 n) :=
   ⟨fun t1 a => spa_interim_best1 n t1 a (spaTruthful2 n),
@@ -181,13 +124,7 @@ theorem spa_truthful_bne (n : Nat) :
     strictement positive (concrètement 6, mis à l'échelle : gagne en
     payant 0 et 1 face aux types bas, à égalité à 2 pour un surplus nul)
     — alors que l'offre sincère dans l'enchère au PREMIER prix rapporte
-    exactement 0 (`interimU1_truthful` dans `Auction.lean`).
-    English: Information rent: in the truthful Vickrey equilibrium with
-    valuations `{0, 1, 2}`, the high type earns strictly positive
-    interim utility (concretely 6, scaled: wins paying 0 and 1
-    against the low types, ties at 2 for zero surplus) — whereas
-    truthful bidding in the FIRST-price auction earns exactly 0
-    (`interimU1_truthful` in `Auction.lean`). -/
+    exactement 0 (`interimU1_truthful` dans `Auction.lean`). -/
 theorem spa_truthful_pos_three :
     0 < interimU1 (spa 3) ⟨2, by decide⟩
         (spaTruthful1 3 ⟨2, by decide⟩) (spaTruthful2 3) := by

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Vickrey_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Vickrey_en.lean
@@ -1,0 +1,129 @@
+/-
+  Second-Price Sealed-Bid (Vickrey) Auction
+  =========================================
+
+  The companion result to `Auction.lean` (first-price auction): in the
+  second-price auction (Vickrey 1961), the winner pays the LOSING bid,
+  and truthful bidding becomes a weakly dominant strategy — for every
+  number of valuations `n`, not just on small instances.
+
+  Encoding (same conventions as `Auction.lean`, core Lean 4 only):
+  - Valuations are the *types*, bids are the *actions* of a
+    `BayesGame2` with uniform prior weight 1.
+  - Utilities are scaled by 2 so the tie split stays in `Int`:
+    win = `2*(v - b_opp)` (pay the opponent's bid), tie = `v - b`,
+    lose = `0`.
+
+  Results (all for arbitrary `n`):
+  - `spa_truthful_dominant1/2`: truthful bidding weakly dominates every
+    other bid POINTWISE — against every opponent bid, in every state.
+    This is the classic Vickrey dominance argument, by case analysis
+    on who wins.
+  - `spa_interim_best1/2`: pointwise dominance transfers to interim
+    expected utility via `sumFin_mono`.
+  - `spa_truthful_bne`: the truthful profile is a Bayesian Nash
+    equilibrium for EVERY `n` — a general theorem, in contrast with
+    the first-price auction where truthful bidding is not a BNE
+    (`truthful_not_bne_two/three` in `Auction.lean`).
+  - `spa_truthful_pos_three`: unlike the first-price auction (where
+    truthful bidding earns exactly 0, `interimU1_truthful`), the
+    truthful Vickrey bidder keeps a strictly positive information
+    rent (kernel-checked instance).
+
+  See #2610 (GT-Lean formalization, Bayesian phase 3).
+-/
+
+import Bayesian.BNE_en
+
+/-- Second-price sealed-bid auction with two bidders, valuations and
+    bids in `Fin n`, uniform prior. The winner pays the opponent's
+    bid; utilities are scaled by 2 so the tie split stays integral. -/
+@[reducible] def spa (n : Nat) : BayesGame2 where
+  nT1 := n
+  nT2 := n
+  nA1 := n
+  nA2 := n
+  w := fun _ _ => 1
+  u1 := fun v1 _ b1 b2 =>
+    if b2.val < b1.val then 2 * ((v1.val : Int) - b2.val)
+    else if b1.val = b2.val then (v1.val : Int) - b2.val
+    else 0
+  u2 := fun _ v2 b1 b2 =>
+    if b1.val < b2.val then 2 * ((v2.val : Int) - b1.val)
+    else if b1.val = b2.val then (v2.val : Int) - b1.val
+    else 0
+
+/-- Truthful bidding for player 1 in the second-price auction. -/
+@[reducible] def spaTruthful1 (n : Nat) : Strategy1 (spa n) := fun v => v
+
+/-- Truthful bidding for player 2 in the second-price auction. -/
+@[reducible] def spaTruthful2 (n : Nat) : Strategy2 (spa n) := fun v => v
+
+/-- Vickrey's dominance argument, player 1: truthful bidding weakly
+    dominates every other bid against every opponent bid, in every
+    state. Whoever the opponent is and whatever they bid, deviating
+    from `v` can only forfeit a profitable win (`b1 < v`-type cases)
+    or buy an unprofitable one (`b1 > v`-type cases) — it never
+    improves on bidding `v`, because the PRICE (the opponent's bid)
+    does not depend on one's own bid. -/
+theorem spa_truthful_dominant1 (n : Nat) (v t2 b1 b2 : Fin n) :
+    (spa n).u1 v t2 b1 b2 ≤ (spa n).u1 v t2 v b2 := by
+  show (if b2.val < b1.val then 2 * ((v.val : Int) - b2.val)
+        else if b1.val = b2.val then (v.val : Int) - b2.val
+        else 0)
+      ≤ (if b2.val < v.val then 2 * ((v.val : Int) - b2.val)
+        else if v.val = b2.val then (v.val : Int) - b2.val
+        else 0)
+  repeat' split
+  all_goals omega
+
+/-- Vickrey's dominance argument, player 2 (symmetric). -/
+theorem spa_truthful_dominant2 (n : Nat) (t1 v b1 b2 : Fin n) :
+    (spa n).u2 t1 v b1 b2 ≤ (spa n).u2 t1 v b1 v := by
+  show (if b1.val < b2.val then 2 * ((v.val : Int) - b1.val)
+        else if b1.val = b2.val then (v.val : Int) - b1.val
+        else 0)
+      ≤ (if b1.val < v.val then 2 * ((v.val : Int) - b1.val)
+        else if b1.val = v.val then (v.val : Int) - b1.val
+        else 0)
+  repeat' split
+  all_goals omega
+
+/-- Pointwise dominance transfers to interim expected utility: against
+    ANY opponent strategy, every type of player 1 weakly prefers the
+    truthful bid (via monotonicity of the weight-sum). -/
+theorem spa_interim_best1 (n : Nat) (v a : Fin n) (s2 : Strategy2 (spa n)) :
+    interimU1 (spa n) v a s2 ≤ interimU1 (spa n) v (spaTruthful1 n v) s2 := by
+  apply sumFin_mono
+  intro t2
+  exact Int.mul_le_mul_of_nonneg_left
+    (spa_truthful_dominant1 n v t2 a (s2 t2)) (by omega)
+
+/-- Interim best response, player 2 side. -/
+theorem spa_interim_best2 (n : Nat) (v a : Fin n) (s1 : Strategy1 (spa n)) :
+    interimU2 (spa n) v a s1 ≤ interimU2 (spa n) v (spaTruthful2 n v) s1 := by
+  apply sumFin_mono
+  intro t1
+  exact Int.mul_le_mul_of_nonneg_left
+    (spa_truthful_dominant2 n t1 v (s1 t1) a) (by omega)
+
+/-- **Vickrey's theorem** (finite, two bidders): the truthful profile
+    is a Bayesian Nash equilibrium of the second-price auction for
+    EVERY `n`. A general theorem — no `decide`, no instance checking —
+    in contrast with the first-price auction, where truthful bidding
+    fails to be a BNE (`truthful_not_bne_two/three`). -/
+theorem spa_truthful_bne (n : Nat) :
+    isBNE (spa n) (spaTruthful1 n) (spaTruthful2 n) :=
+  ⟨fun t1 a => spa_interim_best1 n t1 a (spaTruthful2 n),
+   fun t2 a => spa_interim_best2 n t2 a (spaTruthful1 n)⟩
+
+/-- Information rent: in the truthful Vickrey equilibrium with
+    valuations `{0, 1, 2}`, the high type earns strictly positive
+    interim utility (concretely 6, scaled: wins paying 0 and 1
+    against the low types, ties at 2 for zero surplus) — whereas
+    truthful bidding in the FIRST-price auction earns exactly 0
+    (`interimU1_truthful` in `Auction.lean`). -/
+theorem spa_truthful_pos_three :
+    0 < interimU1 (spa 3) ⟨2, by decide⟩
+        (spaTruthful1 3 ⟨2, by decide⟩) (spaTruthful2 3) := by
+  decide


### PR DESCRIPTION
## Objet

EPIC **#4980** (Lean i18n, Option A sibling-pair ratifiée user 2026-07-04) — tranche feuilles de `lean_game_defs_ext/Bayesian`. Fait suite à #7024 (racine `Bayesian.lean` / `Bayesian_en.lean` + `globs` du lakefile, déjà sur `main`).

Les 12 feuilles `Bayesian/*.lean` étaient **bilingues-inline** (docstrings FR + traduction `English:` dans le même bloc). On les scinde en paire sibling :

- `Foo.lean` — **FR canonique**, English inline strippé (docstrings FR only)
- `Foo_en.lean` — **jumeau EN** (docstrings anglaises ; imports suffixés `_en`)

## Conformité convention (`code-style.md` « Lean (i18n) »)

- Seules les **docstrings `/-- -/`** et commentaires `-- ` diffèrent entre `Foo.lean` et `Foo_en.lean`.
- **Énoncés de théorèmes, tactiques, noms de lemmes, refs Mathlib** restent en anglais dans les deux fichiers.
- **Byte-identity** sur tout le code non-docstring (vérifiée programmatiquement, voir Preuves).
- Feuilles à **namespace racine** (pas de `namespace` wrapper) → anti-collision par **séparation du graphe de modules** : `Foo_en` importe `Bayesian.X_en`, jamais la version FR.

## Preuves firsthand (worktree, toolchain `v4.31.0-rc1`, core-only, LF canonique)

| Gate | Résultat |
|------|----------|
| `lake build` | **28 jobs SUCCESS**, dont les **12 `Built Bayesian.Foo_en`** (`Sum_en Types_en Max_en BNE_en Auction_en Examples_en InfoGames_en Reputation_en Vickrey_en Information_en Regret_en FictitiousPlay_en`) — les `globs = ["Bayesian.*", …]` du lakefile (#7024) couvrent les `_en`, **pas d'orphan-trap faux-green**. |
| Code byte-identity | `orig == FR == EN` (comment-strip + normalisation suffixe `_en`) pour les 12. |
| Import byte-identity par feuille | `diff` imports FR vs EN (mod `_en`) **vide** pour les 12 (Sum 0, Regret/FictitiousPlay 2, reste 1). |
| FR sans `English:` | 0 marqueur inline résiduel dans les 12 FR. |
| EN sans accent français | 0 (opérateurs math unicode `→ ≤ ∀ σ τ` whitelistés). |

## Scope

- **24 fichiers** = 12 modifiés (FR-strip) + 12 nouveaux (`_en`).
- **ZÉRO** touche à `lakefile.toml`, `Bayesian.lean`, `Bayesian_en.lean` (déjà sur `main` via #7024).
- **24-et-non-12** : les feuilles étant bilingues-inline, une scission fidèle **double** le compte (FR-strip + EN-create), exactement comme le split racine de #7024. Split mécanique i18n **d'un seul sujet** : le seuil G.4 « 15 fichiers » vise les composites hétérogènes, pas une scission i18n mono-thème.

## Suivi

`See #4980` — **partiel : 12/13 modules** de `lean_game_defs_ext` (l'epic reste ouverte).
