### PR TITLE
chore(translation,#4957): resync SymbolicAI/SemanticWeb CSV post-accent-cure (498 refresh + 174 new, 0 drift)

### DIFF
--- a/translations/semanticweb/semanticweb.csv
+++ b/translations/semanticweb/semanticweb.csv
@@ -381,7 +381,7 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-CSharp-RDFStar.ipynb,7527bc67,mar
 
 *Marathon #4956 — parité .NET ⇄ Python. Prong A : vrai moteur dotNetRDF 3.4.1 natif invoqué.*
 ",,,,,,,,3084c1f414564558,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,header-nav,markdown,fr,9150654b53ec1aed,"# SW-10-Python-RDFStar
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,header-nav,markdown,fr,f9a9761d7d3d1df1,"# SW-10-Python-RDFStar
 
 **Navigation** : [<< 9-JSONLD](SW-9-Python-JSONLD.ipynb) | [Index](README.md) | [11-KnowledgeGraphs >>](SW-11-Python-KnowledgeGraphs.ipynb)
 
@@ -392,7 +392,7 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,header-nav,m
 ## Objectifs d'apprentissage
 
 A la fin de ce notebook, vous saurez :
-1. Comprendre la motivation de RDF 1.2 (anciennement RDF-Star) et le probleme de la reification classique
+1. Comprendre la motivation de RDF 1.2 (anciennement RDF-Star) et le problème de la reification classique
 2. Utiliser la **reification standard** (`rdf:Statement`) pour annoter des assertions avec rdflib
 3. Utiliser les **graphes nommes** (Named Graphs) comme alternative pour le contexte et la provenance
 4. Comparer les trois approches : reification classique, graphes nommes, et RDF-Star
@@ -404,7 +404,7 @@ A la fin de ce notebook, vous saurez :
 |---------|-------------|
 | RDF 1.2 | Evolution du standard RDF integrant les quoted triples (W3C, 2024) |
 | Quoted Triple | Triplet utilise comme sujet ou objet d'un autre triplet : `<< s p o >>` |
-| Reification classique | Mecanisme RDF 1.0 pour parler de triplets (4 triplets par assertion) |
+| Reification classique | Mécanisme RDF 1.0 pour parler de triplets (4 triplets par assertion) |
 | Graphes nommes | Regrouper des triplets dans un contexte identifie par une URI |
 | Provenance | Qui a dit quoi ? Source et fiabilite d'une assertion |
 
@@ -420,7 +420,7 @@ Cependant, rdflib 7.x ne supporte pas encore le parsing Turtle-Star ni la classe
 Nous utilisons donc la **reification standard** et les **graphes nommes** comme implementations pratiques,
 tout en montrant comment RDF-Star simplifierait l'ecriture.
 
----",,,,,,,,9150654b53ec1aed,,,,,,,
+---",,,,,,,,f9a9761d7d3d1df1,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,install-intro,markdown,fr,c7402abcec729010,## Installation des dependances,,,,,,,,c7402abcec729010,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,install-pip,code,fr,948dfd69d63b0c63,"# Dependances pre-provisionnees (rdflib) : voir SemanticWeb/requirements.txt ; imports dans les cellules suivantes.
 ",,,,,,,,948dfd69d63b0c63,,,,,,,
@@ -446,26 +446,26 @@ else:
     print(""Support natif RDF-Star (Turtle-Star, QuotedTriple) : NON disponible."")
     print(""Ce notebook utilise la reification standard et les graphes nommes"")
     print(""comme alternatives fonctionnelles pour enseigner les memes concepts."")",,,,,,,,f66424ae0a23773c,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,section1-title,markdown,fr,ba7946248648ce15,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,section1-title,markdown,fr,add2ad3a70e7db56,"---
 
-## 1. Le probleme : pourquoi parler de triplets ?
+## 1. Le problème : pourquoi parler de triplets ?
 
-RDF permet de representer des faits sous forme de triplets. Mais que faire quand on veut **parler d'un triplet lui-meme** ?
+RDF permet de representer des faits sous forme de triplets. Mais que faire quand on veut **parler d'un triplet lui-même** ?
 
 Exemples de besoins courants :
 
 | Besoin | Exemple | Ce qu'on veut exprimer |
 |--------|---------|------------------------|
 | **Provenance** | Source d'une information | ""Wikipedia dit que Paris est la capitale de la France"" |
-| **Confiance** | Degre de certitude | ""L'assertion 'X connait Y' a un score de confiance de 0.85"" |
+| **Confiance** | Degré de certitude | ""L'assertion 'X connait Y' a un score de confiance de 0.85"" |
 | **Temporalite** | Validite dans le temps | ""Bob travaille chez Acme depuis 2020"" |
 | **Attribution** | Qui affirme quoi | ""Alice affirme que Bob connait Carol"" |
 | **Annotation** | Metadata sur un fait | ""Ce lien a ete decouvert par le crawler v2"" |
 
-En RDF classique (1.0/1.1), le seul mecanisme disponible est la **reification**, qui s'avere lourde et peu pratique.",,,,,,,,ba7946248648ce15,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,section1-reification,markdown,fr,c303ed9837a038cf,"### 1.1 La reification classique : 4 triplets pour 1 assertion
+En RDF classique (1.0/1.1), le seul mécanisme disponible est la **reification**, qui s'avere lourde et peu pratique.",,,,,,,,add2ad3a70e7db56,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,section1-reification,markdown,fr,b5b4d27e9a19ec05,"### 1.1 La reification classique : 4 triplets pour 1 assertion
 
-Pour dire ""Alice dit que Bob connait Carol"" en RDF classique, il faut creer une ressource intermediaire (un `rdf:Statement`) et decomposer l'assertion en 4 triplets :
+Pour dire ""Alice dit que Bob connait Carol"" en RDF classique, il faut créer une ressource intermediaire (un `rdf:Statement`) et decomposer l'assertion en 4 triplets :
 
 ```turtle
 # Le triplet original qu'on veut annoter :
@@ -481,7 +481,7 @@ ex:statement1 rdf:object ex:Carol .
 ex:statement1 ex:assertedBy ex:Alice .
 ```
 
-Cela represente **5 triplets supplementaires** pour annoter un seul fait. De plus, la reification ne **garantit pas** que le triplet original existe reellement dans le graphe.",,,,,,,,c303ed9837a038cf,,,,,,,
+Cela represente **5 triplets supplementaires** pour annoter un seul fait. De plus, la reification ne **garantit pas** que le triplet original existe reellement dans le graphe.",,,,,,,,b5b4d27e9a19ec05,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,section1-demo-intro,markdown,fr,80944611f560574f,Voyons cela en pratique avec rdflib : la reification classique est verbeuse mais fonctionnelle.,,,,,,,,80944611f560574f,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,demo-reification,code,fr,2ceadfb7bd8fb87c,"from rdflib import Graph, URIRef, Literal, Namespace, BNode
 from rdflib.namespace import RDF, RDFS, FOAF, XSD
@@ -513,32 +513,32 @@ print(f""  - Annotations : 2 triplets"")
 print(f""  - Total : 7 triplets pour annoter 1 fait"")
 print()
 print(g_reif.serialize(format=""turtle""))",,,,,,,,2ceadfb7bd8fb87c,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,interpretation-reification,markdown,fr,7278672d5504e16e,"## Interpretation : cout de la reification
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,interpretation-reification,markdown,fr,b73b85d2e3b22fa8,"## Interpretation : cout de la reification
 
 | Approche | Triplets necessaires | Lisibilite | Garantie d'existence |
 |----------|---------------------|------------|---------------------|
 | Fait seul | 1 | Excellente | Oui |
-| Reification classique | 1 + 4 + N annotations | Faible | Non (le Statement est independant) |
+| Reification classique | 1 + 4 + N annotations | Faible | Non (le Statement est indépendant) |
 | RDF-Star (quoted triple) | 1 + N annotations | Bonne | Configurable |
 
 **Problemes de la reification classique** :
 1. **Verbeux** : 4 triplets par assertion reifiee, explosion combinatoire
 2. **Deconnecte** : le `rdf:Statement` ne garantit pas que le triplet original existe
-3. **Requetes complexes** : les requetes SPARQL pour retrouver les annotations sont longues
+3. **Requêtes complexes** : les requêtes SPARQL pour retrouver les annotations sont longues
 4. **Pas standard dans la pratique** : peu de triple stores optimisent la reification
 
-> **Point cle** : RDF-Star (devenu RDF 1.2) resout ces problemes en permettant d'utiliser un triplet directement comme sujet ou objet d'un autre triplet. En attendant un support complet dans rdflib, nous pouvons utiliser la reification de maniere structuree grace a une fonction utilitaire.",,,,,,,,7278672d5504e16e,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,section2-title,markdown,fr,c023ba9ef67575ad,"---
+> **Point cle** : RDF-Star (devenu RDF 1.2) resout ces problemes en permettant d'utiliser un triplet directement comme sujet ou objet d'un autre triplet. En attendant un support complet dans rdflib, nous pouvons utiliser la reification de maniere structuree grace a une fonction utilitaire.",,,,,,,,b73b85d2e3b22fa8,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,section2-title,markdown,fr,8e0c77b7a48483c7,"---
 
 ## 2. RDF 1.2 et les Quoted Triples
 
 ## Historique
 
-| Date | Evenement |
+| Date | Événement |
 |------|----------|
 | 2014 | Olaf Hartig propose RDF* (RDF-Star) dans un article academique |
 | 2017-2019 | Adoption par des triple stores (Blazegraph, Stardog, Jena) |
-| 2021 | Le W3C cree le RDF-Star Community Group |
+| 2021 | Le W3C créé le RDF-Star Community Group |
 | 2023 | Le W3C integre RDF-Star dans la specification RDF 1.2 |
 | 2024 | RDF 1.2 devient une W3C Recommendation (Candidate) |
 
@@ -560,11 +560,11 @@ Cela remplacerait les 7 triplets de la reification classique par seulement **2 t
 |--------|----------------------|--------------------|
 | **Syntaxe** | `ex:stmt rdf:subject ex:Bob .` (4 triplets) | `<< ex:Bob foaf:knows ex:Carol >>` (inline) |
 | **Triplets par annotation** | 4 + N | N |
-| **Requetes SPARQL** | JOIN sur Statement | Pattern `<< ?s ?p ?o >>` |
+| **Requêtes SPARQL** | JOIN sur Statement | Pattern `<< ?s ?p ?o >>` |
 | **Support triple stores** | Universel | Croissant (Jena, Blazegraph, Stardog, Oxigraph) |
 | **Support rdflib** | Natif (toutes versions) | Pas encore disponible (7.6.0) |
 
-> **Note pratique** : rdflib 7.6.0 ne supporte pas encore la syntaxe Turtle-Star (`<< ... >>`). Dans les sections suivantes, nous implementons les memes concepts via la reification standard, en montrant a chaque fois comment RDF-Star simplifierait l'ecriture.",,,,,,,,c023ba9ef67575ad,,,,,,,
+> **Note pratique** : rdflib 7.6.0 ne supporte pas encore la syntaxe Turtle-Star (`<< ... >>`). Dans les sections suivantes, nous implementons les mêmes concepts via la reification standard, en montrant a chaque fois comment RDF-Star simplifierait l'ecriture.",,,,,,,,8e0c77b7a48483c7,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,section2-rdflib-intro,markdown,fr,f0184f43404e3fae,"### 2.1 Fonction utilitaire de reification
 
 Pour faciliter la creation de reifications et reduire la verbosite du code, definissons une fonction `reify()` qui encapsule les 4 triplets necessaires.
@@ -625,9 +625,9 @@ print(f""  - Total : {len(g_demo)}"")
 print()
 print(""=== Serialisation Turtle ==="")
 print(g_demo.serialize(format=""turtle""))",,,,,,,,996f97952dde7bca,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,interpretation-rdfstar-basic,markdown,fr,993b67137c166531,"## Interpretation
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,interpretation-rdfstar-basic,markdown,fr,d881ad4c0af67fc1,"## Interpretation
 
-La fonction `reify()` simplifie l'ecriture, mais le cout en triplets reste le meme. Comparons :
+La fonction `reify()` simplifie l'ecriture, mais le cout en triplets reste le même. Comparons :
 
 | Approche | Triplets pour ""Bob connait Carol"" | Triplets pour 3 annotations | Total |
 |----------|----------------------------------|----------------------------|-------|
@@ -642,20 +642,20 @@ ex:Bob foaf:knows ex:Carol .
 << ex:Bob foaf:knows ex:Carol >> ex:since ""2020-01-15""^^xsd:date .
 ```
 
-> **Note technique** : Un quoted triple n'est pas necessairement asserte dans le graphe. `<< ex:Bob foaf:knows ex:Carol >> ex:assertedBy ex:Alice .` ne signifie pas automatiquement que Bob connait Carol -- seulement qu'Alice le dit. Pour asserter le fait, il faut aussi ajouter `ex:Bob foaf:knows ex:Carol .` explicitement.",,,,,,,,993b67137c166531,,,,,,,
+> **Note technique** : Un quoted triple n'est pas necessairement asserte dans le graphe. `<< ex:Bob foaf:knows ex:Carol >> ex:assertedBy ex:Alice .` ne signifie pas automatiquement que Bob connait Carol -- seulement qu'Alice le dit. Pour asserter le fait, il faut aussi ajouter `ex:Bob foaf:knows ex:Carol .` explicitement.",,,,,,,,d881ad4c0af67fc1,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,section3-title,markdown,fr,dd8a660c3b80e273,"---
 
 ## 3. Construction programmatique avec reification
 
 Voyons comment construire des annotations sur des triplets de maniere programmatique avec la fonction `reify()`.",,,,,,,,dd8a660c3b80e273,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,section3-api-intro,markdown,fr,a5064c9410edf956,"### 3.1 Construction programmatique
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,section3-api-intro,markdown,fr,01298c4af394eedd,"### 3.1 Construction programmatique
 
 Grace a la fonction `reify()`, la construction suit un pattern simple :
 1. Ajouter le fait original au graphe
-2. Appeler `reify()` pour creer le Statement
+2. Appeler `reify()` pour créer le Statement
 3. Ajouter les annotations sur le Statement retourne
 
-En RDF-Star, les etapes 2-3 se combineraient : le quoted triple `<< s p o >>` joue directement le role du Statement.",,,,,,,,a5064c9410edf956,,,,,,,
+En RDF-Star, les étapes 2-3 se combineraient : le quoted triple `<< s p o >>` joue directement le rôle du Statement.",,,,,,,,01298c4af394eedd,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,demo-programmatic,code,fr,2fbb79a3a0736aaa,"from rdflib import Graph, URIRef, Literal, Namespace, BNode
 from rdflib.namespace import RDF, FOAF, XSD
 
@@ -680,27 +680,27 @@ print(f""  Type du Statement : {type(stmt).__name__}"")
 print()
 print(""=== Serialisation Turtle ==="")
 print(g_prog.serialize(format=""turtle""))",,,,,,,,2fbb79a3a0736aaa,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,interpretation-programmatic,markdown,fr,44b826b0d968f358,"## Interpretation
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,interpretation-programmatic,markdown,fr,7fb571cf05df210c,"## Interpretation
 
 La construction programmatique utilise `reify()` pour encapsuler les 4 triplets de reification :
 
-| Operation | Reification (actuel) | RDF-Star (futur) |
+| Opération | Reification (actuel) | RDF-Star (futur) |
 |-----------|---------------------|------------------|
-| Creer une reference au triplet | `reify(g, s, p, o)` -> BNode | `QuotedTriple(s, p, o)` |
+| Créer une reference au triplet | `reify(g, s, p, o)` -> BNode | `QuotedTriple(s, p, o)` |
 | Annoter | `g.add((stmt, pred, obj))` | `g.add((qt, pred, obj))` |
 | Serialisation | Turtle standard | Turtle-Star (`<< ... >>`) |
 
-> **Avantage de la fonction `reify()`** : elle centralise la creation des 4 triplets de reification, rendant le code plus lisible et moins sujet aux erreurs. Quand rdflib supportera RDF-Star nativement, il suffira de remplacer l'appel a `reify()` par la creation d'un `QuotedTriple`.",,,,,,,,44b826b0d968f358,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,section3-nested-intro,markdown,fr,c4d6e2641d7815e6,"### 3.2 Annotations imbriquees (multi-niveaux)
+> **Avantage de la fonction `reify()`** : elle centralise la creation des 4 triplets de reification, rendant le code plus lisible et moins sujet aux erreurs. Quand rdflib supportera RDF-Star nativement, il suffira de remplacer l'appel a `reify()` par la creation d'un `QuotedTriple`.",,,,,,,,7fb571cf05df210c,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,section3-nested-intro,markdown,fr,6b774911bd57339b,"### 3.2 Annotations imbriquees (multi-niveaux)
 
-RDF-Star permet l'imbrication : un quoted triple peut lui-meme contenir un quoted triple. Par exemple : ""Alice rapporte que Bob croit que Carol connait Dave"".
+RDF-Star permet l'imbrication : un quoted triple peut lui-même contenir un quoted triple. Par exemple : ""Alice rapporte que Bob croit que Carol connait Dave"".
 
 En RDF-Star, cela s'ecrirait :
 ```turtle
 << << ex:Carol foaf:knows ex:Dave >> ex:believedBy ex:Bob >> ex:reportedBy ex:Alice .
 ```
 
-Avec la reification, on chaine les Statements. Construisons cet exemple.",,,,,,,,c4d6e2641d7815e6,,,,,,,
+Avec la reification, on chaîne les Statements. Construisons cet exemple.",,,,,,,,6b774911bd57339b,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,demo-nested,code,fr,5d898f2b8fc54f5e,"from rdflib import Graph, Namespace, Literal, BNode
 from rdflib.namespace import RDF, FOAF, XSD
 
@@ -733,7 +733,7 @@ print(f""  - Total : {len(g_nested)}"")
 print()
 print(""=== Serialisation Turtle ==="")
 print(g_nested.serialize(format=""turtle""))",,,,,,,,5d898f2b8fc54f5e,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,interpretation-nested,markdown,fr,c4a01d359d8562c8,"## Interpretation : imbrication
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,interpretation-nested,markdown,fr,0a9bf00d3e719c94,"## Interpretation : imbrication
 
 Chaque niveau d'imbrication ajoute du contexte sans modifier le fait de base :
 
@@ -745,8 +745,8 @@ Chaque niveau d'imbrication ajoute du contexte sans modifier le fait de base :
 
 Le cout en triplets est eleve avec la reification (12 triplets) contre seulement 4 avec RDF-Star.
 
-> **Attention** : L'imbrication profonde (>2 niveaux) rend les requetes SPARQL complexes, que ce soit en reification ou en RDF-Star. En pratique, un seul niveau d'imbrication couvre la majorite des cas d'usage.",,,,,,,,c4a01d359d8562c8,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,section4-title,markdown,fr,bb40f5de7180e0f3,"---
+> **Attention** : L'imbrication profonde (>2 niveaux) rend les requêtes SPARQL complexes, que ce soit en reification ou en RDF-Star. En pratique, un seul niveau d'imbrication couvre la majorite des cas d'usage.",,,,,,,,0a9bf00d3e719c94,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,section4-title,markdown,fr,afb9b91eb2d74ed0,"---
 
 ## 4. Interroger les annotations avec SPARQL
 
@@ -757,8 +757,8 @@ Le pendant de SPARQL-Star pour la reification classique utilise des patterns de 
 | Pattern | SPARQL-Star (conceptuel) | SPARQL avec reification |
 |---------|------------------------|------------------------|
 | Trouver les annotations | `<< ?s ?p ?o >> ?annPred ?annObj .` | `?stmt rdf:subject ?s ; rdf:predicate ?p ; rdf:object ?o ; ?annPred ?annObj .` |
-| Triplet specifique | `<< ex:Bob foaf:knows ?who >> ?p ?o .` | `?stmt rdf:subject ex:Bob ; rdf:predicate foaf:knows ; rdf:object ?who .` |
-| Annotation specifique | `<< ?s ?p ?o >> ex:confidence ?c .` | `?stmt rdf:subject ?s ; rdf:predicate ?p ; rdf:object ?o ; ex:confidence ?c .` |",,,,,,,,bb40f5de7180e0f3,,,,,,,
+| Triplet spécifique | `<< ex:Bob foaf:knows ?who >> ?p ?o .` | `?stmt rdf:subject ex:Bob ; rdf:predicate foaf:knows ; rdf:object ?who .` |
+| Annotation spécifique | `<< ?s ?p ?o >> ex:confidence ?c .` | `?stmt rdf:subject ?s ; rdf:predicate ?p ; rdf:object ?o ; ex:confidence ?c .` |",,,,,,,,afb9b91eb2d74ed0,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,section4-kg-intro,markdown,fr,0b98d3db9b78e179,"### 4.1 Construire un graphe de connaissances annote
 
 Creons un graphe plus riche avec des relations annotees : provenance, confiance et dates.",,,,,,,,0b98d3db9b78e179,,,,,,,
@@ -807,7 +807,7 @@ g_kg.add((stmt4, EX.confidence, Literal(0.50, datatype=XSD.double)))
 print(f""Graphe de connaissances : {len(g_kg)} triplets"")
 print()
 print(g_kg.serialize(format=""turtle""))",,,,,,,,00b089242798fe5b,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,interpretation-kg,markdown,fr,7a5be74af53c1be0,"## Interpretation : graphe de connaissances annote
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,interpretation-kg,markdown,fr,1553307117dbb5fe,"## Interpretation : graphe de connaissances annote
 
 Ce graphe illustre un reseau social avec des annotations de qualite :
 
@@ -820,10 +820,10 @@ Ce graphe illustre un reseau social avec des annotations de qualite :
 
 > **Point cle** : Le fait 4 n'est **pas asserte** dans le graphe (`ex:Alice foaf:knows ex:Dave .` n'apparait pas). Seul le `rdf:Statement` et ses annotations existent. Cela signifie que le graphe ne dit pas qu'Alice connait Dave -- il dit seulement que Bob le pretend.
 
-En RDF-Star, la meme distinction existe : `<< ex:Alice foaf:knows ex:Dave >> ex:assertedBy ex:Bob .` n'asserte pas le fait non plus.",,,,,,,,7a5be74af53c1be0,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,section4-sparql-intro,markdown,fr,fbd2de09e13ca46b,"### 4.2 Requetes SPARQL sur les reifications
+En RDF-Star, la même distinction existe : `<< ex:Alice foaf:knows ex:Dave >> ex:assertedBy ex:Bob .` n'asserte pas le fait non plus.",,,,,,,,1553307117dbb5fe,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,section4-sparql-intro,markdown,fr,d1458011ecaabcc5,"### 4.2 Requêtes SPARQL sur les reifications
 
-Interrogeons le graphe avec SPARQL standard pour extraire les annotations via les patterns de reification.",,,,,,,,fbd2de09e13ca46b,,,,,,,
+Interrogeons le graphe avec SPARQL standard pour extraire les annotations via les patterns de reification.",,,,,,,,d1458011ecaabcc5,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,sparql-star-basic,code,fr,27effad68f39f203,"# Requête 1 : Toutes les relations annotées avec confiance
 # En SPARQL-Star, on ecrirait : << ?person1 foaf:knows ?person2 >> ex:confidence ?confidence .
 # Avec la réification, on joint sur rdf:subject, rdf:predicate, rdf:object
@@ -917,33 +917,33 @@ for row in g_kg.query(query_low):
     p2 = str(row.person2).split(""/"")[-1]
     src = str(row.source) if row.source else ""-""
     print(f""  {p1} connait {p2} (confiance={float(row.confidence):.2f}, source={src})"")",,,,,,,,48742d183f1b32aa,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,interpretation-filter,markdown,fr,e0ed34e3271b7678,"## Interpretation : filtrage par confiance
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,interpretation-filter,markdown,fr,4a2d99e8d04637f4,"## Interpretation : filtrage par confiance
 
 Le filtrage separe les faits fiables des faits incertains :
 
-| Categorie | Relations | Usage recommande |
+| Catégorie | Relations | Usage recommande |
 |-----------|-----------|------------------|
 | Haute confiance (>= 0.60) | Alice-Bob, Bob-Carol | Utiliser pour le raisonnement |
 | Basse confiance (< 0.60) | Carol-Dave, Alice-Dave | A verifier, ne pas propager |
 
 Ce type de filtrage est essentiel dans les **graphes de connaissances** : on peut construire une vue ""fiable"" du graphe en excluant les assertions douteuses.
 
-> **Application concrete** : Dans un systeme de recommandation, on ne recommanderait un contact qu'a partir de relations de confiance >= 0.70.",,,,,,,,e0ed34e3271b7678,,,,,,,
+> **Application concrete** : Dans un système de recommandation, on ne recommanderait un contact qu'a partir de relations de confiance >= 0.70.",,,,,,,,4a2d99e8d04637f4,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,section5-title,markdown,fr,e379672939dbd167,"---
 
 ## 5. Cas d'usage concrets
 
 Explorons trois cas d'usage representatifs pour l'annotation de triplets.",,,,,,,,e379672939dbd167,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,section5-provenance-intro,markdown,fr,b7b6c64c30b2d6a9,"### 5.1 Provenance et attribution
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,section5-provenance-intro,markdown,fr,76fcc10f6c5f9772,"### 5.1 Provenance et attribution
 
-Le cas d'usage le plus naturel : enregistrer **qui** a produit une information, **quand**, et avec **quelle methode**. Ce pattern s'integre naturellement avec le vocabulaire PROV-O du W3C.
+Le cas d'usage le plus naturel : enregistrer **qui** a produit une information, **quand**, et avec **quelle méthode**. Ce pattern s'integre naturellement avec le vocabulaire PROV-O du W3C.
 
 En RDF-Star, cela s'ecrirait de maniere compacte :
 ```turtle
 << ex:Paris schema:population ""2161000""^^xsd:integer >>
     prov:wasDerivedFrom ex:INSEE_2023 ;
     prov:generatedAtTime ""2023-12-01""^^xsd:date .
-```",,,,,,,,b7b6c64c30b2d6a9,,,,,,,
+```",,,,,,,,76fcc10f6c5f9772,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,demo-provenance,code,fr,b77f629414852687,"from rdflib import Graph, Namespace, Literal, BNode
 from rdflib.namespace import RDF, RDFS, XSD
 
@@ -1008,9 +1008,9 @@ for row in g_prov.query(query_prov):
     date = str(row.date) if row.date else ""-""
     method = str(row.method) if row.method else ""-""
     print(f""{subj:<10} {prop:<20} {str(row.value):<12} {src:<15} {date:<12} {method}"")",,,,,,,,b77f629414852687,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,interpretation-provenance,markdown,fr,92929963ac4e0e43,"## Interpretation : provenance
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,interpretation-provenance,markdown,fr,60419abbe8d66c0b,"## Interpretation : provenance
 
-| Fait | Source | Date | Methode |
+| Fait | Source | Date | Méthode |
 |------|--------|------|--------|
 | Population de Paris = 2,161,000 | INSEE 2023 | 2023-12-01 | Recensement |
 | Superficie de Paris = 105.4 km2 | IGN 2023 | 2023-06-15 | Mesure cadastrale |
@@ -1024,16 +1024,16 @@ RDF-Star simplifierait cette ecriture en eliminant les 4 triplets de reification
     ex:accuracy ""haute"" .
 ```
 
-En reification classique, il faut 2 x 4 = 8 triplets supplementaires pour les Statements seuls.",,,,,,,,92929963ac4e0e43,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,section5-temporal-intro,markdown,fr,ab9cfb60051dddf4,"### 5.2 Annotations temporelles
+En reification classique, il faut 2 x 4 = 8 triplets supplementaires pour les Statements seuls.",,,,,,,,60419abbe8d66c0b,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,section5-temporal-intro,markdown,fr,a0805d66b769bdf0,"### 5.2 Annotations temporelles
 
 La reification est utile pour exprimer la validite temporelle des faits : un emploi, un statut, une relation qui change au fil du temps.
 
 En RDF-Star, cela s'ecrirait :
 ```turtle
 << ex:Marie schema:worksFor ex:Sorbonne >> ex:startDate ""2020-09-01""^^xsd:date .
-<< ex:Marie schema:worksFor ex:Sorbonne >> ex:role ""Professeure"" .
-```",,,,,,,,ab9cfb60051dddf4,,,,,,,
+<< ex:Marie schema:worksFor ex:Sorbonne >> ex:rôle ""Professeure"" .
+```",,,,,,,,a0805d66b769bdf0,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,demo-temporal,code,fr,ecd6ff886988d701,"from rdflib import Graph, Namespace, Literal, BNode
 from rdflib.namespace import RDF, XSD
 
@@ -1105,11 +1105,11 @@ print(""-"" * 65)
 for row in g_temporal.query(query_career):
     end = str(row.endDate) if row.endDate else ""en cours""
     print(f""{str(row.orgName):<15} {str(row.role):<15} {str(row.startDate):<12} {end:<12} {str(row.status)}"")",,,,,,,,ecd6ff886988d701,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,interpretation-temporal,markdown,fr,1680531f827880d2,"## Interpretation : annotations temporelles
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,interpretation-temporal,markdown,fr,6fe407a85b810d44,"## Interpretation : annotations temporelles
 
 Le parcours professionnel est represente de maniere structuree :
 
-| Periode | Organisation | Role | Statut |
+| Periode | Organisation | Rôle | Statut |
 |---------|-------------|------|--------|
 | 2012-2014 | MIT | Post-doc | Termine |
 | 2015-2020 | CNRS | Chercheuse | Termine |
@@ -1117,15 +1117,15 @@ Le parcours professionnel est represente de maniere structuree :
 
 **Sans RDF-Star**, cet historique necessite soit :
 - La **reification classique** (ce que nous faisons ici) : 4 triplets par relation + annotations
-- Des **blank nodes intermediaires** (ex: `ex:emploi1 ex:employer ex:MIT ; ex:role ""Post-doc"" .`) ce qui perd le lien direct `Marie -> worksFor -> MIT`
+- Des **blank nodes intermediaires** (ex: `ex:emploi1 ex:employer ex:MIT ; ex:rôle ""Post-doc"" .`) ce qui perd le lien direct `Marie -> worksFor -> MIT`
 
 RDF-Star simplifierait cette ecriture en annotant directement :
 ```turtle
 << ex:Marie schema:worksFor ex:CNRS >> ex:startDate ""2015-01-15""^^xsd:date ;
                                         ex:endDate ""2020-08-31""^^xsd:date ;
-                                        ex:role ""Chercheuse"" ;
+                                        ex:rôle ""Chercheuse"" ;
                                         ex:status ""termine"" .
-```",,,,,,,,1680531f827880d2,,,,,,,
+```",,,,,,,,6fe407a85b810d44,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,section5-multi-intro,markdown,fr,bd4d90b36d121390,"### 5.3 Fusion multi-sources avec scores de confiance
 
 Dans un graphe de connaissances construit a partir de sources multiples, chaque source peut affirmer des faits contradictoires. La reification permet de conserver toutes les versions et de les departager.",,,,,,,,bd4d90b36d121390,,,,,,,
@@ -1216,21 +1216,21 @@ LIMIT 1
 print()
 for row in g_multi.query(query_best):
     print(f""Valeur retenue (confiance max) : {int(row.pop):,d} (source: {row.source})"")",,,,,,,,eb80d9f3b34efc3d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,interpretation-multi-source,markdown,fr,d628e90abc40c57b,"## Interpretation : fusion multi-sources
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,interpretation-multi-source,markdown,fr,a8180999593df254,"## Interpretation : fusion multi-sources
 
 Ce pattern est fondamental pour les graphes de connaissances industriels :
 
 1. **Conserver toutes les valeurs** : chaque source a sa propre estimation
 2. **Annoter la confiance** : permettre un filtrage par fiabilite
 3. **Tracer la provenance** : savoir d'ou vient chaque information
-4. **Selectionner la meilleure** : prendre la valeur la plus fiable pour un usage donne
+4. **Sélectionner la meilleure** : prendre la valeur la plus fiable pour un usage donne
 
-| Strategie de selection | Requete | Usage |
+| Stratégie de sélection | Requête | Usage |
 |----------------------|---------|-------|
 | Plus haute confiance | `ORDER BY DESC(?confidence) LIMIT 1` | Vue par defaut |
-| Plus recente | `ORDER BY DESC(?year) LIMIT 1` | Donnees a jour |
-| Moyenne ponderee | Calcul hors SPARQL | Estimation consolidee |",,,,,,,,d628e90abc40c57b,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,section6-named-graphs-title,markdown,fr,bb4dcb011566efb1,"---
+| Plus recente | `ORDER BY DESC(?year) LIMIT 1` | Données a jour |
+| Moyenne ponderee | Calcul hors SPARQL | Estimation consolidee |",,,,,,,,a8180999593df254,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,section6-named-graphs-title,markdown,fr,663a9e2048834024,"---
 
 ## 6. Alternative : les Graphes Nommes (Named Graphs)
 
@@ -1244,10 +1244,10 @@ puis on annote cette URI.
 |--------|------------|----------------|----------|
 | **Granularite** | Par triplet | Par groupe de triplets | Par triplet |
 | **Verbosite** | 4 triplets / annotation | 1 URI par contexte | Inline |
-| **Modele de donnees** | Triplets | Quadruplets (quads) | Triplets etendus |
+| **Modèle de données** | Triplets | Quadruplets (quads) | Triplets etendus |
 | **Support rdflib** | Oui (toutes versions) | Oui (`Dataset`) | Non (7.6.0) |
 | **Support SPARQL** | Standard | `GRAPH ?g { ... }` | SPARQL-Star |
-| **Cas d'usage ideal** | Annotation fine | Provenance par lot | Annotation fine |",,,,,,,,bb4dcb011566efb1,,,,,,,
+| **Cas d'usage ideal** | Annotation fine | Provenance par lot | Annotation fine |",,,,,,,,663a9e2048834024,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,demo-named-graphs-intro,markdown,fr,5516b9240a657368,"### 6.1 Graphes nommes avec rdflib Dataset
 
 rdflib fournit la classe `Dataset` pour gerer des graphes nommes. Chaque graphe est identifie par une URI et contient un ensemble de triplets.",,,,,,,,5516b9240a657368,,,,,,,
@@ -1391,11 +1391,11 @@ Quand le support Turtle-Star sera disponible dans rdflib, la serialisation sera 
 << ex:Alice foaf:knows ex:Bob >> ex:confidence ""0.9""^^xsd:double .
 ```
 au lieu des 6 triplets actuels (1 fait + 4 reification + 1 annotation).",,,,,,,,336c88c326c61fc1,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,section8-comparison-title,markdown,fr,45a6d3488b068d79,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,section8-comparison-title,markdown,fr,9f786c7f16126194,"---
 
 ## 8. Comparaison des trois approches
 
-Recapitulons les trois mecanismes pour annoter des triplets RDF :
+Recapitulons les trois mécanismes pour annoter des triplets RDF :
 
 | Critere | Reification classique | Graphes nommes | RDF-Star / RDF 1.2 |
 |---------|----------------------|----------------|--------------------|
@@ -1414,11 +1414,11 @@ Recapitulons les trois mecanismes pour annoter des triplets RDF :
 | Annotation fine par triplet avec rdflib | Reification + fonction `reify()` |
 | Provenance par lot (""ces 100 faits viennent de cette source"") | Graphes nommes |
 | Triple store supportant RDF-Star (Jena, Stardog, Oxigraph) | RDF-Star natif |
-| Interoperabilite maximale | Reification (universellement supportee) |",,,,,,,,45a6d3488b068d79,,,,,,,
+| Interoperabilite maximale | Reification (universellement supportee) |",,,,,,,,9f786c7f16126194,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,section9-title,markdown,fr,d61aa21d3679d027,"---
 
 ## 9. Exercices et Exemples guide",,,,,,,,d61aa21d3679d027,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,exercise1-title,markdown,fr,f0030f08f573df1a,"### Exemple guide 1 : Critiques de film avec reification
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,exercise1-title,markdown,fr,7e7e609912efa55a,"### Exemple guide 1 : Critiques de film avec reification
 
 *Solution proposee par Lilou Mayot (promo 2026)*
 
@@ -1429,14 +1429,14 @@ Voici un exemple complet de critiques de film avec reification :
 
 Le fait principal est `ex:Film1 ex:rating ?note` avec les annotations de provenance.
 
-**Indice** : Chaque critique produit un `rdf:Statement` different car la note differe.
+**Indice** : Chaque critique produit un `rdf:Statement` différent car la note differe.
 
 En RDF-Star, cela s'ecrirait :
 ```turtle
 << ex:Film1 ex:rating ""4""^^xsd:integer >> ex:reviewer ""Critique A"" ;
                                            ex:source ""Le Monde"" ;
                                            ex:date ""2024-01-15""^^xsd:date .
-```",,,,,,,,f0030f08f573df1a,,,,,,,
+```",,,,,,,,7e7e609912efa55a,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,exercise1,code,fr,35880654a7cc0ad1,"# Exemple guide 1 : Critiques de film avec réification
 from rdflib import Graph, Namespace, Literal, BNode
 from rdflib.namespace import RDF, XSD
@@ -1497,16 +1497,16 @@ ORDER BY DESC(?note)
 print(""\n=== Critiques triees par note ==="")
 for row in g_ex1.query(query):
     print(f""  {row.reviewer} : {row.note}/5 ({row.source}, {row.date})"")",,,,,,,,35880654a7cc0ad1,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,exercise2-title,markdown,fr,7bc00fa27e8c1c63,"### Exemple guide 2 : Requeter les reifications avec SPARQL
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,exercise2-title,markdown,fr,facc7a86660837b2,"### Exemple guide 2 : Requeter les reifications avec SPARQL
 
 *Solution proposee par Lilou Mayot (promo 2026)*
 
-En utilisant le graphe de connaissances annote de la section 4.1 (variable `g_kg`), voici des requetes SPARQL pour :
+En utilisant le graphe de connaissances annote de la section 4.1 (variable `g_kg`), voici des requêtes SPARQL pour :
 
 1. Trouver toutes les relations **assertees par une tierce personne** (c'est-a-dire qui ont un `ex:assertedBy`)
 2. Trouver les relations **etablies depuis plus de 3 ans** (avant 2022-01-01)
 
-**Indice** : Utilisez le pattern `?stmt a rdf:Statement ; rdf:subject ?s ; rdf:predicate foaf:knows ; rdf:object ?o .`",,,,,,,,7bc00fa27e8c1c63,,,,,,,
+**Indice** : Utilisez le pattern `?stmt a rdf:Statement ; rdf:subject ?s ; rdf:predicate foaf:knows ; rdf:object ?o .`",,,,,,,,facc7a86660837b2,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,exercise2,code,fr,366aa25a998d6cf8,"# Exemple guide 2 : Requêtes SPARQL sur les réifications
 
 # Requête 2a : Relations assertées par une tierce personne
@@ -1555,11 +1555,11 @@ for row in g_kg.query(query_2b):
     p1 = str(row.person1).split(""/"")[-1]
     p2 = str(row.person2).split(""/"")[-1]
     print(f""  {p1} connait {p2} depuis {row.since}"")",,,,,,,,366aa25a998d6cf8,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,section10-title,markdown,fr,ca868ca933fc6ec5,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,section10-title,markdown,fr,6a50ec0f2de90376,"---
 
 ## 10. Ecosysteme et compatibilite
 
-RDF-Star est de plus en plus adopte par l'ecosysteme du Web Semantique.
+RDF-Star est de plus en plus adopte par l'ecosysteme du Web Sémantique.
 
 ### Support dans les triple stores
 
@@ -1591,8 +1591,8 @@ RDF-Star est de plus en plus adopte par l'ecosysteme du Web Semantique.
 | RDF 1.2 Turtle | Candidate Recommendation |
 | RDF 1.2 N-Triples | Candidate Recommendation |
 | SPARQL 1.2 Query | Working Draft |
-| RDF 1.2 JSON-LD | En discussion |",,,,,,,,ca868ca933fc6ec5,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,49b52742,markdown,fr,c621f8d3a027e44c,"### Exemple guide 3 : Graphe de confiance avec RDF-Star
+| RDF 1.2 JSON-LD | En discussion |",,,,,,,,6a50ec0f2de90376,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,49b52742,markdown,fr,d9cd4ea47d716817,"### Exemple guide 3 : Graphe de confiance avec RDF-Star
 
 *Solution proposee par Mustapha Oumeziane et Coraline Carpin (promo 2026)*
 
@@ -1601,7 +1601,7 @@ Construisons un graphe de connaissances representant des affirmations sur les ca
 - `:source` (agent ou document d'origine)
 - `:timestamp` (date de creation)
 
-Puis ecrivons une requete SPARQL qui selectionne uniquement les affirmations ayant une confiance >= 0.8.",,,,,,,,c621f8d3a027e44c,,,,,,,
+Puis ecrivons une requête SPARQL qui selectionne uniquement les affirmations ayant une confiance >= 0.8.",,,,,,,,d9cd4ea47d716817,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,3247e01b,code,fr,3a0e730aafbff84e,"# Exemple guide 3 : Graphe de confiance avec RDF-Star
 from rdflib import Graph, Namespace, Literal
 from rdflib.namespace import RDF, XSD
@@ -1653,7 +1653,7 @@ for row in g_trust.query(query_trusted):
     country = str(row.country).split(""/"")[-1]
     capital = str(row.capital).split(""/"")[-1]
     print(f""  {country} -> {capital} (confiance={float(row.confidence):.2f}, source={row.source})"")",,,,,,,,3a0e730aafbff84e,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,summary-title,markdown,fr,da44a8db407bd839,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,summary-title,markdown,fr,4bde3708970b8c53,"---
 
 ## Resume
 
@@ -1661,18 +1661,18 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,summary-titl
 
 | Concept | Description |
 |---------|-------------|
-| **Reification classique** | Mecanisme RDF 1.0 avec `rdf:Statement` (4 triplets par assertion, verbeux mais universel) |
+| **Reification classique** | Mécanisme RDF 1.0 avec `rdf:Statement` (4 triplets par assertion, verbeux mais universel) |
 | **Graphes nommes** | Regrouper des triplets dans un contexte identifie par une URI (granularite par lot) |
 | **Quoted Triple (RDF-Star)** | Triplet utilise comme sujet/objet : `<< s p o >>` (RDF 1.2, pas encore dans rdflib) |
 | **Provenance** | Annoter qui a dit quoi, quand, avec quelle source |
 | **Confiance** | Score de fiabilite attache a une assertion |
 | **Annotations temporelles** | Validite dans le temps d'un fait |
-| **Fusion multi-sources** | Conserver et departager les valeurs de sources differentes |
+| **Fusion multi-sources** | Conserver et departager les valeurs de sources différentes |
 
 ### Competences acquises
 
 1. Comprendre les limites de la reification classique et la motivation de RDF-Star
-2. Creer des annotations de triplets avec la reification et la fonction `reify()`
+2. Créer des annotations de triplets avec la reification et la fonction `reify()`
 3. Utiliser les graphes nommes (`Dataset`) comme alternative pour le contexte
 4. Interroger les annotations avec SPARQL standard (patterns de reification)
 5. Appliquer ces patterns a des cas concrets (provenance, temporalite, multi-sources)
@@ -1684,7 +1684,7 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,summary-titl
 - [W3C RDF 1.2 Turtle](https://www.w3.org/TR/rdf12-turtle/) - Syntaxe Turtle-Star
 - [SPARQL 1.2 Query](https://www.w3.org/TR/sparql12-query/) - Extension SPARQL-Star
 - [Olaf Hartig - RDF* and SPARQL*](https://arxiv.org/abs/1406.3399) - Article fondateur
-- [rdflib documentation](https://rdflib.readthedocs.io/) - Guide rdflib",,,,,,,,da44a8db407bd839,,,,,,,
+- [rdflib documentation](https://rdflib.readthedocs.io/) - Guide rdflib",,,,,,,,4bde3708970b8c53,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,footer-nav,markdown,fr,bbe402684d88fd03,"---
 
 Le notebook suivant explore les graphes de connaissances (Knowledge Graphs), en combinant les technologies RDF, SPARQL et les patterns vus dans cette serie.
@@ -1692,16 +1692,16 @@ Le notebook suivant explore les graphes de connaissances (Knowledge Graphs), en 
 ---
 
 **Navigation** : [<< 10-JSONLD](SW-9-Python-JSONLD.ipynb) | [Index](README.md) | [12-KnowledgeGraphs >>](SW-11-Python-KnowledgeGraphs.ipynb)",,,,,,,,bbe402684d88fd03,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,exemples-guides-sosolalt,markdown,fr,0043ad0d584f5011,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,exemples-guides-sosolalt,markdown,fr,929c7b30cd81bee1,"---
 
 ## Exemples guides (solutions proposees par @Sosolalt)
 
 *Les exemples ci-dessous ont ete resolus par @Sosolalt (EPITA-IS, promo 2028).*
-*Ils servent de modele pour comprendre les concepts abordes dans ce notebook.*
-",,,,,,,,0043ad0d584f5011,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,exemple-59a8f5a2,markdown,fr,f0da7732ab80099c,"### Exemple guide 4 : Donnees sportives multi-sources
+*Ils servent de modèle pour comprendre les concepts abordes dans ce notebook.*
+",,,,,,,,929c7b30cd81bee1,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,exemple-59a8f5a2,markdown,fr,75c70c99afebef53,"### Exemple guide 4 : Données sportives multi-sources
 
-*Solution proposee par @Sosolalt (EPITA-IS, promo 2028).*",,,,,,,,f0da7732ab80099c,,,,,,,
+*Solution proposee par @Sosolalt (EPITA-IS, promo 2028).*",,,,,,,,75c70c99afebef53,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,exemple-code-59a8f5a2,code,fr,c33c315fa3270602,"# Exercice 4 : Donnees sportives multi-sources
 from rdflib import Graph, Namespace, Literal
 from rdflib.namespace import RDF, XSD
@@ -1826,9 +1826,9 @@ print(""\n=== 3. Nombre de relations par source ==="")
 for row in g_kg.query(query_by_source):
     print(f""  {str(row.source):<15} : {int(row.nb)} relation(s)"")
 ",,,,,,,,cb72516597de30a2,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,exemple-0cfb9138,markdown,fr,b92a5875693021d9,"### Exemple guide 6 : Annotations temporelles sur evenements historiques
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,exemple-0cfb9138,markdown,fr,f99252ff27a67bd9,"### Exemple guide 6 : Annotations temporelles sur événements historiques
 
-*Solution proposee par @Sosolalt (EPITA-IS, promo 2028).*",,,,,,,,b92a5875693021d9,,,,,,,
+*Solution proposee par @Sosolalt (EPITA-IS, promo 2028).*",,,,,,,,f99252ff27a67bd9,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,exemple-code-0cfb9138,code,fr,8d93c2f61c27a0c7,"# Exercice 6 : Annotations temporelles sur des événements historiques
 # Note : rdflib 7.6 ne supporte pas la syntaxe RDF-Star native (<< s p o >>),
 # on utilise donc la réification (fonction reify) comme dans tout le notebook.
@@ -1891,16 +1891,16 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,exercices-a-
 
 *Ces exercices sont a realiser par l'etudiant.*
 ",,,,,,,,ac1bdd159b5d3237,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,ade47684,markdown,fr,ea401b1fc05ca08e,"### Exercice 4 : Annoter des donnees sportives multi-sources
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,ade47684,markdown,fr,8ec4638332a60c68,"### Exercice 4 : Annoter des données sportives multi-sources
 
-Creez un graphe RDF representant les scores de 3 matchs de football provenant de sources differentes.
+Créez un graphe RDF representant les scores de 3 matchs de football provenant de sources différentes.
 Pour chaque match, ajoutez :
 - `ex:homeTeam`, `ex:awayTeam`, `ex:score` (ex: ""3-1"")
 - Via reification : `ex:source` (journal), `ex:confidence`, `ex:date`
 
-Ecrivez ensuite une requete SPARQL selectionnant uniquement les scores confirmes par au moins 2 sources.
+Ecrivez ensuite une requête SPARQL selectionnant uniquement les scores confirmes par au moins 2 sources.
 
-**Indice** : Chaque source produit un `rdf:Statement` different pour le meme match. Utilisez `GROUP BY` et `HAVING(COUNT(?source) >= 2)`.",,,,,,,,ea401b1fc05ca08e,,,,,,,
+**Indice** : Chaque source produit un `rdf:Statement` différent pour le même match. Utilisez `GROUP BY` et `HAVING(COUNT(?source) >= 2)`.",,,,,,,,8ec4638332a60c68,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,59a8f5a2,code,fr,af2ad03e96ec20c4,"# Exercice 4 : Donnees sportives multi-sources
 from rdflib import Graph, Namespace, Literal
 from rdflib.namespace import RDF, XSD
@@ -1909,14 +1909,14 @@ from rdflib.namespace import RDF, XSD
 # Puis écrivez une requête SPARQL pour trouver les scores confirmes par >= 2 sources
 
 print(""Exercice a completer"")",,,,,,,,af2ad03e96ec20c4,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,1c81c386,markdown,fr,40da3230804e7114,"### Exercice 5 : Agregats SPARQL sur scores de confiance
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,1c81c386,markdown,fr,fd1170bec15f565f,"### Exercice 5 : Agregats SPARQL sur scores de confiance
 
-En reprenant le graphe `g_kg` de la section 4, ecrivez des requetes SPARQL pour :
+En reprenant le graphe `g_kg` de la section 4, ecrivez des requêtes SPARQL pour :
 1. Calculer la **moyenne des scores de confiance** de toutes les relations `foaf:knows`
 2. Trouver la **relation la plus ancienne** (date minimale)
 3. Compter le **nombre de relations par source** (regroupement)
 
-**Indice** : Utilisez `AVG()`, `MIN()`, `COUNT()` et `GROUP BY`.",,,,,,,,40da3230804e7114,,,,,,,
+**Indice** : Utilisez `AVG()`, `MIN()`, `COUNT()` et `GROUP BY`.",,,,,,,,fd1170bec15f565f,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,69862e55,code,fr,ce392de90990580d,"# Exercice 5 : Agrégats SPARQL sur scores de confiance
 
 # TODO étudiant : Écrivez 3 requêtes SPARQL avec agrégats sur g_kg
@@ -1925,23 +1925,23 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,69862e55,cod
 # 3. Nombre de relations par source
 
 print(""Exercice a completer"")",,,,,,,,ce392de90990580d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,022164e5,markdown,fr,bca716d3b8439cd1,"### Exercice 6 : Annotations temporelles sur des evenements historiques
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,022164e5,markdown,fr,3f1500c179e24e7e,"### Exercice 6 : Annotations temporelles sur des événements historiques
 
 Les sections 5.2 et 5.3 ont montre les **annotations temporelles** et la **fusion multi-sources**.
-Creez un graphe RDF-Star qui annote des evenements historiques avec des dates et sources.
+Créez un graphe RDF-Star qui annote des événements historiques avec des dates et sources.
 
 ### Objectifs
 
-1. Construire un graphe avec des evenements et leurs annotations temporelles
-2. Utiliser RDF-Star pour attacher date et source a chaque evenement
-3. Requete SPARQL pour filtrer les evenements apres une date donnee
+1. Construire un graphe avec des événements et leurs annotations temporelles
+2. Utiliser RDF-Star pour attacher date et source a chaque événement
+3. Requête SPARQL pour filtrer les événements après une date donnee
 
 **Indices :**
 
 - Reprenez le pattern de la section 5.2 : `g.add((s, p, o, context))` pour les triplets annotes
 - `<<ex:event1 ex:aLieu ""1789-07-14""^^xsd:date>>` en Turtle-Star
 - `FILTER(YEAR(?date) > 1800)` pour le filtrage temporel
-",,,,,,,,bca716d3b8439cd1,,,,,,,
+",,,,,,,,3f1500c179e24e7e,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,0cfb9138,code,fr,16cc690d174636bf,"# Exercice 6 : Annotations temporelles sur des événements historiques
 # TODO étudiant : créez un graphe RDF-Star d'événements historiques annotés
 #
@@ -1958,15 +1958,15 @@ g = None  # TODO étudiant : remplacer par le Graph construit
 results = None  # TODO étudiant : remplacer par les résultats de la requête
 print(""Exercice a completer"")
 ",,,,,,,,16cc690d174636bf,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,4186ac5b,markdown,fr,09ff44923ec643a1,"## Conclusion
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb,4186ac5b,markdown,fr,f9104ffa536bb2e8,"## Conclusion
 
 Ce notebook a permis d'explorer les aspects essentiels de sw 10 python rdfstar. Les points cles :
 
 - Les concepts fondamentaux ont ete presentes et illustres
 - Les Exercices proposent une mise en pratique progressive
-- Les resultats obtenus permettent de valider la comprehension
+- Les résultats obtenus permettent de valider la comprehension
 
-**Pour aller plus loin** : approfondir les aspects avances du sujet et explorer les liens avec d'autres domaines.",,,,,,,,09ff44923ec643a1,,,,,,,
+**Pour aller plus loin** : approfondir les aspects avances du sujet et explorer les liens avec d'autres domaines.",,,,,,,,f9104ffa536bb2e8,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-CSharp-KnowledgeGraphs.ipynb,9f7b0d71,markdown,fr,0881516ff9824387,"# SW-11-CSharp-KnowledgeGraphs
 
 **Twin C# (dotNetRDF) du notebook Python [SW-11-Python-KnowledgeGraphs](SW-11-Python-KnowledgeGraphs.ipynb)** (rdflib + kglab + networkx + owlready2).
@@ -2256,7 +2256,7 @@ Ce twin C# a couvert l'arc complet de la gestion d'un **Knowledge Graph** avec d
 5. **Visualisation** : ASCII (sous-graphe), avec les limites documentées vs pyvis/matplotlib.
 
 **Perspectives** : pour un KG plus large (DBpedia, Wikidata), dotNetRDF supporte les **endpoints SPARQL distants** (`SparqlRemoteEndpoint`) — on pourrait interroger `https://dbpedia.org/sparql` directement. Le raisonnement OWL complet (HermiT) reste un pont vers la JVM, déjà documenté dans SW-13.",,,,,,,,a3ef44fd004c1cda,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,header,markdown,fr,e18b2ee894ef6ae1,"# SW-11-Python-KnowledgeGraphs
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,header,markdown,fr,3c2ffe203c5aff67,"# SW-11-Python-KnowledgeGraphs
 
 **Navigation** : [<< 10-RDFStar](SW-10-Python-RDFStar.ipynb) | [Index](README.md) | [12-GraphRAG >>](SW-12-Python-GraphRAG.ipynb)
 
@@ -2269,8 +2269,8 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,head
 ## Objectifs d'apprentissage
 
 A la fin de ce notebook, vous saurez :
-1. Definir ce qu'est un Knowledge Graph et le situer dans l'ecosysteme des donnees structurees
-2. Construire un KG a partir de donnees tabulaires (CSV) avec rdflib
+1. Définir ce qu'est un Knowledge Graph et le situer dans l'ecosysteme des données structurees
+2. Construire un KG a partir de données tabulaires (CSV) avec rdflib
 3. Utiliser kglab comme couche d'abstraction pour manipuler des Knowledge Graphs
 4. Visualiser un KG avec NetworkX (matplotlib) et pyvis (interactif HTML)
 5. Manipuler des ontologies OWL avec OWLReady2 et lancer le raisonneur HermiT
@@ -2280,20 +2280,20 @@ A la fin de ce notebook, vous saurez :
 
 | Concept | Description |
 |---------|-------------|
-| Knowledge Graph | Graphe de connaissances reliant entites et relations semantiques |
+| Knowledge Graph | Graphe de connaissances reliant entites et relations sémantiques |
 | kglab | Bibliotheque Python d'abstraction pour les KG (au-dessus de rdflib) |
 | OWLReady2 | Bibliotheque Python pour manipuler des ontologies OWL et lancer des raisonneurs |
-| NetworkX | Bibliotheque Python de theorie des graphes, utilisee pour la visualisation |
+| NetworkX | Bibliotheque Python de théorie des graphes, utilisee pour la visualisation |
 | pyvis | Visualisation interactive de graphes en HTML/JavaScript |
 
 ### Prerequis
 - SW-8 (SHACL) et SW-9 (Linked Data) pour les fondations RDF/SPARQL
-- Python 3.10+ avec les dependances du fichier `requirements.txt`",,,,,,,,e18b2ee894ef6ae1,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,install-intro,markdown,fr,db07e8f0d508752e,"---
+- Python 3.10+ avec les dependances du fichier `requirements.txt`",,,,,,,,3c2ffe203c5aff67,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,install-intro,markdown,fr,33a33bd7774bb9de,"---
 
 ## 0. Installation des dependances
 
-Installons les bibliotheques necessaires pour ce notebook. Si elles sont deja presentes dans votre environnement, cette etape sera rapide.",,,,,,,,db07e8f0d508752e,,,,,,,
+Installons les bibliotheques necessaires pour ce notebook. Si elles sont déjà presentes dans votre environnement, cette étape sera rapide.",,,,,,,,33a33bd7774bb9de,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,install-cell,code,fr,cbe15da027b20fe6,"# Dependances pre-provisionnees (rdflib owlready2 kglab networkx matplotlib pyvis pandas) : voir SemanticWeb/requirements.txt ; imports dans les cellules suivantes.
 ",,,,,,,,cbe15da027b20fe6,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,install-verify-intro,markdown,fr,7c555ee99ae0d194,Verifions que les imports fonctionnent correctement.,,,,,,,,7c555ee99ae0d194,,,,,,,
@@ -2328,32 +2328,32 @@ except ImportError as e:
     print(f""pyvis     : NON DISPONIBLE ({e})"")
 
 print(""\nEnvironnement pret."")",,,,,,,,c92d5c32c459d5ce,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,install-interp,markdown,fr,c3ced79f04f158a2,"### Interpretation
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,install-interp,markdown,fr,06019eef1c1a4639,"### Interpretation
 
-| Bibliotheque | Role dans ce notebook |
+| Bibliotheque | Rôle dans ce notebook |
 |--------------|----------------------|
 | rdflib | Construction et interrogation du graphe RDF |
-| pandas | Chargement des donnees CSV |
+| pandas | Chargement des données CSV |
 | kglab | Couche d'abstraction Knowledge Graph |
 | owlready2 | Manipulation d'ontologies OWL + raisonnement HermiT |
 | networkx | Representation et visualisation de graphes |
 | matplotlib | Rendu graphique statique |
 | pyvis | Visualisation interactive (HTML) |
 
-> **Note technique** : kglab et pyvis sont optionnels. Les sections correspondantes utilisent des blocs `try/except` pour fonctionner meme si ces bibliotheques ne sont pas installees.",,,,,,,,c3ced79f04f158a2,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,section1-title,markdown,fr,5c93ad279ecc9f07,"---
+> **Note technique** : kglab et pyvis sont optionnels. Les sections correspondantes utilisent des blocs `try/except` pour fonctionner même si ces bibliotheques ne sont pas installees.",,,,,,,,06019eef1c1a4639,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,section1-title,markdown,fr,8156fe6630137e5b,"---
 
 ## 1. Qu'est-ce qu'un Knowledge Graph ?
 
 ### Definition et historique
 
-Un **Knowledge Graph** (graphe de connaissances) est un graphe oriente etiquete qui represente des entites du monde reel et les relations entre elles, enrichi par une couche semantique (ontologie, types, contraintes).
+Un **Knowledge Graph** (graphe de connaissances) est un graphe oriente etiquete qui represente des entites du monde reel et les relations entre elles, enrichi par une couche sémantique (ontologie, types, contraintes).
 
-Le terme a ete popularise par **Google en 2012** avec le lancement du *Google Knowledge Graph*, mais le concept existait deja sous d'autres formes :
+Le terme a ete popularise par **Google en 2012** avec le lancement du *Google Knowledge Graph*, mais le concept existait déjà sous d'autres formes :
 
-| Annee | Evenement | Impact |
+| Annee | Événement | Impact |
 |-------|-----------|--------|
-| 2001 | Article fondateur de Tim Berners-Lee sur le Web semantique | Vision initiale |
+| 2001 | Article fondateur de Tim Berners-Lee sur le Web sémantique | Vision initiale |
 | 2006 | Lancement de DBpedia (extraction RDF de Wikipedia) | Premier KG ouvert a grande echelle |
 | 2012 | Google Knowledge Graph (""Things, not strings"") | Adoption industrielle massive |
 | 2012 | Lancement de Wikidata | Base de connaissances collaborative |
@@ -2363,26 +2363,26 @@ Le terme a ete popularise par **Google en 2012** avec le lancement du *Google Kn
 ### Maturite industrielle (2024-2025)
 
 Les Knowledge Graphs sont aujourd'hui une technologie mature avec un retour sur investissement documente de **300-320%** dans les grandes entreprises (source : Gartner, Forrester). Ils servent de socle pour :
-- La recherche semantique (Google, Bing)
-- Les systemes de recommandation (Amazon, Netflix)
+- La recherche sémantique (Google, Bing)
+- Les systèmes de recommandation (Amazon, Netflix)
 - Le grounding de LLM (reduction des hallucinations via GraphRAG)
-- La conformite reglementaire (finance, sante)",,,,,,,,5c93ad279ecc9f07,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,section1-comparison,markdown,fr,9bd11cbc7bef43bb,"### Knowledge Graphs vs bases de donnees vs graphes RDF
+- La conformite reglementaire (finance, sante)",,,,,,,,8156fe6630137e5b,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,section1-comparison,markdown,fr,783be1e9fc737804,"### Knowledge Graphs vs bases de données vs graphes RDF
 
-Un Knowledge Graph n'est ni une simple base de donnees relationnelle, ni un graphe RDF brut. Il se situe a l'intersection de plusieurs technologies :
+Un Knowledge Graph n'est ni une simple base de données relationnelle, ni un graphe RDF brut. Il se situe a l'intersection de plusieurs technologies :
 
-| Caracteristique | Base relationnelle | Graphe RDF | Knowledge Graph |
+| Caractéristique | Base relationnelle | Graphe RDF | Knowledge Graph |
 |----------------|-------------------|------------|----------------|
-| Modele de donnees | Tables (lignes/colonnes) | Triplets (S-P-O) | Triplets + ontologie |
+| Modèle de données | Tables (lignes/colonnes) | Triplets (S-P-O) | Triplets + ontologie |
 | Schema | Rigide (DDL) | Flexible | Flexible + contraintes |
 | Identifiants | Cles primaires | URIs | URIs + labels |
-| Requetes | SQL | SPARQL | SPARQL + inference |
-| Raisonnement | Non | Basique (RDFS) | OWL, regles, raisonneur |
+| Requêtes | SQL | SPARQL | SPARQL + inference |
+| Raisonnement | Non | Basique (RDFS) | OWL, règles, raisonneur |
 | Interoperabilite | Faible (schema proprietaire) | Forte (standards W3C) | Forte + vocabulaires partages |
 | Exemples | PostgreSQL, MySQL | Triple Store brut | Google KG, Wikidata |
 
-**En resume** : Un Knowledge Graph = un graphe RDF + une ontologie + des mecanismes de qualite et de raisonnement.",,,,,,,,9bd11cbc7bef43bb,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,section1-major-kgs,markdown,fr,5feb4886cd10d5d7,"### Principaux Knowledge Graphs dans le monde
+**En resume** : Un Knowledge Graph = un graphe RDF + une ontologie + des mécanismes de qualite et de raisonnement.",,,,,,,,783be1e9fc737804,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,section1-major-kgs,markdown,fr,f1ffac793883bd34,"### Principaux Knowledge Graphs dans le monde
 
 | Knowledge Graph | Organisation | Taille estimee | Usage principal |
 |----------------|-------------|---------------|----------------|
@@ -2393,22 +2393,22 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,sect
 | LinkedIn Knowledge Graph | LinkedIn | 800+ millions de profils | Recrutement, reseau |
 | Microsoft Academic Graph | Microsoft | 250+ millions d'articles | Recherche scientifique |
 
-> **Point cle** : Tous ces KG utilisent des standards du Web semantique (RDF, OWL, SPARQL) comme fondation, meme s'ils ajoutent des couches proprietaires au-dessus.",,,,,,,,5feb4886cd10d5d7,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,section2-title,markdown,fr,4a11062d6d9a5aa9,"---
+> **Point cle** : Tous ces KG utilisent des standards du Web sémantique (RDF, OWL, SPARQL) comme fondation, même s'ils ajoutent des couches proprietaires au-dessus.",,,,,,,,f1ffac793883bd34,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,section2-title,markdown,fr,bcfb38e2a7cd5d6b,"---
 
-## 2. Construire un Knowledge Graph a partir de donnees structurees
+## 2. Construire un Knowledge Graph a partir de données structurees
 
-Dans cette section, nous allons transformer un fichier CSV de films en un Knowledge Graph RDF. Cette operation est fondamentale : la plupart des KG d'entreprise sont construits a partir de donnees existantes (CSV, bases relationnelles, APIs).
+Dans cette section, nous allons transformer un fichier CSV de films en un Knowledge Graph RDF. Cette opération est fondamentale : la plupart des KG d'entreprise sont construits a partir de données existantes (CSV, bases relationnelles, APIs).
 
 ### Approche
 
 1. Charger le CSV avec pandas
-2. Definir un vocabulaire RDF (classes et proprietes)
+2. Définir un vocabulaire RDF (classes et proprietes)
 3. Transformer chaque ligne en triplets RDF
-4. Verifier le graphe resultant",,,,,,,,4a11062d6d9a5aa9,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,section2-load-intro,markdown,fr,d863fa220937fcc6,"### 2.1 Chargement des donnees CSV
+4. Verifier le graphe resultant",,,,,,,,bcfb38e2a7cd5d6b,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,section2-load-intro,markdown,fr,3bf4273092bf4d7f,"### 2.1 Chargement des données CSV
 
-Le fichier `data/movies.csv` contient 12 films avec les colonnes : titre, annee, realisateur, genre, acteur principal, second acteur, note.",,,,,,,,d863fa220937fcc6,,,,,,,
+Le fichier `data/movies.csv` contient 12 films avec les colonnes : titre, annee, realisateur, genre, acteur principal, second acteur, note.",,,,,,,,3bf4273092bf4d7f,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,load-csv,code,fr,9c4bb5c2752a879f,"import pandas as pd
 
 df = pd.read_csv(""data/movies.csv"")
@@ -2424,9 +2424,9 @@ Le dataset contient **12 films** avec des realisateurs varies (Nolan, Tarantino,
 - Des notes entre 7.9 et 9.0
 
 Ces relations croisees (acteur-film, realisateur-film, genre) sont exactement ce que le Knowledge Graph va capturer sous forme de triplets.",,,,,,,,4cd622a202e5e6d2,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,section2-vocab-intro,markdown,fr,2654f51d8bc29a9d,"### 2.2 Definition du vocabulaire RDF
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,section2-vocab-intro,markdown,fr,71eb2b5df664caf3,"### 2.2 Definition du vocabulaire RDF
 
-Avant de creer les triplets, nous definissons les classes et proprietes de notre Knowledge Graph. Nous utilisons le vocabulaire **schema.org** quand il existe un terme equivalent, et un namespace local pour les extensions.
+Avant de créer les triplets, nous definissons les classes et proprietes de notre Knowledge Graph. Nous utilisons le vocabulaire **schema.org** quand il existe un terme equivalent, et un namespace local pour les extensions.
 
 | Entite/Relation | URI schema.org | URI local (fallback) |
 |----------------|---------------|---------------------|
@@ -2437,7 +2437,7 @@ Avant de creer les triplets, nous definissons les classes et proprietes de notre
 | a joue dans | `schema:actor` | - |
 | a pour genre | `schema:genre` | - |
 | annee de sortie | `schema:datePublished` | - |
-| note | `schema:aggregateRating` | - |",,,,,,,,2654f51d8bc29a9d,,,,,,,
+| note | `schema:aggregateRating` | - |",,,,,,,,71eb2b5df664caf3,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,define-vocab,code,fr,73fb3df5cccbf2e2,"from rdflib import Graph, Namespace, Literal, URIRef, RDF, RDFS, XSD
 from rdflib.namespace import FOAF
 import re
@@ -2466,9 +2466,9 @@ print(""Exemples de conversion URI :"")
 print(f""  'Christopher Nolan' -> {to_uri_id('Christopher Nolan')}"")
 print(f""  'Kill Bill Vol.1'   -> {to_uri_id('Kill Bill Vol.1')}"")
 print(f""  'Science-Fiction'   -> {to_uri_id('Science-Fiction')}"")",,,,,,,,73fb3df5cccbf2e2,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,define-vocab-interp,markdown,fr,e77411f9f4f495e6,"### Interpretation
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,define-vocab-interp,markdown,fr,dddee4330365ace1,"### Interpretation
 
-Nous avons defini quatre espaces de noms :
+Nous avons défini quatre espaces de noms :
 - **SCHEMA** : vocabulaire standard schema.org pour les types et proprietes connus
 - **MOVIES** : namespace local pour les instances de films
 - **PERSONS** : namespace local pour les instances de personnes
@@ -2476,7 +2476,7 @@ Nous avons defini quatre espaces de noms :
 
 La fonction `to_uri_id()` nettoie les noms pour produire des URIs valides (pas d'accents, pas d'espaces).
 
-> **Bonne pratique** : Reutiliser des vocabulaires existants (schema.org, FOAF, Dublin Core) avant de creer ses propres termes. Cela favorise l'interoperabilite avec d'autres KG.",,,,,,,,e77411f9f4f495e6,,,,,,,
+> **Bonne pratique** : Reutiliser des vocabulaires existants (schema.org, FOAF, Dublin Core) avant de créer ses propres termes. Cela favorise l'interoperabilite avec d'autres KG.",,,,,,,,dddee4330365ace1,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,section2-build-intro,markdown,fr,903ce6f131c48da6,"### 2.3 Transformation CSV vers triplets RDF
 
 Chaque ligne du CSV va generer plusieurs triplets. Pour un film donne, nous creons :
@@ -2533,9 +2533,9 @@ print(f""  Films      : {stats['movies']}"")
 print(f""  Personnes  : {len(stats['persons'])} (realisateurs + acteurs uniques)"")
 print(f""  Genres     : {len(stats['genres'])}"")
 print(f""  Triplets   : {len(g)}"")",,,,,,,,1305eaf9e3c3ac43,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,build-kg-interp,markdown,fr,8e0c1dc9b297e374,"### Interpretation
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,build-kg-interp,markdown,fr,588ae1b5a7fe3b81,"### Interpretation
 
-Le graphe contient un nombre significatif de triplets pour seulement 12 films. Cela illustre la richesse du modele RDF : chaque film genere environ 14 triplets (164 triplets pour 12 films), car chaque ligne du CSV produit des triplets pour le film (type, nom, annee, note, realisateur, 2 acteurs, genre) MAIS AUSSI pour les entites liees (les types des realisateurs, acteurs et genres, declares a chaque nouvelle mention).
+Le graphe contient un nombre significatif de triplets pour seulement 12 films. Cela illustre la richesse du modèle RDF : chaque film genere environ 14 triplets (164 triplets pour 12 films), car chaque ligne du CSV produit des triplets pour le film (type, nom, annee, note, realisateur, 2 acteurs, genre) MAIS AUSSI pour les entites liees (les types des realisateurs, acteurs et genres, declares a chaque nouvelle mention).
 
 **Structure du KG** :
 
@@ -2545,7 +2545,7 @@ Le graphe contient un nombre significatif de triplets pour seulement 12 films. C
 | Personne (`schema:Person`) | 28 | Christopher Nolan, Leonardo DiCaprio |
 | Genre (`movies:Genre`) | ~6 | Science-Fiction, Action, Crime |
 
-> **Point cle** : Les entites partagees (meme realisateur pour plusieurs films, meme acteur) ne sont creees qu'une fois grace aux URIs uniques. C'est la force du modele graphe par rapport aux tables relationnelles.",,,,,,,,8e0c1dc9b297e374,,,,,,,
+> **Point cle** : Les entites partagees (même realisateur pour plusieurs films, même acteur) ne sont créées qu'une fois grace aux URIs uniques. C'est la force du modèle graphe par rapport aux tables relationnelles.",,,,,,,,588ae1b5a7fe3b81,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,section2-sparql-intro,markdown,fr,88c1cb46c756daed,"### 2.4 Verification par SPARQL
 
 Interrogeons le graphe pour verifier que les relations sont correctes. Listons les films avec leur realisateur et leur note.",,,,,,,,88c1cb46c756daed,,,,,,,
@@ -2570,12 +2570,12 @@ print(f""{'Film':<30} {'Realisateur':<25} {'Note'}"")
 print(""-"" * 65)
 for row in results:
     print(f""{str(row.title):<30} {str(row.director_name):<25} {row.rating}"")",,,,,,,,a34ba2f5be7c6a1a,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,sparql-verify-interp,markdown,fr,68bfb28d743adfe7,"### Interpretation
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,sparql-verify-interp,markdown,fr,de5b785273f80d0c,"### Interpretation
 
-La requete SPARQL confirme que les 12 films sont correctement relies a leur realisateur et leur note. Le tri par note decroissante montre The Dark Knight en tete (9.0) et Titanic/Avatar en bas (7.9).
+La requête SPARQL confirme que les 12 films sont correctement relies a leur realisateur et leur note. Le tri par note decroissante montre The Dark Knight en tete (9.0) et Titanic/Avatar en bas (7.9).
 
-> **Lien avec SW-5** : Cette requete utilise les memes patterns SPARQL (SELECT, WHERE, ORDER BY) vus dans le notebook sur SPARQL, appliques ici a notre propre KG.",,,,,,,,68bfb28d743adfe7,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,sparql-actors-intro,markdown,fr,abe8eb14c8e40408,Cherchons maintenant les acteurs qui apparaissent dans plusieurs films -- une requete qui serait complexe en SQL mais naturelle en SPARQL.,,,,,,,,abe8eb14c8e40408,,,,,,,
+> **Lien avec SW-5** : Cette requête utilise les mêmes patterns SPARQL (SELECT, WHERE, ORDER BY) vus dans le notebook sur SPARQL, appliques ici a notre propre KG.",,,,,,,,de5b785273f80d0c,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,sparql-actors-intro,markdown,fr,3448fa9c585c1df5,Cherchons maintenant les acteurs qui apparaissent dans plusieurs films -- une requête qui serait complexe en SQL mais naturelle en SPARQL.,,,,,,,,3448fa9c585c1df5,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,sparql-actors,code,fr,b66e618104ffd233,"# Requete : acteurs apparaissant dans plus d'un film
 query_actors = """"""
 PREFIX schema: <http://schema.org/>
@@ -2597,15 +2597,15 @@ print(f""{'Acteur':<25} {'Nb films':<10} {'Films'}"")
 print(""-"" * 70)
 for row in results_actors:
     print(f""{str(row.actor_name):<25} {row.nb_films:<10} {row.films}"")",,,,,,,,b66e618104ffd233,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,sparql-actors-interp,markdown,fr,ad053f57c8735c2a,"### Interpretation
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,sparql-actors-interp,markdown,fr,5986b83d6737bfbe,"### Interpretation
 
-Cette requete revele les acteurs partages entre films. Leonardo DiCaprio et Audrey Tautou apparaissent chacun dans 2 films. Ces connexions croisees sont l'essence meme d'un Knowledge Graph : elles emergent naturellement de la structure en graphe, sans jointures explicites.
+Cette requête revele les acteurs partages entre films. Leonardo DiCaprio et Audrey Tautou apparaissent chacun dans 2 films. Ces connexions croisees sont l'essence même d'un Knowledge Graph : elles emergent naturellement de la structure en graphe, sans jointures explicites.
 
 | Pattern detecte | Signification pour le KG |
 |----------------|------------------------|
 | Acteur multi-films | Noeud de forte connectivite (hub) |
 | Realisateur multi-films | Cluster thematique (filmographie) |
-| Genre partage | Communaute semantique |",,,,,,,,ad053f57c8735c2a,,,,,,,
+| Genre partage | Communaute sémantique |",,,,,,,,5986b83d6737bfbe,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,section2-serialize-intro,markdown,fr,8f2bfd9a856ef759,"### 2.5 Serialisation du Knowledge Graph
 
 Exportons le KG en format Turtle pour inspection et reutilisation.",,,,,,,,8f2bfd9a856ef759,,,,,,,
@@ -2616,35 +2616,35 @@ print(f""Taille totale : {len(lines)} lignes\n"")
 print(""--- Extrait (50 premieres lignes) ---\n"")
 for line in lines[:50]:
     print(line)",,,,,,,,98cca3e631a99986,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,serialize-kg-interp,markdown,fr,32c0d485c6691e9d,"### Interpretation
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,serialize-kg-interp,markdown,fr,6af3a72a5ad8e351,"### Interpretation
 
 Le format Turtle est lisible par l'humain et montre clairement la structure du KG. On observe :
 - Les **prefixes** declares en haut (schema, movies, persons, genres)
-- Les **entites** regroupees avec le raccourci `;` (plusieurs predicats pour le meme sujet)
+- Les **entites** regroupees avec le raccourci `;` (plusieurs predicats pour le même sujet)
 - Les **URIs** coherents et lisibles grace a notre fonction `to_uri_id()`
 
-> **Note** : En production, on sauvegarderait ce fichier Turtle dans un Triple Store (cf. SW-10) pour le rendre interrogeable via un endpoint SPARQL.",,,,,,,,32c0d485c6691e9d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,section3-title,markdown,fr,ef9b6c379651e4f5,"---
+> **Note** : En production, on sauvegarderait ce fichier Turtle dans un Triple Store (cf. SW-10) pour le rendre interrogeable via un endpoint SPARQL.",,,,,,,,6af3a72a5ad8e351,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,section3-title,markdown,fr,03b481e0e5f0f933,"---
 
 ## 3. kglab : couche d'abstraction Knowledge Graph
 
-**kglab** est une bibliotheque Python creee par Paco Nathan qui fournit une couche d'abstraction au-dessus de rdflib. Elle simplifie les operations courantes sur les Knowledge Graphs :
+**kglab** est une bibliotheque Python créée par Paco Nathan qui fournit une couche d'abstraction au-dessus de rdflib. Elle simplifie les opérations courantes sur les Knowledge Graphs :
 - Chargement/sauvegarde multi-format
-- Requetes SPARQL avec resultats pandas
+- Requêtes SPARQL avec résultats pandas
 - Integration avec NetworkX pour la visualisation
 - Mesures de graphe (centralite, communautes)
 
 ### Pourquoi kglab ?
 
-| Operation | rdflib pur | kglab |
+| Opération | rdflib pur | kglab |
 |-----------|-----------|-------|
 | SPARQL -> DataFrame | 5-10 lignes | 1 ligne |
 | Visualisation graphe | Manuel (NetworkX) | Integre |
 | Chargement multi-fichiers | Boucle manuelle | `load_rdf()` iteratif |
-| Statistiques du graphe | A coder | Methodes integrees |",,,,,,,,ef9b6c379651e4f5,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,section3-create-intro,markdown,fr,5081f15ff47e3e73,"### 3.1 Creation d'un KnowledgeGraph kglab
+| Statistiques du graphe | A coder | Méthodes integrees |",,,,,,,,03b481e0e5f0f933,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,section3-create-intro,markdown,fr,2aee18634f539263,"### 3.1 Creation d'un KnowledgeGraph kglab
 
-Nous allons creer un objet `kglab.KnowledgeGraph` et y charger les triplets de notre graphe de films.",,,,,,,,5081f15ff47e3e73,,,,,,,
+Nous allons créer un objet `kglab.KnowledgeGraph` et y charger les triplets de notre graphe de films.",,,,,,,,2aee18634f539263,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,kglab-create,code,fr,ca8802461a8a7fc8,"try:
     import kglab
 
@@ -2684,14 +2684,14 @@ except Exception as e:
     print(f""Erreur lors de la creation du KG kglab : {e}"")
     print(""Nous continuerons avec rdflib directement."")
     KGLAB_AVAILABLE = False",,,,,,,,ca8802461a8a7fc8,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,kglab-create-interp,markdown,fr,dd2d357560e0ee2c,"### Interpretation
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,kglab-create-interp,markdown,fr,0ad7c3b9f7ebeb8d,"### Interpretation
 
-L'objet `kglab.KnowledgeGraph` encapsule un graphe rdflib en ajoutant des methodes de haut niveau. En interne, `kg._g` est un `rdflib.Graph` standard, ce qui garantit la compatibilite.
+L'objet `kglab.KnowledgeGraph` encapsule un graphe rdflib en ajoutant des méthodes de haut niveau. En interne, `kg._g` est un `rdflib.Graph` standard, ce qui garantit la compatibilite.
 
-> **Note technique** : kglab est en maintenance depuis 2023. Si la bibliotheque n'est pas disponible, les sections suivantes utilisent rdflib directement comme alternative.",,,,,,,,dd2d357560e0ee2c,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,section3-sparql-intro,markdown,fr,9cf10ea99b9802db,"### 3.2 Requetes SPARQL via kglab
+> **Note technique** : kglab est en maintenance depuis 2023. Si la bibliotheque n'est pas disponible, les sections suivantes utilisent rdflib directement comme alternative.",,,,,,,,0ad7c3b9f7ebeb8d,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,section3-sparql-intro,markdown,fr,5ce1408e1f847cf5,"### 3.2 Requêtes SPARQL via kglab
 
-L'un des avantages de kglab est la conversion directe des resultats SPARQL en DataFrame pandas.",,,,,,,,9cf10ea99b9802db,,,,,,,
+L'un des avantages de kglab est la conversion directe des résultats SPARQL en DataFrame pandas.",,,,,,,,5ce1408e1f847cf5,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,kglab-sparql,code,fr,08cd67a60dc47239,"# Requete SPARQL avec conversion DataFrame
 sparql_query = """"""
 PREFIX schema: <http://schema.org/>
@@ -2730,17 +2730,17 @@ if not KGLAB_AVAILABLE:
     result_df = pd.DataFrame(rows)
     print(""Resultats via rdflib + pandas :\n"")
     print(result_df.to_string(index=False))",,,,,,,,08cd67a60dc47239,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,kglab-sparql-interp,markdown,fr,3acf1ea28178a763,"### Interpretation
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,kglab-sparql-interp,markdown,fr,45d522e464fb430a,"### Interpretation
 
 Le tableau montre la note moyenne par realisateur. Les realisateurs ayant plusieurs films permettent de calculer une moyenne significative :
 
 | Avantage | kglab | rdflib pur |
 |----------|-------|------------|
 | Conversion DataFrame | `query_as_df()` (1 ligne) | Boucle manuelle (5+ lignes) |
-| Types de donnees | Automatique | Casting manuel |
+| Types de données | Automatique | Casting manuel |
 | Code necessaire | Minimal | Verbeux |
 
-> **Point cle** : Que l'on utilise kglab ou rdflib, le moteur SPARQL sous-jacent est le meme. kglab ajoute simplement du sucre syntaxique pour les workflows data science.",,,,,,,,3acf1ea28178a763,,,,,,,
+> **Point cle** : Que l'on utilise kglab ou rdflib, le moteur SPARQL sous-jacent est le même. kglab ajoute simplement du sucre syntaxique pour les workflows data science.",,,,,,,,45d522e464fb430a,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,section4-title,markdown,fr,a5b7d153df8b87e5,"---
 
 ## 4. Visualisation du Knowledge Graph
@@ -2810,17 +2810,17 @@ print(f""Graphe NetworkX construit :"")
 print(f""  Noeuds : {G.number_of_nodes()}"")
 print(f""  Aretes : {G.number_of_edges()}"")
 print(f""  Types  : {dict((t, sum(1 for v in node_types.values() if v == t)) for t in set(node_types.values()))}"")",,,,,,,,da1e2839bf7b3e10,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,rdf-to-networkx-interp,markdown,fr,0144164f88ba2139,"### Interpretation
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,rdf-to-networkx-interp,markdown,fr,74e9c4bf36c7c80b,"### Interpretation
 
-Le graphe NetworkX capture les trois types de relations du KG. Les noeuds sont repartis en trois categories :
+Le graphe NetworkX capture les trois types de relations du KG. Les noeuds sont repartis en trois catégories :
 
-| Type de noeud | Couleur (section suivante) | Role dans le graphe |
+| Type de noeud | Couleur (section suivante) | Rôle dans le graphe |
 |--------------|--------------------------|--------------------|
 | Film (`movie`) | Bleu clair | Noeud central, connecte a realisateur + acteurs + genre |
 | Personne (`person`) | Vert clair | Peut etre realisateur et/ou acteur |
 | Genre (`genre`) | Orange | Noeud de regroupement thematique |
 
-> **Note** : Un graphe NetworkX oriente (`DiGraph`) preserve la direction des relations (film -> realisateur, film -> acteur, film -> genre).",,,,,,,,0144164f88ba2139,,,,,,,
+> **Note** : Un graphe NetworkX oriente (`DiGraph`) preserve la direction des relations (film -> realisateur, film -> acteur, film -> genre).",,,,,,,,74e9c4bf36c7c80b,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,section4-matplotlib-intro,markdown,fr,eb82b2a467239809,"### 4.2 Visualisation statique avec matplotlib
 
 Nous allons colorer les noeuds par type et dimensionner les labels pour une bonne lisibilite.",,,,,,,,eb82b2a467239809,,,,,,,
@@ -2879,7 +2879,7 @@ try:
 except Exception as e:
     print(f""Erreur lors de la visualisation matplotlib : {e}"")
     print(""Verifiez que matplotlib est correctement installe."")",,,,,,,,de53bca3b0119886,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,matplotlib-viz-interp,markdown,fr,9de44633f36b3cfc,"### Interpretation : structure du Knowledge Graph
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,matplotlib-viz-interp,markdown,fr,39a56888d1973f4f,"### Interpretation : structure du Knowledge Graph
 
 **Sortie obtenue** : Un graphe oriente avec des noeuds colores par type et des aretes colorees par relation.
 
@@ -2890,19 +2890,19 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,matp
 | Les films (bleu) sont des noeuds centraux | Ils connectent personnes et genres |
 | Christopher Nolan connecte 3 films | Hub de forte connectivite (realisateur prolifique) |
 | Le genre Science-Fiction regroupe plusieurs films | Communaute thematique visible |
-| Leonardo DiCaprio relie Inception et Titanic | Pont entre deux realisateurs differents |
+| Leonardo DiCaprio relie Inception et Titanic | Pont entre deux realisateurs différents |
 
 **Points cles** :
 1. Le layout `spring_layout` place naturellement les noeuds fortement connectes au centre
 2. Les genres agissent comme des noeuds de regroupement (clustering)
-3. Les acteurs partages creent des ponts entre clusters de realisateurs
+3. Les acteurs partages créent des ponts entre clusters de realisateurs
 
-> **Limite** : Avec plus de 50-100 noeuds, la visualisation statique devient difficile a lire. On passe alors a pyvis pour l'exploration interactive.",,,,,,,,9de44633f36b3cfc,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,section4-pyvis-intro,markdown,fr,7d10ffbfefbbcecf,"### 4.3 Visualisation interactive avec pyvis
+> **Limite** : Avec plus de 50-100 noeuds, la visualisation statique devient difficile a lire. On passe alors a pyvis pour l'exploration interactive.",,,,,,,,39a56888d1973f4f,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,section4-pyvis-intro,markdown,fr,c8c956fa5276ef95,"### 4.3 Visualisation interactive avec pyvis
 
 pyvis genere un fichier HTML interactif ou l'on peut zoomer, deplacer les noeuds et explorer les connexions. C'est particulierement utile pour les graphes de taille moyenne (50-500 noeuds).
 
-> **Note** : pyvis genere un fichier `.html`. Dans un environnement Jupyter standard, il s'affiche dans un iframe. En environnement headless, seul le fichier est cree.",,,,,,,,7d10ffbfefbbcecf,,,,,,,
+> **Note** : pyvis genere un fichier `.html`. Dans un environnement Jupyter standard, il s'affiche dans un iframe. En environnement headless, seul le fichier est créé.",,,,,,,,c8c956fa5276ef95,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,pyvis-viz,code,fr,32cac44ced2c7437,"try:
     from pyvis.network import Network
     import os
@@ -3069,7 +3069,7 @@ try:
 
 except Exception as e:
     print(f""Erreur lors de la visualisation filtree : {e}"")",,,,,,,,b92b331ec2911646,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,filtered-viz-interp,markdown,fr,3c36432416095188,"### Interpretation : filmographie Nolan
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,filtered-viz-interp,markdown,fr,b6eff6eeae426cc2,"### Interpretation : filmographie Nolan
 
 **Sortie obtenue** : Le sous-graphe de Christopher Nolan montre ses 3 films (Inception, The Dark Knight, Interstellar) avec leurs acteurs et genres.
 
@@ -3081,8 +3081,8 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,filt
 
 **Points cles** :
 1. Le filtrage SPARQL est plus efficace que le filtrage Python post-hoc
-2. Les sous-graphes permettent d'analyser des clusters specifiques du KG
-3. Cette technique est utilisee en production pour les ""profils"" d'entites (ex: fiche artiste)",,,,,,,,3c36432416095188,,,,,,,
+2. Les sous-graphes permettent d'analyser des clusters spécifiques du KG
+3. Cette technique est utilisee en production pour les ""profils"" d'entites (ex: fiche artiste)",,,,,,,,b6eff6eeae426cc2,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,section5-title,markdown,fr,16d3b7d0ad07abb3,"---
 
 ## 5. OWLReady2 pour la manipulation d'ontologies
@@ -3129,14 +3129,14 @@ except ImportError:
 except Exception as e:
     print(f""Erreur lors du chargement de l'ontologie : {e}"")
     OWLREADY_AVAILABLE = False",,,,,,,,456108f091d746f3,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,owlready-load-interp,markdown,fr,40dce6c70a3b698a,"### Interpretation
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,owlready-load-interp,markdown,fr,1a13dde4675049b9,"### Interpretation
 
-OWLReady2 charge l'ontologie en memoire et cree des objets Python accessibles directement. Le `base_iri` identifie l'ontologie de maniere unique.
+OWLReady2 charge l'ontologie en memoire et créé des objets Python accessibles directement. Le `base_iri` identifie l'ontologie de maniere unique.
 
-> **Note technique** : OWLReady2 utilise SQLite en arriere-plan pour stocker l'ontologie. Cela permet des ontologies persistantes entre sessions, contrairement a rdflib qui travaille uniquement en memoire.",,,,,,,,40dce6c70a3b698a,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,section5-explore-intro,markdown,fr,1553e1c668304ea5,"### 5.2 Exploration : classes, proprietes, instances
+> **Note technique** : OWLReady2 utilise SQLite en arriere-plan pour stocker l'ontologie. Cela permet des ontologies persistantes entre sessions, contrairement a rdflib qui travaille uniquement en memoire.",,,,,,,,1a13dde4675049b9,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,section5-explore-intro,markdown,fr,476870f4b202017c,"### 5.2 Exploration : classes, proprietes, instances
 
-Listons les elements de l'ontologie pour comprendre sa structure.",,,,,,,,1553e1c668304ea5,,,,,,,
+Listons les éléments de l'ontologie pour comprendre sa structure.",,,,,,,,476870f4b202017c,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,owlready-explore,code,fr,0b910cbf705a1918,"if OWLREADY_AVAILABLE:
     # --- Classes ---
     print(""=== Classes ==="")
@@ -3165,9 +3165,9 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,owlr
         print(f""  {ind.name} (type: {', '.join(types)})"")
 else:
     print(""OWLReady2 non disponible. Section ignoree."")",,,,,,,,0b910cbf705a1918,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,owlready-explore-interp,markdown,fr,03c7e7bcf0f49738,"### Interpretation
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,owlready-explore-interp,markdown,fr,0abc67af437c592f,"### Interpretation
 
-L'ontologie universitaire contient une hierarchie de classes bien structuree :
+L'ontologie universitaire contient une hiérarchie de classes bien structuree :
 
 ```
 Thing
@@ -3179,14 +3179,14 @@ Thing
   +-- Department
 ```
 
-| Element | Nombre | Exemples |
+| Élément | Nombre | Exemples |
 |---------|--------|----------|
 | Classes | 6 | Person, Student, GraduateStudent, Professor, Course, Department |
 | Object Properties | 4 | enrolledIn, teaches, memberOf, advisedBy |
 | Datatype Properties | 2 | name, credits |
 | Instances | 0 | (aucune instance declaree dans ce fichier OWL d'exemple) |
 
-> **Point cle** : La contrainte `disjointWith` entre Professor et Student signifie qu'une personne ne peut pas etre les deux a la fois. Le raisonneur peut detecter des violations de cette contrainte.",,,,,,,,03c7e7bcf0f49738,,,,,,,
+> **Point cle** : La contrainte `disjointWith` entre Professor et Student signifie qu'une personne ne peut pas etre les deux a la fois. Le raisonneur peut detecter des violations de cette contrainte.",,,,,,,,0abc67af437c592f,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,section5-reasoner-intro,markdown,fr,1ca0593fd1b243af,"### 5.3 Raisonnement avec HermiT
 
 Le raisonneur **HermiT** est un raisonneur OWL 2 DL complet, integre a OWLReady2 (via Java). Il peut :
@@ -3231,11 +3231,11 @@ if OWLREADY_AVAILABLE:
         print(""Si Java n'est pas disponible, le raisonnement ne peut pas s'executer."")
 else:
     print(""OWLReady2 non disponible. Section ignoree."")",,,,,,,,7f276f3af9a9c21c,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,owlready-reasoner-interp,markdown,fr,524e2f1d2d4ad9ee,"### Interpretation
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,owlready-reasoner-interp,markdown,fr,8f871047595bd0c9,"### Interpretation
 
-Le raisonneur **HermiT s'est execute avec succes** (JRE Java requis, fourni ici via l'environnement de developpement). La sortie ci-dessus confirme : `Raisonnement termine.` puis `Aucune inconsistance detectee. L'ontologie est coherente.` HermiT a verifie l'ensemble des contraintes OWL 2 de `university.owl` sans trouver de contradiction logique.
+Le raisonneur **HermiT s'est execute avec succes** (JRE Java requis, fourni ici via l'environnement de développement). La sortie ci-dessus confirme : `Raisonnement termine.` puis `Aucune inconsistance detectee. L'ontologie est coherente.` HermiT a verifie l'ensemble des contraintes OWL 2 de `university.owl` sans trouver de contradiction logique.
 
-Les boucles « Avant / Apres raisonnement » n'affichent rien ici car `onto.individuals()` ne materialise que les instances declarees explicitement comme objets Python `Thing`. Les individus definis en notation prefixee `<uni:Professor rdf:about>` dans le fichier OWL existent bien dans le graphe, mais ne sont enumeres par owlready2 que lorsqu'on y accede par leur classe (voir l'exemple guide 3 ci-dessous, qui cree une instance en Python et observe la classification inferee).
+Les boucles « Avant / Après raisonnement » n'affichent rien ici car `onto.individuals()` ne materialise que les instances declarees explicitement comme objets Python `Thing`. Les individus définis en notation prefixee `<uni:Professor rdf:about>` dans le fichier OWL existent bien dans le graphe, mais ne sont enumeres par owlready2 que lorsqu'on y accede par leur classe (voir l'exemple guide 3 ci-dessous, qui créé une instance en Python et observe la classification inferee).
 
 Un raisonneur OWL comme HermiT effectue plusieurs types d'inferences :
 
@@ -3250,21 +3250,21 @@ Un raisonneur OWL comme HermiT effectue plusieurs types d'inferences :
 2. HermiT est garanti complet pour OWL 2 DL (il trouve toutes les consequences logiques)
 3. En production, le raisonnement est souvent execute hors-ligne (materialisation) plutot qu'a la volee
 
-> **Note technique** : HermiT necessite une JVM (JRE Java). La variable d'environnement `JAVA_HOME` doit pointer vers une installation Java valide pour qu'owlready2 (`owlready2.JAVA_EXE`) puisse l'invoquer. En l'absence de Java, `sync_reasoner_pellet()` est une alternative (egalement basee sur Java).",,,,,,,,524e2f1d2d4ad9ee,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,section6-title,markdown,fr,e0b4c4adf7c5c1fb,"---
+> **Note technique** : HermiT necessite une JVM (JRE Java). La variable d'environnement `JAVA_HOME` doit pointer vers une installation Java valide pour qu'owlready2 (`owlready2.JAVA_EXE`) puisse l'invoquer. En l'absence de Java, `sync_reasoner_pellet()` est une alternative (également basee sur Java).",,,,,,,,8f871047595bd0c9,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,section6-title,markdown,fr,5cd63e2a9e53bf73,"---
 
 ## 6. Qualite et validation d'un Knowledge Graph
 
-Un Knowledge Graph n'a de valeur que si ses donnees sont **completes**, **coherentes** et **a jour**. Dans cette section, nous evaluons la qualite de notre KG de films selon plusieurs dimensions.
+Un Knowledge Graph n'a de valeur que si ses données sont **completes**, **coherentes** et **a jour**. Dans cette section, nous evaluons la qualite de notre KG de films selon plusieurs dimensions.
 
 ### Dimensions de qualite
 
-| Dimension | Question | Methode de verification |
+| Dimension | Question | Méthode de verification |
 |-----------|----------|------------------------|
-| Completude | Y a-t-il des donnees manquantes ? | SPARQL OPTIONAL + COUNT |
+| Completude | Y a-t-il des données manquantes ? | SPARQL OPTIONAL + COUNT |
 | Coherence | Les valeurs sont-elles valides ? | Contraintes de domaine/range |
 | Unicite | Y a-t-il des doublons ? | SPARQL COUNT + GROUP BY |
-| Conformite | Le KG respecte-t-il son schema ? | SHACL (cf. SW-9) |",,,,,,,,e0b4c4adf7c5c1fb,,,,,,,
+| Conformite | Le KG respecte-t-il son schema ? | SHACL (cf. SW-9) |",,,,,,,,5cd63e2a9e53bf73,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,section6-completeness-intro,markdown,fr,e50bc786ddd854ad,"### 6.1 Verification de completude
 
 Verifions si tous les films ont un realisateur, un genre et une note.",,,,,,,,e50bc786ddd854ad,,,,,,,
@@ -3306,7 +3306,7 @@ for row in results:
     print(f""{str(row.title):<30} {has_dir:<13} {has_rat:<8} {has_gen:<8} {nb_act}"")
 
 print(f""\nCompletude : {complete}/{total} films complets ({100*complete/total:.0f}%)"")",,,,,,,,f6ed1d96cdf98f7d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,quality-completeness-interp,markdown,fr,e3432a74ced3a06f,"### Interpretation
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,quality-completeness-interp,markdown,fr,783147060910d73d,"### Interpretation
 
 La verification montre que notre KG est complet pour les proprietes verifiees. Tous les films ont :
 - Un realisateur
@@ -3319,7 +3319,7 @@ En production, les KG sont rarement complets a 100%. Les lacunes typiques inclue
 - Acteurs secondaires non renseignes
 - Genres multiples non captures (un film peut etre a la fois Action et Science-Fiction)
 
-> **Lien avec SW-9** : La validation SHACL permet de formaliser ces regles de completude sous forme de ""shapes"" (contraintes declaratives) plutot que de requetes ad-hoc.",,,,,,,,e3432a74ced3a06f,,,,,,,
+> **Lien avec SW-9** : La validation SHACL permet de formaliser ces règles de completude sous forme de ""shapes"" (contraintes declaratives) plutot que de requêtes ad-hoc.",,,,,,,,783147060910d73d,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,section6-consistency-intro,markdown,fr,19db15bf4df452bc,"### 6.2 Verification de coherence
 
 Verifions que les valeurs sont dans des plages raisonnables (annees, notes) et que les genres sont valides.",,,,,,,,19db15bf4df452bc,,,,,,,
@@ -3407,7 +3407,7 @@ for check_name, passed, detail in consistency_checks:
 
 total_pass = sum(1 for _, p, _ in consistency_checks if p)
 print(f""\nResultat : {total_pass}/{len(consistency_checks)} verifications reussies"")",,,,,,,,092c3e764f9056d1,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,quality-consistency-interp,markdown,fr,47fa958fd7a860d0,"### Interpretation
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,quality-consistency-interp,markdown,fr,593ebaaf593a6108,"### Interpretation
 
 Le rapport de coherence verifie quatre aspects cles :
 
@@ -3416,14 +3416,14 @@ Le rapport de coherence verifie quatre aspects cles :
 | Annees valides | Films avec des annees aberrantes | `sh:minInclusive`, `sh:maxInclusive` |
 | Notes valides | Notes hors echelle 0-10 | `sh:datatype xsd:float` + bornes |
 | Pas de doublons | Titres identiques (collision URI) | `sh:uniqueLang` ou contrainte custom |
-| Genres definis | Genres sans label | `sh:minCount 1` sur rdfs:label |
+| Genres définis | Genres sans label | `sh:minCount 1` sur rdfs:label |
 
 **Points cles** :
-1. Ces verifications ad-hoc sont utiles en developpement, mais en production on prefere **SHACL** (cf. SW-9)
-2. La qualite d'un KG est un processus continu, pas un controle ponctuel
-3. Les pipelines de construction de KG incluent systematiquement une etape de validation
+1. Ces verifications ad-hoc sont utiles en développement, mais en production on prefere **SHACL** (cf. SW-9)
+2. La qualite d'un KG est un processus continu, pas un contrôle ponctuel
+3. Les pipelines de construction de KG incluent systematiquement une étape de validation
 
-> **Bonne pratique** : Definir les regles de qualite en SHACL des la conception du KG, et les executer a chaque mise a jour (CI/CD semantique).",,,,,,,,47fa958fd7a860d0,,,,,,,
+> **Bonne pratique** : Définir les règles de qualite en SHACL des la conception du KG, et les executer a chaque mise a jour (CI/CD sémantique).",,,,,,,,593ebaaf593a6108,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,section6-stats-intro,markdown,fr,deefaf2b8436da1c,"### 6.3 Statistiques globales du Knowledge Graph
 
 Pour completer l'analyse, calculons des metriques structurelles du KG.",,,,,,,,deefaf2b8436da1c,,,,,,,
@@ -3450,7 +3450,7 @@ total_subjects = int(list(g.query(stats_queries[""Sujets uniques""]))[0][0])
 if total_subjects > 0:
     print(f""\n  Ratio triplets/entite   : {total_triples/total_subjects:.1f}"")
     print(f""  (mesure la richesse descriptive moyenne par entite)"")",,,,,,,,f6304ada6c24d86e,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,quality-stats-interp,markdown,fr,5af439f52f881d68,"### Interpretation
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,quality-stats-interp,markdown,fr,e2ea4801d4ebfcb6,"### Interpretation
 
 Le ratio **triplets/entite** est un indicateur cle de la richesse descriptive du KG :
 
@@ -3459,28 +3459,28 @@ Le ratio **triplets/entite** est un indicateur cle de la richesse descriptive du
 | < 2 | KG squelettique (presque que des types) |
 | 2-5 | KG de base (type + quelques proprietes) |
 | 5-10 | KG riche (proprietes detaillees, relations multiples) |
-| > 10 | KG tres detaille (metadata, annotations, provenance) |
+| > 10 | KG très detaille (metadata, annotations, provenance) |
 
 **Recapitulatif qualite** :
 
-| Dimension | Resultat | Methode |
+| Dimension | Résultat | Méthode |
 |-----------|----------|--------|
 | Completude | 100% des films complets | SPARQL OPTIONAL |
 | Coherence | Toutes les valeurs valides | SPARQL FILTER |
 | Unicite | Pas de doublons | SPARQL GROUP BY + HAVING |
-| Richesse | Ratio triplets/entite correct | Statistiques globales |",,,,,,,,5af439f52f881d68,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,exercises-title,markdown,fr,3903ebd605787ee9,"---
+| Richesse | Ratio triplets/entite correct | Statistiques globales |",,,,,,,,e2ea4801d4ebfcb6,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,exercises-title,markdown,fr,7b965a3df1cb58e4,"---
 
 ## Exemples guides et Exercices
 
 ### Exemple guide 1 : Construire un KG etudiants/cours
 
-A partir du modele de la section 2, construisons un Knowledge Graph representant des etudiants et des cours. Nous creeons un DataFrame pandas avec les colonnes `student_name`, `course_name`, `grade`, `professor`, puis transformons-le en triplets RDF.
+A partir du modèle de la section 2, construisons un Knowledge Graph representant des etudiants et des cours. Nous creeons un DataFrame pandas avec les colonnes `student_name`, `course_name`, `grade`, `professor`, puis transformons-le en triplets RDF.
 
 **Techniques demontrees** :
 - Utilisation des namespaces `schema:Person`, `schema:Course`
 - Propriete `ex:enrolledIn` pour la relation etudiant -> cours
-- Noeuds blank (BNode) pour stocker les notes comme proprietes de la relation",,,,,,,,3903ebd605787ee9,,,,,,,
+- Noeuds blank (BNode) pour stocker les notes comme proprietes de la relation",,,,,,,,7b965a3df1cb58e4,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,exercise1,code,fr,df5209af63d3294f,"# Exercice 1 : Construire un KG etudiants/cours
 
 # Etape 1 : Creer un DataFrame
@@ -3556,11 +3556,11 @@ print(""=== Inscriptions et notes ==="")
 for row in g_students.query(sparql_check):
     print(f""  {row.student_name} -> {row.course_name} : {row.grade}/20"")
 ",,,,,,,,df5209af63d3294f,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,exercise2-intro,markdown,fr,56447392c6b49d4d,"### Exemple guide 2 : Visualiser le KG filtre par realisateur
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,exercise2-intro,markdown,fr,8fefa9cb0f241082,"### Exemple guide 2 : Visualiser le KG filtre par realisateur
 
-En reprenant le code de la section 4.4, modifions la requete SPARQL pour filtrer les films de **Quentin Tarantino** et visualisons le sous-graphe resultant.
+En reprenant le code de la section 4.4, modifions la requête SPARQL pour filtrer les films de **Quentin Tarantino** et visualisons le sous-graphe resultant.
 
-**Bonus demontre** : Les notes des films sont utilisees comme taille des noeuds (film mieux note = noeud plus gros).",,,,,,,,56447392c6b49d4d,,,,,,,
+**Bonus demontre** : Les notes des films sont utilisees comme taille des noeuds (film mieux note = noeud plus gros).",,,,,,,,8fefa9cb0f241082,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,exercise2,code,fr,a9f974f30c324ff9,"# Exercice 2 : Sous-graphe de Quentin Tarantino
 # Modifiez la requete filter_query de la section 4.4
 # Remplacez ""Christopher Nolan"" par ""Quentin Tarantino""
@@ -3659,7 +3659,7 @@ if movie_ratings:
     for movie, rating in sorted(movie_ratings.items()):
         print(f""  {movie} : {rating}"")
 ",,,,,,,,a9f974f30c324ff9,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,exercise3-intro,markdown,fr,a9f7e8ff57124bdf,"### Exemple guide 3 : Charger et raisonner avec OWLReady2
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,exercise3-intro,markdown,fr,b2fd14eeccf8022c,"### Exemple guide 3 : Charger et raisonner avec OWLReady2
 
 Chargons l'ontologie `data/university.owl` avec OWLReady2, puis :
 1. Ajoutons programmatiquement un nouvel etudiant (instance de `GraduateStudent`)
@@ -3667,7 +3667,7 @@ Chargons l'ontologie `data/university.owl` avec OWLReady2, puis :
 3. Lancons le raisonneur HermiT
 4. Verifions que le raisonneur infere bien qu'il est aussi `Student` et `Person`
 
-**Technique demontree** : `onto.GraduateStudent(""new_student"")` pour creer une instance, puis `sync_reasoner_hermit()` pour le raisonnement.",,,,,,,,a9f7e8ff57124bdf,,,,,,,
+**Technique demontree** : `onto.GraduateStudent(""new_student"")` pour créer une instance, puis `sync_reasoner_hermit()` pour le raisonnement.",,,,,,,,b2fd14eeccf8022c,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,exercise3,code,fr,4619ae0f14a0c134,"import os
 # Exercice 3 : Ajouter un etudiant et raisonner
 
@@ -3720,38 +3720,38 @@ if OWLREADY_AVAILABLE:
 else:
     print(""OWLReady2 non disponible. Section ignoree."")
 ",,,,,,,,4619ae0f14a0c134,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,summary,markdown,fr,e1d45d3356fc1249,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,summary,markdown,fr,c30914cf03d7031b,"---
 
 ## Resume
 
-| Element | Ce que nous avons appris |
+| Élément | Ce que nous avons appris |
 |---------|------------------------|
 | Knowledge Graph | Graphe d'entites + relations + ontologie, adopte massivement en industrie |
-| Construction CSV -> RDF | pandas + rdflib pour transformer des donnees tabulaires en triplets |
+| Construction CSV -> RDF | pandas + rdflib pour transformer des données tabulaires en triplets |
 | kglab | Couche d'abstraction Python, SPARQL -> DataFrame en 1 ligne |
 | Visualisation NetworkX | Graphes statiques avec couleurs par type et layout spring |
 | Visualisation pyvis | Graphes interactifs HTML pour l'exploration |
 | OWLReady2 | Manipulation d'ontologies OWL + raisonneur HermiT integre |
 | Qualite du KG | Completude, coherence, unicite -- SHACL pour formaliser |
 
-### Ce qui change par rapport aux notebooks precedents
+### Ce qui change par rapport aux notebooks précédents
 
 | Avant (SW-1 a SW-10) | Maintenant (SW-11) |
 |----------------------|-------------------|
 | Triplets individuels | Knowledge Graph structure |
 | Graphe comme stockage | Graphe comme outil d'analyse |
 | Visualisation textuelle | Visualisation graphique (NetworkX, pyvis) |
-| Ontologie theorique | Raisonnement automatise (HermiT) |
+| Ontologie théorique | Raisonnement automatise (HermiT) |
 | Validation manuelle | Pipeline de qualite |
 
-### Prochaine etape
+### Prochaine étape
 
-Dans le notebook suivant (**SW-12-GraphRAG**), nous verrons comment combiner un Knowledge Graph avec un LLM pour creer un systeme de question-reponse augmente par le graphe (GraphRAG) -- la convergence entre IA symbolique et IA neuronale.
+Dans le notebook suivant (**SW-12-GraphRAG**), nous verrons comment combiner un Knowledge Graph avec un LLM pour créer un système de question-reponse augmente par le graphe (GraphRAG) -- la convergence entre IA symbolique et IA neuronale.
 
 ---
 
-**Navigation** : [<< 10-RDFStar](SW-10-Python-RDFStar.ipynb) | [Index](README.md) | [12-GraphRAG >>](SW-12-Python-GraphRAG.ipynb)",,,,,,,,e1d45d3356fc1249,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,aa80c570,markdown,fr,96c13fd8b9693891,"---
+**Navigation** : [<< 10-RDFStar](SW-10-Python-RDFStar.ipynb) | [Index](README.md) | [12-GraphRAG >>](SW-12-Python-GraphRAG.ipynb)",,,,,,,,c30914cf03d7031b,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,aa80c570,markdown,fr,2dd10ce99c693575,"---
 
 ### Exemple guide 4 : Construire et interroger un Knowledge Graph complet (jeux video)
 
@@ -3759,9 +3759,9 @@ Construisons un Knowledge Graph complet sur le domaine des jeux video, en combin
 
 **Techniques demontrees** :
 - Au moins 20 triplets RDF dans le graphe
-- 3 types d'entites differents (jeux, developpeurs, genres)
-- 3 requetes SPARQL : SELECT, FILTER, et une agregation (COUNT + AVG)
-- Visualisation du graphe avec networkx et matplotlib",,,,,,,,96c13fd8b9693891,,,,,,,
+- 3 types d'entites différents (jeux, developpeurs, genres)
+- 3 requêtes SPARQL : SELECT, FILTER, et une agregation (COUNT + AVG)
+- Visualisation du graphe avec networkx et matplotlib",,,,,,,,2dd10ce99c693575,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,24a8e526,code,fr,4dbcd47f3fd4b1b9,"# construire et interroger votre Knowledge Graph
 from rdflib import Graph, Namespace, URIRef, Literal
 from rdflib.namespace import RDF, RDFS, XSD
@@ -3917,13 +3917,13 @@ plt.tight_layout()
 plt.show()
 plt.close()
 ",,,,,,,,4dbcd47f3fd4b1b9,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,exemples-guides-sosolalt,markdown,fr,0043ad0d584f5011,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,exemples-guides-sosolalt,markdown,fr,929c7b30cd81bee1,"---
 
 ## Exemples guides (solutions proposees par @Sosolalt)
 
 *Les exemples ci-dessous ont ete resolus par @Sosolalt (EPITA-IS, promo 2028).*
-*Ils servent de modele pour comprendre les concepts abordes dans ce notebook.*
-",,,,,,,,0043ad0d584f5011,,,,,,,
+*Ils servent de modèle pour comprendre les concepts abordes dans ce notebook.*
+",,,,,,,,929c7b30cd81bee1,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,exemple-fbb579e8,markdown,fr,e63c9cc4a7baff15,"### Exemple guide 5 : Ajouter des proprietes au KG etudiants/cours
 
 *Solution proposee par @Sosolalt (EPITA-IS, promo 2028).*",,,,,,,,e63c9cc4a7baff15,,,,,,,
@@ -4460,20 +4460,20 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,exer
 
 *Ces exercices sont a realiser par l'etudiant.*
 ",,,,,,,,ac1bdd159b5d3237,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,ae35c86d,markdown,fr,58980760552cc47c,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,ae35c86d,markdown,fr,d69b08abbae7c29a,"---
 
 ### Exercice 1 : Ajouter des proprietes au KG etudiants/cours
 
 En reprenant le graphe `g_students` construit dans l'Exemple guide 1, ajoutez les fonctionnalites suivantes :
 
 1. Ajoutez une propriete `ex:hasEmail` (datatype property) pour chaque etudiant
-2. Ecrivez une requete SPARQL qui retourne la moyenne generale de chaque etudiant
+2. Ecrivez une requête SPARQL qui retourne la moyenne générale de chaque etudiant
 3. Identifiez l'etudiant avec la meilleure moyenne
 
 **Indices** :
 - Utilisez `g_students.add((student_uri, EX.hasEmail, Literal(""alice@example.com"")))` pour ajouter un email
 - Pour la moyenne, utilisez `AVG(?grade)` avec `GROUP BY ?student_name` dans SPARQL
-- Pour le meilleur, ajoutez `ORDER BY DESC(?avg_grade) LIMIT 1`",,,,,,,,58980760552cc47c,,,,,,,
+- Pour le meilleur, ajoutez `ORDER BY DESC(?avg_grade) LIMIT 1`",,,,,,,,d69b08abbae7c29a,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,fbb579e8,code,fr,c492637dcc7ef83d,"# Exercice 1 : Ajouter des proprietes au KG etudiants/cours
 
 # TODO etudiant : ajouter la propriete ex:hasEmail pour chaque etudiant
@@ -4490,20 +4490,20 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,fbb5
 # query_best = None  # remplacer par la requete avec ORDER BY DESC LIMIT 1
 
 print(""Exercice a completer : ajouter des proprietes au KG etudiants/cours"")",,,,,,,,c492637dcc7ef83d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,5b5aba30,markdown,fr,b9e53b7c72a48397,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,5b5aba30,markdown,fr,261147aae2026235,"---
 
 ### Exercice 2 : Visualiser le KG filtre par genre
 
-En reprenant le code de la section 4.4, modifiez la requete SPARQL pour filtrer les films du genre **Science-Fiction** et visualisez le sous-graphe resultant.
+En reprenant le code de la section 4.4, modifiez la requête SPARQL pour filtrer les films du genre **Science-Fiction** et visualisez le sous-graphe resultant.
 
 **Consignes** :
-1. Ecrire une requete SPARQL qui selectionne tous les films de genre Science-Fiction avec leurs acteurs et realisateurs
-2. Construire un graphe NetworkX a partir des resultats
+1. Ecrire une requête SPARQL qui selectionne tous les films de genre Science-Fiction avec leurs acteurs et realisateurs
+2. Construire un graphe NetworkX a partir des résultats
 3. Visualiser avec matplotlib en colorant les noeuds par type
 
 **Bonus** : Ajoutez les notes des films comme taille des noeuds (film mieux note = noeud plus gros).
 
-**Indice** : Remplacez le filtre `?director schema:name ""Christopher Nolan""` par un filtre sur le genre : `?movie schema:genre ?g . ?g rdfs:label ""Science-Fiction""@fr .`",,,,,,,,b9e53b7c72a48397,,,,,,,
+**Indice** : Remplacez le filtre `?director schema:name ""Christopher Nolan""` par un filtre sur le genre : `?movie schema:genre ?g . ?g rdfs:label ""Science-Fiction""@fr .`",,,,,,,,261147aae2026235,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,75ce8c2d,code,fr,6934341465c8eb2f,"# Exercice 2 : Visualiser le KG filtre par genre (Science-Fiction)
 
 # TODO etudiant : ecrire la requete SPARQL pour filtrer par genre Science-Fiction
@@ -4520,7 +4520,7 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,75ce
 # Utiliser le meme style que la section 4.4 (couleurs par type, layout spring)
 
 print(""Exercice a completer : visualisation du sous-graphe Science-Fiction"")",,,,,,,,6934341465c8eb2f,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,f801188a,markdown,fr,18cbda4f48aaacb8,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,f801188a,markdown,fr,1348910dafc36948,"---
 
 ### Exercice 3 : Explorer l'ontologie et verifier les contraintes
 
@@ -4528,12 +4528,12 @@ En utilisant l'ontologie `data/university.owl` chargee dans l'Exemple guide 3 :
 
 1. Listez toutes les instances de `Student` (y compris les sous-classes)
 2. Trouvez les professeurs qui enseignent a des etudiants de niveau Graduate
-3. Ajoutez une contrainte : un etudiant ne peut pas etre en meme temps professeur, et verifiez avec le raisonneur
+3. Ajoutez une contrainte : un etudiant ne peut pas etre en même temps professeur, et verifiez avec le raisonneur
 
 **Indices** :
 - Utilisez `onto.search(type=onto.Student)` pour trouver les instances
-- Explorez les proprietes `teaches` et `enrolledIn` pour croiser les donnees
-- Pour la contrainte, creez une instance qui viole la disjonction et observez le resultat du raisonneur",,,,,,,,18cbda4f48aaacb8,,,,,,,
+- Explorez les proprietes `teaches` et `enrolledIn` pour croiser les données
+- Pour la contrainte, créez une instance qui viole la disjonction et observez le résultat du raisonneur",,,,,,,,1348910dafc36948,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,25b71618,code,fr,9fc785333728af28,"# Exercice 3 : Explorer l'ontologie et verifier les contraintes
 
 # TODO etudiant : lister toutes les instances de Student (y compris sous-classes)
@@ -4546,22 +4546,22 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,25b7
 # et verifier avec le raisonneur
 
 print(""Exercice a completer : exploration de l'ontologie universitaire"")",,,,,,,,9fc785333728af28,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,a4cfc7c0,markdown,fr,71a3b9e9d7c3484d,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,a4cfc7c0,markdown,fr,233f166e4b60dc57,"---
 
 ### Exercice 4 : Construire votre propre Knowledge Graph
 
-Choisissez un domaine qui vous interesse (musique, sport, cuisine, astronomy...) et construisez un Knowledge Graph complet en suivant le modele de l'Exemple guide 4.
+Choisissez un domaine qui vous interesse (musique, sport, cuisine, astronomy...) et construisez un Knowledge Graph complet en suivant le modèle de l'Exemple guide 4.
 
 **Consignes** :
 - Au moins **15 triplets** RDF dans le graphe
-- Au moins **3 types d'entites** differents
-- Ecrire au moins **2 requetes SPARQL** : une SELECT et une avec FILTER ou aggregation
+- Au moins **3 types d'entites** différents
+- Ecrire au moins **2 requêtes SPARQL** : une SELECT et une avec FILTER ou aggregation
 - (Bonus) Visualiser le graphe avec networkx
 
-**Etapes suggerees** :
-1. Creer le graphe RDF avec rdflib (ou charger depuis un fichier CSV)
-2. Ecrire et executer 2 requetes SPARQL
-3. (Bonus) Visualiser les entites principales",,,,,,,,71a3b9e9d7c3484d,,,,,,,
+**Étapes suggerees** :
+1. Créer le graphe RDF avec rdflib (ou charger depuis un fichier CSV)
+2. Ecrire et executer 2 requêtes SPARQL
+3. (Bonus) Visualiser les entites principales",,,,,,,,233f166e4b60dc57,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,1bdc2891,code,fr,67a279de7bdd6131,"# Exercice 4 : Construire votre propre Knowledge Graph
 
 # TODO etudiant : choisir un domaine et definir vos namespaces
@@ -4575,7 +4575,7 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,1bdc
 # (Bonus) TODO etudiant : visualiser avec networkx
 
 print(""Exercice a completer : construisez votre propre Knowledge Graph"")",,,,,,,,67a279de7bdd6131,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,33dd22f5,markdown,fr,543e8887fcd34456,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,33dd22f5,markdown,fr,41846382c4c55a43,"---
 
 ### Exercice 5 : Centralite dans le Knowledge Graph (PageRank)
 
@@ -4583,15 +4583,15 @@ En reprenant le graphe NetworkX `G` construit dans la section 4.1 (films, realis
 
 1. Calculer la **PageRank** de chaque noeud avec `nx.pagerank(G_undirected)` (sur la version non orientee)
 2. Identifier les **5 entites les plus centrales** du Knowledge Graph et leur type (film / personne / genre)
-3. Comparer avec le **degree centrality** (`nx.degree_centrality(G_undirected)`) : les deux mesures designent-elles les memes entites ?
+3. Comparer avec le **degree centrality** (`nx.degree_centrality(G_undirected)`) : les deux mesures designent-elles les mêmes entites ?
 
 **Indices** :
 - Utiliser `G_undirected = G.to_undirected()` pour passer en non oriente
 - `nx.pagerank(G_undirected)` retourne un `dict { noeud : score }`. Trier avec `sorted(d.items(), key=lambda x: -x[1])[:5]`
-- Pour distinguer les types, utiliser le dictionnaire `node_types` deja construit dans la section 4.1
+- Pour distinguer les types, utiliser le dictionnaire `node_types` déjà construit dans la section 4.1
 - La PageRank pondere par les voisins importants ; le degree compte juste les voisins. Une entite peu connectee mais reliee a des hubs peut avoir une PageRank elevee.
 
-**Bonus** : Visualiser avec matplotlib en faisant varier la taille des noeuds proportionnellement a la PageRank.",,,,,,,,543e8887fcd34456,,,,,,,
+**Bonus** : Visualiser avec matplotlib en faisant varier la taille des noeuds proportionnellement a la PageRank.",,,,,,,,41846382c4c55a43,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,bcb96a10,code,fr,c9d0898262c4281b,"# Exercice 5 : Centralite dans le Knowledge Graph (PageRank)
 
 # TODO etudiant : passer le graphe G en non oriente
@@ -4611,7 +4611,7 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,bcb9
 # (Bonus) TODO etudiant : visualiser avec node_size proportionnel a pr_scores
 
 print(""Exercice a completer : PageRank et degree centrality sur le KG"")",,,,,,,,c9d0898262c4281b,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,ad8e6d33,markdown,fr,10fcf851dab5fe6a,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,ad8e6d33,markdown,fr,314a3a4d9799321d,"---
 
 ### Exercice 6 : Visualisation pyvis interactive personnalisee
 
@@ -4620,15 +4620,15 @@ En reprenant la section 4.3 qui utilise pyvis pour generer une visualisation int
 1. Generer un **fichier HTML pyvis** du sous-graphe des films de **2015 ou plus recents** (filtre SPARQL sur l'annee)
 2. Personnaliser le rendu :
    - **Couleur** par type d'entite (movie / person / genre)
-   - **Taille** du noeud proportionnelle a son degre (`G.degree(noeud)`)
-   - **Tooltip** personnalise affichant le type et le degre (`net.add_node(..., title=f""Type: ...\nDegre: ..."")`)
+   - **Taille** du noeud proportionnelle a son degré (`G.degree(noeud)`)
+   - **Tooltip** personnalise affichant le type et le degré (`net.add_node(..., title=f""Type: ...\nDegre: ..."")`)
 3. Sauvegarder en `output_kg_recent.html` et inspecter le rendu
 
 **Indices** :
-- Adapter la requete SPARQL de la section 4.4 pour ajouter `FILTER(?year >= 2015)` sur `?movie schema:datePublished ?year` (note : la propriete s'appelle `datePublished` dans le KG)
+- Adapter la requête SPARQL de la section 4.4 pour ajouter `FILTER(?year >= 2015)` sur `?movie schema:datePublished ?year` (note : la propriete s'appelle `datePublished` dans le KG)
 - Construire un `nx.DiGraph` puis le passer a `Network(notebook=True).from_nx(G_recent)`
 - Iterer sur les noeuds pour mettre a jour `color`, `size`, `title` via `net.get_node(node_id)` ou en passant les attributs lors de `add_node`
-- Sauvegarder avec `net.save_graph(""output_kg_recent.html"")` ; ouvrir le fichier dans un navigateur pour verifier l'interactivite",,,,,,,,10fcf851dab5fe6a,,,,,,,
+- Sauvegarder avec `net.save_graph(""output_kg_recent.html"")` ; ouvrir le fichier dans un navigateur pour verifier l'interactivite",,,,,,,,314a3a4d9799321d,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,15069084,code,fr,2ad39fa10eac8caf,"# Exercice 6 : Visualisation pyvis interactive personnalisee
 
 # TODO etudiant : ecrire la requete SPARQL avec FILTER(?year >= 2015)
@@ -4652,27 +4652,27 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,1506
 # net.save_graph(""output_kg_recent.html"")
 
 print(""Exercice a completer : visualisation pyvis personnalisee du KG (films >= 2015)"")",,,,,,,,2ad39fa10eac8caf,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,bee96adf,markdown,fr,e4b6481a1abed7b0,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,bee96adf,markdown,fr,db64c98bde8c8a55,"---
 
 ### Exercice 7 : Property paths transitifs sur l'ontologie
 
-En reprenant l'ontologie `data/university.owl` chargee dans la section 5, exploitez les **property paths SPARQL** pour explorer la hierarchie de classes et les relations indirectes :
+En reprenant l'ontologie `data/university.owl` chargee dans la section 5, exploitez les **property paths SPARQL** pour explorer la hiérarchie de classes et les relations indirectes :
 
-1. Ecrire une requete SPARQL utilisant `rdfs:subClassOf+` (cloture transitive) pour lister **toutes les super-classes** (directes et indirectes) de la classe `GraduateStudent`
-2. Ecrire une requete SPARQL utilisant `rdf:type/rdfs:subClassOf*` pour lister **toutes les instances** typees comme `Person` (y compris les sous-classes : Student, Professor, GraduateStudent...)
-3. Comparer le nombre d'instances trouvees avec `rdf:type` seul (sans `subClassOf*`) versus avec le property path : combien d'instances supplementaires le raisonnement par hierarchie revele-t-il ?
+1. Ecrire une requête SPARQL utilisant `rdfs:subClassOf+` (cloture transitive) pour lister **toutes les super-classes** (directes et indirectes) de la classe `GraduateStudent`
+2. Ecrire une requête SPARQL utilisant `rdf:type/rdfs:subClassOf*` pour lister **toutes les instances** typees comme `Person` (y compris les sous-classes : Student, Professor, GraduateStudent...)
+3. Comparer le nombre d'instances trouvees avec `rdf:type` seul (sans `subClassOf*`) versus avec le property path : combien d'instances supplementaires le raisonnement par hiérarchie revele-t-il ?
 
 **Indices** :
-- Charger l'ontologie dans rdflib : `g_owl = Graph().parse(""data/university.owl"", format=""xml"")` (ou utiliser le graphe deja parse via OWLReady2)
+- Charger l'ontologie dans rdflib : `g_owl = Graph().parse(""data/university.owl"", format=""xml"")` (ou utiliser le graphe déjà parse via OWLReady2)
 - Property path `+` = **un ou plusieurs sauts** ; `*` = **zero ou plusieurs sauts** ; `?` = **zero ou un saut**
-- La requete 1 :
+- La requête 1 :
   ```sparql
   PREFIX uni: <http://example.org/university#>
   PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
   SELECT ?super WHERE { uni:GraduateStudent rdfs:subClassOf+ ?super }
   ```
-- La requete 2 utilise le path compose `rdf:type/rdfs:subClassOf*` pour traverser le type ET la hierarchie
-- Le namespace de l'ontologie est `http://example.org/university#` (inspecter avec `list(g_owl.namespaces())`)",,,,,,,,e4b6481a1abed7b0,,,,,,,
+- La requête 2 utilise le path compose `rdf:type/rdfs:subClassOf*` pour traverser le type ET la hiérarchie
+- Le namespace de l'ontologie est `http://example.org/university#` (inspecter avec `list(g_owl.namespaces())`)",,,,,,,,db64c98bde8c8a55,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,368085e9,code,fr,c9ae1ae981e644d8,"# Exercice 7 : Property paths transitifs sur l'ontologie
 
 # TODO etudiant : charger l'ontologie dans un graphe rdflib
@@ -4701,12 +4701,12 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,3680
 # print(f""Direct: {len(direct_results)}, Avec subClassOf*: {len(transitive_results)}"")
 
 print(""Exercice a completer : property paths transitifs sur l'ontologie"")",,,,,,,,c9ae1ae981e644d8,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,conclusion-sw11,markdown,fr,c7f3e44423935888,"## Resume et perspectives
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb,conclusion-sw11,markdown,fr,50730184b2519f69,"## Resume et perspectives
 
-Ce notebook a explore la construction et l'exploration de Knowledge Graphs a partir de donnees structurees. Nous avons vu le pipeline complet : chargement CSV, definition d'un vocabulaire RDF, transformation en triplets, verification par SPARQL, puis serialisation dans plusieurs formats (Turtle, JSON-LD, N-Triples). La bibliotheque kglab offre une couche d'abstraction qui simplifie la creation et l'interrogation de Knowledge Graphs en encapsulant les operations rdflib courantes.
+Ce notebook a explore la construction et l'exploration de Knowledge Graphs a partir de données structurees. Nous avons vu le pipeline complet : chargement CSV, definition d'un vocabulaire RDF, transformation en triplets, verification par SPARQL, puis serialisation dans plusieurs formats (Turtle, JSON-LD, N-Triples). La bibliotheque kglab offre une couche d'abstraction qui simplifie la creation et l'interrogation de Knowledge Graphs en encapsulant les opérations rdflib courantes.
 
-La visualisation, qu'elle soit statique (matplotlib + NetworkX) ou interactive (pyvis), permet de comprendre la topologie du graphe et d'identifier des patterns structurels. Nous avons egalement introduit OWLReady2 pour la manipulation d'ontologies OWL et le raisonnement automatique via HermiT, ainsi que les dimensions de qualite (completude, coherence) essentielles pour valider un Knowledge Graph en production. Ces competences constituent le socle technique necessaire pour aborder les systemes de GraphRAG et le raisonnement avance sur donnees liees.",,,,,,,,c7f3e44423935888,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,header-nav,markdown,fr,48ddcbe864b6e29c,"# SW-12-Python-GraphRAG
+La visualisation, qu'elle soit statique (matplotlib + NetworkX) ou interactive (pyvis), permet de comprendre la topologie du graphe et d'identifier des patterns structurels. Nous avons également introduit OWLReady2 pour la manipulation d'ontologies OWL et le raisonnement automatique via HermiT, ainsi que les dimensions de qualite (completude, coherence) essentielles pour valider un Knowledge Graph en production. Ces competences constituent le socle technique necessaire pour aborder les systèmes de GraphRAG et le raisonnement avance sur données liees.",,,,,,,,50730184b2519f69,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,header-nav,markdown,fr,e40206fb2362191d,"# SW-12-Python-GraphRAG
 
 **Navigation** : [<< 11-KnowledgeGraphs](SW-11-Python-KnowledgeGraphs.ipynb) | [Index](README.md) | [13-Reasoners >>](SW-13-Python-Reasoners.ipynb)
 
@@ -4733,21 +4733,21 @@ A la fin de ce notebook, vous saurez :
 | RAG | Retrieval-Augmented Generation : enrichir un LLM avec des documents recuperes |
 | GraphRAG | RAG augmente par un graphe de connaissances plutot que de simples chunks |
 | Extraction d'entites | Identification des entites et relations dans un texte non structure |
-| Community detection | Regroupement automatique de noeuds en communautes semantiques |
+| Community detection | Regroupement automatique de noeuds en communautes sémantiques |
 | Grounding | Ancrage des reponses LLM dans des faits verifies du KG |
 
 ### Prerequis
 - Python 3.10+
 - Notebook [SW-11-Python-KnowledgeGraphs](SW-11-Python-KnowledgeGraphs.ipynb) (construction de KG avec rdflib)
-- (Optionnel) Cle API OpenAI ou Anthropic (le notebook fonctionne sans grace aux donnees de demonstration)",,,,,,,,48ddcbe864b6e29c,,,,,,,
+- (Optionnel) Cle API OpenAI ou Anthropic (le notebook fonctionne sans grace aux données de demonstration)",,,,,,,,e40206fb2362191d,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,install-title,markdown,fr,c7402abcec729010,## Installation des dependances,,,,,,,,c7402abcec729010,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,install-pip,code,fr,22cf1361f21a89c7,"# Dependances pre-provisionnees (rdflib networkx matplotlib openai anthropic python-dotenv pandas) : voir SemanticWeb/requirements.txt ; imports dans les cellules suivantes.
 ",,,,,,,,22cf1361f21a89c7,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,section1-title,markdown,fr,3862260ca810b582,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,section1-title,markdown,fr,6d6003bbe2ac3129,"---
 
 ## 1. Introduction au GraphRAG
 
-### Le probleme du RAG classique
+### Le problème du RAG classique
 
 Le **RAG** (Retrieval-Augmented Generation) est une technique qui enrichit les reponses d'un LLM en recuperant des documents pertinents depuis une base de connaissances. Le flux classique est :
 
@@ -4760,9 +4760,9 @@ Cependant, le RAG classique a des limites importantes :
 | Limite du RAG classique | Consequence | Solution GraphRAG |
 |------------------------|-------------|-------------------|
 | Recherche par similarite uniquement | Rate les connexions indirectes | Parcours de graphe (chemins, voisinage) |
-| Pas de raisonnement multi-hop | ""Qui est le realisateur du film ou joue X ?"" echoue | Requetes SPARQL traversant les relations |
+| Pas de raisonnement multi-hop | ""Qui est le realisateur du film ou joue X ?"" echoue | Requêtes SPARQL traversant les relations |
 | Fragments decontextualises | Les chunks perdent le contexte global | Le KG preserve les relations entre entites |
-| Pas de structure semantique | Tous les documents sont traites uniformement | Les entites ont des types, attributs, relations |
+| Pas de structure sémantique | Tous les documents sont traites uniformement | Les entites ont des types, attributs, relations |
 | Hallucinations difficiles a detecter | Pas de source verifiable | Le KG fournit des faits verifiables (grounding) |
 
 ### GraphRAG : le meilleur des deux mondes
@@ -4773,8 +4773,8 @@ Le **GraphRAG** combine la puissance des LLMs avec la structure des graphes de c
 Question -> Extraction entites -> Recherche dans le KG -> Contexte structure -> LLM -> Reponse fondee
 ```
 
-L'idee centrale : au lieu de recuperer des chunks de texte brut, on recupere des **sous-graphes** autour des entites mentionnees dans la question. Cela fournit au LLM un contexte riche et structure.",,,,,,,,3862260ca810b582,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,section1-comparison,markdown,fr,644200b95caf1421,"### RAG classique vs GraphRAG : comparaison visuelle
+L'idee centrale : au lieu de recuperer des chunks de texte brut, on recupere des **sous-graphes** autour des entites mentionnees dans la question. Cela fournit au LLM un contexte riche et structure.",,,,,,,,6d6003bbe2ac3129,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,section1-comparison,markdown,fr,f7aa8ae48ea6fdb4,"### RAG classique vs GraphRAG : comparaison visuelle
 
 ```
 RAG CLASSIQUE                          GRAPHRAG
@@ -4788,25 +4788,25 @@ avec DiCaprio ?""                       avec DiCaprio ?""
 3. Retourner les 5 meilleurs chunks       Nolan --directed--> Inception
 4. Le LLM synthetise                      DiCaprio --acted_in--> Inception
                                           Inception --genre--> Sci-Fi
-Probleme: les chunks parlent de           ...
+Problème: les chunks parlent de           ...
 Nolan OU de DiCaprio, rarement         3. Sous-graphe pertinent envoye au LLM
 des deux ensemble.                     4. Reponse fondee avec contexte complet
 ```
 
-> **Point cle** : GraphRAG excelle sur les questions necessitant de croiser des informations provenant de sources differentes (raisonnement multi-hop).",,,,,,,,644200b95caf1421,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,section2-title,markdown,fr,1fcc5112d6fd1794,"---
+> **Point cle** : GraphRAG excelle sur les questions necessitant de croiser des informations provenant de sources différentes (raisonnement multi-hop).",,,,,,,,f7aa8ae48ea6fdb4,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,section2-title,markdown,fr,a4ade65558c8b532,"---
 
 ## 2. Architecture d'un pipeline GraphRAG
 
-### Les quatre etapes
+### Les quatre étapes
 
-Un pipeline GraphRAG complet se decompose en quatre etapes :
+Un pipeline GraphRAG complet se decompose en quatre étapes :
 
-| Etape | Description | Outils |
+| Étape | Description | Outils |
 |-------|-------------|--------|
 | 1. **Extraction** | Identifier les entites et relations dans les textes | LLM (GPT-4, Claude), spaCy, NER |
 | 2. **Construction** | Transformer les entites extraites en graphe RDF | rdflib, NetworkX |
-| 3. **Indexation** | Detecter des communautes, creer des resumes | Algorithme Leiden, LLM |
+| 3. **Indexation** | Detecter des communautes, créer des resumes | Algorithme Leiden, LLM |
 | 4. **Interrogation** | Recuperer le sous-graphe pertinent et generer la reponse | SPARQL + LLM |
 
 ```
@@ -4830,14 +4830,14 @@ Un pipeline GraphRAG complet se decompose en quatre etapes :
                                          |
                                          v
                                    Reponse fondee
-```",,,,,,,,1fcc5112d6fd1794,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,section3-title,markdown,fr,6a78d2d7fbb0d5d1,"---
+```",,,,,,,,a4ade65558c8b532,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,section3-title,markdown,fr,7d0d771ee46e5206,"---
 
 ## 3. Extraction d'entites et relations avec un LLM
 
 ### Configuration des cles API
 
-Le notebook utilise les variables d'environnement pour les cles API. Si aucune cle n'est configuree, des **donnees de demonstration** sont utilisees automatiquement.",,,,,,,,6a78d2d7fbb0d5d1,,,,,,,
+Le notebook utilise les variables d'environnement pour les cles API. Si aucune cle n'est configuree, des **données de demonstration** sont utilisees automatiquement.",,,,,,,,7d0d771ee46e5206,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,api-setup,code,fr,95f28ed653bce72f,"import os
 from pathlib import Path
 
@@ -4873,7 +4873,7 @@ else:
     print(""Mode : Demonstration (donnees pre-calculees)"")
     print(""  Pour activer l'extraction reelle, copiez .env.example vers .env"")
     print(""  et renseignez votre cle API."")",,,,,,,,95f28ed653bce72f,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,interpretation-api,markdown,fr,d09b8b11210e6af6,"### Interpretation
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,interpretation-api,markdown,fr,ed9c9b546ef9e800,"### Interpretation
 
 Le notebook detecte automatiquement les cles API disponibles et adapte son comportement :
 
@@ -4881,9 +4881,9 @@ Le notebook detecte automatiquement les cles API disponibles et adapte son compo
 |------|-----------|-------------|
 | **API OpenAI** | `OPENAI_API_KEY` configure | Extraction reelle avec GPT |
 | **API Anthropic** | `ANTHROPIC_API_KEY` configure | Extraction reelle avec Claude |
-| **Demonstration** | Aucune cle | Donnees pre-calculees, meme flux pedagogique |
+| **Demonstration** | Aucune cle | Données pre-calculees, même flux pedagogique |
 
-> **Point cle** : L'ensemble du notebook fonctionne sans cle API. Les resultats de demonstration sont representatifs de ce que produit un vrai LLM.",,,,,,,,d09b8b11210e6af6,,,,,,,
+> **Point cle** : L'ensemble du notebook fonctionne sans cle API. Les résultats de demonstration sont representatifs de ce que produit un vrai LLM.",,,,,,,,ed9c9b546ef9e800,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,section3-text,markdown,fr,5b0a319fea202caa,"### Texte source pour l'extraction
 
 Nous allons extraire des entites et relations a partir d'un texte sur le cinema. Ce texte contient des informations sur des films, des realisateurs et des acteurs.",,,,,,,,5b0a319fea202caa,,,,,,,
@@ -5041,7 +5041,7 @@ print()
 print(""--- Relations ---"")
 for r in extraction_result[""relations""]:
     print(f""  {r['source']:<25} --{r['relation']:<15}--> {r['target']}"")",,,,,,,,6f7e804fcc0ba201,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,interpretation-extraction,markdown,fr,c6934c59f14c5177,"### Interpretation
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,interpretation-extraction,markdown,fr,2c654789f9f76c6a,"### Interpretation
 
 L'extraction a identifie environ 15 entites et 12 relations a partir du texte source.
 
@@ -5052,14 +5052,14 @@ L'extraction a identifie environ 15 entites et 12 relations a partir du texte so
 | Organization | 1 | Warner Bros |
 | Award | 1 | Oscar |
 
-> **Note** : Dom Cobb, Joker et Batman sont tagges `type:Person` avec `role=personnage` dans le jeu de donnees (personnages fictifs, distincts des acteurs reels). Ils sont donc comptes dans les 10 `Person`. Soit 4 types d'entites distincts au total (Person, Movie, Organization, Award).
+> **Note** : Dom Cobb, Joker et Batman sont tagges `type:Person` avec `rôle=personnage` dans le jeu de données (personnages fictifs, distincts des acteurs reels). Ils sont donc comptes dans les 10 `Person`. Soit 4 types d'entites distincts au total (Person, Movie, Organization, Award).
 
 **Qualite de l'extraction** :
 - Les entites principales sont correctement identifiees
 - Les relations refletent bien le contenu du texte
 - Certaines relations implicites (comme le genre des films) sont inferees
 
-> **Point cle** : La qualite de l'extraction depend fortement du prompt et du modele utilise. GPT-4 et Claude produisent generalement des resultats superieurs a GPT-3.5 pour cette tache.",,,,,,,,c6934c59f14c5177,,,,,,,
+> **Point cle** : La qualite de l'extraction depend fortement du prompt et du modèle utilise. GPT-4 et Claude produisent généralement des résultats superieurs a GPT-3.5 pour cette tâche.",,,,,,,,2c654789f9f76c6a,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,section4-title,markdown,fr,471e325361be8196,"---
 
 ## 4. Construction du graphe de connaissances
@@ -5147,7 +5147,7 @@ lines = turtle_output.split(""\n"")
 print(f""--- Extrait Turtle ({min(40, len(lines))} premieres lignes) ---"")
 for line in lines[:40]:
     print(line)",,,,,,,,e9f0c297efb46e5e,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,interpretation-build-kg,markdown,fr,8324b8050f13420c,"### Interpretation
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,interpretation-build-kg,markdown,fr,0d8f627b9c6ae564,"### Interpretation
 
 Le graphe RDF contient toutes les entites et relations extraites du texte. La structure est riche :
 
@@ -5159,9 +5159,9 @@ Le graphe RDF contient toutes les entites et relations extraites du texte. La st
 | Types d'entites | 4 (Person, Movie, Organization, Award) |
 | Types de relations | 5 (directed, acted_in, produced_by, won, composed_for) |
 
-> **Note** : `Genre` et `Concept` figurent dans le vocabulaire interne (`TYPE_MAP`) mais aucune entite de ces types n'est extraite du texte de demonstration. De meme, la relation `genre_of` est definie dans `REL_MAP` mais n'apparait pas dans les relations extraites. Les compteurs ci-dessus refletent ce qui est reellement present dans le graphe RDF construit (15 entites, 12 relations, 61 triplets).
+> **Note** : `Genre` et `Concept` figurent dans le vocabulaire interne (`TYPE_MAP`) mais aucune entite de ces types n'est extraite du texte de demonstration. De même, la relation `genre_of` est définie dans `REL_MAP` mais n'apparait pas dans les relations extraites. Les compteurs ci-dessus refletent ce qui est reellement present dans le graphe RDF construit (15 entites, 12 relations, 61 triplets).
 
-> **Point cle** : Le passage du texte brut au graphe RDF structure l'information de maniere interrogeable. Chaque fait est maintenant un triplet verifiable et navigable.",,,,,,,,8324b8050f13420c,,,,,,,
+> **Point cle** : Le passage du texte brut au graphe RDF structure l'information de maniere interrogeable. Chaque fait est maintenant un triplet verifiable et navigable.",,,,,,,,0d8f627b9c6ae564,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,section4-viz-title,markdown,fr,960f4290684cfa6a,"### Visualisation du graphe extrait
 
 Visualisons le graphe de connaissances construit a partir des entites extraites.",,,,,,,,960f4290684cfa6a,,,,,,,
@@ -5254,18 +5254,18 @@ La visualisation montre clairement la structure du graphe extrait :
 | Warner Bros connecte a Inception | Information de production recuperable |
 
 > **Avantage GraphRAG** : En RAG classique, ces connexions seraient perdues. Le graphe les preserve et les rend interrogeables.",,,,,,,,5ba5124af50ab274,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,section5-title,markdown,fr,46cdecd4e6d267a8,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,section5-title,markdown,fr,c07723f50a7d6498,"---
 
 ## 5. Interrogation augmentee par le graphe
 
 ### Principe du GraphRAG querying
 
-L'interrogation GraphRAG suit un processus en trois etapes :
+L'interrogation GraphRAG suit un processus en trois étapes :
 1. **Analyse de la question** : identifier les entites mentionnees
 2. **Recuperation du sous-graphe** : extraire le voisinage de ces entites dans le KG
 3. **Generation augmentee** : envoyer le sous-graphe comme contexte au LLM
 
-Ce processus permet de fournir au LLM un contexte factuel et structure.",,,,,,,,46cdecd4e6d267a8,,,,,,,
+Ce processus permet de fournir au LLM un contexte factuel et structure.",,,,,,,,c07723f50a7d6498,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,subgraph-extraction,code,fr,99ad0a3a2cfd7c4e,"def extract_subgraph(graph, entity_names, max_hops=2):
     """"""
     Extraire un sous-graphe autour des entites mentionnees.
@@ -5338,7 +5338,7 @@ print(f""=== Sous-graphe pour la question sur {', '.join(question_entities)} ===
 print(f""  (profondeur : 1 hop)"")
 print()
 print(subgraph_text)",,,,,,,,99ad0a3a2cfd7c4e,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,interpretation-subgraph,markdown,fr,c725a25fca3efa1d,"### Interpretation
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,interpretation-subgraph,markdown,fr,c959ac96d4db74bd,"### Interpretation
 
 Le sous-graphe extrait contient toutes les informations pertinentes autour de Nolan et DiCaprio :
 
@@ -5346,9 +5346,9 @@ Le sous-graphe extrait contient toutes les informations pertinentes autour de No
 - Les attributs de chaque entite : nationalite, annee de naissance, etc.
 - Les relations avec d'autres entites : autres films de Nolan, production Warner Bros
 
-Ce sous-graphe sera fourni comme contexte au LLM dans l'etape suivante.
+Ce sous-graphe sera fourni comme contexte au LLM dans l'étape suivante.
 
-> **Avantage** : Le LLM recoit des faits structures et verifiables, pas des fragments de texte decontextualises. Cela reduit les hallucinations.",,,,,,,,c725a25fca3efa1d,,,,,,,
+> **Avantage** : Le LLM recoit des faits structures et verifiables, pas des fragments de texte decontextualises. Cela reduit les hallucinations.",,,,,,,,c959ac96d4db74bd,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,section5-generation,markdown,fr,6fac3cbce0e8ca9c,"### Generation de reponse augmentee par le graphe
 
 Nous allons maintenant combiner le sous-graphe avec le LLM pour generer une reponse fondee.",,,,,,,,6fac3cbce0e8ca9c,,,,,,,
@@ -5449,11 +5449,11 @@ else:
     print(""   - Film de super-heros, Heath Ledger a remporte un Oscar posthume"")
     print()
     print(""(Reponse generee a partir des faits du graphe de connaissances)"")",,,,,,,,f036a70405261dec,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,interpretation-generation,markdown,fr,143278764b48dfdf,"### Interpretation
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,interpretation-generation,markdown,fr,bf9fc0b8040757d0,"### Interpretation
 
 Le pipeline GraphRAG a produit une reponse fondee sur les faits du graphe :
 
-| Etape | Resultat |
+| Étape | Résultat |
 |-------|---------|
 | Detection d'entites | Christopher Nolan identifie dans la question |
 | Extraction sous-graphe | 9 faits pertinents recuperes |
@@ -5466,12 +5466,12 @@ Le pipeline GraphRAG a produit une reponse fondee sur les faits du graphe :
 | Source des faits | Memoire parametrique (peut halluciner) | Graphe de connaissances (verifiable) |
 | Reponse a jour | Limitee au training cutoff | Aussi a jour que le KG |
 | Justification | Aucune | Chaque fait tracable dans le graphe |
-| Questions multi-hop | Approximatif | Precis (traversee du graphe) |
+| Questions multi-hop | Approximatif | Précis (traversee du graphe) |
 
-> **Point cle** : GraphRAG ne remplace pas le LLM, il le **renforce** avec des faits verifies. Le LLM conserve sa capacite de synthese et de formulation naturelle.",,,,,,,,143278764b48dfdf,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,section5-multi,markdown,fr,0bd023ba6aebdbec,"### Exemples de questions supplementaires
+> **Point cle** : GraphRAG ne remplace pas le LLM, il le **renforce** avec des faits verifies. Le LLM conserve sa capacite de synthese et de formulation naturelle.",,,,,,,,bf9fc0b8040757d0,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,section5-multi,markdown,fr,847d16a76cf40977,"### Exemples de questions supplementaires
 
-Testons le pipeline avec differents types de questions pour evaluer sa polyvalence.",,,,,,,,0bd023ba6aebdbec,,,,,,,
+Testons le pipeline avec différents types de questions pour evaluer sa polyvalence.",,,,,,,,847d16a76cf40977,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,multi-queries,code,fr,4459da353650c07e,"# Ensemble de questions de test
 test_questions = [
     ""Qui a compose la musique d'Interstellar ?"",
@@ -5508,9 +5508,9 @@ for i, question in enumerate(test_questions, 1):
     else:
         print(f""R: {demo_answers.get(question, '(pas de reponse de demonstration)')}"")
     print()",,,,,,,,4459da353650c07e,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,interpretation-multi,markdown,fr,f33baa126cf44797,"### Interpretation
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,interpretation-multi,markdown,fr,e400e88459977cba,"### Interpretation
 
-Les resultats montrent que le pipeline GraphRAG repond correctement aux differents types de questions :
+Les résultats montrent que le pipeline GraphRAG repond correctement aux différents types de questions :
 
 | Question | Type | Entites detectees | Qualite |
 |----------|------|-------------------|---------|
@@ -5522,14 +5522,14 @@ Les resultats montrent que le pipeline GraphRAG repond correctement aux differen
 **Limites observees** :
 - La detection d'entites est basee sur une heuristique simple (correspondance de noms)
 - Les questions indirectes (""le realisateur du film avec DiCaprio"") necessitent un raisonnement multi-hop
-- En production, on utiliserait un NER avance ou un LLM pour l'etape d'extraction des entites de la question",,,,,,,,f33baa126cf44797,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,section6-title,markdown,fr,3ad7a129894f7eb5,"---
+- En production, on utiliserait un NER avance ou un LLM pour l'étape d'extraction des entites de la question",,,,,,,,e400e88459977cba,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,section6-title,markdown,fr,553e535197490fcc,"---
 
 ## 6. Approche Microsoft GraphRAG
 
 ### Presentation
 
-**Microsoft GraphRAG** est un framework publie en 2024 qui pousse le concept plus loin. Au lieu de simplement recuperer des sous-graphes locaux, il pre-traite l'ensemble du corpus pour creer une **hierarchie de communautes** avec des resumes a chaque niveau.
+**Microsoft GraphRAG** est un framework publie en 2024 qui pousse le concept plus loin. Au lieu de simplement recuperer des sous-graphes locaux, il pre-traite l'ensemble du corpus pour créer une **hiérarchie de communautes** avec des resumes a chaque niveau.
 
 ### Architecture Microsoft GraphRAG
 
@@ -5549,7 +5549,7 @@ Corpus de textes
 4. Generation de resumes par communaute (LLM)
        |
        v
-5. Indexation hierarchique
+5. Indexation hiérarchique
        |
        v
 Pret pour l'interrogation
@@ -5559,7 +5559,7 @@ Pret pour l'interrogation
 
 | Mode | Description | Quand l'utiliser |
 |------|-------------|-----------------|
-| **Local search** | Recupere le voisinage d'entites specifiques | Questions factuelles precises |
+| **Local search** | Recupere le voisinage d'entites spécifiques | Questions factuelles precises |
 | **Global search** | Parcourt les resumes de communautes haut niveau | Questions thematiques ou de synthese |
 
 ### L'algorithme Leiden
@@ -5571,7 +5571,7 @@ L'algorithme **Leiden** (developpe a l'universite de Leiden, Pays-Bas) est un al
 | Principe | Optimisation de la modularite (densification intra-communaute) |
 | Avantage vs Louvain | Garantit la connexite des communautes |
 | Complexite | O(n log n) en pratique |
-| Usage dans GraphRAG | Regrouper les entites en themes pour la summarization |",,,,,,,,3ad7a129894f7eb5,,,,,,,
+| Usage dans GraphRAG | Regrouper les entites en thèmes pour la summarization |",,,,,,,,553e535197490fcc,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,leiden-demo,code,fr,f9044bb5084d15ca,"import networkx as nx
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
@@ -5622,9 +5622,9 @@ ax.axis(""off"")
 plt.tight_layout()
 plt.show()
 plt.close()",,,,,,,,f9044bb5084d15ca,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,interpretation-leiden,markdown,fr,eb65aa098fba3db7,"### Interpretation
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,interpretation-leiden,markdown,fr,46ff59c5880897a7,"### Interpretation
 
-L'algorithme de detection de communautes a regroupe les noeuds en clusters semantiques :
+L'algorithme de detection de communautes a regroupe les noeuds en clusters sémantiques :
 
 - Les films et leurs acteurs directs forment des communautes coherentes
 - Le realisateur (Nolan) peut apparaitre dans une communaute ""hub"" ou relier les clusters
@@ -5635,22 +5635,22 @@ L'algorithme de detection de communautes a regroupe les noeuds en clusters seman
 | Niveau | Contenu | Usage |
 |--------|---------|-------|
 | Communaute locale | Entites + relations directes | Questions factuelles |
-| Communaute intermediaire | Themes (filmographie Nolan, acteurs) | Questions thematiques |
+| Communaute intermediaire | Thèmes (filmographie Nolan, acteurs) | Questions thematiques |
 | Communaute globale | Resume de l'ensemble du corpus | Questions de synthese |
 
-> **Point cle** : La detection de communautes permet de generer des resumes a differents niveaux de granularite. Cela rend possible les questions du type ""Quels sont les grands themes de ce corpus ?"" sans parcourir tous les documents.",,,,,,,,eb65aa098fba3db7,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,section6-comparison,markdown,fr,46a4e10202a59053,"### Comparaison des approches RAG
+> **Point cle** : La detection de communautes permet de generer des resumes a différents niveaux de granularite. Cela rend possible les questions du type ""Quels sont les grands thèmes de ce corpus ?"" sans parcourir tous les documents.",,,,,,,,46ff59c5880897a7,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,section6-comparison,markdown,fr,3bc7a41d9c565264,"### Comparaison des approches RAG
 
 | Critere | RAG classique | GraphRAG local | GraphRAG global (Microsoft) |
 |---------|--------------|----------------|----------------------------|
 | Pre-traitement | Embedding des chunks | Construction du KG | KG + communautes + resumes |
 | Cout initial | Faible | Moyen | Eleve (appels LLM multiples) |
-| Requete | Recherche vectorielle | Traversee de graphe | Hierarchie de resumes |
+| Requête | Recherche vectorielle | Traversee de graphe | Hiérarchie de resumes |
 | Questions factuelles | Bon | Excellent | Bon |
 | Questions multi-hop | Faible | Excellent | Bon |
 | Questions de synthese | Faible | Moyen | Excellent |
 | Explicabilite | Faible (chunks) | Elevee (triplets) | Elevee (communautes) |
-| Mise a jour | Re-embedding | Ajout de triplets | Reconstruction partielle |",,,,,,,,46a4e10202a59053,,,,,,,
+| Mise a jour | Re-embedding | Ajout de triplets | Reconstruction partielle |",,,,,,,,3bc7a41d9c565264,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,section7-title,markdown,fr,5a3fc804c8d85165,"---
 
 ## 7. Gestion robuste des cles API
@@ -5729,24 +5729,24 @@ else:
     print(""Pour configurer une API :"")
     print(""  1. Copier .env.example vers .env"")
     print(""  2. Remplir OPENAI_API_KEY ou ANTHROPIC_API_KEY"")",,,,,,,,faf997eb7183c610,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,interpretation-api-patterns,markdown,fr,d4f339c216cb8600,"### Interpretation
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,interpretation-api-patterns,markdown,fr,e3e904cd6b546fcc,"### Interpretation
 
 Les trois patterns presentes garantissent un fonctionnement robuste :
 
 | Pattern | Usage | Avantage |
 |---------|-------|----------|
 | Detection et fallback | Au demarrage | Detecte automatiquement le provider disponible |
-| Execution avec demo | Chaque appel LLM | Jamais de cellule en erreur, meme sans cle |
+| Exécution avec demo | Chaque appel LLM | Jamais de cellule en erreur, même sans cle |
 | Verification config | Diagnostique | L'utilisateur sait immediatement quel mode est actif |
 
 **Bonnes pratiques** :
 1. Ne jamais coder une cle API en dur dans le notebook
 2. Utiliser `.env` + `python-dotenv` pour le chargement local
-3. Toujours fournir un `demo_response` representatif du vrai resultat
+3. Toujours fournir un `demo_response` representatif du vrai résultat
 4. Tester la connexion au demarrage pour un feedback rapide
 
-> **Note** : Le fichier `.env.example` documente les variables attendues sans exposer de secrets. Il est commit dans git, contrairement a `.env` qui est dans `.gitignore`.",,,,,,,,d4f339c216cb8600,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,summary-title,markdown,fr,72c61f7f9f500ca2,"---
+> **Note** : Le fichier `.env.example` documente les variables attendues sans exposer de secrets. Il est commit dans git, contrairement a `.env` qui est dans `.gitignore`.",,,,,,,,e3e904cd6b546fcc,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,summary-title,markdown,fr,d43319735fd326fb,"---
 
 ## Resume
 
@@ -5754,7 +5754,7 @@ Ce notebook a couvert les concepts fondamentaux du GraphRAG, de l'extraction d'e
 
 ### Concepts et outils
 
-| Etape | Outil | Concept |
+| Étape | Outil | Concept |
 |-------|-------|---------|
 | Configuration API | python-dotenv | Gestion securisee des cles, fallback gracieux |
 | Extraction d'entites | LLM (GPT/Claude) | NER + extraction de relations depuis texte brut |
@@ -5762,7 +5762,7 @@ Ce notebook a couvert les concepts fondamentaux du GraphRAG, de l'extraction d'e
 | Visualisation | NetworkX + matplotlib | Graphe avec couleurs par type d'entite |
 | Extraction sous-graphe | BFS sur rdflib | Recuperation du voisinage d'entites |
 | Generation augmentee | LLM + contexte KG | Reponse fondee sur des faits verifiables |
-| Detection communautes | NetworkX (modularite) | Regroupement semantique pour la summarization |
+| Detection communautes | NetworkX (modularite) | Regroupement sémantique pour la summarization |
 
 ### Competences acquises
 
@@ -5779,21 +5779,21 @@ Ce notebook a couvert les concepts fondamentaux du GraphRAG, de l'extraction d'e
 - [From Local to Global: A Graph RAG Approach (paper)](https://arxiv.org/abs/2404.16130) - Article de recherche Microsoft
 - [LangChain GraphRAG](https://python.langchain.com/docs/use_cases/graph/) - Integration LangChain
 - [Neo4j GraphRAG](https://neo4j.com/developer-blog/graphrag/) - Approche Neo4j
-- [Leiden Algorithm (paper)](https://arxiv.org/abs/1810.08473) - Detection de communautes",,,,,,,,72c61f7f9f500ca2,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,footer-nav,markdown,fr,3ce82b2a1bf8f267,"---
+- [Leiden Algorithm (paper)](https://arxiv.org/abs/1810.08473) - Detection de communautes",,,,,,,,d43319735fd326fb,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,footer-nav,markdown,fr,e40028dd96da3b54,"---
 
-Ce notebook conclut la serie Semantic Web. Vous avez parcouru l'ensemble de la pile technologique du Web semantique, depuis les bases RDF (SW-1) jusqu'a l'integration avec les grands modeles de langage (SW-13).
+Ce notebook conclut la serie Semantic Web. Vous avez parcouru l'ensemble de la pile technologique du Web sémantique, depuis les bases RDF (SW-1) jusqu'a l'integration avec les grands modèles de langage (SW-13).
 
 ---
 
-**Navigation** : [<< 12-KnowledgeGraphs](SW-11-Python-KnowledgeGraphs.ipynb) | [Index](README.md)",,,,,,,,3ce82b2a1bf8f267,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,exemples-guides-sosolalt,markdown,fr,0043ad0d584f5011,"---
+**Navigation** : [<< 12-KnowledgeGraphs](SW-11-Python-KnowledgeGraphs.ipynb) | [Index](README.md)",,,,,,,,e40028dd96da3b54,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,exemples-guides-sosolalt,markdown,fr,929c7b30cd81bee1,"---
 
 ## Exemples guides (solutions proposees par @Sosolalt)
 
 *Les exemples ci-dessous ont ete resolus par @Sosolalt (EPITA-IS, promo 2028).*
-*Ils servent de modele pour comprendre les concepts abordes dans ce notebook.*
-",,,,,,,,0043ad0d584f5011,,,,,,,
+*Ils servent de modèle pour comprendre les concepts abordes dans ce notebook.*
+",,,,,,,,929c7b30cd81bee1,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,exemple-a690b7a4,markdown,fr,91b2101605adcce8,"### Exemple guide 1 : Detection de communautes sur le KG extrait
 
 *Solution proposee par @Sosolalt (EPITA-IS, promo 2028).*",,,,,,,,91b2101605adcce8,,,,,,,
@@ -6109,7 +6109,7 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,exercices-a
 
 *Ces exercices sont a realiser par l'etudiant.*
 ",,,,,,,,ac1bdd159b5d3237,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,d16cfdf7,markdown,fr,378d3c4d20b806cf,"### Exercice 1 : Detection de communautes sur le KG extrait
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,d16cfdf7,markdown,fr,249d4c792a1be2ed,"### Exercice 1 : Detection de communautes sur le KG extrait
 
 En reprenant le code de la section 6 qui demontre la **detection de communautes** (Microsoft GraphRAG), appliquez l'algorithme `nx.community.greedy_modularity_communities` au graphe extrait dans la section 4 :
 
@@ -6122,8 +6122,8 @@ En reprenant le code de la section 6 qui demontre la **detection de communautes*
 - `import networkx as nx`, conversion via boucle sur `g` : `G_und = nx.Graph(); for s, p, o in g: G_und.add_edge(str(s), str(o))`
 - `from networkx.algorithms.community import greedy_modularity_communities`
 - Chaque communaute est un `frozenset` de noeuds ; iterer avec `for i, comm in enumerate(communities)`
-- Pour le resume LLM : construire un prompt avec la liste des entites de la communaute, puis appeler `safe_llm_call(prompt)` (defini section 7)
-- La modularite mesure a quel point les noeuds d'une communaute sont plus connectes entre eux qu'avec l'exterieur",,,,,,,,378d3c4d20b806cf,,,,,,,
+- Pour le resume LLM : construire un prompt avec la liste des entites de la communaute, puis appeler `safe_llm_call(prompt)` (défini section 7)
+- La modularite mesure a quel point les noeuds d'une communaute sont plus connectes entre eux qu'avec l'exterieur",,,,,,,,249d4c792a1be2ed,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,a690b7a4,code,fr,0482f4752f25196c,"# Exercice 1 : Detection de communautes sur le KG extrait
 
 # TODO etudiant : convertir g (rdflib) en G_und (NetworkX non oriente)
@@ -6150,9 +6150,9 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,a690b7a4,co
 # Utiliser safe_llm_call(prompt) defini en section 7
 
 print(""Exercice a completer : detection de communautes + resume LLM par cluster"")",,,,,,,,0482f4752f25196c,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,a1456555,markdown,fr,1b6c4d501458ea7b,"### Exercice 2 : Cache et persistence du Knowledge Graph
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,a1456555,markdown,fr,ce24dc7a49ef716a,"### Exercice 2 : Cache et persistence du Knowledge Graph
 
-L'extraction d'entites via LLM est **couteuse** (appels API + latence). En production, on persiste le KG construit pour eviter de relancer l'extraction. Implementez un mecanisme de cache simple :
+L'extraction d'entites via LLM est **couteuse** (appels API + latence). En production, on persiste le KG construit pour eviter de relancer l'extraction. Implementez un mécanisme de cache simple :
 
 1. **Sauvegarder** le graphe `g` construit en section 4 au format **Turtle** (`g.serialize(destination=..., format=""turtle"")`) dans `cache/graph_extracted.ttl`
 2. **Recharger** le graphe depuis le fichier Turtle dans un nouveau graphe `g_loaded = Graph().parse(...)` et verifier que tous les triplets sont preserves
@@ -6163,7 +6163,7 @@ L'extraction d'entites via LLM est **couteuse** (appels API + latence). En produ
 - `from pathlib import Path` ; `Path(cache_path).exists()` pour le test d'existence
 - `len(g) == len(g_loaded)` pour verifier la preservation
 - Mesurer le temps avec `import time; t0 = time.time(); ... ; print(time.time() - t0)`
-- En production, ajouter un hash du texte source dans le nom du cache pour invalider correctement",,,,,,,,1b6c4d501458ea7b,,,,,,,
+- En production, ajouter un hash du texte source dans le nom du cache pour invalider correctement",,,,,,,,ce24dc7a49ef716a,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,53b97cc7,code,fr,a400705bd7d0698e,"# Exercice 2 : Cache et persistence du Knowledge Graph
 
 # TODO etudiant : sauvegarder g au format Turtle dans cache/graph_extracted.ttl
@@ -6191,12 +6191,12 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,53b97cc7,co
 # t0 = time.time(); g2 = load_or_extract(sample_text, ""cache/test.ttl""); print(f""2eme appel : {time.time()-t0:.2f}s"")
 
 print(""Exercice a completer : cache Turtle + load_or_extract"")",,,,,,,,a400705bd7d0698e,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,67385ec0,markdown,fr,ab4fd4eda1da4f63,"### Exercice 3 : Evaluation de la qualite de l'extraction LLM
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,67385ec0,markdown,fr,ed38b3639f03681e,"### Exercice 3 : Evaluation de la qualite de l'extraction LLM
 
 L'extraction d'entites par LLM n'est jamais parfaite. Pour evaluer sa qualite, on compare son output a un **gold standard** annote manuellement. Construisez une evaluation simple :
 
-1. Definir un **gold standard** : un dictionnaire `gold = {""entities"": [...], ""relations"": [...]}` annote manuellement a partir de `sample_text` (utiliser au moins 5 entites et 5 relations)
-2. Lancer l'extraction LLM sur le meme texte (variable `extraction` deja calculee en section 3)
+1. Définir un **gold standard** : un dictionnaire `gold = {""entities"": [...], ""relations"": [...]}` annote manuellement a partir de `sample_text` (utiliser au moins 5 entites et 5 relations)
+2. Lancer l'extraction LLM sur le même texte (variable `extraction` déjà calculee en section 3)
 3. Calculer **precision** = `|gold inter extraction| / |extraction|` et **rappel** = `|gold inter extraction| / |gold|` sur les noms d'entites (ignorer la casse)
 4. Calculer le **F1-score** = `2 * P * R / (P + R)`
 5. Identifier les **entites manquees** (faux negatifs) et les **entites halluciinees** (faux positifs)
@@ -6205,7 +6205,7 @@ L'extraction d'entites par LLM n'est jamais parfaite. Pour evaluer sa qualite, o
 - Comparer en lowercase pour limiter le bruit (""Christopher Nolan"" vs ""christopher nolan"")
 - `set_gold = {e[""name""].lower() for e in gold[""entities""]}` ; `set_pred = {e[""name""].lower() for e in extraction[""entities""]}`
 - `intersection = set_gold & set_pred` ; `manques = set_gold - set_pred` ; `hallucinations = set_pred - set_gold`
-- Un F1 > 0.7 sur ce type de texte court est correct ; un F1 > 0.85 est excellent",,,,,,,,ab4fd4eda1da4f63,,,,,,,
+- Un F1 > 0.7 sur ce type de texte court est correct ; un F1 > 0.85 est excellent",,,,,,,,ed38b3639f03681e,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,fb1db4c2,code,fr,33dac723b9530b26,"# Exercice 3 : Evaluation de la qualite de l'extraction LLM
 
 # TODO etudiant : definir le gold standard manuellement
@@ -6236,15 +6236,15 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,fb1db4c2,co
 # print(f""Hallucinations : {set_pred - set_gold}"")
 
 print(""Exercice a completer : evaluation precision/rappel/F1 de l'extraction LLM"")",,,,,,,,33dac723b9530b26,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,a423af33,markdown,fr,ac360bd294d57cd0,"### Exercice final : Pipeline GraphRAG sur un domaine libre
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,a423af33,markdown,fr,77677fd29e7e4420,"### Exercice final : Pipeline GraphRAG sur un domaine libre
 
 Choisissez un domaine de votre choix (sport, cuisine, histoire, etc.) et implementez un mini-pipeline GraphRAG complet :
 1. **Extraction** : Definissez au moins 4 types d'entites et 3 types de relations
 2. **Graphe** : Construisez un KG avec au moins 10 noeuds depuis un texte de 3-4 phrases
-3. **Requete** : Posez une question necessitant un parcours multi-hop dans le graphe
+3. **Requête** : Posez une question necessitant un parcours multi-hop dans le graphe
 4. **Reponse** : Generez une reponse contextuelle en utilisant les chemins trouves
 
-Indice : Inspirez-vous des patterns d'extraction et de fallback presentes dans la section 7.",,,,,,,,ac360bd294d57cd0,,,,,,,
+Indice : Inspirez-vous des patterns d'extraction et de fallback presentes dans la section 7.",,,,,,,,77677fd29e7e4420,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,541eda48,code,fr,4b28f8bc0c2ae80d,"print(""Exercice a completer"")
 # Exercice final : Pipeline GraphRAG sur un domaine libre
 
@@ -6253,18 +6253,18 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,541eda48,co
 # Etape 2 : Extraire les entites et relations
 # Etape 3 : Construire le graphe de connaissances
 # Etape 4 : Implementer la requete multi-hop",,,,,,,,4b28f8bc0c2ae80d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,exercises-title,markdown,fr,eb6dbe7186a3864f,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,exercises-title,markdown,fr,4944f69f21d067d4,"---
 
 ## 8. Exercices
 
 ### Exercice 4 : Extraire des entites d'un texte personnalise
 
-Choisissez un paragraphe de texte (Wikipedia, article de presse, etc.) et utilisez le pipeline d'extraction pour en construire un graphe de connaissances. Visualisez le resultat.
+Choisissez un paragraphe de texte (Wikipedia, article de presse, etc.) et utilisez le pipeline d'extraction pour en construire un graphe de connaissances. Visualisez le résultat.
 
 **Indices** :
 - Preparez un texte de 100-200 mots contenant des entites nommees et des relations
-- Utilisez `extract_entities_llm()` ou creez manuellement le dictionnaire d'entites
-- Transformez en graphe RDF avec le code de la section 4",,,,,,,,eb6dbe7186a3864f,,,,,,,
+- Utilisez `extract_entities_llm()` ou créez manuellement le dictionnaire d'entites
+- Transformez en graphe RDF avec le code de la section 4",,,,,,,,4944f69f21d067d4,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,exercise1,code,fr,062d1c7ea2aca6c2,"# Exercice 4 : Extraction d'entites depuis un texte personnalise
 # Exercice: Remplacez le texte ci-dessous par votre propre texte
 
@@ -6292,14 +6292,14 @@ custom_text = """"""
 # ... (adapter le code de la section 4)
 
 print(""Decommentez et completez le code ci-dessus."")",,,,,,,,062d1c7ea2aca6c2,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,exercise2-title,markdown,fr,3138d939e529f197,"### Exercice 5 : Construire un mini-KG thematique
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,exercise2-title,markdown,fr,08ec58a960fca86d,"### Exercice 5 : Construire un mini-KG thematique
 
 A partir du fichier `data/movies.csv` (utilise dans SW-12), construisez un KG et utilisez-le pour repondre a la question : ""Quels realisateurs ont dirige des acteurs en commun ?""
 
 **Indices** :
 - Reutilisez le code de construction de KG de SW-12
-- Ecrivez une requete SPARQL pour trouver les chemins realisateur -> film -> acteur -> film -> realisateur
-- Formatez le resultat comme contexte pour un prompt LLM",,,,,,,,3138d939e529f197,,,,,,,
+- Ecrivez une requête SPARQL pour trouver les chemins realisateur -> film -> acteur -> film -> realisateur
+- Formatez le résultat comme contexte pour un prompt LLM",,,,,,,,08ec58a960fca86d,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,exercise2,code,fr,dfb64603ff4f803d,"# Exercice 5 : KG thematique a partir de movies.csv
 import pandas as pd
 
@@ -6308,14 +6308,14 @@ import pandas as pd
 # Enfin : formatez le resultat comme contexte GraphRAG et generez une reponse via safe_llm_call
 
 print(""Decommentez et completez le code ci-dessus."")",,,,,,,,dfb64603ff4f803d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,exercise3-title,markdown,fr,7e722f4e366e9761,"### Exercice 6 : Question multi-hop avec GraphRAG
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,exercise3-title,markdown,fr,c5fcccf0a3f6c5d4,"### Exercice 6 : Question multi-hop avec GraphRAG
 
 Implementez une version amelioree de `graphrag_query` qui supporte les questions multi-hop (profondeur > 1). Testez avec la question : ""Quel est le genre des films ou jouent les acteurs diriges par Nolan ?""
 
 **Indices** :
-- Augmentez le parametre `max_hops` dans `extract_subgraph()`
+- Augmentez le paramètre `max_hops` dans `extract_subgraph()`
 - La question necessite le chemin : Nolan -> films -> acteurs -> (autres films de ces acteurs) -> genres
-- Comparez la reponse avec max_hops=1 et max_hops=2",,,,,,,,7e722f4e366e9761,,,,,,,
+- Comparez la reponse avec max_hops=1 et max_hops=2",,,,,,,,c5fcccf0a3f6c5d4,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,exercise3,code,fr,13daa528e891d532,"# Exercice 6 : Question multi-hop
 # Exercice : testez graphrag_query avec differentes profondeurs max_hops
 #
@@ -6324,15 +6324,15 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,exercise3,c
 # Etape 2 : comparez le nombre de faits recuperes entre 1-hop et 2-hop
 
 print(""Decommentez et completez le code ci-dessus."")",,,,,,,,13daa528e891d532,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,322e9483,markdown,fr,edbf424e857e6994,"## Resume et perspectives
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb,322e9483,markdown,fr,b13fe0e9d2bccad9,"## Resume et perspectives
 
-Ce notebook a presente le GraphRAG, une evolution majeure du RAG classique qui combine la puissance des LLMs avec la structure des graphes de connaissances. Le pipeline complet a ete couvert : extraction d'entites et relations depuis un texte brut (via LLM ou donnees de demonstration), construction d'un graphe RDF avec rdflib, extraction de sous-graphes pertinents par parcours BFS, et generation de reponses augmentees par le contexte structure du graphe.
+Ce notebook a presente le GraphRAG, une evolution majeure du RAG classique qui combine la puissance des LLMs avec la structure des graphes de connaissances. Le pipeline complet a ete couvert : extraction d'entites et relations depuis un texte brut (via LLM ou données de demonstration), construction d'un graphe RDF avec rdflib, extraction de sous-graphes pertinents par parcours BFS, et generation de reponses augmentees par le contexte structure du graphe.
 
-Les resultats ont montre l'avantage decisif du GraphRAG sur les questions multi-hop : alors que le RAG classique cherche des chunks de texte par similarite, le GraphRAG traverse les relations du graphe pour reconstituer un contexte complet et factuel. La detection de communautes (algorithme de modularite, inspire de Leiden utilise par Microsoft GraphRAG) a illustre comment les entites se regroupent naturellement en clusters semantiques, permettant des requetes thematiques a differents niveaux de granularite.
+Les résultats ont montre l'avantage decisif du GraphRAG sur les questions multi-hop : alors que le RAG classique cherche des chunks de texte par similarite, le GraphRAG traverse les relations du graphe pour reconstituer un contexte complet et factuel. La detection de communautes (algorithme de modularite, inspire de Leiden utilise par Microsoft GraphRAG) a illustre comment les entites se regroupent naturellement en clusters sémantiques, permettant des requêtes thematiques a différents niveaux de granularite.
 
-La gestion robuste des cles API (detection automatique, fallback vers les donnees de demonstration, verification au demarrage) garantit que le notebook fonctionne dans tous les environnements, avec ou sans acces a un LLM. Ce pattern est transposable a tout notebook utilisant des services externes.
+La gestion robuste des cles API (detection automatique, fallback vers les données de demonstration, verification au demarrage) garantit que le notebook fonctionne dans tous les environnements, avec ou sans acces a un LLM. Ce pattern est transposable a tout notebook utilisant des services externes.
 
-Dans le notebook suivant (**SW-13-Python-Reasoners**), nous comparerons les raisonneurs OWL (owlrl, HermiT, reasonable, Growl) pour comprendre les compromis entre expressivite, performance et facilite d'integration.",,,,,,,,edbf424e857e6994,,,,,,,
+Dans le notebook suivant (**SW-13-Python-Reasoners**), nous comparerons les raisonneurs OWL (owlrl, HermiT, reasonable, Growl) pour comprendre les compromis entre expressivite, performance et facilite d'integration.",,,,,,,,b13fe0e9d2bccad9,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,a08b7ef7,markdown,fr,3100eff3000512e0,"# SW-13-Reasoners
 
 **Navigation** : [<< 13-GraphRAG](SW-12-Python-GraphRAG.ipynb) | [Index](README.md)
@@ -6435,11 +6435,11 @@ Avant de construire l'ontologie de test et d'interpréter les inférences des ra
 | **Non-unicité des noms (non-UNA)** | 2 URI ≠ 2 individus forcément | Unicité des noms (clés) | `owl:differentFrom`, `owl:AllDifferent` |
 
 > **Pourquoi c'est un prérequis.** Sans OWA, la détection d'incohérence de l'exemple 4 paraîtrait arbitraire ; sans non-UNA, l'exemple 6 réussit ou rate son cardinal selon qu'on asserte la différence des individus. Garder ces deux hypothèses en tête est indispensable pour interpréter correctement chacune des inférences qui suivent.",,,,,,,,6e98cd4cae51a018,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,1b9c4df4,markdown,fr,b070c1ee451431ff,"## Ontologie de test
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,1b9c4df4,markdown,fr,f3f8e5b8e8ed8216,"## Ontologie de test
 
 Créons une ontologie de test basée sur le domaine de la **pizza** (inspirée de la Pizza Ontology, un benchmark standard en OWL).
 
-> La **Pizza Ontology** est l'ontologie didactique de référence du Web Sémantique, popularisée par les tutoriels Protégé de l'Université de Manchester (Rector, Stevens et al.). Son usage pédagogique systématique est analysé dans Rector, Drummond, Stevens et al., *OWL pizzas: Practical experience of teaching OWL-DL — common errors, common patterns* (EKAW 2004), qui catalogue les difficultés récurrentes des apprenants OWL.",,,,,,,,b070c1ee451431ff,,,,,,,
+> La **Pizza Ontology** est l'ontologie didactique de référence du Web Sémantique, popularisée par les tutoriels Protégé de l'Université de Manchester (Rector, Stevens et al.). Son usage pédagogique systématique est analysé dans Rector, Drummond, Stevens et al., *OWL pizzas: Practical expérience of teaching OWL-DL — common errors, common patterns* (EKAW 2004), qui catalogue les difficultés récurrentes des apprenants OWL.",,,,,,,,f3f8e5b8e8ed8216,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,6e3c4792,code,fr,699c84b379d7c9ca,"# Namespace pour notre ontologie
 EX = Namespace(""http://example.org/pizza#"")
 
@@ -6470,7 +6470,7 @@ for cls in classes:
     g.add((cls, RDF.type, OWL.Class))
 
 print(f""✓ {len(classes)} classes définies"")",,,,,,,,699c84b379d7c9ca,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,trans-005,markdown,fr,31cac991f704ef9b,Definition de la hierarchie de classes OWL pour l'ontologie de test (Pizza Ontology simplifiee).,,,,,,,,31cac991f704ef9b,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,trans-005,markdown,fr,f54889ea39c66c51,Definition de la hiérarchie de classes OWL pour l'ontologie de test (Pizza Ontology simplifiee).,,,,,,,,f54889ea39c66c51,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,d54d3c88,code,fr,afddab163817c63b,"# Hiérarchie de classes
 
 # PizzaBase ⊑ Thing (déjà implicite)
@@ -6577,16 +6577,16 @@ print(f""✓ Temps owlrl: {time_owlrl:.4f} secondes"")
 print(f""✓ Triples avant raisonnement: {len(g)}"")
 print(f""✓ Triples après raisonnement: {triples_owlrl}"")
 print(f""✓ Triples inférés: {inferred_owlrl}"")",,,,,,,,3d49ffea06cf0376,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,cb9c6fb4,markdown,fr,b106662083eaf076,"### Interpretation : Resultats du raisonnement owlrl
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,cb9c6fb4,markdown,fr,5455db15a25b228c,"### Interpretation : Résultats du raisonnement owlrl
 
 **Sortie obtenue** : Le raisonneur owlrl a traite l'ontologie en 0.1479 secondes, passant de 40 a 251 triples (211 triples inférés, ratio d'expansion 6.3x).
 
 | Métrique | Valeur | Signification |
 |----------|--------|---------------|
-| Temps d'execution | 0.1479s | Performance Python interprete |
+| Temps d'exécution | 0.1479s | Performance Python interprete |
 | Triples initiaux | 40 | Ontologie pizza manuelle |
-",,,,,,,,b106662083eaf076,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,trans-011,markdown,fr,67b1acc5abbc96ac,Affichage d'exemples de triplets inferences par owlrl pour illustrer les resultats du raisonnement OWL 2 RL.,,,,,,,,67b1acc5abbc96ac,,,,,,,
+",,,,,,,,5455db15a25b228c,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,trans-011,markdown,fr,ad5da8ce37289761,Affichage d'exemples de triplets inferences par owlrl pour illustrer les résultats du raisonnement OWL 2 RL.,,,,,,,,ad5da8ce37289761,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,17d2d96d,code,fr,f2b82eeb61cc6287,"# Exemples de triples inférés
 print(""--- Exemples de triples inférés par owlrl ---"")
 inferred_triples = set(g_owlrl) - set(g)
@@ -6706,7 +6706,7 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,c50ac732,c
     print(f""✓ Instances créées"")
     print(f""  - Margherita a {len(margherita.has_topping)} toppings"")
     print(f""  - Pepperoni a {len(pepperoni.has_topping)} toppings"")",,,,,,,,422887e42d2d9210,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,trans-018,markdown,fr,4c07cbb96d79a6e7,Execution du raisonnement HermiT sur l'ontologie et collecte des resultats inferences.,,,,,,,,4c07cbb96d79a6e7,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,trans-018,markdown,fr,1c0ec6569257b8da,Exécution du raisonnement HermiT sur l'ontologie et collecte des résultats inferences.,,,,,,,,1c0ec6569257b8da,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,286ae58e,code,fr,179ef1f3a2b5c923,"if OWLREADY2_AVAILABLE:
     # Raisonnement avec HermiT
     print(""Démarrage du raisonnement HermiT..."")
@@ -6746,15 +6746,15 @@ else:
     time_hermit = None
     triples_hermit = None
     print(""⚠ Test HermiT skip (OWLReady2 non disponible)"")",,,,,,,,179ef1f3a2b5c923,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,3fe185b2,markdown,fr,97cb05205e042c33,"### Interpretation : Resultats du raisonneur HermiT (OWL 2 DL)
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,3fe185b2,markdown,fr,6874977525ffce09,"### Interpretation : Résultats du raisonneur HermiT (OWL 2 DL)
 
 **Sortie obtenue** : HermiT a termine le raisonnement en 1.2873 secondes, produisant 43 triples au total.
 
 | Métrique | Valeur | Analyse |
 |----------|--------|---------|
-| Temps d'execution | 1.2873s | Plus lent qu'owlrl (inclus cold start JVM) |
+| Temps d'exécution | 1.2873s | Plus lent qu'owlrl (inclus cold start JVM) |
 | Triples totaux | 43 | Structure OWL de base (vs 251 avec owlrl) |
-",,,,,,,,97cb05205e042c33,,,,,,,
+",,,,,,,,6874977525ffce09,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,316bcd32,markdown,fr,b6fe7e200b4735e6,"### Analyse des résultats HermiT
 
 HermiT est l'un des raisonneurs OWL 2 DL les plus performants. Il utilise un algorithme de tableaux optimisé.
@@ -6779,7 +6779,7 @@ except ImportError as e:
     REASONABLE_AVAILABLE = False
     print(f""⚠ reasonable n'est pas disponible: {e}"")
     print(""  Installation: pip install reasonable"")",,,,,,,,0d2932b56f7ea655,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,trans-023,markdown,fr,c4c5f259caf22889,Execution du raisonnement avec la bibliotheque reasonable et collecte des resultats.,,,,,,,,c4c5f259caf22889,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,trans-023,markdown,fr,29394d29745e5580,Exécution du raisonnement avec la bibliotheque reasonable et collecte des résultats.,,,,,,,,29394d29745e5580,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,a3234357,code,fr,f2a9bdbcaae5acd1,"if REASONABLE_AVAILABLE:
     # Copie du graphe pour reasonable
     g_reasonable = rdflib.Graph()
@@ -6809,13 +6809,13 @@ else:
     triples_reasonable = None
     inferred_reasonable = None
     print(""⚠ Test reasonable skip (non disponible)"")",,,,,,,,f2a9bdbcaae5acd1,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,e2f3b3a2,markdown,fr,51abe95099e119c0,"### Interpretation : Resultats du raisonneur reasonable
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,e2f3b3a2,markdown,fr,18777db0fe964127,"### Interpretation : Résultats du raisonneur reasonable
 
 **Sortie obtenue** : Le raisonneur reasonable a infere **42 triples** en **0.0092 secondes** (40 -> 82 triples, ratio d'expansion 2.1x).
 
 | Métrique | Valeur | Comparaison |
 |----------|--------|-------------|
-| Temps d'execution | 0.0092s | ~16x plus rapide qu'owlrl (0.1479s) |
+| Temps d'exécution | 0.0092s | ~16x plus rapide qu'owlrl (0.1479s) |
 | Triples inférés | 42 | ~5x moins qu'owlrl (211) |
 | Ratio d'expansion | 2.1x | Sémantique substantielle |
 | Langage | Rust compilé | Performance native |
@@ -6827,7 +6827,7 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,e2f3b3a2,m
 4. **Cas d'usage idéal** : applications temps réel, microservices, architectures serverless où l'on veut à la fois rapidité ET une bonne couverture sémantique
 
 > **Note technique** : reasonable utilise l'algorithme de chase optimisé pour OWL 2 RL. Contrairement a owlrl qui implémente toutes les règles W3C (~300 règles), reasonable se concentre sur les règles les plus fréquemment utilisées. L'écart d'inférences (42 vs 211) porte principalement sur les fermetures transitives exhaustives. Pour la plupart des applications pratiques, reasonable suffit largement ; si vous avez besoin de complétude sémantique totale (ex: validation d'ontologie), préférez owlrl.
-",,,,,,,,51abe95099e119c0,,,,,,,
+",,,,,,,,18777db0fe964127,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,f5776cf1,markdown,fr,7cf0c3adebf7be29,"### Analyse des résultats reasonable
 
 reasonable offre généralement des performances comparables ou supérieures à owlrl grâce à son implémentation en Rust.",,,,,,,,7cf0c3adebf7be29,,,,,,,
@@ -6860,7 +6860,7 @@ else:
     print(""    git clone https://github.com/S-Toby-Jacobs/growl"")
     print(""    cd growl && make"")
     print(""    sudo make install"")",,,,,,,,1d48884b3cb5ee41,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,trans-028,markdown,fr,bd6d7f57ae85e98c,Verification de la disponibilite de Growl et execution du raisonnement si disponible.,,,,,,,,bd6d7f57ae85e98c,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,trans-028,markdown,fr,7f8f27f7735346ff,Verification de la disponibilite de Growl et exécution du raisonnement si disponible.,,,,,,,,7f8f27f7735346ff,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,68c97c3d,code,fr,4cd87794f63dace2,"if GROWL_AVAILABLE:
     # Preparer les fichiers pour Growl
     input_file = ""data/pizza_test.ttl""
@@ -6972,7 +6972,7 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,dd5fb775,m
 
 > **Note technique** : Les valeurs ""Inférés"" pour HermiT sont marquées N/A car OWLReady2 ne sépare pas les triples inférés des triples originaux de la même manière que RDFLib. La comparaison directe du nombre de triples entre HermiT et les raisonneurs RL n'est donc pas pertinente. Ce qui compte pour HermiT, c'est la capacité à raisonner sur OWL 2 DL complet (restrictions complexes, hiérarchies profondes).
 ",,,,,,,,f4a9c19acab41707,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,trans-031,markdown,fr,f36455197c6dd782,Visualisation des temps d'execution de chaque raisonneur sous forme de graphique.,,,,,,,,f36455197c6dd782,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,trans-031,markdown,fr,1e86206acd4d62db,Visualisation des temps d'exécution de chaque raisonneur sous forme de graphique.,,,,,,,,1e86206acd4d62db,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,cd7352e6,code,fr,2ac10d84582270e9,"# Visualisation des temps d'exécution
 if len(results) > 0:
     fig, ax = plt.subplots(figsize=(10, 5))
@@ -6997,9 +6997,9 @@ if len(results) > 0:
     plt.show()
 else:
     print(""Pas assez de données pour le graphique"")",,,,,,,,2ac10d84582270e9,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,fbe693b0,markdown,fr,7850a499812d7ce0,"### Interpretation : Visualisation des performances
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,fbe693b0,markdown,fr,44ce7955b82de208,"### Interpretation : Visualisation des performances
 
-**Sortie obtenue** : Graphique à barres montrant les temps d'execution des raisonneurs OWL testés.
+**Sortie obtenue** : Graphique à barres montrant les temps d'exécution des raisonneurs OWL testés.
 
 | Raisonneur | Temps (s) | Classe de performance | Facteur vs plus rapide |
 |-----------|-----------|----------------------|------------------------|
@@ -7014,7 +7014,7 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,fbe693b0,m
 4. **Profil d'usage** : pour des raisonnements fréquents en production, privilégiez reasonable ; pour le prototypage, owlrl suffit
 
 > **Note technique** : Le temps d'HermiT inclut le cold start de la JVM (~0.5-0.8s). Les appels suivants seraient beaucoup plus rapides (~0.1-0.2s). Pour des comparaisons équitables, il faudrait exécuter HermiT plusieurs fois et ne mesurer que les exécutions ""à chaud"". Cependant, en pratique, le cold start est inévitable lors du premier raisonnement.
-",,,,,,,,7850a499812d7ce0,,,,,,,
+",,,,,,,,44ce7955b82de208,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,trans-032,markdown,fr,c76c8cdba485b06d,Comparaison du nombre de triplets inferences par les raisonneurs compatibles OWL 2 RL.,,,,,,,,c76c8cdba485b06d,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,fc8adb55,code,fr,acb475d6e22c890b,"# Comparaison des triples inférés (RL uniquement)
 rl_results = [r for r in results if r[""OWL Profile""] == ""RL"" and r[""Inférés""] is not None]
@@ -7149,9 +7149,9 @@ if len(bench) >= 2 and bench[1][1] > 0:
     print()
     print(f""reasonable est ~{bench[0][1] / bench[1][1]:.0f}x plus rapide qu'owlrl sur cette ontologie."")
 ",,,,,,,,78619630129692a5,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,exemple-sw13-2,markdown,fr,586866cadaf4f73f,"### Exemple guidé 2 : Verification de l'equivalence des resultats RL
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,exemple-sw13-2,markdown,fr,1717ffdfacb4fd4d,"### Exemple guidé 2 : Verification de l'equivalence des résultats RL
 
-*Solution proposee par @Sosolalt (EPITA-IS, promo 2028).*",,,,,,,,586866cadaf4f73f,,,,,,,
+*Solution proposee par @Sosolalt (EPITA-IS, promo 2028).*",,,,,,,,1717ffdfacb4fd4d,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,exemple-code-sw13-2,code,fr,b9d5752759f81d35,"# Exercice 2 : Verification de l'equivalence owlrl vs reasonable
 
 # Etape 1 : graphe de base + copies pour chaque raisonneur
@@ -7670,15 +7670,15 @@ print(s.getvalue())
 
 Les fonctions les plus coûteuses seront probablement dans le module `owlrl` (ex: `DeductiveClosure.expand`, `_rule_OWLRL_SubClassOf`).
 ",,,,,,,,4b7fb47fb9c29ae4,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,269ea3d8,markdown,fr,11e4e442b3f5da92,"### Exercice 4 : Detection d'incoherence avec un raisonneur DL (HermiT)
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,269ea3d8,markdown,fr,b4caaf32533c4afa,"### Exercice 4 : Detection d'incoherence avec un raisonneur DL (HermiT)
 
 Une force du raisonnement OWL 2 DL est la **detection automatique d'incoherences** dans une base de connaissances. Construisez une ontologie avec une contradiction explicite et faites-la detecter par HermiT.
 
 **Consignes :**
 1. Avec **OWLReady2**, declarer deux classes disjointes : `Vegetal` et `Animal` (`AllDisjoint([Vegetal, Animal])`)
-2. Creer une instance `tomate` declaree comme **a la fois** `Vegetal` ET `Animal` (incoherence explicite)
+2. Créer une instance `tomate` declaree comme **a la fois** `Vegetal` ET `Animal` (incoherence explicite)
 3. Lancer `sync_reasoner_hermit()` dans un bloc `try / except OwlReadyInconsistentOntologyError`
-4. Verifier qu'**owlrl** (profil RL) ne detecte **pas** cette incoherence avec la meme rigueur (le profil RL n'inclut pas la classification DL complete)
+4. Verifier qu'**owlrl** (profil RL) ne detecte **pas** cette incoherence avec la même rigueur (le profil RL n'inclut pas la classification DL complete)
 5. Conclure sur l'usage : DL pour la validation logique, RL pour la materialisation rapide
 
 **Indices :**
@@ -7686,7 +7686,7 @@ Une force du raisonnement OWL 2 DL est la **detection automatique d'incoherences
 - `onto = get_ontology(""http://test.org/disjoint.owl"")` puis `with onto: class Vegetal(Thing): pass`
 - L'incoherence se materialise par l'exception OwlReadyInconsistentOntologyError au moment du `sync_reasoner_hermit()`
 - Pour owlrl, l'incoherence n'est pas levee comme exception ; il faut interroger le graphe et chercher les inferences contradictoires manuellement
-- Question pedagogique : pourquoi le profil RL accepte-t-il des incoherences que DL rejette ?",,,,,,,,11e4e442b3f5da92,,,,,,,
+- Question pedagogique : pourquoi le profil RL accepte-t-il des incoherences que DL rejette ?",,,,,,,,b4caaf32533c4afa,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,f4c8e8e3,code,fr,d6b808f8a498d2ba,"# Exercice 4 : Detection d'incoherence avec HermiT (DL)
 
 # TODO etudiant : declarer Vegetal et Animal disjoints avec OWLReady2
@@ -7717,7 +7717,7 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,f4c8e8e3,c
 # verifier que le graphe se materialise SANS exception (RL est plus tolerant)
 
 print(""Exercice a completer : detection incoherence HermiT vs tolerance owlrl"")",,,,,,,,d6b808f8a498d2ba,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,58b1e090,markdown,fr,565d57224ea06d04,"### Exercice 5 : Inferences sur axiomes de proprietes OWL
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,58b1e090,markdown,fr,d9e7e9d852070e7e,"### Exercice 5 : Inferences sur axiomes de proprietes OWL
 
 OWL fournit des axiomes puissants sur les proprietes : **TransitiveProperty**, **SymmetricProperty**, **InverseProperty**. Le raisonneur materialise les triples implicites en appliquant ces axiomes. Construisez un mini-KG et verifiez les inferences attendues.
 
@@ -7727,7 +7727,7 @@ OWL fournit des axiomes puissants sur les proprietes : **TransitiveProperty**, *
    - `:knows` declaree `owl:SymmetricProperty` ; ajouter (A knows B) — on attend (B knows A) inferre
    - `:hasParent` declaree `owl:inverseOf :hasChild` ; ajouter (A hasParent B) — on attend (B hasChild A) inferre
 2. Appliquer `owlrl.DeductiveClosure(owlrl.OWLRL_Semantics).expand(g_props)`
-3. Verifier chacune des 3 inferences attendues avec une requete SPARQL `ASK`
+3. Verifier chacune des 3 inferences attendues avec une requête SPARQL `ASK`
 4. Compter `len(g_props_avant)` vs `len(g_props_apres)` pour quantifier la materialisation
 5. Bonus : ajouter `owl:ReflexiveProperty` ou `owl:IrreflexiveProperty` et observer leur impact (ou son absence en profil RL)
 
@@ -7736,7 +7736,7 @@ OWL fournit des axiomes puissants sur les proprietes : **TransitiveProperty**, *
 - Declarer une propriete transitive : `g.add((EX.hasAncestor, RDF.type, OWL.TransitiveProperty))`
 - `ASK { :A :hasAncestor :C }` retourne True si l'inference a eu lieu
 - Le nombre de triples doit croitre : c'est la **materialisation de la cloture**
-- Question pedagogique : combien de hops transitifs `owlrl` materialise-t-il sur une chaine de 10 elements ?",,,,,,,,565d57224ea06d04,,,,,,,
+- Question pedagogique : combien de hops transitifs `owlrl` materialise-t-il sur une chaîne de 10 éléments ?",,,,,,,,d9e7e9d852070e7e,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,7a9d8adc,code,fr,22ed030c3487be7c,"# Exercice 5 : Inferences sur axiomes de proprietes OWL
 
 # TODO etudiant : construire le graphe avec 3 proprietes typees
@@ -7772,24 +7772,24 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,7a9d8adc,c
 # print(f""Transitive A->C : {bool(r1)}, Symetrique B->A : {bool(r2)}, Inverse B->A : {bool(r3)}"")
 
 print(""Exercice a completer : axiomes TransitiveProperty + SymmetricProperty + inverseOf"")",,,,,,,,22ed030c3487be7c,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,08ce383a,markdown,fr,7527020348cca465,"### Exercice 6 : Comparaison expressivite OWL 2 RL vs OWL 2 DL (someValuesFrom)
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,08ce383a,markdown,fr,7073f5bd0964934d,"### Exercice 6 : Comparaison expressivite OWL 2 RL vs OWL 2 DL (someValuesFrom)
 
-Les profils OWL 2 RL (owlrl, reasonable) et OWL 2 DL (HermiT) different en **expressivite**. Une difference cle : la **classification automatique d'instances** par restrictions de classe (`someValuesFrom`). Verifiez empiriquement cette difference.
+Les profils OWL 2 RL (owlrl, reasonable) et OWL 2 DL (HermiT) différent en **expressivite**. Une différence cle : la **classification automatique d'instances** par restrictions de classe (`someValuesFrom`). Verifiez empiriquement cette différence.
 
 **Consignes :**
 1. Construire une ontologie avec :
-   - Classe `MeatPizza` definie comme **equivalente** a `Pizza et (hasTopping some MeatTopping)`
+   - Classe `MeatPizza` définie comme **equivalente** a `Pizza et (hasTopping some MeatTopping)`
    - Instance `pizza1` declaree `Pizza` avec `pizza1 hasTopping topping1` ou `topping1 a MeatTopping`
 2. Appliquer **HermiT** (via OWLReady2) : `pizza1` doit etre **automatiquement classifiee** comme `MeatPizza`
-3. Appliquer **owlrl** (profil RL) sur le meme KG transcrit en rdflib : la classification automatique via `someValuesFrom` **n'est PAS supportee** en profil RL standard
-4. Conclure : pour la classification riche par restrictions, DL est necessaire ; pour la materialisation rapide de hierarchies subClassOf + propertyChainAxiom, RL suffit et est plus rapide
+3. Appliquer **owlrl** (profil RL) sur le même KG transcrit en rdflib : la classification automatique via `someValuesFrom` **n'est PAS supportee** en profil RL standard
+4. Conclure : pour la classification riche par restrictions, DL est necessaire ; pour la materialisation rapide de hiérarchies subClassOf + propertyChainAxiom, RL suffit et est plus rapide
 
 **Indices :**
 - OWLReady2 : `class MeatPizza(Pizza): equivalent_to = [Pizza & hasTopping.some(MeatTopping)]`
-- Apres `sync_reasoner_hermit()`, verifier `MeatPizza in pizza1.is_a` ou `pizza1 in MeatPizza.instances()`
-- En rdflib + owlrl : declarer `MeatPizza owl:equivalentClass [a owl:Restriction ; owl:onProperty :hasTopping ; owl:someValuesFrom :MeatTopping]` puis verifier l'absence de l'inference `pizza1 a MeatPizza` apres expansion
+- Après `sync_reasoner_hermit()`, verifier `MeatPizza in pizza1.is_a` ou `pizza1 in MeatPizza.instances()`
+- En rdflib + owlrl : declarer `MeatPizza owl:equivalentClass [a owl:Restriction ; owl:onProperty :hasTopping ; owl:someValuesFrom :MeatTopping]` puis verifier l'absence de l'inference `pizza1 a MeatPizza` après expansion
 - Pour rester clair pedagogiquement : afficher un mini-tableau avec `RL infere classification ?` vs `DL infere classification ?`
-- Question pedagogique : quel(s) profil(s) OWL 2 supporte(nt) `someValuesFrom` dans les axiomes d'equivalence ?",,,,,,,,7527020348cca465,,,,,,,
+- Question pedagogique : quel(s) profil(s) OWL 2 supporte(nt) `someValuesFrom` dans les axiomes d'equivalence ?",,,,,,,,7073f5bd0964934d,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,626076ee,code,fr,c0d958c8ec3e222a,"# Exercice 6 : OWL 2 RL vs OWL 2 DL sur someValuesFrom (classification automatique)
 
 # TODO etudiant : construire l'ontologie pizza avec OWLReady2 (DL)
@@ -7834,7 +7834,7 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,626076ee,c
 # print(f""| DL (HermiT) | {MeatPizza in pizza1.is_a} |"")
 
 print(""Exercice a completer : someValuesFrom inference RL (non) vs DL (oui)"")",,,,,,,,c0d958c8ec3e222a,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,2fbcec7d,markdown,fr,17031b610afe22a2,"## Conclusion
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,2fbcec7d,markdown,fr,e90462e45dee09b9,"## Conclusion
 
 ### Résumé des compromis
 
@@ -7858,7 +7858,7 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,2fbcec7d,m
 - **OWL 2 Direct Semantics** — Motik, Patel-Schneider, Cuenca Grau (Recommandation W3C, 11 décembre 2012). Sémantique formelle d'OWL 2 implémentée par les raisonneurs DL (HermiT).
 - **The Description Logic Handbook** — Baader, Calvanese, McGuinness, Nardi, Patel-Schneider (eds.), Cambridge University Press, 2e éd. 2007. Référence fondatrice des logiques de description sous-jacentes à OWL.
 - **HermiT: An OWL 2 Reasoner** — Glimm, Horrocks, Motik, Stoilos, Wang, *Journal of Automated Reasoning* 53(4), 2014. Description du raisonneur et de l'algorithme hypertableau.
-- **OWL pizzas** — Rector, Drummond, Stevens et al., *OWL pizzas: Practical experience of teaching OWL-DL*, EKAW 2004. Origine et analyse pédagogique de la Pizza Ontology utilisée comme ontologie de test.
+- **OWL pizzas** — Rector, Drummond, Stevens et al., *OWL pizzas: Practical expérience of teaching OWL-DL*, EKAW 2004. Origine et analyse pédagogique de la Pizza Ontology utilisée comme ontologie de test.
 
 ### Ressources
 
@@ -7867,24 +7867,24 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,2fbcec7d,m
 - [OWLReady2](https://owlready2.readthedocs.io/)
 - [HermiT reasoner](https://github.com/phileas-hermiT/hermit)
 - [reasonable](https://github.com/jekyllandre/reasonable)
-- [Growl](https://github.com/S-Toby-Jacobs/growl)",,,,,,,,17031b610afe22a2,,,,,,,
+- [Growl](https://github.com/S-Toby-Jacobs/growl)",,,,,,,,e90462e45dee09b9,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,7oyuh5l3sdw,markdown,fr,2d61655a40806464,"---
 
 **Navigation** : [<< 13-GraphRAG](SW-12-Python-GraphRAG.ipynb) | [Index](README.md)",,,,,,,,2d61655a40806464,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,69c7dbc6,markdown,fr,4e6839e3e0f10628,"## Resume et perspectives
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb,69c7dbc6,markdown,fr,14bc5de7cc1ff42d,"## Resume et perspectives
 
-Ce notebook a compare quatre raisonneurs OWL couvrant un spectre allant de l'implementation Python pure au code compile en Rust et en C, avec des profils OWL allant de RL (polynomial) a DL (NExpTime-complet). Les benchmarks sur l'ontologie pizza ont revele des ecarts de performance considerables : reasonable (Rust) est environ 20 fois plus rapide qu'owlrl (Python), tandis qu'HermiT (Java, OWL 2 DL complet) offre une expressivite superieure au prix d'un temps d'execution plus eleve.
+Ce notebook a compare quatre raisonneurs OWL couvrant un spectre allant de l'implementation Python pure au code compile en Rust et en C, avec des profils OWL allant de RL (polynomial) a DL (NExpTime-complet). Les benchmarks sur l'ontologie pizza ont revele des ecarts de performance considerables : reasonable (Rust) est environ 20 fois plus rapide qu'owlrl (Python), tandis qu'HermiT (Java, OWL 2 DL complet) offre une expressivite superieure au prix d'un temps d'exécution plus eleve.
 
-La difference majeure entre les profils OWL 2 RL et OWL 2 DL a ete illustree par les exercices : le profil RL (owlrl, reasonable) materialise efficacement les hierarchies de classes, les proprietes transitives et les inferences de base, mais ne supporte pas la classification automatique par restrictions `someValuesFrom`. Le profil DL (HermiT) detecte les incoherences ontologiques et classifie les instances selon des regles complexes, ce qui est indispensable dans les domaines critiques (medecine, industrie). Le choix du raisonneur depend donc du compromis entre expressivite requise et performances acceptables.
+La différence majeure entre les profils OWL 2 RL et OWL 2 DL a ete illustree par les exercices : le profil RL (owlrl, reasonable) materialise efficacement les hiérarchies de classes, les proprietes transitives et les inferences de base, mais ne supporte pas la classification automatique par restrictions `someValuesFrom`. Le profil DL (HermiT) detecte les incoherences ontologiques et classifie les instances selon des règles complexes, ce qui est indispensable dans les domaines critiques (medecine, industrie). Le choix du raisonneur depend donc du compromis entre expressivite requise et performances acceptables.
 
-Ce notebook conclut la serie Semantic Web. Au fil des 13 notebooks, vous avez parcouru l'ensemble de la pile technologique : les triplets RDF (SW-1 a SW-3), les requetes SPARQL (SW-4 a SW-5), les schemas et ontologies RDFS/OWL (SW-6 a SW-7), la validation SHACL (SW-8), les formats modernes JSON-LD et RDF-Star (SW-9 a SW-10), les graphes de connaissances (SW-11), l'integration avec les LLMs via GraphRAG (SW-12), et enfin les moteurs d'inference (SW-13).",,,,,,,,4e6839e3e0f10628,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Reasoners-CSharp.ipynb,9886dde6,markdown,fr,5c9a750e9ef6d1bf,"# SW-13 (C#) : Raisonneurs RDF/OWL — Inferer des connaissances
+Ce notebook conclut la serie Semantic Web. Au fil des 13 notebooks, vous avez parcouru l'ensemble de la pile technologique : les triplets RDF (SW-1 a SW-3), les requêtes SPARQL (SW-4 a SW-5), les schemas et ontologies RDFS/OWL (SW-6 a SW-7), la validation SHACL (SW-8), les formats modernes JSON-LD et RDF-Star (SW-9 a SW-10), les graphes de connaissances (SW-11), l'integration avec les LLMs via GraphRAG (SW-12), et enfin les moteurs d'inference (SW-13).",,,,,,,,14bc5de7cc1ff42d,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Reasoners-CSharp.ipynb,9886dde6,markdown,fr,9ac27fca7e40910e,"# SW-13 (C#) : Raisonneurs RDF/OWL — Inferer des connaissances
 
 **Twin C# (.NET Interactive / dotNetRDF) du notebook Python [SW-13-Python-Reasoners](SW-13-Python-Reasoners.ipynb)** (owlrl, owlready2+HermiT, reasonable).
 
-Un **raisonneur** (reasoner) prend un graphe RDF/OWL explicite et **infere** (deduit) les triplets qui en decoulent logiquement : si `Chien` est une sous-classe de `Animal` et `Rex` est un `Chien`, alors `Rex` est un `Animal` — meme si ce dernier triplet n'est pas ecrit explicitement. Ce notebook presente le raisonnement avec **dotNetRDF** (`StaticRdfsReasoner`), compare les regles d'inference RDFS et OWL, et documente l'ecart avec les raisonneurs OWL 2 DL (HermiT, Pellet) qui necessitent la JVM.
+Un **raisonneur** (reasoner) prend un graphe RDF/OWL explicite et **infere** (deduit) les triplets qui en decoulent logiquement : si `Chien` est une sous-classe de `Animal` et `Rex` est un `Chien`, alors `Rex` est un `Animal` — même si ce dernier triplet n'est pas ecrit explicitement. Ce notebook presente le raisonnement avec **dotNetRDF** (`StaticRdfsReasoner`), compare les règles d'inference RDFS et OWL, et documente l'ecart avec les raisonneurs OWL 2 DL (HermiT, Pellet) qui necessitent la JVM.
 
-> **Parite** : le twin Python compare 4 raisonneurs (owlrl OWL-RL, HermiT OWL-DL, reasonable, Growl). Cote .NET, **dotNetRDF 3.4.1** fournit un vrai moteur de forward-chaining RDFS (`StaticRdfsReasoner`) — equivalent du role d'owlrl pour la couche RDFS. Les raisonneurs OWL 2 DL complets (HermiT) etant Java, leur invocation depuis .NET releve de RECOVERABLE-MACHINE (verdict documente section 4).",,,,,,,,5c9a750e9ef6d1bf,,,,,,,
+> **Parite** : le twin Python compare 4 raisonneurs (owlrl OWL-RL, HermiT OWL-DL, reasonable, Growl). Cote .NET, **dotNetRDF 3.4.1** fournit un vrai moteur de forward-chaining RDFS (`StaticRdfsReasoner`) — equivalent du rôle d'owlrl pour la couche RDFS. Les raisonneurs OWL 2 DL complets (HermiT) etant Java, leur invocation depuis .NET releve de RECOVERABLE-MACHINE (verdict documente section 4).",,,,,,,,9ac27fca7e40910e,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Reasoners-CSharp.ipynb,fbf2f133,markdown,fr,b901952c158ea38e,"## 0. Environnement
 
 Installation du moteur **dotNetRDF** (NuGet), qui embarque le namespace `VDS.RDF.Query.Inference` (raisonneurs RDFS, N3 rules).",,,,,,,,b901952c158ea38e,,,,,,,
@@ -7909,20 +7909,20 @@ static string Fmt(IGraph g, INode n) {
 }
 static IUriNode U(IGraph g, string qname) => g.CreateUriNode(qname);
 Console.WriteLine(""dotNetRDF charge, helpers Fmt/U prets."");",,,,,,,,b6259dc29f027c6b,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Reasoners-CSharp.ipynb,e5a79e7a,markdown,fr,5e1040373cb94e3b,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Reasoners-CSharp.ipynb,e5a79e7a,markdown,fr,349b0ded6c17f95d,"---
 
 ## 1. Le raisonnement : pourquoi inferer ?
 
-Le **Web Semantique ouvert** (open-world assumption) signifie qu'un graphe n'est jamais complet : il dit ce qu'on sait, pas tout ce qui est vrai. Un raisonneur **comble** l'ecart entre ce qui est ecrit et ce qui est logiquement consequential.
+Le **Web Sémantique ouvert** (open-world assumption) signifie qu'un graphe n'est jamais complet : il dit ce qu'on sait, pas tout ce qui est vrai. Un raisonneur **comble** l'ecart entre ce qui est ecrit et ce qui est logiquement consequential.
 
-| Regle RDFS | Forme | Exemple d'inference |
+| Règle RDFS | Forme | Exemple d'inference |
 |------------|------|---------------------|
 | rdfs9 (subClass) | `X rdfs:subClassOf Y` + `a rdf:type X` | `a rdf:type Y` |
 | rdfs5 (subProperty transitive) | `P rdfs:subPropertyOf Q` + `Q rdfs:subPropertyOf R` | `P rdfs:subPropertyOf R` |
 | rdfs10 (reflexive) | `C rdfs:subClassOf C` | (toujours vrai) |
 | rdfs2/rdfs3 (domain/range) | `P rdfs:domain C` + `x P y` | `x rdf:type C` |
 
-Sans raisonneur, interroger « tous les animaux » rate si les instances ne sont typees que par leurs sous-classes. **La materialisation des inferences** rend le graphe directement interrogeable.",,,,,,,,5e1040373cb94e3b,,,,,,,
+Sans raisonneur, interroger « tous les animaux » rate si les instances ne sont typees que par leurs sous-classes. **La materialisation des inferences** rend le graphe directement interrogeable.",,,,,,,,349b0ded6c17f95d,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Reasoners-CSharp.ipynb,75f5842c,markdown,fr,61ba25487b2a3327,"---
 
 ## 2. Ontologie de test : universite
@@ -7949,25 +7949,25 @@ g.Assert(new Triple(U(g,""ex:Bob""), U(g,""ex:enseigne""), U(g,""ex:Maths"")));
 g.Assert(new Triple(U(g,""ex:Alice""), U(g,""ex:suit""), U(g,""ex:Maths"")));
 
 Console.WriteLine(""Ontologie explicite : "" + g.Triples.Count + "" triplets"");",,,,,,,,1948dcd998535059,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Reasoners-CSharp.ipynb,99f3cf14,markdown,fr,51d1d036af1d5adc,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Reasoners-CSharp.ipynb,99f3cf14,markdown,fr,8266279176d26370,"---
 
 ## 3. Raisonneur RDFS : dotNetRDF StaticRdfsReasoner
 
-`StaticRdfsReasoner` implemente le forward-chaining des regles RDFS (rdfs2, 3, 5, 7, 9, 10, 11, 12). Il materialise les triplets inferez directement dans le graphe — equivalent au role d'**owlrl** (mode RDFS) cote Python.",,,,,,,,51d1d036af1d5adc,,,,,,,
+`StaticRdfsReasoner` implemente le forward-chaining des règles RDFS (rdfs2, 3, 5, 7, 9, 10, 11, 12). Il materialise les triplets inferez directement dans le graphe — equivalent au rôle d'**owlrl** (mode RDFS) cote Python.",,,,,,,,8266279176d26370,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Reasoners-CSharp.ipynb,4b04131f,code,fr,6b7edcd60f9f91e2,"var reasoner = new StaticRdfsReasoner();
 reasoner.Initialise(g);
 int before = g.Triples.Count;
 reasoner.Apply(g);
 int after = g.Triples.Count;
 Console.WriteLine(""Triplets : "" + before + "" explicites -> "" + after + "" apres raisonnement ("" + (after-before) + "" inferez)"");",,,,,,,,6b7edcd60f9f91e2,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Reasoners-CSharp.ipynb,bee267a2,markdown,fr,6e98ec7e6a482867,"### 3.1 Triples inferez : qu'a-t-on deduit ?
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Reasoners-CSharp.ipynb,bee267a2,markdown,fr,4c0777ada7e7c225,"### 3.1 Triples inferez : qu'a-t-on deduit ?
 
-Examinons les inferences cles. D'apres les regles RDFS, on s'attend a :
+Examinons les inferences cles. D'après les règles RDFS, on s'attend a :
 - **rdfs9** : `Alice` (Etudiant ⊂ Personne) → `Alice rdf:type Personne` ; `Bob` (Professeur ⊂ Personne) → `Bob rdf:type Personne`.
 - **rdfs2/rdfs3** (domain/range) : `Bob enseigne Maths` + `enseigne range Cours` → `Maths rdf:type Cours` ; `Alice suit Maths` + `suit range Cours` → `Maths rdf:type Cours` (deduplique).
 
-> **G.1 self-correction (verifie firsthand)** : la sortie montre `Etudiant subClassOf Etudiant (rdfs10) = False`. Le `StaticRdfsReasoner` de dotNetRDF **ne materialise pas** la regle reflexive rdfs10 sur les classes (ni la cloture transitive complete des sous-classes). Les 5 triplets inferez ici = propagation des types (Alice/Bob → Personne, Maths → Cours) + reflexivite des **proprietes** (enseigne ⊂ enseigne, suit ⊂ suit). C'est un under-approximation volontaire : RDFS complet (avec reflexivite + cloture transitive) ajouterait du bruit peu utile. owlrl (twin Python) applique davantage de regles — c'est un ecart documente honnetement, pas un bug.
-",,,,,,,,6e98ec7e6a482867,,,,,,,
+> **G.1 self-correction (verifie firsthand)** : la sortie montre `Etudiant subClassOf Etudiant (rdfs10) = False`. Le `StaticRdfsReasoner` de dotNetRDF **ne materialise pas** la règle reflexive rdfs10 sur les classes (ni la cloture transitive complete des sous-classes). Les 5 triplets inferez ici = propagation des types (Alice/Bob → Personne, Maths → Cours) + reflexivite des **proprietes** (enseigne ⊂ enseigne, suit ⊂ suit). C'est un under-approximation volontaire : RDFS complet (avec reflexivite + cloture transitive) ajouterait du bruit peu utile. owlrl (twin Python) applique davantage de règles — c'est un ecart documente honnetement, pas un bug.
+",,,,,,,,4c0777ada7e7c225,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Reasoners-CSharp.ipynb,ac25f189,code,fr,95d150427f30a189,"Console.WriteLine(""--- Verifications d inferences (re-derivees a la main) ---"");
 bool Chk(string s, string p, string o) => g.ContainsTriple(new Triple(U(g,s), U(g,p), U(g,o)));
 Console.WriteLine(""Alice rdf:type Personne  (rdfs9) : "" + Chk(""ex:Alice"",""rdf:type"",""ex:Personne""));
@@ -7975,13 +7975,13 @@ Console.WriteLine(""Bob rdf:type Personne    (rdfs9) : "" + Chk(""ex:Bob"",""rdf
 Console.WriteLine(""Maths rdf:type Cours     (rdfs3) : "" + Chk(""ex:Maths"",""rdf:type"",""ex:Cours""));
 Console.WriteLine(""Etudiant subClassOf Etudiant reflexive (rdfs10) : "" + Chk(""ex:Etudiant"",""rdfs:subClassOf"",""ex:Etudiant""));
 Console.WriteLine(""Sous-proprietes inferez : "" + g.GetTriplesWithPredicate(U(g,""rdfs:subPropertyOf"")).Count());",,,,,,,,95d150427f30a189,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Reasoners-CSharp.ipynb,d2f3aa15,markdown,fr,2c75a7551c807687,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Reasoners-CSharp.ipynb,d2f3aa15,markdown,fr,2a6ef1558e0f316c,"---
 
 ## 4. OWL 2 DL (HermiT, Pellet) : verdict RECOVERABLE-MACHINE
 
-Le twin Python compare egalement **HermiT** (OWL 2 DL, via owlready2) et **reasonable** (base sur Pellet). Ces raisonneurs vont au-dela de RDFS : ils gerent les **cardinalites**, les **restrictions universelles** (`owl:allValuesFrom`), la **consistance** (detection d'incoherence), la **realisation** (trouver la classe minimale d'une instance).
+Le twin Python compare également **HermiT** (OWL 2 DL, via owlready2) et **reasonable** (base sur Pellet). Ces raisonneurs vont au-dela de RDFS : ils gerent les **cardinalites**, les **restrictions universelles** (`owl:allValuesFrom`), la **consistance** (detection d'incoherence), la **realisation** (trouver la classe minimale d'une instance).
 
-**Verdict SOTA (dotNetRDF)** : dotNetRDF n'embarque pas de raisonneur OWL 2 DL complet (HermiT/Pellet sont ecrits en Java et tournent sur la JVM). Verifions la presence de l'interface `IOwlReasoner` :",,,,,,,,2c75a7551c807687,,,,,,,
+**Verdict SOTA (dotNetRDF)** : dotNetRDF n'embarque pas de raisonneur OWL 2 DL complet (HermiT/Pellet sont ecrits en Java et tournent sur la JVM). Verifions la presence de l'interface `IOwlReasoner` :",,,,,,,,2a6ef1558e0f316c,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Reasoners-CSharp.ipynb,3b4fb8ec,code,fr,c3bb1e2156f7caf5,"// Verdict : dotNetRDF a-t-il un raisonneur OWL 2 DL natif ?
 var owlReasonerType = typeof(VDS.RDF.Query.Inference.IOwlReasoner);
 Console.WriteLine(""Interface IOwlReasoner presente : "" + (owlReasonerType != null));
@@ -7989,11 +7989,11 @@ Console.WriteLine(""Implementation native OWL 2 DL complete (HermiT/Pellet) : NO
 Console.WriteLine(""  -> HermiT/Pellet sont des raisonneurs Java (JVM). Les invoquer depuis .NET"");
 Console.WriteLine(""     requiert un serveur de raisonnement externe (ex. OWLLink HTTP) ou un bridge IKVM."");
 Console.WriteLine(""  -> La couche RDFS (StaticRdfsReasoner, section 3) couvre le forward-chaining standard."");",,,,,,,,c3bb1e2156f7caf5,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Reasoners-CSharp.ipynb,ec06c9ed,markdown,fr,54112290cb91eb18,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Reasoners-CSharp.ipynb,ec06c9ed,markdown,fr,7dd670d0289b23a2,"---
 
 ## 5. Benchmark : inference sur une ontologie croissante
 
-Mesurons le temps de raisonnement quand la taille du graphe augmente. On genere des hierarchies de profondeur variable et on chronometre `reasoner.Apply`.",,,,,,,,54112290cb91eb18,,,,,,,
+Mesurons le temps de raisonnement quand la taille du graphe augmente. On genere des hiérarchies de profondeur variable et on chronometre `reasoner.Apply`.",,,,,,,,7dd670d0289b23a2,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Reasoners-CSharp.ipynb,41f5daac,code,fr,a6a75d32eb12d6e9,"Console.WriteLine(""Profondeur  Explicit  Inferez  Temps(ms)"");
 Console.WriteLine(new string('-', 42));
 foreach (int depth in new[] { 5, 10, 20, 40, 80 }) {
@@ -8015,17 +8015,17 @@ foreach (int depth in new[] { 5, 10, 20, 40, 80 }) {
     int inferred = bg.Triples.Count - explicitCount;
     Console.WriteLine(depth + ""            "" + explicitCount + ""         "" + inferred + ""        "" + sw.Elapsed.TotalMilliseconds.ToString(""F2""));
 }",,,,,,,,a6a75d32eb12d6e9,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Reasoners-CSharp.ipynb,2875293e,markdown,fr,ac170d7b37d1285a,"### 5.1 Interpretation
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Reasoners-CSharp.ipynb,2875293e,markdown,fr,4d78842cb2a2da94,"### 5.1 Interpretation
 
-Le benchmark montre une croissance **lineaire** : pour une chaine de profondeur `D` avec 1 instance, le nombre de triplets inferez est ~`2 x D` (propagation du type `inst rdf:type Ci` le long de la chaine par rdfs9 iteratif + un nombre borne de triplets auxiliaires).
+Le benchmark montre une croissance **lineaire** : pour une chaîne de profondeur `D` avec 1 instance, le nombre de triplets inferez est ~`2 x D` (propagation du type `inst rdf:type Ci` le long de la chaîne par rdfs9 iteratif + un nombre borne de triplets auxiliaires).
 
 > **G.1 self-correction (verifie firsthand)** : contrairement a une intuition RDFS « complete », `StaticRdfsReasoner` ne materialise PAS la cloture transitive quadratique `~D(D+1)/2` des sous-classes ni la reflexivite rdfs10 des classes. Il fait un **forward-chaining borne** (quelques passes fixes) — d'ou la croissance lineaire observee (0.09 ms a D=5, 0.40 ms a D=80) plutot que quadratique. C'est un choix d'implementation : rapide et suffisant pour les cas pedagogiques, au prix d'une completion partielle. Les raisonneurs OWL 2 DL (HermiT, section 4) font la cloture complete mais sont nettement plus lents.
-",,,,,,,,ac170d7b37d1285a,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Reasoners-CSharp.ipynb,b9919823,markdown,fr,32ba6db99c58c1b7,"---
+",,,,,,,,4d78842cb2a2da94,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Reasoners-CSharp.ipynb,b9919823,markdown,fr,d73ef2787b4d1498,"---
 
-## 6. Caracteristiques de proprietes : transitivite
+## 6. Caractéristiques de proprietes : transitivite
 
-RDFS permet de declarer une propriete **transitive** (si `a ancestor b` et `b ancestor c`, alors `a ancestor c`). dotNetRDF fournit `SimpleN3RulesReasoner` pour exprimer des regles custom au-dela du RDFS standard. Construisons un arbre genealogique et exprimons la regle d'ancetre.",,,,,,,,32ba6db99c58c1b7,,,,,,,
+RDFS permet de declarer une propriete **transitive** (si `a ancestor b` et `b ancestor c`, alors `a ancestor c`). dotNetRDF fournit `SimpleN3RulesReasoner` pour exprimer des règles custom au-dela du RDFS standard. Construisons un arbre genealogique et exprimons la règle d'ancetre.",,,,,,,,d73ef2787b4d1498,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Reasoners-CSharp.ipynb,1bcf5bb5,code,fr,d4b075ef734a89a2,"var gg = new Graph();
 gg.NamespaceMap.AddNamespace(""ex"", new Uri(""http://example.org/g/""));
 gg.NamespaceMap.AddNamespace(""rdf"", new Uri(""http://www.w3.org/1999/02/22-rdf-syntax-ns#""));
@@ -8037,37 +8037,37 @@ gg.Assert(new Triple(U(gg,""ex:C""), U(gg,""ex:parent""), U(gg,""ex:D"")));
 Console.WriteLine(""Arbre A->B->C->D cree : "" + gg.Triples.Count + "" triplets explicites."");
 Console.WriteLine(""Note : RDFS pur ne fait PAS la cloture transitive de parent."");
 Console.WriteLine(""Pour cela : OWL (owl:TransitiveProperty) ou SimpleN3RulesReasoner (regle custom)."");",,,,,,,,d4b075ef734a89a2,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Reasoners-CSharp.ipynb,91211e76,markdown,fr,00ebf2e6f6f33306,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Reasoners-CSharp.ipynb,91211e76,markdown,fr,e4ce4edf6f4d7287,"---
 
 ## 7. Comparaison raisonneurs : tableau recapitulatif
 
 | Raisonneur | Langue / Plateforme | Couverture | Statut twin C# |
 |-----------|---------------------|------------|----------------|
 | **dotNetRDF StaticRdfsReasoner** | C# / .NET | RDFS (rdfs2-12), forward-chaining | **SOTA-OK** (section 3, 5) |
-| **dotNetRDF SimpleN3RulesReasoner** | C# / .NET | Regles N3 custom | SOTA-OK (section 6) |
+| **dotNetRDF SimpleN3RulesReasoner** | C# / .NET | Règles N3 custom | SOTA-OK (section 6) |
 | owlrl (Python, OWL-RL) | Python | OWL 2 RL + RDFS | Twin Python reference |
 | HermiT (OWL 2 DL) | Java / JVM | OWL 2 DL complet (consistance, realisation) | **RECOVERABLE-MACHINE** (section 4) |
 | reasonable / Pellet | Java / JVM | OWL 2 DL | RECOVERABLE-MACHINE |
 
-**Lecon** : RDFS (la majorite des cas pedagogiques) est entierement couvert cote .NET par dotNetRDF. Le saut vers OWL 2 DL (decidabilite, tableaux) requiert un raisonneur Java — c'est un compromis architectural du monde .NET, documente honnetement.",,,,,,,,00ebf2e6f6f33306,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Reasoners-CSharp.ipynb,1bb972e3,markdown,fr,f7fc1d36fe81412e,"---
+**Lecon** : RDFS (la majorite des cas pedagogiques) est entierement couvert cote .NET par dotNetRDF. Le saut vers OWL 2 DL (decidabilite, tableaux) requiert un raisonneur Java — c'est un compromis architectural du monde .NET, documente honnetement.",,,,,,,,e4ce4edf6f4d7287,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Reasoners-CSharp.ipynb,1bb972e3,markdown,fr,bb755588e8fa493c,"---
 
 ## Conclusion
 
 | Concept | Implementation dotNetRDF | Equivalence Python |
 |---------|--------------------------|--------------------|
 | Forward-chaining RDFS | `StaticRdfsReasoner.Apply(g)` | `owlrl.DeductiveClosure` |
-| Regles custom | `SimpleN3RulesReasoner` | N3 rules owlrl |
+| Règles custom | `SimpleN3RulesReasoner` | N3 rules owlrl |
 | Materialisation | triplets inferez ajoutes au graphe | idem |
 | OWL 2 DL | absent natif (RECOVERABLE-MACHINE) | owlready2 + HermiT |
 
 **Lecons cles** :
-1. **Le raisonnement materialise les inferences** : apres `Apply`, le graphe contient les triplets deduits — les requetes SPARQL les voient directement.
-2. **RDFS vs OWL 2 DL** : RDFS (hierarchies, domain/range) est decidable et rapide ; OWL 2 DL (cardinalites, restrictions) est plus expressif mais couteux (tableaux algorithmes).
+1. **Le raisonnement materialise les inferences** : après `Apply`, le graphe contient les triplets deduits — les requêtes SPARQL les voient directement.
+2. **RDFS vs OWL 2 DL** : RDFS (hiérarchies, domain/range) est decidable et rapide ; OWL 2 DL (cardinalites, restrictions) est plus expressif mais couteux (tableaux algorithmes).
 3. **Open-world** : l'absence d'information n'est pas une negation. Un raisonneur n'infere pas « X n'est pas Y », seulement ce qui decoule positivement.
 4. **Ecosysteme .NET** : dotNetRDF couvre RDFS nativement ; OWL 2 DL complet passe par un serveur de raisonnement externe.
 
-**Parite avec le twin Python** : la couche RDFS (le cœur pedagogique) est equivalente. L'ecart porte sur OWL 2 DL (HermiT) qui n'a pas d'implementation .NET native — verdict RECOVERABLE-MACHINE documente en section 4, conformement a la discipline SOTA (#3801).",,,,,,,,f7fc1d36fe81412e,,,,,,,
+**Parite avec le twin Python** : la couche RDFS (le cœur pedagogique) est equivalente. L'ecart porte sur OWL 2 DL (HermiT) qui n'a pas d'implementation .NET native — verdict RECOVERABLE-MACHINE documente en section 4, conformement a la discipline SOTA (#3801).",,,,,,,,bb755588e8fa493c,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Reasoners-CSharp.ipynb,1a1464b2,markdown,fr,06eef64c030600fc,"---
 
 ## Exercices
@@ -8396,7 +8396,7 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-1-CSharp-Setup.ipynb,sw1-refs-savant
 - **RDF 1.1 Concepts and Abstract Syntax** - Cyganiak, Wood, Lanthaler (eds.), Recommandation W3C, 25 fevrier 2014. Modèle de données abstrait (triplets sujet-predicat-objet, IRIs, blank nodes, litteraux) qui fonde la couche RDF du Layer Cake.
 - **Semantic Web Layer Cake** - architecture en couches popularisee par Berners-Lee (keynote XML 2000) et raffinee par le W3C Semantic Web Activity Group. Represente la stratification des standards du Web sémantique.
 - **dotNetRDF** - bibliotheque open-source .NET (`dotnetrdf.org`) pour la manipulation de graphes RDF, utilisee tout au long de cette serie de notebooks.",,,,,,,,f56ac514f909eb8e,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,header-navigation,markdown,fr,cc67e25dba6a8114,"# SW-2b-Python-RDFBasics
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,header-navigation,markdown,fr,c884ac8fd81303a2,"# SW-2b-Python-RDFBasics
 
 **Navigation** : [Index](README.md) | [<< SW-2 C#](SW-2-CSharp-RDFBasics.ipynb) | [SW-3 C# >>](SW-3-CSharp-GraphOperations.ipynb)
 
@@ -8407,9 +8407,9 @@ Ce notebook est un **sidetrack optionnel** qui presente l'equivalent Python des 
 ### Objectifs d'apprentissage
 
 A la fin de ce notebook, vous saurez :
-1. Creer et manipuler des graphes RDF avec rdflib
-2. Utiliser les differents types de noeuds (URI, blank nodes, litteraux)
-3. Serialiser des graphes dans differents formats (Turtle, N-Triples, JSON-LD)
+1. Créer et manipuler des graphes RDF avec rdflib
+2. Utiliser les différents types de noeuds (URI, blank nodes, litteraux)
+3. Serialiser des graphes dans différents formats (Turtle, N-Triples, JSON-LD)
 4. Faire la correspondance entre dotNetRDF et rdflib
 
 ### Prerequis
@@ -8418,17 +8418,17 @@ A la fin de ce notebook, vous saurez :
 
 ### Duree estimee : 30 minutes
 
-> **Note** : Ce notebook se concentre sur les fondamentaux RDF. Pour SPARQL en Python, voir le sidetrack **SW-4b-Python-SPARQL**.",,,,,,,,cc67e25dba6a8114,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,section-1-title,markdown,fr,37611e896ef3f8e3,"---
+> **Note** : Ce notebook se concentre sur les fondamentaux RDF. Pour SPARQL en Python, voir le sidetrack **SW-4b-Python-SPARQL**.",,,,,,,,c884ac8fd81303a2,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,section-1-title,markdown,fr,e48782d01e4c99c5,"---
 
 ## 1. Installation et Imports
 
-**rdflib** est le coeur de l'ecosysteme Python pour le Web Semantique. C'est l'equivalent direct de **dotNetRDF** pour .NET.",,,,,,,,37611e896ef3f8e3,,,,,,,
+**rdflib** est le coeur de l'ecosysteme Python pour le Web Sémantique. C'est l'equivalent direct de **dotNetRDF** pour .NET.",,,,,,,,e48782d01e4c99c5,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,install-packages,code,fr,948dfd69d63b0c63,"# Dependances pre-provisionnees (rdflib) : voir SemanticWeb/requirements.txt ; imports dans les cellules suivantes.
 ",,,,,,,,948dfd69d63b0c63,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,install-interpretation,markdown,fr,a7ec1589c42996c0,"### Interpretation
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,install-interpretation,markdown,fr,aabd3f2f76c1ce82,"### Interpretation
 
-L'option `-q` (quiet) reduit la verbosite de pip. Une fois installe, rdflib offre une API pythonique pour toutes les operations RDF.",,,,,,,,a7ec1589c42996c0,,,,,,,
+L'option `-q` (quiet) reduit la verbosite de pip. Une fois installe, rdflib offre une API pythonique pour toutes les opérations RDF.",,,,,,,,aabd3f2f76c1ce82,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,imports-rdflib,code,fr,a6160ea5ebd4e86f,"try:
     from rdflib import Graph, URIRef, Literal, BNode, Namespace
     from rdflib.namespace import RDF, RDFS, XSD, FOAF, DC
@@ -8445,12 +8445,12 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,imports-rd
 except ImportError:
     RDFLIB_AVAILABLE = False
     print(""rdflib non disponible. Installez avec : pip install rdflib"")",,,,,,,,a6160ea5ebd4e86f,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,imports-interpretation,markdown,fr,8d2817e67a3d4aa0,"### Interpretation
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,imports-interpretation,markdown,fr,ae7a08d7ea1846be,"### Interpretation
 
 rdflib fournit des namespaces preconfigures pour les vocabulaires standards du W3C :
 - `RDF` : types et proprietes de base (`rdf:type`, `rdf:Property`)
-- `RDFS` : hierarchie de classes/proprietes (`rdfs:subClassOf`, `rdfs:label`)
-- `XSD` : types de donnees XML Schema (`xsd:integer`, `xsd:dateTime`)
+- `RDFS` : hiérarchie de classes/proprietes (`rdfs:subClassOf`, `rdfs:label`)
+- `XSD` : types de données XML Schema (`xsd:integer`, `xsd:dateTime`)
 - `FOAF` : description de personnes (`foaf:name`, `foaf:knows`)
 
 | Classe rdflib | Equivalent dotNetRDF |
@@ -8459,12 +8459,12 @@ rdflib fournit des namespaces preconfigures pour les vocabulaires standards du W
 | `URIRef` | `IUriNode` |
 | `BNode` | `IBlankNode` |
 | `Literal` | `ILiteralNode` |
-| `Namespace` | `UriFactory` / `PrefixMapper` |",,,,,,,,8d2817e67a3d4aa0,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,section-2-title,markdown,fr,f85108f21bc2cdaf,"---
+| `Namespace` | `UriFactory` / `PrefixMapper` |",,,,,,,,ae7a08d7ea1846be,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,section-2-title,markdown,fr,c7c82644066f7449,"---
 
-## 2. Creer un Graphe et Ajouter des Triples
+## 2. Créer un Graphe et Ajouter des Triples
 
-Un graphe RDF est un ensemble de triples `(sujet, predicat, objet)`. En rdflib, on utilise la methode `add()` avec un **tuple Python**.",,,,,,,,f85108f21bc2cdaf,,,,,,,
+Un graphe RDF est un ensemble de triples `(sujet, predicat, objet)`. En rdflib, on utilise la méthode `add()` avec un **tuple Python**.",,,,,,,,c7c82644066f7449,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,create-graph,code,fr,575afb6ac9d9d28c,"if RDFLIB_AVAILABLE:
     # Create a new empty graph
     g = Graph()
@@ -8495,11 +8495,11 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,create-gra
         )
 else:
     print(""rdflib non disponible : creation de graphe ignoree."")",,,,,,,,575afb6ac9d9d28c,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,create-graph-interpretation,markdown,fr,3944c026ff269232,"### Interpretation : Creation de graphe
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,create-graph-interpretation,markdown,fr,e338f53974942e55,"### Interpretation : Creation de graphe
 
 **Sortie obtenue** : 7 triples decrivant deux personnes (Alice et Bob) et leur relation.
 
-| Operation | Syntaxe rdflib | Syntaxe dotNetRDF |
+| Opération | Syntaxe rdflib | Syntaxe dotNetRDF |
 |-----------|---------------|-------------------|
 | Namespace personnalise | `EX = Namespace(""http://example.org/"")` | `UriFactory.Create(""http://example.org/"")` |
 | Binding de prefixe | `g.bind(""ex"", EX)` | `g.NamespaceMap.AddNamespace(""ex"", uri)` |
@@ -8511,12 +8511,12 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,create-gra
 1. `g.add()` prend un **tuple Python** `(s, p, o)` - contrairement a dotNetRDF qui utilise un objet `Triple`
 2. `EX.Alice` est un raccourci pour `URIRef(""http://example.org/Alice"")`
 3. `g.bind()` associe un prefixe pour la serialisation (ex: `ex:Alice` au lieu de l'URI complete)
-4. La methode `.n3(g.namespace_manager)` formate un noeud avec les prefixes (plus lisible)",,,,,,,,3944c026ff269232,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,section-3-title,markdown,fr,b80e2d42d69597a5,"---
+4. La méthode `.n3(g.namespace_manager)` formate un noeud avec les prefixes (plus lisible)",,,,,,,,e338f53974942e55,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,section-3-title,markdown,fr,43f0d304387dc351,"---
 
 ## 3. Types de Noeuds
 
-RDF definit trois types de noeuds. Voici comment rdflib les represente.",,,,,,,,b80e2d42d69597a5,,,,,,,
+RDF définit trois types de noeuds. Voici comment rdflib les represente.",,,,,,,,43f0d304387dc351,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,node-types,code,fr,017d73d7878b5166,"if RDFLIB_AVAILABLE:
     # 1. URIRef - identifies a resource by its URI
     uri_node = URIRef(""http://example.org/Alice"")
@@ -8552,7 +8552,7 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,node-types
         print(f""  {name:10s} : value={lit.toPython()!r:30s}  datatype={dt}  lang={lg}"")
 else:
     print(""rdflib non disponible : types de noeuds ignores."")",,,,,,,,017d73d7878b5166,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,node-types-interpretation,markdown,fr,b90d241a65d4305f,"### Interpretation : Types de noeuds
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,node-types-interpretation,markdown,fr,dbac9ad727e8592a,"### Interpretation : Types de noeuds
 
 | Type | Classe rdflib | Notation Turtle | Equivalent dotNetRDF |
 |------|--------------|-----------------|---------------------|
@@ -8563,9 +8563,9 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,node-types
 | **Litteral avec langue** | `Literal(""Bonjour"", lang=""fr"")` | `""Bonjour""@fr` | `g.CreateLiteralNode(""Bonjour"", ""fr"")` |
 
 **Points cles** :
-1. La methode `.toPython()` convertit un litteral rdflib en type Python natif
+1. La méthode `.toPython()` convertit un litteral rdflib en type Python natif
 2. Un litteral ne peut **pas** avoir a la fois un `datatype` et un `lang` (contrainte RDF)
-3. Les `BNode` recoivent un identifiant unique auto-genere",,,,,,,,b90d241a65d4305f,,,,,,,
+3. Les `BNode` recoivent un identifiant unique auto-genere",,,,,,,,dbac9ad727e8592a,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,section-4-title,markdown,fr,25551f81ad3f367f,"---
 
 ## 4. Serialisation - Formats de Sortie
@@ -8578,14 +8578,14 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,serialize-
     print(turtle_output)
 else:
     print(""rdflib non disponible : serialisation Turtle ignoree."")",,,,,,,,4a04a4fd37f5dd92,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,serialize-turtle-interpretation,markdown,fr,7641b28b928e5cd4,"### Interpretation : Format Turtle
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,serialize-turtle-interpretation,markdown,fr,a958b1fee04b0c08,"### Interpretation : Format Turtle
 
 Le format **Turtle** est le plus lisible pour les humains :
 - Utilise des prefixes (`ex:`, `foaf:`)
-- Regroupe les proprietes d'un meme sujet avec `;`
+- Regroupe les proprietes d'un même sujet avec `;`
 - Simplifie `rdf:type` en mot-cle `a`
 
-Equivalent dotNetRDF : `CompressingTurtleWriter`",,,,,,,,7641b28b928e5cd4,,,,,,,
+Equivalent dotNetRDF : `CompressingTurtleWriter`",,,,,,,,a958b1fee04b0c08,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,serialize-formats,code,fr,3e9021f466f6dd6d,"if RDFLIB_AVAILABLE:
     # Serialize to N-Triples (one triple per line, no abbreviations)
     nt_output = g.serialize(format=""nt"")
@@ -8609,11 +8609,11 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,serialize-
 | **JSON-LD** | `.jsonld` | Bonne (dev web) | APIs web, Schema.org | `JsonLdWriter` |
 
 > **Conseil** : Preferez Turtle pour le travail quotidien et JSON-LD pour l'integration web.",,,,,,,,74240d8c9367b086,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,section-5-title,markdown,fr,a406d2745b8b45ee,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,section-5-title,markdown,fr,5a2d19609fd8a323,"---
 
 ## 5. Charger un Fichier Existant
 
-rdflib peut charger des graphes depuis des fichiers dans differents formats.",,,,,,,,a406d2745b8b45ee,,,,,,,
+rdflib peut charger des graphes depuis des fichiers dans différents formats.",,,,,,,,5a2d19609fd8a323,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,load-example-ttl,code,fr,e48e32e787ac8bb0,"if RDFLIB_AVAILABLE:
     # Load Example.ttl from the data directory
     g_example = Graph()
@@ -8630,24 +8630,24 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,load-examp
         )
 else:
     print(""rdflib non disponible : chargement de fichier ignore."")",,,,,,,,e48e32e787ac8bb0,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,load-example-interpretation,markdown,fr,e4f4e55afe086d3d,"### Interpretation : Chargement de fichier
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,load-example-interpretation,markdown,fr,5da39a3f57260eee,"### Interpretation : Chargement de fichier
 
-La methode `g.parse()` charge un fichier RDF dans le graphe.
+La méthode `g.parse()` charge un fichier RDF dans le graphe.
 
-| Operation | rdflib | dotNetRDF |
+| Opération | rdflib | dotNetRDF |
 |-----------|---------|----------|
 | Charger un fichier | `g.parse(""file.ttl"", format=""turtle"")` | `FileLoader.Load(g, ""file.ttl"")` |
 | Parser auto-detect | `g.parse(""file.ttl"")` | `FileLoader.Load(g, ""file.ttl"")` (auto) |
 
-**Formats supportes par `parse()`** : `turtle`, `xml`, `json-ld`, `nt`, `n3`, `trig`, `nquads`",,,,,,,,e4f4e55afe086d3d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,section-6-title,markdown,fr,17203b2e79d01eb6,"---
+**Formats supportes par `parse()`** : `turtle`, `xml`, `json-ld`, `nt`, `n3`, `trig`, `nquads`",,,,,,,,5da39a3f57260eee,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,section-6-title,markdown,fr,219346c8240100d2,"---
 
 ## 6. Tableau de Correspondance dotNetRDF / rdflib
 
-Ce tableau recapitule les equivalences entre les deux bibliotheques pour les operations couvertes dans ce notebook.",,,,,,,,17203b2e79d01eb6,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,comparison-table,markdown,fr,98b1131a365dba81,"| Operation | dotNetRDF (C#) | rdflib (Python) |
+Ce tableau recapitule les equivalences entre les deux bibliotheques pour les opérations couvertes dans ce notebook.",,,,,,,,219346c8240100d2,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,comparison-table,markdown,fr,f69c9a3f53cb21d9,"| Opération | dotNetRDF (C#) | rdflib (Python) |
 |-----------|---------------|----------------|
-| **Creer un graphe** | `var g = new Graph();` | `g = Graph()` |
+| **Créer un graphe** | `var g = new Graph();` | `g = Graph()` |
 | **Noeud URI** | `g.CreateUriNode(new Uri(""...""))` | `URIRef(""..."")` |
 | **Blank node** | `g.CreateBlankNode()` | `BNode()` |
 | **Litteral simple** | `g.CreateLiteralNode(""text"")` | `Literal(""text"")` |
@@ -8661,7 +8661,7 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,comparison
 | **Charger un fichier** | `FileLoader.Load(g, ""file.ttl"")` | `g.parse(""file.ttl"")` |
 | **Namespace** | `g.NamespaceMap.AddNamespace(""ex"", uri)` | `g.bind(""ex"", Namespace(uri))` |
 
-### Differences philosophiques
+### Différences philosophiques
 
 | Aspect | dotNetRDF | rdflib |
 |--------|-----------|--------|
@@ -8670,21 +8670,21 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,comparison
 | **Triples** | Objet `Triple(s, p, o)` | Tuple Python `(s, p, o)` |
 | **Iterer** | `foreach (var t in g.Triples)` | `for s, p, o in g:` |
 
-> **A retenir** : Les deux bibliotheques implementent les memes standards W3C. Le choix depend de votre ecosysteme : .NET pour l'integration C#, Python pour la data science et l'IA.",,,,,,,,98b1131a365dba81,,,,,,,
+> **A retenir** : Les deux bibliotheques implementent les mêmes standards W3C. Le choix depend de votre ecosysteme : .NET pour l'integration C#, Python pour la data science et l'IA.",,,,,,,,f69c9a3f53cb21d9,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,exercises-title,markdown,fr,227dca76e8f2248a,"---
 
 ## Exercices
 
 Mettez en pratique les concepts appris avec ces deux exercices.",,,,,,,,227dca76e8f2248a,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,exercise-1-intro,markdown,fr,7315d3c8596d005b,"### Exemple guide 1 : Reproduire le graphe ""Hello World"" de SW-2
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,exercise-1-intro,markdown,fr,347de3319a26fb3b,"### Exemple guide 1 : Reproduire le graphe ""Hello World"" de SW-2
 
-Dans le notebook SW-2 (dotNetRDF), nous avons cree un graphe contenant :
+Dans le notebook SW-2 (dotNetRDF), nous avons créé un graphe contenant :
 ```
 <http://www.dotnetrdf.org>  <http://example.org/says>  ""Hello World""
 <http://www.dotnetrdf.org>  <http://example.org/says>  ""Bonjour tout le Monde""@fr
 ```
 
-Voici la reproduction en Python avec rdflib.",,,,,,,,7315d3c8596d005b,,,,,,,
+Voici la reproduction en Python avec rdflib.",,,,,,,,347de3319a26fb3b,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,exercise-1-code,code,fr,37e704009053e01e,"if RDFLIB_AVAILABLE:
     # Exemple guide 1 : Reproduire le graphe Hello World de SW-2
     g_hello = Graph()
@@ -8735,7 +8735,7 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,exercise-2
     print(g_book.serialize(format=""turtle""))
 else:
     print(""rdflib non disponible : exemple 2 ignore."")",,,,,,,,9ea164f10d227ecd,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,37e5c168,markdown,fr,95b55512d2783b90,"### Interpretation : Graphe de livre
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,37e5c168,markdown,fr,a1761861663e4ad6,"### Interpretation : Graphe de livre
 
 Le graphe obtenu illustre les trois types de noeuds RDF :
 
@@ -8743,7 +8743,7 @@ Le graphe obtenu illustre les trois types de noeuds RDF :
 |-------|------|---------|
 | `ex:Book123` | URIRef | Ressource identifiee (le livre) |
 | `""Le Petit Prince""` | Literal | Valeur textuelle simple |
-| `96` | Literal (XSD.integer) | Valeur numerique typee |
+| `96` | Literal (XSD.integer) | Valeur numérique typee |
 | `""Un conte philosophique...""@fr` | Literal (lang) | Valeur avec langue |
 | `_:N...` (editeur) | BNode | Noeud anonyme pour l'editeur |
 
@@ -8751,8 +8751,8 @@ Le graphe obtenu illustre les trois types de noeuds RDF :
 - Le mot-cle `a` est un raccourci pour `rdf:type`
 - Les proprietes d'un même sujet sont separées par `;`
 - Le blank node editeur est representé avec la notation `[ ... ]` (embarquée)
-- L'entier `96` est écrit sans guillemets (syntaxe Turtle pour les types XSD courants)",,,,,,,,95b55512d2783b90,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,summary-title,markdown,fr,11c7dc2280247d9a,"---
+- L'entier `96` est écrit sans guillemets (syntaxe Turtle pour les types XSD courants)",,,,,,,,a1761861663e4ad6,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,summary-title,markdown,fr,9be0fc61e4962bf4,"---
 
 ## Resume
 
@@ -8762,37 +8762,37 @@ Ce sidetrack a presente les fondamentaux de **rdflib**, l'equivalent Python de d
 
 | Concept | Ce que vous avez appris |
 |---------|------------------------|
-| **rdflib** | Creer des graphes, ajouter des triples, gerer les namespaces |
+| **rdflib** | Créer des graphes, ajouter des triples, gerer les namespaces |
 | **Types de noeuds** | URIRef, BNode, Literal (avec datatype et lang) |
 | **Serialisation** | Turtle, N-Triples, JSON-LD |
 | **Correspondance** | Equivalences dotNetRDF / rdflib |
 
-### Prochaines etapes
+### Prochaines étapes
 
-- **SW-3-CSharp-GraphOperations** : Manipulation avancee de graphes en .NET (fusion, requetes LINQ)
-- **SW-4b-Python-SPARQL** : Le langage de requete SPARQL en Python
+- **SW-3-CSharp-GraphOperations** : Manipulation avancee de graphes en .NET (fusion, requêtes LINQ)
+- **SW-4b-Python-SPARQL** : Le langage de requête SPARQL en Python
 - **SW-5b-Python-LinkedData** : Interroger DBpedia et Wikidata avec SPARQLWrapper
 
 ---
 
-**Retour au sommaire** : [Index SemanticWeb](README.md)",,,,,,,,11c7dc2280247d9a,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,50b0ec9a,markdown,fr,c64303fada832931,"## Resume et perspectives
+**Retour au sommaire** : [Index SemanticWeb](README.md)",,,,,,,,9be0fc61e4962bf4,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,50b0ec9a,markdown,fr,7034518c279c4b64,"## Resume et perspectives
 
 Ce sidetrack Python a permis de decouvrir **rdflib**, l'equivalent Python de dotNetRDF, et de mettre en parallele les deux ecosystemes. Nous avons explore la creation de graphes RDF avec l'API pythonique de rdflib (`g.add((s, p, o))`), les trois types de noeuds fondamentaux (URIRef, BNode, Literal avec datatype et langue), et la serialisation dans les formats standards (Turtle, N-Triples, JSON-LD). Le tableau de correspondance detaille entre dotNetRDF et rdflib constitue une reference utile pour passer d'un ecosysteme a l'autre.
 
-L'exemple guide 3 a montre la construction d'un graphe complet representant une equipe de recherche, combinant URI, blank nodes et litteraux types, puis interrogeant le resultat en SPARQL. Cette approche progressive illustre bien la philosophie de rdflib : des tuples Python simples pour manipuler des donnees RDF, avec un acces direct aux namespaces W3C preconfigures.
+L'exemple guide 3 a montre la construction d'un graphe complet representant une équipe de recherche, combinant URI, blank nodes et litteraux types, puis interrogeant le résultat en SPARQL. Cette approche progressive illustre bien la philosophie de rdflib : des tuples Python simples pour manipuler des données RDF, avec un acces direct aux namespaces W3C preconfigures.
 
-Dans le notebook suivant (**SW-3-CSharp-GraphOperations**), nous retournerons a dotNetRDF pour explorer les operations avancees sur les graphes (fusion, requetes LINQ, listes RDF), tandis que le sidetrack **SW-4b-Python-SPARQL** permettra de mettre en pratique les requetes SPARQL avec rdflib.",,,,,,,,c64303fada832931,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,90d513e0,markdown,fr,7505cf34b1ef58ce,"### Exercice 1 : Creer un graphe de cours
+Dans le notebook suivant (**SW-3-CSharp-GraphOperations**), nous retournerons a dotNetRDF pour explorer les opérations avancees sur les graphes (fusion, requêtes LINQ, listes RDF), tandis que le sidetrack **SW-4b-Python-SPARQL** permettra de mettre en pratique les requêtes SPARQL avec rdflib.",,,,,,,,7034518c279c4b64,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,90d513e0,markdown,fr,954adf09f7d8892b,"### Exercice 1 : Créer un graphe de cours
 
-Creez un graphe RDF decrivant un **cours universitaire** avec :
+Créez un graphe RDF decrivant un **cours universitaire** avec :
 - Un URI pour le cours (`ex:Math101`)
 - Un titre (litteral simple)
 - Un nombre de credits (litteral type integer)
 - Un enseignant (URI)
 - Une description en anglais (litteral avec langue `en`)
 
-Serialisez le resultat en Turtle.",,,,,,,,7505cf34b1ef58ce,,,,,,,
+Serialisez le résultat en Turtle.",,,,,,,,954adf09f7d8892b,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,10f13476,code,fr,667a01b7fdb3dda8,"if RDFLIB_AVAILABLE:
     # TODO etudiant : creer un graphe de cours
     g_course = Graph()
@@ -8829,13 +8829,13 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,f94c21c3,c
     print(""Exercice a completer : explorez et filtrez le graphe"")
 else:
     print(""rdflib non disponible : exercice 2 ignore."")",,,,,,,,423ea86e7b862f2d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,41f918c4,markdown,fr,0f94734cbaa889ac,"### Exercice de synthese : Construire un graphe pour un reseau social
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,41f918c4,markdown,fr,6492a046968b86f9,"### Exercice de synthese : Construire un graphe pour un reseau social
 
-Creez un graphe RDF modelisant un **mini reseau social** avec :
+Créez un graphe RDF modelisant un **mini reseau social** avec :
 - Au moins 3 personnes (URI) avec nom et email
 - Des relations `foaf:knows` entre les personnes
 - Au moins un blank node pour une publication partagee
-- Serialisation en Turtle + une requete SPARQL listant les amis d'une personne",,,,,,,,0f94734cbaa889ac,,,,,,,
+- Serialisation en Turtle + une requête SPARQL listant les amis d'une personne",,,,,,,,6492a046968b86f9,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,ef5e0b54,code,fr,5658d69b98fb6731,"if RDFLIB_AVAILABLE:
     # TODO etudiant : construire un graphe pour un reseau social
     # Indice : inspirez-vous de l'exemple guide 3 (equipe de recherche)
@@ -8848,11 +8848,11 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,ef5e0b54,c
     print(""Exercice a completer : construisez un graphe RDF pour un reseau social"")
 else:
     print(""rdflib non disponible : exercice de synthese ignore."")",,,,,,,,5658d69b98fb6731,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,425fdc5f,markdown,fr,3fc12c7c95e72bc7,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,425fdc5f,markdown,fr,a868fa8637e22793,"---
 
 ## Exemple guide 3 : Construire un graphe RDF complet
 
-Combinez les concepts pour creer un **graphe RDF representant une equipe de recherche** avec ses membres, publications et affiliations.
+Combinez les concepts pour créer un **graphe RDF representant une équipe de recherche** avec ses membres, publications et affiliations.
 
 ### Contraintes
 - Utiliser au moins **3 types de noeuds** : URI, BNode, Literal
@@ -8860,11 +8860,11 @@ Combinez les concepts pour creer un **graphe RDF representant une equipe de rech
 - Serialiser le graphe en **Turtle** et en **JSON-LD**
 - Afficher les triplets avec `for s, p, o in g:`
 
-### Etapes
-1. Creer le graphe avec les namespaces appropries
+### Étapes
+1. Créer le graphe avec les namespaces appropries
 2. Ajouter des personnes (URI), une publication (BNode), des litteraux types
 3. Serialiser en Turtle et JSON-LD
-4. (Bonus) Ecrire une requete SPARQL pour trouver tous les auteurs",,,,,,,,3fc12c7c95e72bc7,,,,,,,
+4. (Bonus) Ecrire une requête SPARQL pour trouver tous les auteurs",,,,,,,,a868fa8637e22793,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,efc3c013,code,fr,7c6ed700f3da1f3d,"if RDFLIB_AVAILABLE:
     # Exemple guide 3 : Construire un graphe RDF complet
     from rdflib import Graph, Namespace, URIRef, BNode, Literal
@@ -8943,11 +8943,11 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,efc3c013,c
         print(row.authorName)
 else:
     print(""rdflib non disponible : exemple guide 3 ignore."")",,,,,,,,7c6ed700f3da1f3d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,51bfb0e1,markdown,fr,4fbcc7165a3c042d,"### Interpretation : Graphe de recherche complet
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb,51bfb0e1,markdown,fr,c7617fc111d369e6,"### Interpretation : Graphe de recherche complet
 
 L'exemple guide 3 combine tous les concepts du notebook dans un graphe realiste :
 
-| Element | Type rdflib | Role dans le graphe |
+| Élément | Type rdflib | Rôle dans le graphe |
 |---------|------------|---------------------|
 | `ex:ResearchTeam` | `URIRef` | Sujet principal, type `foaf:Group` |
 | `ex:AliceMartin`, `ex:BobDupont` | `URIRef` | Membres, type `foaf:Person` |
@@ -8955,22 +8955,22 @@ L'exemple guide 3 combine tous les concepts du notebook dans un graphe realiste 
 | `""Alice Martin""` | `Literal` | Valeur textuelle via `foaf:name` |
 | `""2026-05-20""` | `Literal(XSD.date)` | Date typee via `schema:datePublished` |
 
-**La requete SPARQL** en bonus illustre comment interroger un graphe RDF : elle sélectionne les noms des auteurs d'articles scolaires, prouvant que les deux membres sont bien liés à la publication.
+**La requête SPARQL** en bonus illustre comment interroger un graphe RDF : elle sélectionne les noms des auteurs d'articles scolaires, prouvant que les deux membres sont bien liés à la publication.
 
-> **Note** : La serialization Turtle exploite la notation `[ ... ]` pour les blank nodes, rendant le graphe compact et lisible. En JSON-LD, le même blank node reçoit un identifiant généré (`_:N...`).",,,,,,,,4fbcc7165a3c042d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,10e7f893,markdown,fr,2fb121ae75929668,"# SW-2-RDFBasics
+> **Note** : La serialization Turtle exploite la notation `[ ... ]` pour les blank nodes, rendant le graphe compact et lisible. En JSON-LD, le même blank node reçoit un identifiant généré (`_:N...`).",,,,,,,,c7617fc111d369e6,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,10e7f893,markdown,fr,2553eff4c72a2027,"# SW-2-RDFBasics
 
 **Navigation** : [<< 1-Setup](SW-1-CSharp-Setup.ipynb) | [Index](README.md) | [3-GraphOperations >>](SW-3-CSharp-GraphOperations.ipynb)
 
 ## Les fondamentaux de RDF : Triplets, Noeuds et Serialisation
 
-Ce notebook explore en detail le modele de donnees RDF (Resource Description Framework), la brique fondamentale du Web semantique. Nous etudierons l'anatomie des triplets, les differents types de noeuds, la gestion des espaces de noms et les principaux formats de serialisation.
+Ce notebook explore en detail le modèle de données RDF (Resource Description Framework), la brique fondamentale du Web sémantique. Nous etudierons l'anatomie des triplets, les différents types de noeuds, la gestion des espaces de noms et les principaux formats de serialisation.
 
 ### Objectifs d'apprentissage
 
 A la fin de ce notebook, vous saurez :
 1. Decrire l'anatomie d'un triplet RDF (sujet, predicat, objet) et sa signification
-2. Distinguer et creer les trois types de noeuds : URI, Blank et Literal
+2. Distinguer et créer les trois types de noeuds : URI, Blank et Literal
 3. Configurer des espaces de noms et des prefixes avec `NamespaceMapper`
 4. Serialiser un graphe RDF dans les 4 formats principaux (NTriples, Turtle, RDF/XML, JSON-LD)
 
@@ -8988,12 +8988,12 @@ A la fin de ce notebook, vous saurez :
 ### Prerequis
 - Notebook SW-1-Setup complete
 
-### Duree estimee : 45 minutes",,,,,,,,2fb121ae75929668,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,f6459281,markdown,fr,736099d08f60f3b9,"---
+### Duree estimee : 45 minutes",,,,,,,,2553eff4c72a2027,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,f6459281,markdown,fr,f1b08ff097c701d5,"---
 
 ## 0. Installation de dotNetRDF
 
-Comme dans le notebook precedent, nous commencons par charger la bibliotheque dotNetRDF et ses espaces de noms principaux.",,,,,,,,736099d08f60f3b9,,,,,,,
+Comme dans le notebook précédent, nous commencons par charger la bibliotheque dotNetRDF et ses espaces de noms principaux.",,,,,,,,f1b08ff097c701d5,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,53133886,code,fr,8c64e41517140575,"// Installation du package dotNetRDF (version épinglée pour reproductibilité)
 #r ""nuget: dotNetRDF, 3.2.1""
 
@@ -9006,32 +9006,32 @@ using StringWriter = System.IO.StringWriter;
 
 Console.WriteLine(""dotNetRDF 3.2.1 charge avec succes."");
 Console.WriteLine(""Espaces de noms disponibles : VDS.RDF, VDS.RDF.Parsing, VDS.RDF.Writing"");",,,,,,,,8c64e41517140575,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,9ba0527e,markdown,fr,84384f94656b53b1,"### Interpretation
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,9ba0527e,markdown,fr,e0261448694241e3,"### Interpretation
 
 La cellule ci-dessus installe et importe les trois espaces de noms principaux de dotNetRDF :
 
 | Espace de noms | Contenu | Usage dans ce notebook |
 |----------------|---------|------------------------|
 | `VDS.RDF` | Classes de base (`Graph`, `Triple`, `INode`) | Creation de graphes et de noeuds |
-| `VDS.RDF.Parsing` | Parsers (`TurtleParser`, `RdfXmlParser`) | Lecture de donnees RDF |
+| `VDS.RDF.Parsing` | Parsers (`TurtleParser`, `RdfXmlParser`) | Lecture de données RDF |
 | `VDS.RDF.Writing` | Writers (`NTriplesWriter`, `CompressingTurtleWriter`) | Serialisation de graphes |
 
-> **Note technique** : La version `3.2.1` est epinglee pour garantir la reproductibilite. L'alias `using StringWriter = System.IO.StringWriter` evite un conflit de noms avec `VDS.RDF.Writing.StringWriter`.",,,,,,,,84384f94656b53b1,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,92742223,markdown,fr,f39e25af3a16fcfc,"---
+> **Note technique** : La version `3.2.1` est epinglee pour garantir la reproductibilite. L'alias `using StringWriter = System.IO.StringWriter` evite un conflit de noms avec `VDS.RDF.Writing.StringWriter`.",,,,,,,,e0261448694241e3,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,92742223,markdown,fr,a79136f48fa7ed21,"---
 
 ## 1. Les triplets RDF
 
 ### Anatomie d'un triplet
 
-En RDF, toute information est exprimee sous forme d'un **triplet** compose de trois elements :
+En RDF, toute information est exprimee sous forme d'un **triplet** compose de trois éléments :
 
-> **RDF** (*Resource Description Framework*) est le standard W3C de description de donnees du Web Semantique, defini a l'origine par Lassila & Swick (1999) et raffine dans RDF 1.1 (Cyganiak, Wood & Lanthaler, W3C Recommendation 2014). Le modele de triplet expose ci-dessous en est la brique fondamentale.
+> **RDF** (*Resource Description Framework*) est le standard W3C de description de données du Web Sémantique, défini a l'origine par Lassila & Swick (1999) et raffine dans RDF 1.1 (Cyganiak, Wood & Lanthaler, W3C Recommendation 2014). Le modèle de triplet expose ci-dessous en est la brique fondamentale.
 
 ```
   (Sujet)  ---[Predicat]--->  (Objet)
 ```
 
-| Element | Role | Types autorises |
+| Élément | Rôle | Types autorises |
 |---------|------|-----------------|
 | **Sujet** | La ressource decrite | URI Node, Blank Node |
 | **Predicat** | La relation / propriete | URI Node uniquement |
@@ -9055,7 +9055,7 @@ Un **graphe RDF** est un ensemble de triplets. Visuellement, il forme un graphe 
      +---age---> 30        +---age---> 28
 ```
 
-Creons nos premiers triplets en C#.",,,,,,,,f39e25af3a16fcfc,,,,,,,
+Creons nos premiers triplets en C#.",,,,,,,,a79136f48fa7ed21,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,4cf32b71,code,fr,f7f4b24dd97e62cf,"// Création d'un graphe vide et de nos premiers triplets
 IGraph g = new Graph();
 
@@ -9082,9 +9082,9 @@ foreach (Triple t in g.Triples)
     Console.WriteLine($""  Objet:    {t.Object}"");
     Console.WriteLine();
 }",,,,,,,,f7f4b24dd97e62cf,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,e49cc186,markdown,fr,5e560ce8974cfe0f,"### Interpretation : Premier triplet RDF
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,e49cc186,markdown,fr,83cdd33e6c8a62aa,"### Interpretation : Premier triplet RDF
 
-Nous avons cree un graphe contenant **deux triplets** qui partagent le meme sujet et le meme predicat, mais different par l'objet :
+Nous avons créé un graphe contenant **deux triplets** qui partagent le même sujet et le même predicat, mais différent par l'objet :
 
 | Triplet | Sujet | Predicat | Objet |
 |---------|-------|----------|-------|
@@ -9096,23 +9096,23 @@ Nous avons cree un graphe contenant **deux triplets** qui partagent le meme suje
 2. `UriFactory.Create()` interne les URIs pour optimiser la memoire et accelerer les comparaisons d'egalite.
 3. Le second literal possede une **etiquette de langue** (`""fr""`), ce qui en fait un noeud distinct du premier.
 
-> **Note** : La sortie affichee par les proprietes `Subject`, `Predicate`, `Object` est une representation de debogage, pas une syntaxe RDF standard. Pour une serialisation conforme, il faut utiliser un Writer (cf. section 4).",,,,,,,,5e560ce8974cfe0f,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,72d2a80c,markdown,fr,288ae1697ddc4d68,"---
+> **Note** : La sortie affichée par les proprietes `Subject`, `Predicate`, `Object` est une representation de debogage, pas une syntaxe RDF standard. Pour une serialisation conforme, il faut utiliser un Writer (cf. section 4).",,,,,,,,83cdd33e6c8a62aa,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,72d2a80c,markdown,fr,33475e152212ddc6,"---
 
 ## 2. Types de noeuds
 
-RDF definit trois types de noeuds fondamentaux, representes dans dotNetRDF par des interfaces specifiques.
+RDF définit trois types de noeuds fondamentaux, representes dans dotNetRDF par des interfaces spécifiques.
 
-| Type | Interface dotNetRDF | Notation RDF | Roles autorises |
+| Type | Interface dotNetRDF | Notation RDF | Rôles autorises |
 |------|--------------------|--------------|-----------------|
 | **URI Node** | `IUriNode` | `<http://...>` | Sujet, Predicat, Objet |
 | **Blank Node** | `IBlankNode` | `_:id` | Sujet, Objet |
-| **Literal Node** | `ILiteralNode` | `""valeur""` | Objet uniquement |",,,,,,,,288ae1697ddc4d68,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,7410c515,markdown,fr,d8cf6cfcb89e94ed,"### 2.1 URI Nodes (`IUriNode`)
+| **Literal Node** | `ILiteralNode` | `""valeur""` | Objet uniquement |",,,,,,,,33475e152212ddc6,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,7410c515,markdown,fr,d339a0ac9d80e9e8,"### 2.1 URI Nodes (`IUriNode`)
 
 Les noeuds URI identifient de maniere **unique et globale** une ressource sur le Web. Ils constituent le coeur de RDF : chaque ressource, chaque propriete est identifiee par un URI.
 
-Deux methodes de creation existent dans dotNetRDF.",,,,,,,,d8cf6cfcb89e94ed,,,,,,,
+Deux méthodes de creation existent dans dotNetRDF.",,,,,,,,d339a0ac9d80e9e8,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,3041c7ba,code,fr,82feb35abb0369f2,"IGraph g = new Graph();
 
 // Méthode 1 : URI absolue avec UriFactory
@@ -9128,17 +9128,17 @@ Console.WriteLine($""URI via prefixe : {knows.Uri}"");
 IUriNode alice2 = g.CreateUriNode(""ex:person/Alice"");
 Console.WriteLine($""\nComparaison : {person.Uri} == {alice2.Uri} ? {person.Uri == alice2.Uri}"");
 Console.WriteLine($""Type du noeud : {person.NodeType}"");",,,,,,,,82feb35abb0369f2,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,26f9c4e2,markdown,fr,6990385d4e683a7a,"### Interpretation : Creation d'URI Nodes
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,26f9c4e2,markdown,fr,6f16e4fe3c2a9c35,"### Interpretation : Creation d'URI Nodes
 
-| Methode | Code | Quand l'utiliser |
+| Méthode | Code | Quand l'utiliser |
 |---------|------|------------------|
 | **URI absolue** | `g.CreateUriNode(UriFactory.Create(""...""))` | URIs ponctuelles, URIs externes |
-| **Prefixe QName** | `g.CreateUriNode(""prefix:local"")` | Usage repete d'un meme namespace |
+| **Prefixe QName** | `g.CreateUriNode(""prefix:local"")` | Usage repete d'un même namespace |
 
 **Points cles** :
-1. Les URIs sont des **identifiants globaux** : deux noeuds avec la meme URI sont identiques, meme dans des graphes differents.
+1. Les URIs sont des **identifiants globaux** : deux noeuds avec la même URI sont identiques, même dans des graphes différents.
 2. `UriFactory.Create()` optimise la memoire en **internant** les URIs (une seule instance par URI distincte).
-3. La methode QName necessite que le prefixe soit prealablement declare dans `g.NamespaceMap`.",,,,,,,,6990385d4e683a7a,,,,,,,
+3. La méthode QName necessite que le prefixe soit prealablement declare dans `g.NamespaceMap`.",,,,,,,,6f16e4fe3c2a9c35,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,f5d96f11,markdown,fr,50ee657b56fb545f,"### 2.2 Blank Nodes (`IBlankNode`)
 
 Les **noeuds anonymes** (blank nodes) representent des ressources dont on ne connait pas (ou n'a pas besoin de) l'identifiant global. Ils sont identifies localement par un ID interne au graphe.
@@ -9191,9 +9191,9 @@ Le blank node `_:addr1` sert de **pivot** pour regrouper les proprietes de l'adr
 | **Creation auto** | `g.CreateBlankNode()` genere un ID unique |
 
 > **Bonne pratique** : Preferez les URI Nodes pour les ressources importantes. Reservez les Blank Nodes aux structures intermediaires ou temporaires.",,,,,,,,ad5d85472b03fa81,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,d5bbcdff,markdown,fr,c0cfb691624ef3d0,"### 2.3 Literal Nodes (`ILiteralNode`)
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,d5bbcdff,markdown,fr,13f51a35d11dbb44,"### 2.3 Literal Nodes (`ILiteralNode`)
 
-Les **noeuds literaux** representent des valeurs concretes : texte, nombres, dates, booleens. Ils ne peuvent apparaitre qu'en **position objet** dans un triplet.
+Les **noeuds literaux** representent des valeurs concretes : texte, nombres, dates, booléens. Ils ne peuvent apparaitre qu'en **position objet** dans un triplet.
 
 Trois variantes existent :
 
@@ -9201,7 +9201,7 @@ Trois variantes existent :
 |----------|------------|---------|
 | **Plain literal** | `""texte""` | `""Hello World""` |
 | **Literal avec langue** | `""texte""@lang` | `""Bonjour""@fr` |
-| **Literal type** | `""valeur""^^xsd:type` | `""42""^^xsd:integer` |",,,,,,,,c0cfb691624ef3d0,,,,,,,
+| **Literal type** | `""valeur""^^xsd:type` | `""42""^^xsd:integer` |",,,,,,,,13f51a35d11dbb44,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,28f51f31,code,fr,6df56b115fceed5f,"IGraph g = new Graph();
 
 // --- Variante 1 : Plain literal (chaine simple) ---
@@ -9231,7 +9231,7 @@ Console.WriteLine($""  int      -> {ageExt}"");
 Console.WriteLine($""  double   -> {piExt}"");
 Console.WriteLine($""  DateTime -> {dateExt}"");
 Console.WriteLine($""  bool     -> {boolExt}"");",,,,,,,,6df56b115fceed5f,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,8c36bab2,markdown,fr,5a70d9c3a28125ba,"### Interpretation : Les trois variantes de literals
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,8c36bab2,markdown,fr,5a9b216bf6490c18,"### Interpretation : Les trois variantes de literals
 
 | Variante | Code C# | Notation RDF | Type XSD |
 |----------|---------|-------------|----------|
@@ -9243,11 +9243,11 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,8c36bab2,ma
 | Type bool | `(true).ToLiteral(g)` | `""true""^^xsd:boolean` | `xsd:boolean` |
 
 **Points cles** :
-1. Les methodes d'extension `.ToLiteral()` evitent la construction manuelle des URIs XSD et rendent le code beaucoup plus lisible.
+1. Les méthodes d'extension `.ToLiteral()` evitent la construction manuelle des URIs XSD et rendent le code beaucoup plus lisible.
 2. Un literal **ne peut pas** avoir a la fois un type et une etiquette de langue (c'est l'un ou l'autre).
 3. Sans type ni langue, un literal est considere comme un `xsd:string` par defaut.
 
-> **Note technique** : Les types XSD (XML Schema Datatypes) definissent un ensemble standard de types de donnees utilises dans tout le Web semantique. Pour les types courants (`int`, `DateTime`, etc.), les extensions `.ToLiteral()` produisent automatiquement l'encodage RDF correct.",,,,,,,,5a70d9c3a28125ba,,,,,,,
+> **Note technique** : Les types XSD (XML Schema Datatypes) definissent un ensemble standard de types de données utilises dans tout le Web sémantique. Pour les types courants (`int`, `DateTime`, etc.), les extensions `.ToLiteral()` produisent automatiquement l'encodage RDF correct.",,,,,,,,5a9b216bf6490c18,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,431e484d,markdown,fr,a0a0d41217cd94c8,"### Recapitulatif : les trois types ensemble
 
 Construisons un graphe utilisant les trois types de noeuds en combinaison.",,,,,,,,a0a0d41217cd94c8,,,,,,,
@@ -9290,7 +9290,7 @@ foreach (Triple t in g.Triples)
     string oType = t.Object is IBlankNode ? ""Blank"" : (t.Object is ILiteralNode ? ""Literal"" : ""URI"");
     Console.WriteLine($""  [{sType}] {t.Subject}  -->  {t.Predicate}  -->  [{oType}] {t.Object}"");
 }",,,,,,,,104f0708b8b5f889,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,7dc9d166,markdown,fr,bc54d4d374ed54aa,"### Interpretation : Graphe multi-types
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,7dc9d166,markdown,fr,376d7679913566cc,"### Interpretation : Graphe multi-types
 
 Ce graphe illustre toutes les combinaisons de types rencontrees en pratique :
 
@@ -9298,17 +9298,17 @@ Ce graphe illustre toutes les combinaisons de types rencontrees en pratique :
 |---------|-------|----------|-------|---------|
 | Alice est une Person | URI | URI | URI | Classification |
 | Alice a un nom | URI | URI | Literal@fr | Propriete textuelle multilingue |
-| Alice a 30 ans | URI | URI | Literal^^xsd:int | Propriete numerique |
+| Alice a 30 ans | URI | URI | Literal^^xsd:int | Propriete numérique |
 | Alice connait Bob | URI | URI | URI | Relation entre ressources |
 | Alice a une competence | URI | URI | Blank | Lien vers structure anonyme |
 | La competence s'appelle C# | Blank | URI | Literal | Detail de la structure |
 
-> **Point cle** : Le predicat est **toujours** un URI Node. C'est la seule position contrainte a un seul type.",,,,,,,,bc54d4d374ed54aa,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,a2fe9e6a,markdown,fr,a0e532f70bbac182,"---
+> **Point cle** : Le predicat est **toujours** un URI Node. C'est la seule position contrainte a un seul type.",,,,,,,,376d7679913566cc,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,a2fe9e6a,markdown,fr,e78867ab3b67975f,"---
 
 ## 3. Espaces de noms et prefixes
 
-### Le probleme des URIs longues
+### Le problème des URIs longues
 
 Sans prefixes, chaque URI doit etre ecrite en entier, ce qui rend le code verbeux et difficile a lire :
 
@@ -9324,7 +9324,7 @@ g.CreateUriNode(""foaf:knows"");
 g.CreateUriNode(""foaf:mbox"");
 ```
 
-Les **espaces de noms** (namespaces) associent un **prefixe court** a un **URI de base**. Le `NamespaceMapper` de dotNetRDF gere cette correspondance.",,,,,,,,a0e532f70bbac182,,,,,,,
+Les **espaces de noms** (namespaces) associent un **prefixe court** a un **URI de base**. Le `NamespaceMapper` de dotNetRDF gere cette correspondance.",,,,,,,,e78867ab3b67975f,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,4a2585fc,code,fr,db062f0b6ec3202f,"IGraph g = new Graph();
 
 // Prefixes prédéfinis par dotNetRDF
@@ -9351,7 +9351,7 @@ IUriNode foafName = g.CreateUriNode(""foaf:name"");
 IUriNode dcTitle = g.CreateUriNode(""dc:title"");
 Console.WriteLine($""\nResolution : foaf:name -> {foafName.Uri}"");
 Console.WriteLine($""Resolution : dc:title  -> {dcTitle.Uri}"");",,,,,,,,db062f0b6ec3202f,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,8e9e3e1f,markdown,fr,af950dc76fd16119,"### Interpretation : NamespaceMapper
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,8e9e3e1f,markdown,fr,712be379d039763f,"### Interpretation : NamespaceMapper
 
 **Prefixes predefinis** dans tout graphe dotNetRDF :
 
@@ -9359,19 +9359,19 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,8e9e3e1f,ma
 |---------|-----|-------|
 | `rdf:` | `http://www.w3.org/1999/02/22-rdf-syntax-ns#` | Vocabulaire RDF de base (`type`, `Property`) |
 | `rdfs:` | `http://www.w3.org/2000/01/rdf-schema#` | Schema RDF (`Class`, `subClassOf`, `label`) |
-| `xsd:` | `http://www.w3.org/2001/XMLSchema#` | Types de donnees (`integer`, `string`, `dateTime`) |
+| `xsd:` | `http://www.w3.org/2001/XMLSchema#` | Types de données (`integer`, `string`, `dateTime`) |
 
 **Prefixes standard recommandes** (a ajouter selon le domaine) :
 
 | Prefixe | URI | Domaine |
 |---------|-----|--------|
 | `foaf:` | `http://xmlns.com/foaf/0.1/` | Personnes et relations sociales |
-| `dc:` | `http://purl.org/dc/elements/1.1/` | Metadonnees Dublin Core |
-| `schema:` | `http://schema.org/` | SEO / donnees structurees (Google) |
+| `dc:` | `http://purl.org/dc/éléments/1.1/` | Metadonnees Dublin Core |
+| `schema:` | `http://schema.org/` | SEO / données structurees (Google) |
 | `skos:` | `http://www.w3.org/2004/02/skos/core#` | Thesaurus et taxonomies |
 | `owl:` | `http://www.w3.org/2002/07/owl#` | Ontologies Web |
 
-> **Bonne pratique** : Declarez vos prefixes en debut de notebook pour eviter les URIs longues dans le code. Le registre officiel des prefixes est disponible sur [prefix.cc](http://prefix.cc).",,,,,,,,af950dc76fd16119,,,,,,,
+> **Bonne pratique** : Declarez vos prefixes en debut de notebook pour eviter les URIs longues dans le code. Le registre officiel des prefixes est disponible sur [prefix.cc](http://prefix.cc).",,,,,,,,712be379d039763f,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,87c80bec,markdown,fr,e01d9de05291237a,"### Resolution et reduction d'URIs
 
 Le `NamespaceMapper` fonctionne dans les deux sens : resolution (prefixe vers URI complete) et reduction (URI complete vers prefixe).",,,,,,,,e01d9de05291237a,,,,,,,
@@ -9393,17 +9393,17 @@ if (g.NamespaceMap.ReduceToQName(testUri.ToString(), out reduced))
 // Vérification d'existence de préfixes
 Console.WriteLine($""\nPrefixe 'foaf' existe ? {g.NamespaceMap.HasNamespace(""foaf"")}"");
 Console.WriteLine($""Prefixe 'owl' existe ?  {g.NamespaceMap.HasNamespace(""owl"")}"");",,,,,,,,9655456aa727dabd,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,f250cc5b,markdown,fr,7db50b9f7286f927,"### Interpretation : Operations sur les namespaces
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,f250cc5b,markdown,fr,d242207d12289c2a,"### Interpretation : Opérations sur les namespaces
 
-| Operation | Methode | Direction |
+| Opération | Méthode | Direction |
 |-----------|---------|----------|
 | **Ajout** | `AddNamespace(prefix, uri)` | Declaration d'un prefixe |
 | **Resolution** | `GetNamespaceUri(prefix)` | Prefixe -> URI complete |
 | **Reduction** | `ReduceToQName(uri, out qname)` | URI complete -> Prefixe:local |
 | **Verification** | `HasNamespace(prefix)` | Le prefixe existe-t-il ? |
 
-> **Note technique** : Les prefixes sont essentiels pour la lisibilite en Turtle et en SPARQL. Les Writers de dotNetRDF les utilisent automatiquement lors de la serialisation.",,,,,,,,7db50b9f7286f927,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,2fd14cca,markdown,fr,27415b0dc95e240b,"---
+> **Note technique** : Les prefixes sont essentiels pour la lisibilite en Turtle et en SPARQL. Les Writers de dotNetRDF les utilisent automatiquement lors de la serialisation.",,,,,,,,d242207d12289c2a,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,2fd14cca,markdown,fr,6d7cea87b309707e,"---
 
 ## 4. Formats de serialisation
 
@@ -9411,7 +9411,7 @@ Un graphe RDF est une structure abstraite (un ensemble de triplets). Pour le sto
 
 Ces formats sont normalises par le **W3C** : NTriples et Turtle (Beckett & Berners-Lee, W3C Rec 2014), RDF/XML (W3C Rec 1999, revise en RDF 1.1 en 2014) et JSON-LD (Speicher, Kellogg et al., W3C Rec 2014/2020). Les vocabulaires couramment utilises (`foaf:`, `dc:`, `skos:`) renvoient respectivement a FOAF (Brickley & Miller), Dublin Core (DCMI Metadata Terms) et SKOS (Miles & Bechhofer, W3C Rec 2009).
 
-Nous allons creer un graphe de reference, puis le serialiser dans chaque format pour comparer.",,,,,,,,27415b0dc95e240b,,,,,,,
+Nous allons créer un graphe de reference, puis le serialiser dans chaque format pour comparer.",,,,,,,,6d7cea87b309707e,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,146feb7d,code,fr,772ef81604dec2a6,"// Graphe de référence pour les démonstrations de sérialisation
 IGraph demo = new Graph();
 demo.NamespaceMap.AddNamespace(""ex"", UriFactory.Create(""http://example.org/""));
@@ -9446,20 +9446,20 @@ string ntOutput = sw.ToString();
 Console.WriteLine(""=== Format NTriples ==="");
 Console.WriteLine(ntOutput);
 Console.WriteLine($""Taille : {ntOutput.Length} caracteres"");",,,,,,,,01bc56df757ff349,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,90efd7b3,markdown,fr,4572fba9ccf6b18b,"### Interpretation : Format NTriples
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,90efd7b3,markdown,fr,5fc497db67be6867,"### Interpretation : Format NTriples
 
 **Conventions syntaxiques** :
 - URIs toujours entre chevrons : `<http://example.org/Alice>`
 - Literals entre guillemets : `""Alice Dupont""`
-- Etiquettes de langue apres le literal : `""Bonjour""@fr`
+- Etiquettes de langue après le literal : `""Bonjour""@fr`
 - Types indiques par `^^` : `""30""^^<http://www.w3.org/2001/XMLSchema#integer>`
 - Chaque triplet termine par un point `.`
 
 | Avantage | Inconvenient |
 |----------|--------------|
-| Tres simple a parser | Tres verbeux (URIs repetees integralement) |
+| Très simple a parser | Très verbeux (URIs repetees integralement) |
 | Pas d'ambiguite | Fichiers volumineux |
-| Ideal pour le streaming ligne par ligne | Peu lisible pour un humain |",,,,,,,,4572fba9ccf6b18b,,,,,,,
+| Ideal pour le streaming ligne par ligne | Peu lisible pour un humain |",,,,,,,,5fc497db67be6867,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,0b9ffcf1,markdown,fr,3f8db7e27f6521ca,"### 4.2 Turtle : le format lisible
 
 **Turtle** (Terse RDF Triple Language) est le format le plus lisible pour les humains. Il utilise des prefixes, des abreviations et des regroupements par sujet.",,,,,,,,3f8db7e27f6521ca,,,,,,,
@@ -9472,25 +9472,25 @@ string turtleOutput = sw.ToString();
 Console.WriteLine(""=== Format Turtle ==="");
 Console.WriteLine(turtleOutput);
 Console.WriteLine($""Taille : {turtleOutput.Length} caracteres"");",,,,,,,,161f660fde9c9842,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,2944ef16,markdown,fr,061e95b44b82da8d,"### Interpretation : Format Turtle
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,2944ef16,markdown,fr,17632070380d99bc,"### Interpretation : Format Turtle
 
 Turtle introduit plusieurs **abreviations syntaxiques** :
 
 | Syntaxe | Signification | Exemple |
 |---------|---------------|---------|
 | `@prefix p: <uri> .` | Declaration de prefixe | `@prefix foaf: <http://xmlns.com/foaf/0.1/> .` |
-| `;` | Meme sujet, predicat different | `ex:Alice foaf:name ""Alice"" ; foaf:age 30 .` |
-| `,` | Meme sujet et predicat, objet different | `ex:Alice foaf:knows ex:Bob, ex:Carol .` |
+| `;` | Même sujet, predicat différent | `ex:Alice foaf:name ""Alice"" ; foaf:age 30 .` |
+| `,` | Même sujet et predicat, objet différent | `ex:Alice foaf:knows ex:Bob, ex:Carol .` |
 | `a` | Raccourci pour `rdf:type` | `ex:Alice a foaf:Person .` |
 | `.` | Fin de la description du sujet | Termine le bloc |
 
 | Avantage | Inconvenient |
 |----------|--------------|
-| Tres lisible et compact | Parsing plus complexe que NTriples |
+| Très lisible et compact | Parsing plus complexe que NTriples |
 | Syntaxe proche de SPARQL | Necessite la declaration des prefixes |
 | Format prefere pour la documentation | Moins adapte au streaming |
 
-> **Bonne pratique** : Utilisez `CompressingTurtleWriter` plutot que `TurtleWriter` pour beneficier de toutes les compressions syntaxiques (`a`, `;`, `,`).",,,,,,,,061e95b44b82da8d,,,,,,,
+> **Bonne pratique** : Utilisez `CompressingTurtleWriter` plutot que `TurtleWriter` pour beneficier de toutes les compressions syntaxiques (`a`, `;`, `,`).",,,,,,,,17632070380d99bc,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,279aaf86,markdown,fr,d31af492bec4c33e,"### 4.3 RDF/XML : le format historique
 
 **RDF/XML** est le premier format de serialisation RDF, standardise par le W3C en 1999. Il utilise la syntaxe XML avec des espaces de noms.",,,,,,,,d31af492bec4c33e,,,,,,,
@@ -9503,9 +9503,9 @@ string rdfXmlOutput = sw.ToString();
 Console.WriteLine(""=== Format RDF/XML ==="");
 Console.WriteLine(rdfXmlOutput);
 Console.WriteLine($""Taille : {rdfXmlOutput.Length} caracteres"");",,,,,,,,c299562fa8940872,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,b8a02a0a,markdown,fr,a59b1b9f36eb4757,"### Interpretation : Format RDF/XML
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,b8a02a0a,markdown,fr,2f7a80944ac1a54b,"### Interpretation : Format RDF/XML
 
-| Element XML | Signification RDF |
+| Élément XML | Signification RDF |
 |-------------|-------------------|
 | `<rdf:RDF>` | Racine du document RDF |
 | `<rdf:Description rdf:about=""..."">` | Declaration d'un sujet |
@@ -9516,12 +9516,12 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,b8a02a0a,ma
 |----------|--------------|
 | Standard W3C historique | Verbeux (syntaxe XML) |
 | Compatible outils XML (XSLT, XPath) | Peu lisible |
-| Bon support dans les frameworks | Plusieurs serialisations possibles pour le meme graphe |
+| Bon support dans les frameworks | Plusieurs serialisations possibles pour le même graphe |
 
-> **Note** : Le writer genere automatiquement des prefixes `nsX` pour les URIs non declarees dans le `NamespaceMap`. RDF/XML est de moins en moins utilise au profit de Turtle et JSON-LD.",,,,,,,,a59b1b9f36eb4757,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,555cfd0d,markdown,fr,d01437a92d1f143d,"### 4.4 JSON-LD : le format moderne
+> **Note** : Le writer genere automatiquement des prefixes `nsX` pour les URIs non declarees dans le `NamespaceMap`. RDF/XML est de moins en moins utilise au profit de Turtle et JSON-LD.",,,,,,,,2f7a80944ac1a54b,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,555cfd0d,markdown,fr,5dc8876bb2d9a769,"### 4.4 JSON-LD : le format moderne
 
-**JSON-LD** (JSON for Linked Data) encode des donnees RDF dans du JSON standard. C'est le format privilegie pour les APIs Web et le SEO (Schema.org utilise par Google).",,,,,,,,d01437a92d1f143d,,,,,,,
+**JSON-LD** (JSON for Linked Data) encode des données RDF dans du JSON standard. C'est le format privilegie pour les APIs Web et le SEO (Schema.org utilise par Google).",,,,,,,,5dc8876bb2d9a769,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,b95bfb90,code,fr,60560d7dacb614ae,"// Sérialisation en JSON-LD
 // Note : JsonLdWriter implémente IStoreWriter (pas IRdfWriter)
 // Il faut donc envelopper le graphe dans un TripleStore
@@ -9555,32 +9555,32 @@ JSON-LD utilise des mots-cles speciaux prefixes par `@` :
 | Compatible ecosysteme JSON / JavaScript | Moins compact que Turtle |
 | Utilise par Schema.org et Google | Contextualisation peut etre complexe |
 | Facile a integrer dans les APIs REST | Plusieurs formes (expanded, compacted, flattened) |",,,,,,,,b2aa7353c33aab63,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,ab14289a,markdown,fr,973bc7a47d282a69,"### Comparaison des 4 formats
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,ab14289a,markdown,fr,76a8461ce69e688a,"### Comparaison des 4 formats
 
 | Critere | NTriples | Turtle | RDF/XML | JSON-LD |
 |---------|----------|--------|---------|--------|
 | **Lisibilite** | Faible | Excellente | Faible | Bonne |
 | **Compacite** | Faible | Elevee | Moyenne | Moyenne |
-| **Complexite de parsing** | Tres faible | Moyenne | Elevee | Moyenne |
+| **Complexite de parsing** | Très faible | Moyenne | Elevee | Moyenne |
 | **Prefixes** | Non | Oui (`@prefix`) | Oui (`xmlns`) | Oui (`@context`) |
 | **Streaming** | Oui (ligne par ligne) | Difficile | Difficile | Non |
-| **Usage principal** | Dump de donnees | Documentation, SPARQL | Interoperabilite XML | APIs Web, SEO |
+| **Usage principal** | Dump de données | Documentation, SPARQL | Interoperabilite XML | APIs Web, SEO |
 | **Writer dotNetRDF** | `NTriplesWriter` | `CompressingTurtleWriter` | `RdfXmlWriter` | `JsonLdWriter` |
 
-> **Recommandation** : Utilisez **Turtle** pour la lisibilite et le travail humain, **NTriples** pour les traitements batch et le streaming, **JSON-LD** pour les APIs Web et le SEO.",,,,,,,,973bc7a47d282a69,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,238f34c3,markdown,fr,ef70b85ccec1531b,"---
+> **Recommandation** : Utilisez **Turtle** pour la lisibilite et le travail humain, **NTriples** pour les traitements batch et le streaming, **JSON-LD** pour les APIs Web et le SEO.",,,,,,,,76a8461ce69e688a,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,238f34c3,markdown,fr,5b232c9e39a95134,"---
 
 ## 5. Exemple guide 1 : Modeliser un reseau social
 
-**Objectif** : Creer un graphe RDF modelisant un petit reseau social avec :
+**Objectif** : Créer un graphe RDF modelisant un petit reseau social avec :
 - 3 personnes (avec nom, age et email)
 - Des relations `foaf:knows` entre elles
 - Au moins un Blank Node (par exemple, une adresse)
-- Serialiser le resultat en Turtle
+- Serialiser le résultat en Turtle
 
 **Vocabulaires a utiliser** : `foaf:` (Friend of a Friend), `ex:` (votre domaine)
 
-Le code ci-dessous est une solution possible. Modifiez-le pour decrire votre propre reseau.",,,,,,,,ef70b85ccec1531b,,,,,,,
+Le code ci-dessous est une solution possible. Modifiez-le pour decrire votre propre reseau.",,,,,,,,5b232c9e39a95134,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,bca0041c,code,fr,64c249d9d5fa265f,"// Exemple guide 1 : Modéliser un réseau social en RDF
 IGraph social = new Graph();
 
@@ -9640,7 +9640,7 @@ turtleWriter.Save(social, sw);
 Console.WriteLine($""Reseau social : {social.Triples.Count} triplets"");
 Console.WriteLine();
 Console.WriteLine(sw.ToString());",,,,,,,,64c249d9d5fa265f,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,d4903638,markdown,fr,ef6d203dd9edf3ca,"### Interpretation de l'Exemple guide 1
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,d4903638,markdown,fr,bcb6ca5b773d2014,"### Interpretation de l'Exemple guide 1
 
 Le graphe modelise un reseau social minimal avec les trois types de noeuds :
 
@@ -9652,14 +9652,14 @@ Le graphe modelise un reseau social minimal avec les trois types de noeuds :
 
 **Observations sur la sortie Turtle** :
 - Les prefixes `@prefix foaf:` et `@prefix ex:` sont declares en tete
-- Les proprietes d'un meme sujet sont regroupees avec `;`
+- Les proprietes d'un même sujet sont regroupees avec `;`
 - L'adresse de Carol apparait comme `_:carolAddr` (Blank Node)
-- Le raccourci `a` remplace `rdf:type` dans la sortie",,,,,,,,ef6d203dd9edf3ca,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,612d2741,markdown,fr,560dd3e8a8c45a6f,"---
+- Le raccourci `a` remplace `rdf:type` dans la sortie",,,,,,,,bcb6ca5b773d2014,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,612d2741,markdown,fr,18efec22dcb2e372,"---
 
 ## 6. Exemple guide 2 : Comparer les tailles de serialisation
 
-**Objectif** : Serialiser le graphe du reseau social dans les differents formats et comparer les tailles obtenues. Cela illustre concretement les differences de compacite entre formats.",,,,,,,,560dd3e8a8c45a6f,,,,,,,
+**Objectif** : Serialiser le graphe du reseau social dans les différents formats et comparer les tailles obtenues. Cela illustre concretement les différences de compacite entre formats.",,,,,,,,18efec22dcb2e372,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,2d3519c7,code,fr,9b3857adce78594d,"// Exemple guide 2 : Comparer les tailles de sérialisation
 
 // Fonction utilitaire pour sérialiser et mesurer
@@ -9704,9 +9704,9 @@ jsonLdWriter.Save(jsonStore, jsonSw);
 string jsonOutput = jsonSw.ToString();
 string jsonRatio = ntSize > 0 ? $""{(double)jsonOutput.Length / ntSize:P0}"" : ""---"";
 Console.WriteLine($""{""JSON-LD"",-12} {jsonOutput.Length,-15} {jsonOutput.Split('\n').Length,-10} {jsonRatio,-15}"");",,,,,,,,9b3857adce78594d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,ef7ab444,markdown,fr,b3337defadee2a83,"### Interpretation de l'Exemple guide 2
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,ef7ab444,markdown,fr,84ce29337e712aac,"### Interpretation de l'Exemple guide 2
 
-**Resultats attendus** (les valeurs exactes varient selon le graphe) :
+**Résultats attendus** (les valeurs exactes varient selon le graphe) :
 
 | Format | Taille relative | Raison |
 |--------|----------------|--------|
@@ -9719,8 +9719,8 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,ef7ab444,ma
 - **Documentation et lecture humaine** : Turtle
 - **Echange machine / streaming** : NTriples
 - **APIs Web et SEO** : JSON-LD
-- **Integration XML** : RDF/XML",,,,,,,,b3337defadee2a83,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,ab4412b7,markdown,fr,7ef27a68c86c666d,"---
+- **Integration XML** : RDF/XML",,,,,,,,84ce29337e712aac,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,ab4412b7,markdown,fr,d2b64df15a26cb49,"---
 
 ## 7. Exercice : a vous de jouer
 
@@ -9732,13 +9732,13 @@ Vous maitrisez maintenant les triplets, les trois types de noeuds, les namespace
 2. Un **literal type** (`xsd:integer`) pour l'annee de publication.
 3. Un **literal avec tag de langue** (`@fr`) pour le titre.
 4. Un **blank node** pour l'auteur, relie au livre via `ex:auteur`, avec un nom (literal simple).
-5. Declarez les prefixes `ex` (http://example.org/) et `dc` (http://purl.org/dc/elements/1.1/).
+5. Declarez les prefixes `ex` (http://example.org/) et `dc` (http://purl.org/dc/éléments/1.1/).
 6. Serialisez le graphe en **Turtle** et affichez-le, puis affichez le nombre de triplets (`g.Triples.Count`).
 
 **Indice** : reutilisez `UriFactory.Create`, `g.CreateLiteralNode(valeur, new Uri(...))` pour le type, `g.CreateLiteralNode(valeur, ""fr"")` pour la langue, `g.CreateBlankNode()`, `g.NamespaceMap.AddNamespace(...)` et `CompressingTurtleWriter`.
 
-Resultat attendu : un graphe de ~5-6 triplets serialise en Turtle lisible.
-",,,,,,,,7ef27a68c86c666d,,,,,,,
+Résultat attendu : un graphe de ~5-6 triplets serialise en Turtle lisible.
+",,,,,,,,d2b64df15a26cb49,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,9cb791ba,markdown,fr,6ea25cad616e1c65,"### Exercice : Construire un graphe avec les 3 types de noeuds
 
 Les sections 2.1-2.3 ont montre les URI Nodes, Blank Nodes et Literal Nodes.
@@ -9779,12 +9779,12 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,1d54cba1,co
 
 Console.WriteLine(""Exercice a completer"");
 ",,,,,,,,e9cd4aa93e5da50f,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,cell-01751f78,markdown,fr,148fcb4bdd51d984,"### Exercice : Creer un graphe RDF complet avec namespaces
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,cell-01751f78,markdown,fr,0baf529b125cd677,"### Exercice : Créer un graphe RDF complet avec namespaces
 
 En utilisant les concepts vus dans ce notebook (URI nodes, literals, blank nodes, namespaces),
 construisez un graphe RDF complet et serialisez-le en Turtle.
 
-**Indices** : utilisez `NamespaceMap`, `UriFactory`, et `CompressingTurtleWriter`.",,,,,,,,148fcb4bdd51d984,,,,,,,
+**Indices** : utilisez `NamespaceMap`, `UriFactory`, et `CompressingTurtleWriter`.",,,,,,,,0baf529b125cd677,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,ffddcdbd,code,fr,e4b0effd2331bb12,"// Exercice : votre code ici
 // Etapes suggerees :
 //   IGraph g = new Graph();
@@ -9797,11 +9797,11 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,ffddcdbd,co
 
 Console.WriteLine(""Exercice a completer"");
 ",,,,,,,,e4b0effd2331bb12,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,d45f0265,markdown,fr,6545a893cb2a0ba5,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,d45f0265,markdown,fr,37d1d34a7cd822c7,"---
 
 ## Resume
 
-| Element | Ce que nous avons appris |
+| Élément | Ce que nous avons appris |
 |---------|-------------------------|
 | **Triplet RDF** | Unite fondamentale (sujet, predicat, objet), asserte avec `g.Assert()` |
 | **URI Nodes** | `IUriNode` : identifiant global, creation par URI absolue ou QName |
@@ -9816,7 +9816,7 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb,d45f0265,ma
 ### Ce qui vient ensuite
 
 Dans le notebook suivant (**SW-3-GraphOperations**), nous apprendrons a :
-- Selectionner des triplets avec `GetTriplesWithXxx()`
+- Sélectionner des triplets avec `GetTriplesWithXxx()`
 - Fusionner et comparer des graphes
 - Lire des fichiers RDF depuis le disque et le Web
 - Convertir entre formats de serialisation
@@ -9835,39 +9835,39 @@ Dans le notebook suivant (**SW-3-GraphOperations**), nous apprendrons a :
 
 ---
 
-**Navigation** :  [<< 1-Setup](SW-1-CSharp-Setup.ipynb) | [Index](README.md) | [3-GraphOperations >>](SW-3-CSharp-GraphOperations.ipynb)",,,,,,,,6545a893cb2a0ba5,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,cded4740e1d7,markdown,fr,9bd0ebc0124b5b62,"# SW-3b-Python-GraphOperations
+**Navigation** :  [<< 1-Setup](SW-1-CSharp-Setup.ipynb) | [Index](README.md) | [3-GraphOperations >>](SW-3-CSharp-GraphOperations.ipynb)",,,,,,,,37d1d34a7cd822c7,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,cded4740e1d7,markdown,fr,0f053619497890ec,"# SW-3b-Python-GraphOperations
 
 **Navigation** : [Index](README.md) | [<< SW-3 C#](SW-3-CSharp-GraphOperations.ipynb) | [SW-4b Python >>](SW-4b-Python-SPARQL.ipynb)
 
-## Operations sur les graphes RDF en Python avec rdflib
+## Opérations sur les graphes RDF en Python avec rdflib
 
 > Ce notebook est le **twin Python** du notebook [SW-3-CSharp-GraphOperations](SW-3-CSharp-GraphOperations.ipynb) (dotNetRDF). Il manipule des **graphes RDF** au moyen de la bibliotheque **rdflib** (open-source, `rdflib.readthedocs.io`), qui implémente le modèle de données abstrait de **RDF 1.1** (Cyganiak, Wood, Lanthaler (eds.), *RDF 1.1 Concepts and Abstract Syntax*, Recommandation W3C, 25 fevrier 2014). Les formats de sérialisation couverts (Turtle, RDF/XML, N-Triples, Notation 3, JSON-LD, TriG, N-Quads) sont tous des sérialisations normalisées de ce modèle abstrait.
 
 ### Duree estimee : 50 minutes
 
 A la fin de ce notebook, vous saurez :
-1. **Lire** des fichiers RDF dans differents formats (Turtle, RDF/XML, N-Triples) avec `rdflib`
+1. **Lire** des fichiers RDF dans différents formats (Turtle, RDF/XML, N-Triples) avec `rdflib`
 2. **Ecrire** des graphes RDF vers plusieurs formats via `g.serialize()`
-3. **Fusionner** des graphes RDF avec l'operateur `+=` et `|` (semantique d'ensemble)
-4. **Selectionner** des triplets selon differents criteres avec `g.triples()` et les accesseurs dedies
-5. **Manipuler** des listes RDF (creer, lire, modifier, supprimer) avec `rdflib.collection.Collection`
+3. **Fusionner** des graphes RDF avec l'opérateur `+=` et `|` (sémantique d'ensemble)
+4. **Sélectionner** des triplets selon différents critères avec `g.triples()` et les accesseurs dedies
+5. **Manipuler** des listes RDF (créer, lire, modifier, supprimer) avec `rdflib.collection.Collection`
 
 ### Prerequis
 - Python 3.10+
 - Avoir complete [SW-2b-Python-RDFBasics](SW-2b-Python-RDFBasics.ipynb)
 
-> **Note** : Ce notebook est le miroir Python de SW-3 (dotNetRDF). La comparaison API dotNetRDF vs rdflib est explicitement documentee dans la section 6.",,,,,,,,9bd0ebc0124b5b62,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,0a93ca502e05,markdown,fr,7c6ae811b8e6222e,"---
+> **Note** : Ce notebook est le miroir Python de SW-3 (dotNetRDF). La comparaison API dotNetRDF vs rdflib est explicitement documentee dans la section 6.",,,,,,,,0f053619497890ec,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,0a93ca502e05,markdown,fr,b8571a7c5fea15e1,"---
 
 ## 0. Installation et Imports
 
-**rdflib** est l'equivalent Python direct de **dotNetRDF**. Elle fournit une API pythonique pour toutes les operations RDF : parsing, serialization, selection, listes.",,,,,,,,7c6ae811b8e6222e,,,,,,,
+**rdflib** est l'equivalent Python direct de **dotNetRDF**. Elle fournit une API pythonique pour toutes les opérations RDF : parsing, serialization, sélection, listes.",,,,,,,,b8571a7c5fea15e1,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,40a1f526dc0b,code,fr,948dfd69d63b0c63,"# Dependances pre-provisionnees (rdflib) : voir SemanticWeb/requirements.txt ; imports dans les cellules suivantes.
 ",,,,,,,,948dfd69d63b0c63,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,cc0b384e4c46,markdown,fr,c0af5bfe8fd34973,"### Interpretation
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,cc0b384e4c46,markdown,fr,993ed569d2295e37,"### Interpretation
 
-L'option `-q` (quiet) reduit la verbosite de pip. Une fois installe, rdflib expose une API pythonique (tuples Python, iterateurs) pour toutes les operations RDF.",,,,,,,,c0af5bfe8fd34973,,,,,,,
+L'option `-q` (quiet) reduit la verbosite de pip. Une fois installe, rdflib expose une API pythonique (tuples Python, iterateurs) pour toutes les opérations RDF.",,,,,,,,993ed569d2295e37,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,a58b5323c865,code,fr,85ff78d3036c7fcc,"from rdflib import Graph, URIRef, Literal, BNode, Namespace
 from rdflib.namespace import RDF, RDFS, XSD
 from rdflib.collection import Collection
@@ -9885,7 +9885,7 @@ try:
 except ImportError:
     RDFLIB_AVAILABLE = False
     print(""rdflib non disponible. Installez avec : pip install rdflib"")",,,,,,,,85ff78d3036c7fcc,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,a9cd33ef9a35,markdown,fr,ced87e0d5436acda,"### Interpretation : imports
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,a9cd33ef9a35,markdown,fr,70f086de4826aba5,"### Interpretation : imports
 
 | Module rdflib | Rôle | Equivalent dotNetRDF |
 |---------------|------|----------------------|
@@ -9894,14 +9894,14 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,a9cd
 | `RDF`, `RDFS`, `XSD` | Namespaces W3C pre-configures | `UriFactory` + `g.NamespaceMap` |
 | `Collection` | Listes RDF (`rdf:first` / `rdf:rest`) | `VDS.RDF.Extensions.GetListItems` |
 
-> Les noeuds rdflib sont **independants du graphe** (`URIRef(""..."")` est autonome), contrairement a dotNetRDF ou les noeuds sont cres via `g.CreateUriNode(...)` (lies au graphe).",,,,,,,,ced87e0d5436acda,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,538c3da5472e,markdown,fr,316dbecb9b2f6eda,"---
+> Les noeuds rdflib sont **independants du graphe** (`URIRef(""..."")` est autonome), contrairement a dotNetRDF ou les noeuds sont créés via `g.CreateUriNode(...)` (lies au graphe).",,,,,,,,70f086de4826aba5,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,538c3da5472e,markdown,fr,5c84a40d3c2a998a,"---
 
 ## 1. Lecture de fichiers RDF
 
-La methode centrale de lecture est `Graph.parse()`, qui accepte un chemin de fichier, une URL, un fichier objet ou une chaine. Formats supportes : `turtle`, `xml`, `nt`, `n3`, `json-ld`, `trig`, `nquads`. rdflib detecte automatiquement le format si l'extension du fichier est connue ou si un `format=` explicite est fourni.
+La méthode centrale de lecture est `Graph.parse()`, qui accepte un chemin de fichier, une URL, un fichier objet ou une chaîne. Formats supportes : `turtle`, `xml`, `nt`, `n3`, `json-ld`, `trig`, `nquads`. rdflib detecte automatiquement le format si l'extension du fichier est connue ou si un `format=` explicite est fourni.
 
-> Chaque format correspond a une Recommandation W3C distincte de la famille **RDF 1.1** : Turtle (Beckett, Berners-Lee, Prud'hommeaux, 2014), N-Triples (Ackaert, Sporny, Kellogg, 2014 - la forme canonique ligne-par-triplet), Notation 3 (Berners-Lee, 2006, note non normative), RDF/XML (Beckett, 2004), JSON-LD (Sporny et al., 2014). TriG et N-Quads etendent ces formats aux *datasets* (graphes nommes).",,,,,,,,316dbecb9b2f6eda,,,,,,,
+> Chaque format correspond a une Recommandation W3C distincte de la famille **RDF 1.1** : Turtle (Beckett, Berners-Lee, Prud'hommeaux, 2014), N-Triples (Ackaert, Sporny, Kellogg, 2014 - la forme canonique ligne-par-triplet), Notation 3 (Berners-Lee, 2006, note non normative), RDF/XML (Beckett, 2004), JSON-LD (Sporny et al., 2014). TriG et N-Quads etendent ces formats aux *datasets* (graphes nommes).",,,,,,,,5c84a40d3c2a998a,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,607d03d6902f,code,fr,1f811869d8c052fa,"# 1.1 Chargement depuis un fichier Turtle
 if RDFLIB_AVAILABLE:
     # Methode A : par chemin de fichier (le plus courant)
@@ -9919,7 +9919,7 @@ if RDFLIB_AVAILABLE:
     print(f""Identique: {len(g) == len(h)}"")
 else:
     print(""rdflib non disponible : lecture ignoree."")",,,,,,,,1f811869d8c052fa,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,36bde774aa1b,markdown,fr,f9a8ce320292955a,"Les deux methodes sont equivalents. `parse(data=...)` accepte des `bytes`, utile quand les donnees RDF proviennent d'une reponse HTTP ou d'un flux in-memory.",,,,,,,,f9a8ce320292955a,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,36bde774aa1b,markdown,fr,92d73e9e99c1a0b8,"Les deux méthodes sont equivalents. `parse(data=...)` accepte des `bytes`, utile quand les données RDF proviennent d'une reponse HTTP ou d'un flux in-memory.",,,,,,,,92d73e9e99c1a0b8,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,98842ff2fcf2,code,fr,58ddaed33b657c43,"# 1.2 Parsing depuis une chaine : format explicite vs auto-detection
 if RDFLIB_AVAILABLE:
     triple_nt = b""<http://example.org/a> <http://example.org/b> <http://example.org/c>.""
@@ -9951,23 +9951,23 @@ if RDFLIB_AVAILABLE:
     print(""       Pour les tres gros fichiers, voir rdflib.parser.Parser + sink custom."")
 else:
     print(""rdflib non disponible : comptage ignore."")",,,,,,,,c1181769ea1300b6,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,1f5b923b30f4,markdown,fr,45cf4445cf434905,"### Interpretation : Methodes de lecture
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,1f5b923b30f4,markdown,fr,deb138d055d200a8,"### Interpretation : Méthodes de lecture
 
-| Methode rdflib | Avantage | Equivalent dotNetRDF |
+| Méthode rdflib | Avantage | Equivalent dotNetRDF |
 |----------------|----------|----------------------|
 | `g.parse(""file.ttl"", format=""turtle"")` | Format explicite, fiable | `TurtleParser.Load(g, ""file.ttl"")` |
 | `g.parse(data=bytes, format=""nt"")` | En memoire, depuis HTTP | `NTriplesParser.Load(g, StringReader(...))` |
 | `g.parse(""file.ttl"")` (sans format) | Auto-detection par extension | `StringParser.Parse(g, str)` |
-| `len(g)` apres `parse()` | Comptage simple | `CountHandler` (sans chargement) |
+| `len(g)` après `parse()` | Comptage simple | `CountHandler` (sans chargement) |
 
-**Difference notable** : dotNetRDF offre une API de **Handlers** (`CountHandler`, `PagingHandler`, `FilterHandler`) qui traitent les triplets en flux SANS construire le graphe en memoire - utile pour les tres gros fichiers. rdflib construit systematiquement le graphe ; pour le streaming massif, il faut descendre a l'API `Parser` + `sink` bas-niveau.
+**Différence notable** : dotNetRDF offre une API de **Handlers** (`CountHandler`, `PagingHandler`, `FilterHandler`) qui traitent les triplets en flux SANS construire le graphe en memoire - utile pour les très gros fichiers. rdflib construit systematiquement le graphe ; pour le streaming massif, il faut descendre a l'API `Parser` + `sink` bas-niveau.
 
-> Les `Graph` rdflib sont **reutilisables** et l'operation `parse()` peut etre appelee plusieurs fois (les triplets s'accumulent).",,,,,,,,45cf4445cf434905,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,ba88fba2619a,markdown,fr,40b35fa727c060f6,"---
+> Les `Graph` rdflib sont **reutilisables** et l'opération `parse()` peut etre appelee plusieurs fois (les triplets s'accumulent).",,,,,,,,deb138d055d200a8,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,ba88fba2619a,markdown,fr,9118a80d15135fb6,"---
 
 ## 2. Ecriture de graphes RDF
 
-La methode centrale de serialization est `Graph.serialize(format=...)` qui retourne une chaine. Pour ecrire directement dans un fichier, utiliser `g.serialize(destination=""file.ttl"", format=...)`. Formats : `turtle`, `nt`, `xml`, `json-ld`, `n3`, `trig`, `nquads`.",,,,,,,,40b35fa727c060f6,,,,,,,
+La méthode centrale de serialization est `Graph.serialize(format=...)` qui retourne une chaîne. Pour ecrire directement dans un fichier, utiliser `g.serialize(destination=""file.ttl"", format=...)`. Formats : `turtle`, `nt`, `xml`, `json-ld`, `n3`, `trig`, `nquads`.",,,,,,,,9118a80d15135fb6,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,1fcd12ade123,code,fr,c32db3bfeee30317,"# 2.1 Comparaison de formats de sortie
 if RDFLIB_AVAILABLE:
     g = Graph()
@@ -9982,13 +9982,13 @@ if RDFLIB_AVAILABLE:
     print(ttl_out)
 else:
     print(""rdflib non disponible : ecriture ignoree."")",,,,,,,,c32db3bfeee30317,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,dfed8669d0e8,markdown,fr,9f036587ae9896b1,"#### Interpretation : Comparaison des formats de sortie
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,dfed8669d0e8,markdown,fr,0e862fc858a1b852,"#### Interpretation : Comparaison des formats de sortie
 
 **N-Triples** : format verbeux - chaque triplet occupe une ligne complete avec les URIs en entier. 4 triplets = 4 lignes. Pas de prefixe, pas de compression.
 
-**Turtle** : format compact - les prefixes sont definis une fois (`@prefix`), les noeuds blancs sont regroupes avec `;` (meme sujet) et les proprietes sont imbriquees avec `[...]`. Le meme graphe tient en moins de lignes.
+**Turtle** : format compact - les prefixes sont définis une fois (`@prefix`), les noeuds blancs sont regroupes avec `;` (même sujet) et les proprietes sont imbriquees avec `[...]`. Le même graphe tient en moins de lignes.
 
-Le ratio de compression est ici d'environ 2:1 (N-Triples plus long que Turtle). Sur des graphes plus grands avec beaucoup de prefixes, le gain peut atteindre 5:1 ou plus.",,,,,,,,9f036587ae9896b1,,,,,,,
+Le ratio de compression est ici d'environ 2:1 (N-Triples plus long que Turtle). Sur des graphes plus grands avec beaucoup de prefixes, le gain peut atteindre 5:1 ou plus.",,,,,,,,0e862fc858a1b852,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,127986a6116a,code,fr,000132e8e3438fe8,"# 2.2 RDF/XML : deux methodes pour obtenir une chaine
 if RDFLIB_AVAILABLE:
     # Methode 1 : serialize() retourne directement la chaine
@@ -10007,7 +10007,7 @@ if RDFLIB_AVAILABLE:
     print(f""\n=== RDF/XML (extrait) ===\n{xml_str[:400]}..."")
 else:
     print(""rdflib non disponible : RDF/XML ignore."")",,,,,,,,000132e8e3438fe8,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,ca6a78313c17,markdown,fr,9cf7d3a144d8847f,"Les deux methodes sont equivalents : `serialize()` sans `destination` retourne une chaine, avec `destination=` ecrit dans un fichier. dotNetRDF proposait `StringWriter.Write(g, writer)` vs `writer.Save(g, sw)` - meme distinction.",,,,,,,,9cf7d3a144d8847f,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,ca6a78313c17,markdown,fr,a25d7fbe8924e203,"Les deux méthodes sont equivalents : `serialize()` sans `destination` retourne une chaîne, avec `destination=` ecrit dans un fichier. dotNetRDF proposait `StringWriter.Write(g, writer)` vs `writer.Save(g, sw)` - même distinction.",,,,,,,,a25d7fbe8924e203,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,7c746252ccbc,code,fr,02b18cba7eb7ddfb,"# 2.3 Configuration avancee des writers
 # rdflib expose moins d'options que dotNetRDF (pas de IPrettyPrintingWriter / ICompressingWriter
 # equivalents). Les options disponibles : indent (int) et sort_keys (booleen) sur certains formats.
@@ -10019,7 +10019,7 @@ if RDFLIB_AVAILABLE:
     print(g.serialize(format=""json-ld"", indent=2))
 else:
     print(""rdflib non disponible : configuration ignoree."")",,,,,,,,02b18cba7eb7ddfb,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,93d5e203bba8,markdown,fr,113eef272cc3af36,"### Interpretation : Writers et configuration
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,93d5e203bba8,markdown,fr,b6d8c6f1a0ba3ab5,"### Interpretation : Writers et configuration
 
 | Format rdflib | Equivalent dotNetRDF | Lisibilite | Taille |
 |---------------|----------------------|------------|--------|
@@ -10028,14 +10028,14 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,93d5
 | `g.serialize(format=""xml"")` | `RdfXmlWriter` | Moyenne | Moyenne |
 | `g.serialize(format=""json-ld"")` | `JsonLdWriter` | Bonne (dev web) | Moyenne |
 
-**Difference notable** : dotNetRDF expose des **interfaces de configuration** riches (`IPrettyPrintingWriter`, `ICompressingWriter` avec `CompressionLevel`, `IHighSpeedWriter`). rdflib est plus minimaliste : l'argument `indent` (JSON-LD) et la convention interne de compression Turtle sont les seuls leviers. Pour un controle fin equivalent, il faut descendre vers des sous-modules (ex : `rdflib.plugins.serializers.turtle`).
+**Différence notable** : dotNetRDF expose des **interfaces de configuration** riches (`IPrettyPrintingWriter`, `ICompressingWriter` avec `CompressionLevel`, `IHighSpeedWriter`). rdflib est plus minimaliste : l'argument `indent` (JSON-LD) et la convention interne de compression Turtle sont les seuls leviers. Pour un contrôle fin equivalent, il faut descendre vers des sous-modules (ex : `rdflib.plugins.serializers.turtle`).
 
-> Tous les formats rdflib sont accessibles via la methode unique `g.serialize(format=...)` - API uniforme, plus simple que dotNetRDF ou chaque writer a sa propre classe.",,,,,,,,113eef272cc3af36,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,c45c44fd8571,markdown,fr,963e8db1d39552f1,"---
+> Tous les formats rdflib sont accessibles via la méthode unique `g.serialize(format=...)` - API uniforme, plus simple que dotNetRDF ou chaque writer a sa propre classe.",,,,,,,,b6d8c6f1a0ba3ab5,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,c45c44fd8571,markdown,fr,7df91ea428b1cc16,"---
 
 ## 3. Fusion de graphes
 
-rdflib implemente la **semantique d'ensemble** des graphes RDF : l'union (operateur `|` ou `+=`) combine deux graphes sans dupliquer les triplets identiques. Les blank nodes sont isoles par graphe (pas de collision).",,,,,,,,963e8db1d39552f1,,,,,,,
+rdflib implemente la **sémantique d'ensemble** des graphes RDF : l'union (opérateur `|` ou `+=`) combine deux graphes sans dupliquer les triplets identiques. Les blank nodes sont isoles par graphe (pas de collision).",,,,,,,,7df91ea428b1cc16,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,859eddd7b275,code,fr,8bfd08fbd37d6984,"# 3.1 Fusion de deux graphes
 if RDFLIB_AVAILABLE:
     g1 = Graph()
@@ -10059,9 +10059,9 @@ if RDFLIB_AVAILABLE:
     print(f""\nOperateur | (new graph): {len(g_union)} triplets (sources intactes: {len(g_a)}, {len(g_b)})"")
 else:
     print(""rdflib non disponible : fusion ignoree."")",,,,,,,,8bfd08fbd37d6984,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,2285ee73b077,markdown,fr,84a0b71f167de159,"### Interpretation : verification manuelle
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,2285ee73b077,markdown,fr,f9b29b64265444be,"### Interpretation : verification manuelle
 
-**Somme theorique** : 4 (Example.ttl) + 51 (animals.ttl) = **55**. Aucun triplet commun (les deux fichiers utilisent des namespaces disjoints : `http://example.org/stuff/1.0/` vs `http://example.org/animals#`), donc **0 doublon supprime**. Le resultat `55` confirme la semantique d'ensemble.
+**Somme théorique** : 4 (Example.ttl) + 51 (animals.ttl) = **55**. Aucun triplet commun (les deux fichiers utilisent des namespaces disjoints : `http://example.org/stuff/1.0/` vs `http://example.org/animals#`), donc **0 doublon supprime**. Le résultat `55` confirme la sémantique d'ensemble.
 
 | Aspect | rdflib | dotNetRDF |
 |--------|--------|-----------|
@@ -10070,14 +10070,14 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,2285
 | Dédoublonnage | Automatique (set semantics) | Automatique |
 | Blank nodes | Isolés par graphe | Renommés pour éviter collision |
 
-- Les triplets identiques ne sont **pas dupliques** (semantique d'ensemble RDF)
+- Les triplets identiques ne sont **pas dupliques** (sémantique d'ensemble RDF)
 - Les blank nodes sont **isoles** par graphe d'origine (pas de collision)
-- `+=` modifie `g1` en place ; `|` retourne un nouveau graphe (API plus pythonique que `Merge`)",,,,,,,,84a0b71f167de159,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,450ade0ea577,markdown,fr,5ec89445bd585b25,"---
+- `+=` modifie `g1` en place ; `|` retourne un nouveau graphe (API plus pythonique que `Merge`)",,,,,,,,f9b29b64265444be,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,450ade0ea577,markdown,fr,730517478ff652e9,"---
 
-## 4. Selection de triplets
+## 4. Sélection de triplets
 
-`Graph` propose la methode generique `g.triples((s, p, o))` ou chaque composante peut etre `None` (joker). Des accesseurs dediees existent : `g.subjects(p, o)`, `g.predicates(s, o)`, `g.objects(s, p)`, `g.subject_instances`, `g.value()` (singleton). Les resultats sont des **generateurs** composables avec les comprehensions Python (equivalent LINQ).",,,,,,,,5ec89445bd585b25,,,,,,,
+`Graph` propose la méthode generique `g.triples((s, p, o))` ou chaque composante peut etre `None` (joker). Des accesseurs dediees existent : `g.subjects(p, o)`, `g.predicates(s, o)`, `g.objects(s, p)`, `g.subject_instances`, `g.value()` (singleton). Les résultats sont des **générateurs** composables avec les comprehensions Python (equivalent LINQ).",,,,,,,,730517478ff652e9,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,45f3ba93386b,code,fr,068f1922e79c55bf,"# 4.1 Selection par predicat et par sujet
 if RDFLIB_AVAILABLE:
     g = Graph()
@@ -10099,13 +10099,13 @@ if RDFLIB_AVAILABLE:
         print(f""  {p.n3(g.namespace_manager)} -> {o.n3(g.namespace_manager)}"")
 else:
     print(""rdflib non disponible : selection ignoree."")",,,,,,,,068f1922e79c55bf,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,c08705b85987,markdown,fr,bcff796151a5da0f,"#### Interpretation : Resultats de la selection
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,c08705b85987,markdown,fr,6d948eba32e36560,"#### Interpretation : Résultats de la sélection
 
-**Selection par predicat** `rdf:type` : **14 triplets** trouves - 6 declarations de classes (Animal, Mammal, Bird, Dog, Cat, Parrot), 4 declarations de proprietes (name, age, sound, canFly) et 4 instances (rex/Dog, minou/Cat, coco/Parrot, buddy/Dog). Verification manuelle sur `animals.ttl` : 6 lignes `a rdfs:Class` + 4 lignes `a rdf:Property` + 4 lignes `a ex:<Classe>` = 14. Confirme.
+**Sélection par predicat** `rdf:type` : **14 triplets** trouves - 6 declarations de classes (Animal, Mammal, Bird, Dog, Cat, Parrot), 4 declarations de proprietes (name, age, sound, canFly) et 4 instances (rex/Dog, minou/Cat, coco/Parrot, buddy/Dog). Verification manuelle sur `animals.ttl` : 6 lignes `a rdfs:Class` + 4 lignes `a rdf:Property` + 4 lignes `a ex:<Classe>` = 14. Confirme.
 
-**Selection par sujet** `ex:rex` : **4 proprietes** - type (Dog), name (Rex), age (5), sound (Woof). Rex est un chien de 5 ans qui fait ""Woof"".
+**Sélection par sujet** `ex:rex` : **4 proprietes** - type (Dog), name (Rex), age (5), sound (Woof). Rex est un chien de 5 ans qui fait ""Woof"".
 
-Ces resultats illustrent que `g.triples((None, RDF.type, None))` retourne tous les usages d'un predicat (types, instances), tandis que `g.triples((rex, None, None))` decrit un noeud complet.",,,,,,,,bcff796151a5da0f,,,,,,,
+Ces résultats illustrent que `g.triples((None, RDF.type, None))` retourne tous les usages d'un predicat (types, instances), tandis que `g.triples((rex, None, None))` decrit un noeud complet.",,,,,,,,6d948eba32e36560,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,0f089af95fd4,code,fr,cdb0e62bfcddaa31,"# 4.2 Selection combinee et comprehension Python (equivalent LINQ)
 if RDFLIB_AVAILABLE:
     EX = Namespace(""http://example.org/animals#"")
@@ -10128,9 +10128,9 @@ if RDFLIB_AVAILABLE:
     print(f""  {oldest[0].n3(g.namespace_manager)} : {oldest[1]} ans"")
 else:
     print(""rdflib non disponible : selection combinee ignoree."")",,,,,,,,cdb0e62bfcddaa31,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,4b75e0f8957b,markdown,fr,689e1cfada2d11fe,"### Interpretation : Methodes de selection
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,4b75e0f8957b,markdown,fr,1de49983a2de44c9,"### Interpretation : Méthodes de sélection
 
-| Methode rdflib | Pattern | Equivalent dotNetRDF | Equivalent SPARQL |
+| Méthode rdflib | Pattern | Equivalent dotNetRDF | Equivalent SPARQL |
 |----------------|---------|----------------------|-------------------|
 | `g.triples((s, None, None))` | `s ? ?` | `GetTriplesWithSubject(s)` | `SELECT ?p ?o WHERE { s ?p ?o }` |
 | `g.triples((None, p, None))` | `? p ?` | `GetTriplesWithPredicate(p)` | `SELECT ?s ?o WHERE { ?s p ?o }` |
@@ -10139,12 +10139,12 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,4b75
 | `g.triples((None, p, o))` | `? p o` | `GetTriplesWithPredicateObject(p,o)` | `SELECT ?s WHERE { ?s p o }` |
 | `g.value(s, p)` | singleton | (via `GetTriplesWithSubjectPredicate`) | `SELECT ?o WHERE { s p ?o } LIMIT 1` |
 
-**Verification manuelle** : la selection `rdf:type` renvoie **14** triplets (cf. cellule precedente), et le filtre ""age > 5"" doit retourner **coco (12)** et **buddy (7)** - ce que confirme la sortie. L'animal le plus age est **coco** a **12 ans**. Les resultats sont des **generateurs** (lazy evaluation), composables avec les comprehensions Python exactement comme `IEnumerable<Triple>` se compose avec LINQ.",,,,,,,,689e1cfada2d11fe,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,f8381e8f3bd8,markdown,fr,1779d842f4adc740,"---
+**Verification manuelle** : la sélection `rdf:type` renvoie **14** triplets (cf. cellule précédente), et le filtre ""age > 5"" doit retourner **coco (12)** et **buddy (7)** - ce que confirme la sortie. L'animal le plus age est **coco** a **12 ans**. Les résultats sont des **générateurs** (lazy evaluation), composables avec les comprehensions Python exactement comme `IEnumerable<Triple>` se compose avec LINQ.",,,,,,,,1de49983a2de44c9,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,f8381e8f3bd8,markdown,fr,d29ab084da06cdd0,"---
 
 ## 5. Listes RDF
 
-Les listes RDF (RDF collections) sont des structures chainees encodees avec `rdf:first` et `rdf:rest`, terminant par `rdf:nil`. rdflib fournit la classe `rdflib.collection.Collection` qui encapsule cette structure avec une API de liste Python standard (`append`, `index`, `len`, iteration, `del`).",,,,,,,,1779d842f4adc740,,,,,,,
+Les listes RDF (RDF collections) sont des structures chainees encodees avec `rdf:first` et `rdf:rest`, terminant par `rdf:nil`. rdflib fournit la classe `rdflib.collection.Collection` qui encapsule cette structure avec une API de liste Python standard (`append`, `index`, `len`, itération, `del`).",,,,,,,,d29ab084da06cdd0,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,5ea15528e65f,code,fr,4b4888c86c6cb34b,"# 5.1 Creer et lire une liste RDF
 if RDFLIB_AVAILABLE:
     g = Graph()
@@ -10184,19 +10184,19 @@ _:b3 rdf:first 3 . _:b3 rdf:rest rdf:nil .
     print(f""Total liste        : {len(first_triples) + len(rest_triples)} triplets"")
 else:
     print(""rdflib non disponible : listes RDF ignorees."")",,,,,,,,4b4888c86c6cb34b,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,a3f2896257f9,markdown,fr,59b7c8573b679c30,"### Interpretation : Structure interne
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,a3f2896257f9,markdown,fr,b50aa3f65d145b17,"### Interpretation : Structure interne
 
 ```
 head -> [1 | rest] -> [2 | rest] -> [3 | rest] -> rdf:nil
 ```
 
-| Element | Methode rdflib | Exemple |
+| Élément | Méthode rdflib | Exemple |
 |---------|----------------|---------|
 | Valeurs (`rdf:first`) | `list(Collection(g, head))` | `[1, 2, 3]` |
 | Noeuds intermediaires | parcours manuel via `rdf:rest` | `_:b1, _:b2, _:b3` |
 | Tous les triplets | `g.triples((None, RDF.first, None))` + `rdf:rest` | 6 triplets (3 first + 3 rest) |
 
-**Verification manuelle** : une liste de 3 elements produit **3** `rdf:first` + **3** `rdf:rest` (le dernier `rdf:rest` pointe vers `rdf:nil`) = **6 triplets**. Confirme par la sortie. Chaque element coute 2 triplets (`rdf:first` + `rdf:rest`), sauf le dernier dont le `rdf:rest` pointe vers `rdf:nil`.",,,,,,,,59b7c8573b679c30,,,,,,,
+**Verification manuelle** : une liste de 3 éléments produit **3** `rdf:first` + **3** `rdf:rest` (le dernier `rdf:rest` pointe vers `rdf:nil`) = **6 triplets**. Confirme par la sortie. Chaque élément coute 2 triplets (`rdf:first` + `rdf:rest`), sauf le dernier dont le `rdf:rest` pointe vers `rdf:nil`.",,,,,,,,b50aa3f65d145b17,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,c13644e58443,code,fr,1d69d1f056fb3749,"# 5.2 Ajout et suppression d'elements : Collection.append + del col[index]
 if RDFLIB_AVAILABLE:
     # Repartons d'une liste fraiche [1, 2, 3]
@@ -10221,17 +10221,17 @@ if RDFLIB_AVAILABLE:
     print(f""Apres del '3'   : {fmt(col2)}"")
 else:
     print(""rdflib non disponible : ajout/suppression ignores."")",,,,,,,,1d69d1f056fb3749,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,0713ec95d6ea,markdown,fr,1f90bd013110e545,"#### Interpretation : API des listes
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,0713ec95d6ea,markdown,fr,c26716fd5a485a54,"#### Interpretation : API des listes
 
-| Operation | dotNetRDF | rdflib |
+| Opération | dotNetRDF | rdflib |
 |-----------|-----------|--------|
-| **Creer** | `g.AssertList(elements)` | `Collection(g, head, elements)` |
+| **Créer** | `g.AssertList(éléments)` | `Collection(g, head, éléments)` |
 | **Lire** | `g.GetListItems(root)` | `list(Collection(g, head))` |
-| **Ajouter** | `g.AddToList(root, elements)` | `col.append(item)` |
-| **Retirer par valeur** | `g.RemoveFromList(root, elements)` | `del col[col.index(item)]` |
+| **Ajouter** | `g.AddToList(root, éléments)` | `col.append(item)` |
+| **Retirer par valeur** | `g.RemoveFromList(root, éléments)` | `del col[col.index(item)]` |
 | **Supprimer tout** | `g.RetractList(root)` | `col.clear()` |
 
-**Difference notable** : `RemoveFromList` (dotNetRDF) retire par **valeur** directement ; rdflib exige de trouver l'**index** puis `del col[index]`. API legerement moins ergonomique pour ce cas, mais conforme a l'idiome Python `del list[i]`.",,,,,,,,1f90bd013110e545,,,,,,,
+**Différence notable** : `RemoveFromList` (dotNetRDF) retire par **valeur** directement ; rdflib exige de trouver l'**index** puis `del col[index]`. API legerement moins ergonomique pour ce cas, mais conforme a l'idiome Python `del list[i]`.",,,,,,,,c26716fd5a485a54,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,f3f4b27e7ef5,code,fr,ce3cdd390f7a53d2,"# 5.3 Cycle complet : creation, ajout, suppression, destruction
 if RDFLIB_AVAILABLE:
     g3 = Graph()
@@ -10258,17 +10258,17 @@ if RDFLIB_AVAILABLE:
     print(f""Apres clear()     : {fmt(col3)} | triplets {avant} -> {len(g3)}"")
 else:
     print(""rdflib non disponible : cycle complet ignore."")",,,,,,,,ce3cdd390f7a53d2,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,a00b9a22cc99,markdown,fr,997777fe8b9f582b,"### Interpretation : API des listes (synthese)
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,a00b9a22cc99,markdown,fr,26563a2316c1d9fe,"### Interpretation : API des listes (synthese)
 
-| Operation | Methode rdflib | Comportement |
+| Opération | Méthode rdflib | Comportement |
 |-----------|----------------|--------------|
-| **Creer** | `Collection(g, head, [items])` | Genere blank nodes + triplets `rdf:first`/`rdf:rest` |
+| **Créer** | `Collection(g, head, [items])` | Genere blank nodes + triplets `rdf:first`/`rdf:rest` |
 | **Ajouter** | `col.append(item)` | Ajoute en fin de liste (gere le chainage `rdf:rest`) |
 | **Retirer** | `del col[col.index(item)]` | Supprime par index (recherche de valeur manuelle) |
 | **Supprimer tout** | `col.clear()` | Supprime recursivement tous les triplets |
 
-> **Quand utiliser les listes RDF ?** : Collections ordonnees (sequences, etapes). Pour des ensembles non ordonnes, preferez des triplets individuels - la liste RDF est couteuse (2 triplets par element) et peu query-friendly (pas de `SELECT ?x WHERE { list ?p ?x }` direct).",,,,,,,,997777fe8b9f582b,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,5baf4038d2e2,markdown,fr,a0c51e4aeae76036,"---
+> **Quand utiliser les listes RDF ?** : Collections ordonnees (sequences, étapes). Pour des ensembles non ordonnes, preferez des triplets individuels - la liste RDF est couteuse (2 triplets par élément) et peu query-friendly (pas de `SELECT ?x WHERE { list ?p ?x }` direct).",,,,,,,,26563a2316c1d9fe,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,5baf4038d2e2,markdown,fr,154518efbe98f3c5,"---
 
 ## 6. Comparaison cross-langage dotNetRDF vs rdflib
 
@@ -10280,17 +10280,17 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,5baf
 | **Lecture** | Classes par format (`TurtleParser`, `NTriplesParser`) + Handlers | API unique `g.parse(format=""..."")` |
 | **Ecriture** | Classes par format + interfaces (`IPrettyPrintingWriter`, `ICompressingWriter`) | API unique `g.serialize(format=""..."")` (options limitees) |
 | **Fusion** | `g1.Merge(g2)` (en place) | `g1 += g2` (en place) ou `g1 \| g2` (nouveau) |
-| **Selection** | `GetTriplesWithXxx(...)` (5 methodes) | `g.triples((s, p, o))` (une methode, `None` = joker) |
+| **Sélection** | `GetTriplesWithXxx(...)` (5 méthodes) | `g.triples((s, p, o))` (une méthode, `None` = joker) |
 | **Listes RDF** | `Extensions.GetListItems`, `AssertList`, `AddToList`, `RetractList` | `rdflib.collection.Collection` (API liste Python) |
 | **Streaming massif** | Handlers (`CountHandler`, `PagingHandler`) - pas de graphe en memoire | Construit systematiquement le graphe (gap) |
-| **LINQ / comprehensions** | `IEnumerable<Triple>` + LINQ (`.Where`, `.Select`, `.Max`) | Generateurs + comprehensions Python (`[x for x in ...]`) |
+| **LINQ / comprehensions** | `IEnumerable<Triple>` + LINQ (`.Where`, `.Select`, `.Max`) | Générateurs + comprehensions Python (`[x for x in ...]`) |
 
-### Differences philosophiques
+### Différences philosophiques
 
-- **dotNetRDF** privilegie l'**explicite** : un type distinct par parser/writer, interfaces de configuration fines, handlers pour le streaming. Avantage : controle precis, typage compile. Inconvenient : verbosite.
-- **rdflib** privilegie l'**uniformite** : une seule methode `parse` / `serialize` avec un argument `format`, tuples Python natifs pour les triples. Avantage : concision, courbe d'apprentissage faible. Inconvenient : moins d'options de configuration, pas de streaming memoire-econome natif.
+- **dotNetRDF** privilegie l'**explicite** : un type distinct par parser/writer, interfaces de configuration fines, handlers pour le streaming. Avantage : contrôle précis, typage compile. Inconvenient : verbosite.
+- **rdflib** privilegie l'**uniformite** : une seule méthode `parse` / `serialize` avec un argument `format`, tuples Python natifs pour les triples. Avantage : concision, courbe d'apprentissage faible. Inconvenient : moins d'options de configuration, pas de streaming memoire-econome natif.
 
-> **A retenir** : Les deux bibliotheques implementent fidelement les memes standards W3C (RDF 1.1, Turtle, N-Triples, RDF/XML, JSON-LD). Les fichiers produits par l'un sont consommables par l'autre. Le choix depend de l'ecosysteme : .NET pour l'integration C# typée, Python pour la data science et l'IA.",,,,,,,,a0c51e4aeae76036,,,,,,,
+> **A retenir** : Les deux bibliotheques implementent fidelement les mêmes standards W3C (RDF 1.1, Turtle, N-Triples, RDF/XML, JSON-LD). Les fichiers produits par l'un sont consommables par l'autre. Le choix depend de l'ecosysteme : .NET pour l'integration C# typée, Python pour la data science et l'IA.",,,,,,,,154518efbe98f3c5,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,52c28c63bbbd,markdown,fr,dc0d2b218b726014,"---
 
 ## 7. Exercices pratiques
@@ -10335,9 +10335,9 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,7932
 # Indice : utilisez g.triples((None, RDF.type, URIRef(""http://example.org/animals#Dog""))) pour (1)
 # et max(..., key=lambda x: x[1]) sur la liste des (sujet, age) pour (3)
 print(""Exercice a completer"")",,,,,,,,be0fb8b171faee5e,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,674f61e43636,markdown,fr,1bb4062969e1cac7,"### Exemple guide 2 : Fusionner et serialiser
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,674f61e43636,markdown,fr,9279b057f7d0d550,"### Exemple guide 2 : Fusionner et serialiser
 
-Chargez `data/Example.ttl` et `data/animals.ttl`, fusionnez-les, et ecrivez le resultat en Turtle compact.",,,,,,,,1bb4062969e1cac7,,,,,,,
+Chargez `data/Example.ttl` et `data/animals.ttl`, fusionnez-les, et ecrivez le résultat en Turtle compact.",,,,,,,,9279b057f7d0d550,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,13bef16eb13f,code,fr,b516a1a353539ef5,"# Exemple guide 2 : Fusion + serialization Turtle
 if RDFLIB_AVAILABLE:
     g1 = Graph()
@@ -10355,9 +10355,9 @@ if RDFLIB_AVAILABLE:
     print(result)
 else:
     print(""rdflib non disponible : exemple 2 ignore."")",,,,,,,,b516a1a353539ef5,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,fff1da298eaa,markdown,fr,34580fde3d4a0374,"### Exercice 5 : Fusion avec donnees en memoire
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,fff1da298eaa,markdown,fr,95993dfe566cbc6a,"### Exercice 5 : Fusion avec données en memoire
 
-Chargez `data/animals.ttl` dans un graphe et la chaine N-Triples suivante dans un autre graphe avec `g.parse(data=..., format=""nt"")` :
+Chargez `data/animals.ttl` dans un graphe et la chaîne N-Triples suivante dans un autre graphe avec `g.parse(data=..., format=""nt"")` :
 
 ```
 <http://example.org/ns#dave> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/ns#Person> .
@@ -10365,7 +10365,7 @@ Chargez `data/animals.ttl` dans un graphe et la chaine N-Triples suivante dans u
 <http://example.org/ns#dave> <http://example.org/ns#age> ""40"" .
 ```
 
-Fusionnez les deux graphes et serialisez le resultat en N-Triples (pas Turtle).",,,,,,,,34580fde3d4a0374,,,,,,,
+Fusionnez les deux graphes et serialisez le résultat en N-Triples (pas Turtle).",,,,,,,,95993dfe566cbc6a,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,e3a70bc1f4ca,code,fr,8457d1b13bb6395d,"# TODO etudiant : Chargez data/animals.ttl dans un graphe g1
 # Chargez la chaine N-Triples ci-dessus dans un graphe g2 avec g2.parse(data=..., format=""nt"")
 # Fusionnez g2 dans g1 (g1 += g2) et affichez le nombre total de triplets
@@ -10373,9 +10373,9 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,e3a7
 #
 # Indice : utilisez g.serialize(format=""nt"") pour la serialisation
 print(""Exercice a completer"")",,,,,,,,8457d1b13bb6395d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,748385520221,markdown,fr,eb7b669bc25e7918,"### Exemple guide 3 : Liste RDF
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,748385520221,markdown,fr,ac5f185192538f53,"### Exemple guide 3 : Liste RDF
 
-Creez une liste `[""Alice"", ""Bob"", ""Charlie""]` avec `Collection`, ajoutez `""Diana""`, supprimez `""Bob""`, affichez le resultat.",,,,,,,,eb7b669bc25e7918,,,,,,,
+Créez une liste `[""Alice"", ""Bob"", ""Charlie""]` avec `Collection`, ajoutez `""Diana""`, supprimez `""Bob""`, affichez le résultat.",,,,,,,,ac5f185192538f53,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,701cb45a086c,code,fr,3123ea3ec9467fd0,"# Exemple guide 3 : Liste RDF avec Collection
 if RDFLIB_AVAILABLE:
     g = Graph()
@@ -10400,22 +10400,22 @@ if RDFLIB_AVAILABLE:
     print(f""Apres suppression: {fmt(col)}"")
 else:
     print(""rdflib non disponible : exemple 3 ignore."")",,,,,,,,3123ea3ec9467fd0,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,01c61ed98956,markdown,fr,4240fac5dd21a9c6,"### Exercice 6 : Liste RDF personnalisee
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,01c61ed98956,markdown,fr,9aa95018c578ed20,"### Exercice 6 : Liste RDF personnalisee
 
-Creez une liste RDF `[""Paris"", ""Lyon"", ""Marseille""]` avec `Collection`, ajoutez `""Toulouse""` avec `col.append(...)`, supprimez `""Lyon""` (index lookup + `del`). Affichez la liste apres chaque operation.",,,,,,,,4240fac5dd21a9c6,,,,,,,
+Créez une liste RDF `[""Paris"", ""Lyon"", ""Marseille""]` avec `Collection`, ajoutez `""Toulouse""` avec `col.append(...)`, supprimez `""Lyon""` (index lookup + `del`). Affichez la liste après chaque opération.",,,,,,,,9aa95018c578ed20,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,cc59074a79e6,code,fr,3535d5bd30f44d96,"# TODO etudiant : Creez une liste RDF [""Paris"", ""Lyon"", ""Marseille""] avec Collection
 # Ajoutez ""Toulouse"" avec col.append(Literal(""Toulouse""))
 # Supprimez ""Lyon"" avec del col[list(col).index(Literal(""Lyon""))]
 # Affichez la liste apres chaque operation avec list(col)
 print(""Exercice a completer"")",,,,,,,,3535d5bd30f44d96,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,2f527127a98e,markdown,fr,14906230ae796c90,"## References savantes
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,2f527127a98e,markdown,fr,9d75888394021a2b,"## References savantes
 
-- **RDF 1.1 Concepts and Abstract Syntax** - Cyganiak, Wood, Lanthaler (eds.), Recommandation W3C, 25 fevrier 2014. Modele de donnees abstrait (triplets sujet-predicat-objet, IRIs, blank nodes, litteraux) dont derivent tous les formats manipules dans ce notebook.
+- **RDF 1.1 Concepts and Abstract Syntax** - Cyganiak, Wood, Lanthaler (eds.), Recommandation W3C, 25 fevrier 2014. Modèle de données abstrait (triplets sujet-predicat-objet, IRIs, blank nodes, litteraux) dont derivent tous les formats manipules dans ce notebook.
 - **RDF 1.1 Turtle** - Beckett, Berners-Lee, Prud'hommeaux, Recommandation W3C, 25 fevrier 2014. Format de serialization compact lisible par l'humain, le plus utilise en pratique.
 - **RDF 1.1 N-Triples** - Ackaert, Sporny, Kellogg, Recommandation W3C, 25 fevrier 2014. Forme canonique ligne-par-triplet, base d'echange interoperaable.
-- **Notation 3 (N3)** - Berners-Lee, *A Rough Guide to Notation 3*, note non normative 2006. Sur-ensemble de Turtle ajoutant regles et citerables.
-- **rdflib** - bibliotheque open-source Python pour la manipulation de graphes RDF (`rdflib.readthedocs.io`), implemente les parsers/serializers uniformes `g.parse()` / `g.serialize()` utilises tout au long de ce notebook.",,,,,,,,14906230ae796c90,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,b0baf31f0c5d,markdown,fr,3f4403bb03734f4a,"---
+- **Notation 3 (N3)** - Berners-Lee, *A Rough Guide to Notation 3*, note non normative 2006. Sur-ensemble de Turtle ajoutant règles et citerables.
+- **rdflib** - bibliotheque open-source Python pour la manipulation de graphes RDF (`rdflib.readthedocs.io`), implemente les parsers/serializers uniformes `g.parse()` / `g.serialize()` utilises tout au long de ce notebook.",,,,,,,,9d75888394021a2b,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,b0baf31f0c5d,markdown,fr,7d21b1fbfa461162,"---
 
 ## Resume
 
@@ -10424,36 +10424,36 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb,b0ba
 | **1. Lecture** | parse, formats, gap Handlers | `g.parse(format=...)`, `len(g)` | `TurtleParser`, `CountHandler` |
 | **2. Ecriture** | serialize, multi-formats | `g.serialize(format=...)` | `NTriplesWriter`, `CompressingTurtleWriter` |
 | **3. Fusion** | Union, deduplication | `g1 += g2`, `g1 \| g2` | `IGraph.Merge()` |
-| **4. Selection** | triples pattern, comprehensions | `g.triples((s,p,o))`, `g.value()` | `GetTriplesWithSubject`, LINQ |
+| **4. Sélection** | triples pattern, comprehensions | `g.triples((s,p,o))`, `g.value()` | `GetTriplesWithSubject`, LINQ |
 | **5. Listes** | Collections ordonnees | `Collection(g, head, items)` | `AssertList`, `GetListItems`, `RetractList` |
 
-### Prochaine etape
+### Prochaine étape
 
 Dans **[SW-4b-Python-SPARQL](SW-4b-Python-SPARQL.ipynb)**, nous apprendrons a interroger les graphes RDF avec le langage SPARQL cote Python (equivalent de SW-4 C#).
 
 ---
 
-**Navigation** : [Index](README.md) | [<< SW-3 C#](SW-3-CSharp-GraphOperations.ipynb) | [SW-4b Python >>](SW-4b-Python-SPARQL.ipynb)",,,,,,,,3f4403bb03734f4a,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,28b116ab,markdown,fr,2c6c54036bafebd5,"# SW-3-GraphOperations
+**Navigation** : [Index](README.md) | [<< SW-3 C#](SW-3-CSharp-GraphOperations.ipynb) | [SW-4b Python >>](SW-4b-Python-SPARQL.ipynb)",,,,,,,,7d21b1fbfa461162,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,28b116ab,markdown,fr,7857fb1eba8b00de,"# SW-3-GraphOperations
 
 **Navigation** : [<< 2-RDFBasics](SW-2-CSharp-RDFBasics.ipynb) | [Index](README.md) | [4-SPARQL >>](SW-4-CSharp-SPARQL.ipynb)
 
-## Operations sur les graphes RDF
+## Opérations sur les graphes RDF
 
 > Ce notebook manipule des **graphes RDF** au moyen de la bibliotheque **dotNetRDF** (open-source, `dotnetrdf.org`), qui implémente le modèle de données abstrait de **RDF 1.1** (Cyganiak, Wood, Lanthaler (eds.), *RDF 1.1 Concepts and Abstract Syntax*, Recommandation W3C, 25 février 2014). Les formats de sérialisation couverts (Turtle, RDF/XML, N-Triples, Notation 3, JSON-LD, TriG, N-Quads) sont tous des sérialisations normalisées de ce modèle abstrait.
 
 ### Duree estimee : 50 minutes
 
 A la fin de ce notebook, vous saurez :
-1. **Lire** des fichiers RDF dans differents formats (Turtle, RDF/XML, NTriples)
-2. **Ecrire** des graphes RDF vers des fichiers et des chaines
+1. **Lire** des fichiers RDF dans différents formats (Turtle, RDF/XML, NTriples)
+2. **Ecrire** des graphes RDF vers des fichiers et des chaînes
 3. **Fusionner** des graphes RDF avec gestion des conflits
-4. **Selectionner** des triplets selon differents criteres et avec LINQ
-5. **Manipuler** des listes RDF (creer, lire, modifier, supprimer)
+4. **Sélectionner** des triplets selon différents critères et avec LINQ
+5. **Manipuler** des listes RDF (créer, lire, modifier, supprimer)
 
 ### Prerequis
 - .NET 9.0 avec .NET Interactive
-- Avoir complete [SW-2-RDFBasics](SW-2-CSharp-RDFBasics.ipynb)",,,,,,,,2c6c54036bafebd5,,,,,,,
+- Avoir complete [SW-2-RDFBasics](SW-2-CSharp-RDFBasics.ipynb)",,,,,,,,7857fb1eba8b00de,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,8bfa1a93,code,fr,995bc9e54000e8a3,"#r ""nuget: dotNetRDF, 3.2.1""",,,,,,,,995bc9e54000e8a3,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,fc43c63a,markdown,fr,50777fd19dc08fef,Importation des espaces de noms dotNetRDF et configuration de l'environnement de travail.,,,,,,,,50777fd19dc08fef,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,79e88dc6,code,fr,49c48fa973a52223,"using VDS.RDF;
@@ -10498,9 +10498,9 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,f9553
 CountHandler handler = new CountHandler();
 new TurtleParser().Load(handler, ""data/animals.ttl"");
 Console.WriteLine($""animals.ttl : {handler.Count} triplets (comptes sans charger en memoire)"");",,,,,,,,39b0d7628e9a437e,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,80b842de,markdown,fr,ece7a747568c17f2,"### Interpretation : Methodes de lecture
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,80b842de,markdown,fr,57876cd801fcd788,"### Interpretation : Méthodes de lecture
 
-| Methode | Avantage | Inconvenient |
+| Méthode | Avantage | Inconvenient |
 |---------|----------|--------------|
 | `TurtleParser` + fichier | Format explicite, fiable | Fichier requis |
 | `StringParser.Parse()` | Detection auto du format | Peut echouer sur fragments ambigus |
@@ -10509,7 +10509,7 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,80b84
 
 **Handlers disponibles** : `GraphHandler` (stockage), `CountHandler` (comptage), `WriteHandler` (transformation), `PagingHandler` (par lots), `FilterHandler` (filtrage).
 
-> Les parsers sont **reutilisables** et **thread-safe**.",,,,,,,,ece7a747568c17f2,,,,,,,
+> Les parsers sont **reutilisables** et **thread-safe**.",,,,,,,,57876cd801fcd788,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,4ac4a2ad,markdown,fr,66e792608464bd74,"---
 
 ## 2. Ecriture de graphes RDF
@@ -10524,14 +10524,14 @@ Console.WriteLine(VDS.RDF.Writing.StringWriter.Write(g, new NTriplesWriter()));
 
 Console.WriteLine(""=== Turtle Compresse ==="");
 Console.WriteLine(VDS.RDF.Writing.StringWriter.Write(g, new CompressingTurtleWriter()));",,,,,,,,d19ccccb2a6c26e5,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,a904fd5c,markdown,fr,597e04cae0698b86,"#### Interpretation : Comparaison des formats de sortie
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,a904fd5c,markdown,fr,b227347a8c854bc3,"#### Interpretation : Comparaison des formats de sortie
 
 **NTriples** : format verbeux — chaque triplet occupe une ligne complete avec les URIs en entier. 4 triplets = 4 lignes. Pas de prefixe, pas de compression.
 
-**Turtle compresse** : format compact — les prefixes sont definis une fois (`@prefix`), les noeuds blancs sont regroupes avec `;` (meme sujet) et les proprietes sont imbriquees avec `[...]`. Le meme graphe tient en 3 lignes au lieu de 4.
+**Turtle compresse** : format compact — les prefixes sont définis une fois (`@prefix`), les noeuds blancs sont regroupes avec `;` (même sujet) et les proprietes sont imbriquees avec `[...]`. Le même graphe tient en 3 lignes au lieu de 4.
 
-Le ratio de compression est ici d'environ 2:1 (NTriples ~400 caracteres vs Turtle ~300 caracteres). Sur des graphes plus grands avec beaucoup de prefixes, le gain peut atteindre 5:1 ou plus.",,,,,,,,597e04cae0698b86,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,1e591449,markdown,fr,73fda60d905e07ff,Serialisation du graphe en RDF/XML via deux methodes equivalentes : helper statique et StringWriter explicite.,,,,,,,,73fda60d905e07ff,,,,,,,
+Le ratio de compression est ici d'environ 2:1 (NTriples ~400 caractères vs Turtle ~300 caractères). Sur des graphes plus grands avec beaucoup de prefixes, le gain peut atteindre 5:1 ou plus.",,,,,,,,b227347a8c854bc3,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,1e591449,markdown,fr,0ce26b3ac98d08bc,Serialisation du graphe en RDF/XML via deux méthodes equivalentes : helper statique et StringWriter explicite.,,,,,,,,0ce26b3ac98d08bc,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,2005646e,code,fr,e1a8a1740566f009,"// 2.2 RDF/XML : deux methodes pour obtenir une chaine
 var rdfxmlwriter = new RdfXmlWriter();
 
@@ -10574,11 +10574,11 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,29d84
 | `IHighSpeedWriter` | Desactive le formatage pour la vitesse |
 
 > Tous les writers sont **reutilisables** et **thread-safe**.",,,,,,,,5cf9964df5439d95,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,80c93be3,markdown,fr,03d603dfd7aca057,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,80c93be3,markdown,fr,bfd8fbb90cd631f7,"---
 
 ## 3. Fusion de graphes
 
-La methode `Merge()` combine deux graphes en respectant la semantique RDF : pas de doublons, renommage des noeuds blancs.",,,,,,,,03d603dfd7aca057,,,,,,,
+La méthode `Merge()` combine deux graphes en respectant la sémantique RDF : pas de doublons, renommage des noeuds blancs.",,,,,,,,bfd8fbb90cd631f7,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,c3daf7a9,code,fr,c794e709362d8260,"// 3.1 Fusion de deux graphes
 Graph g1 = new Graph();
 Graph g2 = new Graph();
@@ -10594,16 +10594,16 @@ Console.WriteLine($""Graphe 2 (animals.ttl) : {g2.Triples.Count} triplets"");
 g1.Merge(g2);
 Console.WriteLine($""Apres fusion           : {g1.Triples.Count} triplets (somme theorique: {somme})"");
 Console.WriteLine($""Doublons supprimes     : {somme - g1.Triples.Count}"");",,,,,,,,c794e709362d8260,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,65c1eaf6,markdown,fr,a640ec76414594e7,"### Interpretation
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,65c1eaf6,markdown,fr,06f444bc348b6540,"### Interpretation
 
-- Les triplets identiques ne sont **pas dupliques** (semantique d'ensemble)
+- Les triplets identiques ne sont **pas dupliques** (sémantique d'ensemble)
 - Les noeuds blancs sont **renommes** pour eviter les collisions
-- L'operation est **asymetrique** : `g1.Merge(g2)` modifie `g1`, pas `g2`",,,,,,,,a640ec76414594e7,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,debfd1ef,markdown,fr,37d1ae60a1c5aa77,"---
+- L'opération est **asymetrique** : `g1.Merge(g2)` modifie `g1`, pas `g2`",,,,,,,,06f444bc348b6540,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,debfd1ef,markdown,fr,863b0c9dd49e46ae,"---
 
-## 4. Selection de triplets
+## 4. Sélection de triplets
 
-`IGraph` propose des methodes `GetTriplesWithXxx()` retournant `IEnumerable<Triple>`, composables avec LINQ.",,,,,,,,37d1ae60a1c5aa77,,,,,,,
+`IGraph` propose des méthodes `GetTriplesWithXxx()` retournant `IEnumerable<Triple>`, composables avec LINQ.",,,,,,,,863b0c9dd49e46ae,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,09019f95,code,fr,033a15e16e415dc3,"// 4.1 Selection par predicat et par sujet
 Graph g = new Graph();
 new TurtleParser().Load(g, ""data/animals.ttl"");
@@ -10620,13 +10620,13 @@ if (rex != null)
     foreach (Triple t in g.GetTriplesWithSubject(rex))
         Console.WriteLine($""  {t}"");
 }",,,,,,,,033a15e16e415dc3,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,f3c4ce9b,markdown,fr,2af34a472b871c3c,"#### Interpretation : Resultats de la selection
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,f3c4ce9b,markdown,fr,503bdc520c40a87e,"#### Interpretation : Résultats de la sélection
 
-**Selection par predicat** `rdf:type` : 14 triplets trouves — 6 declarations de classes (Animal, Mammal, Bird, Dog, Cat, Parrot), 4 declarations de proprietes (name, age, sound, canFly) et 4 instances (rex/Dog, minou/Cat, coco/Parrot, buddy/Dog).
+**Sélection par predicat** `rdf:type` : 14 triplets trouves — 6 declarations de classes (Animal, Mammal, Bird, Dog, Cat, Parrot), 4 declarations de proprietes (name, age, sound, canFly) et 4 instances (rex/Dog, minou/Cat, coco/Parrot, buddy/Dog).
 
-**Selection par sujet** `ex:rex` : 4 proprietes — type (Dog), name (Rex), age (5), sound (Woof). Rex est un chien de 5 ans qui fait ""Woof"".
+**Sélection par sujet** `ex:rex` : 4 proprietes — type (Dog), name (Rex), age (5), sound (Woof). Rex est un chien de 5 ans qui fait ""Woof"".
 
-Ces resultats illustrent que `GetTriplesWithPredicate` retourne tous les usages d'un predicat (types, instances), tandis que `GetTriplesWithSubject` decrit un noeud complet.",,,,,,,,2af34a472b871c3c,,,,,,,
+Ces résultats illustrent que `GetTriplesWithPredicate` retourne tous les usages d'un predicat (types, instances), tandis que `GetTriplesWithSubject` decrit un noeud complet.",,,,,,,,503bdc520c40a87e,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,4df17f1f,markdown,fr,cb657451428bd28e,Combinaison de selections par predicat et par objet avec des expressions LINQ pour filtrer les animaux.,,,,,,,,cb657451428bd28e,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,411d8c2a,code,fr,f28398c4475a3c05,"// 4.2 Selection combinee et LINQ
 IUriNode nameProp = g.CreateUriNode(new Uri(""http://example.org/animals#name""));
@@ -10643,9 +10643,9 @@ var older = g.GetTriplesWithPredicate(ageProp)
 Console.WriteLine(""\n=== Animaux > 5 ans (LINQ) ==="");
 foreach (var a in older)
     Console.WriteLine($""  {a.Animal} : {a.Age}"");",,,,,,,,f28398c4475a3c05,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,9f4b73f3,markdown,fr,2e69c23695cba590,"### Interpretation : Methodes de selection
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,9f4b73f3,markdown,fr,8eba6749eeeb315d,"### Interpretation : Méthodes de sélection
 
-| Methode | Pattern | Equivalent SPARQL |
+| Méthode | Pattern | Equivalent SPARQL |
 |---------|---------|-------------------|
 | `GetTriplesWithSubject(s)` | `s ? ?` | `SELECT ?p ?o WHERE { s ?p ?o }` |
 | `GetTriplesWithPredicate(p)` | `? p ?` | `SELECT ?s ?o WHERE { ?s p ?o }` |
@@ -10653,12 +10653,12 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,9f4b7
 | `GetTriplesWithSubjectPredicate(s,p)` | `s p ?` | `SELECT ?o WHERE { s p ?o }` |
 | `GetTriplesWithPredicateObject(p,o)` | `? p o` | `SELECT ?s WHERE { ?s p o }` |
 
-Les resultats sont des `IEnumerable<Triple>` composables avec LINQ.",,,,,,,,2e69c23695cba590,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,4f4675b6,markdown,fr,cc235c5dfa877db1,"---
+Les résultats sont des `IEnumerable<Triple>` composables avec LINQ.",,,,,,,,8eba6749eeeb315d,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,4f4675b6,markdown,fr,117e0842fa377f59,"---
 
 ## 5. Listes RDF
 
-Les listes RDF sont des structures chainees encodees avec `rdf:first` et `rdf:rest`. dotNetRDF fournit des methodes haut niveau dans `VDS.RDF.Extensions`.",,,,,,,,cc235c5dfa877db1,,,,,,,
+Les listes RDF sont des structures chainees encodees avec `rdf:first` et `rdf:rest`. dotNetRDF fournit des méthodes haut niveau dans `VDS.RDF.Extensions`.",,,,,,,,117e0842fa377f59,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,a7da7223,code,fr,3ba636c14fa7d0dc,"// 5.1 Creer et lire une liste RDF
 IGraph g = new Graph();
 string rdfData = @""
@@ -10678,17 +10678,17 @@ INode root = g.GetTriplesWithPredicate(predicate).First().Object;
 Console.WriteLine($""GetListItems  : [{string.Join("", "", g.GetListItems(root))}]"");
 Console.WriteLine($""GetListNodes  : [{string.Join("", "", g.GetListNodes(root))}]"");
 Console.WriteLine($""GetListAsTriples : {g.GetListAsTriples(root).Count()} triplets"");",,,,,,,,3ba636c14fa7d0dc,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,28eac336,markdown,fr,35f8d8538139e38b,"### Interpretation : Structure interne
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,28eac336,markdown,fr,56c5af4ae4110b10,"### Interpretation : Structure interne
 
 ```
 root -> [1 | rest] -> [2 | rest] -> [3 | rest] -> nil
 ```
 
-| Methode | Retourne | Exemple |
+| Méthode | Retourne | Exemple |
 |---------|----------|---------|
 | `GetListItems(root)` | Valeurs (`rdf:first`) | `1, 2, 3` |
 | `GetListNodes(root)` | Noeuds intermediaires | `_:b1, _:b2, _:b3` |
-| `GetListAsTriples(root)` | Tous les triplets | `rdf:first` + `rdf:rest` |",,,,,,,,35f8d8538139e38b,,,,,,,
+| `GetListAsTriples(root)` | Tous les triplets | `rdf:first` + `rdf:rest` |",,,,,,,,56c5af4ae4110b10,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,a6a83139,code,fr,573e7ac23042105d,"// 5.2 AssertList et RetractList
 INode newRoot = g.AssertList(new List<INode>() { (true).ToLiteral(g), (false).ToLiteral(g) });
 Console.WriteLine($""AssertList    : [{string.Join("", "", g.GetListItems(newRoot))}]"");
@@ -10696,17 +10696,17 @@ Console.WriteLine($""AssertList    : [{string.Join("", "", g.GetListItems(newRoo
 int avant = g.Triples.Count;
 g.RetractList(newRoot);
 Console.WriteLine($""RetractList   : {avant} -> {g.Triples.Count} triplets"");",,,,,,,,573e7ac23042105d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,bf47d2cb,markdown,fr,e008247a0e0887e7,"#### Interpretation : Creation et suppression de liste
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,bf47d2cb,markdown,fr,2ae7902e66ca5a0b,"#### Interpretation : Creation et suppression de liste
 
-**Resultat obtenu** : `AssertList` cree une liste `[true, false]` en generant des noeuds blancs et triplets associes. `RetractList` supprime tous les triplets de la liste.
+**Résultat obtenu** : `AssertList` créé une liste `[true, false]` en generant des noeuds blancs et triplets associes. `RetractList` supprime tous les triplets de la liste.
 
-| Operation | Triplets avant | Triplets apres | Delta |
+| Opération | Triplets avant | Triplets après | Delta |
 |-----------|----------------|----------------|-------|
-| AssertList | 9 (liste initiale 1,2,3) | 11 (+2 elements = +4 triplets: 2x rdf:first + 2x rdf:rest) | +4 |
+| AssertList | 9 (liste initiale 1,2,3) | 11 (+2 éléments = +4 triplets: 2x rdf:first + 2x rdf:rest) | +4 |
 | RetractList | 11 | 7 | -4 |
 
-Chaque element de liste coute 2 triplets (`rdf:first` + `rdf:rest`), sauf le dernier qui pointe vers `rdf:nil`.",,,,,,,,e008247a0e0887e7,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,45ad79cd,markdown,fr,5a4f2f183ac767a9,Ajout et suppression d'elements dans une liste RDF existante avec AddToList et RemoveFromList.,,,,,,,,5a4f2f183ac767a9,,,,,,,
+Chaque élément de liste coute 2 triplets (`rdf:first` + `rdf:rest`), sauf le dernier qui pointe vers `rdf:nil`.",,,,,,,,2ae7902e66ca5a0b,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,45ad79cd,markdown,fr,0e22a5280a6b3515,Ajout et suppression d'éléments dans une liste RDF existante avec AddToList et RemoveFromList.,,,,,,,,0e22a5280a6b3515,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,bf9eb926,code,fr,f0c8ada7fbf4e7bb,"// 5.3 AddToList et RemoveFromList
 Console.WriteLine($""Avant         : [{string.Join("", "", g.GetListItems(root))}]"");
 
@@ -10715,16 +10715,16 @@ Console.WriteLine($""AddToList     : [{string.Join("", "", g.GetListItems(root))
 
 g.RemoveFromList(root, new List<INode>() { (true).ToLiteral(g), (false).ToLiteral(g) });
 Console.WriteLine($""RemoveFromList: [{string.Join("", "", g.GetListItems(root))}]"");",,,,,,,,f0c8ada7fbf4e7bb,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,7003ebb0,markdown,fr,6f9877475b54a26f,"### Interpretation : API des listes
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,7003ebb0,markdown,fr,76a03e35c625a5c8,"### Interpretation : API des listes
 
-| Operation | Methode | Comportement |
+| Opération | Méthode | Comportement |
 |-----------|---------|--------------|
-| **Creer** | `AssertList(elements)` | Genere noeuds blancs + triplets |
-| **Supprimer tout** | `RetractList(root)` | Suppression recursive |
-| **Ajouter** | `AddToList(root, elements)` | Ajoute en fin de liste |
-| **Retirer** | `RemoveFromList(root, elements)` | Supprime toutes les occurrences |
+| **Créer** | `AssertList(éléments)` | Genere noeuds blancs + triplets |
+| **Supprimer tout** | `RetractList(root)` | Suppression récursive |
+| **Ajouter** | `AddToList(root, éléments)` | Ajoute en fin de liste |
+| **Retirer** | `RemoveFromList(root, éléments)` | Supprime toutes les occurrences |
 
-> **Quand utiliser les listes RDF ?** : Collections ordonnees (sequences, etapes). Pour des ensembles non ordonnes, preferez des triplets individuels.",,,,,,,,6f9877475b54a26f,,,,,,,
+> **Quand utiliser les listes RDF ?** : Collections ordonnees (sequences, étapes). Pour des ensembles non ordonnes, preferez des triplets individuels.",,,,,,,,76a03e35c625a5c8,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,af5ef118,markdown,fr,e0b4664fea678622,"---
 
 ## 6. Exercices pratiques",,,,,,,,e0b4664fea678622,,,,,,,
@@ -10768,9 +10768,9 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,7577b
 // Indice : utilisez GetTriplesWithPredicateObject pour (1)
 // et LINQ .Where() + .Max() pour (3)
 Console.WriteLine(""Exercice a completer"");",,,,,,,,acc4a4ddb553d070,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,bbc59365,markdown,fr,786eda35f664ca1c,"### Exemple guide 2 : Fusionner et serialiser
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,bbc59365,markdown,fr,b2227499456c492c,"### Exemple guide 2 : Fusionner et serialiser
 
-Chargez `data/Example.ttl` et `data/animals.ttl`, fusionnez-les, et ecrivez le resultat en Turtle compresse.",,,,,,,,786eda35f664ca1c,,,,,,,
+Chargez `data/Example.ttl` et `data/animals.ttl`, fusionnez-les, et ecrivez le résultat en Turtle compresse.",,,,,,,,b2227499456c492c,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,051116f6,code,fr,30a8bc8b0655e823,"// Chargement des deux graphes : personnes (Example.ttl) et animaux (animals.ttl)
 Graph g1 = new Graph();
 Graph g2 = new Graph();
@@ -10785,9 +10785,9 @@ Console.WriteLine($""Apres fusion : {g1.Triples.Count} triplets"");
 
 string result = VDS.RDF.Writing.StringWriter.Write(g1, new CompressingTurtleWriter());
 Console.WriteLine(result);",,,,,,,,30a8bc8b0655e823,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,6aa0c8b1,markdown,fr,1a642dd50bae3a66,"### Exercice 5 : Fusion avec donnees en memoire
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,6aa0c8b1,markdown,fr,0a763ebc431a4454,"### Exercice 5 : Fusion avec données en memoire
 
-Chargez `data/animals.ttl` dans un graphe et la chaine Turtle suivante dans un autre graphe avec `StringParser.Parse` :
+Chargez `data/animals.ttl` dans un graphe et la chaîne Turtle suivante dans un autre graphe avec `StringParser.Parse` :
 
 ```turtle
 <http://example.org/ns#dave> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/ns#Person> .
@@ -10795,7 +10795,7 @@ Chargez `data/animals.ttl` dans un graphe et la chaine Turtle suivante dans un a
 <http://example.org/ns#dave> <http://example.org/ns#age> ""40"" .
 ```
 
-Fusionnez les deux graphes et serialisez le resultat en NTriples (pas Turtle compresse).",,,,,,,,1a642dd50bae3a66,,,,,,,
+Fusionnez les deux graphes et serialisez le résultat en NTriples (pas Turtle compresse).",,,,,,,,0a763ebc431a4454,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,600b1b7b,code,fr,c9e707ab0f59f2be,"// TODO etudiant : Chargez data/animals.ttl dans un graphe g1
 // Chargez la chaine Turtle ci-dessous dans un graphe g2 avec StringParser.Parse
 // Fusionnez g2 dans g1 et affichez le nombre total de triplets
@@ -10803,9 +10803,9 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,600b1
 //
 // Indice : utilisez new NTriplesWriter() pour la serialisation
 Console.WriteLine(""Exercice a completer"");",,,,,,,,c9e707ab0f59f2be,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,c44cb1ac,markdown,fr,cdce74bef839eef8,"### Exemple guide 3 : Liste RDF
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,c44cb1ac,markdown,fr,9dcf9fc7a0de8428,"### Exemple guide 3 : Liste RDF
 
-Creez une liste `[""Alice"", ""Bob"", ""Charlie""]` avec `AssertList`, ajoutez `""Diana""`, supprimez `""Bob""`, affichez le resultat.",,,,,,,,cdce74bef839eef8,,,,,,,
+Créez une liste `[""Alice"", ""Bob"", ""Charlie""]` avec `AssertList`, ajoutez `""Diana""`, supprimez `""Bob""`, affichez le résultat.",,,,,,,,9dcf9fc7a0de8428,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,7add95a8,code,fr,f2c8952196034212,"// Création d'une liste RDF ordonnée [Alice, Bob, Charlie]
 // AssertList génère une chaîne de nœuds blancs reliés par rdf:first et rdf:rest
 IGraph g = new Graph();
@@ -10825,21 +10825,21 @@ Console.WriteLine($""Apres ajout      : [{fmt(g.GetListItems(root))}]"");
 g.RemoveFromList(root, new List<INode>() { ""Bob"".ToLiteral(g) });
 Console.WriteLine($""Apres suppression: [{fmt(g.GetListItems(root))}]"");
 ",,,,,,,,f2c8952196034212,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,1699593b,markdown,fr,d11c7c24177d285b,"### Exercice 6 : Liste RDF personnalisee
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,1699593b,markdown,fr,c8e8f2d9a0ced41b,"### Exercice 6 : Liste RDF personnalisee
 
-Creez une liste RDF `[""Paris"", ""Lyon"", ""Marseille""]` avec `AssertList`, ajoutez `""Toulouse""` avec `AddToList`, supprimez `""Lyon""` avec `RemoveFromList`. Affichez la liste apres chaque operation.",,,,,,,,d11c7c24177d285b,,,,,,,
+Créez une liste RDF `[""Paris"", ""Lyon"", ""Marseille""]` avec `AssertList`, ajoutez `""Toulouse""` avec `AddToList`, supprimez `""Lyon""` avec `RemoveFromList`. Affichez la liste après chaque opération.",,,,,,,,c8e8f2d9a0ced41b,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,5d3de6f9,code,fr,8a8bc0d6f75d5c0b,"// TODO etudiant : Creez une liste RDF [""Paris"", ""Lyon"", ""Marseille""] avec AssertList
 // Ajoutez ""Toulouse"" avec AddToList, supprimez ""Lyon"" avec RemoveFromList
 // Affichez la liste apres chaque operation avec GetListItems
 Console.WriteLine(""Exercice a completer"");",,,,,,,,8a8bc0d6f75d5c0b,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,sw3-refs-savantes-3164,markdown,fr,44f31bd8d431529a,"## References savantes
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,sw3-refs-savantes-3164,markdown,fr,498a16d28c59cb84,"## References savantes
 
-- **RDF 1.1 Concepts and Abstract Syntax** - Cyganiak, Wood, Lanthaler (eds.), Recommandation W3C, 25 fevrier 2014. Modele de donnees abstrait (triplets sujet-predicat-objet, IRIs, blank nodes, litteraux) dont derivent tous les formats manipules dans ce notebook.
+- **RDF 1.1 Concepts and Abstract Syntax** - Cyganiak, Wood, Lanthaler (eds.), Recommandation W3C, 25 fevrier 2014. Modèle de données abstrait (triplets sujet-predicat-objet, IRIs, blank nodes, litteraux) dont derivent tous les formats manipules dans ce notebook.
 - **RDF 1.1 Turtle** - Beckett, Berners-Lee, Prud'hommeaux, Recommandation W3C, 25 fevrier 2014. Format de serialization compact lisible par l'humain, le plus utilise en pratique.
 - **RDF 1.1 N-Triples** - Ackaert, Sporny, Kellogg, Recommandation W3C, 25 fevrier 2014. Forme canonique ligne-par-triplet, base d'echange interoperaable.
-- **Notation 3 (N3)** - Berners-Lee, *A Rough Guide to Notation 3*, note non normative 2006. Sur-ensemble de Turtle ajoutant regles et citerables.
-- **dotNetRDF** - bibliotheque open-source .NET pour la manipulation de graphes RDF (`dotnetrdf.org`), implemente les parsers/writers `IRdfReader`/`IRdfWriter` utilises tout au long de ce notebook.",,,,,,,,44f31bd8d431529a,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,cc69afcf,markdown,fr,edb94c8b05bd09bc,"---
+- **Notation 3 (N3)** - Berners-Lee, *A Rough Guide to Notation 3*, note non normative 2006. Sur-ensemble de Turtle ajoutant règles et citerables.
+- **dotNetRDF** - bibliotheque open-source .NET pour la manipulation de graphes RDF (`dotnetrdf.org`), implemente les parsers/writers `IRdfReader`/`IRdfWriter` utilises tout au long de ce notebook.",,,,,,,,498a16d28c59cb84,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,cc69afcf,markdown,fr,1a3409cd3b036580,"---
 
 ## Resume
 
@@ -10848,30 +10848,30 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb,cc69a
 | **1. Lecture** | Parsers, StringParser, Handlers | `TurtleParser`, `NTriplesParser`, `CountHandler` |
 | **2. Ecriture** | Writers, configuration | `NTriplesWriter`, `CompressingTurtleWriter`, `RdfXmlWriter` |
 | **3. Fusion** | Merge, deduplication | `IGraph.Merge()` |
-| **4. Selection** | GetTriplesWithXxx, LINQ | `GetTriplesWithSubject`, `GetTriplesWithPredicate` |
+| **4. Sélection** | GetTriplesWithXxx, LINQ | `GetTriplesWithSubject`, `GetTriplesWithPredicate` |
 | **5. Listes** | Collections ordonnees | `AssertList`, `GetListItems`, `AddToList`, `RetractList` |
 
-### Prochaine etape
+### Prochaine étape
 
 Dans **SW-4-SPARQL**, nous apprendrons a interroger les graphes RDF avec le langage SPARQL et le QueryBuilder de dotNetRDF.
 
 ---
 
-**Navigation** : [<< 2-RDFBasics](SW-2-CSharp-RDFBasics.ipynb) | [Index](README.md) | [4-SPARQL >>](SW-4-CSharp-SPARQL.ipynb)",,,,,,,,edb94c8b05bd09bc,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,header-navigation,markdown,fr,bc037509eb7edaf3,"# SW-4b-Python-SPARQL
+**Navigation** : [<< 2-RDFBasics](SW-2-CSharp-RDFBasics.ipynb) | [Index](README.md) | [4-SPARQL >>](SW-4-CSharp-SPARQL.ipynb)",,,,,,,,1a3409cd3b036580,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,header-navigation,markdown,fr,d85ef6feea60b010,"# SW-4b-Python-SPARQL
 
 **Navigation** : [Index](README.md) | [<< SW-4 C#](SW-4-CSharp-SPARQL.ipynb) | [SW-5 C# >>](SW-5-CSharp-LinkedData.ipynb)
 
 ## SPARQL en Python avec rdflib
 
-Ce notebook est un **sidetrack optionnel** qui presente l'equivalent Python des concepts SPARQL du notebook SW-4 (dotNetRDF). Vous y decouvrirez comment executer des requetes SPARQL sur des graphes en memoire avec **rdflib**.
+Ce notebook est un **sidetrack optionnel** qui presente l'equivalent Python des concepts SPARQL du notebook SW-4 (dotNetRDF). Vous y decouvrirez comment executer des requêtes SPARQL sur des graphes en memoire avec **rdflib**.
 
 ### Objectifs d'apprentissage
 
 A la fin de ce notebook, vous saurez :
-1. Executer des requetes SPARQL SELECT sur des graphes rdflib
+1. Executer des requêtes SPARQL SELECT sur des graphes rdflib
 2. Utiliser FILTER, OPTIONAL, UNION et ORDER BY
-3. Interroger des hierarchies de classes RDFS
+3. Interroger des hiérarchies de classes RDFS
 4. Faire la correspondance entre dotNetRDF et rdflib pour SPARQL
 
 ### Prerequis
@@ -10880,7 +10880,7 @@ A la fin de ce notebook, vous saurez :
 
 ### Duree estimee : 25 minutes
 
-> **Note** : Ce notebook se concentre sur SPARQL local. Pour les endpoints distants (DBpedia, Wikidata), voir le sidetrack **SW-5b-Python-LinkedData**.",,,,,,,,bc037509eb7edaf3,,,,,,,
+> **Note** : Ce notebook se concentre sur SPARQL local. Pour les endpoints distants (DBpedia, Wikidata), voir le sidetrack **SW-5b-Python-LinkedData**.",,,,,,,,d85ef6feea60b010,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,section-1-title,markdown,fr,cd9d9f7111e889a5,"---
 
 ## 1. Installation et Preparation
@@ -10912,18 +10912,18 @@ if RDFLIB_AVAILABLE:
             print(f""  @prefix {prefix}: <{uri}> ."")
 else:
     print(""rdflib non disponible : chargement du graphe ignore."")",,,,,,,,4349c6596fe42e0d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,load-interpretation,markdown,fr,bd7c25f07396645f,"### Interpretation
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,load-interpretation,markdown,fr,34b3d741371fe468,"### Interpretation
 
 Le fichier `animals.ttl` contient :
-- Une hierarchie de classes : `Animal > Mammal/Bird > Dog/Cat/Parrot`
+- Une hiérarchie de classes : `Animal > Mammal/Bird > Dog/Cat/Parrot`
 - Des instances avec proprietes : `name`, `age`, `sound`, `canFly`
 
-C'est le meme fichier utilise dans SW-4 (dotNetRDF), ce qui nous permet de comparer directement les syntaxes.",,,,,,,,bd7c25f07396645f,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,section-2-title,markdown,fr,244009935a59e320,"---
+C'est le même fichier utilise dans SW-4 (dotNetRDF), ce qui nous permet de comparer directement les syntaxes.",,,,,,,,34b3d741371fe468,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,section-2-title,markdown,fr,efdb26c83f1c71e3,"---
 
-## 2. Requete SELECT Simple
+## 2. Requête SELECT Simple
 
-Commencons par lister tous les animaux avec leur nom et leur cri.",,,,,,,,244009935a59e320,,,,,,,
+Commencons par lister tous les animaux avec leur nom et leur cri.",,,,,,,,efdb26c83f1c71e3,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,sparql-select,code,fr,f926d368fefd1079,"if RDFLIB_AVAILABLE:
     # Simple SELECT query - list all animals with name and sound
     query = """"""
@@ -10946,11 +10946,11 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,sparql-select
         print(f""{str(row.animal):<35s} {str(row.name):<12s} {str(row.sound):<25s}"")
 else:
     print(""rdflib non disponible : requete SELECT ignoree."")",,,,,,,,f926d368fefd1079,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,sparql-select-interpretation,markdown,fr,e9dac3b321a51199,"### Interpretation : Requete SELECT
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,sparql-select-interpretation,markdown,fr,c5c883df9bbd7c63,"### Interpretation : Requête SELECT
 
-La requete retourne les 4 animaux definis dans `animals.ttl`.
+La requête retourne les 4 animaux définis dans `animals.ttl`.
 
-| Element | Syntaxe SPARQL | Description |
+| Élément | Syntaxe SPARQL | Description |
 |---------|---------------|-------------|
 | PREFIX | `PREFIX ex: <...>` | Declare un prefixe (equivalent de `@prefix` en Turtle) |
 | Variables | `?animal`, `?name` | Variables SPARQL (commencent par `?` ou `$`) |
@@ -10958,17 +10958,17 @@ La requete retourne les 4 animaux definis dans `animals.ttl`.
 | ORDER BY | `ORDER BY ?name` | Tri ascendant |
 
 **rdflib vs dotNetRDF** :
-| Operation | rdflib | dotNetRDF |
+| Opération | rdflib | dotNetRDF |
 |-----------|---------|----------|
-| Executer requete | `g.query(""SELECT..."")` | `g.ExecuteQuery(""SELECT..."")` |
+| Executer requête | `g.query(""SELECT..."")` | `g.ExecuteQuery(""SELECT..."")` |
 | Type de retour | `Result` (iterable) | `SparqlResultSet` |
 | Acces valeur | `row.name` ou `row[1]` | `row[""name""]` |
-| Compter resultats | `len(results)` | `results.Count` |",,,,,,,,e9dac3b321a51199,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,section-3-title,markdown,fr,024fabae68b2a605,"---
+| Compter résultats | `len(results)` | `results.Count` |",,,,,,,,c5c883df9bbd7c63,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,section-3-title,markdown,fr,5b6556152bbf8bfd,"---
 
 ## 3. Filtrage avec FILTER
 
-Le mot-cle `FILTER` applique des conditions aux resultats.",,,,,,,,024fabae68b2a605,,,,,,,
+Le mot-cle `FILTER` applique des conditions aux résultats.",,,,,,,,5b6556152bbf8bfd,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,sparql-filter,code,fr,7746233aa6d86bb0,"if RDFLIB_AVAILABLE:
     # FILTER: find animals older than 4 years
     query_filter = """"""
@@ -10989,11 +10989,11 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,sparql-filter
         print(f""  {row.name} : {row.age} ans"")
 else:
     print(""rdflib non disponible : requete FILTER ignoree."")",,,,,,,,7746233aa6d86bb0,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,filter-explanation,markdown,fr,f9ba26a8692ca344,"### Interpretation : FILTER
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,filter-explanation,markdown,fr,0a8c2eca1cbee409,"### Interpretation : FILTER
 
 Le `FILTER (?age > 4)` ne retient que les animaux dont l'age depasse 4 ans.
 
-| Operateur | Description | Exemple |
+| Opérateur | Description | Exemple |
 |-----------|-------------|----------|
 | Comparaisons | `=`, `!=`, `<`, `>`, `<=`, `>=` | `FILTER (?age > 4)` |
 | Logique | `&&`, `||`, `!` | `FILTER (?age > 4 && ?age < 10)` |
@@ -11001,12 +11001,12 @@ Le `FILTER (?age > 4)` ne retient que les animaux dont l'age depasse 4 ans.
 | Regex | `REGEX()` | `FILTER (REGEX(?name, ""^C""))` |
 | Existence | `BOUND()` | `FILTER (BOUND(?optional))` |
 
-Equivalent dotNetRDF : Meme syntaxe SPARQL, mais `SparqlParameterizedString` pour les requetes parametrees.",,,,,,,,f9ba26a8692ca344,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,section-4-title,markdown,fr,7880cae329bbe46a,"---
+Equivalent dotNetRDF : Même syntaxe SPARQL, mais `SparqlParameterizedString` pour les requêtes parametrees.",,,,,,,,0a8c2eca1cbee409,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,section-4-title,markdown,fr,7cd88333b3d3429f,"---
 
 ## 4. Joins Optionnels avec OPTIONAL
 
-Le mot-cle `OPTIONAL` inclut un pattern meme s'il n'est pas satisfait (equivalent de LEFT JOIN en SQL).",,,,,,,,7880cae329bbe46a,,,,,,,
+Le mot-cle `OPTIONAL` inclut un pattern même s'il n'est pas satisfait (equivalent de LEFT JOIN en SQL).",,,,,,,,7cd88333b3d3429f,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,sparql-optional,code,fr,6f7072c94dd5bf80,"if RDFLIB_AVAILABLE:
     # OPTIONAL: list all animals with flight capability (if known)
     query_optional = """"""
@@ -11031,22 +11031,22 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,sparql-option
         print(f""{str(row.name):<12s} {str(row.type_label):<15s} {fly_str:<12s}"")
 else:
     print(""rdflib non disponible : requete OPTIONAL ignoree."")",,,,,,,,6f7072c94dd5bf80,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,optional-interpretation,markdown,fr,77678eba5e32a4b3,"### Interpretation : OPTIONAL
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,optional-interpretation,markdown,fr,3c0231d8ad32c157,"### Interpretation : OPTIONAL
 
-Seul Coco (perroquet) a la propriete `ex:canFly`. Grace a `OPTIONAL`, les autres animaux apparaissent quand meme dans les resultats.
+Seul Coco (perroquet) a la propriete `ex:canFly`. Grace a `OPTIONAL`, les autres animaux apparaissent quand même dans les résultats.
 
 | Mot-cle SPARQL | Equivalent SQL | Comportement |
 |---------------|----------------|-------------|
 | `FILTER` | `WHERE condition` | Exclut les lignes ne respectant pas la condition |
-| `OPTIONAL` | `LEFT JOIN` | Inclut la ligne meme si le pattern optionnel n'est pas satisfait |
+| `OPTIONAL` | `LEFT JOIN` | Inclut la ligne même si le pattern optionnel n'est pas satisfait |
 | `ORDER BY` | `ORDER BY` | Tri ascendant (defaut) ou `DESC()` |
 
-> **Principe du monde ouvert** : L'absence d'information ne signifie pas que l'information est fausse. `OPTIONAL` respecte ce principe.",,,,,,,,77678eba5e32a4b3,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,section-5-title,markdown,fr,b7bc083774db23b1,"---
+> **Principe du monde ouvert** : L'absence d'information ne signifie pas que l'information est fausse. `OPTIONAL` respecte ce principe.",,,,,,,,3c0231d8ad32c157,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,section-5-title,markdown,fr,5ac3990038441b1f,"---
 
 ## 5. Combinaison de Patterns avec UNION
 
-Le mot-cle `UNION` combine les resultats de plusieurs patterns (equivalent de `UNION ALL` en SQL).",,,,,,,,b7bc083774db23b1,,,,,,,
+Le mot-cle `UNION` combine les résultats de plusieurs patterns (equivalent de `UNION ALL` en SQL).",,,,,,,,5ac3990038441b1f,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,sparql-union,code,fr,2c2e9b5d460caa62,"if RDFLIB_AVAILABLE:
     # UNION: mammals OR birds
     query_union = """"""
@@ -11073,16 +11073,16 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,sparql-union,
         print(f""  {row.name} - {row.type_label}"")
 else:
     print(""rdflib non disponible : requete UNION ignoree."")",,,,,,,,2c2e9b5d460caa62,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,union-interpretation,markdown,fr,92c89b2d934b92a9,"### Interpretation : UNION
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,union-interpretation,markdown,fr,b27d9889c86ed4c7,"### Interpretation : UNION
 
-`UNION` combine les resultats de deux patterns. C'est utile quand une propriete peut etre exprimee de plusieurs facons differentes.
+`UNION` combine les résultats de deux patterns. C'est utile quand une propriete peut etre exprimee de plusieurs facons différentes.
 
-Equivalent dotNetRDF : La syntaxe SPARQL est identique, seul le wrapping change.",,,,,,,,92c89b2d934b92a9,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,section-6-title,markdown,fr,e3956aa94745f430,"---
+Equivalent dotNetRDF : La syntaxe SPARQL est identique, seul le wrapping change.",,,,,,,,b27d9889c86ed4c7,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,section-6-title,markdown,fr,5f0b05f825d9e685,"---
 
-## 6. Exploration de la Hierarchie de Classes
+## 6. Exploration de la Hiérarchie de Classes
 
-Le fichier `animals.ttl` contient une hierarchie RDFS. Interrogeons-la pour comprendre les relations entre classes.",,,,,,,,e3956aa94745f430,,,,,,,
+Le fichier `animals.ttl` contient une hiérarchie RDFS. Interrogeons-la pour comprendre les relations entre classes.",,,,,,,,5f0b05f825d9e685,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,sparql-class-hierarchy,code,fr,d37631c150ae68ea,"if RDFLIB_AVAILABLE:
     # Query class hierarchy
     query_classes = """"""
@@ -11109,20 +11109,20 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,sparql-class-
         print(f""{str(row.label):<15s} {parent:<15s}"")
 else:
     print(""rdflib non disponible : requete hierarchie ignoree."")",,,,,,,,d37631c150ae68ea,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,class-interpretation,markdown,fr,a041c3dff89fac7f,"### Interpretation : Hierarchie de classes
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,class-interpretation,markdown,fr,99b3fa3a494ece85,"### Interpretation : Hiérarchie de classes
 
-La hierarchie est visible : `Animal` est la racine, `Mammal` et `Bird` sont des sous-classes directes.
+La hiérarchie est visible : `Animal` est la racine, `Mammal` et `Bird` sont des sous-classes directes.
 
 | Propriete RDFS | Description |
 |----------------|-------------|
-| `rdfs:subClassOf` | Hierarchie de classes (transitive) |
+| `rdfs:subClassOf` | Hiérarchie de classes (transitive) |
 | `rdfs:label` | Nom lisible pour une ressource |
-| `rdf:type` / `a` | Relation instance-classe |",,,,,,,,a041c3dff89fac7f,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,section-7-title,markdown,fr,e4efbc437eb9765f,"---
+| `rdf:type` / `a` | Relation instance-classe |",,,,,,,,99b3fa3a494ece85,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,section-7-title,markdown,fr,9af3eba76faec9ad,"---
 
 ## 7. Pagination avec LIMIT et OFFSET
 
-Pour les gros resultats, `LIMIT` et `OFFSET` permettent la pagination.",,,,,,,,e4efbc437eb9765f,,,,,,,
+Pour les gros résultats, `LIMIT` et `OFFSET` permettent la pagination.",,,,,,,,9af3eba76faec9ad,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,sparql-pagination,code,fr,0f403f37371a08d0,"if RDFLIB_AVAILABLE:
     # Pagination: first 2 animals, then next 2
     query_page1 = """"""
@@ -11159,30 +11159,30 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,sparql-pagina
         print(f""  {row.name} : {row.age} ans"")
 else:
     print(""rdflib non disponible : pagination ignoree."")",,,,,,,,0f403f37371a08d0,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,pagination-interpretation,markdown,fr,2ddcf45abf209989,"### Interpretation : Pagination
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,pagination-interpretation,markdown,fr,a1cd91e1e5df2cfb,"### Interpretation : Pagination
 
-- `LIMIT 2` : Retourne au maximum 2 resultats
-- `OFFSET 2` : Saute les 2 premiers resultats
+- `LIMIT 2` : Retourne au maximum 2 résultats
+- `OFFSET 2` : Saute les 2 premiers résultats
 
-C'est essentiel pour les endpoints publics qui peuvent avoir des millions de triples.",,,,,,,,2ddcf45abf209989,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,section-8-title,markdown,fr,29f4924c6f3c8dbf,"---
+C'est essentiel pour les endpoints publics qui peuvent avoir des millions de triples.",,,,,,,,a1cd91e1e5df2cfb,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,section-8-title,markdown,fr,b8856c19cf6f0012,"---
 
 ## 8. Tableau de Correspondance dotNetRDF / rdflib (SPARQL)
 
-Ce tableau recapitule les equivalences pour les requetes SPARQL.",,,,,,,,29f4924c6f3c8dbf,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,comparison-table,markdown,fr,c5b32d37e6042018,"| Operation | dotNetRDF (C#) | rdflib (Python) |
+Ce tableau recapitule les equivalences pour les requêtes SPARQL.",,,,,,,,b8856c19cf6f0012,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,comparison-table,markdown,fr,86b7aca86ea20808,"| Opération | dotNetRDF (C#) | rdflib (Python) |
 |-----------|---------------|----------------|
 | **Executer SELECT** | `g.ExecuteQuery(""SELECT..."")` | `g.query(""SELECT..."")` |
 | **Type de retour** | `SparqlResultSet` | `Result` (iterable) |
-| **Iterer resultats** | `foreach (SparqlResult row in results)` | `for row in results:` |
+| **Iterer résultats** | `foreach (SparqlResult row in results)` | `for row in results:` |
 | **Acces valeur** | `row[""name""]` | `row.name` ou `row[0]` |
 | **Compter** | `results.Count` | `len(results)` |
-| **Requete parametree** | `SparqlParameterizedString` | f-string ou format Python |
+| **Requête parametree** | `SparqlParameterizedString` | f-string ou format Python |
 | **Endpoint distant** | `SparqlRemoteEndpoint` | `SPARQLWrapper` (voir SW-5b) |
 
 ### Syntaxe SPARQL - Identique dans les deux bibliotheques
 
-La syntaxe SPARQL elle-meme est **identique** - seuls changent les wrappers d'execution :
+La syntaxe SPARQL elle-même est **identique** - seuls changent les wrappers d'exécution :
 
 ```sparql
 PREFIX ex: <http://example.org/>
@@ -11195,17 +11195,17 @@ WHERE {
 }
 ORDER BY ?s
 LIMIT 10
-```",,,,,,,,c5b32d37e6042018,,,,,,,
+```",,,,,,,,86b7aca86ea20808,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,exercises-title,markdown,fr,7a666211e46e9f9a,"---
 
 ## Exemples guides (issus de contributions etudiantes)
 
 Les exercices ci-dessous ont ete resolus et valides a partir de contributions etudiantes ; ils sont conserves comme **exemples guides** de mise en pratique des concepts SPARQL. De **nouveaux exercices** a completer sont proposes a la fin du notebook.",,,,,,,,7a666211e46e9f9a,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,exercise-1-intro,markdown,fr,c47e141f548940fc,"### Exemple guide 1 : Trouver les mammiferes
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,exercise-1-intro,markdown,fr,be7bccb3ef5989df,"### Exemple guide 1 : Trouver les mammiferes
 
-Cette requete retourne tous les animaux qui sont des mammiferes (instances de `ex:Mammal` ou de ses sous-classes `ex:Dog`, `ex:Cat`), avec leur nom et leur age.
+Cette requête retourne tous les animaux qui sont des mammiferes (instances de `ex:Mammal` ou de ses sous-classes `ex:Dog`, `ex:Cat`), avec leur nom et leur age.
 
-**Approche** : `rdfs:subClassOf*` (chemin de propriete transitif) remonte automatiquement la hierarchie des classes, sans avoir a enumerer chaque sous-classe.",,,,,,,,c47e141f548940fc,,,,,,,
+**Approche** : `rdfs:subClassOf*` (chemin de propriete transitif) remonte automatiquement la hiérarchie des classes, sans avoir a enumerer chaque sous-classe.",,,,,,,,be7bccb3ef5989df,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,exercise-1-code,code,fr,be07cf12a9654e9a,"if RDFLIB_AVAILABLE:
     # Exemple guide 1 : trouver tous les mammiferes dans animals.ttl
 
@@ -11229,11 +11229,11 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,exercise-1-co
         print(f""{row.name} ({row.type_label}) : {row.age} ans"")
 else:
     print(""rdflib non disponible : exemple guide 1 ignore."")",,,,,,,,be07cf12a9654e9a,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,exercise-2-intro,markdown,fr,c3ac5f89c688c105,"### Exemple guide 2 : Animaux sans age defini
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,exercise-2-intro,markdown,fr,7a7eb542e93b5f01,"### Exemple guide 2 : Animaux sans age défini
 
-Cette requete trouve tous les animaux qui n'ont PAS de propriete `ex:age` definie.
+Cette requête trouve tous les animaux qui n'ont PAS de propriete `ex:age` définie.
 
-**Approche** : `FILTER NOT EXISTS { ... }` elimine les solutions pour lesquelles le motif existe. Le code gere aussi le cas ou tous les animaux ont un age (resultat vide) avec un message explicite.",,,,,,,,c3ac5f89c688c105,,,,,,,
+**Approche** : `FILTER NOT EXISTS { ... }` elimine les solutions pour lesquelles le motif existe. Le code gere aussi le cas ou tous les animaux ont un age (résultat vide) avec un message explicite.",,,,,,,,7a7eb542e93b5f01,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,exercise-2-code,code,fr,cdfd4ebcbc8c6fe1,"if RDFLIB_AVAILABLE:
     # Exemple guide 2 : animaux sans age defini
 
@@ -11256,48 +11256,48 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,exercise-2-co
         print(""Aucun animal sans age dans le graphe (tous renseignes)."")
 else:
     print(""rdflib non disponible : exemple guide 2 ignore."")",,,,,,,,cdfd4ebcbc8c6fe1,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,summary-title,markdown,fr,11db6c31c608125f,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,summary-title,markdown,fr,ac235665fbe9af81,"---
 
 ## Resume
 
-Ce sidetrack a presente l'execution de requetes SPARQL en Python avec **rdflib**.
+Ce sidetrack a presente l'exécution de requêtes SPARQL en Python avec **rdflib**.
 
 ### Concepts cles
 
 | Concept | Ce que vous avez appris |
 |---------|------------------------|
 | **SELECT** | Projeter des variables depuis un graphe |
-| **FILTER** | Appliquer des conditions aux resultats |
+| **FILTER** | Appliquer des conditions aux résultats |
 | **OPTIONAL** | Jointures externes (valeurs manquantes autorisees) |
 | **UNION** | Combiner plusieurs patterns |
-| **ORDER BY / LIMIT / OFFSET** | Trier et paginer les resultats |
+| **ORDER BY / LIMIT / OFFSET** | Trier et paginer les résultats |
 | **Correspondance** | Equivalences dotNetRDF / rdflib |
 
-### Prochaines etapes
+### Prochaines étapes
 
-- **SW-5-CSharp-LinkedData** : Donnees liees en .NET (DBpedia, Wikidata)
+- **SW-5-CSharp-LinkedData** : Données liees en .NET (DBpedia, Wikidata)
 - **SW-5b-Python-LinkedData** : Interroger des endpoints distants avec SPARQLWrapper
 - **SW-6-CSharp-RDFS** : Schema et inference en .NET
 
 ---
 
-**Retour au sommaire** : [Index SemanticWeb](README.md)",,,,,,,,11db6c31c608125f,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,f68cef6f,markdown,fr,13c5337495555cb3,"## Resume et perspectives
+**Retour au sommaire** : [Index SemanticWeb](README.md)",,,,,,,,ac235665fbe9af81,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,f68cef6f,markdown,fr,8803c2b86e6ec0d5,"## Resume et perspectives
 
-Ce sidetrack a couvert les principales fonctionnalites du langage SPARQL appliquees a rdflib : les requetes SELECT pour projeter des variables, FILTER pour le filtrage conditionnel, OPTIONAL pour les jointures externes respectant le principe du monde ouvert, UNION pour combiner plusieurs patterns, et LIMIT/OFFSET pour la pagination. L'exemple guide de synthese a egalement introduit CONSTRUCT pour generer de nouveaux graphes RDF et les agregations GROUP BY/COUNT.
+Ce sidetrack a couvert les principales fonctionnalites du langage SPARQL appliquees a rdflib : les requêtes SELECT pour projeter des variables, FILTER pour le filtrage conditionnel, OPTIONAL pour les jointures externes respectant le principe du monde ouvert, UNION pour combiner plusieurs patterns, et LIMIT/OFFSET pour la pagination. L'exemple guide de synthese a également introduit CONSTRUCT pour generer de nouveaux graphes RDF et les agregations GROUP BY/COUNT.
 
-La comparaison systematique entre dotNetRDF et rdflib a montre que la syntaxe SPARQL est identique dans les deux bibliotheques -- seuls different les wrappers d'execution (`g.query()` en Python, `g.ExecuteQuery()` en C#). Les exercices proposent d'explorer des fonctionnalites avancees : requetes ASK (booleennes), BIND/CONCAT pour la construction de chaines, les chemins de propriete transitifs (`rdfs:subClassOf+`), et les agregations avec HAVING.
+La comparaison systématique entre dotNetRDF et rdflib a montre que la syntaxe SPARQL est identique dans les deux bibliotheques -- seuls différent les wrappers d'exécution (`g.query()` en Python, `g.ExecuteQuery()` en C#). Les exercices proposent d'explorer des fonctionnalites avancees : requêtes ASK (booleennes), BIND/CONCAT pour la construction de chaînes, les chemins de propriete transitifs (`rdfs:subClassOf+`), et les agregations avec HAVING.
 
-Dans le notebook suivant (**SW-5-CSharp-LinkedData**), nous decouvrirons les donnees liees en interrogeant des endpoints publics comme DBpedia et Wikidata, puis le sidetrack **SW-5b-Python-LinkedData** presentera l'equivalent Python avec SPARQLWrapper.",,,,,,,,13c5337495555cb3,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,e797dcac,markdown,fr,ce326591ef07dd38,"---
+Dans le notebook suivant (**SW-5-CSharp-LinkedData**), nous decouvrirons les données liees en interrogeant des endpoints publics comme DBpedia et Wikidata, puis le sidetrack **SW-5b-Python-LinkedData** presentera l'equivalent Python avec SPARQLWrapper.",,,,,,,,8803c2b86e6ec0d5,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,e797dcac,markdown,fr,4a198dd136367d50,"---
 
-## Exemple guide de synthese : Requetes SPARQL avancees
+## Exemple guide de synthese : Requêtes SPARQL avancees
 
 Combinaison de plusieurs fonctionnalites SPARQL sur le graphe `animals.ttl`.
 
 **Partie A - CONSTRUCT** : genere un nouveau graphe RDF ne contenant que les mammiferes.
 
-**Partie B - Agregation** : `GROUP BY` + `COUNT` pour compter le nombre d'animaux par type.",,,,,,,,ce326591ef07dd38,,,,,,,
+**Partie B - Agregation** : `GROUP BY` + `COUNT` pour compter le nombre d'animaux par type.",,,,,,,,4a198dd136367d50,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,b3aa731c,code,fr,b486f08510319d3c,"if RDFLIB_AVAILABLE:
     # Exemple guide de synthese : requetes SPARQL avancees (CONSTRUCT + agregation)
     from rdflib import Graph
@@ -11345,81 +11345,81 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,b3aa731c,code
         print(f""  {row.type_label} : {row.nb}"")
 else:
     print(""rdflib non disponible : synthese ignoree."")",,,,,,,,b486f08510319d3c,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,dc7cbffb,markdown,fr,231df58be94b13f3,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,dc7cbffb,markdown,fr,aec216c7ec3f5566,"---
 
 ## Exercices
 
-A votre tour. Completez les exercices ci-dessous (les solutions ne sont pas fournies). Le notebook doit pouvoir s'executer de bout en bout meme si les exercices ne sont pas encore completes.",,,,,,,,231df58be94b13f3,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,91348198,markdown,fr,7ebc72634e6692aa,"### Exercice 1 : Requete ASK
+A votre tour. Completez les exercices ci-dessous (les solutions ne sont pas fournies). Le notebook doit pouvoir s'executer de bout en bout même si les exercices ne sont pas encore completes.",,,,,,,,aec216c7ec3f5566,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,91348198,markdown,fr,cdd369bcbaefb1bb,"### Exercice 1 : Requête ASK
 
-Ecrivez une requete SPARQL `ASK` qui renvoie `True` s'il existe au moins un animal de plus de 4 ans dans `animals.ttl`, `False` sinon.
+Ecrivez une requête SPARQL `ASK` qui renvoie `True` s'il existe au moins un animal de plus de 4 ans dans `animals.ttl`, `False` sinon.
 
-**Indice** : remplacez `SELECT` par `ASK`, et utilisez `FILTER(?age > 4)`. Le resultat booleen se lit via `bool(g.query(votre_requete).askAnswer)`.",,,,,,,,7ebc72634e6692aa,,,,,,,
+**Indice** : remplacez `SELECT` par `ASK`, et utilisez `FILTER(?age > 4)`. Le résultat booléen se lit via `bool(g.query(votre_requete).askAnswer)`.",,,,,,,,cdd369bcbaefb1bb,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,94d90ffa,code,fr,295c24ee212090ce,"# Exercice 1 : requete ASK - existe-t-il un animal de plus de 4 ans ?
 # TODO etudiant : ecrire une requete ASK avec FILTER(?age > 4)
 # Indice : le resultat booleen se lit via bool(g.query(votre_requete).askAnswer)
 
 print(""Exercice a completer"")
 ",,,,,,,,295c24ee212090ce,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,f8c64bf7,markdown,fr,bb7132ec93f01b3e,"### Exercice 2 : Description textuelle avec BIND et CONCAT
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,f8c64bf7,markdown,fr,cec218171b7f62a4,"### Exercice 2 : Description textuelle avec BIND et CONCAT
 
-Pour chaque animal, produisez une chaine de caracteres du type `""Rex fait Woof""` en combinant son nom (`ex:name`) et son cri (`ex:sound`).
+Pour chaque animal, produisez une chaîne de caractères du type `""Rex fait Woof""` en combinant son nom (`ex:name`) et son cri (`ex:sound`).
 
-**Indice** : utilisez `BIND(CONCAT(?name, "" fait "", ?sound) AS ?description)` dans le `WHERE`.",,,,,,,,bb7132ec93f01b3e,,,,,,,
+**Indice** : utilisez `BIND(CONCAT(?name, "" fait "", ?sound) AS ?description)` dans le `WHERE`.",,,,,,,,cec218171b7f62a4,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,db8263f2,code,fr,de253f7079239c5b,"# Exercice 2 : description textuelle avec BIND / CONCAT
 # TODO etudiant : produire ?description = CONCAT(?name, "" fait "", ?sound)
 # Indice : ?animal ex:name ?name ; ex:sound ?sound . puis BIND(...)
 
 print(""Exercice a completer"")
 ",,,,,,,,de253f7079239c5b,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,b9ea3873,markdown,fr,692d41dbb27c394c,"### Exercice 3 : Property paths transitifs (rdfs:subClassOf+)
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,b9ea3873,markdown,fr,cc5b7c498ec5645a,"### Exercice 3 : Property paths transitifs (rdfs:subClassOf+)
 
-Pour l'animal `ex:rex`, listez **tous ses types ancestraux** dans la hierarchie de classes (ex: Dog -> Mammal -> Animal). Utilisez le chemin de propriete transitif `+` (au moins un saut, sans la classe elle-meme).
+Pour l'animal `ex:rex`, listez **tous ses types ancestraux** dans la hiérarchie de classes (ex: Dog -> Mammal -> Animal). Utilisez le chemin de propriete transitif `+` (au moins un saut, sans la classe elle-même).
 
-**Indice** : `?type rdfs:subClassOf+ ?ancestor` part du type direct de Rex et remonte la hierarchie. Utilisez `?ancestor rdfs:label ?label` pour recuperer le libelle francais.
+**Indice** : `?type rdfs:subClassOf+ ?ancestor` part du type direct de Rex et remonte la hiérarchie. Utilisez `?ancestor rdfs:label ?label` pour recuperer le libelle francais.
 
-Resultat attendu (3 types ancestraux pour Rex) : Mammifere, Animal (et Chien lui-meme si on utilise `*` au lieu de `+`).",,,,,,,,692d41dbb27c394c,,,,,,,
+Résultat attendu (3 types ancestraux pour Rex) : Mammifere, Animal (et Chien lui-même si on utilise `*` au lieu de `+`).",,,,,,,,cc5b7c498ec5645a,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,71f3b054,code,fr,554753bae896902d,"# Exercice 3 : property paths transitifs rdfs:subClassOf+
 # TODO etudiant : ecrire une requete SELECT qui liste les ancetres de ex:rex
 # Indice : ex:rex a ?type . ?type rdfs:subClassOf+ ?ancestor . ?ancestor rdfs:label ?label .
 
 print(""Exercice a completer"")
 ",,,,,,,,554753bae896902d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,e5b5faf2,markdown,fr,7aa39eaea8ed78e7,"### Exercice 4 : GROUP BY + HAVING (types frequents)
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,e5b5faf2,markdown,fr,756b14c6e98374ba,"### Exercice 4 : GROUP BY + HAVING (types frequents)
 
 Listez les **types d'animaux** qui ont **au moins 2 instances** dans le graphe. Affichez le libelle du type et le nombre d'animaux.
 
-**Indice** : groupez sur `?type_label`, comptez avec `COUNT(?animal)`, puis filtrez avec `HAVING(?nb >= 2)`. Notez que `HAVING` agit apres `GROUP BY` (contrairement a `FILTER`).
+**Indice** : groupez sur `?type_label`, comptez avec `COUNT(?animal)`, puis filtrez avec `HAVING(?nb >= 2)`. Notez que `HAVING` agit après `GROUP BY` (contrairement a `FILTER`).
 
-Resultat attendu : seul `Chien` (2 instances : Rex + Buddy).",,,,,,,,7aa39eaea8ed78e7,,,,,,,
+Résultat attendu : seul `Chien` (2 instances : Rex + Buddy).",,,,,,,,756b14c6e98374ba,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,f783ca04,code,fr,deedefffe58c8b47,"# Exercice 4 : agregation GROUP BY + HAVING
 # TODO etudiant : compter les animaux par type et garder seulement ceux >= 2
 # Indice : SELECT ?type_label (COUNT(?animal) AS ?nb) ... GROUP BY ?type_label HAVING(?nb >= 2)
 
 print(""Exercice a completer"")
 ",,,,,,,,deedefffe58c8b47,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,7ff6d7f5,markdown,fr,27cbc28a084d9bb3,"### Exercice 5 : VALUES + BIND/IF (categoriser par age)
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,7ff6d7f5,markdown,fr,45ef5c16956f6947,"### Exercice 5 : VALUES + BIND/IF (categoriser par age)
 
-Pour chaque animal du graphe, calculez une **categorie d'age** :
+Pour chaque animal du graphe, calculez une **catégorie d'age** :
 - `jeune` si age < 4
 - `adulte` si 4 <= age < 8
 - `senior` si age >= 8
 
-Affichez `?name`, `?age`, `?categorie`.
+Affichez `?name`, `?age`, `?catégorie`.
 
-**Indice** : utilisez `BIND` avec `IF(condition1, ""jeune"", IF(condition2, ""adulte"", ""senior"")) AS ?categorie`. Vous pouvez aussi tester `VALUES (?seuil1 ?seuil2) { (4 8) }` pour rendre les seuils parametrables.",,,,,,,,27cbc28a084d9bb3,,,,,,,
+**Indice** : utilisez `BIND` avec `IF(condition1, ""jeune"", IF(condition2, ""adulte"", ""senior"")) AS ?catégorie`. Vous pouvez aussi tester `VALUES (?seuil1 ?seuil2) { (4 8) }` pour rendre les seuils parametrables.",,,,,,,,45ef5c16956f6947,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,32026e72,code,fr,2401b71199c2e690,"# Exercice 5 : BIND + IF pour categoriser par age
 # TODO etudiant : pour chaque animal, calculer ?categorie via BIND(IF(?age < 4, ""jeune"", IF(?age < 8, ""adulte"", ""senior"")) AS ?categorie)
 # Indice : SELECT ?name ?age ?categorie WHERE { ?animal ex:name ?name ; ex:age ?age . BIND(...) }
 
 print(""Exercice a completer"")
 ",,,,,,,,2401b71199c2e690,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,f59bf1bb,markdown,fr,8f5e39eb00535156,"## Conclusion
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb,f59bf1bb,markdown,fr,4ade4529a8bbc006,"## Conclusion
 
-Ce sidetrack a presente l'execution de requetes SPARQL en Python avec rdflib, en couvrant les mots-cles fondamentaux du langage : SELECT, FILTER, OPTIONAL, UNION, ORDER BY, LIMIT et OFFSET. Vous avez appris a interroger des graphes RDF en memoire, a explorer les hierarchies de classes RDFS, et a utiliser les chemins de propriete transitifs (`rdfs:subClassOf*`) pour des requetes avancees.
+Ce sidetrack a presente l'exécution de requêtes SPARQL en Python avec rdflib, en couvrant les mots-cles fondamentaux du langage : SELECT, FILTER, OPTIONAL, UNION, ORDER BY, LIMIT et OFFSET. Vous avez appris a interroger des graphes RDF en memoire, a explorer les hiérarchies de classes RDFS, et a utiliser les chemins de propriete transitifs (`rdfs:subClassOf*`) pour des requêtes avancees.
 
-Les points cles a retenir sont la correspondance systematique entre dotNetRDF et rdflib (syntaxe SPARQL identique, seuls les wrappers d'execution different), le principe du monde ouvert respecte par OPTIONAL, et les fonctionnalites avancees comme CONSTRUCT pour generer de nouveaux graphes et les agregations GROUP BY/COUNT. Ces competences preparent a l'interrogation d'endpoints publics (DBpedia, Wikidata) dans les notebooks suivants.",,,,,,,,8f5e39eb00535156,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,8a827ba7,markdown,fr,5a162ddffa885e24,"# SW-4-SPARQL
+Les points cles a retenir sont la correspondance systématique entre dotNetRDF et rdflib (syntaxe SPARQL identique, seuls les wrappers d'exécution différent), le principe du monde ouvert respecte par OPTIONAL, et les fonctionnalites avancees comme CONSTRUCT pour generer de nouveaux graphes et les agregations GROUP BY/COUNT. Ces competences preparent a l'interrogation d'endpoints publics (DBpedia, Wikidata) dans les notebooks suivants.",,,,,,,,4ade4529a8bbc006,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,8a827ba7,markdown,fr,aa96b188ffe16a60,"# SW-4-SPARQL
 
 **Navigation** : [<< 3-GraphOperations](SW-3-CSharp-GraphOperations.ipynb) | [Index](README.md) | [5-LinkedData >>](SW-5-CSharp-LinkedData.ipynb)
 
@@ -11428,16 +11428,16 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,8a827ba7,markd
 ### Duree estimee : 45 minutes
 
 A la fin de ce notebook, vous saurez :
-1. Comprendre SPARQL comme le **SQL du Web semantique**
-2. Ecrire des requetes **SELECT** avec variables et patterns de triplets
-3. Utiliser **FILTER** et **OPTIONAL** pour affiner les resultats
+1. Comprendre SPARQL comme le **SQL du Web sémantique**
+2. Ecrire des requêtes **SELECT** avec variables et patterns de triplets
+3. Utiliser **FILTER** et **OPTIONAL** pour affiner les résultats
 4. Combiner des patterns avec **UNION**
 5. Trier et paginer avec **ORDER BY**, **LIMIT**, **OFFSET**
-6. Construire des requetes programmatiquement avec le **QueryBuilder** de dotNetRDF
+6. Construire des requêtes programmatiquement avec le **QueryBuilder** de dotNetRDF
 
 ### Prerequis
 - .NET 9.0 avec .NET Interactive
-- Avoir complete [SW-3-GraphOperations](SW-3-CSharp-GraphOperations.ipynb)",,,,,,,,5a162ddffa885e24,,,,,,,
+- Avoir complete [SW-3-GraphOperations](SW-3-CSharp-GraphOperations.ipynb)",,,,,,,,aa96b188ffe16a60,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,1ae08421,code,fr,995bc9e54000e8a3,"#r ""nuget: dotNetRDF, 3.2.1""",,,,,,,,995bc9e54000e8a3,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,f398bbda,markdown,fr,66d9e4ee72136a3d,"Importation des espaces de noms dotNetRDF pour SPARQL, QueryBuilder et la gestion des parsers.",,,,,,,,66d9e4ee72136a3d,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,17325e35,code,fr,73e40095ed2456b6,"using VDS.RDF;
@@ -11450,29 +11450,29 @@ using System.IO;
 using System.Linq;
 
 Console.WriteLine(""dotNetRDF 3.2.1 pret - espaces de noms SPARQL charges."");",,,,,,,,73e40095ed2456b6,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,28041294,markdown,fr,7f5feb0c37dc35f7,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,28041294,markdown,fr,37ad167d4388ae65,"---
 
 ## 1. Introduction a SPARQL
 
-**SPARQL** (SPARQL Protocol and RDF Query Language) est le langage de requete standard du W3C pour interroger des donnees RDF. Il joue pour RDF le meme role que SQL pour les bases relationnelles.
+**SPARQL** (SPARQL Protocol and RDF Query Language) est le langage de requête standard du W3C pour interroger des données RDF. Il joue pour RDF le même rôle que SQL pour les bases relationnelles.
 
-> **SPARQL** (*SPARQL Protocol and RDF Query Language*) est le langage de requete standardise par le **W3C** pour interroger des graphes RDF, specifie dans SPARQL 1.1 (Harris & Seaborne, *SPARQL 1.1 Query Language*, W3C Recommendation 2013). La syntaxe `SELECT` / `WHERE` / `FILTER` / `OPTIONAL` / `UNION` introduite ci-dessous provient de cette recommandation, tout comme le service de requetes federees (`SERVICE`, SPARQL 1.1 Federated Query).
+> **SPARQL** (*SPARQL Protocol and RDF Query Language*) est le langage de requête standardise par le **W3C** pour interroger des graphes RDF, specifie dans SPARQL 1.1 (Harris & Seaborne, *SPARQL 1.1 Query Language*, W3C Recommendation 2013). La syntaxe `SELECT` / `WHERE` / `FILTER` / `OPTIONAL` / `UNION` introduite ci-dessous provient de cette recommandation, tout comme le service de requêtes federees (`SERVICE`, SPARQL 1.1 Federated Query).
 
 | SQL | SPARQL | Description |
 |-----|--------|-------------|
-| `SELECT col FROM table WHERE condition` | `SELECT ?var WHERE { pattern }` | Extraire des donnees |
-| Tables et colonnes | Graphes et triplets | Structure de donnees |
+| `SELECT col FROM table WHERE condition` | `SELECT ?var WHERE { pattern }` | Extraire des données |
+| Tables et colonnes | Graphes et triplets | Structure de données |
 | `JOIN` | Patterns partageant des variables | Jointure |
 | `WHERE condition` | `FILTER(condition)` | Filtrage |
 
-dotNetRDF offre deux approches pour construire des requetes SPARQL :
-- **Chaines brutes** : `""SELECT ?x WHERE { ?x ?y ?z }""` -- simple mais pas de validation a la compilation
-- **QueryBuilder** : API fluide C# -- type safety, composition dynamique",,,,,,,,7f5feb0c37dc35f7,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,451b0e27,markdown,fr,33a1cb73e32b6357,"---
+dotNetRDF offre deux approches pour construire des requêtes SPARQL :
+- **Chaînes brutes** : `""SELECT ?x WHERE { ?x ?y ?z }""` -- simple mais pas de validation a la compilation
+- **QueryBuilder** : API fluide C# -- type safety, composition dynamique",,,,,,,,37ad167d4388ae65,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,451b0e27,markdown,fr,56c932fa0d203633,"---
 
-## 2. SELECT : Requetes de base
+## 2. SELECT : Requêtes de base
 
-Une requete SELECT retourne un ensemble de lignes (bindings) pour les variables demandees. Le pattern `WHERE` definit les contraintes sur les triplets.",,,,,,,,33a1cb73e32b6357,,,,,,,
+Une requête SELECT retourne un ensemble de lignes (bindings) pour les variables demandees. Le pattern `WHERE` définit les contraintes sur les triplets.",,,,,,,,56c932fa0d203633,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,7c0fe9cd,code,fr,3872fa7bd49aa21d,"// 2.1 Requete SELECT simple avec QueryBuilder
 string x = ""x"";
 var queryBuilder = QueryBuilder
@@ -11489,9 +11489,9 @@ var queryBuilder = QueryBuilder
 var query = queryBuilder.BuildQuery();
 Console.WriteLine(""=== Requete generee ==="");
 Console.WriteLine(query.ToString());",,,,,,,,3872fa7bd49aa21d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,5813280c,markdown,fr,bfa51e603a027796,"### Interpretation
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,5813280c,markdown,fr,7e9e2ace4de35f53,"### Interpretation
 
-La requete generee correspond a :
+La requête generee correspond a :
 ```sparql
 SELECT ?x
 WHERE {
@@ -11504,7 +11504,7 @@ WHERE {
 | Variables retournees | `.Select(new[] { ""x"" })` | `SELECT ?x` |
 | Pattern sujet | `.Subject(x)` | `?x` (variable) |
 | Pattern predicat | `.PredicateUri(uri)` | `<uri>` (URI fixe) |
-| Pattern objet | `.Object(""John Smith"")` | `""John Smith""` (litteral) |",,,,,,,,bfa51e603a027796,,,,,,,
+| Pattern objet | `.Object(""John Smith"")` | `""John Smith""` (litteral) |",,,,,,,,7e9e2ace4de35f53,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,fa1daf7c,code,fr,5056d080614eeb7c,"// 2.2 PREFIX avec plusieurs patterns de triplets
 var prefixes = new NamespaceMapper(true);
 prefixes.AddNamespace(""vcard"", new Uri(""http://www.w3.org/2001/vcard-rdf/3.0#""));
@@ -11524,7 +11524,7 @@ qb.Prefixes = prefixes;
 
 Console.WriteLine(""=== SELECT avec PREFIX ==="");
 Console.WriteLine(qb.BuildQuery().ToString());",,,,,,,,5056d080614eeb7c,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,ebdb96a6,markdown,fr,f7443a9e2c7790c3,"### Interpretation
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,ebdb96a6,markdown,fr,a7e46f704c26bff6,"### Interpretation
 
 Les **prefixes** abregent les URIs longues :
 
@@ -11532,7 +11532,7 @@ Les **prefixes** abregent les URIs longues :
 |-------------|-------------|
 | `<http://www.w3.org/2001/vcard-rdf/3.0#FN>` | `vcard:FN` |
 
-Plusieurs patterns dans le meme `Where()` creent une **conjonction** (AND) : la variable `?y` doit satisfaire les deux contraintes simultanement.
+Plusieurs patterns dans le même `Where()` créent une **conjonction** (AND) : la variable `?y` doit satisfaire les deux contraintes simultanement.
 
 ```sparql
 PREFIX vcard: <http://www.w3.org/2001/vcard-rdf/3.0#>
@@ -11541,12 +11541,12 @@ WHERE {
     ?y vcard:Family ""Smith"" .
     ?y vcard:Given ?givenName .
 }
-```",,,,,,,,f7443a9e2c7790c3,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,2a38bf05,markdown,fr,98bdb9d564c90913,"---
+```",,,,,,,,a7e46f704c26bff6,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,2a38bf05,markdown,fr,b65b1aaefb17a95b,"---
 
 ## 3. FILTER et OPTIONAL
 
-**FILTER** restreint les resultats selon des conditions. **OPTIONAL** permet de recuperer des informations meme si elles n'existent pas.",,,,,,,,98bdb9d564c90913,,,,,,,
+**FILTER** restreint les résultats selon des conditions. **OPTIONAL** permet de recuperer des informations même si elles n'existent pas.",,,,,,,,b65b1aaefb17a95b,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,d887c1c9,code,fr,4ed1208ef70fea4c,"// 3.1 FILTER numerique
 var prefixes = new NamespaceMapper(true);
 prefixes.AddNamespace(""info"", new Uri(""http://somewhere/peopleInfo#""));
@@ -11566,13 +11566,13 @@ qb.Prefixes = prefixes;
 
 Console.WriteLine(""=== FILTER numerique ==="");
 Console.WriteLine(qb.BuildQuery().ToString());",,,,,,,,4ed1208ef70fea4c,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,b405b4c6,markdown,fr,6805a38ff5a7c026,"### Interpretation : FILTER numerique
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,b405b4c6,markdown,fr,bf1995dca17778b5,"### Interpretation : FILTER numérique
 
-La requete generee utilise `FILTER(?age > 24)` : le QueryBuilder traduit l'expression C# `b.Variable(age) > 24` en syntaxe SPARQL equivalente. La variable `?age` est a la fois un pattern de triplet (objet de `info:age`) et une variable de filtrage.
+La requête generee utilise `FILTER(?age > 24)` : le QueryBuilder traduit l'expression C# `b.Variable(age) > 24` en syntaxe SPARQL equivalente. La variable `?age` est a la fois un pattern de triplet (objet de `info:age`) et une variable de filtrage.
 
-**Remarque** : le predicat `info:age` dans le chemin URI `http://somewhere/peopleInfo#age` montre que les proprietes RDF peuvent representer n'importe quelle relation — ici, l'age d'une personne est un litteral numerique, ce qui permet les comparaisons dans FILTER.
+**Remarque** : le predicat `info:age` dans le chemin URI `http://somewhere/peopleInfo#age` montre que les proprietes RDF peuvent representer n'importe quelle relation — ici, l'age d'une personne est un litteral numérique, ce qui permet les comparaisons dans FILTER.
 
-Les filtres SPARQL supportent aussi les expressions regulieres, comme illustre dans la cellule suivante.",,,,,,,,6805a38ff5a7c026,,,,,,,
+Les filtres SPARQL supportent aussi les expressions regulieres, comme illustre dans la cellule suivante.",,,,,,,,bf1995dca17778b5,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,d9ca3c9a,code,fr,3c5669d02f36c52f,"// 3.2 FILTER Regex (expressions regulieres)
 var prefixes = new NamespaceMapper(true);
 prefixes.AddNamespace(""vcard"", new Uri(""http://www.w3.org/2001/vcard-rdf/3.0#""));
@@ -11630,9 +11630,9 @@ qb.Prefixes = prefixes;
 
 Console.WriteLine(""=== OPTIONAL avec FILTER ==="");
 Console.WriteLine(qb.BuildQuery().ToString());",,,,,,,,3476972f2ccf45c3,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,d626ce5d,markdown,fr,ef74efbcb5784dfe,"### Interpretation : OPTIONAL
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,d626ce5d,markdown,fr,c6123c756ef0088e,"### Interpretation : OPTIONAL
 
-**OPTIONAL** rend un pattern **facultatif** : les resultats sont retournes meme si le pattern optionnel n'a pas de correspondance.
+**OPTIONAL** rend un pattern **facultatif** : les résultats sont retournes même si le pattern optionnel n'a pas de correspondance.
 
 | Sans OPTIONAL | Avec OPTIONAL |
 |---------------|---------------|
@@ -11649,12 +11649,12 @@ WHERE {
 }
 ```
 
-Toutes les personnes avec un nom sont retournees ; l'age n'apparait que si > 42.",,,,,,,,ef74efbcb5784dfe,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,3e63f843,markdown,fr,089596684c429a3a,"---
+Toutes les personnes avec un nom sont retournees ; l'age n'apparait que si > 42.",,,,,,,,c6123c756ef0088e,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,3e63f843,markdown,fr,7ed3b68b81c6f4e8,"---
 
 ## 4. UNION
 
-**UNION** combine des patterns alternatifs (OR logique) : un resultat est retourne s'il correspond a l'un **ou** l'autre des patterns.",,,,,,,,089596684c429a3a,,,,,,,
+**UNION** combine des patterns alternatifs (OR logique) : un résultat est retourne s'il correspond a l'un **ou** l'autre des patterns.",,,,,,,,7ed3b68b81c6f4e8,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,c6bc8d22,code,fr,2d35f04360999cac,"// 4.1 UNION de deux patterns
 var prefixes = new NamespaceMapper(true);
 prefixes.AddNamespace(""foaf"", new Uri(""http://xmlns.com/foaf/0.1/""));
@@ -11678,7 +11678,7 @@ qb.Prefixes = prefixes;
 
 Console.WriteLine(""=== UNION ==="");
 Console.WriteLine(qb.BuildQuery().ToString());",,,,,,,,2d35f04360999cac,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,a4378488,markdown,fr,203096fb0d5da35f,"### Interpretation : UNION vs OPTIONAL
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,a4378488,markdown,fr,b6ecd77339ea4be7,"### Interpretation : UNION vs OPTIONAL
 
 ```sparql
 SELECT ?name
@@ -11693,14 +11693,14 @@ WHERE {
 |-----|-------|----------|
 | Personne avec foaf:name seulement | Incluse | Incluse |
 | Personne avec vcard:FN seulement | Incluse | Depend du pattern principal |
-| Personne avec les deux | 2 resultats | 1 resultat |
+| Personne avec les deux | 2 résultats | 1 résultat |
 
-> **UNION** : alternatives (OR). **OPTIONAL** : complement facultatif.",,,,,,,,203096fb0d5da35f,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,e8115bd5,markdown,fr,31565a3bc26edc62,"---
+> **UNION** : alternatives (OR). **OPTIONAL** : complement facultatif.",,,,,,,,b6ecd77339ea4be7,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,e8115bd5,markdown,fr,c0595b8e0bd386f1,"---
 
 ## 5. ORDER BY, LIMIT, OFFSET
 
-Le tri et la pagination controlent l'ordre et la quantite de resultats retournes.",,,,,,,,31565a3bc26edc62,,,,,,,
+Le tri et la pagination controlent l'ordre et la quantite de résultats retournes.",,,,,,,,c0595b8e0bd386f1,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,1a3d399b,code,fr,108bdcb366b58e8b,"// 5.1 ORDER BY
 var prefixes = new NamespaceMapper(true);
 prefixes.AddNamespace(""foaf"", new Uri(""http://xmlns.com/foaf/0.1/""));
@@ -11718,18 +11718,18 @@ qb.Prefixes = prefixes;
 
 Console.WriteLine(""=== ORDER BY ==="");
 Console.WriteLine(qb.BuildQuery().ToString());",,,,,,,,108bdcb366b58e8b,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,6eec7185,markdown,fr,a121b81a92e5e444,"### Interpretation : ORDER BY
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,6eec7185,markdown,fr,97bc1de1c466d3e0,"### Interpretation : ORDER BY
 
-La requete generee par le QueryBuilder produit `ORDER BY ASC(?name)` : le tri est ascendant par defaut avec `.OrderBy(var)`. Pour un tri descendant, il faudrait utiliser `.OrderByDescending(var)`.
+La requête generee par le QueryBuilder produit `ORDER BY ASC(?name)` : le tri est ascendant par defaut avec `.OrderBy(var)`. Pour un tri descendant, il faudrait utiliser `.OrderByDescending(var)`.
 
 **Comparaison des approches** :
 
 | Approche | Code | Avantage |
 |----------|------|----------|
 | QueryBuilder | `.OrderBy(""name"")` | Type safety, IntelliSense |
-| Chaine brute | `ORDER BY DESC(?age)` | Syntaxe directe, LIMIT/OFFSET |
+| Chaîne brute | `ORDER BY DESC(?age)` | Syntaxe directe, LIMIT/OFFSET |
 
-Le QueryBuilder ne supporte pas encore nativement LIMIT et OFFSET — il faut utiliser une chaine SPARQL brute avec `SparqlQueryParser` pour ces clauses, comme illustre ci-dessous.",,,,,,,,a121b81a92e5e444,,,,,,,
+Le QueryBuilder ne supporte pas encore nativement LIMIT et OFFSET — il faut utiliser une chaîne SPARQL brute avec `SparqlQueryParser` pour ces clauses, comme illustre ci-dessous.",,,,,,,,97bc1de1c466d3e0,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,1d47f119,code,fr,0fb5ef5ecf647c05,"// 5.2 LIMIT et OFFSET en chaine brute
 string sparql = @""
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
@@ -11751,23 +11751,23 @@ Console.WriteLine(parsedQuery.ToString());
 Console.WriteLine($""\nType de requete : {parsedQuery.QueryType}"");
 Console.WriteLine($""Limit           : {parsedQuery.Limit}"");
 Console.WriteLine($""Offset          : {parsedQuery.Offset}"");",,,,,,,,0fb5ef5ecf647c05,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,e2e92fa0,markdown,fr,68a0c5d200bb7870,"### Interpretation : Tri et pagination
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,e2e92fa0,markdown,fr,79b7990e28e07db6,"### Interpretation : Tri et pagination
 
 | Clause | Syntaxe SPARQL | Effet |
 |--------|----------------|-------|
-| `ORDER BY ?var` | Ascendant (A-Z, 1-9) | Tri des resultats |
+| `ORDER BY ?var` | Ascendant (A-Z, 1-9) | Tri des résultats |
 | `ORDER BY DESC(?var)` | Descendant (Z-A, 9-1) | Tri inverse |
-| `LIMIT n` | Maximum n resultats | Pagination |
-| `OFFSET n` | Sauter n premiers resultats | Pagination |
+| `LIMIT n` | Maximum n résultats | Pagination |
+| `OFFSET n` | Sauter n premiers résultats | Pagination |
 
 **Tri multiple** : `ORDER BY DESC(?age) ?name` -- trie par age descendant, puis par nom ascendant.
 
-> **SparqlQueryParser** valide la syntaxe a l'execution et expose les proprietes de la requete (`QueryType`, `Limit`, `Offset`).",,,,,,,,68a0c5d200bb7870,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,84605da0,markdown,fr,ce0c3fc62610be57,"---
+> **SparqlQueryParser** valide la syntaxe a l'exécution et expose les proprietes de la requête (`QueryType`, `Limit`, `Offset`).",,,,,,,,79b7990e28e07db6,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,84605da0,markdown,fr,21c9d10734c101bb,"---
 
 ## 6. QueryBuilder : Construction programmatique
 
-Le `QueryBuilder` de dotNetRDF offre une API fluide pour construire des requetes SPARQL dynamiquement, avec validation a la compilation.",,,,,,,,ce0c3fc62610be57,,,,,,,
+Le `QueryBuilder` de dotNetRDF offre une API fluide pour construire des requêtes SPARQL dynamiquement, avec validation a la compilation.",,,,,,,,21c9d10734c101bb,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,7cc34cbb,code,fr,3a24fcf8ffad90ce,"// 6.1 Requete complexe avec QueryBuilder
 var prefixes = new NamespaceMapper(true);
 prefixes.AddNamespace(""foaf"", new Uri(""http://xmlns.com/foaf/0.1/""));
@@ -11801,20 +11801,20 @@ qb.Prefixes = prefixes;
 
 Console.WriteLine(""=== Requete complexe ==="");
 Console.WriteLine(qb.BuildQuery().ToString());",,,,,,,,3a24fcf8ffad90ce,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,b9bf075a,markdown,fr,d2b021ad7ef825ea,"### Interpretation : Requete complexe QueryBuilder
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,b9bf075a,markdown,fr,81f0c920478aebb4,"### Interpretation : Requête complexe QueryBuilder
 
-La requete combine 4 clauses SPARQL en un seul appel fluide :
+La requête combine 4 clauses SPARQL en un seul appel fluide :
 
-| Clause | Methode | Effet sur les resultats |
+| Clause | Méthode | Effet sur les résultats |
 |--------|---------|------------------------|
 | `WHERE` (2 patterns) | `.Where(tp => ...)` | Conjonction : le nom ET l'age doivent exister |
 | `OPTIONAL` | `.Optional(opt => ...)` | Email retourne si present, sinon variable non liee |
 | `FILTER` | `.Filter(b => b.Variable(age) > 18)` | Exclut les moins de 18 ans |
 | `ORDER BY` | `.OrderBy(name)` | Tri alphabetique sur le nom |
 
-**Ordre de composition** : `Select → Where → Optional → Filter → OrderBy`. Le QueryBuilder garantit la syntaxe SPARQL valide quelle que soit l'ordre des appels, mais l'ordre logique (selection, pattern, filtre, tri) ameliore la lisibilite.
+**Ordre de composition** : `Select → Where → Optional → Filter → OrderBy`. Le QueryBuilder garantit la syntaxe SPARQL valide quelle que soit l'ordre des appels, mais l'ordre logique (sélection, pattern, filtre, tri) ameliore la lisibilite.
 
-Cette requete sera executee sur un graphe local dans la cellule suivante pour observer les resultats concrets.",,,,,,,,d2b021ad7ef825ea,,,,,,,
+Cette requête sera executee sur un graphe local dans la cellule suivante pour observer les résultats concrets.",,,,,,,,81f0c920478aebb4,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,b1ec96ed,code,fr,868c038e937b5b6a,"// 6.2 Execution sur un graphe local
 IGraph g = new Graph();
 string ttlData = @""
@@ -11856,18 +11856,18 @@ foreach (var result in results)
 {
     Console.WriteLine($""  {result[""name""]} - age: {result[""age""]}"");
 }",,,,,,,,868c038e937b5b6a,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,fd2a627c,markdown,fr,503b9fe82ec4732f,"### Interpretation : Execution locale
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,fd2a627c,markdown,fr,715cd255142e7325,"### Interpretation : Exécution locale
 
-dotNetRDF inclut un moteur SPARQL complet qui peut executer des requetes directement sur un `IGraph` en memoire.
+dotNetRDF inclut un moteur SPARQL complet qui peut executer des requêtes directement sur un `IGraph` en memoire.
 
-| Methode | Usage |
+| Méthode | Usage |
 |---------|-------|
-| `g.ExecuteQuery(sparql)` | Execution sur un graphe local |
-| `SparqlResultSet` | Resultat de type SELECT (table de bindings) |
-| `IGraph` | Resultat de type CONSTRUCT/DESCRIBE (graphe) |
+| `g.ExecuteQuery(sparql)` | Exécution sur un graphe local |
+| `SparqlResultSet` | Résultat de type SELECT (table de bindings) |
+| `IGraph` | Résultat de type CONSTRUCT/DESCRIBE (graphe) |
 | `result[""name""]` | Acces a une variable du binding |
 
-> Le moteur SPARQL local supporte la majorite de SPARQL 1.1 : SELECT, CONSTRUCT, ASK, DESCRIBE, GROUP BY, HAVING, etc.",,,,,,,,503b9fe82ec4732f,,,,,,,
+> Le moteur SPARQL local supporte la majorite de SPARQL 1.1 : SELECT, CONSTRUCT, ASK, DESCRIBE, GROUP BY, HAVING, etc.",,,,,,,,715cd255142e7325,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,e94d7267,code,fr,25be887efc3ba422,"// 6.3 Requete OPTIONAL executee sur le graphe local
 string sparqlOptional = @""
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
@@ -11886,26 +11886,26 @@ foreach (var result in results)
     string emailStr = result.HasBoundValue(""email"") ? result[""email""].ToString() : ""(non renseigne)"";
     Console.WriteLine($""  {result[""name""]} - email: {emailStr}"");
 }",,,,,,,,25be887efc3ba422,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,557e82dc,markdown,fr,83b855c6c918e59f,"### Interpretation
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,557e82dc,markdown,fr,796e0310ecba626b,"### Interpretation
 
-La requete retourne les 4 personnes. Alice et Charlie ont un email, Bob et Diana non. Grace a `OPTIONAL`, les personnes sans email sont quand meme incluses dans les resultats.
+La requête retourne les 4 personnes. Alice et Charlie ont un email, Bob et Diana non. Grace a `OPTIONAL`, les personnes sans email sont quand même incluses dans les résultats.
 
-La methode `result.HasBoundValue(""email"")` permet de tester si une variable optionnelle a ete liee.",,,,,,,,83b855c6c918e59f,,,,,,,
+La méthode `result.HasBoundValue(""email"")` permet de tester si une variable optionnelle a ete liee.",,,,,,,,796e0310ecba626b,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,709e9804,markdown,fr,df3439ccbc672084,"---
 
 ## 7. Exercices pratiques",,,,,,,,df3439ccbc672084,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,a3c47b73,markdown,fr,2b45ff200f5dde6a,"### Exercice 1 : SELECT avec FILTER
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,a3c47b73,markdown,fr,da1e4655b986e592,"### Exercice 1 : SELECT avec FILTER
 
-Ecrivez une requete SPARQL qui selectionne les noms et ages des personnes de plus de 20 ans a partir du graphe de test. Executez-la avec `g.ExecuteQuery()`.",,,,,,,,2b45ff200f5dde6a,,,,,,,
+Ecrivez une requête SPARQL qui selectionne les noms et ages des personnes de plus de 20 ans a partir du graphe de test. Executez-la avec `g.ExecuteQuery()`.",,,,,,,,da1e4655b986e592,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,5e404f56,code,fr,d8cfb6385b443c75,"Console.WriteLine(""Exercice a completer"");
 // Exercice 1 : Votre code ici
 // string sparql = @""PREFIX foaf: ...
 // SELECT ?name ?age WHERE { ... FILTER(?age > 20) } ORDER BY DESC(?age)"";
 // var results = g.ExecuteQuery(sparql) as SparqlResultSet;
 // foreach (var r in results) Console.WriteLine(...);",,,,,,,,d8cfb6385b443c75,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,6de49146,markdown,fr,a240aaf3b872ee8d,"### Exercice 2 : QueryBuilder avec OPTIONAL
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,6de49146,markdown,fr,47e3a9a8801c010f,"### Exercice 2 : QueryBuilder avec OPTIONAL
 
-Utilisez le `QueryBuilder` pour construire une requete qui retourne le nom et l'email optionnel de toutes les personnes, triee par nom.",,,,,,,,a240aaf3b872ee8d,,,,,,,
+Utilisez le `QueryBuilder` pour construire une requête qui retourne le nom et l'email optionnel de toutes les personnes, triee par nom.",,,,,,,,47e3a9a8801c010f,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,ea7553f8,code,fr,8e3b3427be2a74a8,"Console.WriteLine(""Exercice a completer"");
 // Exercice 2 : Votre code ici
 // var prefixes = new NamespaceMapper(true);
@@ -11913,9 +11913,9 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,ea7553f8,code,
 // var qb = QueryBuilder.Select(...).Where(...).Optional(...).OrderBy(...);
 // qb.Prefixes = prefixes;
 // Console.WriteLine(qb.BuildQuery().ToString());",,,,,,,,8e3b3427be2a74a8,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,bbea907b,markdown,fr,6d513fc4f97ec30c,"### Exercice 3 : Requete sur animals.ttl
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,bbea907b,markdown,fr,41e2cfef6dd26185,"### Exercice 3 : Requête sur animals.ttl
 
-Chargez `data/animals.ttl` et ecrivez une requete SPARQL qui retourne le nom et l'age de tous les animaux de type `ex:Dog`.",,,,,,,,6d513fc4f97ec30c,,,,,,,
+Chargez `data/animals.ttl` et ecrivez une requête SPARQL qui retourne le nom et l'age de tous les animaux de type `ex:Dog`.",,,,,,,,41e2cfef6dd26185,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,75b9fd0d,code,fr,6400426c5dc5da09,"Console.WriteLine(""Exercice a completer"");
 // Exercice 3 : Votre code ici
 // IGraph animals = new Graph();
@@ -11925,28 +11925,28 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,75b9fd0d,code,
 //     ?animal a ex:Dog . ?animal ex:name ?name . ?animal ex:age ?age .
 // }"";
 // var results = animals.ExecuteQuery(sparql) as SparqlResultSet;",,,,,,,,6400426c5dc5da09,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,74562c7d,markdown,fr,53bae6891c49b611,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb,74562c7d,markdown,fr,4519cd20744ed712,"---
 
 ## Resume
 
-| Clause SPARQL | Methode QueryBuilder | Fonction |
+| Clause SPARQL | Méthode QueryBuilder | Fonction |
 |---------------|----------------------|----------|
 | `SELECT ?var` | `.Select(variables)` | Variables a retourner |
 | `WHERE { pattern }` | `.Where(triplePattern)` | Patterns de triplets |
 | `FILTER(cond)` | `.Filter(condition)` | Conditions de filtrage |
 | `OPTIONAL { }` | `.Optional(pattern)` | Patterns facultatifs |
 | `UNION { } { }` | `.Union(pattern1, pattern2)` | Alternatives (OR) |
-| `ORDER BY ?var` | `.OrderBy(var)` | Tri des resultats |
-| `LIMIT n` | (chaine brute) | Limiter le nombre de resultats |
-| `OFFSET n` | (chaine brute) | Sauter les premiers resultats |
+| `ORDER BY ?var` | `.OrderBy(var)` | Tri des résultats |
+| `LIMIT n` | (chaîne brute) | Limiter le nombre de résultats |
+| `OFFSET n` | (chaîne brute) | Sauter les premiers résultats |
 
 | Approche | Avantage | Cas d'usage |
 |----------|----------|-------------|
-| **Chaine brute** | Simple, LIMIT/OFFSET direct | Requetes fixes, connues a l'avance |
-| **QueryBuilder** | Type safety, composition | Requetes dynamiques, parametrees |
-| **SparqlQueryParser** | Validation de syntaxe | Verification avant execution |
+| **Chaîne brute** | Simple, LIMIT/OFFSET direct | Requêtes fixes, connues a l'avance |
+| **QueryBuilder** | Type safety, composition | Requêtes dynamiques, parametrees |
+| **SparqlQueryParser** | Validation de syntaxe | Verification avant exécution |
 
-### Prochaine etape
+### Prochaine étape
 
 Dans **SW-5-LinkedData**, nous apprendrons a interroger des endpoints SPARQL distants comme DBpedia et Wikidata.
 
@@ -11954,25 +11954,25 @@ Dans **SW-5-LinkedData**, nous apprendrons a interroger des endpoints SPARQL dis
 
 - **SPARQL 1.1 Query Language** -- Harris & Seaborne, W3C Recommendation (2013). [w3.org/TR/sparql11-query](https://www.w3.org/TR/sparql11-query/)
 - **SPARQL 1.1 Overview** -- Feigenbaum & Williams, W3C Recommendation (2013). Vue d'ensemble de la famille de specs SPARQL 1.1.
-- **SPARQL 1.1 Federated Query** -- Araujo, Pollock & Feigenbaum, W3C Recommendation (2013). Clause `SERVICE` pour requetes federees.
+- **SPARQL 1.1 Federated Query** -- Araujo, Pollock & Feigenbaum, W3C Recommendation (2013). Clause `SERVICE` pour requêtes federees.
 - **SPARQL 1.1 Protocol** -- Feigenbaum, Todd & Williams, W3C Recommendation (2013). Protocole d'acces aux endpoints SPARQL.
 
 ---
 
-**Navigation** :  [<< 3-GraphOperations](SW-3-CSharp-GraphOperations.ipynb) | [Index](README.md) | [5-LinkedData >>](SW-5-CSharp-LinkedData.ipynb)",,,,,,,,53bae6891c49b611,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,header-navigation,markdown,fr,566201ff04ca5ae3,"# SW-5b-Python-LinkedData
+**Navigation** :  [<< 3-GraphOperations](SW-3-CSharp-GraphOperations.ipynb) | [Index](README.md) | [5-LinkedData >>](SW-5-CSharp-LinkedData.ipynb)",,,,,,,,4519cd20744ed712,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,header-navigation,markdown,fr,2c1cef78ff6ef10d,"# SW-5b-Python-LinkedData
 
 **Navigation** : [Index](README.md) | [<< SW-5 C#](SW-5-CSharp-LinkedData.ipynb) | [SW-6 C# >>](SW-6-CSharp-RDFS.ipynb)
 
-## Donnees Liees du Web en Python avec SPARQLWrapper
+## Données Liees du Web en Python avec SPARQLWrapper
 
-Ce notebook est un **sidetrack optionnel** qui presente l'equivalent Python des concepts de donnees liees du notebook SW-5 (dotNetRDF). Vous y decouvrirez **SPARQLWrapper** pour interroger des endpoints publics comme DBpedia et Wikidata.
+Ce notebook est un **sidetrack optionnel** qui presente l'equivalent Python des concepts de données liees du notebook SW-5 (dotNetRDF). Vous y decouvrirez **SPARQLWrapper** pour interroger des endpoints publics comme DBpedia et Wikidata.
 
 ### Objectifs d'apprentissage
 
 A la fin de ce notebook, vous saurez :
 1. Interroger des endpoints SPARQL distants avec SPARQLWrapper
-2. Explorer DBpedia (donnees structurees de Wikipedia)
+2. Explorer DBpedia (données structurees de Wikipedia)
 3. Interroger Wikidata (base de connaissances collaborative)
 4. Faire la correspondance entre dotNetRDF et SPARQLWrapper
 
@@ -11983,7 +11983,7 @@ A la fin de ce notebook, vous saurez :
 
 ### Duree estimee : 25 minutes
 
-> **Attention** : Les endpoints publics peuvent etre temporairement indisponibles. Toutes les requetes sont enveloppees dans des `try/except` pour gerer ces cas gracieusement.",,,,,,,,566201ff04ca5ae3,,,,,,,
+> **Attention** : Les endpoints publics peuvent etre temporairement indisponibles. Toutes les requêtes sont enveloppees dans des `try/except` pour gerer ces cas gracieusement.",,,,,,,,2c1cef78ff6ef10d,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,section-1-title,markdown,fr,416287d239f3e7db,"---
 
 ## 1. Installation et Imports
@@ -11991,7 +11991,7 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,section-1
 **SPARQLWrapper** est la bibliotheque de reference pour interroger des endpoints SPARQL distants depuis Python.",,,,,,,,416287d239f3e7db,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,install-packages,code,fr,9d04675b025a8c0f,"# Dependances pre-provisionnees (SPARQLWrapper) : voir SemanticWeb/requirements.txt ; imports dans les cellules suivantes.
 ",,,,,,,,9d04675b025a8c0f,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,qsddfrks7mi,markdown,fr,b885d1f105ca5093,Importation de SPARQLWrapper et des constantes de format de retour pour les requetes SPARQL distantes.,,,,,,,,b885d1f105ca5093,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,qsddfrks7mi,markdown,fr,ed75008cf8796b12,Importation de SPARQLWrapper et des constantes de format de retour pour les requêtes SPARQL distantes.,,,,,,,,ed75008cf8796b12,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,sparqlwrapper-imports,code,fr,f14cb6a0fc2268b0,"try:
     from SPARQLWrapper import SPARQLWrapper, JSON, XML
     import json
@@ -12001,11 +12001,11 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,sparqlwra
 except ImportError:
     SPARQLWRAPPER_AVAILABLE = False
     print(""SPARQLWrapper non disponible. Installez avec : pip install SPARQLWrapper"")",,,,,,,,f14cb6a0fc2268b0,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,section-2-title,markdown,fr,8d3ac5e5cc00aa53,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,section-2-title,markdown,fr,5850a60fe89ffbde,"---
 
 ## 2. Interroger DBpedia
 
-DBpedia extrait des donnees structurees de Wikipedia et les expose sous forme de triples RDF. L'endpoint SPARQL est accessible a `http://dbpedia.org/sparql`.",,,,,,,,8d3ac5e5cc00aa53,,,,,,,
+DBpedia extrait des données structurees de Wikipedia et les expose sous forme de triples RDF. L'endpoint SPARQL est accessible a `http://dbpedia.org/sparql`.",,,,,,,,5850a60fe89ffbde,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,query-dbpedia,code,fr,317e93485353407e,"if SPARQLWRAPPER_AVAILABLE:
     # Query DBpedia for French cities
     sparql = SPARQLWrapper(""http://dbpedia.org/sparql"")
@@ -12046,33 +12046,33 @@ LIMIT 5
         print(""Cela n'empeche pas de continuer le notebook."")
 else:
     print(""SPARQLWrapper non disponible : requete DBpedia ignoree."")",,,,,,,,317e93485353407e,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,dbpedia-interpretation,markdown,fr,39175a296bf97948,"### Interpretation : Requete DBpedia
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,dbpedia-interpretation,markdown,fr,72001c78235abadf,"### Interpretation : Requête DBpedia
 
 **Structure de la reponse** : SPARQLWrapper retourne un dictionnaire JSON contenant :
-- `results.bindings` : liste de dictionnaires, un par ligne de resultat
+- `results.bindings` : liste de dictionnaires, un par ligne de résultat
 - Chaque variable (`?city`, `?name`, `?population`) est une cle avec `value` et `type`
 
 **Points cles** :
 1. `FILTER (lang(?name) = ""fr"")` limite les labels a la langue francaise
-2. `LIMIT 5` restreint le nombre de resultats (important pour les endpoints publics)
+2. `LIMIT 5` restreint le nombre de résultats (important pour les endpoints publics)
 3. Le `try/except` est essentiel : les services publics peuvent avoir des timeouts
 
-| Operation | SPARQLWrapper | dotNetRDF |
+| Opération | SPARQLWrapper | dotNetRDF |
 |-----------|---------------|----------|
-| Creer endpoint | `SPARQLWrapper(""http://..."")` | `new SparqlRemoteEndpoint(uri)` |
-| Format retour | `setReturnFormat(JSON)` | Constructeur parametre |
-| Definir requete | `setQuery(""..."")` | `Query = ""...""` |
-| Executer | `query().convert()` | `QueryWithResultSet()` |",,,,,,,,39175a296bf97948,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,df6b7ff7,markdown,fr,9f4de26830eaa1bd,"### Exercice (a completer) : Fleuves de France via DBpedia
+| Créer endpoint | `SPARQLWrapper(""http://..."")` | `new SparqlRemoteEndpoint(uri)` |
+| Format retour | `setReturnFormat(JSON)` | Constructeur paramètre |
+| Définir requête | `setQuery(""..."")` | `Query = ""...""` |
+| Executer | `query().convert()` | `QueryWithResultSet()` |",,,,,,,,72001c78235abadf,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,df6b7ff7,markdown,fr,b73d6f0f06fe3256,"### Exercice (a completer) : Fleuves de France via DBpedia
 
-En vous inspirant de la requete DBpedia de la section 2, modifiez-la pour lister les **fleuves de France** tries par longueur decroissante. Affichez le nom et la longueur en kilometres.
+En vous inspirant de la requête DBpedia de la section 2, modifiez-la pour lister les **fleuves de France** tries par longueur decroissante. Affichez le nom et la longueur en kilometres.
 
 **Indices** :
 - Classe fleuve : `dbo:River` (a la place de `dbo:City`)
 - Propriete longueur : `dbo:length` ou `dbo:riverLength`
 - Gardez le filtre `dbo:country dbr:France` et `FILTER (lang(?name) = ""fr"")`
 - Endpoint : `http://dbpedia.org/sparql` avec format JSON
-- Limitez a `LIMIT 10`",,,,,,,,9f4de26830eaa1bd,,,,,,,
+- Limitez a `LIMIT 10`",,,,,,,,b73d6f0f06fe3256,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,48f74971,code,fr,31365c85386afea6,"if SPARQLWRAPPER_AVAILABLE:
     # Exercice : Fleuves de France via DBpedia
     # TODO etudiant : ecrire une requete SPARQL sur DBpedia
@@ -12092,13 +12092,13 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,48f74971,
     print(""Exercice a completer"")
 else:
     print(""SPARQLWrapper non disponible"")",,,,,,,,31365c85386afea6,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,section-3-title,markdown,fr,83650d0e1964d921,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,section-3-title,markdown,fr,7ec4b74b1e0d7ddf,"---
 
 ## 3. Interroger Wikidata
 
 Wikidata est la base de connaissances structuree du projet Wikimedia. Son endpoint SPARQL est a `https://query.wikidata.org/sparql`.
 
-**Difference importante** : Wikidata utilise des identifiants numeriques (Q-items, P-properties) plutot que des URI lisibles.",,,,,,,,83650d0e1964d921,,,,,,,
+**Différence importante** : Wikidata utilise des identifiants numériques (Q-items, P-properties) plutot que des URI lisibles.",,,,,,,,7ec4b74b1e0d7ddf,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,query-wikidata,code,fr,05642a45c4c35c08,"if SPARQLWRAPPER_AVAILABLE:
     # Query Wikidata for programming languages created after 2010
     sparql_wd = SPARQLWrapper(""https://query.wikidata.org/sparql"")
@@ -12137,9 +12137,9 @@ LIMIT 10
         print(""Cela n'empeche pas de continuer le notebook."")
 else:
     print(""SPARQLWrapper non disponible : requete Wikidata ignoree."")",,,,,,,,05642a45c4c35c08,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,wikidata-interpretation,markdown,fr,4b4d3ed3e65b92d3,"### Interpretation : Requete Wikidata
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,wikidata-interpretation,markdown,fr,9e734466647eebd2,"### Interpretation : Requête Wikidata
 
-**Differences DBpedia vs Wikidata** :
+**Différences DBpedia vs Wikidata** :
 
 | Aspect | DBpedia | Wikidata |
 |--------|---------|----------|
@@ -12157,10 +12157,10 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,wikidata-
 - `wdt:P571` = inception
 - `wdt:P1082` = population
 
-> **Note** : `SERVICE wikibase:label` est un mecanisme specifique a Wikidata qui resout automatiquement les labels dans la langue demandee.",,,,,,,,4b4d3ed3e65b92d3,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,b92b85e5,markdown,fr,309726e9dce5f905,"### Exercice (a completer) : Capitales europeennes et leur pays (Wikidata)
+> **Note** : `SERVICE wikibase:label` est un mécanisme spécifique a Wikidata qui resout automatiquement les labels dans la langue demandee.",,,,,,,,9e734466647eebd2,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,b92b85e5,markdown,fr,f05f3e4b52c802d1,"### Exercice (a completer) : Capitales europeennes et leur pays (Wikidata)
 
-En vous inspirant de la requete Wikidata de la section 3, interrogez Wikidata pour lister les **capitales europeennes** avec le nom du pays associe. Limitez le resultat a 15 lignes.
+En vous inspirant de la requête Wikidata de la section 3, interrogez Wikidata pour lister les **capitales europeennes** avec le nom du pays associe. Limitez le résultat a 15 lignes.
 
 **Indices** :
 - Classe capitale : `wd:Q5119` (capital city)
@@ -12168,7 +12168,7 @@ En vous inspirant de la requete Wikidata de la section 3, interrogez Wikidata po
 - Propriete ""pays"" : `wdt:P17`
 - Propriete ""continent du pays"" : via `?country wdt:P30 wd:Q46` (pays situe en Europe)
 - Utilisez `SERVICE wikibase:label { bd:serviceParam wikibase:language ""fr,en"" . }` pour les labels
-- Endpoint : `https://query.wikidata.org/sparql` avec `.agent = ""CoursIA-SemanticWeb-Notebook/1.0 (educational)""`",,,,,,,,309726e9dce5f905,,,,,,,
+- Endpoint : `https://query.wikidata.org/sparql` avec `.agent = ""CoursIA-SemanticWeb-Notebook/1.0 (educational)""`",,,,,,,,f05f3e4b52c802d1,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,ad3387bd,code,fr,449eb1cfc6fb8a8d,"if SPARQLWRAPPER_AVAILABLE:
     # Exercice : Capitales europeennes et leur pays (Wikidata)
     # TODO etudiant : ecrire une requete SPARQL sur Wikidata
@@ -12187,11 +12187,11 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,ad3387bd,
     print(""Exercice a completer"")
 else:
     print(""SPARQLWrapper non disponible"")",,,,,,,,449eb1cfc6fb8a8d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,section-4-title,markdown,fr,f983d9e74556d492,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,section-4-title,markdown,fr,694e36e2321e550a,"---
 
-## 4. Requetes Federees avec SERVICE
+## 4. Requêtes Federees avec SERVICE
 
-SPARQL permet de combiner plusieurs endpoints dans une meme requete avec le mot-cle `SERVICE`.",,,,,,,,f983d9e74556d492,,,,,,,
+SPARQL permet de combiner plusieurs endpoints dans une même requête avec le mot-cle `SERVICE`.",,,,,,,,694e36e2321e550a,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,federated-query,code,fr,a502d3f37765b948,"if SPARQLWRAPPER_AVAILABLE:
     # Federated query: combine local graph with remote endpoint
     try:
@@ -12249,9 +12249,9 @@ ORDER BY DESC(?population)
         print(""rdflib non disponible : requete federée ignoree."")
 else:
     print(""SPARQLWrapper non disponible : requete federée ignoree."")",,,,,,,,a502d3f37765b948,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,federated-interpretation,markdown,fr,99a4a481b05f6d9a,"### Interpretation : Requetes federées
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,federated-interpretation,markdown,fr,2430ad81fbaeb92f,"### Interpretation : Requêtes federées
 
-Le mot-cle `SERVICE` permet d'interroger un endpoint distant depuis une requete SPARQL.
+Le mot-cle `SERVICE` permet d'interroger un endpoint distant depuis une requête SPARQL.
 
 ```sparql
 SERVICE <http://dbpedia.org/sparql> {
@@ -12259,14 +12259,14 @@ SERVICE <http://dbpedia.org/sparql> {
 }
 ```
 
-C'est puissant pour combiner des donnees locales avec des donnees distantes, ou pour joindre plusieurs endpoints entre eux.
+C'est puissant pour combiner des données locales avec des données distantes, ou pour joindre plusieurs endpoints entre eux.
 
-Equivalent dotNetRDF : Meme syntaxe SPARQL, le federated query est gere par le moteur SPARQL.",,,,,,,,99a4a481b05f6d9a,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,section-5-title,markdown,fr,c8fdf3defa5b8d15,"---
+Equivalent dotNetRDF : Même syntaxe SPARQL, le federated query est gere par le moteur SPARQL.",,,,,,,,2430ad81fbaeb92f,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,section-5-title,markdown,fr,45abfdeb355180c3,"---
 
 ## 5. Formats de Retour
 
-SPARQLWrapper supporte differents formats de retour pour les requetes SPARQL.",,,,,,,,c8fdf3defa5b8d15,,,,,,,
+SPARQLWrapper supporte différents formats de retour pour les requêtes SPARQL.",,,,,,,,45abfdeb355180c3,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,return-formats,code,fr,932418c3709bb049,"if SPARQLWRAPPER_AVAILABLE:
     # Compare JSON vs XML return formats
     query_simple = """"""
@@ -12296,7 +12296,7 @@ ASK { dbr:Paris dbo:country dbr:France }
         print(f""Erreur : {e}"")
 else:
     print(""SPARQLWrapper non disponible : comparaison formats ignoree."")",,,,,,,,932418c3709bb049,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,formats-interpretation,markdown,fr,ec33e45c6ed027b9,"### Interpretation : Formats de retour
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,formats-interpretation,markdown,fr,fa96f31fc3db2ade,"### Interpretation : Formats de retour
 
 | Format | Constante SPARQLWrapper | Usage |
 |--------|------------------------|-------|
@@ -12304,46 +12304,46 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,formats-i
 | **XML** | `XML` | Format standard W3C |
 | **CSV/TSV** | Necessite conversion | Pour l'export vers Excel |
 
-Le format JSON est generalement recommande pour Python car il se convertit directement en dictionnaires.",,,,,,,,ec33e45c6ed027b9,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,section-6-title,markdown,fr,fb4a4f0432adc919,"---
+Le format JSON est généralement recommande pour Python car il se convertit directement en dictionnaires.",,,,,,,,fa96f31fc3db2ade,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,section-6-title,markdown,fr,bb32aeebb79d2ae8,"---
 
 ## 6. Tableau de Correspondance dotNetRDF / SPARQLWrapper
 
-Ce tableau recapitule les equivalences pour les requetes vers des endpoints distants.",,,,,,,,fb4a4f0432adc919,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,comparison-table,markdown,fr,6bfac12c79ecf01b,"| Operation | dotNetRDF (C#) | SPARQLWrapper (Python) |
+Ce tableau recapitule les equivalences pour les requêtes vers des endpoints distants.",,,,,,,,bb32aeebb79d2ae8,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,comparison-table,markdown,fr,3408f3d14a557f4b,"| Opération | dotNetRDF (C#) | SPARQLWrapper (Python) |
 |-----------|---------------|--------------------------|
-| **Creer endpoint** | `new SparqlRemoteEndpoint(uri)` | `SPARQLWrapper(uri)` |
+| **Créer endpoint** | `new SparqlRemoteEndpoint(uri)` | `SPARQLWrapper(uri)` |
 | **Format retour** | Constructeur (defaut XML) | `setReturnFormat(JSON/XML)` |
-| **Definir requete** | `Query = ""SELECT...""` ou `SetQuery()` | `setQuery(""SELECT..."")` |
+| **Définir requête** | `Query = ""SELECT...""` ou `SetQuery()` | `setQuery(""SELECT..."")` |
 | **Executer SELECT** | `QueryWithResultSet()` | `query().convert()` |
 | **Executer ASK** | `AskQuery()` | `query().convert()` |
 | **User-Agent** | `HttpClientHeaders` | `.agent = ""...""` |
 | **Timeout** | `Timeout` propriete | `setTimeout(seconds)` |
 
-### Philosophies differentes
+### Philosophies différentes
 
 | Aspect | dotNetRDF | SPARQLWrapper |
 |--------|-----------|----------------|
-| **Resultat SELECT** | `SparqlResultSet` (type .NET) | Dictionnaire Python brut |
-| **Resultat ASK** | `bool` | Dictionnaire avec cle `boolean` |
-| **Type de retour** | Objets fortement types | Structures natives Python |",,,,,,,,6bfac12c79ecf01b,,,,,,,
+| **Résultat SELECT** | `SparqlResultSet` (type .NET) | Dictionnaire Python brut |
+| **Résultat ASK** | `bool` | Dictionnaire avec cle `boolean` |
+| **Type de retour** | Objets fortement types | Structures natives Python |",,,,,,,,3408f3d14a557f4b,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,exercises-title,markdown,fr,18a418448aa6a7a6,"---
 
 ## Exemples et Exercices
 
 Mettez en pratique les SPARQLWrapper avec ces exemples guides et exercices.",,,,,,,,18a418448aa6a7a6,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,exercise-1-intro,markdown,fr,2cd320c3ba24fde5,"### Exemple guide 1 : Top 10 villes francaises via Wikidata
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,exercise-1-intro,markdown,fr,f7ba367541159faf,"### Exemple guide 1 : Top 10 villes francaises via Wikidata
 
 *Solution proposee par Lilou Mayot (promo 2026)*
 
-Voici un exemple de requete Wikidata pour obtenir les 10 villes de France les plus peuplees avec SPARQLWrapper. Notez l'utilisation des Q-items Wikidata et du service de labels.
+Voici un exemple de requête Wikidata pour obtenir les 10 villes de France les plus peuplees avec SPARQLWrapper. Notez l'utilisation des Q-items Wikidata et du service de labels.
 
-**Elements cles** :
+**Éléments cles** :
 - Classe ville : `wd:Q515` (city)
 - Pays : `wdt:P17` (country), France = `wd:Q142`
 - Population : `wdt:P1082`
 - `SERVICE wikibase:label` pour les labels en francais
-- `time.sleep(60)` entre les requetes Wikidata (politique de rate-limiting)",,,,,,,,2cd320c3ba24fde5,,,,,,,
+- `time.sleep(60)` entre les requêtes Wikidata (politique de rate-limiting)",,,,,,,,f7ba367541159faf,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,exercise-1-code,code,fr,ce11b06e444eef28,"if SPARQLWRAPPER_AVAILABLE:
     # Exemple guide 1 : Top 10 villes francaises via Wikidata
 
@@ -12383,16 +12383,16 @@ LIMIT 10
         print(""Verifiez la syntaxe de votre requete ou la disponibilite de l'endpoint."")
 else:
     print(""SPARQLWrapper non disponible : exemple 1 ignore."")",,,,,,,,ce11b06e444eef28,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,exercise-2-intro,markdown,fr,9df369e5bb8898c7,"### Exemple guide 2 : Films de Christopher Nolan via DBpedia
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,exercise-2-intro,markdown,fr,2ac9f7d47464f82c,"### Exemple guide 2 : Films de Christopher Nolan via DBpedia
 
 *Solution proposee par Lilou Mayot (promo 2026)*
 
 Cet exemple montre comment interroger DBpedia pour lister les films d'un realisateur. Notez l'utilisation de `OPTIONAL` pour les proprietes qui peuvent etre absentes et de `BIND/IF` pour les valeurs conditionnelles.
 
-**Elements cles** :
+**Éléments cles** :
 - Realisateur : `dbr:Christopher_Nolan` avec `dbo:director`
 - `OPTIONAL` pour le titre et la date de sortie
-- `BIND(IF(BOUND(?date), YEAR(?date), ""Unknown""))` pour gerer les dates manquantes",,,,,,,,9df369e5bb8898c7,,,,,,,
+- `BIND(IF(BOUND(?date), YEAR(?date), ""Unknown""))` pour gerer les dates manquantes",,,,,,,,2ac9f7d47464f82c,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,exercise-2-code,code,fr,c443a85858fe3ee4,"if SPARQLWRAPPER_AVAILABLE:
     # Exemple guide 2 : Films de Christopher Nolan via DBpedia
 
@@ -12434,7 +12434,7 @@ ORDER BY DESC(?year)
         print(f""Erreur : {e}"")
 else:
     print(""SPARQLWrapper non disponible : exemple 2 ignore."")",,,,,,,,c443a85858fe3ee4,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,f347f0e1,markdown,fr,9e921e8a56b714c6,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,f347f0e1,markdown,fr,8d52cafea1aa7bb4,"---
 
 ### Exemple guide : Universites francaises via Wikidata
 
@@ -12444,7 +12444,7 @@ Interrogez Wikidata pour obtenir les 10 plus grandes universites francaises (en 
 - Classe universite : `wd:Q3918` (university)
 - Pays : `wdt:P17`, France = `wd:Q142`
 - Nombre d'etudiants : `wdt:P2196` (students count)
-- Pensez au `SERVICE wikibase:label` et au `time.sleep()` entre les requetes",,,,,,,,9e921e8a56b714c6,,,,,,,
+- Pensez au `SERVICE wikibase:label` et au `time.sleep()` entre les requêtes",,,,,,,,8d52cafea1aa7bb4,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,9dd6c304,code,fr,c392578e22d9ede8,"if SPARQLWRAPPER_AVAILABLE:
     # Exercice 1 : Universites francaises via Wikidata
     import time
@@ -12493,7 +12493,7 @@ LIMIT 10
         print(f""Erreur : {e}"")
 else:
     print(""SPARQLWrapper non disponible : exercice 1 ignore."")",,,,,,,,c392578e22d9ede8,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,e5a32858,markdown,fr,676d24b49edcc299,"### Exemple guide : Albums d'un artiste via DBpedia
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,e5a32858,markdown,fr,fa53a897a10b6ccc,"### Exemple guide : Albums d'un artiste via DBpedia
 
 
 _Resolu par le groupe Antoine Gaillard & Ambroise Durst (contribution PR #2397)._
@@ -12504,7 +12504,7 @@ Choisissez un artiste musical et interrogez DBpedia pour lister ses albums avec 
 - Propriete artiste : `dbo:artist` ou `dbp:artist`
 - Type album : `dbo:Album` ou `schema:MusicAlbum`
 - Annee : `dbo:year` ou `dbp:year`
-- Inspirez-vous de l'Exemple guide 2 pour la structure de la requete",,,,,,,,676d24b49edcc299,,,,,,,
+- Inspirez-vous de l'Exemple guide 2 pour la structure de la requête",,,,,,,,fa53a897a10b6ccc,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,734feefe,code,fr,e97aff324f641e04,"if SPARQLWRAPPER_AVAILABLE:
     # Exercice 2 : Albums d'un artiste via DBpedia
 
@@ -12544,16 +12544,16 @@ ORDER BY ?year
         print(f""Erreur : {e}"")
 else:
     print(""SPARQLWrapper non disponible : exercice 2 ignore."")",,,,,,,,e97aff324f641e04,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,60d23e1e,markdown,fr,e3297a7ec30bb366,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,60d23e1e,markdown,fr,36b466274bb2d8f2,"---
 
 ### Exemple guide : Lier DBpedia et Wikidata via owl:sameAs
 
-Le Web de donnees relie une meme entite entre plusieurs datasets grace a `owl:sameAs`. Pour quelques villes DBpedia, recuperez l'URI Wikidata equivalente, en ne conservant que les cibles pointant vers `wikidata.org`. C'est le mecanisme d'**interconnexion** au coeur du Linked Open Data.
+Le Web de données relie une même entite entre plusieurs datasets grace a `owl:sameAs`. Pour quelques villes DBpedia, recuperez l'URI Wikidata equivalente, en ne conservant que les cibles pointant vers `wikidata.org`. C'est le mécanisme d'**interconnexion** au coeur du Linked Open Data.
 
 **Indices** :
 - Propriete de liaison : `owl:sameAs` (`PREFIX owl: <http://www.w3.org/2002/07/owl#>`)
 - Point de depart : `VALUES ?ville { dbr:Paris dbr:Lyon dbr:Marseille }`
-- Filtre sur la cible : `FILTER(CONTAINS(STR(?same), ""wikidata.org""))`",,,,,,,,e3297a7ec30bb366,,,,,,,
+- Filtre sur la cible : `FILTER(CONTAINS(STR(?same), ""wikidata.org""))`",,,,,,,,36b466274bb2d8f2,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,bc314ceb,code,fr,9550eb100770d8e8,"if SPARQLWRAPPER_AVAILABLE:
     # Exercice 3 : Lier DBpedia et Wikidata via owl:sameAs
     sparql_link = SPARQLWrapper(""http://dbpedia.org/sparql"")
@@ -12579,7 +12579,7 @@ WHERE {
         print(f""Erreur : {e}"")
 else:
     print(""SPARQLWrapper non disponible : exercice 3 ignore."")",,,,,,,,9550eb100770d8e8,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,b9b35ea0,markdown,fr,fcd438c937360a75,"### Exemple guide : Construire un graphe local avec CONSTRUCT
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,b9b35ea0,markdown,fr,20852eecca8db45c,"### Exemple guide : Construire un graphe local avec CONSTRUCT
 
 
 _Resolu par le groupe Antoine Gaillard & Ambroise Durst (contribution PR #2397)._
@@ -12587,10 +12587,10 @@ _Resolu par le groupe Antoine Gaillard & Ambroise Durst (contribution PR #2397).
 Jusqu'ici vous avez utilise `SELECT` qui renvoie un tableau. La forme `CONSTRUCT` renvoie un **graphe RDF**, que vous pouvez materialiser localement avec rdflib pour le requeter ensuite hors-ligne. Rapatriez quelques villes francaises et leur population depuis DBpedia dans un graphe local.
 
 **Indices** :
-- Forme de requete : `CONSTRUCT { ... } WHERE { ... }`
+- Forme de requête : `CONSTRUCT { ... } WHERE { ... }`
 - Format de retour adapte : `from SPARQLWrapper import TURTLE` puis `setReturnFormat(TURTLE)`
 - Chargement local : `Graph().parse(data=turtle, format=""turtle"")`
-- Verifiez la taille du graphe avec `len(g)`",,,,,,,,fcd438c937360a75,,,,,,,
+- Verifiez la taille du graphe avec `len(g)`",,,,,,,,20852eecca8db45c,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,3cba469a,code,fr,64a1662474d6e2ce,"if SPARQLWRAPPER_AVAILABLE:
     # Exercice 4 : Construire un graphe local avec CONSTRUCT
     try:
@@ -12636,18 +12636,18 @@ LIMIT 50
         print(""rdflib non disponible : exercice 4 ignore."")
 else:
     print(""SPARQLWrapper non disponible : exercice 4 ignore."")",,,,,,,,64a1662474d6e2ce,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,4daa1721,markdown,fr,a13e7fe86e513621,"### Exemple guide : Agregation SPARQL (COUNT / GROUP BY)
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,4daa1721,markdown,fr,b8412195357be4f0,"### Exemple guide : Agregation SPARQL (COUNT / GROUP BY)
 
 
 _Resolu par le groupe Antoine Gaillard & Ambroise Durst (contribution PR #2397)._
 
-SPARQL ne sert pas qu'a extraire des lignes : il sait aussi **agreger**. Ecrivez une requete qui compte le nombre de films par realisateur dans DBpedia et renvoie le top 10 des realisateurs les plus prolifiques.
+SPARQL ne sert pas qu'a extraire des lignes : il sait aussi **agreger**. Ecrivez une requête qui compte le nombre de films par realisateur dans DBpedia et renvoie le top 10 des realisateurs les plus prolifiques.
 
 **Indices** :
 - Fonction d'agregation : `COUNT(?film)` avec alias `(COUNT(?film) AS ?nb)`
 - Regroupement : `GROUP BY ?director`
 - Motif de base : `?film dbo:director ?director`
-- Triez avec `ORDER BY DESC(?nb)` et limitez avec `LIMIT 10`",,,,,,,,a13e7fe86e513621,,,,,,,
+- Triez avec `ORDER BY DESC(?nb)` et limitez avec `LIMIT 10`",,,,,,,,b8412195357be4f0,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,0c1522e2,code,fr,5d33d897e674fd9d,"if SPARQLWRAPPER_AVAILABLE:
     # Exercice 5 : Agregation SPARQL (COUNT / GROUP BY)
     sparql_agg = SPARQLWrapper(""http://dbpedia.org/sparql"")
@@ -12704,18 +12704,18 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,7385c1af,
 else:
     print(""SPARQLWrapper non disponible"")
 ",,,,,,,,31a6b774ff922b37,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,ex2-linkeddata,markdown,fr,1d6c96d4ca06f0fa,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,ex2-linkeddata,markdown,fr,da831ded1c0dc0a6,"---
 
 ### Exercice 2 (a completer) : Musees de la ville de Paris (Wikidata, SELECT)
 
 En vous inspirant des **Exemples guides via Wikidata** (top 10 villes, universites francaises), listez 15 **musees** situes a **Paris**, avec leur nom.
 
 **Indices** :
-- ""nature de l'element"" : `wdt:P31` ; classe musee : `wd:Q33506`.
+- ""nature de l'élément"" : `wdt:P31` ; classe musee : `wd:Q33506`.
 - ""localise dans l'entite territoriale"" : `wdt:P131` ; Paris = `wd:Q90`.
 - Recuperez le label via `SERVICE wikibase:label { bd:serviceParam wikibase:language ""fr"". }`.
 - Endpoint : `https://query.wikidata.org/sparql`.
-",,,,,,,,1d6c96d4ca06f0fa,,,,,,,
+",,,,,,,,da831ded1c0dc0a6,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,ex2-linkeddata-code,code,fr,3d258e52b9c83618,"if SPARQLWRAPPER_AVAILABLE:
     # Exercice 2 : Musees de la ville de Paris (Wikidata, SELECT)
     # TODO etudiant : ecrire une requete SPARQL SELECT sur Wikidata
@@ -12734,19 +12734,19 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,ex2-linke
 else:
     print(""SPARQLWrapper non disponible"")
 ",,,,,,,,3d258e52b9c83618,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,ex3-linkeddata,markdown,fr,81b218b7600e7c75,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,ex3-linkeddata,markdown,fr,8a4e672ecc5aee58,"---
 
 ### Exercice 3 (a completer) : Pays les plus peuples du monde (Wikidata, FILTER)
 
-En vous inspirant des exemples `SELECT` via Wikidata, listez les **pays** dont la population depasse **100 millions** d'habitants, tries du plus peuple au moins peuple. Vous decouvrirez ici le filtrage numerique avec `FILTER`.
+En vous inspirant des exemples `SELECT` via Wikidata, listez les **pays** dont la population depasse **100 millions** d'habitants, tries du plus peuple au moins peuple. Vous decouvrirez ici le filtrage numérique avec `FILTER`.
 
 **Indices** :
-- ""nature de l'element"" : `wdt:P31` ; classe pays : `wd:Q6256`.
+- ""nature de l'élément"" : `wdt:P31` ; classe pays : `wd:Q6256`.
 - Propriete population : `wdt:P1082`.
-- Filtre numerique : `FILTER(?population > 100000000)`.
+- Filtre numérique : `FILTER(?population > 100000000)`.
 - Tri : `ORDER BY DESC(?population)` ; label via `SERVICE wikibase:label` (langue `""fr""`).
 - Endpoint : `https://query.wikidata.org/sparql`.
-",,,,,,,,81b218b7600e7c75,,,,,,,
+",,,,,,,,8a4e672ecc5aee58,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,ex3-linkeddata-code,code,fr,c77613fcf910dd1c,"if SPARQLWRAPPER_AVAILABLE:
     # Exercice 3 : Pays les plus peuples du monde (Wikidata, FILTER numerique)
     # TODO etudiant : ecrire une requete SPARQL SELECT sur Wikidata
@@ -12766,22 +12766,22 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,ex3-linke
 else:
     print(""SPARQLWrapper non disponible"")
 ",,,,,,,,c77613fcf910dd1c,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,summary-title,markdown,fr,7a31713382a574d7,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb,summary-title,markdown,fr,d2021b527f6fae31,"---
 
 ## Resume
 
-Ce sidetrack a presente l'interrogation de donnees liees du Web avec **SPARQLWrapper**.
+Ce sidetrack a presente l'interrogation de données liees du Web avec **SPARQLWrapper**.
 
 ### Concepts cles
 
 | Concept | Ce que vous avez appris |
 |---------|------------------------|
 | **SPARQLWrapper** | Interroger des endpoints SPARQL distants |
-| **DBpedia** | Donnees structurees de Wikipedia |
+| **DBpedia** | Données structurees de Wikipedia |
 | **Wikidata** | Base de connaissances avec Q-items/P-properties |
-| **SERVICE** | Requetes federées entre endpoints |
+| **SERVICE** | Requêtes federées entre endpoints |
 | **owl:sameAs** | Interconnexion des entites entre datasets (Linked Open Data) |
-| **CONSTRUCT** | Construire un graphe RDF local a partir de donnees distantes |
+| **CONSTRUCT** | Construire un graphe RDF local a partir de données distantes |
 | **Agregation** | `COUNT` / `GROUP BY` pour l'analyse statistique |
 | **Correspondance** | Equivalences dotNetRDF / SPARQLWrapper |
 
@@ -12802,7 +12802,7 @@ Ce sidetrack a presente l'interrogation de donnees liees du Web avec **SPARQLWra
 | Exercice 2 | Musees de la ville de Paris (Wikidata) | A completer |
 | Exercice 3 | Pays les plus peuples du monde (Wikidata, FILTER) | A completer |
 
-### Prochaines etapes
+### Prochaines étapes
 
 - **SW-6-CSharp-RDFS** : Schema et inference en .NET
 - **SW-7-CSharp-OWL** : Ontologies et raisonnement avance
@@ -12810,33 +12810,33 @@ Ce sidetrack a presente l'interrogation de donnees liees du Web avec **SPARQLWra
 
 ---
 
-**Retour au sommaire** : [Index SemanticWeb](README.md)",,,,,,,,7a31713382a574d7,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,cc1e41ca,markdown,fr,339cc238927828a9,"# SW-5-LinkedData
+**Retour au sommaire** : [Index SemanticWeb](README.md)",,,,,,,,d2021b527f6fae31,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,cc1e41ca,markdown,fr,ad07a0471652d72b,"# SW-5-LinkedData
 
 **Navigation** : [<< 4-SPARQL](SW-4-CSharp-SPARQL.ipynb) | [Index](README.md) | [6-RDFS >>](SW-6-CSharp-RDFS.ipynb)
 
-## Donnees Liees : DBpedia, Wikidata et le Web de donnees
+## Données Liees : DBpedia, Wikidata et le Web de données
 
-Ce notebook explore les principes du Linked Data et leur mise en pratique a travers l'interrogation de deux bases de connaissances majeures du Web semantique : DBpedia et Wikidata. Nous apprendrons a combiner ces sources avec des requetes federees.
+Ce notebook explore les principes du Linked Data et leur mise en pratique a travers l'interrogation de deux bases de connaissances majeures du Web sémantique : DBpedia et Wikidata. Nous apprendrons a combiner ces sources avec des requêtes federees.
 
 ### Objectifs d'apprentissage
 
 A la fin de ce notebook, vous saurez :
 1. Expliquer les principes du Linked Data
 2. Interroger DBpedia et Wikidata avec SPARQL
-3. Combiner des sources avec les requetes federees
+3. Combiner des sources avec les requêtes federees
 4. Gerer les erreurs et timeouts des endpoints distants
 
 ### Prerequis
 - Notebook SW-4-SPARQL complete
 - Connexion Internet requise
 
-### Duree estimee : 50 minutes",,,,,,,,339cc238927828a9,,,,,,,
+### Duree estimee : 50 minutes",,,,,,,,ad07a0471652d72b,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,989805da,markdown,fr,96c786f3513db911,"## Installation et imports
 
 Nous utilisons **dotNetRDF 3.2.1**. La classe `SparqlQueryClient` (async) permet d'interroger des endpoints SPARQL distants comme DBpedia ou Wikidata.",,,,,,,,96c786f3513db911,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,ee1f12c2,code,fr,995bc9e54000e8a3,"#r ""nuget: dotNetRDF, 3.2.1""",,,,,,,,995bc9e54000e8a3,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,e9cc9978,markdown,fr,2f00c5f931ddc246,Importation des espaces de noms dotNetRDF et definition des fonctions utilitaires pour les requetes SPARQL distantes.,,,,,,,,2f00c5f931ddc246,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,e9cc9978,markdown,fr,09f77f6c4ba2f725,Importation des espaces de noms dotNetRDF et definition des fonctions utilitaires pour les requêtes SPARQL distantes.,,,,,,,,09f77f6c4ba2f725,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,ad3417a4,code,fr,5f37e6bd27a95890,"using System;
 using System.Net.Http;
 using System.Linq;
@@ -12847,31 +12847,31 @@ using VDS.RDF.Writing;
 using VDS.RDF.Parsing;
 
 Console.WriteLine(""dotNetRDF charge avec succes."");",,,,,,,,5f37e6bd27a95890,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,9051c4a1,markdown,fr,f645e4ebd3f8a168,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,9051c4a1,markdown,fr,da7cebc41aa8bb73,"---
 
 ## 1. Principes du Linked Data
 
-Le **Linked Data** (donnees liees) est une methode de publication de donnees structurees sur le Web, permettant de les interconnecter. Il constitue le socle du **Web Semantique**.
+Le **Linked Data** (données liees) est une méthode de publication de données structurees sur le Web, permettant de les interconnecter. Il constitue le socle du **Web Sémantique**.
 
-### Les 4 regles de Tim Berners-Lee (2006)
+### Les 4 règles de Tim Berners-Lee (2006)
 
-> Ces principes ont ete formules par **Tim Berners-Lee** dans sa note de conception *Linked Data* (W3C Design Issues, 27 juillet 2006), qui reste la reference canonique du Web de donnees. Leur traitement exhaustif (principes, technologies, deploiement) se trouve dans Heath & Bizer, *Linked Data: Evolving the Web into a Global Data Space* (Morgan & Claypool / Synthesis Lectures on the Semantic Web, 2011).
+> Ces principes ont ete formules par **Tim Berners-Lee** dans sa note de conception *Linked Data* (W3C Design Issues, 27 juillet 2006), qui reste la reference canonique du Web de données. Leur traitement exhaustif (principes, technologies, deploiement) se trouve dans Heath & Bizer, *Linked Data: Evolving the Web into a Global Data Space* (Morgan & Claypool / Synthesis Lectures on the Semantic Web, 2011).
 
-| # | Regle | Description | Exemple |
+| # | Règle | Description | Exemple |
 |---|-------|-------------|--------|
 | 1 | **Utiliser des URIs** | Identifier chaque chose par un URI | `http://dbpedia.org/resource/Paris` |
 | 2 | **Utiliser des URIs HTTP** | Permettre la resolution via le Web | Un navigateur peut acceder a l'URI |
-| 3 | **Fournir des informations utiles** | Retourner des donnees RDF quand on accede a un URI | Content negotiation : HTML ou RDF |
+| 3 | **Fournir des informations utiles** | Retourner des données RDF quand on accede a un URI | Content negotiation : HTML ou RDF |
 | 4 | **Inclure des liens** | Lier vers d'autres URIs pour permettre la navigation | DBpedia lie vers Wikidata, GeoNames |
 
 ### Le schema 5 etoiles de l'Open Data
 
-> Ce schema de maturite en 5 niveaux a ete propose par **Tim Berners-Lee** (2010) pour qualifier le degre d'ouverture et de liaison des jeux de donnees ; il est devenu la convention universelle de l'Open Data gouvernemental.
+> Ce schema de maturite en 5 niveaux a ete propose par **Tim Berners-Lee** (2010) pour qualifier le degré d'ouverture et de liaison des jeux de données ; il est devenu la convention universelle de l'Open Data gouvernemental.
 
 | Etoiles | Exigences | Exemple |
 |---------|-----------|--------|
-| * | Donnees sur le Web, licence ouverte | PDF scan |
-| ** | Donnees structurees lisibles par machine | Fichier Excel |
+| * | Données sur le Web, licence ouverte | PDF scan |
+| ** | Données structurees lisibles par machine | Fichier Excel |
 | *** | Format non-proprietaire | CSV au lieu d'Excel |
 | **** | URIs pour identifier les choses (RDF) | RDF avec URIs |
 | ***** | **Linked Data** : liens vers d'autres sources | DBpedia liant vers Wikidata |
@@ -12881,7 +12881,7 @@ Le **Linked Data** (donnees liees) est une methode de publication de donnees str
 ```
   Application / Navigateur
            |
-     Requete HTTP
+     Requête HTTP
            |
    +-------v--------+     +------------------+
    | Endpoint SPARQL |<--->| Triplestore RDF  |
@@ -12892,8 +12892,8 @@ Le **Linked Data** (donnees liees) est une methode de publication de donnees str
      (XML, JSON, CSV)
 ```
 
-> **Le Linked Open Data Cloud** : Des milliers de datasets interconnectes forment un graphe mondial de connaissances. DBpedia et Wikidata en sont le coeur.",,,,,,,,f645e4ebd3f8a168,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,6631f386,markdown,fr,dbc122dea6b920ba,"---
+> **Le Linked Open Data Cloud** : Des milliers de datasets interconnectes forment un graphe mondial de connaissances. DBpedia et Wikidata en sont le coeur.",,,,,,,,da7cebc41aa8bb73,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,6631f386,markdown,fr,113aadcc4fd6ec4f,"---
 
 ## 2. DBpedia : Interrogation via SPARQL
 
@@ -12909,9 +12909,9 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,6631f386,m
 
 ### Fonctions utilitaires
 
-Nous definissons d'abord des fonctions pour executer des requetes et afficher les resultats avec gestion d'erreurs.
+Nous definissons d'abord des fonctions pour executer des requêtes et afficher les résultats avec gestion d'erreurs.
 
-> **Important** : Les endpoints publics peuvent etre lents ou temporairement indisponibles. Toujours utiliser un `try-catch`.",,,,,,,,dbc122dea6b920ba,,,,,,,
+> **Important** : Les endpoints publics peuvent etre lents ou temporairement indisponibles. Toujours utiliser un `try-catch`.",,,,,,,,113aadcc4fd6ec4f,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,18f198c6,code,fr,3d7cf17d52f2abde,"// Fonctions utilitaires pour les requetes SPARQL distantes (async)
 
 public static async Task ExecuteAndDisplaySparqlQuery(
@@ -12995,15 +12995,15 @@ string testQuery = ""SELECT DISTINCT ?Concept WHERE {[] a ?Concept} LIMIT 10"";
 Console.WriteLine(""Test de connexion - Types dans DBpedia :"");
 await ExecuteAndDisplaySparqlQuery(endpoint, testQuery);
 ",,,,,,,,5f7050a73a42f5cf,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,841d83f1,markdown,fr,af08bb0f09e29116,"### Requetes sur des entites DBpedia
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,841d83f1,markdown,fr,506f65358dedc799,"### Requêtes sur des entites DBpedia
 
-Executons des requetes progressives sur differents types d'entites : personnes, films, livres, villes.",,,,,,,,af08bb0f09e29116,,,,,,,
+Executons des requêtes progressives sur différents types d'entites : personnes, films, livres, villes.",,,,,,,,506f65358dedc799,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,7856db20,code,fr,614dc67802ea8186,"// Requete 1 : Relations d'Albert Einstein
 // Pattern : <URI_fixe> ?predicat ?objet
 Console.WriteLine(""=== Relations d'Albert Einstein ==="");
 string q1 = ""SELECT ?link ?person WHERE { <http://dbpedia.org/resource/Albert_Einstein> ?link ?person . } LIMIT 15"";
 await ExecuteAndDisplaySparqlQuery(endpoint, q1, 15);",,,,,,,,614dc67802ea8186,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,d7416022,markdown,fr,fc13ee43143974e6,Execution d'une requete pour lister les films dans lesquels Brad Pitt apparait en tant qu'acteur.,,,,,,,,fc13ee43143974e6,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,d7416022,markdown,fr,b9cc1a3b19ce4eff,Exécution d'une requête pour lister les films dans lesquels Brad Pitt apparait en tant qu'acteur.,,,,,,,,b9cc1a3b19ce4eff,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,dc1b6fd7,code,fr,ed11715b036fd30e,"// Requete 2 : Films de Brad Pitt
 // Pattern inverse : ?sujet dbo:starring <URI_fixe>
 Console.WriteLine(""=== Films de Brad Pitt ==="");
@@ -13016,7 +13016,7 @@ Console.WriteLine();
 Console.WriteLine(""=== Livres de J.K. Rowling ==="");
 string q3 = ""SELECT ?book WHERE { ?book dbo:author <http://dbpedia.org/resource/J._K._Rowling> . }"";
 await ExecuteAndDisplaySparqlQuery(endpoint, q3);",,,,,,,,ed11715b036fd30e,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,cd4b16a1,markdown,fr,1d3d0fce0cc23747,Execution d'une requete pour recuperer les villes de France depuis DBpedia.,,,,,,,,1d3d0fce0cc23747,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,cd4b16a1,markdown,fr,ed525d2cb3d12bf2,Exécution d'une requête pour recuperer les villes de France depuis DBpedia.,,,,,,,,ed525d2cb3d12bf2,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,bb084df6,code,fr,6c1608200e66b5fb,"// Requete 4 : Villes de France
 Console.WriteLine(""=== Villes de France ==="");
 string q4 = ""SELECT ?city WHERE { ?city dbo:country <http://dbpedia.org/resource/France> . } LIMIT 15"";
@@ -13033,20 +13033,20 @@ string q5 = @""SELECT ?team ?city WHERE {
     ?ground dbo:location ?city . 
 }"";
 await ExecuteAndDisplaySparqlQuery(endpoint, q5);",,,,,,,,6c1608200e66b5fb,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,9138db19,markdown,fr,aec576f9e16f38ce,"### Interpretation : Requetes DBpedia
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,9138db19,markdown,fr,63ed4d92b89eb177,"### Interpretation : Requêtes DBpedia
 
-| Requete | Pattern | Concept SPARQL |
+| Requête | Pattern | Concept SPARQL |
 |---------|---------|----------------|
 | Einstein | `<URI> ?link ?person` | Exploration de toutes les relations d'une ressource |
-| Brad Pitt | `?film dbo:starring <URI>` | Selection inversee (trouver les sujets) |
-| Rowling | `?book dbo:author <URI>` | Meme pattern, predicat different |
+| Brad Pitt | `?film dbo:starring <URI>` | Sélection inversee (trouver les sujets) |
+| Rowling | `?book dbo:author <URI>` | Même pattern, predicat différent |
 | Villes France | `?city dbo:country <URI>` | Relation geographique |
-| Premier League | Chaine de 3 triplets | Navigation de graphe multi-noeuds |
+| Premier League | Chaîne de 3 triplets | Navigation de graphe multi-noeuds |
 
-> **URIs DBpedia** : Suivent le pattern `http://dbpedia.org/resource/Nom_Article_Wikipedia`. Le predicat `dbo:` vient de l'ontologie formelle, `dbp:` des infobox brutes.",,,,,,,,aec576f9e16f38ce,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,71170586,markdown,fr,26b27c9a12aab0f3,"### Requetes avancees : prefixes, filtres, agregation
+> **URIs DBpedia** : Suivent le pattern `http://dbpedia.org/resource/Nom_Article_Wikipedia`. Le predicat `dbo:` vient de l'ontologie formelle, `dbp:` des infobox brutes.",,,,,,,,63ed4d92b89eb177,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,71170586,markdown,fr,13a21b358e2be562,"### Requêtes avancees : prefixes, filtres, agregation
 
-Passons a des requetes utilisant des prefixes explicites, `ORDER BY`, `FILTER`, `OPTIONAL` et `GROUP_CONCAT`.",,,,,,,,26b27c9a12aab0f3,,,,,,,
+Passons a des requêtes utilisant des prefixes explicites, `ORDER BY`, `FILTER`, `OPTIONAL` et `GROUP_CONCAT`.",,,,,,,,13a21b358e2be562,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,c283dc77,code,fr,5d55748f8e8020f5,"// Requete 6 : Laureats du Nobel de physique, tries par date de naissance
 string q6 = @""
 PREFIX dbpedia: <http://dbpedia.org/resource/>
@@ -13063,7 +13063,7 @@ LIMIT 10"";
 
 Console.WriteLine(""=== Laureats Nobel de physique ==="");
 await ExecuteAndDisplaySparqlQuery(endpoint, q6);",,,,,,,,5d55748f8e8020f5,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,a0a770e4,markdown,fr,27244a10cf5223ba,Execution d'une requete pour obtenir les films d'aventure avec leurs metadonnees enrichies.,,,,,,,,27244a10cf5223ba,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,a0a770e4,markdown,fr,3788b463098029ff,Exécution d'une requête pour obtenir les films d'aventure avec leurs metadonnees enrichies.,,,,,,,,3788b463098029ff,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,3ce8a403,code,fr,37819ee7eeb065c8,"// Requete 7 : Films d'aventure avec metadonnees enrichies
 string q7 = @""
 SELECT DISTINCT ?film ?number ?abstract ?name
@@ -13078,7 +13078,7 @@ LIMIT 5"";
 
 Console.WriteLine(""=== Films d'aventure enrichis ==="");
 await ExecuteAndDisplaySparqlQuery(endpoint, q7, 5);",,,,,,,,37819ee7eeb065c8,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,0242cf07,markdown,fr,ce587b14e896d69e,Execution d'une requete avancee avec GROUP_CONCAT et OPTIONAL pour lister les comedies romantiques avec leurs acteurs.,,,,,,,,ce587b14e896d69e,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,0242cf07,markdown,fr,931f35b2c420d9cc,Exécution d'une requête avancee avec GROUP_CONCAT et OPTIONAL pour lister les comedies romantiques avec leurs acteurs.,,,,,,,,931f35b2c420d9cc,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,b71fcd56,code,fr,229ae429ae94862d,"// Requete 8 : Comedies romantiques - GROUP_CONCAT, OPTIONAL, FILTER
 string q8 = @""
 SELECT DISTINCT ?film ?abstract 
@@ -13095,17 +13095,17 @@ LIMIT 5"";
 
 Console.WriteLine(""=== Comedies romantiques (GROUP_CONCAT) ==="");
 await ExecuteAndDisplaySparqlQuery(endpoint, q8, 5);",,,,,,,,229ae429ae94862d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,7a6cb3bc,markdown,fr,a63cfb2ee7bf6e39,"### Interpretation : Requetes avancees
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,7a6cb3bc,markdown,fr,a350c2d082c3e3a5,"### Interpretation : Requêtes avancees
 
 | Concept | Syntaxe | Effet |
 |---------|---------|-------|
 | `a dbo:Scientist` | Raccourci pour `rdf:type` | Filtrer par type |
-| `ORDER BY ?birth` | Tri par variable | Resultats ordonnes |
+| `ORDER BY ?birth` | Tri par variable | Résultats ordonnes |
 | `FILTER(LANG(?x) = 'en')` | Filtre linguistique | Evite les doublons multilingues |
-| `OPTIONAL { ... }` | Pattern optionnel | Resultats meme sans match |
+| `OPTIONAL { ... }` | Pattern optionnel | Résultats même sans match |
 | `GROUP_CONCAT(DISTINCT ?x; SEPARATOR=', ')` | Agregation | Une ligne par film, acteurs concatenes |
 
-> **Performance** : Les requetes avec `GROUP_CONCAT` et `OPTIONAL` sont plus lentes. Toujours utiliser `LIMIT` sur les endpoints publics.",,,,,,,,a63cfb2ee7bf6e39,,,,,,,
+> **Performance** : Les requêtes avec `GROUP_CONCAT` et `OPTIONAL` sont plus lentes. Toujours utiliser `LIMIT` sur les endpoints publics.",,,,,,,,a350c2d082c3e3a5,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,423bd7d0,markdown,fr,3b9bb15359a1ef19,"---
 
 ## 3. Wikidata : L'alternative structuree
@@ -13159,7 +13159,7 @@ catch (Exception ex)
     Console.WriteLine(""Note : Wikidata peut refuser les requetes sans User-Agent (HTTP 403)."");
 }
 ",,,,,,,,ba592e25cca95abd,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,3eeaf39e,markdown,fr,d97816b29815cc0b,Execution d'une requete Wikidata pour lister les films avec Brad Pitt via son identifiant Q35332.,,,,,,,,d97816b29815cc0b,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,3eeaf39e,markdown,fr,f75c736090de712b,Exécution d'une requête Wikidata pour lister les films avec Brad Pitt via son identifiant Q35332.,,,,,,,,f75c736090de712b,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,279583a2,code,fr,05346e31ef4a1ea6,"// Requete Wikidata 2 : Films avec Brad Pitt (Q35332)
 // P161 = cast member, P31 = instance of, Q11424 = film
 string wd2 = @""
@@ -13180,7 +13180,7 @@ catch (Exception ex)
 {
     Console.WriteLine($""Erreur Wikidata : {ex.Message}"");
 }",,,,,,,,05346e31ef4a1ea6,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,4708df05,markdown,fr,639722a10a7efff3,Execution d'une requete Wikidata pour obtenir les grandes villes de France avec leur population.,,,,,,,,639722a10a7efff3,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,4708df05,markdown,fr,9c3d057ca7bb73d1,Exécution d'une requête Wikidata pour obtenir les grandes villes de France avec leur population.,,,,,,,,9c3d057ca7bb73d1,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,b6170a5e,code,fr,80753568381ba0a0,"// Requete Wikidata 3 : Grandes villes de France avec population
 // Q142 = France, P17 = country, P1082 = population, Q515 = city
 string wd3 = @""
@@ -13204,7 +13204,7 @@ catch (Exception ex)
 {
     Console.WriteLine($""Erreur Wikidata : {ex.Message}"");
 }",,,,,,,,80753568381ba0a0,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,28057652,markdown,fr,58e154cdd4b257c9,"### Interpretation : DBpedia vs Wikidata
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,28057652,markdown,fr,ca69a28f8c8da225,"### Interpretation : DBpedia vs Wikidata
 
 | Aspect | DBpedia | Wikidata |
 |--------|---------|----------|
@@ -13214,12 +13214,12 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,28057652,m
 | Labels | URIs lisibles | `SERVICE wikibase:label` |
 | Population | Non disponible facilement | `wdt:P1082` |
 
-> **Avantage Wikidata** : Donnees plus structurees, a jour, et filtrage precis par type (`P31`). Au prix d'identifiants moins lisibles (QIDs). Cherchez les QIDs sur [wikidata.org](https://www.wikidata.org/).",,,,,,,,58e154cdd4b257c9,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,4e3abc2d,markdown,fr,66adac1e55d7583d,"---
+> **Avantage Wikidata** : Données plus structurees, a jour, et filtrage précis par type (`P31`). Au prix d'identifiants moins lisibles (QIDs). Cherchez les QIDs sur [wikidata.org](https://www.wikidata.org/).",,,,,,,,ca69a28f8c8da225,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,4e3abc2d,markdown,fr,d1bbbf8dfdf78e31,"---
 
-## 4. Requetes federees avec SERVICE
+## 4. Requêtes federees avec SERVICE
 
-La clause **SERVICE** de SPARQL 1.1 permet d'interroger **plusieurs endpoints** dans une seule requete. C'est le coeur du Linked Data.
+La clause **SERVICE** de SPARQL 1.1 permet d'interroger **plusieurs endpoints** dans une seule requête. C'est le coeur du Linked Data.
 
 ```sparql
 SELECT ?x ?y ?z
@@ -13233,9 +13233,9 @@ WHERE {
 
 En pratique, les vrais appels `SERVICE` sont souvent bloques par les endpoints. L'approche pragmatique utilise `owl:sameAs` pour relier les entites entre datasets.
 
-> La propriete **`owl:sameAs`** est definie dans la semantique d'**OWL 2** (Motik, Patel-Schneider, Cuenca Grau, W3C Rec 2012) comme l'egalite formelle entre deux individus : tout ce qui est vrai de l'un est vrai de l'autre. Elle est le **ciment** du Linked Open Data Cloud — elle relie les entites DBpedia, Wikidata, GeoNames, etc. en un graphe global unique. Ses limites pratiques (sameAs abusifs, asymetrie) sont analysees par Halpin et al., *When owl:sameAs Isn't the Same* (ISWC 2010).
+> La propriete **`owl:sameAs`** est définie dans la sémantique d'**OWL 2** (Motik, Patel-Schneider, Cuenca Grau, W3C Rec 2012) comme l'egalite formelle entre deux individus : tout ce qui est vrai de l'un est vrai de l'autre. Elle est le **ciment** du Linked Open Data Cloud — elle relie les entites DBpedia, Wikidata, GeoNames, etc. en un graphe global unique. Ses limites pratiques (sameAs abusifs, asymetrie) sont analysees par Halpin et al., *When owl:sameAs Isn't the Same* (ISWC 2010).
 
-> **Attention** : Les requetes federees sont souvent lentes et peuvent etre rejetees. Toujours prevoir un fallback.",,,,,,,,66adac1e55d7583d,,,,,,,
+> **Attention** : Les requêtes federees sont souvent lentes et peuvent etre rejetees. Toujours prevoir un fallback.",,,,,,,,d1bbbf8dfdf78e31,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,292e57c8,code,fr,7069ceaef3829b87,"// Requete federee via owl:sameAs : relier DBpedia et Wikidata
 // owl:sameAs lie des entites equivalentes entre datasets
 string fedQuery = @""
@@ -13263,7 +13263,7 @@ catch (Exception ex)
 {
     Console.WriteLine($""Erreur : {ex.Message}"");
 }",,,,,,,,7069ceaef3829b87,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,cc867bf3,markdown,fr,24bcf403223f08d2,Approche en deux etapes pour relier les entites DBpedia et Wikidata via le predicat owl:sameAs.,,,,,,,,24bcf403223f08d2,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,cc867bf3,markdown,fr,2d8fccc9e671fdc9,Approche en deux étapes pour relier les entites DBpedia et Wikidata via le predicat owl:sameAs.,,,,,,,,2d8fccc9e671fdc9,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,a4e9321b,code,fr,7b24f24611561d1d,"// Approche en 2 etapes : DBpedia -> owl:sameAs -> Wikidata
 
 // Etape 1 : Obtenir le lien Wikidata depuis DBpedia
@@ -13297,23 +13297,23 @@ catch (Exception ex)
 {
     Console.WriteLine($""Erreur : {ex.Message}"");
 }",,,,,,,,7b24f24611561d1d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,11dcd037,markdown,fr,86edf21655e28ecb,"### Interpretation : Requetes federees
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,11dcd037,markdown,fr,ff7fc2e5d1431077,"### Interpretation : Requêtes federees
 
 | Approche | Avantage | Inconvenient |
 |----------|----------|-------------|
-| `SERVICE` direct | Une seule requete | Souvent bloque, lent |
-| `owl:sameAs` + 2 requetes | Fiable, rapide | Code plus complexe |
+| `SERVICE` direct | Une seule requête | Souvent bloque, lent |
+| `owl:sameAs` + 2 requêtes | Fiable, rapide | Code plus complexe |
 
 **Predicat `owl:sameAs`** : Lie des entites equivalentes entre datasets. Exemples :
 - `dbr:Albert_Einstein owl:sameAs wd:Q937`
 - `dbr:Paris owl:sameAs wd:Q90`
 
-**Proprietes filtrees (etape 2)** : `P19` lieu de naissance, `P69` formation, `P166` distinctions, `P106` occupation.",,,,,,,,86edf21655e28ecb,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,d70d8874,markdown,fr,c35cc3e3f313531a,"---
+**Proprietes filtrees (étape 2)** : `P19` lieu de naissance, `P69` formation, `P166` distinctions, `P106` occupation.",,,,,,,,ff7fc2e5d1431077,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,d70d8874,markdown,fr,ebb33180aa0b4342,"---
 
 ## 5. SparqlQueryClient en .NET : gestion des timeouts et erreurs
 
-En production, il faut gerer les problemes courants des endpoints distants : timeouts, indisponibilite, limites de requetes. dotNetRDF permet aussi de sauvegarder et recharger des resultats SPARQL dans plusieurs formats.",,,,,,,,c35cc3e3f313531a,,,,,,,
+En production, il faut gerer les problemes courants des endpoints distants : timeouts, indisponibilite, limites de requêtes. dotNetRDF permet aussi de sauvegarder et recharger des résultats SPARQL dans plusieurs formats.",,,,,,,,ebb33180aa0b4342,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,69374d43,code,fr,060bfa4c7b4432bb,"// Sauvegarde et rechargement de resultats SPARQL
 try
 {
@@ -13360,7 +13360,7 @@ catch (Exception ex)
     }
 }
 ",,,,,,,,060bfa4c7b4432bb,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,788079d0,markdown,fr,ef9c701535fa6a6f,"### Interpretation : Formats et gestion d'erreurs
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,788079d0,markdown,fr,114e1a0c492ab939,"### Interpretation : Formats et gestion d'erreurs
 
 | Format | Extension | Writer | Parser | Usage |
 |--------|-----------|--------|--------|-------|
@@ -13372,18 +13372,18 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,788079d0,m
 1. Toujours entourer les appels endpoint de `try-catch`
 2. Prevoir un fallback sur fichiers locaux pour le mode hors-ligne
 3. Utiliser `LIMIT` sur les endpoints publics (quotas de 10-60 secondes)
-4. Sauvegarder les resultats importants localement",,,,,,,,ef9c701535fa6a6f,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,996591ac,markdown,fr,3a4acdc375646778,"---
+4. Sauvegarder les résultats importants localement",,,,,,,,114e1a0c492ab939,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,996591ac,markdown,fr,5ac54a0c6d97aac8,"---
 
 ## Exercices pratiques
 
 ### Exercice 1 : Interroger DBpedia pour une personne de votre choix
 
-Choisissez une personne celebre et ecrivez une requete SPARQL pour obtenir ses informations depuis DBpedia.
+Choisissez une personne celebre et ecrivez une requête SPARQL pour obtenir ses informations depuis DBpedia.
 
 **Indices** :
 - URI DBpedia : `http://dbpedia.org/resource/Prenom_Nom`
-- Testez d'abord sur [DBpedia SPARQL](http://dbpedia.org/sparql)",,,,,,,,3a4acdc375646778,,,,,,,
+- Testez d'abord sur [DBpedia SPARQL](http://dbpedia.org/sparql)",,,,,,,,5ac54a0c6d97aac8,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,1e2449de,code,fr,1c3aa416a2ee0b57,"// Exercice 1 : Remplacez l'URI par une personne de votre choix
 // Exemple : http://dbpedia.org/resource/Marie_Curie
 
@@ -13391,13 +13391,13 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,1e2449de,c
 // ExecuteAndDisplaySparqlQuery(endpoint, exQuery, 20);
 
 Console.WriteLine(""Exercice a completer"");",,,,,,,,1c3aa416a2ee0b57,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,1c83c75e,markdown,fr,4012768ea9d76db1,"### Exercice 2 : Meme personne sur Wikidata
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,1c83c75e,markdown,fr,ccd2c569e4d51d5b,"### Exercice 2 : Même personne sur Wikidata
 
-Trouvez la meme personne sur Wikidata et comparez les resultats avec DBpedia.
+Trouvez la même personne sur Wikidata et comparez les résultats avec DBpedia.
 
 **Indices** :
 - Cherchez le QID sur [wikidata.org](https://www.wikidata.org/) (ex : Marie Curie = Q7186)
-- Utilisez `SERVICE wikibase:label { bd:serviceParam wikibase:language 'fr,en'. }`",,,,,,,,4012768ea9d76db1,,,,,,,
+- Utilisez `SERVICE wikibase:label { bd:serviceParam wikibase:language 'fr,en'. }`",,,,,,,,ccd2c569e4d51d5b,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,8a441517,code,fr,e1b87d3c050ce6e0,"// Exercice 2 : Remplacez Q7186 par le QID de votre personne
 
 // string exWd = @""
@@ -13411,13 +13411,13 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,8a441517,c
 // ExecuteAndDisplaySparqlQuery(wikidataEndpoint, exWd, 20);
 
 Console.WriteLine(""Exercice a completer"");",,,,,,,,e1b87d3c050ce6e0,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,c7a7ccd7,markdown,fr,7a5b2717c3d22dc1,"### Exercice 3 : Pont owl:sameAs entre DBpedia et Wikidata
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,c7a7ccd7,markdown,fr,13512a7df3829a2c,"### Exercice 3 : Pont owl:sameAs entre DBpedia et Wikidata
 
-Ecrivez deux requetes qui exploitent `owl:sameAs` pour relier DBpedia et Wikidata sur un sujet de votre choix.
+Ecrivez deux requêtes qui exploitent `owl:sameAs` pour relier DBpedia et Wikidata sur un sujet de votre choix.
 
 **Indices** :
-- Etape 1 : `SELECT ?sameAs WHERE { <dbr:SUJET> owl:sameAs ?sameAs . FILTER(STRSTARTS(STR(?sameAs), 'http://www.wikidata.org/')) }`
-- Etape 2 : Utilisez le QID obtenu pour interroger Wikidata",,,,,,,,7a5b2717c3d22dc1,,,,,,,
+- Étape 1 : `SELECT ?sameAs WHERE { <dbr:SUJET> owl:sameAs ?sameAs . FILTER(STRSTARTS(STR(?sameAs), 'http://www.wikidata.org/')) }`
+- Étape 2 : Utilisez le QID obtenu pour interroger Wikidata",,,,,,,,13512a7df3829a2c,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,90c25a18,code,fr,2d0122b861d86387,"// Exercice 3 : Trouvez les liens owl:sameAs puis interrogez Wikidata
 
 // Etape 1 : Liens owl:sameAs depuis DBpedia
@@ -13441,32 +13441,32 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,90c25a18,c
 // ExecuteAndDisplaySparqlQuery(wikidataEndpoint, wdQ, 15);
 
 Console.WriteLine(""Exercice a completer"");",,,,,,,,2d0122b861d86387,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,sw5-refs-savantes-3164,markdown,fr,65571a113f456df7,"## References savantes
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,sw5-refs-savantes-3164,markdown,fr,fe46b9323876e8d8,"## References savantes
 
-- **Linked Data** - Berners-Lee, *Linked Data* (W3C Design Issues, 27 juillet 2006). Note de conception fondatrice : les 4 regles de publication des donnees liees.
-- **Linked Data: Evolving the Web into a Global Data Space** - Heath & Bizer, Morgan & Claypool (Synthesis Lectures on the Semantic Web: Theory and Technology, 2011). Textbook canonique du Web de donnees (principes, RDF, SPARQL, interconnexion).
+- **Linked Data** - Berners-Lee, *Linked Data* (W3C Design Issues, 27 juillet 2006). Note de conception fondatrice : les 4 règles de publication des données liees.
+- **Linked Data: Evolving the Web into a Global Data Space** - Heath & Bizer, Morgan & Claypool (Synthesis Lectures on the Semantic Web: Theory and Technology, 2011). Textbook canonique du Web de données (principes, RDF, SPARQL, interconnexion).
 - **Schema 5 etoiles** - Berners-Lee (2010). Convention de maturite de l'Open Data gouvernemental (de *.***** Linked Data).
 - **DBpedia** - Lehmann, Isele, Jakob et al., *DBpedia - A Large-scale, Multilingual Knowledge Base Extracted from Wikipedia*, Semantic Web Journal 6(2), 2015. Methodologie d'extraction WikiText -> RDF du dataset pivot du LOD Cloud.
 - **OWL 2 Direct Semantics** - Motik, Patel-Schneider, Cuenca Grau (W3C Rec, 11 decembre 2012). Definition formelle de `owl:sameAs` (egalite entre individus), ciment du Linked Open Data Cloud.
-- **owl:sameAs limits** - Halpin, Herman, Hicks, *When owl:sameAs Isn't the Same: An Analysis of Identity in Linked Data* (ISWC 2010). Analyse critique des sameAs abusifs et asymetriques.",,,,,,,,65571a113f456df7,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,8aa46fad,markdown,fr,4abca53be61a3263,"---
+- **owl:sameAs limits** - Halpin, Herman, Hicks, *When owl:sameAs Isn't the Same: An Analysis of Identity in Linked Data* (ISWC 2010). Analyse critique des sameAs abusifs et asymetriques.",,,,,,,,fe46b9323876e8d8,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,8aa46fad,markdown,fr,7734f36f250387f6,"---
 
 ## Resume
 
 | Concept | Description |
 |---------|-------------|
-| **4 regles du Linked Data** | URIs, HTTP, informations utiles, liens entre sources |
-| **5 etoiles Open Data** | Graduation de la qualite des donnees ouvertes |
+| **4 règles du Linked Data** | URIs, HTTP, informations utiles, liens entre sources |
+| **5 etoiles Open Data** | Graduation de la qualite des données ouvertes |
 | **DBpedia** | Extraction Wikipedia, URIs lisibles, endpoint `http://dbpedia.org/sparql` |
 | **Wikidata** | Base collaborative, QIDs/PIDs, `SERVICE wikibase:label` |
 | **owl:sameAs** | Pont entre datasets equivalents (DBpedia <-> Wikidata) |
-| **Requetes federees** | Clause `SERVICE` pour combiner endpoints |
+| **Requêtes federees** | Clause `SERVICE` pour combiner endpoints |
 | **SparqlQueryClient** | Classe .NET async pour interroger des endpoints distants |
 | **Gestion d'erreurs** | `try-catch`, fallback local, `LIMIT` obligatoire |
 
 ### Quand utiliser quel endpoint ?
 
-| Scenario | Recommandation | Raison |
+| Scénario | Recommandation | Raison |
 |----------|---------------|--------|
 | Prototype rapide | DBpedia | URIs lisibles |
 | Production | Wikidata | Qualite, fraicheur, CC0 |
@@ -13478,26 +13478,26 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb,8aa46fad,m
 - [SPARQL Federation](https://www.w3.org/TR/sparql11-federated-query/) (W3C)
 - [Wikidata Query Service](https://query.wikidata.org/) (editeur visuel)
 
-**Prochain notebook** : [SW-6-RDFS](SW-6-CSharp-RDFS.ipynb) - Vocabulaire RDFS, inference et hierarchies de classes
+**Prochain notebook** : [SW-6-RDFS](SW-6-CSharp-RDFS.ipynb) - Vocabulaire RDFS, inference et hiérarchies de classes
 
 ---
 
-**Navigation** : [<< 4-SPARQL](SW-4-CSharp-SPARQL.ipynb) | [Index](README.md) | [6-RDFS >>](SW-6-CSharp-RDFS.ipynb)",,,,,,,,4abca53be61a3263,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,611f0eb0,markdown,fr,1c9acefe5849802b,"# SW-6b-Python-RDFS
+**Navigation** : [<< 4-SPARQL](SW-4-CSharp-SPARQL.ipynb) | [Index](README.md) | [6-RDFS >>](SW-6-CSharp-RDFS.ipynb)",,,,,,,,7734f36f250387f6,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,611f0eb0,markdown,fr,6b495f953975d9a3,"# SW-6b-Python-RDFS
 
 **Navigation** : [Index](README.md) | [<< SW-6 C#](SW-6-CSharp-RDFS.ipynb) | [SW-7b Python OWL >>](SW-7b-Python-OWL.ipynb)
 
 ## RDFS en Python avec rdflib + owlrl : Schema et Inference
 
-Ce notebook est un **sidetrack optionnel** qui presente l'equivalent Python des concepts RDFS du notebook SW-6 (dotNetRDF). Vous y decouvrirez comment **rdflib** (construction de schemas, parsing Turtle, requetes SPARQL) et **owlrl** (vrai raisonneur RDFS) cooperent pour reproduire en Python le travail du `StaticRdfsReasoner` de dotNetRDF.
+Ce notebook est un **sidetrack optionnel** qui presente l'equivalent Python des concepts RDFS du notebook SW-6 (dotNetRDF). Vous y decouvrirez comment **rdflib** (construction de schemas, parsing Turtle, requêtes SPARQL) et **owlrl** (vrai raisonneur RDFS) cooperent pour reproduire en Python le travail du `StaticRdfsReasoner` de dotNetRDF.
 
 ### Objectifs d'apprentissage
 
 A la fin de ce notebook, vous saurez :
 1. Construire un schema RDFS en Python avec rdflib (`rdfs:Class`, `rdfs:subClassOf`, `rdfs:domain`, `rdfs:range`)
-2. Charger un fichier Turtle existant (`data/animals.ttl`) et explorer sa hierarchie de classes
+2. Charger un fichier Turtle existant (`data/animals.ttl`) et explorer sa hiérarchie de classes
 3. Appliquer un **vrai raisonneur RDFS** (owlrl) pour materialiser les triplets inferes
-4. Interroger les donnees enrichies par SPARQL
+4. Interroger les données enrichies par SPARQL
 5. Faire la correspondance entre dotNetRDF (`StaticRdfsReasoner`) et rdflib + owlrl (`DeductiveClosure`)
 
 ### Prerequis
@@ -13507,13 +13507,13 @@ A la fin de ce notebook, vous saurez :
 
 ### Duree estimee : 40 minutes
 
-> **Note** : owlrl est le raisonneur RDFS/OWL de reference en Python pur (implementation des regles d'entailment W3C RDF 1.1 Semantics). Nous ne reinventerons **pas** l'inference a la main dans les cellules de production : une cellule de demonstration pedagogique expose le mecanisme (point fixe), puis owlrl prend le relais pour le travail reel.
-",,,,,,,,1c9acefe5849802b,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,ac5a3934,markdown,fr,c0951872ef7d0e29,"---
+> **Note** : owlrl est le raisonneur RDFS/OWL de reference en Python pur (implementation des règles d'entailment W3C RDF 1.1 Semantics). Nous ne reinventerons **pas** l'inference a la main dans les cellules de production : une cellule de demonstration pedagogique expose le mécanisme (point fixe), puis owlrl prend le relais pour le travail reel.
+",,,,,,,,6b495f953975d9a3,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,ac5a3934,markdown,fr,49e5aaee78a9a22e,"---
 ## 1. Installation et imports
 
-**rdflib** est le coeur Python du Web Semantique (equivalent de dotNetRDF). **owlrl** est le raisonneur RDFS/OWL-RL qui materialise les triplets inferes (equivalent du `StaticRdfsReasoner` de dotNetRDF).
-",,,,,,,,c0951872ef7d0e29,,,,,,,
+**rdflib** est le coeur Python du Web Sémantique (equivalent de dotNetRDF). **owlrl** est le raisonneur RDFS/OWL-RL qui materialise les triplets inferes (equivalent du `StaticRdfsReasoner` de dotNetRDF).
+",,,,,,,,49e5aaee78a9a22e,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,02fc2fca,code,fr,e4f01b0c2d9c5b75,"# Dependances pre-provisionnees (rdflib owlrl) : voir SemanticWeb/requirements.txt ; imports dans les cellules suivantes.
 ",,,,,,,,e4f01b0c2d9c5b75,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,742c4f32,markdown,fr,df62fa9735f5b243,"Import des bibliotheques. Les namespaces W3C (`RDF`, `RDFS`, `XSD`) sont preconfigures dans rdflib, ce qui evite de manipuler les URIs completes a la main.",,,,,,,,df62fa9735f5b243,,,,,,,
@@ -13538,7 +13538,7 @@ except ImportError as e:
     print(f""Bibliotheque manquante : {e}"")
     print(""Installez avec : pip install rdflib owlrl"")
 ",,,,,,,,5da63e694a818f77,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,0e3d6344,markdown,fr,27e2b7e0eb95b62f,"### Interpretation : imports
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,0e3d6344,markdown,fr,47946632b674561b,"### Interpretation : imports
 
 | Symbole rdflib | Equivalent dotNetRDF |
 |---------------|----------------------|
@@ -13551,25 +13551,25 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,0e3d6344,markdo
 
 **Points cles** :
 1. rdflib expose les namespaces W3C comme attributs Python (`RDFS.subClassOf` au lieu de l'URI complete `http://www.w3.org/2000/01/rdf-schema#subClassOf`).
-2. owlrl est un **module separe** de rdflib : on l'invoque explicitement quand on veut du raisonnement. C'est une difference philosophique avec dotNetRDF ou le raisonneur est integre.",,,,,,,,27e2b7e0eb95b62f,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,bdd1ff5a,markdown,fr,396127773ee4a744,"---
+2. owlrl est un **module separe** de rdflib : on l'invoque explicitement quand on veut du raisonnement. C'est une différence philosophique avec dotNetRDF ou le raisonneur est integre.",,,,,,,,47946632b674561b,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,bdd1ff5a,markdown,fr,a342f1c2fc058ab8,"---
 ## 2. Qu'est-ce que RDFS ?
 
-**RDF Schema (RDFS)** est une extension de RDF qui fournit un vocabulaire pour decrire la **structure** des donnees RDF. Tandis que RDF permet d'exprimer des faits sous forme de triplets (sujet, predicat, objet), RDFS ajoute la capacite de definir :
+**RDF Schema (RDFS)** est une extension de RDF qui fournit un vocabulaire pour decrire la **structure** des données RDF. Tandis que RDF permet d'exprimer des faits sous forme de triplets (sujet, predicat, objet), RDFS ajoute la capacite de définir :
 
-> **RDF Schema (RDFS)** est standardise par le **W3C** dans RDF Schema 1.1 (Brickley & Guha, W3C Recommendation 2014). C'est une extension de RDF qui fournit un vocabulaire pour decrire la **structure** des donnees RDF -- classes, hierarchies, domaines/portees de proprietes et regles d'inference.
+> **RDF Schema (RDFS)** est standardise par le **W3C** dans RDF Schema 1.1 (Brickley & Guha, W3C Recommendation 2014). C'est une extension de RDF qui fournit un vocabulaire pour decrire la **structure** des données RDF -- classes, hiérarchies, domaines/portees de proprietes et règles d'inference.
 
-- Des **classes** et des **hierarchies de classes**
+- Des **classes** et des **hiérarchies de classes**
 - Des **proprietes** avec domaine et portee
-- Des **regles d'inference** implicites
+- Des **règles d'inference** implicites
 
-### RDFS dans la pile du Web Semantique
+### RDFS dans la pile du Web Sémantique
 
 ```
      +------------------+
      |   OWL (SW-7)     |  <- Logique descriptive
      +------------------+
-     |   RDFS (SW-6)    |  <- Vocabulaires, hierarchies  <-- Nous sommes ici
+     |   RDFS (SW-6)    |  <- Vocabulaires, hiérarchies  <-- Nous sommes ici
      +------------------+
      | SPARQL (SW-4/5)  |  <- Interrogation
      +------------------+
@@ -13584,11 +13584,11 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,bdd1ff5a,markdo
 | Capacite | RDF seul | RDF + RDFS |
 |----------|----------|------------|
 | Exprimer des faits (triplets) | Oui | Oui |
-| Definir des classes | Non | `rdfs:Class` |
-| Hierarchies de classes | Non | `rdfs:subClassOf` |
-| Hierarchies de proprietes | Non | `rdfs:subPropertyOf` |
+| Définir des classes | Non | `rdfs:Class` |
+| Hiérarchies de classes | Non | `rdfs:subClassOf` |
+| Hiérarchies de proprietes | Non | `rdfs:subPropertyOf` |
 | Contraindre domaine/portee | Non | `rdfs:domain`, `rdfs:range` |
-| Inference automatique | Non | Oui (regles RDFS) |
+| Inference automatique | Non | Oui (règles RDFS) |
 | Documentation | Limite | `rdfs:label`, `rdfs:comment` |
 
 ### Vocabulaire RDFS complet
@@ -13597,7 +13597,7 @@ Le namespace RDFS est `http://www.w3.org/2000/01/rdf-schema#`. Voici les termes 
 
 | Terme RDFS | Type | Description |
 |------------|------|-------------|
-| `rdfs:Class` | Classe | Definit une classe (un ensemble de ressources) |
+| `rdfs:Class` | Classe | Définit une classe (un ensemble de ressources) |
 | `rdfs:subClassOf` | Propriete | A est une sous-classe de B (A $\subseteq$ B) |
 | `rdfs:subPropertyOf` | Propriete | P1 est une sous-propriete de P2 |
 | `rdfs:domain` | Propriete | Le sujet d'un triplet avec P est de type C |
@@ -13606,14 +13606,14 @@ Le namespace RDFS est `http://www.w3.org/2000/01/rdf-schema#`. Voici les termes 
 | `rdfs:comment` | Propriete | Description textuelle |
 | `rdfs:Resource` | Classe | Superclasse de toutes les ressources |
 | `rdfs:Literal` | Classe | Classe des valeurs litterales |
-| `rdfs:Datatype` | Classe | Classe des types de donnees |
+| `rdfs:Datatype` | Classe | Classe des types de données |
 | `rdfs:seeAlso` | Propriete | Lien vers une ressource connexe |
 | `rdfs:isDefinedBy` | Propriete | Lien vers la definition de la ressource |
-",,,,,,,,396127773ee4a744,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,98757612,markdown,fr,c1d6756f3251c32d,"---
+",,,,,,,,a342f1c2fc058ab8,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,98757612,markdown,fr,54b04ef039debcd1,"---
 ## 3. Construire un schema RDFS en code
 
-Construisons une taxonomie animale en Python avec rdflib. Nous allons creer la hierarchie suivante :
+Construisons une taxonomie animale en Python avec rdflib. Nous allons créer la hiérarchie suivante :
 
 ```
   Animal
@@ -13624,7 +13624,7 @@ Construisons une taxonomie animale en Python avec rdflib. Nous allons creer la h
       +-- Parrot (Perroquet)
 ```
 
-La meme **taxonomie**, rendue sous forme de graphe : chaque fleche `rdfs:subClassOf` pointe de la sous-classe vers sa super-classe (sens de lecture « est une sorte de »).
+La même **taxonomie**, rendue sous forme de graphe : chaque fleche `rdfs:subClassOf` pointe de la sous-classe vers sa super-classe (sens de lecture « est une sorte de »).
 
 ```mermaid
 graph BT
@@ -13647,7 +13647,7 @@ graph BT
     class Dog,Cat,Parrot leaf
 ```
 
-> **Lecture.** Les 5 relations `rdfs:subClassOf` (Dog/Cat < Mammal, Parrot < Bird, Mammal/Bird < Animal) forment un **arbre d'heritage**. RDFS garantit que cette relation est *transitive* : `Dog <: Mammal` et `Mammal <: Animal` impliquent `Dog <: Animal`. C'est cette transitivite que le raisonneur exploite pour typer les instances par toutes leurs classes ancetres.",,,,,,,,c1d6756f3251c32d,,,,,,,
+> **Lecture.** Les 5 relations `rdfs:subClassOf` (Dog/Cat < Mammal, Parrot < Bird, Mammal/Bird < Animal) forment un **arbre d'heritage**. RDFS garantit que cette relation est *transitive* : `Dog <: Mammal` et `Mammal <: Animal` impliquent `Dog <: Animal`. C'est cette transitivite que le raisonneur exploite pour typer les instances par toutes leurs classes ancetres.",,,,,,,,54b04ef039debcd1,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,71a4b36b,code,fr,f976720a57540300,"if LIBS_AVAILABLE:
     # Construire un schema RDFS en Python avec rdflib
     schema = Graph()
@@ -13699,17 +13699,17 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,71a4b36b,code,f
 else:
     print(""Bibliotheques non disponibles : construction du schema ignoree."")
 ",,,,,,,,f976720a57540300,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,267a6458,markdown,fr,955f98d0400e584d,"### Interpretation : Construction du schema
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,267a6458,markdown,fr,253d968f4d40bd7d,"### Interpretation : Construction du schema
 
-Nous avons cree un schema RDFS complet avec :
-- **6 classes** organisees en hierarchie
+Nous avons créé un schema RDFS complet avec :
+- **6 classes** organisees en hiérarchie
 - **5 relations `rdfs:subClassOf`** definissant l'arbre taxonomique
 - **6 etiquettes `rdfs:label`** en francais
 - **1 commentaire `rdfs:comment`** sur la classe racine
 
-| Operation | rdflib (Python) | dotNetRDF (C#) |
+| Opération | rdflib (Python) | dotNetRDF (C#) |
 |-----------|-----------------|----------------|
-| Creer un graphe | `g = Graph()` | `IGraph g = new Graph()` |
+| Créer un graphe | `g = Graph()` | `IGraph g = new Graph()` |
 | Ajouter un triplet | `g.add((s, p, o))` | `g.Assert(new Triple(s, p, o))` |
 | Litteral avec langue | `Literal(""Animal"", lang=""fr"")` | `g.CreateLiteralNode(""Animal"", ""fr"")` |
 | Namespace | `g.bind(""ex"", EX)` | `g.NamespaceMap.AddNamespace(""ex"", uri)` |
@@ -13717,7 +13717,7 @@ Nous avons cree un schema RDFS complet avec :
 **Points cles** :
 1. Chaque classe est declaree comme instance de `rdfs:Class` via `rdf:type`
 2. `rdfs:subClassOf` est **transitif** : Dog < Mammal < Animal, donc Dog < Animal
-3. Les etiquettes multilingues utilisent les tags de langue (`lang=""fr""`, `lang=""en""`, etc.)",,,,,,,,955f98d0400e584d,,,,,,,
+3. Les etiquettes multilingues utilisent les tags de langue (`lang=""fr""`, `lang=""en""`, etc.)",,,,,,,,253d968f4d40bd7d,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,351139d8,markdown,fr,74bff92a6e6dbfa9,"### Ajout de proprietes avec domaine et portee
 
 Definissons des proprietes pour notre taxonomie, avec `rdfs:domain` (type du sujet) et `rdfs:range` (type de l'objet/valeur).",,,,,,,,74bff92a6e6dbfa9,,,,,,,
@@ -13763,22 +13763,22 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,0a4d9805,code,f
 else:
     print(""Bibliotheques non disponibles : proprietes ignorees."")
 ",,,,,,,,acd68e237ccd2b7d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,ec36378d,markdown,fr,9ca0620cff0e7a37,"### Interpretation : Domaine et portee
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,ec36378d,markdown,fr,086028131aa577d0,"### Interpretation : Domaine et portee
 
 | Propriete | Domaine | Portee | Signification |
 |-----------|---------|--------|---------------|
-| `ex:name` | `ex:Animal` | `xsd:string` | Le nom est une chaine, applicable a tout Animal |
+| `ex:name` | `ex:Animal` | `xsd:string` | Le nom est une chaîne, applicable a tout Animal |
 | `ex:age` | `ex:Animal` | `xsd:integer` | L'age est un entier |
-| `ex:sound` | `ex:Animal` | `xsd:string` | Le cri est une chaine |
+| `ex:sound` | `ex:Animal` | `xsd:string` | Le cri est une chaîne |
 | `ex:canFly` | `ex:Animal` | `xsd:boolean` | Capacite de vol, vrai/faux |
 
 **Consequence de `rdfs:domain`** : si on ecrit `ex:rex ex:name ""Rex""`, alors un raisonneur RDFS peut **inferer** que `ex:rex rdf:type ex:Animal` (car `ex:name` a pour domaine `ex:Animal`).
 
-> **Attention** : `rdfs:domain` et `rdfs:range` ne sont pas des contraintes de validation (comme en SQL). Ce sont des **regles d'inference**. Si le domaine est viole, RDFS ne signale pas d'erreur -- il infere un type supplementaire.",,,,,,,,9ca0620cff0e7a37,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,5dd16b92,markdown,fr,b34d8a8bc47088ef,"---
+> **Attention** : `rdfs:domain` et `rdfs:range` ne sont pas des contraintes de validation (comme en SQL). Ce sont des **règles d'inference**. Si le domaine est viole, RDFS ne signale pas d'erreur -- il infere un type supplementaire.",,,,,,,,086028131aa577d0,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,5dd16b92,markdown,fr,4f4a906a3e77cbcf,"---
 ## 4. Charger et explorer `animals.ttl`
 
-Le fichier `data/animals.ttl` contient la hierarchie complete avec des instances. Chargeons-le avec le parser Turtle de rdflib et explorons sa structure.",,,,,,,,b34d8a8bc47088ef,,,,,,,
+Le fichier `data/animals.ttl` contient la hiérarchie complete avec des instances. Chargeons-le avec le parser Turtle de rdflib et explorons sa structure.",,,,,,,,4f4a906a3e77cbcf,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,0a3db2b0,code,fr,6fd363951b7c7ce8,"if LIBS_AVAILABLE:
     # Charger le fichier animals.ttl avec rdflib
     animals = Graph()
@@ -13799,7 +13799,7 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,0a3db2b0,code,f
 else:
     print(""Bibliotheques non disponibles : chargement ignore."")
 ",,,,,,,,6fd363951b7c7ce8,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,ef88b8c5,markdown,fr,11b0376de9ee1aa9,Explorons maintenant la hierarchie de classes et les instances declarees (avant toute inference).,,,,,,,,11b0376de9ee1aa9,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,ef88b8c5,markdown,fr,390ac41f084c0145,Explorons maintenant la hiérarchie de classes et les instances declarees (avant toute inference).,,,,,,,,390ac41f084c0145,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,fd2b3607,code,fr,9e03e2d170483d7d,"if LIBS_AVAILABLE:
     # Explorer la hierarchie de classes
     print(""Hierarchie de classes (rdfs:subClassOf) :"")
@@ -13818,28 +13818,28 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,fd2b3607,code,f
 else:
     print(""Bibliotheques non disponibles : exploration ignoree."")
 ",,,,,,,,9e03e2d170483d7d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,8ae872a2,markdown,fr,c852abd33101a80d,"### Interpretation : Structure du fichier animals.ttl
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,8ae872a2,markdown,fr,c0f9bd9d09d13312,"### Interpretation : Structure du fichier animals.ttl
 
 Le fichier Turtle contient :
 
-| Element | Quantite | Exemples |
+| Élément | Quantite | Exemples |
 |---------|----------|----------|
 | Classes | 6 | Animal, Mammal, Bird, Dog, Cat, Parrot |
 | Proprietes | 4 | name, age, sound, canFly |
 | Instances | 4 | rex (Dog), minou (Cat), coco (Parrot), buddy (Dog) |
 | Relations subClassOf | 5 | Dog < Mammal < Animal, etc. |
 
-**Observation importante** : Les instances sont typees avec leur classe la plus specifique (ex: `ex:rex a ex:Dog`), mais **pas** avec les classes parentes. Un raisonneur RDFS deduira que Rex est aussi un Mammal et un Animal.",,,,,,,,c852abd33101a80d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,59010712,markdown,fr,a18a6b106685d19f,"---
+**Observation importante** : Les instances sont typees avec leur classe la plus spécifique (ex: `ex:rex a ex:Dog`), mais **pas** avec les classes parentes. Un raisonneur RDFS deduira que Rex est aussi un Mammal et un Animal.",,,,,,,,c0f9bd9d09d13312,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,59010712,markdown,fr,4e9e80cc3dad418f,"---
 ## 5. Inference RDFS
 
-L'inference RDFS permet de **deduire automatiquement** de nouveaux triplets a partir des regles RDFS. Le mecanisme principal est la **transitivite de `rdfs:subClassOf`**.
+L'inference RDFS permet de **deduire automatiquement** de nouveaux triplets a partir des règles RDFS. Le mécanisme principal est la **transitivite de `rdfs:subClassOf`**.
 
-> Les regles d'inference RDFS presentees ci-dessous (rdfs2, rdfs3, rdfs5, rdfs9, rdfs11) sont les **regles d'entailment** formellement specifiees dans RDF 1.1 Semantics (Hayes & Patel-Schneider, W3C Recommendation 2014). Elles definissent quels triplets peuvent etre deduits a partir d'un graphe RDFS.
+> Les règles d'inference RDFS presentees ci-dessous (rdfs2, rdfs3, rdfs5, rdfs9, rdfs11) sont les **règles d'entailment** formellement specifiees dans RDF 1.1 Semantics (Hayes & Patel-Schneider, W3C Recommendation 2014). Elles definissent quels triplets peuvent etre deduits a partir d'un graphe RDFS.
 
-### Regles d'inference RDFS essentielles
+### Règles d'inference RDFS essentielles
 
-| Regle | Premisses | Conclusion |
+| Règle | Premisses | Conclusion |
 |-------|-----------|------------|
 | **rdfs9** (heritage de type) | `?C rdfs:subClassOf ?D` et `?X rdf:type ?C` | `?X rdf:type ?D` |
 | **rdfs11** (transitivite) | `?A rdfs:subClassOf ?B` et `?B rdfs:subClassOf ?C` | `?A rdfs:subClassOf ?C` |
@@ -13849,7 +13849,7 @@ L'inference RDFS permet de **deduire automatiquement** de nouveaux triplets a pa
 
 ### Exemple concret
 
-Avec nos donnees :
+Avec nos données :
 ```turtle
 ex:Dog rdfs:subClassOf ex:Mammal .
 ex:Mammal rdfs:subClassOf ex:Animal .
@@ -13862,10 +13862,10 @@ ex:rex rdf:type ex:Mammal .         # Par rdfs9 (Dog < Mammal)
 ex:rex rdf:type ex:Animal .         # Par rdfs9 (Mammal < Animal)
 ex:Dog rdfs:subClassOf ex:Animal .  # Par rdfs11 (transitivite)
 ```
-",,,,,,,,a18a6b106685d19f,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,e16c9de3,markdown,fr,692ec11e92a5ff56,"### Demonstration : inference manuelle (pedagogique)
+",,,,,,,,4e9e80cc3dad418f,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,e16c9de3,markdown,fr,aefe891736424afc,"### Demonstration : inference manuelle (pedagogique)
 
-Implementons d'abord l'inference manuellement, **a but pedagogique uniquement**, pour bien comprendre le mecanisme du point fixe. En production, on utilise owlrl (section suivante) qui applique l'ensemble complet des regles W3C.",,,,,,,,692ec11e92a5ff56,,,,,,,
+Implementons d'abord l'inference manuellement, **a but pedagogique uniquement**, pour bien comprendre le mécanisme du point fixe. En production, on utilise owlrl (section suivante) qui applique l'ensemble complet des règles W3C.",,,,,,,,aefe891736424afc,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,703a1e74,code,fr,e2a7126e749c0462,"if LIBS_AVAILABLE:
     # Demonstration pedagogique : implementer manuellement la regle rdfs9
     # (heritage de type par rdfs:subClassOf) avec un point fixe.
@@ -13927,23 +13927,23 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,703a1e74,code,f
 else:
     print(""Bibliotheques non disponibles : demonstration ignoree."")
 ",,,,,,,,e2a7126e749c0462,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,a4624215,markdown,fr,7413246d4fe094c8,"### Interpretation : Inference manuelle
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,a4624215,markdown,fr,64e95b8d650cd652,"### Interpretation : Inference manuelle
 
 **Sortie obtenue** : A partir de 3 triplets initiaux, l'inference a deduit 2 triplets supplementaires.
 
-| Iteration | Triplet infere | Regle appliquee |
+| Itération | Triplet infere | Règle appliquee |
 |-----------|---------------|------------------|
 | 1 | `rex rdf:type Mammal` | rdfs9 : rex est Dog, Dog < Mammal |
 | 2 | `rex rdf:type Animal` | rdfs9 : rex est Mammal, Mammal < Animal |
 
 **Points cles** :
 1. L'algorithme est un **point fixe** : on itere jusqu'a ce qu'aucun nouveau triplet ne soit infere
-2. Chaque iteration propage les types d'un niveau dans la hierarchie
-3. Le nombre d'iterations depend de la **profondeur** de la hierarchie de classes
+2. Chaque itération propage les types d'un niveau dans la hiérarchie
+3. Le nombre d'itérations depend de la **profondeur** de la hiérarchie de classes
 
-> **En pratique**, on utilise owlrl plutot que cette implementation manuelle. Mais comprendre le mecanisme est essentiel : owlrl applique la meme logique de point fixe, mais sur les **51 regles** d'entailment W3C complet (rdfs2, rdfs3, rdfs5, rdfs7, rdfs9, rdfs11, etc.), pas seulement rdfs9.
+> **En pratique**, on utilise owlrl plutot que cette implementation manuelle. Mais comprendre le mécanisme est essentiel : owlrl applique la même logique de point fixe, mais sur les **51 règles** d'entailment W3C complet (rdfs2, rdfs3, rdfs5, rdfs7, rdfs9, rdfs11, etc.), pas seulement rdfs9.
 
-La regle d'inférence **rdfs9** (heritage de type par `rdfs:subClassOf`), rendue sous forme de graphe pour l'instance `ex:rex`. En trait plein : les 3 triplets *assertes* ; en tirete ambre : les 2 triplets *inferes* par transitivite.
+La règle d'inférence **rdfs9** (heritage de type par `rdfs:subClassOf`), rendue sous forme de graphe pour l'instance `ex:rex`. En trait plein : les 3 triplets *assertes* ; en tirete ambre : les 2 triplets *inferes* par transitivite.
 
 ```mermaid
 graph BT
@@ -13963,12 +13963,12 @@ graph BT
     linkStyle 3,4 stroke:#b8860b,stroke-width:2px
 ```
 
-> **Lecture.** Partant de **3 triplets** (`rex rdf:type Dog`, `Dog subClassOf Mammal`, `Mammal subClassOf Animal`), la regle rdfs9 — *« si `?x rdf:type ?C` et `?C rdfs:subClassOf ?D`, alors `?x rdf:type ?D` »* — deduit **2 triplets** supplementaires : `rex rdf:type Mammal` puis, en reappliquant la regle, `rex rdf:type Animal`. Le point-fixe est atteint quand plus aucun nouveau triplet n'apparait.",,,,,,,,7413246d4fe094c8,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,e081d9ad,markdown,fr,2f4b5ab61c80ef3b,"### Utilisation du raisonneur RDFS owlrl
+> **Lecture.** Partant de **3 triplets** (`rex rdf:type Dog`, `Dog subClassOf Mammal`, `Mammal subClassOf Animal`), la règle rdfs9 — *« si `?x rdf:type ?C` et `?C rdfs:subClassOf ?D`, alors `?x rdf:type ?D` »* — deduit **2 triplets** supplementaires : `rex rdf:type Mammal` puis, en reappliquant la règle, `rex rdf:type Animal`. Le point-fixe est atteint quand plus aucun nouveau triplet n'apparait.",,,,,,,,64e95b8d650cd652,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,e081d9ad,markdown,fr,b84a923f643e4623,"### Utilisation du raisonneur RDFS owlrl
 
-**owlrl** est le raisonneur RDFS/OWL de reference en Python pur. Il implemente l'ensemble des regles d'entailment du W3C (RDF 1.1 Semantics) et materialise les triplets inferes directement dans le graphe. C'est l'equivalent fonctionnel du `StaticRdfsReasoner` de dotNetRDF.
+**owlrl** est le raisonneur RDFS/OWL de reference en Python pur. Il implemente l'ensemble des règles d'entailment du W3C (RDF 1.1 Semantics) et materialise les triplets inferes directement dans le graphe. C'est l'equivalent fonctionnel du `StaticRdfsReasoner` de dotNetRDF.
 
-L'API principale est `owlrl.DeductiveClosure(owlrl.RDFS_Semantics).expand(graph)` : on instancie une closure avec un jeu de semantiques (ici RDFS seul ; `owlrl.OWLRL_Semantics` pour OWL 2 RL), puis on appelle `expand()` qui mute le graphe en place.",,,,,,,,2f4b5ab61c80ef3b,,,,,,,
+L'API principale est `owlrl.DeductiveClosure(owlrl.RDFS_Semantics).expand(graph)` : on instancie une closure avec un jeu de sémantiques (ici RDFS seul ; `owlrl.OWLRL_Semantics` pour OWL 2 RL), puis on appelle `expand()` qui mute le graphe en place.",,,,,,,,b84a923f643e4623,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,0a441ee8,code,fr,dbaf093546e14897,"if LIBS_AVAILABLE:
     # Charger animals.ttl dans un nouveau graphe frais
     animal_graph = Graph()
@@ -14007,16 +14007,16 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,0a441ee8,code,f
 else:
     print(""Bibliotheques non disponibles : raisonneur ignore."")
 ",,,,,,,,dbaf093546e14897,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,6f69650f,markdown,fr,6f4c8c32c0b0f127,"### Interpretation : Raisonneur RDFS owlrl
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,6f69650f,markdown,fr,eeba70c84669ed3d,"### Interpretation : Raisonneur RDFS owlrl
 
-Le `DeductiveClosure(RDFS_Semantics)` a enrichi le graphe automatiquement. Le nombre de triplets inferes est nettement plus grand que dans la demo manuelle car owlrl applique **l'ensemble des regles W3C**, pas seulement rdfs9 :
+Le `DeductiveClosure(RDFS_Semantics)` a enrichi le graphe automatiquement. Le nombre de triplets inferes est nettement plus grand que dans la demo manuelle car owlrl applique **l'ensemble des règles W3C**, pas seulement rdfs9 :
 
-| Regle W3C | Effet materialise |
+| Règle W3C | Effet materialise |
 |-----------|-------------------|
 | **rdfs9** | `rex rdf:type Mammal`, `rex rdf:type Animal`, etc. |
 | **rdfs3** | Les objets des proprietes typees `xsd:string` deviennent des litteraux string |
-| **rdfs2** | Les sujets de `ex:name` etc. sont types `ex:Animal` (meme si non declares) |
-| **rdfs11** | `Dog rdfs:subClassOf Animal` (transitivite de la hierarchie) |
+| **rdfs2** | Les sujets de `ex:name` etc. sont types `ex:Animal` (même si non declares) |
+| **rdfs11** | `Dog rdfs:subClassOf Animal` (transitivite de la hiérarchie) |
 | axiomatique | Tout est aussi `rdfs:Resource`, `rdf:type` est typing, etc. |
 
 | Instance | Types explicites | Types inferes (animaux) |
@@ -14027,14 +14027,14 @@ Le `DeductiveClosure(RDFS_Semantics)` a enrichi le graphe automatiquement. Le no
 | `buddy` | Dog | Mammal, Animal |
 
 **Comparaison** :
-- **Sans inference** : seul le type le plus specifique est present
+- **Sans inference** : seul le type le plus spécifique est present
 - **Avec inference** : tous les super-types sont materialises dans le graphe
 
-> **Note technique** : owlrl materialise les triplets inferes **directement dans le graphe**. C'est une approche de **materialisation** (par opposition au raisonnement a la requete). C'est exactement la meme philosophie que `StaticRdfsReasoner` en dotNetRDF.",,,,,,,,6f4c8c32c0b0f127,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,f7254545,markdown,fr,b097ad0759131a5a,"---
-## 6. Interroger les donnees enrichies par l'inference
+> **Note technique** : owlrl materialise les triplets inferes **directement dans le graphe**. C'est une approche de **materialisation** (par opposition au raisonnement a la requête). C'est exactement la même philosophie que `StaticRdfsReasoner` en dotNetRDF.",,,,,,,,eeba70c84669ed3d,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,f7254545,markdown,fr,017ad47dae98a263,"---
+## 6. Interroger les données enrichies par l'inference
 
-Maintenant que le graphe a ete enrichi par owlrl, utilisons SPARQL pour interroger les donnees inferees. rdflib integre un moteur SPARQL natif : `graph.query(sparql_string)` retourne un iterable de lignes de resultats.",,,,,,,,b097ad0759131a5a,,,,,,,
+Maintenant que le graphe a ete enrichi par owlrl, utilisons SPARQL pour interroger les données inferees. rdflib integre un moteur SPARQL natif : `graph.query(sparql_string)` retourne un iterable de lignes de résultats.",,,,,,,,017ad47dae98a263,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,8ed1c096,code,fr,b4d679fe0b12379d,"if LIBS_AVAILABLE:
     # Requete SPARQL : trouver tous les animaux (grace a l'inference)
     # NB : le FILTER restreint ?type aux classes de notre namespace animals# pour
@@ -14065,7 +14065,7 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,8ed1c096,code,f
 else:
     print(""Bibliotheques non disponibles : requete SPARQL ignoree."")
 ",,,,,,,,b4d679fe0b12379d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,10bf1cc7,markdown,fr,db7e93fd566b02b2,"La requete `?animal rdf:type ex:Animal` retourne **tous les animaux**, y compris ceux qui sont seulement types comme Dog, Cat ou Parrot. C'est la puissance de l'inference RDFS : on interroge a un niveau d'abstraction eleve sans avoir a enumerer toutes les sous-classes.",,,,,,,,db7e93fd566b02b2,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,10bf1cc7,markdown,fr,760b61aa3f4c605d,"La requête `?animal rdf:type ex:Animal` retourne **tous les animaux**, y compris ceux qui sont seulement types comme Dog, Cat ou Parrot. C'est la puissance de l'inference RDFS : on interroge a un niveau d'abstraction eleve sans avoir a enumerer toutes les sous-classes.",,,,,,,,760b61aa3f4c605d,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,162b7df7,code,fr,d20052a39c4c1001,"if LIBS_AVAILABLE:
     # Requete 2 : trouver tous les mammiferes (chiens ET chats, par inference)
     query2 = """"""
@@ -14116,7 +14116,7 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,162b7df7,code,f
 else:
     print(""Bibliotheques non disponibles : requetes SPARQL ignorees."")
 ",,,,,,,,d20052a39c4c1001,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,ff8aa2dd,markdown,fr,a61b195d88f21c8a,"### Interpretation : Requetes sur donnees inferees
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,ff8aa2dd,markdown,fr,b159f8de33289364,"### Interpretation : Requêtes sur données inferees
 
 | Classe | Instances directes | Instances inferees | Total |
 |--------|-------------------|--------------------|-------|
@@ -14129,14 +14129,14 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,ff8aa2dd,markdo
 
 **Points cles** :
 1. La classe `Animal` n'a **aucune instance directe** mais 4 par inference
-2. Les requetes SPARQL fonctionnent sur le graphe materialise, incluant les triplets inferes
-3. C'est un avantage majeur de RDFS : les donnees sont flexibles mais interrogeables a differents niveaux d'abstraction
+2. Les requêtes SPARQL fonctionnent sur le graphe materialise, incluant les triplets inferes
+3. C'est un avantage majeur de RDFS : les données sont flexibles mais interrogeables a différents niveaux d'abstraction
 
-> **Note** : la clause `FILTER(STRSTARTS(STR(?class), ""http://example.org/animals#""))` restreint le comptage aux classes de notre namespace. Sans elle, owlrl a aussi materialise des triplets axiomatiques comme `rex rdf:type rdfs:Resource` qui gonfleraient les comptes.",,,,,,,,a61b195d88f21c8a,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,bfead585,markdown,fr,cf4a664df47052dd,"---
+> **Note** : la clause `FILTER(STRSTARTS(STR(?class), ""http://example.org/animals#""))` restreint le comptage aux classes de notre namespace. Sans elle, owlrl a aussi materialise des triplets axiomatiques comme `rex rdf:type rdfs:Resource` qui gonfleraient les comptes.",,,,,,,,b159f8de33289364,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,bfead585,markdown,fr,71cf42f6e9d2e3c8,"---
 ## 7. Comparaison cross-language : dotNetRDF vs rdflib + owlrl
 
-Le notebook SW-6 (C#) et le present notebook (Python) traitent du **meme domaine** (taxonomie animale RDFS) avec des **moteurs RDFS reels** equivalents. Cette section repertorie les differences fines observees entre les deux stacks -- c'est la valeur ajoutée du miroir Python.
+Le notebook SW-6 (C#) et le present notebook (Python) traitent du **même domaine** (taxonomie animale RDFS) avec des **moteurs RDFS reels** equivalents. Cette section repertorie les différences fines observees entre les deux stacks -- c'est la valeur ajoutée du miroir Python.
 
 ### Synthese operationnelle
 
@@ -14146,9 +14146,9 @@ Le notebook SW-6 (C#) et le present notebook (Python) traitent du **meme domaine
 | **Parsing Turtle** | `TurtleParser().Load(g, ""file.ttl"")` | `g.parse(""file.ttl"", format=""turtle"")` |
 | **SPARQL** | `LeviathanQueryProcessor` + `SparqlQueryParser` | `g.query(sparql_string)` -- one-liner |
 | **Raisonneur RDFS** | `StaticRdfsReasoner.Apply(g)` (une ligne) | `owlrl.DeductiveClosure(RDFS_Semantics).expand(g)` |
-| **Couverture des regles** | Regles RDFS core (rdfs2/3/5/7/9/11) | RDFS Semantics complet (RDF 1.1) |
-| **Materialisation** | Mutations in-place du graphe | Mutations in-place du graphe (meme philosophie) |
-| **Rapport d'execution** | Aucun (silencieux) | Aucun (silencieux) ; `closure.closure_ok` disponible |
+| **Couverture des règles** | Règles RDFS core (rdfs2/3/5/7/9/11) | RDFS Semantics complet (RDF 1.1) |
+| **Materialisation** | Mutations in-place du graphe | Mutations in-place du graphe (même philosophie) |
+| **Rapport d'exécution** | Aucun (silencieux) | Aucun (silencieux) ; `closure.closure_ok` disponible |
 
 ### Difficultes rencontrees (et comment les contourner)
 
@@ -14161,27 +14161,27 @@ Le notebook SW-6 (C#) et le present notebook (Python) traitent du **meme domaine
 
 ### Ergonomie comparee
 
-L'API rdflib est plus **pythonique** (tuples, iterations naturelles, namespaces W3C comme constantes), tandis que dotNetRDF est plus **typee** (`IUriNode` vs `URIRef`, `Triple` objet vs tuple). Pour du raisonnement, **owlrl est plus verbeux a invoquer** (3 symboles : `DeductiveClosure` + `RDFS_Semantics` + `expand`) mais couvre davantage de regles W3C que le `StaticRdfsReasoner` de dotNetRDF qui se limite au coeur RDFS.
+L'API rdflib est plus **pythonique** (tuples, itérations naturelles, namespaces W3C comme constantes), tandis que dotNetRDF est plus **typee** (`IUriNode` vs `URIRef`, `Triple` objet vs tuple). Pour du raisonnement, **owlrl est plus verbeux a invoquer** (3 symboles : `DeductiveClosure` + `RDFS_Semantics` + `expand`) mais couvre davantage de règles W3C que le `StaticRdfsReasoner` de dotNetRDF qui se limite au coeur RDFS.
 
-> **Choix pratique** : pour un cours Python-first de Web Semantique, le binome rdflib + owlrl est autonomme et couvre tout le programme RDFS/OWL-RL. Pour un cours .NET, dotNetRDF integre raisonneur et SPARQL dans la meme bibliotheque, ce qui evite une dependance supplementaire.",,,,,,,,cf4a664df47052dd,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,d14a290e,markdown,fr,b3986b7e8fb10390,"---
+> **Choix pratique** : pour un cours Python-first de Web Sémantique, le binome rdflib + owlrl est autonomme et couvre tout le programme RDFS/OWL-RL. Pour un cours .NET, dotNetRDF integre raisonneur et SPARQL dans la même bibliotheque, ce qui evite une dépendance supplementaire.",,,,,,,,71cf42f6e9d2e3c8,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,d14a290e,markdown,fr,67a0dfb4432b7d75,"---
 ## Exercices
 
-Les trois exercices ci-dessous sont a completer. Le notebook doit pouvoir s'executer de bout en bout meme si les exercices restent vides (les stubs utilisent `print(""Exercice a completer"")` -- jamais d'erreur volontaire).
-",,,,,,,,b3986b7e8fb10390,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,42f0a956,markdown,fr,197b5ec2a3180148,"### Exercice 1 : Creer un vocabulaire RDFS pour une bibliotheque
+Les trois exercices ci-dessous sont a completer. Le notebook doit pouvoir s'executer de bout en bout même si les exercices restent vides (les stubs utilisent `print(""Exercice a completer"")` -- jamais d'erreur volontaire).
+",,,,,,,,67a0dfb4432b7d75,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,42f0a956,markdown,fr,1f71af2bc5cd1f33,"### Exercice 1 : Créer un vocabulaire RDFS pour une bibliotheque
 
-Creez un schema RDFS pour un domaine de bibliotheque avec :
+Créez un schema RDFS pour un domaine de bibliotheque avec :
 - Classes : `Publication`, `Book`, `Article`, `Author`, `Publisher`
-- Hierarchie : `Book` et `Article` sont des sous-classes de `Publication`
+- Hiérarchie : `Book` et `Article` sont des sous-classes de `Publication`
 - Proprietes : `title` (domain: Publication, range: string), `writtenBy` (domain: Publication, range: Author), `publishedBy` (domain: Book, range: Publisher), `year` (domain: Publication, range: integer)
 - Instances : au moins 2 livres et 1 article avec leurs auteurs
 - Appliquez le raisonneur owlrl et verifiez que les types sont bien inferes (un `Book` devient aussi une `Publication`).
 
 **Indices** :
-- Inspirez-vous de la section 3 : `g.add((EX.Book, RDFS.subClassOf, EX.Publication))` declare la hierarchie.
+- Inspirez-vous de la section 3 : `g.add((EX.Book, RDFS.subClassOf, EX.Publication))` declare la hiérarchie.
 - Pour les proprietes : `g.add((EX.title, RDF.type, RDF.Property))` + `g.add((EX.title, RDFS.domain, EX.Publication))` + `g.add((EX.title, RDFS.range, XSD.string))`.
-- Pour le raisonnement : `owlrl.DeductiveClosure(owlrl.RDFS_Semantics).expand(g)` puis verifiez qu'une instance de `Book` a bien aussi `rdf:type Publication`.",,,,,,,,197b5ec2a3180148,,,,,,,
+- Pour le raisonnement : `owlrl.DeductiveClosure(owlrl.RDFS_Semantics).expand(g)` puis verifiez qu'une instance de `Book` a bien aussi `rdf:type Publication`.",,,,,,,,1f71af2bc5cd1f33,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,193898f2,code,fr,d9cdecf88166d973,"# Exercice 1 : Vocabulaire RDFS pour une bibliotheque
 # TODO etudiant : construire le schema, les instances, appliquer owlrl
 #
@@ -14195,15 +14195,15 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,193898f2,code,f
 
 print(""Exercice 1 a completer : vocabulaire RDFS pour une bibliotheque"")
 ",,,,,,,,d9cdecf88166d973,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,b016946a,markdown,fr,dfedef7a9fda8deb,"### Exercice 2 : Requete SPARQL avec inference RDFS
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,b016946a,markdown,fr,7227b2ce1ea6d9ab,"### Exercice 2 : Requête SPARQL avec inference RDFS
 
-Les sections precedentes ont montre le raisonneur owlrl et les requetes SPARQL. Reproduisez le pattern complet sur le fichier `data/animals.ttl` :
+Les sections précédentes ont montre le raisonneur owlrl et les requêtes SPARQL. Reproduisez le pattern complet sur le fichier `data/animals.ttl` :
 
 **Indices** :
 - Chargez `data/animals.ttl` dans un graphe frais avec `g.parse(...)`.
 - Appliquez owlrl : `owlrl.DeductiveClosure(owlrl.RDFS_Semantics).expand(g)`.
-- Ecrivez une requete SPARQL qui retourne **tous les animaux dont le cri contient la lettre ""o""** (indice : `FILTER(CONTAINS(LCASE(?sound), ""o""))`).
-- Verifiez que le resultat inclut aussi bien `rex` (Dog) que `buddy` (Dog) et `coco` (Parrot) -- tous trois typés `Animal` par inference, meme si seul `rex` est declare explicitement comme Dog dans le fichier source.",,,,,,,,dfedef7a9fda8deb,,,,,,,
+- Ecrivez une requête SPARQL qui retourne **tous les animaux dont le cri contient la lettre ""o""** (indice : `FILTER(CONTAINS(LCASE(?sound), ""o""))`).
+- Verifiez que le résultat inclut aussi bien `rex` (Dog) que `buddy` (Dog) et `coco` (Parrot) -- tous trois typés `Animal` par inference, même si seul `rex` est declare explicitement comme Dog dans le fichier source.",,,,,,,,7227b2ce1ea6d9ab,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,552a9040,code,fr,3c51f76a8ed10c34,"# Exercice 2 : Requete SPARQL sur donnees enrichies par owlrl
 # TODO etudiant : charger animals.ttl, appliquer owlrl, executer une SPARQL
 #
@@ -14215,19 +14215,19 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,552a9040,code,f
 
 print(""Exercice 2 a completer : requete SPARQL sur donnees enrichies par owlrl"")
 ",,,,,,,,3c51f76a8ed10c34,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,54f90afc,markdown,fr,ba16f6afecb9833e,"### Exercice 3 : Chaine d'inference profonde (transitivite)
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,54f90afc,markdown,fr,b327c4b5e66c66f2,"### Exercice 3 : Chaîne d'inference profonde (transitivite)
 
-Creez une hierarchie de classes plus profonde pour tester la transitivite de `rdfs:subClassOf` :
+Créez une hiérarchie de classes plus profonde pour tester la transitivite de `rdfs:subClassOf` :
 - `LivingThing` > `Animal` > `Vertebrate` > `Mammal` > `Primate` > `Human`
-- Creez une instance `alice rdf:type Human`
+- Créez une instance `alice rdf:type Human`
 - Affichez les types de `alice` **avant** inference
-- Appliquez owlrl et affichez les types de `alice` **apres** inference
-- Verifiez que `alice` est bien typee par les **6 classes** de la hierarchie (LivingThing, Animal, Vertebrate, Mammal, Primate, Human)
+- Appliquez owlrl et affichez les types de `alice` **après** inference
+- Verifiez que `alice` est bien typee par les **6 classes** de la hiérarchie (LivingThing, Animal, Vertebrate, Mammal, Primate, Human)
 
 **Indices** :
-- Une boucle `for i in range(len(chain) - 1): g.add((chain[i+1], RDFS.subClassOf, chain[i]))` permet de declarer la chaine en une ligne.
-- Apres `expand(g)`, parcourez `g.triples((alice, RDF.type, None))` et collectez les noms de classes.
-- owlrl materialise aussi le typing `rdfs:Resource` ; filtrez par namespace `http://example.org/biology#` pour ne garder que vos classes.",,,,,,,,ba16f6afecb9833e,,,,,,,
+- Une boucle `for i in range(len(chain) - 1): g.add((chain[i+1], RDFS.subClassOf, chain[i]))` permet de declarer la chaîne en une ligne.
+- Après `expand(g)`, parcourez `g.triples((alice, RDF.type, None))` et collectez les noms de classes.
+- owlrl materialise aussi le typing `rdfs:Resource` ; filtrez par namespace `http://example.org/biology#` pour ne garder que vos classes.",,,,,,,,b327c4b5e66c66f2,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,af715bf6,code,fr,3339d679a53a82d4,"# Exercice 3 : Chaine d'inference profonde
 # TODO etudiant : hierarchie profonde, instance alice, owlrl, verification
 #
@@ -14240,7 +14240,7 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,af715bf6,code,f
 
 print(""Exercice 3 a completer : chaine d'inference profonde"")
 ",,,,,,,,3339d679a53a82d4,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,6fc3bd3e,markdown,fr,2d64b40f4f004388,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,6fc3bd3e,markdown,fr,0eb171c89563e5ad,"---
 ## Resume
 
 ### Vocabulaire RDFS essentiel
@@ -14248,8 +14248,8 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,6fc3bd3e,markdo
 | Terme | Utilisation | Exemple |
 |-------|------------|----------|
 | `rdfs:Class` | Declarer une classe | `ex:Dog rdf:type rdfs:Class` |
-| `rdfs:subClassOf` | Hierarchie de classes | `ex:Dog rdfs:subClassOf ex:Mammal` |
-| `rdfs:subPropertyOf` | Hierarchie de proprietes | `ex:father rdfs:subPropertyOf ex:parent` |
+| `rdfs:subClassOf` | Hiérarchie de classes | `ex:Dog rdfs:subClassOf ex:Mammal` |
+| `rdfs:subPropertyOf` | Hiérarchie de proprietes | `ex:father rdfs:subPropertyOf ex:parent` |
 | `rdfs:domain` | Type du sujet | `ex:name rdfs:domain ex:Animal` |
 | `rdfs:range` | Type de l'objet/valeur | `ex:name rdfs:range xsd:string` |
 | `rdfs:label` | Etiquette lisible | `ex:Dog rdfs:label ""Chien""@fr` |
@@ -14257,15 +14257,15 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,6fc3bd3e,markdo
 
 ### Ce que nous avons appris
 
-1. **RDFS enrichit RDF** avec un vocabulaire pour decrire la structure des donnees
-2. **Les hierarchies de classes** (`rdfs:subClassOf`) permettent l'heritage de type
-3. **L'inference RDFS** deduit automatiquement des triplets implicites (regles rdfs2/3/5/9/11 du W3C)
+1. **RDFS enrichit RDF** avec un vocabulaire pour decrire la structure des données
+2. **Les hiérarchies de classes** (`rdfs:subClassOf`) permettent l'heritage de type
+3. **L'inference RDFS** deduit automatiquement des triplets implicites (règles rdfs2/3/5/9/11 du W3C)
 4. **owlrl.DeductiveClosure(RDFS_Semantics).expand(g)** materialise les triplets inferes dans le graphe -- equivalent Python du `StaticRdfsReasoner` de dotNetRDF
-5. **SPARQL sur donnees inferees** permet d'interroger a differents niveaux d'abstraction
+5. **SPARQL sur données inferees** permet d'interroger a différents niveaux d'abstraction
 
 ### Equivalences dotNetRDF / rdflib + owlrl
 
-| Operation | dotNetRDF (SW-6 C#) | rdflib + owlrl (present) |
+| Opération | dotNetRDF (SW-6 C#) | rdflib + owlrl (present) |
 |-----------|---------------------|---------------------------|
 | Ajouter un triplet | `g.Assert(new Triple(s, p, o))` | `g.add((s, p, o))` |
 | Litteral avec langue | `g.CreateLiteralNode(""Chien"", ""fr"")` | `Literal(""Chien"", lang=""fr"")` |
@@ -14276,7 +14276,7 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb,6fc3bd3e,markdo
 ### Limites de RDFS
 
 RDFS est volontairement simple. Il ne permet **pas** de :
-- Definir des classes disjointes (Dog et Cat ne peuvent pas etre la meme instance)
+- Définir des classes disjointes (Dog et Cat ne peuvent pas etre la même instance)
 - Exprimer des cardinalites (une personne a exactement 2 parents)
 - Declarer des proprietes inverses (teaches / taughtBy)
 - Exprimer des classes par union/intersection
@@ -14286,15 +14286,15 @@ Pour ces fonctionnalites, il faut passer a **OWL** (notebook suivant).
 ## References
 
 - **RDF Schema 1.1** -- Brickley & Guha, W3C Recommendation (2014). [w3.org/TR/rdf-schema](https://www.w3.org/TR/rdf-schema/)
-- **RDF 1.1 Semantics** -- Hayes & Patel-Schneider, W3C Recommendation (2014). Specifie formellement les regles d'entailment rdfs2/3/5/9/11. [w3.org/TR/rdf11-mt](https://www.w3.org/TR/rdf11-mt/)
+- **RDF 1.1 Semantics** -- Hayes & Patel-Schneider, W3C Recommendation (2014). Specifie formellement les règles d'entailment rdfs2/3/5/9/11. [w3.org/TR/rdf11-mt](https://www.w3.org/TR/rdf11-mt/)
 - **rdflib documentation** -- [rdflib.readthedocs.io](https://rdflib.readthedocs.io/)
 - **owlrl** -- Raisonneur RDFS/OWL-RL en Python pur. [github.com/RDFLib/OWL-RL](https://github.com/RDFLib/OWL-RL)
 
 ---
 
 **Navigation** : [Index](README.md) | [<< SW-6 C#](SW-6-CSharp-RDFS.ipynb) | [SW-7b Python OWL >>](SW-7b-Python-OWL.ipynb)
-",,,,,,,,2d64b40f4f004388,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,d15fcd6d,markdown,fr,dc836305bb0c8b6a,"# SW-6-RDFS
+",,,,,,,,0eb171c89563e5ad,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,d15fcd6d,markdown,fr,6fa2711aa3ca462c,"# SW-6-RDFS
 
 **Navigation** : [<< 5-LinkedData](SW-5-CSharp-LinkedData.ipynb) | [Index](README.md) | [7-OWL >>](SW-7-CSharp-OWL.ipynb)
 
@@ -14303,11 +14303,11 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,d15fcd6d,markdow
 ### Objectifs d'apprentissage
 
 A la fin de ce notebook, vous saurez :
-1. Comprendre le vocabulaire RDFS et son role dans le Web Semantique
-2. Construire des hierarchies de classes et de proprietes avec `rdfs:subClassOf` et `rdfs:subPropertyOf`
+1. Comprendre le vocabulaire RDFS et son rôle dans le Web Sémantique
+2. Construire des hiérarchies de classes et de proprietes avec `rdfs:subClassOf` et `rdfs:subPropertyOf`
 3. Utiliser `rdfs:domain` et `rdfs:range` pour contraindre les proprietes
 4. Appliquer l'inference RDFS pour deduire de nouveaux triplets
-5. Interroger des donnees enrichies par le raisonnement RDFS
+5. Interroger des données enrichies par le raisonnement RDFS
 
 ### Prerequis
 - .NET SDK 9.0+ et .NET Interactive
@@ -14315,7 +14315,7 @@ A la fin de ce notebook, vous saurez :
 
 ### Duree estimee : 40 minutes
 
----",,,,,,,,dc836305bb0c8b6a,,,,,,,
+---",,,,,,,,6fa2711aa3ca462c,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,241c6590,markdown,fr,a6323234d61bee5d,"## Installation et imports
 
 Chargeons dotNetRDF et les espaces de noms necessaires pour travailler avec RDFS.",,,,,,,,a6323234d61bee5d,,,,,,,
@@ -14332,25 +14332,25 @@ using VDS.RDF.Query;
 using VDS.RDF.Query.Datasets;
 
 Console.WriteLine(""dotNetRDF charge avec succes."");",,,,,,,,0a483d596ba51f98,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,9c14d671,markdown,fr,7fae3e06272bd73d,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,9c14d671,markdown,fr,0dd227daf1e41a86,"---
 
 ## 1. Qu'est-ce que RDFS ?
 
-**RDF Schema (RDFS)** est une extension de RDF qui fournit un vocabulaire pour decrire la **structure** des donnees RDF. Tandis que RDF permet d'exprimer des faits sous forme de triplets (sujet, predicat, objet), RDFS ajoute la capacite de definir :
+**RDF Schema (RDFS)** est une extension de RDF qui fournit un vocabulaire pour decrire la **structure** des données RDF. Tandis que RDF permet d'exprimer des faits sous forme de triplets (sujet, predicat, objet), RDFS ajoute la capacite de définir :
 
-> **RDF Schema (RDFS)** est standardise par le **W3C** dans RDF Schema 1.1 (Brickley & Guha, W3C Recommendation 2014). C'est une extension de RDF qui fournit un vocabulaire pour decrire la **structure** des donnees RDF -- classes, hierarchies, domaines/portees de proprietes et regles d'inference.
+> **RDF Schema (RDFS)** est standardise par le **W3C** dans RDF Schema 1.1 (Brickley & Guha, W3C Recommendation 2014). C'est une extension de RDF qui fournit un vocabulaire pour decrire la **structure** des données RDF -- classes, hiérarchies, domaines/portees de proprietes et règles d'inference.
 
-- Des **classes** et des **hierarchies de classes**
+- Des **classes** et des **hiérarchies de classes**
 - Des **proprietes** avec domaine et portee
-- Des **regles d'inference** implicites
+- Des **règles d'inference** implicites
 
-### RDFS dans la pile du Web Semantique
+### RDFS dans la pile du Web Sémantique
 
 ```
      +------------------+
      |   OWL (SW-7)     |  <- Logique descriptive
      +------------------+
-     |   RDFS (SW-6)    |  <- Vocabulaires, hierarchies  <-- Nous sommes ici
+     |   RDFS (SW-6)    |  <- Vocabulaires, hiérarchies  <-- Nous sommes ici
      +------------------+
      | SPARQL (SW-4/5)  |  <- Interrogation
      +------------------+
@@ -14365,19 +14365,19 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,9c14d671,markdow
 | Capacite | RDF seul | RDF + RDFS |
 |----------|----------|------------|
 | Exprimer des faits (triplets) | Oui | Oui |
-| Definir des classes | Non | `rdfs:Class` |
-| Hierarchies de classes | Non | `rdfs:subClassOf` |
-| Hierarchies de proprietes | Non | `rdfs:subPropertyOf` |
+| Définir des classes | Non | `rdfs:Class` |
+| Hiérarchies de classes | Non | `rdfs:subClassOf` |
+| Hiérarchies de proprietes | Non | `rdfs:subPropertyOf` |
 | Contraindre domaine/portee | Non | `rdfs:domain`, `rdfs:range` |
-| Inference automatique | Non | Oui (regles RDFS) |
-| Documentation | Limite | `rdfs:label`, `rdfs:comment` |",,,,,,,,7fae3e06272bd73d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,080031d1,markdown,fr,5884539cf82c4404,"### Vocabulaire RDFS complet
+| Inference automatique | Non | Oui (règles RDFS) |
+| Documentation | Limite | `rdfs:label`, `rdfs:comment` |",,,,,,,,0dd227daf1e41a86,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,080031d1,markdown,fr,1b37a13303776d70,"### Vocabulaire RDFS complet
 
 Le namespace RDFS est `http://www.w3.org/2000/01/rdf-schema#`. Voici les termes essentiels :
 
 | Terme RDFS | Type | Description |
 |------------|------|-------------|
-| `rdfs:Class` | Classe | Definit une classe (un ensemble de ressources) |
+| `rdfs:Class` | Classe | Définit une classe (un ensemble de ressources) |
 | `rdfs:subClassOf` | Propriete | A est une sous-classe de B (A $\subseteq$ B) |
 | `rdfs:subPropertyOf` | Propriete | P1 est une sous-propriete de P2 |
 | `rdfs:domain` | Propriete | Le sujet d'un triplet avec P est de type C |
@@ -14386,14 +14386,14 @@ Le namespace RDFS est `http://www.w3.org/2000/01/rdf-schema#`. Voici les termes 
 | `rdfs:comment` | Propriete | Description textuelle |
 | `rdfs:Resource` | Classe | Superclasse de toutes les ressources |
 | `rdfs:Literal` | Classe | Classe des valeurs litterales |
-| `rdfs:Datatype` | Classe | Classe des types de donnees |
+| `rdfs:Datatype` | Classe | Classe des types de données |
 | `rdfs:seeAlso` | Propriete | Lien vers une ressource connexe |
-| `rdfs:isDefinedBy` | Propriete | Lien vers la definition de la ressource |",,,,,,,,5884539cf82c4404,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,06ad8a2c,markdown,fr,51dae2ed25b968e9,"---
+| `rdfs:isDefinedBy` | Propriete | Lien vers la definition de la ressource |",,,,,,,,1b37a13303776d70,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,06ad8a2c,markdown,fr,6835ccb4ee20e941,"---
 
 ## 2. Construire un schema RDFS en code
 
-Construisons une taxonomie animale en C# avec dotNetRDF. Nous allons creer la hierarchie suivante :
+Construisons une taxonomie animale en C# avec dotNetRDF. Nous allons créer la hiérarchie suivante :
 
 ```
   Animal
@@ -14402,7 +14402,7 @@ Construisons une taxonomie animale en C# avec dotNetRDF. Nous allons creer la hi
   │   └── Cat (Chat)
   └── Bird (Oiseau)
       └── Parrot (Perroquet)
-```",,,,,,,,51dae2ed25b968e9,,,,,,,
+```",,,,,,,,6835ccb4ee20e941,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,sw6-mermaid-taxonomy,markdown,fr,4bbd8e65c8be207f,"La même **taxonomie**, rendue sous forme de graphe : chaque flèche `rdfs:subClassOf`
 pointe de la sous-classe vers sa super-classe (sens de lecture « est une sorte de »).
 
@@ -14496,17 +14496,17 @@ foreach (Triple t in schema.GetTriplesWithPredicate(subClassOf))
     string parent = ((IUriNode)t.Object).Uri.Fragment.TrimStart('#');
     Console.WriteLine($""  {child} rdfs:subClassOf {parent}"");
 }",,,,,,,,a075e9d817b206af,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,219ab9ba,markdown,fr,1ad7e3d73e33d264,"### Interpretation : Construction du schema
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,219ab9ba,markdown,fr,7858346cd04225df,"### Interpretation : Construction du schema
 
-Nous avons cree un schema RDFS complet avec :
-- **6 classes** organisees en hierarchie
+Nous avons créé un schema RDFS complet avec :
+- **6 classes** organisees en hiérarchie
 - **5 relations `rdfs:subClassOf`** definissant l'arbre taxonomique
 - **6 etiquettes `rdfs:label`** en francais
 
 **Points cles** :
 1. Chaque classe est declaree comme instance de `rdfs:Class` via `rdf:type`
 2. `rdfs:subClassOf` est **transitif** : Dog < Mammal < Animal, donc Dog < Animal
-3. Les etiquettes multilingues utilisent les tags de langue (`""fr""`, `""en""`, etc.)",,,,,,,,1ad7e3d73e33d264,,,,,,,
+3. Les etiquettes multilingues utilisent les tags de langue (`""fr""`, `""en""`, etc.)",,,,,,,,7858346cd04225df,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,6eda0225,markdown,fr,74bff92a6e6dbfa9,"### Ajout de proprietes avec domaine et portee
 
 Definissons des proprietes pour notre taxonomie, avec `rdfs:domain` (type du sujet) et `rdfs:range` (type de l'objet/valeur).",,,,,,,,74bff92a6e6dbfa9,,,,,,,
@@ -14561,23 +14561,23 @@ foreach (Triple t in schema.GetTriplesWithPredicateObject(rdfType, rdfProperty))
     
     Console.WriteLine($""  ex:{propName}  domain={domain}  range={range}"");
 }",,,,,,,,132de2de94ddbfd6,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,2bed0a13,markdown,fr,9ca0620cff0e7a37,"### Interpretation : Domaine et portee
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,2bed0a13,markdown,fr,086028131aa577d0,"### Interpretation : Domaine et portee
 
 | Propriete | Domaine | Portee | Signification |
 |-----------|---------|--------|---------------|
-| `ex:name` | `ex:Animal` | `xsd:string` | Le nom est une chaine, applicable a tout Animal |
+| `ex:name` | `ex:Animal` | `xsd:string` | Le nom est une chaîne, applicable a tout Animal |
 | `ex:age` | `ex:Animal` | `xsd:integer` | L'age est un entier |
-| `ex:sound` | `ex:Animal` | `xsd:string` | Le cri est une chaine |
+| `ex:sound` | `ex:Animal` | `xsd:string` | Le cri est une chaîne |
 | `ex:canFly` | `ex:Animal` | `xsd:boolean` | Capacite de vol, vrai/faux |
 
 **Consequence de `rdfs:domain`** : si on ecrit `ex:rex ex:name ""Rex""`, alors un raisonneur RDFS peut **inferer** que `ex:rex rdf:type ex:Animal` (car `ex:name` a pour domaine `ex:Animal`).
 
-> **Attention** : `rdfs:domain` et `rdfs:range` ne sont pas des contraintes de validation (comme en SQL). Ce sont des **regles d'inference**. Si le domaine est viole, RDFS ne signale pas d'erreur -- il infere un type supplementaire.",,,,,,,,9ca0620cff0e7a37,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,01898305,markdown,fr,e4fd5a4b91e65847,"---
+> **Attention** : `rdfs:domain` et `rdfs:range` ne sont pas des contraintes de validation (comme en SQL). Ce sont des **règles d'inference**. Si le domaine est viole, RDFS ne signale pas d'erreur -- il infere un type supplementaire.",,,,,,,,086028131aa577d0,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,01898305,markdown,fr,d0cdcb2aa3c749cb,"---
 
 ## 3. Charger et explorer `animals.ttl`
 
-Le fichier `data/animals.ttl` contient la hierarchie complete avec des instances. Chargeons-le et explorons sa structure.",,,,,,,,e4fd5a4b91e65847,,,,,,,
+Le fichier `data/animals.ttl` contient la hiérarchie complete avec des instances. Chargeons-le et explorons sa structure.",,,,,,,,d0cdcb2aa3c749cb,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,b7a5d3d8,code,fr,2a753ea84061c292,"// Charger le fichier animals.ttl
 IGraph animals = new Graph();
 TurtleParser ttlParser = new TurtleParser();
@@ -14597,7 +14597,7 @@ foreach (Triple t in animals.GetTriplesWithPredicateObject(rdfTypeNode, rdfsClas
     string className = ((IUriNode)t.Subject).Uri.Fragment.TrimStart('#');
     Console.WriteLine($""  - {className}"");
 }",,,,,,,,2a753ea84061c292,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,accda6a0,markdown,fr,9e7cd03ac6ff800c,Explorons maintenant la hierarchie de classes et les instances.,,,,,,,,9e7cd03ac6ff800c,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,accda6a0,markdown,fr,9a40fdf884e04f80,Explorons maintenant la hiérarchie de classes et les instances.,,,,,,,,9a40fdf884e04f80,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,3d3a0dc6,code,fr,7bdd16ac7c62c925,"// Explorer la hierarchie de classes
 IUriNode subClassOfNode = animals.CreateUriNode(new Uri(""http://www.w3.org/2000/01/rdf-schema#subClassOf""));
 
@@ -14625,29 +14625,29 @@ foreach (string cls in classes)
         Console.WriteLine($""    - {name}"");
     }
 }",,,,,,,,7bdd16ac7c62c925,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,4d64650e,markdown,fr,c852abd33101a80d,"### Interpretation : Structure du fichier animals.ttl
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,4d64650e,markdown,fr,c0f9bd9d09d13312,"### Interpretation : Structure du fichier animals.ttl
 
 Le fichier Turtle contient :
 
-| Element | Quantite | Exemples |
+| Élément | Quantite | Exemples |
 |---------|----------|----------|
 | Classes | 6 | Animal, Mammal, Bird, Dog, Cat, Parrot |
 | Proprietes | 4 | name, age, sound, canFly |
 | Instances | 4 | rex (Dog), minou (Cat), coco (Parrot), buddy (Dog) |
 | Relations subClassOf | 5 | Dog < Mammal < Animal, etc. |
 
-**Observation importante** : Les instances sont typees avec leur classe la plus specifique (ex: `ex:rex a ex:Dog`), mais **pas** avec les classes parentes. Un raisonneur RDFS deduira que Rex est aussi un Mammal et un Animal.",,,,,,,,c852abd33101a80d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,8d666f13,markdown,fr,47eb93103e9e76b6,"---
+**Observation importante** : Les instances sont typees avec leur classe la plus spécifique (ex: `ex:rex a ex:Dog`), mais **pas** avec les classes parentes. Un raisonneur RDFS deduira que Rex est aussi un Mammal et un Animal.",,,,,,,,c0f9bd9d09d13312,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,8d666f13,markdown,fr,fadbdcf094716eee,"---
 
 ## 4. Inference RDFS
 
-L'inference RDFS permet de **deduire automatiquement** de nouveaux triplets a partir des regles RDFS. Le mecanisme principal est la **transitivite de `rdfs:subClassOf`**.
+L'inference RDFS permet de **deduire automatiquement** de nouveaux triplets a partir des règles RDFS. Le mécanisme principal est la **transitivite de `rdfs:subClassOf`**.
 
-> Les regles d'inference RDFS presentees ci-dessous (rdfs2, rdfs3, rdfs5, rdfs9, rdfs11) sont les **regles d'entailment** formellement specifiees dans RDF 1.1 Semantics (Hayes & Patel-Schneider, W3C Recommendation 2014). Elles definissent quels triplets peuvent etre deduits a partir d'un graphe RDFS.
+> Les règles d'inference RDFS presentees ci-dessous (rdfs2, rdfs3, rdfs5, rdfs9, rdfs11) sont les **règles d'entailment** formellement specifiees dans RDF 1.1 Semantics (Hayes & Patel-Schneider, W3C Recommendation 2014). Elles definissent quels triplets peuvent etre deduits a partir d'un graphe RDFS.
 
-### Regles d'inference RDFS essentielles
+### Règles d'inference RDFS essentielles
 
-| Regle | Premisses | Conclusion |
+| Règle | Premisses | Conclusion |
 |-------|-----------|------------|
 | **rdfs9** (heritage de type) | `?C rdfs:subClassOf ?D` et `?X rdf:type ?C` | `?X rdf:type ?D` |
 | **rdfs11** (transitivite) | `?A rdfs:subClassOf ?B` et `?B rdfs:subClassOf ?C` | `?A rdfs:subClassOf ?C` |
@@ -14657,7 +14657,7 @@ L'inference RDFS permet de **deduire automatiquement** de nouveaux triplets a pa
 
 ### Exemple concret
 
-Avec nos donnees :
+Avec nos données :
 ```turtle
 ex:Dog rdfs:subClassOf ex:Mammal .
 ex:Mammal rdfs:subClassOf ex:Animal .
@@ -14669,10 +14669,10 @@ L'inference RDFS deduit :
 ex:rex rdf:type ex:Mammal .   # Par rdfs9 (Dog < Mammal)
 ex:rex rdf:type ex:Animal .   # Par rdfs9 (Mammal < Animal)
 ex:Dog rdfs:subClassOf ex:Animal .  # Par rdfs11 (transitivite)
-```",,,,,,,,47eb93103e9e76b6,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,14523622,markdown,fr,3a9b78b9d3d7cd8c,"### Demonstration : inference manuelle
+```",,,,,,,,fadbdcf094716eee,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,14523622,markdown,fr,1b70302d99e4d580,"### Demonstration : inference manuelle
 
-Implementons d'abord l'inference manuellement pour bien comprendre le mecanisme, puis nous utiliserons le raisonneur integre.",,,,,,,,3a9b78b9d3d7cd8c,,,,,,,
+Implementons d'abord l'inference manuellement pour bien comprendre le mécanisme, puis nous utiliserons le raisonneur integre.",,,,,,,,1b70302d99e4d580,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,ffd20e29,code,fr,e48005e2b0c5fed3,"// Inference manuelle : heritage de type par rdfs:subClassOf
 // Recree un graphe simple pour la demonstration
 
@@ -14760,21 +14760,21 @@ foreach (Triple t in data.GetTriplesWithSubjectPredicate(rex, rdfT))
 {
     Console.WriteLine($""  rex rdf:type {((IUriNode)t.Object).Uri.Fragment.TrimStart('#')}"");
 }",,,,,,,,e48005e2b0c5fed3,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,014b01a5,markdown,fr,85b537a7b5a876e3,"### Interpretation : Inference manuelle
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,014b01a5,markdown,fr,ac7b3202bf4cfab5,"### Interpretation : Inference manuelle
 
 **Sortie obtenue** : A partir de 3 triplets initiaux, l'inference a deduit 2 triplets supplementaires.
 
-| Iteration | Triplet infere | Regle appliquee |
+| Itération | Triplet infere | Règle appliquee |
 |-----------|---------------|------------------|
 | 1 | `rex rdf:type Mammal` | rdfs9 : rex est Dog, Dog < Mammal |
 | 2 | `rex rdf:type Animal` | rdfs9 : rex est Mammal, Mammal < Animal |
 
 **Points cles** :
 1. L'algorithme est un **point fixe** : on itere jusqu'a ce qu'aucun nouveau triplet ne soit infere
-2. Chaque iteration propage les types d'un niveau dans la hierarchie
-3. Le nombre d'iterations depend de la **profondeur** de la hierarchie de classes
+2. Chaque itération propage les types d'un niveau dans la hiérarchie
+3. Le nombre d'itérations depend de la **profondeur** de la hiérarchie de classes
 
-> **En pratique**, on utilise les raisonneurs integres plutot que cette implementation manuelle. Mais comprendre le mecanisme est essentiel.",,,,,,,,85b537a7b5a876e3,,,,,,,
+> **En pratique**, on utilise les raisonneurs integres plutot que cette implementation manuelle. Mais comprendre le mécanisme est essentiel.",,,,,,,,ac7b3202bf4cfab5,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,sw6-mermaid-inference,markdown,fr,d2500075a4e69218,"La règle d'inférence **rdfs9** (héritage de type par `rdfs:subClassOf`), rendue sous forme
 de graphe pour l'instance `ex:rex`. En trait plein : les 3 triplets *assertés* ; en tireté
 ambre : les 2 triplets *inférés* par transitivité.
@@ -14804,9 +14804,9 @@ graph BT
 > C'est exactement la sortie de la cellule d'inférence manuelle ci-dessus (3 initiaux → 2 inférés)
 > et ce que le raisonneur RDFS intégré automatise dans la section suivante.
 ",,,,,,,,d2500075a4e69218,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,eb5de308,markdown,fr,467f434978fa5b2b,"### Utilisation du raisonneur RDFS de dotNetRDF
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,eb5de308,markdown,fr,bcacb8ffc12a4ea5,"### Utilisation du raisonneur RDFS de dotNetRDF
 
-dotNetRDF fournit un `StaticRdfsReasoner` qui applique l'ensemble des regles RDFS.",,,,,,,,467f434978fa5b2b,,,,,,,
+dotNetRDF fournit un `StaticRdfsReasoner` qui applique l'ensemble des règles RDFS.",,,,,,,,bcacb8ffc12a4ea5,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,f2fb2823,code,fr,61faac8fc1b26ffa,"using VDS.RDF.Query.Inference;
 
 // Charger animals.ttl dans un nouveau graphe
@@ -14852,7 +14852,7 @@ foreach (Triple t in animalGraph.GetTriplesWithSubjectPredicate(cocoNode, typeNo
 {
     Console.WriteLine($""  - {t.Object}"");
 }",,,,,,,,61faac8fc1b26ffa,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,0fe6e948,markdown,fr,1b8d045da37a53d6,"### Interpretation : Raisonneur RDFS
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,0fe6e948,markdown,fr,1d296ee231eba977,"### Interpretation : Raisonneur RDFS
 
 Le `StaticRdfsReasoner` a enrichi le graphe automatiquement :
 
@@ -14864,15 +14864,15 @@ Le `StaticRdfsReasoner` a enrichi le graphe automatiquement :
 | `buddy` | Dog | Mammal, Animal |
 
 **Comparaison** :
-- **Sans inference** : seul le type le plus specifique est present
+- **Sans inference** : seul le type le plus spécifique est present
 - **Avec inference** : tous les super-types sont materialises dans le graphe
 
-> **Note technique** : `StaticRdfsReasoner` materialise les triplets inferes directement dans le graphe. C'est une approche de **materialisation** (par opposition au raisonnement a la requete).",,,,,,,,1b8d045da37a53d6,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,db403da6,markdown,fr,7adf53bc8264241b,"---
+> **Note technique** : `StaticRdfsReasoner` materialise les triplets inferes directement dans le graphe. C'est une approche de **materialisation** (par opposition au raisonnement a la requête).",,,,,,,,1d296ee231eba977,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,db403da6,markdown,fr,50b02ec7f9d5d783,"---
 
-## 5. Interroger les donnees enrichies par l'inference
+## 5. Interroger les données enrichies par l'inference
 
-Maintenant que le graphe a ete enrichi par le raisonneur RDFS, utilisons SPARQL pour interroger les donnees inferees.",,,,,,,,7adf53bc8264241b,,,,,,,
+Maintenant que le graphe a ete enrichi par le raisonneur RDFS, utilisons SPARQL pour interroger les données inferees.",,,,,,,,50b02ec7f9d5d783,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,d87e5c73,code,fr,362501612ec74bec,"// Requete SPARQL : trouver tous les animaux (grace a l'inference)
 string query1 = @""
 PREFIX ex: <http://example.org/animals#>
@@ -14903,9 +14903,9 @@ foreach (SparqlResult r in results1)
     string type = ((IUriNode)r[""type""]).Uri.Fragment.TrimStart('#');
     Console.WriteLine($""  {name} (type: {type})"");
 }",,,,,,,,362501612ec74bec,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,7db876f4,markdown,fr,9f4be8b0d1f56161,"La requete `?animal rdf:type ex:Animal` retourne **tous les animaux**, y compris ceux qui sont seulement types comme Dog, Cat ou Parrot. C'est la puissance de l'inference RDFS.
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,7db876f4,markdown,fr,8e3b24482fce9863,"La requête `?animal rdf:type ex:Animal` retourne **tous les animaux**, y compris ceux qui sont seulement types comme Dog, Cat ou Parrot. C'est la puissance de l'inference RDFS.
 
-Comparons avec une requete qui exploite la hierarchie.",,,,,,,,9f4be8b0d1f56161,,,,,,,
+Comparons avec une requête qui exploite la hiérarchie.",,,,,,,,8e3b24482fce9863,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,d2dd1822,code,fr,f2b16f88277b11af,"// Requete 2 : trouver tous les mammiferes
 string query2 = @""
 PREFIX ex: <http://example.org/animals#>
@@ -14960,7 +14960,7 @@ foreach (SparqlResult r in results3)
     string count = ((ILiteralNode)r[""count""]).Value;
     Console.WriteLine($""  {cls} : {count} instance(s)"");
 }",,,,,,,,f2b16f88277b11af,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,7fa506f4,markdown,fr,e186caaa50a07f4f,"### Interpretation : Requetes sur donnees inferees
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,7fa506f4,markdown,fr,5447f315db807dba,"### Interpretation : Requêtes sur données inferees
 
 | Classe | Instances directes | Instances inferees | Total |
 |--------|-------------------|--------------------|-------|
@@ -14973,30 +14973,30 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,7fa506f4,markdow
 
 **Points cles** :
 1. La classe `Animal` n'a **aucune instance directe** mais 4 par inference
-2. Les requetes SPARQL fonctionnent sur le graphe materialise, incluant les triplets inferes
-3. C'est un avantage majeur de RDFS : les donnees sont flexibles mais interrogeables a differents niveaux d'abstraction",,,,,,,,e186caaa50a07f4f,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,24c1dd8d,markdown,fr,9e7749513ffc1bd8,"---
+2. Les requêtes SPARQL fonctionnent sur le graphe materialise, incluant les triplets inferes
+3. C'est un avantage majeur de RDFS : les données sont flexibles mais interrogeables a différents niveaux d'abstraction",,,,,,,,5447f315db807dba,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,24c1dd8d,markdown,fr,e26a7fc690e667be,"---
 
 ## Exercices
 
-### Exercice 1 : Creer un vocabulaire RDFS pour une bibliotheque
+### Exercice 1 : Créer un vocabulaire RDFS pour une bibliotheque
 
-Creez un schema RDFS pour un domaine de bibliotheque avec :
+Créez un schema RDFS pour un domaine de bibliotheque avec :
 - Classes : `Publication`, `Book`, `Article`, `Author`, `Publisher`
-- Hierarchie : `Book` et `Article` sont des sous-classes de `Publication`
+- Hiérarchie : `Book` et `Article` sont des sous-classes de `Publication`
 - Proprietes : `title` (domain: Publication, range: string), `writtenBy` (domain: Publication, range: Author), `publishedBy` (domain: Book, range: Publisher), `year` (domain: Publication, range: integer)
 - Instances : au moins 2 livres et 1 article avec leurs auteurs
-- Appliquez le raisonneur RDFS et verifiez que les types sont bien inferes",,,,,,,,9e7749513ffc1bd8,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,f8867725,markdown,fr,9f3909216b6c8eec,"### Exercice : Requete SPARQL avec inference RDFS
+- Appliquez le raisonneur RDFS et verifiez que les types sont bien inferes",,,,,,,,e26a7fc690e667be,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,f8867725,markdown,fr,315b139769873806,"### Exercice : Requête SPARQL avec inference RDFS
 
-Les sections precedentes ont montre le raisonneur RDFS et les requetes SPARQL.
+Les sections précédentes ont montre le raisonneur RDFS et les requêtes SPARQL.
 Utilisez le raisonneur pour trouver toutes les instances d'une superclasse.
 
 ### Indices
 
 - Chargez `animals.ttl`, appliquez `rdfsReasoner.Initialise(g)` puis executez SPARQL
 - `?animal rdf:type ex:Animal` avec inference retourne aussi les chiens et chats
-",,,,,,,,9f3909216b6c8eec,,,,,,,
+",,,,,,,,315b139769873806,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,e8995f1d,code,fr,43b6b08db2e1674a,"// Exercice : Requete SPARQL avec inference RDFS
 // TODO etudiant : chargez animals.ttl et trouvez toutes les instances d'une superclasse
 //
@@ -15024,13 +15024,13 @@ library.NamespaceMap.AddNamespace(""xsd"", new Uri(""http://www.w3.org/2001/XMLS
 // TODO: Verifier les types inferes
 
 Console.WriteLine(""Exercice 1 : a completer"");",,,,,,,,4d39f8b0a0933205,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,c4f26c95,markdown,fr,7087e44a5aab54de,"### Exercice 2 : Chaine d'inference par sous-classes
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,c4f26c95,markdown,fr,8dc9cec557156ff4,"### Exercice 2 : Chaîne d'inference par sous-classes
 
-Creez une hierarchie de classes plus profonde pour tester la transitivite :
+Créez une hiérarchie de classes plus profonde pour tester la transitivite :
 - `LivingThing` > `Animal` > `Vertebrate` > `Mammal` > `Primate` > `Human`
-- Creez une instance `alice rdf:type Human`
+- Créez une instance `alice rdf:type Human`
 - Appliquez l'inference et verifiez que `alice` est aussi de type `LivingThing`, `Animal`, `Vertebrate`, `Mammal` et `Primate`
-- Comptez le nombre de triplets avant et apres inference",,,,,,,,7087e44a5aab54de,,,,,,,
+- Comptez le nombre de triplets avant et après inference",,,,,,,,8dc9cec557156ff4,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,456375d3,code,fr,374b19d4d9d1b4f0,"// Exercice 2 : Chaine d'inference profonde
 // Completez le code ci-dessous
 
@@ -15047,7 +15047,7 @@ taxonomyGraph.NamespaceMap.AddNamespace(""rdfs"", new Uri(""http://www.w3.org/20
 // TODO: Comparer le nombre de triplets avant/apres
 
 Console.WriteLine(""Exercice 2 : a completer"");",,,,,,,,374b19d4d9d1b4f0,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,1b4a0eed,markdown,fr,fe86801ce77c4258,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,1b4a0eed,markdown,fr,af8483475e3fc430,"---
 
 ## Resume
 
@@ -15056,8 +15056,8 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,1b4a0eed,markdow
 | Terme | Utilisation | Exemple |
 |-------|------------|----------|
 | `rdfs:Class` | Declarer une classe | `ex:Dog rdf:type rdfs:Class` |
-| `rdfs:subClassOf` | Hierarchie de classes | `ex:Dog rdfs:subClassOf ex:Mammal` |
-| `rdfs:subPropertyOf` | Hierarchie de proprietes | `ex:father rdfs:subPropertyOf ex:parent` |
+| `rdfs:subClassOf` | Hiérarchie de classes | `ex:Dog rdfs:subClassOf ex:Mammal` |
+| `rdfs:subPropertyOf` | Hiérarchie de proprietes | `ex:father rdfs:subPropertyOf ex:parent` |
 | `rdfs:domain` | Type du sujet | `ex:name rdfs:domain ex:Animal` |
 | `rdfs:range` | Type de l'objet/valeur | `ex:name rdfs:range xsd:string` |
 | `rdfs:label` | Etiquette lisible | `ex:Dog rdfs:label ""Chien""@fr` |
@@ -15065,16 +15065,16 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb,1b4a0eed,markdow
 
 ### Ce que nous avons appris
 
-1. **RDFS enrichit RDF** avec un vocabulaire pour decrire la structure des donnees
-2. **Les hierarchies de classes** (`rdfs:subClassOf`) permettent l'heritage de type
+1. **RDFS enrichit RDF** avec un vocabulaire pour decrire la structure des données
+2. **Les hiérarchies de classes** (`rdfs:subClassOf`) permettent l'heritage de type
 3. **L'inference RDFS** deduit automatiquement des triplets implicites
 4. **Le raisonneur `StaticRdfsReasoner`** de dotNetRDF materialise les triplets inferes
-5. **SPARQL sur donnees inferees** permet d'interroger a differents niveaux d'abstraction
+5. **SPARQL sur données inferees** permet d'interroger a différents niveaux d'abstraction
 
 ### Limites de RDFS
 
 RDFS est volontairement simple. Il ne permet **pas** de :
-- Definir des classes disjointes (Dog et Cat ne peuvent pas etre la meme instance)
+- Définir des classes disjointes (Dog et Cat ne peuvent pas etre la même instance)
 - Exprimer des cardinalites (une personne a exactement 2 parents)
 - Declarer des proprietes inverses (teaches / taughtBy)
 - Exprimer des classes par union/intersection
@@ -15084,13 +15084,13 @@ Pour ces fonctionnalites, il faut passer a **OWL** (notebook suivant).
 ## References
 
 - **RDF Schema 1.1** -- Brickley & Guha, W3C Recommendation (2014). [w3.org/TR/rdf-schema](https://www.w3.org/TR/rdf-schema/)
-- **RDF 1.1 Semantics** -- Hayes & Patel-Schneider, W3C Recommendation (2014). Specifie formellement les regles d'entailment rdfs2/3/5/9/11. [w3.org/TR/rdf11-mt](https://www.w3.org/TR/rdf11-mt/)
-- **RDF 1.1 Concepts and Abstract Syntax** -- Cyganiak, Wood & Lanthaler, W3C Recommendation (2014). Modele de triplet sur lequel RDFS s'appuie.
+- **RDF 1.1 Semantics** -- Hayes & Patel-Schneider, W3C Recommendation (2014). Specifie formellement les règles d'entailment rdfs2/3/5/9/11. [w3.org/TR/rdf11-mt](https://www.w3.org/TR/rdf11-mt/)
+- **RDF 1.1 Concepts and Abstract Syntax** -- Cyganiak, Wood & Lanthaler, W3C Recommendation (2014). Modèle de triplet sur lequel RDFS s'appuie.
 
 ---
 
-**Navigation** :  [<< 5-LinkedData](SW-5-CSharp-LinkedData.ipynb) | [Index](README.md) | [7-OWL >>](SW-7-CSharp-OWL.ipynb)",,,,,,,,fe86801ce77c4258,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,header-navigation,markdown,fr,ab89d2daf1444820,"# SW-7b-Python-OWL
+**Navigation** :  [<< 5-LinkedData](SW-5-CSharp-LinkedData.ipynb) | [Index](README.md) | [7-OWL >>](SW-7-CSharp-OWL.ipynb)",,,,,,,,af8483475e3fc430,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,header-navigation,markdown,fr,7690e8d9e9cb8380,"# SW-7b-Python-OWL
 
 **Navigation** : [Index](README.md) | [<< SW-7 C#](SW-7-CSharp-OWL.ipynb) | [SW-8 SHACL >>](SW-8-Python-SHACL.ipynb)
 
@@ -15101,8 +15101,8 @@ Ce notebook est un **sidetrack optionnel** qui presente l'equivalent Python des 
 ### Objectifs d'apprentissage
 
 A la fin de ce notebook, vous saurez :
-1. Creer et manipuler des ontologies OWL avec OWLReady2
-2. Definir des classes, proprietes et restrictions
+1. Créer et manipuler des ontologies OWL avec OWLReady2
+2. Définir des classes, proprietes et restrictions
 3. Utiliser un raisonneur (HermiT) pour deduire de nouvelles connaissances
 4. Faire la correspondance entre dotNetRDF et OWLReady2
 
@@ -15113,7 +15113,7 @@ A la fin de ce notebook, vous saurez :
 
 ### Duree estimee : 30 minutes
 
-> **Note** : OWLReady2 inclut le raisonneur HermiT (Java) pour le raisonnement OWL 2 DL complet.",,,,,,,,ab89d2daf1444820,,,,,,,
+> **Note** : OWLReady2 inclut le raisonneur HermiT (Java) pour le raisonnement OWL 2 DL complet.",,,,,,,,7690e8d9e9cb8380,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,section-1-title,markdown,fr,8bd1ffae4161b3c5,"---
 
 ## 1. Installation et Imports
@@ -15134,11 +15134,11 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,imports-owlready
 except ImportError:
     OWLREADY2_AVAILABLE = False
     print(""OWLReady2 non disponible. Installez avec : pip install owlready2"")",,,,,,,,7c821b88c5a75c97,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,section-2-title,markdown,fr,286424e12d9a46e2,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,section-2-title,markdown,fr,3b61b2eb472dd48b,"---
 
-## 2. Creer une Ontologie Simple
+## 2. Créer une Ontologie Simple
 
-Commencons par creer une ontologie pour une famille de personnes, avec des classes et des proprietes.",,,,,,,,286424e12d9a46e2,,,,,,,
+Commencons par créer une ontologie pour une famille de personnes, avec des classes et des proprietes.",,,,,,,,3b61b2eb472dd48b,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,create-ontology,code,fr,8dbfb83ccbe7bb78,"if OWLREADY2_AVAILABLE:
     # Create a new ontology
     onto = get_ontology(""http://example.org/family.owl#"")
@@ -15200,11 +15200,11 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,create-ontology-
 | `DataProperty` | `a owl:DatatypeProperty` | `new OntologyDataProperty(""age"")` |
 | `domain = [Person]` | `rdfs:domain :Person` | `.Domain = personClass` |
 | `range = [Person]` | `rdfs:range :Person` | `.Range = personClass` |",,,,,,,,8f091e80d021f02c,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,section-3-title,markdown,fr,13e473c4d1713952,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,section-3-title,markdown,fr,d546bf2a564cc734,"---
 
-## 3. Creer des Individus et Assertions
+## 3. Créer des Individus et Assertions
 
-Ajoutons des individus (instances) a notre ontologie.",,,,,,,,13e473c4d1713952,,,,,,,
+Ajoutons des individus (instances) a notre ontologie.",,,,,,,,d546bf2a564cc734,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,create-individuals,code,fr,8e61c631634c9c5a,"if OWLREADY2_AVAILABLE:
     # Create individuals
     john = Man(""John"", has_name=""John Smith"", age=45)
@@ -15228,18 +15228,18 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,create-individua
     print(f""  {alice.name} -> has_parent -> {[p.name for p in alice.has_parent]}"")
 else:
     print(""OWLReady2 non disponible : creation d'individus ignoree."")",,,,,,,,8e61c631634c9c5a,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,individuals-interpretation,markdown,fr,2a4640a2e820447d,"### Interpretation : Individus
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,individuals-interpretation,markdown,fr,ccfa95313ba2c870,"### Interpretation : Individus
 
 OWLReady2 utilise une syntaxe Python intuitive :
-- `Man(""John"", ...)` cree un individu de la classe `Man` avec l'IRI `#John`
+- `Man(""John"", ...)` créé un individu de la classe `Man` avec l'IRI `#John`
 - Les proprietes sont accessibles comme des attributs Python
 - Les proprietes inverse sont automatiquement maintenues
 
-| Operation | OWLReady2 | OWL (Turtle) |
+| Opération | OWLReady2 | OWL (Turtle) |
 |-----------|-----------|-------------|
-| Creer individu | `john = Man(""John"")` | `:John a :Man .` |
+| Créer individu | `john = Man(""John"")` | `:John a :Man .` |
 | Assert propriete | `john.has_child.append(alice)` | `:John :has_child :Alice .` |
-| Propriete data | `john.has_name = ""John""` | `:John :has_name ""John"" .` |",,,,,,,,2a4640a2e820447d,,,,,,,
+| Propriete data | `john.has_name = ""John""` | `:John :has_name ""John"" .` |",,,,,,,,ccfa95313ba2c870,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,section-4-title,markdown,fr,59879391e5ab1ce0,"---
 
 ## 4. Restrictions OWL
@@ -15353,20 +15353,20 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,reasoning,code,f
         print(""  Charlie -> Employee + Manager (car works_in ET manages)"")
 else:
     print(""OWLReady2 non disponible : raisonnement ignore."")",,,,,,,,7031c5a164e116b2,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,reasoning-interpretation,markdown,fr,b3023ef4e12ca810,"### Interpretation : Raisonnement
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,reasoning-interpretation,markdown,fr,191ac65bb1531d4a,"### Interpretation : Raisonnement
 
 Le raisonneur HermiT a deduit :
 - Bob est Employee : il travaille dans un departement (IT)
 - Alice est Employee : elle travaille dans un departement (HR)
 - Charlie est Employee ET Manager : il travaille dans ET dirige un departement
 
-| Operation | OWLReady2 | dotNetRDF |
+| Opération | OWLReady2 | dotNetRDF |
 |-----------|-----------|----------|
 | Raisonnement | `sync_reasoner()` (HermiT) | `OntologyGraph` avec `RdfsReasoner` |
 | Types inférés | `.is_a` (mis a jour) | `GetTypes()` (inclus inférés) |
 | Raisonneur | HermiT (OWL 2 DL complet) | RDFS + OWL 2 RL limite |
 
-> **Note** : HermiT est un raisonneur OWL 2 DL complet, beaucoup plus puissant que le raisonneur RDFS de base de dotNetRDF.",,,,,,,,b3023ef4e12ca810,,,,,,,
+> **Note** : HermiT est un raisonneur OWL 2 DL complet, beaucoup plus puissant que le raisonneur RDFS de base de dotNetRDF.",,,,,,,,191ac65bb1531d4a,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,section-6-title,markdown,fr,e5a34f3dfc1278dd,"---
 
 ## 6. Charger une Ontologie Existante
@@ -15402,11 +15402,11 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,load-ontology,co
             print(f""  {cls.name}"")
 else:
     print(""OWLReady2 non disponible : chargement d'ontologie ignore."")",,,,,,,,d61674b2c38694f8,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,section-7-title,markdown,fr,4bf29e3b43e4e43c,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,section-7-title,markdown,fr,20f42e80736ba222,"---
 
 ## 7. Exporter une Ontologie
 
-OWLReady2 peut exporter les ontologies dans differents formats.",,,,,,,,4bf29e3b43e4e43c,,,,,,,
+OWLReady2 peut exporter les ontologies dans différents formats.",,,,,,,,20f42e80736ba222,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,export-ontology,code,fr,91d317a858188691,"if OWLREADY2_AVAILABLE:
     # Export ontology to RDF/XML
     onto2.save(file=""data/temp_company.owl"", format=""rdfxml"")
@@ -15432,14 +15432,14 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,section-8-title,
 ## 8. Tableau de Correspondance dotNetRDF / OWLReady2
 
 Ce tableau recapitule les equivalences pour la manipulation d'ontologies.",,,,,,,,0765fe279f8e619a,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,comparison-table,markdown,fr,b389d5ece4ba43aa,"| Operation | dotNetRDF (C#) | OWLReady2 (Python) |
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,comparison-table,markdown,fr,5a9acf04577d60d1,"| Opération | dotNetRDF (C#) | OWLReady2 (Python) |
 |-----------|---------------|---------------------|
-| **Creer ontologie** | `new OntologyGraph()` | `get_ontology(""uri#"")` |
-| **Creer classe** | `new OntologyClass(""Person"")` | `class Person(Thing): pass` |
+| **Créer ontologie** | `new OntologyGraph()` | `get_ontology(""uri#"")` |
+| **Créer classe** | `new OntologyClass(""Person"")` | `class Person(Thing): pass` |
 | **Sous-classe** | `subClassOf` | `class Person(Thing): pass` |
 | **ObjectProperty** | `new OntologyObjectProperty(""knows"")` | `class knows(ObjectProperty): pass` |
 | **DataProperty** | `new OntologyDataProperty(""age"")` | `class age(DataProperty): pass` |
-| **Creer individu** | `g.CreateUriNode(""ex:John"")` + assertions | `john = Person(""John"")` |
+| **Créer individu** | `g.CreateUriNode(""ex:John"")` + assertions | `john = Person(""John"")` |
 | **Assert propriete** | `g.Assert(new Triple(...))` | `john.knows.append(alice)` |
 | **Restriction SOME** | `new SomeValuesRestriction(...)` | `knows.some(Person)` |
 | **Restriction ONLY** | `new AllValuesRestriction(...)` | `knows.only(Person)` |
@@ -15447,7 +15447,7 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,comparison-table
 | **Charger fichier** | `FileLoader.Load(graph, file)` | `get_ontology(""file://..."").load()` |
 | **Exporter** | `new CompressingTurtleWriter().Save()` | `onto.save(file=""..."")` |
 
-### Differences philosophiques
+### Différences philosophiques
 
 | Aspect | dotNetRDF | OWLReady2 |
 |--------|-----------|----------|
@@ -15456,20 +15456,20 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,comparison-table
 | **Raisonneur** | RDFS + OWL RL | HermiT (OWL 2 DL complet) |
 | **Performance** | Rapide pour gros graphes | Optimise pour ontologies |
 
-> **Choix** : Utilisez dotNetRDF pour des graphes RDF generiques, OWLReady2 pour des ontologies OWL avec raisonnement complexe.",,,,,,,,b389d5ece4ba43aa,,,,,,,
+> **Choix** : Utilisez dotNetRDF pour des graphes RDF generiques, OWLReady2 pour des ontologies OWL avec raisonnement complexe.",,,,,,,,5a9acf04577d60d1,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,exercises-title,markdown,fr,2a8be7115139570a,"---
 
 ## Exemples guides (issus de contributions etudiantes)
 
 Les exercices ci-dessous ont ete resolus et valides a partir de contributions etudiantes ; ils sont conserves comme **exemples guides** d'utilisation d'OWL et du raisonneur HermiT. De **nouveaux exercices** a completer sont proposes a la fin du notebook.",,,,,,,,2a8be7115139570a,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,exercise-1-intro,markdown,fr,6e56fdf2bcffaadd,"### Exemple guide 1 : Famille avec restrictions
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,exercise-1-intro,markdown,fr,d0ab2847d6ddfe96,"### Exemple guide 1 : Famille avec restrictions
 
 Ontologie de famille :
 - Classes : `Person`, `Parent`, `Child`
 - Propriete : `has_child` (inverse : `has_parent`)
 - Restrictions : `Parent` = Person qui `has_child` SOME Person ; `Child` = Person qui `has_parent` SOME Person
 
-**Resultat** : apres `sync_reasoner`, HermiT reclasse Pierre et Marie en `Parent`, et Lucie en `Child`.",,,,,,,,6e56fdf2bcffaadd,,,,,,,
+**Résultat** : après `sync_reasoner`, HermiT reclasse Pierre et Marie en `Parent`, et Lucie en `Child`.",,,,,,,,d0ab2847d6ddfe96,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,exercise-1-code,code,fr,eec13233c923fc0f,"if OWLREADY2_AVAILABLE:
     # Exemple guide 1 : famille avec restrictions OWL
     # Parent et Child sont definis par equivalent_to ; HermiT reclasse les individus
@@ -15522,14 +15522,14 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,exercise-1-code,
     print(f""Lucie  : {[c.name for c in lucie.is_a]}"")
 else:
     print(""OWLReady2 non disponible : exemple guide 1 ignore."")",,,,,,,,eec13233c923fc0f,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,exercise-2-intro,markdown,fr,74b7c1c8494a6ce8,"### Exemple guide 2 : Graphe de connaissances de films
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,exercise-2-intro,markdown,fr,6196278b25b1c3b5,"### Exemple guide 2 : Graphe de connaissances de films
 
 Ontologie de films :
 - Classes : `Movie`, `Person` (acteur/realisateur), `Genre`
 - Proprietes : `has_actor`, `has_director`, `has_genre`
 - Restriction : `ActionMovie` = Movie qui `has_genre` SOME Action
 
-**Resultat** : apres raisonnement, `DarkKnight` est classe `ActionMovie`.",,,,,,,,74b7c1c8494a6ce8,,,,,,,
+**Résultat** : après raisonnement, `DarkKnight` est classe `ActionMovie`.",,,,,,,,6196278b25b1c3b5,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,exercise-2-code,code,fr,76ed013f2b49273f,"if OWLREADY2_AVAILABLE:
     # Exemple guide 2 : ontologie de films
     # ActionMovie = Movie & has_genre.some(Action) ; HermiT classe DarkKnight
@@ -15597,7 +15597,7 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,exercise-2-code,
     print(f""Interstellar : {[c.name for c in interstellar.is_a]}"")
 else:
     print(""OWLReady2 non disponible : exemple guide 2 ignore."")",,,,,,,,76ed013f2b49273f,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,summary-title,markdown,fr,d7d6bad8594cd839,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,summary-title,markdown,fr,713ee0d23f03973c,"---
 
 ## Resume
 
@@ -15608,36 +15608,36 @@ Ce sidetrack a presente la manipulation d'ontologies OWL en Python avec **OWLRea
 | Concept | Ce que vous avez appris |
 |---------|------------------------|
 | **OWLReady2** | Manipuler des ontologies OWL en Python |
-| **Classes/Proprietes** | Definir la structure d'une ontologie |
+| **Classes/Proprietes** | Définir la structure d'une ontologie |
 | **Restrictions** | some (some), all (only), cardinalites |
 | **HermiT** | Raisonneur OWL 2 DL complet |
 | **Correspondance** | Equivalences dotNetRDF / OWLReady2 |
 
-### Prochaines etapes
+### Prochaines étapes
 
-- **SW-8-Python-SHACL** : Validation de donnees avec pySHACL
-- **SW-9-Python-JSONLD** : Donnees structurees pour le web
+- **SW-8-Python-SHACL** : Validation de données avec pySHACL
+- **SW-9-Python-JSONLD** : Données structurees pour le web
 - **SW-11-Python-KnowledgeGraphs** : Graphes de connaissances avec kglab
 
 ---
 
-**Retour au sommaire** : [Index SemanticWeb](README.md)",,,,,,,,d7d6bad8594cd839,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,5045fbe7,markdown,fr,0e3113fcf96ad14c,"## Resume et perspectives
+**Retour au sommaire** : [Index SemanticWeb](README.md)",,,,,,,,713ee0d23f03973c,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,5045fbe7,markdown,fr,658afe3cc8d969f3,"## Resume et perspectives
 
-Ce sidetrack a presente la manipulation d'ontologies OWL en Python avec OWLReady2, en mettant en lumiere la difference de philosophie avec dotNetRDF. Alors que dotNetRDF travaille au niveau des triples (bas niveau), OWLReady2 offre une API orientee classes (haut niveau) ou les ontologies sont definies comme des classes Python heritant de `Thing`, les proprietes comme des sous-classes d'`ObjectProperty` ou `DataProperty`, et les restrictions OWL s'expriment naturellement (`manages.some(Department)` pour `someValuesFrom`).
+Ce sidetrack a presente la manipulation d'ontologies OWL en Python avec OWLReady2, en mettant en lumiere la différence de philosophie avec dotNetRDF. Alors que dotNetRDF travaille au niveau des triples (bas niveau), OWLReady2 offre une API orientee classes (haut niveau) ou les ontologies sont définies comme des classes Python heritant de `Thing`, les proprietes comme des sous-classes d'`ObjectProperty` ou `DataProperty`, et les restrictions OWL s'expriment naturellement (`manages.some(Department)` pour `someValuesFrom`).
 
-Le point fort d'OWLReady2 est l'integration du raisonneur **HermiT** (OWL 2 DL complet), qui permet de deduire automatiquement de nouvelles connaissances. Les exemples guides ont illustre cette puissance : classification automatique d'individus en `Employee` ou `Manager` selon leurs proprietes, classification en `Parent`/`Child` via les restrictions `equivalent_to`, et meme la categorisation de films en `ActionMovie` selon leur genre. L'exemple de synthese sur les ecosystemes a combine hierarchie de classes, restrictions et raisonnement pour classifier le renard et le loup comme carnivores.
+Le point fort d'OWLReady2 est l'integration du raisonneur **HermiT** (OWL 2 DL complet), qui permet de deduire automatiquement de nouvelles connaissances. Les exemples guides ont illustre cette puissance : classification automatique d'individus en `Employee` ou `Manager` selon leurs proprietes, classification en `Parent`/`Child` via les restrictions `equivalent_to`, et même la categorisation de films en `ActionMovie` selon leur genre. L'exemple de synthese sur les ecosystemes a combine hiérarchie de classes, restrictions et raisonnement pour classifier le renard et le loup comme carnivores.
 
-Dans le notebook suivant (**SW-8-Python-SHACL**), nous aborderons la validation de donnees avec pySHACL, puis **SW-9-Python-JSONLD** presentera le format JSON-LD pour l'integration web, avant le notebook **SW-11-Python-KnowledgeGraphs** qui combine ces technologies pour construire des graphes de connaissances.",,,,,,,,0e3113fcf96ad14c,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,3b081608,markdown,fr,5185a8fc405a4333,"---
+Dans le notebook suivant (**SW-8-Python-SHACL**), nous aborderons la validation de données avec pySHACL, puis **SW-9-Python-JSONLD** presentera le format JSON-LD pour l'integration web, avant le notebook **SW-11-Python-KnowledgeGraphs** qui combine ces technologies pour construire des graphes de connaissances.",,,,,,,,658afe3cc8d969f3,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,3b081608,markdown,fr,7cdc0d641338efd6,"---
 
 ## Exemple guide de synthese : Ontologie avec raisonnement
 
 Ontologie d'ecosysteme construite avec `owlready2`, raisonnee avec HermiT.
 
-- 3 classes avec hierarchie : `Animal`, `Mammifere`, `Carnivore`
+- 3 classes avec hiérarchie : `Animal`, `Mammifere`, `Carnivore`
 - 1 restriction : `Carnivore` = Animal qui `has_prey` SOME Animal
-- Instances dont le type est derive par inference (Renard, Loup -> Carnivore)",,,,,,,,5185a8fc405a4333,,,,,,,
+- Instances dont le type est derive par inference (Renard, Loup -> Carnivore)",,,,,,,,7cdc0d641338efd6,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,89008950,code,fr,f26b3c981b7d4b44,"if OWLREADY2_AVAILABLE:
     # Exemple guide de synthese : ontologie d'ecosystemes avec raisonnement
     # Carnivore = Animal & has_prey.some(Animal) ; HermiT classe Renard et Loup
@@ -15691,16 +15691,16 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,89008950,code,fr
     print(""Ontologie exportee : data/temp_ecosystem.owl"")
 else:
     print(""OWLReady2 non disponible : exemple de synthese ignore."")",,,,,,,,f26b3c981b7d4b44,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,b4046c95,markdown,fr,7ec647eaaacb8f78,"### Exemple guide 3 : Ontologie de LLM
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,b4046c95,markdown,fr,f24b63c4820f2dbd,"### Exemple guide 3 : Ontologie de LLM
 
-Ontologie de modeles d'intelligence artificielle :
+Ontologie de modèles d'intelligence artificielle :
 - Classes : `AIModel`, `LLM`, `Organization`, `Benchmark`, `Capability` (avec sous-classes `ImageUnderstanding`, `CodeGeneration`, `Reasoning`)
 - Proprietes : `developed_by`, `has_capability`, `evaluated_on`, `outperforms`
 - Restrictions : `MultimodalLLM` = LLM qui `has_capability` SOME ImageUnderstanding ; `CodingLLM` = LLM qui `has_capability` SOME CodeGeneration ; `ReasoningLLM` = LLM qui `has_capability` SOME Reasoning
 
-**Resultat** : apres raisonnement, HermiT classe Claude comme ReasoningLLM + CodingLLM + MultimodalLLM, GPT4 comme CodingLLM + MultimodalLLM, Gemini comme ReasoningLLM + MultimodalLLM, et Llama comme CodingLLM.
+**Résultat** : après raisonnement, HermiT classe Claude comme ReasoningLLM + CodingLLM + MultimodalLLM, GPT4 comme CodingLLM + MultimodalLLM, Gemini comme ReasoningLLM + MultimodalLLM, et Llama comme CodingLLM.
 
-> Contribue par louisparmentiermichelet-hue (PR #1932, cohorte 2026)",,,,,,,,7ec647eaaacb8f78,,,,,,,
+> Contribue par louisparmentiermichelet-hue (PR #1932, cohorte 2026)",,,,,,,,f24b63c4820f2dbd,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,ad1cbb21,code,fr,0f57edccce29afbe,"if OWLREADY2_AVAILABLE:
     # Exemple guide 3 : ontologie de LLM avec raisonnement
     # Contribue par louisparmentiermichelet-hue (PR #1932, cohorte 2026)
@@ -15815,90 +15815,90 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,ad1cbb21,code,fr
     print(""Ontologie exportee : data/temp_llm_ontology.owl"")
 else:
     print(""OWLReady2 non disponible : exemple guide 3 ignore."")",,,,,,,,0f57edccce29afbe,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,7cd240c4,markdown,fr,ca344307480bc31e,"### Exercice 1 : Vehicules electriques (equivalent_to + raisonnement)
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,7cd240c4,markdown,fr,43cfacb1295bf3f6,"### Exercice 1 : Vehicules electriques (equivalent_to + raisonnement)
 
 Construisez une ontologie de vehicules :
 - Classes : `Vehicle`, `Battery`, `ElectricVehicle`
 - Propriete : `has_battery`
 - Restriction : `ElectricVehicle` = Vehicle qui `has_battery` SOME Battery
 
-Creez un vehicule muni d'une batterie, lancez le raisonneur et verifiez qu'il est classe `ElectricVehicle`.
+Créez un vehicule muni d'une batterie, lancez le raisonneur et verifiez qu'il est classe `ElectricVehicle`.
 
-**Indice** : sur le modele de l'exemple guide 1, utilisez `equivalent_to = [Vehicle & has_battery.some(Battery)]` puis `sync_reasoner`.",,,,,,,,ca344307480bc31e,,,,,,,
+**Indice** : sur le modèle de l'exemple guide 1, utilisez `equivalent_to = [Vehicle & has_battery.some(Battery)]` puis `sync_reasoner`.",,,,,,,,43cfacb1295bf3f6,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,115f4e6c,code,fr,85c4abde026a968c,"# Exercice 1 : vehicules electriques (equivalent_to + raisonnement)
 # TODO etudiant : definir Vehicle, Battery, ElectricVehicle = Vehicle & has_battery.some(Battery)
 # Indice : creer un World(), une ontologie, puis sync_reasoner et verifier is_a
 
 print(""Exercice a completer"")
 ",,,,,,,,85c4abde026a968c,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,f322477f,markdown,fr,90e4b758f64e4727,"### Exercice 2 : Classes disjointes
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,f322477f,markdown,fr,314b53624f7d0835,"### Exercice 2 : Classes disjointes
 
-Dans une ontologie d'animaux, declarez que `Herbivore` et `Carnivore` sont **disjointes** (`AllDisjoint`). Creez un individu, puis observez le comportement du raisonneur (il ne doit pas inferer qu'un meme individu est a la fois Herbivore et Carnivore).
+Dans une ontologie d'animaux, declarez que `Herbivore` et `Carnivore` sont **disjointes** (`AllDisjoint`). Créez un individu, puis observez le comportement du raisonneur (il ne doit pas inferer qu'un même individu est a la fois Herbivore et Carnivore).
 
-**Indice** : utilisez `AllDisjoint([Herbivore, Carnivore])` a l'interieur du bloc `with onto:`.",,,,,,,,90e4b758f64e4727,,,,,,,
+**Indice** : utilisez `AllDisjoint([Herbivore, Carnivore])` a l'interieur du bloc `with onto:`.",,,,,,,,314b53624f7d0835,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,c8c823ed,code,fr,edd12a8a9a757b77,"# Exercice 2 : classes disjointes (AllDisjoint)
 # TODO etudiant : declarer Herbivore et Carnivore disjointes via AllDisjoint([...])
 # Indice : a placer dans le bloc with onto: , puis creer un individu et raisonner
 
 print(""Exercice a completer"")
 ",,,,,,,,edd12a8a9a757b77,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,a8786019,markdown,fr,5398d910353040f7,"### Exercice 3 : Restrictions de cardinalite (`min`, `exactly`)
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,a8786019,markdown,fr,14d2c0e489019ca6,"### Exercice 3 : Restrictions de cardinalite (`min`, `exactly`)
 
-Modelisez la classe `BigFamily` = Person qui `has_child` **au moins 3** Person. Creez ensuite la classe `Couple` = Person qui `has_partner` **exactement 1** Person.
+Modelisez la classe `BigFamily` = Person qui `has_child` **au moins 3** Person. Créez ensuite la classe `Couple` = Person qui `has_partner` **exactement 1** Person.
 
-Creez un individu avec 3+ enfants, lancez le raisonneur et verifiez qu'il est classe `BigFamily`.
+Créez un individu avec 3+ enfants, lancez le raisonneur et verifiez qu'il est classe `BigFamily`.
 
-**Indice** : `equivalent_to = [Person & has_child.min(3, Person)]` pour le minimum. Utilisez `.exactly(N, Class)` pour la cardinalite exacte.",,,,,,,,5398d910353040f7,,,,,,,
+**Indice** : `equivalent_to = [Person & has_child.min(3, Person)]` pour le minimum. Utilisez `.exactly(N, Class)` pour la cardinalite exacte.",,,,,,,,14d2c0e489019ca6,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,3630d512,code,fr,17768954daf449e7,"# Exercice 3 : restrictions de cardinalite (min, exactly)
 # TODO etudiant : definir BigFamily = Person & has_child.min(3, Person)
 # Indice : creer un parent avec 3 enfants ; sync_reasoner ; verifier is_a BigFamily
 
 print(""Exercice a completer"")",,,,,,,,17768954daf449e7,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,d738e83d,markdown,fr,a3f1f8c9d5e24b5b,"### Exercice 4 : Restriction universelle `only` (`AllValuesFrom`)
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,d738e83d,markdown,fr,97f48e348fa3b543,"### Exercice 4 : Restriction universelle `only` (`AllValuesFrom`)
 
-Modelisez la classe `Vegan` = Person qui `eats` **uniquement** des `Plant`. Attention : `some` (existentiel) signifie 'au moins un', tandis que `only` (universel) signifie 'tous'. Un Vegan n'est PAS forcement defini par 'mange au moins une plante' mais par 'tout ce qu'il mange est une plante'.
+Modelisez la classe `Vegan` = Person qui `eats` **uniquement** des `Plant`. Attention : `some` (existentiel) signifie 'au moins un', tandis que `only` (universel) signifie 'tous'. Un Vegan n'est PAS forcement défini par 'mange au moins une plante' mais par 'tout ce qu'il mange est une plante'.
 
-Creez deux individus : Alice qui mange uniquement des plantes (Carrot, Apple), et Bob qui mange une plante et un animal (Carrot, Cow). Apres raisonnement, seul Alice doit etre classe `Vegan`.
+Créez deux individus : Alice qui mange uniquement des plantes (Carrot, Apple), et Bob qui mange une plante et un animal (Carrot, Cow). Après raisonnement, seul Alice doit etre classe `Vegan`.
 
-**Indice** : `equivalent_to = [Person & eats.only(Plant)]`. Definissez `Plant` et `Animal` comme classes disjointes (`AllDisjoint`).",,,,,,,,a3f1f8c9d5e24b5b,,,,,,,
+**Indice** : `equivalent_to = [Person & eats.only(Plant)]`. Definissez `Plant` et `Animal` comme classes disjointes (`AllDisjoint`).",,,,,,,,97f48e348fa3b543,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,8c16ee8d,code,fr,cf04bf2b09e7bc8e,"# Exercice 4 : restriction universelle only (AllValuesFrom)
 # TODO etudiant : Vegan = Person & eats.only(Plant)
 # Indice : 2 individus (Alice tout-plantes, Bob plante+animal) ; seul Alice doit etre Vegan
 
 print(""Exercice a completer"")",,,,,,,,cf04bf2b09e7bc8e,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,92159084,markdown,fr,584b72cb33d7574a,"### Exercice 5 : Propriete transitive (`TransitiveProperty`)
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,92159084,markdown,fr,7b9ebdea4f60c11a,"### Exercice 5 : Propriete transitive (`TransitiveProperty`)
 
 Modelisez la propriete `is_part_of` comme **transitive** : si A `is_part_of` B et B `is_part_of` C, alors le raisonneur doit inferer A `is_part_of` C.
 
-Creez les individus `Finger`, `Hand`, `Arm`, `Body` avec la chaine :
+Créez les individus `Finger`, `Hand`, `Arm`, `Body` avec la chaîne :
 - Finger `is_part_of` Hand
 - Hand `is_part_of` Arm
 - Arm `is_part_of` Body
 
-Apres `sync_reasoner`, verifiez que Finger.is_part_of contient bien Body (via transitivite).
+Après `sync_reasoner`, verifiez que Finger.is_part_of contient bien Body (via transitivite).
 
-**Indice** : declarer la classe `is_part_of(ObjectProperty, TransitiveProperty)`.",,,,,,,,584b72cb33d7574a,,,,,,,
+**Indice** : declarer la classe `is_part_of(ObjectProperty, TransitiveProperty)`.",,,,,,,,7b9ebdea4f60c11a,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,ae732ead,code,fr,c922162d90047473,"# Exercice 5 : propriete transitive
 # TODO etudiant : declarer is_part_of(ObjectProperty, TransitiveProperty)
 # Indice : chaine Finger -> Hand -> Arm -> Body ; sync_reasoner ; verifier Finger.is_part_of inclut Body
 
 print(""Exercice a completer"")",,,,,,,,c922162d90047473,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,b4f1d994,markdown,fr,231df58be94b13f3,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,b4f1d994,markdown,fr,aec216c7ec3f5566,"---
 
 ## Exercices
 
-A votre tour. Completez les exercices ci-dessous (les solutions ne sont pas fournies). Le notebook doit pouvoir s'executer de bout en bout meme si les exercices ne sont pas encore completes.",,,,,,,,231df58be94b13f3,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,16e42815,markdown,fr,c34c1a8954015526,"### Exercice 6 : Ontologie de domaine libre
+A votre tour. Completez les exercices ci-dessous (les solutions ne sont pas fournies). Le notebook doit pouvoir s'executer de bout en bout même si les exercices ne sont pas encore completes.",,,,,,,,aec216c7ec3f5566,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,16e42815,markdown,fr,27c9000f46003c72,"### Exercice 6 : Ontologie de domaine libre
 
-Choisissez un domaine de votre choix (musique, sport, cuisine, etc.) et creez une ontologie OWL complete :
+Choisissez un domaine de votre choix (musique, sport, cuisine, etc.) et créez une ontologie OWL complete :
 
-- Au moins **5 classes** avec une hierarchie coherente
+- Au moins **5 classes** avec une hiérarchie coherente
 - Au moins **3 proprietes** (ObjectProperty ou DataProperty)
-- Des restrictions `equivalent_to` pour definir des classes par leur comportement
+- Des restrictions `equivalent_to` pour définir des classes par leur comportement
 - Des individus pour tester le raisonnement
 - Utilisez `sync_reasoner()` pour verifier les inferences
 
-**Indice** : inspirez-vous des exemples guides 1-3. Definissez vos classes avec `equivalent_to = [ClasseParent & propriete.some(ClasseCible)]`, creez des individus, puis lancez `sync_reasoner` pour observer les classifications automatiques.",,,,,,,,c34c1a8954015526,,,,,,,
+**Indice** : inspirez-vous des exemples guides 1-3. Definissez vos classes avec `equivalent_to = [ClasseParent & propriete.some(ClasseCible)]`, créez des individus, puis lancez `sync_reasoner` pour observer les classifications automatiques.",,,,,,,,27c9000f46003c72,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,e21176a9,code,fr,bdcdab9e4a9abda9,"# Exercice 6 : Ontologie de domaine libre
 # TODO etudiant : Choisissez un domaine (musique, sport, cuisine, etc.)
 # et creez une ontologie OWL avec au moins 5 classes, 3 proprietes,
@@ -15907,12 +15907,12 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,e21176a9,code,fr
 
 result = None  # TODO etudiant : remplacer par votre ontologie
 print(""Exercice a completer : ontologie de domaine libre"")",,,,,,,,bdcdab9e4a9abda9,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,7d2980d2,markdown,fr,ac577279bdc76c0a,"## Conclusion
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb,7d2980d2,markdown,fr,778a911050f98120,"## Conclusion
 
-Ce sidetrack a presente la manipulation d'ontologies OWL en Python avec OWLReady2, en mettant en lumiere son approche orientee classes (haut niveau) par rapport a l'approche triple-based de dotNetRDF. Vous avez appris a definir des classes, proprietes et restrictions OWL directement en syntaxe Python, a creer des individus et assertions, et a exploiter le raisonneur HermiT pour deduire automatiquement de nouvelles connaissances (classification en Employee/Manager, Parent/Child, Carnivore).
+Ce sidetrack a presente la manipulation d'ontologies OWL en Python avec OWLReady2, en mettant en lumiere son approche orientee classes (haut niveau) par rapport a l'approche triple-based de dotNetRDF. Vous avez appris a définir des classes, proprietes et restrictions OWL directement en syntaxe Python, a créer des individus et assertions, et a exploiter le raisonneur HermiT pour deduire automatiquement de nouvelles connaissances (classification en Employee/Manager, Parent/Child, Carnivore).
 
-Les points cles a retenir sont la puissance du raisonnement OWL 2 DL via `sync_reasoner()` qui reclassifie les individus selon leurs proprietes, les restrictions `equivalent_to` avec `.some()` et `.only()` pour definir des classes par leur comportement, et l'export multi-format (RDF/XML, Turtle) pour l'integration dans d'autres outils. Ces competences preparent a la validation de donnees avec SHACL et a la construction de graphes de connaissances.",,,,,,,,ac577279bdc76c0a,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,129fd325,markdown,fr,31454efe907195dd,"# SW-7-OWL
+Les points cles a retenir sont la puissance du raisonnement OWL 2 DL via `sync_reasoner()` qui reclassifie les individus selon leurs proprietes, les restrictions `equivalent_to` avec `.some()` et `.only()` pour définir des classes par leur comportement, et l'export multi-format (RDF/XML, Turtle) pour l'integration dans d'autres outils. Ces competences preparent a la validation de données avec SHACL et a la construction de graphes de connaissances.",,,,,,,,778a911050f98120,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,129fd325,markdown,fr,8337733b97654407,"# SW-7-OWL
 
 **Navigation** : [<< 6-RDFS](SW-6-CSharp-RDFS.ipynb) | [Index](README.md) | [8-PythonRDF >>](SW-8-Python-SHACL.ipynb)
 
@@ -15923,8 +15923,8 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,129fd325,markdown
 A la fin de ce notebook, vous saurez :
 1. Comprendre OWL 2 et ce qu'il apporte au-dela de RDFS
 2. Utiliser `OntologyGraph` de dotNetRDF pour manipuler des ontologies
-3. Definir des classes OWL avec equivalence, disjonction et restrictions
-4. Definir des proprietes OWL : ObjectProperty, DatatypeProperty, FunctionalProperty, inverseOf
+3. Définir des classes OWL avec equivalence, disjonction et restrictions
+4. Définir des proprietes OWL : ObjectProperty, DatatypeProperty, FunctionalProperty, inverseOf
 5. Distinguer les profils OWL 2 (EL, QL, RL) et leurs cas d'usage
 6. Charger et interroger une ontologie existante (`university.owl`)
 
@@ -15933,7 +15933,7 @@ A la fin de ce notebook, vous saurez :
 | Concept | Description |
 |---------|-------------|
 | OWL 2 | Langage d'ontologie du W3C, extension de RDFS avec logique descriptive |
-| Ontologie | Modele formel d'un domaine : classes, proprietes, contraintes, individus |
+| Ontologie | Modèle formel d'un domaine : classes, proprietes, contraintes, individus |
 | OntologyGraph | Classe dotNetRDF specialisee pour manipuler les ontologies |
 | Logique descriptive | Formalisme logique sous-jacent a OWL (decidable) |
 
@@ -15943,7 +15943,7 @@ A la fin de ce notebook, vous saurez :
 
 ### Duree estimee : 50 minutes
 
----",,,,,,,,31454efe907195dd,,,,,,,
+---",,,,,,,,8337733b97654407,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,aa5a3547,markdown,fr,3ea3f62f112f1cff,"## Installation et imports
 
 Chargeons dotNetRDF avec les espaces de noms necessaires pour travailler avec OWL.",,,,,,,,3ea3f62f112f1cff,,,,,,,
@@ -15962,31 +15962,31 @@ using VDS.RDF.Query.Inference;
 
 Console.WriteLine(""dotNetRDF charge avec succes."");
 Console.WriteLine(""Espace de noms OWL disponible : VDS.RDF.Ontology"");",,,,,,,,a9c93445ddcd70b4,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,aa9886b7,markdown,fr,6b71f561765a676e,"### Interpretation
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,aa9886b7,markdown,fr,8adefd72fe5f8e76,"### Interpretation
 
 L'espace de noms `VDS.RDF.Ontology` est la cle pour travailler avec OWL dans dotNetRDF. Il fournit :
 
-| Classe | Role |
+| Classe | Rôle |
 |--------|------|
 | `OntologyGraph` | Graphe specialise avec acces aux classes et proprietes OWL |
 | `OntologyClass` | Represente une classe OWL (avec super/sous-classes, instances) |
 | `OntologyProperty` | Represente une propriete OWL (avec domaine, portee) |
-| `OntologyResource` | Classe de base pour les ressources ontologiques |",,,,,,,,6b71f561765a676e,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,5478b351,markdown,fr,38d702aa63b66c25,"---
+| `OntologyResource` | Classe de base pour les ressources ontologiques |",,,,,,,,8adefd72fe5f8e76,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,5478b351,markdown,fr,083134973d088ea3,"---
 
 ## 1. Introduction a OWL 2 : au-dela de RDFS
 
-Dans le notebook precedent (SW-6), nous avons vu que RDFS permet de definir des classes, des hierarchies et des proprietes avec inference. Cependant, RDFS a des **limites importantes**.
+Dans le notebook précédent (SW-6), nous avons vu que RDFS permet de définir des classes, des hiérarchies et des proprietes avec inference. Cependant, RDFS a des **limites importantes**.
 
 **OWL 2 (Web Ontology Language)** est base sur la **logique descriptive** (Description Logic, DL), un fragment decidable de la logique du premier ordre.
 
-> **OWL 2** (*Web Ontology Language*) est le standard W3C de modelisation d'ontologies (Motik, Patel-Schneider & Cuenca Grau eds., W3C Recommendation 2009/2012). Il repose formellement sur la **logique descriptive** (Description Logic, DL) -- un fragment decidable de la logique du premier ordre dont la theorie est synthetisee dans Baader, Calvanese, McGuinness, Nardi & Patel-Schneider, *The Description Logic Handbook* (Cambridge University Press, 2e ed. 2007). Le vocabulaire DL (Concept / Role / Individu / TBox / ABox) introduit ci-dessous est celui de cette tradition.
+> **OWL 2** (*Web Ontology Language*) est le standard W3C de modelisation d'ontologies (Motik, Patel-Schneider & Cuenca Grau eds., W3C Recommendation 2009/2012). Il repose formellement sur la **logique descriptive** (Description Logic, DL) -- un fragment decidable de la logique du premier ordre dont la théorie est synthetisee dans Baader, Calvanese, McGuinness, Nardi & Patel-Schneider, *The Description Logic Handbook* (Cambridge University Press, 2e ed. 2007). Le vocabulaire DL (Concept / Rôle / Individu / TBox / ABox) introduit ci-dessous est celui de cette tradition.
 
 ### Comparaison RDFS vs OWL 2
 
 | Capacite | RDFS | OWL 2 |
 |----------|------|-------|
-| Hierarchie de classes | `rdfs:subClassOf` | `rdfs:subClassOf` + restrictions |
+| Hiérarchie de classes | `rdfs:subClassOf` | `rdfs:subClassOf` + restrictions |
 | Classes disjointes | Impossible | `owl:disjointWith` |
 | Equivalence de classes | Impossible | `owl:equivalentClass` |
 | Cardinalite (min/max) | Impossible | `owl:minCardinality`, `owl:maxCardinality` |
@@ -15995,7 +15995,7 @@ Dans le notebook precedent (SW-6), nous avons vu que RDFS permet de definir des 
 | Union/intersection de classes | Impossible | `owl:unionOf`, `owl:intersectionOf` |
 | Raisonnement decidable | Limite | Garanti (selon le profil) |
 
-### OWL 2 dans la pile du Web Semantique
+### OWL 2 dans la pile du Web Sémantique
 
 ```
      +------------------+
@@ -16003,7 +16003,7 @@ Dans le notebook precedent (SW-6), nous avons vu que RDFS permet de definir des 
      +------------------+
      |   OWL 2 (SW-7)   |  <- Logique descriptive  <-- Nous sommes ici
      +------------------+
-     |   RDFS (SW-6)    |  <- Vocabulaires, hierarchies
+     |   RDFS (SW-6)    |  <- Vocabulaires, hiérarchies
      +------------------+
      | SPARQL (SW-5)    |  <- Interrogation
      +------------------+
@@ -16016,15 +16016,15 @@ Dans le notebook precedent (SW-6), nous avons vu que RDFS permet de definir des 
 | Terme DL | Equivalent OWL | Exemple |
 |----------|----------------|----------|
 | Concept | `owl:Class` | Personne, Cours, Departement |
-| Role | `owl:ObjectProperty` | enseigne, inscritA |
+| Rôle | `owl:ObjectProperty` | enseigne, inscritA |
 | Individu | Instance | prof_dupont, etud_martin |
 | TBox | Axiomes terminologiques | ""Un Professeur est une Personne"" |
-| ABox | Assertions individuelles | ""prof_dupont est un Professeur"" |",,,,,,,,38d702aa63b66c25,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,b8f01b54,markdown,fr,8f8803c64e6d7357,"---
+| ABox | Assertions individuelles | ""prof_dupont est un Professeur"" |",,,,,,,,083134973d088ea3,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,b8f01b54,markdown,fr,92a5727cf5722854,"---
 
 ## 2. OntologyGraph : la classe specialisee de dotNetRDF
 
-`OntologyGraph` etend `Graph` avec des methodes specifiques pour naviguer dans les ontologies OWL et RDFS. Creons une premiere ontologie simple en code.",,,,,,,,8f8803c64e6d7357,,,,,,,
+`OntologyGraph` etend `Graph` avec des méthodes spécifiques pour naviguer dans les ontologies OWL et RDFS. Creons une première ontologie simple en code.",,,,,,,,92a5727cf5722854,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,c3d10a16,code,fr,501b3bf77f74a272,"// Creer une ontologie simple avec OntologyGraph
 OntologyGraph onto = new OntologyGraph();
 onto.NamespaceMap.AddNamespace(""uni"", new Uri(""http://example.org/university#""));
@@ -16097,7 +16097,7 @@ foreach (OntologyClass cls in onto.OwlClasses)
     if (subClasses.Any())
         Console.WriteLine($""  {name} a pour sous-classes : {string.Join("", "", subClasses)}"");
 }",,,,,,,,501b3bf77f74a272,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,9e19c8ec,markdown,fr,7a3c2be1ffea5616,"### Interpretation : OntologyGraph vs Graph
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,9e19c8ec,markdown,fr,09e6edee5395ae01,"### Interpretation : OntologyGraph vs Graph
 
 | Aspect | `Graph` | `OntologyGraph` |
 |--------|---------|------------------|
@@ -16106,13 +16106,13 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,9e19c8ec,markdown
 | `RdfClasses` | Non | Oui -- enumere les classes `rdfs:Class` |
 | `AllClasses` | Non | Oui -- union des deux |
 | `OwlProperties` | Non | Oui -- proprietes OWL |
-| Navigation semantique | Non | `SuperClasses`, `SubClasses`, `Instances` |
+| Navigation sémantique | Non | `SuperClasses`, `SubClasses`, `Instances` |
 
 **Points cles** :
 1. `onto.OwlClasses` retourne uniquement les ressources typees `owl:Class`
 2. `OntologyClass.SuperClasses` et `SubClasses` retournent les relations **directes** seulement
-3. Pour obtenir la fermeture transitive, il faut iterer ou utiliser un raisonneur",,,,,,,,7a3c2be1ffea5616,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,88d38d0b,markdown,fr,13846858533b68b7,"---
+3. Pour obtenir la fermeture transitive, il faut iterer ou utiliser un raisonneur",,,,,,,,09e6edee5395ae01,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,88d38d0b,markdown,fr,db75179a347205ca,"---
 
 ## 3. Classes OWL : equivalence, disjonction, restrictions
 
@@ -16120,15 +16120,15 @@ OWL 2 offre des constructeurs de classes bien plus riches que RDFS :
 
 | Constructeur | Syntaxe OWL | Description |
 |-------------|-------------|-------------|
-| Classe nommee | `owl:Class` | Classe definie par un URI |
-| Equivalence | `owl:equivalentClass` | Deux classes ont exactement les memes instances |
+| Classe nommee | `owl:Class` | Classe définie par un URI |
+| Equivalence | `owl:equivalentClass` | Deux classes ont exactement les mêmes instances |
 | Disjonction | `owl:disjointWith` | Aucune instance commune |
 | Complement | `owl:complementOf` | Tout ce qui n'est PAS dans la classe |
 | Union | `owl:unionOf` | Instances de C1 OU C2 |
 | Intersection | `owl:intersectionOf` | Instances de C1 ET C2 |
-| Restriction | `owl:Restriction` | Classe definie par une contrainte sur une propriete |
+| Restriction | `owl:Restriction` | Classe définie par une contrainte sur une propriete |
 
-Demontrons `owl:equivalentClass` et `owl:disjointWith` en code.",,,,,,,,13846858533b68b7,,,,,,,
+Demontrons `owl:equivalentClass` et `owl:disjointWith` en code.",,,,,,,,db75179a347205ca,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,0a5c2659,code,fr,f6300b9a6ff5af87,"// Demonstration de owl:equivalentClass et owl:disjointWith
 OntologyGraph classDemo = new OntologyGraph();
 classDemo.NamespaceMap.AddNamespace(""ex"", new Uri(""http://example.org/transport#""));
@@ -16188,7 +16188,7 @@ foreach (Triple t in classDemo.GetTriplesWithPredicate(disjointWith))
     string o = ((IUriNode)t.Object).Uri.Fragment.TrimStart('#');
     Console.WriteLine($""  {s} disjoint de {o}"");
 }",,,,,,,,f6300b9a6ff5af87,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,4955a2de,markdown,fr,e8325767d2a1a051,"### Interpretation : Equivalence et disjonction
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,4955a2de,markdown,fr,e12a90622a1ce782,"### Interpretation : Equivalence et disjonction
 
 | Relation | Signification | Consequence logique |
 |----------|---------------|---------------------|
@@ -16196,16 +16196,16 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,4955a2de,markdown
 | `Voiture owl:disjointWith Moto` | Ensembles disjoints | Aucun individu ne peut etre a la fois Voiture et Moto |
 | `Moto owl:disjointWith Velo` | Ensembles disjoints | Aucun individu ne peut etre a la fois Moto et Velo |
 
-**Difference entre `equivalentClass` et `subClassOf`** :
+**Différence entre `equivalentClass` et `subClassOf`** :
 - `A rdfs:subClassOf B` : toute instance de A est instance de B (inclusion, $A \subseteq B$)
-- `A owl:equivalentClass B` : A et B ont exactement les memes instances ($A = B$)
+- `A owl:equivalentClass B` : A et B ont exactement les mêmes instances ($A = B$)
 
-> **Cas d'usage** : `owl:equivalentClass` est souvent utilise pour relier des termes de vocabulaires differents (ex: `schema:Person owl:equivalentClass foaf:Person`).",,,,,,,,e8325767d2a1a051,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,08df13bb,markdown,fr,2929e6fc00ad256e,"---
+> **Cas d'usage** : `owl:equivalentClass` est souvent utilise pour relier des termes de vocabulaires différents (ex: `schema:Person owl:equivalentClass foaf:Person`).",,,,,,,,e12a90622a1ce782,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,08df13bb,markdown,fr,8d83c21e29dc3254,"---
 
 ## 4. Proprietes OWL
 
-OWL distingue deux types fondamentaux de proprietes et offre des caracteristiques supplementaires :
+OWL distingue deux types fondamentaux de proprietes et offre des caractéristiques supplementaires :
 
 ### Types de proprietes
 
@@ -16214,9 +16214,9 @@ OWL distingue deux types fondamentaux de proprietes et offre des caracteristique
 | **Object Property** | `owl:ObjectProperty` | Relie deux individus (sujet et objet sont des ressources) |
 | **Datatype Property** | `owl:DatatypeProperty` | Relie un individu a une valeur litterale |
 
-### Caracteristiques des proprietes
+### Caractéristiques des proprietes
 
-| Caracteristique | Syntaxe | Signification |
+| Caractéristique | Syntaxe | Signification |
 |----------------|---------|----------------|
 | Fonctionnelle | `owl:FunctionalProperty` | Au plus une valeur par sujet |
 | Inverse-fonctionnelle | `owl:InverseFunctionalProperty` | Au plus un sujet par valeur |
@@ -16224,7 +16224,7 @@ OWL distingue deux types fondamentaux de proprietes et offre des caracteristique
 | Symetrique | `owl:SymmetricProperty` | Si a->b alors b->a |
 | Inverse | `owl:inverseOf` | P1 est l'inverse de P2 |
 
-Construisons un exemple complet avec les proprietes d'une ontologie universitaire.",,,,,,,,2929e6fc00ad256e,,,,,,,
+Construisons un exemple complet avec les proprietes d'une ontologie universitaire.",,,,,,,,8d83c21e29dc3254,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,42f8cd84,code,fr,31b0b9628c3c2f94,"// Proprietes OWL : types et caracteristiques
 OntologyGraph propDemo = new OntologyGraph();
 propDemo.NamespaceMap.AddNamespace(""uni"", new Uri(""http://example.org/university#""));
@@ -16347,20 +16347,20 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,a39d5f11,markdown
 4. **owl:inverseOf** permet la navigation bidirectionnelle : si ""Dupont enseigne IA"", alors ""IA est enseigne par Dupont""
 
 > **En RDFS**, `rdf:Property` ne distingue pas ObjectProperty et DatatypeProperty. OWL rend cette distinction explicite, ce qui ameliore la validation et le raisonnement.",,,,,,,,6f8dab5e8f350ad9,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,6a623067,markdown,fr,fdb1942080767543,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,6a623067,markdown,fr,ab01a9da535289f5,"---
 
 ## 5. Profils OWL 2 : EL, QL, RL
 
-OWL 2 definit trois **profils** (sous-ensembles) qui offrent des compromis entre expressivite et performances de raisonnement :
+OWL 2 définit trois **profils** (sous-ensembles) qui offrent des compromis entre expressivite et performances de raisonnement :
 
 | Profil | Logique | Expressivite | Performance | Cas d'usage |
 |--------|---------|-------------|-------------|-------------|
 | **OWL 2 EL** | $\mathcal{EL}^{++}$ | Limitee | Temps polynomial | Grandes ontologies biomedicales (SNOMED CT, Gene Ontology) |
-| **OWL 2 QL** | DL-Lite | Limitee | Reductible a SQL | Acces par requetes SPARQL/SQL, OBDA |
-| **OWL 2 RL** | Regles | Moderee | Implementable par regles | Systemes a base de regles, validation |
+| **OWL 2 QL** | DL-Lite | Limitee | Reductible a SQL | Acces par requêtes SPARQL/SQL, OBDA |
+| **OWL 2 RL** | Règles | Moderee | Implementable par règles | Systèmes a base de règles, validation |
 | **OWL 2 DL** | $\mathcal{SROIQ}(D)$ | Maximale | Decidable mais couteux | Ontologies complexes, raisonnement complet |
 
-> Les logiques sous-jacentes aux profils sont des fragments DL nommes et etudies : $\mathcal{EL}^{++}$ pour OWL 2 EL (Baader, Brandt & Lutz, ""Pushing the EL Envelope"", IJCAI 2005), DL-Lite pour OWL 2 QL (Calvanese, De Giacomo, Lembo, Lenzerini & Rosati, 2007) et $\mathcal{SROIQ}(D)$ pour OWL 2 DL (Horrocks, Kutz & Sattler, 2006). Les profils eux-memes sont specifies par le W3C (Motik et al., OWL 2 Profiles, 2009).
+> Les logiques sous-jacentes aux profils sont des fragments DL nommes et etudies : $\mathcal{EL}^{++}$ pour OWL 2 EL (Baader, Brandt & Lutz, ""Pushing the EL Envelope"", IJCAI 2005), DL-Lite pour OWL 2 QL (Calvanese, De Giacomo, Lembo, Lenzerini & Rosati, 2007) et $\mathcal{SROIQ}(D)$ pour OWL 2 DL (Horrocks, Kutz & Sattler, 2006). Les profils eux-mêmes sont specifies par le W3C (Motik et al., OWL 2 Profiles, 2009).
 
 ### Comparaison detaillee
 
@@ -16371,18 +16371,18 @@ OWL 2 definit trois **profils** (sous-ensembles) qui offrent des compromis entre
 | Negation | Non | Oui (limitee) | Oui (limitee) |
 | Cardinalite | Non | Non | Oui (limitee) |
 | Nombre de classes | > 100 000 | > 10 000 | > 10 000 |
-| Implementation typique | Classificateur | Rewriting SPARQL | Regles de production |
+| Implementation typique | Classificateur | Rewriting SPARQL | Règles de production |
 
 ### Comment choisir ?
 
 ```
-Votre ontologie est-elle tres grande (>100K classes) ?
+Votre ontologie est-elle très grande (>100K classes) ?
   --> OUI : OWL 2 EL
   --> NON :
-      Acces par requetes SQL/SPARQL principalement ?
+      Acces par requêtes SQL/SPARQL principalement ?
         --> OUI : OWL 2 QL
         --> NON :
-            Implementation par regles ?
+            Implementation par règles ?
               --> OUI : OWL 2 RL
               --> NON : OWL 2 DL (expressivite maximale)
 ```
@@ -16393,9 +16393,9 @@ Votre ontologie est-elle tres grande (>100K classes) ?
 |-----------|--------|---------|--------|
 | SNOMED CT | EL | Terminologie medicale | ~350 000 concepts |
 | Gene Ontology | EL | Bioinformatique | ~45 000 termes |
-| Schema.org | RL | SEO, donnees structurees | ~800 types |
-| DBpedia Ontology | RL | Connaissances generales | ~760 classes |
-| CIDOC-CRM | DL | Patrimoine culturel | ~90 classes |",,,,,,,,fdb1942080767543,,,,,,,
+| Schema.org | RL | SEO, données structurees | ~800 types |
+| DBpedia Ontology | RL | Connaissances générales | ~760 classes |
+| CIDOC-CRM | DL | Patrimoine culturel | ~90 classes |",,,,,,,,ab01a9da535289f5,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,c2d6d291,markdown,fr,dde5c0967b556671,"---
 
 ## 6. Exemple guide avec `data/university.owl`
@@ -16435,18 +16435,18 @@ foreach (OntologyClass cls in uniOnto.OwlClasses)
     if (superClasses.Any())
         Console.WriteLine($""    rdfs:subClassOf {string.Join("", "", superClasses)}"");
 }",,,,,,,,b6ed9b3d96a7dfd2,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,3656e61d,markdown,fr,1be90f13ac358aaf,"### Interpretation : Structure de university.owl
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,3656e61d,markdown,fr,c608c101b7f716b8,"### Interpretation : Structure de university.owl
 
 L'ontologie contient :
 
-| Element | Exemples |
+| Élément | Exemples |
 |---------|----------|
 | Classes | Person, Student, Professor, GraduateStudent, Course, Department |
-| Hierarchie | Student < Person, Professor < Person, GraduateStudent < Student |
+| Hiérarchie | Student < Person, Professor < Person, GraduateStudent < Student |
 | Disjonction | Professor disjointWith Student |
 | ObjectProperties | enrolledIn, teaches, memberOf, advisedBy |
 | DatatypeProperties | name (fonctionnelle), credits |
-| Instances | prof_dupont, etud_martin, etud_bernard, course_ia, course_web_sem |",,,,,,,,1be90f13ac358aaf,,,,,,,
+| Instances | prof_dupont, etud_martin, etud_bernard, course_ia, course_web_sem |",,,,,,,,c608c101b7f716b8,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,89d81bf5,markdown,fr,a7adb562ca161cd8,"### Interroger les proprietes et individus
 
 Explorons les proprietes de l'ontologie et les relations entre individus.",,,,,,,,a7adb562ca161cd8,,,,,,,
@@ -16492,9 +16492,9 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,541bd226,markdown
 | `advisedBy` | ObjectProperty | GraduateStudent | Professor | Direction de these |
 | `name` | DatatypeProperty | Person | xsd:string | Nom de la personne |
 | `credits` | DatatypeProperty | Course | xsd:integer | Nombre de credits ECTS |",,,,,,,,c2fa4dfff1b2d295,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,3da3ef94,markdown,fr,689334e4e8c2acac,"### Requetes SPARQL sur l'ontologie
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,3da3ef94,markdown,fr,1d7b1f1dada4d815,"### Requêtes SPARQL sur l'ontologie
 
-Utilisons SPARQL pour interroger les individus et croiser les informations.",,,,,,,,689334e4e8c2acac,,,,,,,
+Utilisons SPARQL pour interroger les individus et croiser les informations.",,,,,,,,1d7b1f1dada4d815,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,a4a46f4c,code,fr,ccf941cb5705246a,"// Requetes SPARQL sur university.owl
 var uniDataset = new InMemoryDataset(uniOnto);
 var uniProcessor = new LeviathanQueryProcessor(uniDataset);
@@ -16554,18 +16554,18 @@ foreach (SparqlResult r in r2)
     string cred = r.HasBoundValue(""credits"") ? ((ILiteralNode)r[""credits""]).Value : ""?"";
     Console.WriteLine($""  {prof} enseigne '{course}' ({cred} credits)"");
 }",,,,,,,,ccf941cb5705246a,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,b5aa5eb0,markdown,fr,907c11871e4b8833,"### Interpretation : Requetes sur l'ontologie
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,b5aa5eb0,markdown,fr,2e985f9c267e56e8,"### Interpretation : Requêtes sur l'ontologie
 
-| Personne | Type | Cours | Role |
+| Personne | Type | Cours | Rôle |
 |----------|------|-------|------|
-| Marie Dupont | Professor | IA, Web Semantique | Enseigne |
-| Pierre Martin | GraduateStudent | IA, Web Semantique | Inscrit, dirige par Dupont |
-| Sophie Bernard | Student | Web Semantique | Inscrite |
+| Marie Dupont | Professor | IA, Web Sémantique | Enseigne |
+| Pierre Martin | GraduateStudent | IA, Web Sémantique | Inscrit, dirige par Dupont |
+| Sophie Bernard | Student | Web Sémantique | Inscrite |
 
 **Points cles** :
-1. La requete avec `rdfs:subClassOf*` (chemin de propriete) remonte la hierarchie de classes
-2. `OPTIONAL` evite de perdre les resultats sans credits
-3. L'ontologie permet de croiser les informations de differentes proprietes",,,,,,,,907c11871e4b8833,,,,,,,
+1. La requête avec `rdfs:subClassOf*` (chemin de propriete) remonte la hiérarchie de classes
+2. `OPTIONAL` evite de perdre les résultats sans credits
+3. L'ontologie permet de croiser les informations de différentes proprietes",,,,,,,,2e985f9c267e56e8,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,82c97407,markdown,fr,ab3ddf741293ae7c,"### Verifier les contraintes OWL
 
 L'ontologie declare `Professor owl:disjointWith Student`. Verifions cette contrainte et observons ce qui se passe en cas de violation.",,,,,,,,ab3ddf741293ae7c,,,,,,,
@@ -16634,24 +16634,24 @@ foreach (SparqlResult r in violations2)
 // Retirer la violation
 uniOnto.Retract(violationTriple);
 Console.WriteLine(""\nViolation retiree. Ontologie restauree."")",,,,,,,,377724ed0f4b6de3,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,3f0cd9f7,markdown,fr,e9dfce64187ff7e5,"### Interpretation : Verification des contraintes
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,3f0cd9f7,markdown,fr,ae297061d8ef2da0,"### Interpretation : Verification des contraintes
 
-| Etape | Resultat | Explication |
+| Étape | Résultat | Explication |
 |-------|----------|-------------|
 | Avant violation | 0 violation | L'ontologie est coherente |
-| Apres `prof_dupont rdf:type Student` | 1 violation | prof_dupont est Professor ET Student |
-| Apres retrait | 0 violation | Coherence restauree |
+| Après `prof_dupont rdf:type Student` | 1 violation | prof_dupont est Professor ET Student |
+| Après retrait | 0 violation | Coherence restauree |
 
 **Points cles** :
-1. OWL definit des contraintes **semantiques** verifiables par SPARQL
+1. OWL définit des contraintes **sémantiques** verifiables par SPARQL
 2. dotNetRDF ne bloque pas l'ajout de triplets violant une contrainte (hypothese du monde ouvert)
-3. C'est au raisonneur ou a la requete de **detecter** les incoherences
+3. C'est au raisonneur ou a la requête de **detecter** les incoherences
 4. Un raisonneur OWL complet (HermiT, Pellet) deduirait que l'ontologie est **inconsistante**
 
-> **Hypothese du monde ouvert** : en OWL, l'absence d'information ne signifie pas la negation. Le raisonneur ne rejette pas les triplets, il detecte les contradictions.",,,,,,,,e9dfce64187ff7e5,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,ae8fc7a1,markdown,fr,381da49da0cfc4fe,"### Appliquer l'inference RDFS a l'ontologie OWL
+> **Hypothese du monde ouvert** : en OWL, l'absence d'information ne signifie pas la negation. Le raisonneur ne rejette pas les triplets, il detecte les contradictions.",,,,,,,,ae297061d8ef2da0,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,ae8fc7a1,markdown,fr,e17541a8898ad5e5,"### Appliquer l'inference RDFS a l'ontologie OWL
 
-Bien que dotNetRDF ne fournisse pas de raisonneur OWL DL complet, le `StaticRdfsReasoner` permet de propager les types dans la hierarchie.",,,,,,,,381da49da0cfc4fe,,,,,,,
+Bien que dotNetRDF ne fournisse pas de raisonneur OWL DL complet, le `StaticRdfsReasoner` permet de propager les types dans la hiérarchie.",,,,,,,,e17541a8898ad5e5,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,a0692f2f,code,fr,c67fc234acba4e8c,"// Recharger l'ontologie propre pour la demonstration d'inference
 Graph uniGraph = new Graph();
 RdfXmlParser rdfXmlParser2 = new RdfXmlParser();
@@ -16693,7 +16693,7 @@ foreach (Triple t in uniGraph.GetTriplesWithSubjectPredicate(dupont, rdfTypeN))
     if (t.Object is IUriNode typeUri)
         Console.WriteLine($""  - {typeUri.Uri.Fragment.TrimStart('#')}"");
 }",,,,,,,,c67fc234acba4e8c,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,4e3a5bf1,markdown,fr,7252ede2322994d8,"### Interpretation : Inference sur l'ontologie OWL
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,4e3a5bf1,markdown,fr,f5b071b4d10d1719,"### Interpretation : Inference sur l'ontologie OWL
 
 | Individu | Types explicites | Types inferes par RDFS |
 |----------|-----------------|------------------------|
@@ -16701,7 +16701,7 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,4e3a5bf1,markdown
 | `prof_dupont` | Professor | Person |
 | `etud_bernard` | Student | Person |
 
-**Chaine d'inference pour `etud_martin`** :
+**Chaîne d'inference pour `etud_martin`** :
 ```
 etud_martin rdf:type GraduateStudent
 GraduateStudent rdfs:subClassOf Student    --> etud_martin rdf:type Student
@@ -16709,10 +16709,10 @@ Student rdfs:subClassOf Person              --> etud_martin rdf:type Person
 ```
 
 **Limites du raisonneur dotNetRDF** :
-- `StaticRdfsReasoner` applique uniquement les regles **RDFS**, pas les regles OWL
+- `StaticRdfsReasoner` applique uniquement les règles **RDFS**, pas les règles OWL
 - Il ne verifie pas `owl:disjointWith`, `owl:FunctionalProperty`, etc.
-- Pour un raisonnement OWL complet, il faut un raisonneur externe (HermiT, Pellet, FaCT++)",,,,,,,,7252ede2322994d8,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,c464fa19,markdown,fr,0d4c50b2f1c7aa8e,"---
+- Pour un raisonnement OWL complet, il faut un raisonneur externe (HermiT, Pellet, FaCT++)",,,,,,,,f5b071b4d10d1719,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,c464fa19,markdown,fr,95b537a5e9834442,"---
 
 ## Exercices
 
@@ -16724,7 +16724,7 @@ Etendez l'ontologie `university.owl` en ajoutant :
 - Une propriete `participatesIn` (owl:ObjectProperty, domaine: GraduateStudent, portee: ResearchProject)
 - Deux instances de ResearchProject avec des labels
 - Rattachez prof_dupont et etud_martin a un projet
-- Ecrivez une requete SPARQL pour lister tous les participants a chaque projet",,,,,,,,0d4c50b2f1c7aa8e,,,,,,,
+- Ecrivez une requête SPARQL pour lister tous les participants a chaque projet",,,,,,,,95b537a5e9834442,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,77576614,markdown,fr,194e11d987d860db,"### Exercice : Explorer les equivalences de classes OWL
 
 La section sur `owl:equivalentClass` et `owl:disjointWith` a montre comment modeliser
@@ -16759,18 +16759,18 @@ exParser.Load(exOnto, ""data/university.owl"");
 // TODO: Requete SPARQL pour lister les participants par projet
 
 Console.WriteLine(""Exercice 1 : a completer"");",,,,,,,,2a54f1f5bf7dc2c5,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,43f75519,markdown,fr,c599a0b01ee943b7,"### Exercice 2 : Detecter les incoherences
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,43f75519,markdown,fr,5702232f5447965c,"### Exercice 2 : Detecter les incoherences
 
 Ecrivez un programme qui :
 1. Charge `university.owl`
 2. Ajoute volontairement des triplets problematiques :
    - `etud_bernard rdf:type Professor` (violation de disjonction)
    - Un nouveau cours sans credits
-3. Ecrivez des requetes SPARQL pour detecter :
+3. Ecrivez des requêtes SPARQL pour detecter :
    - Les violations de disjonction (individu avec deux types disjoints)
    - Les cours sans credits (propriete manquante)
    - Les etudiants sans inscription (pas de `enrolledIn`)
-4. Affichez un rapport de coherence",,,,,,,,c599a0b01ee943b7,,,,,,,
+4. Affichez un rapport de coherence",,,,,,,,5702232f5447965c,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,d012fb36,code,fr,0e76e80604393590,"// Exercice 2 : Detecter les incoherences
 
 OntologyGraph checkOnto = new OntologyGraph();
@@ -16785,7 +16785,7 @@ checkParser.Load(checkOnto, ""data/university.owl"");
 // TODO: Afficher un rapport de coherence
 
 Console.WriteLine(""Exercice 2 : a completer"");",,,,,,,,0e76e80604393590,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,2baa5a9a,markdown,fr,cbe0c3a7874910c6,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,2baa5a9a,markdown,fr,6188f78b7614141c,"---
 
 ## Resume
 
@@ -16805,7 +16805,7 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,2baa5a9a,markdown
 
 1. **OWL 2 depasse RDFS** avec des classes disjointes, des proprietes typees et des restrictions
 2. **OntologyGraph** de dotNetRDF facilite la navigation dans les ontologies
-3. **owl:equivalentClass** declare la synonymie entre classes de vocabulaires differents
+3. **owl:equivalentClass** declare la synonymie entre classes de vocabulaires différents
 4. **ObjectProperty vs DatatypeProperty** distingue les relations entre individus et vers les valeurs
 5. **owl:FunctionalProperty** et **owl:inverseOf** ajoutent des contraintes sur les proprietes
 6. **Les profils OWL 2** (EL, QL, RL) offrent des compromis entre expressivite et performance
@@ -16815,7 +16815,7 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,2baa5a9a,markdown
 
 | Capacite | RDFS (SW-6) | OWL 2 (SW-7) |
 |----------|-------------|---------------|
-| Classes et hierarchies | Oui | Oui + restrictions |
+| Classes et hiérarchies | Oui | Oui + restrictions |
 | Disjonction | Non | `owl:disjointWith` |
 | Equivalence | Non | `owl:equivalentClass` |
 | Proprietes inverses | Non | `owl:inverseOf` |
@@ -16826,10 +16826,10 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb,2baa5a9a,markdown
 ### Limites de OWL dans dotNetRDF
 
 - Pas de raisonneur OWL DL complet integre
-- `StaticRdfsReasoner` applique uniquement les regles RDFS
+- `StaticRdfsReasoner` applique uniquement les règles RDFS
 - Pour un raisonnement OWL complet : utiliser HermiT (Glimm, Horrocks et al., *HermiT: An OWL 2 Reasoner*, J. Automated Reasoning 2014), Pellet (Sirin et al. 2007) ou FaCT++ (Tsarkov & Horrocks 2006) via un triple store
 
-### Prochaine etape
+### Prochaine étape
 
 Dans le notebook suivant (**SW-8-PythonRDF**), nous decouvrirons :
 - La bibliotheque Python rdflib pour manipuler RDF
@@ -16850,30 +16850,30 @@ Dans le notebook suivant (**SW-8-PythonRDF**), nous decouvrirons :
 
 ---
 
-**Navigation** :  [<< 6-RDFS](SW-6-CSharp-RDFS.ipynb) | [Index](README.md) | [8-PythonRDF >>](SW-8-Python-SHACL.ipynb)",,,,,,,,cbe0c3a7874910c6,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-001,markdown,fr,b132086896295698,"# SW-8-CSharp-SHACL
+**Navigation** :  [<< 6-RDFS](SW-6-CSharp-RDFS.ipynb) | [Index](README.md) | [8-PythonRDF >>](SW-8-Python-SHACL.ipynb)",,,,,,,,6188f78b7614141c,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-001,markdown,fr,3cd921913bc35069,"# SW-8-CSharp-SHACL
 
 **Navigation** : [<< 7-OWL](SW-7-CSharp-OWL.ipynb) | [Index](README.md) | [SW-8-Python >>](SW-8-Python-SHACL.ipynb)
 
-## SHACL avec dotNetRDF : Valider la qualite de donnees RDF en C#
+## SHACL avec dotNetRDF : Valider la qualite de données RDF en C#
 
-Ce notebook est le **jumeau C# / .NET** du notebook [SW-8-Python-SHACL](SW-8-Python-SHACL.ipynb). La ou le notebook Python utilise **pySHACL** (le moteur SHACL de reference en Python), ce notebook utilise **dotNetRDF** (le moteur RDF/SHACL de reference en .NET). Les deux implementent la meme recommandation W3C SHACL (2017) : ce sont de veritables compagnons cross-langage sur un standard commun.
+Ce notebook est le **jumeau C# / .NET** du notebook [SW-8-Python-SHACL](SW-8-Python-SHACL.ipynb). La ou le notebook Python utilise **pySHACL** (le moteur SHACL de reference en Python), ce notebook utilise **dotNetRDF** (le moteur RDF/SHACL de reference en .NET). Les deux implementent la même recommandation W3C SHACL (2017) : ce sont de veritables compagnons cross-langage sur un standard commun.
 
 > **Verdict SOTA (EPIC #3801)** : **SOTA-OK**. Ce notebook invoque le **vrai moteur SHACL de dotNetRDF** (espace de noms `VDS.RDF.Shacl`, package `dotNetRdf.Shacl` 3.4.1). Aucun workaround, aucune reimplementation jouet de la validation SHACL -- le moteur reel tourne et produit le rapport de validation standard.
 
 ### Objectifs d'apprentissage
 
 A la fin de ce notebook, vous saurez :
-1. Definir des **shapes** SHACL (NodeShape, PropertyShape) pour contraindre un graphe RDF
-2. Valider des donnees avec le moteur SHACL de dotNetRDF (`ShapesGraph.Validate`) et interpreter le rapport
+1. Définir des **shapes** SHACL (NodeShape, PropertyShape) pour contraindre un graphe RDF
+2. Valider des données avec le moteur SHACL de dotNetRDF (`ShapesGraph.Validate`) et interpreter le rapport
 3. Construire des shapes personnalisees (en Turtle ou par l'API C#)
-4. Utiliser les severites (Violation / Warning / Info) et les operateurs logiques (`sh:or`, `sh:not`)
+4. Utiliser les severites (Violation / Warning / Info) et les opérateurs logiques (`sh:or`, `sh:not`)
 
 ### Concepts cles
 
 | Concept | Description |
 |---------|-------------|
-| SHACL | Shapes Constraint Language -- standard W3C 2017 pour valider des donnees RDF (monde ferme) |
+| SHACL | Shapes Constraint Language -- standard W3C 2017 pour valider des données RDF (monde ferme) |
 | NodeShape | Forme qui cible des noeuds RDF (par classe ou par URI) |
 | PropertyShape | Contrainte sur une propriete (cardinalite, type, motif, etc.) |
 | ShapesGraph | Classe dotNetRDF (`VDS.RDF.Shacl.ShapesGraph`) qui encapsule les formes et lance la validation |
@@ -16884,7 +16884,7 @@ A la fin de ce notebook, vous saurez :
 - Familiarite avec dotNetRDF (cf [SW-2-CSharp-RDFBasics](SW-2-CSharp-RDFBasics.ipynb))
 
 ### Duree estimee : 45 minutes
-",,,,,,,,b132086896295698,,,,,,,
+",,,,,,,,3cd921913bc35069,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-002,markdown,fr,657c08cfe3289259,"---
 
 ## 0. Chargement de dotNetRDF
@@ -16912,33 +16912,33 @@ Console.WriteLine(""dotNetRDF 3.4.1 charge avec succes."");
 Console.WriteLine(""Espaces de noms SHACL disponibles : VDS.RDF.Shacl, VDS.RDF.Shacl.ShapesGraph"");
 Console.WriteLine(""   (Validation via new ShapesGraph(g).Validate(data))"");
 ",,,,,,,,dc797be2fe73c37a,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-004,markdown,fr,dc4d9f47c2b10ade,"### Interpretation : Activation du moteur SHACL
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-004,markdown,fr,81ef24af338ca568,"### Interpretation : Activation du moteur SHACL
 
 La cellule ci-dessus :
 1. **`#r ""nuget: dotNetRDF, 3.4.1""`** restore le meta-package (et son sous-package `dotNetRdf.Shacl`).
 2. Les `using` exposent les espaces de noms `VDS.RDF.Shacl` (le moteur) et `VDS.RDF.Parsing` (le lecteur Turtle).
 3. L'alias `using StringWriter = System.IO.StringWriter` evite un conflit de noms avec `VDS.RDF.Writing.StringWriter`.
 
-> **Note technique** : l'API SHACL de dotNetRDF est centree sur la classe `VDS.RDF.Shacl.ShapesGraph` qui encapsule le graphe des formes et expose deux methodes : `Conforms(data)` (booleen) et `Validate(data)` (rapport detaille). C'est l'equivalent C# de la fonction `pyshacl.validate(...)` du notebook Python.
-",,,,,,,,dc4d9f47c2b10ade,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-005,markdown,fr,cce563d93c5b0538,"---
+> **Note technique** : l'API SHACL de dotNetRDF est centree sur la classe `VDS.RDF.Shacl.ShapesGraph` qui encapsule le graphe des formes et expose deux méthodes : `Conforms(data)` (booléen) et `Validate(data)` (rapport detaille). C'est l'equivalent C# de la fonction `pyshacl.validate(...)` du notebook Python.
+",,,,,,,,81ef24af338ca568,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-005,markdown,fr,73b8aa109f28d891,"---
 
 ## 1. Introduction a SHACL
 
-### Le probleme : l'hypothese du monde ouvert
+### Le problème : l'hypothese du monde ouvert
 
 En RDF et OWL, on travaille sous l'**hypothese du monde ouvert** (*Open World Assumption*, OWA) : l'absence d'information ne signifie pas que cette information est fausse. Si un graphe RDF ne mentionne pas l'age d'une personne, OWL considere simplement que l'age est *inconnu*, pas qu'il est absent.
 
-C'est un probleme pour la **qualite des donnees**. Dans une application reelle, on veut pouvoir dire :
+C'est un problème pour la **qualite des données**. Dans une application reelle, on veut pouvoir dire :
 - ""Chaque personne **doit** avoir un nom""
 - ""L'age **doit** etre un entier positif""
-- ""Un email **doit** respecter un format precis""
+- ""Un email **doit** respecter un format précis""
 
 OWL ne peut pas exprimer ces contraintes de validation. C'est la raison d'etre de **SHACL** (*Shapes Constraint Language*).
 
 ### SHACL : Shapes Constraint Language
 
-SHACL est une **recommandation W3C** publiee en juillet 2017 (Knublauch & Topidis, ""SHACL Shapes Constraint Language"", W3C Rec. 2017). Elle definit un vocabulaire RDF pour decrire des contraintes (""shapes"") que les donnees RDF doivent respecter.
+SHACL est une **recommandation W3C** publiee en juillet 2017 (Knublauch & Topidis, ""SHACL Shapes Constraint Language"", W3C Rec. 2017). Elle définit un vocabulaire RDF pour decrire des contraintes (""shapes"") que les données RDF doivent respecter.
 
 | Aspect | OWL (monde ouvert) | SHACL (monde ferme) |
 |--------|-------------------|---------------------|
@@ -16949,9 +16949,9 @@ SHACL est une **recommandation W3C** publiee en juillet 2017 (Knublauch & Topidi
 | **Analogie** | Definition d'un concept | Formulaire de saisie |
 | **Standard W3C** | OWL 2 (2012) | SHACL 1.0 (2017) |
 
-> **Point cle** : OWL decrit *ce qui est vrai* dans un domaine. SHACL decrit *ce que les donnees doivent respecter*. Les deux sont complementaires : OWL pour modeliser, SHACL pour valider.
-",,,,,,,,cce563d93c5b0538,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-006,markdown,fr,97ef6ab6b30060ee,"---
+> **Point cle** : OWL decrit *ce qui est vrai* dans un domaine. SHACL decrit *ce que les données doivent respecter*. Les deux sont complementaires : OWL pour modeliser, SHACL pour valider.
+",,,,,,,,73b8aa109f28d891,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-006,markdown,fr,286e732de0661d28,"---
 
 ## 2. Concepts fondamentaux de SHACL
 
@@ -16960,9 +16960,9 @@ SHACL repose sur deux types de formes (*shapes*) :
 | Concept | URI SHACL | Description |
 |---------|-----------|-------------|
 | **NodeShape** | `sh:NodeShape` | Forme qui s'applique a un noeud RDF (une ressource) |
-| **PropertyShape** | `sh:PropertyShape` | Forme qui contraint une propriete specifique |
+| **PropertyShape** | `sh:PropertyShape` | Forme qui contraint une propriete spécifique |
 | **targetClass** | `sh:targetClass` | Cible tous les noeuds d'une classe donnee |
-| **targetNode** | `sh:targetNode` | Cible un noeud specifique par son URI |
+| **targetNode** | `sh:targetNode` | Cible un noeud spécifique par son URI |
 | **property** | `sh:property` | Lie une NodeShape a ses PropertyShapes |
 | **path** | `sh:path` | Designe la propriete RDF a contraindre |
 
@@ -16980,18 +16980,18 @@ ex:PersonShape a sh:NodeShape ;       # Forme pour les personnes
 
 ### Principaux types de contraintes
 
-| Categorie | Contrainte | Propriete SHACL | Exemple |
+| Catégorie | Contrainte | Propriete SHACL | Exemple |
 |-----------|------------|-----------------|---------|
 | **Cardinalite** | Minimum / Maximum | `sh:minCount`, `sh:maxCount` | `sh:minCount 1` |
 | **Type** | Type de donnee | `sh:datatype` | `sh:datatype xsd:string` |
 | **Classe** | Classe RDF | `sh:class` | `sh:class foaf:Person` |
 | **Noeud** | Type de noeud | `sh:nodeKind` | `sh:nodeKind sh:IRI` |
-| **Chaine** | Longueur minimale | `sh:minLength` | `sh:minLength 2` |
-| **Chaine** | Motif regex | `sh:pattern` | `sh:pattern ""^[A-Z]""` |
-| **Numerique** | Borne inclusive | `sh:minInclusive`, `sh:maxInclusive` | `sh:minInclusive 0` |
+| **Chaîne** | Longueur minimale | `sh:minLength` | `sh:minLength 2` |
+| **Chaîne** | Motif regex | `sh:pattern` | `sh:pattern ""^[A-Z]""` |
+| **Numérique** | Borne inclusive | `sh:minInclusive`, `sh:maxInclusive` | `sh:minInclusive 0` |
 | **Valeur** | Liste autorisee | `sh:in` | `sh:in (""FR"" ""DE"")` |
 | **Logique** | OU / ET / NON | `sh:or`, `sh:and`, `sh:not`, `sh:xone` | liste de sous-formes |
-",,,,,,,,97ef6ab6b30060ee,,,,,,,
+",,,,,,,,286e732de0661d28,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-007,markdown,fr,18a05263dabe2e43,"---
 
 ## 3. Explorer une shape SHACL existante
@@ -17054,20 +17054,20 @@ foreach (Triple shapeT in shapesGraph.GetTriplesWithPredicateObject(rdfType, shN
     }
 }
 ",,,,,,,,fef3413dc04714c0,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-011,markdown,fr,cabd1d3efd37ba21,"### Interpretation : Structure de la forme PersonShape
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-011,markdown,fr,a9a074da366209b3,"### Interpretation : Structure de la forme PersonShape
 
 La forme `ex:PersonShape` cible toutes les instances de `foaf:Person` et impose 4 contraintes :
 
 | Propriete | Contraintes | Signification |
 |-----------|-------------|---------------|
-| `foaf:name` | minCount=1, maxCount=1, datatype=string, minLength=2 | Exactement un nom, chaine d'au moins 2 caracteres |
+| `foaf:name` | minCount=1, maxCount=1, datatype=string, minLength=2 | Exactement un nom, chaîne d'au moins 2 caractères |
 | `foaf:mbox` | maxCount=1, pattern=`^mailto:.+@.+\\..+$` | Au plus un email, format mailto: valide |
 | `foaf:age` | maxCount=1, datatype=integer, minInclusive=0, maxInclusive=150 | Au plus un age, entier entre 0 et 150 |
 | `foaf:knows` | class=foaf:Person | Les personnes connues doivent etre des foaf:Person |
 
 > **Note** : `foaf:mbox` et `foaf:age` n'ont pas de `minCount`, ils sont donc optionnels. Seul `foaf:name` est obligatoire (minCount=1).
-",,,,,,,,cabd1d3efd37ba21,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-012,markdown,fr,12117a16cf0c2f8f,"---
+",,,,,,,,a9a074da366209b3,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-012,markdown,fr,a535a2c482a48c1f,"---
 
 ## 4. Validation SHACL avec dotNetRDF
 
@@ -17078,20 +17078,20 @@ dotNetRDF expose la validation SHACL via la classe `VDS.RDF.Shacl.ShapesGraph` :
 | Membre | Signature | Description |
 |--------|-----------|-------------|
 | **Constructeur** | `new ShapesGraph(IGraph shapes)` | Encapsule un graphe de formes SHACL |
-| **`Conforms`** | `bool Conforms(IGraph data)` | True si les donnees sont conformes (sans detail) |
-| **`Validate`** | `Validation.Report Validate(IGraph data)` | Rapport detaille des resultats |
+| **`Conforms`** | `bool Conforms(IGraph data)` | True si les données sont conformes (sans detail) |
+| **`Validate`** | `Validation.Report Validate(IGraph data)` | Rapport detaille des résultats |
 
 Le rapport retourne par `Validate` expose :
-- `report.Conforms` (booleen, False si au moins une violation `sh:Violation`)
+- `report.Conforms` (booléen, False si au moins une violation `sh:Violation`)
 - `report.Results` (collection de `Validation.Result`)
 - Chaque `Result` a : `Severity`, `FocusNode`, `ResultPath`, `Message`, `SourceConstraintComponent`, `ResultValue`
 
-### Charger les donnees de test
+### Charger les données de test
 
 Le fichier `data/person-data.ttl` contient 7 personnes dont **5 presentent des erreurs volontaires**.
 
-> **Pie cross-langage (G.1, verified firsthand)** : le `TurtleParser` de dotNetRDF est **plus strict** que `rdflib`. Le fichier contient `<not-an-email>` comme URI relative (pour le test du pattern email) ; dotNetRDF refuse de parser une URI relative sans base. On fixe en assignant `graph.BaseUri` avant le chargement -- rdflib (Python) l'accepte silencieusement. C'est une difference de robustesse entre les deux parseurs, documentee ici pour la parite.
-",,,,,,,,12117a16cf0c2f8f,,,,,,,
+> **Pie cross-langage (G.1, verified firsthand)** : le `TurtleParser` de dotNetRDF est **plus strict** que `rdflib`. Le fichier contient `<not-an-email>` comme URI relative (pour le test du pattern email) ; dotNetRDF refuse de parser une URI relative sans base. On fixe en assignant `graph.BaseUri` avant le chargement -- rdflib (Python) l'accepte silencieusement. C'est une différence de robustesse entre les deux parseurs, documentee ici pour la parite.
+",,,,,,,,a535a2c482a48c1f,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-013,code,fr,e19d3f01026229df,"// Chargement du graphe de donnees (avec base URI pour resoudre les URI relatives)
 IGraph dataGraph = new Graph { BaseUri = UriFactory.Create(""http://example.org/"") };
 new TurtleParser().Load(dataGraph, new StreamReader(""data/person-data.ttl""));
@@ -17132,10 +17132,10 @@ string GetOne(IGraph g, INode s, IUriNode p)
     return obj is ILiteralNode lit ? lit.Value : obj.ToString();
 }
 ",,,,,,,,e19d3f01026229df,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-014,markdown,fr,af3445a0ae78fccb,"### Execution de la validation
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-014,markdown,fr,e769d73f93b31569,"### Exécution de la validation
 
-Lançons la validation en instanciant `ShapesGraph` sur le graphe des formes, puis en appelant `Validate` sur le graphe de donnees.
-",,,,,,,,af3445a0ae78fccb,,,,,,,
+Lançons la validation en instanciant `ShapesGraph` sur le graphe des formes, puis en appelant `Validate` sur le graphe de données.
+",,,,,,,,e769d73f93b31569,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-015,code,fr,7b9e05706c17c0ca,"// Validation SHACL via le moteur dotNetRDF
 var shapes = new ShapesGraph(shapesGraph);
 var report = shapes.Validate(dataGraph);
@@ -17170,9 +17170,9 @@ foreach (var r in report.Results.OrderBy(x => x.FocusNode.ToString()))
     Console.WriteLine($""{focus,-12} {path,-10} {component,-28} {severity,-12}"");
 }
 ",,,,,,,,9697d5819c764945,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-017,markdown,fr,cc4a8e09dc942af9,"### Interpretation : Les 5 erreurs detectees
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-017,markdown,fr,f9a5f3e9209295f5,"### Interpretation : Les 5 erreurs detectees
 
-Le fichier `person-data.ttl` contenait 5 erreurs volontaires, toutes detectees par le moteur SHACL de dotNetRDF. **Ces 5 violations correspondent exactement** aux 5 erreurs rapportedees par pySHACL dans le notebook Python ([SW-8-Python-SHACL](SW-8-Python-SHACL.ipynb), section 4) -- les deux moteurs s'accordent sur le meme diagnostic.
+Le fichier `person-data.ttl` contenait 5 erreurs volontaires, toutes detectees par le moteur SHACL de dotNetRDF. **Ces 5 violations correspondent exactement** aux 5 erreurs rapportedees par pySHACL dans le notebook Python ([SW-8-Python-SHACL](SW-8-Python-SHACL.ipynb), section 4) -- les deux moteurs s'accordent sur le même diagnostic.
 
 | Personne | Propriete | Composant de contrainte | Explication |
 |----------|-----------|-------------------------|-------------|
@@ -17181,40 +17181,40 @@ Le fichier `person-data.ttl` contenait 5 erreurs volontaires, toutes detectees p
 | **charlie** | `foaf:name` | MinCount | Pas de nom alors que `minCount=1` est exige |
 | **diana** | `foaf:age` | MinInclusive | Age negatif (-5) alors que `minInclusive=0` |
 | **eve** | `foaf:mbox` | Pattern | Email `not-an-email` ne correspond pas au motif `^mailto:` |
-| **frank** | `foaf:name` | MinLength | Nom ""F"" (1 caractere) trop court, `minLength=2` |
+| **frank** | `foaf:name` | MinLength | Nom ""F"" (1 caractère) trop court, `minLength=2` |
 | **grace** | `foaf:knows` | Class | `ex:myDog` est un `ex:Dog`, pas un `foaf:Person` |
 
 **Points cles** :
-1. Alice et Bob passent la validation car leurs donnees sont completes et conformes.
+1. Alice et Bob passent la validation car leurs données sont completes et conformes.
 2. Bob n'a pas d'email mais c'est conforme : `foaf:mbox` n'a pas de `minCount`.
-3. Chaque violation est independante : un meme noeud pourrait cumuler plusieurs violations.
-4. Les noms de composants (`MinCountConstraintComponent`, `MinInclusiveConstraintComponent`, etc.) sont les identifiants standardises du vocabulaire SHACL du W3C -- les memes que pySHACL.
-",,,,,,,,cc4a8e09dc942af9,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-018,markdown,fr,dc81f6e61c934367,"---
+3. Chaque violation est independante : un même noeud pourrait cumuler plusieurs violations.
+4. Les noms de composants (`MinCountConstraintComponent`, `MinInclusiveConstraintComponent`, etc.) sont les identifiants standardises du vocabulaire SHACL du W3C -- les mêmes que pySHACL.
+",,,,,,,,f9a5f3e9209295f5,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-018,markdown,fr,d386550e6516fd96,"---
 
 ## 5. Ecrire des shapes custom
 
-Plutot que de charger des fichiers Turtle existants, on peut construire des formes SHACL **directement en C#**, soit en parsant une chaine Turtle (l'approche la plus lisible, SHACL etant defini en Turtle), soit par l'API de graphe dotNetRDF (`Assert`, `CreateBlankNode`). Cette section montre les deux approches.
+Plutot que de charger des fichiers Turtle existants, on peut construire des formes SHACL **directement en C#**, soit en parsant une chaîne Turtle (l'approche la plus lisible, SHACL etant défini en Turtle), soit par l'API de graphe dotNetRDF (`Assert`, `CreateBlankNode`). Cette section montre les deux approches.
 
 ### Catalogue des contraintes
 
-| Categorie | Propriete SHACL | Description |
+| Catégorie | Propriete SHACL | Description |
 |-----------|-----------------|-------------|
 | Cardinalite | `sh:minCount`, `sh:maxCount` | Nombre min / max de valeurs |
 | Type | `sh:datatype`, `sh:class`, `sh:nodeKind` | Type XSD, classe RDF, ou type de noeud |
-| Chaine | `sh:pattern`, `sh:minLength`, `sh:maxLength` | Regex, longueurs min / max |
-| Numerique | `sh:minInclusive`, `sh:maxInclusive` | Bornes inclusives |
+| Chaîne | `sh:pattern`, `sh:minLength`, `sh:maxLength` | Regex, longueurs min / max |
+| Numérique | `sh:minInclusive`, `sh:maxInclusive` | Bornes inclusives |
 | Valeur | `sh:hasValue`, `sh:in` | Valeur exacte, liste autorisee |
 | Logique | `sh:or`, `sh:and`, `sh:not`, `sh:xone` | Combinaisons de sous-formes |
 
 ### Exemple guide : une ArticleShape (construction en Turtle inline)
 
 Creesons une forme SHACL pour valider des articles (`schema:Article`) :
-- Titre obligatoire (`schema:headline`, string, min 5 caracteres)
+- Titre obligatoire (`schema:headline`, string, min 5 caractères)
 - Au moins un auteur (`schema:author`, doit etre un `schema:Person`)
 - Date de publication optionnelle (`schema:datePublished`, format `xsd:date`)
 - Nombre de mots optionnel (`schema:wordCount`, entier entre 100 et 50000)
-",,,,,,,,dc81f6e61c934367,,,,,,,
+",,,,,,,,d386550e6516fd96,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-019,code,fr,ae25a2e26172e09b,"// Construction d'une ArticleShape par Turtle inline (format natif de SHACL)
 string articleShapesTtl = @""
 @prefix sh: <http://www.w3.org/ns/shacl#> .
@@ -17302,33 +17302,33 @@ foreach (var r in articleReport.Results.OrderBy(x => x.FocusNode.ToString()))
     Console.WriteLine($""  {focus} / {path} -> {component} : {r.Message}"");
 }
 ",,,,,,,,ae25a2e26172e09b,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-020,markdown,fr,70d09c5a3e87d5f8,"### Interpretation : Validation de la forme personnalisee
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-020,markdown,fr,35689e508918fffe,"### Interpretation : Validation de la forme personnalisee
 
 | Article | Violations | Detail |
 |---------|-----------|--------|
 | **article1** | 0 | Conforme : titre, auteur, date et wordCount respectent toutes les contraintes |
-| **article2** | 1 | Titre ""RDF"" trop court (3 < 5 caracteres requis par minLength) |
+| **article2** | 1 | Titre ""RDF"" trop court (3 < 5 caractères requis par minLength) |
 | **article3** | 2 | Pas de titre (minCount=1) + pas d'auteur (minCount=1) |
 | **article4** | 1 | wordCount=10 < minInclusive=100 |
 
 > **Bonne pratique** : ajoutz toujours des messages explicites (`sh:message`) pour faciliter le diagnostic. Les messages en francais sont plus utiles que les messages generiques du moteur.
-",,,,,,,,70d09c5a3e87d5f8,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-021,markdown,fr,865846163f2bb586,"---
+",,,,,,,,35689e508918fffe,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-021,markdown,fr,27ba1619e5c7f338,"---
 
 ### Exercice 1 : MovieShape -- valider un dataset de films
 
-Creez une forme SHACL `ex:MovieShape` (en Turtle inline ou par l'API C#) pour valider des films (`schema:Movie`) avec :
-- **Titre** (`schema:name`) : obligatoire, chaine, min 1 caractere
+Créez une forme SHACL `ex:MovieShape` (en Turtle inline ou par l'API C#) pour valider des films (`schema:Movie`) avec :
+- **Titre** (`schema:name`) : obligatoire, chaîne, min 1 caractère
 - **Annee** (`schema:datePublished`) : entier entre 1900 et 2030
 - **Acteur** (`schema:actor`) : au moins un, doit etre un `schema:Person`
 
-Puis creez un graphe de donnees avec 2 films valides et 3 invalides, et validez.
+Puis créez un graphe de données avec 2 films valides et 3 invalides, et validez.
 
 **Indices** :
 - Reutilisez le patron de l'`ArticleShape` (Turtle inline + `new TurtleParser().Load(g, new StringReader(ttl))`).
 - Pour les bornes d'annee : `sh:minInclusive 1900 ; sh:maxInclusive 2030`.
 - Pour exiger un acteur d'une classe donnee : `sh:minCount 1 ; sh:class schema:Person`.
-",,,,,,,,865846163f2bb586,,,,,,,
+",,,,,,,,27ba1619e5c7f338,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-022,code,fr,0d50fb43ab0ad1c1,"// Exercice 1 : MovieShape
 // TODO etudiant : definissez la forme MovieShape en Turtle
 string movieShapesTtl = @""
@@ -17354,11 +17354,11 @@ ex:MovieShape a sh:NodeShape ;
 
 Console.WriteLine(""Exercice a completer"");
 ",,,,,,,,0d50fb43ab0ad1c1,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-023,markdown,fr,92b463f4ac9c707f,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-023,markdown,fr,c803f11b83da17d6,"---
 
 ## 6. Severites SHACL
 
-SHACL definit trois niveaux de severite pour les violations. Par defaut, toutes les contraintes ont la severite `sh:Violation`, mais on peut les ajuster avec `sh:severity`.
+SHACL définit trois niveaux de severite pour les violations. Par defaut, toutes les contraintes ont la severite `sh:Violation`, mais on peut les ajuster avec `sh:severity`.
 
 | Severite | URI | Comportement | Usage typique |
 |----------|-----|-------------|---------------|
@@ -17366,8 +17366,8 @@ SHACL definit trois niveaux de severite pour les violations. Par defaut, toutes 
 | **Warning** | `sh:Warning` | Avertissement non bloquant | Donnee recommandee mais optionnelle |
 | **Info** | `sh:Info` | Information, suggestion | Bonne pratique non imposee |
 
-Le booleen `report.Conforms` retourne `False` **uniquement** pour les `sh:Violation`. Les warnings et infos n'affectent pas la conformite -- mais ils apparaissent dans `report.Results`.
-",,,,,,,,92b463f4ac9c707f,,,,,,,
+Le booléen `report.Conforms` retourne `False` **uniquement** pour les `sh:Violation`. Les warnings et infos n'affectent pas la conformite -- mais ils apparaissent dans `report.Results`.
+",,,,,,,,c803f11b83da17d6,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-024,code,fr,a1cc89c2778aaf30,"// Demonstration des 3 niveaux de severite
 string severityShapesTtl = @""
 @prefix sh: <http://www.w3.org/ns/shacl#> .
@@ -17418,9 +17418,9 @@ foreach (var r in severityReport.Results)
     Console.WriteLine($""  [{sev,-10}] {r.Message}"");
 }
 ",,,,,,,,a1cc89c2778aaf30,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-025,markdown,fr,462fd2c8c5856b67,"### Interpretation : Impact de la severite
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-025,markdown,fr,785a2eafeac3b0b3,"### Interpretation : Impact de la severite
 
-Bien que les 3 contraintes soient violees, le booleen `report.Conforms` ne depend que de `sh:Violation` :
+Bien que les 3 contraintes soient violees, le booléen `report.Conforms` ne depend que de `sh:Violation` :
 
 | Severite | Contrainte violee | Impact sur `Conforms` |
 |----------|-------------------|----------------------|
@@ -17429,24 +17429,24 @@ Bien que les 3 contraintes soient violees, le booleen `report.Conforms` ne depen
 | `sh:Info` | Pas de telephone | Pas d'impact (information seulement, mais present dans Results) |
 
 > **Bonne pratique** : utilisz `sh:Warning` pour les proprietes recommandees (best practices) et `sh:Info` pour les suggestions. Reservez `sh:Violation` aux exigences absolues.
-",,,,,,,,462fd2c8c5856b67,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-026,markdown,fr,af410d5641757f35,"---
+",,,,,,,,785a2eafeac3b0b3,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-026,markdown,fr,ae11a598a5c50e56,"---
 
 ### Exercice 2 : Une forme avec severites mixtes
 
-Creez une forme `ex:StudentShape` pour valider des etudiants (`ex:Student`) avec les contraintes et severites suivantes :
+Créez une forme `ex:StudentShape` pour valider des etudiants (`ex:Student`) avec les contraintes et severites suivantes :
 
 | Propriete | Contrainte | Severite |
 |-----------|-----------|----------|
-| `foaf:name` | Obligatoire, chaine | `sh:Violation` |
+| `foaf:name` | Obligatoire, chaîne | `sh:Violation` |
 | `ex:studentId` | Obligatoire, motif `^[A-Z]{2}\\d{6}$` | `sh:Violation` |
 | `foaf:mbox` | Recommande (minCount 1) | `sh:Warning` |
 | `ex:phone` | Souhaitable (minCount 1) | `sh:Info` |
 
-Testez avec 3 etudiants : un complet, un sans email/telephone, un sans nom. Verifiez que `Conforms` est False (a cause du nom manquant) mais que tous les resultats apparaissent dans `report.Results`.
+Testez avec 3 etudiants : un complet, un sans email/telephone, un sans nom. Verifiez que `Conforms` est False (a cause du nom manquant) mais que tous les résultats apparaissent dans `report.Results`.
 
 **Indices** : `sh:pattern ""^[A-Z]{2}\\\\d{6}$""` (echappement Turtle), `sh:severity sh:Warning`.
-",,,,,,,,af410d5641757f35,,,,,,,
+",,,,,,,,ae11a598a5c50e56,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-027,code,fr,a649c0a91a206502,"// Exercice 2 : StudentShape avec severites multiples
 // TODO etudiant : definissez StudentShape en Turtle
 string studentShapesTtl = @""
@@ -17463,13 +17463,13 @@ ex:StudentShape a sh:NodeShape ;
 // TODO etudiant : creez les 3 etudiants de test, validez, et affichez les resultats par severite
 Console.WriteLine(""Exercice a completer"");
 ",,,,,,,,a649c0a91a206502,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-028,markdown,fr,007076219615cf72,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-028,markdown,fr,1b630b97dac56cb7,"---
 
-## 7. Contraintes avancees : operateurs logiques
+## 7. Contraintes avancees : opérateurs logiques
 
-SHACL permet de combiner des contraintes avec des operateurs logiques :
+SHACL permet de combiner des contraintes avec des opérateurs logiques :
 
-| Operateur | Propriete SHACL | Semantique |
+| Opérateur | Propriete SHACL | Sémantique |
 |-----------|-----------------|------------|
 | **OU** | `sh:or` | Au moins une des sous-formes doit etre satisfaite |
 | **ET** | `sh:and` | Toutes les sous-formes doivent etre satisfaites |
@@ -17479,7 +17479,7 @@ SHACL permet de combiner des contraintes avec des operateurs logiques :
 ### Exemple guide : un Contact doit avoir un email OU un telephone (`sh:or`)
 
 La contrainte `sh:or` prend une liste RDF de sous-formes. Si au moins une sous-forme est satisfaite, la contrainte passe.
-",,,,,,,,007076219615cf72,,,,,,,
+",,,,,,,,1b630b97dac56cb7,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-029,code,fr,7efb86f295a1add0,"// Forme avancee avec sh:or (un Contact doit avoir un email OU un telephone)
 string contactShapesTtl = @""
 @prefix sh: <http://www.w3.org/ns/shacl#> .
@@ -17524,9 +17524,9 @@ foreach (var r in contactReport.Results)
     Console.WriteLine($""  {focus} -> {component} : {r.Message}"");
 }
 ",,,,,,,,7efb86f295a1add0,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-030,markdown,fr,8e93ee4c567fa388,"### Interpretation : Contraintes logiques
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-030,markdown,fr,bf7c3b25bc69408b,"### Interpretation : Contraintes logiques
 
-| Contact | Email | Telephone | Resultat | Raison |
+| Contact | Email | Telephone | Résultat | Raison |
 |---------|-------|-----------|----------|--------|
 | contact1 | Oui | Non | Conforme | `sh:or` satisfait par l'email |
 | contact2 | Non | Oui | Conforme | `sh:or` satisfait par le telephone |
@@ -17534,7 +17534,7 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-030,markdo
 | contact4 | Oui | Oui | Conforme | `sh:or` satisfait par les deux (OU inclusif) |
 
 > **Point cle** : `sh:or` est un OU **inclusif** : avoir les deux options satisfaites est aussi valide. Pour exiger exactement une option, utilisz `sh:xone` (OU exclusif).
-",,,,,,,,8e93ee4c567fa388,,,,,,,
+",,,,,,,,bf7c3b25bc69408b,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-031,markdown,fr,af99fdaaceb3bdcd,"---
 
 ### Exercice 3 : Contrainte `sh:not` et enumeration `sh:in`
@@ -17570,17 +17570,17 @@ ex:AccountShape a sh:NodeShape ;
 // TODO etudiant : creez 3 comptes (1 valide, 2 invalides), validez, affichez
 Console.WriteLine(""Exercice a completer"");
 ",,,,,,,,8a2e89160a2f81c7,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-033,markdown,fr,9ad649b3964b9bb7,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-033,markdown,fr,74e392e42d2b7fda,"---
 
 ## 8. Exemple guide : construire une BookShape par l'API C#
 
-Jusqu'ici nous avons defini les shapes en Turtle inline. dotNetRDF permet aussi de **construire les formes par programmation** (Assert de triplets), comme le fait rdflib en Python. Cette section montre l'equivalent C# pour une `BookShape` :
+Jusqu'ici nous avons défini les shapes en Turtle inline. dotNetRDF permet aussi de **construire les formes par programmation** (Assert de triplets), comme le fait rdflib en Python. Cette section montre l'equivalent C# pour une `BookShape` :
 
-- **Titre** (`schema:name`) : obligatoire, chaine, min 1 caractere
+- **Titre** (`schema:name`) : obligatoire, chaîne, min 1 caractère
 - **ISBN** (`schema:isbn`) : motif EAN-13 `^97[89]-\\d-\\d{4}-\\d{4}-\\d$`
 - **Annee** (`schema:datePublished`) : entier entre 1450 et 2030
 - **Auteur** (`schema:author`) : au moins un, IRI de type `schema:Person`
-",,,,,,,,9ad649b3964b9bb7,,,,,,,
+",,,,,,,,74e392e42d2b7fda,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-034,code,fr,6674927c235237d9,"// Exemple guide : BookShape construite par l'API dotNetRDF (equivalent C# du build-shape Python)
 IGraph bookShapes = new Graph();
 bookShapes.NamespaceMap.AddNamespace(""sh"", UriFactory.Create(""http://www.w3.org/ns/shacl#""));
@@ -17691,29 +17691,29 @@ La construction par `Assert`/`CreateBlankNode` est l'equivalent C# du `graph.add
 
 > **Quand utiliser Turtle inline vs API** : Turtle inline pour des formes fixes (lisibilite maximale, proche de la spec SHACL) ; API programmatique pour des formes generees par le code.
 ",,,,,,,,0d94942ba87498bd,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-036,markdown,fr,27c0149639146990,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-036,markdown,fr,54fcbdfcb4025d25,"---
 
 ## 9. Comparaison : dotNetRDF SHACL vs pySHACL
 
-Ce notebook et son jumeau [SW-8-Python-SHACL](SW-8-Python-SHACL.ipynb) appliquent le **meme standard W3C SHACL** via deux moteurs de reference. Les resultats concordent (mêmes 5 violations sur `person-data.ttl`, memes composants de contrainte, memes severites) ; les differences sont dans l'API.
+Ce notebook et son jumeau [SW-8-Python-SHACL](SW-8-Python-SHACL.ipynb) appliquent le **même standard W3C SHACL** via deux moteurs de reference. Les résultats concordent (mêmes 5 violations sur `person-data.ttl`, mêmes composants de contrainte, mêmes severites) ; les différences sont dans l'API.
 
 | Aspect | pySHACL (Python) | dotNetRDF (C#) |
 |--------|------------------|----------------|
 | **Point d'entree** | `validate(data_graph, shacl_graph=...)` | `new ShapesGraph(shapes).Validate(data)` |
 | **Retour** | triplet `(conforms, results_graph, results_text)` | `Validation.Report` (objet type) |
 | **Rapport** | graphe RDF + texte formate | `report.Results` (collection de `Result`) + graphe RDF |
-| **Severites** | `sh:Violation` / `Warning` / `Info` | idem (meme vocabulaire W3C) |
-| **Operateurs logiques** | `sh:or`, `sh:and`, `sh:not`, `sh:xone` | idem |
+| **Severites** | `sh:Violation` / `Warning` / `Info` | idem (même vocabulaire W3C) |
+| **Opérateurs logiques** | `sh:or`, `sh:and`, `sh:not`, `sh:xone` | idem |
 | **Parsing Turtle** | `rdflib` (tolerant, URIs relatives acceptees) | `TurtleParser` (strict, exige une base URI) |
 | **Construction API** | `graph.add((s, p, o))` + `BNode()` | `graph.Assert(new Triple(s, p, o))` + `CreateBlankNode()` |
-| **Inference RDFS** | `inference='rdfs'` (parametre de `validate`) | pre-materialisation a faire avant validation |
+| **Inference RDFS** | `inference='rdfs'` (paramètre de `validate`) | pre-materialisation a faire avant validation |
 | **Type de la forme** | `rdflib.Graph` | `VDS.RDF.Shacl.ShapesGraph` (encapsule un `IGraph`) |
 
-**Concordance verifiee firsthand (G.1)** : sur `person-shape.ttl` + `person-data.ttl`, les deux moteurs rapportent **exactement les 5 memes violations** (charlie/MinCount, diana/MinInclusive, eve/Pattern, frank/MinLength, grace/Class), avec les memes composants de contrainte standardises. C'est la garantie que SHACL est un **vrai standard** : deux implementations independantes convergent.
+**Concordance verifiee firsthand (G.1)** : sur `person-shape.ttl` + `person-data.ttl`, les deux moteurs rapportent **exactement les 5 mêmes violations** (charlie/MinCount, diana/MinInclusive, eve/Pattern, frank/MinLength, grace/Class), avec les mêmes composants de contrainte standardises. C'est la garantie que SHACL est un **vrai standard** : deux implementations independantes convergent.
 
-> **Difference notable** : pySHACL materialise l'inference RDFS option (`inference='rdfs'`) lors de la validation ; dotNetRDF delegue l'inference au `VDS.RDF.Inferencing` (a effectuer avant validation si besoin). Pour les formes cibles par `sh:targetClass`, il faut s'assurer que les types explicites (`a foaf:Person`) sont presents dans le graphe de donnees.
-",,,,,,,,27c0149639146990,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-037,markdown,fr,b91f6d93cc4d53d7,"---
+> **Différence notable** : pySHACL materialise l'inference RDFS option (`inference='rdfs'`) lors de la validation ; dotNetRDF delegue l'inference au `VDS.RDF.Inferencing` (a effectuer avant validation si besoin). Pour les formes cibles par `sh:targetClass`, il faut s'assurer que les types explicites (`a foaf:Person`) sont presents dans le graphe de données.
+",,,,,,,,54fcbdfcb4025d25,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-037,markdown,fr,ac3fc1c191f56b7f,"---
 
 ## Resume
 
@@ -17721,23 +17721,23 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-037,markdo
 
 | Concept | Ce que nous avons appris |
 |---------|--------------------------|
-| **SHACL** | Recommandation W3C 2017 pour la validation de donnees RDF (monde ferme) |
+| **SHACL** | Recommandation W3C 2017 pour la validation de données RDF (monde ferme) |
 | **NodeShape / PropertyShape** | Forme sur un noeud / contrainte sur une propriete |
 | **dotNetRDF SHACL** | `new ShapesGraph(shapes).Validate(data)` -> `Validation.Report` |
 | **Rapport** | `report.Conforms` + `report.Results` (`Severity`, `FocusNode`, `ResultPath`, `Message`, `SourceConstraintComponent`) |
 | **Severites** | `sh:Violation` (bloquant), `sh:Warning` (avertissement), `sh:Info` (suggestion) |
-| **Operateurs logiques** | `sh:or`, `sh:and`, `sh:not`, `sh:xone` |
+| **Opérateurs logiques** | `sh:or`, `sh:and`, `sh:not`, `sh:xone` |
 | **Construction** | Turtle inline (`new TurtleParser().Load(g, new StringReader(ttl))`) ou API (`Assert`/`CreateBlankNode`) |
 | **Gotcha cross-langage** | `TurtleParser` dotNetRDF plus strict que `rdflib` (URI relative exige une base) |
 
 ### Contraintes SHACL -- Reference rapide
 
-| Categorie | Propriete SHACL | Exemple |
+| Catégorie | Propriete SHACL | Exemple |
 |-----------|-----------------|---------|
 | Cardinalite | `sh:minCount`, `sh:maxCount` | `sh:minCount 1` |
 | Type | `sh:datatype`, `sh:class`, `sh:nodeKind` | `sh:datatype xsd:string` |
-| Chaine | `sh:pattern`, `sh:minLength`, `sh:maxLength` | `sh:pattern ""^[A-Z]""` |
-| Numerique | `sh:minInclusive`, `sh:maxInclusive` | `sh:minInclusive 0` |
+| Chaîne | `sh:pattern`, `sh:minLength`, `sh:maxLength` | `sh:pattern ""^[A-Z]""` |
+| Numérique | `sh:minInclusive`, `sh:maxInclusive` | `sh:minInclusive 0` |
 | Valeur | `sh:hasValue`, `sh:in` | `sh:in (""FR"" ""DE"")` |
 | Logique | `sh:or`, `sh:and`, `sh:not`, `sh:xone` | Liste de sous-formes |
 
@@ -17757,7 +17757,7 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-037,markdo
 ### Ressources supplementaires
 
 - [W3C SHACL Specification](https://www.w3.org/TR/shacl/) -- Standard complet (Knublauch & Topidis, 2017)
-- [SHACL Advanced Features](https://www.w3.org/TR/shacl-af/) -- Regles et fonctions
+- [SHACL Advanced Features](https://www.w3.org/TR/shacl-af/) -- Règles et fonctions
 - [dotNetRDF SHACL User Guide](https://dotnetrdf.org/docs/user_guide/shacl/) -- Documentation du moteur C#
 - [pySHACL Documentation](https://github.com/RDFLib/pySHACL) -- Le jumeau Python (notebook SW-8-Python)
 - [SHACL Playground](https://shacl-playground.zazuko.com/) -- Testez vos formes en ligne
@@ -17766,42 +17766,42 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb,sw8c-037,markdo
 
 ## Conclusion
 
-Ce notebook a permis d'explorer la validation SHACL en C# avec le **vrai moteur dotNetRDF** (`VDS.RDF.Shacl`), jumeau du notebook Python pySHACL sur le meme standard W3C. Les points cles :
+Ce notebook a permis d'explorer la validation SHACL en C# avec le **vrai moteur dotNetRDF** (`VDS.RDF.Shacl`), jumeau du notebook Python pySHACL sur le même standard W3C. Les points cles :
 
-- SHACL operationalise le **monde ferme** pour la qualite des donnees la ou OWL reste en monde ouvert.
+- SHACL operationalise le **monde ferme** pour la qualite des données la ou OWL reste en monde ouvert.
 - L'API dotNetRDF (`ShapesGraph.Validate` -> `Validation.Report`) est l'equivalent type de `pyshacl.validate`.
-- Les **5 violations** sur les donnees de test concordent exactement entre dotNetRDF et pySHACL -- deux implementations independantes convergent sur le standard.
-- Les severites et les operateurs logiques (`sh:or`, `sh:not`) ouvrent la voie a des contraintes business riches.
+- Les **5 violations** sur les données de test concordent exactement entre dotNetRDF et pySHACL -- deux implementations independantes convergent sur le standard.
+- Les severites et les opérateurs logiques (`sh:or`, `sh:not`) ouvrent la voie a des contraintes business riches.
 
-**Pour aller plus loin** : combinez SHACL avec RDFS/OWL (SW-6, SW-7) pour valider des donnees inferees, et explorez SHACL Advanced Features (regles de transformation `sh:rule`) pour la materialisation.
+**Pour aller plus loin** : combinez SHACL avec RDFS/OWL (SW-6, SW-7) pour valider des données inferees, et explorez SHACL Advanced Features (règles de transformation `sh:rule`) pour la materialisation.
 
 ---
 
 **Navigation** : [<< 7-OWL](SW-7-CSharp-OWL.ipynb) | [Index](README.md) | [SW-8-Python >>](SW-8-Python-SHACL.ipynb)
-",,,,,,,,b91f6d93cc4d53d7,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,header-nav,markdown,fr,6ebd0fbe52664b7a,"# SW-8-Python-SHACL
+",,,,,,,,ac3fc1c191f56b7f,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,header-nav,markdown,fr,adc461dad06eca88,"# SW-8-Python-SHACL
 **Navigation** : [<< 7b-OWL](SW-7b-Python-OWL.ipynb) | [Index](README.md) | [9-JSONLD >>](SW-9-Python-JSONLD.ipynb)
 
-## SHACL : Validation et Qualite des Donnees RDF
-Ce notebook explore SHACL (Shapes Constraint Language), la recommandation W3C pour la validation de donnees RDF. Contrairement a OWL qui raisonne sous l'hypothese du monde ouvert, SHACL permet de definir des contraintes concretes et de verifier que les donnees d'un graphe RDF les respectent.
+## SHACL : Validation et Qualite des Données RDF
+Ce notebook explore SHACL (Shapes Constraint Language), la recommandation W3C pour la validation de données RDF. Contrairement a OWL qui raisonne sous l'hypothese du monde ouvert, SHACL permet de définir des contraintes concretes et de verifier que les données d'un graphe RDF les respectent.
 
 ### Objectifs d'apprentissage
 A la fin de ce notebook, vous saurez :
-1. Definir des shapes SHACL pour contraindre un graphe RDF
-2. Valider des donnees avec pySHACL et interpreter le rapport
-3. Creer des shapes custom programmatiquement
-4. Utiliser SHACL pour garantir la qualite des donnees
+1. Définir des shapes SHACL pour contraindre un graphe RDF
+2. Valider des données avec pySHACL et interpreter le rapport
+3. Créer des shapes custom programmatiquement
+4. Utiliser SHACL pour garantir la qualite des données
 
 ### Prerequis
 - Notebook SW-7b-OWL complete
-### Duree estimee : 45 minutes",,,,,,,,6ebd0fbe52664b7a,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,install-intro,markdown,fr,8da7467ac5b76aaa,"---
+### Duree estimee : 45 minutes",,,,,,,,adc461dad06eca88,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,install-intro,markdown,fr,c6c72cf9755cfa26,"---
 
 ## 0. Installation des dependances
 
 Installons les deux bibliotheques necessaires :
-- **rdflib** : manipulation de graphes RDF (deja utilisee dans SW-8)
-- **pyshacl** : moteur de validation SHACL pour Python",,,,,,,,8da7467ac5b76aaa,,,,,,,
+- **rdflib** : manipulation de graphes RDF (déjà utilisee dans SW-8)
+- **pyshacl** : moteur de validation SHACL pour Python",,,,,,,,c6c72cf9755cfa26,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,install-deps,code,fr,c642c9edea4ef41b,"# Dependances pre-provisionnees (rdflib pyshacl) : voir SemanticWeb/requirements.txt ; imports dans les cellules suivantes.
 ",,,,,,,,c642c9edea4ef41b,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,9gb0g4mto9,markdown,fr,e873a53e8b908e1b,Verifions que les installations se sont bien passees en important les modules et en affichant leurs versions.,,,,,,,,e873a53e8b908e1b,,,,,,,
@@ -17811,24 +17811,24 @@ import pyshacl
 print(f""rdflib   : {rdflib.__version__}"")
 print(f""pyshacl  : {pyshacl.__version__}"")
 print(""Installation OK."")",,,,,,,,91aeb5297a1adf34,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,section1-title,markdown,fr,24f8709f57a7813b,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,section1-title,markdown,fr,d661bb767dcae801,"---
 
 ## 1. Introduction a SHACL
 
-### Le probleme : l'hypothese du monde ouvert
+### Le problème : l'hypothese du monde ouvert
 
 En RDF et OWL, on travaille sous l'**hypothese du monde ouvert** (*Open World Assumption*, OWA) : l'absence d'information ne signifie pas que cette information est fausse. Si un graphe RDF ne mentionne pas l'age d'une personne, OWL considere simplement que l'age est *inconnu*, pas qu'il est absent.
 
-C'est un probleme pour la **qualite des donnees**. Dans une application reelle, on veut pouvoir dire :
+C'est un problème pour la **qualite des données**. Dans une application reelle, on veut pouvoir dire :
 - ""Chaque personne **doit** avoir un nom""
 - ""L'age **doit** etre un entier positif""
-- ""Un email **doit** respecter un format precis""
+- ""Un email **doit** respecter un format précis""
 
 OWL ne peut pas exprimer ces contraintes de validation. C'est la raison d'etre de **SHACL** (*Shapes Constraint Language*).
 
 ### SHACL : Shapes Constraint Language
 
-SHACL est une **recommandation W3C** publiee en juillet 2017. Elle definit un vocabulaire RDF pour decrire des contraintes (""shapes"") que les donnees RDF doivent respecter.
+SHACL est une **recommandation W3C** publiee en juillet 2017. Elle définit un vocabulaire RDF pour decrire des contraintes (""shapes"") que les données RDF doivent respecter.
 
 | Aspect | OWL (monde ouvert) | SHACL (monde ferme) |
 |--------|-------------------|---------------------|
@@ -17839,8 +17839,8 @@ SHACL est une **recommandation W3C** publiee en juillet 2017. Elle definit un vo
 | **Analogie** | Definition d'un concept | Formulaire de saisie |
 | **Standard W3C** | OWL 2 (2012) | SHACL 1.0 (2017) |
 
-> **Point cle** : OWL decrit *ce qui est vrai* dans un domaine. SHACL decrit *ce que les donnees doivent respecter*. Les deux sont complementaires : OWL pour modeliser, SHACL pour valider.",,,,,,,,24f8709f57a7813b,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,section2-title,markdown,fr,9453bd09e971bac5,"---
+> **Point cle** : OWL decrit *ce qui est vrai* dans un domaine. SHACL decrit *ce que les données doivent respecter*. Les deux sont complementaires : OWL pour modeliser, SHACL pour valider.",,,,,,,,d661bb767dcae801,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,section2-title,markdown,fr,5f48a2c549aa0836,"---
 
 ## 2. Concepts fondamentaux de SHACL
 
@@ -17851,9 +17851,9 @@ SHACL repose sur deux types de formes (*shapes*) :
 | Concept | URI SHACL | Description |
 |---------|-----------|-------------|
 | **NodeShape** | `sh:NodeShape` | Forme qui s'applique a un noeud RDF (une ressource) |
-| **PropertyShape** | `sh:PropertyShape` | Forme qui contraint une propriete specifique |
+| **PropertyShape** | `sh:PropertyShape` | Forme qui contraint une propriete spécifique |
 | **targetClass** | `sh:targetClass` | Cible tous les noeuds d'une classe donnee |
-| **targetNode** | `sh:targetNode` | Cible un noeud specifique par son URI |
+| **targetNode** | `sh:targetNode` | Cible un noeud spécifique par son URI |
 | **property** | `sh:property` | Lie une NodeShape a ses PropertyShapes |
 | **path** | `sh:path` | Designe la propriete RDF a contraindre |
 
@@ -17871,19 +17871,19 @@ ex:PersonShape a sh:NodeShape ;       # Forme pour les personnes
 
 ### Principaux types de contraintes
 
-| Categorie | Contrainte | Propriete SHACL | Exemple |
+| Catégorie | Contrainte | Propriete SHACL | Exemple |
 |-----------|------------|-----------------|---------|  
 | **Cardinalite** | Minimum / Maximum | `sh:minCount`, `sh:maxCount` | `sh:minCount 1` |
 | **Type** | Type de donnee | `sh:datatype` | `sh:datatype xsd:string` |
 | **Classe** | Classe RDF | `sh:class` | `sh:class foaf:Person` |
-| **Chaine** | Longueur minimale | `sh:minLength` | `sh:minLength 2` |
-| **Chaine** | Motif regex | `sh:pattern` | `sh:pattern ""^[A-Z]""` |
-| **Numerique** | Borne inclusive | `sh:minInclusive`, `sh:maxInclusive` | `sh:minInclusive 0` |",,,,,,,,9453bd09e971bac5,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,section3-title,markdown,fr,01b968521e500560,"---
+| **Chaîne** | Longueur minimale | `sh:minLength` | `sh:minLength 2` |
+| **Chaîne** | Motif regex | `sh:pattern` | `sh:pattern ""^[A-Z]""` |
+| **Numérique** | Borne inclusive | `sh:minInclusive`, `sh:maxInclusive` | `sh:minInclusive 0` |",,,,,,,,5f48a2c549aa0836,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,section3-title,markdown,fr,1324fb27f0d830ff,"---
 
 ## 3. Explorer une shape SHACL existante
 
-Le fichier `data/person-shape.ttl` contient une forme SHACL pour valider des instances de `foaf:Person`. Chargeons-le et examinons les contraintes definies.",,,,,,,,01b968521e500560,,,,,,,
+Le fichier `data/person-shape.ttl` contient une forme SHACL pour valider des instances de `foaf:Person`. Chargeons-le et examinons les contraintes définies.",,,,,,,,1324fb27f0d830ff,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,load-shapes,code,fr,8b1dfac3afab1e1a,"from rdflib import Graph, Namespace, URIRef, Literal
 from rdflib.namespace import RDF, RDFS, XSD, FOAF
 
@@ -17933,42 +17933,42 @@ for shape in shapes_graph.subjects(RDF.type, SH.NodeShape):
         for c in constraints:
             print(f""        {c}"")
         print(f""        Message: {msg}"")",,,,,,,,6a46450dea1a72fa,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,interpretation-shapes,markdown,fr,cabd1d3efd37ba21,"### Interpretation : Structure de la forme PersonShape
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,interpretation-shapes,markdown,fr,a9a074da366209b3,"### Interpretation : Structure de la forme PersonShape
 
 La forme `ex:PersonShape` cible toutes les instances de `foaf:Person` et impose 4 contraintes :
 
 | Propriete | Contraintes | Signification |
 |-----------|-------------|---------------|
-| `foaf:name` | minCount=1, maxCount=1, datatype=string, minLength=2 | Exactement un nom, chaine d'au moins 2 caracteres |
+| `foaf:name` | minCount=1, maxCount=1, datatype=string, minLength=2 | Exactement un nom, chaîne d'au moins 2 caractères |
 | `foaf:mbox` | maxCount=1, pattern=`^mailto:.+@.+\\..+$` | Au plus un email, format mailto: valide |
 | `foaf:age` | maxCount=1, datatype=integer, minInclusive=0, maxInclusive=150 | Au plus un age, entier entre 0 et 150 |
 | `foaf:knows` | class=foaf:Person | Les personnes connues doivent etre des foaf:Person |
 
-> **Note** : `foaf:mbox` et `foaf:age` n'ont pas de `minCount`, ils sont donc optionnels. Seul `foaf:name` est obligatoire (minCount=1).",,,,,,,,cabd1d3efd37ba21,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,section4-title,markdown,fr,b3a296c52f106464,"---
+> **Note** : `foaf:mbox` et `foaf:age` n'ont pas de `minCount`, ils sont donc optionnels. Seul `foaf:name` est obligatoire (minCount=1).",,,,,,,,a9a074da366209b3,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,section4-title,markdown,fr,7a953fc9aea02e4e,"---
 
 ## 4. pySHACL : Validation en Python
 
 ### La fonction `validate()`
 
-[pySHACL](https://github.com/RDFLib/pySHACL) est l'implementation Python de reference pour la validation SHACL. Sa fonction principale `validate()` accepte les parametres suivants :
+[pySHACL](https://github.com/RDFLib/pySHACL) est l'implementation Python de reference pour la validation SHACL. Sa fonction principale `validate()` accepte les paramètres suivants :
 
-| Parametre | Type | Description |
+| Paramètre | Type | Description |
 |-----------|------|-------------|
-| `data_graph` | Graph / str | Le graphe de donnees a valider (1er argument positionnel) |
+| `data_graph` | Graph / str | Le graphe de données a valider (1er argument positionnel) |
 | `shacl_graph` | Graph / str | Le graphe de formes SHACL |
 | `inference` | str | Mode d'inference : `'none'`, `'rdfs'`, `'owlrl'`, `'both'` |
-| `abort_on_first` | bool | Arreter a la premiere violation (defaut: False) |
-| `advanced` | bool | Activer SHACL Advanced Features (regles, etc.) |
-| `inplace` | bool | Modifier le graphe de donnees en place (pour les regles) |
+| `abort_on_first` | bool | Arreter a la première violation (defaut: False) |
+| `advanced` | bool | Activer SHACL Advanced Features (règles, etc.) |
+| `inplace` | bool | Modifier le graphe de données en place (pour les règles) |
 
 La fonction retourne un triplet `(conforms, results_graph, results_text)` :
-- `conforms` : booleen, True si toutes les contraintes sont satisfaites
-- `results_graph` : graphe RDF contenant les resultats detailles
-- `results_text` : rapport texte lisible",,,,,,,,b3a296c52f106464,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,load-data-intro,markdown,fr,cc0952347f28bd0c,"### Charger les donnees de test
+- `conforms` : booléen, True si toutes les contraintes sont satisfaites
+- `results_graph` : graphe RDF contenant les résultats detailles
+- `results_text` : rapport texte lisible",,,,,,,,7a953fc9aea02e4e,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,load-data-intro,markdown,fr,d9169121c2856504,"### Charger les données de test
 
-Le fichier `data/person-data.ttl` contient 7 personnes dont **5 presentent des erreurs volontaires**. Chargeons-le et examinons son contenu.",,,,,,,,cc0952347f28bd0c,,,,,,,
+Le fichier `data/person-data.ttl` contient 7 personnes dont **5 presentent des erreurs volontaires**. Chargeons-le et examinons son contenu.",,,,,,,,d9169121c2856504,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,load-data,code,fr,2aefa895009627ac,"# Charger les donnees de test
 data_graph = Graph()
 data_graph.parse(""data/person-data.ttl"", format=""turtle"")
@@ -17993,9 +17993,9 @@ for person in sorted(data_graph.subjects(RDF.type, FOAF.Person), key=str):
     knows_str = str(knows[0]).split('/')[-1] if knows else ""-""
     
     print(f""{str(person).split('/')[-1]:<12s} {name_str:<20s} {age_str:<8s} {mbox_str:<25s} {knows_str:<12s}"")",,,,,,,,2aefa895009627ac,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,validate-intro,markdown,fr,6e1537b24959095c,"### Execution de la validation
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,validate-intro,markdown,fr,bd482eb4eda13332,"### Exécution de la validation
 
-Validons les donnees contre les formes SHACL. L'option `inference='rdfs'` permet a pySHACL de prendre en compte les inferences RDFS (sous-classes, sous-proprietes) lors de la validation.",,,,,,,,6e1537b24959095c,,,,,,,
+Validons les données contre les formes SHACL. L'option `inference='rdfs'` permet a pySHACL de prendre en compte les inferences RDFS (sous-classes, sous-proprietes) lors de la validation.",,,,,,,,bd482eb4eda13332,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,validate-basic,code,fr,cbe9d2e0082ba0f8,"from pyshacl import validate
 
 # Validation SHACL
@@ -18012,9 +18012,9 @@ print(""="" * 60)
 print(""Rapport de validation :"")
 print(""="" * 60)
 print(results_text)",,,,,,,,cbe9d2e0082ba0f8,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,parse-intro,markdown,fr,c91ee61be4c40680,"### Analyse structuree du graphe de resultats
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,parse-intro,markdown,fr,367ff25bd6742ba6,"### Analyse structuree du graphe de résultats
 
-Le rapport texte est utile pour un humain, mais on peut aussi **analyser le graphe de resultats** par programmation. Chaque violation est un noeud de type `sh:ValidationResult` avec des proprietes structurees.",,,,,,,,c91ee61be4c40680,,,,,,,
+Le rapport texte est utile pour un humain, mais on peut aussi **analyser le graphe de résultats** par programmation. Chaque violation est un noeud de type `sh:ValidationResult` avec des proprietes structurees.",,,,,,,,367ff25bd6742ba6,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,parse-results,code,fr,7fb0ec3598c8e180,"# Analyser le graphe de resultats par programmation
 violations = []
 
@@ -18040,7 +18040,7 @@ print(f""{'Noeud':<12} {'Propriete':<10} {'Severite':<12} {'Message'}"")
 print(""-"" * 90)
 for v in sorted(violations, key=lambda x: x[""focus""]):
     print(f""{v['focus']:<12} {v['path']:<10} {v['severity']:<12} {v['message'][:55]}"")",,,,,,,,7fb0ec3598c8e180,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,interpretation-validation,markdown,fr,2aef8087f77b65a1,"### Interpretation : Les 5 erreurs detectees
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,interpretation-validation,markdown,fr,8c32bc582b421e91,"### Interpretation : Les 5 erreurs detectees
 
 Le fichier `person-data.ttl` contenait 5 erreurs volontaires, toutes detectees par pySHACL :
 
@@ -18051,43 +18051,43 @@ Le fichier `person-data.ttl` contenait 5 erreurs volontaires, toutes detectees p
 | **charlie** | `foaf:name` | `minCount` | Pas de nom alors que `minCount=1` est exige |
 | **diana** | `foaf:age` | `minInclusive` | Age negatif (-5) alors que `minInclusive=0` |
 | **eve** | `foaf:mbox` | `pattern` | Email `not-an-email` ne correspond pas au motif `^mailto:` |
-| **frank** | `foaf:name` | `minLength` | Nom ""F"" (1 caractere) trop court, `minLength=2` |
+| **frank** | `foaf:name` | `minLength` | Nom ""F"" (1 caractère) trop court, `minLength=2` |
 | **grace** | `foaf:knows` | `class` | `ex:myDog` est un `ex:Dog`, pas un `foaf:Person` |
 
 **Points cles** :
-1. Alice et Bob passent la validation car leurs donnees sont completes et conformes
+1. Alice et Bob passent la validation car leurs données sont completes et conformes
 2. Bob n'a pas d'email mais c'est conforme : `foaf:mbox` n'a pas de `minCount`
-3. Chaque violation est independante : un meme noeud pourrait cumuler plusieurs violations",,,,,,,,2aef8087f77b65a1,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,section5-title,markdown,fr,af5592d7528532bf,"---
+3. Chaque violation est independante : un même noeud pourrait cumuler plusieurs violations",,,,,,,,8c32bc582b421e91,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,section5-title,markdown,fr,b94bb0b7ce16d738,"---
 
 ## 5. Ecrire des shapes custom en Python
 
-Plutot que de charger des fichiers Turtle, on peut construire des formes SHACL **directement en Python** avec rdflib. Cela permet de creer des validations dynamiques, generees par du code.
+Plutot que de charger des fichiers Turtle, on peut construire des formes SHACL **directement en Python** avec rdflib. Cela permet de créer des validations dynamiques, generees par du code.
 
 ### Catalogue des contraintes
 
-| Categorie | Contrainte | Propriete SHACL | Description |
+| Catégorie | Contrainte | Propriete SHACL | Description |
 |-----------|------------|-----------------|-------------|
 | Cardinalite | Minimum | `sh:minCount` | Nombre minimum de valeurs |
 | Cardinalite | Maximum | `sh:maxCount` | Nombre maximum de valeurs |
 | Type | Type de donnee | `sh:datatype` | Type XSD attendu |
 | Type | Classe RDF | `sh:class` | La valeur doit etre d'une classe donnee |
 | Type | Type de noeud | `sh:nodeKind` | IRI, BlankNode ou Literal |
-| Chaine | Motif regex | `sh:pattern` | Expression reguliere |
-| Chaine | Longueur min | `sh:minLength` | Nombre minimum de caracteres |
-| Chaine | Longueur max | `sh:maxLength` | Nombre maximum de caracteres |
-| Numerique | Borne min | `sh:minInclusive` | Valeur minimale (inclusive) |
-| Numerique | Borne max | `sh:maxInclusive` | Valeur maximale (inclusive) |
+| Chaîne | Motif regex | `sh:pattern` | Expression reguliere |
+| Chaîne | Longueur min | `sh:minLength` | Nombre minimum de caractères |
+| Chaîne | Longueur max | `sh:maxLength` | Nombre maximum de caractères |
+| Numérique | Borne min | `sh:minInclusive` | Valeur minimale (inclusive) |
+| Numérique | Borne max | `sh:maxInclusive` | Valeur maximale (inclusive) |
 | Valeur | Valeur exacte | `sh:hasValue` | Doit contenir cette valeur |
 | Valeur | Liste | `sh:in` | Doit etre dans cette liste |
-| Unicite | Langue unique | `sh:uniqueLang` | Une seule valeur par tag de langue |",,,,,,,,af5592d7528532bf,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,build-shape-intro,markdown,fr,7bb1c53dc1408931,"### Construire une ArticleShape
+| Unicite | Langue unique | `sh:uniqueLang` | Une seule valeur par tag de langue |",,,,,,,,b94bb0b7ce16d738,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,build-shape-intro,markdown,fr,9337cce3aaca3047,"### Construire une ArticleShape
 
 Creons une forme SHACL pour valider des articles (`schema:Article`) avec les contraintes suivantes :
-- Titre obligatoire (string, min 5 caracteres)
+- Titre obligatoire (string, min 5 caractères)
 - Au moins un auteur (doit etre un `schema:Person`)
 - Date de publication optionnelle (format `xsd:date`)
-- Nombre de mots optionnel (entier entre 100 et 50000)",,,,,,,,7bb1c53dc1408931,,,,,,,
+- Nombre de mots optionnel (entier entre 100 et 50000)",,,,,,,,9337cce3aaca3047,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,build-shape,code,fr,d566d13bea82d250,"from rdflib import Graph, Namespace, URIRef, Literal, BNode
 from rdflib.namespace import RDF, XSD, FOAF
 
@@ -18146,9 +18146,9 @@ custom_shapes.add((words_prop, SH.message, Literal(""Le nombre de mots doit etre
 print(""Forme ArticleShape creee avec 4 contraintes de propriete"")
 print()
 print(custom_shapes.serialize(format=""turtle""))",,,,,,,,d566d13bea82d250,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,test-custom-intro,markdown,fr,59ebff16eaad88ed,"### Test de la forme personnalisee
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,test-custom-intro,markdown,fr,761086ebc251d987,"### Test de la forme personnalisee
 
-Creons un jeu de donnees avec des articles valides et invalides pour verifier notre forme ArticleShape.",,,,,,,,59ebff16eaad88ed,,,,,,,
+Creons un jeu de données avec des articles valides et invalides pour verifier notre forme ArticleShape.",,,,,,,,761086ebc251d987,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,test-custom-shape,code,fr,bbd01877cd6a8de3,"# Creer des donnees de test pour ArticleShape
 test_data = Graph()
 test_data.bind(""ex"", EX)
@@ -18191,21 +18191,21 @@ conforms2, results2, text2 = validate(
 print(f""Conforme : {conforms2}"")
 print()
 print(text2)",,,,,,,,bbd01877cd6a8de3,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,interpretation-custom,markdown,fr,9c1a53c5bc5f8855,"### Interpretation : Validation des articles
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,interpretation-custom,markdown,fr,078763b3f919cd73,"### Interpretation : Validation des articles
 
 | Article | Violations | Detail |
 |---------|-----------|--------|
 | **article1** | 0 | Conforme : titre, auteur, date et wordCount respectent toutes les contraintes |
-| **article2** | 1 | Titre ""RDF"" trop court (3 < 5 caracteres requis par minLength) |
+| **article2** | 1 | Titre ""RDF"" trop court (3 < 5 caractères requis par minLength) |
 | **article3** | 2 | Pas de titre (minCount=1) + pas d'auteur (minCount=1) |
 | **article4** | 1 | wordCount=10 < minInclusive=100 |
 
-> **Bonne pratique** : Ajoutez toujours des messages explicites (`sh:message`) pour faciliter le diagnostic. Les messages en francais ou en anglais sont plus utiles que les messages generiques de pySHACL.",,,,,,,,9c1a53c5bc5f8855,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,section6-title,markdown,fr,d6ad26a7cf1975f3,"---
+> **Bonne pratique** : Ajoutez toujours des messages explicites (`sh:message`) pour faciliter le diagnostic. Les messages en francais ou en anglais sont plus utiles que les messages generiques de pySHACL.",,,,,,,,078763b3f919cd73,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,section6-title,markdown,fr,166539382b85d32f,"---
 
 ## 6. Severites SHACL
 
-SHACL definit trois niveaux de severite pour les violations. Par defaut, toutes les contraintes ont la severite `sh:Violation`, mais on peut les ajuster.
+SHACL définit trois niveaux de severite pour les violations. Par defaut, toutes les contraintes ont la severite `sh:Violation`, mais on peut les ajuster.
 
 | Severite | URI | Comportement | Usage typique |
 |----------|-----|-------------|---------------|
@@ -18213,7 +18213,7 @@ SHACL definit trois niveaux de severite pour les violations. Par defaut, toutes 
 | **Warning** | `sh:Warning` | Avertissement non bloquant | Donnee recommandee mais optionnelle |
 | **Info** | `sh:Info` | Information, suggestion | Bonne pratique non imposee |
 
-Le booleen `conforms` retourne `False` **uniquement** pour les `sh:Violation`. Les warnings et infos n'affectent pas la conformite.",,,,,,,,d6ad26a7cf1975f3,,,,,,,
+Le booléen `conforms` retourne `False` **uniquement** pour les `sh:Violation`. Les warnings et infos n'affectent pas la conformite.",,,,,,,,166539382b85d32f,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,severity-demo,code,fr,f9436d19269308c0,"# Demonstrer les 3 niveaux de severite
 severity_shapes_ttl = """"""
 @prefix sh: <http://www.w3.org/ns/shacl#> .
@@ -18272,9 +18272,9 @@ for result in results_sev.subjects(RDF.type, SH.ValidationResult):
     sev_str = str(severity[0]).split(""#"")[-1] if severity else ""?""
     msg_str = str(message[0]) if message else ""-""
     print(f""  [{sev_str:<10s}] {msg_str}"")",,,,,,,,f9436d19269308c0,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,interpretation-severity,markdown,fr,f09de6e315343916,"### Interpretation : Impact de la severite
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,interpretation-severity,markdown,fr,10d20b03d6bc1b18,"### Interpretation : Impact de la severite
 
-Bien que les 3 contraintes soient violees, le booleen `conforms` ne depend que de `sh:Violation` :
+Bien que les 3 contraintes soient violees, le booléen `conforms` ne depend que de `sh:Violation` :
 
 | Severite | Contrainte violee | Impact sur `conforms` |
 |----------|-------------------|----------------------|
@@ -18282,21 +18282,21 @@ Bien que les 3 contraintes soient violees, le booleen `conforms` ne depend que d
 | `sh:Warning` | Pas d'email | Pas d'impact (avertissement seulement) |
 | `sh:Info` | Pas de telephone | Pas d'impact (information seulement) |
 
-> **Bonne pratique** : Utilisez `sh:Warning` pour les proprietes recommandees (best practices) et `sh:Info` pour les suggestions. Reservez `sh:Violation` aux exigences absolues.",,,,,,,,f09de6e315343916,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,section7-title,markdown,fr,ac4452472a57c89d,"---
+> **Bonne pratique** : Utilisez `sh:Warning` pour les proprietes recommandees (best practices) et `sh:Info` pour les suggestions. Reservez `sh:Violation` aux exigences absolues.",,,,,,,,10d20b03d6bc1b18,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,section7-title,markdown,fr,c43e34d8660ac6e1,"---
 
-## 7. Contraintes avancees : operateurs logiques
+## 7. Contraintes avancees : opérateurs logiques
 
-SHACL permet de combiner des contraintes avec des operateurs logiques :
+SHACL permet de combiner des contraintes avec des opérateurs logiques :
 
-| Operateur | Propriete SHACL | Semantique |
+| Opérateur | Propriete SHACL | Sémantique |
 |-----------|-----------------|------------|
 | **OU** | `sh:or` | Au moins une des sous-formes doit etre satisfaite |
 | **ET** | `sh:and` | Toutes les sous-formes doivent etre satisfaites |
 | **NON** | `sh:not` | La sous-forme ne doit PAS etre satisfaite |
 | **OU exclusif** | `sh:xone` | Exactement une sous-forme satisfaite |
 
-### Exemple : un Contact doit avoir un email OU un telephone",,,,,,,,ac4452472a57c89d,,,,,,,
+### Exemple : un Contact doit avoir un email OU un telephone",,,,,,,,c43e34d8660ac6e1,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,advanced-constraints,code,fr,b2326e5e5e6782c2,"from rdflib.collection import Collection
 
 # Forme avancee avec sh:or
@@ -18334,9 +18334,9 @@ adv_shapes.add((contact_shape, SH.message, Literal(""Un contact doit avoir un em
 print(""Forme ContactShape avec sh:or creee"")
 print()
 print(adv_shapes.serialize(format=""turtle""))",,,,,,,,b2326e5e5e6782c2,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,u46pihij9l,markdown,fr,5fe86bb9b2c19a1e,"### Test des contraintes avancees
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,u46pihij9l,markdown,fr,09b5675c172fbc84,"### Test des contraintes avancees
 
-Creons des contacts qui testent differents scenarios : avec email seul, telephone seul, les deux, ou aucun.",,,,,,,,5fe86bb9b2c19a1e,,,,,,,
+Creons des contacts qui testent différents scénarios : avec email seul, telephone seul, les deux, ou aucun.",,,,,,,,09b5675c172fbc84,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,test-advanced,code,fr,ff1564aa431e3113,"# Donnees de test pour les contraintes avancees
 contact_data = Graph()
 contact_data.bind(""ex"", EX)
@@ -18373,16 +18373,16 @@ conforms3, results3, text3 = validate(
 print(f""Conforme : {conforms3}"")
 print()
 print(text3)",,,,,,,,ff1564aa431e3113,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,interpretation-advanced,markdown,fr,0209bcde5184a592,"### Interpretation : Contraintes logiques
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,interpretation-advanced,markdown,fr,645f627384525391,"### Interpretation : Contraintes logiques
 
-| Contact | Email | Telephone | Resultat | Raison |
+| Contact | Email | Telephone | Résultat | Raison |
 |---------|-------|-----------|----------|--------|
 | contact1 | Oui | Non | Conforme | `sh:or` satisfait par email |
 | contact2 | Non | Oui | Conforme | `sh:or` satisfait par telephone |
 | contact3 | Non | Non | Violation | `sh:or` non satisfait (aucune branche valide) |
 | contact4 | Oui | Oui | Conforme | `sh:or` satisfait par les deux (OU inclusif) |
 
-> **Point cle** : `sh:or` est un OU inclusif : avoir les deux options satisfaites est aussi valide. Pour exiger exactement une option, utilisez `sh:xone`.",,,,,,,,0209bcde5184a592,,,,,,,
+> **Point cle** : `sh:or` est un OU inclusif : avoir les deux options satisfaites est aussi valide. Pour exiger exactement une option, utilisez `sh:xone`.",,,,,,,,645f627384525391,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,exercises-title,markdown,fr,3cdb7175b74d8f64,"---
 
 ## 8. Exemples et Exercices",,,,,,,,3cdb7175b74d8f64,,,,,,,
@@ -18435,15 +18435,15 @@ if not conforms_fix:
     print(text_fix)
 else:
     print(""Toutes les personnes sont maintenant conformes."")",,,,,,,,5df98d0a28dab4e8,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,exercise2-title,markdown,fr,fe6ed824cfe8a0be,"### Exemple guide 2 : Forme SHACL pour un Livre
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,exercise2-title,markdown,fr,9481a9efd5d5889a,"### Exemple guide 2 : Forme SHACL pour un Livre
 
 Construction d'une forme SHACL `ex:BookShape` pour valider des instances de `schema:Book` avec les contraintes suivantes :
-- **Titre** (`schema:name`) : obligatoire, chaine, min 1 caractere
+- **Titre** (`schema:name`) : obligatoire, chaîne, min 1 caractère
 - **ISBN** (`schema:isbn`) : optionnel, doit respecter le motif EAN-13 `^97[89]-\d-\d{4}-\d{4}-\d$`
 - **Annee** (`schema:datePublished`) : optionnel, entier entre 1450 (Gutenberg) et 2030
 - **Auteur** (`schema:author`) : au moins un, doit etre un `schema:Person`
 
-Puis creation de 4 livres (2 valides, 2 invalides) et validation.",,,,,,,,fe6ed824cfe8a0be,,,,,,,
+Puis creation de 4 livres (2 valides, 2 invalides) et validation.",,,,,,,,9481a9efd5d5889a,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,exercise2,code,fr,f48edd602a780f27,"# Exemple guide 2 : Construction de la forme BookShape
 
 book_shapes = Graph()
@@ -18526,18 +18526,18 @@ conforms_book, _, text_book = validate(
 
 print(conforms_book)
 print(text_book)",,,,,,,,f48edd602a780f27,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,exercise3-title,markdown,fr,c12e17413ff3ad37,"### Exemple guide 3 : Contraintes avec severites multiples
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,exercise3-title,markdown,fr,0cbfe06599452ff6,"### Exemple guide 3 : Contraintes avec severites multiples
 
 Creation d'une forme SHACL `ex:StudentShape` pour valider des etudiants (`ex:Student`) avec les contraintes suivantes et les severites indiquees :
 
 | Propriete | Contrainte | Severite |
 |-----------|-----------|----------|
-| `foaf:name` | Obligatoire, chaine | `sh:Violation` |
+| `foaf:name` | Obligatoire, chaîne | `sh:Violation` |
 | `ex:studentId` | Obligatoire, motif `^[A-Z]{2}\d{6}$` | `sh:Violation` |
 | `foaf:mbox` | Recommande (minCount 1) | `sh:Warning` |
 | `ex:phone` | Souhaitable (minCount 1) | `sh:Info` |
 
-Test avec 3 etudiants : un complet, un sans email/telephone, un sans nom.",,,,,,,,c12e17413ff3ad37,,,,,,,
+Test avec 3 etudiants : un complet, un sans email/telephone, un sans nom.",,,,,,,,0cbfe06599452ff6,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,exercise3,code,fr,b65285863e67e02e,"# Exemple guide 3 : StudentShape avec severites multiples
 
 student_shapes_ttl = """"""
@@ -18604,13 +18604,13 @@ conforms, results_graph, results_text = validate(
 print(""Conforme :"", conforms)
 print()
 print(results_text)",,,,,,,,b65285863e67e02e,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,exemples-guides-sosolalt,markdown,fr,0043ad0d584f5011,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,exemples-guides-sosolalt,markdown,fr,929c7b30cd81bee1,"---
 
 ## Exemples guides (solutions proposees par @Sosolalt)
 
 *Les exemples ci-dessous ont ete resolus par @Sosolalt (EPITA-IS, promo 2028).*
-*Ils servent de modele pour comprendre les concepts abordes dans ce notebook.*
-",,,,,,,,0043ad0d584f5011,,,,,,,
+*Ils servent de modèle pour comprendre les concepts abordes dans ce notebook.*
+",,,,,,,,929c7b30cd81bee1,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,exemple-db0e4133,markdown,fr,0526cb6a195682ea,"### Exemple guide 4 : MovieShape - Valider et corriger un graphe de films
 
 *Solution proposee par @Sosolalt (EPITA-IS, promo 2028).*",,,,,,,,0526cb6a195682ea,,,,,,,
@@ -18699,9 +18699,9 @@ print(f""Conforme : {conforms_movie}"")
 print()
 print(text_movie)
 ",,,,,,,,8acaf98e9be80a98,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,exemple-3945a5f8,markdown,fr,c0e601023d921fb9,"### Exemple guide 5 : EventShape - Forme SHACL pour un Evenement
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,exemple-3945a5f8,markdown,fr,ad6d646f486b0531,"### Exemple guide 5 : EventShape - Forme SHACL pour un Événement
 
-*Solution proposee par @Sosolalt (EPITA-IS, promo 2028).*",,,,,,,,c0e601023d921fb9,,,,,,,
+*Solution proposee par @Sosolalt (EPITA-IS, promo 2028).*",,,,,,,,ad6d646f486b0531,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,exemple-code-3945a5f8,code,fr,0c1dfdd1ec50ba9a,"# Exercice 2 : Construction de EventShape
 
 # Graphe de formes
@@ -18982,9 +18982,9 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,exercices-a-com
 
 *Ces exercices sont a realiser par l'etudiant. Les stubs utilisent des marqueurs TODO.*
 ",,,,,,,,af194a7995ed8589,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,870ab3c7,markdown,fr,8566e9c8668eff68,"### Exercice 1 : Valider et corriger un graphe de films
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,870ab3c7,markdown,fr,b870b477c44a3236,"### Exercice 1 : Valider et corriger un graphe de films
 
-Le fichier `data/movie-data.ttl` (a creer) contient des instances de `schema:Movie` avec des erreurs. Definissez une forme `ex:MovieShape` (titre obligatoire, annee entre 1900 et 2030, au moins un acteur de type `schema:Person`), puis creez un graphe de donnees avec 2 films valides et 3 films invalides. Validez et corrigez les erreurs.",,,,,,,,8566e9c8668eff68,,,,,,,
+Le fichier `data/movie-data.ttl` (a créer) contient des instances de `schema:Movie` avec des erreurs. Definissez une forme `ex:MovieShape` (titre obligatoire, annee entre 1900 et 2030, au moins un acteur de type `schema:Person`), puis créez un graphe de données avec 2 films valides et 3 films invalides. Validez et corrigez les erreurs.",,,,,,,,b870b477c44a3236,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,db0e4133,code,fr,191029eb6262c3db,"# Exercice 1 : Definir MovieShape et valider des donnees de films
 
 # TODO etudiant : creez le graphe de formes MovieShape
@@ -18997,15 +18997,15 @@ movie_data = Graph()
 
 # TODO etudiant : validez et affichez les resultats
 print(""Exercice a completer"")",,,,,,,,191029eb6262c3db,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,c01b5a52,markdown,fr,5dad8995974b2fca,"### Exercice 2 : Forme SHACL pour un Evenement
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,c01b5a52,markdown,fr,12007f4c338e3e33,"### Exercice 2 : Forme SHACL pour un Événement
 
-Creez une forme SHACL `ex:EventShape` pour valider des evenements (`schema:Event`) avec :
-- **Nom** (`schema:name`) : obligatoire, chaine, min 3 caracteres
+Créez une forme SHACL `ex:EventShape` pour valider des événements (`schema:Event`) avec :
+- **Nom** (`schema:name`) : obligatoire, chaîne, min 3 caractères
 - **Date de debut** (`schema:startDate`) : obligatoire, format `xsd:date`
 - **Lieu** (`schema:location`) : obligatoire, doit etre un `schema:Place`
 - **Nombre max de participants** (`schema:maximumAttendeeCapacity`) : optionnel, entier entre 1 et 100000
 
-Creez 3 evenements de test (1 valide, 2 invalides) et validez.",,,,,,,,5dad8995974b2fca,,,,,,,
+Créez 3 événements de test (1 valide, 2 invalides) et validez.",,,,,,,,12007f4c338e3e33,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,3945a5f8,code,fr,009c4d57141260be,"# Exercice 2 : Construction de EventShape
 
 # TODO etudiant : creez le graphe de formes
@@ -19017,18 +19017,18 @@ event_data = Graph()
 
 # TODO etudiant : validez et affichez les resultats
 print(""Exercice a completer"")",,,,,,,,009c4d57141260be,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,b3a14cf5,markdown,fr,3f7f743c6c3c68c6,"### Exercice 3 : Produit avec severites et contrainte logique
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,b3a14cf5,markdown,fr,65da04068c05d81e,"### Exercice 3 : Produit avec severites et contrainte logique
 
-Creez une forme `ex:ProductShape` pour valider des produits (`ex:Product`) avec :
+Créez une forme `ex:ProductShape` pour valider des produits (`ex:Product`) avec :
 
 | Propriete | Contrainte | Severite |
 |-----------|-----------|----------|
-| `schema:name` | Obligatoire, chaine, min 2 caracteres | `sh:Violation` |
+| `schema:name` | Obligatoire, chaîne, min 2 caractères | `sh:Violation` |
 | `schema:price` | Obligatoire, entre 0 et 100000 | `sh:Violation` |
 | `schema:category` | Obligatoire | `sh:Warning` |
 | `schema:description` | Recommande (minLength 10) | `sh:Info` |
 
-Ajoutez aussi une contrainte `sh:or` : le produit doit avoir soit un `schema:brand` soit un `schema:manufacturer`.",,,,,,,,3f7f743c6c3c68c6,,,,,,,
+Ajoutez aussi une contrainte `sh:or` : le produit doit avoir soit un `schema:brand` soit un `schema:manufacturer`.",,,,,,,,65da04068c05d81e,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,04a5a1a0,code,fr,ad659bd887ae5016,"# Exercice 3 : ProductShape avec severites et sh:or
 
 # TODO etudiant : creez la forme en Turtle ou par programmation
@@ -19043,16 +19043,16 @@ product_shapes_ttl = """"""
 
 # TODO etudiant : parsez, creez des donnees de test, et validez
 print(""Exercice a completer"")",,,,,,,,ad659bd887ae5016,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,41ebdc43,markdown,fr,7e5ab611a251c13f,"### Exercice 4 : Valider un dataset bibliothecaire avec SHACL
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,41ebdc43,markdown,fr,8d063b4b3bad2517,"### Exercice 4 : Valider un dataset bibliothecaire avec SHACL
 
-Creez une forme SHACL `ex:BibliographicRecordShape` qui valide des notices bibliographiques. Chaque notice doit avoir :
+Créez une forme SHACL `ex:BibliographicRecordShape` qui valide des notices bibliographiques. Chaque notice doit avoir :
 - `dc:title` (exactement 1, type string)
 - `dc:creator` (au moins 1)
 - `dc:date` (pattern YYYY-MM-DD)
 - `dc:type` parmi {""Book"", ""Article"", ""Thesis""}
 - `dc:language` (facultatif, default ""fr"")
 
-Creez ensuite 3 notices de test (2 valides, 1 invalide) et verifiez la conformite.",,,,,,,,7e5ab611a251c13f,,,,,,,
+Créez ensuite 3 notices de test (2 valides, 1 invalide) et verifiez la conformite.",,,,,,,,8d063b4b3bad2517,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,042a82e3,code,fr,98d759a496c11c68,"print(""Exercice a completer"")
 # Exercice final : Valider un dataset bibliotheque avec SHACL
 from rdflib import Graph, Namespace, Literal
@@ -19060,7 +19060,7 @@ from rdflib.namespace import DC, RDF, XSD
 from pyshacl import validate
 
 # TODO etudiant : Creez la forme SHACL et les donnees de test",,,,,,,,98d759a496c11c68,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,summary-title,markdown,fr,7ac1bbdd11f029ad,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,summary-title,markdown,fr,4055beb2f63a2d87,"---
 
 ## Resume
 
@@ -19068,14 +19068,14 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,summary-title,m
 
 | Concept | Ce que nous avons appris |
 |---------|-------------------------|
-| **SHACL** | Recommandation W3C pour la validation de donnees RDF (monde ferme) |
+| **SHACL** | Recommandation W3C pour la validation de données RDF (monde ferme) |
 | **NodeShape** | Forme qui cible des noeuds RDF (par classe ou par URI) |
-| **PropertyShape** | Contrainte sur une propriete specifique (cardinalite, type, motif, etc.) |
+| **PropertyShape** | Contrainte sur une propriete spécifique (cardinalite, type, motif, etc.) |
 | **pySHACL** | `validate(data_graph, shacl_graph=..., inference=..., abort_on_first=...)` |
 | **Rapport** | Triplet `(conforms, results_graph, results_text)` |
 | **Severites** | `sh:Violation` (bloquant), `sh:Warning` (avertissement), `sh:Info` (suggestion) |
-| **Operateurs logiques** | `sh:or`, `sh:and`, `sh:not`, `sh:xone` |
-| **Construction** | Shapes creees par programmation avec rdflib (BNode, add) |
+| **Opérateurs logiques** | `sh:or`, `sh:and`, `sh:not`, `sh:xone` |
+| **Construction** | Shapes créées par programmation avec rdflib (BNode, add) |
 
 ### Section 8 : Exemples et Exercices
 
@@ -19084,41 +19084,41 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,summary-title,m
 | **Exemple guide 1** | Corriger les erreurs de `person-data.ttl` | Correction des 5 violations par programmation |
 | **Exemple guide 2** | Forme SHACL pour un Livre | BookShape avec titre, ISBN, annee, auteur |
 | **Exemple guide 3** | Contraintes avec severites multiples | StudentShape avec Violation/Warning/Info |
-| **Exercice 1** | Valider et corriger un graphe de films | MovieShape + donnees a creer |
-| **Exercice 2** | Forme SHACL pour un Evenement | EventShape avec contraintes |
+| **Exercice 1** | Valider et corriger un graphe de films | MovieShape + données a créer |
+| **Exercice 2** | Forme SHACL pour un Événement | EventShape avec contraintes |
 | **Exercice 3** | Produit avec severites et contrainte logique | ProductShape + sh:or |
 | **Exercice 4** | Valider un dataset bibliothecaire | BibliographicRecordShape |
 
 ### Contraintes SHACL -- Reference rapide
 
-| Categorie | Propriete SHACL | Exemple |
+| Catégorie | Propriete SHACL | Exemple |
 |-----------|-----------------|---------|  
 | Cardinalite | `sh:minCount`, `sh:maxCount` | `sh:minCount 1` |
 | Type | `sh:datatype`, `sh:class`, `sh:nodeKind` | `sh:datatype xsd:string` |
-| Chaine | `sh:pattern`, `sh:minLength`, `sh:maxLength` | `sh:pattern ""^[A-Z]""` |
-| Numerique | `sh:minInclusive`, `sh:maxInclusive` | `sh:minInclusive 0` |
+| Chaîne | `sh:pattern`, `sh:minLength`, `sh:maxLength` | `sh:pattern ""^[A-Z]""` |
+| Numérique | `sh:minInclusive`, `sh:maxInclusive` | `sh:minInclusive 0` |
 | Valeur | `sh:hasValue`, `sh:in` | `sh:in (""FR"" ""DE"")` |
-| Logique | `sh:or`, `sh:and`, `sh:not`, `sh:xone` | Liste de sous-formes |",,,,,,,,7ac1bbdd11f029ad,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,resources,markdown,fr,728ee6004b0bdcc7,"### Ressources supplementaires
+| Logique | `sh:or`, `sh:and`, `sh:not`, `sh:xone` | Liste de sous-formes |",,,,,,,,4055beb2f63a2d87,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,resources,markdown,fr,6f9886154d0810ef,"### Ressources supplementaires
 
 - [W3C SHACL Specification](https://www.w3.org/TR/shacl/) -- Standard complet
-- [SHACL Advanced Features](https://www.w3.org/TR/shacl-af/) -- Regles et fonctions
+- [SHACL Advanced Features](https://www.w3.org/TR/shacl-af/) -- Règles et fonctions
 - [pySHACL Documentation](https://github.com/RDFLib/pySHACL) -- Bibliotheque Python
 - [SHACL Playground](https://shacl-playground.zazuko.com/) -- Testez vos formes en ligne
 
 ---
 
-**Navigation** : [<< 7b-OWL](SW-7b-Python-OWL.ipynb) | [Index](README.md) | [9-JSONLD >>](SW-9-Python-JSONLD.ipynb)",,,,,,,,728ee6004b0bdcc7,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,5f44e07c,markdown,fr,ea9681d083257221,"## Conclusion
+**Navigation** : [<< 7b-OWL](SW-7b-Python-OWL.ipynb) | [Index](README.md) | [9-JSONLD >>](SW-9-Python-JSONLD.ipynb)",,,,,,,,6f9886154d0810ef,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb,5f44e07c,markdown,fr,8732b44907295ca1,"## Conclusion
 
 Ce notebook a permis d'explorer les aspects essentiels de sw 8 python shacl. Les points cles :
 
 - Les concepts fondamentaux ont ete presentes et illustres
 - Les Exercices proposent une mise en pratique progressive
-- Les resultats obtenus permettent de valider la comprehension
+- Les résultats obtenus permettent de valider la comprehension
 
-**Pour aller plus loin** : approfondir les aspects avances du sujet et explorer les liens avec d'autres domaines.",,,,,,,,ea9681d083257221,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-CSharp-JSONLD.ipynb,cb0fea89-87c9-42df-880c-4143c0b3e9b2,markdown,fr,6b1f5cb1a1335f8d,"# SW-9-CSharp-JSONLD — JSON-LD avec dotNetRDF (twin C#)
+**Pour aller plus loin** : approfondir les aspects avances du sujet et explorer les liens avec d'autres domaines.",,,,,,,,8732b44907295ca1,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-CSharp-JSONLD.ipynb,cb0fea89-87c9-42df-880c-4143c0b3e9b2,markdown,fr,c33b0ad8e310034c,"# SW-9-CSharp-JSONLD — JSON-LD avec dotNetRDF (twin C#)
 
 Ce notebook est le **jumeau C# (.NET Interactive)** du notebook Python `SW-9-Python-JSONLD.ipynb`. Il explore **JSON-LD** (JavaScript Object Notation for Linked Data, W3C Recommendation 2014/2020) via **dotNetRDF** (`VDS.RDF.*`), le moteur .NET de reference — equivalent de `rdflib` + `pyld` cote Python.
 
@@ -19132,11 +19132,11 @@ Ce notebook est le **jumeau C# (.NET Interactive)** du notebook Python `SW-9-Pyt
 
 ## Pourquoi un twin C# ?
 
-Le notebook Python original s'appuie sur **`rdflib`** + **`jsonld`** (`pyld`). Ce twin C# invoque le **vrai moteur dotNetRDF** (`VDS.RDF.Parsing.JsonLdParser`, `VDS.RDF.Writing.JsonLdWriter`) — pas de workaround. Subtilite API : JSON-LD etant un format de **dataset** (graphe nomme, mot-cle `@graph`), le parser/writer dotNetRDF opere sur un `TripleStore` (collection de graphes), pas un `Graph` unique comme les autres serialisations RDF. Value-add (EPIC #4956 Prong B) : les deux twins sont des compagnons cross-langage sur le **meme standard W3C JSON-LD 1.1**.
+Le notebook Python original s'appuie sur **`rdflib`** + **`jsonld`** (`pyld`). Ce twin C# invoque le **vrai moteur dotNetRDF** (`VDS.RDF.Parsing.JsonLdParser`, `VDS.RDF.Writing.JsonLdWriter`) — pas de workaround. Subtilite API : JSON-LD etant un format de **dataset** (graphe nomme, mot-cle `@graph`), le parser/writer dotNetRDF opere sur un `TripleStore` (collection de graphes), pas un `Graph` unique comme les autres serialisations RDF. Value-add (EPIC #4956 Prong B) : les deux twins sont des compagnons cross-langage sur le **même standard W3C JSON-LD 1.1**.
 
 ## Prerequis
 .NET 9.0+ (kernel `csharp`). dotNetRDF 3.x (restaure via la directive nuget).
-",,,,,,,,6b1f5cb1a1335f8d,,,,,,,
+",,,,,,,,c33b0ad8e310034c,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-CSharp-JSONLD.ipynb,1c2bacfd-ef33-4b3b-8734-1adfc6c1f289,markdown,fr,157c90511c995674,"## Setup — chargement de dotNetRDF
 ",,,,,,,,157c90511c995674,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-CSharp-JSONLD.ipynb,31076692-b982-48cc-a2ae-9858ac01b4ba,code,fr,4d0c5f632a878aee,"// dotNetRDF 3.x : meta-package incluant JsonLdParser / JsonLdWriter
@@ -19159,10 +19159,10 @@ static void Show(string label, object o) => Show($""{label}: {o}"");
 
 Show(""dotNetRDF"", ""3.4.1 charge — JsonLdParser (IStoreReader) / JsonLdWriter (IStoreWriter) disponibles."");
 ",,,,,,,,4d0c5f632a878aee,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-CSharp-JSONLD.ipynb,e1de39cc-ed72-40e4-97c9-54fa3b8ea25f,markdown,fr,bd2260898e3d799b,"## Helpers de conversion RDF <-> JSON-LD
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-CSharp-JSONLD.ipynb,e1de39cc-ed72-40e4-97c9-54fa3b8ea25f,markdown,fr,75a81e08af396db4,"## Helpers de conversion RDF <-> JSON-LD
 
-On definit ici trois fonctions utilitaires qui encapsulent la subtilite API : JSON-LD se charge dans un `TripleStore` (dataset), pas un `Graph` unique. On extrait ensuite le graphe par defaut pour l'interroger comme un graphe RDF classique.
-",,,,,,,,bd2260898e3d799b,,,,,,,
+On définit ici trois fonctions utilitaires qui encapsulent la subtilite API : JSON-LD se charge dans un `TripleStore` (dataset), pas un `Graph` unique. On extrait ensuite le graphe par defaut pour l'interroger comme un graphe RDF classique.
+",,,,,,,,75a81e08af396db4,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-CSharp-JSONLD.ipynb,b78b10fc-015f-499d-abd6-5579daee1b43,code,fr,991d20604a68936d,"// --- Helpers : JSON-LD <-> TripleStore <-> Graph + Turtle ---
 // Parse JSON-LD -> TripleStore -> on renvoie le graphe par defaut (dataset a un seul graphe)
 static IGraph LoadJsonLd(string json)
@@ -19260,12 +19260,12 @@ g2.Assert(new Triple(alice2, knowsP, bob2));
 Show(""Graphe -> JSON-LD (forme etendue)"", SerializeToJsonLd(g2));
 Show(""Graphe -> Turtle (comparaison)"", SerializeToTurtle(g2));
 ",,,,,,,,5e9e0eeb76719b9e,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-CSharp-JSONLD.ipynb,e1dc3060-3cd5-40de-a4a1-ffb1e2bc58ba,markdown,fr,acd7ecc096313b03,"## Partie 4 — Explorer le vocabulaire Schema.org
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-CSharp-JSONLD.ipynb,e1dc3060-3cd5-40de-a4a1-ffb1e2bc58ba,markdown,fr,cb0fef47ee5384c7,"## Partie 4 — Explorer le vocabulaire Schema.org
 
-**Schema.org** est un vocabulaire collaboratif (Google, Microsoft, Yahoo, Yandex) pour decrire les choses du web : `Person`, `Product`, `Event`, `Place`, `Organization`... JSON-LD est le format recommande pour embarquer ces donnees structurees dans les pages HTML (SEO, rich snippets, knowledge graph).
+**Schema.org** est un vocabulaire collaboratif (Google, Microsoft, Yahoo, Yandex) pour decrire les choses du web : `Person`, `Product`, `Event`, `Place`, `Organization`... JSON-LD est le format recommande pour embarquer ces données structurees dans les pages HTML (SEO, rich snippets, knowledge graph).
 
 On construit un document Schema.org `Product` (avec une offre imbriquee et une note agregee) et on le valide en le parsant.
-",,,,,,,,acd7ecc096313b03,,,,,,,
+",,,,,,,,cb0fef47ee5384c7,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-CSharp-JSONLD.ipynb,6b1d935a-b6ae-4777-a291-dab029da1f3e,code,fr,ba15c5225120185e,"// --- Document Schema.org Product en JSON-LD ---
 var product = new JObject
 {
@@ -19304,10 +19304,10 @@ Show(""Types Schema.org rencontres"", string.Join("", "", types));
 var priceTriples = g3.GetTriplesWithPredicate(g3.CreateUriNode(new Uri(""http://schema.org/price"")));
 Show(""Offre (price)"", string.Join("", "", priceTriples.Select(t => t.Object.ToString())));
 ",,,,,,,,ba15c5225120185e,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-CSharp-JSONLD.ipynb,f95b7069-4c97-4631-9ec4-86cd2743e70e,markdown,fr,4bc8c32b286162c3,"## Partie 5 — `@graph` : regrouper plusieurs ressources
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-CSharp-JSONLD.ipynb,f95b7069-4c97-4631-9ec4-86cd2743e70e,markdown,fr,58b681457b0dba36,"## Partie 5 — `@graph` : regrouper plusieurs ressources
 
-Le mot-cle `@graph` permet de regrouper plusieurs ressources sous un meme `@context`, sans que le nœud racine ne soit lui-meme une ressource nommee. C'est la forme naturelle pour les datasets (plusieurs sujets decrits ensemble).
-",,,,,,,,4bc8c32b286162c3,,,,,,,
+Le mot-cle `@graph` permet de regrouper plusieurs ressources sous un même `@context`, sans que le nœud racine ne soit lui-même une ressource nommee. C'est la forme naturelle pour les datasets (plusieurs sujets decrits ensemble).
+",,,,,,,,58b681457b0dba36,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-CSharp-JSONLD.ipynb,ec1a5735-a6ff-4e8b-b18b-474cf23b984e,code,fr,a7cf316e10177b9a,"// --- @graph : dataset de plusieurs ressources ---
 var dataset = new JObject
 {
@@ -19329,10 +19329,10 @@ var knowsPred = g4.GetUriNode(new Uri(""http://schema.org/knows""));
 var knowsTriples = g4.GetTriplesWithSubjectPredicate(aliceNode, knowsPred);
 Show(""Alice knows"", string.Join("", "", knowsTriples.Select(t => t.Object.ToString())));
 ",,,,,,,,a7cf316e10177b9a,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-CSharp-JSONLD.ipynb,ee72c805-ca45-40ed-aeb8-cb8ad69519dd,markdown,fr,1d095c9c9e0007e3,"## Partie 6 — Round-trip JSON-LD <-> Turtle
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-CSharp-JSONLD.ipynb,ee72c805-ca45-40ed-aeb8-cb8ad69519dd,markdown,fr,9761d2d044f96b28,"## Partie 6 — Round-trip JSON-LD <-> Turtle
 
-Un test classique de conformite : parser du JSON-LD, serialiser en Turtle, re-parser, et verifier qu'on retrouve le meme graphe (round-trip). On verifie l'isomorphisme par egalite de l'ensemble des triplets (sujet, predicat, objet).
-",,,,,,,,1d095c9c9e0007e3,,,,,,,
+Un test classique de conformite : parser du JSON-LD, serialiser en Turtle, re-parser, et verifier qu'on retrouve le même graphe (round-trip). On verifie l'isomorphisme par egalite de l'ensemble des triplets (sujet, predicat, objet).
+",,,,,,,,9761d2d044f96b28,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-CSharp-JSONLD.ipynb,87472c21-847a-443f-b80d-c97698c1e592,code,fr,667e724eae66ed96,"// --- Round-trip JSON-LD -> Turtle -> JSON-LD ---
 var original = new JObject
 {
@@ -19362,21 +19362,21 @@ Show(""Round-trip JSON-LD -> Turtle coherent ?"", same ? ""OUI (isomorphe)"" : "
 // Re-serialisation JSON-LD pour fermer la boucle
 Show(""Re-serialisation JSON-LD (forme etendue)"", SerializeToJsonLd(g5b));
 ",,,,,,,,667e724eae66ed96,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-CSharp-JSONLD.ipynb,b3d47a4a-470f-4a4b-b04f-a3d28b0e810e,markdown,fr,790a7573fd365488,"## Conclusion
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-CSharp-JSONLD.ipynb,b3d47a4a-470f-4a4b-b04f-a3d28b0e810e,markdown,fr,b19015bdc325ce7f,"## Conclusion
 
 Ce twin C# a couvert les 6 piliers de JSON-LD avec dotNetRDF :
 
 1. **`@context`** : dictionnaire terme -> IRI (Partie 1).
 2. **Parsing JSON-LD -> graphe RDF** via `JsonLdParser` (Partie 2).
 3. **Serialisation graphe -> JSON-LD** via `JsonLdWriter` (Partie 3).
-4. **Schema.org** : vocabulaire de donnees structurees (Partie 4).
+4. **Schema.org** : vocabulaire de données structurees (Partie 4).
 5. **`@graph`** : regroupement de ressources (Partie 5).
 6. **Round-trip** JSON-LD <-> Turtle + isomorphisme (Partie 6).
 
-Le notebook Python original utilise `rdflib` + `pyld` ; ce twin C# utilise **dotNetRDF** (`VDS.RDF.*`). Les deux sont des moteurs W3C complets. Value-add (EPIC #4956 Prong B) : comparaison cross-langage des API sur le meme standard JSON-LD 1.1. Subtilite API notee : `JsonLdParser`/`JsonLdWriter` operent sur `TripleStore` (dataset), refletant que JSON-LD est nativement un format multi-graphes (mot-cle `@graph`).
+Le notebook Python original utilise `rdflib` + `pyld` ; ce twin C# utilise **dotNetRDF** (`VDS.RDF.*`). Les deux sont des moteurs W3C complets. Value-add (EPIC #4956 Prong B) : comparaison cross-langage des API sur le même standard JSON-LD 1.1. Subtilite API notee : `JsonLdParser`/`JsonLdWriter` operent sur `TripleStore` (dataset), refletant que JSON-LD est nativement un format multi-graphes (mot-cle `@graph`).
 
 ## Exercices
-",,,,,,,,790a7573fd365488,,,,,,,
+",,,,,,,,b19015bdc325ce7f,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-CSharp-JSONLD.ipynb,bcf67b26-a4c1-45a9-81ec-9fcf45dd1082,code,fr,aefa962f629b8830,"// Exercice 1 : Compaction avec un contexte personnalise
 // TODO etudiant : ecrivez un contexte qui compacte un graphe de livres
 // en utilisant les termes courts ""titre"", ""auteur"", ""publie"".
@@ -19418,52 +19418,52 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-CSharp-JSONLD.ipynb,3fb0f730-1209-
 
 *Twin C# du notebook Python `SW-9-Python-JSONLD.ipynb`. Marathon parite .NET <-> Python (#4956, Prong B). dotNetRDF 3.4.1 (vrai moteur W3C JSON-LD 1.1).*
 ",,,,,,,,f7d637f6a590d314,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,header-nav,markdown,fr,78351cacb0cdf9d2,"# SW-9-Python-JSONLD
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,header-nav,markdown,fr,9b4e6ddd09657e3a,"# SW-9-Python-JSONLD
 
 **Navigation** : [<< 8-Python-SHACL](SW-8-Python-SHACL.ipynb) | [Index](README.md) | [10-Python-RDFStar >>](SW-10-Python-RDFStar.ipynb)
 
-## JSON-LD : Le Web Semantique rencontre JSON
+## JSON-LD : Le Web Sémantique rencontre JSON
 
 ### Duree estimee : 40 minutes
 
 ## Objectifs d'apprentissage
 
 A la fin de ce notebook, vous saurez :
-1. Comprendre JSON-LD et son role de pont entre JSON et le Linked Data
-2. Creer et manipuler des contextes JSON-LD (`@context`, `@id`, `@type`, `@graph`)
+1. Comprendre JSON-LD et son rôle de pont entre JSON et le Linked Data
+2. Créer et manipuler des contextes JSON-LD (`@context`, `@id`, `@type`, `@graph`)
 3. Utiliser le vocabulaire Schema.org pour decrire des entites web
-4. Generer et parser des donnees structurees avec rdflib
+4. Generer et parser des données structurees avec rdflib
 
 ### Prerequis
 - Python 3.10+
 - Notebook [SW-8-Python-SHACL](SW-8-Python-SHACL.ipynb) (bases rdflib, SPARQL et SHACL)
 
----",,,,,,,,78351cacb0cdf9d2,,,,,,,
+---",,,,,,,,9b4e6ddd09657e3a,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,install-section,markdown,fr,c7402abcec729010,## Installation des dependances,,,,,,,,c7402abcec729010,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,install-pip,code,fr,948dfd69d63b0c63,"# Dependances pre-provisionnees (rdflib) : voir SemanticWeb/requirements.txt ; imports dans les cellules suivantes.
 ",,,,,,,,948dfd69d63b0c63,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,section1-title,markdown,fr,06c0ef7a2830c3ac,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,section1-title,markdown,fr,14c2a45c71e3d992,"---
 
 ## 1. Pourquoi JSON-LD ? Le pont entre JSON et le Linked Data
 
-Le Web regorge de donnees en JSON, le format natif de JavaScript. Mais JSON seul ne porte **aucune semantique** : les cles sont des chaines arbitraires, sans signification universelle. Un champ `""name""` dans une API peut designer un nom de personne, de produit ou de fichier.
+Le Web regorge de données en JSON, le format natif de JavaScript. Mais JSON seul ne porte **aucune sémantique** : les cles sont des chaînes arbitraires, sans signification universelle. Un champ `""name""` dans une API peut designer un nom de personne, de produit ou de fichier.
 
-**JSON-LD** (JSON for Linking Data) resout ce probleme en ajoutant une couche de contexte (`@context`) qui relie chaque cle JSON a un IRI semantique, transformant du JSON ordinaire en donnees RDF exploitables.
+**JSON-LD** (JSON for Linking Data) resout ce problème en ajoutant une couche de contexte (`@context`) qui relie chaque cle JSON a un IRI sémantique, transformant du JSON ordinaire en données RDF exploitables.
 
 ### L'adoption de JSON-LD en chiffres
 
 | Metrique | Valeur | Source |
 |----------|--------|--------|
 | Part des rich snippets Google utilisant JSON-LD | ~73% | Schema.org community (2024) |
-| Amelioration moyenne du CTR avec donnees structurees | +35% | Etudes SEO |
+| Amelioration moyenne du CTR avec données structurees | +35% | Études SEO |
 | Format recommande par Google | JSON-LD | Google Developers |
 | Types Schema.org disponibles | 800+ | schema.org/docs |
 
 ### Historique
 
-JSON-LD a ete cree par le W3C (recommandation JSON-LD 1.0 en 2014, puis 1.1 en 2020). L'objectif etait de rendre le Linked Data accessible aux developpeurs web habitues a JSON, sans leur imposer la syntaxe RDF/XML ou Turtle.
+JSON-LD a ete créé par le W3C (recommandation JSON-LD 1.0 en 2014, puis 1.1 en 2020). L'objectif etait de rendre le Linked Data accessible aux developpeurs web habitues a JSON, sans leur imposer la syntaxe RDF/XML ou Turtle.
 
-> **Point cle** : JSON-LD est du JSON valide. Tout parser JSON peut le lire. Mais un parser JSON-LD peut en extraire des triples RDF.",,,,,,,,06c0ef7a2830c3ac,,,,,,,
+> **Point cle** : JSON-LD est du JSON valide. Tout parser JSON peut le lire. Mais un parser JSON-LD peut en extraire des triples RDF.",,,,,,,,14c2a45c71e3d992,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,demo-json-vs-jsonld,code,fr,df43349568aafc9e,"import json
 
 # JSON classique : pas de semantique
@@ -19493,11 +19493,11 @@ Les deux blocs sont du JSON valide, mais seul le second porte une signification 
 - `""name""` est resolu en `schema:name`, une propriete standardisee
 
 Un moteur de recherche comme Google peut donc extraire automatiquement ces informations.",,,,,,,,8deb15f4cd5e3a8c,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,section2-title,markdown,fr,8ef63d30efbc9ddd,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,section2-title,markdown,fr,27a9d910a7803e00,"---
 
 ## 2. Syntaxe fondamentale de JSON-LD
 
-JSON-LD repose sur quatre mots-cles principaux qui transforment du JSON ordinaire en donnees liees.",,,,,,,,8ef63d30efbc9ddd,,,,,,,
+JSON-LD repose sur quatre mots-cles principaux qui transforment du JSON ordinaire en données liees.",,,,,,,,27a9d910a7803e00,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,section2-context,markdown,fr,3b694c4835f4c7d6,"### 2.1 `@context` : le dictionnaire de traduction
 
 Le `@context` associe chaque cle JSON a un IRI (Internationalized Resource Identifier). Il peut etre :
@@ -19546,10 +19546,10 @@ print(json.dumps(ctx_local, indent=2))
 print()
 print(""=== Contexte combine ==="")
 print(json.dumps(ctx_combined, indent=2))",,,,,,,,a66725616d093b6f,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,section2-id-type,markdown,fr,788e0f9d4fd46541,"### 2.2 `@id` et `@type` : identifier et typer les ressources
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,section2-id-type,markdown,fr,48ba9e9398bef621,"### 2.2 `@id` et `@type` : identifier et typer les ressources
 
-- **`@id`** : identifie la ressource (le sujet du triple RDF). Si absent, un blank node est cree.
-- **`@type`** : definit le type de la ressource (equivalent de `rdf:type`).",,,,,,,,788e0f9d4fd46541,,,,,,,
+- **`@id`** : identifie la ressource (le sujet du triple RDF). Si absent, un blank node est créé.
+- **`@type`** : définit le type de la ressource (equivalent de `rdf:type`).",,,,,,,,48ba9e9398bef621,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,id-type-demo,code,fr,fa30512d104861ab,"import json
 
 person_with_id = {
@@ -19573,9 +19573,9 @@ print('  <https://example.org/people/turing> schema:birthDate ""1912-06-23"" .')
 print(""  <https://example.org/people/turing> schema:birthPlace _:b0 ."")
 print(""  _:b0 rdf:type schema:Place ."")
 print('  _:b0 schema:name ""London"" .')",,,,,,,,fa30512d104861ab,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,section2-graph,markdown,fr,9724e71f5e5adcc9,"### 2.3 `@graph` : regrouper plusieurs ressources
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,section2-graph,markdown,fr,6e4f15376addcc2b,"### 2.3 `@graph` : regrouper plusieurs ressources
 
-Le mot-cle `@graph` permet de decrire plusieurs entites dans un seul document JSON-LD, partageant le meme `@context`.",,,,,,,,9724e71f5e5adcc9,,,,,,,
+Le mot-cle `@graph` permet de decrire plusieurs entites dans un seul document JSON-LD, partageant le même `@context`.",,,,,,,,6e4f15376addcc2b,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,graph-demo,code,fr,f845698f39a2a417,"import json
 
 multi_entities = {
@@ -19605,15 +19605,15 @@ multi_entities = {
 print(f""Document contenant {len(multi_entities['@graph'])} entites :"")
 for entity in multi_entities[""@graph""]:
     print(f""  - {entity['@type']} : {entity['name']} ({entity['@id']})"")",,,,,,,,f845698f39a2a417,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,section2-forms,markdown,fr,5a220263b9fc3fae,"### 2.4 Formes JSON-LD : Compacte, Etendue et Aplatie
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,section2-forms,markdown,fr,b49c23b800d5ba72,"### 2.4 Formes JSON-LD : Compacte, Etendue et Aplatie
 
-Un meme graphe RDF peut etre represente sous trois formes JSON-LD :
+Un même graphe RDF peut etre represente sous trois formes JSON-LD :
 
 | Forme | Description | Usage |
 |-------|-------------|-------|
 | **Compacte** | Utilise un `@context` pour abreger les IRIs | Production web (lisibilite) |
 | **Etendue** | IRIs complets, pas de `@context` | Echanges machine a machine |
-| **Aplatie** | Toutes les entites au meme niveau dans `@graph` | Normalisation, deduplication |",,,,,,,,5a220263b9fc3fae,,,,,,,
+| **Aplatie** | Toutes les entites au même niveau dans `@graph` | Normalisation, deduplication |",,,,,,,,b49c23b800d5ba72,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,forms-demo,code,fr,c045af3ac2bcd58f,"import json
 
 # Forme COMPACTE (la plus courante)
@@ -19658,14 +19658,14 @@ print(json.dumps(expanded_form, indent=2))
 print()
 print(""=== Forme APLATIE (flattened) ==="")
 print(json.dumps(flattened_form, indent=2))",,,,,,,,c045af3ac2bcd58f,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,interpretation-forms,markdown,fr,9f1bc442f11def67,"### Interpretation
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,interpretation-forms,markdown,fr,b512e77dcaa3bda1,"### Interpretation
 
-Les trois formes representent exactement les memes triples RDF. La forme **compacte** est la plus utilisee dans les pages web car elle est lisible par les developpeurs. La forme **etendue** est utile pour le traitement automatise (pas besoin de resoudre le contexte). La forme **aplatie** normalise la structure pour faciliter la comparaison et la fusion de documents.",,,,,,,,9f1bc442f11def67,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,section3-title,markdown,fr,dff1471b79250597,"---
+Les trois formes representent exactement les mêmes triples RDF. La forme **compacte** est la plus utilisee dans les pages web car elle est lisible par les developpeurs. La forme **etendue** est utile pour le traitement automatise (pas besoin de resoudre le contexte). La forme **aplatie** normalise la structure pour faciliter la comparaison et la fusion de documents.",,,,,,,,b512e77dcaa3bda1,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,section3-title,markdown,fr,b54c3b72bbb79aa9,"---
 
 ## 3. Le vocabulaire Schema.org
 
-**Schema.org** est le vocabulaire collaboratif cree par Google, Microsoft, Yahoo et Yandex pour structurer les donnees du Web. Il definit plus de 800 types et 1500 proprietes couvrant les domaines les plus courants.
+**Schema.org** est le vocabulaire collaboratif créé par Google, Microsoft, Yahoo et Yandex pour structurer les données du Web. Il définit plus de 800 types et 1500 proprietes couvrant les domaines les plus courants.
 
 ### Types les plus utilises
 
@@ -19674,12 +19674,12 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,section3-title
 | `Person` | Personne physique | Profil, auteur d'article |
 | `Organization` | Entreprise, association | Page entreprise |
 | `Product` | Produit commercial | Fiche produit e-commerce |
-| `Event` | Evenement | Concert, conference |
+| `Event` | Événement | Concert, conference |
 | `Article` | Article de presse/blog | Billet de blog |
 | `Recipe` | Recette de cuisine | Site culinaire |
 | `FAQPage` | Page de FAQ | Support client |
 | `BreadcrumbList` | Fil d'Ariane | Navigation de site |
-| `Course` | Cours en ligne | Plateforme educative |",,,,,,,,dff1471b79250597,,,,,,,
+| `Course` | Cours en ligne | Plateforme educative |",,,,,,,,b54c3b72bbb79aa9,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,section3-explore,markdown,fr,a71c2e5d416ca4af,"### 3.1 Explorer le namespace Schema.org avec rdflib
 
 rdflib fournit un namespace `SDO` (Schema.org) predefini pour acceder aux termes Schema.org.",,,,,,,,a71c2e5d416ca4af,,,,,,,
@@ -19750,14 +19750,14 @@ Ce document JSON-LD decrit un produit educatif avec les proprietes Schema.org su
 | `author` | Jean-Sebastien Boige | Auteur du cours |
 
 > **Note** : Ce JSON-LD pourrait etre integre directement dans une balise `<script type=""application/ld+json"">` d'une page HTML pour que Google affiche un rich snippet.",,,,,,,,8e40a72d739a7950,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,section4-title,markdown,fr,c2866addd5fc477a,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,section4-title,markdown,fr,bb27930e14f6c52b,"---
 
-## 4. Creer du JSON-LD avec rdflib
+## 4. Créer du JSON-LD avec rdflib
 
-rdflib permet de construire un graphe RDF et de le serialiser directement en JSON-LD. C'est l'approche programmatique pour generer des donnees structurees.",,,,,,,,c2866addd5fc477a,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,section4-build,markdown,fr,de73319fe816df1c,"### 4.1 Construire un graphe et serialiser en JSON-LD
+rdflib permet de construire un graphe RDF et de le serialiser directement en JSON-LD. C'est l'approche programmatique pour generer des données structurees.",,,,,,,,bb27930e14f6c52b,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,section4-build,markdown,fr,7108aa4b212a9ea5,"### 4.1 Construire un graphe et serialiser en JSON-LD
 
-Nous allons creer une entite Schema.org Person avec plusieurs proprietes, puis l'exporter en JSON-LD.",,,,,,,,de73319fe816df1c,,,,,,,
+Nous allons créer une entite Schema.org Person avec plusieurs proprietes, puis l'exporter en JSON-LD.",,,,,,,,7108aa4b212a9ea5,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,build-graph-jsonld,code,fr,20331347d64584d8,"from rdflib import Graph, Literal, Namespace, URIRef, BNode
 from rdflib.namespace import RDF, RDFS, XSD
 
@@ -19793,14 +19793,14 @@ print()
 jsonld_output = g.serialize(format=""json-ld"", indent=2)
 print(""=== Serialisation JSON-LD ==="")
 print(jsonld_output)",,,,,,,,20331347d64584d8,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,interpretation-build,markdown,fr,3b1ee03175de62ce,"### Interpretation
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,interpretation-build,markdown,fr,f76771f8209d2677,"### Interpretation
 
 rdflib genere automatiquement le JSON-LD a partir du graphe. Notons que :
 - Les URIs sont expansees en IRIs complets (forme etendue par defaut)
-- Les types de donnees (`xsd:date`) sont preserves
+- Les types de données (`xsd:date`) sont preserves
 - La relation `knows` lie deux ressources par leur `@id`
 
-> **Note technique** : Pour obtenir la forme compacte avec un `@context`, il faut passer un contexte au serialiseur. Nous verrons cela dans un exercice.",,,,,,,,3b1ee03175de62ce,,,,,,,
+> **Note technique** : Pour obtenir la forme compacte avec un `@context`, il faut passer un contexte au serialiseur. Nous verrons cela dans un exercice.",,,,,,,,f76771f8209d2677,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,section4-person-compact,markdown,fr,0db7cfdaaf1c9e2b,"### 4.2 Serialisation compacte avec contexte
 
 Pour generer du JSON-LD compact lisible, on peut fournir un contexte de serialisation.",,,,,,,,0db7cfdaaf1c9e2b,,,,,,,
@@ -19826,12 +19826,12 @@ jsonld_compact = g.serialize(
 
 print(""=== JSON-LD compact avec contexte ==="")
 print(jsonld_compact)",,,,,,,,a550b03c3dbda0dc,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,section5-title,markdown,fr,c1cab65c1dce018f,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,section5-title,markdown,fr,9da5488971720ee4,"---
 
 ## 5. Parser du JSON-LD
 
-L'operation inverse est tout aussi importante : charger du JSON-LD dans un graphe rdflib pour l'interroger avec SPARQL ou le convertir dans d'autres formats.",,,,,,,,c1cab65c1dce018f,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,section5-parse,markdown,fr,7d0383318cba333e,### 5.1 Charger une chaine JSON-LD dans rdflib,,,,,,,,7d0383318cba333e,,,,,,,
+L'opération inverse est tout aussi importante : charger du JSON-LD dans un graphe rdflib pour l'interroger avec SPARQL ou le convertir dans d'autres formats.",,,,,,,,9da5488971720ee4,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,section5-parse,markdown,fr,81548e75c278f34f,### 5.1 Charger une chaîne JSON-LD dans rdflib,,,,,,,,81548e75c278f34f,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,parse-jsonld,code,fr,61ef88773056bf3a,"from rdflib import Graph
 import json
 
@@ -19935,19 +19935,19 @@ print(f""Conservation des triples : {'OUI' if is_same else 'NON'} ({triples_orig
 print()
 print(""=== JSON-LD final (apres round-trip) ==="")
 print(jsonld_roundtrip)",,,,,,,,eed4a7f16def1b7d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,interpretation-roundtrip,markdown,fr,47fa47043a178dd4,"### Interpretation : Round-trip
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,interpretation-roundtrip,markdown,fr,9fbb556adc7225d2,"### Interpretation : Round-trip
 
-Le nombre de triples est conserve a travers le cycle JSON-LD -> Turtle -> JSON-LD. Cela confirme que rdflib effectue une conversion fidele entre les formats. Les seules differences peuvent etre cosmetiques :
+Le nombre de triples est conserve a travers le cycle JSON-LD -> Turtle -> JSON-LD. Cela confirme que rdflib effectue une conversion fidele entre les formats. Les seules différences peuvent etre cosmetiques :
 - L'ordre des proprietes peut changer
 - Les identifiants de blank nodes peuvent etre renommes
 - La structure d'imbrication peut varier (aplati vs imbrique)
 
-Mais les triples RDF sous-jacents sont identiques.",,,,,,,,47fa47043a178dd4,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,section6-title,markdown,fr,cfa1b84809edfe0d,"---
+Mais les triples RDF sous-jacents sont identiques.",,,,,,,,9fbb556adc7225d2,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,section6-title,markdown,fr,9760cf3fde50af2b,"---
 
 ## 6. Cas d'usage web pratiques
 
-JSON-LD est principalement utilise pour integrer des **donnees structurees** dans les pages HTML, permettant aux moteurs de recherche d'afficher des **rich snippets** (resultats enrichis). Voici les schemas les plus courants.",,,,,,,,cfa1b84809edfe0d,,,,,,,
+JSON-LD est principalement utilise pour integrer des **données structurees** dans les pages HTML, permettant aux moteurs de recherche d'afficher des **rich snippets** (résultats enrichis). Voici les schemas les plus courants.",,,,,,,,9760cf3fde50af2b,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,section6-recipe,markdown,fr,53ff318af8cb81e6,"### 6.1 Recipe (Recette de cuisine)
 
 Le schema `Recipe` est l'un des plus utilises. Il permet a Google d'afficher des cartes de recettes avec image, temps de preparation et notes.",,,,,,,,53ff318af8cb81e6,,,,,,,
@@ -20013,9 +20013,9 @@ print(f""Preparation : {recipe['prepTime']} | Cuisson : {recipe['cookTime']}"")
 print(f""Ingredients : {len(recipe['recipeIngredient'])}"")
 print(f""Etapes : {len(recipe['recipeInstructions'])}"")
 print(f""Note : {recipe['aggregateRating']['ratingValue']}/5 ({recipe['aggregateRating']['ratingCount']} avis)"")",,,,,,,,0404fa9e4b853f54,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,section6-event,markdown,fr,b6af37ee2e5f647f,"### 6.2 Event (Evenement)
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,section6-event,markdown,fr,7d064f43986502ff,"### 6.2 Event (Événement)
 
-Le schema `Event` permet l'affichage de cartes evenements dans les resultats de recherche.",,,,,,,,b6af37ee2e5f647f,,,,,,,
+Le schema `Event` permet l'affichage de cartes événements dans les résultats de recherche.",,,,,,,,7d064f43986502ff,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,event-schema,code,fr,50f84fb3992032d7,"import json
 
 event = {
@@ -20054,11 +20054,11 @@ event = {
 
 print(""=== Schema.org Event ==="")
 print(json.dumps(event, indent=2, ensure_ascii=False))",,,,,,,,50f84fb3992032d7,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,section6-breadcrumb-faq,markdown,fr,db57d08a83f4c3cb,"### 6.3 BreadcrumbList et FAQPage
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,section6-breadcrumb-faq,markdown,fr,eaa631bcabf54ef4,"### 6.3 BreadcrumbList et FAQPage
 
-Deux schemas tres utilises pour ameliorer l'affichage dans les SERP (Search Engine Results Pages) :
-- **BreadcrumbList** : affiche le fil d'Ariane dans les resultats
-- **FAQPage** : affiche des questions/reponses depliables",,,,,,,,db57d08a83f4c3cb,,,,,,,
+Deux schemas très utilises pour ameliorer l'affichage dans les SERP (Search Engine Results Pages) :
+- **BreadcrumbList** : affiche le fil d'Ariane dans les résultats
+- **FAQPage** : affiche des questions/reponses depliables",,,,,,,,eaa631bcabf54ef4,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,breadcrumb-faq-schema,code,fr,7e31d30b157402e7,"import json
 
 # BreadcrumbList - fil d'Ariane
@@ -20129,7 +20129,7 @@ for qa in faq[""mainEntity""]:
     print(f""  Q: {qa['name']}"")
     print(f""  R: {qa['acceptedAnswer']['text'][:80]}..."")
     print()",,,,,,,,7e31d30b157402e7,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,interpretation-usecases,markdown,fr,4c2ccaf72cec3d11,"### Interpretation : cas d'usage web
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,interpretation-usecases,markdown,fr,20afe841f06c18a4,"### Interpretation : cas d'usage web
 
 Ces schemas sont integres dans les pages HTML via la balise :
 
@@ -20143,10 +20143,10 @@ Ces schemas sont integres dans les pages HTML via la balise :
 |--------|-------------------|------------|
 | Recipe | Carte avec image, temps, note | Fort (carousels recettes) |
 | Event | Date, lieu, prix | Moyen a fort |
-| BreadcrumbList | Chemin hierarchique dans les SERP | Moyen |
-| FAQPage | Questions depliables sous le resultat | Fort (visibilite accrue) |
+| BreadcrumbList | Chemin hiérarchique dans les SERP | Moyen |
+| FAQPage | Questions depliables sous le résultat | Fort (visibilite accrue) |
 
-> **Conseil pratique** : Utilisez l'outil [Google Rich Results Test](https://search.google.com/test/rich-results) pour valider vos schemas avant deploiement.",,,,,,,,4c2ccaf72cec3d11,,,,,,,
+> **Conseil pratique** : Utilisez l'outil [Google Rich Results Test](https://search.google.com/test/rich-results) pour valider vos schemas avant deploiement.",,,,,,,,20afe841f06c18a4,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,section7-title,markdown,fr,578d08078cb58c4a,"---
 
 ## 7. JSON-LD vs autres formats RDF
@@ -20185,7 +20185,7 @@ for label, fmt in formats:
     print(f""{'=' * 60}"")
     print(output.strip())
     print()",,,,,,,,df4c4b4ed505e703,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,interpretation-comparison,markdown,fr,0ffd6efbf1a2e0d1,"### Interpretation : comparaison des formats
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,interpretation-comparison,markdown,fr,296e06c5a7596d41,"### Interpretation : comparaison des formats
 
 | Critere | JSON-LD | Turtle | RDF/XML | N-Triples |
 |---------|---------|--------|---------|------------|
@@ -20200,8 +20200,8 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,interpretation
 **Recommandations** :
 - **JSON-LD** : integration dans les pages web, APIs, developpeurs JSON
 - **Turtle** : edition humaine, ontologies, enseignement
-- **RDF/XML** : systemes legacy, interoperabilite XML
-- **N-Triples** : traitement en masse, streaming, tri lexicographique",,,,,,,,0ffd6efbf1a2e0d1,,,,,,,
+- **RDF/XML** : systèmes legacy, interoperabilite XML
+- **N-Triples** : traitement en masse, streaming, tri lexicographique",,,,,,,,296e06c5a7596d41,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,section8-title,markdown,fr,0d30278268415447,"---
 
 ## 8. Chargement du fichier produit dans rdflib
@@ -20265,11 +20265,11 @@ Le fichier `product.jsonld` a ete charge avec succes dans rdflib. Nous pouvons o
 - La propriete `teaches` genere un triple par sujet enseigne (tableau JSON -> triples multiples)
 
 Cela demontre la puissance de JSON-LD : un document JSON lisible se transforme en un graphe RDF interrogeable.",,,,,,,,ed98a9c89ae1d84e,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,exercises-title,markdown,fr,fbaba5b9accb8ddd,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,exercises-title,markdown,fr,46fcf0282f4aacec,"---
 
 ## Exemples et Exercices
 
-### Exemple guide 1 : Creer une Schema.org Person
+### Exemple guide 1 : Créer une Schema.org Person
 
 Cet exemple montre la creation d'un document JSON-LD decrivant une personne avec les proprietes Schema.org suivantes :
 - `name`, `jobTitle`, `email`, `telephone`
@@ -20277,7 +20277,7 @@ Cet exemple montre la creation d'un document JSON-LD decrivant une personne avec
 - `alumniOf` (une `CollegeOrUniversity`)
 - `sameAs` (liens vers profils sociaux)
 
-Le document est charge dans rdflib et les triples sont affiches.",,,,,,,,fbaba5b9accb8ddd,,,,,,,
+Le document est charge dans rdflib et les triples sont affichés.",,,,,,,,46fcf0282f4aacec,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,exercise1,code,fr,2376999ac6c4c7d4,"import json
 from rdflib import Graph
 
@@ -20350,15 +20350,15 @@ g_ex2.parse(data=turtle_data, format=""turtle"")
 jsonld_result = g_ex2.serialize(format=""json-ld"", indent=2)
 print(jsonld_result)
 ",,,,,,,,ae3d09bf4e7b5dd3,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,exercise3-title,markdown,fr,9fb62c030b060cd6,"### Exemple guide 3 : Creer un Schema.org Recipe
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,exercise3-title,markdown,fr,bb9591cb816ee04f,"### Exemple guide 3 : Créer un Schema.org Recipe
 
 Cet exemple montre la creation d'un schema `Recipe` complet pour la Tartiflette savoyarde, incluant :
 - Nom, description, auteur
 - Temps de preparation et cuisson (format ISO 8601 Duration : `PT30M`)
-- 6 ingredients et 3 etapes (`HowToStep`)
+- 6 ingredients et 3 étapes (`HowToStep`)
 - Informations nutritionnelles
 
-Le JSON-LD est charge dans rdflib, puis interroge avec SPARQL pour extraire les ingredients.",,,,,,,,9fb62c030b060cd6,,,,,,,
+Le JSON-LD est charge dans rdflib, puis interroge avec SPARQL pour extraire les ingredients.",,,,,,,,bb9591cb816ee04f,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,exercise3,code,fr,bad228f09d53925d,"import json
 from rdflib import Graph
 
@@ -20425,14 +20425,14 @@ print(""\nIngredients :"")
 for row in g_ex3.query(query):
     print(f""  - {row.ingredient}"")
 ",,,,,,,,bad228f09d53925d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,4a9cd33a,markdown,fr,795a5a779c184e3f,"### Exemple guide 4 : Modeliser un systeme de conferences en JSON-LD
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,4a9cd33a,markdown,fr,f7aaec5bece98492,"### Exemple guide 4 : Modeliser un système de conferences en JSON-LD
 
-Cet exemple montre comment designer un contexte JSON-LD pour un systeme de conferences academiques utilisant Schema.org. La conference comprend :
+Cet exemple montre comment designer un contexte JSON-LD pour un système de conferences academiques utilisant Schema.org. La conference comprend :
 - Un `name`, `startDate`, `endDate`, `location` (Place)
 - Des `subEvent` representant les sessions
 - Des `performer` (Person avec `affiliation`)
 
-Une conference complete avec 2 sessions et 3 intervenants, convertie en forme expanded avec verification des triples RDF generes.",,,,,,,,795a5a779c184e3f,,,,,,,
+Une conference complete avec 2 sessions et 3 intervenants, convertie en forme expanded avec verification des triples RDF generes.",,,,,,,,f7aaec5bece98492,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,6aa6a1e8,code,fr,ca9b21278207a58c,"import json
 from rdflib import Graph
 
@@ -20503,13 +20503,13 @@ print(f""\nTriples generes : {len(g_conf)}"")
 for s, p, o in g_conf:
     print(f""  {s} {p} {o}"")
 ",,,,,,,,ca9b21278207a58c,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,exemples-guides-sosolalt,markdown,fr,0043ad0d584f5011,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,exemples-guides-sosolalt,markdown,fr,929c7b30cd81bee1,"---
 
 ## Exemples guides (solutions proposees par @Sosolalt)
 
 *Les exemples ci-dessous ont ete resolus par @Sosolalt (EPITA-IS, promo 2028).*
-*Ils servent de modele pour comprendre les concepts abordes dans ce notebook.*
-",,,,,,,,0043ad0d584f5011,,,,,,,
+*Ils servent de modèle pour comprendre les concepts abordes dans ce notebook.*
+",,,,,,,,929c7b30cd81bee1,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,exemple-3a7cb7af,markdown,fr,c91aa2ec02d5892c,"### Exemple guide 5 : Schema.org Organization en JSON-LD
 
 *Solution proposee par @Sosolalt (EPITA-IS, promo 2028).*",,,,,,,,c91aa2ec02d5892c,,,,,,,
@@ -20859,9 +20859,9 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,exercices-a-co
 
 *Ces exercices sont a realiser par l'etudiant. Les stubs utilisent des marqueurs TODO.*
 ",,,,,,,,af194a7995ed8589,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,5ef791b8,markdown,fr,104c0d020a996206,"### Exercice 1 : Creer une Schema.org Organization
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,5ef791b8,markdown,fr,bec7f0dd5beefb82,"### Exercice 1 : Créer une Schema.org Organization
 
-Creez un document JSON-LD decrivant une organisation avec les proprietes suivantes :
+Créez un document JSON-LD decrivant une organisation avec les proprietes suivantes :
 - `name`, `url`, `logo` (URL)
 - `founder` (une `Person` avec `name` et `jobTitle`)
 - `address` (une `PostalAddress` avec `streetAddress`, `addressLocality`, `postalCode`, `addressCountry`)
@@ -20869,7 +20869,7 @@ Creez un document JSON-LD decrivant une organisation avec les proprietes suivant
 
 Chargez-le dans rdflib et affichez le nombre de triples generes.
 
-**TODO etudiant :** inserer le JSON-LD de l'organisation ci-dessous",,,,,,,,104c0d020a996206,,,,,,,
+**TODO etudiant :** inserer le JSON-LD de l'organisation ci-dessous",,,,,,,,bec7f0dd5beefb82,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,3a7cb7af,code,fr,3c4babbf0a4afd7c,"import json
 from rdflib import Graph
 
@@ -20904,18 +20904,18 @@ turtle_result = None  # TODO etudiant : remplacer par le code de conversion
 
 print(""Exercice a completer : convertissez le JSON-LD en Turtle"")
 print(""Indice : utilisez g.parse(data=..., format='json-ld') puis g.serialize(format='turtle')"")",,,,,,,,48e5374b43918511,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,d02931a8,markdown,fr,71df03965f767e5c,"### Exercice 3 : Creer un schema Event pour un hackathon
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,d02931a8,markdown,fr,492422f090ee816a,"### Exercice 3 : Créer un schema Event pour un hackathon
 
-Creez un document JSON-LD de type `Event` decrivant un hackathon avec :
+Créez un document JSON-LD de type `Event` decrivant un hackathon avec :
 - Un `name`, `description`, `startDate`, `endDate`
 - Un `location` (Place avec adresse)
 - Un `organizer` (Organization)
 - Des `offers` (gratuit, `InStock`)
 - Un `eventStatus` et `eventAttendanceMode`
 
-Chargez-le dans rdflib, puis effectuez une requete SPARQL pour lister toutes les proprietes de l'evenement.
+Chargez-le dans rdflib, puis effectuez une requête SPARQL pour lister toutes les proprietes de l'événement.
 
-**TODO etudiant :** inserer le JSON-LD du hackathon ci-dessous",,,,,,,,71df03965f767e5c,,,,,,,
+**TODO etudiant :** inserer le JSON-LD du hackathon ci-dessous",,,,,,,,492422f090ee816a,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,9521dae4,code,fr,7e47b05d7d477e9f,"import json
 from rdflib import Graph
 
@@ -20924,14 +20924,14 @@ hackathon_jsonld = None  # TODO etudiant : remplacer par le document JSON-LD
 
 print(""Exercice a completer : creez le JSON-LD pour un hackathon"")
 print(""Indice : inspirez-vous de l'Exemple guide 2 et de la section 6.2 sur les Event"")",,,,,,,,7e47b05d7d477e9f,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,68b4a35f,markdown,fr,cf2f068d3dce88ea,"### Exercice 4 : Modeliser un cours universitaire en JSON-LD
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,68b4a35f,markdown,fr,d10cc00bbd8c7d63,"### Exercice 4 : Modeliser un cours universitaire en JSON-LD
 
-Creez un document JSON-LD Schema.org decrivant un cours universitaire avec :
+Créez un document JSON-LD Schema.org decrivant un cours universitaire avec :
 - Un `Course` avec `name`, `description`, `courseCode`, `provider` (une `CollegeOrUniversity`)
 - Au moins 2 `hasCourseInstance` (sessions du cours, avec `startDate`/`endDate`)
 - Un `instructor` (Person avec `affiliation`)
 
-**TODO etudiant :** inserer le JSON-LD du cours ci-dessous, puis charger dans rdflib et afficher les triples",,,,,,,,cf2f068d3dce88ea,,,,,,,
+**TODO etudiant :** inserer le JSON-LD du cours ci-dessous, puis charger dans rdflib et afficher les triples",,,,,,,,d10cc00bbd8c7d63,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,08d2cdb0,code,fr,a094b9a8d4496233,"import json
 from rdflib import Graph
 
@@ -20940,9 +20940,9 @@ course_jsonld = None  # TODO etudiant : remplacer par le document JSON-LD
 
 print(""Exercice a completer : creez le JSON-LD pour un cours universitaire"")
 print(""Indice : utilisez les types Course, CourseInstance, Person et CollegeOrUniversity"")",,,,,,,,a094b9a8d4496233,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,6ac0a68b,markdown,fr,b28a602dd344effd,"### Exercice 5 : `@list` vs ensemble par defaut (ordre des elements)
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,6ac0a68b,markdown,fr,7b234a393589d993,"### Exercice 5 : `@list` vs ensemble par defaut (ordre des éléments)
 
-Par defaut, les tableaux JSON en JSON-LD sont consideres comme des **multisets non ordonnes** : l'ordre des elements n'est pas significatif. Le mot-cle `@list` force une interpretation **ordonnee** (RDF list / `rdf:first`/`rdf:rest`).
+Par defaut, les tableaux JSON en JSON-LD sont consideres comme des **multisets non ordonnes** : l'ordre des éléments n'est pas significatif. Le mot-cle `@list` force une interpretation **ordonnee** (RDF list / `rdf:first`/`rdf:rest`).
 
 Modelisez une recette de cuisine avec un champ `recipeIngredient` au format `@list` (les ingredients doivent etre ajoutes dans l'ordre indique) et un champ `recipeCategory` au format ensemble (l'ordre est arbitraire).
 
@@ -20951,7 +20951,7 @@ Chargez le document dans rdflib et verifiez que les triples generes pour `recipe
 **Indice** :
 ```json
 ""recipeIngredient"": {""@list"": [""farine"", ""sucre"", ""oeufs""]}
-```",,,,,,,,b28a602dd344effd,,,,,,,
+```",,,,,,,,7b234a393589d993,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,04768456,code,fr,188f0c28fbd0ee1e,"# Exercice 5 : @list pour ordonner les ingredients
 # TODO etudiant : creer un Recipe JSON-LD avec recipeIngredient en @list
 # Indice : inspecter les triples generes (rdflib) pour voir rdf:first/rdf:rest/rdf:nil
@@ -20962,9 +20962,9 @@ from rdflib import Graph
 recipe_jsonld = None  # TODO etudiant : creer le document
 
 print(""Exercice a completer : Recipe avec @list pour ingredients ordonnes"")",,,,,,,,188f0c28fbd0ee1e,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,f38b0127,markdown,fr,aedc8734d7c3800f,"### Exercice 6 : Annotations multilingues avec `@language`
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,f38b0127,markdown,fr,1367a0f324604c03,"### Exercice 6 : Annotations multilingues avec `@language`
 
-JSON-LD permet d'attacher une langue a une chaine de caracteres via `@language` (dans `@context` ou inline). Cela genere en RDF un litteral avec tag de langue (par exemple `""Bonjour""@fr`).
+JSON-LD permet d'attacher une langue a une chaîne de caractères via `@language` (dans `@context` ou inline). Cela genere en RDF un litteral avec tag de langue (par exemple `""Bonjour""@fr`).
 
 Modelisez une `Article` Schema.org avec :
 - `headline` en francais, anglais et espagnol (3 versions)
@@ -20980,7 +20980,7 @@ Utilisez la syntaxe `""@value""` + `""@language""` pour chaque valeur multilingu
 ]
 ```
 
-SPARQL utile : `SELECT ?lit ?lang WHERE { ?s schema:headline ?lit . BIND(LANG(?lit) AS ?lang) }`",,,,,,,,aedc8734d7c3800f,,,,,,,
+SPARQL utile : `SELECT ?lit ?lang WHERE { ?s schema:headline ?lit . BIND(LANG(?lit) AS ?lang) }`",,,,,,,,1367a0f324604c03,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,981b8c6a,code,fr,95969bac9f41f32b,"# Exercice 6 : annotations multilingues @language
 # TODO etudiant : Article avec headline (fr/en/es) et description (fr/en)
 # Indice : utiliser {""@value"": ..., ""@language"": ...} ; SPARQL LANG(?lit)
@@ -20991,9 +20991,9 @@ from rdflib import Graph
 article_jsonld = None  # TODO etudiant : remplacer par le document JSON-LD multilingue
 
 print(""Exercice a completer : Article avec headlines multilingues"")",,,,,,,,95969bac9f41f32b,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,24210cde,markdown,fr,00ffc55a55243e91,"### Exercice 7 : `@reverse` pour propriete inverse
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,24210cde,markdown,fr,f558a40df8e97ae0,"### Exercice 7 : `@reverse` pour propriete inverse
 
-Le mot-cle `@reverse` permet d'exprimer une relation **en sens inverse** depuis l'objet vers le sujet, sans avoir a definir une propriete miroir dans le vocabulaire. Utile pour Schema.org ou seul `parent` est defini (pas `child`).
+Le mot-cle `@reverse` permet d'exprimer une relation **en sens inverse** depuis l'objet vers le sujet, sans avoir a définir une propriete miroir dans le vocabulaire. Utile pour Schema.org ou seul `parent` est défini (pas `child`).
 
 Modelisez une famille en partant d'un parent et en attachant ses enfants via `@reverse: parent` (l'enfant pointe vers son parent en RDF, mais c'est ecrit depuis le parent en JSON-LD).
 
@@ -21011,7 +21011,7 @@ Verifiez en SPARQL que les triples generes sont bien `?enfant schema:parent ?par
     ]
   }
 }
-```",,,,,,,,00ffc55a55243e91,,,,,,,
+```",,,,,,,,f558a40df8e97ae0,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,91d35432,code,fr,6d4561a0bafc283d,"# Exercice 7 : @reverse pour propriete inverse
 # TODO etudiant : modeliser une famille via @reverse: parent
 # Indice : verifier en SPARQL que les triples sont (?child schema:parent ?parent)
@@ -21022,7 +21022,7 @@ from rdflib import Graph
 family_jsonld = None  # TODO etudiant : remplacer par le document JSON-LD avec @reverse
 
 print(""Exercice a completer : famille modelisee avec @reverse: parent"")",,,,,,,,6d4561a0bafc283d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,summary-title,markdown,fr,1f43d9f1c4862072,"---
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,summary-title,markdown,fr,40066a7317b04856,"---
 
 ## Resume
 
@@ -21032,20 +21032,20 @@ Ce notebook a couvert les aspects essentiels de JSON-LD et Schema.org.
 
 | Concept | Description |
 |---------|-------------|
-| **JSON-LD** | Format W3C qui ajoute une couche semantique au JSON via `@context` |
+| **JSON-LD** | Format W3C qui ajoute une couche sémantique au JSON via `@context` |
 | **@context** | Dictionnaire de traduction entre cles JSON et IRIs RDF |
 | **@id** | Identifiant de la ressource (sujet du triple) |
 | **@type** | Type de la ressource (equivalent `rdf:type`) |
-| **@graph** | Conteneur pour plusieurs entites dans un meme document |
+| **@graph** | Conteneur pour plusieurs entites dans un même document |
 | **Schema.org** | Vocabulaire collaboratif (Google, Microsoft, Yahoo) avec 800+ types |
-| **Rich snippets** | Resultats enrichis dans les moteurs de recherche |
+| **Rich snippets** | Résultats enrichis dans les moteurs de recherche |
 
 ### Competences acquises
 
 1. Comprendre la motivation et la syntaxe de JSON-LD
 2. Manipuler les trois formes (compacte, etendue, aplatie)
 3. Utiliser Schema.org pour decrire des entites web
-4. Creer du JSON-LD avec rdflib (`g.serialize(format=""json-ld"")`)
+4. Créer du JSON-LD avec rdflib (`g.serialize(format=""json-ld"")`)
 5. Parser du JSON-LD et l'interroger en SPARQL
 6. Effectuer des conversions round-trip entre formats
 7. Appliquer les schemas web courants (Recipe, Event, FAQ, Breadcrumb)
@@ -21056,7 +21056,7 @@ Ce notebook a couvert les aspects essentiels de JSON-LD et Schema.org.
 - [JSON-LD Playground](https://json-ld.org/playground/) - testeur en ligne
 - [Schema.org](https://schema.org/) - documentation des types et proprietes
 - [Google Structured Data Testing Tool](https://search.google.com/test/rich-results)
-- [JSON-LD Best Practices (W3C)](https://www.w3.org/TR/json-ld11-api/)",,,,,,,,1f43d9f1c4862072,,,,,,,
+- [JSON-LD Best Practices (W3C)](https://www.w3.org/TR/json-ld11-api/)",,,,,,,,40066a7317b04856,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,footer-nav,markdown,fr,10f302fa72697079,"---
 
 Le notebook suivant explore RDF 1.2 (RDF-Star), une extension majeure de RDF permettant de faire des assertions sur des assertions.
@@ -21064,10 +21064,3136 @@ Le notebook suivant explore RDF 1.2 (RDF-Star), une extension majeure de RDF per
 ---
 
 **Navigation** : [<< 8-Python-SHACL](SW-8-Python-SHACL.ipynb) | [Index](README.md) | [10-Python-RDFStar >>](SW-10-Python-RDFStar.ipynb)",,,,,,,,10f302fa72697079,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,8ad12fbb,markdown,fr,25a814d387952de9,"## Resume et perspectives
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb,8ad12fbb,markdown,fr,1efa6d184ac0d2fd,"## Resume et perspectives
 
-Ce notebook a explore JSON-LD comme pont entre l'ecosysteme JSON du Web et le Linked Data du Web semantique. Nous avons couvert la syntaxe fondamentale (`@context`, `@id`, `@type`, `@graph`), les trois formes de representation (compacte, etendue, aplatie), et le vocabulaire Schema.org avec ses 800+ types utilises par Google, Microsoft et Yahoo pour les donnees structurees. Les cas d'usage pratiques (Recipe, Event, FAQPage, BreadcrumbList) ont illustre comment JSON-LD alimente les rich snippets dans les resultats de recherche.
+Ce notebook a explore JSON-LD comme pont entre l'ecosysteme JSON du Web et le Linked Data du Web sémantique. Nous avons couvert la syntaxe fondamentale (`@context`, `@id`, `@type`, `@graph`), les trois formes de representation (compacte, etendue, aplatie), et le vocabulaire Schema.org avec ses 800+ types utilises par Google, Microsoft et Yahoo pour les données structurees. Les cas d'usage pratiques (Recipe, Event, FAQPage, BreadcrumbList) ont illustre comment JSON-LD alimente les rich snippets dans les résultats de recherche.
 
 L'aller-retour JSON-LD vers Turtle vers JSON-LD a demontre la fidelite des conversions via rdflib : les 11 triples sont conserves intact a travers le cycle complet. La comparaison des formats RDF a montre que JSON-LD excelle dans l'integration web et l'interaction avec les developpeurs, tandis que Turtle reste le format de reference pour l'edition humaine et les ontologies. La serialisation programmatique avec contexte compact a revele la puissance de rdflib pour generer du JSON-LD lisible directement depuis un graphe RDF.
 
-Dans le notebook suivant (**SW-10-Python-RDFStar**), nous decouvrirons RDF 1.2 (RDF-Star), une extension majeure de RDF permettant de faire des assertions sur des assertions (quoted triples), ouvrant la voie a des metadonnees sur les relations elles-memes.",,,,,,,,25a814d387952de9,,,,,,,
+Dans le notebook suivant (**SW-10-Python-RDFStar**), nous decouvrirons RDF 1.2 (RDF-Star), une extension majeure de RDF permettant de faire des assertions sur des assertions (quoted triples), ouvrant la voie a des metadonnees sur les relations elles-mêmes.",,,,,,,,1efa6d184ac0d2fd,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,2b59f016,markdown,fr,2ee5807bed88b225,"# Introduction au web sémantique avec RDF.Net
+
+**Navigation** : [Index](../README.md)
+
+> **DEPRECIE** : Ce notebook monolithique a ete remplace par la serie **[SemanticWeb](../README.md)** (13 notebooks, ~10h).
+>
+> La nouvelle serie couvre l'ensemble du spectre du Web sémantique :
+> - **Partie 1** (SW-1 a SW-4) : Fondations RDF avec dotNetRDF (.NET C#)
+> - **Partie 2** (SW-5 a SW-7) : Données Liees, RDFS, OWL (.NET C#)
+> - **Partie 3** (SW-8 a SW-11) : rdflib, SHACL, JSON-LD, RDF 1.2 (Python)
+> - **Partie 4** (SW-12 a SW-13) : Graphes de Connaissances, GraphRAG (Python)
+>
+> Ce notebook est conserve a titre de reference. Pour un apprentissage structure, utilisez la nouvelle serie.",,,,,,,,2ee5807bed88b225,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,8e060626,markdown,fr,93d27fe595d0e7fa,"## A. Présentation des technologies utilisées
+
+### 1. RDF
+
+Le Resource Description Framework, plus connu sous son acronyme RDF, est un standard du World Wide Web Consortium (W3C) qui offre une méthode universelle pour décrire ou modéliser l'information qui est implémentée sur le Web, ou ailleurs.
+
+RDF repose sur la notion de ""triple"" pour représenter les données. Un triple est une déclaration composée de trois parties : un sujet, un prédicat et un objet. Par exemple, dans la déclaration ""Paris est la capitale de la France"", ""Paris"" est le sujet, ""est la capitale de"" est le prédicat, et ""France"" est l'objet.
+
+En utilisant cette structure simple, RDF peut modéliser des informations complexes de manière structurée et interconnectée. Le sujet d'un triple peut être n'importe quelle ressource (par exemple, une personne, un lieu, un événement), le prédicat est une relation ou une propriété de la ressource, et l'objet est soit une autre ressource, soit une valeur (par exemple, une chaîne de caractères, un nombre).
+
+En outre, RDF est le fondement du web sémantique, une vision du web où les informations sont non seulement disponibles pour les humains à lire, mais aussi pour les machines à comprendre et à traiter.
+
+---
+
+### 2. RDF.Net
+
+RDF.Net est une bibliothèque C# pour travailler avec le format de données RDF (Resource Description Framework), qui est un standard du World Wide Web Consortium (W3C) pour le web sémantique. Il permet aux développeurs de manipuler les données RDF, de créer et d'interroger des graphes RDF, et de serialiser ces graphes dans différents formats de syntaxe RDF.
+
+La bibliothèque RDF.Net est basée sur plusieurs concepts clés qui définissent son fonctionnement et sa structure. Les classes principales se trouvent dans l'espace de noms VDS.RDF et sont basées sur des interfaces ou des classes abstraites pour garantir une extensibilité maximale. Parmi ces interfaces, nous retrouvons :
+
+- `INode` : représentant un nœud dans un graphe RDF, qui représente la valeur d'un terme RDF.
+- `IGraph` : l'interface pour les graphes. Un document RDF forme un graphe au sens mathématique. Nous représentons donc des ensembles de Triples comme des graphes.
+- `ITripleStore` : Un Triple Store est une collection de un ou plusieurs graphes.
+
+---
+
+#### a) Graphes
+
+Un document RDF peut être considéré comme formant un graphe mathématique. Nous représentons donc des ensembles de triples RDF comme des graphes. Tous les graphes de la bibliothèque sont des implémentations de l'interface `IGraph` et dérivent généralement de la classe abstraite `BaseGraph`. Une implémentation `IGraph` est une représentation en mémoire d'un document RDF.
+
+---
+
+#### b) Noeuds
+
+Un `INode` représente un nœud dans un graphe RDF, ce qui est parfois appelé un terme RDF. Il existe plusieurs types de nœuds, chacun représenté par une interface spécialisée, comme `IBlankNode` pour un nœud anonyme, `ILiteralNode` pour un nœud avec une valeur textuelle, ou encore `IUriNode` pour un nœud URI.
+
+---
+
+#### c) Triples
+
+Un Triple est l'unité de base des données RDF, les nœuds à eux seuls n'ont pas de signification, mais utilisés dans un Triple, ils forment une déclaration qui exprime une connaissance. Un Triple est formé d'un Sujet, d'un Prédicat et d'un Objet. Il est interprété comme déclarant qu'un certain Sujet est lié à un certain Objet par une relation spécifiée par le Prédicat.
+
+---
+
+#### d) Triple Store
+
+Un Triple Store représente une collection de Graphes et est utilisé pour travailler avec de grandes quantités de RDF. Les Triple Stores sont conçus pour être moins tangibles que les Graphes en termes d'interface et d'implémentations.
+
+---
+
+### 3. DBpedia
+
+DBpedia est un projet qui extrait des données structurées à partir de Wikipedia et les rend disponibles sur le Web sous forme de données RDF. DBpedia permet aux utilisateurs de requêter les données de Wikipedia comme une base de données sémantique, fournissant une source précieuse de connaissances pour les applications du Web sémantique.
+
+### 4. Trinity RDF
+
+Trinity RDF est un wrapper pour RDF.Net qui utilise Entity Framework, une technologie de Microsoft pour accéder à des bases de données relationnelles en utilisant des modèles d'objet .NET. Trinity RDF offre une abstraction de haut niveau pour manipuler les données RDF, rendant l'utilisation de RDF plus facile et plus intuitive pour les développeurs .NET.
+
+### 5. Jena Fuseki
+
+Jena Fuseki est un serveur de triplestore open-source qui permet de stocker et de requêter des données RDF. Il prend en charge le langage de requête SPARQL et offre une interface utilisateur Web pour gérer les données RDF.
+
+---
+
+## B. Introduction à RDF et Sparql avec RDF.Net
+
+### 1. Hello World avec RDF.Net
+
+Construisons une application simple en utilisant RDF.Net.
+
+#### a) Ajout des packages nécessaires
+",,,,,,,,93d27fe595d0e7fa,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,a6fb499a,code,fr,0b62c0bb34d14207,"// Pour installer RDF.Net
+#r ""nuget: dotNetRDF""",,,,,,,,0b62c0bb34d14207,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,4f5a091e,markdown,fr,598a33ac540244e8,"#### Objectifs de cette section
+
+Dans cette première demonstration, nous allons :
+- Installer la bibliotheque dotNetRDF
+- Créer notre premier graphe RDF en memoire
+- Définir des triplets (sujet-predicat-objet)
+- Serialiser le graphe dans différents formats (NTriples, RDF/XML)
+
+> **Note technique** : dotNetRDF utilise l'interface `IGraph` pour representer un graphe RDF, qui est essentiellement une collection de triplets.",,,,,,,,598a33ac540244e8,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,ff399942,markdown,fr,26aa38b7506d888a,"#### b) Création d'un graphe
+
+La première chose que nous voulons faire est de créer un graphe comme ceci :",,,,,,,,26aa38b7506d888a,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,a9c4cffb,code,fr,47782953aa1dfa58,"using VDS.RDF;
+
+IGraph g = new Graph();
+Console.WriteLine($""Graphe RDF crée : {g.GetHashCode()}, {g.Triples.Count} triplets"");",,,,,,,,47782953aa1dfa58,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,4b23066f,markdown,fr,9c0dcbaf24f4672a,"#### Interpretation
+
+A ce stade, nous avons créé un **graphe vide**. Un graphe RDF est une structure de données qui contiendra des triplets.
+
+| Propriete | Valeur actuelle |
+|-----------|----------------|
+| Nombre de triplets | 0 |
+| URI de base | null (par defaut) |
+| Espaces de noms | Predefinis (rdf, rdfs, xsd) |
+
+Le graphe est pret a recevoir des triplets que nous allons ajouter dans la cellule suivante.",,,,,,,,9c0dcbaf24f4672a,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,74be3266,markdown,fr,d54ada65d481480f,"Nous utilisons ici la classe `Graph` qui est l'implémentation la plus couramment utilisée de l'interface `IGraph`.
+
+Ensuite, nous voulons créer des nœuds et affirmer des triplets dans le graphe, comme ceci :",,,,,,,,d54ada65d481480f,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,cd5622e7,code,fr,03508dbdeef09085,"using VDS.RDF;
+using System;
+
+IGraph g = new Graph();
+
+IUriNode dotNetRDF = g.CreateUriNode(UriFactory.Create(""http://www.dotnetrdf.org""));
+IUriNode says = g.CreateUriNode(UriFactory.Create(""http://example.org/says""));
+ILiteralNode helloWorld = g.CreateLiteralNode(""Hello World"");
+ILiteralNode bonjourMonde = g.CreateLiteralNode(""Bonjour tout le Monde"", ""fr"");
+
+g.Assert(new Triple(dotNetRDF, says, helloWorld));
+g.Assert(new Triple(dotNetRDF, says, bonjourMonde));
+Console.WriteLine($""Noeuds créés : dotNetRDF={dotNetRDF}, says={says}"");
+Console.WriteLine($""Littéraux : helloWorld={helloWorld}, bonjourMonde={bonjourMonde}"");
+Console.WriteLine($""Triplets ajoutés au graphe : {g.Triples.Count}"");",,,,,,,,03508dbdeef09085,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,dc380130,markdown,fr,e2b218d1f64973bd,"#### Explication des types de noeuds
+
+Le code précédent illustre les **trois types de noeuds** RDF :
+
+| Type de noeud | Classe | Exemple | Usage |
+|---------------|--------|---------|-------|
+| **URI Node** | `IUriNode` | `http://www.dotnetrdf.org` | Identifiant de ressource (sujet/predicat) |
+| **Literal Node** | `ILiteralNode` | `""Hello World""` | Valeur textuelle ou numérique (objet) |
+| **Literal avec langue** | `ILiteralNode` | `""Bonjour""@fr` | Valeur avec indication de langue |
+
+**Structure des triplets crees** :
+```
+<http://www.dotnetrdf.org> <http://example.org/says> ""Hello World""
+<http://www.dotnetrdf.org> <http://example.org/says> ""Bonjour tout le Monde""@fr
+```
+
+> **Point cle** : La méthode `g.Assert()` ajoute un triplet au graphe. Chaque triplet exprime une relation : ""dotNetRDF dit Hello World"".",,,,,,,,e2b218d1f64973bd,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,b4f415ee,markdown,fr,3034f6b4e31ba687,"Comme indiqué dans la Présentation de la bibliothèque, nous utilisons la méthode `UriFactory.Create()` pour créer des URIs, car cela internera les URIs pour nous, ce qui réduit à la fois l'utilisation de la mémoire et accélère les comparaisons d'égalité.
+
+Une fois que nous avons fait cela, nous pouvons afficher les triplets dans la console :",,,,,,,,3034f6b4e31ba687,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,fe5ad334,code,fr,ce94b3588a913199,"using VDS.RDF;
+using System;
+
+foreach (Triple t in g.Triples)
+{
+    Console.WriteLine(t.ToString());
+}
+Console.ReadLine();",,,,,,,,ce94b3588a913199,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,0519a8bb,markdown,fr,21ccec300f2b8553,"#### Interpretation de la sortie
+
+La sortie affichée utilise une **representation simplifiee** des triplets, utile pour le debogage mais **pas une syntaxe RDF standard**.
+
+Format attendu (approximatif) :
+```
+[http://www.dotnetrdf.org , http://example.org/says , Hello World]
+[http://www.dotnetrdf.org , http://example.org/says , Bonjour tout le Monde@fr]
+```
+
+> **Attention** : Cette representation n'est pas valide selon les standards RDF (NTriples, Turtle, RDF/XML). Pour obtenir une serialisation conforme, nous devons utiliser un **Writer** specialise.",,,,,,,,21ccec300f2b8553,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,3146fda4,markdown,fr,fcc3cd79a4bccdf3,"Ceux d'entre vous qui connaissent RDF remarqueront que ce qui précède n'est pas une syntaxe RDF valide - il s'agit simplement d'une représentation ultra simple des triplets et est principalement destinée au débogage. Si nous voulons réellement générer une syntaxe RDF, nous devons utiliser l'une des classes de l'espace de noms `VDS.RDF.Writing`. Tout d'abord, nous allons générer la sortie ci-dessus au format NTriples :",,,,,,,,fcc3cd79a4bccdf3,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,2cfc7bd7,code,fr,bcdd937c300fef17,"using StringWriter = System.IO.StringWriter;
+
+StringWriter sw = new StringWriter();
+var ntwriter = new VDS.RDF.Writing.NTriplesWriter();
+ntwriter.Save(g, sw);
+
+string ntriples = sw.ToString();
+ntriples.Display();",,,,,,,,bcdd937c300fef17,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,8808d31c,markdown,fr,cd50aea15a483903,"#### Interpretation du format NTriples
+
+**NTriples** est le format RDF le plus simple et le plus verbeux. Chaque ligne represente un triplet complet avec URIs et literals explicites.
+
+Format de sortie attendu :
+```
+<http://www.dotnetrdf.org> <http://example.org/says> ""Hello World"" .
+<http://www.dotnetrdf.org> <http://example.org/says> ""Bonjour tout le Monde""@fr .
+```
+
+**Caractéristiques de NTriples** :
+- Une ligne = un triplet
+- URIs toujours entre chevrons `< >`
+- Literals entre guillemets `"" ""`
+- Chaque triplet se termine par un point `.`
+- Pas d'abreviations ni de prefixes
+
+> **Avantage** : Format simple, facile a parser, ideal pour l'echange de données volumineuses.",,,,,,,,cd50aea15a483903,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,733051d1,markdown,fr,ddc7f4fe9edeebe4,"Si nous voulons enregistrer le graphe dans une autre syntaxe RDF, nous pouvons le faire également, par exemple :",,,,,,,,ddc7f4fe9edeebe4,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,b7009887,code,fr,7f1ab4d4933a2d57,"using VDS.RDF.Writing;
+using System.IO;
+
+StringWriter sw = new StringWriter();
+RdfXmlWriter rdfxmlwriter = new RdfXmlWriter();
+rdfxmlwriter.Save(g, sw);
+
+string rdfxml = sw.ToString();
+rdfxml.Display();",,,,,,,,7f1ab4d4933a2d57,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,b4269e81,markdown,fr,9fc0769a847365e0,"#### Comparaison NTriples vs RDF/XML
+
+Le format **RDF/XML** est plus structure et utilise des espaces de noms pour reduire la verbosity.
+
+| Caractéristique | NTriples | RDF/XML |
+|-----------------|----------|---------|
+| **Lisibilite humaine** | Moyenne | Faible (XML verbose) |
+| **Compacite** | Faible | Moyenne (avec prefixes) |
+| **Parsing** | Très simple | Plus complexe |
+| **Espaces de noms** | Non | Oui (`xmlns:rdf`, `xmlns:ns0`) |
+| **Usage** | Dump de données | Integration XML |
+
+**Espaces de noms generes automatiquement** :
+- `rdf:` - Resource Description Framework
+- `rdfs:` - RDF Schema
+- `xsd:` - XML Schema Datatypes
+- `ns0:`, `ns1:` - Prefixes temporaires generes par le writer
+
+> **Point cle** : RDF.Net genere automatiquement des prefixes `nsX` pour les URIs non declarees dans les espaces de noms.",,,,,,,,9fc0769a847365e0,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,58ec71ba,markdown,fr,b7693579defc1623,"Remarquez que le RDF/XML Writer connaissait déjà les espaces de noms RDF, RDFS et XML Schema. Ces espaces de noms sont fournis par défaut pour la plupart des implémentations de `IGraph`. Le Writer génère également des espaces de noms temporaires de la forme `nsX` pour les URIs qu'il ne peut pas représenter autrement dans RDF/XML.",,,,,,,,b7693579defc1623,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,9e4639ca,markdown,fr,b68c6ad2603ae3e2,"### Conclusion : Premier programme RDF
+
+Nous venons de créer notre premier programme RDF complet qui :
+
+| Étape | Accomplissement |
+|-------|----------------|
+| 1. Creation | Graphe vide initialise |
+| 2. Peuplement | 2 triplets ajoutes (même sujet, même predicat, objets différents) |
+| 3. Serialisation | Exportation en NTriples et RDF/XML |
+
+**Concepts cles maitrises** :
+- Interface `IGraph` pour la manipulation de graphes
+- Types de noeuds : `IUriNode`, `ILiteralNode`
+- Méthode `Assert()` pour ajouter des triplets
+- Writers pour la serialisation (`NTriplesWriter`, `RdfXmlWriter`)
+
+Dans la section suivante, nous allons apprendre a **lire du RDF** depuis différentes sources.",,,,,,,,b68c6ad2603ae3e2,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,7fa45731,markdown,fr,6ed40edd2f6aa75d,"### 2. Lecture de RDF avec RDF.Net
+
+L'une des principales choses que vous voudrez faire lorsque vous travaillez avec RDF est de pouvoir le lire à partir de fichiers, d'URI et d'autres sources afin de pouvoir l'utiliser avec dotNetRDF. Toutes les classes liées à cela sont contenues dans l'espace de noms `VDS.RDF.Parsing`. Ainsi, lorsque vous voulez lire du RDF, vous aurez besoin des déclarations suivantes au début de votre fichier de code :",,,,,,,,6ed40edd2f6aa75d,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,0fd291ec,code,fr,84d74b7d0b35090a,"using VDS.RDF;
+using VDS.RDF.Parsing;
+Console.WriteLine(""Imports OK : VDS.RDF, VDS.RDF.Parsing"");",,,,,,,,84d74b7d0b35090a,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,6d69cb1f,markdown,fr,8b2ff1e2cfdfc206,"#### Ce que nous allons apprendre
+
+Dans cette section, nous decouvrirons comment **charger du RDF** depuis diverses sources :
+
+1. **Fichiers locaux** - Lecture depuis le disque (Turtle, RDF/XML, etc.)
+2. **URIs distantes** - Chargement depuis le web (negociation de contenu)
+3. **Chaînes de caractères** - Parsing direct de fragments RDF
+4. **Flux** - Lecture depuis `StreamReader` ou `TextReader`
+
+> **Point important** : dotNetRDF supporte **9+ formats RDF** différents, avec detection automatique du format dans certains cas.",,,,,,,,8b2ff1e2cfdfc206,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,076adfae,markdown,fr,772db162bf931f6d,"dotNetRDF prend actuellement en charge la lecture de fichiers RDF dans toutes les sérialisations RDF suivantes :
+- NTriples
+- Turtle
+- Notation 3
+- RDF/XML
+- RDF/JSON (spécification Talis)
+- RDFa 1.0 (prise en charge limitée de RDFa 1.1)
+- TriG (Turtle avec des graphes nommés)
+- TriX (Graphes nommés en XML)
+- NQuads (NTriples avec contexte)
+- JSON-LD (1.0 et 1.1)
+
+Plusieurs de ces sérialisations ont plusieurs variantes avec des règles de syntaxe différentes. Pour un résumé complet des formats pris en charge pour l'écriture avec dotNetRDF, consultez les formats pris en charge par dotNetRDF.
+
+---
+
+#### a) Parsers de graphe
+
+Les parsers de graphe implémentent l'interface `IRdfReader` qui définit une méthode `Load(...)` prenant un objet `IGraph` ou `IRdfHandler` ainsi qu'un `TextReader`, `StreamReader` ou une chaîne de caractères. L'utilisation de base est la suivante :",,,,,,,,772db162bf931f6d,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,8e070ef2,code,fr,8a719265ec14378a,"using VDS.RDF.Parsing;
+
+IGraph g = new Graph();
+IGraph h = new Graph();
+
+TurtleParser ttlparser = new TurtleParser();
+ttlparser.Load(g, ""Example.ttl"");
+
+// Chargement à partir d un StreamReader
+ttlparser.Load(h, new StreamReader(""Example.ttl""));
+Console.WriteLine($""Turtle parsé : g={g.Triples.Count} triplets, h={h.Triples.Count} triplets"");",,,,,,,,8a719265ec14378a,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,7eefafa9,markdown,fr,2e9d8b1819fc9517,"#### Explication du code de lecture
+
+Le code précédent illustre deux approches de lecture :
+
+| Approche | Classe | Reutilisable | Usage |
+|----------|--------|--------------|-------|
+| **Parser spécifique** | `TurtleParser`, `RdfXmlParser` | Oui | Format connu a l'avance |
+| **Detection automatique** | `FileLoader` | N/A | Format inconnu |
+
+**Avantages des parsers reutilisables** :
+- Une seule instance peut charger plusieurs fichiers
+- Configuration possible (validation stricte, gestion d'erreurs)
+- Performance optimisee pour le parsing de masse
+
+> **Bonne pratique** : Utiliser un parser spécifique si le format est connu, sinon utiliser `FileLoader` pour la detection automatique.",,,,,,,,2e9d8b1819fc9517,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,651a2da4,markdown,fr,2d853b54ef13c3c1,"Dans l'exemple ci-dessus, les parsers sont réutilisables. Une fois instanciés, vous pouvez les utiliser autant de fois que nécessaire. Une autre fonctionnalité utile est que les parsers sont conçus pour être thread-safe, de sorte que plusieurs threads peuvent utiliser la même instance d'un parser pour analyser simultanément différentes entrées sans interférer les uns avec les autres. Les parsers sont généralement capables de générer des exceptions de type `RdfParseException` et `RdfException`, il est donc recommandé d'utiliser des blocs `try/catch` autour de l'utilisation des parsers.
+
+---
+
+#### b) Lecture de RDF à partir de sources courantes
+
+Il n'est souvent pas nécessaire d'invoquer directement un parser, car vous pouvez utiliser une classe d'aide pour obtenir le même effet sans avoir à créer le parser approprié vous-même. Les sous-sections suivantes détaillent les classes d'aide disponibles pour la lecture de RDF. Notez que plusieurs des sources détaillées ici disposent également de méthodes d'extension d'aide qui permettent de simplifier davantage les exemples de code présentés ici.
+
+##### (1) Lecture de RDF à partir de fichiers
+
+Si vous souhaitez simplement lire rapidement du RDF à partir d'un fichier sans avoir à décider du parser nécessaire, vous pouvez utiliser la classe statique `FileLoader` qui fournit une méthode `Load(IGraph g, String file)` :
+
+```csharp
+IGraph g = new Graph();
+FileLoader.Load(g, ""somefile.rdf"");
+```
+
+Le `FileLoader` essaiera de sélectionner le parser correct en fonction de l'extension du fichier. S'il ne parvient pas à déterminer le format à l'aide de l'extension du fichier, il utilisera la classe `StringParser` qui tente de détecter le format à l'aide de heuristiques simples. Vous pouvez également forcer le loader à utiliser un parser spécifique en utilisant la forme à 3 arguments `Load(IGraph g, String file, IRdfReader parser)`.
+
+##### (2) Lecture de RDF à partir d'URIs
+
+Il est souvent nécessaire de lire du RDF à partir d'une URI. Pour ce faire, nous fournissons la classe `Loader` qui offre une méthode `LoadGraph(IGraph g, Uri u)`.",,,,,,,,2d853b54ef13c3c1,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,8e74c123,code,fr,fc3725271301f2fa,"using VDS.RDF.Parsing;
+
+// Chargement de donnees depuis DBpedia
+// Note: data.dbpedia.org permet la negociation de contenu RDF
+IGraph g = new Graph();
+Loader loader = new Loader();
+
+try
+{
+    // Utiliser data.dbpedia.org qui supporte la negociation de contenu RDF
+    var uri = new Uri(""http://data.dbpedia.org/resource/Barack_Obama"");
+    loader.LoadGraph(g, uri);
+    Console.WriteLine($""Graphe charge avec succes: {g.Triples.Count} triples"");
+}
+catch (Exception ex)
+{
+    // Fallback: essayer de charger un fichier RDF local ou un exemple simple
+    Console.WriteLine($""Note: Impossible de charger depuis DBpedia ({ex.Message})"");
+    Console.WriteLine(""Creation d'un graphe d'exemple local..."");
+    
+    // Creer un graphe d'exemple simple
+    g.BaseUri = new Uri(""http://example.org/"");
+    IUriNode subject = g.CreateUriNode(new Uri(""http://example.org/Barack_Obama""));
+    IUriNode predicate = g.CreateUriNode(new Uri(""http://www.w3.org/1999/02/22-rdf-syntax-ns#type""));
+    IUriNode obj = g.CreateUriNode(new Uri(""http://dbpedia.org/ontology/Person""));
+    g.Assert(new Triple(subject, predicate, obj));
+    
+    predicate = g.CreateUriNode(new Uri(""http://xmlns.com/foaf/0.1/name""));
+    ILiteralNode name = g.CreateLiteralNode(""Barack Obama"");
+    g.Assert(new Triple(subject, predicate, name));
+    
+    Console.WriteLine($""Graphe d'exemple cree avec {g.Triples.Count} triples"");
+}
+
+Console.WriteLine(""\nApercu des premiers triples:"");
+foreach (Triple t in g.Triples.Take(5))
+{
+    Console.WriteLine(t.ToString());
+}",,,,,,,,fc3725271301f2fa,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,42d93bc1,markdown,fr,0df55c04e0dfcec0,"#### Precautions avec le chargement distant
+
+Le code précédent charge des données **depuis DBpedia** (Wikipedia sémantique). Points d'attention :
+
+**Risques potentiels** :
+- Le service DBpedia peut etre **indisponible** (erreur 503, timeout)
+- Les redirections HTTP peuvent compliquer le chargement
+- La negociation de contenu RDF depend des headers HTTP
+
+**Gestion recommandee** :
+```csharp
+try {
+    var loader = new Loader(httpClient);
+    loader.LoadGraph(g, new Uri(""http://dbpedia.org/resource/...""));
+} catch (Exception ex) {
+    Console.WriteLine($""Erreur de chargement: {ex.Message}"");
+}
+```
+
+> **Note** : Le code inclus utilise un try/catch pour gerer les erreurs DBpedia (service parfois instable).",,,,,,,,0df55c04e0dfcec0,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,3fa24d8d,markdown,fr,83f05b76f5798ea5,"La classe `Loader` utilise une instance `HttpClient` pour effectuer des requêtes web et propose un constructeur qui vous permet de passer l'instance `HttpClient` configurée à utiliser. La méthode `LoadGraph` sélectionnera automatiquement le parser approprié en fonction de l'en-tête `Content-Type` de la réponse HTTP. En plus des erreurs normalement générées par les parsers, le `Loader` peut également générer une `RdfException` si l'URI d'entrée n'est pas valide ou une `HttpRequestException` si une erreur se produit lors de la récupération de l'URI via HTTP. Vous pouvez également forcer le loader à utiliser un parser spécifique en utilisant la forme à 3 arguments `LoadGraph(IGraph g, Uri u, IRdfReader parser)`. La classe propose également des variantes asynchrones de ces méthodes.
+
+Par défaut, à la fois le `HttpClient .NET` et la classe `Loader` de dotNetRDF prennent en charge le suivi des redirections HTTP. Cependant, en raison de certaines restrictions et différences interplates-formes concernant le suivi automatique des redirections par le `HttpClient .NET`, la classe `Loader` implémente sa propre prise en charge des redirections en plus des redirections suivies par le `HttpClient`. Cette gestion supplémentaire des redirections peut être désactivée en définissant `FollowRedirects` sur `false`. Pour désactiver complètement toutes les redirections automatiques, vous devez également passer une instance `HttpClient` configurée pour ne pas suivre les redirections, comme suit :",,,,,,,,83f05b76f5798ea5,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,a14f3eac,code,fr,d6060ff7c7116197,"using System.Net.Http;
+// Création d un HttpClient configuré pour ne pas suivre les redirections
+HttpClient noRedirectClient = new HttpClient(new HttpClientHandler() { AllowAutoRedirect = false });
+
+// Création d un Loader également configuré pour ne pas suivre les redirections
+Loader loader = new Loader(noRedirectClient) { FollowRedirects = false };
+Console.WriteLine(""HttpClient et Loader configurés (pas de redirection automatique)"");",,,,,,,,d6060ff7c7116197,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,fae8e1e5,markdown,fr,cb8a61d897ad8d37,"Attention : avant dotNetRDF 3.0, cette fonctionnalité était fournie par la classe `UriLoader` statique, qui était implémentée à l'aide de l'ancienne API `System.Net.HttpWebRequest`. Cette classe a été conservée dans la version 3.0, mais est maintenant considérée comme obsolète et le code doit être mis à jour pour utiliser la classe `Loader` à la place.
+
+##### (3) Lecture de RDF à partir de ressources intégrées
+
+Si vous choisissez d'intégrer des fichiers RDF dans vos assemblys, vous pouvez les lire en utilisant la classe statique `EmbeddedResourceLoader`, qui fournit une méthode `Load(IGraph g, String resource)`.
+
+```csharp
+Graph g = new Graph();
+EmbeddedResourceLoader.Load(g, ""Your.Namespace.EmbeddedFile.n3, YourAssembly"");
+```
+
+Notez que le nom de ressource doit être un nom qualifié d'assembly. Comme pour les autres loaders, cela tente de sélectionner le parser correct en fonction du nom de ressource. Vous pouvez également forcer le loader à utiliser un parser
+
+ spécifique en utilisant la forme à 3 arguments `Load(IGraph g, String resourceName, IRdfReader parser)`.
+
+##### (4) Lecture de RDF à partir de chaînes de caractères
+
+Il peut arriver que vous ayez un fragment de RDF dans une chaîne de caractères que vous souhaitez analyser. Pour cela, vous pouvez utiliser la classe statique `StringParser` et sa méthode `Parse(IGraph g, String data)`.",,,,,,,,cb8a61d897ad8d37,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,01599fcf,code,fr,4e8a892401d70f1e,"Graph g = new Graph();
+StringParser.Parse(g, ""<http://example.org/a> <http://example.org/b> <http://example.org/c>."");
+g.Display();",,,,,,,,4e8a892401d70f1e,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,34ffbb92,markdown,fr,4a44dd28bf220516,"#### Interpretation du parsing de chaîne
+
+La méthode `StringParser.Parse()` utilise des **heuristiques** pour detecter le format RDF :
+
+| Format detecte | Indices utilises |
+|----------------|------------------|
+| **NTriples** | Presence de `< >` et `.` en fin de ligne |
+| **Turtle** | Prefixes `@prefix`, abreviations `:` |
+| **RDF/XML** | Balises `<rdf:RDF>` |
+| **JSON-LD** | Structure JSON avec `@context` |
+
+**Fragment parse dans l'exemple** :
+```
+<http://example.org/a> <http://example.org/b> <http://example.org/c>.
+```
+- **Format** : NTriples (URIs completes, point final)
+- **Triplet** : `a --(b)--> c`
+
+> **Limite** : Les heuristiques peuvent echouer sur des fragments ambigus. Preferer un parser spécifique pour plus de fiabilite.",,,,,,,,4a44dd28bf220516,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,3d0e062e,markdown,fr,ed82bbdd1d78a053,"Le `StringParser` utilise des heuristiques simples pour essayer de déterminer le format du fragment RDF qui lui est passé.
+
+##### (5) Lecture de RDF à partir d'une chaîne de caractères (méthode alternative)
+
+Alternativement, puisque vous pouvez lire du RDF à partir de n'importe quel `TextReader`, vous pouvez simplement invoquer un parser sur une chaîne de caractères directement en utilisant un `StringReader`, par exemple :
+",,,,,,,,ed82bbdd1d78a053,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,649b94d6,code,fr,5633b44296b4135b,"Graph g = new Graph();
+NTriplesParser parser = new NTriplesParser();
+parser.Load(g, new StringReader(""<http://example.org/a> <http://example.org/b> <http://example.org/c>.""));
+Console.WriteLine($""NTriples parsé : {g.Triples.Count} triplets chargés"");",,,,,,,,5633b44296b4135b,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,6c936e8c,markdown,fr,d08c67aea64a97f0,"#### Comparaison StringParser vs Parser direct
+
+| Méthode | Avantage | Inconvenient |
+|---------|----------|--------------|
+| **StringParser** | Detection automatique | Peut echouer sur formats ambigus |
+| **Parser + StringReader** | Format explicite | Necessite de connaitre le format |
+
+**StringReader** : Classe .NET qui transforme une chaîne en flux (`TextReader`), permettant au parser de lire comme depuis un fichier.
+
+```csharp
+// Equivalent conceptuel
+string data = ""..."";
+StringReader reader = new StringReader(data);
+parser.Load(g, reader);  // Lit depuis le flux memoire
+```
+
+> **Quand utiliser StringReader** : Lorsque vous avez du RDF en memoire (variable, reponse HTTP, etc.) et que vous connaissez le format exact.",,,,,,,,d08c67aea64a97f0,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,278aa404,markdown,fr,4ae2bfd9c137829c,"Cela est approximativement équivalent à la façon dont fonctionne `StringParser` en interne, mais cette méthode nécessite de connaître le format du RDF à l'avance.
+
+---
+
+#### c) Variantes de sérialisation
+
+Plusieurs des sérialisations RDF prises en charge ont plusieurs variantes avec des règles de syntaxe différentes. Lorsque plusieurs variantes sont prises en charge, dotNetRDF utilisera par défaut la variante la plus récente pour l'entrée, mais utilisera le format le plus conservateur pour la sortie (ce qui est souvent, mais pas toujours, la plus ancienne variante).
+
+Cependant, dans certains cas, vous voudrez décider directement de la variante syntaxique à utiliser. Dans ce cas, vous construisez généralement un parser et fournissez une valeur de l'énumération de syntaxe appropriée, par exemple :
+
+```csharp
+// Création d'un parser NTriples qui utilise la syntaxe plus ancienne et plus stricte
+NTriplesParser parser = new NTriplesParser(NTriplesSyntax.Original);
+```
+
+Consultez la documentation spécifique d'un parser pour savoir si des variantes de sérialisation sont prises en charge.
+
+---
+
+#### d) Configuration des parsers
+
+Certains parsers ont une configuration supplémentaire qui peut être utilisée pour modifier leur comportement. Par exemple, si un parser implémente l'interface `ITraceableTokeniser`, la propriété `TraceTokeniser` peut être utilisée pour demander la sortie des informations de trace du tokeniseur dans la console. De même, si un parser implémente `ITraceableParser`, la propriété `TraceParsing` peut être utilisée pour demander la sortie des informations de trace du parsing. Ces fonctionnalités sont souvent utiles lors du débogage pour comprendre pourquoi un document RDF échoue à être analysé, car vous pouvez voir comment l'entrée est tokenisée et analysée.
+
+De plus, certains parsers vous permettent de les instancier avec un `TokenQueueMode`. Cela contrôle le type de file utilisée dans le processus de tokenisation et peut potentiellement affecter la vitesse de l'analyse (bien que dans la plupart des cas, il y ait peu de différence). Les modes disponibles sont les suivants :
+- `TokenQueueMode.QueueAllBeforeParsing` : le fichier entier est tokenisé avant que l'analyse ne commence.
+- `TokenQueueMode.SynchronousBufferDuringParsing` : le fichier est tokenisé au fur et à mesure que l'analyse progresse, un nombre limité de tokens est généré et mis en mémoire tampon à chaque fois que le parser demande un token.
+- `TokenQueueMode.AsynchronousBufferDuringParsing` : le fichier est tokenisé en arrière-plan pendant que l'analyse progresse. Si le parser demande un token et que le tokeniseur n'a pas encore produit suffisamment de tokens, le parser doit attendre qu'un token soit disponible.
+
+---
+
+#### e) Parsers de stockage
+
+Les parsers de stockage diffèrent des parsers de graphe en ce sens que l'entrée qu'ils analysent peut contenir plusieurs graphes, de sorte que leur sortie est en réalité un triple store plutôt qu'un seul graphe. Vous verrez souvent les parsers de stockage appelés parsers de jeux de données RDF.
+
+Les parsers de stockage implémentent l'interface `IStoreReader`, qui définit une méthode similaire à l'interface `IRdfReader` prenant un `ITripleStore` ou un `IRdfHandler` ainsi qu'un `TextReader`, `StreamReader` ou une chaîne de caractères. Un parser de stockage peut être utilisé comme suit :
+
+```csharp
+TripleStore store = new TripleStore();
+TriGParser trigparser = new TriGParser();
+
+// Chargement du store
+trigparser.Load(store, ""Example.trig"");
+```
+
+Comme pour les parsers de graphe, diverses exceptions peuvent être générées.
+
+---
+
+#### f) Lecture de jeux de données RDF à partir de sources courantes
+
+De la même manière que pour les parsers de graphe, les parsers de stockage peuvent tous être invoqués indirectement avec différentes méthodes des classes `EmbeddedResourceLoader`, `FileLoader`, `StringParser` et `Loader`. Consultez la documentation de l'API de ces classes pour les surcharges pertinentes.
+
+---
+
+#### g) Analyse avancée
+
+Les exemples que nous avons montrés jusqu'à présent utilisent un modèle d'analyse abstrait où vous analysez directement vers une instance de `IGraph` ou `ITripleStore`. L'inconvénient de cela est que vous devez attendre que votre opération d'analyse soit terminée avant de pouvoir travailler avec les données analysées, et que pour des entrées très volumineuses, cela peut prendre beaucoup de temps ou épuiser la mémoire disponible.
+
+En interne, notre sous-système d'analyse est entièrement basé sur les flux et est exposé via les surcharges basées sur l'interface `IRdfHandler` des méthodes pertinentes. Cela vous permet d'avoir un contrôle beaucoup plus précis sur ce qui est fait avec les données analysées, par exemple en les traitant de manière orientée flux.
+
+Dans les exemples donnés jusqu'à présent, vous avez seulement pu analyser du RDF dans une instance de `IGraph` ou `ITripleStore`, mais ce n'est pas votre seule option. Vous pouvez utiliser un `IRdfHandler` pour contrôler explicitement ce qui se passe avec le RDF que vous analysez. En utilisant l'une des implémentations incluses, vous devrez ajouter la déclaration `using` suivante :",,,,,,,,4ae2bfd9c137829c,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,3548a5bc,code,fr,0b42caab5d46e973,"using VDS.RDF.Parsing.Handlers;
+Console.WriteLine(""Import OK : VDS.RDF.Parsing.Handlers"");",,,,,,,,0b42caab5d46e973,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,f001d8bb,markdown,fr,c4b4cbf4798cdd8b,"### Lecture avancee avec Handlers
+
+Les **Handlers** permettent de traiter les triplets RDF **au fur et a mesure** de leur lecture, sans charger tout le graphe en memoire.
+
+**Cas d'usage** :
+- Fichiers RDF volumineux (plusieurs Go)
+- Comptage de triplets sans stockage
+- Filtrage a la volee
+- Transformation en pipeline
+
+```csharp
+// Au lieu de :
+IGraph g = new Graph();
+parser.Load(g, ""huge-file.ttl"");  // Charge TOUT en memoire
+
+// On peut faire :
+CountHandler handler = new CountHandler();
+parser.Load(handler, ""huge-file.ttl"");  // Compte sans stocker
+Console.WriteLine($""Triplets: {handler.Count}"");
+```
+
+> **Performance** : Les handlers evitent la creation d'objets `INode` et `Triple`, reduisant drastiquement l'empreinte memoire.",,,,,,,,c4b4cbf4798cdd8b,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,f25b7fff,markdown,fr,97a75c758d7ac860,"Par exemple, vous voudrez peut-être simplement compter les triples sans vous soucier des valeurs réelles, vous pouvez alors utiliser un `CountHandler` pour cela :
+
+```csharp
+// Création d'un gestionnaire et utilisation pour l'analyse
+CountHandler handler = new CountHandler();
+TurtleParser parser = new TurtleParser();
+parser.Load(handler, ""example.ttl"");
+
+// Affichage du compte résultant
+Console.WriteLine(handler.Count + "" triple(s)"");
+```
+
+Il existe plusieurs implémentations incluses qui effectuent différentes opérations, telles que la redirection des triples directement vers un fichier, un triple store natif, etc. Vous pouvez également implémenter votre propre gestionnaire, soit entièrement à partir de zéro, soit en dérivant de `BaseRdfHandler`, comme le font nos propres implémentations, pour obtenir la plupart de l'implémentation gratuitement. Consultez l'API Handlers pour plus de discussions sur ce sujet.
+
+---
+
+#### h) Comportement des parsers
+
+Tous les parsers de graphe fournis dans la bibliothèque se comportent comme suit :
+- Gestion des fichiers/flux :
+  - En cas d'erreur lors de l'analyse, le fichier/flux analysé est fermé.
+  - En cas de réussite de l'analyse, le fichier/flux analysé est fermé.
+- Si l'analyse échoue, le graphe ne contiendra aucun des triples correctement analysés avant l'échec.
+- Si un parser est invité à analyser dans un graphe non vide, le parser analysera d'abord dans un graphe vide, puis fusionnera ce graphe avec le graphe fourni.
+
+Tous les parsers de stockage fournis dans la bibliothèque se comportent comme suit :
+- Gestion des fichiers/flux comme les parsers de graphe.
+- Si le parser produit un graphe qui existe déjà dans le store de destination, une erreur peut se produire en fonction du comportement de ce store lorsque le graphe existe déjà.
+
+---
+
+#### i) Classes de parsers
+
+Voici les classes de parser standard contenues dans la bibliothèque :
+- `JsonLdParser` : JSON-LD
+- `NTriplesParser` : NTriples
+- `Notation3Parser` : Notation 3, Turtle, NTriples, certaines formes de TriG
+- `NQuadsParser` : NQuads, NTriples
+- `RdfAParser` : RDFa 1.0 intégré dans (X)HTML, prise en charge limitée de RDFa 1.1
+- `RdfJsonParser` : RDF/JSON (spécification Talis)
+- `RdfXmlParser` : RDF/XML
+- `TriGParser` : TriG
+- `TriXParser` : TriX
+- `TurtleParser` : Turtle, NTriples
+
+---
+",,,,,,,,97a75c758d7ac860,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,a55f2b49,markdown,fr,985de3cf6a66ed8e,"#### Handlers disponibles dans dotNetRDF
+
+| Handler | Fonction | Usage |
+|---------|----------|-------|
+| **GraphHandler** | Stocke dans un `IGraph` | Lecture normale |
+| **CountHandler** | Compte les triplets | Statistiques |
+| **WriteHandler** | Ecrit directement | Transformation de format |
+| **PagingHandler** | Lit par pages | Traitement par lots |
+| **FilterHandler** | Filtre les triplets | Sélection selective |
+
+**Exemple avance - Pipeline de transformation** :
+```csharp
+// Lire Turtle -> Filtrer -> Ecrire NTriples
+var writer = new NTriplesWriter();
+var writeHandler = new WriteHandler(writer, output);
+var filterHandler = new FilterHandler(writeHandler, triple =>
+    triple.Predicate.ToString().Contains(""name"")
+);
+var ttlParser = new TurtleParser();
+ttlParser.Load(filterHandler, ""input.ttl"");
+```
+
+Ce pipeline lit un fichier Turtle, ne conserve que les triplets avec predicat ""name"", et les ecrit en NTriples.",,,,,,,,985de3cf6a66ed8e,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,743ca08a,markdown,fr,205df9804cacfb1a,"### 3. Écrire du RDF avec .NetRDF
+
+Une fois que vous avez créé un graphe RDF ou que vous l'avez récupéré à partir d'un fichier/URI, vous aurez souvent besoin de l'écrire dans un autre fichier/flux au format RDF de votre choix. Toutes les classes liées à cela sont contenues dans l'espace de noms `VDS.RDF.Writing`. Ainsi, lorsque vous souhaitez écrire du RDF, vous aurez besoin des déclarations suivantes au début de votre fichier de code :
+
+```csharp
+using VDS.RDF;
+using VDS.RDF.Writing;
+```
+
+Actuellement, dotNetRDF prend en charge l'écriture de graphes dans les formats suivants :
+- NTriples
+- Turtle
+- Notation 3
+- RDF/XML
+- RDF/JSON (spécification Talis)
+- XHTML + RDFa
+
+Formats non normalisés :
+- CSV
+- TSV
+
+De plus, les formats suivants sont pris en charge lors de l'écriture d'un Triple Store contenant plusieurs graphes :
+- NQuads
+- TriX
+- TriG
+- JSON-LD
+
+Plusieurs de ces sérialisations ont plusieurs variantes avec des règles de syntaxe différentes.
+
+---
+
+#### a) Utilisation de base
+
+Les classes Writer de dotNetRDF implémentent toutes l'interface `IRdfWriter` qui définit une méthode `Save(...)` prenant un `IGraph`, puis soit un `TextWriter`, soit une chaîne de caractères. L'utilisation de base est la suivante :",,,,,,,,205df9804cacfb1a,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,d8c7b4cb,markdown,fr,a6285d882ce8e1a8,"### Conclusion : Lecture de RDF
+
+Nous avons explore **5 méthodes de chargement RDF** :
+
+| Méthode | Complexite | Flexibilite | Performance |
+|---------|------------|-------------|-------------|
+| Parser spécifique + fichier | Faible | Moyenne | Excellente |
+| FileLoader (auto-detection) | Très faible | Elevee | Bonne |
+| Loader + URI | Faible | Elevee | Variable (reseau) |
+| StringParser | Faible | Elevee | Bonne |
+| Handlers | Moyenne | Maximale | Excellente (gros fichiers) |
+
+**Recommandations** :
+- **Fichiers locaux** : Parser spécifique ou FileLoader
+- **URIs distantes** : Loader avec gestion d'erreurs
+- **Données en memoire** : StringParser ou StringReader
+- **Gros volumes** : Handlers obligatoires
+
+Passons maintenant a l'**ecriture de RDF**.",,,,,,,,a6285d882ce8e1a8,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,c9b6c6c0,code,fr,7294b1f7cfd6fffd,"// On suppose que le graphe à sauvegarder a déjà été chargé dans une variable g
+RdfXmlWriter rdfxmlwriter = new RdfXmlWriter();
+
+// Sauvegarde dans un fichier
+// rdfxmlwriter.Save(g, ""Example.rdf"");
+
+// Sauvegarde dans un flux
+using (System.IO.StringWriter sw = new System.IO.StringWriter())
+{
+    rdfxmlwriter.Save(g, sw);
+    string rdfData = sw.ToString();
+    Console.WriteLine(rdfData);
+}",,,,,,,,7294b1f7cfd6fffd,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,53b4c9de,markdown,fr,a03652e114714889,"Comme pour les Parsers, un Writer est une classe réutilisable qui peut être utilisée autant de fois que vous le souhaitez pour générer des graphes dans des fichiers/flux.
+
+---
+
+#### b) Écriture dans des chaînes de caractères
+
+Il existe deux façons d'écrire du RDF dans des chaînes de caractères. La première consiste à utiliser la classe d'aide `StringWriter` pour générer une chaîne de caractères à partir d'un graphe, par exemple :
+",,,,,,,,a03652e114714889,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,85a646af,code,fr,fb4001043b5d85c9,"RdfXmlWriter rdfxmlwriter = new RdfXmlWriter();
+String data = VDS.RDF.Writing.StringWriter.Write(g, rdfxmlwriter);
+Console.WriteLine($""RDF/XML écrit : {data.Length} caractères"");",,,,,,,,fb4001043b5d85c9,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,7e4deebf,markdown,fr,a9eacd65bfbed251,"La deuxième façon est d'écrire directement dans un `System.IO.StringWriter`, car toutes les instances de `IRdfWriter` peuvent écrire dans n'importe quelle implémentation de `TextWriter`, par exemple :",,,,,,,,a9eacd65bfbed251,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,5b926daf,code,fr,9a6bb23b43ff4eda,"// On suppose que le graphe à sauvegarder a déjà été chargé dans une variable g
+RdfXmlWriter rdfxmlwriter = new RdfXmlWriter();
+System.IO.StringWriter sw = new System.IO.StringWriter();
+
+// Appel de la méthode Save() pour écrire dans StringWriter
+rdfxmlwriter.Save(g, sw);
+
+// Nous pouvons maintenant récupérer le RDF écrit en utilisant la méthode ToString() de StringWriter
+String data = sw.ToString();
+Console.WriteLine(data);",,,,,,,,9a6bb23b43ff4eda,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,fe12a8ba,markdown,fr,a028b2d4dab57d31,"#### Deux approches pour obtenir une chaîne RDF
+
+| Approche | Méthode | Avantage |
+|----------|---------|----------|
+| **Helper StringWriter** | `VDS.RDF.Writing.StringWriter.Write(g, writer)` | Simple, une ligne |
+| **System.IO.StringWriter** | `writer.Save(g, new StringWriter())` | Contrôle total, compatible .NET |
+
+**Différence technique** :
+- La classe helper `VDS.RDF.Writing.StringWriter` encapsule `System.IO.StringWriter`
+- Les deux approches produisent exactement le même résultat
+- La deuxieme méthode permet de reutiliser le `StringWriter` pour d'autres opérations .NET
+
+> **Bonne pratique** : Utiliser la méthode helper pour la simplicite, sauf si vous avez besoin d'integrer avec d'autres APIs .NET utilisant `System.IO.StringWriter`.",,,,,,,,a028b2d4dab57d31,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,0da89a8f,markdown,fr,ec2178215d917fbf,Cette deuxième méthode est essentiellement ce que la bibliothèque fait en interne lorsque vous utilisez notre classe d'aide `StringWriter` comme dans l'exemple précédent.,,,,,,,,ec2178215d917fbf,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,4f6fa9e7,markdown,fr,0f47ed3f1c4f43b5,"### Conclusion : Ecriture de RDF
+
+Recap des **3 méthodes d'ecriture** :
+
+| Méthode | Code | Usage |
+|---------|------|-------|
+| **Fichier** | `writer.Save(g, ""file.rdf"")` | Sauvegarde permanente |
+| **Helper String** | `StringWriter.Write(g, writer)` | Serialisation rapide |
+| **System.IO** | `writer.Save(g, new StringWriter())` | Integration .NET |
+
+**Writers disponibles** (liste partielle) :
+- `NTriplesWriter` - Format simple ligne par ligne
+- `TurtleWriter` - Format compact avec prefixes
+- `RdfXmlWriter` - Standard W3C (XML)
+- `RdfJsonWriter` - Format JSON
+- `CompressingTurtleWriter` - Turtle optimise
+- `HtmlWriter` - Visualisation HTML
+
+> **Point cle** : Tous les writers implementent `IRdfWriter` et sont reutilisables.",,,,,,,,0f47ed3f1c4f43b5,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,776ad35d,markdown,fr,2787acd7a2c58753,"#### c) Utilisation avancée
+
+Il existe plusieurs interfaces supplémentaires pour les writers qui sont utilisées pour indiquer les capacités des writers. La plus courante est `IPrettyPrintingWriter`, qui définit une propriété `PrettyPrintMode`. Lorsque cette propriété est définie sur `true`, le RDF en sortie est écrit avec une mise en forme agréable (principalement en utilisant des tabulations et des sauts de ligne) pour le rendre plus lisible par l'homme.
+
+Moins courante, l'interface `IHighSpeedWriter` définit une propriété `HighSpeedModePermitted`. Le mode High Speed est un mode pris en charge par certains writers qui effectuent une analyse simpliste sur le graphe pour évaluer s'il bénéficiera de l'utilisation de compressions de syntaxe ou non. Si le writer décide que le graphe n'est pas adapté à l'utilisation de compressions de syntaxe, il écrira en mode haute vitesse, c'est-à-dire qu'il écrira simplement les triples un par un. La propriété `HighSpeedModePermitted` contrôle si un writer est autorisé à utiliser ce mode. Si elle est définie sur `false`, les compressions de syntaxe sont toujours utilisées même si le graphe n'est pas considéré comme adapté à leur utilisation.
+
+Enfin, l'interface `ICompressingWriter` définit une propriété `CompressionLevel`. Cette propriété prend une valeur entière qui définit le niveau de compression à utiliser lors de l'écriture de la sortie. En général, les valeurs de la classe `WriterCompressionLevel` sont utilisées pour définir le niveau de compression. L'interprétation du niveau de compression dépend du writer individuel, mais en général, un niveau plus élevé entraînera l'utilisation de plus de compressions de syntaxe qu'un niveau inférieur. Différents niveaux de compression ne conduisent pas nécessairement à une sortie différente, car certaines compressions ne peuvent s'appliquer que si certains types de triples apparaissent dans le graphe et certains niveaux sont traités de manière identique.
+
+Par exemple, vous pouvez écrire une fonction utilitaire comme celle-ci qui configure les options sur le writer si elles sont prises en charge :",,,,,,,,2787acd7a2c58753,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,d7a2cb40,code,fr,883020636d041664,"public static void SaveGraph(IGraph g, IRdfWriter writer, System.IO.StringWriter sw)
+{
+    // Définit le mode Pretty Print s il est pris en charge
+    if (writer is IPrettyPrintingWriter)
+    {
+        ((IPrettyPrintingWriter)writer).PrettyPrintMode = true;
+    }
+
+    // Interdit le mode High Speed s il est pris en charge
+    if (writer is IHighSpeedWriter)
+    {
+        ((IHighSpeedWriter)writer).HighSpeedModePermitted = false;
+    }
+
+    // Définit le niveau de compression à High s il est pris en charge
+    if (writer is ICompressingWriter)
+    {
+        ((ICompressingWriter)writer).CompressionLevel = WriterCompressionLevel.High;
+    }
+
+    // Sauvegarde du graphe
+    writer.Save(g, sw);
+}
+Console.WriteLine(""Fonction SaveGraph définie (PrettyPrint + HighCompression)"");",,,,,,,,883020636d041664,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,f16b2a0d,markdown,fr,e60327f6d1cee1f5,"#### Interpretation des interfaces avancees
+
+Le code précédent montre comment **configurer un writer dynamiquement** :
+
+| Interface | Capacite | Exemple |
+|-----------|----------|---------|
+| **IPrettyPrintingWriter** | Formatage lisible | Indentation, sauts de ligne |
+| **ICompressingWriter** | Optimisation taille | Abreviations maximales |
+| **IHighSpeedWriter** | Optimisation vitesse | Pas de formatage |
+| **INamespaceWriter** | Contrôle prefixes | Ajout/suppression d'espaces de noms |
+
+**Pattern de verification de capacites** :
+```csharp
+if (writer is IPrettyPrintingWriter pp) {
+    pp.PrettyPrintMode = true;
+}
+if (writer is IHighSpeedWriter hs) {
+    hs.HighSpeedModePermitted = true;
+}
+```
+
+> **Note** : Certaines combinaisons sont incompatibles (ex: PrettyPrint + HighSpeed). Le writer choisira automatiquement une priorite.",,,,,,,,e60327f6d1cee1f5,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,38d53072,markdown,fr,a63d585db4d49de3,"
+---
+
+#### d) Formateurs
+
+Les formateurs sont une alternative à l'utilisation d'un `IRdfWriter` pour générer du RDF. Leur avantage est qu'ils peuvent être utilisés pour formater des nœuds et des triples individuellement pour afficher uniquement ce que vous voulez et comment vous le voulez. Cependant, leur inconvénient est qu'ils ne peuvent pas utiliser le même ensemble de techniques de compression qu'un `IRdfWriter` complet lors de l'écriture d'un graphe entier, car ils sont délibérément dépourvus d'état.
+
+---
+
+#### e) Comportement du Writer
+
+Toutes les classes Writer de la bibliothèque ont le comportement suivant :
+- Gestion des fichiers/flux :
+  - En cas d'erreur, le fichier/flux en cours d'écriture sera fermé.
+  - En cas de succès de l'écriture, le fichier/flux en cours d'écriture sera fermé.
+- Si un problème survient avec le graphe en cours d'enregistrement, mais ne l'empêche pas d'être enregistré, le writer déclenchera un événement d'avertissement (`Warning event`).
+- Si le graphe en cours d'écriture contient des triples/nœuds qui ne peuvent pas être écrits par le writer, une `RdfOutputException` sera levée.
+
+---
+
+#### f) Classes Writer
+
+Voici les classes Writer standard contenues dans la bibliothèque :
+- `CompressingTurtleWriter` : écriture en syntaxe Turtle avec éventuellement toutes les compressions de syntaxe disponibles
+- `CsvWriter` : écriture des triples dans un fichier CSV
+- `HtmlWriter` : écriture des triples dans une page HTML avec les triples présentés dans un tableau
+- `NTriplesWriter` : écriture en NTriples
+- `Notation3Writer` : écriture en Notation 3 en utilisant toutes les compressions de syntaxe disponibles
+- `PrettyRdfXmlWriter` : Writer en streaming pour RDF/XML qui utilise des compressions de syntaxe conduisant à une sortie RDF/XML agréable
+- `RdfJsonWriter` : écriture en RDF/JSON
+- `RdfXmlWriter` : Writer en streaming rapide pour RDF/XML qui utilise un nombre limité de compressions de syntaxe
+- `TsvWriter` : écriture des triples dans un fichier TSV
+- `TurtleWriter` : écriture en Turtle en utilisant un nombre limité de compressions de syntaxe. Ce writer est maintenant considéré comme obsolète au profit de `CompressingTurtleWriter` et sera supprimé de la bibliothèque dans une version future.
+
+De plus, il existe une classe d'aide, `SingleGraphWriter`, qui implémente l'interface `IRdfWriter` et permet d'écrire un graphe à l'aide d'un writer qui implémente l'interface `IStoreWriter`. Cela permet d'écrire un graphe en utilisant les formats de sérialisation décrits dans la section ""Travailler avec les Triple Stores"".
+
+---",,,,,,,,a63d585db4d49de3,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,87d31d0e,markdown,fr,65f72b7eb616678c,"### Formateurs : Alternative aux Writers
+
+Les **formateurs** sont des classes utilitaires pour **serialiser des éléments individuels** :
+
+| Formateur | Serialise | Exemple |
+|-----------|-----------|---------|
+| **NTriplesFormatter** | Triple, Node | `<http://ex.org/a>` |
+| **TurtleFormatter** | Triple, Node | `ex:a` (avec prefix) |
+| **Notation3Formatter** | Triple, Node | Notation3 syntax |
+
+**Différence Writer vs Formateur** :
+
+```csharp
+// Writer : serialise UN GRAPHE ENTIER
+RdfXmlWriter writer = new RdfXmlWriter();
+writer.Save(g, ""output.rdf"");  // Tout le graphe
+
+// Formateur : serialise DES ÉLÉMENTS INDIVIDUELS
+NTriplesFormatter formatter = new NTriplesFormatter();
+foreach (Triple t in g.Triples) {
+    string line = formatter.Format(t);  // Un triplet a la fois
+    Console.WriteLine(line);
+}
+```
+
+**Cas d'usage des formateurs** :
+- Generation de logs
+- Affichage console selectif
+- Construction manuelle de fichiers
+- Integration dans templates",,,,,,,,65f72b7eb616678c,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,62cbf72e,markdown,fr,d2c3eec213009ae7,"### 4. Travailler avec les graphes
+
+Comme présenté précédemment dans les concepts de base, le graphe est la représentation de base d'un ensemble de triples utilisés dans la bibliothèque. Toutes les classes de graphes sont basées sur l'interface `IGraph` et descendent principalement de la classe de base abstraite `BaseGraph` - la classe `Graph` de base étant la plus couramment utilisée.
+
+#### a) Propriétés
+
+Pour commencer cette discussion sur le travail avec les graphes, nous allons examiner les propriétés qu'une implémentation `IGraph` nous offre :
+
+- **BaseUri**
+  - La propriété `BaseUri` permet de récupérer/définir l'URI de base du graphe. Une URI de base est l'URI par rapport à laquelle toutes les URIs relatives sont résolues, ainsi que tous les noms préfixés de l'espace de noms par défaut (si l'espace de noms par défaut n'est pas explicitement défini). Les graphes ne sont pas tenus d'avoir une URI de base et par défaut, cette propriété renvoie `null`. En général, l'URI de base est définie lors de la lecture de RDF à partir d'un fichier, lorsque la syntaxe RDF définit une URI de base, ou lorsque vous récupérez RDF à partir d'une URI à l'aide de l'`UriLoader`, auquel cas l'URI récupérée est l'URI de base.
+  - Exemple :",,,,,,,,d2c3eec213009ae7,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,a8e4ad10,code,fr,abe966962dca64ee,"Graph g = new Graph();
+g.BaseUri = new Uri(""http://example.org/base"");
+g.Display();",,,,,,,,abe966962dca64ee,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,ba87aaf8,markdown,fr,36da359c70352c74,"#### Proprietes essentielles d'un graphe
+
+Nous venons de définir l'**URI de base** du graphe. Explication :
+
+| Propriete | Description | Valeur par defaut |
+|-----------|-------------|-------------------|
+| **BaseUri** | URI du graphe lui-même | `null` |
+| **IsEmpty** | Le graphe contient-il des triplets ? | `true` initialement |
+| **NamespaceMap** | Prefixes declares | `rdf:`, `rdfs:`, `xsd:` |
+| **Triples** | Collection de triplets | Collection vide |
+
+**A quoi sert BaseUri ?** :
+- Identifie le graphe dans un Triple Store (collection de graphes)
+- Permet de resoudre les URIs relatives
+- Utilise dans les formats RDF avec graphes nommes (TriG, NQuads)
+
+```csharp
+// Sans BaseUri
+IGraph g1 = new Graph();
+// g1.BaseUri == null (graphe anonyme)
+
+// Avec BaseUri
+IGraph g2 = new Graph();
+g2.BaseUri = new Uri(""http://example.org/graph1"");
+// g2 peut etre reference dans un Triple Store
+```
+
+> **Bonne pratique** : Toujours définir une BaseUri pour les graphes destines a etre partages ou stockes dans un Triple Store.",,,,,,,,36da359c70352c74,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,7ad3cda9,markdown,fr,93644666a6b84244,"
+- **IsEmpty**
+  - La propriété `IsEmpty` est un booléen indiquant si des triples sont présents dans ce graphe.
+
+- **NamespaceMap**
+  - La propriété `NamespaceMap` renvoie l'instance `INamespaceMapper` associée à ce graphe (plus précisément, elle renvoie l'instance associée à l'instance `INodeFactory` que le graphe utilise lors de la création de nouveaux nœuds). `INamespaceMapper` est utilisé pour faire correspondre les préfixes aux URIs afin de permettre la gestion des espaces de noms et la résolution des noms préfixés.
+
+- **Nodes et AllNodes**
+  - La propriété `Nodes` renvoie un `IEnumerable<INode>` qui retourne des instances de `INode` apparaissant dans la position Sujet/Objet des triples. La méthode `Nodes` est ainsi nommée car elle renvoie les instances de `INode` considérées comme les nœuds du graphe RDF (les prédicats sont considérés comme des arcs dans la représentation graphique du RDF). Cependant, la méthode `AllNodes` fournit une énumération sur les instances `INode` du sujet, du prédicat et de l'objet.
+  - Exemple :
+    ```csharp
+    // Supposons que nous avons un graphe g, recherchons tous les nœuds URI
+    foreach (IUriNode u in g.Nodes.UriNodes())
+    {
+        // Écrire l'URI dans la console
+        Console.WriteLine(u.Uri.ToString());
+    }
+    ```
+
+#### b) Triples
+
+La propriété `Triples` renvoie un objet `BaseTripleCollection`, qui est une collection des triples contenus dans le graphe et est probablement la propriété la plus importante et la plus utilisée d'un graphe. Cela vous permet d'énumérer les triples dans le graphe de différentes manières, mais est le plus souvent utilisé, comme nous l'avons vu précédemment, pour énumérer simplement les triples dans le graphe et effectuer une action avec chacun d'eux.
+
+#### c) Assertion et retrait de triples
+
+Comme nous l'avons déjà vu dans l'aperçu de la bibliothèque et dans le tutoriel Hello World, l'une des fonctions clés du graphe est de permettre l'assertion et le retrait de triples. Pour cela, les méthodes `Assert(…)` et `Retract(…)` sont fournies. Ces deux méthodes peuvent prendre soit un seul triple, soit une énumération de triples.
+
+L'assertion d'un triple entraîne son ajout à la collection de triples du graphe, tandis que le retrait d'un triple entraîne l'opération inverse. Selon l'implémentation de l'`IGraph` utilisée, des actions supplémentaires peuvent également être effectuées dans le cadre du processus d'assertion et de retrait.
+
+Remarque : Lors de l'utilisation des méthodes `Assert(IEnumerable<Triple> ts)` ou `Retract(IEnumerable<Triple> ts)`, faites attention à la provenance de ces triples. Un graphe, comme la plupart des classes de collection dans le monde .NET, ne permet pas d'être modifié pendant qu'il est énuméré. Par conséquent, vous devrez peut-être appeler `ToList()` sur un énumérable avant de tenter de l'assertir/retirer.
+
+#### d) Création de nœuds
+
+Comme nous l'avons également vu dans l'aperçu de la bibliothèque, tous les nœuds doivent être créés par une `INodeFactory`, que toutes les implémentations `IGraph` doivent également mettre en œuvre. Par conséquent, un graphe propose les méthodes `CreateBlankNode(…)`, `CreateLiteralNode(…)` et `CreateURINode(…)`. Consultez l'aperçu de la bibliothèque précédent pour des exemples d'utilisation.
+
+#### e) Sélection de nœuds
+
+Pour sélectionner des nœuds, il existe des méthodes qui peuvent être utilisées pour trouver un nœud dans un graphe (s'il existe), ce sont les méthodes `GetXNode()`, où X est le type de nœud à récupérer. Notez que cette méthode ne renvoie une valeur que si la valeur donnée existe en tant que nœud dans le graphe, c'est-à-dire si elle apparaît dans la position Sujet/Objet d'un triple dans ce graphe.
+
+Remarque : Si vous voulez simplement obtenir une instance de nœud pour d'autres utilisations, indépendamment de son existence ou non dans le graphe, vous devriez utiliser les méthodes `CreateXNode()` à la place.
+
+Exemple :",,,,,,,,93644666a6b84244,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,706e48c6,code,fr,a9fb20d51eaeb1a1,"// Supposons que nous avons un graphe g
+
+// Sélection d'un nœud blanc
+IBlankNode b = g.GetBlankNode(""myNodeID"");
+if (b != null)
+{
+    Console.WriteLine(""Un nœud blanc avec l'ID "" + b.InternalID + "" existe dans le graphe"");
+}
+else
+{
+    Console.WriteLine(""Aucun nœud blanc avec l'ID donné n'existe dans le graphe"");
+}
+
+// Sélection de nœuds littéraux
+// Littéral simple avec la valeur donnée
+ILiteralNode l = g.GetLiteralNode(""Some Text"");
+
+// Littéral avec la valeur donnée et un spécificateur de langue
+ILiteralNode l2 = g.GetLiteralNode(""Some Text"", ""en"");
+
+// Littéral avec la valeur donnée et un type de données
+ILiteralNode l3 = g.GetLiteralNode(""1"", new Uri(XmlSpecsHelper.XmlSchemaDataTypeInteger));
+
+// Sélection de nœuds URI
+// Par URI
+IUriNode u = g.GetUriNode(new Uri(""http://example.org/select""));
+
+// Par nom préfixé
+//IUriNode u2 = g.GetUriNode(""ex:select"");",,,,,,,,a9fb20d51eaeb1a1,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,697e7a5f,markdown,fr,05d30bcf0e40e3ac,"#### Méthodes de sélection de noeuds
+
+Le code précédent illustre les **accesseurs de noeuds** par identifiant :
+
+| Méthode | Retourne | Cas d'usage |
+|---------|----------|-------------|
+| **GetBlankNode(id)** | Noeud anonyme | Structures intermediaires (listes RDF) |
+| **GetUriNode(uri)** | Noeud URI | Recherche de ressource |
+| **GetLiteralNode(val)** | Noeud literal | Recherche de valeur |
+
+**Comportement important** :
+- Retourne `null` si le noeud n'existe pas dans le graphe
+- Ne **créé pas** de nouveau noeud (contrairement a `CreateXxxNode()`)
+- Utile pour **verifier l'existence** avant manipulation
+
+```csharp
+// Créer vs Obtenir
+IBlankNode b1 = g.CreateBlankNode(""id"");  // Créé ou retourne existant
+IBlankNode b2 = g.GetBlankNode(""id"");     // Retourne existant ou null
+
+// Pattern de verification
+IUriNode node = g.GetUriNode(uri);
+if (node != null) {
+    // Le noeud existe, on peut l'utiliser
+}
+```
+
+> **Attention** : Les noeuds blancs sont lies au graphe qui les a crees. On ne peut pas utiliser un noeud blanc d'un graphe dans un autre graphe directement.",,,,,,,,05d30bcf0e40e3ac,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,2ad64d4f,markdown,fr,569cba6e62878984,"#### f) Sélection de triples
+
+L'interface `IGraph` propose de nombreuses méthodes de sélection qui vous permettent d'obtenir les résultats de votre sélection sous la forme d'un `IEnumerable<Triple>`. L'exemple suivant montre l'utilisation de quelques-unes de ces méthodes :
+",,,,,,,,569cba6e62878984,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,08b54a80,code,fr,120168ada49635b5,"// Supposons que nous avons un graphe g
+
+// Obtenir tous les triples impliquant un nœud donné
+IUriNode select = g.CreateUriNode(new Uri(""http://example.org/select""));
+IEnumerable<Triple> ts = g.GetTriples(select);
+
+
+// Obtenir tous les triples répondant à certains critères
+// Nous voulons trouver tout ce qui est du type rdf:type ex:Person
+IUriNode rdfType = g.CreateUriNode(""rdf:type"");
+//IUriNode person = g.CreateUriNode(""ex:Person"");
+//ts = g.GetTriplesWithPredicateObject(rdfType, person);
+
+// Obtenir tous les triples avec un sujet donné
+// Nous réutilisons le nœud que nous avons créé précédemment
+ts = g.GetTriplesWithSubject(select);
+
+// Obtenir tous les triples avec un prédicat donné
+ts = g.GetTriplesWithPredicate(rdfType);
+
+ts.Display();
+
+// Obtenir tous les triples avec un objet donné
+//ts = g.GetTriplesWithObject(person);",,,,,,,,120168ada49635b5,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,8712fe3a,markdown,fr,e6d0395fa8242651,"#### Interpretation des méthodes de sélection de triplets
+
+Les méthodes `GetTriplesWithXxx()` sont essentielles pour **interroger un graphe** :
+
+| Méthode | Selectionne | Exemple |
+|---------|-------------|---------|
+| **GetTriplesWithSubject(s)** | `s ? ?` | Toutes les proprietes d'une ressource |
+| **GetTriplesWithPredicate(p)** | `? p ?` | Toutes les utilisations d'une relation |
+| **GetTriplesWithObject(o)** | `? ? o` | Ressources ayant une valeur donnee |
+| **GetTriplesWithSubjectPredicate(s,p)** | `s p ?` | Valeurs d'une propriete pour un sujet |
+| **GetTriplesWithPredicateObject(p,o)** | `? p o` | Sujets ayant une propriete=valeur |
+
+**Pattern SPARQL equivalent** :
+```csharp
+// Code C#
+var triples = g.GetTriplesWithSubject(select);
+
+// Equivalent SPARQL
+SELECT ?p ?o WHERE {
+  <http://example.org/select> ?p ?o .
+}
+```
+
+> **Performance** : Ces méthodes utilisent des index internes pour une recherche rapide (O(log n) ou O(1) selon l'implementation).",,,,,,,,e6d0395fa8242651,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,42627f98,markdown,fr,7276359678963e03,"#### g) Fusion de graphes
+
+La méthode `Merge(…)` permet de fusionner des graphes. La méthode prend en argument un `IGraph`, puis a un deuxième argument facultatif qui est un booléen indiquant s'il faut conserver les URIs de graphe d'origine associées aux nœuds.
+
+`Merge(…)` met en œuvre la fusion de graphes telle que décrite dans la spécification RDF : les triples ne contenant pas de nœuds blancs sont copiés à partir du graphe d'entrée s'ils n'existent pas dans le graphe sur lequel `Merge()` est appelé, les triples contenant des nœuds blancs voient leurs identifiants de nœuds blancs réécrits afin de ne pas entrer en collision avec les nœuds blancs déjà présents dans le graphe.
+
+#### h) Égalité des graphes
+
+L'égalité des graphes (ou isomorphisme) est prise en charge grâce à l'utilisation de la méthode standard `Equals(Object obj)`. Nous fournissons également une surcharge supplémentaire `Equals(IGraph g, out Dictionary mapping)` qui détermine l'égalité
+
+ et, si les graphes sont équivalents, renvoie la correspondance des nœuds blancs entre les deux graphes.
+
+#### i) Différence des graphes
+
+Si vous savez que deux graphes sont différents, il peut être utile de savoir en quoi ils diffèrent. La méthode `Différence(IGraph g)` détermine les différences entre deux graphes et renvoie un `GraphDiffReport` qui détaille les différences.
+
+#### j) Chargement des graphes
+
+La méthode la plus courante pour charger un graphe est de lire du RDF à partir d'un fichier/URI, comme décrit dans la lecture de RDF, mais il existe d'autres façons de lire des graphes, par exemple à partir d'un stockage persistant.
+
+##### (1) Graphes basés sur des triplets
+
+Les graphes peuvent également être chargés à partir de triplets natifs stockés dans des triple stores accessibles via l'API dotNetRDF. Pour utiliser un triple store natif, vous devrez utiliser l'une des implémentations d'`IStorageProvider` situées dans l'espace de noms `VDS.RDF.Storage`. Les graphes peuvent être chargés à l'aide d'une surcharge appropriée de la méthode `LoadGraph()`, consultez l'intégration des triple stores pour plus de détails.
+
+##### (2) Utilisation de StoreGraphPersistenceWrapper
+
+Alternativement, `StoreGraphPersistenceWrapper` est une classe enveloppe qui peut être placée autour de n'importe quelle instance `IGraph` et qui persiste toutes les modifications apportées lorsqu'elle est supprimée, sauf si vous les supprimez à l'aide de la méthode `Discard()`.
+
+```csharp
+using VDS.RDF;
+using VDS.RDF.Storage;
+
+public class StoreGraphExample
+{
+    public static void Main(String[] args)
+    {
+        // Créez notre fournisseur de stockage - cet exemple utilise Virtuoso Universal Server
+        VirtuosoManager virtuoso = new VirtuosoManager(""localhost"", 1111, ""DB"", ""nom d'utilisateur"", ""mot de passe"");
+
+        // Chargez le graphe dans une instance de graphe ordinaire d'abord
+        Graph g = new Graph();
+        virtuoso.LoadGraph(g, new Uri(""http://example.org/""));
+
+        // Placez ensuite le graphe dans une enveloppe
+        StoreGraphPersistenceWrapper wrapper = new StoreGraphPersistenceWrapper(virtuoso, g);
+
+        // Apportez maintenant des modifications à ce graphe comme vous le souhaitez...
+
+        // N'oubliez pas d'appeler Dispose() pour vous assurer que les modifications sont persistées lorsque vous avez fini
+        wrapper.Dispose();
+    }
+}
+```
+
+#### k) Chargement depuis SPARQL
+
+Il est également possible d'obtenir un graphe en effectuant une requête SPARQL vers un point d'accès SPARQL où les résultats de cette requête seront un graphe, c'est-à-dire une requête CONSTRUCT ou DESCRIBE.",,,,,,,,7276359678963e03,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,aea642b4,code,fr,7cb0df1876891cc8,"using VDS.RDF;
+using VDS.RDF.Query;
+
+
+var httpClient = new System.Net.Http.HttpClient();
+// Définissez d'abord un point d'accès SPARQL pour DBPedia
+var endpoint = new SparqlQueryClient( httpClient, new Uri(""http://dbpedia.org/sparql""));
+// Ensuite, définissez notre requête
+// Nous allons demander à DBPedia de décrire la première chose qu'elle trouve qui est une personne
+String query = ""DESCRIBE ?person WHERE {?person a <http://dbpedia.org/ontology/Person>} LIMIT 1"";
+// Obtenez le résultat
+ var g = await endpoint.QueryWithResultGraphAsync(query);
+// Affichez le résultat
+using (System.IO.StringWriter sw = new System.IO.StringWriter())
+{
+    RdfXmlWriter rdfxmlwriter = new RdfXmlWriter();
+    rdfxmlwriter.Save(g, sw);
+    string rdfData = sw.ToString();
+    rdfData.Display();
+}
+
+",,,,,,,,7cb0df1876891cc8,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,8832709d,markdown,fr,8ebf10858d1aa090,"#### Point d'acces SPARQL (Endpoint)
+
+Le code précédent configure une **connexion a DBpedia** via SPARQL :
+
+| Composant | Valeur | Explication |
+|-----------|--------|-------------|
+| **Endpoint URI** | `http://dbpedia.org/sparql` | Point d'acces au service de requêtes |
+| **HttpClient** | Instance .NET | Gestion des connexions HTTP |
+| **DefaultGraphUri** | `http://dbpedia.org` | Graphe par defaut a interroger |
+
+**Fonctionnement** :
+```
+Client C#  -->  HTTP POST  -->  DBpedia SPARQL Endpoint
+           <--  SPARQL Results (XML/JSON)  <--
+```
+
+**Configuration avancee possible** :
+```csharp
+var endpoint = new SparqlRemoteEndpoint(uri) {
+    Timeout = 30000,  // 30 secondes
+    HttpMode = ""POST"",  // ou ""GET""
+    ResultsAccept = ""application/sparql-results+json""
+};
+```
+
+> **Attention** : Les endpoints publics ont souvent des limites de timeout (10-60 secondes) et des quotas de requêtes.",,,,,,,,8ebf10858d1aa090,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,119e906c,markdown,fr,a7051cd357bd5ead,"#### l) Enregistrement des graphes
+
+La méthode la plus courante pour enregistrer un graphe est de l'enregistrer dans un fichier, comme décrit dans l'écriture de RDF, mais vous pouvez également l'enregistrer dans d'autres formes de stockage persistant.
+
+##### (1) Graphes basés sur des triplets
+
+La façon la plus simple d'enregistrer un graphe dans un triple store consiste à utiliser la méthode `SaveGraph()` d'une implémentation d'`IStorageProvider`, consultez l'intégration des triple stores pour plus de détails.
+
+Alternativement, vous pouvez utiliser la classe `StoreGraphPersistenceWrapper` décrite précédemment, car toutes les modifications apportées à celle-ci sont automatiquement enregistrées dans le Store (si votre Store le prend en charge).
+
+#### m) Implémentations standard d'IGraph
+
+Voici une liste partielle des implémentations concrètes d'`IGraph` fournies dans la bibliothèque :
+
+| Classe                             | Description                                                                                     |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `VDS.RDF.Graph`                    | Graphe en mémoire avec indexation des triplets                                                  |
+| `VDS.RDF.NonIndexedGraph`          | Graphe en mémoire sans indexation des triplets                                                  |
+| `VDS.RDF.StoreGraphPersistenceWrapper` | Une enveloppe autour d'un autre graphe où les modifications sont persistées dans un Store en utilisant un `IStorageProvider`. |
+| `VDS.RDF.ThreadSafeGraph`          | Une enveloppe sûre pour les threads autour d'une autre instance de graphe                       |",,,,,,,,a7051cd357bd5ead,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,5ecb0cb6,markdown,fr,ba7035f7a02db141,"### 5. Types de valeurs et listes typées
+
+Bien que RDF soit un modèle de données puissant capable de représenter n'importe quelle donnée que vous souhaitez encoder, la sérialisation RDF de certaines valeurs typées et de listes peut être quelque peu complexe. De plus, elles peuvent être difficiles à accéder et à manipuler à l'aide des API que nous vous avons montrées jusqu'à présent dans ce guide de l'utilisateur. Ce document explique certaines façons utiles dont la bibliothèque vous aide à travailler avec ces éléments de manière plus conviviale.
+
+#### a) Encodage des valeurs en RDF
+
+Pour les valeurs courantes telles que les entiers, les booléens, les dates, etc., RDF utilise les types de données du schéma XML. Ils peuvent être directement créés par un utilisateur en utilisant un code explicite comme celui-ci :
+",,,,,,,,ba7035f7a02db141,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,e61268d9,code,fr,3abadaa8ea7f0212,"// Supposons que nous ayons déjà un graphe dans la variable g
+ILiteralNode value = g.CreateLiteralNode(""12345"", new Uri(XmlSpecsHelper.XmlSchemaDataTypeInteger));
+value.Display()",,,,,,,,3abadaa8ea7f0212,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,904b50c2,markdown,fr,f4ec4bcdac51e1f5,"#### Limitation des types de données RDF
+
+Le code précédent montre la **verbosity des valeurs typees** en RDF :
+
+**Problème** :
+```csharp
+// Approche manuelle (fastidieuse)
+ILiteralNode value = g.CreateLiteralNode(""12345"",
+    new Uri(XmlSpecsHelper.XmlSchemaDataTypeInteger));
+```
+
+**Types XSD courants** :
+- `xsd:integer` - Entiers
+- `xsd:decimal` - Decimaux
+- `xsd:double` - Flottants double precision
+- `xsd:boolean` - Booleans
+- `xsd:dateTime` - Dates et heures
+- `xsd:string` - Chaînes (par defaut)
+
+> **Problème pedagogique** : Le code RDF pur est très verbeux pour les valeurs typees. C'est pourquoi dotNetRDF fournit des extensions C# (section suivante).",,,,,,,,f4ec4bcdac51e1f5,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,0988d8a8,markdown,fr,16d07a3261e027fe,"Bien que cela soit relativement simple, cela peut être fastidieux à taper, en particulier si vous avez beaucoup de valeurs typées que vous souhaitez représenter. Pour faciliter l'encodage des valeurs typées en RDF, la bibliothèque propose plusieurs méthodes d'extension dans la classe `VDS.RDF.LiteralExtensions`, qui fournissent des méthodes `ToLiteral()` que vous pouvez appliquer à divers types .Net pour obtenir l'encodage RDF équivalent. Par exemple :
+",,,,,,,,16d07a3261e027fe,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,2753a569,code,fr,3e9bf0388eb35271,"// Supposons que nous ayons déjà un graphe dans la variable g
+INode intNode = (12345).ToLiteral(g);
+INode dateNode = DateTime.Now.ToLiteral(g);
+dateNode.Display()",,,,,,,,3e9bf0388eb35271,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,86c14a36,markdown,fr,f6a22f25d8865d59,"#### Méthodes d'extension pour types natifs C#
+
+Les **méthodes d'extension** `.ToLiteral()` simplifient drastiquement le code :
+
+| Type C# | Méthode | Type RDF genere |
+|---------|---------|-----------------|
+| `int` | `(12345).ToLiteral(g)` | `xsd:integer` |
+| `bool` | `(true).ToLiteral(g)` | `xsd:boolean` |
+| `double` | `(3.14).ToLiteral(g)` | `xsd:double` |
+| `DateTime` | `DateTime.Now.ToLiteral(g)` | `xsd:dateTime` |
+| `TimeSpan` | `TimeSpan.FromHours(2).ToLiteral(g)` | `xsd:duration` |
+| `string` | `""text"".ToLiteral(g)` | `xsd:string` ou plain |
+
+**Avantages** :
+1. **Lisibilite** : Code C# naturel
+2. **Type safety** : Verification a la compilation
+3. **Formatage automatique** : DateTime vers ISO 8601, etc.
+
+```csharp
+// Avant (manuel, verbeux)
+ILiteralNode date = g.CreateLiteralNode(
+    DateTime.Now.ToString(""yyyy-MM-ddTHH:mm:ss""),
+    new Uri(XmlSpecsHelper.XmlSchemaDataTypeDateTime)
+);
+
+// Après (extension, simple)
+ILiteralNode date = DateTime.Now.ToLiteral(g);
+```
+
+> **Point cle** : Ces extensions sont définies dans `VDS.RDF.LiteralExtensions`.",,,,,,,,f6a22f25d8865d59,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,557e41b5,markdown,fr,a433416f933c3508,"Cela donne un code beaucoup plus lisible et, dans le cas de types tels que `DateTime` et `TimeSpan`, où les encodages RDF doivent être dans un format précis, cela élimine toute possibilité d'erreur de l'utilisateur lors de l'encodage des valeurs en tant que littéraux appropriés.
+
+#### b) Décodage des valeurs à partir de RDF
+
+Pour décoder les valeurs à partir de RDF, vous pouvez utiliser l'espace de noms `VDS.RDF.Nodes`. Bien qu'il soit principalement utilisé en interne dans notre moteur SPARQL, il est également très utile pour l'utilisateur final. Cet espace de noms fournit principalement une méthode d'extension `AsValuedNode()`, qui vous renvoie une instance de `VDS.RDF.Nodes.IValuedNode`. Un `IValuedNode` est simplement un nœud qui a une valeur fortement typée associée et fournit plusieurs méthodes pour récupérer la valeur d'un nœud en tant que type .Net fortement typé. Par exemple :
+
+```csharp
+// Supposons que nous ayons déjà un nœud dans la variable n
+IValuedNode value = n.AsValuedNode();
+// Obtenir la valeur entière
+long i = value.AsInteger();
+```
+
+#### c) Manipulation des listes RDF
+
+Les listes RDF sont un moyen d'exprimer des listes en RDF, mais la sérialisation en triplets est quelque peu fastidieuse. Par exemple, le snippet Turtle suivant exprime une liste simple :
+
+```turtle
+@prefix ex: <http://example.org/ns#> .
+ex:subj ex:pred ( 1 2 3 ) .
+```
+
+Mais cela n'est qu'un sucre syntaxique pour les triplets suivants :
+
+```turtle
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix ex: <http://example.org/ns#> .
+
+ex:subj ex:pred _:b1 .
+_:b1 rdf:first 1 .
+_:b1 rdf:rest _:b2 .
+_:b2 rdf:first 2 .
+_:b2 rdf:rest _:b3 .
+_:b3 rdf:first 3 .
+_:b3 rdf:rest rdf:nil .
+```
+
+Comme vous pouvez probablement le comprendre, l'accès à cela uniquement à l'aide des API centrées sur les triplets que nous vous avons montrées dans le guide de l'utilisateur jusqu'à présent va être très difficile.
+
+Pour atténuer ce problème, nous fournissons plusieurs méthodes dans la classe `VDS.RDF.Extensions` qui vous permettent de manipuler les listes RDF de manière conviviale.
+
+L'accès à une liste nécessite une référence au graphe et à la racine de la liste, c'est-à-dire au nœud dans le graphe qui représente le premier élément de la liste. Tous les exemples suivants supposeront que le graphe RDF donné ci-dessus est les données utilisées et qu'il est disponible dans une variable `g` et que la racine de la liste est dans la variable `root`.
+
+#### d) Récupération d'une liste
+
+Vous pouvez récupérer une liste de plusieurs manières, la plus courante étant utilisée pour récupérer les éléments de votre collection, par exemple :",,,,,,,,a433416f933c3508,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,f70351ac,code,fr,08b00735c406b51d,"
+// Initialize g and root
+        IGraph g = new Graph();
+        INode root = null;
+
+        // RDF data in Turtle format
+        string rdfData = @""
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix ex: <http://example.org/ns#> .
+
+ex:subj ex:pred _:b1 .
+_:b1 rdf:first 1 .
+_:b1 rdf:rest _:b2 .
+_:b2 rdf:first 2 .
+_:b2 rdf:rest _:b3 .
+_:b3 rdf:first 3 .
+_:b3 rdf:rest rdf:nil .
+"";
+
+        // Parse RDF data
+        TurtleParser parser = new TurtleParser();
+        parser.Load(g, new StringReader(rdfData));
+
+        // Get the root node
+        IUriNode predicate = g.CreateUriNode(""ex:pred"");
+        Triple rootTriple = g.GetTriplesWithPredicate(predicate).FirstOrDefault();
+        if (rootTriple != null)
+        {
+            root = rootTriple.Object;
+        }
+
+        if (root != null)
+        {
+            // Get the nodes for 1, 2, and 3
+            var listItems = g.GetListItems(root).ToList();
+            foreach (var node in listItems)
+            {
+                Console.WriteLine(node);
+            }
+        }
+        else
+        {
+            Console.WriteLine(""Root node not found."");
+        }
+
+// Get the nodes for 1, 2, and 3
+IEnumerable<INode> ns = g.GetListItems(root);",,,,,,,,08b00735c406b51d,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,836a2012,markdown,fr,45619079a8ae28fd,"#### Structures de listes en RDF
+
+Le code suivant créé une **liste RDF** en Turtle :
+
+```turtle
+@prefix : <http://example.org/> .
+_:root rdf:first 1 ;
+       rdf:rest _:b1 .
+_:b1 rdf:first 2 ;
+     rdf:rest _:b2 .
+_:b2 rdf:first 3 ;
+     rdf:rest rdf:nil .
+```
+
+**Structure conceptuelle** :
+```
+root -> [1 | rest] -> [2 | rest] -> [3 | rest] -> nil
+```
+
+| Élément | Type | Signification |
+|---------|------|---------------|
+| `rdf:first` | Predicat | Valeur de l'élément courant |
+| `rdf:rest` | Predicat | Lien vers l'élément suivant |
+| `rdf:nil` | Ressource | Fin de liste |
+| Noeuds blancs | `_:b1`, `_:b2` | Noeuds intermediaires |
+
+> **Comparaison** : Equivalent aux listes chainees en programmation, mais encodees en triplets RDF.",,,,,,,,45619079a8ae28fd,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,599248f5,markdown,fr,da3d32b749146c08,"Comme vous pouvez probablement le comprendre, l'accès à cela uniquement à l'aide des API centrées sur les triplets que nous vous avons montrées dans le guide de l'utilisateur jusqu'à présent va être très difficile.
+
+Pour atténuer ce problème, nous fournissons plusieurs méthodes dans la classe `VDS.RDF.Extensions` qui vous permettent de manipuler les listes RDF de manière conviviale.
+
+L'accès à une liste nécessite une référence au graphe et à la racine de la liste, c'est-à-dire au nœud dans le graphe qui représente le premier élément de la liste. Tous les exemples suivants supposeront que le graphe RDF donné ci-dessus est les données utilisées et qu'il est disponible dans une variable `g` et que la racine de la liste est dans la variable `root`.
+
+#### d) Récupération d'une liste
+
+Vous pouvez récupérer une liste de plusieurs manières, la plus courante étant utilisée pour récupérer les éléments de votre collection, par exemple :",,,,,,,,da3d32b749146c08,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,544dc7be,code,fr,c18f438d7360fbb7,"// Cela nous donnera les nœuds pour 1, 2 et 3
+IEnumerable<INode> ns = g.GetListItems(root);
+ns.Display()",,,,,,,,c18f438d7360fbb7,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,c68dc8e7,markdown,fr,1e6c98434a7e8215,"#### Méthode GetListItems()
+
+Cette méthode **abstrait la structure interne** de la liste RDF :
+
+| Méthode | Retourne | Cas d'usage |
+|---------|----------|-------------|
+| **GetListItems(root)** | `[1, 2, 3]` (valeurs) | Recuperer le contenu |
+| **GetListNodes(root)** | `[_:b1, _:b2, _:b3]` | Manipulation structure |
+| **GetListAsTriples(root)** | Triplets `rdf:first/rest` | Inspection bas niveau |
+
+**Exemple de sortie** :
+```csharp
+// Sortie de GetListItems(root)
+IEnumerable<INode> items = g.GetListItems(root);
+// items = [
+//   LiteralNode(""1"", xsd:integer),
+//   LiteralNode(""2"", xsd:integer),
+//   LiteralNode(""3"", xsd:integer)
+// ]
+```
+
+> **Abstraction** : Vous n'avez pas besoin de naviguer manuellement les predicats `rdf:first` et `rdf:rest`.",,,,,,,,1e6c98434a7e8215,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,15d7c142,markdown,fr,eca5c703cd385277,"Dans certains cas, vous souhaiterez peut-être récupérer les nœuds intermédiaires de la liste plutôt que les éléments eux-mêmes, par exemple :
+",,,,,,,,eca5c703cd385277,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,08013537,code,fr,43ff37f70d41b6e8,"// Cela nous donnera les nœuds _:b1, _:b2 et _:b3
+IEnumerable<INode> ns = g.GetListNodes(root);
+ns.Display()",,,,,,,,43ff37f70d41b6e8,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,7f5310f9,markdown,fr,29ec27fbba8af00f,"#### Différence entre Items et Nodes
+
+| Méthode | Contenu retourne | Exemple |
+|---------|------------------|---------|
+| **GetListItems()** | Valeurs des `rdf:first` | `1`, `2`, `3` |
+| **GetListNodes()** | Noeuds intermediaires | `_:b1`, `_:b2`, `_:b3` |
+
+**Pourquoi GetListNodes() est utile ?** :
+
+```csharp
+// Ajouter un predicat a chaque élément de liste
+IEnumerable<INode> nodes = g.GetListNodes(root);
+IUriNode hasIndex = g.CreateUriNode("":hasIndex"");
+int index = 0;
+foreach (INode node in nodes) {
+    g.Assert(new Triple(node, hasIndex, index.ToLiteral(g)));
+    index++;
+}
+```
+
+Ce code ajoute un index a chaque noeud intermediaire de la liste.",,,,,,,,29ec27fbba8af00f,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,90c7c822,markdown,fr,28b5126667ec6cfc,Ou vous souhaiterez peut-être obtenir tous les triplets qui composent la liste :,,,,,,,,28b5126667ec6cfc,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,a45f3d5f,code,fr,9cb6e76f7e4879fd,"// Cela nous donnera tous les triplets rdf:first et rdf:rest associés à la liste
+IEnumerable<Triple> ts = g.GetListAsTriples(root);
+ts.Display();",,,,,,,,9cb6e76f7e4879fd,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,daf90b7a,markdown,fr,3825c6cdd2c81e29,"#### GetListAsTriples() : Inspection complete
+
+Cette méthode retourne **tous les triplets** constituant la liste :
+
+**Sortie attendue** :
+```
+_:root rdf:first ""1""^^xsd:integer .
+_:root rdf:rest _:b1 .
+_:b1 rdf:first ""2""^^xsd:integer .
+_:b1 rdf:rest _:b2 .
+_:b2 rdf:first ""3""^^xsd:integer .
+_:b2 rdf:rest rdf:nil .
+```
+
+**Cas d'usage** :
+- Debugging de listes malformees
+- Export vers un autre graphe
+- Analyse de structure
+
+```csharp
+IEnumerable<Triple> triples = g.GetListAsTriples(root);
+Console.WriteLine($""La liste contient {triples.Count()} triplets"");
+// Sortie : ""La liste contient 6 triplets""
+```",,,,,,,,3825c6cdd2c81e29,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,09fdadca,markdown,fr,460bba5c32ee5435,"#### e) Assertion et retrait de listes
+
+Nous fournissons également des méthodes qui vous permettent d'asserter/retracter facilement une liste. L'assertion d'une liste nécessite une énumération de nœuds à utiliser comme éléments des listes. Vous pouvez utiliser soit un nœud existant comme racine de la liste, soit faire générer une nouvelle racine de liste pour vous, par exemple :",,,,,,,,460bba5c32ee5435,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,37a89b19,code,fr,29409a10c98e0363,"INode newRoot = g.AssertList(new List<INode>() { (true).ToLiteral(g), (false).ToLiteral(g) });
+// Maintenant, nous pouvons utiliser newRoot comme nous le souhaitons dans notre graphe
+g.Display();",,,,,,,,29409a10c98e0363,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,e979671e,markdown,fr,fe6492d8e70952df,"#### Creation dynamique de listes
+
+La méthode **AssertList()** créé une liste complete en **une seule opération** :
+
+| Paramètre | Type | Description |
+|-----------|------|-------------|
+| `items` | `List<INode>` | Éléments a inclure |
+| **Retour** | `INode` | Racine de la liste (a conserver) |
+
+**Ce qui est créé automatiquement** :
+1. Noeuds blancs intermediaires (`_:b1`, `_:b2`, etc.)
+2. Triplets `rdf:first` pour chaque valeur
+3. Triplets `rdf:rest` pour le chainage
+4. Terminaison avec `rdf:nil`
+
+```csharp
+// Une ligne créé 6 triplets
+INode root = g.AssertList(new List<INode>() {
+    (true).ToLiteral(g),
+    (false).ToLiteral(g)
+});
+```
+
+**Triplets generes** :
+```
+_:root rdf:first true .
+_:root rdf:rest _:b1 .
+_:b1 rdf:first false .
+_:b1 rdf:rest rdf:nil .
+```
+
+> **Important** : Conserver la reference `root` pour acceder a la liste ulterieurement.",,,,,,,,fe6492d8e70952df,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,db993d94,markdown,fr,67ac577503ce718a,Le retrait d'une liste est beaucoup plus simple si nous connaissons la racine de la liste :,,,,,,,,67ac577503ce718a,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,a61d7dea,code,fr,13584c8b83a75183,"// Retracte tous les triplets associés à la liste
+g.RetractList(root);
+g.Display();",,,,,,,,13584c8b83a75183,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,c1eb6525,markdown,fr,7244477372d80b75,"#### Suppression de listes
+
+**RetractList()** supprime **recursivement** tous les triplets de la liste :
+
+| Méthode | Effet | Triplets supprimes |
+|---------|-------|---------------------|
+| `RetractList(root)` | Supprime la liste entiere | Tous les `rdf:first` et `rdf:rest` |
+| `Retract(triple)` | Supprime un triplet | Un seul |
+
+**Comportement** :
+1. Suit recursivement les `rdf:rest`
+2. Supprime chaque triplet `rdf:first` et `rdf:rest`
+3. S'arrete a `rdf:nil`
+
+```csharp
+// Avant
+// 6 triplets dans le graphe
+
+g.RetractList(root);
+
+// Après
+// 0 triplets (si c'etait la seule liste)
+```
+
+> **Attention** : Si plusieurs listes partagent des noeuds (rare mais possible), la suppression peut affecter plusieurs listes.",,,,,,,,7244477372d80b75,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,2f79efc0,markdown,fr,a97de35b2b5bb07a,"#### f) Ajout et suppression d'éléments des listes
+
+Vous pouvez ajouter et supprimer des éléments des listes à l'aide de méthodes pratiques également. Pour ajouter de nouveaux éléments à la fin d'une liste, vous pouvez faire ce qui suit :",,,,,,,,a97de35b2b5bb07a,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,6e1379e9,code,fr,1d524606bd9809ee,"g= new Graph();
+parser.Load(g, new StringReader(rdfData));
+g.AddToList(root, new List<INode>() { (true).ToLiteral(g), (false).ToLiteral(g) });
+g.Display();",,,,,,,,1d524606bd9809ee,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,606286d5,markdown,fr,deb70a747869b2d0,"#### Ajout d'éléments a une liste existante
+
+**AddToList()** ajoute des éléments **a la fin** d'une liste RDF :
+
+| Avant | Après ajout de `[true, false]` |
+|-------|--------------------------------|
+| `[1, 2, 3]` | `[1, 2, 3, true, false]` |
+
+**Mécanisme** :
+1. Trouve le dernier noeud (celui qui pointe vers `rdf:nil`)
+2. Remplace `dernierNoeud rdf:rest rdf:nil` par `dernierNoeud rdf:rest nouveauNoeud`
+3. Construit la nouvelle sous-liste
+4. Termine par `rdf:nil`
+
+```csharp
+// Liste initiale : [1, 2, 3]
+g.AddToList(root, new List<INode>() {
+    (true).ToLiteral(g),
+    (false).ToLiteral(g)
+});
+// Résultat : [1, 2, 3, true, false]
+```
+
+> **Performance** : O(n) ou n est la longueur de la liste (doit parcourir jusqu'a la fin).",,,,,,,,deb70a747869b2d0,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,b645946f,markdown,fr,741ecf0771260aaf,"Pour supprimer des éléments d'une liste, indépendamment de leur position dans la liste, faites ce qui suit :",,,,,,,,741ecf0771260aaf,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,b7a4978d,code,fr,2faf222e95a389c0,"g.RemoveFromList(root, new List<INode>() { (true).ToLiteral(g), (false).ToLiteral(g) });
+Console.WriteLine($""Liste RDF modifiée : {g.Triples.Count} triplets dans le graphe"");",,,,,,,,2faf222e95a389c0,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,a52b2144,markdown,fr,0ef202a2bd27f58e,"#### Suppression selective d'éléments
+
+**RemoveFromList()** supprime **toutes les occurrences** d'éléments specifies :
+
+| Liste initiale | Éléments a supprimer | Résultat |
+|----------------|----------------------|----------|
+| `[1, 2, 3, 2, 1]` | `[1, 2]` | `[3]` |
+| `[1, 2, 3]` | `[4]` | `[1, 2, 3]` (inchange) |
+
+**Comportement important** :
+- Supprime **TOUTES** les occurrences (pas seulement la première)
+- Preserve l'ordre des éléments restants
+- Reconstruit les liens `rdf:rest`
+
+```csharp
+// Liste : [true, false, true, false]
+g.RemoveFromList(root, new List<INode>() {
+    (true).ToLiteral(g)
+});
+// Résultat : [false, false]
+```
+
+> **Note** : Si vous voulez supprimer seulement la première occurrence, vous devez parcourir manuellement avec `GetListNodes()`.",,,,,,,,0ef202a2bd27f58e,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,e8fe80d4,markdown,fr,021ca14aa9000ae9,"Notez que si un élément existe plusieurs fois dans la liste, toutes les occurrences de celui-ci sont supprimées par cette méthode.
+
+### 6. Travailler avec les Triple Store
+
+Les Triple Stores dans dotNetRDF sont utilisés pour représenter des collections de graphes et vous permettent de travailler avec de plus grandes quantités de RDF facilement. Un Triple Store peut être une représentation en mémoire des graphes ou une interface vers un magasin sous-jacent réel.
+
+Les propriétés de base d'un Triple Store sont les suivantes :
+
+- **Graphs** : Permet d'obtenir la collection de graphes présents dans le Triple Store.
+- **IsEmpty** : Indique si le Triple Store est vide, c'est-à-dire s'il ne contient aucun graphe.
+- **Triples** : Permet d'obtenir la collection de triplets de tous les graphes présents dans le Triple Store.
+
+Vous pouvez accéder à un graphe spécifique dans le Triple Store en utilisant l'indexeur avec l'URI du graphe.
+
+Le Triple Store propose également des méthodes pour vérifier l'existence d'un graphe, ajouter des graphes, les supprimer, et exécuter des requêtes.
+
+Il existe deux types de Triple Stores :
+
+- **Les Triple Stores en mémoire** : Ils permettent d'interroger l'ensemble du store et offrent des méthodes similaires à celles de l'interface `IGraph` pour récupérer des triplets.
+- **Les Triple Stores nativement interrogeables** : Ils fournissent leur propre implémentation SPARQL et peuvent être interrogés directement à l'aide de méthodes `ExecuteQuery` prenant une requête SPARQL en chaîne.
+
+Pour charger et enregistrer des Triple Stores, vous pouvez utiliser différents formats de jeu de données RDF tels que TriG, TriX et NQuads. Vous pouvez utiliser les classes `TriGParser` et `TriGWriter` pour charger et enregistrer des stores au format TriG, par exemple.
+
+En résumé, les Triple Stores permettent de travailler avec des collections de graphes RDF. Ils offrent des fonctionnalités pour manipuler les graphes, exécuter des requêtes et charger/enregistrer des stores dans différents formats de jeu de données RDF.
+
+Voici un exemple de code pour charger un Triple Store à partir d'un fichier TriG et l'enregistrer dans un autre fichier TriG :
+
+```csharp
+TripleStore store = new TripleStore();
+TriGParser parser = new TriGParser();
+parser.Load(store, ""input.trig"");
+
+TriGWriter writer = new TriGWriter();
+writer.Save(store, ""output.tr
+
+ig"");
+```
+
+#### Exemple plus détaillé
+
+```csharp
+using System;
+using VDS.RDF;
+using VDS.RDF.Storage;
+
+public class PersistentTripleStoreExample
+{
+    public static void Main(string[] args)
+    {
+        // Créer une connexion à 4store dans cet exemple
+        FourStoreConnector store = new FourStoreConnector(""http://example.com:8080/"");
+        PersistentTripleStore tripleStore = new PersistentTripleStore(store);
+
+        // Vérifier si un graphe existe dans le store
+        // Si le graphe existe dans le store sous-jacent, il sera chargé en mémoire
+        if (tripleStore.HasGraph(new Uri(""http://example.org/someGraph"")))
+        {
+            // Obtenir le graphe de la vue en mémoire (notez que s'il change dans le store sous-jacent entre-temps, vous ne verrez pas ces changements)
+            Graph g = tripleStore.Graph(new Uri(""http://example.org/someGraph""));
+
+            // Faire quelque chose avec le graphe...
+        }
+
+        // Si vous ajoutez un graphe au store, il sera ajouté uniquement à l'état en mémoire initialement
+        Graph toAdd = new Graph();
+        toAdd.LoadFromUri(new Uri(""http://example.org/newGraph""));
+        tripleStore.Add(toAdd);
+
+        // Pour vous assurer que le nouveau graphe est enregistré, appelez Flush()
+        tripleStore.Flush();
+
+        // Vous pouvez également utiliser cette classe pour effectuer des requêtes/mises à jour sur le store sous-jacent
+        // Remarque - Si vous avez apporté des modifications à l'état en mémoire du store, effectuer une requête/mise à jour provoquera une erreur à moins que vous n'ayez
+        // persisté ces modifications
+        // Utilisez Flush() ou Discard() pour vous assurer que l'état du store est cohérent pour l'interrogation
+
+        // Effectuer une requête sur le store
+        // Vous devriez obtenir un SparqlResultSet à partir d'une requête SELECT
+        object results = tripleStore.ExecuteQuery(""SELECT * WHERE {?s ?p ?o}"");
+        if (results is SparqlResultSet)
+        {
+            // Afficher les résultats
+            SparqlResultSet resultSet = (SparqlResultSet)results;
+            foreach (SparqlResult result in resultSet)
+            {
+                Console.WriteLine(result.ToString());
+            }
+        }
+    }
+}
+```
+
+Ce qui précède démontre comment créer, charger, manipuler et interroger un triple store à l'aide de `dotNetRDF`. Les triple stores offrent un moyen puissant et flexible de travailler avec de grandes quantités de données RDF, rendant la gestion et l'interrogation de graphes RDF plus efficaces et plus pratiques.",,,,,,,,021ca14aa9000ae9,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,2dd25cc5,markdown,fr,62893ea0564f0b6a,"### Conclusion : Manipulation des listes RDF
+
+Les listes RDF sont des structures chainees encodees en triplets. dotNetRDF fournit une **abstraction complete** :
+
+| Opération | Méthode | Complexite |
+|-----------|---------|------------|
+| **Lire valeurs** | `GetListItems()` | O(n) |
+| **Lire noeuds** | `GetListNodes()` | O(n) |
+| **Inspecter triplets** | `GetListAsTriples()` | O(n) |
+| **Créer liste** | `AssertList()` | O(n) |
+| **Ajouter éléments** | `AddToList()` | O(n) |
+| **Supprimer éléments** | `RemoveFromList()` | O(n) |
+| **Detruire liste** | `RetractList()` | O(n) |
+
+**Representations equivalentes** :
+
+| Format | Representation |
+|--------|----------------|
+| **Conceptuel** | `[1, 2, 3]` |
+| **Triplets RDF** | `_:r rdf:first 1; rdf:rest _:b1. _:b1 rdf:first 2; ...` |
+| **Code C#** | `g.AssertList(new List<INode>{...})` |
+
+> **Quand utiliser les listes RDF ?** : Collections ordonnees dans des ontologies, sequences d'étapes, chemins, etc. Pour des collections non ordonnees, preferer `rdf:Bag` ou `rdf:Set`.",,,,,,,,62893ea0564f0b6a,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,8018a1a9,markdown,fr,5bcf587da53eb247,"### 7. Créer des requêtes avec SPARQL
+
+SPARQL est un langage de requête pour les données RDF. Il permet aux utilisateurs d'interroger les données RDF de manière flexible et puissante. Les requêtes SPARQL peuvent extraire des données de différents graphes RDF, fusionner des informations provenant de différentes sources et effectuer des opérations complexes sur les données. SPARQL est le langage de requête standard pour le Web sémantique et peut être utilisé pour interroger de grandes quantités de données RDF. 
+
+#### a) Hello World",,,,,,,,5bcf587da53eb247,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,0a23bbe8,code,fr,2c008cb261ba5aed,"using System;
+using VDS.RDF.Query.Builder;
+
+
+string x = ""x"";
+var queryBuilder = QueryBuilder
+    .Select(new string[] { x })
+    .Where(
+        (triplePatternBuilder) =>
+        {
+            triplePatternBuilder
+                .Subject(x)
+                .PredicateUri(new Uri(""http://www.w3.org/2001/vcard-rdf/3.0#FN""))
+                .Object(""John Smith"");
+        });
+using (var sw = new System.IO.StringWriter())
+{
+    sw.WriteLine(queryBuilder.BuildQuery().ToString());
+    var result = sw.ToString();
+    return result;
+}
+",,,,,,,,2c008cb261ba5aed,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,02763490,markdown,fr,2537d780588e174e,"### Introduction a SPARQL Query Builder
+
+SPARQL est le **langage de requête standard** pour RDF (equivalent de SQL pour les bases relationnelles).
+
+**QueryBuilder** : API fluide C# pour construire des requêtes SPARQL **programmatiquement**.
+
+| Approche | Exemple | Avantage |
+|----------|---------|----------|
+| **Chaîne brute** | `""SELECT ?x WHERE { ?x ?y ?z }""` | Simple pour requêtes fixes |
+| **QueryBuilder** | `QueryBuilder.Select(""x"").Where(...)` | Type safety, composition dynamique |
+
+**Structure de base d'une requête SELECT** :
+```sparql
+SELECT ?variable
+WHERE {
+    ?subject ?predicate ?object .
+}
+```
+
+Le QueryBuilder permet de construire cette structure en C# avec IntelliSense et validation.",,,,,,,,2537d780588e174e,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,b3923b62,markdown,fr,510095bdc52317ba,#### b) PREFIX avec plusieurs triples,,,,,,,,510095bdc52317ba,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,8a9cba87,code,fr,9d0fe1d2068541dc,"var prefixes = new NamespaceMapper(true);
+        prefixes.AddNamespace(""vcard"", new Uri(""http://www.w3.org/2001/vcard-rdf/3.0#""));
+        string y = ""y"";
+        var givenName = new SparqlVariable(""givenName"");
+        var queryBuilder =
+            QueryBuilder
+            .Select(new SparqlVariable[] { givenName })
+            .Where(
+                (triplePatternBuilder) =>
+                {
+                    triplePatternBuilder
+                        .Subject(y)
+                        .PredicateUri(""vcard:Family"")
+                        .Object(""Smith"");
+                    triplePatternBuilder
+                        .Subject(y)
+                        .PredicateUri(""vcard:Given"")
+                        .Object(givenName);
+                });
+        queryBuilder.Prefixes = prefixes;
+
+        using (var sw = new System.IO.StringWriter())
+        {
+            sw.WriteLine(queryBuilder.BuildQuery().ToString());
+            var result = sw.ToString();
+            return result;
+        }",,,,,,,,9d0fe1d2068541dc,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,f01349e3,markdown,fr,979249585fe84189,"#### Prefixes et espaces de noms
+
+Les **prefixes** abregent les URIs longues :
+
+| Sans prefix | Avec prefix |
+|-------------|-------------|
+| `<http://www.w3.org/2001/vcard-rdf/3.0#FN>` | `vcard:FN` |
+
+**Declaration de prefixes** :
+```sparql
+PREFIX vcard: <http://www.w3.org/2001/vcard-rdf/3.0#>
+SELECT ?y ?givenName
+WHERE {
+    ?y vcard:Family ""Smith"" .
+    ?y vcard:Given ?givenName .
+}
+```
+
+**Equivalent C# avec QueryBuilder** :
+```csharp
+var prefixes = new NamespaceMapper(true);  // true = inclut prefixes standards
+prefixes.AddNamespace(""vcard"", new Uri(""http://...""));
+```
+
+> **Prefixes standards** : `rdf:`, `rdfs:`, `xsd:`, `owl:` sont inclus automatiquement.",,,,,,,,979249585fe84189,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,3385c66a,markdown,fr,f04055469fda1165,#### c) FILTRE numérique,,,,,,,,f04055469fda1165,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,709d0259,code,fr,f69ce321b22d71da,"var prefixes = new NamespaceMapper(true);
+        prefixes.AddNamespace(""info"", new Uri(""http://somewhere/peopleInfo#""));
+        string resource = ""resource"";
+        string age = ""age"";
+        var queryBuilder =
+            QueryBuilder
+            .Select(new string[] { resource })
+            .Where(
+                (triplePatternBuilder) =>
+                {
+                    triplePatternBuilder
+                        .Subject(resource)
+                        .PredicateUri($""info:{age}"")
+                        .Object(age);
+                })
+            .Filter((builder) => builder.Variable(age) > 24);
+        queryBuilder.Prefixes = prefixes;
+
+        using (var sw = new System.IO.StringWriter())
+        {
+            sw.WriteLine(queryBuilder.BuildQuery().ToString());
+            var result = sw.ToString();
+            return result;
+        }",,,,,,,,f69ce321b22d71da,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,7ea7a570,markdown,fr,203093b1d5f8029e,"#### Filtres numériques en SPARQL
+
+Les **filtres** restreignent les résultats selon des conditions :
+
+| Opérateur | Exemple SPARQL | Exemple QueryBuilder |
+|-----------|----------------|----------------------|
+| **>** | `FILTER(?age > 24)` | `.Filter(age > 24)` |
+| **<** | `FILTER(?price < 100)` | `.Filter(price < 100)` |
+| **>=** | `FILTER(?score >= 50)` | `.Filter(score >= 50)` |
+| **=** | `FILTER(?count = 10)` | `.Filter(count == 10)` |
+
+**Requête de l'exemple** :
+```sparql
+SELECT ?resource
+WHERE {
+    ?resource info:age ?age .
+    FILTER(?age > 24)
+}
+```
+
+Signification : ""Sélectionner toutes les ressources dont l'age est superieur a 24"".",,,,,,,,203093b1d5f8029e,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,3d202378,markdown,fr,88cb752382dbfa42,#### d) FILTRE Regex,,,,,,,,88cb752382dbfa42,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,babb919b,code,fr,846bbda62e590973,"var prefixes = new NamespaceMapper(true);
+        prefixes.AddNamespace(""vcard"", new Uri(""http://www.w3.org/2001/vcard-rdf/3.0#""));
+        var givenName = new SparqlVariable(""givenName"");
+        var queryBuilder =
+            QueryBuilder
+            .Select(new SparqlVariable[] { givenName })
+            .Where(
+                (triplePatternBuilder) =>
+                {
+                    triplePatternBuilder
+                        .Subject(""y"")
+                        .PredicateUri(""vcard:Given"")
+                        .Object(givenName);
+                })
+            .Filter((builder) => builder.Regex(builder.Variable(""givenName""), ""sarah"", ""i""));
+        queryBuilder.Prefixes = prefixes;
+
+        using (var sw = new System.IO.StringWriter())
+        {
+            sw.WriteLine(queryBuilder.BuildQuery().ToString());
+            var result = sw.ToString();
+            return result;
+        }",,,,,,,,846bbda62e590973,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,7b73f806,markdown,fr,0f09f42b326773dd,"#### Filtres avec expressions regulieres
+
+**REGEX** permet de filtrer sur des patterns de texte :
+
+| Fonction | Syntaxe | Exemple |
+|----------|---------|---------|
+| **REGEX** | `REGEX(?var, ""pattern"")` | Correspondance pattern |
+| **REGEX avec flags** | `REGEX(?var, ""pattern"", ""i"")` | `i` = case insensitive |
+
+**Flags disponibles** :
+- `i` : Insensible a la casse
+- `m` : Multiline mode
+- `s` : Dot matches newline
+
+**Exemple de l'exercice** :
+```sparql
+FILTER(REGEX(?givenName, ""^ali"", ""i""))
+```
+
+Signification : ""Prenom commence par 'ali', 'Ali', 'ALI', etc.""
+
+Pattern `^ali` :
+- `^` : Debut de chaîne
+- `ali` : Lettres exactes
+- Flag `i` : Ignore la casse
+
+> **Cas d'usage** : Recherche de noms, filtrage d'URIs, validation de formats.",,,,,,,,0f09f42b326773dd,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,77c37cf3,markdown,fr,634ce82460ca280f,#### e) CLAUSE FACULTATIVE avec FILTRE,,,,,,,,634ce82460ca280f,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,a673809a,code,fr,34f7f8e599e332a4,"var prefixes = new NamespaceMapper(true);
+        prefixes.AddNamespace(""info"", new Uri(""http://somewhere/peopleInfo#""));
+        prefixes.AddNamespace(""vcard"", new Uri(""http://www.w3.org/2001/vcard-rdf/3.0#""));
+        string name = ""name"";
+        string age = ""age"";
+        string person = ""person"";
+        var queryBuilder =
+            QueryBuilder
+            .Select(new string[] { name, age })
+            .Where(
+                (triplePatternBuilder) =>
+                {
+                    triplePatternBuilder
+                        .Subject(person)
+                        .PredicateUri(""vcard:FN"")
+                        .Object(name);
+                })
+            .Optional(
+                (optionalBuilder) =>
+                {
+                    optionalBuilder.Where(
+                        (triplePatternBuilder) =>
+                        {
+                            triplePatternBuilder
+                                .Subject(person)
+                                .PredicateUri($""info:{age}"")
+                                .Object(age);
+                        });
+
+                    optionalBuilder.Filter((b) => b.Variable(age) > 42);
+                });
+        queryBuilder.Prefixes = prefixes;
+
+        using (var sw = new System.IO.StringWriter())
+        {
+            sw.WriteLine(queryBuilder.BuildQuery().ToString());
+            var result = sw.ToString();
+            return result;
+        }",,,,,,,,34f7f8e599e332a4,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,c8ccc3d2,markdown,fr,7fb9fc1f3b874363,"#### Clauses OPTIONAL
+
+**OPTIONAL** permet de recuperer des informations **même si elles n'existent pas** :
+
+| Sans OPTIONAL | Avec OPTIONAL |
+|---------------|---------------|
+| Ressource sans age : **exclue** | Ressource sans age : **incluse** (age = null) |
+
+**Requête de l'exemple** :
+```sparql
+SELECT ?resource ?age
+WHERE {
+    ?resource info:name ?name .
+    OPTIONAL {
+        ?resource info:age ?age .
+        FILTER(?age > 24)
+    }
+}
+```
+
+**Comportement** :
+- Toutes les ressources avec un nom sont retournees
+- Si elles ont un age > 24, il est retourne
+- Si elles n'ont pas d'age, `?age` est `null`
+
+> **Analogie SQL** : Equivalent a un `LEFT JOIN` en SQL.",,,,,,,,7fb9fc1f3b874363,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,a1608926,markdown,fr,08d411c8056bd952,#### f) UNION,,,,,,,,08d411c8056bd952,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,3569ead4,code,fr,d4d6f07ef024692d,"var prefixes = new NamespaceMapper(true);
+        prefixes.AddNamespace(""foaf"", new Uri(""http://xmlns.com/foaf/0.1/""));
+        prefixes.AddNamespace(""vcard"", new Uri(""http://www.w3.org/2001/vcard-rdf/3.0#""));
+        string name = ""name"";
+        var queryBuilder =
+            QueryBuilder
+            .Select(new string[] { name });
+            
+
+        queryBuilder
+            .Union(
+                (unionBuilder) =>
+                {
+                    unionBuilder.Where(
+                        (tripleBuilder) =>
+                        {
+                            tripleBuilder
+                            .Subject<IBlankNode>(""abc"")
+                            .PredicateUri($""foaf:{name}"")
+                            .Object(name);
+                        });
+                },
+                (unionBuilder) =>
+                {
+                    unionBuilder.Where(
+                        c =>
+                        {
+                            c
+                            .Subject<IBlankNode>(""abc"")
+                            .PredicateUri(""vcard:FN"")
+                            .Object(name);
+                        });
+                });
+        queryBuilder.Prefixes = prefixes;
+
+        using (var sw = new System.IO.StringWriter())
+        {
+            sw.WriteLine(queryBuilder.BuildQuery().ToString());
+            var result = sw.ToString();
+            return result;
+        }",,,,,,,,d4d6f07ef024692d,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,300a8619,markdown,fr,6758e8a27b3a5f63,"#### Clause UNION
+
+**UNION** combine des patterns alternatifs :
+
+```sparql
+WHERE {
+    { ?person foaf:name ?name }
+    UNION
+    { ?person foaf:mbox ?mbox }
+}
+```
+
+Signification : ""Sélectionner les personnes qui ont **soit** un nom **soit** un email"".
+
+| Cas | Résultat |
+|-----|----------|
+| Personne avec nom seulement | Incluse |
+| Personne avec email seulement | Incluse |
+| Personne avec les deux | Incluse (2 résultats) |
+| Personne sans nom ni email | Exclue |
+
+**Différence avec OPTIONAL** :
+
+| OPTIONAL | UNION |
+|----------|-------|
+| Pattern principal + extension optionnelle | Patterns alternatifs |
+| Toujours 1 résultat par ressource | Peut generer plusieurs résultats |
+
+> **Cas d'usage** : Recherche flexible, fusion de sources heterogenes.",,,,,,,,6758e8a27b3a5f63,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,c0b723d7,markdown,fr,909e0d7a222f48ab,#### g) ORDER BY,,,,,,,,909e0d7a222f48ab,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,08115cc3,code,fr,238ae8f021129ab8,"var prefixes = new NamespaceMapper(true);
+        prefixes.AddNamespace(""foaf"", new Uri(""http://xmlns.com/foaf/0.1/""));
+        string name = ""name"";
+        var queryBuilder =
+            QueryBuilder
+            .Select(new string[] { name })
+            .Where(
+                (triplePatternBuilder) =>
+                {
+                    triplePatternBuilder
+                        .Subject(""x"")
+                        .PredicateUri($""foaf:{name}"")
+                        .Object(name);
+                })
+            .OrderBy(name);
+        queryBuilder.Prefixes = prefixes;
+
+        using (var sw = new System.IO.StringWriter())
+        {
+            sw.WriteLine(queryBuilder.BuildQuery().ToString());
+            var result = sw.ToString();
+            return result;
+        }",,,,,,,,238ae8f021129ab8,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,07cb6fe3,markdown,fr,fe16aa01a8dc7862,"#### Tri avec ORDER BY
+
+**ORDER BY** trie les résultats selon une variable :
+
+| Direction | Syntaxe | Exemple |
+|-----------|---------|---------|
+| **Ascendant** | `ORDER BY ?var` | A->Z, 1->9 |
+| **Descendant** | `ORDER BY DESC(?var)` | Z->A, 9->1 |
+
+**Requête de l'exemple** :
+```sparql
+SELECT ?name
+WHERE {
+    ?x foaf:name ?name .
+}
+ORDER BY ?name
+```
+
+Résultat : Noms tries alphabetiquement.
+
+**Tri multiple** :
+```sparql
+ORDER BY DESC(?age) ?name
+```
+Signification : Trier par age decroissant, puis par nom croissant (pour ages identiques).
+
+> **Note** : Le tri s'applique **après** le filtrage et la sélection.",,,,,,,,fe16aa01a8dc7862,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,813436cc,markdown,fr,9581c2782b16e8e6,"Ces exemples montrent comment construire et afficher des requêtes SPARQL en utilisant `dotNetRDF`. Vous pouvez les exécuter dans un notebook pour voir les requêtes générées.
+",,,,,,,,9581c2782b16e8e6,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,0971f824,markdown,fr,ed5e8fceb849b7c1,"### Conclusion : Construction de requêtes SPARQL
+
+Le **QueryBuilder** offre une API fluide pour construire des requêtes SPARQL complexes :
+
+| Clause SPARQL | Méthode QueryBuilder | Fonction |
+|---------------|----------------------|----------|
+| **SELECT** | `.Select(variables)` | Variables a retourner |
+| **WHERE** | `.Where(pattern)` | Pattern de triplets |
+| **FILTER** | `.Filter(condition)` | Conditions de filtrage |
+| **OPTIONAL** | `.Optional(pattern)` | Patterns optionnels |
+| **UNION** | `.Union(pattern1, pattern2)` | Patterns alternatifs |
+| **ORDER BY** | `.OrderBy(variable)` | Tri des résultats |
+
+**Avantages du QueryBuilder** :
+- **Type safety** : Erreurs detectees a la compilation
+- **IntelliSense** : Autocompletion dans l'IDE
+- **Composition dynamique** : Construction conditionnelle de requêtes
+- **Lisibilite** : Code plus clair que les chaînes SPARQL
+
+**Exemple de composition dynamique** :
+```csharp
+var query = QueryBuilder.Select(""x"");
+if (filterByAge) {
+    query = query.Filter(age > 18);
+}
+if (sortByName) {
+    query = query.OrderBy(""name"");
+}
+```
+
+Nous allons maintenant utiliser ces requêtes pour interroger **DBpedia**.",,,,,,,,ed5e8fceb849b7c1,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,ea77eebf,markdown,fr,6a2567e64376686a,"## A la découverte de DBpedia avec RDF.Net
+
+RDF.Net peut être utilisé pour interroger DBpedia en utilisant SPARQL. Il offre des fonctionnalités pour créer des requêtes SPARQL et pour parser les résultats des requêtes. De plus, avec RDF.Net, les développeurs peuvent manipuler les données de DBpedia comme s'il s'agissait de graphes RDF locaux.
+
+DBpedia est un projet qui extrait et structure le contenu de Wikipedia afin de le rendre accessible et réutilisable. Il s'agit d'un vaste graphe de connaissances qui représente une grande partie des informations contenues dans Wikipedia sous une forme structurée et interrogeable. DBpedia fournit un point d'accès SPARQL, qui est une interface permettant d'interroger les données de DBpedia à l'aide de la langue SPARQL. RDF.Net nous permet d'interroger ce point d'accès facilement et efficacement.
+
+### 1. Interrogation d'un point d'accès SPARQL à distance
+
+Les points d'accès SPARQL à distance peuvent être interrogés à l'aide de la classe `SparqlRemoteEndpoint`. Cette classe est une enveloppe autour d'un point d'accès à distance qui envoie des requêtes au point d'accès, puis transforme la réponse en un `SparqlResultSet` ou un `IGraph`, selon le cas.
+
+Un point d'accès à distance est une combinaison d'un URI de point d'accès et d'un URI de graphe par défaut facultatif. `SparqlRemoteEndpoint` propose des méthodes spécifiques fortement typées pour réaliser des requêtes, ce qui signifie que vous n'avez pas besoin de vérifier le type et de couler le résultat. La méthode `QueryWithResultGraph(String sparqlQuery)` peut être utilisée pour faire une requête `CONSTRUCT` ou `DESCRIBE`, tandis que la méthode `QueryWithResultSet(String sparqlQuery)` peut être utilisée pour faire des requêtes `SELECT` et `ASK`. Vous pouvez également utiliser la méthode `QueryRaw(String sparqlQuery, out String ctype)` si vous souhaitez obtenir le flux de réponse brut du point d'accès et le traiter vous-même.
+
+Un point d'accès à distance peut être utilisé comme suit :",,,,,,,,6a2567e64376686a,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,c1956e1e,code,fr,ae8222abbb91d804,"using System;
+using VDS.RDF;
+using VDS.RDF.Query;
+
+public static void ExecuteAndDisplaySparqlQuery(SparqlRemoteEndpoint endpoint, string query, int resultLimit = 10)
+{
+    try
+    {
+        SparqlResultSet results = endpoint.QueryWithResultSet(query);
+        DisplaySparqlResultSet(results, resultLimit);
+    }
+    catch (Exception ex)
+    {
+        Console.WriteLine($""Erreur lors de l'exécution de la requête SPARQL : {ex.Message}"");
+    }
+}
+
+public static void DisplaySparqlResultSet(SparqlResultSet results, int resultLimit)
+{
+    if (results != null && results.Count > 0)
+    {
+        int count = 0;
+        foreach (var result in results)
+        {
+            Console.WriteLine(result.ToString());
+            count++;
+            if (count >= resultLimit)
+            {
+                Console.WriteLine($""...affiché {resultLimit} résultats sur {results.Count}."");
+                break;
+            }
+        }
+    }
+    else
+    {
+        Console.WriteLine(""Aucun résultat trouvé."");
+    }
+}
+
+public static void ExecuteAndDisplaySparqlDescribe(SparqlRemoteEndpoint endpoint, string query)
+{
+    try
+    {
+        IGraph graph = endpoint.QueryWithResultGraph(query);
+        DisplayGraphTriples(graph);
+    }
+    catch (Exception ex)
+    {
+        Console.WriteLine($""Erreur lors de l'exécution de la requête SPARQL DESCRIBE : {ex.Message}"");
+    }
+}
+
+public static void DisplayGraphTriples(IGraph graph, int resultLimit = 10)
+{
+    if (graph != null && graph.Triples.Count > 0)
+    {
+        int count = 0;
+        foreach (var triple in graph.Triples)
+        {
+            Console.WriteLine(triple.ToString());
+            count++;
+            if (count >= resultLimit)
+            {
+                Console.WriteLine($""...affiché {resultLimit} triples sur {graph.Triples.Count}."");
+                break;
+            }
+        }
+    }
+    else
+    {
+        Console.WriteLine(""Aucun triple trouvé."");
+    }
+}
+
+
+SparqlRemoteEndpoint endpoint = new SparqlRemoteEndpoint(new Uri(""http://dbpedia.org/sparql""), ""http://dbpedia.org"");
+// Exemple de requête SELECT
+string selectQuery = ""SELECT DISTINCT ?Concept WHERE {[] a ?Concept}"";
+Console.WriteLine(""Résultats de la requête SELECT :"");
+ExecuteAndDisplaySparqlQuery(endpoint, selectQuery);
+// Exemple de requête DESCRIBE
+string describeQuery = ""DESCRIBE <http://dbpedia.org/resource/Albert_Einstein>"";
+Console.WriteLine(""\nRésultats de la requête DESCRIBE :"");
+ExecuteAndDisplaySparqlDescribe(endpoint, describeQuery);
+// Autres exemples de requêtes intéressantes
+List<string> interestingQueries = new List<string>
+{
+    ""SELECT ?person ?link WHERE { <http://dbpedia.org/resource/Albert_Einstein> ?link ?person . }"",
+    ""SELECT ?film WHERE { ?film dbo:starring <http://dbpedia.org/resource/Brad_Pitt> . }"",
+    ""SELECT ?book WHERE { ?book dbo:author <http://dbpedia.org/resource/J._K._Rowling> . }"",
+    ""SELECT ?city WHERE { ?city dbo:country <http://dbpedia.org/resource/France> . }"",
+    ""SELECT ?team ?city WHERE { ?team dbo:league <http://dbpedia.org/resource/Premier_League> . ?team dbo:ground ?ground . ?ground dbo:location ?city . }""
+};
+foreach (var query in interestingQueries)
+{
+    Console.WriteLine(""\nRésultats de la requête :"");
+    ExecuteAndDisplaySparqlQuery(endpoint, query);
+}
+
+",,,,,,,,ae8222abbb91d804,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,f271c7f1,markdown,fr,50876bed1c25ab45,"### Interrogation de DBpedia
+
+**DBpedia** est une base de connaissances extraite de Wikipedia, accessible via SPARQL.
+
+**Fonction utilitaire** `ExecuteAndDisplaySparqlQuery()` :
+- Execute une requête sur l'endpoint DBpedia
+- Affiche les résultats dans un tableau formate
+- Limite le nombre de résultats (`resultsLimit`)
+
+| Paramètre | Type | Description |
+|-----------|------|-------------|
+| `endpoint` | `SparqlRemoteEndpoint` | Connexion a DBpedia |
+| `query` | `string` | Requête SPARQL |
+| `resultsLimit` | `int` | Nombre max de résultats |
+
+**Structure de la reponse SPARQL** :
+```json
+{
+  ""head"": { ""vars"": [""person"", ""link""] },
+  ""results"": {
+    ""bindings"": [
+      { ""person"": { ""type"": ""uri"", ""value"": ""http://..."" } },
+      ...
+    ]
+  }
+}
+```
+
+> **Important** : DBpedia peut etre lent ou indisponible. Toujours utiliser un timeout et gerer les erreurs.",,,,,,,,50876bed1c25ab45,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,77ece187,markdown,fr,0486645af393fb8e,"### 2. Requêtes SPARQL intéressantes sur DBpedia
+
+Comprendre l'utilité du SPARQL pour ceux qui sont habitués au SQL peut être facilité par des exemples de requêtes intéressantes. Voici quelques exemples de requêtes que vous pourriez trouver utiles :
+
+#### Trouver toutes les personnes liées à une personne spécifique (par exemple, Albert Einstein) :
+
+```sparql
+SELECT ?person ?link WHERE {
+  <http://dbpedia.org/resource/Albert_Einstein> ?link ?person .
+}
+```",,,,,,,,0486645af393fb8e,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,c4ada934,code,fr,c5e30f229f9f892e,"string query = ""SELECT ?person ?link WHERE { <http://dbpedia.org/resource/Albert_Einstein> ?link ?person . }"";
+ExecuteAndDisplaySparqlQuery(endpoint, query);",,,,,,,,c5e30f229f9f892e,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,41f8368a,markdown,fr,0b28d41dbcbe44e5,"#### Interpretation de la requête Albert Einstein
+
+**Requête** :
+```sparql
+SELECT ?person ?link
+WHERE {
+    <http://dbpedia.org/resource/Albert_Einstein> ?link ?person .
+}
+```
+
+**Signification** : ""Trouver toutes les relations (?link) et objets (?person) associes a Albert Einstein""
+
+**Résultats attendus** (exemples) :
+
+| link | person |
+|------|--------|
+| `dbo:birthPlace` | `dbr:Ulm` |
+| `dbo:almaMater` | `dbr:ETH_Zurich` |
+| `dbo:award` | `dbr:Nobel_Prize_in_Physics` |
+| `foaf:name` | ""Albert Einstein""@en |
+| `dbo:field` | `dbr:Theoretical_physics` |
+
+> **Note** : DBpedia contient des centaines de triplets par ressource. Limiter les résultats avec `LIMIT 20`.",,,,,,,,0b28d41dbcbe44e5,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,49b3dea0,markdown,fr,95b975ea3d20caa5,"#### Trouver tous les films dans lesquels un acteur spécifique (par exemple, Brad Pitt) a joué :
+
+
+```sparql
+SELECT ?film WHERE {
+  ?film dbo:starring <http://dbpedia.org/resource/Brad_Pitt> .
+}
+```",,,,,,,,95b975ea3d20caa5,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,a03a26b6,code,fr,075a6e1d40a896be,"string query = ""SELECT ?film WHERE { ?film dbo:starring <http://dbpedia.org/resource/Brad_Pitt> . }"";
+ExecuteAndDisplaySparqlQuery(endpoint, query);",,,,,,,,075a6e1d40a896be,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,a86d9f5e,markdown,fr,422d6c950932555c,"#### Films de Brad Pitt
+
+**Requête** :
+```sparql
+SELECT ?film
+WHERE {
+    ?film dbo:starring <http://dbpedia.org/resource/Brad_Pitt> .
+}
+```
+
+**Structure du triplet recherche** :
+```
+?film --[dbo:starring]--> Brad_Pitt
+```
+
+Signification : ""Quels films ont Brad Pitt comme acteur ?""
+
+**Predicat** `dbo:starring` : Relation ""X a comme acteur Y"" dans l'ontologie DBpedia.
+
+**Résultats attendus** (extrait) :
+- `http://dbpedia.org/resource/Fight_Club`
+- `http://dbpedia.org/resource/Ocean's_Eleven`
+- `http://dbpedia.org/resource/Troy_(film)`
+- ...
+
+> **Point important** : Les URIs DBpedia suivent le pattern `http://dbpedia.org/resource/Nom_Article_Wikipedia`.",,,,,,,,422d6c950932555c,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,aa336cdf,markdown,fr,6b2609dd692c919f,"#### Trouver tous les livres d'un auteur spécifique (par exemple, J.K. Rowling) :
+
+```sparql
+SELECT ?book WHERE {
+  ?book dbo:author <http://dbpedia.org/resource/J._K._Rowling> .
+}
+```",,,,,,,,6b2609dd692c919f,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,f2fd0d24,code,fr,c1eb4f4330072d26,"string query = ""SELECT ?book WHERE { ?book dbo:author <http://dbpedia.org/resource/J._K._Rowling> . }"";
+ExecuteAndDisplaySparqlQuery(endpoint, query);",,,,,,,,c1eb4f4330072d26,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,4f6dfcac,markdown,fr,43a1883d39631add,"#### Livres de J.K. Rowling
+
+**Requête** :
+```sparql
+SELECT ?book
+WHERE {
+    ?book dbo:author <http://dbpedia.org/resource/J._K._Rowling> .
+}
+```
+
+**Structure du triplet** :
+```
+?book --[dbo:author]--> J.K._Rowling
+```
+
+Signification : ""Quels livres ont J.K. Rowling comme auteur ?""
+
+**Résultats attendus** (extrait) :
+- `dbr:Harry_Potter_and_the_Philosopher's_Stone`
+- `dbr:Harry_Potter_and_the_Chamber_of_Secrets`
+- `dbr:The_Casual_Vacancy`
+- ...
+
+**Différence avec la requête Brad Pitt** :
+
+| Requête | Predicat | Domaine | Range |
+|---------|----------|---------|-------|
+| Films | `dbo:starring` | Film | Acteur |
+| Livres | `dbo:author` | Livre | Auteur |
+
+> **Note** : DBpedia distingue les classes (Film, Livre, Personne) via `rdf:type`.",,,,,,,,43a1883d39631add,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,557f67e7,markdown,fr,591db44a312ae57a,"#### Trouver toutes les villes dans un pays spécifique (par exemple, la France) :
+```sparql
+SELECT ?city WHERE {
+  ?city dbo:country <http://dbpedia.org/resource/France> .
+}
+```",,,,,,,,591db44a312ae57a,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,97815c27,code,fr,ce768ea2371e372d,"string query = ""SELECT ?city WHERE { ?city dbo:country <http://dbpedia.org/resource/France> . }"";
+ExecuteAndDisplaySparqlQuery(endpoint, query);",,,,,,,,ce768ea2371e372d,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,35b277b9,markdown,fr,4c1086396780ae24,"#### Villes de France
+
+**Requête** :
+```sparql
+SELECT ?city
+WHERE {
+    ?city dbo:country <http://dbpedia.org/resource/France> .
+}
+```
+
+**Structure du triplet** :
+```
+?city --[dbo:country]--> France
+```
+
+Signification : ""Quelles villes sont dans le pays France ?""
+
+**Résultats attendus** (extrait) :
+- `dbr:Paris`
+- `dbr:Lyon`
+- `dbr:Marseille`
+- `dbr:Toulouse`
+- ...
+
+**Point important** : La requête retourne des URIs, pas des labels. Pour obtenir les noms lisibles :
+
+```sparql
+SELECT ?city ?name
+WHERE {
+    ?city dbo:country dbr:France .
+    ?city rdfs:label ?name .
+    FILTER(LANG(?name) = ""fr"")
+}
+```
+
+> **Performance** : Cette requête peut retourner des milliers de résultats. Utiliser `LIMIT` et `OFFSET` pour la pagination.",,,,,,,,4c1086396780ae24,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,7228621e,markdown,fr,3faafc690bf26cec,"#### Trouver toutes les équipes de football de la Premier League anglaise et leurs villes respectives :
+
+```sparql
+SELECT ?team ?city WHERE {
+  ?team dbo:league <http://dbpedia.org/resource/Premier_League> .
+  ?team dbo:ground ?ground .
+  ?ground dbo:location ?city .
+}",,,,,,,,3faafc690bf26cec,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,fe3ce436,code,fr,51116e998bbe5ef3,"string query = ""SELECT ?team ?city WHERE { ?team dbo:league <http://dbpedia.org/resource/Premier_League> . ?team dbo:ground ?ground . ?ground dbo:location ?city . }"";
+ExecuteAndDisplaySparqlQuery(endpoint, query);",,,,,,,,51116e998bbe5ef3,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,95060fa2,markdown,fr,4a68a261bb383cc4,"#### Requête complexe : Équipes Premier League
+
+**Requête** :
+```sparql
+SELECT ?team ?city
+WHERE {
+    ?team dbo:league <http://dbpedia.org/resource/Premier_League> .
+    ?team dbo:ground ?ground .
+    ?ground dbo:location ?city .
+}
+```
+
+**Pattern de triplets** (chaîne de relations) :
+```
+?team --[dbo:league]--> Premier_League
+?team --[dbo:ground]--> ?ground
+?ground --[dbo:location]--> ?city
+```
+
+Signification : ""Trouver les équipes de Premier League, leur stade, et la ville du stade""
+
+**Exemple de résultat** :
+
+| team | city |
+|------|------|
+| `dbr:Manchester_United_F.C.` | `dbr:Manchester` |
+| `dbr:Arsenal_F.C.` | `dbr:London` |
+
+**Navigation de graphe** : Cette requête navigue a travers **3 noeuds** et **2 aretes**.
+
+> **Concept cle** : SPARQL permet de naviguer dans le graphe RDF en suivant les relations.",,,,,,,,4a68a261bb383cc4,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,b109ba66,markdown,fr,4c790ca78b70bad7,"### 3. Requêtes avancées
+
+Voici quelques requêtes SPARQL plus avancées et subtiles qui peuvent être exécutées sur le endpoint DBpedia :
+
+#### Rechercher tous les scientifiques lauréats du prix Nobel en physique et les classer par leur date de naissance :
+```sparql
+PREFIX dbpedia: <http://dbpedia.org/resource/>
+PREFIX dbpedia-owl: <http://dbpedia.org/ontology/>
+PREFIX dbpprop: <http://dbpedia.org/property/>
+
+SELECT ?scientist ?birth 
+WHERE {
+  ?scientist a dbpedia-owl:Scientist .
+  ?scientist dbpedia-owl:award dbpedia:Nobel_Prize_in_Physics .
+  ?scientist dbo:birthDate ?birth
+} 
+ORDER BY ?birth
+```",,,,,,,,4c790ca78b70bad7,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,9f3fb460,code,fr,bacd9dd5b26360f6,"string query = @""
+PREFIX dbpedia: <http://dbpedia.org/resource/>
+PREFIX dbpedia-owl: <http://dbpedia.org/ontology/>
+PREFIX dbpprop: <http://dbpedia.org/property/>
+
+SELECT ?scientist ?birth 
+WHERE {
+  ?scientist a dbpedia-owl:Scientist .
+  ?scientist dbpedia-owl:award dbpedia:Nobel_Prize_in_Physics .
+  ?scientist dbo:
+
+birthDate ?birth
+} 
+ORDER BY ?birth"";
+ExecuteAndDisplaySparqlQuery(endpoint, query);",,,,,,,,bacd9dd5b26360f6,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,db00d54b,markdown,fr,57d599e4404db0e7,"#### Requête avancee : Joueurs francais NBA
+
+**Requête** :
+```sparql
+PREFIX dbpedia: <http://dbpedia.org/resource/>
+PREFIX dbo: <http://dbpedia.org/ontology/>
+SELECT ?player ?name
+WHERE {
+    ?player a dbo:BasketballPlayer .
+    ?player dbo:birthPlace ?place .
+    ?place dbo:country dbpedia:France .
+    ?player foaf:name ?name .
+}
+```
+
+**Decomposition** :
+
+| Pattern | Signification |
+|---------|---------------|
+| `?player a dbo:BasketballPlayer` | X est un joueur de basket |
+| `?player dbo:birthPlace ?place` | X est ne a Y |
+| `?place dbo:country dbpedia:France` | Y est en France |
+| `?player foaf:name ?name` | Le nom de X est Z |
+
+**Prefixes utilises** :
+- `dbo:` - DBpedia Ontology (classes et proprietes)
+- `foaf:` - Friend of a Friend (proprietes de personnes)
+- `dbpedia:` - Ressources DBpedia
+
+> **Note** : `?player a dbo:BasketballPlayer` est un raccourci pour `?player rdf:type dbo:BasketballPlayer`.",,,,,,,,57d599e4404db0e7,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,b03c6781,markdown,fr,51a11ee481586f17,"### Trouver toutes les pages Wikipedia qui contiennent un lien vers le film d'aventure :
+
+```sparql
+SELECT DISTINCT ?film
+WHERE
+{
+   ?film dbo:wikiPageWikiLink dbr:Adventure_film .
+}
+```",,,,,,,,51a11ee481586f17,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,d78eca1f,code,fr,e87b65164b7d9a12,"string query = ""SELECT DISTINCT ?film WHERE { ?film dbo:wikiPageWikiLink dbr:Adventure_film . }"";
+ExecuteAndDisplaySparqlQuery(endpoint, query);",,,,,,,,e87b65164b7d9a12,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,a28aef98,markdown,fr,b8e6408ded214d6b,"#### Films d'aventure via wikiPageWikiLink
+
+**Requête** :
+```sparql
+SELECT DISTINCT ?film
+WHERE {
+    ?film dbo:wikiPageWikiLink dbr:Adventure_film .
+}
+```
+
+**Predicat** `dbo:wikiPageWikiLink` : Liens internes de Wikipedia.
+
+Signification : ""Films dont la page Wikipedia contient un lien vers l'article 'Adventure film'""
+
+**Utilite de DISTINCT** :
+- Sans `DISTINCT` : Un film peut apparaitre plusieurs fois (liens multiples)
+- Avec `DISTINCT` : Chaque film apparait une seule fois
+
+**Limite de cette approche** :
+- Basee sur les liens Wikipedia, pas sur une classification formelle
+- Peut inclure des faux positifs (films mentionnant les films d'aventure)
+- Peut manquer des films d'aventure sans lien explicite
+
+> **Meilleure approche** : Utiliser `?film dbo:genre dbr:Adventure_film` pour une classification formelle.",,,,,,,,b8e6408ded214d6b,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,33048c5e,markdown,fr,1c659691c1dc81f9,"#### En plus de la requête précédente, retourner le pageID, le résumé (abstract) et le nom du film :
+```sparql
+SELECT DISTINCT ?film, ?number, ?abstract, ?name
+WHERE
+{
+   ?film dbo:wikiPageWikiLink dbr:Adventure_film .
+   ?film dbo:wikiPageID ?number .
+   ?film rdfs:comment ?abstract .
+   ?film dbp:name ?name .
+}
+```",,,,,,,,1c659691c1dc81f9,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,ecbbd937,code,fr,9414dfd9d825001d,"string query = @""
+SELECT DISTINCT ?film, ?number, ?abstract, ?name
+WHERE
+{
+   ?film dbo:wikiPageWikiLink dbr:Adventure_film .
+   ?film dbo:wikiPageID ?number .
+   ?film rdfs:comment ?abstract .
+   ?film dbp:name ?name .
+}"";
+ExecuteAndDisplaySparqlQuery(endpoint, query);",,,,,,,,9414dfd9d825001d,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,c5dfcb02,markdown,fr,5132e25697633a90,"#### Enrichissement de la requête
+
+**Nouvelle requête** :
+```sparql
+SELECT DISTINCT ?film, ?number, ?abstract, ?name
+WHERE {
+    ?film dbo:wikiPageWikiLink dbr:Adventure_film .
+    ?film dbo:wikiPageID ?number .
+    ?film dbo:abstract ?abstract .
+    ?film foaf:name ?name .
+}
+```
+
+**Proprietes ajoutees** :
+
+| Propriete | Type | Exemple |
+|-----------|------|---------|
+| `dbo:wikiPageID` | Integer | `12345` (ID Wikipedia) |
+| `dbo:abstract` | Literal | Resume du film |
+| `foaf:name` | Literal | Titre du film |
+
+**Problème potentiel** : Les `abstract` existent souvent en **plusieurs langues**.
+
+Résultat sans filtre :
+```
+film: dbr:Avatar
+abstract: ""Avatar is a 2009 film...""@en
+abstract: ""Avatar est un film de 2009...""@fr
+abstract: ""Avatar ist ein Film von 2009...""@de
+```
+
+> **Solution** : Filtrer par langue (voir cellule suivante).",,,,,,,,5132e25697633a90,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,74917d00,markdown,fr,109dce8895cbf7d5,"#### Filtrer les films dont le résumé est en anglais :
+
+```sparql
+FILTER ( LANG ( ?abstract ) = 'en' )
+```
+
+Cette ligne de code peut être ajoutée à n'importe quelle requête pour filtrer les films dont le résumé est en anglais.
+
+#### Utiliser la fonction OPTIONAL pour retourner des champs qui peuvent ne pas être présents sur toutes les pages :
+
+```sparql
+OPTIONAL { ?film dbo:cinematography ?cinematography }
+```
+
+Cette ligne de code peut être ajoutée à n'importe quelle requête pour retourner le champ ""cinématographie"" d'un film, même si ce champ n'est pas présent sur toutes les pages.
+
+#### Grouper tous les objets dans un seul champ en utilisant GROUP_CONCAT :
+
+```sparql
+SELECT DISTINCT ?film, ?number, ?abstract, (GROUP_CONCAT(DISTINCT ?starring; SEPARATOR=""-"") AS ?starring), ?name, (GROUP_CONCAT(DISTINCT ?subject; SEPARATOR=""-"") AS ?subjects)
+, ?cinematography, ?director, ?gross, (GROUP_CONCAT(DISTINCT ?producer; SEPARATOR=""-"") AS ?producer), ?language
+WHERE
+{
+  ?film dbo:wikiPageWikiLink dbr:Romantic_comedy .
+  ?film dbo:wikiPageID ?number .
+  ?film dbp:starring ?starring .
+  ?film rdfs:comment ?abstract .
+  ?film dbp:name ?name .
+  OPTIONAL { ?film dct:subject ?subject} .
+  OPTIONAL { ?film dbo:cinematography ?cinematography } .
+  OPTIONAL { ?film dbo:director ?director } .
+  OPTIONAL { ?film dbo:gross ?gross } .
+  OPTIONAL { ?film dbo:producer ?producer } .
+  OPTIONAL { ?film dbp:language ?language } .
+
+  FILTER ( LANG ( ?abstract ) = 'en' )
+}
+```",,,,,,,,109dce8895cbf7d5,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,a3f1fb31,code,fr,5e6fe5776ba4cf72,"string query = @""
+SELECT DISTINCT ?film, ?number, ?abstract, (GROUP_CONCAT(DISTINCT ?starring; SEPARATOR='-') AS ?starring), ?name, (GROUP_CONCAT(DISTINCT ?subject; SEPARATOR='-') AS ?subjects)
+, ?cinematography, ?director, ?gross, (GROUP_CONCAT(DISTINCT ?producer; SEPARATOR='-') AS ?producer), ?language
+WHERE
+{
+  ?film dbo:wikiPageWikiLink dbr:Romantic_comedy .
+  ?film dbo:wikiPageID ?number .
+  ?film dbp:starring ?starring .
+  ?film rdfs:comment ?abstract .
+  ?film dbp:name ?name .
+  OPTIONAL { ?film dct:subject ?subject} .
+  OPTIONAL { ?film dbo:cinematography ?cinematography } .
+  OPTIONAL { ?film dbo:director ?director } .
+  OPTIONAL { ?film dbo:gross ?gross } .
+  OPTIONAL { ?film dbo:producer ?producer } .
+  OPTIONAL { ?film dbp:language ?language } .
+
+  FILTER ( LANG ( ?abstract ) = 'en' )
+}"";
+ExecuteAndDisplaySparqlQuery(endpoint, query);",,,,,,,,5e6fe5776ba4cf72,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,df16a293,markdown,fr,9bf812ff45464871,"#### Requête complexe avec GROUP_CONCAT
+
+**Requête complete** :
+```sparql
+SELECT DISTINCT ?film, ?number, ?abstract,
+       (GROUP_CONCAT(DISTINCT ?starring; SEPARATOR='-') AS ?starring),
+       ?name,
+       (GROUP_CONCAT(DISTINCT ?genre; SEPARATOR=',') AS ?genre)
+WHERE {
+    ...
+    OPTIONAL { ?film dbo:starring ?starring }
+    OPTIONAL { ?film dbo:genre ?genre }
+    FILTER(LANG(?abstract) = 'en')
+}
+GROUP BY ?film ?number ?abstract ?name
+```
+
+**Fonctions d'agregation** :
+
+| Fonction | Effet | Exemple |
+|----------|-------|---------|
+| **GROUP_CONCAT** | Concatene les valeurs | `""Actor1-Actor2-Actor3""` |
+| **SEPARATOR** | Separateur entre valeurs | `-` ou `,` |
+| **DISTINCT** | Elimine les doublons | Acteurs uniques |
+
+**Pourquoi GROUP BY ?** :
+- Un film a plusieurs acteurs -> plusieurs lignes sans GROUP BY
+- GROUP_CONCAT + GROUP BY -> une ligne par film avec acteurs concatenes
+
+**Exemple de résultat** :
+
+| film | starring | genre |
+|------|----------|-------|
+| Avatar | Sam Worthington-Zoe Saldana | Science fiction,Adventure |
+
+> **Note** : OPTIONAL permet de retourner les films **même s'ils n'ont pas d'acteurs ou de genres** enregistres.",,,,,,,,9bf812ff45464871,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,d6c1f84a,markdown,fr,4eca3bad7a0fb95c,"Ces requêtes avancées permettent d'obtenir des informations plus détaillées et spécifiques de DBpedia. Elles utilisent des concepts tels que les filtres, les options et le regroupement pour affiner les résultats de la requête.
+
+### 4. Chargement et sauvegarde des résultats
+
+Un `SparqlResultSet` peut être chargé/sauvegardé à l'aide des interfaces `ISparqlResultsReader` et `ISparqlResultsWriter` respectivement. Ces interfaces sont fonctionnellement très similaires aux interfaces `IRdfReader` et `IRdfWriter` décrites sur les pages `Reading RDF` et `Writing RDF`.
+
+Voici un exemple rapide :",,,,,,,,4eca3bad7a0fb95c,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,b120d3a4,code,fr,89af8def9a500b16,"using System;
+using VDS.RDF;
+using VDS.RDF.Query;
+using VDS.RDF.Writing;
+using VDS.RDF.Data;
+
+
+
+SparqlRemoteEndpoint endpoint = new SparqlRemoteEndpoint(new Uri(""http://dbpedia.org/sparql""));
+SparqlResultSet results = endpoint.QueryWithResultSet(""SELECT DISTINCT ?type WHERE { ?s a ?type } LIMIT 100"");
+// Maintenant, sauvegardez ceci sur le disque en tant que SPARQL JSON
+SparqlJsonWriter writer = new SparqlJsonWriter();
+writer.Save(results, ""example.srj"");
+// Sauvegarder ceci sur le disque en tant que SPARQL XML
+SparqlXmlWriter writer2 = new SparqlXmlWriter();
+writer2.Save(results, ""example.srx"");
+// Lire à nouveau les résultats à partir du fichier
+SparqlXmlParser parser = new SparqlXmlParser();
+SparqlResultSet results2 = new SparqlResultSet();
+parser.Load(results2, ""example.srx"");
+
+results2.Take(10).Display();
+",,,,,,,,89af8def9a500b16,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,217bfada,markdown,fr,6338653247dd56be,"#### Exemple d'exécution de requête SPARQL
+
+Le code précédent :
+1. **Définit une requête** - Recherche de pays francophones
+2. **Execute sur DBpedia** - Via `QueryWithResultSet()`
+3. **Affiche les résultats** - Avec le writer SPARQL Results XML
+
+**Requête executee** :
+```sparql
+SELECT ?country ?capital
+WHERE {
+    ?country a dbo:Country .
+    ?country dbo:officialLanguage dbr:French_language .
+    ?country dbo:capital ?capital .
+}
+```
+
+Signification : ""Pays ayant le francais comme langue officielle, et leur capitale""
+
+**Formats de résultats SPARQL** :
+
+| Format | Extension | Writer |
+|--------|-----------|--------|
+| **XML** | `.srx` | `SparqlXmlWriter` |
+| **JSON** | `.srj` | `SparqlJsonWriter` |
+| **CSV** | `.csv` | `SparqlCsvWriter` |
+| **TSV** | `.tsv` | `SparqlTsvWriter` |
+
+> **Note** : Le format XML est verbeux mais standard W3C.",,,,,,,,6338653247dd56be,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,e13e40d8,markdown,fr,90102205969b3765,"### D. Utilisation d’une abstraction de haut niveau avec Trinity RDF
+
+#### 1. Comment Trinity RDF simplifie la gestion de RDF
+
+Trinity RDF offre une abstraction orientée objet pour les données RDF. Avec Trinity RDF, les développeurs peuvent travailler avec des données RDF comme s'ils travaillaient avec des objets .NET normaux. Trinity RDF automatise également certaines tâches courantes, comme la création de triples RDF et la sérialisation des données RDF.
+
+#### 2. Exemple d'application de Trinity RDF",,,,,,,,90102205969b3765,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,5f463e52,code,fr,76c1b02b75ed075a,"// #i ""nuget: https://api.nuget.org/v3/index.json""
+#r ""nuget: dotNetRDF""
+#r ""nuget: OpenLink.Data.Virtuoso""
+#r ""nuget: Semiodesk.Trinity""
+#r ""nuget: Semiodesk.Trinity.Virtuoso""
+",,,,,,,,76c1b02b75ed075a,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,b1749a4d,markdown,fr,bbeb1bcf3ccba414,"### Trinity RDF : Abstraction de haut niveau
+
+**Trinity RDF** est un ORM (Object-Relational Mapping) pour RDF :
+
+| Concept | RDF classique | Trinity RDF |
+|---------|---------------|-------------|
+| **Graphe** | `IGraph` | `IModel` |
+| **Triplet** | `Triple` | Proprietes C# |
+| **Noeud** | `INode` | Objets C# |
+| **Store** | `ITripleStore` | `IStore` |
+
+**Principe** : Mapper des classes C# sur des ontologies RDF.
+
+```csharp
+// RDF classique
+IUriNode person = g.CreateUriNode("":john"");
+IUriNode name = g.CreateUriNode(""foaf:name"");
+ILiteralNode value = g.CreateLiteralNode(""John Doe"");
+g.Assert(new Triple(person, name, value));
+
+// Trinity RDF (exemple conceptuel)
+var person = new Person { Name = ""John Doe"" };
+model.AddResource(person);
+```
+
+> **Limitation** : Necessite un Triple Store compatible (Virtuoso, Stardog, etc.). Les cellules suivantes sont **optionnelles** car elles dependent d'un serveur externe.",,,,,,,,bbeb1bcf3ccba414,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,df91d197,markdown,fr,441ce79892bd07b8,"## Section optionnelle : connexion a Virtuoso (legacy)
+
+> **Note pedagogique** — Cette cellule etait un exemple de connexion au triple store **Virtuoso** via la librairie `dotNetRDF`. Elle est conservee a titre documentaire mais n'est plus executee :
+>
+> 1. Virtuoso n'est pas installe sur les machines cluster du cours
+> 2. Le notebook RDF.Net est explicitement deplace en `RDF.Net-Legacy/` (cf commit `a9afcfbd`) et n'est plus une cible pedagogique principale. Voir `SemanticWeb/SW-1` a `SW-13` pour le parcours actuel.
+>
+> Le code original est preserve ci-dessous a titre de reference :
+
+```csharp
+// SECTION OPTIONNELLE: Connexion a Virtuoso (serveur externe requis)
+// Cette section necessite un serveur Virtuoso installe et configure
+// Si vous n'avez pas Virtuoso, cette cellule affichera un message d'information
+
+using VDS.RDF;
+using VDS.RDF.Storage;
+using VDS.RDF.Query;
+
+try
+{
+    Console.WriteLine(""NOTE: Cette section necessite un serveur Virtuoso externe."");
+    Console.WriteLine(""Si Virtuoso n'est pas installe, les exemples suivants ne fonctionneront pas."");
+    Console.WriteLine(""Pour installer Virtuoso: https://virtuoso.openlinksw.com/"");
+    Console.WriteLine("""");
+    
+    // Tenter la connexion a Virtuoso
+    VirtuosoManager virtuoso = new VirtuosoManager(""localhost"", 1111, ""DB"", ""user"", ""password"");
+    PersistentTripleStore store = new PersistentTripleStore(virtuoso);
+    
+    Console.WriteLine(""Connexion Virtuoso reussie!"");
+    
+    // Liste les graphes disponibles
+    foreach (var graphUri in store.Graphs.GraphUris)
+    {
+        Console.WriteLine($""Graphe: {graphUri}"");
+    }
+    
+    store.Dispose();
+    virtuoso.Dispose();
+}
+catch (Exception ex)
+{
+    Console.WriteLine($""INFO: Virtuoso non disponible (attendu si serveur non installe): {ex.Message}"");
+    Console.WriteLine("""");
+    Console.WriteLine(""Cette erreur est NORMALE si Virtuoso n'est pas installe sur cette machine."");
+}
+```
+",,,,,,,,441ce79892bd07b8,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,0fa9cb98,markdown,fr,34d6b784f565663a,"**Note sur la section Virtuoso :**
+
+La cellule suivante tente de se connecter a **Virtuoso**, un Triple Store serveur.
+
+**Pourquoi cette section est optionnelle ?** :
+- Virtuoso doit etre **installe et demarre** separement
+- Configuration requise : hostname, port, credentials
+- Ne fonctionne pas ""out of the box"" dans ce notebook
+
+**Alternative pour tester Trinity** :
+- Utiliser un store en memoire (sans persistence)
+- Utiliser SQLite comme backend (pas besoin de serveur)
+
+**Message d'erreur attendu** :
+```
+Connection failed: No connection could be made because the target machine actively refused it
+```
+
+> **Pour les utilisateurs avances** : Installer Virtuoso Open Source et configurer les paramètres de connexion.",,,,,,,,34d6b784f565663a,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,53d0ee0c,markdown,fr,258fb693a0c7e950,"### E. Inférence avec OWL
+
+#### 1. Concepts de base d'OWL
+
+OWL, ou Web Ontology Language, est un langage de représentation de connaissances pour le Web sémantique, développé par le W3C. OWL permet aux utilisateurs de définir des ontologies, qui sont des modèles de connaissances structurés qui décrivent les concepts dans un domaine et les relations entre ces concepts.
+
+#### 2. Comment utiliser OWL avec RDF.Net
+
+RDF.Net offre des fonctionnalités pour manipuler les ontologies OWL. Les développeurs peuvent utiliser RDF.Net pour créer, modifier et interroger des ontologies OWL, et pour utiliser ces ontologies pour effectuer des inférences sur les données RDF.
+
+#### 3. Exemple de base
+
+##### Avec l'API Ontologie :",,,,,,,,258fb693a0c7e950,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,2ac61fe0,code,fr,3672c31396aac0c3,"// SECTION DEMO: Manipulation d'ontologies avec OntologyGraph
+// Cette section utilise un fichier Ontology.rdf d'exemple
+
+using System;
+using System.Linq;
+using VDS.RDF;
+using VDS.RDF.Ontology;
+using VDS.RDF.Parsing;
+using Graph = VDS.RDF.Graph;
+
+try
+{
+
+
+    // Créer un exemple d'ontologie en mémoire au lieu de charger un fichier
+    OntologyGraph g = new OntologyGraph();
+    
+    // Définir des namespaces
+    g.NamespaceMap.AddNamespace(""ex"", new Uri(""http://example.org/""));
+    g.NamespaceMap.AddNamespace(""rdfs"", new Uri(""http://www.w3.org/2000/01/rdf-schema#""));
+    
+    // Créer une hiérarchie de classes simple
+    var animal = g.CreateOntologyClass(new Uri(""http://example.org/Animal""));
+    var mammal = g.CreateOntologyClass(new Uri(""http://example.org/Mammal""));
+    var dog = g.CreateOntologyClass(new Uri(""http://example.org/Dog""));
+    
+    // Ajouter les relations de sous-classe
+    g.Assert(new Triple(
+        g.CreateUriNode(new Uri(""http://example.org/Mammal"")),
+        g.CreateUriNode(new Uri(""http://www.w3.org/2000/01/rdf-schema#subClassOf"")),
+        g.CreateUriNode(new Uri(""http://example.org/Animal""))
+    ));
+    g.Assert(new Triple(
+        g.CreateUriNode(new Uri(""http://example.org/Dog"")),
+        g.CreateUriNode(new Uri(""http://www.w3.org/2000/01/rdf-schema#subClassOf"")),
+        g.CreateUriNode(new Uri(""http://example.org/Mammal""))
+    ));
+    
+    Console.WriteLine(""Hiérarchie de classes créée:"");
+    Console.WriteLine(""  Animal"");
+    Console.WriteLine(""    └── Mammal"");
+    Console.WriteLine(""          └── Dog"");
+    Console.WriteLine($""Nombre de triplets: {g.Triples.Count}"");
+    Console.WriteLine(""✓ Section OntologyGraph terminée avec succès"");
+}
+catch (Exception ex)
+{
+    Console.WriteLine($""Erreur dans la section OntologyGraph: {ex.Message}"");
+}",,,,,,,,3672c31396aac0c3,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,affe4b8b,markdown,fr,2eb570e34c3e9a8b,"### Ontologies avec OntologyGraph
+
+**OntologyGraph** : Extension d'`IGraph` specialisee pour les **ontologies OWL**.
+
+| Classe standard | Classe ontologie | Fonction |
+|-----------------|------------------|----------|
+| `IGraph` | `OntologyGraph` | Graphe avec helpers OWL |
+| `INode` | `OntologyClass` | Classe OWL |
+| `INode` | `OntologyProperty` | Propriete OWL |
+
+**Helpers disponibles** :
+- `GetOntologyClass(uri)` - Acceder a une classe
+- `GetOntologyProperty(uri)` - Acceder a une propriete
+- `CreateOntologyClass(uri)` - Créer une classe
+- Navigation de hiérarchies (`SubClassOf`, `SuperClassOf`)
+
+**Exemple de fichier Ontology.rdf** :
+```xml
+<owl:Class rdf:about=""&ex;Person"">
+    <rdfs:subClassOf rdf:resource=""&owl;Thing""/>
+</owl:Class>
+<owl:ObjectProperty rdf:about=""&ex;hasParent"">
+    <rdfs:domain rdf:resource=""&ex;Person""/>
+    <rdfs:range rdf:resource=""&ex;Person""/>
+</owl:ObjectProperty>
+```
+
+> **Note** : La cellule suivante necessite un fichier `Ontology.rdf` d'exemple (absent dans le notebook vierge).",,,,,,,,2eb570e34c3e9a8b,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,f47763c7,markdown,fr,5740fffeb0886183,##### Avec les API de Graphe et de Triple :,,,,,,,,5740fffeb0886183,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,3409a42b,code,fr,f4cc71cc8fd02d55,"// SECTION DEMO: Navigation dans un graphe RDF
+// Exemple avec des données créées en mémoire
+using VDS.RDF;
+using VDS.RDF.Parsing;
+
+try
+{
+    
+    
+    // Créer un graphe avec une hiérarchie simple
+    IGraph g = new VDS.RDF.Graph();
+    g.NamespaceMap.AddNamespace(""ex"", new Uri(""http://example.org/""));
+    g.NamespaceMap.AddNamespace(""rdfs"", new Uri(""http://www.w3.org/2000/01/rdf-schema#""));
+    
+    IUriNode subClassOf = g.CreateUriNode(new Uri(""http://www.w3.org/2000/01/rdf-schema#subClassOf""));
+    IUriNode animal = g.CreateUriNode(new Uri(""http://example.org/Animal""));
+    IUriNode mammal = g.CreateUriNode(new Uri(""http://example.org/Mammal""));
+    IUriNode dog = g.CreateUriNode(new Uri(""http://example.org/Dog""));
+    
+    g.Assert(new Triple(mammal, subClassOf, animal));
+    g.Assert(new Triple(dog, subClassOf, mammal));
+    
+    // Navigation: trouver les super-classes de Dog
+    Console.WriteLine(""Super-classes de Dog:"");
+    foreach (Triple t in g.GetTriplesWithSubjectPredicate(dog, subClassOf))
+    {
+        Console.WriteLine($""  - {t.Object}"");
+    }
+    
+    Console.WriteLine(""✓ Section navigation RDF terminée avec succès"");
+}
+catch (Exception ex)
+{
+    Console.WriteLine($""Erreur: {ex.Message}"");
+}",,,,,,,,f4cc71cc8fd02d55,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,84f0ca18,markdown,fr,1ac3fb81ac233e67,"### Navigation dans un graphe RDF
+
+Le code précédent créé un **graphe d'exemple en memoire** pour demonstrer la navigation :
+
+**Triplets crees** :
+```turtle
+@prefix ex: <http://example.org/> .
+ex:Alice ex:knows ex:Bob .
+ex:Bob ex:knows ex:Charlie .
+ex:Alice ex:age ""30""^^xsd:integer .
+```
+
+**Navigation possible** :
+1. **Suivre les relations** - De Alice vers Bob via `knows`
+2. **Obtenir les proprietes** - Age de Alice
+3. **Traverser le graphe** - Alice -> Bob -> Charlie
+
+**Code de navigation** :
+```csharp
+IUriNode knows = g.GetUriNode(new Uri(""http://example.org/knows""));
+INode alice = g.GetUriNode(new Uri(""http://example.org/Alice""));
+
+// Qui Alice connait-elle ?
+var friends = g.GetTriplesWithSubjectPredicate(alice, knows);
+foreach (Triple t in friends) {
+    Console.WriteLine($""Alice knows {t.Object}"");
+}
+```
+
+> **Avantage de RDF** : Navigation flexible sans schema fixe.",,,,,,,,1ac3fb81ac233e67,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,69e9dcd1,markdown,fr,2a7b68196565ac73,"### 4. Concepts
+
+L'API fournit les concepts suivants :
+
+- **OntologyGraph** : Représente un graphe dont les éléments d'ontologie peuvent être accédés.
+- **Ontology** : Représente des informations sur une ontologie.
+- **OntologyResource** : Représente une ressource dans l'ontologie.
+- **OntologyClass** : Représente une classe dans une ontologie.
+- **OntologyProperty** : Représente une propriété dans une ontologie.
+- **Individual** : Représente une instance d'une classe dans une ontologie.
+
+### 5. Inférence
+
+L'inférence et le raisonnement sont des mécanismes par lesquels une application peut découvrir des informations supplémentaires qui ne sont pas explicitement indiquées dans les données initiales. 
+
+#### a) L'interface IInferenceEngine
+
+L'interface `IInferenceEngine` a deux principales méthodes :
+
+- **Initialise(IGraph g)** : Initialise le raisonneur avec un graphe de schéma/règles.
+- **Apply()** : Applique l'inférence à un graphe.
+
+#### b) Implémentations Existantes
+
+Trois types de raisonneurs sont actuellement fournis :
+
+1. **Raisonneur RDFS** : Pour les hiérarchies de classes et de propriétés.
+2. **Raisonneur SKOS** : Pour les taxonomies de concepts.
+3. **Simple N3 Rules Reasoner** : Pour appliquer de simples règles N3.
+
+#### Exemple de Raisonneur RDFS",,,,,,,,2a7b68196565ac73,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,5ffcb7d0,code,fr,5b1bc5bbf62dede5,"// SECTION DEMO: Inférence RDFS
+// Exemple avec des données créées en mémoire
+
+using VDS.RDF;
+using VDS.RDF.Parsing;
+
+try
+{
+    
+    
+    
+    // Créer un graphe de données
+    Graph data = new Graph();
+    data.NamespaceMap.AddNamespace(""ex"", new Uri(""http://example.org/""));
+    data.NamespaceMap.AddNamespace(""rdf"", new Uri(""http://www.w3.org/1999/02/22-rdf-syntax-ns#""));
+    data.NamespaceMap.AddNamespace(""rdfs"", new Uri(""http://www.w3.org/2000/01/rdf-schema#""));
+    
+    IUriNode rdfType = data.CreateUriNode(new Uri(""http://www.w3.org/1999/02/22-rdf-syntax-ns#type""));
+    IUriNode subClassOf = data.CreateUriNode(new Uri(""http://www.w3.org/2000/01/rdf-schema#subClassOf""));
+    
+    // Définir le schéma: Car est une sous-classe de Vehicle
+    IUriNode vehicle = data.CreateUriNode(new Uri(""http://example.org/Vehicle""));
+    IUriNode car = data.CreateUriNode(new Uri(""http://example.org/Car""));
+    data.Assert(new Triple(car, subClassOf, vehicle));
+    
+    // Données: myCar est de type Car
+    IUriNode myCar = data.CreateUriNode(new Uri(""http://example.org/myCar""));
+    data.Assert(new Triple(myCar, rdfType, car));
+    
+    Console.WriteLine(""Données RDF:"");
+    Console.WriteLine(""  - Car rdfs:subClassOf Vehicle"");
+    Console.WriteLine(""  - myCar rdf:type Car"");
+    Console.WriteLine($""Nombre de triplets: {data.Triples.Count}"");
+    
+    // Avec inférence RDFS, myCar serait aussi de type Vehicle
+    Console.WriteLine(""Avec inférence RDFS, on pourrait déduire:"");
+    Console.WriteLine(""  - myCar rdf:type Vehicle (par transitivité)"");
+    
+    Console.WriteLine(""✓ Section inférence RDFS terminée avec succès"");
+}
+catch (Exception ex)
+{
+    Console.WriteLine($""Erreur: {ex.Message}"");
+}",,,,,,,,5b1bc5bbf62dede5,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,add56d3d,markdown,fr,af5a97db6c9500f2,"### Inference RDFS
+
+**RDFS (RDF Schema)** définit une sémantique de base pour RDF :
+
+| Constructeur RDFS | Signification |
+|-------------------|---------------|
+| `rdfs:subClassOf` | A est une sous-classe de B |
+| `rdfs:subPropertyOf` | P1 est une sous-propriete de P2 |
+| `rdfs:domain` | La propriete P s'applique aux instances de C |
+| `rdfs:range` | La propriete P a des valeurs de type C |
+
+**Exemple d'inference** :
+```turtle
+# Données
+ex:Dog rdfs:subClassOf ex:Animal .
+ex:Fido rdf:type ex:Dog .
+
+# Inference automatique
+ex:Fido rdf:type ex:Animal .  # Deduit par transitivite
+```
+
+**Moteurs d'inference RDF.Net** :
+- **StaticRdfsReasoner** - Inference RDFS complete
+- **OwlReasoner** - Inference OWL (plus complexe)
+
+> **Performance** : L'inference peut etre couteuse sur de gros graphes. Elle est souvent faite a la creation, pas a chaque requête.",,,,,,,,af5a97db6c9500f2,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/RDF.Net.ipynb,a1b33196,markdown,fr,bfd9d411218dfd99,"### 6. Conclusion
+
+Les fonctionnalités de Trinity RDF et les capacités d'inférence d'OWL dans RDF.Net permettent de manipuler des données RDF de manière plus intuitive et efficace. Grâce à ces outils, les développeurs peuvent interroger, inférer et travailler avec des graphes RDF et des ontologies de manière simplifiée et puissante.
+
+---
+
+**Retour au sommaire** : [Index SemanticWeb](../README.md)",,,,,,,,bfd9d411218dfd99,,,,,,,


### PR DESCRIPTION
## Objet

3rd pass of the T2 durable resync vein (casestudies #7317 c.646, audio #7319 c.647). La campagne accent-cure (#7272/#7273/#7277 + SW-specific cures) a corrigé le français ASCII -> accents propres dans les sources SymbolicAI/SemanticWeb Python. Le CSV `translations/semanticweb/semanticweb.csv`, seedé avant, avait stale pivot -> **498 SRC_DRIFT**. De plus, **174 nouvelles cells** détectées (notebooks ont grandi depuis le seed) et ajoutées.

## Changement

Resync via `extract_cells_to_csv.py --update` (whole SemanticWeb family — SW-8 SHACL, SW-9 JSONLD, SW-10 RDFStar, SW-11 KnowledgeGraphs, SW-12 GraphRAG, SW-4b SPARQL, etc.) :
- **498 rows refreshed** + **174 NEW rows added**, 695 already in-sync
- 0 orphan
- **0 prior translations lost** (0 rows had text_en/es/ru/zh/ar filled)

## Verification (firsthand, fresh worktree origin/main @ 4c81b1c9a)

- `check_translation_sync.py` **AVANT** : 498 anomalies (SRC_DRIFT)
- **APRES** : `0 anomalies` ✓
- Diff : 1 fichier, +4941/-1815 (498 refresh + 174 new rows, coherent)
- 2306 accented chars now present in text_fr (was ASCII pre-campaign)
- Catalogue byte-identique à main (CSV traduction ≠ catalogue)

## Scope atomique + R6 note

1 famille (symbolicai/semanticweb), 1 fichier CSV. Per R6 cap, families resync separately. Cette passe est un **rattrapage one-shot post-accent-campaign** (~8054 repo-wide drift / 15000 cures), pas un registre récurrent monotone — distinct du nettoyage routine plafonné R6.6. Still pending : search-applications (518), QC-py (467), planners (428), etc.

See #4957. Credential = jsboige active this cycle (push:true upstream).

Co-Authored-By: Claude-Code <noreply@anthropic.com>