### PR TITLE
fix(ml,#2876): restore French accents in ML-9-Anomaly-Detection markdown (51 cures, code untouched)

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-9-Anomaly-Detection.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-9-Anomaly-Detection.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# ML-9 : Detection d'anomalies avec Randomized PCA\n",
     "\n",
-    "**Navigation** : [Index](README.md) | [<< Precedent](ML-8-Clustering.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [<< Précédent](ML-8-Clustering.ipynb)\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -29,13 +29,13 @@
    "source": [
     "## Du clustering a la detection d'anomalies\n",
     "\n",
-    "Le [ML-8](ML-8-Clustering.ipynb) regroupait des points en clusters sans etiquettes. La **detection d'anomalies** repond a une question differente : etant donne un regime de fonctionnement **normal** (apprentissage), quels points s'en ecartent suffisamment pour etre soupconnes anormaux ? C'est encore de l'apprentissage **non-supervise** au sens ou le modele n'apprend qu'a partir de donnees normales — mais la tache est un **test** (chaque point est-il dans la distribution normale ?), pas une partition.\n",
+    "Le [ML-8](ML-8-Clustering.ipynb) regroupait des points en clusters sans etiquettes. La **detection d'anomalies** repond a une question différente : etant donne un regime de fonctionnement **normal** (apprentissage), quels points s'en ecartent suffisamment pour etre soupconnes anormaux ? C'est encore de l'apprentissage **non-supervise** au sens ou le modèle n'apprend qu'a partir de données normales — mais la tâche est un **test** (chaque point est-il dans la distribution normale ?), pas une partition.\n",
     "\n",
     "Le cas d'usage industriel canonique est la **maintenance predictive** : une machine saine (capteurs : temperature, pression, vibration) opere dans un etroite ellipse de regimx ; une usure, une fuite ou un desequilibre la fait deriver hors de cette zone. On veut declencher une alerte avant la casse. ML.NET fournit le trainer [Randomized PCA](https://learn.microsoft.com/dotnet/api/microsoft.ml.trainers.randomizedpcatrainer) via `mlContext.AnomalyDetection.Trainers.RandomizedPca`.\n",
     "\n",
-    "L'intuition (Pfiefer et al., 2011 ; Lakhina et al., 2004) : la PCA projette les donnees normales sur un **sous-espace de faible dimension** (les *k* premieres composantes). Un point normal se reconstruit bien dans ce sous-espace (faible residu) ; un point anormal, lui, s'etale hors du sous-espace et laisse un **fort residu de reconstruction**. Ce residu est le **score d'anomalie** : plus il est eleve, plus le point s'ecarte du regime appris.\n",
+    "L'intuition (Pfiefer et al., 2011 ; Lakhina et al., 2004) : la PCA projette les données normales sur un **sous-espace de faible dimension** (les *k* premières composantes). Un point normal se reconstruit bien dans ce sous-espace (faible residu) ; un point anormal, lui, s'etale hors du sous-espace et laisse un **fort residu de reconstruction**. Ce residu est le **score d'anomalie** : plus il est eleve, plus le point s'ecarte du regime appris.\n",
     "\n",
-    "> **Subtilite importante.** Le trainer est non-supervise au **Fit** (il ignore toute etiquette), mais l'**Evaluate** a besoin d'une colonne `Label` (colonne `float`, 1.0 = anomalie, 0.0 = normal) sur le jeu de test pour calculer l'AUC. On s'entraine donc sur des donnees normales et l'on evalue sur un jeu de test **labellise** melangeant normaux et anomalies.\n",
+    "> **Subtilite importante.** Le trainer est non-supervise au **Fit** (il ignore toute etiquette), mais l'**Evaluate** a besoin d'une colonne `Label` (colonne `float`, 1.0 = anomalie, 0.0 = normal) sur le jeu de test pour calculer l'AUC. On s'entraine donc sur des données normales et l'on evalue sur un jeu de test **labellise** melangeant normaux et anomalies.\n",
     "\n"
    ]
   },
@@ -118,7 +118,7 @@
    "id": "ml9-md-6",
    "metadata": {},
    "source": [
-    "Comme dans [ML-1](ML-1-Introduction.ipynb), on cree le [MLContext](https://learn.microsoft.com/dotnet/api/microsoft.ml.mlcontext) — le point d'entree commun. On fixe la graine (`seed: 42`) pour rendre la PCA randomisee deterministe (sinon la projection stochastique varie d'une execution a l'autre)."
+    "Comme dans [ML-1](ML-1-Introduction.ipynb), on créé le [MLContext](https://learn.microsoft.com/dotnet/api/microsoft.ml.mlcontext) — le point d'entree commun. On fixe la graine (`seed: 42`) pour rendre la PCA randomisee déterministe (sinon la projection stochastique varie d'une exécution a l'autre)."
    ]
   },
   {
@@ -152,7 +152,7 @@
    "id": "ml9-md-8",
    "metadata": {},
    "source": [
-    "## Jeu de donnees : capteurs d'une machine\n",
+    "## Jeu de données : capteurs d'une machine\n",
     "\n",
     "On simule trois capteurs d'une machine industrielle. Plutot que les valeurs brutes, on travaille avec les **ecarts au point de fonctionnement nominal** : c'est cette deviation qui est informative. Le regime sain est ainsi centre sur l'origine :\n",
     "\n",
@@ -164,12 +164,12 @@
     "\n",
     "On construit **deux** jeux distincts :\n",
     "\n",
-    "- **`trainData`** (200 points **normaux** uniquement) — c'est le regime que le modele apprend. Le `Label` vaut `0.0` partout et le trainer **l'ignore** au Fit.\n",
+    "- **`trainData`** (200 points **normaux** uniquement) — c'est le regime que le modèle apprend. Le `Label` vaut `0.0` partout et le trainer **l'ignore** au Fit.\n",
     "- **`testData`** (120 points normaux + 40 anomalies, labellises) — sert a evaluer l'AUC et a tuner le seuil.\n",
     "\n",
     "Les anomalies sont volontairement moderees (~3 ecarts-types par capteur) afin que la detection reste **non-triviale** : un peu de chevauchement subsiste, et le choix du seuil aura un vrai cout.\n",
     "\n",
-    "Definissons d'abord les classes de donnees ML.NET et un utilitaire gaussien (Box-Muller)."
+    "Definissons d'abord les classes de données ML.NET et un utilitaire gaussien (Box-Muller)."
    ]
   },
   {
@@ -232,7 +232,7 @@
    "id": "ml9-md-10",
    "metadata": {},
    "source": [
-    "On genere maintenant les deux jeux. Le regime sain centre les trois ecarts autour de 0 (machine reglee au nominal) avec un bruit gaussien realiste. La **pression** est une variable etroitement regulate (faible ecart-type) ; les anomalies simulent une fuite ou un desequilibre qui la fait deriver fortement (pic de ~8 ecarts-types), accompagne d'une surchauffe et de vibrations. Ce decalage **orthogonal au plan de variance normale** est precisement ce que la PCA detecte."
+    "On genere maintenant les deux jeux. Le regime sain centre les trois ecarts autour de 0 (machine reglee au nominal) avec un bruit gaussien realiste. La **pression** est une variable etroitement regulate (faible ecart-type) ; les anomalies simulent une fuite ou un desequilibre qui la fait deriver fortement (pic de ~8 ecarts-types), accompagne d'une surchauffe et de vibrations. Ce decalage **orthogonal au plan de variance normale** est précisément ce que la PCA detecte."
    ]
   },
   {
@@ -339,16 +339,16 @@
    "source": [
     "## Pipeline : concatenation, Randomized PCA\n",
     "\n",
-    "Le pipeline a **deux** etapes :\n",
+    "Le pipeline a **deux** étapes :\n",
     "\n",
     "1. **Concatenation** des trois capteurs en un vecteur `\"Features\"`,\n",
     "2. **Randomized PCA** de rang `2`.\n",
     "\n",
-    "> **Pourquoi PAS de normalisation MinMax ici, contrairement a [ML-8](ML-8-Clustering.ipynb) ?** K-Means mesure des **distances euclidiennes** et exige que les features soient a la meme echelle. La detection d'anomalies par PCA, elle, exploite justement la **structure de variance** : les composantes principales sont definies par les directions de plus grande variance. Normaliser ecraserait cette structure. C'est une difference fondamentale entre les deux familles non-supervisees.\n",
+    "> **Pourquoi PAS de normalisation MinMax ici, contrairement a [ML-8](ML-8-Clustering.ipynb) ?** K-Means mesure des **distances euclidiennes** et exige que les features soient a la même echelle. La detection d'anomalies par PCA, elle, exploite justement la **structure de variance** : les composantes principales sont définies par les directions de plus grande variance. Normaliser ecraserait cette structure. C'est une différence fondamentale entre les deux familles non-supervisees.\n",
     "\n",
-    "> **Pourquoi `rank: 2` ?** Avec 3 features, la PCA de rang 2 projette les donnees sur un **plan** ; le score d'anomalie est la composante **hors-plan** (le residu le long de la 3e direction). Si l'on choisissait `rank: 3` (le maximum), **tout** serait explique et le residu serait nul : la detection deviendrait impossible. Le rang controle donc la **sensibilite** du detecteur (cf. [Exercice 1](#Exercice-1-:-Effet-du-rang-PCA-sur-l'AUC)). **C'est un piege frequent** : le rang par defaut est 20, qui planterait ici avec seulement 3 features.\n",
+    "> **Pourquoi `rank: 2` ?** Avec 3 features, la PCA de rang 2 projette les données sur un **plan** ; le score d'anomalie est la composante **hors-plan** (le residu le long de la 3e direction). Si l'on choisissait `rank: 3` (le maximum), **tout** serait explique et le residu serait nul : la detection deviendrait impossible. Le rang contrôle donc la **sensibilite** du detecteur (cf. [Exercice 1](#Exercice-1-:-Effet-du-rang-PCA-sur-l'AUC)). **C'est un piege frequent** : le rang par defaut est 20, qui planterait ici avec seulement 3 features.\n",
     "\n",
-    "Nos donnees sont deja **recentrees sur l'origine** (ecarts au point nominal) : la PCA passe donc par le centroid, condition essentielle pour que le residu reflete bien l'ecart au regime normal."
+    "Nos données sont déjà **recentrees sur l'origine** (ecarts au point nominal) : la PCA passe donc par le centroid, condition essentielle pour que le residu reflete bien l'ecart au regime normal."
    ]
   },
   {
@@ -385,7 +385,7 @@
    "id": "ml9-md-16",
    "metadata": {},
    "source": [
-    "On entraine le modele sur **`trainData` (donnees normales uniquement)** via [Fit](https://learn.microsoft.com/dotnet/api/microsoft.ml.iestimator-1.fit). Le modele apprend ainsi la geometrie du regime sain ; il n'a jamais vu d'anomalies."
+    "On entraine le modèle sur **`trainData` (données normales uniquement)** via [Fit](https://learn.microsoft.com/dotnet/api/microsoft.ml.iestimator-1.fit). Le modèle apprend ainsi la geometrie du regime sain ; il n'a jamais vu d'anomalies."
    ]
   },
   {
@@ -424,9 +424,9 @@
     "Contrairement au clustering (ML-8), la detection d'anomalies **se laisse evaluer** des lors que le jeu de test est labellise. On dispose de deux metriques complementaires :\n",
     "\n",
     "- **`AreaUnderRocCurve`** (AUC, area under the ROC curve) : probabilite qu'un point anormal tire au hasard ait un score plus eleve qu'un point normal tire au hasard. 1.0 = separation parfaite ; 0.5 = hasard.\n",
-    "- **`DetectionRateAtFalsePositiveCount`** : parmi les vraies anomalies, quelle fraction est detectee avant que le modele ne produise *K* fausses alarmes (par defaut, *K* = 10). C'est la metrique operationnelle : a quel point mon detecteur est-il utile **a faible taux de fausse alarme** ?\n",
+    "- **`DetectionRateAtFalsePositiveCount`** : parmi les vraies anomalies, quelle fraction est detectee avant que le modèle ne produise *K* fausses alarmes (par defaut, *K* = 10). C'est la metrique operationnelle : a quel point mon detecteur est-il utile **a faible taux de fausse alarme** ?\n",
     "\n",
-    "On obtient ces metriques via `mlContext.AnomalyDetection.Evaluate`, qui lit la colonne `Label` (verite terrain) et la colonne `Score` (sortie du modele)."
+    "On obtient ces metriques via `mlContext.AnomalyDetection.Evaluate`, qui lit la colonne `Label` (verite terrain) et la colonne `Score` (sortie du modèle)."
    ]
   },
   {
@@ -485,7 +485,7 @@
     "| AreaUnderRocCurve (AUC) | **0,848** | bonne separation (1,0 = parfait, 0,5 = hasard) |\n",
     "| DetectionRate @ 10 FP | 0,225 | fraction des anomalies detectee avant 10 fausses alarmes |\n",
     "\n",
-    "Un AUC de **0,85** signale une bonne separation : un point anormal tire au hasard a ~85 % de chances d'etre score plus haut qu'un point normal. Ce n'est **pas** 1,0 car le chevauchement subsiste — une anomalie dont le pic de pression est modere ressemble, dans le sous-espace PCA, a un point normal bruite. Le Detection Rate @ 10 FP (0,225) traduit cette limite : a tres faible budget de fausses alarmes, on ne rattrape qu'un quart des anomalies. Le sweep de seuil ci-dessous montrera comment on ameliore ce taux en acceptant plus de fausses alarmes."
+    "Un AUC de **0,85** signale une bonne separation : un point anormal tire au hasard a ~85 % de chances d'etre score plus haut qu'un point normal. Ce n'est **pas** 1,0 car le chevauchement subsiste — une anomalie dont le pic de pression est modere ressemble, dans le sous-espace PCA, a un point normal bruite. Le Detection Rate @ 10 FP (0,225) traduit cette limite : a très faible budget de fausses alarmes, on ne rattrape qu'un quart des anomalies. Le sweep de seuil ci-dessous montrera comment on ameliore ce taux en acceptant plus de fausses alarmes."
    ]
   },
   {
@@ -495,12 +495,12 @@
    "source": [
     "## Prediction : scorer un nouveau point\n",
     "\n",
-    "On cree un [PredictionEngine](https://learn.microsoft.com/dotnet/api/microsoft.ml.predictionengine-2) (comme en [ML-1](ML-1-Introduction.ipynb) et [ML-8](ML-8-Clustering.ipynb)) pour inferer le score de nouveaux points. La prediction renvoie :\n",
+    "On créé un [PredictionEngine](https://learn.microsoft.com/dotnet/api/microsoft.ml.predictionengine-2) (comme en [ML-1](ML-1-Introduction.ipynb) et [ML-8](ML-8-Clustering.ipynb)) pour inferer le score de nouveaux points. La prediction renvoie :\n",
     "\n",
     "- `Score` : le residu de reconstruction PCA (plus eleve = plus anomalous),\n",
-    "- `PredictedLabel` : un booleen, `true` si `Score` depasse un seuil **calibre pendant le Fit** (par defaut, le trainer suppose ~10 % de contamination).\n",
+    "- `PredictedLabel` : un booléen, `true` si `Score` depasse un seuil **calibre pendant le Fit** (par defaut, le trainer suppose ~10 % de contamination).\n",
     "\n",
-    "> **Avertissement sur le seuil par defaut.** Le seuil embarque est calibre sur une hypothese de contamination (~10 %). Si votre jeu d'entrainement est **integrallement normal** (ce qui est l'ideal), ce seuil est trop bas : le modele flagge les ~10 % de normaux les plus extremes. C'est pourquoi l'[Exercice 2](#Exercice-2-:-Accorder-le-seuil-a-un-cout-operationnel) vous fera tuner ce seuil vous-meme — le `Score`, lui, est fiable."
+    "> **Avertissement sur le seuil par defaut.** Le seuil embarque est calibre sur une hypothese de contamination (~10 %). Si votre jeu d'entrainement est **integrallement normal** (ce qui est l'ideal), ce seuil est trop bas : le modèle flagge les ~10 % de normaux les plus extremes. C'est pourquoi l'[Exercice 2](#Exercice-2-:-Accorder-le-seuil-a-un-cout-operationnel) vous fera tuner ce seuil vous-même — le `Score`, lui, est fiable."
    ]
   },
   {
@@ -570,9 +570,9 @@
    "source": [
     "### Redemption : la ou PCA est vraiment indispensable\n",
     "\n",
-    "Le cas ci-dessus (pic de pression a **8 ecarts-types**) est **unidimensionnel** : un simple seuil sur `Pressure` seul le detecte, et la PCA n'apporte rien de plus (son AUC de 0,85 est meme *inferieure* a ce que donnerait un seuil direct sur la pression). Ou la detection d'anomalies par PCA **brille-t-elle vraiment** ?\n",
+    "Le cas ci-dessus (pic de pression a **8 ecarts-types**) est **unidimensionnel** : un simple seuil sur `Pressure` seul le detecte, et la PCA n'apporte rien de plus (son AUC de 0,85 est même *inferieure* a ce que donnerait un seuil direct sur la pression). Ou la detection d'anomalies par PCA **brille-t-elle vraiment** ?\n",
     "\n",
-    "Sur des anomalies **multivariees subtiles** : des points ou **chaque capteur pris isolement est dans la norme**, mais dont la **combinaison** est anormale. Aucun seuil par capteur isole ne les voit ; seul le residu hors-sous-espace de la PCA les isole. C'est precisement la capacite distinctive que la demo principale (et l'[Exercice 3](#Exercice-3-:-Anomalies-subtiles-(limite-de-l'approche-PCA))) ne montrait pas — l'Exercice 3 explorait seulement des **decalages moyens reduits**, qui restent unidimensionnels.\n",
+    "Sur des anomalies **multivariees subtiles** : des points ou **chaque capteur pris isolement est dans la norme**, mais dont la **combinaison** est anormale. Aucun seuil par capteur isole ne les voit ; seul le residu hors-sous-espace de la PCA les isole. C'est précisément la capacite distinctive que la demo principale (et l'[Exercice 3](#Exercice-3-:-Anomalies-subtiles-(limite-de-l'approche-PCA))) ne montrait pas — l'Exercice 3 explorait seulement des **decalages moyens reduits**, qui restent unidimensionnels.\n",
     "\n",
     "On reconstruit un jeu ou les trois capteurs sont **physiquement couples** en regime sain : la vibration du palier reflete a la fois la temperature et la pression, `Vibration = 0,4 * Temperature + 0,5 * Pressure`. Les points sains vivent donc sur un **plan 2D** dans l'espace 3D des capteurs ; la troisieme direction (orthogonale au plan) a une **variance quasi nulle** — c'est elle que la PCA de rang 2 laisse de cote. Les **anomalies violent ce couplage** : `Temperature` et `Pressure` restent dans leurs gammes normales, mais la `Vibration` s'ecarte de la relation predite. Ces points sortent du plan sain -> residu eleve."
    ]
@@ -711,16 +711,16 @@
    "source": [
     "### Interpretation : PCA bat tous les seuils univaries\n",
     "\n",
-    "| Methode | AUC | Lecture |\n",
+    "| Méthode | AUC | Lecture |\n",
     "|---------|-----|---------|\n",
-    "| Seuil `Temperature` seul | ~0,5 | aucun signal (meme marginale que le normal) |\n",
+    "| Seuil `Temperature` seul | ~0,5 | aucun signal (même marginale que le normal) |\n",
     "| Seuil `Vibration` seul | ~0,5-0,6 | la rupture est a moyenne nulle : la Vibration drift des deux cotes |\n",
     "| Seuil `Pressure` seul | ~0,5 | aucun signal |\n",
     "| **PCA rank=2 (residu hors-plan)** | **~0,95** | **detecte la violation du couplage** |\n",
     "\n",
-    "**Chaque capteur isole est a peu pres au hasard** (~0,5-0,6), parce que les anomalies ont ete construites avec les *memes distributions marginales* que le regime sain. Pourtant la PCA atteint ~0,95 : elle a appris le **plan de couplage** sain, et les points qui le violent sortent du plan (residu eleve le long de la 3e composante). C'est la capacite que **aucune methode univariee ne peut reproduire** : la detection d'anomalies par PCA est un detecteur de **structure multivariee**, pas de seuils par capteur.\n",
+    "**Chaque capteur isole est a peu pres au hasard** (~0,5-0,6), parce que les anomalies ont ete construites avec les *mêmes distributions marginales* que le regime sain. Pourtant la PCA atteint ~0,95 : elle a appris le **plan de couplage** sain, et les points qui le violent sortent du plan (residu eleve le long de la 3e composante). C'est la capacite que **aucune méthode univariee ne peut reproduire** : la detection d'anomalies par PCA est un detecteur de **structure multivariee**, pas de seuils par capteur.\n",
     "\n",
-    "**Contraste avec la demo principale** : sur le pic de pression a 8 sigma, la PCA etait superflue (un seuil sur `Pressure` suffisait, et battait meme la PCA). Ici, la PCA est le **seul** outil qui marche. Les deux cas ensemble montrent *quand* la PCA est justifiee : non pas sur des pics unidimensionnels qu'un seuil capte, mais sur des anomalies relationnelles que seule la geometrie du sous-espace revelle. C'est le cœur de la [Lakhina et al. (2004)](#References) — detecter les anomalies qui resident dans le sous-espace residual, invisibles feature par feature."
+    "**Contraste avec la demo principale** : sur le pic de pression a 8 sigma, la PCA etait superflue (un seuil sur `Pressure` suffisait, et battait même la PCA). Ici, la PCA est le **seul** outil qui marche. Les deux cas ensemble montrent *quand* la PCA est justifiee : non pas sur des pics unidimensionnels qu'un seuil capte, mais sur des anomalies relationnelles que seule la geometrie du sous-espace revelle. C'est le cœur de la [Lakhina et al. (2004)](#References) — detecter les anomalies qui resident dans le sous-espace residual, invisibles feature par feature."
    ]
   },
   {
@@ -732,8 +732,8 @@
     "\n",
     "Les scores sont proches (0,06 a 0,14) et les trois points sont flagges **normaux** — le seuil par defaut (calibre pour ~10 % de contamination) est trop conservateur quand on s'entraine sur un jeu integralement normal. Deux points pedagogiques :\n",
     "\n",
-    "- Le profil **defaillant** a bien le score le plus eleve (0,143) : le modele le classe comme le plus anomalous, ce qui est correct.\n",
-    "- Le score **n'est pas monotone en \"distance a l'origine\"** : le point legerement off (0,064) score plus bas que le point sain (0,127). C'est attendu : le score mesure le **residu de reconstruction PCA** (l'ecart au sous-espace normal), pas la norme du vecteur. Un point peut etre eloigne de l'origine mais bien explique par le plan PCA (faible residu), ou proche de l'origine mais legerement hors-plan (residu non negligeable). La signature qui compte ici est le **pic de pression** (orthogonal au plan) — d'ou l'interet de tuner le seuil plutot que de se fier au `PredictedLabel` par defaut."
+    "- Le profil **defaillant** a bien le score le plus eleve (0,143) : le modèle le classe comme le plus anomalous, ce qui est correct.\n",
+    "- Le score **n'est pas monotone en \"distance a l'origine\"** : le point legerement off (0,064) score plus bas que le point sain (0,127). C'est attendu : le score mesure le **residu de reconstruction PCA** (l'ecart au sous-espace normal), pas la norme du vecteur. Un point peut etre eloigne de l'origine mais bien explique par le plan PCA (faible residu), ou proche de l'origine mais legerement hors-plan (residu non negligeable). La signature qui compte ici est le **pic de pression** (orthogonal au plan) — d'ou l'intérêt de tuner le seuil plutot que de se fier au `PredictedLabel` par defaut."
    ]
   },
   {
@@ -750,7 +750,7 @@
     "\n",
     "Abaisser le seuil augmente le TPR (on rate moins d'anomalies) **mais** augmente aussi le FPR (plus de fausses alarmes). Le bon seuil depend du **cout relatif** d'une casse ratee vs d'une intervention inutile.\n",
     "\n",
-    "Plutot que de tester des seuils absolus (dont l'echelle depend des donnees), on balaie des seuils **relatifs** repartis entre le min et le max des scores observes. Pour chacun, on calcule TPR, FPR et precision."
+    "Plutot que de tester des seuils absolus (dont l'echelle depend des données), on balaie des seuils **relatifs** repartis entre le min et le max des scores observes. Pour chacun, on calcule TPR, FPR et precision."
    ]
   },
   {
@@ -902,7 +902,7 @@
     "| 0,05 | 1,00 | 0,41 | 0,45 | on rattrape tout, mais 41 % de fausses alarmes |\n",
     "| **0,10** | **0,93** | **0,23** | **0,58** | **bon compromis operationnel** |\n",
     "| 0,21 | 0,12 | 0,05 | 0,45 | FPR < 5 %, mais on rate 88 % des anomalies |\n",
-    "| 0,46 | 0,03 | 0,00 | 1,00 | precis mais quasi inutile (3 % de detection) |\n",
+    "| 0,46 | 0,03 | 0,00 | 1,00 | précis mais quasi inutile (3 % de detection) |\n",
     "\n",
     "Le seuil **0,10** est un point de fonctionnement raisonnable : on detecte 93 % des anomalies pour 23 % de fausses alarmes. Si le metier exige `FPR <= 5 %`, il faut monter a ~0,21 — mais on accepte alors de rater la plupart des anomalies. Ce compromis n'a pas de reponse universelle : il depend du **cout relatif** d'une casse ratee (très eleve en maintenance predictive) face au cout d'une intervention inutile. L'[Exercice 2](#Exercice-2-:-Accorder-le-seuil-a-un-cout-operationnel) formalise cette accord sur une contrainte `TPR >= 0,95`."
    ]
@@ -914,9 +914,9 @@
    "source": [
     "## Exercice 1 : Effet du rang PCA sur l'AUC\n",
     "\n",
-    "Le rang de la PCA controle la **sensibilite** du detecteur. Avec 3 features :\n",
+    "Le rang de la PCA contrôle la **sensibilite** du detecteur. Avec 3 features :\n",
     "\n",
-    "- `rank: 1` -> sous-espace 1D, residu sur 2 dimensions (detecteur **tres sensible** : beaucoup de normaux flagges),\n",
+    "- `rank: 1` -> sous-espace 1D, residu sur 2 dimensions (detecteur **très sensible** : beaucoup de normaux flagges),\n",
     "- `rank: 2` -> sous-espace plan, residu sur 1 dimension (compromis utilise dans le notebook),\n",
     "- `rank: 3` -> tout est explique, residu nul (**aucune detection possible**).\n",
     "\n",
@@ -975,7 +975,7 @@
     "2. Identifier le seuil qui realise **TPR >= 0.95 avec FPR minimal**\n",
     "3. Reporter ce seuil operationnel et sa precision\n",
     "\n",
-    "**Indice** : meme boucle que le sweep, mais avec 50 seuils ; parcourir les couples (TPR, FPR) et garder le premier seuil (du plus eleve au plus bas) qui atteint TPR >= 0.95."
+    "**Indice** : même boucle que le sweep, mais avec 50 seuils ; parcourir les couples (TPR, FPR) et garder le premier seuil (du plus eleve au plus bas) qui atteint TPR >= 0.95."
    ]
   },
   {
@@ -1021,7 +1021,7 @@
     "\n",
     "**Objectifs** :\n",
     "1. Regenerer `testAnomalies` avec un decalage reduit (ex. Temperature ~ N(2, 2), Pressure ~ N(0.25, 0.1), Vibration ~ N(1.0, 0.8))\n",
-    "2. Reconstituer `testData`, re-evaluer l'AUC du modele (sans re-entrainer)\n",
+    "2. Reconstituer `testData`, re-evaluer l'AUC du modèle (sans re-entrainer)\n",
     "3. Constater la chute de l'AUC et conclure sur la **limite** de la detection PCA\n",
     "\n",
     "**Indice** : plus les anomalies se rapprochent du regime normal, plus elles entrent dans le nuage appris et plus leur residu ressemble a celui d'un point normal. L'AUC chute vers 0.5. La PCA ne detecte bien que les anomalies **orthogonales** au sous-espace normal ; les anomalies « inline » (le long d'une direction normale) lui echappent."
@@ -1073,14 +1073,14 @@
     "| Detection d'anomalies | Apprentissage **non-supervise** : on apprend le regime normal, on teste si un point s'en ecarte |\n",
     "| `AnomalyDetectionCatalog` | Catalogue ML.NET pour Randomized PCA (`mlContext.AnomalyDetection.Trainers.RandomizedPca`) |\n",
     "| Score d'anomalie | **Residu de reconstruction** dans le sous-espace PCA (plus eleve = plus anomalous) |\n",
-    "| `rank` | Dimension du sous-espace ; controle la sensibilite (rank=n_features -> aucune detection) |\n",
+    "| `rank` | Dimension du sous-espace ; contrôle la sensibilite (rank=n_features -> aucune detection) |\n",
     "| AUC | **Separation** normaux/anormaux (1.0 = parfait, 0.5 = hasard) |\n",
     "| DetectionRate@K FP | Fraction des anomalies detectee avant *K* fausses alarmes (metrique operationnelle) |\n",
     "| Seuil de decision | Arbitre **TPR vs FPR** ; s'accorde au cout operationnel, pas au seuil par defaut |\n",
     "\n",
     "**Points cles** :\n",
     "\n",
-    "- Comme en [ML-8](ML-8-Clustering.ipynb), le Fit est **non-supervise** : on s'entraine sur des donnees **normales** uniquement. Mais contrairement au clustering, l'Evaluate exploite des **etiquettes** (Label 0/1) pour calculer l'AUC.\n",
+    "- Comme en [ML-8](ML-8-Clustering.ipynb), le Fit est **non-supervise** : on s'entraine sur des données **normales** uniquement. Mais contrairement au clustering, l'Evaluate exploite des **etiquettes** (Label 0/1) pour calculer l'AUC.\n",
     "- Le **rang** est un piege : `rank` ne peut pas depasser le nombre de features, et `rank = n_features` annule toute detection (residu nul). Le defaut (20) planterait ici.\n",
     "- Le **seuil par defaut** suppose ~10 % de contamination ; sur un jeu d'entrainement integralement normal, il est trop bas et faut tuner (Exercice 2).\n",
     "- La PCA detecte les anomalies **orthogonales** au sous-espace normal ; les anomalies « inline » subtiles lui echappent (Exercice 3) — c'est sa limite structurelle.\n"
@@ -1102,7 +1102,7 @@
     "**Metriques d'evaluation (ROC et detection rate)**\n",
     "\n",
     "- Fawcett, T. (2006). *An introduction to ROC analysis*. Pattern Recognition Letters, 27(8), 861-874. --- l'AUC et la courbe ROC, lues dans le contexte de la detection.\n",
-    "- Aggarwal, C. C. (2017). *Outlier Analysis* (2nd ed.). Springer. --- cadre general de la detection d'anomalies (distance, densite, angle, reconstruction), ou la PCA est une des methodes de reconstruction.\n",
+    "- Aggarwal, C. C. (2017). *Outlier Analysis* (2nd ed.). Springer. --- cadre general de la detection d'anomalies (distance, densite, angle, reconstruction), ou la PCA est une des méthodes de reconstruction.\n",
     "\n",
     "**Cas d'usage (maintenance predictive)**\n",
     "\n",


### PR DESCRIPTION
## Summary

Markdown-only French accent restoration in `ML/ML.Net/ML-9-Anomaly-Detection.ipynb` (Randomized PCA anomaly detection). **51 cures across 20 markdown cells**, code cells **untouched**.

Scope follows **ai-01's #2876 adjudication (2026-07-17, markdown-only strict)** + the forensic insight that ~41% of accent-stripping hits in code cells are Python/dict-key identifiers (renaming to accented form breaks execution). Markdown cells contain no executable identifiers, so prose accents are safe to restore.

## Verification firsthand (read-only detector + byte-level diff)

| Check | Before | After |
|-------|--------|-------|
| `detect_accent_stripping.py` markdown hits | 51 | **0** |
| `detect_accent_stripping.py` code hits | 20 | **20** (unchanged) |
| Code cell `source` changed | — | **0** |
| Code cell `outputs` changed | — | **0** |
| Code cell `execution_count` changed | — | **0** |
| Markdown cells changed | — | 20 |
| C.1 violations introduced (diff) | — | 0 |
| Secrets-like patterns in diff | — | 0 |
| Metadata + nbformat 4.5 preserved | — | ✓ |

Diff = `37 insertions / 37 deletions` on a single file (multiple cures per line). JSON parses, 37 cells. No inline-code-span or fenced-block content was cured (verified: all inline code spans in ML-9 markdown are English/code identifiers like `Label`, `Score`, `rank: 2`, `Pressure`).

## Scope note (fleet-consistent)

Words cured are those flagged by the current detector dict (161 pairs, incl. #7064 +55). The -tion/-ence anglicisms (`detection`, `execution`, …) are deliberately left as-is — the detector excludes them as FP-risk (common EN words); curing them is out of scope of this dict-driven rollout and will be addressed by future dict extensions. Consistent with the established #2876 PR standard (#7075 IIT-2, #7073 GameTheory-2, #7069 Sudoku-1, #7062 Search-1).

## Rotation

ML family = fresh rotation (no open PR on ML, no recent accent commit on ML; recent ML commits are #6914 cell-count, #7002/#7019 ML-5 bug, #6714 ML-9 Prong-B). Base fresh `origin/main f92a53852`.

C.2: markdown-only edit (no code cell source changed) → existing outputs remain valid, no re-execution required per the markdown-only exception.

See #2876

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
