### PR TITLE
docs(genai,#5780): dissolve 03-Orchestration README mosaic into in-situ narrative

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/README.md
@@ -18,7 +18,7 @@ Ce module couvre l'orchestration de plusieurs modèles, les workflows complexes,
 ## Notebooks
 
 | # | Notebook | Contenu | Service | VRAM |
-|---|----------|---------|---------|------ |
+|---|----------|---------|---------|------|
 | 1 | [03-1-Multi-Model-Comparison](03-1-Multi-Model-Comparison.ipynb) | Comparaison multi-modèles | Mixed | Variable |
 | 2 | [03-2-Workflow-Orchestration](03-2-Workflow-Orchestration.ipynb) | Orchestration de workflows | ComfyUI | Variable |
 | 3 | [03-3-Performance-Optimization](03-3-Performance-Optimization.ipynb) | Optimisation performance | ComfyUI | Variable |
@@ -60,35 +60,19 @@ Le notebook [03-2-Workflow-Orchestration](03-2-Workflow-Orchestration.ipynb) ill
 
 **Pipeline séquentiel** (génération → style → upscaling) — un coucher de soleil sur montagnes passe par trois étapes successives : Qwen produit l'image initiale (1024×1024), un node de style applique le rendu painterly, puis un upscaler double la résolution à 2048×2048. La même scène gagne en détail au fil des étapes sans perdre la composition d'origine :
 
-<table>
-<tr>
-<td align="center"><img src="assets/readme/img3-workflow1.webp" alt="Pipeline séquentiel ComfyUI en 3 étapes (Generated / Styled / Upscaled) sur la même scène coucher de soleil sur montagnes enneigées — composition préservée aux 3 étapes, seule la définition/lumière varie" width="600"/></td>
-</tr>
-</table>
+<p align="center"><img src="assets/readme/img3-workflow1.webp" alt="Pipeline séquentiel ComfyUI en 3 étapes (Generated / Styled / Upscaled) sur la même scène coucher de soleil sur montagnes enneigées — composition préservée aux 3 étapes, seule la définition/lumière varie" width="900"/><br/><em>img3-workflow1 — Pipeline séquentiel ComfyUI (Generated / Styled / Upscaled) sur un coucher de soleil sur montagnes enneigées. La composition (montagnes alignées + soleil + brume) reste identique aux trois étapes — seule la définition/lumière varie.</em></p>
 
 **Comparaison multi-modèles en parallèle** — le même prompt *« A futuristic city with flying cars and neon lights… »* est soumis simultanément à Qwen, FLUX et SD35. Les trois modèles tournent en parallèle via des nœuds ComfyUI distincts (~55s chacun) et leurs sorties sont assemblées dans une seule grille pour comparaison directe :
 
-<table>
-<tr>
-<td align="center"><img src="assets/readme/img3-workflow2.webp" alt="Comparaison parallèle Qwen / FLUX / SD35 sur le même prompt (ville futuriste cyberpunk nocturne avec voitures volantes et néons rose/violet/cyan) — 3 modèles tournent en ~55 s avec variations mineures" width="600"/></td>
-</tr>
-</table>
+<p align="center"><img src="assets/readme/img3-workflow2.webp" alt="Comparaison parallèle Qwen / FLUX / SD35 sur le même prompt (ville futuriste cyberpunk nocturne avec voitures volantes et néons rose/violet/cyan) — 3 modèles tournent en ~55 s avec variations mineures" width="900"/><br/><em>img3-workflow2 — Comparaison parallèle Qwen (55.47s) / FLUX (55.47s) / SD35 (55.47s) sur le même prompt « A futuristic city with flying cars and neon lights… ». Trois rendus très similaires d'une ville futuriste cyberpunk nocturne (gratte-ciels néon rose/violet/cyan, voitures volantes), variations mineures entre modèles.</em></p>
 
 **Pipeline conditionnel** — un score de qualité seuille les tentatives successives : tant que la sortie est sous le seuil (ligne rouge pointillée à 0.75), le pipeline re-tente automatiquement avec un seed différent. L'histogramme montre la stabilisation du score (≈0.53) après trois tentatives — sous le seuil mais dans une bande stable qui permet d'arbitrer entre relancer et accepter :
 
-<table>
-<tr>
-<td align="center"><img src="assets/readme/img3-workflow3.png" alt="Diagramme en barres matplotlib du score qualité (3 tentatives) d'un pipeline conditionnel — 3 barres orange identiques à ~0.53, ligne pointillée rouge à 0.75 (seuil) que le pipeline cherche à franchir en relançant" width="400"/></td>
-</tr>
-</table>
+<p align="center"><img src="assets/readme/img3-workflow3.png" alt="Diagramme en barres matplotlib du score qualité (3 tentatives) d'un pipeline conditionnel — 3 barres orange identiques à ~0.53, ligne pointillée rouge à 0.75 (seuil) que le pipeline cherche à franchir en relançant" width="600"/><br/><em>img3-workflow3 — Diagramme en barres matplotlib du score qualité d'un pipeline conditionnel. 3 barres orange identiques à ~0.53 (tentatives 1, 2, 3) sous la ligne pointillée rouge à 0.75 (seuil) — le score plafonne sans franchir le seuil.</em></p>
 
 **Variations stylistiques** — un même prompt (chalet de montagne sous la neige) est exécuté sur SD35 avec trois styles distincts : photoréaliste, aquarelle, anime. Le pipeline ne change pas la géométrie de la scène, seulement l'apparence — c'est l'usage classique des conditioning nodes de ComfyUI :
 
-<table>
-<tr>
-<td align="center"><img src="assets/readme/img3-workflow4.webp" alt="Variations stylistiques SD35 sur un même prompt (chalet en rondins de bois dans montagnes enneigées) — 3 styles : photoréaliste (rendu photographique chaud), aquarelle (couleurs pastel, contours fondus), anime (couleurs saturées, contours marqués, ambiance manga)" width="600"/></td>
-</tr>
-</table>
+<p align="center"><img src="assets/readme/img3-workflow4.webp" alt="Variations stylistiques SD35 sur un même prompt (chalet en rondins de bois dans montagnes enneigées) — 3 styles : photoréaliste (rendu photographique chaud), aquarelle (couleurs pastel, contours fondus), anime (couleurs saturées, contours marqués, ambiance manga)" width="900"/><br/><em>img3-workflow4 — Variations stylistiques SD35 sur un même prompt (chalet en rondins de bois dans montagnes enneigées) : photoréaliste (rendu photographique chaud, cheminée, fenêtres éclairées), aquarelle (couleurs pastel, contours fondus, ambiance onirique), anime (couleurs saturées, contours marqués, ambiance manga).</em></p>
 
 Provenance et poids de chaque figure : [`assets/readme/MANIFEST.md`](assets/readme/MANIFEST.md).
 


### PR DESCRIPTION
## Summary

Dissolves the 4-block mosaic in `MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/README.md` (1 `<table>` × 4 figures) into in-situ narrative with `<p align="center">` blocks and `<em>` captions under bolded lead prose.

## Figures preserved (multiset identical to origin/main)

| File | Topic |
|------|-------|
| img3-workflow1.webp | Pipeline séquentiel (Generated / Styled / Upscaled) coucher de soleil sur montagnes enneigées |
| img3-workflow2.webp | Comparaison parallèle Qwen/FLUX/SD35 sur prompt cyberpunk |
| img3-workflow3.png | Pipeline conditionnel — 3 barres score ~0.53 sous seuil 0.75 |
| img3-workflow4.webp | Variations stylistiques SD35 (photoréaliste/aquarelle/anime) chalet en bois |

**Note**: `img3-multimodel.webp` existe dans `assets/readme/` (MANIFEST catalogue 03-1 Multi-Model) mais n'était pas référencé dans le README origin/main — **hors scope** de cette dissolution, multiset invariant respecté.

## 5-axis verification (doctrine #5780)

- **AXIS 1 (multiset)**: `diff` of `grep -oE 'img3-[a-z0-9]+\.(webp|png)'` origin/main vs branch = empty (PASS)
- **AXIS 2 (`<table>` count)**: 0 (PASS)
- **AXIS 3 (`<p align="center">` count)**: 4 = figure count (PASS)
- **AXIS 4 (`<sub>` count / `<em>` count)**: 0 / 4 (PASS)
- **AXIS 5 (LF-only)**: CR=0 (PASS)

## Diff

```
MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/README.md  | 5 insertions, 21 deletions
```

Net `-16` : 4 `<table><tr><td align="center">...` boilerplate blocks (3 lines each = 12 lines) → 4 single-line `<p align="center">` blocks. Each new block enriched with bolded lead prose (already present) + `<em>` caption synthesizing the figure's pedagogical content.

## R6 anti-monotonie

After c.642 (EMA-Cross-Index QC), c.643 (EMA-Cross-Crypto QC), this c.644 PR pivots cross-family to GenAI/Image. R6 (mandat user 2026-07-06) respected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)