### PR TITLE
fix(probas,#2876): restore French accents in Infer-6-Debugging markdown (134 cures, code untouched)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb
@@ -33,7 +33,7 @@
     "\n",
     "## Navigation\n",
     "\n",
-    "| Precedent | Suivant |\n",
+    "| précédent | Suivant |\n",
     "|-----------|--------|\n",
     "| [Infer-7-Skills-IRT](Infer-7-Skills-IRT.ipynb) | [Infer-9-Classification](Infer-9-Classification.ipynb) |\n",
     "\n",
@@ -132,10 +132,10 @@
    "source": [
     "### Packages charges\n",
     "\n",
-    "| Package | Role |\n",
+    "| Package | rôle |\n",
     "|---------|------|\n",
     "| `Microsoft.ML.Probabilistic` | Distributions, moteur d'inference, algorithmes (EP, VMP, Gibbs) |\n",
-    "| `Microsoft.ML.Probabilistic.Compiler` | Compilation des modeles en code C# optimise |\n",
+    "| `Microsoft.ML.Probabilistic.Compiler` | Compilation des modèles en code C# optimise |\n",
     "\n",
     "Les namespaces importants pour le debugging sont :\n",
     "- `Algorithms` : contient `ExpectationPropagation`, `VariationalMessagePassing`, `GibbsSampling`\n",
@@ -157,15 +157,15 @@
     "tags": []
    },
    "source": [
-    "> **Note technique** : Ce notebook est oriente *troubleshooting*. Il suppose que vous avez deja explore plusieurs notebooks de la serie et rencontre des comportements inattendus. Les exemples sont volontairement simplifies pour isoler chaque type de probleme.\n",
+    "> **Note technique** : Ce notebook est oriente *troubleshooting*. Il suppose que vous avez déjà explore plusieurs notebooks de la serie et rencontre des comportements inattendus. Les exemples sont volontairement simplifies pour isoler chaque type de problème.\n",
     "\n",
     "Le debugging en programmation probabiliste differe du debugging classique :\n",
     "\n",
     "| Debugging classique | Debugging probabiliste |\n",
     "|---------------------|------------------------|\n",
     "| Erreur = crash ou mauvaise valeur | Erreur = distribution inattendue ou divergence |\n",
-    "| Cause souvent deterministe | Cause souvent liee aux priors ou a l'algorithme |\n",
-    "| Solution : corriger le code | Solution : ajuster le modele ou l'algorithme |"
+    "| Cause souvent déterministe | Cause souvent liee aux priors ou a l'algorithme |\n",
+    "| Solution : corriger le code | Solution : ajuster le modèle ou l'algorithme |"
    ]
   },
   {
@@ -186,11 +186,11 @@
     "\n",
     "Le `FactorGraphHelper` est un utilitaire qui permet d'afficher les **graphes de facteurs** generes par Infer.NET directement dans le notebook. Ces graphes sont essentiels pour :\n",
     "\n",
-    "- **Verifier la structure** du modele probabiliste\n",
+    "- **Verifier la structure** du modèle probabiliste\n",
     "- **Identifier les connexions** manquantes ou incorrectes\n",
     "- **Comprendre le flux** des messages d'inference\n",
     "\n",
-    "> **Prerequis** : Graphviz doit etre installe sur le systeme pour generer les visualisations SVG. Si Graphviz n'est pas disponible, le helper retournera `False` et les graphes ne seront pas affiches."
+    "> **Prerequis** : Graphviz doit etre installe sur le système pour generer les visualisations SVG. Si Graphviz n'est pas disponible, le helper retournera `False` et les graphes ne seront pas affichés."
    ]
   },
   {
@@ -270,8 +270,8 @@
     "|--------|-------|----------|\n",
     "| `Model has no support` | Observation impossible sous le prior | Elargir le prior ou verifier les observations |\n",
     "| `Improper distribution` | Divergence de l'inference | Utiliser des priors plus informatifs |\n",
-    "| `Could not find method` | Operation non supportee | Reformuler avec des operations de base |\n",
-    "| `Compilation timeout` | Modele trop complexe | Simplifier ou compiler separement |\n",
+    "| `Could not find method` | opération non supportee | Reformuler avec des opérations de base |\n",
+    "| `Compilation timeout` | modèle trop complexe | Simplifier ou compiler separement |\n",
     "| `Memory exceeded` | Trop de variables | Reduire la taille ou utiliser des arrays |"
    ]
   },
@@ -405,14 +405,14 @@
     "tags": []
    },
    "source": [
-    "**Interpretation des resultats** :\n",
+    "**Interpretation des résultats** :\n",
     "\n",
-    "Le resultat `Gaussian.PointMass(100)` signifie que le posterieur est une distribution degeneree concentree exactement sur la valeur observee. C'est le comportement attendu quand :\n",
+    "Le résultat `Gaussian.PointMass(100)` signifie que le posterieur est une distribution degeneree concentree exactement sur la valeur observee. C'est le comportement attendu quand :\n",
     "\n",
-    "1. L'observation est deterministe (`ObservedValue`)\n",
+    "1. L'observation est déterministe (`ObservedValue`)\n",
     "2. Le prior est suffisamment large pour \"accepter\" cette valeur\n",
     "\n",
-    "> **Regle pratique** : Si votre prior a une precision `prec`, alors les observations situees a plus de `3/sqrt(prec)` ecarts-types du centre auront un support quasi-nul. Avec `prec=1000`, cela represente environ `0.1` unites autour de la moyenne."
+    "> **règle pratique** : Si votre prior a une precision `prec`, alors les observations situees a plus de `3/sqrt(prec)` ecarts-types du centre auront un support quasi-nul. Avec `prec=1000`, cela represente environ `0.1` unites autour de la moyenne."
    ]
   },
   {
@@ -585,9 +585,9 @@
     "tags": []
    },
    "source": [
-    "### 2.2 Probleme de convergence\n",
+    "### 2.2 problème de convergence\n",
     "\n",
-    "Le deuxieme type d'erreur courant concerne la **convergence vers des modes non desires**. Cela se produit souvent dans les modeles de melange ou les variables ont des roles symetriques."
+    "Le deuxieme type d'erreur courant concerne la **convergence vers des modes non desires**. Cela se produit souvent dans les modèles de melange ou les variables ont des rôles symetriques."
    ]
   },
   {
@@ -720,19 +720,19 @@
     "tags": []
    },
    "source": [
-    "### Le probleme du \"label switching\"\n",
+    "### Le problème du \"label switching\"\n",
     "\n",
-    "Dans les modeles de melange, le probleme des modes symetriques est connu sous le nom de **label switching**. Si les composantes sont echangeables (meme prior), l'inference peut :\n",
+    "Dans les modèles de melange, le problème des modes symetriques est connu sous le nom de **label switching**. Si les composantes sont echangeables (même prior), l'inference peut :\n",
     "\n",
-    "1. **Converger vers la moyenne** : toutes les composantes au meme endroit\n",
-    "2. **Osciller entre permutations** : les labels des composantes s'echangent entre iterations\n",
+    "1. **Converger vers la moyenne** : toutes les composantes au même endroit\n",
+    "2. **Osciller entre permutations** : les labels des composantes s'echangent entre itérations\n",
     "\n",
     "Les solutions incluent :\n",
     "\n",
     "| Solution | Avantage | Inconvenient |\n",
     "|----------|----------|--------------|\n",
     "| Priors asymetriques | Simple a implementer | Introduit un biais |\n",
-    "| Contraintes d'ordre | Mathematiquement propre | Complexifie le modele |\n",
+    "| Contraintes d'ordre | Mathematiquement propre | Complexifie le modèle |\n",
     "| Post-traitement | Pas de biais | Necessite analyse manuelle |"
    ]
   },
@@ -756,9 +756,9 @@
     "\n",
     "| Algorithme | Forces | Faiblesses | Usage recommande |\n",
     "|------------|--------|------------|------------------|\n",
-    "| **EP** | Rapide, bon pour melanges continus | Peut diverger, approximatif | Modeles Gaussian, Probit |\n",
+    "| **EP** | Rapide, bon pour melanges continus | Peut diverger, approximatif | modèles Gaussian, Probit |\n",
     "| **VMP** | Stable, bon pour discret | Sous-estime l'incertitude | LDA, melanges categoriques |\n",
-    "| **Gibbs** | Exact asymptotiquement | Lent, diagnostics difficiles | Validation, petits modeles |"
+    "| **Gibbs** | Exact asymptotiquement | Lent, diagnostics difficiles | Validation, petits modèles |"
    ]
   },
   {
@@ -775,14 +775,14 @@
     "tags": []
    },
    "source": [
-    "La cellule suivante compare EP et VMP sur un probleme simple d'estimation de moyenne avec precision inconnue.\n",
+    "La cellule suivante compare EP et VMP sur un problème simple d'estimation de moyenne avec precision inconnue.\n",
     "\n",
     "**Configuration du test** :\n",
     "- 6 observations autour de 2.0\n",
     "- Prior vague sur la moyenne : Gaussian(0, 0.01)\n",
     "- Prior informatif sur la precision : Gamma(2, 0.5)\n",
     "\n",
-    "Ce type de modele (donnees gaussiennes avec parametres inconnus) est un cas classique ou EP et VMP donnent des resultats comparables mais avec des niveaux d'incertitude differents."
+    "Ce type de modèle (données gaussiennes avec paramètres inconnus) est un cas classique ou EP et VMP donnent des résultats comparables mais avec des niveaux d'incertitude différents."
    ]
   },
   {
@@ -948,9 +948,9 @@
     "tags": []
    },
    "source": [
-    "**Interpretation des resultats EP vs VMP** :\n",
+    "**Interpretation des résultats EP vs VMP** :\n",
     "\n",
-    "Les deux algorithmes estiment la moyenne autour de 2.05 (proche de la moyenne empirique 2.05), mais avec des caracteristiques differentes :\n",
+    "Les deux algorithmes estiment la moyenne autour de 2.05 (proche de la moyenne empirique 2.05), mais avec des caractéristiques différentes :\n",
     "\n",
     "| Metrique | EP | VMP | Interpretation |\n",
     "|----------|----|----|----------------|\n",
@@ -959,14 +959,14 @@
     "\n",
     "> **Pourquoi VMP sous-estime l'incertitude ?**\n",
     "> \n",
-    "> VMP (Variational Message Passing) approxime le posterieur par une distribution factorisee. Cette hypothese d'independance ignore les correlations entre variables, ce qui conduit typiquement a des posterieurs trop \"confiants\".\n",
+    "> VMP (Variational Message Passing) approxime le posterieur par une distribution factorisee. Cette hypothese d'indépendance ignore les correlations entre variables, ce qui conduit typiquement a des posterieurs trop \"confiants\".\n",
     ">\n",
     "> EP (Expectation Propagation) maintient des correlations locales via les messages, produisant des approximations plus realistes de l'incertitude.\n",
     "\n",
     "**Quand cela importe** : La sous-estimation de l'incertitude par VMP peut etre problematique pour :\n",
     "- La prise de decision sous incertitude\n",
     "- Les intervalles de prediction\n",
-    "- La propagation de l'incertitude dans des modeles hierarchiques"
+    "- La propagation de l'incertitude dans des modèles hiérarchiques"
    ]
   },
   {
@@ -1039,16 +1039,16 @@
     "tags": []
    },
    "source": [
-    "## Exercice 1 : Diagnostic d'un modele de melange gaussien\n",
+    "## Exercice 1 : Diagnostic d'un modèle de melange gaussien\n",
     "\n",
-    "**Objectif** : Identifiez et corrigez les problemes dans un modele de melange gaussien a 2 composantes.\n",
+    "**Objectif** : Identifiez et corrigez les problemes dans un modèle de melange gaussien a 2 composantes.\n",
     "\n",
-    "**Contexte** : Un modele de melange gaussien tente de separer des donnees issues de deux distributions distinctes, mais l'inference produit des resultats inattendus (moyennes identiques ou divergence).\n",
+    "**Contexte** : Un modèle de melange gaussien tente de separer des données issues de deux distributions distinctes, mais l'inference produit des résultats inattendus (moyennes identiques ou divergence).\n",
     "\n",
-    "**Etapes** :\n",
-    "1. Analysez le modele fourni et identifiez au moins 2 problemes parmi : prior symetrique, algorithme mal adapte, observation hors-support\n",
-    "2. Corrigez chaque probleme en vous basant sur les bonnes pratiques vues dans ce notebook\n",
-    "3. Comparez les resultats obtenus avec EP et VMP sur votre modele corrige\n",
+    "**étapes** :\n",
+    "1. Analysez le modèle fourni et identifiez au moins 2 problemes parmi : prior symetrique, algorithme mal adapte, observation hors-support\n",
+    "2. Corrigez chaque problème en vous basant sur les bonnes pratiques vues dans ce notebook\n",
+    "3. Comparez les résultats obtenus avec EP et VMP sur votre modèle corrige\n",
     "\n",
     "**Indices** :\n",
     "- # Indice 1 : Les composantes d'un melange doivent avoir des priors distincts pour eviter le label switching\n",
@@ -1332,7 +1332,7 @@
     "### 4.1 Options du Moteur\n",
     "\n",
     "```csharp\n",
-    "engine.ShowProgress = true;           // Affiche les iterations\n",
+    "engine.ShowProgress = true;           // Affiche les itérations\n",
     "engine.ShowSchedule = true;           // Affiche l'ordre des messages\n",
     "engine.ShowFactorGraph = true;        // Genere le graphe de facteurs\n",
     "engine.Compiler.WriteSourceFiles = true;  // Sauvegarde le code genere\n",
@@ -1473,7 +1473,7 @@
     "tags": []
    },
    "source": [
-    "**Interpretation du resultat** :\n",
+    "**Interpretation du résultat** :\n",
     "\n",
     "Le posterieur `Gaussian(2.5, 0.5)` resulte de la mise a jour bayesienne :\n",
     "\n",
@@ -1481,7 +1481,7 @@
     "\n",
     "$$\\tau_{\\text{post}} = \\tau_{\\text{prior}} + \\tau_{\\text{likelihood}} = 1 + 1 = 2 \\quad \\Rightarrow \\quad \\sigma^2_{\\text{post}} = 0.5$$\n",
     "\n",
-    "Ou $\\tau$ represente la precision (inverse de la variance). Le posterieur est exactement a mi-chemin entre le prior (0) et l'observation (5), car les deux ont la meme precision."
+    "Ou $\\tau$ represente la precision (inverse de la variance). Le posterieur est exactement a mi-chemin entre le prior (0) et l'observation (5), car les deux ont la même precision."
    ]
   },
   {
@@ -1793,11 +1793,11 @@
    "source": [
     "### Comment lire un Factor Graph ?\n",
     "\n",
-    "Le graphe de facteurs visualise la structure du modele probabiliste :\n",
+    "Le graphe de facteurs visualise la structure du modèle probabiliste :\n",
     "\n",
-    "| Element | Representation | Signification |\n",
+    "| élément | Representation | Signification |\n",
     "|---------|----------------|---------------|\n",
-    "| **Cercles** | Variables | Variables aleatoires du modele |\n",
+    "| **Cercles** | Variables | Variables aleatoires du modèle |\n",
     "| **Carres** | Facteurs | Distributions ou contraintes |\n",
     "| **Aretes** | Connexions | Dependances entre variables et facteurs |\n",
     "| **Couleur grise** | Observe | Variables avec valeurs fixees |\n",
@@ -1808,9 +1808,9 @@
     "> 1. Les variables sont connectees comme prevu\n",
     "> 2. Les observations sont bien marquees\n",
     "> 3. Il n'y a pas de composantes deconnectees\n",
-    "> 4. La structure hierarchique est correcte\n",
+    "> 4. La structure hiérarchique est correcte\n",
     "\n",
-    "Dans le graphe ci-dessus, on voit que `hyperMean` et `hyperPrec` sont les hyperparametres partages par les deux observations `obs1` et `obs2`, formant un modele hierarchique classique."
+    "Dans le graphe ci-dessus, on voit que `hyperMean` et `hyperPrec` sont les hyperparametres partages par les deux observations `obs1` et `obs2`, formant un modèle hiérarchique classique."
    ]
   },
   {
@@ -1868,10 +1868,10 @@
     "Le choix des priors est souvent la source principale de problemes en programmation probabiliste. Un prior mal choisi peut :\n",
     "\n",
     "1. **Rendre l'inference impossible** : si l'observation a probabilite nulle sous le prior\n",
-    "2. **Biaiser les resultats** : si le prior \"domine\" les donnees\n",
-    "3. **Ralentir la convergence** : si le prior est tres different des donnees\n",
+    "2. **Biaiser les résultats** : si le prior \"domine\" les données\n",
+    "3. **Ralentir la convergence** : si le prior est très différent des données\n",
     "\n",
-    "La cellule suivante illustre l'impact de differents priors Beta sur l'estimation d'une probabilite binomiale avec seulement 5 observations."
+    "La cellule suivante illustre l'impact de différents priors Beta sur l'estimation d'une probabilite binomiale avec seulement 5 observations."
    ]
   },
   {
@@ -2032,7 +2032,7 @@
     "tags": []
    },
    "source": [
-    "**Analyse detaillee des resultats** :\n",
+    "**Analyse detaillee des résultats** :\n",
     "\n",
     "| Prior | Alpha | Beta | Moyenne prior | Moyenne posterieure | Ecart au MLE |\n",
     "|-------|-------|------|---------------|---------------------|--------------|\n",
@@ -2049,7 +2049,7 @@
     "\n",
     "> **Interpretation bayesienne** :\n",
     "> \n",
-    "> - Le prior **uniforme** (Beta(1,1)) est le plus \"neutre\" et donne un resultat proche du MLE\n",
+    "> - Le prior **uniforme** (Beta(1,1)) est le plus \"neutre\" et donne un résultat proche du MLE\n",
     "> - Les priors **centres** (Beta(2,2) et Beta(5,5)) \"tirent\" le posterieur vers 0.5\n",
     "> - Le prior **biaise** (Beta(8,2)) domine les observations et maintient une estimation elevee\n",
     ">\n",
@@ -2109,16 +2109,16 @@
    "source": [
     "### Exercice 2 : Impact du prior sur un diagnostic medical\n",
     "\n",
-    "**Objectif** : Modeliser un test de depistage avec des priors differents et observer l'impact sur le diagnostic posterieur.\n",
+    "**Objectif** : Modeliser un test de depistage avec des priors différents et observer l'impact sur le diagnostic posterieur.\n",
     "\n",
     "**Contexte** : Un test medical a un taux de faux positifs de 5% et un taux de sensibilite de 90%. La prevalence de la maladie est de 1%. Vous observez un test positif. Quelle est la probabilite que le patient soit reellement malade ?\n",
     "\n",
     "**Indices** :\n",
     "- # Indice 1 : Modelisez la probabilite de maladie avec `Variable.Beta(alpha, beta)` ou `Variable.Bernoulli(prevalence)`\n",
     "- # Indice 2 : Testez avec `Beta(1, 99)` (prevalence 1%), puis `Beta(10, 90)` (prevalence 10%)\n",
-    "- # Etape 1 : Definir le modele avec la probabilite de maladie comme variable latente\n",
-    "- # Etape 2 : Ajouter la vraisemblance du test (sensibilite et taux de faux positifs)\n",
-    "- # Etape 3 : Observer un test positif et calculer le posterieur pour differentes prevalences"
+    "- # étape 1 : définir le modèle avec la probabilite de maladie comme variable latente\n",
+    "- # étape 2 : Ajouter la vraisemblance du test (sensibilite et taux de faux positifs)\n",
+    "- # étape 3 : Observer un test positif et calculer le posterieur pour différentes prevalences"
    ]
   },
   {
@@ -2137,23 +2137,23 @@
    "source": [
     "## 6. Checklist de Debugging\n",
     "\n",
-    "Quand votre modele ne fonctionne pas, verifiez :\n",
+    "Quand votre modèle ne fonctionne pas, verifiez :\n",
     "\n",
-    "**Etape 1 : Verification du Modele**\n",
+    "**étape 1 : Verification du modèle**\n",
     "- [ ] Les types des variables sont corrects (double vs int vs bool)\n",
     "- [ ] Les observations sont dans le support du prior\n",
     "- [ ] Les arrays ont les bonnes dimensions\n",
-    "- [ ] Les Range sont correctement definis\n",
+    "- [ ] Les Range sont correctement définis\n",
     "\n",
-    "**Etape 2 : Verification de l'Inference**\n",
-    "- [ ] L'algorithme est adapte au modele (EP/VMP/Gibbs)\n",
-    "- [ ] Le nombre d'iterations est suffisant\n",
+    "**étape 2 : Verification de l'Inference**\n",
+    "- [ ] L'algorithme est adapte au modèle (EP/VMP/Gibbs)\n",
+    "- [ ] Le nombre d'itérations est suffisant\n",
     "- [ ] Les warnings de compilation sont examines\n",
     "\n",
-    "**Etape 3 : Verification des Resultats**\n",
+    "**étape 3 : Verification des résultats**\n",
     "- [ ] Les posterieurs ne sont pas degeneres (variance > 0)\n",
     "- [ ] Les moyennes sont dans des plages raisonnables\n",
-    "- [ ] Les predictions sur donnees connues sont correctes"
+    "- [ ] Les predictions sur données connues sont correctes"
    ]
   },
   {
@@ -2172,11 +2172,11 @@
    "source": [
     "### 6.1 Fonctions de diagnostic automatisees\n",
     "\n",
-    "Plutot que d'inspecter manuellement chaque posterieur, il est recommande de creer des fonctions de diagnostic reutilisables. Les fonctions ci-dessous verifient automatiquement les conditions de sante des posterieurs pour les trois types de distributions les plus courants : Gaussian, Gamma et Beta.\n",
+    "Plutot que d'inspecter manuellement chaque posterieur, il est recommande de créer des fonctions de diagnostic reutilisables. Les fonctions ci-dessous verifient automatiquement les conditions de sante des posterieurs pour les trois types de distributions les plus courants : Gaussian, Gamma et Beta.\n",
     "\n",
     "Ces fonctions peuvent etre integrees dans un pipeline de validation pour detecter automatiquement :\n",
     "- Les distributions degenerees (variance quasi-nulle)\n",
-    "- Les inferences non informatives (variance tres elevee)\n",
+    "- Les inferences non informatives (variance très elevee)\n",
     "- Les valeurs hors plage attendue"
    ]
   },
@@ -2322,14 +2322,14 @@
     "\n",
     "| Condition | Seuil | Signification si viole |\n",
     "|-----------|-------|------------------------|\n",
-    "| Variance trop faible | < 10^-10 | Distribution degeneree, possible erreur numerique |\n",
-    "| Variance trop elevee | > 10^6 | Inference non informative, donnees insuffisantes |\n",
+    "| Variance trop faible | < 10^-10 | Distribution degeneree, possible erreur numérique |\n",
+    "| Variance trop elevee | > 10^6 | Inference non informative, données insuffisantes |\n",
     "\n",
     "Pour l'exemple `test`, le diagnostic montre :\n",
     "- **Moyenne ~2.73** : compromise entre le prior (0) et l'observation (3)\n",
     "- **Variance ~0.91** : incertitude reduite par l'observation mais non nulle\n",
     "\n",
-    "> **Bonne pratique** : Integrez ces diagnostics dans vos pipelines d'inference pour detecter automatiquement les cas problematiques, surtout dans les modeles complexes avec de nombreuses variables latentes.\n",
+    "> **Bonne pratique** : Integrez ces diagnostics dans vos pipelines d'inference pour detecter automatiquement les cas problematiques, surtout dans les modèles complexes avec de nombreuses variables latentes.\n",
     "\n",
     "---\n",
     "\n",
@@ -2339,14 +2339,14 @@
     "|---------|-------------|--------------------------|\n",
     "| **Support** | Ensemble des valeurs possibles sous une distribution | Verifier que les observations sont dans le support du prior |\n",
     "| **Precision** | Inverse de la variance (1/sigma^2) | Plus la precision est elevee, plus la distribution est concentree |\n",
-    "| **Label switching** | Permutation des labels dans les modeles de melange | Utiliser des priors asymetriques ou des contraintes d'ordre |\n",
-    "| **EP** | Expectation Propagation | Algorithme rapide pour modeles continus, peut diverger |\n",
+    "| **Label switching** | Permutation des labels dans les modèles de melange | Utiliser des priors asymetriques ou des contraintes d'ordre |\n",
+    "| **EP** | Expectation Propagation | Algorithme rapide pour modèles continus, peut diverger |\n",
     "| **VMP** | Variational Message Passing | Stable mais sous-estime l'incertitude |\n",
-    "| **Factor Graph** | Representation graphique du modele | Visualiser la structure pour identifier les erreurs |\n",
+    "| **Factor Graph** | Representation graphique du modèle | Visualiser la structure pour identifier les erreurs |\n",
     "\n",
     "### Distributions utilisees dans ce notebook\n",
     "\n",
-    "| Distribution | Parametres | Usage typique |\n",
+    "| Distribution | paramètres | Usage typique |\n",
     "|--------------|------------|---------------|\n",
     "| **Gaussian** | (mean, precision) | Variables continues, estimations de moyennes |\n",
     "| **Gamma** | (shape, scale) | Precisions, variances, taux |\n",
@@ -2368,11 +2368,11 @@
     "tags": []
    },
    "source": [
-    "## 7. Exemple guide : Debugger un Modele\n",
+    "## 7. Exemple guide : Debugger un modèle\n",
     "\n",
     "### Enonce\n",
     "\n",
-    "Le modele ci-dessous a plusieurs problemes. Identifiez et corrigez-les."
+    "Le modèle ci-dessous a plusieurs problemes. Identifiez et corrigez-les."
    ]
   },
   {
@@ -2648,7 +2648,7 @@
     "tags": []
    },
    "source": [
-    "A votre tour : identifiez les problemes dans le modele suivant."
+    "A votre tour : identifiez les problemes dans le modèle suivant."
    ]
   },
   {
@@ -2790,14 +2790,14 @@
    "source": [
     "**Analyse des corrections** :\n",
     "\n",
-    "| Probleme original | Consequence | Correction appliquee |\n",
+    "| problème original | Consequence | Correction appliquee |\n",
     "|-------------------|-------------|----------------------|\n",
     "| Precision 100 sur le prior | Prior concentre autour de 0 (ecart-type ~0.1) | Precision 0.01 (ecart-type ~10) |\n",
     "| Observation a 50 | 500 ecarts-types du centre du prior | Prior centre a 25 pour couvrir l'observation |\n",
     "| Gamma(0.1, 0.1) | Shape < 1 donne une densite infinie en 0 | Gamma(2, 0.5) avec shape >= 1 |\n",
     "| Variables anonymes | Difficulte a interpreter les erreurs | Nommage explicite avec `.Named()` |\n",
     "\n",
-    "Le resultat corrige montre :\n",
+    "Le résultat corrige montre :\n",
     "- **Moyenne ~49.5** : proche de l'observation (50) car le prior est large\n",
     "- **Precision ~0.98** : estime a partir d'une seule observation (incertitude elevee)"
    ]
@@ -2818,7 +2818,7 @@
    "source": [
     "### Points cles a retenir\n",
     "\n",
-    "> **Strategie de debugging en 3 etapes** :\n",
+    "> **stratégie de debugging en 3 étapes** :\n",
     ">\n",
     "> 1. **Verifier le support** : Les observations sont-elles probables sous le prior ?\n",
     "> 2. **Verifier l'algorithme** : EP pour continu, VMP pour discret, Gibbs pour validation\n",
@@ -2826,8 +2826,8 @@
     "\n",
     "La plupart des problemes d'inference proviennent de :\n",
     "- **Priors mal specifies** (trop etroits, mauvais support)\n",
-    "- **Mauvais choix d'algorithme** (EP sur modele discret, VMP sur correlations fortes)\n",
-    "- **Modele trop complexe** (simplifier d'abord, complexifier ensuite)\n",
+    "- **Mauvais choix d'algorithme** (EP sur modèle discret, VMP sur correlations fortes)\n",
+    "- **modèle trop complexe** (simplifier d'abord, complexifier ensuite)\n",
     "\n",
     "---"
    ]
@@ -2848,12 +2848,12 @@
    "source": [
     "## 8. Resume\n",
     "\n",
-    "| Probleme | Symptome | Solution |\n",
+    "| problème | Symptome | Solution |\n",
     "|----------|----------|----------|\n",
     "| **Prior trop etroit** | \"No support\" ou posterieurs etranges | Elargir le prior |\n",
     "| **Mode symetrique** | Posterieurs uniformes | Priors asymetriques |\n",
     "| **Divergence** | Valeurs infinies ou NaN | Changer d'algorithme ou regulariser |\n",
-    "| **Lenteur** | Compilation longue | Simplifier le modele, cacher les types |\n",
+    "| **Lenteur** | Compilation longue | Simplifier le modèle, cacher les types |\n",
     "\n",
     "---\n",
     "\n",
@@ -2878,16 +2878,16 @@
     "tags": []
    },
    "source": [
-    "## Exercice 3 : Deboguer un Modele Hierarchique Casse\n",
+    "## Exercice 3 : Deboguer un modèle hiérarchique Casse\n",
     "\n",
     "### Enonce\n",
     "\n",
-    "Le modele ci-dessous tente d'estimer les moyennes de performance de 3 groupes, mais il contient **3 erreurs intentionnelles**. Identifiez et corrigez chaque erreur.\n",
+    "Le modèle ci-dessous tente d'estimer les moyennes de performance de 3 groupes, mais il contient **3 erreurs intentionnelles**. Identifiez et corrigez chaque erreur.\n",
     "\n",
     "**Indices** :\n",
     "1. Une precision de distribution ne peut pas etre negative\n",
-    "2. Une variable observee doit dependre du parametre correct du groupe, pas d'une variable partagee\n",
-    "3. Un tableau de donnees doit etre indexe par l'indice de boucle courant\n",
+    "2. Une variable observee doit dependre du paramètre correct du groupe, pas d'une variable partagee\n",
+    "3. Un tableau de données doit etre indexe par l'indice de boucle courant\n",
     "\n",
     "Corrigez le code et verifiez que les posterieurs correspondent aux moyennes des groupes."
    ]
@@ -2984,7 +2984,7 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "Ce notebook a couvert les techniques essentielles pour diagnostiquer et corriger les modeles probabilistes Infer.NET.\n",
+    "Ce notebook a couvert les techniques essentielles pour diagnostiquer et corriger les modèles probabilistes Infer.NET.\n",
     "\n",
     "| Concept | Point cle |\n",
     "|---------|-----------|\n",
@@ -2998,9 +2998,9 @@
     "|--------------|---------------------|\n",
     "| Gaussian | Verifier precision non-infinie, moyenne dans plage attendue |\n",
     "| Gamma | Shape >= 1 pour eviter densite infinie en 0 |\n",
-    "| Beta | Pseudo-observations du prior vs donnees reelles |\n",
+    "| Beta | Pseudo-observations du prior vs données reelles |\n",
     "\n",
-    "> **Demarche systematique** : Support -> Algorithme -> Posterieurs. La plupart des problemes d'inference proviennent de priors mal specifies ou d'un mauvais choix d'algorithme."
+    "> **Demarche systématique** : Support -> Algorithme -> Posterieurs. La plupart des problemes d'inference proviennent de priors mal specifies ou d'un mauvais choix d'algorithme."
    ]
   },
   {
@@ -3017,18 +3017,18 @@
     "tags": []
    },
    "source": [
-    "### Exercice 4 : Debugging d'un modele de regression bayesienne\n",
+    "### Exercice 4 : Debugging d'un modèle de regression bayesienne\n",
     "\n",
-    "**Objectif** : Identifiez et corrigez les problemes dans un modele de regression lineaire bayesienne qui produit des posterieurs degeneres.\n",
+    "**Objectif** : Identifiez et corrigez les problemes dans un modèle de regression lineaire bayesienne qui produit des posterieurs degeneres.\n",
     "\n",
-    "**Contexte** : Un chercheur tente d'etablir une relation lineaire entre les heures d'etude (`x`) et les scores d'examen (`y`). Le modele utilise une pente `slope`, une ordonnee a l'origine `intercept` et un bruit `noise`. Malheureusement, les posterieurs sont inutilisables (variance quasi-nulle ou infinie).\n",
+    "**Contexte** : Un chercheur tente d'etablir une relation lineaire entre les heures d'étude (`x`) et les scores d'examen (`y`). Le modèle utilise une pente `slope`, une ordonnee a l'origine `intercept` et un bruit `noise`. Malheureusement, les posterieurs sont inutilisables (variance quasi-nulle ou infinie).\n",
     "\n",
     "**Indices** :\n",
     "- # Indice 1 : Verifiez le prior sur la precision du bruit. Un shape < 1 produit une densite infinie en 0.\n",
-    "- # Indice 2 : La precision du prior sur la pente est-elle adaptee a l'echelle des donnees (scores sur ~50-100) ?\n",
-    "- # Etape 1 : Identifiez les 2 problemes dans le modele fourni (prior sur le bruit + precision de la pente)\n",
-    "- # Etape 2 : Corrigez les priors et relancez l'inference\n",
-    "- # Etape 3 : Utilisez `DiagnosticGaussian()` pour verifier la sante des posterieurs corriges"
+    "- # Indice 2 : La precision du prior sur la pente est-elle adaptee a l'echelle des données (scores sur ~50-100) ?\n",
+    "- # étape 1 : Identifiez les 2 problemes dans le modèle fourni (prior sur le bruit + precision de la pente)\n",
+    "- # étape 2 : Corrigez les priors et relancez l'inference\n",
+    "- # étape 3 : Utilisez `DiagnosticGaussian()` pour verifier la sante des posterieurs corriges"
    ]
   },
   {
@@ -3106,19 +3106,19 @@
    "source": [
     "## Synthese : la demarche du debuggeur probabiliste\n",
     "\n",
-    "Les quatre exercices de fin illustrent une meme realite : en programmation probabiliste, l'erreur se manifeste rarement par un crash, mais par un posterieur **degenere** (variance quasi-nulle ou infinie) ou **non informatif**. Le reflexe du debuggeur classique -- ou est le bug dans le code -- doit ceder la place a une demarche en trois temps, dont chaque exercice isole un symptome.\n",
+    "Les quatre exercices de fin illustrent une même realite : en programmation probabiliste, l'erreur se manifeste rarement par un crash, mais par un posterieur **degenere** (variance quasi-nulle ou infinie) ou **non informatif**. Le reflexe du debuggeur classique -- ou est le bug dans le code -- doit ceder la place a une demarche en trois temps, dont chaque exercice isole un symptome.\n",
     "\n",
     "| Exercice | Piege decouvert | Ou le diagnostic le repere |\n",
     "|----------|-----------------|----------------------------|\n",
-    "| Ex 3 (modele hierarchique) | `Gamma` de shape negatif + moyenne de population figee | shape < 0 leve une exception ; une precision de 10000 fige la moyenne |\n",
+    "| Ex 3 (modèle hiérarchique) | `Gamma` de shape negatif + moyenne de population figee | shape < 0 leve une exception ; une precision de 10000 fige la moyenne |\n",
     "| Ex 4 (regression bayesienne) | Prior trop etroit sur la pente + bruit `Gamma(0.1, 0.1)` | `DiagnosticGaussian` revele une variance nulle ; le bruit a une densite infinie en 0 |\n",
     "\n",
     "### Les deux familles de fautifs\n",
     "\n",
     "Dans toute la serie, les pannes se ramenent a deux familles :\n",
     "\n",
-    "1. **Les priors** -- trop etroits (`GaussianFromMeanAndPrecision(0, 10000)` fige la variable), hors-support de l'observation (`ObservedValue = 100` sous un prior centre sur 0), ou invalides (`Gamma` de shape < 1, precision negative). La regle empirique reste : un `Gamma` doit avoir `shape >= 1`, et la precision d'un prior vague vaut `0.01`, pas `10000`.\n",
-    "2. **Le choix d'algorithme** -- EP pour le continu (rapide mais peut diverger), VMP pour le discret (stable mais sous-estime l'incertitude, comme on l'a mesure : variance posterieure plus etroite), Gibbs pour la validation exacte sur petits modeles. Un melange gaussien brise sous VMP peut converger sous EP.\n",
+    "1. **Les priors** -- trop etroits (`GaussianFromMeanAndPrecision(0, 10000)` fige la variable), hors-support de l'observation (`ObservedValue = 100` sous un prior centre sur 0), ou invalides (`Gamma` de shape < 1, precision negative). La règle empirique reste : un `Gamma` doit avoir `shape >= 1`, et la precision d'un prior vague vaut `0.01`, pas `10000`.\n",
+    "2. **Le choix d'algorithme** -- EP pour le continu (rapide mais peut diverger), VMP pour le discret (stable mais sous-estime l'incertitude, comme on l'a mesure : variance posterieure plus etroite), Gibbs pour la validation exacte sur petits modèles. Un melange gaussien brise sous VMP peut converger sous EP.\n",
     "\n",
     "### Le factor graph, juge de paix\n",
     "\n",
@@ -3126,7 +3126,7 @@
     "\n",
     "### Ce quil faut emporter\n",
     "\n",
-    "Le debugging probabiliste est avant tout un **changement de regard** : un mauvais resultat n'est pas un bug a corriger dans le code, mais un signal que le modele ou l'algorithme ne correspond pas aux hypotheses implicites des donnees. La demarche systematique -- **Support, Algorithme, Posterieurs**, validee par les fonctions `DiagnosticGaussian` / `DiagnosticGamma` / `DiagnosticBeta` -- est transferable a tous les notebooks suivants de la serie (modeles hierarchiques, series temporelles, modeles de recommandation). Gardez-la sous la main : les pannes se ressemblent, seules les distributions changent.\n"
+    "Le debugging probabiliste est avant tout un **changement de regard** : un mauvais résultat n'est pas un bug a corriger dans le code, mais un signal que le modèle ou l'algorithme ne correspond pas aux hypotheses implicites des données. La demarche systématique -- **Support, Algorithme, Posterieurs**, validee par les fonctions `DiagnosticGaussian` / `DiagnosticGamma` / `DiagnosticBeta` -- est transferable a tous les notebooks suivants de la serie (modèles hiérarchiques, series temporelles, modèles de recommandation). Gardez-la sous la main : les pannes se ressemblent, seules les distributions changent.\n"
    ]
   }
  ],


### PR DESCRIPTION
fix(probas,#2876): restore French accents in Infer-6-Debugging markdown (134 cures, code untouched)

## Summary

Markdown-only French accent restoration in `MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb` (troubleshooting/debugging notebook: prior predictive checks, model compilation diagnostics, observability). **134 cures across 30 markdown cells**, code cells **untouched**. **1 file / +99/-99** — `+99/-99` strict cette fois (cf note L677-L2 ★★ refined ci-dessous) : cellules moins denses qu'Infer-7, majoritairement 1 cure/ligne.

Scope follows **ai-01's #2876 adjudication (2026-07-17, markdown-only strict)** + the forensic insight that accent-stripping hits in code cells live in **comments + string literals** (`Console.WriteLine`, `// Etape 1`) which are user-visible C# surface; curing them is **out of scope** of the dict-driven rollout (separate `#2161` exo pass).

## Detector verify (read-only)

| Check | Before | After |
|-------|--------|-------|
| `detect_accent_stripping.py` markdown hits | 134 | **0** |
| `detect_accent_stripping.py` code hits | 66 | 66 (untouched, dict-driven-out-of-scope) |
| Code cell `source` changed | — | **0** (assert byte-identical) |
| Code cell `outputs` changed | — | **0** (assert byte-identical) |
| Code cell `execution_count` changed | — | **0** (assert byte-identical) |
| Markdown cells touched | — | 30 |
| Diff stat | — | +99 / -99 (1 cure/ligne, cellules peu denses) |
| C.1 violations introduced (diff) | — | 0 |
| Secrets-like patterns in diff | — | 0 |
| Cell ids + metadata preserved | — | ✓ (35 cells, count ✓) |
| nbformat 4.5 preserved | — | ✓ |

## Compliance

- **Stop&Repair règle 6** : metadata.papermill = `metadata['papermill']['input/output_path']` → basename toléré, mais OUTPUT cellule **interdit** d'éditer. Frontière respectée : aucun `outputs` ni `execution_count` modifié.
- **C.2** : N/N code cells avec `execution_count != None` + `outputs: [...]` préservés. **Re-exécution PAS requise** car markdown-only edit.
- **C.1** : 0 `raise NotImplementedError` / `assert False` / `1/0` introduit.
- **secrets-hygiene** : 0 literal secret-like pattern dans le diff.
- **#7085 rotation ML** : ML-9 livré (#7085, 51 cures) ; PR pivote cross-famille ML → Probas/Infer (R6 anti-monotonie post c.677c/c.677d ML-1/ML-7).
- **catalog-pr-hygiene R1** : aucun catalogue régénéré (1 fichier .ipynb uniquement).

## Note technique sur le `+99/-99` (L677-L2 ★★ refined)

Sur Infer-7 (c.677e), `+125/-134` ≠ `+156/-156` à cause de cellules denses (3-4 cures par bullet, 5-8 cures par phrase) → git diff consolide visuellement. **Sur Infer-6, `+99/-99` strict** car :
- Cellules plus courtes (tableaux de diagnostic, notes techniques brèves)
- Majoritairement 1 cure par ligne (rarement 2-3)
- Pas de bullet-lists denses comme Infer-7

La **byte-identity per-cell préservée** (30 cellules, `list[str]` length inchangée) reste la **preuve canonique** que 0 cure perdue. Vérification post-cure : 134 md hits → **0**, 66 code hits préservés (cellules C# avec `// PROBLEME`, `// tres concentre`, `// Resultat` etc. — out-of-scope par décision ai-01 markdown-only strict).

## R3 collision scan (OPEN papermill/accent pool)

OPEN PRs #2876 accent = 12 (tous complémentaires, hors Infer-6) :
- **#7099** (c.677f moi, Infer-15-Recommenders 149 cures, OPEN MERGEABLE) — DIFFÉRENT fichier, OK
- **#7096** (c.677e moi, Infer-7-Skills-IRT 156 cures, OPEN MERGEABLE) — DIFFÉRENT fichier, OK
- **#7094** (c.579 po-2023, ML-4, 27 cures) — DIFFÉRENT fichier, OK
- **#7093** (c.677d moi, ML-7, 22 cures) — DIFFÉRENT fichier, OK
- **#7092** (c.677c moi, ML-1, 45 cures, MERGED-ready) — DIFFÉRENT fichier, OK
- **#7091** (c.677b moi, ML-8, 39 cures, MERGED-ready) — DIFFÉRENT fichier, OK
- **#7085** (ML-9, 51 cures) — DIFFÉRENT fichier, OK
- **#7086** (SL-1, 182 cures) — DIFFÉRENT fichier, OK
- **#7082** (GenAI/Texte/11, 159 cures) — DIFFÉRENT fichier, OK
- **#7078** (DecInfer-5, 126 cures) — Note: **même dossier Probas mais DecInfer- ≠ Infer-** (DecisionTheory/Infer vs Probas/Infer)
- **#7101/#7102** (po-2023 c.582 DecInfer-7/8 DecisionTheory/Infer) — partition distincte, OK
- + #7075 (IIT-2) et #7073 (GameTheory-2) déjà mergés

Aucun chevauchement avec CE PR (Infer-6 partition Probas/Infer, distinct de DecInfer-5 DecisionTheory). R3 disjoint OK.

OPEN PRs papermill (5 PRs, partition-safe) : #7088 (c.677 moi, ML-5 cell-level, [ALERT R3] en cours arbitrage ai-01 vs po-2023 #7090) + #7087 (c.676 detector) + #7083 (c.675 fix Z3) + #7080 (DecInfer-4 top-level fix po-2025) + #7079 (c.674 detector). Partition-safe.

## Rotation (R6 anti-monotonie)

c.673-c.676 = 3 détecteurs papermill + 1 substance fix-up Z3-Python (#7083) + 1 substance fix-up ML-5 cell-level (#7088).
c.677b = pivot accents rollout ML-8 (39 cures).
c.677c = pivot accents rollout ML-1 (45 cures).
c.677d = pivot accents rollout ML-7 (22 cures).
c.677e = pivot accents rollout Infer-7 (156 cures, cross-famille ML → Probas/Infer).
c.677f = pivot accents rollout Infer-15 (149 cures, sustained Probas/Infer).
**c.677g (CE PR) = pivot accents rollout Infer-6 (134 cures, sustained Probas/Infer, 3e PR Probas/Infer consécutive)**. Partition po-2024 OWN (Probas/Infer listé en ligne 6 MEMORY.md).

## Forward

- **Infer-4-Bayesian-Networks** (115 markdown curable, partition Probas/Infer) — prochaine cible si cadence.
- **Infer-9-Classification** (X markdown curable, partition Probas/Infer).
- **Infer-11-Topic-Models** (X markdown curable, partition Probas/Infer).
- **Infer-13-Crowdsourcing** (X markdown curable, partition Probas/Infer).
- **Infer-14-Sequences** (X markdown curable, partition Probas/Infer).
- **Infer-3-Factor-Graphs** (X markdown curable, partition Probas/Infer).
- **Search-5-GeneticAlgorithms** (173 markdown curable, partition Search).
- **Sudoku-18-Comparison-Csharp** (170 markdown curable, partition Sudoku).

## Voir aussi

- Issue **#2876** (accents rollout)
- PRs anterieurs fleet-wide : #7099 (Infer-15 c.677f moi), #7096 (Infer-7 c.677e moi), #7094 (ML-4 c.579 po-2023), #7093 (ML-7 c.677d moi), #7092 (ML-1 c.677c moi), #7091 (ML-8 c.677b moi), #7085 (ML-9), #7075 (IIT-2), #7073 (GameTheory-2), #7069 (Sudoku-1), #7062 (Search-1)
- `scripts/notebook_tools/detect_accent_stripping.py` (161 paires, c.589 dict-extension)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
