### PR TITLE
fix(sudoku): align Sudoku-3-Genetic-Python link display-text with sibling convention

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb
@@ -1398,8 +1398,8 @@
     "### Alternatives recommandees\n",
     "\n",
     "Pour resoudre efficacement le Sudoku, preferez:\n",
-    "- **Backtracking avec MRV**: [Sudoku-Python-Backtracking.ipynb](Sudoku-1-Backtracking-Python.ipynb)\n",
-    "- **OR-Tools CP-SAT**: [Sudoku-Python-ORTools-Z3.ipynb](Sudoku-10-ORTools-Python.ipynb)\n",
+    "- **Backtracking avec MRV**: [Sudoku-1-Backtracking-Python](Sudoku-1-Backtracking-Python.ipynb)\n",
+    "- **OR-Tools CP-SAT**: [Sudoku-10-ORTools-Python](Sudoku-10-ORTools-Python.ipynb)\n",
     "- **Z3 SMT**: [Sudoku-12-Z3-Python](Sudoku-12-Z3-Python.ipynb)\n",
     "\n",
     "Ces methodes garantissent de trouver une solution (si elle existe) en un temps raisonnable."


### PR DESCRIPTION
## Summary

The « Alternatives recommandees » conclusion cell of `Sudoku-3-Genetic-Python.ipynb` named two **non-existent files in the link DISPLAY text**, while the link TARGETS were correct:

| Display text (misleading) | Target (correct, works) |
|---------------------------|-------------------------|
| `[Sudoku-Python-Backtracking.ipynb]` | `(Sudoku-1-Backtracking-Python.ipynb)` |
| `[Sudoku-Python-ORTools-Z3.ipynb]` | `(Sudoku-10-ORTools-Python.ipynb)` |

The links themselves worked (no 404), but a student reading the rendered display text, or browsing the folder looking for `Sudoku-Python-Backtracking.ipynb`, would not find that file — the display text is an invented name.

## Fix (convention-grounded)

Aligned display text to the repo's own convention: **display = real target filename without `.ipynb` extension**. This is exactly what the sibling `Sudoku-1-Backtracking-Python.ipynb` cell25 does (`[Sudoku-10-ORTools-Python] -> (Sudoku-10-ORTools-Python.ipynb)`), and what the **third line in the same cell** (`[Sudoku-12-Z3-Python]`) already followed — so now all three alternatives are mutually consistent.

## Why a notebook-cell fix (not §E doc PR)

This is a **notebook-cell consistency fix** (pedagogical navigation clarity), not a docs/README/CLAUDE.md admin edit. §E targets the latter. The change improves a student-facing navigation surface.

## Forensic verification (firsthand)

- Markdown-only: code 12/12 byte-identical, outputs / execution_count / metadata untouched. Exactly 1 markdown cell changed.
- `python scripts/check_docs_links.py --check` → **OK: No new broken links.**
- H.3: 0 `execution_count: null`.
- Repo-wide scan confirms only **2** such display-text mismatches exist repo-wide, both in this single cell — isolated, atomic fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
