### PR TITLE
feat(ict,#7258): Couche 2 MDL frontier (Levin/PowerPlay/Speed Prior) + 11 tests

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/beauty.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/beauty.py
@@ -80,6 +80,7 @@ Dependances : ``compression`` (``compressed_length``, ``canonical_int_sequence``
 
 from __future__ import annotations
 
+import math
 from typing import List, Optional, Sequence, Tuple
 
 import numpy as np
@@ -365,3 +366,245 @@ def diagnose(
     steps_k, K = local_compressibility(states, window=window, level=level)
     rep["fold"] = fold_in_compressibility_curve(steps_k, K, smooth=smooth)
     return rep
+
+
+# =========================================================================== #
+#  COUCHE 2 -- Frontiere MDL : Levin / PowerPlay / Speed Prior                 #
+#  (formalisation du compression-progress de Schmidhuber, See #7258)           #
+# =========================================================================== #
+#
+# La couche 1 operationnalise la beaute de Schmidhuber (saut de compressibilite
+# = compression-progress) de facun EMPIRIQUE : zlib sur une fenetre glissante,
+# controle iid apparie. La couche 2 en donne la formalisation MDL : la
+# *frontiere* de description d'une trajectoire a mesure qu'elle s'etend, et sa
+# derivee (compression-progress en code en deux parties). Elle ajoute aussi les
+# deux machineries de Schmidhuber qui cadrent cette frontiere :
+#
+#   - la **complexite de Levin** ``Kt = program_bits + log2(runtime)`` et la
+#     **Speed Prior** ``2^{-Kt}`` (Schmidhuber 2000) : un programme court mais
+#     lent coute plus a *trouver* qu'un programme legerement plus long mais
+#     rapide -- le cout universel de la recherche ;
+#   - la frontiere **PowerPlay** (Schmidhuber 2011) : l'agent ne garde une
+#     nouvelle theorie que si elle resout toutes les taches precedentes **et**
+#     au moins une nouvelle -- compression-progress monotone, sans abandon.
+#
+# La derivee de la frontiere PowerPlay EST le compression-progress : la beaute
+# de la couche 1, formalisee en MDL plutot qu'estimee par zlib.
+#
+# Caveat honnete (cf comments de l'issue #7258) : appliquee a la *string de
+# predictions* d'un reseau en phase de grokking, la frontiere MDL localise la
+# MEMORISATION, pas le grok -- la MDL de la string recompense la structure
+# Markovienne parcimonieuse qu'engendre la memorisation (table lookup). Sur une
+# transition de structure veritable (bruit iid -> cycle deterministe), en
+# revanche, le cycle est nettement moins couteux par symbole que le bruit
+# (gate B4 du test). Le notebook strand confronte honnetement cette limite sur
+# le grokking et explore la description length *des poids* (information de
+# Fisher) comme proxy K-modele.
+# =========================================================================== #
+
+
+def levin_complexity(program_bits: float, runtime_steps: float) -> float:
+    """Complexite de Levin ``Kt = program_bits + log2(runtime_steps)``.
+
+    Cout universel de *trouver* un programme par recherche de Levin (Levin
+    1973) : on somme la longueur du programme (simplicite) et le logarithme
+    du nombre de pas d'execution (rapidite). Un programme court mais lent
+    coute plus a decouvrir qu'un programme legerement plus long mais rapide.
+    C'est la fonction de cout sous-jacente a la **Speed Prior** de Schmidhuber
+    (2000), qui pondere chaque programme par ``2^{-Kt}`` (cf
+    ``speed_prior_weight``).
+
+    Parametres :
+      - ``program_bits`` : longueur de description du programme (>= 0).
+      - ``runtime_steps`` : nombre de pas d'execution (>= 1).
+
+    Retourne ``Kt`` en bits (log base 2).
+    """
+    if program_bits < 0:
+        raise ValueError(f"program_bits doit etre >= 0, recu {program_bits}")
+    if runtime_steps < 1:
+        raise ValueError(
+            f"runtime_steps doit etre >= 1, recu {runtime_steps}"
+        )
+    return float(program_bits) + math.log2(float(runtime_steps))
+
+
+def speed_prior_weight(program_bits: float, runtime_steps: float) -> float:
+    """Poids **Speed Prior** de Schmidhuber : ``2^{-Kt}`` avec ``Kt`` de Levin.
+
+    Probabilite a priori qu'un programme tire selon la Speed Prior soit ce
+    programme-ci : decroit exponentiellement avec la complexite de Levin
+    (longueur + log temps). Les programmes courts et rapides dominent. Cette
+    ponderation est le prior naturel sous lequel l'agent cherche le prochain
+    saut de compression (la frontiere PowerPlay).
+    """
+    return 2.0 ** (-levin_complexity(program_bits, runtime_steps))
+
+
+def powerplay_frontier(theories: Sequence) -> dict:
+    """Frontiere **PowerPlay** de Schmidhuber (2011) : compression-progress monotone.
+
+    PowerPlay est un agent qui ne garde une nouvelle theorie que si elle resout
+    **toutes** les taches deja resolues par la theorie courante **et** au moins
+    une tache nouvelle -- le progres de compression est monotone (aucune tache
+    abandonee). La *frontiere* est la suite des theories acceptees : elle
+    avance dans le plan (longueur de programme ``K``, nombre cumul de taches
+    resolues), et sa derivee **est** le compression-progress (la beaute de la
+    couche 1, ici formalisee en MDL plutot qu'estimee par zlib).
+
+    Version stricte (sans abandon de tache) : un candidat qui lache une tache
+    deja resolue est rejete, mene s'il en resout de nouvelles. L'extension
+    PowerPlay generale (abandon tolerate si le net de compression est positif)
+    est laisse au notebook.
+
+    Parametres :
+      - ``theories`` : sequence de couples ``(program_bits, solved)`` ou
+        ``solved`` est un ensemble (ou iterable) de labels de taches resolues,
+        dans l'ordre ou l'agent les rencontre.
+
+    Retourne ``{"frontier": [...], "rejected": [...], "total_accepted": int}``
+    ou chaque entree acceptee contient ``index, program_bits,
+    cumulative_solved, new`` et chaque rejet ``index, program_bits, reason``
+    (``"no_new"`` = aucune tache nouvelle ; ``"dropped_existing"`` = une tache
+    deja resolue est perdue).
+    """
+    accepted: List[dict] = []
+    rejected: List[dict] = []
+    cumulative: frozenset = frozenset()
+    for idx, entry in enumerate(theories):
+        kbits, solved = entry
+        solved_fs = frozenset(solved)
+        grows = len(solved_fs) > len(cumulative)
+        keeps_all = cumulative <= solved_fs
+        if grows and keeps_all:
+            accepted.append({
+                "index": int(idx),
+                "program_bits": float(kbits),
+                "cumulative_solved": len(solved_fs),
+                "new": len(solved_fs) - len(cumulative),
+            })
+            cumulative = solved_fs
+        else:
+            reason = "dropped_existing" if not keeps_all else "no_new"
+            rejected.append({
+                "index": int(idx),
+                "program_bits": float(kbits),
+                "reason": reason,
+            })
+    return {"frontier": accepted, "rejected": rejected,
+            "total_accepted": len(accepted)}
+
+
+def mdl_frontier(states: Sequence,
+                 prefix_schedule: Optional[Sequence[int]] = None,
+                 split: float = 0.5, n_points: int = 10) -> dict:
+    """Courbe MDL (``two_part_code``) sur des prefixes croissants de la trajectoire.
+
+    Pour chaque longueur de prefix ``L``, estime le code en deux parties
+    (``ict.mdl.two_part_code``) sur ``states[:L]`` : ``model_bits`` (TPM sous
+    prior KT) + ``residual_bits`` (-log2 proba held-out) = ``total_bits``.
+    C'est l'analogue MDL-formel de ``local_compressibility`` (couche 1 zlib) :
+    la frontiere de description de la trajectoire a mesure qu'elle s'etend. Sa
+    derivee (``mdl_compression_progress``) = compression-progress en termes de
+    code en deux parties.
+
+    **Caveat honnete (cf comments #7258)** : appliquee a la *string de
+    predictions* d'un reseau en phase de grokking, cette frontiere localise la
+    memorisation, pas le grok -- la MDL de la string recompense la structure
+    Markovienne parcimonieuse qu'engendre la memorisation. Sur une transition
+    de structure veritable (bruit iid -> cycle deterministe), en revanche, le
+    cycle est nettement moins couteux par symbole que le bruit (gate B4 du
+    test) : la machinerie est correcte, c'est son application naive au grokking
+    qui est piegeuse.
+
+    Parametres :
+      - ``states`` : trajectoire d'etats.
+      - ``prefix_schedule`` : longueurs de prefix a evaluer (defaut :
+        ``n_points`` points echantillonnes entre ~10% et 100% de la
+        trajectoire).
+      - ``split`` : proportion train/held-out pour ``two_part_code``
+        (defaut 0.5).
+      - ``n_points`` : nombre de points si ``prefix_schedule`` est None.
+
+    Retourne ``{"rows": [...]}`` ou chaque row contient ``L, model_bits,
+    residual_bits, total_bits, bits_per_symbol``.
+    """
+    from . import mdl as MDL
+
+    seq = list(states)
+    n = len(seq)
+    if n < 2:
+        raise ValueError(f"il faut au moins 2 etats, recu n={n}")
+    if prefix_schedule is None:
+        lo = max(2, int(round(0.1 * n)))
+        if n <= lo:
+            prefix_schedule = [n]
+        else:
+            grid = {int(round(lo + (n - lo) * i / max(n_points - 1, 1)))
+                    for i in range(n_points)}
+            prefix_schedule = sorted(p for p in grid if 2 <= p <= n)
+    rows: List[dict] = []
+    for L in prefix_schedule:
+        L = int(L)
+        if L < 2 or L > n:
+            continue
+        try:
+            r = MDL.two_part_code(seq[:L], split=split)
+        except ValueError:
+            continue
+        total = float(r["total_bits"])
+        rows.append({
+            "L": L,
+            "model_bits": float(r["model_bits"]),
+            "residual_bits": float(r["residual_bits"]),
+            "total_bits": total,
+            "bits_per_symbol": total / L,
+        })
+    return {"rows": rows}
+
+
+def mdl_compression_progress(states: Sequence,
+                             prefix_schedule: Optional[Sequence[int]] = None,
+                             split: float = 0.5, n_points: int = 10,
+                             horizon: int = 2) -> dict:
+    """Derivee de la frontiere MDL = compression-progress formel.
+
+    Calcule ``mdl_frontier`` puis, sur ``bits_per_symbol``,
+    ``delta[i] = bps[i-horizon] - bps[i]`` : positif quand le prefix recent se
+    decrit plus economiquement (progress de compression), negatif s'il devient
+    plus couteux. C'est l'analogue MDL de ``compressibility_gain_curve``
+    (couche 1) : la courbe porteuse de beaute, en code en deux parties plutot
+    qu'en zlib.
+
+    Pas de controle iid ici (contrairement a ``beauty_events``) : la frontiere
+    MDL est Deterministe sur une trajectoire fixee, et la quantification MDL
+    (TPM KT) est beaucoup moins bruitee que zlib -- on present le signal brut
+    a l'utilisateur du module ; le seuil/event-picking est laisse au notebook,
+    ou il se confronte au caveat grokking (comments #7258).
+
+    Retourne ``{"rows": [...], "max_progress": float, "argmax_L": int|None}``
+    ou chaque row contient ``L, bits_per_symbol, delta`` (``delta`` = ``nan``
+    pour les ``horizon`` premiers points).
+    """
+    front = mdl_frontier(states, prefix_schedule=prefix_schedule, split=split,
+                         n_points=n_points)
+    rows = front["rows"]
+    h = int(horizon)
+    if h < 1:
+        raise ValueError(f"horizon doit etre >= 1, recu {h}")
+    out: List[dict] = []
+    for i, r in enumerate(rows):
+        d = float("nan")
+        if i >= h:
+            d = float(rows[i - h]["bits_per_symbol"] - r["bits_per_symbol"])
+        out.append({
+            "L": r["L"],
+            "bits_per_symbol": r["bits_per_symbol"],
+            "delta": d,
+        })
+    finite = [(r["delta"], r["L"]) for r in out if np.isfinite(r["delta"])]
+    if finite:
+        max_d, arg_L = max(finite, key=lambda t: t[0])
+    else:
+        max_d, arg_L = float("nan"), None
+    return {"rows": out, "max_progress": float(max_d), "argmax_L": arg_L}

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_beauty.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_beauty.py
@@ -22,6 +22,7 @@ Numpy + pytest, comme les tests existants du package.
 
 import os
 import sys
+import math
 
 import numpy as np
 import pytest
@@ -187,3 +188,145 @@ def test_diagnose_couples_gate_and_fold():
                        rng=np.random.default_rng(1))
     assert "fold" in rep and "events" in rep
     assert set(rep["fold"]) >= {"fold_step", "curvature", "smooth"}
+
+
+# =========================================================================== #
+#  Couche 2 -- Frontiere MDL (Levin / PowerPlay / Speed Prior), See #7258      #
+# =========================================================================== #
+#
+# La couche 2 formalise en MDL le compression-progress de Schmidhuber (la
+# beaute de la couche 1 etait empirique / zlib). Trois machineries :
+#
+#   - complexite de Levin ``Kt`` + Speed Prior ``2^{-Kt}`` (deterministe) ;
+#   - frontiere PowerPlay (compression-progress monotone, sans abandon) ;
+#   - frontiere MDL ``mdl_frontier`` + sa derivee ``mdl_compression_progress``
+#     (analogue MDL de ``compressibility_gain_curve``).
+#
+# Gate falsifiable centrale : **B4** -- sur une transition de structure
+# veritable (bruit iid -> cycle deterministe), le cycle est nettement moins
+# couteux par symbole que le bruit (la machinerie MDL detecte la structure).
+# Caveat honnete (cf comments #7258) : ce qui est VRAI pour une transition de
+# structure ne l'est PAS pour la string de predictions d'un reseau grokkant --
+# la MDL de la string recompense la memorisation. On test donc la machinerie
+# sur ce qu'elle mesure correctement, sans sur-claimer le grokking.
+
+
+# --------------------------------------------------------------------------- #
+#  Complexite de Levin + Speed Prior                                          #
+# --------------------------------------------------------------------------- #
+
+
+def test_levin_complexity_formula():
+    assert BTY.levin_complexity(10.0, 1024) == pytest.approx(
+        10.0 + math.log2(1024)
+    )
+    # programme de 0 bits s'executant en 1 pas -> Kt = 0
+    assert BTY.levin_complexity(0.0, 1) == pytest.approx(0.0)
+
+
+def test_levin_complexity_rejects_bad_inputs():
+    with pytest.raises(ValueError):
+        BTY.levin_complexity(-1.0, 10)
+    with pytest.raises(ValueError):
+        BTY.levin_complexity(10.0, 0)
+
+
+def test_speed_prior_weight_is_2pow_minus_kt_and_decreases():
+    kt = BTY.levin_complexity(8.0, 16.0)
+    w = BTY.speed_prior_weight(8.0, 16.0)
+    assert w == pytest.approx(2.0 ** (-kt))
+    # un programme plus long ou plus lent est moins probable sous Speed Prior
+    assert w > BTY.speed_prior_weight(10.0, 16.0)
+    assert w > BTY.speed_prior_weight(8.0, 256.0)
+
+
+# --------------------------------------------------------------------------- #
+#  Frontiere PowerPlay                                                        #
+# --------------------------------------------------------------------------- #
+
+
+def test_powerplay_frontier_accepts_monotonic_growth():
+    # chaque theorie resout tout ce que la precedente resolait + une nouvelle
+    theories = [(100, {"A"}), (90, {"A", "B"}), (85, {"A", "B", "C"})]
+    rep = BTY.powerplay_frontier(theories)
+    assert rep["total_accepted"] == 3
+    assert rep["rejected"] == []
+    # cumulative_solved croit de 1 en 1
+    assert [f["cumulative_solved"] for f in rep["frontier"]] == [1, 2, 3]
+    assert [f["new"] for f in rep["frontier"]] == [1, 1, 1]
+
+
+def test_powerplay_frontier_rejects_dropped_task():
+    # la 2e theorie perd la tache B -> rejetee (strict, sans abandon)
+    theories = [(100, {"A", "B"}), (50, {"A"})]
+    rep = BTY.powerplay_frontier(theories)
+    assert rep["total_accepted"] == 1
+    assert rep["rejected"][0]["index"] == 1
+    assert rep["rejected"][0]["reason"] == "dropped_existing"
+
+
+def test_powerplay_frontier_rejects_no_new_task():
+    # la 2e theorie resout exactement la meme chose -> rejetee (pas de progres)
+    theories = [(100, {"A"}), (90, {"A"})]
+    rep = BTY.powerplay_frontier(theories)
+    assert rep["total_accepted"] == 1
+    assert rep["rejected"][0]["reason"] == "no_new"
+
+
+# --------------------------------------------------------------------------- #
+#  Frontiere MDL + compression-progress                                       #
+# --------------------------------------------------------------------------- #
+
+
+def test_mdl_frontier_returns_rows_with_keys():
+    seq = [i % 4 for i in range(200)]
+    rep = BTY.mdl_frontier(seq, n_points=5)
+    assert "rows" in rep and len(rep["rows"]) >= 1
+    r0 = rep["rows"][0]
+    assert set(r0) >= {"L", "model_bits", "residual_bits",
+                       "total_bits", "bits_per_symbol"}
+    assert r0["bits_per_symbol"] == pytest.approx(r0["total_bits"] / r0["L"])
+
+
+def test_mdl_frontier_rejects_short_sequence():
+    with pytest.raises(ValueError):
+        BTY.mdl_frontier([0])
+
+
+def test_b4_mdl_frontier_cycle_lower_bps_than_noise():
+    # Gate B4 (falsifiable) : la machinerie MDL detecte la structure -- un
+    # cycle deterministe est nettement moins couteux par symbole qu'un bruit
+    # iid. C'est l'analogue MDL de B1 (couche 1).
+    #
+    # Caveat grokking (cf comments #7258) : ce QUI EST VRAI pour une transition
+    # de structure ne l'est PAS pour la string de predictions d'un reseau
+    # grokkant (la MDL de la string recompense la memorisation). On test donc
+    # la machinerie sur ce qu'elle mesure correctement.
+    rng = np.random.default_rng(0)
+    noise = list(rng.integers(0, 4, size=400))
+    cycle = [i % 4 for i in range(400)]
+    fn = BTY.mdl_frontier(noise, n_points=5)["rows"]
+    fc = BTY.mdl_frontier(cycle, n_points=5)["rows"]
+    bps_noise = float(np.mean([r["bits_per_symbol"] for r in fn]))
+    bps_cycle = float(np.mean([r["bits_per_symbol"] for r in fc]))
+    assert bps_cycle < bps_noise, (
+        f"le cycle devrait etre moins couteux que le bruit, "
+        f"recu cycle={bps_cycle:.3f} noise={bps_noise:.3f}"
+    )
+
+
+def test_mdl_compression_progress_returns_delta_and_max():
+    rng = np.random.default_rng(1)
+    seq = list(rng.integers(0, 4, size=300)) + [i % 4 for i in range(300)]
+    rep = BTY.mdl_compression_progress(seq, n_points=8, horizon=2)
+    assert set(rep) >= {"rows", "max_progress", "argmax_L"}
+    deltas = [r["delta"] for r in rep["rows"]]
+    # les `horizon` premiers points sont nan, les suivants finis
+    assert np.isnan(deltas[0]) and np.isnan(deltas[1])
+    assert np.all(np.isfinite(deltas[2:]))
+    assert rep["argmax_L"] is not None
+
+
+def test_mdl_compression_progress_rejects_bad_horizon():
+    with pytest.raises(ValueError):
+        BTY.mdl_compression_progress([i % 4 for i in range(20)], horizon=0)


### PR DESCRIPTION
## Summary

**Couche 2 of the Schmidhuber K-strand** (Epic #4588, See #7258): the MDL-formal layer of `ict/beauty.py` that was missing. Couche 1 (PR #7257) operationalized Schmidhuber's compression-progress *empirically* (zlib on a sliding window, iid control). This PR adds the **MDL formalization** + the two Schmidhuber machineries that frame it.

### Correction (G.9 — my own prior inaccuracy)

A comment on #7258 stated *"Couche 2 module Levin/PowerPlay livrée (PR #7257, 21/21 tests)"*. **That was inaccurate.** #7257 delivered only Couche 1 (`beauty.py` 367 lines zlib beauty + `fold_in_compressibility_curve`, 13 tests — not 21). Verified firsthand: `git show --stat 0407eddbb` = 2 files / 556 insertions, and `beauty.py` contained no Levin/PowerPlay/Speed Prior code. **This PR actually delivers Couche 2.**

### What's added (additive to `ict/beauty.py`, +243 lines)

| Function | Role |
|---|---|
| `levin_complexity(program_bits, runtime_steps)` | Levin `Kt = bits + log2(runtime)` — the universal *search* cost (Levin 1973) |
| `speed_prior_weight(...)` | Schmidhuber Speed Prior weight `2^{-Kt}` (2000) |
| `powerplay_frontier(theories)` | PowerPlay acceptance curve — monotone compression-progress, strict no-task-drop (Schmidhuber 2011) |
| `mdl_frontier(states, ...)` | `two_part_code` curve over growing prefixes — MDL analog of `local_compressibility` |
| `mdl_compression_progress(...)` | derivative of the MDL frontier — MDL analog of `compressibility_gain_curve` (the "beauty" curve in two-part-code terms) |

### Honest caveat — the grokking application does NOT localize grok (per #7258 comments 2-3)

Applied to a grokking net's **prediction string**, `mdl_frontier` localizes **memorization** (step ~400), not the grok point (step ~3000): the string's Markov compressibility rewards the memorization lookup table — *string compressibility ≠ model algorithmic complexity*. This was established empirically in prior cycles (all 4 naive proxies fail: zlib string, MDL string, L2 weight norm, naive model-MDL).

**The machinery itself is correct** — gate **B4** verifies it on a *true* structure transition: a deterministic cycle is markedly cheaper per symbol than iid noise (`test_b4_mdl_frontier_cycle_lower_bps_than_noise`). The naive grokking application is the pitfall, not the tool. The strand notebook (next deliverable) confronts this honestly and tests the **Fisher-weighted MDL of weights** (Nanda progress measure) as the one untested proxy.

## Verification

- **24/24 beauty tests green** (13 Couche 1 regression + 11 Couche 2) in 1.11s.
- **Full ICT suite: 445 passed, 2 skipped** (79.7s) — no regression, no import cycle.
- GPU-free: numpy + pytest only.
- New falsifiable gate **B4** (MDL detects structure: cycle `bps` < noise `bps`, robust margin).

## Scope — partial

This PR delivers **Piece 1 only** (the Couche 2 module + tests, an explicit #7258 acceptance item). The **strand notebook** (Piece 2 — grokking CPU demo + Fisher experiment + honest verdict) is genuine research (comment 2: *"un travail de recherche focalisé, pas une démo mécanique"*); it is built next, carefully, not rushed. Track GPU-2 (Piece 3) stays routed to the GPU lane.

See #7258 (partial — module only) · See #4588

🤖 Generated with [Claude Code](https://claude.com/claude-code)
