### PR TITLE
fix(gametheory-4c): portable cross-family #load path (../Probas/Infer/)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-4c-NashExistence-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-4c-NashExistence-Csharp.ipynb
@@ -578,7 +578,7 @@
     "// Chaque depart converge vers l'equilibre de Nash (0.5, 0.5) : illustration du theoreme du point fixe de Brouwer.\n",
     "// Helper canon SvgChartHelper.cs (#6942 MERGED) ; Overlay multi-series (#6958 MERGED) pour les 3 traces partageant\n",
     "// l'axe X numerique P(Heads). Remplace le rendu Plotly-CDN qui apparaissait blanc en statique (#6927).\n",
-    "#load \"SvgChartHelper.cs\"\n",
+    "#load \"../Probas/Infer/SvgChartHelper.cs\"\n",
     "\n",
     "// Trajectoire de n iterations de la dynamique de meilleure reponse depuis un point de depart.\n",
     "List<(double x, double y)> Trajectory(double[] start, int n = 50) {\n",


### PR DESCRIPTION
## Summary

`GameTheory-4c-NashExistence-Csharp.ipynb` cell[10] used `#load "SvgChartHelper.cs"` (bare). `SvgChartHelper.cs` exists **ONLY** in `Probas/Infer/` (single canonical copy, #6942), but the notebook lives in `GameTheory/` — so the bare `#load` resolves only when the kernel CWD happens to find it (interactive VS Code with a stale CWD). The repo's headless executor (`scripts/notebook_tools/dotnet_executor.py`, sets `CWD=notebook-dir`) could NOT re-exec: `CS1504 "Fichier introuvable"` at the `#load` cell.

Same **cross-family defect class** as GameTheory-12 (#7047 MERGED, po-2025), which ratified the `../Probas/Infer/` path.

## Changes

- **1 line changed** (byte-level string replace on the JSON-escaped literal, preserving exact file format).
- Source-only commit: validation re-exec was run on **SEPARATE scratch copies**; the real file's outputs were NOT re-executed and are **byte-identical to `origin/main`** (`exec_count=5`, 1 SVG output preserved).
- `cell[10]` output byte-identical (no semantic change, only the load resolution path differs).

## Validation (firsthand, po-2024)

`dotnet_executor.py` (`.net-csharp` kernel, `cwd=GameTheory/`, Infer.NET + SvgChartHelper cached):

| Variant | #load | Result |
|---------|-------|--------|
| **CONTROL** (scratch copy, bare) | `#load "SvgChartHelper.cs"` | 10/10 cells, **1 error** (CS1504 compilation error at the `#load` cell, exec_count 5) — reproduces the defect |
| **FIX** (scratch copy, relative path) | `#load "../Probas/Infer/SvgChartHelper.cs"` | 10/10 cells, **0 errors**, 6.5s — the cross-family path resolves, `SvgChartHelper.Overlay` renders |

## H.3 / integrity

- `execution_count != null` for all 10 code cells (0 null-exec). No re-exec artifacts committed.
- `git diff | grep -c probeAddresses` = **0** (no dotnet-interactive probe banner leak).
- `git diff | grep -cE 'http://[0-9a-fA-F:.]+:2048'` = **0** (no host-IP leak).
- `git diff | grep -cE '(192\.168|172\.[0-9]+\.[0-9]+)\.[0-9]+'` = **0** (no machine IP leak — validation re-exec run on throwaway scratch copies, never on the committed file).
- Diff = **1 line**, source-only (no output churn).

## Anti-regression

`cell[10]` is a semantically-equivalent `#load` (same helper, different resolution path) with unchanged output. The SVG visualization (technique C548-L2, EPIC #3801 Prong A, #6942/#6958) is preserved. No `sorry`/`pass`/`return None` regression (n/a — this is a `#load` path fix).

## Scope

- **GameTheory-4c only** (atomic, one notebook per PR — cf catalog-pr-hygiene §3 / G.4).
- **Remaining** bare `SvgChartHelper` `#load` in GameTheory: `GameTheory-8c` (cells 8,22), `GameTheory-15c` (cells 9,23), `GameTheory-17` (cell 18) — same fix, separate PRs.

See #3801

🤖 Generated with [Claude Code](https://claude.com/claude-code)