### PR TITLE
docs(casestudies,#3975): document extension exercises in Diagnostic-Medical + Oncology-Planning leaf READMEs

### DIFF
--- a/MyIA.AI.Notebooks/CaseStudies/Diagnostic-Medical/README.md
+++ b/MyIA.AI.Notebooks/CaseStudies/Diagnostic-Medical/README.md
@@ -239,6 +239,14 @@ Chaque cellule à remplir ou compléter sera évaluée pour constituer la note f
 - Tests exhaustifs
 - Performance exceptionnelle
 
+### Exercices d'extension
+
+Trois exercices d'extension, laissés en squelette dans le notebook étudiant, permettent d'approfondir le pipeline au-delà du barème principal :
+
+- un **score de risque composite** qui agrège plusieurs facteurs cliniques au-delà de la règle de classification de l'agent rationnel ;
+- une **heuristique alternative pour A\*** — comparer une seconde fonction admissible à celle du notebook et en mesurer l'effet sur le nombre de nœuds explorés ;
+- l'ajout de **contraintes d'interaction médicamenteuse au solveur Z3**, pour enrichir la validation formelle du protocole thérapeutique.
+
 ### Compétences développées
 
 À la fin de ce devoir, vous aurez acquis :

--- a/MyIA.AI.Notebooks/CaseStudies/Oncology-Planning/README.md
+++ b/MyIA.AI.Notebooks/CaseStudies/Oncology-Planning/README.md
@@ -147,6 +147,18 @@ C'est la conception d'un **Jumeau Numérique** du patient, capable d'éclairer l
 
 ---
 
+## Exercices d'extension
+
+Trois exercices d'extension, laissés en squelette dans le notebook étudiant, prolongent le jumeau numérique au-delà du barème principal :
+
+- **étendre l'ontologie médicamenteuse** (RDFLib) avec de nouveaux traitements et interactions, puis re-vérifier la prescription ;
+- **sensibilité au prior du profil patient** — faire varier le prior de l'inférence Pyro et observer comment évolue la probabilité d'adaptation du traitement ;
+- **journal d'audit du contrat intelligent** — tracer les décisions du smart contract (partie Bonus optionnelle) pour rendre le calendrier de cures auditable.
+
+Les squelettes correspondants figurent dans la version étudiante du notebook.
+
+---
+
 ## Conclusion
 
 Ce cas d'étude réunit deux familles d'IA que l'on oppose souvent, pour montrer qu'elles sont en réalité **complémentaires** dans une chaîne décisionnelle :


### PR DESCRIPTION
## Objet

Parite documentaire des READMEs feuille de la serie **CaseStudies** sur les exercices d'extension.

`SmartGrid-Energy/README.md` **nomme deja** ses 3 exercices d'extension (reserve tournante n-1 / sensibilite au prior / equite territoriale). Les deux autres etudes de cas etaient en retrait :

| README feuille | Etat avant | Etat apres |
|----------------|-----------|-----------|
| `Diagnostic-Medical/README.md` | 0/3 nomme (seulement un « Bonus » abstrait) | 3/3 nommes |
| `Oncology-Planning/README.md` | 1/3 nomme (« Smart Contract » seul) | 3/3 nommes |
| `SmartGrid-Energy/README.md` | 3/3 (reference) | inchange |

## Contenu ajoute

Une section **« Exercices d'extension »** en francais dans chaque README, nommant les 3 exercices reels — ancres dans les notebooks `solution/` correspondants :

- **Diagnostic-Medical** (`### Exercices d'extension`, apres le bloc Bonus) : score de risque composite / heuristique alternative pour A* / contraintes d'interaction medicamenteuse au solveur Z3.
- **Oncology-Planning** (`## Exercices d'extension`, avant la Conclusion) : etendre l'ontologie medicamenteuse (RDFLib) / sensibilite au prior du profil patient (Pyro) / journal d'audit du contrat intelligent (partie Bonus optionnelle).

## Conformite §E / hygiene catalogue

- **Aucun point invente** : Diagnostic n'a pas de bareme par-item (formulation « au-dela du bareme principal ») ; Oncology conserve son « Bareme indicatif » existant, les 3 extensions y sont nommees sans chiffrer de points.
- **Aucun marqueur `CATALOG-STATUS` touche** : ces deux READMEs feuille n'en portent pas ; le catalogue reste byte-identique a `main`.
- **Prose en francais** (readme-french-first) : sections redigees directement en francais accentue, non copiees des titres notebook.

`git diff --shortstat` = `2 files changed, 20 insertions(+)`.

## Perimetre

PR **documentaire pure** — aucun notebook, aucune cellule, aucun output touche. Les stubs d'exercices eux-memes existent deja dans les notebooks etudiants (livres separement : #7304 Diagnostic, #7306 Oncology).

See #3975
See #3973
