### PR TITLE
fix(decinfer-1): portable #load path (../../Infer/) for headless re-exec

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-1-Utility-Foundations.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-1-Utility-Foundations.ipynb
@@ -265,7 +265,7 @@
    ],
    "source": [
     "// Chargement du helper pour visualiser les factor graphs\n",
-    "#load \"FactorGraphHelper.cs\"\n",
+    "#load \"../../Infer/FactorGraphHelper.cs\"\n",
     "\n",
     "Console.WriteLine(\"FactorGraphHelper charge.\");\n",
     "Console.WriteLine($\"Graphviz disponible : {FactorGraphHelper.IsGraphvizAvailable()}\");"


### PR DESCRIPTION
## Summary

`DecInfer-1-Utility-Foundations.ipynb` cell[6] used bare `#load "FactorGraphHelper.cs"`, which resolves relative to the kernel CWD. The helper lives in `Probas/Infer/`, but DecInfer-1 is in `Probas/DecisionTheory/DecInfer/` — so the `#load` only resolves when the kernel starts from `Probas/Infer/` (interactive VS Code). The repo's dedicated headless executor ([dotnet_executor.py](scripts/notebook_tools/dotnet_executor.py), sets `CWD=notebook-dir`) cannot re-exec the notebook: `CS1504 "Fichier introuvable"` at the `#load` cell.

**Fix:** replace `#load` path with `"../../Infer/FactorGraphHelper.cs"` so it resolves from the notebook's own directory, **byte-identical to the proven FIXED pattern in #7028 (DecInfer-4)**, **#7034 (DecInfer-5)**, **#7030 (DecInfer-8)** — all MERGED, all 0 execution-error post-fix.

## Changes

- **1 file, +1/-1** — purely `#load` path string, 1 cell (cell[6] FactorGraphHelper).
- Source-only commit: outputs and `execution_count` preserved on every cell (no re-exec, mirrors the proven source-only discipline from #7034 and #7039 source-only fix).
- No whitespace churn, no `probeAddresses` banner injection (po-2024 c.600 lesson — banner guard clean), no Graphviz coordinate churn.

## Validation (provenance + structural proof)

| Gate | Result |
|------|--------|
| Source-only diff | `git diff` = **+1/-1**, no `execution_count` or `outputs` changes (verified fingerprint-vs-origin on all 16 code cells) |
| Path resolution | helper exists on disk at `Probas/Infer/FactorGraphHelper.cs` (9907 bytes) — `../../Infer/` from `DecInfer-1` resolves to `Probas/Infer/` |
| Byte-identity to merged twins | DecInfer-4/5/8 use the identical `../../Infer/<name>` pattern (verified via prior diffs) |
| Notebook JSON | `json.load` OK (43 cells, 16 code cells, nbformat 4) |
| Catalog | `git status | grep catalog` = 0 (catalog-pr-hygiene R1) |
| Banner/path leak | `git diff | grep -iE 'probeAddresses|C:\\Users|secret|token|172\.|192\.168'` = **0** matches |
| Verdict | **SOTA-OK** (real portable `#load` pointing at real helper on disk; no degraded workaround) |

## Pre-existing errors (out of scope, NOT introduced)

Per the proven DecInfer-8 (`#7030`) baseline-confirmation pattern: any `#load` re-exec on a partial defect may surface pre-existing Infer.NET env-drift or student-exercise stub errors. Pre-existing errors are out of scope; this PR does NOT re-exec and therefore does NOT introduce or hide errors.

## Anti-regression (D)

cell[6] is a semantically-equivalent `#load` with unchanged runtime semantics. No other cell touched. No `sorry`/`pass`/`return None` regression (n/a — `.cs #load` path fix, not Lean code). Source-only commit preserves `execution_count` and outputs on all 16 code cells (verified by source-fingerprint + outputs-length diff against origin/main).

## Scope

- DecInfer-1 only (atomic, one notebook = one PR; cf catalog-pr-hygiene §3 / G.4).
- Series continues from **#7028** (DecInfer-4) → **#7034** (DecInfer-5) → **#7030** (DecInfer-8) → **#7038** (DecInfer-6, jsboige OPEN) → **#7039** (DecInfer-3, jsboige OPEN) → **#7040** (DecInfer-7, this lane) → **this PR** (DecInfer-1).
- **Final remaining FactorGraphHelper bare-#load sibling:** DecInfer-10 (`Thompson-Sampling`) — flagged for future lane pickup.

See #6927
See #3801