### PR TITLE
fix(translation,#4957): resync probas-decinfer CSV drift after DecInfer .NET merges (T2)

### DIFF
--- a/translations/probas-decinfer/probas_decinfer.csv
+++ b/translations/probas-decinfer/probas_decinfer.csv
@@ -90,11 +90,11 @@ using Microsoft.ML.Probabilistic.Algorithms;
 
 Console.WriteLine(""Infer.NET charge pour Decision Theory !"");",,,,,,,,76a08ccd57dfbcbc,,,,,,,
 MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-1-Utility-Foundations.ipynb,cda519cf,markdown,fr,0d35df980368841a,Chargement du helper de visualisation des graphes de facteurs.,,,,,,,,0d35df980368841a,,,,,,,
-MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-1-Utility-Foundations.ipynb,878ff30c,code,fr,9bc484403a7944cd,"// Chargement du helper pour visualiser les factor graphs
-#load ""FactorGraphHelper.cs""
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-1-Utility-Foundations.ipynb,878ff30c,code,fr,bd005494504ce7c5,"// Chargement du helper pour visualiser les factor graphs
+#load ""../../Infer/FactorGraphHelper.cs""
 
 Console.WriteLine(""FactorGraphHelper charge."");
-Console.WriteLine($""Graphviz disponible : {FactorGraphHelper.IsGraphvizAvailable()}"");",,,,,,,,9bc484403a7944cd,,,,,,,
+Console.WriteLine($""Graphviz disponible : {FactorGraphHelper.IsGraphvizAvailable()}"");",,,,,,,,bd005494504ce7c5,,,,,,,
 MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-1-Utility-Foundations.ipynb,14ebe53a,markdown,fr,057f4d09c239871e,"### Implementation de la classe Loterie
 
 Nous definissons une classe generique `Loterie<T>` qui encapsule une distribution discrete sur des outcomes de type T. Cette implementation :
@@ -1024,8 +1024,8 @@ using Microsoft.ML.Probabilistic.Algorithms;
 
 Console.WriteLine(""Infer.NET charge !"");",,,,,,,,0592ef57ae439bbd,,,,,,,
 MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-3-Utility-Money.ipynb,430a1ea4,markdown,fr,9e745e97dd58c436,Chargement des utilitaires de visualisation des graphes de facteurs.,,,,,,,,9e745e97dd58c436,,,,,,,
-MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-3-Utility-Money.ipynb,d7b26cdd,code,fr,2b43e45bc33cd44d,"// Chargement du helper pour les visualisations de factor graphs
-#load ""FactorGraphHelper.cs""
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-3-Utility-Money.ipynb,d7b26cdd,code,fr,b2ac44f384e542a5,"// Chargement du helper pour les visualisations de factor graphs
+#load ""../../Infer/FactorGraphHelper.cs""
 
 // NOTE: Les visualisations Plotly ont ete remplacees par des sorties console
 // pour assurer la compatibilite avec toutes les versions de .NET Interactive.
@@ -1033,7 +1033,7 @@ MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-3-Utility-Money.ipynb,
 
 Console.WriteLine(""FactorGraphHelper charge !"");
 Console.WriteLine(""Note : Les graphiques ont ete remplaces par des tableaux console."");
-",,,,,,,,2b43e45bc33cd44d,,,,,,,
+",,,,,,,,b2ac44f384e542a5,,,,,,,
 MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-3-Utility-Money.ipynb,1340bb63,markdown,fr,bb8a352d84d6f0d6,"### Simulation du paradoxe
 
 Verifions empiriquement les predictions de Bernoulli avec une simulation Monte Carlo. Le code ci-dessous :
@@ -2209,11 +2209,12 @@ using Microsoft.ML.Probabilistic.Algorithms;
 
 Console.WriteLine(""Infer.NET charge !"");",,,,,,,,0592ef57ae439bbd,,,,,,,
 MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-4-Multi-Attribute.ipynb,f6fea224,markdown,fr,9e745e97dd58c436,Chargement des utilitaires de visualisation des graphes de facteurs.,,,,,,,,9e745e97dd58c436,,,,,,,
-MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-4-Multi-Attribute.ipynb,6c990e0f,code,fr,9eba9b206e87e583,"// Chargement du helper pour visualisation des graphes de facteurs
-#load ""FactorGraphHelper.cs""
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-4-Multi-Attribute.ipynb,6c990e0f,code,fr,a8985c0cf04f42bd,"// Chargement du helper pour visualisation des graphes de facteurs
+// (FactorGraphHelper.cs vit dans Probas/Infer/ ; chemin relatif ../../Infer pour re-exec headless CWD=notebook-dir.)
+#load ""../../Infer/FactorGraphHelper.cs""
 
 Console.WriteLine(""FactorGraphHelper charge !"");
-Console.WriteLine($""Graphviz disponible : {FactorGraphHelper.IsGraphvizAvailable()}"");",,,,,,,,9eba9b206e87e583,,,,,,,
+Console.WriteLine($""Graphviz disponible : {FactorGraphHelper.IsGraphvizAvailable()}"");",,,,,,,,a8985c0cf04f42bd,,,,,,,
 MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-4-Multi-Attribute.ipynb,0888c796,markdown,fr,797d3c1edd6921c4,"### Configuration Infer.NET effectuee
 
 Le message ""Infer.NET charge !"" confirme que les packages NuGet sont correctement installes. Nous disposons maintenant de :
@@ -2351,14 +2352,6 @@ Ou :
 1. Pour chaque attribut, definir vi(xi) : [xi_min, xi_max] -> [0, 1]
 2. Determiner les poids wi par comparaison des ""swings""
 3. Calculer V(.) pour chaque alternative",,,,,,,,97bcada580ead3e2,,,,,,,
-MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-4-Multi-Attribute.ipynb,20467e54,code,fr,77e7ba4749c28f50,"// Installation Plotly.NET pour les visualisations
-#r ""nuget: Plotly.NET.Interactive, 5.0.0""
-using Plotly.NET;
-using Plotly.NET.LayoutObjects;
-using Plotly.NET.TraceObjects;
-using Microsoft.FSharp.Core;
-
-Console.WriteLine(""Plotly.NET charge pour les visualisations interactives !"");",,,,,,,,77e7ba4749c28f50,,,,,,,
 MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-4-Multi-Attribute.ipynb,e43bdd61,markdown,fr,a77e91e47cf61317,Implementation du modele de decision multi-attributs avec la forme additive.,,,,,,,,a77e91e47cf61317,,,,,,,
 MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-4-Multi-Attribute.ipynb,77e722ba,code,fr,a1f425fbddeebb5e,"// Implementation de la forme additive
 
@@ -3487,14 +3480,14 @@ using Microsoft.ML.Probabilistic.Algorithms;
 
 Console.WriteLine(""Infer.NET charge !"");",,,,,,,,0592ef57ae439bbd,,,,,,,
 MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-5-Decision-Networks.ipynb,3cc4d2cc,markdown,fr,0d35df980368841a,Chargement du helper de visualisation des graphes de facteurs.,,,,,,,,0d35df980368841a,,,,,,,
-MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-5-Decision-Networks.ipynb,db6810cf,code,fr,57f0461aa42a4585,"// Chargement du helper pour visualiser les factor graphs inline
-#load ""FactorGraphHelper.cs""
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-5-Decision-Networks.ipynb,db6810cf,code,fr,221efc0628942033,"// Chargement du helper pour visualiser les factor graphs inline
+#load ""../../Infer/FactorGraphHelper.cs""
 
 // Verification de la disponibilite de Graphviz
 if (FactorGraphHelper.IsGraphvizAvailable())
     Console.WriteLine(""Graphviz disponible - les factor graphs seront affiches en SVG inline"");
 else
-    Console.WriteLine(""Graphviz non installe - les factor graphs seront disponibles en fichiers .gv"");",,,,,,,,57f0461aa42a4585,,,,,,,
+    Console.WriteLine(""Graphviz non installe - les factor graphs seront disponibles en fichiers .gv"");",,,,,,,,221efc0628942033,,,,,,,
 MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-5-Decision-Networks.ipynb,f59d5400,markdown,fr,7c0ab61d05a31509,"## 2. Types de Noeuds
 
 Les reseaux de decision utilisent une notation graphique standardisee (Howard, 1984) qui distingue clairement les differents types de noeuds. Cette convention visuelle permet de lire immediatement la structure du probleme decisionnel.
@@ -4759,13 +4752,13 @@ using Microsoft.ML.Probabilistic.Algorithms;
 
 Console.WriteLine(""Infer.NET charge !"");",,,,,,,,0592ef57ae439bbd,,,,,,,
 MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-6-Value-Information.ipynb,7c66bec4,markdown,fr,0d35df980368841a,Chargement du helper de visualisation des graphes de facteurs.,,,,,,,,0d35df980368841a,,,,,,,
-MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-6-Value-Information.ipynb,13a6ec35,code,fr,8512de1e8d84e98a,"// Chargement du helper pour visualiser les factor graphs Infer.NET
-#load ""FactorGraphHelper.cs""
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-6-Value-Information.ipynb,13a6ec35,code,fr,05869e3223dcfdf6,"// Chargement du helper pour visualiser les factor graphs Infer.NET
+#load ""../../Infer/FactorGraphHelper.cs""
 
 // Active la generation des factor graphs pour les modeles Infer.NET
 bool ShowFactorGraph = true;
 
-Console.WriteLine(""FactorGraphHelper charge - ShowFactorGraph = "" + ShowFactorGraph);",,,,,,,,8512de1e8d84e98a,,,,,,,
+Console.WriteLine(""FactorGraphHelper charge - ShowFactorGraph = "" + ShowFactorGraph);",,,,,,,,05869e3223dcfdf6,,,,,,,
 MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-6-Value-Information.ipynb,25b2f59b,markdown,fr,866e0ade75d8d519,"### Environnement charge
 
 Infer.NET est maintenant disponible pour :
@@ -5381,17 +5374,13 @@ Le tableau ci-dessus revele un phenomene fondamental en theorie de la decision :
 **L'EVPI est maximal autour de P = 35-40%** car c'est la que l'incertitude a le plus d'impact sur la decision. Loin de ce seuil, la decision est ""robuste"" et l'information a moins de valeur.
 
 Cette propriete est generale : **la valeur de l'information est maximale quand la decision est marginale**.",,,,,,,,a78c0dc8d9c03dea,,,,,,,
-MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-6-Value-Information.ipynb,7d7e2b8e,code,fr,adfb8aed7646141f,"// Outil de visualisation : rendu Plotly.js via le formatter HTML integre du kernel.
-// (Zero `#r ""nuget:""` sur une charting-lib : les charting libs pinent une vieille beta
-//  de Microsoft.DotNet.Interactive et font timeout le restore, cluster-wide. Le formatter
-//  ci-dessous emet du HTML Plotly brut, sans dependence. Cf #3801 / C548-L2.)
-using Microsoft.DotNet.Interactive.Formatting;
-using System.IO;
-record PlotlyHtml(string Markup);
-Formatter.Register(typeof(PlotlyHtml),
-    (obj, writer) => ((TextWriter)writer).Write(((PlotlyHtml)obj).Markup), ""text/html"");
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-6-Value-Information.ipynb,7d7e2b8e,code,fr,075e12afda2d190e,"#load ""../../Infer/SvgChartHelper.cs""
 
 // Visualisation graphique : EVPI en fonction de P(petrole).
+// Technique C548-L2 : SVG inline via SvgChartHelper.cs (#6942 MERGED), zero-dependance NuGet.
+// Le CDN Plotly precedent rendait BLANC en static (GitHub sandbox les <script src=cdn.plot.ly>).
+// Cf #6927 / #3801 / #6942 / See #6954 (App-7b modele).
+
 // Calcul des valeurs EVPI pour differentes probabilites.
 var evpiValues = new List<(double p, double evpi, string decision)>();
 for (double p = 0.05; p <= 0.95; p += 0.05)
@@ -5408,41 +5397,16 @@ for (double p = 0.05; p <= 0.95; p += 0.05)
 }
 double maxEvpi = evpiValues.Max(x => x.evpi);
 
-// Trace bar : EVPI vs P(petrole), colore par decision optimale (Forer vs Vendre).
-var xP = evpiValues.Select(v => v.p).ToArray();
-var yEvpi = evpiValues.Select(v => v.evpi).ToArray();
-var barColors = evpiValues.Select(v => v.decision == ""F"" ? ""#4C72B0"" : ""#DD8452"").ToArray();
-var barTrace = new Dictionary<string, object> {
-    [""name""] = ""EVPI"", [""x""] = xP, [""y""] = yEvpi, [""type""] = ""bar"",
-    [""marker""] = new { color = barColors } };
-string barJson = System.Text.Json.JsonSerializer.Serialize(barTrace);
+// Bar chart SVG inline : EVPI vs P(petrole). Couleur uniforme (palette canon C548-L2).
+// Le decodage F=Forer / V=Vendre par barre est preserve via la legende textuelle ci-dessous.
+var xLabels29 = evpiValues.Select(v => (v.p * 100).ToString(""F0"") + ""%"").ToArray();
+var yEvpi29 = evpiValues.Select(v => v.evpi).ToArray();
+display(SvgChartHelper.Bar(""Profil de l'EVPI selon P(petrole)"", xLabels29, yEvpi29));
 
-// Ligne verticale au seuil de basculement de la decision.
-double seuil = 0.35;  // Calcule precedemment
-string vline = ""{\""type\"":\""line\"",\""x0\"":"" + seuil + "",\""x1\"":"" + seuil +
-               "",\""y0\"":0,\""y1\"":1,\""yref\"":\""paper\"","" +
-               ""\""line\"":{\""color\"":\""#C44E52\"",\""width\"":1.5,\""dash\"":\""dash\""}}"";
-
-var layout = ""{\""title\"":{\""text\"":\""Profil de l'EVPI selon P(petrole)\""},"" +
-             ""\""xaxis\"":{\""title\"":{\""text\"":\""P(petrole)\""},\""tickformat\"":\""0%\""},"" +
-             ""\""yaxis\"":{\""title\"":{\""text\"":\""EVPI (EUR)\""}},"" +
-             ""\""shapes\"":["" + vline + ""],"" +
-             ""\""annotations\"":["" +
-             ""{\""x\"":"" + seuil + "",\""y\"":1,\""yref\"":\""paper\"",\""text\"":\""seuil Forer/Vendre (P=35%)\"","" +
-               ""\""showarrow\"":false,\""xanchor\"":\""left\"",\""font\"":{\""color\"":\""#C44E52\"",\""size\"":10}},"" +
-             ""{\""x\"":0.96,\""y\"":0.95,\""yref\"":\""paper\"",\""text\"":\""bleu=Forer optimal, orange=Vendre optimal\"","" +
-               ""\""showarrow\"":false,\""xanchor\"":\""right\"",\""font\"":{\""size\"":9}}"" +
-             ""]}"";
-var divId = ""plt"" + Guid.NewGuid().ToString(""N"");
-var markup = ""<div id=\"""" + divId + ""\""></div>"" +
-             ""<script src=\""https://cdn.plot.ly/plotly-2.35.2.min.js\""></script>"" +
-             ""<script>Plotly.newPlot('"" + divId + ""',["" + barJson + ""],"" + layout + "")</script>"";
-display(new PlotlyHtml(markup));
-
-Console.WriteLine($""Seuil de basculement (Forer/Vendre) : P = {seuil:P0}"");
+Console.WriteLine($""Seuil de basculement (Forer/Vendre) : P = 35%"");
 Console.WriteLine(""EVPI maximal autour de P = 35-40% ou la decision est marginale :"");
 Console.WriteLine(""l'information parfaite vaut le plus quand l'incertitude change la decision."");
-",,,,,,,,adfb8aed7646141f,,,,,,,
+",,,,,,,,075e12afda2d190e,,,,,,,
 MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-6-Value-Information.ipynb,b4c078a6,markdown,fr,caabf1a59ab46d3c,"### Transition vers l'implementation generique
 
 Apres avoir vu les calculs manuels, nous allons maintenant construire un **calculateur generique** reutilisable pour n'importe quel probleme de decision sous incertitude.",,,,,,,,caabf1a59ab46d3c,,,,,,,
@@ -5563,7 +5527,9 @@ MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-6-Value-Information.ip
 Cette section illustre **visuellement** comment l'observation d'un signal met a jour nos croyances et change potentiellement notre decision.
 
 L'inference bayesienne d'Infer.NET calcule automatiquement les posterieurs, eliminant les calculs manuels de Bayes.",,,,,,,,59018cfcca0ed51e,,,,,,,
-MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-6-Value-Information.ipynb,78936704,code,fr,a88dfafc4cfc19a0,"// Demonstration Prior -> Posterior avec Infer.NET pour le forage petrolier
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-6-Value-Information.ipynb,78936704,code,fr,b69d470c2d19df89,"#load ""../../Infer/SvgChartHelper.cs""
+
+// Demonstration Prior -> Posterior avec Infer.NET pour le forage petrolier
 
 // Modele generatif avec Infer.NET
 Variable<bool> petrole = Variable.Bernoulli(0.3).Named(""petrole"");
@@ -5623,27 +5589,14 @@ Console.WriteLine($""   Impact : {p_neg - p_prior:P1} de confiance\n"");
 Console.WriteLine(""=== Visualisation de l'Impact de l'Information ==="");
 Console.WriteLine();
 {
-    var labs = new object[] { ""Prior"", ""Posterior T+ (FORER)"", ""Posterior T- (VENDRE)"" };
-    var probs = new object[] { p_prior, p_pos, p_neg };
-    var colors = new object[] { ""#9aa0a6"", ""#2a6dba"", ""#e8743b"" };
-    var divId = ""plt"" + Guid.NewGuid().ToString(""N"");
-    var trace = System.Text.Json.JsonSerializer.Serialize(
-        new Dictionary<string, object> { [""x""] = labs, [""y""] = probs, [""type""] = ""bar"",
-                                         [""marker""] = new Dictionary<string,object>{ [""color""] = colors },
-                                         [""text""] = probs.Select(v => ((double)v).ToString(""P0"")).ToArray(),
-                                         [""textposition""] = ""auto"" });
-    var layout = ""{\""title\"":{\""text\"":\""Impact du test sismique : P(petrole) prior vs posteriors\""},"" +
-                 ""\""yaxis\"":{\""title\"":{\""text\"":\""P(petrole)\""},\""range\"":[0,1],\""tickformat\"":\"".0%\""},"" +
-                 ""\""xaxis\"":{\""title\"":{\""text\"":\""Croyance\""}},"" +
-                 ""\""margin\"":{\""l\"":50,\""r\"":30,\""b\"":60}}"";
-    var markup = ""<div id=\"""" + divId + ""\""></div>"" +
-                 ""<script src=\""https://cdn.plot.ly/plotly-2.35.2.min.js\""></script>"" +
-                 ""<script>Plotly.newPlot('"" + divId + ""',["" + trace + ""],"" + layout + "")</script>"";
-    display(new PlotlyHtml(markup));
+    var pLabels35 = new[] { ""Prior"", ""Posterior T+ (FORER)"", ""Posterior T- (VENDRE)"" };
+    var pValues35 = new double[] { p_prior, p_pos, p_neg };
+    display(SvgChartHelper.Bar(""Impact du test sismique : P(petrole) prior vs posteriors"", pLabels35, pValues35));
 }
 
 Console.WriteLine();
-Console.WriteLine(""=> Le test change la decision : c'est pourquoi il a de la valeur !"");",,,,,,,,a88dfafc4cfc19a0,,,,,,,
+Console.WriteLine(""=> Le test change la decision : c'est pourquoi il a de la valeur !"");
+",,,,,,,,b69d470c2d19df89,,,,,,,
 MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-6-Value-Information.ipynb,62e9cae9,markdown,fr,bfec5dd5eae5a8e8,"### Visualisation du Factor Graph
 
 Le factor graph ci-dessous illustre la **structure** du modele bayesien utilise pour l'inference.
@@ -5968,7 +5921,9 @@ L'IRM est **plus informative** (77% vs 44%) mais son cout eleve (500 EUR) depass
 - L'IRM ne serait justifiee que si son cout baissait a moins de 273 EUR
 
 > **Lecon pratique** : En medecine comme ailleurs, le test le plus precis n'est pas toujours le meilleur choix. Le ratio cout/benefice doit guider la decision.",,,,,,,,dfdbde0718e707c2,,,,,,,
-MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-6-Value-Information.ipynb,dc7482b8,code,fr,9ed809b71f36566f,"// Visualisation : Comparaison des tests medicaux (EVSI, Cout, Efficacite)
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-6-Value-Information.ipynb,dc7482b8,code,fr,eaf6cbb647566e44,"#load ""../../Infer/SvgChartHelper.cs""
+
+// Visualisation : Comparaison des tests medicaux (EVSI, Cout, Efficacite)
 // Diagramme en barres comparant les metriques cles des deux tests
 
 Console.WriteLine(""\n=== Visualisation : Comparaison des Tests Medicaux ===\n"");
@@ -5987,40 +5942,15 @@ int barLen = 35;
 Console.WriteLine(""                 EVSI brute / Cout / EVSI nette (EUR) - voir chart ci-dessous"");
 Console.WriteLine();
 {
-    var names = testsData.Select(t => (object)t.Item1).ToArray();
-    var evsiBrute = testsData.Select(t => (object)Math.Round(t.Item2,0)).ToArray();
-    var couts = testsData.Select(t => (object)Math.Round(t.Item3,0)).ToArray();
-    var evsiNet = testsData.Select(t => (object)Math.Round(t.Item4,0)).ToArray();
-    string tr(string n, object[] y, string c) => System.Text.Json.JsonSerializer.Serialize(
-        new Dictionary<string, object> { [""x""] = names, [""y""] = y, [""type""] = ""bar"", [""name""] = n,
-                                         [""marker""] = new Dictionary<string,object>{ [""color""] = c } });
-    var tEvsi = tr(""EVSI brute"", evsiBrute, ""#2a6dba"");
-    var tCout = tr(""Cout"", couts, ""#9aa0a6"");
-    var tNet = tr(""EVSI nette"", evsiNet, ""#e8743b"");
-    var divId = ""plt"" + Guid.NewGuid().ToString(""N"");
-    var layout = ""{\""barmode\"":\""group\"",\""title\"":{\""text\"":\""Comparaison des tests medicaux : EVSI brute, cout, EVSI nette\""},"" +
-                 ""\""yaxis\"":{\""title\"":{\""text\"":\""EUR\""}},\""margin\"":{\""l\"":60,\""r\"":30,\""b\"":50}}"";
-    var markup = ""<div id=\"""" + divId + ""\""></div>"" +
-                 ""<script src=\""https://cdn.plot.ly/plotly-2.35.2.min.js\""></script>"" +
-                 ""<script>Plotly.newPlot('"" + divId + ""',["" + tEvsi + "","" + tCout + "","" + tNet + ""],"" + layout + "")</script>"";
-    display(new PlotlyHtml(markup));
+    var names45a = new[] { ""Test Rapide"", ""IRM"" };
+    var vals45a = new double[] { Math.Round(EVSI_T1, 0), Math.Round(EVSI_T2, 0) };
+    display(SvgChartHelper.Bar(""Comparaison des tests medicaux : EVSI brute (EUR)"", names45a, vals45a));
 }
 Console.WriteLine();
 {
-    var names = testsData.Select(t => (object)t.Item1).ToArray();
-    var effs = testsData.Select(t => (object)Math.Round(t.Item5*100,1)).ToArray();
-    var divId = ""plt"" + Guid.NewGuid().ToString(""N"");
-    var trace = System.Text.Json.JsonSerializer.Serialize(
-        new Dictionary<string, object> { [""x""] = names, [""y""] = effs, [""type""] = ""bar"",
-                                         [""marker""] = new Dictionary<string,object>{ [""color""] = ""#2a6dba"" },
-                                         [""text""] = effs, [""textposition""] = ""auto"" });
-    var layout = ""{\""title\"":{\""text\"":\""Efficacite (EVSI/EVPI) : proportion de l'info parfaite capturee (%)\""},"" +
-                 ""\""yaxis\"":{\""title\"":{\""text\"":\""Efficacite (%)\""},\""range\"":[0,100]},"" +
-                 ""\""margin\"":{\""l\"":50,\""r\"":30,\""b\"":50}}"";
-    var markup = ""<div id=\"""" + divId + ""\""></div>"" +
-                 ""<script src=\""https://cdn.plot.ly/plotly-2.35.2.min.js\""></script>"" +
-                 ""<script>Plotly.newPlot('"" + divId + ""',["" + trace + ""],"" + layout + "")</script>"";
-    display(new PlotlyHtml(markup));
+    var names45b = new[] { ""Test Rapide"", ""IRM"" };
+    var vals45b = new double[] { Math.Round((EVSI_T1 / EVPI_med) * 100, 1), Math.Round((EVSI_T2 / EVPI_med) * 100, 1) };
+    display(SvgChartHelper.Bar(""Efficacite (EVSI/EVPI) : proportion de l'info parfaite capturee (%)"", names45b, vals45b));
 }
 
 Console.WriteLine();
@@ -6031,7 +5961,8 @@ Console.WriteLine(""  +/- = EVSI nette (EVSI - Cout) : + rentable, - non rentabl
 Console.WriteLine(""  = = Efficacite (EVSI/EVPI) : proportion de l'info parfaite capturee"");
 Console.WriteLine();
 Console.WriteLine($""=> Le Test Rapide est OPTIMAL : meilleure rentabilite malgre efficacite inferieure"");
-Console.WriteLine($""   Ratio cout-efficacite : Test Rapide = {(EVSI_T1/coutT1):F1} EUR/EUR de cout"");",,,,,,,,9ed809b71f36566f,,,,,,,
+Console.WriteLine($""   Ratio cout-efficacite : Test Rapide = {(EVSI_T1/coutT1):F1} EUR/EUR de cout"");
+",,,,,,,,eaf6cbb647566e44,,,,,,,
 MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-6-Value-Information.ipynb,2237bf16,markdown,fr,723ada0b0d9a2ae6,"### Extension : strategie sequentielle
 
 Une approche plus sophistiquee serait de faire le test rapide d'abord, puis l'IRM uniquement si le test rapide est positif. Cette strategie ""en entonnoir"" est typique des protocoles medicaux reels et necessite un arbre de decision a plusieurs niveaux.
@@ -6084,7 +6015,9 @@ Apres avoir implemente le code, analysez :
 2. L'EVSI est-elle superieure au cout du test ?
 3. La decision change-t-elle selon le resultat du test (positif vs negatif) ?
 4. Si la prevalence etait 20% au lieu de 5%, le test serait-il plus utile ?",,,,,,,,bcf3b72ab17cb031,,,,,,,
-MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-6-Value-Information.ipynb,59ba6395,code,fr,c93df6ff20e22cce,"// Visualisation recapitulative : Comparaison VoI sur tous les exemples du notebook
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-6-Value-Information.ipynb,59ba6395,code,fr,e6a6bcf4850cf51d,"#load ""../../Infer/SvgChartHelper.cs""
+
+// Visualisation recapitulative : Comparaison VoI sur tous les exemples du notebook
 
 Console.WriteLine(""=== Tableau Recapitulatif : Valeur de l'Information ===\n"");
 
@@ -6119,25 +6052,20 @@ Console.WriteLine(""  3. Meme un test performant peut etre inutile si prior trop
 Console.WriteLine(""  4. Cout vs valeur : IRM (77% eff) moins rentable que test rapide (44% eff)"");
 Console.WriteLine();
 
-// Visualisation en barres de l'efficacite
+// Visualisation en barres de l'efficacite : la couleur encode la rentabilite (par-barre).
 {
-    var labels = exemples.Select(e => (object)e.Item2).ToArray();
-    var effs = exemples.Select(e => (object)Math.Round(e.Item5,1)).ToArray();
-    var colors = exemples.Select(e => e.Item6.StartsWith(""Oui"") ? (object)""#2a6dba"" : (object)""#e8743b"").ToArray();
-    var divId = ""plt"" + Guid.NewGuid().ToString(""N"");
-    var trace = System.Text.Json.JsonSerializer.Serialize(
-        new Dictionary<string, object> { [""y""] = labels, [""x""] = effs, [""type""] = ""bar"", [""orientation""] = ""h"",
-                                         [""marker""] = new Dictionary<string,object>{ [""color""] = colors },
-                                         [""text""] = effs, [""textposition""] = ""auto"" });
-    var layout = ""{\""title\"":{\""text\"":\""Efficacite des tests (EVSI/EVPI) - bleu = rentable, orange = non rentable\""},"" +
-                 ""\""xaxis\"":{\""title\"":{\""text\"":\""Efficacite (%)\""},\""range\"":[0,100]},"" +
-                 ""\""yaxis\"":{\""title\"":{\""text\"":\""Test\""}},\""margin\"":{\""l\"":120,\""r\"":40}}"";
-    var markup = ""<div id=\"""" + divId + ""\""></div>"" +
-                 ""<script src=\""https://cdn.plot.ly/plotly-2.35.2.min.js\""></script>"" +
-                 ""<script>Plotly.newPlot('"" + divId + ""',["" + trace + ""],"" + layout + "")</script>"";
-    display(new PlotlyHtml(markup));
+    var labels49 = exemples.Select(e => e.Item2).ToArray();
+    var effs49 = exemples.Select(e => Math.Round(e.Item5, 1)).ToArray();
+    // Couleur conditionnelle par barre : bleu si rentable (colonne ""Rentable"" commence par
+    // ""Oui""), orange sinon. Rend visible le paradoxe cout/valeur - l'IRM affiche 77 %
+    // d'efficacite mais reste NON rentable a cause de son cout - qu'une couleur unique masquait.
+    var colors49 = exemples.Select(e => e.Item6.StartsWith(""Oui"") ? ""#4C72B0"" : ""#DD8452"").ToArray();
+    var legend49 = new List<(string, string)> { (""#4C72B0"", ""rentable""), (""#DD8452"", ""non rentable"") };
+    display(SvgChartHelper.Bar(
+        ""Efficacite des tests (EVSI/EVPI) - couleur = rentabilite"",
+        labels49, effs49, width: 720, colors: colors49, legend: legend49));
 }
-Console.WriteLine(""  Legende : # = efficacite, [OK] = rentable, [--] = non rentable"");",,,,,,,,c93df6ff20e22cce,,,,,,,
+Console.WriteLine(""  Chart : hauteur = efficacite (EVSI/EVPI, %), couleur = rentabilite (voir legende)."");",,,,,,,,e6a6bcf4850cf51d,,,,,,,
 MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-6-Value-Information.ipynb,ca542056,markdown,fr,da237be8b735b663,"### Points cles a retenir de ce notebook
 
 **1. L'EVPI mesure le ""cout de l'ignorance""**
@@ -6382,11 +6310,11 @@ Aujourd'hui, les systemes experts bayesiens utilisent des moteurs d'inference co
 - Propager automatiquement l'incertitude
 - Combiner plusieurs sources de preuves
 - Apprendre les parametres a partir de donnees",,,,,,,,32110d52be9809d0,,,,,,,
-MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-7-Expert-Systems.ipynb,cc659944,code,fr,c8d23f4b90137af8,"// Chargement du helper pour visualiser les graphes de facteurs
-#load ""FactorGraphHelper.cs""
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-7-Expert-Systems.ipynb,cc659944,code,fr,c3d89f74be52452e,"// Chargement du helper pour visualiser les graphes de facteurs
+#load ""../../Infer/FactorGraphHelper.cs""
 
 Console.WriteLine(""FactorGraphHelper charge."");
-Console.WriteLine($""Graphviz disponible : {FactorGraphHelper.IsGraphvizAvailable()}"");",,,,,,,,c8d23f4b90137af8,,,,,,,
+Console.WriteLine($""Graphviz disponible : {FactorGraphHelper.IsGraphvizAvailable()}"");",,,,,,,,c3d89f74be52452e,,,,,,,
 MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-7-Expert-Systems.ipynb,5371461a,markdown,fr,3a43f5525a3a972a,Installation et chargement des packages Infer.NET.,,,,,,,,3a43f5525a3a972a,,,,,,,
 MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-7-Expert-Systems.ipynb,9fa85542,code,fr,0592ef57ae439bbd,"// Installation Infer.NET
 #r ""nuget: Microsoft.ML.Probabilistic""
@@ -7237,201 +7165,317 @@ Le code suivant implemente un systeme expert bayesien complet avec Infer.NET, co
 - Logs : scores = [OK:0.10, RAM:0.15, Disque:0.65, CPU:0.10]
 - Utilisateur : dit ""Disque""
 - Capteur RAM : pas d'alerte",,,,,,,,d1ab428aa8c1bd09,,,,,,,
-MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-7-Expert-Systems.ipynb,ff83d823,code,fr,eadcfd12f02622c7,"using Microsoft.DotNet.Interactive.Formatting;
-using System.IO;
-// Systeme Expert Bayesien Multi-Sources : Diagnostic Informatique avec Infer.NET
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-7-Expert-Systems.ipynb,ff83d823,code,fr,802b272218fbe605,"// Visualisation graphique du systeme expert Bayesien multi-sources : posterior + utilites.
 
-using Microsoft.ML.Probabilistic.Math;
+// Technique C548-L2 : SVG inline via SvgChartHelper.cs (#6942 MERGED), zero-dependance NuGet.
+
+// Les deux traces (posterior + utilite) sont tracees en deux chartes distinctes car elles
+
+// partagent PAS un meme axe X categoriel (panne: OK/RAM/Disque/CPU vs action: Rien/Remplacer...).
+
+// SvgChartHelper.Overlay (#6958 MERGED) requiert un axe X numerique partage => inapplicable.
+
+// Le helper Overlay reste disponible pour les courbes VoI type DecInfer-6 EVPI ; ici c'est
+
+// l'usage canonique Bar() qui s'applique. Cf #6927 / #3801 / #6942 / #6958 / See #6954 (App-7b).
+
+#load ""../../Infer/SvgChartHelper.cs""
+
+
 
 int nPannes = 4;  // 0=OK, 1=RAM, 2=Disque, 3=CPU
+
 Range panneRange = new Range(nPannes).Named(""panneRange"");
+
 string[] pannes = { ""OK"", ""RAM"", ""Disque"", ""CPU"" };
 
+
+
 // === Panne latente (verite a inferer) ===
+
 Variable<int> panne = Variable.DiscreteUniform(nPannes).Named(""panne"");
+
 panne.SetValueRange(panneRange);
 
+
+
 // === Source 1 : Logs systeme (fiabilite a inferer) ===
+
 // Prior sur la precision des logs (Gamma car precision > 0)
+
 Variable<double> precisionLogs = Variable.GammaFromShapeAndScale(5, 2).Named(""precLogs"");
 
+
+
 // Scores observes dans les logs pour chaque type de panne
+
 // (Plus le score est eleve, plus la panne est probable selon les logs)
+
 double[] scoresLogsObserves = { 0.1, 0.15, 0.65, 0.10 };  // Logs suggerent Disque
 
+
+
 // Le score observe est un indicateur bruite de la vraie panne
+
 // Modele : Si panne=k, alors score[k] est tire d'une distribution plus haute
+
 VariableArray<double> vraiScoreMoyen = Variable.Array<double>(panneRange).Named(""vraiScoreMoyen"");
+
 vraiScoreMoyen[panneRange] = Variable.GaussianFromMeanAndPrecision(0.3, 1.0).ForEach(panneRange);
 
+
+
 // On observe les scores (simplifie : on conditionne sur la panne)
+
 // Score eleve pour la vraie panne, bas pour les autres
+
 Variable.ConstrainTrue(
+
     Variable.Bernoulli(0.9)  // 90% chance que le score max corresponde a la vraie panne
+
 );
 
+
+
 // === Source 2 : Avis utilisateur (matrice de confusion) ===
+
 // L'utilisateur peut confondre les symptomes
+
 // Matrice de confusion fixee (connaissance experte)
+
 double[,] confusionUser = {
+
     // L'utilisateur dit:  OK    RAM   Disque  CPU
+
     /* Vraie panne OK */  { 0.85, 0.05, 0.05, 0.05 },
+
     /* Vraie panne RAM */ { 0.05, 0.60, 0.20, 0.15 },
+
     /* Vraie panne Disque */{ 0.05, 0.10, 0.75, 0.10 },
+
     /* Vraie panne CPU */ { 0.05, 0.15, 0.15, 0.65 }
+
 };
 
+
+
 Variable<int> avisUser = Variable.New<int>().Named(""avisUser"");
+
 avisUser.SetValueRange(panneRange);
 
+
+
 // Avis utilisateur conditionne a la vraie panne
+
 using (Variable.Case(panne, 0))
+
     avisUser.SetTo(Variable.Discrete(confusionUser[0, 0], confusionUser[0, 1], confusionUser[0, 2], confusionUser[0, 3]));
+
 using (Variable.Case(panne, 1))
+
     avisUser.SetTo(Variable.Discrete(confusionUser[1, 0], confusionUser[1, 1], confusionUser[1, 2], confusionUser[1, 3]));
+
 using (Variable.Case(panne, 2))
+
     avisUser.SetTo(Variable.Discrete(confusionUser[2, 0], confusionUser[2, 1], confusionUser[2, 2], confusionUser[2, 3]));
+
 using (Variable.Case(panne, 3))
+
     avisUser.SetTo(Variable.Discrete(confusionUser[3, 0], confusionUser[3, 1], confusionUser[3, 2], confusionUser[3, 3]));
 
+
+
 // Observation : l'utilisateur dit ""Disque""
+
 avisUser.ObservedValue = 2;
 
+
+
 // === Source 3 : Capteur RAM (tres fiable pour RAM, bruit pour autres) ===
+
 Variable<bool> alerteRAM = Variable.New<bool>().Named(""alerteRAM"");
 
+
+
 using (Variable.Case(panne, 0))  // OK
+
     alerteRAM.SetTo(Variable.Bernoulli(0.02));  // Faux positif 2%
+
 using (Variable.Case(panne, 1))  // RAM
+
     alerteRAM.SetTo(Variable.Bernoulli(0.95));  // Detection 95%
+
 using (Variable.Case(panne, 2))  // Disque
+
     alerteRAM.SetTo(Variable.Bernoulli(0.05));  // Bruit 5%
+
 using (Variable.Case(panne, 3))  // CPU
+
     alerteRAM.SetTo(Variable.Bernoulli(0.08));  // Bruit 8%
 
+
+
 // Observation : pas d'alerte RAM
+
 alerteRAM.ObservedValue = false;
 
+
+
 // === Inference ===
+
 InferenceEngine engineExpert = new InferenceEngine();
+
 engineExpert.Compiler.CompilerChoice = Microsoft.ML.Probabilistic.Compiler.CompilerChoice.Roslyn;
+
 engineExpert.Algorithm = new ExpectationPropagation();
 
+
+
 Console.WriteLine(""=== Systeme Expert Bayesien Multi-Sources ===\n"");
+
 Console.WriteLine(""Sources combinees :"");
+
 Console.WriteLine(""  1. Logs systeme : scores = [OK:0.10, RAM:0.15, Disque:0.65, CPU:0.10]"");
+
 Console.WriteLine(""  2. Avis utilisateur : 'Disque'"");
+
 Console.WriteLine(""  3. Capteur RAM : pas d'alerte\n"");
 
+
+
 var posteriorPanne = engineExpert.Infer<Discrete>(panne);
+
 var posteriorPrecLogs = engineExpert.Infer<Gamma>(precisionLogs);
+
+
 
 Console.WriteLine(""Posterior sur la panne :"");
 
-// Outil de visualisation : rendu Plotly.js via le formatter HTML integre du kernel.
-// (Zero `#r ""nuget:""` sur une charting-lib : les charting libs pinent une vieille beta
-//  de Microsoft.DotNet.Interactive et font timeout le restore, cluster-wide. Le formatter
-//  ci-dessous emet du HTML Plotly brut, sans dependence. Cf #3801 / C548-L2.)
-record PlotlyHtml(string Markup);
-Formatter.Register(typeof(PlotlyHtml),
-    (obj, writer) => ((TextWriter)writer).Write(((PlotlyHtml)obj).Markup), ""text/html"");
 
-// Visualisation graphique : posterior sur la panne + utilites attendues des actions.
-// Deux traces juxtaposees pour mettre en regard le diagnostic et le cout attendu.
-var panneProbs = posteriorPanne.GetProbs();
-var panneColors = new[] { ""#4C72B0"", ""#DD8452"", ""#55A868"", ""#C44E52"" };
-var panneTrace = new Dictionary<string, object> {
-    [""name""] = ""Posterior P(panne)"",
-    [""x""] = panneProbs.Select((v, i) => pannes[i]).ToArray(),
-    [""y""] = panneProbs,
-    [""type""] = ""bar"",
-    [""marker""] = new { color = panneColors },
-    [""text""] = panneProbs.Select(v => $""{v:P1}"").ToArray(),
-    [""textposition""] = ""outside"",
-    [""hovertemplate""] = ""P(%{x}) = %{y:.3f}<extra></extra>""
-};
-string panneJson = System.Text.Json.JsonSerializer.Serialize(panneTrace);
 
-// Cout attendu de chaque action (chartEU) pour l'annotation, avec des noms distincts
-// du bloc ""Decision robuste"" ci-dessous (coutsActions/actionsRep/bestAction/maxEU).
+// === Visualisation SVG inline canon (C548-L2) ===
+
+// Avant : trace Plotly.js + cdn.plot.ly (rend BLANC en static, cf #6927).
+
+// Apres : 2 chartes SvgChartHelper.Bar() distinctes (axes categoriels distincts => Overlay N/A).
+
+
+
+var panneProbsVec = posteriorPanne.GetProbs();var panneProbs = new double[nPannes];for (int i = 0; i < nPannes; i++) panneProbs[i] = panneProbsVec[i];var panneColors = new[] { ""#4C72B0"", ""#DD8452"", ""#55A868"", ""#C44E52"" };
+
+Console.WriteLine(""  Mapping pedagogique (couleurs du chart Plotly originel preservees en legende Console) :"");
+
+for (int i = 0; i < nPannes; i++)
+
+    Console.WriteLine($""    {pannes[i],-8} : {panneProbs[i]:P2}  (Plotly color {panneColors[i]})"");
+
+
+
+// Bar 1 : posterior P(panne), couleur uniforme canon C548-L2.
+
+display(SvgChartHelper.Bar(
+
+    ""Posterior P(panne) - 4 categories"",
+
+    pannes,
+
+    panneProbs,
+
+    width: 560,
+
+    height: 320));
+
+
+
+// Cout attendu de chaque action (matrice identique au bloc Decision robuste ci-dessous,
+
+// renommee ici chartCouts/chartActions pour eviter la collision de noms).
+
 var chartCouts = new double[,] {
+
     //                OK      RAM     Disque   CPU
+
     /* Rien */      { 0,     -500,   -1000,   -800 },
+
     /* Rempl. RAM */{ -100,  0,      -900,    -700 },
+
     /* Rempl. Disk*/{ -150,  -400,   0,       -600 },
+
     /* Rempl. CPU */{ -300,  -300,   -800,    0 }
+
 };
+
 var chartActions = new[] { ""Rien"", ""Remplacer RAM"", ""Remplacer Disque"", ""Remplacer CPU"" };
+
 var chartEU = new double[4];
+
 for (int a = 0; a < 4; a++)
+
     for (int p = 0; p < nPannes; p++)
+
         chartEU[a] += panneProbs[p] * chartCouts[a, p];
+
 int chartBestA = 0;
+
 for (int a = 1; a < 4; a++)
+
     if (chartEU[a] > chartEU[chartBestA]) chartBestA = a;
-var euColors = Enumerable.Range(0, 4).Select(a => a == chartBestA ? ""#2CA02C"" : ""#7F7F7F"").ToArray();
-var euTrace = new Dictionary<string, object> {
-    [""name""] = ""E[U(action)]"",
-    [""x""] = chartActions,
-    [""y""] = chartEU,
-    [""type""] = ""bar"",
-    [""marker""] = new { color = euColors },
-    [""text""] = chartEU.Select(v => $""{v:F0}"").ToArray(),
-    [""textposition""] = ""outside"",
-    [""hovertemplate""] = ""E[U(%{x})] = %{y:.0f}<extra></extra>""
-};
-string euJson = System.Text.Json.JsonSerializer.Serialize(euTrace);
 
-string annotationJson = ""{\""x\"":0.5,\""y\"":1.10,\""xref\"":\""paper\"",\""yref\"":\""paper\"","" +
-                       ""\""text\"":\""Diagnostic recommande : <b>\"" + chartActions[chartBestA] + \""</b> (E[U]=\"" + chartEU[chartBestA].ToString(\""F0\"") + \"")</b>\"","" +
-                       ""\""showarrow\"":false,\""xanchor\"":\""center\"",\""font\"":{\""size\"":12,\""color\"":\""#2CA02C\""}}"";
-string layout = ""{\""title\"":{\""text\"":\""Systeme Expert Bayesien - posterior et utilites\""},"" +
-                ""\""barmode\"":\""group\"","" +
-                ""\""xaxis\"":{\""title\"":{\""text\"":\""Panne (gauche) / Action (droite)\""},\""type\"":\""category\""},"" +
-                ""\""yaxis\"":{\""title\"":{\""text\"":\""Probabilite (gauche) / Utilite (droite)\""},\""zeroline\"":true},"" +
-                ""\""annotations\"":["" + annotationJson + ""],"" +
-                ""\""template\"":\""plotly_white\""}"";
-var divId = ""plt"" + Guid.NewGuid().ToString(""N"");
-var markup = ""<div id=\"""" + divId + ""\"" style=\""width:100%;max-width:1100px;height:480px;\""></div>"" +
-             ""<script src=\""https://cdn.plot.ly/plotly-2.35.2.min.js\""></script>"" +
-             ""<script>Plotly.newPlot(\"""" + divId + ""\"",["" + panneJson + "","" + euJson + ""],"" + layout + "")</script>"";
-display(new PlotlyHtml(markup));
 
-Console.WriteLine($""\nPrecision inferee des logs : {posteriorPrecLogs.GetMean():F2} (shape={posteriorPrecLogs.Shape:F1}, scale={1.0/posteriorPrecLogs.Rate:F2})"");
 
-// === Decision robuste ===
-Console.WriteLine(""\n=== Decision Robuste ===\n"");
+Console.WriteLine();
 
-// Matrice de couts des actions
-double[,] coutsActions = {
-    //                OK      RAM     Disque   CPU
-    /* Rien */      { 0,     -500,   -1000,   -800 },
-    /* Rempl. RAM */{ -100,  0,      -900,    -700 },
-    /* Rempl. Disk*/{ -150,  -400,   0,       -600 },
-    /* Rempl. CPU */{ -300,  -300,   -800,    0 }
-};
-string[] actionsRep = { ""Rien"", ""Remplacer RAM"", ""Remplacer Disque"", ""Remplacer CPU"" };
+Console.WriteLine($""Diagnostic recommande : {chartActions[chartBestA]} (E[U] = {chartEU[chartBestA]:F0})"");
 
-// Calcul EU pour chaque action
-Console.WriteLine(""Utilites esperees :"");
-double maxEU = double.NegativeInfinity;
-string bestAction = null;
+Console.WriteLine(""  Mapping pedagogique (meilleure action en vert, autres en gris) :"");
+
+var euColors = new[] { ""#2CA02C"", ""#7F7F7F"", ""#7F7F7F"", ""#7F7F7F"" };
 
 for (int a = 0; a < 4; a++)
+
 {
-    double eu = 0;
-    for (int p = 0; p < nPannes; p++)
-        eu += posteriorPanne.GetProbs()[p] * coutsActions[a, p];
-    
-    Console.WriteLine($""  E[U({actionsRep[a],-16})] = {eu,7:F0}"");
-    if (eu > maxEU)
-    {
-        maxEU = eu;
-        bestAction = actionsRep[a];
-    }
+
+    string tag = a == chartBestA ? ""[BEST]"" : ""[--]"";
+
+    Console.WriteLine($""    {chartActions[a],-16} {tag} : E[U] = {chartEU[a],7:F0}  (Plotly color {euColors[a]})"");
+
 }
 
-Console.WriteLine($""\n=> Recommandation : {bestAction} (EU = {maxEU:F0})"");",,,,,,,,eadcfd12f02622c7,,,,,,,
+
+
+// Bar 2 : E[U(action)], couleur uniforme canon.
+
+var euLabelsComposed = new string[4];
+
+for (int a = 0; a < 4; a++)
+
+{
+
+    string tag = a == chartBestA ? ""[BEST]"" : ""[--]"";
+
+    euLabelsComposed[a] = $""{chartActions[a]} {tag}"";
+
+}
+
+display(SvgChartHelper.Bar(
+
+    ""E[U(action)] - utilite attendue par action"",
+
+    euLabelsComposed,
+
+    chartEU,
+
+    width: 560,
+
+    height: 320));
+
+
+
+Console.WriteLine();
+
+
+
+Console.WriteLine($""\nPrecision inferee des logs : {posteriorPrecLogs.GetMean():F2} (shape={posteriorPrecLogs.Shape:F1}, scale={1.0/posteriorPrecLogs.Rate:F2})"");",,,,,,,,802b272218fbe605,,,,,,,
 MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-7-Expert-Systems.ipynb,a3156f4b,markdown,fr,7815bde425b97f61,"### Interpretation du diagnostic multi-sources avec Infer.NET
 
 **Analyse de la combinaison des sources :**
@@ -7799,14 +7843,14 @@ des modeles probabilistes sequentiels comme les MDPs et POMDPs.
 
 Le helper utilise Graphviz pour generer des diagrammes SVG des modeles.
 ",,,,,,,,e838062c2a4c41f3,,,,,,,
-MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-8-Sequential.ipynb,2ab4cddc,code,fr,3187a643f7511023,"// Charger le helper pour visualiser les factor graphs
-#load ""FactorGraphHelper.cs""
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-8-Sequential.ipynb,2ab4cddc,code,fr,00e0e93196785e71,"// Charger le helper pour visualiser les factor graphs
+#load ""../../Infer/FactorGraphHelper.cs""
 
 // Flag pour activer les visualisations de factor graphs
 bool ShowFactorGraph = true;
 
 Console.WriteLine(""FactorGraphHelper charge."");
-Console.WriteLine($""Graphviz disponible : {FactorGraphHelper.IsGraphvizAvailable()}"");",,,,,,,,3187a643f7511023,,,,,,,
+Console.WriteLine($""Graphviz disponible : {FactorGraphHelper.IsGraphvizAvailable()}"");",,,,,,,,00e0e93196785e71,,,,,,,
 MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-8-Sequential.ipynb,101c5555,markdown,fr,63800bf85d937596,"### Environnement pret
 
 L'infrastructure Infer.NET est chargee. Dans ce notebook, nous utiliserons principalement Infer.NET pour la section sur les **belief states** dans les POMDPs, ou l'inference bayesienne automatique simplifie considerablement les calculs.
@@ -9506,15 +9550,11 @@ Reinforcement Learning (Serie RL/)
 
 **Message cle :**
 > La theorie de la decision fournit les **fondements mathematiques** (utilite, rationalite, Bellman) sur lesquels reposent les algorithmes modernes de RL. Comprendre ces concepts permet de mieux concevoir, debugger et ameliorer les systemes d'apprentissage.",,,,,,,,afb871cac8889ce7,,,,,,,
-MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-8-Sequential.ipynb,513a917e,code,fr,5b7b79b01fe28ae4,"// Belief State Updates avec Infer.NET : Maintenance Predictive
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-8-Sequential.ipynb,513a917e,code,fr,2946cb7a1a78b942,"#load ""../../Infer/SvgChartHelper.cs""
+
+// Belief State Updates avec Infer.NET : Maintenance Predictive
 
 using Microsoft.ML.Probabilistic.Math;
-using Microsoft.DotNet.Interactive.Formatting;
-using System.IO;
-using System.Collections.Generic;
-record PlotlyHtml(string Markup);
-Formatter.Register(typeof(PlotlyHtml),
-    (obj, writer) => ((TextWriter)writer).Write(((PlotlyHtml)obj).Markup), ""text/html"");
 
 // Historique des croyances pour la visualisation (Prior + chaque pas de temps)
 var beliefHist = new List<(string Label, double[] Probs)>();
@@ -9640,33 +9680,38 @@ for (int t = 0; t < observations.Length; t++)
         belief[e] = probs[e];
 }
 
-// Visualisation Plotly : evolution des croyances (Prior + chaque pas de temps).
-// Les observations ""Anormal"" successives font chuter P(Bon) et monter P(Defaillant)
-// -- la decision bascule de Continuer vers Maintenance puis Remplacer.
+// Visualisation SVG inline : evolution des croyances (Belief State Updates).
+// La version Plotly-CDN precedente rendait BLANC en static (GitHub sandbox les <script src=cdn.plot.ly>).
+// Technique C548-L2 : SVG inline via SvgChartHelper.cs (#6942 MERGED), zero-dependance NuGet.
+// L'API Bar() ne suporte pas les barres groupees (un seul array de valeurs), donc on deploie
+// 3 Bar() distincts (un par etat) montrant l'evolution temporelle de chaque probabilite.
+// La legende textuelle ci-dessous preserve le role pedagogique de la viz d'origine
+// (anomalies successives font chuter P(Bon) et basculer la decision Continuer -> Maintenance -> Remplacer).
+
+// Labels X partages (Prior + chaque pas de temps)
+var xLabels49 = beliefHist.Select(b => b.Label).ToArray();
 {
-    var labels = beliefHist.Select(b => (object)b.Label).ToArray();
-    string tr(string name, int ei, string color) => System.Text.Json.JsonSerializer.Serialize(
-        new Dictionary<string, object> { [""x""] = labels, [""y""] = beliefHist.Select(b => (object)Math.Round(b.Probs[ei],3)).ToArray(),
-                                         [""type""] = ""bar"", [""name""] = name,
-                                         [""marker""] = new Dictionary<string,object>{ [""color""] = color } });
-    var tBon = tr(""Bon"", 0, ""#2a6dba"");
-    var tDeg = tr(""Degrade"", 1, ""#e8743b"");
-    var tDef = tr(""Defaillant"", 2, ""#c5392f"");
-    var divId = ""plt"" + Guid.NewGuid().ToString(""N"");
-    var layout = ""{\""barmode\"":\""group\"",\""title\"":{\""text\"":\""Evolution des croyances (maintenance predictive) : le belief bascule avec les anomalies\""},"" +
-                 ""\""xaxis\"":{\""title\"":{\""text\"":\""Pas de temps (observation)\""}},"" +
-                 ""\""yaxis\"":{\""title\"":{\""text\"":\""Probabilite de l etat\""},\""range\"":[0,1],\""tickformat\"":\"".0%\""},"" +
-                 ""\""margin\"":{\""l\"":50,\""r\"":30,\""b\"":70}}"";
-    var markup = ""<div id=\"""" + divId + ""\""></div>"" +
-                 ""<script src=\""https://cdn.plot.ly/plotly-2.35.2.min.js\""></script>"" +
-                 ""<script>Plotly.newPlot('"" + divId + ""',["" + tBon + "","" + tDeg + "","" + tDef + ""],"" + layout + "")</script>"";
-    display(new PlotlyHtml(markup));
+    // Serie 1 : Bon (devrait chuter avec anomalies)
+    var yBon = beliefHist.Select(b => Math.Round(b.Probs[0], 3)).ToArray();
+    display(SvgChartHelper.Bar(""Evolution de P(Bon) - chute avec anomalies successives"", xLabels49, yBon));
+    Console.WriteLine(""  [Bon] les observations 'Anormal' font chuter P(Bon) sous 0.05 au 3e pas."");
+
+    // Serie 2 : Degrade (devrait monter puis transferer vers Defaillant)
+    var yDeg = beliefHist.Select(b => Math.Round(b.Probs[1], 3)).ToArray();
+    display(SvgChartHelper.Bar(""Evolution de P(Degrade) - pic intermediaire avant Defaillant"", xLabels49, yDeg));
+    Console.WriteLine(""  [Degrade] pic au 2e pas (0.55) puis transfer progressif vers Defaillant."");
+
+    // Serie 3 : Defaillant (devrait monter lineairement)
+    var yDef = beliefHist.Select(b => Math.Round(b.Probs[2], 3)).ToArray();
+    display(SvgChartHelper.Bar(""Evolution de P(Defaillant) - croissance monotone avec anomalies"", xLabels49, yDef));
+    Console.WriteLine(""  [Defaillant] croissance monotone : 0.01 (prior) -> 0.55 (3 anomalies cumulees)."");
 }
 
 Console.WriteLine(""=== Resume ==="");
 Console.WriteLine(""Les observations 'Anormal' successives ont fait augmenter P(Degrade),"");
 Console.WriteLine(""declenchant le passage de 'Continuer' a 'Maintenance' ou 'Remplacer'."");
-Console.WriteLine(""\nC'est le principe de la maintenance predictive bayesienne !"");",,,,,,,,5b7b79b01fe28ae4,,,,,,,
+Console.WriteLine(""\nC'est le principe de la maintenance predictive bayesienne !"");
+",,,,,,,,2946cb7a1a78b942,,,,,,,
 MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-8-Sequential.ipynb,ce194610,markdown,fr,1caf6b5dbca79275,"### Interpretation de la maintenance predictive bayesienne
 
 **Scenario simule :** Observations = [Normal, Anormal, Anormal]
@@ -9850,9 +9895,9 @@ using Microsoft.ML.Probabilistic.Algorithms;
 using Microsoft.ML.Probabilistic.Compiler;
 Console.WriteLine(""Infer.NET charge."");",,,,,,,,9661672f1a9cccc5,,,,,,,
 MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-10-Thompson-Sampling.ipynb,cell-45c5e1c5,markdown,fr,83b8a5792b144855,Chargement du helper de visualisation des graphes de facteurs (Graphviz).,,,,,,,,83b8a5792b144855,,,,,,,
-MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-10-Thompson-Sampling.ipynb,cell-b0f29d4f,code,fr,89111102404290a3,"#load ""FactorGraphHelper.cs""
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-10-Thompson-Sampling.ipynb,cell-b0f29d4f,code,fr,712878d44cb85a79,"#load ""../../Infer/FactorGraphHelper.cs""
 Console.WriteLine(""FactorGraphHelper charge."");
-Console.WriteLine($""Graphviz disponible : {FactorGraphHelper.IsGraphvizAvailable()}"");",,,,,,,,89111102404290a3,,,,,,,
+Console.WriteLine($""Graphviz disponible : {FactorGraphHelper.IsGraphvizAvailable()}"");",,,,,,,,712878d44cb85a79,,,,,,,
 MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-10-Thompson-Sampling.ipynb,cell-8be332b6,markdown,fr,77ffb495f7b19c45,"## 3. Le modele Beta-Bernoulli d'un bras
 
 Soit un bras de probabilite de succes inconnue `theta`. Modele :
@@ -10216,3 +10261,816 @@ MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-10-Thompson-Sampling.i
 ---
 
 [<- Infer-8-Sequential](DecInfer-8-Sequential.ipynb) | [Infer-5-Causal-Inference ->](../../Infer/Infer-5-Causal-Inference.ipynb) | [Retour a la serie](README.md)",,,,,,,,c8764bde4cab0cd4,,,,,,,
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-2-Lean-ExpectedUtility.ipynb,ff8c6dc9,markdown,fr,de13b1e4bcb67cf5,"# DecInfer-2-Théorème de représentation de von Neumann–Morgenstern (companion formel natif)
+Ce notebook est le **companion formel** du lake [`decision_theory_lean`](../../decision_theory_lean/)
+(lib `Utility`), qui prouve la **direction sound** du théorème de représentation d'utilité
+espérée de **von Neumann–Morgenstern** : si une fonction d'utilité `u` *représente* une
+préférence `P` (`P p q ↔ E_p[u] ≥ E_q[u]`), alors `P` est **rationnelle** (satisfait les
+quatre axiomes vNM), avec **zéro `sorry`**.
+
+C'est le fondement formel du classement par espérance d'utilité — la justification
+décisionnelle des notebooks `DecInfer-1` (Infer.NET) et `PyMC-1` (PyMC), où l'utilité
+espérée est calculée sous incertitude bayésienne.
+
+## Convention de vérification — `#check` *natif* dans le kernel Lean
+
+Ce notebook est un **notebook Lean natif** (kernel `lean4-wsl`) : il `import`e les
+modules du lake directement et le compilateur Lean rend les signatures **dans le
+notebook**. C'est rendu possible par l'UNLOCK (patch `lean4_jupyter` + jonction
+Mathlib #2611).
+
+> ⚠️ À l'exécution, la première cellule (`import`) peut prendre **~3 min** :
+> le kernel charge les oleans Mathlib via la jonction NTFS. Les suivantes sont
+> instantanées.",,,,,,,,de13b1e4bcb67cf5,,,,,,,
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-2-Lean-ExpectedUtility.ipynb,827e74e6,markdown,fr,09d0b6b4eda3c446,"## 1. Import des modules `Utility` du lake `decision_theory_lean`
+
+Le lake porte 3 libs indépendantes (`Utility`, `Gittins`, `Coherence`). On importe
+**uniquement les 3 modules de `Utility`** (`Basic`, `Axioms`, `Representation`) — la lib
+`Utility` est déclarée via `roots := #[`Utility]`, qui ne build **pas** l'umbrella racine
+`Utility.olean` (on importe donc les modules directement). On évite `Gittins` (sorries
+HOLD) et `Coherence` : le companion cible la seule lib sorry-free du théorème vNM.",,,,,,,,09d0b6b4eda3c446,,,,,,,
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-2-Lean-ExpectedUtility.ipynb,b526705c,code,fr,fb10c8d36819fbb2,"import Utility.Basic
+import Utility.Axioms
+import Utility.Representation
+open Utility",,,,,,,,fb10c8d36819fbb2,,,,,,,
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-2-Lean-ExpectedUtility.ipynb,8a2b12cd,markdown,fr,eea6a55aeea34cc9,"## 2. Preuve sans `sorry` — `#print axioms`
+
+Le théorème phare `expected_utility_rep_is_rational` (direction sound : représentation ⟹
+rationalité) ne dépend que des **3 axiomes standards de Lean** (`propext`, `Classical.choice`,
+`Quot.sound`) — pas de `sorryAx` — ce qui prouve que la preuve est **complète** (0 sorry).",,,,,,,,eea6a55aeea34cc9,,,,,,,
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-2-Lean-ExpectedUtility.ipynb,f07f7b04,code,fr,910fa935eefcc8c2,#print axioms expected_utility_rep_is_rational,,,,,,,,910fa935eefcc8c2,,,,,,,
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-2-Lean-ExpectedUtility.ipynb,406e428c,markdown,fr,f3dd43298419a61d,"## 3. Loteries, espérance et mélange convexe
+
+Le module `Utility/Basic.lean` pose les primitives de la décision dans le risque :
+
+- `Lottery α` — une loterie : poids non négatifs par issue, sommant à 1 (distribution à support fini sur `α`).
+- `expectation p f` — l'espérance de `f` (typiquement une utilité) sous `p` : `∑ a, p.probs a * f a`.
+- `mix t p r` — le mélange convexe `t • p + (1 - t) • r` (valide pour `t ∈ [0,1]`).
+- `expectation_mix` — l'identité affine clé : `E_{mix}[f] = t·E_p[f] + (1-t)·E_r[f]` (cœur algébrique de l'indépendance).
+- `expectation_affine` — `E_p[a·u + b] = a·E_p[u] + b` (cœur de l'unicité affine de l'utilité).",,,,,,,,f3dd43298419a61d,,,,,,,
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-2-Lean-ExpectedUtility.ipynb,b4281842,code,fr,10090ce060b7a81e,"#check Lottery
+#check expectation
+#check mix
+#check expectation_mix
+#check expectation_affine",,,,,,,,10090ce060b7a81e,,,,,,,
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-2-Lean-ExpectedUtility.ipynb,6e13fadd,markdown,fr,64885a9b8870fe95,"### Lecture : l'algèbre de l'espérance
+
+| Symbole Lean | Lecture |
+|-------------|---------|
+| `Lottery α` | distribution à support fini (`probs`, `nonneg`, `sum_one`) |
+| `expectation p f` | `∑ a, p.probs a * f a` |
+| `mix t p r` | mélange convexe `t·p + (1-t)·r` |
+| `expectation_mix` | `E_{mix}[f] = t·E_p[f] + (1-t)·E_r[f]` (affinité) |
+| `expectation_affine` | `E_p[a·u+b] = a·E_p[u] + b` (unicité affine) |",,,,,,,,64885a9b8870fe95,,,,,,,
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-2-Lean-ExpectedUtility.ipynb,ac38228d,markdown,fr,a29785e12213a916,"## 4. Les quatre axiomes de rationalité de von Neumann–Morgenstern
+
+Le module `Utility/Axioms.lean` formalise les quatre axiomes qu'une préférence sur les
+loteries doit satisfaire pour admettre une représentation en utilité espérée :
+
+- `Pref α = Lottery α → Lottery α → Prop` — une préférence (`P p q` se lit « `p` ≽ `q` »).
+- `IsComplete P` — **complétude** : toute paire de loteries est comparable.
+- `IsTransitive P` — **transitivité** : les chaînes de préférence ne cyclent pas.
+- `IsIndependent P` — **indépendance (substitution)** : un mélange commun préserve la préférence.
+- `IsContinuous P` — **continuité (Archimède)** : pas de loterie infiniment meilleure ; des mélanges intermédiaires existent.
+- `IsRational P` — une préférence **rationnelle** satisfait les quatre axiomes (structure).",,,,,,,,a29785e12213a916,,,,,,,
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-2-Lean-ExpectedUtility.ipynb,ebc86b51,code,fr,c62142c2b464ffe3,"#check Pref
+#check IsComplete
+#check IsTransitive
+#check IsIndependent
+#check IsContinuous
+#check IsRational",,,,,,,,c62142c2b464ffe3,,,,,,,
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-2-Lean-ExpectedUtility.ipynb,fe12aa94,markdown,fr,0097939982b8d124,"### Lecture : les quatre piliers de la rationalité
+
+| Axiome | Lecture |
+|--------|---------|
+| `Pref α` | relation binaire sur les loteries (`p ≽ q`) |
+| `IsComplete` | toute paire comparable |
+| `IsTransitive` | `p ≽ q ≽ r ⟹ p ≽ r` |
+| `IsIndependent` | `p ≽ q ⟹ mix t p r ≽ mix t q r` |
+| `IsContinuous` | `p ≽ q ≽ r ⟹ ∃ t, mix t p r ~ q` (Archimède) |
+| `IsRational` | satisfait les quatre (structure) |",,,,,,,,0097939982b8d124,,,,,,,
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-2-Lean-ExpectedUtility.ipynb,5833cba9,markdown,fr,070ac9aa94cbd202,"## 5. Le théorème de représentation : direction sound + stabilité affine
+
+Le module `Utility/Representation.lean` prouve la **direction sound** du théorème vNM :
+si `u` représente `P`, alors `P` satisfait chacun des quatre axiomes (les axiomes se
+réduisent à des faits élémentaires sur l'ordre et la structure affine de `ℝ`).
+
+- `IsExpectedUtilityRep u P` — `u` représente `P` : `P p q ↔ E_p[u] ≥ E_q[u]`.
+- `rep_complete` / `rep_transitive` / `rep_independent` / `rep_continuous` — `u` représentée ⟹ chaque axiome.
+- **`expected_utility_rep_is_rational`** (flagship) — `IsExpectedUtilityRep u P → IsRational P` (direction sound).
+- `affine_rep_is_rep` — **stabilité affine** : `a·u + b` (`a > 0`) représente aussi `P` (unicité de l'utilité à transformation affine positive près).
+- `rep_strict_iff` / `rep_indifference_iff` / `strict_irrefl` — préférence stricte et indifférence sous une représentation.",,,,,,,,070ac9aa94cbd202,,,,,,,
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-2-Lean-ExpectedUtility.ipynb,9368de8e,code,fr,951b3c2da42a2bda,"#check IsExpectedUtilityRep
+#check rep_complete
+#check rep_independent
+#check expected_utility_rep_is_rational
+#check affine_rep_is_rep
+#check rep_strict_iff",,,,,,,,951b3c2da42a2bda,,,,,,,
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-2-Lean-ExpectedUtility.ipynb,5ca27e4b,markdown,fr,421decedf0dfe647,"### Lecture : la direction sound, prouvée entièrement
+
+| Théorème | Conclusion |
+|----------|-----------|
+| `expected_utility_rep_is_rational` | représentation ⟹ rationalité (sound, flagship) |
+| `affine_rep_is_rep` | `a·u + b` (`a>0`) représente aussi `P` (unicité affine) |
+| `rep_strict_iff` | `p ≻ q ⟺ E_p[u] > E_q[u]` |
+| `rep_indifference_iff` | `p ~ q ⟺ E_p[u] = E_q[u]` |
+
+### Le jalon laissé ouvert (honnêtement)
+
+La **réciproque** — toute préférence rationnelle admet une représentation en utilité
+espérée — est la moitié **substantielle** du théorème vNM (Herstein & Milnor, 1953). Elle
+exige un argument de séparation / algèbre linéaire non trivial, et est laissée comme
+jalon suivant, délibérément **non `sorry`-backed** : la lib reste entièrement sorry-free.
+Seules les **différences** d'utilité (pas les niveaux) sont identifiées par les données
+de choix — c'est l'unicité affine.",,,,,,,,421decedf0dfe647,,,,,,,
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-2-Lean-ExpectedUtility.ipynb,ec40e48c,markdown,fr,ff4ad0dd5bcd017b,"## 6. La chaîne causale complète
+
+Les trois modules composent une chaîne unique, des loteries à la rationalité :
+
+1. **`Basic`** — `Lottery`/`expectation`/`mix` + `expectation_mix`/`expectation_affine` (l'algèbre affine de l'espérance).
+2. **`Axioms`** — `Pref`/les 4 axiomes/`IsRational` (le cadre de la rationalité).
+3. **`Representation`** — `IsExpectedUtilityRep` ⟶ les 4 axiomes sous représentation ⟶ flagship `expected_utility_rep_is_rational` + stabilité affine.",,,,,,,,ff4ad0dd5bcd017b,,,,,,,
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-2-Lean-ExpectedUtility.ipynb,92be5b63,markdown,fr,1633006f9f83db36,"## 7. Exemple guidé et exercices
+
+### Exercice 1 — Loteries, mélange et espérance (Python)
+
+Ancrez l'intuition : une loterie = dictionnaire `{issue: probabilité}` sommant à 1.
+Implémentez `expectation` (utilité espérée) et `mix` (mélange convexe), puis vérifiez
+que l'espérance est affine sous le mélange.
+
+```python
+def expectation(lottery, utility):
+    # Esperance de la fonction d'utilite sous la loterie
+    # lottery : {issue: prob}, utility : {issue: float}
+    # TODO etudiant : somme des prob * utility
+    return None  # TODO
+
+def mix(t, lottery_p, lottery_r):
+    # Mélange convexe t*p + (1-t)*r (t dans [0,1])
+    # TODO etudiant : pour chaque issue, t*proba_p + (1-t)*proba_r
+    return None  # TODO
+```",,,,,,,,1633006f9f83db36,,,,,,,
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-2-Lean-ExpectedUtility.ipynb,939c955f,markdown,fr,52b358f931e6fa0d,"### Exercice 2 — Une préférence représentée est transitive (Lean)
+
+Prouvez la transitivité d'une préférence représentée, **sans** utiliser `rep_transitive`.
+Indice : sous une représentation, `P p q ⟺ E_p[u] ≥ E_q[u]`. La transitivité suit de
+celle de `≥` sur `ℝ` (`linarith` avec les deux hypothèses décantées).
+
+```lean
+-- TODO etudiant : remplacer le sorry
+-- example (u : α → ℝ) (P : Pref α) (h : IsExpectedUtilityRep u P)
+--     (p q r : Lottery α) (hpq : P p q) (hqr : P q r) : P p r := by
+--   sorry
+```",,,,,,,,52b358f931e6fa0d,,,,,,,
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-2-Lean-ExpectedUtility.ipynb,441f4cee,markdown,fr,30a1202395945bb0,"### Exercice 3 — Pourquoi l'utilité est unique à transformation affine près (Python)
+
+Illustrez la stabilité affine (`affine_rep_is_rep`). Si `u` représente `P`, alors `a·u + b`
+(`a > 0`) représente **aussi** `P` : le classement des loteries par espérance est invariant.
+Implémentez la transformation et vérifiez que l'**ordre** des loteries est préservé
+(mais pas les valeurs absolues — d'où le fait que seules les **différences** d'utilité
+sont identifiées par les données de choix).
+
+```python
+def affine_transform(u, a, b):
+    # Transformee affine a*u + b (a > 0)
+    # TODO etudiant : retourner {issue: a*val + b}
+    return None  # TODO
+
+def preserves_order(lottery_p, lottery_q, u, a, b):
+    # Si E_p[u] >= E_q[u] alors E_p[a*u+b] >= E_q[a*u+b] ?
+    # TODO etudiant : verifier la preservation de l'ordre (a > 0)
+    return None  # TODO
+```",,,,,,,,30a1202395945bb0,,,,,,,
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-2-Lean-ExpectedUtility.ipynb,24f5cfbd,markdown,fr,86a75cbf331b34e9,"## Conclusion
+
+Ce companion **natif** exhibe la preuve formelle 0-sorry de la direction sound du
+théorème de représentation d'utilité espérée de von Neumann–Morgenstern dans le kernel
+Lean lui-même : `#check` et `#print axioms` rendent les signatures et les axiomes réels
+produits par le compilateur, sans intermédiaire Python.
+
+Le résultat phare `expected_utility_rep_is_rational` fonde le classement par espérance
+d'utilité : toute préférence qu'une utilité représente est rationnelle. Combinée à la
+stabilité affine (`affine_rep_is_rep`), c'est la justification formelle de pourquoi
+DecInfer-1 et PyMC-1 rangent les décisions par espérance d'utilité, et pourquoi seules
+les **différences** d'utilité (et non les niveaux) sont identifiées.
+
+**Jalon ouvert** : la réciproque (existence d'une représentation pour toute préférence
+rationnelle, Herstein–Milnor 1953) n'est pas formalisée ; la lib reste sorry-free.",,,,,,,,86a75cbf331b34e9,,,,,,,
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-9-Lean-Gittins.ipynb,fdb57963,markdown,fr,033005ee1e874f5e,"# DecInfer-9-Preuves formelles — Indice de Gittins
+**Companion notebook** — [DecInfer-8 : Decision sequentielle](DecInfer-8-Sequential.ipynb)
+
+**Navigation** : [<< 20-Decision-Sequential](DecInfer-8-Sequential.ipynb) | [Index](README.md)
+
+**Kernel** : Lean 4 (WSL)
+
+---
+
+## Configuration du projet Lake avec Mathlib
+
+Ce notebook utilise **Lean 4 pur** (sans import Mathlib) en mode pedagogique. Un projet Lake independant `../../decision_theory_lean/` contient les preuves formelles avec Mathlib.
+
+### Projet Lake
+
+```bash
+# 1. Aller dans le repertoire du projet Lake
+cd MyIA.AI.Notebooks/Probas/decision_theory_lean
+
+# 2. Telecharger le cache Mathlib pre-compile
+lake exe cache get
+
+# 3. Construire le projet
+lake build
+```
+
+### Fichiers Lean du projet
+
+| Fichier | Contenu | Sorry |
+|---------|---------|-------|
+| `Gittins/Basic.lean` | BanditArm, BanditInstance, Policy, RewardHistory | 0 |
+| `Gittins/Discount.lean` | Convergence geometrique, valeur actualisee | 0 (post-#5272 Float->R) |
+| `Gittins/GittinsTheorem.lean` | Indice de Gittins, theoreme d'optimalite | 2 (L99 V + L103 proof, INTRINSIC #4039) |
+
+---
+
+## Introduction
+
+L'**indice de Gittins** (Gittins 1979) est un concept fondamental en theorie des bandits manchots. Il fournit une politique optimale pour le probleme du bandit multi-bras avec escompte geometrique, en assignant a chaque bras un ""indice"" independant et en jouant le bras d'indice maximal.
+
+Ce notebook formalise les concepts cles en Lean 4 :
+
+1. **Types de base** : Bras de bandit, instance, politique, historique
+2. **Escompte geometrique** : Sommes actualisees, convergence
+3. **Politiques** : Gloutonne, epsilon-greedy, UCB1
+4. **Indice de Gittins** : Definition, theoreme d'optimalite
+5. **Exemples numeriques** : Calculs et demonstrations
+
+### Correspondance Python / Lean (bandits multi-bras)
+
+| Notebook | Contenu |
+|----------|---------|
+| [**DecPyMC-7 (Python)**](../PyMC/DecPyMC-7-Sequential.ipynb) | Implementation : bandits, Gittins, UCB, Thompson Sampling |
+| **DecInfer-9 (Lean)** (ce notebook) | Formalisation : types, lemmes, theoreme d'optimalite |
+
+### Duree estimee : 60 minutes",,,,,,,,033005ee1e874f5e,,,,,,,
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-9-Lean-Gittins.ipynb,4dc004ad,markdown,fr,a4b8164f98085599,"---
+
+## 1. Types de base — Bandits manchots
+
+### 1.1 Definition mathematique
+
+Un **bandit manchot a K bras** est defini par :
+- Un ensemble de K bras, chacun avec une distribution de recompense $R_k$
+- Un facteur d'escompte geometrique $\gamma \in (0, 1)$
+- Un objectif : maximiser $\mathbb{E}\left[\sum_{t=0}^{\infty} \gamma^t r_{a_t}\right]$
+
+Le nom ""bandit manchot"" vient des machines a sous (one-armed bandits) — avec plusieurs bras, lequel tirer ?
+
+> **Note Lean** : Les definitions ci-dessous utilisent `Float` comme approximation de $\mathbb{R}$ (Lean 4 pur, sans Mathlib). Le projet Lake `../../decision_theory_lean/` utilise `Mathlib.Data.Real.Basic` pour les preuves rigoureuses.",,,,,,,,a4b8164f98085599,,,,,,,
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-9-Lean-Gittins.ipynb,99bb79ff,code,fr,fba08141f351a2b0,"-- Definitions fondamentales pour les bandits manchots (Lean 4 pur)
+
+abbrev Real := Float
+
+-- Un bras de bandit est caracterise par sa distribution de recompense
+structure BanditArm where
+  name : String
+  trueMean : Real  -- esperance de la recompense
+  deriving Repr
+
+-- Instance de bandit : ensemble de bras avec facteur d'escompte
+structure BanditInstance where
+  arms : Array BanditArm
+  discount : Real  -- gamma in (0, 1)
+  deriving Repr
+
+-- Politique : a chaque etape, choisir un bras
+def Policy := Nat → Nat
+
+-- Historique de recompenses pour un bras
+def RewardHistory := List Real
+
+-- Nombre de tirages d'un bras
+def pullCount (h : RewardHistory) : Nat := h.length
+
+-- Moyenne empirique (0 si historique vide)
+def empiricalMean (h : RewardHistory) : Real :=
+  match h with
+  | [] => 0.0
+  | _ => h.foldl (· + ·) 0.0 / h.length.toFloat
+
+-- Exemple : bandit a 2 bras
+def exampleBandit : BanditInstance := {
+  arms := #[{ name := ""Bras A"", trueMean := 0.3 },
+             { name := ""Bras B"", trueMean := 0.7 }],
+  discount := 0.95
+}
+
+#check BanditArm
+#check BanditInstance
+#check Policy
+#eval s!""Bras : {exampleBandit.arms.toList.map (·.name)} | gamma = {exampleBandit.discount}""",,,,,,,,fba08141f351a2b0,,,,,,,
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-9-Lean-Gittins.ipynb,9b23a5bd,markdown,fr,ab750d5a441e4848,"### 1.2 Proprietes structurelles
+
+Les bandits manchots opposent deux objectifs :
+- **Exploitation** : Jouer le bras qui semble le meilleur (maximiser la recompense immediate)
+- **Exploration** : Tester d'autres bras pour reduire l'incertitude
+
+Le dilemma exploration-exploitation est au coeur du probleme. Sans exploration, on risque de rater le meilleur bras. Sans exploitation, on gaspille des tirages sur des bras sous-optimaux.
+
+> **Note** : `pullCount` et `empiricalMean` sont des outils pour suivre l'etat de connaissance. Le nombre de tirages d'un bras determine la confiance dans l'estimation de sa moyenne.",,,,,,,,ab750d5a441e4848,,,,,,,
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-9-Lean-Gittins.ipynb,d7020231,markdown,fr,8f13e8ad952b78ae,"---
+
+## 2. Escompte geometrique
+
+### 2.1 Valeur actualisee
+
+L'escompte geometrique est le mecanisme central de la theorie de Gittins. Avec un facteur $\gamma \in (0, 1)$, la valeur actualisee d'une sequence de recompenses est :
+
+$$V = \sum_{t=0}^{\infty} \gamma^t r_t$$
+
+Pour des recompenses constantes $r_t = r$, cette somme converge vers $\frac{r}{1-\gamma}$.
+
+> **Note Lean** : Mathlib fournit `tsum_geometric_of_lt_one` qui prouve $\sum'_{n:\mathbb{N}} \gamma^n = \frac{1}{1-\gamma}$ pour $0 \leq \gamma < 1$. Le projet Lake `../../decision_theory_lean/Discount.lean` l'utilise directement.",,,,,,,,8f13e8ad952b78ae,,,,,,,
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-9-Lean-Gittins.ipynb,55dc748b,code,fr,3be6ddbe83378688,"-- Somme actualisee d'une sequence de recompenses
+-- V = sum gamma^t * r_t
+
+def discountedSum (gamma : Real) (rewards : List Real) : Real :=
+  rewards.enum.foldl (fun acc (t, r) => acc + gamma ^ t.toFloat * r) 0
+
+-- Recompenses constantes
+def constantRewards (n : Nat) : List Real := List.replicate n 1.0
+
+-- Demonstration numerique : convergence vers 1/(1-gamma)
+-- gamma = 0.9 : somme exacte = 10.0
+#eval discountedSum 0.9 (constantRewards 10)   -- ≈ 6.51
+#eval discountedSum 0.9 (constantRewards 50)   -- ≈ 9.95
+#eval 1.0 / (1.0 - 0.9)                        -- = 10.0
+
+-- gamma = 0.95 : somme exacte = 20.0
+#eval discountedSum 0.95 (constantRewards 20)  -- ≈ 13.09
+#eval discountedSum 0.95 (constantRewards 100) -- ≈ 19.87
+#eval 1.0 / (1.0 - 0.95)                       -- = 20.0
+
+-- gamma = 0.99 : somme exacte = 100.0
+#eval discountedSum 0.99 (constantRewards 100) -- ≈ 63.4
+#eval 1.0 / (1.0 - 0.99)                       -- = 100.0",,,,,,,,3be6ddbe83378688,,,,,,,
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-9-Lean-Gittins.ipynb,e9ef272d,code,fr,29f59e80826db5f2,"-- Preuve sur Nat : la somme geometrique de puissances de 2
+-- sum_{k=0}^{n-1} 2^k = 2^n - 1
+
+def geometricNatSum (base : Nat) (n : Nat) : Nat :=
+  (List.range n).foldl (fun acc k => acc + base ^ k) 0
+
+-- La somme des 2^k pour k=0..n-1 vaut 2^n - 1
+-- La preuve par induction sur n est INTRACTABLE en Lean 4 pur
+-- car List.range et List.foldl ne se reduisent pas bien avec simp/omega.
+-- Le projet Lake (decision_theory_lean/Gittins/Discount.lean) prouve la version reelle
+-- avec Mathlib (tsum_geometric_of_lt_one).
+theorem geometric_sum_base2 (n : Nat) :
+    geometricNatSum 2 n = 2 ^ n - 1 := by
+  sorry  -- INTRACTABLE : List.foldl sur List.range ne se reduit pas
+
+-- Verification numerique (la formule est correcte)
+#eval geometricNatSum 2 5  -- 31 = 2^5 - 1 = 32 - 1
+#eval 2 ^ 5 - 1            -- 31
+#eval geometricNatSum 2 10 -- 1023 = 2^10 - 1
+
+-- Factorielle (utilisee dans les coefficients de Shapley et les calculs de regret)
+def factorial : Nat → Nat
+  | 0 => 1
+  | n + 1 => (n + 1) * factorial n
+
+-- Propriete fondamentale (prouvee par rfl : definition recursive directe)
+theorem factorial_succ (n : Nat) : factorial (n + 1) = (n + 1) * factorial n := rfl
+
+#eval factorial 5   -- 120
+#eval factorial 10  -- 3628800",,,,,,,,29f59e80826db5f2,,,,,,,
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-9-Lean-Gittins.ipynb,10e2f3f2,markdown,fr,86528727cd47c8c0,"### 2.2 Interpretation
+
+La demonstration numerique montre que la somme partielle converge rapidement vers la limite $\frac{1}{1-\gamma}$ :
+
+| $\gamma$ | Limite $\frac{1}{1-\gamma}$ | 50 termes | 100 termes |
+|----------|------------------------------|-----------|------------|
+| 0.9 | 10.0 | 9.95 | 9.9997 |
+| 0.95 | 20.0 | 18.46 | 19.87 |
+| 0.99 | 100.0 | 39.5 | 63.4 |
+
+Plus $\gamma$ est proche de 1, plus l'agent est ""patient"" (valorise le futur), et plus la convergence est lente. Pour $\gamma = 0.99$, il faut plus de 400 termes pour atteindre 98% de la limite.
+
+La preuve `geometric_sum_base2` sur les entiers utilise `sorry` car `List.foldl` sur `List.range` ne se reduit pas avec les tactiques `simp`/`omega`. Le projet Lake `../../decision_theory_lean/Discount.lean` prouve la version reelle avec Mathlib (`tsum_geometric_of_lt_one`).",,,,,,,,86528727cd47c8c0,,,,,,,
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-9-Lean-Gittins.ipynb,cd4d1f4e,markdown,fr,7ce9ea750bb35a21,"---
+
+## 3. Politiques de decision
+
+### 3.1 Politique gloutonne (greedy)
+
+La politique la plus simple : a chaque etape, jouer le bras avec la meilleure moyenne empirique. Le probleme : elle peut se bloquer sur un bras sous-optimal si l'exploration initiale est defavorable.",,,,,,,,7ce9ea750bb35a21,,,,,,,
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-9-Lean-Gittins.ipynb,4754c6f2,code,fr,d98f535e4084feac,"-- Politique gloutonne : toujours choisir le bras avec la meilleure estimation
+
+-- Choix du bras avec la plus haute moyenne empirique (via Array.range.foldl)
+-- Note : Array.foldlIdx n'existe pas en Lean 4 ; on utilise Array.range pour iterer
+-- avec l'indice, calque sur le pattern de gittinsPolicy dans GittinsTheorem.lean L64-71.
+def greedyChoice (estimates : Array Real) : Nat :=
+  (Array.range estimates.size).foldl (fun bestIdx idx =>
+    let val := estimates[idx]?.getD 0.0
+    let bestVal := estimates[bestIdx]?.getD 0.0
+    if val > bestVal then idx else bestIdx) 0
+
+-- Exemple : estimations apres quelques tirages
+-- Bras A : 3 tirages, moyenne = 0.6
+-- Bras B : 1 tirage, moyenne = 0.2 (malchance !)
+-- Bras C : 1 tirage, moyenne = 0.5
+def estimates1 : Array Real := #[0.6, 0.2, 0.5]
+
+#eval s!""Choix glouton : Bras {greedyChoice estimates1}""
+-- Le greedy choisit le Bras A (estimation 0.6)
+-- Mais le vrai meilleur est peut-etre le B ou le C
+
+-- Politique epsilon-greedy : explorer avec probabilite epsilon
+structure EpsilonGreedyPolicy where
+  epsilon : Real  -- probabilite d'exploration in [0, 1]
+  estimates : Array Real
+  pullCounts : Array Nat
+  deriving Repr
+
+-- Choix du bras le moins explore (pour forcer l'exploration)
+def leastExplored (pullCounts : Array Nat) : Nat :=
+  (Array.range pullCounts.size).foldl (fun bestIdx idx =>
+    let val := pullCounts[idx]?.getD 999999
+    let bestVal := pullCounts[bestIdx]?.getD 999999
+    if val < bestVal then idx else bestIdx) 0
+
+-- Politique UCB1 : Upper Confidence Bound
+-- Balance exploration/exploitation via un bonus d'incertitude
+def ucb1Score (mean : Real) (pulls : Nat) (totalPulls : Nat) : Real :=
+  if pulls = 0 then 1.0 / 0.0  -- +infinity : bras non explore
+  else mean + (2.0 * (totalPulls.toFloat.log) / pulls.toFloat).sqrt
+
+def ucb1Choice (estimates : Array Real) (pullCounts : Array Nat) : Nat :=
+  let totalPulls := pullCounts.toList.foldl (· + ·) 0
+  let scores := estimates.mapIdx (fun i mean =>
+    ucb1Score mean (pullCounts[i]?.getD 0) totalPulls)
+  greedyChoice scores
+
+#check @greedyChoice
+#check @ucb1Score
+#check @ucb1Choice",,,,,,,,d98f535e4084feac,,,,,,,
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-9-Lean-Gittins.ipynb,7815b258,code,fr,3f3050ccdfdf0475,"-- Contre-exemple : le greedy est strictement sous-optimal
+-- Scenario : 2 bras, apres 1 tirage chacun
+--   Bras 0 : tire 0.8 (malchance, vrai moyenne = 0.3)
+--   Bras 1 : tire 0.2 (malchance, vrai moyenne = 0.7)
+-- Le greedy choisit le Bras 0 alors que le Bras 1 est optimal
+
+-- Le bonus UCB1 decroit avec le nombre de tirages
+-- Cela garantit que l'exploration diminue avec le temps
+theorem ucb_bonus_decreases_with_pulls :
+    -- Pour t fixe, le bonus sqrt(2*ln(t)/n) decroit quand n augmente
+    -- Sur Nat : si n1 < n2, le denominateur grandit donc la fraction decroit
+    forall n1 n2 t : Nat,
+      0 < n1 -> n1 < n2 -> 0 < t ->
+      -- On ne peut pas le prouver sur Float directement
+      -- mais le principe est que n1 < n2 => 1/n1 > 1/n2
+      (n1 : Nat) < (n2 : Nat) := by
+  intro n1 n2 t h1 h2 ht
+  exact h2
+
+-- Le UCB1 choisit toujours les bras non explores en priorite
+-- (leur score est +infinity)
+theorem ucb1_explores_unvisited :
+    -- Si un bras n'a jamais ete tire (pulls = 0),
+    -- son score UCB1 est +infinity
+    -- (donc il sera choisi en priorite)
+    forall t : Nat, 0 < t ->
+    ucb1Score 0.0 0 t > 0.0 := by
+  intro t ht
+  simp [ucb1Score]
+  -- 0.0 / 0.0 = NaN sur Float, pas > 0.0
+  -- En pratique, on utilise +infinity comme convention
+  sorry
+
+-- Regret cumulatif du UCB1 : O(sqrt(K*T*log(T)))
+-- (Auer et al. 2002)
+-- Ce resultat fondamental est INTRACTABLE a formaliser sans MDP
+theorem ucb1_sublinear_regret :
+    -- Le regret cumulatif du UCB1 est sous-lineaire en T
+    -- Regret(T) = O(sqrt(K*T*log(T)))
+    True := by
+  sorry  -- INTRACTABLE : necessite des inegalites de concentration et l'analyse asymptotique
+
+#check @ucb1_explores_unvisited
+#check @ucb1_sublinear_regret",,,,,,,,3f3050ccdfdf0475,,,,,,,
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-9-Lean-Gittins.ipynb,e5f68563,markdown,fr,ed7c056691bf3108,"### 3.2 Interpretation : exploration vs exploitation
+
+Le contre-exemple ci-dessus illustre le piege du greedy :
+1. Apres 1 tirage, le Bras 0 semble meilleur (0.8 > 0.2)
+2. Le greedy continue a tirer le Bras 0 indefiniment
+3. Mais le Bras 1 a une vraie moyenne de 0.7 > 0.3
+
+Le **UCB1** resout ce probleme en ajoutant un **bonus d'exploration** qui decroit avec le nombre de tirages. Le bonus est infini pour les bras non explores, garantissant qu'ils seront tries au moins une fois.
+
+La preuve du regret sous-lineaire (`ucb1_sublinear_regret`) est l'un des resultats fondamentaux de l'apprentissage par renforcement (Auer et al. 2002), mais sa formalisation complete necessite des outils d'analyse asymptotique et de probabilites absents de Mathlib.",,,,,,,,ed7c056691bf3108,,,,,,,
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-9-Lean-Gittins.ipynb,f52d8ffb,markdown,fr,92688f0f85cb2a80,"---
+
+## 4. L'indice de Gittins
+
+### 4.1 Intuition : le probleme de la retraite
+
+L'indice de Gittins d'un bras est defini via un **probleme de stopping optimal** : ""Jusqu'a quelle valeur de retraite $M$ est-il preferable de continuer a tirer ce bras ?""
+
+$$G_k(\text{historique}) = \sup\left\{ M : V_k^{\text{continuer}}(\text{historique}, M) \geq M \right\}$$
+
+ou $V_k^{\text{continuer}}$ est la valeur de continuer a jouer le bras $k$ (avec option de retraite $M$).
+
+**Cle de l'optimalite** : chaque bras a un indice independant. Il suffit de jouer le bras d'indice maximal a chaque etape.",,,,,,,,92688f0f85cb2a80,,,,,,,
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-9-Lean-Gittins.ipynb,78be2941,code,fr,975258979f3f4103,"-- Definition de l'indice de Gittins (specialisation pour historique vide)
+-- L'indice de Gittins exact necessite la resolution d'un probleme d'arret optimal
+-- sur la distribution a posteriori des recompenses (INTRINSIC : MDP absent Mathlib,
+-- voir gittins_optimality dans GittinsTheorem.lean L95-103, #4039).
+-- Pour la version ""bras connu"" (historique vide, distribution a posteriori
+-- concentree sur trueMean), l'indice se reduit a la vraie moyenne du bras.
+-- Cette specialisation permet de prouver formellement `gittins_index_known_arm`
+-- dans le notebook (cellule 14), alignee sur decision_theory_lean/Gittins/GittinsTheorem.lean L50-51
+-- post-#5272 (Float->R port).
+def gittinsIndex (arm : BanditArm) (_gamma : Real) (_history : RewardHistory) : Real :=
+  arm.trueMean
+
+-- Approximation pour un bras Bernoulli avec prior Beta(alpha, beta)
+-- L'indice est approximativement la moyenne a posteriori + un bonus
+-- qui depend de la variance et de gamma
+def gittinsIndexBernoulliApprox (alpha beta : Nat) (gamma : Real) : Real :=
+  let posteriorMean := alpha.toFloat / (alpha + beta).toFloat
+  let uncertainty :=
+    let s := (alpha + beta).toFloat
+    (alpha.toFloat * beta.toFloat / (s * s * (alpha + beta + 1).toFloat)).sqrt
+  posteriorMean + uncertainty * gamma / (1.0 - gamma)  -- formule simplifiee
+
+-- Exemples numeriques
+#eval gittinsIndexBernoulliApprox 1 1 0.9   -- Bras uniforme (peu d'info)
+#eval gittinsIndexBernoulliApprox 10 2 0.9   -- Bras probablement bon
+#eval gittinsIndexBernoulliApprox 2 10 0.9   -- Bras probablement mauvais
+#eval gittinsIndexBernoulliApprox 50 50 0.9  -- Bras bien connu, moyen
+
+#check @gittinsIndex
+#check @gittinsIndexBernoulliApprox",,,,,,,,975258979f3f4103,,,,,,,
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-9-Lean-Gittins.ipynb,f38d19db,code,fr,17470b0ffbd0384d,"-- Proprietes de l'indice de Gittins (specialisation historique vide)
+-- Alignees sur decision_theory_lean/Gittins/GittinsTheorem.lean post-#5272 Float->R port
+-- (L117-119, L134-138, L141-144 ; voir memory c.238.22b).
+
+-- Un bras connu (variance nulle) a un indice egal a sa vraie moyenne
+-- Lake L117-119 : preuve par `rfl` (egalite definitionnelle directe)
+theorem gittins_index_known_arm (arm : BanditArm) (gamma : Real) :
+    gittinsIndex arm gamma [] = arm.trueMean := by
+  rfl
+
+-- L'indice est croissant en gamma (plus de patience = plus d'exploration)
+-- Pour la specialisation historique vide, l'indice ne depend PAS de gamma
+-- (gittinsIndex body = arm.trueMean, _gamma ignoree), donc l'inegalite tient
+-- avec egalite (x <= x). C'est trivialement vrai sur un type avec LE,
+-- mais Real := Float n'a pas d'instance `LE Float` derivable en Lean 4.31.0
+-- vanilla (IEEE 754 ; pas de `Preorder Float` standard).
+-- c.238.22b : `le_refl` PAS tactic en Lean 4 pur vanilla (teste -> `unknown
+-- tactic`). CE NOTEBOOK = Real := Float (Lean 4 pur, sans Mathlib) -> sorry
+-- legitime ICI. Le lake associe (decision_theory_lean/Gittins/
+-- GittinsTheorem.lean) utilise R (Mathlib) ou `le_refl` EST valide (preuve
+-- `apply le_refl`, CI #5272 Lean CI SUCCESS) : pas de regression lake.
+-- Barriere Float = specifique au notebook. Verdict (notebook) : sorry + WART.
+theorem gittins_index_monotone_gamma (arm : BanditArm) (gamma1 gamma2 : Real)
+    (h : gamma1 <= gamma2) :
+    gittinsIndex arm gamma1 [] <= gittinsIndex arm gamma2 [] := by
+  sorry  -- FLOAT-ORDER WART : LE Float indisponible (c.238.22b first-hand)
+
+-- Un bras uniformement mal connu (prior plat) a un indice eleve
+-- car le potentiel d'amelioration est grand
+-- INTRACTABLE sur Float en IEEE 754 (pas d'instance `Preorder` derivable pour
+-- les expressions algebriques). Barriere notebook (Real := Float) ; le lake
+-- (decision_theory_lean, R Mathlib) n'a plus ce wart post-#5272 (CI #5272).
+theorem gittins_index_high_uncertainty :
+    -- L'indice d'un bras avec un prior uniforme (Beta(1,1))
+    -- est >= 0.5 (la moyenne du prior)
+    gittinsIndexBernoulliApprox 1 1 0.9 >= 0.5 := by
+  sorry  -- FLOAT-ORDER WART : IEEE 754 sur Float, pas de Preorder derivable
+
+#check @gittins_index_known_arm
+#check @gittins_index_monotone_gamma",,,,,,,,17470b0ffbd0384d,,,,,,,
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-9-Lean-Gittins.ipynb,11091b1d,markdown,fr,6686b4fe98df84b0,"### 4.2 Interpretation
+
+L'approximation de Gittins pour un bras Bernoulli illustre le compromis exploration/exploitation :
+
+| Prior $\alpha, \beta$ | Moyenne a posteriori | Incertitude | Indice approx. |
+|------------------------|---------------------|-------------|----------------|
+| 1, 1 (uniforme) | 0.50 | 0.41 | eleve |
+| 10, 2 (bon bras) | 0.83 | 0.11 | eleve (justifie) |
+| 2, 10 (mauvais bras) | 0.17 | 0.11 | faible |
+| 50, 50 (bien connu) | 0.50 | 0.05 | moyen |
+
+Un bras mal connu a un indice eleve **meme si sa moyenne est moyenne**, car l'incertitude offre un potentiel d'amelioration. C'est l'essence de l'exploration dirigee par l'indice de Gittins.",,,,,,,,6686b4fe98df84b0,,,,,,,
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-9-Lean-Gittins.ipynb,86628910,markdown,fr,29a801173ebb283b,"---
+
+## 5. Theoreme d'optimalite de Gittins
+
+### 5.1 Enonce du theoreme
+
+**Theoreme (Gittins 1979, Weber 1992)** : Pour le bandit multi-bras avec escompte geometrique $\gamma \in (0,1)$, la politique qui joue a chaque etape le bras d'indice de Gittins maximal est **optimale** parmi toutes les politiques adaptatives.
+
+Ce resultat est remarquable car il decompose un probleme dynamique complexe en un probleme statique simple : calculer un indice par bras (independamment des autres bras) et jouer le maximum.",,,,,,,,29a801173ebb283b,,,,,,,
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-9-Lean-Gittins.ipynb,2670e17c,code,fr,54816aa5200fddc8,"-- Politique de Gittins : jouer le bras d'indice maximal
+
+-- Valeur d'une politique (somme actualisee des esperances de recompense)
+-- Note : la valeur exacte necessite un calcul d'esperance sur les distributions.
+-- INTRINSIC : pas de formalisation de l'esperance mathematique sans MDP/Bellman
+-- (cf gittins_optimality dans GittinsTheorem.lean L95-103, #4039).
+def policyValue (inst : BanditInstance) (policy : Policy) : Real := by
+  sorry  -- Necessite une formalisation des esperances mathematiques
+
+-- Helper : indice du maximum d'un Array de BanditArm par score
+-- Note : Array.foldlIdx n'existe pas en Lean 4 ; on utilise Array.range.foldl
+-- (pattern identique a gittinsPolicy dans GittinsTheorem.lean L64-71 post-#5272).
+def armsArgmax (arms : Array BanditArm) (score : BanditArm → Real) : Nat :=
+  (Array.range arms.size).foldl (fun bestIdx idx =>
+    let arm := arms[idx]?.getD { name := """", trueMean := 0.0 }
+    let bestArm := arms[bestIdx]?.getD { name := """", trueMean := 0.0 }
+    if score arm > score bestArm then idx else bestIdx) 0
+
+-- Politique de Gittins : a chaque etape, jouer le bras d'indice maximal
+-- Aligne sur decision_theory_lean/Gittins/GittinsTheorem.lean L61-71 post-#5272.
+-- Le parametre `_histories` est conserve pour la coherence API (per-met l'extension
+-- ulterieure vers une politique adaptative historique-dependante, voir #4039 backlog).
+def gittinsPolicy (inst : BanditInstance)
+    (_histories : Array RewardHistory) : Nat :=
+  armsArgmax inst.arms (fun arm => gittinsIndex arm inst.discount [])
+
+-- **THEOREME D'OPTIMALITE DE GITTINS**
+-- La politique de Gittins maximise la valeur actualisee totale
+-- parmi TOUTES les politiques adaptatives.
+-- INTRINSIC : necessite MDP/Bellman/optimal-stopping absent de Mathlib.
+-- decision_theory_lean/Gittins/GittinsTheorem.lean L95-103 a la meme barriere documentee.
+-- Note de typage : gittinsPolicy retourne `Nat` (indice du bras), mais Policy := Nat -> Nat.
+-- On etend en Policy via eta-expansion `fun _ => gittinsPolicy inst #[]`.
+theorem gittins_optimality (inst : BanditInstance)
+    (hγ : 0 < inst.discount ∧ inst.discount < 1) :
+    forall π : Policy,
+      policyValue inst (fun _ => gittinsPolicy inst #[]) >=
+      policyValue inst π := by
+  intro π
+  sorry  -- INTRACTABLE : MDP/Bellman absent Mathlib (#4039 INTRINSIC)
+  -- La preuve complete necessite :
+  -- 1. Formalisation des MDP et politiques adaptatives
+  -- 2. Theoreme de decomposition index
+  -- 3. Preuve d'optimalite par induction sur l'horizon
+
+#check @gittins_optimality
+#check @gittinsPolicy
+#check @policyValue",,,,,,,,54816aa5200fddc8,,,,,,,
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-9-Lean-Gittins.ipynb,761e60c8,code,fr,64cfac53c06f23c6,"-- Corollaires et resultats lies
+
+-- La politique de Gittins bat le greedy dans le cas general
+-- INTRINSIC : la formulation complete necessite policyValue formalisee
+-- (cf policyValue sorry + gittins_optimality sorry).
+-- Version placeholder `True` : preuve par `trivial` (coherent avec
+-- decision_theory_lean/Gittins/GittinsTheorem.lean L141-144 post-#5272).
+theorem gittins_beats_greedy (inst : BanditInstance)
+    (h : inst.arms.size >= 2)
+    (hγ : 0 < inst.discount ∧ inst.discount < 1) :
+    -- Il existe des instances ou Gittins > greedy
+    -- (formulation simplifiee car la comparaison exacte
+    -- necessite la formalisation des esperances)
+    True := by
+  trivial
+
+-- La politique de Gittins est equivalente au greedy quand
+-- tous les bras sont parfaitement connus (variance nulle)
+theorem gittins_equals_greedy_known :
+    -- Si tous les bras sont connus, Gittins = greedy = jouer le meilleur bras
+    forall inst : BanditInstance,
+      inst.arms.size > 0 ->
+      True := by  -- Placeholder : la vraie statement necessite policyValue
+  intro inst h
+  trivial
+
+-- L'indice de Gittins pour un bras Bernoulli exact
+-- G(alpha, beta, gamma) peut se calculer via un developpement en serie
+-- Gittins & Glazebrook (1977)
+theorem gittins_bernoulli_exact :
+    -- L'indice de Gittins pour Bernoulli(alpha, beta) avec escompte gamma
+    -- est la racine d'une equation implicite
+    forall alpha beta : Nat, forall gamma : Real,
+      0 < gamma -> gamma < 1 -> alpha + beta > 0 ->
+      True := by  -- Placeholder
+  intro alpha beta gamma h1 h2 h3
+  trivial
+
+#check @gittins_beats_greedy
+#check @gittins_equals_greedy_known
+#check @gittins_bernoulli_exact",,,,,,,,64cfac53c06f23c6,,,,,,,
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-9-Lean-Gittins.ipynb,2802f15e,markdown,fr,249e7ca1113c8f64,"### 5.2 Discussion : pourquoi le theoreme est-il difficile a prouver ?
+
+La preuve du theoreme d'optimalite de Gittins est l'une des plus profondes en theorie des bandits. Elle repose sur trois piliers :
+
+1. **Arret optimal** : L'indice de Gittins est la solution d'un probleme d'arret optimal sur chaque bras individuel. Mathlib a `IsStoppingTime` et `stoppedValue` mais pas les outils pour les bandits.
+
+2. **Decomposition index** : La valeur d'un bras ne depend que de son propre historique, pas de l'etat des autres bras. Cette ""separabilite"" est la cle de la simplification.
+
+3. **Induction sur l'horizon** : L'optimalite se prouve en etendant le resultat de l'horizon $T$ a $T+1$. La version a horizon infini suit par convergence monotone.
+
+> **Etat de Mathlib** : Les types `Real`, `tsum`, les series geometriques, les temps d'arret existent. Mais il manque un cadre complet de **processus de decision markovien (MDP)**, de **bandits**, et d'**equations de Bellman**. Une formalisation complete est estimee a 2000-5000 lignes de definitions prealables.",,,,,,,,249e7ca1113c8f64,,,,,,,
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-9-Lean-Gittins.ipynb,1f72cf8b,markdown,fr,76dedefd387773a5,"---
+
+## 6. Exemples numeriques
+
+### Exemple guide 1 : Bandit a 2 bras Bernoulli
+
+Scenario :
+- Bras A : Bernoulli(0.3), prior Beta(1,1)
+- Bras B : Bernoulli(0.7), prior Beta(1,1)
+- $\gamma = 0.95$
+
+Apres 10 tirages de chaque bras, calculer les indices de Gittins approximes et determiner quel bras jouer.",,,,,,,,76dedefd387773a5,,,,,,,
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-9-Lean-Gittins.ipynb,1590e407,code,fr,6934e2325d999090,"-- Exemple numerique : comparaison des indices de Gittins
+
+-- Scenario : 2 bras Bernoulli avec priors Beta
+-- Bras A : Beta(1,1) -> uniforme, puis on observe 3 succes / 10 tirages
+-- Bras B : Beta(1,1) -> uniforme, puis on observe 7 succes / 10 tirages
+
+-- Parametres a posteriori :
+-- Bras A : Beta(1+3, 1+7) = Beta(4, 8) -> moyenne = 4/12 = 0.333
+-- Bras B : Beta(1+7, 1+3) = Beta(8, 4) -> moyenne = 8/12 = 0.667
+
+def posteriorA_alpha : Nat := 4   -- 1 + 3 succes
+def posteriorA_beta : Nat := 8    -- 1 + 7 echecs
+def posteriorB_alpha : Nat := 8   -- 1 + 7 succes
+def posteriorB_beta : Nat := 4    -- 1 + 3 echecs
+
+def gamma_val : Real := 0.95
+
+-- Calcul des indices approximes
+#eval s!""Indice Gittins (Bras A, Beta(4,8)) : {gittinsIndexBernoulliApprox posteriorA_alpha posteriorA_beta gamma_val}""
+#eval s!""Indice Gittins (Bras B, Beta(8,4)) : {gittinsIndexBernoulliApprox posteriorB_alpha posteriorB_beta gamma_val}""
+
+-- Valeurs de comparaison
+#eval s!""Moyenne post. A : {posteriorA_alpha.toFloat / (posteriorA_alpha + posteriorA_beta).toFloat}""
+#eval s!""Moyenne post. B : {posteriorB_alpha.toFloat / (posteriorB_alpha + posteriorB_beta).toFloat}""
+
+-- Resultat attendu :
+-- Le Bras B a un indice plus eleve (meilleure moyenne + meme incertitude)
+-- La politique de Gittins choisit le Bras B
+
+-- Exemple guide 2 : Impact de gamma sur l'exploration
+#eval s!""gamma=0.5, Beta(4,8) : {gittinsIndexBernoulliApprox 4 8 0.5}""
+#eval s!""gamma=0.9, Beta(4,8) : {gittinsIndexBernoulliApprox 4 8 0.9}""
+#eval s!""gamma=0.99, Beta(4,8) : {gittinsIndexBernoulliApprox 4 8 0.99}""
+-- Plus gamma est eleve, plus l'indice du bras incertain augmente",,,,,,,,6934e2325d999090,,,,,,,
+MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-9-Lean-Gittins.ipynb,a9c7510e,markdown,fr,4bd5ebfdc3abdb50,"---
+
+## 7. Resume et reference enseignant
+
+### 7.1 Concepts formalises
+
+| Concept | Definition Lean | Statut |
+|---------|----------------|--------|
+| Bras de bandit | `BanditArm` | Defini |
+| Instance | `BanditInstance` | Defini |
+| Politique | `Policy = Nat → Nat` | Defini |
+| Somme actualisee | `discountedSum` | Defini + #eval |
+| Serie geometrique | `geometricNatSum` | sorry (Lean 4 pur, cf Mathlib) |
+| Factorielle | `factorial` | Defini + `factorial_succ` prouve |
+| Greedy | `greedyChoice` | Defini (foldlIdx) |
+| UCB1 | `ucb1Score`, `ucb1Choice` | Defini |
+| Indice de Gittins | `gittinsIndex` | sorry |
+| Approx. Bernoulli | `gittinsIndexBernoulliApprox` | Defini + #eval |
+| Theoreme optimalite | `gittins_optimality` | sorry (INTRACTABLE) |
+| Gittins bat greedy | `gittins_beats_greedy` | sorry |
+| Indice bras connu | `gittins_index_known_arm` | sorry |
+| Monotonie en gamma | `gittins_index_monotone_gamma` | sorry |
+| Regret UCB1 | `ucb1_sublinear_regret` | sorry (INTRACTABLE) |
+
+### 7.2 Repertoire des sorry (8 sorry au total : 2 INTRINSIC lake + 6 locaux)
+
+| sorry | Cellule | Raison |
+|-------|---------|--------|
+| `geometric_sum_base2` | 3 | List.foldl/List.range non reductibles |
+| `gittinsIndex` (def) | 7 | **specialisation historique vide = `arm.trueMean`** (aligne lake L50-51) |
+| `gittins_index_known_arm` | 8 | **prouve par `rfl`** (aligne lake L117-119) |
+| `gittins_index_monotone_gamma` | 8 | **sorry (FLOAT-ORDER WART)** : `le_refl` inexistant en Lean 4.31.0 + `LE Float` indisponible (first-hand c.238.22b) |
+| `gittins_index_high_uncertainty` | 8 | Arithmetic Float |
+| `policyValue` (def) | 9 | Esperance mathematique |
+| `gittins_optimality` | 9 | **INTRACTABLE** (MDP/Bellman) |
+| `gittins_beats_greedy` | 10 | **prouve par `trivial`** (aligne lake L141-144, `True` placeholder) |
+| `ucb1_explores_unvisited` | 6 | Float NaN |
+| `ucb1_sublinear_regret` | 6 | **INTRACTABLE** (concentration) |
+
+### 7.3 Projet Lake `../../decision_theory_lean/`
+
+Le projet Lake contient les memes definitions avec Mathlib pour les preuves rigoureuses :
+
+- `Discount.lean` : `geometric_series_converges`, `present_value_constant`, `discount_monotone` — tous prouves via Mathlib (0 sorry)
+- `GittinsTheorem.lean` : `gittinsIndex` (def = `arm.trueMean`, prouve), `gittins_index_known_arm` (prouve par `rfl`), `gittins_beats_greedy` (`trivial`), `gittins_optimality` (sorry — INTRACTABLE : MDP/Bellman absent Mathlib), `gittins_index_monotone_discount` (sorry — barriere FLOAT-ORDER : IEEE 754 sur `Float`, pas d'instance `Preorder`)
+
+**Total sorry (lake)** : 0 (Discount) + 2 (GittinsTheorem) = 2 sorry dans le projet Lake
+
+> Note first-hand c.238.22b : la docstring lake L131 pretend `le_refl` mais ce tactic n'existe pas en Lean 4.31.0 ; la preuve `gittins_index_monotone_discount` du lake a probablement une regression silencieuse post-#5272. Le lake build n'est pas execute localement, donc le bug n'est pas remonte. Cote notebook : `gittins_index_monotone_gamma` reste `sorry` avec FLOAT-ORDER WART documente (Real := Float, pas de `LE Float` derivable).
+
+> Post-merge #5272 (Float->R port) : `gittins_index_known_arm` (L117-119 `rfl`), `gittins_index_monotone_discount` (L134-138 `le_refl`), `gittins_beats_greedy` (L141-144 `trivial`) sont maintenant PROUVES. Les 2 sorries residuelles relevent de barrieres INTRINSIC documentees dans le README du lake : (1) MDP/Bellman/optimal-stopping absent de Mathlib (L99 V operator + L103 `gittins_optimality` proof body), (2) FLOAT-ORDER WART sur `Float` (IEEE 754, pas d'instance `Preorder` derivable pour expressions algebriques - `gittins_index_high_uncertainty` reste en sorry local).
+
+> Post-merge #5074 (decomposition GittinsTheorem) : `gittinsIndex` (def) et `gittins_index_known_arm` ont ete prouves (GittinsTheorem 5->3 sorry). Les 3 residuels relevent de 2 barrieres DISTINCTES et honnetement documentees dans le README du lake : (1) MDP-intrinsic (Bellman/optimal-stopping absent de Mathlib), (2) FLOAT-ORDER WART (`a <= a` non prouvable sur `Float` en IEEE 754).
+
+---
+
+**Navigation** : [<< 20-Decision-Sequential](DecInfer-8-Sequential.ipynb) | [Index](README.md)",,,,,,,,4bd5ebfdc3abdb50,,,,,,,


### PR DESCRIPTION
## Summary

Resync the `probas-decinfer` translation drift-tracking CSV after the recent DecInfer .NET PRs (#7028/#7030/#7034/#7038/#7039/#7040/#7045) modified the source notebooks. The CSV pivot hashes (`src_hash`/`text_fr`/`hash_fr`) were stale, producing **15 anomalies** (14 `SRC_DRIFT` + 1 `ORPHAN_ROW`) in `check_translation_sync.py`.

## What changed

`translations/probas-decinfer/probas_decinfer.csv` — refreshed via `extract_cells_to_csv.py --update`:
- 14 `SRC_DRIFT` rows re-hashed (e.g. `#load "FactorGraphHelper.cs"` → `#load "../../Infer/FactorGraphHelper.cs"` portability fix changed cell content → hash).
- 42 new cells added (present in source, not yet tracked).
- 1 `ORPHAN_ROW` removed (cell `20467e54` — a Plotly install comment — deleted from DecInfer-4; **0 target translation carried**, purely obsolete pivot row).
- 368 rows already in-sync (preserved).

## Evidence (firsthand, worktree fresh `origin/main` 9598ca6dc)

```
$ python scripts/translation/check_translation_sync.py translations/probas-decinfer/
BEFORE: DRIFT DETECTE (15 anomalie(s) sur 1 CSV) : SRC_DRIFT=14, ORPHAN_ROW=1
AFTER:  "anomalies": []   (0 drift)
```

- **Target translations untouched**: `text_en`/`hash_en`/… columns carry 0 non-empty cells both before and after (DecInfer has no T3 translations yet — only the `fr` pivot hash is maintained at this stage). 0 translation lost.
- CSV well-formed: 21 columns uniform, 424 data rows (was 425).
- No notebook source touched (translation registry only).

## Scope

Atomique — 1 CSV, 1 série (DecInfer). Registre translation T2 (distinct des c.588/c.589 accents/tooling/security). Residuel : 32 autres CSVs / ~89 drifts restants (autres familles) — atomique 1 CSV/PR.

See #4957 (T2 partial — 1/33 CSV resynchronized). Part of EPIC #1650.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
