### PR TITLE
docs(gametheory,#3973): fix README drift — sorry 6→2, lean_lib 2→4, post-absorption state

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/README.md
@@ -17,11 +17,19 @@ en un seul package multi-`lean_lib` aligné sur le modèle éprouvé de
 - **Type** : Projet Lake multi-module (multi `lean_lib`, racine agrégée)
 - **Toolchain** : `leanprover/lean4:v4.31.0-rc1` (cf `lean-toolchain`)
 - **Mathlib** : `v4.31.0-rc1` (cf `lake-manifest.json`)
-- **Compte de `sorry`** : 6 (3 dans `StableMarriage.Lattice` + son
-  sibling `_en` ; énoncés **contrefactuels documentés** dans le module —
-  voir `StableMarriage/Lattice.lean:778-784` — ni eux ni leur traduction
-  anglaise ne sont prouvables, pas un oubli)
-- **Lignes** : 11 099 (FR + EN confondus, modules frères)
+- **Compte de `sorry`** : 2 (1 dans `RepeatedGames/Folk.lean` + son
+  sibling `_en` ; théorème **STRETCH** `folk_theorem_discounted` — Folk
+  theorem en jeux répétés actualisés, preuve Fudenberg-Maskin 1986 sur
+  plusieurs pages, scaffold documenté comme stretch avec sorries comptés
+  per l'Issue [#4880](https://github.com/jsboige/CoursIA/issues/4880) ;
+  placeholder pour le harnais BG prover, pas un oubli). Les énoncés
+  contrefactuels qui occupaient auparavant `StableMarriage/Lattice`
+  (`man_optimality_key_step`, `doctor_optimal_eq_top`) ont été **retirés** :
+  ils étaient FAUX tels qu'énoncés et sont réfutés par
+  `NoCrossCounterexample` (carré latin 3×3, cf `StableMarriage/Lattice.lean`
+  bloc « Man-optimalité, version honnête »). `Lattice` est désormais
+  sorry-free.
+- **Lignes** : ~17 890 (FR + EN confondus, modules frères, hors `lakefile.lean`)
 - **CI** : `lean-social-choice.yml` ne build PAS ce projet (cf
   [lean-merge-discipline.md](../../../.claude/rules/lean-merge-discipline.md) — seul
   `lake build <module>` local fait foi)
@@ -46,8 +54,8 @@ Le track Lean de GameTheory accueillait six projets Lake avant le regroupement :
 
 `game_theory_lean/` est la **cible de regroupement** qui résout ces trois
 points : un seul `lakefile.lean`, une seule toolchain, un seul
-`lake-manifest.json`, et **deux `lean_lib` distincts** (`StableMarriage` +
-`CooperativeGames`) qui cohabitent comme modules siblings sans coupler leurs
+`lake-manifest.json`, et **quatre `lean_lib` distincts** (`StableMarriage` +
+`CooperativeGames` + `SocialChoice` + `RepeatedGames`) qui cohabitent comme modules siblings sans coupler leurs
 preuves ni leurs imports Mathlib. Le squelette a été posé en c.299 (PR #5902)
 puis rempli incrémentalement c.300–c.308 (PRs #5904 → #5940 + suppression du
 doublon `stable_marriage_lean/` via PR #5971).
@@ -70,12 +78,21 @@ package «game_theory_lean» where
   @[default_target]
   lean_lib CooperativeGames where
     globs := #[`CooperativeGames.*]    -- auto-découverte siblings _en
+
+  @[default_target]
+  lean_lib SocialChoice where
+    globs := #[`SocialChoice.*]        -- auto-découverte siblings _en (absorbé c.300, PR #6058)
+
+  @[default_target]
+  lean_lib RepeatedGames where
+    globs := #[`RepeatedGames.*]       -- auto-découverte siblings _en (absorbé c.371 depuis repeated_games_lean)
 ```
 
 Le pattern Lake retenu est celui de `decision_theory_lean/` : plusieurs
 `lean_lib` cohabitent comme **points d'entrée indépendants** vers Mathlib,
 sans coupler les graphes d'imports. Chaque `lean_lib` racine
-(`StableMarriage.lean` / `CooperativeGames.lean` / `GameTheory.lean`)
+(`StableMarriage.lean` / `CooperativeGames.lean` / `SocialChoice.lean` /
+`RepeatedGames.lean`, le tout ré-importé par l'agrégateur `GameTheory.lean`)
 sert d'**agrégateur** qui re-importe ses sous-modules FR ; les siblings
 `_en.lean` restent accessibles via `import <Module>.<SousModule>_en`
 direct.
@@ -277,20 +294,26 @@ pour éviter de retélécharger `~3 GB` à chaque incrément.
 `game_theory_lean/` est la **cible de regroupement** du track Lean de
 GameTheory (EPIC #4365) : un seul projet Lake multi-`lean_lib` qui
 absorbe les preuves formelles de **mariage stable** (Gale-Shapley,
-treillis des mariages, optimalité) et de **jeux coopératifs** (valeur
-de Shapley, cône de Bondareva-Shapley, décomposition de Möbius), avec
-**11 sous-modules** totalisant 11 099 lignes, **6 sorries documentées**
-(3 paires FR/EN d'énoncés contrefactuels dans `StableMarriage.Lattice`),
-et **convention i18n FR/EN sibling pair** (EPIC #4980). Le pattern Lake
-multi-lib retenu est calqué sur `decision_theory_lean/` (modèle éprouvé
-c.299–c.308), avec deux `lean_lib` distincts (`StableMarriage` +
-`CooperativeGames`) qui cohabitent sans coupler leurs imports Mathlib.
+treillis des mariages, optimalité), de **jeux coopératifs** (valeur
+de Shapley, cône de Bondareva-Shapley, décomposition de Möbius), de
+**choix social** (Arrow, Sen, vote, Vickrey) et de **jeux répétés**
+(folk theorem, grim trigger, actualisation), avec une vingtaine de
+sous-modules totalisant ~17 890 lignes, **2 sorries** (théorème
+**STRETCH** `folk_theorem_discounted` dans `RepeatedGames/Folk` + son
+sibling `_en`, Issue [#4880](https://github.com/jsboige/CoursIA/issues/4880) ;
+les anciens énoncés contrefactuels de `StableMarriage.Lattice` ont été
+retirés car réfutés par `NoCrossCounterexample`), et **convention i18n
+FR/EN sibling pair** (EPIC #4980). Le pattern Lake multi-lib retenu est
+calqué sur `decision_theory_lean/` (modèle éprouvé c.299–c.308), avec
+**quatre `lean_lib` distincts** (`StableMarriage` + `CooperativeGames`
++ `SocialChoice` + `RepeatedGames`) qui cohabitent sans coupler leurs
+imports Mathlib.
 **État actuel** : squelette posé en c.299, remplissage incrémental c.300
 → c.308, doublon `stable_marriage_lean/` supprimé via PR #5971,
-`social_choice_lean/` absorbé sous `SocialChoice/` via PR #6058 ;
-l'absorption restante (`social_choice_lean_peters/`) reste une **PR
-dédiée** trackée séparément et pinnée sur la convergence v4.31.0-rc1
-de Mathlib.
+`social_choice_lean/` absorbé sous `SocialChoice/` via PR #6058,
+`repeated_games_lean/` absorbé sous `RepeatedGames/` (c.371) ; l'absorption
+restante (`social_choice_lean_peters/`) reste une **PR dédiée** trackée
+séparément et pinnée sur la convergence v4.31.0-rc1 de Mathlib.
 
 ### Ce qu'il couvre
 


### PR DESCRIPTION
## Summary

`game_theory_lean/README.md` had drifted significantly after the **c.300 SocialChoice absorption** (PR #6058) and **c.371 RepeatedGames absorption**. The Status, Architecture, and Recap sections all understated the project. Driver: #3978 "refleter les preuves avancees, retirer les WIP/admis resolus, decrire l'etat formel reel."

### Changes (1 file, +43/-20, FR-only — no .en.md mirror)

| Claim | README (stale) | Actual (firsthand) |
|-------|----------------|---------------------|
| **sorry count** | 6 (3 StableMarriage.Lattice + 3 _en) | **2** — folk_theorem_discounted STRETCH in RepeatedGames/Folk.lean (+ _en) |
| **lean_lib count** | 2 (StableMarriage + CooperativeGames) | **4** (+ SocialChoice + RepeatedGames) |
| **lines** | 11 099 | **~17 890** (FR+_en, excl lakefile.lean) |
| **Etat actuel** | stops at SocialChoice | + RepeatedGames absorbed (c.371) |

## §E whole-file audit proof (pr-review-discipline §E)

Audited the **entire README** against disk on a fresh origin/main worktree (f92a53852).

**sorry count verification (the core #3978 driver)** — the README claimed "6 (3 StableMarriage.Lattice + _en, counterfactual statements)", but a precise tactic-sorry scan (strip block + line comments, per-file) gives:
- RepeatedGames/Folk.lean: 1 tactic-sorry (real remaining)
- RepeatedGames/Folk_en.lean: 1 tactic-sorry
- StableMarriage/Lattice.lean: 0 tactic-sorry (3 mentions are PROSE in comments)
- TOTAL: 2

The 2 real sorries are `folk_theorem_discounted` (Folk theorem for discounted repeated games, Fudenberg-Maskin 1986 multi-page proof) — a **documented STRETCH theorem** (Issue #4880: "scaffoldé avec ses sorries comptés, le 0-sorry n'est exigé que sur le théorème-phare"), a placeholder for the BG prover harness.

The prior StableMarriage.Lattice sorries (man_optimality_key_step, doctor_optimal_eq_top) were **REMOVED** — they were FALSE as stated (claimed any two stable marriages are ManLE-comparable both ways, implying stable marriage is unique) and are refuted by NoCrossCounterexample (3x3 latin square instance, Lattice.lean L185-234). Lattice is now sorry-free. The README line ref "Lattice.lean:778-784" pointed at the **comment block documenting the removal**, not active sorries — misleading.

**lean_lib count verification** — `grep "lean_lib " lakefile.lean` = 4 declarations (StableMarriage, CooperativeGames, SocialChoice, RepeatedGames). The README "Architecture multi-lib" code block + prose updated to show all 4 (the code block was missing SocialChoice + RepeatedGames entirely).

**Final sweep**: grep for stale mentions (6 sorry / 11 099 / deux lean_lib / 11 sous-modules) = 0 remaining (was 4 stale mentions across Status/Architecture/Recap sections).

## Notes

- **Docs-only** (no .lean touched) — no lake build needed, no proof-state change.
- CATALOG-STATUS markers: none in this file (confirmed) — no catalog churn.
- No README.en.md mirror exists for this lake (FR-only) — single-file fix.
- **R6 variety**: different family (GameTheory) vs my c.470 grothendieck PR #7106 (SymbolicAI/Lean).

See #3973 (README feuilles epic, tranche). No Closes (epic tranche).

Co-Authored-By: Claude <noreply@anthropic.com>
