### PR TITLE
test(prover,#6058): drop obsolete STALE_POST_ABSORPTION — config.py now resolves game_theory_lean (228→229 passed)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
@@ -2678,17 +2678,15 @@ def test_path_constants_resolve_to_active_workspace():
         "NASH_CALIBRATION_FILE": NASH_CALIBRATION_FILE,
         "CONWAY_NIM_FILE": CONWAY_NIM_FILE,
     }
-    # VOTING_FILE and GALESHAPLEY_FILE were moved into game_theory_lean by the
-    # #4365 anti-proliferation absorption (#5913 StableMarriage, #6058
-    # SocialChoice), but prover/config.py still derives them from the now-gutted
-    # social_choice_lean / stable_marriage_lean dirs — so the resolved paths no
-    # longer exist on disk. That is a REAL config.py regression (the prover
-    # cannot target those demos post-absorption), tracked separately. It is
-    # unrelated to the #5891 workspace-resolution contract pinned here, so we
-    # do not conflate them: we assert workspace-membership for every constant,
-    # pin the two stale paths as "known broken until config.py follows #6058",
-    # and assert existence for the rest.
-    STALE_POST_ABSORPTION = {"VOTING_FILE", "GALESHAPLEY_FILE"}
+    # config.py was reconciled with the #4365 anti-proliferation absorption:
+    # SOCIAL_CHOICE_DIR / STABLE_MARRIAGE_DIR candidate lists now resolve to
+    # game_theory_lean FIRST (config.py:140, 167), so VOTING_FILE and
+    # GALESHAPLEY_FILE resolve to the canonical game_theory_lean/{SocialChoice,
+    # StableMarriage}/ paths that exist on disk. The previous STALE_POST_ABSORPTION
+    # exemption (tracking "config.py still derives from the gutted legacy dirs")
+    # is therefore obsolete and removed — existence is asserted for these two
+    # constants like every other, which is the correct post-reconciliation state.
+    STALE_POST_ABSORPTION: set[str] = set()
     for name, p in paths.items():
         assert p is not None, f"{name} is None — candidate list resolved to nothing"
         # Contract: the resolved path lives inside the workspace that hosts


### PR DESCRIPTION
test(prover,#6058): drop obsolete STALE_POST_ABSORPTION now config.py resolves game_theory_lean

The workspace-resolution test `test_path_constants_resolve_to_active_workspace`
pinned VOTING_FILE and GALESHAPLEY_FILE in a STALE_POST_ABSORPTION exemption
set, with a comment claiming "config.py still derives them from the now-gutted
social_choice_lean / stable_marriage_lean dirs — so the resolved paths no
longer exist on disk."

That claim is obsolete. config.py's SOCIAL_CHOICE_DIR and STABLE_MARRIAGE_DIR
candidate lists now resolve to game_theory_lean FIRST (config.py:140, 167),
so VOTING_FILE -> game_theory_lean/SocialChoice/Voting.lean and
GALESHAPLEY_FILE -> game_theory_lean/StableMarriage/GaleShapley.lean, both
of which exist on disk (verified firsthand on origin/main + via the resolved
paths). config.py was reconciled with the #4365 anti-proliferation absorption
(#5913 StableMarriage, #6058 SocialChoice).

The test's self-detection mechanism (assert not p.exists(), which intentionally
fails the moment the file appears) fired correctly during the post-#7308
regression audit: the two constants now exist, so the stale-exemption is
itself the staleness. Drop the two names from STALE_POST_ABSORPTION (now an
empty set) and replace the misleading comment with one documenting the
post-reconciliation state. The if-name-in-STALE_POST_ABSORPTION branch is
retained as dead-but-correct scaffolding: it never fires on an empty set but
preserves the auto-detection mechanism should a future path re-stale.

Validation: prover offline test suite, 228 passed/2 failed -> 229 passed/1
failed. The removed failure was test_path_constants_resolve_to_active_workspace
(now asserts existence correctly). Residual failure =
test_coordinator_agent_has_set_attack_plan_tool (OPENAI_API_KEY env missing,
integration-test, pre-existing, unrelated to this diff).

Scope: 1 file, +9/-11. 0 .lean touched. proof_knowledge.json side-effect
from the test run was reverted (not part of this fix). Surfaced during the
G.6 post-#7308-merge regression audit (c.510).

See #4365 (GT 6->2 absorption), #6058 (Phase-4 SocialChoice archive),
#5913 (StableMarriage absorption), #5891 (workspace-resolution contract).

Co-Authored-By: Claude <noreply@anthropic.com>
