### PR TITLE
fix(ml): repair 2 broken intra-notebook TOC anchors in ML-8-Clustering

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-8-Clustering.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-8-Clustering.ipynb
@@ -319,7 +319,7 @@
     "\n",
     "Le pipeline comporte **trois** étapes. La concatenation regroupe les trois features en un vecteur `\"Features\"`. La **normalisation MinMax** ramene chaque feature dans `[0, 1]`. Le trainer **K-Means** partitionne ensuite l'espace normalise en `numberOfClusters: 3` groupes.\n",
     "\n",
-    "**Pourquoi normaliser absolument ?** K-Means mesure la proximite par **distance euclidienne**. Sans normalisation, `Monetary` (50 a 500 EUR) ecrase totalement `Frequency` (2 a 20) et `Recency` (8 a 85 jours) : la distance serait dominee par la depense, et le clustering reflete surtout l'argent. Normaliser met les trois dimensions a la même echelle — c'est l'objet de l'[Exercice 3](#Exercice-3-:-Effet-de-la-normalisation). C'est l'equivalent, en non-supervise, de l'ingenierie de features vue en [ML-2](ML-2-Data&Features.ipynb)."
+    "**Pourquoi normaliser absolument ?** K-Means mesure la proximite par **distance euclidienne**. Sans normalisation, `Monetary` (50 a 500 EUR) ecrase totalement `Frequency` (2 a 20) et `Recency` (8 a 85 jours) : la distance serait dominee par la depense, et le clustering reflete surtout l'argent. Normaliser met les trois dimensions a la même echelle — c'est l'objet de l'[Exercice 3](#exercice-3-normalisation). C'est l'equivalent, en non-supervise, de l'ingenierie de features vue en [ML-2](ML-2-Data&Features.ipynb)."
    ]
   },
   {
@@ -677,7 +677,7 @@
    "source": [
     "### Redemption : la ou K-Means multivarie est vraiment indispensable\n",
     "\n",
-    "Le jeu principal ci-dessus (3 segments Dormants / Reguliers / VIP) est **presqu'unidimensionnel** : la depense `Monetary` seule (50 / 150 / 500 EUR) separe déjà les trois segments. L'[Exercice 3](#Exercice-3-:-Effet-de-la-normalisation-sur-K-Means) le reconnait (« sans normalisation, le clustering reflete surtout la depense »). Sur un tel cas, K-Means n'apporte pas grand-chose qu'un simple seuil sur `Monetary` ne donnerait pas.\n",
+    "Le jeu principal ci-dessus (3 segments Dormants / Reguliers / VIP) est **presqu'unidimensionnel** : la depense `Monetary` seule (50 / 150 / 500 EUR) separe déjà les trois segments. L'[Exercice 3](#exercice-3-normalisation) le reconnait (« sans normalisation, le clustering reflete surtout la depense »). Sur un tel cas, K-Means n'apporte pas grand-chose qu'un simple seuil sur `Monetary` ne donnerait pas.\n",
     "\n",
     "La capacite distinctive de K-Means — **combiner plusieurs features** pour separer des segments qu'aucune feature isolee ne distingue — ne s'exerce que sur un jeu ou chaque feature **prise separement chevauche** les segments. On construit donc trois segments disposes en **triangle** dans le plan (Recency, Frequency) :\n",
     "\n",
@@ -929,7 +929,7 @@
    "id": "ml8-md-31",
    "metadata": {},
    "source": [
-    "## Exercice 3 : Effet de la normalisation sur K-Means\n",
+    "## Exercice 3 : Effet de la normalisation sur K-Means\n<a id=\"exercice-3-normalisation\"></a>\n",
     "\n",
     "Le pipeline principal normalise (`NormalizeMinMax`). Que se passe-t-il **sans** normalisation ?\n",
     "\n",


### PR DESCRIPTION
## Summary

`ML-8-Clustering.ipynb` had **2 broken intra-notebook anchors** — both links to "Exercice 3" 404'd on click because the hand-written anchor slugs did not match GitHub/Jupyter auto-slug generation:

| Cell | Link target (broken) | Problem |
|------|----------------------|---------|
| cell13 (Pipeline interpretation) | `#Exercice-3-:-Effet-de-la-normalisation` | truncated (missing "sur-K-Means"), keeps colon + capital letters |
| cell26 (Redemption) | `#Exercice-3-:-Effet-de-la-normalisation-sur-K-Means` | keeps colon + capital letters |

The heading `## Exercice 3 : Effet de la normalisation sur K-Means` relies on auto-slug, but colons and capital letters in the link targets never match the generated slug (`exercice-3--effet-de-la-normalisation-sur-k-means`).

## Fix (slug-ambiguity-proof)

Added an **explicit HTML anchor** `<a id="exercice-3-normalisation"></a>` immediately after the Exercice 3 heading (the proven pattern used by `Lean-1-Setup.ipynb` cell1 `<a id="introduction"></a>`), and repointed both links to `#exercice-3-normalisation`.

Explicit anchors are **deterministic across GitHub/Jupyter/nbconvert renderers** — they don't depend on slugger colon/case rules, so the fix can't drift.

## Forensic verification (firsthand)

- **byte-safety**: 15/15 code cells byte-identical vs `origin/main` (source + outputs + execution_count unchanged). Exactly 3 markdown cells touched.
- **H.3**: 0 `execution_count: null`.
- `python scripts/check_docs_links.py --check` → **OK (0 broken, 4023 total)**.
- **re-scan**: explicit anchor `exercice-3-normalisation` defined, both `#` links resolve, 0 broken.

## Context — systemic defect class (for coordinated cleanup)

This is one instance of a **systemic defect from the three-exercises rollout (#2161)**: when exercise headings were added, TOC/inline anchors were hand-written with colons + capital letters that don't match auto-slugs. A repo-wide scan found ~17 notebooks with suspect intra-notebook anchors — BUT many are false positives (notebooks using explicit `<a id>` HTML anchors that the scan must account for). ML-8 is a confirmed real case (no explicit anchor fallback). ML-9-Anomaly-Detection has the same pattern and likely needs the same fix. I'm scoping this PR to ML-8 only (atomic, one-notebook) and flagging the systemic class for the notebook-cleaner / a coordinated follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
