### PR TITLE
feat(notebook-tools,#7050): CI detector + gate for bare cross-dir `#load "X.cs"`

### DIFF
--- a/.github/workflows/bare-cross-dir-load-gate.yml
+++ b/.github/workflows/bare-cross-dir-load-gate.yml
@@ -1,0 +1,150 @@
+name: Bare cross-dir #load gate
+
+# Purpose
+# -------
+# Per-PR gate for .NET Interactive cells that carry a BARE `#load "X.cs"`
+# directive (bare filename, no path separator) whose `.cs` source is NOT
+# present in the notebook's own directory. Such a `#load` resolves ONLY when
+# the kernel's cwd already happens to contain the file; in a clean headless
+# re-exec from the notebook's directory it fails with CS1504 (source file not
+# found), the helper's `Formatter.Register` never runs, and the chart cell
+# renders BLANK. This is the SOURCE-CLASS root cause upstream of the empty
+# SVG output caught by `svg-empty-display-gate.yml` (#6971): that gate catches
+# the SYMPTOM (empty `outputs`), this one catches the CAUSE (the unresolvable
+# `#load`) at the source line, before exec.
+#
+# Root cause
+# ----------
+# The SVG inline rollout (#6927) makes dozens of .NET notebooks converge on
+# the shared `SvgChartHelper.cs`, which lives in ONE place
+# (`MyIA.AI.Notebooks/Probas/Infer/`, 0 copies elsewhere). The
+# `dotnet-interactive` kernel resolves `#load "X"` RELATIVE to the notebook's
+# directory (its real cwd at headless exec). A notebook in a DIFFERENT family
+# (e.g. `GameTheory/`) that loads the helper via a bare
+# `#load "SvgChartHelper.cs"` therefore cannot resolve it from its own
+# directory — it only rendered because the kernel happened to run from a cwd
+# that found the file. Same defect class as the DecInfer portability batch
+# (10+ merged PRs), but CROSS-FAMILY (the `.cs` lives in a different folder
+# than the notebook).
+#
+# Why this is NOT redundant with svg-empty-display-gate.yml
+# ---------------------------------------------------------
+# `svg-empty-display-gate.yml` inspects the OUTPUT (a cell with a chart
+# `display()` and `outputs == []`). It only fires AFTER a bad exec has been
+# committed, and only if the notebook was executed with the wrong cwd. This
+# gate inspects the SOURCE `#load` directive and fires DETERMINISTICALLY on
+# the unresolvable-bare-load pattern regardless of whether the notebook was
+# executed — catching the defect at its cause, one step earlier in the
+# pipeline. The two gates are COMPLEMENTARY: source-cause vs output-symptom.
+#
+# This gate runs scripts/notebook_tools/detect_bare_cross_dir_load.py in
+# --check mode on every notebook changed by the PR and FAILs if any code cell
+# carries a bare `#load "X.cs"` whose `.cs` is not in the notebook's directory.
+# The detector is deterministic and zero-FP:
+#  - Explicit-path loads (`#load "../Probas/Infer/SvgChartHelper.cs"`, any
+#    load whose target contains `/` or `\`) are NOT flagged — they carry a
+#    human's resolution intent; the recommended fix form has separators and
+#    passes by construction.
+#  - Co-located bare loads (`#load "Foo.cs"` where `Foo.cs` IS in the
+#    notebook's directory) are NOT flagged — they resolve in headless exec.
+#  - Non-source targets (`#r "nuget:..."`, `.dll`) are NOT `#load` of a
+#    source file and are out of scope.
+#
+# Absolute (not regression) semantics: on `main` the only residual bare
+# cross-dir loads are the 4 GameTheory notebooks (4c/8c/15c/17) being drained
+# by #7052 / #7049 (issue #7050). This gate is DIFF-SCOPED — it only checks
+# notebooks changed by the PR — so it does not fail unrelated PRs on the
+# pre-existing baseline; it prevents NEW bare cross-dir loads and enforces the
+# fix on the 4 residuals as they are touched.
+#
+# Fix (design-gate tranched by ai-01, issue #7050)
+# ------------------------------------------------
+# Replace the bare `#load "X.cs"` with an EXPLICIT relative path that reaches
+# the source file from the notebook's directory, e.g.
+# `#load "../Probas/Infer/SvgChartHelper.cs"` (the single SvgChartHelper.cs
+# lives in MyIA.AI.Notebooks/Probas/Infer/). Rejected alternatives: copying
+# the helper next to each notebook (4 divergent copies, DRY violation);
+# a centralised refactor (over-engineering for 4 call sites). Source-only fix
+# (the `#load` line only; execution_count/outputs unchanged — run a separate
+# verification re-exec with the notebook dir as cwd and confirm 0 errors, do
+# NOT commit it). Stop&Repair (secrets-hygiene rule 6): fix the cause +
+# re-execute, never scrub the output by hand.
+#
+# See EPIC #3801 (SOTA/portability), rollout #6927 (SVG inline fleet-wide),
+# issue #7050 (design-gate + class closure), sibling gate
+# svg-empty-display-gate.yml (#6971).
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'MyIA.AI.Notebooks/**/*.ipynb'
+      - 'scripts/notebook_tools/detect_bare_cross_dir_load.py'
+      - '.github/workflows/bare-cross-dir-load-gate.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  bare-cross-dir-load:
+    name: "No bare cross-dir #load in changed notebooks"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Gate changed notebooks
+        run: |
+          set -uo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "::notice title=Bare cross-dir #load gate::Manual dispatch — nothing to diff."
+            exit 0
+          fi
+
+          BASE="origin/${{ github.base_ref }}"
+          CHANGED=$(git diff --name-only "$BASE"...HEAD -- 'MyIA.AI.Notebooks/**/*.ipynb' || true)
+          if [ -z "$CHANGED" ]; then
+            echo "::notice title=Bare cross-dir #load gate::No notebooks changed — clean."
+            exit 0
+          fi
+
+          echo "## Bare cross-dir #load gate" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          fail=0
+          checked=0
+          while IFS= read -r nb; do
+            [ -z "$nb" ] && continue
+            # Skip notebooks deleted by the PR.
+            [ -f "$nb" ] || continue
+            checked=$((checked + 1))
+            out=$(python scripts/notebook_tools/detect_bare_cross_dir_load.py "$nb" --check 2>&1)
+            rc=$?
+            if [ "$rc" -eq 1 ]; then
+              echo "::error title=Bare cross-dir #load::$nb carries a bare \`#load \"X.cs\"\` whose source is not in the notebook's directory (breaks headless re-exec, CS1504; renders BLANK)."
+              echo "<details><summary><code>$nb</code></summary>" >> "$GITHUB_STEP_SUMMARY"
+              echo "" >> "$GITHUB_STEP_SUMMARY"
+              echo '```' >> "$GITHUB_STEP_SUMMARY"
+              echo "$out" >> "$GITHUB_STEP_SUMMARY"
+              echo '```' >> "$GITHUB_STEP_SUMMARY"
+              echo "</details>" >> "$GITHUB_STEP_SUMMARY"
+              fail=1
+            elif [ "$rc" -eq 2 ]; then
+              echo "::warning title=Bare cross-dir #load gate::$nb could not be read (rc=2); see detector log."
+            fi
+          done <<< "$CHANGED"
+
+          if [ "$fail" -ne 0 ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "FIX: replace the bare \`#load \"X.cs\"\` with an EXPLICIT relative path that reaches the source file from the notebook's directory (e.g. \`#load \"../Probas/Infer/SvgChartHelper.cs\"\` — the single SvgChartHelper.cs lives in MyIA.AI.Notebooks/Probas/Infer/). Design-gate tranched by ai-01 (issue #7050): explicit relative path is canonical (copying the helper = divergent copies / DRY violation; centralised refactor = over-engineering, both rejected). Source-only fix (the \`#load\` line; execution_count/outputs unchanged — run a separate verification re-exec with the notebook dir as cwd, confirm 0 errors, do NOT commit it). Stop&Repair: fix the cause + re-execute, never scrub the output by hand (secrets-hygiene rule 6)." >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          echo "::notice title=Bare cross-dir #load gate::Checked $checked changed notebook(s); no bare cross-dir #load."

--- a/scripts/notebook_tools/detect_bare_cross_dir_load.py
+++ b/scripts/notebook_tools/detect_bare_cross_dir_load.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+r"""Detecte un `#load "X.cs"` **bare** (nom de fichier nu, sans separateur) dont le `.cs` n'existe PAS dans le dossier du notebook.
+
+Pourquoi cet outil existe
+-------------------------
+Le rollout SVG inline (#6927) fait converger des dizaines de notebooks .NET vers
+le helper partage `SvgChartHelper.cs` (qui vit dans `MyIA.AI.Notebooks/Probas/Infer/`,
+0 copie ailleurs). Le kernel `dotnet-interactive` resout un `#load "X"` **relativement
+au dossier du notebook** (son cwd reel a l'exec headless). Donc un
+`#load "SvgChartHelper.cs"` **bare** ne resout QUE si `SvgChartHelper.cs` est
+co-localise avec le notebook. Un notebook d'une AUTRE famille (ex `GameTheory/`)
+qui charge le helper via un `#load "SvgChartHelper.cs"` bare casse en re-exec
+propre : **CS1504 -- source file not found**. Ces cellules rendent aujourd'hui
+uniquement parce que le kernel tournait avec un cwd qui trouvait le fichier ;
+en re-exec headless depuis le dossier du notebook, elles cassent silencieusement.
+
+Meme classe de defaut que le batch DecInfer/portability (`FactorGraphHelper.cs` /
+`SvgChartHelper.cs`, 10+ PR deja mergees) -- mais **cross-family** (le `.cs` vit
+dans un dossier different de celui du notebook). Le correctif canonique
+(design-gate tranche ai-01 2026-07-17, issue #7050) = **path relatif explicite**
+`#load "../Probas/Infer/SvgChartHelper.cs"` (rejete : copier le helper = 4 copies
+divergentes DRY-violation ; rejete : refactor centralise = sur-ingenierie). Ce
+gate ferme la classe et previent la regression apres que les 4 notebooks
+residuels (GameTheory-4c/8c/15c/17) auront ete corriges (#7052 / #7049).
+
+Ce que l'outil DETECTE (DETERMINISTE, zero faux-positif)
+-------------------------------------------------------
+Pour chaque cellule **code**, pour chaque directive `#load "<cible>"` :
+
+  1. La `<cible>` est **BARE** -- aucun separateur de chemin (`/` ni `\`). Un
+     chemin explicite (`../Probas/Infer/SvgChartHelper.cs`, `helpers/Foo.cs`,
+     absolu) est HORS scope : il porte l'intention de resolution d'un humain et
+     le valider entierement demanderait des hypotheses de cwd (source de FP).
+     Le correctif recommande (`../Probas/Infer/SvgChartHelper.cs`) contient des
+     separateurs -> il **PASSE** ce gate, par construction.
+  2. La `<cible>` est un fichier **source .NET** (`.cs`, `.csx`, `.fsx`) -- pas
+     un `#r "nuget:..."` (reference de package, jamais un `#load`) ni un `.dll`.
+  3. Le fichier `<dossier_du_notebook>/<cible>` **n'existe PAS** (verification
+     disque, insensible a la casse pour ne pas FP sur un notebook Windows dont
+     le fichier co-localise a une casse differente). Un `#load "Foo.cs"` bare
+     dont `Foo.cs` est **co-localise** resout parfaitement en headless -> il
+     n'est **PAS** flagge (c'est le cas legitime intra-dossier).
+
+La combinaison (bare + source .cs + absent du dossier) est la **signature exacte**
+du cross-dir load casse. **Zero faux-positif** : un `#load` bare co-localise
+resout ; un `#load` avec chemin explicite est hors scope ; un `#r`/nuget n'est
+pas un `#load`.
+
+Ce qu'il NE corrige PAS
+-----------------------
+Il DETECTE, il ne CORRIGE PAS. La correction (issue #7050, design-gate tranche) =
+remplacer `#load "SvgChartHelper.cs"` par le **path relatif explicite** qui
+atteint le helper depuis le dossier du notebook (ex `#load "../Probas/Infer/SvgChartHelper.cs"`).
+Fix **source-only** : la ligne `#load` change ; `execution_count`/`outputs`
+restent inchanges (la re-exec de verification -- `dotnet_executor` ContentRoot =
+dossier du notebook, 0 erreur -- se fait separement, PAS committee ; lecon
+banner-leak). Stop&Repair : on repare la cause + re-execute pour verifier, on ne
+scrubbe jamais la sortie a la main (secrets-hygiene regle 6).
+
+Known blind spots (hors scope par design)
+-----------------------------------------
+- **Chemin relatif explicite qui ne resout pas** (`#load "../mauvais/chemin.cs"`) :
+  hors scope. Valider qu'un chemin relatif atteint sa cible demande de connaitre
+  le cwd d'exec reel du kernel (source de FP). L'outil cible UNIQUEMENT le cas
+  bare-non-co-localise, deterministe et zero-FP.
+- **`#load` d'un `.cs` co-localise mais absent a l'exec** (fichier genere a la
+  volee) : rare ; le fichier existe sur disque au commit -> non flagge (correct).
+- **Notebooks non-.NET** : `#load` est une directive C#/F# script. Un notebook
+  Python n'en contient pas -> jamais flagge.
+
+Usage
+-----
+    python detect_bare_cross_dir_load.py NB.ipynb                 # un notebook
+    python detect_bare_cross_dir_load.py --family GameTheory      # une famille
+    python detect_bare_cross_dir_load.py                          # tous les notebooks
+    python detect_bare_cross_dir_load.py NB.ipynb --json          # sortie machine
+    python detect_bare_cross_dir_load.py NB.ipynb --check         # exit 1 si defauts (CI-ready)
+
+Exit codes
+----------
+    0 -- aucun defaut (ou mode non --check)
+    1 -- un ou plusieurs defauts (--check seulement)
+    2 -- erreur (notebook illisible, famille introuvable)
+
+Voir aussi
+----------
+- `detect_svg_empty_display.py` (#6971) -- l'AUTRE face du meme pitfall : quand
+  le `#load` du helper ne resout pas, la cellule emet un output VIDE (figure
+  blanche). Celui-ci attrape la cause a la SOURCE (le `#load` bare cross-dir) ;
+  #6971 attrape le SYMPTOME dans l'output (blanc). Complementaires.
+- `.github/workflows/bare-cross-dir-load-gate.yml` -- gate CI per-PR pour cet outil.
+- issue #7050 (design-gate tranche ai-01 : path relatif explicite canonique) --
+  la regle que cet outil encode mecaniquement + la classe qu'il ferme.
+
+See #7050 (suivi optionnel : detecteur CI de la classe #load cross-family).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# Directive #load avec une cible entre guillemets doubles (dotnet-interactive).
+# Gere le prefixe optionnel @ (`#load @"..."`). Ignore #r (reference de package/dll,
+# jamais un #load de fichier source).
+_LOAD_RE = re.compile(r'#load\s+@?"([^"]+)"')
+
+# Extensions de fichier source .NET script chargeables par #load.
+_SOURCE_EXTS = (".cs", ".csx", ".fsx")
+
+
+def _cell_source(cell: dict) -> str:
+    src = cell.get("source", "")
+    if isinstance(src, list):
+        return "".join(src)
+    return str(src)
+
+
+def _is_bare(target: str) -> bool:
+    """True si la cible est un nom de fichier nu (aucun separateur de chemin)."""
+    return "/" not in target and "\\" not in target
+
+
+def _colocated(nb_dir: Path, target: str) -> bool:
+    """True si `target` existe dans `nb_dir` (insensible a la casse -> pas de FP
+    sur un fichier co-localise a casse differente, qui resout sur le FS d'exec)."""
+    direct = nb_dir / target
+    if direct.exists():
+        return True
+    tl = target.lower()
+    try:
+        for entry in nb_dir.iterdir():
+            if entry.is_file() and entry.name.lower() == tl:
+                return True
+    except OSError:
+        pass
+    return False
+
+
+def detect_cell(cell: dict, nb_dir: Path) -> list[dict]:
+    """Retourne la liste des defauts (une entree par directive #load bare cassee)."""
+    if cell.get("cell_type") != "code":
+        return []
+    hits = []
+    src = _cell_source(cell)
+    for m in _LOAD_RE.finditer(src):
+        target = m.group(1)
+        if not target.lower().endswith(_SOURCE_EXTS):
+            continue  # pas un fichier source .NET (ex .dll) -> hors scope
+        if not _is_bare(target):
+            continue  # chemin explicite -> hors scope (assume intentionnel)
+        if _colocated(nb_dir, target):
+            continue  # co-localise -> resout en headless -> legitime
+        hits.append({
+            "target": target,
+            "directive": m.group(0),
+        })
+    return hits
+
+
+# Dossiers a ignorer (alignes sur detect_svg_empty_display.py / detect_blank_figures.py).
+SKIP_DIRS = {
+    ".lake", ".git", "__pycache__", "_archives", "archive", "_archive",
+    ".ipynb_checkpoints", ".pytest_cache", "worktrees",
+    "foundry-lib",  # lib vendored tierce, pas a nous a fixer
+}
+_OUTPUT_SUFFIX = "_output.ipynb"
+
+
+def _should_skip(rel: Path) -> bool:
+    if any(part in SKIP_DIRS for part in rel.parts):
+        return True
+    return rel.name.endswith(_OUTPUT_SUFFIX)
+
+
+def scan_notebook(path: Path) -> dict:
+    """Return a result dict for one notebook: path, kernel, hits[], error."""
+    try:
+        with open(path, encoding="utf-8") as f:
+            nb = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        return {"path": str(path), "error": str(exc), "hits": []}
+    nb_dir = path.parent
+    hits = []
+    for ci, cell in enumerate(nb.get("cells", [])):
+        for detail in detect_cell(cell, nb_dir):
+            hits.append({"cell_index": ci, **detail})
+    kernel = nb.get("metadata", {}).get("kernelspec", {}).get("name", "?")
+    return {"path": str(path), "kernel": kernel, "hits": hits, "error": None}
+
+
+def _iter_notebooks(root: Path, family: str | None):
+    base = root / "MyIA.AI.Notebooks"
+    if family:
+        base = base / family
+    if not base.exists():
+        return
+    for nb in sorted(base.rglob("*.ipynb")):
+        if _should_skip(nb.relative_to(base)):
+            continue
+        yield nb
+
+
+def _human_report(results: list[dict]) -> str:
+    total_hits = sum(len(r["hits"]) for r in results)
+    affected = [r for r in results if r["hits"]]
+    errored = [r for r in results if r.get("error")]
+    lines = [
+        f"Notebooks scanned         : {len(results)}",
+        f"Bare cross-dir #load hits : {total_hits}",
+        f"Affected notebooks        : {len(affected)}",
+        "",
+    ]
+    if not affected:
+        lines.append(
+            'No bare cross-dir `#load "X.cs"` detected (bare filename not present in '
+            "the notebook's own directory)."
+        )
+        if errored:
+            lines.append("")
+            lines.append(f"NOTE: {len(errored)} notebook(s) unreadable (see --json for details).")
+        return "\n".join(lines)
+    for r in affected:
+        short = r["path"].split("MyIA.AI.Notebooks")[-1].lstrip("\\/")
+        lines.append(f"## {short}  [{r['kernel']}]")
+        for h in r["hits"]:
+            lines.append(
+                f"  - cell [{h['cell_index']}] bare `{h['directive']}` "
+                f"-> `{h['target']}` NOT in notebook dir (breaks headless re-exec, CS1504)"
+            )
+        lines.append("")
+    lines.append(
+        'FIX: replace the bare `#load "X.cs"` with an EXPLICIT relative path that '
+        "reaches the source file from the notebook's directory "
+        '(e.g. `#load "../Probas/Infer/SvgChartHelper.cs"` -- the single '
+        "SvgChartHelper.cs lives in MyIA.AI.Notebooks/Probas/Infer/). Design-gate "
+        "tranched by ai-01 (issue #7050): explicit relative path is canonical "
+        "(copying the helper = DRY-violating divergent copies; centralised refactor "
+        "= over-engineering, both rejected). Source-only fix (the `#load` line "
+        "only; execution_count/outputs unchanged -- run a separate verification "
+        "re-exec with the notebook dir as cwd, do NOT commit it). Stop&Repair: fix "
+        "the cause + re-execute to verify, never scrub the output by hand "
+        "(secrets-hygiene rule 6)."
+    )
+    return "\n".join(lines)
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__.split("\n\n")[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("notebook", nargs="?", help="Notebook to scan (default: all pedagogical)")
+    parser.add_argument("--family", help="Top-level family under MyIA.AI.Notebooks/ (e.g. GameTheory)")
+    parser.add_argument("--root", default=".", help="Repo root (default: cwd)")
+    parser.add_argument("--json", action="store_true", help="Machine-readable JSON output")
+    parser.add_argument("--check", action="store_true", help="Exit 1 if any bare cross-dir #load (CI-ready)")
+    args = parser.parse_args(argv)
+
+    root = Path(args.root).resolve()
+    if args.notebook:
+        paths = [Path(args.notebook)]
+        if not paths[0].is_absolute():
+            paths[0] = root / paths[0]
+        if not paths[0].exists():
+            print(f"error: notebook not found: {paths[0]}", file=sys.stderr)
+            return 2
+    else:
+        paths = list(_iter_notebooks(root, args.family))
+        if args.family and not paths:
+            print(f"error: family not found: {args.family}", file=sys.stderr)
+            return 2
+
+    results = [scan_notebook(p) for p in paths]
+    total_hits = sum(len(r["hits"]) for r in results)
+
+    if args.json:
+        payload = {"notebooks_scanned": len(results), "total_hits": total_hits, "results": results}
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+    else:
+        print(_human_report(results))
+
+    if args.check and total_hits > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Objet

Ferme la classe **`#load "X.cs"` bare cross-dir** par un détecteur CI + gate per-PR — le **suivi optionnel** de #7050 (explicitement « à claim séparément — non mandaté par cette issue »).

Une cellule .NET Interactive avec un `#load "SvgChartHelper.cs"` **bare** (nom nu, sans séparateur) dont le `.cs` **n'est pas dans le dossier du notebook** ne résout QUE si le cwd du kernel contient déjà le fichier. En re-exec headless propre depuis le dossier du notebook → **CS1504** (source introuvable), `Formatter.Register` ne tourne pas, la cellule graphique rend **BLANC**. Le seul `SvgChartHelper.cs` vit dans `MyIA.AI.Notebooks/Probas/Infer/` (0 copie ailleurs) ; les notebooks d'autres familles doivent l'atteindre par **chemin relatif explicite**.

## Complémentarité (pas de redondance)

| Gate | Inspecte | Attrape |
|------|----------|---------|
| `svg-empty-display-gate.yml` (#6971) | l'**output** (`display(chart)` + `outputs == []`) | le **symptôme** (figure blanche), après un mauvais exec committé |
| **ce gate** | la **source** (`#load` bare non-résoluble) | la **cause**, déterministe, avant exec |

## Détection (déterministe, zéro faux-positif)

Une ligne de cellule code `#load "<cible>"` est flaggée ssi : `<cible>` **bare** (pas de `/` ni `\`) **ET** finit `.cs`/`.csx`/`.fsx` **ET** `<dossier_notebook>/<cible>` **absent** (scan dossier insensible à la casse, robustesse Windows).

**Hors scope par design (jamais flaggé)** :
- **chemins explicites** (`#load "../Probas/Infer/SvgChartHelper.cs"`) — le **correctif canonique** (design-gate tranché ai-01 sur #7050) passe par construction ;
- **loads bare co-localisés** (`#load "Foo.cs"` où `Foo.cs` est dans le dossier) — ils résolvent en headless ;
- `#r "nuget:..."` / `.dll` — pas un `#load` de fichier source.

## Preuves firsthand (repo-wide, Python 3.13, 930 notebooks)

- **Flagge EXACTEMENT les 4 GameTheory résiduels / 6 loads** nommés dans #7050 (GT-4c cell[10] ; GT-8c cell[8]+[22] ; GT-15c cell[9]+[23] ; GT-17 cell[18]) — en cours de drainage par #7052 / #7049.
- **0 faux-positif** sur les 18 notebooks qui `#load` le helper : formes explicites (GameTheory-12, ML-5, DecInfer-6/7/8, Search ×3, Sudoku-18, Z3-06) **et** bare co-localisés (Infer-11, Infer-12) → tous correctement **non** flaggés.
- **Exit codes** : `--check` flaggé → 1, `--check` clean → 0, notebook absent → 2 ; modes `--family` / `--json` / `--check` vérifiés.

## Gate DIFF-SCOPED

`git diff --name-only "$BASE"...HEAD` sur les notebooks changés par la PR uniquement. La baseline pré-existante (4 GT) ne fait donc **jamais** échouer une PR non liée ; le gate **empêche les nouveaux** bare cross-dir loads et **impose le fix** sur les 4 résiduels quand ils sont touchés (par #7052/#7049). Miroir de `svg-empty-display-gate.yml` (`permissions: contents: read`, ubuntu, setup-python 3.11, `workflow_dispatch` no-op, `GITHUB_STEP_SUMMARY`).

*Note : cette PR ne touche aucun notebook → sur sa propre ouverture, le gate voit `CHANGED` vide et sort proprement (0).*

## Scope

- **2 fichiers nouveaux** : `scripts/notebook_tools/detect_bare_cross_dir_load.py` (+291), `.github/workflows/bare-cross-dir-load-gate.yml` (+150).
- **0 touche** aux notebooks, au catalogue (byte-identique à `main`), au code de production.

## Suivi

`See #7050` — **suivi optionnel** (le détecteur, non mandaté par l'issue elle-même) ; les 4 fixes notebooks résiduels restent portés par #7052 / #7049. L'issue reste ouverte.
