### PR TITLE
fix(genai-audio,security): remove hardcoded WHISPER API_KEY literal (secrets-hygiene)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/wer_validate_post_fix.py
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/wer_validate_post_fix.py
@@ -4,7 +4,13 @@ import json, os, time, re, sys
 import requests
 
 WHISPER_URL = "http://localhost:8190/v1/audio/transcriptions"
-API_KEY = "ucoQtp68sir65NNPmxP-Ef_BOKNsEebDlHTB9ytCKT_UYR6HQ7yDXF9lgR5zz6R6"
+API_KEY = os.getenv("WHISPER_API_KEY")
+if not API_KEY:
+    raise ValueError(
+        "WHISPER_API_KEY manquant (secrets-hygiene.md). "
+        "Definir dans .secrets/master.env puis python scripts/secrets/render_envs.py "
+        "+ docker compose restart whisper-api."
+    )
 THRESHOLD = 0.15
 
 script_dir = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
## ⚠️ SECURITY FIX — hardcoded API key literal on `main`

`MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/wer_validate_post_fix.py:7` carried a **complete cleartext API key** literal (64 chars), used as `Authorization: Bearer {API_KEY}` at L75 toward the local Whisper service (`localhost:8190`). **gitleaks v8.21.2 missed it** — content-based vigilance remains required ([secrets-hygiene.md](.claude/rules/secrets-hygiene.md)).

- **Finding**: po-2024 (c.611) — credit
- **Adjudicated + dispatched**: ai-01 ([SECURITY HIGH] DM msg-20260717T183026, verified firsthand via `git grep origin/main`)
- **Blast radius**: this single file on current main (1 occurrence, `git grep` confirms). The key targets `localhost:8190` (local service, not externally exposed) → external attacker gain is nil, but rotation is still required hygiene.

## Fix (minimal scope)

```python
# Before
API_KEY = "ucoQtp68...zz6R6"   # literal on main

# After
API_KEY = os.getenv("WHISPER_API_KEY")
if not API_KEY:
    raise ValueError("WHISPER_API_KEY manquant (secrets-hygiene.md). ...")
```

Per [secrets-hygiene.md](.claude/rules/secrets-hygiene.md) canon: `os.getenv("KEY")` with **no literal default** + `raise ValueError` if absent. `os` already imported (L3). `WHISPER_URL` (localhost, not a secret) untouched — minimal scope.

Diff: `+7/-1`, 1 file. Syntax checked (`ast.parse` OK), leak confirmed gone (`grep -c ucoQtp68` = 0), no new secret literal introduced.

## What this PR does NOT do (rotation — tracked separately)

The exposed value **remains in git history**. The real remediation is **rotation, not revert** (secrets-hygiene rule 5):
1. Generate a new key service-side (Whisper)
2. `.secrets/master.env` → `WHISPER_API_KEY=<new>`
3. `python scripts/secrets/render_envs.py` → `docker-configurations/services/whisper-api/.env`
4. `docker compose restart whisper-api` (env re-read at restart only)

**No `git revert`** — history keeps the secret; this clean commit removes the literal from current main.

**Rotation timing = coordinated** (not in this PR): restart impacts the NanoClaw ASR dependency on whisper-api + user is live on GenAI Audio. [ASK USER] for restart window.

## Verification

- `python -c "import ast; ast.parse(...)"` → SYNTAX OK
- `grep -c "ucoQtp68"` on fixed file → `0` (leak removed)
- No other secret literal in file (regex scan)

See ai-01 dispatch msg-20260717T183026. Security issue to be opened once GitHub GraphQL 5000/h frees up (currently 0/5000 until ~18:25Z).
