### PR TITLE
fix(symboliclearning,#2876): restore French accents in SL-2-KnowledgeBasedLearning markdown (213 cures, code untouched)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-2-KnowledgeBasedLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-2-KnowledgeBasedLearning.ipynb
@@ -22,14 +22,14 @@
     "\n",
     "A la fin de ce notebook, vous saurez :\n",
     "1. Comprendre la **contrainte d'entrainement** qui relie hypothese, descriptions et classifications\n",
-    "2. Implementer l'apprentissage base sur les explications (**EBL**) : extraire une regle generale d'un seul exemple\n",
+    "2. Implementer l'apprentissage base sur les explications (**EBL**) : extraire une règle générale d'un seul exemple\n",
     "3. Comprendre les **determinations** et verifier la pertinence d'attributs (introduction au RBL, approfondi dans SL-3)\n",
     "4. Comparer les trois paradigmes : EBL (deductif), RBL (pertinence), KBIL (inductif base sur la connaissance)\n",
     "\n",
     "### Prerequis\n",
     "- SL-1 : Apprentissage logique (CBH, Version Space)\n",
     "- Python 3.10+\n",
-    "- Notions de logique du premier ordre (predicats, regles d'inference)\n",
+    "- Notions de logique du premier ordre (predicats, règles d'inference)\n",
     "\n",
     "### Duree estimee : 45 minutes\n",
     "\n",
@@ -110,7 +110,7 @@
     "\n",
     "Dans le notebook SL-1, nous avons etudie l'apprentissage inductif **pur** : trouver une hypothese qui agree avec les exemples observes, sans aucune connaissance prealable du domaine.\n",
     "\n",
-    "L'approche moderne (AIMA Chapitre 19.2) est **cumulative** : un agent qui sait deja quelque chose peut apprendre plus efficacement.\n",
+    "L'approche moderne (AIMA Chapitre 19.2) est **cumulative** : un agent qui sait déjà quelque chose peut apprendre plus efficacement.\n",
     "\n",
     "### La contrainte d'entrainement\n",
     "\n",
@@ -124,19 +124,19 @@
     "\n",
     "### Trois types d'apprentissage utilisant la connaissance\n",
     "\n",
-    "| Type | Principe | Methode | Nouvelle connaissance ? |\n",
+    "| Type | Principe | Méthode | Nouvelle connaissance ? |\n",
     "|------|----------|---------|------------------------|\n",
     "| **EBL** | La connaissance de fond implique l'hypothese | Deduction pure | Non (specialisation) |\n",
     "| **RBL** | Les observations determinent l'hypothese | Deduction + pertinence | Non (reduction d'espace) |\n",
     "| **KBIL** | Connaissance + hypothese expliquent les observations | Induction guidee | Oui |\n",
     "\n",
-    "L'equation generale du KBIL est :\n",
+    "L'equation générale du KBIL est :\n",
     "\n",
     "$$\n",
     "\\text{Background} \\wedge H \\wedge \\text{Descriptions} \\models \\text{Classifications} \\quad \\text{(19.5)}\n",
     "$$\n",
     "\n",
-    "Ce notebook couvre les deux premieres approches : EBL et RBL."
+    "Ce notebook couvre les deux premières approches : EBL et RBL."
    ]
   },
   {
@@ -261,14 +261,14 @@
    "source": [
     "### Interpretation : Contraintes d'apprentissage\n",
     "\n",
-    "| Approche | Source de l'hypothese | Role de la connaissance |\n",
+    "| Approche | Source de l'hypothese | Rôle de la connaissance |\n",
     "|----------|----------------------|------------------------|\n",
     "| **Inductif pur** | Exploration de H | Aucune |\n",
     "| **EBL** | Deduction de Background | Genere directement H |\n",
     "| **RBL** | Deduction de Background + observations | Reduit l'espace de recherche |\n",
     "| **KBIL** | Induction guidee | Contraint les hypotheses possibles |\n",
     "\n",
-    "> **Point cle** : EBL et RBL sont **deductifs** --- ils ne creent pas de connaissance factuellement nouvelle. Ils transforment la connaissance existante en formes plus utiles."
+    "> **Point cle** : EBL et RBL sont **deductifs** --- ils ne créent pas de connaissance factuellement nouvelle. Ils transforment la connaissance existante en formes plus utiles."
    ]
   },
   {
@@ -289,27 +289,27 @@
     "\n",
     "## 2. EBL --- Idee principale\n",
     "\n",
-    "L'apprentissage base sur les explications (Explanation-Based Learning) permet d'extraire une **regle generale** a partir d'un **seul exemple**, en utilisant la connaissance de fond du domaine.\n",
+    "L'apprentissage base sur les explications (Explanation-Based Learning) permet d'extraire une **règle générale** a partir d'un **seul exemple**, en utilisant la connaissance de fond du domaine.\n",
     "\n",
     "### L'exemple de Zog (AIMA)\n",
     "\n",
     "Zog observe qu'un baton pointu tue un gibier. A partir de cette **unique observation** et de sa connaissance de la physique/physiologie, il generalise : \"Tout objet pointu peut tuer le gibier\".\n",
     "\n",
-    "EBL ne decouvre pas un nouveau fait --- Zog savait deja que les objets pointus traversent la peau, que la penetration entraine la mort, etc. EBL **compile** cette connaissance en une regle operationnelle.\n",
+    "EBL ne decouvre pas un nouveau fait --- Zog savait déjà que les objets pointus traversent la peau, que la penetration entraine la mort, etc. EBL **compile** cette connaissance en une règle operationnelle.\n",
     "\n",
-    "### Le processus EBL (4 etapes)\n",
+    "### Le processus EBL (4 étapes)\n",
     "\n",
     "1. **Construire une explication** (arbre de preuve) montrant que le predicat cible s'applique a l'exemple\n",
     "2. **Variabiliser** --- remplacer les constantes de l'exemple par des variables\n",
-    "3. **Extraire la regle** a partir des feuilles de l'arbre de preuve generalise\n",
+    "3. **Extraire la règle** a partir des feuilles de l'arbre de preuve generalise\n",
     "4. **Simplifier** --- supprimer les conditions toujours vraies\n",
     "\n",
-    "> **Origine.** Ce processus en 4 etapes (1. expliquer, 2. variabiliser, 3. extraire la regle, 4. simplifier) est la formalisation canonique de l'EBL donnee par Mitchell, T. M., Keller, R. M. & Kedar-Cabelli, S. T. (1986), *Explanation-based generalization: A unifying view*, Machine Learning 1(1):47-80. C'est le pendant complementaire (vue *generalisation*) du travail de DeJong & Mooney (1986) deja cite en Ressources (vue *apprentissage*).\n",
+    "> **Origine.** Ce processus en 4 étapes (1. expliquer, 2. variabiliser, 3. extraire la règle, 4. simplifier) est la formalisation canonique de l'EBL donnee par Mitchell, T. M., Keller, R. M. & Kedar-Cabelli, S. T. (1986), *Explanation-based generalization: A unifying view*, Machine Learning 1(1):47-80. C'est le pendant complementaire (vue *generalisation*) du travail de DeJong & Mooney (1986) déjà cite en Ressources (vue *apprentissage*).\n",
     "\n",
     "### Pourquoi EBL est utile ?\n",
     "\n",
-    "- Accelerer le raisonnement futur en evitant de re-construire la meme preuve\n",
-    "- Convertir des theories de premiers principes en heuristiques operationnelles\n",
+    "- Accelerer le raisonnement futur en evitant de re-construire la même preuve\n",
+    "- Convertir des théories de premiers principes en heuristiques operationnelles\n",
     "- Analogie : transformer un theoreme general en corollaire specialise"
    ]
   },
@@ -455,14 +455,14 @@
    "source": [
     "### Interpretation : Principe EBL\n",
     "\n",
-    "| Etape | Entree | Sortie | Operation |\n",
+    "| Étape | Entree | Sortie | Opération |\n",
     "|-------|--------|--------|-----------|\n",
     "| 1. Expliquer | 1 exemple + connaissance | Arbre de preuve | Deduction |\n",
     "| 2. Variabiliser | Arbre de preuve concret | Arbre de preuve general | Substitution |\n",
-    "| 3. Extraire | Arbre general | Regle candidate | Projection des feuilles |\n",
-    "| 4. Simplifier | Regle candidate | Regle finale | Elimination des tautologies |\n",
+    "| 3. Extraire | Arbre general | Règle candidate | Projection des feuilles |\n",
+    "| 4. Simplifier | Règle candidate | Règle finale | Elimination des tautologies |\n",
     "\n",
-    "> **Point cle** : L'hypothese EBL ne contient aucune information qui n'etait pas deja presente dans la connaissance de fond. EBL est un **mecanisme d'efficacite**, pas un mecanisme de decouverte."
+    "> **Point cle** : L'hypothese EBL ne contient aucune information qui n'etait pas déjà presente dans la connaissance de fond. EBL est un **mécanisme d'efficacite**, pas un mécanisme de decouverte."
    ]
   },
   {
@@ -483,16 +483,16 @@
     "\n",
     "## 3. EBL --- Exemple de simplification arithmetique\n",
     "\n",
-    "L'exemple canonique de l'AIMA est la simplification d'expressions arithmetiques. Etant donne une base de regles de reecriture, nous voulons montrer comment simplifier une expression specifique, puis generaliser cette preuve.\n",
+    "L'exemple canonique de l'AIMA est la simplification d'expressions arithmetiques. Etant donne une base de règles de reecriture, nous voulons montrer comment simplifier une expression spécifique, puis generaliser cette preuve.\n",
     "\n",
     "### Base de connaissances pour la simplification\n",
     "\n",
-    "Les regles sont :\n",
+    "Les règles sont :\n",
     "- `Rewrite(u, v) ^ Simplify(v, w) => Simplify(u, w)` --- composition\n",
-    "- `Primitive(u) => Simplify(u, u)` --- un primitif est deja simplifie\n",
+    "- `Primitive(u) => Simplify(u, u)` --- un primitif est déjà simplifie\n",
     "- `ArithmeticUnknown(u) => Primitive(u)` --- une variable est un primitif\n",
-    "- `Rewrite(1 * u, u)` --- regle de reecriture pour 1*x\n",
-    "- `Rewrite(0 + u, u)` --- regle de reecriture pour 0+x"
+    "- `Rewrite(1 * u, u)` --- règle de reecriture pour 1*x\n",
+    "- `Rewrite(0 + u, u)` --- règle de reecriture pour 0+x"
    ]
   },
   {
@@ -602,7 +602,7 @@
     "tags": []
    },
    "source": [
-    "Avec ces regles de reecriture, nous pouvons maintenant construire la preuve complete pour simplifier `1*(0+x)` et observer chaque etape de la derivation."
+    "Avec ces règles de reecriture, nous pouvons maintenant construire la preuve complete pour simplifier `1*(0+x)` et observer chaque étape de la derivation."
    ]
   },
   {
@@ -730,15 +730,15 @@
    "source": [
     "### Interpretation : Arbre de preuve EBL\n",
     "\n",
-    "| Etape | Expression | Regle | Resultat |\n",
+    "| Étape | Expression | Règle | Résultat |\n",
     "|-------|-----------|-------|----------|\n",
     "| 1 | `1*(0+x)` | `1*u -> u` | `0+x` |\n",
     "| 2 | `0+x` | `0+u -> u` | `x` |\n",
-    "| 3 | `x` | primitive | `x` (deja simplifie) |\n",
+    "| 3 | `x` | primitive | `x` (déjà simplifie) |\n",
     "\n",
-    "La preuve montre que `Simplify(1*(0+x), x)` est derivable en 2 etapes de reecriture puis une verification de primalite.\n",
+    "La preuve montre que `Simplify(1*(0+x), x)` est derivable en 2 étapes de reecriture puis une verification de primalite.\n",
     "\n",
-    "> **Note** : Cette preuve est specifique a l'expression `1*(0+x)`. L'etape suivante (variabilisation) va la generaliser."
+    "> **Note** : Cette preuve est spécifique a l'expression `1*(0+x)`. L'étape suivante (variabilisation) va la generaliser."
    ]
   },
   {
@@ -757,16 +757,16 @@
    "source": [
     "---\n",
     "\n",
-    "## 4. EBL --- Variabilisation et extraction de regle\n",
+    "## 4. EBL --- Variabilisation et extraction de règle\n",
     "\n",
-    "L'etape centrale d'EBL est la **variabilisation** : remplacer les constantes de l'exemple par des variables dans l'arbre de preuve, puis extraire une regle generale.\n",
+    "L'étape centrale d'EBL est la **variabilisation** : remplacer les constantes de l'exemple par des variables dans l'arbre de preuve, puis extraire une règle générale.\n",
     "\n",
     "### Principe\n",
     "\n",
     "1. Identifier les constantes dans l'exemple (ex: `x` dans `1*(0+x)` est une variable, mais le `0` et le `1` sont des constantes structurelles)\n",
     "2. Remplacer les constantes exemplaires par des variables fraiches\n",
     "3. Les conditions qui sont toujours vraies (tautologies) sont supprimees\n",
-    "4. La regle extraite est la generalisation la plus large possible qui preserve la structure de la preuve"
+    "4. La règle extraite est la generalisation la plus large possible qui preserve la structure de la preuve"
    ]
   },
   {
@@ -898,13 +898,13 @@
     "\n",
     "| Phase | Expression | Commentaire |\n",
     "|-------|-----------|-------------|\n",
-    "| Preuve concrete | `1*(0+x)` -> `(x)` | Specifique a l'exemple observe |\n",
+    "| Preuve concrete | `1*(0+x)` -> `(x)` | Spécifique a l'exemple observe |\n",
     "| Preuve variabilisee | `1*(0+z)` -> `(z)` | Variable `z` remplace `x` |\n",
-    "| Regle extraite | `ArithmeticUnknown(z) => Simplify(1*(0+z), (z))` | Condition : `z` doit etre un inconnu arithmetique |\n",
+    "| Règle extraite | `ArithmeticUnknown(z) => Simplify(1*(0+z), (z))` | Condition : `z` doit etre un inconnu arithmetique |\n",
     "\n",
-    "La condition `ArithmeticUnknown(z)` est la seule precondition non-tautologique. Les regles `1*u->u` et `0+u->u` sont des axiomes de la base de connaissance --- elles sont toujours vraies. (Les parentheses residuelles de `(z)` restent en l'etat : notre mini-systeme ne reecrit que `1*` et `0+`.)\n",
+    "La condition `ArithmeticUnknown(z)` est la seule precondition non-tautologique. Les règles `1*u->u` et `0+u->u` sont des axiomes de la base de connaissance --- elles sont toujours vraies. (Les parentheses residuelles de `(z)` restent en l'etat : notre mini-système ne reecrit que `1*` et `0+`.)\n",
     "\n",
-    "> **Point cle** : La regle extraite dit \"pour TOUT z qui est un inconnu arithmetique, Simplify(1*(0+z), (z))\". Cette regle est **nouvelle** par rapport a la base de connaissance (elle n'y etait pas), mais elle est **deduite** de cette base."
+    "> **Point cle** : La règle extraite dit \"pour TOUT z qui est un inconnu arithmetique, Simplify(1*(0+z), (z))\". Cette règle est **nouvelle** par rapport a la base de connaissance (elle n'y etait pas), mais elle est **deduite** de cette base."
    ]
   },
   {
@@ -925,19 +925,19 @@
     "\n",
     "## 5. EBL --- Implementation complete\n",
     "\n",
-    "Nous integrons maintenant les 4 etapes de l'EBL dans une classe complete : explanation, variabilisation, extraction et stockage des regles apprises.\n",
+    "Nous integrons maintenant les 4 étapes de l'EBL dans une classe complete : explanation, variabilisation, extraction et stockage des règles apprises.\n",
     "\n",
     "### Architecture\n",
     "\n",
     "``` \n",
     "ArithmeticEBL\n",
-    "  |- kb_rules        : base de regles de reecriture\n",
-    "  |- learned_rules   : regles extraites par EBL\n",
+    "  |- kb_rules        : base de règles de reecriture\n",
+    "  |- learned_rules   : règles extraites par EBL\n",
     "  |- explain()       : construit l'arbre de preuve\n",
     "  |- variabilize()   : generalise la preuve\n",
-    "  |- extract_rule()  : extrait la regle finale\n",
+    "  |- extract_rule()  : extrait la règle finale\n",
     "  |- learn()         : pipeline complet\n",
-    "  |- simplify_with_learned() : simplification utilisant les regles apprises\n",
+    "  |- simplify_with_learned() : simplification utilisant les règles apprises\n",
     "```"
    ]
   },
@@ -1210,17 +1210,17 @@
    "source": [
     "### Interpretation : Implementation EBL\n",
     "\n",
-    "| Composant | Role | Complexite |\n",
+    "| Composant | Rôle | Complexite |\n",
     "|-----------|------|------------|\n",
-    "| `explain()` | Construit l'arbre de preuve lineaire | O(n * |regles|) ou n = profondeur de simplification |\n",
+    "| `explain()` | Construit l'arbre de preuve lineaire | O(n * |règles|) ou n = profondeur de simplification |\n",
     "| `variabilize()` | Substitution constante -> variable | O(n * |mapping|) |\n",
     "| `extract_rule()` | Projection des feuilles | O(n) |\n",
     "| `learn()` | Pipeline complet | Lineaire en la taille de la preuve |\n",
-    "| `simplify_with_learned()` | Utilisation des regles | O(1) en cas de hit, O(n*|regles|) sinon |\n",
+    "| `simplify_with_learned()` | Utilisation des règles | O(1) en cas de hit, O(n*|règles|) sinon |\n",
     "\n",
-    "L'interet principal est le **lookup O(1)** : une regle apprise permet de court-circuiter la chaine de preuve complete.\n",
+    "L'intérêt principal est le **lookup O(1)** : une règle apprise permet de court-circuiter la chaîne de preuve complete.\n",
     "\n",
-    "> **Note** : Dans notre implementation simplifiee, la correspondance de pattern est textuelle. Un systeme reel utiliserait un unificateur (pattern matching avec variables) pour une generalisation correcte."
+    "> **Note** : Dans notre implementation simplifiee, la correspondance de pattern est textuelle. Un système reel utiliserait un unificateur (pattern matching avec variables) pour une generalisation correcte."
    ]
   },
   {
@@ -1243,17 +1243,17 @@
     "\n",
     "EBL introduit un compromis fondamental entre **operationalite** et **generalite** :\n",
     "\n",
-    "- **Regles tres specifiques** (ex: `Simplify(1*(0+x), x)`) : faciles a evaluer mais couvrent peu de cas\n",
-    "- **Regles tres generales** (ex: `Simplify(u, u)`) : couvrent tout mais n'apportent rien\n",
+    "- **Règles très spécifiques** (ex: `Simplify(1*(0+x), x)`) : faciles a evaluer mais couvrent peu de cas\n",
+    "- **Règles très générales** (ex: `Simplify(u, u)`) : couvrent tout mais n'apportent rien\n",
     "\n",
-    "Le benefice reel d'EBL depend du **taux de reutilisation** des regles apprises.\n",
+    "Le benefice reel d'EBL depend du **taux de reutilisation** des règles apprises.\n",
     "\n",
-    "### Risque : la proliferation de regles\n",
+    "### Risque : la proliferation de règles\n",
     "\n",
-    "Ajouter trop de regles specifiques peut ralentir le systeme :\n",
-    "- Chaque regle supplementaire augmente le temps de recherche (branching factor)\n",
-    "- Les regles trop specifiques ne sont presque jamais reutilisees\n",
-    "- Il faut un mecanisme de filtrage ou de desapprentissage"
+    "Ajouter trop de règles spécifiques peut ralentir le système :\n",
+    "- Chaque règle supplementaire augmente le temps de recherche (branching factor)\n",
+    "- Les règles trop spécifiques ne sont presque jamais reutilisees\n",
+    "- Il faut un mécanisme de filtrage ou de desapprentissage"
    ]
   },
   {
@@ -1379,17 +1379,17 @@
     "\n",
     "| Metrique | Sans EBL | Avec EBL | Amelioration |\n",
     "|----------|----------|----------|-------------|\n",
-    "| Etapes totales | Variable | Reduit | Court-circuit de la chaine de preuve |\n",
-    "| Lookup | Recherche sequentielle | Matching direct | O(n) -> O(1) |\n",
-    "| Regles stockees | 5 (KB) | 5 + k (apprises) | Memoire croissante |\n",
+    "| Étapes totales | Variable | Reduit | Court-circuit de la chaîne de preuve |\n",
+    "| Lookup | Recherche séquentielle | Matching direct | O(n) -> O(1) |\n",
+    "| Règles stockees | 5 (KB) | 5 + k (apprises) | Memoire croissante |\n",
     "\n",
     "Le compromis est clair :\n",
-    "- **Avantage** : Les expressions correspondant aux regles apprises sont simplifiees en 1 etape au lieu de 2-3\n",
-    "- **Inconvenient** : Chaque regle apprise prend de l'espace et du temps de recherche\n",
-    "- **Quand EBL est efficace** : Quand les memes patterns de simplification apparaissent souvent\n",
-    "- **Quand EBL est inefficace** : Quand les expressions sont toutes differentes (regles jamais reutilisees)\n",
+    "- **Avantage** : Les expressions correspondant aux règles apprises sont simplifiees en 1 étape au lieu de 2-3\n",
+    "- **Inconvenient** : Chaque règle apprise prend de l'espace et du temps de recherche\n",
+    "- **Quand EBL est efficace** : Quand les mêmes patterns de simplification apparaissent souvent\n",
+    "- **Quand EBL est inefficace** : Quand les expressions sont toutes différentes (règles jamais reutilisees)\n",
     "\n",
-    "> **Point cle AIMA** : \"EBL converts first-principles theories into useful special-purpose knowledge.\" La valeur d'EBL depend entierement de la frequence de reutilisation."
+    "> **Point cle AIMA** : \"EBL converts first-principles théories into useful special-purpose knowledge.\" La valeur d'EBL depend entierement de la frequence de reutilisation."
    ]
   },
   {
@@ -1410,7 +1410,7 @@
     "\n",
     "## 7. RBL --- Introduction aux determinations\n",
     "\n",
-    "L'apprentissage base sur la pertinence (Relevance-Based Learning) utilise la connaissance prealable pour identifier **quels attributs sont pertinents** pour la tache d'apprentissage.\n",
+    "L'apprentissage base sur la pertinence (Relevance-Based Learning) utilise la connaissance prealable pour identifier **quels attributs sont pertinents** pour la tâche d'apprentissage.\n",
     "\n",
     "### Determinations\n",
     "\n",
@@ -1420,7 +1420,7 @@
     "\\text{Nationalite}(x, n) > \\text{Langue}(x, l)\n",
     "$$\n",
     "\n",
-    "Cela signifie : si deux personnes ont la meme nationalite, elles parlent la meme langue.\n",
+    "Cela signifie : si deux personnes ont la même nationalite, elles parlent la même langue.\n",
     "\n",
     "### Impact sur l'espace des hypotheses\n",
     "\n",
@@ -1562,8 +1562,8 @@
     "\n",
     "| Attributs testes | Determine langue ? | Raison |\n",
     "|-----------------|-------------------|--------|\n",
-    "| `nationality` | **Oui** | Meme nationalite => meme langue |\n",
-    "| `age` | **Non** | Alice (30) et Ivan (33) parlent des langues differentes |\n",
+    "| `nationality` | **Oui** | Même nationalite => même langue |\n",
+    "| `age` | **Non** | Alice (30) et Ivan (33) parlent des langues différentes |\n",
     "| `city` | **Non** | Pas de correlation ville -> langue unique |\n",
     "| `nationality, age` | **Oui** | Plus restrictif mais toujours valide |\n",
     "\n",
@@ -1588,7 +1588,7 @@
    "source": [
     "### Pour aller plus loin : SL-3\n",
     "\n",
-    "Nous nous arretons volontairement ici. La formalisation complete du RBL --- proprietes des determinations (monotonie, minimalite), **treillis des determinations**, algorithme **MINIMAL-CONSISTENT-DET** et sa complexite, cas d'echec sur les concepts disjonctifs (le restaurant de SL-1), et comparaison avec la selection statistique d'attributs (information mutuelle, sklearn) --- est l'objet du notebook dedie [SL-3 - Apprentissage Base sur la Pertinence](SL-3-RelevanceLearning.ipynb).\n",
+    "Nous nous arretons volontairement ici. La formalisation complete du RBL --- proprietes des determinations (monotonie, minimalite), **treillis des determinations**, algorithme **MINIMAL-CONSISTENT-DET** et sa complexite, cas d'echec sur les concepts disjonctifs (le restaurant de SL-1), et comparaison avec la sélection statistique d'attributs (information mutuelle, sklearn) --- est l'objet du notebook dedie [SL-3 - Apprentissage Base sur la Pertinence](SL-3-RelevanceLearning.ipynb).\n",
     "\n",
     "Pour situer le RBL parmi les paradigmes d'apprentissage utilisant la connaissance, le concept de determination introduit ci-dessus suffit.\n"
    ]
@@ -1616,21 +1616,21 @@
     "| Aspect | EBL | RBL | KBIL |\n",
     "|--------|-----|-----|------|\n",
     "| **Type** | Deductif | Deductif | Inductif |\n",
-    "| **Connaissance requise** | Theorie complete du domaine | Determinations (attributs pertinents) | Theorie partielle + exemples |\n",
+    "| **Connaissance requise** | Théorie complete du domaine | Determinations (attributs pertinents) | Théorie partielle + exemples |\n",
     "| **Nouveaux faits** | Non | Non | Oui |\n",
     "| **Exemples necessaires** | 1 seul | Peu | Beaucoup |\n",
-    "| **Resultat** | Regles operationnelles | Reduction d'espace | Hypotheses inductives |\n",
+    "| **Résultat** | Règles operationnelles | Reduction d'espace | Hypotheses inductives |\n",
     "| **Exemple AIMA** | Simplification arithmetique | Nationalite -> Langue | Programmation logique inductive |\n",
     "\n",
     "### Points cles\n",
     "\n",
-    "1. **EBL** compile les theories de premiers principes en heuristiques operationnelles. Il n'apprend rien de nouveau factuellement, mais rend le raisonnement plus efficace.\n",
+    "1. **EBL** compile les théories de premiers principes en heuristiques operationnelles. Il n'apprend rien de nouveau factuellement, mais rend le raisonnement plus efficace.\n",
     "\n",
     "2. **RBL** utilise les determinations pour reduire exponentiellement l'espace des hypotheses. Il suffit de connaitre les attributs pertinents pour accelerer considerablement l'apprentissage.\n",
     "\n",
     "3. **KBIL** (couvert a partir de SL-4) combine la connaissance de fond avec l'induction pour apprendre de veritables nouvelles hypotheses que ni EBL ni RBL ne pourraient decouvrir seuls.\n",
     "\n",
-    "4. L'**operationalite** en EBL est un compromis : les regles trop specifiques ne sont pas reutilisees, les regles trop generales n'apportent rien."
+    "4. L'**operationalite** en EBL est un compromis : les règles trop spécifiques ne sont pas reutilisees, les règles trop générales n'apportent rien."
    ]
   },
   {
@@ -1811,13 +1811,13 @@
    "source": [
     "### Exercice 1 (variation) : EBL sur le carre d/dx(u*u)\n",
     "\n",
-    "L'exemple guide montre comment l'EBL extrait le *chain rule* `d/dx(sin(u))=cos(u)*du` par variabilisation de la preuve. Appliquez la meme idee au **carre** : a partir de l'exemple particulier `d/dx(x*x) = 1*x+x*1`, **variabilisez** `x -> u` pour extraire la regle generale `d/dx(u*u)`, puis verifiez-la avec `symbolic_diff`.\n",
+    "L'exemple guide montre comment l'EBL extrait le *chain rule* `d/dx(sin(u))=cos(u)*du` par variabilisation de la preuve. Appliquez la même idee au **carre** : a partir de l'exemple particulier `d/dx(x*x) = 1*x+x*1`, **variabilisez** `x -> u` pour extraire la règle générale `d/dx(u*u)`, puis verifiez-la avec `symbolic_diff`.\n",
     "\n",
     "**Indices** :\n",
     "1. Calculez `symbolic_diff(\"x*x\")` (cas particulier ou `u = x`).\n",
-    "2. Remplacez `x` par `u` dans le resultat -> c'est la regle generalisee `d/dx(u*u)`.\n",
-    "3. Verifiez : `symbolic_diff(\"y*y\")` doit donner la meme forme (avec `y` au lieu de `x`), ce qui prouve que la regle est bien generale (independante du nom de la variable).\n",
-    "4. Bonus : apres simplification arithmetique, `d/dx(u*u) = 2*u` -- retrouve-t-on le *product rule* ?"
+    "2. Remplacez `x` par `u` dans le résultat -> c'est la règle generalisee `d/dx(u*u)`.\n",
+    "3. Verifiez : `symbolic_diff(\"y*y\")` doit donner la même forme (avec `y` au lieu de `x`), ce qui prouve que la règle est bien générale (independante du nom de la variable).\n",
+    "4. Bonus : après simplification arithmetique, `d/dx(u*u) = 2*u` -- retrouve-t-on le *product rule* ?"
    ]
   },
   {
@@ -1873,13 +1873,13 @@
     "tags": []
    },
    "source": [
-    "### Exemple guide 2 : Filtrage des regles apprises (operationalite)\n",
+    "### Exemple guide 2 : Filtrage des règles apprises (operationalite)\n",
     "\n",
-    "La section 6 a montre le compromis fondamental de l'EBL : chaque regle apprise augmente le **branching factor** (temps de recherche), et n'est rentable que si elle est suffisamment **reutilisee**. Une regle trop specifique -- apprise pour un seul exemple -- ne sert presque jamais et ralentit le systeme pour rien. On implemente ici le mecanisme de **desapprentissage** annonce : (a) compter les utilisations de chaque regle lors d'un batch de simplifications, puis (b) ne conserver que les regles dont le taux de reutilisation atteint un seuil.\n",
+    "La section 6 a montre le compromis fondamental de l'EBL : chaque règle apprise augmente le **branching factor** (temps de recherche), et n'est rentable que si elle est suffisamment **reutilisee**. Une règle trop spécifique -- apprise pour un seul exemple -- ne sert presque jamais et ralentit le système pour rien. On implemente ici le mécanisme de **desapprentissage** annonce : (a) compter les utilisations de chaque règle lors d'un batch de simplifications, puis (b) ne conserver que les règles dont le taux de reutilisation atteint un seuil.\n",
     "\n",
     "**Principe**. `ArithmeticEBL.simplify_with_learned` renvoie `(result, method, steps)` ou `method` vaut :\n",
-    "- `kb` : aucune regle apprise utilisee (fallback sur la base de regles generale) ;\n",
-    "- `learned(<pattern>-><result>)` : la regle apprise identifiee par son **pattern**.\n",
+    "- `kb` : aucune règle apprise utilisee (fallback sur la base de règles générale) ;\n",
+    "- `learned(<pattern>-><result>)` : la règle apprise identifiee par son **pattern**.\n",
     "\n",
     "On exploite ce champ `method` pour compter, puis on filtre `ebl.learned` selon un seuil d'utilisation."
    ]
@@ -2037,16 +2037,16 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : l'EBL n'est rentable que si les regles sont reutilisees\n",
+    "### Interpretation : l'EBL n'est rentable que si les règles sont reutilisees\n",
     "\n",
     "La mesure confirme quantitativement le compromis d'operationalite de la section 6 :\n",
     "\n",
-    "- Les regles **tres reutilisees** (ici `1*(0+z)`, utilisee 8 fois) sont precisement celles que l'EBL a compilees avec le plus de benefice : chaque utilisation economise une chaine de preuve complete (lookup O(1) au lieu de O(n)).\n",
-    "- Les regles **rarement declenchees** (ici `0+w`, utilisee 1 seule fois) coutent plus en branching factor qu'elles ne rapportent : les **desapprendre** assainit la base sans perte pratique.\n",
+    "- Les règles **très reutilisees** (ici `1*(0+z)`, utilisee 8 fois) sont précisément celles que l'EBL a compilees avec le plus de benefice : chaque utilisation economise une chaîne de preuve complete (lookup O(1) au lieu de O(n)).\n",
+    "- Les règles **rarement declenchees** (ici `0+w`, utilisee 1 seule fois) coutent plus en branching factor qu'elles ne rapportent : les **desapprendre** assainit la base sans perte pratique.\n",
     "\n",
-    "**Lien avec AIMA 19.3.4**. Le desapprentissage par seuil d'utilisation est une reponse directe au risque de *proliferation des regles* : sans filtrage, un EBL qui apprend une regle par exemple vu finit par memoriser plutot qu'a compiler. Le seuil `min_usage` incarne le **taux de rentabilite** en dessous duquel une regle n'est pas operationnelle -- l'equivalent, pour l'EBL, du rasoir d'Occam de l'Exemple guide 5 (SL-1) : un critere de **selection** parmi les connaissances consistantes.\n",
+    "**Lien avec AIMA 19.3.4**. Le desapprentissage par seuil d'utilisation est une reponse directe au risque de *proliferation des règles* : sans filtrage, un EBL qui apprend une règle par exemple vu finit par memoriser plutot qu'a compiler. Le seuil `min_usage` incarne le **taux de rentabilite** en dessous duquel une règle n'est pas operationnelle -- l'equivalent, pour l'EBL, du rasoir d'Occam de l'Exemple guide 5 (SL-1) : un critere de **sélection** parmi les connaissances consistantes.\n",
     "\n",
-    "**Point de vigilance** : le seuil et le corpus determinent quelles regles survivent. Un corpus non representatif ferait disparaitre une regle en realite utile (faux negatif d'utilisation) ; un seuil trop bas laisserait proliferer les regles specifiques. C'est l'eternel compromis biais-variance applique a la memoire de regles."
+    "**Point de vigilance** : le seuil et le corpus determinent quelles règles survivent. Un corpus non representatif ferait disparaitre une règle en realite utile (faux negatif d'utilisation) ; un seuil trop bas laisserait proliferer les règles spécifiques. C'est l'eternel compromis biais-variance applique a la memoire de règles."
    ]
   },
   {
@@ -2065,12 +2065,12 @@
    "source": [
     "### Exemple guide 3 : Mesurer empiriquement le speedup EBL\n",
     "\n",
-    "On mesure maintenant le speedup obtenu par les regles EBL sur un **corpus systematique de 100 expressions**, en comparant les temps de simplification avec et sans apprentissage. Deux metriques sont suivies :\n",
+    "On mesure maintenant le speedup obtenu par les règles EBL sur un **corpus systématique de 100 expressions**, en comparant les temps de simplification avec et sans apprentissage. Deux metriques sont suivies :\n",
     "\n",
-    "- **Nombre d'etapes** (metrique deterministe, reproductible) : le nombre de pas de reecriture effectues par `simplify_with_learned`. C'est la mesure canonique du speedup algorithmique de l'EBL (cf section precedente).\n",
+    "- **Nombre d'étapes** (metrique déterministe, reproductible) : le nombre de pas de reecriture effectues par `simplify_with_learned`. C'est la mesure canonique du speedup algorithmique de l'EBL (cf section précédente).\n",
     "- **Temps wall-clock** (metrique secondaire, bruitee) : la duree reelle via `time.perf_counter()`, moyennee sur plusieurs repetitions pour amortir le bruit de la charge CPU.\n",
     "\n",
-    "On attend qu'un corpus heterogene revele **sur quelle categorie d'expressions l'EBL est rentable** -- et, surprise, que la reponse differe selon la metrique choisie."
+    "On attend qu'un corpus heterogene revele **sur quelle catégorie d'expressions l'EBL est rentable** -- et, surprise, que la reponse differe selon la metrique choisie."
    ]
   },
   {
@@ -2257,22 +2257,22 @@
    "source": [
     "### Interpretation : le speedup de l'EBL est algorithmique, pas (toujours) wall-clock\n",
     "\n",
-    "La mesure revele un resultat **contre-intuitif mais fondamental** -- et reproductible :\n",
+    "La mesure revele un résultat **contre-intuitif mais fondamental** -- et reproductible :\n",
     "\n",
     "| Metrique | Sans EBL | Avec EBL | Verdict |\n",
     "|----------|---------:|---------:|---------|\n",
-    "| **Etapes** (deterministe) | 101 | 67 | EBL gagne : **1.51x**, -34% |\n",
+    "| **Étapes** (déterministe) | 101 | 67 | EBL gagne : **1.51x**, -34% |\n",
     "| **Temps wall-clock** (mediane) | ~520 us | ~860 us | EBL **perd** : ~0.6x |\n",
     "\n",
-    "(Les chiffres wall-clock precis fluctuent avec la charge CPU ; le **classement**, lui, est stable : l'EBL est ici plus lente en temps alors qu'elle gagne en etapes.)\n",
+    "(Les chiffres wall-clock précis fluctuent avec la charge CPU ; le **classement**, lui, est stable : l'EBL est ici plus lente en temps alors qu'elle gagne en étapes.)\n",
     "\n",
-    "**Pourquoi cette inversion ?** Le speedup EBL est un gain **algorithmique en profondeur de preuve** : une regle compilee remplace une chaine de 2 reecritures par un lookup direct. Mais sur ce *toy-example* -- expressions triviales, base de 3 regles -- le **cout de recherche** parmi les regles apprises (le branching factor de la section 6) **domine** le gain en etapes. C'est l'illustration exacte du **utility problem** decrit par Minton (1990) : au-dela d'un certain nombre de regles apprises, apprendre *plus* ralentit le systeme, parce que le cout de matcher chaque regle supplementaire depasse l'economie realisee sur les quelques-unes qui s'appliquent. Le wall-clock ne redevient favorable qu'a plus grande echelle, sur de vraies chaines de preuve ou chaque etape economisee coute cher.\n",
+    "**Pourquoi cette inversion ?** Le speedup EBL est un gain **algorithmique en profondeur de preuve** : une règle compilee remplace une chaîne de 2 reecritures par un lookup direct. Mais sur ce *toy-example* -- expressions triviales, base de 3 règles -- le **cout de recherche** parmi les règles apprises (le branching factor de la section 6) **domine** le gain en étapes. C'est l'illustration exacte du **utility problem** decrit par Minton (1990) : au-dela d'un certain nombre de règles apprises, apprendre *plus* ralentit le système, parce que le cout de matcher chaque règle supplementaire depasse l'economie realisee sur les quelques-unes qui s'appliquent. Le wall-clock ne redevient favorable qu'a plus grande echelle, sur de vraies chaînes de preuve ou chaque étape economisee coute cher.\n",
     "\n",
-    "**Dependence au type d'expression (Q2)** : la decomposition par famille tranche net. Seules les expressions **profondes** (`1*(0+x)`, 2 etapes -> 1) beneficient du gain ; les expressions **shallow** (`0+x`, deja 1 etape) et **non-matchantes** (`2+3`) sont strictement neutres (0 etape gagnee). C'est la formalisation du principe de compilation : on ne gagne qu'en court-circuitant une chaine qui existait deja.\n",
+    "**Dependence au type d'expression (Q2)** : la decomposition par famille tranche net. Seules les expressions **profondes** (`1*(0+x)`, 2 étapes -> 1) beneficient du gain ; les expressions **shallow** (`0+x`, déjà 1 étape) et **non-matchantes** (`2+3`) sont strictement neutres (0 étape gagnee). C'est la formalisation du principe de compilation : on ne gagne qu'en court-circuitant une chaîne qui existait déjà.\n",
     "\n",
-    "**Point de bascule memoire (Q3)** : lie a l'**Exemple guide 2** et au utility problem. Une regle apprise paie son surcout de stockage des qu'elle evite au moins une chaine de preuve complete lors d'une reutilisation. En dessous, elle alourdit inutilement la base -- c'est exactement ce que le `prune_learned_rules` par seuil d'utilisation detecte et elimine. Le compromis etapes-temps ci-dessus est donc le **cahier des charges** du seuil `min_usage` : garder une regle seulement si, sur le corpus reel, ses economies en etapes compensent son cout de recherche.\n",
+    "**Point de bascule memoire (Q3)** : lie a l'**Exemple guide 2** et au utility problem. Une règle apprise paie son surcout de stockage des qu'elle evite au moins une chaîne de preuve complete lors d'une reutilisation. En dessous, elle alourdit inutilement la base -- c'est exactement ce que le `prune_learned_rules` par seuil d'utilisation detecte et elimine. Le compromis étapes-temps ci-dessus est donc le **cahier des charges** du seuil `min_usage` : garder une règle seulement si, sur le corpus reel, ses economies en étapes compensent son cout de recherche.\n",
     "\n",
-    "**Lien avec SL-1 / Occam** : ici encore, l'EBL applique un critere de *selection* parmi des connaissances consistantes (toutes les regles apprises sont correctes), exactement comme le rasoir d'Occam selectionnait l'hypothese minimale en SL-1."
+    "**Lien avec SL-1 / Occam** : ici encore, l'EBL applique un critere de *sélection* parmi des connaissances consistantes (toutes les règles apprises sont correctes), exactement comme le rasoir d'Occam selectionnait l'hypothese minimale en SL-1."
    ]
   },
   {
@@ -2291,11 +2291,11 @@
    "source": [
     "### Exercice 2 (variation) : RBL robuste face a un attribut bruite\n",
     "\n",
-    "La section 7 a montre que `nationality` **determine** seul la langue, tandis que `age` et `city` ne la determinent pas (table idx24). Une question naturelle : que se passe-t-il si l'on **ajoute** un attribut totalement decorrele (un bruit) aux donnees ? RBL doit rester robuste : la determination minimale `nationality -> language` ne doit pas changer.\n",
+    "La section 7 a montre que `nationality` **determine** seul la langue, tandis que `age` et `city` ne la determinent pas (table idx24). Une question naturelle : que se passe-t-il si l'on **ajoute** un attribut totalement decorrele (un bruit) aux données ? RBL doit rester robuste : la determination minimale `nationality -> language` ne doit pas changer.\n",
     "\n",
     "Ajoutez un 5e attribut `forecaster` (le nom du meteorologue, sans aucun lien avec la langue) a chaque ligne de `nationality_data`, puis verifiez que la determination minimale est toujours `nationality`.\n",
     "\n",
-    "**Etapes** :\n",
+    "**Étapes** :\n",
     "1. Construisez `nationality_noisy` en ajoutant `forecaster` (valeurs arbitraires : `\"Alice\", \"Bob\", ...`) a chaque ligne via `dict(row, forecaster=f)`.\n",
     "2. Ajoutez `\"forecaster\"` a `ALL_ATTRS`.\n",
     "3. Re-testez `check_determination` sur `[\"nationality\"]`, `[\"forecaster\"]`, `[\"nationality\", \"forecaster\"]`.\n",
@@ -2368,17 +2368,17 @@
    "source": [
     "### Exercice 3 (variation) : EBL operationalite -- faire varier le seuil de desapprentissage\n",
     "\n",
-    "L'Exemple guide 2 a fixe `min_usage=2` et observe que la regle `0+w` (1 utilisation) est desapprise tandis que `1*(0+z)` (8) et `1*v` (2) sont conservees. Mais le seuil est un **parametre libre** : sa valeur decide quelles regles survivent. Faites-le varier et observez la frontiere d'operationalite -- c'est le **utility problem** de Minton (1990) introduit dans l'interpretation de l'Exemple guide 3.\n",
+    "L'Exemple guide 2 a fixe `min_usage=2` et observe que la règle `0+w` (1 utilisation) est desapprise tandis que `1*(0+z)` (8) et `1*v` (2) sont conservees. Mais le seuil est un **paramètre libre** : sa valeur decide quelles règles survivent. Faites-le varier et observez la frontiere d'operationalite -- c'est le **utility problem** de Minton (1990) introduit dans l'interpretation de l'Exemple guide 3.\n",
     "\n",
-    "Reutilisez `count_rule_usage` et `prune_learned_rules` de l'Exemple guide 2, et tabulez le nombre de regles conservees pour plusieurs seuils.\n",
+    "Reutilisez `count_rule_usage` et `prune_learned_rules` de l'Exemple guide 2, et tabulez le nombre de règles conservees pour plusieurs seuils.\n",
     "\n",
-    "**Etapes** :\n",
-    "1. Reconstruisez une instance `ArithmeticEBL` fraiche et apprenez-lui les 3 regles (`1*(0+x)`, `1*y`, `0+u`).\n",
-    "2. Recomptez les utilisations sur le **meme corpus** que l'Exemple guide 2 (12 expressions).\n",
-    "3. Pour `min_usage` dans `{1, 2, 3, 5}`, appliquez `prune_learned_rules` et affichez le nombre de regles conservees + leurs patterns.\n",
-    "4. Observez : a partir de quel seuil la regle la **plus reutilisee** (`1*(0+z)`) est-elle elle-meme desapprise ? Pourquoi cela illustre-t-il que le seuil traduit un compromis biais-variance ?\n",
+    "**Étapes** :\n",
+    "1. Reconstruisez une instance `ArithmeticEBL` fraiche et apprenez-lui les 3 règles (`1*(0+x)`, `1*y`, `0+u`).\n",
+    "2. Recomptez les utilisations sur le **même corpus** que l'Exemple guide 2 (12 expressions).\n",
+    "3. Pour `min_usage` dans `{1, 2, 3, 5}`, appliquez `prune_learned_rules` et affichez le nombre de règles conservees + leurs patterns.\n",
+    "4. Observez : a partir de quel seuil la règle la **plus reutilisee** (`1*(0+z)`) est-elle elle-même desapprise ? Pourquoi cela illustre-t-il que le seuil traduit un compromis biais-variance ?\n",
     "\n",
-    "**Indice** : chaque regle a un *compte d'utilisation fixe* sur un corpus donne. Le seuil ne fait que selectionner un *prefixe* du classement par utilisation decroissante. Un seuil trop eleve = base sous-apprise (perte de speedup) ; un seuil trop bas = proliferation (utility problem). Le seuil optimal depend du **corpus reel futur**, qui est inconnu -- d'ou l'eternel compromis.\n"
+    "**Indice** : chaque règle a un *compte d'utilisation fixe* sur un corpus donne. Le seuil ne fait que sélectionner un *prefixe* du classement par utilisation decroissante. Un seuil trop eleve = base sous-apprise (perte de speedup) ; un seuil trop bas = proliferation (utility problem). Le seuil optimal depend du **corpus reel futur**, qui est inconnu -- d'ou l'eternel compromis.\n"
    ]
   },
   {
@@ -2449,11 +2449,11 @@
    "source": [
     "## Resume et perspectives\n",
     "\n",
-    "Ce notebook a etudie deux approches qui exploitent la connaissance prealable du domaine pour ameliorer l'apprentissage : l'EBL (Explanation-Based Learning) et le RBL (Relevance-Based Learning). L'EBL compile une theorie de premiers principes en regles operationnelles a partir d'un seul exemple, en construisant un arbre de preuve puis en variabilisant les constantes. L'implementation sur la simplification arithmetique a montre comment les regles `1*u -> u` et `0+u -> u` peuvent etre combinees en une regle composee `Simplify(1*(0+z), z)` qui court-circuite les etapes intermediaires. Le compromis fondamental de l'EBL reside dans l'operationalite : les regles trop specifiques ne sont jamais reutilisees, tandis que les regles trop generales n'apportent aucun gain.\n",
+    "Ce notebook a etudie deux approches qui exploitent la connaissance prealable du domaine pour ameliorer l'apprentissage : l'EBL (Explanation-Based Learning) et le RBL (Relevance-Based Learning). L'EBL compile une théorie de premiers principes en règles operationnelles a partir d'un seul exemple, en construisant un arbre de preuve puis en variabilisant les constantes. L'implementation sur la simplification arithmetique a montre comment les règles `1*u -> u` et `0+u -> u` peuvent etre combinees en une règle composee `Simplify(1*(0+z), z)` qui court-circuite les étapes intermediaires. Le compromis fondamental de l'EBL reside dans l'operationalite : les règles trop spécifiques ne sont jamais reutilisees, tandis que les règles trop générales n'apportent aucun gain.\n",
     "\n",
-    "Le RBL, quant a lui, identifie les attributs pertinents via les determinations : si un sous-ensemble de d attributs determine la cible parmi n attributs, l'espace des hypotheses se reduit de O(2^n) a O(2^d) --- une reduction exponentielle quand d << n. Sur le domaine nationalite-langue, la determination `nationality` seule suffit a predire la langue, rendant les autres attributs (age, ville) inutiles a l'apprentissage. La formalisation complete du cadre --- treillis des determinations, algorithme MINIMAL-CONSISTENT-DET, cas d'echec sur les concepts disjonctifs et comparaison avec la selection statistique d'attributs --- est l'objet du notebook suivant.\n",
+    "Le RBL, quant a lui, identifie les attributs pertinents via les determinations : si un sous-ensemble de d attributs determine la cible parmi n attributs, l'espace des hypotheses se reduit de O(2^n) a O(2^d) --- une reduction exponentielle quand d << n. Sur le domaine nationalite-langue, la determination `nationality` seule suffit a predire la langue, rendant les autres attributs (age, ville) inutiles a l'apprentissage. La formalisation complete du cadre --- treillis des determinations, algorithme MINIMAL-CONSISTENT-DET, cas d'echec sur les concepts disjonctifs et comparaison avec la sélection statistique d'attributs --- est l'objet du notebook suivant.\n",
     "\n",
-    "Ces deux approches sont deductives et ne creent pas de connaissance factuellement nouvelle. Le notebook suivant, [SL-3 - Apprentissage Base sur la Pertinence](SL-3-RelevanceLearning.ipynb), approfondit le RBL ; le passage a l'apprentissage inductif base sur la connaissance (KBIL), qui combine connaissances de fond et induction pour decouvrir de veritables nouvelles hypotheses, sera explore a partir de [SL-4 - Programmation Logique Inductive](SL-4-InductiveLogicProgramming.ipynb).\n"
+    "Ces deux approches sont deductives et ne créent pas de connaissance factuellement nouvelle. Le notebook suivant, [SL-3 - Apprentissage Base sur la Pertinence](SL-3-RelevanceLearning.ipynb), approfondit le RBL ; le passage a l'apprentissage inductif base sur la connaissance (KBIL), qui combine connaissances de fond et induction pour decouvrir de veritables nouvelles hypotheses, sera explore a partir de [SL-4 - Programmation Logique Inductive](SL-4-InductiveLogicProgramming.ipynb).\n"
    ]
   },
   {
@@ -2481,9 +2481,9 @@
     "\n",
     "| Exercice | Question-twist a traiter en plus |\n",
     "|----------|----------------------------------|\n",
-    "| **Ex. 1 (EBL, differentiation symbolique)** | Exhibez un cas ou la variabilisation trop agressive de l'arbre de preuve produit une regle compilee *fausse* (appliquee hors de ses conditions de validite). Quelle partie de la preuve aurait du rester constante ? |\n",
-    "| **Ex. 2 (filtrage des regles)** | L'utilite d'une regle depend de la distribution des problemes futurs : construisez deux distributions de requetes qui *inversent* le classement de vos regles (une regle filtree devient la plus rentable). |\n",
-    "| **Ex. 3 (speedup EBL)** | Augmentez le nombre de regles apprises jusqu'a observer le point ou apprendre *plus* ralentit le systeme (utility problem, Minton 1990). Pourquoi ce point existe-t-il quelle que soit l'implementation ? |\n"
+    "| **Ex. 1 (EBL, differentiation symbolique)** | Exhibez un cas ou la variabilisation trop agressive de l'arbre de preuve produit une règle compilee *fausse* (appliquee hors de ses conditions de validite). Quelle partie de la preuve aurait du rester constante ? |\n",
+    "| **Ex. 2 (filtrage des règles)** | L'utilite d'une règle depend de la distribution des problemes futurs : construisez deux distributions de requêtes qui *inversent* le classement de vos règles (une règle filtree devient la plus rentable). |\n",
+    "| **Ex. 3 (speedup EBL)** | Augmentez le nombre de règles apprises jusqu'a observer le point ou apprendre *plus* ralentit le système (utility problem, Minton 1990). Pourquoi ce point existe-t-il quelle que soit l'implementation ? |\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
Restores French accents in **SL-2-KnowledgeBasedLearning** markdown cells (SymbolicLearning family). Part of EPIC #2876, **markdown-only-strict** adjudication (ai-01, 2026-07-17).

## Scope (markdown-only-strict)
- **27 markdown cells cured, 213 accent restorations. Code cells: 0 changed** (comments/stdout/identifiers untouched).

## Verification (firsthand, byte-safe)
| Check | Result |
|-------|--------|
| Markdown cells changed | 27 |
| Code-source cells changed | **0** |
| Outputs / execution_count changed | 0 / 0 |
| Structure + metadata preserved | Yes (44 cells) |
| Identifier-regression guard (#7157) | **OK, exit 0** |
| nbformat / H.3 unexecuted | 4 / 0 |

Note: this replaces the composite #7182 (closed — my mistake pushing 2 notebooks to one branch). Single-subject now. See #2876.

Co-Authored-By: Claude <noreply@anthropic.com>
