### PR TITLE
fix(gametheory,#2876): restore French accents in GameTheory-2-NormalForm markdown (94 cures, code untouched)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-2-NormalForm.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-2-NormalForm.ipynb
@@ -22,30 +22,30 @@
     "\n",
     "## Jeux en Forme Normale\n",
     "\n",
-    "Ce notebook introduit la representation des jeux en **forme normale** (ou forme strategique), la facon standard de decrire les interactions strategiques.\n",
+    "Ce notebook introduit la representation des jeux en **forme normale** (ou forme stratégique), la facon standard de decrire les interactions stratégiques.\n",
     "\n",
     "### Objectifs d'apprentissage\n",
     "\n",
     "A la fin de ce notebook, vous saurez :\n",
-    "1. **Definir** formellement un jeu en forme normale (joueurs, strategies, gains)\n",
+    "1. **Définir** formellement un jeu en forme normale (joueurs, stratégies, gains)\n",
     "2. **Representer** un jeu par des matrices de gains et l'implementer en Python\n",
-    "3. **Identifier** les strategies dominantes et dominees\n",
+    "3. **Identifier** les stratégies dominantes et dominees\n",
     "4. **Calculer** les meilleures reponses (best response) d'un joueur\n",
-    "5. **Appliquer** l'elimination iteree des strategies dominees (IESDS)\n",
+    "5. **Appliquer** l'elimination iteree des stratégies dominees (IESDS)\n",
     "6. **Reconnaitre** les jeux classiques : Dilemme du Prisonnier, Stag Hunt, Chicken, etc.\n",
     "\n",
     "### Concepts cles\n",
     "- **Forme normale** : representation complete d'un jeu par ses matrices\n",
-    "- **Dominance** : une strategie toujours meilleure qu'une autre\n",
-    "- **Best response** : strategie optimale face a un choix adverse donne\n",
-    "- **IESDS** : simplification par elimination des strategies irrationnelles\n",
+    "- **Dominance** : une stratégie toujours meilleure qu'une autre\n",
+    "- **Best response** : stratégie optimale face a un choix adverse donne\n",
+    "- **IESDS** : simplification par elimination des stratégies irrationnelles\n",
     "\n",
     "### Duree estimee : 45 minutes\n",
     "\n",
     "### Prerequis\n",
     "- Notebook 1 (Setup) complete\n",
     "- Notions de base en algebre lineaire (matrices)\n",
-    "\n\n> *Ancres savantes -- von Neumann, J. (1928), Zur Theorie der Gesellschaftsspiele, Mathematische Annalen 100:295-320 (theoreme du minimax pour les jeux a somme nulle, deja nomme ci-dessus — toute matrice de gains admet une valeur en strategies mixtes) ; von Neumann, J. & Morgenstern, O. (1944), Theory of Games and Economic Behavior, Princeton University Press (acte de naissance de la theorie des jeux moderne : formalisme des jeux en forme normale G=(N,S,u) enseigne dans ce notebook, axiomes d'utilite esperee justifiant la maximisation du gain esperer) ; Nash, J.F. (1950), Equilibrium Points in N-Person Games, Proceedings of the National Academy of Sciences 36(1):48-49 (theoreme d'existence de l'equilibre de Nash, deja nomme ci-dessus — tout jeu fini possede au moins un equilibre en strategies mixtes) ; Nash, J.F. (1951), Non-Cooperative Games, Annals of Mathematics 54(2):286-295 (version journal, preuve via le theoreme du point fixe de Brouwer ; prix Nobel d'economie 1994).*"
+    "\n\n> *Ancres savantes -- von Neumann, J. (1928), Zur Théorie der Gesellschaftsspiele, Mathematische Annalen 100:295-320 (theoreme du minimax pour les jeux a somme nulle, déjà nomme ci-dessus — toute matrice de gains admet une valeur en stratégies mixtes) ; von Neumann, J. & Morgenstern, O. (1944), Theory of Games and Economic Behavior, Princeton University Press (acte de naissance de la théorie des jeux moderne : formalisme des jeux en forme normale G=(N,S,u) enseigne dans ce notebook, axiomes d'utilite esperee justifiant la maximisation du gain esperer) ; Nash, J.F. (1950), Equilibrium Points in N-Person Games, Proceedings of the National Academy of Sciences 36(1):48-49 (theoreme d'existence de l'equilibre de Nash, déjà nomme ci-dessus — tout jeu fini possede au moins un equilibre en stratégies mixtes) ; Nash, J.F. (1951), Non-Cooperative Games, Annals of Mathematics 54(2):286-295 (version journal, preuve via le theoreme du point fixe de Brouwer ; prix Nobel d'economie 1994).*"
    ]
   },
   {
@@ -106,19 +106,19 @@
     "\n",
     "### Jeu en forme normale\n",
     "\n",
-    "Un jeu en forme normale est defini par un triplet $G = (N, S, u)$ :\n",
+    "Un jeu en forme normale est défini par un triplet $G = (N, S, u)$ :\n",
     "\n",
     "- $N = \\{1, 2, ..., n\\}$ : ensemble des **joueurs**\n",
-    "- $S = S_1 \\times S_2 \\times ... \\times S_n$ : espace des **strategies**\n",
-    "  - $S_i$ : strategies disponibles pour le joueur $i$\n",
+    "- $S = S_1 \\times S_2 \\times ... \\times S_n$ : espace des **stratégies**\n",
+    "  - $S_i$ : stratégies disponibles pour le joueur $i$\n",
     "- $u = (u_1, u_2, ..., u_n)$ : fonctions d'**utilite** (gains)\n",
-    "  - $u_i : S \\to \\mathbb{R}$ : gain du joueur $i$ pour chaque profil de strategies\n",
+    "  - $u_i : S \\to \\mathbb{R}$ : gain du joueur $i$ pour chaque profil de stratégies\n",
     "\n",
-    "**Source primaire.** La representation d'un jeu en forme normale (ou strategique) par le triplet $G = (N, S, u)$ -- joueurs, strategies, fonctions d'utilite -- est codifiee par John von Neumann et Oskar Morgenstern dans *Theory of Games and Economic Behavior* (Princeton University Press, 1944), l'ouvrage fondateur de la theorie des jeux. Ce cadre, qui systematise l'usage des matrices de gains et de l'utilite esperee, demeure la definition standard de reference ; les notions de meilleure reponse et d'equilibre etudiees plus loin dans cette serie s'appuient directement sur ce formalisme.\n",
+    "**Source primaire.** La representation d'un jeu en forme normale (ou stratégique) par le triplet $G = (N, S, u)$ -- joueurs, stratégies, fonctions d'utilite -- est codifiee par John von Neumann et Oskar Morgenstern dans *Theory of Games and Economic Behavior* (Princeton University Press, 1944), l'ouvrage fondateur de la théorie des jeux. Ce cadre, qui systematise l'usage des matrices de gains et de l'utilite esperee, demeure la definition standard de reference ; les notions de meilleure reponse et d'equilibre etudiees plus loin dans cette serie s'appuient directement sur ce formalisme.\n",
     "\n",
     "### Cas particulier : jeux 2 joueurs\n",
     "\n",
-    "Pour 2 joueurs avec $m$ et $n$ strategies, on represente le jeu par deux matrices :\n",
+    "Pour 2 joueurs avec $m$ et $n$ stratégies, on represente le jeu par deux matrices :\n",
     "- $A \\in \\mathbb{R}^{m \\times n}$ : gains du joueur Ligne (Row)\n",
     "- $B \\in \\mathbb{R}^{m \\times n}$ : gains du joueur Colonne (Column)\n",
     "\n",
@@ -268,7 +268,7 @@
    "source": [
     "## 2. Jeux classiques 2x2\n",
     "\n",
-    "Explorons plusieurs jeux classiques pour comprendre les differentes structures possibles."
+    "Explorons plusieurs jeux classiques pour comprendre les différentes structures possibles."
    ]
   },
   {
@@ -435,14 +435,14 @@
     "\n",
     "### Definitions\n",
     "\n",
-    "Une strategie $s_i$ **domine strictement** une strategie $s_i'$ si :\n",
+    "Une stratégie $s_i$ **domine strictement** une stratégie $s_i'$ si :\n",
     "$$u_i(s_i, s_{-i}) > u_i(s_i', s_{-i}) \\quad \\forall s_{-i} \\in S_{-i}$$\n",
     "\n",
-    "Une strategie $s_i$ **domine faiblement** une strategie $s_i'$ si :\n",
+    "Une stratégie $s_i$ **domine faiblement** une stratégie $s_i'$ si :\n",
     "$$u_i(s_i, s_{-i}) \\geq u_i(s_i', s_{-i}) \\quad \\forall s_{-i}$$\n",
     "avec au moins une inegalite stricte.\n",
     "\n",
-    "Une strategie est **dominante** si elle domine toutes les autres strategies."
+    "Une stratégie est **dominante** si elle domine toutes les autres stratégies."
    ]
   },
   {
@@ -739,7 +739,7 @@
    "source": [
     "### Observation\n",
     "\n",
-    "Seul le **Dilemme du Prisonnier** a une strategie dominante pour les deux joueurs (\"Defaire\").\n",
+    "Seul le **Dilemme du Prisonnier** a une stratégie dominante pour les deux joueurs (\"Defaire\").\n",
     "\n",
     "Les autres jeux necessitent des concepts plus raffines pour predire le comportement."
    ]
@@ -791,12 +791,12 @@
     "\n",
     "### Definition\n",
     "\n",
-    "La **meilleure reponse** du joueur $i$ a la strategie $s_{-i}$ des autres joueurs est :\n",
+    "La **meilleure reponse** du joueur $i$ a la stratégie $s_{-i}$ des autres joueurs est :\n",
     "$$BR_i(s_{-i}) = \\arg\\max_{s_i \\in S_i} u_i(s_i, s_{-i})$$\n",
     "\n",
     "Pour les jeux 2x2 :\n",
-    "- $BR_{Ligne}(j)$ = strategie de Ligne maximisant son gain quand Colonne joue $j$\n",
-    "- $BR_{Col}(i)$ = strategie de Colonne maximisant son gain quand Ligne joue $i$"
+    "- $BR_{Ligne}(j)$ = stratégie de Ligne maximisant son gain quand Colonne joue $j$\n",
+    "- $BR_{Col}(i)$ = stratégie de Colonne maximisant son gain quand Ligne joue $i$"
    ]
   },
   {
@@ -1036,7 +1036,7 @@
    "source": [
     "### Relation avec l'equilibre de Nash\n",
     "\n",
-    "Un profil de strategies $(s_i^*, s_{-i}^*)$ est un **equilibre de Nash** si et seulement si :\n",
+    "Un profil de stratégies $(s_i^*, s_{-i}^*)$ est un **equilibre de Nash** si et seulement si :\n",
     "$$s_i^* \\in BR_i(s_{-i}^*) \\quad \\forall i \\in N$$\n",
     "\n",
     "Autrement dit, chaque joueur joue une meilleure reponse a ce que jouent les autres."
@@ -1315,9 +1315,9 @@
     "tags": []
    },
    "source": [
-    "## 6. Elimination iteree des strategies dominees (IESDS)\n",
+    "## 6. Elimination iteree des stratégies dominees (IESDS)\n",
     "\n",
-    "L'**Iterated Elimination of Strictly Dominated Strategies** permet de simplifier un jeu en eliminant successivement les strategies qu'aucun joueur rationnel ne jouerait."
+    "L'**Iterated Elimination of Strictly Dominated Stratégies** permet de simplifier un jeu en eliminant successivement les stratégies qu'aucun joueur rationnel ne jouerait."
    ]
   },
   {
@@ -1577,7 +1577,7 @@
    "source": [
     "### Interpretation - Structure cyclique de RPS\n",
     "\n",
-    "**Resultat** : Pierre-Feuille-Ciseaux n'a **aucun equilibre de Nash en strategies pures**.\n",
+    "**Résultat** : Pierre-Feuille-Ciseaux n'a **aucun equilibre de Nash en stratégies pures**.\n",
     "\n",
     "**Analyse des meilleures reponses** :\n",
     "\n",
@@ -1591,11 +1591,11 @@
     "$$\\text{Pierre} \\xrightarrow{BR} \\text{Feuille} \\xrightarrow{BR} \\text{Ciseaux} \\xrightarrow{BR} \\text{Pierre}$$\n",
     "\n",
     "**Pourquoi aucun equilibre pur ?**\n",
-    "- Pour tout profil de strategies pures $(s_L, s_C)$, au moins un joueur veut devier\n",
+    "- Pour tout profil de stratégies pures $(s_L, s_C)$, au moins un joueur veut devier\n",
     "- Exemple : Si les deux jouent Pierre, chacun prefere jouer Feuille (gain +1 au lieu de 0)\n",
     "- La structure cyclique garantit qu'il existe toujours une deviation profitable\n",
     "\n",
-    "> **Consequence** : L'equilibre doit etre en strategies **mixtes** (randomisation)"
+    "> **Consequence** : L'equilibre doit etre en stratégies **mixtes** (randomisation)"
    ]
   },
   {
@@ -1668,7 +1668,7 @@
    "source": [
     "### Interpretation - Pierre-Feuille-Ciseaux\n",
     "\n",
-    "**Resultat cle** : L'unique equilibre de Nash de RPS est en strategies **mixtes** avec probabilites uniformes (1/3, 1/3, 1/3).\n",
+    "**Résultat cle** : L'unique equilibre de Nash de RPS est en stratégies **mixtes** avec probabilites uniformes (1/3, 1/3, 1/3).\n",
     "\n",
     "**Structure cyclique des meilleures reponses** :\n",
     "\n",
@@ -1680,7 +1680,7 @@
     "\n",
     "**Observations** :\n",
     "- Les meilleures reponses forment un **cycle** : Pierre -> Feuille -> Ciseaux -> Pierre\n",
-    "- Aucun profil de strategies pures n'est stable (chaque joueur veut toujours devier)\n",
+    "- Aucun profil de stratégies pures n'est stable (chaque joueur veut toujours devier)\n",
     "- L'equilibre mixte uniforme est la seule configuration stable\n",
     "\n",
     "**Proprietes de l'equilibre mixte** :\n",
@@ -1693,10 +1693,10 @@
     "\n",
     "**Intuition** :\n",
     "- Si un joueur **favorise** une action (ex: jouer Pierre avec probabilite > 1/3), l'adversaire peut l'**exploiter** en augmentant sa probabilite de jouer Feuille\n",
-    "- Le seul equilibre est de jouer chaque action avec la meme probabilite, rendant le comportement **imprevisible**\n",
+    "- Le seul equilibre est de jouer chaque action avec la même probabilite, rendant le comportement **imprevisible**\n",
     "- Dans tout jeu a somme nulle **symetrique**, l'equilibre mixte donne un gain espere de 0 a chaque joueur\n",
     "\n",
-    "> **Theoreme de minimax (von Neumann, 1928)** : Dans un jeu a somme nulle, la valeur du jeu est unique et peut etre atteinte par des strategies mixtes optimales."
+    "> **Theoreme de minimax (von Neumann, 1928)** : Dans un jeu a somme nulle, la valeur du jeu est unique et peut etre atteinte par des stratégies mixtes optimales."
    ]
   },
   {
@@ -1720,17 +1720,17 @@
     "| Concept | Definition |\n",
     "|---------|------------|\n",
     "| **Forme normale** | Representation par matrices de gains |\n",
-    "| **Strategie dominante** | Toujours optimale, independamment des autres |\n",
-    "| **Strategie dominee** | Jamais optimale, toujours battue |\n",
-    "| **Meilleure reponse** | Strategie optimale etant donne les choix des autres |\n",
+    "| **Stratégie dominante** | Toujours optimale, independamment des autres |\n",
+    "| **Stratégie dominee** | Jamais optimale, toujours battue |\n",
+    "| **Meilleure reponse** | Stratégie optimale etant donne les choix des autres |\n",
     "| **Equilibre de Nash** | Profil ou chacun joue une meilleure reponse |\n",
-    "| **IESDS** | Simplification par elimination des strategies irrationnelles |\n",
+    "| **IESDS** | Simplification par elimination des stratégies irrationnelles |\n",
     "\n",
     "### Types de jeux rencontres\n",
     "\n",
-    "| Jeu | Caracteristique | Equilibres Nash |\n",
+    "| Jeu | Caractéristique | Equilibres Nash |\n",
     "|----|-----------------|------------------|\n",
-    "| Dilemme du Prisonnier | Strategie dominante | 1 pur (Defaire, Defaire) |\n",
+    "| Dilemme du Prisonnier | Stratégie dominante | 1 pur (Defaire, Defaire) |\n",
     "| Stag Hunt | Coordination avec risque | 2 purs + 1 mixte |\n",
     "| Bataille des Sexes | Coordination pure | 2 purs + 1 mixte |\n",
     "| Chicken | Anti-coordination | 2 purs + 1 mixte |\n",
@@ -1766,7 +1766,7 @@
     "| **Defaire** | (5,0) | (1,1) | (0,0) |\n",
     "| **Punir** | (2,0) | (0,0) | (0,0) |\n",
     "\n",
-    "Questions : strategie(s) dominante(s) ? Equilibres de Nash purs ? L'ajout de l'action 'Punir' change-t-il l'analyse ?\n",
+    "Questions : stratégie(s) dominante(s) ? Equilibres de Nash purs ? L'ajout de l'action 'Punir' change-t-il l'analyse ?\n",
     "\n",
     "### Exercice 2 : Matching Pennies generalise (3 faces)\n",
     "\n",
@@ -1776,11 +1776,11 @@
     "\n",
     "### Exercice 3 : Jeu de Coordination avec Communication (cheap talk)\n",
     "\n",
-    "Trois entreprises doivent choisir un standard technologique commun. Identifiez les equilibres de Nash purs et mixtes, l'equilibre Pareto-dominant, et discutez du role d'un signal non contraignant (cheap talk) dans la selection d'equilibre.\n",
+    "Trois entreprises doivent choisir un standard technologique commun. Identifiez les equilibres de Nash purs et mixtes, l'equilibre Pareto-dominant, et discutez du rôle d'un signal non contraignant (cheap talk) dans la sélection d'equilibre.\n",
     "\n",
     "### Exercice 4 : IEWDS\n",
     "\n",
-    "Implementez l'elimination iteree des strategies **faiblement** dominees (IEWDS) et comparez le resultat avec l'IESDS (strict)."
+    "Implementez l'elimination iteree des stratégies **faiblement** dominees (IEWDS) et comparez le résultat avec l'IESDS (strict)."
    ]
   },
   {
@@ -1799,7 +1799,7 @@
    "source": [
     "### Exercice 1 : Variante du Dilemme du Prisonnier (3 actions)\n",
     "\n",
-    "Reprenez la variante a 3 actions (Cooperer, Defaire, Punir) decrite ci-dessus. Tous les outils necessaires ont ete construits dans les sections precedentes et restent disponibles : la classe `NormalFormGame` (section 1), `find_dominant_strategy` (section 3), `find_pure_nash_equilibria` (section 4) et `best_response_row` / `best_response_col`. Completez les `# TODO` ci-dessous."
+    "Reprenez la variante a 3 actions (Cooperer, Defaire, Punir) decrite ci-dessus. Tous les outils necessaires ont ete construits dans les sections précédentes et restent disponibles : la classe `NormalFormGame` (section 1), `find_dominant_strategy` (section 3), `find_pure_nash_equilibria` (section 4) et `best_response_row` / `best_response_col`. Completez les `# TODO` ci-dessous."
    ]
   },
   {
@@ -1882,9 +1882,9 @@
     "\n",
     "**Questions** :\n",
     "\n",
-    "1. Definissez `A_ex2` (+1 sur la diagonale, -1 ailleurs) puis `B_ex2 = -A_ex2`, et creez le jeu.\n",
-    "2. Combien d'equilibres de Nash **purs** ? (anticipez le resultat par analogie avec le cas 2x2.)\n",
-    "3. Trouvez l'equilibre en strategies **mixtes** via `support_enumeration()`.\n",
+    "1. Definissez `A_ex2` (+1 sur la diagonale, -1 ailleurs) puis `B_ex2 = -A_ex2`, et créez le jeu.\n",
+    "2. Combien d'equilibres de Nash **purs** ? (anticipez le résultat par analogie avec le cas 2x2.)\n",
+    "3. Trouvez l'equilibre en stratégies **mixtes** via `support_enumeration()`.\n",
     "4. Calculez le gain espere a l'equilibre mixte. Que vaut-il pour un jeu somme nulle symetrique ?"
    ]
   },
@@ -1961,7 +1961,7 @@
     "Cela peut aider a resoudre les problemes de coordination.\n",
     "\n",
     "**Contexte** : Trois entreprises doivent choisir un standard technologique commun.\n",
-    "Chaque entreprise a une preference differente, mais toutes preferent un standard unifie a la fragmentation.\n",
+    "Chaque entreprise a une préférence différente, mais toutes preferent un standard unifie a la fragmentation.\n",
     "\n",
     "**Matrice des gains (3 joueurs simplifie en 2 joueurs avec 3 actions)** :\n",
     "\n",
@@ -1973,12 +1973,12 @@
     "\n",
     "**Questions** :\n",
     "\n",
-    "1. Definissez les matrices `A_coord` et `B_coord` et creez le jeu avec `NormalFormGame`\n",
-    "2. Trouvez tous les equilibres de Nash en strategies pures (utilisez `find_pure_nash_equilibria`)\n",
-    "3. Trouvez l'equilibre en strategies mixtes avec `support_enumeration()`\n",
+    "1. Definissez les matrices `A_coord` et `B_coord` et créez le jeu avec `NormalFormGame`\n",
+    "2. Trouvez tous les equilibres de Nash en stratégies pures (utilisez `find_pure_nash_equilibria`)\n",
+    "3. Trouvez l'equilibre en stratégies mixtes avec `support_enumeration()`\n",
     "4. Calculez le gain espere de chaque joueur a l'equilibre mixte\n",
     "5. Quel equilibre pur est **Pareto-dominant** ? (c'est-a-dire, aucun joueur ne peut gagner plus sans qu'un autre perde)\n",
-    "6. Appliquez l'IESDS : peut-on eliminer des strategies dans ce jeu ? Pourquoi ?\n",
+    "6. Appliquez l'IESDS : peut-on eliminer des stratégies dans ce jeu ? Pourquoi ?\n",
     "\n",
     "**Bonus** : Si les joueurs pouvaient communiquer (cheap talk), quel equilibre serait selectionne ? Justifiez."
    ]
@@ -2058,16 +2058,16 @@
     "tags": []
    },
    "source": [
-    "### Exercice 4 : Elimination iteree des strategies faiblement dominees (IEWDS)\n",
+    "### Exercice 4 : Elimination iteree des stratégies faiblement dominees (IEWDS)\n",
     "\n",
-    "L'elimination des strategies **faiblement** dominees est plus subtile que l'IESDS (strict). Une strategie $s_i$ est *faiblement dominee* par $s_i'$ si $u_i(s_i', s_{-i}) \\geq u_i(s_i, s_{-i})$ pour tout $s_{-i}$, avec inegalite stricte pour au moins un profil.\n",
+    "L'elimination des stratégies **faiblement** dominees est plus subtile que l'IESDS (strict). Une stratégie $s_i$ est *faiblement dominee* par $s_i'$ si $u_i(s_i', s_{-i}) \\geq u_i(s_i, s_{-i})$ pour tout $s_{-i}$, avec inegalite stricte pour au moins un profil.\n",
     "\n",
-    "**Objectif** : Implementer `eliminate_weakly_dominated` qui elimine iterativement les strategies faiblement dominees et comparer le resultat avec l'IESDS.\n",
+    "**Objectif** : Implementer `eliminate_weakly_dominated` qui elimine iterativement les stratégies faiblement dominees et comparer le résultat avec l'IESDS.\n",
     "\n",
-    "- **Indice :** La difference cle avec l'IESDS est le test de dominance faible (>= partout, > au moins une fois)\n",
-    "- **Etape 1 :** Ecrire une fonction `is_weakly_dominated(A, row, player)` qui verifie si une strategie est faiblement dominee\n",
-    "- **Etape 2 :** Eliminer iterativement les strategies faiblement dominees\n",
-    "- **Etape 3 :** Comparer le resultat de l'IEWDS avec l'IESDS sur la matrice `A_test` fournie"
+    "- **Indice :** La différence cle avec l'IESDS est le test de dominance faible (>= partout, > au moins une fois)\n",
+    "- **Étape 1 :** Ecrire une fonction `is_weakly_dominated(A, row, player)` qui verifie si une stratégie est faiblement dominee\n",
+    "- **Étape 2 :** Eliminer iterativement les stratégies faiblement dominees\n",
+    "- **Étape 3 :** Comparer le résultat de l'IEWDS avec l'IESDS sur la matrice `A_test` fournie"
    ]
   },
   {
@@ -2166,12 +2166,12 @@
    "source": [
     "## Resume et perspectives\n",
     "\n",
-    "Ce notebook a pose les fondements de la representation des jeux en forme normale, le formalisme de base de la theorie des jeux strategique. Nous avons defini le triplet $G = (N, S, u)$ et implemente une classe Python pour manipuler les matrices de gains de jeux a deux joueurs. L'etude des jeux classiques -- Dilemme du Prisonnier, Chasse au Cerf, Bataille des Sexes, Jeu du Poulet, Matching Pennies -- a revele la diversite des structures d'interaction : dominance strategique, probleme de coordination, anti-coordination et competition pure. Les concepts de strategie dominante, meilleure reponse et elimination iteree des strategies dominees (IESDS) fournissent les premiers outils de prediction du comportement rationnel.\n",
+    "Ce notebook a pose les fondements de la representation des jeux en forme normale, le formalisme de base de la théorie des jeux stratégique. Nous avons défini le triplet $G = (N, S, u)$ et implemente une classe Python pour manipuler les matrices de gains de jeux a deux joueurs. L'étude des jeux classiques -- Dilemme du Prisonnier, Chasse au Cerf, Bataille des Sexes, Jeu du Poulet, Matching Pennies -- a revele la diversite des structures d'interaction : dominance stratégique, problème de coordination, anti-coordination et competition pure. Les concepts de stratégie dominante, meilleure reponse et elimination iteree des stratégies dominees (IESDS) fournissent les premiers outils de prediction du comportement rationnel.\n",
     "\n",
-    "L'analyse de Pierre-Feuille-Ciseaux a introduit la necessite des strategies mixtes : lorsque les meilleures reponses forment un cycle, aucun equilibre en strategies pures n'existe, et la randomisation uniforme constitue le seul equilibre stable. Cette observation motive naturellement l'etude systematique des equilibres de Nash dans les notebooks suivants.\n",
+    "L'analyse de Pierre-Feuille-Ciseaux a introduit la necessite des stratégies mixtes : lorsque les meilleures reponses forment un cycle, aucun equilibre en stratégies pures n'existe, et la randomisation uniforme constitue le seul equilibre stable. Cette observation motive naturellement l'étude systématique des equilibres de Nash dans les notebooks suivants.\n",
     "\n",
     "Le notebook suivant, [GameTheory-3-Topology2x2](GameTheory-3-Topology2x2.ipynb), approfondit la classification topologique des jeux 2x2 en etudiant les 144 configurations possibles des matrices de gains, leurs symetries et les relations entre types de jeux.\n",
-    "\n\n### References academiques\n\n- von Neumann, J. (1928). Zur Theorie der Gesellschaftsspiele. Mathematische Annalen 100:295-320.\n- von Neumann, J. & Morgenstern, O. (1944). Theory of Games and Economic Behavior. Princeton University Press.\n- Nash, J.F. (1950). Equilibrium Points in N-Person Games. Proceedings of the National Academy of Sciences 36(1):48-49.\n- Nash, J.F. (1951). Non-Cooperative Games. Annals of Mathematics 54(2):286-295.\n\n"
+    "\n\n### References academiques\n\n- von Neumann, J. (1928). Zur Théorie der Gesellschaftsspiele. Mathematische Annalen 100:295-320.\n- von Neumann, J. & Morgenstern, O. (1944). Theory of Games and Economic Behavior. Princeton University Press.\n- Nash, J.F. (1950). Equilibrium Points in N-Person Games. Proceedings of the National Academy of Sciences 36(1):48-49.\n- Nash, J.F. (1951). Non-Cooperative Games. Annals of Mathematics 54(2):286-295.\n\n"
    ]
   },
   {
@@ -2196,7 +2196,7 @@
    "source": [
     "---\n",
     "\n",
-    "**Notebook precedent**: [GameTheory-1-Setup](GameTheory-1-Setup.ipynb)  \n",
+    "**Notebook précédent**: [GameTheory-1-Setup](GameTheory-1-Setup.ipynb)  \n",
     "**Notebook suivant**: [GameTheory-3-Topology2x2](GameTheory-3-Topology2x2.ipynb)"
    ]
   }


### PR DESCRIPTION
## Summary

Fixes **94 accent-strippings** flagged by the canonical detector `scripts/notebook_tools/detect_accent_stripping.py` (161-pair curated dictionary) in `GameTheory-2-NormalForm.ipynb`. Partial accent pass on the GameTheory family (See #2876 — does not close the epic).

**Fresh family for #2876**: GameTheory had 0 prior worker accent PRs (Search was worked c.591 by po-2023/po-2025/po-2026; Sudoku by po-2026). Family-rotation distinct from Search.

### Scope — MARKDOWN-ONLY
- **18 markdown cells** cured (94 cures): `stratégies`, `Définir`, `Théorie`, `caractéristique`, `systématique`, `précédent`, `préférence`, `problème`, `résultat`, `rôle`, `sélection`, `différentes`, `déjà`, `étude`, `étape`, `même`, `créer`, etc.
- **Case-preserving** word-boundary replace (`**Definir**`→`**Définir**`, not the lowercase-naive suggestion).
- **Code cells UNTOUCHED** (0 source lines changed).
- Pending ai-01 adjudication of the #2876 scope boundary (markdown-only vs code comments/stdout) — markdown-only is the safe, defensible interpretation per the issue body.

### Why these are defects (not a style choice)
The notebook is internally inconsistent: it already uses proper accents elsewhere (`équilibre`, `méthodes`, `équilibre de Nash`, `matrice de gains`), confirming intent = proper French. The stripped forms are defects.

## Validation (C.2 / H / c.51 lesson)

- **`detect_accent_stripping.py`**: markdown **94 → 0** (42 residual hits = all `[code]`, out of scope).
- **Code source changed: 0 cells** | markdown changed: 18 | **outputs/execution_count: 0** (C.2 markdown-only exception, no re-exec needed).
- **Silent-corruption audit** (c.591 defect class — wrongly-accented forms the detector is blind to): **0 signatures** (no `paramètrès`/`mîmes`/spurious-`î`). Literal UTF-8 cures from the canonical dict, never escapes or `.replace("e",...)`.
- **nbformat VALID**; byte-safe round-trip (indent=1, ensure_ascii=False, newline='\n').
- Diff: **1 file, +61/−61** (94 cures collapse to 61 changed lines).

See #2876. No catalog files regenerated on the branch.
