### PR TITLE
fix(genai-texte,#5081): repair 2 stale inbound .ipynb refs after RAG/Vision renumber

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/4_Function_Calling.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/4_Function_Calling.ipynb
@@ -2083,7 +2083,7 @@
     "\n",
     "### Prochaine Étape\n",
     "\n",
-    "Dans le notebook suivant (**5_RAG_Introduction.ipynb**), nous verrons comment combiner function calling avec le RAG (Retrieval-Augmented Generation) pour créer des assistants qui peuvent chercher dans des bases de connaissances.\n",
+    "Dans le notebook suivant (**5_RAG_Modern.ipynb**), nous verrons comment combiner function calling avec le RAG (Retrieval-Augmented Generation) pour créer des assistants qui peuvent chercher dans des bases de connaissances.\n",
     "\n",
     "---\n",
     "\n",

--- a/MyIA.AI.Notebooks/GenAI/Texte/8_Reasoning_Models.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/8_Reasoning_Models.ipynb
@@ -2236,7 +2236,7 @@
     "\n",
     "### Prochaines étapes\n",
     "\n",
-    "Notebook suivant : **9_Vision_Models.ipynb** (GPT-5 Vision, analyse d'images)\n",
+    "Notebook suivant : **9_Production_Patterns.ipynb** (Patterns de production : Conversations API, Background Mode, Rate Limiting)\n",
     "\n",
     "**Note de mise à jour**\n",
     "\n",


### PR DESCRIPTION
## Summary

Two **stale inbound `.ipynb` navigation refs** in `GenAI/Texte/` pointed at notebooks that no longer exist — post-renumber inbound-link rot (the **#5052 pattern**, EPIC **#5081**). Both were in series-conclusion prose ("Prochaine Étape"), so a student clicking the next-notebook link would hit a 404.

| File | Cell | Stale ref | Correct ref |
|------|------|-----------|-------------|
| `4_Function_Calling.ipynb` | 41 | `5_RAG_Introduction.ipynb` | `5_RAG_Modern.ipynb` |
| `8_Reasoning_Models.ipynb` | 36 | `9_Vision_Models.ipynb` (GPT-5 Vision, analyse d'images) | `9_Production_Patterns.ipynb` (Patterns de production : Conversations API, Background Mode, Rate Limiting) |

- `4_Function_Calling`: the RAG notebook was renamed Introduction → Modern; the cell-0 nav-header was already updated, only the conclusion prose lagged.
- `8_Reasoning_Models`: both filename AND content description were stale — notebook 9 is Production Patterns, not a Vision notebook. Description corrected to match the actual target's intro.

## Forensic verification (per-cell, firsthand)

- **Markdown-only**: code cells byte-identical to main (`4_FC`: 21/21 code+outputs+ec unchanged; `8_RM`: 14/14 unchanged). Exactly 1 markdown cell changed per notebook.
- **Diff**: 2 files, 2 insertions / 2 deletions — nothing else touched.
- `python scripts/check_docs_links.py --check` → **OK: No new broken links. (0 pre-existing, 4010 total)**
- H.3: 0 `execution_count: null` code cells (outputs intact).
- Source-list structure preserved (per-chunk replace, no join/split).

## Scope note (§E)

Two files, but a single cohesive subject (post-renumber stale inbound refs in one series, `GenAI/Texte`). Not a trivial <20-line doc PR — it's a functional navigation fix (404 → working link) with forensic per-cell verification. `See #5081` (partial: 2 of N stale refs in GenAI/Texte; broader sweep is separate work).

See #5081. See #5052 (precedent: SocialChoice stale code-cell refs post-renumber).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
