### PR TITLE
i18n(lean,#4980): francize grothendieck MayerVietoris canonical + add EN sibling

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafCohomology/MayerVietoris.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafCohomology/MayerVietoris.lean
@@ -1,72 +1,38 @@
 /-
-Grothendieck Part 22 -- Mayer-Vietoris long exact sequence in sheaf cohomology
+Grothendieck Partie 22 — Suite exacte longue de Mayer-Vietoris en cohomologie des faisceaux
 
-Part 21 (MayerVietorisSquare.lean) introduced Mayer-Vietoris squares: the
-geometric input (a pushout square in sheaves) and the associated short
-exact complex of free abelian sheaves.
+La Partie 21 (MayerVietorisSquare.lean) a introduit les carrés de
+Mayer-Vietoris : l'entrée géométrique (un carré pushout de faisceaux) et
+le complexe court exact de faisceaux abéliens libres associé.
 
-This module bridges the **Mayer-Vietoris long exact sequence** in sheaf
-cohomology from Mathlib (`CategoryTheory.Sites.SheafCohomology.MayerVietoris`).
+Ce module fait le pont avec la **suite exacte longue de Mayer-Vietoris**
+en cohomologie des faisceaux depuis Mathlib
+(`CategoryTheory.Sites.SheafCohomology.MayerVietoris`).
 
-Given a Mayer-Vietoris square S for a site (C, J) and an abelian sheaf F,
-there is a long exact sequence:
+Étant donné un carré de Mayer-Vietoris S pour un site (C, J) et un
+faisceau abélien F, il existe une suite exacte longue :
 
   ... ⟶ H^n(X₄, F) ⟶ H^n(X₂, F) ⊞ H^n(X₃, F) ⟶ H^n(X₁, F) ⟶ H^{n+1}(X₄, F) ⟶ ...
 
-where X₁ = intersection, X₂/X₃ = covering opens, X₄ = covered space.
+où X₁ = intersection, X₂/X₃ = ouverts du recouvrement, X₄ = espace
+recouvert.
 
-Key constructions bridged from Mathlib:
+Constructions clés récupérées de Mathlib :
 
-  - `toBiprod` : sum of restrictions H^n(X₄) → H^n(X₂) ⊞ H^n(X₃)
-  - `fromBiprod` : difference of restrictions H^n(X₂) ⊞ H^n(X₃) → H^n(X₁)
-  - `toBiprod_fromBiprod` : composition is zero
-  - `δ` : connecting homomorphism H^{n₀}(X₁) → H^{n₁}(X₄) (n₁ = n₀ + 1)
-  - `sequence` : the full long exact sequence (ComposableArrows AddCommGrp 5)
-  - `sequence_exact` : the sequence is exact
+  - `toBiprod` : somme des restrictions H^n(X₄) → H^n(X₂) ⊞ H^n(X₃)
+  - `fromBiprod` : différence des restrictions H^n(X₂) ⊞ H^n(X₃) → H^n(X₁)
+  - `toBiprod_fromBiprod` : la composition est nulle
+  - `δ` : homomorphisme de connexion H^{n₀}(X₁) → H^{n₁}(X₄) (n₁ = n₀ + 1)
+  - `sequence` : la suite exacte longue complète (ComposableArrows AddCommGrp 5)
+  - `sequence_exact` : la suite est exacte
   - `δ_toBiprod` : δ >> toBiprod = 0
   - `fromBiprod_δ` : fromBiprod >> δ = 0
 
-This completes the Mayer-Vietoris machinery: from a geometric covering
-condition (Part 21) to the cohomological consequence (this part).
+Ceci complète la machinerie de Mayer-Vietoris : de la condition
+géométrique de recouvrement (Partie 21) à la conséquence cohomologique
+(cette partie).
 
-Epic #1646, See #2159. All `sorry`s eliminated at creation.
--/
-
-/-
-  Bloc miroir FR (convention i18n EPIC #4980, Option A inline)
-  =============================================================
-
-  Hommage a Grothendieck -- Partie 22 : suite exacte longue de Mayer-Vietoris
-  en cohomologie des faisceaux.
-
-  La Partie 21 (MayerVietorisSquare.lean) a introduit les carres de
-  Mayer-Vietoris : l'entree geometrique (un carre pushout de faisceaux) et
-  le complexe court exact de faisceaux abeliens libres associe.
-
-  Ce module fait le pont avec la **suite exacte longue de Mayer-Vietoris**
-  en cohomologie des faisceaux depuis Mathlib
-  (CategoryTheory.Sites.SheafCohomology.MayerVietoris).
-
-  Etant donne un carre de Mayer-Vietoris S pour un site (C, J) et un
-  faisceau abelien F, il existe une suite exacte longue :
-
-    ... -> H^n(X_4, F) -> H^n(X_2, F) (+) H^n(X_3, F) -> H^n(X_1, F) -> H^(n+1)(X_4, F) -> ...
-
-  ou X_1 = intersection, X_2/X_3 = ouverts du recouvrement, X_4 = espace
-  recouvert.
-
-  Constructions cles recuperees de Mathlib :
-
-    - toBiprod : somme des restrictions H^n(X_4) -> H^n(X_2) (+) H^n(X_3)
-    - fromBiprod : difference des restrictions H^n(X_2) (+) H^n(X_3) -> H^n(X_1)
-    - toBiprod_fromBiprod : la composition est nulle
-    - delta : homomorphisme de connexion H^{n_0}(X_1) -> H^{n_1}(X_4) (n_1 = n_0 + 1)
-    - sequence : la suite exacte longue complete (ComposableArrows AddCommGrp 5)
-    - sequence_exact : la suite est exacte
-    - delta_toBiprod : delta >> toBiprod = 0
-    - fromBiprod_delta : fromBiprod >> delta = 0
-
-  EPIC #1646. Tous les sorry elimines a la creation.
+EPIC #1646, See #2159. Tous les `sorry` éliminés à la création.
 -/
 
 import Mathlib.CategoryTheory.Sites.SheafCohomology.MayerVietoris
@@ -81,84 +47,84 @@ variable {C : Type u} [Category.{v} C] {J : GrothendieckTopology C}
   [HasWeakSheafify J (Type v)] [HasSheafify J AddCommGrpCat.{v}]
   [HasExt.{w} (Sheaf J AddCommGrpCat.{v})]
 
-/-! ## 1. Restriction maps in cohomology
+/-! ## 1. Applications de restriction en cohomologie
 
-Given a Mayer-Vietoris square S and an abelian sheaf F, the maps
-between cohomology groups are induced by the restriction maps
-in the square.
+Étant donné un carré de Mayer-Vietoris S et un faisceau abélien F, les
+applications entre groupes de cohomologie sont induites par les
+applications de restriction dans le carré.
 
-`toBiprod` is the sum of restrictions:
+`toBiprod` est la somme des restrictions :
   H^n(X₄, F) ⟶ H^n(X₂, F) ⊞ H^n(X₃, F)
-sending y to (f₂₄* y, f₃₄* y).
+envoyant y sur (f₂₄* y, f₃₄* y).
 
-`fromBiprod` is the difference of restrictions:
+`fromBiprod` est la différence des restrictions :
   H^n(X₂, F) ⊞ H^n(X₃, F) ⟶ H^n(X₁, F)
-sending (y₁, y₃) to f₁₂* y₁ - f₁₃* y₃.
+envoyant (y₁, y₃) sur f₁₂* y₁ - f₁₃* y₃.
 -/
 
--- Sum of restrictions: H^n(X₄, F) ⟶ H^n(X₂, F) ⊞ H^n(X₃, F).
+-- Somme des restrictions : H^n(X₄, F) ⟶ H^n(X₂, F) ⊞ H^n(X₃, F).
 #check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.toBiprod
 
--- Explicit formula for toBiprod.
+-- Formule explicite pour toBiprod.
 #check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.toBiprod_apply
 
--- Difference of restrictions: H^n(X₂, F) ⊞ H^n(X₃, F) ⟶ H^n(X₁, F).
+-- Différence des restrictions : H^n(X₂, F) ⊞ H^n(X₃, F) ⟶ H^n(X₁, F).
 #check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.fromBiprod
 
-/-! ## 2. Composition and the zero condition
+/-! ## 2. Composition et la condition de nullité
 
-The composition toBiprod >> fromBiprod is zero:
+La composition toBiprod >> fromBiprod est nulle :
   H^n(X₄) ⟶ H^n(X₂) ⊞ H^n(X₃) ⟶ H^n(X₁)
-This is the cohomological shadow of the commutativity of the square.
+C'est l'ombre cohomologique de la commutativité du carré.
 -/
 
 -- toBiprod >> fromBiprod = 0.
 #check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.toBiprod_fromBiprod
 
--- Explicit formula for fromBiprod applied to a pair.
+-- Formule explicite pour fromBiprod appliqué à un couple.
 #check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.fromBiprod_biprodIsoProd_inv_apply
 
-/-! ## 3. The connecting homomorphism
+/-! ## 3. L'homomorphisme de connexion
 
-The connecting homomorphism δ : H^{n₀}(X₁, F) ⟶ H^{n₁}(X₄, F) (where
-n₁ = n₀ + 1) is the key map in the long exact sequence. It measures
-the obstruction to lifting a cohomology class from the intersection
-to the covered space.
+L'homomorphisme de connexion δ : H^{n₀}(X₁, F) ⟶ H^{n₁}(X₄, F) (où
+n₁ = n₀ + 1) est l'application clé de la suite exacte longue. Elle mesure
+l'obstruction à relever une classe de cohomologie de l'intersection
+vers l'espace recouvert.
 
-This is defined as `shortComplex_shortExact.extClass.precomp`.
+Ceci est défini comme `shortComplex_shortExact.extClass.precomp`.
 -/
 
--- The connecting homomorphism δ : H^{n₀}(X₁) ⟶ H^{n₁}(X₄).
+-- L'homomorphisme de connexion δ : H^{n₀}(X₁) ⟶ H^{n₁}(X₄).
 #check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.δ
 
-/-! ## 4. The long exact sequence
+/-! ## 4. La suite exacte longue
 
-The Mayer-Vietoris long exact sequence is packaged as a
-`ComposableArrows AddCommGrp 5`:
+La suite exacte longue de Mayer-Vietoris est encapsulée comme un
+`ComposableArrows AddCommGrp 5` :
 
   H^n(X₄) ⟶ H^n(X₂) ⊞ H^n(X₃) ⟶ H^n(X₁) ⟶ H^{n+1}(X₄) ⟶ H^{n+1}(X₂) ⊞ H^{n+1}(X₃) ⟶ H^{n+1}(X₁)
 
-This is `sequence S F n₀ n₁ h` where `h : n₀ + 1 = n₁`.
+Ceci est `sequence S F n₀ n₁ h` où `h : n₀ + 1 = n₁`.
 -/
 
--- The Mayer-Vietoris long exact sequence (6 terms, ComposableArrows 5).
+-- La suite exacte longue de Mayer-Vietoris (6 termes, ComposableArrows 5).
 #check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.sequence
 
-/-! ## 5. Exactness
+/-! ## 5. Exactitude
 
-The long exact sequence is exact at every position. This is the main
-theorem of the module, proven by comparison with the contravariant
-sequence of Ext-groups.
+La suite exacte longue est exacte en toute position. Ceci est le théorème
+principal du module, prouvé par comparaison avec la suite contravariante
+des groupes Ext.
 -/
 
--- The Mayer-Vietoris sequence is exact.
+-- La suite de Mayer-Vietoris est exacte.
 #check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.sequence_exact
 
-/-! ## 6. Boundary conditions
+/-! ## 6. Conditions de bord
 
-The connecting homomorphism satisfies two boundary conditions:
-  - δ >> toBiprod = 0  (δ lands in the kernel of toBiprod)
-  - fromBiprod >> δ = 0  (δ factors through the cokernel of fromBiprod)
+L'homomorphisme de connexion satisfait deux conditions de bord :
+  - δ >> toBiprod = 0  (δ atterrit dans le noyau de toBiprod)
+  - fromBiprod >> δ = 0  (δ factorise par le conoyau de fromBiprod)
 -/
 
 -- δ >> toBiprod = 0.
@@ -167,31 +133,31 @@ The connecting homomorphism satisfies two boundary conditions:
 -- fromBiprod >> δ = 0.
 #check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.fromBiprod_δ
 
-/-! ## 7. Bridge theorems
+/-! ## 7. Théorèmes ponts
 
-Bridge theorems connecting the Mayer-Vietoris long exact sequence
-to concrete verification.
+Théorèmes ponts reliant la suite exacte longue de Mayer-Vietoris
+à une vérification concrète.
 -/
 
-/-- Bridge theorem: the Mayer-Vietoris sequence is exact. For a
-    Mayer-Vietoris square S and abelian sheaf F, the sequence of
-    cohomology groups is exact at every position. -/
+/-- Théorème pont : la suite de Mayer-Vietoris est exacte. Pour un
+    carré de Mayer-Vietoris S et un faisceau abélien F, la suite de
+    groupes de cohomologie est exacte en toute position. -/
 theorem mv_sequence_exact
     (S : J.MayerVietorisSquare) (F : Sheaf J AddCommGrpCat.{v})
     (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :
     (S.sequence F n₀ n₁ h).Exact :=
   S.sequence_exact F n₀ n₁ h
 
-/-- Bridge theorem: the connecting homomorphism composed with the
-    sum of restrictions is zero: δ >> toBiprod = 0. -/
+/-- Théorème pont : l'homomorphisme de connexion composé avec la
+    somme des restrictions est nul : δ >> toBiprod = 0. -/
 theorem mv_delta_toBiprod_eq_zero
     (S : J.MayerVietorisSquare) (F : Sheaf J AddCommGrpCat.{v})
     (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :
     S.δ F n₀ n₁ h ≫ S.toBiprod F n₁ = 0 :=
   S.δ_toBiprod F n₀ n₁ h
 
-/-- Bridge theorem: the difference of restrictions composed with the
-    connecting homomorphism is zero: fromBiprod >> δ = 0. -/
+/-- Théorème pont : la différence des restrictions composée avec
+    l'homomorphisme de connexion est nulle : fromBiprod >> δ = 0. -/
 theorem mv_fromBiprod_delta_eq_zero
     (S : J.MayerVietorisSquare) (F : Sheaf J AddCommGrpCat.{v})
     (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafCohomology/MayerVietoris_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafCohomology/MayerVietoris_en.lean
@@ -1,0 +1,164 @@
+/-
+Grothendieck Part 22 -- Mayer-Vietoris long exact sequence in sheaf cohomology
+
+Part 21 (MayerVietorisSquare.lean) introduced Mayer-Vietoris squares: the
+geometric input (a pushout square in sheaves) and the associated short
+exact complex of free abelian sheaves.
+
+This module bridges the **Mayer-Vietoris long exact sequence** in sheaf
+cohomology from Mathlib (`CategoryTheory.Sites.SheafCohomology.MayerVietoris`).
+
+Given a Mayer-Vietoris square S for a site (C, J) and an abelian sheaf F,
+there is a long exact sequence:
+
+  ... ⟶ H^n(X₄, F) ⟶ H^n(X₂, F) ⊞ H^n(X₃, F) ⟶ H^n(X₁, F) ⟶ H^{n+1}(X₄, F) ⟶ ...
+
+where X₁ = intersection, X₂/X₃ = covering opens, X₄ = covered space.
+
+Key constructions bridged from Mathlib:
+
+  - `toBiprod` : sum of restrictions H^n(X₄) → H^n(X₂) ⊞ H^n(X₃)
+  - `fromBiprod` : difference of restrictions H^n(X₂) ⊞ H^n(X₃) → H^n(X₁)
+  - `toBiprod_fromBiprod` : composition is zero
+  - `δ` : connecting homomorphism H^{n₀}(X₁) → H^{n₁}(X₄) (n₁ = n₀ + 1)
+  - `sequence` : the full long exact sequence (ComposableArrows AddCommGrp 5)
+  - `sequence_exact` : the sequence is exact
+  - `δ_toBiprod` : δ >> toBiprod = 0
+  - `fromBiprod_δ` : fromBiprod >> δ = 0
+
+This completes the Mayer-Vietoris machinery: from a geometric covering
+condition (Part 21) to the cohomological consequence (this part).
+
+Epic #1646, See #2159. All `sorry`s eliminated at creation.
+-/
+
+import Mathlib.CategoryTheory.Sites.SheafCohomology.MayerVietoris
+
+universe w v u
+
+namespace Grothendieck.SheafCohomology.MayerVietoris_en
+
+open CategoryTheory Category Opposite Limits
+
+variable {C : Type u} [Category.{v} C] {J : GrothendieckTopology C}
+  [HasWeakSheafify J (Type v)] [HasSheafify J AddCommGrpCat.{v}]
+  [HasExt.{w} (Sheaf J AddCommGrpCat.{v})]
+
+/-! ## 1. Restriction maps in cohomology
+
+Given a Mayer-Vietoris square S and an abelian sheaf F, the maps
+between cohomology groups are induced by the restriction maps
+in the square.
+
+`toBiprod` is the sum of restrictions:
+  H^n(X₄, F) ⟶ H^n(X₂, F) ⊞ H^n(X₃, F)
+sending y to (f₂₄* y, f₃₄* y).
+
+`fromBiprod` is the difference of restrictions:
+  H^n(X₂, F) ⊞ H^n(X₃, F) ⟶ H^n(X₁, F)
+sending (y₁, y₃) to f₁₂* y₁ - f₁₃* y₃.
+-/
+
+-- Sum of restrictions: H^n(X₄, F) ⟶ H^n(X₂, F) ⊞ H^n(X₃, F).
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.toBiprod
+
+-- Explicit formula for toBiprod.
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.toBiprod_apply
+
+-- Difference of restrictions: H^n(X₂, F) ⊞ H^n(X₃, F) ⟶ H^n(X₁, F).
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.fromBiprod
+
+/-! ## 2. Composition and the zero condition
+
+The composition toBiprod >> fromBiprod is zero:
+  H^n(X₄) ⟶ H^n(X₂) ⊞ H^n(X₃) ⟶ H^n(X₁)
+This is the cohomological shadow of the commutativity of the square.
+-/
+
+-- toBiprod >> fromBiprod = 0.
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.toBiprod_fromBiprod
+
+-- Explicit formula for fromBiprod applied to a pair.
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.fromBiprod_biprodIsoProd_inv_apply
+
+/-! ## 3. The connecting homomorphism
+
+The connecting homomorphism δ : H^{n₀}(X₁, F) ⟶ H^{n₁}(X₄, F) (where
+n₁ = n₀ + 1) is the key map in the long exact sequence. It measures
+the obstruction to lifting a cohomology class from the intersection
+to the covered space.
+
+This is defined as `shortComplex_shortExact.extClass.precomp`.
+-/
+
+-- The connecting homomorphism δ : H^{n₀}(X₁) ⟶ H^{n₁}(X₄).
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.δ
+
+/-! ## 4. The long exact sequence
+
+The Mayer-Vietoris long exact sequence is packaged as a
+`ComposableArrows AddCommGrp 5`:
+
+  H^n(X₄) ⟶ H^n(X₂) ⊞ H^n(X₃) ⟶ H^n(X₁) ⟶ H^{n+1}(X₄) ⟶ H^{n+1}(X₂) ⊞ H^{n+1}(X₃) ⟶ H^{n+1}(X₁)
+
+This is `sequence S F n₀ n₁ h` where `h : n₀ + 1 = n₁`.
+-/
+
+-- The Mayer-Vietoris long exact sequence (6 terms, ComposableArrows 5).
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.sequence
+
+/-! ## 5. Exactness
+
+The long exact sequence is exact at every position. This is the main
+theorem of the module, proven by comparison with the contravariant
+sequence of Ext-groups.
+-/
+
+-- The Mayer-Vietoris sequence is exact.
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.sequence_exact
+
+/-! ## 6. Boundary conditions
+
+The connecting homomorphism satisfies two boundary conditions:
+  - δ >> toBiprod = 0  (δ lands in the kernel of toBiprod)
+  - fromBiprod >> δ = 0  (δ factors through the cokernel of fromBiprod)
+-/
+
+-- δ >> toBiprod = 0.
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.δ_toBiprod
+
+-- fromBiprod >> δ = 0.
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.fromBiprod_δ
+
+/-! ## 7. Bridge theorems
+
+Bridge theorems connecting the Mayer-Vietoris long exact sequence
+to concrete verification.
+-/
+
+/-- Bridge theorem: the Mayer-Vietoris sequence is exact. For a
+    Mayer-Vietoris square S and abelian sheaf F, the sequence of
+    cohomology groups is exact at every position. -/
+theorem mv_sequence_exact
+    (S : J.MayerVietorisSquare) (F : Sheaf J AddCommGrpCat.{v})
+    (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :
+    (S.sequence F n₀ n₁ h).Exact :=
+  S.sequence_exact F n₀ n₁ h
+
+/-- Bridge theorem: the connecting homomorphism composed with the
+    sum of restrictions is zero: δ >> toBiprod = 0. -/
+theorem mv_delta_toBiprod_eq_zero
+    (S : J.MayerVietorisSquare) (F : Sheaf J AddCommGrpCat.{v})
+    (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :
+    S.δ F n₀ n₁ h ≫ S.toBiprod F n₁ = 0 :=
+  S.δ_toBiprod F n₀ n₁ h
+
+/-- Bridge theorem: the difference of restrictions composed with the
+    connecting homomorphism is zero: fromBiprod >> δ = 0. -/
+theorem mv_fromBiprod_delta_eq_zero
+    (S : J.MayerVietorisSquare) (F : Sheaf J AddCommGrpCat.{v})
+    (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :
+    S.fromBiprod F n₀ ≫ S.δ F n₀ n₁ h = 0 :=
+  S.fromBiprod_δ F n₀ n₁ h
+
+end Grothendieck.SheafCohomology.MayerVietoris_en


### PR DESCRIPTION
## Summary

Bring `grothendieck_lean/SheafCohomology/MayerVietoris.lean` in line with the ratified **Option A** i18n convention (EPIC #4980, c.398 sibling-pair migration #6154). The file was a **pre-migration remnant**: an EN top docstring + an inline FR "Bloc miroir" block (the **rejected Option B** inline-bilingual pattern, cf `code-style.md`), and **no `_en` sibling** — inconsistent with its already-migrated peers (`Cech.lean`/`Cech_en.lean` in the same subdir, `Conservative.lean`/`Conservative_en.lean`, …).

### Changes (2 files, atomic)

- **`MayerVietoris.lean` (canonical) → FR-first**: module docstring + section headers + `#check` comments + bridge-theorem docstrings translated EN→FR. The redundant inline FR "Bloc miroir" block is **removed** (Option B rejected). Namespace `Grothendieck.SheafCohomology.MayerVietoris` **unchanged** → root aggregator `Grothendieck.lean` import (L197) unaffected.
- **`MayerVietoris_en.lean` (new sibling) → EN**: clean EN content (no FR mirror), namespace `Grothendieck.SheafCohomology.MayerVietoris_en` (**leaf-suffix**, matching the `Cech_en` peer in the same subdir — namespace = module path; the alternative root-suffix `Grothendieck_en.…` is also valid but leaf-suffix is locally consistent within `SheafCohomology/`).

### Note on diff stat (deletions > insertions)

`MayerVietoris.lean` shows 68 insertions / 102 deletions. This is **docstring/comment content only** (FR translation is more compact + the inline FR mirror block removed), **NOT** code/proof deletion. All code lines are byte-identical to `origin/main` (verified by code-line diff: import/universe/namespace/open/variable/`#check`/theorem signatures/proofs/end match exactly).

## Lean proof (pr-review-discipline §B)

- `grep -c sorry` (strip docstrings): **0** in both files (no sorries introduced — `All sorry's eliminated at creation` per the module header; this PR changes only docstrings).
- **Byte-identity on code**: code-line diff vs `origin/main` = 0 real changes for canonical (namespace identical); only the `_en` namespace suffix differs for the sibling.
- **Lake build SUCCESS**: `Build completed successfully (1970 jobs)`, 0 errors. Both targets compiled:
  - `✔ [1969/1970] Built Grothendieck.SheafCohomology.MayerVietoris (19s)`
  - `✔ [1970/1970] Built Grothendieck.SheafCohomology.MayerVietoris_en (19s)`
  - (mathlib/batteries "local changes" warnings are benign — `.lake` junction used for warm cache; the build itself is clean.)

## See

See #4980 (i18n epic). See #2159 (Grothendieck epic). No `Closes` (tranche of a long-running epic).
