### PR TITLE
docs(genai-video,#5780): normalize 6 single-image table wrappers to <p align=center> in 01-Foundation

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Video/01-Foundation/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Video/01-Foundation/README.md
@@ -23,9 +23,7 @@ Ce module pose les fondamentaux du pipeline vidéo : opérations techniques (ffm
 
 Le notebook [01-1-Video-Operations-Basics](01-1-Video-Operations-Basics.ipynb) part d'une vidéo de test (5 secondes, 24 fps, 120 frames) et expose les primitives du traitement : découpage, changement de résolution, extraction audio, concatenation. C'est le socle sans lequel les notebooks de compréhension (01-2, 01-3) et d'amélioration (01-4) ne peuvent rien ingérer.
 
-<table>
-<tr><td align="center"><img src="assets/readme/vid1-ops.png" alt="Cinq frames extraites d'une vidéo de test colorée — Frame 1 (t=0.00s, vert, cercle blanc à droite), Frame 31 (t=1.25s, rouge, cercle en bas-centre), Frame 61 (t=2.50s, violet, cercle au centre-gauche), Frame 91 (t=3.75s, cyan, cercle en haut-centre), Frame 120 (t=4.96s, vert, cercle à droite)" width="600"/></td></tr>
-</table>
+<p align="center"><img src="assets/readme/vid1-ops.png" alt="Cinq frames extraites d'une vidéo de test colorée — Frame 1 (t=0.00s, vert, cercle blanc à droite), Frame 31 (t=1.25s, rouge, cercle en bas-centre), Frame 61 (t=2.50s, violet, cercle au centre-gauche), Frame 91 (t=3.75s, cyan, cercle en haut-centre), Frame 120 (t=4.96s, vert, cercle à droite)" width="600"/></p>
 
 *Figure extraite du notebook 01-1 (cellule 8, output 3). La grille présente 5 frames échantillonnées à intervalle régulier (t = 0.00s, 1.25s, 2.50s, 3.75s, 4.96s) sur une vidéo synthétique 5 secondes. Chaque frame change de couleur de fond (vert, rouge, violet, cyan, vert) et le cercle blanc se déplace à différentes positions — un terrain jouet volontairement contrasté pour valider visuellement que les opérations de découpage, sous-échantillonnage et concatenation préservent l'ordre temporel. La figure documente la capacité de moviepy à produire une mosaïque-frames à partir d'une source `.mp4`, pas le contenu sémantique de la vidéo.*
 
@@ -33,9 +31,7 @@ Le notebook [01-1-Video-Operations-Basics](01-1-Video-Operations-Basics.ipynb) p
 
 Une fois la vidéo techniquement manipulable, on veut en extraire du sens. Le notebook [01-2-GPT-5-Video-Understanding](01-2-GPT-5-Video-Understanding.ipynb) soumet une vidéo pédagogique à GPT-5 et lui demande d'en produire une analyse structurée : identification des scènes, transcription des sous-titres, Q&A sur le contenu. C'est le pont entre manipulation bas-niveau et compréhension haut-niveau.
 
-<table>
-<tr><td align="center"><img src="assets/readme/vid1-gpt5.png" alt="Cinq scènes vidéo analysées par GPT-5 — t=1.0s (orange, cercle orange + sous-titre 'Scene 1 — Intro'), t=3.0s (bleu, carré bleu + 'Scene 2 — Concept clé'), t=5.0s (vert, triangle vert + 'Scene 3 — Démonstration'), t=7.0s (rose, cercle rose + 'Scene 4 — Résultats'), t=9.0s (bleu nuit, 5 cercles jaunes + 'Scene 5 — Conclusion')" width="600"/></td></tr>
-</table>
+<p align="center"><img src="assets/readme/vid1-gpt5.png" alt="Cinq scènes vidéo analysées par GPT-5 — t=1.0s (orange, cercle orange + sous-titre 'Scene 1 — Intro'), t=3.0s (bleu, carré bleu + 'Scene 2 — Concept clé'), t=5.0s (vert, triangle vert + 'Scene 3 — Démonstration'), t=7.0s (rose, cercle rose + 'Scene 4 — Résultats'), t=9.0s (bleu nuit, 5 cercles jaunes + 'Scene 5 — Conclusion')" width="600"/></p>
 
 *Figure extraite du notebook 01-2 (cellule 8, output 2). La mosaïque présente les 5 scènes extraites d'une vidéo pédagogique — chaque scène a un fond de couleur distinct (orange, bleu, vert, rose, bleu nuit), un objet géométrique différent (cercle, carré, triangle, cercle, 5 cercles) et un sous-titre identifiant la phase pédagogique (Intro, Concept clé, Démonstration, Résultats, Conclusion). Cette structure répétitive scène-sous-titre est exactement ce que GPT-5 détecte pour produire une analyse temporelle segmentée. Limitation illustrative assumée : la figure documente la **structure** d'une vidéo analysable par GPT-5 (variation de couleur + sous-titres), pas le contenu textuel de l'analyse GPT-5 elle-même (voir cellules 9-18 du notebook pour la sortie JSON structurée du modèle).*
 
@@ -43,9 +39,7 @@ Une fois la vidéo techniquement manipulable, on veut en extraire du sens. Le no
 
 GPT-5 est généraliste ; Qwen-VL est spécialisé multimodal. Le notebook [01-3-Qwen-VL-Video-Analysis](01-3-Qwen-VL-Video-Analysis.ipynb) pousse plus loin : annotation automatique des scènes, Q&A ciblé, détection des entités visuelles (texte, objets, transitions). Utile quand on a besoin d'une extraction structurée plutôt que d'une analyse libre.
 
-<table>
-<tr><td align="center"><img src="assets/readme/vid1-qwen-vl.png" alt="Cinq scènes vidéo d'un cours — Introduction (fond bleu nuit, point jaune), Chapitre 1 (fond brun, point jaune), Demo (fond vert forêt, point jaune), Résultats (fond olive, point jaune), Conclusion (fond violet, point jaune)" width="600"/></td></tr>
-</table>
+<p align="center"><img src="assets/readme/vid1-qwen-vl.png" alt="Cinq scènes vidéo d'un cours — Introduction (fond bleu nuit, point jaune), Chapitre 1 (fond brun, point jaune), Demo (fond vert forêt, point jaune), Résultats (fond olive, point jaune), Conclusion (fond violet, point jaune)" width="600"/></p>
 
 *Figure extraite du notebook 01-3 (cellule 10, output 2). La vidéo source est un mini-cours découpé en 5 segments titrés (Introduction, Chapitre 1, Demo, Résultats, Conclusion), chacun sur un fond de couleur distinct et marqué par un point jaune central (la zone d'attention que Qwen-VL doit suivre). Les sous-titres incrustés en bas de chaque frame donnent le contexte sémantique que Qwen-VL doit corréler avec la perception visuelle. Limitation illustrative assumée : la figure montre la vidéo **à analyser**, pas la sortie Qwen-VL — le JSON produit par le modèle est dans les cellules 11-15 du notebook.*
 
@@ -53,15 +47,11 @@ GPT-5 est généraliste ; Qwen-VL est spécialisé multimodal. Le notebook [01-3
 
 Quand la vidéo source est basse résolution (LR), on peut l'upscaller (vers HR) avec Real-ESRGAN, un réseau convolutif entraîné sur des paires LR/HR. Le notebook [01-4-Video-Enhancement-ESRGAN](01-4-Video-Enhancement-ESRGAN.ipynb) couvre deux usages : l'**upscale spatial** (chaque frame gagne en résolution) et l'**interpolation temporelle** (de nouvelles frames sont insérées entre deux frames existantes pour fluidifier le mouvement).
 
-<table>
-<tr><td align="center"><img src="assets/readme/vid1-esrgan.png" alt="Comparaison HR (Référence, ligne haute) vs LR (Input, ligne basse) sur 4 frames (Frame 0, 12, 24, 35) — HR320x240 plus détaillé que LR320x240, cercle rouge et points verts" width="600"/></td></tr>
-</table>
+<p align="center"><img src="assets/readme/vid1-esrgan.png" alt="Comparaison HR (Référence, ligne haute) vs LR (Input, ligne basse) sur 4 frames (Frame 0, 12, 24, 35) — HR320x240 plus détaillé que LR320x240, cercle rouge et points verts" width="600"/></p>
 
 *Figure extraite du notebook 01-4 (cellule 8, output 3). La grille 2×4 juxtapose la version HR (Réference, ligne haute, HR320x240) et la version LR (Input, ligne basse, LR320x240) sur 4 frames échantillonnées (Frame 0, 12, 24, 35). Les frames HR portent un quadrillage blanc qui matérialise la grille de pixels upscale ; les frames LR sont plus pixelisées sur les bords du cercle rouge et des points verts. L'écart visuel entre les deux lignes illustre ce qu'ESRGAN apprend à reconstruire : textures fines, contours nets, séparation des objets superposés. Limitation illustrative assumée : la résolution HR reste 320×240 (l'upscale est de 1× ici à des fins pédagogiques — un upscale 4× est traité dans les cellules 12-18 du notebook avec un vrai modèle Real-ESRGAN chargé).*
 
-<table>
-<tr><td align="center"><img src="assets/readme/vid1-esrgan2.png" alt="Interpolation linéaire entre Frame A et Frame B — Frame A (Frame 1/36, cercle rouge + points verts), Interp 1/2/3 (frames intermédiaires avec deux cercles superposés), Frame B (Frame 6/36, cercle rouge + points verts)" width="600"/></td></tr>
-</table>
+<p align="center"><img src="assets/readme/vid1-esrgan2.png" alt="Interpolation linéaire entre Frame A et Frame B — Frame A (Frame 1/36, cercle rouge + points verts), Interp 1/2/3 (frames intermédiaires avec deux cercles superposés), Frame B (Frame 6/36, cercle rouge + points verts)" width="600"/></p>
 
 *Figure extraite du notebook 01-4 (cellule 16, output 1). L'interpolation linéaire entre Frame A (Frame 1/36, début de la séquence) et Frame B (Frame 6/36, fin) produit 3 frames intermédiaires (Interp 1, 2, 3) où deux cercles rouges se superposent — l'un hérité de A, l'autre de B — montrant la transition continue des positions. C'est l'opération duale de l'upscale spatial : au lieu d'augmenter la résolution des pixels, on **augmente la fréquence temporelle** en synthétisant les frames manquantes. Limitation illustrative assumée : l'interpolation linéaire produit un fantôme visible (deux cercles semi-transparents superposés) ; un modèle d'interpolation par flux optique (RIFE, FILM) produit une fusion nette et est traité dans les cellules 17-22 du notebook.*
 
@@ -69,9 +59,7 @@ Quand la vidéo source est basse résolution (LR), on peut l'upscaller (vers HR)
 
 Jusqu'ici on **analyse** ou **améliore** des vidéos existantes. AnimateDiff va plus loin : à partir d'un prompt textuel, il **génère** une vidéo courte (≈16 frames à 8 fps, soit 2 secondes) en injectant un module d'attention temporelle dans un UNet Stable Diffusion pré-entraîné. Le notebook [01-5-AnimateDiff-Introduction](01-5-AnimateDiff-Introduction.ipynb) montre comment combiner un prompt descriptif, un scheduler et un nombre de frames pour produire une animation cohérente.
 
-<table>
-<tr><td align="center"><img src="assets/readme/vid1-animatediff.png" alt="Huit frames d'animation générée par AnimateDiff — 'A serene lake at sunset with mountains in the background' style painterly/pastel, Frames 1/3/5/7/9/11/13/16 sur 16 (échantillonnées via np.linspace), disposées sur 2 lignes × 4 colonnes" width="600"/></td></tr>
-</table>
+<p align="center"><img src="assets/readme/vid1-animatediff.png" alt="Huit frames d'animation générée par AnimateDiff — 'A serene lake at sunset with mountains in the background' style painterly/pastel, Frames 1/3/5/7/9/11/13/16 sur 16 (échantillonnées via np.linspace), disposées sur 2 lignes × 4 colonnes" width="600"/></p>
 
 *Figure extraite du notebook 01-5 (cellule 10, output 3). L'animation représente un lac au coucher de soleil avec des montagnes en arrière-plan, rendue dans un style painterly/pastel caractéristique des modèles Stable Diffusion + module AnimateDiff. Les 8 frames échantillonnées (Frame 1, 3, 5, 7, 9, 11, 13, 16 sur 16, via `np.linspace`) montrent une variation subtile de la lumière et de la position des reflets — le mouvement est continu mais lent, signature typique d'AnimateDiff sur 16 frames. Limitation illustrative assumée : la qualité visuelle varie entre frames (l'une des frames du milieu porte un artefact de flou) et la cohérence personnage-objets est limitée — AnimateDiff est adapté aux paysages et ambiances, pas aux scènes avec personnages articulés (limitation traitée dans les cellules 11-14 du notebook).*
 


### PR DESCRIPTION
## Résumé

Normalisation doctrinale de 6 wrappers-bloc HTML autour de figures individuelles dans le README de `GenAI/Video/01-Foundation/`. Le contenu pédagogique adjacent (prose in-situ narrative par figure) avait été dissous par PR #6014, mais les wrappers-bloc 2-lignes `<table><tr><td align="center"><img ...></td></tr></table>` étaient restés en place.

**Doctrine post-#5780 stricte** : placement de figure = `<p align="center">`, pas de wrapper-bloc HTML. Aucune figure supprimée, aucune prose modifiée, aucun alt-text touché.

## Substance du diff

| Métrique | Avant | Après |
|---|---|---|
| Fichier | `MyIA.AI.Notebooks/GenAI/Video/01-Foundation/README.md` | (idem) |
| Lignes | 129 | 117 (-12 net) |
| `<table>` count | 6 | 0 |
| `<tr>` count | 6 | 0 |
| `<img>` count | 6 | 6 (préservées) |
| `<p align="center">` count | 0 | 6 |
| Alt-texts | 6 byte-identical | 6 byte-identical |
| Widths | 600 (×6) | 600 (×6) |
| Sources PNG | vid1-ops, vid1-gpt5, vid1-qwen-vl, vid1-esrgan, vid1-esrgan2, vid1-animatediff | (idem) |
| CR / LF | 0 / mixte | 0 CR / LF-only |

**Grain du diff** : 6 substitutions isolées 2-lignes → 1-ligne. Chaque figure conserve sa position relative dans la prose, ses alt-texts, sa largeur et son src. Aucune ligne de prose modifiée.

## 5-axis verification (doctrine #5780 stricte)

| Axe | Avant | Après | Verdict |
|---|---|---|---|
| `<table>` count | 6 | 0 | PASS |
| `<p align="center">` count | 0 | 6 (= figure count) | PASS |
| `<sub>` count | 0 | 0 | PASS |
| Alt-texts préservés | yes | yes (byte-identical) | PASS |
| LF-only (CR=0) | yes | yes | PASS |
| Net line delta | — | +6/-18 (-12 net) | — |
| Prose bytes modifiés | — | 0 hors wrappers | PASS |

## Hygiene catalog-pr-hygiene R1-R4

| Règle | Statut |
|---|---|
| R1 (1 fichier = 1 sujet) | OK : 1 fichier, 1 sujet (wrapper normalize) |
| R2 (CATALOG-STATUS byte-identique) | OK : fichier ne porte pas de marqueur CATALOG-STATUS |
| R3 (rebase frais avant push) | OK : rebase depuis origin/main@68548d8ae, 0 commits de retard |
| R4 (`See #X` vs `Closes #X`) | OK : `See #5780` (contribution partielle à l'EPIC) |

## Provenance figures

| Figure | Notebook source | Cellule | Output | Alt-text |
|---|---|---|---|---|
| vid1-ops.png | 01-1-Video-Operations-Basics | cell 8 | output 3 | byte-identical préservé |
| vid1-gpt5.png | 01-2-GPT-5-Video-Understanding | cell 8 | output 2 | byte-identical préservé |
| vid1-qwen-vl.png | 01-3-Qwen-VL-Video-Analysis | cell 10 | output 2 | byte-identical préservé |
| vid1-esrgan.png | 01-4-Video-Enhancement-ESRGAN | cell 8 | output 3 | byte-identical préservé |
| vid1-esrgan2.png | 01-4-Video-Enhancement-ESRGAN | cell 16 | output 1 | byte-identical préservé |
| vid1-animatediff.png | 01-5-AnimateDiff-Introduction | cell 10 | output 3 | byte-identical préservé |

Voir `MyIA.AI.Notebooks/GenAI/Video/01-Foundation/assets/readme/MANIFEST.md` pour la fiche canonique.

## Cross-référence

- **EPIC #5780** : doctrine figures README (intégration narrative sans galerie). PR #6014 MERGED avait déjà dissous la galerie en prose in-situ ; ce PR complète l'alignement doctrinel en normalisant les wrappers-bloc résiduels.
- **PR #6014** (`docs(genai-video): 01-Foundation figures in-line narratif (doctrine #5780 stricte)`) : dissolution galerie → in-situ narrative (6 figures, prose alignée). MERGED.
- **PR #6905** (`fix(genai-video,#5780): corrige les numéros de frames fabriqués de vid1-animatediff`) : correctness alt-text. MERGED.

**Verdict honnête** : grain R3 atomic = 1 fichier, 1 sujet, pas de composite. EPIC #5780 doctrine stricte respectée (5/5 axes PASS). Wrapper normalization sans impact sur les figures elles-mêmes (srcs, alt-texts, widths byte-identical).