### PR TITLE
feat(notebook-tools): detect_papermill_failed_state (read-only CI-friendly detector)

### DIFF
--- a/scripts/notebook_tools/detect_papermill_failed_state.py
+++ b/scripts/notebook_tools/detect_papermill_failed_state.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""
+Detect notebooks whose papermill run did not complete cleanly.
+
+When papermill executes a notebook it stamps ``metadata.papermill`` with a
+small status block. A clean run leaves ``exception == None`` and ``status``
+unset (or set to ``completed``). Two failure modes leave **detectable
+fingerprints**:
+
+  * **Hard failure**: ``metadata.papermill.exception`` is truthy (a
+    non-``None`` value, typically ``True``). papermill caught an exception
+    during execution and recorded the notebook as failed. The cell
+    outputs may contain a partial traceback and the cells after the
+    failure point never ran. Committing such a notebook is a C.2 violation
+    (regression of substance — outputs do not reflect the source).
+
+  * **Soft failure (pending)**: ``metadata.papermill.status == "pending"``.
+    papermill started the run but never finished writing the metadata
+    block — typically because the executor process was killed (OOM, manual
+    abort, machine reboot). The notebook looks like it executed but the
+    metadata is stale; re-executing it produces fresh metadata.
+
+**Scope vs ``detect_papermill_path_leak.py``.** That detector inspects
+**paths** inside papermill metadata and output streams. This one inspects
+**state fields** (``exception``, ``status``, ``end_time``, ``start_time``).
+Both are read-only companions of the same family of papermill hygiene
+checks. They can be combined in a single CI step without conflict.
+
+**Usage.**
+
+    # Single file:
+    python detect_papermill_failed_state.py --scan path/to/notebook.ipynb
+
+    # Whole directory tree (skips .git/_archives/__pycache__/node_modules):
+    python detect_papermill_failed_state.py --scan-all .
+
+    # CI gate: exit 1 if any notebook is in a failed state:
+    python detect_papermill_failed_state.py --scan-all . --check
+
+    # Human-readable summary alongside JSON:
+    python detect_papermill_failed_state.py --scan-all . --summary
+
+**Design choices.**
+
+- **No external deps** beyond the Python 3.10 stdlib (``json``, ``re``,
+  ``argparse``, ``pathlib``).
+- **State semantics**: ``exception is None and status != 'pending'`` →
+  clean. Anything else is flagged with a ``severity`` (``high`` for hard
+  failures, ``medium`` for pending). The JSON defect entry includes the
+  raw ``exception``/``status`` value and the run's ``end_time`` /
+  ``start_time`` (when present) so a reviewer can triage quickly.
+- **Output files (``_output.ipynb``)** are intentionally scanned alongside
+  source notebooks: they are exactly where papermill writes its metadata
+  block, and committing a failed-output notebook into the repo is the
+  regression this detector is designed to catch.
+- **No ``--apply``**: this is a read-only detector. The fix is to
+  re-execute the notebook through papermill (or to drop the failed output
+  if the source is the canonical artifact). Fix-up stays in the user's
+  hands; the detector's job is to surface the failure list.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+# --- Defect classification ---
+
+
+def _classify_papermill_state(pm: dict) -> list[dict]:
+    """Return a list of defects for the papermill state of one notebook.
+
+    Empty list = clean state. One defect per failure mode, not per field:
+    a notebook with both ``exception`` truthy and ``status == "pending"``
+    produces a single ``hard_failure`` defect (the more severe class).
+    """
+    defects: list[dict] = []
+    if not isinstance(pm, dict):
+        return defects
+
+    exception = pm.get("exception")
+    status = pm.get("status")
+    end_time = pm.get("end_time")
+    start_time = pm.get("start_time")
+
+    # Hard failure: papermill caught an exception during execution.
+    # ``exception`` is None for clean runs; any other value (typically
+    # True, but papermill also records a string traceback in some
+    # versions) means a failure occurred.
+    if exception is not None:
+        defects.append({
+            "kind": "papermill_hard_failure",
+            "location": "metadata.papermill.exception",
+            "exception": exception,
+            "status": status,
+            "start_time": start_time,
+            "end_time": end_time,
+            "severity": "high",
+        })
+        return defects  # hard failure dominates pending
+
+    # Soft failure: status is "pending" (run was started but never
+    # finished writing the metadata block).
+    if status == "pending":
+        defects.append({
+            "kind": "papermill_pending",
+            "location": "metadata.papermill.status",
+            "exception": exception,
+            "status": status,
+            "start_time": start_time,
+            "end_time": end_time,
+            "severity": "medium",
+        })
+
+    return defects
+
+
+# --- Scanner glue ---
+
+
+def _read_notebook(nb_path: Path) -> dict | None:
+    try:
+        with nb_path.open(encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+# Directories skipped during recursive scans. Mirrors the conventions in
+# ``scrub_papermill_paths.py`` and ``detect_papermill_path_leak.py``.
+_SKIP_DIR_NAMES = frozenset({
+    ".git",
+    "_archives",
+    "__pycache__",
+    "node_modules",
+    ".venv",
+    "venv",
+})
+
+
+def iter_notebooks(root: Path) -> list[Path]:
+    """Yield every ``*.ipynb`` under ``root`` recursively, skipping noise dirs."""
+    if root.is_file():
+        return [root] if root.suffix == ".ipynb" else []
+    if not root.is_dir():
+        return []
+    out: list[Path] = []
+    for p in root.rglob("*.ipynb"):
+        if any(part in _SKIP_DIR_NAMES for part in p.parts):
+            continue
+        out.append(p)
+    return sorted(out)
+
+
+def scan_notebook(nb_path: Path) -> list[dict]:
+    """Return the defects list for a single notebook."""
+    nb = _read_notebook(nb_path)
+    if nb is None:
+        return [{
+            "kind": "unreadable_notebook",
+            "location": str(nb_path),
+            "severity": "high",
+            "reason": "JSON decode error or unreadable file",
+        }]
+    pm = nb.get("metadata", {}).get("papermill")
+    if pm is None:
+        # No papermill metadata at all = the notebook was not run through
+        # papermill. We intentionally do NOT flag this as a defect; manual
+        # execution is a valid authoring path.
+        return []
+    return _classify_papermill_state(pm)
+
+
+def scan_tree(root: Path) -> list[dict]:
+    """Scan every notebook under ``root``; return a flat defects report.
+
+    Each defect is augmented with ``file`` (relative to ``root`` when
+    possible) so a CI gate can pinpoint the offender. Defects from
+    different notebooks are not merged — order is preserved.
+    """
+    report: list[dict] = []
+    for nb_path in iter_notebooks(root):
+        try:
+            rel = str(nb_path.relative_to(root))
+        except ValueError:
+            rel = str(nb_path)
+        for d in scan_notebook(nb_path):
+            d_with_file = {"file": rel, **d}
+            report.append(d_with_file)
+    return report
+
+
+# --- CLI ---
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="detect_papermill_failed_state.py",
+        description=(
+            "Detect notebooks whose papermill run did not complete "
+            "cleanly (read-only, CI-friendly)."
+        ),
+    )
+    mode = p.add_mutually_exclusive_group(required=True)
+    mode.add_argument(
+        "--scan", metavar="PATH",
+        help="Scan a single notebook file (.ipynb).",
+    )
+    mode.add_argument(
+        "--scan-all", metavar="DIR", nargs="?", const=".",
+        help="Scan every notebook under DIR (default: current directory).",
+    )
+    p.add_argument(
+        "--check", action="store_true",
+        help="CI gate: exit 1 if any defect is found, suppress JSON.",
+    )
+    p.add_argument(
+        "--summary", action="store_true",
+        help="Print a human-readable summary alongside the JSON report.",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_arg_parser().parse_args(argv)
+    target = Path(args.scan if args.scan is not None else args.scan_all)
+    if not target.exists():
+        print(f"error: path does not exist: {target}", file=sys.stderr)
+        return 2
+    if args.scan is not None:
+        report = [
+            {"file": str(target), **d}
+            for d in scan_notebook(target)
+        ]
+    else:
+        report = scan_tree(target)
+
+    if args.summary and not args.check:
+        _print_summary(report)
+    elif not args.check:
+        print(json.dumps(report, indent=2, ensure_ascii=False))
+
+    if args.check and report:
+        if args.summary:
+            _print_summary(report)
+        return 1
+    return 0
+
+
+def _print_summary(report: list[dict]) -> None:
+    n = len(report)
+    by_kind: dict[str, int] = {}
+    files_with_defects: set[str] = set()
+    for d in report:
+        by_kind[d.get("kind", "?")] = by_kind.get(d.get("kind", "?"), 0) + 1
+        if "file" in d:
+            files_with_defects.add(d["file"])
+    print(
+        f"[detect_papermill_failed_state] {n} defect(s) in "
+        f"{len(files_with_defects)} file(s).",
+        file=sys.stderr,
+    )
+    for kind, count in sorted(by_kind.items()):
+        print(f"  - {kind}: {count}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/notebook_tools/tests/test_detect_papermill_failed_state.py
+++ b/scripts/notebook_tools/tests/test_detect_papermill_failed_state.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""Tests for ``detect_papermill_failed_state.py``.
+
+Coverage:
+
+- ``_classify_papermill_state`` — clean / hard failure (exception truthy)
+  / pending status / both failure modes coexisting / missing metadata /
+  malformed types.
+- ``scan_notebook`` — unreadable notebook returns a structured defect,
+  no papermill metadata returns no defect (manual execution is valid).
+- ``scan_tree`` — recursive discovery skips ``.git``/``_archives``/etc,
+  preserves a sorted order, and tags each defect with the file path
+  relative to the scan root.
+- CLI behaviour (``main``) — exit codes (0 clean, 1 defects, 2 usage),
+  JSON output suppression under ``--check``, and summary rendering.
+
+Run with::
+
+    cd scripts/notebook_tools
+    python -m pytest tests/test_detect_papermill_failed_state.py -v
+
+or directly::
+
+    python tests/test_detect_papermill_failed_state.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# Allow running the test directly without installing the package.
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE.parent))
+
+from detect_papermill_failed_state import (  # noqa: E402
+    _classify_papermill_state,
+    iter_notebooks,
+    main as cli_main,
+    scan_notebook,
+    scan_tree,
+)
+
+
+def _make_nb(tmp: Path, name: str, nb: dict) -> Path:
+    p = tmp / name
+    p.write_text(json.dumps(nb), encoding="utf-8")
+    return p
+
+
+def _empty_nb() -> dict:
+    return {
+        "cells": [],
+        "metadata": {},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+
+
+def _clean_papermill_meta() -> dict:
+    """Return a papermill metadata block corresponding to a successful run."""
+    return {
+        "exception": None,
+        "start_time": "2026-07-17T19:00:00.000000+00:00",
+        "end_time": "2026-07-17T19:00:08.578410+00:00",
+        "duration": 8.57841,
+        "parameters": {},
+        "input_path": "MyNotebook.ipynb",
+        "output_path": "MyNotebook.ipynb",
+        "version": "2.7.0",
+    }
+
+
+# --- _classify_papermill_state ---
+
+
+class ClassifyPapermillStateTests(unittest.TestCase):
+    def test_clean_state_no_defect(self):
+        self.assertEqual(_classify_papermill_state(_clean_papermill_meta()), [])
+
+    def test_hard_failure_flagged(self):
+        pm = _clean_papermill_meta()
+        pm["exception"] = True
+        defects = _classify_papermill_state(pm)
+        self.assertEqual(len(defects), 1)
+        self.assertEqual(defects[0]["kind"], "papermill_hard_failure")
+        self.assertEqual(defects[0]["location"], "metadata.papermill.exception")
+        self.assertEqual(defects[0]["severity"], "high")
+        self.assertTrue(defects[0]["exception"])
+
+    def test_pending_status_flagged(self):
+        pm = _clean_papermill_meta()
+        pm["status"] = "pending"
+        # exception stays None → only soft failure
+        defects = _classify_papermill_state(pm)
+        self.assertEqual(len(defects), 1)
+        self.assertEqual(defects[0]["kind"], "papermill_pending")
+        self.assertEqual(defects[0]["severity"], "medium")
+
+    def test_hard_failure_dominates_pending(self):
+        # If both are present, the hard failure is reported and the
+        # pending signal is suppressed (single defect entry per notebook).
+        pm = _clean_papermill_meta()
+        pm["exception"] = True
+        pm["status"] = "pending"
+        defects = _classify_papermill_state(pm)
+        self.assertEqual(len(defects), 1)
+        self.assertEqual(defects[0]["kind"], "papermill_hard_failure")
+
+    def test_string_exception_treated_as_hard_failure(self):
+        # Older papermill versions may record a string traceback in
+        # ``exception`` rather than the boolean True. Treat any
+        # non-None value as a hard failure.
+        pm = _clean_papermill_meta()
+        pm["exception"] = "ZeroDivisionError at cell 12"
+        defects = _classify_papermill_state(pm)
+        self.assertEqual(len(defects), 1)
+        self.assertEqual(defects[0]["kind"], "papermill_hard_failure")
+
+    def test_explicit_none_exception_with_completed_status_clean(self):
+        # ``status == "completed"`` is a no-op signal: the canonical
+        # clean state has status unset and exception None.
+        pm = _clean_papermill_meta()
+        pm["status"] = "completed"
+        self.assertEqual(_classify_papermill_state(pm), [])
+
+    def test_missing_metadata_no_crash(self):
+        # No papermill block at all = the notebook was not run through
+        # papermill. Not flagged (manual execution is valid).
+        self.assertEqual(_classify_papermill_state({}), [])
+        # Malformed type → no crash, no defect.
+        self.assertEqual(_classify_papermill_state({"papermill": "x"}), [])
+
+
+# --- scan_notebook ---
+
+
+class ScanNotebookTests(unittest.TestCase):
+    def test_clean_notebook_no_defect(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = _make_nb(
+                Path(tmp), "clean.ipynb",
+                {"metadata": {"papermill": _clean_papermill_meta()}, "cells": []},
+            )
+            self.assertEqual(scan_notebook(p), [])
+
+    def test_notebook_without_papermill_no_defect(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = _make_nb(Path(tmp), "manual.ipynb", _empty_nb())
+            self.assertEqual(scan_notebook(p), [])
+
+    def test_hard_failure_defect(self):
+        pm = _clean_papermill_meta()
+        pm["exception"] = True
+        with tempfile.TemporaryDirectory() as tmp:
+            p = _make_nb(
+                Path(tmp), "failed.ipynb",
+                {"metadata": {"papermill": pm}, "cells": []},
+            )
+            defects = scan_notebook(p)
+            self.assertEqual(len(defects), 1)
+            self.assertEqual(defects[0]["kind"], "papermill_hard_failure")
+
+    def test_unreadable_notebook_structured_defect(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "bad.ipynb"
+            p.write_text("{ not valid json", encoding="utf-8")
+            defects = scan_notebook(p)
+            self.assertEqual(len(defects), 1)
+            self.assertEqual(defects[0]["kind"], "unreadable_notebook")
+            self.assertEqual(defects[0]["severity"], "high")
+
+
+# --- iter_notebooks / scan_tree ---
+
+
+class ScanTreeTests(unittest.TestCase):
+    def test_iter_notebooks_skips_noise_dirs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "good").mkdir()
+            (root / "good" / "a.ipynb").write_text("{}", encoding="utf-8")
+            (root / ".git").mkdir()
+            (root / ".git" / "b.ipynb").write_text("{}", encoding="utf-8")
+            (root / "_archives").mkdir()
+            (root / "_archives" / "c.ipynb").write_text("{}", encoding="utf-8")
+            (root / "__pycache__").mkdir()
+            (root / "__pycache__" / "d.ipynb").write_text("{}", encoding="utf-8")
+            found = iter_notebooks(root)
+            self.assertEqual([p.name for p in found], ["a.ipynb"])
+
+    def test_iter_notebooks_sorted(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for name in ("c.ipynb", "a.ipynb", "b.ipynb"):
+                (root / name).write_text("{}", encoding="utf-8")
+            found = iter_notebooks(root)
+            self.assertEqual([p.name for p in found], ["a.ipynb", "b.ipynb", "c.ipynb"])
+
+    def test_iter_notebooks_single_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            f = _make_nb(Path(tmp), "solo.ipynb", _empty_nb())
+            self.assertEqual(iter_notebooks(f), [f])
+            txt = Path(tmp) / "readme.txt"
+            txt.write_text("hi", encoding="utf-8")
+            self.assertEqual(iter_notebooks(txt), [])
+
+    def test_scan_tree_tags_relative_file_path(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            nb_dir = root / "sub"
+            nb_dir.mkdir()
+            failed_pm = _clean_papermill_meta()
+            failed_pm["exception"] = True
+            _make_nb(
+                nb_dir, "fail.ipynb",
+                {"metadata": {"papermill": failed_pm}, "cells": []},
+            )
+            _make_nb(
+                nb_dir, "clean.ipynb",
+                {"metadata": {"papermill": _clean_papermill_meta()}, "cells": []},
+            )
+            _make_nb(nb_dir, "manual.ipynb", _empty_nb())
+            report = scan_tree(root)
+            files = sorted({d["file"] for d in report})
+            self.assertEqual(files, [str(Path("sub") / "fail.ipynb")])
+            self.assertEqual(report[0]["kind"], "papermill_hard_failure")
+
+    def test_scan_tree_preserves_file_order(self):
+        # When multiple notebooks fail, the order matches iter_notebooks
+        # (sorted by path) so CI logs are reproducible.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            failed_pm = _clean_papermill_meta()
+            failed_pm["exception"] = True
+            for name in ("z_fail.ipynb", "a_fail.ipynb", "m_fail.ipynb"):
+                _make_nb(
+                    root, name,
+                    {"metadata": {"papermill": failed_pm}, "cells": []},
+                )
+            report = scan_tree(root)
+            files = [d["file"] for d in report]
+            self.assertEqual(files, ["a_fail.ipynb", "m_fail.ipynb", "z_fail.ipynb"])
+
+
+# --- CLI integration ---
+
+
+class CliTests(unittest.TestCase):
+    def _run(self, *args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [sys.executable,
+             str(_HERE.parent / "detect_papermill_failed_state.py"),
+             *args],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+
+    def test_scan_clean_exits_0(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _make_nb(
+                Path(tmp), "clean.ipynb",
+                {"metadata": {"papermill": _clean_papermill_meta()}, "cells": []},
+            )
+            cp = self._run("--scan", str(Path(tmp) / "clean.ipynb"))
+            self.assertEqual(cp.returncode, 0)
+            self.assertEqual(json.loads(cp.stdout), [])
+
+    def test_scan_no_papermill_exits_0(self):
+        # Manual notebook (no papermill metadata) is NOT a defect.
+        with tempfile.TemporaryDirectory() as tmp:
+            p = _make_nb(Path(tmp), "manual.ipynb", _empty_nb())
+            cp = self._run("--scan", str(p))
+            self.assertEqual(cp.returncode, 0)
+            self.assertEqual(json.loads(cp.stdout), [])
+
+    def test_scan_failure_exits_0_with_json(self):
+        # JSON output mode: report on stdout, exit 0 (defects don't
+        # trigger a non-zero exit unless ``--check`` is passed).
+        failed_pm = _clean_papermill_meta()
+        failed_pm["exception"] = True
+        with tempfile.TemporaryDirectory() as tmp:
+            p = _make_nb(
+                Path(tmp), "fail.ipynb",
+                {"metadata": {"papermill": failed_pm}, "cells": []},
+            )
+            cp = self._run("--scan", str(p))
+            self.assertEqual(cp.returncode, 0)
+            report = json.loads(cp.stdout)
+            self.assertEqual(len(report), 1)
+            self.assertEqual(report[0]["kind"], "papermill_hard_failure")
+
+    def test_check_clean_exits_0(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _make_nb(
+                Path(tmp), "clean.ipynb",
+                {"metadata": {"papermill": _clean_papermill_meta()}, "cells": []},
+            )
+            cp = self._run("--scan-all", tmp, "--check")
+            self.assertEqual(cp.returncode, 0)
+            self.assertEqual(cp.stdout.strip(), "")
+
+    def test_check_defects_exits_1(self):
+        failed_pm = _clean_papermill_meta()
+        failed_pm["exception"] = True
+        with tempfile.TemporaryDirectory() as tmp:
+            _make_nb(
+                Path(tmp), "fail.ipynb",
+                {"metadata": {"papermill": failed_pm}, "cells": []},
+            )
+            cp = self._run("--scan-all", tmp, "--check")
+            self.assertEqual(cp.returncode, 1)
+
+    def test_check_with_summary_keeps_human_output(self):
+        failed_pm = _clean_papermill_meta()
+        failed_pm["exception"] = True
+        with tempfile.TemporaryDirectory() as tmp:
+            _make_nb(
+                Path(tmp), "fail.ipynb",
+                {"metadata": {"papermill": failed_pm}, "cells": []},
+            )
+            cp = self._run(
+                "--scan-all", tmp, "--check", "--summary",
+            )
+            self.assertEqual(cp.returncode, 1)
+            self.assertIn("papermill_hard_failure", cp.stderr)
+
+    def test_pending_reported_as_pending(self):
+        pm = _clean_papermill_meta()
+        pm["status"] = "pending"
+        with tempfile.TemporaryDirectory() as tmp:
+            p = _make_nb(
+                Path(tmp), "pending.ipynb",
+                {"metadata": {"papermill": pm}, "cells": []},
+            )
+            cp = self._run("--scan", str(p))
+            self.assertEqual(cp.returncode, 0)
+            report = json.loads(cp.stdout)
+            self.assertEqual(len(report), 1)
+            self.assertEqual(report[0]["kind"], "papermill_pending")
+            self.assertEqual(report[0]["severity"], "medium")
+
+    def test_missing_path_exits_2(self):
+        cp = self._run("--scan", "/nonexistent/path.ipynb")
+        self.assertEqual(cp.returncode, 2)
+
+    def test_cli_main_handles_clean_run(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _make_nb(
+                Path(tmp), "clean.ipynb",
+                {"metadata": {"papermill": _clean_papermill_meta()}, "cells": []},
+            )
+            rc = cli_main(["--scan-all", tmp])
+            self.assertEqual(rc, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
feat(notebook-tools): detect_papermill_failed_state (read-only CI-friendly detector)

Companion to detect_papermill_path_leak.py (#7076). That detector inspects **paths** in papermill metadata; this one inspects **state fields** (exception, status, end_time, start_time).

Two defect classes:

* **papermill_hard_failure** (severity high) -- `metadata.papermill.exception` is non-None (typically True, occasionally a string traceback in older papermill). Committing such a notebook is a C.2 violation (outputs do not reflect the source after a partial failure -- cells after the exception point never ran).

* **papermill_pending** (severity medium) -- `metadata.papermill.status == "pending"` (run was started but the executor was killed before the metadata block was written -- OOM, manual abort, machine reboot).

When both are present, the hard failure dominates (single defect entry per notebook, the more severe class). Manual notebooks (no papermill metadata at all) are NOT flagged -- manual execution is a valid authoring path.

## Output

* `--scan <nb>` -- single file JSON defects list
* `--scan-all <dir>` -- recursive tree scan, skipping `.git`/`_archives`/`__pycache__`/`node_modules`/`.venv`/`venv`
* `--check` -- exit 1 if any defect, suppresses JSON (CI gate)
* `--summary` -- human-readable tally on stderr

Exit codes: 0 (clean) / 1 (defects, only with `--check`) / 2 (usage).

## Tests

25 unit tests in `tests/test_detect_papermill_failed_state.py` cover:
* classification: clean / hard / pending / both / string exception / completed status / missing metadata
* scan_notebook: clean / no papermill / failure / unreadable
* scan_tree: skip noise dirs / sorted / single file / relative path / file order
* CLI: 0/1/2 exit codes + JSON + `--check` + `--summary`

All 25 tests PASS. First-iteration repo scan finds 4 failures on origin/main (DecInfer-4 + Argument-Analysis-3 + Z3-Python-08/09 pending) -- validating real-world signal.

## Scope

Pure addition. No external deps. No `--apply` (read-only). Fix-up stays in the user hands: re-execute the notebook through papermill.

Partition po-2024 (L143 SAFE). L671-L3* gate honored: `git merge-base --is-ancestor f653bb4ad origin/main` = FALSE (OWN substance, base f92a53852 from origin/main HEAD).

See #2161 for the broader notebook-hygiene programme.
