### PR TITLE
fix(gametheory,#2876): restore French accents in GameTheory-2b-Lean-Definitions markdown (73 cures, 26 cells)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-2b-Lean-Definitions.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-2b-Lean-Definitions.ipynb
@@ -24,14 +24,14 @@
     "\n",
     "## Introduction\n",
     "\n",
-    "Ce notebook inaugure la **Partie 4** de la serie : la **formalisation en Lean 4** des concepts de theorie des jeux. Apres avoir explore les algorithmes et simulations en Python (notebooks 1-16), nous passons maintenant a la **verification formelle**.\n",
+    "Ce notebook inaugure la **Partie 4** de la serie : la **formalisation en Lean 4** des concepts de théorie des jeux. Après avoir explore les algorithmes et simulations en Python (notebooks 1-16), nous passons maintenant a la **verification formelle**.\n",
     "\n",
     "### Pourquoi formaliser en Lean ?\n",
     "\n",
     "| Aspect | Python (simulation) | Lean (formalisation) |\n",
     "|--------|---------------------|----------------------|\n",
     "| **Objectif** | Calculer, simuler, visualiser | Prouver, verifier, garantir |\n",
-    "| **Erreurs** | Detectees a l'execution | Impossibles si compile |\n",
+    "| **Erreurs** | Detectees a l'exécution | Impossibles si compile |\n",
     "| **Theoremes** | Illustres par exemples | Prouves mathematiquement |\n",
     "| **Confiance** | Tests, intuition | Preuves formelles |\n",
     "\n",
@@ -44,9 +44,9 @@
     "\n",
     "### Objectifs pedagogiques\n",
     "\n",
-    "1. Definir formellement les structures `Game`, `Strategy`, `Payoff`\n",
-    "2. Formaliser les strategies mixtes via le simplexe standard\n",
-    "3. Definir l'equilibre de Nash et la notion de meilleure reponse\n",
+    "1. Définir formellement les structures `Game`, `Strategy`, `Payoff`\n",
+    "2. Formaliser les stratégies mixtes via le simplexe standard\n",
+    "3. Définir l'equilibre de Nash et la notion de meilleure reponse\n",
     "4. Encoder le Dilemme du Prisonnier et verifier ses proprietes\n",
     "\n",
     "### Prerequis\n",
@@ -63,7 +63,7 @@
     "\n",
     "1. [Configuration et Imports](#1-configuration)\n",
     "2. [Structure Game](#2-structure-game)\n",
-    "3. [Strategies Pures et Mixtes](#3-strategies)\n",
+    "3. [Stratégies Pures et Mixtes](#3-stratégies)\n",
     "4. [Equilibre de Nash](#4-nash-equilibrium)\n",
     "5. [Exemple : Dilemme du Prisonnier](#5-prisoners-dilemma)\n",
     "6. [Exemples guides](#6-exemples-guides)\n",
@@ -227,9 +227,9 @@
     "\n",
     "### 2.1 Definition minimale\n",
     "\n",
-    "Un **jeu en forme normale** est defini par :\n",
+    "Un **jeu en forme normale** est défini par :\n",
     "- Un ensemble de **joueurs** `I`\n",
-    "- Pour chaque joueur `i`, un ensemble d'**actions** (ou strategies pures) `A i`\n",
+    "- Pour chaque joueur `i`, un ensemble d'**actions** (ou stratégies pures) `A i`\n",
     "- Pour chaque joueur `i`, une fonction de **gain** qui associe un reel a chaque profil d'actions\n",
     "\n",
     "En Lean 4, nous pouvons encoder cela avec une structure :"
@@ -662,14 +662,14 @@
    ],
    "source": [
     "-- Jeu 2x2 : 2 joueurs, 2 actions chacun\n",
-    "-- Actions : 0 = premiere action, 1 = deuxieme action\n",
+    "-- Actions : 0 = première action, 1 = deuxieme action\n",
     "structure Game2x2 where\n",
     "  /-- Matrice des gains du joueur 1 (lignes) -/\n",
     "  payoff1 : Fin 2 → Fin 2 → Int\n",
     "  /-- Matrice des gains du joueur 2 (colonnes) -/\n",
     "  payoff2 : Fin 2 → Fin 2 → Int\n",
     "\n",
-    "-- Helper pour creer un jeu 2x2 a partir de 4 paires de gains\n",
+    "-- Helper pour créer un jeu 2x2 a partir de 4 paires de gains\n",
     "def mkGame2x2 (a11 b11 a12 b12 a21 b21 a22 b22 : Int) : Game2x2 := {\n",
     "  payoff1 := fun i j =>\n",
     "    match i.val, j.val with\n",
@@ -701,12 +701,12 @@
     "tags": []
    },
    "source": [
-    "<a id=\"3-strategies\"></a>\n",
-    "## 3. Strategies Pures et Mixtes\n",
+    "<a id=\"3-stratégies\"></a>\n",
+    "## 3. Stratégies Pures et Mixtes\n",
     "\n",
-    "### 3.1 Strategie pure\n",
+    "### 3.1 Stratégie pure\n",
     "\n",
-    "Une **strategie pure** est simplement une action choisie par le joueur."
+    "Une **stratégie pure** est simplement une action choisie par le joueur."
    ]
   },
   {
@@ -804,10 +804,10 @@
     }
    ],
    "source": [
-    "-- Une strategie pure est juste une action\n",
+    "-- Une stratégie pure est juste une action\n",
     "def PureStrategy (g : FiniteGame) (i : Fin g.numPlayers) := Fin (g.numActions i)\n",
     "\n",
-    "-- Un profil de strategies pures : une strategie pour chaque joueur\n",
+    "-- Un profil de stratégies pures : une stratégie pour chaque joueur\n",
     "def PureStrategyProfile (g : FiniteGame) := (i : Fin g.numPlayers) → Fin (g.numActions i)\n",
     "\n",
     "#check @PureStrategy\n",
@@ -828,9 +828,9 @@
     "tags": []
    },
    "source": [
-    "### 3.2 Strategie mixte et simplexe standard\n",
+    "### 3.2 Stratégie mixte et simplexe standard\n",
     "\n",
-    "Une **strategie mixte** est une distribution de probabilite sur les actions. Mathematiquement, c'est un point du **simplexe standard** :\n",
+    "Une **stratégie mixte** est une distribution de probabilite sur les actions. Mathematiquement, c'est un point du **simplexe standard** :\n",
     "\n",
     "$$\\Delta^{n-1} = \\{(p_1, ..., p_n) \\in \\mathbb{R}^n : p_i \\geq 0, \\sum_i p_i = 1\\}$$\n",
     "\n",
@@ -958,10 +958,10 @@
     }
    ],
    "source": [
-    "-- Pour les strategies mixtes, nous avons besoin de nombres reels\n",
+    "-- Pour les stratégies mixtes, nous avons besoin de nombres reels\n",
     "-- Utilisons Float pour la simplicite (Rat ou Real pour plus de rigueur)\n",
     "\n",
-    "-- Simplexe standard : distribution de probabilite sur n elements\n",
+    "-- Simplexe standard : distribution de probabilite sur n éléments\n",
     "-- C'est un sous-type avec deux conditions :\n",
     "-- 1. Toutes les probabilites sont >= 0\n",
     "-- 2. La somme des probabilites = 1\n",
@@ -995,9 +995,9 @@
     "tags": []
    },
    "source": [
-    "### 3.3 Strategie mixte pour un jeu\n",
+    "### 3.3 Stratégie mixte pour un jeu\n",
     "\n",
-    "Une strategie mixte pour un joueur dans un jeu fini :"
+    "Une stratégie mixte pour un joueur dans un jeu fini :"
    ]
   },
   {
@@ -1109,12 +1109,12 @@
     }
    ],
    "source": [
-    "-- Strategie mixte : distribution sur les actions d'un joueur\n",
+    "-- Stratégie mixte : distribution sur les actions d'un joueur\n",
     "def MixedStrategy (numActions : Nat) := \n",
     "  { f : Fin numActions → Float // (∀ i, f i >= 0) ∧ \n",
     "    (List.ofFn f).foldl (· + ·) 0 = 1 }\n",
     "\n",
-    "-- Profil de strategies mixtes pour un jeu a 2 joueurs\n",
+    "-- Profil de stratégies mixtes pour un jeu a 2 joueurs\n",
     "structure MixedProfile2 (n1 n2 : Nat) where\n",
     "  sigma1 : Fin n1 → Float  -- Distribution joueur 1\n",
     "  sigma2 : Fin n2 → Float  -- Distribution joueur 2\n",
@@ -1142,7 +1142,7 @@
    "source": [
     "### 3.4 Gain espere\n",
     "\n",
-    "Le gain espere d'un joueur sous un profil de strategies mixtes :"
+    "Le gain espere d'un joueur sous un profil de stratégies mixtes :"
    ]
   },
   {
@@ -1276,7 +1276,7 @@
     }
    ],
    "source": [
-    "-- Gain espere pour un jeu 2x2 avec strategies mixtes\n",
+    "-- Gain espere pour un jeu 2x2 avec stratégies mixtes\n",
     "-- E[u1] = sum_i sum_j sigma1(i) * sigma2(j) * payoff1(i,j)\n",
     "\n",
     "-- Helper pour convertir Int en Float\n",
@@ -1321,7 +1321,7 @@
     "\n",
     "### 4.1 Definition formelle\n",
     "\n",
-    "Un **equilibre de Nash** est un profil de strategies tel qu'aucun joueur ne peut ameliorer son gain en changeant unilateralement de strategie.\n",
+    "Un **equilibre de Nash** est un profil de stratégies tel qu'aucun joueur ne peut ameliorer son gain en changeant unilateralement de stratégie.\n",
     "\n",
     "Formellement, $(\\sigma_1^*, \\sigma_2^*)$ est un equilibre de Nash si :\n",
     "- $\\forall \\sigma_1, E[u_1(\\sigma_1^*, \\sigma_2^*)] \\geq E[u_1(\\sigma_1, \\sigma_2^*)]$\n",
@@ -1467,9 +1467,9 @@
     "tags": []
    },
    "source": [
-    "### 4.2 Equilibre de Nash en strategies pures\n",
+    "### 4.2 Equilibre de Nash en stratégies pures\n",
     "\n",
-    "Pour les strategies pures, la definition est plus simple :"
+    "Pour les stratégies pures, la definition est plus simple :"
    ]
   },
   {
@@ -1558,7 +1558,7 @@
     }
    ],
    "source": [
-    "-- Equilibre de Nash en strategies pures pour jeu 2x2\n",
+    "-- Equilibre de Nash en stratégies pures pour jeu 2x2\n",
     "def isPureNashEquilibrium (g : Game2x2) (a1 : Fin 2) (a2 : Fin 2) : Prop :=\n",
     "  -- Joueur 1 ne peut pas ameliorer en changeant d'action\n",
     "  (∀ a1' : Fin 2, g.payoff1 a1 a2 >= g.payoff1 a1' a2) ∧\n",
@@ -1704,10 +1704,10 @@
     }
    ],
    "source": [
-    "-- Propriete : un equilibre en strategies pures est aussi un equilibre en strategies mixtes\n",
-    "-- (quand on identifie une strategie pure avec la distribution degeneree)\n",
+    "-- Propriete : un equilibre en stratégies pures est aussi un equilibre en stratégies mixtes\n",
+    "-- (quand on identifie une stratégie pure avec la distribution degeneree)\n",
     "\n",
-    "-- Strategie pure comme strategie mixte degeneree\n",
+    "-- Stratégie pure comme stratégie mixte degeneree\n",
     "def pureToMixed (a : Fin 2) : Fin 2 → Float :=\n",
     "  fun i => if i == a then 1.0 else 0.0\n",
     "\n",
@@ -1945,7 +1945,7 @@
    "source": [
     "### 5.2 Verification que (Trahir, Trahir) est un equilibre de Nash\n",
     "\n",
-    "Prouvons formellement que (T, T) est l'unique equilibre de Nash en strategies pures :"
+    "Prouvons formellement que (T, T) est l'unique equilibre de Nash en stratégies pures :"
    ]
   },
   {
@@ -2140,7 +2140,7 @@
    "source": [
     "### 5.3 Verification que (C, C) n'est PAS un equilibre\n",
     "\n",
-    "Montrons que (Cooperer, Cooperer) n'est pas un equilibre car chaque joueur a interet a devier :"
+    "Montrons que (Cooperer, Cooperer) n'est pas un equilibre car chaque joueur a intérêt a devier :"
    ]
   },
   {
@@ -2411,8 +2411,8 @@
     "\n",
     "#check trahir_dominates_cooperer\n",
     "\n",
-    "-- Corollaire : Une strategie strictement dominante est toujours jouee a l'equilibre\n",
-    "-- (Ceci est une propriete generale, pas specifique au PD)"
+    "-- Corollaire : Une stratégie strictement dominante est toujours jouee a l'equilibre\n",
+    "-- (Ceci est une propriete générale, pas spécifique au PD)"
    ]
   },
   {
@@ -2434,7 +2434,7 @@
     "\n",
     "### Exemple guide 1 : Jeu de la Poule Mouillee (Chicken)\n",
     "\n",
-    "Definir le jeu Chicken et prouver qu'il a deux equilibres de Nash en strategies pures.\n",
+    "Définir le jeu Chicken et prouver qu'il a deux equilibres de Nash en stratégies pures.\n",
     "\n",
     "|  | Ceder (0) | Foncer (1) |\n",
     "|--|-----------|------------|\n",
@@ -2442,13 +2442,13 @@
     "| **Foncer (1)** | (4, 2) | (0, 0) |\n",
     "\n",
     "**Questions** :\n",
-    "1. Definir `chickenGame : Game2x2`\n",
+    "1. Définir `chickenGame : Game2x2`\n",
     "2. Prouver que (Foncer, Ceder) est un equilibre de Nash\n",
     "3. Prouver que (Ceder, Foncer) est un equilibre de Nash\n",
     "\n",
     "### Exemple guide 2 : Matching Pennies\n",
     "\n",
-    "Definir le jeu Matching Pennies (jeu a somme nulle) et montrer qu'il n'a pas d'equilibre de Nash en strategies pures.\n",
+    "Définir le jeu Matching Pennies (jeu a somme nulle) et montrer qu'il n'a pas d'equilibre de Nash en stratégies pures.\n",
     "\n",
     "|  | Pile (0) | Face (1) |\n",
     "|--|----------|----------|\n",
@@ -2456,12 +2456,12 @@
     "| **Face (1)** | (-1, 1) | (1, -1) |\n",
     "\n",
     "**Questions** :\n",
-    "1. Definir `matchingPennies : Game2x2`\n",
+    "1. Définir `matchingPennies : Game2x2`\n",
     "2. Prouver qu'aucune des 4 paires d'actions pures n'est un equilibre\n",
     "\n",
     "### Exemple guide 3 : Chasse au Cerf (Stag Hunt)\n",
     "\n",
-    "Definir le jeu Stag Hunt et prouver qu'il a deux equilibres de Nash purs.\n",
+    "Définir le jeu Stag Hunt et prouver qu'il a deux equilibres de Nash purs.\n",
     "\n",
     "|  | Cerf (0) | Lievre (1) |\n",
     "|--|----------|------------|\n",
@@ -2469,7 +2469,7 @@
     "| **Lievre (1)** | (3, 0) | (2, 2) |\n",
     "\n",
     "**Questions** :\n",
-    "1. Definir `stagHunt : Game2x2`\n",
+    "1. Définir `stagHunt : Game2x2`\n",
     "2. Prouver que (Cerf, Cerf) est un equilibre (Pareto-optimal)\n",
     "3. Prouver que (Lievre, Lievre) est aussi un equilibre (risk-dominant)"
    ]
@@ -2491,11 +2491,11 @@
     "<a id=\"7-exercices\"></a>\n",
     "## 7. Exercices\n",
     "\n",
-    "Apres avoir etudie les exemples guides (Chicken, Matching Pennies, Stag Hunt), voici trois exercices pour mettre en pratique les concepts de definition de jeux, preuve d'equilibre de Nash et preuve de non-equilibre.\n",
+    "Après avoir etudie les exemples guides (Chicken, Matching Pennies, Stag Hunt), voici trois exercices pour mettre en pratique les concepts de definition de jeux, preuve d'equilibre de Nash et preuve de non-equilibre.\n",
     "\n",
     "### Exercice 1 : Bataille des Sexes\n",
     "\n",
-    "Definir le jeu **Battle of the Sexes** et prouver que l'un de ses equilibres de Nash purs.\n",
+    "Définir le jeu **Battle of the Sexes** et prouver que l'un de ses equilibres de Nash purs.\n",
     "\n",
     "|  | Opera (0) | Foot (1) |\n",
     "|--|-----------|----------|\n",
@@ -2503,10 +2503,10 @@
     "| **Foot (1)** | (0, 0) | (2, 3) |\n",
     "\n",
     "**Questions** :\n",
-    "1. Definir `battleOfSexes : Game2x2`\n",
+    "1. Définir `battleOfSexes : Game2x2`\n",
     "2. Prouver que (Opera, Opera) est un equilibre de Nash\n",
     "\n",
-    "**Indice** : Suivre le meme pattern que `prisoners_dilemma_nash` — utiliser `constructor`, puis `intro` et `cases Decidable.em` pour enumerer les actions possibles."
+    "**Indice** : Suivre le même pattern que `prisoners_dilemma_nash` — utiliser `constructor`, puis `intro` et `cases Decidable.em` pour enumerer les actions possibles."
    ]
   },
   {
@@ -2675,7 +2675,7 @@
    ],
    "source": [
     "-- Exercice 1 : Bataille des Sexes\n",
-    "-- TODO etudiant : definir le jeu battleOfSexes\n",
+    "-- TODO etudiant : définir le jeu battleOfSexes\n",
     "-- La matrice de gains est : (Opera,Opera)=(3,2), (Opera,Foot)=(0,0), (Foot,Opera)=(0,0), (Foot,Foot)=(2,3)\n",
     "def battleOfSexes : Game2x2 := {\n",
     "  payoff1 := fun i j =>\n",
@@ -2692,8 +2692,8 @@
     "\n",
     "-- TODO etudiant : prouver que (Opera, Opera) est un equilibre de Nash\n",
     "-- Indice : suivre le pattern de prisoners_dilemma_nash\n",
-    "-- Etape 1 : utiliser constructor pour separer les deux joueurs\n",
-    "-- Etape 2 : pour chaque joueur, utiliser intro, simp only, cases Decidable.em, omega\n",
+    "-- Étape 1 : utiliser constructor pour separer les deux joueurs\n",
+    "-- Étape 2 : pour chaque joueur, utiliser intro, simp only, cases Decidable.em, omega\n",
     "theorem battleOfSexes_nash_opera : isPureNashEquilibrium battleOfSexes Opera Opera := by\n",
     "  constructor\n",
     "  · intro a1\n",
@@ -2857,10 +2857,10 @@
     "-- Exercice 2 : (Cooperer, Trahir) n'est PAS un equilibre de Nash\n",
     "-- TODO etudiant : completer la preuve\n",
     "-- Indice : suivre le pattern de cooperer_not_nash\n",
-    "-- Etape 1 : intro h pour supposer que c'est un equilibre\n",
-    "-- Etape 2 : have h1 := h.1 Trahir (le joueur 1 peut devier vers Trahir)\n",
-    "-- Etape 3 : simp only [Cooperer, Trahir, prisonersDilemma] at h1\n",
-    "-- Etape 4 : omega (car payoff1(Trahir, Trahir)=1 >= payoff1(Cooperer, Trahir)=0 est vrai, mais on peut utiliser h.2)\n",
+    "-- Étape 1 : intro h pour supposer que c'est un equilibre\n",
+    "-- Étape 2 : have h1 := h.1 Trahir (le joueur 1 peut devier vers Trahir)\n",
+    "-- Étape 3 : simp only [Cooperer, Trahir, prisonersDilemma] at h1\n",
+    "-- Étape 4 : omega (car payoff1(Trahir, Trahir)=1 >= payoff1(Cooperer, Trahir)=0 est vrai, mais on peut utiliser h.2)\n",
     "theorem cooperer_trahir_not_nash : ¬ isPureNashEquilibrium prisonersDilemma Cooperer Trahir := by\n",
     "  intro h\n",
     "  -- TODO etudiant : completer la preuve\n",
@@ -2886,10 +2886,10 @@
    "source": [
     "### Exercice 3 : Dominance stricte pour le joueur 2\n",
     "\n",
-    "Definir la **dominance stricte pour le joueur 2** (symetrique de `strictlyDominates1`) et prouver que Trahir domine strictement Cooperer pour le joueur 2 dans le Dilemme du Prisonnier.\n",
+    "Définir la **dominance stricte pour le joueur 2** (symetrique de `strictlyDominates1`) et prouver que Trahir domine strictement Cooperer pour le joueur 2 dans le Dilemme du Prisonnier.\n",
     "\n",
     "**Questions** :\n",
-    "1. Definir `strictlyDominates2 : (g : Game2x2) → (a : Fin 2) → (a' : Fin 2) → Prop` analogue a `strictlyDominates1` mais pour le joueur 2\n",
+    "1. Définir `strictlyDominates2 : (g : Game2x2) → (a : Fin 2) → (a' : Fin 2) → Prop` analogue a `strictlyDominates1` mais pour le joueur 2\n",
     "2. Prouver `strictlyDominates2 prisonersDilemma Trahir Cooperer`\n",
     "\n",
     "**Indice** : La definition `strictlyDominates1` quantifie sur `a2 : Fin 2` et utilise `g.payoff1`. Pour le joueur 2, quantifier sur `a1 : Fin 2` et utiliser `g.payoff2`."
@@ -3069,7 +3069,7 @@
    "source": [
     "-- Exercice 3 : Dominance stricte pour le joueur 2\n",
     "\n",
-    "-- TODO etudiant : definir strictlyDominates2 (symetrique de strictlyDominates1)\n",
+    "-- TODO etudiant : définir strictlyDominates2 (symetrique de strictlyDominates1)\n",
     "-- Indice : strictlyDominates1 utilise payoff1 et quantifie sur a2\n",
     "-- Pour le joueur 2, utiliser payoff2 et quantifier sur a1\n",
     "def strictlyDominates2 (g : Game2x2) (a a' : Fin 2) : Prop :=\n",
@@ -3667,7 +3667,7 @@
     "    | _, _ => 0\n",
     "  payoff2 := fun i j =>\n",
     "    match i.val, j.val with\n",
-    "    | 0, 0 => -1  -- J2 veut des resultats differents\n",
+    "    | 0, 0 => -1  -- J2 veut des résultats différents\n",
     "    | 0, 1 => 1\n",
     "    | 1, 0 => 1\n",
     "    | 1, 1 => -1\n",
@@ -4054,9 +4054,9 @@
     "| Concept | Definition Lean | Description |\n",
     "|---------|-----------------|-------------|\n",
     "| **Jeu en forme normale** | `NormalFormGame`, `FiniteGame`, `Game2x2` | Joueurs, actions, gains |\n",
-    "| **Strategie pure** | `Fin n` | Une action deterministe |\n",
-    "| **Strategie mixte** | `Simplex n` | Distribution sur les actions |\n",
-    "| **Gain espere** | `expectedPayoff1`, `expectedPayoff2` | Esperance sous strategies mixtes |\n",
+    "| **Stratégie pure** | `Fin n` | Une action déterministe |\n",
+    "| **Stratégie mixte** | `Simplex n` | Distribution sur les actions |\n",
+    "| **Gain espere** | `expectedPayoff1`, `expectedPayoff2` | Esperance sous stratégies mixtes |\n",
     "| **Equilibre de Nash** | `isNashEquilibrium`, `isPureNashEquilibrium` | Aucune deviation profitable |\n",
     "| **Dominance stricte** | `strictlyDominates1` | Une action toujours meilleure |\n",
     "\n",
@@ -4071,7 +4071,7 @@
     "| `matching_pennies_no_pure_nash_*` | MP n'a pas d'equilibre pur |\n",
     "| `stag_hunt_nash_cerf`, `stag_hunt_nash_lievre` | Stag Hunt a 2 equilibres purs |\n",
     "\n",
-    "### Prochaines etapes\n",
+    "### Prochaines étapes\n",
     "\n",
     "Dans le notebook suivant (**GameTheory-4b-Lean-NashExistence**), nous etudierons :\n",
     "- Le theoreme de Brouwer (point fixe)\n",


### PR DESCRIPTION
## fix(gametheory,#2876): restore French accents in GameTheory-2b-Lean-Definitions markdown (73 cures, 26 cells)

### Scope

Single-file PR. Touches **only** `MyIA.AI.Notebooks/GameTheory/GameTheory-2b-Lean-Definitions.ipynb`.

Cure les accents francais perdus dans le markdown pedagogique + commentaires code du notebook (definitions formelles de jeux, strategies, ensembles d'information, portage en Lean 4 pour game theory). Aucune cellule code executable modifiee.

### R6 anti-monotonie — sous-domaine GameTheory/Lean Definitions (distinct c.604 NashExistence, c.605 CooperativeGames)

c.604 GameTheory/4b-Lean-NashExistence → c.605 GameTheory/15b-Lean-CooperativeGames → **c.606 GameTheory/2b-Lean-Definitions** (sous-domaine Lean Definitions — formalisation structures de base de la theorie des jeux : strategies, ensembles d'information, fonctions de paiement, lemmes Mathlib).

11ᵉ registre vague accents #2876. Meme famille GameTheory/Lean mais sous-domaine **Definitions** (vs c.604 Nash existence, c.605 CooperativeGames). Substance alignee **EPIC #4980** Lean i18n (game_theory_lean infrastructure).

### c.606 — caps_ratio diagnostic appliqué

Diagnostic pre-cure revele `caps_ratio = 0.0057` (légèrement > seuil 0.005). **Guard C598-L1 ★★ APPLIQUÉ** (skip ALL-CAPS stylistic emphasis), 0 casse stylistique.

**Script cure_text** = pattern eprouve c.597-L1 ★★ + c.598-L1 ★★ : case-insensitive dict lookup preserving original casing + skip ALL-CAPS stylistic emphasis.

### Verification

| Check | Resultat |
|-------|----------|
| ACCENT-ONLY invariant (NFD-normalized diff vs origin/main) | **0/47 cells mismatch** |
| Stop & Repair : diff outputs | **0** (aucune cellule `outputs` touchee) |
| Stop & Repair : diff execution_count | **0** (tous preserved) |
| H.3 pre-commit : `execution_count: null` en code cells | **0/21** (toutes preservees) |
| LF preservation (c.591 ★ binary write) | CR=0 / CRLF=0 (LF-only strict) |
| C596-L2 grep `determine\|detectee\|geenere\|predite\|predits` | **0 hits** dans le diff |
| Bytes delta | +77 (384,687 → 384,764) |
| Files changed | **1** |
| Domaines | **1** (GameTheory/Lean-Definitions) |
| One-to-one line replacement | 63 insertions / 63 deletions |
| R3 scan post-push (C596-L1 ★★) | **0 collision** |

### Anti-§D byte-identity

Source length UNCHANGED (63/63). Contenu accent-stripped byte-identique a origin/main (NFD-normalized 0/47 cells). Aucune cellule `# Solution` / `# Exemple resolu` touchee.

### Lessons capitalized (durable)

- **C597-L1 ★★** : `pairs.get(word.lower())` + preserve first letter casing (`replacement_lower[0].upper() + replacement_lower[1:]` si `word[0].isupper()`). Lookup case-sensitive ratait ~50% cures.
- **C598-L1 ★★** : skip ALL-CAPS stylistic emphasis `if word.isupper() and len(word) >= 3: replacement = word`.
- **C598-L2 ★** : pre-cure heuristic caps_ratio > 0.005 = cible risquée. c.606 = 0.0057 = guard obligatoire appliqué, 0 casse stylistique.
- **C604-L1 ★** : Lean game theory notebooks tendent a etre safe (caps_ratio < 0.005 systematiquement). **c.606 nuance** = premier Lean game theory avec caps > 0.005 (Definitions contient ENS/INF/Theory plus souvent en majuscules) mais guard tient.
- **C591 ★** : `path.write_bytes()` binary preserve LF sur Windows.
- **C596-L1 ★★** : R3 scan APRÈS `git push` AVANT `gh pr create`.

### Issues

`See #2876` — partial delivery (1 notebook sur ~1,135 restants dans la vague accents). Registre #2876 reste ouvert jusqu'a epuisement du scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)