### PR TITLE
fix(genai-image,#5780): harmonize Image/03-Orchestration README figure centring (4 table -> 4 p align=center, post-#6145)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/README.md
@@ -60,35 +60,19 @@ Le notebook [03-2-Workflow-Orchestration](03-2-Workflow-Orchestration.ipynb) ill
 
 **Pipeline séquentiel** (génération → style → upscaling) — un coucher de soleil sur montagnes passe par trois étapes successives : Qwen produit l'image initiale (1024×1024), un node de style applique le rendu painterly, puis un upscaler double la résolution à 2048×2048. La même scène gagne en détail au fil des étapes sans perdre la composition d'origine :
 
-<table>
-<tr>
-<td align="center"><img src="assets/readme/img3-workflow1.webp" alt="Pipeline séquentiel ComfyUI en 3 étapes (Generated / Styled / Upscaled) sur la même scène coucher de soleil sur montagnes enneigées — composition préservée aux 3 étapes, seule la définition/lumière varie" width="600"/></td>
-</tr>
-</table>
+<p align="center"><img src="assets/readme/img3-workflow1.webp" alt="Pipeline séquentiel ComfyUI en 3 étapes (Generated / Styled / Upscaled) sur la même scène coucher de soleil sur montagnes enneigées — composition préservée aux 3 étapes, seule la définition/lumière varie" width="840"/></p>
 
 **Comparaison multi-modèles en parallèle** — le même prompt *« A futuristic city with flying cars and neon lights… »* est soumis simultanément à Qwen, FLUX et SD35. Les trois modèles tournent en parallèle via des nœuds ComfyUI distincts (~55s chacun) et leurs sorties sont assemblées dans une seule grille pour comparaison directe :
 
-<table>
-<tr>
-<td align="center"><img src="assets/readme/img3-workflow2.webp" alt="Comparaison parallèle Qwen / FLUX / SD35 sur le même prompt (ville futuriste cyberpunk nocturne avec voitures volantes et néons rose/violet/cyan) — 3 modèles tournent en ~55 s avec variations mineures" width="600"/></td>
-</tr>
-</table>
+<p align="center"><img src="assets/readme/img3-workflow2.webp" alt="Comparaison parallèle Qwen / FLUX / SD35 sur le même prompt (ville futuriste cyberpunk nocturne avec voitures volantes et néons rose/violet/cyan) — 3 modèles tournent en ~55 s avec variations mineures" width="840"/></p>
 
 **Pipeline conditionnel** — un score de qualité seuille les tentatives successives : tant que la sortie est sous le seuil (ligne rouge pointillée à 0.75), le pipeline re-tente automatiquement avec un seed différent. L'histogramme montre la stabilisation du score (≈0.53) après trois tentatives — sous le seuil mais dans une bande stable qui permet d'arbitrer entre relancer et accepter :
 
-<table>
-<tr>
-<td align="center"><img src="assets/readme/img3-workflow3.png" alt="Diagramme en barres matplotlib du score qualité (3 tentatives) d'un pipeline conditionnel — 3 barres orange identiques à ~0.53, ligne pointillée rouge à 0.75 (seuil) que le pipeline cherche à franchir en relançant" width="400"/></td>
-</tr>
-</table>
+<p align="center"><img src="assets/readme/img3-workflow3.png" alt="Diagramme en barres matplotlib du score qualité (3 tentatives) d'un pipeline conditionnel — 3 barres orange identiques à ~0.53, ligne pointillée rouge à 0.75 (seuil) que le pipeline cherche à franchir en relançant" width="560"/></p>
 
 **Variations stylistiques** — un même prompt (chalet de montagne sous la neige) est exécuté sur SD35 avec trois styles distincts : photoréaliste, aquarelle, anime. Le pipeline ne change pas la géométrie de la scène, seulement l'apparence — c'est l'usage classique des conditioning nodes de ComfyUI :
 
-<table>
-<tr>
-<td align="center"><img src="assets/readme/img3-workflow4.webp" alt="Variations stylistiques SD35 sur un même prompt (chalet en rondins de bois dans montagnes enneigées) — 3 styles : photoréaliste (rendu photographique chaud), aquarelle (couleurs pastel, contours fondus), anime (couleurs saturées, contours marqués, ambiance manga)" width="600"/></td>
-</tr>
-</table>
+<p align="center"><img src="assets/readme/img3-workflow4.webp" alt="Variations stylistiques SD35 sur un même prompt (chalet en rondins de bois dans montagnes enneigées) — 3 styles : photoréaliste (rendu photographique chaud), aquarelle (couleurs pastel, contours fondus), anime (couleurs saturées, contours marqués, ambiance manga)" width="840"/></p>
 
 Provenance et poids de chaque figure : [`assets/readme/MANIFEST.md`](assets/readme/MANIFEST.md).
 


### PR DESCRIPTION
## Summary

Harmonisation post-#6145 doctrine #5780 stricte : conversion des **4 `<table>` de centrage** en **4 `<p align="center">`** dans `MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/README.md`. Suite directe de la vague c.444 (#6145 Image/README + #6157 Video/04 + #6159 Audio/01 + #6164 Image/02) qui a établi le pattern moderne.

**Substance** : la mosaïque-bloc du README `Image/03-Orchestration` (réintégration narrative déjà faite par #5952 c.346) gardait 4 `<table><tr><td align="center">…</td></tr></table>` autour de chaque figure — pattern pré-c.444. La doctrine post-#6145 utilise systématiquement `<p align="center">` (cf Sudoku #5815 + SocialChoice #5894 + Image #6145), alignement markdown natif, et largeur 840 px (WebP panoramiques) / 560 px (PNG histogramme) cohérente avec les autres README GenAI.

## Changement

4 substitutions 1-pour-1 (table → p) :

| # | Figure | Ancien | Nouveau |
|---|--------|--------|---------|
| 1 | `img3-workflow1.webp` | `<table><tr><td align="center">…width="600"…</td></tr></table>` | `<p align="center">…width="840"…</p>` |
| 2 | `img3-workflow2.webp` | `<table><tr><td align="center">…width="600"…</td></tr></table>` | `<p align="center">…width="840"…</p>` |
| 3 | `img3-workflow3.png` | `<table><tr><td align="center">…width="400"…</td></tr></table>` | `<p align="center">…width="560"…</p>` |
| 4 | `img3-workflow4.webp` | `<table><tr><td align="center">…width="600"…</td></tr></table>` | `<p align="center">…width="840"…</p>` |

## 5-axis verify

| # | Axe | Outil | Résultat |
|---|-----|-------|----------|
| 1 | counts | `grep -c` | `<table>` 4 → 0 ✅ ; `<p align="center">` 0 → 4 ✅ ; `<tr>` 4 → 0 ✅ ; `<td>` 4 → 0 ✅ |
| 2 | figures byte-identity | `sha256sum` | 4/4 IDENTICAL vs origin/main ✅ |
| 3 | LF-only | PowerShell char13 count | CR=0 ; ends with LF ✅ (5737 chars) |
| 4 | R3 atomique | `git diff --stat` | 1 file / +4 / -20 ✅ |
| 5 | src+alt préservés | diff verbatim | 4 src paths + 4 alt-texts byte-identiques (sauf width 600→840 / 400→560) ✅ |

## Conformité

- **§A atomicité** : 1 sujet (harmonisation post-#6145), 1 fichier ✅
- **R1 catalog-pr-hygiene** : `CATALOG-STATUS` byte-identique (0 hit grep `pedagogical_count\|breakdown\|maturity` dans diff) ✅
- **L268 #4 LF-only** : CR=0 sur README ✅
- **L327 additif strict** : +4/-20 sans suppression prose narrative ✅
- **R6 anti-monotonie** : c.638 LSH (QC) + c.639 ForexCarry (QC) + c.640 RiskParity (QC) + c.641 Conway/Knots Lean (Lean accents) + **c.642 Image/03-Orchestration (GenAI)** = **5ᵉ genre diversity tenue** — registre = figures mosaic/harmonisation, famille = QC ×3 / Lean / GenAI ✅
- **C628-L1 ★★★ HARD** : registre ≠ famille tenu (registre harmonisation centrage, famille GenAI ≠ QC ≠ Lean) ✅

## Cross-references

- EPIC **#5780** — doctrine figures narrative in-situ
- EPIC **#5654** — politique figures (≤200 KB, ≤1200 px)
- PR **#5952** (MERGED c.346) — dissolution mosaïque-bloc Image/03-Orchestration (sub-READMEs)
- PR **#6145** (MERGED c.444) — dissolution mosaïque + conversion `<p align>` Image/README racine
- PR **#5815** (MERGED Sudoku) + **#5894** (MERGED SocialChoice) — pionniers du pattern `<p align="center">`
- C638-L1 ★★★ / C640-L1 ★★★ — G.1 firsthand OBLIGATOIRE sur tables/chiffres README

See #5780
See #5654

🤖 Generated with [Claude Code](https://claude.com/claude-code)
