### PR TITLE
fix(gametheory): portable SvgChartHelper #load path (../Probas/Infer/) — drain 4 residuals [GT-4c/8c/15c/17]

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-15c-CooperativeGames-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-15c-CooperativeGames-Csharp.ipynb
@@ -624,7 +624,7 @@
     }
    ],
    "source": [
-    "#load \"SvgChartHelper.cs\"\n",
+    "#load \"../Probas/Infer/SvgChartHelper.cs\"\n",
     "// Visualisation Plotly des valeurs de Shapley (jeu de gants) -- technique C548-L2\n",
     "// (formatter HTML integre au kernel, zero dependence NuGet cote charting, rendu Plotly.js brut).\n",
     "using Microsoft.DotNet.Interactive.Formatting;\n",
@@ -1366,7 +1366,7 @@
     }
    ],
    "source": [
-    "#load \"SvgChartHelper.cs\"\n",
+    "#load \"../Probas/Infer/SvgChartHelper.cs\"\n",
     "// Comparaison Plotly Shapley vs Banzhaf (Mini-ONU) -- (PlotlyHtml defini en cell[9], technique C548-L2).\n",
     "// Deux indices de pouvoir : Shapley (valeur) et Banzhaf (pivots). Comparer les deux met en evidence\n",
     "// que le pouvoir reel differe du poids nominal, et que les deux indices divergent legerement.\n",

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-17-MultiAgent-RL-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-17-MultiAgent-RL-Csharp.ipynb
@@ -1001,7 +1001,7 @@
     "// NFSP chute puis plafonne (version tabulaire non stationnaire).\n",
     "// Helper canon SvgChartHelper.cs (#6942 MERGED) ; Overlay multi-series (#6958 MERGED) pour les\n",
     "// 3 courbes partageant l'axe X numerique \"iteration\". Cf #6927 / #3801.\n",
-    "#load \"SvgChartHelper.cs\"\n",
+    "#load \"../Probas/Infer/SvgChartHelper.cs\"\n",
     "\n",
     "int N = 300;\n",
     "var spC = new NaiveSelfPlay(rps, 0.3);\n",

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-4c-NashExistence-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-4c-NashExistence-Csharp.ipynb
@@ -578,7 +578,7 @@
     "// Chaque depart converge vers l'equilibre de Nash (0.5, 0.5) : illustration du theoreme du point fixe de Brouwer.\n",
     "// Helper canon SvgChartHelper.cs (#6942 MERGED) ; Overlay multi-series (#6958 MERGED) pour les 3 traces partageant\n",
     "// l'axe X numerique P(Heads). Remplace le rendu Plotly-CDN qui apparaissait blanc en statique (#6927).\n",
-    "#load \"SvgChartHelper.cs\"\n",
+    "#load \"../Probas/Infer/SvgChartHelper.cs\"\n",
     "\n",
     "// Trajectoire de n iterations de la dynamique de meilleure reponse depuis un point de depart.\n",
     "List<(double x, double y)> Trajectory(double[] start, int n = 50) {\n",

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-8c-CombinatorialGames-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-8c-CombinatorialGames-Csharp.ipynb
@@ -487,7 +487,7 @@
     }
    ],
    "source": [
-    "#load \"SvgChartHelper.cs\"\n",
+    "#load \"../Probas/Infer/SvgChartHelper.cs\"\n",
     "// Visualisation de la sequence de Grundy (valeurs G(n)) et de sa structure periodique.\n",
     "// Rendu SVG inline statique via SvgChartHelper.cs (#6942/#6927) : zero dependance, s'affiche\n",
     "// sur GitHub / nbviewer / offline. Le CDN Plotly precedent rendait BLANC en sandbox statique\n",
@@ -3706,7 +3706,7 @@
     }
    ],
    "source": [
-    "#load \"SvgChartHelper.cs\"\n",
+    "#load \"../Probas/Infer/SvgChartHelper.cs\"\n",
     "// Visualisation comparee des valeurs de Grundy (matplotlib subplots -> barres ASCII compactes).\n",
     "var gamesToCompare = new Dictionary<string, HashSet<int>>\n",
     "{\n",


### PR DESCRIPTION
## Summary

Completes the **cross-family SvgChartHelper portability drain** post-#7047 (po-2025 canonical pattern, ratified by ai-01 merge). 4 `GameTheory-*-Csharp` notebooks had a bare `#load "SvgChartHelper.cs"` — but the **only** `SvgChartHelper.cs` in the repo lives in `Probas/Infer/` (0 copy in `GameTheory/`), so the bare load breaks headless re-exec (`CS1504 file not found`) when `dotnet_executor` sets `cwd=notebook_dir`.

Fix = `#load "../Probas/Infer/SvgChartHelper.cs"` — identical to #7047 (GT-12, po-2025) and #7045 (DecInfer-6/8, po-2023).

**6 occurrences / 4 notebooks** (GT-4c:1, GT-8c:2, GT-15c:2, GT-17:1). Source-only byte-level; SVG outputs (C548-L2 inline-SVG technique #6942, `text/html` MIME) **preserved** — chart content is path-independent of the `#load` directive.

## Why now (resolves the c.582 deferral)

Deferred in my c.582 [DONE] for two reasons, **both now resolved**:
1. **R6 "2 SvgChartHelper PRs same cycle"** → c.583 is a new cycle; #7045 is merged.
2. **"Cross-family design defect"** → po-2025 #7047 established `../Probas/Infer/SvgChartHelper.cs` with firsthand `CS1504 → 0-error` verification, and ai-01 **merged it** → the design decision is made. This PR follows the ratified canonical pattern, not a rogue naive fix.

## Verification (firsthand)

- **dotnet_executor GT-4c**: `10/10 cells, 0 errors, 7.2s` (`ContentRoot=GameTheory/` — relative path resolves correctly, SvgChartHelper cell ran without CS1504). Re-exec was verification-only; GT-4c reset to source-only after (po-204 c.601 lesson — commit source-only, verify separately, avoid banner leak).
- **H.3 validator**: 4/4 PASS (40+10 cells, 0 null-exec, 0 empty-output, 0 C.1 violation).
- **0 secret/banner/IP leak** on changed lines (scanned).
- **Outputs preserved**: all 6 SvgChartHelper cells retain original `execution_count` + `display_data` SVG + 0 errors.

## Repo-wide bare-#load map (post-merge, fresh origin/main `815a5e0ea`)

This PR drains the **last** cross-directory SvgChartHelper defects:
- `Infer/FactorGraphHelper.cs` ×15 + `Infer/SvgChartHelper.cs` ×4 → **same-dir legit** (helpers co-located in `Probas/Infer/`).
- `ML/ML.Net/TP-prevision-ventes` Infer.NETCacheHelper → **same-dir legit** (helper in `ML/ML.Net/`).
- DecInfer → **DRAINED** (#7045 + #7043 + #7040 + #7041).
- GameTheory → **this PR drains the last 4** (GT-12 was #7047).

See #6927 (#6942 C548-L2 inline-SVG technique). See #3801 (SOTA axe-2 — real tool, not degraded workaround: `SvgChartHelper` is the genuine charting helper, headless-re-executable).