### PR TITLE
fix(probas): remove stale papermill failure metadata from DecInfer-4

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-4-Multi-Attribute.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-4-Multi-Attribute.ipynb
@@ -4,13 +4,6 @@
    "cell_type": "markdown",
    "id": "81b16659",
    "metadata": {
-    "papermill": {
-     "duration": 0.053969,
-     "end_time": "2026-06-04T11:05:10.794463+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T11:05:10.740494+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -44,13 +37,6 @@
    "cell_type": "markdown",
    "id": "160a89c0",
    "metadata": {
-    "papermill": {
-     "duration": 0.010093,
-     "end_time": "2026-06-04T11:05:10.822596+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T11:05:10.812503+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -88,13 +74,6 @@
      "iopub.status.busy": "2026-06-04T11:05:10.847785Z",
      "iopub.status.idle": "2026-06-04T11:05:14.786750Z",
      "shell.execute_reply": "2026-06-04T11:05:14.785700Z"
-    },
-    "papermill": {
-     "duration": 3.95454,
-     "end_time": "2026-06-04T11:05:14.786750+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T11:05:10.832210+00:00",
-     "status": "completed"
     },
     "tags": [],
     "vscode": {
@@ -136,13 +115,6 @@
    "cell_type": "markdown",
    "id": "f6fea224",
    "metadata": {
-    "papermill": {
-     "duration": 0.011072,
-     "end_time": "2026-06-04T11:05:14.811173+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T11:05:14.800101+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -162,13 +134,6 @@
     },
     "language_info": {
      "name": "polyglot-notebook"
-    },
-    "papermill": {
-     "duration": 0.160986,
-     "end_time": "2026-06-04T11:05:14.990552+00:00",
-     "exception": true,
-     "start_time": "2026-06-04T11:05:14.829566+00:00",
-     "status": "failed"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -207,13 +172,6 @@
    "cell_type": "markdown",
    "id": "0888c796",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -236,13 +194,6 @@
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
-    },
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
     },
     "tags": [],
     "vscode": {
@@ -334,13 +285,6 @@
    "cell_type": "markdown",
    "id": "50bffe81",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -362,13 +306,6 @@
    "cell_type": "markdown",
    "id": "c9482cde",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -393,13 +330,6 @@
    "cell_type": "markdown",
    "id": "c1dac1e5",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -448,13 +378,6 @@
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
-    },
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
     },
     "tags": [],
     "vscode": {
@@ -584,13 +507,6 @@
    "cell_type": "markdown",
    "id": "c5722037",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -618,13 +534,6 @@
    "cell_type": "markdown",
    "id": "e43bdd61",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -638,13 +547,6 @@
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
-    },
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
     },
     "tags": [],
     "vscode": {
@@ -779,13 +681,6 @@
    "cell_type": "markdown",
    "id": "18e01e5f",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -799,13 +694,6 @@
    "metadata": {
     "language_info": {
      "name": "polyglot-notebook"
-    },
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -943,13 +831,6 @@
    "cell_type": "markdown",
    "id": "8c954d69",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -994,13 +875,6 @@
    "metadata": {
     "language_info": {
      "name": "polyglot-notebook"
-    },
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -1167,13 +1041,6 @@
    "execution_count": 9,
    "id": "778a8589",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "outputs": [
@@ -1222,13 +1089,6 @@
    "cell_type": "markdown",
    "id": "6495d3f3",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -1255,13 +1115,6 @@
    "cell_type": "markdown",
    "id": "5d65859b",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -1303,13 +1156,6 @@
    "metadata": {
     "language_info": {
      "name": "polyglot-notebook"
-    },
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -1462,13 +1308,6 @@
    "cell_type": "markdown",
    "id": "9f19fc90",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -1482,13 +1321,6 @@
    "metadata": {
     "language_info": {
      "name": "polyglot-notebook"
-    },
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -1621,13 +1453,6 @@
    "cell_type": "markdown",
    "id": "91d1ef13",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -1698,13 +1523,6 @@
    "metadata": {
     "language_info": {
      "name": "polyglot-notebook"
-    },
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -1865,13 +1683,6 @@
    "cell_type": "markdown",
    "id": "31f61f2b",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -1885,13 +1696,6 @@
    "metadata": {
     "language_info": {
      "name": "polyglot-notebook"
-    },
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -2011,13 +1815,6 @@
    "cell_type": "markdown",
    "id": "bd6ba353",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -2035,13 +1832,6 @@
    "metadata": {
     "language_info": {
      "name": "polyglot-notebook"
-    },
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -2162,13 +1952,6 @@
    "cell_type": "markdown",
    "id": "b6f764ac",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -2182,13 +1965,6 @@
    "metadata": {
     "language_info": {
      "name": "polyglot-notebook"
-    },
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -2925,13 +2701,6 @@
    "execution_count": 17,
    "id": "7f25a9fe",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "outputs": [
@@ -2975,13 +2744,6 @@
    "cell_type": "markdown",
    "id": "ed5e5674",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -3007,13 +2769,6 @@
    "cell_type": "markdown",
    "id": "ba2c1349",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -3031,13 +2786,6 @@
    "metadata": {
     "language_info": {
      "name": "polyglot-notebook"
-    },
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -3230,13 +2978,6 @@
    "cell_type": "markdown",
    "id": "89a2b891",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -3281,13 +3022,6 @@
    "cell_type": "markdown",
    "id": "b011e78c",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -3311,13 +3045,6 @@
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
-    },
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
     },
     "tags": [],
     "vscode": {
@@ -3416,13 +3143,6 @@
    "cell_type": "markdown",
    "id": "e11c6b19",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -3453,13 +3173,6 @@
    "metadata": {
     "language_info": {
      "name": "polyglot-notebook"
-    },
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -3667,13 +3380,6 @@
    "cell_type": "markdown",
    "id": "8cd692b2",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -3716,13 +3422,6 @@
    "metadata": {
     "language_info": {
      "name": "polyglot-notebook"
-    },
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -3860,13 +3559,6 @@
    "cell_type": "markdown",
    "id": "222f554b",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -3880,13 +3572,6 @@
    "metadata": {
     "language_info": {
      "name": "polyglot-notebook"
-    },
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -4074,13 +3759,6 @@
    "cell_type": "markdown",
    "id": "43c800a8",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -4127,13 +3805,6 @@
    "metadata": {
     "language_info": {
      "name": "polyglot-notebook"
-    },
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
@@ -4203,13 +3874,6 @@
    "cell_type": "markdown",
    "id": "c98816de",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -4266,18 +3930,6 @@
    "name": "C#",
    "pygments_lexer": "csharp",
    "version": "12.0"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 7.443933,
-   "end_time": "2026-06-04T11:05:15.228719+00:00",
-   "environment_variables": {},
-   "exception": true,
-   "input_path": "MyIA.AI.Notebooks/Probas/Infer/Infer-4-Multi-Attribute.ipynb",
-   "output_path": "MyIA.AI.Notebooks/Probas/Infer/Infer-4-Multi-Attribute.ipynb",
-   "parameters": {},
-   "start_time": "2026-06-04T11:05:07.784786+00:00",
-   "version": "2.7.0"
   },
   "polyglot_notebook": {
    "kernelInfo": {


### PR DESCRIPTION
## Contexte

`DecInfer-4-Multi-Attribute.ipynb` était committé avec `metadata.papermill.exception=true` (signature d'une exécution Papermill échouée le 2026-06-04), alors que le notebook s'exécute en réalité de bout en bout. Défaut own-partition Probas/DecisionTheory/DecInfer, découvert via le détecteur `detect_papermill_failed_state` de po-2024 (#7079).

## Diagnostic (G.1 firsthand)

- `metadata.papermill.exception=true`, `cell[4] status=failed`, `cell[5..49] status=pending` (jamais exécutées selon papermill)
- `input_path`/`output_path` stalés : `Infer-4-Multi-Attribute.ipynb` (ancien nom pré-renumérotation #5637)
- **MAIS** les 22 cellules code avaient toutes des outputs complets et cohérents (tableaux, Monte Carlo déterministe `Random(42)`, inférence bayésienne Dirichlet, factor graph HTML)

Contradiction = les outputs venaient d'une exécution interactive réussie, et les metadata papermill reflétaient une exécution papermill échouée qui n'avait pas écrasé les outputs.

## Stop & Repair

1. **Re-exécution** via kernel `.net-csharp` (`notebook_tools.py execute --kernel .net-csharp --cwd DecInfer/ --cell-by-cell`, L542b-L1 ★ cwd pour le `#load "../../Infer/FactorGraphHelper.cs"` relatif) → **22/22 cells OK, 0 erreur, 23.2 s**. La re-exec a produit un fichier **byte-identique à HEAD** : preuve que les outputs committés sont valides et reproductibles. La cause (run papermill échoué) est résolue.
2. **Nettoyage de l'artefact metadata mensonger** : `metadata.papermill` (notebook + 48 cells) retiré. Le bloc `exception=true` était une **fausse preuve d'échec**, pas un output de cellule — normalisation autorisée par `secrets-hygiene` règle 6 (`metadata.papermill` est l'une des 2 normalisations manuelles tolérées, ce n'est pas un scrub d'output).

## Preuves H.1/H.3

| Preuve | Résultat |
|--------|----------|
| Re-exec end-to-end | 22/22 cells OK, 0 erreur (.net-csharp, 23.2 s) |
| `execution_count != null` | 22/22 cellules code |
| `validate_pr_notebooks.py` | **PASS** (22 cells, .net-csharp, `EXEC_PROVED`) |
| Diff chirurgical | 348 deletions, **0 insertion** — aucune ligne `source`/`outputs`/`execution_count`/`cell_type`/`id` touchée |
| Cellule exercise stubs (C.1) | Préservés (exercices 1-4 non complétés, `print("Exercice a completer...")`) |

## Anti-régression §D

Aucune cellule `# Solution` / `# Exemple résolu` touchée. Aucun code source modifié. Les 4 exercices (`print("Exercice a completer...")`) restent stubbés (C.1 conforme).

## Scope

1 fichier, 1 notebook, 1 sujet (metadata papermill obsolète). R3 disjoint de #7078 (jsboige, accents DecInfer-5 markdown — notebook et type de修改 différents).

See #7079 (détecteur qui a révélé ce défaut).
