### PR TITLE
docs(grothendieck,#3973): fix i18n drift in README — 15→23 _en siblings, 8 stale table rows

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.en.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.en.md
@@ -8,7 +8,7 @@ Alexandre Grothendieck (1928-2014).
 - **Sorry**: **0 sorry, 0 axiom** — all 24 modules are complete at creation (Parts 1-24 merged)
 - **Build**: `lake build Grothendieck` — compiles the 24 modules (~3350 lines)
 - **Dependencies**: Mathlib 4 (via `lakefile.lean`)
-- **i18n coverage (EPIC #4980)**: extended coverage — **24 `.lean` modules** + **15 `_en.lean` siblings** on `main`. Per the ratified convention (Option A: `Foo.lean` FR-canonical + `Foo_en.lean` EN mirror), 12 modules are already bilingual in Pattern A: `Calibration`, `CategoryAndSites`, `CoverageGen`, `DenseTopology`, `LeftExact`, `SchemesTour`, `SheafHom`, `SitePoints`, `Subcanonical`, `ZariskiSite`, `SheafCohomology/Basic`, `SheafCohomology/Cech`. 3 additional modules have an `_en` sibling (`ConstantSheaf`, `Conservative`, `MayerVietorisSquare`) — their FR/EN direction is being harmonized with ai-01 (convention conflict flagged); `_en` namespaces anti-collision, non-docstring content byte-identical CI-detectable. The remaining 9 modules stay FR-only at this stage of the rollout. **`README.md`** present (FR-canonical sibling of this file). Out-of-scope: `.lake/packages/`, vendored libs.
+- **i18n coverage (EPIC #4980)**: near-complete coverage — **24 `.lean` modules** + **23 `_en.lean` siblings** on `main`. Per the ratified convention (Option A: `Foo.lean` FR-canonical + `Foo_en.lean` EN mirror), 23 of the 24 modules are already bilingual in Pattern A (`_en` namespaces anti-collision, non-docstring content byte-identical CI-detectable). The only remaining FR-only module is `SheafCohomology/MayerVietoris` (its `_en` sibling awaits merge via PR [#7089](https://github.com/jsboige/CoursIA/pull/7089)). **`README.md`** present (FR-canonical sibling of this file). Out-of-scope: `.lake/packages/`, vendored libs.
 
 ## Purpose
 
@@ -35,16 +35,16 @@ in order by the umbrella `Grothendieck.lean`. Each module self-numbers via its h
 | 1 | `Grothendieck/CategoryAndSites.lean` | `CategoryAndSites_en.lean` | Sieves, Grothendieck topologies (trivial/discrete/dense), three axioms | 106 |
 | 2 | `Grothendieck/SchemesTour.lean` | `SchemesTour_en.lean` | Scheme type, Spec functor, Γ, `homeoOfIso`, fully-faithful | 79 |
 | 3 | `Grothendieck/ZariskiSite.lean` | `ZariskiSite_en.lean` | Zariski pretopology, `zariskiTopology_eq` bridge theorem, subcanonical | 84 |
-| 4 | `Grothendieck/MathlibMap.lean` | — | `#check` index of Grothendieck-related Mathlib definitions | 90 |
+| 4 | `Grothendieck/MathlibMap.lean` | `MathlibMap_en.lean` | `#check` index of Grothendieck-related Mathlib definitions | 90 |
 | 5 | `Grothendieck/Calibration.lean` | `Calibration_en.lean` | 4 micro-proof targets for the prover harness (Epic #1453) | 80 |
-| 6 | `Grothendieck/SieveLattice.lean` | — | Sieve pullback identities: `pullback_id`, `pullback_pullback`, `pullback_bot`, `pullback_monotone` | 88 |
-| 7 | `Grothendieck/SheafBasics.lean` | — | Sheaf/separated presheaf basics, sheaf transfer along J₁ ≤ J₂ | 128 |
-| 8 | `Grothendieck/SieveOps.lean` | — | Topology ordering, covering closure, sieve composition | 124 |
+| 6 | `Grothendieck/SieveLattice.lean` | `SieveLattice_en.lean` | Sieve pullback identities: `pullback_id`, `pullback_pullback`, `pullback_bot`, `pullback_monotone` | 88 |
+| 7 | `Grothendieck/SheafBasics.lean` | `SheafBasics_en.lean` | Sheaf/separated presheaf basics, sheaf transfer along J₁ ≤ J₂ | 128 |
+| 8 | `Grothendieck/SieveOps.lean` | `SieveOps_en.lean` | Topology ordering, covering closure, sieve composition | 124 |
 | 9 | `Grothendieck/CoverageGen.lean` | `CoverageGen_en.lean` | Coverage-to-topology, sheaf characterization, sup of coverages | 148 |
-| 10 | `Grothendieck/CanonicalProps.lean` | — | Canonical topology, subcanonicity, representable sheaves | 133 |
-| 11 | `Grothendieck/SieveGenerate.lean` | — | Sieve generation identities | 128 |
+| 10 | `Grothendieck/CanonicalProps.lean` | `CanonicalProps_en.lean` | Canonical topology, subcanonicity, representable sheaves | 133 |
+| 11 | `Grothendieck/SieveGenerate.lean` | `SieveGenerate_en.lean` | Sieve generation identities | 128 |
 | 12 | `Grothendieck/DenseTopology.lean` | `DenseTopology_en.lean` | The dense topology | 131 |
-| 13 | `Grothendieck/Sheafification.lean` | — | Sheafification (the associated sheaf functor) | 175 |
+| 13 | `Grothendieck/Sheafification.lean` | `Sheafification_en.lean` | Sheafification (the associated sheaf functor) | 175 |
 | 14 | `Grothendieck/LeftExact.lean` | `LeftExact_en.lean` | Left exactness of sheafification | 133 |
 | 15 | `Grothendieck/SitePoints.lean` | `SitePoints_en.lean` | Points of a site (fiber functors) | 220 |
 | 16 | `Grothendieck/Subcanonical.lean` | `Subcanonical_en.lean` | Subcanonical Grothendieck topologies | 88 |
@@ -55,7 +55,7 @@ in order by the umbrella `Grothendieck.lean`. Each module self-numbers via its h
 | 21 | `Grothendieck/MayerVietorisSquare.lean` | `MayerVietorisSquare_en.lean` | Mayer-Vietoris squares | 195 |
 | 22 | `Grothendieck/SheafCohomology/MayerVietoris.lean` | — | Mayer-Vietoris long exact sequence | 164 |
 | 23 | `Grothendieck/SheafCohomology/Cech.lean` | `SheafCohomology/Cech_en.lean` | Čech cohomology | 123 |
-| 24 | `Grothendieck/YonedaLemma.lean` | — | The Yoneda lemma (embedding, equivalence, naturality, fully-faithful, coyoneda) | 168 |
+| 24 | `Grothendieck/YonedaLemma.lean` | `YonedaLemma_en.lean` | The Yoneda lemma (embedding, equivalence, naturality, fully-faithful, coyoneda) | 168 |
 
 The extension (Parts 6-24) was developed under Issue #2159 / Epic #1646 and is
 **complete**: all 24 modules merged, 0 `sorry`, 0 axiom added.
@@ -96,7 +96,7 @@ The language toured here — Grothendieck topologies, sites, sheaves, and scheme
 - Epic #1453 (prover harness calibration)
 - Conway tribute workspace (`../conway_lean/`)
 - Lean notebook series (`../README.md`)
-- **EPIC #4980** — Lean i18n convention (Option A sibling pair post-2026-07-04; 15 `_en.lean` siblings on `main` in this lake)
+- **EPIC #4980** — Lean i18n convention (Option A sibling pair post-2026-07-04; 23 `_en.lean` siblings on `main` in this lake)
 - **[`README.md`](./README.md)** — FR canonical sibling of this file
 
 ## Conclusion

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.md
@@ -8,7 +8,7 @@ Alexandre Grothendieck (1928-2014).
 - **Sorry** : **0 sorry, 0 axiome** — les 24 modules sont complets à la création (Parties 1-24 mergées)
 - **Build** : `lake build Grothendieck` — compile les 24 modules (~3350 lignes)
 - **Dépendances** : Mathlib 4 (via `lakefile.lean`)
-- **Couverture i18n (EPIC #4980)** : couverture étendue — **24 modules `.lean`** + **15 siblings `_en.lean`** sur `main`. Conformément à la convention ratifiée (Option A : `Foo.lean` FR canonique + `Foo_en.lean` miroir EN), 12 modules sont déjà bilingues au pattern A : `Calibration`, `CategoryAndSites`, `CoverageGen`, `DenseTopology`, `LeftExact`, `SchemesTour`, `SheafHom`, `SitePoints`, `Subcanonical`, `ZariskiSite`, `SheafCohomology/Basic`, `SheafCohomology/Cech`. 3 modules additionnels ont un sibling `_en` (`ConstantSheaf`, `Conservative`, `MayerVietorisSquare`) — leur direction FR/EN est en cours d'harmonisation avec ai-01 (cf conflit de convention signalé) ; namespaces `_en` anti-collision, contenu non-docstring byte-identique détectable par CI. Les 9 modules restants sont FR-only à ce stade du rollout. **`README.en.md`** présent (miroir EN du présent fichier). Hors-scope : `.lake/packages/`, libs vendored.
+- **Couverture i18n (EPIC #4980)** : couverture quasi-complète — **24 modules `.lean`** + **23 siblings `_en.lean`** sur `main`. Conformément à la convention ratifiée (Option A : `Foo.lean` FR canonique + `Foo_en.lean` miroir EN), 23 modules sur 24 sont déjà bilingues au pattern A (namespaces `_en` anti-collision, contenu non-docstring byte-identique détectable par CI). Le seul module encore FR-only est `SheafCohomology/MayerVietoris` (son sibling `_en` est en attente de merge via PR [#7089](https://github.com/jsboige/CoursIA/pull/7089)). **`README.en.md`** présent (miroir EN du présent fichier). Hors-scope : `.lake/packages/`, libs vendored.
 
 ## Objectif
 
@@ -50,16 +50,16 @@ flowchart LR
 | 1 | `Grothendieck/CategoryAndSites.lean` | `CategoryAndSites_en.lean` | Cribles, topologies de Grothendieck (triviale/discrète/dense), trois axiomes | 106 |
 | 2 | `Grothendieck/SchemesTour.lean` | `SchemesTour_en.lean` | Type des schémas, foncteur Spec, Γ, `homeoOfIso`, pleinement fidèle | 79 |
 | 3 | `Grothendieck/ZariskiSite.lean` | `ZariskiSite_en.lean` | Prétopologie de Zariski, théorème-pont `zariskiTopology_eq`, sous-canonique | 84 |
-| 4 | `Grothendieck/MathlibMap.lean` | — | Index `#check` des définitions Mathlib liées à Grothendieck | 90 |
+| 4 | `Grothendieck/MathlibMap.lean` | `MathlibMap_en.lean` | Index `#check` des définitions Mathlib liées à Grothendieck | 90 |
 | 5 | `Grothendieck/Calibration.lean` | `Calibration_en.lean` | 4 cibles de micro-preuve pour le harnais du prouveur (Epic #1453) | 80 |
-| 6 | `Grothendieck/SieveLattice.lean` | — | Identités de pullback de cribles : `pullback_id`, `pullback_pullback`, `pullback_bot`, `pullback_monotone` | 88 |
-| 7 | `Grothendieck/SheafBasics.lean` | — | Bases faisceau/préfaisceau séparé, transfert de faisceau le long de J₁ ≤ J₂ | 128 |
-| 8 | `Grothendieck/SieveOps.lean` | — | Ordre sur les topologies, clôture de recouvrement, composition de cribles | 124 |
+| 6 | `Grothendieck/SieveLattice.lean` | `SieveLattice_en.lean` | Identités de pullback de cribles : `pullback_id`, `pullback_pullback`, `pullback_bot`, `pullback_monotone` | 88 |
+| 7 | `Grothendieck/SheafBasics.lean` | `SheafBasics_en.lean` | Bases faisceau/préfaisceau séparé, transfert de faisceau le long de J₁ ≤ J₂ | 128 |
+| 8 | `Grothendieck/SieveOps.lean` | `SieveOps_en.lean` | Ordre sur les topologies, clôture de recouvrement, composition de cribles | 124 |
 | 9 | `Grothendieck/CoverageGen.lean` | `CoverageGen_en.lean` | Coverage-vers-topologie, caractérisation des faisceaux, sup de coverages | 148 |
-| 10 | `Grothendieck/CanonicalProps.lean` | — | Topologie canonique, sous-canoïcité, faisceaux représentables | 133 |
-| 11 | `Grothendieck/SieveGenerate.lean` | — | Identités de génération de cribles | 128 |
+| 10 | `Grothendieck/CanonicalProps.lean` | `CanonicalProps_en.lean` | Topologie canonique, sous-canoïcité, faisceaux représentables | 133 |
+| 11 | `Grothendieck/SieveGenerate.lean` | `SieveGenerate_en.lean` | Identités de génération de cribles | 128 |
 | 12 | `Grothendieck/DenseTopology.lean` | `DenseTopology_en.lean` | La topologie dense | 131 |
-| 13 | `Grothendieck/Sheafification.lean` | — | Faisceautisation (le foncteur faisceau associé) | 175 |
+| 13 | `Grothendieck/Sheafification.lean` | `Sheafification_en.lean` | Faisceautisation (le foncteur faisceau associé) | 175 |
 | 14 | `Grothendieck/LeftExact.lean` | `LeftExact_en.lean` | Exactitude à gauche de la faisceautisation | 133 |
 | 15 | `Grothendieck/SitePoints.lean` | `SitePoints_en.lean` | Points d'un site (foncteurs fibres) | 220 |
 | 16 | `Grothendieck/Subcanonical.lean` | `Subcanonical_en.lean` | Topologies de Grothendieck sous-canoniques | 88 |
@@ -70,7 +70,7 @@ flowchart LR
 | 21 | `Grothendieck/MayerVietorisSquare.lean` | `MayerVietorisSquare_en.lean` | Carrés de Mayer-Vietoris | 195 |
 | 22 | `Grothendieck/SheafCohomology/MayerVietoris.lean` | — | Suite exacte longue de Mayer-Vietoris | 164 |
 | 23 | `Grothendieck/SheafCohomology/Cech.lean` | `SheafCohomology/Cech_en.lean` | Cohomologie de Čech | 123 |
-| 24 | `Grothendieck/YonedaLemma.lean` | — | Le lemme de Yoneda (plongement, équivalence, naturalité, pleinement fidèle, coyoneda) | 168 |
+| 24 | `Grothendieck/YonedaLemma.lean` | `YonedaLemma_en.lean` | Le lemme de Yoneda (plongement, équivalence, naturalité, pleinement fidèle, coyoneda) | 168 |
 
 L'extension (Parties 6-24) a été développée sous l'Issue #2159 / Epic #1646 et
 est **complète** : tous les 24 modules mergés, 0 `sorry`, 0 axiome ajouté.
@@ -111,7 +111,7 @@ The language toured here — Grothendieck topologies, sites, sheaves, and scheme
 - PR #2675 (Phases 4-6 : SieveOps + CoverageGen + CanonicalProps)
 - Epic #1453 (calibration du harnais prouveur)
 - Workspace hommage Conway (`../conway_lean/`)
-- **EPIC #4980** — convention i18n Lean (Option A sibling pair post-2026-07-04 ; 15 siblings `_en.lean` sur `main` dans cette lake)
+- **EPIC #4980** — convention i18n Lean (Option A sibling pair post-2026-07-04 ; 23 siblings `_en.lean` sur `main` dans cette lake)
 - **[`README.en.md`](./README.en.md)** — miroir EN du présent fichier
 - Série de notebooks Lean (`../README.md`)
 


### PR DESCRIPTION
## Summary

`grothendieck_lean/README.md` (FR canonical) + `README.en.md` (EN mirror) claimed **"15 `_en.lean` siblings on `main`"** but the actual count is **23** — the lake is near-fully drained (EPIC #4980). The i18n coverage section + 8 table rows were stale (never updated as the rollout completed).

### Changes (2 files, +20/−20)

- **i18n coverage paragraph** (FR L11 + EN L11): `15 siblings` → `23 siblings`; rewrote the outdated breakdown ("12 pattern-A + 3 harmonizing + 9 FR-only") to the current state ("23 of 24 bilingual; only `SheafCohomology/MayerVietoris` remains FR-only, `_en` pending PR #7089").
- **8 stale table rows** (FR + EN): `—` → `_en.lean` for `MathlibMap`, `SieveLattice`, `SheafBasics`, `SieveOps`, `CanonicalProps`, `SieveGenerate`, `Sheafification`, `YonedaLemma` — each `_en` sibling exists on `main`.
- **"See also" reference** (FR L114 + EN L99): `15 siblings` → `23 siblings`.

## §E whole-file audit proof (pr-review-discipline §E)

Audited the **entire README** against disk on a fresh `origin/main` worktree (`f92a53852`):

```
FR modules (exclude _en/_*): 24   ✓ matches README "24 modules"
_en siblings:                  23   ✗ README claimed 15 (STALE by 8)
sorry count:                    0   ✓ matches README "0 sorry"
```

Per-row table verification (each `_en` column checked against actual file existence):
- 8 rows showed `—` while `Module_en.lean` **exists** → fixed.
- 1 row `SheafCohomology/MayerVietoris | —` is **correct** — `MayerVietoris_en.lean` does NOT exist on `main` (PR #7089 that adds it is **OPEN, not merged**; the dashboard status line "MERGED" was a condensation error, caught via `gh pr view 7089 --json state` = OPEN + `git show origin/main:...MayerVietoris_en.lean` = absent).
- The remaining 15 table rows were already correct.

## Notes

- **Docs-only** (no `.lean` touched) — no `lake build` needed, no sorry/proof-state change.
- `CATALOG-STATUS` markers: none in this file (confirmed) — no catalog churn.
- FR-first respected (fixing accuracy of existing FR canonical + EN mirror).
- G.1 self-correction: this PR documents that **#7089 is OPEN not merged** — my c.465 `[DONE]` claim and the dashboard "MERGED" status were both wrong (condensation error); flagged for ai-01.

See #3973 (README feuilles epic, tranche). No `Closes` (epic tranche).

Co-Authored-By: Claude <noreply@anthropic.com>