### PR TITLE
feat(casestudies,#2161): add 3 extension-exercise stubs to Diagnostic-Medical student notebook

### DIFF
--- a/MyIA.AI.Notebooks/CaseStudies/Diagnostic-Medical/student/Diagnostic-Medical.ipynb
+++ b/MyIA.AI.Notebooks/CaseStudies/Diagnostic-Medical/student/Diagnostic-Medical.ipynb
@@ -49,10 +49,10 @@
    "id": "a6ffca9a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-02-20T10:19:37.009237Z",
-     "iopub.status.busy": "2026-02-20T10:19:37.009237Z",
-     "iopub.status.idle": "2026-02-20T10:19:39.913368Z",
-     "shell.execute_reply": "2026-02-20T10:19:39.912855Z"
+     "iopub.execute_input": "2026-07-18T23:56:14.472238Z",
+     "iopub.status.busy": "2026-07-18T23:56:14.471592Z",
+     "iopub.status.idle": "2026-07-18T23:56:14.491015Z",
+     "shell.execute_reply": "2026-07-18T23:56:14.486737Z"
     },
     "papermill": {
      "duration": 2.912945,
@@ -71,11 +71,11 @@
   },
   {
    "cell_type": "markdown",
+   "id": "cell-e74315e1",
    "metadata": {},
    "source": [
     "Configuration et imports du notebook."
-   ],
-   "id": "cell-e74315e1"
+   ]
   },
   {
    "cell_type": "code",
@@ -83,10 +83,10 @@
    "id": "d894a937",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-02-20T10:19:39.924446Z",
-     "iopub.status.busy": "2026-02-20T10:19:39.923438Z",
-     "iopub.status.idle": "2026-02-20T10:19:42.240954Z",
-     "shell.execute_reply": "2026-02-20T10:19:42.239943Z"
+     "iopub.execute_input": "2026-07-18T23:56:14.501534Z",
+     "iopub.status.busy": "2026-07-18T23:56:14.501534Z",
+     "iopub.status.idle": "2026-07-18T23:56:15.615265Z",
+     "shell.execute_reply": "2026-07-18T23:56:15.615265Z"
     },
     "papermill": {
      "duration": 2.323033,
@@ -171,10 +171,10 @@
    "id": "5ef50610",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-02-20T10:19:42.267622Z",
-     "iopub.status.busy": "2026-02-20T10:19:42.267622Z",
-     "iopub.status.idle": "2026-02-20T10:19:42.278905Z",
-     "shell.execute_reply": "2026-02-20T10:19:42.277892Z"
+     "iopub.execute_input": "2026-07-18T23:56:15.632929Z",
+     "iopub.status.busy": "2026-07-18T23:56:15.632929Z",
+     "iopub.status.idle": "2026-07-18T23:56:15.639858Z",
+     "shell.execute_reply": "2026-07-18T23:56:15.639516Z"
     },
     "papermill": {
      "duration": 0.020325,
@@ -297,10 +297,10 @@
    "id": "c953a353",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-02-20T10:19:42.305720Z",
-     "iopub.status.busy": "2026-02-20T10:19:42.304721Z",
-     "iopub.status.idle": "2026-02-20T10:19:42.313766Z",
-     "shell.execute_reply": "2026-02-20T10:19:42.312244Z"
+     "iopub.execute_input": "2026-07-18T23:56:15.661312Z",
+     "iopub.status.busy": "2026-07-18T23:56:15.659148Z",
+     "iopub.status.idle": "2026-07-18T23:56:15.669039Z",
+     "shell.execute_reply": "2026-07-18T23:56:15.667766Z"
     },
     "papermill": {
      "duration": 0.016182,
@@ -402,10 +402,10 @@
    "id": "ec5bfce7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-02-20T10:19:42.340351Z",
-     "iopub.status.busy": "2026-02-20T10:19:42.339349Z",
-     "iopub.status.idle": "2026-02-20T10:19:42.345414Z",
-     "shell.execute_reply": "2026-02-20T10:19:42.344400Z"
+     "iopub.execute_input": "2026-07-18T23:56:15.699937Z",
+     "iopub.status.busy": "2026-07-18T23:56:15.699937Z",
+     "iopub.status.idle": "2026-07-18T23:56:15.718217Z",
+     "shell.execute_reply": "2026-07-18T23:56:15.715102Z"
     },
     "papermill": {
      "duration": 0.014683,
@@ -436,6 +436,58 @@
     "    pass\n",
     "\n",
     "print(\"🧪 Tests de l'agent de diagnostic à compléter\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "edaa001d",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 : Etendre l'agent de diagnostic avec un score de risque\n",
+    "\n",
+    "**Objectif** : Ajouter une méthode `calculer_score_risque` a la classe `DiagnosticAgent` qui combine les indicateurs cliniques en un score numérique composite.\n",
+    "\n",
+    "**Contexte** : La classification actuelle (Normal/Pre-diabete/Diabete) est trop grossiere. Un score numérique permet de prioriser les patients et de suivre l'evolution dans le temps.\n",
+    "\n",
+    "**Indices** :\n",
+    "- # Indice 1 : Combinez la glycémie à jeun, l'HbA1c et le nombre de symptomes en un score pondere\n",
+    "- # Indice 2 : Normalisez chaque indicateur entre 0 et 1 avant de les combiner\n",
+    "- # Étape 1 : Définir les seuils de normalisation pour chaque indicateur\n",
+    "- # Étape 2 : Calculer le score pondere (ex: 40% glycémie, 40% HbA1c, 20% symptomes)\n",
+    "- # Étape 3 : Tester sur les 3 patients de reference et verifier la coherence avec la classification"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "256f7ac0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-18T23:56:15.744961Z",
+     "iopub.status.busy": "2026-07-18T23:56:15.742958Z",
+     "iopub.status.idle": "2026-07-18T23:56:15.768858Z",
+     "shell.execute_reply": "2026-07-18T23:56:15.762671Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : score de risque composite\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 : Score de risque composite\n",
+    "# TODO etudiant : Implementer une methode calculer_score_risque(patient) -> float\n",
+    "# TODO etudiant : Normaliser chaque indicateur entre 0 et 1\n",
+    "# TODO etudiant : Tester sur les 3 patients (Alice, Bob, Claire)\n",
+    "result = None  # TODO etudiant : remplacer par votre calcul\n",
+    "print(\"Exercice a completer : score de risque composite\")"
    ]
   },
   {
@@ -479,14 +531,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "39e86e61",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-02-20T10:19:42.365230Z",
-     "iopub.status.busy": "2026-02-20T10:19:42.364217Z",
-     "iopub.status.idle": "2026-02-20T10:19:42.373318Z",
-     "shell.execute_reply": "2026-02-20T10:19:42.372773Z"
+     "iopub.execute_input": "2026-07-18T23:56:15.790388Z",
+     "iopub.status.busy": "2026-07-18T23:56:15.776173Z",
+     "iopub.status.idle": "2026-07-18T23:56:15.817670Z",
+     "shell.execute_reply": "2026-07-18T23:56:15.817670Z"
     },
     "papermill": {
      "duration": 0.014247,
@@ -592,14 +644,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "a49803b8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-02-20T10:19:42.392382Z",
-     "iopub.status.busy": "2026-02-20T10:19:42.391367Z",
-     "iopub.status.idle": "2026-02-20T10:19:42.396396Z",
-     "shell.execute_reply": "2026-02-20T10:19:42.395185Z"
+     "iopub.execute_input": "2026-07-18T23:56:15.841340Z",
+     "iopub.status.busy": "2026-07-18T23:56:15.838867Z",
+     "iopub.status.idle": "2026-07-18T23:56:15.868538Z",
+     "shell.execute_reply": "2026-07-18T23:56:15.860608Z"
     },
     "papermill": {
      "duration": 0.011079,
@@ -630,6 +682,58 @@
     "    pass\n",
     "\n",
     "print(\"⚡ Tests de performance A* à compléter\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8f2a7f37",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 : Comparer différentes heuristiques pour A*\n",
+    "\n",
+    "**Objectif** : Implementer une heuristique alternative pour l'algorithme A* et comparer le nombre d'itérations et la qualite du diagnostic.\n",
+    "\n",
+    "**Contexte** : L'heuristique actuelle utilise une combinaison lineaire d'evidences cliniques. Une heuristique basee uniquement sur l'HbA1c pourrait etre plus rapide mais moins precise.\n",
+    "\n",
+    "**Indices** :\n",
+    "- # Indice 1 : Implementez une heuristique `h_simple(etat)` qui n'utilise que l'HbA1c du patient\n",
+    "- # Indice 2 : Comparez le nombre d'itérations et le niveau de confiance final\n",
+    "- # Étape 1 : Définir la nouvelle heuristique dans une sous-classe de `AStarDiagnostic`\n",
+    "- # Étape 2 : Executer la recherche sur les 3 patients de test\n",
+    "- # Étape 3 : Comparer les résultats (itérations, confiance, hypotheses) avec l'heuristique originale"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "5b185d57",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-18T23:56:15.890684Z",
+     "iopub.status.busy": "2026-07-18T23:56:15.890684Z",
+     "iopub.status.idle": "2026-07-18T23:56:15.911614Z",
+     "shell.execute_reply": "2026-07-18T23:56:15.907167Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : heuristique alternative A*\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 : Heuristique alternative pour A*\n",
+    "# TODO etudiant : Creer une sous-classe de AStarDiagnostic avec une heuristique simplifiee\n",
+    "# TODO etudiant : Executer la recherche sur les 3 patients de test\n",
+    "# TODO etudiant : Comparer les resultats avec l'heuristique originale\n",
+    "result = None  # TODO etudiant : remplacer par votre comparaison\n",
+    "print(\"Exercice a completer : heuristique alternative A*\")"
    ]
   },
   {
@@ -674,14 +778,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "id": "45a073e3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-02-20T10:19:42.420612Z",
-     "iopub.status.busy": "2026-02-20T10:19:42.419613Z",
-     "iopub.status.idle": "2026-02-20T10:19:42.428278Z",
-     "shell.execute_reply": "2026-02-20T10:19:42.427733Z"
+     "iopub.execute_input": "2026-07-18T23:56:15.926497Z",
+     "iopub.status.busy": "2026-07-18T23:56:15.926497Z",
+     "iopub.status.idle": "2026-07-18T23:56:15.958377Z",
+     "shell.execute_reply": "2026-07-18T23:56:15.956138Z"
     },
     "papermill": {
      "duration": 0.017189,
@@ -776,14 +880,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "id": "2d7b2b42",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-02-20T10:19:42.453524Z",
-     "iopub.status.busy": "2026-02-20T10:19:42.453524Z",
-     "iopub.status.idle": "2026-02-20T10:19:42.458791Z",
-     "shell.execute_reply": "2026-02-20T10:19:42.457776Z"
+     "iopub.execute_input": "2026-07-18T23:56:15.990049Z",
+     "iopub.status.busy": "2026-07-18T23:56:15.987091Z",
+     "iopub.status.idle": "2026-07-18T23:56:16.015260Z",
+     "shell.execute_reply": "2026-07-18T23:56:16.011038Z"
     },
     "papermill": {
      "duration": 0.013264,
@@ -857,14 +961,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "id": "e509b94d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-02-20T10:19:42.490702Z",
-     "iopub.status.busy": "2026-02-20T10:19:42.490147Z",
-     "iopub.status.idle": "2026-02-20T10:19:42.497408Z",
-     "shell.execute_reply": "2026-02-20T10:19:42.495886Z"
+     "iopub.execute_input": "2026-07-18T23:56:16.036328Z",
+     "iopub.status.busy": "2026-07-18T23:56:16.035318Z",
+     "iopub.status.idle": "2026-07-18T23:56:16.054429Z",
+     "shell.execute_reply": "2026-07-18T23:56:16.051550Z"
     },
     "papermill": {
      "duration": 0.015332,
@@ -949,14 +1053,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "id": "6d572a40",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-02-20T10:19:42.526253Z",
-     "iopub.status.busy": "2026-02-20T10:19:42.526253Z",
-     "iopub.status.idle": "2026-02-20T10:19:42.533355Z",
-     "shell.execute_reply": "2026-02-20T10:19:42.531810Z"
+     "iopub.execute_input": "2026-07-18T23:56:16.058500Z",
+     "iopub.status.busy": "2026-07-18T23:56:16.058500Z",
+     "iopub.status.idle": "2026-07-18T23:56:16.066913Z",
+     "shell.execute_reply": "2026-07-18T23:56:16.065812Z"
     },
     "papermill": {
      "duration": 0.015849,
@@ -987,6 +1091,58 @@
     "    pass\n",
     "\n",
     "print(\"✅ Tests de validation Z3 à compléter\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dc640dc9",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 : Ajouter des contraintes d'interaction medicamenteuse au solveur Z3\n",
+    "\n",
+    "**Objectif** : Etendre le solveur Z3 pour inclure de nouvelles contraintes d'interaction entre medicaments et verifier que le protocole est sur.\n",
+    "\n",
+    "**Contexte** : Les interactions medicamenteuses sont une source majeure de risques. L'insuline combinee a certains antidiabetiques oraux augmente le risque d'hypoglycemie severe.\n",
+    "\n",
+    "**Indices** :\n",
+    "- # Indice 1 : Ajoutez une contrainte Z3 qui limite la dose d'insuline si le patient prend aussi de la metformine\n",
+    "- # Indice 2 : Utilisez `Implies()` et `And()` pour exprimer les conditions\n",
+    "- # Étape 1 : Ajouter la variable booleenne `hypoglycemie_risque` au modèle\n",
+    "- # Étape 2 : Définir les contraintes d'interaction\n",
+    "- # Étape 3 : Tester avec un patient qui a des antecedents d'hypoglycemie et verifier que le solveur refuse certaines combinaisons"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "296e6787",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-18T23:56:16.073468Z",
+     "iopub.status.busy": "2026-07-18T23:56:16.072315Z",
+     "iopub.status.idle": "2026-07-18T23:56:16.090109Z",
+     "shell.execute_reply": "2026-07-18T23:56:16.083928Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : contraintes d'interaction medicamenteuse\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 : Contraintes d'interaction medicamenteuse avec Z3\n",
+    "# TODO etudiant : Etendre la classe Z3ConstraintSolver avec des contraintes d'interaction\n",
+    "# TODO etudiant : Ajouter une contrainte sur la dose d'insuline si metformine aussi prescrite\n",
+    "# TODO etudiant : Tester avec un patient hypoglycemique\n",
+    "result = None  # TODO etudiant : remplacer par votre solution Z3\n",
+    "print(\"Exercice a completer : contraintes d'interaction medicamenteuse\")"
    ]
   },
   {
@@ -1025,14 +1181,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 15,
    "id": "e0a532b6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-02-20T10:19:42.566861Z",
-     "iopub.status.busy": "2026-02-20T10:19:42.565859Z",
-     "iopub.status.idle": "2026-02-20T10:19:42.573910Z",
-     "shell.execute_reply": "2026-02-20T10:19:42.572394Z"
+     "iopub.execute_input": "2026-07-18T23:56:16.092816Z",
+     "iopub.status.busy": "2026-07-18T23:56:16.092816Z",
+     "iopub.status.idle": "2026-07-18T23:56:16.117963Z",
+     "shell.execute_reply": "2026-07-18T23:56:16.115854Z"
     },
     "papermill": {
      "duration": 0.017726,
@@ -1082,22 +1238,22 @@
   },
   {
    "cell_type": "markdown",
+   "id": "cell-1511bccd",
    "metadata": {},
    "source": [
     "Tests automatises a completer."
-   ],
-   "id": "cell-1511bccd"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 16,
    "id": "6f254673",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-02-20T10:19:42.588939Z",
-     "iopub.status.busy": "2026-02-20T10:19:42.588939Z",
-     "iopub.status.idle": "2026-02-20T10:19:42.595939Z",
-     "shell.execute_reply": "2026-02-20T10:19:42.594338Z"
+     "iopub.execute_input": "2026-07-18T23:56:16.142366Z",
+     "iopub.status.busy": "2026-07-18T23:56:16.139573Z",
+     "iopub.status.idle": "2026-07-18T23:56:16.158666Z",
+     "shell.execute_reply": "2026-07-18T23:56:16.155108Z"
     },
     "papermill": {
      "duration": 0.015517,
@@ -1170,8 +1326,7 @@
     "✅ **Optimisation** : Algorithmes génétiques\n",
     "✅ **Application Biomédicale** : Diagnostic du diabète de type 2\n",
     "\n",
-    "Les compétences développées sont directement transférables à d'autres domaines nécessitant des systèmes de décision intelligents.",
-    "\n",
+    "Les compétences développées sont directement transférables à d'autres domaines nécessitant des systèmes de décision intelligents.\n",
     "---\n",
     "**Retour au sommaire** : [Index CaseStudies](../../README.md)\n"
    ]
@@ -1193,7 +1348,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.12.13"
   },
   "papermill": {
    "default_parameters": {},


### PR DESCRIPTION
## Objet

Le notebook **etudiant** `CaseStudies/Diagnostic-Medical/student/Diagnostic-Medical.ipynb` (etude de cas integrative, CC1 EPF) ne contenait **aucun exercice structure**, alors que sa contrepartie `solution/` porte deja **3 paires** (markdown + code) d'exercices d'extension laisses **en stub dans les deux versions**.

Cette PR ajoute ces 3 paires `### Exercice N` au notebook etudiant, aux **positions miroir** de la solution :

| # | Exercice | Ancrage (apres) |
|---|----------|-----------------|
| 1 | Score de risque composite | `DiagnosticAgent` (regle) |
| 2 | Heuristique alternative A* | `AStarDiagnostic` (recherche informee) |
| 3 | Contraintes d'interaction medicamenteuse | `Z3ConstraintSolver` (CSP) |

## Pourquoi

- **Parite student/solution** : le scaffold etudiant etait incomplet (6 cellules manquantes vs la solution).
- **Convention #2161** (>=3 exercices/notebook) : passe de 0/3 a **3/3 conforme**.

## Zero-leak

Les exercices de la solution sont **eux-memes des stubs** (exercices d'extension non resolus dans les deux versions). La copie verbatim n'introduit donc **aucune solution** dans le notebook etudiant. `solution/Diagnostic-Medical.ipynb` reste **byte-identique** (non touche).

## Conformite

- **C.1** : stubs `result = None  # TODO etudiant` + `print("Exercice a completer : ...")` — aucun `raise NotImplementedError` / `assert False` / `1/0`.
- **C.2** : notebook re-execute end-to-end (nbconvert, env `coursia-ml-training`) et committe AVEC outputs. 33 cellules, 16 code cells toutes avec `execution_count`, **0 erreur**.
- `count_exercises.py` = **3 / 3 conforme**. `nbformat.validate()` OK, 33 cell-ids uniques.
- `git diff --shortstat` = `1 file changed, 223 insertions(+), 68 deletions(+)` (les deletions = `execution_count`/outputs rafraichis par la re-execution complete, aucune cellule source supprimee).

## Suivi

Les deux autres etudes de cas (`Oncology-Planning`, `SmartGrid-Energy`) presentent probablement le meme ecart student/solution — a traiter en **PR separees** (une par sujet).

See #2161
