### PR TITLE
fix(sudoku,#2876): restore French accents in Sudoku-5-PSO-Python markdown (63 cures, 20 cells)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb
@@ -18,11 +18,11 @@
    "source": [
     "# Sudoku-5 : Particle Swarm Optimization (Python)\n",
     "\n",
-    "**Niveau** : Metaheuristique | **Duree** : ~20 min | **Prerequis** : Sudoku-0 Environment\n",
+    "**Niveau** : Métaheuristique | **Duree** : ~20 min | **Prerequis** : Sudoku-0 Environment\n",
     "\n",
     "## Navigation\n",
     "\n",
-    "| << Precedent | [Index](README.md) | Suivant >> |\n",
+    "| << Précédent | [Index](README.md) | Suivant >> |\n",
     "|-------------|---------------------|-----------|\n",
     "| [Sudoku-4-SimulatedAnnealing-Python](Sudoku-4-SimulatedAnnealing-Python.ipynb) | | [Sudoku-6-AIMA-CSP-Python](Sudoku-6-AIMA-CSP-Python.ipynb) |\n",
     "\n",
@@ -32,7 +32,7 @@
     "1. Comprendre les principes de l'optimisation par essaim de particules (PSO)\n",
     "2. Adapter le PSO a la resolution de Sudoku\n",
     "3. Implementer un solveur d'essaim discret (Workers/Explorers) adapte au Sudoku\n",
-    "4. Comparer les performances avec les autres metaheuristiques\n",
+    "4. Comparer les performances avec les autres métaheuristiques\n",
     "\n",
     "---\n",
     "\n",
@@ -41,7 +41,7 @@
     "\n",
     "## Introduction\n",
     "\n",
-    "Le **Particle Swarm Optimization** (PSO) est une metaheuristique inspiree du comportement social des oiseaux et des poissons. Developpe par Kennedy et Eberhart en 1995, l'algorithme simule un essaim de particules qui explorent l'espace de recherche.\n",
+    "Le **Particle Swarm Optimization** (PSO) est une métaheuristique inspiree du comportement social des oiseaux et des poissons. Developpe par Kennedy et Eberhart en 1995, l'algorithme simule un essaim de particules qui explorent l'espace de recherche.\n",
     "\n",
     "### Principes fondamentaux (PSO canonique)\n",
     "\n",
@@ -57,20 +57,20 @@
     "$$x(t+1) = x(t) + v(t+1)$$\n",
     "\n",
     "Ou :\n",
-    "- $w$ : poids d'inertie (impact de la vitesse precedente)\n",
+    "- $w$ : poids d'inertie (impact de la vitesse précédente)\n",
     "- $c_1$, $c_2$ : coefficients d'apprentissage (cognitif et social)\n",
     "- $r_1$, $r_2$ : nombres aleatoires [0, 1]\n",
     "\n",
     "### Adaptation au Sudoku : une variante discrete inspiree de l'essaim\n",
     "\n",
-    "L'equation de vitesse ci-dessus est definie sur un espace **continu** : additionner une vitesse a une position suppose des coordonnees reelles. Le Sudoku est un probleme **combinatoire discret** (permutations de chiffres), ou cette addition n'a pas de sens direct. Ce notebook n'implemente donc **pas** l'equation de vitesse canonique ; il utilise une **heuristique d'essaim discrete** (classe `PSOSudokuSolver`) inspiree du PSO et des colonies d'organismes :\n",
+    "L'equation de vitesse ci-dessus est définie sur un espace **continu** : additionner une vitesse a une position suppose des coordonnees reelles. Le Sudoku est un problème **combinatoire discret** (permutations de chiffres), ou cette addition n'a pas de sens direct. Ce notebook n'implemente donc **pas** l'equation de vitesse canonique ; il utilise une **heuristique d'essaim discrete** (classe `PSOSudokuSolver`) inspiree du PSO et des colonies d'organismes :\n",
     "\n",
-    "- **Workers** (`worker_ratio = 0.90`) : exploitent leur voisinage par **echange de deux cases dans un meme bloc** (`neighbor_matrix`, recherche locale), en acceptant un voisin s'il reduit l'erreur (ou rarement, via un faible `mutation_rate`). Un worker qui stagne trop longtemps (`age > max_age`) est reinitialise.\n",
-    "- **Explorers** (10%) : repartent d'une grille **aleatoire** complete (`random_matrix`) a chaque iteration, pour diversifier la recherche.\n",
+    "- **Workers** (`worker_ratio = 0.90`) : exploitent leur voisinage par **echange de deux cases dans un même bloc** (`neighbor_matrix`, recherche locale), en acceptant un voisin s'il reduit l'erreur (ou rarement, via un faible `mutation_rate`). Un worker qui stagne trop longtemps (`age > max_age`) est reinitialise.\n",
+    "- **Explorers** (10%) : repartent d'une grille **aleatoire** complete (`random_matrix`) a chaque itération, pour diversifier la recherche.\n",
     "- **Fusion** : a chaque epoque, le pire worker est remplace par un croisement par blocs (`merge_matrices`) du meilleur worker et du meilleur explorer.\n",
     "- **Meilleure globale** : l'essaim conserve la meilleure grille rencontree (`best_error` / `best_solution`), qui est la solution retournee.\n",
     "\n",
-    "> **A retenir** : il n'y a ici ni champ de vitesse, ni memoire `pBest` par particule, ni coefficients $w$/$c_1$/$c_2$. Les workers ne sont pas attires par `gBest` au sens de l'equation canonique : chaque worker se compare a sa **propre** erreur courante. C'est un exemple typique de la difficulte a transposer une metaheuristique **continue** (PSO) vers un espace **discret** : on garde l'idee d'essaim (exploration parallele + memoire de la meilleure solution), mais le mecanisme de deplacement est entierement repense (echanges locaux + fusion + redemarrages).\n",
+    "> **A retenir** : il n'y a ici ni champ de vitesse, ni memoire `pBest` par particule, ni coefficients $w$/$c_1$/$c_2$. Les workers ne sont pas attires par `gBest` au sens de l'equation canonique : chaque worker se compare a sa **propre** erreur courante. C'est un exemple typique de la difficulte a transposer une métaheuristique **continue** (PSO) vers un espace **discret** : on garde l'idee d'essaim (exploration parallele + memoire de la meilleure solution), mais le mécanisme de deplacement est entierement repense (echanges locaux + fusion + redemarrages).\n",
     "\n",
     "## Installation\n",
     "\n",
@@ -156,7 +156,7 @@
     "| `mealpy` | Optimisation (optionnel) | Implementation manuelle |\n",
     "\n",
     "**Points cles** :\n",
-    "1. **Independance** : Ce notebook implemente PSO manuellement (mealpy optionnel)\n",
+    "1. **Indépendance** : Ce notebook implemente PSO manuellement (mealpy optionnel)\n",
     "2. **NumPy** : Essentiel pour la representation matricielle\n",
     "3. **Typing** : Annotations de type pour la clarte du code\n",
     "\n",
@@ -250,7 +250,7 @@
     "\n",
     "**Structure des fichiers** :\n",
     "\n",
-    "| Element | Chemin | Role |\n",
+    "| Élément | Chemin | Rôle |\n",
     "|---------|--------|------|\n",
     "| `NOTEBOOK_DIR` | `D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku` | Racine de la serie |\n",
     "| `PUZZLES_DIR` | `.../Sudoku/Puzzles` | Conteneur des fichiers de puzzles |\n",
@@ -281,7 +281,7 @@
    "source": [
     "## 1. Classe SudokuGrid\n",
     "\n",
-    "Representation d'une grille de Sudoku avec methodes pour calculer le nombre d'erreurs."
+    "Representation d'une grille de Sudoku avec méthodes pour calculer le nombre d'erreurs."
    ]
   },
   {
@@ -427,15 +427,15 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : Structure de donnees Sudoku\n",
+    "### Interpretation : Structure de données Sudoku\n",
     "\n",
-    "**Sortie obtenue** : 5 puzzles charges, grille de test affichee\n",
+    "**Sortie obtenue** : 5 puzzles charges, grille de test affichée\n",
     "\n",
     "**Composants de la classe SudokuGrid** :\n",
     "\n",
-    "| Methode | Role | Complexite |\n",
+    "| Méthode | Rôle | Complexite |\n",
     "|---------|------|------------|\n",
-    "| `from_string()` | Parse une chaine de 81 caracteres | O(1) |\n",
+    "| `from_string()` | Parse une chaîne de 81 caractères | O(1) |\n",
     "| `count_errors()` | Compte doublons lignes/colonnes/blocs | O(9*9) = O(1) |\n",
     "| `is_solved()` | Verifie si grille valide | O(1) |\n",
     "| `clone()` | Copie profonde | O(1) |\n",
@@ -446,11 +446,11 @@
     "- Cases vides : 36 (sur 81)\n",
     "\n",
     "**Points cles** :\n",
-    "1. **Representation compacte** : Chaine de 81 caracteres pour le stockage\n",
+    "1. **Representation compacte** : Chaîne de 81 caractères pour le stockage\n",
     "2. **Validation efficace** : Utilisation de `np.unique` pour detecter les doublons\n",
     "3. **Affichage lisible** : Separateurs visuels pour les blocs 3x3\n",
     "\n",
-    "> **Note technique** : La methode `count_errors()` compte les doublons dans chaque ligne, colonne et bloc. Une grille resolue a 0 erreurs. Cette fonction sera la base de notre fonction de fitness pour le PSO."
+    "> **Note technique** : La méthode `count_errors()` compte les doublons dans chaque ligne, colonne et bloc. Une grille resolue a 0 erreurs. Cette fonction sera la base de notre fonction de fitness pour le PSO."
    ]
   },
   {
@@ -498,7 +498,7 @@
    "source": [
     "## 3. Implementation manuelle du PSO\n",
     "\n",
-    "Nous implementons un PSO specifique au Sudoku, sans utiliser mealpy, pour mieux comprendre l'algorithme."
+    "Nous implementons un PSO spécifique au Sudoku, sans utiliser mealpy, pour mieux comprendre l'algorithme."
    ]
   },
   {
@@ -633,11 +633,11 @@
    "source": [
     "### Interpretation : Helpers matriciels pour PSO\n",
     "\n",
-    "**Sortie obtenue** : Classe MatrixHelperPSO definie\n",
+    "**Sortie obtenue** : Classe MatrixHelperPSO définie\n",
     "\n",
-    "**Operations cles** :\n",
+    "**Opérations cles** :\n",
     "\n",
-    "| Methode | Role | Strategie |\n",
+    "| Méthode | Rôle | Stratégie |\n",
     "|---------|------|-----------|\n",
     "| `random_matrix` | Initialisation | Remplit chaque bloc 3x3 avec 1-9 |\n",
     "| `neighbor_matrix` | Voisinage | Echange 2 cases dans un bloc |\n",
@@ -646,9 +646,9 @@
     "**Points cles** :\n",
     "1. **Encodage par blocs** : Chaque bloc 3x3 contient toujours 1-9 (pas d'erreur de bloc)\n",
     "2. **Respect des contraintes** : Les cases fixes du puzzle ne sont jamais modifiees\n",
-    "3. **Efficacite** : Operations locales (un bloc) pour limiter les changements\n",
+    "3. **Efficacite** : Opérations locales (un bloc) pour limiter les changements\n",
     "\n",
-    "> **Note technique** : L'approche par blocs reduit drastiquement l'espace de recherche. Au lieu de 9^81 possibilites, on a (9!)^9 configurations, et chaque bloc est deja valide localement."
+    "> **Note technique** : L'approche par blocs reduit drastiquement l'espace de recherche. Au lieu de 9^81 possibilites, on a (9!)^9 configurations, et chaque bloc est déjà valide localement."
    ]
   },
   {
@@ -746,22 +746,22 @@
    "source": [
     "### Interpretation : Fonction d'evaluation PSO\n",
     "\n",
-    "**Sortie obtenue** : Classe SudokuPSO definie\n",
+    "**Sortie obtenue** : Classe SudokuPSO définie\n",
     "\n",
-    "**Mecanisme de calcul d'erreur** :\n",
+    "**Mécanisme de calcul d'erreur** :\n",
     "\n",
-    "| Type de verification | Methode | Erreur comptee |\n",
+    "| Type de verification | Méthode | Erreur comptee |\n",
     "|---------------------|---------|----------------|\n",
     "| Lignes | Valeurs manquantes (1-9) | +1 par valeur absente |\n",
     "| Colonnes | Valeurs manquantes (1-9) | +1 par valeur absente |\n",
     "| Total | Somme lignes + colonnes | 0 a 162 |\n",
     "\n",
     "**Points cles** :\n",
-    "1. **Optimisation** : On ne verifie PAS les blocs 3x3 (deja valides par construction)\n",
+    "1. **Optimisation** : On ne verifie PAS les blocs 3x3 (déjà valides par construction)\n",
     "2. **Fitness inverse** : Erreur = 0 signifie solution valide\n",
     "3. **Efficacite** : Comptage par tableaux d'occurrences (O(1) par ligne/colonne)\n",
     "\n",
-    "> **Note technique** : Cette fonction d'evaluation est specifique a l'encodage par blocs. Puisque chaque bloc contient exactement les chiffres 1-9, il ne peut pas y avoir d'erreur de bloc. Les seules erreurs possibles sont les conflits entre lignes et colonnes."
+    "> **Note technique** : Cette fonction d'evaluation est spécifique a l'encodage par blocs. Puisque chaque bloc contient exactement les chiffres 1-9, il ne peut pas y avoir d'erreur de bloc. Les seules erreurs possibles sont les conflits entre lignes et colonnes."
    ]
   },
   {
@@ -845,11 +845,11 @@
    "source": [
     "### Interpretation : Modelisation des particules\n",
     "\n",
-    "**Sortie obtenue** : Classes OrganismType et Organism definies\n",
+    "**Sortie obtenue** : Classes OrganismType et Organism définies\n",
     "\n",
     "**Structure d'une particule** :\n",
     "\n",
-    "| Attribut | Type | Role |\n",
+    "| Attribut | Type | Rôle |\n",
     "|----------|------|------|\n",
     "| `type` | OrganismType | WORKER ou EXPLORER |\n",
     "| `matrix` | np.ndarray | Grille 9x9 representant la position |\n",
@@ -857,7 +857,7 @@
     "| `age` | int | Epochs sans amelioration |\n",
     "\n",
     "**Points cles** :\n",
-    "1. **Dualite des roles** : Workers exploitent localement, explorers cherchent globalement\n",
+    "1. **Dualite des rôles** : Workers exploitent localement, explorers cherchent globalement\n",
     "2. **Age comme indicateur** : Permet de detecter la stagnation\n",
     "3. **Fitness inverse** : On minimise l'erreur (0 = solution valide)\n",
     "\n",
@@ -1058,11 +1058,11 @@
    "source": [
     "### Interpretation : Architecture du solveur PSO\n",
     "\n",
-    "**Sortie obtenue** : Classe PSOSudokuLoader definie avec succes\n",
+    "**Sortie obtenue** : Classe PSOSudokuLoader définie avec succes\n",
     "\n",
     "**Composants principaux** :\n",
     "\n",
-    "| Composant | Role | Parametre cle |\n",
+    "| Composant | Rôle | Paramètre cle |\n",
     "|-----------|------|---------------|\n",
     "| **Workers** (90%) | Exploitation locale | Voisinage par echange dans bloc |\n",
     "| **Explorers** (10%) | Exploration globale | Reinitialisation aleatoire |\n",
@@ -1070,7 +1070,7 @@
     "| **Age** | Detection de stagnation | Reinitialisation si > max_age |\n",
     "\n",
     "**Points cles** :\n",
-    "1. **Double strategie** : Workers exploitent, explorers decouvrent\n",
+    "1. **Double stratégie** : Workers exploitent, explorers decouvrent\n",
     "2. **Fusion intelligente** : Le pire worker est remplace par la fusion des meilleurs\n",
     "3. **Redemarrages** : Plusieurs tentatives pour eviter les optima locaux\n",
     "\n",
@@ -1201,7 +1201,7 @@
     "\n",
     "| Aspect | Observation |\n",
     "|--------|-------------|\n",
-    "| Resultat | Le PSO peut trouver la solution pour les puzzles faciles |\n",
+    "| Résultat | Le PSO peut trouver la solution pour les puzzles faciles |\n",
     "| Temps | Variable selon la configuration |\n",
     "| Workers vs Explorers | Les workers exploitent, les explorers decouvrent |\n",
     "\n",
@@ -1436,7 +1436,7 @@
    "source": [
     "### Interpretation : Benchmark PSO sur plusieurs puzzles\n",
     "\n",
-    "**Sortie obtenue** : Resultats sur 2 puzzles de difficulte croissante\n",
+    "**Sortie obtenue** : Résultats sur 2 puzzles de difficulte croissante\n",
     "\n",
     "| Puzzle | Cases vides | Temps | Statut | Redemarrages |\n",
     "|--------|-------------|-------|--------|--------------|\n",
@@ -1473,18 +1473,18 @@
     "## Exercice : Detection de convergence\n",
     "\n",
     "### Contexte\n",
-    "Le PSO s'arrete apres un nombre fixe d'epochs. Mais si la solution stagne, continuer est inutile. Un **critere de convergence** permet d'arreter plus tot.\n",
+    "Le PSO s'arrete après un nombre fixe d'epochs. Mais si la solution stagne, continuer est inutile. Un **critere de convergence** permet d'arreter plus tot.\n",
     "\n",
     "### Objectif\n",
     "Implementez la fonction  qui detecte si le PSO a converge, en verifiant que l'erreur n'a pas baisse depuis un nombre donne d'epochs.\n",
     "\n",
     "### Ce que la fonction doit verifier\n",
-    "1. La liste  contient au moins  elements\n",
-    "2. La difference entre l'erreur la plus recente et celle d'il y a  epochs est inferieure a \n",
+    "1. La liste  contient au moins  éléments\n",
+    "2. La différence entre l'erreur la plus recente et celle d'il y a  epochs est inferieure a \n",
     "\n",
     "### Indices\n",
     "- Comparez  avec \n",
-    "- Si la liste a moins de  elements, retournez  (pas assez de donnees)"
+    "- Si la liste a moins de  éléments, retournez  (pas assez de données)"
    ]
   },
   {
@@ -1554,7 +1554,7 @@
    },
    "outputs": [],
    "source": [
-    "## 7. Comparaison des Parametres"
+    "## 7. Comparaison des Paramètres"
    ]
   },
   {
@@ -1653,7 +1653,7 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : Impact des parametres PSO\n",
+    "### Interpretation : Impact des paramètres PSO\n",
     "\n",
     "**Sortie obtenue** : Temps de resolution selon trois configurations\n",
     "\n",
@@ -1666,9 +1666,9 @@
     "**Points cles** :\n",
     "1. **Configuration conservateur** : Plus rapide pour ce puzzle facile (2.11s)\n",
     "2. **Toutes les configurations** reussissent sur les puzzles faciles\n",
-    "3. **Le temps de resolution** ne croit pas lineairement avec les parametres\n",
+    "3. **Le temps de resolution** ne croit pas lineairement avec les paramètres\n",
     "\n",
-    "> **Note technique** : Pour les puzzles faciles, une configuration legere suffit. Les parametres agressifs sont utiles pour les puzzles difficiles ou l'essaim peut stagner dans des optima locaux."
+    "> **Note technique** : Pour les puzzles faciles, une configuration legere suffit. Les paramètres agressifs sont utiles pour les puzzles difficiles ou l'essaim peut stagner dans des optima locaux."
    ]
   },
   {
@@ -1688,7 +1688,7 @@
     "## Exercice : Ratio workers/explorers adaptatif\n",
     "\n",
     "### Contexte\n",
-    "Dans le solveur PSO, le parametre `worker_ratio` fixe la proportion de workers (exploitation) par rapport aux explorers (exploration). Une valeur statique de 0.90 signifie 90% de workers et 10% d'explorers, independamment de la progression de la recherche.\n",
+    "Dans le solveur PSO, le paramètre `worker_ratio` fixe la proportion de workers (exploitation) par rapport aux explorers (exploration). Une valeur statique de 0.90 signifie 90% de workers et 10% d'explorers, independamment de la progression de la recherche.\n",
     "\n",
     "Or, les besoins en exploration vs exploitation changent au cours de la resolution :\n",
     "- **Debut** : Il faut beaucoup d'exploration pour couvrir l'espace de recherche\n",
@@ -1698,7 +1698,7 @@
     "### Objectif\n",
     "Implementez la fonction `adaptive_worker_ratio` qui calcule dynamiquement le ratio workers/explorers en fonction de la progression de l'erreur.\n",
     "\n",
-    "### Resultats attendus\n",
+    "### Résultats attendus\n",
     "\n",
     "| Situation | current_error | initial_error | worker_ratio attendu |\n",
     "|-----------|---------------|---------------|---------------------|\n",
@@ -1708,7 +1708,7 @@
     "| Erreur nulle (100%) | 0 | 20 | 0.950 |\n",
     "\n",
     "**Indice :**\n",
-    "La formule est un interpolation lineaire : plus l'erreur baisse (bonne progression), plus on augmente le ratio de workers. Utilisez `max()` et `min()` pour borner le resultat."
+    "La formule est un interpolation lineaire : plus l'erreur baisse (bonne progression), plus on augmente le ratio de workers. Utilisez `max()` et `min()` pour borner le résultat."
    ]
   },
   {
@@ -1871,11 +1871,11 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : Comparaison des metaheuristiques\n",
+    "### Interpretation : Comparaison des métaheuristiques\n",
     "\n",
-    "**Sortie obtenue** : Tableau comparatif des caracteristiques de PSO, GA et SA\n",
+    "**Sortie obtenue** : Tableau comparatif des caractéristiques de PSO, GA et SA\n",
     "\n",
-    "| Aspect | PSO | Algorithme Genetique | Recuit Simule |\n",
+    "| Aspect | PSO | Algorithme Génétique | Recuit Simule |\n",
     "|--------|-----|---------------------|---------------|\n",
     "| **Inspiration** | Oiseaux/poissons | Evolution biologique | Thermodynamique |\n",
     "| **Population** | Multiple (essaim) | Multiple (generation) | Unique (solution courante) |\n",
@@ -1885,8 +1885,8 @@
     "\n",
     "**Points cles** :\n",
     "1. **PSO** se situe entre GA et SA en termes de performance\n",
-    "2. L'architecture a double role (workers/explorers) offre un bon equilibre\n",
-    "3. Le choix de la methode depend du type de puzzle et des contraintes de temps\n",
+    "2. L'architecture a double rôle (workers/explorers) offre un bon equilibre\n",
+    "3. Le choix de la méthode depend du type de puzzle et des contraintes de temps\n",
     "\n",
     "> **Note technique** : PSO est particulierement efficace pour les problemes ou l'espace de recherche peut etre partitionne (ici, par blocs 3x3)."
    ]
@@ -1942,7 +1942,7 @@
     "1. `local_search_improve(matrix, problem, max_attempts)` : Pour chaque bloc, essaye tous les echanges de paires de cases libres et garde le meilleur (descente de gradient)\n",
     "2. `HybridPSOSudokuSolver` : Etend `PSOSudokuSolver` en detectant la stagnation et en appelant `local_search_improve`\n",
     "\n",
-    "### Resultats attendus\n",
+    "### Résultats attendus\n",
     "\n",
     "Le PSO hybride devrait avoir moins de redemarrages et etre plus fiable sur les puzzles difficiles.\n",
     "\n",
@@ -2066,11 +2066,11 @@
    "source": [
     "## Resume et perspectives\n",
     "\n",
-    "Ce notebook a implemente le Particle Swarm Optimization (PSO) pour la resolution de Sudoku, avec un encodage par blocs 3x3 qui garantit la validite locale de chaque bloc. L'architecture a double role (Workers pour l'exploitation locale, Explorers pour l'exploration globale) offre un equilibre entre convergence et diversification. Les benchmarks ont montre une grande variabilite : d'environ 2 secondes pour les puzzles faciles a pres de 47 secondes pour les grilles plus contraintes, avec un taux de succes de 2/2 sur le benchmark execute ici. La stagnation frequente a quelques erreurs (2 a 4) illustre la difficulte des metaheuristiques a echapper aux optima locaux sur les problemes fortement contraints.\n",
+    "Ce notebook a implemente le Particle Swarm Optimization (PSO) pour la resolution de Sudoku, avec un encodage par blocs 3x3 qui garantit la validite locale de chaque bloc. L'architecture a double rôle (Workers pour l'exploitation locale, Explorers pour l'exploration globale) offre un equilibre entre convergence et diversification. Les benchmarks ont montre une grande variabilite : d'environ 2 secondes pour les puzzles faciles a pres de 47 secondes pour les grilles plus contraintes, avec un taux de succes de 2/2 sur le benchmark execute ici. La stagnation frequente a quelques erreurs (2 a 4) illustre la difficulte des métaheuristiques a echapper aux optima locaux sur les problemes fortement contraints.\n",
     "\n",
-    "L'analyse des parametres (taille de l'essaim, nombre d'epochs, redemarrages) a montre que la configuration \"Conservatrice\" suffit souvent pour les puzzles faciles, tandis que les puzzles difficiles necessitent une configuration \"Agressive\" avec un cout temporel significatif. L'exercice propose sur le PSO hybride avec recherche locale vise precisement a resoudre le probleme de stagnation en combinant l'exploration globale de l'essaim avec une descente de gradient locale.\n",
+    "L'analyse des paramètres (taille de l'essaim, nombre d'epochs, redemarrages) a montre que la configuration \"Conservatrice\" suffit souvent pour les puzzles faciles, tandis que les puzzles difficiles necessitent une configuration \"Agressive\" avec un cout temporel significatif. L'exercice propose sur le PSO hybride avec recherche locale vise précisément a resoudre le problème de stagnation en combinant l'exploration globale de l'essaim avec une descente de gradient locale.\n",
     "\n",
-    "Le notebook suivant, [Sudoku-6-AIMA-CSP-Python](Sudoku-6-AIMA-CSP-Python.ipynb), aborde une approche deterministe : la programmation par contraintes (CSP) selon le cadre academique AIMA, avec les algorithmes AC-3, Forward Checking et MAC qui garantissent la resolution complete."
+    "Le notebook suivant, [Sudoku-6-AIMA-CSP-Python](Sudoku-6-AIMA-CSP-Python.ipynb), aborde une approche déterministe : la programmation par contraintes (CSP) selon le cadre academique AIMA, avec les algorithmes AC-3, Forward Checking et MAC qui garantissent la resolution complete."
    ]
   },
   {
@@ -2095,18 +2095,18 @@
     "\n",
     "| Concept | Description |\n",
     "|---------|-------------|\n",
-    "| **PSO** | Metaheuristique d'essaim inspiree des oiseaux |\n",
+    "| **PSO** | Métaheuristique d'essaim inspiree des oiseaux |\n",
     "| **Particules** | Solutions candidates avec position et vitesse |\n",
     "| **pBest/gBest** | Meilleures positions personnelle et globale |\n",
     "| **Workers** | Exploitent leur voisinage (90% de l'essaim) |\n",
     "| **Explorers** | Explorent aleatoirement (10% de l'essaim) |\n",
     "\n",
-    "### Parametres cles\n",
+    "### Paramètres cles\n",
     "\n",
-    "| Parametre | Effet | Valeur recommandee |\n",
+    "| Paramètre | Effet | Valeur recommandee |\n",
     "|-----------|-------|-------------------|\n",
     "| NumOrganisms | Taille de l'essaim | 100-300 |\n",
-    "| MaxEpochs | Iterations par essai | 3000-5000 |\n",
+    "| MaxEpochs | Itérations par essai | 3000-5000 |\n",
     "| MaxRestarts | Redemarrages autorises | 10-20 |\n",
     "| WorkerRatio | Proportion de workers | 0.85-0.95 |\n",
     "| MaxAge | Age max avant reinit | 500-1000 |\n",
@@ -2117,13 +2117,13 @@
     "|-----------|---------------|\n",
     "| Parallelisation naturelle | Pas de garantie de convergence |\n",
     "| Equilibre exploration/exploitation | Performance variable selon puzzles |\n",
-    "| Conceptuellement simple | Parametres a ajuster |\n",
+    "| Conceptuellement simple | Paramètres a ajuster |\n",
     "\n",
     "### Quand l'utiliser\n",
     "\n",
     "- Puzzles moyens (pas trop difficiles)\n",
     "- Quand on veut plusieurs solutions candidates\n",
-    "- Pour comprendre les metaheuristiques d'essaim\n",
+    "- Pour comprendre les métaheuristiques d'essaim\n",
     "\n",
     "### Alternatives recommandees\n",
     "\n",


### PR DESCRIPTION
## Scope

Single-file PR. Touches **only** `MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb` (Particle Swarm Optimization). Restores FR accents lost in the pedagogical markdown. **No executable code cell modified.**

## Method

Canonical `ACCENT_PAIRS` dict from `detect_accent_stripping.py` (161 pairs, case-preserving). **Markdown-only by construction**: the cure script skips every non-markdown cell (`if cell_type != markdown: continue`), so code identifiers / comments / stdout are untouched by construction — defensive prevention of the identifier-regression defect class (cf #7094/#7143/#7154/#7150/#7146/#7159). URL spans `](...)` masked before cure (L677-L5 nav-link protection).

## Verification (full battery)

| Check | Result |
|-------|--------|
| `code_src_changed` | **0** (markdown-only) |
| `md_src_changed` | 20 (the cures) |
| `outputs_changed` / `ec_changed` | **0** / **0** |
| `detect_accent_stripping.py` markdown hits post-cure | **0** (drift resolved) |
| `check_identifier_regression.py` (PR #7157 guard) regressions | **0** — guard **dogfooded on my own output** |
| one-to-one line replacement | 63 insertions / 63 deletions |
| backslash-u escapes | 0 (literal UTF-8) |
| CRLF | 0 (LF preserved) |

The guard dogfood is the new discipline: I ran the identifier-regression guard (shipped this same wave in #7157) on my own cure *before* commit to prove I did not over-reach into code identifiers — the exact defect class that invalidated 6 other accents PRs this cycle.

## Honest disclosure

The notebook has a **pre-existing structural quirk** (papermill wrote `execution_count: null` + `outputs: []` on 12 markdown cells, making it nbformat-invalid). This is **unchanged** by this PR — verified byte-identical on `origin/main`. Fixing that structural issue is out of #2876 scope (would be a separate subject). My diff touches only markdown `source` text.

## R6

Family rotation: SemanticWeb (c.601) → IIT (c.603) → Search (c.604) → **Sudoku (c.606)**. Genres rotated c.605 (tooling #7157) → c.606 (accent cure). 1 accent/lane/jour cap honored (18/07 reset).

## Issues

`See #2876` (partial delivery, markdown-only STRICT scope — ai-01 adjudication 17/07).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
