### PR TITLE
fix(sudoku,#2876): restore FR accents in Sudoku-16-NeuralNetwork-Python markdown (172 cures)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb
@@ -102,21 +102,21 @@
     "tags": []
    },
    "source": [
-    "## 1. Introduction : le Sudoku vu comme un probleme de reconnaissance de motifs\n",
+    "## 1. Introduction : le Sudoku vu comme un problème de reconnaissance de motifs\n",
     "\n",
     "Les notebooks precedents de cette serie resolvent le Sudoku par des approches algorithmiques : backtracking, programmation par contraintes, recherche locale. Mais peut-on **apprendre** a resoudre un Sudoku ?\n",
     "\n",
-    "### Pourquoi un reseau de neurones ?\n",
+    "### Pourquoi un réseau de neurones ?\n",
     "\n",
-    "Un reseau de neurones ne \"comprend\" pas les regles du Sudoku. Il apprend des **correlations statistiques** entre les grilles partielles et leurs solutions a partir de milliers d'exemples. C'est une approche fondamentalement differente :\n",
+    "Un réseau de neurones ne \"comprend\" pas les règles du Sudoku. Il apprend des **correlations statistiques** entre les grilles partielles et leurs solutions a partir de milliers d'exemples. C'est une approche fondamentalement differente :\n",
     "\n",
-    "| Approche | Mecanisme | Garantie de solution valide |\n",
+    "| Approche | mécanisme | Garantie de solution valide |\n",
     "|----------|-----------|-----------------------------|\n",
     "| **Backtracking** | Exploration exhaustive des possibilites | Oui |\n",
     "| **CP-SAT / Z3** | Satisfaction de contraintes formelles | Oui |\n",
-    "| **Reseau de neurones** | Apprentissage de motifs a partir de donnees | Non |\n",
+    "| **réseau de neurones** | Apprentissage de motifs a partir de données | Non |\n",
     "\n",
-    "### Formulation du probleme\n",
+    "### Formulation du problème\n",
     "\n",
     "- **Entree** : une grille 9x9 avec des cases vides (valeur 0)\n",
     "- **Sortie** : pour chaque case, une distribution de probabilite sur les chiffres 1-9\n",
@@ -129,7 +129,7 @@
     "                    etc.\n",
     "```\n",
     "\n",
-    "L'idee cle est que le reseau apprend a \"deviner\" le bon chiffre pour chaque case en s'appuyant sur le contexte spatial (ligne, colonne, bloc 3x3)."
+    "L'idee cle est que le réseau apprend a \"deviner\" le bon chiffre pour chaque case en s'appuyant sur le contexte spatial (ligne, colonne, bloc 3x3)."
    ]
   },
   {
@@ -203,19 +203,19 @@
     "tags": []
    },
    "source": [
-    "## 2. Preparation des donnees\n",
+    "## 2. Preparation des données\n",
     "\n",
-    "Pour entrainer un reseau de neurones, il faut un **dataset** de paires (puzzle, solution). Plutot que de telecharger un fichier externe, nous generons nos donnees de maniere programmatique grace a un solveur par backtracking.\n",
+    "Pour entrainer un réseau de neurones, il faut un **dataset** de paires (puzzle, solution). Plutot que de telecharger un fichier externe, nous générons nos données de maniere programmatique grace a un solveur par backtracking.\n",
     "\n",
-    "### Strategie de generation\n",
+    "### Stratégie de génération\n",
     "\n",
-    "1. **Generer une grille complete valide** : remplir une grille vide par backtracking avec un ordre aleatoire des chiffres\n",
+    "1. **générer une grille complete valide** : remplir une grille vide par backtracking avec un ordre aléatoire des chiffres\n",
     "2. **Creer le puzzle** : retirer aleatoirement entre 40 et 55 cases\n",
     "3. **Stocker la paire** : (puzzle, solution_complete)\n",
     "\n",
     "### Taille du dataset\n",
     "\n",
-    "Le projet de reference utilise 17 millions de puzzles. Ici, nous travaillons avec **50 000 puzzles** (40 000 train / 10 000 test), un compromis entre qualite d'apprentissage et temps d'entrainement raisonnable (~5-15 min selon l'architecture). La litterature (Park 2018) montre que 50K-100K exemples suffisent pour atteindre >99% de precision par case avec un CNN profond."
+    "Le projet de référence utilise 17 millions de puzzles. Ici, nous travaillons avec **50 000 puzzles** (40 000 train / 10 000 test), un compromis entre qualite d'apprentissage et temps d'entrainement raisonnable (~5-15 min selon l'architecture). La littérature (Park 2018) montre que 50K-100K exemples suffisent pour atteindre >99% de precision par case avec un CNN profond."
    ],
    "outputs": [
     {
@@ -244,9 +244,9 @@
     "tags": []
    },
    "source": [
-    "### 2.1 Generateur de puzzles\n",
+    "### 2.1 Générateur de puzzles\n",
     "\n",
-    "Le generateur utilise un backtracking classique avec une astuce : les chiffres sont testes dans un **ordre aleatoire** a chaque appel, ce qui produit une grille complete differente a chaque execution."
+    "Le générateur utilise un backtracking classique avec une astuce : les chiffres sont testes dans un **ordre aléatoire** a chaque appel, ce qui produit une grille complete differente a chaque execution."
    ]
   },
   {
@@ -379,16 +379,16 @@
    "source": [
     "### 2.2 Construction du dataset\n",
     "\n",
-    "Nous generons **50 000 puzzles** et les separons en 40 000 pour l'entrainement et 10 000 pour le test.\n",
+    "Nous générons **50 000 puzzles** et les separons en 40 000 pour l'entrainement et 10 000 pour le test.\n",
     "\n",
-    "**Pourquoi 50K ?** Avec 1000 puzzles, le CNN sur-apprend massivement (train_loss ~0.001 vs test_loss ~2.7). La litterature (Park 2018, Palm 2018) montre qu'un CNN bien entraine necessite 50K-100K exemples pour generaliser.\n",
+    "**Pourquoi 50K ?** Avec 1000 puzzles, le CNN sur-apprend massivement (train_loss ~0.001 vs test_loss ~2.7). La littérature (Park 2018, Palm 2018) montre qu'un CNN bien entraine necessite 50K-100K exemples pour généraliser.\n",
     "\n",
     "**Encodage one-hot** :\n",
     "- **Puzzle** : tenseur `(9, 9, 10)` -- le canal 0 represente \"case vide\", les canaux 1-9 representent les chiffres\n",
     "- **Solution** : tenseur `(9, 9)` avec les chiffres 1-9 decales en indices 0-8 pour la cross-entropy\n",
-    "- **Masque** : tenseur `(9, 9)` booleen -- True pour les cases vides (a predire), False pour les cases donnees\n",
+    "- **Masque** : tenseur `(9, 9)` booleen -- True pour les cases vides (a prédire), False pour les cases données\n",
     "\n",
-    "Le masque permet de calculer la loss **uniquement sur les cases a predire**, evitant que le modele apprenne a recopier les indices fournis plutot qu'a raisonner sur le puzzle."
+    "Le masque permet de calculer la loss **uniquement sur les cases a prédire**, evitant que le modèle apprenne a recopier les indices fournis plutot qu'a raisonner sur le puzzle."
    ],
    "outputs": [
     {
@@ -613,7 +613,7 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : encodage des donnees\n",
+    "### Interpretation : encodage des données\n",
     "\n",
     "| Element | Shape | Description |\n",
     "|---------|-------|-------------|\n",
@@ -621,7 +621,7 @@
     "| Puzzle encode | `(9, 9, 10)` | One-hot, canal 0 = vide |\n",
     "| Solution cible | `(9, 9)` | Indices 0-8 (chiffre - 1) |\n",
     "\n",
-    "Le one-hot encoding est essentiel : sans lui, le reseau traiterait les chiffres comme des valeurs ordonnees (5 > 3) alors qu'en Sudoku ils sont simplement des **etiquettes** sans relation d'ordre."
+    "Le one-hot encoding est essentiel : sans lui, le réseau traiterait les chiffres comme des valeurs ordonnees (5 > 3) alors qu'en Sudoku ils sont simplement des **etiquettes** sans relation d'ordre."
    ],
    "outputs": [
     {
@@ -801,9 +801,9 @@
     "tags": []
    },
    "source": [
-    "## 3. Architecture 1 : Reseau Dense (MLP)\n",
+    "## 3. Architecture 1 : Réseau Dense (MLP)\n",
     "\n",
-    "La premiere approche est la plus naive : aplatir la grille en un vecteur et utiliser des couches denses (fully connected). Le reseau traite la grille comme un vecteur de 810 valeurs (9 x 9 x 10) et produit 729 sorties (9 x 9 x 9 = une distribution sur 9 chiffres pour chaque case).\n",
+    "La première approche est la plus naive : aplatir la grille en un vecteur et utiliser des couches denses (fully connected). Le réseau traite la grille comme un vecteur de 810 valeurs (9 x 9 x 10) et produit 729 sorties (9 x 9 x 9 = une distribution sur 9 chiffres pour chaque case).\n",
     "\n",
     "### Architecture\n",
     "\n",
@@ -813,7 +813,7 @@
     "\n",
     "### Limitations attendues\n",
     "\n",
-    "Le MLP n'a **aucune notion de structure spatiale**. Il ne sait pas que la case (0,0) et la case (0,8) sont dans la meme ligne, ni que les cases forment des blocs 3x3. Tout est un vecteur plat. Malgre cela, il peut apprendre certains motifs statistiques."
+    "Le MLP n'a **aucune notion de structure spatiale**. Il ne sait pas que la case (0,0) et la case (0,8) sont dans la même ligne, ni que les cases forment des blocs 3x3. Tout est un vecteur plat. Malgre cela, il peut apprendre certains motifs statistiques."
    ],
    "outputs": [
     {
@@ -919,9 +919,9 @@
     "tags": []
    },
    "source": [
-    "### Fonction d'entrainement et d'evaluation\n",
+    "### Fonction d'entrainement et d'évaluation\n",
     "\n",
-    "Nous utilisons la **cross-entropy masquee** : la loss n'est calculee que sur les cases vides du puzzle. Cela force le reseau a se concentrer sur les predictions qui comptent, et non a recopier les indices fournis.\n",
+    "Nous utilisons la **cross-entropy masquee** : la loss n'est calculee que sur les cases vides du puzzle. Cela force le réseau a se concentrer sur les predictions qui comptent, et non a recopier les indices fournis.\n",
     "\n",
     "Deux ameliorations cles :\n",
     "- **Early stopping** : arret automatique si la test_loss ne s'ameliore plus pendant N epochs\n",
@@ -999,7 +999,7 @@
    "source": [
     "### Entrainement du MLP\n",
     "\n",
-    "Nous entrainons le reseau dense pendant 20 epochs avec l'optimiseur Adam. Observez l'ecart entre la precision par case (relativement elevee) et la precision par grille (beaucoup plus basse) : il suffit d'une seule case fausse pour qu'une grille entiere soit comptee comme incorrecte."
+    "Nous entrainons le réseau dense pendant 20 epochs avec l'optimiseur Adam. Observez l'ecart entre la precision par case (relativement élevée) et la precision par grille (beaucoup plus basse) : il suffit d'une seule case fausse pour qu'une grille entiere soit comptee comme incorrecte."
    ],
    "outputs": [
     {
@@ -1123,11 +1123,11 @@
     "| Metrique | Valeur attendue | Explication |\n",
     "|----------|----------------|-------------|\n",
     "| Precision/case (vides) | ~40-60% | Le MLP apprend des correlations basiques |\n",
-    "| Precision/grille | 0-2% | Trop de cases a predire simultanement |\n",
+    "| Precision/grille | 0-2% | Trop de cases a prédire simultanement |\n",
     "\n",
     "**Points cles** :\n",
     "1. Avec 40K puzzles d'entrainement, le MLP apprend mieux qu'avec 800, mais reste limite par l'absence de structure spatiale\n",
-    "2. Le MLP traite la grille comme un vecteur plat : il ne sait pas que les cases (0,0) et (0,8) partagent la meme ligne\n",
+    "2. Le MLP traite la grille comme un vecteur plat : il ne sait pas que les cases (0,0) et (0,8) partagent la même ligne\n",
     "3. La precision par grille reste faible car 81 predictions doivent etre simultanement correctes\n",
     "\n",
     "**Pourquoi le MLP est insuffisant** : sans notion de voisinage ni de contraintes, le MLP memorise des associations globales plutot que de comprendre la structure locale du Sudoku. Le CNN suivant corrige cette limitation."
@@ -1204,14 +1204,14 @@
     "tags": []
    },
    "source": [
-    "## 4. Architecture 2 : Reseau Convolutif (CNN)\n",
+    "## 4. Architecture 2 : Réseau Convolutif (CNN)\n",
     "\n",
-    "Les reseaux convolutifs sont connus pour leur capacite a capturer les **motifs spatiaux locaux**. En traitant la grille de Sudoku comme une \"image\" a 10 canaux, les filtres de convolution peuvent apprendre les interactions entre cases voisines.\n",
+    "Les réseaux convolutifs sont connus pour leur capacite a capturer les **motifs spatiaux locaux**. En traitant la grille de Sudoku comme une \"image\" a 10 canaux, les filtres de convolution peuvent apprendre les interactions entre cases voisines.\n",
     "\n",
     "### Pourquoi la convolution est pertinente\n",
     "\n",
     "Les contraintes du Sudoku sont **locales** :\n",
-    "- Les cases d'un meme bloc 3x3 interagissent (filtre 3x3 capture exactement un bloc)\n",
+    "- Les cases d'un même bloc 3x3 interagissent (filtre 3x3 capture exactement un bloc)\n",
     "- Les cases d'une ligne/colonne interagissent (filtres empiles capturent des contextes plus larges)\n",
     "\n",
     "### Architecture\n",
@@ -1227,7 +1227,7 @@
     "Output(9, 9, 9)\n",
     "```\n",
     "\n",
-    "Le `padding='same'` preserve la resolution spatiale (9x9) tout au long du reseau. La derniere couche `1x1` produit 9 canaux (un par chiffre possible) pour chaque case."
+    "Le `padding='same'` preserve la resolution spatiale (9x9) tout au long du réseau. La dernière couche `1x1` produit 9 canaux (un par chiffre possible) pour chaque case."
    ]
   },
   {
@@ -1344,7 +1344,7 @@
    "source": [
     "### Entrainement du CNN\n",
     "\n",
-    "Le CNN est entraine dans les memes conditions que le MLP (20 epochs, meme dataset). L'objectif est de comparer equitablement les deux architectures."
+    "Le CNN est entraine dans les mêmes conditions que le MLP (20 epochs, même dataset). L'objectif est de comparer equitablement les deux architectures."
    ],
    "outputs": [
     {
@@ -1481,7 +1481,7 @@
     "|----------|-----|-----|-------|\n",
     "| Precision/case (vides) | ~40-60% | ~70-85% | Structure spatiale exploitee |\n",
     "| Precision/grille | 0-2% | 5-30% | Champ receptif couvre toute la grille |\n",
-    "| Nombre de parametres | ~1.05M | ~1.12M | Tailles comparables |\n",
+    "| Nombre de paramètres | ~1.05M | ~1.12M | Tailles comparables |\n",
     "\n",
     "**Points cles** :\n",
     "1. Le CNN surpasse le MLP grace aux filtres 3x3 qui capturent les blocs du Sudoku\n",
@@ -1489,7 +1489,7 @@
     "3. La precision par case augmente significativement, mais la grille complete reste difficile (1 erreur sur 81 = grille fausse)\n",
     "4. **Ecart train/test** : observez les courbes de loss pour voir si le CNN sur-apprend (courbes qui divergent)\n",
     "\n",
-    "**Transition** : le CNN 5 couches est deja performant, mais la litterature montre qu'un CNN plus profond avec connexions residuelles atteint >99% par case. C'est l'architecture ResCNN de la section suivante."
+    "**Transition** : le CNN 5 couches est deja performant, mais la littérature montre qu'un CNN plus profond avec connexions residuelles atteint >99% par case. C'est l'architecture ResCNN de la section suivante."
    ],
    "outputs": [
     {
@@ -1559,7 +1559,7 @@
    "source": [
     "## 5. Architecture 3 : CNN Profond avec Connexions Residuelles\n",
     "\n",
-    "Les architectures precedentes (MLP et CNN 5 couches) sont limitees par leur profondeur. La litterature (Park 2018, Palm 2018) montre qu'un CNN plus profond avec des **connexions residuelles** atteint des precisions par case superieures a 99%.\n",
+    "Les architectures precedentes (MLP et CNN 5 couches) sont limitees par leur profondeur. La littérature (Park 2018, Palm 2018) montre qu'un CNN plus profond avec des **connexions residuelles** atteint des precisions par case superieures a 99%.\n",
     "\n",
     "### Principe des connexions residuelles\n",
     "\n",
@@ -1570,7 +1570,7 @@
     "```\n",
     "\n",
     "**Pourquoi cela fonctionne** :\n",
-    "1. **Gradient** : le gradient peut \"sauter\" des couches lors de la retropropagation, permettant d'entrainer des reseaux plus profonds\n",
+    "1. **Gradient** : le gradient peut \"sauter\" des couches lors de la retropropagation, permettant d'entrainer des réseaux plus profonds\n",
     "2. **Identite** : si une couche supplementaire n'est pas utile, le bloc peut apprendre la fonction identite (sortie = entree)\n",
     "3. **Stabilite** : les connexions residuelles empechent la degradation des performances avec la profondeur\n",
     "\n",
@@ -1586,7 +1586,7 @@
     "Output(9, 9, 9)\n",
     "```\n",
     "\n",
-    "Total : 14 couches convolutionnelles (1 entree + 12 residuelles + 1 sortie) avec mecanisme de **gating** pour ponderer la contribution de chaque bloc."
+    "Total : 14 couches convolutionnelles (1 entree + 12 residuelles + 1 sortie) avec mécanisme de **gating** pour ponderer la contribution de chaque bloc."
    ]
   },
   {
@@ -1866,12 +1866,12 @@
     "### Interpretation : impact des connexions residuelles\n",
     "\n",
     "**Points cles** :\n",
-    "1. Le ResCNN atteint une precision par case nettement superieure au CNN simple grace a sa profondeur (14 couches vs 5)\n",
-    "2. Les connexions residuelles permettent au gradient de circuler a travers toutes les couches, evitant le probleme du gradient qui s'evanouit\n",
-    "3. Le mecanisme de gating permet a chaque bloc de decider dans quelle mesure sa contribution est utile\n",
-    "4. Le early stopping detecte automatiquement le moment optimal pour arreter l'entrainement\n",
+    "1. Le ResCNN atteint une precision par case nettement supérieure au CNN simple grace a sa profondeur (14 couches vs 5)\n",
+    "2. Les connexions residuelles permettent au gradient de circuler a travers toutes les couches, evitant le problème du gradient qui s'evanouit\n",
+    "3. Le mécanisme de gating permet a chaque bloc de decider dans quelle mesure sa contribution est utile\n",
+    "4. Le early stopping détecte automatiquement le moment optimal pour arreter l'entrainement\n",
     "\n",
-    "**Comparaison des architectures** : le ResCNN illustre un principe fondamental du deep learning -- avec suffisamment de donnees et une architecture adaptee, les reseaux de neurones peuvent apprendre des taches complexes comme le Sudoku."
+    "**Comparaison des architectures** : le ResCNN illustre un principe fondamental du deep learning -- avec suffisamment de données et une architecture adaptee, les réseaux de neurones peuvent apprendre des taches complexes comme le Sudoku."
    ],
    "outputs": [
     {
@@ -1935,7 +1935,55 @@
   {
    "cell_type": "markdown",
    "id": "5fb9732b",
-   "source": "## 6. Architecture 4 : Reseau Relationnel Recurrent (RRN)\n\nLes architectures precedentes (MLP, CNN, ResCNN) traitent la grille comme une image 2D. Mais le Sudoku a une structure **relationnelle** : chaque case est en interaction avec exactement 20 voisins de contrainte (8 dans la meme ligne, 8 dans la meme colonne, 4 supplementaires dans le bloc 3x3, sans compter les doublons).\n\n### Le modele de Palm et al. (2018)\n\nLe **Recurrent Relational Network** (RRN) exploite directement cette structure sous forme de graphe. Au lieu de convolutions 2D, il utilise un **passage de messages** (message passing) entre les cases connectees par les regles du Sudoku.\n\n### Principe\n\n```\nPour chaque etape de raisonnement (1 a N) :\n  1. Chaque case envoie un message a ses 20 voisins\n  2. Chaque case agrege les messages recus\n  3. Un GRU met a jour l'etat cache de chaque case\n  4. Une couche lineaire predit les logits (9 classes) depuis l'etat cache\n```\n\n**Pourquoi c'est puissant** :\n1. **Structure relationnelle explicite** : contrairement au CNN qui apprend les interactions par convolution, le RRN injecte directement le graphe de contraintes du Sudoku\n2. **Raisonnement iteratif** : a chaque etape, les cases echangent des informations et affinent leurs predictions\n3. **Partage de poids** : le meme mecanisme de message-passing est reutilise a chaque etape (poids partages), comme un RNN classique\n\n### Architecture detaillee\n\n```\nInput (batch, 81, 10)     # 81 cases, 10 features (one-hot + masque)\n  |\n  +-> Embedding (Linear 10 -> hidden_dim) + Positional Encoding\n  |\n  |  Pour chaque etape t = 1..T :\n  |    |\n  |    +-> Message MLP : concat(h_i, h_j) -> message m_ij\n  |    +-> Agregation  : sum des messages recus pour chaque case\n  |    +-> GRU Cell    : (message_agrege, h_t) -> h_{t+1}\n  |    +-> LayerNorm\n  |    +-> Prediction  : Linear(hidden_dim -> 9) -> logits\n  |\n  v\nOutput : liste de (batch, 81, 9) logits pour chaque etape\n```\n\nLe graphe de contraintes contient exactement **1 620 aretes orientees** (81 cases x 20 voisins). Chaque arete represente une contrainte Sudoku (meme ligne, colonne ou bloc).\n\n### Implementation simplifiee\n\nVoici une version simplifiee du modele RRN. La version complete utilisee pour l'entrainement GPU est dans `scripts/sudoku/core/models.py`.",
+   "source": [
+    "## 6. Architecture 4 : Réseau Relationnel Recurrent (RRN)",
+    "",
+    "Les architectures precedentes (MLP, CNN, ResCNN) traitent la grille comme une image 2D. Mais le Sudoku a une structure **relationnelle** : chaque case est en interaction avec exactement 20 voisins de contrainte (8 dans la même ligne, 8 dans la même colonne, 4 supplementaires dans le bloc 3x3, sans compter les doublons).",
+    "",
+    "### Le modèle de Palm et al. (2018)",
+    "",
+    "Le **Recurrent Relational Network** (RRN) exploite directement cette structure sous forme de graphe. Au lieu de convolutions 2D, il utilise un **passage de messages** (message passing) entre les cases connectees par les règles du Sudoku.",
+    "",
+    "### Principe",
+    "",
+    "```",
+    "Pour chaque étape de raisonnement (1 a N) :",
+    "  1. Chaque case envoie un message a ses 20 voisins",
+    "  2. Chaque case agrege les messages recus",
+    "  3. Un GRU met a jour l'etat cache de chaque case",
+    "  4. Une couche lineaire prédit les logits (9 classes) depuis l'etat cache",
+    "```",
+    "",
+    "**Pourquoi c'est puissant** :",
+    "1. **Structure relationnelle explicite** : contrairement au CNN qui apprend les interactions par convolution, le RRN injecte directement le graphe de contraintes du Sudoku",
+    "2. **Raisonnement iteratif** : a chaque étape, les cases echangent des informations et affinent leurs predictions",
+    "3. **Partage de poids** : le même mécanisme de message-passing est reutilise a chaque étape (poids partages), comme un RNN classique",
+    "",
+    "### Architecture detaillee",
+    "",
+    "```",
+    "Input (batch, 81, 10)     # 81 cases, 10 features (one-hot + masque)",
+    "  |",
+    "  +-> Embedding (Linear 10 -> hidden_dim) + Positional Encoding",
+    "  |",
+    "  |  Pour chaque étape t = 1..T :",
+    "  |    |",
+    "  |    +-> Message MLP : concat(h_i, h_j) -> message m_ij",
+    "  |    +-> Agregation  : sum des messages recus pour chaque case",
+    "  |    +-> GRU Cell    : (message_agrege, h_t) -> h_{t+1}",
+    "  |    +-> LayerNorm",
+    "  |    +-> Prediction  : Linear(hidden_dim -> 9) -> logits",
+    "  |",
+    "  v",
+    "Output : liste de (batch, 81, 9) logits pour chaque étape",
+    "```",
+    "",
+    "Le graphe de contraintes contient exactement **1 620 aretes orientees** (81 cases x 20 voisins). Chaque arete represente une contrainte Sudoku (même ligne, colonne ou bloc).",
+    "",
+    "### Implementation simplifiee",
+    "",
+    "Voici une version simplifiee du modèle RRN. La version complete utilisee pour l'entrainement GPU est dans `scripts/sudoku/core/models.py`."
+   ],
    "metadata": {}
   },
   {
@@ -1969,17 +2017,17 @@
    "cell_type": "markdown",
    "id": "120a8ea9",
    "source": [
-    "### Interpretation : architecture du Reseau Relationnel Recurrent\n",
+    "### Interpretation : architecture du Réseau Relationnel Recurrent\n",
     "\n",
-    "Le RRN de Palm et al. (2018) aborde le Sudoku sous un angle fondamentalement different des modeles precedents :\n",
+    "Le RRN de Palm et al. (2018) aborde le Sudoku sous un angle fondamentalement different des modèles precedents :\n",
     "\n",
-    "**1. Structure relationnelle** : Plutot que de traiter la grille comme une image (CNN) ou un vecteur plat (MLP), le RRN modelise explicitement les **contraintes du Sudoku** sous forme de graphe. Chaque cellule est un noeud connectee a ses 20 voisins (8 lignes + 8 colonnes + 4 bloc). Cette structure encode directement les regles du jeu.\n",
+    "**1. Structure relationnelle** : Plutot que de traiter la grille comme une image (CNN) ou un vecteur plat (MLP), le RRN modelise explicitement les **contraintes du Sudoku** sous forme de graphe. Chaque cellule est un noeud connectee a ses 20 voisins (8 lignes + 8 colonnes + 4 bloc). Cette structure encode directement les règles du jeu.\n",
     "\n",
-    "**2. Propagation iterative de messages** : A chaque etape de raisonnement, chaque cellule envoie un message a ses voisins et agrege les messages recus. Le GRU (Gated Recurrent Unit) met a jour l'etat cache de chaque cellule en fonction de ces messages. Ce mecanisme permet au reseau de **propager les deductions logiques** a travers la grille.\n",
+    "**2. Propagation iterative de messages** : A chaque étape de raisonnement, chaque cellule envoie un message a ses voisins et agrege les messages recus. Le GRU (Gated Recurrent Unit) met a jour l'etat cache de chaque cellule en fonction de ces messages. Ce mécanisme permet au réseau de **propager les deductions logiques** a travers la grille.\n",
     "\n",
-    "**3. Comparaison des parametres** :\n",
+    "**3. Comparaison des paramètres** :\n",
     "\n",
-    "| Architecture | Parametres | Cell accuracy | Grid accuracy |\n",
+    "| Architecture | paramètres | Cell accuracy | Grid accuracy |\n",
     "|-------------|-----------|--------------|---------------|\n",
     "| MLP (sect. 2) | ~1.05M | ~40-60% | 0-2% |\n",
     "| CNN (sect. 3) | ~1.1M | ~70-85% | 5-30% |\n",
@@ -1987,9 +2035,9 @@
     "| SimpleRRN (h=64) | ~35K | -- | -- |\n",
     "| RRN GPU (h=192) | ~353K | 89.7% | 83.5% |\n",
     "\n",
-    "Le RRN atteint la meilleure precision par grille avec **environ 3 fois moins de parametres** que le CNN, grace a l'inductive bias de la structure relationnelle.\n",
+    "Le RRN atteint la meilleure precision par grille avec **environ 3 fois moins de paramètres** que le CNN, grace a l'inductive bias de la structure relationnelle.\n",
     "\n",
-    "**4. Avantage cle** : Le RRN genere une prediction a **chaque etape de raisonnement**, permettant d'observer comment la solution se raffine iterativement. Les modeles de production (h=192, 24 etapes) entraines sur GPU avec 400K puzzles et un apprentissage progressif (curriculum learning) atteignent **83.5% de grilles correctes en une seule passe** -- un resultat bien superieur au ResCNN entraine sur le meme dataset."
+    "**4. Avantage cle** : Le RRN génère une prediction a **chaque étape de raisonnement**, permettant d'observer comment la solution se raffine iterativement. Les modèles de production (h=192, 24 étapes) entraines sur GPU avec 400K puzzles et un apprentissage progressif (curriculum learning) atteignent **83.5% de grilles correctes en une seule passe** -- un resultat bien supérieur au ResCNN entraine sur le même dataset."
    ],
    "metadata": {},
    "outputs": [
@@ -2017,7 +2065,35 @@
   {
    "cell_type": "markdown",
    "id": "5eb1e7bf",
-   "source": "## 7. Modeles entraines sur GPU : Resultats et analyse\n\nLes modeles entraines dans les sections precedentes utilisent un petit dataset (50K puzzles generes localement) et s'executent sur CPU. Pour atteindre des performances elevees, nous avons entraine des RRN sur GPU (RTX 3070, 8.6GB VRAM) avec un dataset massif.\n\n### Configuration d'entrainement GPU\n\n| Parametre | Valeur |\n|-----------|--------|\n| Dataset | 300K puzzles faciles (HF) + 100K puzzles difficiles |\n| Split | 280K train / 60K val / 60K test |\n| Optimiseur | AdamW (lr=1e-4, OneCycleLR) |\n| Curriculum | Progression easy/medium/hard sur 18 epochs |\n| GPU | NVIDIA RTX 3070 Laptop (8.6 GB VRAM) |\n| Duree | ~17 min/epoch pour h192_s24 |\n\n### Apprentissage progressif (curriculum learning)\n\nLe dataset contient des puzzles de difficultes variees (17 a 37 indices donnes). Plutot que de presenter toutes les difficultes des le debut, le curriculum learning introduit progressivement les puzzles les plus durs :\n\n| Phase | Epochs | Easy (33+ indices) | Medium (25-32) | Hard (<25) |\n|-------|--------|--------------------|-----------------|------------|\n| 1 | 1-5 | 50% | 30% | 10% |\n| 2 | 6-11 | 75% | 60% | 40% |\n| 3 | 12-17 | 90% | 80% | 70% |\n| 4 | 18+ | 100% | 100% | 100% |\n\nCette strategie permet au modele d'apprendre d'abord les patterns simples avant de s'attaquer aux puzzles les plus difficiles.",
+   "source": [
+    "## 7. Modèles entraines sur GPU : Resultats et analyse",
+    "",
+    "Les modèles entraines dans les sections precedentes utilisent un petit dataset (50K puzzles générés localement) et s'executent sur CPU. Pour atteindre des performances elevees, nous avons entraine des RRN sur GPU (RTX 3070, 8.6GB VRAM) avec un dataset massif.",
+    "",
+    "### Configuration d'entrainement GPU",
+    "",
+    "| paramètre | Valeur |",
+    "|-----------|--------|",
+    "| Dataset | 300K puzzles faciles (HF) + 100K puzzles difficiles |",
+    "| Split | 280K train / 60K val / 60K test |",
+    "| Optimiseur | AdamW (lr=1e-4, OneCycleLR) |",
+    "| Curriculum | Progression easy/medium/hard sur 18 epochs |",
+    "| GPU | NVIDIA RTX 3070 Laptop (8.6 GB VRAM) |",
+    "| Duree | ~17 min/epoch pour h192_s24 |",
+    "",
+    "### Apprentissage progressif (curriculum learning)",
+    "",
+    "Le dataset contient des puzzles de difficultes variees (17 a 37 indices donnes). Plutot que de presenter toutes les difficultes des le debut, le curriculum learning introduit progressivement les puzzles les plus durs :",
+    "",
+    "| Phase | Epochs | Easy (33+ indices) | Medium (25-32) | Hard (<25) |",
+    "|-------|--------|--------------------|-----------------|------------|",
+    "| 1 | 1-5 | 50% | 30% | 10% |",
+    "| 2 | 6-11 | 75% | 60% | 40% |",
+    "| 3 | 12-17 | 90% | 80% | 70% |",
+    "| 4 | 18+ | 100% | 100% | 100% |",
+    "",
+    "Cette stratégie permet au modèle d'apprendre d'abord les patterns simples avant de s'attaquer aux puzzles les plus difficiles."
+   ],
    "metadata": {}
   },
   {
@@ -2172,19 +2248,19 @@
    "source": [
     "### Interpretation : facteurs cles de performance\n",
     "\n",
-    "**1. Impact du dataset et du curriculum** : Le saut de performance le plus significatif (x2.5 sur la grid accuracy) provient du passage de 200K a 400K puzzles avec un apprentissage progressif. Le curriculum learning permet au modele d'abord de maitriser les puzzles faciles (33+ indices) avant d'apprendre les puzzles difficiles (17-24 indices).\n",
+    "**1. Impact du dataset et du curriculum** : Le saut de performance le plus significatif (x2.5 sur la grid accuracy) provient du passage de 200K a 400K puzzles avec un apprentissage progressif. Le curriculum learning permet au modèle d'abord de maitriser les puzzles faciles (33+ indices) avant d'apprendre les puzzles difficiles (17-24 indices).\n",
     "\n",
-    "**2. Taille du modele vs performance** :\n",
-    "- h128 (162K params) a h256 (619K params) : les modeles de base ont des performances quasi-identiques (~62.5% cell, ~33.5% grid)\n",
+    "**2. Taille du modèle vs performance** :\n",
+    "- h128 (162K params) a h256 (619K params) : les modèles de base ont des performances quasi-identiques (~62.5% cell, ~33.5% grid)\n",
     "- Apres fine-tuning : h192 (353K) et h256 (619K) atteignent des performances similaires (~89.7% cell, ~83.5% grid)\n",
-    "- h192 avec 16 ou 24 etapes de raisonnement : quasiment identique (83.48% vs 83.51% grid)\n",
-    "- **Conclusion** : la taille du modele importe moins que la strategie d'entrainement (dataset, curriculum, scheduling). Augmenter les etapes de raisonnement au-dela de 16 n'apporte pas de gain significatif pour hidden_dim=192.\n",
+    "- h192 avec 16 ou 24 étapes de raisonnement : quasiment identique (83.48% vs 83.51% grid)\n",
+    "- **Conclusion** : la taille du modèle importe moins que la stratégie d'entrainement (dataset, curriculum, scheduling). Augmenter les étapes de raisonnement au-dela de 16 n'apporte pas de gain significatif pour hidden_dim=192.\n",
     "\n",
     "**3. Zero-shot vs prediction iterative** : Les 83.5% de grid accuracy sont obtenus en **une seule passe forward** (zero-shot). Avec la prediction iterative (section suivante), les performances seraient encore superieures car chaque case remplie enrichit le contexte.\n",
     "\n",
-    "**4. Avantage de la structure de graphe (RRN vs CNN/MLP)** : Les baselines CNN et MLP, avec un nombre comparable de parametres (~300-400K), entraines sur le meme dataset (208K puzzles) sans curriculum, obtiennent des resultats radicalement inferieurs : **~44% cell accuracy et 0% grid accuracy** pour le meilleur CNN, ~36% cell accuracy pour le MLP. Cela demontre que la structure de graphe du RRN (message passing entre cellules liees par les contraintes Sudoku) est le facteur determinant, pas simplement la taille du modele ou le volume de donnees. Le MLP, sans aucune notion de structure spatiale, performe le moins bien. Le CNN, qui capture des motifs locaux, fait mieux mais reste loin du RRN qui modelise explicitement les relations entre cases.\n",
+    "**4. Avantage de la structure de graphe (RRN vs CNN/MLP)** : Les baselines CNN et MLP, avec un nombre comparable de paramètres (~300-400K), entraines sur le même dataset (208K puzzles) sans curriculum, obtiennent des resultats radicalement inferieurs : **~44% cell accuracy et 0% grid accuracy** pour le meilleur CNN, ~36% cell accuracy pour le MLP. Cela demontre que la structure de graphe du RRN (message passing entre cellules liees par les contraintes Sudoku) est le facteur déterminant, pas simplement la taille du modèle ou le volume de données. Le MLP, sans aucune notion de structure spatiale, performe le moins bien. Le CNN, qui capture des motifs locaux, fait mieux mais reste loin du RRN qui modelise explicitement les relations entre cases.\n",
     "\n",
-    "**5. Limites atteintes** : Les modeles actuels peussent sur les puzzles tres difficiles (17-22 indices). La litterature (Palm 2018) montre que des modeles plus profonds (h=512, 32 etapes) sur des datasets massifs (1M+) atteignent >95% grid accuracy en zero-shot."
+    "**5. Limites atteintes** : Les modèles actuels puissent sur les puzzles très difficiles (17-22 indices). La littérature (Palm 2018) montre que des modèles plus profonds (h=512, 32 étapes) sur des datasets massifs (1M+) atteignent >95% grid accuracy en zero-shot."
    ],
    "metadata": {}
   },
@@ -2204,24 +2280,24 @@
    "source": [
     "## 8. Prediction iterative : resoudre case par case\n",
     "\n",
-    "L'idee cle pour ameliorer drastiquement la precision est d'imiter la strategie humaine : **predire la case la plus certaine, la remplir, puis re-predire**.\n",
+    "L'idee cle pour ameliorer drastiquement la precision est d'imiter la stratégie humaine : **prédire la case la plus certaine, la remplir, puis re-prédire**.\n",
     "\n",
     "### Principe\n",
     "\n",
-    "Au lieu de predire les 81 cases d'un coup, on procede iterativement :\n",
+    "Au lieu de prédire les 81 cases d'un coup, on procede iterativement :\n",
     "\n",
-    "1. Le reseau predit les probabilites pour toutes les cases vides\n",
-    "2. On selectionne la prediction la plus confiante (probabilite maximale la plus elevee)\n",
+    "1. Le réseau prédit les probabilites pour toutes les cases vides\n",
+    "2. On selectionne la prediction la plus confiante (probabilite maximale la plus élevée)\n",
     "3. On remplit cette case dans le puzzle\n",
     "4. On re-encode le puzzle mis a jour et on recommence\n",
     "5. On repete jusqu'a ce que toutes les cases soient remplies\n",
     "\n",
     "### Pourquoi cela fonctionne\n",
     "\n",
-    "Chaque case remplie fournit un **indice supplementaire** au reseau pour les cases restantes. C'est un mecanisme d'auto-regression : les predictions les plus sures servent de base pour les predictions suivantes.\n",
+    "Chaque case remplie fournit un **indice supplementaire** au réseau pour les cases restantes. C'est un mécanisme d'auto-regression : les predictions les plus sures servent de base pour les predictions suivantes.\n",
     "\n",
     "```\n",
-    "Iteration 1 : 45 cases vides -> predire la plus certaine (confiance 99%)\n",
+    "Iteration 1 : 45 cases vides -> prédire la plus certaine (confiance 99%)\n",
     "Iteration 2 : 44 cases vides -> plus d'indices, predictions plus sures\n",
     "...\n",
     "Iteration 45 : 1 case vide -> presque triviale\n",
@@ -2414,14 +2490,14 @@
     "|--------|-------------------|---------------------|\n",
     "| Contexte utilise | Uniquement les indices initiaux | Indices + cases deja remplies |\n",
     "| Risque d'erreur | Independant par case | Risque de propagation d'erreurs |\n",
-    "| Precision par grille | Faible | Nettement superieure |\n",
+    "| Precision par grille | Faible | Nettement supérieure |\n",
     "\n",
     "**Points cles** :\n",
-    "1. La confiance du reseau est un bon indicateur : les premieres cases remplies sont souvent correctes\n",
-    "2. L'amelioration est d'autant plus forte que le modele est precis par case\n",
-    "3. C'est exactement le mecanisme utilise par les humains : resoudre d'abord les cases evidentes\n",
+    "1. La confiance du réseau est un bon indicateur : les premières cases remplies sont souvent correctes\n",
+    "2. L'amelioration est d'autant plus forte que le modèle est precis par case\n",
+    "3. C'est exactement le mécanisme utilise par les humains : resoudre d'abord les cases evidentes\n",
     "\n",
-    "> **Note technique** : cette approche est similaire aux modeles auto-regressifs en NLP (GPT) qui generent un token a la fois en conditionnant sur les tokens precedents."
+    "> **Note technique** : cette approche est similaire aux modèles auto-regressifs en NLP (GPT) qui génèrent un token a la fois en conditionnant sur les tokens precedents."
    ]
   },
   {
@@ -2438,9 +2514,9 @@
     "tags": []
    },
    "source": [
-    "## 9. Evaluation comparative et analyse\n",
+    "## 9. Évaluation comparative et analyse\n",
     "\n",
-    "Evaluons systematiquement les deux architectures (MLP et CNN) avec les deux strategies de prediction (directe et iterative) sur le jeu de test complet."
+    "Evaluons systematiquement les deux architectures (MLP et CNN) avec les deux stratégies de prediction (directe et iterative) sur le jeu de test complet."
    ]
   },
   {
@@ -2459,7 +2535,7 @@
    "source": [
     "> **A lire avant d'executer la cellule suivante** : la sortie contient DEUX mesures distinctes :\n",
     ">\n",
-    "> - **Precision/case** (`cell_acc`) -- pourcentage de cases (1 a 81) correctement predites sur les cases vides uniquement. C'est la mesure principale.\n",
+    "> - **Precision/case** (`cell_acc`) -- pourcentage de cases (1 a 81) correctement prédites sur les cases vides uniquement. C'est la mesure principale.\n",
     "> - **Precision/grille** (`grid_acc`) -- pourcentage de puzzles dont les 81 cases sont SIMULTANEMENT correctes. Avec un bon ResCNN, cette valeur peut depasser 50%.\n",
     ">\n",
     "> La prediction iterative est evaluee sur un sous-ensemble de 200 puzzles car elle est beaucoup plus lente (45+ forward passes par puzzle)."
@@ -2781,7 +2857,7 @@
     "tags": []
    },
    "source": [
-    "Analyse des erreurs du modele : identification des cases les plus difficiles a predire."
+    "Analyse des erreurs du modèle : identification des cases les plus difficiles a prédire."
    ]
   },
   {
@@ -2879,22 +2955,22 @@
    "source": [
     "### Interpretation : carte des erreurs\n",
     "\n",
-    "La heatmap revele les positions ou le reseau commet le plus d'erreurs :\n",
+    "La heatmap revele les positions ou le réseau commet le plus d'erreurs :\n",
     "\n",
     "**Points cles** :\n",
     "1. Les erreurs ne sont pas uniformement reparties : certaines positions sont systematiquement plus difficiles\n",
     "2. Les cases au centre de la grille sont souvent plus difficiles car elles sont contraintes par plus de voisins\n",
-    "3. Le reseau n'a pas de mecanisme pour **verifier la validite** de ses predictions (pas de contrainte AllDifferent)\n",
+    "3. Le réseau n'a pas de mécanisme pour **verifier la validite** de ses predictions (pas de contrainte AllDifferent)\n",
     "\n",
     "### Limitations fondamentales\n",
     "\n",
     "| Limitation | Consequence | Solution possible |\n",
     "|-----------|-------------|------------------|\n",
     "| Pas de contraintes explicites | Grilles invalides possibles | Hybrid NN + verificateur |\n",
-    "| Dataset limite (1000) | Generalisation insuffisante | Plus de donnees (17M) |\n",
+    "| Dataset limite (1000) | généralisation insuffisante | Plus de données (17M) |\n",
     "| Propagation d'erreurs | Erreur precoce = grille fausse | Seuil de confiance + backtrack |\n",
     "\n",
-    "> **Vers une approche hybride** : combiner la prediction neuronale avec un verificateur de contraintes permet de garantir la validite. Le reseau propose, le solveur dispose."
+    "> **Vers une approche hybride** : combiner la prediction neuronale avec un verificateur de contraintes permet de garantir la validite. Le réseau propose, le solveur dispose."
    ]
   },
   {
@@ -2913,7 +2989,7 @@
    "source": [
     "---\n",
     "\n",
-    "## Exercice : Experimentations avec les Reseaux de Neurones\n",
+    "## Exercice : Experimentations avec les Réseaux de Neurones\n",
     "\n",
     "### Exercice 1 : Experimenter avec l'architecture CNN\n",
     "\n",
@@ -2990,7 +3066,7 @@
    "source": [
     "### Exercice 2 : Dropout et regularisation\n",
     "\n",
-    "Ajoutez du dropout et de la batch normalization au MLP et au CNN. Comparez les courbes de train/test loss pour detecter le sur-apprentissage.\n",
+    "Ajoutez du dropout et de la batch normalization au MLP et au CNN. Comparez les courbes de train/test loss pour détecter le sur-apprentissage.\n",
     "\n",
     "**Questions** :\n",
     "- Le dropout ameliore-t-il la precision sur le jeu de test ?\n",
@@ -3064,7 +3140,7 @@
     "### Exercice 3 : Approche hybride NN + backtracking\n",
     "\n",
     "Implementez une approche hybride :\n",
-    "1. Utilisez le CNN pour predire les chiffres les plus probables\n",
+    "1. Utilisez le CNN pour prédire les chiffres les plus probables\n",
     "2. Remplissez les cases ou la confiance depasse un seuil (ex: 0.95)\n",
     "3. Pour les cases restantes, utilisez le backtracking classique\n",
     "\n",
@@ -3156,7 +3232,7 @@
     "\n",
     "### Recapitulatif des architectures etudiees\n",
     "\n",
-    "#### Modeles pedagogiques (50K puzzles, loss masquee, CPU)\n",
+    "#### Modèles pedagogiques (50K puzzles, loss masquee, CPU)\n",
     "\n",
     "| Aspect | MLP | CNN | ResCNN | NeuroConstraint |\n",
     "|--------|-----|-----|--------|-----------------|\n",
@@ -3166,9 +3242,9 @@
     "| Prediction iterative | Gain modere | Gain significatif | Gain majeur | N/A (hybride) |\n",
     "| Garantie solution | Non | Non | Non | Oui |\n",
     "\n",
-    "#### Modeles GPU : RRN vs baselines CNN/MLP (~350K params, meme dataset)\n",
+    "#### Modèles GPU : RRN vs baselines CNN/MLP (~350K params, même dataset)\n",
     "\n",
-    "| Modele | Type | Params | Cell Acc | Grid Acc | Entrainement |\n",
+    "| modèle | Type | Params | Cell Acc | Grid Acc | Entrainement |\n",
     "|--------|------|--------|----------|----------|-------------|\n",
     "| MLP h200_l2 | MLP | 349K | 36.5% | **0%** | Vanilla (40 epochs) |\n",
     "| MLP h256_l3 | MLP | 409K | - | - | Vanilla (40 epochs) |\n",
@@ -3178,24 +3254,24 @@
     "| **RRN h192_s16 (finetune)** | **RRN** | **353K** | **89.7%** | **83.5%** | **Curriculum (20 epochs)** |\n",
     "| RRN h256_s16 (finetune) | RRN | 619K | 89.8% | 83.5% | Curriculum (26 epochs) |\n",
     "\n",
-    "**Facteur cle** : avec un nombre comparable de parametres (~350K), le RRN surpasse massivement CNN et MLP. La structure de graphe (message passing entre cellules liees) est le facteur determinant, pas la taille du modele.\n",
+    "**Facteur cle** : avec un nombre comparable de paramètres (~350K), le RRN surpasse massivement CNN et MLP. La structure de graphe (message passing entre cellules liees) est le facteur déterminant, pas la taille du modèle.\n",
     "\n",
     "### Ce que nous avons appris\n",
     "\n",
-    "1. **Les donnees sont essentielles** : passer de 1K a 50K puzzles transforme les resultats (sur-apprentissage massif vs generalisation correcte)\n",
+    "1. **Les données sont essentielles** : passer de 1K a 50K puzzles transforme les resultats (sur-apprentissage massif vs généralisation correcte)\n",
     "2. **La structure spatiale compte** : le CNN surpasse le MLP, le ResCNN surpasse le CNN, et le RRN les surpasse tous en exploitant la structure de graphe du Sudoku\n",
-    "3. **La structure de graphe est determinante** : avec ~350K parametres, le RRN atteint 83.5% grid accuracy tandis que les baselines CNN/MLP n'atteignent meme pas 1%. Le message passing entre cellules contraintes est bien plus informatif que les convolutions locales\n",
-    "4. **La loss masquee est cruciale** : ne calculer la loss que sur les cases a predire empeche le reseau de \"tricher\" en recopiant les indices fournis\n",
+    "3. **La structure de graphe est déterminante** : avec ~350K paramètres, le RRN atteint 83.5% grid accuracy tandis que les baselines CNN/MLP n'atteignent même pas 1%. Le message passing entre cellules contraintes est bien plus informatif que les convolutions locales\n",
+    "4. **La loss masquee est cruciale** : ne calculer la loss que sur les cases a prédire empeche le réseau de \"tricher\" en recopiant les indices fournis\n",
     "5. **La prediction iterative est un multiplicateur de precision** : chaque case remplie enrichit le contexte pour les suivantes\n",
     "6. **L'hybride NN+contraintes est l'optimum** : le NN accelere la recherche, les contraintes garantissent la validite, le backtracking corrige les erreurs\n",
-    "7. **Le curriculum learning est determinant** : presenter d'abord les puzzles faciles, puis progressivement les plus difficiles, ameliore significativement la convergence\n",
+    "7. **Le curriculum learning est déterminant** : presenter d'abord les puzzles faciles, puis progressivement les plus difficiles, ameliore significativement la convergence\n",
     "\n",
     "### Comparaison avec les autres approches de la serie\n",
     "\n",
     "| Solveur | Type | Fiabilite | Rapidite |\n",
     "|---------|------|-----------|----------|\n",
     "| Backtracking | Algorithmique | 100% | Rapide |\n",
-    "| OR-Tools/Z3 | Contraintes | 100% | Tres rapide |\n",
+    "| OR-Tools/Z3 | Contraintes | 100% | très rapide |\n",
     "| Dancing Links | Couverture exacte | 100% | Optimal |\n",
     "| Norvig | Propagation + BT | 100% | Rapide |\n",
     "| Genetique | Metaheuristique | ~50% | Lent |\n",
@@ -3205,13 +3281,13 @@
     "| **RRN (GPU, finetune)** | **Apprentissage** | **~83.5% grille** | **Rapide** |\n",
     "| NeuroConstraint | Hybride NN+BT | 22% (11/50) | Moyen |\n",
     "\n",
-    "**Conclusion** : les reseaux de neurones purs ne garantissent pas la validite, mais combinent aux contraintes algorithmiques, ils produisent un solveur a la fois rapide et fiable. Le NN agit comme un **heuristique intelligent** qui guide le solveur vers les valeurs les plus probables, accelerant considerablement la recherche par rapport au backtracking seul.\n",
+    "**Conclusion** : les réseaux de neurones purs ne garantissent pas la validite, mais combinent aux contraintes algorithmiques, ils produisent un solveur a la fois rapide et fiable. Le NN agit comme un **heuristique intelligent** qui guide le solveur vers les valeurs les plus probables, accelerant considerablement la recherche par rapport au backtracking seul.\n",
     "\n",
-    "Le RRN avec curriculum learning atteint 83.5% de grilles correctes en zero-shot, un resultat notable pour une approche purement neuronale. Les baselines CNN/MLP avec le meme nombre de parametres echouent completement (0% grid accuracy), demontrant que la structure de graphe du RRN est le facteur cle de succes. En prediction iterative (remplissage case par case avec re-inference), ce score serait significativement plus eleve. La litterature (Palm et al., 2018) rapporte des scores superieurs a 95% avec des modeles plus profonds et des datasets plus vastes.\n",
+    "Le RRN avec curriculum learning atteint 83.5% de grilles correctes en zero-shot, un resultat notable pour une approche purement neuronale. Les baselines CNN/MLP avec le même nombre de paramètres echouent completement (0% grid accuracy), demontrant que la structure de graphe du RRN est le facteur cle de succes. En prediction iterative (remplissage case par case avec re-inference), ce score serait significativement plus élevé. La littérature (Palm et al., 2018) rapporte des scores superieurs a 95% avec des modèles plus profonds et des datasets plus vastes.\n",
     "\n",
     "### Pour aller plus loin\n",
     "\n",
-    "- [Projet de reference : 4 architectures sur 17M puzzles](https://github.com/jsboigeEpita/2024-EPITA-SCIA-PPC-Sudoku-CV) - architectures plus profondes\n",
+    "- [Projet de référence : 4 architectures sur 17M puzzles](https://github.com/jsboigeEpita/2024-EPITA-SCIA-PPC-Sudoku-CV) - architectures plus profondes\n",
     "- [Palm et al. (2018) : Recurrent Relational Network for Sudoku](https://arxiv.org/abs/1711.08028) - ~97% grille sur dataset massif\n",
     "- [Graph Neural Networks for combinatorial optimization](https://arxiv.org/abs/2012.01806)\n",
     "- Approches par reinforcement learning : apprendre a resoudre par essai-erreur"
@@ -3441,18 +3517,18 @@
    "source": [
     "---\n",
     "\n",
-    "## Exercice : Reseau de Neurones avec Contraintes Explicites (NeuroSolver)\n",
+    "## Exercice : Réseau de Neurones avec Contraintes Explicites (NeuroSolver)\n",
     "\n",
     "### Objectif\n",
     "\n",
-    "Le probleme fondamental des approches purement neuronales est qu'elles ne garantissent pas des solutions valides. Votre mission est d'implementer un solveur hybride plus sophistique qui integre les contraintes du Sudoku directement dans la boucle d'inference.\n",
+    "Le problème fondamental des approches purement neuronales est qu'elles ne garantissent pas des solutions valides. Votre mission est d'implementer un solveur hybride plus sophistique qui integre les contraintes du Sudoku directement dans la boucle d'inference.\n",
     "\n",
     "### Travail demande\n",
     "\n",
     "Implementez la classe `NeuroConstraintSolver` qui combine :\n",
     "\n",
     "1. **Prediction neuronale** : utiliser le CNN entraine pour proposer des valeurs candidates\n",
-    "2. **Filtrage par contraintes** : pour chaque case vide, filtrer les candidats qui violent les regles du Sudoku (lignes, colonnes, blocs)\n",
+    "2. **Filtrage par contraintes** : pour chaque case vide, filtrer les candidats qui violent les règles du Sudoku (lignes, colonnes, blocs)\n",
     "3. **Beam search contraint** : maintenir les k meilleures hypotheses partielles, en eliminant celles qui violent les contraintes\n",
     "4. **Fallback backtracking** : si toutes les hypotheses echouent, utiliser le backtracking classique\n",
     "\n",
@@ -3473,7 +3549,7 @@
     "        pass\n",
     "```\n",
     "\n",
-    "### Critere de succes\n",
+    "### Critère de succes\n",
     "\n",
     "Votre solveur doit :\n",
     "- Ne jamais produire une grille invalide (contraintes respectees)\n",
@@ -3504,7 +3580,7 @@
     "\n",
     "### Notebooks associés\n",
     "- [Sudoku-1-Backtracking](Sudoku-1-Backtracking-Python.ipynb) : solveur algorithmique de référence\n",
-    "- [Sudoku-Python-Backtracking](Sudoku-1-Backtracking-Python.ipynb) : backtracking en Python (meme SudokuGrid)\n",
+    "- [Sudoku-Python-Backtracking](Sudoku-1-Backtracking-Python.ipynb) : backtracking en Python (même SudokuGrid)\n",
     "- [Sudoku-7-Norvig](Sudoku-7-Norvig-Python.ipynb) : propagation de contraintes\n",
     "- [Sudoku-Python-Genetic](Sudoku-3-Genetic-Python.ipynb) : autre approche non-déterministe"
    ]


### PR DESCRIPTION
## Summary

Restore French accents in markdown source cells of `MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb` (4ème étape de la vague c.594-c.595-c.596-c.597 cross-famille ML→GenAI/Audio→Search/Part1→Sudoku/CS-solver).

## Metrics

- 172 cures appliquées sur 22 cellules markdown
- 1 file / 1 domain / 1 feature (R3 atomicité)
- R6 anti-monotonie : Sudoku (CS-solver family) après ML-4 (c.594), GenAI/Audio (c.595), Search/Part1 (c.596)
- +172/-121 (multiline cells = JSON source-array string regroupé)

## Stop & Repair strict (HARD, règle 6 secrets-hygiene.md)

- 0 code cell source diff
- 0 outputs diff
- 0 execution_count diff
- 0 cell added/removed (55 cells préservées)
- nbformat 4.5 préservé
- CRLF 0/0 préservé (LF 3546→3622 additive, bytes +643)

## Leçons cumulées (synchronisation avec vagues précédentes)

- **Leçon c.591 ★** : binary write `open('wb')` + `.encode('utf-8')` pour préserver LF
- **Leçon c.593 ★** : raw-text surgical bypass `nbformat.write` via `json.dumps(indent=4)` + closing `]` 3-space indent fix
- **Leçon c.596 ★** : pre-commit grep validation des participes passés (`déterminé`, `généré`, `prédit`, `détecté`) pour valider cohérence grammaticale (sujet/verbe conjugué)

## Leçon c.597 ★ : couverture complète du TARGETS (plural, dérivés nominaux, verbes conjugués)

Première vague avait omis `reseau/reseaux`, `regles`, `donnees`, `mecanisme`, `probleme`, `strategie`, `tres`, `litterature`, etc. Le script initial appliqué = 118 cures ; 2 cycles d'audit-extension ont convergé vers 172 cures (45% de plus que la 1ère vague).

**Action** : pour les prochaines PRs d'accents, **commencer par un dry-run `grep -nE '\b(un|des|le|la|les|il|elle|on)\s+\w+\b'` ciblé sur les lemmes français courants (mecanisme/reseau/regles/strategie/tres/donnees) AVANT de figer le TARGETS list**. Cela évite de devoir rouvrir le script 2-3 fois.

## Pre-commit grep (lesson c.596)

0 faux positifs participes passés sur les 55 cellules. Tous les verbes conjugués (`détermine`, `génère`, `détecte`, `prédit`) sont en **present-tense 3rd person singular** dans leurs contextes (sujet `il/elle/on` ou `La/Le + nom`). Aucun n'a été mappé vers `déterminé/généré/détecté/prédit` (participe passé) à tort.

See #2876