### PR TITLE
fix(decinfer-6): portable #load path (../../Infer/) for headless re-exec

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-6-Value-Information.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-6-Value-Information.ipynb
@@ -289,7 +289,7 @@
    ],
    "source": [
     "// Chargement du helper pour visualiser les factor graphs Infer.NET\n",
-    "#load \"FactorGraphHelper.cs\"\n",
+    "#load \"../../Infer/FactorGraphHelper.cs\"\n",
     "\n",
     "// Active la generation des factor graphs pour les modeles Infer.NET\n",
     "bool ShowFactorGraph = true;\n",


### PR DESCRIPTION
## Summary

DecInfer-6-Value-Information.ipynb cell[4] used `#load "FactorGraphHelper.cs"`, which resolves relative to the **kernel CWD**. `FactorGraphHelper.cs` lives in `Probas/Infer/`, but DecInfer-6 is in `Probas/DecisionTheory/DecInfer/` — so the `#load` only resolves when the kernel starts from `Probas/Infer/` (interactive VS Code). The repo's dedicated headless executor (`scripts/notebook_tools/dotnet_executor.py`, sets `CWD=notebook-dir`) could NOT re-exec the notebook: `CS1504 "Fichier introuvable"` at the `#load` cell.

Same defect family as DecInfer-4 (#7028 MERGED), DecInfer-8 (#7030), DecInfer-5 (#7034 MERGED). **Fix:** `#load "../../Infer/FactorGraphHelper.cs"`.

## Changes

- **1 line changed** (byte-level string replace on the JSON-escaped literal, preserving exact file format).
- Source-only commit: validation re-exec was run SEPARATELY; outputs reset to `origin/main` before commit.
- cell[4] output byte-identical to `origin/main` (no semantic change, only the load resolution path differs).

## Validation (firsthand, po-2024)

`dotnet_executor.py` (`.net-csharp` kernel, Infer.NET cached in `~/.nuget/packages/`, Graphviz 14.1.2):

- **AFTER fix:** cell[4] `#load` resolves correctly, the helper loads, the defect is fixed.
- **Pre-existing errors (out of scope):** 4 errors remain at cells `[11]`, `[13]`, `[16]`, `[18]`.

### G.1 baseline confirmation (the 4 errors are PRE-EXISTING)

To prove my fix introduces **0 new errors**, I ran the baseline (`git show origin/main:<nb>` + temporary `#load` fix) through the same executor:

```
DONE d6-base-tmp.ipynb: 19/19 cells, 4 errors, 9.2s
```

**Baseline produces the IDENTICAL 4 errors** (cells `[11]`, `[13]`, `[16]`, `[18]`). Breakdown:
- `[16]`, `[18]` = **student EXERCISE STUBS** ("Exercice : Decision de test medical", "Exercice : VoI pour un Portfolio") — C.1-compliant stubs, out of scope.
- `[11]`, `[13]` = **pre-existing Infer.NET env-drift on po-2024** ("Calculateur generique de VoI avec Infer.NET", "Visualisation du Factor Graph pour le modele de forage petrolier") — also fail on baseline; the committed outputs are valid from a prior clean run and are preserved.

My fix introduces **ZERO new errors**.

## H.3 / integrity

- `execution_count != null` for all committed code cells (no re-exec artifacts committed).
- `git diff | grep -c probeAddresses` = **0** (no dotnet-interactive probe banner leak).
- `git diff | grep -c "http://[0-9a-f:.]\+:2048"` = **0** (no host-IP leak).
- Diff = **1 line**, source-only (no Graphviz coordinate churn, no output refresh).

## Anti-regression

cell[4] is a semantically-equivalent `#load` (same helper, different resolution path) with unchanged output. No other cell touched. No `sorry`/`pass`/`return None` regression (n/a — this is a `#load` path fix, not Lean code).

## Scope

- **DecInfer-6 only** (atomic, one notebook per PR — cf catalog-pr-hygiene §3 / G.4).
- Series continues from #7028, #7034, #7030.
- **Remaining:** DecInfer-1, DecInfer-3, DecInfer-7, DecInfer-10 (same `#load` fix).

See #6927
See #3801

🤖 Generated with [Claude Code](https://claude.com/claude-code)