### PR TITLE
ci(docs-link-check): drop --quiet so CI prints the broken link on failure

### DIFF
--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -17,4 +17,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Check docs/ links
-        run: python scripts/check_docs_links.py --check --quiet
+        # No --quiet: on failure, print each new broken link (source:line -> target)
+        # so the CI log is self-diagnosing. On success the output is a single summary
+        # line, so verbosity costs nothing. --quiet stays available for local/pre-commit use.
+        run: python scripts/check_docs_links.py --check


### PR DESCRIPTION
## Résumé

Le job CI `check-links` (`.github/workflows/docs-link-check.yml`) invoquait `check_docs_links.py --check --quiet`. Sous `--quiet`, le script **supprime le détail de régression** (`scripts/check_docs_links.py` L378-382) : un run en échec ne loggue que `Process completed with exit code 1`, **sans indiquer QUEL lien est cassé**.

Cette PR retire `--quiet` de l'invocation CI (le flag reste disponible pour usage local/pre-commit).

## Motivation (friction rencontrée)

En triant **#7057** (secrets-hygiene GenAI/Image), `check-links` échouait légitimement : la PR introduisait un lien relatif à mauvaise profondeur (`../../../.claude/rules/secrets-hygiene.md` au lieu de `../../../../...`). Mais le log CI ne montrait que l'exit-1 — j'ai dû **rejouer le diagnostic à la main hors-CI** (résoudre les chemins avec `test -f`) pour identifier le lien. Un log CI auto-diagnostiquant aurait donné la réponse immédiatement.

## Comportement après le fix

| Cas | Sortie |
|-----|--------|
| **Échec** (nouveau lien cassé) | `REGRESSION: N new broken link(s):` + chaque `source:line -> target` (L378-382) |
| **Succès** | 1 ligne : `OK: No new broken links. (0 pre-existing, N total)` (L386-387) |

La sortie en succès reste **une seule ligne** (pas de dump des N liens), donc la verbosité ne coûte rien ; en échec elle devient exploitable directement dans le log.

## Scope & vérif

- **1 fichier**, +4/-1 (le `run:` + un commentaire explicatif). ai-01-exclusif (`.github/workflows`, interdit aux workers).
- Aucun changement de comportement de gating : mêmes codes retour (0 = OK / seuls liens baseline, 1 = régression), même `--check`. Seule la **verbosité du log** change.
- Baseline `main` vérifiée firsthand : `python scripts/check_docs_links.py --check` → `OK: No new broken links. (0 pre-existing, 4010 total)`.

Pas de catalogue, pas de notebook, pas de Lean touché.