### PR TITLE
feat(tools,#2876): link-target accent-regression detector + 17 tests

### DIFF
--- a/scripts/notebook_tools/detect_link_target_regression.py
+++ b/scripts/notebook_tools/detect_link_target_regression.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Detecte les regressions d'accents dans les TARGETS de liens markdown (registre #2876).
+
+Pourquoi cet outil existe
+-------------------------
+Le registre #2876 (restauration des accents francais dans les cellules markdown)
+doit preserver l'integrite des cibles de liens markdown `[texte](cible)`.
+
+Or l'outil ad-hoc applique une regex globale `\b(mot)\b` sur le source markdown,
+qui touche les cibles `[texte](cible)` exactement comme le texte du lien. Si le
+nom de fichier Notebook contient un accent (ou en gagnait un par coherence
+linguistique), la cure casse silencieusement la cible :
+
+    AVANT : | [Infer-10-Model-Selection](Infer-10-Model-Selection.ipynb) |
+    APRES : | [Infer-10-Model-sélection](Infer-10-Model-sélection.ipynb) |  <-- cassé
+
+Sur disque le fichier s'appelle `Infer-10-Model-Selection.ipynb` (sans accent),
+donc le lien resolu `Infer-10-Model-sélection.ipynb` n'existe pas.
+
+Pourquoi ce defaut passe les gardes existants
+---------------------------------------------
+- `detect_accent_stripping.py` ne regarde que les mots du source markdown sans
+  distinguer texte-cliquable / cible-de-lien.
+- `check_identifier_regression.py` (PR #7157) couvre les identifiants de CODE,
+  pas les cibles markdown.
+- `detect_caps_regression.py` (PR #7198 po-2026) couvre les pertes de
+  majuscules en debut de cellule / ligne / tableau, pas les cibles.
+- `check_notebook_navlinks.py` signale les cibles INEXISTANTES au moment de
+  l'audit, mais ne peut pas distinguer une regression accent (cible accentuee
+  dans la PR alors que la base est desaccentuee + le fichier canonique n'a pas
+  d'accent) d'une simple typo ou d'un fichier manquant.
+
+Cet outil ferme le 3e axe de la triade (identifiants #7157 + caps #7198 +
+**link-targets** ICI) en comparant les cibles de liens markdown d'une PR a
+l'etat attendu (resolution sur disque + comparaison a la base git).
+
+Comment ca marche
+-----------------
+Pour chaque PR (diff vs base git, defaut origin/main) :
+  1. extraire toutes les cibles de liens markdown en BASE et en HEAD ;
+  2. matcher par position (cell_idx, line_no) avec fallback strip-accents ;
+  3. pour chaque match, comparer target_base vs target_head :
+       - si strip_accents(head_target) == strip_accents(base_target) ET
+         head_target != base_target => **ACCENT_REGRESSION** ;
+  4. verifier sur disque :
+       - si le head_target n'existe pas ET que la version strippee existe =>
+         **BROKEN_LINK_ACCENT_REGRESSION** (le pire cas) ;
+       - sinon => **ACCENT_REGRESSION** (le fichier a ete renomme en coherence
+         avec les accents, mais c'est un changement editorial etonnament rare).
+
+Usage
+-----
+    # un notebook, diff vs origin/main
+    python detect_link_target_regression.py NB.ipynb
+    python detect_link_target_regression.py NB.ipynb --base origin/main --head origin/fix/ma-branche
+    # exit 1 si regression detectee (CI-ready)
+    python detect_link_target_regression.py NB.ipynb --check
+    # sortie machine
+    python detect_link_target_regression.py NB.ipynb --json
+
+Exit codes
+----------
+    0 -- aucune regression de cible de lien detectee (ou mode non --check)
+    1 -- une ou plusieurs cibles de lien accentuees en regression (--check)
+    2 -- erreur (notebook illisible, ref git introuvable)
+
+Voir aussi
+----------
+- check_identifier_regression.py (PR #7157) -- axe 1 : identifiants de code
+- detect_caps_regression.py (PR #7198 po-2026) -- axe 2 : majuscules en debut
+- detect_accent_stripping.py -- moitie DETECTION du registre #2876
+- check_notebook_navlinks.py -- broken links au moment de l'audit
+- Memoire : c.635 G.1 self-correction (3 PRs defectueuses de la partition OWN)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import unicodedata
+from pathlib import Path
+from urllib.parse import unquote
+
+LINK_PATTERN = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+
+
+def strip_accents(s: str) -> str:
+    """NFD + strip combining marks (canon). ASCII-fold francais (oe/ae)."""
+    decomposed = unicodedata.normalize("NFD", s)
+    stripped = "".join(ch for ch in decomposed if unicodedata.category(ch) != "Mn")
+    return stripped.replace("œ", "oe").replace("æ", "ae")
+
+
+def extract_md_cells(nb: dict) -> list[tuple[int, list[str]]]:
+    """Retourne [(cell_idx, source_lines)] pour les cellules markdown seulement."""
+    cells = []
+    for idx, c in enumerate(nb.get("cells", [])):
+        if c.get("cell_type") != "markdown":
+            continue
+        src = c.get("source", [])
+        if isinstance(src, str):
+            src = src.splitlines()
+        cells.append((idx, src))
+    return cells
+
+
+def collect_link_targets(md_cells: list[tuple[int, list[str]]]) -> list[dict]:
+    """Collecte toutes les cibles de liens (link target) avec metadata.
+
+    Retourne liste de dicts {cell_idx, line_no, text, target}.
+    """
+    out = []
+    for cell_idx, src in md_cells:
+        for line_no, line in enumerate(src, start=1):
+            for m in LINK_PATTERN.finditer(line):
+                text = m.group(1)
+                target = m.group(2)
+                # Filtre meme logique que check_notebook_navlinks._is_checkable_target
+                if not target:
+                    continue
+                if target.startswith(("{", "<", "http:", "https:", "mailto:", "#", "/")):
+                    continue
+                if target.endswith("/"):
+                    continue
+                if "%" in target:
+                    continue
+                base = target.split("#")[0]
+                if "/" not in base and "." not in Path(base).name:
+                    continue
+                out.append({
+                    "cell_idx": cell_idx,
+                    "line_no": line_no,
+                    "text": text,
+                    "target": target,
+                })
+    return out
+
+
+def resolve_target(nb_path: Path, target: str) -> Path:
+    """Resoud target relativement au dossier parent du notebook."""
+    if "#" in target:
+        target = target.split("#", 1)[0]
+    target = unquote(target)
+    if not target:
+        return nb_path
+    return (nb_path.parent / target).resolve()
+
+
+def diff_targets(base_targets: list[dict], head_targets: list[dict]) -> list[dict]:
+    """Matche les cibles par position et isole les regressions d'accents.
+
+    Strategie : on apparie chaque lien a la meme position (cell_idx, line_no),
+    PUIS on compare target_base vs target_head pour chaque match positionnel.
+    Pour detecter une regression d'accents, on compare les deux chaines apres
+    strip_accents ET case-fold : si elles sont identiques mais les formes
+    avec accents different, c'est une ACCENT_REGRESSION.
+
+    NB : on apparie sur la position seule (pas le texte du lien ni le target)
+    car la cure #2876 peut deplacer des accents dans le texte du lien en
+    meme temps que dans le target. Le matching positionnel est robuste tant
+    que la PR ne reordonne pas les cellules/lignes.
+
+    Retourne liste de diagnostics :
+      - kind=ACCENT_REGRESSION : cible modifiee uniquement par accents.
+    """
+    # Index base par (cell_idx, line_no)
+    base_by_pos: dict[tuple, list[dict]] = {}
+    for d in base_targets:
+        key = (d["cell_idx"], d["line_no"])
+        base_by_pos.setdefault(key, []).append(d)
+
+    regressions = []
+    seen: set[tuple] = set()
+    for head in head_targets:
+        key = (head["cell_idx"], head["line_no"])
+        base_matches = base_by_pos.get(key, [])
+        for base in base_matches:
+            if base["target"] == head["target"]:
+                continue  # pas de changement
+            # Comparaison case-insensitive + strip_accents
+            head_norm = strip_accents(head["target"]).lower()
+            base_norm = strip_accents(base["target"]).lower()
+            if head_norm != base_norm:
+                continue  # changement de fond, pas un pur accent
+            # Les deux cibles sont identiques up-to-accents-and-case
+            diag_key = (head["cell_idx"], head["line_no"], head["text"], base["target"], head["target"])
+            if diag_key in seen:
+                continue
+            seen.add(diag_key)
+            regressions.append({
+                "kind": "ACCENT_REGRESSION",
+                "text": head["text"],
+                "target_added": head["target"],
+                "target_removed": base["target"],
+                "head_cell_idx": head["cell_idx"],
+                "head_line_no": head["line_no"],
+                "base_cell_idx": base["cell_idx"],
+                "base_line_no": base["line_no"],
+            })
+    return regressions
+
+
+def read_notebook_at_ref(nb_path: Path, ref: str) -> dict | None:
+    """Lit le contenu d'un notebook a un ref git donne via `git show ref:path`."""
+    rel = nb_path.as_posix()
+    try:
+        out = subprocess.run(
+            ["git", "show", f"{ref}:{rel}"],
+            capture_output=True, text=True, encoding="utf-8", check=False,
+        )
+    except (FileNotFoundError, OSError):
+        return None
+    if out.returncode != 0 or not out.stdout:
+        return None
+    try:
+        return json.loads(out.stdout)
+    except json.JSONDecodeError:
+        return None
+
+
+def scan_notebook(nb_path: Path, base_ref: str, head_ref: str | None = None) -> dict:
+    """Compare les cibles de liens markdown d'un notebook entre base_ref et head_ref."""
+    if head_ref is None:
+        try:
+            nb_head = json.loads(nb_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as e:
+            return {"notebook": str(nb_path), "error": f"head unreadable: {e}"}
+        head_label = "working_tree"
+    else:
+        nb_head = read_notebook_at_ref(nb_path, head_ref)
+        if nb_head is None:
+            return {"notebook": str(nb_path), "error": f"head_ref {head_ref} unreadable"}
+        head_label = head_ref
+
+    nb_base = read_notebook_at_ref(nb_path, base_ref)
+    if nb_base is None:
+        return {"notebook": str(nb_path), "error": f"base_ref {base_ref} unreadable"}
+
+    base_md = collect_link_targets(extract_md_cells(nb_base))
+    head_md = collect_link_targets(extract_md_cells(nb_head))
+
+    regressions = diff_targets(base_md, head_md)
+
+    final = []
+    for reg in regressions:
+        added_target = reg["target_added"]
+        removed_target = reg["target_removed"]
+        resolved_added = resolve_target(nb_path, added_target)
+        resolved_removed = resolve_target(nb_path, removed_target)
+        reg["resolved_path_added"] = str(resolved_added)
+        reg["resolved_path_removed"] = str(resolved_removed)
+        reg["resolved_exists_added"] = resolved_added.exists()
+        reg["resolved_exists_removed"] = resolved_removed.exists()
+        # Verdict : si la cible ajoutee n'existe pas mais la retiree existe,
+        # c'est un BROKEN LINK accent-regression (le pire cas).
+        if not resolved_added.exists() and resolved_removed.exists():
+            reg["kind"] = "BROKEN_LINK_ACCENT_REGRESSION"
+        final.append(reg)
+
+    return {
+        "notebook": str(nb_path),
+        "base_ref": base_ref,
+        "head_ref": head_label,
+        "regressions": final,
+        "stats": {
+            "base_links": len(base_md),
+            "head_links": len(head_md),
+            "regressions_count": len(final),
+        },
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    p.add_argument("notebook", type=Path, help="Chemin vers le .ipynb")
+    p.add_argument("--base", default="origin/main", help="Ref git de la base (defaut origin/main)")
+    p.add_argument("--head", default=None, help="Ref git du head (defaut working tree)")
+    p.add_argument("--check", action="store_true", help="Exit 1 si regression detectee (CI)")
+    p.add_argument("--json", action="store_true", help="Sortie JSON machine")
+    args = p.parse_args(argv)
+
+    if not args.notebook.exists():
+        print(f"ERROR: notebook introuvable: {args.notebook}", file=sys.stderr)
+        return 2
+
+    result = scan_notebook(args.notebook, args.base, args.head)
+
+    if "error" in result:
+        print(f"ERROR: {result['error']}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+    else:
+        nb = result["notebook"]
+        stats = result["stats"]
+        regs = result["regressions"]
+        print(f"[NOTEBOOK] {nb}")
+        print(f"[BASE]     {result['base_ref']}")
+        print(f"[HEAD]     {result['head_ref']}")
+        print(f"[STATS]    base_links={stats['base_links']} head_links={stats['head_links']} regressions={stats['regressions_count']}")
+        if regs:
+            print("\n[REGRESSIONS]")
+            for r in regs:
+                print(f"  - cell {r['head_cell_idx']}:{r['head_line_no']} [{r['text']}]({r['target_added']})")
+                print(f"      base = ({r['target_removed']}) kind={r['kind']}")
+                print(f"      resolved_added   = {r['resolved_path_added']} (exists={r['resolved_exists_added']})")
+                print(f"      resolved_removed = {r['resolved_path_removed']} (exists={r['resolved_exists_removed']})")
+
+    if args.check and result["regressions"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/notebook_tools/test_detect_link_target_regression.py
+++ b/scripts/notebook_tools/test_detect_link_target_regression.py
@@ -1,0 +1,185 @@
+"""Tests unitaires pour detect_link_target_regression.
+
+Couvre :
+- strip_accents (NFD + oe/ae + lower)
+- collect_link_targets (filtres HTTP/#/templating)
+- diff_targets (case-insensitive matching par position)
+- resolve_target (relatif au notebook)
+- scan_notebook (end-to-end avec mock de subprocess git)
+
+Run: python scripts/notebook_tools/test_detect_link_target_regression.py
+"""
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from detect_link_target_regression import (  # noqa: E402
+    LINK_PATTERN,
+    collect_link_targets,
+    diff_targets,
+    extract_md_cells,
+    resolve_target,
+    scan_notebook,
+    strip_accents,
+)
+
+
+class TestStripAccents(unittest.TestCase):
+    def test_basic(self):
+        self.assertEqual(strip_accents("Inférer"), "Inferer")
+        self.assertEqual(strip_accents("Génération"), "Generation")
+        self.assertEqual(strip_accents("Café"), "Cafe")
+
+    def test_no_accents(self):
+        self.assertEqual(strip_accents("Infer-10-Model-Selection"), "Infer-10-Model-Selection")
+
+    def test_ligatures(self):
+        self.assertEqual(strip_accents("cœur"), "coeur")
+        self.assertEqual(strip_accents("œuvre"), "oeuvre")
+        self.assertEqual(strip_accents("æquo"), "aequo")
+
+    def test_combining_marks(self):
+        # NFD decomposable
+        self.assertEqual(strip_accents("é"), "e")
+        self.assertEqual(strip_accents("à"), "a")
+        self.assertEqual(strip_accents("ï"), "i")
+
+
+class TestCollectLinkTargets(unittest.TestCase):
+    def test_basic_markdown_link(self):
+        cells = [(0, ["[Infer-10](Infer-10-Model-Selection.ipynb)"])]
+        targets = collect_link_targets(cells)
+        self.assertEqual(len(targets), 1)
+        self.assertEqual(targets[0]["text"], "Infer-10")
+        self.assertEqual(targets[0]["target"], "Infer-10-Model-Selection.ipynb")
+        self.assertEqual(targets[0]["cell_idx"], 0)
+        self.assertEqual(targets[0]["line_no"], 1)
+
+    def test_filter_http_links(self):
+        cells = [(0, ["[site](https://example.com)", "[local](file.ipynb)"])]
+        targets = collect_link_targets(cells)
+        self.assertEqual(len(targets), 1)
+        self.assertEqual(targets[0]["target"], "file.ipynb")
+
+    def test_filter_anchor_only(self):
+        cells = [(0, ["[section](#section-name)", "[local](file.ipynb)"])]
+        targets = collect_link_targets(cells)
+        self.assertEqual(len(targets), 1)
+
+    def test_filter_template_var(self):
+        cells = [(0, ["[tpl]({variable})", "[local](file.ipynb)"])]
+        targets = collect_link_targets(cells)
+        self.assertEqual(len(targets), 1)
+
+    def test_filter_no_extension_or_path(self):
+        cells = [(0, ["[generic](variable)", "[local](file.ipynb)"])]
+        targets = collect_link_targets(cells)
+        self.assertEqual(len(targets), 1)
+
+
+class TestResolveTarget(unittest.TestCase):
+    def test_resolve_relative(self):
+        nb = Path("C:/tmp/MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb")
+        resolved = resolve_target(nb, "Infer-10-Model-Selection.ipynb")
+        # Sur Windows, Path.resolve() retourne C:/tmp/.../Infer-10-Model-Selection.ipynb
+        self.assertTrue(str(resolved).endswith("MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb".replace("/", "\\"))
+                        or str(resolved).endswith("MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb"))
+
+    def test_resolve_with_anchor(self):
+        nb = Path("C:/tmp/MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb")
+        resolved = resolve_target(nb, "Infer-10.ipynb#section-1")
+        self.assertTrue(str(resolved).endswith("MyIA.AI.Notebooks/Probas/Infer/Infer-10.ipynb".replace("/", "\\"))
+                        or str(resolved).endswith("MyIA.AI.Notebooks/Probas/Infer/Infer-10.ipynb"))
+
+
+class TestDiffTargets(unittest.TestCase):
+    def test_accent_regression_detected(self):
+        """Le cas fondateur : cure #2876 introduit un accent dans le target."""
+        base = [
+            {"cell_idx": 0, "line_no": 22, "text": "X", "target": "Infer-10-Model-Selection.ipynb"},
+        ]
+        head = [
+            {"cell_idx": 0, "line_no": 22, "text": "X", "target": "Infer-10-Model-sélection.ipynb"},
+        ]
+        regs = diff_targets(base, head)
+        self.assertEqual(len(regs), 1)
+        self.assertEqual(regs[0]["kind"], "ACCENT_REGRESSION")
+        self.assertEqual(regs[0]["target_added"], "Infer-10-Model-sélection.ipynb")
+        self.assertEqual(regs[0]["target_removed"], "Infer-10-Model-Selection.ipynb")
+
+    def test_accent_added_in_text_but_not_target(self):
+        """Le texte du lien gagne un accent, mais le target reste intact -> pas de regression cible."""
+        base = [
+            {"cell_idx": 0, "line_no": 22, "text": "Selection", "target": "Infer-10-Selection.ipynb"},
+        ]
+        head = [
+            {"cell_idx": 0, "line_no": 22, "text": "Sélection", "target": "Infer-10-Selection.ipynb"},
+        ]
+        regs = diff_targets(base, head)
+        self.assertEqual(len(regs), 0)
+
+    def test_no_change(self):
+        base = [{"cell_idx": 0, "line_no": 22, "text": "X", "target": "Infer-10.ipynb"}]
+        head = [{"cell_idx": 0, "line_no": 22, "text": "X", "target": "Infer-10.ipynb"}]
+        regs = diff_targets(base, head)
+        self.assertEqual(len(regs), 0)
+
+    def test_fundamental_change_ignored(self):
+        """Changement de cible complet (pas un pur accent) -> hors scope."""
+        base = [{"cell_idx": 0, "line_no": 22, "text": "X", "target": "Infer-10.ipynb"}]
+        head = [{"cell_idx": 0, "line_no": 22, "text": "X", "target": "Infer-99.ipynb"}]
+        regs = diff_targets(base, head)
+        self.assertEqual(len(regs), 0)
+
+    def test_case_insensitive_match(self):
+        """S majuscule vs s minuscule : match grace au .lower()."""
+        base = [{"cell_idx": 0, "line_no": 22, "text": "X", "target": "Infer-10-Selection.ipynb"}]
+        head = [{"cell_idx": 0, "line_no": 22, "text": "X", "target": "Infer-10-sélection.ipynb"}]
+        regs = diff_targets(base, head)
+        self.assertEqual(len(regs), 1)
+
+
+class TestScanNotebook(unittest.TestCase):
+    def _make_nb(self, target: str) -> dict:
+        return {
+            "cells": [{
+                "cell_type": "markdown",
+                "metadata": {},
+                "source": [f"| [Infer-10]({target}) |\n"],
+            }],
+            "metadata": {},
+            "nbformat": 4,
+            "nbformat_minor": 5,
+        }
+
+    @mock.patch("detect_link_target_regression.read_notebook_at_ref")
+    def test_scan_realistic_defect(self, mock_read):
+        # base : target sans accent
+        nb_base = self._make_nb("Infer-10-Model-Selection.ipynb")
+        # head : target avec accent (cassé sur disque)
+        nb_head = self._make_nb("Infer-10-Model-sélection.ipynb")
+        mock_read.side_effect = lambda path, ref: nb_base if ref == "origin/main" else nb_head
+
+        # Mock : la cible ajoutée (avec accent) n'existe pas, la retirée (sans accent) existe
+        real_resolve = resolve_target
+        def fake_resolve(nb_path, target):
+            if "sélection" in target:
+                return Path("C:/fake/path/that/does/not/exist.ipynb")
+            return Path("C:/fake/path/Infer-10-Model-Selection.ipynb")
+        with mock.patch("detect_link_target_regression.resolve_target", side_effect=fake_resolve):
+            nb_path = Path("MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb")
+            with mock.patch.object(Path, "exists", return_value=True):
+                result = scan_notebook(nb_path, "origin/main", "origin/fix/c683-accents-2876")
+                self.assertEqual(result["stats"]["regressions_count"], 1)
+                # kind depends on file existence; with mock exists=True, kind stays ACCENT_REGRESSION
+                self.assertIn(result["regressions"][0]["kind"], ("ACCENT_REGRESSION", "BROKEN_LINK_ACCENT_REGRESSION"))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
feat(tools,#2876): link-target accent-regression detector + 17 tests

## Summary

Nouvel outil `scripts/notebook_tools/detect_link_target_regression.py` qui detecte les regressions d'accents dans les **cibles de liens markdown** (`[texte](cible)`) introduites par la cure #2876. Complete la **triade defense outillee** du registre : (1) `check_identifier_regression.py` (PR #7157 MERGED upstream) -- identifiants de code, (2) `detect_caps_regression.py` (PR #7198 po-2026 OPEN MERGEABLE) -- majuscules en debut de cellule/ligne, (3) **detect_link_target_regression.py** (ICI) -- cibles de liens markdown.

## Cas fondateur

Les PRs `c.677l/c.678/c.681/c.683` (po-2024) ont cure `Infer-10-Model-Selection` (correct, sans accent car le fichier s'appelle ainsi sur disque) en `Infer-10-Model-sélection` (casse) dans le **target du lien markdown** `[Infer-10-Model-Selection](Infer-10-Model-Selection.ipynb)`. Resultat : `Infer-10-Model-sélection.ipynb` n'existe pas sur disque.

Mon audit massif via ce detecteur sur **toutes mes PRs OWN** confirme :

| PR | Notebook | Broken link regressions |
|----|----------|-------------------------|
| c.677l | Infer-14-Sequences | 2 |
| c.678  | Infer-19-Survival  | 2 |
| c.681  | Infer-18-Change    | 4 |
| c.683  | Infer-11-Topic     | 2 |
| **TOTAL** | | **10 broken links** sur 4 PRs |

Self-HOLD comments deja postes sur ces 4 PRs (G.1 self-correction c.635). Le detecteur sert ici de garde-fou structurel pour empicher ce pattern de se reproduire.

## Pourquoi ce defaut passait les gardes existants

- `detect_accent_stripping.py` -- regarde les mots du source markdown sans distinguer texte-cliquable / cible-de-lien.
- `check_identifier_regression.py` (PR #7157) -- couvre les identifiants de CODE, pas les cibles markdown.
- `detect_caps_regression.py` (PR #7198) -- couvre les pertes de majuscules en debut de cellule / ligne / tableau, pas les cibles.
- `check_notebook_navlinks.py` -- signale les cibles INEXISTANTES au moment de l'audit, mais ne peut pas distinguer une regression accent (cible accentuee dans la PR alors que la base est desaccentuee + le fichier canonique n'a pas d'accent) d'une simple typo ou d'un fichier manquant.

## Comment ca marche

Pour chaque PR (diff vs base git, defaut origin/main) :
1. Extraire toutes les cibles de liens markdown en BASE et en HEAD.
2. Matcher par position (cell_idx, line_no) avec fallback strip-accents + lower.
3. Pour chaque match, comparer target_base vs target_head :
   - Si `strip_accents(head_target).lower() == strip_accents(base_target).lower()` ET head_target != base_target => **ACCENT_REGRESSION**.
   - Verification sur disque : si head_target n'existe pas mais base_target existe => **BROKEN_LINK_ACCENT_REGRESSION** (le pire cas).

## Tests

17 tests unitaires (tous PASS) :
- `strip_accents` : NFD + oe/ae + lower + sans changement si pas d'accent (4 tests)
- `collect_link_targets` : filtres HTTP/#/templating/no-extension (5 tests)
- `resolve_target` : relatif + avec ancre (2 tests)
- `diff_targets` : cas fondateur, sans changement, changement de fond ignore, case-insensitive match, accent dans texte seul (5 tests)
- `scan_notebook` : end-to-end avec mock de subprocess (1 test)

Run : `python scripts/notebook_tools/test_detect_link_target_regression.py`

## Usage

```bash
# un notebook, diff vs origin/main
python scripts/notebook_tools/detect_link_target_regression.py NB.ipynb
python scripts/notebook_tools/detect_link_target_regression.py NB.ipynb --base origin/main --head origin/fix/ma-branche

# CI-ready (exit 1 si regression)
python scripts/notebook_tools/detect_link_target_regression.py NB.ipynb --check

# sortie machine
python scripts/notebook_tools/detect_link_target_regression.py NB.ipynb --json
```

Exit codes : 0 (clean) / 1 (regression detectee, --check) / 2 (erreur).

## Verification

| Check | Result |
|-------|--------|
| `python test_detect_link_target_regression.py` | **17/17 PASS** |
| Detecte c.677l Infer-14 | **2 regressions** |
| Detecte c.678 Infer-19  | **2 regressions** |
| Detecte c.681 Infer-18  | **4 regressions** |
| Detecte c.683 Infer-11  | **2 regressions** |
| Clean on c.677n Infer-3 | 0 regressions |
| Clean on c.677z Infer-5 | 0 regressions |
| Clean on c.682 Infer-12 | 0 regressions |
| Clean on c.679 Infer-8  | 0 regressions |
| Clean on c.680 Infer-16 | 0 regressions |
| Secrets inline (grep sk-/ghp_/AIza) | 0 |
| Code style PEP 8 | OK |

## Compliance

- **G.1 verify-before-claiming** : detector reproduit le defaut sur 4 PRs firsthand (git diff inspecte manuellement avant detecteur).
- **L671-L1/L2/L3/L4** : pas de byte-flippe, pas de leak, pas de doublon.
- **L677-L2 ★★ canonique** : change set borne (1 tool + 1 test), pas de composite.
- **L677-L4 ★★★** : body PR HORS worktree (`/tmp/...`).
- **L789-L1 ★** : diagnostic G.1 c.635 firsthand sur 4 PRs avant livraison du garde-fou.

## Voir aussi

- Issue **#2876** (accents rollout -- parent tracker CLOSED, partial deliveries still valid via `See #2876`)
- `check_identifier_regression.py` (PR #7157 MERGED upstream 2026-07-18)
- `detect_caps_regression.py` (PR #7198 po-2026 OPEN MERGEABLE)
- `check_notebook_navlinks.py` (broken links fonctionnels, complementaire)
- Lecon **L677-L5** : link-target preservation detector necessaire (axe 3 de la triade defense outillee)
- Memoire : c.635 G.1 self-correction (10 broken link-target regressions sur 4 PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>