### PR TITLE
fix(tools,#7157): filter 1-char accentued-token FP from nested C# interpolated strings

### DIFF
--- a/scripts/notebook_tools/check_identifier_regression.py
+++ b/scripts/notebook_tools/check_identifier_regression.py
@@ -169,11 +169,27 @@ def partitioned_idents(source: str):
 
 def accented_identifiers(source: str):
     """Yield (token_accentue, ligne, ligne_contexte) pour chaque identifiant
-    structurel accentue present dans le source code."""
+    structurel accentue present dans le source code.
+
+    Filtre len >= 2 (anti-faux-positif) : un identifiant accentue d'un seul
+    caractere (``a`` ``e`` ``c`` accentues) est statistiquement toujours une
+    fuite de chaine, pas un vrai identifiant. Le strip regex (_STRIP_RE) ne
+    gere pas les chaines C# interpolees contenant des chaines imbriquees
+    (``$\"...{cond ? \\\"a\\\" : \\\"b\\\"}...\"``) : les guillemets internes
+    cassent le match et le contenu des chaines internes (``barque a gauche``)
+    fuie dans le code analyse. Le token accentue 1-char qui en resulte
+    (preposition/article FR ``a``) est elimine ici. Les vrais identifiants
+    accentues (variables/parametres/proprietes) sont toujours > 1 char dans
+    la pratique (min historique : ``cle`` 3, ``resultat`` 7 ; Python/C#
+    autorisent ``a`` comme nom mais pedagogiquement jamais utilise). Limite
+    residuelle connue : un mot accentue > 1 char fuissant d'une chaine
+    imbriquee resterait un FP (rare ; necessiterait un parser C# leger)."""
     stripped = _strip_preserve_lines(source)
     src_lines = source.split("\n")
     for m in _IDENT_RE.finditer(stripped):
         tok = m.group(0)
+        if len(tok) < 2:
+            continue
         if _has_accent(tok):
             line_no = stripped.count("\n", 0, m.start()) + 1
             ctx = src_lines[line_no - 1].strip() if 0 < line_no <= len(src_lines) else ""

--- a/scripts/notebook_tools/tests/test_check_identifier_regression.py
+++ b/scripts/notebook_tools/tests/test_check_identifier_regression.py
@@ -302,6 +302,27 @@ class TestRegressionCov:
         assert "résultat" not in ids
         assert "msg" in ids and "var" in ids
 
+    def test_cs_nested_interp_string_no_one_char_leak_fp(self):
+        # C# $"...{cond ? "a" : "b"}..." : chaines IMBRIQUEES dans l'interpolation.
+        # Les guillemets internes (des chaines "barque à gauche"/"barque à droite")
+        # cassent le strip regex (_STRIP_RE) : la chaine externe est tronquee au
+        # premier guillemet interne, et le contenu des chaines internes fuie dans
+        # le code analyse. Le token accentue 1-char qui fuie (preposition FR "à")
+        # doit etre FILTRE (len >= 2 dans accented_identifiers), pas flagge comme
+        # regression. Cas reel : Z3-Linq2Z3/04_Array_Theory cell[18] L62 (FP
+        # rapporte po-2025 c.624 ; gate signalait a->à en --base main --head main).
+        DQ = self.DQ
+        lit = ('Console.WriteLine($"Étape {t,2} : ({(t % 2 == 0 ? '
+               + DQ + 'barque à gauche' + DQ + ' : '
+               + DQ + 'barque à droite' + DQ + ')})");')
+        # 1. accented_identifiers ne doit yield AUCUN token 1-char fuyant.
+        leaks = list(cir.accented_identifiers(lit))
+        assert all(len(tok) >= 2 for tok, _, _ in leaks), f"1-char leak survived: {leaks}"
+        # 2. base == head (aucun diff possible) : scan doit retourner 0 regression.
+        nb = _nb([("code", lit)])
+        regs, _ = cir.scan(nb, nb)
+        assert regs == [], f"FP regression on nested C# interpolated string: {regs}"
+
     def test_accented_dict_key_is_regression(self):
         # Cle de dictionnaire accentuee Python = identifiant structurel.
         old = _nb([("code", "d = {'resultat': 1}")])


### PR DESCRIPTION
## Summary

Fix a **false-positive** in the identifier-regression gate `check_identifier_regression.py` (#7157, MERGED, live in CI) reported firsthand by po-2025 (c.624) on `Z3-Linq2Z3/04_Array_Theory.ipynb`. The gate flagged `a -> à` (cell[18] L62) even with `--base origin/main --head origin/main` (no possible diff) — a vacuous FP.

## Root cause (verified firsthand)

The line is a C# **interpolated string with nested strings**:
```
Console.WriteLine($"Étape {t,2} : ({(t % 2 == 0 ? "barque à gauche" : "barque à droite")})");
```

The strip regex `_STRIP_RE` matches a C# string from `$"` to the next `"`. The **inner quotes** (delimiting the nested strings `"barque à gauche"` / `"barque à droite"`) break the match — the outer string is truncated at the first inner `"`, and the content of the nested strings leaks into the analyzed code. `accented_identifiers` then sees the leaked `à` (French preposition) as an identifier, and `scan()` reports `a -> à` because the de-accented form `a` exists everywhere in `old_unaccented`. Proven by `_STRIP_RE.finditer` tokenization (3 string fragments instead of 1) + `_strip_preserve_lines` output (`Console.WriteLine(barque à gauchebarque à droite);`).

A regex cannot correctly parse C# interpolated strings with nested strings (arbitrary `{}` depth + inner quotes) — a full C# lexer would be needed.

## Fix (surgical, post-filter)

`accented_identifiers` now skips tokens of length < 2. **Real accentued identifiers** (variables/parameters/properties/classes) are always > 1 char in practice (historical min: `clé` 3, `résultat` 7; the regressions that motivated #7157 were `Différence`/`itération`/`préférences`). A 1-char accentued token (`à`/`é`/`ç`) is statistically always a **string leak** (French preposition/article). This eliminates the dominant FP class without weakening real detection.

## Validation (all firsthand)

- **39/39 tests pass** (38 existing + 1 new `test_cs_nested_interp_string_no_one_char_leak_fp`).
- **Mutation proof**: reverting the fix → the new test fails with `1-char leak survived: ['à','à']` (proves the test genuinely catches the bug).
- **End-to-end on the real Z3 notebook**: `--base origin/main --head origin/main --check` → **exit 0** (before the fix: `IDENTIFIER REGRESSION (x2)`).
- **Real-regression sanity**: `scan()` still detects `Difference -> Différence` (C# property) — the fix does NOT weaken detection.

## Residual (honest)

A multi-char accentued word leaking from a nested C# string (e.g. `café`) would remain a residual FP (rarer; would need a lightweight C# lexer). Documented in the `accented_identifiers` docstring.

See #7157 (gate already MERGED; this is a corrective fix on the live tool). No notebook touched, no catalogue touched.

## Tested

```
39 passed in 0.57s  (scripts/notebook_tools/tests/test_check_identifier_regression.py)
```
