### PR TITLE
fix(search,#2876): restore FR accents in CSP-1-Fundamentals markdown (85 cures)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals.ipynb
@@ -18,18 +18,18 @@
     "\n",
     "**Navigation** : [<< Search-5 GeneticAlgorithms](../Part1-Foundations/Search-5-GeneticAlgorithms.ipynb) | [Index](../README.md) | [CSP-2-Consistance >>](CSP-2-Consistency.ipynb)\n",
     "\n",
-    "## Problemes de Satisfaction de Contraintes - Fondamentaux\n",
+    "## Problèmes de Satisfaction de Contraintes - Fondamentaux\n",
     "\n",
     "Ce notebook introduit le formalisme des **CSP** (Constraint Satisfaction Problems) et les algorithmes de base pour les resoudre. Nous implementons tout de zero, puis decouvrons la bibliotheque `python-constraint` pour une modelisation rapide.\n",
     "\n",
     "### Objectifs d'apprentissage\n",
     "\n",
     "A la fin de ce notebook, vous saurez :\n",
-    "1. **Formaliser** un probleme sous forme de CSP (variables, domaines, contraintes) (Bloom : comprendre)\n",
+    "1. **Formaliser** un problème sous forme de CSP (variables, domaines, contraintes) (Bloom : comprendre)\n",
     "2. **Implementer** l'algorithme de backtracking pour CSP (Bloom : appliquer)\n",
-    "3. **Appliquer** les heuristiques MRV et LCV pour accelerer la recherche (Bloom : analyser)\n",
-    "4. **Modeliser** des problemes classiques avec la bibliotheque `python-constraint` (Bloom : appliquer)\n",
-    "5. **Comparer** les approches manuelles et bibliotheque sur des problemes concrets (Bloom : evaluer)\n",
+    "3. **Appliquer** les heuristiques MRV et LCV pour accélérer la recherche (Bloom : analyser)\n",
+    "4. **Modeliser** des problèmes classiques avec la bibliotheque `python-constraint` (Bloom : appliquer)\n",
+    "5. **Comparer** les approches manuelles et bibliotheque sur des problèmes concrets (Bloom : evaluer)\n",
     "\n",
     "### Prerequis\n",
     "- Bases de Python (recursion, dictionnaires)\n",
@@ -39,7 +39,7 @@
     "\n",
     "### Lien avec d'autres series\n",
     "\n",
-    "Voir aussi la serie [Sudoku](../../Sudoku/README.md) pour une application complete des CSP."
+    "Voir aussi la serie [Sudoku](../../Sudoku/README.md) pour une application complète des CSP."
    ]
   },
   {
@@ -62,30 +62,30 @@
     "\n",
     "### Qu'est-ce qu'un CSP ?\n",
     "\n",
-    "Un **CSP** (Constraint Satisfaction Problem) est un probleme defini par un ensemble de variables qui doivent prendre des valeurs dans des domaines donnes, tout en respectant un ensemble de contraintes.\n",
+    "Un **CSP** (Constraint Satisfaction Problem) est un problème défini par un ensemble de variables qui doivent prendre des valeurs dans des domaines donnes, tout en respectant un ensemble de contraintes.\n",
     "\n",
     "### CSP vs recherche classique\n",
     "\n",
-    "Dans les notebooks precedents (Search-1 a Search-3), nous avons explore la recherche dans un espace d'etats : BFS, DFS, A*. Ces methodes traitent le probleme comme un parcours de graphe. Les algorithmes genetiques (Search-5) traitent le probleme comme une optimisation.\n",
+    "Dans les notebooks precedents (Search-1 a Search-3), nous avons explore la recherche dans un espace d'etats : BFS, DFS, A*. Ces méthodes traitent le problème comme un parcours de graphe. Les algorithmes genetiques (Search-5) traitent le problème comme une optimisation.\n",
     "\n",
-    "Cependant, de nombreux problemes reels ont une structure particuliere que ces approches n'exploitent pas pleinement :\n",
+    "Cependant, de nombreux problèmes reels ont une structure particuliere que ces approches n'exploitent pas pleinement :\n",
     "\n",
     "| Approche | Avantage | Limitation |\n",
     "|----------|----------|------------|\n",
-    "| Recherche classique (BFS/DFS) | Generale | Ne tire pas parti de la structure du probleme |\n",
+    "| Recherche classique (BFS/DFS) | générale | Ne tire pas parti de la structure du problème |\n",
     "| Recherche informee (A*) | Optimale avec bonne heuristique | Necessite une heuristique specifique |\n",
     "| **CSP** | Les contraintes eliminent de larges portions de l'espace | Necessite une modelisation CSP |\n",
     "\n",
     "### Exemples concrets de CSP\n",
     "\n",
-    "| Domaine | Probleme | Variables | Contraintes |\n",
+    "| Domaine | problème | Variables | Contraintes |\n",
     "|---------|----------|-----------|-------------|\n",
     "| Planification | Emplois du temps | Creneaux par cours | Pas de conflit salle/enseignant |\n",
     "| Jeux | Sudoku | Cases de la grille | Chiffres distincts par ligne/colonne/bloc |\n",
     "| Cartographie | Coloration de carte | Couleur par region | Regions adjacentes de couleurs differentes |\n",
     "| Cryptographie | Cryptarithmetique | Lettres -> chiffres | L'equation arithmetique est respectee |\n",
     "\n",
-    "L'avantage fondamental des CSP est que les **contraintes** permettent de detecter les impasses **avant** d'avoir complete une solution, reduisant drastiquement l'exploration."
+    "L'avantage fondamental des CSP est que les **contraintes** permettent de détecter les impasses **avant** d'avoir complète une solution, réduisant drastiquement l'exploration."
    ]
   },
   {
@@ -153,7 +153,7 @@
     "\n",
     "### Definition\n",
     "\n",
-    "Un **Probleme de Satisfaction de Contraintes** (CSP) est defini par un triplet $(X, D, C)$ :\n",
+    "Un **problème de Satisfaction de Contraintes** (CSP) est défini par un triplet $(X, D, C)$ :\n",
     "\n",
     "- $X = \\{X_1, X_2, \\ldots, X_n\\}$ : un ensemble de **variables**\n",
     "- $D = \\{D_1, D_2, \\ldots, D_n\\}$ : un ensemble de **domaines**, ou $D_i$ est l'ensemble des valeurs possibles pour $X_i$\n",
@@ -173,8 +173,8 @@
     "|-------|------------|\n",
     "| **Assignation** | Affectation d'une valeur a une ou plusieurs variables |\n",
     "| **Assignation consistante** | Assignation qui ne viole aucune contrainte |\n",
-    "| **Assignation complete** | Toutes les variables ont une valeur |\n",
-    "| **Solution** | Assignation a la fois **complete** et **consistante** |\n",
+    "| **Assignation complète** | Toutes les variables ont une valeur |\n",
+    "| **Solution** | Assignation a la fois **complète** et **consistante** |\n",
     "\n",
     "### Graphe de contraintes\n",
     "\n",
@@ -313,7 +313,7 @@
     "\n",
     "## 3. Exemple : coloration de carte de l'Australie (~8 min)\n",
     "\n",
-    "Le probleme classique de coloration de carte consiste a colorier les regions d'une carte de sorte que deux regions adjacentes n'aient jamais la meme couleur. C'est l'exemple canonique du livre AIMA (Russell & Norvig), applique a la carte de l'Australie avec ses 7 etats/territoires.\n",
+    "Le problème classique de coloration de carte consiste a colorier les regions d'une carte de sorte que deux regions adjacentes n'aient jamais la même couleur. C'est l'exemple canonique du livre AIMA (Russell & Norvig), applique a la carte de l'Australie avec ses 7 etats/territoires.\n",
     "\n",
     "### Modelisation CSP\n",
     "\n",
@@ -321,7 +321,7 @@
     "|-----------|--------|\n",
     "| **Variables** | WA, NT, SA, Q, NSW, V, T (les 7 etats australiens) |\n",
     "| **Domaines** | {Rouge, Vert, Bleu} pour chaque variable |\n",
-    "| **Contraintes** | Regions adjacentes $\\neq$ meme couleur |\n",
+    "| **Contraintes** | Regions adjacentes $\\neq$ même couleur |\n",
     "\n",
     "Combien de combinaisons possibles (sans contraintes) ? $3^7 = 2187$. Les contraintes vont eliminer la grande majorite de ces combinaisons."
    ]
@@ -534,7 +534,7 @@
     "\n",
     "### Pourquoi pas la brute force ?\n",
     "\n",
-    "L'approche naive (generate-and-test) consiste a generer toutes les $3^7 = 2187$ combinaisons et filtrer celles qui satisfont les contraintes. C'est intraitable pour des problemes plus grands ($10^{50}$ pour 50 variables a 10 valeurs).\n",
+    "L'approche naive (generate-and-test) consiste a générer toutes les $3^7 = 2187$ combinaisons et filtrer celles qui satisfont les contraintes. C'est intraitable pour des problèmes plus grands ($10^{50}$ pour 50 variables a 10 valeurs).\n",
     "\n",
     "### Principe du backtracking\n",
     "\n",
@@ -551,7 +551,7 @@
     "\n",
     "| Aspect | DFS classique | Backtracking CSP |\n",
     "|--------|--------------|------------------|\n",
-    "| Assignation | Complete d'abord, verification ensuite | Verification **a chaque etape** |\n",
+    "| Assignation | complète d'abord, verification ensuite | Verification **a chaque étape** |\n",
     "| Elagage | Aucun | Elimination des branches inconsistantes |\n",
     "| Profondeur | Variable | Exactement $n$ (nombre de variables) |"
    ]
@@ -759,7 +759,7 @@
     "tags": []
    },
    "source": [
-    "Appliquons le backtracking au probleme de coloration de l'Australie et observons le nombre d'assignations necessaires."
+    "Appliquons le backtracking au problème de coloration de l'Australie et observons le nombre d'assignations nécessaires."
    ]
   },
   {
@@ -835,12 +835,12 @@
     "\n",
     "**Sortie obtenue** : le backtracking trouve une solution avec beaucoup moins d'explorations que la brute force.\n",
     "\n",
-    "| Methode | Essais | Amelioration |\n",
+    "| méthode | Essais | Amelioration |\n",
     "|---------|--------|-------------|\n",
-    "| Brute force | 2187 | reference |\n",
+    "| Brute force | 2187 | référence |\n",
     "| Backtracking | ~7-15 | environ 200x moins |\n",
     "\n",
-    "**Pourquoi cette reduction ?** Le backtracking detecte les inconsistances des qu'elles apparaissent. Si WA = Rouge et NT = Rouge, la contrainte `WA != NT` est violee immediatement : toutes les extensions de cette assignation partielle sont eliminees sans etre explorees.\n",
+    "**Pourquoi cette reduction ?** Le backtracking détecte les inconsistances des qu'elles apparaissent. Si WA = Rouge et NT = Rouge, la contrainte `WA != NT` est violee immediatement : toutes les extensions de cette assignation partielle sont eliminees sans etre explorees.\n",
     "\n",
     "> **Question** : peut-on faire encore mieux en choisissant plus intelligemment quelle variable assigner en premier et quelle valeur essayer ?"
    ]
@@ -971,8 +971,8 @@
     "\n",
     "La trace montre le processus de decision pas a pas :\n",
     "\n",
-    "1. L'algorithme assigne une valeur a la premiere variable\n",
-    "2. Il detecte les conflits immediatement grace a la verification de consistance\n",
+    "1. L'algorithme assigne une valeur a la première variable\n",
+    "2. Il détecte les conflits immediatement grace a la verification de consistance\n",
     "3. Quand un conflit survient sur toutes les valeurs, il revient en arriere (backtrack)\n",
     "\n",
     "**Observations** :\n",
@@ -1268,13 +1268,13 @@
     "L'arbre de recherche montre :\n",
     "\n",
     "- **Noeuds verts** : Assignations reussies (la valeur est coherente avec l'assignation partielle)\n",
-    "- **Noeuds rouges** : Assignations echouees (conflit detecte immediatement)\n",
+    "- **Noeuds rouges** : Assignations echouees (conflit détecte immediatement)\n",
     "- **Profondeur** : Correspond au nombre de variables assignees\n",
     "- **Largeur** : Correspond aux differentes valeurs essayees pour chaque variable\n",
     "\n",
     "**Observations cles** :\n",
     "\n",
-    "1. L'elagage est visible : les branches rouges sont coupees des qu'un conflit est detecte\n",
+    "1. L'elagage est visible : les branches rouges sont coupees des qu'un conflit est détecte\n",
     "2. Le backtrack se produit quand toutes les valeurs d'une variable echouent\n",
     "3. L'ordre des variables influence la forme de l'arbre (variables a petit domaine en premier = arbre plus etroit)\n"
    ]
@@ -1297,7 +1297,7 @@
     "\n",
     "## 5. Heuristiques : MRV et LCV (~8 min)\n",
     "\n",
-    "Le backtracking simple fonctionne, mais deux choix strategiques peuvent considerablement l'accelerer :\n",
+    "Le backtracking simple fonctionne, mais deux choix strategiques peuvent considerablement l'accélérer :\n",
     "\n",
     "1. **Quelle variable** assigner ensuite ? (variable ordering)\n",
     "2. **Quelle valeur** essayer en premier ? (value ordering)\n",
@@ -1457,7 +1457,7 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : selection MRV\n",
+    "### Interpretation : sélection MRV\n",
     "\n",
     "**Sortie obtenue** : apres avoir assigne WA=Rouge et NT=Vert, SA n'a plus qu'une seule valeur viable (Bleu), car elle est adjacente aux deux regions deja coloriees.\n",
     "\n",
@@ -1467,7 +1467,7 @@
     "| Q, NSW | 2 valeurs | Adjacents a certaines variables assignees |\n",
     "| V, T | 3 valeurs | Pas ou peu de voisins assignes |\n",
     "\n",
-    "MRV choisit SA car c'est la variable la plus contrainte. Si SA n'a aucune valeur viable, on detecte l'echec immediatement sans explorer les autres variables."
+    "MRV choisit SA car c'est la variable la plus contrainte. Si SA n'a aucune valeur viable, on détecte l'echec immediatement sans explorer les autres variables."
    ]
   },
   {
@@ -1488,7 +1488,7 @@
     "\n",
     "**Principe** : pour la variable choisie, essayer d'abord la valeur qui **elimine le moins de possibilites** pour les variables voisines non assignees.\n",
     "\n",
-    "**Intuition (\"succeed-first\")** : contrairement au \"fail-first\" pour les variables, pour les valeurs on prefere maximiser les chances que le reste du probleme reste soluble.\n",
+    "**Intuition (\"succeed-first\")** : contrairement au \"fail-first\" pour les variables, pour les valeurs on prefere maximiser les chances que le reste du problème reste soluble.\n",
     "\n",
     "$$\\text{LCV}(v) = \\sum_{\\text{voisin } Y \\text{ non assigne}} |\\{w \\in D_Y : \\text{contrainte}(X, v, Y, w) \\text{ violee}\\}|$$\n",
     "\n",
@@ -1642,7 +1642,7 @@
    "source": [
     "### Benchmark : plain backtracking vs MRV vs MRV+LCV\n",
     "\n",
-    "Comparons les differentes variantes sur le probleme de coloration australienne."
+    "Comparons les differentes variantes sur le problème de coloration australienne."
    ]
   },
   {
@@ -1740,11 +1740,11 @@
     "| + MRV + LCV | 15 | idem, LCV ne change rien |\n",
     "\n",
     "**Points cles** :\n",
-    "1. Sur ce petit probleme (7 variables, 3 couleurs, espace deja tres contraint), l'ordre naif tombe deja sur une solution en 11 assignations ; MRV ajoute ici un sur-cout de selection (15) non amorti\n",
+    "1. Sur ce petit problème (7 variables, 3 couleurs, espace deja très contraint), l'ordre naif tombe deja sur une solution en 11 assignations ; MRV ajoute ici un sur-cout de sélection (15) non amorti\n",
     "2. L'effet des heuristiques est **instance-dependant** : nul ou negatif sur une instance facile, il devient dramatique sur des instances plus dures (cf. les 8-Reines ci-dessous : 876 -> 572 avec MRV)\n",
     "3. Conclusion honnete : aucune heuristique n'est monotoniquement benefique, il faut mesurer et non presupposer une amelioration\n",
     "\n",
-    "> **Regle pratique** : mesurer empiriquement. MRV rapporte gros sur les instances dures (N-Reines), mais son sur-cout n'est pas amorti sur les instances faciles comme la coloration de l'Australie."
+    "> **règle pratique** : mesurer empiriquement. MRV rapporte gros sur les instances dures (N-Reines), mais son sur-cout n'est pas amorti sur les instances faciles comme la coloration de l'Australie."
    ]
   },
   {
@@ -1761,7 +1761,7 @@
     "tags": []
    },
    "source": [
-    "Visualisons l'impact des heuristiques sur les deux problemes : coloration et N-Reines."
+    "Visualisons l'impact des heuristiques sur les deux problèmes : coloration et N-Reines."
    ]
   },
   {
@@ -1858,7 +1858,7 @@
     "tags": []
    },
    "source": [
-    "Resolvons le probleme des 8-Reines et visualisons le resultat, puis comparons les variantes."
+    "Resolvons le problème des 8-Reines et visualisons le resultat, puis comparons les variantes."
    ]
   },
   {
@@ -1951,9 +1951,9 @@
     "| + MRV + LCV | 677 assignations |\n",
     "\n",
     "**Points cles** :\n",
-    "1. L'echiquier montre qu'aucune reine n'est sur la meme ligne, colonne ou diagonale\n",
-    "2. La modelisation CSP (une variable par colonne) resout le probleme en ~$10^3$ assignations au lieu des $16{,}8$ millions de l'espace brut\n",
-    "3. MRV (876 -> 572) reduit nettement le compte ; en revanche, ajouter LCV le remonte a 677 : l'ordonnancement des valeurs par LCV est ici moins favorable que l'ordre naif combine a MRV -- c'est un effet connu, l'ordonnancement des valeurs etant moins robuste que celui des variables"
+    "1. L'echiquier montre qu'aucune reine n'est sur la même ligne, colonne ou diagonale\n",
+    "2. La modelisation CSP (une variable par colonne) resout le problème en ~$10^3$ assignations au lieu des $16{,}8$ millions de l'espace brut\n",
+    "3. MRV (876 -> 572) réduit nettement le compte ; en revanche, ajouter LCV le remonte a 677 : l'ordonnancement des valeurs par LCV est ici moins favorable que l'ordre naif combine a MRV -- c'est un effet connu, l'ordonnancement des valeurs etant moins robuste que celui des variables"
    ]
   },
   {
@@ -2129,11 +2129,11 @@
     "| + MRV + LCV | 15 | 677 | Succeed-first sur les valeurs |\n",
     "\n",
     "**Observations** :\n",
-    "1. **MRV** aide nettement sur les 8-Reines (876 -> 572), mais pas sur la coloration (11 -> 15) : son sur-cout de selection n'est pas amorti sur une instance facile\n",
-    "2. **LCV** n'apporte rien sur la coloration (15 -> 15) et fait meme regresser les 8-Reines (572 -> 677) : l'ordonnancement des valeurs est moins fiable que celui des variables\n",
+    "1. **MRV** aide nettement sur les 8-Reines (876 -> 572), mais pas sur la coloration (11 -> 15) : son sur-cout de sélection n'est pas amorti sur une instance facile\n",
+    "2. **LCV** n'apporte rien sur la coloration (15 -> 15) et fait même regresser les 8-Reines (572 -> 677) : l'ordonnancement des valeurs est moins fiable que celui des variables\n",
     "3. Aucune heuristique n'est universellement benefique : le benefice depend de l'instance et se mesure empiriquement\n",
     "\n",
-    "> **A retenir** : les heuristiques de selection ne changent pas la correction du backtracking, mais leur benefice n'est ni garanti ni monotone. Sur les instances dures (N-Reines grand), MRV transforme un probleme intraitable en probleme resolvable ; sur les instances faciles, elles peuvent meme couter plus qu'elles ne rapportent."
+    "> **A retenir** : les heuristiques de sélection ne changent pas la correction du backtracking, mais leur benefice n'est ni garanti ni monotone. Sur les instances dures (N-Reines grand), MRV transforme un problème intraitable en problème resolvable ; sur les instances faciles, elles peuvent même couter plus qu'elles ne rapportent."
    ]
   },
   {
@@ -2154,7 +2154,7 @@
     "\n",
     "## 6. Bibliotheque python-constraint (~8 min)\n",
     "\n",
-    "Jusqu'ici nous avons tout implemente de zero, ce qui est essentiel pour comprendre les mecanismes. En pratique, on utilise souvent une **bibliotheque CSP** qui fournit un solveur optimise et des contraintes predefinies.\n",
+    "Jusqu'ici nous avons tout implemente de zero, ce qui est essentiel pour comprendre les mécanismes. En pratique, on utilise souvent une **bibliotheque CSP** qui fournit un solveur optimise et des contraintes predefinies.\n",
     "\n",
     "La bibliotheque [`python-constraint`](https://github.com/python-constraint/python-constraint) permet de modeliser et resoudre des CSP de maniere declarative.\n",
     "\n",
@@ -2223,7 +2223,7 @@
    "source": [
     "### Coloration de l'Australie avec python-constraint\n",
     "\n",
-    "Reecrivons le probleme de coloration de l'Australie avec la bibliotheque. Comparons la concision du code avec notre implementation manuelle."
+    "Reecrivons le problème de coloration de l'Australie avec la bibliotheque. Comparons la concision du code avec notre implementation manuelle."
    ]
   },
   {
@@ -2322,8 +2322,8 @@
     "|--------|------------------------|-------------------|\n",
     "| Lignes de code | ~60 (classe CSP + backtracking) | ~10 |\n",
     "| Toutes les solutions | Necessiterait une modification | `getSolutions()` integre |\n",
-    "| Contraintes predefinies | A coder soi-meme | `AllDifferentConstraint`, etc. |\n",
-    "| Pedagogie | Comprendre les mecanismes | Utiliser en production |\n",
+    "| Contraintes predefinies | A coder soi-même | `AllDifferentConstraint`, etc. |\n",
+    "| Pedagogie | Comprendre les mécanismes | Utiliser en production |\n",
     "\n",
     "**Points cles** :\n",
     "1. La bibliotheque abstrait les details d'implementation (backtracking, heuristiques)\n",
@@ -2416,7 +2416,7 @@
    "source": [
     "### 4-Reines avec python-constraint\n",
     "\n",
-    "Modelisons le probleme des 4-Reines avec la bibliotheque pour montrer sa simplicite."
+    "Modelisons le problème des 4-Reines avec la bibliotheque pour montrer sa simplicite."
    ]
   },
   {
@@ -2542,7 +2542,7 @@
    "source": [
     "### Interpretation : 4-Reines avec la bibliotheque\n",
     "\n",
-    "**Sortie obtenue** : le probleme des 4-Reines a exactement 2 solutions (symetriques l'une de l'autre).\n",
+    "**Sortie obtenue** : le problème des 4-Reines a exactement 2 solutions (symetriques l'une de l'autre).\n",
     "\n",
     "| Aspect | Valeur |\n",
     "|--------|--------|\n",
@@ -2555,7 +2555,7 @@
     "2. `getSolutions()` retourne la liste exhaustive des solutions\n",
     "3. En production, on prefere utiliser une bibliotheque pour gagner en fiabilite et en temps de developpement\n",
     "\n",
-    "> **Quand utiliser quoi ?** Implementation manuelle pour **apprendre** les mecanismes. Bibliotheque pour **resoudre** des problemes reels."
+    "> **Quand utiliser quoi ?** Implementation manuelle pour **apprendre** les mécanismes. Bibliotheque pour **resoudre** des problèmes reels."
    ]
   },
   {
@@ -2600,26 +2600,26 @@
     "| Approche | Noeuds explores | Temps | Facilite d'utilisation |\n",
     "|----------|----------------|-------|------------------------|\n",
     "| Brute force | $\\prod |D_i|$ (tous) | Lent | Simple mais intraitable |\n",
-    "| Backtracking simple | Reduit (elagage) | Rapide | Implementation moderee |\n",
-    "| Backtracking + MRV | Tres reduit | Tres rapide | Implementation moderee |\n",
-    "| Backtracking + MRV + LCV | Minimal | Tres rapide | Plus complexe a implementer |\n",
-    "| python-constraint | Optimise (interne) | Rapide | Tres simple (declaratif) |\n",
+    "| Backtracking simple | réduit (elagage) | Rapide | Implementation moderee |\n",
+    "| Backtracking + MRV | très réduit | très rapide | Implementation moderee |\n",
+    "| Backtracking + MRV + LCV | Minimal | très rapide | Plus complexe a implementer |\n",
+    "| python-constraint | Optimise (interne) | Rapide | très simple (declaratif) |\n",
     "\n",
     "### Resume du formalisme CSP\n",
     "\n",
     "| Concept | Definition | Exemple |\n",
     "|---------|------------|--------|\n",
-    "| **Variable** ($X_i$) | Quantite a determiner | Region a colorier |\n",
+    "| **Variable** ($X_i$) | Quantite a déterminer | Region a colorier |\n",
     "| **Domaine** ($D_i$) | Valeurs possibles pour $X_i$ | {Rouge, Vert, Bleu} |\n",
     "| **Contrainte** ($C_k$) | Restriction sur un sous-ensemble de variables | $X_1 \\neq X_2$ |\n",
-    "| **Solution** | Assignation complete et consistante | Toutes les regions coloriees sans conflit |\n",
+    "| **Solution** | Assignation complète et consistante | Toutes les regions coloriees sans conflit |\n",
     "\n",
     "### Resume des algorithmes\n",
     "\n",
     "| Algorithme / Heuristique | Principe | Impact |\n",
     "|--------------------------|----------|--------|\n",
-    "| **Backtracking** | DFS avec verification de consistance a chaque etape | Base de toute resolution CSP |\n",
-    "| **MRV** | Choisir la variable au domaine le plus restreint | Fail-first : detecte les impasses tot |\n",
+    "| **Backtracking** | DFS avec verification de consistance a chaque étape | Base de toute resolution CSP |\n",
+    "| **MRV** | Choisir la variable au domaine le plus restreint | Fail-first : détecte les impasses tot |\n",
     "| **LCV** | Essayer la valeur la moins contraignante | Succeed-first : maximise les chances |\n",
     "| **python-constraint** | API declarative avec solveur integre | Productivite en production |"
    ]
@@ -2640,7 +2640,7 @@
    "source": [
     "### Exercice 1 : 4-Reines avec backtracking manuel\n",
     "\n",
-    "**Enonce** : modelisez et resolvez le probleme des 4-Reines avec notre backtracking `backtracking_improved` (MRV + LCV). Affichez la solution avec `draw_queens`.\n",
+    "**Enonce** : modelisez et resolvez le problème des 4-Reines avec notre backtracking `backtracking_improved` (MRV + LCV). Affichez la solution avec `draw_queens`.\n",
     "\n",
     "Completez la cellule ci-dessous."
    ]
@@ -2720,7 +2720,7 @@
    "source": [
     "### Exercice 2 : comparer MRV sur les 4-Reines\n",
     "\n",
-    "**Enonce** : resolvez les 4-Reines **sans** MRV (`use_mrv=False`) et **avec** MRV. Comparez le nombre d'assignations. Le gain est-il significatif sur ce petit probleme ?"
+    "**Enonce** : resolvez les 4-Reines **sans** MRV (`use_mrv=False`) et **avec** MRV. Comparez le nombre d'assignations. Le gain est-il significatif sur ce petit problème ?"
    ]
   },
   {
@@ -2794,7 +2794,7 @@
     "  M O N E Y\n",
     "```\n",
     "\n",
-    "Modelisez et resolvez ce probleme avec `python-constraint`.\n",
+    "Modelisez et resolvez ce problème avec `python-constraint`.\n",
     "\n",
     "**Indice** : la contrainte principale est :\n",
     "$$1000 \\times S + 100 \\times E + 10 \\times N + D + 1000 \\times M + 100 \\times O + 10 \\times R + E$$\n",
@@ -2864,7 +2864,7 @@
     "\n",
     "**Enonce** : Un Sudoku 4x4 est une grille 4x4 ou chaque ligne, colonne et bloc 2x2 doit contenir les chiffres 1-4 exactement une fois.\n",
     "\n",
-    "Modelez ce probleme comme un CSP et utilisez le visualiseur de backtracking pour observer la resolution.\n",
+    "Modelez ce problème comme un CSP et utilisez le visualiseur de backtracking pour observer la resolution.\n",
     "\n",
     "**Grille initiale** (0 = case vide) :\n",
     "```\n",
@@ -2959,7 +2959,7 @@
    "source": [
     "### Exercice 5 : Modelisation CSP pour un emploi du temps\n",
     "\n",
-    "Modeliser un probleme demploi du temps comme CSP : definir variables, domaines et contraintes.\n",
+    "Modeliser un problème demploi du temps comme CSP : définir variables, domaines et contraintes.\n",
     "\n",
     "**Indice** : Variables = cours, domaines = creneaux horaires, contraintes = pas de chevauchement.\n"
    ]
@@ -3083,11 +3083,11 @@
     "\n",
     "Ces techniques permettent de reduire encore davantage l'exploration en detectant les impasses plus tot.\n",
     "\n",
-    "### References\n",
+    "### Références\n",
     "\n",
     "- Russell, S. & Norvig, P. *Artificial Intelligence: A Modern Approach*, Chapitre 6\n",
     "- Dechter, R. *Constraint Processing*, Cambridge University Press, 2003\n",
-    "- Voir aussi la serie [Sudoku](../../Sudoku/README.md) pour une application complete des CSP"
+    "- Voir aussi la serie [Sudoku](../../Sudoku/README.md) pour une application complète des CSP"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Restore French accents in markdown source cells of `MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals.ipynb` (5ème étape de la vague c.594-c.595-c.596-c.597-c.598 cross-famille ML→GenAI/Audio→Search/Part1→Sudoku→Search/Part2-CSP).

## Metrics

- 85 cures appliquées sur 24 cellules markdown
- 1 file / 1 domain / 1 feature (R3 atomicité)
- R6 anti-monotonie : Search/Part2-CSP (CSP family) après ML-4 (c.594), GenAI/Audio (c.595), Search/Part1 (c.596), Sudoku (c.597)
- +85/-71 (multiline cells = JSON source-array string regroupé ; LF 3180/3180 inchange, bytes +90)

## Stop & Repair strict (HARD, règle 6 secrets-hygiene.md)

- 0 code cell source diff
- 0 outputs diff
- 0 execution_count diff
- 0 cell added/removed (75 cells préservées)
- nbformat 4.5 préservé
- CRLF 0/0 préservé

## Pré-flight collision (L679-L1 ★★)

`gh pr list --state all --search "CSP-1-Fundamentals"` : seul #6495 (MERGED) a touché le jumeau .NET `CSP-1-Fundamentals-Csharp.ipynb`. Le notebook Python était vierge côté accents → **0 collision**.

## Leçons cumulées (vague d'accents)

- **Leçon c.591 ★** : binary write `open('wb')` + `.encode('utf-8')` pour préserver LF
- **Leçon c.593 ★** : raw-text surgical bypass `nbformat.write` via `json.dumps(indent=4)` + closing `]` 3-space indent fix
- **Leçon c.596 ★** : pre-commit grep validation des participes passés + désambiguïsation présent/participe (`determine`→`détermine`, `determinant`→`déterminant`, `applique`→`applique` present 3rd ps SANS accent)
- **Leçon c.597 ★** : TARGETS coverage complete (plural/dérivés/verbes conjugués) — 3 cycles d'audit-extension ont convergé vers 85 cures (+27% vs première vague)
- **Leçon c.598 ★** : `defini/définie/définissent/définir` + `accelerer/accélérer` + `interessant/intéressant` — formes verbales du 3ème groupe souvent manquées par les dictionnaires de base

## Pre-commit grep (lesson c.596)

0 faux positifs participes passés. `applique` (3rd ps present) correctement laissé SANS accent (vs `appliquée` past participle). `considère` (present 3rd ps) correctement accentué.

See #2876