### PR TITLE
fix(search,#2876): restore French accents in Search-16-QuikGraph markdown (23 cures, code untouched)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-16-QuikGraph.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-16-QuikGraph.ipynb
@@ -45,7 +45,7 @@
     "\n",
     "\n",
     "\n",
-    "| Precedent | Suivant |\n",
+    "| précédent | Suivant |\n",
     "\n",
     "|-----------|---------|\n",
     "\n",
@@ -81,11 +81,11 @@
     "\n",
     "\n",
     "\n",
-    "### Caracteristiques principales\n",
+    "### caractéristiques principales\n",
     "\n",
     "\n",
     "\n",
-    "| Caracteristique | Description |\n",
+    "| caractéristique | Description |\n",
     "\n",
     "|-----------------|-------------|\n",
     "\n",
@@ -99,7 +99,7 @@
     "\n",
     "\n",
     "\n",
-    "> **Note** : QuikGraph n'embarque pas d'algorithmes de centralite (betweenness, closeness, PageRank). Pour ces metriques, il faut soit les calculer a la main (degre : `graph.AdjacentDegree(v)`), soit brancher une autre bibliotheque. C'est l'un des **verdicts honnetes** a porter dans le body de la PR (cf. parite ci-dessous).\n"
+    "> **Note** : QuikGraph n'embarque pas d'algorithmes de centralite (betweenness, closeness, PageRank). Pour ces metriques, il faut soit les calculer a la main (degré : `graph.AdjacentDegree(v)`), soit brancher une autre bibliotheque. C'est l'un des **verdicts honnetes** a porter dans le body de la PR (cf. parite ci-dessous).\n"
    ]
   },
   {
@@ -227,7 +227,7 @@
     "\n",
     "\n",
     "\n",
-    "QuikGraph distingue trois familles. Le choix depend de la semantique (oriente vs non) et du type d'aretes (simple, avec poids, avec donnees metier).\n",
+    "QuikGraph distingue trois familles. Le choix depend de la sémantique (oriente vs non) et du type d'aretes (simple, avec poids, avec données metier).\n",
     "\n",
     "\n",
     "\n",
@@ -237,7 +237,7 @@
     "\n",
     "| `AdjacencyGraph<TV,TE>` | non | `TE` (souvent `Edge<TV>`) | Reseaux sociaux, collaborations |\n",
     "\n",
-    "| `BidirectionalGraph<TV,TE>` | oui | `TE` (souvent `SEdge<TV>`) | Reseaux de transport, graphes de taches |\n",
+    "| `BidirectionalGraph<TV,TE>` | oui | `TE` (souvent `SEdge<TV>`) | Reseaux de transport, graphes de tâches |\n",
     "\n",
     "| `UndirectedGraph<TV,TE>` | non (forcement) | `TE` symetrise | Modelisation physique (circuits) |\n",
     "\n",
@@ -595,7 +595,7 @@
     "\n",
     "\n",
     "\n",
-    "Sur le reseau routier `A..F` avec distances en km, BFS donnerait `A -> B -> D -> F` (3 sauts, 4+6=10 km) ou `A -> B -> D -> E -> F` (4 sauts, 2+4+1+2.5=9.5 km), mais le **vrai plus court chemin en km** est different.\n",
+    "Sur le reseau routier `A..F` avec distances en km, BFS donnerait `A -> B -> D -> F` (3 sauts, 4+6=10 km) ou `A -> B -> D -> E -> F` (4 sauts, 2+4+1+2.5=9.5 km), mais le **vrai plus court chemin en km** est différent.\n",
     "\n",
     "\n",
     "\n",
@@ -712,7 +712,7 @@
     "\n",
     "\n",
     "\n",
-    "QuikGraph **ne fournit pas** d'algorithmes de centralite tout faits (betweenness, closeness, PageRank). C'est un **verdict honnete** a porter dans le body de la PR : la bibliotheque couvre les **chemins, flots, composantes** mais pas les metriques d'**influence par centralite** -- c'est un choix de scope du mainteneur (KeRNeLith), pas un oubli. Pour ces dernieres, on les calcule a la main ou on branche une autre bibliotheque (`FastGraph` par exemple, plus recente mais moins documentee).\n",
+    "QuikGraph **ne fournit pas** d'algorithmes de centralite tout faits (betweenness, closeness, PageRank). C'est un **verdict honnete** a porter dans le body de la PR : la bibliotheque couvre les **chemins, flots, composantes** mais pas les metriques d'**influence par centralite** -- c'est un choix de scope du mainteneur (KeRNeLith), pas un oubli. Pour ces dernières, on les calcule a la main ou on branche une autre bibliotheque (`FastGraph` par exemple, plus recente mais moins documentee).\n",
     "\n",
     "\n",
     "\n",
@@ -720,11 +720,11 @@
     "\n",
     "\n",
     "\n",
-    "- **Degre** d'un sommet : `graph.AdjacentDegree(v)` (en O(1)) ou `graph.Degree(v)` sur `UndirectedGraph`.\n",
+    "- **degré** d'un sommet : `graph.AdjacentDegree(v)` (en O(1)) ou `graph.Degree(v)` sur `UndirectedGraph`.\n",
     "\n",
     "- **Composantes connexes** (WeaklyConnectedComponents) sur graphes orientes, ou `ConnectedComponents` sur non orientes.\n",
     "\n",
-    "- **Centralite de degre normalisee** : `degree(v) / (n - 1)` -- identique en .NET et Python (NetworkX la nomme `degree_centrality`).\n",
+    "- **Centralite de degré normalisee** : `degree(v) / (n - 1)` -- identique en .NET et Python (NetworkX la nomme `degree_centrality`).\n",
     "\n",
     "\n",
     "\n",
@@ -932,7 +932,7 @@
     "\n",
     "\n",
     "\n",
-    "**Application** : sur le reseau routier `A..F`, on prend A comme **source** (entrepot) et F comme **puits** (client). Chaque arete a une **capacite** egale au poids en km -- c'est un abus de modelisation pour le notebook (la vraie capacite d'une arete routiere serait un debit), mais le resultat reste **correct** et pedagogique : on cherche le debit max que peut transporter le reseau entre A et F.\n"
+    "**Application** : sur le reseau routier `A..F`, on prend A comme **source** (entrepot) et F comme **puits** (client). Chaque arete a une **capacite** egale au poids en km -- c'est un abus de modelisation pour le notebook (la vraie capacite d'une arete routiere serait un debit), mais le résultat reste **correct** et pedagogique : on cherche le debit max que peut transporter le reseau entre A et F.\n"
    ]
   },
   {
@@ -1043,7 +1043,7 @@
    "id": "a53b7b57",
    "metadata": {},
    "source": [
-    "## 7. Probleme non-trivial : reseau routier 5x5 avec bruit\n",
+    "## 7. problème non-trivial : reseau routier 5x5 avec bruit\n",
     "\n",
     "\n",
     "\n",
@@ -1169,7 +1169,7 @@
     "\n",
     "| **Aretes attributs multiples** | `G.add_edge(u, v, **d)` | `Edge<TV,TEdgeData>` | parite |\n",
     "\n",
-    "| **BFS** | `nx.bfs_tree(G, src)` / `nx.shortest_path` | `BreadthFirstSearchAlgorithm` (a implementer a la main ou via `algorithm.Search`) | parite (QuikGraph fournit les callbacks, pas le generateur de chemin) |\n",
+    "| **BFS** | `nx.bfs_tree(G, src)` / `nx.shortest_path` | `BreadthFirstSearchAlgorithm` (a implementer a la main ou via `algorithm.Search`) | parite (QuikGraph fournit les callbacks, pas le générateur de chemin) |\n",
     "\n",
     "| **DFS** | `nx.dfs_tree(G, src)` | `DepthFirstSearchAlgorithm` | parite |\n",
     "\n",
@@ -1185,7 +1185,7 @@
     "\n",
     "| **Flot maximum** | `nx.maximum_flow(G, s, t)` | `MaximumFlowAlgorithm<TV,TE>` (Edmonds-Karp / Push-Relabel) | parite |\n",
     "\n",
-    "| **Centralite degre** | `nx.degree_centrality(G)` | `graph.AdjacentDegree(v)` / `graph.Degree(v)` | parite (calcul manuelle, pas un methode nommee) |\n",
+    "| **Centralite degré** | `nx.degree_centrality(G)` | `graph.AdjacentDegree(v)` / `graph.Degree(v)` | parite (calcul manuelle, pas un méthode nommee) |\n",
     "\n",
     "| **Centralite betweenness** | `nx.betweenness_centrality(G)` | absente | verdict honnete : a implementer ou brancher une autre bibliotheque |\n",
     "\n",
@@ -1199,7 +1199,7 @@
     "\n",
     "\n",
     "\n",
-    "**Resume** : QuikGraph est l'equivalent .NET de NetworkX pour les **chemins, flots et composantes**. Pour les **centralites** et **communautes**, il faut soit implementer a la main (degre, BFS a etages), soit brancher une autre bibliotheque (`FastGraph`, `Microsoft.Graph`, ou calculer la betweenness a partir de Floyd-Warshall).\n"
+    "**Resume** : QuikGraph est l'equivalent .NET de NetworkX pour les **chemins, flots et composantes**. Pour les **centralites** et **communautes**, il faut soit implementer a la main (degré, BFS a etages), soit brancher une autre bibliotheque (`FastGraph`, `Microsoft.Graph`, ou calculer la betweenness a partir de Floyd-Warshall).\n"
    ]
   },
   {
@@ -1219,13 +1219,13 @@
     "\n",
     "\n",
     "\n",
-    "1. Affichez le degre de chaque sommet.\n",
+    "1. Affichez le degré de chaque sommet.\n",
     "\n",
     "2. Lancez `DijkstraShortestPathAlgorithm` depuis le sommet `1`.\n",
     "\n",
     "3. Affichez la distance minimale `1 -> 3` **avec le chemin** (la liste des sommets parcourus).\n",
     "\n",
-    "4. Comparez avec BFS sur le meme graphe : combien de sauts faut-il de `1` a `3` ? Le chemin le plus court en **sauts** est-il le meme qu'en **km** ?\n",
+    "4. Comparez avec BFS sur le même graphe : combien de sauts faut-il de `1` a `3` ? Le chemin le plus court en **sauts** est-il le même qu'en **km** ?\n",
     "\n",
     "\n",
     "\n",
@@ -1267,7 +1267,7 @@
    "cell_type": "markdown",
    "id": "555705b6",
    "metadata": {},
-   "source": "### Exercice 2 : Flot maximum sur un mini-reseau electrique\n\n**Ennonce** : Modelisez un reseau electrique simplifie du **CaseStudy SmartGrid CC3** (cf. `MyIA.AI.Notebooks/CaseStudies/`) avec 5 noeuds :\n\n- Producteur `P1` (centrale solaire)\n- Producteur `P2` (eolien)\n- Noeud intermediaire `J1` (jonction)\n- Noeud intermediaire `J2` (jonction)\n- Client `C1` (quartier residentiel)\n\nAretes (avec capacite en MW) : `P1 -> J1 : 10`, `P1 -> J2 : 5`, `P2 -> J1 : 8`, `P2 -> J2 : 5`, `J1 -> C1 : 12`, `J2 -> C1 : 7`.\n\nLancez `EdmondsKarpMaximumFlowAlgorithm<string, STaggedEdge<string, double>>` entre `P1+P2` (super source) et `C1`. **Indice** : QuikGraph ne supporte pas directement une super-source ; ajoutez un sommet `S` relie a `P1` et `P2` avec capacites infinies (ou tres grandes), puis appelez `algo.Compute(\"S\", \"C1\")`."
+   "source": "### Exercice 2 : Flot maximum sur un mini-reseau electrique\n\n**Ennonce** : Modelisez un reseau electrique simplifie du **CaseStudy SmartGrid CC3** (cf. `MyIA.AI.Notebooks/CaseStudies/`) avec 5 noeuds :\n\n- Producteur `P1` (centrale solaire)\n- Producteur `P2` (eolien)\n- Noeud intermediaire `J1` (jonction)\n- Noeud intermediaire `J2` (jonction)\n- Client `C1` (quartier residentiel)\n\nAretes (avec capacite en MW) : `P1 -> J1 : 10`, `P1 -> J2 : 5`, `P2 -> J1 : 8`, `P2 -> J2 : 5`, `J1 -> C1 : 12`, `J2 -> C1 : 7`.\n\nLancez `EdmondsKarpMaximumFlowAlgorithm<string, STaggedEdge<string, double>>` entre `P1+P2` (super source) et `C1`. **Indice** : QuikGraph ne supporte pas directement une super-source ; ajoutez un sommet `S` relie a `P1` et `P2` avec capacites infinies (ou très grandes), puis appelez `algo.Compute(\"S\", \"C1\")`."
   },
   {
    "cell_type": "code",
@@ -1313,9 +1313,9 @@
     "\n",
     "1. Affichez le nombre de composantes connexes (devrait etre 1 si le graphe est encore lie).\n",
     "\n",
-    "2. Calculez la **centralite de degre normalisee** de chaque noeud et trouvez les **3 noeuds les plus centraux**.\n",
+    "2. Calculez la **centralite de degré normalisee** de chaque noeud et trouvez les **3 noeuds les plus centraux**.\n",
     "\n",
-    "3. **Defi bonus** : implementez une variante de la detection de communautes \"remove the 3 aretes inter-communautes les plus faibles\" puis recomparez les composantes avant/apres.\n",
+    "3. **Defi bonus** : implementez une variante de la detection de communautes \"remove the 3 aretes inter-communautes les plus faibles\" puis recomparez les composantes avant/après.\n",
     "\n",
     "\n",
     "\n",


### PR DESCRIPTION
fix(search,#2876): restore French accents in Search-16-QuikGraph markdown (23 cures, code untouched)

## Summary

Markdown-only French accent restoration in `MyIA.AI.Notebooks/Search/Part1-Foundations/Search-16-QuikGraph.ipynb` (théorie des graphes / QuikGraph, parcours BFS/DFS, plus court chemin). Code cells **untouched** (preserved). **1 file strict**. Per-cell byte-identity preserved.

**R6 partition Search OWN continué** : Search-4-LocalSearch c.677o → Search-5-GeneticAlgorithms c.677p → Search-2-Uninformed c.677s → Search-11-Metaheuristics c.677t → Search-8-DancingLinks c.677u → Search-7-MCTS c.677v → Search-6-AdversarialSearch c.677w → Search-16-QuikGraph c.677x (8e pivot partition Search OWN, 20e PRs depuis c.677b). Balance cross-famille fleet-wide.

**C596-L1 ★★ + L778-L1 ★ appliquées** : R3 scan AVANT worktree + APRÈS `git push` AVANT `gh pr create`. Cible Search-16-QuikGraph vérifiée via `gh pr list --state open --search "Search-16-QuikGraph.ipynb in:title"` → **0 PR OPEN**.

Scope follows **ai-01's #2876 adjudication (2026-07-18, markdown-only STRICT)** + the forensic insight that accent-stripping hits in code cells live in **comments + string literals** which are user-visible Python surface; curing them is **out of scope** of the dict-driven rollout.

## Detector verify (read-only)

| Check | Before | After |
|-------|--------|-------|
| `detect_accent_stripping.py` markdown hits | 23 | **0** |
| `detect_accent_stripping.py` code hits | 12 | preserved (untouched) |
| Code cell `source` changed | — | **0** (byte-identity test) |
| Code cells changed (full JSON byte-identity) | — | **0** / all code cells |
| Code cell `outputs` changed | — | **0** (assert byte-identical) |
| Code cell `execution_count` changed | — | **0** (assert byte-identical) |
| Top-level metadata preserved | — | ✓ |
| Markdown cells touched | — | 11 |
| C.1 violations introduced (diff) | — | 0 |
| Secrets-like patterns in diff | — | 0 |
| C596-L2 ★ conjugated-verb FP grep | — | **0** (clean) |
| LF/CRLF preservation (L593-L1 ★) | LF=1371 CRLF=0 | LF=1370 CRLF=0 (LF préservé via `path.write_bytes()`) |
| Cell ids + metadata preserved | — | ✓ |
| nbformat 4.5 preserved | — | ✓ |
| Cell count preserved | — | ✓ (25 cells: 12 md + 13 code) |

## Compliance

- **Stop&Repair règle 6** : metadata.papermill = `metadata['papermill']['input/output_path']` → basename toléré, mais OUTPUT cellule **interdit** d'éditer. Frontière respectée : aucun `outputs` ni `execution_count` modifié.
- **C.2** : markdown-only edit (cf #7085 PR description precedent), re-execution PAS requise.
- **C.1** : 0 `raise NotImplementedError` / `assert False` / `1/0` introduit.
- **secrets-hygiene** : 0 literal secret-like pattern dans le diff.
- **catalog-pr-hygiene R1** : aucun catalogue régénéré (1 fichier .ipynb uniquement).
- **L593-L1 ★★★ appliquée** : `path.write_bytes()` binary préserve LF.
- **L677-L2 ★★ appliquée** : per-element regex sur `c["source"]` list, `+N/-N` strict garanti par densité cures/ligne ≤2 (k=3 fusions cellules denses consolidées en `+20/-20` strict, 0 cure perdue prouvée par detector post-cure = 0 hits).
- **L677-L4 ★★★ appliquée** : body PR HORS worktree (`/tmp/c677x_pr_body_real.md` tracké détecté via `git ls-files | grep -i pr_body`).
- **identifier-regression guard (po-2025 #7157, scope manuel)** : 0 identifiant Python régressé — toutes les cures sont en prose markdown.

## R3 collision scan (pre + post push)

**C596-L1 ★★ renforcée par L778-L1 ★** : R3 scan AVANT worktree + APRÈS `git push`. Cible Search-16-QuikGraph vérifiée → **0 PR OPEN**.

## Rotation (R6 anti-monotonie)

c.673-c.676 = 3 détecteurs papermill + 1 substance fix-up Z3-Python (#7083) + 1 substance fix-up ML-5 cell-level (#7088).
c.677b/c/c/d/e/f/g/h/i/j/l/n = accents rollout ML → Probas/Infer (10 PRs).
c.677k = pivot cross-famille Probas/Infer → Search (R6 anti-monotonie 11e PRs) — COLLISIONNÉ par po-2023 c.596, arbitrage ai-01 close #7128.
c.677m = pivot cross-famille Probas/Infer → Sudoku (R6 anti-monotonie 12e PRs).
c.677n = retour Probas/Infer Infer-3 après pivot cross-famille Sudoku (c.677m).
c.677o = pivot cross-famille Probas/Infer-Sudoku → Search/Part1-Foundations (R6 anti-monotonie 13e PRs) — Search-4-LocalSearch.
c.677p = continuation partition Search OWN Search-5-GeneticAlgorithms (R6 anti-monotonie 14e PRs).
c.677s = continuation partition Search OWN Search-2-Uninformed (R6 anti-monotonie 15e PRs).
c.677t = continuation partition Search OWN Search-11-Metaheuristics (R6 anti-monotonie 16e PRs).
c.677u = continuation partition Search OWN Search-8-DancingLinks (R6 anti-monotonie 17e PRs).
c.677v = continuation partition Search OWN Search-7-MCTS-And-Beyond (R6 anti-monotonie 18e PRs).
c.677w = continuation partition Search OWN Search-6-AdversarialSearch (R6 anti-monotonie 19e PRs).
**c.677x (CE PR) = continuation partition Search OWN Search-16-QuikGraph (R6 anti-monotonie 20e PRs)**.

## Forward

- **Search-3-Informed** (20 md cells, partition Search OWN) — Search OWN light pivot.
- **Search-1-StateSpace** (10 md cells, partition Search OWN) — dernier pivot Search OWN possible.
- **Search-15-NetworkX** (0 md = déjà curé) — fallback.
- **Sudoku-19** (markdown-only partition Sudoku) — si R3 clean post-#7062 MERGED.
- **Pivot cross-famille post-Search** : si Search OWN s'épuise, repartir sur partition Probas/Infer 4-12 (#4212 en cours rollout par po-2025) ou Probas/Infer-Dec/Infer-PyMC (#2161).

## Voir aussi

- Issue **#2876** (accents rollout — parent tracker CLOSED, partial deliveries still valid via `See #2876`)
- PRs anterieurs fleet-wide
- `scripts/notebook_tools/detect_accent_stripping.py` (161 paires, c.589 dict-extension)
- `scripts/notebook_tools/check_identifier_regression.py` (#7157 OPEN, po-2025 — scope classification mode)
- Leçon L593-L1 ★★★ : `path.write_bytes()` binary préserve LF sur Windows
- Leçon C596-L1 ★★ : R3 scan APRÈS `git push` AVANT `gh pr create`
- Leçon C596-L2 ★ : pre-commit grep FP verbes conjugués
- Leçon L677-L2 ★★ : per-element regex sur `c["source"]` list, `+N/-N` strict
- Leçon L677-L4 ★★★ : body PR HORS worktree (`PR_BODY.md` tracked contamination)
- Leçon L778-L1 ★ : R3 scan APRÈS claim (15 min window)
- Leçon L789-L1 ★ : G.1 verify-before-claiming applique aux claims techniques (jsboige stale comments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>