### PR TITLE
fix(decinfer-10): portable #load path (../../Infer/) for headless re-exec

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-10-Thompson-Sampling.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-10-Thompson-Sampling.ipynb
@@ -84,7 +84,7 @@
     }
    ],
    "source": [
-    "#load \"FactorGraphHelper.cs\"\n",
+    "#load \"../../Infer/FactorGraphHelper.cs\"\n",
     "Console.WriteLine(\"FactorGraphHelper charge.\");\n",
     "Console.WriteLine($\"Graphviz disponible : {FactorGraphHelper.IsGraphvizAvailable()}\");"
    ],


### PR DESCRIPTION
## Contexte

`DecInfer-10-Thompson-Sampling.ipynb` (Thompson Sampling bandits) déclare en cell[6] un bare `#load "FactorGraphHelper.cs"` qui **échoue sous re-exécution headless** : kernel CWD = notebook-dir, mais FactorGraphHelper.cs vit dans `../../Infer/FactorGraphHelper.cs` (2 niveaux au-dessus dans la hiérarchie Probas/DecisionTheory/DecInfer → Probas/Infer/).

**Série DecInfer load-portability — clôture.** Ce PR complète la série initiée par #7028 (DecInfer-4) : seul DecInfer-10 restait avec un bare-#load, après les merges successifs de #7034/#7030/#7038/#7039/#7040/#7041 dans le cycle c.656-c.657.

## Changement

```diff
-    "#load \"FactorGraphHelper.cs\"\n",
+    "#load \"../../Infer/FactorGraphHelper.cs\"\n",
```

**Surgical source-only : +1/-1, 1 fichier, 1 cellule touchée.** Toutes les autres cellules byte-equal à `origin/main` (exec_count et outputs préservés).

## Vérifications

| Gate | Statut |
|------|--------|
| Pattern canon L656-L1★ (raw strings + byte-level replace) | ✓ |
| `git diff --stat` = +1/-1 (sanity check, pas +482) | ✓ |
| `git diff` = UNIQUE ligne `#load` modifiée | ✓ |
| Other cells byte-equal (C.3-strict) | ✓ |
| JSON validity post-fix | ✓ (parsed sans erreur) |
| Single cell modified (targeted) | ✓ |
| Mirror DecInfer-1 pattern (#7041) | ✓ |

## Inventaire série DecInfer load-portability (post-c.657)

| Notebook | Status | PR | Notes |
|----------|--------|----|-------|
| DecInfer-2, DecInfer-9 | OK (Lean, no #load) | n/a | n/a |
| DecInfer-4 | MERGED | #7028 | jsboige |
| DecInfer-5 | MERGED | #7034 | jsboige |
| DecInfer-8 | MERGED | #7030 | jsboige + po-2024 |
| DecInfer-7 | MERGED | #7040 | po-2024 c.656 |
| DecInfer-1 | MERGED | #7041 | po-2024 c.656 |
| DecInfer-3 | MERGED | #7039 | jsboige |
| DecInfer-6 | MERGED | #7038 | jsboige |
| **DecInfer-10** | OPEN MERGEABLE | **ce PR** | po-2024 c.657 (closes series) |

## Références

- #6927 (EPIC SVG migration — résolu, cloture série SVG-side)
- #3801 (EPIC SOTA ledger — registres Prong-A et Prong-B)
- #7028 / #7034 / #7030 / #7038 / #7039 / #7040 / #7041 (siblings)
- L656-L1★ : raw-strings + nbformat-UNSAFE pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)