### PR TITLE
feat(notebook-tools): detect_papermill_path_leak (read-only CI-friendly detector)

### DIFF
--- a/scripts/notebook_tools/detect_papermill_path_leak.py
+++ b/scripts/notebook_tools/detect_papermill_path_leak.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+"""
+Detect machine-local path leaks in Jupyter notebooks.
+
+This is the read-only companion of ``scrub_papermill_paths.py``. It scans a
+notebook (or every notebook in a directory tree) and reports two defect
+classes that are **content-based anti-patterns** (cf
+[secrets-hygiene.md Stop & Repair rule 6](../../docs/reference/secrets-and-coord-detail.md#1-secrets-hygiene--content-based-pas-path-based)):
+
+**Defect class A — ``metadata.papermill`` absolute path leak.**
+When a notebook is re-executed via papermill with an absolute output path
+(e.g. ``C:/Users/jsboi/AppData/Local/Temp/x.ipynb`` or ``/home/user/x.ipynb``),
+papermill records that path in ``metadata.papermill.output_path`` (and
+sometimes ``input_path``). This leaks the contributor's local directory
+structure and is inconsistent with cleanly-executed notebooks where both
+fields carry the notebook's relative basename.
+
+**Defect class B — machine-local path inside ``outputs`` text streams.**
+ipykernel temp paths in matplotlib UserWarnings
+(``C:\\Users\\<user>\\AppData\\Local\\Temp\\ipykernel_<PID>\\<hash>.py:line``),
+pip ``already satisfied: ... in C:\\Users\\<user>\\AppData\\Local\\Packages``
+lines, .NET Interactive ``Loading extensions from C:\\Users\\<user>\\.nuget\\packages``
+lines, and ``tempfile`` paths in user messages all leak the contributor's
+home directory. Re-executing them regenerates a fresh leak each run, so
+they are non-portable by construction.
+
+**Scope vs ``scrub_papermill_paths.py``.** That script *fixes* defects in
+place (text-level surgical edit, preserving cell structure). This detector
+is **read-only** and CI-friendly: it returns a structured JSON report and
+proper exit codes (``0`` clean, ``1`` defects found, ``2`` usage error) so
+a pre-commit hook or CI workflow can gate a PR on this signal without
+touching the notebook bytes. The fix-up is intentionally a separate
+concern.
+
+**Usage.**
+
+    # Single file, JSON output to stdout:
+    python detect_papermill_path_leak.py --scan path/to/notebook.ipynb
+
+    # Single file, also include class B (output-text leaks). Off by default
+    # because class B can be noisy on first scan; opt in once the metadata
+    # leaks are clean:
+    python detect_papermill_path_leak.py --scan path/to/nb.ipynb --outputs
+
+    # Whole directory tree, JSON to stdout:
+    python detect_papermill_path_leak.py --scan-all notebooks/
+
+    # Repo-wide from repo root (skips ``.git``/``_archives``/``__pycache__``):
+    python detect_papermill_path_leak.py --scan-all .
+
+    # CI gate: exit 1 if any defect is found, suppress JSON:
+    python detect_papermill_path_leak.py --scan-all . --check
+
+    # Human-readable summary alongside JSON:
+    python detect_papermill_path_leak.py --scan-all . --summary
+
+**Design choices.**
+
+- **No external deps** beyond the Python 3.10 stdlib (``json``, ``re``,
+  ``argparse``, ``pathlib``). Mirrors the style of the other detectors in
+  ``scripts/notebook_tools/``.
+- **Path leak regexes are conservative.** A path is flagged only when it
+  contains *both* a strong machine-local marker (``C:\\Users\\``,
+  ``/home/``, ``/Users/`` macOS, ``/root/``, ``/tmp/ipykernel``) and a
+  separator (``\\`` or ``/``) — single ``C:\\`` alone is too noisy (any
+  Windows error message contains it). This matches the leak patterns
+  documented in ``scrub_papermill_paths.py`` docstring §1.6.
+- **Class B output scan** walks ``cell.outputs[*].text`` (stdout/stderr)
+  and ``data['text/plain']`` only. Image and HTML data is skipped (binary
+  / non-text). ``stream`` outputs (stderr) and ``display_data`` with
+  ``text/plain`` are the two realistic leak channels.
+- **Severity is binary** (``high`` for class A — metadata pollution;
+  ``medium`` for class B — output noise). Future work: weight by leak
+  density if a CI dashboard needs a numeric score.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+# --- Defect class A: metadata.papermill absolute paths ---
+
+# ``metadata.papermill.output_path`` / ``input_path`` should carry the
+# notebook's relative basename (e.g. ``MyNotebook.ipynb``). Absolute paths
+# indicate the notebook was re-executed with an absolute papermill target.
+ABS_PATH_RE = re.compile(
+    r"""(?xi)
+    ^
+    (?:
+        [a-z]:[\\/]              # Windows: C:\ C:/ D:\ ...
+        | /                      # POSIX root: /home /Users /root /tmp
+        | \\\\ [^\\/.\s]+ [\\/]  # UNC: \\server\share
+    )
+    """
+)
+
+
+def _is_absolute(p: Any) -> bool:
+    return isinstance(p, str) and bool(ABS_PATH_RE.match(p))
+
+
+def _read_notebook(nb_path: Path) -> dict | None:
+    try:
+        with nb_path.open(encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _scan_metadata_papermill(nb: dict) -> list[dict]:
+    """Return a list of defects in ``metadata.papermill.{input,output}_path``."""
+    pm = nb.get("metadata", {}).get("papermill")
+    if not isinstance(pm, dict):
+        return []
+    defects: list[dict] = []
+    for key in ("output_path", "input_path"):
+        val = pm.get(key)
+        if _is_absolute(val):
+            defects.append({
+                "kind": "metadata_papermill_absolute",
+                "location": f"metadata.papermill.{key}",
+                "value": val,
+                "severity": "high",
+            })
+    return defects
+
+
+# --- Defect class B: machine-local paths inside output text streams ---
+
+# Conservative: require BOTH a strong machine-local marker (home-dir or
+# python-specific temp/ipykernel) AND a path separator. This filters out
+# generic Windows path mentions in error messages that don't actually leak
+# the contributor's identity.
+#
+# Rationale: ``C:\`` alone matches virtually every Windows error traceback
+# and is too noisy to be useful. ``C:\Users\`` is a reliable indicator that
+# the contributor's home directory is being exposed.
+#
+# Each pattern matches the *full leaked path* (home dir + rest of the path
+# until a whitespace / quote / bracket / newline boundary), so consumers
+# see exactly what to scrub. The trailing ``(?:[\\/][^\\\s:"'<>]*)?``
+# is optional — the home-dir root alone (e.g. ``/home/jesse``) is enough
+# to flag a leak, but longer paths are preferred when present.
+#
+# The POSIX patterns use a negative look-behind for ``:`` so that a Windows
+# path like ``C:/Users/jsboi/foo`` is matched only by the Windows rule, not
+# also by the macOS rule (which would otherwise see ``/Users/jsboi/foo``
+# inside the Windows path). Without this guard, every Windows user-profile
+# leak would be double-flagged.
+LEAK_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"""(?xi)
+        C: [\\/] Users [\\/] [^\\\s:"'<>]+           # Windows user profile
+    """),
+    re.compile(r"""(?xi)
+        (?<! :) / home / [^\\\s:"'<>]+               # Linux home dir
+    """),
+    re.compile(r"""(?xi)
+        (?<! :) / Users / [^\\\s:"'<>]+              # macOS home dir
+    """),
+    re.compile(r"""(?xi)
+        (?<! :) / root (?:[\\/][^\\\s:"'<>]*)?       # Linux root home
+    """),
+    re.compile(r"""(?xi)
+        (?<! :) / tmp / ipykernel [_\-] [^\\\s:"'<>]*  # ipykernel temp
+    """),
+    re.compile(r"""(?xi)
+        C: [\\/] Windows [\\/] system32 [^\\\s:"'<>]*  # Windows system path
+    """),
+)
+
+
+def _scan_output_text(nb: dict) -> list[dict]:
+    """Walk ``cells[*].outputs[*].text`` and ``data['text/plain']`` for leaks.
+
+    Skips image and HTML data. ``stream`` (stderr) and ``display_data`` with
+    ``text/plain`` are the two realistic leak channels; ``execute_result``
+    with ``text/plain`` is included for completeness.
+    """
+    defects: list[dict] = []
+    cells = nb.get("cells") or []
+    for ci, cell in enumerate(cells):
+        if not isinstance(cell, dict):
+            continue
+        outputs = cell.get("outputs") or []
+        if not isinstance(outputs, list):
+            continue
+        for oi, out in enumerate(outputs):
+            if not isinstance(out, dict):
+                continue
+            # Channel 1: stream outputs (stdout/stderr). nbformat wraps
+            # text as ``str`` for short outputs and as ``list[str]`` for
+            # longer streams (one element per line break); handle both.
+            text = out.get("text")
+            if isinstance(text, str):
+                _collect_leaks(defects, ci, oi, "stream.text", text)
+            elif isinstance(text, list):
+                for li, piece in enumerate(text):
+                    if isinstance(piece, str):
+                        _collect_leaks(
+                            defects, ci, oi,
+                            f"stream.text[{li}]", piece,
+                        )
+            # Channel 2: display_data / execute_result with text/plain
+            data = out.get("data")
+            if isinstance(data, dict):
+                tp = data.get("text/plain")
+                if isinstance(tp, str):
+                    _collect_leaks(defects, ci, oi, "data['text/plain']", tp)
+                elif isinstance(tp, list):
+                    # nbformat sometimes wraps long text in a list of strings
+                    for li, piece in enumerate(tp):
+                        if isinstance(piece, str):
+                            _collect_leaks(
+                                defects, ci, oi,
+                                f"data['text/plain'][{li}]", piece,
+                            )
+    return defects
+
+
+def _collect_leaks(
+    defects: list[dict],
+    cell_idx: int,
+    output_idx: int,
+    location: str,
+    text: str,
+) -> None:
+    """Append a defect for each regex match in ``text``."""
+    for pat in LEAK_PATTERNS:
+        for m in pat.finditer(text):
+            defects.append({
+                "kind": "output_text_path_leak",
+                "location": f"cells[{cell_idx}].outputs[{output_idx}].{location}",
+                "match": m.group(0),
+                "severity": "medium",
+            })
+
+
+# --- Scanner glue ---
+
+# Directories skipped during recursive scans. Mirrors the conventions in
+# ``scrub_papermill_paths.py`` and the other detectors.
+_SKIP_DIR_NAMES = frozenset({
+    ".git",
+    "_archives",
+    "__pycache__",
+    "node_modules",
+    ".venv",
+    "venv",
+})
+
+
+def iter_notebooks(root: Path) -> list[Path]:
+    """Yield every ``*.ipynb`` under ``root`` recursively, skipping noise dirs."""
+    if root.is_file():
+        return [root] if root.suffix == ".ipynb" else []
+    if not root.is_dir():
+        return []
+    out: list[Path] = []
+    for p in root.rglob("*.ipynb"):
+        if any(part in _SKIP_DIR_NAMES for part in p.parts):
+            continue
+        out.append(p)
+    return sorted(out)
+
+
+def scan_notebook(nb_path: Path, *, include_outputs: bool = False) -> list[dict]:
+    """Return the defects list for a single notebook."""
+    nb = _read_notebook(nb_path)
+    if nb is None:
+        return [{
+            "kind": "unreadable_notebook",
+            "location": str(nb_path),
+            "severity": "high",
+            "reason": "JSON decode error or unreadable file",
+        }]
+    defects = _scan_metadata_papermill(nb)
+    if include_outputs:
+        defects.extend(_scan_output_text(nb))
+    return defects
+
+
+def scan_tree(
+    root: Path,
+    *,
+    include_outputs: bool = False,
+) -> list[dict]:
+    """Scan every notebook under ``root``; return a flat defects report.
+
+    Each defect is augmented with ``file`` (relative to ``root`` when
+    possible) so a CI gate can pinpoint the offender. Defects from
+    different notebooks are not merged — order is preserved.
+    """
+    report: list[dict] = []
+    for nb_path in iter_notebooks(root):
+        try:
+            rel = str(nb_path.relative_to(root))
+        except ValueError:
+            rel = str(nb_path)
+        for d in scan_notebook(nb_path, include_outputs=include_outputs):
+            d_with_file = {"file": rel, **d}
+            report.append(d_with_file)
+    return report
+
+
+# --- CLI ---
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="detect_papermill_path_leak.py",
+        description=(
+            "Detect machine-local path leaks in Jupyter notebooks "
+            "(read-only companion of scrub_papermill_paths.py)."
+        ),
+    )
+    mode = p.add_mutually_exclusive_group(required=True)
+    mode.add_argument(
+        "--scan", metavar="PATH",
+        help="Scan a single notebook file (.ipynb).",
+    )
+    mode.add_argument(
+        "--scan-all", metavar="DIR", nargs="?", const=".",
+        help="Scan every notebook under DIR (default: current directory).",
+    )
+    p.add_argument(
+        "--outputs", action="store_true",
+        help="Also scan output text streams for path leaks (class B). "
+             "Off by default — class B can be noisy on first scan.",
+    )
+    p.add_argument(
+        "--check", action="store_true",
+        help="CI gate: exit 1 if any defect is found, suppress JSON.",
+    )
+    p.add_argument(
+        "--summary", action="store_true",
+        help="Print a human-readable summary alongside the JSON report.",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_arg_parser().parse_args(argv)
+    target = Path(args.scan if args.scan is not None else args.scan_all)
+    if not target.exists():
+        print(f"error: path does not exist: {target}", file=sys.stderr)
+        return 2
+    include_outputs = bool(args.outputs)
+    if args.scan is not None:
+        report = [
+            {"file": str(target), **d}
+            for d in scan_notebook(target, include_outputs=include_outputs)
+        ]
+    else:
+        report = scan_tree(target, include_outputs=include_outputs)
+
+    if args.summary and not args.check:
+        _print_summary(report)
+    elif not args.check:
+        print(json.dumps(report, indent=2, ensure_ascii=False))
+
+    if args.check and report:
+        if args.summary:
+            _print_summary(report)
+        return 1
+    return 0
+
+
+def _print_summary(report: list[dict]) -> None:
+    n = len(report)
+    by_kind: dict[str, int] = {}
+    files_with_defects: set[str] = set()
+    for d in report:
+        by_kind[d.get("kind", "?")] = by_kind.get(d.get("kind", "?"), 0) + 1
+        if "file" in d:
+            files_with_defects.add(d["file"])
+    print(
+        f"[detect_papermill_path_leak] {n} defect(s) in "
+        f"{len(files_with_defects)} file(s).",
+        file=sys.stderr,
+    )
+    for kind, count in sorted(by_kind.items()):
+        print(f"  - {kind}: {count}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/notebook_tools/tests/test_detect_papermill_path_leak.py
+++ b/scripts/notebook_tools/tests/test_detect_papermill_path_leak.py
@@ -1,0 +1,558 @@
+#!/usr/bin/env python3
+"""Tests for ``detect_papermill_path_leak.py``.
+
+Coverage:
+
+- ``_is_absolute`` — positive (Windows drive, POSIX root, UNC) and negative
+  (basename, empty string, non-string) cases.
+- ``_scan_metadata_papermill`` — absolute path in ``output_path`` /
+  ``input_path`` is flagged, relative basenames are clean, missing /
+  malformed metadata is tolerated.
+- ``_scan_output_text`` — class B leak patterns across ``stream.text``,
+  ``data['text/plain']`` (str and list), and the skip rules (HTML / image
+  data ignored).
+- ``scan_notebook`` — unreadable notebooks are reported with a structured
+  defect, never raised as exceptions.
+- ``scan_tree`` — recursive discovery skips ``.git``/``_archives``/etc,
+  preserves a sorted order, and tags each defect with the file path
+  relative to the scan root.
+- CLI behaviour (``main``) — exit codes (0 clean, 1 defects, 2 usage),
+  JSON output suppression under ``--check``, and summary rendering.
+
+Run with::
+
+    cd scripts/notebook_tools
+    python -m pytest tests/test_detect_papermill_path_leak.py -v
+
+or directly::
+
+    python tests/test_detect_papermill_path_leak.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from textwrap import dedent
+
+# Allow running the test directly without installing the package.
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE.parent))
+
+from detect_papermill_path_leak import (  # noqa: E402
+    ABS_PATH_RE,
+    LEAK_PATTERNS,
+    _is_absolute,
+    _scan_metadata_papermill,
+    _scan_output_text,
+    iter_notebooks,
+    main as cli_main,
+    scan_notebook,
+    scan_tree,
+)
+
+
+def _make_nb(tmp: Path, name: str, nb: dict) -> Path:
+    p = tmp / name
+    p.write_text(json.dumps(nb), encoding="utf-8")
+    return p
+
+
+def _empty_nb() -> dict:
+    return {
+        "cells": [],
+        "metadata": {},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+
+
+# --- _is_absolute ---
+
+
+class IsAbsoluteTests(unittest.TestCase):
+    def test_windows_drive_backslash(self):
+        self.assertTrue(_is_absolute(r"C:\Users\jsboi\AppData\Local\Temp\x.ipynb"))
+
+    def test_windows_drive_forward_slash(self):
+        self.assertTrue(_is_absolute("D:/tmp/x.ipynb"))
+
+    def test_posix_root_home(self):
+        self.assertTrue(_is_absolute("/home/jesse/x.ipynb"))
+
+    def test_posix_root_users_macos(self):
+        self.assertTrue(_is_absolute("/Users/jsboige/x.ipynb"))
+
+    def test_unc_path(self):
+        self.assertTrue(_is_absolute(r"\\server\share\x.ipynb"))
+
+    def test_relative_basename_is_not_absolute(self):
+        self.assertFalse(_is_absolute("MyNotebook.ipynb"))
+
+    def test_relative_subdir_is_not_absolute(self):
+        self.assertFalse(_is_absolute("notebooks/MyNotebook.ipynb"))
+
+    def test_empty_string_is_not_absolute(self):
+        self.assertFalse(_is_absolute(""))
+
+    def test_none_is_not_absolute(self):
+        self.assertFalse(_is_absolute(None))
+
+    def test_int_is_not_absolute(self):
+        self.assertFalse(_is_absolute(42))
+
+
+# --- _scan_metadata_papermill ---
+
+
+class ScanMetadataPapermillTests(unittest.TestCase):
+    def test_clean_relative_paths(self):
+        nb = {
+            "metadata": {
+                "papermill": {
+                    "input_path": "MyNotebook.ipynb",
+                    "output_path": "MyNotebook.ipynb",
+                }
+            }
+        }
+        self.assertEqual(_scan_metadata_papermill(nb), [])
+
+    def test_absolute_output_path_flagged(self):
+        nb = {
+            "metadata": {
+                "papermill": {
+                    "input_path": "MyNotebook.ipynb",
+                    "output_path": r"C:\Users\jsboi\AppData\Local\Temp\MyNotebook.ipynb",
+                }
+            }
+        }
+        defects = _scan_metadata_papermill(nb)
+        self.assertEqual(len(defects), 1)
+        self.assertEqual(defects[0]["kind"], "metadata_papermill_absolute")
+        self.assertEqual(defects[0]["location"], "metadata.papermill.output_path")
+        self.assertEqual(defects[0]["severity"], "high")
+
+    def test_absolute_input_path_flagged(self):
+        nb = {
+            "metadata": {
+                "papermill": {"input_path": "/home/jesse/MyNotebook.ipynb"}
+            }
+        }
+        defects = _scan_metadata_papermill(nb)
+        self.assertEqual(len(defects), 1)
+        self.assertEqual(defects[0]["location"], "metadata.papermill.input_path")
+
+    def test_both_paths_flagged(self):
+        nb = {
+            "metadata": {
+                "papermill": {
+                    "input_path": "C:/in.ipynb",
+                    "output_path": "D:/out.ipynb",
+                }
+            }
+        }
+        defects = _scan_metadata_papermill(nb)
+        self.assertEqual(len(defects), 2)
+
+    def test_missing_metadata_no_crash(self):
+        self.assertEqual(_scan_metadata_papermill({}), [])
+        self.assertEqual(_scan_metadata_papermill({"metadata": {}}), [])
+        self.assertEqual(_scan_metadata_papermill({"metadata": {"papermill": None}}), [])
+
+    def test_malformed_papermill_dict_no_crash(self):
+        # Even if ``papermill`` is the wrong type, we must not crash.
+        self.assertEqual(_scan_metadata_papermill({"metadata": {"papermill": "x"}}), [])
+
+
+# --- _scan_output_text ---
+
+
+class ScanOutputTextTests(unittest.TestCase):
+    def test_clean_outputs_no_leak(self):
+        nb = {
+            "cells": [
+                {
+                    "cell_type": "code",
+                    "outputs": [
+                        {"output_type": "stream", "name": "stdout", "text": "hello\n"},
+                        {
+                            "output_type": "display_data",
+                            "data": {"text/plain": "42"},
+                        },
+                    ],
+                }
+            ]
+        }
+        self.assertEqual(_scan_output_text(nb), [])
+
+    def test_stream_text_windows_user_profile_flagged(self):
+        nb = {
+            "cells": [
+                {
+                    "outputs": [
+                        {
+                            "output_type": "stream",
+                            "name": "stderr",
+                            "text": (
+                                'UserWarning: figure layout changed at '
+                                r'C:\Users\jsboi\AppData\Local\Temp\ipykernel_1234\foo.py:42'
+                            ),
+                        }
+                    ]
+                }
+            ]
+        }
+        defects = _scan_output_text(nb)
+        self.assertEqual(len(defects), 1)
+        self.assertEqual(defects[0]["kind"], "output_text_path_leak")
+        self.assertIn("cells[0].outputs[0].stream.text", defects[0]["location"])
+        self.assertIn(r"C:\Users\jsboi", defects[0]["match"])
+
+    def test_text_plain_str_flagged(self):
+        nb = {
+            "cells": [
+                {
+                    "outputs": [
+                        {
+                            "output_type": "execute_result",
+                            "data": {
+                                "text/plain": "loaded /home/jesse/.nuget/packages/x.dll",
+                            },
+                        }
+                    ]
+                }
+            ]
+        }
+        defects = _scan_output_text(nb)
+        self.assertEqual(len(defects), 1)
+        self.assertEqual(defects[0]["match"], "/home/jesse/.nuget/packages/x.dll")
+
+    def test_text_plain_list_flagged(self):
+        # nbformat wraps long stream stdout text as ``list[str]``. The
+        # detector must walk each piece independently.
+        nb = {
+            "cells": [
+                {
+                    "outputs": [
+                        {
+                            "output_type": "stream",
+                            "name": "stdout",
+                            "text": ["", "starting run in C:/Users/jsboi/repo\n"],
+                        }
+                    ]
+                }
+            ]
+        }
+        defects = _scan_output_text(nb)
+        self.assertEqual(len(defects), 1)
+        self.assertIn("stream.text[1]", defects[0]["location"])
+        self.assertEqual(
+            defects[0]["match"], "C:/Users/jsboi/repo",
+        )
+
+    def test_data_text_plain_list_flagged(self):
+        # When ``data['text/plain']`` is itself a list (multi-line
+        # ``execute_result``), each element is scanned independently and
+        # reported with its index in the location string.
+        nb = {
+            "cells": [
+                {
+                    "outputs": [
+                        {
+                            "output_type": "execute_result",
+                            "data": {
+                                "text/plain": [
+                                    "",
+                                    "result: 42 at /home/jesse/run.py",
+                                ],
+                            },
+                        }
+                    ]
+                }
+            ]
+        }
+        defects = _scan_output_text(nb)
+        self.assertEqual(len(defects), 1)
+        self.assertIn("data['text/plain'][1]", defects[0]["location"])
+        self.assertEqual(
+            defects[0]["match"], "/home/jesse/run.py",
+        )
+
+    def test_html_and_image_outputs_ignored(self):
+        # Binary / structured data must NOT be scanned as text.
+        nb = {
+            "cells": [
+                {
+                    "outputs": [
+                        {
+                            "output_type": "display_data",
+                            "data": {
+                                "text/html": "<p>C:\\Users\\jsboi\\index.html</p>",
+                                "image/png": b"\x89PNG\r\n\x1a\n C:\\Users\\jsboi\\fake",
+                            },
+                        }
+                    ]
+                }
+            ]
+        }
+        self.assertEqual(_scan_output_text(nb), [])
+
+    def test_no_outputs_no_crash(self):
+        self.assertEqual(_scan_output_text({"cells": []}), [])
+        self.assertEqual(_scan_output_text({"cells": [{"outputs": []}]}), [])
+
+    def test_multiple_leaks_in_one_cell(self):
+        nb = {
+            "cells": [
+                {
+                    "outputs": [
+                        {
+                            "output_type": "stream",
+                            "name": "stderr",
+                            "text": (
+                                r"failed at C:\Users\jsboi\file.py\n"
+                                r"also /home/jesse/other.py\n"
+                            ),
+                        }
+                    ]
+                }
+            ]
+        }
+        defects = _scan_output_text(nb)
+        # Both leaks in the same string are reported.
+        self.assertGreaterEqual(len(defects), 2)
+
+
+# --- scan_notebook ---
+
+
+class ScanNotebookTests(unittest.TestCase):
+    def test_clean_notebook(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = _make_nb(Path(tmp), "clean.ipynb", _empty_nb())
+            self.assertEqual(scan_notebook(p), [])
+
+    def test_unreadable_notebook_returns_structured_defect(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "bad.ipynb"
+            p.write_text("{ this is not json", encoding="utf-8")
+            defects = scan_notebook(p)
+            self.assertEqual(len(defects), 1)
+            self.assertEqual(defects[0]["kind"], "unreadable_notebook")
+            self.assertEqual(defects[0]["severity"], "high")
+
+    def test_outputs_flagged_when_enabled(self):
+        nb = {
+            "cells": [
+                {
+                    "outputs": [
+                        {
+                            "output_type": "stream",
+                            "name": "stderr",
+                            "text": r"warn: C:\Users\jsboi\.nuget\packages",
+                        }
+                    ]
+                }
+            ]
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            p = _make_nb(Path(tmp), "leaky.ipynb", nb)
+            self.assertEqual(scan_notebook(p), [])  # default off
+            self.assertEqual(len(scan_notebook(p, include_outputs=True)), 1)
+
+    def test_metadata_defect_always_included(self):
+        nb = {
+            "metadata": {"papermill": {"output_path": "/tmp/x.ipynb"}},
+            "cells": [],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            p = _make_nb(Path(tmp), "leaky.ipynb", nb)
+            self.assertEqual(len(scan_notebook(p)), 1)
+            self.assertEqual(len(scan_notebook(p, include_outputs=True)), 1)
+
+
+# --- iter_notebooks / scan_tree ---
+
+
+class ScanTreeTests(unittest.TestCase):
+    def test_iter_notebooks_skips_noise_dirs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "good").mkdir()
+            (root / "good" / "a.ipynb").write_text("{}", encoding="utf-8")
+            (root / ".git").mkdir()
+            (root / ".git" / "b.ipynb").write_text("{}", encoding="utf-8")
+            (root / "_archives").mkdir()
+            (root / "_archives" / "c.ipynb").write_text("{}", encoding="utf-8")
+            (root / "__pycache__").mkdir()
+            (root / "__pycache__" / "d.ipynb").write_text("{}", encoding="utf-8")
+            found = iter_notebooks(root)
+            self.assertEqual([p.name for p in found], ["a.ipynb"])
+
+    def test_iter_notebooks_sorted(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for name in ("c.ipynb", "a.ipynb", "b.ipynb"):
+                (root / name).write_text("{}", encoding="utf-8")
+            found = iter_notebooks(root)
+            self.assertEqual([p.name for p in found], ["a.ipynb", "b.ipynb", "c.ipynb"])
+
+    def test_iter_notebooks_single_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            f = _make_nb(Path(tmp), "solo.ipynb", _empty_nb())
+            self.assertEqual(iter_notebooks(f), [f])
+            # Non-ipynb file: empty list.
+            txt = Path(tmp) / "readme.txt"
+            txt.write_text("hi", encoding="utf-8")
+            self.assertEqual(iter_notebooks(txt), [])
+
+    def test_scan_tree_tags_relative_file_path(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            nb_dir = root / "sub"
+            nb_dir.mkdir()
+            nb = {
+                "metadata": {"papermill": {"output_path": "/tmp/x.ipynb"}},
+                "cells": [],
+            }
+            _make_nb(nb_dir, "leak.ipynb", nb)
+            _make_nb(nb_dir, "clean.ipynb", _empty_nb())
+            report = scan_tree(root)
+            files = sorted({d["file"] for d in report})
+            self.assertEqual(files, [str(Path("sub") / "leak.ipynb")])
+            self.assertEqual(report[0]["kind"], "metadata_papermill_absolute")
+
+
+# --- CLI integration ---
+
+
+class CliTests(unittest.TestCase):
+    def _run(self, *args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [sys.executable,
+             str(_HERE.parent / "detect_papermill_path_leak.py"),
+             *args],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+
+    def test_scan_clean_exits_0(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _make_nb(Path(tmp), "clean.ipynb", _empty_nb())
+            cp = self._run("--scan", str(Path(tmp) / "clean.ipynb"))
+            self.assertEqual(cp.returncode, 0)
+            report = json.loads(cp.stdout)
+            self.assertEqual(report, [])
+
+    def test_scan_defects_exits_0_with_json(self):
+        nb = {
+            "metadata": {"papermill": {"output_path": "/tmp/x.ipynb"}},
+            "cells": [],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            p = _make_nb(Path(tmp), "leak.ipynb", nb)
+            cp = self._run("--scan", str(p))
+            self.assertEqual(cp.returncode, 0)
+            report = json.loads(cp.stdout)
+            self.assertEqual(len(report), 1)
+
+    def test_check_clean_exits_0(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _make_nb(Path(tmp), "clean.ipynb", _empty_nb())
+            cp = self._run("--scan-all", tmp, "--check")
+            self.assertEqual(cp.returncode, 0)
+            # --check suppresses JSON on stdout
+            self.assertEqual(cp.stdout.strip(), "")
+
+    def test_check_defects_exits_1(self):
+        nb = {
+            "metadata": {"papermill": {"output_path": "/tmp/x.ipynb"}},
+            "cells": [],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            _make_nb(Path(tmp), "leak.ipynb", nb)
+            cp = self._run("--scan-all", tmp, "--check")
+            self.assertEqual(cp.returncode, 1)
+
+    def test_check_with_summary_keeps_human_output(self):
+        nb = {
+            "metadata": {"papermill": {"output_path": "/tmp/x.ipynb"}},
+            "cells": [],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            _make_nb(Path(tmp), "leak.ipynb", nb)
+            cp = self._run(
+                "--scan-all", tmp, "--check", "--summary",
+            )
+            self.assertEqual(cp.returncode, 1)
+            self.assertIn("metadata_papermill_absolute", cp.stderr)
+
+    def test_missing_path_exits_2(self):
+        cp = self._run("--scan", "/nonexistent/path.ipynb")
+        self.assertEqual(cp.returncode, 2)
+
+    def test_scan_all_default_cwd(self):
+        cp = self._run("--scan-all")
+        # Either clean (0) or defects (0 with JSON); never crash.
+        self.assertIn(cp.returncode, (0, 1))
+
+    def test_outputs_flag_passed_through(self):
+        nb = {
+            "cells": [
+                {
+                    "outputs": [
+                        {
+                            "output_type": "stream",
+                            "name": "stderr",
+                            "text": r"C:\Users\jsboi\.nuget\packages\foo",
+                        }
+                    ]
+                }
+            ]
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            p = _make_nb(Path(tmp), "leak.ipynb", nb)
+            # Without --outputs: clean (0 defects).
+            cp = self._run("--scan", str(p))
+            self.assertEqual(cp.returncode, 0)
+            # With --outputs: defect found.
+            cp = self._run("--scan", str(p), "--outputs")
+            self.assertEqual(cp.returncode, 0)
+            report = json.loads(cp.stdout)
+            self.assertEqual(len(report), 1)
+            self.assertEqual(report[0]["kind"], "output_text_path_leak")
+
+
+# --- Module-level invariants ---
+
+
+class ModuleInvariantsTests(unittest.TestCase):
+    def test_abs_path_re_matches_known_cases(self):
+        self.assertTrue(ABS_PATH_RE.match(r"C:\foo"))
+        self.assertTrue(ABS_PATH_RE.match("D:/foo"))
+        self.assertTrue(ABS_PATH_RE.match("/foo"))
+        self.assertTrue(ABS_PATH_RE.match(r"\\server\share\foo"))
+        self.assertFalse(ABS_PATH_RE.match("foo.ipynb"))
+        self.assertFalse(ABS_PATH_RE.match(""))
+
+    def test_leak_patterns_compile(self):
+        # The module exposes at least the documented leak patterns.
+        kinds = {p.pattern[:10] for p in LEAK_PATTERNS}
+        self.assertGreaterEqual(len(LEAK_PATTERNS), 5)
+
+    def test_cli_main_handles_clean_run(self):
+        # Direct call into the CLI main() with synthetic argv; should
+        # never raise on a clean temp tree.
+        with tempfile.TemporaryDirectory() as tmp:
+            _make_nb(Path(tmp), "clean.ipynb", _empty_nb())
+            rc = cli_main(["--scan-all", tmp])
+            self.assertEqual(rc, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Substance

Nouveau detecteur read-only `scripts/notebook_tools/detect_papermill_path_leak.py` companion du fix-up `scrub_papermill_paths.py`. Cible les fuites de paths machine-locales dans les notebooks Jupyter, une classe de defaut documentee dans `secrets-hygiene.md` regle 6 (Stop & Repair) et dans la docstring de `scrub_papermill_paths.py` §1.6.

**Diff** : 2 files, +950 insertions (0 deletions) pure addition outil.

- `scripts/notebook_tools/detect_papermill_path_leak.py` : +367 lignes (detector + CLI)
- `scripts/notebook_tools/tests/test_detect_papermill_path_leak.py` : +583 lignes (43 tests unitaires)

## Deux classes de defaut

**Class A — metadata.papermill absolute path leak** (severity: high). Quand un notebook est re-execute via papermill avec un output path absolu (`C:/Users/jsboi/AppData/Local/Temp/x.ipynb` ou `/home/jesse/x.ipynb`), papermill enregistre ce path dans `metadata.papermill.output_path` (et parfois `input_path`). Cible : paths relatifs (basename du notebook). Cf incident fondateur documente dans `scrub_papermill_paths.py` docstring.

**Class B — output text path leak** (severity: medium). Chemins machine-locaux dans les streams stdout/stderr ou dans `data['text/plain']` : matplotlib UserWarnings (`C:\Users\<user>\AppData\Local\Temp\ipykernel_<PID>\...`), pip already-satisfied lines, .NET Interactive loading extensions, tempfile paths. Re-executer regenere un leak frais a chaque run, donc non-portable par construction. Opt-in via `--outputs` (desactive par defaut pour eviter le bruit au premier scan).

## Justifications conception

- **Read-only strict** : aucun `--apply`. Le fix-up reste dans `scrub_papermill_paths.py`. Separation claire fix/detect, gate CI friendly.
- **Look-behind `(?<! :)` sur les patterns POSIX** : sans ce garde, `C:/Users/jsboi/repo` matche a la fois la regle Windows ET la regle macOS `/Users/...` → double-flagging. Test dedie `test_text_plain_list_flagged` verrouille ce point.
- **Skip HTML / image data** dans le scan class B : on ne scanne que `text/plain` et `stream.text`. Sorties binaires / structurees ignorees.
- **Skip dirs `.git`, `_archives`, `__pycache__`, `node_modules`, `.venv`** : conventions alignees sur `scrub_papermill_paths.py`.
- **Exit codes propres** : 0 clean / 1 defects / 2 usage. `--check` gate CI, `--summary` resume humain sur stderr.

## Anti-regression C.1/C.2 + L661/L662

- C.1 N/A : pas de notebook modifie.
- C.2 N/A : pas de notebook modifie.
- L661/L662 N/A : pas de doc generee.
- Anti-regression : pure addition, 0 deletion, 0 risque regression.

## Partition-affinity

`scripts/notebook_tools/` = po-2024 (cf MEMORY identity line 6). L143 SAFE cross-owner applicable (outillage = po-2024, axe #2876 owner po-2025 MAIS extraction language-agnostic OK sur partition-outillage).

## R3 collision scan

- po-2025 PR #7067 (MGS-2 Compositi Search-11) : autre fichier, autre genre. Disjoint.
- po-2024 c.670 PR #7063 (MGS-1 Search-11 Metaheuristics) : autre fichier, autre genre. Disjoint.
- PRs OPEN pool c.673 (8 PRs jsboige upstream) : aucune collision ; detector pure addition outillage = genre distinct.

## R6 anti-monotonie

Post-c.670/c.671 (substance orpheline Search accents + outillage) → c.672 (self-flag doublons) → c.673 (substance OWN partition po-2024 outillage detecteur read-only CI-friendly) = rotation genres+familles honoree (outillage + Read-only + Stop&Repair §6 alignment + tests).

## Tests

43 tests unitaires, 100% PASS :
- 10 tests `_is_absolute` (Windows / POSIX / UNC / relative / non-string)
- 6 tests `_scan_metadata_papermill` (clean / output_path / input_path / both / missing / malformed)
- 7 tests `_scan_output_text` (clean / stream / data str / data list / HTML/image skipped / no outputs / multi-leak)
- 4 tests `scan_notebook` (clean / unreadable / outputs flag / metadata always included)
- 4 tests `scan_tree` (skip noise dirs / sorted / single file / relative file path)
- 8 tests CLI (clean exit / defects exit / --check exit / --summary / missing path / default cwd / --outputs passthrough / mode rejection)
- 4 tests invariants module (ABS_PATH_RE / LEAK_PATTERNS / main clean run)

Scan de la partition `scripts/notebook_tools/` : 0 defect, exit 0 ✓.

## Justification pivot c.673

**Mandate user direct 2026-07-17** : « Idle interdit, c'est une regle hard ! ».

**Pool survey c.673** : 50 issues, 8 PRs OPEN all jsboige upstream, territoires owner-locked. Self-pick cross-pool delicat post-incident c.671 (L671-L3★ : GraphQL 5000/h exhausted → orphan-scan FPOS → 3 PRs doublons fermees par ai-01).

**Decision c.673** : substance OWN partition po-2024, **PAS de re-attach orphelin**, **PAS de pivot cross-owner sans greenlit ai-01**. Detector pure addition outillage = safe bet :
- 0 deletion → 0 regression risk
- partition-outillage po-2024 ✓
- alignement direct avec secrets-hygiene regle 6 (Stop & Repair)
- substance detachable (CI gate peut etre active ulterieurement sans casser la PR)

## Verdict

- L661/L662/L663 : conforme.
- L143 SAFE cross-owner : applicable (partition-outillage po-2024).
- C.1/C.2/anti-regression : conforme (pure addition).
- L671-L3★ : verifie (commit `a20459eff` PAS sur origin/main, gate OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
