### PR TITLE
fix(sota,#3801): SC-18 cell[16] real anvil on-chain deploy (#7031 residual)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-18-Vyper.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-18-Vyper.ipynb
@@ -912,8 +912,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Anvil non disponible. Lancez : anvil\n",
-      "Le deploiement sera simule.\n"
+      "DEPLOIEMENT SUR ANVIL\n",
+      "============================================================\n",
+      "Deployer : 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266\n",
+      "Contrat deploye : 0x5FbDB2315678afecb367f032d93F642f64180aa3\n",
+      "Gas utilise : 165,655\n",
+      "\n",
+      "Valeur initiale : 42\n",
+      "Apres set_value(100) : 100\n",
+      "Owner : 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266\n",
+      "Owner == deployer : True\n"
      ]
     }
    ],


### PR DESCRIPTION
## What

Completes the residual flagged in **#7031** (SC-18 Vyper real compilation): cell[16] on-chain deployment was left at the honest `"Anvil non disponible"` branch because Foundry's `anvil` local chain was not running. This PR deploys the contract for real on anvil and commits the genuine transaction output. EPIC #3801 axe-2 (SOTA, Prong-A residual). Sibling to #7031 + #7027.

## Defect → residual → now fixed

cell[16] source is SOTA-correct: `w3=Web3(Web3.HTTPProvider("127.0.0.1:8545"))` → `if w3.is_connected(): contract.constructor(42).transact()` → real deploy + view calls. After #7031 (which installed vyper+web3), the cell reached its honest `else` ("Anvil non disponible") — correct but incomplete. This PR runs the full happy path.

## Fix — real EVM deployment

**Env (RECOVERABLE-MACHINE→LOCAL via WSL):** installed Foundry 1.7.1 in WSL via `foundryup` (precompiled binary — `anvil` 1.7.1 verified), reused the WSL py3.12 venv with vyper 0.4.3 + web3 7.16.0. Started `anvil` daemon on 127.0.0.1:8545, ran the **unchanged** cell[16] logic, captured the real on-chain result, injected surgically.

**Real deployment output now committed (cell[16]):**
```
DEPLOIEMENT SUR ANVIL
============================================================
Deployer : 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
Contrat deploye : 0x5FbDB2315678afecb367f032d93F642f64180aa3
Gas utilise : 165,655

Valeur initiale : 42
Apres set_value(100) : 100
Owner : 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
Owner == deployer : True
```

Real EVM transaction: contract at `0x5FbDB231...` deployed with **165,655 gas**, constructor `__init__(42)` set initial value, `set_value(100)` transaction mutated on-chain state (42→100), `owner == deployer` confirms access control. The full smart-contract lifecycle (compile → deploy → transact → read) that a "describe-the-deploy-in-prose" baseline cannot replicate (**Prong-B non-triviality**).

## Gates verified firsthand

| Gate | Result |
|------|--------|
| Source unchanged | `git diff \| grep -cE '^\+.*"source"'` = **0** / `-` = **0** |
| Catalogue | **0 diff** (clean) |
| nbformat | `nbformat.validate()` **OK** |
| H.3 validator | OK:1, Warnings:**0**, Errors:**0** (matches origin/main baseline) |
| Real vs fallback | `DEPLOIEMENT SUR ANVIL` + contract addr + gas; no "mode démonstration" / "Anvil non disponible" |
| Collision | `gh pr list --search anvil` = **0** SC-18 deploy PR |
| Verdict | **SOTA-OK** (real EVM deployment on anvil) |

## SmartContracts SOTA status (post #7027 + #7031 + this PR)

SC-16 (TenSEAL #6750 + concrete-FHE #7027) and SC-18 (Vyper compile #7031 + anvil deploy this PR) are now genuinely SOTA-OK end-to-end. Ledger entry #016 (PR #5994) "27 nb SOTA-OK" no longer premature for these.

See #3801 (EPIC axe-2 SOTA). Siblings: #7031, #7027, #6750.

🤖 po-2025 (GLM no-vision lane; on-chain deploy captured via deterministic WSL anvil exec, not visual QA)
