### PR TITLE
docs(qc,#3976): projects/README stale project count 116 -> 112

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/README.md
@@ -1,6 +1,6 @@
 # QuantConnect Algorithmic Trading Projects
 
-**116 projets** de trading algorithmique sur QuantConnect Cloud. Chaque stratégie illustre un concept pédagogique ; les performances varient volontairement pour montrer ce qui survive au backtest réaliste.
+**112 projets** de trading algorithmique sur QuantConnect Cloud. Chaque stratégie illustre un concept pédagogique ; les performances varient volontairement pour montrer ce qui survive au backtest réaliste.
 
 > **Visiteur ?** Lire le [Quick Tour](../QUICK_TOUR.md) (2 min) pour comprendre l'ensemble.
 
@@ -111,7 +111,7 @@ MonProjet/
 
 ### Ce que vous avez appris
 
-Ce catalogue de **116 projets** est un **zoo de stratégies backtestées**, organisé non pas par thème mais par **robustesse** (Robuste / Historique / Exploratoire). La classification elle-même est la leçon :
+Ce catalogue de **112 projets** est un **zoo de stratégies backtestées**, organisé non pas par thème mais par **robustesse** (Robuste / Historique / Exploratoire). La classification elle-même est la leçon :
 
 - **La robustesse prime sur le Sharpe brut** : une stratégie à Sharpe 1.6 qui s'effondre hors-échantillon vaut moins qu'une stratégie à Sharpe 0.6 stable à travers les régimes. Le label *Robuste* (> 0.5 soutenu) est la barre pédagogique, pas le chiffre spectaculaire.
 - **Les contre-exemples sont aussi importants que les succès** : les stratégies *Exploratoire* (Sharpe < 0) et *Historique* (0-0.5) sont conservées **délibérément** pour montrer *ce qui ne marche pas* et pourquoi — PairsTrading sur ETF corrélés, ForexCarry, MeanReversion naïf. On apprend autant d'un edge négatif bien diagnostiqué que d'un edge positif.
@@ -126,7 +126,7 @@ Le fil rouge : **chaque projet est reproductible** — `main.py` (ou `Main.cs`) 
 3. **Consulter le détail** : `STRATEGIES_DETAIL.md` donne le contexte complet de chaque stratégie (catégorie, ML/DL/RL, clones QC Library).
 4. **Reproduire sur QC Cloud** : créer un projet, copier le `main.py`, lancer le backtest, et comparer vos métriques au tableau ci-dessus.
 5. **Étendre un projet Robuste** : choisir une stratégie *Robuste* (ex. `RegimeSwitching`, `SectorMomentum`) et itérer — changer l'univers, ajouter un filtre de risque, tester la sensibilité aux coûts de transaction.
-6. **Voir les leçons transversales** : `docs/qc/quantconnect.md` recense les 20 patterns confirmés et les anti-patterns observés à travers ces 116 projets.
+6. **Voir les leçons transversales** : `docs/qc/quantconnect.md` recense les 20 patterns confirmés et les anti-patterns observés à travers ces 112 projets.
 
 > **Rappel honnête** : un Sharpe de backtest, même *Robuste*, n'est pas une garantie live. Les coûts de transaction réels, le slippage et l'impact de marché dégradent systématiquement la performance paper. La barre *Robuste* (> 0.5 soutenu sur la période) est nécessaire mais pas suffisante — le walk-forward et l'out-of-sample strict restent obligatoires avant tout déploiement.
 


### PR DESCRIPTION
## Summary

Fichier-entier audit (`projects/README.md` vs disk reality) of the QuantConnect projects hub README, part of **#3976** (leaf READMEs — QC, owner po-2024:CoursIA), itself a sub-issue of **#3973**.

## Drift found & fixed

`projects/README.md` claimed **`116 projets`** in 3 places (L3 intro, L114 conclusion, L129 step-6). Disk reality = **112**:

- `find projects -maxdepth 1 -mindepth 1 -type d | wc -l` = **112** subdirs
- `101` with `main.py` (deployable strategies) + `11` others (5 recherches, 2 stubs, 2 templates, 2 BROKEN pédagogiques) = 112
- The hub `QuantConnect/README.md` already says **`112 entrées brutes (101 stratégies déployables)`** consistently at L52, L57, L307 — so `projects/README.md` was the outlier.

Stale since before #5175 (2026-07-03, which fixed the Historique count 15→13 but left 116). **3 occurrences corrected 116 → 112** (diff = exactly 3 lines).

## Fichier-entier audit (other counts verified accurate, left unchanged)

| Claim | Verified | Match |
|-------|----------|-------|
| Robuste ``19 stratégies`` (L17) | table L21-39 = 19 rows; canon `qc-strategies-status.md` Sharpe>0.5 count = 19 | ✓ |
| Historique ``13 stratégies`` (L41) | L43 list = 13 items | ✓ |
| Exploratoire ``4 stratégies`` (L45) | L47 list = 4 items | ✓ |
| ML/DL/RL 35+, QC Library Clones 8 | overlapping classifications, not a partition — no single total implied | ✓ |
| BTC-ML in both Robuste (1.647) & Historique (0.282) | intentional catalog-vs-aligned dual listing | ✓ (not a dupe) |

## Constraints respected

- **FR-first** preserved (file is already FR).
- **CATALOG-STATUS untouched** (none in this file; cron's job per catalog-pr-hygiene).
- **All 5 internal links re-resolve OK** (`STRATEGIES_DETAIL.md`, `../QUICK_TOUR.md`, `../docs/qc_strategies_catalog.md`, `../../../docs/qc/{quantconnect,qc-comparative-backtests}.md`).
- **No conflict with #7279** (touches only `projects/LongShortHarvest-QC/README.md` child, not this parent).

See #3973
See #3976

Co-Authored-By: Claude-Code <noreply@anthropic.com>