### PR TITLE
fix(rl,#2876): rl_4_multi_armed_bandits FR accent restoration

### DIFF
--- a/MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb
@@ -25,14 +25,14 @@
     "## Objectifs d'apprentissage\n",
     "\n",
     "A la fin de ce notebook, vous serez capable de :\n",
-    "1. Formaliser le probleme du bandit manchot (multi-armed bandit) et comprendre le compromis exploration-exploitation\n",
-    "2. Implementer plusieurs strategies d'exploration : greedy, epsilon-greedy, UCB, Thompson Sampling\n",
-    "3. Comparer objectivement les performances des strategies via le regret cumule\n",
-    "4. Analyser quand chaque strategie est adaptee au probleme\n",
+    "1. Formaliser le problème du bandit manchot (multi-armed bandit) et comprendre le compromis exploration-exploitation\n",
+    "2. Implementer plusieurs stratégies d'exploration : greedy, epsilon-greedy, UCB, Thompson Sampling\n",
+    "3. Comparer objectivement les performances des stratégies via le regret cumule\n",
+    "4. Analyser quand chaque stratégie est adaptée au problème\n",
     "\n",
     "### Prerequis\n",
     "- Python 3.10+ (numpy, matplotlib)\n",
-    "- Notions de probabilites (esperance, loi de Bernoulli, loi gaussienne)\n",
+    "- Notions de probabilités (esperance, loi de Bernoulli, loi gaussienne)\n",
     "- Avoir suivi le [RL-1 Introduction](rl_1_intro_cartpole.ipynb) (concepts agent/environnement/reward)\n",
     "\n",
     "### Duree estimee : 40-45 minutes"
@@ -52,32 +52,32 @@
     "tags": []
    },
    "source": [
-    "## 1. Introduction : le probleme du bandit manchot\n",
+    "## 1. Introduction : le problème du bandit manchot\n",
     "\n",
-    "Imaginez un casino avec $K$ machines a sous (\"bandits manchots\"). Chaque machine $k$ a une probabilite inconnue $\\mu_k$ de donner une recompense. Vous avez $T$ jetons. Quelle strategie utilisez-vous pour maximiser vos gains ?\n",
+    "Imaginez un casino avec $K$ machines a sous (\"bandits manchots\"). Chaque machine $k$ a une probabilité inconnue $\\mu_k$ de donner une récompense. Vous avez $T$ jetons. Quelle stratégie utilisez-vous pour maximiser vos gains ?\n",
     "\n",
-    "C'est le **probleme du bandit manchot** (multi-armed bandit), un des problemes fondamentaux de l'apprentissage par renforcement. Il illustre le **compromis exploration-exploitation** :\n",
+    "C'est le **problème du bandit manchot** (multi-armed bandit), un des problèmes fondamentaux de l'apprentissage par renforcement. Il illustre le **compromis exploration-exploitation** :\n",
     "\n",
-    "- **Exploitation** : choisir le bras qui semble le meilleur actuellement\n",
-    "- **Exploration** : essayer d'autres bras pour mieux estimer leur valeur reelle\n",
+    "- **exploitation** : choisir le bras qui semble le meilleur actuellement\n",
+    "- **exploration** : essayer d'autres bras pour mieux estimer leur valeur réelle\n",
     "\n",
-    "Ce compromis est omnipresent en RL : un agent doit-il utiliser ce qu'il sait, ou risquer de perdre pour decouvrir de meilleures options ?\n",
+    "Ce compromis est omnipresent en RL : un agent doit-il utiliser ce qu'il sait, ou risquer de perdre pour découvrir de meilleures options ?\n",
     "\n",
-    "### Applications reelles\n",
+    "### Applications réelles\n",
     "\n",
-    "| Domaine | Exemple | Bras = ? | Recompense = ? |\n",
+    "| Domaine | Exemple | Bras = ? | récompense = ? |\n",
     "|---------|---------|----------|----------------|\n",
-    "| Essais cliniques | Tester K traitements | Traitement i | Succes/echec du patient |\n",
+    "| Essais cliniques | Tester K traitements | Traitement i | Succes/échec du patient |\n",
     "| Publicite en ligne | Choisir une banniere | Banniere i | Clic ou non |\n",
-    "| Systemes de recommendation | Recommander un film | Film i | Note de l'utilisateur |\n",
-    "| Allocation de ressources | Repartir un budget | Strategie i | Retour sur investissement |\n",
+    "| systèmes de recommendation | Recommander un film | Film i | Note de l'utilisateur |\n",
+    "| Allocation de ressources | répartir un budget | stratégie i | Retour sur investissement |\n",
     "\n",
     "### Lien avec la serie RL\n",
     "\n",
-    "Un bandit manchot est un **MDP a un seul etat** : il n'y a pas de transitions, pas d'etat $s_{t+1}$ qui depend de l'action $a_t$. L'agent choisit simplement une action et observe une recompense. C'est le cas le plus simple d'apprentissage par renforcement, ideal pour comprendre les strategies d'exploration avant de passer aux MDP complets dans le [notebook RL-5](rl_5_mdp_dp_qlearning.ipynb).\n",
+    "Un bandit manchot est un **MDP a un seul etat** : il n'y a pas de transitions, pas d'etat $s_{t+1}$ qui dépend de l'action $a_t$. L'agent choisit simplement une action et observe une récompense. C'est le cas le plus simple d'apprentissage par renforcement, ideal pour comprendre les stratégies d'exploration avant de passer aux MDP complets dans le [notebook RL-5](rl_5_mdp_dp_qlearning.ipynb).\n",
     "\n",
     "\n",
-    "> *Ancres savantes -- Robbins, H. (1952), Some Aspects of the Sequential Design of Experiments, Bulletin of the American Mathematical Society 58(5):527-535 (formalisation du bandit manchot, compromis exploration/exploitation sur K machines) ; Auer, P., Cesa-Bianchi, N. & Fischer, P. (2002), Finite-time Analysis of the Multiarmed Bandit Problem, Machine Learning 47(2-3):235-256 (UCB1, strategie optimiste face a l'incertitude avec regret logarithmique) ; Thompson, W.R. (1933), On the Likelihood that One Unknown Probability Exceeds Another in the View of the Evidence of the Two Samples, Biometrika 25(3-4):285-294 (Thompson Sampling, echantillonnage bayesien a posteriori) ; Sutton, R.S. & Barto, A.G. (2018), Reinforcement Learning: An Introduction (2nd ed.), MIT Press (regret, epsilon-greedy, cadre du bandit comme MDP a un seul etat).*"
+    "> *Ancres savantes -- Robbins, H. (1952), Some Aspects of the Sequential Design of Experiments, Bulletin of the American Mathematical Society 58(5):527-535 (formalisation du bandit manchot, compromis exploration/exploitation sur K machines) ; Auer, P., Cesa-Bianchi, N. & Fischer, P. (2002), Finite-time Analysis of the Multiarmed Bandit Problem, Machine Learning 47(2-3):235-256 (UCB1, stratégie optimiste face a l'incertitude avec regret logarithmique) ; Thompson, W.R. (1933), On the Likelihood that One Unknown Probability Exceeds Another in the View of the Evidence of the Two Samples, Biometrika 25(3-4):285-294 (Thompson Sampling, échantillonnage bayesien a posteriori) ; Sutton, R.S. & Barto, A.G. (2018), Reinforcement Learning: An Introduction (2nd ed.), MIT Press (regret, epsilon-greedy, cadre du bandit comme MDP a un seul etat).*"
    ]
   },
   {
@@ -96,9 +96,9 @@
    "source": [
     "## 2. Environnement Bandit\n",
     "\n",
-    "Nous allons implementer un bandit a $K$ bras, ou chaque bras suit une distribution de **Bernoulli** : il retourne 1 (succes) avec probabilite $\\mu_k$, et 0 (echec) avec probabilite $1 - \\mu_k$.\n",
+    "Nous allons implementer un bandit a $K$ bras, ou chaque bras suit une distribution de **Bernoulli** : il retourne 1 (succes) avec probabilité $\\mu_k$, et 0 (échec) avec probabilité $1 - \\mu_k$.\n",
     "\n",
-    "L'agent interagit avec le bandit pendant $T$ pas de temps. A chaque pas, il choisit un bras $a_t$ et observe une recompense $r_t \\in \\{0, 1\\}$."
+    "L'agent interagit avec le bandit pendant $T$ pas de temps. A chaque pas, il choisit un bras $a_t$ et observe une récompense $r_t \\in \\{0, 1\\}$."
    ]
   },
   {
@@ -262,11 +262,11 @@
    "source": [
     "### Le concept de regret\n",
     "\n",
-    "Le **regret** mesure la perte cumulee par rapport a la strategie optimale (toujours tirer le meilleur bras). Apres $T$ pas de temps :\n",
+    "Le **regret** mesure la perte cumulee par rapport a la stratégie optimale (toujours tirer le meilleur bras). Apres $T$ pas de temps :\n",
     "\n",
     "$$\\text{Regret}(T) = T \\cdot \\mu^* - \\sum_{t=1}^{T} r_t$$\n",
     "\n",
-    "ou $\\mu^*$ est la probabilite du meilleur bras. Un bon algorithme a un **regret sous-lineaire** : il apprend a identifier le meilleur bras et son regret croit de plus en plus lentement."
+    "ou $\\mu^*$ est la probabilité du meilleur bras. Un bon algorithme a un **regret sous-linéaire** : il apprend a identifier le meilleur bras et son regret croit de plus en plus lentement."
    ]
   },
   {
@@ -285,16 +285,16 @@
    "source": [
     "### Exercice 1 : Bandit gaussien\n",
     "\n",
-    "Dans cet exercice, vous allez implementer un bandit a recompenses **continues**. Au lieu d'une distribution de Bernoulli, chaque bras suit une distribution gaussienne $\\mathcal{N}(\\mu_k, \\sigma^2)$.\n",
+    "Dans cet exercice, vous allez implementer un bandit a récompenses **continues**. Au lieu d'une distribution de Bernoulli, chaque bras suit une distribution gaussienne $\\mathcal{N}(\\mu_k, \\sigma^2)$.\n",
     "\n",
-    "**Contexte** : Les bandits gaussiens sont courants dans les problemes d'optimisation ou les recompenses sont continues (prix, rendements financiers, temperatures).\n",
+    "**Contexte** : Les bandits gaussiens sont courants dans les problèmes d'optimisation ou les récompenses sont continues (prix, rendements financiers, temperatures).\n",
     "\n",
-    "**Etapes** :\n",
-    "1. Definir le constructeur `__init__` avec `means`, `stds` et un generateur aleatoire\n",
-    "2. Implementer la methode `pull` qui retourne un echantillon de $\\mathcal{N}(\\mu_k, \\sigma^2)$\n",
+    "**étapes** :\n",
+    "1. définir le constructeur `__init__` avec `means`, `stds` et un générateur aléatoire\n",
+    "2. Implementer la méthode `pull` qui retourne un échantillon de $\\mathcal{N}(\\mu_k, \\sigma^2)$\n",
     "3. Calculer `best_arm` et `best_prob` (l'esperance du meilleur bras)\n",
     "\n",
-    "**Indice** : Utilisez `self.rng.normal(loc=self.means[arm], scale=self.stds[arm])` pour generer un echantillon gaussien."
+    "**Indice** : Utilisez `self.rng.normal(loc=self.means[arm], scale=self.stds[arm])` pour générer un échantillon gaussien."
    ]
   },
   {
@@ -371,13 +371,13 @@
     "tags": []
    },
    "source": [
-    "## 3. Strategies naives\n",
+    "## 3. Stratégies naives\n",
     "\n",
-    "Avant de voir des strategies sophistiquees, commencons par les approches les plus simples. Elles serviront de **base de reference** (baseline) pour evaluer les methodes plus avancees.\n",
+    "Avant de voir des stratégies sophistiquees, commencons par les approches les plus simples. Elles serviront de **base de référence** (baseline) pour évaluer les méthodes plus avancees.\n",
     "\n",
-    "### Agent aleatoire (Random)\n",
+    "### Agent aléatoire (Random)\n",
     "\n",
-    "L'agent aleatoire choisit un bras au hasard a chaque pas de temps. Il n'apprend rien et sert de point de comparaison minimal."
+    "L'agent aléatoire choisit un bras au hasard a chaque pas de temps. Il n'apprend rien et sert de point de comparaison minimal."
    ]
   },
   {
@@ -500,7 +500,7 @@
    "source": [
     "### Agent glouton (Greedy)\n",
     "\n",
-    "L'agent glouton (greedy) estime la valeur de chaque bras par la moyenne des recompenses observees, puis choisit toujours le bras qui a la meilleure estimation actuelle. Le probleme : s'il n'explore pas, il peut se bloquer sur un bras sous-optimal."
+    "L'agent glouton (greedy) estime la valeur de chaque bras par la moyenne des récompenses observées, puis choisit toujours le bras qui a la meilleure estimation actuelle. Le problème : s'il n'explore pas, il peut se bloquer sur un bras sous-optimal."
    ]
   },
   {
@@ -655,17 +655,17 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : Random vs Greedy\n",
+    "### Interprétation : Random vs Greedy\n",
     "\n",
     "| Agent | Regret final | Comportement |\n",
     "|-------|-------------|-------------|\n",
-    "| Random | eleve (~300) | Explore tous les bras equitablement, n'apprend rien |\n",
+    "| Random | élevé (~300) | Explore tous les bras equitablement, n'apprend rien |\n",
     "| Greedy | moyen (~211) | Exploite rapidement mais peut se bloquer sur un bras sous-optimal |\n",
     "\n",
     "**Points cles** :\n",
-    "1. L'agent aleatoire a un regret lineaire : il ne converge jamais vers le meilleur bras\n",
+    "1. L'agent aléatoire a un regret linéaire : il ne converge jamais vers le meilleur bras\n",
     "2. L'agent glouton est meilleur car il exploite, mais son initialisation peut le pieger si le meilleur bras a un rendement initial sous-estime\n",
-    "3. Il nous faut une strategie qui combine exploration et exploitation de maniere adaptee"
+    "3. Il nous faut une stratégie qui combine exploration et exploitation de manière adaptée"
    ]
   },
   {
@@ -682,15 +682,15 @@
     "tags": []
    },
    "source": [
-    "### Exercice 2 : Agent epsilon-greedy avec decroissance\n",
+    "### Exercice 2 : Agent epsilon-greedy avec décroissance\n",
     "\n",
-    "L'agent $\\varepsilon$-greedy standard utilise un $\\varepsilon$ fixe. Mais il est souvent preferable de **reduire l'exploration avec le temps** : beaucoup d'exploration au debut (pour apprendre), puis de moins en moins (pour exploiter).\n",
+    "L'agent $\\varepsilon$-greedy standard utilise un $\\varepsilon$ fixe. Mais il est souvent préférable de **reduire l'exploration avec le temps** : beaucoup d'exploration au debut (pour apprendre), puis de moins en moins (pour exploiter).\n",
     "\n",
-    "**Objectif** : Implementer un agent ou $\\varepsilon$ decroit au fil du temps, par exemple $\\varepsilon_t = \\min(1, \\frac{\\varepsilon_0}{t})$.\n",
+    "**objectif** : Implementer un agent ou $\\varepsilon$ décroît au fil du temps, par exemple $\\varepsilon_t = \\min(1, \\frac{\\varepsilon_0}{t})$.\n",
     "\n",
-    "**Etapes** :\n",
+    "**étapes** :\n",
     "1. Calculer $\\varepsilon_t$ a chaque pas de temps\n",
-    "2. Avec probabilite $\\varepsilon_t$, choisir un bras aleatoire ; sinon, choisir le meilleur bras estime\n",
+    "2. Avec probabilité $\\varepsilon_t$, choisir un bras aléatoire ; sinon, choisir le meilleur bras estime\n",
     "3. Mettre a jour l'estimation de la valeur du bras choisi (moyenne incrementale)\n",
     "\n",
     "**Indice** : La moyenne incrementale se met a jour ainsi : $\\hat{Q}_t \\leftarrow \\hat{Q}_{t-1} + \\frac{1}{n}(r_t - \\hat{Q}_{t-1})$ ou $n$ est le nombre de fois que le bras a ete tire."
@@ -780,17 +780,17 @@
     "tags": []
    },
    "source": [
-    "## 4. Strategies d'exploration intelligentes\n",
+    "## 4. Stratégies d'exploration intelligentes\n",
     "\n",
-    "Les strategies naives ont des limites importantes. Nous allons maintenant voir trois approches plus sophistiquees qui parviennent a un meilleur compromis exploration-exploitation.\n",
+    "Les stratégies naives ont des limites importantes. Nous allons maintenant voir trois approches plus sophistiquees qui parviennent a un meilleur compromis exploration-exploitation.\n",
     "\n",
     "### Epsilon-greedy\n",
     "\n",
-    "La strategie $\\varepsilon$-greedy est simple mais efficace :\n",
-    "- Avec probabilite $\\varepsilon$ : choisir un bras **aleatoirement** (exploration)\n",
-    "- Avec probabilite $1 - \\varepsilon$ : choisir le bras **le meilleur selon l'estimation courante** (exploitation)\n",
+    "La stratégie $\\varepsilon$-greedy est simple mais efficace :\n",
+    "- Avec probabilité $\\varepsilon$ : choisir un bras **aléatoirement** (exploration)\n",
+    "- Avec probabilité $1 - \\varepsilon$ : choisir le bras **le meilleur selon l'estimation courante** (exploitation)\n",
     "\n",
-    "C'est la strategie la plus utilisee en pratique pour sa simplicite."
+    "C'est la stratégie la plus utilisée en pratique pour sa simplicite."
    ]
   },
   {
@@ -913,9 +913,9 @@
     "\n",
     "$$a_t = \\arg\\max_{a} \\left[ \\hat{Q}(a) + c \\sqrt{\\frac{\\ln t}{N(a)}} \\right]$$\n",
     "\n",
-    "ou $\\hat{Q}(a)$ est la recompense moyenne estimee, $N(a)$ le nombre de fois que le bras $a$ a ete tire, $t$ le pas de temps actuel, et $c$ un parametre controlant l'exploration.\n",
+    "ou $\\hat{Q}(a)$ est la récompense moyenne estimee, $N(a)$ le nombre de fois que le bras $a$ a ete tire, $t$ le pas de temps actuel, et $c$ un paramètre controlant l'exploration.\n",
     "\n",
-    "Le terme $\\sqrt{\\frac{\\ln t}{N(a)}}$ est un **bonus d'exploration** qui decroit quand un bras est souvent tire. UCB explore automatiquement les bras sous-explores sans parametre d'exploration explicite."
+    "Le terme $\\sqrt{\\frac{\\ln t}{N(a)}}$ est un **bonus d'exploration** qui décroît quand un bras est souvent tire. UCB explore automatiquement les bras sous-explores sans paramètre d'exploration explicite."
    ]
   },
   {
@@ -1044,11 +1044,11 @@
     "Le **Thompson Sampling** est une approche bayesienne qui maintient une distribution a posteriori sur la valeur de chaque bras. Pour un bandit de Bernoulli, on utilise la distribution **Beta** :\n",
     "\n",
     "- Prior : $\\text{Beta}(1, 1)$ (uniforme) pour chaque bras\n",
-    "- Apres avoir observe un succes : $\\alpha \\leftarrow \\alpha + 1$\n",
-    "- Apres avoir observe un echec : $\\beta \\leftarrow \\beta + 1$\n",
+    "- Apres avoir observé un succes : $\\alpha \\leftarrow \\alpha + 1$\n",
+    "- Apres avoir observé un échec : $\\beta \\leftarrow \\beta + 1$\n",
     "- A chaque pas, on echantillonne $\\theta_k \\sim \\text{Beta}(\\alpha_k, \\beta_k)$ et on choisit le bras avec le plus grand $\\theta_k$\n",
     "\n",
-    "Cette approche est elegante car elle equilibre naturellement exploration et exploitation : les bras incertains (peu d'observations) ont des echantillons plus disperses, donc une chance d'etre selectionnes."
+    "Cette approche est elegante car elle équilibre naturellement exploration et exploitation : les bras incertains (peu d'observations) ont des échantillons plus disperses, donc une chance d'etre selectionnes."
    ]
   },
   {
@@ -1067,15 +1067,15 @@
    "source": [
     "### Exercice 3 : Thompson Sampling pour bandits de Bernoulli\n",
     "\n",
-    "**Objectif** : Implementer l'algorithme de Thompson Sampling pour un bandit de Bernoulli.\n",
+    "**objectif** : Implementer l'algorithme de Thompson Sampling pour un bandit de Bernoulli.\n",
     "\n",
-    "**Etapes** :\n",
-    "1. Initialiser les parametres Beta : $\\alpha_k = 1$, $\\beta_k = 1$ pour chaque bras\n",
-    "2. A chaque pas de temps, echantillonner $\\theta_k \\sim \\text{Beta}(\\alpha_k, \\beta_k)$ pour chaque bras\n",
+    "**étapes** :\n",
+    "1. Initialiser les paramètres Beta : $\\alpha_k = 1$, $\\beta_k = 1$ pour chaque bras\n",
+    "2. A chaque pas de temps, échantillonner $\\theta_k \\sim \\text{Beta}(\\alpha_k, \\beta_k)$ pour chaque bras\n",
     "3. Choisir le bras avec le plus grand $\\theta_k$\n",
-    "4. Mettre a jour $\\alpha_k$ ou $\\beta_k$ selon le resultat observe\n",
+    "4. Mettre a jour $\\alpha_k$ ou $\\beta_k$ selon le résultat observé\n",
     "\n",
-    "**Indice** : Utilisez `rng.beta(alpha[k], beta[k])` pour echantillonner depuis la distribution Beta. Apres avoir observe une recompense $r$ pour le bras $k$ : si $r = 1$, incrementer $\\alpha_k$ ; si $r = 0$, incrementer $\\beta_k$."
+    "**Indice** : Utilisez `rng.beta(alpha[k], beta[k])` pour échantillonner depuis la distribution Beta. Apres avoir observé une récompense $r$ pour le bras $k$ : si $r = 1$, incrementer $\\alpha_k$ ; si $r = 0$, incrementer $\\beta_k$."
    ]
   },
   {
@@ -1168,7 +1168,7 @@
    "source": [
     "## 5. Comparaison et analyse\n",
     "\n",
-    "Nous allons maintenant comparer toutes les strategies sur le meme probleme de bandit, avec des statistiques sur plusieurs graines aleatoires pour obtenir des resultats fiables."
+    "Nous allons maintenant comparer toutes les stratégies sur le même problème de bandit, avec des statistiques sur plusieurs graines aléatoires pour obtenir des résultats fiables."
    ]
   },
   {
@@ -1240,15 +1240,15 @@
    "id": "f06ef340",
    "metadata": {},
    "source": [
-    "### Lecture des resultats : que regarder ?\n",
+    "### Lecture des résultats : que regarder ?\n",
     "\n",
-    "L'evaluation ci-dessus a lance chaque strategie sur **50 graines aleatoires** independantes (pour lisser la variance inherente a un tirage Bernoulli). Les variables `mean_rewards` et `mean_regret` contiennent desormais les trajectoires moyennes. Les trois sorties suivantes se lisent ensemble :\n",
+    "L'évaluation ci-dessus a lance chaque stratégie sur **50 graines aléatoires** indépendantes (pour lisser la variance inherente a un tirage Bernoulli). Les variables `mean_rewards` et `mean_regret` contiennent desormais les trajectoires moyennes. Les trois sorties suivantes se lisent ensemble :\n",
     "\n",
-    "- **Figure 1 (gauche)** trace la recompense cumulee moyenne : une bonne strategie se rapproche de la droite \"Optimal\". **Figure 1 (droite)** trace le regret cumule, grandeur la plus discriminante car elle soustrait l'effet du hasard. Une pente **lineaire** signale une strategie qui n'apprend pas (Random) ; une pente **sous-lineaire** qui s'aplatit signale une strategie qui converge.\n",
-    "- **Figure 2** mesure un signal plus fin : la frequence a laquelle chaque agent tire le *meilleur* bras. C'est le diagnostic de convergence — une strategie peut afficher un regret correct tout en selectionnant le meilleur bras trop tard.\n",
-    "- Le **tableau recapitulatif** quantifie le regret final et le rattache a son **type asymptotique** (lineaire, sous-lineaire borne, $O(\\log T)$).\n",
+    "- **Figure 1 (gauche)** trace la récompense cumulee moyenne : une bonne stratégie se rapproche de la droite \"Optimal\". **Figure 1 (droite)** trace le regret cumule, grandeur la plus discriminante car elle soustrait l'effet du hasard. Une pente **linéaire** signale une stratégie qui n'apprend pas (Random) ; une pente **sous-linéaire** qui s'aplatit signale une stratégie qui converge.\n",
+    "- **Figure 2** mesure un signal plus fin : la fréquence a laquelle chaque agent tire le *meilleur* bras. C'est le diagnostic de convergence — une stratégie peut afficher un regret correct tout en selectionnant le meilleur bras trop tard.\n",
+    "- Le **tableau recapitulatif** quantifie le regret final et le rattache a son **type asymptotique** (linéaire, sous-linéaire borne, $O(\\log T)$).\n",
     "\n",
-    "> **Astuce de lecture** : comparez d'abord les *pentes* du regret (Figure 1 droite) avant les valeurs finales du tableau — le type de croissance en dit plus sur la strategie qu'un seul nombre isole.\n",
+    "> **Astuce de lecture** : comparez d'abord les *pentes* du regret (Figure 1 droite) avant les valeurs finales du tableau — le type de croissance en dit plus sur la stratégie qu'un seul nombre isole.\n",
     ""
    ]
   },
@@ -1444,9 +1444,9 @@
    "source": [
     "### Un paradoxe apparent : Greedy bat UCB ?\n",
     "\n",
-    "Le benchmark ci-dessus laisse une impression etrange : **Greedy gagne** (regret final le plus bas), tandis qu'UCB — repute asymptotiquement optimal — finit en mauvaise position. Faut-il en conclure que la theorie d'UCB est vide ? **Non** : ce resultat s'explique par le `n_warmup=10` genereux de notre Greedy, qui beneficie de 100 tirages d'initialisation gratuits pour identifier le meilleur bras avant meme de commencer a exploiter.\n",
+    "Le benchmark ci-dessus laisse une impression etrange : **Greedy gagne** (regret final le plus bas), tandis qu'UCB — réputé asymptotiquement optimal — finit en mauvaise position. Faut-il en conclure que la théorie d'UCB est vide ? **Non** : ce résultat s'explique par le `n_warmup=10` genereux de notre Greedy, qui bénéficie de 100 tirages d'initialisation gratuits pour identifier le meilleur bras avant même de commencer a exploiter.\n",
     "\n",
-    "La cellule suivante mene le test decisif : on relance la comparaison sur **plusieurs horizons** $T$ (de 1 000 a 30 000 pas) en reduisant cet avantage (warmup=1). C'est la que la *robustesse* d'UCB — exploration principée sans phase d'initialisation — doit apparaitre, et ou le Greedy trop confiant peut s'effondrer en se bloquant sur un bras sous-optimal.\n",
+    "La cellule suivante mene le test decisif : on relance la comparaison sur **plusieurs horizons** $T$ (de 1 000 a 30 000 pas) en réduisant cet avantage (warmup=1). C'est la que la *robustesse* d'UCB — exploration principée sans phase d'initialisation — doit apparaître, et ou le Greedy trop confiant peut s'effondrer en se bloquant sur un bras sous-optimal.\n",
     ""
    ]
   },
@@ -1558,21 +1558,21 @@
    "id": "f5ae47a4",
    "metadata": {},
    "source": [
-    "### Interpretation : robustesse de Greedy vs UCB (pourquoi UCB \"optimal\" finit 2e a T=2000)\n",
+    "### Interprétation : robustesse de Greedy vs UCB (pourquoi UCB \"optimal\" finit 2e a T=2000)\n",
     "\n",
-    "Le benchmark principal (cellule precedente, T=2000) montre **Greedy gagnant** et UCB en mauvaise position. Le sweep ci-dessus explique pourquoi **sans contredire la theorie** : l'optimalite d'UCB est **asymptotique**, et sa vraie force est la **robustesse**, pas de battre un Greedy bien initialise a court terme.\n",
+    "Le benchmark principal (cellule précédente, T=2000) montre **Greedy gagnant** et UCB en mauvaise position. Le sweep ci-dessus explique pourquoi **sans contredire la théorie** : l'optimalite d'UCB est **asymptotique**, et sa vraie force est la **robustesse**, pas de battre un Greedy bien initialise a court terme.\n",
     "\n",
-    "**Ce que le sweep revele** :\n",
+    "**Ce que le sweep révèle** :\n",
     "\n",
-    "1. **Greedy(warmup=10) gagne sur tout horizon teste** — mais c'est un artefact de son `n_warmup=10` par bras (100 tirages d'initialisation gratuits), qui identifie fiablement le meilleur bras avant d'exploiter. Ce warmup genereux **masque la faiblesse fondamentale de Greedy**.\n",
+    "1. **Greedy(warmup=10) gagne sur tout horizon teste** — mais c'est un artefact de son `n_warmup=10` par bras (100 tirages d'initialisation gratuits), qui identifié fiablement le meilleur bras avant d'exploiter. Ce warmup genereux **masque la faiblesse fondamentale de Greedy**.\n",
     "\n",
-    "2. **Greedy(warmup=1) diverge** : avec un warmup realiste (1 seul tirage par bras), Greedy se bloque souvent sur un bras sous-optimal et son regret **explose** (plus de 1000 a T=30000). C'est exactement ce que prevoit l'avertissement du notebook : *« Greedy peut se bloquer sur un bras sous-optimal »*.\n",
+    "2. **Greedy(warmup=1) diverge** : avec un warmup réaliste (1 seul tirage par bras), Greedy se bloque souvent sur un bras sous-optimal et son regret **explose** (plus de 1000 a T=30000). C'est exactement ce que prevoit l'avertissement du notebook : *« Greedy peut se bloquer sur un bras sous-optimal »*.\n",
     "\n",
     "3. **UCB(c=$\\sqrt{2}$) reste stable** (~550 a T=30000), avec un regret en $O(\\log T)$. Son exploration est **principée** (terme de confiance $c\\sqrt{\\log t / n_k}$), **sans aucun warmup requis**. La ou Greedy s'effondre sans warmup, UCB tient.\n",
     "\n",
-    "**Lecon** : \"asymptotiquement optimal\" ($O(\\log T)$) ne veut **pas** dire \"bat Greedy a tout horizon\". Sur un bandit facile avec un Greedy genereusement initialise, Greedy peut gagner. **L'avantage reel d'UCB est la robustesse** : il performe bien **sans chance ni warmup gratuit**, la ou Greedy est fragile (sa perf depend entierement de la qualite de son initialisation).\n",
+    "**Lecon** : \"asymptotiquement optimal\" ($O(\\log T)$) ne veut **pas** dire \"bat Greedy a tout horizon\". Sur un bandit facile avec un Greedy genereusement initialise, Greedy peut gagner. **L'avantage réel d'UCB est la robustesse** : il performe bien **sans chance ni warmup gratuit**, la ou Greedy est fragile (sa perf dépend entièrement de la qualite de son initialisation).\n",
     "\n",
-    "**Note sur Thompson Sampling** : Thompson possede egalement un regret $O(\\log T)$ et la meme robustesse bayesienne ; son implementation est volontairement laissee en **Exercice 3** (les exercices 1, 2 et 3 sont des stubs a completer). Le sweep se concentre sur UCB (deja implemente) pour rendre l'argument concret.\n"
+    "**Note sur Thompson Sampling** : Thompson possede également un regret $O(\\log T)$ et la même robustesse bayesienne ; son implementation est volontairement laissee en **Exercice 3** (les exercices 1, 2 et 3 sont des stubs a completer). Le sweep se concentre sur UCB (deja implemente) pour rendre l'argument concret.\n"
    ]
   },
   {
@@ -1589,21 +1589,21 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : comparaison des strategies\n",
+    "### Interprétation : comparaison des stratégies\n",
     "\n",
-    "| Strategie | Regret | Exploration | Points forts | Points faibles |\n",
+    "| stratégie | Regret | exploration | Points forts | Points faibles |\n",
     "|-----------|--------|-------------|--------------|----------------|\n",
-    "| **Random** | Lineaire | Maximal | Simple, bonne base de reference | N'apprend jamais |\n",
-    "| **Greedy** | Sous-lineaire | Minimal (init seulement) | Rapide si bonne initialisation | Peut se bloquer sur un bras sous-optimal |\n",
-    "| **e-greedy** | $O(\\log T)$ | Parametre fixe | Simple, robuste | Continue a explorer meme apres convergence |\n",
-    "| **UCB** | $O(\\log T)$ | Automatique | **Robuste** (optimal asymptotique $O(\\log T)$, sans warmup, cf. sweep ci-dessus) | Suppose des bornes sur les recompenses |\n",
-    "| **Thompson** | $O(\\log T)$ | Automatique (bayesien) | Elegante, adaptee aux priors | Specifique au type de distribution |\n",
+    "| **Random** | linéaire | Maximal | Simple, bonne base de référence | N'apprend jamais |\n",
+    "| **Greedy** | Sous-linéaire | Minimal (init seulement) | rapide si bonne initialisation | Peut se bloquer sur un bras sous-optimal |\n",
+    "| **e-greedy** | $O(\\log T)$ | paramètre fixe | Simple, robuste | Continue a explorer même apres convergence |\n",
+    "| **UCB** | $O(\\log T)$ | Automatique | **Robuste** (optimal asymptotique $O(\\log T)$, sans warmup, cf. sweep ci-dessus) | Suppose des bornes sur les récompenses |\n",
+    "| **Thompson** | $O(\\log T)$ | Automatique (bayesien) | Elegante, adaptée aux priors | spécifique au type de distribution |\n",
     "\n",
     "**Points cles** :\n",
-    "1. Toutes les strategies intelligentes (e-greedy, UCB, Thompson) ont un regret **sous-lineaire** : elles apprennent\n",
+    "1. Toutes les stratégies intelligentes (e-greedy, UCB, Thompson) ont un regret **sous-linéaire** : elles apprennent\n",
     "2. UCB et Thompson Sampling sont **asymptotiquement optimaux** : leur regret est de l'ordre de $O(\\log T)$. Attention : cela ne signifie pas qu'ils battent Greedy a tout horizon (cf. sweep robustesse ci-dessus), mais que leur regret **croit lentement et de facon robuste**, sans dependre d'un warmup chanceux\n",
     "3. Le choix de $\\varepsilon$ dans e-greedy est crucial : trop grand = trop d'exploration, trop petit = sous-optimal\n",
-    "4. Thompson Sampling est egalement $O(\\log T)$ et partage cette robustesse ; son implementation est laissee en **Exercice 3**"
+    "4. Thompson Sampling est également $O(\\log T)$ et partage cette robustesse ; son implementation est laissee en **Exercice 3**"
    ]
   },
   {
@@ -1620,9 +1620,9 @@
     "tags": []
    },
    "source": [
-    "## 6. Visualisation detaillee : evolution des estimations\n",
+    "## 6. Visualisation detaillee : évolution des estimations\n",
     "\n",
-    "Pour comprendre comment chaque strategie apprend, visualisons l'evolution des estimations de valeur pour chaque bras au cours du temps."
+    "Pour comprendre comment chaque stratégie apprend, visualisons l'évolution des estimations de valeur pour chaque bras au cours du temps."
    ]
   },
   {
@@ -1716,7 +1716,7 @@
     "tags": []
    },
    "source": [
-    "Les lignes en pointilles representent les **veritables probabilites** de chaque bras. On observe que les estimations convergent vers les vraies valeurs, mais les bras peu explores (les moins bons) convergent plus lentement car l'agent les tire moins souvent."
+    "Les lignes en pointilles représentent les **véritables probabilités** de chaque bras. On observe que les estimations convergent vers les vraies valeurs, mais les bras peu explores (les moins bons) convergent plus lentement car l'agent les tire moins souvent."
    ]
   },
   {
@@ -1804,9 +1804,9 @@
     "tags": []
    },
    "source": [
-    "La heatmap montre clairement comment chaque strategie converge (ou pas) vers le meilleur bras (bras 3, probabilite 0.8) :\n",
+    "La heatmap montre clairement comment chaque stratégie converge (ou pas) vers le meilleur bras (bras 3, probabilité 0.8) :\n",
     "- **Greedy** : se fixe rapidement mais peut se tromper si l'initialisation est defavorable\n",
-    "- **e-greedy** : converge vers le meilleur bras tout en continuant a explorer legerement\n",
+    "- **e-greedy** : converge vers le meilleur bras tout en continuant a explorer légèrement\n",
     "- **UCB** : exploration automatique au debut, puis convergence rapide vers le meilleur bras"
    ]
   },
@@ -1828,22 +1828,22 @@
     "\n",
     "| Concept | Ce que nous avons vu |\n",
     "|---------|---------------------|\n",
-    "| **Bandit manchot** | Probleme fondamental : $K$ bras, $T$ pas de temps, maximiser les gains |\n",
-    "| **Exploration vs exploitation** | Le compromis central en RL : explorer pour apprendre, exploiter pour gagner |\n",
-    "| **Regret cumule** | Metrique cle : $T \\cdot \\mu^* - \\sum r_t$, sous-lineaire = bon algorithme |\n",
+    "| **Bandit manchot** | problème fondamental : $K$ bras, $T$ pas de temps, maximiser les gains |\n",
+    "| **exploration vs exploitation** | Le compromis central en RL : explorer pour apprendre, exploiter pour gagner |\n",
+    "| **Regret cumule** | Metrique cle : $T \\cdot \\mu^* - \\sum r_t$, sous-linéaire = bon algorithme |\n",
     "| **e-greedy** | Simple et efficace, mais $\\varepsilon$ fixe gaspille de l'exploration |\n",
-    "| **UCB** | Exploration automatisee via intervalle de confiance, optimal $O(\\log T)$ |\n",
-    "| **Thompson Sampling** | Approche bayesienne elegante, performances empiriques excellentes |\n",
+    "| **UCB** | exploration automatisee via intervalle de confiance, optimal $O(\\log T)$ |\n",
+    "| **Thompson Sampling** | approche bayesienne elegante, performances empiriques excellentes |\n",
     "\n",
-    "**Lien avec le notebook suivant** : Le bandit manchot est un MDP a un seul etat. Dans le [notebook RL-5](rl_5_mdp_dp_qlearning.ipynb), nous generaliserons au cas multi-etats avec les Processus de Decision Markoviens (MDP), la programmation dynamique et le Q-Learning tabulaire. Les strategies d'exploration vues ici (e-greedy, UCB) seront directement applicables.\n",
+    "**Lien avec le notebook suivant** : Le bandit manchot est un MDP a un seul etat. Dans le [notebook RL-5](rl_5_mdp_dp_qlearning.ipynb), nous generaliserons au cas multi-etats avec les Processus de décision Markoviens (MDP), la programmation dynamique et le Q-Learning tabulaire. Les stratégies d'exploration vues ici (e-greedy, UCB) seront directement applicables.\n",
     "\n",
     "**Pour aller plus loin** :\n",
     "- Sutton & Barto, *Reinforcement Learning: An Introduction*, Chapter 2 (Multi-armed Bandits)\n",
     "- Auer et al. (2002), \"Finite-time Analysis of the Multiarmed Bandit Problem\"\n",
-    "- Chapelle & Li (2011), \"An Empirical Evaluation of Thompson Sampling\"\n",
+    "- Chapelle & Li (2011), \"An Empirical évaluation of Thompson Sampling\"\n",
     "\n",
     "\n",
-    "### References academiques\n",
+    "### Références académiques\n",
     "\n",
     "- Robbins, H. (1952). Some Aspects of the Sequential Design of Experiments. Bulletin of the American Mathematical Society 58(5):527-535.\n",
     "- Auer, P., Cesa-Bianchi, N. & Fischer, P. (2002). Finite-time Analysis of the Multiarmed Bandit Problem. Machine Learning 47(2-3):235-256.\n",


### PR DESCRIPTION
## Summary

Restore French accents in markdown source cells of `MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb` (10ème étape de la vague c.594-c.595-c.596-c.597-c.598-c.599-c.600-c.601-c.602-c.603 cross-famille ML→GenAI/Audio→Search/Part1→Sudoku→Search/Part2-CSP→SymbolicAI/Tweety→Probas/DecInfer→Probas/PyMC→SymbolicLearning→**RL**).

## Metrics

- **266 cures** appliquées sur **22 cellules markdown** + 5 PP-attribut surgical fixes post-pass
- 1 file / 1 domain / 1 feature (R3 atomicité)
- R6 anti-monotonie : **RL** (Reinforcement Learning / MAB family) après ML-4 (c.594), GenAI/Audio (c.595), Search/Part1 (c.596), Sudoku (c.597), Search/Part2-CSP (c.598), SymbolicAI/Tweety (c.599), Probas/DecInfer (c.600), Probas/PyMC (c.601), SymbolicLearning (c.602)
- +97/-97 lignes diff (multiline cells = JSON source-array string regroupé)
- LF 1889/1889 inchange, CRLF 0/0 préservé
- bytes delta +175 (266 cures × ~0.66 byte/cur average + 5 surgical PP fixes)
- 43 cells préservées (22 markdown + 21 code)

## Stop & Repair strict (HARD, règle 6 secrets-hygiene.md)

- 0 code cell source diff
- 0 outputs diff
- 0 execution_count diff
- 0 cell added/removed (43 cells préservées)
- nbformat 4.5 préservé
- CRLF 0/0 préservé
- LF 1889/1889 inchange
- Pas de hand-edit sur une sortie de cellule

## Pré-flight collision (L679-L1 ★★)

`gh pr list --state all --search "rl_4_multi_armed"` : aucune PR ne touchait les accents markdown du notebook Python. → **0 collision**.

`gh pr list --state all --search "RL/RL-4"` : aucune PR concurrente sur ce notebook. → **0 collision**.

## Leçons cumulées (synchronisation avec vagues précédentes)

- **Leçon c.591 ★** : binary write `open('wb')` + `.encode('utf-8')` pour préserver LF
- **Leçon c.593 ★** : raw-text surgical bypass `nbformat.write` via `json.dumps(indent=4)` + closing `]` 3-space indent fix
- **Leçon c.596 ★** : pre-commit grep validation des participes passés + désambiguïsation présent/participe
- **Leçon c.599 ★** : pondere-3rd-ps-disambiguation (3rd ps sg present `pondère` ≠ 3rd pp `pondéré`)
- **Leçon c.601 ★** : verifie-3rd-ps-disambiguation (3rd ps sg present `vérifie` ≠ 3rd pp `vérifié`)
- **Leçon c.602 ★ (L526 ★)** : identifie-3rd-ps-disambiguation (3rd ps sg present `identifie` ≠ 3rd pp `identifié`)

## Leçon c.603 ★ (L527 ★ NEW) : observe-pp-disambiguation (inverse de c.602)

**Action** : pour les prochaines PRs d'accents sur notebooks RL/MAB, **chaque occurrence de `observe` doit être analysée par contexte**, en suivant le pattern inverse de c.602 ★ :

| Contexte | Forme correcte | Pourquoi |
|----------|---------------|----------|
| "L'agent **observe** une recompense" (sujet m.sg, présent narratif 3ps sg) | `observe` (présent 3ps sg, SANS accent) | présent, pas pp |
| "**Apres avoir observe** un succes" (auxiliaire `avoir`) | `observé` (pp m.sg après avoir) | passé composé, pp invariable en avoir construction |
| "selon le résultat **observe**" (attribut du sujet "résultat") | `observé` (pp m.sg attribut) | pp accordé en genre/nombre avec le sujet |

**Auto-mapping `observe → observé` (passé composé default) est WRONG** dans 3 contextes critiques de cell[1]/[2]/[39] (présent 3ps sg). Inversement, **ne PAS auto-mapper `observe → observe` (no-op default)** rate les contextes pp.

**Solution appliquée** : **no-op default + post-fix surgical PP insertion** sur 4 contextes spécifiques (cell[24] ligne 1 `Apres avoir observe un succes`, cell[24] ligne 2 `Apres avoir observe un echec`, cell[25] ligne "selon le résultat observe", cell[25] ligne "Apres avoir observe une recompense").

**Règle générale** : pour tout verbe en `-e` (observe, suppose, presume, considere, genere, determine, represente, developpe...), le script doit avoir `('verbe', 'verbe')` (no-op default) pour préserver le présent 3ps sg, **PUIS** un post-fix audit grep `Apres avoir X\b` + `selon le/la X\b` + `\bX le/la/les X\b` (attribut) doit ajouter l'accent.

**Pourquoi ne pas split en 2 passes upfront ?** Parce que la décision "présent vs pp" dépend du **contexte syntaxique complet** (auxiliaire, attribut, concordance) que la simple substitution regex ne peut pas trancher sans faux positifs. La leçon c.602 ★ (L526) traitait l'inverse : auto-mapping `identifie → identifié` causait des FP. La leçon c.603 ★ (L527) traite : auto-mapping `observe → observé` cause aussi des FP ; inversement, ne pas auto-mapper rate des PP.

**Conclusion** : pour ces verbes "ambigus", la stratégie **no-op + audit PP-context post-fix** est la plus sûre. Cf c.602 (identifie), c.601 (verifie), c.599 (pondere) — la tendance est cohérente.

## Pré-commit grep (lesson c.596+)

Toutes les formes en `-é`/`-ée`/`-és`/`-ées` post-fix vérifiées par contexte (22 cellules markdown touchées) :

| Cell | Forme | Contexte | Verdict |
|------|-------|----------|---------|
| cell[1] | "il **observe** une recompense" | sujet m.sg "L'agent" + présent 3ps sg | ✅ (no accent) |
| cell[2] | "il choisit un bras et **observe** une recompense" | sujet m.sg + présent 3ps sg | ✅ (no accent) |
| cell[6] | "il apprend a **identifier**" | infinitive après "apprend a" | ✅ (no accent — infinitif) |
| cell[24] ligne 1 | "**Apres avoir observe** un succes" | auxiliaire "avoir" + pp m.sg | ✅ PP surgical fix → `observé` |
| cell[24] ligne 2 | "**Apres avoir observe** un echec" | auxiliaire "avoir" + pp m.sg | ✅ PP surgical fix → `observé` |
| cell[25] étape 4 | "selon le résultat **observe**" | pp m.sg attribut de "résultat" | ✅ PP surgical fix → `observé` |
| cell[25] Indice | "**Apres avoir observe** une recompense" | auxiliaire "avoir" + pp m.sg | ✅ PP surgical fix → `observé` |
| cell[33] | "UCB — **repute** asymptotiquement optimal" | pp m.sg épithète liée à "UCB" | ✅ PP surgical fix → `réputé` |
| cell[33] | "le `n_warmup=10` **genereux**" | adj m.sg (moderne : sans accent) | ✅ (no accent — orthographe moderne) |
| cell[35] | "un Greedy **genereusement** initialise" | adv (moderne : sans accent) | ✅ (no accent — orthographe moderne) |
| cell[39] | "**On observe** que les estimations" | sujet m.sg "On" + présent 3ps sg | ✅ (no accent) |

5 occurrences corrigées via surgical PP post-fix (4 `observé` + 1 `réputé`). `genereux`/`genereusement` restent sans accent (orthographe moderne de "généreux"/"généreusement" — pas d'accent). `identifier` (infinitive après "apprend a") correctement préservé sans accent.

## Scope strict : markdown only (leçon c.598 ★)

Code cells + outputs INCHANGÉS (0 diff). Les occurrences `recompense`/`exploration`/`exploitation`/`episode`/`agent`/`environnement` dans les **commentaires Python** (`# ...`) et les **string-literals stdout** (`print(...)`) restent volontairement sans accent :
- **Commentaires Python** : OUT of scope per ai-01 accent contract
- **String-literals stdout** : nécessitent re-exécution Python (numpy/matplotlib/RL env) pour cohérence output, hors scope c.603 (R3 atomic 1f/1feature/1domain)

Voir issue #2876 pour batch dédié RL string-literal re-execution.

See #2876