### PR TITLE
docs(readme,#4959): fix stale Lean lake refs in hub README §E table (post-#4365)

### DIFF
--- a/MyIA.AI.Notebooks/README.md
+++ b/MyIA.AI.Notebooks/README.md
@@ -126,11 +126,11 @@ Le dépôt pratique **explicitement** la double culture IA : Python (PyTorch, Di
 |---------|:---:|:---:|:---:|------|
 | GenAI | ● | ◐ | — | Python dominant ; C# pour Semantic Kernel |
 | QuantConnect | ● | ◐ | ◐ | Python + LEAN Engine C# + `kelly_lean` |
-| SymbolicAI | ● | ◐ | ● | Trilogie complète : Python (SymbolicLearning), C# (Tweety/Z3/SW/SC), Lean (Arrow/Conway/FWT) |
+| SymbolicAI | ● | ◐ | ● | Trilogie complète : Python (SymbolicLearning), C# (Tweety/Z3/SW/SC), Lean (Conway/FWT/Grothendieck) |
 | Search | ● | ● | ◐ | Parité CSP livrée — marathon jumeaux accompli (EPIC #4956) |
 | Probas | ● | ● | ◐ | Infer.NET + PyMC sur mêmes modèles ; `decision_theory_lean` (VNM + Gittins) |
 | Sudoku | ● | ● | ◐ | Backtracking/DLX Python + propagation C# + lake exact-cover |
-| GameTheory | ● | ◐ | ● | OpenSpiel Python + jumeau C# (MARL) ; `social_choice_lean` (Arrow) |
+| GameTheory | ● | ◐ | ● | OpenSpiel Python + jumeau C# (MARL) ; `game_theory_lean` (Arrow + Bondareva-Shapley) |
 | ML | ● | ● | ◐ | ML.NET (tutoriels) + jumeaux Python (sklearn, ONNX) + `learning_theory_lean` |
 | RL | ● | — | — | Stable-Baselines3 / Gym |
 | CaseStudies | ● | — | — | Projets interdisciplinaires |
@@ -276,12 +276,12 @@ Le Niveau 3 promet de « prouver ce qu'on a calculé » ; le dépôt tient cette
 | Famille | Lake phare | Théorème | Branchement notebook |
 |---------|-----------|----------|----------------------|
 | **SymbolicAI** (Tweety) | `argumentation_lean` | Théorèmes d'extension (Dung) + pragmatique Walton-Krabbe (cf. `#4046`) | Notebook Tweety + Argument_Analysis |
-| **SymbolicAI** (Lean) | `bondareva_lean` (résolu 0 sorry), `knot_lean` (GF(3) Path B), `fwt_lean` | Bondareva-Shapley, nœud trinôme, Fermat | SymbolicAI/Lean/Grothendieck + Conway |
+| **SymbolicAI** (Lean) | `knot_lean` (tricolorabilité Fox GF(3) + Piccirillo), `conway_lean` (Free Will Theorem 0 sorry), `grothendieck_lean` | Nœud trinôme / sliceness, théorème du libre arbitre (Kochen-Specker), visite catégorielle | SymbolicAI/Lean-16a (Conway) + 17a/b (Nœuds) + 15b (Grothendieck) |
 | **SymbolicAI** (SC) | `erc20_lean` | Pas de réentrance ERC-20 (cf. `#4047`) | SmartContracts/Erc20 |
 | **Search** | `search_lean` | Consistance + heuristique admissible = optimalité (cf. `#4048`) | Search-13 (A*), Part3-Advanced |
 | **Probas** | `decision_theory_lean/VNM` | Axiomes VNM ⇔ utilité espérée (cf. `#4049`) | DecisionTheory/DecInfer-1..2 (VNM) + DecInfer-9 (Gittins) |
 | **QuantConnect** | `kelly_lean` | Kelly `g(f) ≤ g(f*)` + unicité (cf. `#4052`) | QuantConnect QC-Py-10 Risk Management |
-| **GameTheory** | `social_choice_lean` (Arrow) | Théorème d'impossibilité d'Arrow (cf. `arrow_lean`) | GameTheory/16b-* Choix social |
+| **GameTheory** | `game_theory_lean` (SocialChoice + CooperativeGames, absorption `#4365`) | Impossibilité d'Arrow + Bondareva-Shapley (0 sorry) | GameTheory/16b-* Choix social |
 
 ```mermaid
 flowchart LR


### PR DESCRIPTION
## Summary

Corrige 4 références de lake Lean **stale** dans le hub central `MyIA.AI.Notebooks/README.md` — la table §E « Pont vers les Preuves Formelles » (L276-284) + la table d'aperçu cross-famille (L129, L133). Toutes obsolètes post-EPIC #4365 (absorption GT 6→2). **Toutes vérifiées firsthand** contre origin/main dans un worktree frais.

## Défauts corrigés (G.1 firsthand)

| Ligne | État (stale) | Réalité sur origin/main |
|-------|-------------|------------------------|
| L279 | `bondareva_lean` (0 sorry) | n'existe PAS standalone — Shapley vit dans `game_theory_lean/CooperativeGames/Shapley.lean` (GameTheory, absorbé sous #4365) |
| L279 | `fwt_lean` | n'existe PAS standalone — Free Will Theorem vit dans `conway_lean/Conway/FreeWillTheorem.lean` |
| L279 | "...Fermat" (théorème) | FAUX — fwt = théorème du libre arbitre (Conway-Kochen, Kochen-Specker 18-vecteurs), PAS Fermat ; le README conway_lean documente lui-même « théorème du libre arbitre » |
| L284 | `social_choice_lean` (Arrow) + `arrow_lean` | stale — Arrow vit dans `game_theory_lean/SocialChoice/Arrow.lean` ; `social_choice_lean/` a 0 .lean (absorbé) ; `arrow_lean` n'a jamais existé |
| L129 | SymbolicAI « Lean (Arrow/Conway/FWT) » | Arrow est un résultat GameTheory, pas SymbolicAI — corrigé en Conway/FWT/Grothendieck (les vrais lakes SymbolicAI/Lean) |
| L133 | GameTheory « `social_choice_lean` (Arrow) » | corrigé en `game_theory_lean` (Arrow + Bondareva-Shapley) |

## Audit fichier-entier §E (règle E)

Audit complet de TOUTES les refs `*_lean` dans le fichier (13 occurrences L128-320) : tous les autres noms de lake (`argumentation_lean`, `erc20_lean`, `search_lean`, `decision_theory_lean`, `kelly_lean`, `learning_theory_lean`, `knot_lean`, `conway_lean`, `grothendieck_lean`, `game_theory_lean`) sont **accurate et vérifiés présents sur disque**. Seules les 4 refs stale ci-dessus ont été corrigées. L'arbre de structure L102 (`game_theory_lean ... (Arrow, Shapley, Conway, Stable Marriage)`) était déjà correct et est maintenant **cohérent** avec la table.

## Source du dispatch

Défaut surfaced par po-2024 §E audit c.663 (msg-20260719T010448-5qoazf, relayé à ai-01), qui l'a correctement **partitionné à la lane Lean** (po-2026, décision dashboard #16) plutôt que de le fixer lui-même (le piège shared-tree `cooperative_games_lean/` WIP a été attrapé via la leçon anti-poison c.606). Cette PR = le fix lane-Lean.

## Validation

- Fresh worktree from origin/main (pas de risque composite, cf leçon `worktree-checkout-b`).
- `find` firsthand : `bondareva_lean`/`fwt_lean`/`arrow_lean` = 0 résultat standalone ; Shapley → `game_theory_lean/CooperativeGames/`, Arrow → `game_theory_lean/SocialChoice/`, FWT → `conway_lean/Conway/`.
- `COURSE_CATALOG.generated.{json,md}` byte-identique à main (HARD 1 catalog-pr-hygiene vérifié).
- CRLF=0.

## Scope (1 fichier, 4 edits, +4/−4)

Pure documentation (0 `.lean`, 0 preuve, 0 code). Cohérent avec #7311 (po-2024 Tweety C# fix sur `SymbolicAI/README.md` — autre fichier, pas de collision).

See #4959 (README ascendant hub), #4365 (absorption GT 6→2 qui a rendu ces refs stale), #2874 (knot_lean), #2154/#1647 (conway_lean FWT).

Co-Authored-By: Claude <noreply@anthropic.com>
