### PR TITLE
fix(hygiene,#3160): scrub machine-local papermill metadata paths to basename (2 notebooks)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb
@@ -1436,7 +1436,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/accents_reexec_43693/out.ipynb",
+   "output_path": "Sudoku-9-GraphColoring-Python.ipynb",
    "parameters": {},
    "start_time": "2026-07-17T05:24:53.102317",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-16-Homomorphic-Encryption.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-16-Homomorphic-Encryption.ipynb
@@ -2164,8 +2164,8 @@
    "end_time": "2026-07-17T13:39:55.263661+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "/mnt/c/dev/CoursIA-7029-sc16-concrete-wsl/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-16-Homomorphic-Encryption.ipynb",
-   "output_path": "/mnt/c/Users/jsboi/AppData/Local/Temp/sc16-repro2.ipynb",
+   "input_path": "SC-16-Homomorphic-Encryption.ipynb",
+   "output_path": "SC-16-Homomorphic-Encryption.ipynb",
    "parameters": {},
    "start_time": "2026-07-17T13:39:39.825103+00:00",
    "version": "2.6.0"


### PR DESCRIPTION
## Summary

Scrub 3 machine-local absolute paths from `metadata.papermill.input_path`/`output_path` in 2 notebooks. These leaked the contributor's home directory and worktree paths into committed metadata.

## What changed (3 lines, 2 files)

| Notebook | Field | Before (leak) | After |
|----------|-------|---------------|-------|
| `Sudoku/Sudoku-9-GraphColoring-Python.ipynb` | `metadata.papermill.output_path` | `C:/Users/jsboi/AppData/Local/Temp/accents_reexec_43693/out.ipynb` | `Sudoku-9-GraphColoring-Python.ipynb` |
| `SmartContracts/.../SC-16-Homomorphic-Encryption.ipynb` | `metadata.papermill.output_path` | `/mnt/c/Users/jsboi/AppData/Local/Temp/sc16-repro2.ipynb` | `SC-16-Homomorphic-Encryption.ipynb` |
| `SmartContracts/.../SC-16-Homomorphic-Encryption.ipynb` | `metadata.papermill.input_path` | `/mnt/c/dev/CoursIA-7029-sc16-concrete-wsl/MyIA.AI.Notebooks/.../SC-16-Homomorphic-Encryption.ipynb` | `SC-16-Homomorphic-Encryption.ipynb` |

## Method / compliance

- Tool: `scripts/notebook_tools/scrub_papermill_paths.py --apply` (default mode).
- **This is the tolerated exception per `secrets-hygiene.md` §6** (mandate 2026-06-22): `metadata.papermill.input/output_path` → basename is explicitly allowed (it is **metadata**, not a cell output scrub — no Stop & Repair violation). The tool's `--outputs` mode (scrubbing paths inside stdout/stderr text) was deliberately **NOT used** — that would be the banned pattern.
- Surgical: diff is exactly 3 lines (the 3 paths). Cell sources, outputs, execution_count, cell metadata all preserved byte-identical (verified via `git diff`).

## Evidence (firsthand, worktree fresh `origin/main` 9598ca6dc)

```
$ python scrub_papermill_paths.py --scan-all   # default mode
BEFORE: scan summary: 2 notebook(s) with 3 absolute papermill path(s)
AFTER:  (this PR) 0 metadata.papermill leaks remain
grep -cE "jsboi|AppData|/mnt/c|C:/Users" <nb> = 0 (both files, post-apply)
```
- Both notebooks still parse: Sudoku-9 = 29 cells, SC-16 = 44 cells.
- 0 collision: no open PR touches either notebook.

## Scope

Atomique — 2 notebooks, registre distinct (papermill metadata hygiene ≠ accents/tooling/security/translation de mes cycles c.588–c.590). R6 variété honorée (5e registre distinct en 4 cycles).

Note: the repo-wide `--scan-all --outputs` mode flags 69 notebooks / 102 output-text leaks, but those are stdout/stderr leaks requiring Stop & Repair (re-exec or source fix), **not** a scrub — out of scope here.

See #3160 (secrets/path-leak hygiene). Part of metadata-hygiene workstream.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
