### PR TITLE
fix(decinfer-3): portable #load path (../../Infer/FactorGraphHelper.cs)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-3-Utility-Money.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-3-Utility-Money.ipynb
@@ -218,7 +218,7 @@
    ],
    "source": [
     "// Chargement du helper pour les visualisations de factor graphs\n",
-    "#load \"FactorGraphHelper.cs\"\n",
+    "#load \"../../Infer/FactorGraphHelper.cs\"\n",
     "\n",
     "// NOTE: Les visualisations Plotly ont ete remplacees par des sorties console\n",
     "// pour assurer la compatibilite avec toutes les versions de .NET Interactive.\n",


### PR DESCRIPTION
## What

Fixes a portable-`#load` defect in **DecInfer-3-Utility-Money** (`Probas/DecisionTheory/DecInfer`): cell[4] used the bare `#load "FactorGraphHelper.cs"` form that **fails headless re-execution** (the helper lives two directories up, in `Probas/Infer/`), making the notebook non-reproducible outside the interactive VS Code session. Replaced with the relative path `#load "../../Infer/FactorGraphHelper.cs"` — **byte-identical to the proven FIXED pattern in DecInfer-4 and DecInfer-5**. Hygiene fix, mirrors #7034 (DecInfer-8 bare `#load`, po-2024).

## Defect (firsthand, G.1)

`#load` resolution in .NET Interactive is **relative to the notebook file's directory** when the path is not absolute. DecInfer-3 lives at `Probas/DecisionTheory/DecInfer/`; `FactorGraphHelper.cs` lives at `Probas/Infer/FactorGraphHelper.cs`. The bare `#load "FactorGraphHelper.cs"` only resolves when the working directory happens to be the notebook's own dir (interactive VS Code) — it **breaks under Papermill/headless `dotnet-interactive`** where cwd differs.

Full family G.1 scan confirms the two classes:

| Notebook | `#load` form | Status |
|----------|-------------|--------|
| **DecInfer-3** (this PR) | ~~`"FactorGraphHelper.cs"`~~ → `"../../Infer/FactorGraphHelper.cs"` | **FIXED** |
| DecInfer-4-Multi-Attribute | `"../../Infer/FactorGraphHelper.cs"` | FIXED (reference) |
| DecInfer-5-Decision-Networks | `"../../Infer/FactorGraphHelper.cs"` | FIXED (reference) |
| DecInfer-1-Utility-Foundations | `"FactorGraphHelper.cs"` | bare (sibling residual) |
| DecInfer-6-Value-Information | `"FactorGraphHelper.cs"` | bare (sibling residual) |
| DecInfer-7-Expert-Systems | `"FactorGraphHelper.cs"` | bare (sibling residual) |
| DecInfer-8-Sequential | `"FactorGraphHelper.cs"` | bare (sibling residual, #7030 by po-2024) |
| DecInfer-10-Thompson-Sampling | `"FactorGraphHelper.cs"` | bare (sibling residual) |

Path math (verified): from `Probas/DecisionTheory/DecInfer/`, `../../Infer/` = `Probas/Infer/` where the helper (9907 bytes) lives. Identical to the merged DecInfer-4/5 = the path provably resolves headless (those PRs passed CI).

## Fix — source-only 1-line edit (po-2024 c.600 lesson)

Source-only commit: `exec_count: 2` + `outputs` **unchanged**. The committed cell already ran successfully in an interactive session (outputs are valid — they are NOT a degraded fallback); only the `#load` directive was non-portable. Re-execing the full cell separately would risk a banner/probe leak (po-2024 c.600 incident — committed a re-exec'd file that leaked machine paths) and gains nothing since the only change is a path string the interactive outputs don't surface. Mirrors how source-path fixes were committed in #7034.

## Residual — bare-`#load` siblings (RECOVERABLE-LOCAL)

DecInfer-1, 6, 7, 8, 10 carry the **same bare-`#load` bug** but are out of scope for this atomic PR (one notebook = one PR, cf catalog-pr-hygiene HARD 3; anti-monotony R6 — not tunnelizing a DecInfer sweep). #7030 (po-2024) already targets DecInfer-8. Flagged here so a future lane can pick up 1/6/7/10 cleanly.

## Gates verified firsthand

| Gate | Result |
|------|--------|
| Source-only | `git diff --stat` = **1 file, +1/-1**; `git diff \| grep -cE '^\+.*"execution_count"\|"outputs"'` = **0** new exec/output lines |
| Catalogue | **clean** (`git status \| grep catalog` = 0) |
| nbformat | `nbformat.validate()` **OK** |
| H.3 validator | OK:0, Warnings:**1**, Errors:**0** — warning count **matches origin/main baseline** (1==1, pre-existing, unrelated to path fix) |
| Path resolves | helper exists at `Probas/Infer/FactorGraphHelper.cs` (9907 bytes); `../../Infer/` from DecInfer dir = `Probas/Infer/` (verified); syntax byte-identical to merged DecInfer-4/5 |
| Banner/path leak | `git diff \| grep -iE 'probeAddresses\|C:\\\\Users\|secret\|token'` = **0** (po-2024 gotcha avoided) |
| Collision | `gh pr list --search "DecInfer-3"` = **0** prior PR |
| Verdict | **SOTA-OK** (real portable `#load` to the real helper; no degraded workaround) |

Sibling: #7034 (DecInfer-8 bare `#load` fix). Reference FIXED: DecInfer-4, DecInfer-5.

🤖 po-2025 (GLM no-vision lane; .NET path-resolution verified by structural proof — helper-on-disk + byte-identical-to-merged-twins — not visual QA)
