### PR TITLE
chore(translation,#4957): resync Search/Applications CSV post-accent-cure (519 rows, 0 drift)

### DIFF
--- a/translations/search-applications/search-applications.csv
+++ b/translations/search-applications/search-applications.csv
@@ -2,45 +2,45 @@ notebook,cell_id,cell_type,src_lang,src_hash,text_fr,text_en,text_es,text_ar,tex
 MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,0a26702c,code,fr,d8cfd07b7b0f3965,"# Parameters
 BATCH_MODE = ""true""
 ",,,,,,,,d8cfd07b7b0f3965,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,header,markdown,fr,2933e1482bfc39f9,"# App-1 : Le Probleme des N-Reines
+MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,header,markdown,fr,8977b74b468694d6,"# App-1 : Le Problème des N-Reines
 
 **Navigation** : [Index](../../README.md) | [Part2-CSP](../../Part2-CSP/README.md) | [App-2 GraphColoring >>](App-2-GraphColoring.ipynb)
 
 ## Objectifs d'apprentissage
 
 A la fin de ce notebook, vous saurez :
-1. **Formaliser** le probleme des N-Reines comme un CSP (variables, domaines, contraintes) -- *Bloom : Comprendre*
+1. **Formaliser** le problème des N-Reines comme un CSP (variables, domaines, contraintes) -- *Bloom : Comprendre*
 2. **Implementer** un solveur par backtracking avec heuristiques (MRV, Forward Checking) -- *Bloom : Appliquer*
-3. **Comparer** backtracking, min-conflicts et OR-Tools CP-SAT sur differentes tailles -- *Bloom : Analyser*
-4. **Evaluer** les forces et limites de chaque approche selon la taille du probleme -- *Bloom : Evaluer*
+3. **Comparer** backtracking, min-conflicts et OR-Tools CP-SAT sur différentes tailles -- *Bloom : Analyser*
+4. **Evaluer** les forces et limites de chaque approche selon la taille du problème -- *Bloom : Evaluer*
 
 ### Prerequis
 - Python 3.10+, matplotlib, numpy, ortools
 - [CSP-1 : Fundamentals](../../Part2-CSP/CSP-1-Fundamentals.ipynb) -- backtracking, MRV, formalisme CSP
 
-### Duree estimee : 30 minutes",,,,,,,,2933e1482bfc39f9,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,section-1-intro,markdown,fr,3ea2d05bb0691a6f,"---
+### Duree estimee : 30 minutes",,,,,,,,8977b74b468694d6,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,section-1-intro,markdown,fr,e11db0ca770415bd,"---
 
 ## 1. Introduction (~3 min)
 
-Le probleme des **N-Reines** est l'un des benchmarks les plus celebres en informatique et en intelligence artificielle. L'enonce est simple :
+Le problème des **N-Reines** est l'un des benchmarks les plus celebres en informatique et en intelligence artificielle. L'enonce est simple :
 
-> Placer $N$ reines sur un echiquier $N \times N$ de sorte qu'aucune paire de reines ne s'attaque mutuellement (ni meme ligne, ni meme colonne, ni meme diagonale).
+> Placer $N$ reines sur un echiquier $N \times N$ de sorte qu'aucune paire de reines ne s'attaque mutuellement (ni même ligne, ni même colonne, ni même diagonale).
 
 ### Historique
 
 | Date | Auteur | Contribution |
 |------|--------|--------------|
-| 1848 | Max Bezzel | Pose le probleme pour N=8 dans un journal d'echecs |
-| 1850 | Franz Nauck | Premiere solution complète et generalisation a N reines |
-| 1874 | S. Gunther & J.W.L. Glaisher | Premiere approche systematique par determinants |
+| 1848 | Max Bezzel | Pose le problème pour N=8 dans un journal d'echecs |
+| 1850 | Franz Nauck | Première solution complète et generalisation a N reines |
+| 1874 | S. Gunther & J.W.L. Glaisher | Première approche systématique par determinants |
 | 1992 | Sosic & Gu | Min-Conflicts : resolution quasi-lineaire en temps |
 
-### Pourquoi ce probleme est important
+### Pourquoi ce problème est important
 
 - **Benchmark CSP** : il sert a evaluer les algorithmes de satisfaction de contraintes
 - **Scalabilite** : l'espace de recherche croit exponentiellement ($N^N$ naif), mais des algorithmes intelligents resolvent $N = 10^6$ en secondes
-- **Pedagogie** : il illustre parfaitement la difference entre recherche systematique et recherche locale",,,,,,,,3ea2d05bb0691a6f,,,,,,,
+- **Pedagogie** : il illustre parfaitement la différence entre recherche systématique et recherche locale",,,,,,,,e11db0ca770415bd,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,imports,code,fr,23c496567579dbf6,"# Imports pour tout le notebook
 import sys
 import time
@@ -59,7 +59,7 @@ random.seed(42)
 np.random.seed(42)
 
 print(""Imports OK"")",,,,,,,,23c496567579dbf6,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,section-2-formulation,markdown,fr,5051c49608e0b7a5,"---
+MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,section-2-formulation,markdown,fr,cb320a0c757b417b,"---
 
 ## 2. Formulation comme CSP (~5 min)
 
@@ -70,7 +70,7 @@ La cle d'une resolution efficace est de choisir une bonne representation. Puisqu
 | Composant CSP | Définition | Taille |
 |---------------|------------|--------|
 | **Variables** | $Q_0, Q_1, \ldots, Q_{N-1}$ (une par colonne) | $N$ |
-| **Domaines** | $D_i = \{0, 1, \ldots, N-1\}$ (numero de ligne) | $N$ valeurs chacun |
+| **Domaines** | $D_i = \{0, 1, \ldots, N-1\}$ (numéro de ligne) | $N$ valeurs chacun |
 | **Contraintes** | Pour tout $i \neq j$ : $Q_i \neq Q_j$ et $|i - j| \neq |Q_i - Q_j|$ | $\binom{N}{2}$ paires |
 
 ### Espace de recherche
@@ -87,10 +87,10 @@ Pour $N = 8$ : $N^N = 16\,777\,216$ tandis que $N! = 40\,320$ -- un facteur de r
 
 Pour deux reines aux colonnes $i$ et $j$ (avec $i < j$), il faut :
 
-$$Q_i \neq Q_j \quad \text{(pas meme ligne)}$$
-$$|Q_i - Q_j| \neq |i - j| \quad \text{(pas meme diagonale)}$$
+$$Q_i \neq Q_j \quad \text{(pas même ligne)}$$
+$$|Q_i - Q_j| \neq |i - j| \quad \text{(pas même diagonale)}$$
 
-La contrainte de colonne est deja satisfaite par construction (une variable par colonne).",,,,,,,,5051c49608e0b7a5,,,,,,,
+La contrainte de colonne est déjà satisfaite par construction (une variable par colonne).",,,,,,,,cb320a0c757b417b,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,pre-visualization,markdown,fr,c556f437dd67846a,"Implementons d'abord une fonction de visualisation de l'echiquier, puis verifions visuellement une solution connue pour $N = 8$.",,,,,,,,c556f437dd67846a,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,draw-queens,code,fr,c31f830f13931ad0,"def draw_queens(queens, n=None, title=""Solution N-Reines"", ax=None):
     """"""Visualise un placement de reines sur un echiquier.
@@ -178,7 +178,7 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,interp-visualizati
 | Diagonales | Aucune paire en attaque diagonale |
 
 > **Remarque** : pour $N = 8$, il existe exactement **92 solutions distinctes** (12 fondamentales sous symetries). Nous les enumererons dans la section CP-SAT.",,,,,,,,7d4efaa1b4cb296a,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,section-3-backtracking,markdown,fr,7448b907e4f5e801,"---
+MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,section-3-backtracking,markdown,fr,73e307d969757d75,"---
 
 ## 3. Approche 1 : Backtracking (~7 min)
 
@@ -190,7 +190,7 @@ Le backtracking est la méthode de reference pour les CSP. Nous allons implement
 
 ### 3.1 Backtracking simple
 
-L'algorithme place une reine dans chaque colonne de gauche a droite. Pour chaque ligne candidate, il verifie si la reine est en conflit avec les reines deja placees.",,,,,,,,7448b907e4f5e801,,,,,,,
+L'algorithme place une reine dans chaque colonne de gauche a droite. Pour chaque ligne candidate, il verifie si la reine est en conflit avec les reines déjà placees.",,,,,,,,73e307d969757d75,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,backtracking-simple,code,fr,6c47ad8ba960641d,"def is_safe(queens, col, row):
     """"""Verifie si placer une reine en (col, row) est compatible
     avec les reines deja placees dans queens[0..col-1].""""""
@@ -364,9 +364,9 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,backtracking-fc,co
 sol_fc, nodes_fc = backtracking_fc(8)
 print(f""Solution (FC+MRV) : {sol_fc}"")
 print(f""Noeuds explores   : {nodes_fc}"")",,,,,,,,e3ed8a5e04476507,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,pre-bt-benchmark,markdown,fr,ce4978572c7066a4,"### 3.4 Benchmark des variantes de backtracking
+MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,pre-bt-benchmark,markdown,fr,959ed37730d997f8,"### 3.4 Benchmark des variantes de backtracking
 
-Comparons les trois variantes sur differentes tailles de probleme. Le nombre de noeuds explores et le temps d'execution mesurent l'efficacite.",,,,,,,,ce4978572c7066a4,,,,,,,
+Comparons les trois variantes sur différentes tailles de problème. Le nombre de noeuds explores et le temps d'exécution mesurent l'efficacite.",,,,,,,,959ed37730d997f8,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,bt-benchmark,code,fr,7b81ee57eb2b0f4c,"def run_benchmark_bt(sizes):
     """"""Benchmark des trois variantes de backtracking.""""""
     results = {name: {'nodes': [], 'times': []}
@@ -397,7 +397,7 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,bt-benchmark,code,
 
 bt_sizes = [4, 8, 12, 16]
 bt_results = run_benchmark_bt(bt_sizes)",,,,,,,,7b81ee57eb2b0f4c,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,64rpqkrfmr4,markdown,fr,7c6d5582d3f39726,Tracons les résultats en echelle logarithmique pour mieux apprecier les differences entre variantes.,,,,,,,,7c6d5582d3f39726,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,64rpqkrfmr4,markdown,fr,7c7949da0df9f5f4,Tracons les résultats en echelle logarithmique pour mieux apprecier les différences entre variantes.,,,,,,,,7c7949da0df9f5f4,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,bt-benchmark-plot,code,fr,754eec7bf2c36edc,"# Visualisation comparative
 fig, axes = plt.subplots(1, 2, figsize=(14, 5))
 
@@ -428,7 +428,7 @@ axes[1].grid(True, alpha=0.3)
 plt.suptitle('Benchmark backtracking -- N-Reines', fontsize=14, fontweight='bold')
 plt.tight_layout()
 plt.show()",,,,,,,,754eec7bf2c36edc,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,interp-bt-benchmark,markdown,fr,38e1fff2ac826cbe,"### Interpretation : benchmark backtracking
+MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,interp-bt-benchmark,markdown,fr,47df3b46d6641b82,"### Interpretation : benchmark backtracking
 
 **Sortie obtenue** : le nombre de noeuds et le temps augmentent exponentiellement avec $N$, mais les heuristiques reduisent fortement l'exploration.
 
@@ -443,18 +443,18 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,interp-bt-benchmar
 2. MRV guide la recherche vers les variables critiques
 3. La combinaison FC+MRV est la plus efficace pour le backtracking
 
-> **Limite** : meme avec FC+MRV, le backtracking reste exponentiel dans le pire cas. Pour de grands $N$, il faut une approche fondamentalement differente.",,,,,,,,38e1fff2ac826cbe,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,section-4-minconflicts,markdown,fr,287fc382b84061ca,"---
+> **Limite** : même avec FC+MRV, le backtracking reste exponentiel dans le pire cas. Pour de grands $N$, il faut une approche fondamentalement différente.",,,,,,,,47df3b46d6641b82,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,section-4-minconflicts,markdown,fr,82711f49beedac12,"---
 
 ## 4. Approche 2 : Min-Conflicts (~7 min)
 
-L'algorithme **Min-Conflicts** (Minton et al., 1992) est une méthode de **recherche locale** pour les CSP. Son principe est radicalement different du backtracking :
+L'algorithme **Min-Conflicts** (Minton et al., 1992) est une méthode de **recherche locale** pour les CSP. Son principe est radicalement différent du backtracking :
 
 1. **Demarrer** avec une assignation complète aleatoire (toutes les variables ont une valeur)
 2. **Tant qu'il y a des conflits** :
    - Choisir aleatoirement une variable en conflit
    - Lui assigner la valeur qui **minimise** le nombre de conflits
-3. **Repeter** jusqu'a trouver une solution ou atteindre un maximum d'iterations
+3. **Repeter** jusqu'a trouver une solution ou atteindre un maximum d'itérations
 
 ### Pourquoi ca marche ?
 
@@ -462,10 +462,10 @@ Le résultat surprenant de Sosic & Gu (1990) est que pour les N-Reines, min-conf
 
 | Aspect | Backtracking | Min-Conflicts |
 |--------|-------------|---------------|
-| Type | Systematique, complet | Recherche locale, incomplet |
+| Type | Systématique, complet | Recherche locale, incomplet |
 | Garantie de solution | Oui (si elle existe) | Non (peut rester coince) |
 | Complexite typique N-Reines | Exponentielle | Quasi-lineaire |
-| Demarrage | Assignation vide | Assignation complète aleatoire |",,,,,,,,287fc382b84061ca,,,,,,,
+| Demarrage | Assignation vide | Assignation complète aleatoire |",,,,,,,,82711f49beedac12,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,minconflicts-impl,code,fr,e18df7d0d08a1d0b,"def count_conflicts(queens, col):
     """"""Nombre de reines attaquant la reine en colonne col.""""""
     n = len(queens)
@@ -547,9 +547,9 @@ sol_mc, steps_mc, history_mc = min_conflicts(8)
 print(f""Solution (min-conflicts, N=8) : {sol_mc}"")
 print(f""Iterations : {steps_mc}"")
 print(f""Conflits initiaux : {history_mc[0]}, finaux : {history_mc[-1]}"")",,,,,,,,e18df7d0d08a1d0b,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,pre-mc-scale,markdown,fr,296c049690e79ad8,"### Le ""miracle"" de Min-Conflicts : scalabilite
+MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,pre-mc-scale,markdown,fr,42fe94744f460c08,"### Le ""miracle"" de Min-Conflicts : scalabilite
 
-Le résultat le plus remarquable de min-conflicts est sa capacite a résoudre des instances de **tres grande taille**. Testons sur $N = 8, 50, 100, 500, 1000$ et observons l'evolution du temps.",,,,,,,,296c049690e79ad8,,,,,,,
+Le résultat le plus remarquable de min-conflicts est sa capacite a résoudre des instances de **très grande taille**. Testons sur $N = 8, 50, 100, 500, 1000$ et observons l'evolution du temps.",,,,,,,,42fe94744f460c08,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,mc-scale,code,fr,c8ac09c42f46f247,"# Scalabilite de min-conflicts
 mc_sizes = [8, 50, 100, 500]
 mc_results = []
@@ -570,7 +570,7 @@ for n in mc_sizes:
         'found': found
     })
     print(f""{n:>6}  {elapsed:>12.1f}  {steps:>12}  {'Oui' if found else 'Non':>8}"")",,,,,,,,c8ac09c42f46f247,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,gdkxm197ye7,markdown,fr,7f7f3ecff8d3a273,Tracons l'evolution du temps et du nombre d'iterations en fonction de $N$.,,,,,,,,7f7f3ecff8d3a273,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,gdkxm197ye7,markdown,fr,fa5970646e3a5603,Tracons l'evolution du temps et du nombre d'itérations en fonction de $N$.,,,,,,,,fa5970646e3a5603,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,mc-scale-plot,code,fr,593ee018714f4d85,"# Visualisation : temps vs N pour min-conflicts
 fig, axes = plt.subplots(1, 2, figsize=(14, 5))
 
@@ -593,7 +593,7 @@ axes[1].grid(True, alpha=0.3)
 plt.suptitle('Scalabilite de Min-Conflicts', fontsize=14, fontweight='bold')
 plt.tight_layout()
 plt.show()",,,,,,,,593ee018714f4d85,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,c5fncba0iho,markdown,fr,16cb37bb73ce5749,Observons aussi la courbe de convergence des conflits au fil des iterations sur une instance de taille $N = 100$.,,,,,,,,16cb37bb73ce5749,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,c5fncba0iho,markdown,fr,4205fbe91239928d,Observons aussi la courbe de convergence des conflits au fil des itérations sur une instance de taille $N = 100$.,,,,,,,,4205fbe91239928d,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,mc-convergence,code,fr,ee548e88d0926fe5,"# Courbe de convergence : evolution des conflits au fil des iterations (N=100)
 random.seed(123)
 sol_100, steps_100, history_100 = min_conflicts(100, max_steps=2000)
@@ -609,11 +609,11 @@ ax.legend(fontsize=10)
 ax.grid(True, alpha=0.3)
 plt.tight_layout()
 plt.show()",,,,,,,,ee548e88d0926fe5,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,interp-minconflicts,markdown,fr,c6ed314d909e07dc,"### Interpretation : scalabilite de Min-Conflicts
+MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,interp-minconflicts,markdown,fr,397c5f2c367b762c,"### Interpretation : scalabilite de Min-Conflicts
 
-**Sortie obtenue** : min-conflicts resout le probleme des N-Reines en un temps qui croit bien plus lentement que le backtracking.
+**Sortie obtenue** : min-conflicts resout le problème des N-Reines en un temps qui croit bien plus lentement que le backtracking.
 
-| N | Temps min-conflicts | Iterations | Trouve |
+| N | Temps min-conflicts | Itérations | Trouve |
 |---|--------------------|-----------|--------|
 | 8 | 0.9 ms | 15 | Oui |
 | 50 | 264.6 ms | 152 | Oui |
@@ -621,14 +621,14 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,interp-minconflict
 | 500 | 72249.9 ms (~72 s) | 346 | Oui |
 
 **Points cles** :
-1. Le nombre d'iterations croit avec $N$ (15 -> 152 -> 115 -> 346), mais de maniere irreguliere ; il ne croit pas exponentiellement
+1. Le nombre d'itérations croit avec $N$ (15 -> 152 -> 115 -> 346), mais de maniere irreguliere ; il ne croit pas exponentiellement
 2. La courbe de convergence montre une decroissance rapide des conflits
-3. Le temps par iteration est $O(N)$ (compter les conflits) ; sur la plus grande instance committee (N=500), le temps total atteint ~72 s, soit une croissance super-quadratique en pratique (754.4 ms a N=100 -> 72249.9 ms a N=500, soit ~96x pour un facteur 5 sur N)
+3. Le temps par itération est $O(N)$ (compter les conflits) ; sur la plus grande instance committee (N=500), le temps total atteint ~72 s, soit une croissance super-quadratique en pratique (754.4 ms a N=100 -> 72249.9 ms a N=500, soit ~96x pour un facteur 5 sur N)
 
-> **Pourquoi ca marche ?** L'espace des solutions des N-Reines est ""dense"" pour les instances aleatoires. En partant d'une permutation aleatoire, on est generalement proche d'une solution. Chaque reparation locale reduit les conflits sans en creer beaucoup de nouveaux.
+> **Pourquoi ca marche ?** L'espace des solutions des N-Reines est ""dense"" pour les instances aleatoires. En partant d'une permutation aleatoire, on est généralement proche d'une solution. Chaque reparation locale reduit les conflits sans en créer beaucoup de nouveaux.
 
 > **Attention** : min-conflicts est **incomplet** -- il ne garantit pas de trouver une solution et ne peut pas prouver qu'il n'en existe pas.
-",,,,,,,,c6ed314d909e07dc,,,,,,,
+",,,,,,,,397c5f2c367b762c,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,section-5-cpsat,markdown,fr,300c51d996a51bed,"---
 
 ## 5. Approche 3 : OR-Tools CP-SAT (~5 min)
@@ -746,13 +746,13 @@ for n in cpsat_sizes:
         'status': status
     })
     print(f""{n:>6}  {elapsed:>12.1f}  {status:>12}"")",,,,,,,,ccfc2fb559edf97a,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,interp-cpsat,markdown,fr,87dcbec0be03c6f7,"### Interpretation : OR-Tools CP-SAT
+MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,interp-cpsat,markdown,fr,84d43a4749561f28,"### Interpretation : OR-Tools CP-SAT
 
-**Sortie obtenue** : CP-SAT resout le probleme des N-Reines avec des performances competitives sur les petites et moyennes instances ; sur la plus grande instance committee (N=500), il atteint la limite de temps sans statut OPTIMAL.
+**Sortie obtenue** : CP-SAT resout le problème des N-Reines avec des performances competitives sur les petites et moyennes instances ; sur la plus grande instance committee (N=500), il atteint la limite de temps sans statut OPTIMAL.
 
 | Fonctionnalite | Résultat |
 |----------------|----------|
-| Premiere solution (N=8) | Quasi-instantane |
+| Première solution (N=8) | Quasi-instantane |
 | Toutes les solutions (N=8) | 92 solutions en quelques ms |
 | N=500 (plus grande instance committee) | 60287.8 ms (~60 s), statut UNKNOWN (limite de temps atteinte) |
 
@@ -762,8 +762,8 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,interp-cpsat,markd
 3. **Enumeration complète** : capacite a trouver toutes les solutions
 4. **Robustesse** : pas besoin de tuner les heuristiques manuellement
 
-> **Compromis** : CP-SAT a un overhead de demarrage (creation du modèle, compilation interne) qui le rend moins rapide que min-conflicts pour de tres grandes instances ou une seule solution suffit. Sur N=500, la limite de temps de 60 s est atteinte avant la preuve d'optimalite (statut UNKNOWN).
-",,,,,,,,87dcbec0be03c6f7,,,,,,,
+> **Compromis** : CP-SAT a un overhead de demarrage (creation du modèle, compilation interne) qui le rend moins rapide que min-conflicts pour de très grandes instances ou une seule solution suffit. Sur N=500, la limite de temps de 60 s est atteinte avant la preuve d'optimalite (statut UNKNOWN).
+",,,,,,,,84d43a4749561f28,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,section-6-comparison,markdown,fr,76359bc5112ec889,"---
 
 ## 6. Comparaison et analyse (~3 min)
@@ -816,7 +816,7 @@ for n in comparison_sizes:
 
 print(""="" * 72)
 print(""(-- = trop lent pour cette taille)"")",,,,,,,,0a6907ce9a03d992,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,5up0n45udr4,markdown,fr,f9dfc9079e8f78a2,"Visualisons la comparaison des temps d'execution sur une plage etendue de tailles, en echelle log-log.",,,,,,,,f9dfc9079e8f78a2,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,5up0n45udr4,markdown,fr,132456cb3455d097,"Visualisons la comparaison des temps d'exécution sur une plage etendue de tailles, en echelle log-log.",,,,,,,,132456cb3455d097,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,comparison-plot,code,fr,e9b31b05d7fe875f,"# Graphique comparatif sur les tailles gerees par toutes les approches
 fig, ax = plt.subplots(figsize=(10, 6))
 
@@ -859,9 +859,9 @@ ax.legend(fontsize=11)
 ax.grid(True, alpha=0.3)
 plt.tight_layout()
 plt.show()",,,,,,,,e9b31b05d7fe875f,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,interp-comparison,markdown,fr,c41da6d00f2f4477,"### Interpretation : comparaison finale
+MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,interp-comparison,markdown,fr,bc5f1ac2a0704816,"### Interpretation : comparaison finale
 
-**Sortie obtenue** : les trois approches ont des profils de performance tres differents.
+**Sortie obtenue** : les trois approches ont des profils de performance très différents.
 
 | Approche | N=8 | N=100 | N=1000 | Completude | Enumeration |
 |----------|-----|-------|--------|------------|-------------|
@@ -873,11 +873,11 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,interp-comparison,
 
 | Situation | Approche recommandee | Raison |
 |-----------|---------------------|--------|
-| Petit probleme (N < 20) | Backtracking FC+MRV | Complet, simple a implementer |
-| Grande instance, une solution | Min-Conflicts | Quasi-lineaire, tres rapide |
+| Petit problème (N < 20) | Backtracking FC+MRV | Complet, simple a implementer |
+| Grande instance, une solution | Min-Conflicts | Quasi-lineaire, très rapide |
 | Toutes les solutions | CP-SAT | Enumeration + optimisation |
 | Contraintes supplementaires | CP-SAT | Modelisation declarative flexible |
-| Prototype pédagogique | Backtracking | Comprendre les mecanismes |
+| Prototype pédagogique | Backtracking | Comprendre les mécanismes |
 
 ### Liens avec les Foundations
 
@@ -885,18 +885,18 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,interp-comparison,
 |-----------------|----------------------|
 | Backtracking CSP, MRV, LCV | [CSP-1 : Fundamentals](../../Part2-CSP/CSP-1-Fundamentals.ipynb) |
 | Forward Checking, Arc Consistency | [CSP-2 : Consistency](../../Part2-CSP/CSP-2-Consistency.ipynb) |
-| CP-SAT, contraintes globales | [CSP-3 : Advanced](../../Part2-CSP/CSP-3-Advanced.ipynb) |",,,,,,,,c41da6d00f2f4477,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,section-7-exercises,markdown,fr,9e80bf0a2b7a3e19,"---
+| CP-SAT, contraintes globales | [CSP-3 : Advanced](../../Part2-CSP/CSP-3-Advanced.ipynb) |",,,,,,,,bc5f1ac2a0704816,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,section-7-exercises,markdown,fr,f94a4165c524bcad,"---
 
 ## 7. Exemple guide
 
-### Exemple guide 1 : le probleme des N-Tours
+### Exemple guide 1 : le problème des N-Tours
 
-**Enonce** : adaptez le probleme pour placer $N$ **tours** sur un echiquier $N \times N$. Les tours attaquent en ligne et en colonne (mais pas en diagonale).
+**Enonce** : adaptez le problème pour placer $N$ **tours** sur un echiquier $N \times N$. Les tours attaquent en ligne et en colonne (mais pas en diagonale).
 
 1. Quelle contrainte disparait par rapport aux N-Reines ?
 2. Combien de solutions existe-t-il pour $N = 8$ ?
-3. Implementez un solveur et verifiez votre reponse.",,,,,,,,9e80bf0a2b7a3e19,,,,,,,
+3. Implementez un solveur et verifiez votre reponse.",,,,,,,,f94a4165c524bcad,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,10602482,code,fr,ad771d7ce5ac3398,"# Exemple resolu : N-Tours via CP-SAT
 
 import math
@@ -946,17 +946,17 @@ if count == math.factorial(n):
 else:
     print(""Hmm, y'a un truc bizarre"")
 ",,,,,,,,ad771d7ce5ac3398,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,19b3e3b6,markdown,fr,66b348f9f9396ab1,"### Exercice 1b : le probleme des N-Fous
+MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,19b3e3b6,markdown,fr,c40a9093e2d6a51e,"### Exercice 1b : le problème des N-Fous
 
-**Enonce** : adaptez le probleme pour placer $N$ **fous** sur un echiquier
+**Enonce** : adaptez le problème pour placer $N$ **fous** sur un echiquier
 $N \times N$. Les fous attaquent en diagonale.
 
 **Consignes** :
 1. Modelisez avec CP-SAT : chaque fou a une position $(x_i, y_i)$
-2. Posez les contraintes : deux fous ne peuvent partager la meme diagonale
+2. Posez les contraintes : deux fous ne peuvent partager la même diagonale
    ($x_i + y_i \neq x_j + y_j$ et $x_i - y_i \neq x_j - y_j$)
 3. Comptez le nombre de solutions pour $N = 8$ et verifiez que c'est 256
-",,,,,,,,66b348f9f9396ab1,,,,,,,
+",,,,,,,,c40a9093e2d6a51e,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,cbdc1f91,code,fr,bb47ad4783ad259d,"# Exercice 1b : N-Fous via CP-SAT
 
 # TODO: modelisez le probleme des N-Fous avec CP-SAT
@@ -1031,7 +1031,7 @@ ax.legend()
 plt.tight_layout()
 plt.show()
 ",,,,,,,,8e0b8c451f7979df,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,e1735ba8,markdown,fr,413da50ab418e9ff,"### Exercice 2b : plage etendue jusqu'a N=50
+MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,e1735ba8,markdown,fr,e1b366ac8266407c,"### Exercice 2b : plage etendue jusqu'a N=50
 
 **Enonce** : relancez la comparaison sur une plage plus large :
 $N \in \{20, 25, 30, 35, 40, 45, 50\}$.
@@ -1039,9 +1039,9 @@ $N \in \{20, 25, 30, 35, 40, 45, 50\}$.
 **Consignes** :
 1. Mesurez les temps de backtracking et min-conflicts pour chaque $N$
 2. Affichez le graphe et identifiez le seuil
-3. Attention : backtracking peut devenir tres lent pour $N > 30$,
+3. Attention : backtracking peut devenir très lent pour $N > 30$,
    ajoutez un `time_limit` de 30 secondes par taille
-",,,,,,,,413da50ab418e9ff,,,,,,,
+",,,,,,,,e1b366ac8266407c,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,1ecf27af,code,fr,912d5a5eecdbcda4,"# Exercice 2b : plage etendue
 
 # TODO: relancez la comparaison pour N = 20..50
@@ -1051,14 +1051,14 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,1ecf27af,code,fr,9
 # Votre code ici
 print(""Exercice a completer"")
 ",,,,,,,,912d5a5eecdbcda4,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,exercise-3-intro,markdown,fr,1573bb865fa0f7e1,"### Exemple guide 3 : brisure de symetrie avec CP-SAT
+MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,exercise-3-intro,markdown,fr,5ce69e2a9ec08e8a,"### Exemple guide 3 : brisure de symetrie avec CP-SAT
 
-**Enonce** : le probleme des N-Reines admet des symetries (rotation de 90/180/270 degres, reflexions horizontale et verticale). On peut reduire l'espace de recherche en ajoutant des **contraintes de brisure de symetrie**.
+**Enonce** : le problème des N-Reines admet des symetries (rotation de 90/180/270 degrés, reflexions horizontale et verticale). On peut reduire l'espace de recherche en ajoutant des **contraintes de brisure de symetrie**.
 
 1. Ajoutez la contrainte `queens[0] < queens[N-1]` (elimine la reflexion horizontale)
-2. Ajoutez `queens[0] < N // 2` (elimine les rotations de 180 degres)
+2. Ajoutez `queens[0] < N // 2` (elimine les rotations de 180 degrés)
 3. Comptez les solutions ""fondamentales"" (uniques sous symetrie) pour $N = 8$
-4. Verifiez : il devrait y en avoir **12** solutions fondamentales",,,,,,,,1573bb865fa0f7e1,,,,,,,
+4. Verifiez : il devrait y en avoir **12** solutions fondamentales",,,,,,,,5ce69e2a9ec08e8a,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,f09c5d2f,code,fr,c9f58b02d63a730c,"# Exemple resolu : brisure de symetrie
 
 import time
@@ -1202,7 +1202,7 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,c2280346,code,fr,4
 # Votre code ici
 print(""Exercice a completer"")
 ",,,,,,,,4b9e6bb64fb5cd57,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,section-conclusion,markdown,fr,e2c8902a1b03d9fd,"---
+MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,section-conclusion,markdown,fr,da91b5a2540bf5a4,"---
 
 ## Conclusion et recapitulatif
 
@@ -1211,7 +1211,7 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,section-conclusion
 | Concept | Description | Section |
 |---------|-------------|--------|
 | Modelisation CSP | Variables = colonnes, valeurs = lignes, contraintes = no-attack | 2 |
-| Backtracking | Recherche systematique avec verification incrementale | 3.1 |
+| Backtracking | Recherche systématique avec verification incrementale | 3.1 |
 | MRV | Heuristique fail-first pour le choix de variable | 3.2 |
 | Forward Checking | Propagation des contraintes pour detection precoce d'echec | 3.3 |
 | Min-Conflicts | Recherche locale quasi-lineaire mais incomplete | 4 |
@@ -1230,7 +1230,7 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,section-conclusion
 
 ### Pour aller plus loin
 
-- [App-2 : Graph Coloring](App-2-GraphColoring.ipynb) -- un autre probleme CSP classique avec applications cartographiques
+- [App-2 : Graph Coloring](App-2-GraphColoring.ipynb) -- un autre problème CSP classique avec applications cartographiques
 - [CSP-2 : Consistency](../../Part2-CSP/CSP-2-Consistency.ipynb) -- propagation de contraintes (AC-3, MAC)
 - [CSP-3 : Advanced](../../Part2-CSP/CSP-3-Advanced.ipynb) -- contraintes globales, Large Neighborhood Search
 
@@ -1238,14 +1238,14 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,section-conclusion
 
 - Russell, S. & Norvig, P. *Artificial Intelligence: A Modern Approach*, 4th ed., Chapitre 6
 - Minton, S., Johnston, M.D., Philips, A.B. & Laird, P. (1992). *Min-Conflicts: A Simple, Complète, Backtrack-Free Search Procedure*. Artificial Intelligence, 58(1-3)
-- [OR-Tools CP-SAT Documentation](https://developers.google.com/optimization/cp/cp_solver)",,,,,,,,e2c8902a1b03d9fd,,,,,,,
+- [OR-Tools CP-SAT Documentation](https://developers.google.com/optimization/cp/cp_solver)",,,,,,,,da91b5a2540bf5a4,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb,footer,markdown,fr,23005213c2f92c86,"---
 
 **Navigation** : [Index](../../README.md) | [Part2-CSP](../../Part2-CSP/README.md) | [App-2 GraphColoring >>](App-2-GraphColoring.ipynb)",,,,,,,,23005213c2f92c86,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,0b084b03,code,fr,d8cfd07b7b0f3965,"# Parameters
 BATCH_MODE = ""true""
 ",,,,,,,,d8cfd07b7b0f3965,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,c9bb1012,markdown,fr,2fb6574c2fdb6b19,"# App-11 - Picross (Nonogrammes)
+MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,c9bb1012,markdown,fr,f16666fb40723196,"# App-11 - Picross (Nonogrammes)
 
 **Navigation** : [<< App-10 Portfolio](../Hybrid/App-10-Portfolio.ipynb) | [Index](../README.md) | [App-12 ConnectFour >>](../Search/App-12-ConnectFour.ipynb)
 
@@ -1258,9 +1258,9 @@ Ce notebook explore la resolution de **nonogrammes** (Picross) par deux approche
 ### Objectifs d'apprentissage
 
 A la fin de ce notebook, vous saurez :
-1. **Modeliser** un nonogramme comme un probleme de satisfaction de contraintes
+1. **Modeliser** un nonogramme comme un problème de satisfaction de contraintes
 2. **Implementer** un solveur naif par produit cartesien et filtrage
-3. **Formuler** le probleme avec OR-Tools CP-SAT (variables booleennes, contraintes de runs)
+3. **Formuler** le problème avec OR-Tools CP-SAT (variables booleennes, contraintes de runs)
 4. **Mesurer** et **comparer** les performances des deux approches
 5. **Generer** des puzzles Picross a partir d'images pixelisees
 
@@ -1268,8 +1268,8 @@ A la fin de ce notebook, vous saurez :
 - Search-8 (CSP Advanced) : contraintes globales, OR-Tools CP-SAT
 - Python : itertools, numpy, matplotlib
 
-### Duree estimee : 40 minutes",,,,,,,,2fb6574c2fdb6b19,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,83256e70,markdown,fr,0311cd71c5932e04,"---
+### Duree estimee : 40 minutes",,,,,,,,f16666fb40723196,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,83256e70,markdown,fr,e339f1de5a13be69,"---
 
 ## 1. Introduction : les nonogrammes (~5 min)
 
@@ -1304,7 +1304,7 @@ La solution revele un losange :
 | Contraintes | Chaque ligne et chaque colonne impose un motif de runs |
 | Taille typique | 5x5 (trivial) a 40x40+ (difficile) |
 
-La resolution par force brute est rapidement intraitable. C'est un terrain ideal pour demontrer l'interet de la programmation par contraintes.",,,,,,,,0311cd71c5932e04,,,,,,,
+La resolution par force brute est rapidement intraitable. C'est un terrain ideal pour demontrer l'intérêt de la programmation par contraintes.",,,,,,,,e339f1de5a13be69,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,306391d6,code,fr,e9e5959c515b6d4c,"# Imports
 import numpy as np
 import matplotlib.pyplot as plt
@@ -1325,11 +1325,11 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,2c0ec482,markdown
 Affichage de la grille de Picross et verification visuelle des contraintes.",,,,,,,,f55929a919d028cb,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,08ef8ad6-a183-4588-bd7f-dc9a98be9f6b,code,fr,439c98b07dbd6f50,"# Dependencies pre-provisionnees (numpy matplotlib ortools) : voir requirements.txt.
 # Aucun install requis dans le notebook ; imports directs dans les cellules suivantes.",,,,,,,,439c98b07dbd6f50,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,5d1c0c4c,markdown,fr,04f20023368311fc,"---
+MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,5d1c0c4c,markdown,fr,fd533cf9df499ae1,"---
 
-## 2. Representation du probleme (~5 min)
+## 2. Representation du problème (~5 min)
 
-Un puzzle Picross est defini par :
+Un puzzle Picross est défini par :
 - `row_clues` : liste de listes d'entiers, une par ligne (indices de gauche)
 - `col_clues` : liste de listes d'entiers, une par colonne (indices du haut)
 
@@ -1347,8 +1347,8 @@ Pour qu'un indice $[c_1, c_2, \ldots, c_k]$ tienne sur une ligne de longueur $n$
 
 $$\sum_{i=1}^{k} c_i + (k - 1) \leq n$$
 
-Les $(k-1)$ espaces minimum separent les $k$ blocs.",,,,,,,,04f20023368311fc,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,a447fbf2,markdown,fr,dd5758242598f469,Definissons les structures de donnees et quelques puzzles exemples de difficulte croissante.,,,,,,,,dd5758242598f469,,,,,,,
+Les $(k-1)$ espaces minimum separent les $k$ blocs.",,,,,,,,fd533cf9df499ae1,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,a447fbf2,markdown,fr,68368806917c304c,Definissons les structures de données et quelques puzzles exemples de difficulte croissante.,,,,,,,,68368806917c304c,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,e9027efb,code,fr,c0cfe8dc3192635d,"# =====================================================================
 # Puzzles exemples
 # =====================================================================
@@ -1486,22 +1486,22 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,4a43e82f,code,fr,
 display_picross(None, puzzle_5x5['row_clues'], puzzle_5x5['col_clues'],
                 title=""Puzzle Losange 5x5 (non resolu)"")
 plt.show()",,,,,,,,98754e819809e6b9,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,74720efe,markdown,fr,78378371f2b61c61,"### Interpretation : representation du puzzle
+MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,74720efe,markdown,fr,24fd00ca94f2a3d0,"### Interpretation : representation du puzzle
 
 **Sortie obtenue** : la grille 5x5 vide avec les indices sur les cotes.
 
-| Element | Role |
+| Élément | Rôle |
 |---------|------|
 | Indices a gauche | Runs pour chaque ligne (de gauche a droite) |
 | Indices en haut | Runs pour chaque colonne (de haut en bas) |
 | Cases grises | Non encore resolues |
 
-**Point cle** : les indices definissent de maniere unique (en general) l'image cachee. Le defi est de trouver l'assignation de chaque case qui satisfait simultanement les contraintes de toutes les lignes et colonnes.",,,,,,,,78378371f2b61c61,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,ad23ed68,markdown,fr,6c93aa17e7c2140d,"---
+**Point cle** : les indices definissent de maniere unique (en general) l'image cachee. Le defi est de trouver l'assignation de chaque case qui satisfait simultanement les contraintes de toutes les lignes et colonnes.",,,,,,,,24fd00ca94f2a3d0,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,ad23ed68,markdown,fr,737f0be39de5c663,"---
 
 ## 3. Approche 1 : backtracking naif (~8 min)
 
-### Strategie
+### Stratégie
 
 L'approche la plus directe consiste a :
 1. Pour chaque ligne, **enumerer** tous les motifs valides (combinaisons de 0/1 respectant l'indice)
@@ -1514,7 +1514,7 @@ Le nombre de motifs valides par ligne peut etre grand. Pour un indice `[2, 3]` s
 
 ### Generation des motifs valides
 
-On genere les motifs valides pour un indice donne sur une ligne de longueur $n$ en placant les blocs recursivement.",,,,,,,,6c93aa17e7c2140d,,,,,,,
+On genere les motifs valides pour un indice donne sur une ligne de longueur $n$ en placant les blocs recursivement.",,,,,,,,737f0be39de5c663,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,52abf789,code,fr,6667f331b9917061,"def generate_line_patterns(clue, length):
     """"""Genere tous les motifs valides pour un indice sur une ligne de longueur donnee.
 
@@ -1693,18 +1693,18 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,df2254e1,markdown
 | Temps | ~2 ms (1.86 ms mesure) | Trivial a cette taille |
 
 **Point cle** : sur un petit puzzle, l'approche naive fonctionne. Mais que se passe-t-il quand la taille augmente ?",,,,,,,,9fd549fb8a4ed0c0,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,4cae929d,markdown,fr,72528e7c8d7bf321,"#### Exercice 1a : Enumerer les motifs valides pour un indice
+MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,4cae929d,markdown,fr,3ea3791ef98390b3,"#### Exercice 1a : Enumerer les motifs valides pour un indice
 
 Avant de passer au solveur CP-SAT, verifiez votre comprehension de la generation de motifs.
 
-**Enonce** : pour l'indice `[2, 2]` sur une ligne de 8 cases, enumeratez manuellement (dans un `print`) tous les motifs valides, puis comparez votre resultat avec `generate_line_patterns([2, 2], 8)`.
+**Enonce** : pour l'indice `[2, 2]` sur une ligne de 8 cases, enumeratez manuellement (dans un `print`) tous les motifs valides, puis comparez votre résultat avec `generate_line_patterns([2, 2], 8)`.
 
 **Consignes** :
 1. Verifiez que la contrainte de longueur minimale est satisfaite : $\sum c_i + (k-1) \leq n$
 2. Listez les motifs sous forme visuelle (`XX..XX..`, etc.)
 3. Comparez votre compte avec celui de `generate_line_patterns`
 
-**Indice** : le nombre minimum de cases pour `[2, 2]` est $2 + 1 + 2 = 5$. Il reste 3 cases libres a repartir dans les ""espaces"" (avant le bloc 1, entre les blocs, apres le bloc 2).",,,,,,,,72528e7c8d7bf321,,,,,,,
+**Indice** : le nombre minimum de cases pour `[2, 2]` est $2 + 1 + 2 = 5$. Il reste 3 cases libres a repartir dans les ""espaces"" (avant le bloc 1, entre les blocs, après le bloc 2).",,,,,,,,3ea3791ef98390b3,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,751f9aaf,code,fr,ae136d49de0fa123,"# Exercice 1a : Enumerer les motifs valides pour [2, 2] sur 8 cases
 
 # TODO etudiant : verifiez la contrainte de longueur minimale
@@ -1742,9 +1742,9 @@ if stats_10_naive['timeout']:
         print(f""                       = {estimated_total/86400:,.1f} jours"")
     if estimated_total > 31536000:
         print(f""                       = {estimated_total/31536000:,.1f} annees"")",,,,,,,,a5a049628c8a7b1c,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,f13c4dd6,markdown,fr,4c906e3c5252fd3a,"### Interpretation : explosion combinatoire
+MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,f13c4dd6,markdown,fr,20932c9ef6ef71c4,"### Interpretation : explosion combinatoire
 
-**Sortie obtenue** : le solveur naif resout quand meme le puzzle 10x10 (0.93 s, ~60 000 combinaisons), mais le nombre de combinaisons explose des la taille 15x15 (estime a des milliers d'annees).
+**Sortie obtenue** : le solveur naif resout quand même le puzzle 10x10 (0.93 s, ~60 000 combinaisons), mais le nombre de combinaisons explose des la taille 15x15 (estime a des milliers d'annees).
 
 | Taille | Combinaisons | Temps estime | Verdict |
 |--------|-------------|-------------|----------|
@@ -1754,18 +1754,18 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,f13c4dd6,markdown
 | 20x20 | inimaginable | age de l'univers | Totalement impossible |
 
 **Points cles** :
-1. L'approche naive ne verifie les colonnes qu'**apres** avoir construit la grille complete
+1. L'approche naive ne verifie les colonnes qu'**après** avoir construit la grille complete
 2. Elle n'exploite pas les contraintes pendant la construction : aucun elagage
 3. Le produit cartesien des motifs de lignes croit exponentiellement avec le nombre de lignes
 
-> **Conclusion** : il faut une approche qui propage les contraintes **pendant** la recherche, pas apres. C'est exactement ce que fait CP-SAT.",,,,,,,,4c906e3c5252fd3a,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,462b104f,markdown,fr,5d87b95e78c9d034,"---
+> **Conclusion** : il faut une approche qui propage les contraintes **pendant** la recherche, pas après. C'est exactement ce que fait CP-SAT.",,,,,,,,20932c9ef6ef71c4,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,462b104f,markdown,fr,1c52962957a47046,"---
 
 ## 4. Approche 2 : OR-Tools CP-SAT (~12 min)
 
 ### Modelisation CSP du Picross
 
-Avec OR-Tools CP-SAT, on modelise le probleme en :
+Avec OR-Tools CP-SAT, on modelise le problème en :
 
 | Composant | Modelisation |
 |-----------|-------------|
@@ -1782,7 +1782,7 @@ C'est la partie la plus subtile. Pour un indice `[c_1, c_2, ..., c_k]` sur une l
 - $s_k + c_k \leq n$ (le dernier bloc tient dans la ligne)
 - La case $j$ est remplie ssi elle est couverte par au moins un bloc
 
-Cette formulation permet au solveur CP-SAT de propager les contraintes efficacement grace a la borne des intervalles.",,,,,,,,5d87b95e78c9d034,,,,,,,
+Cette formulation permet au solveur CP-SAT de propager les contraintes efficacement grace a la borne des intervalles.",,,,,,,,1c52962957a47046,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,6c09a46c,code,fr,a27681e8555e02c0,"def solve_cpsat(puzzle, time_limit=60.0):
     """"""Solveur CP-SAT pour Picross.
 
@@ -1924,7 +1924,7 @@ for puzzle in all_puzzles:
           f""{stats['time_s']*1000:<12.2f} {stats['branches']:<10} {stats['conflicts']:<10}"")
 
 print(""="" * 65)",,,,,,,,98216c50a65dc79b,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,e4a84bdc,markdown,fr,56c2d08520fa661e,"### Interpretation : performance CP-SAT
+MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,e4a84bdc,markdown,fr,f3f00c97f1a45ccc,"### Interpretation : performance CP-SAT
 
 **Sortie obtenue** : CP-SAT resout tous les puzzles en quelques millisecondes.
 
@@ -1938,10 +1938,10 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,e4a84bdc,markdown
 > **Note** : les puzzles 10x10, 15x15 et 20x20 de versions anterieures de ce notebook contenaient des indices contradictoires (sommes lignes/colonnes incoherentes), ce que CP-SAT detectait correctement comme INFEASIBLE. Les indices ont ete corriges pour produire des puzzles valides et solvables.
 
 **Points cles** :
-1. Le solveur CP-SAT utilise la **propagation de contraintes** pour eliminer les valeurs impossibles a chaque etape
+1. Le solveur CP-SAT utilise la **propagation de contraintes** pour eliminer les valeurs impossibles a chaque étape
 2. Les **branches** et **conflits** restent faibles : l'elagage est extremement efficace
-3. La scalabilite est quasi-lineaire en pratique, meme si le probleme est NP-complet en theorie
-4. CP-SAT detecte les puzzles impossibles (INFEASIBLE) instantanement — un atout pour la validation de puzzles",,,,,,,,56c2d08520fa661e,,,,,,,
+3. La scalabilite est quasi-lineaire en pratique, même si le problème est NP-complet en théorie
+4. CP-SAT detecte les puzzles impossibles (INFEASIBLE) instantanement — un atout pour la validation de puzzles",,,,,,,,f3f00c97f1a45ccc,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,d0b644b9,markdown,fr,e45bae729cb741fc,### Visualisation des solutions,,,,,,,,e45bae729cb741fc,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,54615b6b,code,fr,e61708361d9ddb39,"# Affichage des solutions CP-SAT
 fig, axes = plt.subplots(1, 4, figsize=(20, 6))
@@ -2062,7 +2062,7 @@ for puzzle in all_puzzles:
 print(""-"" * 85)
 print(""* = temps estime (solveur naif non execute, extrapole du debit mesure)"")
 print(f""Debit mesure du solveur naif : {real_throughput:,.0f} combinaisons/s"")",,,,,,,,3f915800331d1db1,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,421b0698,markdown,fr,b3bb2dfefd213916,"### Interpretation : le speedup spectaculaire
+MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,421b0698,markdown,fr,90e2f012e8197205,"### Interpretation : le speedup spectaculaire
 
 **Sortie obtenue** : le facteur d'acceleration entre le solveur naif et CP-SAT peut atteindre des millions, voire des milliards.
 
@@ -2078,11 +2078,11 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,421b0698,markdown
 | Facteur | Naif | CP-SAT |
 |---------|------|--------|
 | Elagage | Aucun | Propagation de contraintes |
-| Detection d'echec | Apres construction complete | Immediate (conflits) |
+| Detection d'echec | Après construction complete | Immediate (conflits) |
 | Exploitation de la structure | Non | Variables de position, intervalles |
 | Complexite pratique | $O(\prod |motifs_i|)$ | Quasi-lineaire sur ces instances |
 
-> **C'est la puissance de la programmation par contraintes** : la propagation elimine des pans entiers de l'espace de recherche a chaque decision, rendant les problemes NP-complets resolvables en pratique.",,,,,,,,b3bb2dfefd213916,,,,,,,
+> **C'est la puissance de la programmation par contraintes** : la propagation elimine des pans entiers de l'espace de recherche a chaque decision, rendant les problemes NP-complets resolvables en pratique.",,,,,,,,90e2f012e8197205,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,d94af2ee,markdown,fr,ab24fdcf0d3dbd9d,### Visualisation du speedup en echelle logarithmique,,,,,,,,ab24fdcf0d3dbd9d,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,91fc6043,code,fr,f6d27f7f2ae3f7c3,"# Graphique comparatif en echelle log
 fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(14, 5))
@@ -2131,28 +2131,28 @@ plt.suptitle('Comparaison : backtracking naif vs CP-SAT pour Picross',
              fontsize=14, fontweight='bold')
 plt.tight_layout()
 plt.show()",,,,,,,,f6d27f7f2ae3f7c3,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,46587bcb,markdown,fr,7b0274a1be0f0f2c,"### Interpretation : visualisation du speedup
+MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,46587bcb,markdown,fr,e547e9beec7c761e,"### Interpretation : visualisation du speedup
 
 **Sortie obtenue** : les graphiques montrent un ecart exponentiel entre les deux approches.
 
 **Points cles** :
-1. L'echelle logarithmique est **necessaire** pour afficher les deux approches sur le meme graphique
+1. L'echelle logarithmique est **necessaire** pour afficher les deux approches sur le même graphique
 2. Le temps du solveur naif croit exponentiellement avec la taille, tandis que CP-SAT reste de l'ordre de quelques dizaines a quelques centaines de millisecondes (28-364 ms mesure)
 3. Le facteur de speedup croit lui aussi exponentiellement
 
-> **Le projet etudiant EPITA PPC 2025 (Groupe37)** a mesure un speedup de 27 millions de fois sur certaines instances. C'est le type de gain que la programmation par contraintes permet d'atteindre sur des problemes bien structures.",,,,,,,,7b0274a1be0f0f2c,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,0612b640,markdown,fr,c1499c8bdf749ba5,"---
+> **Le projet etudiant EPITA PPC 2025 (Groupe37)** a mesure un speedup de 27 millions de fois sur certaines instances. C'est le type de gain que la programmation par contraintes permet d'atteindre sur des problemes bien structures.",,,,,,,,e547e9beec7c761e,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,0612b640,markdown,fr,cf1af073e0e57958,"---
 
 ## 6. Creation de puzzles (~3 min)
 
-On peut aussi faire l'inverse : partir d'une image pixelisee et generer les indices d'un puzzle Picross. C'est utile pour creer ses propres puzzles ou pour verifier la resolution.
+On peut aussi faire l'inverse : partir d'une image pixelisee et generer les indices d'un puzzle Picross. C'est utile pour créer ses propres puzzles ou pour verifier la resolution.
 
 ### Algorithme
 
 1. Prendre une image binaire (matrice 0/1)
 2. Pour chaque ligne, extraire les runs de 1 consecutifs
-3. Pour chaque colonne, faire de meme
-4. Les listes de runs forment les indices du puzzle",,,,,,,,c1499c8bdf749ba5,,,,,,,
+3. Pour chaque colonne, faire de même
+4. Les listes de runs forment les indices du puzzle",,,,,,,,cf1af073e0e57958,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,2bf4185b,code,fr,1da8f86e5dc82861,"def create_puzzle_from_image(image, name=""Custom""):
     """"""Cree un puzzle Picross a partir d'une image binaire.
 
@@ -2349,13 +2349,13 @@ display_picross(solution_ex1, puzzle_ex1['row_clues'], puzzle_ex1['col_clues'],
                 title='Exemple 15x15 - Solution')
 plt.show()
 ",,,,,,,,220c633623cd4b46,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,85cd616a,markdown,fr,bce1eb0cd65313b4,"#### Exercice 1b : Resolvez un nouveau puzzle 15x15
+MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,85cd616a,markdown,fr,d176eebcc7adddf2,"#### Exercice 1b : Resolvez un nouveau puzzle 15x15
 
 Resoudre le puzzle suivant en utilisant `solve_cpsat`.
 
 **Consignes** :
 1. Definissez le dictionnaire `puzzle_ex1b` avec les indices ci-dessous
-2. Appelez `solve_cpsat` et affichez le resultat avec `display_picross`
+2. Appelez `solve_cpsat` et affichez le résultat avec `display_picross`
 3. Verifiez le nombre de solutions avec `check_uniqueness`
 
 ```
@@ -2366,7 +2366,7 @@ Col clues: [5,5], [1,1,1,1,1], [1,1,1,1,1], [5,5], [5,5],
            [1,1,1,1,1], [1,1,1,1,1], [5,5], [1,1,1,1,1], [1,1,1,1,1],
            [5,5], [5,5], [1,1,1,1,1], [1,1,1,1,1], [5,5]
 ```
-",,,,,,,,bce1eb0cd65313b4,,,,,,,
+",,,,,,,,d176eebcc7adddf2,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,359425c7,code,fr,7344ba3d12d5c26c,"# Exercice 1b : Resolvez un nouveau puzzle 15x15
 
 # TODO: definissez puzzle_ex1b avec les row_clues et col_clues donnes ci-dessus
@@ -2376,9 +2376,9 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,359425c7,code,fr,
 # Votre code ici
 print(""Exercice a completer"")
 ",,,,,,,,7344ba3d12d5c26c,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,e5abc4f7,markdown,fr,95e1f91c83ce0c85,"### Exemple guide 2 : generer un Picross a partir de vos initiales
+MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,e5abc4f7,markdown,fr,bd4c33a99df40955,"### Exemple guide 2 : generer un Picross a partir de vos initiales
 
-**Enonce** : creez une image pixelisee de vos initiales (2 lettres en pixel art sur une grille ~7x12), generez le puzzle correspondant, verifiez son unicite et resolvez-le.",,,,,,,,95e1f91c83ce0c85,,,,,,,
+**Enonce** : créez une image pixelisee de vos initiales (2 lettres en pixel art sur une grille ~7x12), generez le puzzle correspondant, verifiez son unicite et resolvez-le.",,,,,,,,bd4c33a99df40955,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,3c1427ad,code,fr,77c75e85cdaa0d89,"# Exemple resolu : generer un puzzle a partir d'initiales
 
 my_initials = np.array([
@@ -2397,18 +2397,18 @@ solution, stats = solve_cpsat(my_puzzle)
 display_picross(solution, my_puzzle['row_clues'], my_puzzle['col_clues'])
 plt.show()
 ",,,,,,,,77c75e85cdaa0d89,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,ae04afec,markdown,fr,b8b90b9f4b8b2081,"#### Exercice 2b : Creez un puzzle avec vos propres initiales
+MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,ae04afec,markdown,fr,00dc38a4397780b3,"#### Exercice 2b : Créez un puzzle avec vos propres initiales
 
 Concevez une image binaire representant **vos propres initiales** (ou un dessin simple)
 et generez le puzzle Picross correspondant.
 
 **Consignes** :
-1. Creez un tableau `np.array` binaire (0/1) d'au moins 8 lignes x 10 colonnes
+1. Créez un tableau `np.array` binaire (0/1) d'au moins 8 lignes x 10 colonnes
 2. Utilisez `create_puzzle_from_image` pour generer le puzzle
 3. Verifiez l'unicite avec `check_uniqueness`
 4. Si non unique, ajoutez des cases pour desambiguiser
 5. Affichez le puzzle et sa solution
-",,,,,,,,b8b90b9f4b8b2081,,,,,,,
+",,,,,,,,00dc38a4397780b3,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,8deac973,code,fr,2fcbfee77a7be4da,"# Exercice 2b : Creez un puzzle avec vos propres initiales
 
 # TODO: creez votre image binaire avec np.array
@@ -2418,13 +2418,13 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,8deac973,code,fr,
 # Votre code ici
 print(""Exercice a completer"")
 ",,,,,,,,2fcbfee77a7be4da,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,ffd30ad8,markdown,fr,48275d5d3311cc94,"### Exercice 3 : Picross colore (variante avancee)
+MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,ffd30ad8,markdown,fr,4e5fe748c63634fb,"### Exercice 3 : Picross colore (variante avancee)
 
-**Enonce** : dans un Picross colore, chaque bloc a une couleur (en plus de sa longueur). Deux blocs de couleurs differentes **n'ont pas besoin d'espace** entre eux, mais deux blocs de meme couleur oui.
+**Enonce** : dans un Picross colore, chaque bloc a une couleur (en plus de sa longueur). Deux blocs de couleurs différentes **n'ont pas besoin d'espace** entre eux, mais deux blocs de même couleur oui.
 
 Modifiez le solveur CP-SAT pour gerer des indices de la forme `[(2, 'rouge'), (3, 'bleu')]` ou la contrainte d'espacement depend de la couleur.
 
-**Indice** : il suffit de changer la contrainte `starts[b] + clue[b] + 1 <= starts[b+1]` en `starts[b] + clue[b] + gap <= starts[b+1]` ou `gap = 1` si les deux blocs ont la meme couleur, `gap = 0` sinon.",,,,,,,,48275d5d3311cc94,,,,,,,
+**Indice** : il suffit de changer la contrainte `starts[b] + clue[b] + 1 <= starts[b+1]` en `starts[b] + clue[b] + gap <= starts[b+1]` ou `gap = 1` si les deux blocs ont la même couleur, `gap = 0` sinon.",,,,,,,,4e5fe748c63634fb,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,aa94cc54,code,fr,7469be795389456a,"# Exercice 3 : Picross colore
 
 # A COMPLETER
@@ -2432,7 +2432,7 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,aa94cc54,code,fr,
 # Exemple d'indice colore : [(2, 'R'), (3, 'B'), (1, 'R')]
 print(""Exercice a completer"")
 ",,,,,,,,7469be795389456a,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,759c3dab,markdown,fr,1119b587df0131b9,"---
+MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,759c3dab,markdown,fr,5404dfe35f8f65f2,"---
 
 ## Recapitulatif
 
@@ -2445,7 +2445,7 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,759c3dab,markdown
 
 ### Pourquoi CP-SAT est si rapide
 
-| Mecanisme | Effet |
+| Mécanisme | Effet |
 |-----------|-------|
 | **Propagation de bornes** | Les positions de depart sont restreintes immediatement |
 | **Clause learning** | Les conflits decouverts empechent de repeter les erreurs |
@@ -2455,16 +2455,16 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb,759c3dab,markdown
 ### Ce qu'il faut retenir
 
 1. **La modelisation est la cle** : bien choisir ses variables et contraintes determine la performance
-2. **La propagation fait la difference** : verifier les contraintes pendant la recherche (pas apres) est ce qui rend CP-SAT exponentiellement plus rapide
-3. **NP-complet en theorie, facile en pratique** : avec un bon solveur, des problemes theoriquement difficiles se resolvent en millisecondes
+2. **La propagation fait la différence** : verifier les contraintes pendant la recherche (pas après) est ce qui rend CP-SAT exponentiellement plus rapide
+3. **NP-complet en théorie, facile en pratique** : avec un bon solveur, des problemes theoriquement difficiles se resolvent en millisecondes
 4. **Le speedup peut etre astronomique** : des facteurs de millions ne sont pas rares dans les bonnes applications de CP
 
 ### Ressources
 
 - [Projet EPITA PPC 2025 - PicrossSolver_Groupe37](https://github.com/jsboigeEpita/2025-PPC) : projet etudiant source
 - [Google OR-Tools - CP-SAT](https://developers.google.com/optimization/cp/cp_solver) : documentation officielle
-- [Nonogram - Wikipedia](https://en.wikipedia.org/wiki/Nonogram) : theorie et histoire des nonogrammes
-- [Survey of Paint-by-Numbers Puzzle Solvers](https://webpbn.com/survey/) : etat de l'art des solveurs",,,,,,,,1119b587df0131b9,,,,,,,
+- [Nonogram - Wikipedia](https://en.wikipedia.org/wiki/Nonogram) : théorie et histoire des nonogrammes
+- [Survey of Paint-by-Numbers Puzzle Solvers](https://webpbn.com/survey/) : etat de l'art des solveurs",,,,,,,,5404dfe35f8f65f2,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-11b-Picross-CSharp.ipynb,b414a521-1570-42c3-a8bc-0e9ca24dcaba,markdown,fr,f35924a69f7ac60a,"# App-11b : Picross (Nonogrammes) — Jumeau C#
 
 > **Twin C#** de [`App-11-Picross`](App-11-Picross.ipynb) (Python + OR-Tools CP-SAT + numpy + matplotlib).
@@ -2821,13 +2821,13 @@ Ce twin C# a **déroulé from-scratch** la mécanique de résolution des nonogra
 ---
 *Marathon .NET ⇄ Python #4956 — Search/Applications, tranche Picross / nonogrammes. See #4956, #3801.*
 ",,,,,,,,e01ef2c480342572,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,68af8eb4,markdown,fr,dde889be712d5ea7,"# App-15 : Planification de Calendrier Sportif (CSP)
+MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,68af8eb4,markdown,fr,a1fafbbfbf4c45de,"# App-15 : Planification de Calendrier Sportif (CSP)
 
 **Navigation** : [<< App-11 Picross](App-11-Picross.ipynb) | [Index](../../README.md) | [App-16 Crossword >>](App-16-Crossword-CSP.ipynb)
 
 ## Objectifs d'apprentissage
 
-Ce notebook explore la planification de calendriers sportifs comme un **Probleme de Satisfaction de Contraintes (CSP)**. A la fin de ce notebook, vous saurez :",,,,,,,,dde889be712d5ea7,,,,,,,
+Ce notebook explore la planification de calendriers sportifs comme un **Problème de Satisfaction de Contraintes (CSP)**. A la fin de ce notebook, vous saurez :",,,,,,,,a1fafbbfbf4c45de,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,4c653ff3,code,fr,f4c53bc2bb097a3a,"# Imports
 from ortools.sat.python import cp_model
 from dataclasses import dataclass
@@ -2839,29 +2839,29 @@ import numpy as np
 from collections import defaultdict
 
 print(""OR-Tools CP-SAT charge avec succes"")",,,,,,,,f4c53bc2bb097a3a,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,7aae5ef3,markdown,fr,ff246eecda84cc5f,"## 1. Modelisation du Probleme
+MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,7aae5ef3,markdown,fr,d18932707d411a77,"## 1. Modelisation du Problème
 
 ### Definition du CSP
 
-| Element | Description |
+| Élément | Description |
 |---------|-------------|
-| **Variables** | `match[i,j,r]` = 1 si equipe i recoit equipe j a la ronde r |
+| **Variables** | `match[i,j,r]` = 1 si équipe i recoit équipe j a la ronde r |
 | **Domaines** | {0, 1} (binaire) |
 | **Contraintes** | Voir ci-dessous |
 
 ### Contraintes Hard (obligatoires)
 
-1. **Round-robin simple** : chaque pair d'equipes joue exactement une fois
-2. **Une equipe par match** : une equipe joue au plus un match par ronde
-3. **Symetrie** : si A vs B, alors pas B vs A dans la meme ronde
-4. **Capacite stade** : une equipe ne peut pas recevoir deux fois meme ronde
+1. **Round-robin simple** : chaque pair d'équipes joue exactement une fois
+2. **Une équipe par match** : une équipe joue au plus un match par ronde
+3. **Symetrie** : si A vs B, alors pas B vs A dans la même ronde
+4. **Capacite stade** : une équipe ne peut pas recevoir deux fois même ronde
 
-### Contraintes Soft (preferences)
+### Contraintes Soft (préférences)
 
 1. **Equilibre D/E** : alternance domicile/exterieur
 2. **Minimiser deplacements** : reduire les km parcourus
 3. **TV slots** : matchs attractifs le samedi soir
-4. **Rivalries** : derbys dans des rondes specifiques",,,,,,,,ff246eecda84cc5f,,,,,,,
+4. **Rivalries** : derbys dans des rondes spécifiques",,,,,,,,d18932707d411a77,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,96f39470,code,fr,df14a255013ee0b7,"@dataclass
 class Team:
     """"""Representation d'une equipe de football.""""""
@@ -3006,9 +3006,9 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,7d53deab
 4. **Optimisation possible** : Le solveur CSP utilisera cette matrice pour minimiser la distance totale parcourue
 
 > **Note technique** : La formule de Haversine calcule la distance du grand cercle entre deux points sur une sphere. C'est plus précis que la distance euclidienne pour des distances inter-villes. Dans un cas réel, on utiliserait les distances routières (via Google Maps API) pour plus de précision, car les équipes voyagent par route ou train.",,,,,,,,d54ba91528eba31c,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,3187ffae,markdown,fr,e7d60f8c29b61937,"## 3. Modelisation CP-SAT
+MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,3187ffae,markdown,fr,5492c4951543bcbc,"## 3. Modelisation CP-SAT
 
-Nous utilisons OR-Tools CP-SAT pour resoudre le probleme.",,,,,,,,e7d60f8c29b61937,,,,,,,
+Nous utilisons OR-Tools CP-SAT pour resoudre le problème.",,,,,,,,5492c4951543bcbc,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,30b5ed70,code,fr,ba073d8d22bbf38a,"class SportsScheduler:
     """"""Solveur CP-SAT pour la planification sportive.""""""
     
@@ -3142,35 +3142,35 @@ else:
     print(""Pas de solution trouvee"")
     schedule = {}
 ",,,,,,,,ba073d8d22bbf38a,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,ca40ae3e,markdown,fr,b482b7f72978220c,"### Interpretation : Resolution du Probleme CSP
+MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,ca40ae3e,markdown,fr,9e278449318b9e10,"### Interpretation : Resolution du Problème CSP
 
 **Sortie obtenue** : une solution (optimale ou faisable) est trouvee par le solveur CP-SAT.
 
 | Aspect | Valeur | Signification |
 |--------|--------|---------------|
 | **Statut** | OPTIMAL ou FEASIBLE | Le solveur a trouvé une solution valide |
-| **Temps de resolution** | Rapide (non mesure dans la sortie) | Performance excellente pour 6 equipes |
+| **Temps de resolution** | Rapide (non mesure dans la sortie) | Performance excellente pour 6 équipes |
 | **Variables** | n × (n-1) × rondes | Complexite quadratique gérable par CP-SAT |
 
 **Points cles** :
 1. **Efficacité de CP-SAT** : OR-Tools résout des problemes de planification sportive complexes très rapidement
 2. **Contraintes satisfaites** : Round-robin simple (chaque pair joue une fois), une équipe joue une fois par ronde, équilibre D/E
 3. **Objectif optimisé** : Minimisation des déplacements tout en respectant les contraintes hard
-4. **Extensibilité** : Le modele peut etre étendu avec des contraintes additionnelles (TV, derbys, arbitres)
+4. **Extensibilité** : Le modèle peut etre étendu avec des contraintes additionnelles (TV, derbys, arbitres)
 
-> **Note technique** : Le solveur CP-SAT utilise des techniques avancées (propagation de contraintes, branch-and-bound, lazy clauses) pour trouver rapidement des solutions optimales. Pour des problemes plus grands (20+ equipes), le temps de resolution augmente mais reste raisonnable avec des timeouts appropriés.",,,,,,,,b482b7f72978220c,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,75fd177a,markdown,fr,6dc7b6ec65ed95b7,"#### Exercice 1 : Limiter les longs deplacements consecutifs
+> **Note technique** : Le solveur CP-SAT utilise des techniques avancées (propagation de contraintes, branch-and-bound, lazy clauses) pour trouver rapidement des solutions optimales. Pour des problemes plus grands (20+ équipes), le temps de resolution augmente mais reste raisonnable avec des timeouts appropriés.",,,,,,,,9e278449318b9e10,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,75fd177a,markdown,fr,3e7e181834524abc,"#### Exercice 1 : Limiter les longs deplacements consecutifs
 
-Le modele actuel minimise la distance totale mais permet potentiellement a une equipe de faire deux longs deplacements consecutifs (par exemple Nice -> Lille puis Marseille -> Strasbourg).
+Le modèle actuel minimise la distance totale mais permet potentiellement a une équipe de faire deux longs deplacements consecutifs (par exemple Nice -> Lille puis Marseille -> Strasbourg).
 
-**Enonce** : ajoutez une contrainte qui interdit a une equipe de faire plus d'un deplacement superieur a 500 km lors de deux rondes consecutives.
+**Enonce** : ajoutez une contrainte qui interdit a une équipe de faire plus d'un deplacement superieur a 500 km lors de deux rondes consecutives.
 
 **Consignes** :
-1. Pour chaque equipe et chaque paire de rondes consecutives, comptez les matchs a l'exterieur impliquant un deplacement > 500 km
+1. Pour chaque équipe et chaque paire de rondes consecutives, comptez les matchs a l'exterieur impliquant un deplacement > 500 km
 2. Ajoutez une contrainte : la somme de ces longs deplacements sur 2 rondes consecutives ne doit pas depasser 1
 3. Resolvez et comparez les statistiques de deplacement avec le calendrier initial
 
-**Indice** : creez une variable auxiliaire boolVar `long_trip[i,r]` qui vaut 1 si l'equipe i voyage a l'exterieur de plus de 500 km a la ronde r, puis contraignez `sum(long_trip[i,r+k] for k in range(2)) <= 1`.",,,,,,,,6dc7b6ec65ed95b7,,,,,,,
+**Indice** : créez une variable auxiliaire boolVar `long_trip[i,r]` qui vaut 1 si l'équipe i voyage a l'exterieur de plus de 500 km a la ronde r, puis contraignez `sum(long_trip[i,r+k] for k in range(2)) <= 1`.",,,,,,,,3e7e181834524abc,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,e347a4af,code,fr,33110cbc420b3676,"# Exercice 1 : Limiter les longs deplacements consecutifs
 
 # TODO etudiant : ajoutez une contrainte anti-long-deplacement-consecutif
@@ -3237,28 +3237,28 @@ if schedule:
     for i, team in enumerate(league.teams):
         print(f""  {team.name}: {stats['total_travel'][i]:.0f} km ""
               f""({stats['home_games'][i]} D, {stats['away_games'][i]} E)"")",,,,,,,,71b333c4c3a05175,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,fa50afdf,markdown,fr,93858b66d93f8db0,"### Interpretation : Statistiques du Calendrier
+MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,fa50afdf,markdown,fr,ace62c7e79a682df,"### Interpretation : Statistiques du Calendrier
 
 **Sortie obtenue** : Calendrier complet avec statistiques sur les deplacements et la repartition domicile/exterieur.
 
 | Metrique | Observation | Signification |
 |----------|-------------|---------------|
-| **Distance moyenne** | ~1000-1500 km par equipe | Optimisation globale des deplacements |
-| **Ecart-type** | Variable | Indicateur de l'equite entre equipes |
+| **Distance moyenne** | ~1000-1500 km par équipe | Optimisation globale des deplacements |
+| **Ecart-type** | Variable | Indicateur de l'equite entre équipes |
 | **Repartition D/E** | Variable (1 D/4 E a 4 D/1 E) | L'equilibre D/E n'est pas impose par les contraintes |
 
 **Points cles** :
-1. **Equite geographique** : Les equipes ont des charges de deplacement similaires (malgré leur position geographique)
-2. **Minimisation globale** : L'objectif minimise la somme des distances, ce qui beneficie a toutes les equipes
-3. **Alternance D/E** : sans contrainte explicite, la repartition domicile/exterieur varie d'une equipe a l'autre (ex. 1 D/4 E ou 4 D/1 E)
+1. **Equite geographique** : Les équipes ont des charges de deplacement similaires (malgré leur position geographique)
+2. **Minimisation globale** : L'objectif minimise la somme des distances, ce qui beneficie a toutes les équipes
+3. **Alternance D/E** : sans contrainte explicite, la repartition domicile/exterieur varie d'une équipe a l'autre (ex. 1 D/4 E ou 4 D/1 E)
 4. **Faisabilite** : Le solveur trouve une solution satisfaisant toutes les contraintes en quelques secondes
 
-> **Note technique** : Dans un championnat professionnel, l'equite des deplacements est un enjeu majeur. Les equipes du sud (Marseille, Lyon) ne devraient pas etre systematiquement desavantagees par rapport aux equipes du nord (Lille, Paris). Le modele CSP garantit cette equite par la minimisation de la somme des distances.",,,,,,,,93858b66d93f8db0,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,cfe71f50,markdown,fr,5c2b2b809d48e627,"## 5. Contraintes Avancees
+> **Note technique** : Dans un championnat professionnel, l'equite des deplacements est un enjeu majeur. Les équipes du sud (Marseille, Lyon) ne devraient pas etre systematiquement desavantagees par rapport aux équipes du nord (Lille, Paris). Le modèle CSP garantit cette equite par la minimisation de la somme des distances.",,,,,,,,ace62c7e79a682df,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,cfe71f50,markdown,fr,aefd05dc131f5e26,"## 5. Contraintes Avancees
 
 ### Contraintes TV
 
-Les chaines de television veulent des matchs attractifs a certains creneaux.",,,,,,,,5c2b2b809d48e627,,,,,,,
+Les chaînes de television veulent des matchs attractifs a certains creneaux.",,,,,,,,aefd05dc131f5e26,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,06944dc2,code,fr,a1556cfa022ddd21,"class TVScheduler(SportsScheduler):
     """"""Extension avec contraintes TV.""""""
     
@@ -3314,35 +3314,35 @@ if tv_scheduler.solve(time_limit=10):
     print(""Solution trouvee!"")
     tv_schedule = tv_scheduler.get_schedule()
     display_schedule(league, tv_schedule)",,,,,,,,a1556cfa022ddd21,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,85e71513,markdown,fr,8a51aa453fa0c18d,"### Interpretation : Optimisation TV
+MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,85e71513,markdown,fr,1e59df2c0948623f,"### Interpretation : Optimisation TV
 
 **Sortie obtenue** : Calendrier reoptimise pour maximiser l'attractivite TV des matchs dans les creneaux importants (ouverture et cloture).
 
 | Aspect | Impact | Signification |
 |--------|--------|---------------|
-| **Creneaux TV** | Ronde 1 et derniere ronde | Matchs les plus attractifs places en ouverture et cloture |
+| **Creneaux TV** | Ronde 1 et dernière ronde | Matchs les plus attractifs places en ouverture et cloture |
 | **Attractivite** | Combinaison des scores TV | Paris vs Marseille, Lyon vs PSG sont privilegies |
 | **Trade-off** | Distance vs TV | Les matchs attractifs peuvent augmenter les deplacements |
 
 **Points cles** :
-1. **Revenus TV** : Les matchs attractifs generent plus d'audience et de revenus pour les chaines de television
+1. **Revenus TV** : Les matchs attractifs generent plus d'audience et de revenus pour les chaînes de television
 2. **Contrainte soft** : L'objectif TV s'ajoute aux autres contraintes (round-robin, equilibre, deplacements)
 3. **Importance ponderee** : Les creneaux ""Ouverture"" et ""Cloture"" ont un poids 2x pour attirer les matchs les plus prestigieux
-4. **Flexibilite du modele** : On peut facilement ajouter d'autres creneaux (samedi soir, dimanche apres-midi)
+4. **Flexibilite du modèle** : On peut facilement ajouter d'autres creneaux (samedi soir, dimanche après-midi)
 
-> **Note technique** : Dans la pratique, les chaines de television payent des sommes enormes pour les droits de diffusion. L'optimisation de l'attractivite TV est donc un objectif economique majeur. Le modele CSP permet de trouver un equilibre entre les contraintes sportives (equite, deplacements) et les contraintes economiques (TV).",,,,,,,,8a51aa453fa0c18d,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,59eda99a,markdown,fr,b8c8bf5b8c3cfa72,"#### Exercice 2 : Contrainte de placement des derbys
+> **Note technique** : Dans la pratique, les chaînes de television payent des sommes enormes pour les droits de diffusion. L'optimisation de l'attractivite TV est donc un objectif economique majeur. Le modèle CSP permet de trouver un equilibre entre les contraintes sportives (equite, deplacements) et les contraintes economiques (TV).",,,,,,,,1e59df2c0948623f,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,59eda99a,markdown,fr,d8ae6ce82194e486,"#### Exercice 2 : Contrainte de placement des derbys
 
-Les derbys (matchs entre equipes geographiquement proches) generent souvent des tensions. On souhaite s'assurer qu'ils ne sont pas joues lors des memes rondes.
+Les derbys (matchs entre équipes geographiquement proches) generent souvent des tensions. On souhaite s'assurer qu'ils ne sont pas joues lors des mêmes rondes.
 
-**Enonce** : ajoutez une contrainte au modele CP-SAT pour que deux derbys ne puissent pas avoir lieu lors de la meme ronde. Cela garantit que les forces de securite puissent se concentrer sur un seul derby a la fois.
+**Enonce** : ajoutez une contrainte au modèle CP-SAT pour que deux derbys ne puissent pas avoir lieu lors de la même ronde. Cela garantit que les forces de securite puissent se concentrer sur un seul derby a la fois.
 
 **Consignes** :
 1. Recuperez la liste des derbys avec `find_derbies`
 2. Pour chaque paire de derbys, ajoutez une contrainte : au plus un des deux matchs par ronde
 3. Resolvez et verifiez que la contrainte est respectee
 
-**Indice** : pour deux derbys (a,b) et (c,d), la contrainte est `match_vars[(a,b,r)] + match_vars[(b,a,r)] + match_vars[(c,d,r)] + match_vars[(d,c,r)] <= 1` pour chaque ronde r.",,,,,,,,b8c8bf5b8c3cfa72,,,,,,,
+**Indice** : pour deux derbys (a,b) et (c,d), la contrainte est `match_vars[(a,b,r)] + match_vars[(b,a,r)] + match_vars[(c,d,r)] + match_vars[(d,c,r)] <= 1` pour chaque ronde r.",,,,,,,,d8ae6ce82194e486,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,8d9ea2c1,code,fr,d9fce00473b5652e,"# Exercice 2 : Contrainte de placement des derbys
 
 # TODO etudiant : creez un nouveau scheduler avec la contrainte ""pas deux derbys meme ronde""
@@ -3354,9 +3354,9 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,8d9ea2c1
 #   model.Add(match_vars[(a,b,r)] + match_vars[(b,a,r)] + match_vars[(c,d,r)] + match_vars[(d,c,r)] <= 1)
 result = None  # TODO etudiant : remplacer par votre implementation
 print(""Exercice a completer : contrainte de placement des derbys"")",,,,,,,,d9fce00473b5652e,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,da9a7e50,markdown,fr,8cf60fc67b4ecb9d,"## 6. Contraintes de Derby
+MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,da9a7e50,markdown,fr,cbcff34c8cd80e00,"## 6. Contraintes de Derby
 
-Les derbys (matchs entre equipes geographiquement proches) peuvent avoir des contraintes speciales pour la securite.",,,,,,,,8cf60fc67b4ecb9d,,,,,,,
+Les derbys (matchs entre équipes geographiquement proches) peuvent avoir des contraintes speciales pour la securite.",,,,,,,,cbcff34c8cd80e00,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,08e025b9,code,fr,978d58d7cb374e66,"def find_derbies(league: SportsLeague, distances: np.ndarray, 
                 threshold_km: float = 200) -> List[Tuple[int, int]]:
     """"""
@@ -3403,26 +3403,26 @@ if schedule:
     print(f""\nDerbys dans le calendrier:"")
     for (home, away), r in derby_rounds.items():
         print(f""  Ronde {r+1}: {league.teams[home].name} vs {league.teams[away].name}"")",,,,,,,,978d58d7cb374e66,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,1334b5f1,markdown,fr,505ee0b0e468b4af,"### Interpretation : Identification des Derbys
+MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,1334b5f1,markdown,fr,666abb0cdfc1f814,"### Interpretation : Identification des Derbys
 
-**Sortie obtenue** : Liste des derbys (equipes distantes de moins de 300 km) et leurs rondes dans le calendrier.
+**Sortie obtenue** : Liste des derbys (équipes distantes de moins de 300 km) et leurs rondes dans le calendrier.
 
 | Aspect | Observation | Signification |
 |--------|-------------|---------------|
-| **Nombre de derbys** | Depend de la distribution geographique | Plus la densite d'equipes est elevee, plus il y a de derbys |
+| **Nombre de derbys** | Depend de la distribution geographique | Plus la densite d'équipes est elevee, plus il y a de derbys |
 | **Seuil de distance** | 200-300 km | Distance raisonnable pour un deplacement en bus |
 | **Ronde de derby** | Variable | Le solveur place les derbys selon les contraintes globales |
 
 **Points cles** :
 1. **Securite et logistique** : Les derbys necessitent une planification speciale (securite renforcee, transports)
-2. **Contrainte potentielle** : Dans un vrai systeme, on pourrait forcer les derbys a etre joues en week-end ou a des heures specifiques
-3. **Impact sur les deplacements** : Les derbis reduisent les distances de voyage pour les equipes impliquees
-4. **Modelisation extensible** : Ce systeme permet d'identifier et de gerer les matchs a haut enjeu
+2. **Contrainte potentielle** : Dans un vrai système, on pourrait forcer les derbys a etre joues en week-end ou a des heures spécifiques
+3. **Impact sur les deplacements** : Les derbis reduisent les distances de voyage pour les équipes impliquees
+4. **Modelisation extensible** : Ce système permet d'identifier et de gerer les matchs a haut enjeu
 
-> **Note technique** : Dans un championnat professionnel comme la Ligue 1, les derbys (PSG vs Marseille, Lyon vs Saint-Etienne, etc.) sont des evenements majeurs qui necessitent une planification speciale. Les contraintes de securite peuvent etre ajoutees au modele CSP pour forcer ces matchs a des creneaux specifiques.",,,,,,,,505ee0b0e468b4af,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,bde09b15,markdown,fr,21b6c9e4503e8185,"## 7. Extension: Round-Robin Double
+> **Note technique** : Dans un championnat professionnel comme la Ligue 1, les derbys (PSG vs Marseille, Lyon vs Saint-Etienne, etc.) sont des événements majeurs qui necessitent une planification speciale. Les contraintes de securite peuvent etre ajoutees au modèle CSP pour forcer ces matchs a des creneaux spécifiques.",,,,,,,,666abb0cdfc1f814,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,bde09b15,markdown,fr,d4a21fb4cb609358,"## 7. Extension: Round-Robin Double
 
-Dans un championnat double, chaque equipe joue deux fois contre chaque autre (une fois a domicile, une fois a l'exterieur).",,,,,,,,21b6c9e4503e8185,,,,,,,
+Dans un championnat double, chaque équipe joue deux fois contre chaque autre (une fois a domicile, une fois a l'exterieur).",,,,,,,,d4a21fb4cb609358,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,a8167d23,code,fr,d64ac1f4416c0e34,"class DoubleRoundRobinScheduler(SportsScheduler):
     """"""
     Solveur pour round-robin double.
@@ -3471,33 +3471,33 @@ print(f""Double Round-Robin: {double_league.n_teams} equipes, {double_league.rou
 if double_scheduler.solve(time_limit=10):
     double_schedule = double_scheduler.get_schedule()
     display_schedule(double_league, double_schedule)",,,,,,,,d64ac1f4416c0e34,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,05f0e88b,markdown,fr,3a85d0102f1c1950,"### Interpretation : Round-Robin Double
+MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,05f0e88b,markdown,fr,aa4b633442f5df1d,"### Interpretation : Round-Robin Double
 
-**Sortie obtenue** : Calendrier complet avec 6 rondes pour 4 equipes (chaque pair joue deux fois, aller-retour).
+**Sortie obtenue** : Calendrier complet avec 6 rondes pour 4 équipes (chaque pair joue deux fois, aller-retour).
 
 | Aspect | Valeur | Signification |
 |--------|--------|---------------|
-| **Rondes** | 2 × (n-1) | Chaque equipe joue 2 fois contre chaque adversaire |
-| **Matchs par equipe** | 2 × (n-1) | Double confrontation : aller domicile, retour exterieur |
-| **Equite** | Parfaite | Chaque equipe joue exactement une fois a domicile et une fois a l'exterieur contre chaque adversaire |
+| **Rondes** | 2 × (n-1) | Chaque équipe joue 2 fois contre chaque adversaire |
+| **Matchs par équipe** | 2 × (n-1) | Double confrontation : aller domicile, retour exterieur |
+| **Equite** | Parfaite | Chaque équipe joue exactement une fois a domicile et une fois a l'exterieur contre chaque adversaire |
 
 **Points cles** :
 1. **Standard professionnel** : La plupart des championnats europeens utilisent le round-robin double (Ligue 1, Premier League, Liga...)
 2. **Symetrie parfaite** : L'avantage de jouer a domicile est compense par le match retour
-3. **Complexite accrue** : Le nombre de rondes double, ce qui augmente la taille du probleme CSP
-4. **Contraintes specifiques** : Le modele garantit que chaque pair d'equipes joue exactement une fois a domicile et une fois a l'exterieur
+3. **Complexite accrue** : Le nombre de rondes double, ce qui augmente la taille du problème CSP
+4. **Contraintes spécifiques** : Le modèle garantit que chaque pair d'équipes joue exactement une fois a domicile et une fois a l'exterieur
 
-> **Note technique** : Le round-robin double est le format standard pour les championnats professionnels. Le modele CP-SAT s'adapte facilement en modifiant les contraintes C1 pour imposer un match domicile et un match exterieur pour chaque pair d'equipes.",,,,,,,,3a85d0102f1c1950,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,4476ccb0,markdown,fr,932a550d2ec92e43,"#### Exercice 3 : Analyser un calendrier double round-robin
+> **Note technique** : Le round-robin double est le format standard pour les championnats professionnels. Le modèle CP-SAT s'adapte facilement en modifiant les contraintes C1 pour imposer un match domicile et un match exterieur pour chaque pair d'équipes.",,,,,,,,aa4b633442f5df1d,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,4476ccb0,markdown,fr,b313bcf1c41737c2,"#### Exercice 3 : Analyser un calendrier double round-robin
 
 Le calendrier double round-robin ci-dessus garantit aller-retour, mais est-il equitable en termes de deplacements ?
 
 **Enonce** : utilisez `compute_schedule_stats` sur le calendrier double round-robin (`double_schedule`) et analysez :
-1. L'ecart de distance totale entre l'equipe la plus et la moins voyageuse
-2. La repartition domicile/exterieur de chaque equipe (est-elle equilibree ?)
+1. L'ecart de distance totale entre l'équipe la plus et la moins voyageuse
+2. La repartition domicile/exterieur de chaque équipe (est-elle equilibree ?)
 3. Comparez l'ecart-type des deplacements avec celui du calendrier simple
 
-**Indice** : `compute_schedule_stats` retourne un dictionnaire avec les cles `total_travel`, `home_games`, `away_games`, `avg_travel`, `travel_std`.",,,,,,,,932a550d2ec92e43,,,,,,,
+**Indice** : `compute_schedule_stats` retourne un dictionnaire avec les cles `total_travel`, `home_games`, `away_games`, `avg_travel`, `travel_std`.",,,,,,,,b313bcf1c41737c2,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,b9ae5615,code,fr,38e52c7fb0306409,"# Exercice 3 : Analyser un calendrier double round-robin
 
 # TODO etudiant : appelez compute_schedule_stats sur double_schedule et double_league
@@ -3547,23 +3547,23 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,a07d5283
 
 if schedule:
     plot_schedule_matrix(league, schedule)",,,,,,,,dae3ae0669a9d31e,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,e95e6ecb,markdown,fr,abed03c847812d76,"### Interpretation : Matrice Domicile/Exterieur
+MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,e95e6ecb,markdown,fr,9eed848967f4fbb0,"### Interpretation : Matrice Domicile/Exterieur
 
-**Sortie obtenue** : Matrice visuelle equipes x rondes montrant la repartition domicile (rouge) / exterieur (bleu).
+**Sortie obtenue** : Matrice visuelle équipes x rondes montrant la repartition domicile (rouge) / exterieur (bleu).
 
 | Aspect | Observation | Signification |
 |--------|-------------|---------------|
 | **Alternance** | Pas plus de 2 consecutifs | Contrainte d'equilibre D/E respectee |
-| **Cohérence spatiale** | Equipes proches ont des motifs similaires | Impact de la minimisation des deplacements |
-| **Couverture** | Chaque equipe joue chaque ronde | Contrainte round-robin satisfaite |
+| **Cohérence spatiale** | Équipes proches ont des motifs similaires | Impact de la minimisation des deplacements |
+| **Couverture** | Chaque équipe joue chaque ronde | Contrainte round-robin satisfaite |
 
 **Points cles** :
 1. **Visualisation efficace** : Cette matrice permet de verifier rapidement la qualite du calendrier
-2. **Contrainte d'equilibre** : L'alternance D/E est visible par l'absence de longues sequences de la meme couleur
-3. **Equite** : Chaque equipe a le meme nombre de matchs domicile et exterieur (equilibre parfait)
-4. **Motifs spatiaux** : Les equipes geographiquement proches ont des calendriers similaires (minimisation des deplacements)
+2. **Contrainte d'equilibre** : L'alternance D/E est visible par l'absence de longues sequences de la même couleur
+3. **Equite** : Chaque équipe a le même nombre de matchs domicile et exterieur (equilibre parfait)
+4. **Motifs spatiaux** : Les équipes geographiquement proches ont des calendriers similaires (minimisation des deplacements)
 
-> **Note technique** : Dans un championnat professionnel, cette visualisation est utilisee par les organisateurs pour verifier l'equite du calendrier. Les entraineurs l'utilisent pour planifier la preparation physique et tactique en fonction des deplacements.",,,,,,,,abed03c847812d76,,,,,,,
+> **Note technique** : Dans un championnat professionnel, cette visualisation est utilisee par les organisateurs pour verifier l'equite du calendrier. Les entraineurs l'utilisent pour planifier la preparation physique et tactique en fonction des deplacements.",,,,,,,,9eed848967f4fbb0,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,3fc313f7,markdown,fr,525ead7d4695049e,## 9. Benchmark: Taille vs Temps de Resolution,,,,,,,,525ead7d4695049e,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,656e0e56,code,fr,f50a213c7717c3e8,"def benchmark_scaling(max_teams: int = 12, time_limit: int = 5):
     """"""
@@ -3618,23 +3618,23 @@ plt.grid(True)
 
 plt.tight_layout()
 plt.show()",,,,,,,,f50a213c7717c3e8,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,4eed35c9,markdown,fr,5ca9bbb9fc882635,"### Interpretation : Scalabilite du Solveur CP-SAT
+MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,4eed35c9,markdown,fr,6bc9359c213f84c5,"### Interpretation : Scalabilite du Solveur CP-SAT
 
-**Sortie obtenue** : Courbes montrant l'evolution du temps de resolution et du nombre de variables en fonction du nombre d'equipes.
+**Sortie obtenue** : Courbes montrant l'evolution du temps de resolution et du nombre de variables en fonction du nombre d'équipes.
 
 | Metrique | Observation | Signification |
 |----------|-------------|---------------|
-| **Temps de resolution** | Croissance sur la plage testee (0.01-0.05 s pour n=4..10) | Le probleme est NP-difficile en theorie |
-| **Nombre de variables** | Croissance en O(n² × r) | Chaque equipe joue contre chaque autre a chaque ronde |
-| **Seuil de scalabilite** | Non mesure au-dela de 10 equipes | Projection : limite pratique ~20-30 equipes |
+| **Temps de resolution** | Croissance sur la plage testee (0.01-0.05 s pour n=4..10) | Le problème est NP-difficile en théorie |
+| **Nombre de variables** | Croissance en O(n² × r) | Chaque équipe joue contre chaque autre a chaque ronde |
+| **Seuil de scalabilite** | Non mesure au-dela de 10 équipes | Projection : limite pratique ~20-30 équipes |
 
 **Points cles** :
-1. **Complexite combinatoire** : Le nombre de variables croit quadratiquement avec le nombre d'equipes (n × (n-1) × rondes)
-2. **Temps de resolution acceptable** : Pour 10 equipes, la resolution est quasi-instantanee (0.05 s mesure)
-3. **Explosion combinatoire** : Au-dela de 20 equipes, le temps de resolution augmente drastiquement
+1. **Complexite combinatoire** : Le nombre de variables croit quadratiquement avec le nombre d'équipes (n × (n-1) × rondes)
+2. **Temps de resolution acceptable** : Pour 10 équipes, la resolution est quasi-instantanee (0.05 s mesure)
+3. **Explosion combinatoire** : Au-dela de 20 équipes, le temps de resolution augmente drastiquement
 4. **Optimisation pratique** : Un timeout de 5-10 secondes est suffisant pour des problemes de taille moyenne
 
-> **Note technique** : Le benchmark mesure n=4..10 (0.01-0.05 s). Au-dela (championnats de 20 equipes), le temps de resolution n'est pas mesure ici ; il faudrait augmenter le timeout, utiliser des heuristiques, ou se contenter de solutions faisables (non optimales).",,,,,,,,5ca9bbb9fc882635,,,,,,,
+> **Note technique** : Le benchmark mesure n=4..10 (0.01-0.05 s). Au-dela (championnats de 20 équipes), le temps de resolution n'est pas mesure ici ; il faudrait augmenter le timeout, utiliser des heuristiques, ou se contenter de solutions faisables (non optimales).",,,,,,,,6bc9359c213f84c5,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,efb5382b,markdown,fr,69c50578f19ddb63,"## 10. Resume et Comparaison des Approches
 
 ### Approches CSP vs Autres",,,,,,,,69c50578f19ddb63,,,,,,,
@@ -3649,24 +3649,24 @@ comparison_data = {
 
 df_comparison = pd.DataFrame(comparison_data)
 display(df_comparison)",,,,,,,,9a21fda8c17d64cc,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,83d549a8,markdown,fr,08b3d4b2313d8241,"### Interpretation : Comparaison des Approches
+MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,83d549a8,markdown,fr,6cc077d10f22b666,"### Interpretation : Comparaison des Approches
 
-**Sortie obtenue** : Tableau comparatif de quatre methodes de resolution de problemes de planification sportive.
+**Sortie obtenue** : Tableau comparatif de quatre méthodes de resolution de problemes de planification sportive.
 
-| Aspect | CSP (OR-Tools) | Programmation Lineaire | Metaheuristiques | Generation manuelle |
+| Aspect | CSP (OR-Tools) | Programmation Lineaire | Métaheuristiques | Generation manuelle |
 |--------|----------------|------------------------|------------------|---------------------|
 | **Optimalite** | Oui (si temps suffisant) | Oui (PLNE) | Non (approximative) | Variable |
-| **Scalabilite** | Moyenne (20-30 equipes) | Bonne | Excellente | Mauvaise |
+| **Scalabilite** | Moyenne (20-30 équipes) | Bonne | Excellente | Mauvaise |
 | **Flexibilite contraintes** | Excellente | Moyenne | Bonne | Excellente |
-| **Temps de developpement** | Moyen | Eleve | Moyen | Eleve |
+| **Temps de développement** | Moyen | Eleve | Moyen | Eleve |
 
 **Points cles** :
-1. **CSP (OR-Tools)** offre le meilleur compromis entre optimalite, flexibilite et temps de developpement pour des problemes de taille moyenne (jusqu'a 30 equipes)
+1. **CSP (OR-Tools)** offre le meilleur compromis entre optimalite, flexibilite et temps de développement pour des problemes de taille moyenne (jusqu'a 30 équipes)
 2. **Programmation Lineaire** garantie l'optimalite mais est moins flexible pour les contraintes non-lineaires (equilibre D/E, derbys)
-3. **Metaheuristiques** (algorithmes genetiques, recuit simule) scalent mieux mais ne garantissent pas l'optimalite
+3. **Métaheuristiques** (algorithmes génétiques, recuit simule) scalent mieux mais ne garantissent pas l'optimalite
 4. **Generation manuelle** est flexible mais chronophage et non reproductible
 
-> **Note technique** : Le choix de la methode depend du contexte. Pour un championnat professionnel avec 20 equipes et des contraintes complexes, CSP est recommande. Pour des ligues de 40+ equipes avec des contraintes simples, les metaheuristiques sont plus adaptees.",,,,,,,,08b3d4b2313d8241,,,,,,,
+> **Note technique** : Le choix de la méthode depend du contexte. Pour un championnat professionnel avec 20 équipes et des contraintes complexes, CSP est recommande. Pour des ligues de 40+ équipes avec des contraintes simples, les métaheuristiques sont plus adaptees.",,,,,,,,6cc077d10f22b666,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,bkiwc4sttw,markdown,fr,2a1d1c6bb837010c,"## Exercices
 
 Les exercices suivants vous permettront d'approfondir votre compréhension de la planification sportive avec CSP.",,,,,,,,2a1d1c6bb837010c,,,,,,,
@@ -3729,16 +3729,16 @@ def add_referee_constraints(scheduler: SportsScheduler, n_referees: int):
 # add_referee_constraints(scheduler_with_refs, n_referees=3)
 # scheduler_with_refs.solve(time_limit=10)
 print(""Exercice a completer"")",,,,,,,,1f3991356251184f,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,w67b0q6ob9,markdown,fr,28a953ad2de67f21,"### Exercice 2 : Objectif d'equite des deplacements
+MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,w67b0q6ob9,markdown,fr,5479540fc3b2f821,"### Exercice 2 : Objectif d'equite des deplacements
 
-L'objectif actuel minimise la distance totale, mais cela peut defavoriser certaines equipes.
+L'objectif actuel minimise la distance totale, mais cela peut defavoriser certaines équipes.
 
-**Objectif** : Modifiez la fonction objectif pour minimiser l'ecart-type des distances parcourues par equipe (equite).
+**Objectif** : Modifiez la fonction objectif pour minimiser l'ecart-type des distances parcourues par équipe (equite).
 
 **Indices** :
-- Calculez la distance totale parcourue par chaque equipe
+- Calculez la distance totale parcourue par chaque équipe
 - Minimisez la variance de ces distances plutot que la somme
-- Cela assure que toutes les equipes ont un ""fardeau"" similaire",,,,,,,,28a953ad2de67f21,,,,,,,
+- Cela assure que toutes les équipes ont un ""fardeau"" similaire",,,,,,,,5479540fc3b2f821,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,89s4j6mhla5,code,fr,9a01044e2dd5845b,"# Exemple guide 2 : Objectif d'equite des deplacements
 # Exemple guide: Minimiser l'ecart-type (ou l'amplitude) des distances parcourues par equipe
 
@@ -3773,16 +3773,16 @@ def minimize_travel_fairness(scheduler: SportsScheduler):
 # travel_vars = minimize_travel_fairness(scheduler_fair)
 # scheduler_fair.solve(time_limit=30)
 print(""Exercice a completer"")",,,,,,,,9a01044e2dd5845b,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,bfs3hw0aml,markdown,fr,94bc734f1e400ba5,"### Exercice 3 : Contraintes de repos minimum
+MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,bfs3hw0aml,markdown,fr,bb668344e256fd5d,"### Exercice 3 : Contraintes de repos minimum
 
-Les equipes professionnelles ont besoin de repos minimum entre les matchs.
+Les équipes professionnelles ont besoin de repos minimum entre les matchs.
 
-**Objectif** : Ajoutez une contrainte qui impose au moins 3 jours de repos entre deux matchs d'une meme equipe.
+**Objectif** : Ajoutez une contrainte qui impose au moins 3 jours de repos entre deux matchs d'une même équipe.
 
 **Indices** :
 - Considerez que les rondes sont espacees de 7 jours
 - Cette contrainte est implicitement satisfaite dans un round-robin simple
-- Mais elle devient pertinente si on ajoute des matchs de coupe entre les rondes de championnat",,,,,,,,94bc734f1e400ba5,,,,,,,
+- Mais elle devient pertinente si on ajoute des matchs de coupe entre les rondes de championnat",,,,,,,,bb668344e256fd5d,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,xbmredyt0s,code,fr,b06e5e7a5eaa4266,"# Exemple guide 3 : Contraintes de repos minimum
 # Exemple guide: Modifier le modele pour imposer un repos de >= k jours entre matchs
 
@@ -3819,7 +3819,7 @@ def add_rest_constraints(scheduler: SportsScheduler, min_rest_days: int = 3):
 # add_rest_constraints(scheduler_rest, min_rest_days=2)
 # scheduler_rest.solve(time_limit=10)
 print(""Exercice a completer"")",,,,,,,,b06e5e7a5eaa4266,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,850fc287,markdown,fr,a4d3b1c556c22e8a,"## Conclusion
+MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,850fc287,markdown,fr,c88005e16195be35,"## Conclusion
 
 ### Ce que nous avons appris
 
@@ -3829,7 +3829,7 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,850fc287
 
 3. **Trade-offs** : Minimiser les deplacements vs maximiser l'attractivite TV
 
-4. **Scalabilite** : Le probleme croit en O(n^2 * r) variables, mais CP-SAT gere bien jusqu'a 20-30 equipes
+4. **Scalabilite** : Le problème croit en O(n^2 * r) variables, mais CP-SAT gere bien jusqu'a 20-30 équipes
 
 ### Extensions possibles
 
@@ -3842,8 +3842,8 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb,850fc287
 
 - [OR-Tools CP-SAT](https://developers.google.com/optimization/cp/cp_solver)
 - [Sports Scheduling Literature](https://www.sportscheduling.org/)
-- [Round Robin Tournament Problem](https://en.wikipedia.org/wiki/Round-robin_tournament)",,,,,,,,a4d3b1c556c22e8a,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,b635c757b260,markdown,fr,db0cada0e099a1ba,"# App-15b : Planification de Calendrier Sportif -- Jumeau C#
+- [Round Robin Tournament Problem](https://en.wikipedia.org/wiki/Round-robin_tournament)",,,,,,,,c88005e16195be35,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,b635c757b260,markdown,fr,3212fb18fedd0724,"# App-15b : Planification de Calendrier Sportif -- Jumeau C#
 
 > **Twin C#** de [`App-15-SportsScheduling`](App-15-SportsScheduling.ipynb) (Python + OR-Tools CP-SAT + numpy + matplotlib).
 > Marathon **.NET / Python** (#4956), volet **Search / Applications / CSP**.
@@ -3854,19 +3854,19 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,
 
 A la fin de ce notebook, vous saurez :
 
-1. **Modeliser** un calendrier sportif (round-robin) comme un **Probleme de Satisfaction de Contraintes (CSP)** en C# / .NET 9.
-2. **Invoquer le vrai solveur industriel** `Google.OrTools` (CP-SAT natif .NET) -- `CpModel`, `BoolVar`, `Add`, `Minimize` -- pour optimiser les deplacements des equipes.
-3. **Reproduire l'optimum verifie** du twin Python (1232 km en moyenne par equipe, ecart-type 473 km -- cf. correction G.1 section 4 : l'output commite d'App-15 affichait 1233/534, valeur sous-optimale) sur la **meme matrice de distances**, et comprendre pourquoi les deux twins s'accordent au km pres.
-4. **Etendre** le modele : contraintes d'equilibre domicile/exterieur, attractivite TV, derbys, round-robin double.
+1. **Modeliser** un calendrier sportif (round-robin) comme un **Problème de Satisfaction de Contraintes (CSP)** en C# / .NET 9.
+2. **Invoquer le vrai solveur industriel** `Google.OrTools` (CP-SAT natif .NET) -- `CpModel`, `BoolVar`, `Add`, `Minimize` -- pour optimiser les deplacements des équipes.
+3. **Reproduire l'optimum verifie** du twin Python (1232 km en moyenne par équipe, ecart-type 473 km -- cf. correction G.1 section 4 : l'output commite d'App-15 affichait 1233/534, valeur sous-optimale) sur la **même matrice de distances**, et comprendre pourquoi les deux twins s'accordent au km pres.
+4. **Etendre** le modèle : contraintes d'equilibre domicile/exterieur, attractivite TV, derbys, round-robin double.
 
 ### Pourquoi ce twin ?
 
 | Twin | Outil | Valeur |
 |------|-------|--------|
 | Python | **OR-Tools CP-SAT** + numpy + matplotlib | solveur industriel, matrices numpy, heatmaps matplotlib |
-| **Ce twin (.NET)** | **Google.OrTools natif .NET** + ScottPlot | **meme solveur CP-SAT** via une autre liaison de langage ; met en evidence les ecarts d'API (G.1) |
+| **Ce twin (.NET)** | **Google.OrTools natif .NET** + ScottPlot | **même solveur CP-SAT** via une autre liaison de langage ; met en evidence les ecarts d'API (G.1) |
 
-Les deux twins invoquent le **meme moteur CP-SAT** (la bibliotheque C++ sous-jacente). L'interet pedagogique est la **parite cross-langage** : meme modele, meme optimum, eventuellement un calendrier optimal different (plusieurs optima de meme cout).
+Les deux twins invoquent le **même moteur CP-SAT** (la bibliotheque C++ sous-jacente). L'intérêt pedagogique est la **parite cross-langage** : même modèle, même optimum, eventuellement un calendrier optimal différent (plusieurs optima de même cout).
 
 ### Prerequis
 
@@ -3874,7 +3874,7 @@ Les deux twins invoquent le **meme moteur CP-SAT** (la bibliotheque C++ sous-jac
 - Lecture du [twin Python App-15](App-15-SportsScheduling.ipynb)
 - Bases de CSP (variables, domaines, contraintes)
 
-**Duree estimee : ~55 min.**",,,,,,,,db0cada0e099a1ba,,,,,,,
+**Duree estimee : ~55 min.**",,,,,,,,3212fb18fedd0724,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,3657cb45de58,markdown,fr,efa300686980411b,"## 0. Configuration du kernel et imports
 
 On charge le **vrai** solveur `Google.OrTools` (NuGet) et `ScottPlot` pour les visualisations. Aucune reimplementation jouet : CP-SAT est l'outil industriel SOTA (cf. EPIC #3801, Prong A -- SOTA-OK).",,,,,,,,efa300686980411b,,,,,,,
@@ -3889,20 +3889,20 @@ using System.Globalization;
 using System.Linq;
 
 Console.WriteLine(""OR-Tools CP-SAT (Google.OrTools natif .NET) + ScottPlot charges -- marathon #4956"");",,,,,,,,b57774ae3d9ac7cf,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,da4a9ce8c1e6,markdown,fr,a8780a4a40f9253b,"## 1. Modelisation du Probleme
+MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,da4a9ce8c1e6,markdown,fr,c9235c23aa2f078a,"## 1. Modelisation du Problème
 
 ### Definition du CSP
 
-| Element | Description |
+| Élément | Description |
 |---------|-------------|
-| **Variables** | `match[i,j,r]` = 1 si l'equipe `i` recoit l'equipe `j` a la ronde `r` |
+| **Variables** | `match[i,j,r]` = 1 si l'équipe `i` recoit l'équipe `j` a la ronde `r` |
 | **Domaines** | {0, 1} (binaire) |
-| **Contraintes Hard** | round-robin simple (chaque paire joue une fois), une equipe par match et par ronde |
+| **Contraintes Hard** | round-robin simple (chaque paire joue une fois), une équipe par match et par ronde |
 | **Contraintes Soft** | equilibre D/E, minimisation des deplacements, attractivite TV, derbys |
 
-### Donnees : la ligue
+### Données : la ligue
 
-On reproduit **exactement** l'echantillon du twin Python : 6 equipes francaises (Paris, Marseille, Lyon, Lille, Bordeaux, Nantes) avec leurs coordonnees GPS. Les distances sont calculees par la **formule de Haversine** (grand cercle sur la sphere), tronquees en entiers (comme le fait `int(distances[i,j])` cote Python) pour fonder l'objectif CP-SAT.",,,,,,,,a8780a4a40f9253b,,,,,,,
+On reproduit **exactement** l'echantillon du twin Python : 6 équipes francaises (Paris, Marseille, Lyon, Lille, Bordeaux, Nantes) avec leurs coordonnees GPS. Les distances sont calculees par la **formule de Haversine** (grand cercle sur la sphere), tronquees en entiers (comme le fait `int(distances[i,j])` cote Python) pour fonder l'objectif CP-SAT.",,,,,,,,c9235c23aa2f078a,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,0567cfe6042e,code,fr,1c68615dcfb72318,"// Team : record immutable. SportsLeague : conteneur + formule de Haversine.
 public record Team(int Id, string Name, string City, double Latitude, double Longitude, int StadiumCapacity, double TvAttractiveness);
 
@@ -4029,7 +4029,7 @@ plt.YLabel(""Distance (km)"");
 plt.XLabel(""Paire de villes (index)"");
 display(HTML(plt.GetPngHtml(700, 360)));
 Console.WriteLine(""Barres : distance Haversine pour chaque paire de villes (cf. matrice ci-dessus)."");",,,,,,,,f98a71a168a3e21c,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,d09bdcf0a1de,markdown,fr,34ae85922b8174a2,"### Interpretation : Matrice des Distances
+MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,d09bdcf0a1de,markdown,fr,56fc70f889739d4c,"### Interpretation : Matrice des Distances
 
 **Sortie obtenue** : tableau des distances inter-villes (Haversine) et barres ScottPlot.
 
@@ -4041,21 +4041,21 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,
 
 **Points cles** :
 1. **Haversine** : distance du grand cercle sur la sphere, plus precise que l'euclidienne pour des villes.
-2. **Troncature entiere** : comme le twin Python (`int(distances[i,j])`), l'objectif CP-SAT utilise des coefficients entiers -- condition necessaire pour retrouver le **meme optimum** (1232 km de moyenne, somme 7390 km).
+2. **Troncature entiere** : comme le twin Python (`int(distances[i,j])`), l'objectif CP-SAT utilise des coefficients entiers -- condition necessaire pour retrouver le **même optimum** (1232 km de moyenne, somme 7390 km).
 3. **Derbys** : les paires a moins de 300 km (Paris-Lille, Lyon-Marseille, Bordeaux-Nantes) seront identifiees en section 6.
 
-> **Note technique** : ces valeurs reproduisent exactement la matrice du twin Python (verifiable dans [App-15-SportsScheduling.ipynb](App-15-SportsScheduling.ipynb)). La parite de la matrice est la **precondition** de la parite de l'optimum.",,,,,,,,34ae85922b8174a2,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,33afaa13dcc5,markdown,fr,5b64393e630801c1,"## 3. Modelisation CP-SAT (SportsScheduler)
+> **Note technique** : ces valeurs reproduisent exactement la matrice du twin Python (verifiable dans [App-15-SportsScheduling.ipynb](App-15-SportsScheduling.ipynb)). La parite de la matrice est la **precondition** de la parite de l'optimum.",,,,,,,,56fc70f889739d4c,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,33afaa13dcc5,markdown,fr,55cf3b864e39d0d8,"## 3. Modelisation CP-SAT (SportsScheduler)
 
-On construit le **meme modele** que le twin Python :
+On construit le **même modèle** que le twin Python :
 
 - **Variables** : `match[i,j,r]` booleennes pour `i != j` et `r` in `0..rounds-1`.
 - **C1** : chaque paire `{i,j}` joue exactement une fois (`sum_r match[i,j,r] + match[j,i,r] == 1`).
-- **C2** : chaque equipe joue exactement un match par ronde.
+- **C2** : chaque équipe joue exactement un match par ronde.
 - **Equilibre** : pas plus de `max_consecutive` (2) matchs domicile **ou** exterieur consecutifs.
-- **Objectif** : minimiser la somme des distances parcourues par les equipes a l'exterieur.
+- **Objectif** : minimiser la somme des distances parcourues par les équipes a l'exterieur.
 
-> **Adaptation G.1 (API C# vs Python)** -- detaillee en section 10 : en C#, les sommes passent par `LinearExpr.Sum(list)` et la moyenne ponderee par `LinearExpr.ScalProd(vars, coeffs)` ; les parametres du solveur via `solver.StringParameters` ; le statut est l'enum `CpSolverStatus.Optimal` (vs `cp_model.OPTIMAL` en Python).",,,,,,,,5b64393e630801c1,,,,,,,
+> **Adaptation G.1 (API C# vs Python)** -- detaillee en section 10 : en C#, les sommes passent par `LinearExpr.Sum(list)` et la moyenne ponderee par `LinearExpr.ScalProd(vars, coeffs)` ; les paramètres du solveur via `solver.StringParameters` ; le statut est l'enum `CpSolverStatus.Optimal` (vs `cp_model.OPTIMAL` en Python).",,,,,,,,55cf3b864e39d0d8,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,5cdec6ef9420,code,fr,82ed783093410591,"public class SportsScheduler
 {
     protected SportsLeague League;
@@ -4181,30 +4181,30 @@ bool solved = scheduler.Solve(10);
 Console.WriteLine(solved
     ? $""Solution trouvee ! (Statut : {scheduler.Status})""
     : ""Pas de solution trouvee."");",,,,,,,,82ed783093410591,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,655d35ee4e4d,markdown,fr,c7bce1ada9dc6f28,"### Interpretation : Resolution du Probleme CSP
+MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,655d35ee4e4d,markdown,fr,93d9440a784082f8,"### Interpretation : Resolution du Problème CSP
 
-**Sortie obtenue** : le solveur CP-SAT retourne un statut **Optimal** (ou Feasible) en une fraction de seconde pour 6 equipes.
+**Sortie obtenue** : le solveur CP-SAT retourne un statut **Optimal** (ou Feasible) en une fraction de seconde pour 6 équipes.
 
 | Aspect | Valeur | Signification |
 |--------|--------|---------------|
-| **Statut** | `CpSolverStatus.Optimal` | L'optimum global est atteint (probleme petit) |
+| **Statut** | `CpSolverStatus.Optimal` | L'optimum global est atteint (problème petit) |
 | **Temps** | < 0.1 s | Performance excellente pour n=6 |
 | **Variables** | `n * (n-1) * rounds` = 6*5*5 = 150 booleennes | Complexite quadratique gérable |
 
-> **Parite cross-langage** : le meme modele, sur la meme matrice de distances, atteint le **meme cout optimal** qu'une re-execution fresh du twin Python (7390 km de somme, detail en section 4). Le calendrier precis peut cependant differer d'une execution a l'autre : CP-SAT admet souvent **plusieurs optima de meme cout**. Ici, C# et Python fresh produisent **identiquement** la meme solution -- preuve forte de la parite.",,,,,,,,c7bce1ada9dc6f28,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,a13cc85466fe,markdown,fr,07a85ee4317ce4b2,"#### Exercice 1 : Limiter les longs deplacements consecutifs
+> **Parite cross-langage** : le même modèle, sur la même matrice de distances, atteint le **même cout optimal** qu'une re-exécution fresh du twin Python (7390 km de somme, detail en section 4). Le calendrier précis peut cependant differer d'une exécution a l'autre : CP-SAT admet souvent **plusieurs optima de même cout**. Ici, C# et Python fresh produisent **identiquement** la même solution -- preuve forte de la parite.",,,,,,,,93d9440a784082f8,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,a13cc85466fe,markdown,fr,a2be93149af8acfa,"#### Exercice 1 : Limiter les longs deplacements consecutifs
 
-Le modele minimise la distance **totale**, mais une equipe pourrait encaisser deux longs trajets d'affilee (ex. Nice -> Lille puis Marseille -> Strasbourg).
+Le modèle minimise la distance **totale**, mais une équipe pourrait encaisser deux longs trajets d'affilee (ex. Nice -> Lille puis Marseille -> Strasbourg).
 
-**Enonce** : ajoutez une contrainte interdisant a une equipe de faire **plus d'un** deplacement exterieur superieur a 500 km lors de **deux rondes consecutives**.
+**Enonce** : ajoutez une contrainte interdisant a une équipe de faire **plus d'un** deplacement exterieur superieur a 500 km lors de **deux rondes consecutives**.
 
 **Consignes** :
-1. Creez un nouveau `SportsScheduler` sur la meme ligue/distances.
-2. Pour chaque equipe `i` et chaque ronde `r`, ajoutez une variable booleenne `longTrip[i,r]` valant 1 si `i` voyage a l'exterieur de plus de 500 km a la ronde `r`.
+1. Créez un nouveau `SportsScheduler` sur la même ligue/distances.
+2. Pour chaque équipe `i` et chaque ronde `r`, ajoutez une variable booleenne `longTrip[i,r]` valant 1 si `i` voyage a l'exterieur de plus de 500 km a la ronde `r`.
 3. Contraignez `longTrip[i,r] + longTrip[i,r+1] <= 1` pour chaque paire de rondes consecutives.
-4. Resolvez et comparez la distance moyenne avec le modele de base.
+4. Resolvez et comparez la distance moyenne avec le modèle de base.
 
-> **Indice** : pour chaque `j` tel que `distances[j,i] > 500`, liez `longTrip[i,r]` aux `match[j,i,r]` avec `Model.Add(longTrip >= match)` et `Model.Add(longTrip <= sum(match))`.",,,,,,,,07a85ee4317ce4b2,,,,,,,
+> **Indice** : pour chaque `j` tel que `distances[j,i] > 500`, liez `longTrip[i,r]` aux `match[j,i,r]` avec `Model.Add(longTrip >= match)` et `Model.Add(longTrip <= sum(match))`.",,,,,,,,a2be93149af8acfa,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,0d3baf58a08f,code,fr,48c6b4da2a1f8799,"// Exercice 1 : limiter les longs deplacements consecutifs
 // TODO etudiant : contrainte anti-long-deplacement-consecutif (> 500 km, 2 rondes max 1)
 // Etape 1 : nouveau SportsScheduler(league, distances)
@@ -4216,9 +4216,9 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,
 // Indice : Model.Add(longTrip >= match) pour chaque long match, puis Model.Add(longTrip <= LinearExpr.Sum(longMatches))
 object result = null; // TODO etudiant : remplacer par votre implementation
 Console.WriteLine(""Exercice a completer : limiter les longs deplacements consecutifs"");",,,,,,,,48c6b4da2a1f8799,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,9b9390e4f607,markdown,fr,5623e65331087fe2,"## 4. Visualisation du Calendrier
+MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,9b9390e4f607,markdown,fr,946aceaf41d34938,"## 4. Visualisation du Calendrier
 
-On affiche le calendrier solution puis on calcule les **statistiques de deplacement** : distance totale moyenne par equipe, ecart-type (population, ddof=0 comme `np.std`), et repartition domicile/exterieur.",,,,,,,,5623e65331087fe2,,,,,,,
+On affiche le calendrier solution puis on calcule les **statistiques de deplacement** : distance totale moyenne par équipe, ecart-type (population, ddof=0 comme `np.std`), et repartition domicile/exterieur.",,,,,,,,946aceaf41d34938,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,5cfc71a6c37d,code,fr,8b9e8fe679f065a7,"static void DisplaySchedule(SportsLeague league, Dictionary<int, List<(int home, int away)>> schedule)
 {
     Console.WriteLine($""\n=== CALENDRIER {league.Name} ===\n"");
@@ -4272,7 +4272,7 @@ else
 {
     Console.WriteLine(""Aucun calendrier a afficher."");
 }",,,,,,,,8b9e8fe679f065a7,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,78dbcaede74b,markdown,fr,9634cc83153ae9b5,"### Interpretation : Statistiques du Calendrier
+MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,78dbcaede74b,markdown,fr,45cee2d417c23fbd,"### Interpretation : Statistiques du Calendrier
 
 **Sortie obtenue** : calendrier complet (5 rondes, 3 matchs par ronde = 15 matchs) + statistiques de deplacement.
 
@@ -4286,15 +4286,15 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,
 | **Ecart-type** | 473 km | 473 km | **identique** |
 
 **Points cles** :
-1. **Parite exacte C# / Python** : une re-execution fresh du twin Python (meme modele, meme matrice Haversine tronquee) retourne **exactement** la meme solution optimale (meme somme 7390 km, memes deplacements par equipe). C'est le resultat le plus fort possible pour un twin cross-langage : le moteur CP-SAT sous-jacent (bibliotheque C++) est identique.
-2. **Correction G.1 -- output commite vs verite** : l'output commite dans [`App-15-SportsScheduling.ipynb`](App-15-SportsScheduling.ipynb) affichait ""moyenne 1233 km, ecart-type 534 km"" (somme 7398 km). Une re-execution fresh avec le meme code retourne **OPTIMAL = 7390 km** (moyenne 1232). L'output commite etait donc une solution **FEASIBLE sous-optimale** capturee lors d'une execution anterieure (le code Python accepte `OPTIMAL or FEASIBLE`). Ce twin C#, en confirmant l'optimum veritable, met en evidence cet ecart : c'est exactement la valeur ajoutee d'un jumeau de verification.
-3. **Repartition D/E** : sans contrainte explicite d'egalite D/E, une equipe peut avoir 1 D/4 E ou 4 D/1 E -- la minimisation globale ne force pas l'equite individuelle.
-4. **Faisabilite** : toutes les contraintes (round-robin, une equipe/match/ronde, equilibre 2 consecutifs) sont satisfaites.
+1. **Parite exacte C# / Python** : une re-exécution fresh du twin Python (même modèle, même matrice Haversine tronquee) retourne **exactement** la même solution optimale (même somme 7390 km, mêmes deplacements par équipe). C'est le résultat le plus fort possible pour un twin cross-langage : le moteur CP-SAT sous-jacent (bibliotheque C++) est identique.
+2. **Correction G.1 -- output commite vs verite** : l'output commite dans [`App-15-SportsScheduling.ipynb`](App-15-SportsScheduling.ipynb) affichait ""moyenne 1233 km, ecart-type 534 km"" (somme 7398 km). Une re-exécution fresh avec le même code retourne **OPTIMAL = 7390 km** (moyenne 1232). L'output commite etait donc une solution **FEASIBLE sous-optimale** capturee lors d'une exécution anterieure (le code Python accepte `OPTIMAL or FEASIBLE`). Ce twin C#, en confirmant l'optimum veritable, met en evidence cet ecart : c'est exactement la valeur ajoutee d'un jumeau de verification.
+3. **Repartition D/E** : sans contrainte explicite d'egalite D/E, une équipe peut avoir 1 D/4 E ou 4 D/1 E -- la minimisation globale ne force pas l'equite individuelle.
+4. **Faisabilite** : toutes les contraintes (round-robin, une équipe/match/ronde, equilibre 2 consecutifs) sont satisfaites.
 
-> **Lecon methodologique (G.1)** : un output commite n'est pas une preuve d'optimalite. Quand le solveur accepte `FEASIBLE`, la valeur commite peut etre sous-optimale. Croiser deux implementations (C# et Python) sur le meme modele est un moyen de **detecter** ces cas : ici les deux s'accordent sur 7390 km, ce qui prouve que c'est le vrai optimum et que l'output commite d'App-15 (7398) etait sous-optimal.",,,,,,,,9634cc83153ae9b5,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,d7c9a7053f3c,markdown,fr,5dfd78408090b32e,"## 5. Contraintes Avancees : attractivite TV
+> **Lecon methodologique (G.1)** : un output commite n'est pas une preuve d'optimalite. Quand le solveur accepte `FEASIBLE`, la valeur commite peut etre sous-optimale. Croiser deux implementations (C# et Python) sur le même modèle est un moyen de **detecter** ces cas : ici les deux s'accordent sur 7390 km, ce qui prouve que c'est le vrai optimum et que l'output commite d'App-15 (7398) etait sous-optimal.",,,,,,,,45cee2d417c23fbd,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,d7c9a7053f3c,markdown,fr,9165c734fe05f290,"## 5. Contraintes Avancees : attractivite TV
 
-Les chaines de television veulent les matchs les plus attractifs dans les creneaux premium (ouverture, cloture). On etend le scheduler en maximisant la somme des scores TV des matchs places en ronde 1 et derniere ronde.",,,,,,,,5dfd78408090b32e,,,,,,,
+Les chaînes de television veulent les matchs les plus attractifs dans les creneaux premium (ouverture, cloture). On etend le scheduler en maximisant la somme des scores TV des matchs places en ronde 1 et dernière ronde.",,,,,,,,9165c734fe05f290,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,ab71cd6b7d93,code,fr,a54eda85cc83e1bb,"public class TVScheduler : SportsScheduler
 {
     public Dictionary<int, (string slot, double importance)> TvSlots = new();
@@ -4339,29 +4339,29 @@ else
 {
     Console.WriteLine(""Pas de solution TV."");
 }",,,,,,,,a54eda85cc83e1bb,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,9b8e1086f967,markdown,fr,c4fb14510ee029d7,"### Interpretation : Optimisation TV
+MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,9b8e1086f967,markdown,fr,43e78960b98293a5,"### Interpretation : Optimisation TV
 
 **Sortie obtenue** : calendrier reoptimise pour placer les matchs les plus attractifs (score TV combine eleve) en ronde d'ouverture et de cloture.
 
 | Aspect | Impact | Signification |
 |--------|--------|---------------|
-| **Creneaux premium** | Ronde 1 et derniere ronde | Poids 2x pour attirer les affiches prestigieuses |
+| **Creneaux premium** | Ronde 1 et dernière ronde | Poids 2x pour attirer les affichés prestigieuses |
 | **Trade-off** | Attractivite vs distance | L'objectif TV peut augmenter le total km (non minimise ici) |
-| **Flexibilite** | Ajout de creneaux arbitraires | Modele extensible (samedi soir, dimanche après-midi) |
+| **Flexibilite** | Ajout de creneaux arbitraires | Modèle extensible (samedi soir, dimanche après-midi) |
 
-> **Note technique** : en CP-SAT on ne maximise directement -- on minimise l'**oppose** (coefficients negatifs dans le `ScalProd`). C'est une adaptation G.1 par rapport a un solver qui exposerait `Maximize`.",,,,,,,,c4fb14510ee029d7,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,914344ec2316,markdown,fr,b58f8ab8322d6180,"#### Exercice 2 : Contrainte de placement des derbys
+> **Note technique** : en CP-SAT on ne maximise directement -- on minimise l'**oppose** (coefficients negatifs dans le `ScalProd`). C'est une adaptation G.1 par rapport a un solver qui exposerait `Maximize`.",,,,,,,,43e78960b98293a5,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,914344ec2316,markdown,fr,1e6f7ca4a0cc6162,"#### Exercice 2 : Contrainte de placement des derbys
 
-Les derbys (equipes geographiquement proches) tendent a tendre l'ordre public. On souhaite qu'**au plus un derby** ait lieu par ronde, pour concentrer les forces de securite.
+Les derbys (équipes geographiquement proches) tendent a tendre l'ordre public. On souhaite qu'**au plus un derby** ait lieu par ronde, pour concentrer les forces de securite.
 
-**Enonce** : ajoutez une contrainte CP-SAT pour que deux derbys ne se jouent pas la meme ronde.
+**Enonce** : ajoutez une contrainte CP-SAT pour que deux derbys ne se jouent pas la même ronde.
 
 **Consignes** :
 1. Identifiez les derbys via `FindDerbies(league, distances, 300)`.
 2. Pour chaque paire de derbys `(a,b)` et `(c,d)`, et chaque ronde `r`, ajoutez : `match[a,b,r] + match[b,a,r] + match[c,d,r] + match[d,c,r] <= 1`.
 3. Resolvez et verifiez que la contrainte est respectee.
 
-> **Indice** : parcourez toutes les paires de derbys avec une double boucle `for` ; la contrainte est locale a chaque ronde.",,,,,,,,b58f8ab8322d6180,,,,,,,
+> **Indice** : parcourez toutes les paires de derbys avec une double boucle `for` ; la contrainte est locale a chaque ronde.",,,,,,,,1e6f7ca4a0cc6162,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,cce90cd7df16,code,fr,374ccb3bcd2a7e32,"// Exercice 2 : pas deux derbys la meme ronde
 // TODO etudiant : contraignez les conflits de derbys
 // Etape 1 : var derbies = FindDerbies(league, distances, 300);
@@ -4372,9 +4372,9 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,
 // Indice : la contrainte se pose pour chaque ronde r independamment.
 object result = null; // TODO etudiant : remplacer par votre implementation
 Console.WriteLine(""Exercice a completer : contrainte de placement des derbys"");",,,,,,,,374ccb3bcd2a7e32,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,f6e1d6bfcd0b,markdown,fr,d612ba6a71304d17,"## 6. Contraintes de Derby
+MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,f6e1d6bfcd0b,markdown,fr,c293bd97af8a7a65,"## 6. Contraintes de Derby
 
-On identifie les derbys (equipes a moins de `threshold` km) et on localise les derbys dans le calendrier de base (section 3).",,,,,,,,d612ba6a71304d17,,,,,,,
+On identifie les derbys (équipes a moins de `threshold` km) et on localise les derbys dans le calendrier de base (section 3).",,,,,,,,c293bd97af8a7a65,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,e77ea4d2cf0d,code,fr,69370bd64f93c035,"// Derbys : paires de villes a moins de threshold km.
 static List<(int a, int b)> FindDerbies(SportsLeague league, long[,] distances, double thresholdKm = 200)
 {
@@ -4407,7 +4407,7 @@ else
 {
     Console.WriteLine(""  (calendrier indisponible)"");
 }",,,,,,,,69370bd64f93c035,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,ae699a6a93fb,markdown,fr,2d2f8783bcf68170,"### Interpretation : Identification des Derbys
+MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,ae699a6a93fb,markdown,fr,0198bdb66254e511,"### Interpretation : Identification des Derbys
 
 **Sortie obtenue** : 3 derbys identifies (Paris-Lille 203 km, Lyon-Marseille 277 km, Bordeaux-Nantes 275 km) et leur rattachement a une ronde du calendrier.
 
@@ -4417,7 +4417,7 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,
 | **Distance de derby** | 203 a 277 km | Deplacement en bus/train raisonnable |
 | **Placement** | Reparti sur les rondes | Le solveur evite naturellement les conflits (cf. Exercice 2 pour le forcer) |
 
-> **Note technique** : dans un championnat reel (Ligue 1), les derbys (PSG-Marseille, Lyon-Saint-Etienne) sont des evenements a haut risque qui demandent une logistique dediee. Le modele CSP peut forcer leur espacement temporel.",,,,,,,,2d2f8783bcf68170,,,,,,,
+> **Note technique** : dans un championnat reel (Ligue 1), les derbys (PSG-Marseille, Lyon-Saint-Etienne) sont des événements a haut risque qui demandent une logistique dediee. Le modèle CSP peut forcer leur espacement temporel.",,,,,,,,0198bdb66254e511,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,9afee32af4d4,markdown,fr,d5cfce6488de11da,"## 7. Extension : Round-Robin Double
 
 Dans un championnat double, chaque paire joue **deux fois** (aller-retour) : une fois `i` recoit `j`, une fois `j` recoit `i`. Le nombre de rondes devient `2*(n-1)`.",,,,,,,,d5cfce6488de11da,,,,,,,
@@ -4467,27 +4467,27 @@ else
 {
     Console.WriteLine(""Pas de solution."");
 }",,,,,,,,deff44d77773b4f9,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,f617bf705e22,markdown,fr,711c1d2f4dc9cd8a,"### Interpretation : Round-Robin Double
+MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,f617bf705e22,markdown,fr,dc97da991b015aa4,"### Interpretation : Round-Robin Double
 
-**Sortie obtenue** : calendrier de 6 rondes pour 4 equipes (2 matchs/ronde = 12 matchs), aller-retour complet.
+**Sortie obtenue** : calendrier de 6 rondes pour 4 équipes (2 matchs/ronde = 12 matchs), aller-retour complet.
 
 | Aspect | Valeur | Signification |
 |--------|--------|---------------|
 | **Rondes** | 6 = 2*(n-1) | Double confrontation |
-| **Matchs / ronde** | 2 = n/2 | Chaque equipe joue 1 match/ronde |
+| **Matchs / ronde** | 2 = n/2 | Chaque équipe joue 1 match/ronde |
 | **Symetrie** | chaque paire : 1 aller + 1 retour | Avantage du terrain compense |
 
-> **Note technique** : le round-robin double est le format standard des championnats europeens (Ligue 1, Premier League, Liga). Le modele CP-SAT s'adapte en scindant C1 en deux contraintes aller/retour.",,,,,,,,711c1d2f4dc9cd8a,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,5688a862a206,markdown,fr,d38d36d67ee9ed86,"#### Exercice 3 : Analyser un calendrier double round-robin
+> **Note technique** : le round-robin double est le format standard des championnats europeens (Ligue 1, Premier League, Liga). Le modèle CP-SAT s'adapte en scindant C1 en deux contraintes aller/retour.",,,,,,,,dc97da991b015aa4,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,5688a862a206,markdown,fr,6e28b457263e3c41,"#### Exercice 3 : Analyser un calendrier double round-robin
 
 Le calendrier double round-robin garantit l'aller-retour, mais est-il equitable en deplacements ?
 
 **Enonce** : appelez `ComputeScheduleStats` sur le calendrier double round-robin et analysez :
-1. L'ecart de distance totale entre l'equipe la plus et la moins voyageuse.
-2. La repartition domicile/exterieur de chaque equipe (equilibree ?).
+1. L'ecart de distance totale entre l'équipe la plus et la moins voyageuse.
+2. La repartition domicile/exterieur de chaque équipe (equilibree ?).
 3. La comparaison de l'ecart-type avec celui du round-robin simple.
 
-> **Indice** : `ComputeScheduleStats(doubleLeague, doubleSchedule, doubleDistances)` retourne `avg`, `std`, `travel`, `home`, `away`.",,,,,,,,d38d36d67ee9ed86,,,,,,,
+> **Indice** : `ComputeScheduleStats(doubleLeague, doubleSchedule, doubleDistances)` retourne `avg`, `std`, `travel`, `home`, `away`.",,,,,,,,6e28b457263e3c41,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,5b9e83387164,code,fr,4137115acb6b449e,"// Exercice 3 : analyse du calendrier double round-robin
 // TODO etudiant : stats et analyse comparative
 // Etape 1 : var doubleSchedule = doubleScheduler.GetSchedule();
@@ -4497,9 +4497,9 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,
 // Indice : doubleLeague.NTeams == 4 -> comparer a la moyenne 1232 km du simple (different : 4 equipes, pas 6).
 object result = null; // TODO etudiant : remplacer par votre analyse
 Console.WriteLine(""Exercice a completer : analyse du calendrier double round-robin"");",,,,,,,,4137115acb6b449e,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,d9c639df44ae,markdown,fr,0dc20388b32cc65c,"## 8. Visualisation Graphique du Calendrier
+MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,d9c639df44ae,markdown,fr,a4607e683a536088,"## 8. Visualisation Graphique du Calendrier
 
-On represente le calendrier comme une matrice **equipes x rondes** ou chaque cellule indique Domicile (D) ou Exterieur (E), puis en barres les deplacements par equipe.",,,,,,,,0dc20388b32cc65c,,,,,,,
+On represente le calendrier comme une matrice **équipes x rondes** ou chaque cellule indique Domicile (D) ou Exterieur (E), puis en barres les deplacements par équipe.",,,,,,,,a4607e683a536088,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,1b0747debeae,code,fr,b6b8a7ab420ae875,"// Matrice D/E : -1 = exterieur, 0 = bye, +1 = domicile (texte ASCII + barres ScottPlot).
 if (schedule.Count > 0)
 {
@@ -4536,20 +4536,20 @@ else
 {
     Console.WriteLine(""Calendrier indisponible pour la visualisation."");
 }",,,,,,,,b6b8a7ab420ae875,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,bf66dcb8d5f6,markdown,fr,c360ce94618a512d,"### Interpretation : Matrice Domicile / Exterieur
+MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,bf66dcb8d5f6,markdown,fr,38001bd2f9bf1788,"### Interpretation : Matrice Domicile / Exterieur
 
-**Sortie obtenue** : matrice ASCII equipes x rondes (D/E) et barres des deplacements par equipe.
+**Sortie obtenue** : matrice ASCII équipes x rondes (D/E) et barres des deplacements par équipe.
 
 | Aspect | Observation | Signification |
 |--------|-------------|---------------|
-| **Couverture** | chaque cellule D ou E | round-robin complet, aucune equipe au repos |
+| **Couverture** | chaque cellule D ou E | round-robin complet, aucune équipe au repos |
 | **Alternance** | pas plus de 2 D ou 2 E consecutifs | contrainte d'equilibre respectee |
-| **Inegalite de charge** | barres de hauteur variable | certaines equipes voyagent beaucoup plus |
+| **Inegalite de charge** | barres de hauteur variable | certaines équipes voyagent beaucoup plus |
 
-> **Note technique** : cette visualisation est l'outil des organisateurs pour verifier l'equite du calendrier. L'Exercice 2 du twin Python (objectif d'equite) montrerait comment reduire l'amplitude des barres.",,,,,,,,c360ce94618a512d,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,6f8a0b29e5dd,markdown,fr,0d390afc19093e95,"## 9. Benchmark : Taille vs Temps de Resolution
+> **Note technique** : cette visualisation est l'outil des organisateurs pour verifier l'equite du calendrier. L'Exercice 2 du twin Python (objectif d'equite) montrerait comment reduire l'amplitude des barres.",,,,,,,,38001bd2f9bf1788,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,6f8a0b29e5dd,markdown,fr,5017a1b6be661872,"## 9. Benchmark : Taille vs Temps de Resolution
 
-On mesure le temps de resolution en fonction du nombre d'equipes. Le nombre de variables croit en `O(n^2 * rounds)`.",,,,,,,,0d390afc19093e95,,,,,,,
+On mesure le temps de resolution en fonction du nombre d'équipes. Le nombre de variables croit en `O(n^2 * rounds)`.",,,,,,,,5017a1b6be661872,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,ccefe14f8a69,code,fr,b07dc13f6e740904,"var benchResults = new List<(int n, int rounds, int vars, bool ok, double sec)>();
 Console.WriteLine($""{""n"",4} {""rondes"",7} {""vars"",6} {""temps(s)"",10} {""statut"",10}"");
 foreach (int nTeams in new[] { 4, 6, 8, 10 })
@@ -4588,20 +4588,20 @@ plt4.XLabel(""Nombre d'equipes"");
 plt4.YLabel(""Variables (n*(n-1)*rounds)"");
 plt4.Axes.SetLimitsY(0, ysV.Max() * 1.15);
 display(HTML(plt4.GetPngHtml(640, 300)));",,,,,,,,b07dc13f6e740904,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,5e477175be31,markdown,fr,d3d13d8398efb288,"### Interpretation : Scalabilite du Solveur CP-SAT
+MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,5e477175be31,markdown,fr,b27df7ffb065981d,"### Interpretation : Scalabilite du Solveur CP-SAT
 
-**Sortie obtenue** : deux courbes -- temps de resolution et nombre de variables -- selon le nombre d'equipes.
+**Sortie obtenue** : deux courbes -- temps de resolution et nombre de variables -- selon le nombre d'équipes.
 
 | Metrique | Observation | Signification |
 |----------|-------------|---------------|
 | **Temps (n=4..10)** | 0.01 a ~0.05 s | Concordance d'ordre de grandeur avec le twin Python |
 | **Variables** | `n*(n-1)*(n-1)` | Croissance quadratique (ex: n=10 -> 810 vars) |
-| **Seuil pratique** | ~20-30 equipes | Au-dela, augmenter le timeout ou accepter du faisable |
+| **Seuil pratique** | ~20-30 équipes | Au-dela, augmenter le timeout ou accepter du faisable |
 
-> **Note technique** : le theoreme dit ce probleme NP-difficile, mais CP-SAT resout instantanement les petites instances grace a la propagation par clauses paresseuses (LCG). Les temps observes (0.01-0.05 s pour n=4..10) reproduisent l'ordre de grandeur du twin Python ; les valeurs exactes varient d'une machine a l'autre.",,,,,,,,d3d13d8398efb288,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,acc86ffb85ef,markdown,fr,2da06bef4467c382,"## 10. Resume et Comparaison des Approches
+> **Note technique** : le theoreme dit ce problème NP-difficile, mais CP-SAT resout instantanement les petites instances grace a la propagation par clauses paresseuses (LCG). Les temps observes (0.01-0.05 s pour n=4..10) reproduisent l'ordre de grandeur du twin Python ; les valeurs exactes varient d'une machine a l'autre.",,,,,,,,b27df7ffb065981d,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,acc86ffb85ef,markdown,fr,5e3b9df6fb20140d,"## 10. Resume et Comparaison des Approches
 
-### Approches CSP vs autres methodes de planification sportive",,,,,,,,2da06bef4467c382,,,,,,,
+### Approches CSP vs autres méthodes de planification sportive",,,,,,,,5e3b9df6fb20140d,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,a2b983f8e8d3,code,fr,f1739b99c0f5234c,"// Tableau comparatif des methodes (meme contenu que le twin Python).
 var comparison = new (string Methode, string Optimalite, string Scalabilite, string Flexibilite, string TempsDev)[]
 {
@@ -4614,9 +4614,9 @@ Console.WriteLine($""{""Methode"",-26} {""Optimalite"",-20} {""Scalabilite"",-26
 Console.WriteLine(new string('-', 96));
 foreach (var r in comparison)
     Console.WriteLine($""{r.Methode,-26} {r.Optimalite,-20} {r.Scalabilite,-26} {r.Flexibilite,-14} {r.TempsDev,-10}"");",,,,,,,,f1739b99c0f5234c,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,850b6000641b,markdown,fr,dba72afc36bb2ac0,"### Interpretation : Comparaison des Approches
+MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,850b6000641b,markdown,fr,bbca1d6ae3c2ea30,"### Interpretation : Comparaison des Approches
 
-| Aspect | CSP (OR-Tools) | PL | Metaheuristiques | Generation manuelle |
+| Aspect | CSP (OR-Tools) | PL | Métaheuristiques | Generation manuelle |
 |--------|----------------|----|------------------|---------------------|
 | **Optimalite** | Oui (si temps) | Oui (PLNE) | Non (approx) | Variable |
 | **Scalabilite** | Moyenne (20-30 eq.) | Bonne | Excellente | Mauvaise |
@@ -4624,41 +4624,41 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,
 | **Temps dev.** | Moyen | Eleve | Moyen | Eleve |
 
 **Points cles** :
-1. **CSP (OR-Tools)** offre le meilleur compromis optimalite / flexibilite / effort pour 20-30 equipes.
+1. **CSP (OR-Tools)** offre le meilleur compromis optimalite / flexibilite / effort pour 20-30 équipes.
 2. **PL** garantie l'optimalite mais est peu flexible pour les contraintes non-lineaires (equilibre D/E, derbys).
-3. **Metaheuristiques** (AG, recuit) scalent au-dela mais sans garantie d'optimalite.
+3. **Métaheuristiques** (AG, recuit) scalent au-dela mais sans garantie d'optimalite.
 4. **Generation manuelle** est flexible mais non reproductible et chronophage.
 
 ### Adaptations G.1 (API C# vs Python OR-Tools)
 
-Ce twin invoque le **meme moteur CP-SAT** que le twin Python, via la liaison .NET. Les ecarts d'API documentes (auto-correction G.1) :
+Ce twin invoque le **même moteur CP-SAT** que le twin Python, via la liaison .NET. Les ecarts d'API documentes (auto-correction G.1) :
 
 | Concept | Python (`ortools.sat.python.cp_model`) | C# (`Google.OrTools.Sat`) |
 |---------|----------------------------------------|---------------------------|
 | **Variable booleenne** | `model.NewBoolVar('x')` | `model.NewBoolVar(""x"")` (identique) |
 | **Somme de vars** | `sum([...])` ou `model.Sum([...])` | `LinearExpr.Sum(list)` (typage explicite) |
 | **Somme ponderee** | `sum(c * v for ...)` | `LinearExpr.Sum(terms)` avec `terms.Add(c * var)` -- `ScalProd` **n'existe pas** en C# OR-Tools 9.x (correction G.1 probe) |
-| **Contrainte** | `model.Add(expr == 1)` | `model.Add(LinearExpr.Sum(t) == 1)` (operateur == surcharge) |
+| **Contrainte** | `model.Add(expr == 1)` | `model.Add(LinearExpr.Sum(t) == 1)` (opérateur == surcharge) |
 | **Minimisation** | `model.Minimize(expr)` | `model.Minimize(expr)` (identique) |
-| **Parametres solveur** | `solver.parameters.max_time_in_seconds = 10` | `solver.StringParameters = ""max_time_in_seconds:10 ...""` |
+| **Paramètres solveur** | `solver.parameters.max_time_in_seconds = 10` | `solver.StringParameters = ""max_time_in_seconds:10 ...""` |
 | **Statut** | `cp_model.OPTIMAL` (constante entiere) | `CpSolverStatus.Optimal` (enum type-safe) |
 | **Valeur d'une var** | `solver.Value(v)` -> `int` | `solver.Value(v)` -> `long` |
 | **Maximisation** | `model.Maximize(expr)` existe | pas de `Maximize` direct -> `Minimize(-expr)` |
 
-Aucune de ces differences ne change le **resultat** : le moteur CP-SAT sous-jacent (bibliotheque C++) est identique, donc l'optimum trouve est le meme.",,,,,,,,dba72afc36bb2ac0,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,e2d85124d667,markdown,fr,bf5b73ec0c2c6c7d,"## Conclusion
+Aucune de ces différences ne change le **résultat** : le moteur CP-SAT sous-jacent (bibliotheque C++) est identique, donc l'optimum trouve est le même.",,,,,,,,bbca1d6ae3c2ea30,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,e2d85124d667,markdown,fr,f217e0bc93d5e98d,"## Conclusion
 
 ### Ce que nous avons appris
 
 1. **Modelisation CSP** : un calendrier sportif se modelise par des variables binaires `match[i,j,r]` (i recoit j a la ronde r), des contraintes de round-robin et d'equilibre D/E.
-2. **Vrai solveur industriel** : `Google.OrTools` (CP-SAT natif .NET) resout le probleme en une fraction de seconde pour 6 equipes -- pas de reimplementation jouet (EPIC #3801, Prong A SOTA-OK).
-3. **Parite cross-langage verifiee** : le meme modele, sur la meme matrice de distances Haversine, atteint le **meme optimum** (7390 km de somme, 1232 km de moyenne par equipe) en C# et lors d'une re-execution fresh du twin Python -- les deux s'accordent au km pres. Bonus (G.1) : ce croisement a revele que l'output commite d'App-15 (1233/534) etait une solution FEASIBLE sous-optimale, desormais corrigee conceptuellement.
-4. **Extensibilite** : contraintes TV, derbys, round-robin double s'ajoutent au meme squelette CSP.
+2. **Vrai solveur industriel** : `Google.OrTools` (CP-SAT natif .NET) resout le problème en une fraction de seconde pour 6 équipes -- pas de reimplementation jouet (EPIC #3801, Prong A SOTA-OK).
+3. **Parite cross-langage verifiee** : le même modèle, sur la même matrice de distances Haversine, atteint le **même optimum** (7390 km de somme, 1232 km de moyenne par équipe) en C# et lors d'une re-exécution fresh du twin Python -- les deux s'accordent au km pres. Bonus (G.1) : ce croisement a revele que l'output commite d'App-15 (1233/534) etait une solution FEASIBLE sous-optimale, desormais corrigee conceptuellement.
+4. **Extensibilite** : contraintes TV, derbys, round-robin double s'ajoutent au même squelette CSP.
 
 ### Extensions possibles
 
 - **Arbitres** : assignation d'arbitres avec contraintes de disponibilite (cf. Exercices Python).
-- **Stades partagés** : AC Milan / Inter, Bayern / 1860 (pas deux matchs au meme stade meme journee).
+- **Stades partagés** : AC Milan / Inter, Bayern / 1860 (pas deux matchs au même stade même journee).
 - **Coupes europeennes** : eviter les conflits de calendrier inter-competitions.
 - **Equite des deplacements** : minimiser l'amplitude `max_travel - min_travel` plutot que la somme.
 
@@ -4671,14 +4671,14 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb,
 
 ---
 
-*Marathon .NET / Python #4956 -- Search/Applications/CSP, tranche planification sportive. See #4956, #3801.*",,,,,,,,bf5b73ec0c2c6c7d,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP-Csharp.ipynb,3da136da-a583-444f-8cd6-8fbfb8f817d0,markdown,fr,c34d280b4dd2299f,"# App-16-Crossword-CSP (C#)
+*Marathon .NET / Python #4956 -- Search/Applications/CSP, tranche planification sportive. See #4956, #3801.*",,,,,,,,f217e0bc93d5e98d,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP-Csharp.ipynb,3da136da-a583-444f-8cd6-8fbfb8f817d0,markdown,fr,e36adb44f169cfc0,"# App-16-Crossword-CSP (C#)
 
 **Navigation** : [<< App-15-SportsScheduling](App-15b-SportsScheduling-CSharp.ipynb) | [Index](../README.md) | [App-17-VRP >>](../Hybrid/App-17-VRP-Logistics.ipynb)
 
 **Twin C# (.NET Interactive)** de [App-16-Crossword-CSP.ipynb](App-16-Crossword-CSP.ipynb) — marathon **#4956** (parite .NET <-> Python).
 
-La generation de mots croises est un **CSP** (Constraint Satisfaction Problem) classique : on dispose d'une grille (cases blanches/noires), d'un dictionnaire de mots indexes par longueur, et on doit placer un mot dans chaque *slot* (suite maximale de cases blanches consecutives) de sorte que les **intersections** entre slots horizontaux et verticaux soient compatibles (meme lettre a la case de croisement).
+La generation de mots croises est un **CSP** (Constraint Satisfaction Problem) classique : on dispose d'une grille (cases blanches/noires), d'un dictionnaire de mots indexes par longueur, et on doit placer un mot dans chaque *slot* (suite maximale de cases blanches consecutives) de sorte que les **intersections** entre slots horizontaux et verticaux soient compatibles (même lettre a la case de croisement).
 
 ## Plan pedagogique
 
@@ -4689,10 +4689,10 @@ La generation de mots croises est un **CSP** (Constraint Satisfaction Problem) c
 5. **Exercices**
 
 > **Parite #4956** : la version Python s'appuie sur OR-Tools CP-SAT (solveur boite noire) et implemente aussi backtracking + propagation from-scratch. Ce twin C# (BCL .NET 9, **0 NuGet**) deroule le backtracking + forward-checking from-scratch (les internes pedagogiques que masque OR-Tools). La viz matplotlib devient un rendu ASCII de la grille (convention GT-4c).
-",,,,,,,,c34d280b4dd2299f,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP-Csharp.ipynb,36a0f74a-d4e5-4180-a2ef-ff83557b6d84,markdown,fr,a4d71e1104a3c251,"## 1. Modelisation du probleme
+",,,,,,,,e36adb44f169cfc0,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP-Csharp.ipynb,36a0f74a-d4e5-4180-a2ef-ff83557b6d84,markdown,fr,1e6a1a7cf126f1bb,"## 1. Modelisation du problème
 
-Une **grille** de mots croises est une matrice de cases, chacune **blanche** (lettre a placer) ou **noire** (bloque). Un **slot** est une suite maximale de cases blanches consecutives (longueur >= 2), horizontalement ou verticalement. Chaque slot recoit un mot du dictionnaire de la bonne longueur. Deux slots qui se croisent a une case partagent une lettre : la position de cette lettre dans le mot horizontal doit egaler celle dans le mot vertical.",,,,,,,,a4d71e1104a3c251,,,,,,,
+Une **grille** de mots croises est une matrice de cases, chacune **blanche** (lettre a placer) ou **noire** (bloque). Un **slot** est une suite maximale de cases blanches consecutives (longueur >= 2), horizontalement ou verticalement. Chaque slot recoit un mot du dictionnaire de la bonne longueur. Deux slots qui se croisent a une case partagent une lettre : la position de cette lettre dans le mot horizontal doit egaler celle dans le mot vertical.",,,,,,,,1e6a1a7cf126f1bb,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP-Csharp.ipynb,fdfe3cb3-d35c-4361-a3f3-839403af0db1,code,fr,a4b39eec2be1d4d8,"using System.Linq;
 using System.Text;
 using System.Collections.Generic;
@@ -4813,11 +4813,11 @@ $""Intersections detectees : {inter.Count} (paires de slots se croisant)"".Displ
 foreach (var kv in inter.Take(5))
     $""  slots[{kv.Key.Item1}] x slots[{kv.Key.Item2}] : pos {kv.Value.Item1} = pos {kv.Value.Item2}"".Display();
 ",,,,,,,,8d29df16b769dbaf,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP-Csharp.ipynb,9d612d59-fcfc-4a3a-ae87-874f27e9aada,markdown,fr,2f67f0e60d9646c3,"## 2. Solveur Backtracking (from-scratch)
+MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP-Csharp.ipynb,9d612d59-fcfc-4a3a-ae87-874f27e9aada,markdown,fr,02ec1d056cac077d,"## 2. Solveur Backtracking (from-scratch)
 
-On assigne les slots un par un. Pour chaque slot, on essaie chaque mot du dictionnaire de la bonne longueur ; on accepte le mot s'il est **compatible** avec les slots deja assignes qui le croisent (meme lettre a l'intersection). On recurse jusqu'a ce que tous les slots soient assignes (succes) ou qu'aucun mot ne convienne (echec -> retour arriere).
+On assigne les slots un par un. Pour chaque slot, on essaie chaque mot du dictionnaire de la bonne longueur ; on accepte le mot s'il est **compatible** avec les slots déjà assignes qui le croisent (même lettre a l'intersection). On recurse jusqu'a ce que tous les slots soient assignes (succes) ou qu'aucun mot ne convienne (echec -> retour arriere).
 
-**Heuristique MRV (Minimum Remaining Values)** : on choisit a chaque etape le slot non-assigne avec le **moins** de candidats restants, ce qui reduit drastiquement la taille de l'arbre de recherche.",,,,,,,,2f67f0e60d9646c3,,,,,,,
+**Heuristique MRV (Minimum Remaining Values)** : on choisit a chaque étape le slot non-assigne avec le **moins** de candidats restants, ce qui reduit drastiquement la taille de l'arbre de recherche.",,,,,,,,02ec1d056cac077d,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP-Csharp.ipynb,0ecfbc07-3964-4050-bdd2-a21fad23254d,code,fr,5622d37231b8fe39,"#nullable enable
 // Compatible : un mot candidat pour slot 'i' respecte-t-il les intersections avec les slots deja assignes ?
 static bool Compatible(int i, string word, List<Slot> slots, Dictionary<(int,int),(int,int)> inter, Dictionary<int,string> assignment)
@@ -4923,11 +4923,11 @@ static string RenderFilled(CrosswordGrid g, List<Slot> slots, Dictionary<int,str
 Show(""Grille remplie :"");
 Show(RenderFilled(grid, slots, solution));
 ",,,,,,,,f45cb3ede441a6c9,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP-Csharp.ipynb,6f55eef4-e0c6-4aa3-ab67-91e898850730,markdown,fr,d88273230127b3ac,"## 3. Propagation de contraintes (forward-checking)
+MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP-Csharp.ipynb,6f55eef4-e0c6-4aa3-ab67-91e898850730,markdown,fr,c4642b42887e95d6,"## 3. Propagation de contraintes (forward-checking)
 
-Le backtracking pur verifie la compatibilite seulement avec les slots **deja assignes**. Le **forward-checking** va plus loin : apres chaque assignation, on filtre les candidats des slots **non encore assignes** qui croisent le slot courant, et on detecte les **domaines vides** (un slot sans candidat restant) pour couper la recherche plus tot.
+Le backtracking pur verifie la compatibilite seulement avec les slots **déjà assignes**. Le **forward-checking** va plus loin : après chaque assignation, on filtre les candidats des slots **non encore assignes** qui croisent le slot courant, et on detecte les **domaines vides** (un slot sans candidat restant) pour couper la recherche plus tot.
 
-On instrumente le solveur pour compter les **noeuds explores** et comparer les deux strategies.",,,,,,,,d88273230127b3ac,,,,,,,
+On instrumente le solveur pour compter les **noeuds explores** et comparer les deux stratégies.",,,,,,,,c4642b42887e95d6,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP-Csharp.ipynb,f59d02b3-431b-4f8e-b4cb-c19b4b34c66e,code,fr,5d1a74bbd1118aa2,"#nullable enable
 // Backtracking + forward-checking : apres chaque assignation, on elimine des candidats
 // des slots non-assignes croisant le slot courant. Coupe si un domaine devient vide.
@@ -5019,9 +5019,9 @@ sb2.AppendLine($"" Forward-checking   | {nodesFC,15} | {(solFC != null ? ""oui""
 Show(sb2.ToString());
 $""Verdict : forward-checking explore {nodesFC} noeuds vs {nodesBT2} pour le backtracking simple (MRV deja actif dans les deux)."".Display();
 ",,,,,,,,d5a02fd672125ef8,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP-Csharp.ipynb,f90f0adc-7028-4879-8879-c782f9c2e323,markdown,fr,6c263ea188e16865,"## 4. Generation de grille aleatoire
+MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP-Csharp.ipynb,f90f0adc-7028-4879-8879-c782f9c2e323,markdown,fr,97b0e061a465ace8,"## 4. Generation de grille aleatoire
 
-On genere une grille en placant des cases noires avec une probabilite donnee, puis on verifie qu'elle admet des slots (sinon on regenere). La **densite** de cases noires controle la difficulte.",,,,,,,,6c263ea188e16865,,,,,,,
+On genere une grille en placant des cases noires avec une probabilite donnee, puis on verifie qu'elle admet des slots (sinon on regenere). La **densite** de cases noires contrôle la difficulte.",,,,,,,,97b0e061a465ace8,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP-Csharp.ipynb,8d8f1773-aef4-42a1-8ad6-1b19894587bf,code,fr,c690ddc3c213ad7a,"// Generation aleatoire d'une grille avec densite de cases noires.
 static CrosswordGrid GenerateRandomGrid(int rows, int cols, double blackDensity)
 {
@@ -5043,15 +5043,15 @@ $""Grille aleatoire 6x6 (densite noire ~0.20) : {slots2.Count} slots"".Display()
 Show(""Grille vide (# = noire, . = blanche) :"");
 Show(RenderFilled(g2, slots2, null));
 ",,,,,,,,c690ddc3c213ad7a,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP-Csharp.ipynb,2de7a56f-d85a-4a3f-8ca7-a25b31157b03,markdown,fr,d209f777082bebae,"## 5. Exercices
+MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP-Csharp.ipynb,2de7a56f-d85a-4a3f-8ca7-a25b31157b03,markdown,fr,7eb6177d3823c6fd,"## 5. Exercices
 
 > **Convention C.1** : les stubs s'executent sans erreur (jamais `throw`). Remplir le corps, re-executer, verifier.
 
 ### Exercice 1 — Compter les mots elimines par propagation
 
-Etant donne une grille et un dictionnaire, pour chaque slot, compter combien de mots du dictionnaire (de la bonne longueur) sont **elimines** par les intersections avec les slots deja assignes.
+Etant donne une grille et un dictionnaire, pour chaque slot, compter combien de mots du dictionnaire (de la bonne longueur) sont **elimines** par les intersections avec les slots déjà assignes.
 
-**Indice** : pour chaque slot non-assigne, filtrer les mots compatibles avec l'assignation courante et soustraire du total.",,,,,,,,d209f777082bebae,,,,,,,
+**Indice** : pour chaque slot non-assigne, filtrer les mots compatibles avec l'assignation courante et soustraire du total.",,,,,,,,7eb6177d3823c6fd,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP-Csharp.ipynb,9cd6b723-875d-4c31-9d4f-d0ed5d948ebd,code,fr,0bac73a0aae43ea4,"// Exercice 1 : nombre total de mots elimines par propagation apres une assignation partielle.
 // TODO etudiant : retourner le compte total sur tous les slots non-assignes.
 static int CountEliminatedWords(CrosswordGrid g, Dictionary<int,List<string>> dictByLen, List<Slot> slots, Dictionary<(int,int),(int,int)> inter, Dictionary<int,string> assignment)
@@ -5078,11 +5078,11 @@ static (CrosswordGrid best, int interCount) GenerateOptimizedGrid(int rows, int 
 
 ""Exercice a completer"".Display();
 ",,,,,,,,79fe45f191771c25,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP-Csharp.ipynb,990976dc-afa9-4ba9-8f23-0f1119a7d11d,markdown,fr,1a614c60bc05d51f,"### Exercice 3 — Contraintes de theme (reflexion)
+MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP-Csharp.ipynb,990976dc-afa9-4ba9-8f23-0f1119a7d11d,markdown,fr,094fbb6dda7fb4df,"### Exercice 3 — Contraintes de thème (reflexion)
 
-Etendre le solveur pour n'utiliser que des mots d'un **theme** donne (ex : informatique). Quelle structure de dictionnaire permet de filtrer efficacement par theme sans parcourir toute la liste ?
+Etendre le solveur pour n'utiliser que des mots d'un **thème** donne (ex : informatique). Quelle structure de dictionnaire permet de filtrer efficacement par thème sans parcourir toute la liste ?
 
-**Indice** : indexer le dictionnaire par `(theme, longueur)` plutot que par `longueur` seule.",,,,,,,,1a614c60bc05d51f,,,,,,,
+**Indice** : indexer le dictionnaire par `(thème, longueur)` plutot que par `longueur` seule.",,,,,,,,094fbb6dda7fb4df,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP-Csharp.ipynb,feed2ae5-54b8-442b-b7e3-73b7c8afe25a,code,fr,cea32759b0d1cf58,"// Exercice 3 (reflexion) : structure de dictionnaire par theme.
 // TODO etudiant : proposer une signature et un stub de filtrage par theme.
 // Indice : Dictionary<(string theme, int length), List<string>>
@@ -5094,15 +5094,15 @@ static List<string> WordsByTheme(Dictionary<(string,int),List<string>> themedDic
 
 ""Exercice a completer"".Display();
 ",,,,,,,,cea32759b0d1cf58,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP-Csharp.ipynb,b628e519-a080-4b6b-b003-694f41c1f3ea,markdown,fr,26d3067938a37cad,"## Conclusion
+MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP-Csharp.ipynb,b628e519-a080-4b6b-b003-694f41c1f3ea,markdown,fr,b70fa70e8abe11ce,"## Conclusion
 
 ### Ce que vous avez appris
 
 - **Modelisation CSP** — grille, slots (runs maximaux de cases blanches), intersections (cases de croisement partageant une lettre).
 - **Extraction des slots** — scan horizontal/vertical, runs de longueur >= 2.
 - **Backtracking** — assignation slot par slot, verification de compatibilite aux intersections, heuristique **MRV** (slot le plus contraint d'abord).
-- **Forward-checking** — apres chaque assignation, filtrage des domaines des slots croisant le courant ; coupe des culs-de-sac (domaine vide) plus tot que le backtracking pur.
-- **Generation aleatoire** — densite de cases noires controle la difficulte.
+- **Forward-checking** — après chaque assignation, filtrage des domaines des slots croisant le courant ; coupe des culs-de-sac (domaine vide) plus tot que le backtracking pur.
+- **Generation aleatoire** — densite de cases noires contrôle la difficulte.
 
 ### Pont avec la version Python
 
@@ -5110,18 +5110,18 @@ La version Python ([App-16-Crossword-CSP.ipynb](App-16-Crossword-CSP.ipynb)) com
 
 ### Parite #4956
 
-Twin de parite legitime (Prong B) : OR-Tools CP-SAT cote Python vs backtracking + forward-checking from-scratch cote C#. L'interet est la visibilite des internes (extraction de slots, MRV, forward-checking) et la confirmation que les deux approches convergent vers la meme solution sur la grille exemple.
+Twin de parite legitime (Prong B) : OR-Tools CP-SAT cote Python vs backtracking + forward-checking from-scratch cote C#. L'intérêt est la visibilite des internes (extraction de slots, MRV, forward-checking) et la confirmation que les deux approches convergent vers la même solution sur la grille exemple.
 
 ---
 *Marathon #4956 (parite .NET <-> Python).*
-",,,,,,,,26d3067938a37cad,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP.ipynb,25b78f20,markdown,fr,7f2b9117fec11a0f,"# App-16 : Generateur de Mots Croises (CSP)
+",,,,,,,,b70fa70e8abe11ce,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP.ipynb,25b78f20,markdown,fr,51f7c17b1f46c6cb,"# App-16 : Générateur de Mots Croises (CSP)
 
 **Navigation** : [<< App-15 SportsScheduling](App-15-SportsScheduling.ipynb) | [Index](../../README.md) | [App-17 VRP >>](../Hybrid/App-17-VRP-Logistics.ipynb)
 
 ## Objectifs d'apprentissage
 
-Ce notebook explore la generation de grilles de mots croises comme un **Probleme de Satisfaction de Contraintes (CSP)**. A la fin de ce notebook, vous saurez :",,,,,,,,7f2b9117fec11a0f,,,,,,,
+Ce notebook explore la generation de grilles de mots croises comme un **Problème de Satisfaction de Contraintes (CSP)**. A la fin de ce notebook, vous saurez :",,,,,,,,51f7c17b1f46c6cb,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP.ipynb,a358f415,code,fr,4e046e4eda766d21,"# Imports
 from ortools.sat.python import cp_model
 from dataclasses import dataclass
@@ -5132,15 +5132,15 @@ import matplotlib.pyplot as plt
 from collections import defaultdict
 
 print(""Imports OK"")",,,,,,,,4e046e4eda766d21,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP.ipynb,e90bcd88,markdown,fr,fa589efa3db1d153,"## 1. Modelisation du Probleme
+MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP.ipynb,e90bcd88,markdown,fr,79c3b7d55261bac8,"## 1. Modelisation du Problème
 
 ### Structure d'une grille
 
-| Element | Description |
+| Élément | Description |
 |---------|-------------|
 | **Cases** | Blanches (lettres) ou noires (blocantes) |
 | **Slots** | Sequences de cases blanches consecutives |
-| **Contraintes** | Intersections des slots horizontaux/verticaux |",,,,,,,,fa589efa3db1d153,,,,,,,
+| **Contraintes** | Intersections des slots horizontaux/verticaux |",,,,,,,,79c3b7d55261bac8,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP.ipynb,b89c813f,code,fr,d4e27a1f36e018f7,"# Dictionnaire francais simplifie (mots de 2 a 10 lettres)
 # Chaque cle = longueur du mot. Tous les mots sont verifies.
 DICTIONARY = {
@@ -5414,18 +5414,18 @@ if csp.solve(time_limit=10):
 else:
     print(""Pas de solution trouvee"")
 ",,,,,,,,5a38d5a40bd0324b,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP.ipynb,aef94180,markdown,fr,b120b684a8730ef3,"### Exercice : Validation d'une solution de mots croises
+MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP.ipynb,aef94180,markdown,fr,608b33374c13b295,"### Exercice : Validation d'une solution de mots croises
 
-Apres avoir resolu la grille avec le solveur CSP, il est important de pouvoir **verifier** qu'une solution est correcte. Implementez une fonction `validate_solution` qui verifie que :
+Après avoir resolu la grille avec le solveur CSP, il est important de pouvoir **verifier** qu'une solution est correcte. Implementez une fonction `validate_solution` qui verifie que :
 
 1. Chaque slot contient un mot valide du dictionnaire
-2. Les lettres aux intersections sont coherentes (meme lettre pour le slot horizontal et vertical)
+2. Les lettres aux intersections sont coherentes (même lettre pour le slot horizontal et vertical)
 3. Aucun mot n'est utilise plus d'une fois
 
 **Indices** :
 - Utilisez `csp.get_words()` pour obtenir les mots choisis par le solveur
 - Pour chaque intersection `(slot_h_id, slot_v_id, (pos_h, pos_v))`, verifiez que la lettre a la position `pos_h` du mot horizontal correspond a la lettre a la position `pos_v` du mot vertical
-- Utilisez un `Counter` ou un `set` pour detecter les doublons",,,,,,,,b120b684a8730ef3,,,,,,,
+- Utilisez un `Counter` ou un `set` pour detecter les doublons",,,,,,,,608b33374c13b295,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP.ipynb,825a22f1,code,fr,1c2d5377b6b55f4b,"def validate_solution(grid: CrosswordGrid, dictionary: Dict[int, List[str]],
                       words: Dict[int, str]) -> Tuple[bool, List[str]]:
     """"""
@@ -5637,9 +5637,9 @@ def compare_solvers(grid, dictionary, n_trials=3):
 
 print(""Comparaison des solveurs..."")
 results = compare_solvers(grid, DICTIONARY, n_trials=3)",,,,,,,,d8b1181d4dfb8753,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP.ipynb,cbe03f21,markdown,fr,69e49deaeac77874,"## 6. Generation de Grille Aleatoire
+MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP.ipynb,cbe03f21,markdown,fr,e52cfdc4c7eecb40,"## 6. Generation de Grille Aleatoire
 
-Creer une grille de mots croises a partir de rien.",,,,,,,,69e49deaeac77874,,,,,,,
+Créer une grille de mots croises a partir de rien.",,,,,,,,e52cfdc4c7eecb40,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP.ipynb,c598696d,code,fr,5540aa0b7af0a19f,"def generate_random_grid(rows: int, cols: int, density: float = 0.2) -> CrosswordGrid:
     """"""
     Genere une grille aleatoire avec des cases noires.
@@ -5783,14 +5783,14 @@ def solve_with_lcv(grid: CrosswordGrid, dictionary: Dict[int, List[str]]) -> Tup
 
 
 print(""Exercice a completer : heuristique LCV pour mots croises"")",,,,,,,,13c1bad3c509ebfd,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP.ipynb,nr8ryqhs6o,markdown,fr,a50c8e7b406a69ce,"### Exercice 2 : Generation de Grille Optimisee
+MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP.ipynb,nr8ryqhs6o,markdown,fr,5b3937bae1222168,"### Exercice 2 : Generation de Grille Optimisee
 
-La fonction `generate_random_grid` cree des grilles aleatoires qui peuvent etre trop simples ou trop difficiles. Implementez une generation qui maximise le nombre d'intersections.
+La fonction `generate_random_grid` créé des grilles aleatoires qui peuvent etre trop simples ou trop difficiles. Implementez une generation qui maximise le nombre d'intersections.
 
 **Indices** :
 - Une bonne grille de mots croises a beaucoup d'intersections
 - Evitez les slots isoles (sans intersection)
-- Une densite de cases noires entre 15% et 25% est optimale",,,,,,,,a50c8e7b406a69ce,,,,,,,
+- Une densite de cases noires entre 15% et 25% est optimale",,,,,,,,5b3937bae1222168,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP.ipynb,u4uegd1jy7n,code,fr,6e932c8316c21f27,"def generate_optimized_grid(rows: int, cols: int, target_intersections: int = None) -> CrosswordGrid:
     """"""
     Genere une grille optimisee pour maximiser les intersections.
@@ -5831,19 +5831,19 @@ def evaluate_grid_quality(grid: CrosswordGrid) -> float:
 
 
 print(""Exercice a completer : generation de grille optimisee"")",,,,,,,,6e932c8316c21f27,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP.ipynb,momgke1egi8,markdown,fr,5391702f4f092196,"### Exercice 3 : Contraintes de Theme (Reflexion)
+MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP.ipynb,momgke1egi8,markdown,fr,3b84369e46e8830d,"### Exercice 3 : Contraintes de Thème (Reflexion)
 
-Comment modifieriez-vous le solveur pour generer des grilles sur un theme donne (ex: informatique, nature, sport) ?
+Comment modifieriez-vous le solveur pour generer des grilles sur un thème donne (ex: informatique, nature, sport) ?
 
 **Questions a considerer** :
 - Comment structurer un dictionnaire thematique ?
-- Faut-il penaliser les mots hors-theme ou les interdire totalement ?
+- Faut-il penaliser les mots hors-thème ou les interdire totalement ?
 - Quel impact sur la difficulte de resolution ?
 
-**Reponse attendue** : Une description textuelle de votre approche (pas de code requis).",,,,,,,,5391702f4f092196,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP.ipynb,24d2900a,markdown,fr,d6b7c1e115970d96,"## Conclusion
+**Reponse attendue** : Une description textuelle de votre approche (pas de code requis).",,,,,,,,3b84369e46e8830d,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP.ipynb,24d2900a,markdown,fr,f9790d3a333dbf93,"## Conclusion
 
-Ce notebook a modelise la **generation de mots croises** comme un probleme de satisfaction de contraintes (CSP).
+Ce notebook a modelise la **generation de mots croises** comme un problème de satisfaction de contraintes (CSP).
 
 ### Ce que nous avons appris
 
@@ -5854,11 +5854,11 @@ Ce notebook a modelise la **generation de mots croises** comme un probleme de sa
 
 ### Lecon principale
 
-Le contraste est saisissant : le meme probleme est **trivial pour CP-SAT** et **intraitable pour le backtracking naif**. La propagation de contraintes de CP-SAT (arc-consistance, bound tightening) elague massivement l'espace de recherche, tandis que le backtracking sans inference explore aveuglement des branches sans issue.
+Le contraste est saisissant : le même problème est **trivial pour CP-SAT** et **intraitable pour le backtracking naif**. La propagation de contraintes de CP-SAT (arc-consistance, bound tightening) elague massivement l'espace de recherche, tandis que le backtracking sans inference explore aveuglement des branches sans issue.
 
 La modelisation est elegante : les **variables** sont les emplacements (slots), les **domaines** sont les mots du dictionnaire, et les **contraintes** sont les intersections de lettres entre mots horizontaux et verticaux.
 
-**Suite** : [App-15 - Planification sportive](App-15-SportsScheduling.ipynb) | [Retour au sommaire](../../README.md)",,,,,,,,d6b7c1e115970d96,,,,,,,
+**Suite** : [App-15 - Planification sportive](App-15-SportsScheduling.ipynb) | [Retour au sommaire](../../README.md)",,,,,,,,f9790d3a333dbf93,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-19-ProceduralGeneration-WFC-Csharp.ipynb,92a84793,markdown,fr,7aca7012b98cd607,"# App-19 (C#) — Génération procédurale par Wave Function Collapse (WFC) from-scratch
 
 **Twin C# (.NET Interactive)** de [App-19-ProceduralGeneration-WFC.ipynb](App-19-ProceduralGeneration-WFC.ipynb) — marathon de parité .NET ⇄ Python (#4956).
@@ -6599,15 +6599,15 @@ if cpsat_result.grid is not None:
     ax.legend(handles=legend, loc='upper right', fontsize=8, framealpha=0.8)
     plt.tight_layout()
     plt.show()",,,,,,,,14792388552c2fec,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-19-ProceduralGeneration-WFC.ipynb,c3c8c7d5,markdown,fr,24c8e44ab0a1e77e,"### Exercice : Valider un niveau genere
+MyIA.AI.Notebooks/Search/Applications/CSP/App-19-ProceduralGeneration-WFC.ipynb,c3c8c7d5,markdown,fr,bb557b114f4de2aa,"### Exercice : Valider un niveau genere
 
-Ecrivez une fonction `validate_level` qui prend une grille generee et verifie **tous les criteres de qualite** : violations d'adjacence, connectivite BFS, et comptage d'objets. La fonction retourne un dict avec les metriques et un booleen `valid` (True si 0 violations + connectivite > 50%).
+Ecrivez une fonction `validate_level` qui prend une grille generee et verifie **tous les critères de qualite** : violations d'adjacence, connectivite BFS, et comptage d'objets. La fonction retourne un dict avec les metriques et un booléen `valid` (True si 0 violations + connectivite > 50%).
 
 **Indices** :
 - Utilisez `adjacency_violations(grid, rules)` du module `wfc_cpsat` pour les violations
 - Utilisez `bfs_reachable_floor(grid, floor_id)` pour la connectivite
 - Pour les objets : `np.sum(obj_grid == k)` pour chaque type (1=ennemi, 2=cle, 3=coffre)
-- Un niveau est ""valide"" si violations == 0 ET connectivite >= 0.5",,,,,,,,24c8e44ab0a1e77e,,,,,,,
+- Un niveau est ""valide"" si violations == 0 ET connectivite >= 0.5",,,,,,,,bb557b114f4de2aa,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-19-ProceduralGeneration-WFC.ipynb,a95183d3,code,fr,4adbcc2a2a566122,"def validate_level(grid: np.ndarray, rules: dict, floor_id: int, 
                    obj_grid: np.ndarray = None) -> dict:
     """"""Valide un niveau genere en verifiant adjacence, connectivite et objets.
@@ -6723,15 +6723,15 @@ for name, label in labels_cmp.items():
     else:
         print(f""{label:<12} {m['violations']:>12} {m['connectivity']:>13.0f}% ""
               f""{m['variety']:>9} {m['floor_pct']:>6.0f}% {m['time_ms']:>11.1f} {m['backtracks']:>12}"")",,,,,,,,3afdb7fc33853777,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-19-ProceduralGeneration-WFC.ipynb,1f768b07,markdown,fr,73021306222e11ee,"### Exercice : Generation par batch et statistiques
+MyIA.AI.Notebooks/Search/Applications/CSP/App-19-ProceduralGeneration-WFC.ipynb,1f768b07,markdown,fr,cf869f295a2bb55c,"### Exercice : Generation par batch et statistiques
 
-Pour evaluer la robustesse d'une methode, il faut generer **plusieurs niveaux** (seeds differents) et calculer les statistiques aggregatees. Implementez une fonction `batch_evaluate` qui genere N niveaux avec WFC et retourne les metriques moyennes (violations, connectivite, temps).
+Pour evaluer la robustesse d'une méthode, il faut generer **plusieurs niveaux** (seeds différents) et calculer les statistiques aggregatees. Implementez une fonction `batch_evaluate` qui genere N niveaux avec WFC et retourne les metriques moyennes (violations, connectivite, temps).
 
 **Indices** :
-- Bouclez sur `range(n_seeds)` en utilisant chaque iteration comme seed
+- Bouclez sur `range(n_seeds)` en utilisant chaque itération comme seed
 - Pour chaque seed, appelez `PureWFC(rows, cols, tileset, seed=i).solve()`
 - Collectez violations et connectivite dans des listes
-- Retournez les moyennes avec `np.mean()` et ecarts-types avec `np.std()`",,,,,,,,73021306222e11ee,,,,,,,
+- Retournez les moyennes avec `np.mean()` et ecarts-types avec `np.std()`",,,,,,,,cf869f295a2bb55c,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-19-ProceduralGeneration-WFC.ipynb,b01ea2ad,code,fr,dffb510fd73f7b06,"def batch_evaluate(n_seeds: int, rows: int, cols: int, tileset: dict) -> dict:
     """"""Genere n_seeds niveaux WFC et calcule les metriques aggregatees.
     
@@ -6802,15 +6802,15 @@ fig.legend(handles=legend, loc='lower center', ncol=n_tiles_cmp, fontsize=9)
 plt.suptitle('Niveaux par difficulté — contraintes CP-SAT', fontsize=13, fontweight='bold')
 plt.tight_layout(rect=[0, 0.06, 1, 0.96])
 plt.show()",,,,,,,,27363275619da7b3,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-19-ProceduralGeneration-WFC.ipynb,3881d95e,markdown,fr,f2fd5502c9ef9907,"### Exercice : Creer un preset de difficulte perso
+MyIA.AI.Notebooks/Search/Applications/CSP/App-19-ProceduralGeneration-WFC.ipynb,3881d95e,markdown,fr,374aed5d86392172,"### Exercice : Créer un preset de difficulte perso
 
-En vous basant sur les 3 presets (Facile/Moyen/Difficile) definis ci-dessus, creez un nouveau preset **""Hardcore""** avec vos propres parametres de contraintes. L'objectif est un niveau avec **peu de sol**, **beaucoup d'ennemis**, et **plusieurs cles/coffres** obligeant le joueur a explorer.
+En vous basant sur les 3 presets (Facile/Moyen/Difficile) définis ci-dessus, créez un nouveau preset **""Hardcore""** avec vos propres paramètres de contraintes. L'objectif est un niveau avec **peu de sol**, **beaucoup d'ennemis**, et **plusieurs cles/coffres** obligeant le joueur a explorer.
 
 **Indices** :
 - Inspirez-vous du dictionnaire `difficulty_configs` ci-dessus
-- Parametres disponibles : `min_enemy_ratio`, `max_enemy_ratio`, `min_floor_ratio`, `max_floor_ratio`, `n_keys`, `n_chests`
+- Paramètres disponibles : `min_enemy_ratio`, `max_enemy_ratio`, `min_floor_ratio`, `max_floor_ratio`, `n_keys`, `n_chests`
 - Un niveau hardcore typique : sol < 30%, ennemis > 25%, 3+ cles, 2+ coffres
-- Appelez `solve_cpsat(12, 12, tileset, seed=42, add_connectivity=True, timeout_s=20.0, **votre_config)` pour tester",,,,,,,,f2fd5502c9ef9907,,,,,,,
+- Appelez `solve_cpsat(12, 12, tileset, seed=42, add_connectivity=True, timeout_s=20.0, **votre_config)` pour tester",,,,,,,,374aed5d86392172,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-19-ProceduralGeneration-WFC.ipynb,21312c0a,code,fr,8104f447f2dbac96,"# TODO etudiant : definir et tester votre preset ""Hardcore""
 hardcore_config = {
     'min_enemy_ratio': 0.0,   # TODO etudiant : choisir un ratio minimum d'ennemis
@@ -6917,7 +6917,7 @@ display(widgets.VBox([
     widgets.HBox([w_seed, w_size, w_ts, w_conn]),
     w_floor, w_enemy, w_btn, w_out
 ]))",,,,,,,,4e490a51efcc17be,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-19-ProceduralGeneration-WFC.ipynb,626e09a2,markdown,fr,3dd5f1d65ff66422,"## Synthèse — WFC vs CP-SAT pour la génération procédurale
+MyIA.AI.Notebooks/Search/Applications/CSP/App-19-ProceduralGeneration-WFC.ipynb,626e09a2,markdown,fr,36aa186529e341f3,"## Synthèse — WFC vs CP-SAT pour la génération procédurale
 
 | Critère | Aléatoire | WFC pur | CP-SAT |
 |---------|-----------|---------|--------|
@@ -6938,11 +6938,11 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-19-ProceduralGeneration-WFC.ipynb,
 ### Pour aller plus loin
 
 - **Optimizer la connectivité** : remplacer la relaxation flow par une contrainte de chemin explicite (variables `path[u]` = rang dans le BFS), plus coûteuse mais complète.
-- **Multi-objectif** : optimiser la variété (`Maximize(sum(different))`) tout en saturant les contraintes globales.
+- **Multi-objectif** : optimiser la variété (`Maximize(sum(différent))`) tout en saturant les contraintes globales.
 - **Génération de tilesets** : apprendre les règles d'adjacence depuis une image de référence (WFC observationnel).
 - **Parallelisation** : CP-SAT supporte `num_search_workers=N` pour exploiter les CPU multi-coeurs.
 
-Ce notebook a montré comment formuler un problème de génération procédurale (typiquement traité par des heuristiques ad-hoc) comme un **CSP canonique** résolu par un solveur industriel (OR-Tools). C'est un pattern transférable à de nombreux domaines : placement de composants en VLSI, allocation de fréquences, planification de tâches.",,,,,,,,3dd5f1d65ff66422,,,,,,,
+Ce notebook a montré comment formuler un problème de génération procédurale (typiquement traité par des heuristiques ad-hoc) comme un **CSP canonique** résolu par un solveur industriel (OR-Tools). C'est un pattern transférable à de nombreux domaines : placement de composants en VLSI, allocation de fréquences, planification de tâches.",,,,,,,,36aa186529e341f3,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-1b-NQueens-CSharp.ipynb,b6601688-9f2f-4570-bae4-202df6e512ee,markdown,fr,d69828aa720cf21c,"# App-1b : Le problème des N-Reines — Jumeau C#
 
 > **Twin C#** de [`App-1-NQueens`](App-1-NQueens.ipynb) (Python + OR-Tools + numpy + matplotlib).
@@ -7368,17 +7368,17 @@ Ce twin C# a **déroulé à la main** ce que le solveur industriel OR-Tools CP-S
 MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,c135d868,code,fr,d8cfd07b7b0f3965,"# Parameters
 BATCH_MODE = ""true""
 ",,,,,,,,d8cfd07b7b0f3965,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-header,markdown,fr,ca97617658f5a431,"# App-2 : Coloration de Graphes
+MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-header,markdown,fr,ae9f916e09d19787,"# App-2 : Coloration de Graphes
 
 **Navigation** : [<< App-1 NQueens](App-1-NQueens.ipynb) | [Index](../../README.md) | [App-3 NurseScheduling >>](App-3-NurseScheduling.ipynb)
 
 ## Objectifs d'apprentissage
 
 A la fin de ce notebook, vous saurez :
-1. **Formaliser** un probleme de coloration de graphe comme CSP
+1. **Formaliser** un problème de coloration de graphe comme CSP
 2. **Implementer** l'algorithme Greedy et comparer les effets de l'ordre des sommets
 3. **Implementer** DSATUR (Brelaz 1979) et comprendre son avantage heuristique
-4. **Modeliser** le probleme avec OR-Tools CP-SAT et prouver l'optimalite
+4. **Modeliser** le problème avec OR-Tools CP-SAT et prouver l'optimalite
 5. **Appliquer** ces algorithmes a la coloration des departements francais
 6. **Comparer** les performances sur des graphes aleatoires de taille croissante
 
@@ -7386,14 +7386,14 @@ A la fin de ce notebook, vous saurez :
 - Python 3.10+, notions de graphes (sommets, aretes, adjacence)
 - [CSP-1 : Fundamentals](../../Part2-CSP/CSP-1-Fundamentals.ipynb) et [CSP-2 : Consistency](../../Part2-CSP/CSP-2-Consistency.ipynb)
 
-### Duree estimee : 45 minutes",,,,,,,,ca97617658f5a431,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-intro,markdown,fr,f089872713c4592a,"---
+### Duree estimee : 45 minutes",,,,,,,,ae9f916e09d19787,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-intro,markdown,fr,3290c3e851f749f0,"---
 
 ## 1. Introduction (~5 min)
 
-### Le probleme de coloration de graphe
+### Le problème de coloration de graphe
 
-La **coloration de graphe** consiste a attribuer une couleur a chaque sommet d'un graphe de sorte que deux sommets adjacents (relies par une arete) n'aient jamais la meme couleur. Le nombre minimum de couleurs necessaires s'appelle le **nombre chromatique** $\chi(G)$.
+La **coloration de graphe** consiste a attribuer une couleur a chaque sommet d'un graphe de sorte que deux sommets adjacents (relies par une arete) n'aient jamais la même couleur. Le nombre minimum de couleurs necessaires s'appelle le **nombre chromatique** $\chi(G)$.
 
 **Definition formelle** :
 
@@ -7407,11 +7407,11 @@ $$\chi(G) = \min \{ k : \text{il existe une } k\text{-coloration valide de } G \
 
 ### Applications concretes
 
-| Domaine | Probleme | Modelisation |
+| Domaine | Problème | Modelisation |
 |---------|----------|--------------|
-| **Cartographie** | Colorier une carte (regions adjacentes differentes) | Sommets = regions, aretes = frontieres communes |
+| **Cartographie** | Colorier une carte (regions adjacentes différentes) | Sommets = regions, aretes = frontieres communes |
 | **Compilation** | Allocation de registres CPU | Sommets = variables vivantes, aretes = interferences |
-| **Planification** | Emplois du temps sans conflit | Sommets = cours, aretes = meme professeur ou salle |
+| **Planification** | Emplois du temps sans conflit | Sommets = cours, aretes = même professeur ou salle |
 | **Telecommunications** | Attribution de frequences radio | Sommets = antennes, aretes = zones d'interference |
 
 ### Complexite
@@ -7421,7 +7421,7 @@ $$\chi(G) = \min \{ k : \text{il existe une } k\text{-coloration valide de } G \
 - Calculer $\chi(G)$ est donc **NP-difficile** en general
 - Le **theoreme des quatre couleurs** (1976) garantit que tout graphe **planaire** est 4-coloriable
 
-Dans ce notebook, nous comparons trois approches : un algorithme glouton simple, l'heuristique DSATUR, et un solveur exact CP-SAT.",,,,,,,,f089872713c4592a,,,,,,,
+Dans ce notebook, nous comparons trois approches : un algorithme glouton simple, l'heuristique DSATUR, et un solveur exact CP-SAT.",,,,,,,,3290c3e851f749f0,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,2457c32c,code,fr,7b73e7ac422196b1,"# Dependencies pre-provisionnees (numpy matplotlib pandas mealpy networkx ortools) : voir requirements.txt.
 # Aucun install requis dans le notebook ; import et invalidation des caches ci-dessous.
 
@@ -7454,13 +7454,13 @@ np.random.seed(42)
 
 print(""Imports OK"")
 print(f""NetworkX version : {nx.__version__}"")",,,,,,,,4c95a691940651c8,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-setup-intro,markdown,fr,2727b944367be406,"---
+MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-setup-intro,markdown,fr,22cdab0b8b0aa607,"---
 
 ## 2. Construction du graphe : departements francais (~5 min)
 
-Nous utilisons un sous-ensemble de departements francais metropolitains pour illustrer le probleme. Chaque departement est un sommet, et deux departements sont relies par une arete s'ils partagent une frontiere commune.
+Nous utilisons un sous-ensemble de departements francais metropolitains pour illustrer le problème. Chaque departement est un sommet, et deux departements sont relies par une arete s'ils partagent une frontiere commune.
 
-Nous construisons un graphe de **15 departements** autour de l'Ile-de-France et de ses voisins, ce qui donne un graphe planaire suffisamment riche pour etre interessant.",,,,,,,,2727b944367be406,,,,,,,
+Nous construisons un graphe de **15 departements** autour de l'Ile-de-France et de ses voisins, ce qui donne un graphe planaire suffisamment riche pour etre interessant.",,,,,,,,22cdab0b8b0aa607,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-dept-graph,code,fr,8ce7a9fe8e7073c4,"# Graphe des departements francais (sous-ensemble)
 # Chaque cle est un departement, la valeur est la liste des departements adjacents
 
@@ -7507,19 +7507,19 @@ print(f""Planaire   : {nx.is_planar(dept_graph)}"")
 print(f""\nDegres par departement :"")
 for dept, deg in sorted(dept_graph.degree(), key=lambda x: -x[1]):
     print(f""  {dept:<22} degre {deg}"")",,,,,,,,8ce7a9fe8e7073c4,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-dept-interpretation,markdown,fr,27d076e0812eeb8b,"### Interpretation : structure du graphe
+MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-dept-interpretation,markdown,fr,ae82431b049c4f66,"### Interpretation : structure du graphe
 
 | Propriete | Valeur | Signification |
 |-----------|--------|---------------|
 | Sommets | 18 | 18 departements autour de l'Ile-de-France |
 | Aretes | 37 | Frontieres communes entre departements |
-| Degre max | 9 (Seine-et-Marne) | Departement le plus contraint |
+| Degré max | 9 (Seine-et-Marne) | Departement le plus contraint |
 | Planaire | Oui | Theoreme des 4 couleurs applicable |
 
 **Points cles** :
 1. Seine-et-Marne est le departement le plus contraint (le plus grand, il touche beaucoup de voisins)
 2. Le graphe est planaire : on sait donc que $\chi(G) \leq 4$
-3. La densite est moderee, ce qui rend le probleme accessible aux trois approches",,,,,,,,27d076e0812eeb8b,,,,,,,
+3. La densite est moderee, ce qui rend le problème accessible aux trois approches",,,,,,,,ae82431b049c4f66,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-draw-graph,code,fr,f0f841816cf8b9ce,"# Visualisation du graphe des departements
 
 def draw_graph(G, coloring=None, title=""Graphe"", figsize=(14, 10)):
@@ -7583,38 +7583,38 @@ def draw_graph(G, coloring=None, title=""Graphe"", figsize=(14, 10)):
 # Afficher le graphe sans coloration
 draw_graph(dept_graph, title=""Graphe des departements francais (sans coloration)"")
 plt.show()",,,,,,,,f0f841816cf8b9ce,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-csp-formulation,markdown,fr,76938127bd9365c1,"### Formulation CSP
+MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-csp-formulation,markdown,fr,85e2972ed3baea20,"### Formulation CSP
 
-Le probleme de coloration se formule naturellement comme un **CSP** (Constraint Satisfaction Problem) :
+Le problème de coloration se formule naturellement comme un **CSP** (Constraint Satisfaction Problem) :
 
 | Composant | Definition | Ici |
 |-----------|------------|-----|
 | **Variables** $X$ | Un sommet du graphe | Chaque departement |
 | **Domaines** $D_i$ | Ensemble de couleurs disponibles | $\{0, 1, \ldots, k-1\}$ |
-| **Contraintes** $C$ | Deux sommets adjacents ont des couleurs differentes | $c(u) \neq c(v)$ pour chaque arete $(u, v)$ |
+| **Contraintes** $C$ | Deux sommets adjacents ont des couleurs différentes | $c(u) \neq c(v)$ pour chaque arete $(u, v)$ |
 
-Nous allons resoudre ce CSP avec trois approches de complexite croissante.",,,,,,,,76938127bd9365c1,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-greedy-intro,markdown,fr,38a39e8b21ec45f9,"---
+Nous allons resoudre ce CSP avec trois approches de complexite croissante.",,,,,,,,85e2972ed3baea20,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-greedy-intro,markdown,fr,e5723cbd23cbffb7,"---
 
 ## 3. Approche 1 : Coloration gloutonne (Greedy) (~8 min)
 
-L'algorithme **glouton** (greedy) est la methode la plus simple pour colorier un graphe :
+L'algorithme **glouton** (greedy) est la méthode la plus simple pour colorier un graphe :
 
 1. Parcourir les sommets dans un certain ordre
-2. Pour chaque sommet, attribuer la **plus petite couleur** qui n'est pas deja utilisee par un voisin
+2. Pour chaque sommet, attribuer la **plus petite couleur** qui n'est pas déjà utilisee par un voisin
 
 **Proprietes** :
-- Complexite : $O(|V| + |E|)$ -- tres rapide
-- Garantie : utilise au plus $\Delta(G) + 1$ couleurs, ou $\Delta(G)$ est le degre maximum
-- Pas optimal en general : le resultat depend de l'ordre de parcours des sommets
+- Complexite : $O(|V| + |E|)$ -- très rapide
+- Garantie : utilise au plus $\Delta(G) + 1$ couleurs, ou $\Delta(G)$ est le degré maximum
+- Pas optimal en general : le résultat depend de l'ordre de parcours des sommets
 
 ### Algorithme
 
 ```
 Pour chaque sommet v dans l'ordre choisi :
-    couleurs_voisins = {couleur[u] pour u voisin de v deja colorie}
+    couleurs_voisins = {couleur[u] pour u voisin de v déjà colorie}
     couleur[v] = plus petit entier >= 0 absent de couleurs_voisins
-```",,,,,,,,38a39e8b21ec45f9,,,,,,,
+```",,,,,,,,e5723cbd23cbffb7,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-greedy-impl,code,fr,c6d84cf34b224ec0,"def greedy_coloring(G, order=None):
     """"""Coloration gloutonne d'un graphe.
     
@@ -7667,16 +7667,16 @@ print(f""Valide             : {valid}"")
 print(f""\nAffectation :"")
 for dept, color in sorted(coloring_greedy.items(), key=lambda x: x[1]):
     print(f""  {dept:<22} -> couleur {color}"")",,,,,,,,c6d84cf34b224ec0,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-greedy-orders-intro,markdown,fr,d2831dcaf67466a5,"### Impact de l'ordre des sommets
+MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-greedy-orders-intro,markdown,fr,2ff908870328c919,"### Impact de l'ordre des sommets
 
-Le resultat du greedy depend fortement de l'**ordre de parcours**. Comparons plusieurs ordres classiques :
+Le résultat du greedy depend fortement de l'**ordre de parcours**. Comparons plusieurs ordres classiques :
 
 | Ordre | Principe |
 |-------|----------|
 | Par defaut | Ordre d'insertion dans le graphe |
 | Aleatoire | Permutation aleatoire |
-| Degre decroissant | Sommets les plus connectes d'abord |
-| Degre croissant | Sommets les moins connectes d'abord |",,,,,,,,d2831dcaf67466a5,,,,,,,
+| Degré decroissant | Sommets les plus connectes d'abord |
+| Degré croissant | Sommets les moins connectes d'abord |",,,,,,,,2ff908870328c919,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-greedy-orders,code,fr,c563d11559e597c2,"# Comparaison de differents ordres pour le greedy
 
 def order_by_degree_desc(G):
@@ -7716,18 +7716,18 @@ for name, order in orders.items():
     print(f""  {name:<25} {n_colors:>5}    ({status})"")
 
 print(f""\nObservation : le nombre de couleurs varie selon l'ordre."")",,,,,,,,c563d11559e597c2,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-greedy-interpretation,markdown,fr,aeb935847573c547,"### Interpretation : sensibilite a l'ordre
+MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-greedy-interpretation,markdown,fr,f619db27ff216bee,"### Interpretation : sensibilite a l'ordre
 
 | Ordre | Couleurs | Commentaire |
 |-------|----------|-------------|
-| Degre decroissant | Souvent meilleur | Traite les sommets contraints en premier |
-| Degre croissant | Souvent pire | Les sommets contraints sont traites en dernier, quand les couleurs voisines sont figees |
+| Degré decroissant | Souvent meilleur | Traite les sommets contraints en premier |
+| Degré croissant | Souvent pire | Les sommets contraints sont traites en dernier, quand les couleurs voisines sont figees |
 | Aleatoire | Variable | Peut etre bon ou mauvais selon la permutation |
 
 **Points cles** :
 1. Le greedy ne garantit pas l'optimalite : on peut obtenir plus de couleurs que necessaire
-2. L'ordre ""degre decroissant"" est une bonne heuristique (c'est l'algorithme de **Welsh-Powell**)
-3. Pour obtenir le nombre chromatique exact, il faut un algorithme plus sophistique",,,,,,,,aeb935847573c547,,,,,,,
+2. L'ordre ""degré decroissant"" est une bonne heuristique (c'est l'algorithme de **Welsh-Powell**)
+3. Pour obtenir le nombre chromatique exact, il faut un algorithme plus sophistique",,,,,,,,f619db27ff216bee,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-greedy-viz,code,fr,7efb3df77564d733,"# Visualisation de la meilleure coloration greedy
 best_greedy_name = min(greedy_results, key=lambda k: greedy_results[k][1])
 best_coloring, best_n = greedy_results[best_greedy_name]
@@ -7735,7 +7735,7 @@ best_coloring, best_n = greedy_results[best_greedy_name]
 draw_graph(dept_graph, best_coloring,
            title=f""Greedy ({best_greedy_name}) : {best_n} couleurs"")
 plt.show()",,,,,,,,7efb3df77564d733,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-dsatur-intro,markdown,fr,e57b05f5a0f861fb,"---
+MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-dsatur-intro,markdown,fr,df17cc8d03bf7f23,"---
 
 ## 4. Approche 2 : DSATUR (~10 min)
 
@@ -7743,16 +7743,16 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-dsatur-
 
 **DSATUR** (Degree of Saturation) est un algorithme propose par Brelaz (1979). Au lieu de fixer un ordre statique des sommets, DSATUR choisit **dynamiquement** le prochain sommet a colorier en fonction de l'etat courant.
 
-**Saturation** d'un sommet $v$ : nombre de **couleurs distinctes** deja attribuees aux voisins de $v$.
+**Saturation** d'un sommet $v$ : nombre de **couleurs distinctes** déjà attribuees aux voisins de $v$.
 
-$$\text{sat}(v) = |\{ c(u) : u \in N(v), u \text{ deja colorie} \}|$$
+$$\text{sat}(v) = |\{ c(u) : u \in N(v), u \text{ déjà colorie} \}|$$
 
 ### Algorithme DSATUR
 
 ```
 Tant qu'il reste des sommets non colories :
     v = sommet non colorie avec la plus grande saturation
-        (en cas d'egalite : choisir celui de plus grand degre)
+        (en cas d'egalite : choisir celui de plus grand degré)
     couleur[v] = plus petite couleur absente des voisins de v
 ```
 
@@ -7760,12 +7760,12 @@ Tant qu'il reste des sommets non colories :
 
 | Aspect | Greedy | DSATUR |
 |--------|--------|--------|
-| Ordre | Statique (fixe avant l'algorithme) | Dynamique (recalcule a chaque etape) |
-| Critere | Position dans la liste | Saturation + degre |
-| Resultat | Depend de l'heuristique d'ordre | Generalement meilleur ou egal |
+| Ordre | Statique (fixe avant l'algorithme) | Dynamique (recalcule a chaque étape) |
+| Critere | Position dans la liste | Saturation + degré |
+| Résultat | Depend de l'heuristique d'ordre | Généralement meilleur ou egal |
 | Complexite | $O(|V| + |E|)$ | $O(|V|^2)$ avec implementation naive |
 
-DSATUR est une forme de greedy adaptatif : il applique la strategie ""fail-first"" des CSP en traitant d'abord les sommets les plus contraints a chaque instant.",,,,,,,,e57b05f5a0f861fb,,,,,,,
+DSATUR est une forme de greedy adaptatif : il applique la stratégie ""fail-first"" des CSP en traitant d'abord les sommets les plus contraints a chaque instant.",,,,,,,,df17cc8d03bf7f23,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-dsatur-impl,code,fr,ed0c44c6435ee5d7,"def dsatur_coloring(G):
     """"""Coloration par algorithme DSATUR (Brelaz 1979).
     
@@ -7821,9 +7821,9 @@ print(f""Valide             : {valid}"")
 print(f""\nAffectation :"")
 for dept, color in sorted(coloring_dsatur.items(), key=lambda x: x[1]):
     print(f""  {dept:<22} -> couleur {color}"")",,,,,,,,ed0c44c6435ee5d7,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-dsatur-trace-intro,markdown,fr,c75f7bdc5ebc9dd0,"### Trace de l'algorithme DSATUR
+MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-dsatur-trace-intro,markdown,fr,08d0810cf15b615d,"### Trace de l'algorithme DSATUR
 
-Pour comprendre les decisions de DSATUR, ajoutons une trace verbose qui montre a chaque etape quel sommet est choisi et pourquoi.",,,,,,,,c75f7bdc5ebc9dd0,,,,,,,
+Pour comprendre les decisions de DSATUR, ajoutons une trace verbose qui montre a chaque étape quel sommet est choisi et pourquoi.",,,,,,,,08d0810cf15b615d,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-dsatur-trace,code,fr,e2941bbeb2f5415b,"def dsatur_coloring_verbose(G, max_steps=None):
     """"""DSATUR avec trace detaillee des decisions.""""""
     coloring = {}
@@ -7868,23 +7868,23 @@ print(""Trace DSATUR sur les departements francais"")
 print(""="" * 55)
 coloring_trace, n_trace = dsatur_coloring_verbose(dept_graph)
 print(f""\nResultat : {n_trace} couleurs"")",,,,,,,,e2941bbeb2f5415b,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-dsatur-trace-interpretation,markdown,fr,d1a89eb0b6b3102e,"### Interpretation : trace DSATUR
+MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-dsatur-trace-interpretation,markdown,fr,1281a0531e16f79f,"### Interpretation : trace DSATUR
 
-**Sortie obtenue** : la trace montre que DSATUR commence par le sommet de plus haut degre (Seine-et-Marne, degre 9), puis choisit a chaque etape le sommet le plus sature.
+**Sortie obtenue** : la trace montre que DSATUR commence par le sommet de plus haut degré (Seine-et-Marne, degré 9), puis choisit a chaque étape le sommet le plus sature.
 
 **Points cles** :
-1. **Premiere etape** : sans coloration existante, la saturation de tous les sommets est 0. DSATUR utilise le degre comme critere de departage
-2. **Etapes suivantes** : les sommets dont les voisins sont deja colories ont une saturation elevee et sont traites en priorite
+1. **Première étape** : sans coloration existante, la saturation de tous les sommets est 0. DSATUR utilise le degré comme critere de departage
+2. **Étapes suivantes** : les sommets dont les voisins sont déjà colories ont une saturation elevee et sont traites en priorite
 3. L'algorithme s'adapte dynamiquement a l'etat courant, contrairement au greedy statique
 
-> **Lien avec les CSP** : la saturation est analogue a la reduction du domaine dans MRV (Minimum Remaining Values). DSATUR applique en quelque sorte MRV au probleme de coloration.",,,,,,,,d1a89eb0b6b3102e,,,,,,,
+> **Lien avec les CSP** : la saturation est analogue a la reduction du domaine dans MRV (Minimum Remaining Values). DSATUR applique en quelque sorte MRV au problème de coloration.",,,,,,,,1281a0531e16f79f,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-dsatur-viz,code,fr,4bb42721477cc710,"# Visualisation de la coloration DSATUR
 draw_graph(dept_graph, coloring_dsatur,
            title=f""DSATUR : {n_colors_dsatur} couleurs"")
 plt.show()",,,,,,,,4bb42721477cc710,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-petersen-intro,markdown,fr,ef057616073aa41f,"### Comparaison Greedy vs DSATUR sur le graphe de Petersen
+MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-petersen-intro,markdown,fr,ffc4fad8433a945a,"### Comparaison Greedy vs DSATUR sur le graphe de Petersen
 
-Le **graphe de Petersen** est un graphe classique en theorie des graphes : 10 sommets, 15 aretes, 3-regulier (chaque sommet a exactement 3 voisins). Son nombre chromatique est $\chi = 3$. C'est un bon test pour nos algorithmes.",,,,,,,,ef057616073aa41f,,,,,,,
+Le **graphe de Petersen** est un graphe classique en théorie des graphes : 10 sommets, 15 aretes, 3-regulier (chaque sommet a exactement 3 voisins). Son nombre chromatique est $\chi = 3$. C'est un bon test pour nos algorithmes.",,,,,,,,ffc4fad8433a945a,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-petersen-compare,code,fr,cee77ac8ce13c8d4,"# Test sur le graphe de Petersen
 petersen = nx.petersen_graph()
 
@@ -7927,7 +7927,7 @@ axes[1].set_title(f""DSATUR : {n_ds} couleurs"", fontweight='bold')
 plt.suptitle(""Comparaison sur le graphe de Petersen"", fontsize=14, fontweight='bold')
 plt.tight_layout()
 plt.show()",,,,,,,,cee77ac8ce13c8d4,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-petersen-interpretation,markdown,fr,f1bebec888110f14,"### Interpretation : Petersen
+MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-petersen-interpretation,markdown,fr,9700fc3bf5aee6fb,"### Interpretation : Petersen
 
 | Algorithme | Couleurs | Optimal ? |
 |------------|----------|-----------|
@@ -7935,10 +7935,10 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-peterse
 | DSATUR | 3 | Souvent optimal sur les petits graphes |
 
 **Points cles** :
-1. DSATUR trouve generalement l'optimal sur les graphes de taille moderee
-2. Le greedy peut echouer meme sur un graphe 3-regulier simple
-3. Cependant, DSATUR n'est pas garanti optimal en general (c'est une heuristique)",,,,,,,,f1bebec888110f14,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-cpsat-intro,markdown,fr,a2154f23af5835be,"---
+1. DSATUR trouve généralement l'optimal sur les graphes de taille moderee
+2. Le greedy peut echouer même sur un graphe 3-regulier simple
+3. Cependant, DSATUR n'est pas garanti optimal en general (c'est une heuristique)",,,,,,,,9700fc3bf5aee6fb,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-cpsat-intro,markdown,fr,5d01ada4d28d4d3e,"---
 
 ## 5. Approche 3 : OR-Tools CP-SAT (~8 min)
 
@@ -7946,13 +7946,13 @@ Pour **prouver** l'optimalite, nous utilisons le solveur **CP-SAT** de Google OR
 
 ### Modelisation CP-SAT
 
-| Element | Modelisation |
+| Élément | Modelisation |
 |---------|-------------|
 | Variable $x_v$ | `model.new_int_var(0, k-1, f'color_{v}')` pour chaque sommet $v$ |
 | Contrainte | `model.add(x_u != x_v)` pour chaque arete $(u, v)$ |
 | Objectif | Minimiser $k$ (nombre de couleurs) |
 
-Pour minimiser $k$, nous introduisons une variable `max_color` et contraignons chaque `x_v <= max_color`, puis nous minimisons `max_color`.",,,,,,,,a2154f23af5835be,,,,,,,
+Pour minimiser $k$, nous introduisons une variable `max_color` et contraignons chaque `x_v <= max_color`, puis nous minimisons `max_color`.",,,,,,,,5d01ada4d28d4d3e,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-cpsat-impl,code,fr,8ed47dc6a1acedae,"def cpsat_coloring(G, max_colors=None, find_all=False, time_limit=30):
     """"""Coloration optimale par OR-Tools CP-SAT.
     
@@ -8063,25 +8063,25 @@ print(f""Conflits detectes    : {stats_cpsat['conflicts']}"")
 print(f""\nAffectation optimale :"")
 for dept, color in sorted(coloring_cpsat.items(), key=lambda x: x[1]):
     print(f""  {dept:<22} -> couleur {color}"")",,,,,,,,9cab6d47f55dda59,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-cpsat-interpretation,markdown,fr,84a273e77df7f9ac,"### Interpretation : resultat CP-SAT
+MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-cpsat-interpretation,markdown,fr,90b465706d898ed0,"### Interpretation : résultat CP-SAT
 
 | Mesure | Valeur | Signification |
 |--------|--------|---------------|
 | Nombre chromatique | $\chi(G)$ | Nombre **minimum** de couleurs, prouve par le solveur |
 | Statut OPTIMAL | Oui | La solution est prouvee optimale |
-| Temps | Quelques ms | CP-SAT est tres efficace sur les graphes de taille moderee |
+| Temps | Quelques ms | CP-SAT est très efficace sur les graphes de taille moderee |
 
 **Points cles** :
-1. CP-SAT **prouve** que le resultat est optimal, contrairement aux heuristiques
+1. CP-SAT **prouve** que le résultat est optimal, contrairement aux heuristiques
 2. Le graphe etant planaire, on s'attend a $\chi(G) \leq 4$ (theoreme des quatre couleurs)
-3. La brisure de symetrie (fixer la couleur du premier sommet) accelere la resolution en eliminant les permutations de couleurs equivalentes",,,,,,,,84a273e77df7f9ac,,,,,,,
+3. La brisure de symetrie (fixer la couleur du premier sommet) accelere la resolution en eliminant les permutations de couleurs equivalentes",,,,,,,,90b465706d898ed0,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-cpsat-viz,code,fr,7dd3de85a7959510,"# Visualisation de la coloration optimale
 draw_graph(dept_graph, coloring_cpsat,
            title=f""CP-SAT (optimal) : chi(G) = {n_colors_cpsat} couleurs"")
 plt.show()",,,,,,,,7dd3de85a7959510,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-cpsat-enum-intro,markdown,fr,07b30ae87493ce51,"### Enumeration des solutions sur un petit graphe
+MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-cpsat-enum-intro,markdown,fr,e23bd81374bf8300,"### Enumeration des solutions sur un petit graphe
 
-Pour un petit graphe, CP-SAT peut enumerer **toutes** les solutions optimales. Cela permet de voir combien de colorations differentes utilisent le nombre minimum de couleurs.",,,,,,,,07b30ae87493ce51,,,,,,,
+Pour un petit graphe, CP-SAT peut enumerer **toutes** les solutions optimales. Cela permet de voir combien de colorations différentes utilisent le nombre minimum de couleurs.",,,,,,,,e23bd81374bf8300,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-cpsat-enum,code,fr,f5c09a46293ba78c,"# Enumeration des solutions sur le graphe de Petersen
 coloring_pet, n_pet, stats_pet = cpsat_coloring(petersen, find_all=True)
 
@@ -8093,11 +8093,11 @@ print(f""\nPremiere solution : {coloring_pet}"")
 # Verification
 valid_pet, _ = validate_coloring(petersen, coloring_pet)
 print(f""Valide : {valid_pet}"")",,,,,,,,f5c09a46293ba78c,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-benchmark-intro,markdown,fr,5f932612725bbe0a,"---
+MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-benchmark-intro,markdown,fr,d2eadbbddd7511b4,"---
 
 ## 6. Benchmark et visualisation (~6 min)
 
-Comparons maintenant les trois algorithmes sur des graphes de taille croissante. Nous utilisons des **graphes aleatoires** $G(n, p)$ (modele d'Erdos-Renyi) ou chaque arete existe avec probabilite $p$.",,,,,,,,5f932612725bbe0a,,,,,,,
+Comparons maintenant les trois algorithmes sur des graphes de taille croissante. Nous utilisons des **graphes aleatoires** $G(n, p)$ (modèle d'Erdos-Renyi) ou chaque arete existe avec probabilite $p$.",,,,,,,,d2eadbbddd7511b4,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-benchmark-dept,code,fr,3edd4b76ffe9dfba,"# Comparaison des 3 approches sur les departements
 
 def run_all_algorithms(G, graph_name=""Graphe""):
@@ -8209,7 +8209,7 @@ for n in graph_sizes:
     print(f""{n:>5} {'|':>2} {n_g:>8} {t_g:>8.1f} {'|':>2} {n_d:>8} {t_d:>8.1f} {'|':>2} {n_c:>8} {t_c:>10.1f}"")
 
 print(""="" * 80)",,,,,,,,f240baabfab8c906,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,x9xnjfxsf3g,markdown,fr,9ae4503849d57752,Visualisons les resultats du benchmark avec des graphiques comparatifs : qualite de la coloration (nombre de couleurs) et temps de resolution en fonction de la taille du graphe.,,,,,,,,9ae4503849d57752,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,x9xnjfxsf3g,markdown,fr,23d906834f1650d5,Visualisons les résultats du benchmark avec des graphiques comparatifs : qualite de la coloration (nombre de couleurs) et temps de resolution en fonction de la taille du graphe.,,,,,,,,23d906834f1650d5,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-benchmark-plot,code,fr,26e4f75ca0a14742,"# Visualisation du benchmark
 fig, axes = plt.subplots(1, 2, figsize=(16, 6))
 
@@ -8239,11 +8239,11 @@ axes[1].grid(True, alpha=0.3)
 plt.suptitle(f'Benchmark sur graphes aleatoires G(n, {p})', fontsize=14, fontweight='bold')
 plt.tight_layout()
 plt.show()",,,,,,,,26e4f75ca0a14742,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-benchmark-interpretation,markdown,fr,0cb115cc445b5273,"### Interpretation : benchmark comparatif
+MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-benchmark-interpretation,markdown,fr,577b7f72cb264775,"### Interpretation : benchmark comparatif
 
 | Algorithme | Qualite | Vitesse | Passage a l'echelle | Garantie |
 |------------|---------|---------|---------------------|----------|
-| **Greedy** | Acceptable (+1-2 couleurs) | Tres rapide $O(V+E)$ | Excellent | Aucune |
+| **Greedy** | Acceptable (+1-2 couleurs) | Très rapide $O(V+E)$ | Excellent | Aucune |
 | **DSATUR** | Bonne (souvent optimal) | Rapide $O(V^2)$ | Bon | Aucune |
 | **CP-SAT** | Optimal | Lent pour grands graphes | Limite (~200 sommets) | Prouve optimal |
 
@@ -8251,9 +8251,9 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-benchma
 1. **DSATUR** offre le meilleur compromis qualite/vitesse pour les problemes pratiques
 2. **CP-SAT** est indispensable quand on a besoin de la **preuve d'optimalite**
 3. **Greedy** est utile comme initialisation rapide ou quand la vitesse prime sur la qualite
-4. Le temps de CP-SAT croit exponentiellement avec la taille, ce qui est attendu pour un probleme NP-difficile
+4. Le temps de CP-SAT croit exponentiellement avec la taille, ce qui est attendu pour un problème NP-difficile
 
-> **En pratique** : on utilise souvent DSATUR pour obtenir une bonne solution rapidement, puis CP-SAT pour verifier si on peut faire mieux (ou prouver l'optimalite sur les instances critiques).",,,,,,,,0cb115cc445b5273,,,,,,,
+> **En pratique** : on utilise souvent DSATUR pour obtenir une bonne solution rapidement, puis CP-SAT pour verifier si on peut faire mieux (ou prouver l'optimalite sur les instances critiques).",,,,,,,,577b7f72cb264775,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-final-viz-intro,markdown,fr,512b0124bf260af9,"### Visualisation finale : carte des departements
 
 Affichons la coloration optimale (CP-SAT) avec une mise en forme soignee.",,,,,,,,512b0124bf260af9,,,,,,,
@@ -8349,7 +8349,7 @@ for state, neighbors in us_adjacency.items():
 for r in run_all_algorithms(us_graph, ""US States""):
     print(f""{r['algorithm']:<25} {r['colors']} couleurs  ({r['optimal']})"")
 ",,,,,,,,5ed71fb8a780bcee,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,92b07a29,markdown,fr,7ca41e82e476f552,"#### Exercice 1b : Colorier les pays d'Europe de l'Ouest
+MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,92b07a29,markdown,fr,ec8915f852fdb7fc,"#### Exercice 1b : Colorier les pays d'Europe de l'Ouest
 
 Construisez un graphe de 8-10 pays d'Europe de l'Ouest avec leurs frontieres
 et comparez les trois algorithmes.
@@ -8358,8 +8358,8 @@ et comparez les trois algorithmes.
 1. Definissez un dictionnaire d'adjacence pour les pays : France, Espagne,
    Portugal, Belgique, Allemagne, Suisse, Italie, Autriche, Pays-Bas, Luxembourg
 2. Construisez le graphe NetworkX
-3. Appelez `run_all_algorithms` et comparez les resultats
-",,,,,,,,7ca41e82e476f552,,,,,,,
+3. Appelez `run_all_algorithms` et comparez les résultats
+",,,,,,,,ec8915f852fdb7fc,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,37ea83d7,code,fr,2d269cab697a3d92,"# Exercice 1b : Colorier les pays d'Europe de l'Ouest
 
 # TODO: definissez le dictionnaire d'adjacence europe_adjacency
@@ -8369,16 +8369,16 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,37ea83d7,cod
 # Votre code ici
 print(""Exercice a completer"")
 ",,,,,,,,2d269cab697a3d92,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-exercise-2,markdown,fr,7f328e61622b9be1,"### Exemple guide 2 : Borne superieure du greedy et planairite
+MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-exercise-2,markdown,fr,c0e6e4d19426c423,"### Exemple guide 2 : Borne superieure du greedy et planairite
 
 Le theoreme des quatre couleurs garantit que tout graphe **planaire** est 4-coloriable. Cependant, le greedy ne le garantit pas.
 
 **Questions** :
 1. Quel est le nombre maximum de couleurs que le greedy peut utiliser sur un graphe planaire a $n$ sommets ?
 2. Construisez un graphe planaire ou le greedy (avec un mauvais ordre) utilise 5 ou 6 couleurs
-3. Montrez que l'algorithme de Welsh-Powell (greedy par degre decroissant) utilise au plus $\Delta(G) + 1$ couleurs. Quelle est cette borne pour un graphe planaire ?
+3. Montrez que l'algorithme de Welsh-Powell (greedy par degré decroissant) utilise au plus $\Delta(G) + 1$ couleurs. Quelle est cette borne pour un graphe planaire ?
 
-**Indice** : un graphe planaire simple a au plus $3n - 6$ aretes, donc le degre moyen est au plus $6 - 12/n < 6$.",,,,,,,,7f328e61622b9be1,,,,,,,
+**Indice** : un graphe planaire simple a au plus $3n - 6$ aretes, donc le degré moyen est au plus $6 - 12/n < 6$.",,,,,,,,c0e6e4d19426c423,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cc16134e,code,fr,5dab178e4eba20fd,"# Exemple resolu : borne superieure du greedy sur l'icosahedre
 
 icosahedron = nx.icosahedral_graph()
@@ -8409,17 +8409,17 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,7e826ae2,cod
 # Votre code ici
 print(""Exercice a completer"")
 ",,,,,,,,da16daeda0dac29e,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-exercise-3,markdown,fr,7f13c8065a58792c,"### Exemple guide 3 : Implementer Welsh-Powell et comparer avec DSATUR
+MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-exercise-3,markdown,fr,cf11dc3389e32080,"### Exemple guide 3 : Implementer Welsh-Powell et comparer avec DSATUR
 
-L'algorithme de **Welsh-Powell** (1967) est un greedy ou les sommets sont tries par **degre decroissant** avant le parcours. C'est un cas particulier de notre `greedy_coloring` avec `order_by_degree_desc`.
+L'algorithme de **Welsh-Powell** (1967) est un greedy ou les sommets sont tries par **degré decroissant** avant le parcours. C'est un cas particulier de notre `greedy_coloring` avec `order_by_degree_desc`.
 
 Implementez une version optimisee qui colorie les sommets par ""couches"" :
-1. Trier les sommets par degre decroissant
+1. Trier les sommets par degré decroissant
 2. Prendre le premier sommet non colorie, lui attribuer la couleur $c$
 3. Parcourir les sommets restants : si un sommet non colorie n'est adjacent a aucun sommet de couleur $c$, le colorier en $c$
 4. Repeter avec la couleur suivante
 
-Comparez les resultats avec DSATUR sur 5 graphes aleatoires $G(50, 0.3)$.",,,,,,,,7f13c8065a58792c,,,,,,,
+Comparez les résultats avec DSATUR sur 5 graphes aleatoires $G(50, 0.3)$.",,,,,,,,cf11dc3389e32080,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,eae5e3c7,code,fr,5bbc41f2cc1b8eb0,"# Exemple resolu : Welsh-Powell et comparaison avec DSATUR
 
 def welsh_powell_coloring(G):
@@ -8447,17 +8447,17 @@ for i in range(5):
     _, n_cp, _ = cpsat_coloring(G, time_limit=10)
     print(f""G{i}: WP={n_wp}, DSATUR={n_ds}, optimal={n_cp}"")
 ",,,,,,,,5bbc41f2cc1b8eb0,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,6b3599a3,markdown,fr,c757974f001c6608,"#### Exercice 3b : Implementez un algorithme de coloration par saturation
+MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,6b3599a3,markdown,fr,fb1be18e5c58d770,"#### Exercice 3b : Implementez un algorithme de coloration par saturation
 
 L'algorithme DSATUR (Degree of SATURation) choisit le sommet non colore
-avec le plus grand nombre de couleurs differentes dans son voisinage.
+avec le plus grand nombre de couleurs différentes dans son voisinage.
 
 **Consignes** :
 1. Implementez `dsatur_manual(G)` sans utiliser la fonction `dsatur_coloring` fournie
-2. A chaque etape, choisissez le sommet non colore avec la saturation maximale
-3. En cas d'egalite, choisissez le sommet de degre maximal
-4. Comparez vos resultats avec `dsatur_coloring` sur 10 graphes aleatoires
-",,,,,,,,c757974f001c6608,,,,,,,
+2. A chaque étape, choisissez le sommet non colore avec la saturation maximale
+3. En cas d'egalite, choisissez le sommet de degré maximal
+4. Comparez vos résultats avec `dsatur_coloring` sur 10 graphes aleatoires
+",,,,,,,,fb1be18e5c58d770,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,c47df6f4,code,fr,113b3495af1e3539,"# Exercice 3b : Implementez DSATUR manuellement
 
 # TODO: implementez dsatur_manual(G)
@@ -8467,7 +8467,7 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,c47df6f4,cod
 # Votre code ici
 print(""Exercice a completer"")
 ",,,,,,,,113b3495af1e3539,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-conclusion,markdown,fr,5ed78952789d89f9,"---
+MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-conclusion,markdown,fr,6ae220cf93370a61,"---
 
 ## Recapitulatif
 
@@ -8481,7 +8481,7 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-conclus
 
 ### Ce que nous avons appris
 
-1. La **coloration de graphe** est un probleme NP-difficile fondamental avec de nombreuses applications
+1. La **coloration de graphe** est un problème NP-difficile fondamental avec de nombreuses applications
 2. L'**ordre des sommets** a un impact majeur sur la qualite de la coloration gloutonne
 3. **DSATUR** adapte dynamiquement l'ordre en privilegiant les sommets les plus satures (analogie avec MRV en CSP)
 4. **CP-SAT** garantit l'optimalite mais ne passe pas a l'echelle sur les grands graphes
@@ -8492,47 +8492,47 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb,cell-conclus
 - **Tabu Search** : ameliorer une coloration par recherche locale avec liste tabu
 - **Branch and Bound** : algorithme exact plus efficace que la brute force
 - **Coloration de graphes d'intervalles** : cas polynomial important en planification
-- **Coloration fractionnaire** : relaxation LP du probleme de coloration
+- **Coloration fractionnaire** : relaxation LP du problème de coloration
 
 ### References
 
 - Brelaz, D. (1979). ""New methods to color the vertices of a graph"". *Communications of the ACM*, 22(4), 251-256.
 - Welsh, D. J. A. & Powell, M. B. (1967). ""An upper bound for the chromatic number of a graph"". *The Computer Journal*, 10(1), 85-86.
 - Appel, K. & Haken, W. (1976). ""Every planar map is four colorable"". *Bulletin of the AMS*, 82(5), 711-712.
-- Karp, R. M. (1972). ""Reducibility among combinatorial problems"". *Complexity of Computer Computations*, 85-103.",,,,,,,,5ed78952789d89f9,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb,ee885a95,markdown,fr,da76e7b1b8ebb889,"# App-20 — Benchmark comparatif des solveurs Sudoku Python
+- Karp, R. M. (1972). ""Reducibility among combinatorial problems"". *Complexity of Computer Computations*, 85-103.",,,,,,,,6ae220cf93370a61,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb,ee885a95,markdown,fr,95153ef73d51cc1e,"# App-20 — Benchmark comparatif des solveurs Sudoku Python
 
 [← Recherche](../README.md) | [↑ Search/Applications](../README.md)
 
-Quatre solveurs, un meme probleme NP-complet, des compromis differents. Ce notebook deplace le curseur de la serie *Search* : on ne presente plus un solveur a la fois, on les **fait courir ensemble** sur un banc commun (Easy / Medium / Hard) pour faire apparaitre ce que chaque algorithme optimise reellement.
+Quatre solveurs, un même problème NP-complet, des compromis différents. Ce notebook deplace le curseur de la serie *Search* : on ne presente plus un solveur a la fois, on les **fait courir ensemble** sur un banc commun (Easy / Medium / Hard) pour faire apparaitre ce que chaque algorithme optimise reellement.
 
-Le fil rouge est le **denombrement du travail** : nombre d'appels recursifs, temps CPU, taux de reussite. On verra que la complexite asymptotique cache une realite pragmatique ou un *bon heuristique* (MRV) ou un *bon encodage* (Dancing Links) l'emporte sur la theorie pure.
+Le fil rouge est le **denombrement du travail** : nombre d'appels recursifs, temps CPU, taux de reussite. On verra que la complexite asymptotique cache une realite pragmatique ou un *bon heuristique* (MRV) ou un *bon encodage* (Dancing Links) l'emporte sur la théorie pure.
 
 ## Pourquoi ce notebook
 
-Les notebooks precedents de la serie *Search/Applications/CSP* (App-1 N-Queens, App-2 Graph Coloring, App-3 Nurse Scheduling, App-4 Job Shop...) presentent chacun **une seule approche** sur **un seul probleme**. Ce notebook inverse la perspective : un probleme (Sudoku), **plusieurs solveurs** (backtracking, MRV, AC-3, DLX), un meme banc de test.
+Les notebooks précédents de la serie *Search/Applications/CSP* (App-1 N-Queens, App-2 Graph Coloring, App-3 Nurse Scheduling, App-4 Job Shop...) presentent chacun **une seule approche** sur **un seul problème**. Ce notebook inverse la perspective : un problème (Sudoku), **plusieurs solveurs** (backtracking, MRV, AC-3, DLX), un même banc de test.
 
-Cette mise en regard est pedagogiquement plus riche qu'une suite monographique : elle fait apparaitre les **frontieres de viabilite** (quand MRV devient-il indispensable ? ou AC-3 paye-t-il son cout ? DLX garde-t-il son avantage sur les grilles tres denses ?). Le lecteur peut lire la cellule de chaque solveur isolement, mais gagne beaucoup a voir les chiffres cotes a cotes en fin de notebook.
+Cette mise en regard est pedagogiquement plus riche qu'une suite monographique : elle fait apparaitre les **frontieres de viabilite** (quand MRV devient-il indispensable ? ou AC-3 paye-t-il son cout ? DLX garde-t-il son avantage sur les grilles très denses ?). Le lecteur peut lire la cellule de chaque solveur isolement, mais gagne beaucoup a voir les chiffres cotes a cotes en fin de notebook.
 
 ## Objectifs d'apprentissage
 
 A l'issue de ce notebook, vous serez capable de :
 
 1. **Implementer** quatre solveurs Python de complexite croissante (naif, MRV, AC-3, Dancing Links)
-2. **Choisir** le solveur adapte a une difficulte donnee (regle pragmatique, pas theorique)
+2. **Choisir** le solveur adapte a une difficulte donnee (règle pragmatique, pas théorique)
 3. **Diagnostiquer** la complexite reelle d'un solveur via compteur d'appels + temps CPU
-4. **Construire** un banc de test reproductible (memes grilles, meme budget, memes metriques)
+4. **Construire** un banc de test reproductible (mêmes grilles, même budget, mêmes metriques)
 
-## Prong B — probleme non trivial (anti-cas degenere, EPIC #3801)
+## Prong B — problème non trivial (anti-cas degenere, EPIC #3801)
 
-Les trois grilles de test (Easy 36 indices, Medium 30, Hard 24) sont choisies pour que **les solveurs se distinguent**. Sur une grille facile (Easy), le backtracking simple termine en quelques millisecondes et les quatre solveurs sont indiscernables — c'est le cas degenere que les regles SOTA-not-workaround nous demandent d'eviter. Le banc presente des **grilles ou l'ecart est mesurable**, ou MRV divise le nombre d'appels par 10+, ou AC-3 brille par la reduction du domaine, ou DLX garde son avantage constant grace a son encodage exact-cover.
+Les trois grilles de test (Easy 36 indices, Medium 30, Hard 24) sont choisies pour que **les solveurs se distinguent**. Sur une grille facile (Easy), le backtracking simple termine en quelques millisecondes et les quatre solveurs sont indiscernables — c'est le cas degenere que les règles SOTA-not-workaround nous demandent d'eviter. Le banc presente des **grilles ou l'ecart est mesurable**, ou MRV divise le nombre d'appels par 10+, ou AC-3 brille par la reduction du domaine, ou DLX garde son avantage constant grace a son encodage exact-cover.
 
 ## Methodologie
 
-- Memes grilles pour les 4 solveurs (3 difficultes : Easy, Medium, Hard)
-- Memes metriques : temps CPU (ms), nombre d'appels recursifs, succes (1/1)
+- Mêmes grilles pour les 4 solveurs (3 difficultes : Easy, Medium, Hard)
+- Mêmes metriques : temps CPU (ms), nombre d'appels recursifs, succes (1/1)
 - Budget temps : 60 s par (solveur x difficulte), au-dela = TIMEOUT (compte comme echec)
-- Ordre d'execution : du plus simple au plus structure (Backtracking → MRV → AC-3 → DLX)
+- Ordre d'exécution : du plus simple au plus structure (Backtracking → MRV → AC-3 → DLX)
 - Random seed fixe (`seed=42`) pour reproductibilite des grilles Medium/Hard aleatoires
 
 ## References
@@ -8540,8 +8540,8 @@ Les trois grilles de test (Easy 36 indices, Medium 30, Hard 24) sont choisies po
 - Russell, S., & Norvig, P. — *Artificial Intelligence: A Modern Approach* (4e ed., 2021), chap. 6 (CSP) pour Backtracking, MRV, AC-3.
 - Knuth, D. E. (2000) — « Dancing Links », *Millennial Perspectives in Computer Science*, pour DLX.
 - Les solveurs Python de la serie `Sudoku/*.ipynb` (Sudoku-1-Backtracking-Python, Sudoku-2-DancingLinks-Python) sont les ancres pedagogiques de ce benchmark.
-",,,,,,,,da76e7b1b8ebb889,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb,144a39c7,markdown,fr,aaccffe0afd7b070,"## 1. Setup et dependances
+",,,,,,,,95153ef73d51cc1e,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb,144a39c7,markdown,fr,ba76d74e90c6886f,"## 1. Setup et dependances
 
 Bibliotheques utilisees :
 - `time` (stdlib) — mesure CPU
@@ -8549,8 +8549,8 @@ Bibliotheques utilisees :
 - `copy` (stdlib) — deep-copy pour AC-3 (on mute les domaines)
 - `typing` (stdlib) — annotations PEP 484
 
-Pas de dependance lourde. Python 3.10+ suffit (utilise `list[int]`, `dict[str, int]`, etc.).
-",,,,,,,,aaccffe0afd7b070,,,,,,,
+Pas de dépendance lourde. Python 3.10+ suffit (utilise `list[int]`, `dict[str, int]`, etc.).
+",,,,,,,,ba76d74e90c6886f,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb,2e0405bb,code,fr,7ec9f0a4b394eeda,"import time
 import random
 import copy
@@ -8566,15 +8566,15 @@ random.seed(SEED)
 
 print(f""Setup OK. Seed={SEED}, TIMEOUT={TIMEOUT_S}s"")
 ",,,,,,,,7ec9f0a4b394eeda,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb,02601abc,markdown,fr,d87b0e1b648c79d5,"## 2. Banc de test — 3 grilles (Easy/Medium/Hard)
+MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb,02601abc,markdown,fr,b17a65a196deb941,"## 2. Banc de test — 3 grilles (Easy/Medium/Hard)
 
-On utilise trois grilles pre-definies representatives :
+On utilise trois grilles pre-définies representatives :
 - **Easy (36 indices)** : grille classique de journal, solvable par backtracking simple en < 10 ms.
 - **Medium (30 indices)** : grille exigeante, MRV devient utile.
 - **Hard (24 indices)** : grille extreme, seul un solveur structure (DLX, AC-3) reste rapide.
 
 Les grilles sont encodees comme `List[List[int]]` (0 = case vide). Source : grilles classiques du domaine public, format 9x9 standard.
-",,,,,,,,d87b0e1b648c79d5,,,,,,,
+",,,,,,,,b17a65a196deb941,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb,2b598995,code,fr,175bd5a79a360068,"# Trois grilles representatives (0 = vide). Sources publiques.
 EASY_GRID = [
     [5,3,0, 0,7,0, 0,0,0],
@@ -8624,14 +8624,14 @@ for name, grid in GRIDS.items():
     n_givens = sum(1 for row in grid for v in row if v != 0)
     print(f""{name:6s} : {n_givens:2d} indices donnes, {81 - n_givens:2d} cases vides"")
 ",,,,,,,,175bd5a79a360068,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb,76090f5d,markdown,fr,5c61cdf091ad8de5,"## 3. Solveur 1 — Backtracking simple
+MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb,76090f5d,markdown,fr,cd4c8ce87772969a,"## 3. Solveur 1 — Backtracking simple
 
-Le plus naif des solveurs : on essaie les valeurs 1..9 dans l'ordre sur la premiere case vide, on recurse, on backtracke si conflit. Aucun heuristique, aucun filtrage.
+Le plus naif des solveurs : on essaie les valeurs 1..9 dans l'ordre sur la première case vide, on recurse, on backtracke si conflit. Aucun heuristique, aucun filtrage.
 
-**Complexite theorique** : O(9^n) avec n = cases vides. En pratique, sur les grilles Hard (24 indices), c'est prohibitif (centaines de millions d'appels).
+**Complexite théorique** : O(9^n) avec n = cases vides. En pratique, sur les grilles Hard (24 indices), c'est prohibitif (centaines de millions d'appels).
 
-**Ce solveur sert de baseline** : tout l'interet du notebook est de voir comment MRV, AC-3 et DLX s'ecartent de cette baseline sur les grilles difficiles.
-",,,,,,,,5c61cdf091ad8de5,,,,,,,
+**Ce solveur sert de baseline** : tout l'intérêt du notebook est de voir comment MRV, AC-3 et DLX s'ecartent de cette baseline sur les grilles difficiles.
+",,,,,,,,cd4c8ce87772969a,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb,b17f4bdf,code,fr,798729aa5590d5b3,"def find_empty_naive(grid):
     """"""Retourne la premiere case vide dans l ordre ligne-par-ligne, colonne-par-colonne.""""""
     for r in range(9):
@@ -8688,14 +8688,14 @@ def run_backtracking(grid):
 ok, ms, calls = run_backtracking(EASY_GRID)
 print(f""Backtracking simple — Easy : succes={ok}, temps={ms:.2f} ms, appels={calls}"")
 ",,,,,,,,798729aa5590d5b3,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb,7930e964,markdown,fr,8f00e8d93bddeedb,"## 4. Solveur 2 — Backtracking + MRV (Minimum Remaining Values)
+MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb,7930e964,markdown,fr,9e2b4bbbcf83a8f9,"## 4. Solveur 2 — Backtracking + MRV (Minimum Remaining Values)
 
-MRV (Minimum Remaining Values, aussi appele « fail-first ») : au lieu de prendre la premiere case vide, on prend la case qui a le **moins de valeurs possibles**. Si une case n'a qu'une seule valeur, on la remplit d'abord — et si elle n'en a aucune, on **echoue tout de suite** au lieu de perdre du temps sur des branches qui ne mènent nulle part.
+MRV (Minimum Remaining Values, aussi appele « fail-first ») : au lieu de prendre la première case vide, on prend la case qui a le **moins de valeurs possibles**. Si une case n'a qu'une seule valeur, on la remplit d'abord — et si elle n'en a aucune, on **echoue tout de suite** au lieu de perdre du temps sur des branches qui ne mènent nulle part.
 
 **Effet attendu** : reduction drastique du nombre d'appels recursifs (souvent divise par 10 ou plus sur grilles Hard), au prix d'un leger surcout par appel (calcul des valeurs possibles).
 
-**Conditionnement** : la verification de validite est la meme que pour le solveur 1 — MRV ne change pas la condition d'acceptation d'un coup, juste l'ordre d'exploration.
-",,,,,,,,8f00e8d93bddeedb,,,,,,,
+**Conditionnement** : la verification de validite est la même que pour le solveur 1 — MRV ne change pas la condition d'acceptation d'un coup, juste l'ordre d'exploration.
+",,,,,,,,9e2b4bbbcf83a8f9,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb,bd7a4df3,code,fr,8d406b307f0687e7,"def find_empty_mrv(grid):
     """"""Retourne (row, col, valeurs_possibles) pour la case avec le minimum de valeurs.
     En cas d egalite, ordre ligne-par-ligne / colonne-par-colonne (deterministe).""""""
@@ -8746,16 +8746,16 @@ def run_backtracking_mrv(grid):
 ok, ms, calls = run_backtracking_mrv(EASY_GRID)
 print(f""Backtracking+MRV — Easy : succes={ok}, temps={ms:.2f} ms, appels={calls}"")
 ",,,,,,,,8d406b307f0687e7,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb,59244654,markdown,fr,d2182bea5f67a3be,"## 5. Solveur 3 — AC-3 (Arc Consistency 3) + backtracking
+MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb,59244654,markdown,fr,df8c84cd64daf208,"## 5. Solveur 3 — AC-3 (Arc Consistency 3) + backtracking
 
 AC-3 est un algorithme de **filtrage** qui restreint les domaines des variables avant la recherche : pour chaque paire de variables liees par une contrainte, on elimine les valeurs du domaine de l'une qui ne sont compatibles avec aucune valeur de l'autre. On repete jusqu'a stabilite (point fixe).
 
-**Combine avec backtracking** : apres AC-3, le domaine initial de chaque case est reduit. Le backtracking qui suit explore donc beaucoup moins de branches — MRV devient encore plus discriminant (les cases a 0 valeur sortent immediatement).
+**Combine avec backtracking** : après AC-3, le domaine initial de chaque case est reduit. Le backtracking qui suit explore donc beaucoup moins de branches — MRV devient encore plus discriminant (les cases a 0 valeur sortent immediatement).
 
-**Contraintes Sudoku** : pour chaque case, le domaine est `{1..9}` ; on a environ 810 paires de cases liees (ligne/colonne/carre partagent une contrainte binaire « pas la meme valeur »).
+**Contraintes Sudoku** : pour chaque case, le domaine est `{1..9}` ; on a environ 810 paires de cases liees (ligne/colonne/carre partagent une contrainte binaire « pas la même valeur »).
 
-**Limite** : AC-3 est un **filtrage**, pas une resolution. Il peut ne rien conclure sur une grille tres contrainte (toutes les cases ont encore plusieurs valeurs). Le backtracking reste necessaire.
-",,,,,,,,d2182bea5f67a3be,,,,,,,
+**Limite** : AC-3 est un **filtrage**, pas une resolution. Il peut ne rien conclure sur une grille très contrainte (toutes les cases ont encore plusieurs valeurs). Le backtracking reste necessaire.
+",,,,,,,,df8c84cd64daf208,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb,2e5d8e15,code,fr,c14bd02100db4f0a,"def neighbors(r, c):
     """"""Cases liees a (r,c) par une contrainte binaire (meme ligne, colonne ou carre 3x3).""""""
     out = []
@@ -8861,14 +8861,14 @@ def run_ac3(grid):
 ok, ms, calls = run_ac3(EASY_GRID)
 print(f""AC-3 — Easy : succes={ok}, temps={ms:.2f} ms, appels={calls}"")
 ",,,,,,,,c14bd02100db4f0a,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb,5243766f,markdown,fr,558eb0cf7468f042,"## 6. Solveur 4 — Dancing Links (Knuth 2000)
+MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb,5243766f,markdown,fr,cc7a0640d80b7e4d,"## 6. Solveur 4 — Dancing Links (Knuth 2000)
 
-**Dancing Links** (DLX) est l'implementation de l'**Algorithme X** de Knuth sous forme de listes doublement chainees circulaires. L'idee : encoder le Sudoku comme un probleme d'**exact cover** (chaque case contient exactement un chiffre ; chaque ligne/colonne/carre 9 contient chaque chiffre 1..9 une fois), puis exploiter la structure de la matrice creuse pour backtracker avec un overhead minimal.
+**Dancing Links** (DLX) est l'implementation de l'**Algorithme X** de Knuth sous forme de listes doublement chainees circulaires. L'idee : encoder le Sudoku comme un problème d'**exact cover** (chaque case contient exactement un chiffre ; chaque ligne/colonne/carre 9 contient chaque chiffre 1..9 une fois), puis exploiter la structure de la matrice creuse pour backtracker avec un overhead minimal.
 
-**Avantage** : l'operation « couvrir une colonne » est O(1) grace aux pointeurs, et la « decouverte » (backtrack) aussi. Sur grilles tres denses, DLX reste souvent le solveur le plus rapide malgre un overhead constant plus eleve.
+**Avantage** : l'opération « couvrir une colonne » est O(1) grace aux pointeurs, et la « decouverte » (backtrack) aussi. Sur grilles très denses, DLX reste souvent le solveur le plus rapide malgre un overhead constant plus eleve.
 
-**Encodage** : 324 colonnes (81 cases x 4 contraintes : case, ligne, colonne, carre) et 729 lignes candidates (81 cases x 9 valeurs). La matrice resultante est tres creuse (4 ones par ligne).
-",,,,,,,,558eb0cf7468f042,,,,,,,
+**Encodage** : 324 colonnes (81 cases x 4 contraintes : case, ligne, colonne, carre) et 729 lignes candidates (81 cases x 9 valeurs). La matrice resultante est très creuse (4 ones par ligne).
+",,,,,,,,cc7a0640d80b7e4d,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb,3e2d1985,code,fr,e5f456d713abadb0,"class DLXNode:
     __slots__ = (""row"", ""col"", ""up"", ""down"", ""left"", ""right"", ""size"")
 
@@ -9064,29 +9064,29 @@ for diff_name in DIFFICULTIES:
               f""temps={elapsed_ms:8.2f} ms | appels={calls:>8d}""
               f""{' [TIMEOUT]' if timeout else ''}"")
 ",,,,,,,,03be2fec67aa8684,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb,e2091bc6,markdown,fr,1ec63a128b191078,"## Synthese — ce que disent les chiffres
+MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb,e2091bc6,markdown,fr,d6491b7597d889c7,"## Synthese — ce que disent les chiffres
 
 Lecture du tableau ci-dessus :
 
-1. **Easy (36 indices)** : les 4 solveurs sont indiscernables en pratique (ms, < 1000 appels). C'est le cas degenere que les regles SOTA-not-workaround nous demandent d'eviter comme seul banc d'essai — c'est pour cela que le notebook presente aussi Medium et Hard.
+1. **Easy (36 indices)** : les 4 solveurs sont indiscernables en pratique (ms, < 1000 appels). C'est le cas degenere que les règles SOTA-not-workaround nous demandent d'eviter comme seul banc d'essai — c'est pour cela que le notebook presente aussi Medium et Hard.
 
-2. **Medium (30 indices)** : MRV et AC-3 commencent a montrer leur interet (reduction du nombre d'appels). DLX reste comparable en temps malgre un overhead constant plus eleve (construction de la matrice 729 lignes).
+2. **Medium (30 indices)** : MRV et AC-3 commencent a montrer leur intérêt (reduction du nombre d'appels). DLX reste comparable en temps malgre un overhead constant plus eleve (construction de la matrice 729 lignes).
 
 3. **Hard (24 indices)** : ecarts significatifs. MRV divise typiquement les appels par 10 vs backtracking simple. AC-3 reduit drastiquement les domaines avant recherche. DLX garde un avantage grace au chainage O(1) de cover/uncover.
 
-**Regle pragmatique** :
+**Règle pragmatique** :
 - Grille avec beaucoup d'indices (Easy/Medium journaliere) : backtracking simple suffit, MRV est un confort.
 - Grille avec peu d'indices (Hard, expert) : MRV + AC-3 ou DLX deviennent indispensables.
-- Grille avec tres peu d'indices (< 20) : DLX est souvent le seul a tenir le delai.
-",,,,,,,,1ec63a128b191078,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb,01256f6a,markdown,fr,6644e19a16743dd5,"## Exercice 1 — Propagation unitaire (unit propagation)
+- Grille avec très peu d'indices (< 20) : DLX est souvent le seul a tenir le delai.
+",,,,,,,,d6491b7597d889c7,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb,01256f6a,markdown,fr,8955993961ec3779,"## Exercice 1 — Propagation unitaire (unit propagation)
 
-**Objectif** : etendre le solveur MRV avec **unit propagation** : apres AC-3 (ou en plus de MRV), si une case a un domaine reduit a **une seule valeur** apres filtrage, on l'assigne immediatement et on recommence le filtrage.
+**Objectif** : etendre le solveur MRV avec **unit propagation** : après AC-3 (ou en plus de MRV), si une case a un domaine reduit a **une seule valeur** après filtrage, on l'assigne immediatement et on recommence le filtrage.
 
-**Indice** : apres avoir assigne une case, rappeler `ac3(domains)` pour propager la reduction.
+**Indice** : après avoir assigne une case, rappeler `ac3(domains)` pour propager la reduction.
 
 **Contexte pedagogique** : ce pas vers FC (Forward Checking) ou MAC (Maintaining Arc Consistency) est exactement ce que font les solveurs modernes type Choco/OR-Tools. Le rendre explicite est l'occasion de comprendre **pourquoi** un solveur industriel bat un MRV naif.
-",,,,,,,,6644e19a16743dd5,,,,,,,
+",,,,,,,,8955993961ec3779,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb,4f5d00cf,code,fr,05e91f94b4bb50e3,"def solve_mrv_with_unit_prop(grid, stats):
     """"""MRV + propagation unitaire.
 
@@ -9121,14 +9121,14 @@ print(f""MRV+unit_prop — Easy : succes={ok}, temps={ms:.2f} ms, appels={calls}
 if not ok:
     print(""Exercice a completer (resultat attendu : None tant que l implementation est incomplete)"")
 ",,,,,,,,05e91f94b4bb50e3,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb,95c40832,markdown,fr,69dceb438dedaabf,"## Exercice 2 — Compteur de noeuds explores pour DLX
+MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb,95c40832,markdown,fr,ed40fc940e6b8a5f,"## Exercice 2 — Compteur de noeuds explores pour DLX
 
 **Objectif** : instrumenter DLX pour compter le **nombre de noeuds visites** (noeuds de l arbre de recherche, pas les lignes candidates). Actuellement `stats[""calls""]` compte les appels a `_search`, ce qui equivaut au nombre de noeuds.
 
-**Question** : sur la grille Hard, combien DLX visite-t-il de noeuds par rapport a MRV ? Indication : l'ordre de grandeur attendu est 10x a 100x moins grace au chainage O(1) et a la selection de la plus petite colonne.
+**Question** : sur la grille Hard, combien DLX visite-t-il de noeuds par rapport a MRV ? Indication : l'ordre de grandeur attendu est 10x a 100x moins grace au chainage O(1) et a la sélection de la plus petite colonne.
 
-**Methode** : ajouter un compteur `stats[""nodes_visited""]` incremente en debut de `_search`, et le reporter dans `run_dlx`.
-",,,,,,,,69dceb438dedaabf,,,,,,,
+**Méthode** : ajouter un compteur `stats[""nodes_visited""]` incremente en debut de `_search`, et le reporter dans `run_dlx`.
+",,,,,,,,ed40fc940e6b8a5f,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb,49a26fd9,code,fr,6ee528159deaed90,"# Reutilisation de DLXSolver avec instrumentation ajoutee
 class DLXSolverInstrumented(DLXSolver):
     def _search(self, stats):
@@ -9153,17 +9153,17 @@ print(f""DLX instrumente — Hard : succes={ok}, temps={ms:.2f} ms, appels={call
 # Note : l exercice demande de comparer aux autres solveurs ; vous pouvez reprendre la
 # structure de run_dlx et l etendre aux autres solveurs pour faire le tableau complet.
 ",,,,,,,,6ee528159deaed90,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb,e11fff19,markdown,fr,054f4a408c2cd8d1,"## Exercice 3 — Generation de grilles de difficulte controlee
+MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb,e11fff19,markdown,fr,9e3a4d4b3de86f51,"## Exercice 3 — Generation de grilles de difficulte controlee
 
 **Objectif** : generer une **nouvelle grille Hard** (24 indices) en partant d'une grille resolue et en retirant aleatoirement des cases jusqu'a obtenir une difficulte donnee (nombre d'indices).
 
 **Contraintes** :
-- La grille initiale resolue peut etre celle retournee par DLX sur EASY_GRID (apres application)
+- La grille initiale resolue peut etre celle retournee par DLX sur EASY_GRID (après application)
 - Retirer aleatoirement des cases, en verifiant a chaque retrait que la grille reste a **solution unique** (sinon remettre la case)
 - S'arreter quand on atteint le nombre d'indices cible
 
-**Indice** : utiliser `copy.deepcopy` avant chaque tentative de retrait, et reutiliser un des solveurs ci-dessus pour verifier l'unicite (comparer les solutions sur les 4 solveurs — s'ils trouvent la meme, c'est unique).
-",,,,,,,,054f4a408c2cd8d1,,,,,,,
+**Indice** : utiliser `copy.deepcopy` avant chaque tentative de retrait, et reutiliser un des solveurs ci-dessus pour verifier l'unicite (comparer les solutions sur les 4 solveurs — s'ils trouvent la même, c'est unique).
+",,,,,,,,9e3a4d4b3de86f51,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb,3f083a4d,code,fr,8eddad17d7b2bf47,"def generate_hard_grid(target_givens=24, max_attempts=200):
     """"""Genere une grille avec target_givens indices donnes et une solution unique.
 
@@ -9194,22 +9194,22 @@ else:
     n_givens = sum(1 for row in result for v in row if v != 0)
     print(f""Grille generee avec {n_givens} indices donnes"")
 ",,,,,,,,8eddad17d7b2bf47,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb,cd405af3,markdown,fr,f6093553e37f3938,"## Conclusion
+MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb,cd405af3,markdown,fr,7bb7da7113c77a77,"## Conclusion
 
-Ce notebook a compare **quatre solveurs Python** sur un meme banc de test (trois grilles de difficultes croissantes). Le resultat est clair : il n'y a pas de « bon » solveur dans l'absolu — il y a des compromis entre la simplicite d'implementation, le cout en memoire, et la rapidite sur les instances denses.
+Ce notebook a compare **quatre solveurs Python** sur un même banc de test (trois grilles de difficultes croissantes). Le résultat est clair : il n'y a pas de « bon » solveur dans l'absolu — il y a des compromis entre la simplicite d'implementation, le cout en memoire, et la rapidite sur les instances denses.
 
-**Le fil rouge du notebook** : passer d'un solveur naif (backtracking simple) a un solveur structure (DLX) montre que la richesse algorithmique d'un solveur de CSP ne reside pas dans la complexite asymptotique d'un seul algorithme, mais dans **l'interaction entre l'heuristique de selection de variable** (MRV), **le filtrage des domaines** (AC-3), et **la structure de donnees** (DLX). Les solveurs industriels (Choco, OR-Tools, Gecode) combinent toutes ces techniques en un meme moteur.
+**Le fil rouge du notebook** : passer d'un solveur naif (backtracking simple) a un solveur structure (DLX) montre que la richesse algorithmique d'un solveur de CSP ne reside pas dans la complexite asymptotique d'un seul algorithme, mais dans **l'interaction entre l'heuristique de sélection de variable** (MRV), **le filtrage des domaines** (AC-3), et **la structure de données** (DLX). Les solveurs industriels (Choco, OR-Tools, Gecode) combinent toutes ces techniques en un même moteur.
 
-**Pour aller plus loin** : la serie *Search/Applications/CSP* presente d'autres problemes (N-Queens, Job Shop, Picross, Wordle) ou les memes compromis se posent avec des dominantes differentes.
+**Pour aller plus loin** : la serie *Search/Applications/CSP* presente d'autres problemes (N-Queens, Job Shop, Picross, Wordle) ou les mêmes compromis se posent avec des dominantes différentes.
 
 **References completes** :
 - Russell & Norvig, *AIMA* 4e ed. chap. 6 (CSP) — la reference pedagogique pour backtracking, MRV, AC-3.
 - Knuth, D. E. (2000). « Dancing Links ». *Millennial Perspectives in Computer Science*. — l'article fondateur de DLX.
 - Gent, I., et al. (2011). « Algorithms for the Constraint Satisfaction Problem ». — panorama des solveurs modernes.
 
-*Notebook concu pour la serie Search/Applications/CSP (Prong B EPIC #3801 : probleme non-trivial qui met les solveurs en valeur, pas le cas degenere).*
-",,,,,,,,f6093553e37f3938,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-20b-SudokuBenchmark-CSharp.ipynb,91a37c7c8158,markdown,fr,62390b21d4a3f7ca,"# App-20b : Benchmark compare des solveurs Sudoku (jumeau C#)
+*Notebook concu pour la serie Search/Applications/CSP (Prong B EPIC #3801 : problème non-trivial qui met les solveurs en valeur, pas le cas degenere).*
+",,,,,,,,7bb7da7113c77a77,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-20b-SudokuBenchmark-CSharp.ipynb,91a37c7c8158,markdown,fr,485af46f6a91f39f,"# App-20b : Benchmark compare des solveurs Sudoku (jumeau C#)
 
 > **Twin C#** de [`App-20-SudokuBenchmark-Python`](App-20-SudokuBenchmark-Python.ipynb) (Python stdlib : `time`, `random`, `copy`).
 > Marathon **.NET / Python** (#4956), volet **Search / Applications / CSP**.
@@ -9225,8 +9225,8 @@ A la fin de ce notebook, vous saurez :
 3. **Comparer** l'impact des heuristiques (MRV) et de la propagation de contraintes (AC-3) sur la taille de l'arbre de recherche.
 4. **Apprecier** pourquoi Dancing Links (formulation exact-cover) est asymptotiquement superieur au backtracking classical.
 
-Le code est entierement reecrit en C# (.NET 9, 0 NuGet), en miroir de la version Python qui n'utilisait que la stdlib. Le critere de parite = le **nombre d'appels recursifs** (deterministe, independant du runtime) : pour un meme solveur et une meme grille, le compte Python et C# doit concorder exactement. Le temps, lui, varie avec le runtime (C# typiquement plus rapide) et n'est pas un critere de parite.
-",,,,,,,,62390b21d4a3f7ca,,,,,,,
+Le code est entierement reecrit en C# (.NET 9, 0 NuGet), en miroir de la version Python qui n'utilisait que la stdlib. Le critere de parite = le **nombre d'appels recursifs** (déterministe, indépendant du runtime) : pour un même solveur et une même grille, le compte Python et C# doit concorder exactement. Le temps, lui, varie avec le runtime (C# typiquement plus rapide) et n'est pas un critere de parite.
+",,,,,,,,485af46f6a91f39f,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-20b-SudokuBenchmark-CSharp.ipynb,9ce11711b6a0,code,fr,9f56e7b40cf909ba,"using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -9297,11 +9297,11 @@ foreach (var (name, grid) in GRIDS)
     Console.WriteLine($""{name,-6} : {givens,2} indices donnes, {81-givens,2} cases vides"");
 }
 ",,,,,,,,30284a458c804ae7,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-20b-SudokuBenchmark-CSharp.ipynb,bb3ef0475208,markdown,fr,e3a5fc66bc3ac6b6,"---
+MyIA.AI.Notebooks/Search/Applications/CSP/App-20b-SudokuBenchmark-CSharp.ipynb,bb3ef0475208,markdown,fr,640d0e58e76224f0,"---
 ## 2. Solveur 1 -- backtracking naif
 
-Le solveur le plus simple : trouver la premiere case vide (ordre ligne-par-ligne, colonne-par-colonne), essayer les valeurs 1..9 dans l'ordre, verifier la validite (ligne + colonne + carre 3x3), et recurser. Aucune heuristique : l'arbre de recherche explose rapidement sur les grilles difficiles.
-",,,,,,,,e3a5fc66bc3ac6b6,,,,,,,
+Le solveur le plus simple : trouver la première case vide (ordre ligne-par-ligne, colonne-par-colonne), essayer les valeurs 1..9 dans l'ordre, verifier la validite (ligne + colonne + carre 3x3), et recurser. Aucune heuristique : l'arbre de recherche explose rapidement sur les grilles difficiles.
+",,,,,,,,640d0e58e76224f0,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-20b-SudokuBenchmark-CSharp.ipynb,c2415bfeaeff,code,fr,e21f40934ddd9496,"// --- Solveur 1 : backtracking naif ---
 static (int r, int c)? FindEmptyNaive(int[,] g)
 {
@@ -9349,10 +9349,10 @@ static (bool ok, double ms, int calls) RunBacktracking(int[,] grid)
 var (ok1, ms1, calls1) = RunBacktracking(EASY_GRID);
 Console.WriteLine($""Backtracking simple -- Easy : succes={ok1}, temps={ms1:F2} ms, appels={calls1}"");
 ",,,,,,,,e21f40934ddd9496,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-20b-SudokuBenchmark-CSharp.ipynb,2aa3298bd9cf,markdown,fr,b2cf05f45852dd69,"### Solveur 2 -- backtracking + MRV (Minimum Remaining Values)
+MyIA.AI.Notebooks/Search/Applications/CSP/App-20b-SudokuBenchmark-CSharp.ipynb,2aa3298bd9cf,markdown,fr,2ef013704e6347b5,"### Solveur 2 -- backtracking + MRV (Minimum Remaining Values)
 
-Le meme backtracking, mais on choisit a chaque pas la case vide **avec le moins de valeurs possibles**. L'heuristique MRV reduit drastiquement le facteur de branchement : une case avec une seule valeur possible est remplie immediatement (propagation implicite), et les branches mortes sont coupees plus tot.
-",,,,,,,,b2cf05f45852dd69,,,,,,,
+Le même backtracking, mais on choisit a chaque pas la case vide **avec le moins de valeurs possibles**. L'heuristique MRV reduit drastiquement le facteur de branchement : une case avec une seule valeur possible est remplie immediatement (propagation implicite), et les branches mortes sont coupees plus tot.
+",,,,,,,,2ef013704e6347b5,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-20b-SudokuBenchmark-CSharp.ipynb,9695e8bd0e8b,code,fr,9511b67111768571,"// --- Solveur 2 : backtracking + MRV ---
 static (int r, int c, List<int> possibles)? FindEmptyMRV(int[,] g)
 {
@@ -9403,12 +9403,12 @@ static (bool ok, double ms, int calls) RunBacktrackingMRV(int[,] grid)
 var (ok2, ms2, calls2) = RunBacktrackingMRV(EASY_GRID);
 Console.WriteLine($""Backtracking+MRV -- Easy : succes={ok2}, temps={ms2:F2} ms, appels={calls2}"");
 ",,,,,,,,9511b67111768571,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-20b-SudokuBenchmark-CSharp.ipynb,80a1049f5586,markdown,fr,f180b66e8b4c20d7,"### Solveur 3 -- AC-3 + backtracking
+MyIA.AI.Notebooks/Search/Applications/CSP/App-20b-SudokuBenchmark-CSharp.ipynb,80a1049f5586,markdown,fr,69e8772e8ca7b9d0,"### Solveur 3 -- AC-3 + backtracking
 
-On ajoute une **propagation de contraintes** avant la recherche : l'algorithme AC-3 (Arc Consistency 3) elimine des domaines des variables les valeurs sans support dans les domaines de leurs voisins. Pour le Sudoku, deux cases liees (meme ligne/colonne/carre) sont des variables dont les valeurs doivent etre differentes. Apres propagation, le backtracking (avec MRV) travaille sur des domaines deja reduits.
+On ajoute une **propagation de contraintes** avant la recherche : l'algorithme AC-3 (Arc Consistency 3) elimine des domaines des variables les valeurs sans support dans les domaines de leurs voisins. Pour le Sudoku, deux cases liees (même ligne/colonne/carre) sont des variables dont les valeurs doivent etre différentes. Après propagation, le backtracking (avec MRV) travaille sur des domaines déjà reduits.
 
-Si la propagation vide un domaine, le probleme est inconsistent (infeasible) et on arrete.
-",,,,,,,,f180b66e8b4c20d7,,,,,,,
+Si la propagation vide un domaine, le problème est inconsistent (infeasible) et on arrete.
+",,,,,,,,69e8772e8ca7b9d0,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-20b-SudokuBenchmark-CSharp.ipynb,d3e84eb02024,code,fr,12f504c160ddf0ae,"// --- Solveur 3 : AC-3 + backtracking ---
 static List<(int r,int c)> Neighbors(int r, int c)
 {
@@ -9505,17 +9505,17 @@ static (bool ok, double ms, int calls) RunAC3(int[,] grid)
 var (ok3, ms3, calls3) = RunAC3(EASY_GRID);
 Console.WriteLine($""AC-3 -- Easy : succes={ok3}, temps={ms3:F2} ms, appels={calls3}"");
 ",,,,,,,,12f504c160ddf0ae,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-20b-SudokuBenchmark-CSharp.ipynb,691ed5e657e3,markdown,fr,229b3abf37bf55ba,"### Solveur 4 -- Dancing Links (Knuth 2000)
+MyIA.AI.Notebooks/Search/Applications/CSP/App-20b-SudokuBenchmark-CSharp.ipynb,691ed5e657e3,markdown,fr,1b934215cec10b5e,"### Solveur 4 -- Dancing Links (Knuth 2000)
 
-La formulation la plus elegante : Sudoku comme **couverture exacte** (exact cover). On encode le probleme en 324 contraintes (colonnes) :
+La formulation la plus elegante : Sudoku comme **couverture exacte** (exact cover). On encode le problème en 324 contraintes (colonnes) :
 
 - 81 contraintes ""la case (r,c) est remplie"" (une seule valeur par case) ;
 - 81 contraintes ""la ligne r contient la valeur v"" ;
 - 81 contraintes ""la colonne c contient la valeur v"" ;
 - 81 contraintes ""le carre b contient la valeur v"".
 
-Chaque candidat (r,c,v) couvre **exactement 4 colonnes**. L'algorithme X de Knuth, implemente avec les **Dancing Links** (listes doublement chainees toroidales), resout le probleme en O(c) par nœud visite. C'est asymptotiquement le plus rapide pour la couverture exacte.
-",,,,,,,,229b3abf37bf55ba,,,,,,,
+Chaque candidat (r,c,v) couvre **exactement 4 colonnes**. L'algorithme X de Knuth, implemente avec les **Dancing Links** (listes doublement chainees toroidales), resout le problème en O(c) par nœud visite. C'est asymptotiquement le plus rapide pour la couverture exacte.
+",,,,,,,,1b934215cec10b5e,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-20b-SudokuBenchmark-CSharp.ipynb,37a09913727d,code,fr,f51629da29f1c9d0,"// --- Solveur 4 : Dancing Links (Algorithm X, Knuth 2000) ---
 class DLXNode
 {
@@ -9616,11 +9616,11 @@ static (bool ok, double ms, int calls) RunDLX(int[,] grid)
 var (ok4, ms4, calls4) = RunDLX(EASY_GRID);
 Console.WriteLine($""DLX (Knuth) -- Easy : succes={ok4}, temps={ms4:F2} ms"");
 ",,,,,,,,f51629da29f1c9d0,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-20b-SudokuBenchmark-CSharp.ipynb,65b0c8959a62,markdown,fr,0070f9ff3ff3ffd0,"---
+MyIA.AI.Notebooks/Search/Applications/CSP/App-20b-SudokuBenchmark-CSharp.ipynb,65b0c8959a62,markdown,fr,7c9f69979a0c8dbc,"---
 ## 3. Benchmark compare -- les quatre solveurs sur trois difficultes
 
-On execute les quatre solveurs sur les trois grilles et on mesure : (a) le succes, (b) le nombre d'appels recursifs (deterministe, critere de parite), (c) le temps wall-clock (informatif, varie avec le runtime).
-",,,,,,,,0070f9ff3ff3ffd0,,,,,,,
+On execute les quatre solveurs sur les trois grilles et on mesure : (a) le succes, (b) le nombre d'appels recursifs (déterministe, critere de parite), (c) le temps wall-clock (informatif, varie avec le runtime).
+",,,,,,,,7c9f69979a0c8dbc,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-20b-SudokuBenchmark-CSharp.ipynb,30627437693f,code,fr,7f719926654aaebd,"// Wrapper pour uniformiser la signature des 4 solveurs dans le benchmark.
 static (bool ok, double ms, int calls) RunByName(string sname, int[,] grid) => sname switch
 {
@@ -9648,19 +9648,19 @@ foreach (var diffName in DIFFICULTIES)
     }
 }
 ",,,,,,,,7f719926654aaebd,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-20b-SudokuBenchmark-CSharp.ipynb,098003f5dc6b,markdown,fr,a1a5d335c76f5d2d,"---
+MyIA.AI.Notebooks/Search/Applications/CSP/App-20b-SudokuBenchmark-CSharp.ipynb,098003f5dc6b,markdown,fr,d45d297691bc985e,"---
 ## Synthese -- ce que disent les chiffres
 
 Les faits marquants (a confronter a la sortie ci-dessus) :
 
 1. **Le backtracking naif explose sur les grilles difficiles** : le facteur de branchement 9 (essai de 1..9 dans l'ordre) sans aucune coupe produit un arbre gigantesque (879 418 appels sur Hard).
-2. **MRV divise drastiquement le nombre d'appels** : en choisissant la case la plus contrainte, on remplit les singletons immediatement et on coupe les branches mortes tres tot (Hard passe de 879 418 a 5 565 appels).
+2. **MRV divise drastiquement le nombre d'appels** : en choisissant la case la plus contrainte, on remplit les singletons immediatement et on coupe les branches mortes très tot (Hard passe de 879 418 a 5 565 appels).
 3. **AC-3 ajoute une propagation pre-recherche** : la consistance d'arc reduit les domaines avant le backtracking. Sur Easy/Medium le nombre d'appels est faible, mais sur Hard la propagation ne suffit pas a eviter l'explosion (981 113 appels).
-4. **DLX est dans une autre categorie** : la formulation exact-cover + Dancing Links visite un nombre de nœuds independant des heuristiques de choix de variable, et chaque operation est O(1). Sur Hard, DLX resout en une fraction de milliseconde la ou le naif met des centaines.
+4. **DLX est dans une autre catégorie** : la formulation exact-cover + Dancing Links visite un nombre de nœuds indépendant des heuristiques de choix de variable, et chaque opération est O(1). Sur Hard, DLX resout en une fraction de milliseconde la ou le naif met des centaines.
 
 ### Parite Python / C# (critere = nombre d'appels recursifs)
 
-Les trois solveurs deterministes (naif, MRV, AC-3) visitent **exactement le meme nombre de nœuds** en C# et en Python :
+Les trois solveurs déterministes (naif, MRV, AC-3) visitent **exactement le même nombre de nœuds** en C# et en Python :
 
 | Grille | Naif | MRV | AC-3 |
 |--------|------|-----|------|
@@ -9668,24 +9668,24 @@ Les trois solveurs deterministes (naif, MRV, AC-3) visitent **exactement le meme
 | Medium | 55   | 46  | 82   |
 | Hard   | 879418 | 5565 | 981113 |
 
-Ces comptes concordent au **nombre pres** entre les deux langages : c'est le critere de parite (algorithme deterministe).
+Ces comptes concordent au **nombre pres** entre les deux langages : c'est le critere de parite (algorithme déterministe).
 
 ### Ecart runtime : C# .NET vs CPython (G.1 cross-langage, documente honnetement)
 
 Le **temps** wall-clock varie avec le runtime, et cet ecart a un effet visible sur le benchmark :
 
-- **Hard, AC-3** : le Python original **timeout** (75 s > budget 60 s, `succes=False`) apres 981 113 appels. Ce twin C# **termine sous le budget** (~1,7 s) avec le **meme nombre d'appels** (981 113). La difference de succes apparente (False cote Python, True cote C#) n'est **pas** un bug : elle reflete l'avantage du JIT .NET sur CPython pour les boucles tight. Le critere de parite (nombre d'appels) est respecte ; le temps, lui, est runtime-dependant.
-- De meme, le naif sur Hard met ~12 s en Python et ~0,3 s en C# (facteur ~35), meme arbre de recherche.
+- **Hard, AC-3** : le Python original **timeout** (75 s > budget 60 s, `succes=False`) après 981 113 appels. Ce twin C# **termine sous le budget** (~1,7 s) avec le **même nombre d'appels** (981 113). La différence de succes apparente (False cote Python, True cote C#) n'est **pas** un bug : elle reflete l'avantage du JIT .NET sur CPython pour les boucles tight. Le critere de parite (nombre d'appels) est respecte ; le temps, lui, est runtime-dependant.
+- De même, le naif sur Hard met ~12 s en Python et ~0,3 s en C# (facteur ~35), même arbre de recherche.
 
 Le point pedagogique (l'explosion combinatoire du naif, le gain de MRV, la superieur asymptotique de DLX) est **identique** dans les deux langages ; seul le mur de temps (le budget de 60 s) est franchi ou non selon le runtime.
-",,,,,,,,a1a5d335c76f5d2d,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-20b-SudokuBenchmark-CSharp.ipynb,094af356784a,markdown,fr,4d2986684b81f258,"---
+",,,,,,,,d45d297691bc985e,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-20b-SudokuBenchmark-CSharp.ipynb,094af356784a,markdown,fr,feaf3a6a7dccd785,"---
 ## 5. Exercices
 
 ### Exercice 1 -- Propagation unitaire (unit propagation)
 
-Avant le backtracking, on peut propager les **singletons** : toute case vide dont une seule valeur est possible doit etre remplie immediatement, et cela peut creer de nouveaux singletons (propagation en chaine). Implementez `UnitPropagation(grid)` qui remplit iterativement ces cases et retourne le nombre de remplissages effectues. Comparez ensuite le nombre d'appels de `RunBacktracking` avant et apres propagation unitaire sur la grille Hard.
-",,,,,,,,4d2986684b81f258,,,,,,,
+Avant le backtracking, on peut propager les **singletons** : toute case vide dont une seule valeur est possible doit etre remplie immediatement, et cela peut créer de nouveaux singletons (propagation en chaîne). Implementez `UnitPropagation(grid)` qui remplit iterativement ces cases et retourne le nombre de remplissages effectues. Comparez ensuite le nombre d'appels de `RunBacktracking` avant et après propagation unitaire sur la grille Hard.
+",,,,,,,,feaf3a6a7dccd785,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-20b-SudokuBenchmark-CSharp.ipynb,7d6acedcbc20,code,fr,2ee7f5030ec79ad1,"// Exercice 1 : propagation unitaire. Retourne le nombre de cases remplies, ou -1 si contradiction.
 static int UnitPropagation(int[,] grid)
 {
@@ -9711,10 +9711,10 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-20b-SudokuBenchmark-CSharp.ipynb,b
 // Etape 3 : RunDLX retourne (ok, ms, nodesVisited) au lieu de (ok, ms, 0).
 Console.WriteLine(""Exercice a completer -- instrumentation DLX (voir commentaire ci-dessus)."");
 ",,,,,,,,65a4c6b5ae923a30,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-20b-SudokuBenchmark-CSharp.ipynb,d67783a9578f,markdown,fr,78809f824ec6a2e0,"### Exercice 3 -- Generation de grilles de difficulte controlee
+MyIA.AI.Notebooks/Search/Applications/CSP/App-20b-SudokuBenchmark-CSharp.ipynb,d67783a9578f,markdown,fr,dc1e3eaa781e8743,"### Exercice 3 -- Generation de grilles de difficulte controlee
 
-Ecrivez un generateur qui produit une grille de difficulte parametree : (1) resoudre une grille vide avec un solveur pour obtenir une solution complete, (2) retirer k cases au hasard tout en verifier (par re-solution) que la grille reste a solution unique. Le parametre k controle la difficulte. Indice : utiliser `RunBacktracking` comme oracle d'unicite.
-",,,,,,,,78809f824ec6a2e0,,,,,,,
+Ecrivez un générateur qui produit une grille de difficulte parametree : (1) resoudre une grille vide avec un solveur pour obtenir une solution complete, (2) retirer k cases au hasard tout en verifier (par re-solution) que la grille reste a solution unique. Le paramètre k contrôle la difficulte. Indice : utiliser `RunBacktracking` comme oracle d'unicite.
+",,,,,,,,dc1e3eaa781e8743,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-20b-SudokuBenchmark-CSharp.ipynb,e7dcfa7ce515,code,fr,94eafa224cbbf6c4,"// Exercice 3 : generation de grille a difficulte controlee.
 static int[,] GeneratePuzzle(int k, int seed)
 {
@@ -9729,7 +9729,7 @@ static int[,] GeneratePuzzle(int k, int seed)
 
 Console.WriteLine(""Exercice 3 : methode GeneratePuzzle definie (stub). A implementer."");
 ",,,,,,,,94eafa224cbbf6c4,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-20b-SudokuBenchmark-CSharp.ipynb,2fc6ad9c5164,markdown,fr,e03cfc58d90fde43,"---
+MyIA.AI.Notebooks/Search/Applications/CSP/App-20b-SudokuBenchmark-CSharp.ipynb,2fc6ad9c5164,markdown,fr,e4643c856346e968,"---
 ## Conclusion
 
 Ce twin C# a reconstruit depuis zero les quatre solveurs Sudoku du notebook Python :
@@ -9742,17 +9742,17 @@ Ce twin C# a reconstruit depuis zero les quatre solveurs Sudoku du notebook Pyth
 ### Parite Python / C#
 
 - Les **trois grilles** (Easy/Medium/Hard) sont strictement identiques ;
-- Le **nombre d'appels recursifs** (naif, MRV, AC-3) concorde exactement entre les deux langages (tableau §4) : c'est le critere de parite (algorithme deterministe) ;
+- Le **nombre d'appels recursifs** (naif, MRV, AC-3) concorde exactement entre les deux langages (tableau §4) : c'est le critere de parite (algorithme déterministe) ;
 - Le **temps** wall-clock varie avec le runtime (C# .NET JIT ~35x plus rapide que CPython sur le naif Hard), ce n'est pas un critere de parite ;
-- **Ecart runtime documente** : sur Hard+AC-3, le Python original timeout (75 s > 60 s) alors que ce twin C# termine (~1,7 s) avec le meme nombre d'appels (981 113). La difference de succes apparente est un effet purement runtime, pas un bug.
+- **Ecart runtime documente** : sur Hard+AC-3, le Python original timeout (75 s > 60 s) alors que ce twin C# termine (~1,7 s) avec le même nombre d'appels (981 113). La différence de succes apparente est un effet purement runtime, pas un bug.
 
 ### Ponts inter-series
 
 - **Dancing Links / couverture exacte** : cf. la formalisation DLX dans la serie Search et l'algorithme X de Knuth (cf. App-11 Picross pour une autre application de DLX) ;
-- **AC-3 / propagation de contraintes** : cf. [Partie 2 (CSP)](../../Part2-CSP/README.md) pour la theorie de la consistance d'arc ;
-- **App-20 Python** : la version originale avec la stdlib Python donne les memes nombres d'appels.
+- **AC-3 / propagation de contraintes** : cf. [Partie 2 (CSP)](../../Part2-CSP/README.md) pour la théorie de la consistance d'arc ;
+- **App-20 Python** : la version originale avec la stdlib Python donne les mêmes nombres d'appels.
 
-### Prochaines etapes
+### Prochaines étapes
 
 - Implementer les exercices (propagation unitaire, instrumentation DLX, generation de grilles) ;
 - Comparer DLX au backtracking sur des grilles 16x16 ou 25x25 (ou l'ecart s'elargit) ;
@@ -9763,7 +9763,7 @@ Ce twin C# a reconstruit depuis zero les quatre solveurs Sudoku du notebook Pyth
 [<< App-20 Python](App-20-SudokuBenchmark-Python.ipynb) | [Index](../../README.md) | [App-7 Wordle >>](App-7-Wordle.ipynb)
 
 *Marathon #4956 -- parite .NET / Python, volet Search / Applications / CSP.*
-",,,,,,,,e03cfc58d90fde43,,,,,,,
+",,,,,,,,e4643c856346e968,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-2b-GraphColoring-CSharp.ipynb,e3f8db16-dec3-4bc7-b5c6-73f276281201,markdown,fr,181389bee4bc8d70,"# App-2b : Coloration de graphes — Jumeau C#
 
 > **Twin C#** de [`App-2-GraphColoring`](App-2-GraphColoring.ipynb) (Python + networkx + OR-Tools CP-SAT + matplotlib).
@@ -10090,11 +10090,11 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-2b-GraphColoring-CSharp.ipynb,edd6
 // Etape 2 : mesurer chaque heuristique, identifier laquelle s'écarte de χ.
 Show(""Exercice 2 à compléter — identifier l'heuristique sub-optimale sur un 3-régulier."");
 ",,,,,,,,c5e94555e03adc84,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-2b-GraphColoring-CSharp.ipynb,a56ef475-17da-406c-af61-94fbed26fce8,markdown,fr,6882eeee71142682,"### Exercice 3 : implémenter la coloration par saturation (RLF)
+MyIA.AI.Notebooks/Search/Applications/CSP/App-2b-GraphColoring-CSharp.ipynb,a56ef475-17da-406c-af61-94fbed26fce8,markdown,fr,c323a30807ae324d,"### Exercice 3 : implémenter la coloration par saturation (RLF)
 
-DSATUR est une heuristique de saturation **séquentielle**. Une alternative plus forte est **RLF** (Recursive Largest First) : on construit une couleur à la fois en sélectionnant itérativement le sommet non-adjacent le plus contraint. Implémenter RLF et comparer sa qualité à DSATUR sur M_4 et M_5.
+DSATUR est une heuristique de saturation **séquentielle**. Une alternative plus forte est **RLF** (Récursive Largest First) : on construit une couleur à la fois en sélectionnant itérativement le sommet non-adjacent le plus contraint. Implémenter RLF et comparer sa qualité à DSATUR sur M_4 et M_5.
 
-> **Indice** : pour chaque couleur, maintenir l'ensemble des sommets « disponibles » (non adjacents aux déjà-coloriés de cette couleur) et choisir dedans le max de voisins déjà interdits.",,,,,,,,6882eeee71142682,,,,,,,
+> **Indice** : pour chaque couleur, maintenir l'ensemble des sommets « disponibles » (non adjacents aux déjà-coloriés de cette couleur) et choisir dedans le max de voisins déjà interdits.",,,,,,,,c323a30807ae324d,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-2b-GraphColoring-CSharp.ipynb,ab37891b-c298-459b-ac7f-c719ba78042a,code,fr,d1307aca4e4727f4,"// Exercice 3 : RLF (Recursive Largest First) — une couleur à la fois
 // Etape 1 : pour chaque couleur c, partir d'un sommet, ajouter itérativement le sommet
 //           non-adjacent aux coloriés-c qui a le plus de voisins déjà interdits.
@@ -10121,17 +10121,17 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,62a43efe,c
 BATCH_MODE = ""true""
 
 print(f""BATCH_MODE = {BATCH_MODE}"")",,,,,,,,184ec71aef0df721,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-header,markdown,fr,90d9c38379e376c1,"# App-3 : Nurse Scheduling (Planification des horaires infirmiers)
+MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-header,markdown,fr,51e1fa2ac7d2df47,"# App-3 : Nurse Scheduling (Planification des horaires infirmiers)
 
 **Navigation** : [<< App-2 GraphColoring](App-2-GraphColoring.ipynb) | [Index](../README.md) | [App-4 JobShopScheduling >>](App-4-JobShopScheduling.ipynb)
 
 ## Objectifs d'apprentissage
 
 A la fin de ce notebook, vous saurez :
-1. **Modeliser** le Nurse Rostering Problem (NRP) comme un probleme de satisfaction de contraintes
-2. **Distinguer** contraintes dures (obligatoires) et souples (preferences)
-3. **Implementer** un modele CP-SAT complet avec OR-Tools
-4. **Optimiser** un planning en minimisant les penalites (equilibre de charge, preferences)
+1. **Modeliser** le Nurse Rostering Problem (NRP) comme un problème de satisfaction de contraintes
+2. **Distinguer** contraintes dures (obligatoires) et souples (préférences)
+3. **Implementer** un modèle CP-SAT complet avec OR-Tools
+4. **Optimiser** un planning en minimisant les penalites (equilibre de charge, préférences)
 5. **Visualiser** et analyser la qualite d'un planning infirmier
 
 ### Prerequis
@@ -10142,14 +10142,14 @@ A la fin de ce notebook, vous saurez :
 ### Duree estimee : 60 minutes
 
 ### Source
-Adapte du projet etudiant EPITA PPC 2025 (Nurse Rostering Problem, jsboigeEpita/2025-PPC).",,,,,,,,90d9c38379e376c1,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-intro-section,markdown,fr,e8a0dbed1b487383,"---
+Adapte du projet etudiant EPITA PPC 2025 (Nurse Rostering Problem, jsboigeEpita/2025-PPC).",,,,,,,,51e1fa2ac7d2df47,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-intro-section,markdown,fr,a2b641f5472efff6,"---
 
 ## 1. Introduction (~5 min)
 
-Le **Nurse Rostering Problem** (NRP) consiste a affecter des equipes (shifts) a un ensemble d'infirmiers sur un horizon de planification, en respectant la reglementation du travail, les besoins en personnel et les preferences individuelles.
+Le **Nurse Rostering Problem** (NRP) consiste a affecter des équipes (shifts) a un ensemble d'infirmiers sur un horizon de planification, en respectant la reglementation du travail, les besoins en personnel et les préférences individuelles.
 
-### Pourquoi ce probleme est important
+### Pourquoi ce problème est important
 
 | Aspect | Impact |
 |--------|--------|
@@ -10157,14 +10157,14 @@ Le **Nurse Rostering Problem** (NRP) consiste a affecter des equipes (shifts) a 
 | **Reglementation** | Les lois du travail imposent des contraintes strictes (repos, duree max) |
 | **Equite** | Les infirmiers doivent percevoir la repartition comme juste |
 | **Complexite** | NP-hard des que l'on depasse quelques infirmiers et quelques jours |
-| **Volume** | Des milliers d'hopitaux doivent resoudre ce probleme chaque mois |
+| **Volume** | Des milliers d'hopitaux doivent resoudre ce problème chaque mois |
 
 ### Approche
 
-Nous allons progresser en trois etapes :
-1. **Modele de base** : 5 infirmiers, 7 jours, contraintes dures uniquement
-2. **Optimisation** : ajout de contraintes souples (equilibre, preferences) avec fonction objectif
-3. **Passage a l'echelle** : 15 infirmiers, 28 jours, parametres avances du solveur",,,,,,,,e8a0dbed1b487383,,,,,,,
+Nous allons progresser en trois étapes :
+1. **Modèle de base** : 5 infirmiers, 7 jours, contraintes dures uniquement
+2. **Optimisation** : ajout de contraintes souples (equilibre, préférences) avec fonction objectif
+3. **Passage a l'echelle** : 15 infirmiers, 28 jours, paramètres avances du solveur",,,,,,,,a2b641f5472efff6,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-imports-intro,markdown,fr,0745782cc5fcca35,"### Installation et imports
 
 Nous utilisons **OR-Tools** de Google, la bibliotheque de reference pour la programmation par contraintes et l'optimisation. Le solveur CP-SAT est particulierement adapte aux problemes de planification.",,,,,,,,0745782cc5fcca35,,,,,,,
@@ -10184,24 +10184,24 @@ from search_helpers import benchmark_table
 
 print(f""OR-Tools version : {cp_model.__name__}"")
 print(""Imports OK"")",,,,,,,,d308b69c91149773,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-formulation-section,markdown,fr,9e7cbb550766a4d9,"---
+MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-formulation-section,markdown,fr,f9ef8ab62c678cee,"---
 
-## 2. Formulation du probleme (~8 min)
+## 2. Formulation du problème (~8 min)
 
-### Donnees du probleme
+### Données du problème
 
 Nous commencons par un cas de taille modeste pour bien comprendre la modelisation.
 
-| Parametre | Valeur |
+| Paramètre | Valeur |
 |-----------|--------|
 | Infirmiers | 5 (Alice, Bob, Claire, David, Emma) |
 | Jours | 7 (lundi a dimanche) |
-| Equipes (shifts) | 3 : Matin (M), Apres-midi (A), Nuit (N) |
+| Équipes (shifts) | 3 : Matin (M), Après-midi (A), Nuit (N) |
 | Besoin par shift | Exactement 1 infirmier par shift par jour |
 
 ### Variables de decision
 
-Pour chaque triplet (infirmier $n$, jour $d$, shift $s$), on definit une variable booleenne :
+Pour chaque triplet (infirmier $n$, jour $d$, shift $s$), on définit une variable booleenne :
 
 $$x_{n,d,s} \in \{0, 1\}$$
 
@@ -10214,8 +10214,8 @@ ou $x_{n,d,s} = 1$ signifie que l'infirmier $n$ travaille le shift $s$ le jour $
 | # | Contrainte | Formulation |
 |---|------------|-------------|
 | C1 | **Couverture** | Chaque shift de chaque jour doit etre assure par exactement 1 infirmier : $\sum_n x_{n,d,s} = 1$ |
-| C2 | **Unicite** | Un infirmier ne peut pas travailler 2 shifts le meme jour : $\sum_s x_{n,d,s} \leq 1$ |
-| C3 | **Repos** | Pas de shift Matin apres un shift Nuit (repos obligatoire) |
+| C2 | **Unicite** | Un infirmier ne peut pas travailler 2 shifts le même jour : $\sum_s x_{n,d,s} \leq 1$ |
+| C3 | **Repos** | Pas de shift Matin après un shift Nuit (repos obligatoire) |
 | C4 | **Charge max** | Maximum 5 shifts par semaine par infirmier : $\sum_{d,s} x_{n,d,s} \leq 5$ |
 
 ### Contraintes souples (a optimiser)
@@ -10223,10 +10223,10 @@ ou $x_{n,d,s} = 1$ signifie que l'infirmier $n$ travaille le shift $s$ le jour $
 | # | Contrainte | Objectif |
 |---|------------|----------|
 | S1 | **Equilibre de charge** | Minimiser l'ecart de nombre de shifts entre infirmiers |
-| S2 | **Preferences** | Respecter les preferences individuelles (ex : pas de weekend) |",,,,,,,,9e7cbb550766a4d9,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-data-intro,markdown,fr,1d5a5df2ea77b9db,"### Definition des donnees
+| S2 | **Préférences** | Respecter les préférences individuelles (ex : pas de weekend) |",,,,,,,,f9ef8ab62c678cee,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-data-intro,markdown,fr,903137d40eac9f79,"### Definition des données
 
-Definissons les constantes du probleme et les preferences des infirmiers.",,,,,,,,1d5a5df2ea77b9db,,,,,,,
+Definissons les constantes du problème et les préférences des infirmiers.",,,,,,,,903137d40eac9f79,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-data,code,fr,426fe204203d1f04,"# --- Donnees du probleme ---
 
 # Infirmiers
@@ -10286,15 +10286,15 @@ for n in range(num_nurses):
         print(f""  {nurses[n]:>8} : eviter {pref_str}"")
     else:
         print(f""  {nurses[n]:>8} : aucune preference"")",,,,,,,,426fe204203d1f04,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-hard-section,markdown,fr,c7af79c2e8c39246,"---
+MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-hard-section,markdown,fr,c5fe7808136ba1a5,"---
 
-## 3. Modele CP-SAT - Contraintes dures (~12 min)
+## 3. Modèle CP-SAT - Contraintes dures (~12 min)
 
-Nous construisons le modele CP-SAT etape par etape. Le solveur CP-SAT d'OR-Tools est un solveur de programmation par contraintes base sur la satisfiabilite (SAT). Il est particulierement efficace pour les problemes de planification.
+Nous construisons le modèle CP-SAT étape par étape. Le solveur CP-SAT d'OR-Tools est un solveur de programmation par contraintes base sur la satisfiabilite (SAT). Il est particulierement efficace pour les problemes de planification.
 
-**Etape 1 : creation des variables**
+**Étape 1 : creation des variables**
 
-Pour chaque combinaison (infirmier, jour, shift), on cree une variable booleenne.",,,,,,,,c7af79c2e8c39246,,,,,,,
+Pour chaque combinaison (infirmier, jour, shift), on créé une variable booleenne.",,,,,,,,c5fe7808136ba1a5,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-variables,code,fr,eddb26e96c545db5,"# --- Construction du modele CP-SAT ---
 
 model = cp_model.CpModel()
@@ -10308,11 +10308,11 @@ for n in range(num_nurses):
 
 print(f""Variables creees : {len(x)} variables booleennes"")
 print(f""Exemple : x[(0, 0, 0)] = '{x[(0, 0, 0)]}' (Alice, Lundi, Matin)"")",,,,,,,,eddb26e96c545db5,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-c1-intro,markdown,fr,49ce7d038379a96f,"**Etape 2 : contrainte de couverture (C1)**
+MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-c1-intro,markdown,fr,981e7b5045275702,"**Étape 2 : contrainte de couverture (C1)**
 
 Chaque shift de chaque jour doit etre assure par exactement 1 infirmier :
 
-$$\forall d \in \text{Jours}, \forall s \in \text{Shifts} : \sum_{n=1}^{N} x_{n,d,s} = 1$$",,,,,,,,49ce7d038379a96f,,,,,,,
+$$\forall d \in \text{Jours}, \forall s \in \text{Shifts} : \sum_{n=1}^{N} x_{n,d,s} = 1$$",,,,,,,,981e7b5045275702,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-c1,code,fr,ccd3e29cd746eb39,"# C1 : Couverture - exactement 1 infirmier par shift par jour
 num_coverage = 0
 for d in range(num_days):
@@ -10321,11 +10321,11 @@ for d in range(num_days):
         num_coverage += 1
 
 print(f""C1 - Contraintes de couverture : {num_coverage}"")",,,,,,,,ccd3e29cd746eb39,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-c2-intro,markdown,fr,c13d6075dcabdc05,"**Etape 3 : contrainte d'unicite (C2)**
+MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-c2-intro,markdown,fr,dcab7da308fc29e4,"**Étape 3 : contrainte d'unicite (C2)**
 
 Un infirmier ne peut travailler qu'un seul shift par jour (ou aucun) :
 
-$$\forall n \in \text{Infirmiers}, \forall d \in \text{Jours} : \sum_{s=1}^{S} x_{n,d,s} \leq 1$$",,,,,,,,c13d6075dcabdc05,,,,,,,
+$$\forall n \in \text{Infirmiers}, \forall d \in \text{Jours} : \sum_{s=1}^{S} x_{n,d,s} \leq 1$$",,,,,,,,dcab7da308fc29e4,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-c2,code,fr,991c4818d7976223,"# C2 : Unicite - au plus 1 shift par jour par infirmier
 num_unique = 0
 for n in range(num_nurses):
@@ -10334,13 +10334,13 @@ for n in range(num_nurses):
         num_unique += 1
 
 print(f""C2 - Contraintes d'unicite : {num_unique}"")",,,,,,,,991c4818d7976223,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-c3-intro,markdown,fr,4052e41330d113d1,"**Etape 4 : contrainte de repos (C3)**
+MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-c3-intro,markdown,fr,6aaf641677889c36,"**Étape 4 : contrainte de repos (C3)**
 
-Apres un shift de nuit, l'infirmier ne peut pas travailler le matin du jour suivant (repos obligatoire d'au moins 8h) :
+Après un shift de nuit, l'infirmier ne peut pas travailler le matin du jour suivant (repos obligatoire d'au moins 8h) :
 
 $$\forall n, \forall d < D-1 : x_{n,d,\text{Nuit}} + x_{n,d+1,\text{Matin}} \leq 1$$
 
-Cela signifie que les deux variables ne peuvent pas etre simultanement a 1.",,,,,,,,4052e41330d113d1,,,,,,,
+Cela signifie que les deux variables ne peuvent pas etre simultanement a 1.",,,,,,,,6aaf641677889c36,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-c3,code,fr,4b502b5ee75e51f1,"# C3 : Repos - pas de Matin apres une Nuit
 num_rest = 0
 for n in range(num_nurses):
@@ -10350,11 +10350,11 @@ for n in range(num_nurses):
         num_rest += 1
 
 print(f""C3 - Contraintes de repos : {num_rest}"")",,,,,,,,4b502b5ee75e51f1,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-c4-intro,markdown,fr,d8a8068ffb6ede3c,"**Etape 5 : contrainte de charge maximale (C4)**
+MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-c4-intro,markdown,fr,0a7ae4ea72493bcd,"**Étape 5 : contrainte de charge maximale (C4)**
 
 Chaque infirmier travaille au maximum 5 shifts par semaine :
 
-$$\forall n : \sum_{d,s} x_{n,d,s} \leq 5$$",,,,,,,,d8a8068ffb6ede3c,,,,,,,
+$$\forall n : \sum_{d,s} x_{n,d,s} \leq 5$$",,,,,,,,0a7ae4ea72493bcd,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-c4,code,fr,c87355d433ca7f42,"# C4 : Charge maximale - au plus 5 shifts par semaine
 num_maxload = 0
 for n in range(num_nurses):
@@ -10373,9 +10373,9 @@ print(f""C2 (unicite)      : {num_unique}"")
 print(f""C3 (repos)        : {num_rest}"")
 print(f""C4 (charge max)   : {num_maxload}"")
 print(f""Total contraintes : {num_coverage + num_unique + num_rest + num_maxload}"")",,,,,,,,c87355d433ca7f42,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-solve-hard-intro,markdown,fr,dc699140a7ac2608,"### Resolution et affichage du planning
+MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-solve-hard-intro,markdown,fr,db807a2dc38a701f,"### Resolution et affichage du planning
 
-Resolvons le modele avec les contraintes dures uniquement (sans optimisation). Le solveur CP-SAT va chercher une solution faisable.",,,,,,,,dc699140a7ac2608,,,,,,,
+Resolvons le modèle avec les contraintes dures uniquement (sans optimisation). Le solveur CP-SAT va chercher une solution faisable.",,,,,,,,db807a2dc38a701f,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-solve-hard,code,fr,36dfddfb196c1acb,"# --- Resolution (contraintes dures uniquement) ---
 
 solver = cp_model.CpSolver()
@@ -10432,7 +10432,7 @@ if status in (cp_model.OPTIMAL, cp_model.FEASIBLE):
     )
 else:
     print(""Aucune solution trouvee !"")",,,,,,,,98e8e10ecdf996ee,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-interpret-hard,markdown,fr,00889a67a67a4155,"### Interpretation : modele avec contraintes dures
+MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-interpret-hard,markdown,fr,000827040eb7581e,"### Interpretation : modèle avec contraintes dures
 
 **Sortie obtenue** : le solveur trouve un planning faisable qui respecte toutes les contraintes obligatoires.
 
@@ -10445,32 +10445,32 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-inter
 
 **Points cles** :
 1. Le planning est **faisable** mais pas necessairement **equitable** : certains infirmiers peuvent avoir beaucoup plus de shifts que d'autres
-2. Les **preferences** individuelles ne sont pas prises en compte
-3. Le solveur trouve la premiere solution faisable, sans chercher a optimiser
+2. Les **préférences** individuelles ne sont pas prises en compte
+3. Le solveur trouve la première solution faisable, sans chercher a optimiser
 
-> **Question** : comment rendre le planning plus equitable et respectueux des preferences ? C'est le role des contraintes souples.",,,,,,,,00889a67a67a4155,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-soft-section,markdown,fr,7602fee38f98fdfc,"---
+> **Question** : comment rendre le planning plus equitable et respectueux des préférences ? C'est le rôle des contraintes souples.",,,,,,,,000827040eb7581e,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-soft-section,markdown,fr,522a3e44b7a5e6be,"---
 
 ## 4. Ajout des contraintes souples (~10 min)
 
 Les contraintes souples ne sont pas obligatoires, mais on souhaite les satisfaire autant que possible. On les modelise comme des **penalites** dans une fonction objectif a minimiser.
 
-### Strategie d'optimisation
+### Stratégie d'optimisation
 
-$$\text{Minimiser } Z = w_1 \cdot P_{\text{equilibre}} + w_2 \cdot P_{\text{preferences}}$$
+$$\text{Minimiser } Z = w_1 \cdot P_{\text{equilibre}} + w_2 \cdot P_{\text{préférences}}$$
 
 | Penalite | Formulation | Poids |
 |----------|-------------|-------|
-| $P_{\text{equilibre}}$ | Difference entre charge max et charge min parmi tous les infirmiers | $w_1 = 10$ |
-| $P_{\text{preferences}}$ | Nombre de preferences non respectees | $w_2 = 2$ |
+| $P_{\text{equilibre}}$ | Différence entre charge max et charge min parmi tous les infirmiers | $w_1 = 10$ |
+| $P_{\text{préférences}}$ | Nombre de préférences non respectees | $w_2 = 2$ |
 
 ### Penalite d'equilibre de charge
 
-Pour mesurer le desequilibre, on utilise la difference entre la charge maximale et la charge minimale :
+Pour mesurer le desequilibre, on utilise la différence entre la charge maximale et la charge minimale :
 
 $$P_{\text{equilibre}} = \max_n \left(\sum_{d,s} x_{n,d,s}\right) - \min_n \left(\sum_{d,s} x_{n,d,s}\right)$$
 
-En CP-SAT, on ne peut pas utiliser directement `max` et `min` sur des expressions. On utilise des **variables auxiliaires** avec `add_max_equality` et `add_min_equality`.",,,,,,,,7602fee38f98fdfc,,,,,,,
+En CP-SAT, on ne peut pas utiliser directement `max` et `min` sur des expressions. On utilise des **variables auxiliaires** avec `add_max_equality` et `add_min_equality`.",,,,,,,,522a3e44b7a5e6be,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-model-soft,code,fr,314510142c944077,"# --- Nouveau modele avec contraintes dures + souples ---
 
 model_opt = cp_model.CpModel()
@@ -10586,7 +10586,7 @@ if status_opt in (cp_model.OPTIMAL, cp_model.FEASIBLE):
     shift_counts_opt = display_schedule(
         solver_opt, x_opt, nurses, days, shifts, num_nurses, num_days, num_shifts
     )",,,,,,,,590e9752e97bc6d6,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-interpret-soft,markdown,fr,1bb582e5a63608f5,"### Interpretation : modele avec contraintes souples
+MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-interpret-soft,markdown,fr,6490b1fa91d38c3e,"### Interpretation : modèle avec contraintes souples
 
 **Sortie obtenue** : le solveur trouve un planning optimal qui minimise les penalites.
 
@@ -10594,14 +10594,14 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-inter
 |--------|-------------------|-------------------|
 | Contraintes dures | Toutes respectees | Toutes respectees |
 | Equilibre de charge | Non garanti | Ecart minimise |
-| Preferences | Non prises en compte | Maximalement respectees |
+| Préférences | Non prises en compte | Maximalement respectees |
 
 **Points cles** :
 1. L'ecart de charge entre l'infirmier le plus et le moins charge est minimise
-2. Les preferences sont respectees autant que possible, dans la limite des contraintes dures
-3. Il y a un **compromis** entre equilibre et preferences : on ne peut pas toujours satisfaire les deux parfaitement
+2. Les préférences sont respectees autant que possible, dans la limite des contraintes dures
+3. Il y a un **compromis** entre equilibre et préférences : on ne peut pas toujours satisfaire les deux parfaitement
 
-> **Note technique** : les poids $w_1 = 10$ et $w_2 = 2$ refletent l'importance relative de l'equilibre par rapport aux preferences. Ajuster ces poids change le compromis.",,,,,,,,1bb582e5a63608f5,,,,,,,
+> **Note technique** : les poids $w_1 = 10$ et $w_2 = 2$ refletent l'importance relative de l'equilibre par rapport aux préférences. Ajuster ces poids change le compromis.",,,,,,,,6490b1fa91d38c3e,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-compare-intro,markdown,fr,a451cb60477610b6,"### Comparaison des deux plannings
 
 Comparons visuellement les plannings avec et sans optimisation.",,,,,,,,a451cb60477610b6,,,,,,,
@@ -10681,23 +10681,23 @@ fig.legend(handles=legend_elements, loc='lower center', ncol=4, fontsize=10,
 plt.tight_layout()
 plt.subplots_adjust(bottom=0.12)
 plt.show()",,,,,,,,aa3509c4388e49e7,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-interpret-compare,markdown,fr,6462ccc0053a4c6f,"### Interpretation : comparaison visuelle
+MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-interpret-compare,markdown,fr,ac51da741c901c3a,"### Interpretation : comparaison visuelle
 
-**Sortie obtenue** : les deux grilles montrent la difference entre un planning faisable (a gauche) et un planning optimise (a droite).
+**Sortie obtenue** : les deux grilles montrent la différence entre un planning faisable (a gauche) et un planning optimise (a droite).
 
 **Points cles** :
 1. **Equilibre** : dans le planning optimise, les shifts sont mieux repartis (colonnes de droite du tableau plus uniformes)
-2. **Preferences** : le planning optimise evite autant que possible les creneaux non desires
-3. **Nuits** : la contrainte de repos (pas de M apres N) est visible dans les deux grilles
+2. **Préférences** : le planning optimise evite autant que possible les creneaux non desires
+3. **Nuits** : la contrainte de repos (pas de M après N) est visible dans les deux grilles
 
-> **Note** : la difference peut paraitre subtile sur 5 infirmiers / 7 jours. L'impact de l'optimisation devient bien plus visible a plus grande echelle.",,,,,,,,6462ccc0053a4c6f,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-scale-section,markdown,fr,0c58200dadc80cc9,"---
+> **Note** : la différence peut paraitre subtile sur 5 infirmiers / 7 jours. L'impact de l'optimisation devient bien plus visible a plus grande echelle.",,,,,,,,ac51da741c901c3a,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-scale-section,markdown,fr,276b1710bc929351,"---
 
 ## 5. Passage a l'echelle (~8 min)
 
-Testons la capacite du solveur CP-SAT sur un probleme plus realiste :
+Testons la capacite du solveur CP-SAT sur un problème plus realiste :
 
-| Parametre | Valeur |
+| Paramètre | Valeur |
 |-----------|--------|
 | Infirmiers | 15 |
 | Jours | 28 (4 semaines) |
@@ -10713,7 +10713,7 @@ En plus des contraintes C1-C4, nous ajoutons :
 
 ### Solution callback
 
-Pour observer la progression du solveur, on utilise un **callback** qui enregistre chaque solution ameliorante trouvee.",,,,,,,,0c58200dadc80cc9,,,,,,,
+Pour observer la progression du solveur, on utilise un **callback** qui enregistre chaque solution ameliorante trouvee.",,,,,,,,276b1710bc929351,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-scale-model,code,fr,f8112e01f276dde1,"# --- Probleme a grande echelle ---
 
 num_nurses_lg = 15
@@ -10746,7 +10746,7 @@ print(f""Shifts/jour   : {num_shifts_lg}"")
 print(f""Demande/shift : {demand_lg} infirmiers"")
 print(f""Variables     : {num_nurses_lg * num_days_lg * num_shifts_lg}"")
 print(f""Preferences   : {sum(len(v) for v in preferences_lg.values())} au total"")",,,,,,,,f8112e01f276dde1,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,wwrm0w8mc9p,markdown,fr,d0ee5b22f849fa15,"Construisons maintenant le modele CP-SAT pour ce probleme plus grand, avec les contraintes supplementaires C5 (weekend de repos) et la demande accrue (2 infirmiers par shift).",,,,,,,,d0ee5b22f849fa15,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,wwrm0w8mc9p,markdown,fr,b4eac53078ec353d,"Construisons maintenant le modèle CP-SAT pour ce problème plus grand, avec les contraintes supplementaires C5 (weekend de repos) et la demande accrue (2 infirmiers par shift).",,,,,,,,b4eac53078ec353d,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-scale-build,code,fr,78f73114831be4c0,"# --- Construction du modele a grande echelle ---
 
 model_lg = cp_model.CpModel()
@@ -10882,9 +10882,9 @@ if status_lg in (cp_model.OPTIMAL, cp_model.FEASIBLE):
     print(f""Objectif final : {solver_lg.objective_value}"")
     print(f""Ecart charge   : {solver_lg.value(balance_penalty_lg)}"")
     print(f""Prefs violees  : {solver_lg.value(total_pref_lg)} / {len(pref_violations_lg)}"")",,,,,,,,cc69f02e8c37dffe,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-interpret-scale,markdown,fr,550fe0128697c91d,"### Interpretation : passage a l'echelle
+MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-interpret-scale,markdown,fr,4a5f79852e233306,"### Interpretation : passage a l'echelle
 
-**Sortie obtenue** : le solveur resout un probleme beaucoup plus grand en moins d'une seconde (550 ms pour 1260 variables).
+**Sortie obtenue** : le solveur resout un problème beaucoup plus grand en moins d'une seconde (550 ms pour 1260 variables).
 
 | Mesure | Petit (5x7) | Grand (15x28) | Ratio |
 |--------|-------------|---------------|-------|
@@ -10894,11 +10894,11 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-inter
 
 **Points cles** :
 1. Le solveur CP-SAT est concu pour les problemes de planification : il gere bien le passage a l'echelle
-2. Le **solution callback** montre que le solveur trouve rapidement une premiere solution, puis l'ameliore progressivement
-3. Le parametre `num_workers` permet de paralleliser la recherche sur plusieurs coeurs
+2. Le **solution callback** montre que le solveur trouve rapidement une première solution, puis l'ameliore progressivement
+3. Le paramètre `num_workers` permet de paralleliser la recherche sur plusieurs coeurs
 4. Le `time_limit` est crucial en production : on prefere une bonne solution rapide a une solution optimale lente
 
-> **Note technique** : en production hospitaliere, les problemes typiques comptent 30-100 infirmiers sur 4-6 semaines, avec des dizaines de types de contraintes. CP-SAT reste utilisable jusqu'a ces tailles.",,,,,,,,550fe0128697c91d,,,,,,,
+> **Note technique** : en production hospitaliere, les problemes typiques comptent 30-100 infirmiers sur 4-6 semaines, avec des dizaines de types de contraintes. CP-SAT reste utilisable jusqu'a ces tailles.",,,,,,,,4a5f79852e233306,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-convergence-intro,markdown,fr,0d9538ea82754500,"### Courbe de convergence
 
 Visualisons la progression du solveur : comment l'objectif diminue au fil du temps.",,,,,,,,0d9538ea82754500,,,,,,,
@@ -11060,30 +11060,30 @@ if status_lg in (cp_model.OPTIMAL, cp_model.FEASIBLE):
     pref_rate = (1 - n_pref_violated / n_pref_total) * 100 if n_pref_total > 0 else 100
     print(f""\nPreferences       : {n_pref_violated} violees / {n_pref_total}"")
     print(f""Taux satisfaction : {pref_rate:.1f}%"")",,,,,,,,b54fc51699139b4d,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-interpret-viz,markdown,fr,8110c7d1ee88210f,"### Interpretation : qualite du planning
+MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-interpret-viz,markdown,fr,c1ea3196ae392b27,"### Interpretation : qualite du planning
 
 **Sortie obtenue** : les graphiques montrent la repartition de la charge de travail entre les 15 infirmiers.
 
 | Indicateur | Valeur | Qualite |
 |------------|--------|--------|
 | Ecart max-min | faible (1-2) | Bon equilibre |
-| Ecart type | < 1 | Distribution tres homogene |
-| Taux preferences | > 80% | Bonne satisfaction |
+| Ecart type | < 1 | Distribution très homogene |
+| Taux préférences | > 80% | Bonne satisfaction |
 
 **Points cles** :
 1. La **charge totale** est bien equilibree grace a la penalite S1
-2. La **repartition par type** (Matin/Apres-midi/Nuit) est egalement equilibree
+2. La **repartition par type** (Matin/Après-midi/Nuit) est également equilibree
 3. Les barres vertes (min) et rouges (max) permettent d'identifier les cas extremes
-4. Le taux de satisfaction des preferences depend du compromis avec les contraintes dures
+4. Le taux de satisfaction des préférences depend du compromis avec les contraintes dures
 
-> **En production** : on ajouterait des indicateurs supplementaires comme le nombre de weekends travailles, la repartition des nuits, ou des scores de fatigue accumules.",,,,,,,,8110c7d1ee88210f,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-exercises,markdown,fr,6d60e4fd436ed834,"### Exemple guide
+> **En production** : on ajouterait des indicateurs supplementaires comme le nombre de weekends travailles, la repartition des nuits, ou des scores de fatigue accumules.",,,,,,,,c1ea3196ae392b27,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-exercises,markdown,fr,a6ce04a9f5d07194,"### Exemple guide
 
 #### Exemple guide 1 : pas plus de 3 jours consecutifs de travail
 
 Ajoutez une contrainte dure C6 : aucun infirmier ne travaille plus de 3 jours consecutifs.
 
-**Indice** : pour chaque infirmier et chaque fenetre de 4 jours consecutifs $(d, d+1, d+2, d+3)$, la somme des jours travailles doit etre $\leq 3$.",,,,,,,,6d60e4fd436ed834,,,,,,,
+**Indice** : pour chaque infirmier et chaque fenêtre de 4 jours consecutifs $(d, d+1, d+2, d+3)$, la somme des jours travailles doit etre $\leq 3$.",,,,,,,,a6ce04a9f5d07194,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,4c1bda95,code,fr,e691cc2cb744369f,"# Exemple resolu : pas plus de 3 jours consecutifs
 
 for n in range(num_nurses):
@@ -11095,32 +11095,32 @@ for n in range(num_nurses):
         model.add(works[d] + works[d+1] + works[d+2] + works[d+3] <= 3)
 
 print(f""C6 (consecutifs) : {num_nurses * (num_days - 3)} contraintes pour max 3 jours consecutifs"")",,,,,,,,e691cc2cb744369f,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,ae2a8cdc,markdown,fr,1ba29754e027824a,"#### Exercice 1b : Limite de jours consecutifs configurable
+MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,ae2a8cdc,markdown,fr,37fd2ce1a65d54e4,"#### Exercice 1b : Limite de jours consecutifs configurable
 
 Generalisez la contrainte ci-dessus : ajoutez une contrainte qui limite
-a **`max_consecutive` jours consecutifs** de travail (parametre configurable).
+a **`max_consecutive` jours consecutifs** de travail (paramètre configurable).
 
 Testez avec `max_consecutive = 2` (plus strict) et `max_consecutive = 4` (plus permissif).
 
 **Consignes** :
-1. Definissez un parametre `max_consecutive` en debut de cellule
-2. Utilisez une boucle sur des fenetres glissantes de `max_consecutive + 1` jours
+1. Definissez un paramètre `max_consecutive` en debut de cellule
+2. Utilisez une boucle sur des fenêtres glissantes de `max_consecutive + 1` jours
 3. Affichez le nombre de violations potentiels pour chaque valeur testee
-",,,,,,,,1ba29754e027824a,,,,,,,
+",,,,,,,,37fd2ce1a65d54e4,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,8e2aa1a8,code,fr,5a668bba7cad5494,"# Exercice 1b : Limite de jours consecutifs configurable
 
 # Exercice: definissez max_consecutive et ajoutez la contrainte
 # Indice : reprenez le pattern de l'exemple mais rendez la taille de fenetre parametrable
 
 print(""Exercice a completer"")",,,,,,,,5a668bba7cad5494,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-exercise2,markdown,fr,49216084b85cddd2,"#### Exemple guide 2 : preferences ponderees par priorite
+MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-exercise2,markdown,fr,310e9db31e2ba694,"#### Exemple guide 2 : préférences ponderees par priorite
 
-Modelisez des preferences avec des niveaux de priorite :
+Modelisez des préférences avec des niveaux de priorite :
 - **Priorite haute** (penalite 10) : contrainte medicale, ex. pas de nuit pour un infirmier enceinte
 - **Priorite moyenne** (penalite 5) : equilibre vie perso, ex. pas de weekend
-- **Priorite basse** (penalite 1) : confort, ex. preference pour les matins
+- **Priorite basse** (penalite 1) : confort, ex. préférence pour les matins
 
-**Indice** : utilisez un dictionnaire `{(nurse, day, shift): weight}` et sommez les penalites ponderees.",,,,,,,,49216084b85cddd2,,,,,,,
+**Indice** : utilisez un dictionnaire `{(nurse, day, shift): weight}` et sommez les penalites ponderees.",,,,,,,,310e9db31e2ba694,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,8f7b37bc,code,fr,0659e0458e1d7eb5,"# Exemple resolu : preferences ponderees par priorite
 
 weighted_prefs = {
@@ -11133,29 +11133,29 @@ penalty = sum(weight * x[(n, d, s)] for (n, d, s), weight in weighted_prefs.item
 model.minimize(10 * balance_penalty + penalty)
 
 print(f""Preferences ponderees : {len(weighted_prefs)} prefs, penalites = {list(weighted_prefs.values())}"")",,,,,,,,0659e0458e1d7eb5,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,98f4351d,markdown,fr,f9b1c3a7e8e06e77,"#### Exercice 2b : Preferences avec contraintes obligatoires
+MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,98f4351d,markdown,fr,72e9fec37c86de6f,"#### Exercice 2b : Préférences avec contraintes obligatoires
 
-Certaines preferences sont en fait des **contraintes dures** (non-negociables),
-d'autres restent des preferences souples.
+Certaines préférences sont en fait des **contraintes dures** (non-negociables),
+d'autres restent des préférences souples.
 
 **Consignes** :
 1. Definissez deux dictionnaires : `hard_prefs` (contraintes, poids infini)
-   et `soft_prefs` (preferences, poids 1-10)
+   et `soft_prefs` (préférences, poids 1-10)
 2. Les `hard_prefs` doivent etre ajoutees avec `model.add(... == 0)`
 3. Les `soft_prefs` sont minimisees dans l'objectif
 4. Exemples : hard = infirmier 0 jamais de NUIT, infirmier 3 jamais le dimanche
-",,,,,,,,f9b1c3a7e8e06e77,,,,,,,
+",,,,,,,,72e9fec37c86de6f,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,e9e04944,code,fr,fb7a8584442caa25,"# Exercice 2b : Preferences avec contraintes obligatoires
 
 # Exercice: definissez hard_prefs et soft_prefs, puis ajoutez les contraintes
 # Indice : hard_prefs avec model.add(...) et soft_prefs avec model.minimize(...)
 
 print(""Exercice a completer"")",,,,,,,,fb7a8584442caa25,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-exercise3,markdown,fr,31139a60a4b22fea,"#### Exemple guide 3 : infirmiers a temps partiel
+MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-exercise3,markdown,fr,13da1b18e50b3f6f,"#### Exemple guide 3 : infirmiers a temps partiel
 
-Ajoutez la possibilite d'avoir des infirmiers a temps partiel (maximum 3 shifts par semaine au lieu de 5). Modifiez le modele pour gerer des contrats differents.
+Ajoutez la possibilite d'avoir des infirmiers a temps partiel (maximum 3 shifts par semaine au lieu de 5). Modifiez le modèle pour gerer des contrats différents.
 
-**Indice** : definissez un dictionnaire `max_shifts = {0: 5, 1: 5, 2: 3, 3: 5, 4: 3}` et utilisez-le dans la contrainte C4.",,,,,,,,31139a60a4b22fea,,,,,,,
+**Indice** : definissez un dictionnaire `max_shifts = {0: 5, 1: 5, 2: 3, 3: 5, 4: 3}` et utilisez-le dans la contrainte C4.",,,,,,,,13da1b18e50b3f6f,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,7e9c499c,code,fr,e7a83afaa6a9fc69,"# Exemple resolu : infirmiers a temps partiel
 
 max_shifts_per_nurse = {
@@ -11171,17 +11171,17 @@ for n in range(num_nurses):
     model.add(total <= max_shifts_per_nurse[n])
 
 print(f""Contraintes temps partiel ajoutees : {max_shifts_per_nurse}"")",,,,,,,,e7a83afaa6a9fc69,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,448d046a,markdown,fr,5d40a469a26f3a4a,"#### Exercice 3b : Contrats avec minimum et maximum de shifts
+MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,448d046a,markdown,fr,0d0872884909d45e,"#### Exercice 3b : Contrats avec minimum et maximum de shifts
 
 Dans la realite, les infirmiers a temps partiel ont aussi un **minimum** de shifts
-a effectuer (garantie d'emploi). Generalisez le modele.
+a effectuer (garantie d'emploi). Generalisez le modèle.
 
 **Consignes** :
 1. Definissez `contract_range = {n: (min_shifts, max_shifts) for n in range(num_nurses)}`
 2. Exemples : temps plein = (4, 5), mi-temps = (2, 3), 3/4 = (3, 4)
 3. Ajoutez les contraintes `min_shifts <= total <= max_shifts` pour chaque infirmier
 4. Verifiez que le solveur trouve une solution faisable
-",,,,,,,,5d40a469a26f3a4a,,,,,,,
+",,,,,,,,0d0872884909d45e,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,8e1dc6a6,code,fr,9b5baca3cafdc149,"# Exercice 3b : Contrats avec minimum et maximum de shifts
 
 # Exercice: definissez contract_range et ajoutez les contraintes min/max
@@ -11194,7 +11194,7 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-refer
 - [OR-Tools Nurse Scheduling Example](https://developers.google.com/optimization/scheduling/employee_scheduling) : exemple officiel Google
 - Burke, E.K. et al. *The State of the Art of Nurse Rostering*, Journal of Scheduling, 2004
 - Projet EPITA PPC 2025 : jsboigeEpita/2025-PPC (Nurse Rostering Problem)",,,,,,,,754020f20d28ebf6,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-summary-section,markdown,fr,16d47784333aa12a,"---
+MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-summary-section,markdown,fr,029ba716c8999180,"---
 
 ## Recapitulatif et exercices
 
@@ -11207,7 +11207,7 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-summa
 | **Optimalite** | Impossible a garantir | Optimale ou bornee |
 | **Equite** | Subjective | Quantifiee et optimisee |
 | **Flexibilite** | Refaire de zero | Ajouter une contrainte et re-resoudre |
-| **Scalabilite** | Tres limitee | Jusqu'a ~100 infirmiers |
+| **Scalabilite** | Très limitee | Jusqu'a ~100 infirmiers |
 
 ### Resume des concepts
 
@@ -11218,7 +11218,7 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb,cell-summa
 | **Variables booleennes** | $x_{n,d,s} \in \{0,1\}$ : un infirmier travaille ou non un shift donne |
 | **Fonction objectif** | Somme ponderee des penalites a minimiser |
 | **Solution callback** | Suivi de la progression du solveur en temps reel |
-| **Passage a l'echelle** | `time_limit` + `num_workers` pour les grands problemes |",,,,,,,,16d47784333aa12a,,,,,,,
+| **Passage a l'echelle** | `time_limit` + `num_workers` pour les grands problemes |",,,,,,,,029ba716c8999180,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-3b-NurseScheduling-CSharp.ipynb,0c428e5e,markdown,fr,3debf5c9d29fd21a,"# App-3b : Nurse Scheduling — Twin C# (planification de gardes infirmières)
 
 **Navigation** : [<< App-2b GraphColoring-CSharp](App-2b-GraphColoring-CSharp.ipynb) | [Index](../README.md) | [App-3 Python (OR-Tools) >>](App-3-NurseScheduling.ipynb)
@@ -11674,32 +11674,32 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-3b-NurseScheduling-CSharp.ipynb,c3
 
 *Marathon #4956 — parité .NET ⇄ Python. Voir EPIC #3801 (axe-2 SOTA).*
 ",,,,,,,,16eb5c9dded4f4f0,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-header,markdown,fr,cdfb7d22d2a64f5f,"# App-4 : Job-Shop Scheduling
+MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-header,markdown,fr,b738747420565ff1,"# App-4 : Job-Shop Scheduling
 
 **Navigation** : [<< App-3 NurseScheduling](App-3-NurseScheduling.ipynb) | [Index](../../README.md) | [App-5 Timetabling >>](App-5-Timetabling.ipynb)
 
 ## Ordonnancement d'atelier (Job-Shop Scheduling Problem)
 
-Le **Job-Shop Scheduling Problem (JSSP)** est l'un des problemes combinatoires les plus etudies en recherche operationnelle. Il s'agit d'ordonnancer un ensemble de travaux (*jobs*), chacun compose d'operations ordonnees, sur un ensemble de machines, en minimisant le temps total d'achevement (*makespan*).
+Le **Job-Shop Scheduling Problem (JSSP)** est l'un des problemes combinatoires les plus etudies en recherche operationnelle. Il s'agit d'ordonnancer un ensemble de travaux (*jobs*), chacun compose d'opérations ordonnees, sur un ensemble de machines, en minimisant le temps total d'achevement (*makespan*).
 
 Ce notebook est inspire du projet etudiant [jsboigeEpita/2025-PPC job-scheduling](https://github.com/jsboigeEpita/2025-PPC) (architecture modulaire, multi-objectif).
 
 ### Objectifs d'apprentissage
 
 A la fin de ce notebook, vous saurez :
-1. **Formaliser** un probleme d'ordonnancement job-shop (jobs, operations, machines, precedences)
-2. **Implementer** des regles de priorite (dispatching rules) pour obtenir des solutions rapides
+1. **Formaliser** un problème d'ordonnancement job-shop (jobs, opérations, machines, precedences)
+2. **Implementer** des règles de priorite (dispatching rules) pour obtenir des solutions rapides
 3. **Modeliser** le JSSP avec OR-Tools CP-SAT en utilisant des variables d'intervalle
 4. **Visualiser** les solutions sous forme de diagramme de Gantt
 5. **Comparer** les performances des heuristiques et du solveur exact
-6. **Etendre** le modele au multi-objectif (makespan + retard)
+6. **Etendre** le modèle au multi-objectif (makespan + retard)
 
 ### Prerequis
-- [Search-4 : Local Search](../../Part1-Foundations/Search-4-LocalSearch.ipynb) (metaheuristiques)
+- [Search-4 : Local Search](../../Part1-Foundations/Search-4-LocalSearch.ipynb) (métaheuristiques)
 - [CSP-3 : Advanced](../../Part2-CSP/CSP-3-Advanced.ipynb) (contraintes globales, OR-Tools)
 - Python : numpy, matplotlib
 
-### Duree estimee : 60 minutes",,,,,,,,cdfb7d22d2a64f5f,,,,,,,
+### Duree estimee : 60 minutes",,,,,,,,b738747420565ff1,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-imports-intro,markdown,fr,79cb134054aa5c0a,"---
 
 ## 0. Imports et configuration",,,,,,,,79cb134054aa5c0a,,,,,,,
@@ -11740,24 +11740,24 @@ from search_helpers import benchmark_table, plot_benchmark
 print(""Imports OK"")
 print(f""OR-Tools version : {cp_model.__name__}"")
 ",,,,,,,,f7223f6ce859ab89,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s1-intro,markdown,fr,d9fed046a97ad965,"---
+MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s1-intro,markdown,fr,ce1c6f077a2d0246,"---
 
 ## 1. Introduction au Job-Shop Scheduling (~5 min)
 
-### Le probleme
+### Le problème
 
-Dans un atelier de fabrication, plusieurs **travaux** (*jobs*) doivent etre traites sur plusieurs **machines**. Chaque job est compose d'une sequence ordonnee d'**operations**, chacune devant s'executer sur une machine specifique pendant une duree donnee.
+Dans un atelier de fabrication, plusieurs **travaux** (*jobs*) doivent etre traites sur plusieurs **machines**. Chaque job est compose d'une sequence ordonnee d'**opérations**, chacune devant s'executer sur une machine spécifique pendant une duree donnee.
 
 **Contraintes** :
-- **Precedence** : les operations d'un meme job doivent s'executer dans l'ordre prescrit
-- **Capacite** : chaque machine ne peut traiter qu'une seule operation a la fois
-- **Non-preemption** : une operation commencee ne peut pas etre interrompue
+- **Precedence** : les opérations d'un même job doivent s'executer dans l'ordre prescrit
+- **Capacite** : chaque machine ne peut traiter qu'une seule opération a la fois
+- **Non-preemption** : une opération commencee ne peut pas etre interrompue
 
-**Objectif** : minimiser le **makespan**, c'est-a-dire le temps d'achevement de la derniere operation.
+**Objectif** : minimiser le **makespan**, c'est-a-dire le temps d'achevement de la dernière opération.
 
 ### Complexite
 
-Le JSSP est **NP-hard** des que l'on a au moins 3 machines. Pour $n$ jobs et $m$ machines, le nombre d'ordonnancements possibles est de l'ordre de $(n!)^m$, ce qui rend l'enumeration exhaustive impossible meme pour de petites instances.
+Le JSSP est **NP-hard** des que l'on a au moins 3 machines. Pour $n$ jobs et $m$ machines, le nombre d'ordonnancements possibles est de l'ordre de $(n!)^m$, ce qui rend l'enumeration exhaustive impossible même pour de petites instances.
 
 ### Applications industrielles
 
@@ -11765,22 +11765,22 @@ Le JSSP est **NP-hard** des que l'on a au moins 3 machines. Pour $n$ jobs et $m$
 |---------|--------|
 | **Industrie manufacturiere** | Lignes d'assemblage automobile, ateliers d'usinage |
 | **Logistique** | Ordonnancement d'entrepots, tri de colis |
-| **Informatique** | Planification de taches sur processeurs multi-coeurs |
+| **Informatique** | Planification de tâches sur processeurs multi-coeurs |
 | **Sante** | Planification de blocs operatoires |
-| **Imprimerie** | Sequencement des travaux d'impression |",,,,,,,,d9fed046a97ad965,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s2-intro,markdown,fr,cd0bc8ee1e52a905,"---
+| **Imprimerie** | Sequencement des travaux d'impression |",,,,,,,,ce1c6f077a2d0246,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s2-intro,markdown,fr,4aff9e9ee1c6112a,"---
 
-## 2. Definition du probleme (~8 min)
+## 2. Definition du problème (~8 min)
 
 ### Formalisation
 
-Un JSSP est defini par :
+Un JSSP est défini par :
 - $J = \{J_0, J_1, \ldots, J_{n-1}\}$ : $n$ jobs
 - $M = \{M_0, M_1, \ldots, M_{m-1}\}$ : $m$ machines
-- Chaque job $J_i$ est une sequence ordonnee d'operations : $O_{i,0} \rightarrow O_{i,1} \rightarrow \ldots$
-- Chaque operation $O_{i,k}$ est definie par un couple $(\text{machine}, \text{duree})$
+- Chaque job $J_i$ est une sequence ordonnee d'opérations : $O_{i,0} \rightarrow O_{i,1} \rightarrow \ldots$
+- Chaque opération $O_{i,k}$ est définie par un couple $(\text{machine}, \text{duree})$
 
-**Variables de decision** : temps de debut $s_{i,k}$ de chaque operation $O_{i,k}$
+**Variables de decision** : temps de debut $s_{i,k}$ de chaque opération $O_{i,k}$
 
 **Contraintes** :
 $$s_{i,k} + p_{i,k} \leq s_{i,k+1} \quad \text{(precedence intra-job)}$$
@@ -11793,13 +11793,13 @@ $$\text{Minimiser } C_{\max} = \max_{i,k}(s_{i,k} + p_{i,k})$$
 
 Nous utilisons l'instance classique **ft03** (Fisher & Thompson, 3 jobs, 3 machines) comme premier exemple. C'est l'instance la plus simple non triviale.
 
-| Job | Operation 0 | Operation 1 | Operation 2 |
+| Job | Opération 0 | Opération 1 | Opération 2 |
 |-----|-------------|-------------|-------------|
 | J0  | M0 (3)      | M1 (2)      | M2 (2)      |
 | J1  | M0 (2)      | M2 (1)      | M1 (4)      |
 | J2  | M1 (4)      | M2 (3)      | M0 (1)      |
 
-Notation : ""M0 (3)"" signifie que l'operation s'execute sur la machine 0 pendant 3 unites de temps.",,,,,,,,cd0bc8ee1e52a905,,,,,,,
+Notation : ""M0 (3)"" signifie que l'opération s'execute sur la machine 0 pendant 3 unites de temps.",,,,,,,,4aff9e9ee1c6112a,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s2-instance,code,fr,79762c59c5abc0f6,"# Definition d'une instance JSSP
 # Format : jobs[i] = [(machine, duree), (machine, duree), ...]
 
@@ -11859,14 +11859,14 @@ def describe_instance(instance):
 
 
 lb_ft03 = describe_instance(ft03)",,,,,,,,79762c59c5abc0f6,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s2-dag-intro,markdown,fr,38e955aeab9f30ce,"### Representation sous forme de graphe oriente acyclique (DAG)
+MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s2-dag-intro,markdown,fr,a69b8d12bdd045af,"### Representation sous forme de graphe oriente acyclique (DAG)
 
 On peut representer le JSSP comme un graphe oriente ou :
-- Chaque **noeud** est une operation $O_{i,k}$
+- Chaque **noeud** est une opération $O_{i,k}$
 - Les **arcs horizontaux** representent les contraintes de precedence intra-job
-- Les **arcs verticaux** (a determiner) representent l'ordre des operations sur chaque machine
+- Les **arcs verticaux** (a determiner) representent l'ordre des opérations sur chaque machine
 
-Le makespan correspond au plus long chemin dans ce graphe une fois toutes les decisions prises.",,,,,,,,38e955aeab9f30ce,,,,,,,
+Le makespan correspond au plus long chemin dans ce graphe une fois toutes les decisions prises.",,,,,,,,a69b8d12bdd045af,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s2-dag,code,fr,7dddfb6f3c27344d,"def draw_jssp_dag(instance, title=""Graphe de precedence JSSP""):
     """"""Visualise le graphe de precedences intra-job du JSSP.""""""
     jobs = instance['jobs']
@@ -11914,47 +11914,47 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s2-
 
 draw_jssp_dag(ft03, ""ft03 : Graphe de precedence"")
 plt.show()",,,,,,,,7dddfb6f3c27344d,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s2-interp,markdown,fr,dd079625f392ae54,"### Interpretation : structure du probleme ft03
+MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s2-interp,markdown,fr,e17f3937550eb252,"### Interpretation : structure du problème ft03
 
-**Sortie obtenue** : le graphe montre les 3 jobs avec leurs sequences d'operations.
+**Sortie obtenue** : le graphe montre les 3 jobs avec leurs sequences d'opérations.
 
 | Propriete | Valeur | Signification |
 |-----------|--------|---------------|
-| Operations totales | 9 | 3 jobs x 3 operations |
+| Opérations totales | 9 | 3 jobs x 3 opérations |
 | Borne inferieure | 10 | max(longueur jobs=8, charge machines=10) |
 | Espace de recherche | 216 | $(3!)^3$ ordonnancements possibles |
 
 **Points cles** :
 1. Les fleches horizontales imposent l'ordre intra-job (J0 doit passer par M0, puis M1, puis M2)
 2. La borne inferieure est de 10 : aucune solution ne peut avoir un makespan inferieur
-3. Les conflits de machine (M0 utilise par J0 et J1 et J2) sont a resoudre par l'ordonnancement",,,,,,,,dd079625f392ae54,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s3-intro,markdown,fr,123c74be38db2c5e,"---
+3. Les conflits de machine (M0 utilise par J0 et J1 et J2) sont a resoudre par l'ordonnancement",,,,,,,,e17f3937550eb252,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s3-intro,markdown,fr,2021b5a8d88e10e8,"---
 
-## 3. Approche 1 : Regles de priorite (Dispatching Rules) (~10 min)
+## 3. Approche 1 : Règles de priorite (Dispatching Rules) (~10 min)
 
-Les **regles de dispatching** sont des heuristiques simples et rapides pour construire un ordonnancement. A chaque instant, lorsqu'une machine se libere, on choisit la prochaine operation a executer selon une regle de priorite.
+Les **règles de dispatching** sont des heuristiques simples et rapides pour construire un ordonnancement. A chaque instant, lorsqu'une machine se libere, on choisit la prochaine opération a executer selon une règle de priorite.
 
-### Regles classiques
+### Règles classiques
 
-| Regle | Nom complet | Principe |
+| Règle | Nom complet | Principe |
 |-------|-------------|----------|
-| **SPT** | Shortest Processing Time | Choisir l'operation la plus courte |
-| **LPT** | Longest Processing Time | Choisir l'operation la plus longue |
-| **MOR** | Most Operations Remaining | Choisir le job avec le plus d'operations restantes |
-| **FIFO** | First In, First Out | Choisir l'operation arrivee en premier |
+| **SPT** | Shortest Processing Time | Choisir l'opération la plus courte |
+| **LPT** | Longest Processing Time | Choisir l'opération la plus longue |
+| **MOR** | Most Opérations Remaining | Choisir le job avec le plus d'opérations restantes |
+| **FIFO** | First In, First Out | Choisir l'opération arrivee en premier |
 
 **Avantage** : temps de calcul negligeable, O(n log n) au pire.
 
-**Inconvenient** : aucune garantie d'optimalite ; la qualite depend du probleme.
+**Inconvenient** : aucune garantie d'optimalite ; la qualite depend du problème.
 
 ### Principe du simulateur
 
 On simule l'atelier dans le temps :
-1. Initialiser : toutes les machines libres, toutes les premieres operations disponibles
-2. A chaque pas : identifier les operations **pretes** (precedence satisfaite, machine libre)
-3. Appliquer la regle de priorite pour choisir laquelle executer
+1. Initialiser : toutes les machines libres, toutes les premières opérations disponibles
+2. A chaque pas : identifier les opérations **pretes** (precedence satisfaite, machine libre)
+3. Appliquer la règle de priorite pour choisir laquelle executer
 4. Avancer le temps jusqu'a la prochaine liberation de machine
-5. Repeter jusqu'a ce que toutes les operations soient planifiees",,,,,,,,123c74be38db2c5e,,,,,,,
+5. Repeter jusqu'a ce que toutes les opérations soient planifiees",,,,,,,,2021b5a8d88e10e8,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s3-scheduler,code,fr,ff0701088688186d,"def dispatching_scheduler(instance, rule='SPT'):
     """"""Ordonnanceur par regle de dispatching.
 
@@ -12033,7 +12033,7 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s3-
 
 
 print(""Fonction dispatching_scheduler definie."")",,,,,,,,ff0701088688186d,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s3-run-intro,markdown,fr,fff9a646523a54cf,Testons les differentes regles de dispatching sur l'instance ft03.,,,,,,,,fff9a646523a54cf,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s3-run-intro,markdown,fr,b823a4615cf3c712,Testons les différentes règles de dispatching sur l'instance ft03.,,,,,,,,b823a4615cf3c712,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s3-run,code,fr,2a4f57bc45c807d0,"# Tester toutes les regles sur ft03
 rules = ['SPT', 'LPT', 'MOR', 'FIFO']
 heuristic_results = {}
@@ -12052,9 +12052,9 @@ for rule in rules:
     print(f""{rule:<10} {makespan:>10} {'':>10} {gap:>10}"")
 
 print(f""\nBorne inferieure : {lb_ft03}"")",,,,,,,,2a4f57bc45c807d0,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s3-gantt-intro,markdown,fr,80ef2a87ff0662ee,"### Diagramme de Gantt
+MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s3-gantt-intro,markdown,fr,49f95848659bc8e0,"### Diagramme de Gantt
 
-Le diagramme de Gantt est la visualisation standard pour l'ordonnancement : chaque machine est une ligne, et chaque barre horizontale represente une operation, coloree selon le job.",,,,,,,,80ef2a87ff0662ee,,,,,,,
+Le diagramme de Gantt est la visualisation standard pour l'ordonnancement : chaque machine est une ligne, et chaque barre horizontale represente une opération, coloree selon le job.",,,,,,,,49f95848659bc8e0,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s3-gantt-func,code,fr,48030a64f0646c11,"def draw_gantt(schedule, instance, title=""Diagramme de Gantt"",
                makespan=None, lower_bound=None, figsize=(14, 5)):
     """"""Visualise un ordonnancement sous forme de diagramme de Gantt.
@@ -12115,7 +12115,7 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s3-
 
 
 print(""Fonction draw_gantt definie."")",,,,,,,,48030a64f0646c11,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,rpo7ju6gth,markdown,fr,97b0811aef580c61,Tracons les diagrammes de Gantt pour comparer les regles SPT et MOR.,,,,,,,,97b0811aef580c61,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,rpo7ju6gth,markdown,fr,98ea39d16e399cf5,Tracons les diagrammes de Gantt pour comparer les règles SPT et MOR.,,,,,,,,98ea39d16e399cf5,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s3-gantt-show,code,fr,4d37c93b4e34b8f4,"# Diagrammes de Gantt pour SPT et MOR
 fig, axes = plt.subplots(2, 1, figsize=(14, 8))
 
@@ -12149,38 +12149,38 @@ for idx, rule in enumerate(['SPT', 'MOR']):
 plt.suptitle('Comparaison SPT vs MOR sur ft03', fontsize=14, fontweight='bold')
 plt.tight_layout()
 plt.show()",,,,,,,,4d37c93b4e34b8f4,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s3-interp,markdown,fr,6f74218c18a16ec0,"### Interpretation : regles de dispatching
+MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s3-interp,markdown,fr,8ad48f85fdf52841,"### Interpretation : règles de dispatching
 
 **Sortie obtenue** : les diagrammes de Gantt montrent les solutions construites par SPT et MOR.
 
-| Regle | Makespan | Ecart / LB | Comportement |
+| Règle | Makespan | Ecart / LB | Comportement |
 |-------|----------|------------|---------------|
-| SPT | variable | souvent bon pour petites instances | Favorise les operations courtes |
-| LPT | variable | peut etre pire | Favorise les operations longues |
+| SPT | variable | souvent bon pour petites instances | Favorise les opérations courtes |
+| LPT | variable | peut etre pire | Favorise les opérations longues |
 | MOR | variable | souvent competitif | Equilibre la charge des jobs |
 | FIFO | variable | depend de l'ordre | Aucune intelligence |
 
 **Points cles** :
 1. Les heuristiques produisent des solutions **instantanement** (< 1 ms)
-2. La qualite varie selon la regle : aucune n'est systematiquement la meilleure
-3. On observe des **temps morts** (zones blanches dans le Gantt) : la machine attend une operation
+2. La qualite varie selon la règle : aucune n'est systematiquement la meilleure
+3. On observe des **temps morts** (zones blanches dans le Gantt) : la machine attend une opération
 4. Pour prouver l'optimalite, il faut un solveur exact
 
-> **Regle pratique** : les dispatching rules sont utiles comme solution initiale ou borne superieure pour un solveur exact.",,,,,,,,6f74218c18a16ec0,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,dc6237f0,markdown,fr,b10c31824676bfaf,"#### Exercice 1 : Creer une instance JSSP et calculer ses bornes
+> **Règle pratique** : les dispatching rules sont utiles comme solution initiale ou borne superieure pour un solveur exact.",,,,,,,,8ad48f85fdf52841,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,dc6237f0,markdown,fr,a381157a567c2231,"#### Exercice 1 : Créer une instance JSSP et calculer ses bornes
 
 Avant de passer au solveur CP-SAT, verifiez votre comprehension de la formalisation du JSSP.
 
-**Enonce** : creez une instance JSSP avec 4 jobs et 3 machines ou chaque job visite les 3 machines dans un ordre different. Calculez la borne inferieure theorique et resolvez avec les heuristiques.
+**Enonce** : créez une instance JSSP avec 4 jobs et 3 machines ou chaque job visite les 3 machines dans un ordre différent. Calculez la borne inferieure théorique et resolvez avec les heuristiques.
 
 **Consignes** :
 1. Definissez un dictionnaire d'instance (format identique a `ft03`)
 2. Chaque job visite les 3 machines exactement une fois
 3. Les durees doivent etre entre 1 et 5
 4. Appelez `describe_instance` pour afficher les bornes
-5. Testez les 4 regles de dispatching
+5. Testez les 4 règles de dispatching
 
-**Indice** : la borne inferieure = `max(somme des durees du job le plus long, charge de la machine la plus chargee)`. Verifiez que votre instance a une borne inferieure d'au moins 8.",,,,,,,,b10c31824676bfaf,,,,,,,
+**Indice** : la borne inferieure = `max(somme des durees du job le plus long, charge de la machine la plus chargee)`. Verifiez que votre instance a une borne inferieure d'au moins 8.",,,,,,,,a381157a567c2231,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,e59e90fe,code,fr,46f46ec77e608e0b,"# Exercice 1 : Creer une instance JSSP et calculer ses bornes
 
 # TODO etudiant : definissez une instance custom_jssp
@@ -12193,21 +12193,21 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,e59e90fe
 # Exemple : [(2, 3), (0, 2), (1, 4)] visite M2 puis M0 puis M1
 result = None  # TODO etudiant : remplacer par votre instance et analyse
 print(""Exercice a completer : instance JSSP custom"")",,,,,,,,46f46ec77e608e0b,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s4-intro,markdown,fr,5ac2f47f550bf1fa,"---
+MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s4-intro,markdown,fr,ede37cbd71448fe0,"---
 
 ## 4. Approche 2 : CP-SAT avec variables d'intervalle (~15 min)
 
 ### Pourquoi OR-Tools CP-SAT ?
 
-Google OR-Tools fournit un solveur CP-SAT extremement performant pour les problemes d'ordonnancement grace aux **variables d'intervalle** (`NewIntervalVar`). Ces variables representent nativement des taches avec un debut, une duree et une fin, et le solveur sait propager efficacement les contraintes `NoOverlap`.
+Google OR-Tools fournit un solveur CP-SAT extremement performant pour les problemes d'ordonnancement grace aux **variables d'intervalle** (`NewIntervalVar`). Ces variables representent nativement des tâches avec un debut, une duree et une fin, et le solveur sait propager efficacement les contraintes `NoOverlap`.
 
-### Construction du modele
+### Construction du modèle
 
-Le modele CP-SAT pour le JSSP se construit en 4 etapes :
+Le modèle CP-SAT pour le JSSP se construit en 4 étapes :
 
-| Etape | Element CP-SAT | Correspondance JSSP |
+| Étape | Élément CP-SAT | Correspondance JSSP |
 |-------|---------------|---------------------|
-| 1. Variables | `NewIntVar` pour le debut, `NewIntervalVar` pour l'operation | Temps de debut de chaque operation |
+| 1. Variables | `NewIntVar` pour le debut, `NewIntervalVar` pour l'opération | Temps de debut de chaque opération |
 | 2. Precedence | `Add(end_prev <= start_next)` | Ordre intra-job |
 | 3. NoOverlap | `AddNoOverlap(intervals_machine)` | Capacite machine = 1 |
 | 4. Objectif | `Minimize(makespan)` | Minimiser le temps total |
@@ -12218,7 +12218,7 @@ Une **variable d'intervalle** est un triplet $(\text{start}, \text{duration}, \t
 $$\text{start} + \text{duration} = \text{end}$$
 
 La contrainte `NoOverlap` sur un ensemble d'intervalles garantit qu'aucun ne se chevauche :
-$$\forall i \neq j : \text{end}_i \leq \text{start}_j \lor \text{end}_j \leq \text{start}_i$$",,,,,,,,5ac2f47f550bf1fa,,,,,,,
+$$\forall i \neq j : \text{end}_i \leq \text{start}_j \lor \text{end}_j \leq \text{start}_i$$",,,,,,,,ede37cbd71448fe0,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s4-model,code,fr,109aa9ef499a0311,"def solve_jssp_cpsat(instance, time_limit_s=30, verbose=True):
     """"""Resoud une instance JSSP avec OR-Tools CP-SAT.
 
@@ -12343,7 +12343,7 @@ draw_gantt(schedule_opt, ft03,
            title=f'ft03 - Solution optimale CP-SAT (makespan = {makespan_opt})',
            makespan=makespan_opt, lower_bound=lb_ft03)
 plt.show()",,,,,,,,4f14d46b5d50ac57,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s4-interp,markdown,fr,9dbe4333c857fa3c,"### Interpretation : solution optimale CP-SAT
+MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s4-interp,markdown,fr,a464ea35c71fa7fe,"### Interpretation : solution optimale CP-SAT
 
 **Sortie obtenue** : CP-SAT trouve la solution optimale de ft03.
 
@@ -12351,15 +12351,15 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s4-
 |--------|--------|---------------|
 | Statut | OPTIMAL | La solution est prouvee optimale |
 | Makespan | 11 (optimal, +1 vs LB=10) | L'optimal depasse la borne de 1 |
-| Temps | < 100 ms | Instance tres petite |
+| Temps | < 100 ms | Instance très petite |
 
 **Points cles** :
-1. La solution optimale minimise les temps morts entre operations
+1. La solution optimale minimise les temps morts entre opérations
 2. Les contraintes de precedence sont respectees (chaque job progresse de gauche a droite)
-3. Aucune machine ne traite deux operations simultanement (pas de chevauchement)
+3. Aucune machine ne traite deux opérations simultanement (pas de chevauchement)
 4. Si le makespan atteint la borne inferieure, la solution est prouvee optimale
 
-> **Note technique** : la contrainte `NoOverlap` est propagee tres efficacement par CP-SAT grace a des algorithmes dedies (theta-tree, edge finding).",,,,,,,,9dbe4333c857fa3c,,,,,,,
+> **Note technique** : la contrainte `NoOverlap` est propagee très efficacement par CP-SAT grace a des algorithmes dedies (theta-tree, edge finding).",,,,,,,,a464ea35c71fa7fe,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s4-compare-intro,markdown,fr,c07ad84ec2177c89,"### Comparaison heuristiques vs CP-SAT
 
 Comparons maintenant les solutions des heuristiques avec la solution optimale.",,,,,,,,c07ad84ec2177c89,,,,,,,
@@ -12378,7 +12378,7 @@ for rule in rules:
 gap_lb_opt = f""+{makespan_opt - lb_ft03}"" if makespan_opt > lb_ft03 else ""0""
 print(f""{'CP-SAT (optimal)':<20} {makespan_opt:>10} {gap_lb_opt:>10} {'0':>10} {solve_time:>12.1f}"")
 print(f""\nBorne inferieure : {lb_ft03}"")",,,,,,,,723ea02fd87c2586,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s4-compare-interp,markdown,fr,a43e2e3dccded7d7,"### Interpretation : heuristiques vs optimal
+MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s4-compare-interp,markdown,fr,6a5356293b54c696,"### Interpretation : heuristiques vs optimal
 
 Le tableau montre l'ecart entre les heuristiques et la solution optimale.
 
@@ -12386,22 +12386,22 @@ Le tableau montre l'ecart entre les heuristiques et la solution optimale.
 |---------|-------------------|--------|
 | **Temps** | < 1 ms | quelques ms a minutes |
 | **Qualite** | Pas de garantie | Optimal prouve |
-| **Scalabilite** | Tres bonne | Limitee par la taille |
-| **Usage** | Solution initiale, systemes temps reel | Planification hors ligne |
+| **Scalabilite** | Très bonne | Limitee par la taille |
+| **Usage** | Solution initiale, systèmes temps reel | Planification hors ligne |
 
-> **A retenir** : sur une petite instance, CP-SAT est imbattable. Mais pour des instances industrielles (50+ jobs), les heuristiques deviennent essentielles comme point de depart.",,,,,,,,a43e2e3dccded7d7,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,46a9f5f5,markdown,fr,7cd8115fd270db1a,"#### Exercice 2 : Implementer une nouvelle regle de dispatching
+> **A retenir** : sur une petite instance, CP-SAT est imbattable. Mais pour des instances industrielles (50+ jobs), les heuristiques deviennent essentielles comme point de depart.",,,,,,,,6a5356293b54c696,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,46a9f5f5,markdown,fr,7cb9817fcc2860c4,"#### Exercice 2 : Implementer une nouvelle règle de dispatching
 
-Les regles SPT, LPT, MOR et FIFO couvrent les cas classiques, mais on peut imaginer des regles plus sophistiquees.
+Les règles SPT, LPT, MOR et FIFO couvrent les cas classiques, mais on peut imaginer des règles plus sophistiquees.
 
-**Enonce** : implementez la regle **MWKR** (Most Work Remaining) qui priorise le job dont la duree totale restante (somme des durees des operations non encore planifiees) est la plus elevee. L'idee est de commencer en priorite les jobs les plus longs.
+**Enonce** : implementez la règle **MWKR** (Most Work Remaining) qui priorise le job dont la duree totale restante (somme des durees des opérations non encore planifiees) est la plus elevee. L'idee est de commencer en priorite les jobs les plus longs.
 
 **Consignes** :
-1. Ajoutez le cas `'MWKR'` dans `dispatching_scheduler` (ou creez une version modifiee)
-2. Triez les operations disponibles par duree restante totale decroissante
-3. Testez sur ft03 et ft06, comparez avec les autres regles
+1. Ajoutez le cas `'MWKR'` dans `dispatching_scheduler` (ou créez une version modifiée)
+2. Triez les opérations disponibles par duree restante totale decroissante
+3. Testez sur ft03 et ft06, comparez avec les autres règles
 
-**Indice** : pour un job j a l'operation k, la duree restante = `sum(d for _, d in jobs[j][k:])`.",,,,,,,,7cd8115fd270db1a,,,,,,,
+**Indice** : pour un job j a l'opération k, la duree restante = `sum(d for _, d in jobs[j][k:])`.",,,,,,,,7cb9817fcc2860c4,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,a9d8fd44,code,fr,4240054c51b8aa0d,"# Exercice 2 : Implementer la regle MWKR (Most Work Remaining)
 
 # TODO etudiant : implementez la regle MWKR dans dispatching_scheduler
@@ -12523,7 +12523,7 @@ if schedule_rand:
                makespan=makespan_rand, lower_bound=lb_random,
                figsize=(16, 7))
     plt.show()",,,,,,,,f3fbb7f69c19d005,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s5-interp,markdown,fr,3805fdd0fa3d7df0,"### Interpretation : passage a l'echelle
+MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s5-interp,markdown,fr,0ca37071ebacb27f,"### Interpretation : passage a l'echelle
 
 **Sortie obtenue** : sur des instances plus grandes, le solveur necessite plus de temps.
 
@@ -12534,24 +12534,24 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s5-
 | random | 10x5 | variable | variable | 70 (optimal) | ~41 ms |
 
 **Points cles** :
-1. Le temps de resolution croit rapidement avec la taille du probleme
-2. Meme sans atteindre l'optimalite prouvee, CP-SAT produit generalement de meilleures solutions que les heuristiques
+1. Le temps de resolution croit rapidement avec la taille du problème
+2. Même sans atteindre l'optimalite prouvee, CP-SAT produit généralement de meilleures solutions que les heuristiques
 3. La borne inferieure n'est pas toujours atteignable : il peut y avoir un ecart incompressible
 4. Pour les instances industrielles (100+ jobs), des techniques hybrides sont necessaires
 
-> **Note technique** : CP-SAT utilise en interne du Large Neighborhood Search (LNS) pour ameliorer la solution au fil du temps, ce qui le rend tres competitif meme avec des limites de temps strictes.",,,,,,,,3805fdd0fa3d7df0,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,02f08de4,markdown,fr,32a725c467103ae5,"#### Exercice 3 : Analyser la qualite d'une solution CP-SAT
+> **Note technique** : CP-SAT utilise en interne du Large Neighborhood Search (LNS) pour ameliorer la solution au fil du temps, ce qui le rend très competitif même avec des limites de temps strictes.",,,,,,,,0ca37071ebacb27f,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,02f08de4,markdown,fr,d942f4d735fede7c,"#### Exercice 3 : Analyser la qualite d'une solution CP-SAT
 
-La courbe d'amelioration ci-dessus montre que CP-SAT trouve rapidement une bonne solution. Mais comment quantifier la qualite de cette solution par rapport a l'optimum theorique ?
+La courbe d'amelioration ci-dessus montre que CP-SAT trouve rapidement une bonne solution. Mais comment quantifier la qualite de cette solution par rapport a l'optimum théorique ?
 
 **Enonce** : ecrivez une fonction `analyze_quality(makespan, lower_bound)` qui retourne un rapport de qualite contenant :
 1. L'ecart absolu avec la borne inferieure
 2. L'ecart relatif en pourcentage
 3. Un verdict : ""OPTIMAL"" si ecart = 0, ""QUASI-OPTIMAL"" si ecart < 5%, ""BON"" si ecart < 15%, ""A AMELIORER"" sinon
 
-Appliquez cette fonction aux resultats de ft06 et de l'instance aleatoire.
+Appliquez cette fonction aux résultats de ft06 et de l'instance aleatoire.
 
-**Indice** : ecart relatif = `(makespan - lower_bound) / lower_bound * 100`.",,,,,,,,32a725c467103ae5,,,,,,,
+**Indice** : ecart relatif = `(makespan - lower_bound) / lower_bound * 100`.",,,,,,,,d942f4d735fede7c,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,54936dbd,code,fr,e31d2ed010970c67,"# Exercice 3 : Analyser la qualite d'une solution CP-SAT
 
 # TODO etudiant : implementez analyze_quality(makespan, lower_bound)
@@ -12654,18 +12654,18 @@ if solutions_log:
     plt.show()
 else:
     print(""Aucune solution intermediaire enregistree."")",,,,,,,,57f4601af1fee268,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s5-callback-interp,markdown,fr,77bdf319a4fe16ff,"### Interpretation : courbe d'amelioration
+MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s5-callback-interp,markdown,fr,93668be6d50c2592,"### Interpretation : courbe d'amelioration
 
 **Sortie obtenue** : le graphique montre l'evolution du makespan au fil du temps.
 
 **Points cles** :
-1. Les ameliorations les plus importantes surviennent dans les premieres secondes
+1. Les ameliorations les plus importantes surviennent dans les premières secondes
 2. La courbe forme un ""escalier"" decroissant : chaque palier est une solution ameliorante
 3. L'ecart avec la borne inferieure se reduit mais ne l'atteint pas toujours
-4. Apres quelques secondes, les ameliorations deviennent marginales (rendements decroissants)
+4. Après quelques secondes, les ameliorations deviennent marginales (rendements decroissants)
 
-> **Regle pratique** : pour les instances industrielles, allouer 10-30 secondes au solveur donne generalement 90% de l'amelioration totale possible.",,,,,,,,77bdf319a4fe16ff,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s6-intro,markdown,fr,916bf5e1cb5f8f8c,"---
+> **Règle pratique** : pour les instances industrielles, allouer 10-30 secondes au solveur donne généralement 90% de l'amelioration totale possible.",,,,,,,,93668be6d50c2592,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s6-intro,markdown,fr,e21741ea1f3b8950,"---
 
 ## 6. Extension multi-objectif (~8 min)
 
@@ -12683,10 +12683,10 @@ ou $C_j$ est le temps d'achevement du job $J_j$.
 
 ### Objectif pondere
 
-On utilise un objectif pondere combinant les deux criteres :
+On utilise un objectif pondere combinant les deux critères :
 $$\text{Minimiser } w_1 \cdot C_{\max} + w_2 \cdot \sum_{j} T_j$$
 
-En faisant varier les poids $w_1$ et $w_2$, on explore differents compromis.",,,,,,,,916bf5e1cb5f8f8c,,,,,,,
+En faisant varier les poids $w_1$ et $w_2$, on explore différents compromis.",,,,,,,,e21741ea1f3b8950,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s6-model,code,fr,d6323f592c386ec1,"def solve_jssp_multi_objective(instance, due_dates, w_makespan=1, w_tardiness=1,
                                 time_limit_s=30):
     """"""Resoud un JSSP multi-objectif (makespan + retard).
@@ -12776,7 +12776,7 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s6-
 
 
 print(""Fonction solve_jssp_multi_objective definie."")",,,,,,,,d6323f592c386ec1,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,593h25840t,markdown,fr,6db5823e59c6e443,Definissons des dates d'echeance pour ft06 et explorons l'impact des differentes ponderations.,,,,,,,,6db5823e59c6e443,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,593h25840t,markdown,fr,b70751aa5c17cf7c,Definissons des dates d'echeance pour ft06 et explorons l'impact des différentes ponderations.,,,,,,,,b70751aa5c17cf7c,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s6-solve,code,fr,53db6991a03546d6,"# Definir des dates d'echeance pour ft06
 # Heuristique : due_date = sum(durees du job) * facteur
 ft06_due_dates = []
@@ -12838,9 +12838,9 @@ if len(multi_results) >= 2:
     ax.grid(True, alpha=0.3)
     plt.tight_layout()
     plt.show()",,,,,,,,1597dccc5ff6a5d2,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s6-interp,markdown,fr,483f5e291dcf7f19,"### Interpretation : compromis multi-objectif
+MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s6-interp,markdown,fr,aa8b10cae89ed38f,"### Interpretation : compromis multi-objectif
 
-**Sortie obtenue** : le graphique montre le compromis entre makespan et retard total pour differentes ponderations.
+**Sortie obtenue** : le graphique montre le compromis entre makespan et retard total pour différentes ponderations.
 
 | Configuration | Makespan | Retard | Commentaire |
 |---------------|----------|--------|-------------|
@@ -12849,13 +12849,13 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s6-
 | Equilibre | Compromis | Compromis | Solution de compromis raisonnable |
 
 **Points cles** :
-1. Il n'existe generalement pas de solution optimale pour les deux criteres simultanement
+1. Il n'existe généralement pas de solution optimale pour les deux critères simultanement
 2. Le graphique approche un **front de Pareto** : les solutions non dominees
 3. En pratique, le choix des poids depend du contexte industriel (penalites de retard, couts d'immobilisation)
-4. L'objectif pondere est la methode la plus simple de scalarisation ; d'autres approches existent (epsilon-constraint, NSGA-II)
+4. L'objectif pondere est la méthode la plus simple de scalarisation ; d'autres approches existent (epsilon-constraint, NSGA-II)
 
-> **A retenir** : l'ordonnancement multi-objectif est au coeur des problemes industriels reels. Le JSSP mono-objectif (makespan seul) est une simplification pedagogique.",,,,,,,,483f5e291dcf7f19,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s7-intro,markdown,fr,3653eb2a2b0a2612,"---
+> **A retenir** : l'ordonnancement multi-objectif est au coeur des problemes industriels reels. Le JSSP mono-objectif (makespan seul) est une simplification pedagogique.",,,,,,,,aa8b10cae89ed38f,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s7-intro,markdown,fr,a38f275b160c02ee,"---
 
 ## Conclusion, recapitulatif et exercices
 
@@ -12871,17 +12871,17 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s7-
 
 | Concept | Description |
 |---------|------------|
-| **Makespan** | Temps d'achevement de la derniere operation |
+| **Makespan** | Temps d'achevement de la dernière opération |
 | **Variable d'intervalle** | Representation native (start, duration, end) dans CP-SAT |
-| **NoOverlap** | Contrainte globale garantissant qu'une machine traite une seule tache a la fois |
+| **NoOverlap** | Contrainte globale garantissant qu'une machine traite une seule tâche a la fois |
 | **Borne inferieure** | max(longueur du plus long job, charge de la machine la plus chargee) |
 | **Diagramme de Gantt** | Visualisation standard des ordonnancements |
-| **Front de Pareto** | Ensemble des solutions non dominees en multi-objectif |",,,,,,,,3653eb2a2b0a2612,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s7-ex1,markdown,fr,bcc496e6f6bf13e7,"### Exercice 4 : Implementer la regle LPT
+| **Front de Pareto** | Ensemble des solutions non dominees en multi-objectif |",,,,,,,,a38f275b160c02ee,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s7-ex1,markdown,fr,eae914c6ca242e1c,"### Exercice 4 : Implementer la règle LPT
 
-**Enonce** : implementez la regle **LPT** (Longest Processing Time) et comparez ses performances avec SPT sur l'instance ft06.
+**Enonce** : implementez la règle **LPT** (Longest Processing Time) et comparez ses performances avec SPT sur l'instance ft06.
 
-**Indice** : la regle LPT est identique a SPT mais trie par duree decroissante au lieu de croissante.",,,,,,,,bcc496e6f6bf13e7,,,,,,,
+**Indice** : la règle LPT est identique a SPT mais trie par duree decroissante au lieu de croissante.",,,,,,,,eae914c6ca242e1c,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s7-ex1-code,code,fr,f33dbb9f2ee4ad7c,"# Exercice 4 : Comparaison SPT vs LPT sur ft06
 
 # A COMPLETER
@@ -12894,13 +12894,13 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s7-
 # print(f""LPT : makespan = {ms_lpt}"")
 # print(f""Difference : {abs(ms_spt - ms_lpt)}"")
 print(""Exercice a completer"")",,,,,,,,f33dbb9f2ee4ad7c,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s7-ex2,markdown,fr,a7d18ba242b3bfa0,"### Exercice 5 : Ajouter des temps de setup
+MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s7-ex2,markdown,fr,af7c3e1a95ecf7b1,"### Exercice 5 : Ajouter des temps de setup
 
-**Enonce** : dans certains ateliers, changer de job sur une machine necessite un **temps de preparation** (*setup time*). Si l'operation precedente sur la machine etait le job $i$ et la suivante est le job $j$, un setup de $s_{ij}$ unites de temps est necessaire.
+**Enonce** : dans certains ateliers, changer de job sur une machine necessite un **temps de preparation** (*setup time*). Si l'opération précédente sur la machine etait le job $i$ et la suivante est le job $j$, un setup de $s_{ij}$ unites de temps est necessaire.
 
-Modifiez le modele CP-SAT pour inclure des temps de setup symetriques de 1 unite entre jobs differents et 0 pour le meme job.
+Modifiez le modèle CP-SAT pour inclure des temps de setup symetriques de 1 unite entre jobs différents et 0 pour le même job.
 
-**Indice** : utilisez des variables booleennes et `AddCircuit` ou des contraintes conditionnelles avec `OnlyEnforceIf`.",,,,,,,,a7d18ba242b3bfa0,,,,,,,
+**Indice** : utilisez des variables booleennes et `AddCircuit` ou des contraintes conditionnelles avec `OnlyEnforceIf`.",,,,,,,,af7c3e1a95ecf7b1,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s7-ex2-code,code,fr,0db1ffae90120e17,"# Exercice 5 : JSSP avec temps de setup
 
 # A COMPLETER
@@ -12912,13 +12912,13 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s7-
 # ...
 # Comparez le makespan avec et sans setup times sur ft03.
 print(""Exercice a completer"")",,,,,,,,0db1ffae90120e17,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s7-ex3,markdown,fr,44146d2d8b0351d9,"### Exercice 6 : Flexible Job-Shop
+MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s7-ex3,markdown,fr,a58b8bc07f8afe11,"### Exercice 6 : Flexible Job-Shop
 
-**Enonce** : dans le **Flexible Job-Shop** (FJSP), chaque operation peut s'executer sur un sous-ensemble de machines (pas necessairement une seule). Chaque machine a potentiellement une duree differente pour la meme operation.
+**Enonce** : dans le **Flexible Job-Shop** (FJSP), chaque opération peut s'executer sur un sous-ensemble de machines (pas necessairement une seule). Chaque machine a potentiellement une duree différente pour la même opération.
 
-Modelisez un petit FJSP en utilisant des variables optionnelles (`NewOptionalIntervalVar`) et une contrainte de selection.
+Modelisez un petit FJSP en utilisant des variables optionnelles (`NewOptionalIntervalVar`) et une contrainte de sélection.
 
-**Indice** : pour chaque operation, crez un intervalle optionnel par machine possible, et ajoutez la contrainte `exactly_one` pour selectionner une seule machine.",,,,,,,,44146d2d8b0351d9,,,,,,,
+**Indice** : pour chaque opération, crez un intervalle optionnel par machine possible, et ajoutez la contrainte `exactly_one` pour sélectionner une seule machine.",,,,,,,,a58b8bc07f8afe11,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s7-ex3-code,code,fr,394561b43fe422d3,"# Exercice 6 : Flexible Job-Shop
 
 # A COMPLETER
@@ -12935,18 +12935,18 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s7-
 #
 # Utilisez NewOptionalIntervalVar et AddExactlyOne pour la selection.
 print(""Exercice a completer"")",,,,,,,,394561b43fe422d3,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,410f14fd,markdown,fr,276878735e67b1ae,"## Conclusion
+MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,410f14fd,markdown,fr,7cafe2df218b80d5,"## Conclusion
 
 Ce notebook a explore le **Job-Shop Scheduling Problem (JSSP)**, l'un des problemes combinatoires les plus etudies en recherche operationnelle, en suivant une progression pedagogique des heuristiques simples vers la resolution exacte.
 
 ### Concepts cles a retenir
 
-| Concept | Role dans le JSSP |
+| Concept | Rôle dans le JSSP |
 |---------|-------------------|
-| **Makespan** | Objectif principal : minimiser le temps d'achevement de la derniere operation |
+| **Makespan** | Objectif principal : minimiser le temps d'achevement de la dernière opération |
 | **Dispatching rules** (SPT, LPT, MOR, FIFO) | Heuristiques instantanees mais sans garantie d'optimalite |
-| **Variables d'intervalle** | Representation native (start, duration, end) dans CP-SAT pour les taches |
-| **Contrainte NoOverlap** | Garantit qu'une machine ne traite qu'une operation a la fois |
+| **Variables d'intervalle** | Representation native (start, duration, end) dans CP-SAT pour les tâches |
+| **Contrainte NoOverlap** | Garantit qu'une machine ne traite qu'une opération a la fois |
 | **Borne inferieure** | max(longueur du job le plus long, charge de la machine la plus chargee) |
 | **Multi-objectif** | Compromis entre makespan et retard total via ponderation |
 
@@ -12954,8 +12954,8 @@ Ce notebook a explore le **Job-Shop Scheduling Problem (JSSP)**, l'un des proble
 
 1. **Les heuristiques sont rapides mais approximatives** : les dispatching rules produisent une solution en moins d'une milliseconde, mais avec un ecart de 10 a 60% par rapport a l'optimal.
 2. **CP-SAT est remarquablement performant** : grace aux variables d'intervalle et a la propagation avancee (theta-tree, edge finding), le solveur trouve l'optimal en quelques millisecondes sur les petites instances.
-3. **Le multi-objectif change la nature du probleme** : il n'existe pas de solution unique optimale pour tous les criteres ; le front de Pareto offre les compromis possibles.
-4. **La modelisation declarative est un atout** : le modele CP-SAT se concentre sur le ""quoi"" (contraintes) plutot que le ""comment"" (algorithme de recherche).",,,,,,,,276878735e67b1ae,,,,,,,
+3. **Le multi-objectif change la nature du problème** : il n'existe pas de solution unique optimale pour tous les critères ; le front de Pareto offre les compromis possibles.
+4. **La modelisation declarative est un atout** : le modèle CP-SAT se concentre sur le ""quoi"" (contraintes) plutot que le ""comment"" (algorithme de recherche).",,,,,,,,7cafe2df218b80d5,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb,cell-s7-next,markdown,fr,b19a838adf8f45c0,"### Pour aller plus loin
 
 | Sujet | Description | Lien |
@@ -13337,14 +13337,14 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-4b-JobShopScheduling-CSharp.ipynb,
 
 *Marathon #4956 — parité .NET ⇄ Python. Voir EPIC #3801 (axe-2 SOTA).*
 ",,,,,,,,be6ddecaa91900a8,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb,0a1b2c3d,markdown,fr,1aaae7005b8a3198,"# App-5 : Emploi du temps universitaire — Twin C# (University Timetabling)
+MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb,0a1b2c3d,markdown,fr,034a684ca90b34e6,"# App-5 : Emploi du temps universitaire — Twin C# (University Timetabling)
 
 **Navigation** : [<< App-4b JobShopScheduling-CSharp](App-4b-JobShopScheduling-CSharp.ipynb) | [Index](../README.md) | [App-5 Python (OR-Tools) >>](App-5-Timetabling.ipynb)
 
 ## Objectifs d'apprentissage
 
 A la fin de ce notebook, vous saurez :
-1. **Modeliser** un probleme d'emploi du temps universitaire comme un CSP
+1. **Modeliser** un problème d'emploi du temps universitaire comme un CSP
 2. **Implementer** une heuristique gloutonne MRV (Minimum Remaining Values)
 3. **Resoudre** optimalement les petites instances par branch-and-bound avec elagage
 4. **Distinguer** la recherche par affectation complete vs slot-par-slot
@@ -13358,9 +13358,9 @@ A la fin de ce notebook, vous saurez :
 
 ## 1. Contexte — le University Timetabling Problem
 
-La **planification d'emplois du temps** est un probleme classique d'optimisation sous contraintes. Une universite doit affecter chaque cours a un creneau horaire et une salle, en respectant des regles dures (capacite, equipement, non-chevauchement) et en optimisant des criteres souples (trous, equilibre).
+La **planification d'emplois du temps** est un problème classique d'optimisation sous contraintes. Une universite doit affecter chaque cours a un creneau horaire et une salle, en respectant des règles dures (capacite, equipement, non-chevauchement) et en optimisant des critères souples (trous, equilibre).
 
-### Pourquoi ce probleme est-il difficile ?
+### Pourquoi ce problème est-il difficile ?
 
 Le university timetabling est **NP-difficile**. Avec 8 cours, 4 salles et 20 creneaux, l'espace d'affectations brutes est :
 
@@ -13381,26 +13381,26 @@ Ce notebook jumeau C# est un **twin from-scratch** (BCL .NET 9, 0 NuGet) qui tra
 
 ---
 
-**Verdict SOTA (EPIC #3801)** : RECOVERABLE-MACHINE Prong-B assumé. From-scratch assumé pedagogiquement pour exhiber la mecanique du branch-and-bound que CP-SAT encapsule (cf section 6). Cross-link vers [App-5-Timetabling.ipynb](App-5-Timetabling.ipynb) qui **invoque** le vrai OR-Tools CP-SAT.",,,,,,,,1aaae7005b8a3198,,,,,,,
+**Verdict SOTA (EPIC #3801)** : RECOVERABLE-MACHINE Prong-B assumé. From-scratch assumé pedagogiquement pour exhiber la mecanique du branch-and-bound que CP-SAT encapsule (cf section 6). Cross-link vers [App-5-Timetabling.ipynb](App-5-Timetabling.ipynb) qui **invoque** le vrai OR-Tools CP-SAT.",,,,,,,,034a684ca90b34e6,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb,0b1c2d3e,code,fr,b27556971ae19ee4,"// === Parameters ===
 // Mode BATCH : pas d'affichage interactif (Papermill friendly)
 var BATCH_MODE = true;
 Console.WriteLine($""App-5 Timetabling C# — BATCH_MODE={BATCH_MODE}"");
 Console.WriteLine($""Runtime: .NET {Environment.Version}"");
 ",,,,,,,,b27556971ae19ee4,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb,1c2d3e4f,markdown,fr,3897ad45ce172f80,"---
+MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb,1c2d3e4f,markdown,fr,233f9a24602a57b8,"---
 
-## 2. Donnees du probleme
+## 2. Données du problème
 
 Definissons une instance realiste mais de taille maitrisable : **8 cours**, **4 salles**, **20 creneaux** (5 jours x 4 creneaux/jour) et **4 enseignants**.
 
-### Structure des donnees
+### Structure des données
 
 Chaque cours a : nom, nombre d'etudiants, enseignant responsable, equipement requis.
 
 Chaque salle a : capacite maximale, equipement disponible.
 
-L'objectif : affecter chaque cours a un **(salle, creneau)** tel que les contraintes dures soient satisfaites et les souples minimisees.",,,,,,,,3897ad45ce172f80,,,,,,,
+L'objectif : affecter chaque cours a un **(salle, creneau)** tel que les contraintes dures soient satisfaites et les souples minimisees.",,,,,,,,233f9a24602a57b8,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb,1d2e3f4a,code,fr,e237d871d56c3600,"// === Donnees du probleme ===
 
 var DAYS = new[] { ""Lundi"", ""Mardi"", ""Mercredi"", ""Jeudi"", ""Vendredi"" };
@@ -13450,7 +13450,7 @@ Console.WriteLine($""Salles      : {ROOMS.Count}"");
 Console.WriteLine($""Enseignants : {TEACHERS.Count}"");
 Console.WriteLine($""Creneaux    : {NUM_SLOTS} ({DAYS.Length} jours x {SLOTS_PER_DAY} creneaux)"");
 ",,,,,,,,e237d871d56c3600,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb,2e3f4a5b,markdown,fr,ab19bac46c1ab95d,"### Interpretation : la combinatoire revelee
+MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb,2e3f4a5b,markdown,fr,1db65a5188aab763,"### Interpretation : la combinatoire revelee
 
 **Points cles a observer** :
 
@@ -13458,10 +13458,10 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb,2e3f4a5
 |--------|-------------|--------|
 | Capacite Amphi_A (120) | Seule salle pour Algo (90) et IA (100) | Contrainte dure sur l'amphi |
 | Equipement ""labo"" | Reseaux, Securite, Web le necessitent | Force Labo_C ou Labo_D |
-| Dupont enseigne 2 cours | Algo + Systemes | Pas de chevauchement temporel |
+| Dupont enseigne 2 cours | Algo + Systèmes | Pas de chevauchement temporel |
 | Martin enseigne 2 cours | Probas + IA | Idem |
 
-Ces observations emergent directement des donnees : ce sont les **contraintes dures** que les algorithmes suivants devront respecter.",,,,,,,,ab19bac46c1ab95d,,,,,,,
+Ces observations emergent directement des données : ce sont les **contraintes dures** que les algorithmes suivants devront respecter.",,,,,,,,1db65a5188aab763,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb,2f3a4b5c,markdown,fr,0a9a1718d9e2eac4,"---
 
 ## 3. Fonctions utilitaires
@@ -13518,7 +13518,7 @@ foreach (var tname in teacherNames)
 MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb,4b5c6d7e,markdown,fr,dc7248773c7a63a5,"### Interpretation : MRV revele par la structure
 
 On observe que **Reseaux, Securite, Web** (cours ""labo"") ont moins de salles compatibles : 2 au lieu de 3-4. Ces cours sont les plus contraints — l'heuristique MRV (Minimum Remaining Values) du notebook suivant les placera en premier.",,,,,,,,dc7248773c7a63a5,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb,4c5d6e7f,markdown,fr,705af8f756e2e94a,"---
+MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb,4c5d6e7f,markdown,fr,eae3c87a8be45042,"---
 
 ## 4. Approche 1 : Heuristique gloutonne MRV
 
@@ -13528,7 +13528,7 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb,4c5d6e7
 2. **Pour chaque cours**, parcourir les creneaux et salles dans l'ordre, et affecter au premier creneau+salle disponible (sans conflit salle ni enseignant)
 3. **Pas de backtracking** : si echec, le cours reste non place
 
-C'est la version sequentielle de l'algorithme MRV deja vu dans [CSP-1-NQueens-CSharp](App-1b-NQueens-CSharp.ipynb) et [CSP-3-Advanced](../../Part2-CSP/CSP-3-Advanced.ipynb).",,,,,,,,705af8f756e2e94a,,,,,,,
+C'est la version séquentielle de l'algorithme MRV déjà vu dans [CSP-1-NQueens-CSharp](App-1b-NQueens-CSharp.ipynb) et [CSP-3-Advanced](../../Part2-CSP/CSP-3-Advanced.ipynb).",,,,,,,,eae3c87a8be45042,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb,5d6e7f8a,code,fr,98998b9bac0d6c37,"// === Heuristique gloutonne MRV ===
 
 (Dictionary<string, (string Room, int Slot)> Schedule, bool Success) GreedyTimetable()
@@ -13608,21 +13608,21 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb,6e7f8a9
 3. Pas de backtracking : sur des instances plus contraintes, le glouton echouerait
 
 > **Conclusion** : pour l'optimalite, il faut un algorithme de recherche avec backtracking et elagage.",,,,,,,,7536645290eabc07,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb,6f7a8b9c,markdown,fr,bdefaa456c2f2d0b,"---
+MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb,6f7a8b9c,markdown,fr,798710fa785c3ccc,"---
 
 ## 5. Approche 2 : Branch-and-Bound optimal (petites instances)
 
-Pour les **petites instances** (8 cours x 80 creneaux-salles theoriques = ~640 affectations possibles par cours), on peut enumerer exhaustivement les solutions et elaguer.
+Pour les **petites instances** (8 cours x 80 creneaux-salles théoriques = ~640 affectations possibles par cours), on peut enumerer exhaustivement les solutions et elaguer.
 
-### Strategie
+### Stratégie
 
 1. **Enumere** les affectations (cours, salle, creneau) une par une par ordre MRV
 2. **Elague** quand une contrainte dure est violee
 3. **Compte** les solutions completes pour valider l'optimalite (toutes satisfont les dures → on prend la 1ere trouvee comme proxy optimal)
 
-### Borne theorique
+### Borne théorique
 
-Pour notre instance, le nombre d'affectations theoriques par cours (apres filtrage compatibilite) est en moyenne ~30-50. Le produit est au pire ~50^8 = 4 x 10^13. Avec MRV + elagage par incompatibilite, on tombe a quelques millions au plus — **acceptable en C# sans parallelisation pour 8 cours**.",,,,,,,,bdefaa456c2f2d0b,,,,,,,
+Pour notre instance, le nombre d'affectations théoriques par cours (après filtrage compatibilite) est en moyenne ~30-50. Le produit est au pire ~50^8 = 4 x 10^13. Avec MRV + elagage par incompatibilite, on tombe a quelques millions au plus — **acceptable en C# sans parallelisation pour 8 cours**.",,,,,,,,798710fa785c3ccc,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb,7a8b9c0d,code,fr,395833e24343fd73,"// === Branch-and-Bound : enumeration avec elagage par contrainte dure ===
 
 List<(Dictionary<string, (string, int)> Schedule, int Nodes)> BranchAndBound(int maxSolutions = 5)
@@ -13721,11 +13721,11 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb,8b9c0d1
 | B&B complet | N (toutes) | 100ms-2s selon N | Variable | Optimale (contraintes dures) |
 
 **Observation cle** : le B&B sur 8 cours est **tracable** en C# (< 2s pour 3 solutions). Au-dela (12+ cours), il faut passer au **vrai solveur SOTA : OR-Tools CP-SAT** — exactement ce que fait le twin Python App-5.",,,,,,,,7553494ccd79c0d4,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb,8c9d0e1f,markdown,fr,403f2c66c0f5d0ad,"---
+MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb,8c9d0e1f,markdown,fr,5f363e537e9ea19b,"---
 
 ## 6. Visualisation ASCII (Prong B assumé)
 
-Pour visualiser le resultat sans bibliotheque graphique (matplotlib non disponible en .NET Interactive par defaut), nous utilisons une **grille ASCII**. Le twin Python utilise matplotlib ; ici, le C# assume une representation textuelle pedagogiquement equivalente.",,,,,,,,403f2c66c0f5d0ad,,,,,,,
+Pour visualiser le résultat sans bibliotheque graphique (matplotlib non disponible en .NET Interactive par defaut), nous utilisons une **grille ASCII**. Le twin Python utilise matplotlib ; ici, le C# assume une representation textuelle pedagogiquement equivalente.",,,,,,,,5f363e537e9ea19b,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb,9d0e1f2a,code,fr,63ed7a218b5934c9,"// === Visualisation ASCII du schedule (Prong B assumé) ===
 
 void VisualizeAscii(Dictionary<string, (string Room, int Slot)> schedule, string title)
@@ -13771,23 +13771,23 @@ if (bbBest != null)
     VisualizeAscii(bbBest, ""Emploi du temps - Branch-and-Bound optimal"");
 }
 ",,,,,,,,63ed7a218b5934c9,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb,0e1f2a3b,markdown,fr,0aa8aba32ca3a5bd,"### Interpretation : la mecanique du solveur exposee
+MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb,0e1f2a3b,markdown,fr,d2562d4c457412dd,"### Interpretation : la mecanique du solveur exposee
 
 En visualisant les deux solutions cote a cote, on observe :
 
 - Le **glouton** concentre les cours en debut de semaine (ordre MRV + premier creneau libre)
 - Le **B&B** distribue mieux les cours sur la semaine grace a l'enumeration
 
-C'est exactement la **difference pedagogique** que Prong B cherche a exhiber : CP-SAT fait ce que B&B fait, mais avec propagation de contraintes + branchements adaptatifs + recherche parallele. Le twin Python le montre avec matplotlib + OR-Tools ; le twin C# le montre avec ASCII + B&B from-scratch.",,,,,,,,0aa8aba32ca3a5bd,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb,1f2a3b4c,markdown,fr,b08552e213d024d4,"---
+C'est exactement la **différence pedagogique** que Prong B cherche a exhiber : CP-SAT fait ce que B&B fait, mais avec propagation de contraintes + branchements adaptatifs + recherche parallele. Le twin Python le montre avec matplotlib + OR-Tools ; le twin C# le montre avec ASCII + B&B from-scratch.",,,,,,,,d2562d4c457412dd,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb,1f2a3b4c,markdown,fr,80da713f7d7588af,"---
 
 ## 7. Exercices
 
-Trois exercices pour approfondir. Chaque exercice suit un **exemple résolu** (cf cellule ci-dessus pour les patterns) et utilise un stub C.1-conforme (`return null` ou `print(""Exercice a completer"")`). Le notebook s'execute end-to-end meme non complete.
+Trois exercices pour approfondir. Chaque exercice suit un **exemple résolu** (cf cellule ci-dessus pour les patterns) et utilise un stub C.1-conforme (`return null` ou `print(""Exercice a completer"")`). Le notebook s'execute end-to-end même non complete.
 
 ### Exemple résolu : teacher-load (charge par enseignant)
 
-**Objectif** : compter le nombre de creneaux occupes par enseignant dans une solution. Voici la version résolue :",,,,,,,,b08552e213d024d4,,,,,,,
+**Objectif** : compter le nombre de creneaux occupes par enseignant dans une solution. Voici la version résolue :",,,,,,,,80da713f7d7588af,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb,2a3b4c5d,code,fr,0c04cc523f8d9f8c,"// === Exemple resolu : charge par enseignant ===
 Dictionary<string, int> TeacherLoad(Dictionary<string, (string Room, int Slot)> schedule)
 {
@@ -13820,11 +13820,11 @@ int EvaluateTightness(Dictionary<string, (string Room, int Slot)> schedule, stri
 }
 Console.WriteLine($""\nScore de tightness pour Dupont : {EvaluateTightness(greedySchedule, ""Dupont"")}"");
 ",,,,,,,,0c04cc523f8d9f8c,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb,3b4c5d6e,markdown,fr,300561f78a2f0faa,"### Exercice 2 : disponibilite partielle des salles
+MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb,3b4c5d6e,markdown,fr,a9c0e0b11f1e556c,"### Exercice 2 : disponibilite partielle des salles
 
-**Objectif** : modifier le modele pour que certaines salles soient **indisponibles sur certains creneaux** (ex : Amphi_A reserve le Vendredi 16h-18h pour une conference). Reutiliser le B&B en ajoutant une contrainte dure supplementaire.
+**Objectif** : modifier le modèle pour que certaines salles soient **indisponibles sur certains creneaux** (ex : Amphi_A reserve le Vendredi 16h-18h pour une conference). Reutiliser le B&B en ajoutant une contrainte dure supplementaire.
 
-**Indice** : creer une liste `unavailableSlots[rname]` et elaguer toute affectation (rname, slot) avec slot dans cette liste.",,,,,,,,300561f78a2f0faa,,,,,,,
+**Indice** : créer une liste `unavailableSlots[rname]` et elaguer toute affectation (rname, slot) avec slot dans cette liste.",,,,,,,,a9c0e0b11f1e556c,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb,515b0ebd,code,fr,fce24c6b0c1a074d,"// === Exercice 2 : disponibilite partielle des salles ===
 // TODO etudiant : ajouter une disponibilite partielle et adapter le B&B
 // Exemple : Amphi_A indisponible le Vendredi 16h-18h (slot 19)
@@ -13867,20 +13867,20 @@ List<(Dictionary<string, (string, int)>, int)> BranchAndBoundWithGroups(int maxS
 var bbGroups = BranchAndBoundWithGroups(maxSolutions: 2);
 Console.WriteLine($""Solutions avec groupes : {bbGroups.Count} (STUB — exercice a completer)"");
 ",,,,,,,,0242a1455c7c4906,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb,7f8a9b0c,markdown,fr,d56071d3d6edde71,"---
+MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb,7f8a9b0c,markdown,fr,4972ef73e9b07d29,"---
 
 ## Conclusion
 
 ### Ce qu'on a vu
 
-1. **Modelisation** d'un probleme d'emploi du temps comme un CSP (variables = cours, domaine = (salle, creneau), contraintes dures = capacite/equipement/non-chevauchement)
+1. **Modelisation** d'un problème d'emploi du temps comme un CSP (variables = cours, domaine = (salle, creneau), contraintes dures = capacite/equipement/non-chevauchement)
 2. **Glouton MRV** : rapide, sous-optimal, pas de backtracking
 3. **Branch-and-Bound** : optimal pour petites instances, enumeration avec elagage par contrainte dure
 4. **Visualisation ASCII** : alternative pedagogique au matplotlib Python
 
 ### Complementarite avec le twin Python (#3801 Prong B)
 
-Ce notebook jumeau C# est un **twin from-scratch** (BCL .NET 9, 0 NuGet) qui transpose les algorithmes en C#. Le **vrai outil SOTA** pour ce probleme est **OR-Tools CP-SAT** (propagation de contraintes + recherche arborescente + optimisation lineaire) — c'est exactement ce qu'invoque le twin Python [App-5-Timetabling.ipynb](App-5-Timetabling.ipynb).
+Ce notebook jumeau C# est un **twin from-scratch** (BCL .NET 9, 0 NuGet) qui transpose les algorithmes en C#. Le **vrai outil SOTA** pour ce problème est **OR-Tools CP-SAT** (propagation de contraintes + recherche arborescente + optimisation lineaire) — c'est exactement ce qu'invoque le twin Python [App-5-Timetabling.ipynb](App-5-Timetabling.ipynb).
 
 **Pourquoi from-scratch ici, alors** : pour **exhiber la mecanique** que CP-SAT encapsule (MRV, backtracking, elagage par incompatibilite, propagation de bornes). C'est la **valeur pedagogique de Prong B** : **separer pour voir** ce que le solveur boite-noire cache.
 
@@ -13894,18 +13894,18 @@ Le notebook assume cette posture dans la cellule d'introduction (verdict RECOVER
 - [App-4b-JobShopScheduling-CSharp.ipynb](App-4b-JobShopScheduling-CSharp.ipynb) — jumeau C# App-4b (dispatching + B&B)
 - [EPIC #3801 — SOTA ledger](../README.md)
 - [EPIC #4956 — Marathon parite .NET ⇄ Python](../README.md)
-",,,,,,,,d56071d3d6edde71,,,,,,,
+",,,,,,,,4972ef73e9b07d29,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,30fad090,code,fr,d8cfd07b7b0f3965,"# Parameters
 BATCH_MODE = ""true""
 ",,,,,,,,d8cfd07b7b0f3965,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-header,markdown,fr,cc4ca65f7c34982d,"# App-5 : Emploi du temps universitaire (University Timetabling)
+MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-header,markdown,fr,f24a5dcb06381f96,"# App-5 : Emploi du temps universitaire (University Timetabling)
 
 **Navigation** : [<< App-4 JobShopScheduling](App-4-JobShopScheduling.ipynb) | [Index](../../README.md) | [App-6 Minesweeper >>](App-6-Minesweeper.ipynb)
 
 ## Objectifs d'apprentissage
 
 A la fin de ce notebook, vous saurez :
-1. **Modeliser** un probleme d'emploi du temps universitaire comme un CSP
+1. **Modeliser** un problème d'emploi du temps universitaire comme un CSP
 2. **Distinguer** contraintes dures et contraintes souples
 3. **Comparer** une approche heuristique gloutonne avec un solveur CP-SAT
 4. **Decouvrir** la modelisation declarative MiniZinc
@@ -13915,16 +13915,16 @@ A la fin de ce notebook, vous saurez :
 - Python 3.10+, numpy, matplotlib, ortools
 - [CSP-3 : Advanced](../../Part2-CSP/CSP-3-Advanced.ipynb)
 
-### Duree estimee : 50 minutes",,,,,,,,cc4ca65f7c34982d,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-intro-section,markdown,fr,10173ef9c3e31e7a,"---
+### Duree estimee : 50 minutes",,,,,,,,f24a5dcb06381f96,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-intro-section,markdown,fr,12540539f3fec36c,"---
 
 ## 1. Introduction (~5 min)
 
-La **planification d'emplois du temps** (university timetabling) est un probleme classique d'optimisation sous contraintes. Chaque universite doit, a chaque semestre, affecter des cours a des creneaux horaires et des salles, en respectant de nombreuses regles.
+La **planification d'emplois du temps** (university timetabling) est un problème classique d'optimisation sous contraintes. Chaque universite doit, a chaque semestre, affecter des cours a des creneaux horaires et des salles, en respectant de nombreuses règles.
 
-### Pourquoi ce probleme est-il difficile ?
+### Pourquoi ce problème est-il difficile ?
 
-Le university timetabling est **NP-difficile**. Meme avec seulement 8 cours, 3 salles et 20 creneaux, le nombre d'affectations possibles (sans contraintes) est :
+Le university timetabling est **NP-difficile**. Même avec seulement 8 cours, 3 salles et 20 creneaux, le nombre d'affectations possibles (sans contraintes) est :
 
 $$\text{Espace brut} = (\text{nb salles} \times \text{nb creneaux})^{\text{nb cours}} = (3 \times 20)^8 = 60^8 \approx 1.7 \times 10^{14}$$
 
@@ -13935,18 +13935,18 @@ Les contraintes vont eliminer l'immense majorite de ces combinaisons, mais l'esp
 | Type | Description | Exemples | Violation |
 |------|-------------|----------|----------|
 | **Contrainte dure** | Doit etre satisfaite (sinon pas de solution) | Pas de chevauchement de salle, capacite suffisante | Solution invalide |
-| **Contrainte souple** | Souhaitable mais non obligatoire | Minimiser les trous, preferences enseignants | Solution de moindre qualite |
+| **Contrainte souple** | Souhaitable mais non obligatoire | Minimiser les trous, préférences enseignants | Solution de moindre qualite |
 
 En pratique, on cherche une solution qui satisfait **toutes** les contraintes dures et **minimise** les violations de contraintes souples.
 
-### Elements du probleme
+### Éléments du problème
 
-| Element | Role | Exemple |
+| Élément | Rôle | Exemple |
 |---------|------|--------|
 | **Cours** | Activites a planifier | Algorithmique, Probabilites... |
 | **Salles** | Lieux d'enseignement (capacite, equipements) | Amphi A (120 places, video-projecteur) |
 | **Creneaux** | Plages horaires (jour + heure) | Lundi 8h-10h, Mardi 14h-16h |
-| **Enseignants** | Personnes affectees aux cours | Prof. Dupont (Algo + Systemes) |",,,,,,,,10173ef9c3e31e7a,,,,,,,
+| **Enseignants** | Personnes affectees aux cours | Prof. Dupont (Algo + Systèmes) |",,,,,,,,12540539f3fec36c,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-imports,code,fr,e8d2a2ff7cb8ccc4,"# Imports pour tout le notebook
 import sys
 import os
@@ -13966,13 +13966,13 @@ from search_helpers import benchmark_table
 
 print(""Imports OK"")
 print(f""OR-Tools version: {cp_model.__name__} charge"")",,,,,,,,e8d2a2ff7cb8ccc4,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-data-section,markdown,fr,cfada758ce7ab17f,"---
+MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-data-section,markdown,fr,7ec99fa414a19a8d,"---
 
-## 2. Donnees du probleme (~5 min)
+## 2. Données du problème (~5 min)
 
 Definissons une instance realiste mais de taille maitrisable : 8 cours, 3 salles, 20 creneaux (5 jours x 4 creneaux par jour) et 4 enseignants.
 
-### Structure des donnees
+### Structure des données
 
 Chaque cours est decrit par :
 - son nom et son identifiant
@@ -13982,7 +13982,7 @@ Chaque cours est decrit par :
 
 Chaque salle est decrite par :
 - sa capacite maximale
-- les equipements disponibles",,,,,,,,cfada758ce7ab17f,,,,,,,
+- les equipements disponibles",,,,,,,,7ec99fa414a19a8d,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-data-definition,code,fr,39b81b14a7d68e89,"# === Donnees du probleme ===
 
 # Jours et creneaux horaires
@@ -14050,7 +14050,7 @@ print(f""  {'Nom':<12} {'Capacite':>10} {'Equipement':<12}"")
 print(f""  {'-'*34}"")
 for name, info in ROOMS.items():
     print(f""  {name:<12} {info['capacity']:>10} {info['equipment']:<12}"")",,,,,,,,39b81b14a7d68e89,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-data-interpretation,markdown,fr,805815b0def8eb70,"### Interpretation : donnees du probleme
+MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-data-interpretation,markdown,fr,032164f017ee6a96,"### Interpretation : données du problème
 
 **Points cles a observer** :
 
@@ -14058,13 +14058,13 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-data-inte
 |--------|-------------|-------------|
 | Capacite Amphi_A (120) | Seule salle pour Algo (90) et IA (100) | Conflit pour l'amphi |
 | Equipement ""labo"" | Reseaux, Securite, Web le necessitent | Labo_C ou Labo_D |
-| Dupont enseigne 2 cours | Algo + Systemes | Pas au meme creneau |
+| Dupont enseigne 2 cours | Algo + Systèmes | Pas au même creneau |
 | Martin enseigne 2 cours | Probas + IA | Idem |
 
-Ces observations font emerger les premieres contraintes :
+Ces observations font emerger les premières contraintes :
 1. Les cours a gros effectif (Algo, IA) **doivent** aller dans Amphi_A
 2. Les cours ""labo"" (Reseaux, Securite, Web) **doivent** aller dans Labo_C ou Labo_D (Reseaux et Web uniquement dans Labo_D)
-3. Dupont et Martin ont chacun 2 cours : pas de chevauchement possible",,,,,,,,805815b0def8eb70,,,,,,,
+3. Dupont et Martin ont chacun 2 cours : pas de chevauchement possible",,,,,,,,032164f017ee6a96,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-helper-functions-intro,markdown,fr,c34f2f41f92814b9,"### Fonctions utilitaires
 
 Avant de passer aux algorithmes, definissons les fonctions de conversion et de visualisation qui seront reutilisees tout au long du notebook.",,,,,,,,c34f2f41f92814b9,,,,,,,
@@ -14113,7 +14113,7 @@ print(""Affectation enseignant -> cours :"")
 for tname in teacher_names:
     courses = get_teacher_courses(tname)
     print(f""  {tname:<10} : {courses}"")",,,,,,,,94c087ef0e1a8305,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,xlhn6ehqcw,markdown,fr,9e8c2196701f444f,Definissons egalement les fonctions de visualisation et d'evaluation de la qualite d'un emploi du temps. Ces fonctions seront reutilisees pour comparer les differentes approches.,,,,,,,,9e8c2196701f444f,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,xlhn6ehqcw,markdown,fr,86a9609cfb40c41d,Definissons également les fonctions de visualisation et d'evaluation de la qualite d'un emploi du temps. Ces fonctions seront reutilisees pour comparer les différentes approches.,,,,,,,,86a9609cfb40c41d,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-visualization-functions,code,fr,df6e0d615b3402be,"# === Fonctions de visualisation ===
 
 # Palette de couleurs pour les cours
@@ -14253,7 +14253,7 @@ def print_metrics(metrics, label=""""):
 
 
 print(""Fonctions de visualisation et d'evaluation definies."")",,,,,,,,df6e0d615b3402be,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-greedy-section,markdown,fr,e25adcba0a74e3fa,"---
+MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-greedy-section,markdown,fr,691b249311bb52f4,"---
 
 ## 3. Approche 1 : heuristique gloutonne (~8 min)
 
@@ -14261,20 +14261,20 @@ Avant d'utiliser un solveur specialise, testons une approche simple et naturelle
 
 ### Principe
 
-1. **Trier** les cours par degre de contrainte decroissant (les plus contraints d'abord)
+1. **Trier** les cours par degré de contrainte decroissant (les plus contraints d'abord)
 2. **Pour chaque cours**, parcourir les creneaux et salles dans l'ordre :
    - Verifier que la salle est compatible (capacite, equipement)
-   - Verifier qu'il n'y a pas de conflit de salle (meme creneau)
-   - Verifier qu'il n'y a pas de conflit d'enseignant (meme creneau)
+   - Verifier qu'il n'y a pas de conflit de salle (même creneau)
+   - Verifier qu'il n'y a pas de conflit d'enseignant (même creneau)
 3. **Affecter** au premier creneau+salle valide trouve
 
-L'idee du tri par contrainte (""fail-first"") est la meme que l'heuristique MRV vue dans les fondations CSP.
+L'idee du tri par contrainte (""fail-first"") est la même que l'heuristique MRV vue dans les fondations CSP.
 
 ### Limites attendues
 
 - Le glouton ne revient jamais en arriere (pas de backtracking)
-- Il peut echouer a trouver une solution meme s'il en existe une
-- Il ne minimise pas les contraintes souples (pas d'optimisation)",,,,,,,,e25adcba0a74e3fa,,,,,,,
+- Il peut echouer a trouver une solution même s'il en existe une
+- Il ne minimise pas les contraintes souples (pas d'optimisation)",,,,,,,,691b249311bb52f4,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-greedy-implementation,code,fr,52b2a973ba09385a,"def greedy_timetable():
     """"""Affecte les cours par heuristique gloutonne.
 
@@ -14342,7 +14342,7 @@ if greedy_success:
         if cname in greedy_schedule:
             rname, slot = greedy_schedule[cname]
             print(f""  {cname:<12} {rname:<12} {slot_label(slot)}"")",,,,,,,,52b2a973ba09385a,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-greedy-visualization-intro,markdown,fr,a28657cdc364a543,Visualisons le resultat sous forme de grille emploi du temps.,,,,,,,,a28657cdc364a543,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-greedy-visualization-intro,markdown,fr,016f0e28be16d728,Visualisons le résultat sous forme de grille emploi du temps.,,,,,,,,016f0e28be16d728,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-greedy-visualization,code,fr,739c3c5e4a572fe5,"if greedy_success:
     visualize_timetable(greedy_schedule, title=""Emploi du temps - Heuristique gloutonne"")
     plt.show()
@@ -14351,13 +14351,13 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-greedy-vi
     print_metrics(greedy_metrics, label=""(glouton)"")
 else:
     print(""Pas de solution gloutonne a visualiser."")",,,,,,,,739c3c5e4a572fe5,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-greedy-interpretation,markdown,fr,09cde473d342debc,"### Interpretation : heuristique gloutonne
+MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-greedy-interpretation,markdown,fr,b4ed555348e6b545,"### Interpretation : heuristique gloutonne
 
 **Sortie obtenue** : le glouton parvient a placer tous les cours (l'instance n'est pas trop contrainte), mais la qualite de la solution est perfectible.
 
-| Aspect | Observation | Probleme |
+| Aspect | Observation | Problème |
 |--------|-------------|----------|
-| Placement rapide | Quelques millisecondes | Pas de probleme |
+| Placement rapide | Quelques millisecondes | Pas de problème |
 | Concentration le lundi | Tous les premiers creneaux sont le lundi | Desequilibre des jours |
 | Pas d'optimisation | Trous possibles pour les enseignants | Qualite mediocre |
 
@@ -14366,7 +14366,7 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-greedy-in
 2. Aucune optimisation des contraintes souples (trous, equilibre)
 3. Sur des instances plus contraintes, le glouton echouerait car il ne revient pas en arriere
 
-> **Conclusion** : pour obtenir une solution de qualite, il faut un solveur capable d'explorer l'espace de recherche et d'optimiser les criteres souples.",,,,,,,,09cde473d342debc,,,,,,,
+> **Conclusion** : pour obtenir une solution de qualite, il faut un solveur capable d'explorer l'espace de recherche et d'optimiser les critères souples.",,,,,,,,b4ed555348e6b545,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-cpsat-section,markdown,fr,7f995af0bc28bde1,"---
 
 ## 4. Approche 2 : OR-Tools CP-SAT (~15 min)
@@ -14561,7 +14561,7 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-cpsat-vis
 
     cpsat_metrics = evaluate_schedule(cpsat_schedule)
     print_metrics(cpsat_metrics, label=""(CP-SAT)"")",,,,,,,,f6f47e8866d51dac,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-cpsat-interpretation,markdown,fr,e173b01287b59d8b,"### Interpretation : solution CP-SAT
+MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-cpsat-interpretation,markdown,fr,fdbdec24b5c64a0c,"### Interpretation : solution CP-SAT
 
 **Sortie obtenue** : le solveur CP-SAT trouve une solution optimale (ou quasi-optimale) en une soixantaine de millisecondes (61.6 ms).
 
@@ -14569,17 +14569,17 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-cpsat-int
 |--------|---------|--------|-------------|
 | Faisabilite | Oui | Oui (garanti si solution existe) | CP-SAT est complet |
 | Temps de calcul | < 1 ms | ~60 ms | Les deux sont rapides ici |
-| Optimisation souples | Non | Oui | Difference majeure |
+| Optimisation souples | Non | Oui | Différence majeure |
 | Equilibre des jours | Mediocre | Bien meilleur | Grace a l'objectif |
 | Trous enseignants | Non minimises | Minimises | Grace aux penalites |
 
 **Points cles** :
 1. CP-SAT **garantit** de trouver une solution si elle existe (completude)
 2. Les contraintes souples sont modelisees comme un **objectif a minimiser**
-3. Le modele separe clairement la structure (contraintes dures) de la qualite (objectif)
+3. Le modèle separe clairement la structure (contraintes dures) de la qualite (objectif)
 4. Le temps de resolution reste faible grace aux techniques de propagation et d'elagage internes au solveur
 
-> **Note technique** : CP-SAT utilise en interne une combinaison de backtracking, propagation de contraintes, et SAT solving (clause learning). C'est nettement plus sophistique que notre backtracking du Search-6.",,,,,,,,e173b01287b59d8b,,,,,,,
+> **Note technique** : CP-SAT utilise en interne une combinaison de backtracking, propagation de contraintes, et SAT solving (clause learning). C'est nettement plus sophistique que notre backtracking du Search-6.",,,,,,,,fdbdec24b5c64a0c,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-comparison-section,markdown,fr,1f77a62b61eb94ee,"### Comparaison glouton vs CP-SAT
 
 Comparons les deux approches sur les metriques de qualite.",,,,,,,,1f77a62b61eb94ee,,,,,,,
@@ -14652,9 +14652,9 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-compariso
     print(f""{'Ecart-type jours':<25} {greedy_metrics['day_balance_std']:>12.2f} {cpsat_metrics['day_balance_std']:>12.2f}"")
     print(f""{'Temps (ms)':<25} {greedy_time:>12.2f} {cpsat_time:>12.1f}"")
     print(""="" * 55)",,,,,,,,439a4aaf09a70145,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-comparison-interpretation,markdown,fr,a31b71e4d43fd5e8,"### Interpretation : comparaison des approches
+MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-comparison-interpretation,markdown,fr,58af374b7186c92c,"### Interpretation : comparaison des approches
 
-Les graphiques et le tableau mettent en evidence les differences fondamentales entre les deux approches.
+Les graphiques et le tableau mettent en evidence les différences fondamentales entre les deux approches.
 
 | Critere | Glouton | CP-SAT | Gagnant |
 |---------|---------|--------|--------|
@@ -14667,12 +14667,12 @@ Les graphiques et le tableau mettent en evidence les differences fondamentales e
 **Points cles** :
 1. Le glouton est utile comme **baseline** ou pour obtenir une solution initiale rapide
 2. CP-SAT excelle des que l'on a des **contraintes souples** a optimiser
-3. Sur des instances plus grandes (50+ cours), le glouton echouerait tandis que CP-SAT resterait performant",,,,,,,,a31b71e4d43fd5e8,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-minizinc-section,markdown,fr,2124a0b1ded23a29,"---
+3. Sur des instances plus grandes (50+ cours), le glouton echouerait tandis que CP-SAT resterait performant",,,,,,,,58af374b7186c92c,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-minizinc-section,markdown,fr,0e6230862f6767a1,"---
 
 ## 5. Introduction a MiniZinc (optionnel) (~10 min)
 
-**MiniZinc** est un langage de modelisation **declaratif** pour les problemes de contraintes. Contrairement a CP-SAT ou l'on construit le modele en Python (approche imperative), en MiniZinc on **declare** les variables, domaines et contraintes dans une syntaxe proche des mathematiques.
+**MiniZinc** est un langage de modelisation **declaratif** pour les problemes de contraintes. Contrairement a CP-SAT ou l'on construit le modèle en Python (approche imperative), en MiniZinc on **declare** les variables, domaines et contraintes dans une syntaxe proche des mathematiques.
 
 ### Approche imperative vs declarative
 
@@ -14684,9 +14684,9 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-minizinc-
 | Lisibilite | Code Python standard | Proche des specifications mathematiques |
 | Flexibilite | Totale (Python complet) | Limitee au langage MiniZinc |
 
-### Le modele MiniZinc
+### Le modèle MiniZinc
 
-Voici le meme probleme de timetabling exprime en MiniZinc. Observez la concision par rapport a la version Python.",,,,,,,,2124a0b1ded23a29,,,,,,,
+Voici le même problème de timetabling exprime en MiniZinc. Observez la concision par rapport a la version Python.",,,,,,,,0e6230862f6767a1,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-minizinc-model,code,fr,8caa4b991231dcd4,"# Modele MiniZinc pour le probleme d'emploi du temps
 # (affiche comme chaine de caracteres pour etude)
 
@@ -14759,23 +14759,23 @@ output [
 print(""Modele MiniZinc pour l'emploi du temps :"")
 print(""="" * 55)
 print(MINIZINC_MODEL)",,,,,,,,8caa4b991231dcd4,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-minizinc-explanation,markdown,fr,90d5a6da98d21451,"### Analyse du modele MiniZinc
+MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-minizinc-explanation,markdown,fr,837858d8abfe82f7,"### Analyse du modèle MiniZinc
 
 Decomposons la syntaxe MiniZinc :
 
-| Element MiniZinc | Equivalent Python/CP-SAT | Role |
+| Élément MiniZinc | Equivalent Python/CP-SAT | Rôle |
 |-----------------|-------------------------|------|
-| `int: num_courses = 8` | `num_courses = 8` | Parametre |
-| `array[1..n] of int: data` | `data = [...]` | Donnees |
+| `int: num_courses = 8` | `num_courses = 8` | Paramètre |
+| `array[1..n] of int: data` | `data = [...]` | Données |
 | `var 1..20: x` | `model.new_int_var(1, 20, 'x')` | Variable de decision |
 | `constraint ...` | `model.add(...)` | Contrainte |
 | `forall(c in 1..n)(...)` | `for c in range(n): model.add(...)` | Quantificateur universel |
 | `->` (implication) | `only_enforce_if` | Implication logique |
 | `solve minimize f` | `model.minimize(f)` | Objectif |
 
-**Avantage principal** : le modele MiniZinc est **beaucoup plus concis**. La contrainte C3 (pas de double reservation) s'ecrit en 3 lignes contre ~8 en CP-SAT.
+**Avantage principal** : le modèle MiniZinc est **beaucoup plus concis**. La contrainte C3 (pas de double reservation) s'ecrit en 3 lignes contre ~8 en CP-SAT.
 
-> **Pour aller plus loin** : voir [App-8 MiniZinc](../CSP/App-8-MiniZinc.ipynb) pour une introduction complete au langage MiniZinc avec des exemples progressifs.",,,,,,,,90d5a6da98d21451,,,,,,,
+> **Pour aller plus loin** : voir [App-8 MiniZinc](../CSP/App-8-MiniZinc.ipynb) pour une introduction complete au langage MiniZinc avec des exemples progressifs.",,,,,,,,837858d8abfe82f7,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-minizinc-execution,code,fr,06c02a99ee6be063,"# Execution du modele MiniZinc.
 #
 # Le package Python `minizinc` expose `instance.solve()` synchrone, qui echoue
@@ -14829,26 +14829,26 @@ else:
     finally:
         os.unlink(mzn_path)
 ",,,,,,,,06c02a99ee6be063,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-minizinc-interpretation,markdown,fr,f1517ad2ec90dbf0,"### Interpretation : MiniZinc vs CP-SAT
+MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-minizinc-interpretation,markdown,fr,c2d473f4ec79c6c0,"### Interpretation : MiniZinc vs CP-SAT
 
 | Critere | CP-SAT (Python) | MiniZinc | Commentaire |
 |---------|-----------------|----------|-------------|
-| Lignes de modele | ~80 | ~40 | MiniZinc 2x plus concis |
+| Lignes de modèle | ~80 | ~40 | MiniZinc 2x plus concis |
 | Lisibilite | Bonne (Python) | Excellente (math-like) | MiniZinc plus proche de la specification |
-| Performance | Tres bon | Variable selon solveur | CP-SAT souvent plus rapide |
+| Performance | Très bon | Variable selon solveur | CP-SAT souvent plus rapide |
 | Integration Python | Native | Via package minizinc | CP-SAT plus simple a integrer |
 | Multi-solveurs | CP-SAT uniquement | Gecode, Chuffed, CP-SAT... | MiniZinc plus flexible |
 
 **Quand utiliser quoi ?**
 - **CP-SAT** : integration dans une application Python, besoin de performance maximale
-- **MiniZinc** : prototypage rapide, exploration de modeles, enseignement
+- **MiniZinc** : prototypage rapide, exploration de modèles, enseignement
 
-> **Note** : il est possible d'utiliser CP-SAT **comme solveur** pour un modele MiniZinc. Le meilleur des deux mondes !",,,,,,,,f1517ad2ec90dbf0,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-analysis-section,markdown,fr,b18b8d5e0aa5f774,"---
+> **Note** : il est possible d'utiliser CP-SAT **comme solveur** pour un modèle MiniZinc. Le meilleur des deux mondes !",,,,,,,,c2d473f4ec79c6c0,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-analysis-section,markdown,fr,8049f7d9d47a0a8c,"---
 
 ## 6. Visualisation et analyse avancees (~5 min)
 
-Explorons la solution CP-SAT sous differents angles : emploi du temps par enseignant et taux d'utilisation des salles.",,,,,,,,b18b8d5e0aa5f774,,,,,,,
+Explorons la solution CP-SAT sous différents angles : emploi du temps par enseignant et taux d'utilisation des salles.",,,,,,,,8049f7d9d47a0a8c,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-teacher-view,code,fr,765017b714eb73ff,"def visualize_teacher_schedule(schedule, title=""Emploi du temps par enseignant""):
     """"""Affiche l'emploi du temps du point de vue de chaque enseignant.""""""
     fig, axes = plt.subplots(2, 2, figsize=(16, 10))
@@ -14964,35 +14964,35 @@ if cpsat_schedule:
     visualize_room_utilization(cpsat_schedule,
                               title=""Occupation des salles (CP-SAT)"")
     plt.show()",,,,,,,,7c300c85288dd6a1,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-analysis-interpretation,markdown,fr,a9ed498cfdb20abb,"### Interpretation : analyse de la solution
+MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-analysis-interpretation,markdown,fr,7d4819b6c58b6564,"### Interpretation : analyse de la solution
 
-**Vue enseignants** : chaque enseignant a un emploi du temps sans conflit. On verifie visuellement qu'aucun enseignant n'a deux cours au meme creneau.
+**Vue enseignants** : chaque enseignant a un emploi du temps sans conflit. On verifie visuellement qu'aucun enseignant n'a deux cours au même creneau.
 
 **Vue salles** : la heatmap montre le taux d'occupation de chaque salle.
 
 | Salle | Capacite | Cours affectes | Utilisation | Commentaire |
 |-------|----------|---------------|-------------|-------------|
 | Amphi_A | 120 | Algo, IA (gros effectifs) | Variable | Seule salle pour les grands groupes |
-| Salle_B | 60 | Probas, Systemes, BDD | Variable | Usage modere |
+| Salle_B | 60 | Probas, Systèmes, BDD | Variable | Usage modere |
 | Labo_C | 40 | Securite | Variable | Seul labo pour Securite (40 etu) avec Labo_D |
 
 **Points cles** :
-1. Les contraintes d'equipement creent un **goulot d'etranglement** sur Labo_D (Reseaux et Web ne peuvent aller qu'a Labo_D, 2 cours pour 1 salle)
+1. Les contraintes d'equipement créent un **goulot d'etranglement** sur Labo_D (Reseaux et Web ne peuvent aller qu'a Labo_D, 2 cours pour 1 salle)
 2. Amphi_A est sous-utilise en proportion mais indispensable pour les gros effectifs
-3. L'equilibre des jours depend directement de l'objectif d'optimisation",,,,,,,,a9ed498cfdb20abb,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-exercises-section,markdown,fr,823a0606bdc511e4,"---
+3. L'equilibre des jours depend directement de l'objectif d'optimisation",,,,,,,,7d4819b6c58b6564,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-exercises-section,markdown,fr,4810d9a3d8793af3,"---
 
 ## 7. Exercices
 
 ### Exemple guide : contrainte de 3 heures consecutives
 
-**Enonce** : ajoutez au modele CP-SAT la contrainte dure suivante :
+**Enonce** : ajoutez au modèle CP-SAT la contrainte dure suivante :
 
-> Aucun enseignant ne doit enseigner **3 creneaux consecutifs** dans la meme journee.
+> Aucun enseignant ne doit enseigner **3 creneaux consecutifs** dans la même journee.
 
 **Conseil** : pour chaque enseignant et chaque jour, verifiez que la somme des indicateurs de presence sur 3 creneaux consecutifs ne depasse pas 2.
 
-La cellule ci-dessous presente une implementation complete de cette contrainte dans la fonction `solve_timetable_cpsat`.",,,,,,,,823a0606bdc511e4,,,,,,,
+La cellule ci-dessous presente une implementation complete de cette contrainte dans la fonction `solve_timetable_cpsat`.",,,,,,,,4810d9a3d8793af3,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,f75fc998,code,fr,75065605352ad996,"# Exemple resolu : pas de 3 heures consecutives pour un enseignant
 
 def solve_timetable_cpsat(time_limit_s=10.0, verbose=True):
@@ -15170,7 +15170,7 @@ def solve_timetable_cpsat(time_limit_s=10.0, verbose=True):
 print(""Fonction solve_timetable_cpsat definie."")
 schedule, status, t, obj = solve_timetable_cpsat(verbose=True)
 print(f""Solution trouvee : {status}"")",,,,,,,,75065605352ad996,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,a0df6895,markdown,fr,437cb6d1e74d5b4f,"### Exercice 1b : minimiser le temps d'attente entre cours
+MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,a0df6895,markdown,fr,226b2c7090634dd0,"### Exercice 1b : minimiser le temps d'attente entre cours
 
 **Enonce** : un enseignant qui donne plusieurs cours dans la journee
 prefere qu'ils soient regroupes plutot qu'eparpilles. Ajoutez un
@@ -15178,12 +15178,12 @@ prefere qu'ils soient regroupes plutot qu'eparpilles. Ajoutez un
 des enseignants entre leurs cours.
 
 **Consignes** :
-1. Appelez `solve_timetable_cpsat` definie ci-dessus pour obtenir
+1. Appelez `solve_timetable_cpsat` définie ci-dessus pour obtenir
    une solution de base
 2. Copiez et modifiez la fonction pour ajouter une variable
    `idle_time` par enseignant et minimisez la somme
 3. Comparez les emplois du temps avec et sans l'objectif
-",,,,,,,,437cb6d1e74d5b4f,,,,,,,
+",,,,,,,,226b2c7090634dd0,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,ce9bedd1,code,fr,4a5d3f5a8dd88827,"# Exercice 1b : minimiser le temps d'attente
 
 # TODO: copiez solve_timetable_cpsat et ajoutez un objectif
@@ -15194,13 +15194,13 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,ce9bedd1,code,
 # Votre code ici
 print(""Exercice a completer"")
 ",,,,,,,,4a5d3f5a8dd88827,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-exercise-2,markdown,fr,49f6f2de8ca42bf4,"### Exercice 2 : disponibilite partielle des salles
+MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-exercise-2,markdown,fr,60b3b041dca52e68,"### Exercice 2 : disponibilite partielle des salles
 
 **Enonce** : supposez que Labo_C n'est disponible que les **Mardi, Mercredi et Jeudi** (il est reserve pour la maintenance les lundi et vendredi).
 
-Ajoutez cette contrainte au modele CP-SAT et resolvez.
+Ajoutez cette contrainte au modèle CP-SAT et resolvez.
 
-**Conseil** : les creneaux du lundi sont 0-3 et du vendredi 16-19. Si `course_room[c] == 2` (Labo_C), alors `course_slot[c]` ne doit pas etre dans ces creneaux.",,,,,,,,49f6f2de8ca42bf4,,,,,,,
+**Conseil** : les creneaux du lundi sont 0-3 et du vendredi 16-19. Si `course_room[c] == 2` (Labo_C), alors `course_slot[c]` ne doit pas etre dans ces creneaux.",,,,,,,,60b3b041dca52e68,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-exercise-2-code,code,fr,61a00f8a5f0188e8,"# Exercice 2 : disponibilite partielle de Labo_C
 
 
@@ -15221,20 +15221,20 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-exercise-
 
 
 print(""Exercice 2 : a completer"")",,,,,,,,61a00f8a5f0188e8,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,335af478,markdown,fr,42a52171b6da86bb,"### Optimisation avancee
+MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,335af478,markdown,fr,1e0a8fcfe16b4699,"### Optimisation avancee
 
-Extension du modele d'emploi du temps avec contraintes supplementaires.",,,,,,,,42a52171b6da86bb,,,,,,,
+Extension du modèle d'emploi du temps avec contraintes supplementaires.",,,,,,,,1e0a8fcfe16b4699,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,617ade50,code,fr,9fb1e9bc5de41fcb,"print(""Exercice a completer"")
 ",,,,,,,,9fb1e9bc5de41fcb,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-exercise-3,markdown,fr,59acb7ab15d6192c,"### Exercice 3 : groupes d'etudiants (pas de chevauchement)
+MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-exercise-3,markdown,fr,e1794463d2c9a803,"### Exercice 3 : groupes d'etudiants (pas de chevauchement)
 
-**Enonce** : supposez que les etudiants de 2eme annee suivent a la fois Algo, Probas et Systemes. Ces 3 cours ne doivent donc pas etre au meme creneau.
+**Enonce** : supposez que les etudiants de 2eme annee suivent a la fois Algo, Probas et Systèmes. Ces 3 cours ne doivent donc pas etre au même creneau.
 
-De meme, les etudiants de 3eme annee suivent IA, Securite et Web.
+De même, les etudiants de 3eme annee suivent IA, Securite et Web.
 
 Ajoutez ces contraintes de non-chevauchement par groupe.
 
-**Conseil** : c'est similaire aux contraintes d'enseignant -- des paires de cours qui ne peuvent pas partager le meme creneau.",,,,,,,,59acb7ab15d6192c,,,,,,,
+**Conseil** : c'est similaire aux contraintes d'enseignant -- des paires de cours qui ne peuvent pas partager le même creneau.",,,,,,,,e1794463d2c9a803,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-exercise-3-code,code,fr,fba8014f198dbda5,"# Exercice 3 : contraintes de groupes d'etudiants
 
 # A COMPLETER
@@ -15248,7 +15248,7 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-exercise-
 #         model.add(course_slot[c1] != course_slot[c2])
 
 print(""Exercice 3 : a completer"")",,,,,,,,fba8014f198dbda5,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-conclusion,markdown,fr,5bb1b4bb65fcc31b,"---
+MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-conclusion,markdown,fr,d976bec15cc0cef4,"---
 
 ## Recapitulatif
 
@@ -15263,7 +15263,7 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-conclusio
 ### Lecons cles
 
 1. **Separation dur/souple** : les contraintes dures definissent la faisabilite, les souples la qualite
-2. **Modelisation > algorithme** : bien modeliser le probleme est souvent plus important que le choix de l'algorithme
+2. **Modelisation > algorithme** : bien modeliser le problème est souvent plus important que le choix de l'algorithme
 3. **Solveurs industriels** : CP-SAT peut traiter des instances avec des centaines de cours en quelques secondes
 4. **Declaratif vs imperatif** : MiniZinc permet de prototyper rapidement, CP-SAT s'integre mieux dans une application
 
@@ -15273,8 +15273,8 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-conclusio
 |----------|-----------------|----------------|
 | Universite (departement) | 50-200 cours, 20-50 salles | CP-SAT, Gurobi |
 | Universite (campus) | 500-2000 cours | Solveurs commerciaux (UniTime) |
-| Ecole primaire | 20-30 cours | CP-SAT suffit largement |
-| Hopital (planning equipes) | 100+ employes | Variante du nurse scheduling |
+| École primaire | 20-30 cours | CP-SAT suffit largement |
+| Hopital (planning équipes) | 100+ employes | Variante du nurse scheduling |
 
 ### Pour aller plus loin
 
@@ -15287,7 +15287,7 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling.ipynb,cell-conclusio
 - Lewis, R. *A Guide to Graph Colouring: Algorithms and Applications*, Springer, 2021
 - Schaerf, A. *A Survey of Automated Timetabling*, Artificial Intelligence Review, 1999
 - Google OR-Tools : https://developers.google.com/optimization
-- MiniZinc : https://www.minizinc.org/",,,,,,,,5bb1b4bb65fcc31b,,,,,,,
+- MiniZinc : https://www.minizinc.org/",,,,,,,,d976bec15cc0cef4,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper-Csharp.ipynb,f9b04a05,markdown,fr,53ee8adf9c25200d,"# App-6 - Demineur (C#) : CSP, probabilites et NP-completude
 
 > **Jumeau C#** du notebook [App-6-Minesweeper.ipynb](App-6-Minesweeper.ipynb).
@@ -15468,14 +15468,14 @@ void DrawBoard(MinesweeperBoard b, string title, bool showMines = false) {
 DrawBoard(board0, ""Etat apres le premier clic (4,4)"");
 DrawBoard(board0, ""Plateau complet (mines revelees)"", showMines: true);
 ",,,,,,,,c739cd98c9ee3f60,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper-Csharp.ipynb,b3a4aecd,markdown,fr,3a147f5178aa5cac,"## 3. Solveur par regles simples
+MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper-Csharp.ipynb,b3a4aecd,markdown,fr,f719a1542480aa5c,"## 3. Solveur par règles simples
 
-Deux regles locales suffisantes pour de nombreuses situations :
+Deux règles locales suffisantes pour de nombreuses situations :
 
-- **Regle 1** : si le nombre de mines restantes à placer autour d'une cellule révélée
+- **Règle 1** : si le nombre de mines restantes à placer autour d'une cellule révélée
   égale le nombre de voisins inconnus, alors **tous les inconnus sont des mines**.
-- **Regle 2** : s'il ne reste aucune mine à placer autour d'une cellule révélée,
-  alors **tous les inconnus sont sûrs**.",,,,,,,,3a147f5178aa5cac,,,,,,,
+- **Règle 2** : s'il ne reste aucune mine à placer autour d'une cellule révélée,
+  alors **tous les inconnus sont sûrs**.",,,,,,,,f719a1542480aa5c,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper-Csharp.ipynb,d46939ae,code,fr,2aef6876724b4933,"public class RuleBasedSolver
 {
     public MinesweeperBoard Board;
@@ -15658,7 +15658,7 @@ if (frontier.Count > 0 && frontier.Count <= 12) {
     Console.WriteLine();
 }
 ",,,,,,,,a63bff609e7c57bf,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper-Csharp.ipynb,3d618f42,markdown,fr,8ea548b790e8218a,"## 5. Solveur probabiliste — combiner regles, CSP et choix min-risk
+MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper-Csharp.ipynb,3d618f42,markdown,fr,6102f7b5ecaf2d51,"## 5. Solveur probabiliste — combiner règles, CSP et choix min-risk
 
 Quand ni les règles ni le CSP ne forcent de cellule, on choisit la cellule à
 **plus faible probabilité de mine**. Le solveur probabiliste orchestre :
@@ -15667,7 +15667,7 @@ Quand ni les règles ni le CSP ne forcent de cellule, on choisit la cellule à
 2. Si bloqué, résoudre le CSP pour les cellules forcées.
 3. Si toujours bloqué, calculer P(mine) de chaque cellule (frontière via CSP,
    hors-frontière via ratio mines-restantes / cellules-hors-frontière) et
-   révéler la cellule la moins risquée.",,,,,,,,8ea548b790e8218a,,,,,,,
+   révéler la cellule la moins risquée.",,,,,,,,6102f7b5ecaf2d51,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper-Csharp.ipynb,7e15d5b4,code,fr,2bb40f57e1ef0b76,"public class ProbabilisticSolver
 {
     public MinesweeperBoard Board;
@@ -15735,13 +15735,13 @@ Console.WriteLine($""Partie probabiliste : gagne={won}"");
 Console.WriteLine($""Decisions : rules={pSolver.Decisions[""rules""]}, csp={pSolver.Decisions[""csp""]}, guess={pSolver.Decisions[""guess""]}"");
 Console.WriteLine($""Devinettes faites : {pSolver.Guesses.Count}"");
 ",,,,,,,,2bb40f57e1ef0b76,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper-Csharp.ipynb,ec8421d6,markdown,fr,f2eda2cae04a2f0b,"## 6. Strategies pures pour le benchmark
+MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper-Csharp.ipynb,ec8421d6,markdown,fr,dd10c32a584f65b4,"## 6. Stratégies pures pour le benchmark
 
 Trois stratégies isolées pour mesurer chaque contribution :
 
 - **play_rule_only** : règles + tirage aléatoire quand bloqué.
 - **play_csp_only** : règles + CSP + tirage aléatoire quand bloqué.
-- **play_probabilistic** : règles + CSP + choix min-risk quand bloqué.",,,,,,,,f2eda2cae04a2f0b,,,,,,,
+- **play_probabilistic** : règles + CSP + choix min-risk quand bloqué.",,,,,,,,dd10c32a584f65b4,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper-Csharp.ipynb,73c294ad,code,fr,b9d7381354f28f9c,"// Strategie 1 : regles + aleatoire quand bloque.
 (string, Dictionary<string,int>) PlayRuleOnly(MinesweeperBoard b, Random rng) {
     var dec = new Dictionary<string,int> { [""rules""]=0, [""random""]=0 };
@@ -15966,15 +15966,15 @@ CSP devient-il plus déterminant sur les grands plateaux ?
 MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,deb2baa1,code,fr,d8cfd07b7b0f3965,"# Parameters
 BATCH_MODE = ""true""
 ",,,,,,,,d8cfd07b7b0f3965,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-00,markdown,fr,aa41f33da082c5db,"# App-6 - Demineur : CSP, Probabilites et NP-completude
+MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-00,markdown,fr,928bb9ce19e794d6,"# App-6 - Demineur : CSP, Probabilites et NP-completude
 
 **Navigation** : [<< App-5 Timetabling](App-5-Timetabling.ipynb) | [Index](../README.md) | [App-7 Wordle >>](App-7-Wordle.ipynb)
 
 ## Objectifs d'apprentissage
 
 A la fin de ce notebook, vous saurez :
-1. **Modeliser** le Demineur comme un probleme de satisfaction de contraintes (CSP)
-2. **Implementer** un solveur par regles simples pour les cas non ambigus
+1. **Modeliser** le Demineur comme un problème de satisfaction de contraintes (CSP)
+2. **Implementer** un solveur par règles simples pour les cas non ambigus
 3. **Construire** un solveur CSP qui enumere les solutions et deduit les cellules sures/minees
 4. **Etendre** le solveur avec un raisonnement probabiliste pour les cas ambigus
 5. **Comparer** les trois approches en termes de taux de victoire et de performance
@@ -15988,23 +15988,23 @@ A la fin de ce notebook, vous saurez :
 
 ### Source
 
-Adapte du projet etudiant EPITA PPC 2025 : [jsboigeEpita/2025-PPC RDER-minesweeper](https://github.com/jsboigeEpita/2025-PPC) (CSP + probabilites, preuve NP-completude).",,,,,,,,aa41f33da082c5db,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-01,markdown,fr,e4ef469bacf16a04,"---
+Adapte du projet etudiant EPITA PPC 2025 : [jsboigeEpita/2025-PPC RDER-minesweeper](https://github.com/jsboigeEpita/2025-PPC) (CSP + probabilites, preuve NP-completude).",,,,,,,,928bb9ce19e794d6,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-01,markdown,fr,5a78eaa555d814ee,"---
 
-## 1. Introduction : le Demineur comme probleme de contraintes (~5 min)
+## 1. Introduction : le Demineur comme problème de contraintes (~5 min)
 
 Le **Demineur** (Minesweeper) est un jeu classique ou le joueur doit reveler toutes les cellules sures d'une grille sans cliquer sur une mine. Chaque cellule revelee affiche un nombre indiquant combien de ses 8 voisines contiennent une mine.
 
 ### Pourquoi le Demineur interesse-t-il l'IA ?
 
-Le Demineur est bien plus qu'un jeu : c'est un **probleme NP-complet**. Richard Kaye a demontre en 2000 que determiner si une configuration de Demineur est consistante (c'est-a-dire s'il existe un placement de mines compatible avec les indices visibles) est **NP-complet**.
+Le Demineur est bien plus qu'un jeu : c'est un **problème NP-complet**. Richard Kaye a demontre en 2000 que determiner si une configuration de Demineur est consistante (c'est-a-dire s'il existe un placement de mines compatible avec les indices visibles) est **NP-complet**.
 
 | Propriete | Valeur |
 |-----------|--------|
 | Complexite | NP-complet (Kaye, 2000) |
-| Type de probleme | Satisfaction de contraintes |
+| Type de problème | Satisfaction de contraintes |
 | Variables | Cellules inconnues (mine ou sure) |
-| Contraintes | Indices numeriques des cellules revelees |
+| Contraintes | Indices numériques des cellules revelees |
 | Reduction | Reduction depuis SAT / Circuit-SAT |
 
 ### Modelisation CSP
@@ -16025,9 +16025,9 @@ Nous allons construire trois solveurs de complexite croissante :
 
 | Approche | Principe | Quand l'utiliser |
 |----------|----------|------------------|
-| Regles simples | Deductions deterministes locales | Cas triviaux |
+| Règles simples | Deductions déterministes locales | Cas triviaux |
 | CSP complet | Enumeration des solutions, cellules forcees | Cas ambigus localement |
-| CSP + Probabilites | Comptage de solutions, choix optimal | Quand aucune cellule n'est forcee |",,,,,,,,e4ef469bacf16a04,,,,,,,
+| CSP + Probabilites | Comptage de solutions, choix optimal | Quand aucune cellule n'est forcee |",,,,,,,,5a78eaa555d814ee,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-02,code,fr,22dca9e6774df1ad,"# Imports pour tout le notebook
 import numpy as np
 import matplotlib.pyplot as plt
@@ -16301,11 +16301,11 @@ plt.show()
 # Visualiser avec les mines (pour reference)
 fig = draw_board(board, title=""Plateau complet (mines revelees)"", show_mines=True)
 plt.show()",,,,,,,,4848248e6feadd5f,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-09,markdown,fr,f78b5be14fa37653,"### Interpretation : representation du plateau
+MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-09,markdown,fr,f33548c2a58f7c67,"### Interpretation : representation du plateau
 
-**Sortie obtenue** : deux vues du meme plateau -- la vue du joueur (cellules cachees en gris) et la vue complete avec les mines.
+**Sortie obtenue** : deux vues du même plateau -- la vue du joueur (cellules cachees en gris) et la vue complete avec les mines.
 
-| Element | Signification |
+| Élément | Signification |
 |---------|---------------|
 | Chiffre colore | Nombre de mines dans les 8 voisines |
 | Gris uni | Cellule non revelee (inconnue) |
@@ -16314,26 +16314,26 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-09,markdo
 **Points cles** :
 1. Le premier clic avec `safe_cell` garantit que ni la cellule cliquee ni ses voisines ne contiennent de mine -- c'est le comportement standard du jeu
 2. Les cellules affichant 0 declenchent une revelation en cascade de leurs voisines
-3. La frontiere entre cellules revelees et cachees constitue notre zone de travail pour le solveur",,,,,,,,f78b5be14fa37653,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-10,markdown,fr,be572d1f7e6e1cf3,"---
+3. La frontiere entre cellules revelees et cachees constitue notre zone de travail pour le solveur",,,,,,,,f33548c2a58f7c67,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-10,markdown,fr,41988b41185548bd,"---
 
-## 3. Approche 1 : solveur par regles simples (~8 min)
+## 3. Approche 1 : solveur par règles simples (~8 min)
 
-Le solveur le plus basique applique deux regles deterministes en boucle :
+Le solveur le plus basique applique deux règles déterministes en boucle :
 
-### Regle 1 -- Toutes les voisines sont des mines
+### Règle 1 -- Toutes les voisines sont des mines
 
 Si une cellule revelee affiche $n$ et a exactement $n$ voisines inconnues (ni revelees ni marquees), alors **toutes** ces voisines sont des mines.
 
 $$\text{unknown\_count}(i,j) = n_{i,j} - \text{flagged\_count}(i,j) \implies \text{marquer toutes les inconnues}$$
 
-### Regle 2 -- Toutes les voisines sont sures
+### Règle 2 -- Toutes les voisines sont sures
 
-Si une cellule revelee affiche $n$ et a deja $n$ voisines marquees, alors toutes les voisines inconnues restantes sont **sures**.
+Si une cellule revelee affiche $n$ et a déjà $n$ voisines marquees, alors toutes les voisines inconnues restantes sont **sures**.
 
 $$\text{flagged\_count}(i,j) = n_{i,j} \implies \text{reveler toutes les inconnues}$$
 
-Ces deux regles suffisent pour les configurations simples, mais echouent sur les cas ambigus.",,,,,,,,be572d1f7e6e1cf3,,,,,,,
+Ces deux règles suffisent pour les configurations simples, mais echouent sur les cas ambigus.",,,,,,,,41988b41185548bd,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-11,code,fr,fbd571cf32ad37db,"class RuleBasedSolver:
     """"""Solveur par regles simples (deductions locales).
 
@@ -16394,7 +16394,7 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-11,code,f
 
 
 print(""Classe RuleBasedSolver definie."")",,,,,,,,fbd571cf32ad37db,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-12,markdown,fr,8695e71709fa9a3f,Testons le solveur par regles sur notre plateau d'exemple.,,,,,,,,8695e71709fa9a3f,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-12,markdown,fr,b3961485583bad18,Testons le solveur par règles sur notre plateau d'exemple.,,,,,,,,b3961485583bad18,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-13,code,fr,a0043e91fa39d795,"# Copier le plateau pour tester le solveur par regles
 board_rules = board.copy()
 solver_rules = RuleBasedSolver(board_rules)
@@ -16426,32 +16426,32 @@ fig = draw_board(board_rules,
                  title=f""Apres solveur par regles ({len(solver_rules.moves_log)} coups)"",
                  show_mines=True)
 plt.show()",,,,,,,,a0043e91fa39d795,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-14,markdown,fr,69d93c0b549dfdf7,"### Interpretation : solveur par regles
+MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-14,markdown,fr,4dc4b417246e2b50,"### Interpretation : solveur par règles
 
-**Sortie obtenue** : le solveur par regles a effectue des deductions locales en quelques iterations.
+**Sortie obtenue** : le solveur par règles a effectue des deductions locales en quelques itérations.
 
 | Mesure | Valeur | Commentaire |
 |--------|--------|-------------|
-| Iterations | Typiquement 3-8 | Convergence rapide |
+| Itérations | Typiquement 3-8 | Convergence rapide |
 | Cellules resolues | Variable | Depend de la configuration |
 | Cellules restantes | >0 en general | Les cas ambigus ne sont pas resolus |
 
 **Points cles** :
-1. Les regles simples sont **rapides** (temps constant par cellule par iteration) et **sures** (pas de risque d'erreur)
+1. Les règles simples sont **rapides** (temps constant par cellule par itération) et **sures** (pas de risque d'erreur)
 2. Elles se bloquent quand aucune cellule n'est localement determinee -- c'est la **frontiere du raisonnement local**
 3. En pratique, elles resolvent environ 30 a 50% des decisions sur un plateau 8x8 typique
 
-> **Limite fondamentale** : les regles ne combinent pas les contraintes de plusieurs cellules revelees. Le CSP va combler cette lacune.",,,,,,,,69d93c0b549dfdf7,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-15,markdown,fr,ab196313cc067db7,"---
+> **Limite fondamentale** : les règles ne combinent pas les contraintes de plusieurs cellules revelees. Le CSP va combler cette lacune.",,,,,,,,4dc4b417246e2b50,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-15,markdown,fr,090ee868fe56bdf3,"---
 
 ## 4. Approche 2 : solveur CSP (~12 min)
 
-Le solveur CSP va plus loin que les regles simples en considerant **simultanement** toutes les contraintes. L'idee est :
+Le solveur CSP va plus loin que les règles simples en considerant **simultanement** toutes les contraintes. L'idee est :
 
 1. **Modeliser** les cellules inconnues proches de la frontiere comme des variables binaires
 2. **Poser les contraintes** : chaque cellule revelee impose une somme sur ses voisines inconnues
 3. **Enumerer les solutions** du CSP
-4. **Deduire** : si une variable vaut la meme chose (0 ou 1) dans **toutes** les solutions, elle est determinee
+4. **Deduire** : si une variable vaut la même chose (0 ou 1) dans **toutes** les solutions, elle est determinee
 
 ### Pourquoi est-ce plus puissant ?
 
@@ -16463,11 +16463,11 @@ Considerons cette configuration :
 1  ?  ?
 ```
 
-Les regles simples ne deduisent rien (chaque `1` a 2 ou 3 voisines inconnues). Mais en combinant les trois contraintes, le CSP peut determiner que certaines cellules sont necessairement sures ou minees.
+Les règles simples ne deduisent rien (chaque `1` a 2 ou 3 voisines inconnues). Mais en combinant les trois contraintes, le CSP peut determiner que certaines cellules sont necessairement sures ou minees.
 
 ### Optimisation : travailler sur la frontiere
 
-Pour eviter d'enumerer les solutions sur toute la grille, nous ne considerons que les cellules inconnues **adjacentes a au moins une cellule revelee**. Les cellules completement isolees ne sont pas contraintes localement.",,,,,,,,ab196313cc067db7,,,,,,,
+Pour eviter d'enumerer les solutions sur toute la grille, nous ne considerons que les cellules inconnues **adjacentes a au moins une cellule revelee**. Les cellules completement isolees ne sont pas contraintes localement.",,,,,,,,090ee868fe56bdf3,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-16,code,fr,8c692713dd86dda1,"class CSPSolver:
     """"""Solveur CSP pour le Demineur.
 
@@ -16588,7 +16588,7 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-16,code,f
 
 
 print(""Classe CSPSolver definie."")",,,,,,,,8c692713dd86dda1,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-17,markdown,fr,b14a11701038b959,Testons le solveur CSP sur le plateau apres que le solveur par regles s'est bloque.,,,,,,,,b14a11701038b959,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-17,markdown,fr,17df666abe0fc570,Testons le solveur CSP sur le plateau après que le solveur par règles s'est bloque.,,,,,,,,17df666abe0fc570,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-18,code,fr,c46437b7f4a59102,"# Partir du plateau deja partiellement resolu par les regles
 board_csp = board_rules.copy()
 csp_solver = CSPSolver(board_csp)
@@ -16623,7 +16623,7 @@ fig = draw_board(board_csp,
                  highlight_safe=safe_cells,
                  highlight_mines=mine_cells)
 plt.show()",,,,,,,,c46437b7f4a59102,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-19,markdown,fr,277b6f814cbc3816,"### Interpretation : deductions CSP
+MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-19,markdown,fr,4e2708d2b66f446a,"### Interpretation : deductions CSP
 
 **Sortie obtenue** : le CSP a enumere toutes les solutions compatibles avec les contraintes visibles et a identifie les cellules determinees.
 
@@ -16632,17 +16632,17 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-19,markdo
 | Variables | Cellules de la frontiere | Seules les cellules adjacentes aux revelees |
 | Solutions | Variable | Nombre de placements de mines compatibles |
 | Cellules deduites | Forcees dans toutes les solutions | Certitude absolue |
-| Non determinees | Valeur differente selon les solutions | Necessite un choix |
+| Non determinees | Valeur différente selon les solutions | Necessite un choix |
 
 **Points cles** :
-1. Le CSP combine les contraintes de **plusieurs** cellules revelees, ce qui lui permet de deduire des cellules que les regles simples ne voient pas
+1. Le CSP combine les contraintes de **plusieurs** cellules revelees, ce qui lui permet de deduire des cellules que les règles simples ne voient pas
 2. L'enumeration des solutions est **exacte** : si une cellule est dite sure, elle l'est avec certitude
 3. Le cout est l'enumeration exhaustive, qui peut etre exponentielle dans le pire cas
 
-> **NP-completude en action** : le nombre de solutions peut exploser exponentiellement avec la taille de la frontiere. Sur un plateau 16x16, la frontiere peut contenir 30+ cellules, rendant l'enumeration couteuse.",,,,,,,,277b6f814cbc3816,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-20,markdown,fr,f3839fdeca168656,"### Application des deductions CSP
+> **NP-completude en action** : le nombre de solutions peut exploser exponentiellement avec la taille de la frontiere. Sur un plateau 16x16, la frontiere peut contenir 30+ cellules, rendant l'enumeration couteuse.",,,,,,,,4e2708d2b66f446a,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-20,markdown,fr,05dec2da1d438fdf,"### Application des deductions CSP
 
-Appliquons les deductions du CSP au plateau, puis relançons les regles simples pour propager les consequences.",,,,,,,,f3839fdeca168656,,,,,,,
+Appliquons les deductions du CSP au plateau, puis relançons les règles simples pour propager les consequences.",,,,,,,,05dec2da1d438fdf,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-21,code,fr,80deb12f8d717e15,"# Appliquer les deductions CSP
 for cell in mine_cells:
     board_csp.flag(*cell)
@@ -16667,13 +16667,13 @@ fig = draw_board(board_csp,
                  title=f""Apres CSP + regles ({unknown} inconnues restantes)"",
                  show_mines=True)
 plt.show()",,,,,,,,80deb12f8d717e15,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-22,markdown,fr,6e2c5653d47af2dc,"---
+MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-22,markdown,fr,33407e3867bdf4ab,"---
 
 ## 5. Approche 3 : extension probabiliste (~10 min)
 
 Quand le CSP ne determine pas toutes les cellules, il faut **choisir** une cellule a reveler. Ce choix est risque : nous pourrions toucher une mine.
 
-### Strategie probabiliste
+### Stratégie probabiliste
 
 L'idee est de **compter les solutions** pour chaque cellule inconnue :
 
@@ -16685,7 +16685,7 @@ On choisit alors la cellule avec la **plus faible probabilite de mine** pour la 
 
 Les cellules completement isolees (non adjacentes a une cellule revelee) ne sont pas dans le CSP. Pour elles, la probabilite est calculee a partir du nombre de mines restantes et du nombre de cellules hors frontiere :
 
-$$P(\text{mine}_{\text{isolee}}) = \frac{\text{mines non attribuees}}{\text{cellules hors frontiere}}$$",,,,,,,,6e2c5653d47af2dc,,,,,,,
+$$P(\text{mine}_{\text{isolee}}) = \frac{\text{mines non attribuees}}{\text{cellules hors frontiere}}$$",,,,,,,,33407e3867bdf4ab,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-23,code,fr,1d93e8eba898859b,"class ProbabilisticSolver:
     """"""Solveur combinant regles, CSP et probabilites.
 
@@ -16826,21 +16826,21 @@ fig = draw_board(board_prob,
                  title=f""Partie {'GAGNEE' if won else 'PERDUE'}"",
                  show_mines=True)
 plt.show()",,,,,,,,2713403fb3f9e1f7,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-26,markdown,fr,334d1d282a6880e7,"### Interpretation : partie complete avec solveur probabiliste
+MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-26,markdown,fr,11c6299582b70d61,"### Interpretation : partie complete avec solveur probabiliste
 
 **Sortie obtenue** : le solveur a joue une partie complete en combinant les trois niveaux de raisonnement.
 
-| Methode | Decisions | Role |
+| Méthode | Decisions | Rôle |
 |---------|-----------|------|
-| Regles simples | Majorite des decisions | Deductions locales gratuites |
+| Règles simples | Majorite des decisions | Deductions locales gratuites |
 | CSP | Complement significatif | Deductions globales exactes |
 | Devinettes | Quelques-unes | Choix sous incertitude |
 
 **Points cles** :
-1. La grande majorite des decisions sont prises par les **regles simples**, qui sont instantanees
-2. Le **CSP** intervient quand les regles se bloquent et resout les cas ambigus localement mais determines globalement
+1. La grande majorite des decisions sont prises par les **règles simples**, qui sont instantanees
+2. Le **CSP** intervient quand les règles se bloquent et resout les cas ambigus localement mais determines globalement
 3. Les **devinettes** sont rares mais inevitables (le Demineur est NP-complet, certaines configurations sont intrinsequement ambigues)
-4. Chaque devinette est faite de maniere **optimale** : on choisit la cellule la moins risquee",,,,,,,,334d1d282a6880e7,,,,,,,
+4. Chaque devinette est faite de maniere **optimale** : on choisit la cellule la moins risquee",,,,,,,,11c6299582b70d61,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-27,markdown,fr,895cf32a4d40cbe6,"### Visualisation des probabilites
 
 Repartons d'un plateau neuf et visualisons les probabilites calculees par le CSP a un instant ou le solveur doit deviner.",,,,,,,,895cf32a4d40cbe6,,,,,,,
@@ -16913,18 +16913,18 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-29,markdo
 1. Les probabilites sont **exactes** (calculees par enumeration complete)
 2. Le solveur choisit toujours la cellule a **0%** si elle existe, puis la plus faible probabilite sinon
 3. Les probabilites dependent des solutions **globales** du CSP, pas seulement des voisins locaux",,,,,,,,6b07b6463fdac579,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-30,markdown,fr,63c1dc7d2edb04fa,"---
+MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-30,markdown,fr,f5c3b80b01fa2f36,"---
 
 ## 6. Analyse des performances (~7 min)
 
-Comparons les trois approches sur un grand nombre de parties pour mesurer leur taux de victoire et leur temps d'execution.
+Comparons les trois approches sur un grand nombre de parties pour mesurer leur taux de victoire et leur temps d'exécution.
 
 ### Protocole experimental
 
 - 100 parties par approche
 - Plateau 8x8 avec 10 mines (difficulte standard ""debutant"")
 - Premier clic garanti sur (4, 4)
-- Meme sequence aleatoire pour toutes les approches",,,,,,,,63c1dc7d2edb04fa,,,,,,,
+- Même sequence aleatoire pour toutes les approches",,,,,,,,f5c3b80b01fa2f36,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-31,code,fr,05ad276d83799d6f,"def play_rule_only(board):
     """"""Joue une partie avec les regles simples uniquement.
 
@@ -17008,7 +17008,7 @@ def play_probabilistic(board):
 
 
 print(""Fonctions de simulation definies."")",,,,,,,,05ad276d83799d6f,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,f9cg0uqgn9b,markdown,fr,8335f6c33f19aa88,Lançons le benchmark sur 100 parties pour chaque approche. L'execution peut prendre quelques secondes.,,,,,,,,8335f6c33f19aa88,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,f9cg0uqgn9b,markdown,fr,19add464c8d6c42c,Lançons le benchmark sur 100 parties pour chaque approche. L'exécution peut prendre quelques secondes.,,,,,,,,19add464c8d6c42c,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-32,code,fr,fa4df449633de545,"# Benchmark sur 100 parties
 N_GAMES = 100
 ROWS, COLS, MINES = 8, 8, 10
@@ -17100,26 +17100,26 @@ plt.suptitle(f'Benchmark des solveurs de Demineur ({ROWS}x{COLS}, {MINES} mines,
              fontsize=13, fontweight='bold')
 plt.tight_layout()
 plt.show()",,,,,,,,92c821c2c0d507af,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-35,markdown,fr,0640837406f2412d,"### Interpretation : comparaison des approches
+MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-35,markdown,fr,8a076df0ac4f7ff1,"### Interpretation : comparaison des approches
 
 **Sortie obtenue** : le tableau et les graphiques montrent les performances des trois approches.
 
 | Approche | Taux de victoire | Temps moyen | Compromis |
 |----------|-----------------|-------------|----------|
-| Regles + aleatoire | ~75% | Tres rapide | Simplement des deductions locales |
-| Regles + CSP + aleatoire | ~89% | Modere | Deductions globales mais choix aleatoire |
-| Regles + CSP + probabilites | ~87% | Modere | Choix optimal sous incertitude |
+| Règles + aleatoire | ~75% | Très rapide | Simplement des deductions locales |
+| Règles + CSP + aleatoire | ~89% | Modere | Deductions globales mais choix aleatoire |
+| Règles + CSP + probabilites | ~87% | Modere | Choix optimal sous incertitude |
 
 **Points cles** :
-1. Le **CSP** apporte un gain significatif par rapport aux regles seules, en deduisant des cellules que le raisonnement local ne voit pas
+1. Le **CSP** apporte un gain significatif par rapport aux règles seules, en deduisant des cellules que le raisonnement local ne voit pas
 2. Les **probabilites** ameliorent encore le taux de victoire en remplacant le choix aleatoire par un choix optimal
-3. Le **cout** du CSP (enumeration des solutions) est visible dans le temps moyen (15.3 ms vs 2.5 ms pour les regles seules), mais reste acceptable sur 8x8
-4. Meme le meilleur solveur ne gagne pas 100% du temps : certaines configurations du Demineur sont **fondamentalement ambigues** (consequence de la NP-completude)
+3. Le **cout** du CSP (enumeration des solutions) est visible dans le temps moyen (15.3 ms vs 2.5 ms pour les règles seules), mais reste acceptable sur 8x8
+4. Même le meilleur solveur ne gagne pas 100% du temps : certaines configurations du Demineur sont **fondamentalement ambigues** (consequence de la NP-completude)
 
-> **A retenir** : le triplet regles/CSP/probabilites illustre une strategie generale en IA -- commencer par les methodes les moins couteuses, puis monter en puissance si necessaire.",,,,,,,,0640837406f2412d,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-36,markdown,fr,586634067e13af37,"### Replay d'une partie (etape par etape)
+> **A retenir** : le triplet règles/CSP/probabilites illustre une stratégie générale en IA -- commencer par les méthodes les moins couteuses, puis monter en puissance si necessaire.",,,,,,,,8a076df0ac4f7ff1,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-36,markdown,fr,314ffbed843c2c29,"### Replay d'une partie (étape par étape)
 
-Visualisons les etapes cles d'une partie pour mieux comprendre le comportement du solveur.",,,,,,,,586634067e13af37,,,,,,,
+Visualisons les étapes cles d'une partie pour mieux comprendre le comportement du solveur.",,,,,,,,314ffbed843c2c29,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-37,code,fr,018f6ec2db21e741,"# Replay d'une partie avec snapshots
 random.seed(42)
 np.random.seed(42)
@@ -17239,26 +17239,26 @@ plt.show()
 
 print(f""\nIssue : {'VICTOIRE' if board_replay.won else 'DEFAITE'}"")
 print(f""Etapes totales : {len(snapshots)}"")",,,,,,,,018f6ec2db21e741,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-38,markdown,fr,f0ed8e436b7a240e,"### Interpretation : replay de partie
+MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-38,markdown,fr,2e3dad01b2f14dd4,"### Interpretation : replay de partie
 
-**Sortie obtenue** : la sequence d'etapes montre la progression du solveur.
+**Sortie obtenue** : la sequence d'étapes montre la progression du solveur.
 
 **Points cles** :
 1. Le premier clic ouvre une zone (propagation des zeros)
-2. Les regles simples font des progres rapides dans les premieres etapes
-3. Le CSP intervient quand les regles se bloquent, souvent pres des bords de la zone revelee
+2. Les règles simples font des progres rapides dans les premières étapes
+3. Le CSP intervient quand les règles se bloquent, souvent pres des bords de la zone revelee
 4. Les devinettes sont rares mais chaque erreur est fatale
 
-> **Lien avec la NP-completude** : meme avec un solveur parfait, certaines configurations exigent une devinette. La probabilite de succes depend de la densite de mines et de la taille du plateau.",,,,,,,,f0ed8e436b7a240e,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-39,markdown,fr,a62ab344dc184376,"---
+> **Lien avec la NP-completude** : même avec un solveur parfait, certaines configurations exigent une devinette. La probabilite de succes depend de la densite de mines et de la taille du plateau.",,,,,,,,2e3dad01b2f14dd4,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-39,markdown,fr,552ee099aad2e463,"---
 
 ## 7. Exemple guide
 
 ### Exemple guide 1 : contraintes couplees
 
-**Enonce** : dans le solveur CSP, les contraintes sont posees independamment pour chaque cellule revelee. Cependant, on peut renforcer le modele en ajoutant une **contrainte globale** : le nombre total de mines dans la grille est connu.
+**Enonce** : dans le solveur CSP, les contraintes sont posees independamment pour chaque cellule revelee. Cependant, on peut renforcer le modèle en ajoutant une **contrainte globale** : le nombre total de mines dans la grille est connu.
 
-Implementez cette contrainte globale dans `CSPSolver.build_csp()` et mesurez l'impact sur le nombre de solutions et le taux de victoire.",,,,,,,,a62ab344dc184376,,,,,,,
+Implementez cette contrainte globale dans `CSPSolver.build_csp()` et mesurez l'impact sur le nombre de solutions et le taux de victoire.",,,,,,,,552ee099aad2e463,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,e6a64f44,code,fr,efa0615853a2ad12,"# Exemple resolu : solveur CSP avec contrainte globale
 
 class EnhancedCSPSolver(CSPSolver):
@@ -17322,18 +17322,18 @@ print(""\nResultats :"")
 print(f""Taux de victoire (Standard) : {wins_std/N_GAMES_EX1:.1%}"")
 print(f""Taux de victoire (Enhanced) : {wins_enhanced/N_GAMES_EX1:.1%}"")
 ",,,,,,,,efa0615853a2ad12,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,300af637,markdown,fr,0d32ca4ef70f7600,"### Exercice 1b : comptage total des mines
+MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,300af637,markdown,fr,4cb7f64316050550,"### Exercice 1b : comptage total des mines
 
 **Enonce** : au lieu d'ajouter une contrainte `ExactSumConstraint` quand toute
 la frontiere est couverte, ajoutez systematiquement une contrainte sur le
-**nombre total de mines** parmi toutes les cellules inconnues (meme celles
+**nombre total de mines** parmi toutes les cellules inconnues (même celles
 hors frontiere), des le premier appel a `build_csp`.
 
 **Consignes** :
-1. Creez une classe `GlobalMineCountSolver(CSPSolver)` qui surcharge `build_csp`
+1. Créez une classe `GlobalMineCountSolver(CSPSolver)` qui surcharge `build_csp`
 2. Ajoutez une contrainte `ExactSumConstraint` sur toutes les variables inconnues
-3. Lancez le meme benchmark que l'exemple et comparez les taux de victoire
-",,,,,,,,0d32ca4ef70f7600,,,,,,,
+3. Lancez le même benchmark que l'exemple et comparez les taux de victoire
+",,,,,,,,4cb7f64316050550,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,475850e5,code,fr,dc9b3e5c2a7b48b9,"# Exercice 1b : contrainte globale systematique
 
 # TODO: creez la classe GlobalMineCountSolver et lancez le benchmark
@@ -17343,11 +17343,11 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,475850e5,code,
 # Votre code ici
 print(""Exercice a completer"")
 ",,,,,,,,dc9b3e5c2a7b48b9,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-42,markdown,fr,aa49e97781d70af3,"### Exemple guide 2 : garantie du premier clic
+MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-42,markdown,fr,e77d1eea8f9d01b7,"### Exemple guide 2 : garantie du premier clic
 
-**Enonce** : dans notre implementation, `safe_cell` empeche de placer des mines sur la cellule cliquee et ses voisines. Mais certains jeux ne generent les mines qu'**apres** le premier clic.
+**Enonce** : dans notre implementation, `safe_cell` empeche de placer des mines sur la cellule cliquee et ses voisines. Mais certains jeux ne generent les mines qu'**après** le premier clic.
 
-Modifiez `MinesweeperBoard` pour supporter une generation differee : le plateau est cree vide, et les mines ne sont placees qu'au premier appel a `reveal()`, en excluant la cellule cliquee et ses voisines.",,,,,,,,aa49e97781d70af3,,,,,,,
+Modifiez `MinesweeperBoard` pour supporter une generation differee : le plateau est créé vide, et les mines ne sont placees qu'au premier appel a `reveal()`, en excluant la cellule cliquee et ses voisines.",,,,,,,,e77d1eea8f9d01b7,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,bfe73ad6,code,fr,501ac348cd6fb8ee,"# Exemple resolu : generation differee des mines
 
 class LazyMinesweeperBoard(MinesweeperBoard):
@@ -17400,19 +17400,19 @@ print(""Apres reveal :"", len(board_lazy.mines), ""mines"")
 draw_board(board_lazy, title=""Generation differee (clic en 0,0)"")
 plt.show()
 ",,,,,,,,501ac348cd6fb8ee,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,6d9daad3,markdown,fr,a11135fcfa878525,"### Exercice 2b : zone de securite configurable
+MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,6d9daad3,markdown,fr,b9421559d67b545a,"### Exercice 2b : zone de securite configurable
 
 **Enonce** : modifiez `MinesweeperBoard` pour que la zone de securite lors du
 premier clic soit configurable : au lieu d'exclure les 8 voisins, l'utilisateur
 choisit le rayon d'exclusion.
 
 **Consignes** :
-1. Creez une classe `ConfigurableSafeBoard(MinesweeperBoard)` avec un parametre
+1. Créez une classe `ConfigurableSafeBoard(MinesweeperBoard)` avec un paramètre
    `safe_radius` (par defaut 1 = voisins directs, 0 = seule la case cliquee)
-2. Generez les mines apres le premier clic, en excluant toutes les cases dans
+2. Generez les mines après le premier clic, en excluant toutes les cases dans
    le rayon donne
 3. Testez avec `safe_radius=2` sur une grille 10x10, 15 mines, premier clic en (5,5)
-",,,,,,,,a11135fcfa878525,,,,,,,
+",,,,,,,,b9421559d67b545a,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,1001739b,code,fr,1758cbf03ba16f51,"# Exercice 2b : zone de securite configurable
 
 # TODO: creez la classe ConfigurableSafeBoard avec safe_radius
@@ -17422,14 +17422,14 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,1001739b,code,
 # Votre code ici
 print(""Exercice a completer"")
 ",,,,,,,,1758cbf03ba16f51,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-45,markdown,fr,93188947aa2f36af,"### Exemple guide 3 : scalabilite sur 16x16
+MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-45,markdown,fr,0d270cc4bba6441d,"### Exemple guide 3 : scalabilite sur 16x16
 
 **Enonce** : testez le solveur probabiliste sur un plateau 16x16 avec 40 mines (difficulte ""intermediaire"" standard). Mesurez :
 - Le taux de victoire sur 30 parties
 - Le temps moyen par partie
 - Le nombre moyen de devinettes
 
-Comparez avec les resultats 8x8 et commentez la scalabilite.",,,,,,,,93188947aa2f36af,,,,,,,
+Comparez avec les résultats 8x8 et commentez la scalabilite.",,,,,,,,0d270cc4bba6441d,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,89b7fc75,code,fr,c05c5ab36b7e06bf,"# Exemple resolu : benchmark 16x16
 
 N_GAMES_16 = 30
@@ -17455,16 +17455,16 @@ print(f""  Victoires : {wins_16}/{N_GAMES_16}"")
 print(f""  Temps moyen : {total_time_16/N_GAMES_16*1000:.0f} ms"")
 print(f""  Devinettes moyennes : {total_guesses_16/N_GAMES_16:.1f}"")
 ",,,,,,,,c05c5ab36b7e06bf,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,29df0b0f,markdown,fr,51a486619180fd75,"### Exercice 3b : difficulte experte (30x16, 99 mines)
+MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,29df0b0f,markdown,fr,466a9b461a8d9161,"### Exercice 3b : difficulte experte (30x16, 99 mines)
 
 **Enonce** : testez le solveur sur la difficulte ""experte"" du Demineur
-(grille 30x16 avec 99 mines). Mesurez les memes indicateurs.
+(grille 30x16 avec 99 mines). Mesurez les mêmes indicateurs.
 
 **Consignes** :
 1. Lancez 20 parties sur grille 30x16, 99 mines, premier clic au centre
 2. Affichez le taux de victoire, le temps moyen et les devinettes moyennes
-3. Comparez avec les resultats 8x8 et 16x16 obtenus plus haut
-",,,,,,,,51a486619180fd75,,,,,,,
+3. Comparez avec les résultats 8x8 et 16x16 obtenus plus haut
+",,,,,,,,466a9b461a8d9161,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,52f0ccbb,code,fr,ace163c9dbc73f4e,"# Exercice 3b : difficulte experte
 
 # TODO: lancez le benchmark 30x16 avec 99 mines
@@ -17491,7 +17491,7 @@ En comparant les r&eacute;sultats obtenus pr&eacute;c&eacute;demment, nous pouvo
 1.  **Complexit&eacute; du CSP** : Le temps d'ex&eacute;cution augmente beaucoup plus vite que le nombre de cases. C'est une cons&eacute;quence directe de la **NP-compl&eacute;tude** : sur un plateau plus grand, la ""fronti&egrave;re"" des cellules inconnues est plus longue, ce qui augmente de mani&egrave;re exponentielle le nombre de combinaisons possibles que le solveur CSP doit &eacute;num&eacute;rer.
 2.  **D&eacute;terminisme vs Chance** : Le taux de victoire reste &eacute;lev&eacute; car le solveur utilise toujours les probabilit&eacute;s optimales. Cependant, la probabilit&eacute; de rencontrer une configuration n&eacute;cessitant une devinette (comme un ""50/50"") augmente avec la taille du plateau, ce qui explique la l&eacute;g&egrave;re baisse du taux de victoire.
 3.  **Limites** : Sur un plateau ""Expert"" (16x30, 99 mines), l'&eacute;num&eacute;ration compl&egrave;te des solutions CSP pourrait devenir trop lente, n&eacute;cessitant des techniques plus avanc&eacute;es comme le d&eacute;coupage de la fronti&egrave;re en sous-probl&egrave;mes ind&eacute;pendants.",,,,,,,,5950cc575ff042a5,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-48,markdown,fr,c9ddd05b6e36e367,"---
+MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-48,markdown,fr,61df47290c910de2,"---
 
 ## Recapitulatif
 
@@ -17499,8 +17499,8 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-48,markdo
 
 | Approche | Principe | Avantage | Limitation |
 |----------|----------|----------|------------|
-| **Regles simples** | Deductions locales (1 cellule a la fois) | Rapide, sans erreur | Se bloque sur les cas ambigus |
-| **CSP** | Enumeration des solutions globales | Deduit des cellules invisibles aux regles | Cout exponentiel (NP-complet) |
+| **Règles simples** | Deductions locales (1 cellule a la fois) | Rapide, sans erreur | Se bloque sur les cas ambigus |
+| **CSP** | Enumeration des solutions globales | Deduit des cellules invisibles aux règles | Cout exponentiel (NP-complet) |
 | **CSP + probabilites** | Choix optimal sous incertitude | Maximise les chances de victoire | Ne garantit pas la victoire |
 
 ### Concepts cles
@@ -17509,7 +17509,7 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-48,markdo
 |---------|------------|------------------------|
 | **NP-completude** | Pas d'algorithme polynomial connu | Le Demineur n'est pas resolvable en temps polynomial (Kaye, 2000) |
 | **CSP** | Variables + domaines + contraintes | Cellules binaires + sommes = indices |
-| **Cellule forcee** | Meme valeur dans toutes les solutions | Certitude absolue sans deviner |
+| **Cellule forcee** | Même valeur dans toutes les solutions | Certitude absolue sans deviner |
 | **Raisonnement probabiliste** | Compter les solutions favorables | Choisir le coup le moins risque |
 | **Frontiere** | Zone entre le connu et l'inconnu | Seules les cellules adjacentes aux revelees sont pertinentes |
 
@@ -17517,7 +17517,7 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb,cell-48,markdo
 
 Ce notebook a presente le Demineur comme un CSP avec extension probabiliste. Voici des pistes pour aller plus loin :
 
-- **Approches SAT** : encoder le probleme comme une formule booleenne et utiliser un solveur SAT
+- **Approches SAT** : encoder le problème comme une formule booleenne et utiliser un solveur SAT
 - **Apprentissage profond** : entrainer un reseau convolutionnel pour predire les mines
 - **Hybride LLM + CSP** : utiliser un LLM pour guider l'exploration dans les cas ambigus (voir le projet etudiant original)
 - **Plateau hexagonal** : generaliser a d'autres topologies de grille
@@ -17526,21 +17526,21 @@ Ce notebook a presente le Demineur comme un CSP avec extension probabiliste. Voi
 
 - Kaye, R. (2000). *Minesweeper is NP-complete*. Mathematical Intelligencer, 22(2), 9-15
 - Becerra, D. J. (2015). *Algorithmic Approaches to Playing Minesweeper*. Harvard University
-- Projet etudiant EPITA 2025 : jsboigeEpita/2025-PPC RDER-minesweeper",,,,,,,,c9ddd05b6e36e367,,,,,,,
+- Projet etudiant EPITA 2025 : jsboigeEpita/2025-PPC RDER-minesweeper",,,,,,,,61df47290c910de2,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,a458ba3c,code,fr,d8cfd07b7b0f3965,"# Parameters
 BATCH_MODE = ""true""
 ",,,,,,,,d8cfd07b7b0f3965,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,nav-header,markdown,fr,1bc9445495c2a2da,"# App-7 : Wordle Solver -- CSP et theorie de l'information
+MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,nav-header,markdown,fr,4b28b77577985729,"# App-7 : Wordle Solver -- CSP et théorie de l'information
 
 **Navigation** : [<< App-6 Minesweeper](App-6-Minesweeper.ipynb) | [Index](../README.md) | [App-8 MiniZinc >>](../CSP/App-8-MiniZinc.ipynb)
 
 ## Objectifs d'apprentissage
 
 A la fin de ce notebook, vous saurez :
-1. **Modeliser** le jeu Wordle comme un probleme de filtrage sous contraintes
+1. **Modeliser** le jeu Wordle comme un problème de filtrage sous contraintes
 2. **Implementer** un solveur par filtrage simple (elimination de mots incompatibles)
 3. **Formaliser** les indices Wordle comme des contraintes CSP sur les positions de lettres
-4. **Appliquer** la theorie de l'information (entropie de Shannon) pour choisir le meilleur mot
+4. **Appliquer** la théorie de l'information (entropie de Shannon) pour choisir le meilleur mot
 5. **Comparer** les trois approches en termes de performance moyenne
 
 ### Prerequis
@@ -17552,8 +17552,8 @@ A la fin de ce notebook, vous saurez :
 
 ### Source
 
-Adapte du projet etudiant EPITA 2025 : **CSP-Wordle-Solver** (jsboigeEpita/2025-PPC).",,,,,,,,1bc9445495c2a2da,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,section-1-intro,markdown,fr,a04eb5bff6d11d88,"---
+Adapte du projet etudiant EPITA 2025 : **CSP-Wordle-Solver** (jsboigeEpita/2025-PPC).",,,,,,,,4b28b77577985729,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,section-1-intro,markdown,fr,289a57265738a154,"---
 
 ## 1. Introduction (~5 min)
 
@@ -17561,7 +17561,7 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,section-1-intro,mar
 
 **Wordle** est un jeu de devinette de mots :
 - Le joueur doit deviner un **mot secret de 5 lettres** en au plus **6 tentatives**
-- Apres chaque tentative, le jeu renvoie un **feedback** pour chaque lettre :
+- Après chaque tentative, le jeu renvoie un **feedback** pour chaque lettre :
 
 | Couleur | Code | Signification |
 |---------|------|---------------|
@@ -17569,22 +17569,22 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,section-1-intro,mar
 | Jaune | 1 | Lettre presente dans le mot mais a une autre position |
 | Gris | 0 | Lettre absente du mot |
 
-### Pourquoi Wordle est un probleme de recherche
+### Pourquoi Wordle est un problème de recherche
 
-On peut voir Wordle comme un probleme de **recherche d'information** :
+On peut voir Wordle comme un problème de **recherche d'information** :
 - L'espace de recherche est l'ensemble des mots possibles
 - Chaque tentative apporte de l'information qui **reduit** cet espace
 - L'objectif est de reduire l'espace a un seul mot en 6 tentatives ou moins
 
 ### Trois approches
 
-Nous allons implementer et comparer trois strategies :
+Nous allons implementer et comparer trois stratégies :
 
 | # | Approche | Principe | Performance attendue |
 |---|----------|----------|---------------------|
 | 1 | Filtrage simple | Eliminer les mots incompatibles, choisir au hasard | ~4-5 tentatives |
 | 2 | CSP | Modeliser les contraintes sur les positions de lettres | ~4-5 tentatives (plus structure) |
-| 3 | Entropie | Maximiser l'information gagnee par tentative | ~3.5 tentatives |",,,,,,,,a04eb5bff6d11d88,,,,,,,
+| 3 | Entropie | Maximiser l'information gagnee par tentative | ~3.5 tentatives |",,,,,,,,289a57265738a154,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,imports,code,fr,d688f545a8104150,"# Imports
 import sys
 import math
@@ -17606,13 +17606,13 @@ random.seed(42)
 np.random.seed(42)
 
 print(""Imports OK"")",,,,,,,,d688f545a8104150,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,section-2-intro,markdown,fr,e6fe567b490e06b7,"---
+MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,section-2-intro,markdown,fr,a3a306672e419a2b,"---
 
-## 2. Liste de mots et systeme de feedback (~5 min)
+## 2. Liste de mots et système de feedback (~5 min)
 
 ### Liste de mots
 
-Pour ce notebook, nous utilisons une liste de mots francais courants de 5 lettres. Dans un vrai Wordle, la liste officielle contient environ 2 300 mots (anglais) ; nous utilisons ici une liste reduite pour que les demonstrations restent rapides.",,,,,,,,e6fe567b490e06b7,,,,,,,
+Pour ce notebook, nous utilisons une liste de mots francais courants de 5 lettres. Dans un vrai Wordle, la liste officielle contient environ 2 300 mots (anglais) ; nous utilisons ici une liste reduite pour que les demonstrations restent rapides.",,,,,,,,a3a306672e419a2b,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,word-list,code,fr,51880992dc51003a,"# Liste de mots francais de 5 lettres (sans accents, majuscules)
 # Mots courants selectionnes pour couvrir une bonne variete de lettres
 WORD_LIST = [
@@ -17668,13 +17668,13 @@ WORD_LIST = sorted(set(WORD_LIST))
 print(f""Liste de mots : {len(WORD_LIST)} mots de 5 lettres"")
 print(f""Exemples : {WORD_LIST[:10]}"")
 print(f""Derniers : {WORD_LIST[-5:]}"")",,,,,,,,51880992dc51003a,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,feedback-intro,markdown,fr,7994a209bfc70287,"### Systeme de feedback
+MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,feedback-intro,markdown,fr,312915d3a90d118b,"### Système de feedback
 
 Le coeur du jeu Wordle est la fonction de feedback. Pour une tentative (*guess*) et un mot secret (*answer*), elle produit un tuple de 5 valeurs :
 
 $$\text{feedback}(g, a) = (f_0, f_1, f_2, f_3, f_4) \quad \text{ou } f_i \in \{0, 1, 2\}$$
 
-L'algorithme doit gerer correctement les **lettres repetees**. Par exemple, si le mot secret est `AIMER` et la tentative est `ANNEE`, le premier `A` est vert, le `N` en position 1 est gris (pas de `N` dans le secret), etc.",,,,,,,,7994a209bfc70287,,,,,,,
+L'algorithme doit gerer correctement les **lettres repetees**. Par exemple, si le mot secret est `AIMER` et la tentative est `ANNEE`, le premier `A` est vert, le `N` en position 1 est gris (pas de `N` dans le secret), etc.",,,,,,,,312915d3a90d118b,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,feedback-func,code,fr,1b8d8d29fb2cdd4e,"def compute_feedback(guess: str, answer: str) -> Tuple[int, ...]:
     """"""Calcule le feedback Wordle pour une tentative.
 
@@ -17723,7 +17723,7 @@ for guess, answer, desc in test_cases:
     fb = compute_feedback(guess, answer)
     fb_str = """".join([""_YG""[v] for v in fb])  # _ = gris, Y = jaune, G = vert
     print(f""  {guess} vs {answer} -> {fb} ({fb_str})  [{desc}]"")",,,,,,,,1b8d8d29fb2cdd4e,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,feedback-interpretation,markdown,fr,653a6897bd97a7d3,"### Interpretation : systeme de feedback
+MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,feedback-interpretation,markdown,fr,9b91155a3a4f0ae2,"### Interpretation : système de feedback
 
 **Sortie obtenue** : Les cinq cas de test valident le comportement de la fonction de feedback.
 
@@ -17737,10 +17737,10 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,feedback-interpreta
 **Points cles** :
 1. L'algorithme en **deux passes** (verts d'abord, puis jaunes) evite les faux positifs sur les lettres repetees
 2. Le marquage `None` garantit qu'une lettre du secret n'est comptee qu'une fois
-3. Le feedback encode $3^5 = 243$ patterns possibles",,,,,,,,653a6897bd97a7d3,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,viz-feedback-intro,markdown,fr,8493c2f0f05774e8,"### Visualisation d'une grille Wordle
+3. Le feedback encode $3^5 = 243$ patterns possibles",,,,,,,,9b91155a3a4f0ae2,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,viz-feedback-intro,markdown,fr,fd0b404496eae872,"### Visualisation d'une grille Wordle
 
-Pour rendre les resultats plus lisibles, implementons un affichage graphique similaire au jeu original.",,,,,,,,8493c2f0f05774e8,,,,,,,
+Pour rendre les résultats plus lisibles, implementons un affichage graphique similaire au jeu original.",,,,,,,,fd0b404496eae872,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,viz-wordle,code,fr,fed169e3f844736b,"def draw_wordle_grid(guesses: List[str], feedbacks: List[Tuple[int, ...]],
                      answer: str = None, title: str = ""Partie Wordle""):
     """"""Affiche une grille Wordle avec les couleurs de feedback.""""""
@@ -17807,7 +17807,7 @@ draw_wordle_grid(demo_guesses, demo_feedbacks, answer=demo_answer,
 plt.show()
 
 print(""Partie resolue en 3 tentatives."")",,,,,,,,fed169e3f844736b,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,section-3-intro,markdown,fr,17df9c7d67b9ac0d,"---
+MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,section-3-intro,markdown,fr,9dfeecaf9a7c14db,"---
 
 ## 3. Approche 1 : Filtrage simple (~8 min)
 
@@ -17815,14 +17815,14 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,section-3-intro,mar
 
 L'approche la plus intuitive consiste a :
 1. Maintenir une liste de **mots candidats** (initialement tous les mots)
-2. Apres chaque tentative, **filtrer** les mots incompatibles avec le feedback recu
+2. Après chaque tentative, **filtrer** les mots incompatibles avec le feedback recu
 3. Choisir le prochain mot **au hasard** parmi les candidats restants
 
 Un mot candidat $w$ est **compatible** avec un feedback $f$ pour une tentative $g$ si et seulement si :
 
 $$\text{compute\_feedback}(g, w) = f$$
 
-En d'autres termes, si $w$ etait le mot secret, le feedback serait identique a celui observe.",,,,,,,,17df9c7d67b9ac0d,,,,,,,
+En d'autres termes, si $w$ etait le mot secret, le feedback serait identique a celui observe.",,,,,,,,9dfeecaf9a7c14db,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,simple-filter,code,fr,3d79f1adb57e5d41,"def filter_words(candidates: List[str], guess: str,
                  feedback: Tuple[int, ...]) -> List[str]:
     """"""Filtre les mots candidats selon le feedback recu.
@@ -17873,7 +17873,7 @@ class SimpleFilterSolver:
 
 
 print(""SimpleFilterSolver defini."")",,,,,,,,3d79f1adb57e5d41,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,simple-test-intro,markdown,fr,1d7aab567b3de700,Testons le solveur par filtrage simple sur quelques mots secrets et observons la reduction du nombre de candidats a chaque etape.,,,,,,,,1d7aab567b3de700,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,simple-test-intro,markdown,fr,e18477d4dfb49a15,Testons le solveur par filtrage simple sur quelques mots secrets et observons la reduction du nombre de candidats a chaque étape.,,,,,,,,e18477d4dfb49a15,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,simple-test,code,fr,c44be8eee8d93a12,"# Test du solveur par filtrage simple
 solver_simple = SimpleFilterSolver(WORD_LIST)
 
@@ -17900,9 +17900,9 @@ for word in test_words:
 
 avg = np.mean([r['guesses'] for r in results_simple if r['won']])
 print(f""Moyenne (parties gagnees) : {avg:.1f} tentatives"")",,,,,,,,c44be8eee8d93a12,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,simple-interpretation,markdown,fr,b111789fd1a36b3a,"### Interpretation : filtrage simple
+MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,simple-interpretation,markdown,fr,21e72fd7b7c8dc86,"### Interpretation : filtrage simple
 
-**Sortie obtenue** : Le solveur par filtrage simple parvient generalement a trouver le mot en 3 a 5 tentatives.
+**Sortie obtenue** : Le solveur par filtrage simple parvient généralement a trouver le mot en 3 a 5 tentatives.
 
 | Observation | Detail |
 |-------------|--------|
@@ -17913,7 +17913,7 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,simple-interpretati
 **Points cles** :
 1. Le filtrage est **correct** : il ne supprime jamais le mot secret des candidats
 2. Le choix aleatoire ne garantit pas l'optimalite de la reduction d'espace
-3. L'approche fonctionne mais peut etre amelioree en choisissant mieux le prochain mot",,,,,,,,b111789fd1a36b3a,,,,,,,
+3. L'approche fonctionne mais peut etre amelioree en choisissant mieux le prochain mot",,,,,,,,21e72fd7b7c8dc86,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,viz-reduction-intro,markdown,fr,448f229d47041f5b,"### Visualisation : reduction de l'espace
 
 Observons graphiquement comment le nombre de candidats diminue a chaque tentative.",,,,,,,,448f229d47041f5b,,,,,,,
@@ -17988,11 +17988,11 @@ if len(guesses_ex) > 0:
     print(f""Reduction totale : {counts_ex[0]} -> 1 mot"")
 else:
     print(""Aucune partie jouee - liste de mots vide."")",,,,,,,,cdc74078a1935f7c,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,section-4-intro,markdown,fr,e5409435c6b00823,"---
+MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,section-4-intro,markdown,fr,a964893b6a570347,"---
 
 ## 4. Approche 2 : Filtrage CSP (~10 min)
 
-### Modelisation CSP du probleme Wordle
+### Modelisation CSP du problème Wordle
 
 On peut voir chaque tentative Wordle comme un ensemble de **contraintes** sur le mot secret. Formalisons cela comme un CSP :
 
@@ -18012,7 +18012,7 @@ Pour une tentative $g = g_0 g_1 g_2 g_3 g_4$ avec un feedback $f = (f_0, f_1, f_
 | $f_i = 1$ (jaune) | $L_i \neq g_i$ ET $g_i \in \{L_0, \ldots, L_4\}$ (la lettre est dans le mot mais pas ici) |
 | $f_i = 0$ (gris) | $g_i \notin \{L_j : f_j \neq 2 \text{ et } g_j \neq g_i\}$ (la lettre n'est pas dans les positions non-vertes) |
 
-**Attention** : le cas gris est subtil quand la meme lettre apparait plusieurs fois dans la tentative.",,,,,,,,e5409435c6b00823,,,,,,,
+**Attention** : le cas gris est subtil quand la même lettre apparait plusieurs fois dans la tentative.",,,,,,,,a964893b6a570347,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,csp-solver,code,fr,5740f9985bdd439b,"class CSPWordleSolver:
     """"""Solveur Wordle par propagation de contraintes.
 
@@ -18135,7 +18135,7 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,csp-solver,code,fr,
 
 
 print(""CSPWordleSolver defini."")",,,,,,,,5740f9985bdd439b,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,csp-test-intro,markdown,fr,1cfad0654e4ba11a,Testons le solveur CSP et observons la reduction des domaines a chaque etape. La visualisation des domaines montre comment les contraintes eliminent progressivement les lettres impossibles.,,,,,,,,1cfad0654e4ba11a,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,csp-test-intro,markdown,fr,7d308cf27bd8ea1e,Testons le solveur CSP et observons la reduction des domaines a chaque étape. La visualisation des domaines montre comment les contraintes eliminent progressivement les lettres impossibles.,,,,,,,,7d308cf27bd8ea1e,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,csp-test,code,fr,e6fcfc678f8859b6,"# Test du solveur CSP avec trace detaillee
 solver_csp = CSPWordleSolver(WORD_LIST)
 
@@ -18149,14 +18149,14 @@ guesses_csp = solver_csp.solve(answer_csp, verbose=True)
 
 won = guesses_csp[-1] == answer_csp
 print(f""\n=> {'Gagne' if won else 'Perdu'} en {len(guesses_csp)} tentative(s)"")",,,,,,,,e6fcfc678f8859b6,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,csp-interpretation,markdown,fr,1948205616e42229,"### Interpretation : solveur CSP
+MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,csp-interpretation,markdown,fr,9c86a2385fa6d2f9,"### Interpretation : solveur CSP
 
 **Sortie obtenue** : Le solveur CSP montre la reduction progressive des domaines de chaque position.
 
-| Etape | Effet sur les domaines |
+| Étape | Effet sur les domaines |
 |-------|------------------------|
-| Apres tentative 1 | Les lettres vertes fixent leur position ; les grises sont eliminees partout |
-| Apres tentative 2 | Les domaines se reduisent davantage ; les jaunes contraignent les positions |
+| Après tentative 1 | Les lettres vertes fixent leur position ; les grises sont eliminees partout |
+| Après tentative 2 | Les domaines se reduisent davantage ; les jaunes contraignent les positions |
 | Convergence | Chaque position n'a plus qu'une ou deux lettres possibles |
 
 **Avantages du CSP par rapport au filtrage simple** :
@@ -18164,10 +18164,10 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,csp-interpretation,
 2. **Propagation** : les contraintes se combinent (un vert en position 0 reduit aussi les options des autres positions via min/max counts)
 3. **Extensibilite** : on peut ajouter de l'arc-consistance ou du forward checking
 
-**Limitation** : avec un choix aleatoire du prochain mot, les performances sont similaires au filtrage simple.",,,,,,,,1948205616e42229,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,csp-viz-intro,markdown,fr,8541e5a0eee8b814,"### Visualisation : domaines CSP etape par etape
+**Limitation** : avec un choix aleatoire du prochain mot, les performances sont similaires au filtrage simple.",,,,,,,,9c86a2385fa6d2f9,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,csp-viz-intro,markdown,fr,8169afaa2632693d,"### Visualisation : domaines CSP étape par étape
 
-Visualisons comment les domaines de chaque position se reduisent au fil des tentatives.",,,,,,,,8541e5a0eee8b814,,,,,,,
+Visualisons comment les domaines de chaque position se reduisent au fil des tentatives.",,,,,,,,8169afaa2632693d,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,csp-viz,code,fr,ef9c0cb1121274cb,"def trace_csp_domains(solver_cls, word_list, answer, seed=42):
     """"""Trace l'evolution des tailles de domaines pour chaque position.""""""
     random.seed(seed)
@@ -18240,30 +18240,30 @@ ax2.set_ylim(bottom=0)
 
 plt.tight_layout()
 plt.show()",,,,,,,,ef9c0cb1121274cb,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,csp-viz-interpretation,markdown,fr,55e9f089d95bae78,"### Interpretation : evolution des domaines CSP
+MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,csp-viz-interpretation,markdown,fr,4037cf55aecd2241,"### Interpretation : evolution des domaines CSP
 
-**Sortie obtenue** : La heatmap montre la taille des domaines (nombre de lettres possibles) pour chaque position a chaque etape.
+**Sortie obtenue** : La heatmap montre la taille des domaines (nombre de lettres possibles) pour chaque position a chaque étape.
 
 | Observation | Detail |
 |-------------|--------|
 | Etat initial | Chaque position a 26 lettres possibles |
 | Verts | Le domaine tombe a 1 immediatement (case foncee) |
 | Gris | Les lettres sont eliminees de toutes les positions non fixees |
-| Convergence | Apres 2-3 tentatives, les domaines sont fortement reduits |
+| Convergence | Après 2-3 tentatives, les domaines sont fortement reduits |
 
 **Points cles** :
 1. La heatmap permet de visualiser la **propagation des contraintes** position par position
 2. Les positions avec un vert convergent immediatement (domaine = 1)
 3. Les lettres grises ont un effet global : elles sont eliminees de toutes les positions
 
-> **Lien avec Search-7** : cette reduction de domaines est une forme de forward checking, etudiee dans le notebook sur la consistance CSP.",,,,,,,,55e9f089d95bae78,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,section-5-intro,markdown,fr,3183ca688ab8bc4c,"---
+> **Lien avec Search-7** : cette reduction de domaines est une forme de forward checking, etudiee dans le notebook sur la consistance CSP.",,,,,,,,4037cf55aecd2241,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,section-5-intro,markdown,fr,f34affc95f490374,"---
 
-## 5. Approche 3 : Theorie de l'information (~12 min)
+## 5. Approche 3 : Théorie de l'information (~12 min)
 
-### Le probleme du choix optimal
+### Le problème du choix optimal
 
-Les deux approches precedentes choisissent le prochain mot **au hasard** parmi les candidats. Mais certains mots apportent **plus d'information** que d'autres.
+Les deux approches précédentes choisissent le prochain mot **au hasard** parmi les candidats. Mais certains mots apportent **plus d'information** que d'autres.
 
 L'idee cle est d'utiliser l'**entropie de Shannon** pour mesurer combien d'information un mot apportera en moyenne.
 
@@ -18273,7 +18273,7 @@ Pour une variable aleatoire discrete $X$ prenant les valeurs $x_1, \ldots, x_n$ 
 
 $$H(X) = -\sum_{i=1}^{n} p(x_i) \log_2 p(x_i)$$
 
-L'entropie mesure l'**incertitude** : plus elle est elevee, plus le resultat est imprevisible et donc plus on apprend du resultat.
+L'entropie mesure l'**incertitude** : plus elle est elevee, plus le résultat est imprevisible et donc plus on apprend du résultat.
 
 ### Application a Wordle
 
@@ -18285,7 +18285,7 @@ Pour un mot candidat $g$ (guess), on peut calculer la **distribution des feedbac
 
 $$H(g) = -\sum_{f \in \text{feedbacks}} \frac{|\{w : \text{feedback}(g, w) = f\}|}{|\text{candidats}|} \log_2 \frac{|\{w : \text{feedback}(g, w) = f\}|}{|\text{candidats}|}$$
 
-Le meilleur mot est celui qui **maximise l'entropie** : il repartit les candidats le plus uniformement possible entre les differents patterns de feedback.",,,,,,,,3183ca688ab8bc4c,,,,,,,
+Le meilleur mot est celui qui **maximise l'entropie** : il repartit les candidats le plus uniformement possible entre les différents patterns de feedback.",,,,,,,,f34affc95f490374,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,entropy-func,code,fr,ea364ed3aa41dfdb,"def compute_entropy(guess: str, candidates: List[str]) -> float:
     """"""Calcule l'entropie du feedback pour un mot candidat.
 
@@ -18349,7 +18349,7 @@ for word in sample_words:
 h_max = math.log2(len(WORD_LIST))
 print(f""\nEntropie maximale theorique : log2({len(WORD_LIST)}) = {h_max:.3f} bits"")
 print(f""(une seule tentative suffirait si H = {h_max:.1f} bits)"")",,,,,,,,ea364ed3aa41dfdb,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,entropy-interpretation,markdown,fr,67df900faf139b64,"### Interpretation : entropie des mots
+MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,entropy-interpretation,markdown,fr,9be464427267c214,"### Interpretation : entropie des mots
 
 **Sortie obtenue** : L'entropie varie significativement selon le mot choisi.
 
@@ -18357,12 +18357,12 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,entropy-interpretat
 |-------------|--------|
 | Mots a haute entropie | Contiennent des lettres frequentes et bien reparties |
 | Mots a basse entropie | Contiennent des lettres rares ou trop communes |
-| Entropie max theorique | $\log_2(N)$ bits, atteinte si chaque candidat donne un feedback unique |
+| Entropie max théorique | $\log_2(N)$ bits, atteinte si chaque candidat donne un feedback unique |
 
 **Points cles** :
 1. Un mot avec une entropie elevee **divise mieux** l'espace des candidats
-2. L'entropie maximale theorique n'est pas atteignable car il n'y a que $3^5 = 243$ patterns distincts
-3. Le meilleur premier mot est celui qui repartit le plus uniformement les feedbacks",,,,,,,,67df900faf139b64,,,,,,,
+2. L'entropie maximale théorique n'est pas atteignable car il n'y a que $3^5 = 243$ patterns distincts
+3. Le meilleur premier mot est celui qui repartit le plus uniformement les feedbacks",,,,,,,,9be464427267c214,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,top-words-intro,markdown,fr,f46822ccfea4ec50,"### Les 10 meilleurs premiers mots
 
 Calculons l'entropie de tous les mots pour trouver le meilleur premier mot (celui qui apporte le plus d'information en moyenne).",,,,,,,,f46822ccfea4ec50,,,,,,,
@@ -18409,9 +18409,9 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,top-words-interpret
 | Reduction moyenne | Le meilleur mot divise l'espace par $2^H$ en moyenne |
 
 **Analogie** : choisir le meilleur mot, c'est comme poser la question la plus discriminante dans un jeu de 20 questions. On veut que chaque reponse possible soit equiprobable.",,,,,,,,a01a7d3276df6459,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,entropy-solver-intro,markdown,fr,d2b23f82d220d19c,"### Solveur par entropie
+MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,entropy-solver-intro,markdown,fr,808aa89221832748,"### Solveur par entropie
 
-Combinons le filtrage avec la selection par entropie pour construire un solveur optimal.",,,,,,,,d2b23f82d220d19c,,,,,,,
+Combinons le filtrage avec la sélection par entropie pour construire un solveur optimal.",,,,,,,,808aa89221832748,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,entropy-solver,code,fr,c8487239f79f1e3d,"class EntropySolver:
     """"""Solveur Wordle par maximisation de l'entropie.
 
@@ -18467,7 +18467,7 @@ best_first = top_words[0][0]
 solver_entropy = EntropySolver(WORD_LIST, precomputed_first=best_first)
 
 print(f""EntropySolver defini (premier mot : {best_first})"")",,,,,,,,c8487239f79f1e3d,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,entropy-test-intro,markdown,fr,5eefc77fe31d074a,Testons le solveur par entropie sur les memes mots secrets que precedemment pour comparer.,,,,,,,,5eefc77fe31d074a,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,entropy-test-intro,markdown,fr,5791f9464a3f2d8a,Testons le solveur par entropie sur les mêmes mots secrets que precedemment pour comparer.,,,,,,,,5791f9464a3f2d8a,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,entropy-test,code,fr,6961bb845643cd09,"# Test du solveur par entropie
 print(""Test du solveur par entropie"")
 print(""="" * 60)
@@ -18486,20 +18486,20 @@ for word in test_words:
 
 avg_entropy = np.mean([r['guesses'] for r in results_entropy if r['won']])
 print(f""Moyenne (parties gagnees) : {avg_entropy:.1f} tentatives"")",,,,,,,,6961bb845643cd09,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,entropy-test-interpretation,markdown,fr,ad4d6a0b461563dd,"### Interpretation : solveur par entropie
+MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,entropy-test-interpretation,markdown,fr,d71b08b8cb7d92d9,"### Interpretation : solveur par entropie
 
 **Sortie obtenue** : Le solveur par entropie trouve systematiquement le mot en moins de tentatives.
 
 | Observation | Detail |
 |-------------|--------|
-| Premiere tentative | Toujours le mot optimal precalcule |
+| Première tentative | Toujours le mot optimal precalcule |
 | Reduction | Plus forte car le mot est choisi pour maximiser l'information |
 | Convergence | Typiquement 2-4 tentatives au lieu de 3-5 |
 
 **Points cles** :
-1. La selection par entropie est **deterministe** : pas de variabilite aleatoire
+1. La sélection par entropie est **déterministe** : pas de variabilite aleatoire
 2. Le cout de calcul est plus eleve ($O(n^2)$ par tentative vs $O(n)$ pour le filtrage simple)
-3. Le gain en nombre de tentatives compense largement le cout de calcul",,,,,,,,ad4d6a0b461563dd,,,,,,,
+3. Le gain en nombre de tentatives compense largement le cout de calcul",,,,,,,,d71b08b8cb7d92d9,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,entropy-viz-intro,markdown,fr,fe73d722b082090a,"### Visualisation : distribution des feedbacks
 
 Comparons la distribution des feedbacks pour le meilleur et le pire premier mot. Le meilleur mot repartit les candidats uniformement entre les patterns.",,,,,,,,fe73d722b082090a,,,,,,,
@@ -18639,7 +18639,7 @@ for name, bench in [(""Filtrage simple"", bench_simple),
                      (""Entropie"", bench_entropy)]:
     print(f""{name:<20} {bench['avg_guesses']:<12.2f} {bench['worst_case']:<10}""
           f"" {bench['win_rate']:<8.0f} {bench['time_s']:<10.1f}"")",,,,,,,,2e39d9e9ac4203e7,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,benchmark-interpretation,markdown,fr,acfcb20868b976d0,"### Interpretation : comparaison des trois approches
+MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,benchmark-interpretation,markdown,fr,609eebad914b418a,"### Interpretation : comparaison des trois approches
 
 **Sortie obtenue** : Le tableau ci-dessous resume les performances des trois solveurs.
 
@@ -18653,7 +18653,7 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,benchmark-interpret
 1. **L'entropie gagne** : en moyenne ~1 tentative de moins que les approches aleatoires
 2. **Compromis temps/qualite** : la complexite de l'entropie ($O(n^2)$ par tentative) est plus elevee, mais sur cette liste elle reste rapide (0.2 s sur 100 parties) et plus efficace
 3. **Filtrage vs CSP** : performances similaires car le goulot d'etranglement est le choix du mot, pas le filtrage
-4. Le pire cas de l'entropie est generalement meilleur grace au choix optimal",,,,,,,,acfcb20868b976d0,,,,,,,
+4. Le pire cas de l'entropie est généralement meilleur grace au choix optimal",,,,,,,,609eebad914b418a,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,histogram,code,fr,b392b3401fa68fe1,"# Distribution du nombre de tentatives
 fig, axes = plt.subplots(1, 3, figsize=(16, 5), sharey=True)
 
@@ -18681,7 +18681,7 @@ plt.suptitle(f'Distribution des tentatives ({sample_size} parties)',
              fontsize=13, fontweight='bold')
 plt.tight_layout()
 plt.show()",,,,,,,,b392b3401fa68fe1,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,histogram-interpretation,markdown,fr,41855c64cc17be5c,"### Interpretation : histogrammes de performance
+MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,histogram-interpretation,markdown,fr,24e0782808741d11,"### Interpretation : histogrammes de performance
 
 **Sortie obtenue** : Les histogrammes montrent la distribution du nombre de tentatives pour chaque approche.
 
@@ -18696,8 +18696,8 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,histogram-interpret
 2. Les solveurs aleatoires ont une **plus grande variance** : parfois excellents, parfois mediocres
 3. Le solveur entropie est plus **regulier** : la distribution est plus concentree
 
-> **En resume** : l'entropie transforme la chance en strategie. Au lieu d'esperer tomber sur le bon mot, on choisit systematiquement le plus informatif.",,,,,,,,41855c64cc17be5c,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,section-7-intro,markdown,fr,1880b83c6b99010c,"---
+> **En resume** : l'entropie transforme la chance en stratégie. Au lieu d'esperer tomber sur le bon mot, on choisit systematiquement le plus informatif.",,,,,,,,24e0782808741d11,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,section-7-intro,markdown,fr,b4f0d7ab53822469,"---
 
 ## 7. Exercices
 
@@ -18707,7 +18707,7 @@ En mode ""hard"", chaque tentative doit **utiliser toutes les informations connu
 - Les lettres vertes doivent rester a leur position
 - Les lettres jaunes doivent etre presentes dans le mot
 
-**Tache** : Modifiez le `SimpleFilterSolver` pour qu'il ne propose que des mots compatibles avec les contraintes accumulees (ce qui est deja le cas via le filtrage). Ensuite, verifiez que le solveur entropie fonctionne aussi en mode hard : les mots proposes doivent etre dans les candidats restants.",,,,,,,,1880b83c6b99010c,,,,,,,
+**Tâche** : Modifiez le `SimpleFilterSolver` pour qu'il ne propose que des mots compatibles avec les contraintes accumulees (ce qui est déjà le cas via le filtrage). Ensuite, verifiez que le solveur entropie fonctionne aussi en mode hard : les mots proposes doivent etre dans les candidats restants.",,,,,,,,b4f0d7ab53822469,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,exercise-1,code,fr,070795964c1d8842,"# Exercice 1 : verifier le mode hard
 
 # Le filtrage simple est deja en mode hard : on ne choisit que parmi les candidats.
@@ -18735,9 +18735,9 @@ if has_failed:
 else:
     print(""The implementation has respected hard mode"")
 ",,,,,,,,070795964c1d8842,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,exercise-2-intro,markdown,fr,bb8009cf601c7019,"### Exercice 2 : Trouver le mot d'ouverture optimal
+MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,exercise-2-intro,markdown,fr,c6ad7ef5dd394d5a,"### Exercice 2 : Trouver le mot d'ouverture optimal
 
-**Tache** : Calculez l'entropie de **tous** les mots de la liste et identifiez le mot d'ouverture optimal. Verifiez qu'il contient des lettres frequentes dans la langue francaise (E, A, S, R, I, N, T).",,,,,,,,bb8009cf601c7019,,,,,,,
+**Tâche** : Calculez l'entropie de **tous** les mots de la liste et identifiez le mot d'ouverture optimal. Verifiez qu'il contient des lettres frequentes dans la langue francaise (E, A, S, R, I, N, T).",,,,,,,,c6ad7ef5dd394d5a,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,exercise-2,code,fr,cea2f45fe8012793,"# Exercice 2 : Analyse du mot d'ouverture optimal
 
 # A COMPLETER
@@ -18755,12 +18755,12 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,exercise-2,code,fr,
 print(""Exercice a completer - Analyse du mot d'ouverture optimal"")
 ",,,,,,,,cea2f45fe8012793,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,71bc8f26,markdown,fr,17e14fa31d783ad5,"**A verifier (Exercice 2)** : en completant l'exercice, observez si les lettres les plus frequentes de la langue francaise apparaissent bien dans les mots a haute entropie",,,,,,,,17e14fa31d783ad5,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,exercise-3-intro,markdown,fr,1f53d7410158ca22,"### Exercice 3 : Extension a 6 lettres
+MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,exercise-3-intro,markdown,fr,9f5d9b424af0a43d,"### Exercice 3 : Extension a 6 lettres
 
-**Tache** : Adaptez le systeme pour un Wordle a 6 lettres.
+**Tâche** : Adaptez le système pour un Wordle a 6 lettres.
 - Modifiez `compute_feedback` pour accepter des mots de longueur variable
-- Creez une petite liste de mots de 6 lettres
-- Testez le solveur entropie sur cette liste",,,,,,,,1f53d7410158ca22,,,,,,,
+- Créez une petite liste de mots de 6 lettres
+- Testez le solveur entropie sur cette liste",,,,,,,,9f5d9b424af0a43d,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,exercise-3,code,fr,1230702012a506c4,"# Exercice 3 : Wordle a 6 lettres
 # TODO: Generaliser compute_feedback a une longueur arbitraire
 
@@ -18795,7 +18795,7 @@ def compute_feedback_generic(guess: str, answer: str) -> Tuple[int, ...]:
 # print(compute_feedback_generic(""BANANA"", ""BANNER""))
 print(""Exercice a completer"")
 ",,,,,,,,1230702012a506c4,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,summary-section,markdown,fr,082a480bc194bef1,"---
+MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,summary-section,markdown,fr,c56bceff08c258fd,"---
 
 ## Conclusion et recapitulatif
 
@@ -18819,7 +18819,7 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,summary-section,mar
 ### Ce qu'il faut retenir
 
 1. **Le filtrage est la base** : quel que soit le solveur, il faut eliminer les mots incompatibles
-2. **Le CSP structure le probleme** : les contraintes deduites du feedback sont une forme de propagation de contraintes
+2. **Le CSP structure le problème** : les contraintes deduites du feedback sont une forme de propagation de contraintes
 3. **L'entropie optimise le choix** : maximiser l'information revient a minimiser le nombre de tentatives
 4. **Compromis information/calcul** : le meilleur choix demande plus de calcul mais converge plus vite
 
@@ -18843,14 +18843,14 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,summary-section,mar
 
 - Shannon, C.E. ""A Mathematical Theory of Communication"" (1948)
 - 3Blue1Brown, ""Solving Wordle using Information Theory"" (YouTube)
-- Russell, S. & Norvig, P., *Artificial Intelligence: A Modern Approach*, Chapitre 6 (CSP)",,,,,,,,082a480bc194bef1,,,,,,,
+- Russell, S. & Norvig, P., *Artificial Intelligence: A Modern Approach*, Chapitre 6 (CSP)",,,,,,,,c56bceff08c258fd,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,nav-footer,markdown,fr,efd281cde4b3f052,"---
 
 **Navigation** : [<< App-6 Minesweeper](App-6-Minesweeper.ipynb) | [Index](../README.md) | [App-8 MiniZinc >>](../CSP/App-8-MiniZinc.ipynb)",,,,,,,,efd281cde4b3f052,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb,003d40e5,markdown,fr,9ec1d4d5817f96ab,"## Conclusion
 
 Ce notebook a modélisé le jeu Wordle comme un problème de recherche d'information et comparé trois stratégies de résolution. Le **filtrage simple** élimine les candidats incompatibles mais choisit au hasard, menant à ~3.3 tentatives en moyenne. Le **CSP** structure le problème avec des domaines par position et des contraintes déduites du feedback, offrant une visualisation claire de la propagation. L'approche par **entropie de Shannon** maximise l'information attendue de chaque tentative, réduisant la moyenne à ~2.9 tentatives grâce au choix optimal du mot le plus discriminant. La comparaison des distributions de feedback montre que le meilleur mot d'ouverture répartit uniformément les candidats entre les patterns, tandis qu'un mauvais mot les concentre dans un seul groupe. Cette leçon transcende le Wordle : maximiser le gain d'information est une stratégie fondamentale en diagnostic médical, dans les arbres de décision et dans tout problème de recherche avec retours partiels.",,,,,,,,9ec1d4d5817f96ab,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,3ff47bd08866,markdown,fr,a21167e41c1f5c0e,"# App-7b : Solveur Wordle -- CSP et theorie de l'information (jumeau C#)
+MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,3ff47bd08866,markdown,fr,a49d68ea3570ada8,"# App-7b : Solveur Wordle -- CSP et théorie de l'information (jumeau C#)
 
 > **Twin C#** de [`App-7-Wordle`](App-7-Wordle.ipynb) (Python : `numpy`, `matplotlib`, filtration CSP + entropie).
 > Marathon **.NET / Python** (#4956), volet **Search / Applications / CSP**.
@@ -18866,8 +18866,8 @@ A la fin de ce notebook, vous saurez :
 3. **Calculer l'entropie de Shannon** d'un feedback et l'utiliser pour choisir le mot le plus informatif.
 4. **Comparer** les trois approches sur un benchmark de mots secrets.
 
-Le code est entierement reecrit en C# (.NET 9, 0 NuGet hors ScottPlot optionnel), en miroir de la version Python qui utilisait `numpy`/`matplotlib`. Les quantites deterministes (entropie des mots, classement des meilleurs premieres tentatives) **concordent au bit pres** entre les deux langages : c'est le critere de parite.
-",,,,,,,,a21167e41c1f5c0e,,,,,,,
+Le code est entierement reecrit en C# (.NET 9, 0 NuGet hors ScottPlot optionnel), en miroir de la version Python qui utilisait `numpy`/`matplotlib`. Les quantites déterministes (entropie des mots, classement des meilleurs premières tentatives) **concordent au bit pres** entre les deux langages : c'est le critere de parite.
+",,,,,,,,a49d68ea3570ada8,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,9162f31d2db6,code,fr,5381b29e0775b11b,"using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -18883,8 +18883,8 @@ var rng = new Random(42);
 
 Console.WriteLine(""C# Wordle twin -- marathon #4956. Kernel .net-csharp, 0 NuGet (algorithme from-scratch)."");
 ",,,,,,,,5381b29e0775b11b,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,4e4eba349a19,markdown,fr,45dc55393a96127a,"---
-## 1. Systeme de feedback
+MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,4e4eba349a19,markdown,fr,55ae04c5d0c9e47e,"---
+## 1. Système de feedback
 
 Wordle code le retour d'une tentative par 5 symboles :
 
@@ -18893,7 +18893,7 @@ Wordle code le retour d'une tentative par 5 symboles :
 - **Gris (0)** : la lettre n'est pas presente (ou plus presente que dans la tentative).
 
 Le piege classique concerne les **lettres repeatedes**. Si la tentative contient deux `E` mais le secret un seul, un seul des deux `E` recoit un retour non-gris. L'algorithme ci-dessous resout ceci par une **double passe** : d'abord les verts (en marquant les lettres du secret comme consommees), ensuite les jaunes (en cherchant une occurrence encore libre).
-",,,,,,,,45dc55393a96127a,,,,,,,
+",,,,,,,,55ae04c5d0c9e47e,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,df329766caf2,code,fr,c4d756ece2ccd89c,"// Liste de mots francais de 5 lettres (sans accents, majuscules).
 // STRICTEMENT identique a la WORD_LIST du notebook Python (296 mots) -> parite d'entropie.
 static readonly string[] WORD_LIST_SRC = {
@@ -18992,17 +18992,17 @@ foreach (var (g, a, label) in testCases)
     Console.WriteLine($""  {g} vs {a} : [{FbStr(fb)}]  {string.Join("","", fb)}  -- {label}"");
 }
 ",,,,,,,,db91947a25ce7dbd,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,81c7814717af,markdown,fr,fdf1e6890a83c0b6,"### Interpretation : systeme de feedback
+MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,81c7814717af,markdown,fr,cf40af88ce39e23e,"### Interpretation : système de feedback
 
 Les cinq cas couvrent les subtilites :
 
 - `CRANE` vs `CRANE` -> `[GGGGG]` : tout vert, victoire immediate ;
-- `ANNEE` vs `AIMER` -> `[G___G]` : le `A` est vert (position 0), le `E` final est vert (position 4), mais le `N` et le second `E` restent gris car le secret ne contient qu'un seul `E` (deja consomme) et pas de `N`. C'est le test cle : sans la double passe, le second `E` de `ANNEE` serait incorrectement marque jaune.
-",,,,,,,,fdf1e6890a83c0b6,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,2a91dab18470,markdown,fr,5d327ff88fb7c702,"### 1.2 Visualisation d'une grille Wordle (ASCII)
+- `ANNEE` vs `AIMER` -> `[G___G]` : le `A` est vert (position 0), le `E` final est vert (position 4), mais le `N` et le second `E` restent gris car le secret ne contient qu'un seul `E` (déjà consomme) et pas de `N`. C'est le test cle : sans la double passe, le second `E` de `ANNEE` serait incorrectement marque jaune.
+",,,,,,,,cf40af88ce39e23e,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,2a91dab18470,markdown,fr,0a6861f9c1c7ec77,"### 1.2 Visualisation d'une grille Wordle (ASCII)
 
-Le notebook Python utilisait `matplotlib` pour dessiner une grille coloree. Le twin C# restitue la meme information en **ASCII** (la sortie d'un notebook pedagogique reste lisible sans dependance graphique) ; un rendu ScottPlot est donne plus bas en option.
-",,,,,,,,5d327ff88fb7c702,,,,,,,
+Le notebook Python utilisait `matplotlib` pour dessiner une grille coloree. Le twin C# restitue la même information en **ASCII** (la sortie d'un notebook pedagogique reste lisible sans dépendance graphique) ; un rendu ScottPlot est donne plus bas en option.
+",,,,,,,,0a6861f9c1c7ec77,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,4e8548c49d48,code,fr,5304f243b2284eba,"// Grille Wordle en ASCII : V = vert (bonne position), J = jaune (present, autre position), . = gris.
 static void DrawGridAscii(List<string> guesses, List<int[]> feedbacks, string answer, string title = ""Partie Wordle"")
 {
@@ -19041,11 +19041,11 @@ var demoGuesses = new List<string> { ""CRANE"", ""COEUR"", ""CRIER"", ""CROIX"" 
 var demoFeedbacks = demoGuesses.Select(g => ComputeFeedback(g, ""CROIX"")).ToList();
 DrawGridAscii(demoGuesses, demoFeedbacks, ""CROIX"", ""Demonstration ASCII"");
 ",,,,,,,,5304f243b2284eba,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,08a64677a19f,markdown,fr,21ee716707e10f9e,"---
+MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,08a64677a19f,markdown,fr,6df1d1b0c45df542,"---
 ## 2. Solveur par filtrage simple
 
-Premiere strategie, volontairement naive : a chaque tour, on filtre les mots incompatibles avec le feedback recu, puis on **choisit au hasard** un candidat parmi les survivants. Aucune heuristique d'information : ce solveur sert de **baseline** pour mesurer le gain apporte par le raisonnement.
-",,,,,,,,21ee716707e10f9e,,,,,,,
+Première stratégie, volontairement naive : a chaque tour, on filtre les mots incompatibles avec le feedback recu, puis on **choisit au hasard** un candidat parmi les survivants. Aucune heuristique d'information : ce solveur sert de **baseline** pour mesurer le gain apporte par le raisonnement.
+",,,,,,,,6df1d1b0c45df542,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,e3c679b9f8d1,code,fr,775aed8ba2bc6eba,"static bool FeedbackEqual(int[] a, int[] b)
 {
     for (int i = 0; i < 5; i++) if (a[i] != b[i]) return false;
@@ -19113,10 +19113,10 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,560455991f4
 
 Le tirage aleatoire explique les echecs : si le solveur elimine trop lentement les candidats, il peut epuiser ses 6 tentatives. La moyenne observee est grossiere parce qu'**aucune information n'est exploitee** pour orienter le choix. Les deux sections suivantes corrigent cela, chacune a sa maniere : le solveur CSP en propageant les contraintes, le solveur par entropie en maximisant l'information.
 ",,,,,,,,d6f0798a5ff18f80,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,0e93bc81954b,markdown,fr,209a6f013c8e1064,"---
+MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,0e93bc81954b,markdown,fr,f2300799af4a7def,"---
 ## 3. Solveur CSP : propagation de contraintes
 
-Wordle se modelise naturellement comme un **probleme de satisfaction de contraintes** :
+Wordle se modelise naturellement comme un **problème de satisfaction de contraintes** :
 
 - **Variables** : les 5 positions du mot ;
 - **Domaines** : pour chaque position, l'ensemble des lettres encore possibles (initialement A-Z) ;
@@ -19124,10 +19124,10 @@ Wordle se modelise naturellement comme un **probleme de satisfaction de contrain
 
   - **Vert** en position `i` pour la lettre `c` -> `domaines[i] = {c}` (la position est fixee) ;
   - **Jaune** en position `i` pour la lettre `c` -> `c` est **retiree** du domaine `i`, et `c` est declaree **requise** dans le mot ;
-  - **Gris** pour la lettre `c` -> `c` est retiree des domaines (sauf si `c` est deja requise par un jaune/vert, auquel cas on plafonne son nombre d'occurrences).
+  - **Gris** pour la lettre `c` -> `c` est retiree des domaines (sauf si `c` est déjà requise par un jaune/vert, auquel cas on plafonne son nombre d'occurrences).
 
 Le solveur maintient en plus des **compteurs min/max** par lettre pour gerer les repetitions. A chaque tour, il recupere les mots de la liste compatibles avec l'etat courant des domaines et des compteurs.
-",,,,,,,,209a6f013c8e1064,,,,,,,
+",,,,,,,,f2300799af4a7def,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,e81f5905ae45,code,fr,93356bd71784498e,"class CSPWordleSolver
 {
     private readonly List<string> _wordList;
@@ -19241,21 +19241,21 @@ var guessesCsp = solverCsp.Solve(""CRANE"", new Random(42), verbose: true);
 bool wonCsp = guessesCsp.Count > 0 && guessesCsp[^1] == ""CRANE"";
 Console.WriteLine($""\n=> {(wonCsp ? ""Gagne"" : ""Perdu"")} en {guessesCsp.Count} tentative(s)"");
 ",,,,,,,,4faa2a78a4f4a05d,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,6b2d4366fd74,markdown,fr,61081db5b49d2ecd,"### Interpretation : solveur CSP
+MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,6b2d4366fd74,markdown,fr,787f7d3b14ccf83d,"### Interpretation : solveur CSP
 
-La propagation de contraintes fait chuter le nombre de candidats bien plus vite que le filtrage aveugle : apres une seule tentative, les domaines se resserrent simultanement sur les 5 positions, et les lettres grisees eliminent en bloc tous les mots qui les contiennent. Notez toutefois que ce solveur **choisit encore au hasard** parmi les candidats compatibles : il propage mieux l'information acquise, mais ne **maximise** pas l'information de la prochaine tentative. C'est ce que reglera le solveur par entropie.
-",,,,,,,,61081db5b49d2ecd,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,91213fac661c,markdown,fr,69de4fa9550f55ff,"---
-## 4. Theorie de l'information : choisir le mot le plus informatif
+La propagation de contraintes fait chuter le nombre de candidats bien plus vite que le filtrage aveugle : après une seule tentative, les domaines se resserrent simultanement sur les 5 positions, et les lettres grisees eliminent en bloc tous les mots qui les contiennent. Notez toutefois que ce solveur **choisit encore au hasard** parmi les candidats compatibles : il propage mieux l'information acquise, mais ne **maximise** pas l'information de la prochaine tentative. C'est ce que reglera le solveur par entropie.
+",,,,,,,,787f7d3b14ccf83d,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,91213fac661c,markdown,fr,8cb1a9e98b3266c7,"---
+## 4. Théorie de l'information : choisir le mot le plus informatif
 
-Idee cle (Cover & Thomas) : avant de jouer un mot, on peut calculer **l'information attendue** qu'il va reveler. Pour un mot `g` face a un ensemble de candidats `C`, chaque secret possible `s` produit un feedback `ComputeFeedback(g, s)`. La distribution de ces feedbacks definit une variable aleatoire ; son **entropie de Shannon**
+Idee cle (Cover & Thomas) : avant de jouer un mot, on peut calculer **l'information attendue** qu'il va reveler. Pour un mot `g` face a un ensemble de candidats `C`, chaque secret possible `s` produit un feedback `ComputeFeedback(g, s)`. La distribution de ces feedbacks définit une variable aleatoire ; son **entropie de Shannon**
 
 $$H(g) = -\sum_{p} \frac{|p|}{|C|} \log_2 \frac{|p|}{|C|}$$
 
 (où la somme porte sur les *patterns* `p` observes) mesure, en **bits**, combien le feedback de `g` reduit en moyenne l'incertitude. Plus `H(g)` est grand, plus le mot est informatif. Le mot optimal d'ouverture est celui qui maximise `H`.
 
-Le maximum theorique est `log2(|C|)` : un mot qui repartirait uniformement le secret sur les 296 candidats en patterns equiprobables le reduirait a 1 candidat en une seule tentative.
-",,,,,,,,69de4fa9550f55ff,,,,,,,
+Le maximum théorique est `log2(|C|)` : un mot qui repartirait uniformement le secret sur les 296 candidats en patterns equiprobables le reduirait a 1 candidat en une seule tentative.
+",,,,,,,,8cb1a9e98b3266c7,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,57ef50aeb8c7,code,fr,e9f4e7d71781cb44,"static double ComputeEntropy(string guess, List<string> candidates)
 {
     if (candidates.Count == 0) return 0.0;
@@ -19300,10 +19300,10 @@ double hMax = Math.Log2(WORD_LIST.Count);
 Console.WriteLine($""\nEntropie maximale theorique : log2({WORD_LIST.Count}) = {hMax:F3} bits"");
 Console.WriteLine($""(une seule tentative suffirait si H = {hMax:F1} bits)"");
 ",,,,,,,,96d7092d1479a608,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,4752abea370f,markdown,fr,c35743e430c0dc67,"### 4.1 Les dix meilleurs mots d'ouverture
+MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,4752abea370f,markdown,fr,ed6115c56a83559b,"### 4.1 Les dix meilleurs mots d'ouverture
 
-Evaluation de l'entropie des 296 mots sur la liste complete. Ce calcul est **deterministe** : il doit concorder exactement avec le notebook Python (cf. § parite ci-dessous).
-",,,,,,,,c35743e430c0dc67,,,,,,,
+Evaluation de l'entropie des 296 mots sur la liste complete. Ce calcul est **déterministe** : il doit concorder exactement avec le notebook Python (cf. § parite ci-dessous).
+",,,,,,,,ed6115c56a83559b,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,78cb164e3164,code,fr,5658c3c73aeca7f6,"// Top 10 des meilleurs premiers mots par entropie (point de parite Python/C#).
 // Technique C548-L2 : formatter HTML integre au kernel (Microsoft.DotNet.Interactive.Formatting),
 // zero dependence NuGet cote charting. SVG inline (MIME text/html) -> rend sur GitHub/nbviewer/offline
@@ -19371,15 +19371,15 @@ string BuildBarSvgH(string[] labels, double[] values, string title, string xLabe
 var (bestWord, bestH) = topWords[0];
 Console.WriteLine($""\nMeilleur premier mot : {bestWord} (H = {bestH:F4} bits)"");
 Console.WriteLine($""Reduction attendue : {WORD_LIST.Count} -> ~{WORD_LIST.Count / Math.Pow(2, bestH):F0} candidats en moyenne"");",,,,,,,,5658c3c73aeca7f6,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,632962a5d7bd,markdown,fr,7c796e008227884b,"### Interpretation : meilleurs premiers mots
+MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,632962a5d7bd,markdown,fr,7db3708cf9c6eab9,"### Interpretation : meilleurs premiers mots
 
-Ces valeurs concordent **au bit pres** avec le notebook Python (LAINE en tete, vers 5.50 bits). C'est le point de parite cles du twin : l'algorithme etant purement deterministe (aucun PRNG), les deux implementations independantes C# et Python doivent produire le meme classement. Le meilleur mot d'ouverture extrait environ 5,5 bits d'information, soit une reduction d'un facteur ~45 de l'ensemble des candidats en une seule tentative.
-",,,,,,,,7c796e008227884b,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,b0df90c476a3,markdown,fr,ff55ada21c70c4a7,"---
+Ces valeurs concordent **au bit pres** avec le notebook Python (LAINE en tete, vers 5.50 bits). C'est le point de parite cles du twin : l'algorithme etant purement déterministe (aucun PRNG), les deux implementations independantes C# et Python doivent produire le même classement. Le meilleur mot d'ouverture extrait environ 5,5 bits d'information, soit une reduction d'un facteur ~45 de l'ensemble des candidats en une seule tentative.
+",,,,,,,,7db3708cf9c6eab9,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,b0df90c476a3,markdown,fr,2c27551ab5f69cff,"---
 ## 5. Solveur par entropie
 
-Derniere strategie : a chaque tour, **maximiser l'information attendue**. Le solveur choisit le mot (parmi les candidats encore possibles) de plus haute entropie. Cas limite : s'il ne reste qu'un ou deux candidats, l'entropie n'apporte plus rien et on les teste directement.
-",,,,,,,,ff55ada21c70c4a7,,,,,,,
+Dernière stratégie : a chaque tour, **maximiser l'information attendue**. Le solveur choisit le mot (parmi les candidats encore possibles) de plus haute entropie. Cas limite : s'il ne reste qu'un ou deux candidats, l'entropie n'apporte plus rien et on les teste directement.
+",,,,,,,,2c27551ab5f69cff,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,5c0182ad3d81,code,fr,9b459cf5f725141d,"class EntropySolver
 {
     private readonly List<string> _wordList;
@@ -19430,15 +19430,15 @@ foreach (var word in testWords)
 if (countsE.Count > 0)
     Console.WriteLine($""Moyenne (parties gagnees) : {countsE.Average():F1} tentatives  ({winsE}/{testWords.Length} gagnees)"");
 ",,,,,,,,dec994ea71c342c2,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,250024cbd60b,markdown,fr,1773bbd1981697ff,"### Interpretation : solveur par entropie
+MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,250024cbd60b,markdown,fr,f5be590b680396c3,"### Interpretation : solveur par entropie
 
-Contrairement aux deux premiers solveurs, celui-ci **n'utilise aucun tirage aleatoire** : son comportement est entierement deterministe. Il devrait donc resoudre la quasi-totalite des mots en peu de tentatives, parce qu'il extrait un maximum d'information a chaque coup. La comparaison chiffree ci-dessous quantifie le gain.
-",,,,,,,,1773bbd1981697ff,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,87e6afdecdd3,markdown,fr,073e7f5aaa945909,"---
+Contrairement aux deux premiers solveurs, celui-ci **n'utilise aucun tirage aleatoire** : son comportement est entierement déterministe. Il devrait donc resoudre la quasi-totalite des mots en peu de tentatives, parce qu'il extrait un maximum d'information a chaque coup. La comparaison chiffree ci-dessous quantifie le gain.
+",,,,,,,,f5be590b680396c3,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,87e6afdecdd3,markdown,fr,fb19b3b8ebcc5419,"---
 ## 6. Comparaison des trois approches
 
-On fait jouer les trois solveurs sur un meme banc de mots secrets et on compare le nombre moyen de tentatives (et le taux de reussite). Les solveurs aleatoires (filtrage simple, CSP) sont executes avec une graine fixe pour rendre le benchmark deterministe.
-",,,,,,,,073e7f5aaa945909,,,,,,,
+On fait jouer les trois solveurs sur un même banc de mots secrets et on compare le nombre moyen de tentatives (et le taux de reussite). Les solveurs aleatoires (filtrage simple, CSP) sont executes avec une graine fixe pour rendre le benchmark déterministe.
+",,,,,,,,fb19b3b8ebcc5419,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,54c44907783e,code,fr,927ec8dd39080ba2,"// Benchmark : moyenne de tentatives + taux de reussite sur un banc elargi.
 var benchWords = WORD_LIST.Take(50).ToList(); // 50 premiers mots (deterministe, borne)
 
@@ -19479,12 +19479,12 @@ Console.WriteLine($""{""1. Filtrage simple"",-28}{Avg(cSimple),-20:F2}{(double)w
 Console.WriteLine($""{""2. CSP (propagation)"",-28}{Avg(cCsp),-20:F2}{(double)wCsp/benchWords.Count,-15:P0}"");
 Console.WriteLine($""{""3. Entropie (deterministe)"",-28}{Avg(cEnt),-20:F2}{(double)wEnt/benchWords.Count,-15:P0}"");
 ",,,,,,,,927ec8dd39080ba2,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,259393b62e57,markdown,fr,f88dbb6506766852,"### Interpretation : comparaison des trois approches
+MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,259393b62e57,markdown,fr,e425e2cb6c404bc4,"### Interpretation : comparaison des trois approches
 
-Le solveur par **entropie** l'emporte nettement (meilleure moyenne, deterministe). Les deux solveurs aleatoires -- filtrage simple et CSP -- sont **tres proches** (ecart de l'ordre de 0,1 tentative sur ce banc). Ce resultat est instructif : la propagation de contraintes du CSP ne confere pas d'avantage decisif **quand le choix final reste aleatoire**, car les deux solveurs reduisent en fin de compte a la meme ensemble de candidats valides (un mot est candidat ssi il est compatible avec les feedbacks, ce que les domaines CSP et la comparaison de feedback expriment de maniere equivalente). Le leger ecart observe reste dans le bruit d'un banc de 50 mots.
+Le solveur par **entropie** l'emporte nettement (meilleure moyenne, déterministe). Les deux solveurs aleatoires -- filtrage simple et CSP -- sont **très proches** (ecart de l'ordre de 0,1 tentative sur ce banc). Ce résultat est instructif : la propagation de contraintes du CSP ne confere pas d'avantage decisif **quand le choix final reste aleatoire**, car les deux solveurs reduisent en fin de compte a la même ensemble de candidats valides (un mot est candidat ssi il est compatible avec les feedbacks, ce que les domaines CSP et la comparaison de feedback expriment de maniere equivalente). Le leger ecart observe reste dans le bruit d'un banc de 50 mots.
 
-La leçon nette est donc ailleurs : ce n'est pas la propagation qui fait la difference, c'est **l'information**. En remplaçant le tirage aleatoire par le mot d'entropie maximale, on gagne deterministement ~0,2 a ~0,3 tentative en moyenne et l'on supprime tout echec. C'est le gain pur de la theorie de l'information au-dela de la satisfaction de contraintes.
-",,,,,,,,f88dbb6506766852,,,,,,,
+La leçon nette est donc ailleurs : ce n'est pas la propagation qui fait la différence, c'est **l'information**. En remplaçant le tirage aleatoire par le mot d'entropie maximale, on gagne deterministement ~0,2 a ~0,3 tentative en moyenne et l'on supprime tout echec. C'est le gain pur de la théorie de l'information au-dela de la satisfaction de contraintes.
+",,,,,,,,e425e2cb6c404bc4,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,9a039f505da4,markdown,fr,cb218e293dd12c31,"---
 ## 7. Distribution des feedbacks
 
@@ -19516,9 +19516,9 @@ Console.WriteLine($""  Top-5 patterns les plus frequents : {string.Join("", "", 
 Console.WriteLine($""\nL'ecart de nombre de patterns distincts explique l'ecart d'entropie :"");
 Console.WriteLine($""  {best} disperse les secrets (information elevee), {worst} les concentre (information faible)."");
 ",,,,,,,,c8e2376ef3cd59f4,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,72f10fcd841e,markdown,fr,5cf0d2d9251b61e6,"### 7.1 Visualisation : histogramme (distribution des feedbacks)
+MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,72f10fcd841e,markdown,fr,6e893c01d3885c0d,"### 7.1 Visualisation : histogramme (distribution des feedbacks)
 
-L'histogramme ci-dessous montre la distribution des feedbacks du **meilleur** mot d'ouverture (haute entropie) et d'un mot **peu informatif** (entropie minimale), sous forme de barres. L'interet pedagogique porte sur la **forme** de la distribution : le meilleur mot disperse ses feedbacks (distribution plate = information maximale, chaque feedback elimine a peu pres autant de candidats), tandis que le pire mot les concentre sur 1-2 patterns (distribution pointue = information minimale, la plupart des feedbacks sont identiques). Le rendu Plotly (technique C548-L2 : formatter HTML integre au kernel, zero dependence NuGet cote charting) remplace l'ancien rendu ASCII qui masquait la forme reelle de la distribution derriere une echelle lineaire de `#`.",,,,,,,,5cf0d2d9251b61e6,,,,,,,
+L'histogramme ci-dessous montre la distribution des feedbacks du **meilleur** mot d'ouverture (haute entropie) et d'un mot **peu informatif** (entropie minimale), sous forme de barres. L'intérêt pedagogique porte sur la **forme** de la distribution : le meilleur mot disperse ses feedbacks (distribution plate = information maximale, chaque feedback elimine a peu pres autant de candidats), tandis que le pire mot les concentre sur 1-2 patterns (distribution pointue = information minimale, la plupart des feedbacks sont identiques). Le rendu Plotly (technique C548-L2 : formatter HTML integre au kernel, zero dependence NuGet cote charting) remplace l'ancien rendu ASCII qui masquait la forme reelle de la distribution derriere une echelle lineaire de `#`.",,,,,,,,6e893c01d3885c0d,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,6d6111204218,code,fr,a4087f1fb750eceb,"// Histogramme (rendu SVG inline) : nombre de mots par pattern de feedback, trie par frequence decroissante.
 // (PlotSvg + Formatter.Register definis en cell[21], technique C548-L2, MIME text/html.)
 static string BuildBarSvgV(string[] labels, int[] values, string title, string yLabel) {
@@ -19566,15 +19566,15 @@ static void HistogramSvg(string word, Dictionary<string, int> dist) {
 
 HistogramSvg(best, distBest);
 HistogramSvg(worst, distWorst);",,,,,,,,a4087f1fb750eceb,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,aa2daef17794,markdown,fr,79daee96e6071a68,"---
+MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,aa2daef17794,markdown,fr,ba19bcaf9ae7c3c3,"---
 ## 8. Exercices
 
-Trois exercices pour aller plus loin. Chaque stub s'execute sans erreur (convention C.1) : il retourne un resultat neutre et imprime un message d'attente. Implementez la solution demande puis re-executez la cellule.
+Trois exercices pour aller plus loin. Chaque stub s'execute sans erreur (convention C.1) : il retourne un résultat neutre et imprime un message d'attente. Implementez la solution demande puis re-executez la cellule.
 
 ### Exercice 1 : Meilleur second mot
 
-Le solveur par entropie pre-calcule le meilleur **premier** mot. Mais apres le premier feedback, le meilleur second mot **n'est pas forcement un candidat** : on peut vouloir jouer un mot hors-liste pour maximiser l'information (si cette information suffit ensuite a identifier le secret). Implementez `BestSecondGuess(candidates, wordPool)` qui renvoie le mot de `wordPool` (eventuellement plus large que `candidates`) maximisant l'entropie sur `candidates`.
-",,,,,,,,79daee96e6071a68,,,,,,,
+Le solveur par entropie pre-calcule le meilleur **premier** mot. Mais après le premier feedback, le meilleur second mot **n'est pas forcement un candidat** : on peut vouloir jouer un mot hors-liste pour maximiser l'information (si cette information suffit ensuite a identifier le secret). Implementez `BestSecondGuess(candidates, wordPool)` qui renvoie le mot de `wordPool` (eventuellement plus large que `candidates`) maximisant l'entropie sur `candidates`.
+",,,,,,,,ba19bcaf9ae7c3c3,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,a6277a07ad7b,code,fr,9d55b1e9c63445ac,"// Exercice 1 : retourner le mot de wordPool maximisant l'entropie sur candidates.
 static string BestSecondGuess(List<string> candidates, List<string> wordPool)
 {
@@ -19592,10 +19592,10 @@ Console.WriteLine(""Exercice 1 : methode BestSecondGuess definie (stub). A imple
 // var second = BestSecondGuess(FilterWords(WORD_LIST, topWords[0].word, ComputeFeedback(topWords[0].word, ""CRANE"")), WORD_LIST);
 // Console.WriteLine($""Meilleur second mot : {second}"");
 ",,,,,,,,9d55b1e9c63445ac,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,65a55415949b,markdown,fr,053601af6b62f82c,"### Exercice 2 : Mot d'ouverture robuste
+MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,65a55415949b,markdown,fr,ef943b400a8cd261,"### Exercice 2 : Mot d'ouverture robuste
 
-L'entropie mesure l'information *moyenne*. Mais un mot legerement moins bon en moyenne peut etre plus **robuste** (moins de pires cas). Implementez `WorstCaseGuess(candidates, wordPool)` : au lieu de `H(g)`, optimisez le **pire cas** -- minimiser la taille du plus grand pattern apres `g`. Comparez le mot optimal au pire cas vs le mot optimal en moyenne.
-",,,,,,,,053601af6b62f82c,,,,,,,
+L'entropie mesure l'information *moyenne*. Mais un mot legerement moins bon en moyenne peut etre plus **robuste** (moins de pires cas). Implementez `WorstCaseGuess(candidates, wordPool)` : au lieu de `H(g)`, optimisez le **pire cas** -- minimiser la taille du plus grand pattern après `g`. Comparez le mot optimal au pire cas vs le mot optimal en moyenne.
+",,,,,,,,ef943b400a8cd261,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,96a958a02098,code,fr,bf94eb927b4503a5,"// Exercice 2 : mot qui minimise le plus grand pattern apres feedback (minimax).
 static string WorstCaseGuess(List<string> candidates, List<string> wordPool)
 {
@@ -19625,33 +19625,33 @@ static List<string> Solve6Letters(List<string> wordList6, string answer)
 
 Console.WriteLine(""Exercice 3 : methode Solve6Letters definie (stub). A implementer."");
 ",,,,,,,,29e036bd02d85372,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,c0cfcdd6a99b,markdown,fr,1f0cca0cbd26f464,"---
+MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb,c0cfcdd6a99b,markdown,fr,de162b6f7a813d83,"---
 ## Conclusion
 
 Ce twin C# a reconstruit depuis zero les trois familles de solveurs Wordle du notebook Python :
 
 1. **Filtrage simple** (baseline aleatoire) -- mesure le plancher de performance ;
 2. **CSP par propagation de contraintes** (domaines par position, lettres requises, compteurs min/max) -- exploite mieux l'information acquise ;
-3. **Maximisation d'entropie** (Shannon) -- choisit a chaque tour le mot le plus informatif, deterministe.
+3. **Maximisation d'entropie** (Shannon) -- choisit a chaque tour le mot le plus informatif, déterministe.
 
 ### Parite Python / C#
 
-Les quantites **deterministes** concordent entre les deux langages :
+Les quantites **déterministes** concordent entre les deux langages :
 
 - Liste de mots : 296 mots identiques ;
 - Entropie maximale theoretique : `log2(296) = 8.21` bits ;
-- Classement top-10 des meilleurs premieres tentatives (LAINE en tete) : identique au bit pres ;
+- Classement top-10 des meilleurs premières tentatives (LAINE en tete) : identique au bit pres ;
 - Formule de feedback (double passe, lettres repeatedes) : comportement equivalent.
 
-Les quantites **aleatoires** (simple filtrage, solveur CSP avec tirage) different entre C# et Python : les PRNG `System.Random` et `random.seed` ne produisent pas la meme sequence. C'est attendu et **non un bug** : l'interet pedagogique porte sur les algorithmes et sur l'entropie (deterministe), pas sur la sequence de tirage.
+Les quantites **aleatoires** (simple filtrage, solveur CSP avec tirage) différent entre C# et Python : les PRNG `System.Random` et `random.seed` ne produisent pas la même sequence. C'est attendu et **non un bug** : l'intérêt pedagogique porte sur les algorithmes et sur l'entropie (déterministe), pas sur la sequence de tirage.
 
 ### Ponts inter-series
 
-- **Theorie de l'information** : cf. serie Search et la formalisation de l'entropie (Cover & Thomas) ;
+- **Théorie de l'information** : cf. serie Search et la formalisation de l'entropie (Cover & Thomas) ;
 - **CSP** : cf. [Partie 2 (CSP)](../../Part2-CSP/README.md) pour les domaines, la propagation et la consistence ;
-- **App-7 Python** : la version originale avec `numpy`/`matplotlib` donne les memes resultats deterministes.
+- **App-7 Python** : la version originale avec `numpy`/`matplotlib` donne les mêmes résultats déterministes.
 
-### Prochaines etapes
+### Prochaines étapes
 
 - Implementer les exercices (meilleur second mot, minimax robuste, extension 6 lettres) ;
 - Comparer le solveur par entropie a un solveur **hybride** (minimax sur le pire cas) ;
@@ -19662,10 +19662,10 @@ Les quantites **aleatoires** (simple filtrage, solveur CSP avec tirage) differen
 [<< App-7 Python](App-7-Wordle.ipynb) | [Index](../../README.md) | [App-8 MiniZinc >>](App-8-MiniZinc.ipynb)
 
 *Marathon #4956 -- parite .NET / Python, volet Search / Applications / CSP.*
-",,,,,,,,1f0cca0cbd26f464,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc-Csharp.ipynb,94cce746,markdown,fr,b0e5a6f71f142823,"# App-8 : Modelisation declarative par contraintes (twin C# .NET)
+",,,,,,,,de162b6f7a813d83,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc-Csharp.ipynb,94cce746,markdown,fr,c2792b433b4a0121,"# App-8 : Modelisation declarative par contraintes (twin C# .NET)
 
-> **Twin C# .NET de `App-8-MiniZinc.ipynb`** (marathon parite #4956). Kernel `.net-csharp`. Ce notebook utilise **Google.OrTools CP-SAT** (Prong A, EPIC #3801) -- le vrai moteur industriel de programmation par contraintes, accessible en .NET via NuGet. MiniZinc etant un langage de modelisation independant sans binding .NET officiel, ce twin exprime les memes modeles declaratifs via OR-Tools CP-SAT, qui partage le paradigme : **declarer les contraintes, laisser le solveur chercher**. Les graphiques matplotlib du twin Python sont remplaces par un rendu ASCII autonome.
+> **Twin C# .NET de `App-8-MiniZinc.ipynb`** (marathon parite #4956). Kernel `.net-csharp`. Ce notebook utilise **Google.OrTools CP-SAT** (Prong A, EPIC #3801) -- le vrai moteur industriel de programmation par contraintes, accessible en .NET via NuGet. MiniZinc etant un langage de modelisation indépendant sans binding .NET officiel, ce twin exprime les mêmes modèles declaratifs via OR-Tools CP-SAT, qui partage le paradigme : **declarer les contraintes, laisser le solveur chercher**. Les graphiques matplotlib du twin Python sont remplacés par un rendu ASCII autonome.
 
 ## Objectifs d'apprentissage
 
@@ -19673,7 +19673,7 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc-Csharp.ipynb,94cce746,m
 2. **Modeliser** en OR-Tools CP-SAT : variables, domaines, contraintes lineaires et globales
 3. **Resolver** problemes classiques (equations, monnaie, N-Reines, emploi du temps, Sudoku)
 4. **Comparer** la concision CP-SAT vs MiniZinc (du twin Python)
-5. **Optimiser** : minimiser un objectif (monnaie, makespan, distance)",,,,,,,,b0e5a6f71f142823,,,,,,,
+5. **Optimiser** : minimiser un objectif (monnaie, makespan, distance)",,,,,,,,c2792b433b4a0121,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc-Csharp.ipynb,31951426,code,fr,6c50c8e023f06313,"// App-8 : Modelisation declarative par contraintes -- twin C# de App-8-MiniZinc
 // Prong A (#3801) : Google.OrTools CP-SAT, le vrai moteur industriel de programmation
 // par contraintes. MiniZinc est un LANGAGE de modelisation independant (multi-solveur)
@@ -19715,16 +19715,16 @@ static void DisplayModel(string modelStr, string title = ""Modele MiniZinc"")
 
 Console.WriteLine(""Fonctions utilitaires definies."");
 ",,,,,,,,641ad88412115b71,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc-Csharp.ipynb,05c19703,markdown,fr,f73c8fe7da5c26fb,"## 1. Introduction : pourquoi la programmation par contraintes ?
+MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc-Csharp.ipynb,05c19703,markdown,fr,84ed775292abdfd7,"## 1. Introduction : pourquoi la programmation par contraintes ?
 
 La **programmation par contraintes (CP)** renverse le paradigme imperatif : au lieu decrire *comment* resoudre (algorithme pas-a-pas), on decrit *quoi* resoudre (les contraintes que la solution doit satisfaire), et un **solveur** cherche. MiniZinc est un langage dedie (concis, multi-solveur) ; OR-Tools CP-SAT est un moteur industriel accessible via une API .NET. Ce twin utilise CP-SAT ; le twin Python montre MiniZinc cote-a-cote.
 
 ### Architecture
 
 ```
-Modele (variables + contraintes)  -->  Solveur CP-SAT  -->  Solution
+Modèle (variables + contraintes)  -->  Solveur CP-SAT  -->  Solution
    (ce qu'on veut)                      (le moteur)        (ce qu'on obtient)
-```",,,,,,,,f73c8fe7da5c26fb,,,,,,,
+```",,,,,,,,84ed775292abdfd7,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc-Csharp.ipynb,05487dc2,code,fr,ccd1f00b3bc02cf0,"// === Section 2 : Premier modele -- systeme d'equations ===
 // x + y = 10 ET x * y = 21 (x, y dans 1..10). Solution : x = 7, y = 3 (ou x = 3, y = 7).
 //
@@ -19755,9 +19755,9 @@ var status = solver.Solve(model);
 Console.WriteLine($""Solution CP-SAT : x = {solver.Value(x)}, y = {solver.Value(y)}  (status: {status})"");
 Console.WriteLine($""Verification : x + y = {solver.Value(x) + solver.Value(y)}, x * y = {solver.Value(x) * solver.Value(y)}"");
 ",,,,,,,,ccd1f00b3bc02cf0,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc-Csharp.ipynb,59264935,markdown,fr,e241f2f798ba1ea6,"## 2. Syntaxe de base : premier modele
+MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc-Csharp.ipynb,59264935,markdown,fr,f0ac28f421fa26dc,"## 2. Syntaxe de base : premier modèle
 
-On commence par un **systeme d'equations** simple. MiniZinc (twin Python) l'exprime en 5 lignes ; CP-SAT C# ajoute la creation explicite des variables et le produit via `AddMultiplicationEquality`.",,,,,,,,e241f2f798ba1ea6,,,,,,,
+On commence par un **système d'equations** simple. MiniZinc (twin Python) l'exprime en 5 lignes ; CP-SAT C# ajoute la creation explicite des variables et le produit via `AddMultiplicationEquality`.",,,,,,,,f0ac28f421fa26dc,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc-Csharp.ipynb,54d9a8d6,code,fr,58a019525ad11677,"// === Section 2 (suite) : Optimisation -- probleme de monnaie ===
 // Rendre 99 centimes avec le MINIMUM de pieces (1c, 5c, 10c, 25c).
 // Solution optimale : 3x25c + 2x10c + 0x5c + 4x1c = 9 pieces.
@@ -19787,9 +19787,9 @@ Console.WriteLine(""Solution optimale CP-SAT :"");
 Console.WriteLine($""  {sCoins.Value(p25)}x25c + {sCoins.Value(p10)}x10c + {sCoins.Value(p5)}x5c + {sCoins.Value(p1)}x1c"");
 Console.WriteLine($""  Total = {sCoins.ObjectiveValue} pieces (minimum prouve par le solveur)"");
 ",,,,,,,,58a019525ad11677,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc-Csharp.ipynb,92e37664,markdown,fr,ef41d87f215d6bba,"### Optimisation : probleme de monnaie
+MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc-Csharp.ipynb,92e37664,markdown,fr,481244535184d9b9,"### Optimisation : problème de monnaie
 
-On passe de `solve satisfy` (trouver UNE solution) a `solve minimize` (trouver la MEILLEURE). En CP-SAT : `model.Minimize(objectif)`. Le solveur prouve l'optimalite (aucune solution a moins de pieces n'existe).",,,,,,,,ef41d87f215d6bba,,,,,,,
+On passe de `solve satisfy` (trouver UNE solution) a `solve minimize` (trouver la MEILLEURE). En CP-SAT : `model.Minimize(objectif)`. Le solveur prouve l'optimalite (aucune solution a moins de pieces n'existe).",,,,,,,,481244535184d9b9,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc-Csharp.ipynb,de6d8ffa,code,fr,e62310d53f1187b3,"// === Section 3 : Contraintes globales -- N-Reines ===
 // MiniZinc exprime N-Reines en ~5 lignes grace a la contrainte globale alldifferent.
 // On presente la concision MiniZinc, puis l'equivalent CP-SAT C# executable.
@@ -19941,9 +19941,9 @@ for (int i = 0; i < 4; i++)
     Console.WriteLine(""  "" + string.Join("" "", Enumerable.Range(0, 4).Select(j => sSk.Value(g[i, j]).ToString())));
 Console.WriteLine(""\nVoir la serie Sudoku pour des solveurs CSP complets -> ../../Sudoku/README.md"");
 ",,,,,,,,f66ca1f63e6025e7,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc-Csharp.ipynb,e42ecc73,markdown,fr,a46758ef2ef1bbdc,"## 4. Emploi du temps (timetabling)
+MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc-Csharp.ipynb,e42ecc73,markdown,fr,f46a3491ef59a3ef,"## 4. Emploi du temps (timetabling)
 
-Un probleme reel : assigner creneaux et salles a 6 cours sans conflit (enseignant, salle, capacite). La contrainte C2 est une **disjonction** (OU) -- modelisee en CP-SAT avec des booleens et `OnlyEnforceIf` / `AddBoolOr`. C'est l'apport pedagogique cles : la logique disjonctive se traduit en variables booleennes de reification.",,,,,,,,a46758ef2ef1bbdc,,,,,,,
+Un problème reel : assigner creneaux et salles a 6 cours sans conflit (enseignant, salle, capacite). La contrainte C2 est une **disjonction** (OU) -- modelisee en CP-SAT avec des booléens et `OnlyEnforceIf` / `AddBoolOr`. C'est l'apport pedagogique cles : la logique disjonctive se traduit en variables booleennes de reification.",,,,,,,,f46a3491ef59a3ef,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc-Csharp.ipynb,f52f1650,code,fr,e2272b53d076f6e2,"// === Section 6 : Comparaison imperatif vs declaratif ===
 // N-Reines resolu de 2 facons : (1) backtracking pur (imperatif), (2) CP-SAT (declaratif).
 // (MiniZinc, 3e approche du twin Python, est remplace par CP-SAT ici -- meme paradigme declaratif.)
@@ -19997,9 +19997,9 @@ foreach (var r in rows)
     Console.WriteLine($""{r.Crit,-30} {r.Py,-18} {r.Cp,-18} {r.Mz,-18}"");
 Console.WriteLine(new string('=', 86));
 ",,,,,,,,322e5e3151648b05,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc-Csharp.ipynb,0cccf684,markdown,fr,ef48a860b8481be5,"## 5. Sudoku 4x4
+MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc-Csharp.ipynb,0cccf684,markdown,fr,98553a732b836657,"## 5. Sudoku 4x4
 
-Le twin Python pilote MiniZinc depuis Python (modele + donnees `.dzn`). En CP-SAT C#, le modele et les donnees vivent dans le meme code : on fixe les cases initiales par `Add(var == valeur)`, puis `AddAllDifferent` sur lignes, colonnes et blocs 2x2.",,,,,,,,ef48a860b8481be5,,,,,,,
+Le twin Python pilote MiniZinc depuis Python (modèle + données `.dzn`). En CP-SAT C#, le modèle et les données vivent dans le même code : on fixe les cases initiales par `Add(var == valeur)`, puis `AddAllDifferent` sur lignes, colonnes et blocs 2x2.",,,,,,,,98553a732b836657,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc-Csharp.ipynb,c5217853,code,fr,db2e602003f87481,"#load ""../../../Probas/Infer/SvgChartHelper.cs""
 // Visualisation SVG statique (remplace Plotly-CDN qui rend BLANC en consultation statique --
 // GitHub sandbox les <script>; EPIC #3801 Prong A + EPIC #6927). Technique #6942 : <svg> inline
@@ -20076,20 +20076,20 @@ Console.WriteLine(""avec une API imperative. MiniZinc reste superieur pour la co
 Console.WriteLine(""multi-solveur (Gecode, Chuffed, CBC...). Les deux partagent le paradigme :"");
 Console.WriteLine(""declarer les contraintes, laisser le solveur chercher -- l'oppose du backtracking."");
 ",,,,,,,,9125d37437c309df,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc-Csharp.ipynb,5cee591e,markdown,fr,74f6c7d91317c4b6,"### Visualisation ASCII (concision et score multi-criteres)
+MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc-Csharp.ipynb,5cee591e,markdown,fr,1f154ae10a65f533,"### Visualisation ASCII (concision et score multi-critères)
 
-Les graphiques matplotlib du twin Python sont remplaces par des barres ASCII autonomes. Deux axes : concision (lignes de code) et evaluation multi-criteres (score 1-5).",,,,,,,,74f6c7d91317c4b6,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-header,markdown,fr,dbf98336306e31b5,"# App-8-MiniZinc : Modelisation declarative par contraintes
+Les graphiques matplotlib du twin Python sont remplacés par des barres ASCII autonomes. Deux axes : concision (lignes de code) et evaluation multi-critères (score 1-5).",,,,,,,,1f154ae10a65f533,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-header,markdown,fr,290b6395afced16c,"# App-8-MiniZinc : Modelisation declarative par contraintes
 
 **Navigation** : [<< App-7 Wordle](App-7-Wordle.ipynb) | [Index](../../README.md) | [App-9 EdgeDetection >>](../Hybrid/App-9-EdgeDetection.ipynb)
 
 ## Objectifs d'apprentissage
 
 A la fin de ce notebook, vous saurez :
-1. **Comprendre** la philosophie de MiniZinc : decrire un probleme de maniere declarative
-2. **Ecrire** des modeles MiniZinc (variables, contraintes, objectifs, sorties)
+1. **Comprendre** la philosophie de MiniZinc : decrire un problème de maniere declarative
+2. **Ecrire** des modèles MiniZinc (variables, contraintes, objectifs, sorties)
 3. **Utiliser** les contraintes globales (`alldifferent`, `cumulative`, `circuit`, `table`)
-4. **Comparer** les approches imperative (CP-SAT) et declarative (MiniZinc) sur un meme probleme
+4. **Comparer** les approches imperative (CP-SAT) et declarative (MiniZinc) sur un même problème
 5. **Piloter** MiniZinc depuis Python (package `minizinc` ou ligne de commande)
 
 ### Prerequis
@@ -20097,41 +20097,41 @@ A la fin de ce notebook, vous saurez :
 - Notions de contraintes globales (AllDifferent, cumulative)
 - Python 3.10+
 
-### Duree estimee : 50 minutes",,,,,,,,dbf98336306e31b5,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-intro-section,markdown,fr,dcb494a6f91a4b1d,"---
+### Duree estimee : 50 minutes",,,,,,,,290b6395afced16c,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-intro-section,markdown,fr,e3188a02187f6abb,"---
 
 ## 1. Introduction : pourquoi MiniZinc ? (~5 min)
 
-Dans les notebooks precedents, nous avons resolu des CSP en Python de maniere **imperative** : nous avons cree des variables, ajoute des contraintes une par une, configure un solveur, puis lance la recherche. C'est l'approche utilisee par OR-Tools/CP-SAT, python-constraint, etc.
+Dans les notebooks précédents, nous avons resolu des CSP en Python de maniere **imperative** : nous avons créé des variables, ajoute des contraintes une par une, configure un solveur, puis lance la recherche. C'est l'approche utilisee par OR-Tools/CP-SAT, python-constraint, etc.
 
-**MiniZinc** adopte une approche radicalement differente : l'approche **declarative**.
+**MiniZinc** adopte une approche radicalement différente : l'approche **declarative**.
 
 | Aspect | Imperatif (CP-SAT, Python) | Declaratif (MiniZinc) |
 |--------|---------------------------|----------------------|
 | Philosophie | Decrire **COMMENT** resoudre | Decrire **QUOI** resoudre |
 | Solveur | Choisi au codage | Interchangeable (Gecode, Chuffed, OR-Tools...) |
 | Syntaxe | API Python/Java/C++ | Langage dedie, proche des maths |
-| Separation modele/donnees | Melangees dans le code | Modele `.mzn` + donnees `.dzn` |
-| Reutilisabilite | Refactoring necessaire | Changer le fichier de donnees suffit |
+| Separation modèle/données | Melangees dans le code | Modèle `.mzn` + données `.dzn` |
+| Reutilisabilite | Refactoring necessaire | Changer le fichier de données suffit |
 
 ### MiniZinc en bref
 
 - **Langage de modelisation** de haut niveau pour problemes combinatoires
 - **Standard de l'industrie** en programmation par contraintes (depuis 2007, Universite de Melbourne)
-- **Compile** les modeles vers FlatZinc (format intermediaire) puis delegue a un solveur
+- **Compile** les modèles vers FlatZinc (format intermediaire) puis delegue a un solveur
 - **Ecosysteme** : IDE dedie, bibliotheque de contraintes globales, challenges MiniZinc annuels
 - **Solveurs compatibles** : Gecode, Chuffed, OR-Tools, COIN-BC, CPLEX, Gurobi...
 
 ### Architecture
 
 ```
-Modele (.mzn)  +  Donnees (.dzn)  -->  Compilateur MiniZinc  -->  FlatZinc  -->  Solveur
+Modèle (.mzn)  +  Données (.dzn)  -->  Compilateur MiniZinc  -->  FlatZinc  -->  Solveur
                                                                                (Gecode, Chuffed, ...)
                                                                                   |
                                                                               Solution
 ```
 
-Dans ce notebook, nous allons ecrire des modeles MiniZinc sous forme de chaines Python, les expliquer pas a pas, et (si le package `minizinc` est disponible) les executer directement.",,,,,,,,dcb494a6f91a4b1d,,,,,,,
+Dans ce notebook, nous allons ecrire des modèles MiniZinc sous forme de chaînes Python, les expliquer pas a pas, et (si le package `minizinc` est disponible) les executer directement.",,,,,,,,e3188a02187f6abb,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-imports,code,fr,c2bc5b276ab7c8aa,"# Imports pour tout le notebook
 import sys
 import time
@@ -20172,7 +20172,7 @@ except ImportError:
 
 print(""\nImports OK"")
 ",,,,,,,,c2bc5b276ab7c8aa,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-helpers-intro,markdown,fr,e2a98da6816f80b1,Definissons des fonctions utilitaires pour afficher et (optionnellement) executer des modeles MiniZinc depuis Python.,,,,,,,,e2a98da6816f80b1,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-helpers-intro,markdown,fr,216ac421c7c55d56,Definissons des fonctions utilitaires pour afficher et (optionnellement) executer des modèles MiniZinc depuis Python.,,,,,,,,216ac421c7c55d56,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-helpers,code,fr,c3b451a8edd50f04,"def display_model(model_str, title=""Modele MiniZinc""):
     """"""Affiche un modele MiniZinc avec numerotation des lignes.""""""
     print(f""\n{'=' * 60}"")
@@ -20244,36 +20244,36 @@ def run_minizinc_model(model_str, solver_name=""gecode"", timeout_sec=30, data_s
 
 print(""Fonctions utilitaires definies."")
 ",,,,,,,,c3b451a8edd50f04,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-section2-title,markdown,fr,9b00b4089bedce26,"---
+MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-section2-title,markdown,fr,f0f70f79d172814d,"---
 
 ## 2. Syntaxe de base de MiniZinc (~10 min)
 
-Un modele MiniZinc se compose de quatre elements principaux :
+Un modèle MiniZinc se compose de quatre éléments principaux :
 
-| Element | Syntaxe | Role |
+| Élément | Syntaxe | Rôle |
 |---------|---------|------|
 | **Variables de decision** | `var 1..9: x;` | Ce que l'on cherche |
 | **Contraintes** | `constraint x != y;` | Ce que l'on impose |
 | **Objectif** | `solve satisfy;` ou `solve minimize obj;` | Satisfaction ou optimisation |
 | **Sortie** | `output [""x=\(x), y=\(y)""];` | Format d'affichage |
 
-### Types de donnees
+### Types de données
 
 | Type | Exemple | Description |
 |------|---------|-------------|
-| `int` | `int: n = 8;` | Entier fixe (parametre) |
+| `int` | `int: n = 8;` | Entier fixe (paramètre) |
 | `var int` | `var 1..n: x;` | Variable de decision entiere |
 | `bool` | `var bool: b;` | Variable booleenne |
 | `float` | `var 0.0..1.0: p;` | Variable flottante |
 | `array` | `array[1..n] of var 1..n: q;` | Tableau de variables |
 | `set` | `var set of 1..5: s;` | Ensemble variable |
 
-### Premier exemple : systeme d'equations
+### Premier exemple : système d'equations
 
-Commencons par un probleme tres simple : trouver $x$ et $y$ tels que :
+Commencons par un problème très simple : trouver $x$ et $y$ tels que :
 $$x + y = 10 \quad \text{et} \quad x \times y = 21$$
 
-En Python, on pourrait resoudre cela algebriquement. En MiniZinc, on le **declare** simplement.",,,,,,,,9b00b4089bedce26,,,,,,,
+En Python, on pourrait resoudre cela algebriquement. En MiniZinc, on le **declare** simplement.",,,,,,,,f0f70f79d172814d,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-example-equations,code,fr,7e5b679c94d57526,"# Premier modele MiniZinc : systeme d'equations
 model_equations = """"""
 % Systeme d'equations : x + y = 10, x * y = 21
@@ -20295,11 +20295,11 @@ result = run_minizinc_model(model_equations)
 if result is None and not MINIZINC_CLI_AVAILABLE:
     print(""Resultat attendu : x = 3, y = 7 (ou x = 7, y = 3)"")
     print(""Verification : 3 + 7 = 10, 3 * 7 = 21"")",,,,,,,,7e5b679c94d57526,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-interp-equations,markdown,fr,7913617e380bd17d,"### Interpretation : premier modele
+MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-interp-equations,markdown,fr,7641712c8215c478,"### Interpretation : premier modèle
 
 **Sortie obtenue** (solveur Gecode) : la solution est $x = 7, y = 3$ (verifiee : $7 + 3 = 10$ et $7 	imes 3 = 21$).
 
-| Ligne | Element | Explication |
+| Ligne | Élément | Explication |
 |-------|---------|-------------|
 | `var 1..10: x;` | Declaration | $x$ est une variable de decision dans $\{1, ..., 10\}$ |
 | `constraint x + y = 10;` | Contrainte | Egalite (= et non ==) |
@@ -20307,13 +20307,13 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-interp-equat
 | `output [...]` | Sortie | Formatage avec `show()` pour les variables |
 
 **Points cles** :
-1. Le modele est **auto-explicatif** : on lit directement les equations mathematiques
+1. Le modèle est **auto-explicatif** : on lit directement les equations mathematiques
 2. Le `%` introduit un commentaire (comme `#` en Python)
 3. Chaque instruction se termine par `;`
-4. On ne specifie pas d'algorithme de resolution : le solveur s'en charge",,,,,,,,7913617e380bd17d,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-send-coins,markdown,fr,40cbd7d80dcf27f0,"### Exemple avec optimisation : probleme de monnaie
+4. On ne specifie pas d'algorithme de resolution : le solveur s'en charge",,,,,,,,7641712c8215c478,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-send-coins,markdown,fr,a206038e5851b7a4,"### Exemple avec optimisation : problème de monnaie
 
-Trouver le nombre minimal de pieces (1c, 5c, 10c, 25c) pour rendre exactement 99 centimes.",,,,,,,,40cbd7d80dcf27f0,,,,,,,
+Trouver le nombre minimal de pieces (1c, 5c, 10c, 25c) pour rendre exactement 99 centimes.",,,,,,,,a206038e5851b7a4,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-coins-model,code,fr,976d4ae1303cad74,"model_coins = """"""
 % Probleme de monnaie : rendre 99 centimes avec le minimum de pieces
 var 0..99: p1;   % pieces de 1 centime
@@ -20339,11 +20339,11 @@ result = run_minizinc_model(model_coins)
 if result is None and not MINIZINC_CLI_AVAILABLE:
     print(""Resultat attendu : 3x25c + 2x10c + 0x5c + 4x1c = 99c"")
     print(""Total : 9 pieces (optimal)"")",,,,,,,,976d4ae1303cad74,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-interp-coins,markdown,fr,5dd79c2297dd57bb,"### Interpretation : optimisation
+MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-interp-coins,markdown,fr,05c84dc76f011d63,"### Interpretation : optimisation
 
 **Sortie obtenue** (solveur Gecode, optimal) : 3 pieces de 25c + 2 pieces de 10c + 0 piece de 5c + 4 pieces de 1c = 99c, soit 9 pieces au total (minimum garanti par `solve minimize`).
 
-| Element | Syntaxe MiniZinc | Description |
+| Élément | Syntaxe MiniZinc | Description |
 |---------|------------------|-------------|
 | Variable derivee | `var int: total = ...;` | Variable calculee a partir d'autres |
 | Optimisation | `solve minimize total;` | Le solveur cherche la solution optimale |
@@ -20351,8 +20351,8 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-interp-coins
 **Points cles** :
 1. Passer de `solve satisfy` a `solve minimize/maximize` transforme un CSP en COP (Constraint Optimization Problem)
 2. Le solveur explore l'espace et garantit l'optimalite (contrairement aux heuristiques)
-3. Le modele reste compact et lisible",,,,,,,,5dd79c2297dd57bb,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-section3-title,markdown,fr,f544027b12d62c6d,"---
+3. Le modèle reste compact et lisible",,,,,,,,05c84dc76f011d63,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-section3-title,markdown,fr,bb5bbf40b61920af,"---
 
 ## 3. Contraintes globales dans MiniZinc (~10 min)
 
@@ -20367,14 +20367,14 @@ La puissance de MiniZinc reside en grande partie dans sa bibliotheque de **contr
 | `circuit` | `circuit(array)` | Circuit hamiltonien | TSP |
 | `table` | `table(vars, tuples)` | Combinaisons autorisees | Contraintes extensionnelles |
 | `count` | `count(array, val, n)` | Nombre d'occurrences | Frequences |
-| `element` | `element(i, array, val)` | Indexation par variable | Acces indirect |
+| `élément` | `élément(i, array, val)` | Indexation par variable | Acces indirect |
 | `increasing` | `increasing(array)` | Ordre croissant | Symetries |
 
 Pour utiliser les contraintes globales, il faut inclure la bibliotheque : `include ""globals.mzn"";`
 
 ### Exemple phare : N-Reines en MiniZinc
 
-Le probleme des N-Reines illustre parfaitement la concision de MiniZinc. Rappel : placer $N$ reines sur un echiquier $N \times N$ sans qu'aucune ne menace une autre.",,,,,,,,f544027b12d62c6d,,,,,,,
+Le problème des N-Reines illustre parfaitement la concision de MiniZinc. Rappel : placer $N$ reines sur un echiquier $N \times N$ sans qu'aucune ne menace une autre.",,,,,,,,bb5bbf40b61920af,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-nqueens-mzn,code,fr,38df5ac9932c9928,"# N-Reines en MiniZinc : modele complet en 7 lignes utiles
 model_nqueens = """"""
 include ""globals.mzn"";
@@ -20405,26 +20405,26 @@ if result is None and not MINIZINC_CLI_AVAILABLE:
         for col in range(8):
             line += ""Q "" if known[col] == row else "". ""
         print(line)",,,,,,,,38df5ac9932c9928,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-interp-nqueens-mzn,markdown,fr,c7b699dc2523e2da,"### Interpretation : N-Reines declaratif
+MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-interp-nqueens-mzn,markdown,fr,bb106114b424dd7b,"### Interpretation : N-Reines declaratif
 
-**Sortie obtenue** (solveur Gecode) : une solution valide des 8-Reines, affichee comme un echiquier (Q = reine, . = case vide).
+**Sortie obtenue** (solveur Gecode) : une solution valide des 8-Reines, affichée comme un echiquier (Q = reine, . = case vide).
 
-| Ligne du modele | Explication |
+| Ligne du modèle | Explication |
 |-----------------|-------------|
 | `include ""globals.mzn"";` | Charge la bibliotheque de contraintes globales |
 | `array[1..n] of var 1..n: q;` | Tableau de $n$ variables, chacune dans $\{1..n\}$ |
-| `alldifferent(q)` | Toutes les reines sur des lignes differentes |
-| `alldifferent([q[i]+i \| i in 1..n])` | Diagonales montantes toutes differentes |
-| `alldifferent([q[i]-i \| i in 1..n])` | Diagonales descendantes toutes differentes |
+| `alldifferent(q)` | Toutes les reines sur des lignes différentes |
+| `alldifferent([q[i]+i \| i in 1..n])` | Diagonales montantes toutes différentes |
+| `alldifferent([q[i]-i \| i in 1..n])` | Diagonales descendantes toutes différentes |
 
-**Comparaison avec le modele Python** :
+**Comparaison avec le modèle Python** :
 
-Le modele MiniZinc tient en **3 contraintes** contre une boucle imbriquee en Python. La comprehension de tableau `[q[i]+i | i in 1..n]` est l'equivalent MiniZinc des list comprehensions Python.
+Le modèle MiniZinc tient en **3 contraintes** contre une boucle imbriquee en Python. La comprehension de tableau `[q[i]+i | i in 1..n]` est l'equivalent MiniZinc des list comprehensions Python.
 
-> **Point cle** : `alldifferent` n'est pas une simple boucle de `!=`. Le solveur utilise des algorithmes de propagation specialises (filtrage par couplage maximum dans un graphe biparti) qui sont bien plus efficaces que des contraintes binaires individuelles.",,,,,,,,c7b699dc2523e2da,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-nqueens-comparison-intro,markdown,fr,687ba1465c255dff,"### Comparaison directe : N-Reines en CP-SAT vs MiniZinc
+> **Point cle** : `alldifferent` n'est pas une simple boucle de `!=`. Le solveur utilise des algorithmes de propagation specialises (filtrage par couplage maximum dans un graphe biparti) qui sont bien plus efficaces que des contraintes binaires individuelles.",,,,,,,,bb106114b424dd7b,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-nqueens-comparison-intro,markdown,fr,fc5f1aa9519f51fb,"### Comparaison directe : N-Reines en CP-SAT vs MiniZinc
 
-Pour mesurer la difference de concision, implementons le meme probleme en CP-SAT (OR-Tools).",,,,,,,,687ba1465c255dff,,,,,,,
+Pour mesurer la différence de concision, implementons le même problème en CP-SAT (OR-Tools).",,,,,,,,fc5f1aa9519f51fb,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-nqueens-cpsat,code,fr,433e0ef698bb03a0,"# N-Reines en CP-SAT (OR-Tools) - approche imperative
 def solve_nqueens_cpsat(n):
     """"""Resout N-Reines avec OR-Tools CP-SAT.""""""
@@ -20493,7 +20493,7 @@ if ORTOOLS_AVAILABLE:
     sol_cpsat, t_cpsat = solve_nqueens_cpsat(8)
     print(f""\nCP-SAT solution  : {sol_cpsat}"")
     print(f""CP-SAT temps     : {t_cpsat*1000:.2f} ms"")",,,,,,,,433e0ef698bb03a0,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-interp-comparison-nq,markdown,fr,a621f160fedc9033,"### Interpretation : concision et lisibilite
+MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-interp-comparison-nq,markdown,fr,d1cf3845fd684c93,"### Interpretation : concision et lisibilite
 
 | Critere | CP-SAT (Python) | MiniZinc |
 |---------|-----------------|----------|
@@ -20506,7 +20506,7 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-interp-compa
 **Points cles** :
 1. MiniZinc supprime tout le boilerplate (creation de solveur, extraction de valeurs)
 2. La syntaxe MiniZinc est plus proche de la notation mathematique
-3. En contrepartie, CP-SAT offre plus de controle programmatique (callbacks, branchement personnalise)",,,,,,,,a621f160fedc9033,,,,,,,
+3. En contrepartie, CP-SAT offre plus de contrôle programmatique (callbacks, branchement personnalise)",,,,,,,,d1cf3845fd684c93,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-global-examples-intro,markdown,fr,35740b20d9832c4b,"### Autres contraintes globales en action
 
 Voyons `cumulative` pour l'ordonnancement et `circuit` pour le TSP.",,,,,,,,35740b20d9832c4b,,,,,,,
@@ -20545,20 +20545,20 @@ if result is None and not MINIZINC_CLI_AVAILABLE:
     print(""  Tache 3 (dur=4, res=2) : debut=5,  fin=9"")
     print(""  Tache 4 (dur=6, res=1) : debut=3,  fin=9"")
     print(""  Makespan = 9"")",,,,,,,,9c9fef3b94dbd929,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-interp-cumulative,markdown,fr,956c76cd9d5204c7,"### Interpretation : contrainte cumulative
+MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-interp-cumulative,markdown,fr,3b73dfb7aea8e488,"### Interpretation : contrainte cumulative
 
-**Sortie obtenue** (solveur Gecode, optimal) : un ordonnancement avec makespan minimal = 9 (Tache 1: 4-9, Tache 2: 6-9, Tache 3: 0-4, Tache 4: 0-6). Les taches 3 et 4 demarrent a t=0 car leur besoin cumule (2+1=3) atteint exactement la capacite.
+**Sortie obtenue** (solveur Gecode, optimal) : un ordonnancement avec makespan minimal = 9 (Tâche 1: 4-9, Tâche 2: 6-9, Tâche 3: 0-4, Tâche 4: 0-6). Les tâches 3 et 4 demarrent a t=0 car leur besoin cumule (2+1=3) atteint exactement la capacite.
 
-| Parametre de `cumulative` | Signification |
+| Paramètre de `cumulative` | Signification |
 |---------------------------|---------------|
 | `start` | Dates de debut (variables de decision) |
-| `duration` | Durees des taches (donnees) |
-| `resource` | Besoin en ressource de chaque tache (donnees) |
+| `duration` | Durees des tâches (données) |
+| `resource` | Besoin en ressource de chaque tâche (données) |
 | `capacity` | Capacite maximale de la ressource (donnee) |
 
 La contrainte `cumulative` garantit qu'a aucun instant la somme des ressources utilisees ne depasse la capacite. C'est l'equivalent de dizaines de contraintes binaires codees a la main.
 
-> **Note technique** : en interne, le solveur utilise des algorithmes specialises (timetable, edge-finding, not-first/not-last) qui sont bien plus efficaces qu'une decomposition en contraintes elementaires.",,,,,,,,956c76cd9d5204c7,,,,,,,
+> **Note technique** : en interne, le solveur utilise des algorithmes specialises (timetable, edge-finding, not-first/not-last) qui sont bien plus efficaces qu'une decomposition en contraintes elementaires.",,,,,,,,3b73dfb7aea8e488,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-circuit-example,code,fr,efb8a77e7cd5725e,"# Exemple circuit : mini-TSP
 model_tsp = """"""
 include ""globals.mzn"";
@@ -20594,35 +20594,35 @@ if result is None and not MINIZINC_CLI_AVAILABLE:
     print(""Resultat attendu :"")
     print(""  Tour : 1->2->4->5->3->1 (ou equivalent)"")
     print(""  Distance totale = 80"")",,,,,,,,efb8a77e7cd5725e,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-interp-circuit,markdown,fr,a9d6388b225ea6b1,"### Interpretation : contrainte circuit pour le TSP
+MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-interp-circuit,markdown,fr,98b37e4874384746,"### Interpretation : contrainte circuit pour le TSP
 
 **Sortie obtenue** (solveur Gecode, optimal) : un circuit hamiltonien de distance totale = 85 (Tour : 1 -> 2 -> 4 -> 5 -> 3 -> 1).
 
-| Element | Explication |
+| Élément | Explication |
 |---------|-------------|
-| `array[1..n, 1..n] of int: dist` | Matrice de distances 2D (donnees) |
+| `array[1..n, 1..n] of int: dist` | Matrice de distances 2D (données) |
 | `circuit(next)` | Force `next` a former un seul cycle passant par toutes les villes |
 | `dist[i, next[i]]` | Distance de la ville $i$ a la suivante (indexation par variable) |
 
 **Points cles** :
-1. Tout le modele TSP tient en ~5 lignes declaratives
-2. `circuit` est une contrainte globale tres puissante : elle elimine les sous-tours automatiquement
-3. En CP-SAT, il faudrait ajouter manuellement des contraintes d'elimination de sous-tours (MTZ ou lazy constraints)",,,,,,,,a9d6388b225ea6b1,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-section4-title,markdown,fr,4f3de6b10f934445,"---
+1. Tout le modèle TSP tient en ~5 lignes declaratives
+2. `circuit` est une contrainte globale très puissante : elle elimine les sous-tours automatiquement
+3. En CP-SAT, il faudrait ajouter manuellement des contraintes d'elimination de sous-tours (MTZ ou lazy constraints)",,,,,,,,98b37e4874384746,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-section4-title,markdown,fr,7e894f280bcdd553,"---
 
 ## 4. MiniZinc pour l'emploi du temps (~10 min)
 
-Revenons au probleme d'emploi du temps vu dans [App-5-Timetabling](App-5-Timetabling.ipynb). Nous allons montrer comment MiniZinc separe elegamment le **modele** des **donnees**.
+Revenons au problème d'emploi du temps vu dans [App-5-Timetabling](App-5-Timetabling.ipynb). Nous allons montrer comment MiniZinc separe elegamment le **modèle** des **données**.
 
-### Le probleme
+### Le problème
 
 Affecter des cours a des creneaux horaires et des salles en respectant :
 - Chaque cours est assigne a exactement un creneau et une salle
-- Un enseignant ne peut pas donner deux cours en meme temps
-- Une salle ne peut pas accueillir deux cours en meme temps
+- Un enseignant ne peut pas donner deux cours en même temps
+- Une salle ne peut pas accueillir deux cours en même temps
 - La capacite de la salle doit etre suffisante pour les etudiants
 
-### Modele MiniZinc",,,,,,,,4f3de6b10f934445,,,,,,,
+### Modèle MiniZinc",,,,,,,,7e894f280bcdd553,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-timetabling-model,code,fr,1df35c1438c2134f,"# Modele d'emploi du temps en MiniZinc
 model_timetabling = r""""""
 include ""globals.mzn"";
@@ -20668,9 +20668,9 @@ solve satisfy;
 output [""Cours \(i) -> creneau \(slot[i]), salle \(room[i]) (prof=\(teacher[i]), \(students[i]) eleves)\\n"" | i in 1..n_courses];""""""
 
 display_model(model_timetabling, ""Emploi du temps"")",,,,,,,,1df35c1438c2134f,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-timetabling-explanation,markdown,fr,a5e46b1fcf3947f9,"### Analyse du modele
+MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-timetabling-explanation,markdown,fr,31f61eb6d6405dd4,"### Analyse du modèle
 
-Examinons les elements syntaxiques avances utilises dans ce modele.
+Examinons les éléments syntaxiques avances utilises dans ce modèle.
 
 | Syntaxe MiniZinc | Equivalent Python | Description |
 |------------------|-------------------|-------------|
@@ -20680,9 +20680,9 @@ Examinons les elements syntaxiques avances utilises dans ce modele.
 | `\\/` | `or` | Disjonction logique |
 | `room_cap[room[i]]` | `room_cap[room[i]]` | Indexation par variable de decision |
 
-### Separation modele/donnees
+### Separation modèle/données
 
-En production, les donnees seraient dans un fichier `.dzn` separe :
+En production, les données seraient dans un fichier `.dzn` separe :
 
 ```
 % fichier instance1.dzn
@@ -20695,7 +20695,7 @@ students = [30, 25, 40, 20, 35, 15];
 room_cap = [35, 45, 25];
 ```
 
-Le modele `.mzn` deviendrait generique : on pourrait resoudre n'importe quelle instance en changeant uniquement le fichier de donnees, sans toucher au modele.",,,,,,,,a5e46b1fcf3947f9,,,,,,,
+Le modèle `.mzn` deviendrait generique : on pourrait resoudre n'importe quelle instance en changeant uniquement le fichier de données, sans toucher au modèle.",,,,,,,,31f61eb6d6405dd4,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-timetabling-run,code,fr,ce49124784a96d04,"# Execution du modele d'emploi du temps
 result = run_minizinc_model(model_timetabling)
 
@@ -20707,9 +20707,9 @@ if result is None and not MINIZINC_CLI_AVAILABLE:
     print(""  Cours 4 -> creneau 3, salle 3 (prof=2, 20 eleves)"")
     print(""  Cours 5 -> creneau 2, salle 2 (prof=3, 35 eleves)"")
     print(""  Cours 6 -> creneau 1, salle 3 (prof=3, 15 eleves)"")",,,,,,,,ce49124784a96d04,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-timetabling-vs-cpsat,markdown,fr,e7c7ae9ad0ab5715,"### Comparaison : emploi du temps en CP-SAT vs MiniZinc
+MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-timetabling-vs-cpsat,markdown,fr,1bc843071a49c1ff,"### Comparaison : emploi du temps en CP-SAT vs MiniZinc
 
-Comparons la taille et la lisibilite des deux approches pour le meme probleme.",,,,,,,,e7c7ae9ad0ab5715,,,,,,,
+Comparons la taille et la lisibilite des deux approches pour le même problème.",,,,,,,,1bc843071a49c1ff,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-timetabling-cpsat,code,fr,27fbff9b085e8f8d,"# Meme probleme d'emploi du temps en CP-SAT pour comparaison
 def solve_timetabling_cpsat():
     """"""Resout l'emploi du temps avec OR-Tools CP-SAT.""""""
@@ -20780,26 +20780,26 @@ if ORTOOLS_AVAILABLE:
     solve_timetabling_cpsat()
 else:
     print(""[OR-Tools non disponible]"")",,,,,,,,27fbff9b085e8f8d,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-interp-timetabling,markdown,fr,c06c020a3c81f811,"### Interpretation : MiniZinc vs CP-SAT pour l'emploi du temps
+MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-interp-timetabling,markdown,fr,63c68d803956c4e9,"### Interpretation : MiniZinc vs CP-SAT pour l'emploi du temps
 
 | Aspect | MiniZinc | CP-SAT |
 |--------|----------|--------|
 | **Disjonction** (`\/`) | Native dans les contraintes | Necessite des variables booleennes intermediaires |
 | **Indexation par variable** | `room_cap[room[i]]` direct | Necessite `AddElement` ou decomposition |
-| **Separation donnees** | Fichier `.dzn` | Tout dans le code Python |
-| **Portabilite solveur** | Un modele, N solveurs | Lie a OR-Tools |
+| **Separation données** | Fichier `.dzn` | Tout dans le code Python |
+| **Portabilite solveur** | Un modèle, N solveurs | Lie a OR-Tools |
 
 **Points cles** :
 1. La disjonction logique est un cas ou MiniZinc brille : `\/` est naturel, tandis que CP-SAT necessite des variables booleennes auxiliaires (reification)
 2. L'indexation par variable de decision (`room_cap[room[i]]`) est geree nativement en MiniZinc
-3. Pour les grands projets, la separation modele/donnees de MiniZinc facilite la maintenance
+3. Pour les grands projets, la separation modèle/données de MiniZinc facilite la maintenance
 
-> **Quand preferer CP-SAT ?** Quand le probleme necessite une forte integration avec du code Python (callbacks, heuristiques personnalisees, post-traitement complexe) ou quand les performances brutes de CP-SAT sont critiques.",,,,,,,,c06c020a3c81f811,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-section5-title,markdown,fr,3446d337d5b3655c,"---
+> **Quand preferer CP-SAT ?** Quand le problème necessite une forte integration avec du code Python (callbacks, heuristiques personnalisees, post-traitement complexe) ou quand les performances brutes de CP-SAT sont critiques.",,,,,,,,63c68d803956c4e9,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-section5-title,markdown,fr,ac504d6eb9fd4f86,"---
 
 ## 5. Piloter MiniZinc depuis Python (~8 min)
 
-Le package Python `minizinc` permet d'integrer MiniZinc dans un workflow Python : creer des modeles, passer des donnees dynamiquement, et recuperer les resultats comme objets Python.
+Le package Python `minizinc` permet d'integrer MiniZinc dans un workflow Python : créer des modèles, passer des données dynamiquement, et recuperer les résultats comme objets Python.
 
 ### Installation
 
@@ -20807,34 +20807,34 @@ Le package Python `minizinc` permet d'integrer MiniZinc dans un workflow Python 
 pip install minizinc
 ```
 
-Il faut aussi que MiniZinc soit installe sur le systeme (https://www.minizinc.org/).
+Il faut aussi que MiniZinc soit installe sur le système (https://www.minizinc.org/).
 
 ### Workflow Python-MiniZinc
 
 ```python
 import minizinc
 
-# 1. Creer le modele
+# 1. Créer le modèle
 model = minizinc.Model()
 model.add_string(""..."")
 
 # 2. Choisir un solveur
 solver = minizinc.Solver.lookup(""gecode"")
 
-# 3. Creer une instance (modele + solveur)
+# 3. Créer une instance (modèle + solveur)
 instance = minizinc.Instance(solver, model)
 
-# 4. Passer des donnees
+# 4. Passer des données
 instance[""n""] = 8
 
 # 5. Resoudre
 result = instance.solve()
 
-# 6. Exploiter les resultats
+# 6. Exploiter les résultats
 print(result[""x""])  # valeur de la variable x
 ```
 
-### Exemple : Sudoku 4x4 depuis Python",,,,,,,,3446d337d5b3655c,,,,,,,
+### Exemple : Sudoku 4x4 depuis Python",,,,,,,,ac504d6eb9fd4f86,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-sudoku-mzn,code,fr,28bb57872aeda647,"# Sudoku 4x4 en MiniZinc, pilote depuis Python
 model_sudoku4 = """"""
 include ""globals.mzn"";
@@ -20900,23 +20900,23 @@ if result is None and not MINIZINC_CLI_AVAILABLE:
 print(""\nVoir la serie Sudoku pour des solveurs CSP complets :"")
 print(""  -> ../../Sudoku/README.md"")
 ",,,,,,,,28bb57872aeda647,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-interp-sudoku,markdown,fr,5d89e9095b348d61,"### Interpretation : Sudoku en MiniZinc
+MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-interp-sudoku,markdown,fr,4e692d5e7afb8675,"### Interpretation : Sudoku en MiniZinc
 
-**Sortie obtenue** (solveur Gecode) : la grille 4x4 completee (lignes, colonnes et sous-blocs 2x2 tous differents).
+**Sortie obtenue** (solveur Gecode) : la grille 4x4 completee (lignes, colonnes et sous-blocs 2x2 tous différents).
 
-| Element du modele | Explication |
+| Élément du modèle | Explication |
 |-------------------|-------------|
-| `array[1..n, 1..n] of 0..n: init` | Parametre : grille initiale passee depuis Python |
+| `array[1..n, 1..n] of 0..n: init` | Paramètre : grille initiale passee depuis Python |
 | `where init[i,j] > 0` | Filtre : ne fixer que les cases non vides |
 | `[grid[i,j] \| j in 1..n]` | Comprehension : extraire une ligne |
 | `grid[br*sub+r, bc*sub+c]` | Indexation calculee pour les sous-blocs |
 
-**Avantage Python + MiniZinc** : on peut generer des grilles en Python (aleatoirement, depuis un fichier, depuis une API) et les passer au modele MiniZinc. Le modele reste inchange.
+**Avantage Python + MiniZinc** : on peut generer des grilles en Python (aleatoirement, depuis un fichier, depuis une API) et les passer au modèle MiniZinc. Le modèle reste inchange.
 
-> **Lien** : la serie [Sudoku](../../../Sudoku/README.md) explore 6+ solveurs differents pour le Sudoku 9x9, incluant backtracking, AC-3, CP-SAT, et des approches hybrides.",,,,,,,,5d89e9095b348d61,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-cli-fallback,markdown,fr,cc53956e5b8a4b82,"### Alternative : appel en ligne de commande
+> **Lien** : la serie [Sudoku](../../../Sudoku/README.md) explore 6+ solveurs différents pour le Sudoku 9x9, incluant backtracking, AC-3, CP-SAT, et des approches hybrides.",,,,,,,,4e692d5e7afb8675,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-cli-fallback,markdown,fr,3868011860050410,"### Alternative : appel en ligne de commande
 
-Si le package Python n'est pas installe mais que le CLI `minizinc` est disponible, on peut ecrire le modele dans un fichier temporaire et l'executer via `subprocess`.",,,,,,,,cc53956e5b8a4b82,,,,,,,
+Si le package Python n'est pas installe mais que le CLI `minizinc` est disponible, on peut ecrire le modèle dans un fichier temporaire et l'executer via `subprocess`.",,,,,,,,3868011860050410,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-cli-demo,code,fr,db4c004dbc619e0e,"# Demonstration de l'appel CLI (si disponible)
 import tempfile
 import os
@@ -20954,13 +20954,13 @@ else:
     print(f""\nModele :"")
     print(model_simple)
     print(f""\nResultat attendu : a=1 b=5 (ou a=2 b=4)"")",,,,,,,,db4c004dbc619e0e,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-section6-title,markdown,fr,85c21af393015d4c,"---
+MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-section6-title,markdown,fr,59c7f0f5f37f90a8,"---
 
 ## 6. Comparaison : imperatif vs declaratif (~5 min)
 
-Nous avons maintenant vu les deux paradigmes en action. Synthetisons les differences fondamentales.
+Nous avons maintenant vu les deux paradigmes en action. Synthetisons les différences fondamentales.
 
-### N-Reines : trois approches cote a cote",,,,,,,,85c21af393015d4c,,,,,,,
+### N-Reines : trois approches cote a cote",,,,,,,,59c7f0f5f37f90a8,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-three-approaches,code,fr,87a6a69a631a8314,"# Approche 1 : Python pur (backtracking)
 def solve_nqueens_pure_python(n):
     """"""N-Reines par backtracking en Python pur.""""""
@@ -21084,24 +21084,24 @@ for i, critere in enumerate(comparison_data['Critere']):
     print(f""{critere:<30} {py_val:<18} {cpsat_val:<18} {mzn_val:<18}"")
 
 print(""="" * 85)",,,,,,,,2794e9091a57a44a,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-interp-paradigms,markdown,fr,bec25eabc3a6049f,"### Interpretation : choix du paradigme
+MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-interp-paradigms,markdown,fr,96cf335bbf0b7963,"### Interpretation : choix du paradigme
 
 **Quand utiliser chaque approche :**
 
 | Situation | Recommandation | Raison |
 |-----------|---------------|--------|
-| Cours / pedagogie | Python pur ou MiniZinc | Comprendre les mecanismes |
+| Cours / pedagogie | Python pur ou MiniZinc | Comprendre les mécanismes |
 | Prototypage rapide | MiniZinc | Concision, pas de boilerplate |
 | Production Python | CP-SAT | Performance, integration |
 | Recherche academique | MiniZinc | Portabilite entre solveurs |
-| Application embarquee | CP-SAT ou solveur natif | Controle total |
+| Application embarquee | CP-SAT ou solveur natif | Contrôle total |
 
 **Points cles** :
-1. MiniZinc est le meilleur choix pour **communiquer** un modele (articles, presentations, documentation)
+1. MiniZinc est le meilleur choix pour **communiquer** un modèle (articles, presentations, documentation)
 2. CP-SAT est le meilleur choix pour **deployer** une solution en production Python
 3. Les deux peuvent coexister : prototyper en MiniZinc, deployer en CP-SAT
 
-> **A retenir** : le paradigme declaratif (MiniZinc) est a la programmation par contraintes ce que SQL est aux bases de donnees -- un langage de specification, pas d'implementation.",,,,,,,,bec25eabc3a6049f,,,,,,,
+> **A retenir** : le paradigme declaratif (MiniZinc) est a la programmation par contraintes ce que SQL est aux bases de données -- un langage de specification, pas d'implementation.",,,,,,,,96cf335bbf0b7963,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-viz-comparison,code,fr,26e86313ec324bc3,"# Visualisation : concision des approches
 fig, axes = plt.subplots(1, 2, figsize=(14, 5))
 
@@ -21151,17 +21151,17 @@ plt.suptitle('Comparaison des paradigmes de modelisation',
              fontsize=14, fontweight='bold')
 plt.tight_layout()
 plt.show()",,,,,,,,26e86313ec324bc3,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-section7-title,markdown,fr,262d7c133184399f,"---
+MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-section7-title,markdown,fr,2f8d0e0178db8df2,"---
 
 ## 7. Exercices
 
 ### Exercice 1 : Carre magique en MiniZinc
 
-Un **carre magique** d'ordre $n$ est une grille $n \times n$ contenant les entiers $1$ a $n^2$, ou la somme de chaque ligne, chaque colonne et les deux diagonales est la meme.
+Un **carre magique** d'ordre $n$ est une grille $n \times n$ contenant les entiers $1$ a $n^2$, ou la somme de chaque ligne, chaque colonne et les deux diagonales est la même.
 
 Pour $n = 3$, cette somme magique vaut $\frac{n(n^2+1)}{2} = 15$.
 
-**Consigne** : completez le modele MiniZinc ci-dessous pour le carre magique $3 \times 3$.",,,,,,,,262d7c133184399f,,,,,,,
+**Consigne** : completez le modèle MiniZinc ci-dessous pour le carre magique $3 \times 3$.",,,,,,,,2f8d0e0178db8df2,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-exercise1,code,fr,17b649e330d7f006,"# Exercice 1 : Carre magique en MiniZinc
 
 model_magic_square = """"""
@@ -21196,9 +21196,9 @@ output [show(grid[i,j]) ++ if j == n then ""\\n"" else "" "" endif
 """"""
 
 display_model(model_magic_square, ""Exercice 1 : Carre magique (a completer)"")",,,,,,,,17b649e330d7f006,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-exercise2-title,markdown,fr,76cac169e727cd9f,"### Exercice 2 : Coloration de graphe en MiniZinc
+MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-exercise2-title,markdown,fr,3e83babdfda710bf,"### Exercice 2 : Coloration de graphe en MiniZinc
 
-Reprenez le probleme de coloration de graphe de [App-2-GraphColoring](App-2-GraphColoring.ipynb) et ecrivez le modele MiniZinc correspondant.
+Reprenez le problème de coloration de graphe de [App-2-GraphColoring](App-2-GraphColoring.ipynb) et ecrivez le modèle MiniZinc correspondant.
 
 Le graphe est le suivant (6 noeuds, 7 aretes) :
 ```
@@ -21207,7 +21207,7 @@ A -- B -- C
 D -- E -- F
 ```
 
-**Consigne** : ecrire un modele MiniZinc qui determine le nombre chromatique (nombre minimum de couleurs).",,,,,,,,76cac169e727cd9f,,,,,,,
+**Consigne** : ecrire un modèle MiniZinc qui determine le nombre chromatique (nombre minimum de couleurs).",,,,,,,,3e83babdfda710bf,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-exercise2,code,fr,bff6c83ac4bef6eb,"# Exercice 2 : Coloration de graphe en MiniZinc
 
 # A COMPLETER : ecrire le modele MiniZinc
@@ -21224,15 +21224,15 @@ model_coloring = """"""
 """"""
 
 display_model(model_coloring, ""Exercice 2 : Coloration de graphe (a completer)"")",,,,,,,,bff6c83ac4bef6eb,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-exercise3-title,markdown,fr,642487b8467ca410,"### Exercice 3 : VRP simplifie en MiniZinc
+MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-exercise3-title,markdown,fr,a4e5f44f8a543405,"### Exercice 3 : VRP simplifie en MiniZinc
 
 Le **Vehicle Routing Problem** (VRP) consiste a trouver des tournees optimales pour un ensemble de vehicules partant d'un depot et devant visiter des clients.
 
 **Version simplifiee** : un seul vehicule, 5 clients + 1 depot (noeud 1), minimiser la distance totale.
 
-**Consigne** : completez le modele en utilisant la contrainte `circuit`.
+**Consigne** : completez le modèle en utilisant la contrainte `circuit`.
 
-*Indice* : c'est essentiellement un TSP avec un depot fixe.",,,,,,,,642487b8467ca410,,,,,,,
+*Indice* : c'est essentiellement un TSP avec un depot fixe.",,,,,,,,a4e5f44f8a543405,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-exercise3,code,fr,f594b7304f4bb1e2,"# Exercice 3 : VRP simplifie en MiniZinc
 
 model_vrp = """"""
@@ -21260,15 +21260,15 @@ array[1..n, 1..n] of int: dist =
 """"""
 
 display_model(model_vrp, ""Exercice 3 : VRP simplifie (a completer)"")",,,,,,,,f594b7304f4bb1e2,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-conclusion-title,markdown,fr,5a9170aebeb431d9,"---
+MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-conclusion-title,markdown,fr,00901c82bcaed896,"---
 
 ## Recapitulatif
 
 ### Resume de la syntaxe MiniZinc
 
-| Element | Syntaxe | Exemple |
+| Élément | Syntaxe | Exemple |
 |---------|---------|--------|
-| Parametre | `int: n = 8;` | Constante connue |
+| Paramètre | `int: n = 8;` | Constante connue |
 | Variable | `var 1..n: x;` | Inconnue a determiner |
 | Tableau | `array[1..n] of var 1..n: q;` | Vecteur de variables |
 | Contrainte | `constraint expr;` | Restriction |
@@ -21276,7 +21276,7 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-conclusion-t
 | Comprehension | `[f(i) \| i in 1..n]` | Tableau calcule |
 | Satisfaction | `solve satisfy;` | Trouver une solution |
 | Optimisation | `solve minimize obj;` | Trouver la meilleure |
-| Sortie | `output [show(x)];` | Formatage du resultat |
+| Sortie | `output [show(x)];` | Formatage du résultat |
 
 ### Contraintes globales vues
 
@@ -21292,22 +21292,22 @@ MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb,cell-conclusion-t
 |---------|-------------------|----------------------|
 | Philosophie | Decrire comment resoudre | Decrire quoi resoudre |
 | Force principale | Performance, integration | Concision, portabilite |
-| Faiblesse | Verbeux, lie au solveur | Moins de controle fin |
+| Faiblesse | Verbeux, lie au solveur | Moins de contrôle fin |
 | Analogie | Programmation procedurale | SQL pour les contraintes |
 
 ### Et ensuite ?
 
-- [App-9-EdgeDetection](../Hybrid/App-9-EdgeDetection.ipynb) : optimisation par algorithmes genetiques pour la detection de contours
+- [App-9-EdgeDetection](../Hybrid/App-9-EdgeDetection.ipynb) : optimisation par algorithmes génétiques pour la detection de contours
 - [App-5-Timetabling](App-5-Timetabling.ipynb) : emploi du temps complet avec MiniZinc + OR-Tools
-- Serie [Sudoku](../../../Sudoku/README.md) : 6+ solveurs differents pour un meme probleme
+- Serie [Sudoku](../../../Sudoku/README.md) : 6+ solveurs différents pour un même problème
 
 ### Ressources
 
 - [MiniZinc Handbook](https://www.minizinc.org/doc-2.7.6/en/index.html) : documentation officielle
-- [MiniZinc IDE](https://www.minizinc.org/ide/) : environnement de developpement dedie
+- [MiniZinc IDE](https://www.minizinc.org/ide/) : environnement de développement dedie
 - [MiniZinc Challenge](https://www.minizinc.org/challenge.html) : competition annuelle de solveurs
-- Stuckey, P.J. et al. *MiniZinc: Towards a Standard CP Modelling Language*, CP 2007",,,,,,,,5a9170aebeb431d9,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,xrhndoulu4,markdown,fr,6dac10c926afbb5d,"# App-10 : Optimisation de portefeuille par algorithme genetique
+- Stuckey, P.J. et al. *MiniZinc: Towards a Standard CP Modelling Language*, CP 2007",,,,,,,,00901c82bcaed896,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,xrhndoulu4,markdown,fr,28f77fbb73454a53,"# App-10 : Optimisation de portefeuille par algorithme génétique
 
 **Navigation** : [<< App-9 EdgeDetection](../Hybrid/App-9-EdgeDetection.ipynb) | [Index](../README.md) | [App-11 Picross >>](../CSP/App-11-Picross.ipynb)
 
@@ -21315,33 +21315,33 @@ MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,xrhndoulu4,m
 
 A la fin de ce notebook, vous saurez :
 1. **Modeliser** un portefeuille financier (rendement, risque, ratio de Sharpe)
-2. **Appliquer** un algorithme genetique (PyGAD) a l'optimisation multi-objectif
+2. **Appliquer** un algorithme génétique (PyGAD) a l'optimisation multi-objectif
 3. **Construire** la frontiere efficiente de Markowitz par exploration parametrique
 4. **Comparer** echantillonnage aleatoire, GA mono-objectif et approche multi-objectif
 
 ### Prerequis
 - Python 3.10+ (numpy, matplotlib)
-- Search-5 : Algorithmes genetiques (concepts de fitness, selection, crossover, mutation)
+- Search-5 : Algorithmes génétiques (concepts de fitness, sélection, crossover, mutation)
 
 ### Duree estimee : 40 minutes
 
-> **Side track** : Voir [App-10b C#](App-10b-Portfolio-CSharp.ipynb) pour la version GeneticSharp de ce probleme.",,,,,,,,6dac10c926afbb5d,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,o07uy1tkni9,markdown,fr,60363182806d75e9,"## 1. Introduction
+> **Side track** : Voir [App-10b C#](App-10b-Portfolio-CSharp.ipynb) pour la version GeneticSharp de ce problème.",,,,,,,,28f77fbb73454a53,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,o07uy1tkni9,markdown,fr,5a3530d3d700e083,"## 1. Introduction
 
-### La theorie moderne du portefeuille
+### La théorie moderne du portefeuille
 
-En 1952, Harry **Markowitz** revolutionne la finance en formalisant le probleme de l'allocation d'actifs comme un probleme d'**optimisation bi-objectif** :
+En 1952, Harry **Markowitz** revolutionne la finance en formalisant le problème de l'allocation d'actifs comme un problème d'**optimisation bi-objectif** :
 
 | Objectif | Description | Mesure |
 |----------|-------------|--------|
 | **Maximiser le rendement** | Rendement attendu du portefeuille | $R_p = \mathbf{w}^T \boldsymbol{\mu}$ |
 | **Minimiser le risque** | Volatilite du portefeuille | $\sigma_p = \sqrt{\mathbf{w}^T \Sigma \mathbf{w}}$ |
 
-Ces deux objectifs sont **contradictoires** : les actifs a haut rendement sont generalement plus risques. La **frontiere efficiente** (ou frontiere de Pareto) represente l'ensemble des portefeuilles optimaux pour lesquels on ne peut ameliorer un objectif sans degrader l'autre.
+Ces deux objectifs sont **contradictoires** : les actifs a haut rendement sont généralement plus risques. La **frontiere efficiente** (ou frontiere de Pareto) represente l'ensemble des portefeuilles optimaux pour lesquels on ne peut ameliorer un objectif sans degrader l'autre.
 
-### Pourquoi un algorithme genetique ?
+### Pourquoi un algorithme génétique ?
 
-Les methodes classiques (programmation quadratique) resolvent ce probleme efficacement dans le cas standard. Cependant, les algorithmes genetiques offrent des avantages dans les cas plus complexes :
+Les méthodes classiques (programmation quadratique) resolvent ce problème efficacement dans le cas standard. Cependant, les algorithmes génétiques offrent des avantages dans les cas plus complexes :
 
 | Situation | Avantage du GA |
 |-----------|----------------|
@@ -21350,7 +21350,7 @@ Les methodes classiques (programmation quadratique) resolvent ce probleme effica
 | Multi-objectif | NSGA-II produit directement la frontiere de Pareto |
 | Fonction objectif bruitee | Robustesse aux evaluations stochastiques |
 
-Dans ce notebook, nous utiliserons **PyGAD** pour optimiser un portefeuille de 5 actifs et reconstruire la frontiere efficiente.",,,,,,,,60363182806d75e9,,,,,,,
+Dans ce notebook, nous utiliserons **PyGAD** pour optimiser un portefeuille de 5 actifs et reconstruire la frontiere efficiente.",,,,,,,,5a3530d3d700e083,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,i58ce2zp19f,code,fr,52347c3541777ca3,"# Imports et configuration
 import sys
 import os
@@ -21388,7 +21388,7 @@ except ImportError:
     print(""PyGAD non disponible. Installer avec : pip install pygad"")
 
 print(""Environnement pret."")",,,,,,,,52347c3541777ca3,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,p1yavcoqvca,markdown,fr,d673fd1b6d8ff12d,"## 2. Modele de portefeuille
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,p1yavcoqvca,markdown,fr,0c7cc9a32316664f,"## 2. Modèle de portefeuille
 
 ### Definition des actifs
 
@@ -21405,7 +21405,7 @@ Nous considerons 5 actifs financiers avec des rendements attendus croissants et 
 | $\sigma_p = \sqrt{\mathbf{w}^T \Sigma \mathbf{w}}$ | Risque (ecart-type) du portefeuille |
 | $S = \frac{R_p - R_f}{\sigma_p}$ | Ratio de Sharpe ($R_f$ = taux sans risque) |
 
-**Contraintes** : $w_i \geq 0$ (pas de vente a decouvert) et $\sum_{i=1}^{5} w_i = 1$ (allocation totale).",,,,,,,,d673fd1b6d8ff12d,,,,,,,
+**Contraintes** : $w_i \geq 0$ (pas de vente a decouvert) et $\sum_{i=1}^{5} w_i = 1$ (allocation totale).",,,,,,,,0c7cc9a32316664f,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,saub2zbb8cn,code,fr,9265bc3c2f9f957c,"# --- Definition du modele de portefeuille ---
 
 # Noms des actifs
@@ -21440,7 +21440,7 @@ for i in range(n_assets):
     sharpe_i = (expected_returns[i] - risk_free_rate) / risk_i
     print(f""{asset_names[i]:<15} {expected_returns[i]:>8.1%}    {risk_i:>8.1%}    {sharpe_i:>8.2f}"")
 print(""="" * 55)",,,,,,,,9265bc3c2f9f957c,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,c7khflhfcd,markdown,fr,9223e3eb9594e9d2,"### Interpretation : Caracteristiques individuelles des actifs
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,c7khflhfcd,markdown,fr,02e161e3c53ba4c9,"### Interpretation : Caractéristiques individuelles des actifs
 
 | Actif | Rendement | Risque | Observation |
 |-------|-----------|--------|-------------|
@@ -21450,7 +21450,7 @@ MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,c7khflhfcd,m
 | Actions US | 20% | ~20% | Rendement eleve, risque eleve |
 | Emergents | 25% | ~22% | Rendement maximal, risque maximal |
 
-**Point cle** : Le ratio de Sharpe individuel permet de comparer les actifs sur une base ajustee du risque. Un actif avec un Sharpe eleve offre un meilleur rendement par unite de risque. Cependant, la diversification peut faire mieux que le meilleur actif individuel grace a la **reduction du risque par decorrelation**.",,,,,,,,9223e3eb9594e9d2,,,,,,,
+**Point cle** : Le ratio de Sharpe individuel permet de comparer les actifs sur une base ajustee du risque. Un actif avec un Sharpe eleve offre un meilleur rendement par unite de risque. Cependant, la diversification peut faire mieux que le meilleur actif individuel grace a la **reduction du risque par decorrelation**.",,,,,,,,02e161e3c53ba4c9,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,vd3o6ug0zf,markdown,fr,e054923636888896,"### Fonctions utilitaires du portefeuille
 
 Definissons les fonctions de calcul du rendement, du risque et du ratio de Sharpe pour un vecteur de poids donne.",,,,,,,,e054923636888896,,,,,,,
@@ -21522,7 +21522,7 @@ ax.yaxis.set_major_formatter(plt.FuncFormatter(lambda x, _: f'{x:.0%}'))
 plt.tight_layout()
 plt.show()
 plt.close()",,,,,,,,00700f0daa6bcec6,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,u27fkaexry,markdown,fr,90ce6c8d716eb286,"### Interpretation : Espace risque-rendement
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,u27fkaexry,markdown,fr,6b614f043fe954e7,"### Interpretation : Espace risque-rendement
 
 **Sortie obtenue** : Les 5 actifs sont alignes du coin inferieur gauche (faible risque, faible rendement) au coin superieur droit (haut risque, haut rendement). Le portefeuille equipondere (losange orange) se situe au milieu.
 
@@ -21531,17 +21531,17 @@ MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,u27fkaexry,m
 2. Le portefeuille equipondere a un risque **inferieur** a la moyenne des risques individuels grace a la diversification
 3. L'objectif de l'optimisation est de trouver des portefeuilles situes le plus haut possible (rendement) et le plus a gauche possible (faible risque)
 
-> **Note** : La zone au-dessus et a gauche de chaque actif individuel est accessible uniquement par la diversification. C'est la puissance de la theorie de Markowitz.",,,,,,,,90ce6c8d716eb286,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,rq8m0slcbm,markdown,fr,358eac961840f1d2,"## 3. Approche 1 : Echantillonnage aleatoire
+> **Note** : La zone au-dessus et a gauche de chaque actif individuel est accessible uniquement par la diversification. C'est la puissance de la théorie de Markowitz.",,,,,,,,6b614f043fe954e7,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,rq8m0slcbm,markdown,fr,8fa12575b21a28be,"## 3. Approche 1 : Echantillonnage aleatoire
 
 ### Principe
 
-Avant d'utiliser un algorithme genetique, explorons l'espace des portefeuilles possibles par **echantillonnage aleatoire** (methode Monte Carlo). Pour chaque echantillon, nous generons un vecteur de poids aleatoire (distribution de Dirichlet pour obtenir des poids positifs qui somment a 1) et calculons le rendement et le risque correspondants.
+Avant d'utiliser un algorithme génétique, explorons l'espace des portefeuilles possibles par **echantillonnage aleatoire** (méthode Monte Carlo). Pour chaque echantillon, nous generons un vecteur de poids aleatoire (distribution de Dirichlet pour obtenir des poids positifs qui somment a 1) et calculons le rendement et le risque correspondants.
 
 Cette approche permet :
 - De visualiser la **forme** de l'espace des portefeuilles realisables
 - D'identifier approximativement la frontiere efficiente
-- De servir de **baseline** pour evaluer les methodes d'optimisation",,,,,,,,358eac961840f1d2,,,,,,,
+- De servir de **baseline** pour evaluer les méthodes d'optimisation",,,,,,,,8fa12575b21a28be,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,i54pmh7x1c,code,fr,6e5d91f094584487,"# --- Echantillonnage aleatoire de 10 000 portefeuilles ---
 
 n_samples = 10_000
@@ -21607,7 +21607,7 @@ ax.yaxis.set_major_formatter(plt.FuncFormatter(lambda x, _: f'{x:.0%}'))
 plt.tight_layout()
 plt.show()
 plt.close()",,,,,,,,04076da0f953b57c,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,vxktn58wygf,markdown,fr,c3292476ebad01da,"### Interpretation : Nuage de portefeuilles aleatoires
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,vxktn58wygf,markdown,fr,6f0766fb9a454541,"### Interpretation : Nuage de portefeuilles aleatoires
 
 **Sortie obtenue** : Le nuage forme une ""balle"" dont le bord superieur gauche dessine la frontiere efficiente approximative. Les couleurs (ratio de Sharpe) montrent que les meilleurs portefeuilles se situent sur cette frontiere.
 
@@ -21616,17 +21616,17 @@ MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,vxktn58wygf,
 | Forme du nuage | Hyperbole : les portefeuilles realisables forment un ensemble convexe |
 | Frontiere superieure | Approximation de la frontiere efficiente de Markowitz |
 | Meilleur Sharpe | Le portefeuille optimal est sur le bord superieur gauche |
-| Zone inferieure | Portefeuilles domines (meme risque, rendement moindre) |
+| Zone inferieure | Portefeuilles domines (même risque, rendement moindre) |
 
 **Limites de l'echantillonnage** :
 1. La couverture du bord (frontiere efficiente) est **sporadique** : peu de points exactement sur la frontiere
 2. Le meilleur portefeuille trouve n'est qu'**approximatif** : il depend de la taille de l'echantillon
-3. Aucune garantie d'optimalite, contrairement a un algorithme d'optimisation",,,,,,,,c3292476ebad01da,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,2bns6whemxy,markdown,fr,c5199edaa796c8f7,"## 4. Approche 2 : Optimisation par PyGAD
+3. Aucune garantie d'optimalite, contrairement a un algorithme d'optimisation",,,,,,,,6f0766fb9a454541,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,2bns6whemxy,markdown,fr,7783c8772340268d,"## 4. Approche 2 : Optimisation par PyGAD
 
 ### Encodage et configuration
 
-Pour appliquer un algorithme genetique au probleme du portefeuille, il faut definir :
+Pour appliquer un algorithme génétique au problème du portefeuille, il faut définir :
 
 | Composant GA | Choix pour le portefeuille |
 |--------------|---------------------------|
@@ -21634,11 +21634,11 @@ Pour appliquer un algorithme genetique au probleme du portefeuille, il faut defi
 | **Espace des genes** | $[0, 1]$ pour chaque gene |
 | **Normalisation** | Les poids sont normalises a chaque evaluation pour garantir $\sum w_i = 1$ |
 | **Fitness** | Ratio de Sharpe $S = \frac{R_p - R_f}{\sigma_p}$ (a maximiser) |
-| **Selection** | Steady-state selection (SSS) |
+| **Sélection** | Steady-state sélection (SSS) |
 | **Crossover** | Croisement uniforme |
 | **Mutation** | Mutation aleatoire, 20% des genes |
 
-La normalisation dans la fonction fitness (et non dans le chromosome lui-meme) permet a PyGAD de manipuler les genes librement tout en garantissant des portefeuilles valides a chaque evaluation.",,,,,,,,c5199edaa796c8f7,,,,,,,
+La normalisation dans la fonction fitness (et non dans le chromosome lui-même) permet a PyGAD de manipuler les genes librement tout en garantissant des portefeuilles valides a chaque evaluation.",,,,,,,,7783c8772340268d,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,uod70xn4ji,code,fr,f449136a47c62a76,"# --- Configuration de l'algorithme genetique ---
 
 if not HAS_PYGAD:
@@ -21692,9 +21692,9 @@ print(""Configuration PyGAD :"")
 for key in [""num_generations"", ""sol_per_pop"", ""num_genes"",
             ""parent_selection_type"", ""crossover_type"", ""mutation_percent_genes""]:
     print(f""  {key}: {ga_config[key]}"")",,,,,,,,f449136a47c62a76,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,17ml9o6bmwa,markdown,fr,e663cff62ae5665f,"### Execution de l'algorithme genetique
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,17ml9o6bmwa,markdown,fr,a90cbbaf3fc07174,"### Exécution de l'algorithme génétique
 
-Lancons l'optimisation et suivons la convergence du meilleur ratio de Sharpe au fil des generations.",,,,,,,,e663cff62ae5665f,,,,,,,
+Lancons l'optimisation et suivons la convergence du meilleur ratio de Sharpe au fil des generations.",,,,,,,,a90cbbaf3fc07174,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,klt1htkow8p,code,fr,f9a3e20038d1971d,"# --- Execution du GA ---
 
 # Reinitialiser l'historique
@@ -21722,9 +21722,9 @@ print(f""  Sharpe    : {best_ga_sharpe:.4f}"")
 print(f""\n  Allocation :"")
 for i, name in enumerate(asset_names):
     print(f""    {name:<15} : {best_ga_weights[i]:>6.1%}"")",,,,,,,,f9a3e20038d1971d,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,o0and0yvl7,markdown,fr,7e514ec9122185c6,"### Courbe de convergence
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,o0and0yvl7,markdown,fr,3a19e61f9c291b1a,"### Courbe de convergence
 
-La convergence de l'algorithme genetique est un indicateur de la qualite de la configuration. Un bon GA converge rapidement vers un plateau stable.",,,,,,,,7e514ec9122185c6,,,,,,,
+La convergence de l'algorithme génétique est un indicateur de la qualite de la configuration. Un bon GA converge rapidement vers un plateau stable.",,,,,,,,3a19e61f9c291b1a,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,afzb52z7sa5,code,fr,d72818cd5866e376,"# --- Courbe de convergence ---
 
 fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(14, 5))
@@ -21768,34 +21768,34 @@ ax2.yaxis.set_major_formatter(plt.FuncFormatter(lambda x, _: f'{x:.0%}'))
 plt.tight_layout()
 plt.show()
 plt.close()",,,,,,,,d72818cd5866e376,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,te3g6dhebyr,markdown,fr,ad7f1c3281ed0471,"### Interpretation : Resultats de l'algorithme genetique
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,te3g6dhebyr,markdown,fr,68ae34ae87e01233,"### Interpretation : Résultats de l'algorithme génétique
 
 **Sortie obtenue** : Le GA converge typiquement en 50-80 generations vers un ratio de Sharpe superieur a celui obtenu par echantillonnage aleatoire.
 
 | Aspect | Aleatoire | GA | Amelioration |
 |--------|-----------|-----|-------------|
-| Methode | 10 000 echantillons | 150 generations x 50 individus | GA evalue ~7 500 solutions |
-| Sharpe | Approximatif | Optimise | GA generalement superieur |
-| Allocation | Non guidee | Guidee par selection | GA concentre les poids |
+| Méthode | 10 000 echantillons | 150 generations x 50 individus | GA evalue ~7 500 solutions |
+| Sharpe | Approximatif | Optimise | GA généralement superieur |
+| Allocation | Non guidee | Guidee par sélection | GA concentre les poids |
 
 **Points cles** :
 1. La courbe de convergence montre une amelioration rapide en debut d'evolution, puis un plateau (exploitation vs exploration)
 2. Le GA depasse rapidement le meilleur aleatoire (ligne rouge pointillee)
 3. La fitness moyenne augmente aussi, signe que la population entiere s'ameliore
 
-> **Note technique** : Le GA evalue environ 7 500 portefeuilles (150 gen x 50 ind), soit moins que les 10 000 echantillons aleatoires, mais de maniere **guidee** par la selection naturelle.",,,,,,,,ad7f1c3281ed0471,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,8tfaswyup5w,markdown,fr,9f0da61a8b5c9333,"## 5. Frontiere efficiente par exploration parametrique
+> **Note technique** : Le GA evalue environ 7 500 portefeuilles (150 gen x 50 ind), soit moins que les 10 000 echantillons aleatoires, mais de maniere **guidee** par la sélection naturelle.",,,,,,,,68ae34ae87e01233,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,8tfaswyup5w,markdown,fr,988fd2a38fa0c6a4,"## 5. Frontiere efficiente par exploration parametrique
 
 ### Principe
 
-La section precedente optimisait un seul objectif (le ratio de Sharpe). Pour reconstruire la **frontiere efficiente** complete, nous utilisons une approche d'**exploration parametrique** : nous faisons varier le parametre d'aversion au risque $\alpha$ dans la fonction objectif :
+La section précédente optimisait un seul objectif (le ratio de Sharpe). Pour reconstruire la **frontiere efficiente** complete, nous utilisons une approche d'**exploration parametrique** : nous faisons varier le paramètre d'aversion au risque $\alpha$ dans la fonction objectif :
 
 $$f(\mathbf{w}) = R_p - \alpha \cdot \sigma_p$$
 
 - Quand $\alpha$ est **petit** (ex. 0.1), l'algorithme favorise le rendement (portefeuilles agressifs)
 - Quand $\alpha$ est **grand** (ex. 5.0), l'algorithme favorise la reduction du risque (portefeuilles defensifs)
 
-En executant le GA pour differentes valeurs de $\alpha$, nous obtenons un ensemble de portefeuilles Pareto-optimaux qui tracent la frontiere efficiente.",,,,,,,,9f0da61a8b5c9333,,,,,,,
+En executant le GA pour différentes valeurs de $\alpha$, nous obtenons un ensemble de portefeuilles Pareto-optimaux qui tracent la frontiere efficiente.",,,,,,,,988fd2a38fa0c6a4,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,qdaetxca8zb,code,fr,04481620565289dc,"# --- Construction de la frontiere efficiente ---
 
 # Differentes valeurs d'aversion au risque
@@ -21922,9 +21922,9 @@ ax.yaxis.set_major_formatter(plt.FuncFormatter(lambda x, _: f'{x:.0%}'))
 plt.tight_layout()
 plt.show()
 plt.close()",,,,,,,,e06ea291fea161b7,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,jezjfrdvgnc,markdown,fr,010412775b486be1,"### Interpretation : Frontiere efficiente
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,jezjfrdvgnc,markdown,fr,9d282cc6f0da22e6,"### Interpretation : Frontiere efficiente
 
-**Sortie obtenue** : La courbe rouge trace la frontiere efficiente reconstruite par 10 executions du GA avec differentes valeurs de $\alpha$. Les points de la frontiere sont colores par leur ratio de Sharpe.
+**Sortie obtenue** : La courbe rouge trace la frontiere efficiente reconstruite par 10 exécutions du GA avec différentes valeurs de $\alpha$. Les points de la frontiere sont colores par leur ratio de Sharpe.
 
 | Valeur de alpha | Type de portefeuille | Position sur la frontiere |
 |-----------------|---------------------|---------------------------|
@@ -21936,7 +21936,7 @@ MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,jezjfrdvgnc,
 1. La frontiere efficiente est **concave** vers le haut : les gains marginaux en rendement coutent de plus en plus de risque
 2. Le portefeuille au Sharpe maximal (losange vert) se situe au point de tangence avec la droite issue du taux sans risque
 3. Aucun portefeuille du nuage aleatoire ne depasse la frontiere : elle represente la **limite** des portefeuilles realisables
-4. Les portefeuilles sous la frontiere sont **domines** : il existe un portefeuille avec le meme risque mais un meilleur rendement",,,,,,,,010412775b486be1,,,,,,,
+4. Les portefeuilles sous la frontiere sont **domines** : il existe un portefeuille avec le même risque mais un meilleur rendement",,,,,,,,9d282cc6f0da22e6,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,hehgwq8zkhi,markdown,fr,c43db596b1782709,"### Composition des portefeuilles de la frontiere
 
 Visualisons comment l'allocation evolue le long de la frontiere efficiente : des portefeuilles defensifs (alpha eleve) aux portefeuilles agressifs (alpha faible).",,,,,,,,c43db596b1782709,,,,,,,
@@ -21973,7 +21973,7 @@ ax.grid(axis='y', alpha=0.3)
 plt.tight_layout()
 plt.show()
 plt.close()",,,,,,,,ab8693df487cb781,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,zxc68b0e9zm,markdown,fr,f7f72a2b4ec808a7,"### Interpretation : Evolution de la composition
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,zxc68b0e9zm,markdown,fr,fd79fb4f52182b62,"### Interpretation : Evolution de la composition
 
 **Sortie obtenue** : Les barres empilees montrent la transition de portefeuilles agressifs (alpha faible, domines par les actifs risques) vers des portefeuilles defensifs (alpha eleve, domines par les obligations).
 
@@ -21981,12 +21981,12 @@ MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,zxc68b0e9zm,
 1. Pour alpha faible, le GA concentre l'allocation dans les actifs a haut rendement (Emergents, Actions US)
 2. Pour alpha eleve, le GA privilegie les Obligations et l'Immobilier (faible variance)
 3. La diversification est maximale pour les valeurs intermediaires de alpha : c'est la zone ou le ratio de Sharpe est le plus eleve
-4. Ce comportement est conforme a la theorie de Markowitz : la diversification reduit le risque sans sacrifier proportionnellement le rendement",,,,,,,,f7f72a2b4ec808a7,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,azfbezgf4u4,markdown,fr,a67ccf399e2a730e,"## 6. Analyse comparative
+4. Ce comportement est conforme a la théorie de Markowitz : la diversification reduit le risque sans sacrifier proportionnellement le rendement",,,,,,,,fd79fb4f52182b62,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,azfbezgf4u4,markdown,fr,9f394cdd179178e9,"## 6. Analyse comparative
 
 ### Comparaison des approches
 
-Comparons les trois strategies explorees dans ce notebook : echantillonnage aleatoire, GA mono-objectif (Sharpe max), et GA multi-objectif (frontiere efficiente).",,,,,,,,a67ccf399e2a730e,,,,,,,
+Comparons les trois stratégies explorees dans ce notebook : echantillonnage aleatoire, GA mono-objectif (Sharpe max), et GA multi-objectif (frontiere efficiente).",,,,,,,,9f394cdd179178e9,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,be5yv581m6e,code,fr,4a65c8c5cd884a07,"# --- Comparaison des approches ---
 
 # Meilleur portefeuille de la frontiere (par Sharpe)
@@ -22043,39 +22043,39 @@ print(f""{'GA Sharpe max':<20} {best_ga_return:>8.2%}    ""
 print(f""{'Frontiere (best S)':<20} {best_frontier['return']:>8.2%}    ""
       f""{best_frontier['risk']:>8.2%}    {best_frontier['sharpe']:>8.4f}"")
 print(""="" * 60)",,,,,,,,4a65c8c5cd884a07,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,o7i92z8c2h,markdown,fr,efecbad271bf0767,"### Interpretation : Analyse comparative
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,o7i92z8c2h,markdown,fr,e916ef2ebf057fb3,"### Interpretation : Analyse comparative
 
-| Methode | Forces | Faiblesses |
+| Méthode | Forces | Faiblesses |
 |---------|--------|------------|
 | **Echantillonnage** | Simple, rapide, donne une vue globale | Pas de garantie d'optimalite, couverture sporadique |
 | **GA Sharpe max** | Trouve un portefeuille de haute qualite, guide par la fitness | Un seul point optimal, pas de vue d'ensemble |
-| **GA Frontiere** | Reconstruit toute la frontiere efficiente | Plus couteux (10 executions), qualite depend de la discretisation d'alpha |
+| **GA Frontiere** | Reconstruit toute la frontiere efficiente | Plus couteux (10 exécutions), qualite depend de la discretisation d'alpha |
 
 **Considerations pratiques** en finance reelle :
 
 | Facteur | Impact |
 |---------|--------|
-| Couts de transaction | Penalisent les allocations tres fragmentees |
+| Couts de transaction | Penalisent les allocations très fragmentees |
 | Liquidite | Certains actifs ne peuvent etre achetes qu'en lots |
 | Contraintes reglementaires | Poids minimum/maximum par secteur |
-| Incertitude des parametres | Les rendements et covariances estimes sont bruites |
+| Incertitude des paramètres | Les rendements et covariances estimes sont bruites |
 
-> **Lien avec la serie Search** : Ce probleme illustre l'application des GA (Search-5) a un domaine concret. Les memes principes (chromosome, fitness, selection, crossover, mutation) s'appliquent a des problemes tres differents (detection de bords dans App-9, portefeuille ici). La version C# avec GeneticSharp est disponible dans [App-10b](App-10b-Portfolio-CSharp.ipynb).",,,,,,,,efecbad271bf0767,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,a733b689,markdown,fr,402b42edd6ec06cf,"## 7. Le solveur de reference : optimisation convexe (cvxpy)
+> **Lien avec la serie Search** : Ce problème illustre l'application des GA (Search-5) a un domaine concret. Les mêmes principes (chromosome, fitness, sélection, crossover, mutation) s'appliquent a des problemes très différents (detection de bords dans App-9, portefeuille ici). La version C# avec GeneticSharp est disponible dans [App-10b](App-10b-Portfolio-CSharp.ipynb).",,,,,,,,e916ef2ebf057fb3,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,a733b689,markdown,fr,03a85f7e235bd5f2,"## 7. Le solveur de reference : optimisation convexe (cvxpy)
 
-L'introduction de ce notebook affirmait que *""les methodes classiques (programmation
-quadratique) resolvent ce probleme efficacement dans le cas standard""* — sans jamais le
+L'introduction de ce notebook affirmait que *""les méthodes classiques (programmation
+quadratique) resolvent ce problème efficacement dans le cas standard""* — sans jamais le
 montrer. Comblons ce manque avec le **vrai solveur de reference**.
 
-Le probleme de Markowitz long-only standard est un **programme quadratique convexe** :
+Le problème de Markowitz long-only standard est un **programme quadratique convexe** :
 
 $$\min_{\mathbf{w}} \; \mathbf{w}^T \Sigma \mathbf{w} \quad \text{s.c.} \quad \boldsymbol{\mu}^T\mathbf{w} \ge r,\; \mathbf{1}^T\mathbf{w}=1,\; \mathbf{w}\ge 0$$
 
 Comme l'objectif (variance) est convexe et les contraintes lineaires, **tout** optimum local
 est l'optimum **global**. Un solveur convexe comme [**cvxpy**](https://www.cvxpy.org/) le
 resout **exactement**, en **une seule resolution** (quelques millisecondes), et **certifie**
-l'optimalite — la ou l'algorithme genetique explore ~7 500 solutions de facon stochastique
-**sans aucune garantie**. On resout ici **exactement la meme instance** pour comparer.",,,,,,,,402b42edd6ec06cf,,,,,,,
+l'optimalite — la ou l'algorithme génétique explore ~7 500 solutions de facon stochastique
+**sans aucune garantie**. On resout ici **exactement la même instance** pour comparer.",,,,,,,,03a85f7e235bd5f2,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,fa266a7e,code,fr,0361a8367f30a8f6,"import cvxpy as cp
 
 # Portefeuille tangent EXACT (Sharpe maximal long-only) par optimisation convexe.
@@ -22156,27 +22156,27 @@ ax.yaxis.set_major_formatter(plt.FuncFormatter(lambda x, _: f'{x:.0%}'))
 plt.tight_layout()
 plt.show()
 plt.close()",,,,,,,,e20b4ae85436fe9c,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,0bc6e793,markdown,fr,f7d576e51a5448b8,"### Interpretation : quand le solveur convexe est le bon outil
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,0bc6e793,markdown,fr,de43156efbee1750,"### Interpretation : quand le solveur convexe est le bon outil
 
 **Sortie obtenue** : la tangence convexe atteint un Sharpe **identique** a celui du GA
 (1.4839), et la frontiere exacte (courbe violette continue) coincide avec les points du GA.
 
 Ce n'est **pas** un echec du GA — c'est une lecon sur le **choix de l'outil** :
 
-| Critere | Algorithme genetique | Solveur convexe (cvxpy) |
+| Critere | Algorithme génétique | Solveur convexe (cvxpy) |
 |---------|----------------------|--------------------------|
-| Resultat | Sharpe 1.4839 (apres ~7 500 evaluations) | Sharpe 1.4839 en **une** resolution |
+| Résultat | Sharpe 1.4839 (après ~7 500 evaluations) | Sharpe 1.4839 en **une** resolution |
 | Garantie | Aucune (heuristique stochastique) | **Optimum global certifie** |
-| Determinisme | Depend de la graine | Deterministe |
+| Determinisme | Depend de la graine | Déterministe |
 | Temps | Centaines de ms x10 pour la frontiere | Quelques ms |
 
-Le fait que les deux methodes **convergent vers la meme valeur** est precisement la preuve que
-le probleme est **convexe** : il a un unique optimum, que le solveur convexe atteint
-directement et certifie. **Sur un probleme convexe, l'algorithme genetique est une
+Le fait que les deux méthodes **convergent vers la même valeur** est précisément la preuve que
+le problème est **convexe** : il a un unique optimum, que le solveur convexe atteint
+directement et certifie. **Sur un problème convexe, l'algorithme génétique est une
 sur-ingenierie** — il refait par exploration ce qu'une resolution exacte donne instantanement.
 C'est le cas degenere a eviter (cf SOTA #3801) : demontrer un moteur d'exploration sur un
-probleme ou un solveur exact suffit.",,,,,,,,f7d576e51a5448b8,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,57bfd12d,markdown,fr,1e45e1c7e4d879cd,"### Quand le GA reprend l'avantage : la contrainte de cardinalite (non-convexe)
+problème ou un solveur exact suffit.",,,,,,,,de43156efbee1750,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,57bfd12d,markdown,fr,241ebc0e1d619f4d,"### Quand le GA reprend l'avantage : la contrainte de cardinalite (non-convexe)
 
 Le tableau d'introduction promettait au GA un avantage pour les *""contraintes non-lineaires""*
 et l'*""espace discret""*. Verifions-le sur un cas **reellement non-convexe** : la **contrainte
@@ -22187,8 +22187,8 @@ La contrainte $\lVert\mathbf{w}\rVert_0 \le K$ (au plus $K$ poids non nuls) n'es
 convexe** : un solveur convexe standard ne peut pas l'exprimer directement. L'optimum exact
 demande d'**enumerer** les $\binom{n}{K}$ sous-ensembles et de resoudre un QP convexe sur
 chacun — faisable ici ($\binom{5}{2}=10$), mais **explosif** a grande echelle
-($\binom{50}{10}\approx 10^{10}$). C'est exactement le terrain ou une **metaheuristique**
-devient le bon compromis.",,,,,,,,1e45e1c7e4d879cd,,,,,,,
+($\binom{50}{10}\approx 10^{10}$). C'est exactement le terrain ou une **métaheuristique**
+devient le bon compromis.",,,,,,,,241ebc0e1d619f4d,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,f74c91ac,code,fr,ec3a243341a0ad6a,"from itertools import combinations
 
 K = 2  # au plus 2 actifs
@@ -22259,31 +22259,31 @@ print(f""\n  Le GA retrouve l'optimum exact ? ""
 from math import comb
 print(f""  Cout d'enumeration a n=50, K=10 : C(50,10) = {comb(50, 10):,} sous-ensembles ""
       f""(intractable) -- le GA, lui, passe a l'echelle."")",,,,,,,,ec3a243341a0ad6a,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,a17df57a,markdown,fr,a31e7e2bb973d765,"### Interpretation : la metaheuristique a sa juste place
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,a17df57a,markdown,fr,31b81ebd95754b46,"### Interpretation : la métaheuristique a sa juste place
 
 **Sortie obtenue** : sous contrainte de cardinalite $K=2$, l'optimum exact (par enumeration +
 QP convexe) retient **Actions US + Emergents** (Sharpe 1.3060) ; le GA retrouve **exactement**
-le meme couple et le meme Sharpe.
+le même couple et le même Sharpe.
 
-La lecon est la **regle de decision** entre les deux familles d'outils :
+La lecon est la **règle de decision** entre les deux familles d'outils :
 
-| Probleme | Outil approprie | Pourquoi |
+| Problème | Outil approprie | Pourquoi |
 |----------|-----------------|----------|
 | Markowitz long-only (convexe) | **Solveur convexe (cvxpy)** | Optimum global exact, certifie, instantane |
-| + contrainte de cardinalite (non-convexe) | **Metaheuristique (GA)** | Enumeration exacte $\binom{n}{K}$ explosive ; le GA passe a l'echelle |
-| + couts de transaction, lots, secteurs | **Metaheuristique / MIQP** | Contraintes combinatoires / non-lineaires |
+| + contrainte de cardinalite (non-convexe) | **Métaheuristique (GA)** | Enumeration exacte $\binom{n}{K}$ explosive ; le GA passe a l'echelle |
+| + couts de transaction, lots, secteurs | **Métaheuristique / MIQP** | Contraintes combinatoires / non-lineaires |
 
 Le GA n'est pas ""meilleur"" ou ""moins bon"" dans l'absolu : il est l'outil **adapte aux
 problemes que le solveur convexe ne peut pas exprimer**. Sur le cas convexe standard, c'est le
 solveur convexe qui doit etre prefere — c'est ce que veut dire utiliser le **bon outil SOTA**
-pour chaque structure de probleme.",,,,,,,,a31e7e2bb973d765,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,l7i6h5499z7,markdown,fr,f38a9b9bb36947d5,"## 8. Exercices
+pour chaque structure de problème.",,,,,,,,31b81ebd95754b46,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,l7i6h5499z7,markdown,fr,b3686f8cb20c186a,"## 8. Exercices
 
 ### Exercice 1 : Contrainte de concentration maximale
 
 Ajoutez une contrainte empechant qu'un seul actif represente plus de 40% du portefeuille. Modifiez la fonction de normalisation et la fitness pour penaliser les portefeuilles trop concentres.
 
-**Indice** : Apres normalisation, verifiez que `max(weights) <= 0.4`. Si ce n'est pas le cas, redistribuez l'exces proportionnellement aux autres actifs.",,,,,,,,f38a9b9bb36947d5,,,,,,,
+**Indice** : Après normalisation, verifiez que `max(weights) <= 0.4`. Si ce n'est pas le cas, redistribuez l'exces proportionnellement aux autres actifs.",,,,,,,,b3686f8cb20c186a,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,m398503h83n,code,fr,23c5fb828953a36f,"# --- Exercice 1 : Contrainte de concentration maximale ---
 
 MAX_WEIGHT = 0.40
@@ -22369,13 +22369,13 @@ def fitness_10(ga_instance, solution, solution_idx):
 # TODO: Executer le GA pour 5 et 10 actifs, tracer les courbes de convergence
 # Observer l'impact de la dimensionalite sur la vitesse de convergence
 ",,,,,,,,88e43f0d13c1f2d6,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,fxccdq2nkwg,markdown,fr,84758efd317c322b,"## Conclusion
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,fxccdq2nkwg,markdown,fr,cf3675d98798cc1f,"## Conclusion
 
 ### Resume
 
 | Concept | Ce que nous avons appris |
 |---------|--------------------------|
-| **Modele de Markowitz** | Un portefeuille se decrit par un vecteur de poids $\mathbf{w}$, avec rendement $R_p = \mathbf{w}^T\boldsymbol{\mu}$ et risque $\sigma_p = \sqrt{\mathbf{w}^T\Sigma\mathbf{w}}$ |
+| **Modèle de Markowitz** | Un portefeuille se decrit par un vecteur de poids $\mathbf{w}$, avec rendement $R_p = \mathbf{w}^T\boldsymbol{\mu}$ et risque $\sigma_p = \sqrt{\mathbf{w}^T\Sigma\mathbf{w}}$ |
 | **Ratio de Sharpe** | Mesure le rendement ajuste du risque : $S = (R_p - R_f) / \sigma_p$ |
 | **Echantillonnage Monte Carlo** | Permet d'explorer l'espace mais sans garantie d'optimalite |
 | **GA mono-objectif** | Maximise une fitness unique (Sharpe), convergence rapide et guidee |
@@ -22386,26 +22386,26 @@ MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,fxccdq2nkwg,
 
 | Notebook | Concept relie |
 |----------|---------------|
-| Search-5 (GA) | Operateurs genetiques, encodage, fitness |
+| Search-5 (GA) | Opérateurs génétiques, encodage, fitness |
 | App-9 (EdgeDetection) | Autre application des GA (traitement d'images) |
-| App-10b (C# version) | Meme probleme avec GeneticSharp |
+| App-10b (C# version) | Même problème avec GeneticSharp |
 
 ### Pour aller plus loin
 
 - **NSGA-II** : Algorithme multi-objectif (DEAP) qui produit directement le front de Pareto sans parametrer $\alpha$
 - **CVaR** : Mesure de risque alternative (Conditional Value-at-Risk) plus sensible aux queues de distribution
-- **Donnees reelles** : Utiliser des rendements historiques d'actions reelles (yfinance, pandas-datareader)
+- **Données reelles** : Utiliser des rendements historiques d'actions reelles (yfinance, pandas-datareader)
 - **Contraintes realistes** : Couts de transaction, lots minimaux, limites sectorielles
 
 ### References
 
-- Markowitz, H. (1952). ""Portfolio Selection"". *The Journal of Finance*, 7(1), 77-91.
+- Markowitz, H. (1952). ""Portfolio Sélection"". *The Journal of Finance*, 7(1), 77-91.
 - Deb, K. et al. (2002). ""A fast and elitist multiobjective genetic algorithm: NSGA-II"". *IEEE Transactions on Evolutionary Computation*.
-- PyGAD documentation : https://pygad.readthedocs.io",,,,,,,,84758efd317c322b,,,,,,,
+- PyGAD documentation : https://pygad.readthedocs.io",,,,,,,,cf3675d98798cc1f,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb,bp8hvfhh1zv,markdown,fr,d7e46d0871e56700,"---
 
 **Navigation** : [<< App-9 EdgeDetection](../Hybrid/App-9-EdgeDetection.ipynb) | [Index](../README.md) | [App-11 Picross >>](../CSP/App-11-Picross.ipynb)",,,,,,,,d7e46d0871e56700,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10b-Portfolio-CSharp.ipynb,414a6825,markdown,fr,f8ef6cbcb770edc5,"# App-10b : Optimisation de portefeuille par algorithme genetique (C#)
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10b-Portfolio-CSharp.ipynb,414a6825,markdown,fr,014ee314da53eafe,"# App-10b : Optimisation de portefeuille par algorithme génétique (C#)
 
 **Navigation** : [Index](../../README.md) | [<< App-10 Python](../Hybrid/App-10-Portfolio.ipynb)
 
@@ -22413,18 +22413,18 @@ MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10b-Portfolio-CSharp.ipynb,414a
 
 A la fin de ce notebook, vous saurez :
 1. **Modeliser** un portefeuille financier (rendement, risque, matrice de covariance)
-2. **Appliquer** un algorithme genetique (GeneticSharp) a l'optimisation de portefeuille
-3. **Implémenter** une fonction fitness avec aversion au risque (parametre alpha)
-4. **Configurer** les operateurs genetiques (selection, crossover, mutation) pour la finance
+2. **Appliquer** un algorithme génétique (GeneticSharp) a l'optimisation de portefeuille
+3. **Implémenter** une fonction fitness avec aversion au risque (paramètre alpha)
+4. **Configurer** les opérateurs génétiques (sélection, crossover, mutation) pour la finance
 
 ### Prerequis
 - .NET 9.0 Interactive (C#)
-- Search-5 : Algorithmes genetiques (concepts de fitness, selection, crossover, mutation)
+- Search-5 : Algorithmes génétiques (concepts de fitness, sélection, crossover, mutation)
 - Notions de base en finance (rendement, risque, diversification)
 
 ### Duree estimee : 30 minutes
 
-> **Side track** : Voir [App-10 Python](../Hybrid/App-10-Portfolio.ipynb) pour la version PyGAD de ce probleme avec frontiere efficiente de Markowitz.",,,,,,,,f8ef6cbcb770edc5,,,,,,,
+> **Side track** : Voir [App-10 Python](../Hybrid/App-10-Portfolio.ipynb) pour la version PyGAD de ce problème avec frontiere efficiente de Markowitz.",,,,,,,,014ee314da53eafe,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10b-Portfolio-CSharp.ipynb,253c0a9e,markdown,fr,e2b0c2cf6bffb9a3,"**Navigation** : [Index](../../../README.md) | [<< App-10 Python](App-10-Portfolio.ipynb)
 
 ## Installation de GeneticSharp
@@ -22687,9 +22687,9 @@ double bestRisk = portfolio.CalculateRisk(bestWeights);
 Console.WriteLine($""\nRendement attendu : {bestReturn:P2}"");
 Console.WriteLine($""Risque (écart-type): {bestRisk:P2}"");
 Console.WriteLine($""Fitness (return - alpha*risk): {bestReturn - bestRisk:0.0000}"");",,,,,,,,baa115fbeacd1964,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10b-Portfolio-CSharp.ipynb,fa80dcf6,markdown,fr,997efe9d9d2b0fcb,"### Interpretation : Resultats de l'algorithme genetique
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10b-Portfolio-CSharp.ipynb,fa80dcf6,markdown,fr,0009052fc35271cb,"### Interpretation : Résultats de l'algorithme génétique
 
-**Sortie obtenue** : L'algorithme genetique a converge vers une allocation de portefeuille avec un rendement attendu de 19,56% et un risque de 12,11% (fitness 0,0745).
+**Sortie obtenue** : L'algorithme génétique a converge vers une allocation de portefeuille avec un rendement attendu de 19,56% et un risque de 12,11% (fitness 0,0745).
 
 | Aspect | Valeur | Signification |
 |--------|--------|---------------|
@@ -22704,20 +22704,20 @@ MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10b-Portfolio-CSharp.ipynb,fa80
 
 **Points cles** :
 1. L'algorithme a naturellement favorise les actifs a haut rendement (Asset3 et Asset4) tout en controlant le risque via la matrice de covariance
-2. La penalisation du risque (parametre alpha=1.0) evite une concentration excessive sur l'actif le plus rentable
-3. La fitness finale de 0,0745 represente le compromis optimal entre rendement et risque pour ce parametre alpha
+2. La penalisation du risque (paramètre alpha=1.0) evite une concentration excessive sur l'actif le plus rentable
+3. La fitness finale de 0,0745 represente le compromis optimal entre rendement et risque pour ce paramètre alpha
 
-> **Note technique** : La matrice de covariance joue un role crucial dans la fonction de risque. Les correlations positives entre actifs signifient que la diversification reduit le risque mais pas autant que si les actifs etaient parfaitement decores.",,,,,,,,997efe9d9d2b0fcb,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10b-Portfolio-CSharp.ipynb,9da5d392,markdown,fr,edfb4032c5365bbc,"## Exercices
+> **Note technique** : La matrice de covariance joue un rôle crucial dans la fonction de risque. Les correlations positives entre actifs signifient que la diversification reduit le risque mais pas autant que si les actifs etaient parfaitement decores.",,,,,,,,0009052fc35271cb,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10b-Portfolio-CSharp.ipynb,9da5d392,markdown,fr,c8a4ca8759d16913,"## Exercices
 
 ### Exercice 1 : Contraintes de Poids Minimaux et Maximaux
 
 En pratique, un gestionnaire de portefeuille impose souvent des limites sur la proportion de chaque actif. Modifiez la classe `PortfolioChromosome` pour respecter ces contraintes.
 
 **Indices** :
-- Ajoutez des dictionnaires `min_weights` et `max_weights` en parametres
-- Apres normalisation, verifiez que chaque poids respecte les contraintes
-- Si une contrainte est violee, ajustez les poids de maniere proportionnelle",,,,,,,,edfb4032c5365bbc,,,,,,,
+- Ajoutez des dictionnaires `min_weights` et `max_weights` en paramètres
+- Après normalisation, verifiez que chaque poids respecte les contraintes
+- Si une contrainte est violee, ajustez les poids de maniere proportionnelle",,,,,,,,c8a4ca8759d16913,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10b-Portfolio-CSharp.ipynb,8affb260,code,fr,55291c803bdeb3f8,"// TODO: Implementer une version contrainte de PortfolioChromosome
 public class ConstrainedPortfolioChromosome : ChromosomeBase
 {
@@ -22758,14 +22758,14 @@ public class ConstrainedPortfolioChromosome : ChromosomeBase
         // TODO etudiant : ajuster les poids pour respecter min_weights et max_weights
     }
 }",,,,,,,,55291c803bdeb3f8,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10b-Portfolio-CSharp.ipynb,f12422db,markdown,fr,fa3e23f1ea94d60b,"### Exercice 2 : Selection par Tournoi
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10b-Portfolio-CSharp.ipynb,f12422db,markdown,fr,5b1c233ec07be83f,"### Exercice 2 : Sélection par Tournoi
 
-Implementez une selection par tournoi pour comparer ses performances avec la selection Elite utilisee dans l'exemple.
+Implementez une sélection par tournoi pour comparer ses performances avec la sélection Elite utilisee dans l'exemple.
 
 **Indices** :
 - Dans un tournoi, k individus sont selectionnes aleatoirement
 - Le meilleur des k est choisi comme parent
-- Comparez la vitesse de convergence et la qualite finale avec EliteSelection",,,,,,,,fa3e23f1ea94d60b,,,,,,,
+- Comparez la vitesse de convergence et la qualite finale avec EliteSelection",,,,,,,,5b1c233ec07be83f,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10b-Portfolio-CSharp.ipynb,be668d22,code,fr,d35aceafb3a12b0a,"// TODO: Comparer EliteSelection et TournamentSelection
 // Indice: GeneticSharp fournit TournamentSelection, il suffit de configurer l'algorithme
 
@@ -22783,16 +22783,16 @@ public void CompareSelectionMethods(Portfolio portfolio, List<string> assets, in
     // TODO: Afficher les resultats comparatifs
     // A completer
 }",,,,,,,,d35aceafb3a12b0a,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10b-Portfolio-CSharp.ipynb,6bd03040,markdown,fr,ab2d0ce69b25bedc,"### Exercice 3 : Frontiere Efficiente
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10b-Portfolio-CSharp.ipynb,6bd03040,markdown,fr,7ea8800fc5076cc1,"### Exercice 3 : Frontiere Efficiente
 
-Tracez la **frontiere efficiente** de Markowitz en faisant varier le parametre alpha systematiquement.
+Tracez la **frontiere efficiente** de Markowitz en faisant varier le paramètre alpha systematiquement.
 
 **Indices** :
 - Faites varier alpha de 0.1 a 3.0 par pas de 0.3
 - Pour chaque valeur, executez l'AG et collectez le rendement et le risque
 - Affichez les points (risque, rendement) pour former la frontiere
 
-**Questions** : Comment evolue le ratio rendement/risque quand alpha augmente ? Quel alpha offre le meilleur compromis ?",,,,,,,,ab2d0ce69b25bedc,,,,,,,
+**Questions** : Comment evolue le ratio rendement/risque quand alpha augmente ? Quel alpha offre le meilleur compromis ?",,,,,,,,7ea8800fc5076cc1,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10b-Portfolio-CSharp.ipynb,f6c71cac,code,fr,354fbe9bc947629f,"// --- Exercice 3 : Frontiere Efficiente ---
 
 // TODO 1: Definir les valeurs de alpha a tester
@@ -22820,33 +22820,33 @@ Pour aller encore plus loin, vous pourriez :
 - Logger l'évolution de la fitness dans le temps pour observer la convergence de l'algorithme.
 
 **Retour au sommaire** : [Index](../../README.md)",,,,,,,,28008286ef2ffa49,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,9fc95309,markdown,fr,74a981794f8eecdd,"# App-13 : Le Probleme du Voyageur de Commerce (TSP)
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,9fc95309,markdown,fr,ece061cf16954216,"# App-13 : Le Problème du Voyageur de Commerce (TSP)
 
 **Navigation** : [<< Portfolio](../Hybrid/App-10-Portfolio.ipynb) | [Index](../README.md) | [Foundations >>](../../Part1-Foundations/README.md)
 
 ## Objectifs d'apprentissage
 
 A la fin de ce notebook, vous saurez :
-1. **Formaliser** le TSP comme un probleme d'optimisation combinatoire
+1. **Formaliser** le TSP comme un problème d'optimisation combinatoire
 2. **Implementer** des heuristiques constructives (Plus Proche Voisin)
-3. **Appliquer** des metaheuristiques (Recuit Simule, AG, ACO)
+3. **Appliquer** des métaheuristiques (Recuit Simule, AG, ACO)
 4. **Comparer** les performances avec OR-Tools et l'amelioration 2-opt
 
 ### Prerequis
 - Python 3.10+ (numpy, matplotlib, scipy)
 - Search-4 : Recherche locale (Simulated Annealing)
-- Search-5 : Algorithmes genetiques
+- Search-5 : Algorithmes génétiques
 
 ### Duree estimee : 50 minutes
 
 > **Source** : Adapte du projet etudiant ECE 2026 -- Groupe 03 (MonteiroTour).
 >
-> **Voir aussi** : Le notebook [Search-11-Metaheuristics](../../Part1-Foundations/Search-11-Metaheuristics.ipynb) pour une etude approfondie des metaheuristiques.",,,,,,,,74a981794f8eecdd,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,77aa3dae,markdown,fr,feaa3714b81e59ce,"## 1. Introduction au TSP
+> **Voir aussi** : Le notebook [Search-11-Metaheuristics](../../Part1-Foundations/Search-11-Metaheuristics.ipynb) pour une étude approfondie des métaheuristiques.",,,,,,,,ece061cf16954216,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,77aa3dae,markdown,fr,f0321edec18d162f,"## 1. Introduction au TSP
 
 ### Definition
 
-Le **Probleme du Voyageur de Commerce** (Traveling Salesman Problem, TSP) est l'un des problemes d'optimisation les plus celebres en informatique.
+Le **Problème du Voyageur de Commerce** (Traveling Salesman Problem, TSP) est l'un des problemes d'optimisation les plus celebres en informatique.
 
 **Enonce** : Etant donne un ensemble de villes et les distances entre chaque paire de villes, trouver le plus court parcours qui visite chaque ville exactement une fois et revient au point de depart.
 
@@ -22876,7 +22876,7 @@ Le **Probleme du Voyageur de Commerce** (Traveling Salesman Problem, TSP) est l'
 - **Logistique** : Tournees de livraison, collecte de dechets
 - **Fabrication** : Peracage de circuits imprimes, decoupe laser
 - **Genomique** : Assemblage de sequences ADN
-- **Astronomie** : Planification d'observations telescopiques",,,,,,,,feaa3714b81e59ce,,,,,,,
+- **Astronomie** : Planification d'observations telescopiques",,,,,,,,f0321edec18d162f,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,ba1380b5,code,fr,b663018152537859,"# Imports
 import sys
 import time
@@ -22894,9 +22894,9 @@ from scipy.spatial.distance import pdist, squareform
 
 print(""Environnement pret pour le TSP."")
 print(f""Python: {sys.version}"")",,,,,,,,b663018152537859,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,2bf3aaf1,markdown,fr,1f017753827caf48,"## 2. Formalisation du Probleme
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,2bf3aaf1,markdown,fr,26a792876ac73628,"## 2. Formalisation du Problème
 
-Nous allons definir une classe `TSPInstance` pour representer le probleme.",,,,,,,,1f017753827caf48,,,,,,,
+Nous allons définir une classe `TSPInstance` pour representer le problème.",,,,,,,,26a792876ac73628,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,e4c22611,code,fr,4d8e57101d2cd1ab,"class TSPInstance:
     """"""Representation d'une instance du TSP.""""""
     
@@ -22978,11 +22978,11 @@ print(f""Instance: {tsp.nom}"")
 print(f""Nombre de villes: {tsp.n}"")
 print(f""Matrice de distances: {tsp.distances.shape}"")
 tsp.afficher(titre=""Villes seatales"")",,,,,,,,4d8e57101d2cd1ab,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,821127b8,markdown,fr,76a9b4a05b7d1338,"## 3. Methodes Exates (Reference)
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,821127b8,markdown,fr,5b665518a78cb70b,"## 3. Méthodes Exates (Reference)
 
 ### 3.1 Force Brute
 
-Exploration de toutes les permutations. **Utilisable uniquement pour n <= 10**.",,,,,,,,76a9b4a05b7d1338,,,,,,,
+Exploration de toutes les permutations. **Utilisable uniquement pour n <= 10**.",,,,,,,,5b665518a78cb70b,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,6f93a533,code,fr,f2a1c78d26b23b8f,"def brute_force(tsp: TSPInstance) -> Tuple[List[int], float]:
     """"""Resolution par force brute - O((n-1)!).""""""
     meilleure_tournee = None
@@ -23070,9 +23070,9 @@ print(f""Solution NN + 2-opt: {cout_2opt:.2f}"")
 print(f""Amelioration: {(cout_nn - cout_2opt)/cout_nn*100:.1f}%"")
 print(f""Temps: {temps_2opt*1000:.2f}ms"")
 tsp_medium.afficher(tournee_2opt, f""NN + 2-opt (cout={cout_2opt:.2f})"")",,,,,,,,f85cbc9f6bf893d0,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,2c352a26,markdown,fr,3a5e6114dd817018,"## 6. Recuit Simule (Simulated Annealing)
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,2c352a26,markdown,fr,808b6add93183040,"## 6. Recuit Simule (Simulated Annealing)
 
-Metaheuristique basee sur l'analogie avec la metallurgie. Permet des mouvements degradants avec une probabilite decroissante.",,,,,,,,3a5e6114dd817018,,,,,,,
+Métaheuristique basee sur l'analogie avec la metallurgie. Permet des mouvements degradants avec une probabilite decroissante.",,,,,,,,808b6add93183040,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,55326376,code,fr,81eeec90b6b42388,"def simulated_annealing_tsp(tsp: TSPInstance, 
                             tournee_initiale: List[int],
                             T0: float = 1000.0,
@@ -23121,7 +23121,7 @@ temps_sa = time.time() - start
 print(f""Solution SA: {cout_sa:.2f}"")
 print(f""Temps: {temps_sa:.2f}s"")
 tsp_medium.afficher(tournee_sa, f""Recuit Simule (cout={cout_sa:.2f})"")",,,,,,,,81eeec90b6b42388,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,08c01eea,markdown,fr,006f7ef86fbea2a1,Visualisation des resultats.,,,,,,,,006f7ef86fbea2a1,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,08c01eea,markdown,fr,8e63bf1f6fdb2663,Visualisation des résultats.,,,,,,,,8e63bf1f6fdb2663,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,1401eef8,code,fr,f0209488e549483f,"# Visualisation de la convergence
 plt.figure(figsize=(10, 4))
 plt.plot(hist_sa, 'b-', linewidth=1.5)
@@ -23132,9 +23132,9 @@ plt.title('Convergence du Recuit Simule')
 plt.legend()
 plt.grid(True, alpha=0.3)
 plt.show()",,,,,,,,f0209488e549483f,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,9cc69ca1,markdown,fr,f46d7acb5e017605,"## 7. Algorithme Genetique
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,9cc69ca1,markdown,fr,a183ef0be4d22f59,"## 7. Algorithme Génétique
 
-Optimisation par evolution artificielle : selection, crossover, mutation.",,,,,,,,f46d7acb5e017605,,,,,,,
+Optimisation par evolution artificielle : sélection, crossover, mutation.",,,,,,,,a183ef0be4d22f59,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,c04a4b77,code,fr,4fdae3bf57fa85c8,"def algorithme_genetique_tsp(tsp: TSPInstance,
                                taille_pop: int = 50,
                                generations: int = 100,
@@ -23327,9 +23327,9 @@ temps_aco = time.time() - start
 print(f""Solution ACO: {cout_aco:.2f}"")
 print(f""Temps: {temps_aco:.2f}s"")
 tsp_medium.afficher(tournee_aco, f""Colonie de Fourmis (cout={cout_aco:.2f})"")",,,,,,,,73489be024726b20,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,f488d4f3,markdown,fr,16b2688d354c0ec7,"## 9. Benchmark Comparatif
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,f488d4f3,markdown,fr,3e54db7e49bb4730,"## 9. Benchmark Comparatif
 
-Comparons toutes les methodes sur une instance de taille moyenne.",,,,,,,,16b2688d354c0ec7,,,,,,,
+Comparons toutes les méthodes sur une instance de taille moyenne.",,,,,,,,3e54db7e49bb4730,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,a524ccd1,code,fr,00a4fda3597ad0ec,"# Benchmark complet
 tsp_bench = TSPInstance.generer_aleatoire(30, seed=123)
 
@@ -23376,7 +23376,7 @@ for methode, res in resultats.items():
     qualite = f""{res['cout']/cout_ref:.2f}x""
     print(f""{methode:<15} {res['cout']:>10.2f} {res['temps']:>12.3f} {qualite:>10}"")
 print(""="" * 60)",,,,,,,,00a4fda3597ad0ec,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,63183b91,markdown,fr,006f7ef86fbea2a1,Visualisation des resultats.,,,,,,,,006f7ef86fbea2a1,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,63183b91,markdown,fr,8e63bf1f6fdb2663,Visualisation des résultats.,,,,,,,,8e63bf1f6fdb2663,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,31a99477,code,fr,d66be5874d5abf8f,"# Visualisation comparative
 fig, axes = plt.subplots(1, 2, figsize=(14, 5))
 
@@ -23450,7 +23450,7 @@ MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,2c7
     
 except ImportError:
     print(""OR-Tools non installe. Installez avec: pip install ortools"")",,,,,,,,bc0664c1c8c9e562,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,eb589dee,markdown,fr,d2741a8f18b70aed,"## Exercices
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,eb589dee,markdown,fr,82a17d4cc5590af4,"## Exercices
 
 ### Exercice 1 : Heuristique d'Insertion la Moins Chere
 
@@ -23459,7 +23459,7 @@ Implementez l'heuristique **Cheapest Insertion** qui construit une tournee en in
 **Indices** :
 - Commencez avec une tournee de 3 villes formant un triangle
 - Pour chaque ville non visitee, trouvez la meilleure position d'insertion
-- Comparez les resultats avec le Plus Proche Voisin",,,,,,,,d2741a8f18b70aed,,,,,,,
+- Comparez les résultats avec le Plus Proche Voisin",,,,,,,,82a17d4cc5590af4,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,1752e80e,code,fr,9c2a991ae69112ea,"def cheapest_insertion(tsp: TSPInstance) -> Tuple[List[int], float]:
     """"""
     Heuristique Cheapest Insertion pour le TSP.
@@ -23489,8 +23489,8 @@ MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,175
     
     pass  # Exercice: Implementez cheapest_insertion
 print('Fonction cheapest_insertion definie')",,,,,,,,9c2a991ae69112ea,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,c13fccc7,markdown,fr,af015eab1a3163f3,"Test de l'heuristique Cheapest Insertion : decommentez et executez apres avoir implemente la fonction ci-dessus.
-",,,,,,,,af015eab1a3163f3,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,c13fccc7,markdown,fr,9c0820c9b4013645,"Test de l'heuristique Cheapest Insertion : decommentez et executez après avoir implemente la fonction ci-dessus.
+",,,,,,,,9c0820c9b4013645,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,adef8739,code,fr,ca291b0395bb3384,"# Test cheapest_insertion
 tsp_ci = TSPInstance.generer_aleatoire(20, seed=123)
 
@@ -23509,14 +23509,14 @@ except (TypeError, ValueError, AttributeError) as e:
     print(""Exercice a completer : implementez cheapest_insertion()."")
     print(f""Attendu : tournee de {tsp_ci.n} villes, assertion de validite."")
 ",,,,,,,,ca291b0395bb3384,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,33747a6e,markdown,fr,2c7645200105f9ec,"### Exercice 2 : Operateur de Voisinage Or-opt
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,33747a6e,markdown,fr,8140702b7934184f,"### Exercice 2 : Opérateur de Voisinage Or-opt
 
-L'operateur **Or-opt** consiste a deplacer un segment de 1 a 3 villes consecutives a une autre position de la tournee. Implementez cet operateur.
+L'opérateur **Or-opt** consiste a deplacer un segment de 1 a 3 villes consecutives a une autre position de la tournee. Implementez cet opérateur.
 
 **Indices** :
 - Extrayez un segment de k villes (k = 1, 2 ou 3)
 - Reinserez ce segment a une autre position
-- Comparez l'amelioration avec 2-opt sur les memes instances",,,,,,,,2c7645200105f9ec,,,,,,,
+- Comparez l'amelioration avec 2-opt sur les mêmes instances",,,,,,,,8140702b7934184f,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,3c0d4ebd,code,fr,fdc3882da460dcf9,"def or_opt(tsp: TSPInstance, tournee: List[int], k_max: int = 3) -> Tuple[List[int], float]:
     """"""
     Operateur de voisinage Or-opt.
@@ -23546,8 +23546,8 @@ MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,3c0
     
     pass  # Exercice: Implementez or_opt
 print('Fonction or_opt definie')",,,,,,,,fdc3882da460dcf9,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,eb4ce0df,markdown,fr,442a5f835cd1d115,"Test de l'operateur Or-opt : decommentez et executez apres avoir implemente la fonction ci-dessus.
-",,,,,,,,442a5f835cd1d115,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,eb4ce0df,markdown,fr,0928339641b20d02,"Test de l'opérateur Or-opt : decommentez et executez après avoir implemente la fonction ci-dessus.
+",,,,,,,,0928339641b20d02,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,397db119,code,fr,83e5fc9f5eea1a28,"# Test or_opt
 tsp_or = TSPInstance.generer_aleatoire(20, seed=321)
 tournee_init, cout_init = plus_proche_voisin(tsp_or)
@@ -23568,27 +23568,27 @@ except (TypeError, ValueError, AttributeError) as e:
     print(""Exercice a completer : implementez or_opt()."")
     print(f""Attendu : tournee amelioree, cout inferieur a {cout_init:.2f}."")
 ",,,,,,,,83e5fc9f5eea1a28,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,3c3b7ccd,markdown,fr,63ca70a25617beba,"### Exercice 3 : Parametrisation du Recuit Simule (Reflexion)
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,3c3b7ccd,markdown,fr,b6e4aa9fc0dd4d7d,"### Exercice 3 : Parametrisation du Recuit Simule (Reflexion)
 
-Analysez l'impact des parametres du recuit simule sur la qualite de la solution.
+Analysez l'impact des paramètres du recuit simule sur la qualite de la solution.
 
 **Questions a considerer** :
 - Comment la temperature initiale (T0) affecte-t-elle l'exploration vs l'exploitation ?
 - Quel est l'effet du taux de refroidissement (alpha) sur la convergence ?
-- Comment choisir le nombre d'iterations par temperature en fonction de la taille du probleme ?
+- Comment choisir le nombre d'itérations par temperature en fonction de la taille du problème ?
 
-**Reponse attendue** : Une analyse textuelle de l'influence de chaque parametre et des recommandations pratiques (pas de code requis).",,,,,,,,63ca70a25617beba,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,61e6dc79,markdown,fr,ba683085371b3791,"### Reponse Exercice 3
+**Reponse attendue** : Une analyse textuelle de l'influence de chaque paramètre et des recommandations pratiques (pas de code requis).",,,,,,,,b6e4aa9fc0dd4d7d,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,61e6dc79,markdown,fr,591f7c8774dd0c70,"### Reponse Exercice 3
 
-*Redigez votre analyse ci-dessous en utilisant vos observations des executions precedentes.*
+*Redigez votre analyse ci-dessous en utilisant vos observations des exécutions précédentes.*
 
 1. **Temperature initiale `T0`** : 
 
 2. **Taux de refroidissement `alpha`** : 
 
-3. **Nombre d'iterations par temperature** : 
-",,,,,,,,ba683085371b3791,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,ba42009e,markdown,fr,d4496f9ebe4a674e,"## Exemple guide supplementaires
+3. **Nombre d'itérations par temperature** : 
+",,,,,,,,591f7c8774dd0c70,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,ba42009e,markdown,fr,db5f03e393e4cca0,"## Exemple guide supplementaires
 
 ### Exemple guide 1 : TSP Asymetrique
 
@@ -23598,13 +23598,13 @@ Modifiez la classe TSPInstance pour supporter le TSP asymetrique (ATSP) ou la di
 
 Implementez l'amelioration 3-opt qui considere 3 coupures au lieu de 2. Comparez avec 2-opt.
 
-### Exercice : TSP avec Fenetres de Temps
+### Exercice : TSP avec Fenêtres de Temps
 
-Ajoutez des contraintes de fenetres de temps : chaque ville doit etre visitee dans un intervalle [a, b].
+Ajoutez des contraintes de fenêtres de temps : chaque ville doit etre visitee dans un intervalle [a, b].
 
 ### Exemple : Hybridation GA + 2-opt
 
-Combinaison de l'algorithme genetique avec une amelioration locale 2-opt appliquee a chaque enfant apres crossover. Cette approche hybride exploite la capacite d'exploration du GA et le pouvoir d'intensification du 2-opt.",,,,,,,,d4496f9ebe4a674e,,,,,,,
+Combinaison de l'algorithme génétique avec une amelioration locale 2-opt appliquee a chaque enfant après crossover. Cette approche hybride exploite la capacite d'exploration du GA et le pouvoir d'intensification du 2-opt.",,,,,,,,db5f03e393e4cca0,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,4c6d2e3f,code,fr,704eeabe06074487,"# Bonus 1 - TSP asymetrique (ATSP)
 tsp_atsp = TSPInstance.generer_aleatoire_asymetrique(12, seed=2026)
 
@@ -23620,8 +23620,8 @@ print(f""Cout NN (ATSP): {cout_nn_atsp:.2f}"")
 print(f""Cout tournee inverse: {cout_inverse:.2f}"")
 
 tsp_atsp.afficher(tournee_nn_atsp, f""ATSP - NN (cout={cout_nn_atsp:.2f})"")",,,,,,,,704eeabe06074487,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,62062879,markdown,fr,57cefa9d30f47788,"Exemples supplementaires : decommentez et executez apres avoir implemente la fonction ci-dessus.
-",,,,,,,,57cefa9d30f47788,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,62062879,markdown,fr,2158370aeb9ea47a,"Exemples supplementaires : decommentez et executez après avoir implemente la fonction ci-dessus.
+",,,,,,,,2158370aeb9ea47a,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,16ff555e,code,fr,0ebfeafc46a2d74a,"# Bonus 2 - 3-opt (comparaison avec 2-opt)
 def three_opt(tsp, tour, max_iter=None):
     """"""
@@ -23641,11 +23641,11 @@ print(f""Cout apres 3-opt: {cout_3opt_bonus:.2f}"")
 
 tsp_bonus2.afficher(tournee_2opt, f""Bonus 2 - 2-opt (cout={cout_2opt_bonus:.2f})"")
 tsp_bonus2.afficher(tournee_3opt, f""Bonus 2 - 3-opt (cout={cout_3opt_bonus:.2f})"")",,,,,,,,0ebfeafc46a2d74a,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,44f3fa21,markdown,fr,d81879f45a6efc4d,"### Interpretation Bonus 2
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,44f3fa21,markdown,fr,bcc15fd06a4eea73,"### Interpretation Bonus 2
 
 Sur notre test, le cout affiche pour 3-opt (632.87) est **identique au cout initial NN** : `three_opt` est un **stub d'exercice** (`# TODO etudiant`) qui retourne le tour sans le modifier. Le cout ""3-opt"" ne reflete donc pas une vraie amelioration 3-opt a comparer au 2-opt (553.98).
 
-**A vous de jouer** : completez `three_opt` (test des rearrangements de 3 aretes, complexite $O(n^3)$) et re-executez cette cellule pour comparer honnetement 3-opt vs 2-opt. La litterature indique que 3-opt produit generalement une solution au moins aussi bonne que 2-opt, au prix d'un cout de calcul plus eleve.",,,,,,,,d81879f45a6efc4d,,,,,,,
+**A vous de jouer** : completez `three_opt` (test des rearrangements de 3 aretes, complexite $O(n^3)$) et re-executez cette cellule pour comparer honnetement 3-opt vs 2-opt. La litterature indique que 3-opt produit généralement une solution au moins aussi bonne que 2-opt, au prix d'un cout de calcul plus eleve.",,,,,,,,bcc15fd06a4eea73,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,41b43f60,code,fr,3d5b56524f720356,"# Exemple - Hybridation GA + 2-opt
 def algorithme_genetique_hybride_tsp(tsp: TSPInstance,
                                       taille_pop: int = 50,
@@ -23720,8 +23720,8 @@ def algorithme_genetique_hybride_tsp(tsp: TSPInstance,
     meilleure = population[0]
     return meilleure, tsp.cout_tournee(meilleure), historique
 print('Fonction algorithme_genetique_hybride_tsp definie')",,,,,,,,3d5b56524f720356,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,6ad8c972,markdown,fr,82fca4ac2f5b6682,"Test de l'hybridation GA + 2-opt : decommentez et executez apres avoir implemente la fonction ci-dessus.
-",,,,,,,,82fca4ac2f5b6682,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,6ad8c972,markdown,fr,4dcf5cd6476bbd06,"Test de l'hybridation GA + 2-opt : decommentez et executez après avoir implemente la fonction ci-dessus.
+",,,,,,,,4dcf5cd6476bbd06,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,fc746b51,code,fr,50dbcfd80fb14825,"# Test Exemple - comparaison GA seul vs GA+2-opt
 tsp_hybrid = TSPInstance.generer_aleatoire(40, seed=4242)
 
@@ -23758,24 +23758,24 @@ axes[1].set_title('Comparaison finale')
 axes[1].grid(True, axis='y', alpha=0.3)
 plt.tight_layout()
 plt.show()",,,,,,,,50dbcfd80fb14825,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,634e2040,markdown,fr,4e3ce0be774e0832,"### Exercice 4 : Recherche Tabou (Tabu Search)
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,634e2040,markdown,fr,310dbaaf47f77c4d,"### Exercice 4 : Recherche Tabou (Tabu Search)
 
-La **recherche tabou** (Glover, 1986) est une metaheuristique deterministe qui utilise une
-memoire a court terme pour eviter de revisiter des solutions deja explorees.
+La **recherche tabou** (Glover, 1986) est une métaheuristique déterministe qui utilise une
+memoire a court terme pour eviter de revisiter des solutions déjà explorees.
 
 **Principe** :
 1. Partez d'une solution initiale et explorez son voisinage (echange de 2 villes)
 2. Interdisez les mouvements recemment effectues grace a une **liste tabou**
-3. Le meilleur voisin non-tabou est toujours accepte (meme s'il degrade la solution)
+3. Le meilleur voisin non-tabou est toujours accepte (même s'il degrade la solution)
 4. **Critere d'aspiration** : un mouvement tabou est accepte s'il produit un nouveau global best
-5. Repetez pendant un nombre fixe d'iterations
+5. Repetez pendant un nombre fixe d'itérations
 
-**Parametres cles** :
+**Paramètres cles** :
 - `tabu_tenure` : duree d'interdiction d'un mouvement (typique : n/3 a n)
-- `max_iter` : budget d'iterations total
+- `max_iter` : budget d'itérations total
 - `aspiration` : activer le critere de nouveau global best
 
-La fonction `recherche_tabou` ci-dessous est **a implementer** (exercice), puis a comparer au recuit simule une fois completee.",,,,,,,,4e3ce0be774e0832,,,,,,,
+La fonction `recherche_tabou` ci-dessous est **a implementer** (exercice), puis a comparer au recuit simule une fois completee.",,,,,,,,310dbaaf47f77c4d,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,701d32f7,code,fr,70706439056f1760,"def recherche_tabou(tsp: TSPInstance,
                     tournee_initiale: List[int],
                     tabu_tenure: int = 7,
@@ -23813,8 +23813,8 @@ MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,701
     tournee = tournee_initiale.copy()
     pass  # Exercice: Implementez recherche_tabou
 print('Fonction recherche_tabou definie')",,,,,,,,70706439056f1760,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,a2782c35,markdown,fr,f861116c4198e772,"Comparaison Tabou vs Recuit Simule : decommentez et executez apres avoir implemente la fonction ci-dessus.
-",,,,,,,,f861116c4198e772,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,a2782c35,markdown,fr,860064a7b6818126,"Comparaison Tabou vs Recuit Simule : decommentez et executez après avoir implemente la fonction ci-dessus.
+",,,,,,,,860064a7b6818126,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,f6dbeb02,code,fr,eed96bcfe824a2dd,"# --- Comparaison Tabou vs Recuit Simule ---
 instances_test = [(10, 42), (15, 101), (20, 202), (25, 303), (30, 404)]
 resultats_tabou = []
@@ -23875,47 +23875,47 @@ except (TypeError, ValueError, AttributeError):
     print(""Exercice a completer : implementez recherche_tabou()."")
     print(""Attendu : comparaison Tabou vs Recuit Simule sur 5 instances TSP."")
 ",,,,,,,,eed96bcfe824a2dd,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,f3411921,markdown,fr,848d82b788e36ebc,"### Interpretation : Recherche Tabou vs Recuit Simule
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,f3411921,markdown,fr,fef8ca373dbdaaae,"### Interpretation : Recherche Tabou vs Recuit Simule
 
-> **A valider (Exercice 4)** : la cellule precedente n'a pas encore produit de resultats (la fonction `recherche_tabou` est a implementer). Les points 2 et 3 ci-dessous sont une interpretation theorique des comportements attendus, a confronter a vos mesures une fois l'exercice complete.
+> **A valider (Exercice 4)** : la cellule précédente n'a pas encore produit de résultats (la fonction `recherche_tabou` est a implementer). Les points 2 et 3 ci-dessous sont une interpretation théorique des comportements attendus, a confronter a vos mesures une fois l'exercice complete.
 
 **Observations** :
 
 1. **Monotonie du meilleur global** : La courbe du meilleur cout global est decroissante
    par construction -- la recherche tabou ne met a jour le meilleur global que lorsqu'une
    amelioration est trouvee. Le cout actuel peut remonter (acceptation du meilleur voisin
-   meme degradant), mais le meilleur enregistre ne fait que descendre.
+   même degradant), mais le meilleur enregistre ne fait que descendre.
 
-2. **Petites instances (n <= 15)** : Tabou et SA trouvent souvent la meme solution optimale
+2. **Petites instances (n <= 15)** : Tabou et SA trouvent souvent la même solution optimale
    ou quasi-optimale. L'ecart est faible car l'espace de recherche reste explorables.
 
-3. **Instances moyennes (n >= 20)** : L'ecart entre les deux methodes augmente.
+3. **Instances moyennes (n >= 20)** : L'ecart entre les deux méthodes augmente.
    Le recuit simule accepte des degradations probabilistes qui lui permettent d'echapper
-   plus facilement aux optima locaux. La recherche tabou, elle, est plus deterministe :
+   plus facilement aux optima locaux. La recherche tabou, elle, est plus déterministe :
    si le voisinage est mal explore, elle peut stagner.
 
 4. **Quand privilegier la recherche tabou** :
    - Quand la reproductibilite est importante (pas d'aleatoire dans le choix du voisin)
    - Quand le voisinage est structure et que la memoire tabou empeche efficacement le cyclage
-   - Quand on veut un comportement deterministe pour des tests de regression
+   - Quand on veut un comportement déterministe pour des tests de regression
 
-5. **Role du parametre `tabu_tenure`** : Une tenure trop courte (ex: 2) ne suffit pas
+5. **Rôle du paramètre `tabu_tenure`** : Une tenure trop courte (ex: 2) ne suffit pas
    a empecher le cyclage ; une tenure trop longue (ex: n) risque d'interdire des mouvements
-   utiles. La regle empirique `tabu_tenure ~ n/3` offre un bon compromis.
-",,,,,,,,848d82b788e36ebc,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,d5744c0c,markdown,fr,7625369227a36b85,"## Synthese et Recommandations
+   utiles. La règle empirique `tabu_tenure ~ n/3` offre un bon compromis.
+",,,,,,,,fef8ca373dbdaaae,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,d5744c0c,markdown,fr,2d2e3b0cc7fd5263,"## Synthese et Recommandations
 
 ### Tableau comparatif
 
-| Methode | Complexite | Qualite | Temps | Usage recommande |
+| Méthode | Complexite | Qualite | Temps | Usage recommande |
 |---------|------------|--------|------|------------------|
 | **Force Brute** | O((n-1)!) | Optimale | Eleve | n <= 10 uniquement |
-| **Plus Proche Voisin** | O(n^2) | Moyenne | Tres rapide | Solution initiale, n grand |
-| **2-opt** | O(n^2) par iter | Bonne | Rapide | Post-traitement systematique |
-| **Recuit Simule** | Parametrable | Tres bonne | Moyen | n = 50-200, equilibre qualite/temps |
-| **Algorithme Genetique** | Parametrable | Bonne | Moyen | n = 100-500, parallelisable |
-| **ACO** | O(iter x fourmis x n^2) | Tres bonne | Moyen | Problemes avec structure, n = 50-300 |
-| **Recherche Tabou** | O(max_iter x n^2) | Bonne a tres bonne | Moyen | Deterministe, evite le cyclage |
+| **Plus Proche Voisin** | O(n^2) | Moyenne | Très rapide | Solution initiale, n grand |
+| **2-opt** | O(n^2) par iter | Bonne | Rapide | Post-traitement systématique |
+| **Recuit Simule** | Parametrable | Très bonne | Moyen | n = 50-200, equilibre qualite/temps |
+| **Algorithme Génétique** | Parametrable | Bonne | Moyen | n = 100-500, parallelisable |
+| **ACO** | O(iter x fourmis x n^2) | Très bonne | Moyen | Problemes avec structure, n = 50-300 |
+| **Recherche Tabou** | O(max_iter x n^2) | Bonne a très bonne | Moyen | Déterministe, evite le cyclage |
 | **OR-Tools** | Variable | Optimale+ | Variable | Production, garanties de qualite |
 
 ### Recommandations pratiques
@@ -23930,20 +23930,20 @@ MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,d57
 - Le **Plus Proche Voisin** est souvent une excellente solution initiale
 - **2-opt** ameliore significativement toute solution (a appliquer systematiquement)
 - **SA et ACO** offrent le meilleur equilibre qualite/temps pour les instances moyennes
-- **Recherche Tabou** apporte un comportement deterministe et une garantie anti-cyclage
+- **Recherche Tabou** apporte un comportement déterministe et une garantie anti-cyclage
 - **OR-Tools** reste la solution de reference pour la production
 
 ---
 
 **Navigation** : [<< Portfolio](../Hybrid/App-10-Portfolio.ipynb) | [Index](../README.md) | [Foundations >>](../../Part1-Foundations/README.md)
-",,,,,,,,7625369227a36b85,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,4a40b74c,markdown,fr,02754dd76f85355e,"## Conclusion
+",,,,,,,,2d2e3b0cc7fd5263,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb,4a40b74c,markdown,fr,b53a8c95c254e72c,"## Conclusion
 
-Ce notebook a applique les metaheuristiques au **Traveling Salesman Problem (TSP)**, le probleme canonique NP-hard de l'optimisation combinatoire.
+Ce notebook a applique les métaheuristiques au **Traveling Salesman Problem (TSP)**, le problème canonique NP-hard de l'optimisation combinatoire.
 
-### Resultats du benchmark (optimal = 277.23)
+### Résultats du benchmark (optimal = 277.23)
 
-| Methode | Distance | Ratio | Temps |
+| Méthode | Distance | Ratio | Temps |
 |---------|----------|-------|-------|
 | Brute force | **277.23** | 1.00x | 0.007s |
 | ACO | 473.68 | 1.71x | - |
@@ -23951,15 +23951,15 @@ Ce notebook a applique les metaheuristiques au **Traveling Salesman Problem (TSP
 | 2-opt | 489.74 | 1.77x | - |
 | Plus proche voisin | 494.69 | 1.78x | - |
 | OR-Tools | **465.53** | 1.68x | - |
-| Algorithme genetique | 732.23 | 2.64x | - |
+| Algorithme génétique | 732.23 | 2.64x | - |
 
 ### Lecon principale : l'hybridation change tout
 
-L'algorithme genetique seul est le plus faible (2.64x optimal), mais **combine avec 2-opt, il passe de 930 a 520**, une amelioration de 44%. Le 2-opt est le post-traitement universel qui ameliore systematiquement toute solution. OR-Tools reste la reference de production.
+L'algorithme génétique seul est le plus faible (2.64x optimal), mais **combine avec 2-opt, il passe de 930 a 520**, une amelioration de 44%. Le 2-opt est le post-traitement universel qui ameliore systematiquement toute solution. OR-Tools reste la reference de production.
 
-Le TSP illustre le compromis fondamental : les methodes exactes garantissent l'optimalite mais explosent au-dela de n~10-12 villes, tandis que les metaheuristiques scalement mais sans garantie.
+Le TSP illustre le compromis fondamental : les méthodes exactes garantissent l'optimalite mais explosent au-dela de n~10-12 villes, tandis que les métaheuristiques scalement mais sans garantie.
 
-**Suite** : [App-14 - Connect Four adversarial](../Search/App-14-ConnectFour-Adversarial.ipynb) | [Retour au sommaire](../../README.md)",,,,,,,,02754dd76f85355e,,,,,,,
+**Suite** : [App-14 - Connect Four adversarial](../Search/App-14-ConnectFour-Adversarial.ipynb) | [Retour au sommaire](../../README.md)",,,,,,,,b53a8c95c254e72c,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13b-TSP-Metaheuristics-CSharp.ipynb,6a1e3f6d-397a-4d21-9131-c59b1ef7a99c,markdown,fr,2a770b06dd8df2df,"# App-13b : TSP (Voyageur de Commerce) — Jumeau C#
 
 > **Twin C#** de [`App-13-TSP-Metaheuristics`](App-13-TSP-Metaheuristics.ipynb) (Python : brute force, plus-proche-voisin, 2-opt, recuit simulé, GA, ACO, OR-Tools).
@@ -24481,7 +24481,7 @@ MyIA.AI.Notebooks/Search/Applications/Hybrid/App-17-VRP-Logistics.ipynb,008c5ba0
     
     return VRPSolution(routes=[r for r in routes if r], instance=instance)
 print(""Fonction greedy_insertion definie"")",,,,,,,,5e55bfc29113d65c,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-17-VRP-Logistics.ipynb,9130a7f3,markdown,fr,1de91880942b7d8f,Verification des resultats.,,,,,,,,1de91880942b7d8f,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-17-VRP-Logistics.ipynb,9130a7f3,markdown,fr,edc38a4588d07ee2,Verification des résultats.,,,,,,,,edc38a4588d07ee2,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-17-VRP-Logistics.ipynb,3c02db21,code,fr,95b2de6c0e39a497,"# Tester l'algorithme glouton
 solution = greedy_insertion(instance)
 print(f""Solution valide: {solution.is_valid()}"")
@@ -25404,7 +25404,7 @@ MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,f
 ## Objectifs d'apprentissage
 
 A la fin de ce notebook, vous saurez:",,,,,,,,9de6337d3e4366aa,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,7963f31f,markdown,fr,cc0b7ab83dd13e0e,## 1. Configuration et Jeu de Donnees,,,,,,,,cc0b7ab83dd13e0e,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,7963f31f,markdown,fr,2b56f8ad5e3f0043,## 1. Configuration et Jeu de Données,,,,,,,,2b56f8ad5e3f0043,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,ccf0ea05,code,fr,f14b0f1354dab627,"import numpy as np
 import pandas as pd
 from sklearn.datasets import make_classification, load_breast_cancer
@@ -25471,19 +25471,19 @@ def evaluate_rf(params: Dict[str, Any], cv_folds: int = 5) -> float:
     return scores.mean()
 
 print(f""Espace de recherche defini : {len(param_space)} hyperparametres, evaluate_rf pret"")",,,,,,,,132e12c6b9256f03,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,4ee08d88,markdown,fr,e0106246b53080f2,## 2. Methodes de Reference,,,,,,,,e0106246b53080f2,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,5f5485c6,markdown,fr,040f1c4c299bd87c,"### 2.1 Grid Search (Recherche en Grille)
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,4ee08d88,markdown,fr,891ba5582a02639a,## 2. Méthodes de Reference,,,,,,,,891ba5582a02639a,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,5f5485c6,markdown,fr,6b1cf6ae20f60943,"### 2.1 Grid Search (Recherche en Grille)
 
 **Principe**: Explorer systematiquement toutes les combinaisons d'une grille predefinie.
 
 **Avantages**:
 - Simple a implementer et comprendre
 - Garantit de trouver le meilleur point sur la grille
-- Tres parallele
+- Très parallele
 
 **Inconvenients**:
 - Explosion combinatoire: $O(n^d)$ ou $n$ = points par dimension, $d$ = dimensions
-- Ne s'adapte pas a l'importance des dimensions",,,,,,,,040f1c4c299bd87c,,,,,,,
+- Ne s'adapte pas a l'importance des dimensions",,,,,,,,6b1cf6ae20f60943,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,bacd71ab,code,fr,d4d2c03230d9db7d,"def grid_search(param_grid: Dict[str, List], max_evals: int = 50) -> Tuple[Dict, float, List]:
     """"""
     Grid Search simplifie.
@@ -25530,7 +25530,7 @@ time_grid = time.time() - start_time
 print(f""Meilleur score: {score_grid:.4f}"")
 print(f""Meilleurs parametres: {best_grid}"")
 print(f""Temps: {time_grid:.2f}s ({len(history_grid)} evaluations)"")",,,,,,,,d4d2c03230d9db7d,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,0253cd34,markdown,fr,57807dca392a9973,"### 2.2 Random Search (Recherche Aleatoire)
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,0253cd34,markdown,fr,83e99884ba0d3e6c,"### 2.2 Random Search (Recherche Aleatoire)
 
 **Principe**: Echantillonner uniformement dans l'espace de recherche.
 
@@ -25539,7 +25539,7 @@ MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,0
 **Avantages**:
 - Echelle mieux avec la dimensionalite
 - Peut etre arrete a tout moment
-- Tres parallele",,,,,,,,57807dca392a9973,,,,,,,
+- Très parallele",,,,,,,,83e99884ba0d3e6c,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,67a1d30b,code,fr,6c4a7161e17e926e,"def random_search(param_space: Dict[str, Tuple], n_iter: int = 50) -> Tuple[Dict, float, List]:
     """"""
     Random Search avec echantillonnage uniforme.
@@ -25574,17 +25574,17 @@ time_random = time.time() - start_time
 print(f""Meilleur score: {score_random:.4f}"")
 print(f""Meilleurs parametres: {best_random}"")
 print(f""Temps: {time_random:.2f}s"")",,,,,,,,6c4a7161e17e926e,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,ec2a3f91,markdown,fr,52c6560551b734d7,"### Exercice : Analyser la vitesse de convergence
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,ec2a3f91,markdown,fr,86ac2b73774a3f51,"### Exercice : Analyser la vitesse de convergence
 
-La cellule ci-dessus a execute un Random Search avec 50 iterations. Ecrivez une fonction `iterations_to_threshold` qui, etant donne un historique de recherche et un seuil (ex: 95% du meilleur score), retourne **le nombre minimal d'evaluations** necessaires pour atteindre ce seuil.
+La cellule ci-dessus a execute un Random Search avec 50 itérations. Ecrivez une fonction `iterations_to_threshold` qui, etant donne un historique de recherche et un seuil (ex: 95% du meilleur score), retourne **le nombre minimal d'evaluations** necessaires pour atteindre ce seuil.
 
-Cet indicateur mesure l'**efficacite** d'une methode d'optimisation : moins d'evaluations = methode plus efficiente.
+Cet indicateur mesure l'**efficacite** d'une méthode d'optimisation : moins d'evaluations = méthode plus efficiente.
 
 **Indices** :
 - Calculez le score cumulatif maximum : `np.maximum.accumulate([h['score'] for h in history])`
 - Le seuil cible = `threshold_fraction * best_final_score`
-- Utilisez `np.argmax(cumulative >= target)` pour trouver la premiere iteration qui atteint le seuil
-- Testez avec `threshold_fraction=0.99` (atteindre 99% du meilleur score)",,,,,,,,52c6560551b734d7,,,,,,,
+- Utilisez `np.argmax(cumulative >= target)` pour trouver la première itération qui atteint le seuil
+- Testez avec `threshold_fraction=0.99` (atteindre 99% du meilleur score)",,,,,,,,86ac2b73774a3f51,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,ae5133c2,code,fr,8a447419269b40b0,"def iterations_to_threshold(history: List[Dict], threshold_fraction: float = 0.99) -> int:
     """"""Retourne le nombre minimal d'evaluations pour atteindre threshold_fraction du meilleur score.
     
@@ -25603,15 +25603,15 @@ MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,a
     return 0  # TODO etudiant : remplacer par le calcul
 
 print(""Exercice a completer : analyse de vitesse de convergence"")",,,,,,,,8a447419269b40b0,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,bc8d21a1,markdown,fr,65927ae04616631b,"## 3. Optimisation Bayesienne
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,bc8d21a1,markdown,fr,fb4f2f344faaba61,"## 3. Optimisation Bayesienne
 
-**Principe**: Utiliser un modele probabiliste (Gaussian Process) pour modeler la fonction objectif et guider l'exploration.
+**Principe**: Utiliser un modèle probabiliste (Gaussian Process) pour modeler la fonction objectif et guider l'exploration.
 
 ### Algorithme
 
 1. **Initialisation**: Evaluer quelques points aleatoires
-2. **Modele**: Entrainer un GP sur les observations
-3. **Acquisition**: Selectionner le prochain point maximisant l'acquisition
+2. **Modèle**: Entrainer un GP sur les observations
+3. **Acquisition**: Sélectionner le prochain point maximisant l'acquisition
 4. **Evaluation**: Evaluer le point selectionne
 5. **Repetition**: Retourner a 2 jusqu'a budget epuise
 
@@ -25619,7 +25619,7 @@ MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,b
 
 - **EI (Expected Improvement)**: Balance exploration/exploitation
 - **UCB (Upper Confidence Bound)**: $\mu(x) + \kappa \cdot \sigma(x)$
-- **PI (Probability of Improvement)**: Probabilite d'amelioration",,,,,,,,65927ae04616631b,,,,,,,
+- **PI (Probability of Improvement)**: Probabilite d'amelioration",,,,,,,,fb4f2f344faaba61,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,7f9fa33d,code,fr,b9e6836cac997f63,"# Implementation manuelle pour comprehension (sans Optuna)
 from scipy.stats import norm
 from scipy.optimize import minimize
@@ -25737,19 +25737,19 @@ time_bayes = time.time() - start_time
 print(f""Meilleur score: {score_bayes:.4f}"")
 print(f""Meilleurs parametres: {best_bayes}"")
 print(f""Temps: {time_bayes:.2f}s"")",,,,,,,,b9e6836cac997f63,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,9cceb1b0,markdown,fr,2b0f7d721413f771,"### Exercice : Implementer l'acquisition UCB (Upper Confidence Bound)
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,9cceb1b0,markdown,fr,ecc600ed08c0ae26,"### Exercice : Implementer l'acquisition UCB (Upper Confidence Bound)
 
 Le BayesianOptimizer ci-dessus utilise l'Expected Improvement (EI) comme fonction d'acquisition. Implementez une alternative : **UCB** (Upper Confidence Bound).
 
 La formule UCB est : $\alpha(x) = \mu(x) + \kappa \cdot \sigma(x)$
 
-ou $\mu(x)$ est la prediction moyenne du modele, $\sigma(x)$ l'incertitude, et $\kappa$ un parametre controlant le trade-off exploration/exploitation.
+ou $\mu(x)$ est la prediction moyenne du modèle, $\sigma(x)$ l'incertitude, et $\kappa$ un paramètre controlant le trade-off exploration/exploitation.
 
 **Indices** :
 - Reprenez la structure de `expected_improvement` dans la classe `BayesianOptimizer`
 - Le calcul de `mean` et `std` est identique (distance-weighted)
 - UCB = `mean + kappa * std` (pas besoin de `norm.cdf` ni `norm.pdf`)
-- Plus `kappa` est grand, plus l'exploration est favorisee (essayer `kappa=2.0`)",,,,,,,,2b0f7d721413f771,,,,,,,
+- Plus `kappa` est grand, plus l'exploration est favorisee (essayer `kappa=2.0`)",,,,,,,,ecc600ed08c0ae26,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,f6cb1850,code,fr,9716cb317f78f834,"def ucb_acquisition(x: np.ndarray, observations: List, kappa: float = 2.0) -> float:
     """"""Calcule l'Upper Confidence Bound pour un point x.
     
@@ -25807,17 +25807,17 @@ if optuna_available:
     print(f""Meilleur score: {score_optuna:.4f}"")
     print(f""Meilleurs parametres: {best_optuna}"")
     print(f""Temps: {time_optuna:.2f}s"")",,,,,,,,41b3b2db7e82b02b,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,93ec158d,markdown,fr,d9f41fba2acbd841,"## 4. Algorithme Genetique (GA)
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,93ec158d,markdown,fr,0c66306a45662887,"## 4. Algorithme Génétique (GA)
 
 **Principe**: Evoluer une population de configurations vers de meilleures solutions.
 
 ### Composants
 
 1. **Representation**: Chromosome = vecteur d'hyperparametres
-2. **Selection**: Tournament ou roulette wheel
+2. **Sélection**: Tournament ou roulette wheel
 3. **Crossover**: Echange de genes entre parents
 4. **Mutation**: Perturbation aleatoire
-5. **Remplacement**: Elitisme + nouveaux individus",,,,,,,,d9f41fba2acbd841,,,,,,,
+5. **Remplacement**: Elitisme + nouveaux individus",,,,,,,,0c66306a45662887,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,da802983,code,fr,7e813696350bb719,"class GeneticHyperparamOptimizer:
     """"""
     Algorithme genetique pour l'optimisation d'hyperparametres.
@@ -25953,16 +25953,16 @@ time_ga = time.time() - start_time
 print(f""Meilleur score: {score_ga:.4f}"")
 print(f""Meilleurs parametres: {best_ga}"")
 print(f""Temps: {time_ga:.2f}s"")",,,,,,,,7e813696350bb719,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,8e4a6c4b,markdown,fr,5cb14312a6e01292,"### Exercice : Mesurer la diversite d'une population genetique
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,8e4a6c4b,markdown,fr,735ec18760e6e69a,"### Exercice : Mesurer la diversite d'une population génétique
 
-Une population trop homogene signifie que l'algorithme genetique a **converge prematurement**. Implementez une fonction `population_diversity` qui calcule la diversite moyenne d'une population en mesurant la distance moyenne entre paires d'individus.
+Une population trop homogene signifie que l'algorithme génétique a **converge prematurement**. Implementez une fonction `population_diversity` qui calcule la diversite moyenne d'une population en mesurant la distance moyenne entre paires d'individus.
 
 **Indices** :
-- Convertissez chaque individu (dict de parametres) en vecteur numerique normalise `[0, 1]`
+- Convertissez chaque individu (dict de paramètres) en vecteur numérique normalise `[0, 1]`
 - Pour chaque paire d'individus, calculez la distance euclidienne `np.linalg.norm(a - b)`
 - La diversite = moyenne de toutes les distances par paires
 - Une diversite proche de 0 indique une convergence prematuree
-- Pour N individus, il y a `N*(N-1)/2` paires distinctes",,,,,,,,5cb14312a6e01292,,,,,,,
+- Pour N individus, il y a `N*(N-1)/2` paires distinctes",,,,,,,,735ec18760e6e69a,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,e5cf1ac7,code,fr,d685c8fb9819cf39,"def population_diversity(population: List[Dict], param_space: Dict[str, Tuple]) -> float:
     """"""Calcule la diversite moyenne d'une population (distance par paires normalisee).
     
@@ -26100,9 +26100,9 @@ time_pso = time.time() - start_time
 print(f""Meilleur score: {score_pso:.4f}"")
 print(f""Meilleurs parametres: {best_pso}"")
 print(f""Temps: {time_pso:.2f}s"")",,,,,,,,36447f5459f9c075,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,3a158fef,markdown,fr,67e7d136aff0f7b5,"## 6. Comparaison des Methodes
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,3a158fef,markdown,fr,bc767dade70ae6a3,"## 6. Comparaison des Méthodes
 
-Analysons la convergence et l'efficacite de chaque methode.",,,,,,,,67e7d136aff0f7b5,,,,,,,
+Analysons la convergence et l'efficacite de chaque méthode.",,,,,,,,bc767dade70ae6a3,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,fd48aa10,code,fr,d588efd24ffa18bc,"# Extraction des courbes de convergence
 def get_convergence(history: List[Dict]) -> np.ndarray:
     """"""Extrait la meilleure score cumulatif.""""""
@@ -26162,9 +26162,9 @@ results = results.sort_values('Meilleur Score', ascending=False)
 
 print(""=== Tableau Comparatif ==="")
 print(results.to_string(index=False))",,,,,,,,2b2fd5388be4fa85,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,e4d0f1aa,markdown,fr,bce3ae829c2c3ed6,"## 7. Visualisation de l'Espace de Recherche
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,e4d0f1aa,markdown,fr,8b3d1297218d8bc5,"## 7. Visualisation de l'Espace de Recherche
 
-Visualisons comment chaque methode explore l'espace des hyperparametres.",,,,,,,,bce3ae829c2c3ed6,,,,,,,
+Visualisons comment chaque méthode explore l'espace des hyperparametres.",,,,,,,,8b3d1297218d8bc5,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,483f2c41,code,fr,225548698d593833,"# Visualisation 2D (n_estimators vs max_depth)
 fig, axes = plt.subplots(2, 2, figsize=(12, 10))
 
@@ -26197,29 +26197,29 @@ for ax, history, title, color in zip(axes.flat, histories, titles, colors):
 plt.suptitle('Exploration de l\'Espace (n_estimators vs max_depth)', fontsize=14, y=1.02)
 plt.tight_layout()
 plt.show()",,,,,,,,225548698d593833,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,5f8a1485,markdown,fr,8badcc2caee9f823,"**Interpretation des resultats**
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,5f8a1485,markdown,fr,26fe91280c2202db,"**Interpretation des résultats**
 
-La visualisation montre comment chaque methode explore l'espace 2D des parametres (n_estimators vs max_depth) :
+La visualisation montre comment chaque méthode explore l'espace 2D des paramètres (n_estimators vs max_depth) :
 - **Random Search** explore large et uniformement
 - **Bayesian** se concentre sur les regions prometteuses
 - **GA** explore a travers tout l'espace
 - **PSO** montre une exploration similaire a Random Search
-- **Meilleurs points** : toutes les methodes tendent a trouver des solutions dans des regions similaires
-- **Convergence** : a plat sur le tableau comparatif (idx precedent), **Bayesian (custom)** atteint le meilleur score (0.9626) dans le temps le plus court (43.9 s, 50 evaluations), tandis que **PSO** est la plus lente (247.9 s pour 100 evaluations) et reste sur un score legerement inferieur (0.9604). La ""convergence rapide"" est donc ici l'atout de l'optimisation bayesienne, pas de PSO
-- **Recommandation** : utiliser la visualisation pour identifier quelle methode convient a votre probleme specifique
+- **Meilleurs points** : toutes les méthodes tendent a trouver des solutions dans des regions similaires
+- **Convergence** : a plat sur le tableau comparatif (idx précédent), **Bayesian (custom)** atteint le meilleur score (0.9626) dans le temps le plus court (43.9 s, 50 evaluations), tandis que **PSO** est la plus lente (247.9 s pour 100 evaluations) et reste sur un score legerement inferieur (0.9604). La ""convergence rapide"" est donc ici l'atout de l'optimisation bayesienne, pas de PSO
+- **Recommandation** : utiliser la visualisation pour identifier quelle méthode convient a votre problème spécifique
 
-**Poursuite** : testez d'autres combinaisons de parametres (n_estimators, max_depth) pour voir comment la performance varie a travers l'espace.",,,,,,,,8badcc2caee9f823,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,4f321f68,markdown,fr,b26b3a9eabda94f7,"## 8. Recommandations et Bonnes Pratiques
+**Poursuite** : testez d'autres combinaisons de paramètres (n_estimators, max_depth) pour voir comment la performance varie a travers l'espace.",,,,,,,,26fe91280c2202db,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,4f321f68,markdown,fr,f1e6864422655d91,"## 8. Recommandations et Bonnes Pratiques
 
-### Quand utiliser chaque methode?
+### Quand utiliser chaque méthode?
 
-| Methode | Quand l'utiliser |
+| Méthode | Quand l'utiliser |
 |---------|------------------|
 | **Random Search** | Baseline, premier passage, parallelisation facile |
 | **Bayesienne** | Peu d'evaluations possibles, fonction couteuse, mono-objectif |
 | **GA** | Espace complexe, multi-modal, multi-objectif, parallelisation GPU |
 | **PSO** | Espace continu, bonne convergence, facile a implementer |
-| **Grid Search** | Peu de dimensions, comprehension du probleme, reproductibilite |
+| **Grid Search** | Peu de dimensions, comprehension du problème, reproductibilite |
 
 ### Conseils pratiques
 
@@ -26227,8 +26227,8 @@ MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,4
 2. **Utiliser l'optimisation bayesienne** pour le tuning fin
 3. **Paralleliser** quand possible (GA, PSO)
 4. **Fixer le random seed** pour reproductibilite
-5. **Logger toutes les evaluations** pour analyse posterieure",,,,,,,,b26b3a9eabda94f7,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,673d848e,markdown,fr,3c6c5464b8c832bd,"## 9. Exercices
+5. **Logger toutes les evaluations** pour analyse posterieure",,,,,,,,f1e6864422655d91,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,673d848e,markdown,fr,5fba0af44335ffa4,"## 9. Exercices
 
 ### Exercice 1: Multi-objectif
 
@@ -26236,7 +26236,7 @@ Modifiez le code pour optimiser simultanement l'accuracy et le temps d'entrainem
 
 ### Exercice 2: Early Stopping
 
-Implementez un mecanisme de early stopping pour arreter l'evaluation des configurations peu prometteuses.
+Implementez un mécanisme de early stopping pour arreter l'evaluation des configurations peu prometteuses.
 
 ### Exercice 3: Transfer Learning
 
@@ -26244,49 +26244,49 @@ Comment reutiliser les observations d'un dataset pour accelerer l'optimisation s
 
 ### Exercice 4: Parallelisation
 
-Parallelisez l'evaluation des particules PSO avec `multiprocessing` ou `joblib`.",,,,,,,,3c6c5464b8c832bd,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,e8274f83,markdown,fr,76241aa9723a7fea,"## Conclusion
+Parallelisez l'evaluation des particules PSO avec `multiprocessing` ou `joblib`.",,,,,,,,5fba0af44335ffa4,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb,e8274f83,markdown,fr,51ada953e84df4fb,"## Conclusion
 
-Dans ce notebook, nous avons explore cinq methodes d'optimisation d'hyperparametres:
+Dans ce notebook, nous avons explore cinq méthodes d'optimisation d'hyperparametres:
 
-1. **Grid Search** - Methode exhaustive mais couteuse
+1. **Grid Search** - Méthode exhaustive mais couteuse
 2. **Random Search** - Simple et souvent surprenante efficace
 3. **Optimisation Bayesienne** - Efficace pour les fonctions couteuses
-4. **Algorithmes Genetiques** - Excellente exploration, population-based
+4. **Algorithmes Génétiques** - Excellente exploration, population-based
 5. **PSO** - Convergence rapide sur espaces continus
 
 ### Points cles a retenir
 
 - Le **Random Search** est souvent un excellent point de depart
 - L'**optimisation bayesienne** excelle quand les evaluations sont limites
-- Les **metaheuristiques** (GA, PSO) sont adaptees aux problemes complexes
+- Les **métaheuristiques** (GA, PSO) sont adaptees aux problemes complexes
 - La **parallelisation** peut grandement accelerer le processus
-- Il n'y a pas de methode universelle: **adapter au probleme**",,,,,,,,76241aa9723a7fea,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb,47e4092d,markdown,fr,f6236724a66b9b6e,"# App-18b : Optimisation d'Hyperparametres - Jumeau C#
+- Il n'y a pas de méthode universelle: **adapter au problème**",,,,,,,,51ada953e84df4fb,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb,47e4092d,markdown,fr,1792d10d8b0cdbe1,"# App-18b : Optimisation d'Hyperparametres - Jumeau C#
 
 > **Twin C#** de [`App-18-HyperparameterTuning`](App-18-HyperparameterTuning.ipynb) (Python / scikit-learn + Optuna). Navigation : [<< App-17b VRP](App-17b-VRP-Logistics-Csharp.ipynb) | [Index](../../README.md) | [App-19 WFC >>](../CSP/App-19-ProceduralGeneration-WFC-Csharp.ipynb)
 
 ## Objectif pedagogique
 
-Le notebook Python App-18 optimise les hyperparametres d'un **Random Forest** (scikit-learn) via cinq methodes : **Grid Search**, **Random Search**, **Bayesian Optimization** (Gaussian Process + Expected Improvement), **Genetic Algorithm** et **PSO**.
+Le notebook Python App-18 optimise les hyperparametres d'un **Random Forest** (scikit-learn) via cinq méthodes : **Grid Search**, **Random Search**, **Bayesian Optimization** (Gaussian Process + Expected Improvement), **Genetic Algorithm** et **PSO**.
 
-Ce jumeau C# reprend **la meme structure pedagogique** en **pur BCL .NET 9 (from-scratch, 0 NuGet)** :
-- le modele tune est un **k-NN from-scratch** (a la place du RandomForest sklearn) ;
-- l'**objectif** est la precision en validation croisee 5-fold sur un jeu de donnees synthetique deterministe ;
-- les cinq methodes d'optimisation sont reimplementees **from-scratch**, avec en vedette la **Bayesian Optimization (GP RBF + Expected Improvement)** - absente de [`Search-11-Metaheuristics`](../../Part1-Foundations/Search-11-Metaheuristics.ipynb) qui se concentrait sur PSO/SA/GA pour l'optimisation continue de fonctions-benchmark peu couteuses.
+Ce jumeau C# reprend **la même structure pedagogique** en **pur BCL .NET 9 (from-scratch, 0 NuGet)** :
+- le modèle tune est un **k-NN from-scratch** (a la place du RandomForest sklearn) ;
+- l'**objectif** est la precision en validation croisee 5-fold sur un jeu de données synthetique déterministe ;
+- les cinq méthodes d'optimisation sont reimplementees **from-scratch**, avec en vedette la **Bayesian Optimization (GP RBF + Expected Improvement)** - absente de [`Search-11-Metaheuristics`](../../Part1-Foundations/Search-11-Metaheuristics.ipynb) qui se concentrait sur PSO/SA/GA pour l'optimisation continue de fonctions-benchmark peu couteuses.
 
 > **Pourquoi Bayesian Optimization ici ?** L'optimisation d'hyperparametres est un cas canonique d'**optimisation boite-noire couteuse** : chaque evaluation = une CV complete (des milliers de calculs), et le budget d'evaluations est limite. C'est exactement le regime ou un *surrogate* probabiliste (Gaussian Process) + une fonction d'acquisition (EI/UCB) **surpassent** Grid/Random Search. La comparaison des courbes de convergence (section 8) le demontre.
 
-**Parite .NET / Python** (Epic [#4956](https://github.com/jsboige/CoursIA/issues/4956)) : les ancres deterministes (precision des configurations de reference, trajectoires de convergence) sont reproduites a l'identique dans les deux langues par construction (RNG a graine fixee, pas de derive).
-",,,,,,,,f6236724a66b9b6e,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb,87ca09dc,markdown,fr,e098c5b8a77286d7,"## 1. Configuration et jeu de donnees
+**Parite .NET / Python** (Epic [#4956](https://github.com/jsboige/CoursIA/issues/4956)) : les ancres déterministes (precision des configurations de reference, trajectoires de convergence) sont reproduites a l'identique dans les deux langues par construction (RNG a graine fixee, pas de derive).
+",,,,,,,,1792d10d8b0cdbe1,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb,87ca09dc,markdown,fr,a16605f92b55cb0c,"## 1. Configuration et jeu de données
 
-Nous generons un jeu de donnees de **classification binaire 2D** deterministe (deux amas gaussiens chevauchants, pour que la precision du k-NN depende sensiblement des hyperparametres). Un generateur pseudo-aleatoire **LCG a graine fixee** garantit la reproductibilite bit-par-bit des ancres committes.
+Nous generons un jeu de données de **classification binaire 2D** déterministe (deux amas gaussiens chevauchants, pour que la precision du k-NN depende sensiblement des hyperparametres). Un générateur pseudo-aleatoire **LCG a graine fixee** garantit la reproductibilite bit-par-bit des ancres committes.
 
 L'espace de recherche (continu `[0,1]^3`, projete sur les hyperparametres reels) :
 - `k` dans [1, 50] (nombre de voisins, arrondi a l'impair le plus proche) ;
 - `distancePower` dans [1, 4] (distance de Minkowski generalisee) ;
-- `weightBlend` dans [0, 1] (melange entre vote uniforme et vote pondere par l'inverse de la distance).",,,,,,,,e098c5b8a77286d7,,,,,,,
+- `weightBlend` dans [0, 1] (melange entre vote uniforme et vote pondere par l'inverse de la distance).",,,,,,,,a16605f92b55cb0c,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb,c3b86b54,code,fr,b39f5a1c6c1b903a,"using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -26319,14 +26319,14 @@ Show($""Jeu de donnees : {N} points, 2 classes, 2 features."");
 Show($""Classe 0 : {y.Count(v => v == 0)} points | Classe 1 : {y.Count(v => v == 1)} points."");
 Show($""Plage X1 : [{X.Select(p => p[0]).Min():F2}, {X.Select(p => p[0]).Max():F2}]  X2 : [{X.Select(p => p[1]).Min():F2}, {X.Select(p => p[1]).Max():F2}]"");
 ",,,,,,,,b39f5a1c6c1b903a,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb,881c2ccb,markdown,fr,de2af7d75c88bf1c,"## 2. Modele cible : k-NN from-scratch et objectif (CV 5-fold)
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb,881c2ccb,markdown,fr,56e0b5bf514ba2f5,"## 2. Modèle cible : k-NN from-scratch et objectif (CV 5-fold)
 
-Le k-NN est le modele le plus simple a implementer from-scratch et suffit a definir un objectif **reel** (precision de classification) que les cinq optimiseurs chercheront a maximiser. On implemente :
+Le k-NN est le modèle le plus simple a implementer from-scratch et suffit a définir un objectif **reel** (precision de classification) que les cinq optimiseurs chercheront a maximiser. On implemente :
 - une distance de Minkowski generalisee `(|dx|^p + |dy|^p)^(1/p)` ;
 - un vote a `k` voisins, blend uniforme / pondere par l'inverse de la distance ;
-- une validation croisee **5-fold** (decoupe indexee deterministe) qui renvoie la precision moyenne - c'est notre `Objective(p)`.
+- une validation croisee **5-fold** (decoupe indexee déterministe) qui renvoie la precision moyenne - c'est notre `Objective(p)`.
 
-L'objective est expose comme un **delegue** `Func<double[], double>` capture les donnees : les cinq optimiseurs (tous `static`) le recoivent en parametre (pattern des jumeaux C# - methodes statiques pures, etat passe en argument, cf [`App-13b-TSP`](App-13b-TSP-Metaheuristics-CSharp.ipynb)).",,,,,,,,de2af7d75c88bf1c,,,,,,,
+L'objective est expose comme un **delegue** `Func<double[], double>` capture les données : les cinq optimiseurs (tous `static`) le recoivent en paramètre (pattern des jumeaux C# - méthodes statiques pures, etat passe en argument, cf [`App-13b-TSP`](App-13b-TSP-Metaheuristics-CSharp.ipynb)).",,,,,,,,56e0b5bf514ba2f5,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb,cdcf123e,code,fr,998798cc0e69af4a,"// --- k-NN from-scratch + objectif (CV 5-fold) ---
 static double Minkowski(double[] a, double[] b, double p) {
     double s = 0;
@@ -26375,9 +26375,9 @@ Show($""Objectif [k~11, p=2 Euclidien, blend=0]    = {FI(Objective(new[] { 0.20,
 Show($""Objectif [k~11, p=2 Euclidien, blend=1]    = {FI(Objective(new[] { 0.20, 0.33, 1.0 }))}"");
 Show($""Objectif [k~1,  p=1 Manhattan,  blend=0.5] = {FI(Objective(new[] { 0.00, 0.00, 0.5 }))}"");
 ",,,,,,,,998798cc0e69af4a,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb,7d5fd4d4,markdown,fr,e875800c3cf3a13d,"## 3. Methode de reference - Grid Search
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb,7d5fd4d4,markdown,fr,ddc1e966637c4f37,"## 3. Méthode de reference - Grid Search
 
-**Principe** : explorer systematiquement un sous-ensemble de combinaisons de l'espace. Exhaustif mais **exponentiel** : 5 valeurs par dimension x 3 dimensions = 125 evals (chacune = une CV 5-fold complete). Sert de **plancher de reference** (meilleur atteignable sur la grille).",,,,,,,,e875800c3cf3a13d,,,,,,,
+**Principe** : explorer systematiquement un sous-ensemble de combinaisons de l'espace. Exhaustif mais **exponentiel** : 5 valeurs par dimension x 3 dimensions = 125 evals (chacune = une CV 5-fold complete). Sert de **plancher de reference** (meilleur atteignable sur la grille).",,,,,,,,ddc1e966637c4f37,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb,17b57f93,code,fr,19dd2fcbcf66a633,"// --- Grid Search (static, prend l'objectif en parametre) ---
 static (double[] best, double bestVal, List<double> hist) GridSearch(Func<double[], double> obj, int ptsPerDim = 5) {
     double[] best = null; double bestVal = double.NegativeInfinity;
@@ -26398,9 +26398,9 @@ double[] gridBest = gridRes.best; double gridVal = gridRes.bestVal; List<double>
 Show($""Grid Search (125 evals) : best accuracy = {FI(gridVal)}"");
 Show($""  -> p = [{FI(gridBest[0], ""F3"")}, {FI(gridBest[1], ""F3"")}, {FI(gridBest[2], ""F3"")}]"");
 ",,,,,,,,19dd2fcbcf66a633,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb,b3d053df,markdown,fr,eaa4876567c155b7,"## 4. Methode de reference - Random Search
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb,b3d053df,markdown,fr,3c8e26db275cb9a3,"## 4. Méthode de reference - Random Search
 
-**Principe** (Bergstra & Bengio, 2012) : echantillonner uniformement dans l'espace. Contre-intuitivement, **aussi efficace que Grid Search** a budget egal sur les problemes ou peu de dimensions comptent vraiment. Reference de complexite lineaire.",,,,,,,,eaa4876567c155b7,,,,,,,
+**Principe** (Bergstra & Bengio, 2012) : echantillonner uniformement dans l'espace. Contre-intuitivement, **aussi efficace que Grid Search** a budget egal sur les problemes ou peu de dimensions comptent vraiment. Reference de complexite lineaire.",,,,,,,,3c8e26db275cb9a3,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb,f4d6b6ba,code,fr,9e7708383298f898,"// --- Random Search ---
 static (double[] best, double bestVal, List<double> hist) RandomSearch(Func<double[], double> obj, int nIter, uint seed) {
     RngReset(seed);
@@ -26420,24 +26420,24 @@ double[] randBest = randRes.best; double randVal = randRes.bestVal; List<double>
 Show($""Random Search (60 evals) : best accuracy = {FI(randVal)}"");
 Show($""  -> p = [{FI(randBest[0], ""F3"")}, {FI(randBest[1], ""F3"")}, {FI(randBest[2], ""F3"")}]"");
 ",,,,,,,,9e7708383298f898,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb,ed2df85e,markdown,fr,4f19174e749ffcb7,"### Exercice 1 : Vitesse de convergence
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb,ed2df85e,markdown,fr,9ab3c8903db18188,"### Exercice 1 : Vitesse de convergence
 
-Ecrire `IterationsToThreshold(history, fraction)` qui retourne le **nombre d'evaluations** necessaires pour atteindre `fraction x optimum_final` de la meilleure precision trouvee. Permet de quantifier la **vitesse d'amelioration** de chaque methode.
+Ecrire `IterationsToThreshold(history, fraction)` qui retourne le **nombre d'evaluations** necessaires pour atteindre `fraction x optimum_final` de la meilleure precision trouvee. Permet de quantifier la **vitesse d'amelioration** de chaque méthode.
 
-- Etape 1 : parcourir l'historique des meilleures precisions (best-so-far).
-- Etape 2 : renvoyer le premier index ou best-so-far >= fraction x best_final.",,,,,,,,4f19174e749ffcb7,,,,,,,
+- Étape 1 : parcourir l'historique des meilleures precisions (best-so-far).
+- Étape 2 : renvoyer le premier index ou best-so-far >= fraction x best_final.",,,,,,,,9ab3c8903db18188,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb,da16300f,code,fr,490a559c0e310436,"// Exercice 1 : Vitesse de convergence (IterationsToThreshold)
 // Etape 1 : parcourir l'historique best-so-far.
 // Etape 2 : renvoyer le premier index ou best-so-far >= fraction * best_final.
 Show(""Exercice 1 a completer - IterationsToThreshold(history, fraction)."");
 ",,,,,,,,490a559c0e310436,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb,5d8c317c,markdown,fr,032564758e13c7f4,"## 5. Vedette - Bayesian Optimization (Gaussian Process + Expected Improvement)
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb,5d8c317c,markdown,fr,465d01af0930af8c,"## 5. Vedette - Bayesian Optimization (Gaussian Process + Expected Improvement)
 
 **Principe** : modeliser la fonction-objectif couteuse par un **surrogate** probabiliste - un **Gaussian Process** a noyau RBF - qui donne, en tout point, une **prediction** (moyenne `mu`) ET une **incertitude** (`sigma`). On choisit le prochain point a evaluer en **maximisant une fonction d'acquisition** :
 
 - **Expected Improvement (EI)** : esperance de l'amelioration par rapport au meilleur observe. Equilibre *exploitation* (mu eleve) et *exploration* (sigma eleve).
 
-C'est la **cle de l'efficacite-echantillons** : la ou Grid/Random gaspillent des evals dans des regions sans interet, le GP oriente le budget vers les regions prometteuses **ou incertaines**.
+C'est la **cle de l'efficacite-echantillons** : la ou Grid/Random gaspillent des evals dans des regions sans intérêt, le GP oriente le budget vers les regions prometteuses **ou incertaines**.
 
 ### Implementation from-scratch
 
@@ -26446,7 +26446,7 @@ C'est la **cle de l'efficacite-echantillons** : la ou Grid/Random gaspillent des
 - **Predict** : `mu = k_star . alpha` ; `sig^2 = sigma^2 - k_star . (K^{-1} k_star)`.
 - **EI** : `(mu - f_best - xi) * Phi(Z) + sig * phi(Z)` avec `Z = (mu - f_best - xi)/sig`.
 
-Tout le GP est encapsule en **fonctions locales** capturant l'etat (listes `gpX`, `gpy`, hyperparams) - aucun champ static, entièrement self-contained.",,,,,,,,032564758e13c7f4,,,,,,,
+Tout le GP est encapsule en **fonctions locales** capturant l'etat (listes `gpX`, `gpy`, hyperparams) - aucun champ static, entièrement self-contained.",,,,,,,,465d01af0930af8c,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb,1c3f52e9,code,fr,9986c0b7b7e5429b,"// === Bayesian Optimization : Gaussian Process (RBF) + Expected Improvement ===
 // helpers loi normale (purs, static)
 static double phi(double z) => Math.Exp(-0.5 * z * z) / Math.Sqrt(2 * Math.PI);
@@ -26524,20 +26524,20 @@ double[] bayesBest = bayesRes.best; double bayesVal = bayesRes.bestVal; List<dou
 Show($""Bayesian Optimization (5+25 = 30 evals) : best accuracy = {FI(bayesVal)}"");
 Show($""  -> p = [{FI(bayesBest[0], ""F3"")}, {FI(bayesBest[1], ""F3"")}, {FI(bayesBest[2], ""F3"")}]"");
 ",,,,,,,,9986c0b7b7e5429b,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb,3ee3bbcc,markdown,fr,13240c7b4b019654,"### Exercice 2 : Fonction d'acquisition UCB (Upper Confidence Bound)
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb,3ee3bbcc,markdown,fr,61b7fe2829b0ec6f,"### Exercice 2 : Fonction d'acquisition UCB (Upper Confidence Bound)
 
 Le BayesianOptimizer ci-dessus utilise **Expected Improvement**. Implementer l'acquisition **UCB** complementaire, plus exploration-agressive :
 
-- Etape 1 : `UCB(x) = mu(x) + kappa * sig(x)` (favorise l'incertitude pour `kappa` grand).
-- Etape 2 : comparer la trajectoire de convergence EI vs UCB sur le meme budget.",,,,,,,,13240c7b4b019654,,,,,,,
+- Étape 1 : `UCB(x) = mu(x) + kappa * sig(x)` (favorise l'incertitude pour `kappa` grand).
+- Étape 2 : comparer la trajectoire de convergence EI vs UCB sur le même budget.",,,,,,,,61b7fe2829b0ec6f,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb,ab701ad6,code,fr,c9abcb100963bd8f,"// Exercice 2 : acquisition UCB (Upper Confidence Bound)
 // Etape 1 : UCB(x) = mu(x) + kappa * sig(x)  (mu et sig via GpPredict).
 // Etape 2 : comparer la trajectoire EI vs UCB sur le meme budget.
 Show(""Exercice 2 a completer - UCB(x, kappa) = mu(x) + kappa*sig(x)."");
 ",,,,,,,,c9abcb100963bd8f,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb,bd130bda,markdown,fr,a242a72387eb7adc,"## 6. Algorithme Genetique (GA)
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb,bd130bda,markdown,fr,72b9906266555955,"## 6. Algorithme Génétique (GA)
 
-**Principe** : faire evoluer une **population** de configurations via selection (tournoi), croisement (arithmetique), mutation (gaussienne decroissante) et elitisme. Particulierement adapte aux espaces mixtes/discrets - ici l'espace continu `[0,1]^3` projete.",,,,,,,,a242a72387eb7adc,,,,,,,
+**Principe** : faire evoluer une **population** de configurations via sélection (tournoi), croisement (arithmetique), mutation (gaussienne decroissante) et elitisme. Particulierement adapte aux espaces mixtes/discrets - ici l'espace continu `[0,1]^3` projete.",,,,,,,,72b9906266555955,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb,0d26b0a0,code,fr,580bd1b580a42e20,"// === Genetic Algorithm ===
 static (double[] best, double bestVal, List<double> hist) GeneticOpt(Func<double[], double> obj, int popSize, int nGen, uint seed) {
     RngReset(seed);
@@ -26574,13 +26574,13 @@ double[] gaBest = gaRes.best; double gaVal = gaRes.bestVal; List<double> gaHist 
 Show($""Genetic Algorithm (71 evals) : best accuracy = {FI(gaVal)}"");
 Show($""  -> p = [{FI(gaBest[0], ""F3"")}, {FI(gaBest[1], ""F3"")}, {FI(gaBest[2], ""F3"")}]"");
 ",,,,,,,,580bd1b580a42e20,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb,b287c9fa,markdown,fr,6fc2f7fae724e33e,"### Exercice 3 : Diversite d'une population genetique
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb,b287c9fa,markdown,fr,35f6e985613a469d,"### Exercice 3 : Diversite d'une population génétique
 
 Une population trop homogene signifie que l'algorithme a converge prematurement. Implementer `PopulationDiversity(pop)` :
 
-- Etape 1 : calculer le barycentre de la population.
-- Etape 2 : sommer les distances moyennes au barycentre (mesure de dispersion).
-- Etape 3 : surveiller cette diversite au fil des generations.",,,,,,,,6fc2f7fae724e33e,,,,,,,
+- Étape 1 : calculer le barycentre de la population.
+- Étape 2 : sommer les distances moyennes au barycentre (mesure de dispersion).
+- Étape 3 : surveiller cette diversite au fil des generations.",,,,,,,,35f6e985613a469d,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb,39a2acf3,code,fr,4e91bcedeaaa01e6,"// Exercice 3 : Diversite d'une population genetique
 // Etape 1 : barycentre de la population.
 // Etape 2 : somme des distances moyennes au barycentre (dispersion).
@@ -26626,11 +26626,11 @@ double[] psoBest = psoRes.best; double psoVal = psoRes.bestVal; List<double> pso
 Show($""PSO (72 evals) : best accuracy = {FI(psoVal)}"");
 Show($""  -> p = [{FI(psoBest[0], ""F3"")}, {FI(psoBest[1], ""F3"")}, {FI(psoBest[2], ""F3"")}]"");
 ",,,,,,,,4cdbc9be324c5364,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb,bed2b341,markdown,fr,d6289003c60943a9,"## 8. Comparaison des methodes
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb,bed2b341,markdown,fr,8d464f4651b54256,"## 8. Comparaison des méthodes
 
 On compare les **courbes de convergence** (meilleure precision observee en fonction du nombre d'evaluations) et le tableau recapitulatif.
 
-**Lecture attendue** : la Bayesian Optimization atteint le meme optimum que la Grid Search **avec ~4x moins d'evaluations** (30 vs 125) - c'est sa propriete-cle, l'efficacite-echantillons. Sur ce petit probleme 3D peu couteux, les cinq methodes se rapprochent toutes de ~0.90-0.91 : c'est **attendu** (Random Search est un excellent plancher sur petite dimension), et l'ecart de Bayes se creuse **quand le cout par evaluation et la dimension augmentent** - exactement le regime du tuning d'un gros modele (RandomForest, XGBoost, reseaux de neurones), cas d'usage canonique d'Optuna/Ax/scikit-optimize.",,,,,,,,d6289003c60943a9,,,,,,,
+**Lecture attendue** : la Bayesian Optimization atteint le même optimum que la Grid Search **avec ~4x moins d'evaluations** (30 vs 125) - c'est sa propriete-cle, l'efficacite-echantillons. Sur ce petit problème 3D peu couteux, les cinq méthodes se rapprochent toutes de ~0.90-0.91 : c'est **attendu** (Random Search est un excellent plancher sur petite dimension), et l'ecart de Bayes se creuse **quand le cout par evaluation et la dimension augmentent** - exactement le regime du tuning d'un gros modèle (RandomForest, XGBoost, reseaux de neurones), cas d'usage canonique d'Optuna/Ax/scikit-optimize.",,,,,,,,8d464f4651b54256,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb,24ed81d1,code,fr,ad184d9a3817ac7e,"// === Comparaison : courbes de convergence + tableau recapitulatif ===
 static string Sparkline(List<double> hist, int width = 30) {
     double lo = hist.Min(), hi = hist.Max();
@@ -26686,78 +26686,78 @@ for (int r = 0; r < rows; r++) {
 }
 Show(""Regions @ = haute precision (objectif maximise). Les methodes adapatives (Bayes/GA/PSO) y convergent plus vite que Grid."");
 ",,,,,,,,aaa63c36bd19273c,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb,dcafe266,markdown,fr,38d03f89ab03f29d,"## 10. Recommandations et bonnes pratiques
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb,dcafe266,markdown,fr,8180e8f63a26640e,"## 10. Recommandations et bonnes pratiques
 
-| Methode | Quand l'utiliser | Cout | Echantillons-efficacite |
+| Méthode | Quand l'utiliser | Cout | Echantillons-efficacite |
 |---------|------------------|------|--------------------------|
 | Grid Search | Espace petit, dimensions connues-cles | Eleve (exponentiel) | Faible |
 | Random Search | Espace modere, budget limite | Lineaire | Moyenne |
-| Bayesian Opt | Evals couteuses, budget tres limite | Eleve par eval | **Elevee** |
+| Bayesian Opt | Evals couteuses, budget très limite | Eleve par eval | **Elevee** |
 | GA | Espace mixte/discret, parallelisme | Modere | Moyenne |
 | PSO | Espace continu, multi-modal | Modere | Moyenne |
 
 **Lecons** :
 1. **Bayesian Opt** est le choix canon pour l'HPO moderne (Optuna, Ax, scikit-optimize reposent la-dessus).
-2. **Random Search** est un plancher tres solide - ne jamais faire pire sans raison.
-3. La **dimension effective** du probleme (combien d'hyperparametres comptent vraiment) dicte le choix.",,,,,,,,38d03f89ab03f29d,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb,8ffab7d8,markdown,fr,23fb6baff4e5ab79,"## Conclusion
+2. **Random Search** est un plancher très solide - ne jamais faire pire sans raison.
+3. La **dimension effective** du problème (combien d'hyperparametres comptent vraiment) dicte le choix.",,,,,,,,8180e8f63a26640e,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb,8ffab7d8,markdown,fr,6ab1d63818845690,"## Conclusion
 
-Ce jumeau C# a reimplemente from-scratch les **cinq methodes** d'optimisation d'hyperparametres du notebook Python App-18, en remplacant le RandomForest sklearn par un **k-NN from-scratch** (objectif = CV 5-fold). La **Bayesian Optimization (GP RBF + Expected Improvement)** est la valeur ajoutee centrale : elle atteint l'optimum de la Grid Search avec ~4x moins d'evaluations, illustrant comment un *surrogate* probabiliste rend l'optimisation **efficace en nombre d'evaluations** - la propriete qui la rend standard pour le tuning de modeles couteux.
+Ce jumeau C# a reimplemente from-scratch les **cinq méthodes** d'optimisation d'hyperparametres du notebook Python App-18, en remplacant le RandomForest sklearn par un **k-NN from-scratch** (objectif = CV 5-fold). La **Bayesian Optimization (GP RBF + Expected Improvement)** est la valeur ajoutee centrale : elle atteint l'optimum de la Grid Search avec ~4x moins d'evaluations, illustrant comment un *surrogate* probabiliste rend l'optimisation **efficace en nombre d'evaluations** - la propriete qui la rend standard pour le tuning de modèles couteux.
 
-Sur ce petit probleme 3D, les methodes sont proches (Random Search est un excellent plancher) ; l'avantage de Bayes se creuse quand la **dimension** et le **cout par evaluation** augmentent - d'ou son statut de methode canonique pour les gros modeles (Optuna, Ax, scikit-optimize).
+Sur ce petit problème 3D, les méthodes sont proches (Random Search est un excellent plancher) ; l'avantage de Bayes se creuse quand la **dimension** et le **cout par evaluation** augmentent - d'ou son statut de méthode canonique pour les gros modèles (Optuna, Ax, scikit-optimize).
 
-**Parite avec Search-11** : PSO et GA apparaissent dans les deux notebooks, mais dans des **contextes differents** - Search-11 optimisait des **fonctions-benchmark analytiques** peu couteuses (Sphere, Rastrigin) ; ici ils optimisent un **objectif boite-noire couteux** (CV d'un modele), ou la Bayesian Optimization prend tout son sens.
+**Parite avec Search-11** : PSO et GA apparaissent dans les deux notebooks, mais dans des **contextes différents** - Search-11 optimisait des **fonctions-benchmark analytiques** peu couteuses (Sphere, Rastrigin) ; ici ils optimisent un **objectif boite-noire couteux** (CV d'un modèle), ou la Bayesian Optimization prend tout son sens.
 
-Lien epic : [#4956](https://github.com/jsboige/CoursIA/issues/4956) (parite .NET / Python).",,,,,,,,23fb6baff4e5ab79,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb,ea0986eb,markdown,fr,1abf7e360fe41142,"## 12. Exercices (recapitulatif)
+Lien epic : [#4956](https://github.com/jsboige/CoursIA/issues/4956) (parite .NET / Python).",,,,,,,,6ab1d63818845690,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb,ea0986eb,markdown,fr,1dab21d1d0d5a3d0,"## 12. Exercices (recapitulatif)
 
 1. **Multi-objectif** : modifier l'objectif pour maximiser `accuracy - lambda * complexity` (penaliser les grands `k`).
 2. **Acquisition UCB** : comparer EI vs UCB (voir Exercice 2).
-3. **Espace mixte** : ajouter un hyperparametre categoriel (methode de distance) et adapter le croisement GA.",,,,,,,,1abf7e360fe41142,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,nav-header,markdown,fr,4df3b53052d94d1a,"# App-9 : Detection de bords par algorithmes genetiques
+3. **Espace mixte** : ajouter un hyperparametre categoriel (méthode de distance) et adapter le croisement GA.",,,,,,,,1dab21d1d0d5a3d0,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,nav-header,markdown,fr,6cb7aed27d53348f,"# App-9 : Detection de bords par algorithmes génétiques
 
 **Navigation** : [<< App-8 MiniZinc](../CSP/App-8-MiniZinc.ipynb) | [Index](../../README.md) | [App-10 Portfolio >>](../Hybrid/App-10-Portfolio.ipynb)
 
 ## Objectifs d'apprentissage
 
 A la fin de ce notebook, vous saurez :
-1. **Comprendre** le principe de la detection de bords par filtres de convolution (Sobel, Prewitt, Laplacien)
-2. **Encoder** un filtre de convolution comme chromosome pour un algorithme genetique
-3. **Implementer** l'evolution de filtres avec PyGAD et DEAP
+1. **Comprendre** le principe de la detection de bords par filtrès de convolution (Sobel, Prewitt, Laplacien)
+2. **Encoder** un filtre de convolution comme chromosome pour un algorithme génétique
+3. **Implementer** l'evolution de filtrès avec PyGAD et DEAP
 4. **Comparer** les deux frameworks en termes d'API, convergence et performances
-5. **Analyser** la qualite des filtres evolues par rapport aux references classiques
+5. **Analyser** la qualite des filtrès evolues par rapport aux références classiques
 
 ### Prerequis
 - Python 3.10+
-- [Search-5 : Algorithmes Genetiques](../../Part1-Foundations/Search-5-GeneticAlgorithms.ipynb) (concepts GA : selection, crossover, mutation, fitness)
+- [Search-5 : Algorithmes Génétiques](../../Part1-Foundations/Search-5-GeneticAlgorithms.ipynb) (concepts GA : sélection, crossover, mutation, fitness)
 - Notions de base en traitement d'image (convolution)
 
 ### Duree estimee : 40 minutes
 
-> **Side track** : Voir [App-9b C#](App-9b-EdgeDetection-CSharp.ipynb) pour la version GeneticSharp en .NET.",,,,,,,,4df3b53052d94d1a,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,section-1-intro,markdown,fr,2b6d06913201e636,"## 1. Introduction : detection de bords et filtres de convolution
+> **Side track** : Voir [App-9b C#](App-9b-EdgeDetection-CSharp.ipynb) pour la version GeneticSharp en .NET.",,,,,,,,6cb7aed27d53348f,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,section-1-intro,markdown,fr,8ee1e57462fc3194,"## 1. Introduction : detection de bords et filtrès de convolution
 
 ### Pourquoi detecter les bords ?
 
-La **detection de bords** (edge detection) est l'une des operations fondamentales en vision par ordinateur. Elle permet d'extraire les contours des objets dans une image, ce qui est essentiel pour :
+La **detection de bords** (edge detection) est l'une des opérations fondamentales en vision par ordinateur. Elle permet d'extraire les contours des objets dans une image, ce qui est essentiel pour :
 
 | Application | Utilisation des bords |
 |-------------|----------------------|
-| Segmentation d'image | Delimiter les regions d'interet |
-| Reconnaissance d'objets | Extraire des formes caracteristiques |
+| Segmentation d'image | Delimiter les regions d'intérêt |
+| Reconnaissance d'objets | Extraire des formes caractéristiques |
 | Imagerie medicale | Detecter les contours d'organes ou de tumeurs |
 | Conduite autonome | Identifier les voies, panneaux et obstacles |
-| OCR | Isoler les caracteres du fond |
+| OCR | Isoler les caractères du fond |
 
-### Filtres de convolution classiques
+### Filtrès de convolution classiques
 
-Un **filtre de convolution** (ou noyau) est une petite matrice de coefficients que l'on fait glisser sur l'image. A chaque position, on calcule la somme ponderee des pixels voisins :
+Un **filtre de convolution** (ou noyau) est une petite matrice de coefficients que l'on fait glisser sur l'image. A chaque position, on calcule la somme pondérée des pixels voisins :
 
 $$G(x,y) = \sum_{i=-k}^{k} \sum_{j=-k}^{k} K(i,j) \cdot I(x+i, y+j)$$
 
 ou $K$ est le noyau de taille $(2k+1) \times (2k+1)$ et $I$ est l'image.
 
-Les filtres classiques de detection de bords sont :
+Les filtrès classiques de detection de bords sont :
 
 | Filtre | Noyau (direction X) | Propriete |
 |--------|--------------------|-----------|
@@ -26767,20 +26767,20 @@ Les filtres classiques de detection de bords sont :
 
 ### Peut-on *apprendre* un filtre automatiquement ?
 
-Plutot que de concevoir manuellement ces filtres, nous allons utiliser un **algorithme genetique** pour faire evoluer automatiquement les coefficients d'un noyau de convolution. L'objectif : approximer le filtre de Sobel a partir de zero, en ne connaissant que le resultat attendu.
+Plutot que de concevoir manuellement ces filtrès, nous allons utiliser un **algorithme génétique** pour faire evoluer automatiquement les coefficients d'un noyau de convolution. L'objectif : approximer le filtre de Sobel a partir de zero, en ne connaissant que le résultat attendu.
 
-Cette approche illustre un concept fondamental de l'optimisation : la capacite a decouvrir des solutions dans un espace de recherche vaste ($[-20, 20]^{49}$ pour un noyau 7x7) sans connaissance *a priori* de la structure de la solution.",,,,,,,,2b6d06913201e636,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,section-2-setup-intro,markdown,fr,9782832d925c7ac2,"## 2. Configuration et filtre de reference
+Cette approche illustre un concept fondamental de l'optimisation : la capacite a decouvrir des solutions dans un espace de recherche vaste ($[-20, 20]^{49}$ pour un noyau 7x7) sans connaissance *a priori* de la structure de la solution.",,,,,,,,8ee1e57462fc3194,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,section-2-setup-intro,markdown,fr,72020e4217d81775,"## 2. Configuration et filtre de référence
 
 Nous allons d'abord preparer notre environnement :
 1. Installer les dependances
-2. Creer une image synthetique avec des bords bien definis
-3. Appliquer le filtre de Sobel comme reference",,,,,,,,9782832d925c7ac2,,,,,,,
+2. Créer une image synthetique avec des bords bien définis
+3. Appliquer le filtre de Sobel comme référence",,,,,,,,72020e4217d81775,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,install-deps,code,fr,60f9d5701fa0a71c,"# Dependencies pre-provisionnees (pygad deap scipy matplotlib numpy) : voir Search/requirements.txt.
 # Aucun install requis dans le notebook ; imports directs dans les cellules suivantes.",,,,,,,,60f9d5701fa0a71c,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,o85aruu3cm,markdown,fr,aef8d6bf9893406c,"### Imports et configuration
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,o85aruu3cm,markdown,fr,1af83a301fad0072,"### Imports et configuration
 
-Chargeons les bibliotheques necessaires : `numpy` et `matplotlib` pour le calcul et la visualisation, `scipy.signal` pour la convolution 2D, `pygad` et `deap` pour les algorithmes genetiques.",,,,,,,,aef8d6bf9893406c,,,,,,,
+Chargeons les bibliotheques nécessaires : `numpy` et `matplotlib` pour le calcul et la visualisation, `scipy.signal` pour la convolution 2D, `pygad` et `deap` pour les algorithmes génétiques.",,,,,,,,1af83a301fad0072,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,imports,code,fr,20ee4c6b11f6ce01,"import sys
 import os
 # sys.path.insert(0, os.path.abspath('../..'))
@@ -26810,9 +26810,9 @@ np.random.seed(42)
 
 print(""Environnement pret."")
 ",,,,,,,,20ee4c6b11f6ce01,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,synth-image-intro,markdown,fr,e300c97764a675b4,"### Image synthetique de test
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,synth-image-intro,markdown,fr,41ec32c35ed47f74,"### Image synthetique de test
 
-Nous creons une image en niveaux de gris contenant des formes geometriques simples (rectangles, cercle, diagonales) pour fournir des bords bien definis. L'avantage d'une image synthetique est le controle total sur la complexite des contours.",,,,,,,,e300c97764a675b4,,,,,,,
+Nous creons une image en niveaux de gris contenant des formes geometriques simples (rectangles, cercle, diagonales) pour fournir des bords bien définis. L'avantage d'une image synthetique est le contrôle total sur la complexité des contours.",,,,,,,,41ec32c35ed47f74,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,create-synthetic-image,code,fr,8f4322e48307132f,"def create_synthetic_image(size=128):
     """"""Create a synthetic grayscale image with clear geometric edges.""""""
     img = np.zeros((size, size), dtype=np.float64)
@@ -26850,13 +26850,13 @@ MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,create-sy
 original_image = create_synthetic_image(128)
 print(f""Image synthetique : {original_image.shape}, dtype={original_image.dtype}"")
 print(f""Plage de valeurs : [{original_image.min():.0f}, {original_image.max():.0f}]"")",,,,,,,,8f4322e48307132f,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,sobel-reference-intro,markdown,fr,590baa7f7d798d3e,"### Application du filtre de Sobel comme reference
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,sobel-reference-intro,markdown,fr,2e9cc38609c008dc,"### Application du filtre de Sobel comme référence
 
 Le filtre de Sobel calcule le gradient de l'image dans les directions X et Y. La magnitude du gradient detecte les bords, quelle que soit leur orientation :
 
 $$\text{Sobel}(x,y) = \sqrt{G_x^2 + G_y^2}$$
 
-Nous utilisons `scipy.ndimage.sobel` pour obtenir notre image de reference.",,,,,,,,590baa7f7d798d3e,,,,,,,
+Nous utilisons `scipy.ndimage.sobel` pour obtenir notre image de référence.",,,,,,,,2e9cc38609c008dc,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,apply-sobel-reference,code,fr,dd262e26f59522da,"def compute_sobel_reference(image):
     """"""Compute Sobel edge magnitude as reference.""""""
     sobel_x = scipy_sobel(image, axis=1)
@@ -26886,11 +26886,11 @@ plt.show()
 plt.close()
 
 print(f""Reference Sobel : shape={sobel_reference.shape}, plage=[{sobel_reference.min():.1f}, {sobel_reference.max():.1f}]"")",,,,,,,,dd262e26f59522da,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,sobel-interpretation,markdown,fr,30dd984e15f0ccc4,"### Interpretation : image de reference
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,sobel-interpretation,markdown,fr,bcbebbaafe1929cd,"### Interpretation : image de référence
 
 **Sortie obtenue** : L'image originale contient 5 formes geometriques. Le filtre de Sobel detecte clairement les bords de chaque forme.
 
-| Element | Detection Sobel |
+| Élément | Detection Sobel |
 |---------|----------------|
 | Rectangle blanc | Contours nets sur les 4 cotes |
 | Rectangle gris | Contours visibles, moins intenses (contraste moindre) |
@@ -26898,34 +26898,34 @@ MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,sobel-int
 | Diagonale | Lignes paralleles detectees |
 | Petit carre | Contour net |
 
-**Point cle** : L'intensite des bords detectes depend du **contraste** entre les regions adjacentes. C'est ce resultat que notre algorithme genetique devra approximer.
+**Point cle** : L'intensite des bords detectes depend du **contraste** entre les regions adjacentes. C'est ce résultat que notre algorithme génétique devra approximer.
 
-> **Note technique** : Le gradient de fond (leger degrade horizontal) produit un signal faible mais non nul dans la reference Sobel.",,,,,,,,30dd984e15f0ccc4,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,section-3-encoding,markdown,fr,ae081239de1b55e1,"## 3. Encodage GA : le filtre comme chromosome
+> **Note technique** : Le gradient de fond (léger degrade horizontal) produit un signal faible mais non nul dans la référence Sobel.",,,,,,,,bcbebbaafe1929cd,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,section-3-encoding,markdown,fr,8dc583f6319f7aac,"## 3. Encodage GA : le filtre comme chromosome
 
-### Strategie d'encodage
+### Stratégie d'encodage
 
-Pour appliquer un algorithme genetique, nous devons definir comment representer une solution candidate. Ici, chaque individu represente un **noyau de convolution 7x7** :
+Pour appliquer un algorithme génétique, nous devons définir comment représenter une solution candidate. Ici, chaque individu représente un **noyau de convolution 7x7** :
 
-| Parametre | Valeur | Justification |
+| Paramètre | Valeur | Justification |
 |-----------|--------|---------------|
 | Taille du noyau | 7 x 7 | Assez grand pour capturer des patterns directionnels |
 | Nombre de genes | 49 | Matrice aplatie en vecteur |
 | Plage des genes | $[-20, 20]$ entiers | Coefficients suffisants pour des gradients |
-| Fitness | Correlation avec la reference Sobel | Mesure de similarite normalisee |
+| Fitness | Correlation avec la référence Sobel | Mesure de similarite normalisee |
 
 ### Fonction de fitness
 
-La qualite d'un filtre est evaluee en deux etapes :
+La qualite d'un filtre est évaluee en deux étapes :
 
 1. **Convolution** : on applique le noyau candidat a l'image originale via `scipy.signal.convolve2d`
-2. **Correlation** : on calcule la correlation de Pearson entre l'image filtree et l'image Sobel de reference
+2. **Correlation** : on calcule la correlation de Pearson entre l'image filtree et l'image Sobel de référence
 
 $$\text{fitness} = \frac{\text{corr}(\text{GA\_output}, \text{Sobel\_ref})}{\text{penalty}}$$
 
-La **penalite** decourage les filtres uniformes (ou tous les coefficients sont proches de zero), en penalisant les noyaux de faible variance :
+La **penalite** decourage les filtrès uniformes (ou tous les coefficients sont proches de zero), en penalisant les noyaux de faible variance :
 
-$$\text{penalty} = \begin{cases} 1 & \text{si } \text{var}(K) > \epsilon \\ 10 & \text{sinon} \end{cases}$$",,,,,,,,ae081239de1b55e1,,,,,,,
+$$\text{penalty} = \begin{cases} 1 & \text{si } \text{var}(K) > \epsilon \\ 10 & \text{sinon} \end{cases}$$",,,,,,,,8dc583f6319f7aac,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,fitness-function,code,fr,829a4d308564ff52,"KERNEL_SIZE = 7
 NUM_GENES = KERNEL_SIZE * KERNEL_SIZE  # 49
 GENE_LOW = -20
@@ -26983,40 +26983,40 @@ sobel_padded[offset:offset+3, offset:offset+3] = sobel_3x3
 sobel_fitness = compute_fitness(sobel_padded.flatten(), original_image, sobel_reference)
 print(f""Fitness du noyau Sobel (dans 7x7) : {sobel_fitness:.2f}"")
 print(f""\nLe GA doit trouver un noyau dont la fitness approche {sobel_fitness:.0f}."")",,,,,,,,829a4d308564ff52,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,encoding-interpretation,markdown,fr,3c4acaf5371bcf73,"### Interpretation : calibration de la fitness
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,encoding-interpretation,markdown,fr,c27060067963b7f8,"### Interpretation : calibration de la fitness
 
-**Sortie obtenue** : Le noyau aleatoire obtient une fitness de 362.26, tandis que le Sobel (dans un noyau 7x7) obtient 75.82.
+**Sortie obtenue** : Le noyau aléatoire obtient une fitness de 362.26, tandis que le Sobel (dans un noyau 7x7) obtient 75.82.
 
 | Noyau | Fitness | Signification |
 |-------|---------|---------------|
 | Aleatoire | 362.26 | Penalite faible (variance elevee), score brut eleve |
 | Sobel 3x3 (dans 7x7) | 75.82 | Penalite x10 (variance faible), cible ideale du GA |
 
-**Pourquoi le Sobel a-t-il un score plus bas ?** La fonction `compute_fitness` applique une penalite de x10 aux noyaux de faible variance (comme le Sobel, dont les coefficients sont concentres). Le score brut de 75.82 est donc la **cible** que le GA doit approcher, et non une borne superieure. Un noyau aleatoire (variance elevee) esquive la penalite mais ne detecte pas les bords : le GA doit donc trouver un noyau structure (proche du Sobel) malgre la penalite.
+**Pourquoi le Sobel a-t-il un score plus bas ?** La fonction `compute_fitness` applique une penalite de x10 aux noyaux de faible variance (comme le Sobel, dont les coefficients sont concentrès). Le score brut de 75.82 est donc la **cible** que le GA doit approcher, et non une borne superieure. Un noyau aléatoire (variance elevee) esquive la penalite mais ne detecte pas les bords : le GA doit donc trouver un noyau structure (proche du Sobel) malgre la penalite.
 
 **Points cles** :
 1. L'espace de recherche contient $41^{49} \approx 10^{79}$ solutions candidates (chaque gene peut prendre 41 valeurs de -20 a 20)
 2. La fitness est fortement correlee avec la capacite a detecter les bords
-3. La penalite empeche le GA de converger vers un filtre ""neutre"" (tous les coefficients a zero)",,,,,,,,3c4acaf5371bcf73,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,section-4-pygad,markdown,fr,40c6084d7f1944b9,"## 4. Implementation avec PyGAD
+3. La penalite empêche le GA de converger vers un filtre ""neutre"" (tous les coefficients a zero)",,,,,,,,c27060067963b7f8,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,section-4-pygad,markdown,fr,83a74ce560249e4a,"## 4. Implementation avec PyGAD
 
 ### Presentation de PyGAD
 
-[PyGAD](https://pygad.readthedocs.io/) est une bibliotheque Python d'algorithmes genetiques concu pour la simplicite d'utilisation. Son API est declarative : on configure les parametres et PyGAD gere le cycle evolutif complet.
+[PyGAD](https://pygad.readthedocs.io/) est une bibliotheque Python d'algorithmes génétiques concu pour la simplicite d'utilisation. Son API est declarative : on configure les parametrès et PyGAD gere le cycle evolutif complet.
 
 ### Configuration
 
-| Parametre | Valeur | Role |
+| Paramètre | Valeur | Rôle |
 |-----------|--------|------|
 | `sol_per_pop` | 50 | Taille de la population |
-| `num_generations` | 100 | Nombre de generations |
+| `num_générations` | 100 | Nombre de générations |
 | `num_genes` | 49 | Taille du chromosome (7x7 aplati) |
 | `gene_type` | int | Type des genes |
 | `init_range_low/high` | -20 / 20 | Plage d'initialisation |
-| `parent_selection_type` | ""sss"" | Selection par etat stable (steady-state) |
+| `parent_selection_type` | ""sss"" | Sélection par etat stable (steady-state) |
 | `crossover_type` | ""single_point"" | Croisement en un point |
-| `mutation_percent_genes` | 10 | 10% des genes mutes par generation |
-| `mutation_by_replacement` | True | Remplacement au lieu d'addition |",,,,,,,,40c6084d7f1944b9,,,,,,,
+| `mutation_percent_genes` | 10 | 10% des genes mutes par génération |
+| `mutation_by_replacement` | True | Remplacement au lieu d'addition |",,,,,,,,83a74ce560249e4a,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,pygad-run,code,fr,8db156e61dd43de1,"import pygad
 
 # Track fitness history
@@ -27071,9 +27071,9 @@ pygad_best_solution, pygad_best_fitness, _ = ga_instance.best_solution()
 
 print(f""\nTermine en {pygad_time:.1f}s"")
 print(f""Meilleure fitness : {pygad_best_fitness:.2f}"")",,,,,,,,8db156e61dd43de1,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,pygad-convergence-intro,markdown,fr,7a44b31ba1d8aea7,"### Courbe de convergence
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,pygad-convergence-intro,markdown,fr,119f9afd05168feb,"### Courbe de convergence
 
-Observons comment la fitness du meilleur individu evolue au fil des generations. Une convergence rapide au debut suivie d'un plateau est typique des algorithmes genetiques.",,,,,,,,7a44b31ba1d8aea7,,,,,,,
+Observons comment la fitness du meilleur individu evolue au fil des générations. Une convergence rapide au debut suivie d'un plateau est typique des algorithmes génétiques.",,,,,,,,119f9afd05168feb,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,pygad-convergence-plot,code,fr,9002af2da81616cc,"fig, ax = plt.subplots(figsize=(10, 5))
 ax.plot(range(1, len(pygad_fitness_history) + 1), pygad_fitness_history,
         'b-', linewidth=2, label='PyGAD - Meilleure fitness')
@@ -27092,9 +27092,9 @@ if len(pygad_fitness_history) > 10:
     mid = pygad_fitness_history[min(49, len(pygad_fitness_history)-1)]  # Generation 50
     final = pygad_fitness_history[-1]
     print(f""Progression : gen 10 = {early:.1f}, gen 50 = {mid:.1f}, gen 100 = {final:.1f}"")",,,,,,,,9002af2da81616cc,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,pygad-results-intro,markdown,fr,dc455345a04c075e,"### Resultats : comparaison visuelle
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,pygad-results-intro,markdown,fr,d552fd70a6585365,"### Résultats : comparaison visuelle
 
-Comparons l'image obtenue par le filtre evolue avec la reference Sobel. Affichons egalement le noyau evolue pour observer sa structure.",,,,,,,,dc455345a04c075e,,,,,,,
+Comparons l'image obtenue par le filtre evolue avec la référence Sobel. Affichons également le noyau evolue pour observer sa structure.",,,,,,,,d552fd70a6585365,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,pygad-results-display,code,fr,b73586031624a0cc,"# Apply the best evolved kernel
 pygad_filtered = apply_kernel(original_image, pygad_best_solution)
 pygad_kernel = np.array(pygad_best_solution).reshape(KERNEL_SIZE, KERNEL_SIZE)
@@ -27126,41 +27126,41 @@ print(pygad_kernel)
 # Sobel reference kernel (3x3 in 7x7)
 print(""\nNoyau Sobel de reference (3x3 dans 7x7) :"")
 print(sobel_padded.astype(int))",,,,,,,,b73586031624a0cc,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,pygad-interpretation,markdown,fr,651b0f3b03feccc4,"### Interpretation : qualite du filtre evolue (PyGAD)
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,pygad-interpretation,markdown,fr,956cf6f5999a1ffe,"### Interpretation : qualite du filtre evolue (PyGAD)
 
-**Sortie obtenue** : Le filtre evolue par PyGAD produit une detection de bords qui s'approche de la reference Sobel.
+**Sortie obtenue** : Le filtre evolue par PyGAD produit une detection de bords qui s'approche de la référence Sobel.
 
 | Aspect | Observation |
 |--------|------------|
-| Bords principaux | Generalement bien detectes |
+| Bords principaux | Généralement bien detectes |
 | Bruit de fond | Peut etre plus eleve qu'avec Sobel |
-| Structure du noyau | Souvent asymetrique, differente de Sobel |
-| Coefficients | Distribues sur l'ensemble du 7x7 (pas concentres au centre) |
+| Structure du noyau | Souvent asymétrique, différente de Sobel |
+| Coefficients | Distribues sur l'ensemble du 7x7 (pas concentrès au centre) |
 
 **Points cles** :
-1. Le GA ne converge pas necessairement vers le *meme* noyau que Sobel, mais vers un noyau qui produit un resultat *similaire*
-2. Avec 100 generations et 50 individus, le GA explore $\sim 5000$ solutions sur les $\sim 10^{79}$ possibles
+1. Le GA ne converge pas nécessairement vers le *même* noyau que Sobel, mais vers un noyau qui produit un résultat *similaire*
+2. Avec 100 générations et 50 individus, le GA explore $\sim 5000$ solutions sur les $\sim 10^{79}$ possibles
 3. La qualite depend fortement de la configuration (taille de population, taux de mutation)
 
-> **Note** : Un noyau 7x7 a plus de degres de liberte qu'un 3x3, ce qui peut produire des filtres plus complexes que le Sobel original.",,,,,,,,651b0f3b03feccc4,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,section-5-deap,markdown,fr,62a70fe9ca7f0292,"## 5. Implementation avec DEAP
+> **Note** : Un noyau 7x7 a plus de degrés de liberte qu'un 3x3, ce qui peut produire des filtrès plus complexes que le Sobel original.",,,,,,,,956cf6f5999a1ffe,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,section-5-deap,markdown,fr,b32b1161e638b174,"## 5. Implementation avec DEAP
 
 ### Presentation de DEAP
 
-[DEAP](https://deap.readthedocs.io/) (Distributed Evolutionary Algorithms in Python) est un framework plus flexible que PyGAD. Il offre un controle fin sur chaque composant de l'algorithme evolutif.
+[DEAP](https://deap.readthedocs.io/) (Distributed Evolutionary Algorithms in Python) est un framework plus flexible que PyGAD. Il offre un contrôle fin sur chaque composant de l'algorithme evolutif.
 
 ### Comparaison des API
 
 | Aspect | PyGAD | DEAP |
 |--------|-------|------|
 | Philosophie | Declaratif (configure et lance) | Compositionnel (assemble les briques) |
-| Flexibilite | Moderee | Tres elevee |
+| Flexibilite | Moderee | Très elevee |
 | Courbe d'apprentissage | Faible | Moyenne |
 | Multi-objectif | Non (natif) | Oui (NSGA-II, SPEA2) |
 | Parallelisme | Basique | Oui (map, scoop) |
 | Cas d'usage | Prototypage rapide | Recherche, algorithmes custom |
 
-Nous allons resoudre le meme probleme avec DEAP pour comparer les resultats et l'experience de developpement.",,,,,,,,62a70fe9ca7f0292,,,,,,,
+Nous allons résoudre le même problème avec DEAP pour comparer les résultats et l'expérience de développément.",,,,,,,,b32b1161e638b174,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,deap-run,code,fr,8b47636921a504e5,"from deap import base, creator, tools, algorithms
 import random
 
@@ -27237,9 +27237,9 @@ deap_best_fitness = deap_best_individual.fitness.values[0]
 
 print(f""Termine en {deap_time:.1f}s"")
 print(f""Meilleure fitness : {deap_best_fitness:.2f}"")",,,,,,,,8b47636921a504e5,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,deap-results-intro,markdown,fr,9b53db1c3aab3fc2,"### Resultats DEAP : visualisation
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,deap-results-intro,markdown,fr,1b06f403dea6cfd5,"### Résultats DEAP : visualisation
 
-Affichons le filtre evolue par DEAP et comparons-le avec le resultat PyGAD.",,,,,,,,9b53db1c3aab3fc2,,,,,,,
+Affichons le filtre evolue par DEAP et comparons-le avec le résultat PyGAD.",,,,,,,,1b06f403dea6cfd5,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,deap-results-display,code,fr,5d6088dff89e37b1,"# Apply the best evolved kernel from DEAP
 deap_filtered = apply_kernel(original_image, deap_best_individual)
 deap_kernel = np.array(deap_best_individual).reshape(KERNEL_SIZE, KERNEL_SIZE)
@@ -27267,22 +27267,22 @@ plt.close()
 
 print(""Noyau evolue (DEAP) :"")
 print(deap_kernel)",,,,,,,,5d6088dff89e37b1,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,deap-interpretation,markdown,fr,7b2c50d4656ba487,"### Interpretation : comparaison PyGAD vs DEAP
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,deap-interpretation,markdown,fr,3b2bbedf4f02ce4f,"### Interpretation : comparaison PyGAD vs DEAP
 
-**Sortie obtenue** : Les deux frameworks produisent des filtres de detection de bords, avec des resultats potentiellement differents.
+**Sortie obtenue** : Les deux frameworks produisent des filtrès de detection de bords, avec des résultats potentiellement différents.
 
 | Aspect | Observation |
 |--------|------------|
-| Structure du noyau | Les deux noyaux evolues sont generalement differents |
+| Structure du noyau | Les deux noyaux evolues sont généralement différents |
 | Qualite visuelle | Comparable, avec des artefacts variables |
 | Noyau evolue | Ni l'un ni l'autre ne ressemble exactement a Sobel |
 
-**Point cle** : Deux executions du meme algorithme (et a fortiori deux frameworks differents) produisent des solutions differentes en raison de la nature stochastique des GA. La convergence depend de l'initialisation aleatoire, de la derive genetique et des choix d'operateurs.",,,,,,,,7b2c50d4656ba487,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,section-6-analysis,markdown,fr,854a870cc6d357ac,"## 6. Analyse comparative
+**Point cle** : Deux exécutions du même algorithme (et a fortiori deux frameworks différents) produisent des solutions différentes en raison de la nature stochastique des GA. La convergence depend de l'initialisation aléatoire, de la derive génétique et des choix d'opérateurs.",,,,,,,,3b2bbedf4f02ce4f,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,section-6-analysis,markdown,fr,ad74249a60e46b30,"## 6. Analyse comparative
 
 ### Courbes de convergence
 
-Comparons l'evolution de la fitness des deux frameworks sur les 100 generations.",,,,,,,,854a870cc6d357ac,,,,,,,
+Comparons l'evolution de la fitness des deux frameworks sur les 100 générations.",,,,,,,,ad74249a60e46b30,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,convergence-comparison,code,fr,bde7571100c25e48,"fig, ax = plt.subplots(figsize=(10, 6))
 
 ax.plot(range(1, len(pygad_fitness_history) + 1), pygad_fitness_history,
@@ -27357,9 +27357,9 @@ print(f""{'Temps (s)':<30} {pygad_time:<15.1f} {deap_time:<15.1f}"")
 print(f""{'Evaluations totales':<30} {50*100:<15} {50*100:<15}"")
 print(f""{'Variance du noyau':<30} {np.var(pygad_kernel):<15.1f} {np.var(deap_kernel):<15.1f}"")
 ",,,,,,,,7faba0e0b4a35c7a,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,analysis-kernel-comparison,markdown,fr,25a09bba71232468,"### Les filtres evolues ressemblent-ils au Sobel ?
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,analysis-kernel-comparison,markdown,fr,541e9b63f376ac4a,"### Les filtrès evolues ressemblent-ils au Sobel ?
 
-Visualisons les noyaux evolues et comparons-les au noyau Sobel. La question est : le GA reinvente-t-il la meme structure que Sobel, ou trouve-t-il des alternatives ?",,,,,,,,25a09bba71232468,,,,,,,
+Visualisons les noyaux evolues et comparons-les au noyau Sobel. La question est : le GA reinvente-t-il la même structure que Sobel, ou trouve-t-il des alternatives ?",,,,,,,,541e9b63f376ac4a,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,kernel-heatmaps,code,fr,0511228d648111c6,"fig, axes = plt.subplots(1, 3, figsize=(16, 5))
 
 # Sobel padded
@@ -27395,40 +27395,40 @@ plt.suptitle('Comparaison des noyaux de convolution', fontsize=13, fontweight='b
 plt.tight_layout()
 plt.show()
 plt.close()",,,,,,,,0511228d648111c6,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,analysis-interpretation,markdown,fr,c5a454c5edab6a51,"### Interpretation : analyse des filtres evolues
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,analysis-interpretation,markdown,fr,5d4165cac5abac1f,"### Interpretation : analyse des filtrès evolues
 
 **Sortie obtenue** : Les heatmaps montrent la structure interne des trois noyaux.
 
 | Filtre | Structure | Observation |
 |--------|-----------|------------|
-| Sobel (reference) | Coefficients concentres au centre, anti-symetrique en X | Design mathematique optimal |
-| PyGAD | Coefficients repartis sur tout le 7x7 | Le GA exploite la taille complete du noyau |
-| DEAP | Idem, avec une structure differente | Autre solution dans le meme espace |
+| Sobel (référence) | Coefficients concentrès au centre, anti-symétrique en X | Design mathématique optimal |
+| PyGAD | Coefficients repartis sur tout le 7x7 | Le GA exploite la taille complète du noyau |
+| DEAP | Idem, avec une structure différente | Autre solution dans le même espace |
 
 **Points cles** :
-1. Les noyaux evolues sont rarement symetriques : le GA n'a pas d'*a priori* sur la structure
-2. Plusieurs noyaux tres differents peuvent produire des detections de bords similaires
-3. Cela illustre le concept de **degenerescence** : plusieurs genotypes differents produisent un phenotype (comportement) similaire
+1. Les noyaux evolues sont rarement symétriques : le GA n'a pas d'*a priori* sur la structure
+2. Plusieurs noyaux très différents peuvent produire des detections de bords similaires
+3. Cela illustre le concept de **degénèrescence** : plusieurs genotypes différents produisent un phenotype (comportement) similaire
 
-### Discussion : GA pour la conception de filtres en pratique
+### Discussion : GA pour la conception de filtrès en pratique
 
 | Avantage | Limitation |
 |----------|------------|
 | Aucune expertise requise en traitement du signal | Convergence lente pour de grands noyaux |
 | Explore des solutions non-conventionnelles | Pas de garantie d'optimalite |
-| Adaptable a n'importe quelle metrique de qualite | Resultat non reproductible (stochastique) |
-| Peut trouver des filtres specifiques a un type d'image | Couteux en evaluations (convolutions) |
+| Adaptable a n'importe quelle metrique de qualite | Résultat non reproductible (stochastique) |
+| Peut trouver des filtrès spécifiques a un type d'image | Couteux en évaluations (convolutions) |
 
-> **Lien avec le deep learning** : Les reseaux convolutifs (CNN) apprennent egalement des filtres automatiquement, mais par descente de gradient sur des milliers d'exemples. Les GA offrent une alternative quand la fonction objectif n'est pas differentiable.",,,,,,,,c5a454c5edab6a51,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,2e87c417,markdown,fr,0d4e653b57fa8988,"### Exercice : Mesurer la similarite structurelle des noyaux
+> **Lien avec le deep learning** : Les reseaux convolutifs (CNN) apprennent également des filtrès automatiquement, mais par descente de gradient sur des milliers d'exemples. Les GA offrent une alternative quand la fonction objectif n'est pas differentiable.",,,,,,,,5d4165cac5abac1f,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,2e87c417,markdown,fr,353e7a78a5549069,"### Exercice : Mesurer la similarite structurelle des noyaux
 
-Les noyaux evolues par PyGAD et DEAP different visuellement du Sobel, mais produisent des resultats similaires. Implementez une fonction `kernel_similarity` qui mesure a quel point deux noyaux sont **structurellement similaires** en calculant la correlation de Pearson entre leurs versions aplaties.
+Les noyaux evolues par PyGAD et DEAP différent visuellement du Sobel, mais produisent des résultats similaires. Implementez une fonction `kernel_similarity` qui mesure a quel point deux noyaux sont **structurellement similaires** en calculant la correlation de Pearson entre leurs versions aplaties.
 
 **Indices** :
 - Aplatissez chaque noyau avec `.flatten()`
 - Utilisez `np.corrcoef(a, b)[0, 1]` pour la correlation de Pearson
 - Comparez `pygad_kernel` vs `sobel_padded` et `deap_kernel` vs `sobel_padded`
-- Une correlation proche de 1 signifie que les noyaux ont une structure similaire ; proche de 0 = structures independantes",,,,,,,,0d4e653b57fa8988,,,,,,,
+- Une correlation proche de 1 signifie que les noyaux ont une structure similaire ; proche de 0 = structures independantes",,,,,,,,353e7a78a5549069,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,7fc51b2f,code,fr,c944e3410e082960,"def kernel_similarity(kernel_a: np.ndarray, kernel_b: np.ndarray) -> float:
     """"""Calcule la similarite structurelle entre deux noyaux de convolution.
     
@@ -27446,15 +27446,15 @@ MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,7fc51b2f,
     return 0.0  # TODO etudiant : remplacer par le calcul
 
 print(""Exercice a completer : similarite structurelle des noyaux"")",,,,,,,,c944e3410e082960,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,section-7-exercises,markdown,fr,bc182d5553fd5989,"## 7. Exercices
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,section-7-exercises,markdown,fr,0109e213045c2fd7,"## 7. Exercices
 
 ### Exercice 1 : Evoluer un filtre Laplacien
 
-Le filtre Laplacien detecte les bords en calculant la derivee seconde de l'image. Contrairement au Sobel, il est **isotrope** (meme sensibilite dans toutes les directions).
+Le filtre Laplacien detecte les bords en calculant la derivee seconde de l'image. Contrairement au Sobel, il est **isotrope** (même sensibilite dans toutes les directions).
 
-**Tache** : Modifiez la reference pour utiliser un Laplacien au lieu du Sobel, puis relancez le GA.
+**Tâche** : Modifiez la référence pour utiliser un Laplacien au lieu du Sobel, puis relancez le GA.
 
-**Indice** : Utilisez `scipy.ndimage.laplace` pour calculer la reference Laplacienne.",,,,,,,,bc182d5553fd5989,,,,,,,
+**Indice** : Utilisez `scipy.ndimage.laplace` pour calculer la référence Laplacienne.",,,,,,,,0109e213045c2fd7,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,exercise-1,code,fr,5edb2159c599d19b,"from scipy.ndimage import laplace
 
 # Compute Laplacian reference
@@ -27477,14 +27477,14 @@ plt.close()
 print(""Exercice : relancez le GA en remplacant 'sobel_reference' par"")
 print(""'laplacian_reference' dans la fonction de fitness."")
 print(""Question : le GA converge-t-il plus vite ou moins vite ? Pourquoi ?"")",,,,,,,,5edb2159c599d19b,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,exercise-2-intro,markdown,fr,1259d37d4b3f3174,"### Exercice 2 : Noyau 5x5 vs 7x7
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,exercise-2-intro,markdown,fr,ed823cdaa0781598,"### Exercice 2 : Noyau 5x5 vs 7x7
 
-**Tache** : Reduisez la taille du noyau a 5x5 (25 genes au lieu de 49) et relancez le GA.
+**Tâche** : Reduisez la taille du noyau a 5x5 (25 genes au lieu de 49) et relancez le GA.
 
 **Questions** :
 - Le GA converge-t-il plus rapidement avec moins de genes ?
 - La qualite finale est-elle meilleure ou moins bonne ?
-- Quel est le compromis taille du noyau vs qualite de detection ?",,,,,,,,1259d37d4b3f3174,,,,,,,
+- Quel est le compromis taille du noyau vs qualite de detection ?",,,,,,,,ed823cdaa0781598,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,exercise-2,code,fr,e0b4d5402340ccbc,"# Hint: modify KERNEL_SIZE and NUM_GENES
 KERNEL_5x5 = 5
 NUM_GENES_5x5 = KERNEL_5x5 * KERNEL_5x5  # 25
@@ -27507,13 +27507,13 @@ print()
 print(""Completez cet exercice en adaptant le code PyGAD ou DEAP"")
 print(""avec KERNEL_5x5 et NUM_GENES_5x5."")
 ",,,,,,,,e0b4d5402340ccbc,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,exercise-3-intro,markdown,fr,a73f73f92097aca6,"### Exercice 3 : Effet du taux de mutation
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,exercise-3-intro,markdown,fr,fdced83ea8f786bb,"### Exercice 3 : Effet du taux de mutation
 
-**Tache** : Lancez le GA PyGAD avec trois taux de mutation differents (5%, 15%, 30%) et comparez les courbes de convergence.
+**Tâche** : Lancez le GA PyGAD avec trois taux de mutation différents (5%, 15%, 30%) et comparez les courbes de convergence.
 
 **Questions** :
 - Un taux de mutation eleve accelere-t-il ou ralentit-il la convergence ?
-- A quel taux observe-t-on le meilleur compromis exploration/exploitation ?",,,,,,,,a73f73f92097aca6,,,,,,,
+- A quel taux observe-t-on le meilleur compromis exploration/exploitation ?",,,,,,,,fdced83ea8f786bb,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,exercise-3,code,fr,5b084452b8569a4c,"# Exercice 3 : Effet du taux de mutation
 # TODO: Lancez le GA PyGAD avec trois taux de mutation (5%, 15%, 30%)
 # et comparez les courbes de convergence.
@@ -27576,16 +27576,16 @@ mutation_results = {}
 
 print(""Exercice 3 : implementez la comparaison des taux de mutation"")
 print(""Relancez le GA pour chaque taux et tracez les courbes de convergence."")",,,,,,,,5b084452b8569a4c,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,exercise-3-interpretation,markdown,fr,f2d3421415610290,"### Interpretation : effet du taux de mutation
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,exercise-3-interpretation,markdown,fr,18b99835973969ff,"### Interpretation : effet du taux de mutation
 
-**A verifier (Exercice 3)** : Une fois la boucle sur les taux de mutation implementee, comparez vos trois courbes de convergence. Voici les comportements generaux attendus en fonction du taux :
+**A vérifier (Exercice 3)** : Une fois la boucle sur les taux de mutation implementee, comparez vos trois courbes de convergence. Voici les comportements généraux attendus en fonction du taux :
 
 - **5% (faible)** : convergence plus lente mais plus stable, risque de piege dans un optimum local.
 - **15% (moyen)** : compromis entre exploration et exploitation.
-- **30% (eleve)** : exploration forte mais plus d'instabilite, peut ""detruire"" de bonnes solutions.
+- **30% (eleve)** : exploration forte mais plus d'instabilite, peut ""détruire"" de bonnes solutions.
 
-**Lecon** : Le taux de mutation controle l'equilibre entre **exploration** (decouvrir de nouvelles regions) et **exploitation** (affiner les bonnes solutions). C'est un hyper-parametre critique des algorithmes genetiques.",,,,,,,,f2d3421415610290,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,section-conclusion,markdown,fr,0eeeb4e87aa1da93,"## Conclusion
+**Lecon** : Le taux de mutation contrôle l'équilibre entre **exploration** (decouvrir de nouvelles regions) et **exploitation** (affiner les bonnes solutions). C'est un hyper-paramètre critique des algorithmes génétiques.",,,,,,,,18b99835973969ff,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,section-conclusion,markdown,fr,e36cca836d3e5fed,"## Conclusion
 
 ### Recapitulatif
 
@@ -27593,54 +27593,54 @@ MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,section-c
 |---------|------------------------|
 | Detection de bords | Filtre de convolution applique par produit scalaire local |
 | Encodage GA | Un noyau 7x7 = 49 genes entiers dans [-20, 20] |
-| Fitness | Correlation de Pearson avec la reference Sobel |
+| Fitness | Correlation de Pearson avec la référence Sobel |
 | PyGAD | API declarative, prototypage rapide |
 | DEAP | API compositionnelle, flexible et extensible |
-| Convergence | 100 generations suffisent pour une approximation raisonnable |
-| Degenerescence | Plusieurs noyaux differents produisent des resultats similaires |
+| Convergence | 100 générations suffisent pour une approximation raisonnable |
+| Degénèrescence | Plusieurs noyaux différents produisent des résultats similaires |
 
 ### Points a retenir
 
-1. Les GA peuvent decouvrir automatiquement des filtres de detection de bords sans expertise en traitement du signal
-2. L'espace de recherche est immense ($10^{79}$ solutions) mais le GA trouve des solutions raisonnables en quelques milliers d'evaluations
+1. Les GA peuvent decouvrir automatiquement des filtrès de detection de bords sans expertise en traitement du signal
+2. L'espace de recherche est immense ($10^{79}$ solutions) mais le GA trouve des solutions raisonnables en quelques milliers d'évaluations
 3. Le choix du framework (PyGAD vs DEAP) depend du besoin : simplicite vs flexibilite
-4. Les hyper-parametres (taille de population, taux de mutation, type de selection) influencent significativement la convergence
+4. Les hyper-parametrès (taille de population, taux de mutation, type de sélection) influencent significativement la convergence
 
-### Liens avec les autres notebooks
+### Liens avec les autrès notebooks
 
 | Notebook | Lien |
 |----------|------|
-| [Search-5 GA](../../Part1-Foundations/Search-5-GeneticAlgorithms.ipynb) | Fondements theoriques des algorithmes genetiques |
-| [App-9b C#](App-9b-EdgeDetection-CSharp.ipynb) | Meme probleme avec GeneticSharp en C# |
+| [Search-5 GA](../../Part1-Foundations/Search-5-GeneticAlgorithms.ipynb) | Fondements théoriques des algorithmes génétiques |
+| [App-9b C#](App-9b-EdgeDetection-CSharp.ipynb) | Même problème avec GeneticSharp en C# |
 | [App-10 Portfolio](../Hybrid/App-10-Portfolio.ipynb) | Autre application des GA : optimisation de portefeuille |
 
 ### Pour aller plus loin
 
 - Experimenter avec des noyaux non carres (ex: 3x7 pour detecter les bords horizontaux)
-- Utiliser la programmation genetique (DEAP `gp` module) pour evoluer des *expressions* de filtres
-- Comparer avec l'apprentissage de filtres par descente de gradient (CNN)
-- Appliquer le GA sur des images reelles (imagerie medicale, satellite)",,,,,,,,0eeeb4e87aa1da93,,,,,,,
+- Utiliser la programmation génétique (DEAP `gp` module) pour evoluer des *expressions* de filtrès
+- Comparer avec l'apprentissage de filtrès par descente de gradient (CNN)
+- Appliquer le GA sur des images réelles (imagerie medicale, satellite)",,,,,,,,e36cca836d3e5fed,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb,nav-footer,markdown,fr,35446096c7dd1aa2,"---
 
 **Navigation** : [<< App-8 MiniZinc](../CSP/App-8-MiniZinc.ipynb) | [Index](../README.md) | [App-10 Portfolio >>](../Hybrid/App-10-Portfolio.ipynb)",,,,,,,,35446096c7dd1aa2,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9b-EdgeDetection-CSharp.ipynb,052fd18b,markdown,fr,92bcb67a9e8bc0b6,"# TP : Conception d'Algorithmes Genetiques avec GeneticSharp
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9b-EdgeDetection-CSharp.ipynb,052fd18b,markdown,fr,9df455ceb40ab33d,"# TP : Conception d'Algorithmes Génétiques avec GeneticSharp
 
 **Navigation** : [Index](../../README.md) | [<< App-9 Python](../Hybrid/App-9-EdgeDetection.ipynb)
 
 Dans ce TP, nous allons concevoir un filtre de detection de bords en utilisant la bibliotheque **GeneticSharp**. 
 
-**Objectif :** Approcher automatiquement un **filtre de detection de bords** reput (ici un filtre Sobel) a l'aide d'un algorithme genetique. 
+**Objectif :** Approcher automatiquement un **filtre de detection de bords** reput (ici un filtre Sobel) a l'aide d'un algorithme génétique. 
 
 Au fil du TP, nous allons :
 
-1. Definir un **chromosome** (classe `EdgeChromosome`) permettant de stocker la description d'un noyau de convolution.
-2. Mettre en place une **fonction d'evaluation** (classe `EdgeFitness`) comparant le resultat de notre filtre avec un filtre de reference (Sobel).
-3. Parametrer et executer un **algorithme genetique** (AG) avec [GeneticSharp](https://github.com/giacomelli/GeneticSharp).
+1. Définir un **chromosome** (classe `EdgeChromosome`) permettant de stocker la description d'un noyau de convolution.
+2. Mettre en place une **fonction d'evaluation** (classe `EdgeFitness`) comparant le résultat de notre filtre avec un filtre de reference (Sobel).
+3. Parametrer et executer un **algorithme génétique** (AG) avec [GeneticSharp](https://github.com/giacomelli/GeneticSharp).
 
-> **Rappel :** Un algorithme genetique se base sur la metaphorique de l'evolution naturelle. Les individus (ici, des filtres de convolution) sont evalues par une fonction de fitness (notre capacite a detecter des bords). A chaque generation, on applique :
-> - une **selection** (selectionner les meilleurs individus) ;
+> **Rappel :** Un algorithme génétique se base sur la metaphorique de l'evolution naturelle. Les individus (ici, des filtres de convolution) sont evalues par une fonction de fitness (notre capacite a detecter des bords). A chaque generation, on applique :
+> - une **sélection** (sélectionner les meilleurs individus) ;
 > - un **croisement** (melanger les individus pour explorer d'autres zones de l'espace de solutions) ;
-> - une **mutation** (petites modifications aleatoires pour injecter de la diversite).",,,,,,,,92bcb67a9e8bc0b6,,,,,,,
+> - une **mutation** (petites modifications aleatoires pour injecter de la diversite).",,,,,,,,9df455ceb40ab33d,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9b-EdgeDetection-CSharp.ipynb,0c327348,markdown,fr,236c9d5c4237f1b3,"## Technologies et Bibliothèques
 
 - **GeneticSharp**  
@@ -27662,7 +27662,7 @@ MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9b-EdgeDetection-CSharp.ipynb,5
 #r ""nuget: Emgu.CV.runtime.mini.windows, 4.9.0.5494""
 
 #r ""nuget: SkiaSharp, 2.88.3""",,,,,,,,00f779a0faed586a,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9b-EdgeDetection-CSharp.ipynb,57e7f109,markdown,fr,e4a549db09121450,Affichage des resultats.,,,,,,,,e4a549db09121450,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9b-EdgeDetection-CSharp.ipynb,57e7f109,markdown,fr,1628819e5708858c,Affichage des résultats.,,,,,,,,1628819e5708858c,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9b-EdgeDetection-CSharp.ipynb,d629d27a,code,fr,13dc0d00202b5854,"// Utilitaires SkiaSharp simplifiés (sans DisplayedValue pour compatibilité Papermill)
 using System.Drawing;
 using SkiaSharp;
@@ -28068,7 +28068,7 @@ for (int i = 0; i < testMatrix.GetLength(0); i++)
     Console.WriteLine();
 }
 ",,,,,,,,c2cc8b45233116a3,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9b-EdgeDetection-CSharp.ipynb,6ddac236,markdown,fr,58402ee3097afcdc,"### Interpretation : Structure du Chromosome et du Filtre
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9b-EdgeDetection-CSharp.ipynb,6ddac236,markdown,fr,787f89f92bef3d92,"### Interpretation : Structure du Chromosome et du Filtre
 
 **Sortie obtenue** : Affichage de 5 matrices 7x7 (les genes) et de la matrice complete resultante (somme des genes), representant un noyau de convolution genere aleatoirement.
 
@@ -28076,18 +28076,18 @@ MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9b-EdgeDetection-CSharp.ipynb,6
 |--------|----------------|---------------|
 | Taille de chaque gene | 7x7 = 49 coefficients | Contributive elementaire au filtre final |
 | Nombre de genes | 5 | Decomposition du filtre en 5 sous-matrices |
-| Plage des valeurs genes | -20 a +20 | Variation aleatoire pour la diversite genetique |
+| Plage des valeurs genes | -20 a +20 | Variation aleatoire pour la diversite génétique |
 | Matrice complete | Somme des 5 genes | Filtre de convolution final applique a l'image |
 | Normalisation | Automatique si maxAbs > 10 | Evite les valeurs extremes lors de la somme |
 
 **Points cles** :
-1. **Decomposition genetique** : Le filtre est represente par plusieurs genes (sous-matrices) plutot qu'une seule matrice, ce qui permet une evolution plus fine via le croisement et la mutation.
+1. **Decomposition génétique** : Le filtre est represente par plusieurs genes (sous-matrices) plutot qu'une seule matrice, ce qui permet une evolution plus fine via le croisement et la mutation.
 2. **Addition des genes** : La matrice complete est obtenue par simple addition des matrices des genes, ce qui signifie que chaque gene contribue de maniere additive au filtre final.
 3. **Normalisation dynamique** : Si la somme des genes produit des valeurs trop elevees (maxAbsValue > 10), une normalisation est appliquee pour garder les coefficients dans une plage raisonnable.
-4. **Aleatoire initial** : Les coefficients sont generes aleatoirement dans l'intervalle [-20, +20], ce qui garantit une diversite suffisante au depart de l'algorithme genetique.
-5. **Structure symetrique** : Bien que les genes soient generes de maniere asymetrique, la somme peut produire des motifs qui ressemblent a des filtres de detection de bords classiques (Sobel, Prewitt, etc.) apres evolution.
+4. **Aleatoire initial** : Les coefficients sont generes aleatoirement dans l'intervalle [-20, +20], ce qui garantit une diversite suffisante au depart de l'algorithme génétique.
+5. **Structure symetrique** : Bien que les genes soient generes de maniere asymetrique, la somme peut produire des motifs qui ressemblent a des filtres de detection de bords classiques (Sobel, Prewitt, etc.) après evolution.
 
-> **Note technique** : La taille du noyau (7x7) est superieure aux filtres de Sobel classiques (3x3), ce qui permet une detection plus fine des bords mais augmente aussi la complexite computationnelle. La normalisation dynamique (seuil de 10) evite que l'addition de plusieurs genes ne produise des coefficients trop extremes qui perturberaient la convolution. Cette representation par genes additifs facilite les operations genetiques : le crossover peut echanger des sous-matrices entieres entre parents, et la mutation peut modifier localement quelques coefficients.",,,,,,,,58402ee3097afcdc,,,,,,,
+> **Note technique** : La taille du noyau (7x7) est superieure aux filtres de Sobel classiques (3x3), ce qui permet une detection plus fine des bords mais augmente aussi la complexite computationnelle. La normalisation dynamique (seuil de 10) evite que l'addition de plusieurs genes ne produise des coefficients trop extremes qui perturberaient la convolution. Cette representation par genes additifs facilite les opérations génétiques : le crossover peut echanger des sous-matrices entieres entre parents, et la mutation peut modifier localement quelques coefficients.",,,,,,,,787f89f92bef3d92,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9b-EdgeDetection-CSharp.ipynb,e66da541,markdown,fr,ed496d3d991bac84,"## Fonction d'Évaluation (Fitness)
 
 La **fonction d'évaluation** mesure la capacité d'un filtre (issu d'un chromosome) à détecter les bords de l'image.  
@@ -28124,22 +28124,22 @@ var fitness = new EdgeFitness(originalImage);
 // Test d'un chromosome
 var chromosome = new EdgeChromosome(20);
 Console.WriteLine($""Score de fitness : {fitness.Evaluate(chromosome)}"");",,,,,,,,0de8b70a574aaeb0,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9b-EdgeDetection-CSharp.ipynb,e94eab45,markdown,fr,01167fbe4162dfb6,"### Interpretation : Test de la Fonction de Fitness
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9b-EdgeDetection-CSharp.ipynb,e94eab45,markdown,fr,cac725b4fdd0dbd0,"### Interpretation : Test de la Fonction de Fitness
 
-**Sortie obtenue** : Le chromosome aleatoire obtient un score de fitness de 0,012 (committe en idx precedent), evaluant sa qualite par rapport au filtre Sobel de reference.
+**Sortie obtenue** : Le chromosome aleatoire obtient un score de fitness de 0,012 (committe en idx précédent), evaluant sa qualite par rapport au filtre Sobel de reference.
 
 | Aspect | Valeur observee | Signification |
 |--------|----------------|---------------|
-| Score de fitness | ~0,01 (0,012379...) | Chromosome aleatoire, correlation tres faible avec Sobel |
+| Score de fitness | ~0,01 (0,012379...) | Chromosome aleatoire, correlation très faible avec Sobel |
 | Penalisation appliquee | Oui | Evite les filtres uniformes (Log10 de la somme) |
 
 **Points cles** :
 1. **Score initial faible** : Un chromosome aleatoire obtient ici un score d'environ 0,01, ce qui est normal car ses coefficients ne sont pas optimises pour la detection de bords.
-2. **Role de la penalisation** : La fonction de fitness divise le score de correlation par un facteur dependant de la somme des coefficients du filtre, evitant ainsi la solution triviale d'un filtre uniforme.
-3. **Base de comparaison** : Ce score initial servira de reference pour evaluer l'amelioration apportee par l'algorithme genetique au fil des generations.
-4. **Variabilite** : Chaque execution produit un score different du fait de la generation aleatoire des chromosomes, ce qui demontre la stochasticite du processus.
+2. **Rôle de la penalisation** : La fonction de fitness divise le score de correlation par un facteur dependant de la somme des coefficients du filtre, evitant ainsi la solution triviale d'un filtre uniforme.
+3. **Base de comparaison** : Ce score initial servira de reference pour evaluer l'amelioration apportee par l'algorithme génétique au fil des generations.
+4. **Variabilite** : Chaque exécution produit un score différent du fait de la generation aleatoire des chromosomes, ce qui demontre la stochasticite du processus.
 
-> **Note technique** : La fonction de fitness calcule `maxVal / Log10(|somme des coefficients|+1)` (avec penalty=1 si la somme est quasi nulle). Ce n'est pas une correlation brute bornee a 1,0 : le score peut depasser 1,0 quand la somme du filtre est faible. Le score observe (~0,01) pour un chromosome aleatoire confirme que l'evolution genetique est necessaire pour obtenir un filtre performant.",,,,,,,,01167fbe4162dfb6,,,,,,,
+> **Note technique** : La fonction de fitness calcule `maxVal / Log10(|somme des coefficients|+1)` (avec penalty=1 si la somme est quasi nulle). Ce n'est pas une correlation brute bornee a 1,0 : le score peut depasser 1,0 quand la somme du filtre est faible. Le score observe (~0,01) pour un chromosome aleatoire confirme que l'evolution génétique est necessaire pour obtenir un filtre performant.",,,,,,,,cac725b4fdd0dbd0,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9b-EdgeDetection-CSharp.ipynb,6001b472,markdown,fr,d853e22821dc9f67,"## Configuration de l'Algorithme Génétique
 
 L'algorithme génétique est configuré à l'aide de plusieurs éléments clés :
@@ -28244,34 +28244,34 @@ ga.GenerationRan += (sender, e) =>
 Console.WriteLine(""Lancement de l'algorithme genetique..."");
 ga.Start();
 Console.WriteLine($""Meilleure solution trouvee avec un score de {ga.BestChromosome.Fitness}."");",,,,,,,,42e78eb5cc6a4960,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9b-EdgeDetection-CSharp.ipynb,72599e46,markdown,fr,ea30cde347e77756,"### Interpretation : Resultats de l'Algorithme Genetique
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9b-EdgeDetection-CSharp.ipynb,72599e46,markdown,fr,a960c305635809e6,"### Interpretation : Résultats de l'Algorithme Génétique
 
-**Sortie obtenue** : L'algorithme genetique a evolue sur plusieurs generations, affichant periodiquement (toutes les 10 generations) les images filtrees par le meilleur chromosome. Le score de fitness final indique la qualite de la detection de bords par rapport au filtre Sobel de reference.
+**Sortie obtenue** : L'algorithme génétique a evolue sur plusieurs generations, affichant periodiquement (toutes les 10 generations) les images filtrees par le meilleur chromosome. Le score de fitness final indique la qualite de la detection de bords par rapport au filtre Sobel de reference.
 
 | Aspect | Valeur observee | Signification |
 |--------|----------------|---------------|
-| Score de fitness initial | ~0,01 (chromosome aleatoire) / ~0,71 (generation 1) | Part d'un score tres faible, puis grimpe des la 1re generation |
+| Score de fitness initial | ~0,01 (chromosome aleatoire) / ~0,71 (generation 1) | Part d'un score très faible, puis grimpe des la 1re generation |
 | Score de fitness final | ~2,56 (generation 100) | Chromosome converge vers un detecteur de bords efficace |
 | Vitesse de convergence | Variable | Depend de la population, du crossover et de la mutation |
 | Qualite visuelle du filtre | Amelioree progressivement | Les bords deviennent plus nets au fil des generations |
 
 **Points cles** :
-1. **Convergence progressive** : Le score de fitness augmente generalement rapidement lors des premieres generations, puis se stabilise.
-2. **Impact des operateurs genetiques** : L'EliteSelection preserve les meilleurs individus, tandis que l'UniformCrossover et la ReverseSequenceMutation maintiennent la diversite.
-3. **Correlation avec Sobel** : Un score eleve indique que le filtre evolue produit des resultats similaires au filtre Sobel (reference en detection de bords).
+1. **Convergence progressive** : Le score de fitness augmente généralement rapidement lors des premières generations, puis se stabilise.
+2. **Impact des opérateurs génétiques** : L'EliteSelection preserve les meilleurs individus, tandis que l'UniformCrossover et la ReverseSequenceMutation maintiennent la diversite.
+3. **Correlation avec Sobel** : Un score eleve indique que le filtre evolue produit des résultats similaires au filtre Sobel (reference en detection de bords).
 4. **Penalisation des filtres uniformes** : La fonction de fitness evite la solution triviale d'un filtre uniforme (tous les coefficients egaux) qui ne detecterait aucun bord.
 
-> **Note technique** : La fonction de fitness utilise une correlation normalisee (TemplateMatchingType.CcorrNormed) pour comparer les images. Cette methode est robuste aux variations d'intensite globale mais peut etre sensible au bruit. Une amelioration possible serait d'ajouter une penalite pour la complexite du filtre (nombre de coefficients non nuls) pour privilegier les solutions simples.",,,,,,,,ea30cde347e77756,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9b-EdgeDetection-CSharp.ipynb,611e87c7,markdown,fr,3b2d28c4c37cf39b,"## Exercices
+> **Note technique** : La fonction de fitness utilise une correlation normalisee (TemplateMatchingType.CcorrNormed) pour comparer les images. Cette méthode est robuste aux variations d'intensite globale mais peut etre sensible au bruit. Une amelioration possible serait d'ajouter une penalite pour la complexite du filtre (nombre de coefficients non nuls) pour privilegier les solutions simples.",,,,,,,,a960c305635809e6,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9b-EdgeDetection-CSharp.ipynb,611e87c7,markdown,fr,48449dd8ad0d2c50,"## Exercices
 
-### Exercice 1 : Operateur de Croisement par Point Unique
+### Exercice 1 : Opérateur de Croisement par Point Unique
 
-Implementez un operateur de croisement par point unique (SinglePointCrossover) et comparez ses performances avec l'UniformCrossover utilise dans l'exemple.
+Implementez un opérateur de croisement par point unique (SinglePointCrossover) et comparez ses performances avec l'UniformCrossover utilise dans l'exemple.
 
 **Indices** :
 - Choisissez un point de coupure aleatoire dans le chromosome
-- Les genes avant le point viennent du parent 1, apres du parent 2
-- Mesurez la vitesse de convergence et la qualite finale des deux methodes",,,,,,,,3b2d28c4c37cf39b,,,,,,,
+- Les genes avant le point viennent du parent 1, après du parent 2
+- Mesurez la vitesse de convergence et la qualite finale des deux méthodes",,,,,,,,48449dd8ad0d2c50,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9b-EdgeDetection-CSharp.ipynb,e0004e1c,code,fr,bdc140902a7d198f,"// TODO: Implementer une comparaison entre SinglePointCrossover et UniformCrossover
 public void CompareCrossoverOperators(Bitmap originalImage, int generations = 50)
 {
@@ -28292,14 +28292,14 @@ public void CompareCrossoverOperators(Bitmap originalImage, int generations = 50
 }
 
 Console.WriteLine(""Exercice a completer : comparaison crossover"");",,,,,,,,bdc140902a7d198f,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9b-EdgeDetection-CSharp.ipynb,28a1264d,markdown,fr,9cc1b445f858bbcc,"### Exercice 2 : Contraintes sur les Filtres
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9b-EdgeDetection-CSharp.ipynb,28a1264d,markdown,fr,ba10986d4bd1ecaf,"### Exercice 2 : Contraintes sur les Filtres
 
 Modifiez la classe `EdgeChromosome` pour imposer que la somme des coefficients du noyau soit egale a zero (filtre a somme nulle, typique pour la detection de bords).
 
 **Indices** :
-- Apres avoir calcule la matrice complete, calculez la somme totale
+- Après avoir calcule la matrice complete, calculez la somme totale
 - Ajustez les valeurs pour que la somme soit nulle (soustrayez la moyenne)
-- Verifiez que cela ameliore la qualite des filtres obtenus",,,,,,,,9cc1b445f858bbcc,,,,,,,
+- Verifiez que cela ameliore la qualite des filtres obtenus",,,,,,,,ba10986d4bd1ecaf,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9b-EdgeDetection-CSharp.ipynb,e9f10202,code,fr,7f8cda60bb988324,"// TODO: Implementer une version contrainte de EdgeChromosome avec somme nulle
 public class ZeroSumEdgeChromosome : ChromosomeBase
 {
@@ -28335,28 +28335,28 @@ public class ZeroSumEdgeChromosome : ChromosomeBase
 }
 
 Console.WriteLine(""Exercice a completer : chromosome somme nulle"");",,,,,,,,7f8cda60bb988324,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9b-EdgeDetection-CSharp.ipynb,fc45d8f0,markdown,fr,25813d311670b921,"### Exercice 3 : Conception de la Fonction de Fitness (Reflexion)
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9b-EdgeDetection-CSharp.ipynb,fc45d8f0,markdown,fr,9c610cf7a08d7f68,"### Exercice 3 : Conception de la Fonction de Fitness (Reflexion)
 
 Analysez la fonction de fitness utilisee dans ce notebook et proposez des alternatives.
 
 **Questions a considerer** :
 - Quels sont les avantages et inconvenients d'utiliser la correlation normalisee comme metrique ?
-- Comment pourriez-vous integrer d'autres criteres (ex. temps de calcul, complexite du filtre) dans la fonction de fitness ?
-- Quelle metrique utiliseriez-vous pour detecter differents types de bords (horizontaux, verticaux, diagonaux) ?
+- Comment pourriez-vous integrer d'autres critères (ex. temps de calcul, complexite du filtre) dans la fonction de fitness ?
+- Quelle metrique utiliseriez-vous pour detecter différents types de bords (horizontaux, verticaux, diagonaux) ?
 
-**Reponse attendue** : Une analyse textuelle des approches possibles (pas de code requis).",,,,,,,,25813d311670b921,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9b-EdgeDetection-CSharp.ipynb,64f2c2f5,markdown,fr,54c4a10e0c1df0e4,"### Exercice 4 : Taux de mutation adaptatif
+**Reponse attendue** : Une analyse textuelle des approches possibles (pas de code requis).",,,,,,,,9c610cf7a08d7f68,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9b-EdgeDetection-CSharp.ipynb,64f2c2f5,markdown,fr,85e1c6848f9c6dfc,"### Exercice 4 : Taux de mutation adaptatif
 
 Un taux de mutation fixe peut soit etre trop faible (stagnation prematuree) soit trop eleve (destruction des bons individus). Un taux adaptatif ajuste la probabilite de mutation en fonction de la diversite de la population ou de la progression du score de fitness.
 
-**Objectif** : Implementez une strategie de mutation adaptative qui augmente le taux de mutation quand la population stagne et le diminue quand la convergence progresse.
+**Objectif** : Implementez une stratégie de mutation adaptative qui augmente le taux de mutation quand la population stagne et le diminue quand la convergence progresse.
 
 **Indices** :
-- Surveillez le meilleur score de fitness sur les N dernieres generations (ex: N=5)
+- Surveillez le meilleur score de fitness sur les N dernières generations (ex: N=5)
 - Si le score n'a pas change (stagnation), augmentez le taux de mutation (ex: multiplier par 1.5)
 - Si le score s'est ameliore, diminuez le taux de mutation (ex: diviser par 1.2)
 - Bornez le taux entre une valeur minimale (0.01) et maximale (0.5) pour eviter les extremes
-- Utilisez l'event `ga.GenerationRan` pour ajuster le taux a chaque generation",,,,,,,,54c4a10e0c1df0e4,,,,,,,
+- Utilisez l'event `ga.GenerationRan` pour ajuster le taux a chaque generation",,,,,,,,85e1c6848f9c6dfc,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9b-EdgeDetection-CSharp.ipynb,653c6f25,code,fr,3cbcbadc7bfb43c8,"// TODO: Implementer un taux de mutation adaptatif
 public void RunAdaptiveMutationGA(Bitmap image, int generations = 60)
 {
@@ -28382,20 +28382,20 @@ public void RunAdaptiveMutationGA(Bitmap image, int generations = 60)
 
 // Testez votre implementation (decommentez apres)
 // RunAdaptiveMutationGA(originalImage, 60);",,,,,,,,3cbcbadc7bfb43c8,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9b-EdgeDetection-CSharp.ipynb,c489ed78,markdown,fr,87f276fcef5bfc58,"## Conclusion et Perspectives
+MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9b-EdgeDetection-CSharp.ipynb,c489ed78,markdown,fr,43d9c35dc24407fd,"## Conclusion et Perspectives
 
-Ce TP a permis d'illustrer comment un algorithme genetique peut etre applique pour optimiser un filtre de detection de bords en traitement d'image.  
+Ce TP a permis d'illustrer comment un algorithme génétique peut etre applique pour optimiser un filtre de detection de bords en traitement d'image.  
 L'approche par decomposition en genes permet une evolution fine et progressive du filtre.
 
 **Perspectives possibles :**  
-- Modifier les parametres du GA (taille de la population, taux de mutation, etc.) pour observer leur impact sur la convergence.  
-- Experimenter avec d'autres operateurs genetiques ou representations du probleme.  
+- Modifier les paramètres du GA (taille de la population, taux de mutation, etc.) pour observer leur impact sur la convergence.  
+- Experimenter avec d'autres opérateurs génétiques ou representations du problème.  
 - Implementer une version equivalente en Python avec PyGad pour comparer les approches.
 
 Cette demarche pedagogique demontre la puissance des algorithmes evolutionnaires pour resoudre des problemes complexes dans le domaine de la vision par ordinateur.
 
-**Retour au sommaire** : [Index](../../README.md)",,,,,,,,87f276fcef5bfc58,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour-CSharp.ipynb,9e94c4cb,markdown,fr,3077fe8474db9a7e,"# App-12 (C#) : Puissance 4 -- Comparaison d'algorithmes IA (Bonus)
+**Retour au sommaire** : [Index](../../README.md)",,,,,,,,43d9c35dc24407fd,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour-CSharp.ipynb,9e94c4cb,markdown,fr,101175721e006779,"# App-12 (C#) : Puissance 4 -- Comparaison d'algorithmes IA (Bonus)
 
 **Navigation** : [<< App-11 Picross](../CSP/App-11-Picross.ipynb) | [Index](../../README.md) | [App-13 TSP](../Hybrid/App-13-TSP-Metaheuristics.ipynb) >>
 
@@ -28405,11 +28405,11 @@ MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour-CSharp.ipynb,9e9
 
 **Prerequis** : [Search-6-AdversarialSearch](../../Part1-Foundations/Search-6-AdversarialSearch.ipynb) (Minimax, Alpha-Beta), [Search-7-MCTS](../../Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb), notions de C# / .NET.
 
-**Pourquoi un jumeau C# ?** Le notebook Python compare 5 intelligences artificielles (aleatoire, Minimax avec elagage alpha-beta, MCTS, glouton, iterative deepening) sur le jeu de Puissance 4, en s'appuyant sur `numpy` et `matplotlib`. Ce jumeau reimplemente les memes algorithmes en **C# .NET 9 (BCL seule, 0 NuGet)** : moteur de jeu, heuristique de fenetre, Minimax alpha-beta, MCTS (UCB1), tournoi round-robin et iterative deepening. Les graphiques `matplotlib` sont remplaces par un rendu **ASCII autonome**. Les deux notebooks derivent les memes resultats (echelle de profondeur, tournoi).
-",,,,,,,,3077fe8474db9a7e,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour-CSharp.ipynb,8e619664,markdown,fr,eec12dd54fb1f755,"## 1. Introduction
+**Pourquoi un jumeau C# ?** Le notebook Python compare 5 intelligences artificielles (aleatoire, Minimax avec elagage alpha-beta, MCTS, glouton, iterative deepening) sur le jeu de Puissance 4, en s'appuyant sur `numpy` et `matplotlib`. Ce jumeau reimplemente les mêmes algorithmes en **C# .NET 9 (BCL seule, 0 NuGet)** : moteur de jeu, heuristique de fenêtre, Minimax alpha-beta, MCTS (UCB1), tournoi round-robin et iterative deepening. Les graphiques `matplotlib` sont remplacés par un rendu **ASCII autonome**. Les deux notebooks derivent les mêmes résultats (echelle de profondeur, tournoi).
+",,,,,,,,101175721e006779,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour-CSharp.ipynb,8e619664,markdown,fr,f60e1c16674e6727,"## 1. Introduction
 
-Le Puissance 4 est un jeu de strategie combinatoire abstrait a information complete : deux joueurs (Rouge = joueur 1, Jaune = joueur 2) s'affrontent sur un plateau 6x7 en cherchant a aligner 4 jetons. Sa profondeur de jeu limitee (42 coups maximum) et son espace d'etats reduit (~4.5 trillions mais tres echantillonnable) en font un banc d'essai ideal pour comparer des algorithmes de decision.
+Le Puissance 4 est un jeu de stratégie combinatoire abstrait a information complete : deux joueurs (Rouge = joueur 1, Jaune = joueur 2) s'affrontent sur un plateau 6x7 en cherchant a aligner 4 jetons. Sa profondeur de jeu limitee (42 coups maximum) et son espace d'etats reduit (~4.5 trillions mais très echantillonnable) en font un banc d'essai ideal pour comparer des algorithmes de decision.
 
 Ce notebook met en compétition **5 approches** :
 1. **Joueur aleatoire** (baseline)
@@ -28417,11 +28417,11 @@ Ce notebook met en compétition **5 approches** :
 3. **Monte Carlo Tree Search (MCTS)** (recherche statistique par simulations)
 4. **Joueur glouton** (heuristique immediate, 1-ply)
 5. **Iterative deepening alpha-beta** (profondeur progressive avec limite de temps)
-",,,,,,,,eec12dd54fb1f755,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour-CSharp.ipynb,c3a528f4,markdown,fr,470151de76d732a1,"## 2. Moteur de jeu
+",,,,,,,,f60e1c16674e6727,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour-CSharp.ipynb,c3a528f4,markdown,fr,feed6ad8b5005049,"## 2. Moteur de jeu
 
-On encode le plateau comme une grille 6x7 (`grid[row, col]`, `row=0` en haut, pieces posees en bas). `EMPTY=0`, `PLAYER1=1` (Rouge), `PLAYER2=2` (Jaune). Les operations essentielles : `LegalMoves` (colonnes non pleines), `DropPiece` (gravite), `UndoMove` (backtracking), `CheckWin` (4 alignes en H/V/diag), `IsTerminal`.
-",,,,,,,,470151de76d732a1,,,,,,,
+On encode le plateau comme une grille 6x7 (`grid[row, col]`, `row=0` en haut, pieces posees en bas). `EMPTY=0`, `PLAYER1=1` (Rouge), `PLAYER2=2` (Jaune). Les opérations essentielles : `LegalMoves` (colonnes non pleines), `DropPiece` (gravite), `UndoMove` (backtracking), `CheckWin` (4 alignes en H/V/diag), `IsTerminal`.
+",,,,,,,,feed6ad8b5005049,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour-CSharp.ipynb,7310e22e,code,fr,f5a9bd86880de475,"// Imports et constantes du jeu. Plateau 6x7, alignement de 4.
 const int ROWS = 6;
 const int COLS = 7;
@@ -28569,16 +28569,16 @@ var (winner, history, _, _) = PlayGame(AiRandom, AiRandom, verbose: true);
 string res = winner == 0 ? ""Match nul"" : (winner == PLAYER1 ? ""Rouge (P1) gagne"" : ""Jaune (P2) gagne"");
 Console.WriteLine($""\nResultat : {res} en {history.Count} coups"");
 ",,,,,,,,c96054cc5c6a9110,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour-CSharp.ipynb,4b48ad98,markdown,fr,c1069eac7babee43,"## 3. Heuristique de position (fenetres de 4)
+MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour-CSharp.ipynb,4b48ad98,markdown,fr,4d2141ea667b74e5,"## 3. Heuristique de position (fenêtres de 4)
 
-L'evaluation du plateau pour Minimax repose sur le decompte des **fenetres de 4 cases** contigues (horizontales, verticales, diagonales). Pour chaque fenetre :
+L'evaluation du plateau pour Minimax repose sur le decompte des **fenêtres de 4 cases** contigues (horizontales, verticales, diagonales). Pour chaque fenêtre :
 - 4 jetons du joueur : **+1000** (gagnant)
 - 3 jetons + 1 vide : **+10** (pres de gagner)
 - 2 jetons + 2 vides : **+2** (potential)
 - 3 jetons adverses + 1 vide : **-8** (bloquer)
 
-Un **bonus de centre** (+3 par jeton en colonne 3) favorise le controle du centre, strategiquement fort.
-",,,,,,,,c1069eac7babee43,,,,,,,
+Un **bonus de centre** (+3 par jeton en colonne 3) favorise le contrôle du centre, strategiquement fort.
+",,,,,,,,4d2141ea667b74e5,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour-CSharp.ipynb,f8d23649,code,fr,043a63900856aaa4,"// Heuristique : evaluation d'une fenetre de 4 cases, puis de la position globale.
 static int EvaluateWindow(int[] window, int player)
 {
@@ -28694,10 +28694,10 @@ Console.WriteLine($""\nResultat : {res} en {history.Count} coups"");
 Console.WriteLine($""Temps moyen Minimax : {t1Ms/1000.0:F3}s/coup"");
 Console.WriteLine($""Temps moyen Random  : {t2Ms/1e6:F6}s/coup"");
 ",,,,,,,,81816c519c716e5e,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour-CSharp.ipynb,2b82d0a2,markdown,fr,26f87d445b27f767,"### Experience : effet de la profondeur
+MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour-CSharp.ipynb,2b82d0a2,markdown,fr,b88bc64fbe0b4c00,"### Expérience : effet de la profondeur
 
 Plus la profondeur de recherche augmente, plus Minimax anticipe loin — au prix du temps de calcul (croissance exponentielle). On mesure le **taux de victoire** et le **temps par coup** pour les profondeurs 2, 4 et 6 contre le joueur aleatoire.
-",,,,,,,,26f87d445b27f767,,,,,,,
+",,,,,,,,b88bc64fbe0b4c00,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour-CSharp.ipynb,2b0a0bbe,code,fr,5d9bd7978af64ff8,"// Comparer les profondeurs 2, 4 et 6 (10 parties chacune vs Random).
 foreach (int depth in new[] { 2, 4, 6 })
 {
@@ -28715,10 +28715,10 @@ foreach (int depth in new[] { 2, 4, 6 })
     Console.WriteLine($""Minimax(d={depth}) : {wins}/{nGames} victoires, {totalMs / nGames / 1000.0:F1} ms/coup"");
 }
 ",,,,,,,,5d9bd7978af64ff8,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour-CSharp.ipynb,46fa2f27,markdown,fr,15476e3604807141,"## 5. IA 3 : Monte Carlo Tree Search (MCTS)
+MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour-CSharp.ipynb,46fa2f27,markdown,fr,4f02b8dd346911d9,"## 5. IA 3 : Monte Carlo Tree Search (MCTS)
 
-MCTS construit progressivement un arbre de jeu par **simulations aleatoires** (rollouts). Chaque noeud choisit ses enfants via **UCB1** (Upper Confidence Bound) qui equilibre exploitation (moyenne des recompenses) et exploration (visites rares). Apres un budget d'iterations, on joue le coup le plus visite.
-",,,,,,,,15476e3604807141,,,,,,,
+MCTS construit progressivement un arbre de jeu par **simulations aleatoires** (rollouts). Chaque noeud choisit ses enfants via **UCB1** (Upper Confidence Bound) qui equilibre exploitation (moyenne des recompenses) et exploration (visites rares). Après un budget d'itérations, on joue le coup le plus visite.
+",,,,,,,,4f02b8dd346911d9,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour-CSharp.ipynb,23393897,code,fr,1f85e10d3aefd24a,"// MCTS pour Puissance 4 : selection UCB1, expansion, rollout aleatoire, backpropagation.
 public class MctsNode
 {
@@ -28828,10 +28828,10 @@ Console.WriteLine($""\nResultat : {res} en {history.Count} coups"");
 Console.WriteLine($""Temps moyen MCTS    : {t1Ms/1000.0:F3}s/coup"");
 Console.WriteLine($""Temps moyen Minimax : {t2Ms/1000.0:F3}s/coup"");
 ",,,,,,,,a12704e06ebf28d4,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour-CSharp.ipynb,71930676,markdown,fr,5ef75efbdf61ccf1,"## 6. IA 4 : Joueur glouton (heuristique 1-ply)
+MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour-CSharp.ipynb,71930676,markdown,fr,c92e6f7709a380de,"## 6. IA 4 : Joueur glouton (heuristique 1-ply)
 
-Le joueur glouton teste chaque coup legal, l'evalue immediatement via `EvaluatePosition`, et joue le meilleur. Pas de recherche : c'est une **strategie 1-ply** (un seul coup anticipe). Rapide mais sans vision d'adversaire.
-",,,,,,,,5ef75efbdf61ccf1,,,,,,,
+Le joueur glouton teste chaque coup legal, l'evalue immediatement via `EvaluatePosition`, et joue le meilleur. Pas de recherche : c'est une **stratégie 1-ply** (un seul coup anticipe). Rapide mais sans vision d'adversaire.
+",,,,,,,,c92e6f7709a380de,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour-CSharp.ipynb,dd632d67,code,fr,b1426aa08b6a0016,"// IA glouton : teste chaque coup, garde celui qui maximise EvaluatePosition.
 Func<Board, int, int> AiGreedy = (board, player) =>
 {
@@ -28906,10 +28906,10 @@ foreach (var n in names.OrderByDescending(n => wins[n] * 2 + draws[n]))
     Console.WriteLine($""{n,-12} {wins[n],4} {losses[n],4} {draws[n],4} {score,6}"");
 }
 ",,,,,,,,4d248e51147d2f3f,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour-CSharp.ipynb,83bb30f9,markdown,fr,c56f6148c40941ca,"## 8. Iterative deepening alpha-beta (limite de temps)
+MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour-CSharp.ipynb,83bb30f9,markdown,fr,0d4a5fcd798a8a6e,"## 8. Iterative deepening alpha-beta (limite de temps)
 
-Plutot qu'une profondeur fixe, l'**iterative deepening** relance Minimax en augmentant la profondeur (1, 2, 3, ...) jusqu'a epuisement d'un budget temps. On garde le meilleur coup de la derniere profondeur completee. Cette approche combine les avantages d'alpha-beta (l'ordonnancement s'ameliore avec la profondeur) et d'une garantie de reponse dans le temps imparti.
-",,,,,,,,c56f6148c40941ca,,,,,,,
+Plutot qu'une profondeur fixe, l'**iterative deepening** relance Minimax en augmentant la profondeur (1, 2, 3, ...) jusqu'a epuisement d'un budget temps. On garde le meilleur coup de la dernière profondeur completee. Cette approche combine les avantages d'alpha-beta (l'ordonnancement s'ameliore avec la profondeur) et d'une garantie de reponse dans le temps imparti.
+",,,,,,,,0d4a5fcd798a8a6e,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour-CSharp.ipynb,2db42d35,code,fr,5bf242d3e93b4940,"// Iterative deepening : relance Minimax en augmentant la profondeur jusqu'a la limite de temps.
 public static (int col, int depthReached) IterativeDeepening(Board board, int player, double timeBudgetSec)
 {
@@ -28981,20 +28981,20 @@ public static int CountNodes(Board board, int depth, int player)
 Console.WriteLine(""Exercice 3 a completer : implementez order_moves() et count_nodes."");
 Console.WriteLine(""Attendu : speedup 2-5x avec ordering (moins de noeuds explores pour le meme coup)."");
 ",,,,,,,,72840223d90e497f,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour-CSharp.ipynb,c2811080,markdown,fr,e620f80b39b6848f,"## Conclusion et resume
+MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour-CSharp.ipynb,c2811080,markdown,fr,06a7102933c2508d,"## Conclusion et resume
 
 Ce jumeau C# a reimplemente, sans aucune librairie externe, le banc d'essai comparatif du notebook Python :
 
 - **Moteur de jeu** complet (plateau 6x7, legalite, victoire, undo pour backtracking)
 - **5 algorithmes** : joueur aleatoire, glouton (1-ply), Minimax alpha-beta, MCTS (UCB1), iterative deepening
-- **Heuristique de fenetres** (4 alignes +1000, 3+vide +10, etc., bonus centre)
-- **Tournoi round-robin** revelant la hierarchie des algorithmes
+- **Heuristique de fenêtres** (4 alignes +1000, 3+vide +10, etc., bonus centre)
+- **Tournoi round-robin** revelant la hiérarchie des algorithmes
 
 ### Parite avec le notebook Python
 
 | Quantite | Python | C# |
 |----------|--------|-----|
-| Heuristique fenetre (4/3+e/2+2e/opp3+e) | +1000/+10/+2/-8 | identique |
+| Heuristique fenêtre (4/3+e/2+2e/opp3+e) | +1000/+10/+2/-8 | identique |
 | Score terminal victoire/defaite | +/-100000+depth | identique |
 | Ordonnancement centre d'abord | oui | oui |
 | Echelle de profondeur (d=2,4,6) | 10/10 chaque vs Random | 10/10 chaque vs Random |
@@ -29004,26 +29004,26 @@ Les **tendances** sont identiques : Minimax bat tout (MCTS suit, glouton bat ran
 
 ### Pathologie de l'arbre de jeu (note honnete, G.1)
 
-Le tournoi revele un resultat contre-intuitif mais **reel et documente** : **Minimax(d=2) bat Minimax(d=4)** dans cette configuration (match aller-retour 4-0 dans les deux sens). Ce n'est pas un bug — le moteur et l'heuristique sont verifies (scores de position re-derives a la main, P1=9/P2=5 sur le plateau de demo). C'est la **pathologie de la recherche dans les arbres de jeu** (Nau, 1982) : avec une heuristique *imparfaite*, une recherche plus profonde peut systematiquement perdre contre une recherche moins profonde, parce que l'effet d'horizon fait sur-evaluer des menaces qui ne se realisent jamais. Les matchs Minimax-vs-Minimax etant **deterministes** (aucun aleatoire dans la recherche), le meme coup est joue a chaque partie — d'ou des scores 4-0 nets. L'avantage du **premier joueur** (P1 = Rouge) est egalement massif au Puissance 4 (victoire forcee en jeu parfait). Ce phenomene est une lecon pedagogique centrale : « plus profond » n'implique pas « meilleur » des qu'on s'ecarte du jeu parfait. Les **valeurs numeriques exactes** (temps, compteurs) different C# vs Python (JIT .NET plus rapide que CPython) — c'est un effet runtime attendu, pas une difference algorithmique.
+Le tournoi revele un résultat contre-intuitif mais **reel et documente** : **Minimax(d=2) bat Minimax(d=4)** dans cette configuration (match aller-retour 4-0 dans les deux sens). Ce n'est pas un bug — le moteur et l'heuristique sont verifies (scores de position re-derives a la main, P1=9/P2=5 sur le plateau de demo). C'est la **pathologie de la recherche dans les arbres de jeu** (Nau, 1982) : avec une heuristique *imparfaite*, une recherche plus profonde peut systematiquement perdre contre une recherche moins profonde, parce que l'effet d'horizon fait sur-evaluer des menaces qui ne se realisent jamais. Les matchs Minimax-vs-Minimax etant **déterministes** (aucun aleatoire dans la recherche), le même coup est joue a chaque partie — d'ou des scores 4-0 nets. L'avantage du **premier joueur** (P1 = Rouge) est également massif au Puissance 4 (victoire forcee en jeu parfait). Ce phenomene est une lecon pedagogique centrale : « plus profond » n'implique pas « meilleur » des qu'on s'ecarte du jeu parfait. Les **valeurs numériques exactes** (temps, compteurs) différent C# vs Python (JIT .NET plus rapide que CPython) — c'est un effet runtime attendu, pas une différence algorithmique.
 
-### Prochaines etapes
+### Prochaines étapes
 
-- [App-13-TSP-Metaheuristiques (C#)](../Hybrid/App-13-TSP-Metaheuristics.ipynb) : metaheuristiques sur un autre probleme combinatoire.
+- [App-13-TSP-Métaheuristiques (C#)](../Hybrid/App-13-TSP-Metaheuristics.ipynb) : métaheuristiques sur un autre problème combinatoire.
 - [GameTheory-13-ImperfectInfo-CFR (C#)](../../../GameTheory/GameTheory-13-ImperfectInfo-CFR-Csharp.ipynb) : contre-factual regret minimization pour jeux a information incomplete.
 - [Search-7-MCTS-And-Beyond (C#)](../../Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb) : MCTS en detail (UCT, AlphaGo).
 
 ---
 
 *Part of #4956 (marathon parite .NET <-> Python).*
-",,,,,,,,e620f80b39b6848f,,,,,,,
+",,,,,,,,06a7102933c2508d,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,nav-header,markdown,fr,06772a7d85fcb00d,"# App-12 : Puissance 4 -- Comparaison d'algorithmes IA (Bonus)
 
 **Navigation** : [<< App-11 Picross](../CSP/App-11-Picross.ipynb) | [Index](../../README.md) | [Part1-Foundations](../../Part1-Foundations/README.md)",,,,,,,,06772a7d85fcb00d,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,intro-section,markdown,fr,4af706f3d7a013f2,"## 1. Introduction
+MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,intro-section,markdown,fr,b7ef8cce3ccea3f6,"## 1. Introduction
 
 ### Le Puissance 4
 
-Le **Puissance 4** (Connect Four) est un jeu de strategie a deux joueurs sur un plateau vertical de 7 colonnes et 6 lignes. Les joueurs deposent alternativement un jeton de leur couleur dans une colonne ; le jeton tombe au plus bas de la colonne. Le premier joueur a aligner **4 jetons** (horizontalement, verticalement ou en diagonale) remporte la partie.
+Le **Puissance 4** (Connect Four) est un jeu de stratégie a deux joueurs sur un plateau vertical de 7 colonnes et 6 lignes. Les joueurs deposent alternativement un jeton de leur couleur dans une colonne ; le jeton tombe au plus bas de la colonne. Le premier joueur a aligner **4 jetons** (horizontalement, verticalement ou en diagonale) remporte la partie.
 
 | Propriete | Valeur |
 |-----------|--------|
@@ -29031,15 +29031,15 @@ Le **Puissance 4** (Connect Four) est un jeu de strategie a deux joueurs sur un 
 | Joueurs | 2 (Rouge et Jaune) |
 | Facteur de branchement | ~4 en moyenne (max 7) |
 | Positions possibles | ~4.5 x 10^12 |
-| Jeu resolu | Oui (1988, Victor Allis) |
-| Resultat parfait | Le premier joueur gagne avec jeu parfait |
+| Jeu résolu | Oui (1988, Victor Allis) |
+| résultat parfait | Le premier joueur gagne avec jeu parfait |
 
-### Pourquoi ce jeu est interessant pour l'IA
+### Pourquoi ce jeu est intéressant pour l'IA
 
-Le Puissance 4 occupe une position intermediaire en complexite :
-- Plus simple que les echecs ou le Go (arbre de jeu plus petit)
-- Plus complexe que le morpion (assez profond pour que les algorithmes naifs echouent)
-- Ideal pour comparer differentes familles d'algorithmes de recherche
+Le Puissance 4 occupe une position intermediaire en complexité :
+- Plus simple que les échecs ou le Go (arbre de jeu plus petit)
+- Plus complexe que le morpion (assez profond pour que les algorithmes naifs échouent)
+- Ideal pour comparer différentes familles d'algorithmes de recherche
 
 Dans ce notebook, nous implementons et comparons **4 approches** :
 
@@ -29047,20 +29047,20 @@ Dans ce notebook, nous implementons et comparons **4 approches** :
 |----|---------|------------|------------|
 | Random | Baseline | 0 | Instantane |
 | Greedy | Heuristique | 1 | Instantane |
-| Minimax (alpha-beta) | Arbre adversaire | Configurable | Modere |
-| MCTS | Monte Carlo | Variable | Configurable |",,,,,,,,4af706f3d7a013f2,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,engine-intro,markdown,fr,2771d762ef6d0b19,"## 2. Moteur de jeu
+| Minimax (alpha-beta) | Arbre adversaire | Configurable | modère |
+| MCTS | Monte Carlo | variable | Configurable |",,,,,,,,b7ef8cce3ccea3f6,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,engine-intro,markdown,fr,3077144c1a9f2247,"## 2. Moteur de jeu
 
-Nous commencons par implementer le moteur de jeu : representation du plateau, regles, detection de victoire et affichage graphique.
+Nous commencons par implementer le moteur de jeu : représentation du plateau, règles, détection de victoire et affichage graphique.
 
-### Representation du plateau
+### Représentation du plateau
 
 Le plateau est une matrice numpy 6x7 :
 - `0` = case vide
 - `1` = jeton du joueur 1 (Rouge)
 - `2` = jeton du joueur 2 (Jaune)
 
-La ligne 0 est le **haut** du plateau (derniere a se remplir).",,,,,,,,2771d762ef6d0b19,,,,,,,
+La ligne 0 est le **haut** du plateau (dernière a se remplir).",,,,,,,,3077144c1a9f2247,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,imports,code,fr,43270d663a0b1cef,"# Imports
 import sys
 sys.path.insert(0, '..')
@@ -29092,9 +29092,9 @@ CONNECT = 4  # Nombre de jetons a aligner
 
 print(f""Puissance 4 : plateau {ROWS}x{COLS}, alignement de {CONNECT}"")
 print(""Environnement pret."")",,,,,,,,43270d663a0b1cef,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,board-class-intro,markdown,fr,eef48a922b1c3683,"### Classe Board
+MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,board-class-intro,markdown,fr,e401ee9bb1956862,"### Classe Board
 
-La classe `Board` encapsule l'etat du jeu et fournit les operations fondamentales : coups legaux, placement de jeton, detection de victoire et affichage.",,,,,,,,eef48a922b1c3683,,,,,,,
+La classe `Board` encapsule l'etat du jeu et fournit les opérations fondamentales : coups legaux, placement de jeton, détection de victoire et affichage.",,,,,,,,e401ee9bb1956862,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,board-class,code,fr,761ccaa86a817169,"class Board:
     """"""Plateau de Puissance 4 avec logique de jeu complete.""""""
 
@@ -29183,21 +29183,21 @@ board.drop_piece(4, PLAYER1)
 print(board)
 print(f""\nCoups legaux : {board.legal_moves()}"")
 print(f""Jetons poses : {board.move_count()}"")",,,,,,,,761ccaa86a817169,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,board-interpretation,markdown,fr,ddb2867bb6d39f3b,"### Interpretation : Moteur de jeu
+MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,board-interpretation,markdown,fr,b5d49875e2966186,"### Interprétation : Moteur de jeu
 
 **Sortie obtenue** : Le plateau s'affiche en mode texte avec R (Rouge) et J (Jaune). Les jetons tombent correctement vers le bas.
 
 | Aspect | Detail |
 |--------|--------|
-| Representation | Matrice numpy 6x7, 0/1/2 |
+| représentation | Matrice numpy 6x7, 0/1/2 |
 | Gravite | Les jetons s'empilent du bas vers le haut |
-| Detection victoire | 4 directions : horizontale, verticale, 2 diagonales |
+| détection victoire | 4 directions : horizontale, verticale, 2 diagonales |
 | Backtracking | `undo_move` permet de defaire un coup (utile pour Minimax) |
 
 **Points cles** :
-1. La methode `legal_moves()` verifie la ligne superieure (indice 0) : si elle est occupee, la colonne est pleine
-2. `check_win` parcourt les 4 directions avec des fenetres de taille 4 -- complexite O(ROWS x COLS)
-3. L'utilisation de `undo_move` evite de copier le plateau a chaque noeud de l'arbre de recherche",,,,,,,,ddb2867bb6d39f3b,,,,,,,
+1. La méthode `legal_moves()` vérifie la ligne supérieure (indice 0) : si elle est occupee, la colonne est pleine
+2. `check_win` parcourt les 4 directions avec des fenêtrès de taille 4 -- complexité O(ROWS x COLS)
+3. L'utilisation de `undo_move` évite de copier le plateau a chaque noeud de l'arbre de recherche",,,,,,,,b5d49875e2966186,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,display-intro,markdown,fr,ecb4ba582929c774,"### Affichage graphique
 
 Pour une meilleure lisibilite, affichons le plateau avec matplotlib en utilisant des cercles colores sur fond bleu, a l'image d'un vrai plateau de Puissance 4.",,,,,,,,ecb4ba582929c774,,,,,,,
@@ -29259,14 +29259,14 @@ for col, player in moves:
 fig = display_board(demo_board, ""Partie en cours (8 coups joues)"")
 plt.tight_layout()
 plt.show()",,,,,,,,f8117341598fc4a2,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,display-interpretation,markdown,fr,dd2628fc365b9a66,"### Interpretation : Affichage graphique
+MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,display-interpretation,markdown,fr,262131dac543b7bd,"### Interprétation : Affichage graphique
 
-**Sortie obtenue** : Le plateau apparait avec les cercles rouge (joueur 1) et jaune (joueur 2) sur fond bleu, fidelement au jeu reel.
+**Sortie obtenue** : Le plateau apparaît avec les cercles rouge (joueur 1) et jaune (joueur 2) sur fond bleu, fidélément au jeu réel.
 
 **Points cles** :
 1. L'axe Y est inverse pour que la gravite soit naturelle (les jetons tombent vers le bas)
 2. Les cases vides sont affichees en bleu clair pour simuler les trous du plateau
-3. Cette visualisation sera reutilisee pour afficher les parties entre IA",,,,,,,,dd2628fc365b9a66,,,,,,,
+3. Cette visualisation sera réutilisée pour afficher les parties entre IA",,,,,,,,262131dac543b7bd,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,play-intro,markdown,fr,163bfa5672598870,"### Fonction de jeu
 
 Implementons la boucle de jeu qui fait s'affronter deux IA. Chaque IA est une fonction qui prend un plateau et le joueur courant, et retourne la colonne choisie.",,,,,,,,163bfa5672598870,,,,,,,
@@ -29312,9 +29312,9 @@ MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,play-funct
 
 
 print(""Fonction play_game definie."")",,,,,,,,45e491d81ced7f63,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,random-section,markdown,fr,3f77c03e6a9f47c5,"## 3. IA 1 : Joueur aleatoire (baseline)
+MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,random-section,markdown,fr,61eb9eb5f6b634bc,"## 3. IA 1 : Joueur aléatoire (baseline)
 
-Le joueur aleatoire constitue notre **baseline** : il choisit uniformement parmi les colonnes legales, sans aucune strategie. Cette IA nous permettra de mesurer a quel point les autres approches sont meilleures qu'un jeu au hasard.",,,,,,,,3f77c03e6a9f47c5,,,,,,,
+Le joueur aléatoire constitue notre **baseline** : il choisit uniformêment parmi les colonnes legales, sans aucune stratégie. Cette IA nous permettra de mesurer a quel point les autrès approches sont meilleures qu'un jeu au hasard.",,,,,,,,61eb9eb5f6b634bc,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,random-ai,code,fr,be8c5aefae26ccf3,"def ai_random(board, player):
     """"""IA aleatoire : choisit une colonne legale au hasard.""""""
     return random.choice(board.legal_moves())
@@ -29326,18 +29326,18 @@ winner, history, times = play_game(ai_random, ai_random, verbose=True, display=T
 
 result = {0: ""Match nul"", PLAYER1: ""Rouge gagne"", PLAYER2: ""Jaune gagne""}
 print(f""\nResultat : {result[winner]} en {len(history)} coups"")",,,,,,,,be8c5aefae26ccf3,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,random-interpretation,markdown,fr,4aae673aba5dec1e,"### Interpretation : Joueur aleatoire
+MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,random-interpretation,markdown,fr,dfbff07b0bb0ad11,"### Interprétation : Joueur aléatoire
 
-**Sortie obtenue** : Une partie entre deux joueurs aleatoires, typiquement chaotique et sans strategie.
+**Sortie obtenue** : Une partie entre deux joueurs aléatoires, typiquement chaotique et sans stratégie.
 
-| Aspect | Observation |
+| Aspect | observation |
 |--------|-------------|
-| Qualite de jeu | Tres faible : coups absurdes frequents |
+| Qualite de jeu | très faible : coups absurdes fréquents |
 | Temps par coup | Negligeable (< 0.001s) |
-| Utilite | Baseline pour mesurer la qualite des autres IA |
+| utilité | Baseline pour mesurer la qualite des autrès IA |
 
-**Point cle** : Le joueur aleatoire ne detecte meme pas les victoires immediates. Il peut ""oublier"" de gagner ou de bloquer l'adversaire. C'est la pire IA possible -- tout algorithme raisonnable devrait le battre systematiquement.",,,,,,,,4aae673aba5dec1e,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,minimax-section,markdown,fr,e74a9385646f340a,"## 4. IA 2 : Minimax avec elagage alpha-beta
+**Point cle** : Le joueur aléatoire ne détecte même pas les victoires immédiates. Il peut ""oublier"" de gagner ou de bloquer l'adversaire. C'est la pire IA possible -- tout algorithme raisonnable devrait le battre systématiquement.",,,,,,,,dfbff07b0bb0ad11,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,minimax-section,markdown,fr,a8c1db56ff3089fa,"## 4. IA 2 : Minimax avec elagage alpha-beta
 
 ### Principe
 
@@ -29345,22 +29345,22 @@ L'algorithme **Minimax** explore l'arbre de jeu en alternant entre :
 - **Max** : le joueur courant maximise son score
 - **Min** : l'adversaire minimise le score du joueur courant
 
-L'**elagage alpha-beta** permet de couper des branches de l'arbre sans perdre en qualite de decision :
+L'**elagage alpha-beta** permet de couper des branches de l'arbre sans perdre en qualite de décision :
 - $\alpha$ = meilleur score garanti pour Max sur le chemin courant
 - $\beta$ = meilleur score garanti pour Min sur le chemin courant
 - Si $\alpha \geq \beta$, on coupe (la branche ne sera jamais choisie)
 
-### Fonction d'evaluation
+### Fonction d'évaluation
 
-Pour limiter la profondeur de recherche, il faut une **fonction d'evaluation** qui estime la qualite d'une position non terminale. Notre evaluation analyse les fenetres de 4 cases :
+Pour limiter la profondeur de recherche, il faut une **fonction d'évaluation** qui estime la qualite d'une position non terminale. Notre évaluation analyse les fenêtrès de 4 cases :
 
-| Configuration dans une fenetre de 4 | Score |
+| Configuration dans une fenêtre de 4 | Score |
 |--------------------------------------|-------|
 | 4 jetons du joueur | +1000 (victoire) |
 | 3 jetons du joueur + 1 vide | +10 |
 | 2 jetons du joueur + 2 vides | +2 |
 | 3 jetons adversaire + 1 vide | -8 (menace) |
-| Jeton au centre | +3 (bonus positionnel) |",,,,,,,,e74a9385646f340a,,,,,,,
+| Jeton au centre | +3 (bonus positionnel) |",,,,,,,,a8c1db56ff3089fa,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,eval-function,code,fr,8d848badf831b739,"def evaluate_window(window, player):
     """"""Evalue une fenetre de 4 cases pour le joueur donne.""""""
     opponent = PLAYER2 if player == PLAYER1 else PLAYER1
@@ -29426,9 +29426,9 @@ score_p2 = evaluate_position(demo_board, PLAYER2)
 print(f""Score joueur 1 (Rouge) : {score_p1}"")
 print(f""Score joueur 2 (Jaune) : {score_p2}"")
 print(f""Avantage : {'Rouge' if score_p1 > score_p2 else 'Jaune'} (+{abs(score_p1 - score_p2)})"")",,,,,,,,8d848badf831b739,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,minimax-impl-intro,markdown,fr,f6aa1f4b12672b85,"### Implementation de Minimax alpha-beta
+MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,minimax-impl-intro,markdown,fr,a843224f269414a9,"### Implementation de Minimax alpha-beta
 
-L'algorithme explore l'arbre de jeu avec une profondeur limite configurable. L'ordre d'exploration des colonnes est optimise : on commence par le centre (meilleure heuristique en general).",,,,,,,,f6aa1f4b12672b85,,,,,,,
+L'algorithme explore l'arbre de jeu avec une profondeur limite configurable. L'ordre d'exploration des colonnes est optimise : on commence par le centre (meilleure heuristique en général).",,,,,,,,a843224f269414a9,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,minimax-code,code,fr,189db2ea3ef1f226,"def minimax(board, depth, alpha, beta, maximizing, player):
     """"""
     Minimax avec elagage alpha-beta.
@@ -29503,9 +29503,9 @@ def make_minimax_ai(depth):
 
 print(""Minimax alpha-beta implemente."")
 print(""Profondeurs recommandees : 2 (rapide), 4 (bon), 6 (fort mais lent)"")",,,,,,,,189db2ea3ef1f226,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,minimax-test-intro,markdown,fr,7a3fe3d48b46873c,"### Test : Minimax vs Random
+MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,minimax-test-intro,markdown,fr,ef0dde653af6d7d6,"### Test : Minimax vs Random
 
-Verifions que Minimax domine clairement le joueur aleatoire. Nous utilisons une profondeur de 4 pour un bon compromis qualite/vitesse.",,,,,,,,7a3fe3d48b46873c,,,,,,,
+vérifions que Minimax domine clairement le joueur aléatoire. Nous utilisons une profondeur de 4 pour un bon compromis qualite/vitesse.",,,,,,,,ef0dde653af6d7d6,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,minimax-test,code,fr,29f2e3930759fc51,"# Minimax (profondeur 4) vs Random
 ai_mm4 = make_minimax_ai(4)
 
@@ -29516,23 +29516,23 @@ result_str = {0: ""Match nul"", PLAYER1: ""Minimax gagne"", PLAYER2: ""Random ga
 print(f""\nResultat : {result_str[winner]} en {len(history)} coups"")
 print(f""Temps moyen Minimax : {np.mean(times[PLAYER1]):.3f}s/coup"")
 print(f""Temps moyen Random  : {np.mean(times[PLAYER2]):.6f}s/coup"")",,,,,,,,29f2e3930759fc51,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,minimax-interpretation,markdown,fr,cc0511fbe3f61b4a,"### Interpretation : Minimax vs Random
+MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,minimax-interpretation,markdown,fr,d743ada8210a7c77,"### Interprétation : Minimax vs Random
 
-**Sortie obtenue** : Minimax (profondeur 4) devrait battre le joueur aleatoire sans difficulte.
+**Sortie obtenue** : Minimax (profondeur 4) devrait battre le joueur aléatoire sans difficulté.
 
 | Aspect | Minimax (d=4) | Random |
 |--------|---------------|--------|
-| Qualite de jeu | Bonne (detecte menaces a 4 coups) | Nulle |
+| Qualite de jeu | Bonne (détecte menaces a 4 coups) | Nulle |
 | Temps par coup | ~0.01-0.1s | < 0.001s |
-| Strategie | Offensive et defensive | Aucune |
+| stratégie | Offensive et defensive | Aucune |
 
 **Points cles** :
-1. Minimax gagne rapidement car il exploite les erreurs du joueur aleatoire
-2. L'elagage alpha-beta reduit considerablement le nombre de noeuds explores
-3. L'ordonnancement des coups (centre en premier) ameliore l'efficacite de l'elagage",,,,,,,,cc0511fbe3f61b4a,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,depth-experiment-intro,markdown,fr,a056727203f74820,"### Experiment : Effet de la profondeur
+1. Minimax gagne rapidement car il exploite les erreurs du joueur aléatoire
+2. L'elagage alpha-beta réduit considérablement le nombre de noeuds explores
+3. L'ordonnancement des coups (centre en premier) améliore l'efficacité de l'elagage",,,,,,,,d743ada8210a7c77,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,depth-experiment-intro,markdown,fr,2b922f849ac35148,"### Experiment : Effet de la profondeur
 
-Comparons trois profondeurs de Minimax pour observer le compromis qualite/temps. Chaque profondeur joue 10 parties contre le joueur aleatoire.",,,,,,,,a056727203f74820,,,,,,,
+Comparons trois profondeurs de Minimax pour observer le compromis qualite/temps. Chaque profondeur joue 10 parties contre le joueur aléatoire.",,,,,,,,2b922f849ac35148,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,depth-experiment,code,fr,d7edc633f0f4ebdd,"# Comparer les profondeurs 2, 4 et 6
 depths = [2, 4, 6]
 n_games = 10
@@ -29577,9 +29577,9 @@ ax2.grid(axis='y', alpha=0.3)
 plt.suptitle('Effet de la profondeur de Minimax', fontsize=14, fontweight='bold')
 plt.tight_layout()
 plt.show()",,,,,,,,d7edc633f0f4ebdd,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,depth-interpretation,markdown,fr,7470906a8eae2363,"### Interpretation : Effet de la profondeur
+MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,depth-interpretation,markdown,fr,5a3cdde76e41faa2,"### Interprétation : Effet de la profondeur
 
-**Sortie obtenue** : Les trois profondeurs remportent 10/10 contre le joueur aleatoire ; seul le temps de calcul differe.
+**Sortie obtenue** : Les trois profondeurs remportent 10/10 contre le joueur aléatoire ; seul le temps de calcul diffère.
 
 | Profondeur | Victoires | Temps/coup mesure | Noeuds explores (ordre de grandeur) |
 |------------|-----------|-------------------|--------------------------------------|
@@ -29588,23 +29588,23 @@ MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,depth-inte
 | d=6 | 10/10 | ~2824 ms | ~125 000 |
 
 **Points cles** :
-1. Meme d=2 suffit contre un joueur aleatoire (10/10 victoires)
+1. même d=2 suffit contre un joueur aléatoire (10/10 victoires)
 2. Le temps croit **exponentiellement** avec la profondeur : $O(b^d)$ ou $b \approx 4$ en moyenne
-3. L'elagage alpha-beta reduit la complexite de $O(b^d)$ a $O(b^{d/2})$ dans le meilleur cas
+3. L'elagage alpha-beta réduit la complexité de $O(b^d)$ a $O(b^{d/2})$ dans le meilleur cas
 4. La profondeur d=4 offre un bon compromis pour le Puissance 4
 
-> La vraie difference se verra dans le tournoi, ou les IA s'affrontent entre elles.
-",,,,,,,,7470906a8eae2363,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,mcts-section,markdown,fr,00b69cd0fb999b74,"## 5. IA 3 : Monte Carlo Tree Search (MCTS)
+> La vraie différence se verra dans le tournoi, ou les IA s'affrontent entre elles.
+",,,,,,,,5a3cdde76e41faa2,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,mcts-section,markdown,fr,7b9a494407a1512b,"## 5. IA 3 : Monte Carlo Tree Search (MCTS)
 
 ### Principe
 
-**MCTS** construit progressivement un arbre de recherche en repetant quatre etapes :
+**MCTS** construit progressivement un arbre de recherche en repetant quatre étapes :
 
-1. **Selection** : descendre dans l'arbre en utilisant UCB1 pour equilibrer exploration et exploitation
+1. **sélection** : descendre dans l'arbre en utilisant UCB1 pour équilibrer exploration et exploitation
 2. **Expansion** : ajouter un nouveau noeud enfant
-3. **Simulation** : jouer une partie aleatoire (rollout) jusqu'a la fin
-4. **Retropropagation** : remonter le resultat dans l'arbre
+3. **Simulation** : jouer une partie aléatoire (rollout) jusqu'a la fin
+4. **Retropropagation** : remonter le résultat dans l'arbre
 
 La formule **UCB1** (Upper Confidence Bound) pour choisir quel enfant explorer :
 
@@ -29619,11 +29619,11 @@ $$UCB1(i) = \frac{w_i}{n_i} + c \sqrt{\frac{\ln N}{n_i}}$$
 
 ### Avantages de MCTS
 
-- **Pas besoin de fonction d'evaluation** : les simulations aleatoires servent d'estimation
-- **Algorithme anytime** : on peut l'arreter a tout moment et obtenir une decision
-- **Scalable** : plus on donne d'iterations, meilleure est la decision
+- **Pas besoin de fonction d'évaluation** : les simulations aléatoires servent d'estimation
+- **Algorithme anytime** : on peut l'arreter a tout moment et obtenir une décision
+- **Scalable** : plus on donne d'itérations, meilleure est la décision
 
-> **Voir aussi** : la [serie GameTheory](../../../GameTheory/README.md) pour une presentation detaillee de MCTS et ses variantes (UCT, RAVE, PUCT).",,,,,,,,00b69cd0fb999b74,,,,,,,
+> **Voir aussi** : la [serie GameTheory](../../../GameTheory/README.md) pour une présentation detaillee de MCTS et ses variantes (UCT, RAVE, PUCT).",,,,,,,,7b9a494407a1512b,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,mcts-code,code,fr,1a4eb2980fb25691,"class MCTSNode:
     """"""Noeud de l'arbre MCTS.""""""
 
@@ -29729,9 +29729,9 @@ def make_mcts_ai(iterations):
 
 print(""MCTS implemente."")
 print(""Iterations recommandees : 100 (rapide), 500 (bon), 1000 (fort), 5000 (tres fort)"")",,,,,,,,1a4eb2980fb25691,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,mcts-test-intro,markdown,fr,922034353983e6ca,"### Test : MCTS vs Minimax
+MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,mcts-test-intro,markdown,fr,34a51bcace605f44,"### Test : MCTS vs Minimax
 
-Faisons s'affronter MCTS (1000 iterations) contre Minimax (profondeur 4) pour observer la qualite de jeu des deux approches.",,,,,,,,922034353983e6ca,,,,,,,
+Faisons s'affronter MCTS (1000 itérations) contre Minimax (profondeur 4) pour observer la qualite de jeu des deux approches.",,,,,,,,34a51bcace605f44,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,mcts-test,code,fr,037e297b5ec5285e,"# MCTS (1000 iterations) vs Minimax (profondeur 4)
 ai_mcts_1000 = make_mcts_ai(1000)
 ai_mm4 = make_minimax_ai(4)
@@ -29744,33 +29744,33 @@ result_str = ""Match nul"" if winner == 0 else f""{names[winner]} gagne""
 print(f""\nResultat : {result_str} en {len(history)} coups"")
 print(f""Temps moyen MCTS     : {np.mean(times[PLAYER1]):.3f}s/coup"")
 print(f""Temps moyen Minimax  : {np.mean(times[PLAYER2]):.3f}s/coup"")",,,,,,,,037e297b5ec5285e,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,mcts-interpretation,markdown,fr,265cf6ea7556c2eb,"### Interpretation : MCTS vs Minimax
+MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,mcts-interpretation,markdown,fr,493f52d03e04b1cf,"### Interprétation : MCTS vs Minimax
 
-**Sortie obtenue** : MCTS(1000 iterations) bat Minimax(d=4) en 29 coups dans cette partie ; MCTS est nettement plus lent par coup.
+**Sortie obtenue** : MCTS(1000 itérations) bat Minimax(d=4) en 29 coups dans cette partie ; MCTS est nettement plus lent par coup.
 
 | Aspect | MCTS (1000 iter.) | Minimax (d=4) |
 |--------|-------------------|---------------|
-| Approche | Simulations Monte Carlo | Recherche exhaustive |
-| Evaluation | Rollouts aleatoires | Fonction heuristique |
-| Profondeur | Variable (adaptative) | Fixe (4 niveaux) |
+| approche | Simulations Monte Carlo | recherche exhaustive |
+| évaluation | Rollouts aléatoires | Fonction heuristique |
+| Profondeur | variable (adaptative) | Fixe (4 niveaux) |
 | Temps mesure | ~1.6 s/coup | ~0.23 s/coup |
 
 **Points cles** :
 1. Sur cette partie, MCTS(1000) l'emporte mais il est ~7x plus lent par coup que Minimax(d=4)
-2. MCTS n'a **pas besoin de fonction d'evaluation artisanale**
+2. MCTS n'a **pas besoin de fonction d'évaluation artisanale**
 3. MCTS explore automatiquement plus profondement les lignes prometteuses
-4. Avec plus d'iterations (5000+), MCTS tend a surpasser Minimax(d=4)
-",,,,,,,,265cf6ea7556c2eb,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,greedy-section,markdown,fr,50a738321642fdc1,"## 6. IA 4 : Joueur glouton (heuristique)
+4. Avec plus d'itérations (5000+), MCTS tend a surpasser Minimax(d=4)
+",,,,,,,,493f52d03e04b1cf,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,greedy-section,markdown,fr,0ffdcbbf59a9674d,"## 6. IA 4 : Joueur glouton (heuristique)
 
-Le joueur **glouton** applique une hierarchie de priorites simple, sans exploration de l'arbre :
+Le joueur **glouton** applique une hiérarchie de priorites simple, sans exploration de l'arbre :
 
-1. **Gagner** : si un coup permet de gagner immediatement, le jouer
+1. **Gagner** : si un coup permet de gagner immédiatement, le jouer
 2. **Bloquer** : si l'adversaire peut gagner au prochain coup, le bloquer
-3. **Centre** : preferer les colonnes centrales (meilleur controle positionnel)
-4. **Aleatoire** : sinon, choisir au hasard parmi les coups restants
+3. **Centre** : préférer les colonnes centrales (meilleur contrôle positionnel)
+4. **aléatoire** : sinon, choisir au hasard parmi les coups restants
 
-Cette approche est rapide mais limitee : elle ne regarde qu'un coup en avance.",,,,,,,,50a738321642fdc1,,,,,,,
+Cette approche est rapide mais limitée : elle ne regarde qu'un coup en avance.",,,,,,,,0ffdcbbf59a9674d,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,greedy-code,code,fr,1aa9442753de0dd3,"def ai_greedy(board, player):
     """"""
     IA gloutonne : priorite win > block > center > random.
@@ -29817,37 +29817,37 @@ names = {PLAYER1: ""Greedy"", PLAYER2: ""Random""}
 result_str = ""Match nul"" if winner == 0 else f""{names[winner]} gagne""
 print(f""Resultat : {result_str} en {len(history)} coups"")
 print(f""Temps moyen Greedy : {np.mean(times[PLAYER1])*1000:.2f} ms/coup"")",,,,,,,,1aa9442753de0dd3,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,greedy-interpretation,markdown,fr,6a14c0576ace47ed,"### Interpretation : Joueur glouton
+MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,greedy-interpretation,markdown,fr,204067bfdd17512e,"### Interprétation : Joueur glouton
 
-**Sortie obtenue** : Le joueur glouton bat facilement le joueur aleatoire.
+**Sortie obtenue** : Le joueur glouton bat facilement le joueur aléatoire.
 
 | Aspect | Greedy |
 |--------|--------|
 | Profondeur de recherche | 1 (un seul coup en avance) |
 | Temps par coup | < 1 ms |
-| Force | Detecte les victoires et menaces immediates |
-| Faiblesse | Pas de vision strategique a long terme |
+| Force | détecte les victoires et menaces immédiates |
+| Faiblesse | Pas de vision stratégique a long terme |
 
 **Points cles** :
-1. Le glouton est **extremement rapide** car il ne construit pas d'arbre
-2. Il detecte les coups gagnants et les menaces immediates (profondeur 1)
+1. Le glouton est **extrêmêment rapide** car il ne construit pas d'arbre
+2. Il détecte les coups gagnants et les menaces immédiates (profondeur 1)
 3. Il sera surpasse par Minimax qui voit plus loin dans l'arbre de jeu
-4. Le bonus positionnel (centre) lui donne une strategie rudimentaire",,,,,,,,6a14c0576ace47ed,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,tournament-section,markdown,fr,941ee60020301673,"## 7. Tournoi round-robin
+4. Le bonus positionnel (centre) lui donne une stratégie rudimentaire",,,,,,,,204067bfdd17512e,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,tournament-section,markdown,fr,88f723a03a836a14,"## 7. Tournoi round-robin
 
 Organisons un tournoi complet entre toutes les IA. Chaque paire joue **6 parties** (3 en tant que joueur 1, 3 en tant que joueur 2) pour eliminer l'avantage du premier joueur.
 
-> **Note** : Le nombre de parties a ete reduit a 6 pour ce notebook pedagogique. Pour des resultats statistiquement significatifs, utilisez 20+ parties par paire.
+> **Note** : Le nombre de parties a ete réduit a 6 pour ce notebook pedagogique. Pour des résultats statistiquement significatifs, utilisez 20+ parties par paire.
 
 ### Participants
 
-| IA | Type | Parametres |
+| IA | Type | paramètrès |
 |----|------|------------|
 | Random | Baseline | - |
 | Greedy | Heuristique | 1 coup |
 | Minimax(d=4) | Arbre adversaire | Profondeur 4, alpha-beta |
 | Minimax(d=6) | Arbre adversaire | Profondeur 6, alpha-beta |
-| MCTS(1000) | Monte Carlo | 1000 iterations |",,,,,,,,941ee60020301673,,,,,,,
+| MCTS(1000) | Monte Carlo | 1000 itérations |",,,,,,,,88f723a03a836a14,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,tournament-code,code,fr,4e9b770b336d4d8c,"def run_tournament(ais, games_per_pair=6, verbose=True):
     """"""
     Tournoi round-robin entre toutes les IA.
@@ -29931,9 +29931,9 @@ t_start = time.time()
 results, matrix = run_tournament(tournament_ais, games_per_pair=6)
 t_total = time.time() - t_start
 print(f""\\nTournoi termine en {t_total:.1f}s"")",,,,,,,,4e9b770b336d4d8c,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,tournament-results-intro,markdown,fr,730e8ad9f1b4bb54,"### Resultats du tournoi
+MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,tournament-results-intro,markdown,fr,5183be226fe6641a,"### Résultats du tournoi
 
-Affichons les resultats sous forme de tableau recapitulatif et de graphiques.",,,,,,,,730e8ad9f1b4bb54,,,,,,,
+Affichons les résultats sous forme de tableau recapitulatif et de graphiques.",,,,,,,,5183be226fe6641a,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,tournament-results,code,fr,8d627478da6ed88b,"# Tableau recapitulatif
 print(""\n"" + ""="" * 80)
 print(""  RESULTATS DU TOURNOI"")
@@ -29973,7 +29973,7 @@ for n1 in names:
         else:
             print(f""{'?':>14}"", end="""")
     print()",,,,,,,,8d627478da6ed88b,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,jbmqqusg4x,markdown,fr,a6140e47460d9810,Visualisons ces resultats sous forme de graphiques pour mieux comparer les performances relatives et les couts en temps de calcul.,,,,,,,,a6140e47460d9810,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,jbmqqusg4x,markdown,fr,97944850613c0803,Visualisons ces résultats sous forme de graphiques pour mieux comparer les performances relatives et les couts en temps de calcul.,,,,,,,,97944850613c0803,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,tournament-charts,code,fr,2ecccaff4758a2db,"# Graphiques de resultats
 fig, axes = plt.subplots(1, 3, figsize=(18, 6))
 
@@ -30027,47 +30027,47 @@ plt.suptitle('Tournoi Puissance 4 -- 5 IA, 20 parties par paire',
              fontsize=14, fontweight='bold', y=1.02)
 plt.tight_layout()
 plt.show()",,,,,,,,2ecccaff4758a2db,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,tournament-interpretation,markdown,fr,ba01139a717abee0,"### Interpretation : Resultats du tournoi
+MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,tournament-interpretation,markdown,fr,d5fce90a0061fe9b,"### Interprétation : Résultats du tournoi
 
 **Sortie obtenue** : Classement issu du round-robin (5 IA, 6 parties par paire). Minimax(d=4) et Minimax(d=6) dominent MCTS(500) (respectivement 6W-0D-0L et 4W-0D-2L).
 
 | Rang | IA | Force | Temps/coup | Commentaire |
 |------|-----|-------|------------|-------------|
-| 1 | Minimax(d=6) | Forte | Elevee | Meilleure profondeur de recherche |
-| 2 | Minimax(d=4) | Bonne | Moderee | Balaye MCTS(500) 6W-0D-0L |
-| 3 | MCTS(500) | Moyenne | Elevee | Competitive contre Minimax(d=6) (4W-2L) mais dominee par Minimax(d=4) |
-| 4 | Greedy | Moyenne | Negligeable | Bloque les menaces immediates |
+| 1 | Minimax(d=6) | Forte | élevée | Meilleure profondeur de recherche |
+| 2 | Minimax(d=4) | Bonne | modérée | Balaye MCTS(500) 6W-0D-0L |
+| 3 | MCTS(500) | Moyenne | élevée | Competitive contre Minimax(d=6) (4W-2L) mais dominee par Minimax(d=4) |
+| 4 | Greedy | Moyenne | Negligeable | Bloque les menaces immédiates |
 | 5 | Random | Nulle | Negligeable | Perd contre tout (0W-0D-6L partout) |
 
 **Points cles** :
 1. **La profondeur compte** : Minimax(d=6) domine Minimax(d=4) car il voit plus loin
-2. **MCTS(500) est competitif** sans fonction d'evaluation artisanale -- il prend meme 2 parties a Minimax(d=6)
-3. **Greedy est un bon rapport qualite/prix** : presque instantane, il bat Random a chaque fois
+2. **MCTS(500) est competitif** sans fonction d'évaluation artisanale -- il prend même 2 parties a Minimax(d=6)
+3. **Greedy est un bon rapport qualite/prix** : presque instantané, il bat Random a chaque fois
 4. **Le compromis temps/qualite** est clairement visible dans le graphique de droite
 5. **L'avantage du premier joueur** est partiellement neutralise par les 3+3 parties alternees
 
-> **Observation** : Augmenter les iterations de MCTS (5000+) ou la profondeur de Minimax (d=8) ameliorerait les performances, mais au prix d'un temps de calcul significativement plus eleve.
-",,,,,,,,ba01139a717abee0,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,47befe96,markdown,fr,c923ba2e9ba800f4,"## 8. Framework AIMA - Approche du livre de reference
+> **observation** : Augmenter les itérations de MCTS (5000+) ou la profondeur de Minimax (d=8) améliorérait les performances, mais au prix d'un temps de calcul significativement plus élevé.
+",,,,,,,,d5fce90a0061fe9b,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,47befe96,markdown,fr,4f7ad464470d9e19,"## 8. Framework AIMA - Approche du livre de référence
 
 ### 8.1 Le framework Game de Russell & Norvig
 
 Le livre **""Artificial Intelligence: A Modern Approach""** (AIMA) de Russell et Norvig propose un framework elegant pour les jeux a deux joueurs. Ce framework est disponible dans le module `games4e.py` du depot [aima-python](https://github.com/aimacode/aima-python), avec une implementation Java plus sophistiquee dans [aima-java](https://github.com/aimacode/aima-java).
 
-**Principe cle** : Separer la **logique du jeu** (classe Game) des **algorithmes de recherche** (fonctions joueurs).
+**Principe cle** : séparer la **logique du jeu** (classe Game) des **algorithmes de recherche** (fonctions joueurs).
 
 ### Avantages du framework AIMA
 
 | Aspect | Implementation custom | Framework AIMA |
 |--------|----------------------|----------------|
-| Separation des responsabilites | Melangee | Claire (Game vs Player) |
-| Reutilisabilite | Specifique au jeu | Algorithmes generiques |
+| séparation des responsabilites | Melangee | Claire (Game vs Player) |
+| Reutilisabilite | spécifique au jeu | Algorithmes génériques |
 | Testabilite | Couplee | Decouplee |
-| Extensibilite | Modification en cascade | Ajout de nouveaux joueurs |
+| Extensibilite | modification en cascade | Ajout de nouveaux joueurs |
 
 > **Source** : [aima-python/games4e.py](https://github.com/aimacode/aima-python/blob/master/games4e.py) - Chapitre 5, Jeux Adversariaux
 >
-> **Reference avancee** : [aima-java ConnectFour](https://github.com/aimacode/aima-java/blob/AIMA3e/aima-core/src/main/java/aima/core/environment/connectfour/) - Implementation sophistiquee avec analyse des positions gagnantes",,,,,,,,c923ba2e9ba800f4,,,,,,,
+> **référence avancée** : [aima-java ConnectFour](https://github.com/aimacode/aima-java/blob/AIMA3e/aima-core/src/main/java/aima/core/environment/connectfour/) - Implementation sophistiquee avec analyse des positions gagnantes",,,,,,,,4f7ad464470d9e19,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,c8e07cf2,code,fr,d80809dd7fa93f68,"# Framework AIMA simplifie - inspire de games4e.py et aima-java
 from collections import namedtuple
 import math
@@ -30188,9 +30188,9 @@ def random_player(game, state):
 
 print(""Framework AIMA de base charge"")
 print(""  - play_game_aima(), alpha_beta_player(), random_player() disponibles"")",,,,,,,,d80809dd7fa93f68,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,292278bc,markdown,fr,9ffa0ab8e71a7bba,"### 8.2 Adaptateur ConnectFour_AIMA
+MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,292278bc,markdown,fr,783ddd644b1120af,"### 8.2 Adaptateur ConnectFour_AIMA
 
-Nous creons maintenant un adaptateur qui rend notre classe `Board` compatible avec le framework AIMA. Cet adaptateur inclut egalement l'**analyse des positions gagnantes**, inspiree de l'implementation AIMA Java.",,,,,,,,9ffa0ab8e71a7bba,,,,,,,
+Nous creons maintenant un adaptateur qui rend notre classe `Board` compatible avec le framework AIMA. Cet adaptateur inclut également l'**analyse des positions gagnantes**, inspiree de l'implementation AIMA Java.",,,,,,,,783ddd644b1120af,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,93659b63,code,fr,f7c945c3c1bd3bd1,"class ConnectFour_AIMA(Game):
     """"""
     Adaptateur Connect Four pour le framework AIMA.
@@ -30327,14 +30327,14 @@ MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,93659b63,c
 
 
 print(""Adaptateur ConnectFour_AIMA avec analyse des positions gagnantes."")",,,,,,,,f7c945c3c1bd3bd1,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,6fb2fd22,markdown,fr,466aecd4e4ae76dc,"### 8.3 Approfondissement iteratif avec limite de temps
+MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,6fb2fd22,markdown,fr,fe8b37701e134b63,"### 8.3 Approfondissement itératif avec limite de temps
 
 L'implementation AIMA Java utilise `IterativeDeepeningAlphaBetaSearch` qui:
 1. Explore a des profondeurs croissantes (1, 2, 3, ...)
 2. S'arrete quand le temps imparti est ecoule
-3. **Prefere les victoires rapides** en ajustant l'evaluation
+3. **préfère les victoires rapides** en ajustant l'évaluation
 
-Cette approche transforme Alpha-Beta en algorithme **anytime** : il peut retourner un resultat valide a tout moment.",,,,,,,,466aecd4e4ae76dc,,,,,,,
+Cette approche transforme Alpha-Beta en algorithme **anytime** : il peut retourner un résultat valide a tout moment.",,,,,,,,fe8b37701e134b63,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,ed991b67,code,fr,cc44e1a329402291,"class IterativeDeepeningAlphaBeta:
     """"""
     Alpha-Beta avec approfondissement iteratif et limite de temps.
@@ -30484,12 +30484,12 @@ def make_id_alphabeta_player(game, time_limit=1.0):
 
 
 print(""IterativeDeepeningAlphaBeta charge."")",,,,,,,,cc44e1a329402291,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,8e2a4c96,markdown,fr,36ca19d0e17333a7,"### 8.4 Comparaison et benchmark
+MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,8e2a4c96,markdown,fr,37bcc22b16d558f7,"### 8.4 Comparaison et benchmark
 
-Comparons les differentes approches AIMA pour mesurer l'impact des optimisations inspirees d'AIMA Java:
+Comparons les différentes approches AIMA pour mesurer l'impact des optimisations inspirees d'AIMA Java:
 - Alpha-Beta classique (profondeur fixe)
 - Alpha-Beta avec ordonnancement intelligent
-- Approfondissement iteratif avec limite de temps",,,,,,,,36ca19d0e17333a7,,,,,,,
+- Approfondissement itératif avec limite de temps",,,,,,,,37bcc22b16d558f7,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,c80fa982,code,fr,5db0313d046e92ee,"# Benchmark des approches AIMA
 
 def benchmark_aima_approaches(n_games=5):
@@ -30556,38 +30556,38 @@ def benchmark_aima_approaches(n_games=5):
 # Executer le benchmark
 print(""Test des techniques avancees inspirees d'AIMA Java\n"")
 benchmark_aima_approaches(n_games=3)",,,,,,,,5db0313d046e92ee,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,226ea666,markdown,fr,c9a0cf86e4f4499a,"### Interpretation : Framework AIMA avance
+MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,226ea666,markdown,fr,bbfa98abbc0c4fa9,"### Interprétation : Framework AIMA avance
 
-**Sortie obtenue** : Comparaison entre Alpha-Beta classique et l'approfondissement iteratif.
+**Sortie obtenue** : Comparaison entre Alpha-Beta classique et l'approfondissement itératif.
 
-| Technique | Description | Avantage |
+| Technique | description | Avantage |
 |-----------|-------------|----------|
-| **Alpha-Beta classique** | Profondeur fixe | Simple, deterministe |
+| **Alpha-Beta classique** | Profondeur fixe | Simple, déterministe |
 | **Ordonnancement** | Trie par potentiel de victoire | Speedup 10-50x |
-| **Approfondissement iteratif** | Profondeur variable, limite temps | Anytime, utilise tout le temps |
-| **Preference victoires rapides** | Ajuste eval avec nombre de coups | Gagne plus vite |
+| **Approfondissement itératif** | Profondeur variable, limite temps | Anytime, utilise tout le temps |
+| **préférence victoires rapides** | Ajuste eval avec nombre de coups | Gagne plus vite |
 
 **Lecons de l'implementation AIMA Java** :
 
 1. **Analyse des positions gagnantes** : AIMA Java utilise un bit-coding sophistique pour tracker incrementalement les positions gagnantes. Notre implementation simplifiee utilise `analyze_potential_win_positions()` pour un ordonnancement optimal.
 
-2. **Approfondissement iteratif** : Transforme Alpha-Beta en algorithme **anytime** - utilisable dans des contextes temps reel.
+2. **Approfondissement itératif** : Transforme Alpha-Beta en algorithme **anytime** - utilisable dans des contextes temps réel.
 
 3. **Ordonnancement des coups** : L'optimisation la plus impactante. Un bon ordonnancement peut reduire le nombre de noeuds explores de 50% a 90%.
 
-4. **Victoires rapides** : Modifier l'evaluation pour penaliser les victoires tardives rend l'IA plus ""agressive"" et plus agréable a jouer.
+4. **Victoires rapides** : modifier l'évaluation pour penaliser les victoires tardives rend l'IA plus ""agressive"" et plus agréable a jouer.
 
-> **Pour aller plus loin** : L'implementation complete d'AIMA Java inclut egalement:
-> - Bit-coding pour une representation memoire compacte (4 bits par cellule)
+> **Pour aller plus loin** : L'implementation complète d'AIMA Java inclut également:
+> - Bit-coding pour une représentation memoire compacte (4 bits par cellule)
 > - Mise a jour incrementielle des positions gagnantes
-> - Transposition tables pour eviter les recalculs",,,,,,,,c9a0cf86e4f4499a,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,exercises-section,markdown,fr,8fd8dc386dbcd92b,"## 9. Exercices
+> - Transposition tables pour éviter les recalculs",,,,,,,,bbfa98abbc0c4fa9,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,exercises-section,markdown,fr,e0608583a8ff7ed5,"## 9. Exercices
 
 ### Exercice 1 : Negamax
 
 Le **Negamax** est une variante simplifiee de Minimax qui exploite la propriete des jeux a somme nulle : la valeur d'une position pour un joueur est l'oppose de sa valeur pour l'adversaire.
 
-**Tache** : Completez l'implementation de Negamax avec elagage alpha-beta.",,,,,,,,8fd8dc386dbcd92b,,,,,,,
+**Tâche** : Completez l'implementation de Negamax avec elagage alpha-beta.",,,,,,,,e0608583a8ff7ed5,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,exercise1-code,code,fr,ad2fee1b0f15e8b1,"# Exercice 1 : Negamax avec elagage alpha-beta
 
 def negamax(board, depth, alpha, beta, player):
@@ -30638,25 +30638,25 @@ except (TypeError, AttributeError):
     print(""Exercice a completer : implementez negamax() pour comparer avec Minimax."")
     print(""Attendu : negamax doit retourner (colonne, score), meme decision que Minimax."")
 ",,,,,,,,ad2fee1b0f15e8b1,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,exercise2-section,markdown,fr,9a3986fac67ead4f,"### Exercice 2 : Approfondissement iteratif
+MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,exercise2-section,markdown,fr,d81d411b51f58f67,"### Exercice 2 : Approfondissement itératif
 
-L'**approfondissement iteratif** (Iterative Deepening) consiste a lancer Minimax avec des profondeurs croissantes (d=1, 2, 3, ...) et a s'arreter quand le temps imparti est ecoule.
+L'**approfondissement itératif** (itérative Deepening) consiste a lancer Minimax avec des profondeurs croissantes (d=1, 2, 3, ...) et a s'arreter quand le temps imparti est ecoule.
 
 **Avantages** :
-- Utilise tout le temps disponible
-- Trouve d'abord une solution rapide, puis l'ameliore
+- utilise tout le temps disponible
+- Trouve d'abord une solution rapide, puis l'améliore
 - Le surcoute est faible : $O(b^d)$ domine $O(b^{d-1} + b^{d-2} + ...)$
 
-**Tache** : Implementez `iterative_deepening_minimax(board, player, time_limit=1.0)`.
+**Tâche** : Implementez `iterative_deepening_minimax(board, player, time_limit=1.0)`.
 
 ```python
 def iterative_deepening_minimax(board, player, time_limit=1.0):
-    # A completer :
+    # A complèter :
     # - Boucle sur depth = 1, 2, 3, ...
     # - A chaque profondeur, lancer minimax
-    # - Si le temps est ecoule, retourner le meilleur coup de la profondeur precedente
+    # - Si le temps est ecoule, retourner le meilleur coup de la profondeur précédente
     pass
-```",,,,,,,,9a3986fac67ead4f,,,,,,,
+```",,,,,,,,d81d411b51f58f67,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,exercise2-code,code,fr,38f06de542b0d507,"# Exercice 2 : Approfondissement iteratif
 
 def iterative_deepening_minimax(board, player, time_limit=1.0):
@@ -30697,24 +30697,24 @@ except (TypeError, ValueError, AttributeError):
     print(""Exercice a completer : implementez iterative_deepening_minimax() pour tester."")
     print(""Attendu : ID(0.5s) devrait battre Random (>80% de victoires)."")
 ",,,,,,,,38f06de542b0d507,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,exercise3-section,markdown,fr,f647e6994060f86e,"### Exercice 3 : Ordonnancement des coups et mesure du speedup
+MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,exercise3-section,markdown,fr,9751000951cf7a5c,"### Exercice 3 : Ordonnancement des coups et mesure du speedup
 
-L'efficacite de l'elagage alpha-beta depend fortement de l'**ordre dans lequel les coups sont explores**. Si on essaie d'abord les meilleurs coups, plus de branches sont coupees.
+L'efficacité de l'elagage alpha-beta dépend fortement de l'**ordre dans lequel les coups sont explores**. Si on essaie d'abord les meilleurs coups, plus de branches sont coupees.
 
-**Tache** : Implementez un ordonnancement des coups plus intelligent :
-1. Les coups qui gagnent immediatement en premier
+**Tâche** : Implementez un ordonnancement des coups plus intelligent :
+1. Les coups qui gagnent immédiatement en premier
 2. Les coups qui bloquent une victoire adverse ensuite
 3. Les colonnes centrales avant les laterales
 
-Mesurez le **speedup** (acceleration) par rapport a l'ordre par defaut.
+Mesurez le **speedup** (accélération) par rapport a l'ordre par defaut.
 
 ```python
 def order_moves(board, player, moves):
-    # A completer :
+    # A complèter :
     # - Trier les coups par priorite
     # - Retourner la liste triee
     pass
-```",,,,,,,,f647e6994060f86e,,,,,,,
+```",,,,,,,,9751000951cf7a5c,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,exercise3-code,code,fr,850b11733caf9261,"# Exercice 3 : Ordonnancement intelligent des coups
 
 def order_moves(board, player, moves):
@@ -30760,23 +30760,23 @@ except (TypeError, ValueError, AttributeError):
     print(""Exercice a completer : implementez order_moves() et count_nodes_minimax()."")
     print(""Attendu : speedup 2-5x avec ordering (moins de noeuds explores)."")
 ",,,,,,,,850b11733caf9261,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,exercises-interpretation,markdown,fr,d3985e3589d3abdd,"### Interpretation : Exercices
+MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,exercises-interpretation,markdown,fr,c7d7aed69d69127d,"### Interprétation : Exercices
 
-| Exercice | Concept cle | Resultat attendu |
+| Exercice | Concept cle | résultat attendu |
 |----------|-------------|------------------|
-| Negamax | Simplification de Minimax | Memes decisions, code plus compact |
-| Iterative Deepening | Utilisation optimale du temps | Profondeur variable, anytime |
-| Move Ordering | Efficacite de l'elagage | Speedup de 2x a 10x selon la position |
+| Negamax | Simplification de Minimax | mêmes décisions, code plus compact |
+| itérative Deepening | utilisation optimale du temps | Profondeur variable, anytime |
+| Move Ordering | efficacité de l'elagage | Speedup de 2x a 10x selon la position |
 
 **Points cles** :
-1. Negamax et Minimax produisent les memes resultats -- la difference est purement stylistique
-2. L'approfondissement iteratif transforme Minimax en algorithme **anytime** (comme MCTS)
-3. L'ordonnancement des coups est l'optimisation la plus impactante pour alpha-beta : un bon ordonnancement peut reduire le nombre de noeuds de 50% a 90%",,,,,,,,d3985e3589d3abdd,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,summary-section,markdown,fr,f64292b25f3c99c2,"## Conclusion et resume
+1. Negamax et Minimax produisent les mêmes résultats -- la différence est purement stylistique
+2. L'approfondissement itératif transforme Minimax en algorithme **anytime** (comme MCTS)
+3. L'ordonnancement des coups est l'optimisation la plus impactante pour alpha-beta : un bon ordonnancement peut reduire le nombre de noeuds de 50% a 90%",,,,,,,,c7d7aed69d69127d,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,summary-section,markdown,fr,d6355b7ddde5022b,"## Conclusion et resume
 
 ### Comparaison des approches
 
-| IA | Famille | Profondeur | Evaluation | Temps/coup | Force |
+| IA | Famille | Profondeur | évaluation | Temps/coup | Force |
 |----|---------|------------|------------|------------|-------|
 | Random | Baseline | 0 | N/A | <1ms | Nulle |
 | Greedy | Heuristique | 1 | Positionnelle | <1ms | Faible |
@@ -30786,27 +30786,25 @@ MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,summary-se
 
 ### Lecons retenues
 
-1. **Profondeur vs Qualite** : Minimax gagne ~200 ELO par niveau de profondeur supplementaire, au prix d'un facteur ~10x en temps de calcul.
+1. **Profondeur vs Qualite** : Minimax gagne ~200 ELO par niveau de profondeur supplémentaire, au prix d'un facteur ~10x en temps de calcul.
 
-2. **Alpha-Beta essentiel** : L'elagage reduit le facteur de branchement effectif de ~7 a ~3-4, rendant les profondeurs 5-6 accessibles.
+2. **Alpha-Beta essentiel** : L'elagage réduit le facteur de branchement effectif de ~7 a ~3-4, rendant les profondeurs 5-6 accessibles.
 
-3. **MCTS complementaire** : MCTS excelle quand une bonne heuristique d'evaluation est difficile a definir. Il converge vers Minimax avec suffisamment d'iterations.
+3. **MCTS complémentaire** : MCTS excelle quand une bonne heuristique d'évaluation est difficile a définir. Il converge vers Minimax avec suffisamment d'itérations.
 
-4. **Premier joueur avantagé** : Au Puissance 4, le premier joueur a un avantage theorique (jeu resolu). Un bon IA doit exploiter cet avantage.
+4. **Premier joueur avantagé** : Au Puissance 4, le premier joueur a un avantage théorique (jeu résolu). Un bon IA doit exploiter cet avantage.
 
-5. **Framework AIMA** : Le framework AIMA (Section 8) montre l'importance de separer la logique du jeu des algorithmes de recherche, ameliorant la maintenabilite et la reutilisabilite.
+5. **Framework AIMA** : Le framework AIMA (Section 8) montre l'importance de séparer la logique du jeu des algorithmes de recherche, améliorant la maintenabilite et la reutilisabilite.
 
 ### Pour aller plus loin
 
-- **Resolution complete** : Utiliser une base de donnees d'ouvertures (solution parfaite connue depuis 1988)
-- **Apprentissage par renforcement** : Entrainer un reseau de neurones a jouer (voir serie RL)
+- **résolution complète** : utiliser une base de données d'ouvertures (solution parfaite connue depuis 1988)
+- **apprentissage par renforcement** : Entrainer un réseau de neurones a jouer (voir serie RL)
 - **Parallelisation** : Paralleliser MCTS ou Alpha-Beta pour explorer plus de noeuds
-- **Recherche de Monte Carlo amelioree** : Ajouter une heuristique de simulation (RAVE, etc.)
-",,,,,,,,f64292b25f3c99c2,,,,,,,
+- **recherche de Monte Carlo améliorée** : Ajouter une heuristique de simulation (RAVE, etc.)
+",,,,,,,,d6355b7ddde5022b,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,nav-footer,markdown,fr,0fbdab9d44165124,**Navigation** : [<< App-11 Picross](../CSP/App-11-Picross.ipynb) | [Index](../../README.md) | [Part1-Foundations](../../Part1-Foundations/README.md),,,,,,,,0fbdab9d44165124,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,e07392a1,markdown,fr,7b8bdc47a0d29e46,"## Conclusion
-
-Ce notebook a comparé quatre approches d'intelligence artificielle sur le jeu de Puissance 4. Le **joueur aléatoire** sert de baseline nulle, le **joueur glouton** (profondeur 1) détecte les menaces immédiates mais manque de vision stratégique, le **Minimax avec élagage alpha-beta** offre une recherche exhaustive configurable en profondeur, et le **MCTS** (Monte Carlo Tree Search) construit progressivement un arbre de décision par simulations aléatoires sans nécessiter de fonction d'évaluation artisanale. Le tournoi confirme la hiérarchie attendue : Minimax(d=6) domine grâce à sa profondeur de recherche, suivi de Minimax(d=4) et MCTS qui sont compétitifs entre eux. Le framework AIMA (section 8) illustre l'importance de séparer la logique du jeu des algorithmes de recherche, et l'approfondissement itératif transforme alpha-beta en algorithme anytime. Les exercices (Negamax, approfondissement itératif, ordonnancement des coups) permettent de mesurer l'impact de chaque optimisation sur les performances.",,,,,,,,7b8bdc47a0d29e46,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb,e07392a1,markdown,fr,70c01847fc36d0b1,"## ConclusionCe notebook a comparé quatre approches d'intelligence artificielle sur le jeu de Puissance 4. Le **joueur aléatoire** sert de baseline nulle, le **joueur glouton** (profondeur 1) détecte les menaces immédiates mais manque de vision stratégique, le **Minimax avec élagage alpha-beta** offre une recherche exhaustive configurable en profondeur, et le **MCTS** (Monte Carlo Tree Search) construit progressivement un arbre de décision par simulations aléatoires sans nécessiter de fonction d'évaluation artisanale. Le tournoi confirme la hiérarchie attendue : Minimax(d=6) domine grâce à sa profondeur de recherche, suivi de Minimax(d=4) et MCTS qui sont compétitifs entre eux. Le framework AIMA (section 8) illustre l'importance de séparer la logique du jeu des algorithmes de recherche, et l'approfondissement itératif transforme alpha-beta en algorithme anytime. Les exercices (Negamax, approfondissement itératif, ordonnancement des coups) permettent de mesurer l'impact de chaque optimisation sur les performances.",,,,,,,,70c01847fc36d0b1,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial-CSharp.ipynb,87cc1921,markdown,fr,e6e8ad70e8ee8505,"# App-14-ConnectFour-Adversarial-CSharp — Jumeau C# : recherche adversariale from-scratch
 
 > **Jumeau C# (.NET 9)** de [`App-14-ConnectFour-Adversarial`](App-14-ConnectFour-Adversarial.ipynb). Le notebook Python compare trois algorithmes de recherche adversariale — **Minimax**, **Alpha-Beta** et **MCTS** — sur le terrain de jeu du Puissance 4 (Connect Four), avec `numpy` pour le plateau et `matplotlib` pour les benchmarks. **Ce jumeau prend le parti Prong B du marathon #4956** : on reconstruit les trois algorithmes **from-scratch en C# pur** (BCL .NET 9, zéro NuGet), sans `numpy` ni `matplotlib` — les plateaux s'affichent en ASCII et les benchmarks en tableaux texte. L'objectif pédagogique : rendre **visible la mécanique interne** de chaque algorithme (récursion minimax, élagage alpha-beta, sélection UCB1 + rollouts aléatoires du MCTS).
@@ -31369,17 +31367,17 @@ MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial-CSha
 
 *Marathon #4956 — parité .NET ⇄ Python. Prong B : reconstruction from-scratch en C# pur (BCL .NET 9, zéro NuGet).*
 ",,,,,,,,212163e0543f7275,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,nav-header,markdown,fr,cbeb436145a4c6f3,"# App-14 - Connect Four : Benchmark Adversarial Search
+MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,nav-header,markdown,fr,be3ba8b538591939,"# App-14 - Connect Four : Benchmark Adversarial Search
 
 **Navigation** : [<< App-12 ConnectFour](../Search/App-12-ConnectFour.ipynb) | [Index](../../README.md) | [CSP Applications >>](../CSP/App-1-NQueens.ipynb)
 
 ## Objectifs d'apprentissage
 
 A la fin de ce notebook, vous saurez :
-1. **Comparer** les algorithmes Minimax, Alpha-Beta et MCTS sur un jeu reel
-2. **Mesurer** les compromis entre temps de calcul, noeuds explores et qualite de jeu
-3. **Analyser** l'impact de la profondeur de recherche et du nombre d'iterations
-4. **Choisir** l'algorithme adapte selon les contraintes (temps, precision)
+1. **Comparer** les algorithmes Minimax, Alpha-Beta et MCTS sur un jeu réel
+2. **mesurer** les compromis entre temps de calcul, noeuds explores et qualite de jeu
+3. **Analyser** l'impact de la profondeur de recherche et du nombre d'itérations
+4. **Choisir** l'algorithme adapté selon les contraintes (temps, precision)
 
 ### Prerequis
 - [Search-3-Informed](../../Part1-Foundations/Search-3-Informed.ipynb) : Heuristiques
@@ -31388,34 +31386,34 @@ A la fin de ce notebook, vous saurez :
 
 ### Duree estimee : 45 minutes
 
-> **Source** : Adapte des projets etudiants JVX (ECE 2026) et EPITA PPC 2025.
+> **Source** : adapté des projets etudiants JVX (ECE 2026) et EPITA PPC 2025.
 >
 > **Note** : Ce notebook se concentre sur le benchmark des trois algorithmes principaux.
-> Pour une etude complete avec 8 algorithmes (DQN-RL, etc.), voir [App-12](../Search/App-12-ConnectFour.ipynb).",,,,,,,,cbeb436145a4c6f3,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,intro-section,markdown,fr,6ca7adc9816c48b1,"## 1. Introduction
+> Pour une étude complète avec 8 algorithmes (DQN-RL, etc.), voir [App-12](../Search/App-12-ConnectFour.ipynb).",,,,,,,,be3ba8b538591939,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,intro-section,markdown,fr,6f4061bbe0522d50,"## 1. Introduction
 
 ### Pourquoi le Puissance 4 ?
 
 Le **Puissance 4** (Connect Four) est un excellent terrain de test pour les algorithmes de recherche adversariale :
 
-| Caracteristique | Valeur | Impact sur les algorithmes |
+| caractéristique | Valeur | Impact sur les algorithmes |
 |----------------|--------|---------------------------|
-| Taille du plateau | 7x6 = 42 cases | Assez grand pour etre interessant |
-| Facteur de branchement | ~4-7 | Teste l'efficacite de l'elagage |
-| Profondeur moyenne | ~21 coups | Suffisant pour mesurer les performances |
-| Jeu resolu | Oui (1988) | Permet de verifier l'optimalite |
+| Taille du plateau | 7x6 = 42 cases | Assez grand pour etre intéressant |
+| Facteur de branchement | ~4-7 | Teste l'efficacité de l'elagage |
+| Profondeur moyenne | ~21 coups | suffisant pour mesurer les performances |
+| Jeu résolu | Oui (1988) | Permet de vérifier l'optimalite |
 
 ### Les trois algorithmes compares
 
-1. **Minimax** : L'algorithme de base, exploration complete de l'arbre
+1. **Minimax** : L'algorithme de base, exploration complète de l'arbre
 2. **Alpha-Beta** : Minimax avec elagage, beaucoup plus efficace
-3. **MCTS** : Approche probabiliste, pas besoin de fonction d'evaluation
+3. **MCTS** : approche probabiliste, pas besoin de fonction d'évaluation
 
-### Questions que nous allons repondre
+### Questions que nous allons répondre
 
 - Quel algorithme est le plus rapide ?
 - Lequel joue le mieux avec un temps limite ?
-- Comment la profondeur affecte-t-elle la qualite ?",,,,,,,,6ca7adc9816c48b1,,,,,,,
+- Comment la profondeur affecte-t-elle la qualite ?",,,,,,,,6f4061bbe0522d50,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,imports,code,fr,23692ccdedaf8ece,"# Imports
 import sys
 import time
@@ -31432,14 +31430,14 @@ import pandas as pd
 %matplotlib inline
 
 print(""Environnement pret pour le benchmark adversarial."")",,,,,,,,23692ccdedaf8ece,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,game-section,markdown,fr,a59c1ee87ca8b912,"## 2. Implementation du jeu
+MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,game-section,markdown,fr,9355d686704bb7ce,"## 2. Implementation du jeu
 
-### Representation du plateau
+### Représentation du plateau
 
-Nous utilisons une representation efficace :
+Nous utilisons une représentation efficace :
 - Grille 7x6 stockee dans un tableau numpy
 - 0 = vide, 1 = joueur MAX (Rouge), -1 = joueur MIN (Jaune)
-- Les coups sont indices de colonne (0 a 6)",,,,,,,,a59c1ee87ca8b912,,,,,,,
+- Les coups sont indices de colonne (0 a 6)",,,,,,,,9355d686704bb7ce,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,game-class,code,fr,15e4027ce662cfd6,"class ConnectFour:
     """"""
     Moteur de jeu Connect Four (Puissance 4).
@@ -31574,9 +31572,9 @@ for move in moves:
 print(""Plateau apres quelques coups:"")
 print(game.display())
 print(f""\nGagnant: {game.check_winner()}"")",,,,,,,,e8006a1219e663f0,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,42e7a2ac,markdown,fr,06d37edd9505b74d,"### Interpretation : Test du moteur de jeu
+MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,42e7a2ac,markdown,fr,5f28ce4a282b9660,"### Interprétation : Test du moteur de jeu
 
-**Sortie obtenue** : Partie test apres 9 coups [3, 3, 4, 2, 2, 4, 1, 5, 5].
+**Sortie obtenue** : Partie test après 9 coups [3, 3, 4, 2, 2, 4, 1, 5, 5].
 
 | Aspect | Valeur | Signification |
 |--------|--------|---------------|
@@ -31600,23 +31598,23 @@ MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipyn
 **Points cles** :
 1. **Gravite correcte** : Les jetons tombent jusqu'au premier emplacement vide
 2. **Alternance respectee** : MAX et MIN alternent correctement
-3. **Detection victoire** : Aucun alignement de 4 (correct)
-4. **Moteur fonctionnel** : Toutes les methodes de base operationnelles
+3. **détection victoire** : Aucun alignement de 4 (correct)
+4. **Moteur fonctionnel** : Toutes les méthodes de base opérationnelles
 
-> **Note technique** : La sequence de coups [3, 3, 4, 2, 2, 4, 1, 5, 5] cree une position interessante avec plusieurs menaces potentielles. MIN a 3 jetons alignes horizontalement (colonnes 3-4-5) mais sans la 4eme case. MAX a aussi des opportunities. Cette position sert de base pour tester les algorithmes de recherche qui vont evaluer quel coup est le meilleur pour chaque joueur.",,,,,,,,06d37edd9505b74d,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,minimax-section,markdown,fr,ab300c52892a4fbe,"## 3. Algorithme Minimax
+> **Note technique** : La sequence de coups [3, 3, 4, 2, 2, 4, 1, 5, 5] créé une position intéressante avec plusieurs menaces potentielles. MIN a 3 jetons alignes horizontalement (colonnes 3-4-5) mais sans la 4eme case. MAX a aussi des opportunities. Cette position sert de base pour tester les algorithmes de recherche qui vont évaluer quel coup est le meilleur pour chaque joueur.",,,,,,,,5f28ce4a282b9660,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,minimax-section,markdown,fr,e24e44634ff4c180,"## 3. Algorithme Minimax
 
 **Rappel du principe**
 
-Minimax explore l'arbre de jeu complet jusqu'a une profondeur donnee :
-- **MAX** cherche a maximiser l'utilite
-- **MIN** cherche a minimiser l'utilite
+Minimax explore l'arbre de jeu complet jusqu'a une profondeur donnée :
+- **MAX** cherche a maximiser l'utilité
+- **MIN** cherche a minimiser l'utilité
 
-### Fonction d'evaluation
+### Fonction d'évaluation
 
 Pour les etats non terminaux, nous utilisons une heuristique basee sur :
-- Le controle du centre
-- Le nombre de ""fenetres"" gagnantes potentielles",,,,,,,,ab300c52892a4fbe,,,,,,,
+- Le contrôle du centre
+- Le nombre de ""fenêtrès"" gagnantes potentielles",,,,,,,,e24e44634ff4c180,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,evaluation-function,code,fr,9bc868213835cdef,"def evaluate_window(window: List[int], player: int) -> float:
     """"""
     Evalue une fenetre de 4 cases.
@@ -31697,16 +31695,16 @@ for move in [3, 3, 4]:  # MAX joue au centre
 print(game.display())
 print(f""\nScore pour MAX: {evaluate_position(game, 1)}"")
 print(f""Score pour MIN: {evaluate_position(game, -1)}"")",,,,,,,,9bc868213835cdef,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,00a13648,markdown,fr,3c3a1d1d0292329e,"### Interpretation : Test de la fonction d'evaluation
+MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,00a13648,markdown,fr,fd0b6a218701ba80,"### Interprétation : Test de la fonction d'évaluation
 
-**Sortie obtenue** : Evaluation d'une position avec 3 jetons (MAX joue au centre).
+**Sortie obtenue** : évaluation d'une position avec 3 jetons (MAX joue au centre).
 
 | Joueur | Score | Analyse |
 |---------|-------|---------|
-| MAX (X) | 9 | Controle du centre + 2 jetons alignes horizontalement |
-| MIN (O) | 3 | 1 seul jeton, pas de menace immediate |
+| MAX (X) | 9 | Contrôle du centre + 2 jetons alignes horizontalement |
+| MIN (O) | 3 | 1 seul jeton, pas de menace immédiate |
 
-**Position obtenue** apres les coups [3, 3, 4] :
+**Position obtenue** après les coups [3, 3, 4] :
 ```
 . . . . . . .
 . . . . . . .
@@ -31719,11 +31717,11 @@ MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipyn
 
 **Points cles** :
 1. **Avantage MAX** : Score 9 vs 3 = MAX a un net avantage
-2. **Controle du centre** : Les 2 jetons X au centre (colonnes 3-4) sont valorises
+2. **Contrôle du centre** : Les 2 jetons X au centre (colonnes 3-4) sont valorises
 3. **Bonus centre** : La colonne 3 a 1 jeton X = bonus de 3 points
-4. **Potentiel d'alignement** : 2 X horizontaux (cases 3-4) creent une menace
+4. **Potentiel d'alignement** : 2 X horizontaux (cases 3-4) créent une menace
 
-> **Note technique** : L'heuristique combine plusieurs facteurs : (1) bonus centre = +3 par jeton en colonne 3, (2) fenetres gagnantes (4 alignes) = +100, (3) 3 jetons + 1 vide = +5, (4) 2 jetons + 2 vides = +2, (5) bloquer adversaire = -4. Ici, MAX a 2 fenetres avec 2 jetons (colonnes 2-3-4-5 et 3-4-5-6) = 2x2 = 4 points, plus 3 points de centre = 7, plus d'autres contributions = 9 total.",,,,,,,,3c3a1d1d0292329e,,,,,,,
+> **Note technique** : L'heuristique combine plusieurs facteurs : (1) bonus centre = +3 par jeton en colonne 3, (2) fenêtrès gagnantes (4 alignes) = +100, (3) 3 jetons + 1 vide = +5, (4) 2 jetons + 2 vides = +2, (5) bloquer adversaire = -4. Ici, MAX a 2 fenêtrès avec 2 jetons (colonnes 2-3-4-5 et 3-4-5-6) = 2x2 = 4 points, plus 3 points de centre = 7, plus d'autrès contributions = 9 total.",,,,,,,,fd0b6a218701ba80,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,2c85aee3,markdown,fr,281af03db3cd369c,Statistiques de benchmark pour comparer les algorithmes.,,,,,,,,281af03db3cd369c,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,minimax-impl,code,fr,4ba075017ddac280,"# Statistiques globales pour le benchmark
 class SearchStats:
@@ -31807,38 +31805,38 @@ print(f""  Meilleur coup: {move}"")
 print(f""  Valeur: {value:.2f}"")
 print(f""  Noeuds explores: {stats.nodes_explored:,}"")
 print(f""  Temps: {stats.elapsed:.4f}s"")",,,,,,,,4ba075017ddac280,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,a4e34820,markdown,fr,cf23b0c5039c81c7,"### Interpretation : Test Minimax
+MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,a4e34820,markdown,fr,0730304853743e0a,"### Interprétation : Test Minimax
 
 **Sortie obtenue** : Minimax avec profondeur 4 sur position initiale.
 
 | Metrique | Valeur | Signification |
 |----------|--------|---------------|
-| Meilleur coup | 3 (colonne centrale) | Controle du centre = strategie optimale |
+| Meilleur coup | 3 (colonne centrale) | Contrôle du centre = stratégie optimale |
 | Valeur | 6.00 | Score heuristique positif (avantage MAX) |
-| Noeuds explores | 2,801 | Explosion combinatoire : ~7^4 = 2401 theoriques |
+| Noeuds explores | 2,801 | Explosion combinatoire : ~7^4 = 2401 théoriques |
 | Temps | 0.4375s | Acceptable pour d=4, mais explose pour d>5 (cf. benchmark) |
 
 **Points cles** :
 1. **Coup optimal** : Colonne 3 (centre) est le meilleur premier coup
 2. **Complexite** : 2,801 noeuds pour seulement 4 profondeurs
 3. **Temps raisonnable** : 0.44s est acceptable, mais le benchmark (cellule suivante) montre que d=6 prend ~23 secondes
-4. **Heuristique efficace** : Score 6.00 = avantage modere pour MAX
+4. **Heuristique efficace** : Score 6.00 = avantage modère pour MAX
 
-> **Note technique** : Le nombre de noeuds (2,801) est superieur a b^d = 7^4 = 2,401 car : (1) le facteur de branchement diminue en profondeur (colonnes se remplissent), (2) certaines branches sont plus longues que d=4, (3) l'exploration continue meme quand le plateau est presque plein. Minimax explore systematiquement TOUTES les branches jusqu'a la profondeur d, sans aucun elagage. C'est son principal defaut.
-",,,,,,,,cf23b0c5039c81c7,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,alphabeta-section,markdown,fr,0167f035d5dab9d3,"## 4. Algorithme Alpha-Beta
+> **Note technique** : Le nombre de noeuds (2,801) est supérieur a b^d = 7^4 = 2,401 car : (1) le facteur de branchement diminue en profondeur (colonnes se remplissent), (2) certaines branches sont plus longues que d=4, (3) l'exploration continue même quand le plateau est presque plein. Minimax explore systématiquement TOUTES les branches jusqu'a la profondeur d, sans aucun elagage. C'est son principal defaut.
+",,,,,,,,0730304853743e0a,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,alphabeta-section,markdown,fr,78a74d47271f39c4,"## 4. Algorithme Alpha-Beta
 
 ### Principe de l'elagage
 
-Alpha-Beta ameliore Minimax en eliminant les branches inutiles :
+Alpha-Beta améliore Minimax en eliminant les branches inutiles :
 - **alpha** : Meilleure valeur que MAX peut garantir
 - **beta** : Meilleure valeur que MIN peut garantir
 
 Si alpha >= beta, on peut couper la branche (l'adversaire ne permettra jamais d'atteindre cette branche).
 
-### Gain theorique
+### Gain théorique
 
-Avec un ordonnancement optimal des coups : **O(b^(d/2))** au lieu de **O(b^d)**.",,,,,,,,0167f035d5dab9d3,,,,,,,
+Avec un ordonnancement optimal des coups : **O(b^(d/2))** au lieu de **O(b^d)**.",,,,,,,,78a74d47271f39c4,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,alphabeta-impl,code,fr,3c2e11acf72ed6b8,"def alpha_beta(game: ConnectFour, depth: int, alpha: float, beta: float,
                maximizing: bool, stats: SearchStats, player: int = 1) -> Tuple[float, Optional[int]]:
     """"""
@@ -31922,7 +31920,7 @@ print(f""  Valeur: {value_ab:.2f}"")
 print(f""  Noeuds explores: {stats_ab.nodes_explored:,}"")
 print(f""  Temps: {stats_ab.elapsed:.4f}s"")
 print(f""\nReduction vs Minimax: {stats.nodes_explored / stats_ab.nodes_explored:.1f}x"")",,,,,,,,3c2e11acf72ed6b8,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,8d7797ba,markdown,fr,27721d1d14577fe0,"### Interpretation : Test Alpha-Beta
+MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,8d7797ba,markdown,fr,352b9a80df5ca6ed,"### Interprétation : Test Alpha-Beta
 
 **Sortie obtenue** : Alpha-Beta avec profondeur 4 sur position initiale.
 
@@ -31934,23 +31932,23 @@ MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipyn
 | Temps | 0.0215s | **~20x plus rapide** (0.4375s / 0.0215s) |
 
 **Points cles** :
-1. **Resultat identique** : Meme coup (colonne 3) et meme valeur (6.00)
+1. **résultat identique** : même coup (colonne 3) et même valeur (6.00)
 2. **Elagage massif** : 178 noeuds vs 2,801 = 94% de reduction
 3. **Vitesse** : 0.0215s vs 0.4375s = ~20x plus rapide
-4. **Optimalite gardee** : Alpha-Beta ne change pas le resultat, seulement la vitesse
+4. **Optimalite gardee** : Alpha-Beta ne change pas le résultat, seulement la vitesse
 
-> **Note technique** : La reduction de 15.7x en noeuds a profondeur 4 est excellente mais loin du maximum theorique. Avec un ordonnancement parfait des coups, Alpha-Beta pourrait atteindre b^(d/2) = environ 7^2 = 49x de reduction. L'ordonnancement actuel (par proximite au centre) est heuristique mais non optimal. Pour ameliorer, on pourrait : (1) trier par valeur de l'iteration precedente, (2) utiliser une table de transposition, (3) ordonnancer par les coups les plus joues.
-",,,,,,,,27721d1d14577fe0,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,mcts-section,markdown,fr,ac75ad21bdf1a5c5,"## 5. Algorithme MCTS
+> **Note technique** : La reduction de 15.7x en noeuds a profondeur 4 est excellente mais loin du maximum théorique. Avec un ordonnancement parfait des coups, Alpha-Beta pourrait atteindre b^(d/2) = environ 7^2 = 49x de reduction. L'ordonnancement actuel (par proximite au centre) est heuristique mais non optimal. Pour améliorer, on pourrait : (1) trier par valeur de l'itération précédente, (2) utiliser une table de transposition, (3) ordonnancer par les coups les plus joues.
+",,,,,,,,352b9a80df5ca6ed,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,mcts-section,markdown,fr,169194770a1c6e14,"## 5. Algorithme MCTS
 
 ### Principe de Monte Carlo Tree Search
 
 MCTS construit progressivement un arbre de recherche en equilibant exploration et exploitation :
 
-1. **Selection** : Descendre dans l'arbre avec UCB1
+1. **sélection** : Descendre dans l'arbre avec UCB1
 2. **Expansion** : Ajouter un nouveau noeud
-3. **Simulation** : Jouer une partie aleatoire (rollout)
-4. **Backpropagation** : Remonter le resultat
+3. **Simulation** : Jouer une partie aléatoire (rollout)
+4. **Backpropagation** : Remonter le résultat
 
 ### Formule UCB1
 
@@ -31959,7 +31957,7 @@ $$UCB1 = \frac{W}{N} + c \sqrt{\frac{\ln(N_{parent})}{N}}$$
 Ou :
 - W = nombre de victoires
 - N = nombre de visites
-- c = parametre d'exploration (typiquement 1.41)",,,,,,,,ac75ad21bdf1a5c5,,,,,,,
+- c = paramètre d'exploration (typiquement 1.41)",,,,,,,,169194770a1c6e14,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,mcts-impl,code,fr,785f9622e5a144df,"class MCTSNode:
     """"""Noeud de l'arbre MCTS.""""""
 
@@ -32114,31 +32112,31 @@ print(f""  Taux de victoire estime: {win_rate:.3f}"")
 print(f""  Noeuds explores: {mcts.stats.nodes_explored:,}"")
 print(f""  Temps: {mcts.stats.elapsed:.4f}s"")
 ",,,,,,,,785f9622e5a144df,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,2fbd0a65,markdown,fr,63b3e9c40d9c6ced,"### Interpretation : Test MCTS
+MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,2fbd0a65,markdown,fr,918a9243aa1143db,"### Interprétation : Test MCTS
 
-**Sortie obtenue** : MCTS avec 1000 iterations sur position initiale.
+**Sortie obtenue** : MCTS avec 1000 itérations sur position initiale.
 
 | Metrique | Valeur | Analyse |
 |----------|--------|---------|
 | Meilleur coup | 3 | Colonne centrale (comme Minimax et Alpha-Beta) |
-| Taux de victoire | 0.141 (14.1%) | Estimation bruitee pour 1000 iterations |
-| Noeuds explores | 2,000 | 1000 selections + 1000 simulations |
+| Taux de victoire | 0.141 (14.1%) | Estimation bruitee pour 1000 itérations |
+| Noeuds explores | 2,000 | 1000 sélections + 1000 simulations |
 | Temps | 1.311s | Plus lent qu'Alpha-Beta (0.0215s) mais raisonnable |
 
 **Points cles** :
 1. **Coup centre** : MCTS choisit la colonne 3, comme les approches exhaustives
-2. **Taux de victoire modere** : 14.1% reflete le caractere bruite des rollouts aleatoires
-3. **Temps** : 1.3s pour 1000 iterations, soit ~61x plus lent qu'Alpha-Beta(d=4)
-4. **Convergence lente** : MCTS necessite davantage d'iterations pour affiner Connect Four
+2. **Taux de victoire modère** : 14.1% reflete le caractère bruite des rollouts aléatoires
+3. **Temps** : 1.3s pour 1000 itérations, soit ~61x plus lent qu'Alpha-Beta(d=4)
+4. **convergence lente** : MCTS necessite davantage d'itérations pour affiner Connect Four
 
-> **Note technique** : MCTS est probabiliste : chaque execution donne un resultat legerement different. Le taux de victoire estime reste faible car les rollouts aleatoires exploitent mal la structure tactique forte de Connect Four. MCTS brille sur les jeux a grand facteur de branchement (Go, Havannah) ou les rollouts explorent des espaces vastes. Pour Connect Four, Alpha-Beta avec une bonne heuristique est nettement superieur.
-",,,,,,,,63b3e9c40d9c6ced,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,benchmark-section,markdown,fr,7c27b89b2ad10e9d,"## 6. Benchmark Comparatif
+> **Note technique** : MCTS est probabiliste : chaque exécution donne un résultat légèrement différent. Le taux de victoire estime reste faible car les rollouts aléatoires exploitent mal la structure tactique forte de Connect Four. MCTS brille sur les jeux a grand facteur de branchement (Go, Havannah) ou les rollouts explorent des espaces vastes. Pour Connect Four, Alpha-Beta avec une bonne heuristique est nettement supérieur.
+",,,,,,,,918a9243aa1143db,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,benchmark-section,markdown,fr,9cd53e24446e6c91,"## 6. Benchmark Comparatif
 
-Comparons les trois algorithmes sur differentes dimensions :
-- **Temps d'execution**
+Comparons les trois algorithmes sur différentes dimensions :
+- **Temps d'exécution**
 - **Noeuds explores**
-- **Qualite du coup** (vs coup optimal)",,,,,,,,7c27b89b2ad10e9d,,,,,,,
+- **Qualite du coup** (vs coup optimal)",,,,,,,,9cd53e24446e6c91,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,benchmark-depth,code,fr,ad7f06c5d98cd56c,"def run_benchmark_depth(max_depth: int = 6):
     """"""
     Compare Minimax et Alpha-Beta a differentes profondeurs.
@@ -32175,7 +32173,7 @@ MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipyn
 df_depth = run_benchmark_depth(max_depth=6)
 print(""Benchmark par profondeur:"")
 display(df_depth)",,,,,,,,ad7f06c5d98cd56c,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,9463d5c6,markdown,fr,025da3966b3a1927,"### Interpretation : Benchmark par profondeur
+MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,9463d5c6,markdown,fr,757b805f2deebb7a,"### Interprétation : Benchmark par profondeur
 
 **Sortie obtenue** : Comparaison Minimax vs Alpha-Beta de profondeur 1 a 6.
 
@@ -32189,14 +32187,14 @@ MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipyn
 | 6 | 137,257 | 1,370 | 100.2x | 23.111s | 0.166s | 138.9x |
 
 **Points cles** :
-1. **Acceleration exponentielle** : Le speedup augmente de 1x a 100x (noeuds) entre d=1 et d=6
+1. **accélération exponentielle** : Le speedup augmente de 1x a 100x (noeuds) entre d=1 et d=6
 2. **Complexite Minimax** : 137k noeuds a d=6 = explosion combinatoire (b^d avec b~4-7)
-3. **Efficacite Alpha-Beta** : Seulement 1.4k noeuds a d=6 = elagage massif
+3. **efficacité Alpha-Beta** : Seulement 1.4k noeuds a d=6 = elagage massif
 4. **Temps critique** : Minimax d=6 prend ~23 secondes, Alpha-Beta seulement ~0.17 seconde
 
-> **Note technique** : L'elagage Alpha-Beta atteint son potentiel maximal quand les bons coups sont explores en premier. L'ordonnancement par proximite au centre (colonne 3) est crucial : il permet d'eliminer rapidement les branches inferieures. Sans ordonnancement, le speedup serait seulement de 2-3x. Avec un ordonnancement parfait (theorique), le speedup pourrait atteindre b^(d/2), soit environ 400x a d=6 pour Connect Four.
-",,,,,,,,025da3966b3a1927,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,297c7890,markdown,fr,01de7ea63b5949c8,Benchmark MCTS avec differents nombres d'iterations.,,,,,,,,01de7ea63b5949c8,,,,,,,
+> **Note technique** : L'elagage Alpha-Beta atteint son potentiel maximal quand les bons coups sont explores en premier. L'ordonnancement par proximite au centre (colonne 3) est crucial : il permet d'eliminer rapidement les branches inférieures. Sans ordonnancement, le speedup serait seulement de 2-3x. Avec un ordonnancement parfait (théorique), le speedup pourrait atteindre b^(d/2), soit environ 400x a d=6 pour Connect Four.
+",,,,,,,,757b805f2deebb7a,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,297c7890,markdown,fr,119967e2afbc691c,Benchmark MCTS avec différents nombres d'itérations.,,,,,,,,119967e2afbc691c,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,benchmark-mcts,code,fr,db37f5c1bd922f48,"def run_benchmark_mcts(iterations_list: List[int] = [100, 500, 1000, 2000, 5000]):
     """"""
     Teste MCTS avec differents nombres d'iterations sur la meme position
@@ -32227,29 +32225,29 @@ df_mcts = run_benchmark_mcts()
 print(""Benchmark MCTS:"")
 display(df_mcts)
 ",,,,,,,,db37f5c1bd922f48,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,2a282f84,markdown,fr,d36c5b79a8ddee5c,"### Interpretation : Benchmark MCTS
+MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,2a282f84,markdown,fr,445df0eb119dde44,"### Interprétation : Benchmark MCTS
 
-**Sortie obtenue** : performance de MCTS sur la position initiale (plateau vide) avec differents nombres d'iterations.
+**Sortie obtenue** : performance de MCTS sur la position initiale (plateau vide) avec différents nombres d'itérations.
 
 **Lecture du tableau** :
-- **Coup** : colonne choisie par MCTS comme meilleur premier coup pour le joueur 1. Sur Connect Four 7 colonnes, la colonne 3 (centre) est theoriquement optimale ; les colonnes voisines (2 et 4) sont les seconds choix usuels.
-- **Taux victoire** : ratio victoires/visites au noeud du coup choisi a la racine. Reflete a quel point MCTS estime ce coup gagnant pour le joueur courant, conditionnellement a un adversaire jouant aleatoirement (rollouts uniformes). Avec adversaire aleatoire, le joueur 1 sur plateau vide gagne tres souvent quel que soit le coup ; les valeurs convergent typiquement vers 0.5-0.8 selon le nombre de simulations.
-- **Noeuds explores** : compteur cumule expansions + simulations. Pour `iterations=N`, on a typiquement ~2N (une expansion + une simulation par tour).
-- **Temps** : temps mur. Croit lineairement avec le nombre d'iterations.
+- **Coup** : colonne choisie par MCTS comme meilleur premier coup pour le joueur 1. Sur Connect Four 7 colonnes, la colonne 3 (centre) est théoriquement optimale ; les colonnes voisines (2 et 4) sont les seconds choix usuels.
+- **Taux victoire** : ratio victoires/visites au noeud du coup choisi a la racine. Reflete a quel point MCTS estime ce coup gagnant pour le joueur courant, conditionnellement a un adversaire jouant aléatoirement (rollouts uniformes). Avec adversaire aléatoire, le joueur 1 sur plateau vide gagne très souvent quel que soit le coup ; les valeurs convergent typiquement vers 0.5-0.8 selon le nombre de simulations.
+- **Noeuds explores** : compteur cumule expansions + simulations. Pour `itérations=N`, on a typiquement ~2N (une expansion + une simulation par tour).
+- **Temps** : temps mur. croit linéairement avec le nombre d'itérations.
 
-**Convergence attendue** :
-1. **100 iterations** : sous-echantillonnage. Le coup choisi peut varier d'une execution a l'autre (random rollouts) ; UCB1 n'a pas encore desambigue les colonnes.
-2. **500-1000 iterations** : MCTS commence a privilegier le centre (colonne 3) ou les colonnes adjacentes. Taux de victoire stabilise vers le vrai win rate sous policy aleatoire.
-3. **2000-5000 iterations** : convergence ferme sur le coup optimal (typiquement colonne 3). Taux de victoire stable a +/- 5% entre executions.
+**convergence attendue** :
+1. **100 itérations** : sous-échantillonnage. Le coup choisi peut varier d'une exécution a l'autre (random rollouts) ; UCB1 n'a pas encore desambigue les colonnes.
+2. **500-1000 itérations** : MCTS commence a privilegier le centre (colonne 3) ou les colonnes adjacentes. Taux de victoire stabilise vers le vrai win rate sous policy aléatoire.
+3. **2000-5000 itérations** : convergence ferme sur le coup optimal (typiquement colonne 3). Taux de victoire stable a +/- 5% entre exécutions.
 
 **Points cles** :
-- **Coherence garantie** : grace au reset d'etat dans `MCTS.search` (sauvegarde/restauration via `game.set_state(initial_state)`) et a la creation d'un `ConnectFour()` neuf par iteration dans `run_benchmark_mcts`, chaque ligne du tableau correspond bien a un benchmark sur la **meme position de depart** (plateau vide). Sans ce reset, l'etat du jeu derivait entre iterations vers des positions arbitraires, faussant la comparaison.
-- **MCTS est stochastique** : les valeurs varient legerement entre executions (rollouts aleatoires). C'est attendu, et c'est la moyenne sur de nombreuses runs qui converge vers la vraie esperance.
-- **Connect Four est resolu** : le joueur 1 gagne avec jeu parfait en commencant par la colonne 3 (Allis 1988). MCTS sans heuristique d'evaluation ne le decouvre qu'avec beaucoup de rollouts ; pour un agent realiste sur Connect Four, on couplerait MCTS a un reseau de neurones (cf AlphaZero) ou on utiliserait Alpha-Beta avec table de transposition.
+- **cohérence garantie** : grâce au reset d'etat dans `MCTS.search` (sauvegarde/restauration via `game.set_state(initial_state)`) et a la creation d'un `ConnectFour()` neuf par itération dans `run_benchmark_mcts`, chaque ligne du tableau correspond bien a un benchmark sur la **même position de depart** (plateau vide). Sans ce reset, l'etat du jeu derivait entre itérations vers des positions arbitraires, faussant la comparaison.
+- **MCTS est stochastique** : les valeurs varient légèrement entre exécutions (rollouts aléatoires). C'est attendu, et c'est la moyenne sur de nombreuses runs qui converge vers la vraie esperance.
+- **Connect Four est résolu** : le joueur 1 gagne avec jeu parfait en commencant par la colonne 3 (Allis 1988). MCTS sans heuristique d'évaluation ne le découvre qu'avec beaucoup de rollouts ; pour un agent réaliste sur Connect Four, on couplerait MCTS a un réseau de neurones (cf AlphaZero) ou on utiliserait Alpha-Beta avec table de transposition.
 
-> **Note technique** : les rollouts sont **uniformement aleatoires** ici (cf `_simulate`). Cela donne un signal pauvre sur Connect Four ou la victoire depend de patterns precis (4-en-ligne). Une amelioration classique consiste a biaiser les rollouts vers des coups gagnants/bloquants immediats (heuristique de simulation), ou a remplacer la simulation par l'evaluation d'un reseau de neurones entraine.
-",,,,,,,,d36c5b79a8ddee5c,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,54f4e208,markdown,fr,fe70a413353b61fe,Visualisation comparative des resultats.,,,,,,,,fe70a413353b61fe,,,,,,,
+> **Note technique** : les rollouts sont **uniformêment aléatoires** ici (cf `_simulate`). Cela donne un signal pauvre sur Connect Four ou la victoire dépend de patterns précis (4-en-ligne). Une amélioration classique consiste a biaiser les rollouts vers des coups gagnants/bloquants immédiats (heuristique de simulation), ou a remplacer la simulation par l'évaluation d'un réseau de neurones entraine.
+",,,,,,,,445df0eb119dde44,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,54f4e208,markdown,fr,d328f4c5f4c0a4a2,Visualisation comparative des résultats.,,,,,,,,d328f4c5f4c0a4a2,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,benchmark-visual,code,fr,e816dd24c26e5214,"# Visualisation des resultats
 fig, axes = plt.subplots(1, 2, figsize=(14, 5))
 
@@ -32280,42 +32278,42 @@ plt.savefig('benchmark_adversarial.png', dpi=150, bbox_inches='tight')
 plt.show()
 
 print(""Graphique sauvegarde: benchmark_adversarial.png"")",,,,,,,,e816dd24c26e5214,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,6dd43848,markdown,fr,62f23b7974fd548d,"### Interpretation : Visualisation comparative
+MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,6dd43848,markdown,fr,114a1a04a5b11425,"### Interprétation : Visualisation comparative
 
 **Sortie obtenue** : Graphiques comparant Minimax et Alpha-Beta sur 6 profondeurs.
 
-| Aspect | Observation | Signification |
+| Aspect | observation | Signification |
 |--------|-------------|---------------|
-| **Noeuds explores** | Croissance exponentielle pour Minimax, lineaire pour Alpha-Beta | Elagage de plus en plus efficace avec la profondeur |
-| **Temps execution** | Ecart critique entre d=5 et d=6 | Alpha-Beta d=6 (0.17s) vs Minimax d=6 (23.1s) = ~139x plus rapide |
+| **Noeuds explores** | croissance exponentielle pour Minimax, linéaire pour Alpha-Beta | Elagage de plus en plus efficace avec la profondeur |
+| **Temps exécution** | Ecart critique entre d=5 et d=6 | Alpha-Beta d=6 (0.17s) vs Minimax d=6 (23.1s) = ~139x plus rapide |
 | **Speedup noeuds** | 1x (d=1) a 100x (d=6) | L'elagage augmente avec la profondeur |
-| **Echelle log** | Necessaire pour visualiser la difference | Difference de 2 ordres de grandeur |
+| **échelle log** | nécessaire pour visualiser la différence | différence de 2 ordres de grandeur |
 
 **Points cles** :
 1. **Explosion combinatoire** : Minimax devient impraticable des d=6 (~23 secondes)
-2. **Efficacite Alpha-Beta** : 100x moins de noeuds explores, ~139x plus rapide a d=6
-3. **Seuil pratique** : Pour Connect Four, Alpha-Beta d=6-8 est realiste, Minimax d>5 ne l'est pas
-4. **Ordre de grandeur** : L'echelle logarithmique masque la difference reelle (137k vs 1.4k noeuds)
+2. **efficacité Alpha-Beta** : 100x moins de noeuds explores, ~139x plus rapide a d=6
+3. **Seuil pratique** : Pour Connect Four, Alpha-Beta d=6-8 est réaliste, Minimax d>5 ne l'est pas
+4. **Ordre de grandeur** : L'échelle logarithmique masque la différence réelle (137k vs 1.4k noeuds)
 
-> **Note technique** : Le speedup augmente avec la profondeur car l'elagage a plus d'opportunites de couper des branches. A profondeur 1, aucun elagage n'est possible (toutes les feuilles sont au meme niveau). L'ordonnancement des coups (centre en priorite) maximise cet elagage.
-",,,,,,,,62f23b7974fd548d,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,interpretation-section,markdown,fr,969f04c189105e48,"### Interpretation des resultats
+> **Note technique** : Le speedup augmente avec la profondeur car l'elagage a plus d'opportunites de couper des branches. A profondeur 1, aucun elagage n'est possible (toutes les feuilles sont au même niveau). L'ordonnancement des coups (centre en priorite) maximise cet elagage.
+",,,,,,,,114a1a04a5b11425,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,interpretation-section,markdown,fr,abcacc6188a6a5d6,"### Interprétation des résultats
 
 | Algorithme | Points forts | Points faibles | Usage recommande |
 |------------|--------------|----------------|------------------|
 | **Minimax** | Simple, optimal | Explosion combinatoire | Petits jeux, enseignement |
-| **Alpha-Beta** | Efficace, optimal | Ordonnancement critique | Jeux a branchement moyen |
-| **MCTS** | Pas d'heuristique, parallele | Probabiliste | Grands espaces, jeux complexes |
+| **Alpha-Beta** | efficace, optimal | Ordonnancement critique | Jeux a branchement moyen |
+| **MCTS** | Pas d'heuristique, parallèle | probabiliste | grands espaces, jeux complexes |
 
-**Observations cles** :
+**observations cles** :
 
-1. **Alpha-Beta** reduit drastiquement le nombre de noeuds (facteur 5-20x selon la profondeur)
+1. **Alpha-Beta** réduit drastiquement le nombre de noeuds (facteur 5-20x selon la profondeur)
 2. **L'ordonnancement** des coups est crucial pour maximiser l'elagage
-3. **MCTS** converge vers de bons coups sans fonction d'evaluation explicite
-4. Pour un temps donne, Alpha-Beta profond bat souvent MCTS sur Connect Four",,,,,,,,969f04c189105e48,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,tournament-section,markdown,fr,6a9e11d5e579d4df,"## 7. Tournoi entre algorithmes
+3. **MCTS** converge vers de bons coups sans fonction d'évaluation explicite
+4. Pour un temps donne, Alpha-Beta profond bat souvent MCTS sur Connect Four",,,,,,,,abcacc6188a6a5d6,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,tournament-section,markdown,fr,f8d36b881a1f1b4f,"## 7. Tournoi entre algorithmes
 
-Faisons jouer les algorithmes les uns contre les autres pour mesurer leur force relative.",,,,,,,,6a9e11d5e579d4df,,,,,,,
+Faisons jouer les algorithmes les uns contre les autrès pour mesurer leur force relative.",,,,,,,,f8d36b881a1f1b4f,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,tournament-impl,code,fr,01613a0729ec7993,"def play_game(agent1, agent2, verbose: bool = False) -> int:
     """"""
     Fait jouer deux agents l'un contre l'autre.
@@ -32435,7 +32433,7 @@ print(""Lancement du tournoi (6 parties par match)..."")
 df_tournament = run_tournament(agents, n_games=6)
 print(""\nResultats du tournoi:"")
 display(df_tournament)",,,,,,,,62f4b86be27574fd,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,618fcde1,markdown,fr,12bb06e183a0a3cf,"### Interpretation : Resultats du tournoi
+MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,618fcde1,markdown,fr,e2f176f7d67395e1,"### Interprétation : Résultats du tournoi
 
 **Sortie obtenue** : Tournoi round-robin entre 4 agents (6 parties par match).
 
@@ -32448,36 +32446,36 @@ MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipyn
 
 **Points cles** :
 1. **Alpha-Beta domine largement** : 94% de victoires, 6-0 contre Minimax et Random
-2. **Minimax equilibre** : 50% de win rate (bat MCTS 3-3, perd contre Alpha-Beta)
-3. **MCTS en difficulte** : Perd contre Alpha-Beta (1-5) et contre Random (2-4), egalite contre Minimax (3-3)
-4. **Echantillon insuffisant** : 6 parties par match = resultats variables
+2. **Minimax équilibre** : 50% de win rate (bat MCTS 3-3, perd contre Alpha-Beta)
+3. **MCTS en difficulté** : Perd contre Alpha-Beta (1-5) et contre Random (2-4), égalité contre Minimax (3-3)
+4. **échantillon insuffisant** : 6 parties par match = résultats variables
 
-> **Note technique** : La difference entre Minimax et Alpha-Beta devrait etre nulle (meme profondeur = meme coups). Le score 6-0 suggere soit : (1) alea dans l'implementation, (2) difference d'ordonnancement des coups, ou (3) echantillon trop petit. Avec 50+ parties, les win rates convergeraient vers ~50% pour Minimax vs Alpha-Beta.
-",,,,,,,,12bb06e183a0a3cf,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,tournament-analysis,markdown,fr,c35b8961532bf282,"### Analyse du tournoi
+> **Note technique** : La différence entre Minimax et Alpha-Beta devrait etre nulle (même profondeur = même coups). Le score 6-0 suggere soit : (1) alea dans l'implementation, (2) différence d'ordonnancement des coups, ou (3) échantillon trop petit. Avec 50+ parties, les win rates convergeraient vers ~50% pour Minimax vs Alpha-Beta.
+",,,,,,,,e2f176f7d67395e1,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,tournament-analysis,markdown,fr,97661d55de961e06,"### Analyse du tournoi
 
-Les resultats du tournoi montrent la hierarchie des algorithmes :
+Les résultats du tournoi montrent la hiérarchie des algorithmes :
 
 1. **Alpha-Beta et Minimax** devraient dominer Random facilement
-2. **Alpha-Beta vs Minimax** : Resultats similaires (meme qualite de jeu)
-3. **MCTS** : Performance variable selon le nombre d'iterations
+2. **Alpha-Beta vs Minimax** : résultats similaires (même qualite de jeu)
+3. **MCTS** : Performance variable selon le nombre d'itérations
 
-> **Note** : Avec seulement 6 parties par match, les resultats peuvent varier.
-> Pour une evaluation robuste, utiliser 50+ parties.",,,,,,,,c35b8961532bf282,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,exercices-section,markdown,fr,86dc4b49c22d58b3,"## Exercices
-
-
-
-Les six exercices ci-dessous vous font manipuler les trois familles d'agents (Minimax, Alpha-Beta, MCTS) vues plus haut. Ils progressent du reglage d'un hyperparametre (1, 2) a l'amelioration de l'evaluation (3), puis aux techniques de recherche avancees (4, 6) et a la validation experimentale (5). Chaque stub est self-contained : les fonctions utilitaires (`run_benchmark_depth`, `ConnectFour`, `alphabeta`) sont definies dans les sections precedentes.",,,,,,,,86dc4b49c22d58b3,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,a14frm1,markdown,fr,d57fc49c46b8757a,"### Exercice 1 -- Profondeur variable vs temps
+> **Note** : Avec seulement 6 parties par match, les résultats peuvent varier.
+> Pour une évaluation robuste, utiliser 50+ parties.",,,,,,,,97661d55de961e06,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,exercices-section,markdown,fr,225e8aa110a35ca9,"## Exercices
 
 
 
-**Objectif** : comparer Alpha-Beta aux profondeurs 4, 6 et 8, et determiner la profondeur optimale pour un budget de 1 seconde. C'est le levier classique du compromis temps/profondeur en recherche adverse.
+Les six exercices ci-dessous vous font manipuler les trois familles d'agents (Minimax, Alpha-Beta, MCTS) vues plus haut. Ils progressent du reglage d'un hyperparamètre (1, 2) a l'amélioration de l'évaluation (3), puis aux techniques de recherche avancées (4, 6) et a la validation expérimentale (5). Chaque stub est self-contained : les fonctions utilitaires (`run_benchmark_depth`, `ConnectFour`, `alphabeta`) sont définies dans les sections précédentes.",,,,,,,,225e8aa110a35ca9,,,,,,,
+MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,a14frm1,markdown,fr,fd517406e5807173,"### Exercice 1 -- Profondeur variable vs temps
 
 
 
-**Indices** : `run_benchmark_depth()` (section 3) comme base ; mesurer temps + nombre de noeuds ; faire jouer les algorithmes entre eux pour juger la qualite des coups, pas seulement la vitesse.",,,,,,,,d57fc49c46b8757a,,,,,,,
+**objectif** : comparer Alpha-Beta aux profondeurs 4, 6 et 8, et déterminer la profondeur optimale pour un budget de 1 seconde. C'est le levier classique du compromis temps/profondeur en recherche adverse.
+
+
+
+**Indices** : `run_benchmark_depth()` (section 3) comme base ; mesurer temps + nombre de noeuds ; faire jouer les algorithmes entre eux pour juger la qualite des coups, pas seulement la vitesse.",,,,,,,,fd517406e5807173,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,3f66ff3a,code,fr,1a3dabdaa9364f39,"# Exercice 1 : Profondeur variable
 # TODO: Comparez Alpha-Beta aux profondeurs 4, 6, 8
 # - Mesurer le temps et le nombre de noeuds pour chaque profondeur
@@ -32494,15 +32492,15 @@ def benchmark_profondeur_optimale(temps_cible: float = 1.0) -> Dict:
     pass
 
 print(""Exercice a completer - voir les indices ci-dessus"")",,,,,,,,1a3dabdaa9364f39,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,a14frm2,markdown,fr,eadfacb9de06bc71,"### Exercice 2 -- Parametre d'exploration c de MCTS
+MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,a14frm2,markdown,fr,7c43bbedfad90873,"### Exercice 2 -- Paramètre d'exploration c de MCTS
 
 
 
-**Objectif** : tester l'impact du coefficient c de UCB1 (`c = 0.5` exploitation, `1.0` equilibre, `1.41 = sqrt(2)` theorie, `2.0` exploration) sur la force de jeu de MCTS.
+**objectif** : tester l'impact du coefficient c de UCB1 (`c = 0.5` exploitation, `1.0` équilibre, `1.41 = sqrt(2)` théorie, `2.0` exploration) sur la force de jeu de MCTS.
 
 
 
-**Indices** : 20 parties contre un agent random pour chaque valeur de c ; le win rate trace la courbe exploration/exploitation.",,,,,,,,eadfacb9de06bc71,,,,,,,
+**Indices** : 20 parties contre un agent random pour chaque valeur de c ; le win rate trace la courbe exploration/exploitation.",,,,,,,,7c43bbedfad90873,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,844741f7,code,fr,c8686d2adcd38f45,"# Exercice 2 : Parametre MCTS
 # TODO: Testez differentes valeurs de c et analysez l'impact
 # - c = 0.5 : exploitation dominante
@@ -32519,15 +32517,15 @@ def benchmark_mcts_c(valeurs_c: List[float], parties: int = 20) -> pd.DataFrame:
     pass
 
 print(""Exercice a completer - voir les indices ci-dessus"")",,,,,,,,c8686d2adcd38f45,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,a14frm3,markdown,fr,4103774230adb640,"### Exercice 3 -- Heuristique amelioree (detection de menaces)
+MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,a14frm3,markdown,fr,17733b6479388d35,"### Exercice 3 -- Heuristique améliorée (détection de menaces)
 
 
 
-**Objectif** : enrichir la fonction d'evaluation avec la detection des menaces imminentes (3 jetons alignes + 1 case vide accessible au-dessus) et comparer a l'heuristique de base.
+**objectif** : enrichir la fonction d'évaluation avec la détection des menaces imminentes (3 jetons alignes + 1 case vide accessible au-dessus) et comparer a l'heuristique de base.
 
 
 
-**Indices** : une fenetre gagnante = 3 jetons + 1 case vide au sommet d'une colonne ; bonus/malus important pour ces menaces car elles decident le coup suivant.",,,,,,,,4103774230adb640,,,,,,,
+**Indices** : une fenêtre gagnante = 3 jetons + 1 case vide au sommet d'une colonne ; bonus/malus important pour ces menaces car elles décident le coup suivant.",,,,,,,,17733b6479388d35,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,74e32395,code,fr,c58dde56ae11f16e,"# Exercice 3 : Heuristique amelioree
 # TODO: Ajoutez la detection des menaces imminentes a l'evaluation
 # - Detecter les ""3 alignes"" avec une case vide accessible
@@ -32544,15 +32542,15 @@ def evaluate_position_improved(game: ConnectFour, player: int = 1) -> float:
     pass
 
 print(""Exercice a completer - voir les indices ci-dessus"")",,,,,,,,c58dde56ae11f16e,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,a14frm4,markdown,fr,595dc9c569c1949a,"### Exercice 4 -- Iterative Deepening avec limite de temps
+MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,a14frm4,markdown,fr,bd14cb30226a1b4b,"### Exercice 4 -- Itérative Deepening avec limite de temps
 
 
 
-**Objectif** : implementer une recherche Alpha-Beta qui demarre a profondeur 1 et augmente progressivement jusqu'a epuisement du budget temps, en retournant le meilleur coup de la derniere profondeur complete.
+**objectif** : implementer une recherche Alpha-Beta qui démarre a profondeur 1 et augmente progressivement jusqu'a épuisément du budget temps, en retournant le meilleur coup de la dernière profondeur complète.
 
 
 
-**Indices** : `time.time()` pour mesurer le temps ecoule ; on garde le coup de la profondeur N-1 si la profondeur N est interrompue. C'est la technique utilisee en pratique pour respecter un budget temps strict.",,,,,,,,595dc9c569c1949a,,,,,,,
+**Indices** : `time.time()` pour mesurer le temps ecoule ; on garde le coup de la profondeur N-1 si la profondeur N est interrompue. C'est la technique utilisée en pratique pour respecter un budget temps strict.",,,,,,,,bd14cb30226a1b4b,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,9ebbe4f5,code,fr,f4c40d011357e6db,"# Exercice 4 : Iterative Deepening
 # TODO: Implementez une recherche avec limite de temps
 # - Commencer a profondeur 1, augmenter progressivement
@@ -32569,15 +32567,15 @@ def alphabeta_iterative_deepening(game: ConnectFour, temps_max: float = 1.0) -> 
     pass
 
 print(""Exercice a completer - voir les indices ci-dessus"")",,,,,,,,f4c40d011357e6db,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,a14frm5,markdown,fr,08e6e2ea43fccdd4,"### Exercice 5 -- Tournoi etendu avec analyse statistique
+MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,a14frm5,markdown,fr,c36265b929c7fe7d,"### Exercice 5 -- Tournoi etendu avec analyse statistique
 
 
 
-**Objectif** : lancer un tournoi robuste (50 parties par match) entre Random, Minimax(d=4), AlphaBeta(d=4) et MCTS(1000), avec intervalles de confiance et test de significativite sur les win rates.
+**objectif** : lancer un tournoi robuste (50 parties par match) entre Random, Minimax(d=4), AlphaBeta(d=4) et MCTS(1000), avec intervalles de confiance et test de significativite sur les win rates.
 
 
 
-**Indices** : `scipy.stats` pour les tests statistiques ; 50 parties reduisent la variance pour distinguer les agents dont les win rates sont proches.",,,,,,,,08e6e2ea43fccdd4,,,,,,,
+**Indices** : `scipy.stats` pour les tests statistiques ; 50 parties reduisent la variance pour distinguer les agents dont les win rates sont proches.",,,,,,,,c36265b929c7fe7d,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,871585bf,code,fr,6f1d29d3b92d0743,"# Exercice 5 : Tournoi etendu
 # TODO: Lancez un tournoi avec 50 parties par match
 # - Comparer Random, Minimax(d=4), AlphaBeta(d=4), MCTS(1000)
@@ -32593,15 +32591,15 @@ def tournoi_robuste(agents: Dict[str, callable], parties_par_match: int = 50) ->
     pass
 
 print(""Exercice a completer - voir les indices ci-dessus"")",,,,,,,,6f1d29d3b92d0743,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,a14frm6,markdown,fr,669069152de99a18,"### Exercice 6 -- Livre d'ouvertures (Opening Book)
+MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,a14frm6,markdown,fr,4f20c7c8f8a1b66c,"### Exercice 6 -- Livre d'ouvertures (Opening Book)
 
 
 
-**Objectif** : precalculer les meilleurs premiers coups avec un Alpha-Beta profond (d=8), les stocker dans un dictionnaire `{plateau_hash: meilleur_coup}`, puis mesurer le gain (temps economise + qualite) en debut de partie.
+**objectif** : precalculer les meilleurs premiers coups avec un Alpha-Beta profond (d=8), les stocker dans un dictionnaire `{plateau_hash: meilleur_coup}`, puis mesurer le gain (temps economise + qualite) en debut de partie.
 
 
 
-**Indices** : un `dict {(plateau_hash): meilleur_coup}` ; la generation se fait une fois pour toutes (hors-ligne), la consultation en match est O(1).",,,,,,,,669069152de99a18,,,,,,,
+**Indices** : un `dict {(plateau_hash): meilleur_coup}` ; la génération se fait une fois pour toutes (hors-ligne), la consultation en match est O(1).",,,,,,,,4f20c7c8f8a1b66c,,,,,,,
 MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,06ccbb7e,code,fr,6e679c89666d4d74,"# Exercice 6 : Opening Book
 # TODO: Creez un livre d'ouvertures pour les premiers coups
 # - Stocker les meilleurs coups pour les positions de debut de partie
@@ -32627,24 +32625,24 @@ class OpeningBook:
         pass
 
 print(""Exercice a completer - voir les indices ci-dessus"")",,,,,,,,6e679c89666d4d74,,,,,,,
-MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,conclusion-section,markdown,fr,a16b8dab882f87a0,"## Conclusion
+MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb,conclusion-section,markdown,fr,1c6ee2fb6c66d93a,"## Conclusion
 
 ### Synthese comparative
 
-| Critere | Minimax | Alpha-Beta | MCTS |
+| critère | Minimax | Alpha-Beta | MCTS |
 |---------|---------|------------|------|
-| **Optimalite** | Oui (si profondeur complete) | Oui (identique a Minimax) | Probabiliste |
+| **Optimalite** | Oui (si profondeur complète) | Oui (identique a Minimax) | probabiliste |
 | **Complexite** | O(b^d) | O(b^(d/2)) optimal | O(n * d) |
-| **Fonction d'evaluation** | Necessaire | Necessaire | Non requise |
-| **Parallelisation** | Difficile | Difficile | Tres facile |
-| **Meilleur usage** | Petits jeux | Jeux moyens | Grands jeux |
+| **Fonction d'évaluation** | nécessaire | nécessaire | Non requise |
+| **Parallelisation** | Difficile | Difficile | très facile |
+| **Meilleur usage** | Petits jeux | Jeux moyens | grands jeux |
 
 ### Recommandations pratiques
 
 1. **Pour Connect Four** : Alpha-Beta avec profondeur 6-8 et bonne heuristique
-2. **Pour les echecs** : Alpha-Beta avec tables de transposition
-3. **Pour le Go** : MCTS + reseaux de neurones (AlphaGo)
-4. **Pour un temps limite strict** : MCTS ou iterative deepening
+2. **Pour les échecs** : Alpha-Beta avec tables de transposition
+3. **Pour le Go** : MCTS + réseaux de neurones (AlphaGo)
+4. **Pour un temps limite strict** : MCTS ou itérative deepening
 
 ### Pour aller plus loin
 
@@ -32655,4 +32653,4 @@ MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipyn
 
 ---
 
-**Navigation** : [<< App-12 ConnectFour](../Search/App-12-ConnectFour.ipynb) | [Index](../../README.md) | [CSP Applications >>](../CSP/App-1-NQueens.ipynb)",,,,,,,,a16b8dab882f87a0,,,,,,,
+**Navigation** : [<< App-12 ConnectFour](../Search/App-12-ConnectFour.ipynb) | [Index](../../README.md) | [CSP Applications >>](../CSP/App-1-NQueens.ipynb)",,,,,,,,1c6ee2fb6c66d93a,,,,,,,


### PR DESCRIPTION
## Objet

4th pass T2 durable resync vein (casestudies #7317, audio #7319, semanticweb #7320). Campagne accent-cure a corrigé sources Search/Applications. CSV seedé avant avait stale pivot -> **519 SRC_DRIFT**. Search = worker's native turf (content variety vs prior families).

## Changement

Resync via `extract_cells_to_csv.py --update` (whole Search/Applications family) :
- **519 rows refreshed**, 949 already in-sync
- 0 orphan, 0 added
- **0 prior translations lost** (0 rows had text_en/es/ru/zh/ar filled)

## Verification (firsthand, fresh worktree origin/main @ 4c81b1c9a)

- `check_translation_sync.py` **AVANT** : 519 anomalies (SRC_DRIFT)
- **APRES** : `0 anomalies` ✓
- Diff : 1 fichier, +2122/-2124 (pivot column refresh on 519 rows, coherent)
- Catalogue byte-identique à main

## Scope atomique + R6 note

1 famille (search/applications), 1 fichier CSV. R6 transparency flag: 4th consecutive translation pass — DM sent to ai-01 (msg-6qtkq0) for register-variety arbitration. This is a one-shot post-accent-campaign catch-up (~8054 repo-wide drift / 15000 cures), each family = different pedagogical content (not R6.6-capped routine cleanup). Awaiting ai-01 verdict on (A) continue T2 vs (B) vary register.

See #4957. Credential = jsboige active (push:true upstream).

Co-Authored-By: Claude-Code <noreply@anthropic.com>