### PR TITLE
fix(gametheory-12): portable #load path (../Probas/Infer/SvgChartHelper.cs)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-12-ReputationGames-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-12-ReputationGames-Csharp.ipynb
@@ -870,7 +870,7 @@
     }
    ],
    "source": [
-    "#load \"SvgChartHelper.cs\"\n",
+    "#load \"../Probas/Infer/SvgChartHelper.cs\"\n",
     "\n",
     "#nullable enable\n",
     "using System;\n",


### PR DESCRIPTION
## What

Fixes a portable-`#load` defect in **GameTheory-12-ReputationGames-Csharp** (`GameTheory`): cell[11] used the bare `#load "SvgChartHelper.cs"` form that **fails headless re-execution** (CS1504 — `SvgChartHelper.cs` lives in `Probas/Infer/`, not `GameTheory/`). Replaced with the relative path `#load "../Probas/Infer/SvgChartHelper.cs"`. **Same defect class as the DecInfer series (#7028/#7030/#7034/#7038/#7039), cross-family (GameTheory .NET).** Hygiene fix, source-only.

## Defect (firsthand verified — BOTH directions)

`SvgChartHelper.cs` exists ONLY at `MyIA.AI.Notebooks/Probas/Infer/SvgChartHelper.cs` (single source of truth). The GameTheory notebooks live in `MyIA.AI.Notebooks/GameTheory/`. The bare `#load "SvgChartHelper.cs"` resolves relative to the kernel's working directory, which under headless re-exec (`dotnet_executor.py` l.47 `km.start_kernel(cwd=notebook_dir)`) is the **notebook's own directory** — where the helper is absent.

**Firsthand proof (this lane, .NET kernel):**

| Form | Result |
|------|--------|
| `#load "SvgChartHelper.cs"` (bare) | **CS1504** `Impossible d'ouvrir le fichier source 'SvgChartHelper.cs' -- Fichier introuvable` |
| `#load "../Probas/Infer/SvgChartHelper.cs"` (fix) | **dotnet_executor: 10/10 cells, 0 errors, 6.6s** — cell[11] resolves, ContentRoot = `GameTheory/` |

Path math (verified): from `GameTheory/`, `../Probas/Infer/` = `Probas/Infer/` where the helper lives. Identical resolution logic to the merged DecInfer twins (which use `../../Infer/` from the deeper `DecisionTheory/DecInfer/` dir).

## Fix — source-only 1-line edit (po-2024 c.600 lesson)

Source-only commit: `execution_count: 6` + `outputs` (3 entries) **unchanged**. The committed outputs are from an earlier interactive run; only the `#load` directive was non-portable. Re-execing to refresh outputs risks a `probeAddresses` banner leak (the dotnet-interactive HTML probing script with machine IPs — cf #6336) and gains nothing: the change is a path string the existing outputs don't surface. Verified resolution via a scratch copy through `dotnet_executor` (10/10, 0 errors), then discarded the re-exec'd copy — committed file is source-only.

## Gates verified firsthand

| Gate | Result |
|------|--------|
| Source-only | `git diff --stat` = **1 file, +1/-1**; new `execution_count`/`outputs` lines = **0** |
| Catalogue | **clean** |
| nbformat | `nbformat.validate()` **OK** |
| H.3 validator | OK:0, Warnings:**1**, Errors:**0** — **matches origin/main baseline** (1==1, pre-existing) |
| Resolution verified | `dotnet_executor` on scratch copy: **10/10 cells, 0 errors**; bare form = CS1504 (control) |
| Banner/path/secret leak | `git diff \| grep` probeAddresses/IPs/paths/secrets = **0** (po-2024 c.600 gotcha avoided) |
| Collision | `gh pr list --search GameTheory-12` = 0 prior `#load`-portability PR (prior PRs: #6336 probeAddresses strip, #6972 Plotly->SVG, #4800 pointers — all unrelated) |
| Verdict | **SOTA-OK** (real portable `#load` to the real helper, headless-verified; no degraded workaround) |

## Residual — broader bare-`#load` vein (RECOVERABLE-LOCAL, flagged NOT fixed)

Repo-wide scan found **33 bare `#load "X.cs"` instances**. After filtering same-directory (legit — e.g. `Probas/Infer/Infer-*.ipynb` loading `FactorGraphHelper.cs` from their own dir), the **cross-directory** cases (real bugs, same class) are:

| Family | Notebook | Helper | Cell |
|--------|----------|--------|------|
| **GameTheory** | 12-ReputationGames | SvgChartHelper | cell[11] — **THIS PR** |
| GameTheory | 15c-CooperativeGames | SvgChartHelper | cell[9], cell[23] |
| GameTheory | 17-MultiAgent-RL | SvgChartHelper | cell[18] |
| GameTheory | 4c-NashExistence | SvgChartHelper | cell[10] |
| GameTheory | 8c-CombinatorialGames | SvgChartHelper | cell[8], cell[22] |
| DecInfer | 6-Value-Information | SvgChartHelper | cell[29],[35],[45],[49] (FactorGraphHelper already FIXED) |
| DecInfer | 8-Sequential | SvgChartHelper | cell[49] |
| DecInfer | 10-Thompson-Sampling | FactorGraphHelper | cell[5] — **#7043** (po-2024, in flight) |
| ML/ML.Net | TP-prevision-ventes | Infer.NETCacheHelper | cell[14] |

Each needs the same firsthand-verified relative-path fix in its own atomic PR (G.4 one-subject-per-PR; R6 anti-monotony — not batching). Flagged here so a future lane can drain the vein cleanly. The fix recipe: (1) confirm bare form fails headless (CS1504), (2) compute relative path from notebook dir to the single helper location, (3) verify via `dotnet_executor` scratch copy, (4) source-only commit.

Sibling references: #7028/#7030/#7034/#7038/#7039 (DecInfer FactorGraphHelper fixes), #7043 (DecInfer-10 in flight).

🤖 po-2025 (GLM no-vision lane; .NET #load resolution verified firsthand via dotnet_executor — CS1504 control + 10/10 resolution — not visual QA)
