### PR TITLE
fix(symbolicai,#2876): restore French accents in SW-3b-Python-GraphOperations

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb
@@ -233,7 +233,7 @@
     "    g2.parse(data=b'<http://example.org/a> <http://example.org/b> <http://example.org/c> .', format=\"turtle\")\n",
     "    print(f\"Format explicite (ttl) : {len(g2)} triplet\")\n",
     "else:\n",
-    "    print(\"rdflib non disponible : parsing chaîne ignore.\")"
+    "    print(\"rdflib non disponible : parsing chaine ignore.\")"
    ]
   },
   {
@@ -253,9 +253,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "animals.ttl : 51 triplets (comptes après chargement en memoire)\n",
+      "animals.ttl : 51 triplets (comptes apres chargement en memoire)\n",
       "Note : rdflib n'expose pas de Handler haut-niveau equivalent a CountHandler.\n",
-      "       Pour les très gros fichiers, voir rdflib.parser.Parser + sink custom.\n"
+      "       Pour les tres gros fichiers, voir rdflib.parser.Parser + sink custom.\n"
      ]
     }
    ],
@@ -267,13 +267,13 @@
     "if RDFLIB_AVAILABLE:\n",
     "    g_animals = Graph()\n",
     "    g_animals.parse(\"data/animals.ttl\", format=\"turtle\")\n",
-    "    print(f\"animals.ttl : {len(g_animals)} triplets (comptes après chargement en memoire)\")\n",
+    "    print(f\"animals.ttl : {len(g_animals)} triplets (comptes apres chargement en memoire)\")\n",
     "\n",
     "    # Equivalent \"flux sans graphe\" : on peut iterer sur un Parser brut avec un sink,\n",
     "    # mais l'API est bas-niveau et rarement utilisee en pratique.\n",
     "    from rdflib.parser import Parser\n",
     "    print(\"Note : rdflib n'expose pas de Handler haut-niveau equivalent a CountHandler.\")\n",
-    "    print(\"       Pour les très gros fichiers, voir rdflib.parser.Parser + sink custom.\")\n",
+    "    print(\"       Pour les tres gros fichiers, voir rdflib.parser.Parser + sink custom.\")\n",
     "else:\n",
     "    print(\"rdflib non disponible : comptage ignore.\")"
    ]
@@ -327,10 +327,10 @@
      "output_type": "stream",
      "text": [
       "=== N-Triples ===\n",
+      "_:nb41b3af932154cea84c8b1211f1ea0c5b1 <http://example.org/stuff/1.0/fullname> \"Dave Beckett\" .\n",
+      "_:nb41b3af932154cea84c8b1211f1ea0c5b1 <http://example.org/stuff/1.0/homePage> <http://purl.org/net/dajobe/> .\n",
       "<http://www.w3.org/TR/rdf-syntax-grammar> <http://purl.org/dc/elements/1.1/title> \"RDF/XML Syntax Specification (Revised)\" .\n",
-      "_:n635f961a937e4b4193eeae2daaf4293db1 <http://example.org/stuff/1.0/fullname> \"Dave Beckett\" .\n",
-      "_:n635f961a937e4b4193eeae2daaf4293db1 <http://example.org/stuff/1.0/homePage> <http://purl.org/net/dajobe/> .\n",
-      "<http://www.w3.org/TR/rdf-syntax-grammar> <http://example.org/stuff/1.0/editor> _:n635f961a937e4b4193eeae2daaf4293db1 .\n",
+      "<http://www.w3.org/TR/rdf-syntax-grammar> <http://example.org/stuff/1.0/editor> _:nb41b3af932154cea84c8b1211f1ea0c5b1 .\n",
       "\n",
       "=== Turtle ===\n",
       "@prefix dc: <http://purl.org/dc/elements/1.1/> .\n",
@@ -392,8 +392,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Méthode 1 (chaîne)     : 630 car.\n",
-      "Méthode 2 (fichier)    : 630 car.\n",
+      "Methode 1 (chaine)     : 630 car.\n",
+      "Methode 2 (fichier)    : 630 car.\n",
       "Identiques             : True\n",
       "\n",
       "=== RDF/XML (extrait) ===\n",
@@ -403,9 +403,11 @@
       "   xmlns:ex=\"http://example.org/stuff/1.0/\"\n",
       "   xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\"\n",
       ">\n",
-      "  <rdf:Description rdf:about=\"http://www.w3.org/TR/rdf-syntax-grammar\">\n",
-      "    <dc:title>RDF/XML Syntax Specification (Revised)</dc:title>\n",
-      "    <ex:editor rdf:nodeID=\"n635f961a937e4b4193eeae2daaf4293db1\"/...\n"
+      "  <rdf:Description rdf:nodeID=\"nb41b3af932154cea84c8b1211f1ea0c5b1\">\n",
+      "    <ex:fullname>Dave Beckett</ex:fullname>\n",
+      "    <ex:homePage rdf:resource=\"http://purl.org/net/dajobe/\"/>\n",
+      "  </rdf:Description>\n",
+      "  <r...\n"
      ]
     }
    ],
@@ -422,8 +424,8 @@
     "    with open(tmp, \"r\", encoding=\"utf-8\") as f:\n",
     "        xml_from_file = f.read()\n",
     "\n",
-    "    print(f\"Méthode 1 (chaîne)     : {len(xml_str)} car.\")\n",
-    "    print(f\"Méthode 2 (fichier)    : {len(xml_from_file)} car.\")\n",
+    "    print(f\"Methode 1 (chaine)     : {len(xml_str)} car.\")\n",
+    "    print(f\"Methode 2 (fichier)    : {len(xml_from_file)} car.\")\n",
     "    print(f\"Identiques             : {xml_str == xml_from_file}\")\n",
     "    print(f\"\\n=== RDF/XML (extrait) ===\\n{xml_str[:400]}...\")\n",
     "else:\n",
@@ -470,7 +472,7 @@
       "    \"@id\": \"http://www.w3.org/TR/rdf-syntax-grammar\",\n",
       "    \"http://example.org/stuff/1.0/editor\": [\n",
       "      {\n",
-      "        \"@id\": \"_:n635f961a937e4b4193eeae2daaf4293db1\"\n",
+      "        \"@id\": \"_:nb41b3af932154cea84c8b1211f1ea0c5b1\"\n",
       "      }\n",
       "    ],\n",
       "    \"http://purl.org/dc/elements/1.1/title\": [\n",
@@ -480,7 +482,7 @@
       "    ]\n",
       "  },\n",
       "  {\n",
-      "    \"@id\": \"_:n635f961a937e4b4193eeae2daaf4293db1\",\n",
+      "    \"@id\": \"_:nb41b3af932154cea84c8b1211f1ea0c5b1\",\n",
       "    \"http://example.org/stuff/1.0/fullname\": [\n",
       "      {\n",
       "        \"@value\": \"Dave Beckett\"\n",
@@ -560,7 +562,7 @@
      "text": [
       "Graphe 1 (Example.ttl) : 4 triplets\n",
       "Graphe 2 (animals.ttl) : 51 triplets\n",
-      "Après fusion (+=)      : 55 triplets (somme théorique: 55)\n",
+      "Apres fusion (+=)      : 55 triplets (somme theorique: 55)\n",
       "Doublons supprimes     : 0\n",
       "\n",
       "Operateur | (new graph): 55 triplets (sources intactes: 4, 51)\n"
@@ -581,7 +583,7 @@
     "\n",
     "    # Operateur += : union en place (equivalent de g1.Merge(g2) en dotNetRDF)\n",
     "    g1 += g2\n",
-    "    print(f\"Après fusion (+=)      : {len(g1)} triplets (somme théorique: {somme})\")\n",
+    "    print(f\"Apres fusion (+=)      : {len(g1)} triplets (somme theorique: {somme})\")\n",
     "    print(f\"Doublons supprimes     : {somme - len(g1)}\")\n",
     "\n",
     "    # Variante : operateur | retourne un NOUVEAU graphe (non destructif)\n",
@@ -689,7 +691,7 @@
     "    for s, p, o in g.triples((rex, None, None)):\n",
     "        print(f\"  {p.n3(g.namespace_manager)} -> {o.n3(g.namespace_manager)}\")\n",
     "else:\n",
-    "    print(\"rdflib non disponible : sélection ignoree.\")"
+    "    print(\"rdflib non disponible : selection ignoree.\")"
    ]
   },
   {
@@ -760,7 +762,7 @@
     "    print(f\"\\n=== Animal le plus age ===\")\n",
     "    print(f\"  {oldest[0].n3(g.namespace_manager)} : {oldest[1]} ans\")\n",
     "else:\n",
-    "    print(\"rdflib non disponible : sélection combinee ignoree.\")"
+    "    print(\"rdflib non disponible : selection combinee ignoree.\")"
    ]
   },
   {
@@ -900,8 +902,8 @@
      "output_type": "stream",
      "text": [
       "Avant           : [1, 2, 3]\n",
-      "Après append    : [1, 2, 3, 4, 5]\n",
-      "Après del '3'   : [1, 2, 4, 5]\n"
+      "Apres append    : [1, 2, 3, 4, 5]\n",
+      "Apres del '3'   : [1, 2, 4, 5]\n"
      ]
     }
    ],
@@ -920,14 +922,14 @@
     "    # append = AddToList equivalent (ajoute en fin de liste)\n",
     "    col2.append(Literal(4))\n",
     "    col2.append(Literal(5))\n",
-    "    print(f\"Après append    : {fmt(col2)}\")\n",
+    "    print(f\"Apres append    : {fmt(col2)}\")\n",
     "\n",
     "    # suppression par valeur : trouver l'index puis del (rdflib n'expose pas .remove(value))\n",
     "    target = Literal(3)\n",
     "    items = list(col2)\n",
     "    if target in items:\n",
     "        del col2[items.index(target)]\n",
-    "    print(f\"Après del '3'   : {fmt(col2)}\")\n",
+    "    print(f\"Apres del '3'   : {fmt(col2)}\")\n",
     "else:\n",
     "    print(\"rdflib non disponible : ajout/suppression ignores.\")"
    ]
@@ -968,9 +970,9 @@
      "output_type": "stream",
      "text": [
       "Initial           : [Alice, Bob, Charlie]\n",
-      "Après ajout Diana : [Alice, Bob, Charlie, Diana]\n",
-      "Après del Bob     : [Alice, Charlie, Diana]\n",
-      "Après clear()     : [] | triplets 6 -> 0\n"
+      "Apres ajout Diana : [Alice, Bob, Charlie, Diana]\n",
+      "Apres del Bob     : [Alice, Charlie, Diana]\n",
+      "Apres clear()     : [] | triplets 6 -> 0\n"
      ]
     }
    ],
@@ -988,17 +990,17 @@
     "\n",
     "    # Ajout\n",
     "    col3.append(Literal(\"Diana\"))\n",
-    "    print(f\"Après ajout Diana : {fmt(col3)}\")\n",
+    "    print(f\"Apres ajout Diana : {fmt(col3)}\")\n",
     "\n",
     "    # Suppression par valeur (index lookup)\n",
     "    items = list(col3)\n",
     "    del col3[items.index(Literal(\"Bob\"))]\n",
-    "    print(f\"Après del Bob     : {fmt(col3)}\")\n",
+    "    print(f\"Apres del Bob     : {fmt(col3)}\")\n",
     "\n",
     "    # RetractList equivalent : clear() detruit tous les triplets de la liste\n",
     "    avant = len(g3)\n",
     "    col3.clear()\n",
-    "    print(f\"Après clear()     : {fmt(col3)} | triplets {avant} -> {len(g3)}\")\n",
+    "    print(f\"Apres clear()     : {fmt(col3)} | triplets {avant} -> {len(g3)}\")\n",
     "else:\n",
     "    print(\"rdflib non disponible : cycle complet ignore.\")"
    ]
@@ -1211,7 +1213,7 @@
      "output_type": "stream",
      "text": [
       "Avant fusion - g1: 4, g2: 51\n",
-      "Après fusion : 55 triplets\n",
+      "Apres fusion : 55 triplets\n",
       "@prefix dc: <http://purl.org/dc/elements/1.1/> .\n",
       "@prefix ex: <http://example.org/stuff/1.0/> .\n",
       "@prefix ns1: <http://example.org/animals#> .\n",
@@ -1304,7 +1306,7 @@
     "    # Union : les triplets identiques ne sont pas dupliques (semantique d'ensemble RDF)\n",
     "    # Les blank nodes sont isoles par graphe (pas de collision)\n",
     "    g1 += g2\n",
-    "    print(f\"Après fusion : {len(g1)} triplets\")\n",
+    "    print(f\"Apres fusion : {len(g1)} triplets\")\n",
     "\n",
     "    result = g1.serialize(format=\"turtle\")\n",
     "    print(result)\n",
@@ -1389,8 +1391,8 @@
      "output_type": "stream",
      "text": [
       "Initial          : [Alice, Bob, Charlie]\n",
-      "Après ajout      : [Alice, Bob, Charlie, Diana]\n",
-      "Après suppression: [Alice, Charlie, Diana]\n"
+      "Apres ajout      : [Alice, Bob, Charlie, Diana]\n",
+      "Apres suppression: [Alice, Charlie, Diana]\n"
      ]
     }
    ],
@@ -1411,12 +1413,12 @@
     "\n",
     "    # append insere \"Diana\" en fin de liste\n",
     "    col.append(Literal(\"Diana\"))\n",
-    "    print(f\"Après ajout      : {fmt(col)}\")\n",
+    "    print(f\"Apres ajout      : {fmt(col)}\")\n",
     "\n",
     "    # suppression par valeur : on cherche l'index puis del col[index]\n",
     "    items = list(col)\n",
     "    del col[items.index(Literal(\"Bob\"))]\n",
-    "    print(f\"Après suppression: {fmt(col)}\")\n",
+    "    print(f\"Apres suppression: {fmt(col)}\")\n",
     "else:\n",
     "    print(\"rdflib non disponible : exemple 3 ignore.\")"
    ]

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb
@@ -9,18 +9,18 @@
     "\n",
     "**Navigation** : [Index](README.md) | [<< SW-3 C#](SW-3-CSharp-GraphOperations.ipynb) | [SW-4b Python >>](SW-4b-Python-SPARQL.ipynb)\n",
     "\n",
-    "## Operations sur les graphes RDF en Python avec rdflib\n",
+    "## Opérations sur les graphes RDF en Python avec rdflib\n",
     "\n",
     "> Ce notebook est le **twin Python** du notebook [SW-3-CSharp-GraphOperations](SW-3-CSharp-GraphOperations.ipynb) (dotNetRDF). Il manipule des **graphes RDF** au moyen de la bibliotheque **rdflib** (open-source, `rdflib.readthedocs.io`), qui implémente le modèle de données abstrait de **RDF 1.1** (Cyganiak, Wood, Lanthaler (eds.), *RDF 1.1 Concepts and Abstract Syntax*, Recommandation W3C, 25 fevrier 2014). Les formats de sérialisation couverts (Turtle, RDF/XML, N-Triples, Notation 3, JSON-LD, TriG, N-Quads) sont tous des sérialisations normalisées de ce modèle abstrait.\n",
     "\n",
     "### Duree estimee : 50 minutes\n",
     "\n",
     "A la fin de ce notebook, vous saurez :\n",
-    "1. **Lire** des fichiers RDF dans differents formats (Turtle, RDF/XML, N-Triples) avec `rdflib`\n",
+    "1. **Lire** des fichiers RDF dans différents formats (Turtle, RDF/XML, N-Triples) avec `rdflib`\n",
     "2. **Ecrire** des graphes RDF vers plusieurs formats via `g.serialize()`\n",
-    "3. **Fusionner** des graphes RDF avec l'operateur `+=` et `|` (semantique d'ensemble)\n",
-    "4. **Selectionner** des triplets selon differents criteres avec `g.triples()` et les accesseurs dedies\n",
-    "5. **Manipuler** des listes RDF (creer, lire, modifier, supprimer) avec `rdflib.collection.Collection`\n",
+    "3. **Fusionner** des graphes RDF avec l'opérateur `+=` et `|` (sémantique d'ensemble)\n",
+    "4. **Sélectionner** des triplets selon différents critères avec `g.triples()` et les accesseurs dedies\n",
+    "5. **Manipuler** des listes RDF (créer, lire, modifier, supprimer) avec `rdflib.collection.Collection`\n",
     "\n",
     "### Prerequis\n",
     "- Python 3.10+\n",
@@ -38,7 +38,7 @@
     "\n",
     "## 0. Installation et Imports\n",
     "\n",
-    "**rdflib** est l'equivalent Python direct de **dotNetRDF**. Elle fournit une API pythonique pour toutes les operations RDF : parsing, serialization, selection, listes."
+    "**rdflib** est l'equivalent Python direct de **dotNetRDF**. Elle fournit une API pythonique pour toutes les opérations RDF : parsing, serialization, sélection, listes."
    ]
   },
   {
@@ -65,7 +65,7 @@
    "source": [
     "### Interpretation\n",
     "\n",
-    "L'option `-q` (quiet) reduit la verbosite de pip. Une fois installe, rdflib expose une API pythonique (tuples Python, iterateurs) pour toutes les operations RDF."
+    "L'option `-q` (quiet) reduit la verbosite de pip. Une fois installe, rdflib expose une API pythonique (tuples Python, iterateurs) pour toutes les opérations RDF."
    ]
   },
   {
@@ -128,7 +128,7 @@
     "| `RDF`, `RDFS`, `XSD` | Namespaces W3C pre-configures | `UriFactory` + `g.NamespaceMap` |\n",
     "| `Collection` | Listes RDF (`rdf:first` / `rdf:rest`) | `VDS.RDF.Extensions.GetListItems` |\n",
     "\n",
-    "> Les noeuds rdflib sont **independants du graphe** (`URIRef(\"...\")` est autonome), contrairement a dotNetRDF ou les noeuds sont cres via `g.CreateUriNode(...)` (lies au graphe)."
+    "> Les noeuds rdflib sont **independants du graphe** (`URIRef(\"...\")` est autonome), contrairement a dotNetRDF ou les noeuds sont créés via `g.CreateUriNode(...)` (lies au graphe)."
    ]
   },
   {
@@ -140,7 +140,7 @@
     "\n",
     "## 1. Lecture de fichiers RDF\n",
     "\n",
-    "La methode centrale de lecture est `Graph.parse()`, qui accepte un chemin de fichier, une URL, un fichier objet ou une chaine. Formats supportes : `turtle`, `xml`, `nt`, `n3`, `json-ld`, `trig`, `nquads`. rdflib detecte automatiquement le format si l'extension du fichier est connue ou si un `format=` explicite est fourni.\n",
+    "La méthode centrale de lecture est `Graph.parse()`, qui accepte un chemin de fichier, une URL, un fichier objet ou une chaîne. Formats supportes : `turtle`, `xml`, `nt`, `n3`, `json-ld`, `trig`, `nquads`. rdflib detecte automatiquement le format si l'extension du fichier est connue ou si un `format=` explicite est fourni.\n",
     "\n",
     "> Chaque format correspond a une Recommandation W3C distincte de la famille **RDF 1.1** : Turtle (Beckett, Berners-Lee, Prud'hommeaux, 2014), N-Triples (Ackaert, Sporny, Kellogg, 2014 - la forme canonique ligne-par-triplet), Notation 3 (Berners-Lee, 2006, note non normative), RDF/XML (Beckett, 2004), JSON-LD (Sporny et al., 2014). TriG et N-Quads etendent ces formats aux *datasets* (graphes nommes)."
    ]
@@ -193,7 +193,7 @@
    "id": "36bde774aa1b",
    "metadata": {},
    "source": [
-    "Les deux methodes sont equivalents. `parse(data=...)` accepte des `bytes`, utile quand les donnees RDF proviennent d'une reponse HTTP ou d'un flux in-memory."
+    "Les deux méthodes sont equivalents. `parse(data=...)` accepte des `bytes`, utile quand les données RDF proviennent d'une reponse HTTP ou d'un flux in-memory."
    ]
   },
   {
@@ -233,7 +233,7 @@
     "    g2.parse(data=b'<http://example.org/a> <http://example.org/b> <http://example.org/c> .', format=\"turtle\")\n",
     "    print(f\"Format explicite (ttl) : {len(g2)} triplet\")\n",
     "else:\n",
-    "    print(\"rdflib non disponible : parsing chaine ignore.\")"
+    "    print(\"rdflib non disponible : parsing chaîne ignore.\")"
    ]
   },
   {
@@ -253,9 +253,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "animals.ttl : 51 triplets (comptes apres chargement en memoire)\n",
+      "animals.ttl : 51 triplets (comptes après chargement en memoire)\n",
       "Note : rdflib n'expose pas de Handler haut-niveau equivalent a CountHandler.\n",
-      "       Pour les tres gros fichiers, voir rdflib.parser.Parser + sink custom.\n"
+      "       Pour les très gros fichiers, voir rdflib.parser.Parser + sink custom.\n"
      ]
     }
    ],
@@ -267,13 +267,13 @@
     "if RDFLIB_AVAILABLE:\n",
     "    g_animals = Graph()\n",
     "    g_animals.parse(\"data/animals.ttl\", format=\"turtle\")\n",
-    "    print(f\"animals.ttl : {len(g_animals)} triplets (comptes apres chargement en memoire)\")\n",
+    "    print(f\"animals.ttl : {len(g_animals)} triplets (comptes après chargement en memoire)\")\n",
     "\n",
     "    # Equivalent \"flux sans graphe\" : on peut iterer sur un Parser brut avec un sink,\n",
     "    # mais l'API est bas-niveau et rarement utilisee en pratique.\n",
     "    from rdflib.parser import Parser\n",
     "    print(\"Note : rdflib n'expose pas de Handler haut-niveau equivalent a CountHandler.\")\n",
-    "    print(\"       Pour les tres gros fichiers, voir rdflib.parser.Parser + sink custom.\")\n",
+    "    print(\"       Pour les très gros fichiers, voir rdflib.parser.Parser + sink custom.\")\n",
     "else:\n",
     "    print(\"rdflib non disponible : comptage ignore.\")"
    ]
@@ -283,18 +283,18 @@
    "id": "1f5b923b30f4",
    "metadata": {},
    "source": [
-    "### Interpretation : Methodes de lecture\n",
+    "### Interpretation : Méthodes de lecture\n",
     "\n",
-    "| Methode rdflib | Avantage | Equivalent dotNetRDF |\n",
+    "| Méthode rdflib | Avantage | Equivalent dotNetRDF |\n",
     "|----------------|----------|----------------------|\n",
     "| `g.parse(\"file.ttl\", format=\"turtle\")` | Format explicite, fiable | `TurtleParser.Load(g, \"file.ttl\")` |\n",
     "| `g.parse(data=bytes, format=\"nt\")` | En memoire, depuis HTTP | `NTriplesParser.Load(g, StringReader(...))` |\n",
     "| `g.parse(\"file.ttl\")` (sans format) | Auto-detection par extension | `StringParser.Parse(g, str)` |\n",
-    "| `len(g)` apres `parse()` | Comptage simple | `CountHandler` (sans chargement) |\n",
+    "| `len(g)` après `parse()` | Comptage simple | `CountHandler` (sans chargement) |\n",
     "\n",
-    "**Difference notable** : dotNetRDF offre une API de **Handlers** (`CountHandler`, `PagingHandler`, `FilterHandler`) qui traitent les triplets en flux SANS construire le graphe en memoire - utile pour les tres gros fichiers. rdflib construit systematiquement le graphe ; pour le streaming massif, il faut descendre a l'API `Parser` + `sink` bas-niveau.\n",
+    "**Différence notable** : dotNetRDF offre une API de **Handlers** (`CountHandler`, `PagingHandler`, `FilterHandler`) qui traitent les triplets en flux SANS construire le graphe en memoire - utile pour les très gros fichiers. rdflib construit systematiquement le graphe ; pour le streaming massif, il faut descendre a l'API `Parser` + `sink` bas-niveau.\n",
     "\n",
-    "> Les `Graph` rdflib sont **reutilisables** et l'operation `parse()` peut etre appelee plusieurs fois (les triplets s'accumulent)."
+    "> Les `Graph` rdflib sont **reutilisables** et l'opération `parse()` peut etre appelee plusieurs fois (les triplets s'accumulent)."
    ]
   },
   {
@@ -306,7 +306,7 @@
     "\n",
     "## 2. Ecriture de graphes RDF\n",
     "\n",
-    "La methode centrale de serialization est `Graph.serialize(format=...)` qui retourne une chaine. Pour ecrire directement dans un fichier, utiliser `g.serialize(destination=\"file.ttl\", format=...)`. Formats : `turtle`, `nt`, `xml`, `json-ld`, `n3`, `trig`, `nquads`."
+    "La méthode centrale de serialization est `Graph.serialize(format=...)` qui retourne une chaîne. Pour ecrire directement dans un fichier, utiliser `g.serialize(destination=\"file.ttl\", format=...)`. Formats : `turtle`, `nt`, `xml`, `json-ld`, `n3`, `trig`, `nquads`."
    ]
   },
   {
@@ -327,10 +327,10 @@
      "output_type": "stream",
      "text": [
       "=== N-Triples ===\n",
-      "_:n2a84ade8f61549d8b1596d698048a888b1 <http://example.org/stuff/1.0/homePage> <http://purl.org/net/dajobe/> .\n",
-      "_:n2a84ade8f61549d8b1596d698048a888b1 <http://example.org/stuff/1.0/fullname> \"Dave Beckett\" .\n",
       "<http://www.w3.org/TR/rdf-syntax-grammar> <http://purl.org/dc/elements/1.1/title> \"RDF/XML Syntax Specification (Revised)\" .\n",
-      "<http://www.w3.org/TR/rdf-syntax-grammar> <http://example.org/stuff/1.0/editor> _:n2a84ade8f61549d8b1596d698048a888b1 .\n",
+      "_:n635f961a937e4b4193eeae2daaf4293db1 <http://example.org/stuff/1.0/fullname> \"Dave Beckett\" .\n",
+      "_:n635f961a937e4b4193eeae2daaf4293db1 <http://example.org/stuff/1.0/homePage> <http://purl.org/net/dajobe/> .\n",
+      "<http://www.w3.org/TR/rdf-syntax-grammar> <http://example.org/stuff/1.0/editor> _:n635f961a937e4b4193eeae2daaf4293db1 .\n",
       "\n",
       "=== Turtle ===\n",
       "@prefix dc: <http://purl.org/dc/elements/1.1/> .\n",
@@ -370,7 +370,7 @@
     "\n",
     "**N-Triples** : format verbeux - chaque triplet occupe une ligne complete avec les URIs en entier. 4 triplets = 4 lignes. Pas de prefixe, pas de compression.\n",
     "\n",
-    "**Turtle** : format compact - les prefixes sont definis une fois (`@prefix`), les noeuds blancs sont regroupes avec `;` (meme sujet) et les proprietes sont imbriquees avec `[...]`. Le meme graphe tient en moins de lignes.\n",
+    "**Turtle** : format compact - les prefixes sont définis une fois (`@prefix`), les noeuds blancs sont regroupes avec `;` (même sujet) et les proprietes sont imbriquees avec `[...]`. Le même graphe tient en moins de lignes.\n",
     "\n",
     "Le ratio de compression est ici d'environ 2:1 (N-Triples plus long que Turtle). Sur des graphes plus grands avec beaucoup de prefixes, le gain peut atteindre 5:1 ou plus."
    ]
@@ -392,8 +392,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Methode 1 (chaine)     : 630 car.\n",
-      "Methode 2 (fichier)    : 630 car.\n",
+      "Méthode 1 (chaîne)     : 630 car.\n",
+      "Méthode 2 (fichier)    : 630 car.\n",
       "Identiques             : True\n",
       "\n",
       "=== RDF/XML (extrait) ===\n",
@@ -403,11 +403,9 @@
       "   xmlns:ex=\"http://example.org/stuff/1.0/\"\n",
       "   xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\"\n",
       ">\n",
-      "  <rdf:Description rdf:nodeID=\"n2a84ade8f61549d8b1596d698048a888b1\">\n",
-      "    <ex:fullname>Dave Beckett</ex:fullname>\n",
-      "    <ex:homePage rdf:resource=\"http://purl.org/net/dajobe/\"/>\n",
-      "  </rdf:Description>\n",
-      "  <r...\n"
+      "  <rdf:Description rdf:about=\"http://www.w3.org/TR/rdf-syntax-grammar\">\n",
+      "    <dc:title>RDF/XML Syntax Specification (Revised)</dc:title>\n",
+      "    <ex:editor rdf:nodeID=\"n635f961a937e4b4193eeae2daaf4293db1\"/...\n"
      ]
     }
    ],
@@ -424,8 +422,8 @@
     "    with open(tmp, \"r\", encoding=\"utf-8\") as f:\n",
     "        xml_from_file = f.read()\n",
     "\n",
-    "    print(f\"Methode 1 (chaine)     : {len(xml_str)} car.\")\n",
-    "    print(f\"Methode 2 (fichier)    : {len(xml_from_file)} car.\")\n",
+    "    print(f\"Méthode 1 (chaîne)     : {len(xml_str)} car.\")\n",
+    "    print(f\"Méthode 2 (fichier)    : {len(xml_from_file)} car.\")\n",
     "    print(f\"Identiques             : {xml_str == xml_from_file}\")\n",
     "    print(f\"\\n=== RDF/XML (extrait) ===\\n{xml_str[:400]}...\")\n",
     "else:\n",
@@ -437,7 +435,7 @@
    "id": "ca6a78313c17",
    "metadata": {},
    "source": [
-    "Les deux methodes sont equivalents : `serialize()` sans `destination` retourne une chaine, avec `destination=` ecrit dans un fichier. dotNetRDF proposait `StringWriter.Write(g, writer)` vs `writer.Save(g, sw)` - meme distinction."
+    "Les deux méthodes sont equivalents : `serialize()` sans `destination` retourne une chaîne, avec `destination=` ecrit dans un fichier. dotNetRDF proposait `StringWriter.Write(g, writer)` vs `writer.Save(g, sw)` - même distinction."
    ]
   },
   {
@@ -472,7 +470,7 @@
       "    \"@id\": \"http://www.w3.org/TR/rdf-syntax-grammar\",\n",
       "    \"http://example.org/stuff/1.0/editor\": [\n",
       "      {\n",
-      "        \"@id\": \"_:n2a84ade8f61549d8b1596d698048a888b1\"\n",
+      "        \"@id\": \"_:n635f961a937e4b4193eeae2daaf4293db1\"\n",
       "      }\n",
       "    ],\n",
       "    \"http://purl.org/dc/elements/1.1/title\": [\n",
@@ -482,7 +480,7 @@
       "    ]\n",
       "  },\n",
       "  {\n",
-      "    \"@id\": \"_:n2a84ade8f61549d8b1596d698048a888b1\",\n",
+      "    \"@id\": \"_:n635f961a937e4b4193eeae2daaf4293db1\",\n",
       "    \"http://example.org/stuff/1.0/fullname\": [\n",
       "      {\n",
       "        \"@value\": \"Dave Beckett\"\n",
@@ -526,9 +524,9 @@
     "| `g.serialize(format=\"xml\")` | `RdfXmlWriter` | Moyenne | Moyenne |\n",
     "| `g.serialize(format=\"json-ld\")` | `JsonLdWriter` | Bonne (dev web) | Moyenne |\n",
     "\n",
-    "**Difference notable** : dotNetRDF expose des **interfaces de configuration** riches (`IPrettyPrintingWriter`, `ICompressingWriter` avec `CompressionLevel`, `IHighSpeedWriter`). rdflib est plus minimaliste : l'argument `indent` (JSON-LD) et la convention interne de compression Turtle sont les seuls leviers. Pour un controle fin equivalent, il faut descendre vers des sous-modules (ex : `rdflib.plugins.serializers.turtle`).\n",
+    "**Différence notable** : dotNetRDF expose des **interfaces de configuration** riches (`IPrettyPrintingWriter`, `ICompressingWriter` avec `CompressionLevel`, `IHighSpeedWriter`). rdflib est plus minimaliste : l'argument `indent` (JSON-LD) et la convention interne de compression Turtle sont les seuls leviers. Pour un contrôle fin equivalent, il faut descendre vers des sous-modules (ex : `rdflib.plugins.serializers.turtle`).\n",
     "\n",
-    "> Tous les formats rdflib sont accessibles via la methode unique `g.serialize(format=...)` - API uniforme, plus simple que dotNetRDF ou chaque writer a sa propre classe."
+    "> Tous les formats rdflib sont accessibles via la méthode unique `g.serialize(format=...)` - API uniforme, plus simple que dotNetRDF ou chaque writer a sa propre classe."
    ]
   },
   {
@@ -540,7 +538,7 @@
     "\n",
     "## 3. Fusion de graphes\n",
     "\n",
-    "rdflib implemente la **semantique d'ensemble** des graphes RDF : l'union (operateur `|` ou `+=`) combine deux graphes sans dupliquer les triplets identiques. Les blank nodes sont isoles par graphe (pas de collision)."
+    "rdflib implemente la **sémantique d'ensemble** des graphes RDF : l'union (opérateur `|` ou `+=`) combine deux graphes sans dupliquer les triplets identiques. Les blank nodes sont isoles par graphe (pas de collision)."
    ]
   },
   {
@@ -562,7 +560,7 @@
      "text": [
       "Graphe 1 (Example.ttl) : 4 triplets\n",
       "Graphe 2 (animals.ttl) : 51 triplets\n",
-      "Apres fusion (+=)      : 55 triplets (somme theorique: 55)\n",
+      "Après fusion (+=)      : 55 triplets (somme théorique: 55)\n",
       "Doublons supprimes     : 0\n",
       "\n",
       "Operateur | (new graph): 55 triplets (sources intactes: 4, 51)\n"
@@ -583,7 +581,7 @@
     "\n",
     "    # Operateur += : union en place (equivalent de g1.Merge(g2) en dotNetRDF)\n",
     "    g1 += g2\n",
-    "    print(f\"Apres fusion (+=)      : {len(g1)} triplets (somme theorique: {somme})\")\n",
+    "    print(f\"Après fusion (+=)      : {len(g1)} triplets (somme théorique: {somme})\")\n",
     "    print(f\"Doublons supprimes     : {somme - len(g1)}\")\n",
     "\n",
     "    # Variante : operateur | retourne un NOUVEAU graphe (non destructif)\n",
@@ -602,7 +600,7 @@
    "source": [
     "### Interpretation : verification manuelle\n",
     "\n",
-    "**Somme theorique** : 4 (Example.ttl) + 51 (animals.ttl) = **55**. Aucun triplet commun (les deux fichiers utilisent des namespaces disjoints : `http://example.org/stuff/1.0/` vs `http://example.org/animals#`), donc **0 doublon supprime**. Le resultat `55` confirme la semantique d'ensemble.\n",
+    "**Somme théorique** : 4 (Example.ttl) + 51 (animals.ttl) = **55**. Aucun triplet commun (les deux fichiers utilisent des namespaces disjoints : `http://example.org/stuff/1.0/` vs `http://example.org/animals#`), donc **0 doublon supprime**. Le résultat `55` confirme la sémantique d'ensemble.\n",
     "\n",
     "| Aspect | rdflib | dotNetRDF |\n",
     "|--------|--------|-----------|\n",
@@ -611,7 +609,7 @@
     "| Dédoublonnage | Automatique (set semantics) | Automatique |\n",
     "| Blank nodes | Isolés par graphe | Renommés pour éviter collision |\n",
     "\n",
-    "- Les triplets identiques ne sont **pas dupliques** (semantique d'ensemble RDF)\n",
+    "- Les triplets identiques ne sont **pas dupliques** (sémantique d'ensemble RDF)\n",
     "- Les blank nodes sont **isoles** par graphe d'origine (pas de collision)\n",
     "- `+=` modifie `g1` en place ; `|` retourne un nouveau graphe (API plus pythonique que `Merge`)"
    ]
@@ -623,9 +621,9 @@
    "source": [
     "---\n",
     "\n",
-    "## 4. Selection de triplets\n",
+    "## 4. Sélection de triplets\n",
     "\n",
-    "`Graph` propose la methode generique `g.triples((s, p, o))` ou chaque composante peut etre `None` (joker). Des accesseurs dediees existent : `g.subjects(p, o)`, `g.predicates(s, o)`, `g.objects(s, p)`, `g.subject_instances`, `g.value()` (singleton). Les resultats sont des **generateurs** composables avec les comprehensions Python (equivalent LINQ)."
+    "`Graph` propose la méthode generique `g.triples((s, p, o))` ou chaque composante peut etre `None` (joker). Des accesseurs dediees existent : `g.subjects(p, o)`, `g.predicates(s, o)`, `g.objects(s, p)`, `g.subject_instances`, `g.value()` (singleton). Les résultats sont des **générateurs** composables avec les comprehensions Python (equivalent LINQ)."
    ]
   },
   {
@@ -691,7 +689,7 @@
     "    for s, p, o in g.triples((rex, None, None)):\n",
     "        print(f\"  {p.n3(g.namespace_manager)} -> {o.n3(g.namespace_manager)}\")\n",
     "else:\n",
-    "    print(\"rdflib non disponible : selection ignoree.\")"
+    "    print(\"rdflib non disponible : sélection ignoree.\")"
    ]
   },
   {
@@ -699,13 +697,13 @@
    "id": "c08705b85987",
    "metadata": {},
    "source": [
-    "#### Interpretation : Resultats de la selection\n",
+    "#### Interpretation : Résultats de la sélection\n",
     "\n",
-    "**Selection par predicat** `rdf:type` : **14 triplets** trouves - 6 declarations de classes (Animal, Mammal, Bird, Dog, Cat, Parrot), 4 declarations de proprietes (name, age, sound, canFly) et 4 instances (rex/Dog, minou/Cat, coco/Parrot, buddy/Dog). Verification manuelle sur `animals.ttl` : 6 lignes `a rdfs:Class` + 4 lignes `a rdf:Property` + 4 lignes `a ex:<Classe>` = 14. Confirme.\n",
+    "**Sélection par predicat** `rdf:type` : **14 triplets** trouves - 6 declarations de classes (Animal, Mammal, Bird, Dog, Cat, Parrot), 4 declarations de proprietes (name, age, sound, canFly) et 4 instances (rex/Dog, minou/Cat, coco/Parrot, buddy/Dog). Verification manuelle sur `animals.ttl` : 6 lignes `a rdfs:Class` + 4 lignes `a rdf:Property` + 4 lignes `a ex:<Classe>` = 14. Confirme.\n",
     "\n",
-    "**Selection par sujet** `ex:rex` : **4 proprietes** - type (Dog), name (Rex), age (5), sound (Woof). Rex est un chien de 5 ans qui fait \"Woof\".\n",
+    "**Sélection par sujet** `ex:rex` : **4 proprietes** - type (Dog), name (Rex), age (5), sound (Woof). Rex est un chien de 5 ans qui fait \"Woof\".\n",
     "\n",
-    "Ces resultats illustrent que `g.triples((None, RDF.type, None))` retourne tous les usages d'un predicat (types, instances), tandis que `g.triples((rex, None, None))` decrit un noeud complet."
+    "Ces résultats illustrent que `g.triples((None, RDF.type, None))` retourne tous les usages d'un predicat (types, instances), tandis que `g.triples((rex, None, None))` decrit un noeud complet."
    ]
   },
   {
@@ -762,7 +760,7 @@
     "    print(f\"\\n=== Animal le plus age ===\")\n",
     "    print(f\"  {oldest[0].n3(g.namespace_manager)} : {oldest[1]} ans\")\n",
     "else:\n",
-    "    print(\"rdflib non disponible : selection combinee ignoree.\")"
+    "    print(\"rdflib non disponible : sélection combinee ignoree.\")"
    ]
   },
   {
@@ -770,9 +768,9 @@
    "id": "4b75e0f8957b",
    "metadata": {},
    "source": [
-    "### Interpretation : Methodes de selection\n",
+    "### Interpretation : Méthodes de sélection\n",
     "\n",
-    "| Methode rdflib | Pattern | Equivalent dotNetRDF | Equivalent SPARQL |\n",
+    "| Méthode rdflib | Pattern | Equivalent dotNetRDF | Equivalent SPARQL |\n",
     "|----------------|---------|----------------------|-------------------|\n",
     "| `g.triples((s, None, None))` | `s ? ?` | `GetTriplesWithSubject(s)` | `SELECT ?p ?o WHERE { s ?p ?o }` |\n",
     "| `g.triples((None, p, None))` | `? p ?` | `GetTriplesWithPredicate(p)` | `SELECT ?s ?o WHERE { ?s p ?o }` |\n",
@@ -781,7 +779,7 @@
     "| `g.triples((None, p, o))` | `? p o` | `GetTriplesWithPredicateObject(p,o)` | `SELECT ?s WHERE { ?s p o }` |\n",
     "| `g.value(s, p)` | singleton | (via `GetTriplesWithSubjectPredicate`) | `SELECT ?o WHERE { s p ?o } LIMIT 1` |\n",
     "\n",
-    "**Verification manuelle** : la selection `rdf:type` renvoie **14** triplets (cf. cellule precedente), et le filtre \"age > 5\" doit retourner **coco (12)** et **buddy (7)** - ce que confirme la sortie. L'animal le plus age est **coco** a **12 ans**. Les resultats sont des **generateurs** (lazy evaluation), composables avec les comprehensions Python exactement comme `IEnumerable<Triple>` se compose avec LINQ."
+    "**Verification manuelle** : la sélection `rdf:type` renvoie **14** triplets (cf. cellule précédente), et le filtre \"age > 5\" doit retourner **coco (12)** et **buddy (7)** - ce que confirme la sortie. L'animal le plus age est **coco** a **12 ans**. Les résultats sont des **générateurs** (lazy evaluation), composables avec les comprehensions Python exactement comme `IEnumerable<Triple>` se compose avec LINQ."
    ]
   },
   {
@@ -793,7 +791,7 @@
     "\n",
     "## 5. Listes RDF\n",
     "\n",
-    "Les listes RDF (RDF collections) sont des structures chainees encodees avec `rdf:first` et `rdf:rest`, terminant par `rdf:nil`. rdflib fournit la classe `rdflib.collection.Collection` qui encapsule cette structure avec une API de liste Python standard (`append`, `index`, `len`, iteration, `del`)."
+    "Les listes RDF (RDF collections) sont des structures chainees encodees avec `rdf:first` et `rdf:rest`, terminant par `rdf:nil`. rdflib fournit la classe `rdflib.collection.Collection` qui encapsule cette structure avec une API de liste Python standard (`append`, `index`, `len`, itération, `del`)."
    ]
   },
   {
@@ -875,13 +873,13 @@
     "head -> [1 | rest] -> [2 | rest] -> [3 | rest] -> rdf:nil\n",
     "```\n",
     "\n",
-    "| Element | Methode rdflib | Exemple |\n",
+    "| Élément | Méthode rdflib | Exemple |\n",
     "|---------|----------------|---------|\n",
     "| Valeurs (`rdf:first`) | `list(Collection(g, head))` | `[1, 2, 3]` |\n",
     "| Noeuds intermediaires | parcours manuel via `rdf:rest` | `_:b1, _:b2, _:b3` |\n",
     "| Tous les triplets | `g.triples((None, RDF.first, None))` + `rdf:rest` | 6 triplets (3 first + 3 rest) |\n",
     "\n",
-    "**Verification manuelle** : une liste de 3 elements produit **3** `rdf:first` + **3** `rdf:rest` (le dernier `rdf:rest` pointe vers `rdf:nil`) = **6 triplets**. Confirme par la sortie. Chaque element coute 2 triplets (`rdf:first` + `rdf:rest`), sauf le dernier dont le `rdf:rest` pointe vers `rdf:nil`."
+    "**Verification manuelle** : une liste de 3 éléments produit **3** `rdf:first` + **3** `rdf:rest` (le dernier `rdf:rest` pointe vers `rdf:nil`) = **6 triplets**. Confirme par la sortie. Chaque élément coute 2 triplets (`rdf:first` + `rdf:rest`), sauf le dernier dont le `rdf:rest` pointe vers `rdf:nil`."
    ]
   },
   {
@@ -902,8 +900,8 @@
      "output_type": "stream",
      "text": [
       "Avant           : [1, 2, 3]\n",
-      "Apres append    : [1, 2, 3, 4, 5]\n",
-      "Apres del '3'   : [1, 2, 4, 5]\n"
+      "Après append    : [1, 2, 3, 4, 5]\n",
+      "Après del '3'   : [1, 2, 4, 5]\n"
      ]
     }
    ],
@@ -922,14 +920,14 @@
     "    # append = AddToList equivalent (ajoute en fin de liste)\n",
     "    col2.append(Literal(4))\n",
     "    col2.append(Literal(5))\n",
-    "    print(f\"Apres append    : {fmt(col2)}\")\n",
+    "    print(f\"Après append    : {fmt(col2)}\")\n",
     "\n",
     "    # suppression par valeur : trouver l'index puis del (rdflib n'expose pas .remove(value))\n",
     "    target = Literal(3)\n",
     "    items = list(col2)\n",
     "    if target in items:\n",
     "        del col2[items.index(target)]\n",
-    "    print(f\"Apres del '3'   : {fmt(col2)}\")\n",
+    "    print(f\"Après del '3'   : {fmt(col2)}\")\n",
     "else:\n",
     "    print(\"rdflib non disponible : ajout/suppression ignores.\")"
    ]
@@ -941,15 +939,15 @@
    "source": [
     "#### Interpretation : API des listes\n",
     "\n",
-    "| Operation | dotNetRDF | rdflib |\n",
+    "| Opération | dotNetRDF | rdflib |\n",
     "|-----------|-----------|--------|\n",
-    "| **Creer** | `g.AssertList(elements)` | `Collection(g, head, elements)` |\n",
+    "| **Créer** | `g.AssertList(éléments)` | `Collection(g, head, éléments)` |\n",
     "| **Lire** | `g.GetListItems(root)` | `list(Collection(g, head))` |\n",
-    "| **Ajouter** | `g.AddToList(root, elements)` | `col.append(item)` |\n",
-    "| **Retirer par valeur** | `g.RemoveFromList(root, elements)` | `del col[col.index(item)]` |\n",
+    "| **Ajouter** | `g.AddToList(root, éléments)` | `col.append(item)` |\n",
+    "| **Retirer par valeur** | `g.RemoveFromList(root, éléments)` | `del col[col.index(item)]` |\n",
     "| **Supprimer tout** | `g.RetractList(root)` | `col.clear()` |\n",
     "\n",
-    "**Difference notable** : `RemoveFromList` (dotNetRDF) retire par **valeur** directement ; rdflib exige de trouver l'**index** puis `del col[index]`. API legerement moins ergonomique pour ce cas, mais conforme a l'idiome Python `del list[i]`."
+    "**Différence notable** : `RemoveFromList` (dotNetRDF) retire par **valeur** directement ; rdflib exige de trouver l'**index** puis `del col[index]`. API legerement moins ergonomique pour ce cas, mais conforme a l'idiome Python `del list[i]`."
    ]
   },
   {
@@ -970,9 +968,9 @@
      "output_type": "stream",
      "text": [
       "Initial           : [Alice, Bob, Charlie]\n",
-      "Apres ajout Diana : [Alice, Bob, Charlie, Diana]\n",
-      "Apres del Bob     : [Alice, Charlie, Diana]\n",
-      "Apres clear()     : [] | triplets 6 -> 0\n"
+      "Après ajout Diana : [Alice, Bob, Charlie, Diana]\n",
+      "Après del Bob     : [Alice, Charlie, Diana]\n",
+      "Après clear()     : [] | triplets 6 -> 0\n"
      ]
     }
    ],
@@ -990,17 +988,17 @@
     "\n",
     "    # Ajout\n",
     "    col3.append(Literal(\"Diana\"))\n",
-    "    print(f\"Apres ajout Diana : {fmt(col3)}\")\n",
+    "    print(f\"Après ajout Diana : {fmt(col3)}\")\n",
     "\n",
     "    # Suppression par valeur (index lookup)\n",
     "    items = list(col3)\n",
     "    del col3[items.index(Literal(\"Bob\"))]\n",
-    "    print(f\"Apres del Bob     : {fmt(col3)}\")\n",
+    "    print(f\"Après del Bob     : {fmt(col3)}\")\n",
     "\n",
     "    # RetractList equivalent : clear() detruit tous les triplets de la liste\n",
     "    avant = len(g3)\n",
     "    col3.clear()\n",
-    "    print(f\"Apres clear()     : {fmt(col3)} | triplets {avant} -> {len(g3)}\")\n",
+    "    print(f\"Après clear()     : {fmt(col3)} | triplets {avant} -> {len(g3)}\")\n",
     "else:\n",
     "    print(\"rdflib non disponible : cycle complet ignore.\")"
    ]
@@ -1012,14 +1010,14 @@
    "source": [
     "### Interpretation : API des listes (synthese)\n",
     "\n",
-    "| Operation | Methode rdflib | Comportement |\n",
+    "| Opération | Méthode rdflib | Comportement |\n",
     "|-----------|----------------|--------------|\n",
-    "| **Creer** | `Collection(g, head, [items])` | Genere blank nodes + triplets `rdf:first`/`rdf:rest` |\n",
+    "| **Créer** | `Collection(g, head, [items])` | Genere blank nodes + triplets `rdf:first`/`rdf:rest` |\n",
     "| **Ajouter** | `col.append(item)` | Ajoute en fin de liste (gere le chainage `rdf:rest`) |\n",
     "| **Retirer** | `del col[col.index(item)]` | Supprime par index (recherche de valeur manuelle) |\n",
     "| **Supprimer tout** | `col.clear()` | Supprime recursivement tous les triplets |\n",
     "\n",
-    "> **Quand utiliser les listes RDF ?** : Collections ordonnees (sequences, etapes). Pour des ensembles non ordonnes, preferez des triplets individuels - la liste RDF est couteuse (2 triplets par element) et peu query-friendly (pas de `SELECT ?x WHERE { list ?p ?x }` direct)."
+    "> **Quand utiliser les listes RDF ?** : Collections ordonnees (sequences, étapes). Pour des ensembles non ordonnes, preferez des triplets individuels - la liste RDF est couteuse (2 triplets par élément) et peu query-friendly (pas de `SELECT ?x WHERE { list ?p ?x }` direct)."
    ]
   },
   {
@@ -1039,17 +1037,17 @@
     "| **Lecture** | Classes par format (`TurtleParser`, `NTriplesParser`) + Handlers | API unique `g.parse(format=\"...\")` |\n",
     "| **Ecriture** | Classes par format + interfaces (`IPrettyPrintingWriter`, `ICompressingWriter`) | API unique `g.serialize(format=\"...\")` (options limitees) |\n",
     "| **Fusion** | `g1.Merge(g2)` (en place) | `g1 += g2` (en place) ou `g1 \\| g2` (nouveau) |\n",
-    "| **Selection** | `GetTriplesWithXxx(...)` (5 methodes) | `g.triples((s, p, o))` (une methode, `None` = joker) |\n",
+    "| **Sélection** | `GetTriplesWithXxx(...)` (5 méthodes) | `g.triples((s, p, o))` (une méthode, `None` = joker) |\n",
     "| **Listes RDF** | `Extensions.GetListItems`, `AssertList`, `AddToList`, `RetractList` | `rdflib.collection.Collection` (API liste Python) |\n",
     "| **Streaming massif** | Handlers (`CountHandler`, `PagingHandler`) - pas de graphe en memoire | Construit systematiquement le graphe (gap) |\n",
-    "| **LINQ / comprehensions** | `IEnumerable<Triple>` + LINQ (`.Where`, `.Select`, `.Max`) | Generateurs + comprehensions Python (`[x for x in ...]`) |\n",
+    "| **LINQ / comprehensions** | `IEnumerable<Triple>` + LINQ (`.Where`, `.Select`, `.Max`) | Générateurs + comprehensions Python (`[x for x in ...]`) |\n",
     "\n",
-    "### Differences philosophiques\n",
+    "### Différences philosophiques\n",
     "\n",
-    "- **dotNetRDF** privilegie l'**explicite** : un type distinct par parser/writer, interfaces de configuration fines, handlers pour le streaming. Avantage : controle precis, typage compile. Inconvenient : verbosite.\n",
-    "- **rdflib** privilegie l'**uniformite** : une seule methode `parse` / `serialize` avec un argument `format`, tuples Python natifs pour les triples. Avantage : concision, courbe d'apprentissage faible. Inconvenient : moins d'options de configuration, pas de streaming memoire-econome natif.\n",
+    "- **dotNetRDF** privilegie l'**explicite** : un type distinct par parser/writer, interfaces de configuration fines, handlers pour le streaming. Avantage : contrôle précis, typage compile. Inconvenient : verbosite.\n",
+    "- **rdflib** privilegie l'**uniformite** : une seule méthode `parse` / `serialize` avec un argument `format`, tuples Python natifs pour les triples. Avantage : concision, courbe d'apprentissage faible. Inconvenient : moins d'options de configuration, pas de streaming memoire-econome natif.\n",
     "\n",
-    "> **A retenir** : Les deux bibliotheques implementent fidelement les memes standards W3C (RDF 1.1, Turtle, N-Triples, RDF/XML, JSON-LD). Les fichiers produits par l'un sont consommables par l'autre. Le choix depend de l'ecosysteme : .NET pour l'integration C# typée, Python pour la data science et l'IA."
+    "> **A retenir** : Les deux bibliotheques implementent fidelement les mêmes standards W3C (RDF 1.1, Turtle, N-Triples, RDF/XML, JSON-LD). Les fichiers produits par l'un sont consommables par l'autre. Le choix depend de l'ecosysteme : .NET pour l'integration C# typée, Python pour la data science et l'IA."
    ]
   },
   {
@@ -1192,7 +1190,7 @@
    "source": [
     "### Exemple guide 2 : Fusionner et serialiser\n",
     "\n",
-    "Chargez `data/Example.ttl` et `data/animals.ttl`, fusionnez-les, et ecrivez le resultat en Turtle compact."
+    "Chargez `data/Example.ttl` et `data/animals.ttl`, fusionnez-les, et ecrivez le résultat en Turtle compact."
    ]
   },
   {
@@ -1212,15 +1210,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Avant fusion - g1: 4, g2: 51"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Apres fusion : 55 triplets\n",
+      "Avant fusion - g1: 4, g2: 51\n",
+      "Après fusion : 55 triplets\n",
       "@prefix dc: <http://purl.org/dc/elements/1.1/> .\n",
       "@prefix ex: <http://example.org/stuff/1.0/> .\n",
       "@prefix ns1: <http://example.org/animals#> .\n",
@@ -1313,7 +1304,7 @@
     "    # Union : les triplets identiques ne sont pas dupliques (semantique d'ensemble RDF)\n",
     "    # Les blank nodes sont isoles par graphe (pas de collision)\n",
     "    g1 += g2\n",
-    "    print(f\"Apres fusion : {len(g1)} triplets\")\n",
+    "    print(f\"Après fusion : {len(g1)} triplets\")\n",
     "\n",
     "    result = g1.serialize(format=\"turtle\")\n",
     "    print(result)\n",
@@ -1326,9 +1317,9 @@
    "id": "fff1da298eaa",
    "metadata": {},
    "source": [
-    "### Exercice 5 : Fusion avec donnees en memoire\n",
+    "### Exercice 5 : Fusion avec données en memoire\n",
     "\n",
-    "Chargez `data/animals.ttl` dans un graphe et la chaine N-Triples suivante dans un autre graphe avec `g.parse(data=..., format=\"nt\")` :\n",
+    "Chargez `data/animals.ttl` dans un graphe et la chaîne N-Triples suivante dans un autre graphe avec `g.parse(data=..., format=\"nt\")` :\n",
     "\n",
     "```\n",
     "<http://example.org/ns#dave> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/ns#Person> .\n",
@@ -1336,7 +1327,7 @@
     "<http://example.org/ns#dave> <http://example.org/ns#age> \"40\" .\n",
     "```\n",
     "\n",
-    "Fusionnez les deux graphes et serialisez le resultat en N-Triples (pas Turtle)."
+    "Fusionnez les deux graphes et serialisez le résultat en N-Triples (pas Turtle)."
    ]
   },
   {
@@ -1377,7 +1368,7 @@
    "source": [
     "### Exemple guide 3 : Liste RDF\n",
     "\n",
-    "Creez une liste `[\"Alice\", \"Bob\", \"Charlie\"]` avec `Collection`, ajoutez `\"Diana\"`, supprimez `\"Bob\"`, affichez le resultat."
+    "Créez une liste `[\"Alice\", \"Bob\", \"Charlie\"]` avec `Collection`, ajoutez `\"Diana\"`, supprimez `\"Bob\"`, affichez le résultat."
    ]
   },
   {
@@ -1398,8 +1389,8 @@
      "output_type": "stream",
      "text": [
       "Initial          : [Alice, Bob, Charlie]\n",
-      "Apres ajout      : [Alice, Bob, Charlie, Diana]\n",
-      "Apres suppression: [Alice, Charlie, Diana]\n"
+      "Après ajout      : [Alice, Bob, Charlie, Diana]\n",
+      "Après suppression: [Alice, Charlie, Diana]\n"
      ]
     }
    ],
@@ -1420,12 +1411,12 @@
     "\n",
     "    # append insere \"Diana\" en fin de liste\n",
     "    col.append(Literal(\"Diana\"))\n",
-    "    print(f\"Apres ajout      : {fmt(col)}\")\n",
+    "    print(f\"Après ajout      : {fmt(col)}\")\n",
     "\n",
     "    # suppression par valeur : on cherche l'index puis del col[index]\n",
     "    items = list(col)\n",
     "    del col[items.index(Literal(\"Bob\"))]\n",
-    "    print(f\"Apres suppression: {fmt(col)}\")\n",
+    "    print(f\"Après suppression: {fmt(col)}\")\n",
     "else:\n",
     "    print(\"rdflib non disponible : exemple 3 ignore.\")"
    ]
@@ -1437,7 +1428,7 @@
    "source": [
     "### Exercice 6 : Liste RDF personnalisee\n",
     "\n",
-    "Creez une liste RDF `[\"Paris\", \"Lyon\", \"Marseille\"]` avec `Collection`, ajoutez `\"Toulouse\"` avec `col.append(...)`, supprimez `\"Lyon\"` (index lookup + `del`). Affichez la liste apres chaque operation."
+    "Créez une liste RDF `[\"Paris\", \"Lyon\", \"Marseille\"]` avec `Collection`, ajoutez `\"Toulouse\"` avec `col.append(...)`, supprimez `\"Lyon\"` (index lookup + `del`). Affichez la liste après chaque opération."
    ]
   },
   {
@@ -1476,10 +1467,10 @@
    "source": [
     "## References savantes\n",
     "\n",
-    "- **RDF 1.1 Concepts and Abstract Syntax** - Cyganiak, Wood, Lanthaler (eds.), Recommandation W3C, 25 fevrier 2014. Modele de donnees abstrait (triplets sujet-predicat-objet, IRIs, blank nodes, litteraux) dont derivent tous les formats manipules dans ce notebook.\n",
+    "- **RDF 1.1 Concepts and Abstract Syntax** - Cyganiak, Wood, Lanthaler (eds.), Recommandation W3C, 25 fevrier 2014. Modèle de données abstrait (triplets sujet-predicat-objet, IRIs, blank nodes, litteraux) dont derivent tous les formats manipules dans ce notebook.\n",
     "- **RDF 1.1 Turtle** - Beckett, Berners-Lee, Prud'hommeaux, Recommandation W3C, 25 fevrier 2014. Format de serialization compact lisible par l'humain, le plus utilise en pratique.\n",
     "- **RDF 1.1 N-Triples** - Ackaert, Sporny, Kellogg, Recommandation W3C, 25 fevrier 2014. Forme canonique ligne-par-triplet, base d'echange interoperaable.\n",
-    "- **Notation 3 (N3)** - Berners-Lee, *A Rough Guide to Notation 3*, note non normative 2006. Sur-ensemble de Turtle ajoutant regles et citerables.\n",
+    "- **Notation 3 (N3)** - Berners-Lee, *A Rough Guide to Notation 3*, note non normative 2006. Sur-ensemble de Turtle ajoutant règles et citerables.\n",
     "- **rdflib** - bibliotheque open-source Python pour la manipulation de graphes RDF (`rdflib.readthedocs.io`), implemente les parsers/serializers uniformes `g.parse()` / `g.serialize()` utilises tout au long de ce notebook."
    ]
   },
@@ -1497,10 +1488,10 @@
     "| **1. Lecture** | parse, formats, gap Handlers | `g.parse(format=...)`, `len(g)` | `TurtleParser`, `CountHandler` |\n",
     "| **2. Ecriture** | serialize, multi-formats | `g.serialize(format=...)` | `NTriplesWriter`, `CompressingTurtleWriter` |\n",
     "| **3. Fusion** | Union, deduplication | `g1 += g2`, `g1 \\| g2` | `IGraph.Merge()` |\n",
-    "| **4. Selection** | triples pattern, comprehensions | `g.triples((s,p,o))`, `g.value()` | `GetTriplesWithSubject`, LINQ |\n",
+    "| **4. Sélection** | triples pattern, comprehensions | `g.triples((s,p,o))`, `g.value()` | `GetTriplesWithSubject`, LINQ |\n",
     "| **5. Listes** | Collections ordonnees | `Collection(g, head, items)` | `AssertList`, `GetListItems`, `RetractList` |\n",
     "\n",
-    "### Prochaine etape\n",
+    "### Prochaine étape\n",
     "\n",
     "Dans **[SW-4b-Python-SPARQL](SW-4b-Python-SPARQL.ipynb)**, nous apprendrons a interroger les graphes RDF avec le langage SPARQL cote Python (equivalent de SW-4 C#).\n",
     "\n",


### PR DESCRIPTION
## Contexte

`SemanticWeb/SW-3b-Python-GraphOperations.ipynb` : accents français strippés en markdown. Rollout #2876.

## SCOPE CORRIGÉ (alignement canon ai-01 [2026-07-18T00:08Z])

**Scope = markdown STRICT**. Les cellules code **Y COMPRIS les chaînes stdout** sont **HORS scope** (mon contrat initial autorisait les string-literals stdout — corrigé). Cette PR ré-aligne le notebook sur le canon markdown-only : **0 cellule code source modifiée** (vérifié `git diff origin/main` : code cells source-identical to main).

## Livrable

**95 cures markdown** dans 27 cellules markdown. Les littéraux dans les `print(...)` stdout restent en forme ASCII (forme d'origine du notebook).

**44 hits résiduels** = tous dans le code (commentaires + identifiants + littéraux stdout) — laissés intacts conformément au scope markdown-only.

## C.2 — Outputs cohérents (code inchangé)

La source code est **byte-identique à `origin/main`**. Les outputs committés sont donc ceux du code non-accentué d'origine. Re-exec via papermill CLI (`python3`, `--cwd SemanticWeb` pour les paths relatifs `data/*.ttl`, `--execution-timeout 600`) : **50/50 cells OK, 0 erreur** (3s) — prouve la cohérence source↔outputs.

Les stdout affichent la forme non-accentée (`Methode 1 (chaine)`, `Apres fusion`, `Apres append`) = cohérent avec le code inchangé. **0 hand-edit d'output** (Stop & Repair, règle 6) : la re-execution prouve les outputs, ils ne sont pas maquillés.

## Preuves

| Preuve | Résultat |
|--------|----------|
| Re-exec papermill CLI (python3, cwd SemanticWeb) | 50/50 cells OK, 0 erreur |
| `validate_pr_notebooks.py` | **PASS** (19 cells, EXEC_PROVED) |
| Code cells source-changed vs main | **0** (markdown-only strict) |
| Markdown cells changed vs main | 27 |
| `execution_count` | `[1..20]` monotones |
| C.1 (pas d'erreur volontaire) | 0 violation |
| Committed error outputs | 0 |
| Papermill metadata résiduelle | 0 |
| Diff total | +66/-73 (markdown prose + leur outputs inchangés) |

## Anti-régression §D

0 source code modifié ou supprimé. 0 output hand-edité. Les cures sont de la prose markdown uniquement (restauration d'accents français). Les stubs (`# TODO etudiant`) restent intacts.

## R3 collision

`gh pr list --state open --search "SW-3b"` = 0 PR ouverte concurrente.

See #2876 (rollout accents, famille SemanticWeb, scope markdown-only).

---

**Note** : Cette PR est une v2 qui ré-aligne sur le canon ai-01 [00:08Z]. La v1 (#7132) traitait à tort les string-literals stdout comme IN scope. Code now byte-identical to main.
