### PR TITLE
fix(genai,#2876): restore French accents in GenAI/PostTraining/README.md (3 cures, markdown prose)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/PostTraining/README.md
+++ b/MyIA.AI.Notebooks/GenAI/PostTraining/README.md
@@ -25,7 +25,7 @@ L'angle pédagogique est d'expliquer la **math du loss** avant le code pour chaq
 
 ## Notebooks
 
-| # | Notebook | Sujet | Technique | Modele cible | PR |
+| # | Notebook | Sujet | Technique | Modèle cible | PR |
 |---|----------|-------|-----------|--------------|----|
 | PT-01 | `PT_01_intro_post_training.ipynb` | Vue d'ensemble historique : SFT → RLHF → DPO → GRPO → RLVR | Théorique (markdown + figures) | N/A | — |
 | PT-02 | `PT_02_sft_baseline.ipynb` | Supervised Fine-Tuning baseline | `trl.SFTTrainer` | Qwen2.5-0.5B-Instruct | #1764 |
@@ -196,9 +196,9 @@ Alternatives écartées et raisons : Llama-3.2-1B (gated, friction d'inscription
 
 Pour les apprenants disposant de plus de VRAM (RTX 4090 24Go, A100 40Go), la série indique en encart les hyperparamètres à modifier pour scaler à Qwen2.5-7B sans changer la structure pédagogique.
 
-## References academiques
+## Références académiques
 
-| Reference | Couverture |
+| Référence | Couverture |
 |-----------|------------|
 | Christiano et al., "Deep RL from human preferences" (NeurIPS 2017) | Origine RLHF |
 | Stiennon et al., "Learning to summarize with human feedback" (NeurIPS 2020) | RLHF appliquée aux LMs |


### PR DESCRIPTION
## fix(genai,#2876): restore French accents in GenAI/PostTraining/README.md (3 cures, markdown prose)

### Contexte

EPIC **#2876** — pipeline d'accents français sur les fichiers markdown.

Audit G.1 firsthand de `MyIA.AI.Notebooks/GenAI/PostTraining/README.md` (200 lignes) avec regex word-boundary :

**3 cures réelles** (cohérence FR dans en-têtes tableau / titre H2) :
- **L28** : "Modele cible" → "Modèle cible" (colonne tableau Notebooks)
- **L199** : "References academiques" → "Références académiques" (titre H2 section finale)
- **L201** : "| Reference |" → "| Référence |" (en-tête colonne tableau)

### Fix

```diff
-| # | Notebook | Sujet | Technique | Modele cible | PR |
+| # | Notebook | Sujet | Technique | Modèle cible | PR |
```

```diff
-## References academiques
+## Références académiques
```

Refresh-only : prose markdown, **code untouched** (Stop & Repair). 0 fichier .ipynb / 0 CSV modifié.

### Validation

```bash
$ git diff --stat MyIA.AI.Notebooks/GenAI/PostTraining/README.md
 MyIA.AI.Notebooks/GenAI/PostTraining/README.md | 6 +++---
 1 file changed, 3 insertions(+), 3 deletions(-)
```

**Leçon Stop & Repair appliquée** : écriture binaire (`path.open('wb')` + `.encode('utf-8')`) pour préserver LF sur Windows ; éviter le mode texte Python qui force LF→CRLF sur certains files (incident fondateur c.591 : conversion silencieuse si mode texte ouvert sans newline='').

### Scope

- **1 fichier modifié** : `MyIA.AI.Notebooks/GenAI/PostTraining/README.md` (+3/-3 lignes)
- **1 feature / 1 domaine** : accents FR sur prose markdown
- **R3 atomicité respectée** (1 file / 1 domain / 1 feature)
- **R6 anti-monotonie** : QC accents c.590 → GenAI/PostTraining accents c.591 (cross-famille)
- **G.1 firsthand** : audit `audit_all_readmes.py` (c.590) a identifié PostTraining = 3 cures réelles

### Références

- See #2876
- Cf c.590 #7117 (QC accents) — script audit partagé
- Cf PR précédents : #7073/#7075/#7091-94/#7096-99/#7101-02/#7107-08/#7113 (autres séries/notebooks)