### PR TITLE
fix(qc,#2876): restore French accents in QuantConnect/README.md (4 cures, markdown prose)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/README.md
@@ -21,7 +21,7 @@ maturity: PRODUCTION=59, ALPHA=35, BETA=8, DRAFT=2, TEMPLATE=1
 
 Le trading algorithmique transforme les marchés financiers : aujourd'hui, plus de 60% des volumes aux États-Unis sont générés par des algorithmes. Cette série vous apprend à construire, tester et déployer vos propres stratégies de trading automatisées sur la plateforme **QuantConnect LEAN** — un framework open-source utilisé par des milliers de quants professionnels. Le parcours va des fondements (lifecycle d'un algorithme, gestion des données) aux frontières de l'IA (Transformers, RL, LLMs pour signaux de trading).
 
-La série couvre huit phases progressives. Les **fondements** (phases 1-4) maîtrisent l'écosystème QuantConnect : architecture LEAN, universe selection, options/futures, risk management, et l'Algorithm Framework modulaire. La **préparation ML** (phase 5) intègre les données alternatives et le feature engineering. Le **machine learning** (phases 6-7) applique les modèles classiques (Random Forest, XGBoost) puis le deep learning (LSTM, Transformers, autoencoders) aux séries temporelles financières. La **production** (phase 8) couvre le RL, les LLMs pour le trading, et le déploiement live. Chaque notebook est exécutable sur le cloud QuantConnect (free tier) sans installation locale.
+La série couvre huit phases progressives. Les **fondements** (phases 1-4) maîtrisent l'écosystème QuantConnect : architecture LEAN, universe sélection, options/futures, risk management, et l'Algorithm Framework modulaire. La **préparation ML** (phase 5) intègre les données alternatives et le feature engineering. Le **machine learning** (phases 6-7) applique les modèles classiques (Random Forest, XGBoost) puis le deep learning (LSTM, Transformers, autoencoders) aux séries temporelles financières. La **production** (phase 8) couvre le RL, les LLMs pour le trading, et le déploiement live. Chaque notebook est exécutable sur le cloud QuantConnect (free tier) sans installation locale.
 
 **À qui s'adresse cette série** : étudiants en finance quantitative, ingénieurs ML souhaitant appliquer leurs compétences aux marchés, et développeurs curieux de trading algorithmique. Les notebooks Python s'exécutent sur QuantConnect Cloud (gratuit) ou localement avec le LEAN engine. Le livre de référence est *"Hands-On AI Trading"* (Jared Broad, 2025). Aucun capital de départ nécessaire : tout se passe en backtest et paper trading.
 
@@ -81,7 +81,7 @@ Sélection dynamique d'univers, comprendre les particularités de chaque classe 
 
 | # | Notebook | Durée | Contenu |
 |---|----------|-------|---------|
-| 05 | [QC-Py-05-Universe-Selection](Python/QC-Py-05-Universe-Selection.ipynb) | 75 min | Manual universe, coarse/fine selection, dynamic rebalancing |
+| 05 | [QC-Py-05-Universe-Selection](Python/QC-Py-05-Universe-Selection.ipynb) | 75 min | Manual universe, coarse/fine sélection, dynamic rebalancing |
 | 06 | [QC-Py-06-Options-Trading](Python/QC-Py-06-Options-Trading.ipynb) | 75 min | Options chains, Greeks, covered calls, protective puts |
 | 07 | [QC-Py-07-Futures-Forex](Python/QC-Py-07-Futures-Forex.ipynb) | 75 min | Futures contracts, rollover, Forex pairs, leverage |
 | 08 | [QC-Py-08-Multi-Asset-Strategies](Python/QC-Py-08-Multi-Asset-Strategies.ipynb) | 75 min | Portfolio Equity + Options + Futures, corrélations |
@@ -459,7 +459,7 @@ Après completion de cette série, vous maîtriserez :
 
 ### Compétences Techniques
 
-- ✅ **QuantConnect LEAN** : Architecture, lifecycle, Universe selection
+- ✅ **QuantConnect LEAN** : Architecture, lifecycle, Universe sélection
 - ✅ **Risk Management** : Position sizing, stop-loss, take-profit
 - ✅ **Algorithm Framework** : Alpha, Portfolio Construction, Execution, Risk
 - ✅ **Machine Learning** : Supervised (RF, XGBoost), Deep Learning (LSTM), RL (PPO)
@@ -581,7 +581,7 @@ Pour aller plus loin : [EPIC #4038](https://github.com/jsboige/CoursIA/issues/40
 
 Cette série vous a fait traverser **l'arc complet du trading algorithmique moderne** — de la gestion d'un événement de marché à la production d'un agent RL déployé en live. L'arc pédagogique :
 
-- **Les fondations LEAN** (phases 1-4) : maîtriser le `QCAlgorithm` lifecycle, l'univers selection, les asset classes (equities, crypto, options, futures), le risk management (drawdown, exposure, stop-loss) et l'Algorithm Framework modulaire (Alpha + Portfolio Construction + Risk Management). On apprend à *écrire un algo propre*, pas à empiler des règles ad hoc.
+- **Les fondations LEAN** (phases 1-4) : maîtriser le `QCAlgorithm` lifecycle, l'univers sélection, les asset classes (equities, crypto, options, futures), le risk management (drawdown, exposure, stop-loss) et l'Algorithm Framework modulaire (Alpha + Portfolio Construction + Risk Management). On apprend à *écrire un algo propre*, pas à empiler des règles ad hoc.
 - **La préparation ML** (phase 5) : les données alternatives (sentiment, fundamentals, FRED) et le feature engineering. On apprend que **80% de la performance ML vient de la qualité des features**, pas du modèle.
 - **Le machine learning** (phases 6-7) : Random Forest et XGBoost classiques, puis deep learning (LSTM, Transformers, autoencoders pour l'anomaly detection). On apprend que les modèles de deep learning sont **fragiles aux coûts de transaction réels** et au changement de régime — un edge apparent en backtest peut s'évaporer une fois les frais appliqués (cf. les baselines vérifiées dans le tableau comparatif ci-dessus).
 - **La production** (phase 8 + compléments RL) : Reinforcement Learning (DQN, PPO, SAC/A2C), LLMs pour signaux de trading, et déploiement live (paper trading, brokers IBKR/Binance). On apprend que **la stratégie ne se juge pas sur le Sharpe brut mais sur le Sharpe net** après frais, slippage et impact de marché.


### PR DESCRIPTION
## fix(qc,#2876): restore French accents in QuantConnect/README.md (4 cures, markdown prose)

### Contexte

EPIC **#2876** — pipeline d'accents français sur les fichiers markdown.

Audit G.1 firsthand de `MyIA.AI.Notebooks/QuantConnect/README.md` (584 lignes) avec regex word-boundary + filtre hors-nom-de-fichier :

**4 cures réelles** (fr prose FR, pas chemin / pas nom de fichier / pas bloc mermaid) :
- **L24** : "universe selection" -> "universe sélection" (intro 8 phases)
- **L84** : "coarse/fine selection" -> "coarse/fine sélection" (légende tableau Phase 2)
- **L462** : "Universe selection" -> "Universe sélection" (section Compétences Techniques)
- **L584** : "l'univers selection" -> "l'univers sélection" (récap LEAN phases 1-4)

### Faux positifs écartés par l'audit G.1

- **L114 mermaid** `flowchart LR` + `U["Universe Selection<br/>..."...]` = chaîne EN littérale dans un bloc diagramme -> **non** changée (terme technique anglais).
- Liens markdown `[QC-Py-05-Universe-Selection](Python/QC-Py-05-Universe-Selection.ipynb)` : **non** touchés (le nom de fichier `QC-Py-05-Universe-Selection.ipynb` reste en ASCII sur disque -- casserait le lien, et modifier le nom de fichier = hors-scope PR accents).

### Fix

```diff
-La série couvre huit phases progressives. Les **fondements** (phases 1-4) maîtrisent l'écosystème QuantConnect : architecture LEAN, universe selection, options/futures
+La série couvre huit phases progressives. Les **fondements** (phases 1-4) maîtrisent l'écosystème QuantConnect : architecture LEAN, universe sélection, options/futures
```

Refresh-only : prose markdown, **code untouched** (Stop & Repair). 0 fichier .ipynb / 0 CSV modifié.

### Validation

```bash
$ git diff --stat MyIA.AI.Notebooks/QuantConnect/README.md
 MyIA.AI.Notebooks/QuantConnect/README.md | 8 ++++----
 1 file changed, 4 insertions(+), 4 deletions(-)
```

Aucun faux positif ajouté : regex word-boundary + filtre `"`](file)\b` (noms de fichiers ASCII conservés).

### Scope

- **1 fichier modifié** : `MyIA.AI.Notebooks/QuantConnect/README.md` (+4/-4 lignes)
- **1 feature / 1 domaine** : accents FR sur prose markdown
- **R3 atomicité respectée** (1 file / 1 domain / 1 feature)
- **R6 anti-monotonie** : cycle T2 -> Lean i18n -> Probas/QC accents (cross-famille).
- **G.1 firsthand** : audit script `audit_all_readmes.py` exécuté sur 25 READMEs candidates, filtres links/mermaid/codespan/comment-shell. Résultats stockés pour référence.

### Références

- See #2876
- Cf PR précédents : #7073/#7075/#7091-94/#7096-99/#7101-02/#7107-08/#7113 (autres séries/notebooks)
- Cf. sessions antérieures sur ce registre : c.581 (#7101) / c.581b (#7102)