### PR TITLE
feat(tools,#2876): check_caps_regression.py — markdown caps-regression detector (resolves po-2023/po-2024 conflict)

### DIFF
--- a/scripts/notebook_tools/check_caps_regression.py
+++ b/scripts/notebook_tools/check_caps_regression.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Detecte les caps-regressions des cures d'accents markdown (registre #2876).
+
+Pourquoi cet outil existe
+-------------------------
+Le registre #2876 (restauration des accents francais, markdown-only STRICT) a
+produit un nouveau defect-class en juillet 2026 : des scripts de cure ad-hoc
+accentuent correctement le mot MAIS en minusculent l'INITIALE capitalisee.
+
+  - `Systeme de Classement` -> `système de Classement` (titre H1 : devait etre `Système`)
+  - `| **Equipes** |`          -> `| **équipes** |`        (header table : devait être `**Équipes**`)
+  - `Apres chaque match`      -> `après chaque match`     (debut phrase : devait être `Après`)
+
+La cure canonique `restore_accents_canonical.py` (#7186) preserve la casse PAR
+CONSTRUCTION (`_preserve_case`), mais les scripts ad-hoc anterieurs non. Le
+guard `check_identifier_regression.py` (#7157) detecte les regressions
+d'IDENTIFIANTS (code) mais PAS les caps-regressions markdown — ce tool comble
+ce gap. Incident fondateur : 3 cycles po-2023/po-2024 ont discrepe firsthand
+sur ~10 PRs (alerte -> auto-confirm -> retraction -> retraction elle-meme
+fausse) faute d'un detecteur objectif.
+
+Comment ca marche
+-----------------
+Pour chaque cellule MARKDOWN, on aligne ligne-par-ligne la base (defaut
+origin/main) et la HEAD (working tree ou origin/<branch>). Pour chaque mot
+aligne qui differe entre base et head :
+
+  1. on verifie que c'est bien une CURE (deaccent(head).lower() == base.lower()
+     ET base != head) — sinon on ignore (modification non-accent) ;
+  2. on compare la casse de l'initiale : si base[0] est MAJUSCULE et head[0] ne
+     l'est pas -> **CAPS-REGRESSION** (la cure a perte la capitale) ;
+  3. idem pour le ALL-CAPS : si base est tout-majuscule (len>1) et head ne
+     l'est pas -> **CAPS-REGRESSION**.
+
+L'alignement ligne-par-ligne (methode po-2025 c.615, ratifiee sur #7191 = 36
+vraies regressions byte-verified) evite le faux-positif massif du scan
+non-positionnel : un meme mot FR apparait souvent EN majuscule (titre/header)
+ET en minuscule (mi-phrase) dans deux lignes differentes ; curer legitimement
+l'occurrence minuscule ne doit PAS etre flaggue. On compare la MEME ligne.
+
+L'outil lit seulement (local git : git show). Il ne touche rien.
+
+Usage
+-----
+    # un notebook : working tree vs origin/main
+    python check_caps_regression.py NB.ipynb
+    python check_caps_regression.py NB.ipynb --base origin/main --head origin/fix/ma-branche
+    # exit 1 si caps-regression detectee (CI-ready)
+    python check_caps_regression.py NB.ipynb --check
+    # sortie machine
+    python check_caps_regression.py NB.ipynb --json
+
+Exit codes
+----------
+    0 -- aucune caps-regression detectee (ou mode non --check)
+    1 -- un ou plusieurs mots a initiale minusculee (--check seulement)
+    2 -- erreur (notebook illisible, ref git introuvable)
+
+Voir aussi
+----------
+- check_identifier_regression.py (registre #2876, regressions d'IDENTIFIANTS code)
+- restore_accents_canonical.py (#7186, cure canonique caps-preserving)
+- detect_accent_stripping.py (#2876, moitie DETECTION des accents perdus)
+- Memoires : issue-2876-scope-boundary-markdown-vs-code-pending-adjudication
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import unicodedata
+from pathlib import Path
+
+# Run de mot : lettres (y compris accentuees). On exclut chiffres et underscore
+# pour matcher le vocabulaire francais accentuable (pas les identifiants code,
+# meme si on est en markdown — on cible la prose).
+_WORD_RE = re.compile(r"[A-Za-zÀ-ÖØ-öø-ÿ]+")
+
+# Caracteres accentues : un mot head qui en contient au moins un est candidat
+# cure. Evite de traiter les mots purement ASCII inchanges comme des cures.
+_ACCENT_CHARS = set("àâäéèêëïîôöùûüçÀÂÄÉÈÊËÏÎÔÖÙÛÜÇœŒæÆ")
+
+
+def _deaccent(s: str) -> str:
+    return "".join(
+        c for c in unicodedata.normalize("NFD", s) if unicodedata.category(c) != "Mn"
+    )
+
+
+def _has_accent(s: str) -> bool:
+    return any(ch in _ACCENT_CHARS for ch in s)
+
+
+def _src_str(cell: dict) -> str:
+    s = cell.get("source", "")
+    return "".join(s) if isinstance(s, list) else (s or "")
+
+
+def _git_show_notebook(ref: str, path: str):
+    """Lit un notebook a une ref git (None si introuvable)."""
+    r = subprocess.run(["git", "show", f"{ref}:{path}"], capture_output=True)
+    if r.returncode != 0:
+        return None
+    try:
+        return json.loads(r.stdout.decode("utf-8"))
+    except Exception:
+        return None
+
+
+def _md_lines(nb: dict):
+    """Retourne [(cell_index, line_index, line)] pour les cellules markdown uniquement."""
+    out = []
+    for ci, cell in enumerate(nb.get("cells", [])):
+        if cell.get("cell_type") != "markdown":
+            continue
+        for li, line in enumerate(_src_str(cell).split("\n")):
+            out.append((ci, li, line))
+    return out
+
+
+def scan(old_nb: dict, new_nb: dict):
+    """Compare les cellules markdown old vs new, ligne-par-ligne.
+
+    Retourne (regressions, summary) ou :
+      regressions : [(cell_index, line_index, base_word, head_word, context)]
+      summary     : dict {cures, struct_changed_lines, caps_regressions}
+
+    Une caps-regression = cure (base non-accentue -> head accentue meme mot)
+    dont l'initiale est PASSEE de majuscule a minuscule (ou all-caps -> mixed).
+    """
+    old_map = {(ci, li): line for ci, li, line in _md_lines(old_nb)}
+    new_lines = _md_lines(new_nb)
+
+    regressions = []
+    cures = 0
+    struct_changed = 0
+
+    for ci, li, nline in new_lines:
+        oline = old_map.get((ci, li))
+        if oline is None or oline == nline:
+            continue  # ligne ajoute ou inchangee
+        bwords = _WORD_RE.findall(oline)
+        hwords = _WORD_RE.findall(nline)
+        if len(bwords) != len(hwords):
+            # Le nombre de mots differe = modification structurelle (pas une cure
+            # 1:1). On ne peut pas aligner mot-a-mot sans risque de FP ; on
+            # compte la ligne comme struct-changed et on ne la scanne PAS (un
+            # notebook cure-only n'a JAMAIS de struct-changed — cf test).
+            struct_changed += 1
+            continue
+        for bword, hword in zip(bwords, hwords):
+            if bword == hword:
+                continue
+            # cure candidate : deaccent(head) lower == base lower ?
+            if _deaccent(hword).lower() != bword.lower():
+                continue
+            if not _has_accent(hword):
+                continue  # head n'a pas d'accent -> pas une cure
+            cures += 1
+            # caps check
+            bcap = bool(bword) and bword[0].isupper()
+            hcap = bool(hword) and hword[0].isupper()
+            if bcap and not hcap:
+                regressions.append((ci, li, bword, hword, oline.strip()[:90]))
+            elif len(bword) > 1 and bword.isupper() and not hword.isupper():
+                regressions.append((ci, li, bword, hword, oline.strip()[:90]))
+
+    summary = {
+        "cures": cures,
+        "struct_changed_lines": struct_changed,
+        "caps_regressions": len(regressions),
+    }
+    return regressions, summary
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(
+        description="Detecte les caps-regressions des cures d'accents markdown (#2876)."
+    )
+    p.add_argument("notebook", help="Chemin du notebook (.ipynb)")
+    p.add_argument("--base", default="origin/main",
+                   help="Ref git de la base (defaut origin/main)")
+    p.add_argument("--head", default=None,
+                   help="Ref git de la head (defaut: working tree lu depuis le disque)")
+    p.add_argument("--check", action="store_true",
+                   help="Exit 1 si une caps-regression est detectee (CI-ready, n'ecrit rien)")
+    p.add_argument("--json", action="store_true", help="Sortie machine JSON")
+    args = p.parse_args(argv)
+
+    nb_path = Path(args.notebook)
+    if not nb_path.exists() and args.head is None:
+        print(f"error: notebook introuvable: {args.notebook}", file=sys.stderr)
+        return 2
+
+    # path relatif au repo pour git show
+    git_path = args.notebook.replace("\\", "/")
+    if nb_path.exists():
+        git_path = str(nb_path.resolve().relative_to(Path.cwd().resolve())).replace("\\", "/") \
+            if nb_path.resolve().parent != Path.cwd().resolve() else nb_path.name
+
+    old_nb = _git_show_notebook(args.base, git_path)
+    if old_nb is None:
+        # fallback : lire git_path tel quel (cas ou l'utilisateur a donne un path repo-root)
+        old_nb = _git_show_notebook(args.base, args.notebook.replace("\\", "/"))
+    if old_nb is None:
+        print(f"error: notebook introuvable a la base {args.base}:{git_path}", file=sys.stderr)
+        return 2
+
+    if args.head is None:
+        if not nb_path.exists():
+            print(f"error: notebook introuvable: {args.notebook}", file=sys.stderr)
+            return 2
+        with open(nb_path, encoding="utf-8") as f:
+            new_nb = json.load(f)
+    else:
+        new_nb = _git_show_notebook(args.head, git_path)
+        if new_nb is None:
+            new_nb = _git_show_notebook(args.head, args.notebook.replace("\\", "/"))
+        if new_nb is None:
+            print(f"error: notebook introuvable a la head {args.head}:{git_path}", file=sys.stderr)
+            return 2
+
+    regressions, summary = scan(old_nb, new_nb)
+
+    if args.json:
+        out = {
+            "notebook": str(nb_path) if nb_path.exists() else args.notebook,
+            "base": args.base,
+            "head": args.head or "working-tree",
+            "caps_regressions": [
+                {
+                    "cell": ci, "line": li,
+                    "base_word": bw, "head_word": hw, "context": ctx,
+                }
+                for ci, li, bw, hw, ctx in regressions
+            ],
+            "summary": summary,
+        }
+        json.dump(out, sys.stdout, ensure_ascii=False, indent=2)
+        sys.stdout.write("\n")
+    else:
+        if summary["caps_regressions"] == 0:
+            print(f"OK — aucune caps-regression ({summary['cures']} cures markdown "
+                  f"verifiees, {summary['struct_changed_lines']} ligne(s) struct-modifiee(s), "
+                  f"{args.notebook})")
+        else:
+            print(f"FOUND {summary['caps_regressions']} caps-regression(s) markdown "
+                  f"sur {summary['cures']} cures ({args.notebook}):\n")
+            for ci, li, bw, hw, ctx in regressions:
+                print(f"  cell {ci} L{li}: {bw!r} -> {hw!r}")
+                print(f"    | {ctx}")
+            if summary["struct_changed_lines"]:
+                print(f"\n(note: {summary['struct_changed_lines']} ligne(s) avec nb de mots "
+                      f"modifie = non scannee(s) pour eviter FP d'alignement)")
+
+    if args.check and summary["caps_regressions"] > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/notebook_tools/tests/test_check_caps_regression.py
+++ b/scripts/notebook_tools/tests/test_check_caps_regression.py
@@ -1,0 +1,180 @@
+"""Tests for scripts/notebook_tools/check_caps_regression.py — registre #2876.
+
+Verifie la detection des caps-regressions markdown (cure qui minuscule l'initiale
+d'un mot capitalise). Defense-by-construction : le detecteur line-aligned evite
+les FP du scan non-positionnel (po-2023 c.610/c.611). Valide sur le fleet reel
+(#7191=36, #7187=0/213).
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import check_caps_regression as ccr  # noqa: E402
+
+
+def _nb(cells):
+    """Notebook synthetique : cells = liste de (cell_type, source_str)."""
+    return {"cells": [{"cell_type": t, "source": s, "metadata": {}} for (t, s) in cells],
+            "metadata": {}, "nbformat": 4, "nbformat_minor": 5}
+
+
+def _md(src):
+    return ("markdown", src)
+
+
+# ---------------------------------------------------------------------------
+# 1. detection des vraies caps-regressions
+# ---------------------------------------------------------------------------
+class TestCapsRegressionDetection:
+    def test_title_capital_lowercased(self):
+        # H1 title : Systeme -> systeme (base cap, head lower) = REGRESSION
+        old = _nb([_md("# Infer : Systeme de Classement\n")])
+        new = _nb([_md("# Infer : système de Classement\n")])
+        regs, summ = ccr.scan(old, new)
+        assert summ["caps_regressions"] == 1
+        assert regs[0][2] == "Systeme"   # base_word
+        assert regs[0][3] == "système"   # head_word
+
+    def test_table_header_bold_lowercased(self):
+        old = _nb([_md("| **Equipes** | Moyenne |\n")])
+        new = _nb([_md("| **équipes** | Moyenne |\n")])
+        regs, summ = ccr.scan(old, new)
+        assert summ["caps_regressions"] == 1
+        assert regs[0][2] == "Equipes"
+
+    def test_sentence_start_lowercased(self):
+        old = _nb([_md("Apres chaque match, on continue.\n")])
+        new = _nb([_md("après chaque match, on continue.\n")])
+        regs, summ = ccr.scan(old, new)
+        assert summ["caps_regressions"] == 1
+
+    def test_all_caps_lowercased(self):
+        # MODELE -> modele (all-caps -> mixed) = REGRESSION
+        old = _nb([_md("Les PARAMETRES sont la.\n")])
+        new = _nb([_md("Les parametres sont la.\n")])  # pas d'accent -> pas une cure
+        regs, summ = ccr.scan(old, new)
+        # head n'a pas d'accent -> ignore (pas une cure). On teste avec accent :
+        new2 = _nb([_md("Les paramètres sont la.\n")])
+        regs2, summ2 = ccr.scan(old, new2)
+        assert summ2["caps_regressions"] == 1
+        assert regs2[0][2] == "PARAMETRES"
+
+    def test_multiple_regressions_in_line(self):
+        old = _nb([_md("Le Modele et le Systeme\n")])
+        new = _nb([_md("Le modèle et le système\n")])
+        regs, summ = ccr.scan(old, new)
+        assert summ["caps_regressions"] == 2
+
+
+# ---------------------------------------------------------------------------
+# 2. vrais negatifs : cures legitimes NON flagguees
+# ---------------------------------------------------------------------------
+class TestTrueNegatives:
+    def test_lowercase_cure_mid_sentence_not_flagged(self):
+        # base minuscule mi-phrase -> head minuscule accentue = cure legitime
+        old = _nb([_md("Le systeme encode les donnees.\n")])
+        new = _nb([_md("Le système encode les donnees.\n")])
+        regs, summ = ccr.scan(old, new)
+        assert summ["caps_regressions"] == 0
+        assert summ["cures"] >= 1
+
+    def test_capital_preserved_correctly_not_flagged(self):
+        # Systeme -> Systeme (cap preservee) = cure PARFAITE, pas de regression
+        old = _nb([_md("# Titre : Systeme de calcul\n")])
+        new = _nb([_md("# Titre : Système de calcul\n")])
+        regs, summ = ccr.scan(old, new)
+        assert summ["caps_regressions"] == 0
+        assert summ["cures"] == 1
+
+    def test_all_caps_preserved_not_flagged(self):
+        old = _nb([_md("Les PARAMETRES generaux.\n")])
+        new = _nb([_md("Les PARAMÈTRES generaux.\n")])
+        regs, summ = ccr.scan(old, new)
+        assert summ["caps_regressions"] == 0
+        assert summ["cures"] == 1
+
+    def test_same_word_cap_elsewhere_not_false_positive(self):
+        # FP-class po-2023 c.610 : meme mot en cap dans une ligne (titre) ET en
+        # lower dans une autre (prose). Curer la lower (ligne 1) NE doit PAS etre
+        # flaggue meme si ligne 0 a la cap.
+        old = _nb([
+            _md("# Le Systeme\n"),                      # L0 : cap (titre, inchange)
+            _md("Le systeme encode les donnees.\n"),    # L1 : lower (prose, curee)
+        ])
+        new = _nb([
+            _md("# Le Systeme\n"),                      # L0 inchangé
+            _md("Le système encode les donnees.\n"),    # L1 cure lower->lower+accent
+        ])
+        regs, summ = ccr.scan(old, new)
+        assert summ["caps_regressions"] == 0   # la cure L1 est legitime (lower->lower)
+        assert summ["cures"] == 1
+
+    def test_non_cure_change_ignored(self):
+        # modification non-accent (mot different) : ignore, pas de regression
+        old = _nb([_md("Le chat dort.\n")])
+        new = _nb([_md("Le chien dort.\n")])
+        regs, summ = ccr.scan(old, new)
+        assert summ["caps_regressions"] == 0
+        assert summ["cures"] == 0
+
+    def test_code_cells_ignored(self):
+        # le detecteur est markdown-only : cellules code ignorees
+        old = _nb([("code", "# Systeme comment\n")])
+        new = _nb([("code", "# système comment\n")])
+        regs, summ = ccr.scan(old, new)
+        assert summ["caps_regressions"] == 0
+        assert summ["cures"] == 0
+
+
+# ---------------------------------------------------------------------------
+# 3. robustesse structurelle
+# ---------------------------------------------------------------------------
+class TestStructuralRobustness:
+    def test_struct_changed_line_skipped(self):
+        # ligne dont le NB de mots change = mod struct, skip (evite FP alignement)
+        old = _nb([_md("Le systeme\n")])
+        new = _nb([_md("Le système global\n")])  # 2 mots -> 3 mots
+        regs, summ = ccr.scan(old, new)
+        assert summ["caps_regressions"] == 0
+        assert summ["struct_changed_lines"] == 1
+
+    def test_added_line_ignored(self):
+        old = _nb([_md("Ligne une.\n")])
+        new = _nb([_md("Ligne une.\nAjout systeme.\n")])
+        regs, summ = ccr.scan(old, new)
+        assert summ["caps_regressions"] == 0
+
+    def test_list_source_handled(self):
+        # source en list nbformat (chunks). Cure legitime (lower->lower+accent).
+        old = _nb([("markdown", ["Le systeme\n", "est la.\n"])])
+        new = _nb([("markdown", ["Le système\n", "est la.\n"])])
+        regs, summ = ccr.scan(old, new)
+        assert summ["caps_regressions"] == 0
+        assert summ["cures"] == 1
+
+
+# ---------------------------------------------------------------------------
+# 4. exit codes main()
+# ---------------------------------------------------------------------------
+class TestMainExitCodes:
+    def test_check_exit_1_on_regression(self, tmp_path):
+        old = _nb([_md("# Systeme\n")])
+        # on ecrit le NEW notebook ; base via git n'est pas disponible ici, donc
+        # on test la logique de scan directement + le exit code via mock :
+        new = _nb([_md("# système\n")])
+        p = tmp_path / "nb.ipynb"
+        p.write_text(json.dumps(new), encoding="utf-8")
+        # main() tente git show pour la base -> sans repo, retourne 2. On teste
+        # donc la fonction scan (preuve du verdict) + on verifie que main rejette
+        # une base introuvable proprement.
+        regs, summ = ccr.scan(old, new)
+        assert summ["caps_regressions"] == 1
+
+    def test_apply_mutually_exclusive_with_check_absent(self):
+        # sanity : le CLI accepte --json + --check ensemble
+        rc = ccr.main(["__nonexistent__", "--json", "--check"])
+        # notebook inexistant sans head -> exit 2
+        assert rc == 2


### PR DESCRIPTION
## What

New tool `scripts/notebook_tools/check_caps_regression.py` — a companion detector to `check_identifier_regression.py` (#7157, identifier regressions in **code**) and `restore_accents_canonical.py` (#7186, the case-preserving **cure**). Fills the gap exposed by the po-2023/po-2024 caps-regression forensic conflict this cluster just lived through.

## Why (the defect class)

An accent cure that correctly accents the word but **WRONGLY lowercases the initial capital** (or all-caps). Positional contexts where the capital is mandatory:

| Context | base → head (defective) | correct |
|---|---|---|
| H1/H2/H3 title | `Systeme de Classement` → `système de Classement` | `Système` |
| table header | `\| **Equipes** \|` → `\| **équipes** \|` | `**Équipes**` |
| sentence start | `Apres chaque match` → `après chaque match` | `Après` |
| all-caps | `PARAMETRES` → `paramètres` | `PARAMÈTRES` |

#7157 catches identifier regressions in **code**; it does NOT see markdown case-preservation. The canonical cure #7186 has `_preserve_case` (correct by construction), but the ad-hoc scripts that produced the fleet of accent PRs do not — and there was no objective detector, so two workers spent 3 cycles in firsthand disagreement (po-2023 alert c.610 → po-2024 self-confirm c.633 → po-2023 retraction c.611 → **retraction itself wrong**). This tool resolves such a conflict in one run.

## Method (FP-avoidance)

Markdown-cells-only, **LINE-ALIGNED** by `(cell_index, line_index)`. For each word that differs between base (default `origin/main`) and head: verify it's a cure (`deaccent(head).lower() == base.lower()` AND head has an accent), then compare case — `base[0].isupper() and not head[0].isupper()` → caps-regression.

Line-alignment is the key FP-avoidance. The same FR word often appears **capitalized** (title/header) in one line and **lowercase** (mid-sentence) in another; curing the lowercase occurrence legitimately must NOT be flagged. Comparing the **same line position** (not a non-positional regex scan) eliminates the FP class that tripped po-2023 c.610.

## Validation — real fleet (firsthand, this PR)

| PR | cures | caps-regressions | rc | verdict |
|---|---|---|---|---|
| #7191 Infer-8 | 128 | **36** | 1 | defective (po-2024) |
| #7190 Infer-19 | 60 | **7** | 1 | defective (po-2024) |
| #7185 Infer-10 | 77 | **12** | 1 | defective (po-2024) |
| #7181 Infer-5 | 38 | **6** | 1 | defective (po-2024) |
| #7178 Search-3 | 20 | **5** | 1 | defective (po-2024) |
| #7187 SL-2 | 213 | **0** | 0 | clean (po-2023) ✓ |
| #7188 Infer-8 | 128 | **0** | 0 | clean (po-2023) ✓ |

The detector objectively confirms po-2024 c.633 (their 5 PRs defective) and po-2023's narrower claim (their own 2 PRs clean), and refutes po-2023's c.611 retraction (over-generalized to "all 10 clean"). Fleet verdict delivered to ai-01 (DM msg-20260718T052117-buwwsz).

## Tests

16 unit tests pass (`tests/test_check_caps_regression.py`): detection (title/header/sentence/all-caps/multiple), true-negatives (lowercase-mid-sentence cure, capital-preserved cure, the FP-class same-word-cap-elsewhere, non-cure change, code cells ignored), structural robustness (struct-changed line skipped, added line, list-source), exit codes. Existing #7157 38 tests unaffected.

## CLI

Mirrors #7157: `--base`/`--head`/`--check`/`--json`, exit 0 (clean) / 1 (regression, CI-ready) / 2 (error). Read-only (`git show`).

```
python check_caps_regression.py NB.ipynb --base origin/main --head origin/fix/branch --check
```

See #2876
