### PR TITLE
fix(probas,#2876): restore French accents in PyMC-6-Debugging markdown (288 cures)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-6-Debugging.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-6-Debugging.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# PyMC-6-Debugging : Troubleshooting et Bonnes Pratiques\n",
     "\n",
-    "**Serie** : Programmation Probabiliste avec PyMC (6/20)  \n",
+    "**Serie** : Programmation probabiliste avec PyMC (6/20)  \n",
     "**Duree estimee** : 45 minutes  \n",
     "**Prerequis** : Avoir explore plusieurs notebooks de la serie\n",
     "\n",
@@ -24,16 +24,16 @@
     "\n",
     "## Objectifs\n",
     "\n",
-    "- Diagnostiquer les problemes courants d'inference MCMC\n",
+    "- Diagnostiquer les problèmes courants d'inférence MCMC\n",
     "- Comparer les algorithmes (NUTS, ADVI, SGVM)\n",
-    "- Utiliser les outils de diagnostic d'ArviZ\n",
+    "- utiliser les outils de diagnostic d'ArviZ\n",
     "- Appliquer les bonnes pratiques de modelisation\n",
     "\n",
     "---\n",
     "\n",
     "## Navigation\n",
     "\n",
-    "| Precedent | Index |\n",
+    "| précédent | Index |\n",
     "|-----------|-------|\n",
     "| [PyMC-15-Recommenders](PyMC-15-Recommenders.ipynb) | [README](../Infer/README.md) |\n",
     "\n",
@@ -124,15 +124,15 @@
     "\n",
     "| Package | Role |\n",
     "|---------|------|\n",
-    "| `pymc` | Modeles probabilistes, echantillonneurs (NUTS, ADVI, Metropolis) |\n",
-    "| `arviz` | Diagnostics MCMC (trace plots, R-hat, ESS, divergences) |\n",
-    "| `numpy` | Calculs numeriques et generation de donnees |\n",
+    "| `pymc` | modèles probabilistes, échantillonneurs (NUTS, ADVI, Metropolis) |\n",
+    "| `arviz` | diagnostics MCMC (trace plots, R-hat, ESS, divergences) |\n",
+    "| `numpy` | Calculs numériques et génération de données |\n",
     "\n",
     "Les outils importants pour le debugging sont :\n",
-    "- `pm.sample()` : echantillonnage MCMC avec NUTS par defaut\n",
+    "- `pm.sample()` : échantillonnage MCMC avec NUTS par defaut\n",
     "- `az.summary()` : statistiques de diagnostic (R-hat, ESS)\n",
     "- `az.plot_trace()` : visualisation des traces\n",
-    "- `az.plot_energy()` : diagnostic de l'energie du hamiltonien"
+    "- `az.plot_energy()` : diagnostic de l'énergie du hamiltonien"
    ]
   },
   {
@@ -149,7 +149,7 @@
     "tags": []
    },
    "source": [
-    "> **Note technique** : Ce notebook est oriente *troubleshooting*. Il suppose que vous avez deja explore plusieurs notebooks de la serie et rencontre des comportements inattendus. Les exemples sont volontairement simplifies pour isoler chaque type de probleme.\n",
+    "> **Note technique** : Ce notebook est oriente *troubleshooting*. Il suppose que vous avez deja explore plusieurs notebooks de la serie et rencontre des comportements inattendus. Les exemples sont volontairement simplifies pour isoler chaque type de problème.\n",
     "\n",
     "Le debugging en programmation probabiliste differe du debugging classique :\n",
     "\n",
@@ -157,7 +157,7 @@
     "|---------------------|------------------------|\n",
     "| Erreur = crash ou mauvaise valeur | Erreur = divergence, R-hat > 1.01, ESS faible |\n",
     "| Cause souvent deterministe | Cause souvent liee aux priors ou a la parametrisation |\n",
-    "| Solution : corriger le code | Solution : ajuster le modele ou la parametrisation |"
+    "| Solution : corriger le code | Solution : ajuster le modèle ou la parametrisation |"
    ]
   },
   {
@@ -174,17 +174,17 @@
     "tags": []
    },
    "source": [
-    "## 2. Problemes Courants et Solutions\n",
+    "## 2. Problèmes Courants et Solutions\n",
     "\n",
-    "### 2.1 Catalogue des Problemes\n",
+    "### 2.1 Catalogue des Problèmes\n",
     "\n",
-    "| Probleme | Cause | Solution |\n",
+    "| problème | Cause | Solution |\n",
     "|----------|-------|----------|\n",
-    "| Divergences | Neologie abrupte du posterior | Reparametriser ou augmenter `target_accept` |\n",
-    "| R-hat > 1.01 | Chaines non convergees | Plus d'iterations ou reparametriser |\n",
-    "| ESS faible | Autocorrelation elevee | Plus d'iterations ou thinning |\n",
-    "| Erreur `SamplingError` | Prior incompatible avec les donnees | Elargir le prior ou verifier les observations |\n",
-    "| Erreur `BadInitialEnergy` | Point de depart avec probabilite nulle | Changer l'initialisation ou elargir les priors |"
+    "| divergences | Neologie abrupte du posterior | Reparametriser ou augmenter `target_accept` |\n",
+    "| R-hat > 1.01 | Chaines non convergees | Plus d'itérations ou reparametriser |\n",
+    "| ESS faible | Autocorrelation élevée | Plus d'itérations ou thinning |\n",
+    "| Erreur `SamplingError` | Prior incompatible avec les données | Elargir le prior ou vérifier les observations |\n",
+    "| Erreur `BadInitialEnergy` | Point de depart avec probabilité nulle | Changer l'initialisation ou elargir les priors |"
    ]
   },
   {
@@ -310,11 +310,11 @@
     "tags": []
    },
    "source": [
-    "**Interpretation des resultats** :\n",
+    "**interprétation des résultats** :\n",
     "\n",
-    "Avec un prior large `Normal(0, 100)`, l'observation `y=50` domine le posterior. Le resultat est coherent : la moyenne posterieure est proche de 50.\n",
+    "Avec un prior large `Normal(0, 100)`, l'observation `y=50` domine le posterior. Le résultat est cohérent : la moyenne postérieure est proche de 50.\n",
     "\n",
-    "> **Regle pratique** : Si votre prior a un ecart-type `sigma`, les observations situees a plus de `3*sigma` de la moyenne du prior auront une vraisemblance quasi-nulle sous le prior. Avec `sigma=0.001`, cela represente environ `0.003` unites autour de 0."
+    "> **règle pratique** : Si votre prior a un ecart-type `sigma`, les observations situees a plus de `3*sigma` de la moyenne du prior auront une vraisemblance quasi-nulle sous le prior. Avec `sigma=0.001`, cela représente environ `0.003` unites autour de 0."
    ]
   },
   {
@@ -333,9 +333,9 @@
    "source": [
     "### 2.2 Divergences\n",
     "\n",
-    "Les divergences sont le probleme le plus courant avec NUTS. Elles indiquent que l'echantillonneur a du mal a explorer certaines regions de l'espace des parametres, souvent a cause de la **geometrie du posterior**.\n",
+    "Les divergences sont le problème le plus courant avec NUTS. Elles indiquent que l'échantillonneur a du mal a explorer certaines regions de l'espace des paramètres, souvent a cause de la **geometrie du posterior**.\n",
     "\n",
-    "> **Mecanisme** : Une divergence se produit lorsque l'integrateur hamiltonien de NUTS commet une erreur de simulation trop grande (erreur d'energie depassant le seuil lie a `target_accept`) en traversant une region de forte courbure - typiquement le col etroit d'un entonnoir hierarchique. La trajectoire quitte alors l'ensemble typique (*typical set*) et l'echantillon est rejete. Traitement de reference : Betancourt (2017), *A conceptual introduction to Hamiltonian Monte Carlo*, arXiv:1701.02434."
+    "> **mécanisme** : Une divergence se produit lorsque l'integrateur hamiltonien de NUTS commet une erreur de simulation trop grande (erreur d'énergie depassant le seuil lie a `target_accept`) en traversant une region de forte courbure - typiquement le col etroit d'un entonnoir hierarchique. La trajectoire quitte alors l'ensemble typique (*typical set*) et l'échantillon est rejeté. Traitement de référence : Betancourt (2017), *A conceptual introduction to Hamiltonian Monte Carlo*, arXiv:1701.02434."
    ]
   },
   {
@@ -471,18 +471,18 @@
    "source": [
     "## Exercice 2 : Reparametrisation non-centree\n",
     "\n",
-    "Le modele hierarchique ci-dessous souffre d'un probleme d'entonnoir (funnel) :\n",
-    "la variance de `theta` depend de `sigma_groupe`, ce qui cree une geometrie\n",
+    "Le modèle hierarchique ci-dessous souffre d'un problème d'entonnoir (funnel) :\n",
+    "la variance de `theta` dépend de `sigma_groupe`, ce qui cree une geometrie\n",
     "difficile pour NUTS. Corrigez-le en appliquant la **reparametrisation non-centree**.\n",
     "\n",
-    "**Objectif** : eliminer les divergences en reformulant le modele.\n",
+    "**Objectif** : eliminer les divergences en reformulant le modèle.\n",
     "\n",
     "**Indices** :\n",
     "- Remplacer `theta ~ Normal(mu_groupe, sigma_groupe)` par :\n",
     "  `theta_offset ~ Normal(0, 1)` puis `theta = mu_groupe + sigma_groupe * theta_offset`\n",
-    "- Utiliser `pm.Deterministic` pour declarer theta comme variable derivee\n",
+    "- utiliser `pm.Deterministic` pour declarer theta comme variable dérivée\n",
     "- Echantillonner avec `target_accept=0.95`\n",
-    "- Verifier que le nombre de divergences est 0 avec `trace.sample_stats[\"diverging\"].sum()`"
+    "- vérifier que le nombre de divergences est 0 avec `trace.sample_stats[\"diverging\"].sum()`"
    ]
   },
   {
@@ -550,17 +550,17 @@
    "source": [
     "### La reparametrisation non-centree\n",
     "\n",
-    "Le probleme de l'entonnoir est un cas classique. Quand la variance d'un parametre depend d'un autre, NUTS peut \"diverger\" dans les regions etroites de l'entonnoir.\n",
+    "Le problème de l'entonnoir est un cas classique. Quand la variance d'un paramètre dépend d'un autre, NUTS peut \"diverger\" dans les regions etroites de l'entonnoir.\n",
     "\n",
-    "> **Origine** : L'entonnoir (*funnel*) est decrit par Neal (2003), *Slice sampling*, Annals of Statistics 31(3), et applique aux modeles hierarchiques par Betancourt & Girolami (2015), *Hamiltonian Monte Carlo for hierarchical models*, JRSS C 64(1). La reparametrisation non-centree est le traitement standard recommande par le manuel Stan et par Gelman et al., *Bayesian Data Analysis* (BDA3, ch. 5).\n",
+    "> **Origine** : L'entonnoir (*funnel*) est decrit par Neal (2003), *Slice sampling*, Annals of Statistics 31(3), et applique aux modèles hierarchiques par Betancourt & Girolami (2015), *Hamiltonian Monte Carlo for hierarchical models*, JRSS C 64(1). La reparametrisation non-centree est le traitement standard recommande par le manuel Stan et par Gelman et al., *Bayesian Data Analysis* (BDA3, ch. 5).\n",
     "\n",
     "Les solutions incluent :\n",
     "\n",
     "| Solution | Avantage | Inconvenient |\n",
     "|----------|----------|--------------|\n",
     "| Reparametrisation non-centree | Elimine souvent les divergences | Necessite de reflechir a la geometrie |\n",
-    "| Augmenter `target_accept` | Simple a implementer | Ralentit l'echantillonnage |\n",
-    "| Changer de parametrisation | Peut simplifier la geometrie | Specifique au modele |"
+    "| Augmenter `target_accept` | Simple a implementer | Ralentit l'échantillonnage |\n",
+    "| Changer de parametrisation | Peut simplifier la geometrie | spécifique au modèle |"
    ]
   },
   {
@@ -577,17 +577,17 @@
     "tags": []
    },
    "source": [
-    "## 3. Comparaison des Algorithmes d'Inference\n",
+    "## 3. Comparaison des Algorithmes d'Inférence\n",
     "\n",
     "### Quand utiliser quel algorithme ?\n",
     "\n",
     "| Algorithme | Forces | Faiblesses | Usage recommande |\n",
     "|------------|--------|------------|------------------|\n",
-    "| **NUTS** | Autonome, bon pour modeles continus | Lent pour grands modeles | Defaut, modeles avec ~10-100 parametres |\n",
-    "| **ADVI** | Rapide, passe a l'echelle | Approximation gaussienne, sous-estime l'incertitude | Grands modeles, prototype rapide |\n",
-    "| **Metropolis** | Simple | Autocorrelation elevee, necessite tuning | Modeles discrets, verification |\n",
+    "| **NUTS** | Autonome, bon pour modèles continus | lent pour grands modèles | Defaut, modèles avec ~10-100 paramètres |\n",
+    "| **ADVI** | rapide, passe a l'échelle | Approximation gaussienne, sous-estime l'incertitude | Grands modèles, prototype rapide |\n",
+    "| **Metropolis** | Simple | Autocorrelation élevée, necessite tuning | modèles discrets, vérification |\n",
     "\n",
-    "> **References algorithmiques** : NUTS - Hoffman & Gelman (2014), *The No-U-Turn Sampler*, JMLR 15. ADVI (mean-field) - Kucukelbir, Ranganath, Gelman & Blei (2017), *Automatic variational inference in Stan*, JMLR 18 (analyse la sous-estimation de l'incertitude due a la factorisation). Metropolis-Hastings - Hastings (1970), Biometrika 57(1)."
+    "> **références algorithmiques** : NUTS - Hoffman & Gelman (2014), *The No-U-Turn Sampler*, JMLR 15. ADVI (mean-field) - Kucukelbir, Ranganath, Gelman & Blei (2017), *Automatic variational inférence in Stan*, JMLR 18 (analyse la sous-estimation de l'incertitude due a la factorisation). Metropolis-Hastings - Hastings (1970), Biometrika 57(1)."
    ]
   },
   {
@@ -604,14 +604,14 @@
     "tags": []
    },
    "source": [
-    "La cellule suivante compare NUTS et ADVI sur un probleme simple d'estimation de moyenne avec variance inconnue.\n",
+    "La cellule suivante compare NUTS et ADVI sur un problème simple d'estimation de moyenne avec variance inconnue.\n",
     "\n",
     "**Configuration du test** :\n",
     "- 6 observations autour de 2.0\n",
     "- Prior vague sur la moyenne : Normal(0, 100)\n",
     "- Prior sur l'ecart-type : HalfNormal(10)\n",
     "\n",
-    "Ce type de modele (donnees gaussiennes avec parametres inconnus) est un cas classique ou NUTS et ADVI donnent des resultats comparables mais avec des niveaux d'incertitude differents."
+    "Ce type de modèle (données gaussiennes avec paramètres inconnus) est un cas classique ou NUTS et ADVI donnent des résultats comparables mais avec des niveaux d'incertitude differents."
    ]
   },
   {
@@ -767,27 +767,27 @@
     "tags": []
    },
    "source": [
-    "**Interpretation des resultats NUTS vs ADVI** :\n",
+    "**interprétation des résultats NUTS vs ADVI** :\n",
     "\n",
-    "Les deux algorithmes estiment la moyenne autour de 2.05 (proche de la moyenne empirique), mais avec des caracteristiques differentes :\n",
+    "Les deux algorithmes estiment la moyenne autour de 2.05 (proche de la moyenne empirique), mais avec des caractéristiques differentes :\n",
     "\n",
-    "| Metrique | NUTS | ADVI | Interpretation |\n",
+    "| Metrique | NUTS | ADVI | interprétation |\n",
     "|----------|------|------|----------------|\n",
-    "| Moyenne posterieure | ~2.05 | ~2.05 | Accord sur l'estimation ponctuelle |\n",
-    "| Ecart-type posterieur | ~0.13 (observe) | ~1.00 (observe) | Sur cet exemple n=6, ADVI deplace sa moyenne (1.56 vs 2.04) et sa variance marginale est plus large - voir note ci-dessous |\n",
+    "| Moyenne postérieure | ~2.05 | ~2.05 | Accord sur l'estimation ponctuelle |\n",
+    "| Ecart-type postérieur | ~0.13 (observe) | ~1.00 (observe) | Sur cet exemple n=6, ADVI deplace sa moyenne (1.56 vs 2.04) et sa variance marginale est plus large - voir note ci-dessous |\n",
     "\n",
     "> **Pourquoi ADVI sous-estime l'incertitude ?**\n",
     "> \n",
-    "> ADVI (Automatic Differentiation Variational Inference, Kucukelbir et al. 2017) approxime le posterior par une distribution gaussienne factorisee (\"mean-field\"). Cette hypothese d'independance ignore les correlations entre variables, ce qui conduit **en general (asymptotiquement)** a des posteriors trop \"confiants\" (variance sous-estimee).\n",
+    "> ADVI (Automatic Differentiation Variational inférence, Kucukelbir et al. 2017) approxime le posterior par une distribution gaussienne factorisee (\"mean-field\"). Cette hypothese d'indépendance ignore les corrélations entre variables, ce qui conduit **en général (asymptotiquement)** a des posteriors trop \"confiants\" (variance sous-estimee).\n",
     ">\n",
-    "> **Sur ce petit exemple (n=6)** : l'output montre l'inverse - `ADVI: std=0.9984` vs `NUTS: std=0.1321`. La cause est qu'ADVI deplace sa moyenne (1.56 vs 2.04) sur aussi peu de donnees, ce qui gonfle la variance marginale. Ce cas illustre que la sous-estimation ADVI est une **tendance asymptotique**, pas une garantie sur chaque run. Pour un diagnostic fiable, utiliser un plus grand n ou comparer les intervalles de prediction.\n",
+    "> **Sur ce petit exemple (n=6)** : l'output montre l'inverse - `ADVI: std=0.9984` vs `NUTS: std=0.1321`. La cause est qu'ADVI deplace sa moyenne (1.56 vs 2.04) sur aussi peu de données, ce qui gonfle la variance marginale. Ce cas illustre que la sous-estimation ADVI est une **tendance asymptotique**, pas une garantie sur chaque run. Pour un diagnostic fiable, utiliser un plus grand n ou comparer les intervalles de prediction.\n",
     ">\n",
-    "> NUTS (No-U-Turn Sampler) echantillonne directement du posterior, capturant les correlations et produisant des estimations d'incertitude plus fiables.\n",
+    "> NUTS (No-U-Turn Sampler) echantillonne directement du posterior, capturant les corrélations et produisant des estimations d'incertitude plus fiables.\n",
     "\n",
     "**Quand cela importe** : La sous-estimation de l'incertitude par ADVI peut etre problematique pour :\n",
     "- La prise de decision sous incertitude\n",
     "- Les intervalles de prediction\n",
-    "- La propagation de l'incertitude dans des modeles hierarchiques"
+    "- La propagation de l'incertitude dans des modèles hierarchiques"
    ]
   },
   {
@@ -810,10 +810,10 @@
     "\n",
     "| Indicateur | Seuil acceptable | Signification |\n",
     "|------------|------------------|---------------|\n",
-    "| `R-hat` | < 1.01 | Convergence des chaines |\n",
-    "| `ESS (bulk)` | > 400 | Taille effective de l'echantillon |\n",
-    "| `ESS (tail)` | > 400 | Qualite des quantiles extremes |\n",
-    "| Divergences | 0 | Qualite de l'echantillonnage |\n",
+    "| `R-hat` | < 1.01 | convergence des chaines |\n",
+    "| `ESS (bulk)` | > 400 | Taille effective de l'échantillon |\n",
+    "| `ESS (tail)` | > 400 | Qualite des quantiles extrêmes |\n",
+    "| divergences | 0 | Qualite de l'échantillonnage |\n",
     "\n",
     "> **Source des seuils** : Les valeurs `R-hat < 1.01` et `ESS > 400`, ainsi que les colonnes `r_hat` / `ess_bulk` / `ess_tail` renvoyees par `az.summary()`, suivent la **version moderne rank-normalisee** de Vehtari, Gelman, Simpson, Carpenter & Burkner (2021), *Rank-normalization, folding, and localization: An improved R-hat for assessing convergence of MCMC*, Bayesian Analysis 16(2), doi:10.1214/20-BA1221. Cette version remplace le R-hat original de Gelman & Rubin (1992, Statistical Science 7(4)) et distingue le bulk-ESS du tail-ESS."
    ]
@@ -944,7 +944,7 @@
     "tags": []
    },
    "source": [
-    "**Interpretation du resultat** :\n",
+    "**interprétation du résultat** :\n",
     "\n",
     "Le posterior de `mu` resulte de la mise a jour bayesienne :\n",
     "\n",
@@ -952,7 +952,7 @@
     "\n",
     "$$\\sigma^2_{\\text{post}} = \\frac{1}{\\tau_{\\text{prior}} + \\tau_{\\text{likelihood}}} = \\frac{1}{2} = 0.5$$\n",
     "\n",
-    "Ou $\\tau = 1/\\sigma^2$ represente la precision. Le posterior est exactement a mi-chemin entre le prior (0) et l'observation (5), car les deux ont la meme precision."
+    "Ou $\\tau = 1/\\sigma^2$ représente la precision. Le posterior est exactement a mi-chemin entre le prior (0) et l'observation (5), car les deux ont la même precision."
    ]
   },
   {
@@ -975,10 +975,10 @@
     "\n",
     "| Visualisation | Usage |\n",
     "|---------------|-------|\n",
-    "| `plot_trace()` | Verifier le melange des chaines et la forme des posteriors |\n",
-    "| `plot_energy()` | Verifier la qualite de l'echantillonnage NUTS |\n",
-    "| `plot_rank()` | Detecter les biais d'echantillonnage |\n",
-    "| `plot_pair()` | Identifier les correlations entre parametres |\n",
+    "| `plot_trace()` | vérifier le melange des chaines et la forme des posteriors |\n",
+    "| `plot_energy()` | vérifier la qualite de l'échantillonnage NUTS |\n",
+    "| `plot_rank()` | détecter les biais d'échantillonnage |\n",
+    "| `plot_pair()` | identifier les corrélations entre paramètres |\n",
     "\n",
     "> **Cadre methodologique** : Ces visualisations s'inscrivent dans le *workflow bayesien* de Gabry, Simpson, Vehtari, Betancourt & Gelman (2019), *Visualization in Bayesian workflow*, JRSS C 68(2), doi:10.1111/rssc.12346, et de Gelman et al. (2020), *Bayesian Workflow*, arXiv:2011.01808. `plot_rank()` implemente les *rank plots* de Vehtari et al. (2021)."
    ]
@@ -1113,21 +1113,21 @@
     "tags": []
    },
    "source": [
-    "### Comment interpreter les diagnostics ?\n",
+    "### Comment interpréter les diagnostics ?\n",
     "\n",
     "| Element | Bon signe | Mauvais signe |\n",
     "|---------|-----------|---------------|\n",
-    "| **Trace** | Bruit uniforme, pas de tendance | Motifs periodiques, chaines separees |\n",
+    "| **Trace** | Bruit uniforme, pas de tendance | Motifs periodiques, chaines séparées |\n",
     "| **R-hat** | < 1.01 | > 1.01 (chaines non convergees) |\n",
-    "| **ESS** | > 400 | < 400 (echantillon inefficace) |\n",
-    "| **Divergences** | 0 | > 0 (echantillonnage douteux) |\n",
+    "| **ESS** | > 400 | < 400 (échantillon inefficace) |\n",
+    "| **divergences** | 0 | > 0 (échantillonnage douteux) |\n",
     "\n",
-    "> **Utilite pour le debugging** :\n",
+    "> **utilité pour le debugging** :\n",
     "> \n",
-    "> Les visualisations ArviZ permettent de verifier que :\n",
+    "> Les visualisations ArviZ permettent de vérifier que :\n",
     "> 1. Les chaines sont bien melangees (trace plots)\n",
     "> 2. Les posteriors ont des formes raisonnables\n",
-    "> 3. Il n'y a pas de divergences qui indiqueraient un probleme de geometrie\n",
+    "> 3. Il n'y a pas de divergences qui indiqueraient un problème de geometrie\n",
     "> 4. L'ESS est suffisant pour des estimations fiables"
    ]
   },
@@ -1154,7 +1154,7 @@
     "with pm.Model() as model:\n",
     "    capacite_etudiant = pm.Normal(\"capacite_etudiant\", mu=0, sigma=1, shape=n_etudiants)\n",
     "\n",
-    "# MAUVAIS : Noms generiques\n",
+    "# MAUVAIS : Noms génériques\n",
     "with pm.Model() as model:\n",
     "    x = pm.Normal(\"x\", mu=0, sigma=1)\n",
     "```\n",
@@ -1165,7 +1165,7 @@
     "|-----------|------------------|----------------------|\n",
     "| Moyenne inconnue | Normal large | `pm.Normal(\"x\", mu=0, sigma=100)` |\n",
     "| Ecart-type inconnu | HalfNormal ou HalfCauchy | `pm.HalfNormal(\"sigma\", sigma=10)` |\n",
-    "| Probabilite | Beta ou Uniform | `pm.Beta(\"p\", alpha=1, beta=1)` |\n",
+    "| probabilité | Beta ou Uniform | `pm.Beta(\"p\", alpha=1, beta=1)` |\n",
     "| Poids melange | Dirichlet | `pm.Dirichlet(\"w\", a=np.ones(k))` |"
    ]
   },
@@ -1185,13 +1185,13 @@
    "source": [
     "### Demonstration de l'impact des priors\n",
     "\n",
-    "Le choix des priors est souvent la source principale de problemes en programmation probabiliste. Un prior mal choisi peut :\n",
+    "Le choix des priors est souvent la source principale de problèmes en programmation probabiliste. Un prior mal choisi peut :\n",
     "\n",
-    "1. **Rendre l'inference impossible** : si l'observation a probabilite nulle sous le prior\n",
-    "2. **Biaiser les resultats** : si le prior \"domine\" les donnees\n",
-    "3. **Ralentir la convergence** : si le prior est tres different des donnees\n",
+    "1. **Rendre l'inférence impossible** : si l'observation a probabilité nulle sous le prior\n",
+    "2. **Biaiser les résultats** : si le prior \"domine\" les données\n",
+    "3. **Ralentir la convergence** : si le prior est très different des données\n",
     "\n",
-    "La cellule suivante illustre l'impact de differents priors Beta sur l'estimation d'une probabilite binomiale avec seulement 5 observations."
+    "La cellule suivante illustre l'impact de differents priors Beta sur l'estimation d'une probabilité binomiale avec seulement 5 observations."
    ]
   },
   {
@@ -1448,9 +1448,9 @@
     "tags": []
    },
    "source": [
-    "**Analyse detaillee des resultats** :\n",
+    "**Analyse detaillee des résultats** :\n",
     "\n",
-    "| Prior | Alpha | Beta | Moyenne prior | Moyenne posterieure attendue | Ecart au MLE |\n",
+    "| Prior | Alpha | Beta | Moyenne prior | Moyenne postérieure attendue | Ecart au MLE |\n",
     "|-------|-------|------|---------------|------------------------------|--------------|\n",
     "| Uniforme | 1 | 1 | 0.500 | 0.571 | -0.029 |\n",
     "| Centre | 2 | 2 | 0.500 | 0.556 | -0.044 |\n",
@@ -1459,17 +1459,17 @@
     "\n",
     "Le posterior Beta suit la formule analytique :\n",
     "\n",
-    "$$p \\mid \\text{data} \\sim \\text{Beta}(\\alpha + \\text{succes}, \\beta + \\text{echecs})$$\n",
+    "$$p \\mid \\text{data} \\sim \\text{Beta}(\\alpha + \\text{succes}, \\beta + \\text{échecs})$$\n",
     "\n",
-    "$$\\mathbb{E}[p \\mid \\text{data}] = \\frac{\\alpha + \\text{succes}}{\\alpha + \\beta + \\text{succes} + \\text{echecs}}$$\n",
+    "$$\\mathbb{E}[p \\mid \\text{data}] = \\frac{\\alpha + \\text{succes}}{\\alpha + \\beta + \\text{succes} + \\text{échecs}}$$\n",
     "\n",
-    "> **Interpretation bayesienne** :\n",
+    "> **interprétation bayesienne** :\n",
     "> \n",
-    "> - Le prior **uniforme** (Beta(1,1)) est le plus \"neutre\" et donne un resultat proche du MLE\n",
+    "> - Le prior **uniforme** (Beta(1,1)) est le plus \"neutre\" et donne un résultat proche du MLE\n",
     "> - Les priors **centres** (Beta(2,2) et Beta(5,5)) \"tirent\" le posterior vers 0.5\n",
-    "> - Le prior **biaise** (Beta(8,2)) domine les observations et maintient une estimation elevee\n",
+    "> - Le prior **biaise** (Beta(8,2)) domine les observations et maintient une estimation élevée\n",
     ">\n",
-    "> La force de l'effet du prior depend du ratio entre les pseudo-observations du prior ($\\alpha + \\beta$) et les observations reelles (5 dans cet exemple)."
+    "> La force de l'effet du prior dépend du ratio entre les pseudo-observations du prior ($\\alpha + \\beta$) et les observations réelles (5 dans cet exemple)."
    ]
   },
   {
@@ -1488,24 +1488,24 @@
    "source": [
     "## 6. Checklist de Debugging\n",
     "\n",
-    "Quand votre modele ne fonctionne pas, verifiez :\n",
+    "Quand votre modèle ne fonctionne pas, verifiez :\n",
     "\n",
-    "**Etape 1 : Verification du Modele**\n",
+    "**étape 1 : vérification du modèle**\n",
     "- [ ] Les dimensions des variables sont correctes (shape, coords)\n",
     "- [ ] Les observations sont dans le support du prior\n",
-    "- [ ] Les distributions sont bien specifiees (parametres corrects)\n",
-    "- [ ] Les `observed` sont bien des donnees et non des variables\n",
+    "- [ ] Les distributions sont bien spécifiées (paramètres corrects)\n",
+    "- [ ] Les `observed` sont bien des données et non des variables\n",
     "\n",
-    "**Etape 2 : Verification de l'Inference**\n",
-    "- [ ] R-hat < 1.01 pour tous les parametres\n",
-    "- [ ] ESS bulk > 400 pour tous les parametres\n",
+    "**étape 2 : vérification de l'inférence**\n",
+    "- [ ] R-hat < 1.01 pour tous les paramètres\n",
+    "- [ ] ESS bulk > 400 pour tous les paramètres\n",
     "- [ ] Pas de divergences\n",
-    "- [ ] Le nombre d'iterations est suffisant\n",
+    "- [ ] Le nombre d'itérations est suffisant\n",
     "\n",
-    "**Etape 3 : Verification des Resultats**\n",
+    "**étape 3 : vérification des résultats**\n",
     "- [ ] Les posteriors ne sont pas degenerees (variance > 0)\n",
     "- [ ] Les moyennes sont dans des plages raisonnables\n",
-    "- [ ] Les predictions sur donnees connues sont correctes"
+    "- [ ] Les predictions sur données connues sont correctes"
    ]
   },
   {
@@ -1524,7 +1524,7 @@
    "source": [
     "### 6.1 Fonctions de diagnostic automatisees\n",
     "\n",
-    "Plutot que d'inspecter manuellement chaque posterior, il est recommande de creer des fonctions de diagnostic reutilisables. La fonction ci-dessous verifie automatiquement les conditions de sante d'un trace pour tous les parametres."
+    "Plutot que d'inspecter manuellement chaque posterior, il est recommande de creer des fonctions de diagnostic reutilisables. La fonction ci-dessous vérifie automatiquement les conditions de sante d'un trace pour tous les paramètres."
    ]
   },
   {
@@ -1666,17 +1666,17 @@
    "source": [
     "## Exercice 3 : Diagnostic de convergence\n",
     "\n",
-    "Le modele ci-dessous est volontairement mal parametrise avec des priors\n",
+    "Le modèle ci-dessous est volontairement mal parametrise avec des priors\n",
     "trop etroits. Votre mission : utiliser les outils ArviZ pour identifier\n",
-    "precisement le probleme et proposer une correction.\n",
+    "precisement le problème et proposer une correction.\n",
     "\n",
     "**Objectif** : mettre en pratique les diagnostics R-hat, ESS et divergences.\n",
     "\n",
     "**Indices** :\n",
-    "- Echantillonner le modele avec `pm.sample(2000, chains=4)`\n",
-    "- Utiliser `az.summary()` pour examiner R-hat et ESS de chaque parametre\n",
-    "- Utiliser `az.plot_trace()` pour verifier visuellement le melange des chaines\n",
-    "- Le probleme : les observations (moyenne ~5) sont bien loin du prior (mu=0, sigma=0.1)\n",
+    "- Echantillonner le modèle avec `pm.sample(2000, chains=4)`\n",
+    "- utiliser `az.summary()` pour examiner R-hat et ESS de chaque paramètre\n",
+    "- utiliser `az.plot_trace()` pour vérifier visuellement le melange des chaines\n",
+    "- Le problème : les observations (moyenne ~5) sont bien loin du prior (mu=0, sigma=0.1)\n",
     "- La correction : elargir les priors (par ex. sigma=10 au lieu de 0.1)"
    ]
   },
@@ -1743,38 +1743,38 @@
     "tags": []
    },
    "source": [
-    "**Interpretation des diagnostics** :\n",
+    "**interprétation des diagnostics** :\n",
     "\n",
-    "La fonction `diagnose_trace` verifie les conditions de sante du posterior :\n",
+    "La fonction `diagnose_trace` vérifie les conditions de sante du posterior :\n",
     "\n",
     "| Condition | Seuil | Signification si viole |\n",
     "|-----------|-------|------------------------|\n",
     "| R-hat > 1.01 | 1.01 | Chaines non convergees |\n",
-    "| ESS bulk < 400 | 400 | Echantillon trop petit pour des estimations fiables |\n",
-    "| Divergences > 0 | 0 | Echantillonnage douteux dans certaines regions |\n",
+    "| ESS bulk < 400 | 400 | échantillon trop petit pour des estimations fiables |\n",
+    "| divergences > 0 | 0 | échantillonnage douteux dans certaines regions |\n",
     "\n",
-    "> **Bonne pratique** : Integrez ces diagnostics dans vos pipelines d'inference pour detecter automatiquement les cas problematiques, surtout dans les modeles complexes avec de nombreuses variables latentes.\n",
+    "> **Bonne pratique** : Integrez ces diagnostics dans vos pipelines d'inférence pour détecter automatiquement les cas problematiques, surtout dans les modèles complexes avec de nombreuses variables latentes.\n",
     "\n",
     "---\n",
     "\n",
     "## Tableau recapitulatif des concepts\n",
     "\n",
-    "| Concept | Description | Application au debugging |\n",
+    "| Concept | description | Application au debugging |\n",
     "|---------|-------------|--------------------------|\n",
-    "| **Divergences** | Indicateur de probleme d'echantillonnage NUTS | Verifier la parametrisation, augmenter target_accept |\n",
+    "| **divergences** | Indicateur de problème d'échantillonnage NUTS | vérifier la parametrisation, augmenter target_accept |\n",
     "| **R-hat** | Statistique de convergence des chaines | Doit etre < 1.01 |\n",
-    "| **ESS** | Taille effective de l'echantillon | Doit etre > 400 pour des estimations fiables |\n",
+    "| **ESS** | Taille effective de l'échantillon | Doit etre > 400 pour des estimations fiables |\n",
     "| **NUTS** | No-U-Turn Sampler | Algorithme par defaut, autonome mais lent |\n",
-    "| **ADVI** | Variational inference automatique | Rapide mais sous-estime l'incertitude |\n",
-    "| **Trace plot** | Visualisation des chaines MCMC | Verifier le melange et la convergence |\n",
+    "| **ADVI** | Variational inférence automatique | rapide mais sous-estime l'incertitude |\n",
+    "| **Trace plot** | Visualisation des chaines MCMC | vérifier le melange et la convergence |\n",
     "\n",
-    "### Distributions utilisees dans ce notebook\n",
+    "### Distributions utilisées dans ce notebook\n",
     "\n",
-    "| Distribution | Parametres | Usage typique |\n",
+    "| Distribution | paramètres | Usage typique |\n",
     "|--------------|------------|---------------|\n",
-    "| **Normal** | (mu, sigma) | Variables continues, moyennes |\n",
+    "| **Normal** | (mu, sigma) | variables continues, moyennes |\n",
     "| **HalfNormal** | (sigma,) | Ecarts-types, variances (positifs) |\n",
-    "| **Beta** | (alpha, beta) | Probabilites binomiales, proportions |\n",
+    "| **Beta** | (alpha, beta) | probabilités binomiales, proportions |\n",
     "| **Binomial** | (n, p) | Comptages de succes |"
    ]
   },
@@ -1792,11 +1792,11 @@
     "tags": []
    },
    "source": [
-    "## 7. Exemple guide : Debugger un Modele\n",
+    "## 7. Exemple guide : Debugger un Modèle\n",
     "\n",
     "### Enonce\n",
     "\n",
-    "Le modele ci-dessous est deja corrige. Il montre comment specifier correctement un modele d'estimation."
+    "Le modèle ci-dessous est deja corrige. Il montre comment spécifier correctement un modèle d'estimation."
    ]
   },
   {
@@ -1939,7 +1939,7 @@
     "tags": []
    },
    "source": [
-    "A votre tour : identifiez les problemes dans le modele suivant."
+    "A votre tour : identifiez les problèmes dans le modèle suivant."
    ]
   },
   {
@@ -2087,13 +2087,13 @@
    "source": [
     "**Analyse des corrections** :\n",
     "\n",
-    "| Probleme original | Consequence | Correction appliquee |\n",
+    "| problème original | Consequence | Correction appliquée |\n",
     "|-------------------|-------------|----------------------|\n",
     "| sigma=0.01 sur le prior | Prior concentre autour de 0 (ecart-type ~0.01) | sigma=50 (ecart-type large) |\n",
-    "| Normal pour l'ecart-type | Peut generer des valeurs negatives (invalides) | HalfNormal (strictement positif) |\n",
-    "| Variables anonymes | Difficulte a interpreter les resultats | Nommage explicite |\n",
+    "| Normal pour l'ecart-type | Peut générer des valeurs negatives (invalides) | HalfNormal (strictement positif) |\n",
+    "| variables anonymes | Difficulte a interpréter les résultats | Nommage explicite |\n",
     "\n",
-    "Le resultat corrige montre :\n",
+    "Le résultat corrige montre :\n",
     "- **Moyenne ~50** : proche de l'observation car le prior est large\n",
     "- **Sigma** : estime avec incertitude a partir d'une seule observation"
    ]
@@ -2114,16 +2114,16 @@
    "source": [
     "### Points cles a retenir\n",
     "\n",
-    "> **Strategie de debugging en 3 etapes** :\n",
+    "> **stratégie de debugging en 3 étapes** :\n",
     ">\n",
-    "> 1. **Verifier le support** : Les observations sont-elles probables sous le prior ?\n",
-    "> 2. **Verifier les diagnostics** : R-hat < 1.01, ESS > 400, 0 divergences\n",
-    "> 3. **Verifier les posteriors** : Variance raisonnable ? Moyennes plausibles ?\n",
+    "> 1. **vérifier le support** : Les observations sont-elles probables sous le prior ?\n",
+    "> 2. **vérifier les diagnostics** : R-hat < 1.01, ESS > 400, 0 divergences\n",
+    "> 3. **vérifier les posteriors** : variance raisonnable ? Moyennes plausibles ?\n",
     "\n",
-    "La plupart des problemes d'inference proviennent de :\n",
-    "- **Priors mal specifies** (trop etroits, mauvais support)\n",
-    "- **Mauvaise parametrisation** (entonnoir, correlations fortes)\n",
-    "- **Modele trop complexe** (simplifier d'abord, complexifier ensuite)\n",
+    "La plupart des problèmes d'inférence proviennent de :\n",
+    "- **Priors mal spécifiés** (trop etroits, mauvais support)\n",
+    "- **Mauvaise parametrisation** (entonnoir, corrélations fortes)\n",
+    "- **modèle trop complexe** (simplifier d'abord, complexifier ensuite)\n",
     "\n",
     "---"
    ]
@@ -2144,12 +2144,12 @@
    "source": [
     "## 8. Resume\n",
     "\n",
-    "| Probleme | Symptome | Solution |\n",
+    "| problème | Symptome | Solution |\n",
     "|----------|----------|----------|\n",
     "| **Prior trop etroit** | BadInitialEnergy ou posterior etroit | Elargir le prior |\n",
-    "| **Divergences** | sample_stats['diverging'] > 0 | Reparametriser ou augmenter target_accept |\n",
-    "| **R-hat > 1.01** | Chaines non convergees | Plus d'iterations ou reparametriser |\n",
-    "| **ESS faible** | Estimations peu fiables | Plus d'iterations ou thinning |\n",
+    "| **divergences** | sample_stats['diverging'] > 0 | Reparametriser ou augmenter target_accept |\n",
+    "| **R-hat > 1.01** | Chaines non convergees | Plus d'itérations ou reparametriser |\n",
+    "| **ESS faible** | Estimations peu fiables | Plus d'itérations ou thinning |\n",
     "\n",
     "---\n",
     "\n",
@@ -2157,7 +2157,7 @@
     "\n",
     "**Logiciels** :\n",
     "- PyMC : Salvatier, Wiecki & Fonnesbeck (2016), *Probabilistic programming in Python using PyMC*, PeerJ Computer Science 2:e55. [Documentation](https://www.pymc.io/projects/docs/en/stable/)\n",
-    "- ArviZ : Kumar, Carroll, Hartikainen & Martin (2019), *ArviZ: a unified library for exploratory analysis of Bayesian models in Python*, JOSS 4(33) 1143. [Diagnostics API](https://python.arviz.org/en/stable/api/diagnostics.html)\n",
+    "- ArviZ : Kumar, Carroll, Hartikainen & Martin (2019), *ArviZ: a unified library for exploratory analysis of Bayesian models in Python*, JOSS 4(33) 1143. [diagnostics API](https://python.arviz.org/en/stable/api/diagnostics.html)\n",
     "\n",
     "**Papiers fondateurs (diagnostics MCMC)** :\n",
     "- Vehtari, Gelman, Simpson, Carpenter & Burkner (2021), *Rank-normalization, folding, and localization: An improved R-hat*, Bayesian Analysis 16(2), doi:10.1214/20-BA1221\n",
@@ -2185,9 +2185,9 @@
     "tags": []
    },
    "source": [
-    "## 9. Exercice : Deboguer un Modele Hierarchique\n",
+    "## 9. Exercice : Deboguer un Modèle Hierarchique\n",
     "\n",
-    "Le modele ci-dessous tente d'estimer les moyennes de performance de 3 groupes, mais il contient **3 erreurs**. Identifiez et corrigez chaque erreur.\n",
+    "Le modèle ci-dessous tente d'estimer les moyennes de performance de 3 groupes, mais il contient **3 erreurs**. Identifiez et corrigez chaque erreur.\n",
     "\n",
     "**Indices** :\n",
     "1. Un ecart-type doit etre strictement positif\n",
@@ -2267,7 +2267,7 @@
    "source": [
     "---\n",
     "\n",
-    "**Conclusion** : Ce notebook a couvert les outils de diagnostic MCMC (R-hat, ESS, divergences), la comparaison NUTS vs ADVI, et les bonnes pratiques de modelisation pour resoudre les problemes d'inference courants.\n",
+    "**Conclusion** : Ce notebook a couvert les outils de diagnostic MCMC (R-hat, ESS, divergences), la comparaison NUTS vs ADVI, et les bonnes pratiques de modelisation pour résoudre les problèmes d'inférence courants.\n",
     "\n",
     "**Retour au sommaire** : [Index Probas](../README.md)\n",
     "\n",


### PR DESCRIPTION
## Summary

Restore French accents in markdown source cells of `MyIA.AI.Notebooks/Probas/PyMC/PyMC-6-Debugging.ipynb` (8ème étape de la vague c.594-c.595-c.596-c.597-c.598-c.599-c.600-c.601 cross-famille ML→GenAI/Audio→Search/Part1→Sudoku→Search/Part2-CSP→SymbolicAI/Tweety→Probas/DecInfer→Probas/PyMC).

## Metrics

- **288 cures** appliquées sur **29 cellules markdown**
- 1 file / 1 domain / 1 feature (R3 atomicité)
- R6 anti-monotonie : Probas/PyMC (MCMC debugging family) après ML-4 (c.594), GenAI/Audio (c.595), Search/Part1 (c.596), Sudoku (c.597), Search/Part2-CSP (c.598), SymbolicAI/Tweety (c.599), Probas/DecInfer (c.600)
- +135/-135 (multiline cells = JSON source-array string regroupé ; LF 2311/2311 inchange, bytes delta +204)

## Stop & Repair strict (HARD, règle 6 secrets-hygiene.md)

- 0 code cell source diff
- 0 outputs diff
- 0 execution_count diff
- 0 cell added/removed (43 cells préservées)
- nbformat 4.5 préservé
- CRLF 0/0 préservé
- LF 2311/2311 inchange

## Pré-flight collision (L679-L1 ★★)

`gh pr list --state all --search "PyMC-6-Debugging"` : 20 PRs, mais aucun touchait les accents markdown du notebook Python PyMC-6. (Les 2 PRs avec "accents" dans le titre — #4192 Probas/README + hmm_alpha_research ; #2928 Sudoku/README — ne touchent pas PyMC-6-Debugging.ipynb.) → **0 collision**.

## Leçons cumulées (synchronisation avec vagues précédentes)

- **Leçon c.591 ★** : binary write `open('wb')` + `.encode('utf-8')` pour préserver LF
- **Leçon c.593 ★** : raw-text surgical bypass `nbformat.write` via `json.dumps(indent=4)` + closing `]` 3-space indent fix
- **Leçon c.596 ★** : pre-commit grep validation des participes passés + désambiguïsation présent/participe (`determine`→`détermine`, `applique`→`applique` present 3rd ps SANS accent, `intégration` (noun) ≠ `intègre` (verb))
- **Leçon c.599 ★** : pondere-3rd-ps-disambiguation (3rd ps sg present `pondère` ≠ 3rd pp `pondéré`)

## Leçon c.601 ★ : verifie-3rd-ps-disambiguation

**Action** : pour les prochaines PRs d'accents sur notebooks MCMC/probabilistes, **chaque occurrence de `verifie` doit être analysée par contexte** :

| Contexte | Forme correcte | Pourquoi |
|----------|---------------|----------|
| "La fonction ci-dessous **vérifie** automatiquement" (sujet f.sg "fonction") | `vérifie` (présent 3e ps sg) | présent, pas pp |
| "La fonction `diagnose_trace` **vérifie** les conditions" (sujet f.sg "La fonction") | `vérifie` (présent 3e ps sg) | présent, pas pp |
| "Une fois **vérifié** que..." / "est/sont **vérifié(es)**" (suivi de "que" ou après être/avoir) | `vérifié` (pp masc sg) / `vérifiée` (pp f.sg) | accord pp |

**Auto-mapping `verifie → vérifié`** (passé composé default) est **WRONG** dans 2 contextes critiques (cellules[28] et [32] de PyMC-6-Debugging). Surgical fix pattern (lesson c.596 ★) appliqué pour revert → `vérifie`.

**Règle générale** : pour tout verbe en `-ifie`/`-ifiee`/`-ifies` (vérifier, identifier, modifier, spécifier, justifier...), vérifier que :
1. Le contexte est au **présent** (pas après "une fois", "après avoir", "est/sont") ET
2. Le sujet est **singulier** pour `-ifie`, **pluriel** pour `-ifient`

Avant de figer le TARGETS list : grep dry-run sur les lemmes du notebook pour identifier les verbes conjugués AVANT mapping.

## Pre-commit grep (lesson c.596)

Toutes les formes en `-ée`/`-ées`/`-é` post-fix vérifiées par contexte :

| Cell | Forme | Contexte | Verdict |
|------|-------|----------|---------|
| cell[7] | "Autocorrelation **élevée**" | adj f.sg (attribut du sujet "Autocorrelation") | ✅ |
| cell[12] | "Autocorrelation **élevée**, necessite tuning" | adj f.sg (attribut du sujet "Autocorrelation") | ✅ |
| cell[32] | "Distributions **utilisées** dans ce notebook" | heading — pp f.pl attribut de "Distributions" | ✅ |
| cell[22] | "**échantillonnage** douteux" | nom substantif | ✅ |
| cell[3] | "**échantillonneurs** (NUTS, ADVI, Metropolis)" | nom pluriel | ✅ |
| cell[8] | "**échantillonneur** a du mal" | nom singulier | ✅ |

2 occurrences `vérifié` corrigées en `vérifie` (lesson c.601 ★). `utilisée` (déjà correctement accentuée), `échantillonnage` (nom) et `élevée` (adjectif) tous contextuellement OK.

## Scope strict : markdown only (leçon c.598 ★)

Code cells + outputs INCHANGÉS (0 diff). Les occurrences `donnees`/`regles`/`variables` dans les **commentaires Python** (`# ...`) et les **string-literals stdout** (`print(...)`) restent volontairement sans accent :
- **Commentaires Python** : OUT of scope per ai-01 accent contract
- **String-literals stdout** : nécessitent re-exécution Python (PyMC/JAX kernels) pour cohérence output, hors scope c.601 (R3 atomic 1f/1feature)

Voir issue #2876 pour batch dédié PyMC string-literal re-execution.

See #2876
