### PR TITLE
fix(docs,#4959): resync SymbolicAI hub Tweety C# parity (12→18 modules)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/README.md
@@ -110,7 +110,7 @@ La série SymbolicLearning (12 notebooks Python, doublés de jumeaux C# from-scr
 
 ## Tweety - TweetyProject
 
-Série sur [TweetyProject](https://tweetyproject.org/), bibliothèque Java pour l'IA symbolique. Couvre les logiques formelles, la révision de croyances, l'argumentation computationnelle, le raisonnement incertain (Markov Logic) et causal. **Double stack Python (JPype) et C#/.NET (IKVM)** — voir EPIC #4667 (Tweety .NET) pour le marathon de portage : 12 modules C# mergés en complément des 13 notebooks Python originaux.
+Série sur [TweetyProject](https://tweetyproject.org/), bibliothèque Java pour l'IA symbolique. Couvre les logiques formelles, la révision de croyances, l'argumentation computationnelle, le raisonnement incertain (Markov Logic) et causal. **Double stack Python (JPype) et C#/.NET (IKVM)** — voir EPIC #4667 (Tweety .NET) pour le marathon de portage : 18 modules C# mergés en complément des 13 notebooks Python originaux.
 
 ### Structure détaillée (Python / JPype)
 
@@ -139,9 +139,9 @@ Série sur [TweetyProject](https://tweetyproject.org/), bibliothèque Java pour 
 
 ### Parité C# / .NET (EPIC #4667 — Tweety .NET via IKVM 8.14/8.15)
 
-En complément du parcours Python, **12 modules .NET C#** sont mergés dans le tronc, executés in-kernel `.net-csharp` via IKVM (DLL natives générées par shading Maven + `dotnet build`). Chaque notebook C# porte le suffixe `-Csharp` et expose les mêmes APIs TweetyProject via `Activator.CreateInstance` (IKVM efface les génériques, voir leçon C188). Tableau indicatif (catalogue fait foi pour les chiffres exacts) :
+En complément du parcours Python, **18 modules .NET C#** sont mergés dans le tronc, exécutés in-kernel `.net-csharp`. Deux approches cohabitent : les jumeaux **IKVM** (DLL natives générées par shading Maven + `dotnet build`, exposant les mêmes APIs TweetyProject via `Activator.CreateInstance` — IKVM efface les génériques, voir leçon C188) et les jumeaux **from-scratch** (réimplémentation BCL-only des mêmes algorithmes, sans dépendance Java, pour comparer les écosystèmes sur du code pur). Tableau indicatif (catalogue fait foi pour les chiffres exacts) :
 
-| Module C# | Equivalent Python | Stack IKVM | Statut |
+| Module C# | Equivalent Python | Stack | Statut |
 |-----------|-------------------|------------|--------|
 | Tweety-2-Basic-Logics-Csharp | Tw-2 | IKVM 8.14 + Choco | MERGED |
 | Tweety-2b-Semantics-Csharp | Tw-2 (semantics) | IKVM 8.14 | MERGED |
@@ -155,8 +155,14 @@ En complément du parcours Python, **12 modules .NET C#** sont mergés dans le t
 | Tweety-4-Aspic-Csharp | Tw-6 (ASPIC+) | IKVM 8.14 | MERGED |
 | Tweety-7b-Ranking-Probabilistic-Csharp | Tw-7b | IKVM 8.14 | MERGED |
 | Tweety-10-MLN-Csharp | Tw-10 | IKVM 8.14 | MERGED |
+| Tweety-5-Abstract-Argumentation-Csharp | Tw-5 (Dung) | from-scratch (BCL) | MERGED |
+| Tweety-6-Structured-Argumentation-Csharp | Tw-6 (ASPIC+) | from-scratch (BCL) | MERGED |
+| Tweety-7a-Extended-Frameworks-Csharp | Tw-7a (ADF/SetAF/EAF/VAF) | from-scratch (BCL) | MERGED |
+| Tweety-8-Agent-Dialogues-Csharp | Tw-8 (Dialogues) | from-scratch (BCL) | MERGED |
+| Tweety-9-Preferences-Csharp | Tw-9 (Preferences) | IKVM 8.15 + pref DLL | MERGED |
+| Tweety-11-Causal-Csharp | Tw-11 (Causal) | from-scratch (BCL) | MERGED |
 
-Tw-9 Preferences (PR #5268 OPEN) et Tw-1-Setup-Csharp / Tw-11-Causal-Csharp sont en cours ou planifiés ; leur statut vit dans le tracker EPIC #4667. La documentation complète de la chaîne de build (Maven shade → `dotnet build` → nbconvert `.net-csharp`) est dans le README de chaque notebook C#.
+Seul `Tweety-1-Setup-Csharp` reste planifié ; tous les autres jumeaux C# (Tw-2 à Tw-11) sont mergés (statut détaillé dans le tracker EPIC #4667). La documentation complète de la chaîne de build (Maven shade pour les jumeaux IKVM, BCL-only pour les jumeaux from-scratch → `dotnet build` → nbconvert `.net-csharp`) est dans le README de chaque notebook C#.
 
 ### Technologies
 


### PR DESCRIPTION
## Summary

§E fichier-entier audit of `MyIA.AI.Notebooks/SymbolicAI/README.md` (issue #4959, P0 #2 = hub SymbolicAI). Found the **Tweety C# parity section stale by 6 finalized modules**. Surgical fix (+11/−5, 1 file, 0 notebooks touched).

## Defect (verified firsthand on `origin/main`)

The Tweety C# header (L113, L142, L159) documented **12 modules**, but `origin/main` has **18**:

```
$ git ls-tree origin/main --name-only MyIA.AI.Notebooks/SymbolicAI/Tweety/ | grep -c 'Csharp\.ipynb$'
18
```

The 6 undocumented modules are all **100% executed** (not WIP stubs):

| Notebook | Executed cells | Merged via |
|----------|---------------:|------------|
| Tweety-5-Abstract-Argumentation-Csharp | 12/12 | #5508 |
| Tweety-6-Structured-Argumentation-Csharp | 10/10 | #5556 |
| Tweety-7a-Extended-Frameworks-Csharp | 9/9 | #5599 |
| Tweety-8-Agent-Dialogues-Csharp | 10/10 | f15755c85 |
| Tweety-9-Preferences-Csharp | 9/9 | #5301 |
| Tweety-11-Causal-Csharp | 12/12 | #5582 |

Plus the L159 status claim was **false**: it said "PR #5268 OPEN" for Tw-9 — but #5268 is **CLOSED** (unmerged); Tw-9 was actually merged via #5301. And it said Tw-11 was "planifié" — but Tw-11 is merged via #5582.

## Cross-validation (the count was already canonical elsewhere in the file)

The existing reconciliation note L610 (post-#5894 audit, dated 10/07) **already documented** the canonical count:

> `Tweety 32 = 13 Python + 18 C# + 1 probe`

So a prior whole-file audit had corrected the reconciliation note but **missed the header section**. This PR aligns the header with the already-canonical count.

## Stack accuracy

Each of the 6 new rows carries its verified stack (not blanket "IKVM"):
- 5 are **from-scratch (BCL)** (Tw-5/6/7a/8/11 — réimplémentation sans dépendance Java, per their PR titles)
- 1 is **IKVM 8.15 + pref DLL** (Tw-9)

This is why the table header changed `Stack IKVM` → `Stack` (to accommodate the from-scratch twins), and L142 now describes both approaches.

## §E fichier-entier audit coverage (all 7 sub-series)

| Sub-series | Hub claim | Disk truth | Verdict |
|-----------|----------:|-----------:|---------|
| SmartContracts | 27 (SC-0..26) | 27 topics (variants expand file count) | ✓ accurate |
| Lean | 28 | 28 numbered on disk | ✓ accurate |
| SemanticWeb | 24 (12 Py + 12 C#) | 12 Py + 12 C# = 24 | ✓ accurate (twins named in header) |
| Planners | 15 | 15 (incl. archive Fast-Downward-Legacy) | ✓ accurate |
| SymbolicLearning | 20 (12 Py + 8 C#) | 12 Py + 8 C# = 20 | ✓ accurate |
| Argument_Analysis | 6 (Agentic course) | 21 total but L318 "projet/demo" | ✓ editorial (documented) |
| **Tweety C#** | **12** | **18** | **✗ FIXED (this PR)** |

No other defects found. Only the Tweety C# header was stale.

## Validation

- `git diff --stat`: 1 file, +11/−5
- Table row count post-fix: 18 data rows ✓
- No CATALOG-STATUS marker touched (catalog-guard safe)
- No notebook touched (no C.1/C.2/H.3 gate)
- 0 collision: no open/recent PR touches SymbolicAI/README.md

See #4959

🤖 Generated with [Claude Code](https://claude.com/claude-code)
