### PR TITLE
fix(ml): repair 7 broken intra-notebook TOC anchors in ML-9 anomaly twins

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-9-Anomaly-Detection-Python.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-9-Anomaly-Detection-Python.ipynb
@@ -219,7 +219,7 @@
     "\n",
     "> **Pourquoi PAS de normalisation ici, contrairement au clustering K-Means ?** K-Means mesure des **distances euclidiennes** et exige que les features soient à la même échelle. La détection d'anomalies par PCA, elle, exploite justement la **structure de variance** : les composantes principales sont définies par les directions de plus grande variance. Normaliser écraserait cette structure.\n",
     "\n",
-    "> **Pourquoi `n_components = 2` ?** Avec 3 features, la PCA de rang 2 projette les données sur un **plan** ; le score d'anomalie est la composante **hors-plan** (le résidu le long de la 3ᵉ direction). Si l'on choisissait `n_components = 3` (le maximum), **tout** serait expliqué et le résidu serait nul : la détection deviendrait impossible. Le rang contrôle donc la **sensibilité** du détecteur (cf. [Exercice 1](#Exercice-1-:-Effet-du-rang-PCA-sur-l'AUC)).\n",
+    "> **Pourquoi `n_components = 2` ?** Avec 3 features, la PCA de rang 2 projette les données sur un **plan** ; le score d'anomalie est la composante **hors-plan** (le résidu le long de la 3ᵉ direction). Si l'on choisissait `n_components = 3` (le maximum), **tout** serait expliqué et le résidu serait nul : la détection deviendrait impossible. Le rang contrôle donc la **sensibilité** du détecteur (cf. [Exercice 1](#exercice-1-rang-pca-auc)).\n",
     "\n",
     "Nos données sont déjà **recentrées sur l'origine** (écarts au point nominal) : la PCA passe donc par le centroïde, condition essentielle pour que le résidu reflète bien l'écart au régime normal.\n",
     "\n",
@@ -502,7 +502,7 @@
    "source": [
     "### Interprétation : un compromis détection / fausse alarme\n",
     "\n",
-    "Le sweep dessine la courbe ROC de façon lisible : à seuil bas on rattrape presque toutes les anomalies mais au prix de nombreuses fausses alarmes ; à seuil haut on devient précis mais on rate la plupart des anomalies. Un point de fonctionnement raisonnable détecte la grande majorité des anomalies pour une fraction de fausses alarmes acceptable. Si le métier exige `FPR <= 5 %`, il faut monter le seuil — mais on accepte alors de rater la plupart des anomalies. Ce compromis n'a pas de réponse universelle : il dépend du **coût relatif** d'une casse ratée (très élevé en maintenance prédictive) face au coût d'une intervention inutile. L'[Exercice 2](#Exercice-2-:-Accorder-le-seuil-à-un-coût-opérationnel) formalise cet accord sur une contrainte `TPR >= 0,95`."
+    "Le sweep dessine la courbe ROC de façon lisible : à seuil bas on rattrape presque toutes les anomalies mais au prix de nombreuses fausses alarmes ; à seuil haut on devient précis mais on rate la plupart des anomalies. Un point de fonctionnement raisonnable détecte la grande majorité des anomalies pour une fraction de fausses alarmes acceptable. Si le métier exige `FPR <= 5 %`, il faut monter le seuil — mais on accepte alors de rater la plupart des anomalies. Ce compromis n'a pas de réponse universelle : il dépend du **coût relatif** d'une casse ratée (très élevé en maintenance prédictive) face au coût d'une intervention inutile. L'[Exercice 2](#exercice-2-seuil-cout) formalise cet accord sur une contrainte `TPR >= 0,95`."
    ]
   },
   {
@@ -510,7 +510,7 @@
    "id": "d1f7ba95",
    "metadata": {},
    "source": [
-    "## Exercice 1 : Effet du rang PCA sur l'AUC\n",
+    "## Exercice 1 : Effet du rang PCA sur l'AUC\n<a id=\"exercice-1-rang-pca-auc\"></a>\n",
     "\n",
     "Le rang de la PCA contrôle la **sensibilité** du détecteur. Avec 3 features :\n",
     "\n",
@@ -563,7 +563,7 @@
    "id": "7e4aba4d",
    "metadata": {},
    "source": [
-    "## Exercice 2 : Accorder le seuil à un coût opérationnel\n",
+    "## Exercice 2 : Accorder le seuil à un coût opérationnel\n<a id=\"exercice-2-seuil-cout\"></a>\n",
     "\n",
     "On veut un détecteur qui **rate au plus 5 % des anomalies** (TPR >= 0.95) tout en **minimisant les fausses alarmes**. Le sweep ci-dessus est trop grossier (9 seuils réguliers).\n",
     "\n",

--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-9-Anomaly-Detection.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-9-Anomaly-Detection.ipynb
@@ -346,7 +346,7 @@
     "\n",
     "> **Pourquoi PAS de normalisation MinMax ici, contrairement a [ML-8](ML-8-Clustering.ipynb) ?** K-Means mesure des **distances euclidiennes** et exige que les features soient a la même echelle. La detection d'anomalies par PCA, elle, exploite justement la **structure de variance** : les composantes principales sont définies par les directions de plus grande variance. Normaliser ecraserait cette structure. C'est une différence fondamentale entre les deux familles non-supervisees.\n",
     "\n",
-    "> **Pourquoi `rank: 2` ?** Avec 3 features, la PCA de rang 2 projette les données sur un **plan** ; le score d'anomalie est la composante **hors-plan** (le residu le long de la 3e direction). Si l'on choisissait `rank: 3` (le maximum), **tout** serait explique et le residu serait nul : la detection deviendrait impossible. Le rang contrôle donc la **sensibilite** du detecteur (cf. [Exercice 1](#Exercice-1-:-Effet-du-rang-PCA-sur-l'AUC)). **C'est un piege frequent** : le rang par defaut est 20, qui planterait ici avec seulement 3 features.\n",
+    "> **Pourquoi `rank: 2` ?** Avec 3 features, la PCA de rang 2 projette les données sur un **plan** ; le score d'anomalie est la composante **hors-plan** (le residu le long de la 3e direction). Si l'on choisissait `rank: 3` (le maximum), **tout** serait explique et le residu serait nul : la detection deviendrait impossible. Le rang contrôle donc la **sensibilite** du detecteur (cf. [Exercice 1](#exercice-1-rang-pca-auc)). **C'est un piege frequent** : le rang par defaut est 20, qui planterait ici avec seulement 3 features.\n",
     "\n",
     "Nos données sont déjà **recentrees sur l'origine** (ecarts au point nominal) : la PCA passe donc par le centroid, condition essentielle pour que le residu reflete bien l'ecart au regime normal."
    ]
@@ -500,7 +500,7 @@
     "- `Score` : le residu de reconstruction PCA (plus eleve = plus anomalous),\n",
     "- `PredictedLabel` : un booléen, `true` si `Score` depasse un seuil **calibre pendant le Fit** (par defaut, le trainer suppose ~10 % de contamination).\n",
     "\n",
-    "> **Avertissement sur le seuil par defaut.** Le seuil embarque est calibre sur une hypothese de contamination (~10 %). Si votre jeu d'entrainement est **integrallement normal** (ce qui est l'ideal), ce seuil est trop bas : le modèle flagge les ~10 % de normaux les plus extremes. C'est pourquoi l'[Exercice 2](#Exercice-2-:-Accorder-le-seuil-a-un-cout-operationnel) vous fera tuner ce seuil vous-même — le `Score`, lui, est fiable."
+    "> **Avertissement sur le seuil par defaut.** Le seuil embarque est calibre sur une hypothese de contamination (~10 %). Si votre jeu d'entrainement est **integrallement normal** (ce qui est l'ideal), ce seuil est trop bas : le modèle flagge les ~10 % de normaux les plus extremes. C'est pourquoi l'[Exercice 2](#exercice-2-seuil-cout) vous fera tuner ce seuil vous-même — le `Score`, lui, est fiable."
    ]
   },
   {
@@ -572,7 +572,7 @@
     "\n",
     "Le cas ci-dessus (pic de pression a **8 ecarts-types**) est **unidimensionnel** : un simple seuil sur `Pressure` seul le detecte, et la PCA n'apporte rien de plus (son AUC de 0,85 est même *inferieure* a ce que donnerait un seuil direct sur la pression). Ou la detection d'anomalies par PCA **brille-t-elle vraiment** ?\n",
     "\n",
-    "Sur des anomalies **multivariees subtiles** : des points ou **chaque capteur pris isolement est dans la norme**, mais dont la **combinaison** est anormale. Aucun seuil par capteur isole ne les voit ; seul le residu hors-sous-espace de la PCA les isole. C'est précisément la capacite distinctive que la demo principale (et l'[Exercice 3](#Exercice-3-:-Anomalies-subtiles-(limite-de-l'approche-PCA))) ne montrait pas — l'Exercice 3 explorait seulement des **decalages moyens reduits**, qui restent unidimensionnels.\n",
+    "Sur des anomalies **multivariees subtiles** : des points ou **chaque capteur pris isolement est dans la norme**, mais dont la **combinaison** est anormale. Aucun seuil par capteur isole ne les voit ; seul le residu hors-sous-espace de la PCA les isole. C'est précisément la capacite distinctive que la demo principale (et l'[Exercice 3](#exercice-3-anomalies-subtiles)) ne montrait pas — l'Exercice 3 explorait seulement des **decalages moyens reduits**, qui restent unidimensionnels.\n",
     "\n",
     "On reconstruit un jeu ou les trois capteurs sont **physiquement couples** en regime sain : la vibration du palier reflete a la fois la temperature et la pression, `Vibration = 0,4 * Temperature + 0,5 * Pressure`. Les points sains vivent donc sur un **plan 2D** dans l'espace 3D des capteurs ; la troisieme direction (orthogonale au plan) a une **variance quasi nulle** — c'est elle que la PCA de rang 2 laisse de cote. Les **anomalies violent ce couplage** : `Temperature` et `Pressure` restent dans leurs gammes normales, mais la `Vibration` s'ecarte de la relation predite. Ces points sortent du plan sain -> residu eleve."
    ]
@@ -720,7 +720,7 @@
     "\n",
     "**Chaque capteur isole est a peu pres au hasard** (~0,5-0,6), parce que les anomalies ont ete construites avec les *mêmes distributions marginales* que le regime sain. Pourtant la PCA atteint ~0,95 : elle a appris le **plan de couplage** sain, et les points qui le violent sortent du plan (residu eleve le long de la 3e composante). C'est la capacite que **aucune méthode univariee ne peut reproduire** : la detection d'anomalies par PCA est un detecteur de **structure multivariee**, pas de seuils par capteur.\n",
     "\n",
-    "**Contraste avec la demo principale** : sur le pic de pression a 8 sigma, la PCA etait superflue (un seuil sur `Pressure` suffisait, et battait même la PCA). Ici, la PCA est le **seul** outil qui marche. Les deux cas ensemble montrent *quand* la PCA est justifiee : non pas sur des pics unidimensionnels qu'un seuil capte, mais sur des anomalies relationnelles que seule la geometrie du sous-espace revelle. C'est le cœur de la [Lakhina et al. (2004)](#References) — detecter les anomalies qui resident dans le sous-espace residual, invisibles feature par feature."
+    "**Contraste avec la demo principale** : sur le pic de pression a 8 sigma, la PCA etait superflue (un seuil sur `Pressure` suffisait, et battait même la PCA). Ici, la PCA est le **seul** outil qui marche. Les deux cas ensemble montrent *quand* la PCA est justifiee : non pas sur des pics unidimensionnels qu'un seuil capte, mais sur des anomalies relationnelles que seule la geometrie du sous-espace revelle. C'est le cœur de la [Lakhina et al. (2004)](#references) — detecter les anomalies qui resident dans le sous-espace residual, invisibles feature par feature."
    ]
   },
   {
@@ -904,7 +904,7 @@
     "| 0,21 | 0,12 | 0,05 | 0,45 | FPR < 5 %, mais on rate 88 % des anomalies |\n",
     "| 0,46 | 0,03 | 0,00 | 1,00 | précis mais quasi inutile (3 % de detection) |\n",
     "\n",
-    "Le seuil **0,10** est un point de fonctionnement raisonnable : on detecte 93 % des anomalies pour 23 % de fausses alarmes. Si le metier exige `FPR <= 5 %`, il faut monter a ~0,21 — mais on accepte alors de rater la plupart des anomalies. Ce compromis n'a pas de reponse universelle : il depend du **cout relatif** d'une casse ratee (très eleve en maintenance predictive) face au cout d'une intervention inutile. L'[Exercice 2](#Exercice-2-:-Accorder-le-seuil-a-un-cout-operationnel) formalise cette accord sur une contrainte `TPR >= 0,95`."
+    "Le seuil **0,10** est un point de fonctionnement raisonnable : on detecte 93 % des anomalies pour 23 % de fausses alarmes. Si le metier exige `FPR <= 5 %`, il faut monter a ~0,21 — mais on accepte alors de rater la plupart des anomalies. Ce compromis n'a pas de reponse universelle : il depend du **cout relatif** d'une casse ratee (très eleve en maintenance predictive) face au cout d'une intervention inutile. L'[Exercice 2](#exercice-2-seuil-cout) formalise cette accord sur une contrainte `TPR >= 0,95`."
    ]
   },
   {
@@ -912,7 +912,7 @@
    "id": "ml9-md-27",
    "metadata": {},
    "source": [
-    "## Exercice 1 : Effet du rang PCA sur l'AUC\n",
+    "## Exercice 1 : Effet du rang PCA sur l'AUC\n<a id=\"exercice-1-rang-pca-auc\"></a>\n",
     "\n",
     "Le rang de la PCA contrôle la **sensibilite** du detecteur. Avec 3 features :\n",
     "\n",
@@ -966,7 +966,7 @@
    "id": "ml9-md-29",
    "metadata": {},
    "source": [
-    "## Exercice 2 : Accorder le seuil a un cout operationnel\n",
+    "## Exercice 2 : Accorder le seuil a un cout operationnel\n<a id=\"exercice-2-seuil-cout\"></a>\n",
     "\n",
     "On veut un detecteur qui **rate au plus 5 % des anomalies** (TPR >= 0.95) tout en **minimisant les fausses alarmes**. Le sweep ci-dessus est trop grossier (10 seuils reguliers).\n",
     "\n",
@@ -1015,7 +1015,7 @@
    "id": "ml9-md-31",
    "metadata": {},
    "source": [
-    "## Exercice 3 : Anomalies subtiles (limite de l'approche PCA)\n",
+    "## Exercice 3 : Anomalies subtiles (limite de l'approche PCA)\n<a id=\"exercice-3-anomalies-subtiles\"></a>\n",
     "\n",
     "Les anomalies actuelles sont decalees de ~3 ecarts-types : faciles a detecter. Que se passe-t-il avec des anomalies **subtiles** (~1.5 sigma), qui se rapprochent du regime normal ?\n",
     "\n",
@@ -1091,7 +1091,7 @@
    "id": "ml9-md-34",
    "metadata": {},
    "source": [
-    "## References\n",
+    "## References\n<a id=\"references\"></a>\n",
     "\n",
     "**Algorithme (PCA pour la detection d'anomalies)**\n",
     "\n",


### PR DESCRIPTION
## Summary

Both `ML-9-Anomaly-Detection` notebooks (C# + Python twins) had **hand-written intra-notebook anchors** to exercises that did not match GitHub/Jupyter auto-slug generation (colons, capital letters, apostrophes, parentheses) — all 404'd on click.

| Notebook | Broken links | Targets |
|----------|--------------|---------|
| ML-9-Anomaly-Detection (C#) | 5 | Exercice 1, 2, 3 + References |
| ML-9-Anomaly-Detection-Python | 2 | Exercice 1, 2 |
| **Total** | **7** | |

Examples of the broken hand-written slugs: `#Exercice-3-:-Anomalies-subtiles-(limite-de-l'approche-PCA)`, `#References` (capital R vs auto-slug `references`).

## Fix (slug-ambiguity-proof)

Explicit HTML `<a id="..."></a>` anchors after each referenced heading + repoint links (proven pattern from Lean-1-Setup, already used in #7247). Deterministic across GitHub/Jupyter/nbconvert renderers — no dependency on slugger colon/case/apostrophe rules.

**Minimal-diff discipline (G.9):** only anchors that resolve an existing broken link are added. The Python Exercice 3 heading has no inbound link in the Python twin → no anchor added there (avoids dead markup). The C# twin links to all 4 targets → 4 anchors.

## Forensic verification (firsthand)

- **byte-safety**: C# 15/15 + Python 12/12 code cells byte-identical vs `origin/main` (source + outputs + execution_count). Markdown-only changes.
- **H.3**: 0 `execution_count: null` on both.
- `python scripts/check_docs_links.py --check` → **OK (0 broken, 4023 total)**.
- **local calibrated re-scan** (explicit-anchor-aware, the c.621/c.626 calibrated scanner) → **0 broken anchors on both notebooks**.

## Context — systemic defect class (coordinated cluster)

Same systemic defect as ML-8 (#7247, merged c.621): hand-written TOC anchors from the **three-exercises rollout (#2161)** mismatch GitHub auto-slugs. This PR closes the **ML-9 twin cluster** identified by po-2025's calibrated repo-wide scan (c.626 handoff). MGS-17-ParameterControl (Search, 1 anchor) is the remaining known instance — flagged for its owner.

This is a **coordinated handoff** (po-2025 c.626 identified ML-9 as po-2023's calibrated turf), not auto-pick — I discovered and calibrated this defect class (c.621) and the explicit-anchor fix pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
