### PR TITLE
fix(prover,#6790): FX-12 surface structural-edits counter (pathology 3)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
@@ -1058,6 +1058,17 @@ class MultiAgentSorryProver:
             # (forensic; each hop already covered its in-hop retries).
             "provider_outage": provider_outage,
             "provider_failures": provider_failures,
+            # FX-12 (#6790 pathology 3): count of build-verified *structural*
+            # edits (file_replace_lines / file_insert_lines whose build_check
+            # passed). Distinct from ``structural_progress`` (a boolean
+            # success-gate decision) and from ``iterations``/``attempts``
+            # (tactic-submission turns): a run that aborted after 1 build-
+            # verified structural edit reports ``iterations=0 / attempts=0
+            # / structural_progress=False`` yet made real progress (e.g. a
+            # monolithic sorry decomposed into compiling sub-sorries).
+            # Surfacing this count lets forensic ROI distinguish "no progress
+            # at all" from "structural progress without a tactic".
+            "structural_edits": getattr(tactic_tools, "_structural_edits_verified", 0),
             # FX-6 (#1453): diagnostic fields for the statement-mutation guard.
             "verified_tactic_count": verified_tactic_count,
             **({"flag": "STMT_MUTATION_FALSE_SUCCESS"} if stmt_mutation else {}),
@@ -1939,6 +1950,16 @@ class AutonomousProver:
             # NOT `no_progress` / `structural_progress` — it must be filtered out
             # of progress metrics.
             "provider_outage": _provider_dead,
+            # FX-12 (#6790 pathology 3): count of build-verified *structural*
+            # edits (file_replace_lines / file_insert_lines whose build_check
+            # passed). Distinct from ``structural_progress`` (boolean success
+            # gate) and ``iterations``/``attempts`` (tactic-submission turns):
+            # a run that aborted after a build-verified structural edit reports
+            # ``iterations=0 / attempts=0 / structural_progress=False`` yet
+            # made real progress. Surfacing this count lets forensic ROI
+            # distinguish "no progress at all" from "structural progress
+            # without a tactic" (cf multi-path comment at provers.py:1062).
+            "structural_edits": getattr(tactic_tools, "_structural_edits_verified", 0),
             # FX-6 (#1453): diagnostic fields for the statement-mutation guard.
             "verified_tactic_count": verified_tactic_count,
             **({"flag": "STMT_MUTATION_FALSE_SUCCESS"} if stmt_mutation else {}),

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
@@ -727,6 +727,19 @@ class TacticTools:
         self._best_content: Optional[str] = None
         self._best_sorry_count: int = 999
         self._original_sorry_count: int = 999
+        # FX-12 (#6790 pathology 3): count build-verified *structural* edits
+        # (file_replace_lines / file_insert_lines whose build_check passed).
+        # These are real proof progress (e.g. a monolithic sorry decomposed into
+        # N compiling sub-sorries) but are INVISIBLE to the iterations/attempts
+        # metrics in the result dict — ``iterations`` counts tactic-submission
+        # turns (``max_iterations - remaining_iterations``) and ``attempts``
+        # counts ``len(tactic_history)``, neither of which a structural edit
+        # touches. Result: a run that aborted after 1 build-verified structural
+        # edit + N compiles + 75 trace entries reports ``iterations=0 /
+        # attempts=0`` (DEMO 62 forensic, #6790), hiding the progress from the
+        # forensic ROI. Surfacing this counter lets forensic distinguish
+        # ``no progress at all`` from ``structural progress without a tactic``.
+        self._structural_edits_verified: int = 0
         # P2 (#1453): Delta0-compile stagnation tracking. Counts consecutive
         # successful compiles that failed to reach a new sorry-count low. The
         # verbatim loop detector (_check_tool_loop) only catches *identical*
@@ -1476,6 +1489,10 @@ class TacticTools:
                 # Build verified — safe to update snapshots.
                 self._last_build_ok_content = new_file_content
                 self._last_build_ok_sorry_count = sorry_count
+                # FX-12 (#6790 pathology 3): this file_replace_lines call passed
+                # build_check — it is a build-verified structural edit (real
+                # proof progress), counted separately from tactic submissions.
+                self._structural_edits_verified += 1
 
                 if sorry_count < self._best_sorry_count:
                     self._best_sorry_count = sorry_count
@@ -1589,6 +1606,10 @@ class TacticTools:
 
                 self._last_build_ok_content = new_file_content
                 self._last_build_ok_sorry_count = sorry_count
+                # FX-12 (#6790 pathology 3): this file_insert_lines call passed
+                # build_check -- a build-verified structural edit (real proof
+                # progress), counted separately from tactic submissions.
+                self._structural_edits_verified += 1
                 if sorry_count < self._best_sorry_count:
                     self._best_sorry_count = sorry_count
                     self._best_content = new_file_content

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_pathology3_counter.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_pathology3_counter.py
@@ -1,0 +1,225 @@
+"""Unit tests for the FX-12 structural-edits counter on TacticTools (#6790 pathology 3).
+
+Background: #6790 pathology 3 (DEMO 62 forensic) is a run that aborted after
+ONE build-verified ``file_replace_lines`` (a monolithic sorry decomposed into
+N compiling sub-sorries) plus several compiles and 75 trace entries, yet
+reported ``iterations=0`` and ``attempts=0`` in the result dict. The cause:
+``iterations`` counts tactic-submission turns (``max_iterations -
+remaining_iterations``) and ``attempts`` counts ``len(tactic_history)``, and
+a structural edit (file_replace_lines / file_insert_lines) touches neither.
+
+FX-12 adds ``TacticTools._structural_edits_verified`` — a count of
+build-verified structural edits (those whose build_check passed) — and
+surfaces it in the MultiAgent / Autonomous result dicts as
+``structural_edits``. This lets forensic ROI distinguish ``no progress at
+all`` from ``structural progress without a tactic``.
+
+These tests exercise the counter invariant directly:
+  * starts at 0
+  * increments iff build_check passes (NOT on build failure, NOT when skipped)
+  * accumulates across multiple verified edits
+  * is surfaced for both file_replace_lines and file_insert_lines
+
+They mock ``_build_check_or_revert`` (the only Lean-dependent call) so the
+tests run fully offline — no lake build required.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Mirror the conftest path used by the other prover test modules.
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+sys.path.insert(0, str(ROOT))
+
+from prover.state import ProofState, SorryContext  # noqa: E402
+from prover.tools import TacticTools  # noqa: E402
+
+
+# --- helpers ---------------------------------------------------------------
+
+
+def _make_tactic_tools(tmp_path, sorry_body_lines=("  sorry",)):
+    """Build a TacticTools against a fake .lean file (no real Lean needed).
+
+    The file is padded so the file-size guard (blocks >50% deltas) does not
+    fire on small single-line edits. Mirrors the ``tactic_tools`` fixture in
+    test_prover_guards.py.
+    """
+    fake = tmp_path / "Fake.lean"
+    body = (
+        "import Mathlib.Tactic\n"
+        "namespace TestSpace\n"
+        + "\n".join(f"-- comment line {i} for size padding" for i in range(50))
+        + "\ntheorem t : True := by\n"
+        + "\n".join(sorry_body_lines)
+        + "\n"
+        + "\n".join(f"-- trailing line {i} for size padding" for i in range(50))
+        + "\nend TestSpace\n"
+    )
+    fake.write_text(body, encoding="utf-8")
+    sorry_line = next(
+        i + 1 for i, line in enumerate(body.split("\n")) if "sorry" in line
+    )
+    state = ProofState(theorem_statement="t")
+    sctx = SorryContext(
+        filepath=str(fake), sorry_line=sorry_line, indentation=2,
+        indent_str="  ", full_file=body,
+    )
+    tt = TacticTools(state, str(fake), sctx)
+    return tt, sorry_line
+
+
+# --- counter initialization ------------------------------------------------
+
+
+def test_counter_starts_at_zero(tmp_path):
+    """A fresh TacticTools MUST initialize _structural_edits_verified to 0
+    so a run that makes no structural edits reports 0, not a stale value
+    from a prior run on the same instance."""
+    tt, _ = _make_tactic_tools(tmp_path)
+    assert getattr(tt, "_structural_edits_verified", None) == 0, (
+        "_structural_edits_verified must exist and start at 0"
+    )
+
+
+# --- file_replace_lines counter invariant ----------------------------------
+
+
+def test_counter_increments_on_build_verified_replace(tmp_path, monkeypatch):
+    """file_replace_lines whose build_check PASSES MUST increment the
+    counter — this is precisely the pathology-3 signal (a structural edit
+    made real progress that iterations/attempts cannot see)."""
+    tt, sorry_line = _make_tactic_tools(tmp_path)
+    # Mock the Lean build to report success (no lake build needed).
+    monkeypatch.setattr(tt, "_build_check_or_revert", lambda content, tag: None)
+
+    out = json.loads(tt.file_replace_lines(
+        start=sorry_line, end=sorry_line,
+        new_content="  trivial",
+        build_check=True,
+    ))
+    assert "error" not in out, out
+    assert out["build_check"] == "passed"
+    assert tt._structural_edits_verified == 1, (
+        "build-verified file_replace_lines must increment the counter"
+    )
+
+
+def test_counter_unchanged_on_build_failure_replace(tmp_path, monkeypatch):
+    """file_replace_lines whose build_check FAILS MUST NOT increment the
+    counter — a reverted edit is not progress. This is the guard against
+    counting smoke (non-compiling replacements) as structural progress."""
+    tt, sorry_line = _make_tactic_tools(tmp_path)
+    # Mock the Lean build to report FAILURE (returns an error dict, which
+    # _build_check_or_revert does on compile error before reverting).
+    monkeypatch.setattr(
+        tt, "_build_check_or_revert",
+        lambda content, tag: {"error": "compile failed: unknown identifier"},
+    )
+    before = tt._structural_edits_verified
+    out = json.loads(tt.file_replace_lines(
+        start=sorry_line, end=sorry_line,
+        new_content="  not_a_tactic_xyz",
+        build_check=True,
+    ))
+    assert "error" in out, "build-failure path must surface an error"
+    assert tt._structural_edits_verified == before, (
+        "build-FAILED file_replace_lines must NOT increment the counter"
+    )
+
+
+def test_counter_unchanged_when_build_check_skipped_replace(tmp_path):
+    """file_replace_lines with build_check=False MUST NOT increment the
+    counter — the increment lives inside ``if build_check:``, consistent
+    with the snapshot invariant (no build = no progress recorded)."""
+    tt, sorry_line = _make_tactic_tools(tmp_path)
+    before = tt._structural_edits_verified
+    out = json.loads(tt.file_replace_lines(
+        start=sorry_line, end=sorry_line,
+        new_content="  show ?a ≦ ?b -- PROBE",
+        build_check=False,
+    ))
+    assert "error" not in out, out
+    assert out["build_check"] == "skipped"
+    assert tt._structural_edits_verified == before, (
+        "build_check=False must NOT increment the counter (no verification)"
+    )
+
+
+# --- file_insert_lines counter invariant -----------------------------------
+
+
+def test_counter_increments_on_build_verified_insert(tmp_path, monkeypatch):
+    """file_insert_lines whose build_check PASSES MUST increment the
+    counter too — inserting a helper lemma that compiles is structural
+    progress (the canonical decomposition move)."""
+    tt, sorry_line = _make_tactic_tools(tmp_path)
+    monkeypatch.setattr(tt, "_build_check_or_revert", lambda content, tag: None)
+
+    out = json.loads(tt.file_insert_lines(
+        after_line=2,  # insert right after `namespace TestSpace`
+        content="-- helper inserted by test\n",
+        build_check=True,
+    ))
+    assert "error" not in out, out
+    assert out["build_check"] == "passed"
+    assert tt._structural_edits_verified == 1, (
+        "build-verified file_insert_lines must increment the counter"
+    )
+
+
+def test_counter_unchanged_on_build_failure_insert(tmp_path, monkeypatch):
+    """file_insert_lines whose build_check FAILS MUST NOT increment the
+    counter — symmetric to the file_replace_lines failure invariant."""
+    tt, sorry_line = _make_tactic_tools(tmp_path)
+    monkeypatch.setattr(
+        tt, "_build_check_or_revert",
+        lambda content, tag: {"error": "compile failed: unknown identifier"},
+    )
+    before = tt._structural_edits_verified
+    out = json.loads(tt.file_insert_lines(
+        after_line=2,
+        content="-- bogus insertion\n",
+        build_check=True,
+    ))
+    assert "error" in out, "build-failure path must surface an error"
+    assert tt._structural_edits_verified == before, (
+        "build-FAILED file_insert_lines must NOT increment the counter"
+    )
+
+
+# --- accumulation ----------------------------------------------------------
+
+
+def test_counter_accumulates_across_verified_edits(tmp_path, monkeypatch):
+    """Multiple build-verified structural edits MUST accumulate — the
+    counter is a session-total, not a per-edit flag. This is what lets
+    forensic rank a run that decomposed a goal into 3 sub-sorries above
+    one that made a single edit."""
+    tt, sorry_line = _make_tactic_tools(tmp_path)
+    monkeypatch.setattr(tt, "_build_check_or_revert", lambda content, tag: None)
+
+    # First verified structural edit (replace the sorry).
+    out1 = json.loads(tt.file_replace_lines(
+        start=sorry_line, end=sorry_line,
+        new_content="  have h : True := trivial",
+        build_check=True,
+    ))
+    assert "error" not in out1, out1
+    # Second verified structural edit (insert a helper lemma).
+    # Re-locate a valid insertion anchor after the rewrite.
+    out2 = json.loads(tt.file_insert_lines(
+        after_line=2,
+        content="-- second helper inserted by test\n",
+        build_check=True,
+    ))
+    assert "error" not in out2, out2
+    assert tt._structural_edits_verified == 2, (
+        "two build-verified structural edits must accumulate to 2"
+    )


### PR DESCRIPTION
## Summary

**FX-12 — surface a `structural_edits` counter on `TacticTools`** so forensic ROI can see the build-verified structural progress that `iterations`/`attempts` cannot. Fixes **#6790 pathology 3** (DEMO 62 forensic: a run that aborted after 1 build-verified `file_replace_lines` + several compiles + 75 trace entries reported `iterations=0 / attempts=0`).

## The pathology (why iterations/attempts are blind to structural edits)

| Metric | What it counts | Why a structural edit is invisible |
|--------|----------------|-----------------------------------|
| `iterations` | `max(0, max_iterations - state.remaining_iterations)` | counts tactic-submission TURNS — `file_replace_lines`/`file_insert_lines` never decrement `remaining_iterations` |
| `attempts` | `len(state.tactic_history)` | counts submitted tactics — a structural edit is not a tactic |

So a run that decomposed a monolithic sorry into N compiling sub-sorries (real progress) then aborted reports `iterations=0 / attempts=0` — the forensic ROI cannot distinguish it from "no progress at all".

## The fix (FX-12, additive, +42/−0)

1. **`tools.py TacticTools.__init__`** — `self._structural_edits_verified: int = 0`.
2. **`tools.py file_replace_lines` build_check success path** — `self._structural_edits_verified += 1` (inside `if build_check:`, after `_build_check_or_revert` returns None).
3. **`tools.py file_insert_lines` build_check success path** — same increment (symmetric).
4. **`provers.py` result dicts** — `"structural_edits": getattr(tactic_tools, "_structural_edits_verified", 0)` surfaced in **both** MultiAgent and Autonomous result dicts, beside the existing `provider_outage` (FX-11) and `best_sorry` (FX-10) forensic fields.

`structural_edits` (int) is distinct from the pre-existing `structural_progress` (boolean success-gate decision in `_determine_success`) — they are complementary.

## G.9 correction (scope narrowed: pathology 3 ONLY)

An earlier cycle claimed **pathology 2 (freeze-loop) was unfixed on main**. That was a vocabulary miss — grepped `"frozen"` in `provers.py` instead of `"no_tool_call"` in `workflow.py`. **Pathology 2 is ALREADY completely fixed** in `workflow.py` as the **C617 guard** (`_consecutive_no_tool_call` counter + `PROVER_NO_TOOL_CALL_THRESHOLD` env + Coordinator handoff, tested in `test_prover_freeze_loop_guard.py`). This PR is **pathology 3 ONLY**.

## Validation (firsthand)

```
py -3 -m pytest tests/test_prover_pathology3_counter.py -v   -> 7 passed in 0.79s
py -3 -m pytest tests/ -q                                    -> 228 passed, 2 failed
import prover.tools, prover.provers                          -> OK (both parse clean)
```

The 2 failures are **pre-existing on base `origin/main`**, verified via `git stash` (without FX-12):
- `test_coordinator_agent_has_set_attack_plan_tool` — needs `OPENAI_API_KEY` (credentials, not code).
- `test_path_constants_resolve_to_active_workspace` — stale `VOTING_FILE` assertion post-#4365 absorption (the file now exists, the test wasn't reconciled).

Neither touches `_structural_edits_verified` or the result dicts. **Not introduced by this PR.**

### 7 new tests (all offline — `_build_check_or_revert` mocked, no lake build)

- `test_counter_starts_at_zero`
- `test_counter_increments_on_build_verified_replace`
- `test_counter_unchanged_on_build_failure_replace` (reverted edit ≠ progress)
- `test_counter_unchanged_when_build_check_skipped_replace` (no verification)
- `test_counter_increments_on_build_verified_insert`
- `test_counter_unchanged_on_build_failure_insert`
- `test_counter_accumulates_across_verified_edits` (2 edits → counter == 2)

## Scope (3 files, +42 lines prod / +225 lines test, 0 deletions)

| File | Change |
|------|--------|
| `prover/tools.py` | +21: init counter + 2 increment sites (file_replace_lines, file_insert_lines) with rationale comments |
| `prover/provers.py` | +21: surface `structural_edits` in MultiAgent + Autonomous result dicts |
| `tests/test_prover_pathology3_counter.py` | +225: new, 7 tests, fully offline |

**Anti-regression §D**: pure additive (0 deletions), no proof/implementation replaced. **C.3 scope-strict**: only the 3 files staged; `proof_knowledge.json` contamination from shared tree deliberately excluded. **CRLF=0** on all 3 files.

See #6790 (partial: pathology 3 fix; pathology 1 already resolved upstream, pathology 2 = C617 already fixed).

Co-Authored-By: Claude <noreply@anthropic.com>
