### PR TITLE
fix(search,#2876): restore FR accents in App-12-ConnectFour markdown

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb
@@ -37,7 +37,7 @@
     "\n",
     "### Le Puissance 4\n",
     "\n",
-    "Le **Puissance 4** (Connect Four) est un jeu de strategie a deux joueurs sur un plateau vertical de 7 colonnes et 6 lignes. Les joueurs deposent alternativement un jeton de leur couleur dans une colonne ; le jeton tombe au plus bas de la colonne. Le premier joueur a aligner **4 jetons** (horizontalement, verticalement ou en diagonale) remporte la partie.\n",
+    "Le **Puissance 4** (Connect Four) est un jeu de stratégie a deux joueurs sur un plateau vertical de 7 colonnes et 6 lignes. Les joueurs deposent alternativement un jeton de leur couleur dans une colonne ; le jeton tombe au plus bas de la colonne. Le premier joueur a aligner **4 jetons** (horizontalement, verticalement ou en diagonale) remporte la partie.\n",
     "\n",
     "| Propriete | Valeur |\n",
     "|-----------|--------|\n",
@@ -45,15 +45,15 @@
     "| Joueurs | 2 (Rouge et Jaune) |\n",
     "| Facteur de branchement | ~4 en moyenne (max 7) |\n",
     "| Positions possibles | ~4.5 x 10^12 |\n",
-    "| Jeu resolu | Oui (1988, Victor Allis) |\n",
-    "| Resultat parfait | Le premier joueur gagne avec jeu parfait |\n",
+    "| Jeu résolu | Oui (1988, Victor Allis) |\n",
+    "| résultat parfait | Le premier joueur gagne avec jeu parfait |\n",
     "\n",
-    "### Pourquoi ce jeu est interessant pour l'IA\n",
+    "### Pourquoi ce jeu est intéressant pour l'IA\n",
     "\n",
-    "Le Puissance 4 occupe une position intermediaire en complexite :\n",
-    "- Plus simple que les echecs ou le Go (arbre de jeu plus petit)\n",
-    "- Plus complexe que le morpion (assez profond pour que les algorithmes naifs echouent)\n",
-    "- Ideal pour comparer differentes familles d'algorithmes de recherche\n",
+    "Le Puissance 4 occupe une position intermediaire en complexité :\n",
+    "- Plus simple que les échecs ou le Go (arbre de jeu plus petit)\n",
+    "- Plus complexe que le morpion (assez profond pour que les algorithmes naifs échouent)\n",
+    "- Ideal pour comparer différentes familles d'algorithmes de recherche\n",
     "\n",
     "Dans ce notebook, nous implementons et comparons **4 approches** :\n",
     "\n",
@@ -61,8 +61,8 @@
     "|----|---------|------------|------------|\n",
     "| Random | Baseline | 0 | Instantane |\n",
     "| Greedy | Heuristique | 1 | Instantane |\n",
-    "| Minimax (alpha-beta) | Arbre adversaire | Configurable | Modere |\n",
-    "| MCTS | Monte Carlo | Variable | Configurable |"
+    "| Minimax (alpha-beta) | Arbre adversaire | Configurable | modère |\n",
+    "| MCTS | Monte Carlo | variable | Configurable |"
    ]
   },
   {
@@ -81,16 +81,16 @@
    "source": [
     "## 2. Moteur de jeu\n",
     "\n",
-    "Nous commencons par implementer le moteur de jeu : representation du plateau, regles, detection de victoire et affichage graphique.\n",
+    "Nous commencons par implementer le moteur de jeu : représentation du plateau, règles, détection de victoire et affichage graphique.\n",
     "\n",
-    "### Representation du plateau\n",
+    "### Représentation du plateau\n",
     "\n",
     "Le plateau est une matrice numpy 6x7 :\n",
     "- `0` = case vide\n",
     "- `1` = jeton du joueur 1 (Rouge)\n",
     "- `2` = jeton du joueur 2 (Jaune)\n",
     "\n",
-    "La ligne 0 est le **haut** du plateau (derniere a se remplir)."
+    "La ligne 0 est le **haut** du plateau (dernière a se remplir)."
    ]
   },
   {
@@ -173,7 +173,7 @@
    "source": [
     "### Classe Board\n",
     "\n",
-    "La classe `Board` encapsule l'etat du jeu et fournit les operations fondamentales : coups legaux, placement de jeton, detection de victoire et affichage."
+    "La classe `Board` encapsule l'etat du jeu et fournit les opérations fondamentales : coups legaux, placement de jeton, détection de victoire et affichage."
    ]
   },
   {
@@ -319,21 +319,21 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : Moteur de jeu\n",
+    "### Interprétation : Moteur de jeu\n",
     "\n",
     "**Sortie obtenue** : Le plateau s'affiche en mode texte avec R (Rouge) et J (Jaune). Les jetons tombent correctement vers le bas.\n",
     "\n",
     "| Aspect | Detail |\n",
     "|--------|--------|\n",
-    "| Representation | Matrice numpy 6x7, 0/1/2 |\n",
+    "| représentation | Matrice numpy 6x7, 0/1/2 |\n",
     "| Gravite | Les jetons s'empilent du bas vers le haut |\n",
-    "| Detection victoire | 4 directions : horizontale, verticale, 2 diagonales |\n",
+    "| détection victoire | 4 directions : horizontale, verticale, 2 diagonales |\n",
     "| Backtracking | `undo_move` permet de defaire un coup (utile pour Minimax) |\n",
     "\n",
     "**Points cles** :\n",
-    "1. La methode `legal_moves()` verifie la ligne superieure (indice 0) : si elle est occupee, la colonne est pleine\n",
-    "2. `check_win` parcourt les 4 directions avec des fenetres de taille 4 -- complexite O(ROWS x COLS)\n",
-    "3. L'utilisation de `undo_move` evite de copier le plateau a chaque noeud de l'arbre de recherche"
+    "1. La méthode `legal_moves()` vérifie la ligne supérieure (indice 0) : si elle est occupee, la colonne est pleine\n",
+    "2. `check_win` parcourt les 4 directions avec des fenêtrès de taille 4 -- complexité O(ROWS x COLS)\n",
+    "3. L'utilisation de `undo_move` évite de copier le plateau a chaque noeud de l'arbre de recherche"
    ]
   },
   {
@@ -462,14 +462,14 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : Affichage graphique\n",
+    "### Interprétation : Affichage graphique\n",
     "\n",
-    "**Sortie obtenue** : Le plateau apparait avec les cercles rouge (joueur 1) et jaune (joueur 2) sur fond bleu, fidelement au jeu reel.\n",
+    "**Sortie obtenue** : Le plateau apparaît avec les cercles rouge (joueur 1) et jaune (joueur 2) sur fond bleu, fidélément au jeu réel.\n",
     "\n",
     "**Points cles** :\n",
     "1. L'axe Y est inverse pour que la gravite soit naturelle (les jetons tombent vers le bas)\n",
     "2. Les cases vides sont affichees en bleu clair pour simuler les trous du plateau\n",
-    "3. Cette visualisation sera reutilisee pour afficher les parties entre IA"
+    "3. Cette visualisation sera réutilisée pour afficher les parties entre IA"
    ]
   },
   {
@@ -579,9 +579,9 @@
     "tags": []
    },
    "source": [
-    "## 3. IA 1 : Joueur aleatoire (baseline)\n",
+    "## 3. IA 1 : Joueur aléatoire (baseline)\n",
     "\n",
-    "Le joueur aleatoire constitue notre **baseline** : il choisit uniformement parmi les colonnes legales, sans aucune strategie. Cette IA nous permettra de mesurer a quel point les autres approches sont meilleures qu'un jeu au hasard."
+    "Le joueur aléatoire constitue notre **baseline** : il choisit uniformêment parmi les colonnes legales, sans aucune stratégie. Cette IA nous permettra de mesurer a quel point les autrès approches sont meilleures qu'un jeu au hasard."
    ]
   },
   {
@@ -678,17 +678,17 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : Joueur aleatoire\n",
+    "### Interprétation : Joueur aléatoire\n",
     "\n",
-    "**Sortie obtenue** : Une partie entre deux joueurs aleatoires, typiquement chaotique et sans strategie.\n",
+    "**Sortie obtenue** : Une partie entre deux joueurs aléatoires, typiquement chaotique et sans stratégie.\n",
     "\n",
-    "| Aspect | Observation |\n",
+    "| Aspect | observation |\n",
     "|--------|-------------|\n",
-    "| Qualite de jeu | Tres faible : coups absurdes frequents |\n",
+    "| Qualite de jeu | très faible : coups absurdes fréquents |\n",
     "| Temps par coup | Negligeable (< 0.001s) |\n",
-    "| Utilite | Baseline pour mesurer la qualite des autres IA |\n",
+    "| utilité | Baseline pour mesurer la qualite des autrès IA |\n",
     "\n",
-    "**Point cle** : Le joueur aleatoire ne detecte meme pas les victoires immediates. Il peut \"oublier\" de gagner ou de bloquer l'adversaire. C'est la pire IA possible -- tout algorithme raisonnable devrait le battre systematiquement."
+    "**Point cle** : Le joueur aléatoire ne détecte même pas les victoires immédiates. Il peut \"oublier\" de gagner ou de bloquer l'adversaire. C'est la pire IA possible -- tout algorithme raisonnable devrait le battre systématiquement."
    ]
   },
   {
@@ -713,16 +713,16 @@
     "- **Max** : le joueur courant maximise son score\n",
     "- **Min** : l'adversaire minimise le score du joueur courant\n",
     "\n",
-    "L'**elagage alpha-beta** permet de couper des branches de l'arbre sans perdre en qualite de decision :\n",
+    "L'**elagage alpha-beta** permet de couper des branches de l'arbre sans perdre en qualite de décision :\n",
     "- $\\alpha$ = meilleur score garanti pour Max sur le chemin courant\n",
     "- $\\beta$ = meilleur score garanti pour Min sur le chemin courant\n",
     "- Si $\\alpha \\geq \\beta$, on coupe (la branche ne sera jamais choisie)\n",
     "\n",
-    "### Fonction d'evaluation\n",
+    "### Fonction d'évaluation\n",
     "\n",
-    "Pour limiter la profondeur de recherche, il faut une **fonction d'evaluation** qui estime la qualite d'une position non terminale. Notre evaluation analyse les fenetres de 4 cases :\n",
+    "Pour limiter la profondeur de recherche, il faut une **fonction d'évaluation** qui estime la qualite d'une position non terminale. Notre évaluation analyse les fenêtrès de 4 cases :\n",
     "\n",
-    "| Configuration dans une fenetre de 4 | Score |\n",
+    "| Configuration dans une fenêtre de 4 | Score |\n",
     "|--------------------------------------|-------|\n",
     "| 4 jetons du joueur | +1000 (victoire) |\n",
     "| 3 jetons du joueur + 1 vide | +10 |\n",
@@ -846,7 +846,7 @@
    "source": [
     "### Implementation de Minimax alpha-beta\n",
     "\n",
-    "L'algorithme explore l'arbre de jeu avec une profondeur limite configurable. L'ordre d'exploration des colonnes est optimise : on commence par le centre (meilleure heuristique en general)."
+    "L'algorithme explore l'arbre de jeu avec une profondeur limite configurable. L'ordre d'exploration des colonnes est optimise : on commence par le centre (meilleure heuristique en général)."
    ]
   },
   {
@@ -972,7 +972,7 @@
    "source": [
     "### Test : Minimax vs Random\n",
     "\n",
-    "Verifions que Minimax domine clairement le joueur aleatoire. Nous utilisons une profondeur de 4 pour un bon compromis qualite/vitesse."
+    "vérifions que Minimax domine clairement le joueur aléatoire. Nous utilisons une profondeur de 4 pour un bon compromis qualite/vitesse."
    ]
   },
   {
@@ -1077,20 +1077,20 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : Minimax vs Random\n",
+    "### Interprétation : Minimax vs Random\n",
     "\n",
-    "**Sortie obtenue** : Minimax (profondeur 4) devrait battre le joueur aleatoire sans difficulte.\n",
+    "**Sortie obtenue** : Minimax (profondeur 4) devrait battre le joueur aléatoire sans difficulté.\n",
     "\n",
     "| Aspect | Minimax (d=4) | Random |\n",
     "|--------|---------------|--------|\n",
-    "| Qualite de jeu | Bonne (detecte menaces a 4 coups) | Nulle |\n",
+    "| Qualite de jeu | Bonne (détecte menaces a 4 coups) | Nulle |\n",
     "| Temps par coup | ~0.01-0.1s | < 0.001s |\n",
-    "| Strategie | Offensive et defensive | Aucune |\n",
+    "| stratégie | Offensive et defensive | Aucune |\n",
     "\n",
     "**Points cles** :\n",
-    "1. Minimax gagne rapidement car il exploite les erreurs du joueur aleatoire\n",
-    "2. L'elagage alpha-beta reduit considerablement le nombre de noeuds explores\n",
-    "3. L'ordonnancement des coups (centre en premier) ameliore l'efficacite de l'elagage"
+    "1. Minimax gagne rapidement car il exploite les erreurs du joueur aléatoire\n",
+    "2. L'elagage alpha-beta réduit considérablement le nombre de noeuds explores\n",
+    "3. L'ordonnancement des coups (centre en premier) améliore l'efficacité de l'elagage"
    ]
   },
   {
@@ -1109,7 +1109,7 @@
    "source": [
     "### Experiment : Effet de la profondeur\n",
     "\n",
-    "Comparons trois profondeurs de Minimax pour observer le compromis qualite/temps. Chaque profondeur joue 10 parties contre le joueur aleatoire."
+    "Comparons trois profondeurs de Minimax pour observer le compromis qualite/temps. Chaque profondeur joue 10 parties contre le joueur aléatoire."
    ]
   },
   {
@@ -1226,9 +1226,9 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : Effet de la profondeur\n",
+    "### Interprétation : Effet de la profondeur\n",
     "\n",
-    "**Sortie obtenue** : Les trois profondeurs remportent 10/10 contre le joueur aleatoire ; seul le temps de calcul differe.\n",
+    "**Sortie obtenue** : Les trois profondeurs remportent 10/10 contre le joueur aléatoire ; seul le temps de calcul diffère.\n",
     "\n",
     "| Profondeur | Victoires | Temps/coup mesure | Noeuds explores (ordre de grandeur) |\n",
     "|------------|-----------|-------------------|--------------------------------------|\n",
@@ -1237,12 +1237,12 @@
     "| d=6 | 10/10 | ~2824 ms | ~125 000 |\n",
     "\n",
     "**Points cles** :\n",
-    "1. Meme d=2 suffit contre un joueur aleatoire (10/10 victoires)\n",
+    "1. même d=2 suffit contre un joueur aléatoire (10/10 victoires)\n",
     "2. Le temps croit **exponentiellement** avec la profondeur : $O(b^d)$ ou $b \\approx 4$ en moyenne\n",
-    "3. L'elagage alpha-beta reduit la complexite de $O(b^d)$ a $O(b^{d/2})$ dans le meilleur cas\n",
+    "3. L'elagage alpha-beta réduit la complexité de $O(b^d)$ a $O(b^{d/2})$ dans le meilleur cas\n",
     "4. La profondeur d=4 offre un bon compromis pour le Puissance 4\n",
     "\n",
-    "> La vraie difference se verra dans le tournoi, ou les IA s'affrontent entre elles.\n"
+    "> La vraie différence se verra dans le tournoi, ou les IA s'affrontent entre elles.\n"
    ]
   },
   {
@@ -1263,12 +1263,12 @@
     "\n",
     "### Principe\n",
     "\n",
-    "**MCTS** construit progressivement un arbre de recherche en repetant quatre etapes :\n",
+    "**MCTS** construit progressivement un arbre de recherche en repetant quatre étapes :\n",
     "\n",
-    "1. **Selection** : descendre dans l'arbre en utilisant UCB1 pour equilibrer exploration et exploitation\n",
+    "1. **sélection** : descendre dans l'arbre en utilisant UCB1 pour équilibrer exploration et exploitation\n",
     "2. **Expansion** : ajouter un nouveau noeud enfant\n",
-    "3. **Simulation** : jouer une partie aleatoire (rollout) jusqu'a la fin\n",
-    "4. **Retropropagation** : remonter le resultat dans l'arbre\n",
+    "3. **Simulation** : jouer une partie aléatoire (rollout) jusqu'a la fin\n",
+    "4. **Retropropagation** : remonter le résultat dans l'arbre\n",
     "\n",
     "La formule **UCB1** (Upper Confidence Bound) pour choisir quel enfant explorer :\n",
     "\n",
@@ -1283,11 +1283,11 @@
     "\n",
     "### Avantages de MCTS\n",
     "\n",
-    "- **Pas besoin de fonction d'evaluation** : les simulations aleatoires servent d'estimation\n",
-    "- **Algorithme anytime** : on peut l'arreter a tout moment et obtenir une decision\n",
-    "- **Scalable** : plus on donne d'iterations, meilleure est la decision\n",
+    "- **Pas besoin de fonction d'évaluation** : les simulations aléatoires servent d'estimation\n",
+    "- **Algorithme anytime** : on peut l'arreter a tout moment et obtenir une décision\n",
+    "- **Scalable** : plus on donne d'itérations, meilleure est la décision\n",
     "\n",
-    "> **Voir aussi** : la [serie GameTheory](../../../GameTheory/README.md) pour une presentation detaillee de MCTS et ses variantes (UCT, RAVE, PUCT)."
+    "> **Voir aussi** : la [serie GameTheory](../../../GameTheory/README.md) pour une présentation detaillee de MCTS et ses variantes (UCT, RAVE, PUCT)."
    ]
   },
   {
@@ -1444,7 +1444,7 @@
    "source": [
     "### Test : MCTS vs Minimax\n",
     "\n",
-    "Faisons s'affronter MCTS (1000 iterations) contre Minimax (profondeur 4) pour observer la qualite de jeu des deux approches."
+    "Faisons s'affronter MCTS (1000 itérations) contre Minimax (profondeur 4) pour observer la qualite de jeu des deux approches."
    ]
   },
   {
@@ -1667,22 +1667,22 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : MCTS vs Minimax\n",
+    "### Interprétation : MCTS vs Minimax\n",
     "\n",
-    "**Sortie obtenue** : MCTS(1000 iterations) bat Minimax(d=4) en 29 coups dans cette partie ; MCTS est nettement plus lent par coup.\n",
+    "**Sortie obtenue** : MCTS(1000 itérations) bat Minimax(d=4) en 29 coups dans cette partie ; MCTS est nettement plus lent par coup.\n",
     "\n",
     "| Aspect | MCTS (1000 iter.) | Minimax (d=4) |\n",
     "|--------|-------------------|---------------|\n",
-    "| Approche | Simulations Monte Carlo | Recherche exhaustive |\n",
-    "| Evaluation | Rollouts aleatoires | Fonction heuristique |\n",
-    "| Profondeur | Variable (adaptative) | Fixe (4 niveaux) |\n",
+    "| approche | Simulations Monte Carlo | recherche exhaustive |\n",
+    "| évaluation | Rollouts aléatoires | Fonction heuristique |\n",
+    "| Profondeur | variable (adaptative) | Fixe (4 niveaux) |\n",
     "| Temps mesure | ~1.6 s/coup | ~0.23 s/coup |\n",
     "\n",
     "**Points cles** :\n",
     "1. Sur cette partie, MCTS(1000) l'emporte mais il est ~7x plus lent par coup que Minimax(d=4)\n",
-    "2. MCTS n'a **pas besoin de fonction d'evaluation artisanale**\n",
+    "2. MCTS n'a **pas besoin de fonction d'évaluation artisanale**\n",
     "3. MCTS explore automatiquement plus profondement les lignes prometteuses\n",
-    "4. Avec plus d'iterations (5000+), MCTS tend a surpasser Minimax(d=4)\n"
+    "4. Avec plus d'itérations (5000+), MCTS tend a surpasser Minimax(d=4)\n"
    ]
   },
   {
@@ -1703,12 +1703,12 @@
     "\n",
     "Le joueur **glouton** applique une hierarchie de priorites simple, sans exploration de l'arbre :\n",
     "\n",
-    "1. **Gagner** : si un coup permet de gagner immediatement, le jouer\n",
+    "1. **Gagner** : si un coup permet de gagner immédiatement, le jouer\n",
     "2. **Bloquer** : si l'adversaire peut gagner au prochain coup, le bloquer\n",
-    "3. **Centre** : preferer les colonnes centrales (meilleur controle positionnel)\n",
-    "4. **Aleatoire** : sinon, choisir au hasard parmi les coups restants\n",
+    "3. **Centre** : préférer les colonnes centrales (meilleur contrôle positionnel)\n",
+    "4. **aléatoire** : sinon, choisir au hasard parmi les coups restants\n",
     "\n",
-    "Cette approche est rapide mais limitee : elle ne regarde qu'un coup en avance."
+    "Cette approche est rapide mais limitée : elle ne regarde qu'un coup en avance."
    ]
   },
   {
@@ -1814,22 +1814,22 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : Joueur glouton\n",
+    "### Interprétation : Joueur glouton\n",
     "\n",
-    "**Sortie obtenue** : Le joueur glouton bat facilement le joueur aleatoire.\n",
+    "**Sortie obtenue** : Le joueur glouton bat facilement le joueur aléatoire.\n",
     "\n",
     "| Aspect | Greedy |\n",
     "|--------|--------|\n",
     "| Profondeur de recherche | 1 (un seul coup en avance) |\n",
     "| Temps par coup | < 1 ms |\n",
-    "| Force | Detecte les victoires et menaces immediates |\n",
-    "| Faiblesse | Pas de vision strategique a long terme |\n",
+    "| Force | détecte les victoires et menaces immédiates |\n",
+    "| Faiblesse | Pas de vision stratégique a long terme |\n",
     "\n",
     "**Points cles** :\n",
-    "1. Le glouton est **extremement rapide** car il ne construit pas d'arbre\n",
-    "2. Il detecte les coups gagnants et les menaces immediates (profondeur 1)\n",
+    "1. Le glouton est **extrêmêment rapide** car il ne construit pas d'arbre\n",
+    "2. Il détecte les coups gagnants et les menaces immédiates (profondeur 1)\n",
     "3. Il sera surpasse par Minimax qui voit plus loin dans l'arbre de jeu\n",
-    "4. Le bonus positionnel (centre) lui donne une strategie rudimentaire"
+    "4. Le bonus positionnel (centre) lui donne une stratégie rudimentaire"
    ]
   },
   {
@@ -1850,17 +1850,17 @@
     "\n",
     "Organisons un tournoi complet entre toutes les IA. Chaque paire joue **6 parties** (3 en tant que joueur 1, 3 en tant que joueur 2) pour eliminer l'avantage du premier joueur.\n",
     "\n",
-    "> **Note** : Le nombre de parties a ete reduit a 6 pour ce notebook pedagogique. Pour des resultats statistiquement significatifs, utilisez 20+ parties par paire.\n",
+    "> **Note** : Le nombre de parties a ete réduit a 6 pour ce notebook pedagogique. Pour des résultats statistiquement significatifs, utilisez 20+ parties par paire.\n",
     "\n",
     "### Participants\n",
     "\n",
-    "| IA | Type | Parametres |\n",
+    "| IA | Type | paramètrès |\n",
     "|----|------|------------|\n",
     "| Random | Baseline | - |\n",
     "| Greedy | Heuristique | 1 coup |\n",
     "| Minimax(d=4) | Arbre adversaire | Profondeur 4, alpha-beta |\n",
     "| Minimax(d=6) | Arbre adversaire | Profondeur 6, alpha-beta |\n",
-    "| MCTS(1000) | Monte Carlo | 1000 iterations |"
+    "| MCTS(1000) | Monte Carlo | 1000 itérations |"
    ]
   },
   {
@@ -2074,9 +2074,9 @@
     "tags": []
    },
    "source": [
-    "### Resultats du tournoi\n",
+    "### Résultats du tournoi\n",
     "\n",
-    "Affichons les resultats sous forme de tableau recapitulatif et de graphiques."
+    "Affichons les résultats sous forme de tableau recapitulatif et de graphiques."
    ]
   },
   {
@@ -2183,7 +2183,7 @@
     "tags": []
    },
    "source": [
-    "Visualisons ces resultats sous forme de graphiques pour mieux comparer les performances relatives et les couts en temps de calcul."
+    "Visualisons ces résultats sous forme de graphiques pour mieux comparer les performances relatives et les couts en temps de calcul."
    ]
   },
   {
@@ -2288,26 +2288,26 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : Resultats du tournoi\n",
+    "### Interprétation : Résultats du tournoi\n",
     "\n",
     "**Sortie obtenue** : Classement issu du round-robin (5 IA, 6 parties par paire). Minimax(d=4) et Minimax(d=6) dominent MCTS(500) (respectivement 6W-0D-0L et 4W-0D-2L).\n",
     "\n",
     "| Rang | IA | Force | Temps/coup | Commentaire |\n",
     "|------|-----|-------|------------|-------------|\n",
-    "| 1 | Minimax(d=6) | Forte | Elevee | Meilleure profondeur de recherche |\n",
-    "| 2 | Minimax(d=4) | Bonne | Moderee | Balaye MCTS(500) 6W-0D-0L |\n",
-    "| 3 | MCTS(500) | Moyenne | Elevee | Competitive contre Minimax(d=6) (4W-2L) mais dominee par Minimax(d=4) |\n",
-    "| 4 | Greedy | Moyenne | Negligeable | Bloque les menaces immediates |\n",
+    "| 1 | Minimax(d=6) | Forte | élevée | Meilleure profondeur de recherche |\n",
+    "| 2 | Minimax(d=4) | Bonne | modérée | Balaye MCTS(500) 6W-0D-0L |\n",
+    "| 3 | MCTS(500) | Moyenne | élevée | Competitive contre Minimax(d=6) (4W-2L) mais dominee par Minimax(d=4) |\n",
+    "| 4 | Greedy | Moyenne | Negligeable | Bloque les menaces immédiates |\n",
     "| 5 | Random | Nulle | Negligeable | Perd contre tout (0W-0D-6L partout) |\n",
     "\n",
     "**Points cles** :\n",
     "1. **La profondeur compte** : Minimax(d=6) domine Minimax(d=4) car il voit plus loin\n",
-    "2. **MCTS(500) est competitif** sans fonction d'evaluation artisanale -- il prend meme 2 parties a Minimax(d=6)\n",
-    "3. **Greedy est un bon rapport qualite/prix** : presque instantane, il bat Random a chaque fois\n",
+    "2. **MCTS(500) est competitif** sans fonction d'évaluation artisanale -- il prend même 2 parties a Minimax(d=6)\n",
+    "3. **Greedy est un bon rapport qualite/prix** : presque instantané, il bat Random a chaque fois\n",
     "4. **Le compromis temps/qualite** est clairement visible dans le graphique de droite\n",
     "5. **L'avantage du premier joueur** est partiellement neutralise par les 3+3 parties alternees\n",
     "\n",
-    "> **Observation** : Augmenter les iterations de MCTS (5000+) ou la profondeur de Minimax (d=8) ameliorerait les performances, mais au prix d'un temps de calcul significativement plus eleve.\n"
+    "> **observation** : Augmenter les itérations de MCTS (5000+) ou la profondeur de Minimax (d=8) améliorérait les performances, mais au prix d'un temps de calcul significativement plus élevé.\n"
    ]
   },
   {
@@ -2324,26 +2324,26 @@
     "tags": []
    },
    "source": [
-    "## 8. Framework AIMA - Approche du livre de reference\n",
+    "## 8. Framework AIMA - Approche du livre de référence\n",
     "\n",
     "### 8.1 Le framework Game de Russell & Norvig\n",
     "\n",
     "Le livre **\"Artificial Intelligence: A Modern Approach\"** (AIMA) de Russell et Norvig propose un framework elegant pour les jeux a deux joueurs. Ce framework est disponible dans le module `games4e.py` du depot [aima-python](https://github.com/aimacode/aima-python), avec une implementation Java plus sophistiquee dans [aima-java](https://github.com/aimacode/aima-java).\n",
     "\n",
-    "**Principe cle** : Separer la **logique du jeu** (classe Game) des **algorithmes de recherche** (fonctions joueurs).\n",
+    "**Principe cle** : séparer la **logique du jeu** (classe Game) des **algorithmes de recherche** (fonctions joueurs).\n",
     "\n",
     "### Avantages du framework AIMA\n",
     "\n",
     "| Aspect | Implementation custom | Framework AIMA |\n",
     "|--------|----------------------|----------------|\n",
-    "| Separation des responsabilites | Melangee | Claire (Game vs Player) |\n",
-    "| Reutilisabilite | Specifique au jeu | Algorithmes generiques |\n",
+    "| séparation des responsabilites | Melangee | Claire (Game vs Player) |\n",
+    "| Reutilisabilite | spécifique au jeu | Algorithmes génériques |\n",
     "| Testabilite | Couplee | Decouplee |\n",
-    "| Extensibilite | Modification en cascade | Ajout de nouveaux joueurs |\n",
+    "| Extensibilite | modification en cascade | Ajout de nouveaux joueurs |\n",
     "\n",
     "> **Source** : [aima-python/games4e.py](https://github.com/aimacode/aima-python/blob/master/games4e.py) - Chapitre 5, Jeux Adversariaux\n",
     ">\n",
-    "> **Reference avancee** : [aima-java ConnectFour](https://github.com/aimacode/aima-java/blob/AIMA3e/aima-core/src/main/java/aima/core/environment/connectfour/) - Implementation sophistiquee avec analyse des positions gagnantes"
+    "> **référence avancée** : [aima-java ConnectFour](https://github.com/aimacode/aima-java/blob/AIMA3e/aima-core/src/main/java/aima/core/environment/connectfour/) - Implementation sophistiquee avec analyse des positions gagnantes"
    ]
   },
   {
@@ -2515,7 +2515,7 @@
    "source": [
     "### 8.2 Adaptateur ConnectFour_AIMA\n",
     "\n",
-    "Nous creons maintenant un adaptateur qui rend notre classe `Board` compatible avec le framework AIMA. Cet adaptateur inclut egalement l'**analyse des positions gagnantes**, inspiree de l'implementation AIMA Java."
+    "Nous creons maintenant un adaptateur qui rend notre classe `Board` compatible avec le framework AIMA. Cet adaptateur inclut également l'**analyse des positions gagnantes**, inspiree de l'implementation AIMA Java."
    ]
   },
   {
@@ -2700,14 +2700,14 @@
     "tags": []
    },
    "source": [
-    "### 8.3 Approfondissement iteratif avec limite de temps\n",
+    "### 8.3 Approfondissement itératif avec limite de temps\n",
     "\n",
     "L'implementation AIMA Java utilise `IterativeDeepeningAlphaBetaSearch` qui:\n",
     "1. Explore a des profondeurs croissantes (1, 2, 3, ...)\n",
     "2. S'arrete quand le temps imparti est ecoule\n",
-    "3. **Prefere les victoires rapides** en ajustant l'evaluation\n",
+    "3. **préfère les victoires rapides** en ajustant l'évaluation\n",
     "\n",
-    "Cette approche transforme Alpha-Beta en algorithme **anytime** : il peut retourner un resultat valide a tout moment."
+    "Cette approche transforme Alpha-Beta en algorithme **anytime** : il peut retourner un résultat valide a tout moment."
    ]
   },
   {
@@ -2914,10 +2914,10 @@
    "source": [
     "### 8.4 Comparaison et benchmark\n",
     "\n",
-    "Comparons les differentes approches AIMA pour mesurer l'impact des optimisations inspirees d'AIMA Java:\n",
+    "Comparons les différentes approches AIMA pour mesurer l'impact des optimisations inspirees d'AIMA Java:\n",
     "- Alpha-Beta classique (profondeur fixe)\n",
     "- Alpha-Beta avec ordonnancement intelligent\n",
-    "- Approfondissement iteratif avec limite de temps"
+    "- Approfondissement itératif avec limite de temps"
    ]
   },
   {
@@ -3070,31 +3070,31 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : Framework AIMA avance\n",
+    "### Interprétation : Framework AIMA avance\n",
     "\n",
-    "**Sortie obtenue** : Comparaison entre Alpha-Beta classique et l'approfondissement iteratif.\n",
+    "**Sortie obtenue** : Comparaison entre Alpha-Beta classique et l'approfondissement itératif.\n",
     "\n",
-    "| Technique | Description | Avantage |\n",
+    "| Technique | description | Avantage |\n",
     "|-----------|-------------|----------|\n",
     "| **Alpha-Beta classique** | Profondeur fixe | Simple, deterministe |\n",
     "| **Ordonnancement** | Trie par potentiel de victoire | Speedup 10-50x |\n",
-    "| **Approfondissement iteratif** | Profondeur variable, limite temps | Anytime, utilise tout le temps |\n",
-    "| **Preference victoires rapides** | Ajuste eval avec nombre de coups | Gagne plus vite |\n",
+    "| **Approfondissement itératif** | Profondeur variable, limite temps | Anytime, utilise tout le temps |\n",
+    "| **préférence victoires rapides** | Ajuste eval avec nombre de coups | Gagne plus vite |\n",
     "\n",
     "**Lecons de l'implementation AIMA Java** :\n",
     "\n",
     "1. **Analyse des positions gagnantes** : AIMA Java utilise un bit-coding sophistique pour tracker incrementalement les positions gagnantes. Notre implementation simplifiee utilise `analyze_potential_win_positions()` pour un ordonnancement optimal.\n",
     "\n",
-    "2. **Approfondissement iteratif** : Transforme Alpha-Beta en algorithme **anytime** - utilisable dans des contextes temps reel.\n",
+    "2. **Approfondissement itératif** : Transforme Alpha-Beta en algorithme **anytime** - utilisable dans des contextes temps réel.\n",
     "\n",
     "3. **Ordonnancement des coups** : L'optimisation la plus impactante. Un bon ordonnancement peut reduire le nombre de noeuds explores de 50% a 90%.\n",
     "\n",
-    "4. **Victoires rapides** : Modifier l'evaluation pour penaliser les victoires tardives rend l'IA plus \"agressive\" et plus agréable a jouer.\n",
+    "4. **Victoires rapides** : modifier l'évaluation pour penaliser les victoires tardives rend l'IA plus \"agressive\" et plus agréable a jouer.\n",
     "\n",
-    "> **Pour aller plus loin** : L'implementation complete d'AIMA Java inclut egalement:\n",
-    "> - Bit-coding pour une representation memoire compacte (4 bits par cellule)\n",
+    "> **Pour aller plus loin** : L'implementation complète d'AIMA Java inclut également:\n",
+    "> - Bit-coding pour une représentation memoire compacte (4 bits par cellule)\n",
     "> - Mise a jour incrementielle des positions gagnantes\n",
-    "> - Transposition tables pour eviter les recalculs"
+    "> - Transposition tables pour éviter les recalculs"
    ]
   },
   {
@@ -3216,23 +3216,23 @@
     "tags": []
    },
    "source": [
-    "### Exercice 2 : Approfondissement iteratif\n",
+    "### Exercice 2 : Approfondissement itératif\n",
     "\n",
-    "L'**approfondissement iteratif** (Iterative Deepening) consiste a lancer Minimax avec des profondeurs croissantes (d=1, 2, 3, ...) et a s'arreter quand le temps imparti est ecoule.\n",
+    "L'**approfondissement itératif** (itérative Deepening) consiste a lancer Minimax avec des profondeurs croissantes (d=1, 2, 3, ...) et a s'arreter quand le temps imparti est ecoule.\n",
     "\n",
     "**Avantages** :\n",
-    "- Utilise tout le temps disponible\n",
-    "- Trouve d'abord une solution rapide, puis l'ameliore\n",
+    "- utilise tout le temps disponible\n",
+    "- Trouve d'abord une solution rapide, puis l'améliore\n",
     "- Le surcoute est faible : $O(b^d)$ domine $O(b^{d-1} + b^{d-2} + ...)$\n",
     "\n",
     "**Tache** : Implementez `iterative_deepening_minimax(board, player, time_limit=1.0)`.\n",
     "\n",
     "```python\n",
     "def iterative_deepening_minimax(board, player, time_limit=1.0):\n",
-    "    # A completer :\n",
+    "    # A complèter :\n",
     "    # - Boucle sur depth = 1, 2, 3, ...\n",
     "    # - A chaque profondeur, lancer minimax\n",
-    "    # - Si le temps est ecoule, retourner le meilleur coup de la profondeur precedente\n",
+    "    # - Si le temps est ecoule, retourner le meilleur coup de la profondeur précédente\n",
     "    pass\n",
     "```"
    ]
@@ -3325,18 +3325,18 @@
    "source": [
     "### Exercice 3 : Ordonnancement des coups et mesure du speedup\n",
     "\n",
-    "L'efficacite de l'elagage alpha-beta depend fortement de l'**ordre dans lequel les coups sont explores**. Si on essaie d'abord les meilleurs coups, plus de branches sont coupees.\n",
+    "L'efficacité de l'elagage alpha-beta dépend fortement de l'**ordre dans lequel les coups sont explores**. Si on essaie d'abord les meilleurs coups, plus de branches sont coupees.\n",
     "\n",
     "**Tache** : Implementez un ordonnancement des coups plus intelligent :\n",
-    "1. Les coups qui gagnent immediatement en premier\n",
+    "1. Les coups qui gagnent immédiatement en premier\n",
     "2. Les coups qui bloquent une victoire adverse ensuite\n",
     "3. Les colonnes centrales avant les laterales\n",
     "\n",
-    "Mesurez le **speedup** (acceleration) par rapport a l'ordre par defaut.\n",
+    "Mesurez le **speedup** (accélération) par rapport a l'ordre par defaut.\n",
     "\n",
     "```python\n",
     "def order_moves(board, player, moves):\n",
-    "    # A completer :\n",
+    "    # A complèter :\n",
     "    # - Trier les coups par priorite\n",
     "    # - Retourner la liste triee\n",
     "    pass\n",
@@ -3434,17 +3434,17 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : Exercices\n",
+    "### Interprétation : Exercices\n",
     "\n",
-    "| Exercice | Concept cle | Resultat attendu |\n",
+    "| Exercice | Concept cle | résultat attendu |\n",
     "|----------|-------------|------------------|\n",
-    "| Negamax | Simplification de Minimax | Memes decisions, code plus compact |\n",
-    "| Iterative Deepening | Utilisation optimale du temps | Profondeur variable, anytime |\n",
-    "| Move Ordering | Efficacite de l'elagage | Speedup de 2x a 10x selon la position |\n",
+    "| Negamax | Simplification de Minimax | mêmes décisions, code plus compact |\n",
+    "| itérative Deepening | utilisation optimale du temps | Profondeur variable, anytime |\n",
+    "| Move Ordering | efficacité de l'elagage | Speedup de 2x a 10x selon la position |\n",
     "\n",
     "**Points cles** :\n",
-    "1. Negamax et Minimax produisent les memes resultats -- la difference est purement stylistique\n",
-    "2. L'approfondissement iteratif transforme Minimax en algorithme **anytime** (comme MCTS)\n",
+    "1. Negamax et Minimax produisent les mêmes résultats -- la différence est purement stylistique\n",
+    "2. L'approfondissement itératif transforme Minimax en algorithme **anytime** (comme MCTS)\n",
     "3. L'ordonnancement des coups est l'optimisation la plus impactante pour alpha-beta : un bon ordonnancement peut reduire le nombre de noeuds de 50% a 90%"
    ]
   },
@@ -3466,7 +3466,7 @@
     "\n",
     "### Comparaison des approches\n",
     "\n",
-    "| IA | Famille | Profondeur | Evaluation | Temps/coup | Force |\n",
+    "| IA | Famille | Profondeur | évaluation | Temps/coup | Force |\n",
     "|----|---------|------------|------------|------------|-------|\n",
     "| Random | Baseline | 0 | N/A | <1ms | Nulle |\n",
     "| Greedy | Heuristique | 1 | Positionnelle | <1ms | Faible |\n",
@@ -3476,22 +3476,22 @@
     "\n",
     "### Lecons retenues\n",
     "\n",
-    "1. **Profondeur vs Qualite** : Minimax gagne ~200 ELO par niveau de profondeur supplementaire, au prix d'un facteur ~10x en temps de calcul.\n",
+    "1. **Profondeur vs Qualite** : Minimax gagne ~200 ELO par niveau de profondeur supplémentaire, au prix d'un facteur ~10x en temps de calcul.\n",
     "\n",
-    "2. **Alpha-Beta essentiel** : L'elagage reduit le facteur de branchement effectif de ~7 a ~3-4, rendant les profondeurs 5-6 accessibles.\n",
+    "2. **Alpha-Beta essentiel** : L'elagage réduit le facteur de branchement effectif de ~7 a ~3-4, rendant les profondeurs 5-6 accessibles.\n",
     "\n",
-    "3. **MCTS complementaire** : MCTS excelle quand une bonne heuristique d'evaluation est difficile a definir. Il converge vers Minimax avec suffisamment d'iterations.\n",
+    "3. **MCTS complémentaire** : MCTS excelle quand une bonne heuristique d'évaluation est difficile a définir. Il converge vers Minimax avec suffisamment d'itérations.\n",
     "\n",
-    "4. **Premier joueur avantagé** : Au Puissance 4, le premier joueur a un avantage theorique (jeu resolu). Un bon IA doit exploiter cet avantage.\n",
+    "4. **Premier joueur avantagé** : Au Puissance 4, le premier joueur a un avantage théorique (jeu résolu). Un bon IA doit exploiter cet avantage.\n",
     "\n",
-    "5. **Framework AIMA** : Le framework AIMA (Section 8) montre l'importance de separer la logique du jeu des algorithmes de recherche, ameliorant la maintenabilite et la reutilisabilite.\n",
+    "5. **Framework AIMA** : Le framework AIMA (Section 8) montre l'importance de séparer la logique du jeu des algorithmes de recherche, améliorant la maintenabilite et la reutilisabilite.\n",
     "\n",
     "### Pour aller plus loin\n",
     "\n",
-    "- **Resolution complete** : Utiliser une base de donnees d'ouvertures (solution parfaite connue depuis 1988)\n",
-    "- **Apprentissage par renforcement** : Entrainer un reseau de neurones a jouer (voir serie RL)\n",
+    "- **résolution complète** : utiliser une base de données d'ouvertures (solution parfaite connue depuis 1988)\n",
+    "- **apprentissage par renforcement** : Entrainer un réseau de neurones a jouer (voir serie RL)\n",
     "- **Parallelisation** : Paralleliser MCTS ou Alpha-Beta pour explorer plus de noeuds\n",
-    "- **Recherche de Monte Carlo amelioree** : Ajouter une heuristique de simulation (RAVE, etc.)\n"
+    "- **recherche de Monte Carlo améliorée** : Ajouter une heuristique de simulation (RAVE, etc.)\n"
    ]
   },
   {
@@ -3514,7 +3514,11 @@
   {
    "cell_type": "markdown",
    "id": "e07392a1",
-   "source": "## Conclusion\n\nCe notebook a comparé quatre approches d'intelligence artificielle sur le jeu de Puissance 4. Le **joueur aléatoire** sert de baseline nulle, le **joueur glouton** (profondeur 1) détecte les menaces immédiates mais manque de vision stratégique, le **Minimax avec élagage alpha-beta** offre une recherche exhaustive configurable en profondeur, et le **MCTS** (Monte Carlo Tree Search) construit progressivement un arbre de décision par simulations aléatoires sans nécessiter de fonction d'évaluation artisanale. Le tournoi confirme la hiérarchie attendue : Minimax(d=6) domine grâce à sa profondeur de recherche, suivi de Minimax(d=4) et MCTS qui sont compétitifs entre eux. Le framework AIMA (section 8) illustre l'importance de séparer la logique du jeu des algorithmes de recherche, et l'approfondissement itératif transforme alpha-beta en algorithme anytime. Les exercices (Negamax, approfondissement itératif, ordonnancement des coups) permettent de mesurer l'impact de chaque optimisation sur les performances.",
+   "source": [
+    "## Conclusion",
+    "",
+    "Ce notebook a comparé quatre approches d'intelligence artificielle sur le jeu de Puissance 4. Le **joueur aléatoire** sert de baseline nulle, le **joueur glouton** (profondeur 1) détecte les menaces immédiates mais manque de vision stratégique, le **Minimax avec élagage alpha-beta** offre une recherche exhaustive configurable en profondeur, et le **MCTS** (Monte Carlo Tree Search) construit progressivement un arbre de décision par simulations aléatoires sans nécessiter de fonction d'évaluation artisanale. Le tournoi confirme la hiérarchie attendue : Minimax(d=6) domine grâce à sa profondeur de recherche, suivi de Minimax(d=4) et MCTS qui sont compétitifs entre eux. Le framework AIMA (section 8) illustre l'importance de séparer la logique du jeu des algorithmes de recherche, et l'approfondissement itératif transforme alpha-beta en algorithme anytime. Les exercices (Negamax, approfondissement itératif, ordonnancement des coups) permettent de mesurer l'impact de chaque optimisation sur les performances."
+   ],
    "metadata": {}
   }
  ],


### PR DESCRIPTION
## Summary

Restore French accents in markdown source cells of `MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb` (11ème étape de la vague c.594-c.595-c.596-c.597-c.598-c.599-c.600-c.601-c.602-c.603-c.604 cross-famille ML→GenAI/Audio→Search/Part1→Sudoku→Search/Part2-CSP→SymbolicAI/Tweety→Probas/DecInfer→Probas/PyMC→SymbolicLearning→**RL**→Search/Applications).

## Metrics

- **283 cures** appliquées sur **32 cellules markdown**
- 1 file / 1 domain / 1 feature (R3 atomicité)
- R6 anti-monotonie : **Search/Applications** (Puissance 4 / Minimax/MCTS family) après ML-4 (c.594), GenAI/Audio (c.595), Search/Part1 (c.596), Sudoku (c.597), Search/Part2-CSP (c.598), SymbolicAI/Tweety (c.599), Probas/DecInfer (c.600), Probas/PyMC (c.601), SymbolicLearning (c.602), RL/MAB (c.603)
- +145/-145 lignes diff (multiline cells = JSON source-array string regroupé)
- LF 3557/3557 préservées, CRLF 0/0 préservé
- bytes delta +232 (283 cures × ~0.6 byte/cur average + accent reorganisations)
- 59 cells préservées (37 markdown + 22 code)

## Stop & Repair strict (HARD, règle 6 secrets-hygiene.md)

- 0 code cell source diff
- 0 outputs diff
- 0 execution_count diff
- 0 cell added/removed (59 cells préservées)
- nbformat 4.5 préservé
- CRLF 0/0 préservé
- LF 3557/3557 (avec delta naturel par cell regrouping)
- Pas de hand-edit sur une sortie de cellule

## Pré-flight collision (L679-L1 ★★)

`gh pr list --state all --search "App-12-ConnectFour"`: aucune PR ne touchait les accents markdown du notebook Python. → **0 collision**.

`gh pr list --state all --search "ConnectFour"`: aucune PR concurrente sur ce notebook. → **0 collision**.

## Leçons cumulées (synchronisation avec vagues précédentes)

- **Leçon c.591 ★** : binary write `open('wb')` + `.encode('utf-8')` pour préserver LF
- **Leçon c.593 ★** : raw-text surgical bypass `nbformat.write` via `json.dumps(indent=4)` + closing `]` 3-space indent fix
- **Leçon c.596 ★** : pre-commit grep validation des participes passés + désambiguïsation présent/participe
- **Leçon c.599 ★** : pondere-3rd-ps-disambiguation (3rd ps sg present `pondère` ≠ 3rd pp `pondéré`)
- **Leçon c.601 ★** : verifie-3rd-ps-disambiguation (3rd ps sg present `vérifie` ≠ 3rd pp `vérifié`)
- **Leçon c.602 ★ (L526 ★)** : identifie-3rd-ps-disambiguation (3rd ps sg present `identifie` ≠ 3rd pp `identifié`)
- **Leçon c.603 ★ (L527 ★)** : observe-pp-disambiguation (3rd ps sg present `observe` ≠ 3rd pp `observé`) — no-op default + post-fix audit grep `Apres avoir X\b` + `selon le/la X\b` + `\bX attribut`

## Leçon c.604 ★ (NEW, leçon de vigilance) : MD-only strict surgical fixes

**Action** : pour les prochaines PRs d'accents sur notebooks Search/Applications, les **surgical fixes doivent opérer UNIQUEMENT sur les cellules markdown**, jamais sur les cellules code (qui contiennent docstrings, commentaires, identifiers).

**Contexte incident c.604** : un premier pass de surgical post-fix (`pass 2`) a accidentellement modifié le contenu des **cellules code** :
- `cell[3]`: `"...benchmark seront définies localement..."` au lieu de `"...definies localement..."`
- `cell[5]`: `"...logique de jeu complète"` (docstring) au lieu de `"complete"`
- `cell[11]`: `"print("Fonction play_game définie.")` au lieu de `"definie."`
- `cell[13]`: `"IA aléatoire"` (docstring) au lieu de `aleatoire`
- `cell[16]`: `"fenêtres de 4 cases"` (comment) au lieu de `fenetres`

**Reverted via `git checkout HEAD -- <notebook>` puis relance depuis état clean.**

**Solution appliquée** : 
- Script `surgical_md_only_c604.py` qui :
  1. Charge le notebook JSON
  2. Filtre `cell.get('cell_type') == 'markdown'` avant substitution
  3. Itère sur les `cell['source']` lignes sans toucher au reste
  4. Sauvegarde avec `json.dumps(..., indent=1)`
- Re-run auto-cure `apply_accents_c604.py` (qui ne touche QUE markdown) + post-fix surgical MD-only.

**Règle générale** : Tout surgical fix sur notebook doit passer par une étape **explicite de filtrage `cell_type == 'markdown'`**. Pour les string-literal stdout (Stop & Repair), voir règle scope ai-01 (markdown + string-literals stdout IN, commentaires/identifiants OUT).

**Cell[3] test du module `search_helpers`** : commentaire avant `print(...)` — commentaire Python = OUT of scope per ai-01 accent contract.

## Pre-commit grep (lesson c.596+)

Toutes les formes en `-ée`/`-ées`/`-é` post-fix vérifiées par contexte :

| Cell | Forme | Contexte | Verdict |
|------|-------|----------|---------|
| cell[6] | "La méthode `legal_moves()` vérifié la ligne" | sujet f.sg "La méthode" + présent 3ps sg | ✅ FP surgical fix vers `vérifie` |
| cell[1] | "resultat parfait" | nom m.sg attribut du sujet | ✅ (noun) |
| cell[6] | "complexite $O(...)" | nom f.sg attribut | ✅ (noun) |
| cell[39] | "instantané, il bat Random" | adj m.sg épithète liée au sujet | ✅ (adjectif) |
| cell[1] | "Le Puissance 4 occupe position intermediaire" | verbe présent 3ps sg | ✅ (no accent) |
| cell[6] | "Methode legal_moves verifie" | FP fix appliqué → `vérifie` présent 3ps sg | ✅ |

1 occurrence `vérifié` corrigée en `vérifie` (lesson c.601 ★). Les autres formes en `-é`/`-ée` sont nouns, adjectives, ou past participles contextuellement corrects.

## Scope strict : markdown only (leçon c.598 ★)

Code cells + outputs INCHANGÉS (0 diff). Les occurrences `Logique`, `Board`, `IA`, `Minimax`, `MCTS`, `random`, `greedy`, `alpha`, `beta`, `iterations`, `profondeur` dans les **commentaires Python** (`# ...`), **docstrings** (`"""..."""`), et **string-literals stdout** (`print(...)`) restent volontairement sans accent :
- **Commentaires Python** + **docstrings** : OUT of scope per ai-01 accent contract (cf incident fondateur c.604 ★)
- **String-literals stdout** : nécessitent re-exécution Python (numpy MCTS/Minimax/MCTS-AI) pour cohérence output, hors scope c.604 (R3 atomic 1f/1feature/1domain)

Voir issue #2876 pour batch dédié string-literal re-execution.

## Self-pick cross-pool validation

Issue #2876 (CLOSED erroneously via squash commit mais `See #2876` reste valide — pattern perenne rollout). Pool global = `gh issue list --state open` ~65 issues. R3 atomic = 1f/1feature/1dom, R6 anti-monotonie 11/11 (c.594-c.604 chaîne T1 cross-famille).

See #2876