### PR TITLE
fix(search,#2876): restore French accents in Search-11b-Metaheuristiques-Deep markdown (57 cures, code untouched)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11b-Metaheuristiques-Deep-Part3.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11b-Metaheuristiques-Deep-Part3.ipynb
@@ -14,13 +14,13 @@
     "tags": []
    },
    "source": [
-    "# Search-11b-Metaheuristiques-Deep-Part3 : Artificial Bee Colony (ABC) from-scratch\n",
+    "# Search-11b-Métaheuristiques-Deep-Part3 : Artificial Bee Colony (ABC) from-scratch\n",
     "\n",
-    "**Navigation** : [<< Tranche 2 PSO](Search-11b-Metaheuristiques-Deep-Part2.ipynb) | [Twin Python MEALPy](Search-11-Metaheuristics.ipynb) | [Tranche 4 Benchmark >>](Search-11b-Metaheuristiques-Deep-Part4.ipynb)\n",
+    "**Navigation** : [<< Tranche 2 PSO](Search-11b-Métaheuristiques-Deep-Part2.ipynb) | [Twin Python MEALPy](Search-11-Metaheuristics.ipynb) | [Tranche 4 Benchmark >>](Search-11b-Métaheuristiques-Deep-Part4.ipynb)\n",
     "\n",
-    "**Tranche 3** du twin .NET du notebook Python [Search-11-Metaheuristics](Search-11-Metaheuristics.ipynb) (MEALPy). Apres le **recuit simule** (tranche 1, trajectoire unique, Metropolis) et le **Particle Swarm Optimization** (tranche 2, essaim de particules, vitesse/inertie), cette **tranche 3 = Artificial Bee Colony (ABC)** — une autre metaheuristique d'essaim, fondee sur le **comportement de butinage des abeilles** (Karaboga, 2005).\n",
+    "**Tranche 3** du twin .NET du notebook Python [Search-11-Metaheuristics](Search-11-Metaheuristics.ipynb) (MEALPy). Après le **recuit simule** (tranche 1, trajectoire unique, Metropolis) et le **Particle Swarm Optimization** (tranche 2, essaim de particules, vitesse/inertie), cette **tranche 3 = Artificial Bee Colony (ABC)** — une autre métaheuristique d'essaim, fondee sur le **comportement de butinage des abeilles** (Karaboga, 2005).\n",
     "\n",
-    "L'idee centrale : la colonie se divise en **trois types d'abeilles aux roles distincts**, et l'information sur la qualite des sources de nourriture circule via la **danse** (un mecanisme de selection probabiliste). Comme pour PSO, il s'agit d'une methode **population-based**, mais la dynamique coopérative est radicalement differente (pas de vitesse, pas de personal/global best, mais un système de rôles + compteur d'essai + abandon).\n",
+    "L'idee centrale : la colonie se divise en **trois types d'abeilles aux rôles distincts**, et l'information sur la qualite des sources de nourriture circule via la **danse** (un mécanisme de sélection probabiliste). Comme pour PSO, il s'agit d'une méthode **population-based**, mais la dynamique coopérative est radicalement différente (pas de vitesse, pas de personal/global best, mais un système de rôles + compteur d'essai + abandon).\n",
     "\n",
     "**Stack technique** : BCL .NET seule, **0 NuGet**. Implementation **from-scratch** complete de l'algorithme ABC. Kernel `.net-csharp` (.NET Interactive).\n"
    ]
@@ -48,15 +48,15 @@
     "### Phase 1 — Employees (ouvrieres)\n",
     "Chaque employed bee $i$ exploite sa source $x_i$ et genere une **candidate voisine** :\n",
     "$$v_i^d = x_i^d + \\varphi^d \\cdot (x_i^d - x_k^d)$$\n",
-    "ou $k \\neq i$ est une source partenaire aleatoire et $\\varphi^d \\sim U[-1, 1]$. Elle evalue $f(v_i)$ et **garde la meilleure** des deux (selection gloutonne). Si $v_i$ n'est pas meilleure, `trial_i` augmente.\n",
+    "ou $k \\neq i$ est une source partenaire aleatoire et $\\varphi^d \\sim U[-1, 1]$. Elle evalue $f(v_i)$ et **garde la meilleure** des deux (sélection gloutonne). Si $v_i$ n'est pas meilleure, `trial_i` augmente.\n",
     "\n",
     "### Phase 2 — Onlookers (observatrices)\n",
-    "Les onlooker bees choisissent une source **proportionnellement a sa qualite** (roulette wheel sur $p_i = \\text{fit}_i / \\sum_j \\text{fit}_j$, ou $\\text{fit}_i = 1/(1+f_i)$ pour la minimisation). Chaque onlooker refait la meme exploration locale qu'une employee.\n",
+    "Les onlooker bees choisissent une source **proportionnellement a sa qualite** (roulette wheel sur $p_i = \\text{fit}_i / \\sum_j \\text{fit}_j$, ou $\\text{fit}_i = 1/(1+f_i)$ pour la minimisation). Chaque onlooker refait la même exploration locale qu'une employee.\n",
     "\n",
     "### Phase 3 — Scouts (eclaireuses)\n",
-    "Si une source $x_i$ depasse la **limite d'abandon** `limit` (son `trial_i` est trop grand sans amelioration), elle est **abandonnee** et remplacee par une source **aleatoire** : l'abeille devient eclaireuse. C'est le **mecanisme d'exploration globale** (saut hors des optima locaux).\n",
+    "Si une source $x_i$ depasse la **limite d'abandon** `limit` (son `trial_i` est trop grand sans amelioration), elle est **abandonnee** et remplacée par une source **aleatoire** : l'abeille devient eclaireuse. C'est le **mécanisme d'exploration globale** (saut hors des optima locaux).\n",
     "\n",
-    "> **Contraste avec PSO** : PSO propage le meilleur global via le **terme social** dans la vitesse ; ABC maintient la diversite via le **compteur d'essai + abandon scout**. Deux strategies d'essaim differentes pour echapper aux optima locaux.\n"
+    "> **Contraste avec PSO** : PSO propage le meilleur global via le **terme social** dans la vitesse ; ABC maintient la diversite via le **compteur d'essai + abandon scout**. Deux stratégies d'essaim différentes pour echapper aux optima locaux.\n"
    ]
   },
   {
@@ -136,7 +136,7 @@
    "source": [
     "## 2. Fonctions de benchmark\n",
     "\n",
-    "Comme pour les tranches precedentes, on definit deux fonctions test :\n",
+    "Comme pour les tranches précédentes, on définit deux fonctions test :\n",
     "\n",
     "- **Sphere** (unimodal, sanity check) : $f(x) = \\sum_i x_i^2$, minimum global $f=0$ en $x=0$.\n",
     "- **Rosenbrock** (vallee etroite, cas non-trivial) : $f(x) = \\sum_{i=0}^{n-2} [100(x_{i+1} - x_i^2)^2 + (1-x_i)^2]$, minimum global $f=0$ en $x = (1, 1, \\dots, 1)$.\n",
@@ -235,7 +235,7 @@
     "\n",
     "**Points cles de l'implementation** :\n",
     "- La generation de candidate $v_i = x_i + \\varphi(x_i - x_k)$ se fait **dimension par dimension**, avec bornage dans `[LO, HI]`.\n",
-    "- La probabilite de selection onlooker utilise $\\text{fit} = 1/(1+f)$ (transformation de la minimisation en maximisation de fitness, robuste a $f \\geq 0$).\n",
+    "- La probabilite de sélection onlooker utilise $\\text{fit} = 1/(1+f)$ (transformation de la minimisation en maximisation de fitness, robuste a $f \\geq 0$).\n",
     "- Le **scout** ne declenche que si `trial > limit` — c'est le gardien de l'exploration globale.\n"
    ]
   },
@@ -484,9 +484,9 @@
    "source": [
     "## 5. Cas non-trivial — ABC sur Rosenbrock (vallee etroite)\n",
     "\n",
-    "Maintenant le vrai test : Rosenbrock, dont la **vallee etroite et courbe** piege les optimiseurs naifs. Le twin Python MEALPy trouve une solution proche de $[1, \\dots, 1]$ ($f=0$). Verifions que notre implementation from-scratch fait de meme.\n",
+    "Maintenant le vrai test : Rosenbrock, dont la **vallee etroite et courbe** piege les optimiseurs naifs. Le twin Python MEALPy trouve une solution proche de $[1, \\dots, 1]$ ($f=0$). Verifions que notre implementation from-scratch fait de même.\n",
     "\n",
-    "**Parametres** (alignes sur le twin Python) : `dim=10`, `SN=50` sources, `maxCycles=200`, `limit=50`, bornes `[-5, 10]`.\n"
+    "**Paramètres** (alignes sur le twin Python) : `dim=10`, `SN=50` sources, `maxCycles=200`, `limit=50`, bornes `[-5, 10]`.\n"
    ]
   },
   {
@@ -635,7 +635,7 @@
    "source": [
     "### Interpretation — ABC sur Rosenbrock\n",
     "\n",
-    "ABC atteint une solution dans la **vallee** (f ~ 2.3 sur cette seed), mais **ne converge pas a l'optimum exact** en 200 cycles. C'est un resultat honnete : Rosenbrock est **notoirement difficile pour ABC**, car la vallee etroite et courbe demande de suivre un chemin precis que le mecanisme scout (sauts aleatoires) n'oriente pas bien. La trajectoire (60 000 → 2.3) montre une descente rapide puis un **plateau** typique.\n",
+    "ABC atteint une solution dans la **vallee** (f ~ 2.3 sur cette seed), mais **ne converge pas a l'optimum exact** en 200 cycles. C'est un résultat honnete : Rosenbrock est **notoirement difficile pour ABC**, car la vallee etroite et courbe demande de suivre un chemin précis que le mécanisme scout (sauts aleatoires) n'oriente pas bien. La trajectoire (60 000 → 2.3) montre une descente rapide puis un **plateau** typique.\n",
     "\n",
     "| Aspect | Observation |\n",
     "|--------|-------------|\n",
@@ -646,8 +646,8 @@
     "\n",
     "**Points cles** :\n",
     "1. La **phase onlooker** concentre l'effort sur les bonnes zones, mais la phase **scout** (sauts aleatoires) ne sait pas \"suivre\" la vallee courbe de Rosenbrock — d'ou le plateau.\n",
-    "2. Le parametre `limit` est determinant : le sweep suivant montre qu'un `limit` **grand** (abandon rare) aide sur Rosenbrock, contrairement a l'intuition.\n",
-    "3. **Comparaison avec PSO** (tranche 2) : PSO via le **terme social** (propagation du global best) suit mieux la vallee ; ABC via le **systeme de roles** a plus de mal. Deux strategies differentes, des forces differentes.\n"
+    "2. Le paramètre `limit` est determinant : le sweep suivant montre qu'un `limit` **grand** (abandon rare) aide sur Rosenbrock, contrairement a l'intuition.\n",
+    "3. **Comparaison avec PSO** (tranche 2) : PSO via le **terme social** (propagation du global best) suit mieux la vallee ; ABC via le **système de rôles** a plus de mal. Deux stratégies différentes, des forces différentes.\n"
    ]
   },
   {
@@ -664,9 +664,9 @@
     "tags": []
    },
    "source": [
-    "## 6. Effet du parametre `limit` (equilibre exploration/exploitation)\n",
+    "## 6. Effet du paramètre `limit` (equilibre exploration/exploitation)\n",
     "\n",
-    "Le seul parametre critique d'ABC est `limit` (seuil d'abandon d'une source). Illustrons son impact en faisant varier sa valeur : un `limit` petit declenche beaucoup d'abandons (exploration forte), un `limit` grand laisse les sources tranquilles (exploitation forte).\n"
+    "Le seul paramètre critique d'ABC est `limit` (seuil d'abandon d'une source). Illustrons son impact en faisant varier sa valeur : un `limit` petit declenche beaucoup d'abandons (exploration forte), un `limit` grand laisse les sources tranquilles (exploitation forte).\n"
    ]
   },
   {
@@ -797,7 +797,7 @@
    "source": [
     "## 7. Exercices\n",
     "\n",
-    "Trois exercices pour aller plus loin. Chaque stub est conforme a la regle C.1 (pas d'erreur volontaire) — le notebook s'execute de bout en bout meme exercices non completes.\n"
+    "Trois exercices pour aller plus loin. Chaque stub est conforme a la règle C.1 (pas d'erreur volontaire) — le notebook s'execute de bout en bout même exercices non completes.\n"
    ]
   },
   {
@@ -877,9 +877,9 @@
     "\n",
     "**Enonce** : Comparez ABC (cette tranche), PSO (tranche 2) et SA (tranche 1) sur Rosenbrock en dimension 10. Pour chaque algorithme, reportez la meilleure valeur trouvee sur 5 seeds, le nombre d'evaluations de fonction, et le temps.\n",
     "\n",
-    "**Etape 1** : Recuperez le code PSO (tranche 2) et SA (tranche 1) dans des cellules au-dessus (ou copiez les fonctions).\n",
-    "**Etape 2** : Lancez chaque algorithme avec le meme budget (evaluations de fonction).\n",
-    "**Etape 3** : Presentez un tableau comparatif.\n",
+    "**Étape 1** : Recuperez le code PSO (tranche 2) et SA (tranche 1) dans des cellules au-dessus (ou copiez les fonctions).\n",
+    "**Étape 2** : Lancez chaque algorithme avec le même budget (evaluations de fonction).\n",
+    "**Étape 3** : Presentez un tableau comparatif.\n",
     "\n",
     "**Indice** : Comptez les evaluations en ajoutant un compteur global incremente dans `Sphere`/`Rosenbrock` (ou un wrapper).\n"
    ]
@@ -936,11 +936,11 @@
    "source": [
     "### Exercice 3 — ABC sur une fonction multimodale (Rastrigin)\n",
     "\n",
-    "**Enonce** : Testez ABC sur **Rastrigin** (fortement multimodale, beaucoup d'optima locaux) : $f(x) = 10n + \\sum_i [x_i^2 - 10\\cos(2\\pi x_i)]$, minimum $f=0$ en $x=0$. Comparez la capacite d'ABC a echapper aux optima locaux avec celle de PSO (tranche 2 utilisait deja Rastrigin).\n",
+    "**Enonce** : Testez ABC sur **Rastrigin** (fortement multimodale, beaucoup d'optima locaux) : $f(x) = 10n + \\sum_i [x_i^2 - 10\\cos(2\\pi x_i)]$, minimum $f=0$ en $x=0$. Comparez la capacite d'ABC a echapper aux optima locaux avec celle de PSO (tranche 2 utilisait déjà Rastrigin).\n",
     "\n",
-    "**Etape 1** : Implementez `Rastrigin`.\n",
-    "**Etape 2** : Lancez ABC (dim=10, SN=50, cycles=200, limit=50) sur 5 seeds.\n",
-    "**Etape 3** : Reportez f moyen et le taux de succes (frequence ou $f < 10^{-3}$).\n",
+    "**Étape 1** : Implementez `Rastrigin`.\n",
+    "**Étape 2** : Lancez ABC (dim=10, SN=50, cycles=200, limit=50) sur 5 seeds.\n",
+    "**Étape 3** : Reportez f moyen et le taux de succes (frequence ou $f < 10^{-3}$).\n",
     "\n",
     "**Indice** : Rastrigin a des optima locaux regulierement espaces. La phase scout d'ABC est-elle plus efficace que le terme social de PSO pour en sortir ?\n"
    ]
@@ -1001,23 +1001,23 @@
     "\n",
     "| Concept | Definition |\n",
     "|---------|------------|\n",
-    "| **ABC** | Metaheuristique d'essaim basee sur le butinage des abeilles (Karaboga 2005) |\n",
-    "| **3 roles** | Employed (exploiter), Onlooker (choisir par qualite), Scout (explorer) |\n",
+    "| **ABC** | Métaheuristique d'essaim basee sur le butinage des abeilles (Karaboga 2005) |\n",
+    "| **3 rôles** | Employed (exploiter), Onlooker (choisir par qualite), Scout (explorer) |\n",
     "| **Compteur d'essai** | Mesure la stagnation d'une source ; declenche l'abandon scout |\n",
-    "| **Selection onlooker** | Roulette wheel proportionnelle a `fit = 1/(1+f)` |\n",
-    "| **Equilibre** | Parametre unique `limit` controle exploration/exploitation |\n",
+    "| **Sélection onlooker** | Roulette wheel proportionnelle a `fit = 1/(1+f)` |\n",
+    "| **Equilibre** | Paramètre unique `limit` contrôle exploration/exploitation |\n",
     "\n",
-    "**Comparaison des trois metaheuristiques du marathon** :\n",
+    "**Comparaison des trois métaheuristiques du marathon** :\n",
     "\n",
-    "| Algorithme | Strategie essaim | Exploration via | Meilleur sur |\n",
+    "| Algorithme | Stratégie essaim | Exploration via | Meilleur sur |\n",
     "|------------|------------------|-----------------|--------------|\n",
     "| **SA** (t1) | Trajectoire unique | Acceptation Metropolis (T decroissante) | optima locaux isoles |\n",
     "| **PSO** (t2) | Essaim + vitesse | Terme social (propagation gbest) | unimodal / vallee douce |\n",
-    "| **ABC** (t3) | Essaim + roles | Abandon scout | vallee etroite, multimodal |\n",
+    "| **ABC** (t3) | Essaim + rôles | Abandon scout | vallee etroite, multimodal |\n",
     "\n",
-    "Les **trois strategies** reussissent sur Rosenbrock, mais par des mecanismes cooperatifs distincts. C'est tout l'interet pedagogique du marathon : comprendre **plusieurs dynamiques d'essaim differentes** pour resoudre le meme probleme.\n",
+    "Les **trois stratégies** reussissent sur Rosenbrock, mais par des mécanismes cooperatifs distincts. C'est tout l'intérêt pedagogique du marathon : comprendre **plusieurs dynamiques d'essaim différentes** pour resoudre le même problème.\n",
     "\n",
-    "**Suite (tranche 4)** : benchmark comparatif systematique SA / PSO / ABC sur un panel de fonctions (Sphere, Rastrigin, Rosenbrock, Ackley), avec statistiques multi-seed.\n",
+    "**Suite (tranche 4)** : benchmark comparatif systématique SA / PSO / ABC sur un panel de fonctions (Sphere, Rastrigin, Rosenbrock, Ackley), avec statistiques multi-seed.\n",
     "\n",
     "---\n",
     "\n",


### PR DESCRIPTION
## Summary

Restore 57 accent-strippings across 11 markdown cells in `MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11b-Metaheuristiques-Deep-Part3.ipynb` (deep metaheuristics part 3). Search family is virgin re: #2876 for po-2025 (rotation vs SemanticWeb SW-1 #7118 + IIT ICT-12 #7138 = 3 distinct families this cycle).

## Scope

**Markdown-only strict** (ai-01 adjudication 17/07 #2876). The cure script touches ONLY `cell_type=="markdown"` cells — code cells untouched (6 detector code hits preserved as out-of-scope). Markdown-only by construction to avoid the code-cell-leak failure mode found in 8/33 accent PRs during the c.603 fleet sweep.

## Method

Canonical `ACCENT_PAIRS` dict (161 pairs), literal UTF-8, case-preserving word-boundary replace. 28 distinct forms restored: `etape→étape`, `meme→même`, `roles→rôles`, `differentes→différentes`, `metaheuristique(s)→métaheuristique(s)`, `mecanisme(s)→mécanisme(s)`, `methode→méthode`, `parametre(s)→paramètre(s)`, `strategies→stratégies`, `selection→sélection`, `controle→contrôle`, `probleme→problème`, `resultat→résultat`, `systeme→système`, `precedente→précédente`, etc.

## G.1 firsthand verification (vs git HEAD)

| Check | Result |
|-------|--------|
| detector markdown hits | 57 → **0** (drift resolved) |
| detector code hits | 6 → **6** (unchanged, out-of-scope) |
| code cell source changed | **0** |
| markdown cell source changed | 11 (the cures) |
| outputs / execution_count | **0** (C.2 markdown-only exception) |
| `\uXXXX` escapes | **0** (literal UTF-8) |
| nbformat | **VALID** |
| cell count / types | 24/24 identical |
| git diff | +34/-34 |

See #2876.
