### PR TITLE
fix(probas,#2876): restore French accents in DecInfer-1-Utility-Foundations markdown (74 cures)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-1-Utility-Foundations.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-1-Utility-Foundations.ipynb
@@ -17,7 +17,7 @@
     "# DecInfer-1-Utility-Foundations : Axiomes et Fondements\n",
     "**Serie** : Programmation Probabiliste avec Infer.NET (1/10)  \n",
     "**Duree estimee** : 50 minutes  \n",
-    "**Prerequis** : Notebooks 1-8 (modeles probabilistes de base)\n",
+    "**Prerequis** : Notebooks 1-8 (modèles probabilistes de base)\n",
     "\n",
     "---\n",
     "\n",
@@ -55,7 +55,7 @@
    "source": [
     "## 1. Introduction : Pourquoi l'Utilite ?\n",
     "\n",
-    "### Le probleme de la decision sous incertitude\n",
+    "### Le problème de la decision sous incertitude\n",
     "\n",
     "Jusqu'ici, nous avons utilise Infer.NET pour calculer des distributions de probabilite. Mais comment **agir** face a l'incertitude ?\n",
     "\n",
@@ -122,7 +122,7 @@
     "\n",
     "L = [0.5 : L₁, 0.5 : L₂]\n",
     "\n",
-    "Elle peut etre **reduite** en loterie simple par le calcul des probabilites totales."
+    "Elle peut etre **réduite** en loterie simple par le calcul des probabilites totales."
    ]
   },
   {
@@ -291,7 +291,7 @@
     "- Valide que les probabilites somment a 1\n",
     "- Fournit un affichage lisible de la forme `[p1:o1, p2:o2, ...]`\n",
     "\n",
-    "Cette structure de donnees sera utilisee tout au long de ce notebook pour representer les choix sous incertitude."
+    "Cette structure de données sera utilisée tout au long de ce notebook pour representer les choix sous incertitude."
    ]
   },
   {
@@ -381,7 +381,7 @@
    "source": [
     "## 3. Axiomes de Preferences Rationnelles\n",
     "\n",
-    "Von Neumann et Morgenstern (1944) ont etabli les axiomes qui definissent un **agent rationnel**. Ces quatre axiomes ne sont pas arbitraires : ils capturent les conditions **minimales** pour qu'un systeme de preferences soit coherent et non-exploitable. Un agent qui les viole peut etre \"money-pumped\" (arnaque par cycle de preferences).\n",
+    "Von Neumann et Morgenstern (1944) ont etabli les axiomes qui définissent un **agent rationnel**. Ces quatre axiomes ne sont pas arbitraires : ils capturent les conditions **minimales** pour qu'un système de preferences soit cohérent et non-exploitable. Un agent qui les viole peut etre \"money-pumped\" (arnaque par cycle de preferences).\n",
     "\n",
     "### Notation\n",
     "\n",
@@ -399,7 +399,7 @@
     "\n",
     "**Interpretation** : L'agent peut toujours comparer deux options. Sans cet axiome, l'agent pourrait etre paralyse face a certains choix.\n",
     "\n",
-    "**Pourquoi necessaire ?** Un agent incapable de comparer A et B ne peut pas prendre de decision rationnelle entre eux.\n",
+    "**Pourquoi nécessaire ?** Un agent incapable de comparer A et B ne peut pas prendre de decision rationnelle entre eux.\n",
     "\n",
     "#### Axiome 2 : Transitivite\n",
     "\n",
@@ -407,16 +407,16 @@
     "\n",
     "**Interpretation** : Les preferences sont coherentes, pas de cycles.\n",
     "\n",
-    "**Pourquoi necessaire ?** Si A ≻ B ≻ C ≻ A, on peut vous faire payer pour echanger C→B, B→A, A→C et vous revenez au point de depart avec moins d'argent. C'est le \"money pump\".\n",
+    "**Pourquoi nécessaire ?** Si A ≻ B ≻ C ≻ A, on peut vous faire payer pour echanger C→B, B→A, A→C et vous revenez au point de depart avec moins d'argent. C'est le \"money pump\".\n",
     "\n",
-    "#### Axiome 3 : Continuite\n",
+    "#### Axiome 3 : Continuité\n",
     "\n",
     "> Si A ≻ B ≻ C, alors il existe p ∈ (0,1) tel que :\n",
     "> B ~ [p:A, (1-p):C]\n",
     "\n",
-    "**Interpretation** : Meme le pire outcome peut etre compense par une probabilite suffisante du meilleur.\n",
+    "**Interpretation** : même le pire outcome peut etre compense par une probabilite suffisante du meilleur.\n",
     "\n",
-    "**Pourquoi necessaire ?** Sans continuite, on ne pourrait pas construire une fonction d'utilite a valeurs reelles. Cet axiome garantit l'existence d'un \"equivalent certain\" pour toute loterie.\n",
+    "**Pourquoi nécessaire ?** Sans continuité, on ne pourrait pas construire une fonction d'utilite a valeurs réelles. Cet axiome garantit l'existence d'un \"equivalent certain\" pour toute loterie.\n",
     "\n",
     "#### Axiome 4 : Independance\n",
     "\n",
@@ -425,7 +425,7 @@
     "\n",
     "**Interpretation** : Les preferences ne dependent pas des alternatives non pertinentes.\n",
     "\n",
-    "**Pourquoi necessaire ?** C'est l'axiome le plus controversé. Le \"paradoxe d'Allais\" (1953) montre que les humains le violent souvent, mais un agent qui le viole peut aussi etre exploite."
+    "**Pourquoi nécessaire ?** C'est l'axiome le plus controversé. Le \"paradoxe d'Allais\" (1953) montre que les humains le violent souvent, mais un agent qui le viole peut aussi etre exploite."
    ]
   },
   {
@@ -570,7 +570,7 @@
    "source": [
     "### Analyse des resultats : Transitivite et Indifference\n",
     "\n",
-    "Les resultats ci-dessus revelent un cas interessant :\n",
+    "Les resultats ci-dessus revelent un cas intéressant :\n",
     "\n",
     "| Loterie | Utilite esperee | Interpretation |\n",
     "|---------|-----------------|----------------|\n",
@@ -585,7 +585,7 @@
     "- B ~ C (7 = 7, indifference)\n",
     "- Donc A ≻ C (10 > 7), ce qui est verifie\n",
     "\n",
-    "> **Note technique** : L'indifference B ~ C illustre un point subtil de la theorie. Avec une utilite concave (sqrt), la loterie B a le meme attrait que le montant certain C = 49, bien que E[B] = 98 >> 49. C'est exactement l'**aversion au risque** : l'agent prefere 49 certain a une esperance de 98 avec risque."
+    "> **Note technique** : L'indifference B ~ C illustre un point subtil de la theorie. Avec une utilite concave (sqrt), la loterie B a le même attrait que le montant certain C = 49, bien que E[B] = 98 >> 49. C'est exactement l'**aversion au risque** : l'agent prefere 49 certain a une esperance de 98 avec risque."
    ]
   },
   {
@@ -660,7 +660,7 @@
     "\n",
     "**Contexte** : L'axiome d'independance stipule que si A > B, alors pour toute loterie C et probabilite p : [p:A, (1-p):C] > [p:B, (1-p):C]. Vous allez tester cette propriete avec differentes fonctions d'utilite.\n",
     "\n",
-    "**Etapes** :\n",
+    "**étapes** :\n",
     "1. Definissez trois loteries A, B, C et une fonction d'utilite\n",
     "2. Verifiez que A > B avec votre fonction d'utilite\n",
     "3. Construisez les loteries composees L1 = [0.6:A, 0.4:C] et L2 = [0.6:B, 0.4:C]\n",
@@ -668,7 +668,7 @@
     "5. Testez avec une fonction d'utilite convexe (amateur de risque) et observez si la propriete tient toujours\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice 1 : Utilisez la classe `Loterie<double>` definie precedemment\n",
+    "- # Indice 1 : Utilisez la classe `Loterie<double>` définie precedemment\n",
     "- # Indice 2 : Une fonction convexe comme U(x) = x^2 correspond a un amateur de risque\n",
     "- # Indice 3 : L'axiome d'independance est toujours respecte quand on utilise une fonction d'utilite valide"
    ]
@@ -726,7 +726,7 @@
     "4. **Choisit** l'action qui maximise l'utilite esperee (decision)\n",
     "5. **Agit** dans le monde\n",
     "\n",
-    "C'est exactement ce que nous allons implementer dans les cellules suivantes avec Infer.NET : l'etape 2 (inference) est faite par le moteur probabiliste, et l'etape 3 (evaluation) utilise les posteriors pour calculer les utilites esperees."
+    "C'est exactement ce que nous allons implementer dans les cellules suivantes avec Infer.NET : l'étape 2 (inference) est faite par le moteur probabiliste, et l'étape 3 (évaluation) utilise les posteriors pour calculer les utilites esperees."
    ]
   },
   {
@@ -878,7 +878,7 @@
     "\n",
     "> **Intuition clinique** : Malgre un test positif avec 90% de sensibilite, la probabilite de maladie n'est \"que\" de 66%. C'est parce que la maladie est relativement rare (prior 30%) et que les faux positifs (20% des sains) contribuent significativement au total des tests positifs.\n",
     "\n",
-    "Infer.NET a effectue ce calcul automatiquement grace au modele graphique. C'est la puissance de l'inference probabiliste programmatique !"
+    "Infer.NET a effectue ce calcul automatiquement grace au modèle graphique. C'est la puissance de l'inference probabiliste programmatique !"
    ]
   },
   {
@@ -980,7 +980,7 @@
     "tags": []
    },
    "source": [
-    "Affichage du graphe de facteurs du modele de diagnostic."
+    "Affichage du graphe de facteurs du modèle de diagnostic."
    ]
   },
   {
@@ -1281,7 +1281,7 @@
     "$$E[U(\\text{traiter})] = 0.659 \\times 80 + 0.341 \\times 60 = 52.7 + 20.5 = 73.2$$\n",
     "$$E[U(\\text{ne pas traiter})] = 0.659 \\times 0 + 0.341 \\times 100 = 0 + 34.1 = 34.1$$\n",
     "\n",
-    "> **Decision** : L'ecart de 39.1 unites d'utilite en faveur du traitement est substantiel. Meme si le patient pourrait etre sain (34% de chance), le cout asymetrique des erreurs (0 vs 60) rend le traitement rationnel.\n",
+    "> **Decision** : L'ecart de 39.1 unites d'utilite en faveur du traitement est substantiel. même si le patient pourrait etre sain (34% de chance), le cout asymetrique des erreurs (0 vs 60) rend le traitement rationnel.\n",
     "\n",
     "Cette structure \"inference bayesienne + maximisation d'utilite esperee\" est le paradigme fondamental de l'**agent rationnel** en IA."
    ]
@@ -1362,12 +1362,12 @@
    "source": [
     "## Exercice 2 : Decision medicale avec test sequentiel\n",
     "\n",
-    "**Objectif** : Etendez le modele de decision medicale pour gerer deux tests sequentiels et determinez si le second test est necessaire.\n",
+    "**Objectif** : Etendez le modèle de decision medicale pour gerer deux tests sequentiels et determinez si le second test est nécessaire.\n",
     "\n",
     "**Contexte** : Un medecin peut realiser un second test complementaire (IRM) apres un premier test sanguin positif. L'IRM a une sensibilite de 95% et une specificite de 90%, mais coute 500 EUR d'utilite. La decision finale (traiter ou non) doit integrer les resultats des deux tests.\n",
     "\n",
-    "**Etapes** :\n",
-    "1. Definissez un modele Infer.NET avec deux tests conditionnels sur la variable `malade`\n",
+    "**étapes** :\n",
+    "1. Definissez un modèle Infer.NET avec deux tests conditionnels sur la variable `malade`\n",
     "2. Calculez le posterior P(malade | test1+, test2+) et P(malade | test1+, test2-)\n",
     "3. Pour chaque scenario du second test, calculez l'utilite esperee de traiter vs ne pas traiter\n",
     "4. Determinez si le second test est justifie en comparant E[U(avec test)] vs E[U(sans test)]\n",
@@ -1375,7 +1375,7 @@
     "**Indices** :\n",
     "- # Indice 1 : L'esperance sur le second test utilise la loi des probabilites totales : P(test2+) x E[U|test2+] + P(test2-) x E[U|test2-]\n",
     "- # Indice 2 : Le cout du test (-500) s'ajoute a l'utilite de chaque outcome quand on fait le test\n",
-    "- # Etape 3 : Utilisez `Variable.Case` ou `Variable.If` pour conditionner le second test sur la variable malade"
+    "- # étape 3 : Utilisez `Variable.Case` ou `Variable.If` pour conditionner le second test sur la variable malade"
    ]
   },
   {
@@ -1394,30 +1394,30 @@
    "source": [
     "## 5. Calibration par Mise a l'Indifference\n",
     "\n",
-    "### Le probleme pratique\n",
+    "### Le problème pratique\n",
     "\n",
-    "Comment determiner la fonction d'utilite U d'un agent ? En pratique, on ne peut pas observer U directement - on ne voit que les choix de l'agent. La **calibration** permet de reconstruire U a partir de ces choix.\n",
+    "Comment déterminer la fonction d'utilite U d'un agent ? En pratique, on ne peut pas observer U directement - on ne voit que les choix de l'agent. La **calibration** permet de reconstruire U a partir de ces choix.\n",
     "\n",
-    "### Methode de l'indifference (Axiome de continuite)\n",
+    "### Méthode de l'indifference (Axiome de continuité)\n",
     "\n",
-    "Cette methode exploite l'axiome de continuite pour \"sonder\" la fonction d'utilite point par point :\n",
+    "Cette méthode exploite l'axiome de continuité pour \"sonder\" la fonction d'utilite point par point :\n",
     "\n",
-    "**Etape 1 : Fixer les references**\n",
-    "- Choisissez deux outcomes de reference : \n",
+    "**étape 1 : Fixer les références**\n",
+    "- Choisissez deux outcomes de référence : \n",
     "  - o_best (le meilleur) avec U(o_best) = 1\n",
     "  - o_worst (le pire) avec U(o_worst) = 0\n",
     "\n",
-    "**Etape 2 : Pour chaque outcome intermediaire**\n",
+    "**étape 2 : Pour chaque outcome intermediaire**\n",
     "- Presentez le choix : \n",
     "  - Option A : outcome o avec certitude\n",
     "  - Option B : loterie [p : o_best, (1-p) : o_worst]\n",
     "- Faites varier p jusqu'a trouver p* ou l'agent est indifferent\n",
     "\n",
-    "**Etape 3 : En deduire l'utilite**\n",
-    "- Par l'axiome de continuite : o ~ [p* : o_best, (1-p*) : o_worst]\n",
+    "**étape 3 : En deduire l'utilite**\n",
+    "- Par l'axiome de continuité : o ~ [p* : o_best, (1-p*) : o_worst]\n",
     "- Donc U(o) = p* × U(o_best) + (1-p*) × U(o_worst) = p* × 1 + (1-p*) × 0 = **p***\n",
     "\n",
-    "**Etape 4 : Interpoler**\n",
+    "**étape 4 : Interpoler**\n",
     "- Repetez pour plusieurs outcomes pour obtenir la courbe U(.)\n",
     "- Ajustez une fonction parametrique (log, CRRA, etc.)\n",
     "\n",
@@ -1573,7 +1573,7 @@
     "tags": []
    },
    "source": [
-    "### Analyse du resultat : Pourquoi une prime si elevee ?\n",
+    "### Analyse du resultat : Pourquoi une prime si élevée ?\n",
     "\n",
     "Le resultat montre qu'avec une utilite logarithmique, l'agent accepterait de payer jusqu'a **3691 EUR** pour assurer une voiture de 10 000 EUR contre un risque de vol de 5%.\n",
     "\n",
@@ -1594,7 +1594,7 @@
     "> $$\\text{Prime de risque} = E[L] - CE$$\n",
     "> Ici : Prime = 9 500 - (10 000 - 3691) = 9 500 - 6 309 = 3 191 EUR\n",
     "\n",
-    "Cette valeur elevee explique pourquoi les marches de l'assurance existent : les individus averses au risque sont prets a payer significativement plus que la perte esperee pour obtenir la certitude."
+    "Cette valeur élevée explique pourquoi les marches de l'assurance existent : les individus averses au risque sont prets a payer significativement plus que la perte esperee pour obtenir la certitude."
    ]
   },
   {
@@ -1621,18 +1621,18 @@
     "|---------|----------------------------|\n",
     "| Loteries | Representation formelle des choix incertains |\n",
     "| Axiomes VNM | Garantissent l'existence d'une fonction d'utilite |\n",
-    "| Calibration | Permet de determiner U empiriquement |\n",
-    "| E[U] maximisation | Critere de decision |\n",
+    "| Calibration | Permet de déterminer U empiriquement |\n",
+    "| E[U] maximisation | critère de decision |\n",
     "\n",
     "**Comment Infer.NET s'integre-t-il ?**\n",
     "\n",
-    "Infer.NET excelle dans l'**etape d'inference** : calculer les distributions posterieures sur les etats du monde. Une fois ces distributions obtenues, le calcul de l'utilite esperee devient une simple integration.\n",
+    "Infer.NET excelle dans l'**étape d'inference** : calculer les distributions posterieures sur les etats du monde. Une fois ces distributions obtenues, le calcul de l'utilite esperee devient une simple intégration.\n",
     "\n",
     "```\n",
     "Observation -> [Infer.NET: P(etat|obs)] -> [Calcul E[U]] -> Decision\n",
     "```\n",
     "\n",
-    "Dans la section suivante, nous montrons comment representer une loterie comme un modele probabiliste Infer.NET et comment exploiter l'inference pour la prise de decision."
+    "Dans la section suivante, nous montrons comment representer une loterie comme un modèle probabiliste Infer.NET et comment exploiter l'inference pour la prise de decision."
    ]
   },
   {
@@ -1651,15 +1651,15 @@
    "source": [
     "## 6. Modelisation avec Infer.NET\n",
     "\n",
-    "### Loteries comme modeles probabilistes\n",
+    "### Loteries comme modèles probabilistes\n",
     "\n",
-    "Une loterie peut etre naturellement modelisee comme une variable aleatoire dans Infer.NET. L'avantage de cette approche est triple :\n",
+    "Une loterie peut etre naturellement modelisee comme une variable aléatoire dans Infer.NET. L'avantage de cette approche est triple :\n",
     "\n",
     "1. **Inference** : Infer.NET peut calculer les posteriors sur des variables latentes (comme dans l'exemple medical precedent)\n",
-    "2. **Composition** : Les loteries composees sont modelisees par des modeles graphiques\n",
-    "3. **Integration** : Le calcul de E[U] peut s'appuyer sur les distributions inferees\n",
+    "2. **Composition** : Les loteries composees sont modelisées par des modèles graphiques\n",
+    "3. **intégration** : Le calcul de E[U] peut s'appuyer sur les distributions inferees\n",
     "\n",
-    "L'exemple suivant montre comment une loterie binaire simple est representee comme un modele conditionnel dans Infer.NET."
+    "L'exemple suivant montre comment une loterie binaire simple est représentée comme un modèle conditionnel dans Infer.NET."
    ]
   },
   {
@@ -1854,7 +1854,7 @@
     "- Recevoir 125 EUR avec certitude\n",
     "- Jouer la loterie [50% : +1000, 50% : -500] dont E = 250 EUR\n",
     "\n",
-    "> **Note Infer.NET** : Le moteur approxime la distribution bimodale par une Gaussienne (moyenne 250, variance elevee). Cette approximation suffit pour le calcul de E[X] mais pas pour les moments superieurs. Pour des calculs d'utilite precis, il vaut mieux calculer E[U] manuellement comme montre ci-dessus."
+    "> **Note Infer.NET** : Le moteur approxime la distribution bimodale par une Gaussienne (moyenne 250, variance élevée). Cette approximation suffit pour le calcul de E[X] mais pas pour les moments superieurs. Pour des calculs d'utilite precis, il vaut mieux calculer E[U] manuellement comme montre ci-dessus."
    ]
   },
   {
@@ -1955,7 +1955,7 @@
     "tags": []
    },
    "source": [
-    "Affichage du graphe de facteurs du modele de loterie avec utilite."
+    "Affichage du graphe de facteurs du modèle de loterie avec utilite."
    ]
   },
   {
@@ -2151,7 +2151,7 @@
     "\n",
     "**Question** : Pour quelle valeur de X etes-vous indifferent entre A et B ?\n",
     "\n",
-    "### Methode\n",
+    "### Méthode\n",
     "\n",
     "1. Si votre X* = 500, vous etes **neutre au risque**\n",
     "2. Si votre X* < 500, vous etes **averse au risque**\n",
@@ -2439,7 +2439,7 @@
     "| Menages americains | 1.0 - 3.0 |\n",
     "| Decisions de sante | 2.0 - 5.0 |\n",
     "\n",
-    "> **Note technique** : La loterie utilise `epsilon = 1` au lieu de 0 car CRRA n'est pas definie en 0 pour rho >= 1. Cela affecte legerement les resultats numeriques mais pas l'interpretation qualitative.\n",
+    "> **Note technique** : La loterie utilise `epsilon = 1` au lieu de 0 car CRRA n'est pas définie en 0 pour rho >= 1. Cela affecte legerement les resultats numeriques mais pas l'interpretation qualitative.\n",
     "\n",
     "Le notebook suivant (DecInfer-3) approfondira ces fonctions d'utilite et leurs proprietes."
    ]
@@ -2462,11 +2462,11 @@
     "\n",
     "### Objectif\n",
     "\n",
-    "Implementer et comparer deux familles de fonctions d'utilite classiques en economie pour une meme loterie, et analyser comment leurs primes de risque different.\n",
+    "Implementer et comparer deux familles de fonctions d'utilite classiques en economie pour une même loterie, et analyser comment leurs primes de risque different.\n",
     "\n",
     "### Contexte\n",
     "\n",
-    "Deux grandes familles de fonctions d'utilite sont utilisees en pratique :\n",
+    "Deux grandes familles de fonctions d'utilite sont utilisées en pratique :\n",
     "\n",
     "- **CARA** (Constant Absolute Risk Aversion) : U(x) = -exp(-alpha * x)\n",
     "  - L'aversion absolue au risque est constante : A(x) = -U''(x)/U'(x) = alpha\n",
@@ -2480,8 +2480,8 @@
     "\n",
     "Considerez la loterie suivante : **50% de chance de gagner 2000 EUR, 50% de perdre 500 EUR** (richesse initiale = 10 000 EUR).\n",
     "\n",
-    "1. **Implementer CARA** : Definir U_CARA(x, alpha) = -exp(-alpha * x) et calculer l'equivalent certain CE_CARA pour alpha = 0.001\n",
-    "2. **Implementer CRRA** : Definir U_CRRA(x, rho) = x^(1-rho)/(1-rho) et calculer l'equivalent certain CE_CRRA pour rho = 2.0\n",
+    "1. **Implementer CARA** : définir U_CARA(x, alpha) = -exp(-alpha * x) et calculer l'equivalent certain CE_CARA pour alpha = 0.001\n",
+    "2. **Implementer CRRA** : définir U_CRRA(x, rho) = x^(1-rho)/(1-rho) et calculer l'equivalent certain CE_CRRA pour rho = 2.0\n",
     "3. **Calculer les primes de risque** : Prime = E[gain] - CE pour chaque fonction\n",
     "4. **Comparer** les primes de risque et interpreter la difference\n",
     "5. **Bonus** : Tester avec une richesse initiale differente (ex: 1000 EUR) et observer comment la prime CARA reste constante mais CRRA change\n",
@@ -2489,7 +2489,7 @@
     "**Indices** :\n",
     "- # Indice 1 : Pour trouver l'equivalent certain, utilisez une recherche par dichotomie sur l'intervalle [perteBasse - 100, gainHaut + 100]\n",
     "- # Indice 2 : Pour CRRA, traitez le cas rho = 1 separement avec `Math.Abs(rho - 1) < 1e-6` et utilisez `Math.Log(x)` dans ce cas\n",
-    "- # Etape 3 : Prime de risque = E[gain] - CE. Si la prime est positive, l'agent est averse au risque"
+    "- # étape 3 : Prime de risque = E[gain] - CE. Si la prime est positive, l'agent est averse au risque"
    ]
   },
   {
@@ -2610,10 +2610,10 @@
     "| Concept | Description |\n",
     "|---------|-------------|\n",
     "| **Loterie** | Distribution de probabilite sur des outcomes |\n",
-    "| **Axiomes VNM** | Completude, Transitivite, Continuite, Independance |\n",
+    "| **Axiomes VNM** | Completude, Transitivite, continuité, Independance |\n",
     "| **Theoreme de representation** | Existence d'une fonction U telle que preferences = max E[U] |\n",
     "| **Agent rationnel** | Maximise l'utilite esperee de ses actions |\n",
-    "| **Calibration** | Methode de l'indifference pour determiner U |\n",
+    "| **Calibration** | méthode de l'indifference pour déterminer U |\n",
     "\n",
     "---\n",
     "\n",
@@ -2622,12 +2622,12 @@
     "| Si vous voulez... | Consultez... |\n",
     "|-------------------|-------------|\n",
     "| Approfondir l'aversion au risque | [DecInfer-3-Utility-Money](DecInfer-3-Utility-Money.ipynb) |\n",
-    "| Decisions multi-criteres | [DecInfer-4-Multi-Attribute](DecInfer-4-Multi-Attribute.ipynb) |\n",
-    "| Visualiser les reseaux de decision | [DecInfer-5-Decision-Networks](DecInfer-5-Decision-Networks.ipynb) |\n",
+    "| Decisions multi-critères | [DecInfer-4-Multi-Attribute](DecInfer-4-Multi-Attribute.ipynb) |\n",
+    "| Visualiser les réseaux de decision | [DecInfer-5-Decision-Networks](DecInfer-5-Decision-Networks.ipynb) |\n",
     "\n",
     "---\n",
     "\n",
-    "## Prochaine etape\n",
+    "## Prochaine étape\n",
     "\n",
     "Dans [DecInfer-3-Utility-Money](DecInfer-3-Utility-Money.ipynb), nous approfondirons :\n",
     "\n",
@@ -2638,7 +2638,7 @@
     "\n",
     "---\n",
     "\n",
-    "## References\n",
+    "## Références\n",
     "\n",
     "- Von Neumann & Morgenstern (1944) : Theory of Games and Economic Behavior\n",
     "- Russell & Norvig : Artificial Intelligence, Chapter 16\n",


### PR DESCRIPTION
## Summary

Restore French accents in markdown source cells of `MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-1-Utility-Foundations.ipynb` (7ème étape de la vague c.594-c.595-c.596-c.597-c.598-c.599-c.600 cross-famille ML→GenAI/Audio→Search/Part1→Sudoku→Search/Part2-CSP→SymbolicAI/Tweety→Probas/DecInfer).

## Metrics

- **74 cures** appliquées sur **22 cellules markdown**
- 1 file / 1 domain / 1 feature (R3 atomicité)
- R6 anti-monotonie : Probas/DecInfer (DecisionTheory family) après ML-4 (c.594), GenAI/Audio (c.595), Search/Part1 (c.596), Sudoku (c.597), Search/Part2-CSP (c.598), SymbolicAI/Tweety (c.599)
- +59/-59 (multiline cells = JSON source-array string regroupé ; LF 2689/2689 inchange, bytes delta mineur)

## Stop & Repair strict (HARD, règle 6 secrets-hygiene.md)

- 0 code cell source diff
- 0 outputs diff
- 0 execution_count diff
- 0 cell added/removed (43 cells préservées)
- nbformat 4.5 préservé
- CRLF 0/0 préservé
- LF 2689/2689 inchange

## Pré-flight collision (L679-L1 ★★)

`gh pr list --state all --search "DecInfer-1-Utility-Foundations"` : 18 PRs mais aucune touchait les accents markdown. Le notebook Python était vierge côté accents → **0 collision**.

## Leçons cumulées (synchronisation avec vagues précédentes)

- **Leçon c.591 ★** : binary write `open('wb')` + `.encode('utf-8')` pour préserver LF
- **Leçon c.593 ★** : raw-text surgical bypass `nbformat.write` via `json.dumps(indent=4)` + closing `]` 3-space indent fix
- **Leçon c.596 ★** : pre-commit grep validation des participes passés + désambiguïsation présent/participe (`determine`→`détermine`, `determinant`→`déterminant`, `applique`→`applique` present 3rd ps SANS accent, `intégration` (noun) ≠ `intègre` (verb))
- **Leçon c.597 ★** : TARGETS coverage complète (plural/dérivés/verbes conjugués)
- **Leçon c.598 ★** : verbes 3ème groupe oubliés du base-dict
- **Leçon c.599 ★ (L524 ★)** : pondere-3rd-ps-disambiguation (3rd ps sg present `pondère` ≠ 3rd pp `pondéré`)

## Pre-commit grep (lesson c.596)

Tous les verbes en `-é`/`-ée`/`-ées` post-fix vérifiés par contexte :

| Cell | Forme | Contexte | Verdict |
|------|-------|----------|---------|
| cell[7] | "structure de données sera **utilisée**" | sujet f.sg + "sera" = pp f.sg | ✅ |
| cell[30] | "**intégration** : Le calcul de E[U]" | nom substantif | ✅ |
| cell[31] | "loterie binaire simple est **représentée**" | sujet f.sg + "est" = pp f.sg | ✅ |
| cell[31] | "loteries sont **modelisées** par des modèles" | sujet f.pl + "sont" = pp f.pl | ✅ |
| cell[40] | "fonctions d'utilite sont **utilisées**" | sujet f.pl + "sont" = pp f.pl | ✅ |

0 faux positif post-fix. `applique` (3rd ps present) correctement laissé SANS accent. `considère` (3rd ps present) correctement accentué. `utilisé(es)` toujours pp contextuel ("est/sont utilisé(es)"), jamais verbe présent.

## Scope strict : markdown only (leçon c.598 ★)

Code cells + outputs INCHANGÉS (0 diff). Les occurrences `donnees`/`regles`/`variables` dans les **commentaires C#** (`// ...`) et les **string-literals stdout** (`WriteLine(...)`) restent volontairement sans accent :
- **Commentaires C#** : OUT of scope per ai-01 accent contract
- **String-literals stdout** : nécessitent re-exécution .NET Interactive + Infer.NET setup (heavy) pour cohérence output, hors scope c.600 (R3 atomic 1f/1feature)

Voir issue #2876 pour batch dédié DecInfer string-literal re-execution.

See #2876
