### PR TITLE
feat(case-studies,#2161): add 3 exercise stubs to Oncology-Planning/student (parity 0/3 -> 3/3)

### DIFF
--- a/MyIA.AI.Notebooks/CaseStudies/Oncology-Planning/student/Oncology-Planning.ipynb
+++ b/MyIA.AI.Notebooks/CaseStudies/Oncology-Planning/student/Oncology-Planning.ipynb
@@ -5,10 +5,10 @@
    "id": "9a29eb84",
    "metadata": {
     "papermill": {
-     "duration": 0.003352,
-     "end_time": "2026-06-05T20:39:58.193668+00:00",
+     "duration": 0.002973,
+     "end_time": "2026-07-19T00:06:27.089147",
      "exception": false,
-     "start_time": "2026-06-05T20:39:58.190316+00:00",
+     "start_time": "2026-07-19T00:06:27.086174",
      "status": "completed"
     },
     "tags": []
@@ -31,10 +31,10 @@
    "id": "4e16813a",
    "metadata": {
     "papermill": {
-     "duration": 0.002511,
-     "end_time": "2026-06-05T20:39:58.198864+00:00",
+     "duration": 0.003023,
+     "end_time": "2026-07-19T00:06:27.094732",
      "exception": false,
-     "start_time": "2026-06-05T20:39:58.196353+00:00",
+     "start_time": "2026-07-19T00:06:27.091709",
      "status": "completed"
     },
     "tags": []
@@ -49,16 +49,16 @@
    "id": "c082cf28",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T20:39:58.205493Z",
-     "iopub.status.busy": "2026-06-05T20:39:58.205068Z",
-     "iopub.status.idle": "2026-06-05T20:40:01.089115Z",
-     "shell.execute_reply": "2026-06-05T20:40:01.088177Z"
+     "iopub.execute_input": "2026-07-19T00:06:27.100677Z",
+     "iopub.status.busy": "2026-07-19T00:06:27.100475Z",
+     "iopub.status.idle": "2026-07-19T00:06:27.104905Z",
+     "shell.execute_reply": "2026-07-19T00:06:27.104355Z"
     },
     "papermill": {
-     "duration": 2.888451,
-     "end_time": "2026-06-05T20:40:01.089880+00:00",
+     "duration": 0.008914,
+     "end_time": "2026-07-19T00:06:27.105735",
      "exception": false,
-     "start_time": "2026-06-05T20:39:58.201429+00:00",
+     "start_time": "2026-07-19T00:06:27.096821",
      "status": "completed"
     },
     "tags": []
@@ -74,10 +74,10 @@
    "id": "ca83f5e5",
    "metadata": {
     "papermill": {
-     "duration": 0.002572,
-     "end_time": "2026-06-05T20:40:01.095231+00:00",
+     "duration": 0.003691,
+     "end_time": "2026-07-19T00:06:27.113589",
      "exception": false,
-     "start_time": "2026-06-05T20:40:01.092659+00:00",
+     "start_time": "2026-07-19T00:06:27.109898",
      "status": "completed"
     },
     "tags": []
@@ -92,16 +92,16 @@
    "id": "16131259",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T20:40:01.102718Z",
-     "iopub.status.busy": "2026-06-05T20:40:01.102342Z",
-     "iopub.status.idle": "2026-06-05T20:40:06.774174Z",
-     "shell.execute_reply": "2026-06-05T20:40:06.773115Z"
+     "iopub.execute_input": "2026-07-19T00:06:27.118779Z",
+     "iopub.status.busy": "2026-07-19T00:06:27.118476Z",
+     "iopub.status.idle": "2026-07-19T00:06:30.880499Z",
+     "shell.execute_reply": "2026-07-19T00:06:30.879190Z"
     },
     "papermill": {
-     "duration": 5.676473,
-     "end_time": "2026-06-05T20:40:06.775000+00:00",
+     "duration": 3.766902,
+     "end_time": "2026-07-19T00:06:30.882483",
      "exception": false,
-     "start_time": "2026-06-05T20:40:01.098527+00:00",
+     "start_time": "2026-07-19T00:06:27.115581",
      "status": "completed"
     },
     "tags": []
@@ -133,10 +133,10 @@
    "id": "31fce73e",
    "metadata": {
     "papermill": {
-     "duration": 0.002783,
-     "end_time": "2026-06-05T20:40:06.780764+00:00",
+     "duration": 0.005251,
+     "end_time": "2026-07-19T00:06:30.893820",
      "exception": false,
-     "start_time": "2026-06-05T20:40:06.777981+00:00",
+     "start_time": "2026-07-19T00:06:30.888569",
      "status": "completed"
     },
     "tags": []
@@ -150,10 +150,10 @@
    "id": "e5eace1b",
    "metadata": {
     "papermill": {
-     "duration": 0.002467,
-     "end_time": "2026-06-05T20:40:06.785808+00:00",
+     "duration": 0.005096,
+     "end_time": "2026-07-19T00:06:30.904164",
      "exception": false,
-     "start_time": "2026-06-05T20:40:06.783341+00:00",
+     "start_time": "2026-07-19T00:06:30.899068",
      "status": "completed"
     },
     "tags": []
@@ -167,10 +167,10 @@
    "id": "cb03cd33",
    "metadata": {
     "papermill": {
-     "duration": 0.002397,
-     "end_time": "2026-06-05T20:40:06.790691+00:00",
+     "duration": 0.005434,
+     "end_time": "2026-07-19T00:06:30.914925",
      "exception": false,
-     "start_time": "2026-06-05T20:40:06.788294+00:00",
+     "start_time": "2026-07-19T00:06:30.909491",
      "status": "completed"
     },
     "tags": []
@@ -187,16 +187,16 @@
    "id": "55fc3ca1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T20:40:06.798595Z",
-     "iopub.status.busy": "2026-06-05T20:40:06.798101Z",
-     "iopub.status.idle": "2026-06-05T20:40:06.802095Z",
-     "shell.execute_reply": "2026-06-05T20:40:06.801157Z"
+     "iopub.execute_input": "2026-07-19T00:06:30.927444Z",
+     "iopub.status.busy": "2026-07-19T00:06:30.926572Z",
+     "iopub.status.idle": "2026-07-19T00:06:30.931318Z",
+     "shell.execute_reply": "2026-07-19T00:06:30.930354Z"
     },
     "papermill": {
-     "duration": 0.009681,
-     "end_time": "2026-06-05T20:40:06.802901+00:00",
+     "duration": 0.012573,
+     "end_time": "2026-07-19T00:06:30.932597",
      "exception": false,
-     "start_time": "2026-06-05T20:40:06.793220+00:00",
+     "start_time": "2026-07-19T00:06:30.920024",
      "status": "completed"
     },
     "tags": []
@@ -217,10 +217,10 @@
    "id": "b81448b2",
    "metadata": {
     "papermill": {
-     "duration": 0.002676,
-     "end_time": "2026-06-05T20:40:06.808511+00:00",
+     "duration": 0.003639,
+     "end_time": "2026-07-19T00:06:30.939517",
      "exception": false,
-     "start_time": "2026-06-05T20:40:06.805835+00:00",
+     "start_time": "2026-07-19T00:06:30.935878",
      "status": "completed"
     },
     "tags": []
@@ -235,16 +235,16 @@
    "id": "498cb8cf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T20:40:06.815446Z",
-     "iopub.status.busy": "2026-06-05T20:40:06.815100Z",
-     "iopub.status.idle": "2026-06-05T20:40:06.820149Z",
-     "shell.execute_reply": "2026-06-05T20:40:06.819230Z"
+     "iopub.execute_input": "2026-07-19T00:06:30.947150Z",
+     "iopub.status.busy": "2026-07-19T00:06:30.946865Z",
+     "iopub.status.idle": "2026-07-19T00:06:30.955265Z",
+     "shell.execute_reply": "2026-07-19T00:06:30.954454Z"
     },
     "papermill": {
-     "duration": 0.009752,
-     "end_time": "2026-06-05T20:40:06.820926+00:00",
+     "duration": 0.013685,
+     "end_time": "2026-07-19T00:06:30.956828",
      "exception": false,
-     "start_time": "2026-06-05T20:40:06.811174+00:00",
+     "start_time": "2026-07-19T00:06:30.943143",
      "status": "completed"
     },
     "tags": []
@@ -295,13 +295,71 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a2ae8617",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00288,
+     "end_time": "2026-07-19T00:06:30.963402",
+     "exception": false,
+     "start_time": "2026-07-19T00:06:30.960522",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 : Étendre l'ontologie avec de nouveaux médicaments et interactions\n",
+    "\n",
+    "**Objectif** : Ajouter de nouveaux médicaments à l'ontologie RDF et implémenter une vérification d'interactions étendue.\n",
+    "\n",
+    "**Contexte** : L'ontologie actuelle contient 4 médicaments. En pratique, les protocoles oncologiques combinent davantage de molécules, et les interactions croisées sont critiques.\n",
+    "\n",
+    "**Indices** :\n",
+    "- # Indice 1 : Ajoutez « Paclitaxel » (toxicité_rénale=False, incompatible avec « Docetaxel ») et « Carboplatine » (toxicité_rénale=True, incompatible avec « Cisplatine »)\n",
+    "- # Indice 2 : Vérifiez qu'un protocole `[\"Cisplatine\", \"Carboplatine\"]` déclenche bien une alerte d'incompatibilité\n",
+    "- # Étape 1 : Ajouter les nouveaux médicaments au dictionnaire `medicaments`\n",
+    "- # Étape 2 : Peupler le graphe RDF avec les nouveaux triplets\n",
+    "- # Étape 3 : Tester la fonction `verifier_prescription` avec des combinaisons incluant les nouveaux médicaments"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "16526729",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-19T00:06:30.973639Z",
+     "iopub.status.busy": "2026-07-19T00:06:30.972969Z",
+     "iopub.status.idle": "2026-07-19T00:06:30.978858Z",
+     "shell.execute_reply": "2026-07-19T00:06:30.977430Z"
+    },
+    "papermill": {
+     "duration": 0.014132,
+     "end_time": "2026-07-19T00:06:30.980300",
+     "exception": false,
+     "start_time": "2026-07-19T00:06:30.966168",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Exercice 1 : Étendre l'ontologie médicamenteuse (voir l'énoncé ci-dessus)\n",
+    "# TODO étudiant : Ajouter « Paclitaxel » et « Carboplatine » au dictionnaire medicaments\n",
+    "# Indice : vérifier qu'un protocole [\"Cisplatine\", \"Carboplatine\"] déclenche une alerte\n",
+    "def etendre_ontologie(medicaments, graphe):\n",
+    "    \"\"\"TODO étudiant : étendre l'ontologie et vérifier les interactions croisée.\"\"\"\n",
+    "    pass  # TODO étudiant : implémenter (cf indices ci-dessus)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "ef5ad9fe",
    "metadata": {
     "papermill": {
-     "duration": 0.002654,
-     "end_time": "2026-06-05T20:40:06.826370+00:00",
+     "duration": 0.005636,
+     "end_time": "2026-07-19T00:06:30.990547",
      "exception": false,
-     "start_time": "2026-06-05T20:40:06.823716+00:00",
+     "start_time": "2026-07-19T00:06:30.984911",
      "status": "completed"
     },
     "tags": []
@@ -314,20 +372,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "89e569ee",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T20:40:06.832929Z",
-     "iopub.status.busy": "2026-06-05T20:40:06.832587Z",
-     "iopub.status.idle": "2026-06-05T20:40:06.864169Z",
-     "shell.execute_reply": "2026-06-05T20:40:06.863236Z"
+     "iopub.execute_input": "2026-07-19T00:06:31.002726Z",
+     "iopub.status.busy": "2026-07-19T00:06:31.002328Z",
+     "iopub.status.idle": "2026-07-19T00:06:31.028469Z",
+     "shell.execute_reply": "2026-07-19T00:06:31.027617Z"
     },
     "papermill": {
-     "duration": 0.035874,
-     "end_time": "2026-06-05T20:40:06.864838+00:00",
+     "duration": 0.034026,
+     "end_time": "2026-07-19T00:06:31.030041",
      "exception": false,
-     "start_time": "2026-06-05T20:40:06.828964+00:00",
+     "start_time": "2026-07-19T00:06:30.996015",
      "status": "completed"
     },
     "tags": []
@@ -378,10 +436,10 @@
    "id": "7cf2a7ed",
    "metadata": {
     "papermill": {
-     "duration": 0.002675,
-     "end_time": "2026-06-05T20:40:06.870398+00:00",
+     "duration": 0.003834,
+     "end_time": "2026-07-19T00:06:31.038394",
      "exception": false,
-     "start_time": "2026-06-05T20:40:06.867723+00:00",
+     "start_time": "2026-07-19T00:06:31.034560",
      "status": "completed"
     },
     "tags": []
@@ -395,10 +453,10 @@
    "id": "d43b403b",
    "metadata": {
     "papermill": {
-     "duration": 0.002672,
-     "end_time": "2026-06-05T20:40:06.875691+00:00",
+     "duration": 0.002934,
+     "end_time": "2026-07-19T00:06:31.043730",
      "exception": false,
-     "start_time": "2026-06-05T20:40:06.873019+00:00",
+     "start_time": "2026-07-19T00:06:31.040796",
      "status": "completed"
     },
     "tags": []
@@ -411,20 +469,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "815f392f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T20:40:06.882072Z",
-     "iopub.status.busy": "2026-06-05T20:40:06.881737Z",
-     "iopub.status.idle": "2026-06-05T20:40:06.886588Z",
-     "shell.execute_reply": "2026-06-05T20:40:06.885769Z"
+     "iopub.execute_input": "2026-07-19T00:06:31.052685Z",
+     "iopub.status.busy": "2026-07-19T00:06:31.052261Z",
+     "iopub.status.idle": "2026-07-19T00:06:31.056373Z",
+     "shell.execute_reply": "2026-07-19T00:06:31.055833Z"
     },
     "papermill": {
-     "duration": 0.009126,
-     "end_time": "2026-06-05T20:40:06.887317+00:00",
+     "duration": 0.008051,
+     "end_time": "2026-07-19T00:06:31.057175",
      "exception": false,
-     "start_time": "2026-06-05T20:40:06.878191+00:00",
+     "start_time": "2026-07-19T00:06:31.049124",
      "status": "completed"
     },
     "tags": []
@@ -485,10 +543,10 @@
    "id": "ebfd0923",
    "metadata": {
     "papermill": {
-     "duration": 0.002648,
-     "end_time": "2026-06-05T20:40:06.892597+00:00",
+     "duration": 0.00229,
+     "end_time": "2026-07-19T00:06:31.061807",
      "exception": false,
-     "start_time": "2026-06-05T20:40:06.889949+00:00",
+     "start_time": "2026-07-19T00:06:31.059517",
      "status": "completed"
     },
     "tags": []
@@ -501,20 +559,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "e50bbbb7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T20:40:06.898977Z",
-     "iopub.status.busy": "2026-06-05T20:40:06.898761Z",
-     "iopub.status.idle": "2026-06-05T20:40:06.901960Z",
-     "shell.execute_reply": "2026-06-05T20:40:06.901050Z"
+     "iopub.execute_input": "2026-07-19T00:06:31.068903Z",
+     "iopub.status.busy": "2026-07-19T00:06:31.068559Z",
+     "iopub.status.idle": "2026-07-19T00:06:31.072308Z",
+     "shell.execute_reply": "2026-07-19T00:06:31.071520Z"
     },
     "papermill": {
-     "duration": 0.007487,
-     "end_time": "2026-06-05T20:40:06.902688+00:00",
+     "duration": 0.009194,
+     "end_time": "2026-07-19T00:06:31.073327",
      "exception": false,
-     "start_time": "2026-06-05T20:40:06.895201+00:00",
+     "start_time": "2026-07-19T00:06:31.064133",
      "status": "completed"
     },
     "tags": []
@@ -531,13 +589,71 @@
   },
   {
    "cell_type": "markdown",
+   "id": "80c38ac7",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003202,
+     "end_time": "2026-07-19T00:06:31.079470",
+     "exception": false,
+     "start_time": "2026-07-19T00:06:31.076268",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 : Sensibilité du modèle bayésien au prior sur le profil patient\n",
+    "\n",
+    "**Objectif** : Étudier comment le choix du prior sur les profils (Résistant/Normal/Sensible) influence le diagnostic postérieur.\n",
+    "\n",
+    "**Contexte** : Le prior actuel est `[0.1, 0.6, 0.3]` (10 % Résistants, 60 % Normaux, 30 % Sensibles). Si la population est différente, le diagnostic change.\n",
+    "\n",
+    "**Indices** :\n",
+    "- # Indice 1 : Modifiez `profil_probs` dans la méthode `model()` pour tester : `[0.33, 0.34, 0.33]` (uniforme), `[0.05, 0.90, 0.05]` (peu de sensibles)\n",
+    "- # Indice 2 : Relancez l'inférence SVI et comparez les probabilités a posteriori du profil\n",
+    "- # Étape 1 : Créer une fonction qui accepte le prior en paramètre\n",
+    "- # Étape 2 : Tester 3 configurations de prior différentes\n",
+    "- # Étape 3 : Afficher les postérieurs dans un tableau comparatif"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "3f7b9ba4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-19T00:06:31.087417Z",
+     "iopub.status.busy": "2026-07-19T00:06:31.086949Z",
+     "iopub.status.idle": "2026-07-19T00:06:31.091182Z",
+     "shell.execute_reply": "2026-07-19T00:06:31.090479Z"
+    },
+    "papermill": {
+     "duration": 0.009418,
+     "end_time": "2026-07-19T00:06:31.092093",
+     "exception": false,
+     "start_time": "2026-07-19T00:06:31.082675",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Exercice 2 : Sensibilité au prior du profil patient (voir l'énoncé ci-dessus)\n",
+    "# TODO étudiant : rendre profil_probs paramétrable dans OncoModel.model()\n",
+    "# Indice : tester [0.33, 0.34, 0.33] (uniforme) et [0.05, 0.90, 0.05] (peu de sensibles)\n",
+    "def model_parametrable(doses, profil_probs, observations=None):\n",
+    "    \"\"\"TODO étudiant : version paramétrable du modèle bayésien.\"\"\"\n",
+    "    pass  # TODO étudiant : implémenter (cf indices ci-dessus)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "e1f87420",
    "metadata": {
     "papermill": {
-     "duration": 0.002613,
-     "end_time": "2026-06-05T20:40:06.907939+00:00",
+     "duration": 0.004953,
+     "end_time": "2026-07-19T00:06:31.099750",
      "exception": false,
-     "start_time": "2026-06-05T20:40:06.905326+00:00",
+     "start_time": "2026-07-19T00:06:31.094797",
      "status": "completed"
     },
     "tags": []
@@ -551,10 +667,10 @@
    "id": "009d112d",
    "metadata": {
     "papermill": {
-     "duration": 0.00257,
-     "end_time": "2026-06-05T20:40:06.913105+00:00",
+     "duration": 0.00345,
+     "end_time": "2026-07-19T00:06:31.107358",
      "exception": false,
-     "start_time": "2026-06-05T20:40:06.910535+00:00",
+     "start_time": "2026-07-19T00:06:31.103908",
      "status": "completed"
     },
     "tags": []
@@ -569,20 +685,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "id": "977dbd22",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T20:40:06.919514Z",
-     "iopub.status.busy": "2026-06-05T20:40:06.919314Z",
-     "iopub.status.idle": "2026-06-05T20:40:06.924279Z",
-     "shell.execute_reply": "2026-06-05T20:40:06.923458Z"
+     "iopub.execute_input": "2026-07-19T00:06:31.116353Z",
+     "iopub.status.busy": "2026-07-19T00:06:31.116120Z",
+     "iopub.status.idle": "2026-07-19T00:06:31.120498Z",
+     "shell.execute_reply": "2026-07-19T00:06:31.119970Z"
     },
     "papermill": {
-     "duration": 0.00902,
-     "end_time": "2026-06-05T20:40:06.924945+00:00",
+     "duration": 0.010347,
+     "end_time": "2026-07-19T00:06:31.121839",
      "exception": false,
-     "start_time": "2026-06-05T20:40:06.915925+00:00",
+     "start_time": "2026-07-19T00:06:31.111492",
      "status": "completed"
     },
     "tags": []
@@ -627,6 +743,64 @@
     "print(contract.verifier_execution(plan_final))\n",
     "print(contract.verifier_execution({\"J1\": \"Cisplatine 100mg\"})) # Tentative de fraude"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9f6977cf",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003467,
+     "end_time": "2026-07-19T00:06:31.128693",
+     "exception": false,
+     "start_time": "2026-07-19T00:06:31.125226",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 : Ajouter un journal d'audit au contrat intelligent\n",
+    "\n",
+    "**Objectif** : Étendre la classe `OncoContract` pour maintenir un historique des modifications et détecter les tentatives de fraude.\n",
+    "\n",
+    "**Contexte** : Le contrat actuel enregistre un seul plan. En pratique, les plans peuvent être modifiés plusieurs fois, et il faut tracer qui a fait quoi et quand.\n",
+    "\n",
+    "**Indices** :\n",
+    "- # Indice 1 : Ajoutez un attribut `self.historique = []` qui stocke chaque modification\n",
+    "- # Indice 2 : Chaque entrée du journal doit contenir : horodatage, auteur, action, hash du plan\n",
+    "- # Étape 1 : Ajouter l'attribut `historique` et le mettre à jour à chaque appel de `enregistrer_plan`\n",
+    "- # Étape 2 : Implémenter une méthode `afficher_historique()` qui affiche le journal\n",
+    "- # Étape 3 : Tester en modifiant le plan plusieurs fois et vérifier que l'historique est complet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "5122b76e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-19T00:06:31.135440Z",
+     "iopub.status.busy": "2026-07-19T00:06:31.135209Z",
+     "iopub.status.idle": "2026-07-19T00:06:31.138722Z",
+     "shell.execute_reply": "2026-07-19T00:06:31.138228Z"
+    },
+    "papermill": {
+     "duration": 0.008407,
+     "end_time": "2026-07-19T00:06:31.139967",
+     "exception": false,
+     "start_time": "2026-07-19T00:06:31.131560",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Exercice 3 : Journal d'audit pour le contrat intelligent (voir l'énoncé ci-dessus)\n",
+    "# TODO étudiant : étendre OncoContract avec un attribut self.historique = []\n",
+    "# Indice : chaque entrée = (horodatage, auteur, action, hash du plan)\n",
+    "def creer_contrat_audite(medecin_id, patient_id):\n",
+    "    \"\"\"TODO étudiant : retourner un OncoContract doté d'un journal d'audit.\"\"\"\n",
+    "    pass  # TODO étudiant : implémenter (cf indices ci-dessus)"
+   ]
   }
  ],
  "metadata": {
@@ -645,18 +819,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.7"
+   "version": "3.13.3"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 12.063577,
-   "end_time": "2026-06-05T20:40:08.038153+00:00",
+   "duration": 6.744897,
+   "end_time": "2026-07-19T00:06:31.929360",
    "environment_variables": {},
    "exception": null,
-   "input_path": "Oncology-Planning.ipynb",
-   "output_path": "Oncology-Planning.ipynb",
+   "input_path": "MyIA.AI.Notebooks/CaseStudies/Oncology-Planning/student/Oncology-Planning.ipynb",
+   "output_path": "C:/Users/jsboi/AppData/Local/Temp/onco-exec/executed.ipynb",
    "parameters": {},
-   "start_time": "2026-06-05T20:39:55.974576+00:00",
+   "start_time": "2026-07-19T00:06:25.184463",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
## Summary

Restore student/solution **exercise parity** for `CaseStudies/Oncology-Planning` (rule #2161 ≥3 exercises per notebook). The **student** notebook had **0/3** exercises (`count_exercises.py`) while the **solution** has **3/3** — the student was missing all 3 exercise prompt+stub cells. Mirrors the model of po-2025's Diagnostic-Medical parity claim (c.637).

## Changes (1 file, student only — solution byte-untouched)

Added 3 extension exercises (6 cells: 3 markdown prompts + 3 code stubs), one at the end of each section, following the repo's canonical **PROMPT → STUB** convention (same as `SmartGrid-Energy/student`, the 3/3-compliant reference):

| Exercise | Section | Topic | Mirrors solution cell |
|----------|---------|-------|----------------------|
| Ex1 | end of 1.1 (Ontologie/RDFLib) | Étendre l'ontologie (Paclitaxel, Carboplatine) + vérification interactions | sol cell 12 |
| Ex2 | end of 2.2 (Prédiction/Pyro) | Sensibilité du modèle bayésien au prior profil patient | sol cell 17 |
| Ex3 | end of Partie 3 (Smart Contract) | Journal d'audit pour `OncoContract` | sol cell 22 |

**Stubs** are pure function defs + `pass` + `# TODO étudiant` (rule C.1: no `raise NotImplementedError`/`assert False`/`1/0` — verified 0 violations whole-notebook). New content written in correct French with accents (readme-french-first — does not add to #2876 accent debt).

## Validation (firsthand, EXEC_PROVED)

- **`count_exercises.py`**: `0/3 → 3/3 Conforming` (#2161 satisfied). All scanned notebooks meet threshold.
- **Papermill re-exec** (kernel python3, 27/27 cells, 6s, **0 errors**): all 11 code cells coherent `ec=1..11` sequential, 0 `ec=None`, 0 error outputs. New stub cells `ec=5/9/11`, 0 outputs (def+pass = correct).
- **nbformat VALIDATE OK** (4.5, all 27 cells have `id`).
- **Byte-identity (rule C.3)**: 21/21 original cells source **unchanged** (verified source-array diff vs origin/main); only 6 new cells added. `+280/-106` = 6 new cells + re-exec regenerated outputs/ec (C.2-compliant, real execution). `solution/` byte-untouched (0 diff).
- **H.3 `validate_pr_notebooks.py`**: 1/1 PASS.
- **Catalog hygiene**: `COURSE_CATALOG.generated.{json,md}` byte-identical to main (catalog-pr-hygiene HARD 1 — new notebook entry will be created by cron/CI, not hand-edited).

## Scope

Single subject (one notebook, exercise parity), single domain (CaseStudies/SymbolicAI). `See #2161` (partial — contributes to the ≥3-exercise rollout epic, does not close it). Anti-double-claim: po-2025 claimed Diagnostic-Medical (different case); SmartGrid-Energy already 3/3 compliant.

See #2161
