### PR TITLE
feat(casestudies,#2161): add 3 extension-exercise stubs to Oncology-Planning student notebook

### DIFF
--- a/MyIA.AI.Notebooks/CaseStudies/Oncology-Planning/student/Oncology-Planning.ipynb
+++ b/MyIA.AI.Notebooks/CaseStudies/Oncology-Planning/student/Oncology-Planning.ipynb
@@ -49,10 +49,10 @@
    "id": "c082cf28",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T20:39:58.205493Z",
-     "iopub.status.busy": "2026-06-05T20:39:58.205068Z",
-     "iopub.status.idle": "2026-06-05T20:40:01.089115Z",
-     "shell.execute_reply": "2026-06-05T20:40:01.088177Z"
+     "iopub.execute_input": "2026-07-19T00:21:00.341138Z",
+     "iopub.status.busy": "2026-07-19T00:21:00.341138Z",
+     "iopub.status.idle": "2026-07-19T00:21:00.344301Z",
+     "shell.execute_reply": "2026-07-19T00:21:00.344301Z"
     },
     "papermill": {
      "duration": 2.888451,
@@ -92,10 +92,10 @@
    "id": "16131259",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T20:40:01.102718Z",
-     "iopub.status.busy": "2026-06-05T20:40:01.102342Z",
-     "iopub.status.idle": "2026-06-05T20:40:06.774174Z",
-     "shell.execute_reply": "2026-06-05T20:40:06.773115Z"
+     "iopub.execute_input": "2026-07-19T00:21:00.345307Z",
+     "iopub.status.busy": "2026-07-19T00:21:00.345307Z",
+     "iopub.status.idle": "2026-07-19T00:21:03.735489Z",
+     "shell.execute_reply": "2026-07-19T00:21:03.734919Z"
     },
     "papermill": {
      "duration": 5.676473,
@@ -187,10 +187,10 @@
    "id": "55fc3ca1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T20:40:06.798595Z",
-     "iopub.status.busy": "2026-06-05T20:40:06.798101Z",
-     "iopub.status.idle": "2026-06-05T20:40:06.802095Z",
-     "shell.execute_reply": "2026-06-05T20:40:06.801157Z"
+     "iopub.execute_input": "2026-07-19T00:21:03.738107Z",
+     "iopub.status.busy": "2026-07-19T00:21:03.737591Z",
+     "iopub.status.idle": "2026-07-19T00:21:03.740713Z",
+     "shell.execute_reply": "2026-07-19T00:21:03.740155Z"
     },
     "papermill": {
      "duration": 0.009681,
@@ -235,10 +235,10 @@
    "id": "498cb8cf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T20:40:06.815446Z",
-     "iopub.status.busy": "2026-06-05T20:40:06.815100Z",
-     "iopub.status.idle": "2026-06-05T20:40:06.820149Z",
-     "shell.execute_reply": "2026-06-05T20:40:06.819230Z"
+     "iopub.execute_input": "2026-07-19T00:21:03.742176Z",
+     "iopub.status.busy": "2026-07-19T00:21:03.742176Z",
+     "iopub.status.idle": "2026-07-19T00:21:03.750658Z",
+     "shell.execute_reply": "2026-07-19T00:21:03.750136Z"
     },
     "papermill": {
      "duration": 0.009752,
@@ -294,6 +294,72 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "2b8bbd38",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-19T00:21:03.752725Z",
+     "iopub.status.busy": "2026-07-19T00:21:03.752209Z",
+     "iopub.status.idle": "2026-07-19T00:21:03.755884Z",
+     "shell.execute_reply": "2026-07-19T00:21:03.755330Z"
+    },
+    "papermill": {
+     "duration": 0.009451,
+     "end_time": "2026-06-05T20:38:49.931727+00:00",
+     "exception": false,
+     "start_time": "2026-06-05T20:38:49.922276+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : ontologie etendue\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 : Etendre l'ontologie medicamenteuse\n",
+    "# TODO etudiant : Ajouter \"Paclitaxel\" et \"Carboplatine\" au dictionnaire medicaments\n",
+    "# TODO etudiant : Peupler le graphe RDF avec les nouveaux triplets\n",
+    "# TODO etudiant : Tester verifier_prescription avec les nouvelles combinaisons\n",
+    "result = None  # TODO etudiant : remplacer par votre ontologie etendue\n",
+    "print(\"Exercice a completer : ontologie etendue\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae5963c7",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003514,
+     "end_time": "2026-06-05T20:38:49.938949+00:00",
+     "exception": false,
+     "start_time": "2026-06-05T20:38:49.935435+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 : Etendre l'ontologie avec de nouveaux medicaments et interactions\n",
+    "\n",
+    "**Objectif** : Ajouter de nouveaux medicaments a l'ontologie RDF et implementer une verification d'interactions etendue.\n",
+    "\n",
+    "**Contexte** : L'ontologie actuelle contient 4 medicaments. En pratique, les protocoles oncologiques combinent davantage de molecules, et les interactions croisees sont critiques.\n",
+    "\n",
+    "**Indices** :\n",
+    "- # Indice 1 : Ajoutez \"Paclitaxel\" (toxicite_renale=False, incompatible avec \"Docetaxel\") et \"Carboplatine\" (toxicite_renale=True, incompatible avec \"Cisplatine\")\n",
+    "- # Indice 2 : Verifiez qu'un protocole [\"Cisplatine\", \"Carboplatine\"] declenche bien une alerte d'incompatibilite\n",
+    "- # Étape 1 : Ajouter les nouveaux medicaments au dictionnaire `medicaments`\n",
+    "- # Étape 2 : Peupler le graphe RDF avec les nouveaux triplets\n",
+    "- # Étape 3 : Tester la fonction `verifier_prescription` avec des combinaisons incluant les nouveaux medicaments"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "ef5ad9fe",
    "metadata": {
@@ -314,14 +380,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "89e569ee",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T20:40:06.832929Z",
-     "iopub.status.busy": "2026-06-05T20:40:06.832587Z",
-     "iopub.status.idle": "2026-06-05T20:40:06.864169Z",
-     "shell.execute_reply": "2026-06-05T20:40:06.863236Z"
+     "iopub.execute_input": "2026-07-19T00:21:03.757469Z",
+     "iopub.status.busy": "2026-07-19T00:21:03.757469Z",
+     "iopub.status.idle": "2026-07-19T00:21:03.812428Z",
+     "shell.execute_reply": "2026-07-19T00:21:03.812428Z"
     },
     "papermill": {
      "duration": 0.035874,
@@ -391,6 +457,72 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "ce9bfce9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-19T00:21:03.815914Z",
+     "iopub.status.busy": "2026-07-19T00:21:03.814915Z",
+     "iopub.status.idle": "2026-07-19T00:21:03.818811Z",
+     "shell.execute_reply": "2026-07-19T00:21:03.818811Z"
+    },
+    "papermill": {
+     "duration": 0.010168,
+     "end_time": "2026-06-05T20:38:50.090015+00:00",
+     "exception": false,
+     "start_time": "2026-06-05T20:38:50.079847+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : sensibilite au prior\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 : Sensibilite au prior du profil patient\n",
+    "# TODO etudiant : Creer une version parametrable du modele avec profil_probs en argument\n",
+    "# TODO etudiant : Tester 3 configurations de prior differentes\n",
+    "# TODO etudiant : Comparer les posterieurs dans un tableau\n",
+    "result = None  # TODO etudiant : remplacer par votre analyse\n",
+    "print(\"Exercice a completer : sensibilite au prior\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0243637f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003366,
+     "end_time": "2026-06-05T20:38:50.096901+00:00",
+     "exception": false,
+     "start_time": "2026-06-05T20:38:50.093535+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 : Sensibilite du modèle bayesien au prior sur le profil patient\n",
+    "\n",
+    "**Objectif** : Etudier comment le choix du prior sur les profils (Resistant/Normal/Sensible) influence le diagnostic posterieur.\n",
+    "\n",
+    "**Contexte** : Le prior actuel est `[0.1, 0.6, 0.3]` (10% Resistants, 60% Normaux, 30% Sensibles). Si la population est différente, le diagnostic change.\n",
+    "\n",
+    "**Indices** :\n",
+    "- # Indice 1 : Modifiez `profil_probs` dans la méthode `model()` pour tester : `[0.33, 0.34, 0.33]` (uniforme), `[0.05, 0.90, 0.05]` (peu de sensibles)\n",
+    "- # Indice 2 : Relancez l'inference SVI et comparez les probabilites a posteriori du profil\n",
+    "- # Étape 1 : Créer une fonction qui accepte le prior en paramètre\n",
+    "- # Étape 2 : Tester 3 configurations de prior différentes\n",
+    "- # Étape 3 : Afficher les posterieurs dans un tableau comparatif"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "d43b403b",
    "metadata": {
@@ -411,14 +543,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "id": "815f392f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T20:40:06.882072Z",
-     "iopub.status.busy": "2026-06-05T20:40:06.881737Z",
-     "iopub.status.idle": "2026-06-05T20:40:06.886588Z",
-     "shell.execute_reply": "2026-06-05T20:40:06.885769Z"
+     "iopub.execute_input": "2026-07-19T00:21:03.822392Z",
+     "iopub.status.busy": "2026-07-19T00:21:03.820857Z",
+     "iopub.status.idle": "2026-07-19T00:21:03.827663Z",
+     "shell.execute_reply": "2026-07-19T00:21:03.827663Z"
     },
     "papermill": {
      "duration": 0.009126,
@@ -501,14 +633,80 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
+   "id": "302de264",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-19T00:21:03.829669Z",
+     "iopub.status.busy": "2026-07-19T00:21:03.829669Z",
+     "iopub.status.idle": "2026-07-19T00:21:03.838924Z",
+     "shell.execute_reply": "2026-07-19T00:21:03.837915Z"
+    },
+    "papermill": {
+     "duration": 0.008548,
+     "end_time": "2026-06-05T20:38:54.796581+00:00",
+     "exception": false,
+     "start_time": "2026-06-05T20:38:54.788033+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : journal d'audit\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 : Journal d'audit pour le contrat intelligent\n",
+    "# TODO etudiant : Etendre OncoContract avec un attribut historique\n",
+    "# TODO etudiant : Implementer afficher_historique() qui liste toutes les modifications\n",
+    "# TODO etudiant : Tester avec plusieurs modifications successives\n",
+    "result = None  # TODO etudiant : remplacer par votre contrat avec audit\n",
+    "print(\"Exercice a completer : journal d'audit\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d2746864",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003316,
+     "end_time": "2026-06-05T20:38:54.803226+00:00",
+     "exception": false,
+     "start_time": "2026-06-05T20:38:54.799910+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 : Ajouter un journal d'audit au contrat intelligent\n",
+    "\n",
+    "**Objectif** : Etendre la classe `OncoContract` pour maintenir un historique des modifications et detecter les tentatives de fraude.\n",
+    "\n",
+    "**Contexte** : Le contrat actuel enregistre un seul plan. En pratique, les plans peuvent etre modifiés plusieurs fois, et il faut tracer qui a fait quoi et quand.\n",
+    "\n",
+    "**Indices** :\n",
+    "- # Indice 1 : Ajoutez un attribut `self.historique = []` qui stocke chaque modification\n",
+    "- # Indice 2 : Chaque entree du journal doit contenir : horodatage, auteur, action, hash du plan\n",
+    "- # Étape 1 : Ajouter l'attribut `historique` et le mettre a jour a chaque appel de `enregistrer_plan`\n",
+    "- # Étape 2 : Implementer une méthode `afficher_historique()` qui affiche le journal\n",
+    "- # Étape 3 : Tester en modifiant le plan plusieurs fois et verifier que l'historique est complet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
    "id": "e50bbbb7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T20:40:06.898977Z",
-     "iopub.status.busy": "2026-06-05T20:40:06.898761Z",
-     "iopub.status.idle": "2026-06-05T20:40:06.901960Z",
-     "shell.execute_reply": "2026-06-05T20:40:06.901050Z"
+     "iopub.execute_input": "2026-07-19T00:21:03.840949Z",
+     "iopub.status.busy": "2026-07-19T00:21:03.839926Z",
+     "iopub.status.idle": "2026-07-19T00:21:03.843500Z",
+     "shell.execute_reply": "2026-07-19T00:21:03.843500Z"
     },
     "papermill": {
      "duration": 0.007487,
@@ -569,14 +767,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 11,
    "id": "977dbd22",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T20:40:06.919514Z",
-     "iopub.status.busy": "2026-06-05T20:40:06.919314Z",
-     "iopub.status.idle": "2026-06-05T20:40:06.924279Z",
-     "shell.execute_reply": "2026-06-05T20:40:06.923458Z"
+     "iopub.execute_input": "2026-07-19T00:21:03.845515Z",
+     "iopub.status.busy": "2026-07-19T00:21:03.845515Z",
+     "iopub.status.idle": "2026-07-19T00:21:03.849754Z",
+     "shell.execute_reply": "2026-07-19T00:21:03.849754Z"
     },
     "papermill": {
      "duration": 0.00902,
@@ -645,7 +843,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.7"
+   "version": "3.12.13"
   },
   "papermill": {
    "default_parameters": {},


### PR DESCRIPTION
## Objet

Le notebook **etudiant** `CaseStudies/Oncology-Planning/student/Oncology-Planning.ipynb` (etude de cas integrative, CC1 EPF) ne contenait **aucun exercice structure**, alors que sa contrepartie `solution/` porte deja **3 paires** (code + markdown) d'exercices d'extension laisses **en stub dans les deux versions**.

Cette PR ajoute ces 3 paires `### Exercice N` au notebook etudiant, aux **positions miroir** de la solution :

| # | Exercice | Ancrage (apres) |
|---|----------|-----------------|
| 1 | Etendre l'ontologie medicamenteuse (RDFLib) | `verifier_prescription` (pharmacien symbolique) |
| 2 | Sensibilite au prior du profil patient (Pyro) | fin de la Partie 1 (`---`) |
| 3 | Journal d'audit pour le contrat intelligent | prediction probabiliste (`### 2.2`) |

## Pourquoi

- **Parite student/solution** : le scaffold etudiant etait incomplet (6 cellules manquantes vs la solution).
- **Convention #2161** (>=3 exercices/notebook) : passe de 0/3 a **3/3 conforme**.

## Zero-leak

Les exercices de la solution sont **eux-memes des stubs** (exercices d'extension non resolus dans les deux versions). La copie verbatim n'introduit donc **aucune solution** dans le notebook etudiant. `solution/Oncology-Planning.ipynb` reste **byte-identique** (non touche).

## Conformite

- **C.1** : stubs `result = None  # TODO etudiant` + `print("Exercice a completer : ...")` — aucun `raise NotImplementedError` / `assert False` / `1/0`.
- **C.2** : notebook re-execute end-to-end (nbconvert, env `coursia-ml-training`) et committe AVEC outputs. 27 cellules, 11 code cells toutes avec `execution_count`, **0 erreur**.
- `count_exercises.py` = **3 / 3 conforme**. `nbformat.validate()` OK, 27 cell-ids uniques.
- `git diff --shortstat` = `1 file changed, 236 insertions(+), 38 deletions(-)` (les deletions = `execution_count`/outputs rafraichis par la re-execution complete, aucune cellule source supprimee).

## Note (hors scope, a traiter separement)

Dans **les deux** versions (solution ET etudiant), l'Exercice 2 (sujet bayesien "Sensibilite au prior", Pyro) apparait **avant** la section "Partie 2 : Le Medecin Probabiliste (Pyro)" qui introduit ce paradigme. Cet ordre est **present dans la solution elle-meme** — le miroir fidele le preserve, cette PR ne l'introduit pas. Un reordonnancement editorial (qui toucherait aussi `solution/`) releve d'une **passe separee** pour garder cette PR atomique (parite seule).

## Suivi

`SmartGrid-Energy` est **deja conforme** (student = solution = 3 exercices) — aucune PR necessaire. Cette PR cloture la mise en parite des 3 etudes de cas (cf #7304 pour Diagnostic-Medical).

See #2161
