### PR TITLE
test(prover): coordinator-agent test offline-runnable (dummy api_key via setitem)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
@@ -227,12 +227,22 @@ def test_autonomous_prover_accepts_workflow_timeout():
 # ──────────────────────────────────────────────────────────────────────────
 
 
-def test_coordinator_agent_has_set_attack_plan_tool():
+def test_coordinator_agent_has_set_attack_plan_tool(monkeypatch):
     """CoordinatorAgent must expose set_attack_plan and advance_plan tools.
 
     We verify by checking the CoordinatorTools instance is wired correctly,
-    since the Agent framework stores tools internally (not as _tools).
+    since the Agent framework stores tools internally (not as _tools). The
+    provider client is built via create_client (provider="zai") only as a
+    vehicle to construct the agent — no API call is made — but AsyncOpenAI
+    refuses to instantiate with an empty api_key. PROVIDERS resolves the key
+    from ZAI_API_KEY at module import, so env-based patching at test time is
+    too late; patch the dict entry directly to let the client build offline
+    (local dev / credential-less CI).
     """
+    import prover.config
+    monkeypatch.setitem(
+        prover.config.PROVIDERS["zai"], "api_key", "test-dummy-not-real"
+    )
     from prover.tools import CoordinatorTools
     from prover.agents import create_coordinator_agent
     from prover.trace import TraceLogger


### PR DESCRIPTION
## Summary

Rend `test_coordinator_agent_has_set_attack_plan_tool` exécutable hors-ligne (local dev + CI sans credentials). Le test construisait un vrai `CoordinatorAgent` via `create_coordinator_agent(tools, provider="zai")` → `create_client` → `AsyncOpenAI(api_key=cfg["api_key"], ...)`, où `cfg["api_key"]` est résolu depuis `ZAI_API_KEY` **à l'import du module** (`config.py` `PROVIDERS` est un dict module-level). Sans clé provider dans l'env, la valeur vaut `""` et `AsyncOpenAI` lève `openai.OpenAIError: Missing credentials` — le test échoue pour une raison **sans rapport avec ce qu'il asserte** (le wiring des tools : `agent.name == "CoordinatorAgent"`, `set_attack_plan`/`advance_plan` exposés).

Companion test-hygiene au travail #6790 pathology-3 (#7308) et au drop #7315 stale-absorption — même famille prover-test-suite, **classe de défaut distincte** (gap credential offline, pas une pathologie ni une exemption stale).

## Approches tentées et rejetées (G.1 — éviter au prochain lecteur de boucler)

| Tentative | Pourquoi ça échoue |
|-----------|--------------------|
| `monkeypatch.setenv("OPENAI_API_KEY", "dummy")` | `AsyncOpenAI` est construit avec `api_key=cfg["api_key"]=""` **explicitement** ; une *chaîne vide* n'est pas `None`, donc le fallback env du SDK ne s'active pas → raise quand même. |
| `monkeypatch.setenv("ZAI_API_KEY", "dummy")` | Trop tard : `PROVIDERS` a déjà capturé `""` à l'import ; la var d'env n'est jamais relue. |
| `ZAI_API_KEY=dummy pytest ...` (shell) | Marche (var positionnée avant le démarrage de l'interpréteur) — **mais ce n'est pas une réponse CI viable**. |

## Fix

Patch direct de l'entrée du dict via `monkeypatch.setitem` :

```python
def test_coordinator_agent_has_set_attack_plan_tool(monkeypatch):
    ...
    import prover.config
    monkeypatch.setitem(
        prover.config.PROVIDERS["zai"], "api_key", "test-dummy-not-real"
    )
    from prover.tools import CoordinatorTools
    ...
```

`create_client` lit alors une clé non-vide et le client se construit. **Aucun appel API n'est effectué** (le test n'inspecte que le wiring des tools de l'agent), donc la valeur factice ne quitte jamais le process.

## Validation (firsthand, worktree `CoursIA-prover-regress` depuis `origin/main` `4c81b1c9a`)

- **Isolé** : `tests/test_prover_guards.py::test_coordinator_agent_has_set_attack_plan_tool` → `1 passed in 1.02s` (avant : `Missing credentials`).
- **Suite offline complète** `prover/ tests/` : **228 passed/2 failed → 229 passed/1 failed**. Le failure corrigé = le test coordinator. Le failure résiduel = `test_path_constants_resolve_to_active_workspace` — c'est le **scope de PR #7315** (`STALE_POST_ABSORPTION`, branche ouverte séparée), **non touché ici** ; il échoue sur la baseline `origin/main` indépendamment de ce diff.
- `proof_knowledge.json` side-effect du run de test **reverté** (C.3 : stage uniquement le fichier intentionnel). Diff three-dot vs `origin/main` = 1 fichier, +12/−2, 0 CRLF.

## Scope (1 fichier, +12/−2)

`tests/test_prover_guards.py` uniquement. 0 `.lean`, 0 code de production (test-only). Pure test-hygiene, aucun changement de comportement du harnais prover.

See #1453 (prover harness co-evolution epic), #6790 (prover pathology register).

Co-Authored-By: Claude <noreply@anthropic.com>
