### PR TITLE
docs(gametheory,#4959): fix 4 stale social_choice_lean refs post-#4365 (Arrow home = game_theory_lean/SocialChoice)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/README.md
@@ -309,7 +309,7 @@ GameTheory occupe une place à part dans la couche Lean : c'est la famille qui a
 
 | Famille | Lake phare | Théorème | Branchement notebook |
 | --- | --- | --- | --- |
-| **GameTheory** (choix social) | `social_choice_lean` (cf. `arrow_lean`) | Théorème d'impossibilité d'Arrow + caractérisation Sen + valeur de Shapley (résolu 0 sorry) | Notebooks 16b (Arrow), Argument_Analysis |
+| **GameTheory** (choix social) | `game_theory_lean` (SocialChoice) | Théorème d'impossibilité d'Arrow + caractérisation Sen + valeur de Shapley (résolu 0 sorry) | Notebooks 16b (Arrow), Argument_Analysis |
 | **GameTheory** (équilibres) | `minimax_lean` (Sion) | Existence d'un équilibre en stratégies mixtes via point fixe (Brouwer-Sion) | GameTheory-5b-Lean-Minimax (companion natif) |
 | **GameTheory** (design) | `lean_game_defs_ext` | Vickrey (enchère au second prix = stratégie dominante), théorème de révélation | GameTheory-11b-Lean-BayesianGamesExt |
 | **GameTheory** (coopératif) | `game_theory_lean` (CooperativeGames) | Bondareva-Shapley résolu 0 sorry (#3954), Core non-vide sous balanced | Notebooks 15-15b (coopératif, valeur de Shapley) |
@@ -330,7 +330,7 @@ flowchart LR
         N6["Repeated games grim"]
     end
     subgraph LEAN["Lakes Lean 4 (preuve)"]
-        L1["social_choice_lean<br/>impossibilité"]
+        L1["game_theory_lean/SocialChoice<br/>impossibilité"]
         L2["minimax_lean<br/>Sion"]
         L3["lean_game_defs_ext<br/>Vickrey"]
         L4["game_theory_lean/CooperativeGames<br/>0 sorry #3954"]
@@ -725,7 +725,7 @@ GameTheory/
 ├── conway_cgt_lean/               # Projet Lake jeux combinatoires (Conway CGT, toolchain v4.31.0-rc1)
 ├── minimax_lean/                  # Projet Lake minimax (Sion, cf #4054)
 ├── repeated_games_lean/           # Projet Lake jeux répétés (grim trigger, cf #4880)
-├── social_choice_lean/            # Projet Lake choix social (Arrow, Sen, Voting/Median Voter — 0 sorry)
+├── social_choice_lean/            # Archive — choix social absorbé dans game_theory_lean/SocialChoice/ (EPIC #4365, lean_lib neutralisée)
 ├── social_choice_lean_peters/     # Projet Lake référence DominikPeters (0 sorry, toolchain v4.27.0-rc1)
 ├── game_theory_lean/              # Projet Lake multi-module (4 modules : CooperativeGames, RepeatedGames, SocialChoice, StableMarriage — dont CooperativeGames + StableMarriage absorbés via EPIC #4365)
 ├── lean_game_defs/                # Projet Lake : types Lean partagés (lakefile.toml)
@@ -802,7 +802,7 @@ Cette série mobilise plusieurs couches de l'écosystème MCP du cluster, et ent
 
 | Cette série | Symétrie dans | Pont pédagogique |
 |-------------|---------------|------------------|
-| Lean 4 (Arrow, Sen, Shapley, Vickrey) | [SymbolicAI/Lean](../SymbolicAI/Lean/README.md) | Même toolchain WSL, partage de Mathlib ; notebooks `social_choice_lean` prouvent ce que `social_choice_lean_peters` référence (D. Peters, MIT) |
+| Lean 4 (Arrow, Sen, Shapley, Vickrey) | [SymbolicAI/Lean](../SymbolicAI/Lean/README.md) | Même toolchain WSL, partage de Mathlib ; notebooks `game_theory_lean/SocialChoice` prouvent ce que `social_choice_lean_peters` référence (D. Peters, MIT) |
 | Multi-Agent RL (NFSP, PSRO, AlphaZero) | [RL](../RL/README.md) | Stratégies d'équilibre *apprises* par interaction plutôt que calculées (cf notebook 17) |
 | Arbres de jeu, induction arrière, MCTS | [Search](../README.md) | Minimax (notebook 5) ↔ CSP-8-Temporal (Allen), P/N positions ↔ `Search-9-SatPlan-Symbolic` |
 | Mécanismes VCG, matching Gale-Shapley | [SymbolicAI/SmartContracts](../SymbolicAI/SmartContracts/README.md) | Gouvernance on-chain (DAO, vote vérifiable) ; le design de mécanismes se prolonge en smart contracts |


### PR DESCRIPTION
## Summary

Corrige 4 références **stale** post-EPIC #4365 dans `MyIA.AI.Notebooks/GameTheory/README.md` où `social_choice_lean` (désormais **coquille archive** — `lean_lib` neutralisée, 0 module source) est encore présenté comme le home canonique des preuves Arrow/Sen/Voting. Le home canonique actif est `game_theory_lean/SocialChoice/` (absorption byte-identique #4365 Phase-4). Companion Lean-lane de #7312 (hub central), même classe de défaut, partitionnée par po-2024 vers po-2026.

## Défauts corrigés (firsthand G.1)

Vérifié sur `origin/main` (worktree frais `CoursIA-gt-readme-arrow`, `a9895e71a`) :

- **`social_choice_lean/` = archive shell** : `git ls-tree` retourne UNIQUEMENT `lakefile.lean` (0 module source). Le `lakefile.lean` documente lui-même : « EPIC #4365 Phase-4 : SocialChoice a été absorbé byte-identique dans `game_theory_lean/SocialChoice/`... Ce lake archive conserve son package mais n'expose PLUS la lib ».
- **`game_theory_lean/SocialChoice/` = home canonique** : `Arrow.lean`, `Sen.lean`, `Voting.lean`, `Framework.lean`, `MechanismDesign.lean` (+ siblings `_en`) tous présents et actifs.
- **`arrow_lean` n'a JAMAIS existé** (phantom) : 0 résultat `find`/`ls-tree` standalone.

| Ligne | État (stale) | Correction |
|-------|-------------|------------|
| L312 (table §E « Lake phare ») | `social_choice_lean (cf. arrow_lean)` — phantom `arrow_lean` + archive comme lake phare | `game_theory_lean (SocialChoice)` — aligné avec les lignes coopératif/matching du même tableau (`game_theory_lean (Module)`) |
| L333 (nœud mermaid) | `L1["social_choice_lean<br/>impossibilité"]` | `L1["game_theory_lean/SocialChoice<br/>impossibilité"]` — cohérent avec la table corrigée (node ID `L1` inchangé) |
| L728 (arbre de structure) | `# Projet Lake choix social (Arrow, Sen, Voting — 0 sorry)` — attribue les preuves à l'archive | `# Archive — choix social absorbé dans game_theory_lean/SocialChoice/ (EPIC #4365, lean_lib neutralisée)` |
| L805 (table cross-famille) | `notebooks social_choice_lean prouvent ce que social_choice_lean_peters référence` — les preuves actives ne sont PAS dans l'archive | `notebooks game_theory_lean/SocialChoice prouvent...` |

## Audit fichier-entier §E (règle E)

Sweep complet de TOUTES les refs `social_choice_lean` + `arrow_lean` dans le fichier (L308, L312, L333, L356, L499, L502, L728, L805, L811). Les autres occurrences sont **accurate** :
- L308/L811 : `social_choice_lean_peters` (lake externe Peters, réel) + « 7 lakes en propre » (compte correct incluant l'archive).
- L356 : note de consolidation #4365 AUTHORITATIVE (détaille déjà le statut archive de `social_choice_lean` + les suppressions `cooperative_games_lean`/`stable_marriage_lean`) — c'est la source que cette PR rend cohérente avec L312/L333/L728/L805.
- L499/L502 : instructions de build listant les dirs lake (l'archive reste un projet Lake valide, `lake build` réussit en buildant rien).

§E compliance : corriger L312 en laissant L333/L728/L805 stale 100/400 lignes plus bas = `CHANGES_REQUESTED`. Les 4 fixes sont la **même classe de défaut** (post-#4365 misattribution), 1 fichier, 1 sujet — atomique, pas composite.

## Validation

- Fresh worktree from `origin/main` (pas de risque composite, cf leçon `worktree-checkout-b`).
- `git diff --stat` : 1 fichier, +4/−4.
- 0 `arrow_lean` résiduel (`grep`).
- CRLF=0.
- `COURSE_CATALOG.generated.{json,md}` byte-identique à main (HARD 1 catalog-pr-hygiene).

## Scope (1 fichier, 4 edits, +4/−4)

Pure documentation (0 `.lean`, 0 preuve, 0 code). Cohérent avec #7312 (hub central `MyIA.AI.Notebooks/README.md` — autre fichier, pas de collision) et #7311 (po-2024 Tweety C# — autre famille).

See #4959 (README ascendant hub audit), #4365 (GT 6→2 absorption qui a rendu ces refs stale), #6058 (Phase-4 PR cité dans le lakefile archive).

Co-Authored-By: Claude <noreply@anthropic.com>
