### PR TITLE
fix(symbolic-learning,#2876): restore FR accents in SL-3-RelevanceLearning markdown

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-3-RelevanceLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-3-RelevanceLearning.ipynb
@@ -23,14 +23,14 @@
     "A la fin de ce notebook, vous saurez :\n",
     "1. Formaliser les **determinations** et leurs proprietes mathematiques\n",
     "2. Implementer et visualiser le **treillis des determinations**\n",
-    "3. Appliquer l'algorithme **MINIMAL-CONSISTENT-DET** sur des donnees reelles\n",
-    "4. Comparer la selection d'attributs guidee par la connaissance (**RBL**) vs la selection aveugle (**sklearn**)\n",
+    "3. Appliquer l'algorithme **MINIMAL-CONSISTENT-DET** sur des données réelles\n",
+    "4. Comparer la sélection d'attributs guidee par la connaissance (**RBL**) vs la sélection aveugle (**sklearn**)\n",
     "5. Quantifier la **reduction exponentielle** de l'espace des hypotheses\n",
     "\n",
     "### Prerequis\n",
     "- SL-1 (apprentissage logique, espaces d'hypotheses)\n",
     "- SL-2 section 7 (introduction aux determinations)\n",
-    "- Bases de Python et structures de donnees\n",
+    "- Bases de Python et structures de données\n",
     "\n",
     "### Duree estimee : 50 minutes"
    ]
@@ -104,32 +104,32 @@
     "\n",
     "## 1. Introduction --- Pourquoi la pertinence ?\n",
     "\n",
-    "Dans SL-2, nous avons introduit le concept de **determination**. Ce notebook approfondit le cadre formel du **Relevance-Based Learning** (RBL, AIMA 19.4) : proprietes mathematiques, treillis, algorithme MINIMAL-CONSISTENT-DET et selection d'attributs.\n",
+    "Dans SL-2, nous avons introduit le concept de **détermination**. Ce notebook approfondit le cadre formel du **Relevance-Based Learning** (RBL, AIMA 19.4) : proprietes mathematiques, treillis, algorithme MINIMAL-CONSISTENT-DET et sélection d'attributs.\n",
     "\n",
-    "### Le probleme central\n",
+    "### Le problème central\n",
     "\n",
     "Soit un ensemble de $n$ attributs decrivant chaque exemple. L'espace des hypotheses est de taille $O(2^n)$ --- il croit **exponentiellement** avec le nombre d'attributs.\n",
     "\n",
-    "La question cle : **quels attributs sont pertinents** pour predire la cible ?\n",
+    "La question cle : **quels attributs sont pertinents** pour prédire la cible ?\n",
     "\n",
-    "### L'equation fondamentale du RBL\n",
+    "### L'équation fondamentale du RBL\n",
     "\n",
     "RBL repose sur la relation de consequence logique (*entailment*, AIMA Eq. 19.4) :\n",
     "\n",
     "$$\n",
-    "\\text{Background} \\wedge \\text{Descriptions} \\wedge \\text{Classifications} \\models \\text{Hypothesis}\n",
+    "\\text{Background} \\wedge \\text{descriptions} \\wedge \\text{Classifications} \\models \\text{Hypothesis}\n",
     "$$\n",
     "\n",
-    "La difference avec EBL : dans EBL, Background **explique** completement la classification. Dans RBL, Background **contraint la forme** de l'hypothese sans la determiner entierement --- il nous dit quels attributs considerer, mais pas la regle exacte.\n",
+    "La difference avec EBL : dans EBL, Background **explique** complètement la classification. Dans RBL, Background **contraint la forme** de l'hypothese sans la déterminer entierement --- il nous dit quels attributs considerer, mais pas la règle exacte.\n",
     "\n",
     "### Plan de ce notebook\n",
     "\n",
     "| Section | Contenu | Duree |\n",
     "|---------|---------|-------|\n",
-    "| 2. Determinations | Formalisme, proprietes, verification | 10 min |\n",
+    "| 2. Determinations | Formalisme, proprietes, vérification | 10 min |\n",
     "| 3. Treillis des determinations | Visualisation, relations d'inclusion | 10 min |\n",
     "| 4. Algorithme MINIMAL-CONSISTENT-DET | Implementation detaillee | 10 min |\n",
-    "| 5. Selection d'attributs guidee | RBL vs sklearn, comparaison | 10 min |\n",
+    "| 5. sélection d'attributs guidee | RBL vs sklearn, comparaison | 10 min |\n",
     "| 6. Determinations et semantique web | Parallel RBL <-> OWL | 5 min |\n",
     "| 7. Exercices | 3 exercices pratiques | 10 min |"
    ]
@@ -154,7 +154,7 @@
     "\n",
     "### Definition formelle\n",
     "\n",
-    "Un ensemble d'attributs $X = \\{x_1, \\ldots, x_k\\}$ **determine** l'attribut cible $Y$ (note $X > Y$) si pour toute paire d'exemples qui ont les memes valeurs pour tous les attributs dans $X$, ils ont aussi la meme valeur pour $Y$ :\n",
+    "Un ensemble d'attributs $X = \\{x_1, \\ldots, x_k\\}$ **détermine** l'attribut cible $Y$ (note $X > Y$) si pour toute paire d'exemples qui ont les mêmes valeurs pour tous les attributs dans $X$, ils ont aussi la même valeur pour $Y$ :\n",
     "\n",
     "$$\n",
     "\\forall e_1, e_2 \\in D : \\left(\\forall x_i \\in X : e_1[x_i] = e_2[x_i]\\right) \\Rightarrow e_1[Y] = e_2[Y]\n",
@@ -162,13 +162,13 @@
     "\n",
     "### Proprietes importantes\n",
     "\n",
-    "**Monotonie** : Si $X > Y$ et $X \\subseteq X'$, alors $X' > Y$. Ajouter des attributs a une determination valide conserve sa validite.\n",
+    "**Monotonie** : Si $X > Y$ et $X \\subseteq X'$, alors $X' > Y$. Ajouter des attributs a une détermination valide conserve sa validite.\n",
     "\n",
-    "**Minimalite** : Une determination $X > Y$ est **minimale** si aucun sous-ensemble strict de $X$ ne determine $Y$. C'est la determination la plus petite.\n",
+    "**Minimalite** : Une détermination $X > Y$ est **minimale** si aucun sous-ensemble strict de $X$ ne détermine $Y$. C'est la détermination la plus petite.\n",
     "\n",
-    "**Unicite** : La determination minimale n'est pas forcement unique --- il peut exister plusieurs ensembles minimaux differents.\n",
+    "**Unicite** : La détermination minimale n'est pas forcement unique --- il peut exister plusieurs ensembles minimaux differents.\n",
     "\n",
-    "> **Origine.** Le formalisme logique des *determinations* ($X > Y$) comme base de l'apprentissage base sur la pertinence (RBL) vient de Davies, T. R. & Russell, S. J. (1987), *A logical approach to reasoning by analogy*, Proceedings of IJCAI-87 --- qui montre comment une determination connue rend l'apprentissage independant des attributs non-pertinents."
+    "> **Origine.** Le formalisme logique des *determinations* ($X > Y$) comme base de l'apprentissage base sur la pertinence (RBL) vient de Davies, T. R. & Russell, S. J. (1987), *A logical approach to reasoning by analogy*, Proceedings of IJCAI-87 --- qui montre comment une détermination connue rend l'apprentissage indépendant des attributs non-pertinents."
    ]
   },
   {
@@ -306,9 +306,9 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : Determinations sur les metaux\n",
+    "### Interprétation : Determinations sur les metaux\n",
     "\n",
-    "| Attributs testes | Determine conductivite ? | Raison |\n",
+    "| Attributs testes | détermine conductivite ? | Raison |\n",
     "|-----------------|-------------------------|--------|\n",
     "| `metal` | **Oui** | Chaque metal a une conductivite unique |\n",
     "| `density` | **Non** | Cu et Fe ont tous deux density=high mais conductivites differentes |\n",
@@ -316,7 +316,7 @@
     "| `state` | **Non** | Cu et Na sont tous deux solid mais conductivites differentes |\n",
     "| `metal, density` | **Oui** | Surensemble de `metal` seul, donc toujours valide (monotonie) |\n",
     "\n",
-    "> **Point cle** : La determination minimale est `{metal}`. Les autres attributs (density, color, state) sont des **epiphenomenes** --- ils correlent avec la conductivite mais ne la determinent pas fonctionnellement. La monotonie garantit que tout surensemble d'une determination valide est aussi valide."
+    "> **Point cle** : La détermination minimale est `{metal}`. Les autres attributs (density, color, state) sont des **epiphenomenes** --- ils correlent avec la conductivite mais ne la déterminent pas fonctionnellement. La monotonie garantit que tout surensemble d'une détermination valide est aussi valide."
    ]
   },
   {
@@ -486,17 +486,17 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : Structure du treillis\n",
+    "### Interprétation : Structure du treillis\n",
     "\n",
     "Le treillis revele la structure de la connaissance de pertinence :\n",
     "\n",
     "| Propriete | Observation |\n",
     "|-----------|-------------|\n",
     "| **Up-set** | Tout surensemble de `{metal}` est aussi valide (monotonie) |\n",
-    "| **Determination minimale** | `{metal}` est le plus petit ensemble valide |\n",
-    "| **Bruit** | Les ensembles sans `metal` sont generalement invalides |\n",
+    "| **détermination minimale** | `{metal}` est le plus petit ensemble valide |\n",
+    "| **Bruit** | Les ensembles sans `metal` sont généralement invalides |\n",
     "\n",
-    "> **Analogie mathematique** : Le treillis des determinations est isomorphe a la relation d'inclusion sur $\\mathcal{P}(\\{x_1, \\ldots, x_n\\})$. La connaissance de pertinence identifie un **filtre** dans ce treillis : les ensembles d'attributs a partir desquels on peut predire la cible."
+    "> **Analogie mathematique** : Le treillis des determinations est isomorphe a la relation d'inclusion sur $\\mathcal{P}(\\{x_1, \\ldots, x_n\\})$. La connaissance de pertinence identifie un **filtre** dans ce treillis : les ensembles d'attributs a partir desquels on peut prédire la cible."
    ]
   },
   {
@@ -602,7 +602,7 @@
     "\n",
     "## 4. Algorithme MINIMAL-CONSISTENT-DET\n",
     "\n",
-    "L'algorithme MINIMAL-CONSISTENT-DET (AIMA Figure 19.4) trouve la determination minimale en explorant les sous-ensembles par taille croissante.\n",
+    "L'algorithme MINIMAL-CONSISTENT-DET (AIMA Figure 19.4) trouve la détermination minimale en explorant les sous-ensembles par taille croissante.\n",
     "\n",
     "### Principe\n",
     "\n",
@@ -610,7 +610,7 @@
     "MINIMAL-CONSISTENT-DET(E, A, Y):\n",
     "    Pour k = 1, 2, ..., |A|:\n",
     "        Pour chaque sous-ensemble S de A de taille k:\n",
-    "            Si S determine Y dans E:\n",
+    "            Si S détermine Y dans E:\n",
     "                retourner S\n",
     "    retourner None\n",
     "```\n",
@@ -619,11 +619,11 @@
     "\n",
     "| Cas | Complexite | Explication |\n",
     "|-----|------------|-------------|\n",
-    "| Pire cas | $O(2^n)$ | Aucune determination n'existe |\n",
-    "| Determination de taille $d$ | $O(n^d)$ | Arret apres niveau $d$ |\n",
+    "| Pire cas | $O(2^n)$ | Aucune détermination n'existe |\n",
+    "| détermination de taille $d$ | $O(n^d)$ | Arret apres niveau $d$ |\n",
     "| $d \\ll n$ | Polynomiale | Gain majeur par rapport a l'exhaustion |\n",
     "\n",
-    "> **Origine.** L'idee de chercher la determination *minimale* (moins d'attributs pertinents possible) et l'algorithme MIN-FEATURES/FOCUS sous-jacent sont dus a Almuallim, H. & Dietterich, T. G. (1991), *Learning with many irrelevant features*, Proceedings of AAAI-91, pp. 547-552 --- qui demontrent le gain de complexite quand peu d'attributs sont pertinents."
+    "> **Origine.** L'idee de chercher la détermination *minimale* (moins d'attributs pertinents possible) et l'algorithme MIN-FEATURES/FOCUS sous-jacent sont dus a Almuallim, H. & Dietterich, T. G. (1991), *Learning with many irrelevant features*, Proceedings of AAAI-91, pp. 547-552 --- qui demontrent le gain de complexite quand peu d'attributs sont pertinents."
    ]
   },
   {
@@ -784,17 +784,17 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : Determination moleculaire\n",
+    "### Interprétation : Détermination moleculaire\n",
     "\n",
     "| Aspect | Valeur | Signification |\n",
     "|--------|--------|---------------|\n",
-    "| Determination minimale | `{logp}` | La lipophilite seule suffit a predire l'activite |\n",
+    "| détermination minimale | `{logp}` | La lipophilite seule suffit a prédire l'activite |\n",
     "| Sous-ensembles testes | $O(n^d)$ | Bien moins que $2^n - 1 = 15$ |\n",
     "| Reduction d'espace | $O(2^4) \\to O(2^1)$ | Facteur 8x |\n",
     "\n",
-    "> **Point cle** : Si on sait que `logp` determine l'activite, on peut ignorer `mw`, `hbd`, `hba` dans notre modele. L'espace des hypotheses passe de $2^4 = 16$ a $2^1 = 2$ --- un seul attribut a considerer.\n",
+    "> **Point cle** : Si on sait que `logp` détermine l'activite, on peut ignorer `mw`, `hbd`, `hba` dans notre modèle. L'espace des hypotheses passe de $2^4 = 16$ a $2^1 = 2$ --- un seul attribut a considerer.\n",
     "\n",
-    "> **Connexion moderne** : En chimoinformatique, c'est l'idee de la **regle de Lipinski** (\"Rule of Five\") : certaines proprietes moleculaires sont plus pertinentes que d'autres pour predire l'absorption orale. Le RBL formalise cette intuition."
+    "> **Connexion moderne** : En chimoinformatique, c'est l'idee de la **règle de Lipinski** (\"Rule of Five\") : certaines proprietes moleculaires sont plus pertinentes que d'autres pour prédire l'absorption orale. Le RBL formalise cette intuition."
    ]
   },
   {
@@ -811,9 +811,9 @@
     "tags": []
    },
    "source": [
-    "### Cas d'echec : le concept disjonctif du restaurant\n",
+    "### Cas d'échec : le concept disjonctif du restaurant\n",
     "\n",
-    "Reprenons les donnees du restaurant (SL-1, AIMA Table 19.1). Le concept cible est **disjonctif** : `WillWait` si `Patrons=Some` **ou** (`Patrons=Full` **et** `Hungry=Yes`). Une telle logique n'est une fonction d'aucun petit sous-ensemble d'attributs : que trouve MINIMAL-CONSISTENT-DET ?\n"
+    "Reprenons les données du restaurant (SL-1, AIMA Table 19.1). Le concept cible est **disjonctif** : `WillWait` si `Patrons=Some` **ou** (`Patrons=Full` **et** `Hungry=Yes`). Une telle logique n'est une fonction d'aucun petit sous-ensemble d'attributs : que trouve MINIMAL-CONSISTENT-DET ?\n"
    ]
   },
   {
@@ -920,16 +920,16 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : echec et determination fallacieuse\n",
+    "### Interprétation : échec et détermination fallacieuse\n",
     "\n",
-    "| Recherche | Resultat | Lecture |\n",
+    "| Recherche | résultat | Lecture |\n",
     "|-----------|----------|--------|\n",
-    "| 5 premiers attributs (31 tests) | Aucune determination | Le concept `WillWait` est disjonctif (`Patrons=Some OU (Patrons=Full ET Hungry=Yes)`) : ce n'est une fonction d'aucun petit sous-ensemble de ces attributs |\n",
-    "| 10 attributs (66 tests) | `{Alternate, Fri/Sat, Price}` | Determination **fallacieuse** : 29 triplets distincts \"determinent\" la cible sur ce petit echantillon, par pure coincidence |\n",
+    "| 5 premiers attributs (31 tests) | Aucune détermination | Le concept `WillWait` est disjonctif (`Patrons=Some OU (Patrons=Full ET Hungry=Yes)`) : ce n'est une fonction d'aucun petit sous-ensemble de ces attributs |\n",
+    "| 10 attributs (66 tests) | `{Alternate, Fri/Sat, Price}` | détermination **fallacieuse** : 29 triplets distincts \"déterminent\" la cible sur ce petit échantillon, par pure coincidence |\n",
     "\n",
-    "> **Point cle** : une determination n'a de valeur que si l'echantillon est assez grand pour la contraindre. Sur 12 exemples, beaucoup de triplets d'attributs separent les exemples par coincidence --- c'est l'analogue logique du **sur-apprentissage**. La comparaison statistique de la section 5 ci-dessous (information mutuelle, sklearn) aide precisement a detecter ce piege : les attributs d'une determination fallacieuse ont des scores MI faibles.\n",
+    "> **Point cle** : une détermination n'a de valeur que si l'échantillon est assez grand pour la contraindre. Sur 12 exemples, beaucoup de triplets d'attributs separent les exemples par coincidence --- c'est l'analogue logique du **sur-apprentissage**. La comparaison statistique de la section 5 ci-dessous (information mutuelle, sklearn) aide precisement a détecter ce piège : les attributs d'une détermination fallacieuse ont des scores MI faibles.\n",
     "\n",
-    "> **Deux lecons** : (1) l'absence de determination signale un concept disjonctif ou bruite --- il faut alors passer aux arbres de decision ou a l'ILP ([SL-4](SL-4-InductiveLogicProgramming.ipynb)) ; (2) la presence d'une determination sur un petit echantillon ne prouve rien --- il faut la valider statistiquement.\n"
+    "> **Deux lecons** : (1) l'absence de détermination signale un concept disjonctif ou bruite --- il faut alors passer aux arbres de decision ou a l'ILP ([SL-4](SL-4-InductiveLogicProgramming.ipynb)) ; (2) la presence d'une détermination sur un petit échantillon ne prouve rien --- il faut la valider statistiquement.\n"
    ]
   },
   {
@@ -948,15 +948,15 @@
    "source": [
     "---\n",
     "\n",
-    "## 5. Selection d'attributs guidee par la connaissance\n",
+    "## 5. Sélection d'attributs guidee par la connaissance\n",
     "\n",
-    "Le RBL offre un cadre theorique pour la **selection d'attributs**. Comparons trois approches :\n",
+    "Le RBL offre un cadre theorique pour la **sélection d'attributs**. Comparons trois approches :\n",
     "\n",
     "1. **Aveugle** : Enumeration exhaustive de tous les sous-ensembles\n",
-    "2. **Statistique** : Selection par sklearn (mutual information, chi-squared)\n",
-    "3. **Guidee (RBL)** : Utilisation de determinations comme contraintes\n",
+    "2. **Statistique** : sélection par sklearn (mutual information, chi-squared)\n",
+    "3. **Guidee (RBL)** : utilisation de determinations comme contraintes\n",
     "\n",
-    "Nous allons mesurer l'impact sur un jeu de donnees synthetique ou seul un petit sous-ensemble d'attributs determine reellement la cible."
+    "Nous allons mesurer l'impact sur un jeu de données synthetique ou seul un petit sous-ensemble d'attributs détermine réellement la cible."
    ]
   },
   {
@@ -1064,7 +1064,7 @@
     "tags": []
    },
    "source": [
-    "Les donnees sont pretes, avec seulement 2 attributs pertinents parmi 10. La cellule suivante applique MINIMAL-CONSISTENT-DET pour retrouver automatiquement cette determination."
+    "Les données sont pretes, avec seulement 2 attributs pertinents parmi 10. La cellule suivante applique MINIMAL-CONSISTENT-DET pour retrouver automatiquement cette détermination."
    ]
   },
   {
@@ -1143,11 +1143,11 @@
     "tags": []
    },
    "source": [
-    "### Selection statistique : Information Mutuelle avec sklearn\n",
+    "### Sélection statistique : Information Mutuelle avec sklearn\n",
     "\n",
-    "L'approche RBL a identifie `{R1, R2}` comme determination minimale avec une **garantie logique** (si determination il y a, RBL la trouve). Mais que se passe-t-il si les donnees sont bruitees ou que la determination exacte n'existe pas ?\n",
+    "L'approche RBL a identifié `{R1, R2}` comme détermination minimale avec une **garantie logique** (si détermination il y a, RBL la trouve). Mais que se passe-t-il si les données sont bruitees ou que la détermination exacte n'existe pas ?\n",
     "\n",
-    "L'**information mutuelle** (sklearn) mesure la dependance statistique entre chaque attribut et la cible, sans exiger de determination fonctionnelle exacte. La cellule suivante calcule ces scores et compare les attributs selectionnes par sklearn avec la determination RBL."
+    "L'**information mutuelle** (sklearn) mesure la dépendance statistique entre chaque attribut et la cible, sans exiger de détermination fonctionnelle exacte. La cellule suivante calcule ces scores et compare les attributs selectionnes par sklearn avec la détermination RBL."
    ]
   },
   {
@@ -1250,24 +1250,24 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : RBL vs selection statistique\n",
+    "### Interprétation : RBL vs sélection statistique\n",
     "\n",
-    "| Approche | Methode | Attributs selectionnes | Garantie |\n",
+    "| approche | méthode | Attributs selectionnes | Garantie |\n",
     "|----------|---------|----------------------|----------|\n",
-    "| **RBL** | Determination fonctionnelle | Les attributs qui determinent *exactement* la cible | Completude (si determination existe) |\n",
+    "| **RBL** | détermination fonctionnelle | Les attributs qui déterminent *exactement* la cible | Completude (si détermination existe) |\n",
     "| **sklearn (MI)** | Information mutuelle | Les attributs les plus *correles* avec la cible | Statistique (pas de garantie fonctionnelle) |\n",
     "\n",
     "**Avantages du RBL** :\n",
-    "- **Garantie logique** : si une determination existe, RBL la trouve\n",
-    "- **Interpretabilite** : le resultat est un ensemble d'attributs, pas un score flou\n",
+    "- **Garantie logique** : si une détermination existe, RBL la trouve\n",
+    "- **Interpretabilite** : le résultat est un ensemble d'attributs, pas un score flou\n",
     "- **Parsimonie** : trouve le plus petit ensemble\n",
     "\n",
     "**Limites du RBL** :\n",
-    "- Suppose une **determination fonctionnelle** exacte (pas de bruit)\n",
-    "- **Casse en presence de bruit** : un seul contre-exemple invalide une determination\n",
-    "- Complexite $O(n^d)$ qui reste elevee pour $d$ grand\n",
+    "- Suppose une **détermination fonctionnelle** exacte (pas de bruit)\n",
+    "- **Casse en presence de bruit** : un seul contre-exemple invalide une détermination\n",
+    "- Complexite $O(n^d)$ qui reste élevée pour $d$ grand\n",
     "\n",
-    "> **Synthese** : RBL et sklearn sont **complementaires**. RBL excelle quand on a des connaissances de domaine (determinations connues). Sklearn excelle quand les donnees sont bruitees ou que la determination fonctionnelle n'existe pas."
+    "> **Synthese** : RBL et sklearn sont **complementaires**. RBL excelle quand on a des connaissances de domaine (determinations connues). Sklearn excelle quand les données sont bruitees ou que la détermination fonctionnelle n'existe pas."
    ]
   },
   {
@@ -1367,16 +1367,16 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : Impact quantitatif\n",
+    "### Interprétation : Impact quantitatif\n",
     "\n",
-    "La connaissance de pertinence (sous forme de determination) a un impact **exponentiel** sur l'apprentissage :\n",
+    "La connaissance de pertinence (sous forme de détermination) a un impact **exponentiel** sur l'apprentissage :\n",
     "\n",
     "| Dimension | Sans RBL | Avec RBL (d=3) | Gain |\n",
     "|-----------|----------|----------------|------|\n",
     "| Espace hypotheses | $2^{20} \\approx 10^6$ | $2^3 = 8$ | $125\\,000$x |\n",
     "| Espace hypotheses | $2^{100} \\approx 10^{30}$ | $2^5 = 32$ | $3 \\times 10^{28}$x |\n",
     "\n",
-    "> **Point cle** : C'est la raison fondamentale pour laquelle la **connaissance de domaine** est si precieuse en apprentissage automatique. La determination agit comme un **filtre exponentiel** sur l'espace de recherche. En pratique, cette idee se retrouve dans le **feature engineering** moderne : selectionner les bons attributs est souvent plus important que le choix de l'algorithme."
+    "> **Point cle** : C'est la raison fondamentale pour laquelle la **connaissance de domaine** est si precieuse en apprentissage automatique. La détermination agit comme un **filtre exponentiel** sur l'espace de recherche. En pratique, cette idee se retrouve dans le **feature engineering** moderne : selectionner les bons attributs est souvent plus important que le choix de l'algorithme."
    ]
   },
   {
@@ -1397,17 +1397,17 @@
     "\n",
     "## 6. Determinations et semantique web\n",
     "\n",
-    "Les determinations du RBL ont un parallele direct dans les technologies du Web Semantique :\n",
+    "Les determinations du RBL ont un parallèle direct dans les technologies du Web Semantique :\n",
     "\n",
     "| Concept RBL | Equivalent Web Semantique |\n",
     "|-------------|--------------------------|\n",
-    "| Determination $X > Y$ | Propriete fonctionnelle `owl:FunctionalProperty` |\n",
-    "| Attribut determinant | Cle candidate (`owl:hasKey`) |\n",
+    "| détermination $X > Y$ | Propriete fonctionnelle `owl:FunctionalProperty` |\n",
+    "| Attribut déterminant | Cle candidate (`owl:hasKey`) |\n",
     "| Monotonie | Subpropriete (si $X > Y$ et $X \\subset X'$, $X' > Y$) |\n",
     "\n",
-    "En OWL, declarer qu'une propriete est **fonctionnelle** equivaut a affirmer une determination : pour un individu donne, il n'existe qu'une seule valeur. C'est la meme intuition que RBL.\n",
+    "En OWL, declarer qu'une propriete est **fonctionnelle** equivaut a affirmer une détermination : pour un individu donne, il n'existe qu'une seule valeur. C'est la même intuition que RBL.\n",
     "\n",
-    "> **Connexion inter-series** : Les notebooks SemanticWeb (SW-13) couvrent les reasoners OWL qui exploitent ces proprietes fonctionnelles pour inferer de nouveaux faits. Le RBL fournit le cadre theorique sous-jacent."
+    "> **Connexion inter-series** : Les notebooks SemanticWeb (SW-13) couvrent les reasoners OWL qui exploitent ces proprietes fonctionnelles pour inférer de nouveaux faits. Le RBL fournit le cadre theorique sous-jacent."
    ]
   },
   {
@@ -1532,7 +1532,7 @@
     "\n",
     "| Concept | Formule | Implementation |\n",
     "|---------|---------|----------------|\n",
-    "| Determination | $X > Y$ ssi $\\forall e_1, e_2 : X(e_1) = X(e_2) \\Rightarrow Y(e_1) = Y(e_2)$ | `check_determination()` |\n",
+    "| détermination | $X > Y$ ssi $\\forall e_1, e_2 : X(e_1) = X(e_2) \\Rightarrow Y(e_1) = Y(e_2)$ | `check_determination()` |\n",
     "| Treillis | $\\mathcal{P}(A)$ avec inclusion | `build_determination_lattice()` |\n",
     "| MINIMAL-CONSISTENT-DET | Parcourir par taille croissante | `minimal_consistent_det()` |\n",
     "| Reduction d'espace | $2^n \\to 2^d$ | Analyse PAC |"
@@ -1723,7 +1723,7 @@
     "tags": []
    },
    "source": [
-    "L'exercice suivant compare l'approche RBL a une selection aleatoire d'attributs pour mesurer concretement le benefice de la connaissance de pertinence."
+    "L'exercice suivant compare l'approche RBL a une sélection aléatoire d'attributs pour mesurer concretement le benefice de la connaissance de pertinence."
    ]
   },
   {
@@ -2149,15 +2149,15 @@
     "\n",
     "Ce notebook a approfondi le cadre du **Relevance-Based Learning** (AIMA 19.4) :\n",
     "\n",
-    "1. **Determinations** : un ensemble d'attributs $X$ determine $Y$ si connaitre $X$ suffit pour determiner $Y$ sans ambiguite. La propriete de **monotonie** garantit que tout surensemble d'une determination est aussi une determination.\n",
+    "1. **Determinations** : un ensemble d'attributs $X$ détermine $Y$ si connaitre $X$ suffit pour déterminer $Y$ sans ambiguite. La propriete de **monotonie** garantit que tout surensemble d'une détermination est aussi une détermination.\n",
     "\n",
     "2. **Treillis des determinations** : l'ensemble des sous-ensembles d'attributs forme un treillis sous l'inclusion. Les determinations valides forment un filtre (up-set) dans ce treillis.\n",
     "\n",
-    "3. **MINIMAL-CONSISTENT-DET** : algorithme qui trouve la determination minimale en explorant par taille croissante. Complexite $O(n^d)$ quand la determination est de taille $d$.\n",
+    "3. **MINIMAL-CONSISTENT-DET** : algorithme qui trouve la détermination minimale en explorant par taille croissante. Complexite $O(n^d)$ quand la détermination est de taille $d$.\n",
     "\n",
-    "4. **Reduction exponentielle** : la connaissance de pertinence reduit l'espace des hypotheses de $O(2^n)$ a $O(2^d)$, un gain exponentiel quand $d \\ll n$.\n",
+    "4. **Reduction exponentielle** : la connaissance de pertinence réduit l'espace des hypotheses de $O(2^n)$ a $O(2^d)$, un gain exponentiel quand $d \\ll n$.\n",
     "\n",
-    "5. **RBL vs sklearn** : RBL offre des garanties logiques mais exige des donnees propres (pas de bruit). Sklearn est robuste au bruit mais sans garantie fonctionnelle. Les deux approches sont **complementaires**.\n",
+    "5. **RBL vs sklearn** : RBL offre des garanties logiques mais exige des données propres (pas de bruit). Sklearn est robuste au bruit mais sans garantie fonctionnelle. Les deux approches sont **complementaires**.\n",
     "\n",
     "### Connexions\n",
     "\n",
@@ -2166,7 +2166,7 @@
     "| Suite de la serie | **ILP** (Inductive Logic Programming) | [SL-4](SL-4-InductiveLogicProgramming.ipynb) |\n",
     "| Prerequis | EBL & introduction RBL | [SL-2](SL-2-KnowledgeBasedLearning.ipynb) |\n",
     "| Web Semantique | Proprietes fonctionnelles OWL | SW-13 Reasoners |\n",
-    "| Machine Learning | Feature selection moderne | sklearn.feature_selection |"
+    "| Machine Learning | Feature sélection moderne | sklearn.feature_selection |"
    ]
   },
   {
@@ -2176,17 +2176,17 @@
    "source": [
     "---\n",
     "\n",
-    "## Defi presentation\n",
+    "## Defi présentation\n",
     "\n",
     "Modalite du cours : chaque groupe choisit **un exercice** de la serie, le prepare,\n",
-    "et le presente en seance. Resoudre l'exercice est le minimum ; ce qui distingue une\n",
-    "presentation qui maitrise le sujet, c'est la **question-twist** associee ci-dessous.\n",
-    "Elle fait partie integrante de la presentation attendue.\n",
+    "et le présente en seance. résoudre l'exercice est le minimum ; ce qui distingue une\n",
+    "présentation qui maitrise le sujet, c'est la **question-twist** associee ci-dessous.\n",
+    "Elle fait partie integrante de la présentation attendue.\n",
     "\n",
     "| Exercice | Question-twist a traiter en plus |\n",
     "|----------|----------------------------------|\n",
-    "| **Ex. 1 (determinations meteo)** | Ajoutez UNE observation bruitee a vos donnees : quelle determination minimale survit ? Qu'est-ce que cela illustre de la fragilite du cadre logique face au cadre statistique ? |\n",
-    "| **Ex. 2 (RBL vs selection aleatoire)** | Faites varier le ratio attributs-bruit / attributs-pertinents jusqu'au point de croisement ou la selection statistique bat le RBL. Ou est ce point sur vos donnees, et qu'est-ce qui le determine ? |\n",
+    "| **Ex. 1 (determinations meteo)** | Ajoutez UNE observation bruitee a vos données : quelle détermination minimale survit ? Qu'est-ce que cela illustre de la fragilite du cadre logique face au cadre statistique ? |\n",
+    "| **Ex. 2 (RBL vs sélection aléatoire)** | Faites varier le ratio attributs-bruit / attributs-pertinents jusqu'au point de croisement ou la sélection statistique bat le RBL. Ou est ce point sur vos données, et qu'est-ce qui le détermine ? |\n",
     "| **Ex. 3 (selecteur hybride)** | Votre selecteur hybride herite-t-il des garanties logiques des determinations, de la robustesse de l'information mutuelle, des deux, ou d'aucune ? Justifiez avec un contre-exemple construit. |\n"
    ]
   },
@@ -2211,7 +2211,7 @@
     "- Russell & Norvig, *AI: A Modern Approach*, 3e ed., Section 19.4\n",
     "- T. Mitchell, *Machine Learning*, Chapitre 11 (Computational Learning Theory)\n",
     "- M. Kearns & U. Vazirani, *An Introduction to Computational Learning Theory*\n",
-    "- [AIMA Python Code](https://github.com/aimacode/aima-python) - Implementations de reference\n",
+    "- [AIMA Python Code](https://github.com/aimacode/aima-python) - Implementations de référence\n",
     "\n",
     "---\n",
     "\n",


### PR DESCRIPTION
## Summary

Restore French accents in markdown source cells of `MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-3-RelevanceLearning.ipynb` (9ème étape de la vague c.594-c.595-c.596-c.597-c.598-c.599-c.600-c.601-c.602 cross-famille ML→GenAI/Audio→Search/Part1→Sudoku→Search/Part2-CSP→SymbolicAI/Tweety→Probas/DecInfer→Probas/PyMC→SymbolicAI/SymbolicLearning).

## Metrics

- **149 cures** appliquées sur **21 cellules markdown** (149 occurrences → regroupées sur 80 lignes diff en raison des cellules multi-lignes)
- 1 file / 1 domain / 1 feature (R3 atomicité)
- R6 anti-monotonie : SymbolicAI/SymbolicLearning (relevance determination / RBL family) après ML-4 (c.594), GenAI/Audio (c.595), Search/Part1 (c.596), Sudoku (c.597), Search/Part2-CSP (c.598), SymbolicAI/Tweety (c.599), Probas/DecInfer (c.600), Probas/PyMC (c.601)
- +80/-80 lignes diff (multiline cells regroupées), LF 2255/2255 inchange, bytes delta -1 (1 byte soustrait après revert `identifié → identifie`)
- 42 cells préservées (25 markdown + 17 code)

## Stop & Repair strict (HARD, règle 6 secrets-hygiene.md)

- 0 code cell source diff
- 0 outputs diff
- 0 execution_count diff
- 0 cell added/removed (42 cells préservées)
- nbformat 4.5 préservé
- CRLF 0/0 préservé
- LF 2255/2255 inchange
- Pas de hand-edit sur une sortie de cellule (cf secrets-hygiene.md règle 6)

## Pré-flight collision (L679-L1 ★★)

`gh pr list --state all --search "SL-3-RelevanceLearning"` : aucune PR ne touchait les accents markdown du notebook Python. → **0 collision**.

## Leçons cumulées (synchronisation avec vagues précédentes)

- **Leçon c.591 ★** : binary write `open('wb')` + `.encode('utf-8')` pour préserver LF
- **Leçon c.593 ★** : raw-text surgical bypass `nbformat.write` via `json.dumps(indent=4)` + closing `]` 3-space indent fix
- **Leçon c.596 ★** : pre-commit grep validation des participes passés + désambiguïsation présent/participe
- **Leçon c.599 ★** : pondere-3rd-ps-disambiguation (3rd ps sg present `pondère` ≠ 3rd pp `pondéré`)
- **Leçon c.601 ★** : verifie-3rd-ps-disambiguation (3rd ps sg present `vérifie` ≠ 3rd pp `vérifié`)

## Leçon c.602 ★ (L526 ★ NEW) : identifie-3rd-ps-disambiguation

**Action** : pour les prochaines PRs d'accents sur notebooks pédagogiques/logique, **chaque occurrence de `identifie` doit être analysée par contexte** :

| Contexte | Forme correcte | Pourquoi |
|----------|---------------|----------|
| "L'approche RBL **a identifié** `{R1, R2}`" (auxiliaire `a`) | `a identifié` (pp m.sg après avoir) | passé composé, pp invariable en avoir construction |
| "La connaissance de pertinence **identifie** un **filtre**" (sujet f.sg, présent narratif 3ps sg) | `identifie` (présent 3ps sg, SANS accent) | présent, pas pp |

**Auto-mapping `identifie → identifié`** (passé composé default) est **WRONG** dans le contexte singulier-sujet présent-narratif (cell[8] de SL-3). Surgical fix pattern (lesson c.596/c.601 ★) appliqué pour revert → `identifie` (no accent).

**Règle générale** : pour tout verbe en `-ifie`/`-ifiee`/`-ifies` (identifier, vérifier, modifier, spécifier, justifier, classifier, amplifier, intensifier...), vérifier que :
1. Le contexte est au **présent** (pas après "une fois", "après avoir", "a/ont/est/sont") ET
2. Le sujet est **singulier** pour `-ifie`, **pluriel** pour `-ifient`

Avant de figer le TARGETS list : grep dry-run sur les lemmes du notebook pour identifier les verbes conjugués AVANT mapping.

## Pre-commit grep (lesson c.596+)

Toutes les formes en `-ée`/`-ées`/`-é` post-fix vérifiées par contexte :

| Cell | Forme | Contexte | Verdict |
|------|-------|----------|---------|
| cell[8] | "La connaissance de pertinence **identifie** un filtre" | sujet f.sg "La connaissance" + présent 3ps sg | ✅ (FP revert) |
| cell[20] | "L'approche RBL **a identifié** `{R1, R2}`" | auxiliaire "a" + verbe = passé composé 3ps sg | ✅ |
| cell[22] | "Complexite $O(n^d)$ qui reste **élevée**" | adj f.sg (attribut du sujet "Complexite") | ✅ |
| cell[29] | "un 5ᵉ attribut **bruité**" | adj m.sg (épithète liée à "attribut") | ✅ |
| cell[33] | "Un attribut faiblement **corrélé**" | adj m.sg (épithète liée à "attribut") | ✅ |
| cell[33] | "C'est la limite **abordée** à l'Exercice 3" | pp f.sg (attribut du sujet "la limite") | ✅ |
| cell[37] | "sélecteur **guidé**" | adj m.sg (épithète liée à "sélecteur") | ✅ |
| cell[37] | "en cassant les **égalités**" | nom f.pl (substantif, "les égalités") | ✅ |

1 occurrence `identifié` corrigée en `identifie` (lesson c.602 ★). `utilisée/utilisés` toujours pp contextuel ("est/sont utilisé(es)"), jamais verbe présent. `corrélé`, `abordée`, `guidé`, `égale`, `élevée` tous adjectifs ou pp contextuels — correction correcte conservée.

## Scope strict : markdown only (leçon c.598 ★)

Code cells + outputs INCHANGÉS (0 diff). Les occurrences `donnees`/`regles`/`variables` dans les **commentaires Python** (`# ...`) et les **string-literals stdout** (`print(...)`) restent volontairement sans accent :
- **Commentaires Python** : OUT of scope per ai-01 accent contract
- **String-literals stdout** : nécessitent re-exécution Python (sklearn) pour cohérence output, hors scope c.602 (R3 atomic 1f/1feature/1domain)

Voir issue #2876 pour batch dédié SL-3 string-literal re-execution.

See #2876