### PR TITLE
fix(#2876): restore French accents in CaseStudies+IIT residual markdown (51 cures, 3 notebooks)

### DIFF
--- a/MyIA.AI.Notebooks/CaseStudies/Oncology-Planning/solution/Oncology-Planning.ipynb
+++ b/MyIA.AI.Notebooks/CaseStudies/Oncology-Planning/solution/Oncology-Planning.ipynb
@@ -382,9 +382,9 @@
     "**Indices** :\n",
     "- # Indice 1 : Ajoutez \"Paclitaxel\" (toxicite_renale=False, incompatible avec \"Docetaxel\") et \"Carboplatine\" (toxicite_renale=True, incompatible avec \"Cisplatine\")\n",
     "- # Indice 2 : Verifiez qu'un protocole [\"Cisplatine\", \"Carboplatine\"] declenche bien une alerte d'incompatibilite\n",
-    "- # Etape 1 : Ajouter les nouveaux medicaments au dictionnaire `medicaments`\n",
-    "- # Etape 2 : Peupler le graphe RDF avec les nouveaux triplets\n",
-    "- # Etape 3 : Tester la fonction `verifier_prescription` avec des combinaisons incluant les nouveaux medicaments"
+    "- # Étape 1 : Ajouter les nouveaux medicaments au dictionnaire `medicaments`\n",
+    "- # Étape 2 : Peupler le graphe RDF avec les nouveaux triplets\n",
+    "- # Étape 3 : Tester la fonction `verifier_prescription` avec des combinaisons incluant les nouveaux medicaments"
    ]
   },
   {
@@ -575,18 +575,18 @@
     "tags": []
    },
    "source": [
-    "### Exercice 2 : Sensibilite du modele bayesien au prior sur le profil patient\n",
+    "### Exercice 2 : Sensibilite du modèle bayesien au prior sur le profil patient\n",
     "\n",
     "**Objectif** : Etudier comment le choix du prior sur les profils (Resistant/Normal/Sensible) influence le diagnostic posterieur.\n",
     "\n",
-    "**Contexte** : Le prior actuel est `[0.1, 0.6, 0.3]` (10% Resistants, 60% Normaux, 30% Sensibles). Si la population est differente, le diagnostic change.\n",
+    "**Contexte** : Le prior actuel est `[0.1, 0.6, 0.3]` (10% Resistants, 60% Normaux, 30% Sensibles). Si la population est différente, le diagnostic change.\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice 1 : Modifiez `profil_probs` dans la methode `model()` pour tester : `[0.33, 0.34, 0.33]` (uniforme), `[0.05, 0.90, 0.05]` (peu de sensibles)\n",
+    "- # Indice 1 : Modifiez `profil_probs` dans la méthode `model()` pour tester : `[0.33, 0.34, 0.33]` (uniforme), `[0.05, 0.90, 0.05]` (peu de sensibles)\n",
     "- # Indice 2 : Relancez l'inference SVI et comparez les probabilites a posteriori du profil\n",
-    "- # Etape 1 : Creer une fonction qui accepte le prior en parametre\n",
-    "- # Etape 2 : Tester 3 configurations de prior differentes\n",
-    "- # Etape 3 : Afficher les posterieurs dans un tableau comparatif"
+    "- # Étape 1 : Créer une fonction qui accepte le prior en paramètre\n",
+    "- # Étape 2 : Tester 3 configurations de prior différentes\n",
+    "- # Étape 3 : Afficher les posterieurs dans un tableau comparatif"
    ]
   },
   {
@@ -833,14 +833,14 @@
     "\n",
     "**Objectif** : Etendre la classe `OncoContract` pour maintenir un historique des modifications et detecter les tentatives de fraude.\n",
     "\n",
-    "**Contexte** : Le contrat actuel enregistre un seul plan. En pratique, les plans peuvent etre modifies plusieurs fois, et il faut tracer qui a fait quoi et quand.\n",
+    "**Contexte** : Le contrat actuel enregistre un seul plan. En pratique, les plans peuvent etre modifiés plusieurs fois, et il faut tracer qui a fait quoi et quand.\n",
     "\n",
     "**Indices** :\n",
     "- # Indice 1 : Ajoutez un attribut `self.historique = []` qui stocke chaque modification\n",
     "- # Indice 2 : Chaque entree du journal doit contenir : horodatage, auteur, action, hash du plan\n",
-    "- # Etape 1 : Ajouter l'attribut `historique` et le mettre a jour a chaque appel de `enregistrer_plan`\n",
-    "- # Etape 2 : Implementer une methode `afficher_historique()` qui affiche le journal\n",
-    "- # Etape 3 : Tester en modifiant le plan plusieurs fois et verifier que l'historique est complet"
+    "- # Étape 1 : Ajouter l'attribut `historique` et le mettre a jour a chaque appel de `enregistrer_plan`\n",
+    "- # Étape 2 : Implementer une méthode `afficher_historique()` qui affiche le journal\n",
+    "- # Étape 3 : Tester en modifiant le plan plusieurs fois et verifier que l'historique est complet"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/CaseStudies/SmartGrid-Energy/student/SmartGrid-Energy.ipynb
+++ b/MyIA.AI.Notebooks/CaseStudies/SmartGrid-Energy/student/SmartGrid-Energy.ipynb
@@ -7,8 +7,8 @@
    "source": [
     "# CC3 : SmartGrid - Ordonnancement de la production energetique sous incertitude\n",
     "\n",
-    "**Etude de cas interdisciplinaire** combinant programmation par contraintes (OR-Tools CP-SAT),\n",
-    "inference probabiliste (modele bayesien), optimisation multi-objectif et un jumeau numerique\n",
+    "**Étude de cas interdisciplinaire** combinant programmation par contraintes (OR-Tools CP-SAT),\n",
+    "inference probabiliste (modèle bayesien), optimisation multi-objectif et un jumeau numérique\n",
     "de reseau electrique.\n"
    ]
   },
@@ -19,9 +19,9 @@
    "source": [
     "## Contexte metier\n",
     "\n",
-    "Un operateur de reseau electrique doit, pour chaque heure, decider quelles centrales activer\n",
+    "Un opérateur de reseau electrique doit, pour chaque heure, decider quelles centrales activer\n",
     "et a quel niveau de production (le *unit commitment* / dispatch) afin de satisfaire la demande\n",
-    "tout en minimisant le cout economique et les emissions de CO2. Ce probleme est rendu difficile\n",
+    "tout en minimisant le cout economique et les emissions de CO2. Ce problème est rendu difficile\n",
     "par :\n",
     "\n",
     "- **l'incertitude** sur la production renouvelable (eolien, solaire) et sur la demande ;\n",
@@ -29,8 +29,8 @@
     "  reserve tournante (securite n-1) ;\n",
     "- **les objectifs multiples conflictuels** : cout, emissions, fiabilite.\n",
     "\n",
-    "Une seule technique ne suffit pas : un solveur deterministe ignore l'incertitude, un modele\n",
-    "probabiliste seul ne respecte pas les contraintes physiques. Cette etude de cas materialise\n",
+    "Une seule technique ne suffit pas : un solveur déterministe ignore l'incertitude, un modèle\n",
+    "probabiliste seul ne respecte pas les contraintes physiques. Cette étude de cas materialise\n",
     "leur **composition ordonnee** : filtrer les dispatches impossibles (contraintes), modeliser\n",
     "l'aleatoire (incertitude), puis optimiser (multi-objectif).\n"
    ]
@@ -42,14 +42,14 @@
    "source": [
     "## Architecture en 4 couches\n",
     "\n",
-    "| Couche | Role | Technique | Partie |\n",
+    "| Couche | Rôle | Technique | Partie |\n",
     "|--------|------|-----------|--------|\n",
     "| **Contraintes dures** | Filtrer les dispatches impossibles | OR-Tools CP-SAT | Partie 1 |\n",
-    "| **Incertitude** | Modeliser l'aleatoire renouvelable | Modele bayesien | Partie 2 |\n",
+    "| **Incertitude** | Modeliser l'aleatoire renouvelable | Modèle bayesien | Partie 2 |\n",
     "| **Optimisation** | Choisir le meilleur compromis | Multi-objectif pondere | Partie 3 |\n",
     "| **Decision** | Synthese + comparaison | Workflow + scoring | Partie 4 |\n",
     "\n",
-    "Ce notebook est une **fondation** : le jumeau numerique (couche 0) est operationnel ; les\n",
+    "Ce notebook est une **fondation** : le jumeau numérique (couche 0) est operationnel ; les\n",
     "implementations des 4 couches seront completees et executees dans les cycles suivants.\n"
    ]
   },
@@ -58,9 +58,9 @@
    "id": "c3",
    "metadata": {},
    "source": [
-    "## 0. Installation et jumeau numerique\n",
+    "## 0. Installation et jumeau numérique\n",
     "\n",
-    "Le jumeau numerique represente un reseau electrique : un ensemble de centrales (avec cout,\n",
+    "Le jumeau numérique represente un reseau electrique : un ensemble de centrales (avec cout,\n",
     "capacites, facteur d'emission) et une demande horaire a satisfaire, avec une production\n",
     "renouvelable stochastique.\n"
    ]
@@ -157,7 +157,7 @@
    "source": [
     "## Partie 1 : Le Dispatcher sous Contraintes (OR-Tools CP-SAT)\n",
     "\n",
-    "**Theorie** : le *unit commitment* est un probleme NP-difficile. On modelise, pour chaque\n",
+    "**Théorie** : le *unit commitment* est un problème NP-difficile. On modelise, pour chaque\n",
     "heure et chaque centrale pilotable, une variable binaire (activee) et une variable continue\n",
     "(niveau de production), soumises aux contraintes :\n",
     "\n",
@@ -212,7 +212,7 @@
    "source": [
     "### Exercice 1 : Reserve tournante (securite n-1)\n",
     "\n",
-    "Ajoutez au modele CP-SAT une contrainte de **reserve tournante** : a chaque heure, la somme\n",
+    "Ajoutez au modèle CP-SAT une contrainte de **reserve tournante** : a chaque heure, la somme\n",
     "des capacites disponibles (non utilisees) des centrales activees doit couvrir la perte de la\n",
     "plus grande centrale en service (critere n-1).\n",
     "\n",
@@ -246,9 +246,9 @@
    "id": "c9",
    "metadata": {},
    "source": [
-    "## Partie 2 : Le Previsionniste Probabiliste (modele bayesien)\n",
+    "## Partie 2 : Le Previsionniste Probabiliste (modèle bayesien)\n",
     "\n",
-    "**Theorie** : la production renouvelable est aleatoire. On modelise l'ecart\n",
+    "**Théorie** : la production renouvelable est aleatoire. On modelise l'ecart\n",
     "`demande - renouvelable` comme une variable aleatoire et on infere sa distribution, pour\n",
     "quantifier le **risque de defaillance** (probabilite que la demande nette depasse la capacite\n",
     "pilotable disponible).\n"
@@ -339,9 +339,9 @@
    "source": [
     "## Partie 3 : L'Optimiseur Multi-Objectif\n",
     "\n",
-    "**Theorie** : on veut minimiser simultanement le **cout** economique, les **emissions** CO2\n",
+    "**Théorie** : on veut minimiser simultanement le **cout** economique, les **emissions** CO2\n",
     "et le **risque** de defaillance. Ces objectifs sont conflictuels (le charbon est bon marche\n",
-    "mais tres emissif). On construit un score pondere `S = a*cout + b*co2 + c*risque` et on\n",
+    "mais très emissif). On construit un score pondere `S = a*cout + b*co2 + c*risque` et on\n",
     "cherche le dispatch minimisant S, en explorant le front de Pareto.\n"
    ]
   },
@@ -393,7 +393,7 @@
    "source": [
     "### Exercice 3 : Ajouter un troisieme objectif (equite territoriale)\n",
     "\n",
-    "Ajoutez un troisieme objectif : **equite territoriale** (eviter qu'une meme region subisse\n",
+    "Ajoutez un troisieme objectif : **equite territoriale** (eviter qu'une même region subisse\n",
     "toutes les centrales les plus polluantes). Supposons que chaque centrale a un attribut\n",
     "`region`. Mesurez la concentration regionale de la pollution et ajoutez-la au score.\n"
    ]
@@ -426,7 +426,7 @@
    "source": [
     "## Partie 4 : Decision finale et analyse comparative\n",
     "\n",
-    "**Synthese** : on compare les strategies (CP-SAT pur, multi-objectif weighted-sum, front de\n",
+    "**Synthese** : on compare les stratégies (CP-SAT pur, multi-objectif weighted-sum, front de\n",
     "Pareto) sur les 3 axes cout/CO2/fiabilite + l'equite territoriale. Le tableau comparatif et\n",
     "le graphique radar seront produits une fois les Parties 1-3 executees.\n"
    ]
@@ -471,14 +471,14 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "Cette etude de cas illustre la **composition ordonnee** des paradigmes IA sur un probleme\n",
+    "Cette étude de cas illustre la **composition ordonnee** des paradigmes IA sur un problème\n",
     "metier reel (transition energetique) : on filtre les dispatches impossibles (CP-SAT) avant\n",
     "de modeliser l'incertitude (bayesien) avant d'optimiser (multi-objectif). Inverser l'ordre\n",
-    "produit un systeme soit trop rigide (contraintes ignorent l'aleatoire), soit trop flou\n",
+    "produit un système soit trop rigide (contraintes ignorent l'aleatoire), soit trop flou\n",
     "(decision sans contraintes physiques).\n",
     "\n",
-    "**Etat de la fondation** : jumeau numerique operationnel (couche 0), 4 couches de solveurs\n",
-    "modelisees en stub. Implementations + execution + analyse comparative : cycles suivants.\n"
+    "**Etat de la fondation** : jumeau numérique operationnel (couche 0), 4 couches de solveurs\n",
+    "modelisees en stub. Implementations + exécution + analyse comparative : cycles suivants.\n"
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/IIT/IIT-3-CoarseGrainingMacroPhi.ipynb
+++ b/MyIA.AI.Notebooks/IIT/IIT-3-CoarseGrainingMacroPhi.ipynb
@@ -383,9 +383,9 @@
     "Construire un réseau toy 3-nœuds où chaque nœud calcule un **AND** de ses deux entrées (et non une copie). Mesurer son `effective_info` et son $\\Phi$ dans l'état `(1,1,1)`. Comparer à EI=1.0 du réseau copy ci-dessus : un réseau AND est-il plus ou moins dégénéré ?\n",
     "\n",
     "> **Indice :** TPM AND = pour chaque état courant, le prochain état du noeud i = AND de ses 2 voisins.\n",
-    "> **Etape 1 :** construire la TPM (8 lignes, 3 colonnes).\n",
-    "> **Etape 2 :** pyphi.Network(tpm_and, cm) puis pyphi.macro.effective_info(net).\n",
-    "> **Etape 3 :** pyphi.Subsystem(net, (1,1,1)) puis pyphi.compute.phi(sub)."
+    "> **Étape 1 :** construire la TPM (8 lignes, 3 colonnes).\n",
+    "> **Étape 2 :** pyphi.Network(tpm_and, cm) puis pyphi.macro.effective_info(net).\n",
+    "> **Étape 3 :** pyphi.Subsystem(net, (1,1,1)) puis pyphi.compute.phi(sub)."
    ]
   },
   {
@@ -433,8 +433,8 @@
     "Sur un réseau à 4 nœuds (ex. l'exemple canonique `pyphi.examples.macro_network()`), lister tous les regroupements possibles via `pyphi.macro.all_groupings(range(4))`. Compter combien il y en a. Quel regroupement correspond à \"tout grouper en un seul macro-nœud\" ?\n",
     "\n",
     "> **Indice :** all_partitions renvoie des tuples de tuples. Le regroupement \"tout groupé\" = ((0,1,2,3),).\n",
-    "> **Etape 1 :** parts = list(pyphi.macro.all_partitions([0,1,2,3])).\n",
-    "> **Etape 2 :** len(parts) donne le nombre. Chercher celui egal a ((0,1,2,3),)."
+    "> **Étape 1 :** parts = list(pyphi.macro.all_partitions([0,1,2,3])).\n",
+    "> **Étape 2 :** len(parts) donne le nombre. Chercher celui egal a ((0,1,2,3),)."
    ]
   },
   {
@@ -480,8 +480,8 @@
     "Sur le réseau copy 3-nœuds du §1, on a vu $\\Phi$ micro = 0. Formulez une hypothèse : si l'on coarse-graine les 3 nœuds copy en un seul macro-nœud, le $\\Phi$ macro sera-t-il strictement positif ? Construisez le macro-nœud (TPM 1-nœud identique, copie) et mesurez-le pour confirmer/réfuter.\n",
     "\n",
     "> **Indice :** un macro-nœud \"copy\" a une TPM [[0.0],[1.0]] (1 noeud, self-loop), cm=[[1]].\n",
-    "> **Etape 1 :** macro_net = pyphi.Network(np.array([[0.0],[1.0]]), np.array([[1]])).\n",
-    "> **Etape 2 :** pyphi.Subsystem(macro_net, (1,)) puis pyphi.compute.phi(sub).\n",
+    "> **Étape 1 :** macro_net = pyphi.Network(np.array([[0.0],[1.0]]), np.array([[1]])).\n",
+    "> **Étape 2 :** pyphi.Subsystem(macro_net, (1,)) puis pyphi.compute.phi(sub).\n",
     "> **Question :** phi macro = 0 aussi ? Pourquoi (cf. interpretation §4) ?"
    ]
   },


### PR DESCRIPTION
## Summary

Canonical accent cure (#7186 pipeline `restore_accents_canonical.py`) on the **non-Lean small-family residual** of registre #2876. Markdown-cell-source ONLY by construction — code cells, outputs, execution_count, link targets, identifiers all untouched.

**51 cures / 3 notebooks**, all non-Lean (python3 / pyphi kernels), no partition collision:

| Notebook | Cures | md cells touched | kernel |
|----------|-------|------------------|--------|
| `CaseStudies/Oncology-Planning/solution/Oncology-Planning.ipynb` | 17 | 3/17 | python3 |
| `CaseStudies/SmartGrid-Energy/student/SmartGrid-Energy.ipynb` | 27 | 11/12 | python3 (student version — #7173 cured the solution version) |
| `IIT/IIT-3-CoarseGrainingMacroPhi.ipynb` | 7 | 3/14 | pyphi |

## Why this scope (residual clearance, not full close)

Firsthand dry-run on fresh `origin/main` worktree (G.1 — never scan stale shared tree):
- `SymbolicAI/SMT`: **0 cures** (fully cured by #7241 — confirmed not a vein).
- `CaseStudies` + `IIT`: small non-Lean residuals, no prior PR touched these exact files/cells (idempotent cure surfaces dictionary-expansion pairs).
- **Deferred** (coord decision needed, NOT in this PR):
  - `GameTheory` Lean-notebook `.ipynb` (134/2: `GameTheory-4b-Lean-NashExistence`, `02-Lean-SocialChoice-Formal`) — #7244 deliberately excluded Lean-ipynb; needs ai-01/po-2026 adjudication: markdown `.ipynb` accent cure = #2876 scope vs Lean partition #4980?
  - `QuantConnect` (4215/163) — awaiting scope decision (include `projects/*` stubs? research/?) per po-2025 c.632.

## 5-axis verify CLEAN (firsthand, base HEAD vs working tree)

- **AXE A — C.2 byte-identity**: 0 code/output/`execution_count`/`cell_type` line touched. `git diff --stat` = 44 ins / 44 del (accent-swap balance, no net add/delete).
- **AXE B — accent-fidelity**: `deaccent(base) == deaccent(head)` on every changed markdown line → **0 word substitution** (cure adds accents only, never replaces a word).
- **AXE C — structure**: 0 blank-line collapse (paragraph-break count preserved per cell).
- **AXE D — link-target (defect class 5)**: `set(](...)` targets identical base↔head → **0 link target gained an accent**.
- **AXE E — 3 CI gates**: `check_identifier_regression.py` (#7157) OK / `detect_caps_regression.py` (#7198) 0 caps-regression / `detect_link_target_regression.py` (#7210) 0 regression. Cell-count + cell_type preserved (asserted).

## Bright-lines (canonical cure by construction)

1. markdown-cell-source ONLY (`if cell_type != 'markdown': continue`)
2. link targets `]( ... )` masked before cure, restored byte-identical after
3. no code cell touched
4. only the `source` key rewritten; `outputs` / `execution_count` / `metadata` intact

See #2876 (partial — residual clearance; convergence endgame continues).

---

po-2023, firsthand: fresh origin/main worktree (HEAD 0407eddbb) + canonical cure #7186 + 5-axis forensic (C.2/accent-fidelity/structure/link-target/3 gates).
