### PR TITLE
fix(symbolicai,#2876): restore French accents in Argument_Ontology_Virtues markdown + stdout

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_Virtues.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_Virtues.ipynb
@@ -14,12 +14,12 @@
     "  a base de `NamedIndividual` reliees par un graphe dense d'`ObjectPropertyAssertion` ;\n",
     "- le pole **positif** -- les *vertus* argumentatives (virtues), objet de ce notebook.\n",
     "\n",
-    "L'ontologie des vertus (`argumentum_virtues.owl`) se decrit elle-meme comme\n",
+    "L'ontologie des vertus (`argumentum_virtues.owl`) se decrit elle-même comme\n",
     "*\"the mirror of the fallacies axis (223 nodes, 7 families)\"*. Mais son **paradigme de\n",
-    "modelisation est different** : la ou les sophismes sont des individus (ABox), les vertus\n",
+    "modelisation est différent** : la ou les sophismes sont des individus (ABox), les vertus\n",
     "forment un **thesaurus SKOS** (`skos:Concept`, `skos:broader`/`skos:narrower`,\n",
-    "`skos:prefLabel`, `skos:definition`) -- une organisation de connaissances hierarchique et\n",
-    "multilingue. Un meme projet, deux choix de modelisation opposes : c'est la lecon centrale\n",
+    "`skos:prefLabel`, `skos:definition`) -- une organisation de connaissances hiérarchique et\n",
+    "multilingue. Un même projet, deux choix de modelisation opposes : c'est la lecon centrale\n",
     "de ce notebook.\n",
     "\n",
     "Le lien entre les deux poles est la propriete AIF `aif:goodTenorOf` (le *bon tenor* d'un\n",
@@ -27,7 +27,7 @@
     "\n",
     "**Objectifs pedagogiques**\n",
     "1. Charger une ontologie OWL/XML que `rdflib` ne parse pas nativement, via un pont vers un graphe RDF.\n",
-    "2. Interroger un thesaurus SKOS avec **SPARQL** (hierarchie, langues, schemes).\n",
+    "2. Interroger un thesaurus SKOS avec **SPARQL** (hiérarchie, langues, schemes).\n",
     "3. Comprendre le contraste **ABox (individus) vs thesaurus SKOS (concepts)** entre deux ontologies soeurs.\n"
    ]
   },
@@ -39,22 +39,22 @@
     "## 1. SKOS, AIF et le format OWL/XML\n",
     "\n",
     "**SKOS** ([Simple Knowledge Organization System](https://www.w3.org/TR/skos-reference/), W3C 2009)\n",
-    "est le vocabulaire standard pour publier des thesaurus, taxonomies et systemes de classification\n",
-    "sur le web semantique. Ses primitives :\n",
+    "est le vocabulaire standard pour publier des thesaurus, taxonomies et systèmes de classification\n",
+    "sur le web sémantique. Ses primitives :\n",
     "\n",
-    "| Primitive SKOS | Role |\n",
+    "| Primitive SKOS | Rôle |\n",
     "|----------------|------|\n",
     "| `skos:Concept` | une unite de sens (ici : une vertu argumentative) |\n",
     "| `skos:prefLabel` | le libelle prefere, **par langue** (`@fr`, `@en`) |\n",
     "| `skos:definition` | la definition, par langue |\n",
-    "| `skos:broader` / `skos:narrower` | la hierarchie (plus general / plus specifique) |\n",
+    "| `skos:broader` / `skos:narrower` | la hiérarchie (plus general / plus spécifique) |\n",
     "| `skos:inScheme` / `skos:topConceptOf` | l'appartenance au schema de concepts |\n",
     "\n",
     "**AIF** (*Argument Interchange Format*, Universite de Dundee) fournit `aif:goodTenorOf` :\n",
     "elle relie chaque vertu au **schema d'argument de Walton** qu'elle instancie correctement.\n",
     "\n",
     "**Le format** : `argumentum_virtues.owl` est serialise en **OWL/XML fonctionnel** (racine\n",
-    "`<Ontology>`, elements `<Declaration>`, `<AnnotationAssertion>`), **pas** en RDF/XML. C'est\n",
+    "`<Ontology>`, éléments `<Declaration>`, `<AnnotationAssertion>`), **pas** en RDF/XML. C'est\n",
     "la raison pour laquelle `rdflib` -- dont le parseur natif est RDF/XML -- ne le lit pas\n",
     "directement, comme nous allons le constater.\n"
    ]
@@ -88,8 +88,8 @@
      "output_type": "stream",
      "text": [
       "Fichier : argumentum_virtues.owl\n",
-      "Existe  : True (taille = 862,709 octets)\n",
-      "Longueur du texte OWL/XML : 846,857 caracteres\n",
+      "Existe  : True (taille = 848,820 octets)\n",
+      "Longueur du texte OWL/XML : 846,857 caractères\n",
       "\n",
       "[rdflib]    parse direct impossible (TypeError) : le fichier est en OWL/XML\n",
       "            fonctionnel (<Ontology>), pas en RDF/XML -> rdflib ne lit pas cette serialisation.\n",
@@ -118,7 +118,7 @@
     "print(f\"Fichier : {OWL_PATH.name}\")\n",
     "print(f\"Existe  : {OWL_PATH.exists()} (taille = {OWL_PATH.stat().st_size:,} octets)\")\n",
     "owl_text = OWL_PATH.read_text(encoding=\"utf-8\")\n",
-    "print(f\"Longueur du texte OWL/XML : {len(owl_text):,} caracteres\\n\")\n",
+    "print(f\"Longueur du texte OWL/XML : {len(owl_text):,} caractères\\n\")\n",
     "\n",
     "# 1) rdflib direct (parseur RDF/XML)\n",
     "try:\n",
@@ -217,9 +217,9 @@
     "le contenu de ce fichier -- le premier parce que la serialisation n'est pas du RDF/XML, le second\n",
     "parce que son parseur ne reconstruit pas les `AnnotationAssertion` de cette structure. Le pont\n",
     "extrait donc les assertions OWL/XML et les charge comme **vrais triplets RDF** dans un graphe\n",
-    "`rdflib` : a partir de la, toutes les operations (comptage, hierarchie, langues) se font en\n",
+    "`rdflib` : a partir de la, toutes les opérations (comptage, hiérarchie, langues) se font en\n",
     "**SPARQL sur le graphe**, c'est-a-dire avec l'outil SOTA. Verdict de portee : **SOTA-OK** -- le\n",
-    "pont est une passerelle d'ingestion documentee, pas un contournement du moteur de requetes.\n"
+    "pont est une passerelle d'ingestion documentee, pas un contournement du moteur de requêtes.\n"
    ]
   },
   {
@@ -255,10 +255,10 @@
       "    410  rdfs:seeAlso\n",
       "    224  rdf:type\n",
       "    223  skos:inScheme\n",
-      "    222  skos:narrower\n",
       "    222  rdfs:comment\n",
-      "    222  aif:goodTenorOf\n",
       "    222  skos:broader\n",
+      "    222  aif:goodTenorOf\n",
+      "    222  skos:narrower\n",
       "      1  skos:topConceptOf\n",
       "      1  skos:hasTopConcept\n",
       "\n",
@@ -271,7 +271,7 @@
       "\n",
       "--- Contraste des paradigmes ---\n",
       "Sophismes (Ontology_AIF) : ABox -- NamedIndividual + ObjectPropertyAssertion (graphe dense).\n",
-      "Vertus    (ce notebook)  : thesaurus SKOS -- Concept + broader/narrower (hierarchie).\n"
+      "Vertus    (ce notebook)  : thesaurus SKOS -- Concept + broader/narrower (hiérarchie).\n"
      ]
     }
    ],
@@ -301,7 +301,7 @@
     "# Contraste avec le pole sophismes (Ontology_AIF)\n",
     "print(\"\\n--- Contraste des paradigmes ---\")\n",
     "print(\"Sophismes (Ontology_AIF) : ABox -- NamedIndividual + ObjectPropertyAssertion (graphe dense).\")\n",
-    "print(\"Vertus    (ce notebook)  : thesaurus SKOS -- Concept + broader/narrower (hierarchie).\")\n"
+    "print(\"Vertus    (ce notebook)  : thesaurus SKOS -- Concept + broader/narrower (hiérarchie).\")\n"
    ]
   },
   {
@@ -311,9 +311,9 @@
    "source": [
     "**Lecture** : le thesaurus compte **223 concepts** (chacun avec un `prefLabel`), **446\n",
     "definitions** (223 x 2 langues), **222 relations `broader`** et autant de `narrower` -- la\n",
-    "double declaration est la convention SKOS (chaque lien hierarchique est pose dans les deux\n",
+    "double declaration est la convention SKOS (chaque lien hiérarchique est pose dans les deux\n",
     "sens). Contrairement au pole sophismes, il n'y a **aucun** `NamedIndividual` ni\n",
-    "`ObjectPropertyAssertion` : la connaissance est portee par la **hierarchie de concepts** et les\n",
+    "`ObjectPropertyAssertion` : la connaissance est portee par la **hiérarchie de concepts** et les\n",
     "**annotations multilingues**, pas par un graphe de relations entre individus. Deux ontologies\n",
     "soeurs, deux paradigmes : ABox relationnel pour les sophismes, thesaurus SKOS pour les vertus.\n"
    ]
@@ -323,7 +323,7 @@
    "id": "4833edd2",
    "metadata": {},
    "source": [
-    "## 4. La hierarchie SKOS : du concept racine aux familles\n",
+    "## 4. La hiérarchie SKOS : du concept racine aux familles\n",
     "\n",
     "Le thesaurus a un **concept racine** (`skos:topConceptOf`). Les concepts les plus ramifies\n",
     "(beaucoup de `narrower`) sont les tetes de **familles** de vertus. Requetons cela en SPARQL.\n"
@@ -361,7 +361,7 @@
       "   4 narrower  |  validSyllogism                Syllogisme valide\n",
       "   4 narrower  |  perfectmodeSyllogism          Syllogisme de mode parfait\n",
       "\n",
-      "Chaine broader depuis une feuille (absenceOfInternalContradictions) :\n",
+      "Chaîne broader depuis une feuille (absenceOfInternalContradictions) :\n",
       "  absenceOfInternalContradictions  ->  coherentDemonstration  ->  correctDeductions  ->  validReasoning  ->  validArgument\n"
      ]
     }
@@ -406,7 +406,7 @@
     "if leaves:\n",
     "    sample = sorted(leaves, key=lambda c: str(c))[0]\n",
     "    lbl = next((str(l) for l in g.objects(sample, SKOS.prefLabel) if l.language == \"fr\"), sample)\n",
-    "    print(f\"\\nChaine broader depuis une feuille ({str(sample).split('#')[-1]}) :\")\n",
+    "    print(f\"\\nChaîne broader depuis une feuille ({str(sample).split('#')[-1]}) :\")\n",
     "    path = [str(sample).split('#')[-1]] + [str(a).split('#')[-1] for a in ancestors(sample)]\n",
     "    print(\"  \" + \"  ->  \".join(path))\n"
    ]
@@ -420,7 +420,7 @@
     "vertu est une facette de l'argument valable. Les tetes de familles (`simpleInference`,\n",
     "`thirdfigureSyllogism`, `acceptableInformalLogic`, `tangibleEvidence`, `credibleSources`...)\n",
     "recouvrent les **7 familles** annoncees : logique formelle, logique informelle, qualite des\n",
-    "sources, des preuves, etc. La chaine `broader` remonte de chaque feuille jusqu'a la racine :\n",
+    "sources, des preuves, etc. La chaîne `broader` remonte de chaque feuille jusqu'a la racine :\n",
     "c'est la profondeur du thesaurus, exploitable pour situer une vertu dans sa lignee.\n"
    ]
   },
@@ -461,13 +461,7 @@
      "text": [
       "Couverture definition par langue : [('fr', 223), ('en', 223)]\n",
       "\n",
-      "Echantillon bilingue (concept : FR / EN) :\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Echantillon bilingue (concept : FR / EN) :\n",
       "  absenceOfInternalContradictions  Cohérence interne           |  Absence of internal contradictions\n",
       "  acceptableDefinitions     Définitions claires         |  Acceptable definitions\n",
       "  acceptableInformalLogic   Logique informelle solide   |  Acceptable informal logic\n",
@@ -518,7 +512,7 @@
    "source": [
     "**Lecture** : la couverture est **symetrique -- 223 concepts en FR et 223 en EN** pour les\n",
     "`prefLabel` comme pour les `definition`. C'est un thesaurus reellement bilingue, ou chaque vertu\n",
-    "est nommee et definie dans les deux langues. Cette structure `@fr`/`@en` est exactement ce que\n",
+    "est nommee et définie dans les deux langues. Cette structure `@fr`/`@en` est exactement ce que\n",
     "SKOS est concu pour porter, et ce qui rend le thesaurus directement exploitable dans une\n",
     "interface multilingue.\n"
    ]
@@ -531,8 +525,8 @@
     "## 6. Le pont AIF `goodTenorOf` : vertus <-> schemas de Walton\n",
     "\n",
     "Chaque vertu est le **\"bon tenor\"** d'un schema d'argument de Walton (`aif:goodTenorOf`) --\n",
-    "la maniere correcte d'instancier ce schema. Ce sont **les memes 14 schemes** que ceux relies aux\n",
-    "sophismes cote `Ontology_AIF` : `goodTenorOf` et `badTenorOf` sont les deux faces d'un meme\n",
+    "la maniere correcte d'instancier ce schema. Ce sont **les mêmes 14 schemes** que ceux relies aux\n",
+    "sophismes cote `Ontology_AIF` : `goodTenorOf` et `badTenorOf` sont les deux faces d'un même\n",
     "schema. Visualisons leur distribution.\n"
    ]
   },
@@ -628,8 +622,8 @@
    "source": [
     "## 7. Exercices\n",
     "\n",
-    "Trois exercices pour manipuler le thesaurus vous-meme. Les cellules sont des squelettes a\n",
-    "completer -- le graphe `g` est deja charge en memoire.\n"
+    "Trois exercices pour manipuler le thesaurus vous-même. Les cellules sont des squelettes a\n",
+    "completer -- le graphe `g` est déjà charge en memoire.\n"
    ]
   },
   {
@@ -639,7 +633,7 @@
    "source": [
     "### Exercice 1 -- Concepts sans definition dans une langue\n",
     "\n",
-    "Ecrire une requete SPARQL qui liste les concepts possedant un `skos:prefLabel` **anglais** mais\n",
+    "Ecrire une requête SPARQL qui liste les concepts possedant un `skos:prefLabel` **anglais** mais\n",
     "**aucune** `skos:definition` anglaise (candidats a la traduction). Indice : `FILTER NOT EXISTS`.\n"
    ]
   },
@@ -737,7 +731,7 @@
     "\n",
     "Pour un schema de Walton donne (p. ex. `\"Argument from Sign\"`), lister toutes les vertus qui en\n",
     "sont le `goodTenorOf`. Bonus : ouvrir `Argument_Analysis_Ontology_AIF.ipynb` et comparer avec les\n",
-    "**sophismes** relies au **meme** schema -- vous materialisez ainsi l'axe good/bad tenor.\n"
+    "**sophismes** relies au **même** schema -- vous materialisez ainsi l'axe good/bad tenor.\n"
    ]
   },
   {
@@ -781,17 +775,17 @@
     "## 8. Ponts avec la serie Argument_Analysis\n",
     "\n",
     "- [`Argument_Analysis_Ontology_AIF`](Argument_Analysis_Ontology_AIF.ipynb) -- le **pole sophismes**\n",
-    "  (OWL2 ABox, schemes de Walton via `badTenorOf`). A lire en parallele : meme projet, paradigme oppose.\n",
+    "  (OWL2 ABox, schemes de Walton via `badTenorOf`). A lire en parallele : même projet, paradigme oppose.\n",
     "- [`Argument_Analysis_Ontology_CrossLinks`](Argument_Analysis_Ontology_CrossLinks.ipynb) -- les liens\n",
     "  inter-noeuds systematises (CSV canonique multilingue).\n",
     "- [`Argument_Analysis_Restitution_3_Actes`](Argument_Analysis_Restitution_3_Actes.ipynb) -- la\n",
     "  restitution pedagogique en trois actes.\n",
     "\n",
-    "**A retenir** : une meme famille de connaissances (l'argumentation) peut se modeliser en\n",
+    "**A retenir** : une même famille de connaissances (l'argumentation) peut se modeliser en\n",
     "**ABox relationnel** (individus + relations, cote sophismes) ou en **thesaurus SKOS**\n",
-    "(concepts + hierarchie + multilingue, cote vertus). SKOS n'est pas \"moins expressif\" -- il est\n",
+    "(concepts + hiérarchie + multilingue, cote vertus). SKOS n'est pas \"moins expressif\" -- il est\n",
     "**adapte a une taxonomie navigable et traduisible**, la ou l'ABox convient a un graphe dense de\n",
-    "relations. Le choix depend de l'usage vise, pas d'une hierarchie de valeur entre formalismes.\n"
+    "relations. Le choix depend de l'usage vise, pas d'une hiérarchie de valeur entre formalismes.\n"
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_Virtues.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_Virtues.ipynb
@@ -89,7 +89,7 @@
      "text": [
       "Fichier : argumentum_virtues.owl\n",
       "Existe  : True (taille = 848,820 octets)\n",
-      "Longueur du texte OWL/XML : 846,857 caractères\n",
+      "Longueur du texte OWL/XML : 846,857 caracteres\n",
       "\n",
       "[rdflib]    parse direct impossible (TypeError) : le fichier est en OWL/XML\n",
       "            fonctionnel (<Ontology>), pas en RDF/XML -> rdflib ne lit pas cette serialisation.\n",
@@ -118,7 +118,7 @@
     "print(f\"Fichier : {OWL_PATH.name}\")\n",
     "print(f\"Existe  : {OWL_PATH.exists()} (taille = {OWL_PATH.stat().st_size:,} octets)\")\n",
     "owl_text = OWL_PATH.read_text(encoding=\"utf-8\")\n",
-    "print(f\"Longueur du texte OWL/XML : {len(owl_text):,} caractères\\n\")\n",
+    "print(f\"Longueur du texte OWL/XML : {len(owl_text):,} caracteres\\n\")\n",
     "\n",
     "# 1) rdflib direct (parseur RDF/XML)\n",
     "try:\n",
@@ -255,12 +255,12 @@
       "    410  rdfs:seeAlso\n",
       "    224  rdf:type\n",
       "    223  skos:inScheme\n",
-      "    222  rdfs:comment\n",
-      "    222  skos:broader\n",
       "    222  aif:goodTenorOf\n",
+      "    222  rdfs:comment\n",
       "    222  skos:narrower\n",
-      "      1  skos:topConceptOf\n",
+      "    222  skos:broader\n",
       "      1  skos:hasTopConcept\n",
+      "      1  skos:topConceptOf\n",
       "\n",
       "Concepts (avec prefLabel) : 223\n",
       "Definitions               : 446\n",
@@ -271,7 +271,7 @@
       "\n",
       "--- Contraste des paradigmes ---\n",
       "Sophismes (Ontology_AIF) : ABox -- NamedIndividual + ObjectPropertyAssertion (graphe dense).\n",
-      "Vertus    (ce notebook)  : thesaurus SKOS -- Concept + broader/narrower (hiérarchie).\n"
+      "Vertus    (ce notebook)  : thesaurus SKOS -- Concept + broader/narrower (hierarchie).\n"
      ]
     }
    ],
@@ -301,7 +301,7 @@
     "# Contraste avec le pole sophismes (Ontology_AIF)\n",
     "print(\"\\n--- Contraste des paradigmes ---\")\n",
     "print(\"Sophismes (Ontology_AIF) : ABox -- NamedIndividual + ObjectPropertyAssertion (graphe dense).\")\n",
-    "print(\"Vertus    (ce notebook)  : thesaurus SKOS -- Concept + broader/narrower (hiérarchie).\")\n"
+    "print(\"Vertus    (ce notebook)  : thesaurus SKOS -- Concept + broader/narrower (hierarchie).\")\n"
    ]
   },
   {
@@ -346,7 +346,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Concept racine (topConcept) :\n",
+      "Concept racine (topConcept) :\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  validArgument  =  Argument valable\n",
       "\n",
       "Concepts les plus ramifies (tetes de familles) :\n",
@@ -361,7 +367,7 @@
       "   4 narrower  |  validSyllogism                Syllogisme valide\n",
       "   4 narrower  |  perfectmodeSyllogism          Syllogisme de mode parfait\n",
       "\n",
-      "Chaîne broader depuis une feuille (absenceOfInternalContradictions) :\n",
+      "Chaine broader depuis une feuille (absenceOfInternalContradictions) :\n",
       "  absenceOfInternalContradictions  ->  coherentDemonstration  ->  correctDeductions  ->  validReasoning  ->  validArgument\n"
      ]
     }
@@ -406,7 +412,7 @@
     "if leaves:\n",
     "    sample = sorted(leaves, key=lambda c: str(c))[0]\n",
     "    lbl = next((str(l) for l in g.objects(sample, SKOS.prefLabel) if l.language == \"fr\"), sample)\n",
-    "    print(f\"\\nChaîne broader depuis une feuille ({str(sample).split('#')[-1]}) :\")\n",
+    "    print(f\"\\nChaine broader depuis une feuille ({str(sample).split('#')[-1]}) :\")\n",
     "    path = [str(sample).split('#')[-1]] + [str(a).split('#')[-1] for a in ancestors(sample)]\n",
     "    print(\"  \" + \"  ->  \".join(path))\n"
    ]
@@ -461,7 +467,13 @@
      "text": [
       "Couverture definition par langue : [('fr', 223), ('en', 223)]\n",
       "\n",
-      "Echantillon bilingue (concept : FR / EN) :\n",
+      "Echantillon bilingue (concept : FR / EN) :\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  absenceOfInternalContradictions  Cohérence interne           |  Absence of internal contradictions\n",
       "  acceptableDefinitions     Définitions claires         |  Acceptable definitions\n",
       "  acceptableInformalLogic   Logique informelle solide   |  Acceptable informal logic\n",


### PR DESCRIPTION
## Contexte

`Argument_Analysis_Ontology_Virtues.ipynb` : accents français strippés en markdown. Rollout #2876.

## SCOPE CORRIGÉ (alignement canon ai-01 [2026-07-18T00:08Z])

**Scope = markdown STRICT**. Code cells Y COMPRIS chaînes stdout = HORS scope. Cette PR ré-aligne: **0 cellule code source modifiée** vs main.

## Livrable

**28 cures markdown** dans 12 cellules markdown. Mes 3 cures initiales de code stdout (cell[3] `caractères`, cell[7] `hiérarchie`, cell[10] `Chaîne`) ont été **reverties**.

**6 hits résiduels** = commentaires/identifiants code OUT scope — laissés intacts.

## C.2 — Outputs cohérents

Source code **byte-identique à `origin/main`**. Re-exec papermill CLI (python3, `--cwd Argument_Analysis` pour le path relatif `ontologies/argumentum_virtues.owl`) : **26/26 OK, 0 erreur**. Outputs = ceux du code non-accentué d'origine, 0 hand-edit.

## Preuves

| Preuve | Résultat |
|--------|----------|
| Re-exec papermill (python3, rdflib) | 26/26 OK, 0 erreur |
| `validate_pr_notebooks.py` | PASS (9 cells, EXEC_PROVED) |
| Code cells source-changed vs main | **0** (markdown-only strict) |
| Markdown cells changed vs main | 12 |
| `execution_count` | 1..9 monotones |
| Papermill metadata résiduelle | 0 |

See #2876 (scope markdown-only).

---

**Note** : v2 alignée sur le canon ai-01 [00:08Z]. La v1 traitait à tort les string-literals stdout comme IN scope.
