### PR TITLE
fix(decinfer-5): portable #load path (../../Infer/) for headless re-exec

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-5-Decision-Networks.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-5-Decision-Networks.ipynb
@@ -208,7 +208,7 @@
    ],
    "source": [
     "// Chargement du helper pour visualiser les factor graphs inline\n",
-    "#load \"FactorGraphHelper.cs\"\n",
+    "#load \"../../Infer/FactorGraphHelper.cs\"\n",
     "\n",
     "// Verification de la disponibilite de Graphviz\n",
     "if (FactorGraphHelper.IsGraphvizAvailable())\n",


### PR DESCRIPTION
## Summary

`DecInfer-5-Decision-Networks.ipynb` cell[5] used `#load "FactorGraphHelper.cs"`, which resolves relative to the kernel CWD. `FactorGraphHelper.cs` lives in `Probas/Infer/`, but DecInfer-5 is in `Probas/DecisionTheory/DecInfer/` — so the `#load` only resolves when the kernel starts from `Probas/Infer/` (interactive VS Code). The repo's dedicated headless executor ([dotnet_executor.py](scripts/notebook_tools/dotnet_executor.py), sets CWD=notebook-dir) could **not** re-exec the notebook: `CS1504 "Fichier introuvable"` at the `#load` cell.

Same defect as DecInfer-4 (#7028) and DecInfer-8 (#7030). Fixed: `#load "../../Infer/FactorGraphHelper.cs"` (relative from the notebook's own dir).

## Validation (firsthand, po-2024, .net-csharp kernel, Infer.NET cached, Graphviz 14.1.2)

- **AFTER fix**: cell[5] `#load` resolves, helper loads. Full re-exec: **17/17 code cells, 0 errors, 15.8s**. Baseline (origin/main + temp `#load` fix) also 17/17 0 errors → confirms **0 pre-existing errors, 0 new errors introduced**. Fully clean (unlike DecInfer-8 which had a student-exercise stub error; DecInfer-5 has none).
- **Surgical diff**: 1 line changed (byte-level string replace, preserving exact file format — no whitespace/normalization churn, **no probeAddresses banner**, no Graphviz coordinate churn). The full re-exec was run SEPARATELY only to prove runnability; the commit is source-only (existing outputs retained, `cell[5]` output byte-identical). **H.3**: 0 null-exec.

## Anti-regression

cell[5] is a semantically-equivalent `#load` (same helper, different resolution path) with unchanged output. No other cell touched.

## Scope

DecInfer-5 only (atomic, per-notebook validated). Series continues from #7028 (DecInfer-4), #7030 (DecInfer-8). Remaining: DecInfer-1/3/6/7/10.

See #6927
See #3801