### PR TITLE
fix(gametheory,#2876): restore FR accents in GameTheory-11-BayesianGames markdown (172 cures, 43 cells)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-11-BayesianGames.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-11-BayesianGames.ipynb
@@ -18,26 +18,26 @@
     "\n",
     "**Navigation** : [<< 10-ForwardInduction-SPE](GameTheory-10-ForwardInduction-SPE.ipynb) | [Index](README.md) | [12-ReputationGames >>](GameTheory-12-ReputationGames.ipynb)\n",
     "\n",
-    "## Jeux Bayesiens : Information Incomplete et Croyances\n",
+    "## Jeux Bayesiens : Information Incomplète et Croyances\n",
     "\n",
-    "Ce notebook introduit les **jeux bayesiens** ou les joueurs ont une incertitude sur les caracteristiques des autres (types, gains, strategies disponibles).\n",
+    "Ce notebook introduit les **jeux bayesiens** ou les joueurs ont une incertitude sur les caractéristiques des autrès (types, gains, stratégies disponibles).\n",
     "\n",
     "### Objectifs d'apprentissage\n",
     "\n",
-    "1. Comprendre la distinction information **imparfaite** vs **incomplete**\n",
+    "1. Comprendre la distinction information **imparfaite** vs **incomplète**\n",
     "2. Maitriser le concept de **type** et de **croyance**\n",
-    "3. Definir et calculer l'**equilibre bayesien de Nash**\n",
+    "3. Definir et calculer l'**équilibre bayesien de Nash**\n",
     "4. Analyser des jeux classiques : Cournot incertain, encheres\n",
     "5. Introduire les **jeux de signaling**\n",
     "\n",
     "### Prerequis\n",
     "\n",
-    "- Notebooks 1-10 : Fondations et raffinements d'equilibre\n",
-    "- Notions de base en probabilites (regle de Bayes, distribution conditionnelle)\n",
+    "- Notebooks 1-10 : Fondations et raffinements d'équilibre\n",
+    "- Notions de base en probabilités (regle de Bayes, distribution conditionnelle)\n",
     "- Familiarite avec les jeux extensifs et l'induction avant\n",
     "\n",
     "### Duree estimee : 65 minutes\n",
-    "\n\n> *Ancres savantes -- Harsanyi, J.C. (1967-1968), Games with Incomplete Information Played by 'Bayesian' Players, I-III, Management Science 14(3):159-182, 14(5):320-334, 14(7):406-424 (transformation de Harsanyi et jeux bayesiens : modelisation de l'information incomplete par des types et des croyances, fondement de l'equilibre bayesien de Nash enseigne dans ce notebook ; prix Nobel d'economie 1994) ; Vickrey, W. (1961), Counterspeculation, Auctions, and Competitive Sealed Tenders, Journal of Finance 16(1):8-37 (theorie des encheres : encheres au second prix / Vickrey auction, equivalente revelation des valuations ; prix Nobel d'economie 1996) ; Spence, A.M. (1973), Job Market Signaling, Quarterly Journal of Economics 87(3):355-374 (theorie du signal / signaling : education comme signal couteux d'une productivite, equilibre separateur vs pooling ; prix Nobel d'economie 2001).*"
+    "\n\n> *Ancres savantes -- Harsanyi, J.C. (1967-1968), Games with Incomplète Information Played by 'Bayesian' Players, I-III, Management Science 14(3):159-182, 14(5):320-334, 14(7):406-424 (transformation de Harsanyi et jeux bayesiens : modelisation de l'information incomplète par des types et des croyances, fondement de l'équilibre bayesien de Nash enseigne dans ce notebook ; prix Nobel d'economie 1994) ; Vickrey, W. (1961), Counterspeculation, Auctions, and Competitive Sealed Tenders, Journal of Finance 16(1):8-37 (théorie des encheres : encheres au second prix / Vickrey auction, équivalente revelation des valuations ; prix Nobel d'economie 1996) ; Spence, A.M. (1973), Job Market Signaling, Quarterly Journal of Economics 87(3):355-374 (théorie du signal / signaling : education comme signal couteux d'une productivite, équilibre separateur vs pooling ; prix Nobel d'economie 2001).*"
    ]
   },
   {
@@ -103,12 +103,12 @@
     "### Configuration de l'environnement\n",
     "\n",
     "Ce notebook utilise les bibliotheques suivantes pour l'analyse des jeux bayesiens :\n",
-    "- **NumPy** : Calculs numeriques et generation aleatoire\n",
-    "- **SciPy** : Resolution de systemes d'equations (fsolve) pour l'equilibre de Cournot\n",
-    "- **Matplotlib** : Visualisations des strategies d'enchere et comparaisons\n",
+    "- **NumPy** : Calculs numeriques et génération aléatoire\n",
+    "- **SciPy** : Resolution de systèmes d'equations (fsolve) pour l'équilibre de Cournot\n",
+    "- **Matplotlib** : Visualisations des stratégies d'enchere et comparaisons\n",
     "- **Dataclasses** : Structures de donnees propres pour les jeux\n",
     "\n",
-    "Le code qui suit implemente les concepts fondamentaux des jeux bayesiens : types, croyances, et equilibre bayesien de Nash."
+    "Le code qui suit implemente les concepts fondamentaux des jeux bayesiens : types, croyances, et équilibre bayesien de Nash."
    ]
   },
   {
@@ -125,22 +125,22 @@
     "tags": []
    },
    "source": [
-    "## 1. Information Imparfaite vs Incomplete\n",
+    "## 1. Information Imparfaite vs Incomplète\n",
     "\n",
     "### 1.1 Distinction Fondamentale\n",
     "\n",
     "| Type | Description | Exemple |\n",
     "|------|-------------|----------|\n",
     "| **Imparfaite** | Incertitude sur les **actions** jouees | Poker: je ne vois pas tes cartes jouees |\n",
-    "| **Incomplete** | Incertitude sur les **caracteristiques** du jeu | Je ne connais pas ta fonction de gain |\n",
+    "| **Incomplète** | Incertitude sur les **caractéristiques** du jeu | Je ne connais pas ta fonction de gain |\n",
     "\n",
     "### 1.2 Transformation de Harsanyi\n",
     "\n",
-    "Harsanyi (1967-68) a montre comment transformer un jeu a information incomplete en jeu a information imparfaite :\n",
+    "Harsanyi (1967-68) a montre comment transformer un jeu a information incomplète en jeu a information imparfaite :\n",
     "\n",
-    "1. Introduire des **types** pour chaque joueur (caracteristiques privees)\n",
+    "1. Introduire des **types** pour chaque joueur (caractéristiques privees)\n",
     "2. Ajouter un joueur **Nature** qui tire les types selon une distribution commune\n",
-    "3. Chaque joueur observe son propre type mais pas celui des autres\n",
+    "3. Chaque joueur observe son propre type mais pas celui des autrès\n",
     "4. Le jeu devient a information imparfaite (sur les types)"
    ]
   },
@@ -255,10 +255,10 @@
     "- `payoffs` : Fonction (types, actions) → gains\n",
     "\n",
     "**Methodes implementees** :\n",
-    "- `get_conditional_prob` : Applique la regle de Bayes pour calculer P(types autres | mon type)\n",
+    "- `get_conditional_prob` : Applique la regle de Bayes pour calculer P(types autrès | mon type)\n",
     "- `__post_init__` : Verifie que le prior est une distribution valide\n",
     "\n",
-    "**Design pattern** : Cette structure permet de representer n'importe quel jeu bayesien fini. Les types sont des chaines de caracteres arbitraires, les actions peuvent etre discretes, et la fonction de gains est laissee a la discretion de l'utilisateur."
+    "**Design pattern** : Cette structure permet de représenter n'importe quel jeu bayesien fini. Les types sont des chaines de caractères arbitraires, les actions peuvent etre discretes, et la fonction de gains est laissee a la discretion de l'utilisateur."
    ]
   },
   {
@@ -279,7 +279,7 @@
     "\n",
     "### 2.1 Definition\n",
     "\n",
-    "Un **equilibre bayesien de Nash (BNE)** est un profil de strategies $\\sigma = (\\sigma_1, ..., \\sigma_n)$ ou chaque $\\sigma_i$ est une fonction $\\sigma_i: T_i \\to \\Delta(A_i)$ qui specifie une strategie mixte pour chaque type du joueur $i$.\n",
+    "Un **équilibre bayesien de Nash (BNE)** est un profil de stratégies $\\sigma = (\\sigma_1, ..., \\sigma_n)$ ou chaque $\\sigma_i$ est une fonction $\\sigma_i: T_i \\to \\Delta(A_i)$ qui specifie une stratégie mixte pour chaque type du joueur $i$.\n",
     "\n",
     "Le profil $\\sigma$ est un BNE si pour tout joueur $i$ et tout type $t_i \\in T_i$ :\n",
     "\n",
@@ -288,8 +288,8 @@
     "### 2.2 Interpretation\n",
     "\n",
     "- Chaque type de chaque joueur maximise son gain **espere**\n",
-    "- L'esperance est prise sur les types des autres (conditionnellement au sien)\n",
-    "- Les autres sont supposes jouer selon leur strategie d'equilibre"
+    "- L'esperance est prise sur les types des autrès (conditionnellement au sien)\n",
+    "- Les autrès sont supposes jouer selon leur stratégie d'équilibre"
    ]
   },
   {
@@ -401,15 +401,15 @@
     "tags": []
    },
    "source": [
-    "### Implementation : Verification de l'equilibre bayesien\n",
+    "### Implementation : Verification de l'équilibre bayesien\n",
     "\n",
     "Le code ci-dessus implemente deux fonctions fondamentales pour l'analyse des jeux bayesiens :\n",
     "\n",
-    "1. **`compute_expected_payoff`** : Calcule le gain espere d'un joueur en sommant sur tous les profils de types possibles des autres joueurs, conditionnellement a son propre type. Utilise la regle de Bayes pour les probabilites conditionnelles.\n",
+    "1. **`compute_expected_payoff`** : Calcule le gain espere d'un joueur en sommant sur tous les profils de types possibles des autrès joueurs, conditionnellement a son propre type. Utilise la regle de Bayes pour les probabilités conditionnelles.\n",
     "\n",
     "2. **`is_bayesian_nash_equilibrium`** : Verifie qu'aucun joueur n'a de deviation profitable. Pour chaque joueur et chaque type, on teste toutes les actions alternatives. Si aucune ne donne un gain superieur (a tolerance 1e-6 pres), c'est un BNE.\n",
     "\n",
-    "**Methodologie** : L'approche est exhaustive pour les jeux en strategies pures. On enumere tous les profils d'actions et on verifie la condition d'optimalite pour chaque type."
+    "**Methodologie** : L'approche est exhaustive pour les jeux en stratégies pures. On enumere tous les profils d'actions et on vérifie la condition d'optimalite pour chaque type."
    ]
   },
   {
@@ -540,19 +540,19 @@
    "source": [
     "### Interpretation : Structure du jeu bayesien\n",
     "\n",
-    "**Jeu cree** : Bataille des Sexes avec incertitude sur les preferences de J2\n",
+    "**Jeu cree** : Bataille des Sexes avec incertitude sur les préférences de J2\n",
     "\n",
     "| Element | Valeur | Interpretation |\n",
     "|---------|--------|----------------|\n",
     "| Joueur 1 | Type unique \"N\" | Pas d'incertitude sur J1 |\n",
-    "| Joueur 2 | Types \"O\" (Opera-lover) ou \"F\" (Foot-lover) | Incertitude sur les preferences |\n",
-    "| Prior | P(O) = 0.7, P(F) = 0.3 | J1 pense que J2 prefere Opera avec proba 70% |\n",
+    "| Joueur 2 | Types \"O\" (Opera-lover) ou \"F\" (Foot-lover) | Incertitude sur les préférences |\n",
+    "| Prior | P(O) = 0.7, P(F) = 0.3 | J1 pense que J2 préféré Opera avec proba 70% |\n",
     "| Actions | Opera (O) ou Foot (F) pour les deux | Meme ensemble d'actions |\n",
     "\n",
     "**Structure bayesienne** :\n",
     "- J1 ne connait pas le type de J2, mais connait la distribution a priori\n",
     "- J2 connait son propre type et joue en consequence\n",
-    "- L'information est *incomplete* pour J1, *complete* pour J2\n",
+    "- L'information est *incomplète* pour J1, *complète* pour J2\n",
     "\n",
     "> **Note technique** : Ce jeu se transforme en jeu a information imparfaite via Harsanyi : Nature tire le type de J2, J1 observe seulement sa propre action (pas le type de J2)."
    ]
@@ -571,7 +571,7 @@
     "tags": []
    },
    "source": [
-    "Recherche des equilibres bayesiens du jeu."
+    "Recherche des équilibres bayesiens du jeu."
    ]
   },
   {
@@ -686,7 +686,7 @@
    "source": [
     "### Interpretation : Equilibres bayesiens de la Bataille des Sexes\n",
     "\n",
-    "**Trois equilibres trouves** :\n",
+    "**Trois équilibres trouves** :\n",
     "\n",
     "| BNE | J1 | J2 type O | J2 type F | Gain J1 | Gains J2 |\n",
     "|-----|-----|-----------|-----------|---------|----------|\n",
@@ -694,12 +694,12 @@
     "| #2 (Separateur) | Opera | Opera | Foot | 1.40 | O:1.0, F:0.0 |\n",
     "| #3 (Pooling Foot) | Foot | Foot | Foot | 1.00 | O:0.0, F:2.0 |\n",
     "\n",
-    "**Analyse strategique** :\n",
-    "- **BNE #1** : Equilibre \"pooling\" ou tout le monde va a l'Opera, meme le type F qui prefere Foot ! C'est un equilibre car J1 joue Opera (dominant avec p=0.7) et J2 anticipe cela\n",
-    "- **BNE #2** : Equilibre \"separateur\" ou chaque type joue selon ses vraies preferences. J1 joue Opera car p=0.7 > seuil critique\n",
+    "**Analyse stratégique** :\n",
+    "- **BNE #1** : Equilibre \"pooling\" ou tout le monde va a l'Opera, même le type F qui préféré Foot ! C'est un équilibre car J1 joue Opera (dominant avec p=0.7) et J2 anticipe cela\n",
+    "- **BNE #2** : Equilibre \"separateur\" ou chaque type joue selon ses vraies préférences. J1 joue Opera car p=0.7 > seuil critique\n",
     "- **BNE #3** : Equilibre \"pooling\" ou tout le monde va au Foot, moins favorable pour J1 (gain 1.0 vs 2.0)\n",
     "\n",
-    "> **Note technique** : Le type F a gain 0 dans BNE #1 et #2 car il est \"force\" de jouer contre ses preferences. C'est le cout d'etre un type minoritaire (p=0.3)."
+    "> **Note technique** : Le type F a gain 0 dans BNE #1 et #2 car il est \"force\" de jouer contre ses préférences. C'est le cout d'etre un type minoritaire (p=0.3)."
    ]
   },
   {
@@ -716,26 +716,26 @@
     "tags": []
    },
    "source": [
-    "### Analyse des equilibres bayesiens\n",
+    "### Analyse des équilibres bayesiens\n",
     "\n",
-    "Les resultats ci-dessus illustrent plusieurs phenomenes importants :\n",
+    "Les résultats ci-dessus illustrent plusieurs phénomènes importants :\n",
     "\n",
     "**BNE #1 et #3 : Equilibres de coordination**\n",
-    "- Dans BNE #1, tout le monde va a l'Opera (meme le type F qui prefere Foot !)\n",
+    "- Dans BNE #1, tout le monde va a l'Opera (même le type F qui préféré Foot !)\n",
     "- Dans BNE #3, tout le monde va au Foot\n",
-    "- Ce sont des equilibres \"pooling\" ou le type de J2 ne change pas son comportement\n",
+    "- Ce sont des équilibres \"pooling\" ou le type de J2 ne change pas son comportement\n",
     "\n",
     "**BNE #2 : Equilibre separateur**\n",
     "- Le type O joue Opera, le type F joue Foot\n",
-    "- Chaque type joue selon ses vraies preferences\n",
+    "- Chaque type joue selon ses vraies préférences\n",
     "- J1 joue Opera car p=0.7 (il anticipe plus souvent Opera)\n",
     "\n",
     "**Pourquoi le BNE #2 existe-t-il ?**\n",
-    "- J1 joue Opera → gain = 0.7×2 + 0.3×0 = 1.4 avec la strategie separatrice de J2\n",
+    "- J1 joue Opera → gain = 0.7×2 + 0.3×0 = 1.4 avec la stratégie separatrice de J2\n",
     "- Si J1 jouait Foot → gain = 0.7×0 + 0.3×1 = 0.3\n",
-    "- Donc J1 prefere Opera, ce qui valide les croyances !\n",
+    "- Donc J1 préféré Opera, ce qui valide les croyances !\n",
     "\n",
-    "**Observation cle** : Le gain de J2 type F est **0** dans les BNE #1 et #2 ! Il est force de jouer contre ses preferences car J1 joue majoritairement Opera. C'est le \"cout\" d'etre un type minoritaire."
+    "**Observation cle** : Le gain de J2 type F est **0** dans les BNE #1 et #2 ! Il est force de jouer contre ses préférences car J1 joue majoritairement Opera. C'est le \"cout\" d'etre un type minoritaire."
    ]
   },
   {
@@ -783,12 +783,12 @@
    "source": [
     "### Transition : Du BoS aux applications economiques\n",
     "\n",
-    "Apres avoir analyse la Bataille des Sexes avec incertitude (un jeu \"jouet\"), nous passons maintenant a des applications economiques reelles ou l'information incomplete est centrale : le duopole de Cournot et les encheres.\n",
+    "Apres avoir analyse la Bataille des Sexes avec incertitude (un jeu \"jouet\"), nous passons maintenant a des applications economiques réelles ou l'information incomplète est centrale : le duopole de Cournot et les encheres.\n",
     "\n",
     "**Questions de transition** :\n",
     "- Comment l'incertitude sur les couts affecte-t-elle la concurrence ?\n",
-    "- Comment les encherisseurs se comportent-ils quand ils ne connaissent pas la valeur des autres ?\n",
-    "- Quelles sont les strategies optimales dans ces contextes ?\n",
+    "- Comment les encherisseurs se comportent-ils quand ils ne connaissent pas la valeur des autrès ?\n",
+    "- Quelles sont les stratégies optimales dans ces contextes ?\n",
     "\n",
     "La section suivante explore le duopole de Cournot ou chaque firme ne connait que son propre cout marginal."
    ]
@@ -919,7 +919,7 @@
    "source": [
     "### Interpretation : Solution bayesienne du duopole Cournot\n",
     "\n",
-    "**Resultats de l'equilibre** :\n",
+    "**Resultats de l'équilibre** :\n",
     "\n",
     "| Type de firme | Quantite produite | Rationale |\n",
     "|---------------|-------------------|-----------|\n",
@@ -928,12 +928,12 @@
     "\n",
     "**Analyse des scenarios** (4 cas equiprobables, p=0.25 chacun) :\n",
     "- **(c_L, c_L)** : P=36.7, profits egaux (844.4) - competition intense, prix bas\n",
-    "- **(c_L, c_H)** : P=46.7, asymetrie extreme (1161.1 vs 361.1) - le type bas domine\n",
+    "- **(c_L, c_H)** : P=46.7, asymétrie extrême (1161.1 vs 361.1) - le type bas domine\n",
     "- **(c_H, c_H)** : P=56.7, profits faibles (577.8) - couts eleves pour tous\n",
     "\n",
-    "**Profondeur strategique** : Chaque firme choisit une quantite qui depend de son propre type, mais en anticipant que l'autre firme a aussi une strategie dependante de son type. C'est l'essence de l'equilibre bayesien.\n",
+    "**Profondeur stratégique** : Chaque firme choisit une quantite qui depend de son propre type, mais en anticipant que l'autre firme a aussi une stratégie dependante de son type. C'est l'essence de l'équilibre bayesien.\n",
     "\n",
-    "> **Note technique** : Le systeme d'equations resout simultanement pour q_L et q_H. La solution verifie les conditions de premier ordre pour les deux types."
+    "> **Note technique** : Le système d'equations resout simultanement pour q_L et q_H. La solution vérifie les conditions de premier ordre pour les deux types."
    ]
   },
   {
@@ -950,7 +950,7 @@
     "tags": []
    },
    "source": [
-    "Comparaison avec le modele Cournot a information complete."
+    "Comparaison avec le modele Cournot a information complète."
    ]
   },
   {
@@ -1063,21 +1063,21 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : Impact de l'information incomplete\n",
+    "### Interpretation : Impact de l'information incomplète\n",
     "\n",
-    "**Comparaison des resultats** :\n",
+    "**Comparaison des résultats** :\n",
     "\n",
     "| Scenario | Type L (c=10) | Type H (c=30) | Commentaire |\n",
     "|----------|---------------|---------------|-------------|\n",
-    "| Info complete (c1,c2)=(10,10) | q=30.0 | q=30.0 | Symetrie parfaite |\n",
-    "| Info incomplete | q=31.67 | q=21.67 | Asymetrie strategique |\n",
+    "| Info complète (c1,c2)=(10,10) | q=30.0 | q=30.0 | Symetrie parfaite |\n",
+    "| Info incomplète | q=31.67 | q=21.67 | Asymétrie stratégique |\n",
     "\n",
     "**Observations fondamentales** :\n",
     "1. **Le type a cout bas produit PLUS** (31.67 vs 30.0) car il anticipe qu'un adversaire pourrait etre inefficace (cout haut) et reduira sa quantite\n",
-    "2. **Le type a cout haut produit MOINS** (21.67 vs 23.3) car il anticipe qu'un adversaire pourrait etre tres efficace (cout bas)\n",
-    "3. L'incertitude modifie le comportement de maniere contre-intuitive : le type efficient profite de l'incertitude pour produire davantage\n",
+    "2. **Le type a cout haut produit MOINS** (21.67 vs 23.3) car il anticipe qu'un adversaire pourrait etre très efficace (cout bas)\n",
+    "3. L'incertitude modifie le comportement de manière contre-intuitive : le type efficient profite de l'incertitude pour produire davantage\n",
     "\n",
-    "> **Note technique** : Ce resultat illustre un principe general : l'information incomplete cree de l'heterogeneite strategique, meme quand les types sont ex-ante symetriques."
+    "> **Note technique** : Ce résultat illustre un principe général : l'information incomplète cree de l'heterogeneite stratégique, même quand les types sont ex-ante symétriques."
    ]
   },
   {
@@ -1128,18 +1128,18 @@
    "source": [
     "### Transition : Des oligopoles aux encheres\n",
     "\n",
-    "Nous quittons maintenant le monde de la production industrielle (Cournot) pour entrer dans celui des encheres, ou l'information incomplete joue un role central.\n",
+    "Nous quittons maintenant le monde de la production industrielle (Cournot) pour entrer dans celui des encheres, ou l'information incomplète joue un role central.\n",
     "\n",
     "**Contraste frappant** :\n",
     "- Dans Cournot, l'incertitude porte sur les **couts** de production\n",
     "- Dans les encheres, l'incertitude porte sur les **valuations** privees\n",
     "\n",
     "**Questions cles** :\n",
-    "- Comment maximiser son gain quand on ne connait pas les valeurs des autres ?\n",
+    "- Comment maximiser son gain quand on ne connait pas les valeurs des autrès ?\n",
     "- Faut-il sous-declarer sa valeur (bluff) ou dire la verite ?\n",
-    "- Le format de l'enchere (1er prix vs 2e prix) change-t-il les strategies ?\n",
+    "- Le format de l'enchere (1er prix vs 2e prix) change-t-il les stratégies ?\n",
     "\n",
-    "La section suivante analyse l'enchere au premier prix, ou la strategie optimale est de soustracter."
+    "La section suivante analyse l'enchere au premier prix, ou la stratégie optimale est de soustracter."
    ]
   },
   {
@@ -1257,16 +1257,16 @@
     "### Interpretation : Enchere au premier prix\n",
     "\n",
     "**Resultats de simulation** (10 000 encheres, 2 joueurs) :\n",
-    "- **Revenu moyen du vendeur** : 0.3330 (theorie : 0.3333)\n",
+    "- **Revenu moyen du vendeur** : 0.3330 (théorie : 0.3333)\n",
     "- **Surplus moyen du gagnant** : 0.3330 (le gagnant extrait un surplus egal a ce que le vendeur perd)\n",
     "- **Efficacite** : 100% (le bien va toujours au plus offrant)\n",
     "\n",
     "**Analyse** :\n",
-    "1. Le revenu du vendeur est exactement la valeur theorique (n-1)/(n+1) = 1/3 pour n=2\n",
-    "2. L'efficacite est parfaite : le gagnant est toujours celui avec la plus haute valuation\n",
-    "3. La strategie b(v) = 0.5v est un equilibre bayesien de Nash verifie par simulation\n",
+    "1. Le revenu du vendeur est exactement la valeur théorique (n-1)/(n+1) = 1/3 pour n=2\n",
+    "2. L'efficacité est parfaite : le gagnant est toujours celui avec la plus haute valuation\n",
+    "3. La stratégie b(v) = 0.5v est un équilibre bayesien de Nash vérifie par simulation\n",
     "\n",
-    "> **Note technique** : Avec n=2, chaque joueur offre la moitie de sa valeur. Si v1 > v2, alors b1 > b2, donc le plus \"motiva\" gagne toujours. C'est pourquoi l'efficacite est 100%."
+    "> **Note technique** : Avec n=2, chaque joueur offre la moitie de sa valeur. Si v1 > v2, alors b1 > b2, donc le plus \"motiva\" gagne toujours. C'est pourquoi l'efficacité est 100%."
    ]
   },
   {
@@ -1410,9 +1410,9 @@
     "| 10 | 0.8175 | 0.8186 | 0.8182 |\n",
     "\n",
     "**Observations cles** :\n",
-    "1. Les deux formats donnent quasiment le meme revenu (ecarts < 1%)\n",
+    "1. Les deux formats donnent quasiment le même revenu (ecarts < 1%)\n",
     "2. Le revenu croit avec la concurrence (plus de joueurs = plus de competition = prix plus eleves)\n",
-    "3. Le theoreme d'equivalence est verifie empiriquement\n",
+    "3. Le theoreme d'equivalence est vérifie empiriquement\n",
     "\n",
     "> **Note technique** : L'equivalence tient car dans le 1er prix, les sous-declarent (b < v) mais paient b, tandis que dans le 2e prix, ils declarent vrai (b = v) mais paient v^(2) (2eme plus haute offre). Ces effets se compensent exactement."
    ]
@@ -1433,13 +1433,13 @@
    "source": [
     "### Le theoreme d'equivalence du revenu\n",
     "\n",
-    "Les resultats des simulations confirment un resultat fondamental de la theorie des encheres :\n",
+    "Les résultats des simulations confirment un résultat fondamental de la théorie des encheres :\n",
     "\n",
     "**Theoreme (Equivalence du revenu)** :\n",
-    "Pour des encherisseurs neutres au risque avec valuations i.i.d., tous les formats d'enchere standards (premier prix, second prix, anglais, hollandais) donnent le **meme revenu espere** au vendeur.\n",
+    "Pour des encherisseurs neutrès au risque avec valuations i.i.d., tous les formats d'enchere standards (premier prix, second prix, anglais, hollandais) donnent le **même revenu espere** au vendeur.\n",
     "\n",
     "**Intuition** :\n",
-    "- **Second prix** : Les gens revelent leur vraie valeur, le gagnant paie la 2eme plus haute\n",
+    "- **Second prix** : Les gens révèlent leur vraie valeur, le gagnant paie la 2eme plus haute\n",
     "- **Premier prix** : Les gens sous-declarent, mais le gagnant paie sa propre offre (plus haute)\n",
     "- Ces deux effets se compensent exactement !\n",
     "\n",
@@ -1450,9 +1450,9 @@
     "ou $v^{(2)}$ est la 2eme statistique d'ordre des valuations.\n",
     "\n",
     "**Implications pratiques** :\n",
-    "- Pour un vendeur neutre au risque, le choix du format n'importe pas (en theorie)\n",
+    "- Pour un vendeur neutre au risque, le choix du format n'importe pas (en théorie)\n",
     "- En pratique, les differences apparaissent avec : aversion au risque, collusion, valeurs correlees, etc.\n",
-    "- Le second prix (Vickrey) est souvent prefere car \"dire la verite\" est plus simple"
+    "- Le second prix (Vickrey) est souvent préféré car \"dire la verite\" est plus simple"
    ]
   },
   {
@@ -1548,9 +1548,9 @@
    "source": [
     "### Interpretation : Strategies d'enchere et concurrence\n",
     "\n",
-    "**Visualisation de gauche** : La strategie optimale b(v) = (n-1)/n × v montre que :\n",
+    "**Visualisation de gauche** : La stratégie optimale b(v) = (n-1)/n × v montre que :\n",
     "- Plus il y a de concurrents (n eleve), plus l'offre s'approche de la valeur vraie\n",
-    "- Avec n=2, on offre 50% de sa valeur (strategie tres prudente)\n",
+    "- Avec n=2, on offre 50% de sa valeur (stratégie très prudente)\n",
     "- Avec n=10, on offre 90% de sa valeur (competition intense)\n",
     "\n",
     "**Visualisation de droite** : Le revenu du vendeur croit avec n :\n",
@@ -1590,8 +1590,8 @@
     "| Equilibre | Description |\n",
     "|-----------|-------------|\n",
     "| **Separateur** | Chaque type envoie un signal different |\n",
-    "| **Pooling** | Tous les types envoient le meme signal |\n",
-    "| **Semi-separateur** | Certains types se distinguent, d'autres se melanent |"
+    "| **Pooling** | Tous les types envoient le même signal |\n",
+    "| **Semi-separateur** | Certains types se distinguent, d'autrès se melanent |"
    ]
   },
   {
@@ -1610,14 +1610,14 @@
    "source": [
     "### Transition : De l'information privee a la revelation\n",
     "\n",
-    "Nous avons vu jusqu'ici des situations ou l'information privee reste cachee (types dans Cournot, valuations dans les encheres). Mais que se passe-t-il quand les joueurs veulent **reveler** leur information ?\n",
+    "Nous avons vu jusqu'ici des situations ou l'information privee reste cachee (types dans Cournot, valuations dans les encheres). Mais que se passe-t-il quand les joueurs veulent **révèler** leur information ?\n",
     "\n",
     "**Le paradoxe du signaling** :\n",
     "- Revealer son type peut etre couteux (education, garanties, certifications)\n",
-    "- Ne pas le reveler peut etre pire (etre confondu avec des types inferieurs)\n",
-    "- L'equilibre depend de la credibilite du signal\n",
+    "- Ne pas le révèler peut etre pire (etre confondu avec des types inférieurs)\n",
+    "- L'équilibre depend de la credibilite du signal\n",
     "\n",
-    "La section suivante introduit les **jeux de signaling**, ou l'information privee peut etre transmise de maniere credible via des actions couteuses. L'exemple classique est le modele d'education de Spence."
+    "La section suivante introduit les **jeux de signaling**, ou l'information privee peut etre transmise de manière credible via des actions couteuses. L'exemple classique est le modele d'education de Spence."
    ]
   },
   {
@@ -1763,18 +1763,18 @@
     "\n",
     "**Resultats de l'analyse** :\n",
     "\n",
-    "| Type d'equilibre | Education e | Salaire | Gain type L | Gain type H |\n",
+    "| Type d'équilibre | Education e | Salaire | Gain type L | Gain type H |\n",
     "|------------------|-------------|---------|-------------|-------------|\n",
     "| Pooling | 0 | 1.5 | 1.5 | 1.5 |\n",
     "| Separateur (e*=1) | L:0, H:1 | L:1, H:2 | 1.0 | 1.5 |\n",
     "\n",
     "**Paradoxe fondamental** :\n",
-    "- Dans l'equilibre **pooling**, les types H et L ont le meme gain (1.5). Les types H \"subventionnent\" les types L car l'employeur ne peut pas les distinguer.\n",
-    "- Dans l'equilibre **separateur**, les types H s'eduquent (e*=1) pour signaler leur productivite. Mais le gain ne change pas (1.5 → 1.5) ! L'education est un cout pur sans benefice net.\n",
+    "- Dans l'équilibre **pooling**, les types H et L ont le même gain (1.5). Les types H \"subventionnent\" les types L car l'employeur ne peut pas les distinguer.\n",
+    "- Dans l'équilibre **separateur**, les types H s'eduquent (e*=1) pour signaler leur productivite. Mais le gain ne change pas (1.5 → 1.5) ! L'education est un cout pur sans benefice net.\n",
     "\n",
-    "**Intuition economique** : L'education n'ameliore pas la productivite ici, elle sert seulement de signal. C'est une application classique du principe de \"separation par cout differentiel\" : il est plus couteux pour un type L de s'eduquer que pour un type H.\n",
+    "**Intuition economique** : L'education n'amélioré pas la productivite ici, elle sert seulement de signal. C'est une application classique du principe de \"separation par cout differentiel\" : il est plus couteux pour un type L de s'eduquer que pour un type H.\n",
     "\n",
-    "> **Note technique** : Le seuil de separation e* ∈ [1, 2] depend des parametres. Si le cout de l'education etait le meme pour les deux types, aucun signal credible ne serait possible."
+    "> **Note technique** : Le seuil de separation e* ∈ [1, 2] depend des parametrès. Si le cout de l'education etait le même pour les deux types, aucun signal credible ne serait possible."
    ]
   },
   {
@@ -1795,13 +1795,13 @@
     "\n",
     "Analysez l'enchere all-pay ou :\n",
     "- 2 joueurs, valeurs privees $v_i \\sim U[0,1]$\n",
-    "- Les deux paient leur offre, meme le perdant\n",
+    "- Les deux paient leur offre, même le perdant\n",
     "- Gain gagnant : $v_i - b_i$, perdant : $-b_i$\n",
     "\n",
     "**Questions** :\n",
-    "1. Derivez la strategie d'equilibre $b^*(v)$ et generalisez a $N$ joueurs\n",
+    "1. Derivez la stratégie d'équilibre $b^*(v)$ et généralisez a $N$ joueurs\n",
     "2. Verifiez que c'est un BNE (aucune deviation profitable)\n",
-    "3. Simulez et visualisez les resultats"
+    "3. Simulez et visualisez les résultats"
    ]
   },
   {
@@ -1883,31 +1883,31 @@
    "source": [
     "### Exercice 2 : Mecanisme de Revelation - Enchere de Vickrey\n",
     "\n",
-    "L'enchere de **Vickrey** (second-price sealed bid) est un mecanisme ou :\n",
+    "L'enchere de **Vickrey** (second-price sealed bid) est un mécanisme ou :\n",
     "- Chaque encherisseur soumet une offre en pli scelle\n",
     "- Le plus offrant gagne mais paie le **deuxieme prix** (la deuxieme offre la plus haute)\n",
     "- Gain gagnant : $v_i - b^{(2)}$ ou $b^{(2)}$ est la 2eme offre\n",
     "- Gain perdant : $0$\n",
     "\n",
-    "**Propriete remarquable** : Dans cette enchere, dire la verite ($b_i = v_i$) est une strategie **dominante**.\n",
+    "**Propriete remarquable** : Dans cette enchere, dire la verite ($b_i = v_i$) est une stratégie **dominante**.\n",
     "\n",
     "**Questions** :\n",
     "\n",
     "1. **Implementez** la classe `VickreyAuction` :\n",
-    "   - Methode `run(values, bids)` qui determine le gagnant et calcule les gains\n",
+    "   - Methode `run(values, bids)` qui détermine le gagnant et calcule les gains\n",
     "   - Methode `dominant_strategy(value)` qui retourne l'offre optimale\n",
     "\n",
     "2. **Prouvez l'incitation a la verite** par simulation :\n",
     "   - Simulez 10 000 encheres a 2 joueurs avec valuations $v_i \\sim U[0,1]$\n",
     "   - Montrez que pour un joueur, offrir $b = v$ maximise son gain espere\n",
-    "   - Comparez avec des strategies alternatives : $b = 0.5v$, $b = 0.8v$, $b = 1.2v$\n",
+    "   - Comparez avec des stratégies alternatives : $b = 0.5v$, $b = 0.8v$, $b = 1.2v$\n",
     "\n",
     "3. **Comparez** avec l'enchere au premier prix :\n",
     "   - Calculez le revenu espere du vendeur dans les deux formats\n",
     "   - Verifiez le theoreme d'equivalence du revenu numeriquement\n",
     "\n",
     "4. **Extension** : Que se passe-t-il si les valuations ne sont pas i.i.d. ?\n",
-    "   Simulez un cas ou $v_1 \\sim U[0,1]$ et $v_2 \\sim U[0, 0.5]$ (encherisseur asymetrique).\n",
+    "   Simulez un cas ou $v_1 \\sim U[0,1]$ et $v_2 \\sim U[0, 0.5]$ (encherisseur asymétrique).\n",
     "   La verite reste-t-elle dominante ?\n",
     "\n",
     "**Indice** : Pour la preuve d'incitation, fixez $v_1$ et faites varier $b_1$ sur une grille. Tracez le gain espere en fonction de $b_1$."
@@ -1990,7 +1990,7 @@
     "- Vendeur connait $q$, acheteur non\n",
     "- Valeur pour vendeur: $q$, pour acheteur: $1.5q$\n",
     "\n",
-    "Analysez l'equilibre de marche.\n",
+    "Analysez l'équilibre de marche.\n",
     "\n",
     "**Questions** :\n",
     "1. Quel prix l'acheteur est-il pret a payer s'il ne connait pas $q$ ?\n",
@@ -2069,16 +2069,16 @@
     "### Exercice 4 : Calcul d'un BNE (Bayesian Nash Equilibrium)\n",
     "\n",
     "**Objectifs** :\n",
-    "1. Modeliser un jeu avec information incomplete\n",
+    "1. Modeliser un jeu avec information incomplète\n",
     "2. Calculer les croyances a priori\n",
-    "3. Trouver l'equilibre Bayesien\n",
+    "3. Trouver l'équilibre Bayesien\n",
     "\n",
     "**Contexte** : Enchere first-price a deux joueurs. Chaque joueur a une valeur privee v_i ~ U[0,1]. Les joueurs soumettent des offres b_i simultanement.\n",
     "\n",
     "**Questions** :\n",
-    "1. Quelle est la strategie optimale d'encheres ?\n",
-    "2. Quel est l'equilibre Bayesien symetrique ?\n",
-    "3. Comment le resultat change-t-il avec N joueurs ?"
+    "1. Quelle est la stratégie optimale d'encheres ?\n",
+    "2. Quel est l'équilibre Bayesien symétrique ?\n",
+    "3. Comment le résultat change-t-il avec N joueurs ?"
    ]
   },
   {
@@ -2158,7 +2158,7 @@
     "\n",
     "| Concept | Description |\n",
     "|---------|-------------|\n",
-    "| **Information incomplete** | Incertitude sur les caracteristiques du jeu |\n",
+    "| **Information incomplète** | Incertitude sur les caractéristiques du jeu |\n",
     "| **Type** | Caracteristique privee d'un joueur |\n",
     "| **Prior commun** | Distribution des types connue de tous |\n",
     "| **BNE** | Nash ou chaque type maximise son gain espere |\n",
@@ -2166,14 +2166,14 @@
     "\n",
     "### Points cles\n",
     "\n",
-    "- La transformation de **Harsanyi** convertit info incomplete en imparfaite\n",
+    "- La transformation de **Harsanyi** convertit info incomplète en imparfaite\n",
     "- En **Cournot bayesien**, l'incertitude affecte les quantites\n",
-    "- Les **encheres** illustrent l'interaction strategique sous incertitude\n",
+    "- Les **encheres** illustrent l'interaction stratégique sous incertitude\n",
     "- Le **signaling** permet la revelation credible d'information privee\n",
     "\n",
     "### Prochaine etape\n",
     "\n",
-    "**Notebook 12 : Jeux de Reputation** - Construction de reputation, cheap talk, et modele de Kreps-Wilson."
+    "**Notebook 12 : Jeux de Reputation** - Construction de réputation, cheap talk, et modele de Kreps-Wilson."
    ]
   },
   {
@@ -2192,18 +2192,18 @@
    "source": [
     "## Resume et perspectives\n",
     "\n",
-    "Ce notebook a parcouru les fondements de la theorie des jeux a information incomplete, de la transformation de Harsanyi aux equilibres bayesiens de Nash en passant par les mecanismes d'encheres et de signaling. La Bataille des Sexes avec incertitude a illustre comment l'information incomplete genere trois types d'equilibres (pooling, separateur et hybride), ou le type minoritaire (J2 \"Football\" avec p=0.3) subit systematiquement un gain nul. Le duopole de Cournot bayesien a montre que l'incertitude sur les couts cree une heterogeneite strategique : la firme a cout bas produit davantage qu'en information complete (31.67 vs 30.0), anticipant un adversaire potentiellement moins efficace. Les encheres ont permis de verifier empiriquement le theoreme d'equivalence du revenu : premier prix et second prix generent le meme revenu esperer pour le vendeur, confirme par simulation sur 10000 enchères avec des ecarts inferieurs a 1%.\n",
+    "Ce notebook a parcouru les fondements de la théorie des jeux a information incomplète, de la transformation de Harsanyi aux équilibres bayesiens de Nash en passant par les mécanismes d'encheres et de signaling. La Bataille des Sexes avec incertitude a illustre comment l'information incomplète génère trois types d'équilibres (pooling, separateur et hybride), ou le type minoritaire (J2 \"Football\" avec p=0.3) subit systématiquement un gain nul. Le duopole de Cournot bayesien a montre que l'incertitude sur les couts cree une heterogeneite stratégique : la firme a cout bas produit davantage qu'en information complète (31.67 vs 30.0), anticipant un adversaire potentiellement moins efficace. Les encheres ont permis de vérifier empiriquement le theoreme d'equivalence du revenu : premier prix et second prix génèrent le même revenu esperer pour le vendeur, confirme par simulation sur 10000 enchères avec des ecarts inférieurs a 1%.\n",
     "\n",
-    "Le modele de signaling de Spence a introduit le paradoxe de l'education comme signal couteux : dans l'equilibre separateur, les travailleurs hautement productifs s'eduquent non pas pour ameliorer leur productivite, mais pour se distinguer des types bas, avec un gain net identique a celui de l'equilibre pooling (1.5 dans les deux cas). Ce resultat souligne le role de l'asymetrie des couts de signal comme moteur de la revelation d'information, un principe qui s'etend aux garanties produit, aux certifications professionnelles et aux politiques de dividende en finance.\n",
+    "Le modele de signaling de Spence a introduit le paradoxe de l'education comme signal couteux : dans l'équilibre separateur, les travailleurs hautement productifs s'eduquent non pas pour améliorér leur productivite, mais pour se distinguer des types bas, avec un gain net identique a celui de l'équilibre pooling (1.5 dans les deux cas). Ce résultat souligne le role de l'asymétrie des couts de signal comme moteur de la revelation d'information, un principe qui s'etend aux garanties produit, aux certifications professionnelles et aux politiques de dividende en finance.\n",
     "\n",
-    "Les concepts d'equilibre bayesien de Nash, de theoreme d'equivalence du revenu et de signaling constitueront les briques fondamentales du notebook suivant, consacre aux jeux de reputation. La ou ce notebook traitait de l'information incomplete statique (les types sont fixes et les jeux simultanes), le prochain explorer comment la reputation se construit dynamiquement a travers des interactions repetees, et comment une probabilite infime d'irrationalite suffit a transformer les predictions de la theorie.\n",
-    "\n\n### References academiques\n\n- Harsanyi, J.C. (1967-1968). Games with Incomplete Information Played by 'Bayesian' Players, I-III. Management Science 14(3):159-182, 14(5):320-334, 14(7):406-424.\n- Vickrey, W. (1961). Counterspeculation, Auctions, and Competitive Sealed Tenders. Journal of Finance 16(1):8-37.\n- Spence, A.M. (1973). Job Market Signaling. Quarterly Journal of Economics 87(3):355-374.\n\n"
+    "Les concepts d'équilibre bayesien de Nash, de theoreme d'equivalence du revenu et de signaling constitueront les briques fondamentales du notebook suivant, consacre aux jeux de réputation. La ou ce notebook traitait de l'information incomplète statique (les types sont fixes et les jeux simultanes), le prochain explorer comment la réputation se construit dynamiquement a travers des interactions repetees, et comment une probabilité infime d'irrationalite suffit a transformer les predictions de la théorie.\n",
+    "\n\n### References academiques\n\n- Harsanyi, J.C. (1967-1968). Games with Incomplète Information Played by 'Bayesian' Players, I-III. Management Science 14(3):159-182, 14(5):320-334, 14(7):406-424.\n- Vickrey, W. (1961). Counterspeculation, Auctions, and Competitive Sealed Tenders. Journal of Finance 16(1):8-37.\n- Spence, A.M. (1973). Job Market Signaling. Quarterly Journal of Economics 87(3):355-374.\n\n"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "cb9e8f0b",
-   "source": "> **Lien avec la formalisation Lean** : Les concepts de ce notebook — types, croyances, equilibre bayesien de Nash, jeux de signaling, encheres — sont definis dans [`lean_game_defs/Bayesian.lean`](lean_game_defs/Bayesian.lean) (224 lignes, 0 sorry). On y trouve les structures `BayesianGame` (types, actions, gains dependants du profil de types), `TypeStrategy` et `TypeStrategyProfile` (strategies conditionees par le type), `isBayesianNashEquilibrium` (verification qu'aucune deviation par type n'est profitable), `SignalingGame` (modele de Spence avec emetteur/receveur), `InformationSet` (partition des noeuds de decision), `FirstPriceAuction` (enchere au premier prix) et les definitions du Kuhn poker (`KuhnCard`, `KuhnAction`, `KuhnState`, `kuhnPayoff`). Les modules `Basic.lean` (107 lignes, 0 sorry : `NormalFormGame`, `FiniteGame`) et `Nash.lean` (139 lignes, 0 sorry : meilleure reponse, equilibres de Nash pur/mixte) fournissent les fondements.",
+   "source": "> **Lien avec la formalisation Lean** : Les concepts de ce notebook — types, croyances, équilibre bayesien de Nash, jeux de signaling, encheres — sont définis dans [`lean_game_defs/Bayesian.lean`](lean_game_defs/Bayesian.lean) (224 lignes, 0 sorry). On y trouve les structures `BayesianGame` (types, actions, gains dependants du profil de types), `TypeStrategy` et `TypeStrategyProfile` (stratégies conditionees par le type), `isBayesianNashEquilibrium` (vérification qu'aucune deviation par type n'est profitable), `SignalingGame` (modele de Spence avec emetteur/receveur), `InformationSet` (partition des noeuds de decision), `FirstPriceAuction` (enchere au premier prix) et les définitions du Kuhn poker (`KuhnCard`, `KuhnAction`, `KuhnState`, `kuhnPayoff`). Les modules `Basic.lean` (107 lignes, 0 sorry : `NormalFormGame`, `FiniteGame`) et `Nash.lean` (139 lignes, 0 sorry : meilleure reponse, équilibres de Nash pur/mixte) fournissent les fondements.",
    "metadata": {}
   }
  ],


### PR DESCRIPTION
## fix(gametheory,#2876): restore French accents in GameTheory-11-BayesianGames markdown (172 cures, 43 cells)

### Scope

Single-file PR. Touches **only** `MyIA.AI.Notebooks/GameTheory/GameTheory-11-BayesianGames.ipynb`.

Cure les accents francais perdus dans le markdown pedagogique + commentaires code du notebook (jeux bayesiens, Harsanyi, information incomplete, equilibre de Bayes-Nash). Aucune cellule code executable modifiee.

### R6 anti-monotonie — sous-domaine GameTheory/BayesianGames (distinct de c.598 GameTheory-5 ZeroSum)

c.597 Probas/PyMC → c.598 GameTheory/ZeroSum → c.599 SymbolicAI/SMT 04 → c.600 SymbolicAI/SMT 06 → c.601 Search/Part1 09 → c.602 Sudoku/Comparison-Python → **c.603 GameTheory/11-BayesianGames** (sous-domaine BayesianGames distinct de ZeroSum-Minimax c.598).

7ᵉ registre vague accents, **meme famille GameTheory que c.598 mais sous-domaine neuf** (Bayesian vs ZeroSum — game theory probabiliste vs deterministe).

### c.603 — caps_ratio diagnostic appliqué

Diagnostic pre-cure revele `caps_ratio = 0.0078` (>0.005, <0.01). Guard C598-L1 ★★ applique (skip ALL-CAPS emphasis).

**Script cure_text** = pattern eprouve c.597-L1 ★★ + c.598-L1 ★★ : case-insensitive dict lookup preserving original casing + skip ALL-CAPS stylistic emphasis.

### Verification

| Check | Resultat |
|-------|----------|
| ACCENT-ONLY invariant (NFD-normalized diff vs origin/main) | **0/48 cells mismatch** |
| Stop & Repair : diff outputs | **0** (aucune cellule `outputs` touchee) |
| H.3 pre-commit : `execution_count: null` en code cells | **0/15** (toutes preservees) |
| LF preservation (c.591 ★ binary write) | 2243 → 2243 (CRLF: 0 → 0) |
| C596-L2 grep `determine\|detectee\|geenere\|predite\|predits` | **0 hits** dans le diff |
| Bytes delta | +183 (210,513 → 210,696) |
| Files changed | **1** |
| Domaines | **1** (GameTheory/BayesianGames) |
| One-to-one line replacement | 147 insertions / 147 deletions |

### Anti-§D byte-identity

Source length UNCHANGED. Contenu accent-stripped byte-identique a origin/main (NFD-normalized 0/48 cells). Aucune cellule `# Solution` / `# Exemple resolu` touchee.

### Issues

`See #2876` — partial delivery (1 notebook sur ~1,135 restants dans la vague accents). Registre #2876 reste ouvert jusqu'a epuisement du scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)