### PR TITLE
fix(decinfer-7): portable #load path (../../Infer/) for headless re-exec

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-7-Expert-Systems.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-7-Expert-Systems.ipynb
@@ -270,7 +270,7 @@
    ],
    "source": [
     "// Chargement du helper pour visualiser les graphes de facteurs\n",
-    "#load \"FactorGraphHelper.cs\"\n",
+    "#load \"../../Infer/FactorGraphHelper.cs\"\n",
     "\n",
     "Console.WriteLine(\"FactorGraphHelper charge.\");\n",
     "Console.WriteLine($\"Graphviz disponible : {FactorGraphHelper.IsGraphvizAvailable()}\");"
@@ -2518,7 +2518,7 @@
     "// SvgChartHelper.Overlay (#6958 MERGED) requiert un axe X numerique partage => inapplicable.\n\n",
     "// Le helper Overlay reste disponible pour les courbes VoI type DecInfer-6 EVPI ; ici c'est\n\n",
     "// l'usage canonique Bar() qui s'applique. Cf #6927 / #3801 / #6942 / #6958 / See #6954 (App-7b).\n\n",
-    "#load \"SvgChartHelper.cs\"\n\n",
+    "#load \"../../Infer/SvgChartHelper.cs\"\n\n",
     "\n\n",
     "int nPannes = 4;  // 0=OK, 1=RAM, 2=Disque, 3=CPU\n\n",
     "Range panneRange = new Range(nPannes).Named(\"panneRange\");\n\n",


### PR DESCRIPTION
## Summary

`DecInfer-7-Expert-Systems.ipynb` carried **two bare `#load` defects** that block headless re-execution:

- **cell[2]:** `#load "FactorGraphHelper.cs"` (resolves against kernel CWD)
- **cell[32]:** `#load "SvgChartHelper.cs"` (same defect)

Both helpers live in `Probas/Infer/`. DecInfer-7 is in `Probas/DecisionTheory/DecInfer/`. From the notebook's own directory, the helpers are at `../../Infer/<name>.cs`. The bare form only resolves when the interactive VS Code kernel happens to launch with CWD=`Probas/Infer/` — under the repo's headless executor ([dotnet_executor.py](scripts/notebook_tools/dotnet_executor.py), CWD=notebook-dir) it fails with `CS1504 "Fichier introuvable"` at the `#load` cells.

Fix: replace both `#load` paths with `"../../Infer/..."` so they resolve from the notebook's own directory. **Byte-identical to the proven FIXED pattern in #7028 (DecInfer-4)**, **#7034 (DecInfer-5)**, **#7030 (DecInfer-8)** — all MERGED, all 0 execution-error post-fix.

## Changes

- **1 file, +2/-2** — purely `#load` path strings, 2 cells (FactorGraphHelper cell[2] + SvgChartHelper cell[32]).
- Source-only commit: outputs and `execution_count` preserved on every cell (no re-exec, mirrors the proven source-only discipline from #7034 and #7039 source-only fix).
- No whitespace churn, no `probeAddresses` banner injection (po-2024 c.600 lesson — banner guard clean), no Graphviz coordinate churn.

## Validation (provenance + structural proof)

| Gate | Result |
|------|--------|
| Source-only diff | `git diff` = **+2/-2**, no `execution_count` or `outputs` changes (verified fingerprint-vs-origin) |
| Path resolution | helper locations exist on disk: `Probas/Infer/FactorGraphHelper.cs` (9907 bytes), `Probas/Infer/SvgChartHelper.cs` (verified, 1 file match) — `../../Infer/` from `DecInfer-7` resolves to `Probas/Infer/` |
| Byte-identity to merged twins | DecInfer-4/5/8 use the identical `../../Infer/<name>` pattern (verified via prior diffs); path math = literal `Probas/Infer/` (2 levels up + `Infer/`) |
| Notebook JSON | `json.load` OK (43 cells, nbformat 4) |
| Catalog | `git status | grep catalog` = 0 (catalog-pr-hygiene R1) |
| Banner/path leak | `git diff | grep -iE 'probeAddresses|C:\\Users|secret|token|172\.|192\.168'` = **0** matches |
| Verdict | **SOTA-OK** (real portable `#load`s pointing at real helpers on disk; no degraded workaround) |

## Pre-existing errors (out of scope, NOT introduced)

Per the proven DecInfer-8 (`#7030`) baseline-confirmation pattern: any `#load` re-exec on a partial defect may surface pre-existing Infer.NET env-drift or student-exercise stub errors. Pre-existing errors are out of scope; this PR does NOT re-exec and therefore does NOT introduce or hide errors.

## Anti-regression (D)

cell[2] and cell[32] are semantically-equivalent `#load`s with unchanged runtime semantics. No other cell touched. No `sorry`/`pass`/`return None` regression (n/a — `.cs #load` path fix, not Lean code). **Memory note:** po-2024 c.647 L647-L1★ prev lesson (`source-only #load` fixes proven; cleared-outputs re-exec path carries banner-leak risk via re-exec).

## Scope

- DecInfer-7 only (atomic, one notebook = one PR; cf catalog-pr-hygiene §3 / G.4).
- Series continues from **#7028** (DecInfer-4) → **#7034** (DecInfer-5) → **#7030** (DecInfer-8) → **#7038** (DecInfer-6, jsboige OPEN) → **#7039** (DecInfer-3, jsboige OPEN) → **this PR** (DecInfer-7).
- **Remaining siblings with the same FactorGraphHelper bare-#load defect:** DecInfer-1 (`Utility-Foundations`), DecInfer-10 (`Thompson-Sampling`) — flagged for future lane pickups.
- **DecInfer-7-specific SvgChartHelper bare-#load defect** (also fixed in this PR) does NOT affect DecInfer-1/10 (they only have FactorGraphHelper `#load` cells) or DecInfer-3/6 (their SvgChartHelper cells are bare-#load too — flagged in #7038 scope, separate follow-up).

See #6927
See #3801