### PR TITLE
fix(probas,#2876): restore FR accents in DecPyMC-5-Value-Information markdown

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-5-Value-Information.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-5-Value-Information.ipynb
@@ -26,7 +26,7 @@
     "\n",
     "---\n",
     "\n",
-    "| Notebook precedent | Notebook suivant |\n",
+    "| Notebook précèdent | Notebook suivant |\n",
     "|--------------------|------------------|\n",
     "| [DecPyMC-4 - Reseaux de decision](DecPyMC-4-Decision-Networks.ipynb) | [DecPyMC-6 - Systemes experts](DecPyMC-6-Expert-Systems.ipynb) |"
    ]
@@ -40,7 +40,7 @@
    "source": [
     "## 1. Information et reduction de l'incertitude\n",
     "\n",
-    "En decision sequentielle, une information supplementaire peut changer l'action optimale.\n",
+    "En decision séquentielle, une information supplementaire peut changer l'action optimale.\n",
     "La **valeur de l'information** (Howard, 1966) mesure combien on est pret a payer pour cette information.\n",
     "\n",
     "**Cle** : l'information n'a de valeur que si elle peut **changer la decision**.\n",
@@ -174,7 +174,7 @@
    "source": [
     "### Interpretation : Le parapluie\n",
     "\n",
-    "**Analyse des resultats** :\n",
+    "**Analyse des résultats** :\n",
     "\n",
     "Le scenario du parapluie illustre le concept fondamental de l'EVPI dans un cas simple.\n",
     "\n",
@@ -185,12 +185,12 @@
     "| EVPI | 3.5 unites | Prix maximal d'un bulletin meteo parfait |\n",
     "\n",
     "**Pourquoi l'EVPI est-il si faible ?** La matrice d'utilite est peu contrastee : le pire\n",
-    "cas est -50 (etre mouille), mais la probabilite de pluie est seulement 30%. L'information\n",
+    "cas est -50 (etre mouille), mais la probabilité de pluie est seulement 30%. L'information\n",
     "ne change pas radicalement la decision : on apporte deja le parapluie par precaution.\n",
     "L'EVPI mesure uniquement le gain supplementaire d'une prediction parfaite.\n",
     "\n",
     "> **Note technique** : Si P(pluie) etait plus eleve (ex: 0.50), l'EVPI serait plus\n",
-    "> important car la decision serait plus equilibree. L'EVPI est maximal a la frontiere\n",
+    "> important car la decision serait plus équilibree. L'EVPI est maximal a la frontiere\n",
     "> de decision (voir section 6)."
    ]
   },
@@ -208,22 +208,22 @@
     "\n",
     "| Aspect | EVPI | EVSI |\n",
     "|--------|------|------|\n",
-    "| Information | **Parfaite** (oracle) | **Imperfaite** (test reel) |\n",
-    "| Formule | E[max_action par etat reel] - EU(optimal a priori) | E[max_action apres test] - EU(optimal a priori) |\n",
-    "| Borne | Superieure theorique | Toujours <= EVPI |\n",
+    "| Information | **Parfaite** (oracle) | **Imperfaite** (test réel) |\n",
+    "| Formule | E[max_action par etat réel] - EU(optimal a priori) | E[max_action apres test] - EU(optimal a priori) |\n",
+    "| Borne | Superieure théorique | Toujours <= EVPI |\n",
     "| Pratique | Rarement atteignable | Mesurable pour chaque test |\n",
-    "| Interpretation | \"Budget maximal pour tout test\" | \"Valeur reelle d'un test donne\" |\n",
+    "| Interpretation | \"Budget maximal pour tout test\" | \"Valeur réelle d'un test donne\" |\n",
     "\n",
     "**Propriete fondamentale** : $0 \\leq \\text{EVSI} \\leq \\text{EVPI}$\n",
     "\n",
     "L'EVPI est la **borne superieure** : aucun test, aussi performant soit-il, ne peut\n",
-    "fournir plus de valeur que l'information parfaite. Le ratio EVSI/EVPI (efficacite)\n",
+    "fournir plus de valeur que l'information parfaite. Le ratio EVSI/EVPI (efficacité)\n",
     "mesure la qualite relative d'un test :\n",
-    "- **Efficacite > 50%** : test tres informatif, capture plus de la moitie de la valeur ideale\n",
+    "- **Efficacite > 50%** : test très informatif, capture plus de la moitie de la valeur ideale\n",
     "- **Efficacite 20-50%** : test modement informatif\n",
-    "- **Efficacite < 20%** : test faiblement informatif, a ameliorer ou abandonner\n",
+    "- **Efficacite < 20%** : test faiblement informatif, a améliorér ou abandonner\n",
     "\n",
-    "> **Point cle** : Un test peut avoir une haute efficacite (EVSI proche de EVPI) tout en\n",
+    "> **Point cle** : Un test peut avoir une haute efficacité (EVSI proche de EVPI) tout en\n",
     "> etant non rentable si son cout depasse l'EVPI. Efficacite != rentabilite."
    ]
   },
@@ -311,7 +311,7 @@
     "### Exercice : EVPI pour un diagnostic medical\n",
     "\n",
     "Un patient arrive a l'hopital avec des symptomes ambigus. Le medecin doit decider :\n",
-    "- **Traiter** immediatement (traitement lourd avec effets secondaires)\n",
+    "- **Traiter** immédiatement (traitement lourd avec effets secondaires)\n",
     "- **Ne pas traiter** et attendre (risque d'aggravation si maladie)\n",
     "\n",
     "Une maladie rare affecte 10% de la population. Un test diagnostique existe\n",
@@ -324,9 +324,9 @@
     "**Indices** :\n",
     "- Construire la matrice d'utilite 2x2 (etats : malade/sain, actions : traiter/ne pas traiter)\n",
     "- Sans info : comparer EU(traiter) et EU(ne pas traiter), garder le max\n",
-    "- Avec info parfaite : pour chaque etat reel, choisir la meilleure action\n",
+    "- Avec info parfaite : pour chaque etat réel, choisir la meilleure action\n",
     "- EVPI = EU(info parfaite) - EU(sans info)\n",
-    "- Si EVPI < cout du test, meme un test parfait ne serait pas rentable"
+    "- Si EVPI < cout du test, même un test parfait ne serait pas rentable"
    ]
   },
   {
@@ -417,7 +417,7 @@
    "source": [
     "### Interpretation : Forage petrolier\n",
     "\n",
-    "**Analyse des resultats** :\n",
+    "**Analyse des résultats** :\n",
     "\n",
     "Sans information, la decision optimale est de **vendre** les droits (EU = 200k EUR).\n",
     "Le forage est trop risque : 70% de chance de perdre 500k EUR.\n",
@@ -426,7 +426,7 @@
     "|-----------|--------|--------|\n",
     "| Seuil de decision | P = 0.50 | Au-dessus, forer ; en dessous, vendre |\n",
     "| EVPI | 90k EUR | Valeur maximale d'un test parfait |\n",
-    "| Asymetrie des gains | 500k vs -500k | Forte incertitude = forte valeur d'information |\n",
+    "| Asymétrie des gains | 500k vs -500k | Forte incertitude = forte valeur d'information |\n",
     "\n",
     "L'EVPI de 90k EUR signifie qu'un oracle parfait permettant de savoir avec certitude\n",
     "s'il y a du petrole vaut cette somme. En pratique, aucun test n'est parfait,\n",
@@ -449,7 +449,7 @@
     "- Cout du test : 50k EUR\n",
     "- **Vraisemblance** : P(test+|petrole) = 80%, P(test-|pas petrole) = 90%\n",
     "\n",
-    "On utilise le **theoreme de Bayes** pour mettre a jour la probabilite a posteriori :"
+    "On utilise le **theoreme de Bayes** pour mettre a jour la probabilité a posteriori :"
    ]
   },
   {
@@ -547,7 +547,7 @@
     "|--------|------------|-------------------|\n",
     "| Prior | 30% | Vendre |\n",
     "| Test positif (31% des cas) | 77.4% | Forer |\n",
-    "| Test negatif (69% des cas) | 8.7% | Vendre |\n",
+    "| Test négatif (69% des cas) | 8.7% | Vendre |\n",
     "\n",
     "**Valeur du test** :\n",
     "- EVSI = 23k EUR (brut), -27k EUR (net du cout de 50k)\n",
@@ -555,11 +555,11 @@
     "- **Decision : NE PAS faire le test** (le cout depasse la valeur d'information)\n",
     "\n",
     "**Contraste avec l'Infer.NET** : La version originale (sensibilite 90%, specificite 80%,\n",
-    "gain 2M) obtient un EVSI de 253k EUR et recommande le test. Nos parametres differents\n",
+    "gain 2M) obtient un EVSI de 253k EUR et recommande le test. Nos parametrès différents\n",
     "(gain 1M au lieu de 2M, sensibilite 80% au lieu de 90%) reduisent la valeur du test.\n",
     "\n",
-    "> **Point cle** : L'efficacite d'un test depend de la combinaison de sa qualite ET de\n",
-    "> l'echelle des gains en jeu. Un test identique peut etre rentable ou non selon le contexte."
+    "> **Point cle** : L'efficacité d'un test depend de la combinaison de sa qualite ET de\n",
+    "> l'échelle des gains en jeu. Un test identique peut etre rentable ou non selon le contexte."
    ]
   },
   {
@@ -569,9 +569,9 @@
     "tags": []
    },
    "source": [
-    "## 5. La chasse au tresor\n",
+    "## 5. La chasse au trèsor\n",
     "\n",
-    "5 coffres, un seul contient un tresor (valeur 100). Cout de fouille : 10.\n",
+    "5 coffres, un seul contient un trèsor (valeur 100). Cout de fouille : 10.\n",
     "- **Sans info** : choisir un coffre au hasard (P=1/5), EU = 1/5 * 100 - 10 = 10\n",
     "- **Info parfaite** : savoir exactement quel coffre, EU = 100 - 10 = 90"
    ]
@@ -625,12 +625,12 @@
     "tags": []
    },
    "source": [
-    "### Exercice : Acheter un indice dans la chasse au tresor\n",
+    "### Exercice : Acheter un indice dans la chasse au trèsor\n",
     "\n",
-    "La chasse au tresor passe de 5 a **10 coffres**. Un marchand propose un **indice parfait**\n",
-    "(revelant exactement ou se trouve le tresor) pour un certain prix.\n",
+    "La chasse au trèsor passe de 5 a **10 coffres**. Un marchand propose un **indice parfait**\n",
+    "(revelant exactement ou se trouve le trèsor) pour un certain prix.\n",
     "\n",
-    "**Objectif** : Calculer l'EVPI pour 10 coffres, puis determiner si l'achat de l'indice\n",
+    "**Objectif** : Calculer l'EVPI pour 10 coffres, puis déterminer si l'achat de l'indice\n",
     "a 30 unites est rentable. A partir de combien de coffres l'indice devient-il rentable ?\n",
     "\n",
     "**Indices** :\n",
@@ -707,9 +707,9 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : Chasse au tresor\n",
+    "### Interpretation : Chasse au trèsor\n",
     "\n",
-    "**Analyse des resultats** :\n",
+    "**Analyse des résultats** :\n",
     "\n",
     "| Situation | EU | Justification |\n",
     "|-----------|-----|---------------|\n",
@@ -717,13 +717,13 @@
     "| Info parfaite | 90 | Fouiller directement le bon coffre |\n",
     "| EVPI | 80 | Gain maximal d'information |\n",
     "\n",
-    "**Comparaison avec Infer.NET** : La version Infer.NET modelise une fouille sequentielle\n",
+    "**Comparaison avec Infer.NET** : La version Infer.NET modelise une fouille séquentielle\n",
     "(fouiller case 1, puis 2, etc.), donnant un EU sans info de 70 et un EVPI de 20.\n",
     "Notre version simplifiee choisit un seul coffre au hasard, donnant EU = 10 et EVPI = 80.\n",
     "\n",
-    "Les deux approches sont valides : elles differents par l'hypothese sur la strategie\n",
+    "Les deux approches sont valides : elles différents par l'hypothese sur la stratégie\n",
     "de fouille. L'EVPI reste le concept cle : il mesure combien on gagnerait a savoir\n",
-    "exactement ou se trouve le tresor."
+    "exactement ou se trouve le trèsor."
    ]
   },
   {
@@ -735,12 +735,12 @@
    "source": [
     "### Detecteur de metal\n",
     "\n",
-    "Le detecteur indique la distance au tresor. Plus le signal est fort (proche),\n",
-    "plus la probabilite que le tresor soit dans ce coffre est elevee.\n",
+    "Le detecteur indique la distance au trèsor. Plus le signal est fort (proche),\n",
+    "plus la probabilité que le trèsor soit dans ce coffre est elevee.\n",
     "\n",
-    "$P(\\text{tresor dans coffre } i \\mid d_i) = \\frac{e^{-d_i}}{\\sum_j e^{-d_j}}$\n",
+    "$P(\\text{trèsor dans coffre } i \\mid d_i) = \\frac{e^{-d_i}}{\\sum_j e^{-d_j}}$\n",
     "\n",
-    "Le detecteur mesure la distance avec du bruit. Le rapport signal/bruit determine l'EVSI."
+    "Le detecteur mesure la distance avec du bruit. Le rapport signal/bruit détermine l'EVSI."
    ]
   },
   {
@@ -817,14 +817,14 @@
    "source": [
     "### EVPI en fonction du nombre de coffres\n",
     "\n",
-    "L'EVPI depend de la structure du probleme. Dans la chasse au tresor, le nombre de coffres\n",
-    "est un parametre cle : plus il y a de coffres, plus l'incertitude est grande et plus\n",
+    "L'EVPI depend de la structure du problème. Dans la chasse au trèsor, le nombre de coffres\n",
+    "est un paramètre cle : plus il y a de coffres, plus l'incertitude est grande et plus\n",
     "l'information parfaite est precieuse.\n",
     "\n",
     "Nous allons faire varier N de 2 a 50 et observer :\n",
     "- Comment l'EVPI evolue (croissance et saturation)\n",
     "- Comment l'EVSI du detecteur de metal evolue relativement a l'EVPI\n",
-    "- A partir de quel N le detecteur perd de son efficacite relative"
+    "- A partir de quel N le detecteur perd de son efficacité relative"
    ]
   },
   {
@@ -933,11 +933,11 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : EVPI et complexite de la recherche\n",
+    "### Interpretation : EVPI et complexité de la recherche\n",
     "\n",
     "**Croissance lineaire de l'EVPI avec N** :\n",
     "\n",
-    "Le graphique montre une relation simple : l'EVPI croit lineairement avec le nombre de coffres. Plus il y a de coffres, plus l'information parfaite est precieuse car la probabilite de trouver le tresor au hasard diminue.\n",
+    "Le graphique montre une relation simple : l'EVPI croit lineairement avec le nombre de coffres. Plus il y a de coffres, plus l'information parfaite est precieuse car la probabilité de trouver le trèsor au hasard diminue.\n",
     "\n",
     "| Coffres (N) | P(trouver) sans info | EVPI | Gain marginal par coffre |\n",
     "|-------------|----------------------|------|--------------------------|\n",
@@ -949,9 +949,9 @@
     "\n",
     "**Loi de l'EVPI dans la recherche** : L'EVPI suit la formule `(N-1)/N * (valeur - cout)`, qui converge vers `valeur - cout` quand N augmente. La valeur marginale d'un coffre supplementaire decroit en `1/N^2`.\n",
     "\n",
-    "**Application pratique** : Dans un scenario d'exploration miniere, cette analyse permet de determiner le budget maximal allouable a l'acquisition d'information (sondages, etudes geologiques) en fonction du nombre de sites candidats.\n",
+    "**Application pratique** : Dans un scenario d'exploration miniere, cette analyse permet de déterminer le budget maximal allouable a l'acquisition d'information (sondages, etudes geologiques) en fonction du nombre de sites candidats.\n",
     "\n",
-    "> **Note technique** : Le detecteur de metal avec bruit observe une EVSI qui decroit relativement a l'EVPI quand N augmente. Plus il y a de coffres, plus le signal du detecteur est dilue parmi les faux positifs, reduisant l'efficacite EVSI/EVPI."
+    "> **Note technique** : Le detecteur de metal avec bruit observe une EVSI qui decroit relativement a l'EVPI quand N augmente. Plus il y a de coffres, plus le signal du detecteur est dilue parmi les faux positifs, reduisant l'efficacité EVSI/EVPI."
    ]
   },
   {
@@ -966,7 +966,7 @@
     "L'information n'a de valeur que dans trois conditions :\n",
     "1. **Incertitude** : il existe une incertitude sur l'etat du monde\n",
     "2. **Non-neutralite** : l'incertitude affecte la decision optimale\n",
-    "3. **Action** : on peut agir differemment selon l'information\n",
+    "3. **Action** : on peut agir différemment selon l'information\n",
     "\n",
     "### Analyse de sensibilite : EVPI vs P(petrole)"
    ]
@@ -1047,8 +1047,8 @@
    "source": [
     "### Observation cle\n",
     "\n",
-    "L'EVPI est **maximal quand la decision est la plus equilibree** (zone d'indifference).\n",
-    "Quand P(petrole) est tres faible ou tres eleve, la decision est deja claire\n",
+    "L'EVPI est **maximal quand la decision est la plus équilibree** (zone d'indifference).\n",
+    "Quand P(petrole) est très faible ou très eleve, la decision est deja claire\n",
     "et l'information supplementaire n'apporte rien."
    ]
   },
@@ -1061,8 +1061,8 @@
    "source": [
     "### Carte de chaleur 2D : EVPI en fonction de P(petrole) et du gain\n",
     "\n",
-    "L'EVPI depend simultanement de **deux parametres** : la probabilite a priori P(petrole)\n",
-    "et le gain net en cas de forage reussi. La carte de chaleur ci-dessous montre comment\n",
+    "L'EVPI depend simultanement de **deux parametrès** : la probabilité a priori P(petrole)\n",
+    "et le gain net en cas de forage réussi. La carte de chaleur ci-dessous montre comment\n",
     "l'EVPI varie dans le plan (P, gain), revelant la **ligne de frontiere de decision** ou\n",
     "l'EVPI est maximal et les zones ou l'information n'a aucune valeur."
    ]
@@ -1163,14 +1163,14 @@
     "\n",
     "**Lecture de la carte** :\n",
     "\n",
-    "La carte de chaleur revele la geometrie complete de la valeur de l'information dans le\n",
-    "plan (probabilite, gain). On distingue trois zones :\n",
+    "La carte de chaleur révèle la geometrie complète de la valeur de l'information dans le\n",
+    "plan (probabilité, gain). On distingue trois zones :\n",
     "\n",
     "| Zone | Position | EVPI | Explication |\n",
     "|------|----------|------|-------------|\n",
     "| **Pas de valeur** | P faible ou gain faible | 0 | Vendre domine toujours |\n",
     "| **Pas de valeur** | P eleve ET gain eleve | 0 | Forer domine toujours |\n",
-    "| **Valeur elevee** | Autour de la frontiere bleue | Maximal | Decision equilibree |\n",
+    "| **Valeur elevee** | Autour de la frontiere bleue | Maximal | Decision équilibree |\n",
     "\n",
     "**La frontiere de decision** (ligne bleue) correspond a $P = \\frac{\\text{prix\\_vente} + \\text{cout\\_forage}}{g}$.\n",
     "Le long de cette courbe, EU(forer) = EU(vendre), et l'EVPI atteint son maximum.\n",
@@ -1191,32 +1191,32 @@
    "source": [
     "### Quand l'information n'a PAS de valeur\n",
     "\n",
-    "L'analyse de sensibilite ci-dessus montre que l'EVPI tombe a zero aux extremites.\n",
+    "L'analyse de sensibilite ci-dessus montre que l'EVPI tombe a zero aux extrémités.\n",
     "Identifions les conditions exactes ou l'information est sans valeur :\n",
     "\n",
     "| Condition | Explication | Exemple |\n",
     "|-----------|-------------|---------|\n",
     "| **Pas d'incertitude** | Si l'etat est connu, l'info n'apporte rien | P(petrole) = 0 ou 1 |\n",
-    "| **Decision fixe** | Si l'action optimale est la meme quel que soit l'etat | EU(forage) >> EU(vente) pour tout P |\n",
-    "| **Utilites egales** | Si les actions ont la meme utilite dans chaque etat | Matrice d'utilite constante |\n",
+    "| **Decision fixe** | Si l'action optimale est la même quel que soit l'etat | EU(forage) >> EU(vente) pour tout P |\n",
+    "| **Utilites egales** | Si les actions ont la même utilite dans chaque etat | Matrice d'utilite constante |\n",
     "| **Cout > EVPI** | Meme un test parfait ne rembourse pas son cout | Test a 200k avec EVPI = 90k |\n",
     "\n",
     "**Facteurs qui augmentent la valeur de l'information** :\n",
     "\n",
     "1. **Incertitude elevee** : l'EVPI est maximal a la frontiere de decision (P ~ 0.35 dans notre forage)\n",
-    "2. **Asymetrie des gains** : des utilites tres contrastees augmentent l'enjeu de la bonne decision\n",
+    "2. **Asymétrie des gains** : des utilites très contrastees augmentent l'enjeu de la bonne decision\n",
     "3. **Reversibilite faible** : une decision irreversible rend l'information plus precieuse\n",
     "4. **Cout d'erreur eleve** : plus l'erreur coute cher, plus l'info vaut\n",
     "\n",
     "**Cas limite : maladie rare** :\n",
     "\n",
-    "Pour une maladie avec P = 1% (maladie rare), l'EVPI est souvent tres faible car :\n",
-    "- Sans info, la meilleure action est generalement de \"ne pas traiter\" (99% de chances d'etre sain)\n",
+    "Pour une maladie avec P = 1% (maladie rare), l'EVPI est souvent très faible car :\n",
+    "- Sans info, la meilleure action est généralement de \"ne pas traiter\" (99% de chances d'etre sain)\n",
     "- Meme un test parfait ne change la decision que dans 1% des cas\n",
     "- Le cout du test est donc presque toujours un gaspillage\n",
     "\n",
-    "Ce phenomene explique pourquoi les depistages systematiques de maladies tres rares\n",
-    "sont **deconseilles** en sante publique : le ratio benefice/cout est defavorable."
+    "Ce phénomène explique pourquoi les depistages systématiques de maladies très rares\n",
+    "sont **deconseilles** en sante publique : le ratio benefice/cout est défavorable."
    ]
   },
   {
@@ -1228,8 +1228,8 @@
    "source": [
     "## 7. Calculateur generique de Valeur de l'Information\n",
     "\n",
-    "On generalise avec une classe `ValueOfInformation` qui prend en entree :\n",
-    "- Etats possibles et leurs probabilites a priori\n",
+    "On généralise avec une classe `ValueOfInformation` qui prend en entree :\n",
+    "- Etats possibles et leurs probabilités a priori\n",
     "- Actions disponibles et leurs utilites par etat\n",
     "- Optionnellement : vraisemblance d'un test par etat"
    ]
@@ -1362,7 +1362,7 @@
     "### Validation du calculateur generique\n",
     "\n",
     "**Verification** : Les valeurs calculees par la classe `ValueOfInformation` correspondent\n",
-    "exactement aux calculs manuels des sections precedentes.\n",
+    "exactement aux calculs manuels des sections précèdentes.\n",
     "\n",
     "| Metrique | Calcul manuel | Classe VoI | Statut |\n",
     "|----------|---------------|------------|--------|\n",
@@ -1376,7 +1376,7 @@
     "\n",
     "> **Note technique** : L'interface `compute_evsi(likelihood)` accepte une matrice de\n",
     "> vraisemblance `P(test=j | state=i)` de dimension `(n_states, n_outcomes)`, ce qui\n",
-    "> permet de modeliser des tests a plus de 2 resultats possibles."
+    "> permet de modeliser des tests a plus de 2 résultats possibles."
    ]
   },
   {
@@ -1388,7 +1388,7 @@
    "source": [
     "### Prior -> Posterior : mise a jour bayesienne\n",
     "\n",
-    "Observons comment le posterior change avec differentes observations.\n",
+    "Observons comment le posterior change avec différentes observations.\n",
     "On reprend le scenario du forage avec un test sismique."
    ]
   },
@@ -1461,8 +1461,8 @@
    "source": [
     "## 8. Tests medicaux multiples\n",
     "\n",
-    "Un patient peut etre dans 3 etats : **Sain**, **Maladie legere**, **Maladie grave**.\n",
-    "Trois actions possibles : **Rien**, **Traitement leger**, **Traitement lourd**.\n",
+    "Un patient peut etre dans 3 etats : **Sain**, **Maladie légère**, **Maladie grave**.\n",
+    "Trois actions possibles : **Rien**, **Traitement léger**, **Traitement lourd**.\n",
     "\n",
     "Deux tests disponibles :\n",
     "- **Test 1** ( sanguin) : 50 EUR, sensibilite 70%, specificite 85%\n",
@@ -1566,7 +1566,7 @@
    "source": [
     "### Interpretation : Diagnostic medical\n",
     "\n",
-    "**Analyse des resultats** :\n",
+    "**Analyse des résultats** :\n",
     "\n",
     "Le scenario medical illustre un cas ou les deux tests sont **non rentables** au cout actuel.\n",
     "\n",
@@ -1653,19 +1653,19 @@
     "\n",
     "**Lecture du graphique** :\n",
     "\n",
-    "Le diagramme en barres compare directement l'EVPI (borne theorique) avec les valeurs d'information reelles des deux tests, en brut et en net.\n",
+    "Le diagramme en barres compare directement l'EVPI (borne théorique) avec les valeurs d'information réelles des deux tests, en brut et en net.\n",
     "\n",
     "| Barre | Valeur | Observation |\n",
     "|-------|--------|-------------|\n",
-    "| EVPI | 24 | Borne superieure theorique |\n",
+    "| EVPI | 24 | Borne superieure théorique |\n",
     "| Test 1 brut | ~0 | Information quasiment nulle |\n",
     "| Test 1 net | -50 | Cout du test domine |\n",
     "| Test 2 brut | 13 | Capture 54% de l'EVPI |\n",
     "| Test 2 net | -487 | Cout 500 EUR >> EVSI 13 EUR |\n",
     "\n",
-    "**Lecon pedagogique** : Un test peut avoir une bonne **efficacite relative** (54% de l'EVPI) tout en etant **non rentable** en termes absolus (EVSI net fortement negatif). L'efficacite mesure la qualite intrinseque de l'information ; la rentabilite depend du rapport entre cette qualite et le cout.\n",
+    "**Lecon pedagogique** : Un test peut avoir une bonne **efficacité relative** (54% de l'EVPI) tout en etant **non rentable** en termes absolus (EVSI net fortement négatif). L'efficacité mesure la qualite intrinseque de l'information ; la rentabilite depend du rapport entre cette qualite et le cout.\n",
     "\n",
-    "> **Point cle** : Dans un contexte medical reel, la matrice d'utilite integrerait des facteurs comme la qualite de vie (QALY), le cout des traitements inutiles, et les risques lies au retard diagnostique -- ce qui rendrait les EVSI positifs dans la plupart des cas."
+    "> **Point cle** : Dans un contexte medical réel, la matrice d'utilite integrerait des facteurs comme la qualite de vie (QALY), le cout des traitements inutiles, et les risques lies au retard diagnostique -- ce qui rendrait les EVSI positifs dans la plupart des cas."
    ]
   },
   {
@@ -1677,8 +1677,8 @@
    "source": [
     "### Cas limite : Maladie rare (EVSI = 0)\n",
     "\n",
-    "Appliquons le cadre VoI a une maladie **tres rare** (P = 1%) pour illustrer le cas\n",
-    "ou l'information n'a pratiquement aucune valeur, meme si le test est excellent."
+    "Appliquons le cadre VoI a une maladie **très rare** (P = 1%) pour illustrer le cas\n",
+    "ou l'information n'a pratiquement aucune valeur, même si le test est excellent."
    ]
   },
   {
@@ -1770,18 +1770,18 @@
    "source": [
     "### Interpretation : Maladie rare\n",
     "\n",
-    "**Lecon fondamentale** : la valeur de l'information depend de la **probabilite a priori**.\n",
+    "**Lecon fondamentale** : la valeur de l'information depend de la **probabilité a priori**.\n",
     "\n",
     "| Prior P(malade) | EVPI | Test parfait utile ? | Raison |\n",
     "|------------------|------|---------------------|--------|\n",
-    "| 50% | Eleve | Oui | Decision equilibree, l'info tranche |\n",
+    "| 50% | Eleve | Oui | Decision équilibree, l'info tranche |\n",
     "| 10% | Moyen | Possible | L'info peut changer la decision |\n",
     "| 1% | Quasi nul | Non | Decision deja claire (ne pas traiter) |\n",
     "\n",
-    "Ce resultat justifie les recommandations de sante publique :\n",
+    "Ce résultat justifie les recommandations de sante publique :\n",
     "- **Depistage du cancer du sein** (prevalence ~3% chez les 40-50 ans) : debat actif sur le rapport benefice/cout\n",
     "- **Depistage du cancer de la prostate** (prevalence ~0.5% chez les 50 ans) : deconseille par plusieurs autorites\n",
-    "- **Test COVID systematique** en population faible prevalence : EVSI tres faible vs cout social\n",
+    "- **Test COVID systématique** en population faible prevalence : EVSI très faible vs cout social\n",
     "\n",
     "> **Point cle** : La valeur de l'information est maximale a la **frontiere de decision** (P ~ seuil)\n",
     "> et minimale quand la decision est deja certaine (P proche de 0 ou 1)."
@@ -1794,7 +1794,7 @@
     "tags": []
    },
    "source": [
-    "## 9. Extension : Strategie sequentielle\n\nEt si on pouvait faire le **Test 1 d'abord**, puis decider du **Test 2** en fonction\ndu resultat ? C'est une strategie sequentielle d'acquisition d'information.\n\n### Exercice 3 : EVSI d'une strategie sequentielle (Test1 -> Test2)\n\nCalculez l'**EVSI** (Expected Value of Sample Information) d'une strategie en deux\netapes : on effectue le Test 1 (cout `cout_t1`), puis **conditionnellement au resultat\npositif** on effectue le Test 2 (cout `cout_t2`). Comparez cette strategie sequentielle\na la strategie \"Test 2 directement\" et a la strategie \"ne pas tester\".\n\n**Objectif** : Completez la fonction `strategie_sequentielle` ci-dessous pour calculer\nl'utilite esperee de la strategie sequentielle optimale.\n\n**Indices** :\n- Si Test 1 est negatif : pas de Test 2, decision = action optimale sans information\n- Si Test 1 est positif : le posterior apres Test 1 devient le prior du Test 2\n- L'EVSI = EU(strategie sequentielle optimale) - EU(ne pas tester)\n- Verifiez que la strategie sequentielle >= Test 2 seul (propriete de monotonie de l'information)"
+    "## 9. Extension : Strategie séquentielle\n\nEt si on pouvait faire le **Test 1 d'abord**, puis decider du **Test 2** en fonction\ndu résultat ? C'est une stratégie séquentielle d'acquisition d'information.\n\n### Exercice 3 : EVSI d'une stratégie séquentielle (Test1 -> Test2)\n\nCalculez l'**EVSI** (Expected Value of Sample Information) d'une stratégie en deux\netapes : on effectue le Test 1 (cout `cout_t1`), puis **conditionnellement au résultat\npositif** on effectue le Test 2 (cout `cout_t2`). Comparez cette stratégie séquentielle\na la stratégie \"Test 2 directement\" et a la stratégie \"ne pas tester\".\n\n**Objectif** : Completez la fonction `stratégie_séquentielle` ci-dessous pour calculer\nl'utilite esperee de la stratégie séquentielle optimale.\n\n**Indices** :\n- Si Test 1 est négatif : pas de Test 2, decision = action optimale sans information\n- Si Test 1 est positif : le posterior apres Test 1 devient le prior du Test 2\n- L'EVSI = EU(stratégie séquentielle optimale) - EU(ne pas tester)\n- Verifiez que la stratégie séquentielle >= Test 2 seul (propriete de monotonie de l'information)"
    ]
   },
   {
@@ -1804,15 +1804,15 @@
     "tags": []
    },
    "source": [
-    "### Exemple guide : strategie sequentielle a deux tests\n",
+    "### Exemple guide : stratégie séquentielle a deux tests\n",
     "\n",
-    "Avant de resoudre l'exercice, voyons un **exemple resolu** de strategie sequentielle\n",
+    "Avant de résoudre l'exercice, voyons un **exemple résolu** de stratégie séquentielle\n",
     "avec le scenario du forage petrolier.\n",
     "\n",
     "**Strategie** : faire le test sismique (Test 1, cout 50k), puis **seulement si test+**\n",
-    "faire un test complementaire (Test 2, cout 80k, sensibilite 95%, specificite 95%).\n",
+    "faire un test complémentaire (Test 2, cout 80k, sensibilite 95%, specificite 95%).\n",
     "\n",
-    "La logique est : un test sismique negatif confirme qu'il n'y a probablement pas de petrole\n",
+    "La logique est : un test sismique négatif confirme qu'il n'y a probablement pas de petrole\n",
     "(deja P = 8.7%), donc on vend. Un test positif (P = 77.4%) merite un second test\n",
     "plus couteux mais plus precis avant de decider de forer."
    ]
@@ -1978,8 +1978,8 @@
    "source": [
     "### Questions de reflexion\n",
     "\n",
-    "1. Dans quelles conditions un test **moins precis** peut-il etre preferable ?\n",
-    "2. Pourquoi l'EVPI est-il nul quand la probabilite a priori est proche de 0 ou 1 ?\n",
+    "1. Dans quelles conditions un test **moins precis** peut-il etre préférable ?\n",
+    "2. Pourquoi l'EVPI est-il nul quand la probabilité a priori est proche de 0 ou 1 ?\n",
     "3. Comment l'EVSI change-t-il si on combine deux tests independants ?"
    ]
   },
@@ -1992,14 +1992,14 @@
    "source": [
     "## 10. Extension PyMC : Estimation MCMC de l'EVPI\n",
     "\n",
-    "Dans les sections precedentes, nous avons calcule l'EVPI analytiquement (point prior).\n",
+    "Dans les sections précèdentes, nous avons calcule l'EVPI analytiquement (point prior).\n",
     "PyMC permet d'aller plus loin en estimant l'EVPI **par echantillonnage** quand le prior\n",
     "n'est pas un simple scalaire mais une distribution.\n",
     "\n",
     "Cette approche est pertinente quand :\n",
     "- Le prior sur l'etat du monde est incertain (meta-incertitude)\n",
-    "- On veut propager l'incertitude sur les parametres dans le calcul de VoI\n",
-    "- Le modele implique des distributions conjuguees non-triviales\n",
+    "- On veut propager l'incertitude sur les parametrès dans le calcul de VoI\n",
+    "- Le modele implique des distributions conjuguées non-triviales\n",
     "\n",
     "Nous allons comparer l'EVPI analytique a l'EVPI estime par echantillonnage Monte Carlo,\n",
     "puis utiliser PyMC pour propager un prior Beta sur P(petrole)."
@@ -2073,7 +2073,7 @@
     "\n",
     "L'estimateur MC de l'EVPI converge vers la valeur analytique quand le nombre d'echantillons\n",
     "augmente. Verifions cette convergence visuellement en calculant l'EVPI estime pour\n",
-    "differentes tailles d'echantillon et en traçant la convergence avec des bandes de confiance."
+    "différentes tailles d'echantillon et en traçant la convergence avec des bandes de confiance."
    ]
   },
   {
@@ -2295,15 +2295,15 @@
    "source": [
     "### Diagnostics de convergence MCMC avec ArviZ\n",
     "\n",
-    "Avant de faire confiance aux resultats du sampling PyMC, il est essentiel de verifier\n",
+    "Avant de faire confiance aux résultats du sampling PyMC, il est essentiel de vérifier\n",
     "la qualite de la chaine MCMC. ArviZ fournit des outils de diagnostic standards :\n",
     "\n",
     "- **R-hat** (statistique de Gelman & Rubin, 1992) : mesure la convergence entre les chaines.\n",
     "  Une valeur < 1.01 indique une bonne convergence.\n",
     "- **ESS** (Effective Sample Size) : nombre effectif d'echantillons independants.\n",
     "  Un ESS > 400 par chaine est recommande pour les estimations fiables.\n",
-    "- **Trace plot** : visualisation des trajectoires des chaines pour detecter les problemes\n",
-    "  de melange ou les autocorrelations excessives."
+    "- **Trace plot** : visualisation des trajectoires des chaines pour detecter les problèmes\n",
+    "  de mélange ou les autocorrelations excessives."
    ]
   },
   {
@@ -2423,18 +2423,18 @@
     "\n",
     "**Verification de la convergence** :\n",
     "\n",
-    "Les diagnostics ArviZ confirment la fiabilite de l'echantillonnage MCMC pour le parametre `p_theta`.\n",
+    "Les diagnostics ArviZ confirment la fiabilite de l'echantillonnage MCMC pour le paramètre `p_theta`.\n",
     "\n",
     "| Diagnostic | Valeur | Critere | Statut |\n",
     "|------------|--------|---------|--------|\n",
     "| R-hat | ~1.000 | < 1.01 | Convergence atteinte |\n",
-    "| ESS bulk | ~8000 | > 400 | Echantillons tres independants |\n",
-    "| Trace plot | Homogene | Pas de tendance | Bon melange |\n",
+    "| ESS bulk | ~8000 | > 400 | Echantillons très independants |\n",
+    "| Trace plot | Homogene | Pas de tendance | Bon mélange |\n",
     "| Autocorrelation | Decroit vite | Vers 0 rapidement | Faible correlation |\n",
     "\n",
-    "**Pourquoi 2 chaines suffisent ici** : Le modele est simple (une seule variable `p_theta` avec un prior conjugue Beta-Bernoulli). Le sampler NUTS explore efficacement l'espace. Pour des modeles plus complexes (hierarchiques, multivariables), 4 chaines seraient recommandees.\n",
+    "**Pourquoi 2 chaines suffisent ici** : Le modele est simple (une seule variable `p_theta` avec un prior conjugué Beta-Bernoulli). Le sampler NUTS explore efficacement l'espace. Pour des modeles plus complexes (hierarchiques, multivariables), 4 chaines seraient recommandees.\n",
     "\n",
-    "> **Note technique** : L'ESS (Effective Sample Size) indique combien d'echantillons reellement independants equivalent aux tirages autocorrelles de la chaine. Un ESS bulk de 8000 pour 20000 tirages signifie que le NUTS a un taux d'acceptation eleve et une bonne exploration."
+    "> **Note technique** : L'ESS (Effective Sample Size) indique combien d'echantillons réellement independants equivalent aux tirages autocorrelles de la chaine. Un ESS bulk de 8000 pour 20000 tirages signifie que le NUTS a un taux d'acceptation eleve et une bonne exploration."
    ]
   },
   {
@@ -2534,8 +2534,8 @@
     "### Posterior predictive : distribution des decisions optimales sous meta-prior\n",
     "\n",
     "Avec un meta-prior sur P(petrole), non seulement l'EVPI devient une distribution, mais\n",
-    "la **decision optimale elle-meme** varie selon la realisation du parametre. Analysons\n",
-    "la frequence a laquelle chaque action est optimale sous le meta-prior Beta(3, 7)."
+    "la **decision optimale elle-même** varie selon la réalisation du paramètre. Analysons\n",
+    "la fréquence a laquelle chaque action est optimale sous le meta-prior Beta(3, 7)."
    ]
   },
   {
@@ -2673,7 +2673,7 @@
    "source": [
     "### Interpretation : EVPI sous meta-prior\n",
     "\n",
-    "**Resultat cle** : Quand P(petrole) est incertain, l'EVPI devient une **distribution** plutot\n",
+    "**Resultat cle** : Quand P(petrole) est incertain, l'EVPI devient une **distribution** plutôt\n",
     "qu'un scalaire. L'EVPI moyen sous le meta-prior est proche du ponctuel, mais avec un\n",
     "ecart-type significatif.\n",
     "\n",
@@ -2684,14 +2684,14 @@
     "\n",
     "**Pourquoi l'EVPI moyen est proche du ponctuel** : Le meta-prior Beta(3,7) est centre\n",
     "sur P=0.30, qui est deja en dessous du seuil de decision (P~0.50). L'EVPI sous le meta-prior\n",
-    "reflette cette moyenne, mais la dispersion (ecart-type ~41k) revele que pour certaines\n",
-    "realisations de P(petrole) proches du seuil, l'EVPI peut etre bien plus eleve.\n",
+    "reflette cette moyenne, mais la dispersion (ecart-type ~41k) révèle que pour certaines\n",
+    "réalisations de P(petrole) proches du seuil, l'EVPI peut etre bien plus eleve.\n",
     "\n",
     "> **Note technique** : L'apport principal du meta-prior n'est pas de changer la valeur\n",
     "> centrale de l'EVPI, mais de fournir un **intervalle de credibilite** [29k, 164k] qui\n",
     "> quantifie l'incertitude sur la valeur de l'information. En pratique, cette approche\n",
-    "> PyMC est essentielle quand les parametres du modele sont estimes a partir de donnees\n",
-    "> limitees."
+    "> PyMC est essentielle quand les parametrès du modele sont estimes a partir de donnees\n",
+    "> limitées."
    ]
   },
   {
@@ -2703,7 +2703,7 @@
    "source": [
     "### Decay de la valeur de l'information : EVSI vers EVPI\n",
     "\n",
-    "Un resultat fondamental de la theorie de la valeur de l'information est que l'EVSI\n",
+    "Un résultat fondamental de la théorie de la valeur de l'information est que l'EVSI\n",
     "converge vers l'EVPI lorsque la precision du test (ou la taille d'echantillon) augmente.\n",
     "Cette section visualise cette convergence pour le scenario du forage petrolier.\n",
     "\n",
@@ -2814,23 +2814,23 @@
     "\n",
     "Le graphique montre clairement la relation monotone entre la precision du test et la valeur\n",
     "de l'information. L'EVSI croit de facon concave vers l'EVPI, qui constitue la borne\n",
-    "superieure theorique.\n",
+    "superieure théorique.\n",
     "\n",
     "| Sensibilite | EVSI | Efficacite EVSI/EVPI |\n",
     "|-------------|------|---------------------|\n",
-    "| 50% (aleatoire) | Faible | ~10-20% |\n",
+    "| 50% (aléatoire) | Faible | ~10-20% |\n",
     "| 80% (test actuel) | 23k EUR | 26% |\n",
     "| 90% | Croissance rapide | ~40-50% |\n",
     "| 99% | Proche de EVPI | >90% |\n",
     "\n",
     "**Point cle** : La croissance est **concave** -- les gains marginaux diminuent a mesure que\n",
     "la precision augmente. Passer de 50% a 70% apporte un gain substantiel, tandis que passer\n",
-    "de 95% a 99% apporte un gain marginal plus faible. Ce phenomene est analogue a la loi\n",
+    "de 95% a 99% apporte un gain marginal plus faible. Ce phénomène est analogue a la loi\n",
     "des rendements decroissants.\n",
     "\n",
-    "> **Note technique** : L'efficacite EVSI/EVPI depend aussi de la specificite du test et de\n",
+    "> **Note technique** : L'efficacité EVSI/EVPI depend aussi de la specificite du test et de\n",
     "> la structure de la matrice d'utilite. Un test a 80% de sensibilite peut capturer 90% de\n",
-    "> l'EVPI si les enjeux financiers sont bien alignes avec les resultats du test."
+    "> l'EVPI si les enjeux financiers sont bien alignes avec les résultats du test."
    ]
   },
   {
@@ -2842,29 +2842,29 @@
    "source": [
     "### Comparaison des approches : analytique vs Monte Carlo vs MCMC\n",
     "\n",
-    "Les sections precedentes ont illustre trois methodes pour calculer l'EVPI du forage petrolier.\n",
+    "Les sections précèdentes ont illustre trois methodes pour calculer l'EVPI du forage petrolier.\n",
     "Le tableau suivant synthetise les avantages et limites de chaque approche :\n",
     "\n",
     "| Aspect | Analytique | Monte Carlo | MCMC (PyMC) |\n",
     "|--------|-----------|-------------|-------------|\n",
     "| **Principe** | Formule exacte sur point prior | Tirages depuis le prior ponctuel | Echantillonnage avec meta-prior |\n",
     "| **EVPI obtenu** | Scalaire (90k) | Scalaire + erreur standard (90.1k +/- 0.3k) | Distribution (moyenne 90k, IC90 [29k, 164k]) |\n",
-    "| **Precision** | Exacte | Converge avec N | Depend du melange MCMC |\n",
+    "| **Precision** | Exacte | Converge avec N | Depend du mélange MCMC |\n",
     "| **Incertitude parametrique** | Non | Non | Oui (meta-prior) |\n",
     "| **Scalabilite** | Limitee (explose en dim > 3) | Bonne (parallele) | Bonne (NUTS) |\n",
     "| **Implementation** | Simple | Simple | Complexe (PyMC) |\n",
     "| **Diagnostics** | Aucun | Ecart-type MC | R-hat, ESS, trace |\n",
-    "| **Cas d'usage** | Problemes simples, validation | Problemes moderes | Incertitude sur les parametres |\n",
+    "| **Cas d'usage** | Problemes simples, validation | Problemes modères | Incertitude sur les parametrès |\n",
     "\n",
     "**Quand utiliser quelle approche ?**\n",
     "\n",
     "- **Analytique** : quand le modele est simple (2-3 etats, actions discretes) et le prior est ponctuel. Rapide et exact.\n",
-    "- **Monte Carlo** : quand le modele est modere (grille de parametres, integrales numeriques) mais le prior reste ponctuel. Fournit un intervalle de confiance sur l'estimateur.\n",
-    "- **MCMC (PyMC)** : quand les parametres sont incertains (meta-prior) et on veut propager cette incertitude dans le calcul de VoI. Fournit une distribution complete de l'EVPI.\n",
+    "- **Monte Carlo** : quand le modele est modère (grille de parametrès, integrales numeriques) mais le prior reste ponctuel. Fournit un intervalle de confiance sur l'estimateur.\n",
+    "- **MCMC (PyMC)** : quand les parametrès sont incertains (meta-prior) et on veut propager cette incertitude dans le calcul de VoI. Fournit une distribution complète de l'EVPI.\n",
     "\n",
-    "> **Point cle** : L'approche MCMC ne remplace pas l'analytique -- elle la generalise en ajoutant\n",
-    "> une couche d'incertitude sur les parametres. L'EVPI analytique correspond au cas\n",
-    "> particulier ou le meta-prior est un Dirac (certitude absolue sur les parametres)."
+    "> **Point cle** : L'approche MCMC ne remplace pas l'analytique -- elle la généralise en ajoutant\n",
+    "> une couche d'incertitude sur les parametrès. L'EVPI analytique correspond au cas\n",
+    "> particulier ou le meta-prior est un Dirac (certitude absolue sur les parametrès)."
    ]
   },
   {
@@ -2874,11 +2874,11 @@
     "tags": []
    },
    "source": [
-    "### Limites du modele conjugue : quand le MCMC devient necessaire\n",
+    "### Limites du modele conjugué : quand le MCMC devient nécessaire\n",
     "\n",
-    "Le modele `Beta(3,7) -> Bernoulli` de la section precedente est **conjugue** : la loi a posteriori de `p_theta` admet une forme analytique fermee (une Beta mise a jour). Pire, comme aucune observation n'est fournie a la vraisemblance (`pm.Bernoulli` sans `observed=`), l'echantillonneur NUTS **se contente de reproduire le prior** -- les diagnostics R-hat ~ 1.000 et ESS ~ 8000 sont alors triviaux, car il n'y a ni apprentissage ni geometrie difficile. Autrement dit, sur ce cas **degenere**, `pm.sample` est strictement equivalent a `np.random.beta(3, 7)`.\n",
+    "Le modele `Beta(3,7) -> Bernoulli` de la section précèdente est **conjugué** : la loi a posteriori de `p_theta` admet une forme analytique fermee (une Beta mise a jour). Pire, comme aucune observation n'est fournie a la vraisemblance (`pm.Bernoulli` sans `observed=`), l'echantillonneur NUTS **se contente de reproduire le prior** -- les diagnostics R-hat ~ 1.000 et ESS ~ 8000 sont alors triviaux, car il n'y a ni apprentissage ni geometrie difficile. Autrement dit, sur ce cas **degénère**, `pm.sample` est strictement equivalent a `np.random.beta(3, 7)`.\n",
     "\n",
-    "Pour que le MCMC apporte une valeur distinctive (Prong-B), il faut un probleme ou **aucune solution analytique n'existe** : c'est le cas des lors qu'on evalue la Valeur de l'Information sur un **portefeuille de plusieurs sites** aux rendements heterogenes, en modelisant cette heterogeneite par un **modele hierarchique**. Le *partial pooling* (chaque site emprunte de l'information aux autres) induit une posterior jointe non-conjuguee que seul un echantillonneur MCMC peut explorer."
+    "Pour que le MCMC apporte une valeur distinctive (Prong-B), il faut un problème ou **aucune solution analytique n'existe** : c'est le cas des lors qu'on évalue la Valeur de l'Information sur un **portefeuille de plusieurs sites** aux rendements heterogenes, en modelisant cette heterogeneite par un **modele hierarchique**. Le *partial pooling* (chaque site emprunte de l'information aux autrès) induit une posterior jointe non-conjuguée que seul un echantillonneur MCMC peut explorer."
    ]
   },
   {
@@ -2891,14 +2891,14 @@
     "### Exercice 4 : Valeur de l'Information sur un portefeuille hierarchique\n",
     "\n",
     "On considere maintenant un **portefeuille de N sites petroliers** avec une structure\n",
-    "hierarchique : la probabilite de trouver du petrole sur chaque site suit un prior\n",
+    "hierarchique : la probabilité de trouver du petrole sur chaque site suit un prior\n",
     "commun `p_i ~ Beta(alpha, beta)` avec hyperpriors sur `alpha` et `beta`.\n",
     "\n",
     "**Objectif** : Completez le calcul de la **Valeur de l'Information au niveau du\n",
     "portefeuille** en propageant l'incertitude hierarchique via MCMC (PyMC).\n",
     "\n",
     "**Questions** :\n",
-    "1. Pourquoi le **partial pooling** (modele hierarchique) est-il preferable au\n",
+    "1. Pourquoi le **partial pooling** (modele hierarchique) est-il préférable au\n",
     "   pooling complet ou au no-pooling pour estimer les `p_i` ?\n",
     "2. Tracez la distribution de l'EVPI portfolio : `EVPI_portfolio = sum_i EVPI(p_i)`\n",
     "   sur les posteriors MCMC. Quelle est la **valeur de l'information partagee**\n",
@@ -2908,7 +2908,7 @@
     "\n",
     "**Indice** : Utilisez la parametrisation **non-centree**\n",
     "`p_i = sigmoid(mu + sigma * eta_i)` avec `eta_i ~ N(0, 1)` pour eviter les\n",
-    "problemes de funnel dans le posterior MCMC."
+    "problèmes de funnel dans le posterior MCMC."
    ]
   },
   {
@@ -3088,9 +3088,9 @@
    "source": [
     "### Partial pooling et shrinkage : la signature d'un modele hierarchique\n",
     "\n",
-    "Contrairement au cas conjugue de la section precedente, l'echantillonneur NUTS explore ici une posterior jointe a 10 parametres (`mu`, `sigma`, 8 offsets `z_i`) **sans solution analytique**. Les diagnostics R-hat / ESS deviennent alors veritablement informatifs.\n",
+    "Contrairement au cas conjugué de la section précèdente, l'echantillonneur NUTS explore ici une posterior jointe a 10 parametrès (`mu`, `sigma`, 8 offsets `z_i`) **sans solution analytique**. Les diagnostics R-hat / ESS deviennent alors veritablement informatifs.\n",
     "\n",
-    "Le phenomene caracteristique est le **shrinkage** (retraction) : les sites a faible nombre de forages (ex. `Sud-C` 0/4, `Sud-D` 0/3) ne sont pas estimes a 0% comme le suggererait le MLE no-pooling -- leur posterior est *tire vers la moyenne de la population*, modelisant explicitement notre incertitude sur ces sites sous-echantillonnes. A l'inverse, les sites bien echantillonnes (`Est-2` 6/30) restent proches de leur MLE. C'est le **partial pooling**, impossible a obtenir en forme fermee."
+    "Le phénomène caractéristique est le **shrinkage** (retraction) : les sites a faible nombre de forages (ex. `Sud-C` 0/4, `Sud-D` 0/3) ne sont pas estimes a 0% comme le suggererait le MLE no-pooling -- leur posterior est *tire vers la moyenne de la population*, modelisant explicitement notre incertitude sur ces sites sous-echantillonnes. A l'inverse, les sites bien echantillonnes (`Est-2` 6/30) restent proches de leur MLE. C'est le **partial pooling**, impossible a obtenir en forme fermee."
    ]
   },
   {
@@ -3256,7 +3256,7 @@
     "\n",
     "La **parametrisation non-centree** `logit(p_i) = mu + sigma * z_i` (avec `z_i ~ N(0,1)`) est essentielle dans les modeles hierarchiques : elle decouple l'estimation de la moyenne de population `mu` de celle de la dispersion `sigma`, evitant le **funnel de Neal** -- une pathologie geometrique qui apparait avec la parametrisation centree quand `sigma` est faible et qui piege l'echantillonneur. Avec cette parametrisation, `target_accept = 0.95` suffit a obtenir une convergence stable.\n",
     "\n",
-    "**Lecon Prong-B** : le modele conjugue 1-site (section precedente) reste **pedagogiquement valable** comme introduction au vocabulaire MCMC (prior, posterior, R-hat, ESS), mais il est honnete de reconnaitre qu'il ne met **pas** l'echantillonneur NUTS au defi -- la posterior y egale le prior. Le modele hierarchique multi-sites ci-dessus, en revanche, exhibe une geometrie reelle (partial pooling, shrinkage, posterior jointe non-conjuguee) qui **justifie pleinement** l'usage de PyMC et des diagnostics ArviZ. C'est sur ce type de probleme que la Valeur de l'Information (EVPI/EVSI) devient une distribution non-triviale, issue de la propagation de l'incertitude conjointe entre sites."
+    "**Lecon Prong-B** : le modele conjugué 1-site (section précèdente) reste **pedagogiquement valable** comme introduction au vocabulaire MCMC (prior, posterior, R-hat, ESS), mais il est honnete de reconnaitre qu'il ne met **pas** l'echantillonneur NUTS au defi -- la posterior y egale le prior. Le modele hierarchique multi-sites ci-dessus, en revanche, exhibe une geometrie réelle (partial pooling, shrinkage, posterior jointe non-conjuguée) qui **justifie pleinement** l'usage de PyMC et des diagnostics ArviZ. C'est sur ce type de problème que la Valeur de l'Information (EVPI/EVSI) devient une distribution non-triviale, issue de la propagation de l'incertitude conjointe entre sites."
    ]
   },
   {
@@ -3273,20 +3273,20 @@
     "| EVPI parapluie | EU(info parfaite) - EU(optimal) | Pluie (P=0.3) | 3.5 |\n",
     "| EVPI forage | E[max_action par etat] - max_action | Petrole (P=0.3) | 90k EUR |\n",
     "| EVSI forage | E[max_action apres test] - EU(optimal) | Test sismique | 23k EUR (net -27k) |\n",
-    "| EVPI tresor | 90 - 10 | 5 coffres | 80 |\n",
-    "| EVSI tresor | Monte Carlo | Detecteur de metal | 7.9 (10% eff.) |\n",
+    "| EVPI trèsor | 90 - 10 | 5 coffres | 80 |\n",
+    "| EVSI trèsor | Monte Carlo | Detecteur de metal | 7.9 (10% eff.) |\n",
     "| EVPI medical | Classe generique | 3 etats, 3 actions | 24 |\n",
     "| EVSI Test1 | Classe generique | Test sanguin | ~0 (net -50) |\n",
     "| EVSI Test2 | Classe generique | Imagerie | 13 (net -487, 54% eff.) |\n",
     "| EVPI MCMC | Meta-prior Beta(3,7) | Forage incertain | ~90k (moyenne, IC90 [29k, 164k]) |\n",
     "\n",
-    "### Comparaison des efficacites\n",
+    "### Comparaison des efficacités\n",
     "\n",
     "| Test | Efficacite EVSI/EVPI | Rentable ? |\n",
     "|------|---------------------|------------|\n",
     "| Oracle meteo | 100% (EVPI) | N/A |\n",
     "| Test sismique | 26% | Non (cout > EVSI) |\n",
-    "| Detecteur tresor | 10% | Oui (pas de cout) |\n",
+    "| Detecteur trèsor | 10% | Oui (pas de cout) |\n",
     "| Test sanguin | ~0% | Non |\n",
     "| Imagerie medicale | 54% | Non (cout 500 >> EVSI 13) |"
    ]
@@ -3379,21 +3379,21 @@
     "### Points cles\n",
     "- **EVPI** (Expected Value of Perfect Information) borne superieurement la valeur de toute observation\n",
     "- **EVSI** (Expected Value of Sample Information) mesure la valeur d'un echantillon fini\n",
-    "- Le cout d'observation doit etre inferieur a l'EVSI pour justifier l'acquisition\n",
-    "- L'EVPI est maximal quand la decision est la plus equilibree (zone d'indifference)\n",
+    "- Le cout d'observation doit etre inférieur a l'EVSI pour justifier l'acquisition\n",
+    "- L'EVPI est maximal quand la decision est la plus équilibree (zone d'indifference)\n",
     "- L'information n'a de valeur que si elle peut **changer la decision**\n",
     "\n",
     "### Apport PyMC\n",
-    "- L'estimation MCMC permet de propager l'incertitude sur les parametres dans le calcul de VoI\n",
+    "- L'estimation MCMC permet de propager l'incertitude sur les parametrès dans le calcul de VoI\n",
     "- Un meta-prior Beta sur P(petrole) transforme l'EVPI en distribution, fournissant des intervalles de credibilite\n",
-    "- En pratique, cette approche est essentielle quand les parametres sont estimes a partir de donnees limitees\n",
+    "- En pratique, cette approche est essentielle quand les parametrès sont estimes a partir de donnees limitées\n",
     "\n",
     "### Resume des scenarios\n",
     "\n",
     "| Domaine | Conclusion cles |\n",
     "|---------|----------------|\n",
     "| Meteo | EVPI = 3.5 (faible car l'info ne change qu'un confort) |\n",
-    "| Forage | EVPI = 90k, mais test sismique non rentable avec ces parametres |\n",
+    "| Forage | EVPI = 90k, mais test sismique non rentable avec ces parametrès |\n",
     "| Tresor | Detecteur capture 10% de l'info parfaite (EVSI = 7.9) |\n",
     "| Medical | Les deux tests sont non rentables (utilites trop faibles) |\n",
     "| MCMC | Meta-prior fournit un intervalle de credibilite [29k, 164k] pour l'EVPI |\n",


### PR DESCRIPTION
## Summary

Restore French accents in markdown source cells of `MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-5-Value-Information.ipynb` (15ème étape de la vague c.594-c.605-c.606-c.607-c.608 cross-famille / densification intra-family Probas/PyMC post c.601 PyMC-6 — diversification R6 anti-monotonie après GenAI/Texte c.607).

## Metrics

- **142 cures** appliquées sur **45 cellules markdown** (135 autocure + 7 surgical MD-only)
- 1 file / 1 domain / 1 feature (R3 atomicité)
- R6 intra-family densification : Probas/PyMC (2ème notebook PyMC depuis c.601 PyMC-6, 1er post-c.601) suite chaîne 15/15 T1 cross-famille
- +45/-45 lignes diff (cellules monolignes regroupées)
- LF 3453/3452 (delta -1, naturel par cell regrouping)
- CRLF 0/0 préservé
- bytes delta +217 (142 cures × ~1.5 byte/cur average)
- 78 cells préservées (49 markdown + 29 code)

## Stop & Repair strict (HARD, règle 6 secrets-hygiene.md)

- **0 code cell source diff**
- **0 outputs diff**
- **0 execution_count diff**
- **0 cell added/removed** (78 cells préservées)
- nbformat 4.5 préservé
- CRLF 0/0 préservé
- LF 3453/3452
- Pas de hand-edit sur une sortie de cellule

## Pré-flight collision (L679-L1 ★★)

`gh pr list --state open --search "DecPyMC-5-Value-Information.ipynb in:title"` : aucune PR concurrente. → **0 collision**.

`gh pr list --state all --search "DecPyMC-5-Value-Information"` : 5 PRs MERGED dans scopes distincts (Colab badges, README figures, rename, lift exo, SOTA ledger, seed translation). → **0 collision** accent restoration.

## Leçons cumulées (synchronisation avec vagues précédentes)

- **Leçon c.591 ★** : binary write `open('wb')` + `.encode('utf-8')` pour préserver LF
- **Leçon c.593 ★** : raw-text surgical bypass `nbformat.write` via `json.dumps(indent=4)` + closing `]` 3-space indent fix
- **Leçon c.596 ★** : pre-commit grep validation des participes passés + désambiguïsation présent/participe
- **Leçon c.599 ★** : pondere-3rd-ps-disambiguation
- **Leçon c.601 ★** : verifie-3rd-ps-disambiguation
- **Leçon c.602 ★** : identifie-3rd-ps-disambiguation
- **Leçon c.603 ★** : observe-pp-disambiguation (no-op default + post-fix surgical PP insertion)
- **Leçon c.604 ★ (L528 ★)** : md-only-strict-surgical-fixes — script `surgical_md_only_cXXX.py` filtre `cell_type == 'markdown'` AVANT substitution

## Leçon c.608 ★ (NEW) : conjugue-stem-omission dans TARGETS

**Application directe de c.604 ★ + L528 extension c.606-c.607** : pour cette PR c.608, `surgical_md_only_c608.py` (copie conforme filtrant `cell_type == 'markdown'`) est appelé **même quand l'auto-cure suffit partiellement** — defense in depth :

- **Pre-commit audit grep a détecté 6 FP candidates** : "observer" (cell[22]+cell[63] infinitif présent), "observe" (cell[24] adjectif/participe m.sg), "accepte" (cell[34] présent 3ps sg), "considere" (cell[68] présent 1ps sg), "conjugue" (cell[67]×3 + cell[70] + cell[73] + cell[58] + cell[51] = 9 occurrences adjectif m.sg).
- **5 cas résolus comme no-op** (infinitif/présent sans accent requis) : observer, observe (participe), accepte, considere — TARGETS stem list ne les inclut pas et c'est correct.
- **1 cas NOUVEAU détecté : conjugué family** : "conjugue" absent du TARGETS de c.604-c.607 → autocure n'a rien fixé. Surgical pass ajoute 4 entrées (conjugue/conjugues/conjuguee/conjuguees) → **7 cures** sur **5 cells** (cell[51]+cell[58]+cell[67]+cell[70]+cell[73]).
- **Leçon pour c.609+** : la famille `conjugué` (vocabulaire stats bayésiennes/MCMC) doit être ajoutée au TARGETS master pour les notebooks Probas/PyMC. Cf. issue #2876 backlog pour suivi.

## Pre-commit grep (lesson c.596+)

Toutes les formes en `-é`/`-ée`/`-ées` vérifiées par contexte : **6 cas examinés** (observer×2 + observe + accepte + considere + conjugue×9) — **1 nouveau cas FP potentiel résolu par surgical pass** (conjugue family).

## Scope strict : markdown only (leçon c.598 ★)

Code cells + outputs INCHANGÉS (0 diff). Les occurrences `PyMC`, `pm.sample`, `NUTS`, `MCMC`, `Beta`, `Bernoulli`, `R-hat`, `ESS`, `prior`, `posterior`, `likelihood`, `seed`, `trace` dans les **commentaires Python** (`# ...`), **docstrings** (`"""..."""`), et **string-literals stdout** (`print(...)`) restent volontairement sans accent :

- **Commentaires Python** + **docstrings** : OUT of scope per ai-01 accent contract
- **String-literals stdout** : nécessitent re-exécution Python (PyMC/Aesara/JAX) pour cohérence output, hors scope c.608 (R3 atomic 1f/1feature/1domain)

Voir issue #2876 pour batch dédié string-literal re-execution.

## Self-pick cross-pool validation

Issue #2876 (CLOSED 2026-07-18T01:16:57Z mais `See #2876` reste valide pour contributions partielles pré-close — pattern perenne rollout). Pool global = `gh issue list --state open` ~65 issues. R3 atomic = 1f/1feature/1dom, R6 intra-family densification = Probas/PyMC 2ème notebook (c.601 PyMC-6 + c.608 DecPyMC-5 Value-Information) — 15/15 chaîne T1.

See #2876
