### PR TITLE
fix(ml,#2876): restore French accents in ML-4-Evaluation-Python markdown (46 cures)

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-4-Evaluation-Python.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-4-Evaluation-Python.ipynb
@@ -5,21 +5,21 @@
    "id": "5bde7d0b",
    "metadata": {},
    "source": [
-    "# ML-4 : Evaluation des modeles (Python / sklearn)\n",
+    "# ML-4 : Évaluation des modèles (Python / sklearn)\n",
     "\n",
     "**Navigation** : [Index](README.md) | [<< ML-3](ML-3-Entrainement-Python.ipynb) | [Suivant >>](ML-5-TimeSeries-Python.ipynb)\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
     "A la fin de ce notebook, vous saurez :\n",
-    "1. **Evaluer** un modele de regression avec les metriques standard : R2, MAE, RMSE\n",
+    "1. **Evaluer** un modèle de regression avec les metriques standard : R2, MAE, RMSE\n",
     "2. **Valider** la robustesse via la **cross-validation K-fold** (plutot qu'un seul split train/test)\n",
-    "3. **Expliquer** un modele avec la **Permutation Feature Importance** (PFI)\n",
+    "3. **Expliquer** un modèle avec la **Permutation Feature Importance** (PFI)\n",
     "4. **Comparer** systematiquement plusieurs algorithmes via `GridSearchCV` (equivalent AutoML)\n",
     "\n",
     "### Parite ML.NET <-> Python\n",
     "\n",
-    "Ce notebook est le **jumeau Python** de [ML-4-Evaluation.ipynb](ML-4-Evaluation.ipynb) (ML.NET / C#). Il couvre les memes concepts (metriques, cross-validation, importance des variables) avec **scikit-learn** au lieu de `Microsoft.ML`.\n",
+    "Ce notebook est le **jumeau Python** de [ML-4-Evaluation.ipynb](ML-4-Evaluation.ipynb) (ML.NET / C#). Il couvre les mêmes concepts (metriques, cross-validation, importance des variables) avec **scikit-learn** au lieu de `Microsoft.ML`.\n",
     "\n",
     "| Concept ML.NET (C#) | Equivalent Python (sklearn) |\n",
     "|---------------------|------------------------------|\n",
@@ -37,9 +37,9 @@
     "\n",
     "---\n",
     "\n",
-    "## Preparation : charger les donnees et entrainer un modele de reference\n",
+    "## Preparation : charger les données et entrainer un modèle de référence\n",
     "\n",
-    "Nous reutilisons le dataset **taxi-fare** (cf ML-2-Python). Objectif : predire `fare_amount`. Nous entrainons d'abord un modele de reference (regression lineaire), puis nous l'evaluons rigoureusement."
+    "Nous reutilisons le dataset **taxi-fare** (cf ML-2-Python). Objectif : prédire `fare_amount`. Nous entrainons d'abord un modèle de référence (regression lineaire), puis nous l'evaluons rigoureusement."
    ]
   },
   {
@@ -212,7 +212,7 @@
    "source": [
     "### Split train / test\n",
     "\n",
-    "La regle d'or : **on n'evalue jamais un modele sur les donnees qui l'ont entraene**. On separe un jeu de test (20-30%) garde pour l'evaluation finale. En ML.NET : `mlContext.Data.TrainTestSplit`. En sklearn : `train_test_split`."
+    "La règle d'or : **on n'evalue jamais un modèle sur les données qui l'ont entraene**. On séparé un jeu de test (20-30%) garde pour l'évaluation finale. En ML.NET : `mlContext.Data.TrainTestSplit`. En sklearn : `train_test_split`."
    ]
   },
   {
@@ -249,9 +249,9 @@
    "id": "230ab334",
    "metadata": {},
    "source": [
-    "### Pipeline de preprocessing + modele de reference\n",
+    "### Pipeline de preprocessing + modèle de référence\n",
     "\n",
-    "On reutilise le `ColumnTransformer` du ML-2-Python (one-hot sur categorielles, imputer + scaler sur numeriques) chaine avec un `LinearRegression` (modele de reference simple)."
+    "On reutilise le `ColumnTransformer` du ML-2-Python (one-hot sur categorielles, imputer + scaler sur numeriques) chaine avec un `LinearRegression` (modèle de référence simple)."
    ]
   },
   {
@@ -299,13 +299,13 @@
    "id": "51b0a2ef",
    "metadata": {},
    "source": [
-    "## Metriques d'evaluation : R2, MAE, RMSE\n",
+    "## Metriques d'évaluation : R2, MAE, RMSE\n",
     "\n",
     "En ML.NET, `mlContext.Regression.Evaluate` retourne un objet `RegressionMetrics` avec `RSquared`, `MeanAbsoluteError`, `RootMeanSquaredError`. En sklearn, ces metriques sont des fonctions de `sklearn.metrics`.\n",
     "\n",
     "### Definitions\n",
     "\n",
-    "- **R2 (coefficient de determination)** : proportion de variance expliquee par le modele. `R2=1` = parfait, `R2=0` = predit la moyenne, `R2<0` = pire que la moyenne. **A maximiser.**\n",
+    "- **R2 (coefficient de determination)** : proportion de variance expliquee par le modèle. `R2=1` = parfait, `R2=0` = prédit la moyenne, `R2<0` = pire que la moyenne. **A maximiser.**\n",
     "- **MAE (Mean Absolute Error)** : erreur moyenne en valeur absolue, dans l'unite de la cible. **Interpretable directement.**\n",
     "- **RMSE (Root Mean Squared Error)** : racine de l'erreur quadratique moyenne. Penalise davantage les grandes erreurs. **Plus sensible aux outliers que la MAE.**"
    ]
@@ -357,9 +357,9 @@
    "id": "f7545579",
    "metadata": {},
    "source": [
-    "## Cross-Validation K-fold : une evaluation plus robuste\n",
+    "## Cross-Validation K-fold : une évaluation plus robuste\n",
     "\n",
-    "Un seul split train/test est **bruite** : la metrique depend du tirage aleatoire. La **cross-validation K-fold** entraene et evalue le modele K fois sur des splits differents, puis on moyenne. C'est l'etalon-or pour estimer la performance **generalisable**.\n",
+    "Un seul split train/test est **bruite** : la metrique depend du tirage aléatoire. La **cross-validation K-fold** entraene et evalue le modèle K fois sur des splits differents, puis on moyenne. C'est l'etalon-or pour estimer la performance **generalisable**.\n",
     "\n",
     "En ML.NET : `Regression.CrossValidate`. En sklearn : `cross_validate`."
    ]
@@ -414,7 +414,7 @@
    "id": "2423e12a",
    "metadata": {},
    "source": [
-    "**Pourquoi la CV importe** : si le R2 sur un seul split etait `0.91` mais que la CV donne `0.85 +/- 0.06`, la CV revele que le modele est **moins robuste** qu'on ne le croyait. C'est la difference entre « j'ai eu de la chance sur ce split » et « le modele generalise bien ».\n",
+    "**Pourquoi la CV importe** : si le R2 sur un seul split etait `0.91` mais que la CV donne `0.85 +/- 0.06`, la CV revele que le modèle est **moins robuste** qu'on ne le croyait. C'est la difference entre « j'ai eu de la chance sur ce split » et « le modèle généralisé bien ».\n",
     "\n",
     "## Permutation Feature Importance (PFI)\n",
     "\n",
@@ -481,17 +481,17 @@
     "\n",
     "- **`trip_distance`** dominante : logique, le tarif d'un taxi depend principalement de la distance parcourue.\n",
     "- **`trip_time_in_secs`** secondaire : la duree ajoute un signal (trafic, detour) au-dela de la distance.\n",
-    "- **`vendor_id`, `payment_type`, `rate_code`, `passenger_count`** faibles : la permutation ne degrade presque pas le modele.\n",
+    "- **`vendor_id`, `payment_type`, `rate_code`, `passenger_count`** faibles : la permutation ne degrade presque pas le modèle.\n",
     "\n",
-    "**Insight cle** : la PFI est **conditionnelle** au modele. Une feature peut etre ignoree par un modele lineaire mais cruciale pour un RandomForest.\n",
+    "**Insight cle** : la PFI est **conditionnelle** au modèle. Une feature peut etre ignoree par un modèle lineaire mais cruciale pour un RandomForest.\n",
     "\n",
     "### Feature Contribution Calculation (FCC) - note de parite\n",
     "\n",
-    "Le notebook ML.NET couvre aussi la **Feature Contribution Calculation** (FCC), qui decompose la prediction **d'une instance** en contributions par feature (explicabilite locale). sklearn n'a pas d'equivalent natif direct ; l'ecosysteme Python utilise **SHAP** (`shap` library) ou **`partial_dependence`** pour cet angle. SHAP est hors scope de ce twin (dependance externe), mais le concept se transpose directement via SHAP en production.\n",
+    "Le notebook ML.NET couvre aussi la **Feature Contribution Calculation** (FCC), qui decompose la prédiction **d'une instance** en contributions par feature (explicabilite locale). sklearn n'a pas d'equivalent natif direct ; l'ecosysteme Python utilise **SHAP** (`shap` library) ou **`partial_dependence`** pour cet angle. SHAP est hors scope de ce twin (dependance externe), mais le concept se transpose directement via SHAP en production.\n",
     "\n",
     "## Comparer plusieurs algorithmes : GridSearchCV (equivalent AutoML)\n",
     "\n",
-    "En ML.NET, `mlContext.AutoML` balaie automatiquement l'espace des algorithmes et hyperparametres. En sklearn, `GridSearchCV` fait de meme de facon declarative : on fournit une grille d'hyperparametres, il teste toutes les combinaisons via cross-validation."
+    "En ML.NET, `mlContext.AutoML` balaie automatiquement l'espace des algorithmes et hyperparametres. En sklearn, `GridSearchCV` fait de même de facon declarative : on fournit une grille d'hyperparametres, il teste toutes les combinaisons via cross-validation."
    ]
   },
   {
@@ -551,16 +551,16 @@
    "id": "d8e5ee4d",
    "metadata": {},
    "source": [
-    "## Comment puis-je ameliorer mon modele ?\n",
+    "## Comment puis-je ameliorer mon modèle ?\n",
     "\n",
     "Checklist d'amelioration (transversale ML.NET <-> sklearn) :\n",
     "\n",
-    "1. **Plus de donnees** : la performance plafonne souvent faute d'exemples.\n",
+    "1. **Plus de données** : la performance plafonne souvent faute d'exemples.\n",
     "2. **Feature engineering** : creer des features derivees (ex: `speed = trip_distance / trip_time`). Cf ML-2-Python.\n",
     "3. **Regularisation** : `Ridge`/`Lasso` (sklearn) ou `L2Regularization` (ML.NET SDCA).\n",
-    "4. **Modeles plus expressifs** : GradientBoosting (`HistGradientBoostingRegressor`), ou `xgboost`/`lightgbm`.\n",
+    "4. **modèles plus expressifs** : GradientBoosting (`HistGradientBoostingRegressor`), ou `xgboost`/`lightgbm`.\n",
     "5. **Hyperparametre tuning** : `GridSearchCV` ou `RandomizedSearchCV`.\n",
-    "6. **Cross-validation** : toujours valider par CV avant de conclure qu une amelioration est reelle.\n",
+    "6. **Cross-validation** : toujours valider par CV avant de conclure qu une amelioration est réelle.\n",
     "\n",
     "## Exercices supplementaires\n",
     "\n",
@@ -652,7 +652,7 @@
    "id": "07f5b25d",
    "metadata": {},
    "source": [
-    "## Exercice : Analyse complete d'un modele de prediction\n",
+    "## Exercice : Analyse complete d'un modèle de prédiction\n",
     "\n",
     "### Objectifs\n",
     "- Construisez un pipeline complet sur un nouveau dataset (ex: `trip_duration` au lieu de `fare_amount`)\n",
@@ -708,7 +708,7 @@
    "source": [
     "## Resume\n",
     "\n",
-    "Dans ce notebook vous avez maitrise l'**evaluation rigoureuse** des modeles de regression avec scikit-learn, en miroir du notebook ML-4 .NET :\n",
+    "Dans ce notebook vous avez maitrise l'**évaluation rigoureuse** des modèles de regression avec scikit-learn, en miroir du notebook ML-4 .NET :\n",
     "\n",
     "1. **Metriques** : R2 (variance expliquee), MAE (erreur moyenne interpretable), RMSE (sensible aux outliers). Trois angles complementaires, jamais un seul.\n",
     "2. **Cross-validation K-fold** : estimer la performance **generalisable** plutot que de se fier a un seul split bruite.\n",
@@ -717,13 +717,13 @@
     "\n",
     "### Parite conceptuelle cle\n",
     "\n",
-    "L'evaluation rigoureuse suit le **meme cheminement** en ML.NET et sklearn : (1) split train/test, (2) entrainer un baseline, (3) metriques sur test, (4) cross-validation pour robustesse, (5) explicabilite (PFI), (6) sweep hyperparametres (AutoML / GridSearchCV). Les API different mais la **discipline methodologique** est identique.\n",
+    "L'évaluation rigoureuse suit le **même cheminement** en ML.NET et sklearn : (1) split train/test, (2) entrainer un baseline, (3) metriques sur test, (4) cross-validation pour robustesse, (5) explicabilite (PFI), (6) sweep hyperparametres (AutoML / GridSearchCV). Les API different mais la **discipline methodologique** est identique.\n",
     "\n",
-    "### Prochaine etape\n",
+    "### Prochaine étape\n",
     "\n",
     "[ML-5-TimeSeries-Python.ipynb](ML-5-TimeSeries-Python.ipynb) aborde les **series temporelles** (equivalent SSA ML.NET).\n",
     "\n",
-    "## References\n",
+    "## Références\n",
     "\n",
     "- [scikit-learn metrics](https://scikit-learn.org/stable/modules/model_evaluation.html)\n",
     "- [scikit-learn cross_validate](https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.cross_validate.html)\n",


### PR DESCRIPTION
## fix(ml,#2876): restore French accents in ML-4-Evaluation-Python markdown (46 cures)

### Contexte

EPIC **#2876** — restauration des accents français dans les notebooks.
Suite c.593 (#7125 TP-prevision-ventes.ipynb) : self-pick cross-pool → ML/ML.NET notebook distinct, **ML-4-Evaluation-Python** = jumeau Python du ML-4-Evaluation.ipynb C# (#7094 déjà couvert).

42 hits MD initiaux, 46 cures finales (12 md cells touchés, 10 après skip rules), 1:1 line replacement parfait (+27/-27).

### Diagnostic

Pre-flight G.1 firsthand :
```
gh pr list --state open --search "ML-4-Evaluation-Python"
# -> 0 PR concurrent (distinct file from ML-4-Evaluation #7094)
gh pr list --state open --search "ML-2-Data OR ML-3-Entrainement"
# -> 0 PR concurrent sur autres cibles ML
```

### Fix

Script raw-text surgical (c.593 ★ leçon appliquée) : `scratchpad/apply_accents_c594.py` (worktree local, hors-repo).

**Stratégie identique c.593** : parse JSON in-memory + string.replace sur le bloc exact `"source": [...]` du raw text. Bypass `nbformat.write` (qui re-sérialise outputs et corromprait `text/plain: [""]` → `[]`).

### Validation post-fix

```
$ python scratchpad/apply_accents_c594.py
Markdown cells touched: 10
  cell[0]: 11 cures
  cell[2]: 5 cures
  cell[4]: 4 cures
  cell[6]: 3 cures
  cell[8]: 3 cures
  cell[10]: 3 cures
  cell[12]: 5 cures
  cell[14]: 4 cures
  cell[18]: 2 cures
  cell[20]: 6 cures
TOTAL cures: 46
CRLF pre/post: 0/0 (LF préservés, leçon c.591 ★)
LF pre/post: 758/758
Total bytes pre/post: 30870/30924 (delta +54)
Parse OK: 21 cells, nbformat 4.5
cell[1] output: {'name': 'stdout', 'output_type': 'stream', 'text': ['Dataset : (60, 7)\n']}
```

`git diff --stat` :
```
 MyIA.AI.Notebooks/ML/ML.Net/ML-4-Evaluation-Python.ipynb | 54 +++++++++++-----------
 1 file changed, 27 insertions(+), 27 deletions(-)
```

**+27/-27 = exactement 1:1 line replacement**.

### Skip rules appliqués

- **Liens markdown préservés** : `[Index](README.md)`, `[ML-3](ML-3-Entrainement-Python.ipynb)`, `[ML-5](ML-5-TimeSeries-Python.ipynb)`, `[ML-4-Evaluation.ipynb](ML-4-Evaluation.ipynb)` — paths byte-identiques (L663-L1 ★).
- **Heading capital préservés** : `# ML-4 : Évaluation des modèles` (cap preservée sur Évaluation + modèles).
- **Cellules code intactes** : 11 cellules code avec commentaires FR non touchés (OUT scope, ai-01 contract #2876).
- **Cell outputs intactes** : cell[1] `stream` `text: ['Dataset : (60, 7)\n']` byte-pour-byte préservé (Stop & Repair, secrets-hygiene rule 6).

### Scope

- 1 fichier modifié : `MyIA.AI.Notebooks/ML/ML.Net/ML-4-Evaluation-Python.ipynb`
- 10 cellules markdown curees / 21 cellules totales
- 46 substitutions caractère (e→é, etc.)
- R3 atomicité respectée (1 file / 1 domain / 1 feature)
- R6 anti-monotonie : c.593 TP-prevision → **c.594 ML-4-Python** — diversification intra-famille ML (C# → Python twins).

### Références

- See #2876
- Cf c.593 #7125 (TP-prevision accents, 97 cures — leçon raw-text surgical ★)
- Cf c.591 #7119 (GenAI/PostTraining accents, 3 cures — leçon LF preservation ★)
- Cf c.590 #7117 (QC/README accents, 4 cures — premier README accents)
- Cf c.592 #7122 (S4 deck-3 accents, 50 cures — slides registre)
- Cf L663-L1 ★ (NotebookEdit edit_mode="replace" REPLACE ENTIÈREMENT cell.source)
- Cf L662-L1 ★ (audit fichier ENTIER ≠ "toute la famille")

🤖 Generated with [Claude Code](https://claude.com/claude-code)