### PR TITLE
feat(ict,#5681): co-localisation inter-lentilles SAE↔J-Lens (lens_agreement.py + 9 tests) — verdict négatif honnête

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/lens_agreement.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/lens_agreement.py
@@ -1,0 +1,225 @@
+"""Co-localisation inter-lentilles des ignitions SAE <-> J-Lens (strate 5, #5681 / #4588).
+
+La jambe **lens-agreement** de la triade d'evenements du capstone axe-derivee-temporelle
+(#7259). Le tete-a-tete ``ICT-SAE-JLens-TeteATete.ipynb`` (PR #5959) a etabli que les deux
+lentilles vivent dans des **espaces disjoints** (features SAE vs directions singulieres
+J-space, sec. 8.3) et que leurs *valeurs* de concentration par position ne se correlent que
+faiblement. Il n'a PAS teste la question temporelle qui interesse le workspace global : les
+deux lentilles **s'allument-elles aux MEMES positions de token** ?
+
+Ce module operationalise cette question de facon falsifiable et **GPU-free** (sur les traces
+layer-16 deja extraites, 2699 tokens), en **reutilisant** la primitive deja mergee
+:func:`ict.workspace.event_colocalization` (#7274, distance plus-proche-voisin symetrisee +
+null par rotation circulaire). Ce module n'ajoute PAS de statistique : il fournit la
+**glue inter-lentille** que la primitive laisse explicitement a l'appelant (« l'agregation
+multi-prompts vit dans le notebook/appelant, pas ici »).
+
+Pipeline
+--------
+1. Pour chaque lentille, on tire la **serie de concentration** par position
+   (:func:`ict.workspace.concentration_series`, Gini du panel differentiel) puis on detecte
+   les **ignitions** (:func:`ict.workspace.ignition_events`, pics persistants, lecture
+   Dehaene). Chaque lentille selectionne SES propres features differentielles : la
+   concentration scalaire est la **monnaie commune** entre deux espaces disjoints.
+2. Les **centres** des ignitions de chaque lentille (indices dans ``[0, T)``) alimentent
+   :func:`ict.workspace.event_colocalization` prompt par prompt (memes tokens) : distance
+   moyenne au plus proche voisin, symetrisee, contre un null de rotation circulaire.
+   La distance plus-proche-voisin **tolere les quasi-coincidences** (deux ignitions proches
+   mais non exactement superposees comptent comme un rapprochement) — la bonne question pour
+   « les deux lentilles s'allument-elles ensemble », pas « exactement au meme index ».
+3. On agrege les verdicts par prompt sur les prompts partages.
+
+**Distinction avec #7274.** ``event_colocalization`` est la primitive pure (deux listes
+d'indices). #7274 l'a cablee pour la co-localisation **INTRA-lentille** beauty<->ignition
+(deux flux temporels DANS la meme lentille). Ce module la cable pour la co-localisation
+**INTER-lentille** SAE<->J-Lens (deux appareils differents sur le meme texte) — complementaire,
+pas redondante : c'est la jambe *lens-agreement* de la triade, distincte de la jambe
+*beauty<->ignition*.
+
+Verdict falsifiable
+-------------------
+* ``colocalized`` reproductible sur les prompts -> les deux lentilles allument leurs ignitions
+  aux memes positions : un meme evenement de workspace vu par deux appareils (jambe
+  lens-agreement CREDITEE).
+* ``dissociated`` / ``chance`` -> les deux lentilles s'allument a des positions differentes.
+  Verdict negatif **legitime**, coherent avec la dissociation deja observee a ICT-24
+  (emergence_gain <-> ignition ~17 % crediees) et le constat « espaces disjoints » du
+  tete-a-tete ; il reconnecte le negatif d'ICT-24 a la prediction du Gate 5 de la synthese
+  (la jambe temporelle discrimine orthogonalement). A rapporter **honnetement** : ne pas
+  vendre une co-localisation qui n'existe pas.
+
+Garde-fou (a reporter dans le notebook consommateur)
+----------------------------------------------------
+Le ``densify`` du J-Lens est une approximation de **rang-k** (les directions hors top-50 ont
+un coefficient petit mais non nul), tandis que le SAE top-k est **exact** par construction
+(cf :mod:`ict.jlens_traces`). La concentration J-Lens porte donc cette approximation ; le
+verdict de co-localisation se lit avec cette nuance, deja documentee dans le tete-a-tete.
+Le compte d'ignitions par lentille (``n_ign_a`` / ``n_ign_b`` par prompt) est reporte pour
+juger la **puissance** du test : une lentille qui n'allume presque jamais (J-Lens clairseme
+au seuil q=0.9) rend le prompt peu informatif -- le verdict agrege distingue les prompts
+``undefined`` (flux vide).
+
+Numpy uniquement : AUCUN import torch (le GPU reste confine aux scripts d'extraction).
+
+References
+----------
+* Dehaene, Changeux -- ignition temporelle (P3b) que :func:`ict.workspace.ignition_events`
+  operationalise.
+* Anthropic, *Global Workspace in Claude* (2025) -- substrat J-space (jacobien des logits).
+* Grün (2009) -- null par rotation pour le co-firing de trains d'evenements (via #7274).
+* Tete-a-tete ``ICT-SAE-JLens-TeteATete.ipynb`` (PR #5959) -- concentration par lentille,
+  espaces disjoints (sec. 8.3).
+* :func:`ict.workspace.event_colocalization` (#7274) -- primitive reutilisee telle quelle.
+* #5681 (tete-a-tete SAE<->J-Lens), #7259 (capstone axe derivee temporelle), #4588 (Epic ICT).
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+from .workspace import concentration_series, event_colocalization, ignition_events
+
+__all__ = [
+    "lens_ignition_centers",
+    "colocalize_lenses",
+]
+
+
+# --------------------------------------------------------------------------- #
+# Ignitions par lentille -> centres d'evenements alimentant event_colocalization
+# --------------------------------------------------------------------------- #
+def lens_ignition_centers(
+    traces: dict,
+    feature_ids: np.ndarray,
+    *,
+    q: float = 0.9,
+    persistence: int = 3,
+    metric: str = "gini",
+) -> Dict[Tuple[str, int], Tuple[List[int], int]]:
+    """Centres d'ignition (+ longueur ``T``) par prompt pour une lentille.
+
+    Pour chaque prompt : concentration par position (:func:`concentration_series`
+    du panel differentiel), seuil = **quantile ``q``** de la serie, puis
+    :func:`ignition_events`. On retourne la liste des ``center`` (indices dans
+    ``[0, T)``) et ``T`` -- exactement le format attendu par
+    :func:`ict.workspace.event_colocalization`.
+
+    Le seuil par quantile est calibre **par serie** : deux lentilles de dynamiques
+    differentes gardent chacune leurs ~10 % de positions les plus concentrees.
+    """
+    from .sae_traces import acts_topk_panels
+
+    panels = acts_topk_panels(traces, feature_ids)
+    out: Dict[Tuple[str, int], Tuple[List[int], int]] = {}
+    for key, dense in panels.items():
+        conc = concentration_series(dense, metric)
+        T = int(conc.size)
+        thr = float(np.quantile(conc, q)) if T else 0.0
+        centers = [int(ev["center"]) for ev in ignition_events(conc, thr, persistence=persistence)]
+        out[key] = (centers, T)
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Pilote agrege sur les prompts partages des deux lentilles
+# --------------------------------------------------------------------------- #
+def colocalize_lenses(
+    traces_a: dict,
+    traces_b: dict,
+    *,
+    k: int = 64,
+    q: float = 0.9,
+    persistence: int = 3,
+    metric: str = "gini",
+    n_null: int = 500,
+    rng: Optional[np.random.Generator] = None,
+) -> Dict[str, object]:
+    """Co-localisation agregee des ignitions **inter-lentilles** sur les prompts partages.
+
+    Chaque lentille selectionne SES propres ``k`` features differentielles (espaces
+    disjoints, cf tete-a-tete sec. 8.3) ; on co-localise position par position DANS
+    chaque prompt partage (memes tokens) via :func:`ict.workspace.event_colocalization`,
+    puis on agrege les verdicts.
+
+    Un prompt dont les deux lentilles ne partagent pas la meme longueur ``T`` est
+    **saute** (positions non comparables) et compte dans ``n_skipped`` -- garde-fou
+    contre une mauvaise paire de fixtures. Un prompt ou une lentille n'allume aucune
+    ignition donne ``verdict == "undefined"`` (compte dans ``n_undefined``, exclu des
+    moyennes de ``z``).
+
+    Parametres
+    ----------
+    traces_a, traces_b : dict
+        Traces chargees (cf :func:`ict.sae_traces.load_traces` /
+        :func:`ict.jlens_traces.load_traces`), memes prompts.
+    k, q, persistence, metric
+        Cf :func:`lens_ignition_centers` et :func:`ict.sae_traces.differential_features`.
+    n_null : int
+        Rotations du null par prompt (transmis a :func:`event_colocalization`).
+    rng : numpy.random.Generator, optional
+        Source aleatoire du null (defaut ``default_rng(0)``, reproductible).
+
+    Retour
+    ------
+    dict
+        ``n_prompts`` (prompts co-localises), ``n_skipped`` / ``skipped`` (T
+        incompatible), ``n_undefined`` (une lentille sans ignition),
+        ``n_colocalized`` / ``n_dissociated`` / ``n_chance`` (comptes de verdicts),
+        ``z_mean`` (moyenne des ``z`` definis ; ``> 0`` = plus proche qu'au hasard),
+        ``verdict`` (synthese : ``"colocalized"`` si les prompts co-localises dominent
+        strictement les dissocies, ``"dissociated"`` si l'inverse, ``"chance"`` sinon),
+        ``per_prompt`` (liste des retours :func:`event_colocalization`, chacun enrichi
+        de ``prompt``, ``n_ign_a``, ``n_ign_b``).
+    """
+    from .sae_traces import differential_features
+
+    if rng is None:
+        rng = np.random.default_rng(0)
+    feat_a = differential_features(traces_a, k=k)
+    feat_b = differential_features(traces_b, k=k)
+    ev_a = lens_ignition_centers(traces_a, feat_a, q=q, persistence=persistence, metric=metric)
+    ev_b = lens_ignition_centers(traces_b, feat_b, q=q, persistence=persistence, metric=metric)
+    shared = sorted(set(ev_a) & set(ev_b))
+
+    per_prompt: List[dict] = []
+    skipped: List[dict] = []
+    for key in shared:
+        centers_a, T_a = ev_a[key]
+        centers_b, T_b = ev_b[key]
+        if T_a != T_b:
+            skipped.append({"prompt": key, "T_a": T_a, "T_b": T_b})
+            continue
+        r = event_colocalization(centers_a, centers_b, T_a, n_null=n_null, rng=rng)
+        r["prompt"] = key
+        r["n_ign_a"] = len(centers_a)
+        r["n_ign_b"] = len(centers_b)
+        per_prompt.append(r)
+
+    n_coloc = sum(1 for r in per_prompt if r["verdict"] == "colocalized")
+    n_disso = sum(1 for r in per_prompt if r["verdict"] == "dissociated")
+    n_chance = sum(1 for r in per_prompt if r["verdict"] == "chance")
+    n_undef = sum(1 for r in per_prompt if r["verdict"] == "undefined")
+    zs = [r["z"] for r in per_prompt if not np.isnan(r["z"])]
+    z_mean = float(np.mean(zs)) if zs else float("nan")
+
+    if n_coloc > n_disso:
+        verdict = "colocalized"
+    elif n_disso > n_coloc:
+        verdict = "dissociated"
+    else:
+        verdict = "chance"
+
+    return {
+        "n_prompts": len(per_prompt),
+        "n_skipped": len(skipped),
+        "skipped": skipped,
+        "n_undefined": n_undef,
+        "n_colocalized": n_coloc,
+        "n_dissociated": n_disso,
+        "n_chance": n_chance,
+        "z_mean": z_mean,
+        "verdict": verdict,
+        "per_prompt": per_prompt,
+    }

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_lens_agreement.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_lens_agreement.py
@@ -1,0 +1,261 @@
+"""Tests de la co-localisation inter-lentilles SAE <-> J-Lens (strate 5, #5681 / #4588). GPU-free.
+
+Couvrent la **glue** ajoutee par :mod:`ict.lens_agreement` (la statistique NN-distance +
+null par rotation est deja couverte par ``test_workspace.py`` cote
+:func:`ict.workspace.event_colocalization`) :
+
+* :func:`lens_ignition_centers` retrouve les rafales de concentration plantees ;
+* :func:`colocalize_lenses` -> ``colocalized`` quand les deux lentilles allument aux
+  MEMES positions, ``chance``/``dissociated`` quand elles allument ailleurs ;
+* les prompts a ``T`` incompatible sont SAUTES (``n_skipped``) ;
+* une lentille qui n'allume jamais donne des prompts ``undefined`` (``n_undefined``) ;
+* le module est numpy-only (aucun import torch) ;
+* integration : si les traces reelles committees sont presentes, le pilote tourne et
+  renvoie un verdict structurellement valide sur les 20 prompts partages.
+
+Les traces synthetiques sont construites dans le format post-``load_traces`` : chaque
+lentille a des features "signal" a forte variance inter-jeux (donc selectionnees par
+:func:`ict.sae_traces.differential_features`) ; une rafale a la position ``c`` concentre
+toute la valeur sur UNE feature signal (Gini eleve, ignition), le reste du temps les
+features signal sont equi-actives (Gini ~0, pas d'ignition).
+"""
+
+import os
+import sys
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from ict import lens_agreement as la  # noqa: E402
+from ict.workspace import concentration_series  # noqa: E402
+from ict.sae_traces import differential_features  # noqa: E402
+
+# features signal (fort, variance inter-jeux) et fillers (faibles, non differentiels)
+SIGNAL = [10, 11, 12, 13, 14, 15]
+FILLER = [1, 2, 3]
+
+# Profil de rafale : concentration triangulaire (pic au centre) sur 5 positions.
+BURST_PROFILE = [0.5, 0.75, 0.95, 0.75, 0.5]
+
+
+def _gini_row(L: float, scale: float) -> np.ndarray:
+    """Ligne de panel (6 features SIGNAL) dont le Gini vaut EXACTEMENT ``L``.
+
+    Pour un vecteur ``[f, (1-f)/5, ..., (1-f)/5]`` normalise, le Gini (formule de
+    :func:`ict.workspace.concentration_series`) vaut ``(6 f - 1) / 5`` ; on inverse
+    en ``f = (5 L + 1) / 6`` pour cibler ``L``. Le Gini etant **invariant d'echelle**,
+    la mise a l'echelle par jeu (``scale``) donne la variance inter-jeux qui fait
+    selectionner ces features par :func:`differential_features` SANS toucher la
+    concentration.
+    """
+    F = len(SIGNAL)
+    f = (5.0 * L + 1.0) / 6.0
+    row = np.full(F, (1.0 - f) / (F - 1), dtype=np.float64)
+    row[0] = f
+    return row * scale
+
+
+def _build_traces(
+    bursts: Dict[Tuple[str, int], List[int]],
+    *,
+    T: int = 120,
+    sets=("setA", "setB"),
+    n_prompts: int = 2,
+    d_sae: int = 64,
+    seed: int = 0,
+) -> dict:
+    """Traces synthetiques (format post-load) avec rafales de concentration plantees.
+
+    ``bursts`` : centres de rafale (profil :data:`BURST_PROFILE`, 5 positions de large,
+    pic au centre) par prompt. Hors rafale, la concentration **alterne** bas/moyen-bas
+    (0.02 / 0.06) : cette alternance garantit qu'AUCUNE fenetre baseline de longueur
+    ``persistence=3`` ne franchit le quantile 0.9 (les positions "hautes" sont isolees,
+    espacees de 1), donc une lentille sans rafale ne produit **aucune** ignition. A une
+    rafale, la concentration monte franchement (jusqu'a 0.95) sur >= 3 positions
+    contigues -> une ignition centree sur le pic. Le seuil interne ``quantile(conc, q)``
+    de :func:`lens_ignition_centers` separe ainsi proprement rafales et baseline.
+
+    La concentration ciblee est realisee via :func:`_gini_row` (Gini exact, invariant
+    d'echelle) ; la mise a l'echelle ``1 + si`` par jeu porte la variance inter-jeux qui
+    fait selectionner les features signal par :func:`differential_features`.
+    """
+    rng = np.random.default_rng(seed)
+    F = len(SIGNAL)
+    K = F + len(FILLER)
+    prompts: Dict[Tuple[str, int], dict] = {}
+    for si, s in enumerate(sets):
+        scale = 1.0 + si                          # variance inter-jeux -> signal selectionne
+        for i in range(n_prompts):
+            ids = np.zeros((T, K), dtype=np.int32)
+            vals = np.zeros((T, K), dtype=np.float32)
+            ids[:, :F] = SIGNAL
+            ids[:, F:] = FILLER
+            # baseline : concentration alternee basse (aucun run de 3 au-dessus du q0.9)
+            for t in range(T):
+                L = 0.02 if t % 2 == 0 else 0.06
+                vals[t, :F] = _gini_row(L, scale)
+            # rafales : profil triangulaire (pic au centre) sur 5 positions
+            for c in bursts.get((s, i), []):
+                for off, L in zip(range(-2, 3), BURST_PROFILE):
+                    t = c + off
+                    if 0 <= t < T:
+                        vals[t, :F] = _gini_row(L, scale)
+            # fillers : faibles, quasi constants (variance inter-jeux ~0 -> non selectionnes)
+            vals[:, F:] = 0.01 + rng.uniform(0, 1e-4, size=(T, K - F)).astype(np.float32)
+            prompts[(s, i)] = {
+                "ids": ids,
+                "vals": vals,
+                "tokens": np.array([f"t{t}" for t in range(T)], dtype=str),
+            }
+    return {"meta": {"d_sae": d_sae, "k": K, "layer": 16, "variant": "synthetic"},
+            "prompts": prompts}
+
+
+# --------------------------------------------------------------------------- #
+# lens_ignition_centers
+# --------------------------------------------------------------------------- #
+def test_lens_ignition_centers_finds_planted_bursts():
+    """Les centres d'ignition tombent pres des rafales plantees."""
+    tr = _build_traces({("setA", 0): [30, 80]}, T=120)
+    feats = differential_features(tr, k=6)
+    centers = la.lens_ignition_centers(tr, feats, q=0.9, persistence=3)
+    got = centers[("setA", 0)]
+    ev_centers, T = got
+    assert T == 120
+    assert len(ev_centers) == 2, ev_centers
+    assert any(abs(c - 30) <= 2 for c in ev_centers), ev_centers
+    assert any(abs(c - 80) <= 2 for c in ev_centers), ev_centers
+
+
+def test_lens_ignition_centers_empty_without_bursts():
+    """Sans rafale (concentration plate) : aucun centre d'ignition."""
+    tr = _build_traces({}, T=100)                 # aucune rafale nulle part
+    feats = differential_features(tr, k=6)
+    centers = la.lens_ignition_centers(tr, feats, q=0.9, persistence=3)
+    assert all(len(c) == 0 for c, _ in centers.values())
+
+
+# --------------------------------------------------------------------------- #
+# colocalize_lenses -- verdicts
+# --------------------------------------------------------------------------- #
+def _both_lens(bursts_a, bursts_b, **kw):
+    a = _build_traces(bursts_a, seed=0, **kw)
+    b = _build_traces(bursts_b, seed=1, **kw)     # bruit filler distinct : lentilles differentes
+    return a, b
+
+
+def test_colocalize_lenses_same_positions_is_colocalized():
+    """Deux lentilles allumant aux MEMES positions -> verdict agrege 'colocalized'."""
+    pos = {("setA", 0): [15, 55, 95], ("setA", 1): [20, 60, 100],
+           ("setB", 0): [15, 55, 95], ("setB", 1): [20, 60, 100]}
+    a, b = _both_lens(pos, pos, T=120)
+    r = la.colocalize_lenses(a, b, k=6, q=0.9, persistence=3, n_null=200,
+                             rng=np.random.default_rng(0))
+    assert r["n_prompts"] == 4
+    assert r["n_skipped"] == 0
+    assert r["verdict"] == "colocalized", r
+    assert r["n_colocalized"] > r["n_dissociated"]
+    assert r["z_mean"] > 0
+
+
+def test_colocalize_lenses_different_positions_not_colocalized():
+    """Deux lentilles allumant a des positions decalees -> PAS 'colocalized'."""
+    pos_a = {("setA", 0): [15, 55, 95], ("setA", 1): [15, 55, 95],
+             ("setB", 0): [15, 55, 95], ("setB", 1): [15, 55, 95]}
+    pos_b = {("setA", 0): [35, 75, 110], ("setA", 1): [35, 75, 110],
+             ("setB", 0): [35, 75, 110], ("setB", 1): [35, 75, 110]}
+    a, b = _both_lens(pos_a, pos_b, T=120)
+    r = la.colocalize_lenses(a, b, k=6, q=0.9, persistence=3, n_null=200,
+                             rng=np.random.default_rng(0))
+    assert r["n_prompts"] == 4
+    assert r["verdict"] != "colocalized", r
+
+
+def test_colocalize_lenses_skips_length_mismatch():
+    """Un prompt a T different entre les deux lentilles est saute (n_skipped)."""
+    pos = {("setA", 0): [20, 60], ("setA", 1): [20, 60],
+           ("setB", 0): [20, 60], ("setB", 1): [20, 60]}
+    a, b = _both_lens(pos, pos, T=120)
+    # tronque un prompt de la lentille B a T=90
+    key = ("setA", 0)
+    b["prompts"][key]["ids"] = b["prompts"][key]["ids"][:90]
+    b["prompts"][key]["vals"] = b["prompts"][key]["vals"][:90]
+    b["prompts"][key]["tokens"] = b["prompts"][key]["tokens"][:90]
+    r = la.colocalize_lenses(a, b, k=6, q=0.9, persistence=3, n_null=100,
+                             rng=np.random.default_rng(0))
+    assert r["n_skipped"] == 1
+    assert any(s["prompt"] == key for s in r["skipped"])
+    assert r["n_prompts"] == 3
+
+
+def test_colocalize_lenses_undefined_when_a_lens_never_ignites():
+    """Une lentille sans rafale -> prompts 'undefined' (comptes, exclus des z)."""
+    pos_a = {("setA", 0): [20, 60], ("setA", 1): [20, 60],
+             ("setB", 0): [20, 60], ("setB", 1): [20, 60]}
+    a, b = _both_lens(pos_a, {}, T=120)           # lentille B : aucune ignition
+    r = la.colocalize_lenses(a, b, k=6, q=0.9, persistence=3, n_null=100,
+                             rng=np.random.default_rng(0))
+    assert r["n_undefined"] == 4
+    assert r["n_colocalized"] == 0
+    assert r["verdict"] == "chance"               # ni coloc ni disso -> chance
+    assert np.isnan(r["z_mean"])
+
+
+def test_colocalize_lenses_reproducible_with_seed():
+    """Meme graine -> meme verdict agrege et memes comptes."""
+    pos = {("setA", 0): [15, 55, 95], ("setA", 1): [20, 60, 100],
+           ("setB", 0): [15, 55, 95], ("setB", 1): [20, 60, 100]}
+    a, b = _both_lens(pos, pos, T=120)
+    r1 = la.colocalize_lenses(a, b, k=6, n_null=200, rng=np.random.default_rng(3))
+    r2 = la.colocalize_lenses(a, b, k=6, n_null=200, rng=np.random.default_rng(3))
+    assert r1["verdict"] == r2["verdict"]
+    assert r1["n_colocalized"] == r2["n_colocalized"]
+    assert r1["z_mean"] == r2["z_mean"] or (np.isnan(r1["z_mean"]) and np.isnan(r2["z_mean"]))
+
+
+# --------------------------------------------------------------------------- #
+# Architecture
+# --------------------------------------------------------------------------- #
+def test_lens_agreement_module_is_numpy_only():
+    """Aucune INSTRUCTION d'import torch (le GPU reste confine aux scripts d'extraction).
+
+    Verification par ligne (et non par sous-chaine) : la prose de la docstring peut
+    legitimement contenir les mots ``import torch`` (« aucun import torch ») sans que
+    le module importe torch. Seule une *instruction* ``import torch`` / ``from torch ...``
+    est proscrite.
+    """
+    src = Path(la.__file__).read_text(encoding="utf-8")
+    import_lines = [ln.strip() for ln in src.splitlines()]
+    assert not any(ln.startswith("import torch") for ln in import_lines)
+    assert not any(ln.startswith("from torch") for ln in import_lines)
+
+
+# --------------------------------------------------------------------------- #
+# Integration : traces reelles committees (si presentes)
+# --------------------------------------------------------------------------- #
+REAL = Path(__file__).parent.parent / "traces"
+
+
+def test_real_fixtures_colocalization_runs():
+    """Sur les traces reelles (si presentes) : le pilote tourne, verdict valide sur 20 prompts."""
+    sae_p = REAL / "ict21_sae_layer16_trained.npz"
+    jl_p = REAL / "ict24_jlens_layer16_trained.npz"
+    if not (sae_p.exists() and jl_p.exists()):
+        pytest.skip("traces reelles absentes (extraction GPU non committee ici)")
+    from ict import sae_traces, jlens_traces
+
+    sae = sae_traces.load_traces(sae_p)
+    jl = jlens_traces.load_traces(jl_p)
+    r = la.colocalize_lenses(sae, jl, k=64, q=0.9, persistence=3, n_null=200,
+                             rng=np.random.default_rng(0))
+    assert r["n_prompts"] == 20                    # 5 jeux x 4 prompts, T-alignes
+    assert r["n_skipped"] == 0
+    assert r["verdict"] in {"colocalized", "dissociated", "chance"}
+    # chaque verdict par prompt est bien structure
+    for p in r["per_prompt"]:
+        assert set(p) >= {"prompt", "verdict", "obs", "z", "n_ign_a", "n_ign_b"}
+        assert p["verdict"] in {"colocalized", "dissociated", "chance", "undefined"}


### PR DESCRIPTION
## Résumé

Jambe **lens-agreement** de la triade d'événements du capstone axe-dérivée-temporelle (#7259) — la moitié **GPU-free** de l'approfondissement SAE↔J-Lens (#5681, B-A1).

Nouveau module numpy-only [`ict/lens_agreement.py`](MyIA.AI.Notebooks/IIT/ICT-Series/ict/lens_agreement.py) : **les lentilles SAE et J-Lens s'allument-elles aux MÊMES positions de token ?** Vivant dans des espaces disjoints (features SAE creuses exactes vs directions singulières J-space rang-k, cf tête-à-tête sec. 8.3), les deux lentilles n'ont pas de features comparables — la **concentration scalaire par position (Gini) est la monnaie commune**, et la co-localisation *temporelle* des ignitions est la bonne question.

- `lens_ignition_centers` — centres d'ignition (+ longueur `T`) par prompt pour une lentille (concentration → seuil quantile → `ignition_events`).
- `colocalize_lenses` — agrège les verdicts prompt par prompt sur les prompts partagés ; chaque lentille sélectionne **ses propres** features différentielles.

## Réutilisation (anti-duplication)

Le module **n'ajoute aucune statistique** : il réutilise la primitive déjà mergée `ict.workspace.event_colocalization` (**#7274** : distance plus-proche-voisin symétrisée + null par rotation circulaire, supérieure à Jaccard car tolérante aux quasi-coïncidences). #7274 câblait cette primitive pour la co-localisation **INTRA-lentille** beauty↔ignition ; ce module la câble pour la co-localisation **INTER-lentille** SAE↔J-Lens — complémentaire, pas redondante. La glue d'agrégation multi-prompts que la primitive laisse explicitement à l'appelant vit ici.

## Verdict scientifique — NÉGATIF honnête (pas de co-localisation)

Mesuré sur les fixtures 9B-Base couche 16 (2699 tokens, 20 prompts × 5 registres). Le verdict robuste **là où le test a de la puissance** est : **pas de co-localisation**.

| Config | prompts informatifs | z_mean | verdict agrégé |
|--------|--------------------:|-------:|----------------|
| q=0.9, pers=2  | **20 / 20** (0 undefined) | **−0.116** | dissociated |
| q=0.85, pers=2 | **20 / 20** (0 undefined) | **−0.145** | dissociated |
| q=0.9, pers=3 (défaut)  | 4 / 20 (16 undefined) | −0.007 | chance |
| q=0.85, pers=3 | 8 / 20 (12 undefined) | +0.206 | colocalized* |

`z > 0` = ignitions plus proches qu'au hasard (co-localisées) ; `z < 0` = plus éloignées.

**Lecture honnête :**
- **Aux seuils bien-dotés en puissance** (`pers=2`, les 20 prompts contribuent, 0 `undefined`), `z_mean` est **négatif** (−0.116 / −0.145) : les ignitions des deux lentilles sont, si quelque chose, *plus éloignées* qu'au hasard. **Jamais** co-localisées.
- \*La seule lecture `colocalized` (q=0.85 pers=3, z=+0.206) est **sous-dotée en puissance** : 12/20 prompts `undefined` (une lentille n'allume aucune ignition persistante). Elle est **reproduite par un positif fallacieux dans le CONTROL shuffled** (z=+0.150 à q=0.9 pers=3) → c'est un artefact de faible puissance, **pas** un signal.
- L'**instabilité du verdict** (chance ↔ dissociated ↔ colocalized selon le seuil) est *en soi* un constat négatif : une vraie co-localisation serait stable sur des seuils raisonnables.
- **Caveat de puissance** : J-Lens est **nettement clairsemée** en ignitions soutenues (beaucoup de prompts à `n_ign_b` ∈ {0, 1}) ; à `pers=3` le test manque de prompts informatifs. Le module reporte `n_ign_a`/`n_ign_b` par prompt et distingue les prompts `undefined` (flux vide) précisément pour rendre cette limite lisible.

**Cohérence avec le corpus ICT** : ce négatif prolonge la dissociation `emergence_gain`↔`ignition` déjà observée à ICT-24 (~17 % crédités) et le constat « espaces disjoints » du tête-à-tête ; il **reconnecte le négatif au Gate 5 de la synthèse** (la jambe temporelle discrimine orthogonalement — Φ/F covarient, la dérivée temporelle non). **Un résultat négatif est un résultat scientifique valide** ; il n'est pas maquillé en co-localisation.

## Portée & ce qui reste GPU-gaté

- **3ᵉ lentille raw-logit** (entropie vocab-level, l'autre moitié de B-A1) : **GPU-gatée**. Les fixtures committées sont des features **internes couche 16**, pas les logits de sortie ; extraire la lentille raw-logit demande un forward pass sur le 9B → **RECOVERABLE-MACHINE** (Track-P GPU, lane po-2024/ai-01), non inclus ici.
- **Capstone triade beauty↔ignition↔lens-agreement** (co-localisation à 3 voies + unification micro/macro du pli) = **déféré au livrable C** (#7259).

## Vérification

- `pytest tests/` → **452 passed, 2 skipped** (aucune régression ; les 2 skips = fixtures GPU absentes, gardés par `pytest.skip`).
- **9 nouveaux tests** [`tests/test_lens_agreement.py`](MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_lens_agreement.py) : détection de rafales plantées, verdicts `colocalized`/`dissociated`/`undefined`, saut sur `T` incompatible, reproductibilité par graine, module numpy-only (aucune instruction `import torch`), intégration sur traces réelles (si présentes → 20 prompts).
- Construction synthétique déterministe : concentration baseline **alternée** (aucune fenêtre `persistence=3` ne franchit le quantile 0.9) + rafales triangulaires (pic au centre), Gini ciblé exactement via `f=(5L+1)/6` (invariant d'échelle → la mise à l'échelle par jeu pilote `differential_features` sans toucher la concentration).

Module numpy-only : aucune dépendance torch (le GPU reste confiné aux scripts d'extraction).

See #5681, #7259, #4588
