### PR TITLE
fix(search,#2876): Search-5-GeneticAlgorithms FR accent restoration

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms.ipynb
@@ -22,11 +22,11 @@
     "## Objectifs d'apprentissage\n",
     "\n",
     "A la fin de ce notebook, vous saurez :\n",
-    "1. **Decrire** le cycle d'un algorithme genetique (selection, crossover, mutation, evaluation)\n",
+    "1. **Decrire** le cycle d'un algorithme genetique (sélection, crossover, mutation, évaluation)\n",
     "2. **Implementer** un GA complet from scratch pour un probleme d'optimisation combinatoire\n",
     "3. **Utiliser** les frameworks DEAP et PyGAD pour resoudre des problemes concrets\n",
-    "4. **Analyser** l'impact des parametres (taille de population, taux de mutation, methode de selection) sur la convergence\n",
-    "5. **Comparer** les operateurs genetiques (selection, crossover, mutation) et leurs compromis\n",
+    "4. **Analyser** l'impact des paramètres (taille de population, taux de mutation, méthode de sélection) sur la convergence\n",
+    "5. **Comparer** les operateurs genetiques (sélection, crossover, mutation) et leurs compromis\n",
     "\n",
     "### Prerequis\n",
     "- Notebook Search-4-LocalSearch complete (recherche locale, Hill Climbing, recuit simule)\n",
@@ -57,14 +57,14 @@
     "\n",
     "### De l'evolution naturelle a l'optimisation\n",
     "\n",
-    "Les **algorithmes genetiques** (AG) sont des metaheuristiques inspirees de la theorie de l'evolution de Darwin. Contrairement aux methodes de recherche locale etudiees dans Search-4 (Hill Climbing, Recuit Simule, Tabou) qui manipulent une **seule solution** a la fois, les AG travaillent avec une **population** de solutions candidates qui evolue au fil des generations.\n",
+    "Les **algorithmes genetiques** (AG) sont des metaheuristiques inspirees de la theorie de l'evolution de Darwin. Contrairement aux méthodes de recherche locale etudiees dans Search-4 (Hill Climbing, Recuit Simule, Tabou) qui manipulent une **seule solution** a la fois, les AG travaillent avec une **population** de solutions candidates qui evolue au fil des generations.\n",
     "\n",
     "### Vocabulaire : de la biologie a l'informatique\n",
     "\n",
     "| Biologie | Algorithme Genetique | Description |\n",
     "|----------|---------------------|-------------|\n",
     "| Individu / Organisme | Solution candidate | Un point dans l'espace de recherche |\n",
-    "| Chromosome | Encodage | Representation de la solution (binaire, reel, permutation) |\n",
+    "| Chromosome | Encodage | Representation de la solution (binaire, réel, permutation) |\n",
     "| Gene | Variable de decision | Un element du chromosome |\n",
     "| Allele | Valeur d'un gene | Valeur concrete d'une variable |\n",
     "| Population | Ensemble de solutions | Groupe de solutions explorees simultanement |\n",
@@ -73,16 +73,16 @@
     "\n",
     "### Cycle de l'algorithme genetique\n",
     "\n",
-    "Le cycle d'un AG se decompose en etapes repetees a chaque generation :\n",
+    "Le cycle d'un AG se decompose en étapes repetees a chaque generation :\n",
     "\n",
     "```\n",
-    "Population initiale (aleatoire)\n",
+    "Population initiale (aléatoire)\n",
     "        |\n",
     "        v\n",
-    "   [Evaluation] <-----+\n",
+    "   [évaluation] <-----+\n",
     "        |              |\n",
     "        v              |\n",
-    "   [Selection]         |\n",
+    "   [sélection]         |\n",
     "        |              |\n",
     "        v              |\n",
     "   [Crossover]         |\n",
@@ -106,7 +106,7 @@
     "| **Diversite** | La population explore plusieurs regions de l'espace simultanement |\n",
     "| **Evasion** | Le crossover combine des solutions eloignees, echappant aux optima locaux |\n",
     "| **Generalite** | Applicable a tout probleme ou l'on peut encoder une solution et definir un fitness |\n",
-    "| **Parallelisable** | L'evaluation de chaque individu est independante |"
+    "| **Parallelisable** | L'évaluation de chaque individu est independante |"
    ]
   },
   {
@@ -205,13 +205,13 @@
     "\n",
     "### 2.1 Encodage du chromosome\n",
     "\n",
-    "Le choix de l'encodage est crucial : il determine comment une solution est representee et comment les operateurs genetiques agissent.\n",
+    "Le choix de l'encodage est crucial : il détermine comment une solution est representee et comment les operateurs genetiques agissent.\n",
     "\n",
     "| Encodage | Representation | Exemple de probleme |\n",
     "|----------|---------------|---------------------|\n",
     "| **Binaire** | Chaine de 0 et 1 | OneMax, sac a dos |\n",
     "| **Entier** | Vecteur d'entiers | Allocation de ressources |\n",
-    "| **Reel** | Vecteur de flottants | Optimisation continue (Rastrigin, Rosenbrock) |\n",
+    "| **réel** | Vecteur de flottants | Optimisation continue (Rastrigin, Rosenbrock) |\n",
     "| **Permutation** | Permutation d'indices | TSP, ordonnancement |"
    ]
   },
@@ -287,13 +287,13 @@
     "tags": []
    },
    "source": [
-    "### 2.2 Methodes de selection\n",
+    "### 2.2 Méthodes de sélection\n",
     "\n",
-    "La selection determine quels individus ont le droit de se reproduire. Le compromis fondamental est la **pression de selection** :\n",
+    "La sélection détermine quels individus ont le droit de se reproduire. Le compromis fondamental est la **pression de sélection** :\n",
     "- Trop forte : convergence prematuree vers un optimum local\n",
     "- Trop faible : exploration lente, pas de convergence\n",
     "\n",
-    "Nous implementons les trois methodes les plus courantes."
+    "Nous implementons les trois méthodes les plus courantes."
    ]
   },
   {
@@ -391,9 +391,9 @@
     "tags": []
    },
    "source": [
-    "#### Comparaison de la pression de selection\n",
+    "#### Comparaison de la pression de sélection\n",
     "\n",
-    "Mesurons experimentalement la pression de selection de chaque methode : combien de fois le meilleur individu est-il selectionne par rapport au pire ?"
+    "Mesurons experimentalement la pression de sélection de chaque méthode : combien de fois le meilleur individu est-il selectionne par rapport au pire ?"
    ]
   },
   {
@@ -482,22 +482,22 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : pression de selection\n",
+    "### Interpretation : pression de sélection\n",
     "\n",
-    "**Sortie obtenue** : les trois histogrammes montrent la frequence de selection de chaque individu (classe par fitness croissant).\n",
+    "**Sortie obtenue** : les trois histogrammes montrent la frequence de sélection de chaque individu (classe par fitness croissant).\n",
     "\n",
-    "| Methode | Pression | Comportement |\n",
+    "| méthode | Pression | Comportement |\n",
     "|---------|----------|--------------|\n",
-    "| **Roulette** | Elevee | L'individu 89 est selectionne ~38% du temps, les faibles (<5) sont quasi ignores |\n",
-    "| **Tournoi (k=3)** | Moderee a elevee | Distribution plus lissee, mais les meilleurs dominent |\n",
+    "| **Roulette** | élevée | L'individu 89 est selectionne ~38% du temps, les faibles (<5) sont quasi ignores |\n",
+    "| **Tournoi (k=3)** | Moderee a élevée | Distribution plus lissee, mais les meilleurs dominent |\n",
     "| **Rang** | Moderee | La probabilite croit lineairement avec le rang, independamment des ecarts de fitness |\n",
     "\n",
     "**Points cles** :\n",
-    "1. La **roulette** est tres sensible aux ecarts de fitness : un individu avec un fitness 10x superieur a 10x plus de chances\n",
+    "1. La **roulette** est tres sensible aux ecarts de fitness : un individu avec un fitness 10x supérieur a 10x plus de chances\n",
     "2. Le **tournoi** est le plus utilise en pratique : on controle la pression en ajustant la taille $k$ du tournoi\n",
-    "3. La **selection par rang** est robuste aux ecarts extremes de fitness (utile quand le fitness varie de plusieurs ordres de grandeur)\n",
+    "3. La **sélection par rang** est robuste aux ecarts extremes de fitness (utile quand le fitness varie de plusieurs ordres de grandeur)\n",
     "\n",
-    "> **Regle pratique** : tournoi avec $k=3$ offre un bon equilibre entre exploration et exploitation."
+    "> **règle pratique** : tournoi avec $k=3$ offre un bon equilibre entre exploration et exploitation."
    ]
   },
   {
@@ -775,7 +775,7 @@
    "source": [
     "### 2.4 Operateurs de mutation\n",
     "\n",
-    "La mutation introduit des variations aleatoires dans les chromosomes. Son role est de maintenir la **diversite genetique** et d'explorer des regions de l'espace que le crossover seul ne pourrait pas atteindre."
+    "La mutation introduit des variations aléatoires dans les chromosomes. Son role est de maintenir la **diversite genetique** et d'explorer des regions de l'espace que le crossover seul ne pourrait pas atteindre."
    ]
   },
   {
@@ -1213,7 +1213,7 @@
    "source": [
     "### Etude parametrique\n",
     "\n",
-    "Etudions l'impact de deux parametres critiques : la **taille de population** et le **taux de mutation**."
+    "Etudions l'impact de deux paramètres critiques : la **taille de population** et le **taux de mutation**."
    ]
   },
   {
@@ -1317,17 +1317,17 @@
     "\n",
     "**Sortie obtenue** : deux graphiques montrant l'impact de la taille de population et du taux de mutation.\n",
     "\n",
-    "| Parametre | Valeur faible | Valeur elevee |\n",
+    "| paramètre | Valeur faible | Valeur élevée |\n",
     "|-----------|--------------|---------------|\n",
     "| **Taille de population** | Convergence rapide mais risque de stagnation | Exploration plus large, convergence plus lente mais plus robuste |\n",
-    "| **Taux de mutation** | Diversite insuffisante, convergence prematuree | Trop de perturbation, \"marche aleatoire\" |\n",
+    "| **Taux de mutation** | Diversite insuffisante, convergence prematuree | Trop de perturbation, \"marche aléatoire\" |\n",
     "\n",
     "**Points cles** :\n",
     "1. **Population** : une population trop petite (20) manque de diversite genetique ; trop grande (200) ralentit la convergence par generation\n",
-    "2. **Mutation** : le taux optimal est generalement entre 1/n et 5/n (ici 0.02-0.1 pour n=50)\n",
+    "2. **Mutation** : le taux optimal est généralement entre 1/n et 5/n (ici 0.02-0.1 pour n=50)\n",
     "3. Un taux de mutation de 0.2 est destructeur : il detruit les bonnes solutions plus vite qu'il n'en cree\n",
     "\n",
-    "> **Regle empirique** : taux de mutation $\\approx 1/n$ ou $n$ est la longueur du chromosome."
+    "> **règle empirique** : taux de mutation $\\approx 1/n$ ou $n$ est la longueur du chromosome."
    ]
   },
   {
@@ -1351,13 +1351,13 @@
     "\n",
     "### Introduction a DEAP\n",
     "\n",
-    "[DEAP](https://deap.readthedocs.io/) (Distributed Evolutionary Algorithms in Python) est le framework de reference pour les algorithmes evolutionnaires en Python. Il offre :\n",
+    "[DEAP](https://deap.readthedocs.io/) (Distributed Evolutionary Algorithms in Python) est le framework de référence pour les algorithmes evolutionnaires en Python. Il offre :\n",
     "\n",
-    "| Fonctionnalite | Description |\n",
+    "| fonctionnalité | Description |\n",
     "|---------------|-------------|\n",
     "| `creator` | Definition de classes de fitness et d'individus |\n",
     "| `base.Toolbox` | Enregistrement des operateurs genetiques |\n",
-    "| `tools` | Operateurs pre-implementes (selection, crossover, mutation) |\n",
+    "| `tools` | Operateurs pre-implementes (sélection, crossover, mutation) |\n",
     "| `algorithms` | Algorithmes complets (eaSimple, eaMuPlusLambda, etc.) |\n",
     "| `cma` | CMA-ES (Covariance Matrix Adaptation) |\n",
     "\n",
@@ -1456,7 +1456,7 @@
    "source": [
     "### Execution avec eaSimple\n",
     "\n",
-    "`eaSimple` implemente un AG generationnel standard. Il prend la population, le toolbox et les parametres (taux de crossover, mutation, nombre de generations)."
+    "`eaSimple` implemente un AG generationnel standard. Il prend la population, le toolbox et les paramètres (taux de crossover, mutation, nombre de generations)."
    ]
   },
   {
@@ -1549,7 +1549,7 @@
     "tags": []
    },
    "source": [
-    "Visualisons la convergence de DEAP sur le meme probleme OneMax."
+    "Visualisons la convergence de DEAP sur le même probleme OneMax."
    ]
   },
   {
@@ -1636,7 +1636,7 @@
     "| **Parallelisme** | Non | Support multiprocessing |\n",
     "\n",
     "**Points cles** :\n",
-    "1. DEAP simplifie considerablement le code tout en offrant plus de fonctionnalites\n",
+    "1. DEAP simplifie considerablement le code tout en offrant plus de fonctionnalités\n",
     "2. Le `Logbook` collecte automatiquement les statistiques generation par generation\n",
     "3. Le `HallOfFame` garde les meilleurs individus, equivalent a l'elitisme\n",
     "\n",
@@ -1666,9 +1666,9 @@
     "\n",
     "[PyGAD](https://pygad.readthedocs.io/) est une bibliotheque plus simple que DEAP, orientee vers le prototypage rapide. Elle est particulierement adaptee aux problemes d'optimisation continue.\n",
     "\n",
-    "| Critere | DEAP | PyGAD |\n",
+    "| critère | DEAP | PyGAD |\n",
     "|---------|------|-------|\n",
-    "| Flexibilite | Tres elevee | Moderee |\n",
+    "| Flexibilite | Tres élevée | Moderee |\n",
     "| Courbe d'apprentissage | Raide | Douce |\n",
     "| Operateurs | Tres nombreux | Essentiels |\n",
     "| Multi-objectif | NSGA-II, SPEA2 | Non |\n",
@@ -1788,7 +1788,7 @@
     "| Profondeur des puits | Similaire |\n",
     "\n",
     "**Points cles** :\n",
-    "1. Les methodes de recherche locale (Hill Climbing, Recuit Simule) risquent de rester pieges dans un minimum local\n",
+    "1. Les méthodes de recherche locale (Hill Climbing, Recuit Simule) risquent de rester pieges dans un minimum local\n",
     "2. L'AG explore simultanement plusieurs regions grace a sa population\n",
     "3. Le crossover peut combiner des solutions proches de differents minima pour \"sauter\" vers le minimum global"
    ]
@@ -1973,10 +1973,10 @@
     "\n",
     "**Comparaison DEAP vs PyGAD** :\n",
     "\n",
-    "| Critere | DEAP | PyGAD |\n",
+    "| critère | DEAP | PyGAD |\n",
     "|---------|------|-------|\n",
     "| Configuration | Verbose mais flexible | Compact (un seul constructeur) |\n",
-    "| Operateurs | Registre via Toolbox | Parametres du constructeur |\n",
+    "| Operateurs | Registre via Toolbox | paramètres du constructeur |\n",
     "| Logging | Logbook + Statistics | Callback on_generation |\n",
     "| Quand l'utiliser | Algorithmes sur mesure, multi-objectif | Prototypage rapide, problemes standards |"
    ]
@@ -2089,7 +2089,7 @@
     "\n",
     "**Points cles** :\n",
     "1. L'elitisme garantit que la qualite de la meilleure solution ne diminue jamais\n",
-    "2. Sans elitisme, un taux de mutation eleve (0.05) peut degrader de bonnes solutions\n",
+    "2. Sans elitisme, un taux de mutation élevé (0.05) peut degrader de bonnes solutions\n",
     "3. En pratique, l'elitisme est quasi toujours active ($k = 1$)"
    ]
   },
@@ -2114,7 +2114,7 @@
     "\n",
     "$$\\text{mutation\\_rate}(t) = \\text{rate}_{max} \\cdot \\left(1 - \\frac{t}{T}\\right) + \\text{rate}_{min}$$\n",
     "\n",
-    "- **Debut** : taux eleve pour explorer largement\n",
+    "- **Debut** : taux élevé pour explorer largement\n",
     "- **Fin** : taux faible pour affiner autour des bonnes solutions"
    ]
   },
@@ -2212,29 +2212,29 @@
     "\n",
     "| Composant | Options | Recommandation |\n",
     "|-----------|---------|----------------|\n",
-    "| **Encodage** | Binaire, entier, reel, permutation | Adapter au probleme |\n",
-    "| **Selection** | Roulette, tournoi, rang | Tournoi ($k=3$) par defaut |\n",
+    "| **Encodage** | Binaire, entier, réel, permutation | Adapter au probleme |\n",
+    "| **sélection** | Roulette, tournoi, rang | Tournoi ($k=3$) par defaut |\n",
     "| **Crossover** | 1-point, 2-points, uniforme, PMX | 2-points ou uniforme |\n",
     "| **Mutation** | Bit-flip, swap, gaussienne | Taux $\\approx 1/n$ |\n",
     "| **Elitisme** | $k = 1$ ou $2$ | Toujours activer |\n",
     "\n",
-    "### Comparaison des methodes de selection\n",
+    "### Comparaison des méthodes de sélection\n",
     "\n",
-    "| Methode | Pression | Preservation diversite | Sensibilite aux ecarts |\n",
+    "| méthode | Pression | Preservation diversite | Sensibilite aux ecarts |\n",
     "|---------|----------|----------------------|------------------------|\n",
-    "| **Roulette** | Variable (depend des fitness) | Faible | Tres elevee |\n",
+    "| **Roulette** | Variable (depend des fitness) | Faible | Tres élevée |\n",
     "| **Tournoi** | Controlable via $k$ | Moderee | Faible |\n",
-    "| **Rang** | Fixe (lineaire) | Elevee | Nulle |\n",
+    "| **Rang** | Fixe (lineaire) | élevée | Nulle |\n",
     "\n",
     "### AG vs Recherche locale\n",
     "\n",
-    "| Critere | Recherche locale (Search-4) | Algorithme genetique |\n",
+    "| critère | Recherche locale (Search-4) | Algorithme genetique |\n",
     "|---------|---------------------------|---------------------|\n",
     "| Nombre de solutions | 1 | Population entiere |\n",
     "| Evasion optima locaux | Temperature (SA), memoire (Tabou) | Crossover + diversite |\n",
     "| Parallelisme | Difficile | Naturel |\n",
-    "| Parametres | Peu (temperature, voisinage) | Nombreux (pop, mutation, crossover, selection) |\n",
-    "| Cout par iteration | Faible | Eleve ($\\times$ taille population) |"
+    "| paramètres | Peu (temperature, voisinage) | Nombreux (pop, mutation, crossover, sélection) |\n",
+    "| Cout par iteration | Faible | élevé ($\\times$ taille population) |"
    ]
   },
   {
@@ -2298,7 +2298,7 @@
    "id": "288b77c1",
    "metadata": {},
    "source": [
-    "### Analyse des parametres\n\nEtude de l'impact des parametres (taille population, taux mutation) sur la convergence."
+    "### Analyse des paramètres\n\nEtude de l'impact des paramètres (taille population, taux mutation) sur la convergence."
    ]
   },
   {
@@ -2590,14 +2590,14 @@
     "tags": []
    },
    "source": [
-    "### Exercice 1 : TSP avec selection par tournoi\n",
+    "### Exercice 1 : TSP avec sélection par tournoi\n",
     "\n",
-    "L'exemple resolu 1 utilise PyGAD avec des parametres par defaut. Implementez maintenant un AG **from scratch** pour le TSP en utilisant une selection par tournoi au lieu de la selection par roulette.\n",
+    "L'exemple resolu 1 utilise PyGAD avec des paramètres par defaut. Implementez maintenant un AG **from scratch** pour le TSP en utilisant une sélection par tournoi au lieu de la sélection par roulette.\n",
     "\n",
-    "**Votre mission** : creez un AG simple pour le TSP avec selection par tournoi.\n",
+    "**Votre mission** : creez un AG simple pour le TSP avec sélection par tournoi.\n",
     "\n",
     "**Indices** :\n",
-    "- La selection par tournoi choisit k individus au hasard et garde le meilleur\n",
+    "- La sélection par tournoi choisit k individus au hasard et garde le meilleur\n",
     "- Utilisez l'encodage en permutation (comme l'exemple resolu)\n",
     "- Comparez la qualite de la solution avec celle de PyGAD\n"
    ]
@@ -2909,17 +2909,17 @@
     "tags": []
    },
    "source": [
-    "### Exercice 2 : Modele en iles pour AG\n",
+    "### Exercice 2 : Modèle en iles pour AG\n",
     "\n",
-    "L'exemple resolu 2 compare les operateurs de crossover dans une population unique. Implementez maintenant un **modele en iles** ou plusieurs sous-populations evoluent en parallele et echangent des individus periodiquement (migration).\n",
+    "L'exemple resolu 2 compare les operateurs de crossover dans une population unique. Implementez maintenant un **modèle en iles** ou plusieurs sous-populations evoluent en parallele et echangent des individus periodiquement (migration).\n",
     "\n",
     "**Votre mission** : implementez un AG avec 3 iles qui echangent leurs meilleurs individus.\n",
     "\n",
     "**Indices** :\n",
     "- Chaque ile a sa propre population et evolue independemment\n",
     "- Tous les `migration_interval` generations, echanger les `n_migrants` meilleurs\n",
-    "- Utilisez le meme probleme TSP que l'exemple resolu 1\n",
-    "- Comparez la convergence avec une population unique de meme taille totale\n"
+    "- Utilisez le même probleme TSP que l'exemple resolu 1\n",
+    "- Comparez la convergence avec une population unique de même taille totale\n"
    ]
   },
   {
@@ -3159,8 +3159,8 @@
     "| **Adaptatif** | 0.10 | 0.001 | Exploration forte puis affinage |\n",
     "\n",
     "**Points cles** :\n",
-    "1. Le taux adaptatif explore plus largement au debut (taux eleve) puis affine la solution (taux faible)\n",
-    "2. La strategie adaptative est souvent superieure sur les problemes complexes avec de nombreux optima locaux\n",
+    "1. Le taux adaptatif explore plus largement au debut (taux élevé) puis affine la solution (taux faible)\n",
+    "2. La strategie adaptative est souvent supérieure sur les problemes complexes avec de nombreux optima locaux\n",
     "3. D'autres strategies existent : taux adaptatif base sur la diversite de la population, ou sur le taux d'amelioration"
    ]
   },
@@ -3178,7 +3178,7 @@
     "tags": []
    },
    "source": [
-    "### Exercice 3 : AG steady-state avec selection par rang\n",
+    "### Exercice 3 : AG steady-state avec sélection par rang\n",
     "\n",
     "**Enonce** : implementez un algorithme genetique **steady-state** (remplacement individuel) et comparez-le a l'AG generationnel vu precedemment.\n",
     "\n",
@@ -3186,7 +3186,7 @@
     "\n",
     "**Consignes** :\n",
     "1. Implementez la classe `SteadyStateGA` qui herite de `SimpleGA` (defini dans la section 3)\n",
-    "2. Utilisez la **selection par rang** (`rank_selection`, definie en section 2.2) pour choisir les parents\n",
+    "2. Utilisez la **sélection par rang** (`rank_selection`, definie en section 2.2) pour choisir les parents\n",
     "3. A chaque iteration : selectionnez 2 parents, croisez-les, mutez les enfants, et remplacez les 2 pires individus de la population\n",
     "4. Tracez la courbe de convergence et comparez avec l'AG generationnel (tournoi) sur OneMax (n=100)\n",
     "5. Executez 5 runs pour chaque variante et tracez les courbes moyennes\n",
@@ -3318,12 +3318,40 @@
     },
     "tags": []
    },
-   "source": "---\n\n## Recapitulatif\n\n### Ce qu'il faut retenir\n\n1. Les **algorithmes genetiques** sont des metaheuristiques a base de population, inspirees de l'evolution\n2. Le cycle AG comprend : evaluation, selection, crossover, mutation\n3. Le **choix de l'encodage** est la decision la plus importante (binaire, reel, permutation)\n4. La **pression de selection** controle le compromis exploration/exploitation\n5. L'**elitisme** garantit la monotonie du meilleur fitness\n6. Les frameworks **DEAP** et **PyGAD** simplifient l'implementation\n\n### Pour aller plus loin\n\n- **Notebook suivant** : [CSP-1-Fondamentaux](../Part2-CSP/CSP-1-Fundamentals.ipynb) - Problemes de satisfaction de contraintes\n- **Applications** : [App-9 Edge Detection](../Applications/Hybrid/App-9-EdgeDetection.ipynb), [App-10 Portfolio](../Applications/Hybrid/App-10-Portfolio.ipynb)\n- **References** :\n  - Goldberg, D. *Genetic Algorithms in Search, Optimization, and Machine Learning*, 1989\n  - DEAP documentation : https://deap.readthedocs.io/\n  - PyGAD documentation : https://pygad.readthedocs.io/"
+   "source": [
+    "---",
+    "",
+    "## Recapitulatif",
+    "",
+    "### Ce qu'il faut retenir",
+    "",
+    "1. Les **algorithmes genetiques** sont des metaheuristiques a base de population, inspirees de l'evolution",
+    "2. Le cycle AG comprend : évaluation, sélection, crossover, mutation",
+    "3. Le **choix de l'encodage** est la decision la plus importante (binaire, réel, permutation)",
+    "4. La **pression de sélection** controle le compromis exploration/exploitation",
+    "5. L'**elitisme** garantit la monotonie du meilleur fitness",
+    "6. Les frameworks **DEAP** et **PyGAD** simplifient l'implementation",
+    "",
+    "### Pour aller plus loin",
+    "",
+    "- **Notebook suivant** : [CSP-1-Fondamentaux](../Part2-CSP/CSP-1-Fundamentals.ipynb) - Problemes de satisfaction de contraintes",
+    "- **Applications** : [App-9 Edge Detection](../Applications/Hybrid/App-9-EdgeDetection.ipynb), [App-10 Portfolio](../Applications/Hybrid/App-10-Portfolio.ipynb)",
+    "- **références** :",
+    "  - Goldberg, D. *Genetic Algorithms in Search, Optimization, and Machine Learning*, 1989",
+    "  - DEAP documentation : https://deap.readthedocs.io/",
+    "  - PyGAD documentation : https://pygad.readthedocs.io/"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "d147220a",
-   "source": "## Conclusion et perspectives\n\nCe notebook a couvert le cycle complet d'un algorithme genetique -- encodage du chromosome, selection (roulette, tournoi, rang), crossover (1-point, 2-points, uniforme, PMX), mutation et evaluation du fitness -- en partant d'une implementation from scratch sur OneMax puis en montant en gamme avec DEAP ( OneMax, TSP permutation) et PyGAD (Rastrigin 5D continu). L'etude parametrique a montre que la taille de population, le taux de mutation et l'elitisme sont des leviers determinants pour equilibrer exploration et exploitation.\n\nLes AG ouvrent sur deux directions : les **metaheuristiques avancees** (memetic algorithms, NSGA-II multi-objectif, CMA-ES) et les **applications concretes** dans la serie Search (filtrage de convolution en vision, optimisation de portefeuille en finance). Les concepts de population, de pression de selection et de diversite genetique se retrouveront dans les notebooks suivants sur les algorithmes de colonies de fourmis et les methodes d'essaim particulaire.",
+   "source": [
+    "## Conclusion et perspectives",
+    "",
+    "Ce notebook a couvert le cycle complet d'un algorithme genetique -- encodage du chromosome, sélection (roulette, tournoi, rang), crossover (1-point, 2-points, uniforme, PMX), mutation et évaluation du fitness -- en partant d'une implementation from scratch sur OneMax puis en montant en gamme avec DEAP ( OneMax, TSP permutation) et PyGAD (Rastrigin 5D continu). L'etude parametrique a montre que la taille de population, le taux de mutation et l'elitisme sont des leviers determinants pour equilibrer exploration et exploitation.",
+    "",
+    "Les AG ouvrent sur deux directions : les **metaheuristiques avancees** (memetic algorithms, NSGA-II multi-objectif, CMA-ES) et les **applications concretes** dans la serie Search (filtrage de convolution en vision, optimisation de portefeuille en finance). Les concepts de population, de pression de sélection et de diversite genetique se retrouveront dans les notebooks suivants sur les algorithmes de colonies de fourmis et les méthodes d'essaim particulaire."
+   ],
    "metadata": {}
   },
   {
@@ -3408,7 +3436,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 12. Comparaison quantitative GA vs solveurs exacts sur TSP (Prong B #3801)\n\nL'exemple resolu 1 (cellule 51) a execute l'algorithme genetique (GA) sur le **probleme du voyageur de commerce (TSP)** avec **8 villes**, obtenant une distance totale de **28.73** (route optimale par coIncidence, le GA trouve l'optimum sur ce petit exemple). Pour positionner la famille des **algorithmes genetiques** face aux **solveurs exacts** sur le meme probleme, voici une **comparaison quantitative** avec les chiffres REELS publies dans la cellule 51 (GA, PyGAD) et une nouvelle cellule de calcul exact (brute force exhaustif O(n!), limite aux petites instances).\n\n### Tableau comparatif (chiffres verifies, sources citees)\n\n| Solveur | TSP 8 villes | TSP 9 villes | TSP 10 villes | Garantie optimalite |\n|---------|--------------|--------------|---------------|---------------------|\n| **Algorithme Genetique** (`ga_tsp`, cell 51 + NEW) | 28.73, 1164 ms | 31.66, 1308 ms | 42.11, 1354 ms | Non (heuristique, depend seed) |\n| **Brute force exact** (NEW, Held-Karp DP / O(n!)) | 28.73, 9 ms | 31.66, 92 ms | 36.99, 1008 ms | Oui (exhaustif) |\n| **Gap GA / Exact** (cellule NEW) | 1.00x (optimal trouve) | 1.00x (optimal trouve) | **~1.14x (sous-optimal)** | -- |\n\n### Observations (Prong B illustre)\n\n1. **Sur petites instances (8-9 villes), le GA trouve l'optimum** par chance combinatoire : l'espace de recherche reste suffisamment petit pour que la recherche genetique converge vers la solution exacte. C'est un **cas degeneré** ou la discrimination GA/exact est invisible.\n2. **A 10 villes, le GA commence a degrader** : gap de 14% (42.11 vs 36.99) = demonstration quantitative de l'inadequation progressive du GA quand l'espace de recherche grandit exponentiellement. Le brute force exact O(n!) reste faisable (1 sec) et trouve l'optimum.\n3. **Garantie d'optimalite** : le brute force est **complet** (visite tous les chemins), le GA est **heuristique** (depend de la population initiale, du seed, des operateurs). Pour des applications critiques (logistique, circuits imprimes, planification de tournees), un solveur exact ou une heuristique de plus haute qualite (LKH, OR-Tools) est preferable.\n4. **Valeur pedagogique du GA** : illustre la **famille des methodes evolutionnistes** (population + selection + variation) applicable quand l'espace est trop grand pour l'exhaustif (TSP > 15-20 villes, O(n!) ou O(2^n n^2) intractable). Le GA brille sur des problemes ou une **bonne solution rapide** suffit (temps reel, approximative search).\n\n> **Note methodologique** : tous les chiffres GA cites proviennent de la cellule 51 (PyGAD, seed=42, pop=100, generations=300) ou de la nouvelle cellule ci-dessous. Le brute force est execute en Python pur sur les memes coordonnees de villes (8 premieres + 1, 2, 3 villes ajoutees pour 9 et 10). Aucune valeur fabriquee.\n"
+    "## 12. Comparaison quantitative GA vs solveurs exacts sur TSP (Prong B #3801)\n\nL'exemple resolu 1 (cellule 51) a execute l'algorithme genetique (GA) sur le **probleme du voyageur de commerce (TSP)** avec **8 villes**, obtenant une distance totale de **28.73** (route optimale par coIncidence, le GA trouve l'optimum sur ce petit exemple). Pour positionner la famille des **algorithmes genetiques** face aux **solveurs exacts** sur le même probleme, voici une **comparaison quantitative** avec les chiffres REELS publies dans la cellule 51 (GA, PyGAD) et une nouvelle cellule de calcul exact (brute force exhaustif O(n!), limite aux petites instances).\n\n### Tableau comparatif (chiffres verifies, sources citees)\n\n| Solveur | TSP 8 villes | TSP 9 villes | TSP 10 villes | Garantie optimalite |\n|---------|--------------|--------------|---------------|---------------------|\n| **Algorithme Genetique** (`ga_tsp`, cell 51 + NEW) | 28.73, 1164 ms | 31.66, 1308 ms | 42.11, 1354 ms | Non (heuristique, depend seed) |\n| **Brute force exact** (NEW, Held-Karp DP / O(n!)) | 28.73, 9 ms | 31.66, 92 ms | 36.99, 1008 ms | Oui (exhaustif) |\n| **Gap GA / Exact** (cellule NEW) | 1.00x (optimal trouve) | 1.00x (optimal trouve) | **~1.14x (sous-optimal)** | -- |\n\n### Observations (Prong B illustre)\n\n1. **Sur petites instances (8-9 villes), le GA trouve l'optimum** par chance combinatoire : l'espace de recherche reste suffisamment petit pour que la recherche genetique converge vers la solution exacte. C'est un **cas degeneré** ou la discrimination GA/exact est invisible.\n2. **A 10 villes, le GA commence a degrader** : gap de 14% (42.11 vs 36.99) = demonstration quantitative de l'inadequation progressive du GA quand l'espace de recherche grandit exponentiellement. Le brute force exact O(n!) reste faisable (1 sec) et trouve l'optimum.\n3. **Garantie d'optimalite** : le brute force est **complet** (visite tous les chemins), le GA est **heuristique** (depend de la population initiale, du seed, des operateurs). Pour des applications critiques (logistique, circuits imprimes, planification de tournees), un solveur exact ou une heuristique de plus haute qualite (LKH, OR-Tools) est preferable.\n4. **Valeur pedagogique du GA** : illustre la **famille des méthodes evolutionnistes** (population + sélection + variation) applicable quand l'espace est trop grand pour l'exhaustif (TSP > 15-20 villes, O(n!) ou O(2^n n^2) intractable). Le GA brille sur des problemes ou une **bonne solution rapide** suffit (temps réel, approximative search).\n\n> **Note methodologique** : tous les chiffres GA cites proviennent de la cellule 51 (PyGAD, seed=42, pop=100, generations=300) ou de la nouvelle cellule ci-dessous. Le brute force est execute en Python pur sur les mêmes coordonnees de villes (8 premières + 1, 2, 3 villes ajoutees pour 9 et 10). Aucune valeur fabriquee.\n"
    ],
    "id": "cell-8cbc45fa"
   },
@@ -3432,7 +3460,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Exercice : Estimer le ratio GA / solveur-exact (Prong B reflexif)\n\n### Contexte\n\nLe tableau ci-dessus compare l'algorithme genetique (heuristique, ~1.1-1.4 sec) au brute force exact (solveur exhaustif, 9-1008 ms) sur 3 instances TSP de 8, 9 et 10 villes. Pour faire toucher du doigt le **ratio de cout** et sa **non-linearite avec la taille de l'instance**, on veut le chiffrer.\n\n### Enonce\n\nA partir des **chiffres reels** du tableau comparatif (cellule precedente) :\n\n1. Calculer le ratio `temps_GA / temps_exact` pour chacune des 3 instances (8, 9, 10 villes).\n2. Calculer le ratio `qualite_GA / qualite_exact` (gap) : observe-t-on une degradation lineaire, polynomiale ou autre ?\n3. Conclure sur la **position du GA dans la hierarchie** : efficace / equivalente / nettement inferieure / sans commune mesure, sur le cas TSP.\n\n### Indication\n\n- `ratio_runtime_X = t_ga_X_ms / t_exact_X_ms`\n- `gap_X = dist_ga_X / dist_exact_X` (1.0 = optimal, >1.0 = sous-optimal)\n- Si `gap_10 / gap_8 > 1.10`, on a une **degradation visible** -> methode inadaptee au scaling\n- Suggestion : `conclude_prong_b(runtime_ratios, gaps)` retourne une categorie parmi `\"lineaire\"`, `\"polynomial\"`, `\"exponentiel\"`, `\"autre\"`\n\n### Solution (a completer par l'etudiant)\n\n```\nratio_runtime_8  = None  # TODO etudiant\nratio_runtime_9  = None  # TODO etudiant\nratio_runtime_10 = None  # TODO etudiant\ngap_8, gap_9, gap_10 = None, None, None  # TODO etudiant\nconclusion = None  # TODO etudiant\n```\n"
+    "## Exercice : Estimer le ratio GA / solveur-exact (Prong B reflexif)\n\n### Contexte\n\nLe tableau ci-dessus compare l'algorithme genetique (heuristique, ~1.1-1.4 sec) au brute force exact (solveur exhaustif, 9-1008 ms) sur 3 instances TSP de 8, 9 et 10 villes. Pour faire toucher du doigt le **ratio de cout** et sa **non-linearite avec la taille de l'instance**, on veut le chiffrer.\n\n### Enonce\n\nA partir des **chiffres reels** du tableau comparatif (cellule precedente) :\n\n1. Calculer le ratio `temps_GA / temps_exact` pour chacune des 3 instances (8, 9, 10 villes).\n2. Calculer le ratio `qualite_GA / qualite_exact` (gap) : observe-t-on une degradation lineaire, polynomiale ou autre ?\n3. Conclure sur la **position du GA dans la hierarchie** : efficace / equivalente / nettement inférieure / sans commune mesure, sur le cas TSP.\n\n### Indication\n\n- `ratio_runtime_X = t_ga_X_ms / t_exact_X_ms`\n- `gap_X = dist_ga_X / dist_exact_X` (1.0 = optimal, >1.0 = sous-optimal)\n- Si `gap_10 / gap_8 > 1.10`, on a une **degradation visible** -> méthode inadaptee au scaling\n- Suggestion : `conclude_prong_b(runtime_ratios, gaps)` retourne une categorie parmi `\"lineaire\"`, `\"polynomial\"`, `\"exponentiel\"`, `\"autre\"`\n\n### Solution (a completer par l'etudiant)\n\n```\nratio_runtime_8  = None  # TODO etudiant\nratio_runtime_9  = None  # TODO etudiant\nratio_runtime_10 = None  # TODO etudiant\ngap_8, gap_9, gap_10 = None, None, None  # TODO etudiant\nconclusion = None  # TODO etudiant\n```\n"
    ],
    "id": "cell-5cf504d4"
   },
@@ -3454,7 +3482,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### References citees dans la section 12 (chiffres verifies)\n\n- `MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms.ipynb` (cell 51 — exemple resolu TSP 8 villes, GA via PyGAD)\n- `MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms.ipynb` (NEW — brute force exact + GA replicate pour 9 et 10 villes)\n\n### Liens transverses (autres solveurs pour Prong B)\n\n- `MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming.ipynb` (LP relaxation + branch-and-bound)\n- `MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics.ipynb` (MEALPy : PSO, ABC, SA, BRO)\n- `MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals.ipynb` (CSP/OR-Tools Choco)\n\n> **Note pedagogique** : les ratios GA/exact (gap 1.0x a 8-9 villes puis 1.14x a 10 villes) demontrent que **l'algorithme genetique devient sous-optimal quand l'espace de recherche grandit**, malgre sa richesse theorique. Cf. Section 7 de `Sudoku-3-Genetic-Python.ipynb` (ratio GA/OR-Tools ~700x sur Easy) et Section 11 de `Sudoku-4-SimulatedAnnealing-Python.ipynb` (ratio SA/Backtracking ~24 154x sur Easy) pour des demonstrations equivalentes sur d'autres solveurs heuristiques vs exacts.\n"
+    "### Références citees dans la section 12 (chiffres verifies)\n\n- `MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms.ipynb` (cell 51 — exemple resolu TSP 8 villes, GA via PyGAD)\n- `MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms.ipynb` (NEW — brute force exact + GA replicate pour 9 et 10 villes)\n\n### Liens transverses (autres solveurs pour Prong B)\n\n- `MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming.ipynb` (LP relaxation + branch-and-bound)\n- `MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics.ipynb` (MEALPy : PSO, ABC, SA, BRO)\n- `MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals.ipynb` (CSP/OR-Tools Choco)\n\n> **Note pedagogique** : les ratios GA/exact (gap 1.0x a 8-9 villes puis 1.14x a 10 villes) demontrent que **l'algorithme genetique devient sous-optimal quand l'espace de recherche grandit**, malgre sa richesse theorique. Cf. Section 7 de `Sudoku-3-Genetic-Python.ipynb` (ratio GA/OR-Tools ~700x sur Easy) et Section 11 de `Sudoku-4-SimulatedAnnealing-Python.ipynb` (ratio SA/Backtracking ~24 154x sur Easy) pour des demonstrations equivalentes sur d'autres solveurs heuristiques vs exacts.\n"
    ],
    "id": "cell-4d2aa687"
   }


### PR DESCRIPTION
## Summary

Restore French accents in markdown source cells of `MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms.ipynb` (suite #7126 #7127 ; 3ème étape de la vague c.594-c.595-c.596 cross-famille ML→GenAI/Audio→Search/Part1).

## Metrics

- 95 cures appliquées sur 27 cellules markdown
- 1 file / 1 domain / 1 feature (R3 atomicité)
- R6 anti-monotonie : Search/Part1 après ML-4 (c.594) et GenAI/Audio (c.595)
- +100/-72 (multiline cells = JSON source-array string regroupé) ; sur le contenu, c'est 95 cures unilignes

## Stop & Repair strict (HARD, règle 6 secrets-hygiene.md)

- 0 code cell source diff
- 0 outputs diff
- 0 execution_count diff
- 0 cell added/removed (76 cells préservées)
- nbformat 4.5 préservé

## Bug fix inclus (pre-commit)

Deux **faux positifs** détectés en audit diff :

- `il determine comment une solution est...` → script → `il déterminé comment...` (FAUX, past-participle)
- `La selection determine quels individus...` → script → `La sélectionné quels...` (FAUX, idem)

Cause : `determine` dans TARGETS list mappé vers `déterminé` (participe passé) au lieu de `détermine` (présent 3ᵉ pers. sing.). Avant commit : revert localisé via `scratchpad/fix_false_positives.py` vers `détermine` (forme correcte du verbe conjugué).

## Lessons

- Le script TARGETS list est non-contextuel : pour les verbes conjugués, l'ambiguïté passé/présent nécessite une désambiguïsation manuelle.
- **Leçon c.596 ★** : avant commit d'un PR d'accents, **grep -nE 'déterminé|géenéré|prédite|prédits|detectee|detectes'** dans le diff pour valider la cohérence grammaticale (sujet/verbe conjugué).

See #2876