### PR TITLE
fix(decinfer): portable SvgChartHelper #load path (../../Infer/) residual [DecInfer-6 + DecInfer-8]

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-6-Value-Information.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-6-Value-Information.ipynb
@@ -2055,7 +2055,7 @@
     }
    ],
    "source": [
-    "#load \"SvgChartHelper.cs\"\n",
+    "#load \"../../Infer/SvgChartHelper.cs\"\n",
     "\n",
     "// Visualisation graphique : EVPI en fonction de P(petrole).\n",
     "// Technique C548-L2 : SVG inline via SvgChartHelper.cs (#6942 MERGED), zero-dependance NuGet.\n",
@@ -2546,7 +2546,7 @@
     }
    ],
    "source": [
-    "#load \"SvgChartHelper.cs\"\n",
+    "#load \"../../Infer/SvgChartHelper.cs\"\n",
     "\n",
     "// Demonstration Prior -> Posterior avec Infer.NET pour le forage petrolier\n",
     "\n",
@@ -3698,7 +3698,7 @@
     }
    ],
    "source": [
-    "#load \"SvgChartHelper.cs\"\n",
+    "#load \"../../Infer/SvgChartHelper.cs\"\n",
     "\n",
     "// Visualisation : Comparaison des tests medicaux (EVSI, Cout, Efficacite)\n",
     "// Diagramme en barres comparant les metriques cles des deux tests\n",
@@ -4041,7 +4041,7 @@
     }
    ],
    "source": [
-    "#load \"SvgChartHelper.cs\"\n",
+    "#load \"../../Infer/SvgChartHelper.cs\"\n",
     "\n",
     "// Visualisation recapitulative : Comparaison VoI sur tous les exemples du notebook\n",
     "\n",

--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-8-Sequential.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-8-Sequential.ipynb
@@ -4422,7 +4422,7 @@
     }
    ],
    "source": [
-    "#load \"SvgChartHelper.cs\"\n",
+    "#load \"../../Infer/SvgChartHelper.cs\"\n",
     "\n",
     "// Belief State Updates avec Infer.NET : Maintenance Predictive\n",
     "\n",


### PR DESCRIPTION
## SvgChartHelper.cs `#load` portability residual — DecInfer-6 + DecInfer-8

**Residual from the DecInfer `#load` portability batch** (#7028–7041). That batch fixed `FactorGraphHelper.cs` everywhere, but `SvgChartHelper.cs` (technique **C548-L2 SVG inline**, #6942) was fixed **only in DecInfer-7** (#7040). `DecInfer-6` (4 occurrences) and `DecInfer-8` (1 occurrence) kept the bare `#load "SvgChartHelper.cs"` which breaks headless re-exec from the notebook CWD (the helper lives in `Probas/Infer/`, not `DecisionTheory/DecInfer/`).

### Fix

Same one-line byte-level pattern as `FactorGraphHelper`: bare → `../../Infer/`.

```
- #load "SvgChartHelper.cs"
+ #load "../../Infer/SvgChartHelper.cs"
```

5 occurrences across 2 files: `+5/−5`, **source-only edit**, existing outputs preserved.

### G.1 firsthand verification

- `SvgChartHelper.cs` confirmed at `MyIA.AI.Notebooks/Probas/Infer/SvgChartHelper.cs` (same folder as `FactorGraphHelper.cs`).
- Relative path `../../Infer/` from `Probas/DecisionTheory/DecInfer/` resolves to `Probas/Infer/` ✓ — identical to the merged DecInfer-7 fix.
- All 5 SvgChartHelper cells (DecInfer-6 cells 29/35/45/49, DecInfer-8 cell 49) have `execution_count != null`, `display_data` SVG outputs, **0 errors**. C548-L2 is **SOTA substance** (technique #6942 / #6927 SVG MIME canon), not a workaround.

### Why source-only, outputs preserved (pattern po-204 c.601, merged by ai-01)

The `#load` path change does not alter cell **semantics** — it loads the same `SvgChartHelper.cs` file (just via a portable relative path). Existing valid SVG outputs remain faithful representations. Re-exec verification is separate from the commit (po-204 c.601 lesson reinforced after the #7034 banner-leak incident). H.3 pre-commit check: 0 null-exec + empty-outputs cells.

### Scope

- 2 files, 1 feature (`SvgChartHelper` portability residual), 5 lines — well under G.4 composite thresholds.
- 0 collision: DecInfer-6 (#7038) and DecInfer-8 (#7030) are merged; #7043 = DecInfer-10 (user-active, `FactorGraphHelper` only, no SvgChartHelper).

See #6942 (C548-L2 SVG technique), #6927 (SVG MIME canon), #3801 (SOTA axe-2).

🤖 po-2023 · GLM-text no-vision