### PR TITLE
fix(sota,#7029): SC-16 FHE honest INTRINSIC-on-Windows (reproducible output + WSL note) [HOLD-MERGE]

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-16-Homomorphic-Encryption.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-16-Homomorphic-Encryption.ipynb
@@ -1172,12 +1172,22 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CONCRETE FHE - Addition compilee\n",
-      "======================================================================\n",
-      "Circuit compile avec succes\n",
-      "  addition_secrete(7, 13) = 20  (attendu: 20)\n",
+      "Concrete non installe (pip install concrete-python).\n",
       "\n",
-      "-> Le serveur a calcule 7 + 13 SANS voir les valeurs !\n"
+      "Concrete permet de compiler une fonction Python en circuit FHE.\n",
+      "Exemple conceptuel :\n",
+      "\n",
+      "  @fhe.compiler({'x': 'encrypted', 'y': 'encrypted'})\n",
+      "  def addition_secrete(x, y):\n",
+      "      return x + y\n",
+      "\n",
+      "  # Compilation\n",
+      "  circuit = addition_secrete.compile(inputset)\n",
+      "  circuit.keygen()\n",
+      "\n",
+      "  # Execution sur donnees chiffrees\n",
+      "  result = circuit.encrypt_run_decrypt(7, 13)  # -> 20\n",
+      "  # Le serveur n'a jamais vu 7 ni 13\n"
      ]
     }
    ],
@@ -1245,6 +1255,37 @@
     "except Exception as e:\n",
     "    print(f\"Erreur lors de la compilation Concrete : {e}\")\n",
     "    print(\"Concrete necessite un environnement specifique (Linux recommande).\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sc16-fhe-intrinsic-note",
+   "metadata": {},
+   "source": [
+    "### Note d'exécution : `concrete-python` est Linux/macOS-only\n",
+    "\n",
+    "La cellule ci-dessus affiche le **repli conceptuel** (branche `ImportError`) : `concrete-python`\n",
+    "(Zama) ne publie **aucun wheel Windows** (PyPI : `manylinux_2_28` + `macosx` uniquement, pas de\n",
+    "`cp313` Windows). Sur le kernel déclaré de ce notebook (`python3` / Windows 3.13), l'import\n",
+    "échoue et la cellule retombe proprement sur l'explication conceptuelle — c'est la **sortie\n",
+    "reproductible** (un re-run headless sur ce kernel produit exactement ceci).\n",
+    "\n",
+    "Le circuit FHE réel **fonctionne** : exécuté dans un venv **WSL Linux (Python 3.12,\n",
+    "`concrete-python` 2.11.0)**, il produit\n",
+    "\n",
+    "```\n",
+    "CONCRETE FHE - Addition compilee\n",
+    "Circuit compile avec succes\n",
+    "  addition_secrete(7, 13) = 20  (attendu: 20)\n",
+    "-> Le serveur a calcule 7 + 13 SANS voir les valeurs !\n",
+    "```\n",
+    "\n",
+    "le serveur calculant `7 + 13` **sans jamais voir** les opérandes en clair.\n",
+    "\n",
+    "> **Verdict SOTA (Prong-A, #3801) : INTRINSIC-on-Windows.** L'outil est pleinement fonctionnel,\n",
+    "> mais sur une plateforme (Linux/macOS) distincte du kernel déclaré. On documente ici honnêtement\n",
+    "> le plafond atteignable plutôt que d'injecter dans la cellule une sortie non reproductible sur\n",
+    "> Windows. Pour exécuter le vrai circuit localement : WSL Ubuntu + `pip install concrete-python`.\n"
    ]
   },
   {


### PR DESCRIPTION
## Objet — #7029 (See #3801)

Rework honnête de la cellule FHE `concrete-python` de **SC-16-Homomorphic-Encryption** (04-Privacy-Cryptography), suite à l'issue **#7029**.

**#7027** (mergé) avait injecté dans `cell[24]` (execution_count=8) la vraie sortie WSL de `concrete-python` (`addition_secrete(7,13)=20`). Mais `concrete-python` (Zama) est **Linux/macOS-only** (PyPI : `manylinux_2_28` + `macosx`, **aucun wheel Windows/cp313**). Le kernel **déclaré** du notebook est `python3` / Windows 3.13 → l'import y échoue. La sortie injectée n'était donc **pas reproductible** dans le kernel déclaré : un re-exec headless retombe sur la branche `ImportError`, faisant de `execution_count=8` un **faux témoin** de production native (exactement le mode d'échec anti-scrub « resurfaces at next exec »).

## Correctif (Option 1 de #7029 — INTRINSIC-on-Windows)

- **`cell[24]` : sortie restaurée = repli conceptuel reproductible**, obtenue en **re-exécutant la source (inchangée) de la cellule sur le kernel déclaré** `python3`/Win-3.13 (`concrete` absent → branche `ImportError`). `execution_count=8` **préservé** : le repli est indépendant de l'état, donc un run complet top-to-bottom produit exactement cette sortie à cette position. (Stop&Repair : **re-exécuté, jamais hand-edité**.)
- **Nouvelle cellule markdown adjacente** documentant (a) la contrainte Linux/macOS-only, (b) le **vrai résultat WSL** labellisé explicitement (`concrete-python 2.11.0`, WSL py3.12), (c) le **verdict SOTA Prong-A = INTRINSIC-on-Windows** : plafond honnête + preuve réelle documentée, pas une sortie injectée non-reproductible.

## Preuves

| Gate | Résultat |
|------|----------|
| `concrete` sur kernel déclaré | **absent** (Win py3.13, no wheel) → `ImportError` branch = sortie reproductible |
| Re-exec cellule (kernel `python3`) | produit **`Concrete non installe ...`** (repli conceptuel) — sortie committée |
| Diff | **chirurgical** : `cell[24].outputs` + 1 cellule markdown ; **toutes les autres cellules byte-identiques** (46 insertions / 5 deletions, 1 fichier) |
| nbformat validate | OK (45 cellules) |
| C.1 (erreurs volontaires) | NONE |
| `validate_pr_notebooks.py` | **1/1 passed** (13 code cells) |
| Catalogue | **byte-identique** à `origin/main` (non touché) |

## ⚠️ HOLD-MERGE (ne pas merger avant ce soir)

Deux raisons **réservées à l'utilisateur** :

1. **Arbitrage dual-session** — #7027 a été mergé par un REPL parallèle **avant la fin de la review anti-scrub** ; #7029 le flagge comme élément de l'**arbitrage dual-session prévu ce soir** (agenda user 17/07).
2. **Ratification de convention** — #7029 pose une question de politique : ratifier **Option 1 (INTRINSIC honnête + résultat réel documenté)** comme convention standard pour tout outil SOTA **Linux/macOS-only** sur kernel Windows déclaré (impacte le futur Prong-A #3801).

Cette PR **propose** l'end-state honnête (rôle worker) ; le **merge** revient au coordinateur/utilisateur **après** l'arbitrage + la ratification. La partie « rework du notebook » est complète ; la ratification de convention reste ouverte → **`See #7029`, pas `Closes`**.

## Suivi

- `See #7029` — rework notebook fait ; ratification convention = user-reserved.
- `See #3801` — registre Prong-A SOTA (epic ouverte).
- Auteur : `po-2025:CoursIA-2` (auteur de #7027, dispose du contexte WSL). Priorité basse.
