### PR TITLE
fix(notebook,ml,#7087): scrub cell-level metadata.papermill.status=pending from ML-5

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-5-TimeSeries.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-5-TimeSeries.ipynb
@@ -116,13 +116,6 @@
    "execution_count": 2,
    "id": "18321554",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "outputs": [
@@ -148,13 +141,6 @@
    "cell_type": "markdown",
    "id": "01794d9d",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -168,13 +154,6 @@
    "cell_type": "markdown",
    "id": "c9b3ec50",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -198,13 +177,6 @@
    "cell_type": "markdown",
    "id": "8d4bd678",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -216,13 +188,6 @@
    "execution_count": 3,
    "id": "f0fb3cd6",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "outputs": [
@@ -379,13 +344,6 @@
    "cell_type": "markdown",
    "id": "b161338a",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -404,13 +362,6 @@
    "cell_type": "markdown",
    "id": "79523a3b",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -427,13 +378,6 @@
    "execution_count": 4,
    "id": "b3de7349",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "outputs": [
@@ -468,13 +412,6 @@
    "cell_type": "markdown",
    "id": "0b87ca96",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -495,13 +432,6 @@
    "cell_type": "markdown",
    "id": "6ad7ac19",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -517,13 +447,6 @@
    "execution_count": 5,
    "id": "0ecda37a",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "outputs": [
@@ -550,13 +473,6 @@
    "cell_type": "markdown",
    "id": "e3d81b8f",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -580,13 +496,6 @@
    "execution_count": 6,
    "id": "b1acdeb0",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "outputs": [
@@ -648,13 +557,6 @@
    "cell_type": "markdown",
    "id": "e4581767",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -674,13 +576,6 @@
    "cell_type": "markdown",
    "id": "ea01317c",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -694,13 +589,6 @@
    "execution_count": 7,
    "id": "00d642ff",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "outputs": [
@@ -765,13 +653,6 @@
    "cell_type": "markdown",
    "id": "61277029",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -789,13 +670,6 @@
    "cell_type": "markdown",
    "id": "ac77d757",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -811,13 +685,6 @@
    "execution_count": 8,
    "id": "2a979292",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "outputs": [
@@ -844,13 +711,6 @@
    "cell_type": "markdown",
    "id": "f5ebbf28",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -864,13 +724,6 @@
    "execution_count": 9,
    "id": "c5fd5311",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "outputs": [
@@ -890,13 +743,6 @@
    "cell_type": "markdown",
    "id": "3838c507",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -917,13 +763,6 @@
    "cell_type": "markdown",
    "id": "1a8fba07",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -937,13 +776,6 @@
    "execution_count": 10,
    "id": "e36ae8bf",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "outputs": [
@@ -1030,13 +862,6 @@
    "cell_type": "markdown",
    "id": "0ae03b59",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -1056,13 +881,6 @@
    "cell_type": "markdown",
    "id": "4b0e0340",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -1078,13 +896,6 @@
    "execution_count": 11,
    "id": "41ec1cc7",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "outputs": [
@@ -1111,13 +922,6 @@
    "cell_type": "markdown",
    "id": "7da6261d",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -1131,13 +935,6 @@
    "execution_count": 12,
    "id": "f8bc4c43",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "outputs": [
@@ -1218,13 +1015,6 @@
    "cell_type": "markdown",
    "id": "0db5b025",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -1244,13 +1034,6 @@
    "cell_type": "markdown",
    "id": "ba1f530d",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -1277,13 +1060,6 @@
    "cell_type": "markdown",
    "id": "7c055168",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -1301,13 +1077,6 @@
    "execution_count": 13,
    "id": "fca59f8a",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "outputs": [
@@ -1334,13 +1103,6 @@
    "cell_type": "markdown",
    "id": "0d476059",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -1356,13 +1118,6 @@
    "execution_count": 14,
    "id": "637aa0e9",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "outputs": [
@@ -1389,13 +1144,6 @@
    "cell_type": "markdown",
    "id": "87c9e0f1",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [
@@ -1421,13 +1169,6 @@
    "execution_count": 15,
    "id": "f24c4443",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "outputs": [
@@ -1512,13 +1253,6 @@
    "cell_type": "markdown",
    "id": "refs-bibliography-ml5",
    "metadata": {
-    "papermill": {
-     "duration": null,
-     "end_time": null,
-     "exception": null,
-     "start_time": null,
-     "status": "pending"
-    },
     "tags": []
    },
    "source": [


### PR DESCRIPTION
## Summary

Sister fix-up PR to **#7087** (po-2024 `detect_papermill_cell_level_state` companion
detector — currently OPEN MERGEABLE). Closes the **38 cell-level papermill
defects** detected on `MyIA.AI.Notebooks/ML/ML.Net/ML-5-TimeSeries.ipynb`.

The detector (#7087) found **92 total cell-level defects across 3 notebooks**:
- **ML-5-TimeSeries**: 38 (this PR)
- DecInfer-4: 44 (out of scope here)
- Argument-Analysis-3: 10 (out of scope here)

This PR targets ML-5 only — R3 atomique (1 file, 1 notebook, 1 defect class).

## Root cause

The ML-5 notebook was previously re-executed via Papermill (interrupted run:
top-level `metadata.papermill.end_time=None`, `exception=None`). Papermill
writes **per-cell** `metadata.papermill` blocks during execution; on the
interrupted run, **38 cells** ended up stamped with `status="pending"`
because Papermill never got to update them to `completed`.

Per **L675-L1 ★** (po-2025 shared lesson, 2026-07-17): `notebook_tools`
re-execution via MCP Jupyter **PRESERVES** cell-level `metadata.papermill`
(because MCP Jupyter only touches `outputs`/`execution_count`, not the
`metadata` block). So a successful re-exec leaves the stale `status=pending`
stamps intact — the defect persists even though the run itself succeeded.

The **surgical fix** is the two-step procedure codified by po-2025:
1. **Re-execute** to prove the notebook actually works (proof of success).
2. **Retrait chirurgical** of the stale `metadata.papermill` field from
   cells with `status=pending` (artifact of the failed run).

This is the **Stop & Repair règle 6** frontier: hand-editing **OUTPUTS** is
interdit (false pretense of execution), but **normalising `metadata.papermill`**
is authorized (it's metadata, not output, not source code).

## G.1 firsthand verification

| Metric | Pre-fix | Post-fix |
|--------|---------|----------|
| Cells total | 40 | 40 |
| Cells with `execution_count` | 15 | 15 (unchanged) |
| Cells with `outputs` | 15 | 15 (unchanged) |
| Cells with `metadata.papermill.status="pending"` | **38** | **0** |
| Cells with `metadata.papermill.status="completed"` | 1 | 1 (preserved — legit) |
| Cells with `metadata.papermill.status="running"` | 1 | 1 (preserved — `exception=False` clean baseline per L676-L1 ★) |
| Top-level `metadata.papermill.exception` | `None` | `None` (unchanged — HONEST interrupted run, KEEP per c.675-L1) |
| Top-level `metadata.papermill.end_time` | `None` | `None` (unchanged — HONEST) |
| Detector `detect_papermill_cell_level_state.py` | 38 defects | **0 defects** |
| `git diff --stat` | n/a | **1 file changed, 266 deletions(-)** (chirurgical metadata-only) |
| Source regressions | n/a | **0** (verified per-cell: source/outputs/exec_count/cell_type byte-identical) |

## Procedure (reproducible)

1. `notebook_tools.py execute --notebook ML-5-TimeSeries.ipynb --cell-by-cell --dotnet-only`
   → **15/15 cells OK, 52.2s**, file byte-identical to baseline
   (confirms `notebook_tools` re-exec preserves `metadata.papermill`,
   consistent with L675-L1 ★).
2. Detector run: `python scripts/notebook_tools/detect_papermill_cell_level_state.py MyIA.AI.Notebooks/ML/ML.Net/ML-5-TimeSeries.ipynb`
   → **38 defects** (cell-level `status=pending`).
3. Scrub script (mirror of detector logic: only targets `status="pending"`):
   - Iterates cells, removes `metadata.papermill` field ONLY when
     `pm.get("status") == "pending"`.
   - Preserves everything else: source, outputs, execution_count, cell_type,
     top-level metadata.papermill.
4. Re-run detector → **0 defects**.
5. Anti-regression §D check: per-cell diff on source/outputs/exec_count/cell_type
   → **0 regressions**.

## Why I didn't auto-fix the 2 cells with non-`pending` status

| Cell | Status | Exception | End time | Verdict |
|------|--------|-----------|----------|---------|
| 0 | `completed` | `False` | set | CLEAN — legit papermill stamp, keep |
| 1 | `running` | `False` | `None` | CLEAN — `exception=False` = clean baseline per L676-L1 ★, keep |

Per detector logic (#7087 lines 138 + 164):
- Line 138: `if exception:` (truthy) → only `True`/truthy counts; `False` = clean.
- Line 164: `if status == "pending":` → only literal `pending`; `running`/`completed` = clean.

These 2 are NOT defects. Scrubbing them would erase legitimate papermill audit
trail without cause. **The 38 pending cells** are the actual defect class
(this PR's scope).

## Diff scope

```
MyIA.AI.Notebooks/ML/ML.Net/ML-5-TimeSeries.ipynb | 266 ----------------------
1 file changed, 266 deletions(-)
```

R3 atomique respectée: <3000L/<15f/<4 feat/<1 domaine.

## Self-pick rationale (po-2023, R6 anti-monotonie)

This is a **direct follow-through** on the cross-pool pickup after the c.575
closure (yfinance quantbooks REJETÉS) + c.576/c.577 (Lean docs territory).
PR #7087 (po-2024, OPEN MERGEABLE) created a cell-level papermill detector
that found 92 defects; **38 of them are on ML-5 in my native (.NET) track**,
R6 anti-monotonie honored (Lean docs c.576-c.577 → .NET cell-level scrub c.578).

The other 54 defects (DecInfer-4: 44, Argument-Analysis-3: 10) are out of
scope here — they're Infer.NET (Probas) territory, not ML.Net, and would
need separate sibling PRs by an Infer.NET specialist worker. The detector
itself (#7087) doesn't fix; it only reports. This PR fixes the .NET slice.

## Caveats / post-merge follow-up

- **PR #7087 is still OPEN** (po-2024). After both this PR and #7087 merge,
  the cluster will have: (a) the detector added to `scripts/notebook_tools/`,
  (b) ML-5 scrubbed of its 38 cell-level pending defects. Remaining 54
  defects (DecInfer-4 + Argument-Analysis-3) are untouched.
- **Recommended next PRs** (out of scope here, R3 atomique):
  - Sister PR to scrub DecInfer-4 (44 defects) — Infer.NET territory.
  - Sister PR to scrub Argument-Analysis-3 (10 defects) — also Infer.NET.
- **Recommended CI integration** (out of scope here): once #7087 merges,
  add `detect_papermill_cell_level_state` to the CI notebook-quality gate
  so future regressions are caught at PR time rather than discovered in
  audits.

## References

- #7087 (sister PR, OPEN MERGEABLE) — added the `detect_papermill_cell_level_state.py` detector
- #7079 (po-2024) — original top-level papermill detector (companion to #7087)
- [L675-L1 ★](~/.claude/projects/d--Dev-CoursIA-2/memory/MEMORY.md) — po-2025 shared lesson: notebook_tools re-exec preserves cell-level papermill
- [L676-L1 ★ NEW](~/.claude/projects/d--Dev-CoursIA-2/memory/MEMORY.md) — `exception=False` = clean baseline (truthy check, not `is not None`)
- [secrets-hygiene.md règle 6](../../.claude/rules/secrets-hygiene.md) — Stop & Repair: metadata.papermill normalization autorisée, hand-edit OUTPUT interdit
- [verify-before-claiming.md](../../.claude/rules/verify-before-claiming.md) — G.1 firsthand verification

## Verdict

Atomic, R3-compliant, anti-regression-verified metadata scrub. No source code
touched, no outputs touched, no execution_count touched, no top-level papermill
touched. Diff = 266 deletions / 0 insertions (chirurgical metadata-only).
Detector confirms 0 defects post-fix. Per L675-L1 ★, this is the exact
procedure authorized for this defect class.