### PR TITLE
docs(gt,#4365): correct Peters upstream SHA from d679d950 to actual lake-manifest rev

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/social_choice_lean_peters/README.en.md
+++ b/MyIA.AI.Notebooks/GameTheory/social_choice_lean_peters/README.en.md
@@ -31,14 +31,14 @@ Complementary, not duplicate. `social_choice_lean` uses custom `PrefOrder` (our 
 ## Notes
 
 - Backend Lake for a (planned, not yet created) tour companion notebook
-- Peters' repo pinned at commit `d679d950` for reproducibility
+- Peters' repo pinned at commit `355075e3e35f940a2ade0cbfb5be27b4a53c6776` for reproducibility
 - Peters uses `LinearOrder` (strict, Mathlib); we use `PrefOrder` (reflexive, total, transitif)
 
 ## Conclusion
 
 This project is a **reference tour** of
 [DominikPeters/SocialChoiceLean](https://github.com/DominikPeters/SocialChoiceLean),
-imported as a Lake dependency (pinned at commit `d679d950`, toolchain
+imported as a Lake dependency (pinned at commit `355075e3e35f940a2ade0cbfb5be27b4a53c6776`, toolchain
 `v4.27.0-rc1`) and exhibited via `#check`s in `PetersTour.lean` — **0 `sorry`**,
 `lake build` SUCCESS. It is **not** original formalization: it presents Peters'
 results, the current reference implementation of social-choice theory in Lean 4.

--- a/MyIA.AI.Notebooks/GameTheory/social_choice_lean_peters/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/social_choice_lean_peters/README.md
@@ -33,14 +33,14 @@ Complémentaire, sans doublon. `social_choice_lean` utilise un `PrefOrder` perso
 ## Notes
 
 - Backend Lake pour un notebook compagnon de tour (prévu, pas encore créé)
-- Le dépôt de Peters est pinné au commit `d679d950` pour la reproductibilité
+- Le dépôt de Peters est pinné au commit `355075e3e35f940a2ade0cbfb5be27b4a53c6776` pour la reproductibilité
 - Peters utilise `LinearOrder` (strict, Mathlib) ; nous utilisons `PrefOrder` (réflexif, total, transitif)
 
 ## Conclusion
 
 Ce projet est une **visite de référence** de
 [`DominikPeters/SocialChoiceLean`](https://github.com/DominikPeters/SocialChoiceLean),
-importée comme dépendance Lake (pinnée au commit `d679d950`, toolchain
+importée comme dépendance Lake (pinnée au commit `355075e3e35f940a2ade0cbfb5be27b4a53c6776`, toolchain
 `v4.27.0-rc1`) et exhibée via des `#check` dans `PetersTour.lean` — **0 `sorry`**,
 `lake build` SUCCESS. Ce n'est **pas** une formalisation originale : il présente
 les résultats de Peters, l'implémentation de référence actuelle de la théorie du


### PR DESCRIPTION
## Summary

Sister PR to #7081 (c.576 INTRINSIC verdict for `social_choice_lean_peters/`).
Closes the G.1 SHA divergence flagged in PR #7081 body as scope-creep to
address in a follow-up fix-doc PR.

Replaces 4 occurrences of the **outdated** Peters upstream SHA `d679d950`
with the **actual** rev pinned in `lake-manifest.json`:
`355075e3e35f940a2ade0cbfb5be27b4a53c6776`.

| File | Lines fixed | Pattern |
|------|-------------|---------|
| `MyIA.AI.Notebooks/GameTheory/social_choice_lean_peters/README.md` | L36 + L43 | FR (Notes + Conclusion) |
| `MyIA.AI.Notebooks/GameTheory/social_choice_lean_peters/README.en.md` | L34 + L41 | EN (Notes + Conclusion) |

## Root cause

The original README content (predating #7081) referenced `d679d950` for
the Peters upstream pin — a SHA that does **not** match the actual rev
recorded in `lake-manifest.json`. This G.1 violation was detected during
c.576 work and explicitly flagged in PR #7081 body as scope-creep to
preserve R3 atomicity.

## G.1 firsthand verification

Before this commit (2026-07-17):
- `lake-manifest.json` Peters `rev` = `355075e3e35f940a2ade0cbfb5be27b4a53c6776` (`jq '.packages[] | select(.name=="DominikPeters") | .rev'`, VERIFIED)
- `lake-manifest.json` Mathlib `rev` = `8cb9319191fd34b6f23d7ffea58a4f8fb674cefd` (same jq query, VERIFIED)
- 4 occurrences of `d679d950` on `origin/main` baseline (`grep -n "d679d950"`, VERIFIED)
- 0 occurrences of `d679d950` post-fix on this branch (verified)
- 4 new occurrences of `355075e3e35f940a2ade0cbfb5be27b4a53c6776` (= 4 fixed lines)

## Diff scope

```
MyIA.AI.Notebooks/GameTheory/social_choice_lean_peters/README.en.md | 4 ++--
MyIA.AI.Notebooks/GameTheory/social_choice_lean_peters/README.md    | 4 ++--
2 files changed, 4 insertions(+), 4 deletions(-)
```

R3 atomique respectée: <3000L/<15f/<4 feat/<1 domaine.

## Self-pick rationale (po-2023, R6 anti-monotonie)

This is a **direct follow-through** on PR #7081's body promise:

> "8 anciennes occurrences intactes (scope creep) + flaggé pour PR sœur fix-doc"

Picking it honors the user's R6 anti-monotonie mandate: continue Lean docs
territory (po-2023 native track record c.299-c.448) rather than re-pick
yfinance-quantbook (#6891 — closed on sight per C575-L4 HARD STEER) or
contaminate another worker's PR (#7078/#7079/#7080/#7082/#7083).

## Caveats / post-merge follow-up

After PR #7081 merges, the EN README's `EPIC #4365 Status` section
(introduced by #7081) will introduce **1 additional** occurrence of
`d679d950` at line 45 (same paragraph that already correctly cites
`355075e3e35f940a2ade0cbfb5be27b4a53c6776` at line 66 — internal
inconsistency in the new section).

This is **NOT** addressed in c.577 because:
- c.577 branches from `origin/main` (where the EPIC #4365 Status section
  does not yet exist — it's still in PR #7081's branch).
- Modifying PR #7081's new section here would create a merge conflict with
  the #7081 branch.

**Recommendation** (for ai-01's merge-gate decision):
- Option A (preferred): amend PR #7081 to also fix line 45, keeping the
  EPIC #4365 Status section internally consistent before merging. Then
  close c.577 PR as redundant.
- Option B: merge c.577 first, then merge #7081 (post-merge), then a third
  PR fixes the post-merge line 45.
- Option C: merge #7081 as-is, then this PR, then a third PR fixes line 45.

This is a **documentation accuracy issue**, not a code/runtime issue —
no impact on Lean build, sorry count, or INTRINSIC verdict.

## References

- #7081 (sister PR, OPEN, awaiting review) — added EPIC #4365 Status section
- #4365 (EPIC parent — GT 6→2 regroupement)
- #4364 (Mathlib convergence, COMPLETED 2026-07-03 — context for INTRINSIC)
- [sota-not-workaround.md](.claude/rules/sota-not-workaround.md) — INTRINSIC verdict
- [verify-before-claiming.md](.claude/rules/verify-before-claiming.md) — G.1 rule

## Verdict

Atomic, R3-compliant, G.1-verified documentation fix. No code, no runtime,
no Lean build impact. Closes a promise made in PR #7081's body.