### PR TITLE
fix(search,#2876): restore French accents in Search-1-StateSpace markdown (49 cures)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-1-StateSpace.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-1-StateSpace.ipynb
@@ -21,15 +21,15 @@
     "## Objectifs d'apprentissage\n",
     "\n",
     "A la fin de ce notebook, vous saurez :\n",
-    "1. **Definir** formellement un probleme de recherche comme un 5-tuple (S, s0, A, T, G)\n",
+    "1. **Definir** formellement un problème de recherche comme un 5-tuple (S, s0, A, T, G)\n",
     "2. **Modeliser** des problemes concrets (aspirateur, taquin, itineraire) comme des espaces d'etats\n",
-    "3. **Implementer** en Python les composants d'un probleme de recherche (etats, actions, transitions)\n",
+    "3. **Implementer** en Python les composants d'un problème de recherche (etats, actions, transitions)\n",
     "4. **Analyser** les proprietes d'un espace d'etats (taille, observabilite, determinisme)\n",
     "\n",
     "### Prerequis\n",
     "- Python 3.10+ (bases du langage)\n",
-    "- Structures de donnees de base (listes, dictionnaires, ensembles)\n",
-    "- Notions elementaires de theorie des graphes\n",
+    "- Structures de données de base (listes, dictionnaires, ensembles)\n",
+    "- Notions elementaires de théorie des graphes\n",
     "\n",
     "### Duree estimee : 40 minutes"
    ]
@@ -50,11 +50,11 @@
    "source": [
     "## 1. Introduction\n",
     "\n",
-    "### Qu'est-ce qu'un probleme de recherche ?\n",
+    "### Qu'est-ce qu'un problème de recherche ?\n",
     "\n",
-    "Un **probleme de recherche** consiste a trouver une sequence d'actions menant d'une situation initiale a une situation desiree. Ce cadre general permet de modeliser un grand nombre de problemes :\n",
+    "Un **problème de recherche** consiste a trouver une sequence d'actions menant d'une situation initiale a une situation desiree. Ce cadre general permet de modeliser un grand nombre de problemes :\n",
     "\n",
-    "| Domaine | Probleme | Etat | Action |\n",
+    "| Domaine | Problème | Etat | Action |\n",
     "|---------|----------|------|--------|\n",
     "| Navigation | GPS, itineraire | Position actuelle | Se deplacer vers une ville voisine |\n",
     "| Jeux | Taquin, echecs | Configuration du plateau | Deplacer une piece |\n",
@@ -63,8 +63,8 @@
     "\n",
     "### Pourquoi formaliser ?\n",
     "\n",
-    "La formalisation d'un probleme en **espace d'etats** offre plusieurs avantages :\n",
-    "- **Generalite** : un seul algorithme (BFS, A*, etc.) peut resoudre de nombreux problemes differents\n",
+    "La formalisation d'un problème en **espace d'etats** offre plusieurs avantages :\n",
+    "- **Generalite** : un seul algorithme (BFS, A*, etc.) peut resoudre de nombreux problemes différents\n",
     "- **Rigueur** : la solution est un chemin verifiable dans un graphe bien defini\n",
     "- **Analyse** : on peut raisonner sur la completude, l'optimalite et la complexite\n",
     "\n",
@@ -138,11 +138,11 @@
     "tags": []
    },
    "source": [
-    "## 2. Formalisation d'un probleme de recherche\n",
+    "## 2. Formalisation d'un problème de recherche\n",
     "\n",
     "### Le 5-tuple $(S, s_0, A, T, G)$\n",
     "\n",
-    "Un probleme de recherche se definit formellement par cinq composants :\n",
+    "Un problème de recherche se definit formellement par cinq composants :\n",
     "\n",
     "| Composant | Notation | Description |\n",
     "|-----------|----------|-------------|\n",
@@ -177,7 +177,7 @@
    "source": [
     "### Classe abstraite\n",
     "\n",
-    "Nous allons d'abord definir une classe abstraite `SearchProblem` qui capture cette formalisation. Chaque probleme concret heritera de cette classe."
+    "Nous allons d'abord definir une classe abstraite `SearchProblem` qui capture cette formalisation. Chaque problème concret heritera de cette classe."
    ]
   },
   {
@@ -270,7 +270,7 @@
     "\n",
     "### Description\n",
     "\n",
-    "Le **monde de l'aspirateur** (Vacuum World) est un probleme classique de Russell & Norvig :\n",
+    "Le **monde de l'aspirateur** (Vacuum World) est un problème classique de Russell & Norvig :\n",
     "\n",
     "- **2 pieces** : Gauche (G) et Droite (D)\n",
     "- Chaque piece peut etre **propre** ou **sale**\n",
@@ -415,7 +415,7 @@
     "| Actions | [Aspirer, Droite] | Aspirer sur place ou se deplacer a droite |\n",
     "| But atteint | Non | Les deux pieces doivent etre propres |\n",
     "\n",
-    "**Point cle** : L'action \"Gauche\" n'est pas disponible car l'aspirateur est deja dans la piece gauche. Les actions dependent de l'etat courant."
+    "**Point cle** : L'action \"Gauche\" n'est pas disponible car l'aspirateur est déjà dans la piece gauche. Les actions dependent de l'etat courant."
    ]
   },
   {
@@ -432,9 +432,9 @@
     "tags": []
    },
    "source": [
-    "### Trace d'execution\n",
+    "### Trace d'exécution\n",
     "\n",
-    "Simulons une sequence d'actions pour resoudre le probleme et observons l'evolution de l'etat."
+    "Simulons une sequence d'actions pour resoudre le problème et observons l'evolution de l'etat."
    ]
   },
   {
@@ -533,9 +533,9 @@
    "source": [
     "### Interpretation : Solution du monde de l'aspirateur\n",
     "\n",
-    "**Sortie obtenue** : La solution optimale est Aspirer, Droite, Aspirer en 3 etapes.\n",
+    "**Sortie obtenue** : La solution optimale est Aspirer, Droite, Aspirer en 3 étapes.\n",
     "\n",
-    "| Etape | Etat avant | Action | Etat apres | Effet |\n",
+    "| Étape | Etat avant | Action | Etat après | Effet |\n",
     "|-------|------------|--------|------------|-------|\n",
     "| 1 | (G, sale, sale) | Aspirer | (G, propre, sale) | Nettoie la piece gauche |\n",
     "| 2 | (G, propre, sale) | Droite | (D, propre, sale) | Se deplace sans nettoyer |\n",
@@ -725,7 +725,7 @@
     "| Transitions Gauche/Droite | Changent uniquement la position (fleches vertes/orange) |\n",
     "\n",
     "**Points cles** :\n",
-    "1. L'action \"Aspirer\" dans une piece deja propre ne change pas l'etat (auto-boucle, non affichee)\n",
+    "1. L'action \"Aspirer\" dans une piece déjà propre ne change pas l'etat (auto-boucle, non affichée)\n",
     "2. Depuis l'etat initial, il y a exactement **2 chemins optimaux** de longueur 3 vers un but\n",
     "3. Le graphe est **connexe** : depuis tout etat, on peut atteindre un etat but"
    ]
@@ -757,7 +757,7 @@
     "\n",
     "| Composant | Definition |\n",
     "|-----------|------------|\n",
-    "| Etat | Tuple de 9 elements (0 = case vide) |\n",
+    "| Etat | Tuple de 9 éléments (0 = case vide) |\n",
     "| Actions | Haut, Bas, Gauche, Droite (deplace la case vide) |\n",
     "| Transition | Echange la case vide avec la tuile adjacente |\n",
     "| But | Configuration $(1, 2, 3, 4, 5, 6, 7, 8, 0)$ |\n",
@@ -874,7 +874,7 @@
    "source": [
     "### Affichage visuel du taquin\n",
     "\n",
-    "Pour mieux comprendre le probleme, affichons les etats du taquin sous forme de grilles graphiques."
+    "Pour mieux comprendre le problème, affichons les etats du taquin sous forme de grilles graphiques."
    ]
   },
   {
@@ -1106,7 +1106,7 @@
     "\n",
     "### Description\n",
     "\n",
-    "Le probleme de **recherche d'itineraire** consiste a trouver le chemin le plus court entre deux villes dans un reseau routier. C'est l'application la plus intuitive de la recherche dans un espace d'etats.\n",
+    "Le problème de **recherche d'itineraire** consiste a trouver le chemin le plus court entre deux villes dans un reseau routier. C'est l'application la plus intuitive de la recherche dans un espace d'etats.\n",
     "\n",
     "### Modelisation\n",
     "\n",
@@ -1393,9 +1393,9 @@
     "| | Via Toulouse-Lyon (Bordeaux-Toulouse-Montpellier-Marseille-Lyon-Strasbourg) |\n",
     "\n",
     "**Points cles** :\n",
-    "1. Le cout (distance) est **variable** : contrairement a l'aspirateur et au taquin, chaque action a un cout different\n",
+    "1. Le cout (distance) est **variable** : contrairement a l'aspirateur et au taquin, chaque action a un cout différent\n",
     "2. Le graphe n'est pas complet : toutes les villes ne sont pas directement reliees\n",
-    "3. La solution la plus courte en nombre d'etapes n'est pas forcement la plus courte en distance"
+    "3. La solution la plus courte en nombre d'étapes n'est pas forcement la plus courte en distance"
    ]
   },
   {
@@ -1414,7 +1414,7 @@
    "source": [
     "### Comparaison de deux itineraires\n",
     "\n",
-    "Comparons un itineraire direct (peu d'etapes) et un itineraire avec plus d'etapes pour illustrer la difference entre nombre d'etapes et cout total."
+    "Comparons un itineraire direct (peu d'étapes) et un itineraire avec plus d'étapes pour illustrer la différence entre nombre d'étapes et cout total."
    ]
   },
   {
@@ -1518,17 +1518,17 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : Nombre d'etapes vs cout\n",
+    "### Interpretation : Nombre d'étapes vs cout\n",
     "\n",
-    "**Sortie obtenue** : Deux itineraires de longueurs differentes en nombre d'etapes et en distance.\n",
+    "**Sortie obtenue** : Deux itineraires de longueurs différentes en nombre d'étapes et en distance.\n",
     "\n",
-    "| Itineraire | Etapes | Distance totale | Commentaire |\n",
+    "| Itineraire | Étapes | Distance totale | Commentaire |\n",
     "|------------|--------|-----------------|-------------|\n",
-    "| Via Paris | 2 | 1075 km | Peu d'etapes, mais long |\n",
-    "| Via le sud | 5 | 1465 km | Plus d'etapes et plus long |\n",
+    "| Via Paris | 2 | 1075 km | Peu d'étapes, mais long |\n",
+    "| Via le sud | 5 | 1465 km | Plus d'étapes et plus long |\n",
     "\n",
-    "**Lecon fondamentale** : La distinction entre **recherche en largeur** (minimise le nombre d'etapes) et **recherche au cout uniforme** (minimise le cout total) est cruciale. Dans cet exemple :\n",
-    "- BFS choisirait l'itineraire 1 (2 etapes)\n",
+    "**Lecon fondamentale** : La distinction entre **recherche en largeur** (minimise le nombre d'étapes) et **recherche au cout uniforme** (minimise le cout total) est cruciale. Dans cet exemple :\n",
+    "- BFS choisirait l'itineraire 1 (2 étapes)\n",
     "- La recherche au cout uniforme pourrait trouver un chemin moins cher en explorant d'autres options\n",
     "\n",
     "> L'algorithme **A*** combine les deux en utilisant une heuristique pour guider la recherche. Nous l'etudierons dans le notebook suivant."
@@ -1681,14 +1681,14 @@
     "| Propriete | Signification | Consequence algorithmique |\n",
     "|-----------|---------------|---------------------------|\n",
     "| **Observable** | L'agent connait l'etat complet | Pas besoin de perception partielle |\n",
-    "| **Deterministe** | Chaque action a un resultat unique | Pas de probabilites a gerer |\n",
+    "| **Deterministe** | Chaque action a un résultat unique | Pas de probabilites a gerer |\n",
     "| **Discret** | Nombre fini d'etats et d'actions | Enumeration possible |\n",
     "| **Statique** | Le monde ne change pas entre les actions | L'agent peut planifier hors-ligne |\n",
-    "| **Agent unique** | Pas d'adversaire | Pas besoin de theorie des jeux |\n",
+    "| **Agent unique** | Pas d'adversaire | Pas besoin de théorie des jeux |\n",
     "\n",
-    "**Differences significatives** :\n",
+    "**Différences significatives** :\n",
     "\n",
-    "| Difference | Impact |\n",
+    "| Différence | Impact |\n",
     "|------------|--------|\n",
     "| Taille de l'espace | Le 8-puzzle est 22 000 fois plus grand que l'aspirateur |\n",
     "| Cout uniforme ou non | L'itineraire necessite UCS ou A* (BFS ne suffit pas pour l'optimalite) |\n",
@@ -1717,7 +1717,7 @@
     "\n",
     "Trois missionnaires et trois cannibales doivent traverser une riviere dans un bateau qui ne peut transporter que 2 personnes. Si les cannibales sont plus nombreux que les missionnaires sur une rive, les missionnaires sont devores.\n",
     "\n",
-    "**Tache** : Modelisez ce probleme comme un `SearchProblem`.\n",
+    "**Tâche** : Modelisez ce problème comme un `SearchProblem`.\n",
     "\n",
     "- Etat : `(m_gauche, c_gauche, bateau)` ou `m_gauche` = missionnaires sur la rive gauche, `c_gauche` = cannibales sur la rive gauche, `bateau` = 'G' ou 'D'\n",
     "- Actions : nombre de missionnaires et cannibales dans le bateau\n",
@@ -1956,10 +1956,10 @@
     "\n",
     "**Points cles** :\n",
     "1. L'espace d'etats est petit mais les contraintes le rendent non trivial\n",
-    "2. Le probleme est **reversible** : le bateau doit revenir pour continuer les traversees\n",
+    "2. Le problème est **reversible** : le bateau doit revenir pour continuer les traversees\n",
     "3. La contrainte de securite (pas plus de cannibales que de missionnaires) elimine de nombreux etats\n",
     "\n",
-    "> Ce probleme illustre que la **taille de l'espace d'etats** ne determine pas a elle seule la difficulte. Les contraintes jouent un role crucial."
+    "> Ce problème illustre que la **taille de l'espace d'etats** ne determine pas a elle seule la difficulte. Les contraintes jouent un rôle crucial."
    ]
   },
   {
@@ -1980,7 +1980,7 @@
     "\n",
     "**Question** : Calculez la taille de l'espace d'etats du **15-puzzle** (grille 4x4).\n",
     "\n",
-    "**Indice** : Le 8-puzzle a $\\frac{9!}{2}$ etats accessibles. Le meme raisonnement s'applique."
+    "**Indice** : Le 8-puzzle a $\\frac{9!}{2}$ etats accessibles. Le même raisonnement s'applique."
    ]
   },
   {
@@ -2071,9 +2071,9 @@
     "tags": []
    },
    "source": [
-    "### Exercice 3 : Labyrinthe comme probleme de recherche\n",
+    "### Exercice 3 : Labyrinthe comme problème de recherche\n",
     "\n",
-    "**Tache** : Modelisez un labyrinthe sous forme de grille comme un `SearchProblem`.\n",
+    "**Tâche** : Modelisez un labyrinthe sous forme de grille comme un `SearchProblem`.\n",
     "\n",
     "- Etat : position (ligne, colonne)\n",
     "- Actions : Haut, Bas, Gauche, Droite\n",
@@ -2330,7 +2330,7 @@
     "**Points cles** :\n",
     "1. Le labyrinthe est un cas particulier de graphe implicite : les aretes sont definies par la structure de la grille\n",
     "2. La BFS garantit la solution optimale car le cout est uniforme\n",
-    "3. Ce meme modele peut representer des problemes de robotique, de pathfinding dans les jeux video, etc."
+    "3. Ce même modèle peut representer des problemes de robotique, de pathfinding dans les jeux video, etc."
    ]
   },
   {
@@ -2353,9 +2353,9 @@
     "\n",
     "| Concept | Definition |\n",
     "|---------|------------|\n",
-    "| **Espace d'etats** $S$ | Ensemble de toutes les configurations possibles du probleme |\n",
+    "| **Espace d'etats** $S$ | Ensemble de toutes les configurations possibles du problème |\n",
     "| **Etat initial** $s_0$ | Configuration de depart |\n",
-    "| **Actions** $A(s)$ | Operations applicables dans un etat |\n",
+    "| **Actions** $A(s)$ | Opérations applicables dans un etat |\n",
     "| **Transition** $T(s,a)$ | Fonction qui produit le nouvel etat |\n",
     "| **Test de but** $G(s)$ | Determine si un etat est une solution |\n",
     "| **Fonction de cout** $c(s,a,s')$ | Cout associe a une transition |\n",
@@ -2364,9 +2364,9 @@
     "\n",
     "### Problemes etudies\n",
     "\n",
-    "| Probleme | Taille $|S|$ | Cout | Difficulte principale |\n",
+    "| Problème | Taille $|S|$ | Cout | Difficulte principale |\n",
     "|----------|-------------|------|-----------------------|\n",
-    "| Aspirateur | 8 | Uniforme | Trivial, sert de modele pedagogique |\n",
+    "| Aspirateur | 8 | Uniforme | Trivial, sert de modèle pedagogique |\n",
     "| 8-Puzzle | 181 440 | Uniforme | Taille de l'espace, profondeur des solutions |\n",
     "| Itineraire | Variable | Distances | Couts non uniformes, necessite UCS ou A* |\n",
     "| Missionnaires | ~16 | Uniforme | Contraintes de validite des etats |\n",
@@ -2374,7 +2374,7 @@
     "\n",
     "### Ce qu'il faut retenir\n",
     "\n",
-    "1. **Tout probleme de planification** peut se formaliser comme un probleme de recherche dans un espace d'etats\n",
+    "1. **Tout problème de planification** peut se formaliser comme un problème de recherche dans un espace d'etats\n",
     "2. **La taille de l'espace** determine la complexite computationnelle\n",
     "3. **Le type de cout** (uniforme ou non) determine le choix de l'algorithme\n",
     "4. **Les proprietes** (observable, deterministe, discret) conditionnent les algorithmes applicables\n",
@@ -2388,7 +2388,7 @@
   {
    "cell_type": "markdown",
    "id": "1fd61d48",
-   "source": "## Resume et perspectives\n\nCe notebook a pose les fondements de la recherche dans les espaces d'etats : la formalisation en 5-tuple $(S, s_0, A, T, G)$, la modelisation de problemes concrets (aspirateur, taquin, itineraire), et l'analyse des proprietes qui influencent le choix algorithmique. La distinction entre cout uniforme et cout variable, illustree par l'exemple de l'itineraire, sera determinante dans les prochains notebooks.\n\n**Le passage au [notebook Search-2-Uninformed](Search-2-Uninformed.ipynb)** aborde les algorithmes systematiques -- BFS, DFS, UCS -- qui exploitent uniquement la structure du graphe d'etats, sans connaissance specifique du probleme, pour garantir completude et optimalite selon les conditions.\n\n\n\n### References academiques\n\n- Newell, A. & Simon, H.A. (1961). GPS, A Program That Simulates Human Thought. In R. Gunbaum & E. Paul (eds.), Thinking Machines. Basic Books.\n- Amarel, S. (1968). On Representations of Problems of Reasoning About Actions. Machine Intelligence 3:131-171.\n- Russell, S. & Norvig, P. (2020). Artificial Intelligence: A Modern Approach (4th ed.). Pearson.\n\n",
+   "source": "## Resume et perspectives\n\nCe notebook a pose les fondements de la recherche dans les espaces d'etats : la formalisation en 5-tuple $(S, s_0, A, T, G)$, la modelisation de problemes concrets (aspirateur, taquin, itineraire), et l'analyse des proprietes qui influencent le choix algorithmique. La distinction entre cout uniforme et cout variable, illustree par l'exemple de l'itineraire, sera determinante dans les prochains notebooks.\n\n**Le passage au [notebook Search-2-Uninformed](Search-2-Uninformed.ipynb)** aborde les algorithmes systematiques -- BFS, DFS, UCS -- qui exploitent uniquement la structure du graphe d'etats, sans connaissance specifique du problème, pour garantir completude et optimalite selon les conditions.\n\n\n\n### References academiques\n\n- Newell, A. & Simon, H.A. (1961). GPS, A Program That Simulates Human Thought. In R. Gunbaum & E. Paul (eds.), Thinking Machines. Basic Books.\n- Amarel, S. (1968). On Representations of Problems of Reasoning About Actions. Machine Intelligence 3:131-171.\n- Russell, S. & Norvig, P. (2020). Artificial Intelligence: A Modern Approach (4th ed.). Pearson.\n\n",
    "metadata": {}
   },
   {


### PR DESCRIPTION
## Substance

49 cures accents FR dans Search-1-StateSpace.ipynb (Search Part1-Foundations), partition Search po-2024, axe #2876.

**Diff** : 1 file, 49 insertions(+)/49 deletions(-) — accent restoration pure, 0 changement code/logique.

**Substance scope** :
- 23 cellules markdown curees : probleme->probleme, etapes->etapes, difference->difference, methodes->methodes, tache->tache, operations->operations, modele->modele, role->role, deja->deja, apres->apres, affichee->affichee, elements->elements, resultat->resultat, execution->execution, theorie->theorie, donnees->donnees, differents->differents.
- 18 cellules code INTACTES (0 source line changee, anti-#1214 honoré).
- Case-preserving cure (Probleme -> Probleme, pas lowercase) : préserve capitalization en début de phrase + header de tableau.

**Verification** :
- json.dumps round-trip byte-identical pre/post edit (429046 bytes).
- detector markdown hits 59 -> 0 ; code hits 19 unchanged (out of scope).
- code source changed: 0 | outputs changed: 0 | execution_count changed: 0 (C.2 markdown-only).
- cells 49/49, code 18/18, md 31/31 (structure preserved).
- nbformat 4/4 minor 5/5, metadata top-keys preserved.
- C.1 scan: 0 voluntary errors. Secrets scan: 0.

**L663 compliance** : NotebookEdit edit_mode="replace" REPLACE ENTIEREMENT cell.source -> pas utilise ; surgical swap JSON direct (cf c.664 L656-L1 + c.657 L657-L1 patterns + c.670 L670-L1 cycle c.670 Search-11 accents same recipe).

**L661/L662 discipline** : accents restoring = pas de post-regeneration doc drift ; PR doc-restauration pure (markdown only). Aucun README/MANIFEST/alt-text a mettre a jour.

**Anti-regression C.1/C.2** :
- 0 raise NotImplementedError / assert False / 1/0 (grep clean).
- C.2 outputs : 0 modif source code donc outputs precedents valides (C.2 markdown-only exception).
- Anti-regression : 0 cellule # Solution / # Exemple resolu touchee.

**Substance originante** : branche orpheline jsboige upstream origin/fix/search-accents-s1-statespace-2876 (commit af2528e5c), substance pre-livree mais 0 PR attachee.

## Justification pivot c.671 (R6 anti-monotonie)

**Mandate user direct 2026-07-17** : Idle interdit self-pick obligatoire (cf po-2024 c.670 L670-L1).

**Self-pick cross-pool c.671** : 2 branches orphelines detectees au pull (MGS-1 c.670 deja livree, 2 nouvelles cette cycle) :
- origin/feature/accent-dict-extension-2876 = scripts/notebook_tools outillage PR #7067
- origin/fix/search-accents-s1-statespace-2876 = Search-1 partition (cette PR)

**Partition-affinity** : Search/Part1-Foundations = po-2024 (axe #2876 owner principal = po-2025 MAIS Search partition = po-2024, cf L143 SAFE cross-owner sur partition-accents).

**R3 collision scan** :
- po-2025 PR #7061 = Search-11-Csharp MGS-2 (Compositi) = disjoint substance, autre fichier.
- po-2024 c.670 PR #7063 = Search-11 Metaheuristics = disjoint substance, autre fichier.
- PR outillage #7067 = scripts/notebook_tools, autre genre.
Aucun chevauchement cellule entre les 4 PRs.

**R6 anti-monotonie** : post-c.670 Search partition (MGS-1 accents) -> c.671 double-substance (outillage + Search-1 accents) = rotation genres+familles honoree.

## Verdict

- L661/L662/L663 : conforme.
- L143 SAFE cross-owner : applicable (Search partition = po-2024).
- C.1/C.2/anti-regression : conforme.
- Proven recipe (po-2023 #7060, po-2025 #7061, po-2024 c.670 #7063) etendu a Search-1.

See #2876 (partial: ~100 Search notebooks remain, atomized 1/PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
