### PR TITLE
feat(notebook-tools): detect_papermill_cell_level_state (read-only CI-friendly cell-level companion)

### DIFF
--- a/scripts/notebook_tools/detect_papermill_cell_level_state.py
+++ b/scripts/notebook_tools/detect_papermill_cell_level_state.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""Detect notebooks whose papermill run failed at the cell level.
+
+Companion to ``detect_papermill_failed_state.py`` (#7079). That detector
+inspects the **top-level** ``metadata.papermill`` block and reports two
+defect classes: ``papermill_hard_failure`` (exception non-None) and
+``papermill_pending`` (status="pending"). It does **not** inspect
+**cell-level** metadata — and papermill writes per-cell status metadata
+alongside the top-level block.
+
+This detector picks up that cell-level layer. Three defect classes:
+
+  * **Cell-level hard failure**: ``cells[i].metadata.papermill.exception``
+    is truthy (typically ``True``). papermill caught an exception while
+    executing cell ``i``; the cell's own metadata records the failure
+    even when the top-level block does not (e.g. when a re-execution
+    after the failure cleaned the top-level state but left the cell
+    metadata behind).
+  * **Cell-level pending**: ``cells[i].metadata.papermill.status == "pending"``.
+    papermill started but never finished cell ``i`` — the cell looks
+    like it was executed but the metadata is stale. Re-executing the
+    notebook overwrites these fields with fresh values.
+  * **Cell-level error tag**: ``"papermill-error-cell-tag"`` is in
+    ``cells[i].metadata.tags``. papermill (or its underlying nbconvert
+    pipeline) tags the cell that raised the exception. This is a
+    complementary fingerprint to ``exception=True`` — it persists even
+    after the metadata block is rewritten — and it is the only signal
+    some notebook formats expose when the ``metadata.papermill`` block
+    was scrubbed but the tag was left behind.
+
+**Why a separate detector (vs. extending ``detect_papermill_failed_state``).**
+
+The top-level and cell-level layers are independent failure surfaces:
+
+- A notebook can have a **clean top-level** ``metadata.papermill`` (clean
+  run) but **dirty cell-level** metadata from an earlier failed run that
+  was retried successfully — papermill overwrites the top-level block on
+  every run, but cell-level fields are merged into existing metadata, so
+  stale fields can survive.
+- The inverse is also possible: the top-level block can be ``hard_failure``
+  while every cell reports ``status == "completed"`` if papermill ran
+  per-cell execution through ``--prepare-only`` / ``--execute`` flows that
+  populated cells before the failure point but recorded the global failure
+  on shutdown.
+
+A single detector would conflate these and force reviewers to read every
+flag — a top-level ``exception`` is a single critical defect, while 50
+cell-level ``status=pending`` flags might be one stale run worth one fix.
+Keeping the layers separate matches how a triage process works and how
+the dashboards (#7079 vs this detector) are routed.
+
+**Scope vs ``detect_papermill_path_leak.py`` / ``detect_papermill_failed_state.py``**.
+
+- ``detect_papermill_path_leak.py`` (#7076) inspects **paths** in
+  ``metadata.papermill.{input,output}_path`` and inside output streams.
+- ``detect_papermill_failed_state.py`` (#7079) inspects top-level
+  ``metadata.papermill.{exception,status,start_time,end_time}``.
+- **This detector** inspects the same fields on ``cells[i].metadata.papermill``
+  plus ``cells[i].metadata.tags``.
+
+All three are read-only CI-friendly companions; they can run sequentially
+in the same CI step without conflict.
+
+**Usage.**
+
+    # Single file:
+    python detect_papermill_cell_level_state.py --scan path/to/notebook.ipynb
+
+    # Whole directory tree (skips .git/_archives/__pycache__/node_modules):
+    python detect_papermill_cell_level_state.py --scan-all .
+
+    # CI gate: exit 1 if any notebook has a cell-level defect:
+    python detect_papermill_cell_level_state.py --scan-all . --check
+
+    # Human-readable summary alongside JSON:
+    python detect_papermill_cell_level_state.py --scan-all . --summary
+
+**Design choices.**
+
+- **No external deps** beyond the Python 3.10 stdlib (``json``, ``re``,
+  ``argparse``, ``pathlib``).
+- **Cell-level classification mirrors the top-level one**: ``exception``
+  is the dominant defect, ``status="pending"`` is the secondary one,
+  the ``papermill-error-cell-tag`` is its own class (medium severity —
+  it is a fingerprint, not a runtime state).
+- **Severity ladder** matches the top-level detector: ``high`` for
+  ``exception`` (the cell's own outputs may be partial / missing),
+  ``medium`` for ``status="pending"`` and ``error-tag``. A defect is
+  emitted **per cell** so a reviewer can pinpoint the failure point in
+  the notebook without re-scanning.
+- **Cell with both ``exception=True`` and ``error-tag``** produces a
+  single ``cell_papermill_hard_failure`` defect (the more severe class
+  absorbs the tag) — same single-defect-per-cell discipline as the
+  top-level detector's single-defect-per-notebook.
+- **Output files (``_output.ipynb``)** are intentionally scanned alongside
+  source notebooks: they are exactly where papermill writes its per-cell
+  metadata. A committed ``_output.ipynb`` with stale cell-level metadata
+  is the regression this detector is designed to catch.
+- **No ``--apply``**: this is a read-only detector. Fix is to re-execute
+  the notebook through papermill (which overwrites both top-level and
+  cell-level metadata). Fix-up stays in the user's hands.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+# --- Cell-level defect classification ---
+
+
+def _classify_cell_level_state(cell_meta: dict) -> list[dict]:
+    """Return a list of defects for the papermill state of ONE cell.
+
+    Empty list = clean cell. The discipline mirrors
+    ``detect_papermill_failed_state._classify_papermill_state``: hard
+    failure dominates pending, and the ``papermill-error-cell-tag`` is
+    folded into the hard-failure defect (single defect per cell).
+    """
+    defects: list[dict] = []
+
+    if not isinstance(cell_meta, dict):
+        return defects
+
+    pm = cell_meta.get("papermill")
+    exception = pm.get("exception") if isinstance(pm, dict) else None
+    status = pm.get("status") if isinstance(pm, dict) else None
+    start_time = pm.get("start_time") if isinstance(pm, dict) else None
+    end_time = pm.get("end_time") if isinstance(pm, dict) else None
+
+    # Hard failure: the cell itself failed during papermill execution.
+    # ``exception`` is None for clean runs; ``False`` is the explicit
+    # success baseline (papermill stamps ``False`` on every cell that
+    # did not raise). Only truthy values (typically ``True``, sometimes a
+    # string traceback in some papermill versions) signal a failure.
+    if exception:
+        defects.append({
+            "kind": "cell_papermill_hard_failure",
+            "location": "metadata.papermill.exception",
+            "exception": exception,
+            "status": status,
+            "start_time": start_time,
+            "end_time": end_time,
+            "severity": "high",
+        })
+        return defects  # hard failure dominates pending AND error-tag
+
+    # Tag-based fingerprint: even if ``metadata.papermill`` was scrubbed,
+    # papermill (or nbconvert) leaves a tag on the cell that raised.
+    # Only emitted when the cell is NOT already flagged as a hard
+    # failure (single defect per cell, hard-failure absorbs the tag).
+    tags = cell_meta.get("tags") or []
+    if isinstance(tags, list) and "papermill-error-cell-tag" in tags:
+        defects.append({
+            "kind": "cell_papermill_error_tag",
+            "location": "metadata.tags",
+            "tag": "papermill-error-cell-tag",
+            "severity": "medium",
+        })
+
+    # Soft failure: cell started but never finished.
+    if status == "pending":
+        defects.append({
+            "kind": "cell_papermill_pending",
+            "location": "metadata.papermill.status",
+            "exception": exception,
+            "status": status,
+            "start_time": start_time,
+            "end_time": end_time,
+            "severity": "medium",
+        })
+
+    return defects
+
+
+# --- Scanner glue ---
+
+
+def _read_notebook(nb_path: Path) -> dict | None:
+    try:
+        with nb_path.open(encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+# Directories skipped during recursive scans. Mirrors the conventions in
+# ``scrub_papermill_paths.py``, ``detect_papermill_path_leak.py`` and
+# ``detect_papermill_failed_state.py``.
+_SKIP_DIR_NAMES = frozenset({
+    ".git",
+    "_archives",
+    "__pycache__",
+    "node_modules",
+    ".venv",
+    "venv",
+})
+
+
+def iter_notebooks(root: Path) -> list[Path]:
+    """Yield every ``*.ipynb`` under ``root`` recursively, skipping noise dirs."""
+    if root.is_file():
+        return [root] if root.suffix == ".ipynb" else []
+    if not root.is_dir():
+        return []
+    out: list[Path] = []
+    for p in root.rglob("*.ipynb"):
+        if any(part in _SKIP_DIR_NAMES for part in p.parts):
+            continue
+        out.append(p)
+    return sorted(out)
+
+
+def scan_notebook(nb_path: Path) -> list[dict]:
+    """Return the defects list for a single notebook.
+
+    One defect per affected cell (not per cell field): a cell with both
+    ``exception=True`` and ``error-tag`` yields a single
+    ``cell_papermill_hard_failure`` defect. Defects are returned in cell
+    order so a reviewer can match them to the notebook structure.
+    """
+    nb = _read_notebook(nb_path)
+    if nb is None:
+        return [{
+            "kind": "unreadable_notebook",
+            "location": str(nb_path),
+            "severity": "high",
+            "reason": "JSON decode error or unreadable file",
+        }]
+
+    cells = nb.get("cells") or []
+    if not isinstance(cells, list):
+        return []
+
+    defects: list[dict] = []
+    for idx, cell in enumerate(cells):
+        if not isinstance(cell, dict):
+            continue
+        cell_meta = cell.get("metadata") or {}
+        for d in _classify_cell_level_state(cell_meta):
+            defects.append({
+                "cell_index": idx,
+                "file": str(nb_path),
+                **d,
+            })
+    return defects
+
+
+def scan_tree(root: Path) -> list[dict]:
+    """Scan every notebook under ``root``; return a flat defects report.
+
+    Each defect is augmented with ``file`` (relative to ``root`` when
+    possible) and ``cell_index`` so a CI gate can pinpoint the offender
+    cell. Defects from different notebooks are not merged — order is
+    preserved (notebook order, then cell order within a notebook).
+    """
+    report: list[dict] = []
+    for nb_path in iter_notebooks(root):
+        try:
+            rel = str(nb_path.relative_to(root))
+        except ValueError:
+            rel = str(nb_path)
+        for d in scan_notebook(nb_path):
+            # Spread ``d`` first, then override ``file`` with the
+            # relative path. (In a dict literal the last key wins, so
+            # ``{"file": rel, **d}`` would keep the absolute path
+            # stamped by ``scan_notebook``.)
+            d_with_rel = {**d, "file": rel}
+            report.append(d_with_rel)
+    return report
+
+
+# --- CLI ---
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="detect_papermill_cell_level_state.py",
+        description=(
+            "Detect notebooks whose papermill run failed at the cell "
+            "level (read-only, CI-friendly)."
+        ),
+    )
+    mode = p.add_mutually_exclusive_group(required=True)
+    mode.add_argument(
+        "--scan", metavar="PATH",
+        help="Scan a single notebook file (.ipynb).",
+    )
+    mode.add_argument(
+        "--scan-all", metavar="DIR", nargs="?", const=".",
+        help="Scan every notebook under DIR (default: current directory).",
+    )
+    p.add_argument(
+        "--check", action="store_true",
+        help="CI gate: exit 1 if any defect is found, suppress JSON.",
+    )
+    p.add_argument(
+        "--summary", action="store_true",
+        help="Print a human-readable summary alongside the JSON report.",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_arg_parser().parse_args(argv)
+    target = Path(args.scan if args.scan is not None else args.scan_all)
+    if not target.exists():
+        print(f"error: path does not exist: {target}", file=sys.stderr)
+        return 2
+
+    if args.scan is not None:
+        report = scan_notebook(target)
+    else:
+        report = scan_tree(target)
+
+    if args.summary and not args.check:
+        _print_summary(report)
+    elif not args.check:
+        print(json.dumps(report, indent=2, ensure_ascii=False))
+
+    if args.check and report:
+        if args.summary:
+            _print_summary(report)
+        return 1
+    return 0
+
+
+def _print_summary(report: list[dict]) -> None:
+    n = len(report)
+    by_kind: dict[str, int] = {}
+    files_with_defects: set[str] = set()
+    for d in report:
+        by_kind[d.get("kind", "?")] = by_kind.get(d.get("kind", "?"), 0) + 1
+        if "file" in d:
+            files_with_defects.add(d["file"])
+    print(
+        f"[detect_papermill_cell_level_state] {n} defect(s) in "
+        f"{len(files_with_defects)} file(s).",
+        file=sys.stderr,
+    )
+    for kind, count in sorted(by_kind.items()):
+        print(f"  - {kind}: {count}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/notebook_tools/tests/test_detect_papermill_cell_level_state.py
+++ b/scripts/notebook_tools/tests/test_detect_papermill_cell_level_state.py
@@ -1,0 +1,442 @@
+#!/usr/bin/env python3
+"""Tests for ``detect_papermill_cell_level_state.py``.
+
+Coverage:
+
+- ``_classify_cell_level_state`` — clean cell / cell with exception truthy
+  / cell with status pending / cell with error-tag / cell with both
+  exception and error-tag (single defect) / cell with missing metadata
+  / cell with malformed types / non-dict metadata / ``exception=False``
+  baseline.
+- ``scan_notebook`` — unreadable notebook returns a structured defect,
+  no papermill cell-level metadata returns no defect, cell-level defect
+  is reported with cell_index / file / kind / severity fields.
+- ``scan_tree`` — recursive scan skips noise dirs, returns defects in
+  notebook-then-cell order.
+- ``main`` — CLI exit codes 0 (clean), 1 (defect found, ``--check``),
+  2 (path does not exist), ``--summary`` rendering.
+
+Run::
+
+    python scripts/notebook_tools/tests/test_detect_papermill_cell_level_state.py
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# Make the parent ``scripts/notebook_tools/`` importable so we can load
+# the detector module directly.
+_HERE = Path(__file__).resolve()
+_SCRIPTS_DIR = _HERE.parent.parent
+sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import detect_papermill_cell_level_state as detector  # noqa: E402
+
+
+# --- Test fixtures ---
+
+
+def _nb(cells_meta: list[dict]) -> dict:
+    """Build a minimal notebook with the given per-cell metadata blocks.
+
+    Each entry in ``cells_meta`` becomes one cell; the cell_type defaults
+    to ``"code"`` (the detector does not branch on type — papermill
+    metadata is written on every executed cell, code or markdown).
+    """
+    cells: list[dict] = []
+    for cm in cells_meta:
+        cell: dict = {
+            "cell_type": "code",
+            "metadata": cm,
+            "source": [],
+            "outputs": [],
+            "execution_count": None,
+        }
+        cells.append(cell)
+    return {
+        "cells": cells,
+        "metadata": {},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+
+
+def _clean_meta() -> dict:
+    """A cell-level metadata block representing a clean papermill run."""
+    return {
+        "papermill": {
+            "duration": 0.123,
+            "end_time": "2026-06-03T01:51:47.762780+00:00",
+            "exception": False,
+            "start_time": "2026-06-03T01:51:45.447442+00:00",
+            "status": "completed",
+        }
+    }
+
+
+def _failed_meta() -> dict:
+    """A cell-level metadata block where the cell itself raised."""
+    return {
+        "papermill": {
+            "duration": 4.466384,
+            "end_time": "2026-06-03T01:51:52.343377+00:00",
+            "exception": True,
+            "start_time": "2026-06-03T01:51:47.876993+00:00",
+            "status": "failed",
+        }
+    }
+
+
+def _pending_meta() -> dict:
+    """A cell-level metadata block where the run never finished."""
+    return {
+        "papermill": {
+            "duration": None,
+            "end_time": None,
+            "exception": None,
+            "start_time": None,
+            "status": "pending",
+        }
+    }
+
+
+def _tag_only_meta() -> dict:
+    """Cell-level metadata with the error-tag but no papermill block.
+
+    This is the canonical fingerprint left when ``metadata.papermill``
+    was scrubbed but the tag was not. Same defect class as the version
+    where both are present.
+    """
+    return {"tags": ["papermill-error-cell-tag"]}
+
+
+def _empty_meta() -> dict:
+    """Cell-level metadata with no papermill fingerprint at all."""
+    return {}
+
+
+# --- Classification tests ---
+
+
+class TestClassifyCellLevelState(unittest.TestCase):
+    """``_classify_cell_level_state`` returns the right defects per cell."""
+
+    def test_clean_cell_returns_no_defect(self):
+        self.assertEqual(detector._classify_cell_level_state(_clean_meta()), [])
+
+    def test_empty_metadata_returns_no_defect(self):
+        self.assertEqual(detector._classify_cell_level_state(_empty_meta()), [])
+
+    def test_cell_with_exception_truthy_returns_hard_failure(self):
+        defects = detector._classify_cell_level_state(_failed_meta())
+        self.assertEqual(len(defects), 1)
+        d = defects[0]
+        self.assertEqual(d["kind"], "cell_papermill_hard_failure")
+        self.assertEqual(d["location"], "metadata.papermill.exception")
+        self.assertEqual(d["severity"], "high")
+        self.assertIs(d["exception"], True)
+        self.assertEqual(d["status"], "failed")
+
+    def test_cell_with_pending_status_returns_pending_defect(self):
+        defects = detector._classify_cell_level_state(_pending_meta())
+        self.assertEqual(len(defects), 1)
+        d = defects[0]
+        self.assertEqual(d["kind"], "cell_papermill_pending")
+        self.assertEqual(d["location"], "metadata.papermill.status")
+        self.assertEqual(d["severity"], "medium")
+        self.assertEqual(d["status"], "pending")
+
+    def test_cell_with_error_tag_only_returns_tag_defect(self):
+        defects = detector._classify_cell_level_state(_tag_only_meta())
+        self.assertEqual(len(defects), 1)
+        d = defects[0]
+        self.assertEqual(d["kind"], "cell_papermill_error_tag")
+        self.assertEqual(d["location"], "metadata.tags")
+        self.assertEqual(d["severity"], "medium")
+        self.assertEqual(d["tag"], "papermill-error-cell-tag")
+
+    def test_exception_truthy_dominates_error_tag(self):
+        """A cell with both exception=True and the error tag yields one defect.
+
+        The hard failure absorbs the tag (single defect per cell — the
+        more severe class wins). Same discipline as the top-level
+        detector's single-defect-per-notebook.
+        """
+        meta = {**_failed_meta(), "tags": ["papermill-error-cell-tag"]}
+        defects = detector._classify_cell_level_state(meta)
+        self.assertEqual(len(defects), 1)
+        self.assertEqual(defects[0]["kind"], "cell_papermill_hard_failure")
+
+    def test_exception_falsy_does_not_trigger_hard_failure(self):
+        """``exception: False`` is a clean baseline."""
+        meta = {"papermill": {"exception": False, "status": "completed"}}
+        self.assertEqual(detector._classify_cell_level_state(meta), [])
+
+    def test_non_dict_metadata_returns_no_defect(self):
+        self.assertEqual(detector._classify_cell_level_state("not a dict"), [])  # type: ignore[arg-type]
+
+    def test_malformed_papermill_block_returns_no_defect(self):
+        """A papermill block that is not a dict is silently skipped.
+
+        Mirrors ``detect_papermill_failed_state``: the classifier only
+        inspects well-typed fields. Garbage in, no false defect out.
+        """
+        meta = {"papermill": "not a dict"}
+        self.assertEqual(detector._classify_cell_level_state(meta), [])
+
+    def test_papermill_block_missing_returns_no_defect(self):
+        meta = {"tags": ["unrelated"]}
+        self.assertEqual(detector._classify_cell_level_state(meta), [])
+
+
+# --- scan_notebook tests ---
+
+
+class TestScanNotebook(unittest.TestCase):
+    """``scan_notebook`` walks every cell and emits defects in cell order."""
+
+    def _write_nb(self, nb: dict, tmpdir: Path) -> Path:
+        path = tmpdir / "fixture.ipynb"
+        path.write_text(json.dumps(nb), encoding="utf-8")
+        return path
+
+    def test_no_papermill_metadata_returns_no_defect(self):
+        nb = _nb([_empty_meta(), _empty_meta()])
+        with tempfile.TemporaryDirectory() as td:
+            path = self._write_nb(nb, Path(td))
+            self.assertEqual(detector.scan_notebook(path), [])
+
+    def test_clean_cell_returns_no_defect(self):
+        nb = _nb([_clean_meta(), _clean_meta()])
+        with tempfile.TemporaryDirectory() as td:
+            path = self._write_nb(nb, Path(td))
+            self.assertEqual(detector.scan_notebook(path), [])
+
+    def test_single_failed_cell_returns_single_defect(self):
+        nb = _nb([_clean_meta(), _failed_meta(), _clean_meta()])
+        with tempfile.TemporaryDirectory() as td:
+            path = self._write_nb(nb, Path(td))
+            defects = detector.scan_notebook(path)
+            self.assertEqual(len(defects), 1)
+            self.assertEqual(defects[0]["cell_index"], 1)
+            self.assertEqual(defects[0]["kind"], "cell_papermill_hard_failure")
+            self.assertTrue(defects[0]["file"].endswith("fixture.ipynb"))
+
+    def test_multiple_defects_preserve_cell_order(self):
+        nb = _nb([
+            _clean_meta(),
+            _pending_meta(),
+            _failed_meta(),
+            _tag_only_meta(),
+            _clean_meta(),
+        ])
+        with tempfile.TemporaryDirectory() as td:
+            path = self._write_nb(nb, Path(td))
+            defects = detector.scan_notebook(path)
+            self.assertEqual(len(defects), 3)
+            self.assertEqual([d["cell_index"] for d in defects], [1, 2, 3])
+            self.assertEqual(defects[0]["kind"], "cell_papermill_pending")
+            self.assertEqual(defects[1]["kind"], "cell_papermill_hard_failure")
+            self.assertEqual(defects[2]["kind"], "cell_papermill_error_tag")
+
+    def test_exception_and_tag_in_same_cell_yields_single_defect(self):
+        nb = _nb([
+            {**_failed_meta(), "tags": ["papermill-error-cell-tag"]},
+        ])
+        with tempfile.TemporaryDirectory() as td:
+            path = self._write_nb(nb, Path(td))
+            defects = detector.scan_notebook(path)
+            self.assertEqual(len(defects), 1)
+            self.assertEqual(defects[0]["kind"], "cell_papermill_hard_failure")
+
+    def test_unreadable_notebook_returns_structured_defect(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "broken.ipynb"
+            path.write_text("not valid json {", encoding="utf-8")
+            defects = detector.scan_notebook(path)
+            self.assertEqual(len(defects), 1)
+            self.assertEqual(defects[0]["kind"], "unreadable_notebook")
+            self.assertEqual(defects[0]["severity"], "high")
+
+    def test_malformed_cells_field_returns_no_defect(self):
+        """A notebook whose ``cells`` field is not a list yields no defect.
+
+        Defensive: corrupted notebooks should not crash the scan.
+        """
+        nb = {"cells": "not a list", "metadata": {}, "nbformat": 4, "nbformat_minor": 5}
+        with tempfile.TemporaryDirectory() as td:
+            path = self._write_nb(nb, Path(td))
+            self.assertEqual(detector.scan_notebook(path), [])
+
+    def test_non_dict_cell_is_skipped(self):
+        """A cell that is not a dict is silently skipped.
+
+        Defensive: corrupt cells should not yield phantom defects.
+        """
+        # Build cells list with one valid cell, one malformed entry, one
+        # failed cell. The malformed entry must be skipped, leaving the
+        # failed cell at its original cell index.
+        cells = [
+            {"cell_type": "code", "metadata": _clean_meta(), "source": [], "outputs": [], "execution_count": None},
+            "not a dict",
+            {"cell_type": "code", "metadata": _failed_meta(), "source": [], "outputs": [], "execution_count": None},
+        ]
+        nb = {"cells": cells, "metadata": {}, "nbformat": 4, "nbformat_minor": 5}
+        with tempfile.TemporaryDirectory() as td:
+            path = self._write_nb(nb, Path(td))
+            defects = detector.scan_notebook(path)
+            self.assertEqual(len(defects), 1)
+            self.assertEqual(defects[0]["cell_index"], 2)
+
+
+# --- scan_tree tests ---
+
+
+class TestScanTree(unittest.TestCase):
+    """``scan_tree`` walks a directory tree, skipping noise dirs."""
+
+    def test_clean_tree_returns_no_defects(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "a.ipynb").write_text(
+                json.dumps(_nb([_clean_meta()])), encoding="utf-8"
+            )
+            sub = root / "sub"
+            sub.mkdir()
+            (sub / "b.ipynb").write_text(
+                json.dumps(_nb([_empty_meta()])), encoding="utf-8"
+            )
+            self.assertEqual(detector.scan_tree(root), [])
+
+    def test_finds_defects_recursively(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "top.ipynb").write_text(
+                json.dumps(_nb([_clean_meta(), _pending_meta()])), encoding="utf-8"
+            )
+            sub = root / "sub"
+            sub.mkdir()
+            (sub / "deep.ipynb").write_text(
+                json.dumps(_nb([_failed_meta()])), encoding="utf-8"
+            )
+            defects = detector.scan_tree(root)
+            self.assertEqual(len(defects), 2)
+            # Paths are relative to root (forward- or back-slashes depending
+            # on platform) and file order follows ``rglob`` lexicographic
+            # order on the full absolute paths — assert by content, not
+            # by position.
+            file_to_cell = {d["file"]: d["cell_index"] for d in defects}
+            self.assertEqual(
+                {k.replace(chr(92), "/"): v for k, v in file_to_cell.items()},
+                {"sub/deep.ipynb": 0, "top.ipynb": 1},
+            )
+
+    def test_skips_noise_directories(self):
+        """``.git``, ``_archives``, ``__pycache__``, ``node_modules`` are skipped."""
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            for noise in [".git", "_archives", "__pycache__", "node_modules"]:
+                d = root / noise
+                d.mkdir()
+                (d / "hidden.ipynb").write_text(
+                    json.dumps(_nb([_failed_meta()])), encoding="utf-8"
+                )
+            # One clean notebook to anchor the scan.
+            (root / "anchor.ipynb").write_text(
+                json.dumps(_nb([_clean_meta()])), encoding="utf-8"
+            )
+            self.assertEqual(detector.scan_tree(root), [])
+
+
+# --- CLI tests ---
+
+
+class TestMainCLI(unittest.TestCase):
+    """``main`` returns the right exit codes and JSON shape."""
+
+    def test_exit_0_when_clean(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "clean.ipynb").write_text(
+                json.dumps(_nb([_clean_meta()])), encoding="utf-8"
+            )
+            rc = detector.main(["--scan-all", str(root)])
+            self.assertEqual(rc, 0)
+
+    def test_exit_1_when_defect_with_check(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "broken.ipynb").write_text(
+                json.dumps(_nb([_pending_meta()])), encoding="utf-8"
+            )
+            rc = detector.main(["--scan-all", str(root), "--check"])
+            self.assertEqual(rc, 1)
+
+    def test_exit_2_when_path_missing(self):
+        rc = detector.main(["--scan", "/does/not/exist.ipynb"])
+        self.assertEqual(rc, 2)
+
+    def test_summary_renders_kind_breakdown(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            nb = _nb([_pending_meta(), _failed_meta(), _tag_only_meta()])
+            (root / "mix.ipynb").write_text(json.dumps(nb), encoding="utf-8")
+            rc = detector.main(["--scan-all", str(root), "--summary"])
+            self.assertEqual(rc, 0)
+
+    def test_json_output_is_valid(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "x.ipynb").write_text(
+                json.dumps(_nb([_failed_meta()])), encoding="utf-8"
+            )
+            rc = detector.main(["--scan-all", str(root)])
+            self.assertEqual(rc, 0)
+            # If --summary not passed, JSON is printed to stdout.
+            # Re-run capturing stdout to validate shape.
+            import io
+            from contextlib import redirect_stdout
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                detector.main(["--scan-all", str(root)])
+            data = json.loads(buf.getvalue())
+            self.assertEqual(len(data), 1)
+            self.assertEqual(data[0]["kind"], "cell_papermill_hard_failure")
+            self.assertEqual(data[0]["cell_index"], 0)
+            # ``file`` is the absolute path the detector stamps; the
+            # ``iter_notebooks`` rglob order on Windows puts absolute
+            # paths on stdout. Check suffix, not exact string.
+            self.assertTrue(data[0]["file"].endswith("x.ipynb"))
+
+    def test_single_file_scan(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            path = root / "single.ipynb"
+            path.write_text(json.dumps(_nb([_pending_meta()])), encoding="utf-8")
+            rc = detector.main(["--scan", str(path), "--check"])
+            self.assertEqual(rc, 1)
+
+    def test_subprocess_invocation(self):
+        """End-to-end: invoke the script as a subprocess, like CI would."""
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "z.ipynb").write_text(
+                json.dumps(_nb([_failed_meta()])), encoding="utf-8"
+            )
+            script = Path(detector.__file__).resolve()
+            proc = subprocess.run(
+                [sys.executable, str(script), "--scan-all", str(root), "--check", "--summary"],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(proc.returncode, 1)
+            self.assertIn("cell_papermill_hard_failure", proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Contexte

`detect_papermill_failed_state.py` (#7079) inspecte le bloc top-level `metadata.papermill` et signale 2 classes de défauts (`papermill_hard_failure`, `papermill_pending`). Mais papermill écrit AUSSI des métadonnées **par cellule** dans `cells[i].metadata.papermill` + `cells[i].metadata.tags` — une couche que #7079 ne couvre pas.

**Ce PR ajoute un détecteur cell-level companion**, `detect_papermill_cell_level_state.py`, qui inspecte les fingerprints cellule-par-cellule.

## Défauts détectables (3 classes)

| Classe | Severity | Location | Trigger |
|--------|----------|----------|---------|
| `cell_papermill_hard_failure` | high | `cells[i].metadata.papermill.exception` | `exception` truthy (papermill a catch une exception pendant l'exécution de cell i) |
| `cell_papermill_pending` | medium | `cells[i].metadata.papermill.status` | `status == "pending"` (cell i a démarré mais n'a jamais fini) |
| `cell_papermill_error_tag` | medium | `cells[i].metadata.tags` | `"papermill-error-cell-tag"` dans la liste tags (fingerprint persisté même après scrub de metadata.papermill) |

**Hard failure absorbe pending AND error-tag** (single defect per cell — discipline miroir du détecteur top-level).

## Pourquoi un détecteur séparé (vs étendre #7079)

Les couches top-level et cell-level sont des surfaces de failure **indépendantes** :

- Une **re-execution réussie** overwrite le bloc top-level, mais **merge** cell-level metadata → des fields stale peuvent survivre dans `cells[i].metadata.papermill` après que le top-level soit redevenu clean.
- L'inverse est aussi possible : top-level `hard_failure` + cells `status=completed` si papermill a fait per-cell execution via `--prepare-only` / `--execute` qui a peuplé les cells avant que le shutdown global enregistre l'échec.

Conflater les deux couches forcerait un reviewer à lire CHAQUE flag. Les garder séparées matche le triage : 1 top-level `exception` = 1 critical defect, 50 cell-level `status=pending` = 1 stale run worth 1 fix.

## Survey origin/main (936 notebooks scanned, _output.ipynb filtered)

```
92 cell-level defects across 3 files:
- MyIA.AI.Notebooks/ML/ML.Net/ML-5-TimeSeries.ipynb: 38 (pending)
- MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-4-Multi-Attribute.ipynb: 44 (43 pending + 1 exc)
- MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Agentic-3-orchestration_agent.ipynb: 10 (7 pending + 1 exc + 2 err_tag)
```

Complète le scan top-level #7079 (4 défauts). Le fingerprint `papermill-error-cell-tag` survit même quand `metadata.papermill` est scrubbé → le détecteur signale ce qui échappe à #7079.

## Design

- **No external deps** : stdlib Python 3.10 (`json`, `argparse`, `pathlib`).
- **1 defect par cell** (pas par cell field) : `exception=True` + `error-tag` yield single `cell_papermill_hard_failure`.
- **`exception=True/False` strict** : `if exception:` (truthy check), `False` est le baseline clean. Le test confirme cette discipline via `test_exception_falsy_does_not_trigger_hard_failure`.
- **`_output.ipynb` scannés** aux côtés des sources : c'est exactement où papermill écrit son per-cell metadata. Un `_output.ipynb` commit avec cell-level metadata stale = la régression que ce détecteur attrape.
- **Pas de `--apply`** : read-only. Fix = re-execution via papermill (qui overwrite les 2 couches). Fix-up reste aux mains de l'utilisateur.
- **CLI mirror du top-level** : `--scan`, `--scan-all`, `--check`, `--summary`. Exit codes 0 (clean) / 1 (défaut, `--check`) / 2 (path missing).

## Tests : 28/28 PASS

Coverage :
- `_classify_cell_level_state` : clean / exception truthy / pending / error-tag only / both exception+tag (single defect) / `exception=False` baseline / non-dict metadata / malformed papermill block / missing papermill.
- `scan_notebook` : no papermill → no defect / clean cells → no defect / single failed cell → single defect / multiple defects preserve cell order / unreadable notebook → structured defect / non-dict cell skipped.
- `scan_tree` : clean tree → no defects / finds defects recursively / skips `.git`, `_archives`, `__pycache__`, `node_modules`.
- `main` : exit 0 clean / exit 1 with `--check` / exit 2 missing path / `--summary` rendering / JSON output valid / single-file scan / end-to-end subprocess invocation.

## Compliance

- **L143 SAFE** : po-2024 own-partition outillage, 0 touch cross-owner (po/Lean).
- **L671-L3★ gate honored** : `git merge-base --is-ancestor HEAD origin/main` = TRUE (= HEAD == origin/main = base fraîche, nouveau substance = pas re-attach orphelin).
- **L671-L4★ preserved** : le `_classify_cell_level_state` suit la même discipline exception/status que #7079 ; pas de regex POSIX cross-OS ici (le detector ne touche pas aux paths).
- **Stop & Repair règle 6** : détecteur read-only, **0 modification** de notebook. Fix = re-execution papermill (qui overwrite les 2 couches).
- **Code style** : pas d'emoji, type hints, PEP 8, docstrings complètes (Usage + Scope vs autres détecteurs + Design choices).

## Scope

2 files, 1 sujet (détecteur cell-level + tests). R3 disjoint :
- #7079 (po-2024, top-level detector) — companion, pas collision
- #7080 (po-2025, DecInfer-4 fix top-level) — couvre top-level, ce détecteur ajoute la vue cell-level
- #7083 (po-2024, Z3-Python-08/09 fix top-level) — couvre top-level, complémentaire

See #7079 (companion détecteur top-level, source de cette extension).
