### PR TITLE
docs(lean,#3978): reconcile conway_lean/README.md i18n-coverage tables with main

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/README.md
@@ -22,7 +22,7 @@ flowchart LR
 - **Compte de sorry** : 2 (tous dans `HashlifeCorrectness.lean` — wave-glue P4 `p4_succ_membership` [1] + grand-n P5 `p5_large_n_jump` [1], Epic #2162). Plusieurs sous-lemmes P4 et ingrédients additifs sont prouvés sorry-free (voir § « Jeu de la Vie » ci-dessous). `p5_inductive_step` (colle P5.3) a été close par c.310 PR #5998 via vacuous-arm split (design gate #3846) : sur grilles non vides, la branche `¬ hsmall` est conjointement insatisfaisable avec `BoxAssezGrand`, donc vide par construction. Le placeholder `p4_half_steps_compose` (P4.4) a été supprimé : sa composition pure-evolve est déjà close (`evolve_add` + `evolve_half_step`), son contenu wave-glue porté par le résiduel `p4_succ_membership`. **Audit N1 (PR #5853, ai-01 2026-07-09)** : le frame sub-claim initial (`BoxAssezGrand` ∩ `n ≥ jumpSize`) est **vacuous sur grilles non vides** (`p5_large_n_hyps_unsat` : padding 2 de `gridFrame` ∧ `lvl ≥ 3` ⇒ `n ≤ 2 ∧ js ≥ 8`). **Design gate ai-01 (#3846, 2026-07-10)** : redesigner `gridFrame` pour padding dépendant de `n`, porter l'état `(off, mc)` à travers la boucle de `evolveHashlifeFastAux` sans re-framing intermédiaire, restater l'invariant « marge ≥ n restant, préservé par jump ». La dette de preuve (#3846) reste la cible du BG-prover et du redesign architectural coordonné.
 - **Build** : `lake build Conway` — SUCCESS
 - **Dépendances** : Mathlib4
-- **Couverture i18n (EPIC #4980)** : 11 modules conway_lean livrés en FR-canonique + sibling `_en` sur `main` — Phase 1 : `Angel`, `DoomsdayLemmas`, `FractranLemmas`, `LookAndSayLemmas`, `MathlibMap` (5/9) ; Phase 2 : `Life` (root), `Spaceships`, `Oscillators`, `HashlifeMarginDemo`, `HashlifeMemo`, `Pillars` (6/13). Rollout c.290-#6439 en cours sur les modules restants (`RLE`, `LightCone`, `GridCanonical` PRs c.421-c.423 en attente de merge).
+- **Couverture i18n (EPIC #4980)** : **25 modules** conway_lean livrés en FR-canonique + sibling `_en` sur `main` (tous sauf `HashlifeCorrectness.lean`, la cible P4/P5 du prouveur qui reste EN-only) — Phase 1 : **10/10** ; Phase 2 : **13/14** (`ConeGeometry` inclus) ; Phase 3 : **2/2**. Rollout complet (c.290-#6439 + cycles c.421-c.423 merged).
 
 ## Modules
 
@@ -30,15 +30,15 @@ flowchart LR
 
 | Fichier | `_en` | sorry | Description |
 |---------|-------|-------|-------------|
-| `Conway/Doomsday.lean` | — | 0 | Algorithme Doomsday (calcul du jour de la semaine) |
+| `Conway/Doomsday.lean` | `Doomsday_en.lean` | 0 | Algorithme Doomsday (calcul du jour de la semaine) |
 | `Conway/DoomsdayLemmas.lean` | `DoomsdayLemmas_en.lean` | 0 | Lemmes pour l'algorithme Doomsday |
-| `Conway/Fractran.lean` | — | 0 | Langage de programmation FRACTRAN |
+| `Conway/Fractran.lean` | `Fractran_en.lean` | 0 | Langage de programmation FRACTRAN |
 | `Conway/FractranLemmas.lean` | `FractranLemmas_en.lean` | 0 | Lemmes pour FRACTRAN (step/run : halt vide, 0-run, applicabilité `num/1`, trace concrète `{3/2}` 2→3) |
-| `Conway/LookAndSay.lean` | — | 0 | Suite Look-and-Say |
+| `Conway/LookAndSay.lean` | `LookAndSay_en.lean` | 0 | Suite Look-and-Say |
 | `Conway/LookAndSayLemmas.lean` | `LookAndSayLemmas_en.lean` | 0 | Lemmes pour la suite Look-and-Say |
-| `Conway/Nim.lean` | — | 0 | Théorie des jeux de Nim |
+| `Conway/Nim.lean` | `Nim_en.lean` | 0 | Théorie des jeux de Nim |
 | `Conway/Angel.lean` | `Angel_en.lean` | 0 | Problème de l'ange (Angel problem) |
-| `Conway/CollatzLike.lean` | — | 0 | Fonctions de type Collatz et indécidabilité (`native_decide`) |
+| `Conway/CollatzLike.lean` | `CollatzLike_en.lean` | 0 | Fonctions de type Collatz et indécidabilité (`native_decide`) |
 | `Conway/MathlibMap.lean` | `MathlibMap_en.lean` | 0 | Satellite de cartographie Mathlib pinned (`54f98fd6`) — ce que Mathlib fournit pour l'œuvre de Conway |
 
 ### Phase 2 — Jeu de la Vie (Epic #1647, EN COURS)
@@ -48,12 +48,13 @@ flowchart LR
 | `Conway/Life.lean` | `Life_en.lean` (root) | 0 | Règles B3/S23, opérations sur grille, step/evolve, preuves `native_decide` |
 | `Conway/Life/Spaceships.lean` | `Spaceships_en.lean` | 0 | LWSS/MWSS/HWSS (période 4, déplacement (0,2)), 3 preuves `native_decide` |
 | `Conway/Life/Oscillators.lean` | `Oscillators_en.lean` | 0 | 5 still-lifes + pulsar (p3) + pentadecathlon (p15), 7 `native_decide` |
-| `Conway/Life/RLE.lean` | — | 0 | Parseur de motifs RLE + glider/LWSS/pulsar/Gosper gun, 8 preuves `native_decide` |
-| `Conway/Life/MacroCell.lean` | — | 0 | Type quadtree MacroCell + round-trip `toGrid`/`buildFromGrid` + prédicat `wf` |
-| `Conway/Life/Hashlife.lean` | — | 0 | `step4x4` + `hashlifeResult` récursif + `padCenter2` + `hashlifeJump` + `evolveHashlifeFast` |
-| `Conway/Life/LightCone.lean` | — | 0 | Satellite géométrique light-cone — lemmes sorry-free sur `manhattan`/`lightCone` pontant `HashlifeCorrectness` |
-| `Conway/Life/GridCanonical.lean` | — | 0 | Formes canoniques `sortDedup`, unicité lexicographique, égalité de grille via forme canonique |
-| `Conway/Life/Computation.lean` | — | 0 | Cross-validation Hashlife (6 + 6 fast), still-life eater1 (1), composition de planeurs (5) |
+| `Conway/Life/RLE.lean` | `RLE_en.lean` | 0 | Parseur de motifs RLE + glider/LWSS/pulsar/Gosper gun, 8 preuves `native_decide` |
+| `Conway/Life/MacroCell.lean` | `MacroCell_en.lean` | 0 | Type quadtree MacroCell + round-trip `toGrid`/`buildFromGrid` + prédicat `wf` |
+| `Conway/Life/Hashlife.lean` | `Hashlife_en.lean` | 0 | `step4x4` + `hashlifeResult` récursif + `padCenter2` + `hashlifeJump` + `evolveHashlifeFast` |
+| `Conway/Life/LightCone.lean` | `LightCone_en.lean` | 0 | Satellite géométrique light-cone — lemmes sorry-free sur `manhattan`/`lightCone` pontant `HashlifeCorrectness` |
+| `Conway/Life/ConeGeometry.lean` | `ConeGeometry_en.lean` | 0 | Géométrie du cône — faits purs de treillis (Mathlib uniquement) |
+| `Conway/Life/GridCanonical.lean` | `GridCanonical_en.lean` | 0 | Formes canoniques `sortDedup`, unicité lexicographique, égalité de grille via forme canonique |
+| `Conway/Life/Computation.lean` | `Computation_en.lean` | 0 | Cross-validation Hashlife (6 + 6 fast), still-life eater1 (1), composition de planeurs (5) |
 | `Conway/Life/HashlifeMemo.lean` | `HashlifeMemo_en.lean` | 0 | Hashlife mémoïsé pour témoins des piliers communautaires (OTCA 35K, UnitCell 4096, Gemini 33M) |
 | `Conway/Life/HashlifeMarginDemo.lean` | `HashlifeMarginDemo_en.lean` | 0 | Démo exécutable P5 redesign (#3846) — n-aware framing margin autour de `MacroCell`/`HashlifeCorrectness` |
 | `Conway/Life/Pillars.lean` | `Pillars_en.lean` (c.417) | 0 | Scaffolding du théorème community-witness (4 piliers) |
@@ -63,8 +64,8 @@ flowchart LR
 
 | Fichier | `_en` | sorry | Description |
 |---------|-------|-------|-------------|
-| `Conway/KochenSpecker.lean` | — | 0 | Preuve Cabello à 18 vecteurs du KS (argument de parité) |
-| `Conway/FreeWillTheorem.lean` | — | 0 | Conway-Kochen FWT (SPIN + TWIN + MIN) |
+| `Conway/KochenSpecker.lean` | `KochenSpecker_en.lean` | 0 | Preuve Cabello à 18 vecteurs du KS (argument de parité) |
+| `Conway/FreeWillTheorem.lean` | `FreeWillTheorem_en.lean` | 0 | Conway-Kochen FWT (SPIN + TWIN + MIN) |
 
 ## Résultats clés
 


### PR DESCRIPTION
## Summary

`docs(lean,#3978): reconcile conway_lean/README.md i18n-coverage tables with origin/main` — the module tables listed `_en` siblings as `—` (missing) for **14 modules that actually have a sibling on `main`, and omitted `ConeGeometry.lean` entirely** from the Phase 2 table. Driver #3978: "décrire l'état formel réel" (notebooks/READMEs ← preuves).

This is my explicit partition (#3978: `SymbolicAI/Lean/**` READMEs, owner po-2026:CoursIA). Worktree-isolated from `origin/main` (`b01d92c23`). 1 file, +15/−14.

## What changed (whole-file audited against origin/main, §E)

**All facts verified firsthand via `git ls-tree -r origin/main`** (the authoritative source for which `_en` siblings exist), not from memory:

1. **Phase 1 table** — 6 rows corrected: `Doomsday`→`Doomsday_en`, `Fractran`→`Fractran_en`, `LookAndSay`→`LookAndSay_en`, `Nim`→`Nim_en`, `CollatzLike`→`CollatzLike_en` (were `—` but siblings exist). (`DoomsdayLemmas`/`FractranLemmas`/`LookAndSayLemmas`/`Angel`/`MathlibMap` already correct.)
2. **Phase 2 table** — 6 rows corrected: `RLE`, `MacroCell`, `Hashlife`, `LightCone`, `GridCanonical`, `Computation` → their `_en` siblings (were `—` but exist). **+1 row added**: `ConeGeometry.lean` (`ConeGeometry_en.lean`, 0 sorry) was entirely missing from the table. `HashlifeCorrectness.lean` correctly remains `—` (no `_en` sibling — it is the P4/P5 prover target; verified `ls` returns no `HashlifeCorrectness_en.lean`).
3. **Phase 3 table** — 2 rows corrected: `KochenSpecker`→`KochenSpecker_en`, `FreeWillTheorem`→`FreeWillTheorem_en` (were `—`).
4. **Couverture i18n summary line** — updated from stale "11 modules / rollout en cours (RLE, LightCone, GridCanonical en attente de merge)" to the verified current state: **25 modules** have a sibling `_en` (all except `HashlifeCorrectness`), Phase 1 **10/10**, Phase 2 **13/14** (ConeGeometry included), Phase 3 **2/2**, rollout complete.

## What I deliberately did NOT touch (G.1)

- **The sorry count (L22, "Compte de sorry : 2") is left intact.** `HashlifeCorrectness.lean` (3790 lines) has no `.lake/` build artifacts in the worktree → an authoritative `lake build Conway` would require a full Mathlib4 compilation (not cheap, multi-minute WSL). Per my recurring G.1 lesson (sorry-maps drift, strip-comment grep is unreliable for line numbers), I will **not** assert a sorry number I cannot verify authoritatively. The "2" figure is ai-01's proof-turf (#6724 tracks the canonical sorry map firsthand); editing it without an authoritative build would risk replacing a possibly-stale-but-maintained number with an unverified one. This PR is strictly the i18n-coverage reconciliation — a separate, reliably-verifiable drift.

## Hygiene (catalog-pr-hygiene, §E)

- [x] **Catalogue byte-identique to main** — no `COURSE_CATALOG.generated.*` touched, no `CATALOG-STATUS` markers in this file (verified 0 on both).
- [x] **Whole-file audit** — every module row cross-checked against `git ls-tree -r origin/main conway_lean/`; ConeGeometry docstring read firsthand ("Géométrie du cône — faits purs de treillis (Mathlib uniquement)") rather than guessed.
- [x] **LF-only** (0 CRLF), UTF-8 no-BOM.
- [x] Compact table-pipe style matches the pre-existing file convention (MD060 lint warnings on header/separator rows are pre-existing on `main`, not introduced here).
- [x] `See #3978` (partial: this PR covers `conway_lean/README.md`; `SymbolicAI/Lean/README.md` parent hub and other Lean-series READMEs remain for follow-up tranches per #3978 scope).

See #3978 (part of #3973 README ascendant).

## Residual (this PR does not close #3978)

#3978 scope is broader (`SymbolicAI/Lean/**`, `GameTheory/*_lean`, social_choice, Conway/GOL). This PR delivers `conway_lean/README.md` (the most actively-evolving Lean series, driven by #2162/#3846/#6724). Follow-up tranches: `SymbolicAI/Lean/README.md` parent hub, GameTheory Lean READMEs. One subject per PR.

## Forensic

po-2026, firsthand: `git ls-tree -r origin/main` conway inventory (26 `_en` siblings + 27 `.lean` modules enumerated) + `head` docstrings for ConeGeometry/MacroCell/Hashlife/GridCanonical/Computation/RLE/LightCone + `ls` HashlifeCorrectness_en (absent, confirmed). Sorry-count left untouched (G.1, no authoritative lake build available here).
