### PR TITLE
feat(tools,#2876): detect_caps_regression markdown gate (caps-loss defect class)

### DIFF
--- a/scripts/notebook_tools/detect_caps_regression.py
+++ b/scripts/notebook_tools/detect_caps_regression.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Detect capitalization regression in markdown accent cures (#2876, #3801).
+
+Companion GATE to ``detect_accent_stripping.py`` (the cure direction) and
+``check_identifier_regression.py`` (#7157, the identifier-over-reach gate).
+This tool catches a THIRD defect class those two do not cover: an accent-cure
+script that **lowercases the initial capital** of a token when restoring its
+accent.
+
+Defect signature (caught firsthand on PRs #7191 / #7185, tiebreaker c.484):
+
+    main  (heading) : "## 3. Modele Deux Joueurs"
+    branch (cured)  : "## 3. modele Deux Joueurs"      <- WRONG (should be "Modèle")
+
+    main  (nav)     : "| Precedent | Suivant |"
+    branch (cured)  : "| precedent | Suivant |"        <- WRONG (should be "Précédent")
+
+    main  (table)   : "| **Equipes** | Moyenne ..."
+    branch (cured)  : "| **equipes** | Moyenne ..."    <- WRONG (should be "Équipes")
+
+The cure script restored the accent but used the dictionary's lowercase form
+instead of preserving the source token's initial capital. Positions that MUST
+keep the capital (headings ``#``, nav links, table headers ``|``, list items
+``N. `` / ``- ``, bold ``**``) become visibly broken.
+
+Why ``check_identifier_regression.py`` (#7157) does not catch this : it scans
+CODE-cell identifiers (Python/C#), not markdown prose. The caps defect is a
+MARKDOWN-prose defect, so it sails past the identifier gate. This tool fills
+that gap by comparing base (main) vs head (branch) MARKDOWN cell sources.
+
+Contract
+--------
+Input : a BASE notebook (origin/main) and a HEAD notebook (the PR branch).
+For each markdown cell, line-align the sources and compare word-by-word at
+each position. A regression is a position where:
+
+  (1) the base word and head word differ,
+  (2) the head word carries an accent (``unicodedata`` category Mn after NFD),
+  (3) stripping the accent from the head word yields the base word
+      (case-insensitive) -- i.e. it IS an accent cure of that token, AND
+  (4) the base word started with an uppercase letter that the head word
+      lowercased.
+
+Structural lines (word-count mismatch between base and head -- the cure
+changed the number of tokens, not just substituted accents) are SKIPPED :
+accent cures are 1:1 substitutions, so a count mismatch means the line is not
+a pure cure and positional comparison would misalign. This keeps the detector
+free of the false-positive mode that tripped up earlier non-positional scans.
+
+Exit codes : 0 = clean, 1 = regression(s) found, 2 = error (unreadable base/head).
+
+Usage
+-----
+    # Compare two notebooks directly
+    python detect_caps_regression.py --base main_nb.ipynb --head branch_nb.ipynb
+    # JSON output for CI
+    python detect_caps_regression.py --base ... --head ... --json
+    # Quiet (exit code only)
+    python detect_caps_regression.py --base ... --head ... --quiet
+
+See #2876, #3801. Companion to detect_accent_stripping.py, check_identifier_regression.py (#7157),
+restore_accents_canonical.py (#7186).
+"""
+import argparse
+import json
+import re
+import sys
+import unicodedata
+from pathlib import Path
+
+# A word = run of letters incl. accented Latin. Used for positional alignment.
+_WORD_RE = re.compile(r"[A-Za-zÀ-ÖØ-öø-ÿ]+", re.UNICODE)
+
+
+def _strip_accents(token: str) -> str:
+    """Return the accent-stripped form of a token (NFD + drop combining marks).
+
+    ``"système"`` -> ``"systeme"``, ``"précédent"`` -> ``"precedent"``,
+    ``"Équipes"`` -> ``"Equipes"``. Robust and decoupled from any dictionary :
+    works on ANY accented token, not just the curated ``ACCENT_PAIRS`` set.
+    """
+    decomposed = unicodedata.normalize("NFD", token)
+    return "".join(ch for ch in decomposed if unicodedata.category(ch) != "Mn")
+
+
+def _has_accent(token: str) -> bool:
+    """True if the token loses at least one char under accent-stripping."""
+    return _strip_accents(token) != token
+
+
+def _words(line: str) -> list[tuple[str, int]]:
+    """Ordered (word, column) pairs in a line, used for positional alignment."""
+    return [(m.group(0), m.start()) for m in _WORD_RE.finditer(line)]
+
+
+def _classify_position(line: str, col: int, token: str) -> str:
+    """Best-effort label for WHERE the token sits (helps the human report).
+
+    Not used for the verdict -- the verdict is pure case-preservation. This
+    only annotates the hit so a reviewer sees "heading"/"nav"/"table"/"list".
+    """
+    prefix = line[:col].rstrip()
+    # Heading : line starts with markdown header markers.
+    if re.match(r"\s*#{1,6}\s", line):
+        return "heading"
+    # Table header / cell : token follows a pipe (possibly with bold/markup).
+    if prefix.endswith("|") or prefix.endswith("| **") or prefix.endswith("| *"):
+        return "table"
+    # Nav column (common pattern ``| Precedent | Suivant |``).
+    if "| precedent |" in line.lower() or "| suivant |" in line.lower():
+        return "nav"
+    # List item : line starts with ``N. `` or ``- `` / ``* ``.
+    if re.match(r"\s*(?:[0-9]+\.|[-*])\s", line):
+        return "list"
+    # Bold lead : token right after ``**``.
+    if prefix.endswith("**"):
+        return "bold"
+    # First non-space token of the line (sentence start).
+    if not prefix:
+        return "sentence-start"
+    return "prose"
+
+
+def _check_line(base_line: str, head_line: str):
+    """Yield (base_token, head_token, column, position) for each caps regression.
+
+    Positional and exact : base/head words are aligned by index within the line.
+    A line whose word count differs between base and head is SKIPPED (a pure
+    accent cure preserves the token count ; a mismatch means structural change,
+    not a cure, and positional comparison would misalign).
+    """
+    bw = _words(base_line)
+    hw = _words(head_line)
+    if len(bw) != len(hw):
+        return  # structural change -- not a pure cure line, skip
+    for (b_tok, b_col), (h_tok, _h_col) in zip(bw, hw):
+        if b_tok == h_tok:
+            continue
+        if not _has_accent(h_tok):
+            continue
+        # Is h_tok an accent cure of b_tok (same letters modulo case + accents)?
+        if _strip_accents(h_tok).lower() != b_tok.lower():
+            continue
+        # Case loss : base was initial-capital, head lowercased it.
+        if b_tok[:1].isupper() and h_tok[:1].islower():
+            pos = _classify_position(base_line, b_col, b_tok)
+            yield (b_tok, h_tok, b_col, pos)
+
+
+def _cell_source_lines(cell: dict) -> list[str]:
+    """Markdown source as a list of lines (handles str OR nbformat list form)."""
+    s = cell.get("source", [])
+    if isinstance(s, str):
+        return s.splitlines()
+    out = []
+    for chunk in s:
+        out.extend(chunk.splitlines())
+    return out
+
+
+def scan_pair(base_path: Path, head_path: Path) -> dict:
+    """Compare base vs head notebooks, return a result dict.
+
+    ``{"path": str, "regressions": [...], "error": str | None}`` where each
+    regression is ``{cell_index, line_no, base_token, head_token, column,
+    position, base_line}``.
+    """
+    try:
+        base_nb = json.loads(base_path.read_text(encoding="utf-8"))
+    except Exception as e:  # noqa: BLE001 -- report any read/parse failure as error
+        return {"path": str(head_path), "regressions": [], "error": f"base unreadable: {e}"}
+    try:
+        head_nb = json.loads(head_path.read_text(encoding="utf-8"))
+    except Exception as e:  # noqa: BLE001
+        return {"path": str(head_path), "regressions": [], "error": f"head unreadable: {e}"}
+
+    base_cells = base_nb.get("cells", [])
+    head_cells = head_nb.get("cells", [])
+    regressions = []
+    # Cell-by-cell : only markdown cells are in scope (code cells are the
+    # identifier gate's job, #7157). If the cell counts differ we still compare
+    # index-by-index up to the shorter list ; a count mismatch is itself a
+    # structural signal but not this detector's concern.
+    for ci, (bc, hc) in enumerate(zip(base_cells, head_cells)):
+        if bc.get("cell_type") != "markdown" or hc.get("cell_type") != "markdown":
+            continue
+        blines = _cell_source_lines(bc)
+        hlines = _cell_source_lines(hc)
+        for li, (bl, hl) in enumerate(zip(blines, hlines)):
+            if bl == hl:
+                continue
+            for b_tok, h_tok, col, pos in _check_line(bl, hl):
+                regressions.append({
+                    "cell_index": ci,
+                    "line_no": li,
+                    "column": col,
+                    "base_token": b_tok,
+                    "head_token": h_tok,
+                    "position": pos,
+                    "base_line": bl,
+                })
+    return {"path": str(head_path), "regressions": regressions, "error": None}
+
+
+def _human_report(result: dict) -> str:
+    """Plain-text report for terminal use."""
+    path = result["path"]
+    regs = result["regressions"]
+    if result["error"]:
+        return f"ERROR ({path}): {result['error']}"
+    if not regs:
+        return f"OK   ({path}): 0 caps-regression"
+    out = [f"HIT  ({path}): {len(regs)} caps-regression(s)"]
+    for r in regs[:20]:
+        out.append(
+            f"  cell {r['cell_index']} L{r['line_no']} [{r['position']}] "
+            f"{r['base_token']!r} -> {r['head_token']!r}"
+        )
+        out.append(f"      base: {r['base_line'][:90]!r}")
+    if len(regs) > 20:
+        out.append(f"  ... +{len(regs) - 20} more")
+    return "\n".join(out)
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Detect markdown caps-regression in accent cures (compare base vs head).")
+    parser.add_argument("--base", required=True, help="base notebook (origin/main)")
+    parser.add_argument("--head", required=True, help="head notebook (PR branch)")
+    parser.add_argument("--json", action="store_true", help="machine-readable JSON output")
+    parser.add_argument("--quiet", action="store_true", help="no stdout (exit code only)")
+    args = parser.parse_args(argv)
+
+    result = scan_pair(Path(args.base), Path(args.head))
+
+    if args.json:
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+    elif not args.quiet:
+        print(_human_report(result))
+
+    if result["error"]:
+        return 2
+    return 1 if result["regressions"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/notebook_tools/detect_caps_regression.py
+++ b/scripts/notebook_tools/detect_caps_regression.py
@@ -51,12 +51,19 @@ Exit codes : 0 = clean, 1 = regression(s) found, 2 = error (unreadable base/head
 
 Usage
 -----
-    # Compare two notebooks directly
+Two invocation modes :
+
+    # 1. Direct-file mode : two explicit notebook files
     python detect_caps_regression.py --base main_nb.ipynb --head branch_nb.ipynb
-    # JSON output for CI
-    python detect_caps_regression.py --base ... --head ... --json
-    # Quiet (exit code only)
-    python detect_caps_regression.py --base ... --head ... --quiet
+
+    # 2. Git-ref mode : point at one notebook, compare two git refs of it.
+    #    Head defaults to the working-tree notebook on disk (no need to extract).
+    python detect_caps_regression.py NB.ipynb --base origin/main --head origin/branch
+    python detect_caps_regression.py NB.ipynb --base origin/main          # head = disk
+
+    # JSON output for CI  / quiet (exit code only)
+    python detect_caps_regression.py ... --json
+    python detect_caps_regression.py ... --quiet       # or --check (#7197 alias)
 
 See #2876, #3801. Companion to detect_accent_stripping.py, check_identifier_regression.py (#7157),
 restore_accents_canonical.py (#7186).
@@ -64,6 +71,7 @@ restore_accents_canonical.py (#7186).
 import argparse
 import json
 import re
+import subprocess
 import sys
 import unicodedata
 from pathlib import Path
@@ -158,29 +166,18 @@ def _cell_source_lines(cell: dict) -> list[str]:
     return out
 
 
-def scan_pair(base_path: Path, head_path: Path) -> dict:
-    """Compare base vs head notebooks, return a result dict.
+def _compare_notebooks(base_nb: dict, head_nb: dict) -> list[dict]:
+    """Compare two in-memory notebooks, return the list of regression dicts.
 
-    ``{"path": str, "regressions": [...], "error": str | None}`` where each
-    regression is ``{cell_index, line_no, base_token, head_token, column,
-    position, base_line}``.
+    Shared core of :func:`scan_pair` (direct-file mode) and :func:`scan_ref_mode`
+    (git-ref mode). Cell-by-cell : only markdown cells are in scope (code cells
+    are the identifier gate's job, #7157). If the cell counts differ we still
+    compare index-by-index up to the shorter list ; a count mismatch is itself a
+    structural signal but not this detector's concern.
     """
-    try:
-        base_nb = json.loads(base_path.read_text(encoding="utf-8"))
-    except Exception as e:  # noqa: BLE001 -- report any read/parse failure as error
-        return {"path": str(head_path), "regressions": [], "error": f"base unreadable: {e}"}
-    try:
-        head_nb = json.loads(head_path.read_text(encoding="utf-8"))
-    except Exception as e:  # noqa: BLE001
-        return {"path": str(head_path), "regressions": [], "error": f"head unreadable: {e}"}
-
     base_cells = base_nb.get("cells", [])
     head_cells = head_nb.get("cells", [])
     regressions = []
-    # Cell-by-cell : only markdown cells are in scope (code cells are the
-    # identifier gate's job, #7157). If the cell counts differ we still compare
-    # index-by-index up to the shorter list ; a count mismatch is itself a
-    # structural signal but not this detector's concern.
     for ci, (bc, hc) in enumerate(zip(base_cells, head_cells)):
         if bc.get("cell_type") != "markdown" or hc.get("cell_type") != "markdown":
             continue
@@ -199,7 +196,90 @@ def scan_pair(base_path: Path, head_path: Path) -> dict:
                     "position": pos,
                     "base_line": bl,
                 })
-    return {"path": str(head_path), "regressions": regressions, "error": None}
+    return regressions
+
+
+def scan_pair(base_path: Path, head_path: Path) -> dict:
+    """Direct-file mode : compare two notebooks on disk, return a result dict.
+
+    ``{"path": str, "regressions": [...], "error": str | None}`` where each
+    regression is ``{cell_index, line_no, base_token, head_token, column,
+    position, base_line}``.
+    """
+    try:
+        base_nb = json.loads(base_path.read_text(encoding="utf-8"))
+    except Exception as e:  # noqa: BLE001 -- report any read/parse failure as error
+        return {"path": str(head_path), "regressions": [], "error": f"base unreadable: {e}"}
+    try:
+        head_nb = json.loads(head_path.read_text(encoding="utf-8"))
+    except Exception as e:  # noqa: BLE001
+        return {"path": str(head_path), "regressions": [], "error": f"head unreadable: {e}"}
+    return {"path": str(head_path),
+            "regressions": _compare_notebooks(base_nb, head_nb), "error": None}
+
+
+def _git_show_notebook(ref: str, path: str, cwd=None):
+    """Read a notebook at a git ref via ``git show <ref>:<path>``.
+
+    Returns the parsed nbformat dict, or ``None`` if the ref/path is unreadable
+    (missing blob, bad ref, JSON parse error). ``None`` (not a raised exception)
+    lets the caller distinguish "base unreadable" from "head unreadable" and
+    surface a precise error, mirroring :func:`scan_pair`. ``cwd`` is the
+    directory to run git in (defaults to the process cwd -- for CLI use, the
+    worker is at the repo root ; exposed for testing with a tmp git repo).
+    """
+    r = subprocess.run(["git", "show", f"{ref}:{path}"], capture_output=True, cwd=cwd)
+    if r.returncode != 0:
+        return None
+    try:
+        return json.loads(r.stdout.decode("utf-8"))
+    except Exception:  # noqa: BLE001 -- any parse failure = "unreadable at ref"
+        return None
+
+
+def scan_ref_mode(notebook_path: Path, base_ref: str, head_ref, cwd=None) -> dict:
+    """Git-ref mode : point at ONE notebook and compare two git refs of it.
+
+    Worker-ergonomic alternative to :func:`scan_pair` -- no need to extract the
+    base/head files first. Mirrors the invocation workers learned on
+    ``check_caps_regression.py`` (#7197) so disposing that duplicate is lossless:
+
+        detect_caps_regression.py NB.ipynb --base origin/main --head origin/branch
+        detect_caps_regression.py NB.ipynb --base origin/main   # head = working tree
+
+    ``notebook_path`` : the notebook on disk (used for head when ``head_ref`` is
+    None AND to resolve the repo-relative path for ``git show``).
+    ``base_ref``     : git ref for the base (default ``origin/main`` at the CLI).
+    ``head_ref``     : git ref for the head, OR ``None`` to read the head
+                       notebook from the working tree (the on-disk file).
+    ``cwd``          : directory to run git in (defaults to process cwd).
+    """
+    # Resolve a repo-relative path for `git show` (git wants forward slashes and
+    # a path relative to the repo root, not the cwd).
+    git_path = str(notebook_path).replace("\\", "/")
+    base_nb = _git_show_notebook(base_ref, git_path, cwd=cwd)
+    if base_nb is None:
+        return {"path": str(notebook_path), "regressions": [],
+                "error": f"base unreadable at git ref {base_ref}:{git_path}"}
+
+    if head_ref is None:
+        # Head = working tree : read the on-disk notebook.
+        if not notebook_path.exists():
+            return {"path": str(notebook_path), "regressions": [],
+                    "error": f"head unreadable: {notebook_path} not on disk and no --head given"}
+        try:
+            head_nb = json.loads(notebook_path.read_text(encoding="utf-8"))
+        except Exception as e:  # noqa: BLE001
+            return {"path": str(notebook_path), "regressions": [],
+                    "error": f"head unreadable (disk): {e}"}
+    else:
+        head_nb = _git_show_notebook(head_ref, git_path, cwd=cwd)
+        if head_nb is None:
+            return {"path": str(notebook_path), "regressions": [],
+                    "error": f"head unreadable at git ref {head_ref}:{git_path}"}
+
+    return {"path": str(notebook_path),
+            "regressions": _compare_notebooks(base_nb, head_nb), "error": None}
 
 
 def _human_report(result: dict) -> str:
@@ -224,18 +304,45 @@ def _human_report(result: dict) -> str:
 
 def main(argv=None) -> int:
     parser = argparse.ArgumentParser(
-        description="Detect markdown caps-regression in accent cures (compare base vs head).")
-    parser.add_argument("--base", required=True, help="base notebook (origin/main)")
-    parser.add_argument("--head", required=True, help="head notebook (PR branch)")
+        description=(
+            "Detect markdown caps-regression in accent cures. Two modes:\n"
+            "  direct-file : --base FILE --head FILE\n"
+            "  git-ref     : NOTEBOOK.ipynb --base origin/main --head origin/branch"
+            " (head defaults to working tree)\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("notebook", nargs="?", default=None,
+                        help="git-ref mode : point at one notebook, compare two git refs of it")
+    parser.add_argument("--base", default=None,
+                        help="direct mode = base notebook FILE ; git-ref mode = base git ref "
+                             "(default origin/main)")
+    parser.add_argument("--head", default=None,
+                        help="direct mode = head notebook FILE ; git-ref mode = head git ref "
+                             "(default = working-tree notebook on disk)")
     parser.add_argument("--json", action="store_true", help="machine-readable JSON output")
     parser.add_argument("--quiet", action="store_true", help="no stdout (exit code only)")
+    parser.add_argument("--check", action="store_true",
+                        help="alias of --quiet (CI-ready exit code) -- #7197 muscle memory")
     args = parser.parse_args(argv)
 
-    result = scan_pair(Path(args.base), Path(args.head))
+    quiet = args.quiet or args.check
+
+    if args.notebook is not None:
+        # Git-ref mode : point at one notebook, compare two git refs of it.
+        base_ref = args.base or "origin/main"
+        result = scan_ref_mode(Path(args.notebook), base_ref, args.head)
+    else:
+        # Direct-file mode : two explicit notebook files.
+        if not args.base or not args.head:
+            parser.error(
+                "direct-file mode requires --base FILE and --head FILE "
+                "(or use git-ref mode: NOTEBOOK.ipynb --base origin/main --head origin/branch)")
+        result = scan_pair(Path(args.base), Path(args.head))
 
     if args.json:
         print(json.dumps(result, ensure_ascii=False, indent=2))
-    elif not args.quiet:
+    elif not quiet:
         print(_human_report(result))
 
     if result["error"]:

--- a/scripts/notebook_tools/tests/test_detect_caps_regression.py
+++ b/scripts/notebook_tools/tests/test_detect_caps_regression.py
@@ -334,6 +334,8 @@ class TestGitRefIntegration:
         repo = tmp_path / "repo"
         repo.mkdir()
         sp.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        # Force the default branch to 'main' (CI runners may default to 'master').
+        sp.run(["git", "branch", "-m", "main"], cwd=repo, capture_output=True)
         for k, v in {"user.name": "t", "user.email": "t@t"}.items():
             sp.run(["git", "config", k, v], cwd=repo, check=True, capture_output=True)
         base = {"cells": [{"cell_type": "markdown",
@@ -354,6 +356,8 @@ class TestGitRefIntegration:
         repo = tmp_path / "repo"
         repo.mkdir()
         sp.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        # Force the default branch to 'main' (CI runners may default to 'master').
+        sp.run(["git", "branch", "-m", "main"], cwd=repo, capture_output=True)
         for k, v in {"user.name": "t", "user.email": "t@t"}.items():
             sp.run(["git", "config", k, v], cwd=repo, check=True, capture_output=True)
         base = {"cells": [{"cell_type": "markdown",
@@ -373,6 +377,8 @@ class TestGitRefIntegration:
         repo = tmp_path / "repo"
         repo.mkdir()
         sp.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        # Force the default branch to 'main' (CI runners may default to 'master').
+        sp.run(["git", "branch", "-m", "main"], cwd=repo, capture_output=True)
         for k, v in {"user.name": "t", "user.email": "t@t"}.items():
             sp.run(["git", "config", k, v], cwd=repo, check=True, capture_output=True)
         base = {"cells": [], "metadata": {}}

--- a/scripts/notebook_tools/tests/test_detect_caps_regression.py
+++ b/scripts/notebook_tools/tests/test_detect_caps_regression.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Tests for detect_caps_regression.py (#2876 markdown caps-regression gate).
+
+Covers : accent-stripping helpers, positional line check, scan_pair end-to-end
+on synthetic notebooks, main() exit codes + JSON mode. The regression class is
+the one caught firsthand on PRs #7191 / #7185 (tiebreaker c.484) : an accent
+cure that lowercases the initial capital of a token.
+"""
+import json
+import sys
+from pathlib import Path
+
+# Allow ``import detect_caps_regression`` when run from the tests/ dir.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import detect_caps_regression as dcr  # noqa: E402
+
+
+# --------------------------------------------------------------------------
+# Helpers : build synthetic notebooks.
+# --------------------------------------------------------------------------
+def _nb(md_source_lines: list[str], code_source_lines: list[str] | None = None) -> dict:
+    """Build a minimal nbformat notebook with one markdown + one code cell."""
+    cells = [{"cell_type": "markdown", "source": md_source_lines, "metadata": {}}]
+    if code_source_lines is not None:
+        cells.append({"cell_type": "code", "source": code_source_lines,
+                      "metadata": {}, "execution_count": None, "outputs": []})
+    return {"cells": cells, "metadata": {}, "nbformat": 4, "nbformat_minor": 5}
+
+
+def _write_nb(path: Path, nb: dict) -> Path:
+    path.write_text(json.dumps(nb, ensure_ascii=False), encoding="utf-8")
+    return path
+
+
+# --------------------------------------------------------------------------
+# Accent-stripping helpers.
+# --------------------------------------------------------------------------
+class TestStripAccents:
+    def test_strips_common_accents(self):
+        assert dcr._strip_accents("système") == "systeme"
+        assert dcr._strip_accents("précédent") == "precedent"
+        assert dcr._strip_accents("Équipes") == "Equipes"
+        assert dcr._strip_accents("modèles") == "modeles"
+
+    def test_passes_through_ascii(self):
+        assert dcr._strip_accents("Systeme") == "Systeme"
+        assert dcr._strip_accents("abc123") == "abc123"
+        assert dcr._strip_accents("") == ""
+
+    def test_has_accent_true_only_when_mark_present(self):
+        assert dcr._has_accent("système") is True
+        assert dcr._has_accent("Systeme") is False
+        assert dcr._has_accent("Équipes") is True
+
+
+# --------------------------------------------------------------------------
+# Positional line check : the core signal.
+# --------------------------------------------------------------------------
+class TestCheckLine:
+    def test_heading_capital_lost_flagged(self):
+        # The defect : cure restored the accent but lowercased the initial capital.
+        base = "## 3. Modele Deux Joueurs"
+        head = "## 3. modèle Deux Joueurs"  # wrong : should be "Modèle"
+        regs = list(dcr._check_line(base, head))
+        assert len(regs) == 1
+        assert regs[0][0] == "Modele"  # base token (capital preserved in main)
+        assert regs[0][1] == "modèle"  # head token (accent restored, capital lost)
+
+    def test_nav_capital_lost_flagged(self):
+        base = "| Precedent | Suivant |"
+        head = "| précédent | Suivant |"
+        regs = list(dcr._check_line(base, head))
+        assert len(regs) == 1
+        assert regs[0][0] == "Precedent"
+        assert regs[0][1] == "précédent"
+
+    def test_table_bold_capital_lost_flagged(self):
+        base = "| **Equipes** | Moyenne |"
+        head = "| **équipes** | Moyenne |"
+        regs = list(dcr._check_line(base, head))
+        assert len(regs) == 1
+        assert regs[0][0] == "Equipes"
+        assert regs[0][1] == "équipes"
+
+    def test_list_item_capital_lost_flagged(self):
+        base = "1. **Parametres** : Definition"
+        head = "1. **paramètres** : Definition"
+        regs = list(dcr._check_line(base, head))
+        assert len(regs) == 1
+        assert regs[0][0] == "Parametres"
+        assert regs[0][1] == "paramètres"
+
+    def test_correct_cure_capital_preserved_not_flagged(self):
+        """The happy path : cure restored the accent AND kept the capital."""
+        base = "## 3. Modele Deux Joueurs"
+        head = "## 3. Modèle Deux Joueurs"
+        assert list(dcr._check_line(base, head)) == []
+
+    def test_mid_sentence_lowercase_cure_not_flagged(self):
+        """A legit lowercase cure (base was lowercase) is NOT a regression."""
+        base = "Le systeme de classement est pret."
+        head = "Le système de classement est pret."
+        assert list(dcr._check_line(base, head)) == []
+
+    def test_unrelated_word_change_not_flagged(self):
+        """A non-accent word change is out of scope (no accent on head token)."""
+        base = "Le Modele ici"
+        head = "Le Modele la"  # "ici" -> "la", no accent involved
+        assert list(dcr._check_line(base, head)) == []
+
+    def test_structural_count_mismatch_skipped(self):
+        """Word-count differs (token added/removed) -> not a pure cure, skip."""
+        base = "Le Modele de classement"
+        head = "Le modèle"  # 2 words vs 4 -- structural, skip
+        assert list(dcr._check_line(base, head)) == []
+
+    def test_identical_line_not_flagged(self):
+        assert list(dcr._check_line("Le systeme", "Le systeme")) == []
+
+    def test_full_uppercase_preserved_not_flagged(self):
+        """ALL-CAPS acronym cured to all-caps accented is NOT a regression."""
+        base = "JSON Modeles"
+        head = "JSON Modèles"  # base Mod-eles -> Mod-èles, capital preserved
+        assert list(dcr._check_line(base, head)) == []
+
+
+# --------------------------------------------------------------------------
+# scan_pair end-to-end on synthetic notebooks.
+# --------------------------------------------------------------------------
+class TestScanPair:
+    def test_clean_notebook_zero_regressions(self, tmp_path):
+        base = _nb(["## Le Modele", "Le systeme fonctionne."])
+        head = _nb(["## Le Modèle", "Le système fonctionne."])  # correct cures
+        bp = _write_nb(tmp_path / "base.ipynb", base)
+        hp = _write_nb(tmp_path / "head.ipynb", head)
+        res = dcr.scan_pair(bp, hp)
+        assert res["error"] is None
+        assert res["regressions"] == []
+
+    def test_multiple_regressions_found(self, tmp_path):
+        base = _nb(["## 3. Modele Deux Joueurs",
+                    "| Precedent | Suivant |",
+                    "| **Equipes** | Moyenne |"])
+        head = _nb(["## 3. modèle Deux Joueurs",
+                    "| précédent | Suivant |",
+                    "| **équipes** | Moyenne |"])
+        bp = _write_nb(tmp_path / "base.ipynb", base)
+        hp = _write_nb(tmp_path / "head.ipynb", head)
+        res = dcr.scan_pair(bp, hp)
+        assert res["error"] is None
+        assert len(res["regressions"]) == 3
+        toks = {(r["base_token"], r["head_token"]) for r in res["regressions"]}
+        assert ("Modele", "modèle") in toks
+        assert ("Precedent", "précédent") in toks
+        assert ("Equipes", "équipes") in toks
+
+    def test_code_cells_ignored(self, tmp_path):
+        """Code cells are the identifier gate's scope (#7157), not this tool's."""
+        base = _nb(["Le systeme"],
+                   code_source_lines=["Parametres = 42  # code identifier"])
+        head = _nb(["Le système"],
+                   code_source_lines=["parametres = 42  # would be an ident regression"])
+        bp = _write_nb(tmp_path / "base.ipynb", base)
+        hp = _write_nb(tmp_path / "head.ipynb", head)
+        res = dcr.scan_pair(bp, hp)
+        assert res["regressions"] == []  # markdown cure correct, code ignored
+
+    def test_unreadable_base_returns_error(self, tmp_path):
+        hp = _write_nb(tmp_path / "head.ipynb", _nb(["ok"]))
+        res = dcr.scan_pair(tmp_path / "missing.ipynb", hp)
+        assert res["error"] is not None
+        assert "base unreadable" in res["error"]
+
+    def test_unreadable_head_returns_error(self, tmp_path):
+        bp = _write_nb(tmp_path / "base.ipynb", _nb(["ok"]))
+        res = dcr.scan_pair(bp, tmp_path / "missing.ipynb")
+        assert res["error"] is not None
+        assert "head unreadable" in res["error"]
+
+    def test_regression_dict_shape(self, tmp_path):
+        base = _nb(["## Modele X"])
+        head = _nb(["## modèle X"])
+        bp = _write_nb(tmp_path / "base.ipynb", base)
+        hp = _write_nb(tmp_path / "head.ipynb", head)
+        r = dcr.scan_pair(bp, hp)["regressions"][0]
+        for key in ("cell_index", "line_no", "column", "base_token",
+                    "head_token", "position", "base_line"):
+            assert key in r
+
+
+# --------------------------------------------------------------------------
+# main() exit codes + JSON mode.
+# --------------------------------------------------------------------------
+class TestMainExitCodes:
+    def test_clean_exit_0(self, tmp_path, capsys):
+        base = _nb(["Le systeme"])
+        head = _nb(["Le système"])
+        bp = _write_nb(tmp_path / "base.ipynb", base)
+        hp = _write_nb(tmp_path / "head.ipynb", head)
+        rc = dcr.main(["--base", str(bp), "--head", str(hp), "--quiet"])
+        assert rc == 0
+
+    def test_regression_exit_1(self, tmp_path, capsys):
+        base = _nb(["## Modele X"])
+        head = _nb(["## modèle X"])
+        bp = _write_nb(tmp_path / "base.ipynb", base)
+        hp = _write_nb(tmp_path / "head.ipynb", head)
+        rc = dcr.main(["--base", str(bp), "--head", str(hp), "--quiet"])
+        assert rc == 1
+
+    def test_unreadable_exit_2(self, tmp_path):
+        hp = _write_nb(tmp_path / "head.ipynb", _nb(["ok"]))
+        rc = dcr.main(["--base", str(tmp_path / "missing.ipynb"),
+                       "--head", str(hp), "--quiet"])
+        assert rc == 2
+
+    def test_json_mode_emits_valid_json(self, tmp_path, capsys):
+        base = _nb(["## Modele X"])
+        head = _nb(["## modèle X"])
+        bp = _write_nb(tmp_path / "base.ipynb", base)
+        hp = _write_nb(tmp_path / "head.ipynb", head)
+        rc = dcr.main(["--base", str(bp), "--head", str(hp), "--json"])
+        out = json.loads(capsys.readouterr().out)
+        assert rc == 1
+        assert out["error"] is None
+        assert len(out["regressions"]) == 1
+
+    def test_human_report_clean_and_hit(self, tmp_path, capsys):
+        base = _nb(["## Modele X"])
+        head_clean = _nb(["## Modèle X"])
+        bp = _write_nb(tmp_path / "base.ipynb", base)
+        hp = _write_nb(tmp_path / "head.ipynb", head_clean)
+        dcr.main(["--base", str(bp), "--head", str(hp)])
+        assert "OK" in capsys.readouterr().out
+
+
+# --------------------------------------------------------------------------
+# Position classification (annotation only, not the verdict).
+# --------------------------------------------------------------------------
+class TestPositionClassification:
+    def test_heading_detected(self):
+        assert dcr._classify_position("## Modele", 3, "Modele") == "heading"
+
+    def test_table_detected(self):
+        # "Equipes" in "| **Equipes** |" starts at column 4 (after "| **").
+        assert dcr._classify_position("| **Equipes** |", 4, "Equipes") in ("table", "bold")
+
+    def test_list_detected(self):
+        assert dcr._classify_position("1. Parametres ici", 3, "Parametres") == "list"
+
+    def test_sentence_start_detected(self):
+        assert dcr._classify_position("Apres inference", 0, "Apres") == "sentence-start"
+
+    def test_prose_default(self):
+        assert dcr._classify_position("Le systeme ici", 3, "systeme") == "prose"

--- a/scripts/notebook_tools/tests/test_detect_caps_regression.py
+++ b/scripts/notebook_tools/tests/test_detect_caps_regression.py
@@ -10,6 +10,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest  # noqa: E402 -- for pytest.raises in the no-args guard test
+
 # Allow ``import detect_caps_regression`` when run from the tests/ dir.
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 import detect_caps_regression as dcr  # noqa: E402
@@ -253,3 +255,185 @@ class TestPositionClassification:
 
     def test_prose_default(self):
         assert dcr._classify_position("Le systeme ici", 3, "systeme") == "prose"
+
+
+# --------------------------------------------------------------------------
+# Git-ref mode : scan_ref_mode (unit tests via monkeypatch, no real git).
+# --------------------------------------------------------------------------
+class TestScanRefMode:
+    def test_success_both_refs(self, tmp_path, monkeypatch):
+        base_nb = {"cells": [{"cell_type": "markdown",
+                              "source": ["## Modele X"]}], "metadata": {}}
+        head_nb = {"cells": [{"cell_type": "markdown",
+                              "source": ["## modèle X"]}], "metadata": {}}
+        calls = {"base": base_nb, "head": head_nb}
+
+        def fake_show(ref, path, cwd=None):
+            return calls.get("base") if "main" in ref else calls.get("head")
+        monkeypatch.setattr(dcr, "_git_show_notebook", fake_show)
+        res = dcr.scan_ref_mode(tmp_path / "nb.ipynb", "origin/main", "origin/branch")
+        assert res["error"] is None
+        assert len(res["regressions"]) == 1
+
+    def test_base_ref_unreadable(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(dcr, "_git_show_notebook",
+                            lambda ref, path, cwd=None: None)
+        res = dcr.scan_ref_mode(tmp_path / "nb.ipynb", "origin/main", "origin/branch")
+        assert res["error"] is not None
+        assert "base unreadable at git ref" in res["error"]
+        assert res["regressions"] == []
+
+    def test_head_ref_unreadable(self, tmp_path, monkeypatch):
+        base_nb = {"cells": [], "metadata": {}}
+
+        def fake_show(ref, path, cwd=None):
+            return base_nb if "main" in ref else None
+        monkeypatch.setattr(dcr, "_git_show_notebook", fake_show)
+        res = dcr.scan_ref_mode(tmp_path / "nb.ipynb", "origin/main", "origin/branch")
+        assert res["error"] is not None
+        assert "head unreadable at git ref" in res["error"]
+
+    def test_head_defaults_to_disk(self, tmp_path, monkeypatch):
+        """head_ref=None -> head notebook read from the on-disk file."""
+        base_nb = {"cells": [{"cell_type": "markdown",
+                              "source": ["## Modele X"]}], "metadata": {}}
+        monkeypatch.setattr(dcr, "_git_show_notebook",
+                            lambda ref, path, cwd=None: base_nb)
+        head_nb = {"cells": [{"cell_type": "markdown",
+                              "source": ["## modèle X"]}], "metadata": {}}
+        disk_path = tmp_path / "nb.ipynb"
+        disk_path.write_text(json.dumps(head_nb), encoding="utf-8")
+        res = dcr.scan_ref_mode(disk_path, "origin/main", None)
+        assert res["error"] is None
+        assert len(res["regressions"]) == 1
+
+    def test_head_disk_missing_no_ref(self, tmp_path, monkeypatch):
+        """head_ref=None AND notebook not on disk -> precise error."""
+        base_nb = {"cells": [], "metadata": {}}
+        monkeypatch.setattr(dcr, "_git_show_notebook",
+                            lambda ref, path, cwd=None: base_nb)
+        res = dcr.scan_ref_mode(tmp_path / "ghost.ipynb", "origin/main", None)
+        assert res["error"] is not None
+        assert "not on disk" in res["error"]
+
+
+# --------------------------------------------------------------------------
+# Git-ref mode : real tmp git repo integration (confirms the git show plumbing).
+# --------------------------------------------------------------------------
+class TestGitRefIntegration:
+    def _commit(self, repo, nb_dict, msg):
+        import subprocess as sp
+        (repo / "nb.ipynb").write_text(json.dumps(nb_dict), encoding="utf-8")
+        sp.run(["git", "add", "nb.ipynb"], cwd=repo, check=True,
+               capture_output=True)
+        sp.run(["git", "commit", "-m", msg], cwd=repo, check=True,
+               capture_output=True)
+
+    def test_real_repo_detects_regression(self, tmp_path):
+        import subprocess as sp
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        sp.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        for k, v in {"user.name": "t", "user.email": "t@t"}.items():
+            sp.run(["git", "config", k, v], cwd=repo, check=True, capture_output=True)
+        base = {"cells": [{"cell_type": "markdown",
+                           "source": ["## Modele X"]}], "metadata": {}}
+        self._commit(repo, base, "base")
+        sp.run(["git", "branch", "branch"], cwd=repo, check=True, capture_output=True)
+        sp.run(["git", "checkout", "branch"], cwd=repo, check=True, capture_output=True)
+        head = {"cells": [{"cell_type": "markdown",
+                           "source": ["## modèle X"]}], "metadata": {}}
+        self._commit(repo, head, "head")
+        res = dcr.scan_ref_mode(Path("nb.ipynb"), "main", "branch", cwd=repo)
+        assert res["error"] is None
+        assert len(res["regressions"]) == 1
+        assert res["regressions"][0]["base_token"] == "Modele"
+
+    def test_real_repo_clean_cure(self, tmp_path):
+        import subprocess as sp
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        sp.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        for k, v in {"user.name": "t", "user.email": "t@t"}.items():
+            sp.run(["git", "config", k, v], cwd=repo, check=True, capture_output=True)
+        base = {"cells": [{"cell_type": "markdown",
+                           "source": ["## Modele X"]}], "metadata": {}}
+        self._commit(repo, base, "base")
+        sp.run(["git", "branch", "branch"], cwd=repo, check=True, capture_output=True)
+        sp.run(["git", "checkout", "branch"], cwd=repo, check=True, capture_output=True)
+        head = {"cells": [{"cell_type": "markdown",
+                           "source": ["## Modèle X"]}], "metadata": {}}
+        self._commit(repo, head, "head")
+        res = dcr.scan_ref_mode(Path("nb.ipynb"), "main", "branch", cwd=repo)
+        assert res["error"] is None
+        assert res["regressions"] == []  # correct cure : capital preserved
+
+    def test_real_repo_bad_ref_error(self, tmp_path):
+        import subprocess as sp
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        sp.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        for k, v in {"user.name": "t", "user.email": "t@t"}.items():
+            sp.run(["git", "config", k, v], cwd=repo, check=True, capture_output=True)
+        base = {"cells": [], "metadata": {}}
+        self._commit(repo, base, "base")
+        res = dcr.scan_ref_mode(Path("nb.ipynb"), "nonexistent-ref", "main", cwd=repo)
+        assert res["error"] is not None
+        assert "base unreadable at git ref" in res["error"]
+
+
+# --------------------------------------------------------------------------
+# main() git-ref-mode dispatch + --check alias + no-args guard.
+# --------------------------------------------------------------------------
+class TestMainGitRefMode:
+    def test_git_ref_mode_dispatch(self, tmp_path, capsys, monkeypatch):
+        base_nb = {"cells": [{"cell_type": "markdown",
+                              "source": ["## Modele X"]}], "metadata": {}}
+        head_nb = {"cells": [{"cell_type": "markdown",
+                              "source": ["## modèle X"]}], "metadata": {}}
+
+        def fake_scan(notebook_path, base_ref, head_ref, cwd=None):
+            assert base_ref == "origin/main"
+            assert head_ref == "origin/branch"
+            return {"path": str(notebook_path),
+                    "regressions": [{"cell_index": 0, "line_no": 0, "column": 3,
+                                     "base_token": "Modele", "head_token": "modèle",
+                                     "position": "heading", "base_line": "## Modele X"}],
+                    "error": None}
+        monkeypatch.setattr(dcr, "scan_ref_mode", fake_scan)
+        rc = dcr.main(["nb.ipynb", "--base", "origin/main", "--head", "origin/branch"])
+        assert rc == 1
+        assert "Modele" in capsys.readouterr().out
+
+    def test_git_ref_mode_base_default_origin_main(self, tmp_path, monkeypatch):
+        """Positional notebook + no --base -> defaults to origin/main."""
+        seen = {}
+
+        def fake_scan(notebook_path, base_ref, head_ref, cwd=None):
+            seen["base_ref"] = base_ref
+            return {"path": str(notebook_path), "regressions": [], "error": None}
+        monkeypatch.setattr(dcr, "scan_ref_mode", fake_scan)
+        dcr.main(["nb.ipynb", "--quiet"])
+        assert seen["base_ref"] == "origin/main"
+
+    def test_check_alias_is_quiet(self, tmp_path, capsys, monkeypatch):
+        """--check (the #7197 muscle-memory alias) suppresses stdout like --quiet."""
+        monkeypatch.setattr(dcr, "scan_ref_mode",
+                            lambda p, b, h, cwd=None: {
+                                "path": str(p),
+                                "regressions": [{"cell_index": 0, "line_no": 0,
+                                                 "column": 0, "base_token": "X",
+                                                 "head_token": "x", "position": "prose",
+                                                 "base_line": "X"}],
+                                "error": None})
+        rc = dcr.main(["nb.ipynb", "--base", "origin/main", "--head", "origin/branch",
+                       "--check"])
+        out = capsys.readouterr().out
+        assert rc == 1
+        assert out == ""  # --check writes nothing, exit code only
+
+    def test_no_args_errors_exit_2(self, tmp_path, monkeypatch, capsys):
+        """No positional AND no --base/--head -> parser.error (exit 2)."""
+        with pytest.raises(SystemExit) as ei:
+            dcr.main([])
+        assert ei.value.code == 2


### PR DESCRIPTION
## What

New markdown caps-regression detector `scripts/notebook_tools/detect_caps_regression.py` (252 LOC) + 29 tests. **Companion GATE** for the third defect class uncovered by the #2876 accent-cure sweep — one that `detect_accent_stripping` (cure direction), `check_identifier_regression` (#7157, identifier-over-reach gate), and `restore_accents_canonical` (#7186, canonical cure) all leave uncovered.

## Why — the defect class

An accent-cure script that **lowercases the initial capital** of a token when restoring its accent. Caught firsthand during the po-2026 c.484 tiebreaker (po-2023 c.611 retract vs po-2024 c.633 confirm contradiction):

```
main  (heading) : "## 3. Modele Deux Joueurs"
branch (cured)  : "## 3. modele Deux Joueurs"      <- WRONG (should be "Modèle")

main  (nav)     : "| Precedent | Suivant |"
branch (cured)  : "| precedent | Suivant |"        <- WRONG (should be "Précédent")

main  (table)   : "| **Equipes** | Moyenne ..."
branch (cured)  : "| **equipes** | Moyenne ..."    <- WRONG (should be "Équipes")
```

Positions that MUST keep the capital (headings `#`, nav, table headers `|`, list items `N. `, bold `**`) become visibly broken.

**Why #7157 doesn't catch it** : `check_identifier_regression` scans CODE-cell identifiers (Python/C#). The caps defect is a **MARKDOWN-prose** defect, so it sails past the identifier gate. **Why #7186 doesn't catch it** : `restore_accents_canonical` is the CURE (has `_preserve_case` correct by construction), not a GATE — it can't vet PRs produced by other (ad-hoc) scripts. This tool fills the gap.

## How — the contract

Input : a BASE notebook (origin/main) and a HEAD notebook (PR branch). For each markdown cell, line-align sources and compare **word-by-word at each position**. A regression is a position where:
1. base word and head word differ,
2. head word carries an accent (NFD + combining-mark check),
3. stripping the accent yields the base word (case-insensitive) — i.e. it IS an accent cure of that token, AND
4. base word started uppercase that the head word lowercased.

Structural lines (token-count mismatch base vs head) are **skipped** — accent cures are 1:1 substitutions, so a count mismatch means structural change, not a cure, and positional comparison would misalign. This keeps the detector free of the false-positive mode that tripped up earlier non-positional scans (po-2023 c.610/c.611 methodology debate).

Exit codes : `0` clean, `1` regression(s), `2` error (unreadable base/head). `--json` for CI, `--quiet` for exit-code-only.

## Integration-verified on the 3 tiebreaker PRs (exact reproduction)

The detector reproduces the po-2026 c.484 tiebreaker counts exactly:

| PR | owner | po-claim | **detector output** | tiebreaker c.484 |
|----|-------|----------|---------------------|------------------|
| **#7191** Infer-8 | po-2024 | 27 broken (c.633) | **36 hits** | 36 ✓ |
| **#7185** Infer-10 | po-2024 | 11 broken (c.633) | **12 hits** | 12 ✓ |
| **#7187** SL-2 | po-2023 | clean (c.611) | **0 hits** | 0 ✓ |

Sample hits (`#7191`): `# ... : Systeme de Classement`→`# ... : système de Classement` (H1 heading), `| Precedent | Suivant |`→`| précédent | Suivant |` (nav), `### Parametres par defaut`→`### paramètres par defaut` (H3), `| **Equipes** |`→`| **équipes** |` (table bold), `## 3. Modele Deux Joueurs`→`## 3. modèle Deux Joueurs` (H2), `1. **Parametres** :`→`1. **paramètres** :` (list).

## Proofs

| Proof | Result |
|-------|--------|
| `pytest test_detect_caps_regression.py -v` | **29 passed in 0.11s** |
| Integration #7191 | **36 hits** (matches c.484) |
| Integration #7185 | **12 hits** (matches c.484) |
| Integration #7187 | **0 hits** (matches c.484, po-2023 clean) |
| BOM check (3 first bytes) | `23 21 2f` = `#!` (no-BOM UTF-8) |
| Line endings | CR=0 / CRLF=0 / LF-only |
| Existing source modified | **0** (2 new files only) |
| Notebooks touched | **0** |
| C.1 / C.2 / H.3 | N/A (no notebook, tool-only) |
| R3 collision pre-worktree + post-push | `gh pr list --search detect_caps_regression` = [] ; no prior tool of this name |

## Anti-régression §D

0 source code modified or deleted. 0 notebook touched. 0 output hand-edited. Purely additive (1 new tool + 1 new test file).

## Relationship to cluster state

Resolves the c.484 tiebreaker's "uncovered defect class" finding (po-2023 c.610 + po-2024 c.633 both said the guard misses this). Together with #7157 (identifier gate, merged) and #7186 (canonical cure, peer-validated), this closes the #2876 whack-a-mole on three axes : identifier-over-reach (#7157), caps-loss (this PR), and cure-canonicalization (#7186).

See #2876, See #3801 (EPIC SOTA axe-2). Not `Closes` (the registry has residual re-cure work on the broken PRs; this tool enables that cleanup the same way #7157 did).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
