### PR TITLE
fix(sudoku,#2876): restore FR accents in Sudoku-18-Comparison-Python markdown (200 cures, 50 cells)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb
@@ -23,9 +23,9 @@
     "## Objectifs d'apprentissage\n",
     "\n",
     "A la fin de ce notebook, vous saurez :\n",
-    "1. Classifier les differentes approches de resolution de Sudoku par categorie (exacte, heuristique, propagation, apprentissage)\n",
-    "2. Comparer objectivement les performances de 4 solveurs Python sur des puzzles de difficulte variee\n",
-    "3. Analyser les forces et faiblesses de chaque approche selon plusieurs criteres (vitesse, fiabilite, scalabilite, simplicite)\n",
+    "1. Classifier les différentes approches de résolution de Sudoku par categorie (exacte, heuristique, propagation, apprentissage)\n",
+    "2. Comparer objectivement les performances de 4 solveurs Python sur des puzzles de difficulté variee\n",
+    "3. Analyser les forces et faiblesses de chaque approche selon plusieurs critères (vitesse, fiabilite, scalabilite, simplicite)\n",
     "4. Choisir le bon solveur en fonction du contexte d'utilisation\n",
     "\n",
     "### Prerequis\n",
@@ -51,21 +51,21 @@
    "source": [
     "## 1. Introduction\n",
     "\n",
-    "Au fil de cette serie de notebooks, nous avons explore **9 approches differentes** pour resoudre le Sudoku. Chacune incarne une philosophie algorithmique distincte :\n",
+    "Au fil de cette serie de notebooks, nous avons explore **9 approches différentes** pour résoudre le Sudoku. Chacune incarne une philosophie algorithmique distincte :\n",
     "\n",
     "| # | Notebook | Approche | Philosophie |\n",
     "|---|----------|----------|-------------|\n",
-    "| 1 | [Backtracking](Sudoku-1-Backtracking-Python.ipynb) | Recherche exhaustive | Explorer systematiquement toutes les possibilites |\n",
+    "| 1 | [Backtracking](Sudoku-1-Backtracking-Python.ipynb) | Recherche exhaustive | Explorer systématiquement toutes les possibilites |\n",
     "| 2 | [Genetic](Sudoku-3-Genetic-Python.ipynb) | Metaheuristique | Faire evoluer une population de solutions candidates |\n",
     "| 3 | [OR-Tools](Sudoku-10-ORTools-Python.ipynb) | Programmation par contraintes | Declarer les contraintes, laisser le solveur chercher |\n",
     "| 4 | [Z3](Sudoku-12-Z3-Python.ipynb) | Satisfiabilite (SMT) | Prouver l'existence d'une solution satisfaisant des formules logiques |\n",
-    "| 5 | [Dancing Links](Sudoku-2-DancingLinks-Python.ipynb) | Couverture exacte | Reduire a un probleme de selection de sous-ensembles |\n",
-    "| 6 | [Infer.NET](Sudoku-15-Infer-Python.ipynb) | Inference probabiliste | Propager des distributions de probabilite |\n",
+    "| 5 | [Dancing Links](Sudoku-2-DancingLinks-Python.ipynb) | Couverture exacte | Reduire a un problème de selection de sous-ensembles |\n",
+    "| 6 | [Infer.NET](Sudoku-15-Infer-Python.ipynb) | Inference probabiliste | Propager des distributions de probabilité |\n",
     "| 7 | [Norvig](Sudoku-7-Norvig-Python.ipynb) | Propagation de contraintes | Eliminer les impossibilites avant de chercher |\n",
-    "| 8 | Simulated Annealing | Recuit simule | Optimiser par perturbations aleatoires avec refroidissement |\n",
-    "| 10 | Neural Network | Apprentissage profond | Apprendre les motifs de resolution a partir d'exemples |\n",
+    "| 8 | Simulated Annealing | Recuit simule | Optimiser par perturbations aléatoires avec refroidissement |\n",
+    "| 10 | Neural Network | Apprentissage profond | Apprendre les motifs de résolution a partir d'exemples |\n",
     "\n",
-    "Ce notebook final propose une **comparaison systematique** de ces approches selon plusieurs dimensions : vitesse, fiabilite, elegance du code et scalabilite. Nous implementerons 4 solveurs Python representatifs et les testerons sur un benchmark commun."
+    "Ce notebook final propose une **comparaison systématique** de ces approches selon plusieurs dimensions : vitesse, fiabilite, elegance du code et scalabilite. Nous implementerons 4 solveurs Python représentatifs et les testerons sur un benchmark commun."
    ]
   },
   {
@@ -155,14 +155,14 @@
     "| numpy | 2.4.2 | Calculs numeriques, statistiques (medianne, moyennes) |\n",
     "| matplotlib | - | Visualisations (barres, boxplots, radar) |\n",
     "| ortools | - | Solveur CP-SAT industriel (4e solveur du benchmark) |\n",
-    "| time | - | Mesure des temps d'execution |\n",
+    "| time | - | Mesure des temps d'exécution |\n",
     "\n",
     "**Pourquoi ces choix** :\n",
-    "- **OR-Tools CP-SAT** est le seul solveur externe necessaire. Les trois autres solveurs sont implementes en Python pur pour illustrer les algorithmes\n",
+    "- **OR-Tools CP-SAT** est le seul solveur externe nécessaire. Les trois autrès solveurs sont implementes en Python pur pour illustrer les algorithmes\n",
     "- **numpy** est utilise pour les statistiques du benchmark (medianne des temps)\n",
-    "- **matplotlib** genere les graphiques comparatifs (barres, boxplots, radar)\n",
+    "- **matplotlib** génère les graphiques comparatifs (barres, boxplots, radar)\n",
     "\n",
-    "> **Note** : Aucune dependance lourde (pas de tensorflow, pytorch, etc.). Ce notebook reste leger et s'execute sur n'importe quel environnement Python standard."
+    "> **Note** : Aucune dependance lourde (pas de tensorflow, pytorch, etc.). Ce notebook reste léger et s'exécute sur n'importe quel environnement Python standard."
    ]
   },
   {
@@ -185,13 +185,13 @@
     "\n",
     "### 2.1 Methodes exactes (garantie de solution)\n",
     "\n",
-    "Ces methodes explorent l'espace de recherche de maniere systematique et **trouvent toujours une solution** si elle existe.\n",
+    "Ces methodes explorent l'espace de recherche de manière systématique et **trouvent toujours une solution** si elle existe.\n",
     "\n",
     "| Methode | Principe | Complexite pratique | Notebook |\n",
     "|---------|----------|---------------------|----------|\n",
     "| **Backtracking** | DFS + validation | Rapide (facile), lent (difficile) | [Sudoku-1](Sudoku-1-Backtracking-Python.ipynb) |\n",
-    "| **Backtracking + MRV** | DFS + heuristique MRV | Rapide meme sur puzzles difficiles | [Sudoku-Python-BT](Sudoku-1-Backtracking-Python.ipynb) |\n",
-    "| **Dancing Links** | Couverture exacte (Algorithm X) | Optimal pour les problemes de couverture | [Sudoku-5](Sudoku-2-DancingLinks-Python.ipynb) |\n",
+    "| **Backtracking + MRV** | DFS + heuristique MRV | Rapide même sur puzzles difficiles | [Sudoku-Python-BT](Sudoku-1-Backtracking-Python.ipynb) |\n",
+    "| **Dancing Links** | Couverture exacte (Algorithm X) | Optimal pour les problèmes de couverture | [Sudoku-5](Sudoku-2-DancingLinks-Python.ipynb) |\n",
     "| **OR-Tools CP-SAT** | CP + SAT + CDCL | Tres rapide, constant | [Sudoku-3](Sudoku-10-ORTools-Python.ipynb) |\n",
     "| **Z3 SMT** | Satisfiabilite Modulo Theories | Rapide, overhead d'initialisation | [Sudoku-4](Sudoku-12-Z3-Python.ipynb) |\n",
     "\n",
@@ -206,7 +206,7 @@
     "\n",
     "### 2.3 Methodes heuristiques (pas de garantie)\n",
     "\n",
-    "Ces methodes utilisent des **mecanismes d'optimisation stochastique** et ne garantissent pas de trouver une solution.\n",
+    "Ces methodes utilisent des **mécanismes d'optimisation stochastique** et ne garantissent pas de trouver une solution.\n",
     "\n",
     "| Methode | Principe | Fiabilite | Notebook |\n",
     "|---------|----------|-----------|----------|\n",
@@ -242,18 +242,18 @@
    "source": [
     "## 3. Implementations Python des solveurs\n",
     "\n",
-    "Pour une comparaison equitable, nous implementons **4 solveurs representatifs** dans le meme environnement Python. Chaque solveur represente une categorie differente.\n",
+    "Pour une comparaison equitable, nous implementons **4 solveurs représentatifs** dans le même environnement Python. Chaque solveur représente une categorie différente.\n",
     "\n",
     "| Solveur | Categorie | Pourquoi ce choix |\n",
     "|---------|-----------|-------------------|\n",
-    "| **Backtracking simple** | Recherche exhaustive | Baseline naive, reference de comparaison |\n",
+    "| **Backtracking simple** | Recherche exhaustive | Baseline naive, référence de comparaison |\n",
     "| **Backtracking + MRV** | Recherche avec heuristique | Amelioration classique, montre l'impact des heuristiques |\n",
     "| **Norvig (propagation)** | Propagation de contraintes | Approche elegante, souvent suffisante sans recherche |\n",
-    "| **OR-Tools CP-SAT** | Solveur industriel | Etat de l'art, reference de performance |\n",
+    "| **OR-Tools CP-SAT** | Solveur industriel | Etat de l'art, référence de performance |\n",
     "\n",
     "### Classe SudokuGrid commune\n",
     "\n",
-    "Tous les solveurs utilisent la meme representation de grille pour garantir une comparaison equitable."
+    "Tous les solveurs utilisent la même représentation de grille pour garantir une comparaison equitable."
    ]
   },
   {
@@ -383,24 +383,24 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : Classe SudokuGrid - Representation commune\n",
+    "### Interpretation : Classe SudokuGrid - Représentation commune\n",
     "\n",
     "**Fonctionnalites de la classe** :\n",
     "\n",
     "| Methode | Role | Utilite pour les solveurs |\n",
     "|---------|------|--------------------------|\n",
-    "| `from_string` | Cree une grille depuis 81 caracteres | Format universel pour les benchmarks |\n",
+    "| `from_string` | Cree une grille depuis 81 caractères | Format universel pour les benchmarks |\n",
     "| `clone` | Copie independante | Evite les interferences entre solveurs |\n",
     "| `is_valid_placement` | Valide un placement (ligne/colonne/bloc) | Utilisee par le backtracking |\n",
     "| `find_empty` | Trouve la premiere case vide | Parcours naive pour le backtracking simple |\n",
-    "| `count_empty` | Compte les cases vides | Metrique de difficulte |\n",
+    "| `count_empty` | Compte les cases vides | Metrique de difficulté |\n",
     "| `to_string` | Convertit en chaine | Interface avec le solveur Norvig |\n",
     "\n",
-    "**Grille de test** : 49 cases vides sur 81 (60% de la grille). C'est un puzzle de difficulte moyenne-facile qui servira de validation rapide pour chaque solveur.\n",
+    "**Grille de test** : 49 cases vides sur 81 (60% de la grille). C'est un puzzle de difficulté moyenne-facile qui servira de validation rapide pour chaque solveur.\n",
     "\n",
-    "**Design choisi** : La classe est volontairement simple (liste de listes 9x9) pour ne pas avantager un solveur particulier. Le solveur Norvig utilise sa propre representation interne (dictionnaire de chaines) mais convertit vers/depuis SudokuGrid pour l'interface.\n",
+    "**Design choisi** : La classe est volontairement simple (liste de listes 9x9) pour ne pas avantager un solveur particulier. Le solveur Norvig utilise sa propre représentation interne (dictionnaire de chaines) mais convertit vers/depuis SudokuGrid pour l'interface.\n",
     "\n",
-    "> **Point architecture** : Tous les solveurs implementent la meme interface `solve(grid: SudokuGrid) -> bool`, ce qui permet de les comparer equitablement et de les utiliser de maniere interchangeable dans le benchmark."
+    "> **Point architecture** : Tous les solveurs implementent la même interface `solve(grid: SudokuGrid) -> bool`, ce qui permet de les comparer equitablement et de les utiliser de manière interchangeable dans le benchmark."
    ]
   },
   {
@@ -518,9 +518,9 @@
     "\n",
     "2. **Pourquoi ce sera lent sur les puzzles difficiles** : Sans heuristique, le solveur essaie les cases dans l'ordre (ligne par ligne, de gauche a droite) avec les valeurs 1 a 9. Sur un puzzle difficile avec 60+ cases vides, l'arbre de recherche peut atteindre des milliards de noeuds.\n",
     "\n",
-    "3. **Role de baseline** : Ce solveur sert de reference pour mesurer l'impact des ameliorations. Toute optimisation (MRV, propagation, etc.) sera comparee a cette baseline.\n",
+    "3. **Role de baseline** : Ce solveur sert de référence pour mesurer l'impact des améliorations. Toute optimisation (MRV, propagation, etc.) sera comparee a cette baseline.\n",
     "\n",
-    "> **Comparaison a venir** : Le solveur MRV suivant fera seulement 50 appels sur ce meme puzzle -- deja 4x moins. La difference sera beaucoup plus marquee sur les puzzles Medium et Hard."
+    "> **Comparaison a venir** : Le solveur MRV suivant fera seulement 50 appels sur ce même puzzle -- deja 4x moins. La difference sera beaucoup plus marquee sur les puzzles Medium et Hard."
    ]
   },
   {
@@ -541,7 +541,7 @@
     "\n",
     "### Enonce\n",
     "\n",
-    "Le solveur Backtracking simple essaie les valeurs 1-9 sequentiellement. Mais avant de lancer le backtracking, on peut **propager** les deductions evidentes : les cases qui n'ont qu'un seul candidat possible.\n",
+    "Le solveur Backtracking simple essaie les valeurs 1-9 séquentiellement. Mais avant de lancer le backtracking, on peut **propager** les deductions evidentes : les cases qui n'ont qu'un seul candidat possible.\n",
     "\n",
     "Implementez `propagate_naked_singles(grid)` qui remplit recursivement toutes les cases ayant exactement 1 candidat, jusqu'a ce qu'aucune propagation ne soit possible.\n",
     "\n",
@@ -649,7 +649,7 @@
     "\n",
     "L'heuristique **MRV** (Minimum Remaining Values) selectionne toujours la case ayant le **moins de valeurs possibles**. Cela detecte les impasses plus tot et reduit drastiquement l'arbre de recherche.\n",
     "\n",
-    "L'amelioration est souvent spectaculaire : de 100x a 1000x moins d'appels recursifs sur les puzzles difficiles."
+    "L'amélioration est souvent spectaculaire : de 100x a 1000x moins d'appels recursifs sur les puzzles difficiles."
    ]
   },
   {
@@ -769,13 +769,13 @@
     "\n",
     "**Paradoxe apparent** : MRV fait moins d'appels mais prend plus de temps. Cela s'explique par le cout de l'heuristique :\n",
     "\n",
-    "- **Backtracking simple** : Chaque appel est tres rapide (trouver la premiere case vide, essayer 1-9)\n",
+    "- **Backtracking simple** : Chaque appel est très rapide (trouver la premiere case vide, essayer 1-9)\n",
     "- **BT + MRV** : Chaque appel necessite de calculer les candidats de toutes les cases vides et de trouver celle avec le minimum\n",
     "\n",
-    "**Pourquoi MRV est quand meme preferable** :\n",
+    "**Pourquoi MRV est quand même préférable** :\n",
     "1. Sur les puzzles faciles, la difference de temps est negligeable (millisecondes)\n",
     "2. Sur les puzzles difficiles, MRV reduit l'arbre de recherche de plusieurs ordres de grandeur\n",
-    "3. Le surcout par appel est constant, mais le nombre d'appels evites croit exponentiellement avec la difficulte\n",
+    "3. Le surcout par appel est constant, mais le nombre d'appels evites croit exponentiellement avec la difficulté\n",
     "\n",
     "> **Principe MRV** : Toujours choisir la variable la plus contrainte (\"fail-first\"). En traitant d'abord les cases avec peu de candidats, on detecte les impasses plus tot et on evite d'explorer des sous-arbres inutiles."
    ]
@@ -796,9 +796,9 @@
    "source": [
     "### 3.3 Solveur 3 : Propagation de contraintes (Norvig)\n",
     "\n",
-    "L'approche de Peter Norvig combine deux strategies de propagation :\n",
+    "L'approche de Peter Norvig combine deux stratégies de propagation :\n",
     "\n",
-    "1. **Elimination** : quand une case recoit une valeur, on retire cette valeur des candidats de tous ses voisins (meme ligne, colonne, bloc)\n",
+    "1. **Elimination** : quand une case recoit une valeur, on retire cette valeur des candidats de tous ses voisins (même ligne, colonne, bloc)\n",
     "2. **Naked single** : quand une valeur n'a qu'un seul emplacement possible dans une unite, on l'y assigne\n",
     "\n",
     "Si la propagation seule ne suffit pas, un **backtracking avec MRV** prend le relais. En pratique, la propagation resout la majorite des puzzles faciles/moyens sans aucune recherche."
@@ -961,21 +961,21 @@
     "\n",
     "| Metrique | Valeur | Observation |\n",
     "|----------|--------|-------------|\n",
-    "| Appels recursifs | 1 | Aucune recherche necessaire |\n",
+    "| Appels recursifs | 1 | Aucune recherche nécessaire |\n",
     "| Temps | 2.34 ms | Le plus rapide sur ce puzzle |\n",
     "\n",
     "**Pourquoi un seul appel ?**\n",
     "\n",
-    "La propagation de contraintes (elimination + naked singles) a entierement resolu le puzzle sans qu'aucun backtracking ne soit necessaire. C'est le cas pour la plupart des puzzles faciles/moyens.\n",
+    "La propagation de contraintes (elimination + naked singles) a entierement résolu le puzzle sans qu'aucun backtracking ne soit nécessaire. C'est le cas pour la plupart des puzzles faciles/moyens.\n",
     "\n",
     "**Mecanismes de propagation** :\n",
     "1. **Elimination** : Quand une valeur est assignee a une case, elle est retiree des candidats de tous ses voisins (ligne, colonne, bloc)\n",
     "2. **Naked single** : Si une valeur ne peut aller que dans une seule case d'une unite, on l'y assigne\n",
-    "3. **Cascade** : Chaque assignation declenche une nouvelle propagation, qui peut elle-meme declencher d'autres assignations\n",
+    "3. **Cascade** : Chaque assignation declenche une nouvelle propagation, qui peut elle-même declencher d'autrès assignations\n",
     "\n",
-    "**Comparaison avec le backtracking** : Le solveur simple a necessite 201 appels recursifs pour le meme puzzle. Norvig atteint la meme solution en un seul appel grace a la propagation qui elimine les branches inutiles avant meme de les explorer.\n",
+    "**Comparaison avec le backtracking** : Le solveur simple a necessite 201 appels recursifs pour le même puzzle. Norvig atteint la même solution en un seul appel grâce a la propagation qui elimine les branches inutiles avant même de les explorer.\n",
     "\n",
-    "> **Point cle** : La force de Norvig n'est pas la vitesse pure, mais la capacite a resoudre sans recherche. Sur des puzzles plus difficiles, le backtracking MRV prend le relais avec un espace de recherche deja drastiquement reduit."
+    "> **Point cle** : La force de Norvig n'est pas la vitesse pure, mais la capacite a résoudre sans recherche. Sur des puzzles plus difficiles, le backtracking MRV prend le relais avec un espace de recherche deja drastiquement reduit."
    ]
   },
   {
@@ -1000,7 +1000,7 @@
     "- 81 variables entieres dans {1..9}\n",
     "- 27 contraintes `AllDifferent` (9 lignes + 9 colonnes + 9 blocs)\n",
     "\n",
-    "C'est l'approche la plus concise et generalement la plus performante."
+    "C'est l'approche la plus concise et généralement la plus performante."
    ]
   },
   {
@@ -1104,7 +1104,7 @@
    "source": [
     "### Interpretation : Solveur OR-Tools CP-SAT\n",
     "\n",
-    "**Resultat** : OR-Tools resout le puzzle en 63.21 ms avec succes.\n",
+    "**Resultat** : OR-Tools resout le puzzle en 63.21 ms avec succès.\n",
     "\n",
     "| Metrique | Valeur | Observation |\n",
     "|----------|--------|-------------|\n",
@@ -1115,11 +1115,11 @@
     "\n",
     "1. **Overhead de modelisation** : Le temps inclut la construction du modele (81 variables, 27 contraintes AllDifferent) et l'initialisation du solveur. Pour un seul puzzle, cet overhead est significatif.\n",
     "\n",
-    "2. **Avantage sur les grands problemes** : Contrairement aux solveurs Python purs, OR-Tools est compile en C++ et optimise pour des problemes avec des milliers de variables. Le temps de resolution reste quasi-constant quelle que soit la difficulte du puzzle.\n",
+    "2. **Avantage sur les grands problèmes** : Contrairement aux solveurs Python purs, OR-Tools est compile en C++ et optimise pour des problèmes avec des milliers de variables. Le temps de résolution reste quasi-constant quelle que soit la difficulté du puzzle.\n",
     "\n",
     "3. **Declaratif vs imperatif** : Le code ne contient **aucune logique de recherche** -- on declare les contraintes et le solveur trouve la solution. C'est l'approche la plus concise (~15 lignes utiles).\n",
     "\n",
-    "> **Quand utiliser OR-Tools** : Quand la robustesse et la previsibilite sont plus importantes que la vitesse brute, ou quand le probleme est trop complexe pour un solveur maison."
+    "> **Quand utiliser OR-Tools** : Quand la robustesse et la previsibilite sont plus importantes que la vitesse brute, ou quand le problème est trop complexe pour un solveur maison."
    ]
   },
   {
@@ -1140,13 +1140,13 @@
     "\n",
     "### Enonce\n",
     "\n",
-    "Un Sudoku bien pose possede exactement **une** solution. Avec OR-Tools CP-SAT, on peut le verifier en cherchant une deuxieme solution. Implementez `has_unique_solution(grid)` qui retourne True si le puzzle a exactement 1 solution.\n",
+    "Un Sudoku bien pose possede exactement **une** solution. Avec OR-Tools CP-SAT, on peut le vérifier en cherchant une deuxieme solution. Implementez `has_unique_solution(grid)` qui retourne True si le puzzle a exactement 1 solution.\n",
     "\n",
     "### Indices\n",
     "\n",
     "- Etape 1 : Modelisez le Sudoku comme dans `ORToolsCPSATSolver` (variables 1-9, allDifferent)\n",
     "- Etape 2 : Appelez `solver.solve(model)` une premiere fois\n",
-    "- Etape 3 : Si solution trouvee, ajoutez une contrainte interdisant cette solution (au moins une case differente)\n",
+    "- Etape 3 : Si solution trouvee, ajoutez une contrainte interdisant cette solution (au moins une case différente)\n",
     "- Etape 4 : Appelez `solver.solve(model)` a nouveau. Si pas de solution = unique\n"
    ]
   },
@@ -1238,7 +1238,7 @@
    "source": [
     "## 4. Benchmark\n",
     "\n",
-    "Nous testons les 4 solveurs sur **4 niveaux de difficulte** avec 10 puzzles chacun. Tous les puzzles sont codes en dur ci-dessous pour garantir la reproductibilite (pas de dependance a des fichiers externes).\n",
+    "Nous testons les 4 solveurs sur **4 niveaux de difficulté** avec 10 puzzles chacun. Tous les puzzles sont codes en dur ci-dessous pour garantir la reproductibilite (pas de dependance a des fichiers externes).\n",
     "\n",
     "### Jeux de test\n",
     "\n",
@@ -1246,7 +1246,7 @@
     "|------------|------------------|-----------------------|\n",
     "| **Easy** | Beaucoup d'indices, propagation simple suffit | ~35-45 |\n",
     "| **Medium** | Indices reduits, necessite un peu de recherche | ~45-55 |\n",
-    "| **Hard** | Tres peu d'indices, cas extremes connus | ~55-60 |\n",
+    "| **Hard** | Tres peu d'indices, cas extrêmes connus | ~55-60 |\n",
     "| **Expert** | Regime 17-24 indices : les solveurs exacts (backtracking) timeout, les metaheuristiques (recuit simule, genetique) n'ont aucune garantie de convergence | ~57-64 |"
    ]
   },
@@ -1377,11 +1377,11 @@
     "\n",
     "**Observation contre-intuitive** : Les puzzles Medium ont en moyenne **plus de cases vides** (64) que les puzzles Hard (56.5). Cela s'explique par la provenance des donnees :\n",
     "\n",
-    "- **Easy** : Grilles classiques avec beaucoup d'indices, la propagation suffit generalement\n",
+    "- **Easy** : Grilles classiques avec beaucoup d'indices, la propagation suffit généralement\n",
     "- **Medium** : Puzzles \"top95\" avec peu d'indices (presque toutes les cases vides), ce qui crée un espace de recherche immense\n",
-    "- **Hard** : Puzzles \"hardest\" connus pour leur difficulte logique, mais qui ont parfois plus d'indices que les Medium\n",
+    "- **Hard** : Puzzles \"hardest\" connus pour leur difficulté logique, mais qui ont parfois plus d'indices que les Medium\n",
     "\n",
-    "> **Lecon** : La difficulte algorithmique ne depend pas seulement du nombre de cases vides, mais surtout de la **structure des contraintes**. Un puzzle avec 53 cases vides bien placees peut etre plus resistant qu'un puzzle avec 64 cases vides mal reparties."
+    "> **Lecon** : La difficulté algorithmique ne depend pas seulement du nombre de cases vides, mais surtout de la **structure des contraintes**. Un puzzle avec 53 cases vides bien placees peut etre plus resistant qu'un puzzle avec 64 cases vides mal reparties."
    ]
   },
   {
@@ -1400,7 +1400,7 @@
    "source": [
     "### Execution du benchmark\n",
     "\n",
-    "La fonction `run_benchmark` teste chaque solveur sur chaque ensemble de puzzles et collecte les temps de resolution et le taux de succes. Chaque puzzle est resolu sur une **copie** de la grille pour eviter toute interference entre solveurs."
+    "La fonction `run_benchmark` teste chaque solveur sur chaque ensemble de puzzles et collecte les temps de résolution et le taux de succès. Chaque puzzle est résolu sur une **copie** de la grille pour eviter toute interference entre solveurs."
    ]
   },
   {
@@ -1469,7 +1469,7 @@
    "source": [
     "### Configuration du benchmark\n",
     "\n",
-    "Les 4 solveurs et 3 niveaux de difficulte sont organises en dictionnaires pour permettre une iteration systematique. La fonction `run_benchmark` definie ci-dessous encapsule la logique de test avec gestion des timeouts."
+    "Les 4 solveurs et 3 niveaux de difficulté sont organises en dictionnaires pour permettre une iteration systématique. La fonction `run_benchmark` définie ci-dessous encapsule la logique de test avec gestion des timeouts."
    ]
   },
   {
@@ -1559,7 +1559,7 @@
    "source": [
     "### Lancement du benchmark\n",
     "\n",
-    "Nous executons le benchmark avec un timeout de 30 secondes par puzzle pour eviter que le backtracking simple ne bloque indefiniment sur les puzzles difficiles."
+    "Nous executons le benchmark avec un timeout de 30 secondes par puzzle pour eviter que le backtracking simple ne bloque indéfiniment sur les puzzles difficiles."
    ]
   },
   {
@@ -1619,11 +1619,11 @@
     "tags": []
    },
    "source": [
-    "### Tableau recapitulatif des resultats\n",
+    "### Tableau recapitulatif des résultats\n",
     "\n",
-    "Affichons les resultats sous forme de tableau synthetique, puis sous forme graphique.\n",
+    "Affichons les résultats sous forme de tableau synthetique, puis sous forme graphique.\n",
     "\n",
-    "> **Note** : Le benchmark utilise 1 puzzle par niveau de difficulte avec un timeout de 30s par puzzle pour garantir une execution rapide tout en montrant les differences de performance entre solveurs."
+    "> **Note** : Le benchmark utilise 1 puzzle par niveau de difficulté avec un timeout de 30s par puzzle pour garantir une exécution rapide tout en montrant les differences de performance entre solveurs."
    ]
   },
   {
@@ -1725,8 +1725,8 @@
     "le nombre de cases vides dans un puzzle (de 30 a 55 cases vides).\n",
     "\n",
     "**Indice**\n",
-    "Partez d'un puzzle resolu et supprimez aleatoirement un nombre croissant de valeurs.\n",
-    "Mesurez le temps de resolution pour chaque niveau de difficulte artificielle.\n"
+    "Partez d'un puzzle résolu et supprimez aléatoirement un nombre croissant de valeurs.\n",
+    "Mesurez le temps de résolution pour chaque niveau de difficulté artificielle.\n"
    ]
   },
   {
@@ -1777,15 +1777,15 @@
     "\n",
     "**Resultats cles du tableau** :\n",
     "\n",
-    "1. **Backtracking simple** echoue sur le puzzle Medium (timeout : 58770 ms) mais resout Easy (1.87 ms) et Hard (1862 ms) -- 2/3 resolus. Sans heuristique, l'arbre de recherche explose quand le nombre de cases vides depasse ~60.\n",
+    "1. **Backtracking simple** echoue sur le puzzle Medium (timeout : 58770 ms) mais resout Easy (1.87 ms) et Hard (1862 ms) -- 2/3 résolus. Sans heuristique, l'arbre de recherche explose quand le nombre de cases vides depasse ~60.\n",
     "\n",
-    "2. **BT + MRV** resout les 3 puzzles (3/3), y compris le Medium en 37.58 ms la ou le backtracking simple explose. L'heuristique MRV aide enormement, mais reste plus lent que la propagation (313 ms sur le puzzle Hard).\n",
+    "2. **BT + MRV** resout les 3 puzzles (3/3), y compris le Medium en 37.58 ms la ou le backtracking simple explose. L'heuristique MRV aide enormêment, mais reste plus lent que la propagation (313 ms sur le puzzle Hard).\n",
     "\n",
-    "3. **Norvig** est le champion absolu : 3/3 resolus, avec un temps moyen global de 3.25 ms/puzzle. La propagation de contraintes elimine la quasi-totalite de l'exploration.\n",
+    "3. **Norvig** est le champion absolu : 3/3 résolus, avec un temps moyen global de 3.25 ms/puzzle. La propagation de contraintes elimine la quasi-totalite de l'exploration.\n",
     "\n",
-    "4. **OR-Tools CP-SAT** est egalement 3/3 fiable a ~22 ms/puzzle (21.65). Legerement plus lent que Norvig sur ce probleme en raison de l'overhead de construction du modele, mais plus robuste a la mise a l'echelle.\n",
+    "4. **OR-Tools CP-SAT** est egalement 3/3 fiable a ~22 ms/puzzle (21.65). Legerement plus lent que Norvig sur ce problème en raison de l'overhead de construction du modele, mais plus robuste a la mise a l'échelle.\n",
     "\n",
-    "**Surprise** : Les puzzles Hard ne sont pas les plus lents pour le backtracking simple. Cela s'explique par le fait que la difficulte humaine (nombre de techniques logiques necessaires) ne correspond pas toujours a la difficulte algorithmique (taille de l'arbre de recherche)."
+    "**Surprise** : Les puzzles Hard ne sont pas les plus lents pour le backtracking simple. Cela s'explique par le fait que la difficulté humaine (nombre de techniques logiques nécessaires) ne correspond pas toujours a la difficulté algorithmique (taille de l'arbre de recherche)."
    ]
   },
   {
@@ -1802,9 +1802,9 @@
     "tags": []
    },
    "source": [
-    "### Visualisation : temps moyen par difficulte\n",
+    "### Visualisation : temps moyen par difficulté\n",
     "\n",
-    "Le graphique en barres groupees montre le temps moyen de resolution pour chaque solveur sur chaque niveau de difficulte. L'echelle logarithmique permet de comparer des ordres de grandeur tres differents."
+    "Le graphique en barres groupees montre le temps moyen de résolution pour chaque solveur sur chaque niveau de difficulté. L'échelle logarithmique permet de comparer des ordres de grandeur très différents."
    ]
   },
   {
@@ -1894,13 +1894,13 @@
    "source": [
     "### Interpretation : Ecarts de performance entre solveurs\n",
     "\n",
-    "Le graphique en barres (echelle logarithmique) rend compte de l'ampleur des differences :\n",
+    "Le graphique en barres (échelle logarithmique) rend compte de l'ampleur des differences :\n",
     "\n",
     "| Comparaison | Facteur | Observation |\n",
     "|-------------|---------|-------------|\n",
     "| BT simple vs Norvig | ~15000x sur Medium | L'absence d'heuristique coute jusqu'a 4 ordres de grandeur |\n",
     "| BT + MRV vs BT simple | ~1500x sur Medium | L'heuristique MRV seule apporte un gain massif |\n",
-    "| Norvig vs OR-Tools | ~7x | Performance comparable, Norvig legerement plus rapide sur Python pur |\n",
+    "| Norvig vs OR-Tools | ~7x | Performance comparable, Norvig légèrement plus rapide sur Python pur |\n",
     "\n",
     "**Point remarquable** : Les puzzles Medium sont les plus discriminants. Ils ont suffisamment de cases vides (64 en moyenne) pour pieger les solveurs naifs, mais restent solvables en un temps raisonnable pour tous les solveurs informes. Les puzzles Hard, paradoxalement, ne sont pas les plus lents car ils ont parfois moins de cases vides mais des contraintes plus serrees qui guident mieux la propagation."
    ]
@@ -1921,7 +1921,7 @@
    "source": [
     "### Visualisation : distribution des temps par solveur\n",
     "\n",
-    "Les boites a moustaches (boxplots) montrent la **variabilite** des temps de resolution. Un solveur avec une boite etroite est plus **previsible** dans ses performances."
+    "Les boites a moustaches (boxplots) montrent la **variabilite** des temps de résolution. Un solveur avec une boite etroite est plus **previsible** dans ses performances."
    ]
   },
   {
@@ -1997,16 +1997,16 @@
    "source": [
     "### Interpretation : Variabilite et previsibilite des solveurs\n",
     "\n",
-    "Les boxplots revelent un aspect crucial souvent neglige : la **previsibilite** des performances.\n",
+    "Les boxplots révèlent un aspect crucial souvent neglige : la **previsibilite** des performances.\n",
     "\n",
     "| Solveur | Variabilite | Explication |\n",
     "|---------|-------------|-------------|\n",
-    "| **Backtracking simple** | Tres forte | Certains puzzles faciles se resolvent en 1 ms, d'autres en 200+ secondes |\n",
+    "| **Backtracking simple** | Tres forte | Certains puzzles faciles se resolvent en 1 ms, d'autrès en 200+ secondes |\n",
     "| **BT + MRV** | Forte | L'heuristique reduit l'arbre mais reste sensible a la structure du puzzle |\n",
     "| **Norvig** | Tres faible | La propagation elimine la plupart de l'alea, temps quasi-constant |\n",
     "| **OR-Tools CP-SAT** | Negligeable | Le solveur industriel est optimise pour des performances predictibles |\n",
     "\n",
-    "**Lecon pratique** : Dans un contexte de production, la previsibilite est souvent plus importante que la vitesse moyenne. Un solveur qui resout 99% des puzzles en moins de 20 ms est preferable a un solveur qui resout 99.9% en 1 ms mais explose sur les 0.1% restants."
+    "**Lecon pratique** : Dans un contexte de production, la previsibilite est souvent plus importante que la vitesse moyenne. Un solveur qui resout 99% des puzzles en moins de 20 ms est préférable a un solveur qui resout 99.9% en 1 ms mais explose sur les 0.1% restants."
    ]
   },
   {
@@ -2023,17 +2023,17 @@
     "tags": []
    },
    "source": [
-    "### Visualisation : radar multi-criteres\n",
+    "### Visualisation : radar multi-critères\n",
     "\n",
     "Le graphique radar compare les solveurs sur **5 dimensions** qualitatives. Les scores sont normalises de 1 (faible) a 5 (excellent) pour permettre une vue d'ensemble.\n",
     "\n",
     "| Critere | Description |\n",
     "|---------|-------------|\n",
-    "| **Vitesse** | Temps de resolution moyen |\n",
-    "| **Fiabilite** | Taux de resolution sur tous les niveaux |\n",
-    "| **Scalabilite** | Robustesse face a la difficulte croissante |\n",
+    "| **Vitesse** | Temps de résolution moyen |\n",
+    "| **Fiabilite** | Taux de résolution sur tous les niveaux |\n",
+    "| **Scalabilite** | Robustesse face a la difficulté croissante |\n",
     "| **Simplicite** | Nombre de lignes de code, facilite de comprehension |\n",
-    "| **Generalite** | Capacite a s'adapter a d'autres problemes que le Sudoku |"
+    "| **Generalite** | Capacite a s'adapter a d'autrès problèmes que le Sudoku |"
    ]
   },
   {
@@ -2056,7 +2056,7 @@
     "\n",
     "### Principe du forward checking\n",
     "\n",
-    "Apres chaque assignation tentative dans le backtracking, on verifie immediatement que toutes les cases vides ont encore au moins un candidat valide. Si une case a un domaine vide, la branche est coupee sans appel recursif supplementaire.\n",
+    "Apres chaque assignation tentative dans le backtracking, on vérifie immédiatement que toutes les cases vides ont encore au moins un candidat valide. Si une case a un domaine vide, la branche est coupee sans appel recursif supplementaire.\n",
     "\n",
     "### Implementation\n",
     "\n",
@@ -2232,17 +2232,17 @@
    "source": [
     "### Exemple : Solveur metaheuristique (recuit simule)\n",
     "\n",
-    "Pour completer l'eventail des paradigmes, nous implementons un **sixime solveur** base sur le **recuit simule** (Simulated Annealing). Cette approche est particulierement interessante pour le regime Expert illustre par l'EPIC #3801 :\n",
+    "Pour complèter l'eventail des paradigmes, nous implementons un **sixime solveur** base sur le **recuit simule** (Simulated Annealing). Cette approche est particulièrement intéressante pour le regime Expert illustre par l'EPIC #3801 :\n",
     "\n",
     "- **Aucune garantie** de trouver la solution (c'est une metaheuristique stochastique)\n",
-    "- **Parametrable** par une temperature initiale et un facteur de refroidissement\n",
-    "- **Souvent rapide sur les premiers echelons**, mais peine sur les regimes tres contraints\n",
+    "- **Parametrable** par une température initiale et un facteur de refroidissement\n",
+    "- **Souvent rapide sur les premiers echelons**, mais peine sur les regimes très contraints\n",
     "\n",
     "L'objectif ici n'est PAS de battre Norvig/CP-SAT sur les puzzles faciles : c'est de demontrer concretement qu'une approche *sans garantie* se distingue d'une approche *avec garantie* sur le regime Expert -- le moteur est mis en valeur (il fait quelque chose qui distingue garanties vs heuristiques dans un cas non-trivial), pas contourne.\n",
     "\n",
     "### Implementation\n",
     "\n",
-    "Le solveur demarre par un **pre-remplissage structure** : chaque ligne est completee par une permutation aleatoire des chiffres qui lui manquent, de sorte que chaque ligne soit valide (permutation de 1..9) des le depart -- les conflits ne residuent plus que dans les colonnes et les blocs. Ensuite, a chaque pas, le solveur **echange (swap)** les valeurs de deux cases non-verrouillees prises dans une MEME ligne : ce move preserve la validite de la ligne, seuls les conflits de colonnes et de blocs peuvent changer. L'acceptation d'un move degradeur suit le critere de Metropolis (probabilite exp(-delta/T) qui decroit avec la \"temperature\" T). Le succes est obtenu quand le score (nombre de doublons sur les 9 colonnes et 9 blocs) tombe a 0.\n"
+    "Le solveur demarre par un **pre-remplissage structure** : chaque ligne est complètee par une permutation aléatoire des chiffres qui lui manquent, de sorte que chaque ligne soit valide (permutation de 1..9) des le depart -- les conflits ne residuent plus que dans les colonnes et les blocs. Ensuite, a chaque pas, le solveur **echange (swap)** les valeurs de deux cases non-verrouillees prises dans une MEME ligne : ce move preserve la validite de la ligne, seuls les conflits de colonnes et de blocs peuvent changer. L'acceptation d'un move degradeur suit le critère de Metropolis (probabilité exp(-delta/T) qui decroit avec la \"température\" T). Le succès est obtenu quand le score (nombre de doublons sur les 9 colonnes et 9 blocs) tombe a 0.\n"
    ]
   },
   {
@@ -2427,9 +2427,9 @@
     "**Pourquoi AC-3 est important** :\n",
     "1. C'est la base de nombreux solveurs CSP professionnels\n",
     "2. Il reduit les domaines de chaque variable en eliminant les valeurs impossibles\n",
-    "3. Combine avec le backtracking MRV, il forme un solveur tres competitif\n",
+    "3. Combine avec le backtracking MRV, il forme un solveur très competitif\n",
     "\n",
-    "**Performance attendue** : Un solveur BT + AC-3 bien implemente devrait se rapprocher des performances du solveur Norvig, puisque la propagation de Norvig est une variante simplifiee de la coherence d'arc. La difference principale est qu'AC-3 verifie explicitement chaque paire de contraintes, tandis que Norvig utilise des strategies de propagation plus ciblees (elimination + naked singles)."
+    "**Performance attendue** : Un solveur BT + AC-3 bien implemente devrait se rapprocher des performances du solveur Norvig, puisque la propagation de Norvig est une variante simplifiee de la coherence d'arc. La difference principale est qu'AC-3 vérifie explicitement chaque paire de contraintes, tandis que Norvig utilise des stratégies de propagation plus ciblees (elimination + naked singles)."
    ]
   },
   {
@@ -2448,7 +2448,7 @@
    "source": [
     "### Interpretation : Norvig + Forward Checking (Option B)\n",
     "\n",
-    "L'idee du **forward checking** : apres chaque assignation tentative dans le backtracking, on verifie immediatement que toutes les cases vides ont encore au moins un candidat. Si une case a un domaine vide, la branche est coupee sans appel recursif supplementaire.\n",
+    "L'idee du **forward checking** : apres chaque assignation tentative dans le backtracking, on vérifie immédiatement que toutes les cases vides ont encore au moins un candidat. Si une case a un domaine vide, la branche est coupee sans appel recursif supplementaire.\n",
     "\n",
     "**Ce que j'ai ajoute par rapport a Norvig standard** :\n",
     "- Une methode `_forward_check` qui parcourt toutes les cases et detecte les domaines vides\n",
@@ -2678,13 +2678,13 @@
     "\n",
     "**Explications** :\n",
     "\n",
-    "1. **Performances quasi identiques a Norvig**. Sur le puzzle de test, Norvig + FC resout en 2.39 ms (vs 2.34 ms pour Norvig pur), avec 0 coupe FC. Normal : la propagation `_eliminate` deja presente dans Norvig detecte les domaines vides a la source. Le forward check explicite ne coupe en pratique aucune branche additionnelle (`fc_cuts` = 0).\n",
+    "1. **Performances quasi identiques a Norvig**. Sur le puzzle de test, Norvig + FC resout en 2.39 ms (vs 2.34 ms pour Norvig pur), avec 0 coupe FC. Normal : la propagation `_eliminate` deja présente dans Norvig detecte les domaines vides a la source. Le forward check explicite ne coupe en pratique aucune branche additionnelle (`fc_cuts` = 0).\n",
     "\n",
-    "2. **Legere surcharge par appel**. Le forward check parcourt les 81 cases a chaque descente recursive, ce qui ajoute un cout lineaire par appel. Sur un puzzle ou peu de branches sont coupees, ce cout n'est pas amorti et on peut meme etre un peu plus lent que Norvig standard.\n",
+    "2. **Legere surcharge par appel**. Le forward check parcourt les 81 cases a chaque descente recursive, ce qui ajoute un cout lineaire par appel. Sur un puzzle ou peu de branches sont coupees, ce cout n'est pas amorti et on peut même etre un peu plus lent que Norvig standard.\n",
     "\n",
-    "3. **Ou le forward checking brille reellement**. Si on retirait la propagation puissante de Norvig (elimination + naked singles) et qu'on gardait uniquement un backtracking MRV + forward checking, l'impact du FC serait beaucoup plus visible : il servirait de principal mecanisme d'elagage. Ici, la propagation fait deja l'essentiel du travail.\n",
+    "3. **Ou le forward checking brille réellement**. Si on retirait la propagation puissante de Norvig (elimination + naked singles) et qu'on gardait uniquement un backtracking MRV + forward checking, l'impact du FC serait beaucoup plus visible : il servirait de principal mécanisme d'elagage. Ici, la propagation fait deja l'essentiel du travail.\n",
     "\n",
-    "**Conclusion** : Le forward checking est une **technique fondamentale** en CSP, mais son utilite depend du solveur dans lequel on l'integre. Sur un solveur deja fortement propage comme Norvig, il est redondant ; sur un backtracking naif, il apporte un gain enorme. C'est un bon exemple du principe **\"la somme des ameliorations n'est pas toujours additive\"** : certaines techniques se recouvrent.\n"
+    "**Conclusion** : Le forward checking est une **technique fondamentale** en CSP, mais son utilite depend du solveur dans lequel on l'integre. Sur un solveur deja fortement propage comme Norvig, il est redondant ; sur un backtracking naif, il apporte un gain enorme. C'est un bon exemple du principe **\"la somme des améliorations n'est pas toujours additive\"** : certaines techniques se recouvrent.\n"
    ]
   },
   {
@@ -2703,11 +2703,11 @@
    "source": [
     "## Exemple guide : Comparaison de Profils de Resolution\n",
     "\n",
-    "Dans cet exercice, vous allez analyser finement les comportements de resolution des differents solveurs pour comprendre **pourquoi** certains sont plus efficaces que d'autres.\n",
+    "Dans cet exercice, vous allez analyser finement les comportements de résolution des différents solveurs pour comprendre **pourquoi** certains sont plus efficaces que d'autrès.\n",
     "\n",
     "### Objectif\n",
     "\n",
-    "Implementer un outil de profilage qui mesure, pour chaque solveur et chaque puzzle, non seulement le temps de resolution, mais aussi le **nombre d'operations effectuees** (appels recursifs, eliminations, propagations).\n",
+    "Implementer un outil de profilage qui mesure, pour chaque solveur et chaque puzzle, non seulement le temps de résolution, mais aussi le **nombre d'operations effectuees** (appels recursifs, eliminations, propagations).\n",
     "\n",
     "### Travaux demandes\n",
     "\n",
@@ -2719,19 +2719,19 @@
     "\n",
     "2. **Completer la fonction `profile_solver(solver, grid)`** (scaffold fourni ci-dessous) qui :\n",
     "   - Resout le puzzle en mesurant le temps avec `time.perf_counter()`\n",
-    "   - Retourne un dictionnaire `{\"time_ms\": ..., \"operations\": ..., \"success\": ...}`\n",
+    "   - Retourne un dictionnaire `{\"time_ms\": ..., \"operations\": ..., \"succèss\": ...}`\n",
     "\n",
-    "3. **Lancer un profilage sur 5 puzzles de chaque niveau** (Easy, Medium, Hard) et stocker les resultats dans une structure de donnees appropriee (la boucle est esquissee ci-dessous)\n",
+    "3. **Lancer un profilage sur 5 puzzles de chaque niveau** (Easy, Medium, Hard) et stocker les résultats dans une structure de donnees appropriee (la boucle est esquissee ci-dessous)\n",
     "\n",
     "4. **Completer la visualisation comparative** :\n",
     "   - Un scatter plot : temps (x) vs operations (y), un point par solveur/puzzle\n",
-    "   - Colorer les points par niveau de difficulte (Easy=vert, Medium=orange, Hard=rouge)\n",
+    "   - Colorer les points par niveau de difficulté (Easy=vert, Medium=orange, Hard=rouge)\n",
     "   - Ajouter une legende et des labels clairs (squelette fourni)\n",
     "\n",
-    "5. **Analyser et interpreter** :\n",
+    "5. **Analyser et interprèter** :\n",
     "   - Quels solveurs ont le meilleur ratio temps/operations ?\n",
-    "   - Y a-t-il des puzzles ou un solveur \"explose\" en operations meme s'il est rapide ?\n",
-    "   - Le nombre d'operations est-il un bon predicteur du temps de resolution ?\n",
+    "   - Y a-t-il des puzzles ou un solveur \"explose\" en operations même s'il est rapide ?\n",
+    "   - Le nombre d'operations est-il un bon predicteur du temps de résolution ?\n",
     "\n",
     "**Indice pour le comptage des eliminations Norvig :**\n",
     "\n",
@@ -2739,7 +2739,7 @@
     "\n",
     "### Resultat attendu\n",
     "\n",
-    "Un notebook avec un scatter plot montrant la correlation (ou l'absence de correlation) entre le nombre d'operations et le temps de resolution, accompagne d'une interpretation en 3-4 paragraphes.\n"
+    "Un notebook avec un scatter plot montrant la correlation (ou l'absence de correlation) entre le nombre d'operations et le temps de résolution, accompagne d'une interpretation en 3-4 paragraphes.\n"
    ]
   },
   {
@@ -2896,7 +2896,7 @@
     "### Execution du profilage\n",
     "\n",
     "Utilisez `profile_solver` pour tester chaque solveur sur 5 puzzles de chaque niveau.\n",
-    "La structure de la boucle est esquissee ci-dessous -- completez les parties manquantes.\n",
+    "La structure de la boucle est esquissee ci-dessous -- complètez les parties manquantes.\n",
     "\n",
     "**Attention** : le solveur Backtracking peut mettre plus de 30s sur les puzzles Medium.\n",
     "Pour un premier test, commencez avec `max_puzzles=2` et augmentez ensuite.\n"
@@ -2983,7 +2983,7 @@
     "\n",
     "Completez le scatter plot ci-dessous pour afficher le temps (axe x) vs le nombre\n",
     "d'operations (axe y) pour chaque solveur/puzzle. Utilisez une couleur par niveau de\n",
-    "difficulte et une echelle logarithmique sur les deux axes.\n"
+    "difficulté et une échelle logarithmique sur les deux axes.\n"
    ]
   },
   {
@@ -3063,7 +3063,7 @@
     "   en operations malgre un temps raisonnable ? Que cela indique-t-il ?\n",
     "\n",
     "3. **Predictibilite** : Le nombre d'operations est-il un bon predicteur du\n",
-    "   temps de resolution ? Pourquoi ou pourquoi pas ?\n",
+    "   temps de résolution ? Pourquoi ou pourquoi pas ?\n",
     "\n",
     "*Votre reponse :*\n"
    ]
@@ -3084,13 +3084,13 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "Ce notebook a compare **4 solveurs Python** representatifs de paradigmes algorithmiques distincts pour la resolution du Sudoku.\n",
+    "Ce notebook a compare **4 solveurs Python** représentatifs de paradigmes algorithmiques distincts pour la résolution du Sudoku.\n",
     "\n",
     "### Concepts cles a retenir\n",
     "\n",
     "| Concept | Solveur(s) concerne(s) | Idee principale |\n",
     "|---------|----------------------|-----------------|\n",
-    "| Recherche exhaustive | Backtracking simple | Explorer systematiquement l'arbre des possibilites |\n",
+    "| Recherche exhaustive | Backtracking simple | Explorer systématiquement l'arbre des possibilites |\n",
     "| Heuristique MRV | BT + MRV | Choisir la variable la plus contrainte pour detecter les impasses plus tot |\n",
     "| Propagation de contraintes | Norvig | Eliminer les valeurs impossibles avant la recherche |\n",
     "| Programmation par contraintes | OR-Tools CP-SAT | Declarer les contraintes, laisser le solveur trouver la solution |\n",
@@ -3099,9 +3099,9 @@
     "### Enseignements principaux\n",
     "\n",
     "1. **La propagation domine** : le solveur Norvig resout la majorite des puzzles sans aucun backtracking, confirmant que reduire l'espace de recherche est plus efficace que d'explorer plus intelligemment.\n",
-    "2. **Les heuristiques comptent** : MRV divise le nombre d'appels recursifs par 4 a 1000x selon la difficulte du puzzle, pour un surcout constant par appel.\n",
-    "3. **La previsibilite est cruciale** : en production, un solveur rapide mais imprevisible (backtracking) est souvent moins desirable qu'un solveur legerement plus lent mais constant (CP-SAT).\n",
-    "4. **La difficulte n'est pas monotone** : le nombre de cases vides ne predit pas la difficulte algorithmique. La structure des contraintes importe davantage."
+    "2. **Les heuristiques comptent** : MRV divise le nombre d'appels recursifs par 4 a 1000x selon la difficulté du puzzle, pour un surcout constant par appel.\n",
+    "3. **La previsibilite est cruciale** : en production, un solveur rapide mais imprevisible (backtracking) est souvent moins desirable qu'un solveur légèrement plus lent mais constant (CP-SAT).\n",
+    "4. **La difficulté n'est pas monotone** : le nombre de cases vides ne predit pas la difficulté algorithmique. La structure des contraintes importe davantage."
    ]
   },
   {


### PR DESCRIPTION
## fix(sudoku,#2876): restore French accents in Sudoku-18-Comparison-Python markdown (200 cures, 50 cells)

### Scope

Single-file PR. Touches **only** `MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb`.

Cure les accents francais perdus dans le markdown pedagogique + commentaires code du notebook (comparaison solveurs Python vs C#, benchmarks Sudoku). Aucune cellule code executable modifiee. Distinct de PR #7141 (Sudoku-18-Comparison-Csharp, deja cure).

### R6 anti-monotonie — pivot registre Sudoku

c.597 Probas/PyMC → c.598 GameTheory/ZeroSum → c.599 SymbolicAI/SMT 04-Strings → c.600 SymbolicAI/SMT 06-Adv-Opt → c.601 Search/Part1 09-LinearProgramming → **c.602 Sudoku 18-Comparison-Python** (registre Sudoku, jamais touche par ma lane c.597-c.601).

7ᵉ cycle vague accents #2876 (Probas/PyMC → GameTheory → SymbolicAI 04 → SymbolicAI 06 → Search 09 → **Sudoku 18**).

### c.602 — caps_ratio diagnostic appliqué

Diagnostic pre-cure revele `caps_ratio = 0.0098` (< 0.01, legerement > 0.005). Guard C598-L1 ★★ applique (skip ALL-CAPS emphasis).

**Script cure_text** = pattern eprouve c.597-L1 ★★ + c.598-L1 ★★ : case-insensitive dict lookup preserving original casing + skip ALL-CAPS stylistic emphasis.

### Verification

| Check | Resultat |
|-------|----------|
| ACCENT-ONLY invariant (NFD-normalized diff vs origin/main) | **0/68 cells mismatch** |
| Stop & Repair : diff outputs | **0** (aucune cellule `outputs` touchee) |
| H.3 pre-commit : `execution_count: null` en code cells | **0/25** (toutes preservees) |
| LF preservation (c.591 ★ binary write) | 3168 → 3168 (CRLF: 0 → 0) |
| C596-L2 grep `determine\|detectee\|geenere\|predite\|predits` | **0 hits** dans le diff |
| Bytes delta | +216 (284,589 → 284,805) |
| Files changed | **1** |
| Domaines | **1** (Sudoku) |
| One-to-one line replacement | 161 insertions / 161 deletions |

### Anti-§D byte-identity

Source length UNCHANGED. Contenu accent-stripped byte-identique a origin/main (NFD-normalized 0/68 cells). Aucune cellule `# Solution` / `# Exemple resolu` touchee.

### Issues

`See #2876` — partial delivery (1 notebook sur ~1,135 restants dans la vague accents). Registre #2876 reste ouvert jusqu'a epuisement du scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)