### PR TITLE
fix(probas,#2876): restore French accents in Infer-8-TrueSkill markdown (128 cures, code untouched)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb
@@ -14,7 +14,7 @@
     "tags": []
    },
    "source": [
-    "# Infer-8-TrueSkill : Systeme de Classement et Apprentissage en Ligne\n",
+    "# Infer-8-TrueSkill : Système de Classement et Apprentissage en Ligne\n",
     "\n",
     "**Serie** : Programmation Probabiliste avec Infer.NET (8/20)  \n",
     "**Duree estimee** : 55 minutes  \n",
@@ -24,17 +24,17 @@
     "\n",
     "## Objectifs\n",
     "\n",
-    "- Comprendre le systeme TrueSkill (Xbox Live)\n",
+    "- Comprendre le système TrueSkill (Xbox Live)\n",
     "- Implementer des matchs 1v1 et la mise a jour des skills\n",
     "- Gerer les matchs nuls\n",
     "- Maitriser l'apprentissage en ligne (posterieurs -> priors)\n",
-    "- Etendre aux equipes et multi-joueurs\n",
+    "- Etendre aux équipes et multi-joueurs\n",
     "\n",
     "---\n",
     "\n",
     "## Navigation\n",
     "\n",
-    "| Precedent | Suivant |\n",
+    "| Précédent | Suivant |\n",
     "|-----------|--------|\n",
     "| [Infer-9-Classification](Infer-9-Classification.ipynb) | [Infer-11-Topic-Models](Infer-11-Topic-Models.ipynb) |\n",
     "\n",
@@ -57,7 +57,7 @@
    "source": [
     "## 1. Configuration\n",
     "\n",
-    "Nous chargeons Infer.NET pour implementer le systeme TrueSkill, developpe par Microsoft Research pour Xbox Live. Ce systeme de classement bayesien estime les competences des joueurs a partir des resultats de matchs, tout en quantifiant l'incertitude sur ces estimations."
+    "Nous chargeons Infer.NET pour implementer le système TrueSkill, developpe par Microsoft Research pour Xbox Live. Ce système de classement bayesien estime les competences des joueurs a partir des résultats de matchs, tout en quantifiant l'incertitude sur ces estimations."
    ]
   },
   {
@@ -99,7 +99,6 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
-       
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -109,10 +108,7 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
-       
-       
        "\r\n",
-       
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -127,7 +123,6 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
-       
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -139,8 +134,6 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
-       
-       
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
@@ -189,13 +182,11 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
-       
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
-       
        "}\r\n",
        "\r\n",
        "    </script>\r\n",
@@ -320,7 +311,7 @@
     "| Namespace | Usage |\n",
     "|-----------|-------|\n",
     "| `Microsoft.ML.Probabilistic.Distributions` | Gaussiennes pour modeliser les skills |\n",
-    "| `Microsoft.ML.Probabilistic.Models` | Variables et contraintes du modele |\n",
+    "| `Microsoft.ML.Probabilistic.Models` | Variables et contraintes du modèle |\n",
     "| `Microsoft.ML.Probabilistic.Algorithms` | Expectation Propagation (EP) |\n",
     "\n",
     "> **Note technique** : TrueSkill utilise l'algorithme **Expectation Propagation** car les facteurs de comparaison (perf1 > perf2) ne sont pas conjugues avec les Gaussiennes. EP approxime ces facteurs par des Gaussiennes, permettant une inference efficace."
@@ -344,7 +335,7 @@
     "\n",
     "### Contexte\n",
     "\n",
-    "**TrueSkill** est le systeme de classement developpe par Microsoft Research pour Xbox Live. Il est une generalisation bayesienne du systeme Elo.\n",
+    "**TrueSkill** est le système de classement developpe par Microsoft Research pour Xbox Live. Il est une generalisation bayesienne du système Elo.\n",
     "\n",
     "### Principe\n",
     "\n",
@@ -360,9 +351,9 @@
     "\n",
     "$$\\text{Joueur 1 gagne si} \\quad \\text{performance}_1 > \\text{performance}_2$$\n",
     "\n",
-    "### Parametres par defaut\n",
+    "### Paramètres par defaut\n",
     "\n",
-    "| Parametre | Valeur | Description |\n",
+    "| Paramètre | Valeur | Description |\n",
     "|-----------|--------|-------------|\n",
     "| mu_initial | 25 | Skill initial |\n",
     "| sigma_initial | 25/3 | Incertitude initiale |\n",
@@ -391,7 +382,7 @@
     "| **Incertitude** | Non modelisee | Capturee par sigma |\n",
     "| **Convergence** | Lente (K fixe) | Rapide (adaptatif via sigma) |\n",
     "| **Matchs nuls** | +/- points fixes | Reduction d'incertitude |\n",
-    "| **Equipes** | Moyenne des Elo | Somme des performances |\n",
+    "| **Équipes** | Moyenne des Elo | Somme des performances |\n",
     "| **Multi-joueurs** | Decomposition en paires | Natif via contraintes d'ordre |\n",
     "\n",
     "> **Note historique** : TrueSkill a ete developpe en 2006 par Ralf Herbrich et Thore Graepel chez Microsoft Research. Il est utilise sur Xbox Live depuis 2007 pour le matchmaking de millions de joueurs."
@@ -411,18 +402,18 @@
     "tags": []
    },
    "source": [
-    "## 3. Modele Deux Joueurs\n",
+    "## 3. Modèle Deux Joueurs\n",
     "\n",
-    "### Construction du modele etape par etape\n",
+    "### Construction du modèle étape par étape\n",
     "\n",
-    "Le code suivant construit le modele TrueSkill en quatre phases :\n",
+    "Le code suivant construit le modèle TrueSkill en quatre phases :\n",
     "\n",
-    "1. **Parametres** : Definition des hyperparametres (mu=25, sigma=8.33, beta=4.17)\n",
-    "2. **Priors** : Chaque joueur commence avec la meme distribution Gaussienne\n",
+    "1. **Paramètres** : Definition des hyperparametres (mu=25, sigma=8.33, beta=4.17)\n",
+    "2. **Priors** : Chaque joueur commence avec la même distribution Gaussienne\n",
     "3. **Performances** : Ajout de bruit pour modeliser la variabilite d'un match\n",
-    "4. **Observation** : Le resultat du match (qui a gagne) est observe\n",
+    "4. **Observation** : Le résultat du match (qui a gagne) est observe\n",
     "\n",
-    "Cette structure separe clairement les **croyances initiales** (priors) des **donnees observees** (resultat du match)."
+    "Cette structure separe clairement les **croyances initiales** (priors) des **données observees** (résultat du match)."
    ]
   },
   {
@@ -500,9 +491,9 @@
     "tags": []
    },
    "source": [
-    "### Structure du modele graphique\n",
+    "### Structure du modèle graphique\n",
     "\n",
-    "Le modele TrueSkill peut etre represente comme un graphe de facteurs :\n",
+    "Le modèle TrueSkill peut etre represente comme un graphe de facteurs :\n",
     "\n",
     "```\n",
     "skill1 ~ N(25, 8.33^2)     skill2 ~ N(25, 8.33^2)\n",
@@ -533,9 +524,9 @@
     "tags": []
    },
    "source": [
-    "### Execution de l'inference\n",
+    "### Exécution de l'inference\n",
     "\n",
-    "Nous allons maintenant executer l'inference pour calculer les posterieurs des skills apres avoir observe que le joueur 1 a gagne. L'algorithme EP va propager l'information du resultat vers les distributions de skill."
+    "Nous allons maintenant executer l'inference pour calculer les posterieurs des skills après avoir observe que le joueur 1 a gagne. L'algorithme EP va propager l'information du résultat vers les distributions de skill."
    ]
   },
   {
@@ -1021,12 +1012,12 @@
    "source": [
     "### Lecture du graphe de facteurs TrueSkill 1v1\n",
     "\n",
-    "Le graphe ci-dessus montre la structure du modele TrueSkill pour un match a deux joueurs :\n",
+    "Le graphe ci-dessus montre la structure du modèle TrueSkill pour un match a deux joueurs :\n",
     "\n",
     "**Noeuds de variables (ellipses)** :\n",
     "- `skill1`, `skill2` : Les competences latentes des joueurs (Gaussiennes)\n",
     "- `perf1`, `perf2` : Les performances observees pendant le match\n",
-    "- `joueur1Gagne` : Le resultat du match (observe = true)\n",
+    "- `joueur1Gagne` : Le résultat du match (observe = true)\n",
     "\n",
     "**Noeuds de facteurs (rectangles)** :\n",
     "- `GaussianFromMeanAndVariance` : Lie les priors aux skills et les skills aux performances\n",
@@ -1057,9 +1048,9 @@
    "source": [
     "## 4. Gestion des Matchs Nuls\n",
     "\n",
-    "### Modele\n",
+    "### Modèle\n",
     "\n",
-    "Un match nul se produit quand la difference de performances est dans un intervalle $[-\\epsilon, \\epsilon]$.\n",
+    "Un match nul se produit quand la différence de performances est dans un intervalle $[-\\epsilon, \\epsilon]$.\n",
     "\n",
     "$$|\\text{perf}_1 - \\text{perf}_2| < \\epsilon \\Rightarrow \\text{match nul}$$"
    ]
@@ -1080,7 +1071,7 @@
    "source": [
     "### Implementation avec Variable.ConstrainBetween\n",
     "\n",
-    "Pour modeliser un match nul, nous utilisons `Variable.ConstrainBetween` qui impose que la difference de performances soit dans un intervalle. Cela remplace la contrainte binaire \">\" par une contrainte d'intervalle."
+    "Pour modeliser un match nul, nous utilisons `Variable.ConstrainBetween` qui impose que la différence de performances soit dans un intervalle. Cela remplace la contrainte binaire \">\" par une contrainte d'intervalle."
    ]
   },
   {
@@ -1241,20 +1232,20 @@
     "tags": []
    },
    "source": [
-    "### Exercice : Impact du parametre beta sur la mise a jour des skills\n",
+    "### Exercice : Impact du paramètre beta sur la mise a jour des skills\n",
     "\n",
-    "Le parametre `beta` controle la variance de la performance (bruit dans un match). Un beta faible signifie que le resultat du match reflete fidelement le skill, tandis qu'un beta eleve signifie beaucoup de variance (chance/peur de gagner).\n",
+    "Le paramètre `beta` contrôle la variance de la performance (bruit dans un match). Un beta faible signifie que le résultat du match reflete fidelement le skill, tandis qu'un beta eleve signifie beaucoup de variance (chance/peur de gagner).\n",
     "\n",
-    "**Objectif** : Comparez la mise a jour des skills pour un meme match (joueur 1 gagne) avec trois valeurs de beta : 2.0 (faible), 4.17 (defaut), et 8.0 (eleve).\n",
+    "**Objectif** : Comparez la mise a jour des skills pour un même match (joueur 1 gagne) avec trois valeurs de beta : 2.0 (faible), 4.17 (defaut), et 8.0 (eleve).\n",
     "\n",
-    "**Etapes** :\n",
-    "1. Pour chaque valeur de beta, creez le modele TrueSkill 1v1 avec les priors par defaut (mu=25, sigma=8.33)\n",
+    "**Étapes** :\n",
+    "1. Pour chaque valeur de beta, créez le modèle TrueSkill 1v1 avec les priors par defaut (mu=25, sigma=8.33)\n",
     "2. Observez que joueur 1 gagne\n",
     "3. Calculez les posterieurs des deux joueurs\n",
     "4. Affichez un tableau comparatif des changements de skill pour chaque beta\n",
     "\n",
     "**Indices** :\n",
-    "- Un beta faible => le match est tres informatif => grand changement de skill\n",
+    "- Un beta faible => le match est très informatif => grand changement de skill\n",
     "- Un beta eleve => le match est peu informatif => petit changement de skill\n",
     "- Comparez aussi la reduction de sigma (incertitude) entre les trois cas"
    ]
@@ -1668,17 +1659,17 @@
    "source": [
     "### Lecture du graphe de facteurs - Match nul\n",
     "\n",
-    "Ce graphe differe du modele 1v1 par le facteur de contrainte :\n",
+    "Ce graphe differe du modèle 1v1 par le facteur de contrainte :\n",
     "\n",
-    "**Difference structurelle** :\n",
+    "**Différence structurelle** :\n",
     "- `diff` : Variable intermediaire representant `perfA - perfB`\n",
     "- `ConstrainBetween` : Facteur imposant que `diff` soit dans l'intervalle `[-epsilon, epsilon]`\n",
     "\n",
-    "**Comparaison avec le modele 1v1** :\n",
+    "**Comparaison avec le modèle 1v1** :\n",
     "\n",
     "| Aspect | Match 1v1 | Match nul |\n",
     "|--------|-----------|-----------|\n",
-    "| Facteur de resultat | `IsGreaterThan` | `ConstrainBetween` |\n",
+    "| Facteur de résultat | `IsGreaterThan` | `ConstrainBetween` |\n",
     "| Information | Ordre strict | Proximite |\n",
     "| Effet sur mu | Augmente/diminue | Inchange |\n",
     "| Effet sur sigma | Reduit | Reduit davantage |\n",
@@ -1704,7 +1695,7 @@
     "\n",
     "### Principe\n",
     "\n",
-    "Apres chaque match, les **posterieurs** deviennent les **priors** pour le match suivant.\n",
+    "Après chaque match, les **posterieurs** deviennent les **priors** pour le match suivant.\n",
     "\n",
     "```\n",
     "Match 1 : Prior -> Inference -> Posterieur\n",
@@ -1737,7 +1728,7 @@
     "\n",
     "- **Dictionary skills** : Stocke le posterieur actuel de chaque joueur\n",
     "- **GetSkill()** : Retourne le prior initial si le joueur est nouveau\n",
-    "- **EnregistrerMatch()** : Met a jour les posterieurs apres un match\n",
+    "- **EnregistrerMatch()** : Met a jour les posterieurs après un match\n",
     "- **AfficherClassement()** : Affiche le rating conservatif (mu - 3*sigma)\n",
     "\n",
     "Le **rating conservatif** mu - 3*sigma est la metrique publique utilisee par Xbox Live. Il represente une borne inferieure a 99.7% de confiance sur le vrai skill."
@@ -1879,9 +1870,9 @@
     "$$P(\\theta | D_{1:n}) \\propto P(D_n | \\theta) \\cdot P(\\theta | D_{1:n-1})$$\n",
     "\n",
     "En pratique :\n",
-    "1. Le **posterieur** apres le match n-1 devient le **prior** pour le match n\n",
+    "1. Le **posterieur** après le match n-1 devient le **prior** pour le match n\n",
     "2. Chaque match apporte de l'information incrementale\n",
-    "3. Le systeme \"n'oublie jamais\" mais l'influence des anciens matchs diminue naturellement\n",
+    "3. Le système \"n'oublie jamais\" mais l'influence des anciens matchs diminue naturellement\n",
     "\n",
     "> **Avantage computationnel** : Contrairement a un recalcul global, l'apprentissage en ligne a une complexite O(1) par match, permettant de gerer des millions de joueurs en temps reel."
    ]
@@ -1902,7 +1893,7 @@
    "source": [
     "### Simulation d'un tournoi complet\n",
     "\n",
-    "Nous simulons maintenant un petit tournoi de 6 matchs entre 4 joueurs. Observez comment les skills evoluent au fur et a mesure des matchs, et comment le classement emerge des resultats."
+    "Nous simulons maintenant un petit tournoi de 6 matchs entre 4 joueurs. Observez comment les skills evoluent au fur et a mesure des matchs, et comment le classement emerge des résultats."
    ]
   },
   {
@@ -2182,11 +2173,11 @@
     "tags": []
    },
    "source": [
-    "## 6. Extension aux Equipes\n",
+    "## 6. Extension aux Équipes\n",
     "\n",
-    "### Modele\n",
+    "### Modèle\n",
     "\n",
-    "Pour un match par equipes, la performance d'equipe est la somme des performances individuelles."
+    "Pour un match par équipes, la performance d'équipe est la somme des performances individuelles."
    ]
   },
   {
@@ -2203,12 +2194,12 @@
     "tags": []
    },
    "source": [
-    "### Modelisation de la performance d'equipe\n",
+    "### Modelisation de la performance d'équipe\n",
     "\n",
-    "Dans ce modele 2v2, la performance d'une equipe est la **somme** des performances individuelles. Ce choix de modelisation implique que :\n",
+    "Dans ce modèle 2v2, la performance d'une équipe est la **somme** des performances individuelles. Ce choix de modelisation implique que :\n",
     "\n",
     "- Un bon joueur peut \"porter\" un coequipier plus faible\n",
-    "- La variance de l'equipe augmente avec le nombre de joueurs\n",
+    "- La variance de l'équipe augmente avec le nombre de joueurs\n",
     "- L'attribution du credit est uniforme entre coequipiers"
    ]
   },
@@ -2362,11 +2353,11 @@
     "tags": []
    },
    "source": [
-    "### Analyse du match par equipes\n",
+    "### Analyse du match par équipes\n",
     "\n",
-    "**Resultats** :\n",
+    "**Résultats** :\n",
     "\n",
-    "| Joueur | Equipe | Skill avant | Skill apres | Delta |\n",
+    "| Joueur | Équipe | Skill avant | Skill après | Delta |\n",
     "|--------|--------|-------------|-------------|-------|\n",
     "| A | Gagnante | 25.00 | 27.99 | +2.99 |\n",
     "| B | Gagnante | 25.00 | 27.99 | +2.99 |\n",
@@ -2375,11 +2366,11 @@
     "\n",
     "**Observations cles** :\n",
     "\n",
-    "1. **Attribution uniforme** : Chaque membre recoit le meme changement (priors identiques)\n",
+    "1. **Attribution uniforme** : Chaque membre recoit le même changement (priors identiques)\n",
     "2. **Gain plus faible qu'en 1v1** : +2.99 vs +4.21 car l'information est \"diluee\" entre coequipiers\n",
-    "3. **Probleme de l'attribution** : Impossible de distinguer le \"carry\" du \"porte\"\n",
+    "3. **Problème de l'attribution** : Impossible de distinguer le \"carry\" du \"porte\"\n",
     "\n",
-    "> **Limitation** : TrueSkill basique attribue egalement le credit/blame. Des extensions comme TrueSkill 2 (2018) utilisent des statistiques individuelles (kills, assists) pour une attribution plus fine."
+    "> **Limitation** : TrueSkill basique attribue également le credit/blame. Des extensions comme TrueSkill 2 (2018) utilisent des statistiques individuelles (kills, assists) pour une attribution plus fine."
    ]
   },
   {
@@ -2918,11 +2909,11 @@
     "tags": []
    },
    "source": [
-    "### Lecture du graphe de facteurs - Match par equipes 2v2\n",
+    "### Lecture du graphe de facteurs - Match par équipes 2v2\n",
     "\n",
-    "Le graphe 2v2 illustre l'extension du modele TrueSkill aux equipes :\n",
+    "Le graphe 2v2 illustre l'extension du modèle TrueSkill aux équipes :\n",
     "\n",
-    "**Structure hierarchique** :\n",
+    "**Structure hiérarchique** :\n",
     "\n",
     "```\n",
     "          skillA2   skillB2          skillC   skillD\n",
@@ -2940,16 +2931,16 @@
     "```\n",
     "\n",
     "**Facteurs d'agregation** :\n",
-    "- `Plus` (ou `+`) : Combine les performances individuelles en performance d'equipe\n",
-    "- `IsGreaterThan` : Compare les performances d'equipe\n",
+    "- `Plus` (ou `+`) : Combine les performances individuelles en performance d'équipe\n",
+    "- `IsGreaterThan` : Compare les performances d'équipe\n",
     "\n",
     "**Propagation de credit** :\n",
-    "L'information \"equipe 1 gagne\" se propage :\n",
+    "L'information \"équipe 1 gagne\" se propage :\n",
     "1. Vers `perfEquipe1` (augmente) et `perfEquipe2` (diminue)\n",
     "2. Via les facteurs `Plus`, vers chaque performance individuelle\n",
     "3. Puis vers chaque skill individuel\n",
     "\n",
-    "> **Dilution du signal** : Avec 4 joueurs au lieu de 2, l'information est diluee. Chaque joueur recoit environ la moitie du changement de skill qu'il aurait eu en 1v1. C'est le \"probleme d'attribution de credit\" inherent aux jeux d'equipe."
+    "> **Dilution du signal** : Avec 4 joueurs au lieu de 2, l'information est diluee. Chaque joueur recoit environ la moitie du changement de skill qu'il aurait eu en 1v1. C'est le \"problème d'attribution de credit\" inherent aux jeux d'équipe."
    ]
   },
   {
@@ -2968,9 +2959,9 @@
    "source": [
     "## 7. Multi-joueurs (Free-for-all)\n",
     "\n",
-    "### Modele\n",
+    "### Modèle\n",
     "\n",
-    "Pour N joueurs, on decompose le resultat en N-1 comparaisons par paires :\n",
+    "Pour N joueurs, on decompose le résultat en N-1 comparaisons par paires :\n",
     "- 1er > 2e > 3e > ... > Ne"
    ]
   },
@@ -2996,7 +2987,7 @@
     "- ...\n",
     "- perf[N-2] > perf[N-1] (avant-dernier bat dernier)\n",
     "\n",
-    "Infer.NET resout ce systeme de contraintes simultanement grace a EP."
+    "Infer.NET resout ce système de contraintes simultanement grace a EP."
    ]
   },
   {
@@ -3499,7 +3490,7 @@
    "source": [
     "### Analyse du mode multi-joueurs\n",
     "\n",
-    "**Resultats de la course** :\n",
+    "**Résultats de la course** :\n",
     "\n",
     "| Position | Joueur | Skill mu | Sigma | Delta mu |\n",
     "|----------|--------|----------|-------|----------|\n",
@@ -3515,7 +3506,7 @@
     "- Les positions intermediaires ont des changements moderes\n",
     "- Sigma est plus eleve aux extremes (moins d'info directe)\n",
     "\n",
-    "> **Application** : Ce modele est utilise pour les jeux Battle Royale (Fortnite, PUBG) ou les courses (Mario Kart). Le placement complet apporte plus d'information qu'une simple victoire/defaite."
+    "> **Application** : Ce modèle est utilise pour les jeux Battle Royale (Fortnite, PUBG) ou les courses (Mario Kart). Le placement complet apporte plus d'information qu'une simple victoire/defaite."
    ]
   },
   {
@@ -4184,7 +4175,7 @@
    "source": [
     "### Lecture du graphe de facteurs - Multi-joueurs (Free-for-all)\n",
     "\n",
-    "Le graphe multi-joueurs montre une structure en chaine de contraintes :\n",
+    "Le graphe multi-joueurs montre une structure en chaîne de contraintes :\n",
     "\n",
     "**Topologie du graphe** :\n",
     "\n",
@@ -4192,7 +4183,7 @@
     "skill_P1 -> perf_P1 -\\\n",
     "                      >-- (P1 > P2)\n",
     "skill_P2 -> perf_P2 -/                \\\n",
-    "                      \\                >-- P2 joue 2 roles\n",
+    "                      \\                >-- P2 joue 2 rôles\n",
     "skill_P2 -> perf_P2 ---\\              /\n",
     "                        >-- (P2 > P3)\n",
     "skill_P3 -> perf_P3 ---/\n",
@@ -4201,19 +4192,19 @@
     "skill_P4 -> perf_P4 ----/\n",
     "```\n",
     "\n",
-    "**Caracteristiques cles** :\n",
+    "**Caractéristiques cles** :\n",
     "\n",
-    "1. **Chaine de comparaisons** : N-1 facteurs `IsGreaterThan` pour N joueurs\n",
+    "1. **Chaîne de comparaisons** : N-1 facteurs `IsGreaterThan` pour N joueurs\n",
     "2. **Joueurs intermediaires** : P2 et P3 participent a deux comparaisons chacun\n",
     "3. **Correlation induite** : Les contraintes couplent les variables entre elles\n",
     "\n",
     "**Propagation EP iterative** :\n",
-    "Le graphe montre pourquoi EP necessite des iterations :\n",
+    "Le graphe montre pourquoi EP necessite des itérations :\n",
     "- L'info de P1>P2 affecte P2\n",
     "- L'info de P2>P3 affecte aussi P2\n",
     "- Ces deux sources d'info doivent etre reconciliees\n",
     "\n",
-    "> **Complexite computationnelle** : Contrairement au cas 1v1 (solution analytique), le cas multi-joueurs necessite des iterations EP. C'est pourquoi on observe \"Iterating: ...\" dans la sortie. La complexite est O(N^2) par iteration pour N joueurs."
+    "> **Complexite computationnelle** : Contrairement au cas 1v1 (solution analytique), le cas multi-joueurs necessite des itérations EP. C'est pourquoi on observe \"Iterating: ...\" dans la sortie. La complexite est O(N^2) par itération pour N joueurs."
    ]
   },
   {
@@ -4249,9 +4240,9 @@
    "source": [
     "### Application aux echecs\n",
     "\n",
-    "Nous appliquons TrueSkill aux echecs avec des parametres adaptes a l'echelle Elo :\n",
+    "Nous appliquons TrueSkill aux echecs avec des paramètres adaptes a l'echelle Elo :\n",
     "\n",
-    "| Parametre | Valeur TrueSkill standard | Valeur echecs |\n",
+    "| Paramètre | Valeur TrueSkill standard | Valeur echecs |\n",
     "|-----------|---------------------------|---------------|\n",
     "| mu_initial | 25 | 1500 |\n",
     "| sigma_initial | 8.33 | 350 |\n",
@@ -4591,7 +4582,7 @@
    "source": [
     "### Analyse du classement echecs\n",
     "\n",
-    "**Resultats** :\n",
+    "**Résultats** :\n",
     "\n",
     "| Joueur | Victoires | Defaites | Mu | Sigma | Rating |\n",
     "|--------|-----------|----------|-----|-------|--------|\n",
@@ -4634,13 +4625,13 @@
     "\n",
     "### Enonce\n",
     "\n",
-    "Creez un tournoi avec 6 joueurs et simulez 15 matchs aleatoires.\n",
-    "Comparez le classement final aux \"vrais skills\" que vous aurez definis.\n",
+    "Créez un tournoi avec 6 joueurs et simulez 15 matchs aleatoires.\n",
+    "Comparez le classement final aux \"vrais skills\" que vous aurez définis.\n",
     "\n",
     "**Indice**\n",
     "\n",
     "- Definissez des skills \"vrais\" pour chaque joueur\n",
-    "- Simulez le resultat de chaque match en fonction des skills\n",
+    "- Simulez le résultat de chaque match en fonction des skills\n",
     "- Utilisez TrueSkillOnline pour mettre a jour les estimations"
    ]
   },
@@ -4663,11 +4654,11 @@
     "Cet exercice illustre un cas fondamental en statistique bayesienne : nous connaissons les vrais skills (simulation) et pouvons evaluer la qualite des estimations.\n",
     "\n",
     "**Protocole experimental** :\n",
-    "1. Definir les vrais skills de 6 joueurs (inconnus du modele)\n",
+    "1. Définir les vrais skills de 6 joueurs (inconnus du modèle)\n",
     "2. Simuler 15 matchs ou le meilleur joueur gagne plus souvent\n",
     "3. Comparer les estimations TrueSkill aux vrais skills\n",
     "\n",
-    "Notez que le joueur ne gagne pas toujours meme s'il est meilleur : on ajoute du bruit (+/- 5 points) pour simuler la variance de performance."
+    "Notez que le joueur ne gagne pas toujours même s'il est meilleur : on ajoute du bruit (+/- 5 points) pour simuler la variance de performance."
    ]
   },
   {
@@ -5238,10 +5229,10 @@
     "\n",
     "| Concept | Description |\n",
     "|---------|-------------|\n",
-    "| **TrueSkill** | Systeme de classement bayesien |\n",
+    "| **TrueSkill** | Système de classement bayesien |\n",
     "| **Skill** | Gaussienne N(mu, sigma^2) |\n",
     "| **Performance** | Skill + bruit gaussien |\n",
-    "| **Match nul** | Difference de perf dans [-epsilon, epsilon] |\n",
+    "| **Match nul** | Différence de perf dans [-epsilon, epsilon] |\n",
     "| **Online learning** | Posterieurs -> Priors |\n",
     "| **Rating conservatif** | mu - 3*sigma |\n",
     "\n",
@@ -5249,13 +5240,13 @@
     "\n",
     "- Quantification explicite de l'incertitude via sigma\n",
     "- Convergence rapide pour les nouveaux joueurs (sigma eleve = grands changements)\n",
-    "- Gestion native des equipes et multi-joueurs\n",
+    "- Gestion native des équipes et multi-joueurs\n",
     "- Apprentissage en ligne efficace (O(1) par match)\n",
     "\n",
     "### Limitations\n",
     "\n",
     "- Suppose une skill stable dans le temps (pas d'apprentissage du joueur)\n",
-    "- Attribution uniforme dans les equipes\n",
+    "- Attribution uniforme dans les équipes\n",
     "- Sensible au choix des hyperparametres (beta, epsilon)\n",
     "\n",
     "### Extensions modernes\n",
@@ -5268,7 +5259,7 @@
     "\n",
     "---\n",
     "\n",
-    "## Prochaine etape\n",
+    "## Prochaine étape\n",
     "\n",
     "Dans [Infer-9-Classification](Infer-9-Classification.ipynb), nous explorerons :\n",
     "\n",
@@ -5291,22 +5282,22 @@
     "tags": []
    },
    "source": [
-    "## 11. Exercice : Ligue de Football : 4 Equipes\n",
+    "## 11. Exercice : Ligue de Football : 4 Équipes\n",
     "\n",
     "### Enonce\n",
     "\n",
-    "Modelisez une ligue de football a **4 equipes** avec TrueSkill. Resultats des matchs :\n",
+    "Modelisez une ligue de football a **4 équipes** avec TrueSkill. Résultats des matchs :\n",
     "\n",
     "- PSG bat Marseille (3-0)\n",
     "- Lyon bat Bordeaux (2-1)\n",
     "- Lyon bat PSG (2-1)\n",
     "- Lyon bat Marseille (1-0)\n",
     "\n",
-    "1. Definissez une variable de skill gaussienne pour chaque equipe (a priori : Gaussian(100, 1/33))\n",
-    "2. Encodez chaque resultat par le modele TrueSkill (performance = Gaussian(skill, 1/beta^2))\n",
-    "3. Inferez les skills posterieurs et etablissez le classement des equipes\n",
+    "1. Definissez une variable de skill gaussienne pour chaque équipe (a priori : Gaussian(100, 1/33))\n",
+    "2. Encodez chaque résultat par le modèle TrueSkill (performance = Gaussian(skill, 1/beta^2))\n",
+    "3. Inferez les skills posterieurs et etablissez le classement des équipes\n",
     "\n",
-    "**Indice** : Reutilisez la structure du modele TrueSkill de la section 3."
+    "**Indice** : Reutilisez la structure du modèle TrueSkill de la section 3."
    ]
   },
   {
@@ -5383,22 +5374,22 @@
     "\n",
     "### Enonce\n",
     "\n",
-    "Vous disposez des **skills estimes** de 4 joueurs apres un tournoi. Votre objectif est de **predire le resultat** d'un match entre deux joueurs donnes, en retournant la **probabilite** que le joueur A gagne.\n",
+    "Vous disposez des **skills estimes** de 4 joueurs après un tournoi. Votre objectif est de **predire le résultat** d'un match entre deux joueurs donnes, en retournant la **probabilite** que le joueur A gagne.\n",
     "\n",
-    "**Donnees** : Skills posterieurs apres 10 matchs :\n",
+    "**Données** : Skills posterieurs après 10 matchs :\n",
     "- Alice : N(30, 5^2)\n",
     "- Bob : N(25, 4^2)\n",
     "- Charlie : N(22, 6^2)\n",
     "- Dave : N(20, 3^2)\n",
     "\n",
-    "**Taches** :\n",
-    "1. Implementez un modele qui predit la probabilite de victoire de Alice contre chaque autre joueur\n",
+    "**Tâches** :\n",
+    "1. Implementez un modèle qui predit la probabilite de victoire de Alice contre chaque autre joueur\n",
     "2. Quel match est le plus incertain (probabilite la plus proche de 0.5) ?\n",
     "3. Comment la probabilite change-t-elle si on double beta (variance de performance) ?\n",
     "\n",
     "**Indice**\n",
     "\n",
-    "La probabilite que perf1 > perf2 se calcule en utilisant `Variable.IsPositive` sur la difference des performances. Observez la variable booleenne resultante avec `moteur.Infer<Bernoulli>(...)`."
+    "La probabilite que perf1 > perf2 se calcule en utilisant `Variable.IsPositive` sur la différence des performances. Observez la variable booleenne resultante avec `moteur.Infer<Bernoulli>(...)`."
    ]
   },
   {
@@ -5472,9 +5463,9 @@
     "\n",
     "### Enonce\n",
     "\n",
-    "L'apprentissage en ligne (section 5) met a jour les skills apres chaque match en utilisant les posterieurs comme nouveaux priors. Votre objectif est de **tracer l'evolution** des estimations de skill au fil d'une serie de 8 matchs entre 3 joueurs, afin de visualiser comment le systeme converge.\n",
+    "L'apprentissage en ligne (section 5) met a jour les skills après chaque match en utilisant les posterieurs comme nouveaux priors. Votre objectif est de **tracer l'evolution** des estimations de skill au fil d'une serie de 8 matchs entre 3 joueurs, afin de visualiser comment le système converge.\n",
     "\n",
-    "**Joueurs et vrais skills** (inconnus du modele) :\n",
+    "**Joueurs et vrais skills** (inconnus du modèle) :\n",
     "- Zoe : skill = 30 (forte)\n",
     "- Leo : skill = 25 (moyen)\n",
     "- Max : skill = 20 (faible)\n",
@@ -5489,16 +5480,16 @@
     "7. Zoe bat Max\n",
     "8. Leo bat Max\n",
     "\n",
-    "**Taches** :\n",
-    "1. Utilisez la classe `TrueSkillOnline` definie en section 5 pour enregistrer les 8 matchs\n",
-    "2. Apres chaque match, enregistrez le mu et le sigma de chaque joueur dans des listes\n",
+    "**Tâches** :\n",
+    "1. Utilisez la classe `TrueSkillOnline` définie en section 5 pour enregistrer les 8 matchs\n",
+    "2. Après chaque match, enregistrez le mu et le sigma de chaque joueur dans des listes\n",
     "3. Affichez un tableau de l'evolution : pour chaque match, montrez le mu de chaque joueur\n",
-    "4. *(Bonus)* : Apres le match 5 (upset Leo bat Zoe), comment evolue le sigma de Zoe par rapport a l'avant-match 5 ? L'upset augmente-t-il l'incertitude ?\n",
+    "4. *(Bonus)* : Après le match 5 (upset Leo bat Zoe), comment evolue le sigma de Zoe par rapport a l'avant-match 5 ? L'upset augmente-t-il l'incertitude ?\n",
     "\n",
     "### Indices\n",
     "\n",
-    "- Initialisez `TrueSkillOnline` avec les parametres par defaut\n",
-    "- Apres chaque `EnregistrerMatch()`, appelez `GetSkill()` pour chaque joueur et stockez `GetMean()` et `Math.Sqrt(GetVariance())`\n",
+    "- Initialisez `TrueSkillOnline` avec les paramètres par defaut\n",
+    "- Après chaque `EnregistrerMatch()`, appelez `GetSkill()` pour chaque joueur et stockez `GetMean()` et `Math.Sqrt(GetVariance())`\n",
     "- Observez comment sigma diminue au fil des matchs (convergence) et comment un upset peut modifier la tendance"
    ]
   },
@@ -5607,7 +5598,7 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "Ce notebook a presente le systeme TrueSkill : classement bayesien par matchs 1v1, matchs nuls, apprentissage en ligne et extensions multi-joueurs/equipes.\n",
+    "Ce notebook a presente le système TrueSkill : classement bayesien par matchs 1v1, matchs nuls, apprentissage en ligne et extensions multi-joueurs/équipes.\n",
     "\n",
     "| Concept | Point cle |\n",
     "|---------|-----------|\n",
@@ -5617,7 +5608,7 @@
     "| Match nul | ConstrainBetween(-eps, +eps) : reduit sigma sans changer mu |\n",
     "| Rating conservatif | mu - 3*sigma : borne inferieure a 99.7% de confiance |\n",
     "\n",
-    "| Distribution | Role |\n",
+    "| Distribution | Rôle |\n",
     "|--------------|------|\n",
     "| Gaussian | Skills et performances des joueurs |\n",
     "| ExpectationPropagation | Algorithme pour les facteurs de comparaison non-conjugues |\n",


### PR DESCRIPTION
## Summary
Restores French accents in **Infer-8-TrueSkill** markdown cells (Probas/Infer family, .NET C#). Part of EPIC #2876, **markdown-only-strict** adjudication (ai-01, 2026-07-17).

## Scope (markdown-only-strict)
- **34 markdown cells cured, 128 accent restorations. Code cells: 0 changed** (comments/stdout/identifiers untouched).

## Verification (firsthand, byte-safe)
| Check | Result |
|-------|--------|
| Markdown cells changed | 34 |
| Code-source cells changed | **0** |
| Outputs / execution_count changed | 0 / 0 |
| Structure + metadata preserved | Yes (59 cells) |
| Identifier-regression guard (#7157) | **OK, exit 0** (C#-aware) |
| nbformat / H.3 unexecuted | 4 / 0 |

Note: split out of composite #7182 (closed — my mistake pushing 2 notebooks to one branch). Single-subject now. See #2876.

Co-Authored-By: Claude <noreply@anthropic.com>
