### PR TITLE
feat(ict,#4588): event_colocalization - test position-level beauty<->ignition (null rotation)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/workspace.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/workspace.py
@@ -543,3 +543,122 @@ def event_triggered_battery(
         "n_events": len(per_event),
         "n_neutral": len(per_neutral),
     }
+
+
+# --------------------------------------------------------------------------- #
+# Co-localisation d'evenements (axe derivee temporelle, capstone strate 5)
+# --------------------------------------------------------------------------- #
+def event_colocalization(
+    events_a: Sequence[int],
+    events_b: Sequence[int],
+    T: int,
+    n_null: int = 500,
+    rng: np.random.Generator | None = None,
+) -> Dict:
+    """Co-localisation **position-level** de deux flux d'evenements, null par rotation.
+
+    Question de l'**axe derivee temporelle** (capstone strate 5, Epic #4588) : les
+    evenements du flux A (p.ex. *beauty events* ``dK/dt`` de Schmidhuber, cf.
+    :mod:`ict.beauty`) tombent-ils **plus pres** des evenements du flux B (p.ex.
+    *ignition events*, pics de concentration de :func:`ignition_events`) qu'au
+    hasard ? Un meme "insight" latent vu par deux lentilles temporelles
+    co-localiserait ; deux evenements de nature distincte se dissocieraient. La
+    dissociation est un **negatif honnete** aussi precieux que le pont (elle
+    reconnecte le verdict ICT-24 ``emergence_gain`` <-> ignition au Gate 5 de la
+    synthese : la jambe temporelle discrimine orthogonalement).
+
+    Statistique : distance moyenne au plus proche voisin, **symetrisee** ::
+
+        D(A, B) = ( mean_{a in A} min_{b in B} |a - b|
+                    + mean_{b in B} min_{a in A} |a - b| ) / 2
+
+    Petite ``D`` = les deux flux s'alignent. La symetrisation evite qu'un flux
+    dense "absorbe" artificiellement un flux clairsemé.
+
+    Null par **rotation circulaire** de B : ``b -> (b + s) mod T`` pour un decalage
+    ``s`` tire uniformement dans ``[1, T)``. La rotation **preserve le compte et
+    l'espacement interne** de B (donc son autocorrelation) et ne randomise que la
+    **phase** relative a A — c'est le controle standard du co-firing de trains de
+    spikes (Grün 2009). La distance reste **lineaire** (les positions vivent sur
+    une sequence, pas un anneau) : une seule "couture" a l'origine, sans biais
+    systematique puisque A occupe aussi ``[0, T)``.
+
+    Parametres
+    ----------
+    events_a, events_b : sequences d'int
+        Indices d'evenements (p.ex. ``steps`` de ``beauty_events`` et ``center``
+        de ``ignition_events``) dans ``[0, T)``.
+    T : int
+        Longueur de la sequence porteuse (nombre de pas / positions).
+    n_null : int
+        Nombre de rotations tirees pour le null (defaut 500).
+    rng : np.random.Generator, optionnel
+        Generateur (defaut graine 0, reproductibilite).
+
+    Retour
+    ------
+    dict
+        ``obs`` : float — ``D(A, B)`` observee (``nan`` si un flux est vide).
+        ``null_mean`` / ``null_std`` : float — stats de la distribution nulle.
+        ``z`` : float — ``(null_mean - obs) / null_std`` (``> 0`` = plus proche
+        qu'au hasard = co-localise ; ``nan`` si ``null_std == 0``).
+        ``p_close`` : float — ``P(null <= obs)`` lissee, une queue (petit =
+        co-localisation significative).
+        ``p_far`` : float — ``P(null >= obs)`` lissee, une queue (petit =
+        dissociation significative).
+        ``verdict`` : ``"colocalized"`` si ``p_close < 0.05`` ; ``"dissociated"``
+        si ``p_far < 0.05`` ; ``"chance"`` sinon ; ``"undefined"`` si flux vide.
+        ``n_a`` / ``n_b`` / ``T`` / ``n_null`` : parametres records.
+
+    Notes
+    -----
+    Fonction **pure** sur deux listes d'indices : aucune dependance aux fixtures.
+    L'agregation multi-prompts (test paire obs-vs-null sur plusieurs sequences)
+    vit dans le notebook/appelant, pas ici — meme separation que
+    :func:`concentration_series` (statistique par pas) / :func:`ignition_events`.
+    """
+    rng = rng or np.random.default_rng(0)
+    a = [int(x) for x in events_a]
+    b = [int(x) for x in events_b]
+    if T < 1:
+        raise ValueError(f"T doit etre >= 1, recu {T}")
+
+    def _sym_nn(xs: List[int], ys: List[int]) -> float:
+        if not xs or not ys:
+            return float("nan")
+        xa = np.asarray(xs, dtype=float)[:, None]
+        ya = np.asarray(ys, dtype=float)[None, :]
+        d = np.abs(xa - ya)  # (|A|, |B|)
+        a_to_b = d.min(axis=1).mean()
+        b_to_a = d.min(axis=0).mean()
+        return float(0.5 * (a_to_b + b_to_a))
+
+    if not a or not b:
+        return {
+            "obs": float("nan"), "null_mean": float("nan"),
+            "null_std": float("nan"), "z": float("nan"),
+            "p_close": float("nan"), "p_far": float("nan"),
+            "verdict": "undefined",
+            "n_a": len(a), "n_b": len(b), "T": int(T), "n_null": int(n_null),
+        }
+
+    obs = _sym_nn(a, b)
+    shifts = rng.integers(1, T, size=n_null) if T > 1 else np.zeros(n_null, dtype=int)
+    null = np.array([_sym_nn(a, [(y + int(s)) % T for y in b]) for s in shifts], dtype=float)
+    null_mean = float(null.mean())
+    null_std = float(null.std())
+    z = float((null_mean - obs) / null_std) if null_std > 0 else float("nan")
+    # p lissees (+1 au numerateur et denominateur : jamais 0, cf. North 2002)
+    p_close = float((np.sum(null <= obs) + 1) / (n_null + 1))
+    p_far = float((np.sum(null >= obs) + 1) / (n_null + 1))
+    if p_close < 0.05:
+        verdict = "colocalized"
+    elif p_far < 0.05:
+        verdict = "dissociated"
+    else:
+        verdict = "chance"
+    return {
+        "obs": obs, "null_mean": null_mean, "null_std": null_std, "z": z,
+        "p_close": p_close, "p_far": p_far, "verdict": verdict,
+        "n_a": len(a), "n_b": len(b), "T": int(T), "n_null": int(n_null),
+    }

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_workspace.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_workspace.py
@@ -496,3 +496,87 @@ def test_event_triggered_battery_rejects_bad_window():
     rng = np.random.default_rng(0)
     with pytest.raises(ValueError, match="window >= 1"):
         ws.event_triggered_battery(states, [5], window=0, rng=rng, n_shuffles=2)
+
+
+# --------------------------------------------------------------------------- #
+# event_colocalization (axe derivee temporelle, capstone strate 5)
+# --------------------------------------------------------------------------- #
+def test_event_colocalization_planted_alignment_is_colocalized():
+    """Deux flux alignes (B a <=3 pas de chaque A) -> verdict 'colocalized'.
+
+    Valide la MECANIQUE : l'obs (distance NN symetrique) doit etre bien plus
+    petite que le null par rotation, avec ``z > 0`` et ``p_close < 0.05``.
+    """
+    a = [50, 150, 250]
+    b = [52, 148, 253]  # chaque B a <= 3 pas d'un A
+    r = ws.event_colocalization(a, b, T=300, rng=np.random.default_rng(0))
+    assert r["verdict"] == "colocalized"
+    assert r["obs"] < r["null_mean"]
+    assert r["z"] > 0
+    assert r["p_close"] < 0.05
+
+
+def test_event_colocalization_antiphase_is_dissociated():
+    """Deux peignes reguliers en anti-phase (separation locale maximale) ->
+    verdict 'dissociated'.
+
+    A et B ont la meme periode 20 mais B est decale de 10 (demi-periode) : chaque
+    B est a exactement 10 pas du plus proche A, alors que la rotation trouve des
+    phases ou ils s'alignent (distance ~5 en moyenne). L'obs est donc PLUS LOIN
+    qu'au hasard : ``z < 0`` et ``p_far < 0.05``. C'est le cas ou la jambe
+    temporelle discrimine (echo du negatif ICT-24).
+    """
+    a = list(range(0, 300, 20))    # 0, 20, ..., 280
+    b = list(range(10, 300, 20))   # 10, 30, ..., 290 (anti-phase)
+    r = ws.event_colocalization(a, b, T=300, rng=np.random.default_rng(0))
+    assert r["verdict"] == "dissociated"
+    assert r["obs"] > r["null_mean"]
+    assert r["z"] < 0
+    assert r["p_far"] < 0.05
+
+
+def test_event_colocalization_random_is_chance():
+    """Deux flux tires au hasard -> verdict 'chance' (ni co-localise ni dissocie)."""
+    g = np.random.default_rng(1)
+    a = sorted(g.choice(300, 8, replace=False).tolist())
+    b = sorted(g.choice(300, 8, replace=False).tolist())
+    r = ws.event_colocalization(a, b, T=300, rng=np.random.default_rng(0))
+    assert r["verdict"] == "chance"
+    assert r["p_close"] >= 0.05
+    assert r["p_far"] >= 0.05
+
+
+def test_event_colocalization_empty_stream_is_undefined():
+    """Un flux vide -> verdict 'undefined', obs NaN, pas de crash."""
+    r = ws.event_colocalization([], [10, 20], T=100)
+    assert r["verdict"] == "undefined"
+    assert np.isnan(r["obs"])
+    assert r["n_a"] == 0 and r["n_b"] == 2
+    # symetrie de la degenerescence : B vide aussi
+    r2 = ws.event_colocalization([10, 20], [], T=100)
+    assert r2["verdict"] == "undefined"
+    assert np.isnan(r2["obs"])
+
+
+def test_event_colocalization_symmetric_in_arguments():
+    """D(A, B) == D(B, A) : la statistique NN est symetrisee."""
+    a, b = [10, 50, 90], [12, 48, 93]
+    r1 = ws.event_colocalization(a, b, T=100, rng=np.random.default_rng(3))
+    r2 = ws.event_colocalization(b, a, T=100, rng=np.random.default_rng(3))
+    assert abs(r1["obs"] - r2["obs"]) < 1e-9
+
+
+def test_event_colocalization_reproducible_with_seed():
+    """Meme graine -> null identique (obs/null_mean/p reproductibles)."""
+    a, b = [10, 40, 70], [15, 45, 75]
+    r1 = ws.event_colocalization(a, b, T=100, n_null=200, rng=np.random.default_rng(7))
+    r2 = ws.event_colocalization(a, b, T=100, n_null=200, rng=np.random.default_rng(7))
+    assert r1["obs"] == r2["obs"]
+    assert r1["null_mean"] == r2["null_mean"]
+    assert r1["p_close"] == r2["p_close"]
+
+
+def test_event_colocalization_rejects_bad_T():
+    """T < 1 leve ValueError (sequence porteuse vide)."""
+    with pytest.raises(ValueError, match="T doit etre >= 1"):
+        ws.event_colocalization([1, 2], [1, 2], T=0)


### PR DESCRIPTION
## `event_colocalization` — axe dérivée temporelle (foundation capstone strate 5)

Ajoute `ict.workspace.event_colocalization` : la statistique de **co-localisation position-level** entre deux flux d'événements temporels. C'est la fondation GPU-free du capstone « axe dérivée temporelle » de l'Epic ICT (#4588) — testable, réutilisable, sans dépendance à un notebook ni à une renumérotation.

### Question scientifique

Les **beauty events** (`dK/dt` en catastrophe, Schmidhuber, module `ict.beauty` de #7257) tombent-ils **plus près** des **ignition events** (pics de concentration, `ignition_events`) qu'au hasard ? Un même « insight » latent vu par deux lentilles temporelles co-localiserait ; deux événements de nature distincte se dissocieraient. La **dissociation** est un négatif honnête aussi précieux que le pont (elle reconnecte le verdict ICT-24 `emergence_gain`↔ignition au Gate 5 de la synthèse : la jambe temporelle discrimine orthogonalement).

### Méthode

- **Statistique** : distance moyenne au plus proche voisin, **symétrisée** `D(A,B) = (mean_a min_b |a-b| + mean_b min_a |a-b|) / 2`. Petite `D` = alignement.
- **Null par rotation circulaire** de B (`b -> (b+s) mod T`) : préserve le compte + l'espacement interne (autocorrélation) de B, ne randomise que la phase relative à A. C'est le contrôle standard du co-firing de trains de spikes (Grün 2009).
- **Verdict** : `colocalized` (`p_close < 0.05`) / `dissociated` (`p_far < 0.05`) / `chance` / `undefined` (flux vide).

Fonction **pure** sur deux listes d'indices — l'agrégation multi-prompts vit dans le notebook, pas ici (même séparation que `concentration_series` / `ignition_events`).

### Complémentarité

Mesure **orthogonale** à `event_triggered_battery` (livrée #5875) : celle-ci teste l'émergence créditée **dans les fenêtres** d'événement (via `emergence_gain`) ; `event_colocalization` teste l'**alignement position-level des événements eux-mêmes**. Deux angles sur la même question IIT↔GWT.

### Tests (+7, tous verts)

| Test | Cas | Attendu |
|------|-----|---------|
| `planted_alignment_is_colocalized` | B à ≤3 pas de chaque A | `colocalized`, `z>0`, `p_close<0.05` |
| `antiphase_is_dissociated` | peignes réguliers en anti-phase (séparation locale max) | `dissociated`, `z<0`, `p_far<0.05` |
| `random_is_chance` | flux tirés au hasard | `chance` |
| `empty_stream_is_undefined` | un flux vide | `undefined`, obs NaN, pas de crash |
| `symmetric_in_arguments` | swap A↔B | `D(A,B)==D(B,A)` |
| `reproducible_with_seed` | même graine | null identique |
| `rejects_bad_T` | `T<1` | `ValueError` |

`pytest tests/test_workspace.py` → **34 passed** (27 existants + 7 nouveaux). `test_workspace + test_beauty + test_synthesis` → **63 passed**.

### Portée

PR **additive** (append pur sur `workspace.py` + `test_workspace.py`, aucune modification de fonction existante = 0 risque de régression). Catalogue byte-identique à main. Le **notebook capstone** consommateur (dissociation micro sur fixtures 9B vs co-localisation partielle macro du grokking #7268) suit dans une PR séparée, après scoping numérotation strate-5 (#5681, lead ai-01).

See #4588
See #5681

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>
