### PR TITLE
fix(prover,#6790): _parse_lean_errors skips probe scratch files (GoalExtract/SorryVerify)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
@@ -178,6 +178,19 @@ def _parse_lean_errors(raw_output) -> list:
         raw_output = "\n".join(str(item) for item in raw_output)
     errors = []
     for line in raw_output.split("\n"):
+        # Probe scratch files emit errors BY DESIGN, never a real target error
+        # (#6790 forensic, GoalExtract miscount / Pathologie 1b).  The goal-
+        # extraction probe (``_GoalExtract.lean``) forces a deliberate type
+        # mismatch via ``exact ()`` to make Lean print the current goal, and the
+        # sorry-verify probe (``_SorryVerify.lean``) is a throwaway compile unit;
+        # both live in ``lean_utils.py`` and parse their own output with a
+        # separate inline regex.  Counting their intentional errors here as
+        # target errors produced the illegible "FINAL VERIFY FAILED (0 compile
+        # errors)" signature that misled the forensic read of DEMO 62.  Skip any
+        # line naming a probe scratch file so ``_parse_lean_errors`` only ever
+        # reports errors from the module actually under proof.
+        if "_GoalExtract.lean" in line or "_SorryVerify.lean" in line:
+            continue
         # Standard positional: <file>:<line>:<col>: error: <msg>
         m = re.search(r"(\d+):(\d+): error: (.*)", line)
         if m:

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
@@ -3136,6 +3136,63 @@ def test_parse_lean_errors_catches_lake_prefix_format():
     assert {e["line"] for e in errors} == {2940, 12}, errors
 
 
+def test_parse_lean_errors_skips_goal_extract_probe_errors():
+    """GoalExtract probe errors are BY DESIGN, never target errors (#6790).
+
+    The goal-extraction probe (``_GoalExtract.lean``, emitted by
+    ``lean_utils.py``) forces a deliberate type mismatch via ``exact ()`` so
+    that Lean prints the current goal.  That intentional error must NOT be
+    counted by ``_parse_lean_errors`` as a compile error of the module under
+    proof -- doing so produced the illegible "FINAL VERIFY FAILED (0 compile
+    errors)" signature that misled the forensic read of DEMO 62 (Pathologie
+    1b / GoalExtract miscount).  The probe parses its own output with a
+    separate inline regex in ``lean_utils.py``, so filtering the probe file
+    here does not affect goal extraction."""
+    from prover.tools import _parse_lean_errors
+
+    # Probe-only output: the deliberate mismatch must be ignored -> [].
+    probe_only = (
+        "info: compiling\n"
+        "Conway/Life/_GoalExtract.lean:2973:6: error: type mismatch\n"
+        "  ()\n"
+    )
+    assert _parse_lean_errors(probe_only) == [], _parse_lean_errors(probe_only)
+
+    # Probe line mixed with a REAL target error: only the real one survives.
+    mixed = (
+        "Conway/Life/_GoalExtract.lean:2973:6: error: type mismatch\n"
+        "Conway/Life/HashlifeCorrectness.lean:2940:79: error: unsolved goals\n"
+    )
+    errors = _parse_lean_errors(mixed)
+    assert len(errors) == 1, errors
+    assert errors[0]["line"] == 2940, errors
+    assert "unsolved goals" in errors[0]["message"], errors
+
+
+def test_parse_lean_errors_skips_sorry_verify_probe_errors():
+    """The sorry-verify probe (``_SorryVerify.lean``) is a throwaway compile
+    unit whose errors are never target errors either (#6790).  Filter it the
+    same way, across every error format (lake-prefix included), so a probe
+    line can never inflate the error count of the module under proof."""
+    from prover.tools import _parse_lean_errors
+
+    # Lake-prefix form referencing the sorry-verify probe -> ignored.
+    probe = "error: Foo/_SorryVerify.lean:5:1: unexpected token\n"
+    assert _parse_lean_errors(probe) == [], _parse_lean_errors(probe)
+
+    # Module-level (no line:col) probe form -> ignored.
+    module_probe = "Foo/_SorryVerify.lean: error: cannot find file\n"
+    assert _parse_lean_errors(module_probe) == [], _parse_lean_errors(module_probe)
+
+    # A real error alongside the probe still counts.
+    raw = (
+        "Foo/_SorryVerify.lean:5:1: error: unexpected token\n"
+        "Real.lean:7:2: error: type mismatch\n"
+    )
+    errors = _parse_lean_errors(raw)
+    assert len(errors) == 1 and errors[0]["line"] == 7, errors
+
+
 def test_extract_errors_catches_lake_prefix_format_authority():
     """Grain a-2 alignment (#6790): the authoritative ``LeanVerifier.
     _extract_errors`` must catch the lake-prefix format too, keeping parity


### PR DESCRIPTION
## Summary

Root-cause fix for the **GoalExtract miscount** residual of #6790 (Pathologie 1b): the inline error parser `_parse_lean_errors` (`agent_tests/prover/tools.py`) was counting errors emitted **by design** by the prover's probe scratch files as if they were real compile errors of the module under proof.

- The goal-extraction probe (`_GoalExtract.lean`, emitted by `lean_utils.py`) forces a **deliberate** type mismatch via `exact ()` so Lean prints the current goal.
- The sorry-verify probe (`_SorryVerify.lean`) is a throwaway compile unit.

Neither is ever a target error. Counting them produced the illegible **"FINAL VERIFY FAILED (0 compile errors)"** signature that misled the forensic read of DEMO 62.

## Fix

Skip any line naming a probe scratch file at the top of the per-line loop:

```python
if "_GoalExtract.lean" in line or "_SorryVerify.lean" in line:
    continue
```

The probes parse their **own** output with a separate inline regex in `lean_utils.py`, so goal extraction is unaffected. Change is **purely additive** (+13 lines in `tools.py`, **no deletions**) — no error-format regression (standard positional / lake-prefix / module-level / line-start forms all still parse).

## Tests

+2 in `test_prover_guards.py`, next to the existing `_parse_lean_errors` forensic tests:
- `test_parse_lean_errors_skips_goal_extract_probe_errors` — probe-only output -> `[]`; probe line mixed with a real target error -> only the real one survives.
- `test_parse_lean_errors_skips_sorry_verify_probe_errors` — lake-prefix and module-level probe forms both filtered; a real error alongside the probe still counts.

Local run on ai-01: **7 parse/extract guard tests pass** (5 pre-existing + 2 new).

## Scope

Bounded, additive, pure-function change to the forensic legibility of the prover harness (#1453). **Not** a full close of #6790 — the freeze-loop bound (P2) and structural-edit metrics counting (P3) residuals remain open.

See #6790