### PR TITLE
chore(translation,#4957): resync SymbolicAI/SMT CSVs post-accent-cure (300 rows, 0 drift)

### DIFF
--- a/translations/smt/z3-api.csv
+++ b/translations/smt/z3-api.csv
@@ -1,14 +1,14 @@
 notebook,cell_id,cell_type,src_lang,src_hash,text_fr,text_en,text_es,text_ar,text_fa,text_zh,text_ru,text_pt,hash_fr,hash_en,hash_es,hash_ar,hash_fa,hash_zh,hash_ru,hash_pt
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction-Csharp.ipynb,be974b19,markdown,fr,7937068aa2d56d65,"# Z3 (C# / .NET) — Introduction au solveur SMT
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction-Csharp.ipynb,be974b19,markdown,fr,eaed8fac8469e9f7,"# Z3 (C# / .NET) — Introduction au solveur SMT
 
 **Twin C# de `Z3-Python-01-Introduction.ipynb`** (parite .NET, marathon #4956).
 
-Ce notebook est l'equivalent .NET de l'introduction au solveur SMT Z3. Il utilise le **moteur reel [Microsoft.Z3](https://github.com/Z3Prover/z3)** (binding .NET officiel de Z3), le meme solveur que la version Python (`z3-solver`), via le package NuGet `Microsoft.Z3`. Aucune re-implementation jouet : les contraintes sont resolues par le vrai moteur SOTA.
+Ce notebook est l'equivalent .NET de l'introduction au solveur SMT Z3. Il utilise le **moteur reel [Microsoft.Z3](https://github.com/Z3Prover/z3)** (binding .NET officiel de Z3), le même solveur que la version Python (`z3-solver`), via le package NuGet `Microsoft.Z3`. Aucune re-implementation jouet : les contraintes sont resolues par le vrai moteur SOTA.
 
 ## Pre-requis
 
 - Kernel `.NET (C#)` (.NET Interactive).
-- Le package NuGet `Microsoft.Z3` est restaure automatiquement par la premiere cellule.
+- Le package NuGet `Microsoft.Z3` est restaure automatiquement par la première cellule.
 
 ## Plan
 
@@ -18,7 +18,7 @@ Ce notebook est l'equivalent .NET de l'introduction au solveur SMT Z3. Il utilis
 4. Arithmetique rationnelle exacte.
 5. Mini sac a dos (optimisation).
 6. Trois exercices.
-",,,,,,,,7937068aa2d56d65,,,,,,,
+",,,,,,,,eaed8fac8469e9f7,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction-Csharp.ipynb,eac25c0b,code,fr,714a196310b751e7,"#r ""nuget: Microsoft.Z3""
 using Microsoft.Z3;
 Console.WriteLine(""Imports OK : Microsoft.Z3 version "" + Microsoft.Z3.Version.FullVersion);
@@ -192,22 +192,22 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction-Csharp.ipynb,b
 var res = AllocationOptimale();
 Console.WriteLine(""Allocation optimale : "" + (res.HasValue ? res.ToString() : ""(a completer)""));
 ",,,,,,,,4f4037b4c720aaef,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction-Csharp.ipynb,ea555e2c,markdown,fr,622603873549a29d,"## Conclusion
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction-Csharp.ipynb,ea555e2c,markdown,fr,78a087a9680c2b99,"## Conclusion
 
-Ce twin C# couvre les memes concepts que la version Python : **Satisfiabilite** (`Solver`, `Check`, `Model`), **noyau d'insatisfiabilite** (`AssertAndTrack`, `UnsatCore`), **logique booleenne** (`BoolConst`, `MkNot`, `MkAnd`), **arithmetique rationnelle exacte** (`Real`, fractions), et **optimisation** (`Optimize`, `MkMaximize`).
+Ce twin C# couvre les mêmes concepts que la version Python : **Satisfiabilite** (`Solver`, `Check`, `Model`), **noyau d'insatisfiabilite** (`AssertAndTrack`, `UnsatCore`), **logique booleenne** (`BoolConst`, `MkNot`, `MkAnd`), **arithmetique rationnelle exacte** (`Real`, fractions), et **optimisation** (`Optimize`, `MkMaximize`).
 
-Le binding `Microsoft.Z3` expose exactement le meme moteur Z3 que `z3-solver` (Python) : les resultats sont identiques, seuls l'API et le langage changent. C'est l'illustration qu'un solveur SMT SOTA est utilisable de facon native en .NET.
-",,,,,,,,622603873549a29d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction.ipynb,nb01-title,markdown,fr,a2e7faa767883ca3,"# Z3-Python 01 — Introduction a la resolution de contraintes SMT
+Le binding `Microsoft.Z3` expose exactement le même moteur Z3 que `z3-solver` (Python) : les résultats sont identiques, seuls l'API et le langage changent. C'est l'illustration qu'un solveur SMT SOTA est utilisable de facon native en .NET.
+",,,,,,,,78a087a9680c2b99,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction.ipynb,nb01-title,markdown,fr,dfd19162f832d907,"# Z3-Python 01 — Introduction a la resolution de contraintes SMT
 
 **Navigation** : [Index](README.md) | [Z3-Python-02 Sudoku >>](Z3-Python-02-Sudoku.ipynb)
 
 ## Objectifs d'apprentissage
 
 A la fin de ce notebook, vous saurez :
-1. **Modeliser** un probleme sous forme de contraintes et le resoudre avec le solveur Z3 en Python
+1. **Modeliser** un problème sous forme de contraintes et le resoudre avec le solveur Z3 en Python
 2. **Distinguer** les reponses `sat`, `unsat` et `unknown` du solveur
-3. **Manipuler** les types de base : entiers (`Int`), booleens (`Bool`) et reels (`Real`)
+3. **Manipuler** les types de base : entiers (`Int`), booléens (`Bool`) et reels (`Real`)
 4. **Utiliser** l'optimisation (`Optimize`) pour maximiser/minimiser une variable sous contraintes
 
 ### Prerequis
@@ -218,7 +218,7 @@ A la fin de ce notebook, vous saurez :
 
 ---
 
-**Z3** est un solveur SMT (*Satisfiability Modulo Theories*) developpe par Microsoft Research. Un solveur SMT determine si un ensemble de contraintes logiques et arithmetiques peut etre satisfait, et si oui, fournit un **modele** (une assignation concrete des variables). Cette serie utilise **z3-py**, le binding Python officiel (package pip `z3-solver`), qui expose l'integralite de l'API Z3 sans la limitation d'un binding declaratif. Pour les fondements theoriques de la resolution SMT (DPLL(T)) et la presentation du solveur Z3 lui-meme, voir de Moura & Bjorner, *Z3: An Efficient SMT Solver* (TACAS 2008) et Nieuwenhuis, Oliveras & Tinelli, *Solving SAT and SAT Modulo Theories: From an Abstract DPLL Procedure to DPLL(T)* (JACM 2006) ; les tactiques (notebook 3) et MaxSAT (notebook 6) sont ancrees dans la section References du README.",,,,,,,,a2e7faa767883ca3,,,,,,,
+**Z3** est un solveur SMT (*Satisfiability Modulo Théories*) developpe par Microsoft Research. Un solveur SMT determine si un ensemble de contraintes logiques et arithmetiques peut etre satisfait, et si oui, fournit un **modèle** (une assignation concrete des variables). Cette serie utilise **z3-py**, le binding Python officiel (package pip `z3-solver`), qui expose l'integralite de l'API Z3 sans la limitation d'un binding declaratif. Pour les fondements théoriques de la resolution SMT (DPLL(T)) et la presentation du solveur Z3 lui-même, voir de Moura & Bjorner, *Z3: An Efficient SMT Solver* (TACAS 2008) et Nieuwenhuis, Oliveras & Tinelli, *Solving SAT and SAT Modulo Théories: From an Abstract DPLL Procedure to DPLL(T)* (JACM 2006) ; les tactiques (notebook 3) et MaxSAT (notebook 6) sont ancrees dans la section References du README.",,,,,,,,dfd19162f832d907,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction.ipynb,nb01-imports,code,fr,0ca1d0d4f062e4aa,"# Imports et verification de l'environnement
 # Le package pip s'appelle 'z3-solver' (et non 'z3').
 # Dans cet environnement il est deja installe. Pour l'installer ailleurs :
@@ -227,15 +227,15 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction.ipynb,nb01-imp
 from z3 import *
 
 print(f""Imports OK : z3-solver version {get_version_string()}"")",,,,,,,,0ca1d0d4f062e4aa,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction.ipynb,nb01-solver-intro,markdown,fr,76a756ac992ff6ac,"## 1. Premier solveur : entiers et satisfaction
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction.ipynb,nb01-solver-intro,markdown,fr,83d4dc6a8e7ffd33,"## 1. Premier solveur : entiers et satisfaction
 
-Commencons par le cas le plus simple : deux variables entieres `x` et `y` soumises a un ensemble de contraintes lineaires. Le patron d'usage est toujours le meme :
+Commencons par le cas le plus simple : deux variables entieres `x` et `y` soumises a un ensemble de contraintes lineaires. Le patron d'usage est toujours le même :
 
-1. **Creer** un `Solver()`
+1. **Créer** un `Solver()`
 2. **Declarer** des variables typees (`Int`, `Real`, `Bool`...)
 3. **Ajouter** des contraintes avec `s.add(...)`
 4. **Verifier** la satisfiabilite avec `s.check()` -> renvoie `sat`, `unsat` ou `unknown`
-5. Si `sat`, **extraire** un modele avec `s.model()`",,,,,,,,76a756ac992ff6ac,,,,,,,
+5. Si `sat`, **extraire** un modèle avec `s.model()`",,,,,,,,83d4dc6a8e7ffd33,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction.ipynb,nb01-solver-code,code,fr,7d644ff642f36300,"# Premier exemple : deux entiers sous contraintes lineaires
 s = Solver()
 x = Int('x')
@@ -255,20 +255,20 @@ if resultat == sat:
     print(""  x ="", m[x].as_long())
     print(""  y ="", m[y].as_long())
     print(""  Verification : x + y ="", m[x].as_long() + m[y].as_long())",,,,,,,,7d644ff642f36300,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction.ipynb,nb01-solver-interp,markdown,fr,e05ed06946423532,"### Interpretation : sat / unsat / unknown
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction.ipynb,nb01-solver-interp,markdown,fr,b2ec64da2f5a749a,"### Interpretation : sat / unsat / unknown
 
-**Sortie obtenue** : le solveur repond `sat` et fournit un modele concret (par exemple `x = 6, y = 4`).
+**Sortie obtenue** : le solveur repond `sat` et fournit un modèle concret (par exemple `x = 6, y = 4`).
 
 | Reponse | Signification | Action |
 |---------|---------------|--------|
 | `sat` | Il existe au moins une assignation satisfaisant toutes les contraintes | `s.model()` donne un exemple |
-| `unsat` | Aucune assignation ne peut satisfaire les contraintes (contradiction) | Le systeme est sur-contraint |
+| `unsat` | Aucune assignation ne peut satisfaire les contraintes (contradiction) | Le système est sur-contraint |
 | `unknown` | Le solveur ne peut pas conclure (trop complexe, quantificateurs, timeout) | Simplifier ou changer de tactique |
 
 **Points cles** :
-1. `s.model()` ne donne **qu'un** modele parmi potentiellement plusieurs ; Z3 ne garantit pas lequel.
+1. `s.model()` ne donne **qu'un** modèle parmi potentiellement plusieurs ; Z3 ne garantit pas lequel.
 2. Les variables Z3 sont des **objets symboliques** : `x + y == 10` construit une formule, n'evaluate rien tant que `check()` n'est pas appele.
-3. `m[x].as_long()` convertit la valeur Z3 en entier Python natif.",,,,,,,,e05ed06946423532,,,,,,,
+3. `m[x].as_long()` convertit la valeur Z3 en entier Python natif.",,,,,,,,b2ec64da2f5a749a,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction.ipynb,nb01-unsat-code,code,fr,7e5d33eb4f52fdbb,"# Exemple insatisfiable : contraintes contradictoires
 s2 = Solver()
 x = Int('x')
@@ -289,7 +289,7 @@ s3.assert_and_track(x < 3, c2)
 print(""\nAvec assert_and_track :"")
 print(""Resultat :"", s3.check())
 print(""Noyau d'insatisfiabilite (contraintes en conflit) :"", s3.unsat_core())",,,,,,,,7e5d33eb4f52fdbb,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction.ipynb,nb01-unsat-interp,markdown,fr,5569ffd4fa62b58e,"### Interpretation : contradiction et noyau d'insatisfiabilite
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction.ipynb,nb01-unsat-interp,markdown,fr,3556a0ab8d027a6b,"### Interpretation : contradiction et noyau d'insatisfiabilite
 
 **Sortie obtenue** : `s2.check()` renvoie `unsat`, et le noyau identifie les deux assertions contradictoires.
 
@@ -298,7 +298,7 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction.ipynb,nb01-uns
 | `unsat` | Aucun entier `x` ne peut etre simultanement `> 5` et `< 3` |
 | `unsat_core()` | Sous-ensemble minimal d'assertions responsables du conflit (necessite `assert_and_track`) |
 
-> **Note technique** : Le noyau d'insatisfiabilite est precieux en pratique : il pointe exactement les contraintes a assouplir pour rendre un probleme realisable (utile en planification, configuration, debogage de contrats).",,,,,,,,5569ffd4fa62b58e,,,,,,,
+> **Note technique** : Le noyau d'insatisfiabilite est precieux en pratique : il pointe exactement les contraintes a assouplir pour rendre un problème realisable (utile en planification, configuration, debogage de contrats).",,,,,,,,3556a0ab8d027a6b,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction.ipynb,nb01-bool-intro,markdown,fr,b68a6d5384dbee24,"## 2. Logique booleenne : `Bool`, `And`, `Or`, `Not`, `Implies`
 
 Z3 manipule des variables booleennes et des connecteurs logiques. Illustrons-le avec un classique : le **paradoxe du menteur**.
@@ -329,7 +329,7 @@ print(""B dit la verite :"", bool(m[B]))
 print(""C dit la verite :"", bool(m[C]))
 veridique = ""A"" if bool(m[A]) else (""B"" if bool(m[B]) else ""C"")
 print(""\nSynthese :"", veridique, ""dit la verite."")",,,,,,,,a9784c232f1ca877,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction.ipynb,nb01-bool-interp,markdown,fr,563cf35446e089f9,"### Interpretation : raisonnement propositionnel
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction.ipynb,nb01-bool-interp,markdown,fr,a5dee851d5546d6a,"### Interpretation : raisonnement propositionnel
 
 **Sortie obtenue** : le solveur identifie qui dit la verite de maniere coherente avec les trois affirmations.
 
@@ -342,11 +342,11 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction.ipynb,nb01-boo
 | `Xor(p, q)` | $p \oplus q$ |
 
 **Points cles** :
-1. L'operateur Python `==` est surcharge pour exprimer l'**equivalence logique** entre deux formules Z3.
-2. Z3 resout instantanement des systemes propositionnels qui necessiteraient une enumeration exhaustive manuelle.",,,,,,,,563cf35446e089f9,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction.ipynb,nb01-real-intro,markdown,fr,97d456d4401ad7c9,"## 3. Nombres reels : `Real` et l'arithmetic rationnelle
+1. L'opérateur Python `==` est surcharge pour exprimer l'**equivalence logique** entre deux formules Z3.
+2. Z3 resout instantanement des systèmes propositionnels qui necessiteraient une enumeration exhaustive manuelle.",,,,,,,,a5dee851d5546d6a,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction.ipynb,nb01-real-intro,markdown,fr,f64a4a755b93e527,"## 3. Nombres reels : `Real` et l'arithmetic rationnelle
 
-Le type `Real` modelise des nombres rationnels. Z3 travaille en **arithmetic exacte** (pas de virgule flottante) : les fractions sont manipulees symboliquement. Ideal pour des problemes de partage ou de dosage precis.",,,,,,,,97d456d4401ad7c9,,,,,,,
+Le type `Real` modelise des nombres rationnels. Z3 travaille en **arithmetic exacte** (pas de virgule flottante) : les fractions sont manipulees symboliquement. Ideal pour des problemes de partage ou de dosage précis.",,,,,,,,f64a4a755b93e527,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction.ipynb,nb01-real-code,code,fr,8b630fef12eca6cb,"# Arithmetic rationnelle exacte avec Real.
 # Trois enfants se partagent 10 euros.
 # L'aine recoit le double du cadet, le benjamin recoit 1 euro de plus que le cadet.
@@ -378,11 +378,11 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction.ipynb,nb01-rea
 1. Z3 manipule les **fractions exactes**, jamais d'erreur d'arrondi flottant.
 2. Verification : $9/2 + 9/4 + 13/4 = 18/4 + 9/4 + 13/4 = 40/4 = 10$.
 3. `Real` est ideal pour les problemes de partage, de dosage ou de conversion ou la precision exacte compte.",,,,,,,,ed91fd7f91354840,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction.ipynb,nb01-opt-intro,markdown,fr,4c577c4d662a628c,"## 4. Optimisation : `Optimize`
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction.ipynb,nb01-opt-intro,markdown,fr,9db0f4c654c93743,"## 4. Optimisation : `Optimize`
 
 La classe `Optimize` etend `Solver` en ajoutant un **objectif** a maximiser ou minimiser sous contraintes. C'est l'outil de choix pour l'allocation de ressources, le sac a dos ou la planification.
 
-Modelisons un mini-sac a dos : on dispose de 3 objets de valeurs et poids differents, et d'une capacite maximale. On cherche a **maximiser la valeur** sans depasser le poids.",,,,,,,,4c577c4d662a628c,,,,,,,
+Modelisons un mini-sac a dos : on dispose de 3 objets de valeurs et poids différents, et d'une capacite maximale. On cherche a **maximiser la valeur** sans depasser le poids.",,,,,,,,9db0f4c654c93743,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction.ipynb,nb01-opt-code,code,fr,a1bb0d8ec49c72bb,"# Mini sac a dos : maximiser la valeur transportee sous contrainte de poids.
 opt = Optimize()
 
@@ -411,11 +411,11 @@ poids_total = 2 * m[n_a].as_long() + 3 * m[n_b].as_long() + 5 * m[n_c].as_long()
 valeur_totale = 4 * m[n_a].as_long() + 5 * m[n_b].as_long() + 7 * m[n_c].as_long()
 print(f""  Poids total : {poids_total} / 10 kg"")
 print(f""  Valeur totale : {valeur_totale}"")",,,,,,,,a1bb0d8ec49c72bb,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction.ipynb,nb01-opt-interp,markdown,fr,b18e11f48b51e6c7,"### Interpretation : optimisation sous contraintes
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction.ipynb,nb01-opt-interp,markdown,fr,5f89b8d44ddeffc9,"### Interpretation : optimisation sous contraintes
 
 **Sortie obtenue** : Z3 trouve la combinaison maximisant la valeur sans depasser 10 kg.
 
-| Classe | Role | Equivalent |
+| Classe | Rôle | Equivalent |
 |--------|------|------------|
 | `Solver` | Verifier la satisfiabilite | « Existe-t-il une solution ? » |
 | `Optimize` | Trouver la **meilleure** solution | « Quelle est la solution optimale ? » |
@@ -425,7 +425,7 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction.ipynb,nb01-opt
 2. L'optimisation combinatoire d'entiers est NP-difficile, mais Z3 (moteur branches-bornes) reste efficace sur de petites instances.
 3. On peut combiner plusieurs objectifs avec des priorites (optimisation lexicographique ou ponderee).
 
-> **Note technique** : `Optimize` etend `Solver`. Tout ce qui fonctionne avec `Solver` (types, contraintes) s'applique aussi a `Optimize`.",,,,,,,,b18e11f48b51e6c7,,,,,,,
+> **Note technique** : `Optimize` etend `Solver`. Tout ce qui fonctionne avec `Solver` (types, contraintes) s'applique aussi a `Optimize`.",,,,,,,,5f89b8d44ddeffc9,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction.ipynb,nb01-ex1-intro,markdown,fr,31aa54e33ebf7f60,"## Exercice 1 : Triplets pythagoriciens
 
 ### Enonce
@@ -455,23 +455,23 @@ def trouver_triplet_pythagoricien(borne_max: int = 20) -> tuple:
 
 triplet = trouver_triplet_pythagoricien(20)
 print(""Triplet pythagoricien :"", triplet)",,,,,,,,515623bb01e8dbbc,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction.ipynb,nb01-ex2-intro,markdown,fr,83df1605a7f9ae4b,"## Exercice 2 : Ordonnancement de deux taches
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction.ipynb,nb01-ex2-intro,markdown,fr,2345fd792c4b844e,"## Exercice 2 : Ordonnancement de deux tâches
 
 ### Enonce
 
-Deux taches T1 et T2 doivent etre planifiees. Chacune a une duree (en heures) et ne peut commencer qu'a un entier `debut >= 0`. Les contraintes sont :
+Deux tâches T1 et T2 doivent etre planifiees. Chacune a une duree (en heures) et ne peut commencer qu'a un entier `debut >= 0`. Les contraintes sont :
 - T1 dure 3 heures, T2 dure 2 heures.
-- Les deux taches ne peuvent pas se chevaucher dans le temps.
+- Les deux tâches ne peuvent pas se chevaucher dans le temps.
 - T1 doit commencer avant T2.
 - On veut que T2 se termine le plus tot possible.
 
-Modelisez ce probleme avec Z3 et trouvez l'heure de debut optimale de chaque tache.
+Modelisez ce problème avec Z3 et trouvez l'heure de debut optimale de chaque tâche.
 
 ### Indices
 
 - Variables : `d1 = Int('debut_T1')`, `d2 = Int('debut_T2')`, toutes `>= 0`.
 - Comme T1 commence avant T2 et ne se chevauchent pas, ajoutez `d2 >= d1 + 3`.
-- Utilisez `Optimize` pour minimiser `d2 + 2` (la fin de T2).",,,,,,,,83df1605a7f9ae4b,,,,,,,
+- Utilisez `Optimize` pour minimiser `d2 + 2` (la fin de T2).",,,,,,,,2345fd792c4b844e,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction.ipynb,nb01-ex2-code,code,fr,a4555a88c32159d6,"# EXERCICE 2 : Ordonnancer deux taches sans chevauchement.
 
 def ordonnancer_taches() -> dict:
@@ -515,24 +515,24 @@ def allocation_optimale() -> dict:
 
 resultat = allocation_optimale()
 print(""Allocation optimale :"", resultat)",,,,,,,,658df60593d0b847,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction.ipynb,nb01-conclusion,markdown,fr,5daffebdebee9568,"## Recapitulatif
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction.ipynb,nb01-conclusion,markdown,fr,f8384d5e65013ba5,"## Recapitulatif
 
 Ce notebook a pose les fondations de la resolution de contraintes avec **z3-py** :
 
 | Concept | API Z3 | Usage |
 |---------|--------|-------|
-| Solveur de base | `Solver`, `add`, `check`, `model` | Satisfiabilite d'un systeme de contraintes |
+| Solveur de base | `Solver`, `add`, `check`, `model` | Satisfiabilite d'un système de contraintes |
 | Insatisfiabilite | `unsat`, `unsat_core` | Detecter et expliquer les contradictions |
 | Logique booleenne | `Bool`, `And`, `Or`, `Not`, `Implies` | Raisonnement propositionnel |
 | Nombres reels | `Real` | Arithmetic rationnelle exacte |
 | Optimisation | `Optimize`, `maximize`, `minimize` | Trouver la meilleure solution |
 
-Le changement de paradigme est fondamental : **vous decrivez ce que vous voulez (les contraintes), pas comment l'obtenir (l'algorithme)**. Le notebook suivant, [Z3-Python-02 Sudoku](Z3-Python-02-Sudoku.ipynb), applique cette approche declarative a un probleme concret : la resolution de grilles de Sudoku.",,,,,,,,5daffebdebee9568,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-02-Sudoku-Csharp.ipynb,452f9b5e,markdown,fr,fe81d45dcbc6a9a5,"# Z3 (C# / .NET) — Sudoku par contraintes
+Le changement de paradigme est fondamental : **vous decrivez ce que vous voulez (les contraintes), pas comment l'obtenir (l'algorithme)**. Le notebook suivant, [Z3-Python-02 Sudoku](Z3-Python-02-Sudoku.ipynb), applique cette approche declarative a un problème concret : la resolution de grilles de Sudoku.",,,,,,,,f8384d5e65013ba5,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-02-Sudoku-Csharp.ipynb,452f9b5e,markdown,fr,0f145834c4b5f198,"# Z3 (C# / .NET) — Sudoku par contraintes
 
 **Twin C# de `Z3-Python-02-Sudoku.ipynb`** (parite .NET, marathon #4956, suite de `Z3-Python-01-Introduction-Csharp`).
 
-Ce notebook resout le Sudoku de facon **declarative** avec le **moteur reel [Microsoft.Z3](https://github.com/Z3Prover/z3)** (NuGet, Z3 4.12.2.0), le meme solveur que `z3-solver` (Python). Au lieu d'ecrire un algorithme de backtracking, on **exprime les regles du Sudoku comme des contraintes** et le solveur trouve une solution.
+Ce notebook resout le Sudoku de facon **declarative** avec le **moteur reel [Microsoft.Z3](https://github.com/Z3Prover/z3)** (NuGet, Z3 4.12.2.0), le même solveur que `z3-solver` (Python). Au lieu d'ecrire un algorithme de backtracking, on **exprime les règles du Sudoku comme des contraintes** et le solveur trouve une solution.
 
 ## Principe
 
@@ -550,7 +550,7 @@ La contrainte Z3 clee est `MkDistinct` : elle impose que tous les termes d'un en
 2. Resolution declarative avec `Solver` + `MkDistinct`.
 3. Visualisation ASCII de la grille.
 4. Trois exercices.
-",,,,,,,,fe81d45dcbc6a9a5,,,,,,,
+",,,,,,,,0f145834c4b5f198,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-02-Sudoku-Csharp.ipynb,d3fef19a,code,fr,3975aa8f8ca588fc,"#r ""nuget: Microsoft.Z3""
 using Microsoft.Z3;
 using System.Text;
@@ -595,7 +595,7 @@ int CompterIndices(int[][] g) {
 Console.WriteLine(""Puzzle facile : "" + CompterIndices(puzzle_facile) + "" indices donnes"");
 Console.WriteLine(""Puzzle intermediaire : "" + CompterIndices(puzzle_intermediaire) + "" indices donnes"");
 ",,,,,,,,643015f9f7d82a4a,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-02-Sudoku-Csharp.ipynb,863f6a60,markdown,fr,c4c5516a9ce270ff,"## 2. Resolution declarative avec Z3
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-02-Sudoku-Csharp.ipynb,863f6a60,markdown,fr,417fd6b1366d98af,"## 2. Resolution declarative avec Z3
 
 La fonction `ResoudreSudoku` construit un `Solver` Z3 et pose les contraintes :
 
@@ -603,8 +603,8 @@ La fonction `ResoudreSudoku` construit un `Solver` Z3 et pose les contraintes :
 - **Indices** : les cases pre-remplies sont figees (`MkEq`).
 - **Unicite lignes / colonnes / blocs 3x3** : trois groupes de contraintes `MkDistinct`.
 
-Puis `s.Check()` : si `SATISFIABLE`, on extrait le modele. Aucun backtracking n'est ecrit a la main : c'est le moteur Z3 qui cherche.
-",,,,,,,,c4c5516a9ce270ff,,,,,,,
+Puis `s.Check()` : si `SATISFIABLE`, on extrait le modèle. Aucun backtracking n'est ecrit a la main : c'est le moteur Z3 qui cherche.
+",,,,,,,,417fd6b1366d98af,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-02-Sudoku-Csharp.ipynb,e54eebc6,code,fr,ee12777cc6df88f9,"int[][] ResoudreSudoku(Context ctx, int[][] grille)
 {
     var s = ctx.MkSolver();
@@ -657,10 +657,10 @@ var ctxS = new Context();
 var solution_facile = ResoudreSudoku(ctxS, puzzle_facile);
 Console.WriteLine(""Puzzle facile : "" + (solution_facile != null ? ""resolu"" : ""insatisfiable""));
 ",,,,,,,,ee12777cc6df88f9,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-02-Sudoku-Csharp.ipynb,1c8a9f01,markdown,fr,fbab321c482c0f81,"## 3. Visualisation ASCII
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-02-Sudoku-Csharp.ipynb,1c8a9f01,markdown,fr,27875d3bedc908cc,"## 3. Visualisation ASCII
 
-Le twin Python utilise `matplotlib` pour afficher la grille. Ce twin C# propose une **visualisation ASCII** equivalente : les cases **donnees** sont en gras (`[n]`), les cases **calculees** par Z3 en clair (` n `). Les separateurs `|` et `--+---+--` marquent les blocs 3x3.
-",,,,,,,,fbab321c482c0f81,,,,,,,
+Le twin Python utilise `matplotlib` pour afficher la grille. Ce twin C# propose une **visualisation ASCII** equivalente : les cases **données** sont en gras (`[n]`), les cases **calculees** par Z3 en clair (` n `). Les separateurs `|` et `--+---+--` marquent les blocs 3x3.
+",,,,,,,,27875d3bedc908cc,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-02-Sudoku-Csharp.ipynb,8055e181,code,fr,4b01af058bcd3acb,"void AfficherSudoku(int[][] grille, int[][] donnees = null, string titre = ""Sudoku"")
 {
     Console.WriteLine(""--- "" + titre + "" ---"");
@@ -728,35 +728,35 @@ int CompterSolutions(Context ctx, int[][] grille, int limite = 2)
 int nb = CompterSolutions(new Context(), puzzle_facile, 2);
 Console.WriteLine(""Exercice 3 (nombre de solutions) : "" + (nb > 0 ? nb.ToString() : ""(a completer)""));
 ",,,,,,,,7ceb223961529d61,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-02-Sudoku-Csharp.ipynb,babc68fa,markdown,fr,db20d57ef9d75087,"## Conclusion
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-02-Sudoku-Csharp.ipynb,babc68fa,markdown,fr,eb668bc7b98a7b46,"## Conclusion
 
-Ce twin C# couvre les memes concepts que la version Python : modelisation **declarative** d'un CSP (le Sudoku), contrainte d'unicite `MkDistinct` sur les lignes / colonnes / blocs, extraction du modele, et exercices d'extension (anti-diagonale, enumeration des solutions).
+Ce twin C# couvre les mêmes concepts que la version Python : modelisation **declarative** d'un CSP (le Sudoku), contrainte d'unicite `MkDistinct` sur les lignes / colonnes / blocs, extraction du modèle, et exercices d'extension (anti-diagonale, enumeration des solutions).
 
-La visualisation ASCII remplace `matplotlib` (twin Python) : c'est une **valeur complementaire** (Prong B EPIC #3801) -- la meme information structurelle (indices donnes vs calcules, separation des blocs) rendue dans une modalite differente, sans dependance graphique.
+La visualisation ASCII remplace `matplotlib` (twin Python) : c'est une **valeur complementaire** (Prong B EPIC #3801) -- la même information structurelle (indices donnes vs calcules, separation des blocs) rendue dans une modalite différente, sans dépendance graphique.
 
 Le binding `Microsoft.Z3` resout le Sudoku exactement comme `z3-solver` (Python) : aucun backtracking n'est ecrit, le moteur SOTA fait tout.
-",,,,,,,,db20d57ef9d75087,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-02-Sudoku.ipynb,nb02-title,markdown,fr,6b8d7763bf18324e,"# Z3-Python 02 — Sudoku comme probleme de satisfaction de contraintes
+",,,,,,,,eb668bc7b98a7b46,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-02-Sudoku.ipynb,nb02-title,markdown,fr,c8cbb71990ce3c67,"# Z3-Python 02 — Sudoku comme problème de satisfaction de contraintes
 
 **Navigation** : [<< Z3-Python-01 Introduction](Z3-Python-01-Introduction.ipynb) | [Index](README.md)
 
 ## Objectifs d'apprentissage
 
 A la fin de ce notebook, vous saurez :
-1. **Modeliser** le Sudoku comme un probleme de satisfaction de contraintes (CSP) en z3-py
-2. **Formaliser** les regles (lignes, colonnes, blocs 3x3) sous forme de contraintes `Distinct`
+1. **Modeliser** le Sudoku comme un problème de satisfaction de contraintes (CSP) en z3-py
+2. **Formaliser** les règles (lignes, colonnes, blocs 3x3) sous forme de contraintes `Distinct`
 3. **Visualiser** une grille et sa solution avec matplotlib
 4. **Confronter** l'approche declarative (Z3) a l'approche imperative (backtracking)
 
 ### Prerequis
 - Avoir suivi [Z3-Python-01 Introduction](Z3-Python-01-Introduction.ipynb)
-- Notions de Sudoku (regles du jeu)
+- Notions de Sudoku (règles du jeu)
 
 ### Duree estimee : ~25 min
 
 ---
 
-Le [notebook precedent](Z3-Python-01-Introduction.ipynb) a introduit le solveur Z3. Ici, nous l'appliquons a un probleme NP-complet emblematique : le **Sudoku**. L'approche contraste avec la serie [Sudoku par backtracking](../../../Sudoku/Sudoku-1-Backtracking-Python.ipynb) : au lieu de programmer l'algorithme de recherche, nous **enonc ons les regles** et laissons le solveur deduire la solution.",,,,,,,,6b8d7763bf18324e,,,,,,,
+Le [notebook précédent](Z3-Python-01-Introduction.ipynb) a introduit le solveur Z3. Ici, nous l'appliquons a un problème NP-complet emblematique : le **Sudoku**. L'approche contraste avec la serie [Sudoku par backtracking](../../../Sudoku/Sudoku-1-Backtracking-Python.ipynb) : au lieu de programmer l'algorithme de recherche, nous **enonc ons les règles** et laissons le solveur deduire la solution.",,,,,,,,c8cbb71990ce3c67,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-02-Sudoku.ipynb,nb02-imports,code,fr,58f1658c49fcc56e,"# Imports
 from z3 import *
 import matplotlib.pyplot as plt
@@ -854,11 +854,11 @@ solution_facile = resoudre_sudoku(puzzle_facile)
 print(""Puzzle facile :"", ""resolu"" if solution_facile else ""insatisfiable"")
 for ligne in solution_facile:
     print(ligne)",,,,,,,,a817a1254948432b,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-02-Sudoku.ipynb,nb02-model-interp,markdown,fr,917673db99b4776d,"### Interpretation : la puissance de la declaration
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-02-Sudoku.ipynb,nb02-model-interp,markdown,fr,bf4e141f9a4de1f2,"### Interpretation : la puissance de la declaration
 
 **Sortie obtenue** : Z3 resout le puzzle instantanement et affiche la grille complete.
 
-| Famille de contraintes | Nombre | Role |
+| Famille de contraintes | Nombre | Rôle |
 |------------------------|--------|------|
 | Domaine (1-9) | 81 | Bornes des variables |
 | Indices figes | ~35 | Enonce du puzzle |
@@ -867,9 +867,9 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-02-Sudoku.ipynb,nb02-model-int
 | `Distinct` bloc | 9 | Une seule occurrence par bloc 3x3 |
 
 **Points cles** :
-1. **Aucun algorithme de recherche ecrit a la main** : Z3 gere lui-meme l'exploration.
-2. La contrainte `Distinct([...])` exprime naturellement « tous differents ».
-3. Le meme code resout n'importe quel puzzle, du facile a l'expert : seules les donnees changent.",,,,,,,,917673db99b4776d,,,,,,,
+1. **Aucun algorithme de recherche ecrit a la main** : Z3 gere lui-même l'exploration.
+2. La contrainte `Distinct([...])` exprime naturellement « tous différents ».
+3. Le même code resout n'importe quel puzzle, du facile a l'expert : seules les données changent.",,,,,,,,bf4e141f9a4de1f2,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-02-Sudoku.ipynb,nb02-viz-intro,markdown,fr,13a254995f48f516,"## 3. Visualisation : donne en noir, resolu en bleu
 
 Pour distinguer les indices fournis par l'enonce des valeurs deduites par le solveur, nous reprenons le style de visualisation de la [serie Sudoku par backtracking](../../../Sudoku/Sudoku-1-Backtracking-Python.ipynb). Les valeurs **initiales** s'affichent en noir, les valeurs **ajoutees** par Z3 en bleu.",,,,,,,,13a254995f48f516,,,,,,,
@@ -917,28 +917,28 @@ plot_sudoku(puzzle_facile, ""Puzzle initial (indices)"")
 
 # Solution : indices en noir, valeurs deduites en bleu
 plot_sudoku(solution_facile, ""Solution Z3 (bleu = valeurs deduites)"", puzzle_facile)",,,,,,,,d54e9e9c9bae7944,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-02-Sudoku.ipynb,nb02-viz-interp,markdown,fr,1db6d6eaf97c0c8d,"### Interpretation : declaratif vs imperatif
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-02-Sudoku.ipynb,nb02-viz-interp,markdown,fr,0c5949cbffa77b8d,"### Interpretation : declaratif vs imperatif
 
-La visualisation met en evidence la difference fondamentale d'approche.
+La visualisation met en evidence la différence fondamentale d'approche.
 
 | Aspect | Backtracking (serie Sudoku) | Z3 declaratif (ce notebook) |
 |--------|------------------------------|------------------------------|
-| **Ce qu'on ecrit** | L'algorithme de recherche (DFS, retour-arriere) | Les regles du jeu (`Distinct`, domaines) |
-| **Strategie** | MRV, elagage, heuristiques codees a la main | Deleguee au solveur |
+| **Ce qu'on ecrit** | L'algorithme de recherche (DFS, retour-arriere) | Les règles du jeu (`Distinct`, domaines) |
+| **Stratégie** | MRV, elagage, heuristiques codees a la main | Deleguee au solveur |
 | **Adaptation** | Reecrire l'algorithme pour chaque variante | Ajouter une contrainte |
 | **Lecture du code** | Comment on explore | Ce qu'on veut obtenir |
 
 **Points cles** :
 1. En bleu apparaissent les valeurs que Z3 a deduites : aucun retour-arriere manuel.
-2. Ajouter une regle (anti-diagonale, variante X-Sudoku) se resume a **une contrainte supplementaire**.
-3. Le cout : on perd le controle fin sur la strategie de recherche (mais Z3 est tres optimise).
+2. Ajouter une règle (anti-diagonale, variante X-Sudoku) se resume a **une contrainte supplementaire**.
+3. Le cout : on perd le contrôle fin sur la stratégie de recherche (mais Z3 est très optimise).
 
-> **Note technique** : Z3 combine en interne resolution SAT, propagation et theories arithmetiques. Sur le Sudoku (instance petite), la resolution est quasi instantanee (< 10 ms).",,,,,,,,1db6d6eaf97c0c8d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-02-Sudoku.ipynb,nb02-ex1-intro,markdown,fr,818e0bd56df93143,"## Exercice 1 : Variante anti-diagonale
+> **Note technique** : Z3 combine en interne resolution SAT, propagation et théories arithmetiques. Sur le Sudoku (instance petite), la resolution est quasi instantanee (< 10 ms).",,,,,,,,0c5949cbffa77b8d,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-02-Sudoku.ipynb,nb02-ex1-intro,markdown,fr,38f34c006ceff5d1,"## Exercice 1 : Variante anti-diagonale
 
 ### Enonce
 
-Certains Sudokus imposent une regle supplementaire : l'**anti-diagonale** (du coin haut-droit au coin bas-gauche) doit elle aussi contenir les chiffres 1 a 9 sans repetition.
+Certains Sudokus imposent une règle supplementaire : l'**anti-diagonale** (du coin haut-droit au coin bas-gauche) doit elle aussi contenir les chiffres 1 a 9 sans repetition.
 
 Modifiez la fonction de resolution pour ajouter cette contrainte et resoudre le puzzle facile.
 
@@ -946,7 +946,7 @@ Modifiez la fonction de resolution pour ajouter cette contrainte et resoudre le 
 
 - L'anti-diagonale correspond aux cases `(r, 8 - r)` pour `r` de 0 a 8.
 - Ajoutez un `Distinct([cellules[r][8 - r] for r in range(9)])`.
-- Attention : selon le puzzle, cette contrainte supplementaire peut le rendre `unsat`.",,,,,,,,818e0bd56df93143,,,,,,,
+- Attention : selon le puzzle, cette contrainte supplementaire peut le rendre `unsat`.",,,,,,,,38f34c006ceff5d1,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-02-Sudoku.ipynb,nb02-ex1-code,code,fr,7d947bc2b7860e61,"# EXERCICE 1 : Resoudre le Sudoku avec une contrainte d'anti-diagonale.
 
 def resoudre_sudoku_anti_diagonale(grille: List[List[int]]) -> Optional[List[List[int]]]:
@@ -988,17 +988,17 @@ def resoudre_et_visualiser(grille: List[List[int]]):
 
 resultat_ex2 = resoudre_et_visualiser(puzzle_intermediaire)
 print(""Exercice 2 :"", ""résolu et visualisé"" if resultat_ex2 is not None else ""à compléter (la fonction ne fait rien)"")",,,,,,,,1ec073d2ca6e17d1,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-02-Sudoku.ipynb,nb02-ex3-intro,markdown,fr,c0b0f2d32668529f,"## Exercice 3 : Detecter les solutions multiples
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-02-Sudoku.ipynb,nb02-ex3-intro,markdown,fr,323fa30817258a04,"## Exercice 3 : Detecter les solutions multiples
 
 ### Enonce
 
-Un puzzle de Sudoku bien forme possede une **solution unique**. Une grille trop peu remplie peut en admettre plusieurs. Ecrivez une fonction qui compte le nombre de solutions (borne a 2) en ajoutant une **clause bloquante** apres chaque solution trouvee.
+Un puzzle de Sudoku bien forme possede une **solution unique**. Une grille trop peu remplie peut en admettre plusieurs. Ecrivez une fonction qui compte le nombre de solutions (borne a 2) en ajoutant une **clause bloquante** après chaque solution trouvee.
 
 ### Indices
 
-- Apres avoir trouve un modele, construisez une clause qui interdit exactement cette solution : `Or([cellules[r][c] != val pour toutes les cases])`.
+- Après avoir trouve un modèle, construisez une clause qui interdit exactement cette solution : `Or([cellules[r][c] != val pour toutes les cases])`.
 - Ajoutez cette clause avec `s.add(...)` et rappelez `s.check()`.
-- Arretez des que 2 solutions sont trouvees ou que `check()` renvoie `unsat`.",,,,,,,,c0b0f2d32668529f,,,,,,,
+- Arretez des que 2 solutions sont trouvees ou que `check()` renvoie `unsat`.",,,,,,,,323fa30817258a04,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-02-Sudoku.ipynb,nb02-ex3-code,code,fr,b896e5942a50ef76,"# EXERCICE 3 : Compter le nombre de solutions (jusqu'a 2).
 
 def compter_solutions(grille: List[List[int]], max_solutions: int = 2) -> int:
@@ -1016,18 +1016,18 @@ def compter_solutions(grille: List[List[int]], max_solutions: int = 2) -> int:
 # Test : le puzzle facile bien forme doit avoir exactement 1 solution.
 nb = compter_solutions(puzzle_facile)
 print(f""Nombre de solutions du puzzle facile : {nb} (attendu : 1)"")",,,,,,,,b896e5942a50ef76,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-02-Sudoku.ipynb,nb02-conclusion,markdown,fr,ac7a0c1d04d2cdfd,"## Recapitulatif
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-02-Sudoku.ipynb,nb02-conclusion,markdown,fr,6fbb57eaf252d474,"## Recapitulatif
 
 Ce notebook a montre comment **trois familles de contraintes** (domaine, indices, unicite) suffisent a modeliser et resoudre le Sudoku de facon entierement declarative.
 
-| Element | Approche Z3 | Benefice |
+| Élément | Approche Z3 | Benefice |
 |---------|-------------|----------|
 | Modelisation | `Int` + `Distinct` | Code court, lisible |
 | Resolution | `s.check()` automatique | Aucun algorithme a ecrire |
 | Variante (anti-diagonale) | Une contrainte de plus | Evolutivite immediate |
 | Visualisation | matplotlib (noir = donne, bleu = resolu) | Verification visuelle |
 
-La force du paradigme declaratif est l'**evolutivite** : chaque nouvelle regle se traduit par une contrainte, sans reecrire la logique de recherche. Pour aller plus loin, consultez la [documentation z3-py](https://microsoft.github.io/z3guide/) et la serie [Sudoku par approches multiples](../../../Sudoku/README.md) qui compare Z3 a dix autres techniques algorithmiques.",,,,,,,,ac7a0c1d04d2cdfd,,,,,,,
+La force du paradigme declaratif est l'**evolutivite** : chaque nouvelle règle se traduit par une contrainte, sans reecrire la logique de recherche. Pour aller plus loin, consultez la [documentation z3-py](https://microsoft.github.io/z3guide/) et la serie [Sudoku par approches multiples](../../../Sudoku/README.md) qui compare Z3 a dix autres techniques algorithmiques.",,,,,,,,6fbb57eaf252d474,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics-Csharp.ipynb,f8ed9cd1,markdown,fr,1a398867589df239,"# Z3 (C# / .NET) — Tactiques, théories BitVec et Array
 
 **Twin C# de `Z3-Python-03-Tactics.ipynb`** (parité .NET, marathon #4956, suite de `Z3-Python-02-Sudoku-Csharp`).
@@ -1333,7 +1333,7 @@ Ce twin C# couvre les trois familles avancées de Z3 : **tactiques** (`MkTactic`
 
 **Complémentarité** : le twin Python utilise `len(result)` et `sg.size()` (API Pythonique) ; ce twin C# montre l'API .NET (`ApplyResult.Subgoals.Length`, `Goal.Formulas` comme propriété, composition via méthodes `ctx.*`) — la **valeur ajoutée** est la traduction des idiomes Z3 dans le système de types .NET.
 ",,,,,,,,40134fe80eb8c5c6,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,024ee023,markdown,fr,a37085fa01f63b77,"# Z3-Python 03 — Tactiques et theories
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,024ee023,markdown,fr,c01aef34ecd9aec1,"# Z3-Python 03 — Tactiques et théories
 
 **Navigation** : [Index](README.md) | [<< Z3-Python-02 Sudoku](Z3-Python-02-Sudoku.ipynb)
 
@@ -1341,8 +1341,8 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,024ee023,mark
 
 A la fin de ce notebook, vous saurez :
 1. **Utiliser** les tactiques Z3 pour simplifier et pretraiter les contraintes avant resolution
-2. **Composer** des tactiques avec `Then`, `OrElse`, `Repeat` pour creer des pipelines de resolution
-3. **Manipuler** des vecteurs de bits (`BitVec`) et comprendre la difference entre arithmetic signee et non signee
+2. **Composer** des tactiques avec `Then`, `OrElse`, `Repeat` pour créer des pipelines de resolution
+3. **Manipuler** des vecteurs de bits (`BitVec`) et comprendre la différence entre arithmetic signee et non signee
 4. **Modeliser** des tableaux fonctionnels (`Array`) avec `Select` et `Store`
 5. **Choisir** un solveur specialise (`SolverFor`) adapte au type de contraintes
 
@@ -1354,26 +1354,26 @@ A la fin de ce notebook, vous saurez :
 
 ---
 
-Les notebooks precedents ont utilise le solveur Z3 de maniere directe : on ajoute des contraintes, on appelle `check()`, on obtient un modele. En pratique, les problemes reels contiennent des centaines ou milliers de contraintes, et la **strategie de resolution** peut faire la difference entre une reponse instantanee et un timeout. Z3 offre les **tactiques** (*tactics*) pour controler finement cette strategie.
+Les notebooks précédents ont utilise le solveur Z3 de maniere directe : on ajoute des contraintes, on appelle `check()`, on obtient un modèle. En pratique, les problemes reels contiennent des centaines ou milliers de contraintes, et la **stratégie de resolution** peut faire la différence entre une reponse instantanee et un timeout. Z3 offre les **tactiques** (*tactics*) pour contrôler finement cette stratégie.
 
-Ce notebook explore egalement deux theories supplementaires de Z3 : les **vecteurs de bits** (`BitVec`), essentiels pour la verification de circuits et l'analyse cryptographique, et les **tableaux** (`Array`), qui modelisent des fonctions a acces indexe.",,,,,,,,a37085fa01f63b77,,,,,,,
+Ce notebook explore également deux théories supplementaires de Z3 : les **vecteurs de bits** (`BitVec`), essentiels pour la verification de circuits et l'analyse cryptographique, et les **tableaux** (`Array`), qui modelisent des fonctions a acces indexe.",,,,,,,,c01aef34ecd9aec1,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,bea962f8,code,fr,911fe9d839b6c270,"# Imports et verification de l'environnement
 from z3 import *
 
 print(f""Imports OK : z3-solver version {get_version_string()}"")",,,,,,,,911fe9d839b6c270,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,9de875ab,markdown,fr,60c6ac8321ec2c24,"## 1. Tactiques Z3 : controler la strategie de resolution
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,9de875ab,markdown,fr,aa17d653ce747f92,"## 1. Tactiques Z3 : contrôler la stratégie de resolution
 
 Une **tactique** Z3 est une fonction de transformation qui prend un ensemble de contraintes (un *goal*) et produit zero, un ou plusieurs sous-problemes (*subgoals*). Les tactiques permettent de :
 
 - **Simplifier** les contraintes avant resolution (eliminer les redondances, normaliser les expressions)
-- **Decomposer** un probleme en sous-problemes independants (parallelisme)
+- **Decomposer** un problème en sous-problemes independants (parallelisme)
 - **Pretraiter** les contraintes pour les rendre plus digestes pour le solveur
 
 Le flux de travail typique avec les tactiques :
 
-1. Creer un `Goal` et y ajouter des contraintes
+1. Créer un `Goal` et y ajouter des contraintes
 2. Appliquer une ou plusieurs tactiques au goal
-3. Convertir le resultat en `Solver` avec `solver()` ou iterer sur les sous-but",,,,,,,,60c6ac8321ec2c24,,,,,,,
+3. Convertir le résultat en `Solver` avec `solver()` ou iterer sur les sous-but",,,,,,,,aa17d653ce747f92,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,d01c7b84,code,fr,e3776d7f830be5f7,"# Tactique simplify : simplification syntaxique de base
 x = Int('x')
 y = Int('y')
@@ -1394,18 +1394,18 @@ for i in range(len(result)):
     print(f""  Sous-goal {i} : {sg.size()} contrainte(s)"")
     for j in range(sg.size()):
         print(f""    {sg[j]}"")",,,,,,,,e3776d7f830be5f7,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,af77a485,markdown,fr,baf712db124b6954,"### Interpretation : simplify
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,af77a485,markdown,fr,d80de28c7e26070c,"### Interpretation : simplify
 
 **Sortie obtenue** : la tactique `simplify` a elimine la tautologie `x + x + x == 3 * x` (toujours vraie), fusionne le doublon `And(x > 0, x > 0)` en une seule contrainte, et normalise les expressions.
 
 | Tactique | Effet | Cout |
 |----------|-------|------|
-| `simplify` | Simplification syntaxique locale (propagation, elimination de `True`/`False`) | Tres faible |
+| `simplify` | Simplification syntaxique locale (propagation, elimination de `True`/`False`) | Très faible |
 | `ctx-solver-simplify` | Simplification contextuelle (tient compte des relations entre contraintes) | Plus eleve |
 | `solve-eqs` | Elimine les variables par substitution d'equations | Moyen |
 | `propagate-values` | Propage les constantes | Faible |
 
-> **Note technique** : `simplify` est rapide mais superficielle ; `ctx-solver-simplify` est plus puissante mais plus couteuse. Le choix depend de la taille du probleme.",,,,,,,,baf712db124b6954,,,,,,,
+> **Note technique** : `simplify` est rapide mais superficielle ; `ctx-solver-simplify` est plus puissante mais plus couteuse. Le choix depend de la taille du problème.",,,,,,,,d80de28c7e26070c,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,c641f58e,code,fr,dda2c231cc4d99a5,"# Tactique ctx-solver-simplify : simplification contextuelle
 # Cette tactique utilise le contexte global pour simplifier davantage.
 
@@ -1442,16 +1442,16 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,2296f1db,mark
 1. `simplify` traite chaque contrainte isolement et normalise les expressions.
 2. `ctx-solver-simplify` tient compte du **contexte global** pour eliminer les redundances detectees.
 3. Sur de gros problemes, le pretraitement peut reduire significativement le nombre de contraintes utiles.",,,,,,,,bd83b93813bd129d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,cbe4ea6a,markdown,fr,2c29735063f2aa87,"### 1.1 Composer des tactiques : `Then`, `OrElse`, `Repeat`, `TryFor`
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,cbe4ea6a,markdown,fr,7ebff2a2b37c2bfa,"### 1.1 Composer des tactiques : `Then`, `OrElse`, `Repeat`, `TryFor`
 
-Z3 permet de **composer** des tactiques pour creer des pipelines de resolution. Les combinateurs principaux :
+Z3 permet de **composer** des tactiques pour créer des pipelines de resolution. Les combinateurs principaux :
 
 | Combinateur | Effet |
 |-------------|-------|
 | `Then(t1, t2)` | Applique t1, puis t2 sur chaque sous-but issu de t1 |
 | `OrElse(t1, t2)` | Essaie t1, si echec essaie t2 |
 | `Repeat(t)` | Applique t jusqu'a point fixe |
-| `TryFor(t, ms)` | Applique t avec un timeout (en millisecondes) |",,,,,,,,2c29735063f2aa87,,,,,,,
+| `TryFor(t, ms)` | Applique t avec un timeout (en millisecondes) |",,,,,,,,7ebff2a2b37c2bfa,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,f23d0402,code,fr,8d86246be1fc673f,"# Composition de tactiques : pipeline simplifier -> substituer -> resoudre
 x = Int('x')
 y = Int('y')
@@ -1490,15 +1490,15 @@ print(f""Resolution complete : {s.check()}"")
 if s.check() == sat:
     m = s.model()
     print(f""  x = {m[x]}, y = {m[y]}, z = {m[z]}"")",,,,,,,,8d86246be1fc673f,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,e889366e,markdown,fr,0af372f0f0dc9481,"### Interpretation : composition de tactiques
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,e889366e,markdown,fr,cb8f72d347fd4557,"### Interpretation : composition de tactiques
 
-**Sortie obtenue** : le pipeline `Then(simplify, solve-eqs)` a d'abord simplifie les contraintes, puis elimine les equations `y == x + 5` et `z == y * 2` par substitution. Les variables `x` et `z` ont ete remplacees dans les inequations restantes, ne laissant que des contraintes sur `y`. On utilise ensuite un `Solver` classique pour obtenir un modele complet.
+**Sortie obtenue** : le pipeline `Then(simplify, solve-eqs)` a d'abord simplifie les contraintes, puis elimine les equations `y == x + 5` et `z == y * 2` par substitution. Les variables `x` et `z` ont ete remplacees dans les inequations restantes, ne laissant que des contraintes sur `y`. On utilise ensuite un `Solver` classique pour obtenir un modèle complet.
 
 **Points cles** :
 1. `solve-eqs` detecte les equations de la forme `var == expr` et substitue `var` partout.
 2. La composition `Then` execute les tactiques **en sequence** : la sortie de l'une alimente l'autre.
 3. `as_expr()` convertit un sous-but en expression Z3 (conjonction de ses contraintes).
-4. Les tactiques transforment les contraintes mais ne resolvent pas ; la resolution finale se fait via un `Solver`.",,,,,,,,0af372f0f0dc9481,,,,,,,
+4. Les tactiques transforment les contraintes mais ne resolvent pas ; la resolution finale se fait via un `Solver`.",,,,,,,,cb8f72d347fd4557,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,eafa4e42,code,fr,0180c3a84a217cf2,"# OrElse et Repeat : essayer plusieurs strategies et iterer
 x = Int('x')
 
@@ -1531,19 +1531,19 @@ for i in range(len(result2)):
         print(f""  {sg[j]}"")
 
 print(f""\n{len(result2)} sous-goal(s) traite(s) avec succes"")",,,,,,,,0180c3a84a217cf2,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,308b1bc3,markdown,fr,4895f71a798d40ee,"### Interpretation : combinateurs
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,308b1bc3,markdown,fr,4748ab0958c8dbc0,"### Interpretation : combinateurs
 
-**Sortie obtenue** : les expressions triviales `x + 0 == x` et `x * 1 == x` sont reduites par le pipeline repete. Le combinateur `OrElse` tente la premiere tactique et bascule sur la seconde en cas d'echec.
+**Sortie obtenue** : les expressions triviales `x + 0 == x` et `x * 1 == x` sont reduites par le pipeline repete. Le combinateur `OrElse` tente la première tactique et bascule sur la seconde en cas d'echec.
 
 | Combinateur | Analogie | Usage typique |
 |-------------|----------|---------------|
-| `Then` | Pipeline (pipe `\|`) | Pretraitement en etapes successives |
+| `Then` | Pipeline (pipe `\|`) | Pretraitement en étapes successives |
 | `OrElse` | Try-catch | Tactique rapide d'abord, robuste en fallback |
 | `Repeat` | Boucle while | Raffiner iterativement jusqu'a stabilite |
-| `TryFor` | Timeout | Limiter le temps passe dans une tactique couteuse |",,,,,,,,4895f71a798d40ee,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,80403e3e,markdown,fr,c3feef7cfc3676c5,"## 2. Theorie des vecteurs de bits : `BitVec`
+| `TryFor` | Timeout | Limiter le temps passe dans une tactique couteuse |",,,,,,,,4748ab0958c8dbc0,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,80403e3e,markdown,fr,e2d98309ca14e07b,"## 2. Théorie des vecteurs de bits : `BitVec`
 
-Un **vecteur de bits** (*bitvector*) est une sequence de n bits representant un entier modulo $2^n$. Contrairement a `Int` (entiers mathematiques non bornes), les `BitVec` modelisent le comportement exact du materiel informatique : debordement, arithmetic modulaire, operations bit a bit.
+Un **vecteur de bits** (*bitvector*) est une sequence de n bits representant un entier modulo $2^n$. Contrairement a `Int` (entiers mathematiques non bornes), les `BitVec` modelisent le comportement exact du materiel informatique : debordement, arithmetic modulaire, opérations bit a bit.
 
 Applications : verification de circuits, analyse cryptographique, emulation de processeurs.
 
@@ -1551,7 +1551,7 @@ Applications : verification de circuits, analyse cryptographique, emulation de p
 |--------|-------|-------------|
 | Domaine | $\mathbb{Z}$ (entiers infinis) | $\{0, \ldots, 2^n - 1\}$ (modulo $2^n$) |
 | Debordement | Pas de debordement | Wrapping modulaire |
-| Operations bit a bit | Non disponibles | `&`, `|`, `^`, `~`, `<<`, `>>` |",,,,,,,,c3feef7cfc3676c5,,,,,,,
+| Opérations bit a bit | Non disponibles | `&`, `|`, `^`, `~`, `<<`, `>>` |",,,,,,,,e2d98309ca14e07b,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,db8a4ca1,code,fr,d9628ef586c8d87b,"# BitVec : creation, arithmetic modulaire et operations bit a bit
 x = BitVec('x', 8)  # Vecteur de 8 bits (0 a 255)
 y = BitVec('y', 8)
@@ -1583,14 +1583,14 @@ print(f""  a = {m2[a].as_long():3d} (binaire : {m2[a].as_long():08b})"")
 print(f""  b = {m2[b].as_long():3d} (binaire : {m2[b].as_long():08b})"")
 print(f""  a XOR b = {m2[a].as_long() ^ m2[b].as_long():08b}"")
 print(f""  a AND b = {m2[a].as_long() & m2[b].as_long():08b}"")",,,,,,,,d9628ef586c8d87b,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,2ca6be92,markdown,fr,23395bbebf1429bf,"### Interpretation : vecteurs de bits
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,2ca6be92,markdown,fr,734813abc890e0cb,"### Interpretation : vecteurs de bits
 
-**Sortie obtenue** : l'addition modulaire montre le wrapping caracteristique (255 + 1 = 0). L'exemple XOR/AND illustre les operations bit a bit.
+**Sortie obtenue** : l'addition modulaire montre le wrapping caractéristique (255 + 1 = 0). L'exemple XOR/AND illustre les opérations bit a bit.
 
 **Points cles** :
-1. Les operations arithmetiques sur `BitVec` sont **automatiquement modulaires** : pas de debordement, le resultat ""wraps"" autour de $2^n$.
-2. Les operateurs Python `&`, `|`, `^`, `~`, `<<`, `>>` sont surcharges pour construire des expressions symboliques Z3.
-3. `BitVecVal(255, 8)` cree une constante ; `BitVec('x', 8)` cree une variable symbolique.",,,,,,,,23395bbebf1429bf,,,,,,,
+1. Les opérations arithmetiques sur `BitVec` sont **automatiquement modulaires** : pas de debordement, le résultat ""wraps"" autour de $2^n$.
+2. Les opérateurs Python `&`, `|`, `^`, `~`, `<<`, `>>` sont surcharges pour construire des expressions symboliques Z3.
+3. `BitVecVal(255, 8)` créé une constante ; `BitVec('x', 8)` créé une variable symbolique.",,,,,,,,734813abc890e0cb,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,b80a09c5,code,fr,d1276d2fc84b1e7f,"# Arithmetic signee vs non signee sur les BitVec
 # Un meme vecteur de bits peut etre interprete comme signe ou non signe.
 
@@ -1622,14 +1622,14 @@ print(""| a >= b        | a >= b    | UGE(a, b)  |"")
 print(""| a / b         | a / b     | UDiv(a, b) |"")
 print(""| a % b         | a % b     | URem(a, b) |"")
 print(""| a >> b        | arith.    | LShR(a, b) |"")",,,,,,,,d1276d2fc84b1e7f,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,e03bab00,markdown,fr,4df081aa74f07cbe,"### Interpretation : signe vs non signe
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,e03bab00,markdown,fr,b7523c27c260934e,"### Interpretation : signe vs non signe
 
-**Sortie obtenue** : la valeur 200 est positive en non signe mais negative en signe (-56). Les operateurs `UGT`, `ULT`, etc. permettent de specifier l'interpretation souhaitee.
+**Sortie obtenue** : la valeur 200 est positive en non signe mais negative en signe (-56). Les opérateurs `UGT`, `ULT`, etc. permettent de specifier l'interpretation souhaitee.
 
 **Points cles** :
-1. Les operateurs Python `<`, `>`, `<=`, `>=` sont **signes** par defaut dans Z3.
+1. Les opérateurs Python `<`, `>`, `<=`, `>=` sont **signes** par defaut dans Z3.
 2. Pour les comparaisons non signees, utiliser `UGT`, `ULT`, `UGE`, `ULE`.
-3. La division et le decalage existent aussi en versions signees et non signees.",,,,,,,,4df081aa74f07cbe,,,,,,,
+3. La division et le decalage existent aussi en versions signees et non signees.",,,,,,,,b7523c27c260934e,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,8989b5f3,code,fr,8c7c6e82f64de209,"# Casse-tete BitVec : trouver un nombre dont les bits sont un palindrome
 # Un palindrome binaire 8 bits se lit de la meme facon de gauche a droite et de droite a gauche.
 # Exemple : 10011001 (= 153) est un palindrome binaire.
@@ -1660,21 +1660,21 @@ if s.check() == sat:
     val = m[x].as_long()
     print(f""  x = {val} (binaire : {val:08b})"")
     print(f""  Verification : {val:08b} se lit identiquement dans les deux sens"")",,,,,,,,8c7c6e82f64de209,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,1122d983,markdown,fr,5c8e26560df28c1d,"## 3. Theorie des tableaux : `Array`
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,1122d983,markdown,fr,1075062c8320712a,"## 3. Théorie des tableaux : `Array`
 
-En Z3, un **tableau** (*Array*) est une fonction totale des index vers des valeurs. Les deux operations fondamentales :
+En Z3, un **tableau** (*Array*) est une fonction totale des index vers des valeurs. Les deux opérations fondamentales :
 
 - **`Select(a, i)`** : lecture de la valeur a l'index `i` dans le tableau `a` (equivalent de `a[i]`)
 - **`Store(a, i, v)`** : ecriture de la valeur `v` a l'index `i`, renvoyant un **nouveau** tableau (immutabilite)
 
-La theorie des tableaux est essentielle pour modeliser des memoires, des caches, des registres ou des mappings.
+La théorie des tableaux est essentielle pour modeliser des memoires, des caches, des registres ou des mappings.
 
 | Propriete | Description |
 |-----------|-------------|
 | Immutabilite | `Store` ne modifie pas le tableau ; il en renvoie un nouveau |
 | Totalite | Tout index a une valeur (la valeur par defaut si non initialise) |
-| Axiome de selection | `Select(Store(a, i, v), i) == v` |
-| Axiome de non-selection | `i != j => Select(Store(a, i, v), j) == Select(a, j)` |",,,,,,,,5c8e26560df28c1d,,,,,,,
+| Axiome de sélection | `Select(Store(a, i, v), i) == v` |
+| Axiome de non-sélection | `i != j => Select(Store(a, i, v), j) == Select(a, j)` |",,,,,,,,1075062c8320712a,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,7b839b11,code,fr,28f16ad8ba3ba41f,"# Array : lecture, ecriture et raisonnement sur les tableaux
 # Modelisons un tableau d'entiers indexe par des entiers.
 
@@ -1711,14 +1711,14 @@ if s2.check() == sat:
     m2 = s2.model()
     print(f""  b[0] = {m2.evaluate(Select(b, 0))} (modifie par Store)"")
     print(f""  b[1] = {m2.evaluate(Select(b, 1))} (inchange par Store)"")",,,,,,,,28f16ad8ba3ba41f,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,431cda4c,markdown,fr,693801f92e22f202,"### Interpretation : tableaux Z3
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,431cda4c,markdown,fr,79f22eb9d90d93d7,"### Interpretation : tableaux Z3
 
-**Sortie obtenue** : le solveur trouve un modele coherent pour le tableau. L'operation `Store` cree un nouveau tableau ou seul l'index specifie est modifie ; les autres valeurs sont preservees.
+**Sortie obtenue** : le solveur trouve un modèle coherent pour le tableau. L'opération `Store` créé un nouveau tableau ou seul l'index specifie est modifie ; les autres valeurs sont preservees.
 
 **Points cles** :
 1. Les tableaux Z3 sont des **fonctions pures** : `Store` ne mute pas, il produit une nouvelle fonction.
 2. `Select(a, i)` equivaut a l'application fonctionnelle `a(i)`.
-3. L'axiome fondamental : `Select(Store(a, i, v), j)` vaut `v` si `i == j`, sinon `Select(a, j)`.",,,,,,,,693801f92e22f202,,,,,,,
+3. L'axiome fondamental : `Select(Store(a, i, v), j)` vaut `v` si `i == j`, sinon `Select(a, j)`.",,,,,,,,79f22eb9d90d93d7,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,0ece8020,code,fr,19215f2957cfa09a,"# Array avance : contraintes sur un tableau avec Store successifs
 # Scenario : un tableau represente les soldes de comptes.
 # On effectue des operations et on veut verifier des proprietes.
@@ -1755,9 +1755,9 @@ if s.check() == sat:
           f""c2={m.evaluate(Select(apres_transfer, 2))}"")
     print(f""  Total avant = {m.evaluate(total_avant)}"")
     print(f""  Total apres = {m.evaluate(total_apres)}"")",,,,,,,,19215f2957cfa09a,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,b527b9ed,markdown,fr,1c7af1ea60a9da9c,"## 4. Solveurs specialises : `SolverFor`
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,b527b9ed,markdown,fr,9a6ffc46614453c6,"## 4. Solveurs specialises : `SolverFor`
 
-Z3 dispose de solveurs optimises pour des **fragments** specifiques de la logique. Plutot que d'utiliser le solveur generique `Solver()`, on peut selectionner un solveur adapte a la theorie concernee :
+Z3 dispose de solveurs optimises pour des **fragments** spécifiques de la logique. Plutot que d'utiliser le solveur generique `Solver()`, on peut sélectionner un solveur adapte a la théorie concernee :
 
 | Logique | Description | Types principaux |
 |---------|-------------|------------------|
@@ -1766,7 +1766,7 @@ Z3 dispose de solveurs optimises pour des **fragments** specifiques de la logiqu
 | `QF_BV` | Quantifier-Free BitVectors | `BitVec` |
 | `QF_UFLIA` | QF_LIA + fonctions non interpretees | `Int` + `Array` |
 
-Le prefixe **QF** signifie *Quantifier-Free* (sans quantificateurs `ForAll`/`Exists`). Les solveurs specialises sont souvent **plus rapides** car ils exploitent la structure du fragment.",,,,,,,,1c7af1ea60a9da9c,,,,,,,
+Le prefixe **QF** signifie *Quantifier-Free* (sans quantificateurs `ForAll`/`Exists`). Les solveurs specialises sont souvent **plus rapides** car ils exploitent la structure du fragment.",,,,,,,,9a6ffc46614453c6,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,c1e96389,code,fr,488188cdfa709e3b,"# Comparaison : Solver generique vs SolverFor specialise
 import time
 
@@ -1811,32 +1811,32 @@ print(""\nConfiguration globale avec set_option :"")
 set_option('verbose', 0)       # Niveau de verbosite (0 = silencieux)
 set_option('timeout', 10000)   # Timeout en millisecondes
 print(""  verbose=0, timeout=10000 ms configures"")",,,,,,,,488188cdfa709e3b,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,a304cd8b,markdown,fr,31335fa3b7848456,"### Interpretation : solveurs specialises
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,a304cd8b,markdown,fr,399f211e851d4f7f,"### Interpretation : solveurs specialises
 
-**Sortie obtenue** : les deux solveurs trouvent `sat`, mais le solveur specialise `QF_LIA` est generalement plus rapide sur les contraintes lineaires entieres sans quantificateurs.
+**Sortie obtenue** : les deux solveurs trouvent `sat`, mais le solveur specialise `QF_LIA` est généralement plus rapide sur les contraintes lineaires entieres sans quantificateurs.
 
 **Points cles** :
 1. `SolverFor('QF_LIA')` selectionne le moteur optimise pour l'arithmetic lineaire entiere sans quantificateurs.
 2. `SolverFor('QF_BV')` est adapte aux problemes de vecteurs de bits.
 3. `set_option('timeout', ms)` permet de limiter le temps de calcul global.
-4. Le gain de performance depend du probleme ; sur de petites instances, la difference est souvent negligeable.",,,,,,,,31335fa3b7848456,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,d935da62,markdown,fr,a2f869c69d3fc336,"## Exercice 1 : Composer un pipeline de tactiques
+4. Le gain de performance depend du problème ; sur de petites instances, la différence est souvent negligeable.",,,,,,,,399f211e851d4f7f,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,d935da62,markdown,fr,03d2c5c0c2e7fe14,"## Exercice 1 : Composer un pipeline de tactiques
 
 ### Enonce
 
-On dispose du systeme de contraintes suivant :
+On dispose du système de contraintes suivant :
 - `a == b + 1`
 - `c == a * 2`
 - `b > 5`
 - `c < 20`
 
-Creez un pipeline de tactiques `Then(simplify, solve-eqs)` et appliquez-le a un `Goal` contenant ces contraintes. Affichez les sous-but obtenus, puis resolvez le systeme avec un `Solver` pour obtenir les valeurs de `a`, `b` et `c`.
+Créez un pipeline de tactiques `Then(simplify, solve-eqs)` et appliquez-le a un `Goal` contenant ces contraintes. Affichez les sous-but obtenus, puis resolvez le système avec un `Solver` pour obtenir les valeurs de `a`, `b` et `c`.
 
 ### Indices
-- Creez un `Goal()`, ajoutez les 4 contraintes.
+- Créez un `Goal()`, ajoutez les 4 contraintes.
 - Construisez `Then(Tactic('simplify'), Tactic('solve-eqs'))` et appliquez-le au goal.
 - Utilisez `len(result)` pour le nombre de sous-but et `result[i].size()` pour le nombre de contraintes.
-- Pour obtenir les valeurs, ajoutez les contraintes originales a un `Solver` et appelez `check()` puis `model()`.",,,,,,,,a2f869c69d3fc336,,,,,,,
+- Pour obtenir les valeurs, ajoutez les contraintes originales a un `Solver` et appelez `check()` puis `model()`.",,,,,,,,03d2c5c0c2e7fe14,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,d679f119,code,fr,20fb9f30d0164470,"# EXERCICE 1 : Pipeline de tactiques.
 
 def pipeline_tactiques() -> dict:
@@ -1886,11 +1886,11 @@ def trouver_clef_xor() -> dict:
 
 clef = trouver_clef_xor()
 print(""Clef trouvee :"", clef)",,,,,,,,ed72429af06d271d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,0aa5c18a,markdown,fr,144be6031701a2ef,"## Exercice 3 : Verifier une mise a jour de tableau
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,0aa5c18a,markdown,fr,deb5358c9924aab7,"## Exercice 3 : Verifier une mise a jour de tableau
 
 ### Enonce
 
-On dispose d'un tableau `scores` indexe par des entiers. On veut verifier la propriete suivante : si on effectue deux `Store` successifs sur des index differents `i` et `j` (avec `i != j`), l'ordre des Store n'a pas d'importance sur le resultat final.
+On dispose d'un tableau `scores` indexe par des entiers. On veut verifier la propriete suivante : si on effectue deux `Store` successifs sur des index différents `i` et `j` (avec `i != j`), l'ordre des Store n'a pas d'importance sur le résultat final.
 
 Autrement dit, prouvez que pour tout tableau `a`, index `i != j` et valeurs `v1`, `v2` :
 $$\text{Store}(\text{Store}(a, i, v_1), j, v_2) \text{ est equivalent a } \text{Store}(\text{Store}(a, j, v_2), i, v_1)$$
@@ -1898,10 +1898,10 @@ $$\text{Store}(\text{Store}(a, i, v_1), j, v_2) \text{ est equivalent a } \text{
 Verifiez cette propriete en tentant de trouver un contre-exemple (le solveur doit repondre `unsat`).
 
 ### Indices
-- Creez deux tableaux : `seq1 = Store(Store(a, i, v1), j, v2)` et `seq2 = Store(Store(a, j, v2), i, v1)`.
+- Créez deux tableaux : `seq1 = Store(Store(a, i, v1), j, v2)` et `seq2 = Store(Store(a, j, v2), i, v1)`.
 - Ajoutez la contrainte `i != j`.
 - Ajoutez `Select(seq1, k) != Select(seq2, k)` pour un index `k` quelconque.
-- Si `unsat`, la propriete est prouvee.",,,,,,,,144be6031701a2ef,,,,,,,
+- Si `unsat`, la propriete est prouvee.",,,,,,,,deb5358c9924aab7,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,2b4b4d43,code,fr,d98e505cc05a179c,"# EXERCICE 3 : Commutativite des Store sur des index differents.
 
 def verifier_commutativite_store() -> str:
@@ -1921,53 +1921,53 @@ def verifier_commutativite_store() -> str:
 
 resultat = verifier_commutativite_store()
 print(""Commutativite des Store :"", resultat)",,,,,,,,d98e505cc05a179c,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,9f2dfa5a,markdown,fr,3a782f89f28cadcd,"## Recapitulatif
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb,9f2dfa5a,markdown,fr,862401b6f913a233,"## Recapitulatif
 
-Ce notebook a explore les mecanismes avances de Z3 au-dela du solveur de base :
+Ce notebook a explore les mécanismes avances de Z3 au-dela du solveur de base :
 
 | Concept | API Z3 | Usage |
 |---------|--------|-------|
 | Tactiques | `Tactic`, `Goal`, `Then`, `OrElse`, `Repeat` | Pretraiter, simplifier, decomposer les contraintes |
 | Simplification | `simplify`, `ctx-solver-simplify` | Eliminer les redundances (syntaxique ou contextuelle) |
-| Vecteurs de bits | `BitVec`, `UGT`, `ULT`, `Extract`, `Concat` | Arithmetic modulaire, operations bit a bit, circuits |
+| Vecteurs de bits | `BitVec`, `UGT`, `ULT`, `Extract`, `Concat` | Arithmetic modulaire, opérations bit a bit, circuits |
 | Tableaux | `Array`, `Select`, `Store` | Memoires fonctionnelles, mappings, verification de transitions |
-| Solveurs specialises | `SolverFor('QF_LIA')`, `SolverFor('QF_BV')` | Exploiter la structure du probleme pour accelerer la resolution |
+| Solveurs specialises | `SolverFor('QF_LIA')`, `SolverFor('QF_BV')` | Exploiter la structure du problème pour accelerer la resolution |
 
 **Points essentiels a retenir** :
-1. Les **tactiques** offrent un controle fin sur la strategie de resolution ; elles sont composees en pipelines.
-2. Les `BitVec` modelisent le comportement exact du materiel (wrapping modulaire, operations bit a bit, signe vs non signe).
+1. Les **tactiques** offrent un contrôle fin sur la stratégie de resolution ; elles sont composees en pipelines.
+2. Les `BitVec` modelisent le comportement exact du materiel (wrapping modulaire, opérations bit a bit, signe vs non signe).
 3. Les `Array` sont des fonctions pures ; `Store` est immutable et `Select` lit la valeur.
-4. `SolverFor` permet de selectionner un solveur adapte au fragment logique du probleme.
+4. `SolverFor` permet de sélectionner un solveur adapte au fragment logique du problème.
 
-Les prochains notebooks exploreront les theories de chaines (`String`, `Re`), les quantificateurs (`ForAll`, `Exists`) et l'optimisation avancee (objectifs multiples, Pareto).",,,,,,,,3a782f89f28cadcd,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex-Csharp.ipynb,7f4fda1e,markdown,fr,9ab88f200483401d,"# Z3 (C# / .NET) — Theorie des chaines et expressions regulieres
+Les prochains notebooks exploreront les théories de chaînes (`String`, `Re`), les quantificateurs (`ForAll`, `Exists`) et l'optimisation avancee (objectifs multiples, Pareto).",,,,,,,,862401b6f913a233,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex-Csharp.ipynb,7f4fda1e,markdown,fr,35b9f2d2a2aa3ebc,"# Z3 (C# / .NET) — Théorie des chaînes et expressions regulieres
 
 **Twin C# de `Z3-Python-04-Strings-Regex.ipynb`** (parite .NET, marathon #4956, suite de `Z3-Python-03-Tactics-Csharp`).
 
-Ce notebook explore la **theorie des chaines** (`String`) et des **expressions regulieres** (`Re`) du **moteur reel [Microsoft.Z3](https://github.com/Z3Prover/z3)** (NuGet, Z3 4.12.2.0). En Z3, une chaine est une *sequence* de caracteres : on peut raisonner symboliquement sur sa longueur, son prefixe, ses sous-chaines, et contraindre un solveur a **generer** une chaine satisfaisant une expression reguliere.
+Ce notebook explore la **théorie des chaînes** (`String`) et des **expressions regulieres** (`Re`) du **moteur reel [Microsoft.Z3](https://github.com/Z3Prover/z3)** (NuGet, Z3 4.12.2.0). En Z3, une chaîne est une *sequence* de caractères : on peut raisonner symboliquement sur sa longueur, son prefixe, ses sous-chaînes, et contraindre un solveur a **generer** une chaîne satisfaisant une expression reguliere.
 
 ## Plan
 
-1. Creation de chaines, `Length`, `MkExtract`, concatenation.
+1. Creation de chaînes, `Length`, `MkExtract`, concatenation.
 2. Recherche et substitution : `MkIndexOf`, `MkReplace`.
-3. Trouver une chaine sous contraintes (`MkPrefixOf`, `MkSuffixOf`, `MkContains`).
+3. Trouver une chaîne sous contraintes (`MkPrefixOf`, `MkSuffixOf`, `MkContains`).
 4. Construction d'expressions regulieres (`MkToRe`, `MkRange`, `MkPlus`, `MkStar`).
-5. `MkInRe` : faire generer une chaine par le solveur.
+5. `MkInRe` : faire generer une chaîne par le solveur.
 6. Detection d'insatisfiabilite (contradiction longueur/regex).
 7. Politique de mot de passe (modelisation declarative).
 8. Extraction d'extension de fichier.
 9. Trois exercices.
 
-> **API .NET** : `ctx.StringSort` (sort des chaines), `ctx.MkString(""x"")` (litteral, retourne `SeqExpr`), `ctx.MkConst(""s"", ctx.StringSort)` (constante, a caster en `(SeqExpr)` car la surcharge statique retourne `Expr`). Les operations sur chaines sont des methodes plates : `MkLength`, `MkExtract(seq, off, len)`, `MkConcat(SeqExpr[])`, `MkPrefixOf`, `MkSuffixOf`, `MkContains`, `MkIndexOf`, `MkReplace`. Les regex : `MkToRe`, `MkRange`, `MkPlus`, `MkStar`, `MkUnion(ReExpr[])`, `MkConcat(ReExpr[])`, `MkInRe`.
-",,,,,,,,9ab88f200483401d,,,,,,,
+> **API .NET** : `ctx.StringSort` (sort des chaînes), `ctx.MkString(""x"")` (litteral, retourne `SeqExpr`), `ctx.MkConst(""s"", ctx.StringSort)` (constante, a caster en `(SeqExpr)` car la surcharge statique retourne `Expr`). Les opérations sur chaînes sont des méthodes plates : `MkLength`, `MkExtract(seq, off, len)`, `MkConcat(SeqExpr[])`, `MkPrefixOf`, `MkSuffixOf`, `MkContains`, `MkIndexOf`, `MkReplace`. Les regex : `MkToRe`, `MkRange`, `MkPlus`, `MkStar`, `MkUnion(ReExpr[])`, `MkConcat(ReExpr[])`, `MkInRe`.
+",,,,,,,,35b9f2d2a2aa3ebc,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex-Csharp.ipynb,572cc9af,code,fr,714a196310b751e7,"#r ""nuget: Microsoft.Z3""
 using Microsoft.Z3;
 Console.WriteLine(""Imports OK : Microsoft.Z3 version "" + Microsoft.Z3.Version.FullVersion);
 ",,,,,,,,714a196310b751e7,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex-Csharp.ipynb,0dcefba0,markdown,fr,a9a3b0835bc3515e,"## 1. Chaines, longueur, extraction, concatenation
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex-Csharp.ipynb,0dcefba0,markdown,fr,45bd8c983ff6f91b,"## 1. Chaînes, longueur, extraction, concatenation
 
-Un litteral chaine se cree avec `ctx.MkString(""hello"")` (retourne un `SeqExpr`). La longueur est `ctx.MkLength(s)` (retourne un `IntExpr`). L'extraction d'une sous-chaine est `ctx.MkExtract(s, offset, longueur)` (attention : `offset` et `longueur` sont des `IntExpr`, donc `ctx.MkInt(6)` et non l'entier `6` directement). La concatenation prend un tableau : `ctx.MkConcat(new SeqExpr[]{a, b})`.
-",,,,,,,,a9a3b0835bc3515e,,,,,,,
+Un litteral chaîne se créé avec `ctx.MkString(""hello"")` (retourne un `SeqExpr`). La longueur est `ctx.MkLength(s)` (retourne un `IntExpr`). L'extraction d'une sous-chaîne est `ctx.MkExtract(s, offset, longueur)` (attention : `offset` et `longueur` sont des `IntExpr`, donc `ctx.MkInt(6)` et non l'entier `6` directement). La concatenation prend un tableau : `ctx.MkConcat(new SeqExpr[]{a, b})`.
+",,,,,,,,45bd8c983ff6f91b,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex-Csharp.ipynb,4225307b,code,fr,9fddebfffa51ba53,"using Microsoft.Z3;
 var ctx = new Context();
 
@@ -1988,10 +1988,10 @@ var extrait = ctx.MkExtract(ctx.MkString(""EPITA-2026""), ctx.MkInt(6), ctx.MkIn
 Console.WriteLine();
 Console.WriteLine(""MkExtract(EPITA-2026, 6, 4) = "" + extrait + ""  (= 2026)"");
 ",,,,,,,,9fddebfffa51ba53,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex-Csharp.ipynb,3eb71b96,markdown,fr,e2c2d476b41edb08,"## 2. `MkIndexOf` et `MkReplace` : recherche et substitution
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex-Csharp.ipynb,3eb71b96,markdown,fr,3bb37dccc9c56c1f,"## 2. `MkIndexOf` et `MkReplace` : recherche et substitution
 
-`MkIndexOf(source, aiguille, debut)` retourne l'index de la premiere occurrence de `aiguille` dans `source` a partir de `debut` (ou `-1` si absent). `MkReplace(s, ancien, nouveau)` substitue toutes les occurrences. Sur des litteraux, la methode `.Simplify()` (equivalente de `simplify()` Python) force l'evaluation concrete.
-",,,,,,,,e2c2d476b41edb08,,,,,,,
+`MkIndexOf(source, aiguille, debut)` retourne l'index de la première occurrence de `aiguille` dans `source` a partir de `debut` (ou `-1` si absent). `MkReplace(s, ancien, nouveau)` substitue toutes les occurrences. Sur des litteraux, la méthode `.Simplify()` (equivalente de `simplify()` Python) force l'evaluation concrete.
+",,,,,,,,3bb37dccc9c56c1f,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex-Csharp.ipynb,1c76c6f3,code,fr,891f622036c2667a,"using Microsoft.Z3;
 var ctx = new Context();
 
@@ -2018,10 +2018,10 @@ Console.WriteLine(""Recherche code[L=8, Z3 a l index 3] : "" + slv.Check());
 if (slv.Check() == Status.SATISFIABLE)
     Console.WriteLine(""  code = "" + slv.Model.Evaluate(code).ToString().Trim('""'));
 ",,,,,,,,891f622036c2667a,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex-Csharp.ipynb,2abcce0e,markdown,fr,dfd99546356a0603,"## 3. Chaine sous contraintes : prefixe, suffixe, contenu
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex-Csharp.ipynb,2abcce0e,markdown,fr,9c3a8f58e23fbd2e,"## 3. Chaîne sous contraintes : prefixe, suffixe, contenu
 
-On declare une chaine symbolique `txt` via `ctx.MkConst(""txt"", ctx.StringSort)` (a caster en `(SeqExpr)`). Puis on impose : `txt` commence par `Hello` (`MkPrefixOf`), se termine par `World` (`MkSuffixOf`), contient `_` (`MkContains`), et a une longueur d'au moins 10. Le solveur **genere** une chaine satisfaisant toutes les contraintes.
-",,,,,,,,dfd99546356a0603,,,,,,,
+On declare une chaîne symbolique `txt` via `ctx.MkConst(""txt"", ctx.StringSort)` (a caster en `(SeqExpr)`). Puis on impose : `txt` commence par `Hello` (`MkPrefixOf`), se termine par `World` (`MkSuffixOf`), contient `_` (`MkContains`), et a une longueur d'au moins 10. Le solveur **genere** une chaîne satisfaisant toutes les contraintes.
+",,,,,,,,9c3a8f58e23fbd2e,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex-Csharp.ipynb,2e9e02bb,code,fr,578bb4dbed8bb2fa,"using Microsoft.Z3;
 var ctx = new Context();
 
@@ -2042,10 +2042,10 @@ if (slv.Check() == Status.SATISFIABLE)
     Console.WriteLine(""  prefixe Hello ? "" + valeur.StartsWith(""Hello"") + "", suffixe World ? "" + valeur.EndsWith(""World"") + "", contient _ ? "" + valeur.Contains(""_""));
 }
 ",,,,,,,,578bb4dbed8bb2fa,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex-Csharp.ipynb,8e28a60f,markdown,fr,4c476d714f01bb9d,"## 4. Construction d'expressions regulieres Z3
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex-Csharp.ipynb,8e28a60f,markdown,fr,40c1e390aceed90d,"## 4. Construction d'expressions regulieres Z3
 
-Z3 possede sa propre theorie des expressions regulieres sur les chaines. Un litteral regex est `ctx.MkToRe(ctx.MkString(""abc""))`. Une plage de caracteres est `ctx.MkRange(ctx.MkString(""a""), ctx.MkString(""z""))` (un caractere entre a et z). Les combinateurs : `MkPlus(r)` (une ou plusieurs fois, `[r]+`), `MkStar(r)` (zero ou plus, `[r]*`), `MkUnion(ReExpr[])` (alternation), `MkConcat(ReExpr[])` (sequence).
-",,,,,,,,4c476d714f01bb9d,,,,,,,
+Z3 possede sa propre théorie des expressions regulieres sur les chaînes. Un litteral regex est `ctx.MkToRe(ctx.MkString(""abc""))`. Une plage de caractères est `ctx.MkRange(ctx.MkString(""a""), ctx.MkString(""z""))` (un caractère entre a et z). Les combinateurs : `MkPlus(r)` (une ou plusieurs fois, `[r]+`), `MkStar(r)` (zero ou plus, `[r]*`), `MkUnion(ReExpr[])` (alternation), `MkConcat(ReExpr[])` (sequence).
+",,,,,,,,40c1e390aceed90d,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex-Csharp.ipynb,16c32512,code,fr,cca565c5762c30d6,"using Microsoft.Z3;
 var ctx = new Context();
 
@@ -2074,10 +2074,10 @@ var rComplexe = ctx.MkConcat(new ReExpr[]{
     ctx.MkPlus(ctx.MkRange(ctx.MkString(""0""), ctx.MkString(""9""))) });
 Console.WriteLine(""Mot+chiffre ([a-z]+[0-9]+) = "" + rComplexe);
 ",,,,,,,,cca565c5762c30d6,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex-Csharp.ipynb,d4806366,markdown,fr,89587208a6e44ee6,"## 5. `MkInRe` : appartenance et generation
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex-Csharp.ipynb,d4806366,markdown,fr,23f14e2921292964,"## 5. `MkInRe` : appartenance et generation
 
-`ctx.MkInRe(chaine, regex)` affirme que `chaine` appartient au langage decrit par `regex`. Combine a un solveur, cela permet de **faire generer** une chaine correspondant a un motif. Exemple : un numero a 4 chiffres satisfait `[0-9]+` ET une longueur de 4.
-",,,,,,,,89587208a6e44ee6,,,,,,,
+`ctx.MkInRe(chaîne, regex)` affirme que `chaîne` appartient au langage decrit par `regex`. Combine a un solveur, cela permet de **faire generer** une chaîne correspondant a un motif. Exemple : un numéro a 4 chiffres satisfait `[0-9]+` ET une longueur de 4.
+",,,,,,,,23f14e2921292964,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex-Csharp.ipynb,d0d0fc70,code,fr,bb5da1389347e8c0,"using Microsoft.Z3;
 var ctx = new Context();
 
@@ -2119,10 +2119,10 @@ Console.WriteLine(""Date AAAA-MM-JJ : "" + slv3.Check());
 if (slv3.Check() == Status.SATISFIABLE)
     Console.WriteLine(""  date = "" + slv3.Model.Evaluate(date).ToString().Trim('""'));
 ",,,,,,,,bb5da1389347e8c0,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex-Csharp.ipynb,dba7ca8e,markdown,fr,d4e7a5966e1e4f16,"## 6. Detection d'insatisfiabilite
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex-Csharp.ipynb,dba7ca8e,markdown,fr,a91705de886bf982,"## 6. Detection d'insatisfiabilite
 
-Une chaine de longueur 3 ne peut pas matcher une regex de 4 caracteres. De meme, un prefixe de 2 caracteres plus un suffixe de 2 caracteres depassent une longueur imposee de 3. Le solveur repond `UNSATISFIABLE`.
-",,,,,,,,d4e7a5966e1e4f16,,,,,,,
+Une chaîne de longueur 3 ne peut pas matcher une regex de 4 caractères. De même, un prefixe de 2 caractères plus un suffixe de 2 caractères depassent une longueur imposee de 3. Le solveur repond `UNSATISFIABLE`.
+",,,,,,,,a91705de886bf982,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex-Csharp.ipynb,3ce0adcc,code,fr,a5b87a7fcb88c634,"using Microsoft.Z3;
 var ctx = new Context();
 
@@ -2151,10 +2151,10 @@ Console.WriteLine(""Contraintes : prefixe AB + suffixe CD + longueur 3"");
 Console.WriteLine(""Resultat : "" + slv2.Check());
 Console.WriteLine(""-> Le prefixe (2) + le suffixe (2) depassent la longueur imposee (3)."");
 ",,,,,,,,a5b87a7fcb88c634,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex-Csharp.ipynb,e24f9300,markdown,fr,0259ceccba5c8e07,"## 7. Politique de mot de passe (modelisation declarative)
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex-Csharp.ipynb,e24f9300,markdown,fr,7898fba85bcc72a4,"## 7. Politique de mot de passe (modelisation declarative)
 
-On modelise une politique de mot de passe comme un ensemble de contraintes Z3 : longueur 8, 1er caractere majuscule, 5e caractere chiffre, reste en minuscules. Chaque contrainte positionnelle utilise `MkExtract(pwd, i, 1)` pour isoler le caractere a la position `i`, puis `MkInRe` pour borner sa plage. On fournit aussi une variante deterministe avec egalite exacte par position.
-",,,,,,,,0259ceccba5c8e07,,,,,,,
+On modelise une politique de mot de passe comme un ensemble de contraintes Z3 : longueur 8, 1er caractère majuscule, 5e caractère chiffre, reste en minuscules. Chaque contrainte positionnelle utilise `MkExtract(pwd, i, 1)` pour isoler le caractère a la position `i`, puis `MkInRe` pour borner sa plage. On fournit aussi une variante déterministe avec egalite exacte par position.
+",,,,,,,,7898fba85bcc72a4,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex-Csharp.ipynb,e5e34dfe,code,fr,65d9a2a6ef7fa67f,"using Microsoft.Z3;
 
 string GenererMotDePasseValide(Context ctx)
@@ -2279,24 +2279,24 @@ string ExtraireExtension(Context ctx, string nomFichier)
 
 Console.WriteLine(""Exercice 3 (extension de rapport_final.pdf) : "" + (ExtraireExtension(new Context(), ""rapport_final.pdf"") ?? ""(a completer)""));
 ",,,,,,,,1149e9df8ba08808,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex-Csharp.ipynb,dbc08613,markdown,fr,db22b496ad6c7064,"## Conclusion
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex-Csharp.ipynb,dbc08613,markdown,fr,5bb3ec09bdd95aa4,"## Conclusion
 
-Ce twin C# couvre la **theorie des chaines** (`MkString`/`MkLength`/`MkExtract`/`MkConcat`/`MkPrefixOf`/`MkSuffixOf`/`MkContains`/`MkIndexOf`/`MkReplace`) et la **theorie des expressions regulieres** (`MkToRe`/`MkRange`/`MkPlus`/`MkStar`/`MkUnion`/`MkConcat`/`MkInRe`) du moteur reel Microsoft.Z3. Le solveur peut non seulement *verifier* qu'une chaine satisfait une regex, mais aussi **generer** une chaine correspondant a un motif - une capacite unique de la theorie des chaines Z3.
+Ce twin C# couvre la **théorie des chaînes** (`MkString`/`MkLength`/`MkExtract`/`MkConcat`/`MkPrefixOf`/`MkSuffixOf`/`MkContains`/`MkIndexOf`/`MkReplace`) et la **théorie des expressions regulieres** (`MkToRe`/`MkRange`/`MkPlus`/`MkStar`/`MkUnion`/`MkConcat`/`MkInRe`) du moteur reel Microsoft.Z3. Le solveur peut non seulement *verifier* qu'une chaîne satisfait une regex, mais aussi **generer** une chaîne correspondant a un motif - une capacite unique de la théorie des chaînes Z3.
 
-**Complementarite** : le twin Python utilise `String('s')` / `SubString` / `Range` / `InRe` (API pythonique aux operateurs `+`, `*`) ; ce twin C# montre l'API .NET plate (`ctx.MkString` / `ctx.MkExtract(seq, off, len)` / `ctx.MkRange` / `ctx.MkInRe`) avec ses specificites de typage (`SeqExpr` cast sur `MkConst`, formes tableau `SeqExpr[]`/`ReExpr[]` pour `MkConcat`/`MkUnion`). Les deux executent le **meme** moteur Z3 - la valeur ajoutee est la traduction des idiomes dans le systeme de types .NET.
-",,,,,,,,db22b496ad6c7064,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-title,markdown,fr,ca25638472088e33,"# Z3-Python 04 — Chaines de caracteres et expressions regulieres
+**Complementarite** : le twin Python utilise `String('s')` / `SubString` / `Range` / `InRe` (API pythonique aux opérateurs `+`, `*`) ; ce twin C# montre l'API .NET plate (`ctx.MkString` / `ctx.MkExtract(seq, off, len)` / `ctx.MkRange` / `ctx.MkInRe`) avec ses specificites de typage (`SeqExpr` cast sur `MkConst`, formes tableau `SeqExpr[]`/`ReExpr[]` pour `MkConcat`/`MkUnion`). Les deux executent le **même** moteur Z3 - la valeur ajoutee est la traduction des idiomes dans le système de types .NET.
+",,,,,,,,5bb3ec09bdd95aa4,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-title,markdown,fr,2a0698e183263c94,"# Z3-Python 04 — Chaînes de caractères et expressions regulieres
 
 **Navigation** : [Index](README.md) | [<< Z3-Python-03 Tactiques](Z3-Python-03-Tactics.ipynb)
 
 ## Objectifs d'apprentissage
 
 A la fin de ce notebook, vous saurez :
-1. **Manipuler** des chaines symboliques avec la theorie `String` de Z3 (`StringVal`, `Length`, concatenation, sous-chaines)
-2. **Exprimer** des contraintes sur le contenu des chaines (`Contains`, `PrefixOf`, `SuffixOf`, `IndexOf`, `Replace`)
+1. **Manipuler** des chaînes symboliques avec la théorie `String` de Z3 (`StringVal`, `Length`, concatenation, sous-chaînes)
+2. **Exprimer** des contraintes sur le contenu des chaînes (`Contains`, `PrefixOf`, `SuffixOf`, `IndexOf`, `Replace`)
 3. **Construire** des expressions regulieres symboliques avec le type `Re` (`Re`, `Star`, `Plus`, `Union`, `Range`, `Concat`, `InRe`)
-4. **Resoudre** des problemes concrets : validation de mot de passe, recherche de chaine par motif, extraction d'information
-5. **Distinguer** l'approche declarative de Z3 (generation de chaine satisfaisant un motif) de l'approche imperative de Python `re` (verification qu'une chaine correspond a un motif)
+4. **Resoudre** des problemes concrets : validation de mot de passe, recherche de chaîne par motif, extraction d'information
+5. **Distinguer** l'approche declarative de Z3 (generation de chaîne satisfaisant un motif) de l'approche imperative de Python `re` (verification qu'une chaîne correspond a un motif)
 
 ### Prerequis
 - Avoir suivi [Z3-Python-01 Introduction](Z3-Python-01-Introduction.ipynb) (solveur, sat/unsat, types de base)
@@ -2306,30 +2306,30 @@ A la fin de ce notebook, vous saurez :
 
 ---
 
-Z3 integre une **theorie des chaines de caracteres** (*string theory*) qui permet de raisonner sur des variables de type chaine au meme titre que sur des entiers ou des booleens. La difference essentielle avec le module Python `re` : Z3 ne se contente pas de *verifier* qu'une chaine correspond a un motif, il peut **generer** une chaine qui satisfait un ensemble de contraintes. Ce notebook explore cette theorie en deux volets : les operations sur les chaines (`String`), puis les expressions regulieres symboliques (`Re`).",,,,,,,,ca25638472088e33,,,,,,,
+Z3 integre une **théorie des chaînes de caractères** (*string theory*) qui permet de raisonner sur des variables de type chaîne au même titre que sur des entiers ou des booléens. La différence essentielle avec le module Python `re` : Z3 ne se contente pas de *verifier* qu'une chaîne correspond a un motif, il peut **generer** une chaîne qui satisfait un ensemble de contraintes. Ce notebook explore cette théorie en deux volets : les opérations sur les chaînes (`String`), puis les expressions regulieres symboliques (`Re`).",,,,,,,,2a0698e183263c94,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-imports,code,fr,911fe9d839b6c270,"# Imports et verification de l'environnement
 from z3 import *
 
 print(f""Imports OK : z3-solver version {get_version_string()}"")",,,,,,,,911fe9d839b6c270,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-string-intro,markdown,fr,d1f8e697a5dba9cb,"## 1. La theorie des chaines : `String`
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-string-intro,markdown,fr,df5d6b9a2aee3cef,"## 1. La théorie des chaînes : `String`
 
-Z3 traite les chaines de caracteres comme des **valeurs de premier ordre** : une variable `String('s')` represente une chaine inconnue sur laquelle on peut exprimer des contraintes. Les constantes litterales se construisent avec `StringVal(...)`.
+Z3 traite les chaînes de caractères comme des **valeurs de premier ordre** : une variable `String('s')` represente une chaîne inconnue sur laquelle on peut exprimer des contraintes. Les constantes litterales se construisent avec `StringVal(...)`.
 
-| Operation | API Z3 | Equivalent Python |
+| Opération | API Z3 | Equivalent Python |
 |-----------|--------|-------------------|
-| Variable chaine | `String('s')` | — (pas d'equivalent symbolique) |
+| Variable chaîne | `String('s')` | — (pas d'equivalent symbolique) |
 | Constante | `StringVal('hello')` | `'hello'` |
 | Longueur | `Length(s)` | `len(s)` |
 | Concatenation | `Concat(a, b)` ou `a + b` | `a + b` |
-| Sous-chaine | `SubString(s, debut, longueur)` | `s[debut:debut+longueur]` |",,,,,,,,d1f8e697a5dba9cb,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-string-basic,code,fr,cedbc500913d06fd,"# Creation et operations de base sur les chaines Z3
+| Sous-chaîne | `SubString(s, debut, longueur)` | `s[debut:debut+longueur]` |",,,,,,,,df5d6b9a2aee3cef,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-string-basic,code,fr,d8f4f6c809f17e3f,"# Creation et opérations de base sur les chaînes Z3
 
 # Constantes litterales
 mot = StringVal('hello')
 print(f""Constante : {mot}"")
 print(f""Longueur : {Length(mot)}"")
 
-# Concatenation avec l'operateur +
+# Concatenation avec l'opérateur +
 a = StringVal('foo')
 b = StringVal('bar')
 concatene = a + b
@@ -2338,30 +2338,30 @@ print(f""Longueur resultante : {Length(concatene)}"")
 
 # SubString : extraire une portion
 extrait = SubString(StringVal('EPITA-2026'), 6, 4)
-print(f""\nSubString('EPITA-2026', 6, 4) = {extrait}"")",,,,,,,,cedbc500913d06fd,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-string-basic-interp,markdown,fr,02497a31bd7d9de2,"### Interpretation : chaines symboliques
+print(f""\nSubString('EPITA-2026', 6, 4) = {extrait}"")",,,,,,,,d8f4f6c809f17e3f,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-string-basic-interp,markdown,fr,45c3aa221ffd854b,"### Interpretation : chaînes symboliques
 
-**Sortie obtenue** : les operations `Length`, `Concat` et `SubString` produisent des expressions Z3 (symboliques) qui peuvent etre utilisees dans des contraintes.
+**Sortie obtenue** : les opérations `Length`, `Concat` et `SubString` produisent des expressions Z3 (symboliques) qui peuvent etre utilisees dans des contraintes.
 
 **Points cles** :
-1. `StringVal('hello')` cree une constante chaine Z3, equivalente au litteral Python `'hello'` mais dans le monde symbolique.
-2. L'operateur `+` est surcharge : `a + b` construit une expression de concatenation symbolique.
-3. `SubString(s, debut, longueur)` prend trois arguments : la chaine, l'index de depart et la longueur souhaitee.",,,,,,,,02497a31bd7d9de2,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-string-solver-intro,markdown,fr,b431ec79ec07fb9c,"## 2. Contraintes sur les chaines
+1. `StringVal('hello')` créé une constante chaîne Z3, equivalente au litteral Python `'hello'` mais dans le monde symbolique.
+2. L'opérateur `+` est surcharge : `a + b` construit une expression de concatenation symbolique.
+3. `SubString(s, debut, longueur)` prend trois arguments : la chaîne, l'index de depart et la longueur souhaitee.",,,,,,,,45c3aa221ffd854b,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-string-solver-intro,markdown,fr,90fcf97a2500dedc,"## 2. Contraintes sur les chaînes
 
-Z3 fournit un ensemble de predicats pour exprimer des relations entre chaines. Ces predicats peuvent etre combines avec les connecteurs logiques (`And`, `Or`, `Not`) dans un `Solver`.
+Z3 fournit un ensemble de predicats pour exprimer des relations entre chaînes. Ces predicats peuvent etre combines avec les connecteurs logiques (`And`, `Or`, `Not`) dans un `Solver`.
 
 | Predicat | Signature | Signification |
 |----------|-----------|---------------|
-| `Contains(s, sub)` | chaine, sous-chaine | `s` contient `sub` |
-| `PrefixOf(pre, s)` | prefixe, chaine | `pre` est un prefixe de `s` |
-| `SuffixOf(suf, s)` | suffixe, chaine | `suf` est un suffixe de `s` |
-| `IndexOf(s, sub, start)` | chaine, sous-chaine, debut | Position de la 1re occurrence de `sub` dans `s` a partir de `start` (ou -1) |
-| `Replace(s, src, dst)` | chaine, source, destination | Remplace la 1re occurrence de `src` par `dst` dans `s` |
+| `Contains(s, sub)` | chaîne, sous-chaîne | `s` contient `sub` |
+| `PrefixOf(pre, s)` | prefixe, chaîne | `pre` est un prefixe de `s` |
+| `SuffixOf(suf, s)` | suffixe, chaîne | `suf` est un suffixe de `s` |
+| `IndexOf(s, sub, start)` | chaîne, sous-chaîne, debut | Position de la 1re occurrence de `sub` dans `s` a partir de `start` (ou -1) |
+| `Replace(s, src, dst)` | chaîne, source, destination | Remplace la 1re occurrence de `src` par `dst` dans `s` |
 
-Le principe est le meme qu'avec les entiers : on **decrit** les proprietes que la chaine doit satisfaire, et le solveur trouve une valeur concrete.",,,,,,,,b431ec79ec07fb9c,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-string-solver,code,fr,f53812abedb4f4a1,"# Premier exemple : trouver une chaine sous contraintes
-# On cherche une chaine s telle que :
+Le principe est le même qu'avec les entiers : on **decrit** les proprietes que la chaîne doit satisfaire, et le solveur trouve une valeur concrete.",,,,,,,,90fcf97a2500dedc,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-string-solver,code,fr,bc07f780477384bf,"# Premier exemple : trouver une chaîne sous contraintes
+# On cherche une chaîne s telle que :
 #   - s commence par 'Hello'
 #   - s se termine par 'World'
 #   - s contient '_'
@@ -2383,24 +2383,24 @@ if s.check() == sat:
     print(f""  longueur = {len(valeur)}"")
     print(f""  verifications : prefixe='Hello'? {valeur.startswith('Hello')}, ""
           f""suffixe='World'? {valeur.endswith('World')}, ""
-          f""contient '_'? {'_' in valeur}"")",,,,,,,,f53812abedb4f4a1,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-string-solver-interp,markdown,fr,3557205ef6d4f4c2,"### Interpretation : generation de chaine
+          f""contient '_'? {'_' in valeur}"")",,,,,,,,bc07f780477384bf,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-string-solver-interp,markdown,fr,42bca10ca667874f,"### Interpretation : generation de chaîne
 
-**Sortie obtenue** : le solveur produit une chaine concrete qui satisfait toutes les contraintes simultanement. Ce que ne peut pas faire le module Python `re` : celui-ci *verifie* une correspondance, il ne *genere* pas de chaine.
+**Sortie obtenue** : le solveur produit une chaîne concrete qui satisfait toutes les contraintes simultanement. Ce que ne peut pas faire le module Python `re` : celui-ci *verifie* une correspondance, il ne *genere* pas de chaîne.
 
-| Aspect | Module `re` (Python) | Theorie `String` (Z3) |
+| Aspect | Module `re` (Python) | Théorie `String` (Z3) |
 |--------|----------------------|----------------------|
-| Direction | Chaine -> bool (verifie) | Contraintes -> chaine (genere) |
-| Question | « Cette chaine correspond-elle au motif ? » | « Existe-t-il une chaine valide ? » |
+| Direction | Chaîne -> bool (verifie) | Contraintes -> chaîne (genere) |
+| Question | « Cette chaîne correspond-elle au motif ? » | « Existe-t-il une chaîne valide ? » |
 | Insatisfiabilite | Pas de match | `unsat` |
 
 **Points cles** :
-1. `PrefixOf` et `SuffixOf` testent respectivement le debut et la fin de la chaine.
-2. `m[txt].as_string()` convertit la valeur Z3 en chaine Python native.
-3. Le modele retourne **une** solution parmi d'autres : Z3 ne garantit pas laquelle (ici il pourrait trouver `'Hello_World'` ou `'Hello__World'` ou tout autre chaine valide).",,,,,,,,3557205ef6d4f4c2,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-contains-replace,code,fr,72f5dd5e44bee4eb,"# IndexOf et Replace : recherche et substitution dans les chaines
+1. `PrefixOf` et `SuffixOf` testent respectivement le debut et la fin de la chaîne.
+2. `m[txt].as_string()` convertit la valeur Z3 en chaîne Python native.
+3. Le modèle retourne **une** solution parmi d'autres : Z3 ne garantit pas laquelle (ici il pourrait trouver `'Hello_World'` ou `'Hello__World'` ou tout autre chaîne valide).",,,,,,,,42bca10ca667874f,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-contains-replace,code,fr,8eebda928b8350d8,"# IndexOf et Replace : recherche et substitution dans les chaînes
 
-# IndexOf : trouver la position d'une sous-chaine
+# IndexOf : trouver la position d'une sous-chaîne
 # Signature : IndexOf(source, aiguille, position_debut)
 pos = IndexOf(StringVal('EPITA-Symbolic'), StringVal('-'), 0)
 print(f""IndexOf('EPITA-Symbolic', '-', 0) = {simplify(pos)}"")
@@ -2408,11 +2408,11 @@ print(f""IndexOf('EPITA-Symbolic', '-', 0) = {simplify(pos)}"")
 pos2 = IndexOf(StringVal('EPITA-Symbolic'), StringVal('XYZ'), 0)
 print(f""IndexOf('EPITA-Symbolic', 'XYZ', 0) = {simplify(pos2)}  (non trouve = -1)"")
 
-# Replace : substituer une sous-chaine
+# Replace : substituer une sous-chaîne
 remplace = Replace(StringVal('a-b-c'), StringVal('-'), StringVal('_'))
 print(f""\nReplace('a-b-c', '-', '_') = {simplify(remplace)}"")
 
-# Exemple combinatoire : trouver une chaine ou un motif specifique apparait
+# Exemple combinatoire : trouver une chaîne ou un motif spécifique apparait
 # a une position donnee
 s = Solver()
 code = String('code')
@@ -2420,24 +2420,24 @@ s.add(Length(code) == 8)
 s.add(Contains(code, StringVal('Z3')))
 s.add(IndexOf(code, StringVal('Z3'), 0) == 3)  # 'Z3' commence a l'index 3
 
-resultat = s.check()
-print(f""\nRecherche code[L=8, 'Z3' a l'index 3] : {resultat}"")
-if resultat == sat:
+résultat = s.check()
+print(f""\nRecherche code[L=8, 'Z3' a l'index 3] : {résultat}"")
+if résultat == sat:
     m = s.model()
     val = m[code].as_string()
     print(f""  code = '{val}'"")
-    print(f""  IndexOf('Z3') dans le modele = {val.index('Z3')}"")",,,,,,,,72f5dd5e44bee4eb,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-contains-replace-interp,markdown,fr,0764c7b3f5aa8939,"### Interpretation : IndexOf et Replace
+    print(f""  IndexOf('Z3') dans le modèle = {val.index('Z3')}"")",,,,,,,,8eebda928b8350d8,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-contains-replace-interp,markdown,fr,b5a01cba30ba8b6b,"### Interpretation : IndexOf et Replace
 
-**Sortie obtenue** : `IndexOf` renvoie la position entiere de la premiere occurrence d'une sous-chaine (ou -1 si absente), et `Replace` effectue une substitution symbolique.
+**Sortie obtenue** : `IndexOf` renvoie la position entiere de la première occurrence d'une sous-chaîne (ou -1 si absente), et `Replace` effectue une substitution symbolique.
 
 **Points cles** :
 1. `IndexOf(source, aiguille, debut)` prend **trois** arguments : le troisieme est la position de depart de la recherche (généralement 0).
-2. Une valeur de retour `-1` signifie que la sous-chaine n'a pas ete trouvee.
-3. Ces operations etant **symboliques**, on peut les utiliser comme contraintes dans un `Solver` (par exemple `IndexOf(code, 'Z3', 0) == 3` force la position).",,,,,,,,0764c7b3f5aa8939,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-re-intro,markdown,fr,de272ba1fa994497,"## 3. Expressions regulieres symboliques : `Re`
+2. Une valeur de retour `-1` signifie que la sous-chaîne n'a pas ete trouvee.
+3. Ces opérations etant **symboliques**, on peut les utiliser comme contraintes dans un `Solver` (par exemple `IndexOf(code, 'Z3', 0) == 3` force la position).",,,,,,,,b5a01cba30ba8b6b,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-re-intro,markdown,fr,a83d6d42dbe111ac,"## 3. Expressions regulieres symboliques : `Re`
 
-Z3 dispose d'une theorie d'expressions regulieres (*regular expressions*) qui s'applique aux chaines. Contrairement au module Python `re` ou l'expression reguliere est une chaine precompilee, les expressions regulieres Z3 sont des **objets symboliques** construits par composition.
+Z3 dispose d'une théorie d'expressions regulieres (*regular expressions*) qui s'applique aux chaînes. Contrairement au module Python `re` ou l'expression reguliere est une chaîne precompilee, les expressions regulieres Z3 sont des **objets symboliques** construits par composition.
 
 | Constructeur | API Z3 | Equivalent `re` (Python) |
 |--------------|--------|--------------------------|
@@ -2446,16 +2446,16 @@ Z3 dispose d'une theorie d'expressions regulieres (*regular expressions*) qui s'
 | Plus (un ou plus) | `Plus(r)` | `'a+'` |
 | Optionnel (zero ou un) | `Option(r)` | `'a?'` |
 | Union (ou) | `Union(r1, r2)` | `'a\|b'` |
-| Plage de caracteres | `Range('a', 'z')` | `'[a-z]'` |
+| Plage de caractères | `Range('a', 'z')` | `'[a-z]'` |
 | Concatenation | `Concat(r1, r2)` | `'ab'` |
-| Appartenance | `InRe(s, r)` | `re.fullmatch(r, s)` |",,,,,,,,de272ba1fa994497,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-re-basic,code,fr,2bdaa977de20c510,"# Construction d'expressions regulieres Z3
+| Appartenance | `InRe(s, r)` | `re.fullmatch(r, s)` |",,,,,,,,a83d6d42dbe111ac,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-re-basic,code,fr,bd4b6d19d9611ad6,"# Construction d'expressions regulieres Z3
 
-# Litteral : une chaine specifique
+# Litteral : une chaîne spécifique
 r_lit = Re('abc')
 print(f""Re('abc') = {r_lit}"")
 
-# Plage de caracteres : Range('a', 'z') = une lettre minuscule
+# Plage de caractères : Range('a', 'z') = une lettre minuscule
 r_minuscule = Range('a', 'z')
 print(f""Range('a','z') = {r_minuscule}"")
 
@@ -2473,29 +2473,29 @@ print(f""Mots optionnels [a-z]* = {r_mots_opt}"")
 
 # Concatenation : un mot suivi d'un chiffre
 r_complexe = Concat(Plus(Range('a', 'z')), Plus(Range('0', '9')))
-print(f""Mot+chiffre = {r_complexe}"")",,,,,,,,2bdaa977de20c510,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-re-basic-interp,markdown,fr,b2c932b49be0aba5,"### Interpretation : construction par composition
+print(f""Mot+chiffre = {r_complexe}"")",,,,,,,,bd4b6d19d9611ad6,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-re-basic-interp,markdown,fr,44679e5e9663e984,"### Interpretation : construction par composition
 
 **Sortie obtenue** : chaque expression reguliere est un objet Z3 de type `ReRef` affichable sous forme symbolique.
 
 **Points cles** :
-1. Les expressions regulieres Z3 se construisent **par composition fonctionnelle**, pas par syntaxe de chaine comme en Python (`re.compile('a+')`).
-2. `Range('a', 'z')` represente un caractere dans l'intervalle ASCII, equivalent a `[a-z]`.
-3. `Union` prend un nombre variable d'arguments : `Union(r1, r2, r3, ...)`.",,,,,,,,b2c932b49be0aba5,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-re-solver,code,fr,c26c718cc8eea389,"# InRe : verifier qu'une chaine appartient a une expression reguliere
-# Et faire generer par le solveur une chaine correspondant au motif.
+1. Les expressions regulieres Z3 se construisent **par composition fonctionnelle**, pas par syntaxe de chaîne comme en Python (`re.compile('a+')`).
+2. `Range('a', 'z')` represente un caractère dans l'intervalle ASCII, equivalent a `[a-z]`.
+3. `Union` prend un nombre variable d'arguments : `Union(r1, r2, r3, ...)`.",,,,,,,,44679e5e9663e984,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-re-solver,code,fr,8e4f98dbe7e57c78,"# InRe : verifier qu'une chaîne appartient a une expression reguliere
+# Et faire generer par le solveur une chaîne correspondant au motif.
 
-# Exemple 1 : une chaine composee uniquement de chiffres [0-9]+
+# Exemple 1 : une chaîne composee uniquement de chiffres [0-9]+
 s = Solver()
-numero = String('numero')
+numéro = String('numéro')
 regex_chiffres = Plus(Range('0', '9'))  # equivalent a [0-9]+
-s.add(InRe(numero, regex_chiffres))
-s.add(Length(numero) == 4)  # exactement 4 chiffres
+s.add(InRe(numéro, regex_chiffres))
+s.add(Length(numéro) == 4)  # exactement 4 chiffres
 
-print(f""Numero a 4 chiffres : {s.check()}"")
+print(f""Numéro a 4 chiffres : {s.check()}"")
 if s.check() == sat:
     m = s.model()
-    print(f""  numero = {m[numero].as_string()}"")
+    print(f""  numéro = {m[numéro].as_string()}"")
 
 # Exemple 2 : une adresse email simplifiee (mot@mot.mot)
 s2 = Solver()
@@ -2525,10 +2525,10 @@ s3.add(Length(date) == 10)  # forcer le format compact
 print(f""\nDate AAAA-MM-JJ : {s3.check()}"")
 if s3.check() == sat:
     m3 = s3.model()
-    print(f""  date = {m3[date].as_string()}"")",,,,,,,,c26c718cc8eea389,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-re-solver-interp,markdown,fr,f8a806a18f38f34b,"### Interpretation : generation de chaines par motif
+    print(f""  date = {m3[date].as_string()}"")",,,,,,,,8e4f98dbe7e57c78,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-re-solver-interp,markdown,fr,906aad70eaced05d,"### Interpretation : generation de chaînes par motif
 
-**Sortie obtenue** : le solveur genere une chaine concrete correspondant a l'expression reguliere, sans qu'on lui fournisse de candidat.
+**Sortie obtenue** : le solveur genere une chaîne concrete correspondant a l'expression reguliere, sans qu'on lui fournisse de candidat.
 
 | Cas | Expression reguliere Z3 | Equivalent `re` |
 |-----|------------------------|------------------|
@@ -2537,18 +2537,18 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-re
 | Date | `Concat(chiffres, Re('-'), chiffres, Re('-'), chiffres)` | `[0-9]+-[0-9]+-[0-9]+` |
 
 **Points cles** :
-1. `InRe(s, r)` est le predicat d'appartenance : la chaine `s` doit matcher l'expression reguliere `r`.
-2. Le solveur peut **inventer** une chaine satisfaisant le motif, ce qu'aucun moteur `re` imperatif ne sait faire.
-3. Les expressions regulieres Z3 supportent les memes constructeurs que la theorie classique (Kleene), mais en notation fonctionnelle.
+1. `InRe(s, r)` est le predicat d'appartenance : la chaîne `s` doit matcher l'expression reguliere `r`.
+2. Le solveur peut **inventer** une chaîne satisfaisant le motif, ce qu'aucun moteur `re` imperatif ne sait faire.
+3. Les expressions regulieres Z3 supportent les mêmes constructeurs que la théorie classique (Kleene), mais en notation fonctionnelle.
 
-> **Note technique** : Z3 supporte egalement `Option(r)` (zero ou une occurrence, equivalent `r?`) et la construction `Range(c1, c2)` pour les intervalles de caracteres.",,,,,,,,f8a806a18f38f34b,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-unsat-intro,markdown,fr,197477283926dd5f,"## 4. Contraintes combinees et insatisfiabilite
+> **Note technique** : Z3 supporte également `Option(r)` (zero ou une occurrence, equivalent `r?`) et la construction `Range(c1, c2)` pour les intervalles de caractères.",,,,,,,,906aad70eaced05d,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-unsat-intro,markdown,fr,e89abf69084e0304,"## 4. Contraintes combinees et insatisfiabilite
 
-La puissance de la theorie des chaines reside dans la combinaison de **contraintes structurelles** (longueur, prefixe) et de **contraintes de motif** (expression reguliere). Le solveur peut detecter des contradictions qu'il serait fastidieux de prouver manuellement.
+La puissance de la théorie des chaînes reside dans la combinaison de **contraintes structurelles** (longueur, prefixe) et de **contraintes de motif** (expression reguliere). Le solveur peut detecter des contradictions qu'il serait fastidieux de prouver manuellement.
 
-Illustrons avec un cas d'insatisfiabilite : une contrainte de longueur incompatible avec un motif impose.",,,,,,,,197477283926dd5f,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-unsat-code,code,fr,084a451c5fdb8da9,"# Detection d'insatisfiabilite : une chaine impossible
-# On exige une chaine de longueur 3 qui soit un nombre a 4 chiffres minimum.
+Illustrons avec un cas d'insatisfiabilite : une contrainte de longueur incompatible avec un motif impose.",,,,,,,,e89abf69084e0304,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-unsat-code,code,fr,ae780ea0cf48c81d,"# Detection d'insatisfiabilite : une chaîne impossible
+# On exige une chaîne de longueur 3 qui soit un nombre a 4 chiffres minimum.
 
 s = Solver()
 x = String('x')
@@ -2556,14 +2556,14 @@ regex_4_chiffres = Concat(
     Range('0', '9'), Range('0', '9'), Range('0', '9'), Range('0', '9')
 )
 
-# La chaine doit matcher exactement 4 chiffres (longueur implicite = 4)
+# La chaîne doit matcher exactement 4 chiffres (longueur implicite = 4)
 s.add(InRe(x, regex_4_chiffres))
-# Mais on exige aussi qu'elle fasse exactement 3 caracteres
+# Mais on exige aussi qu'elle fasse exactement 3 caractères
 s.add(Length(x) == 3)
 
 print(f""Contraintes : 4 chiffres ET longueur 3"")
-print(f""Resultat : {s.check()}"")
-print(""-> Une chaine de 3 caracteres ne peut pas matcher une regex de 4 caracteres."")
+print(f""Résultat : {s.check()}"")
+print(""-> Une chaîne de 3 caractères ne peut pas matcher une regex de 4 caractères."")
 
 # Deuxieme cas : contradiction entre prefixe et suffixe qui se chevauchent
 s2 = Solver()
@@ -2571,55 +2571,55 @@ y = String('y')
 s2.add(PrefixOf(StringVal('AB'), y))
 s2.add(SuffixOf(StringVal('CD'), y))
 s2.add(Length(y) == 3)
-# AB + CD = 4 caracteres minimum, mais on exige 3 -> impossible
+# AB + CD = 4 caractères minimum, mais on exige 3 -> impossible
 print(f""\nContraintes : prefixe 'AB' + suffixe 'CD' + longueur 3"")
-print(f""Resultat : {s2.check()}"")
-print(""-> Le prefixe (2) + le suffixe (2) depassent la longueur imposee (3)."")",,,,,,,,084a451c5fdb8da9,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-unsat-interp,markdown,fr,3ad2b2838e006a2a,"### Interpretation : le solveur comme oracle de coherent
+print(f""Résultat : {s2.check()}"")
+print(""-> Le prefixe (2) + le suffixe (2) depassent la longueur imposee (3)."")",,,,,,,,ae780ea0cf48c81d,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-unsat-interp,markdown,fr,d51425c1e5ad64bc,"### Interpretation : le solveur comme oracle de coherent
 
-**Sortie obtenue** : Z3 repond `unsat` pour les deux cas, demonstrant qu'aucune chaine ne peut satisfaire les contraintes contradictoires.
+**Sortie obtenue** : Z3 repond `unsat` pour les deux cas, demonstrant qu'aucune chaîne ne peut satisfaire les contraintes contradictoires.
 
 | Cas | Contradiction | Verdict |
 |-----|---------------|---------|
-| Regex 4 chiffres vs longueur 3 | Une regex de longueur exacte 4 ne peut tenir dans 3 caracteres | `unsat` |
-| Prefixe 'AB' + suffixe 'CD' vs longueur 3 | 2 + 2 > 3 caracteres | `unsat` |
+| Regex 4 chiffres vs longueur 3 | Une regex de longueur exacte 4 ne peut tenir dans 3 caractères | `unsat` |
+| Prefixe 'AB' + suffixe 'CD' vs longueur 3 | 2 + 2 > 3 caractères | `unsat` |
 
 **Points cles** :
-1. Z3 raisonne sur la **semantique** des operations sur les chaines, pas seulement leur syntaxe.
-2. La detection automatique d'insatisfiabilite est utile pour valider des schemas (format de donnees, contrats d'interface).
-3. Le temps de resolution reste faible car la theorie des chaines de Z3 est decidable pour les expressions regulieres lineaires.",,,,,,,,3ad2b2838e006a2a,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-app-password-intro,markdown,fr,d633832663927006,"## 5. Application : validation de mot de passe
+1. Z3 raisonne sur la **sémantique** des opérations sur les chaînes, pas seulement leur syntaxe.
+2. La detection automatique d'insatisfiabilite est utile pour valider des schemas (format de données, contrats d'interface).
+3. Le temps de resolution reste faible car la théorie des chaînes de Z3 est decidable pour les expressions regulieres lineaires.",,,,,,,,d51425c1e5ad64bc,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-app-password-intro,markdown,fr,b2d6838b21ce9ab0,"## 5. Application : validation de mot de passe
 
-Un cas d'usage concret de la theorie des chaines est la **validation de politiques de mot de passe**. Plutot que d'ecrire une suite de `if` imperatifs, on exprime chaque regle comme une contrainte Z3. Le solveur peut alors soit verifier qu'un mot de passe donne est valide, soit **generer** un exemple de mot de passe valide (utile pour les tests).
+Un cas d'usage concret de la théorie des chaînes est la **validation de politiques de mot de passe**. Plutot que d'ecrire une suite de `if` imperatifs, on exprime chaque règle comme une contrainte Z3. Le solveur peut alors soit verifier qu'un mot de passe donne est valide, soit **generer** un exemple de mot de passe valide (utile pour les tests).
 
-Regles de notre politique :
-1. Longueur >= 8 caracteres
+Règles de notre politique :
+1. Longueur >= 8 caractères
 2. Contient au moins une lettre majuscule
-3. Contient au moins un chiffre",,,,,,,,d633832663927006,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-app-password-code,code,fr,59fcbeb1e6ff1345,"# Politique de mot de passe : modelisation declarative
+3. Contient au moins un chiffre",,,,,,,,b2d6838b21ce9ab0,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-app-password-code,code,fr,6755e1cfbad8d97a,"# Politique de mot de passe : modelisation declarative
 
 def generer_mot_de_passe_valide() -> str:
     """"""Genere un mot de passe satisfaisant la politique de securite.
 
     Contraintes :
       - Longueur == 8 (fixee pour rester resolu rapidement)
-      - 1er caractere = majuscule (position connue)
-      - 5e caractere = chiffre (position connue)
+      - 1er caractère = majuscule (position connue)
+      - 5e caractère = chiffre (position connue)
       - Reste = lettres minuscules
     """"""
     s = Solver()
     pwd = String('pwd')
 
-    # Regle 1 : longueur fixee (8) -- une longueur libre rend le probleme NP-hard
+    # Règle 1 : longueur fixee (8) -- une longueur libre rend le problème NP-hard
     s.add(Length(pwd) == 8)
 
-    # Regle 2 : 1er caractere est une majuscule (intervalle [A-Z])
+    # Règle 2 : 1er caractère est une majuscule (intervalle [A-Z])
     s.add(InRe(SubString(pwd, 0, 1), Range('A', 'Z')))
 
-    # Regle 3 : 5e caractere est un chiffre (intervalle [0-9])
+    # Règle 3 : 5e caractère est un chiffre (intervalle [0-9])
     s.add(InRe(SubString(pwd, 4, 1), Range('0', '9')))
 
-    # Regle 4 : les autres positions sont des minuscules
+    # Règle 4 : les autres positions sont des minuscules
     for i in [1, 2, 3, 5, 6, 7]:
         s.add(InRe(SubString(pwd, i, 1), Range('a', 'z')))
 
@@ -2634,9 +2634,9 @@ def generer_mot_de_passe_v2() -> str:
     pwd = String('pwd')
     s.add(Length(pwd) == 8)
 
-    # Forcer des caracteres connus par position (approche deterministic)
-    s.add(SubString(pwd, 0, 1) == StringVal('X'))  # 1er caractere = majuscule
-    s.add(SubString(pwd, 4, 1) == StringVal('7'))   # 5e caractere = chiffre
+    # Forcer des caractères connus par position (approche deterministic)
+    s.add(SubString(pwd, 0, 1) == StringVal('X'))  # 1er caractère = majuscule
+    s.add(SubString(pwd, 4, 1) == StringVal('7'))   # 5e caractère = chiffre
 
     if s.check() == sat:
         return s.model()[pwd].as_string()
@@ -2648,26 +2648,26 @@ print(f""  {mdp1}"")
 
 print(""\nGeneration d'un mot de passe valide (approche Contains) :"")
 mdp2 = generer_mot_de_passe_v2()
-print(f""  {mdp2}"")",,,,,,,,59fcbeb1e6ff1345,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-app-password-interp,markdown,fr,e5cccac5b5c57e17,"### Interpretation : deux strategies de modelisation
+print(f""  {mdp2}"")",,,,,,,,6755e1cfbad8d97a,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-app-password-interp,markdown,fr,07cc7a3911c7daba,"### Interpretation : deux stratégies de modelisation
 
-**Sortie obtenue** : les deux approches produisent un mot de passe valide mais avec des strategies differentes.
+**Sortie obtenue** : les deux approches produisent un mot de passe valide mais avec des stratégies différentes.
 
-| Strategie | Mecanisme | Avantage | Limite |
+| Stratégie | Mécanisme | Avantage | Limite |
 |-----------|-----------|----------|-------|
 | Regex (`InRe`) | Motif global `[a-z]*[A-Z][a-z]*` | Exprime l'ordre et la repetition | Plus verbeux |
-| Positionnel (`SubString`) | Force des positions specifiques | Simple et direct | fige la structure |
+| Positionnel (`SubString`) | Force des positions spécifiques | Simple et direct | fige la structure |
 
 **Points cles** :
-1. La **generation** d'un mot de passe valide est un test immediat de la politique : si le solveur repond `sat`, les regles sont coherentres entre elles.
-2. La premiere approche utilise `Star` pour autoriser un nombre arbitraire de minuscules autour des caracteres obligatoires.
-3. En pratique, pour des politiques complexes (caracteres speciaux, historique), la modelisation declarative est plus maintenable qu'une cascade de `if`.",,,,,,,,e5cccac5b5c57e17,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-app-extract-intro,markdown,fr,88ac7d45b6e2e945,"## 6. Application : recherche de motif et extraction
+1. La **generation** d'un mot de passe valide est un test immediat de la politique : si le solveur repond `sat`, les règles sont coherentres entre elles.
+2. La première approche utilise `Star` pour autoriser un nombre arbitraire de minuscules autour des caractères obligatoires.
+3. En pratique, pour des politiques complexes (caractères speciaux, historique), la modelisation declarative est plus maintenable qu'une cascade de `if`.",,,,,,,,07cc7a3911c7daba,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-app-extract-intro,markdown,fr,f9750ae51044a8c1,"## 6. Application : recherche de motif et extraction
 
-Un autre cas d'usage est la **recherche de chaine contrainte** : on dispose d'un ensemble de proprietes (prefixe, longueur, caracteres obligatoires) et on veut trouver une chaine les satisfaisant. Le module `re` de Python ne sait que filtrer des candidats ; Z3 sait les **inventer**.
+Un autre cas d'usage est la **recherche de chaîne contrainte** : on dispose d'un ensemble de proprietes (prefixe, longueur, caractères obligatoires) et on veut trouver une chaîne les satisfaisant. Le module `re` de Python ne sait que filtrer des candidats ; Z3 sait les **inventer**.
 
-Illustrons avec un exemple : trouver une chaine qui represente un nom de fichier avec une extension specifique.",,,,,,,,88ac7d45b6e2e945,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-app-extract-code,code,fr,a6228a81ba0f8af6,"# Extraction d'extension : trouver un nom de fichier avec extension .py
+Illustrons avec un exemple : trouver une chaîne qui represente un nom de fichier avec une extension spécifique.",,,,,,,,f9750ae51044a8c1,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-app-extract-code,code,fr,079f1aa0a58afe9e,"# Extraction d'extension : trouver un nom de fichier avec extension .py
 # Le nom doit contenir un point, et tout ce qui suit le dernier point est l'extension.
 
 s = Solver()
@@ -2675,10 +2675,10 @@ fichier = String('fichier')
 
 # Contraintes :
 #   - Le nom contient '.py' comme suffixe
-#   - Il y a au moins un caractere avant le point
+#   - Il y a au moins un caractère avant le point
 #   - Le nom ne contient que des lettres minuscules, des chiffres et des points
 s.add(SuffixOf(StringVal('.py'), fichier))
-s.add(Length(fichier) >= 5)  # au moins 'x.py' + un caractere
+s.add(Length(fichier) >= 5)  # au moins 'x.py' + un caractère
 
 # Contrainte de format : [a-z0-9]+\.py
 car_valide = Union(Range('a', 'z'), Range('0', '9'))
@@ -2701,164 +2701,164 @@ if s.check() == sat:
 
     # Extraction du nom sans extension
     nom_seul = m.evaluate(SubString(fichier, 0, pos_point_val))
-    print(f""  Nom sans extension = {nom_seul.as_string()}"")",,,,,,,,a6228a81ba0f8af6,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-app-extract-interp,markdown,fr,b659efaa54087830,"### Interpretation : extraction symbolique
+    print(f""  Nom sans extension = {nom_seul.as_string()}"")",,,,,,,,079f1aa0a58afe9e,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-app-extract-interp,markdown,fr,eea028a07c8ad23e,"### Interpretation : extraction symbolique
 
 **Sortie obtenue** : le solveur genere un nom de fichier valide et on extrait dynamiquement son extension grace a `IndexOf` et `SubString`.
 
-| Etape | Fonction Z3 | Role |
+| Étape | Fonction Z3 | Rôle |
 |-------|-------------|------|
 | Localiser le separateur | `IndexOf(fichier, '.', 0)` | Trouve la position du point |
 | Extraire l'extension | `SubString(fichier, pos, len - pos)` | Prend du point jusqu'a la fin |
 | Extraire le nom seul | `SubString(fichier, 0, pos)` | Prend du debut au point |
 
 **Points cles** :
-1. `m.evaluate(expr)` evalue une expression symbolique dans le contexte du modele trouve.
+1. `m.evaluate(expr)` evalue une expression symbolique dans le contexte du modèle trouve.
 2. L'extraction combine `IndexOf` (position) et `SubString` (decoupage) exactement comme on le ferait en Python avec `str.index` et le *slicing*.
-3. La difference : ici la chaine a ete **generee** par le solveur, pas fournie par l'utilisateur.",,,,,,,,b659efaa54087830,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-comparison-intro,markdown,fr,4a132ffddc92ed87,"## 7. Comparaison : Z3 `Re` vs Python `re`
+3. La différence : ici la chaîne a ete **generee** par le solveur, pas fournie par l'utilisateur.",,,,,,,,eea028a07c8ad23e,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-comparison-intro,markdown,fr,d9e546a6819aaf8c,"## 7. Comparaison : Z3 `Re` vs Python `re`
 
-Avant de conclure, il est essentiel de bien distinguer les deux paradigmes. Le tableau suivant resume les differences fondamentales entre la theorie des chaines de Z3 et le module standard `re` de Python.
+Avant de conclure, il est essentiel de bien distinguer les deux paradigmes. Le tableau suivant resume les différences fondamentales entre la théorie des chaînes de Z3 et le module standard `re` de Python.
 
 | Aspect | Python `re` (imperatif) | Z3 `Re` (declaratif) |
 |--------|--------------------------|----------------------|
-| **Direction** | Chaine donnee -> verification | Contraintes -> chaine generee |
-| **Question** | « Cette chaine correspond-elle au motif ? » | « Existe-t-il une chaine valide ? Laquelle ? » |
-| **Syntaxe du motif** | Chaine precompileee (`re.compile(...)`) | Objets composes (`Re`, `Star`, `Union`, ...) |
-| **Combinaison de regles** | Cascade de `if` / `all(...)` | Conjonction de contraintes (`s.add(...)`) |
+| **Direction** | Chaîne donnee -> verification | Contraintes -> chaîne generee |
+| **Question** | « Cette chaîne correspond-elle au motif ? » | « Existe-t-il une chaîne valide ? Laquelle ? » |
+| **Syntaxe du motif** | Chaîne precompileee (`re.compile(...)`) | Objets composes (`Re`, `Star`, `Union`, ...) |
+| **Combinaison de règles** | Cascade de `if` / `all(...)` | Conjonction de contraintes (`s.add(...)`) |
 | **Insatisfiabilite** | Pas de match (`None`) | Verdict explicite `unsat` |
-| **Cas d'usage typique** | Validation de formulaire, parsing | Generation de donnees de test, verification de coherent |
-| **Performance** | Tres rapide (NFA compile) | Plus lent (resolution SMT) |
+| **Cas d'usage typique** | Validation de formulaire, parsing | Generation de données de test, verification de coherent |
+| **Performance** | Très rapide (NFA compile) | Plus lent (resolution SMT) |
 
-> **Quand utiliser Z3 pour les chaines ?** Quand vous avez besoin de **generer** une chaine satisfaisant des contraintes complexes, de **prouver** qu'un ensemble de regles est coherent (pas `unsat`), ou de combiner des contraintes sur les chaines avec d'autres theories (entiers, booleens) dans un meme solveur.",,,,,,,,4a132ffddc92ed87,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-ex1-intro,markdown,fr,9ba5d94775605b47,"## Exercice 1 : Valider un mot de passe
+> **Quand utiliser Z3 pour les chaînes ?** Quand vous avez besoin de **generer** une chaîne satisfaisant des contraintes complexes, de **prouver** qu'un ensemble de règles est coherent (pas `unsat`), ou de combiner des contraintes sur les chaînes avec d'autres théories (entiers, booléens) dans un même solveur.",,,,,,,,d9e546a6819aaf8c,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-ex1-intro,markdown,fr,931ea0ad34836cfa,"## Exercice 1 : Valider un mot de passe
 
 ### Enonce
 
-Ecrivez une fonction `valider_mot_de_passe(s_chaine)` qui prend une chaine Z3 symbolique (variable `String`) et verifie qu'elle satisfait les regles suivantes :
+Ecrivez une fonction `valider_mot_de_passe(s_chaine)` qui prend une chaîne Z3 symbolique (variable `String`) et verifie qu'elle satisfait les règles suivantes :
 1. Longueur >= 8
 2. Contient au moins un chiffre (`Range('0', '9')`)
 3. Contient au moins une majuscule (`Range('A', 'Z')`)
 
-La fonction doit retourner `True` si un modele existe (mot de passe valide possible), `False` sinon.
+La fonction doit retourner `True` si un modèle existe (mot de passe valide possible), `False` sinon.
 
 ### Indices
 
 - Utilisez `Contains` avec une position forcee, ou `InRe` avec un motif global.
-- Pour la regle « contient un chiffre », une approche simple : forcer une position connue avec `SubString(s, pos, 1)` dans `Range('0', '9')`.
+- Pour la règle « contient un chiffre », une approche simple : forcer une position connue avec `SubString(s, pos, 1)` dans `Range('0', '9')`.
 - Alternative : utiliser `InRe(s, Concat(Star(...), Range('0','9'), Star(...)))`.
-- Appelez `s.check()` et comparez a `sat`.",,,,,,,,9ba5d94775605b47,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-ex1-code,code,fr,7d4d5a67f1a13a2c,"# EXERCICE 1 : Valider qu'un mot de passe respecte les regles de securite.
+- Appelez `s.check()` et comparez a `sat`.",,,,,,,,931ea0ad34836cfa,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-ex1-code,code,fr,421e89844ea7005e,"# EXERCICE 1 : Valider qu'un mot de passe respecte les règles de securite.
 
 def valider_mot_de_passe(s_chaine) -> bool:
-    """"""Verifie si une chaine Z3 String peut satisfaire les regles de mot de passe.
+    """"""Verifie si une chaîne Z3 String peut satisfaire les règles de mot de passe.
 
-    Regles : longueur >= 8, contient un chiffre, contient une majuscule.
+    Règles : longueur >= 8, contient un chiffre, contient une majuscule.
     Retourne True si sat, False sinon.
 
-    # Indice : creez un Solver, ajoutez les 3 contraintes.
-    # Etape 1 : Length(s_chaine) >= 8
-    # Etape 2 : forcer une position a contenir un chiffre (SubString + InRe)
-    # Etape 3 : forcer une position a contenir une majuscule
+    # Indice : créez un Solver, ajoutez les 3 contraintes.
+    # Étape 1 : Length(s_chaine) >= 8
+    # Étape 2 : forcer une position a contenir un chiffre (SubString + InRe)
+    # Étape 3 : forcer une position a contenir une majuscule
     """"""
     # TODO etudiant : implémentez la validation
     return None  # TODO etudiant : remplacer par True ou False
 
 # Test
 pwd = String('pwd_ex1')
-resultat = valider_mot_de_passe(pwd)
-print(""Mot de passe valide (existe-t-il une solution) ?"", resultat)",,,,,,,,7d4d5a67f1a13a2c,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-ex2-intro,markdown,fr,492a976ba6282756,"## Exercice 2 : Trouver une chaine par motif
+résultat = valider_mot_de_passe(pwd)
+print(""Mot de passe valide (existe-t-il une solution) ?"", résultat)",,,,,,,,421e89844ea7005e,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-ex2-intro,markdown,fr,86558b6fe5edd391,"## Exercice 2 : Trouver une chaîne par motif
 
 ### Enonce
 
-Ecrivez une fonction `trouver_mot_matching_regex()` qui trouve une chaine satisfaisant les contraintes suivantes :
+Ecrivez une fonction `trouver_mot_matching_regex()` qui trouve une chaîne satisfaisant les contraintes suivantes :
 1. Commence par `'ab'`
 2. Se termine par `'cd'`
-3. A exactement 6 caracteres de long
+3. A exactement 6 caractères de long
 4. Ne contient que des lettres minuscules
 
-La fonction doit retourner la chaine trouvee sous forme de `str` Python, ou `None` si insatisfiable.
+La fonction doit retourner la chaîne trouvee sous forme de `str` Python, ou `None` si insatisfiable.
 
 ### Indices
 
 - Utilisez `PrefixOf(StringVal('ab'), s)` et `SuffixOf(StringVal('cd'), s)`.
 - Ajoutez `Length(s) == 6`.
 - Pour le motif « lettres minuscules uniquement », utilisez `InRe(s, Star(Range('a', 'z')))`.
-- Appelez `s.model()[s].as_string()` pour extraire le resultat.",,,,,,,,492a976ba6282756,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-ex2-code,code,fr,a20e71d24490a6b6,"# EXERCICE 2 : Trouver une chaine de 6 caracteres commencant par 'ab', finissant par 'cd'.
+- Appelez `s.model()[s].as_string()` pour extraire le résultat.",,,,,,,,86558b6fe5edd391,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-ex2-code,code,fr,d0a7edd06b052425,"# EXERCICE 2 : Trouver une chaîne de 6 caractères commencant par 'ab', finissant par 'cd'.
 
 def trouver_mot_matching_regex() -> str:
-    """"""Trouve une chaine : prefixe 'ab', suffixe 'cd', longueur 6, minuscules uniquement.
+    """"""Trouve une chaîne : prefixe 'ab', suffixe 'cd', longueur 6, minuscules uniquement.
 
-    Retourne la chaine trouvee ou None.
+    Retourne la chaîne trouvee ou None.
 
-    # Indice : creez un Solver avec une variable String.
-    # Etape 1 : PrefixOf, SuffixOf, Length == 6
-    # Etape 2 : InRe avec Star(Range('a', 'z'))
-    # Etape 3 : extraire s.model()[s].as_string()
+    # Indice : créez un Solver avec une variable String.
+    # Étape 1 : PrefixOf, SuffixOf, Length == 6
+    # Étape 2 : InRe avec Star(Range('a', 'z'))
+    # Étape 3 : extraire s.model()[s].as_string()
     """"""
     # TODO etudiant : implémentez la recherche
-    return None  # TODO etudiant : remplacer par la chaine trouvée
+    return None  # TODO etudiant : remplacer par la chaîne trouvée
 
-resultat = trouver_mot_matching_regex()
-print(""Chaine trouvee :"", resultat)",,,,,,,,a20e71d24490a6b6,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-ex3-intro,markdown,fr,7b170087dc82261d,"## Exercice 3 : Extraire une extension de fichier
+résultat = trouver_mot_matching_regex()
+print(""Chaîne trouvee :"", résultat)",,,,,,,,d0a7edd06b052425,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-ex3-intro,markdown,fr,bdaec1938b605e2c,"## Exercice 3 : Extraire une extension de fichier
 
 ### Enonce
 
-Ecrivez une fonction `extraire_extension(nom_fichier)` qui, etant donne une chaine symbolique representant un nom de fichier contenant au moins un point, extrait l'extension (tout ce qui suit le **dernier** point) en utilisant les operations `IndexOf` et `SubString` de Z3.
+Ecrivez une fonction `extraire_extension(nom_fichier)` qui, etant donne une chaîne symbolique representant un nom de fichier contenant au moins un point, extrait l'extension (tout ce qui suit le **dernier** point) en utilisant les opérations `IndexOf` et `SubString` de Z3.
 
 La fonction doit retourner l'extension sous forme de `str` Python, ou `None` si aucun point n'est trouve.
 
 ### Indices
 
-- Z3 fournit `IndexOf(s, sub, start)` qui trouve la **premiere** occurrence a partir de `start`.
+- Z3 fournit `IndexOf(s, sub, start)` qui trouve la **première** occurrence a partir de `start`.
 - Pour trouver le **dernier** point, une approche iterative : chercher a partir de `start=0`, puis incrementer `start` jusqu'a ce que `IndexOf` renvoie `-1`.
 - Alternative plus simple : fixez un nom de fichier concret avec un seul point (ex: `'document.pdf'`) et utilisez `IndexOf` pour localiser le point.
 - Avec `SubString(s, pos_point + 1, longueur - pos_point - 1)` vous obtenez l'extension.
-- Utilisez `simplify(...)` ou un `Solver` + `evaluate` pour obtenir la valeur concrete.",,,,,,,,7b170087dc82261d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-ex3-code,code,fr,81a3d8a79f4e3c28,"# EXERCICE 3 : Extraire l'extension d'un nom de fichier avec Z3.
+- Utilisez `simplify(...)` ou un `Solver` + `evaluate` pour obtenir la valeur concrete.",,,,,,,,bdaec1938b605e2c,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-ex3-code,code,fr,6027f733846edc64,"# EXERCICE 3 : Extraire l'extension d'un nom de fichier avec Z3.
 
 def extraire_extension(nom_fichier: str) -> str:
-    """"""Extrait l'extension d'un nom de fichier (apres le dernier point).
+    """"""Extrait l'extension d'un nom de fichier (après le dernier point).
 
     Utilise IndexOf et SubString de Z3 pour localiser et extraire l'extension.
     Retourne l'extension (sans le point) ou None si pas de point.
 
     # Indice : convertissez nom_fichier en StringVal, puis utilisez IndexOf.
-    # Etape 1 : pos = IndexOf(StringVal(nom_fichier), StringVal('.'), 0)
-    # Etape 2 : si pos == -1 -> return None
-    # Etape 3 : ext = SubString(StringVal(nom_fichier), pos + 1, longueur - pos - 1)
-    # Etape 4 : utiliser simplify() ou un Solver pour obtenir la valeur
+    # Étape 1 : pos = IndexOf(StringVal(nom_fichier), StringVal('.'), 0)
+    # Étape 2 : si pos == -1 -> return None
+    # Étape 3 : ext = SubString(StringVal(nom_fichier), pos + 1, longueur - pos - 1)
+    # Étape 4 : utiliser simplify() ou un Solver pour obtenir la valeur
     """"""
     # TODO etudiant : implémentez l'extraction
     return None  # TODO etudiant : remplacer par l'extension trouvée
 
 # Test avec un exemple concret
-resultat = extraire_extension('rapport_final.pdf')
-print(""Extension extraite :"", resultat)",,,,,,,,81a3d8a79f4e3c28,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-conclusion,markdown,fr,b3ca9c85be632cee,"## Recapitulatif
+résultat = extraire_extension('rapport_final.pdf')
+print(""Extension extraite :"", résultat)",,,,,,,,6027f733846edc64,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb,nb04-conclusion,markdown,fr,89433f9da459afdd,"## Recapitulatif
 
-Ce notebook a explore la theorie des chaines et des expressions regulieres de Z3, qui complement les theories d'entiers, de booleens et de vecteurs de bits vues dans les notebooks precedents.
+Ce notebook a explore la théorie des chaînes et des expressions regulieres de Z3, qui complement les théories d'entiers, de booléens et de vecteurs de bits vues dans les notebooks précédents.
 
 | Concept | API Z3 | Usage |
 |---------|--------|-------|
-| Chaines symboliques | `String`, `StringVal`, `Length`, `Concat`, `SubString` | Variables et operations de base sur les chaines |
-| Predicats de chaine | `Contains`, `PrefixOf`, `SuffixOf`, `IndexOf`, `Replace` | Tester et localiser des sous-chaines |
+| Chaînes symboliques | `String`, `StringVal`, `Length`, `Concat`, `SubString` | Variables et opérations de base sur les chaînes |
+| Predicats de chaîne | `Contains`, `PrefixOf`, `SuffixOf`, `IndexOf`, `Replace` | Tester et localiser des sous-chaînes |
 | Expressions regulieres | `Re`, `Range`, `Star`, `Plus`, `Option`, `Union`, `Concat` | Construire des motifs symboliques |
-| Appartenance | `InRe(s, r)` | Verifier qu'une chaine satisfait un motif |
-| Generation | `Solver` + `model()[s].as_string()` | Produire une chaine concrete satisfaisant les contraintes |
-| Insatisfiabilite | `unsat` | Detecter des contraintes de chaine contradictoires |
+| Appartenance | `InRe(s, r)` | Verifier qu'une chaîne satisfait un motif |
+| Generation | `Solver` + `model()[s].as_string()` | Produire une chaîne concrete satisfaisant les contraintes |
+| Insatisfiabilite | `unsat` | Detecter des contraintes de chaîne contradictoires |
 
 **Points essentiels a retenir** :
-1. Z3 peut **generer** des chaines satisfaisant un ensemble de contraintes, ce que le module Python `re` ne sait pas faire (il ne fait que verifier).
-2. Les expressions regulieres Z3 se construisent **par composition fonctionnelle** (`Star(r)`, `Union(r1, r2)`), pas par syntaxe de chaine.
-3. La theorie des chaines se combine naturellement avec les autres theories Z3 (entiers, booleens) dans un meme solveur.
-4. Les cas d'usage typiques incluent : validation de politiques (mot de passe), generation de donnees de test, verification de coherent de schemas.
+1. Z3 peut **generer** des chaînes satisfaisant un ensemble de contraintes, ce que le module Python `re` ne sait pas faire (il ne fait que verifier).
+2. Les expressions regulieres Z3 se construisent **par composition fonctionnelle** (`Star(r)`, `Union(r1, r2)`), pas par syntaxe de chaîne.
+3. La théorie des chaînes se combine naturellement avec les autres théories Z3 (entiers, booléens) dans un même solveur.
+4. Les cas d'usage typiques incluent : validation de politiques (mot de passe), generation de données de test, verification de coherent de schemas.
 
-Le prochain notebook explorera les **quantificateurs** (`ForAll`, `Exists`) et la verification formelle de proprietes avec Z3.",,,,,,,,b3ca9c85be632cee,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs-Csharp.ipynb,b578c3e9,markdown,fr,a28eef7756f193af,"# Z3 (C# / .NET) — Quantificateurs et preuves par refutation
+Le prochain notebook explorera les **quantificateurs** (`ForAll`, `Exists`) et la verification formelle de proprietes avec Z3.",,,,,,,,89433f9da459afdd,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs-Csharp.ipynb,b578c3e9,markdown,fr,5c3a0b4c1a801e8e,"# Z3 (C# / .NET) — Quantificateurs et preuves par refutation
 
 **Twin C# de `Z3-Python-05-Quantifiers-Proofs.ipynb`** (parite .NET, marathon #4956, suite de `Z3-Python-04-Strings-Regex-Csharp`).
 
@@ -2876,8 +2876,8 @@ Ce notebook aborde les **quantificateurs** (`ForAll`, `Exists`) et la notion de 
 8. Model checking : skolemisation d'un `Exists x, ForAll y`.
 9. Trois exercices.
 
-> **API .NET** : `ctx.MkForall(new Expr[]{x}, body)` / `ctx.MkExists(new Expr[]{x}, body)` ou `x` est une constante creee via `ctx.MkConst(""x"", sort)` (le *body* utilise `x` directement, pas de de-Bruijn). `ctx.MkImplies`, `MkOr`, `MkAnd`, `MkNot` pour les connecteurs. Le timeout se regle via `s.Set(""timeout"", 3000)` ; la raison d'un `UNKNOWN` se lit via la propriete `s.ReasonUnknown`. Les constantes reelles/entieres retournees par `MkConst` sont statiquement `Expr` → a caster en `(ArithExpr)` pour `MkAdd`/`MkMul`/`MkLt`/etc.
-",,,,,,,,a28eef7756f193af,,,,,,,
+> **API .NET** : `ctx.MkForall(new Expr[]{x}, body)` / `ctx.MkExists(new Expr[]{x}, body)` ou `x` est une constante créée via `ctx.MkConst(""x"", sort)` (le *body* utilise `x` directement, pas de de-Bruijn). `ctx.MkImplies`, `MkOr`, `MkAnd`, `MkNot` pour les connecteurs. Le timeout se règle via `s.Set(""timeout"", 3000)` ; la raison d'un `UNKNOWN` se lit via la propriete `s.ReasonUnknown`. Les constantes reelles/entieres retournees par `MkConst` sont statiquement `Expr` → a caster en `(ArithExpr)` pour `MkAdd`/`MkMul`/`MkLt`/etc.
+",,,,,,,,5c3a0b4c1a801e8e,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs-Csharp.ipynb,f4dabbd7,code,fr,714a196310b751e7,"#r ""nuget: Microsoft.Z3""
 using Microsoft.Z3;
 Console.WriteLine(""Imports OK : Microsoft.Z3 version "" + Microsoft.Z3.Version.FullVersion);
@@ -2939,10 +2939,10 @@ foreach (var (nom, formule) in proprietes)
     Console.WriteLine();
 }
 ",,,,,,,,8b4719f646dacb15,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs-Csharp.ipynb,c61e0c9f,markdown,fr,c45156771e222a23,"## 3. `Exists` satisfiable : existe-t-il `x` tel que `x*x == 4` ?
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs-Csharp.ipynb,c61e0c9f,markdown,fr,76f65c5511786c9f,"## 3. `Exists` satisfiable : existe-t-il `x` tel que `x*x == 4` ?
 
-Le quantificateur existentiel `MkExists` demontre l'existence d'un temoin. **Piege classique** : la variable liee par `Exists` n'apparait **pas** dans le modele (elle est quantifiee) — `m.Evaluate(x)` ne donne pas de temoin lisible. Pour obtenir une valeur concrete, on **skolemise** : on reasserte la meme contrainte sur une constante *libre*, dont la valeur est alors lisible dans le modele.
-",,,,,,,,c45156771e222a23,,,,,,,
+Le quantificateur existentiel `MkExists` demontre l'existence d'un temoin. **Piege classique** : la variable liee par `Exists` n'apparait **pas** dans le modèle (elle est quantifiee) — `m.Evaluate(x)` ne donne pas de temoin lisible. Pour obtenir une valeur concrete, on **skolemise** : on reasserte la même contrainte sur une constante *libre*, dont la valeur est alors lisible dans le modèle.
+",,,,,,,,76f65c5511786c9f,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs-Csharp.ipynb,bb7cd41a,code,fr,2d3bdf4d2cee9ddf,"using Microsoft.Z3;
 var ctx = new Context();
 var x = (ArithExpr)ctx.MkConst(""x"", ctx.RealSort);
@@ -3079,10 +3079,10 @@ else
     Console.WriteLine(""   ce n est PAS un bug, mais une limite fondamentale de la decision automatique."");
 }
 ",,,,,,,,a5429795c95d83e2,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs-Csharp.ipynb,6525b475,markdown,fr,d2384e970559a671,"## 8. Model checking : skolemiser un `Exists x, ForAll y`
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs-Csharp.ipynb,6525b475,markdown,fr,4b32e4dd937c7aa9,"## 8. Model checking : skolemiser un `Exists x, ForAll y`
 
-On cherche s'il existe un `x` tel que pour tout `y >= 0`, `x <= y`. Le `Exists x` externe est le temoin recherche. Pour lire sa valeur, on le **skolemise** : on declare `x` comme constante *libre* et le `ForAll` ne porte plus que sur `y`. Le solveur trouve alors un modele (par exemple `x = 0`), dont la valeur devient lisible via `m.Evaluate(x)`.
-",,,,,,,,d2384e970559a671,,,,,,,
+On cherche s'il existe un `x` tel que pour tout `y >= 0`, `x <= y`. Le `Exists x` externe est le temoin recherche. Pour lire sa valeur, on le **skolemise** : on declare `x` comme constante *libre* et le `ForAll` ne porte plus que sur `y`. Le solveur trouve alors un modèle (par exemple `x = 0`), dont la valeur devient lisible via `m.Evaluate(x)`.
+",,,,,,,,4b32e4dd937c7aa9,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs-Csharp.ipynb,adb1e011,code,fr,889ab727c8edba58,"using Microsoft.Z3;
 var ctx = new Context();
 var x = (ArithExpr)ctx.MkConst(""x"", ctx.RealSort);
@@ -3162,15 +3162,15 @@ bool? ProuverPasDePlusGrandReel(Context ctx)
 var r3 = ProuverPasDePlusGrandReel(new Context());
 Console.WriteLine(""Exercice 3 (pas de plus grand reel, valide ?) : "" + (r3.HasValue ? r3.Value.ToString() : ""(a completer)""));
 ",,,,,,,,67ae0ded09432602,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs-Csharp.ipynb,43fd5af5,markdown,fr,2cd90dd101e27201,"## Conclusion
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs-Csharp.ipynb,43fd5af5,markdown,fr,e48cdc7431805227,"## Conclusion
 
 Ce twin C# couvre les **quantificateurs** (`MkForall`/`MkExists` sur `new Expr[]{ constantes }`) et la **preuve par refutation** (une formule universelle est valide ssi sa negation est insatisfiable) avec le moteur reel Microsoft.Z3. On a prouve l'identite additive/multiplicative, la commutativite, la trichotomie, la monotonie du carre, et l'absence de plus grand reel ; traite le piege de la variable liee par `Exists` (skolemisation) ; et affronte honnetement la limite `UNKNOWN` de l'arithmetique non lineaire entiere (Fermat, avec `ReasonUnknown`).
 
-**Complementarite** : le twin Python utilise `ForAll([x], ...)` / `Exists([x], ...)` / `is_true(simplify(...))` (API pythonique, `unsat`/`sat`/`unknown` litteraux) ; ce twin C# montre l'API .NET (`MkForall(new Expr[]{x}, body)` / `Status.UNSATISFIABLE` enum / `ReasonUnknown` propriete / `Set(""timeout"", N)`), avec le casting `(ArithExpr)` systematique des constantes reelles/entieres. Les deux executent le **meme** moteur Z3 et demontrent les memes theoremes.
-",,,,,,,,2cd90dd101e27201,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-title,markdown,fr,5e3bc0ca8d4579e2,"# Z3-Python 05 — Quantificateurs et preuves formelles
+**Complementarite** : le twin Python utilise `ForAll([x], ...)` / `Exists([x], ...)` / `is_true(simplify(...))` (API pythonique, `unsat`/`sat`/`unknown` litteraux) ; ce twin C# montre l'API .NET (`MkForall(new Expr[]{x}, body)` / `Status.UNSATISFIABLE` enum / `ReasonUnknown` propriete / `Set(""timeout"", N)`), avec le casting `(ArithExpr)` systématique des constantes reelles/entieres. Les deux executent le **même** moteur Z3 et demontrent les mêmes theoremes.
+",,,,,,,,e48cdc7431805227,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-title,markdown,fr,b45dd4a46468163e,"# Z3-Python 05 — Quantificateurs et preuves formelles
 
-**Navigation** : [Index](README.md) | [Index SMT](../README.md) | [Index SymbolicAI](../../README.md) | [Serie Z3 C# (Z3.Linq)](../Z3-Linq2Z3/README.md) | [<< Z3-Python-04 Chaines](Z3-Python-04-Strings-Regex.ipynb)
+**Navigation** : [Index](README.md) | [Index SMT](../README.md) | [Index SymbolicAI](../../README.md) | [Serie Z3 C# (Z3.Linq)](../Z3-Linq2Z3/README.md) | [<< Z3-Python-04 Chaînes](Z3-Python-04-Strings-Regex.ipynb)
 
 ## Objectifs d'apprentissage
 
@@ -3189,17 +3189,17 @@ A la fin de ce notebook, vous saurez :
 
 ---
 
-**Ce notebook** marque un tournant dans la serie : jusqu'ici (NB01-04), nous avons utilise Z3 pour trouver des **valeurs concretes** satisfaisant des contraintes (« existe-t-il un `x` tel que... ? »). Desormais, nous voulons **prouver des proprietes generales** : « pour tout `x`, cette egalite hold-t-elle ? » Cela requiere les **quantificateurs** `ForAll` ($\forall$) et `Exists` ($\exists$), et la technique de **preuve par refutation** : une formule est valide si et seulement si sa negation est insatisfiable.
+**Ce notebook** marque un tournant dans la serie : jusqu'ici (NB01-04), nous avons utilise Z3 pour trouver des **valeurs concretes** satisfaisant des contraintes (« existe-t-il un `x` tel que... ? »). Desormais, nous voulons **prouver des proprietes générales** : « pour tout `x`, cette egalite hold-t-elle ? » Cela requiere les **quantificateurs** `ForAll` ($\forall$) et `Exists` ($\exists$), et la technique de **preuve par refutation** : une formule est valide si et seulement si sa negation est insatisfiable.
 
-> **Note technique** : Z3 est un solveur SMT, pas un assistant de preuve interactif comme Lean ou Coq. Une « preuve » ici signifie une **decision algorithmique** : le solveur confirme qu'aucun contre-exemple n'existe. Pour les fragments decidables (arithmetic lineaire, theories de base), cette preuve est **complete et automatique**. Pour les fragments plus riches (quantificateurs arbitraires sur les reels, nonlinear), Z3 peut repondre `unknown`.",,,,,,,,5e3bc0ca8d4579e2,,,,,,,
+> **Note technique** : Z3 est un solveur SMT, pas un assistant de preuve interactif comme Lean ou Coq. Une « preuve » ici signifie une **decision algorithmique** : le solveur confirme qu'aucun contre-exemple n'existe. Pour les fragments decidables (arithmetic lineaire, théories de base), cette preuve est **complete et automatique**. Pour les fragments plus riches (quantificateurs arbitraires sur les reels, nonlinear), Z3 peut repondre `unknown`.",,,,,,,,b45dd4a46468163e,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-imports,code,fr,911fe9d839b6c270,"# Imports et verification de l'environnement
 from z3 import *
 
 print(f""Imports OK : z3-solver version {get_version_string()}"")",,,,,,,,911fe9d839b6c270,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-motivation,markdown,fr,288a9a11a295718d,"## 1. Motivation : au-dela des valeurs concretes
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-motivation,markdown,fr,80eb4a81bfabf4f6,"## 1. Motivation : au-dela des valeurs concretes
 
-Dans les notebooks precedents, nous avons pose des questions **existentielles concretes** :
-- « Existe-t-il des entiers `x, y` tels que `x + y == 10` et `x > y` ? » -> Z3 repond `sat` et donne un modele.
+Dans les notebooks précédents, nous avons pose des questions **existentielles concretes** :
+- « Existe-t-il des entiers `x, y` tels que `x + y == 10` et `x > y` ? » -> Z3 repond `sat` et donne un modèle.
 
 Mais supposons que nous voulions **prouver une identite mathematique**. Par exemple, l'identite additive :
 $$
@@ -3208,7 +3208,7 @@ $$
 
 Nous pourrions tester quelques valeurs : `5 + 0 == 5` (vrai), `3.14 + 0 == 3.14` (vrai)... mais cela ne **prouve** rien : il y a une infinite de reels. Il nous faut un moyen d'exprimer « pour **tous** les `x` ».
 
-C'est precisement le role des **quantificateurs** en logique du premier ordre :
+C'est précisément le rôle des **quantificateurs** en logique du premier ordre :
 
 | Quantificateur | Notation math | API Z3 | Sens |
 |----------------|---------------|--------|------|
@@ -3219,11 +3219,11 @@ Le principe central de ce notebook est la **technique de preuve par refutation**
 
 > Une formule $F$ est **valide** (un theoreme) si et seulement si sa negation $\neg F$ est **insatisfiable**.
 
-| Negation de $F$ | Resultat de Z3 | Conclusion sur $F$ |
+| Negation de $F$ | Résultat de Z3 | Conclusion sur $F$ |
 |-----------------|---------------|---------------------|
 | `Not(F)` est `unsat` | Aucun contre-exemple | $F$ est **valide** (theoreme) |
 | `Not(F)` est `sat` | Un contre-exemple existe | $F$ est **fausse** (contre-exemple donne) |
-| `Not(F)` est `unknown` | Z3 ne peut pas conclure | Indecidable par ce solveur |",,,,,,,,288a9a11a295718d,,,,,,,
+| `Not(F)` est `unknown` | Z3 ne peut pas conclure | Indecidable par ce solveur |",,,,,,,,80eb4a81bfabf4f6,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-forall-intro,markdown,fr,c77b88dd85793ba4,"## 2. `ForAll` — le quantificateur universel
 
 Le quantificateur `ForAll([x], F)` exprime que la formule `F` est vraie pour **toute** valeur de la variable `x`. La syntaxe prend une **liste** de variables en premier argument (on peut quantifier plusieurs variables a la fois).
@@ -3251,11 +3251,11 @@ elif resultat == sat:
     print(""=> Contre-exemple trouve :"", s.model())
 else:
     print(""=> Z3 ne peut pas conclure (unknown)."")",,,,,,,,d3203006a165ae4f,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-forall-identity-interp,markdown,fr,983c3213b26d42b6,"### Interpretation : preuve par refutation
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-forall-identity-interp,markdown,fr,e0d52b4a4c8826a7,"### Interpretation : preuve par refutation
 
 **Sortie obtenue** : la negation `Not(ForAll([x], x + 0 == x))` est `unsat`, donc l'identite additive est valide.
 
-| Etape | Operation | Resultat |
+| Étape | Opération | Résultat |
 |-------|-----------|----------|
 | 1 | Construire `ForAll([x], x + 0 == x)` | La formule a prouver |
 | 2 | Ajouter `Not(formule)` au solveur | Cherche un contre-exemple |
@@ -3265,10 +3265,10 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb
 **Points cles** :
 1. Z3 ne prouve pas directement « cette formule est valide ». Il prouve que sa negation est absurde.
 2. Si la negation etait `sat`, `s.model()` donnerait un **contre-exemple** concret.
-3. Le type `Real` couvre l'arithmetique rationnelle exacte ; l'identite hold sur tout $\mathbb{Q}$.",,,,,,,,983c3213b26d42b6,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-forall-examples-intro,markdown,fr,e05a3674230e4b53,"### 2.1 Trois exemples supplementaires
+3. Le type `Real` couvre l'arithmetique rationnelle exacte ; l'identite hold sur tout $\mathbb{Q}$.",,,,,,,,e0d52b4a4c8826a7,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-forall-examples-intro,markdown,fr,89b39e95c7509e2b,"### 2.1 Trois exemples supplementaires
 
-Prouvons trois proprietes elementaires de l'arithmetique reelle pour solidifier la technique. Pour chacune, nous negons la formule et verifions le resultat.",,,,,,,,e05a3674230e4b53,,,,,,,
+Prouvons trois proprietes elementaires de l'arithmetique reelle pour solidifier la technique. Pour chacune, nous negons la formule et verifions le résultat.",,,,,,,,89b39e95c7509e2b,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-forall-examples,code,fr,0c734fa06688375d,"# Trois proprietes elementaires prouvees par refutation
 x = Real('x')
 y = Real('y')
@@ -3287,7 +3287,7 @@ for nom, formule in proprietes:
     print(f""{nom}"")
     print(f""  => {statut} (negation = {res})"")
     print()",,,,,,,,0c734fa06688375d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-forall-examples-interp,markdown,fr,f7b90aac68fe7cf9,"### Interpretation : trois theoremes automatiques
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-forall-examples-interp,markdown,fr,eefa79bf2c2da21c,"### Interpretation : trois theoremes automatiques
 
 **Sortie obtenue** : les trois proprietes sont validees comme `VALIDE`.
 
@@ -3299,8 +3299,8 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb
 
 **Points cles** :
 1. `ForAll` accepte une **liste** de variables : `ForAll([x, y], ...)` quantifie sur deux variables.
-2. La technique est systematique : **negation -> check -> unsat signifie valide**.
-3. Cette approche automatique contraste avec une preuve manuelle ou une demonstration par induction.",,,,,,,,f7b90aac68fe7cf9,,,,,,,
+2. La technique est systématique : **negation -> check -> unsat signifie valide**.
+3. Cette approche automatique contraste avec une preuve manuelle ou une demonstration par induction.",,,,,,,,eefa79bf2c2da21c,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-exists-intro,markdown,fr,14b7cc8bef37221f,"## 3. `Exists` — le quantificateur existentiel
 
 Le quantificateur `Exists([x], F)` exprime qu'il existe **au moins une** valeur de `x` rendant `F` vraie. Contrairement a `ForAll`, on peut directement chercher un **temoin** concret.
@@ -3335,11 +3335,11 @@ s2.check()
 temoin = s2.model()[racine]
 print(f""Temoin concret (constante libre) : racine = {temoin}"")
 print(f""Verification : {temoin} * {temoin} ="", simplify(temoin * temoin), ""(attendu : 4)"")",,,,,,,,391e01f3e31c744b,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-exists-sat-interp,markdown,fr,30606c71d95e0872,"### Interpretation : prouver l'existence puis extraire le temoin
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-exists-sat-interp,markdown,fr,afa42d752032234a,"### Interpretation : prouver l'existence puis extraire le temoin
 
-**Sortie obtenue** : `Exists([x], x * x == 4)` est `sat` — un temoin existe. Mais `m[x]` vaut `None` : la variable `x` est **liee** par le quantificateur, elle n'apparait donc pas dans le modele. Pour lire un temoin concret, on **skolemise** : on reasserte la contrainte sur une constante **libre** (`racine`), et `m[racine]` donne alors une racine concrete (ici `2`, Z3 pouvant renvoyer l'une des deux racines `2` ou `-2`).
+**Sortie obtenue** : `Exists([x], x * x == 4)` est `sat` — un temoin existe. Mais `m[x]` vaut `None` : la variable `x` est **liee** par le quantificateur, elle n'apparait donc pas dans le modèle. Pour lire un temoin concret, on **skolemise** : on reasserte la contrainte sur une constante **libre** (`racine`), et `m[racine]` donne alors une racine concrete (ici `2`, Z3 pouvant renvoyer l'une des deux racines `2` ou `-2`).
 
-| Etape | Operation | Resultat |
+| Étape | Opération | Résultat |
 |-------|-----------|----------|
 | 1 | `Exists([x], x*x == 4)` puis `check()` | `sat` — l'existence est prouvee |
 | 2 | `m[x]` sur la variable liee | `None` — aucun temoin lisible |
@@ -3347,8 +3347,8 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb
 
 **Points cles** :
 1. Une variable **liee** par `Exists`/`ForAll` n'apparait **pas** dans `s.model()` : `m[x]` y vaut `None`. Le quantificateur prouve l'existence, il ne livre pas le temoin.
-2. Pour **obtenir** le temoin, on skolemise : la meme contrainte posee sur une **constante libre** rend sa valeur lisible via `m[racine]`.
-3. C'est la difference fondamentale entre *prouver qu'un temoin existe* (`Exists` + `sat`) et *exhiber ce temoin* (contrainte sur une constante libre).",,,,,,,,30606c71d95e0872,,,,,,,
+2. Pour **obtenir** le temoin, on skolemise : la même contrainte posee sur une **constante libre** rend sa valeur lisible via `m[racine]`.
+3. C'est la différence fondamentale entre *prouver qu'un temoin existe* (`Exists` + `sat`) et *exhiber ce temoin* (contrainte sur une constante libre).",,,,,,,,afa42d752032234a,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-exists-unsat,code,fr,d13ff671bd4a4257,"# Exemple insatisfiable : existe-t-il un x reel tel que x*x < 0 ?
 x = Real('x')
 
@@ -3378,9 +3378,9 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb
 1. `Exists` directement satisfiable (pas besoin de negation) : le solveur cherche un temoin.
 2. `unsat` sur `Exists` signifie que la propriete n'est **jamais** realisable.
 3. Le domaine compte : sur les `Real`, un carre est toujours positif ; sur les `Int` aussi.",,,,,,,,68733cdb63810228,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-proofs-intro,markdown,fr,ff1aa68863587b06,"## 4. Preuves formelles
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-proofs-intro,markdown,fr,7133ad1eabbce6cd,"## 4. Preuves formelles
 
-Maintenant que nous maitrisons `ForAll`, `Exists` et la technique de refutation, nous pouvons prouver des **theoremes** plus substentiels. La demarche est toujours la meme :
+Maintenant que nous maitrisons `ForAll`, `Exists` et la technique de refutation, nous pouvons prouver des **theoremes** plus substentiels. La demarche est toujours la même :
 
 1. **Enoncer** la propriete sous forme de formule `ForAll`.
 2. **Nier** la formule entiere.
@@ -3388,11 +3388,11 @@ Maintenant que nous maitrisons `ForAll`, `Exists` et la technique de refutation,
 
 ### Qu'est-ce qu'une « preuve » en Z3 ?
 
-Z3 est un **solveur de decision** : pour les fragments decidables (arithmetic lineaire sur $\mathbb{Z}$ et $\mathbb{R}$, theories de base), il repond de maniere **certaine** — `sat` ou `unsat`. Une « preuve » Z3 signifie donc : *le solveur a confirme qu'aucun contre-exemple n'existe*. Ce n'est pas une preuve constructrice comme dans Lean ou Coq (ou l'on construit un terme de preuve pas-a-pas), mais une **verification algorithmique complete**.
+Z3 est un **solveur de decision** : pour les fragments decidables (arithmetic lineaire sur $\mathbb{Z}$ et $\mathbb{R}$, théories de base), il repond de maniere **certaine** — `sat` ou `unsat`. Une « preuve » Z3 signifie donc : *le solveur a confirme qu'aucun contre-exemple n'existe*. Ce n'est pas une preuve constructrice comme dans Lean ou Coq (ou l'on construit un terme de preuve pas-a-pas), mais une **verification algorithmique complete**.
 
 Pour des fragments **indecidables** (quantificateurs arbitraires sur les reels, nonlinear), Z3 peut repondre `unknown` (cf. Section 5).
 
-Prouvons deux proprietes : la trichotomie et la monotonicite de la fonction carre sur les positifs.",,,,,,,,ff1aa68863587b06,,,,,,,
+Prouvons deux proprietes : la trichotomie et la monotonicite de la fonction carre sur les positifs.",,,,,,,,7133ad1eabbce6cd,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-proofs-trichotomy,code,fr,07e1ae3ededb3be1,"# Preuve 1 : trichotomie sur les reels
 # Pour tout x reel : x < 0 OU x == 0 OU x > 0 (un des trois cas)
 x = Real('x')
@@ -3423,7 +3423,7 @@ s2.add(Not(monotonicite))
 res2 = s2.check()
 print(f""Negation = {res2}"")
 print(f""=> Monotonicite : {'VALIDE' if res2 == unsat else 'NON PROUVEE'}"")",,,,,,,,07e1ae3ededb3be1,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-proofs-trichotomy-interp,markdown,fr,18e078abb5eb832b,"### Interpretation : theoremes prouves automatiquement
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-proofs-trichotomy-interp,markdown,fr,777c743c8671a16a,"### Interpretation : theoremes prouves automatiquement
 
 **Sortie obtenue** : les deux proprietes sont validees (`unsat` sur la negation).
 
@@ -3436,8 +3436,8 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb
 1. `Implies(p, q)` correspond a l'implication logique $p \Rightarrow q$.
 2. `And(...)` permet de combiner plusieurs hypotheses dans l'antecedent de l'implication.
 3. Z3 traite l'arithmetic lineaire reelle comme un fragment **decidable** : la preuve est complete et certaine.
-4. Le theoreme de monotonicite utilise l'arithmetic **non lineaire** ($x^2$, $y^2$) ; Z3 parvient tout de meme a le decider.",,,,,,,,18e078abb5eb832b,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-ex1-intro,markdown,fr,ec1d9fb231e4003c,"## Exercice 1 : Prouver l'identite additive
+4. Le theoreme de monotonicite utilise l'arithmetic **non lineaire** ($x^2$, $y^2$) ; Z3 parvient tout de même a le decider.",,,,,,,,777c743c8671a16a,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-ex1-intro,markdown,fr,3e71e79347a85485,"## Exercice 1 : Prouver l'identite additive
 
 ### Enonce
 
@@ -3448,9 +3448,9 @@ La fonction doit retourner `True` si la formule est valide, `False` sinon.
 ### Indices
 
 - `# Indice` : utilisez `Not(ForAll([x], x + 0 == x))` comme contrainte.
-- `# Etape 1` : declarer `x = Real('x')`.
-- `# Etape 2` : creer un `Solver()`, ajouter la negation.
-- `# Etape 3` : si `s.check() == unsat`, la formule est valide -> retourner `True`.",,,,,,,,ec1d9fb231e4003c,,,,,,,
+- `# Étape 1` : declarer `x = Real('x')`.
+- `# Étape 2` : créer un `Solver()`, ajouter la negation.
+- `# Étape 3` : si `s.check() == unsat`, la formule est valide -> retourner `True`.",,,,,,,,3e71e79347a85485,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-ex1-code,code,fr,ccad269c4245d98f,"# EXERCICE 1 : Prouver l'identite additive par refutation.
 
 def prouver_identite_additive() -> bool:
@@ -3469,9 +3469,9 @@ def prouver_identite_additive() -> bool:
 
 valide = prouver_identite_additive()
 print(""Identite additive valide :"", valide)",,,,,,,,ccad269c4245d98f,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-combined-intro,markdown,fr,737d8c236a2477c8,"## 5. Quantificateurs combines et limites
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-combined-intro,markdown,fr,8284c437af068404,"## 5. Quantificateurs combines et limites
 
-Les quantificateurs peuvent etre **imbriques** : une formule peut contenir un `ForAll` et un `Exists` en meme temps. Par exemple, l'enonce « pour tout reel `x`, il existe un reel `y` strictement plus grand que `x` » s'ecrit :
+Les quantificateurs peuvent etre **imbriques** : une formule peut contenir un `ForAll` et un `Exists` en même temps. Par exemple, l'enonce « pour tout reel `x`, il existe un reel `y` strictement plus grand que `x` » s'ecrit :
 $$
 \forall x.\ \exists y.\ y > x
 $$
@@ -3480,12 +3480,12 @@ Cette propriete exprime qu'il n'y a pas de « plus grand reel » : on peut toujo
 ### La limite de Z3 : `unknown`
 
 Z3 est puissant, mais **indecidable** sur certains fragments. Lorsque le solveur ne peut pas conclure, il repond `unknown`. Cela arrive typiquement avec :
-- De l'arithmetic **non lineaire entiere** (multiplication de variables sur $\mathbb{Z}$) — indecidable en general (10e probleme de Hilbert)
+- De l'arithmetic **non lineaire entiere** (multiplication de variables sur $\mathbb{Z}$) — indecidable en general (10e problème de Hilbert)
 - De l'arithmetic non lineaire reelle non bornee
 - Des quantificateurs imbriques complexes
 - Des formules hors des fragments decides
 
-Il est important de comprendre que `unknown` ne signifie ni `sat` ni `unsat` : le solveur **abandonne**, sans conclusion. Ce n'est pas une erreur, c'est une limite fondamentale de la decision automatique. Pour eviter une recherche sans fin, on borne le solveur avec un **timeout** : au-dela du budget, Z3 renvoie `unknown` plutot que de boucler.",,,,,,,,737d8c236a2477c8,,,,,,,
+Il est important de comprendre que `unknown` ne signifie ni `sat` ni `unsat` : le solveur **abandonne**, sans conclusion. Ce n'est pas une erreur, c'est une limite fondamentale de la decision automatique. Pour eviter une recherche sans fin, on borne le solveur avec un **timeout** : au-dela du budget, Z3 renvoie `unknown` plutot que de boucler.",,,,,,,,8284c437af068404,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-combined-no-greatest,code,fr,298031628d387099,"# Quantificateurs imbriques : pour tout x, il existe y > x (pas de plus grand reel)
 x = Real('x')
 y = Real('y')
@@ -3503,7 +3503,7 @@ elif res == sat:
     print(""=> FAUSSE : contre-exemple trouve."", s.model())
 else:
     print(""=> Z3 ne peut pas conclure (unknown)."")",,,,,,,,298031628d387099,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-combined-no-greatest-interp,markdown,fr,d93c6f24a792d48a,"### Interpretation : quantificateurs imbriques
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-combined-no-greatest-interp,markdown,fr,228922abe457e63a,"### Interpretation : quantificateurs imbriques
 
 **Sortie obtenue** : la negation de « pour tout `x`, il existe `y > x` » est `unsat`, donc la propriete est valide.
 
@@ -3515,9 +3515,9 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb
 | Verdict | `unsat` -> formule valide |
 
 **Points cles** :
-1. `ForAll` et `Exists` se combinent naturellement dans une meme formule.
+1. `ForAll` et `Exists` se combinent naturellement dans une même formule.
 2. La negation d'une formule imbriquee negatione l'**ensemble** : `Not(ForAll([x], Exists([y], ...)))`.
-3. L'ordre des quantificateurs compte : $\forall x.\ \exists y$ n'est pas equivalent a $\exists y.\ \forall x$.",,,,,,,,d93c6f24a792d48a,,,,,,,
+3. L'ordre des quantificateurs compte : $\forall x.\ \exists y$ n'est pas equivalent a $\exists y.\ \forall x$.",,,,,,,,228922abe457e63a,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-combined-unknown,code,fr,c0458d89b9151f57,"# Cas ou Z3 repond REELLEMENT unknown : arithmetic non lineaire entiere.
 # Existe-t-il des entiers a, b, c > 1 tels que a^3 + b^3 == c^3 ?
 # (Le dernier theoreme de Fermat dit non, mais cette preuve depasse Z3 :
@@ -3541,19 +3541,19 @@ else:
     print(f""=> UNKNOWN : Z3 abandonne (raison : {s.reason_unknown()})."")
     print(""   L'arithmetic non lineaire entiere est indecidable en general :"")
     print(""   ce n'est PAS un bug, mais une limite fondamentale de la decision automatique."")",,,,,,,,c0458d89b9151f57,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-combined-unknown-interp,markdown,fr,aa0e25e7591d9048,"### Interpretation : honnetete face a `unknown`
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-combined-unknown-interp,markdown,fr,c7c9c3ee806f13d6,"### Interpretation : honnetete face a `unknown`
 
-**Sortie obtenue** : sur `a^3 + b^3 == c^3` (avec `a, b, c > 1`), Z3 ne tranche pas dans le budget imparti et repond `unknown` (raison : `timeout`). Le probleme — un cas du dernier theoreme de Fermat — est hors de portee de la decision automatique : l'arithmetic non lineaire entiere est indecidable en general. Le `timeout` borne la recherche ; sans lui, `check()` ne terminerait pas.
+**Sortie obtenue** : sur `a^3 + b^3 == c^3` (avec `a, b, c > 1`), Z3 ne tranche pas dans le budget imparti et repond `unknown` (raison : `timeout`). Le problème — un cas du dernier theoreme de Fermat — est hors de portee de la decision automatique : l'arithmetic non lineaire entiere est indecidable en general. Le `timeout` borne la recherche ; sans lui, `check()` ne terminerait pas.
 
-| Theorie | Resultat typique | Interpretation |
+| Théorie | Résultat typique | Interpretation |
 |---------|-----------------|----------------|
 | Arithmetic lineaire reelle | `sat` ou `unsat` | Toujours decidable |
 | Arithmetic lineaire entiere | `sat` ou `unsat` | Decidable (Presburger) |
 | Non lineaire reelle (bornee) | `sat`/`unsat` ou `unknown` | Parfois decidable |
 | Non lineaire entiere | souvent `unknown` | Indecidable en general |
 
-> **Note technique** : `unknown` n'est pas un echec du a un bug. C'est une **limite theorique** : par l'indecidabilite de l'arithmetic entiere du premier ordre (theoreme de Matiiassevitch / 10e probleme de Hilbert), aucun algorithme ne peut decider toutes les formules. Z3 fait de son mieux avec des heuristiques puissantes, mais certaines formules restent hors de portee. Quand cela arrive, on peut : (a) simplifier la formule, (b) limiter le domaine (passer a un intervalle entier borne), (c) utiliser une tactique specialisee, (d) accepter `unknown` comme reponse honnete.",,,,,,,,aa0e25e7591d9048,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-ex2-intro,markdown,fr,5398a7e7c312194f,"## Exercice 2 : Verifier l'inexistence d'un carre negatif
+> **Note technique** : `unknown` n'est pas un echec du a un bug. C'est une **limite théorique** : par l'indecidabilite de l'arithmetic entiere du premier ordre (theoreme de Matiiassevitch / 10e problème de Hilbert), aucun algorithme ne peut decider toutes les formules. Z3 fait de son mieux avec des heuristiques puissantes, mais certaines formules restent hors de portee. Quand cela arrive, on peut : (a) simplifier la formule, (b) limiter le domaine (passer a un intervalle entier borne), (c) utiliser une tactique specialisee, (d) accepter `unknown` comme reponse honnete.",,,,,,,,c7c9c3ee806f13d6,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-ex2-intro,markdown,fr,16d4eefd0a96723a,"## Exercice 2 : Verifier l'inexistence d'un carre negatif
 
 ### Enonce
 
@@ -3562,9 +3562,9 @@ Ecrivez une fonction `existe_carre_negatif()` qui verifie si `Exists([x], x * x 
 ### Indices
 
 - `# Indice` : attention au type. `Real('x')` donne des reels ; un carre reel est toujours positif.
-- `# Etape 1` : declarer `x = Real('x')`.
-- `# Etape 2` : creer un `Solver`, ajouter `Exists([x], x * x < 0)`.
-- `# Etape 3` : `s.check() == sat` -> retourner `True`, sinon `False`.",,,,,,,,5398a7e7c312194f,,,,,,,
+- `# Étape 1` : declarer `x = Real('x')`.
+- `# Étape 2` : créer un `Solver`, ajouter `Exists([x], x * x < 0)`.
+- `# Étape 3` : `s.check() == sat` -> retourner `True`, sinon `False`.",,,,,,,,16d4eefd0a96723a,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-ex2-code,code,fr,0b20919800bb51d7,"# EXERCICE 2 : Verifier si un carre negatif existe sur les reels.
 
 def existe_carre_negatif() -> bool:
@@ -3583,9 +3583,9 @@ def existe_carre_negatif() -> bool:
 
 resultat = existe_carre_negatif()
 print(""Un carre negatif existe :"", resultat)",,,,,,,,0b20919800bb51d7,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-model-intro,markdown,fr,17bf0bb482c5f5c1,"## 6. Model checking avec quantificateurs
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-model-intro,markdown,fr,2863ddc69c7db5c5,"## 6. Model checking avec quantificateurs
 
-Le **model checking** (verification de modele) consiste a trouver une assignation concrete satisfaisant un ensemble de contraintes — y compris des contraintes quantifiees. Contrairement a la preuve (ou l'on cherche `unsat` sur une negation), le model checking cherche un **modele** (`sat` + `s.model()`).
+Le **model checking** (verification de modèle) consiste a trouver une assignation concrete satisfaisant un ensemble de contraintes — y compris des contraintes quantifiees. Contrairement a la preuve (ou l'on cherche `unsat` sur une negation), le model checking cherche un **modèle** (`sat` + `s.model()`).
 
 Un exemple classique : existe-t-il un reel `x` tel que, pour tout reel `y` positif, `x <= y` ? En d'autres termes, existe-t-il un reel minimal par rapport aux positifs ?
 $$
@@ -3593,7 +3593,7 @@ $$
 $$
 Sur les reels, cette formule est satisfiable si `x <= 0` (n'importe quel `x` negatif ou nul est inferieur a tout `y >= 0`).
 
-**Pour lire le temoin** `x`, on applique la meme technique qu'a la Section 3 : on **skolemise** le `Exists x` externe en declarant `x` comme une constante **libre**, de sorte que le `ForAll` ne porte plus que sur `y`. La valeur de `x` devient alors directement lisible dans le modele via `m[x]` (au lieu de rester un symbole non evalue si `x` etait lie par `Exists`). Trouvons un tel modele.",,,,,,,,17bf0bb482c5f5c1,,,,,,,
+**Pour lire le temoin** `x`, on applique la même technique qu'a la Section 3 : on **skolemise** le `Exists x` externe en declarant `x` comme une constante **libre**, de sorte que le `ForAll` ne porte plus que sur `y`. La valeur de `x` devient alors directement lisible dans le modèle via `m[x]` (au lieu de rester un symbole non evalue si `x` etait lie par `Exists`). Trouvons un tel modèle.",,,,,,,,2863ddc69c7db5c5,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-model-min,code,fr,c9fe739391247925,"# Model checking : existe-t-il x tel que pour tout y >= 0, x <= y ?
 # x est le temoin recherche (le ""Exists x"" externe). Pour lire sa valeur dans
 # le modele, on le SKOLEMISE : on le declare comme constante LIBRE, et le ForAll
@@ -3620,23 +3620,23 @@ elif res == unsat:
     print(""=> Aucun modele : la formule est fausse."")
 else:
     print(""=> Z3 ne peut pas conclure (unknown)."")",,,,,,,,c9fe739391247925,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-model-min-interp,markdown,fr,bd450f498bbe81c6,"### Interpretation : extraction du temoin par skolemisation
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-model-min-interp,markdown,fr,64952f19159394ef,"### Interpretation : extraction du temoin par skolemisation
 
-**Sortie obtenue** : Z3 trouve un modele ou `x = 0` — un reel inferieur ou egal a tout `y >= 0`. La valeur exacte depend du solveur, mais elle est bien **lisible** ici parce que `x` a ete declare comme constante **libre**.
+**Sortie obtenue** : Z3 trouve un modèle ou `x = 0` — un reel inferieur ou egal a tout `y >= 0`. La valeur exacte depend du solveur, mais elle est bien **lisible** ici parce que `x` a ete declare comme constante **libre**.
 
 | Aspect | Valeur |
 |--------|--------|
 | Question posee | $\exists x.\ \forall y.\ (y \geq 0 \Rightarrow x \leq y)$ |
 | Formule resolue (skolemisee) | `ForAll([y], Implies(y >= 0, x <= y))`, `x` libre |
-| Resultat | `sat` |
-| Modele | `x = 0` (un minorant des reels positifs) |
+| Résultat | `sat` |
+| Modèle | `x = 0` (un minorant des reels positifs) |
 
 **Points cles** :
 1. Le `Exists x` externe est **skolemise** : on transforme « il existe `x` » en « voici la constante `x` » (variable libre). Le `ForAll` ne porte plus que sur `y`.
-2. Une variable **liee** par un quantificateur ne peut **pas** etre extraite du modele : `m[x]` y vaut `None` et `m.evaluate(x)` renvoie le symbole `x` non evalue. Skolemiser (constante libre) est la facon standard de rendre le temoin lisible — c'est exactement la technique de la Section 3.
+2. Une variable **liee** par un quantificateur ne peut **pas** etre extraite du modèle : `m[x]` y vaut `None` et `m.evaluate(x)` renvoie le symbole `x` non evalue. Skolemiser (constante libre) est la facon standard de rendre le temoin lisible — c'est exactement la technique de la Section 3.
 3. `Implies(y >= 0, x <= y)` restreint la contrainte universelle aux `y` positifs uniquement.
-4. Le contraste avec la Section 4 : la, on cherchait `unsat` (preuve) ; ici, on cherche `sat` (modele) et on **lit** le temoin.",,,,,,,,bd450f498bbe81c6,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-ex3-intro,markdown,fr,0422507f3d47a3c8,"## Exercice 3 : Prouver l'absence de plus grand reel
+4. Le contraste avec la Section 4 : la, on cherchait `unsat` (preuve) ; ici, on cherche `sat` (modèle) et on **lit** le temoin.",,,,,,,,64952f19159394ef,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-ex3-intro,markdown,fr,8e352063feb5b688,"## Exercice 3 : Prouver l'absence de plus grand reel
 
 ### Enonce
 
@@ -3647,9 +3647,9 @@ Retournez `True` si la formule est valide (negation `unsat`), `False` sinon.
 ### Indices
 
 - `# Indice` : niez la **formule entiere** : `Not(ForAll([x], Exists([y], y > x)))`.
-- `# Etape 1` : declarer `x = Real('x')` et `y = Real('y')`.
-- `# Etape 2` : creer un `Solver`, ajouter la negation.
-- `# Etape 3` : si `s.check() == unsat`, la formule est valide -> retourner `True`.",,,,,,,,0422507f3d47a3c8,,,,,,,
+- `# Étape 1` : declarer `x = Real('x')` et `y = Real('y')`.
+- `# Étape 2` : créer un `Solver`, ajouter la negation.
+- `# Étape 3` : si `s.check() == unsat`, la formule est valide -> retourner `True`.",,,,,,,,8e352063feb5b688,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-ex3-code,code,fr,437625c2d919f964,"# EXERCICE 3 : Prouver qu'il n'existe pas de plus grand reel.
 
 def prouver_pas_de_plus_grand() -> bool:
@@ -3668,7 +3668,7 @@ def prouver_pas_de_plus_grand() -> bool:
 
 valide = prouver_pas_de_plus_grand()
 print(""Pas de plus grand reel (valide) :"", valide)",,,,,,,,437625c2d919f964,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-recap,markdown,fr,8348c16dd0b1e69a,"## Recapitulatif
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb,nb05-recap,markdown,fr,ecbcf3a1b87a5e69,"## Recapitulatif
 
 Ce notebook a introduit les **quantificateurs** et la **preuve formelle** avec Z3 :
 
@@ -3678,18 +3678,18 @@ Ce notebook a introduit les **quantificateurs** et la **preuve formelle** avec Z
 | Quantificateur existentiel | `Exists([x], F)` | Trouver un temoin verifiant une propriete |
 | Preuve par refutation | `Solver().add(Not(F))` | F est valide ssi `Not(F)` est `unsat` |
 | Quantificateurs imbriques | `ForAll([x], Exists([y], ...))` | Exprimer des proprietes relationnelles |
-| Model checking | `sat` + `s.model()` | Extraire un modele concret |
+| Model checking | `sat` + `s.model()` | Extraire un modèle concret |
 | Limite de decision | `unknown` | Z3 ne peut pas conclure (indecidable) |
 
 **Points essentiels a retenir** :
 1. **`ForAll` vs `Exists`** : le premier exige une propriete universelle, le second cherche un temoin.
 2. **Validite = negation insatisfiable** : pour prouver qu'une formule est un theoreme, on verifie que sa negation est `unsat`. Aucun contre-exemple n'existe.
 3. **`unknown` est honnete** : Z3 est indecidable sur certains fragments (non lineaire, quantificateurs complexes). `unknown` n'est ni `sat` ni `unsat`, c'est un abandon.
-4. **Contraste avec NB01** : dans le notebook d'introduction, nous cherchions des valeurs concretes (`sat` + modele). Desormais, nous prouvons des proprietes **generales** (`unsat` sur la negation = theoreme).
+4. **Contraste avec NB01** : dans le notebook d'introduction, nous cherchions des valeurs concretes (`sat` + modèle). Desormais, nous prouvons des proprietes **générales** (`unsat` sur la negation = theoreme).
 5. **Preuve Z3 vs preuve Lean** : Z3 est une **decision automatique** (algorithme), pas une preuve interactive (construction pas-a-pas). Les deux approches sont complementaires.
 
-Le notebook suivant explorera l'**optimisation avancee** : objectifs multiples, front de Pareto, et `Optimize` hierarchique.",,,,,,,,8348c16dd0b1e69a,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,13ae6171,markdown,fr,4ea0a50c3bdc0aae,"# Z3-Python 06 -- Optimisation avancee (twin C#)
+Le notebook suivant explorera l'**optimisation avancee** : objectifs multiples, front de Pareto, et `Optimize` hiérarchique.",,,,,,,,ecbcf3a1b87a5e69,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,13ae6171,markdown,fr,92295b8eef9215b5,"# Z3-Python 06 -- Optimisation avancee (twin C#)
 
 **Navigation** : [Index](README.md) | [Index SMT](../README.md) | [Index SymbolicAI](../../README.md) | [<< Z3-Python-05 Quantifiers](Z3-Python-05-Quantifiers-Proofs-Csharp.ipynb)
 
@@ -3711,9 +3711,9 @@ A la fin de ce notebook, vous saurez :
 
 ---
 
-**Ce notebook** est le twin C# du notebook Python [Z3-Python-06-Advanced-Optimization.ipynb](Z3-Python-06-Advanced-Optimization.ipynb). Il poursuit l'exploration de la classe `Optimize` au-dela du cas elementaire (un seul objectif vu en NB01). Les problemes reels comportent presque toujours **plusieurs objectifs contradictoires** : maximiser la qualite tout en minimisant le cout, ou satisfaire un maximum de preferences quand toutes ne peuvent l'etre simultanement. Z3 fournit pour cela les contraintes ponderees, l'optimisation multi-objectif lexicographique, et l'enumeration du front de Pareto.
+**Ce notebook** est le twin C# du notebook Python [Z3-Python-06-Advanced-Optimization.ipynb](Z3-Python-06-Advanced-Optimization.ipynb). Il poursuit l'exploration de la classe `Optimize` au-dela du cas elementaire (un seul objectif vu en NB01). Les problemes reels comportent presque toujours **plusieurs objectifs contradictoires** : maximiser la qualite tout en minimisant le cout, ou satisfaire un maximum de préférences quand toutes ne peuvent l'etre simultanement. Z3 fournit pour cela les contraintes ponderees, l'optimisation multi-objectif lexicographique, et l'enumeration du front de Pareto.
 
-> **Kernel** : `.net-csharp` (.NET Interactive). Le moteur est le **vrai** [Microsoft.Z3](https://github.com/Z3Prover/z3) via NuGet `#r ""nuget: Microsoft.Z3""` (v4.12.2.0) -- le meme solveur C++ que `z3-solver` Python.",,,,,,,,4ea0a50c3bdc0aae,,,,,,,
+> **Kernel** : `.net-csharp` (.NET Interactive). Le moteur est le **vrai** [Microsoft.Z3](https://github.com/Z3Prover/z3) via NuGet `#r ""nuget: Microsoft.Z3""` (v4.12.2.0) -- le même solveur C++ que `z3-solver` Python.",,,,,,,,92295b8eef9215b5,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,aa36f72a,code,fr,e56f9c103cb23411,"#r ""nuget: Microsoft.Z3""
 using Microsoft.Z3;
 using System;
@@ -3724,7 +3724,7 @@ using System.Linq;
 var ctx = new Context();
 Console.WriteLine($""Moteur : Microsoft.Z3 {Microsoft.Z3.Version.FullVersion}"");
 Console.WriteLine(""Optimisation multi-criteres : MkOptimize, MkMaximize, MkMinimize, AssertSoft."");",,,,,,,,e56f9c103cb23411,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,8c5be969,markdown,fr,f6a9c3056c8b6288,"## 1. Rappel et motivation -- au-dela d'un seul objectif
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,8c5be969,markdown,fr,248421b7c1cbd206,"## 1. Rappel et motivation -- au-dela d'un seul objectif
 
 Le notebook 01 a introduit `Optimize` avec **un** objectif unique : maximiser la valeur d'un sac a dos, ou minimiser le temps de fin d'un ordonnancement. Le patron etait simple :
 
@@ -3743,27 +3743,27 @@ Dans la vraie vie, les problemes comportent plusieurs objectifs **contradictoire
 |---------|----------------------|----------------------|
 | Logistique | Qualite de service | Cout de transport |
 | Finance | Rendement | Risque |
-| Planification | Satisfaction des preferences | Cout horaire |
+| Planification | Satisfaction des préférences | Cout horaire |
 | Ingenierie | Performance | Consommation energetique |
 
-On ne peut pas « maximiser A et minimiser B » simultanement de facon absolue : il faut choisir une strategie de compromis. Z3 offre trois approches complementaires :
+On ne peut pas « maximiser A et minimiser B » simultanement de facon absolue : il faut choisir une stratégie de compromis. Z3 offre trois approches complementaires :
 
-1. **Priorites hierarchiques** (section 2) : chaque contrainte souple a un poids, on minimise la somme ponderee des violations.
-2. **Objectifs multiples lexicographiques** (section 3) : on optimise les objectifs les uns apres les autres, par ordre de priorite.
+1. **Priorites hiérarchiques** (section 2) : chaque contrainte souple a un poids, on minimise la somme ponderee des violations.
+2. **Objectifs multiples lexicographiques** (section 3) : on optimise les objectifs les uns après les autres, par ordre de priorite.
 3. **Front de Pareto** (section 4) : on enumere tous les compromis optimaux pour laisser un humain decider.
 
 Le vocabulaire utile pour la suite :
 
 | Terme | Definition |
 |-------|------------|
-| **Contrainte dure** (*hard constraint*) | Doit etre satisfaite ; si impossible, le probleme est `UNSATISFIABLE`. |
+| **Contrainte dure** (*hard constraint*) | Doit etre satisfaite ; si impossible, le problème est `UNSATISFIABLE`. |
 | **Contrainte souple** (*soft constraint*) | Devrait etre satisfaite, mais une violation est toleree moyennant une penalite. |
-| **Poids** (*weight*) | Cout numerique attribue a la violation d'une contrainte souple. Plus le poids est eleve, plus Z3 tente de la satisfaire. |
+| **Poids** (*weight*) | Cout numérique attribue a la violation d'une contrainte souple. Plus le poids est eleve, plus Z3 tente de la satisfaire. |
 | **Solution dominee** | Il existe une autre solution strictement meilleure sur au moins un objectif, sans etre pire sur aucun autre. |
-| **Front de Pareto** | Ensemble des solutions non-dominees : les compromis optimaux. |",,,,,,,,f6a9c3056c8b6288,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,2b3f511c,markdown,fr,2a513ec71c3073bc,"## 2. Objectifs hierarchiques avec `Optimize` et priorites
+| **Front de Pareto** | Ensemble des solutions non-dominees : les compromis optimaux. |",,,,,,,,248421b7c1cbd206,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,2b3f511c,markdown,fr,934a78d42e43f901,"## 2. Objectifs hiérarchiques avec `Optimize` et priorites
 
-La technique la plus directe pour gerer des contraintes de priorite variable consiste a introduire des **variables de relaxation booleennes**. Pour chaque contrainte souple `c_i`, on cree une variable `r_i` (un `BoolExpr`) et on ajoute `MkOr(c_i, r_i)` : la contrainte peut etre violee, mais seulement si `r_i` vaut `True`. On minimise ensuite la somme ponderee des `r_i`.
+La technique la plus directe pour gerer des contraintes de priorite variable consiste a introduire des **variables de relaxation booleennes**. Pour chaque contrainte souple `c_i`, on créé une variable `r_i` (un `BoolExpr`) et on ajoute `MkOr(c_i, r_i)` : la contrainte peut etre violee, mais seulement si `r_i` vaut `True`. On minimise ensuite la somme ponderee des `r_i`.
 
 ### Principe
 
@@ -3779,7 +3779,7 @@ En C#/.NET, `ctx.MkITE(r_i, ctx.MkInt(weight_i), ctx.MkInt(0))` construit exacte
 
 ### Exemple : ordonnanceur avec contraintes dures et souples
 
-Trois taches doivent etre planifiees dans des fenetres temporelles. Certaines contraintes sont **imperatives** (dures), d'autres sont **souhaitees** (souples) avec des poids differents : une priorite elevee signifie que Z3 fera de son mieux pour la satisfaire.",,,,,,,,2a513ec71c3073bc,,,,,,,
+Trois tâches doivent etre planifiees dans des fenêtres temporelles. Certaines contraintes sont **imperatives** (dures), d'autres sont **souhaitees** (souples) avec des poids différents : une priorite elevee signifie que Z3 fera de son mieux pour la satisfaire.",,,,,,,,934a78d42e43f901,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,170bb386,code,fr,ba3d26784a4f6051,"// Ordonnanceur hierarchique : contraintes dures + contraintes souples ponderees.
 // Trois taches T0, T1, T2. Chaque tache i demarre a debut_i (entier >= 0),
 // dure 1 unite de temps, et deux taches ne peuvent s'executer au meme instant.
@@ -3838,11 +3838,11 @@ if (opt.Check() == Status.SATISFIABLE) {
     }
     Console.WriteLine($""\nCout total des violations : {((IntNum)m.Evaluate(coutVar)).Int64}"");
 }",,,,,,,,ba3d26784a4f6051,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,75351590,markdown,fr,4b0ee9e13b341055,"### Interpretation : hierarchie ponderee
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,75351590,markdown,fr,53b9752fa51cb99c,"### Interpretation : hiérarchie ponderee
 
-**Sortie obtenue** : Z3 trouve un planning qui satisfait toutes les contraintes dures et minimise la somme ponderee des violations des contraintes souples (cout total nul ici, car toutes les preferences sont compatibles).
+**Sortie obtenue** : Z3 trouve un planning qui satisfait toutes les contraintes dures et minimise la somme ponderee des violations des contraintes souples (cout total nul ici, car toutes les préférences sont compatibles).
 
-| Mecanisme | API Microsoft.Z3 | Role |
+| Mécanisme | API Microsoft.Z3 | Rôle |
 |-----------|------------------|------|
 | Variable de relaxation | `ctx.MkBoolConst($""r_{i}"")` | Vaut `True` si la contrainte souple est violee |
 | Contrainte relachee | `ctx.MkOr(contrainte, r_i)` | Permet la violation via `r_i` |
@@ -3854,23 +3854,23 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Cshar
 2. Toutes les contraintes dures sont satisfaites par construction (elles sont ajoutees avec `opt.Assert` sans relaxation).
 3. Le cout total obtenu est le **minimum** : aucune autre assignation ne donne une somme ponderee de violations inferieure.
 
-> **Note technique (.NET)** : Microsoft.Z3 expose aussi `opt.AssertSoft(BoolExpr, uint weight, string group)` qui automatise le schema relaxation+penalite pour un groupe de contraintes. On l'illustre en section 5. Le codage manuel ci-dessus reste utile pour comprendre le mecanisme et controler finement l'expression du cout. Le choix des poids est decisive : en pratique, on utilise souvent une echelle exponentielle (1, 2, 4, 8...) pour garantir une veritable hierarchie lexicographique approximative.",,,,,,,,4b0ee9e13b341055,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,60efb692,markdown,fr,efd5ad840dde5279,"## 3. Objectifs multiples -- `MkMaximize` vs `MkMinimize` simultanes
+> **Note technique (.NET)** : Microsoft.Z3 expose aussi `opt.AssertSoft(BoolExpr, uint weight, string group)` qui automatise le schema relaxation+penalite pour un groupe de contraintes. On l'illustre en section 5. Le codage manuel ci-dessus reste utile pour comprendre le mécanisme et contrôler finement l'expression du cout. Le choix des poids est decisive : en pratique, on utilise souvent une echelle exponentielle (1, 2, 4, 8...) pour garantir une veritable hiérarchie lexicographique approximative.",,,,,,,,53b9752fa51cb99c,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,60efb692,markdown,fr,824ca59e10471ea8,"## 3. Objectifs multiples -- `MkMaximize` vs `MkMinimize` simultanes
 
 Un `Optimize` peut contenir **plusieurs objectifs** declares via `opt.MkMaximize(...)` et `opt.MkMinimize(...)`. Z3 resout ces objectifs de maniere **lexicographique** (par ordre de declaration) : le premier objectif est optimise en priorite, puis le second est optimise sous la contrainte que le premier reste optimal.
 
 ### Lecture des bornes
 
-Chaque appel a `opt.MkMaximize(expr)` ou `opt.MkMinimize(expr)` renvoie un **handle** de type `Optimize.Handle`. Apres `opt.Check()`, on peut interroger :
+Chaque appel a `opt.MkMaximize(expr)` ou `opt.MkMinimize(expr)` renvoie un **handle** de type `Optimize.Handle`. Après `opt.Check()`, on peut interroger :
 
-- `handle.Upper` : borne superieure de l'objectif (utile apres `MkMaximize`).
-- `handle.Lower` : borne inferieure de l'objectif (utile apres `MkMinimize`).
+- `handle.Upper` : borne superieure de l'objectif (utile après `MkMaximize`).
+- `handle.Lower` : borne inferieure de l'objectif (utile après `MkMinimize`).
 
 Ces proprietes retournent un `Expr` (en pratique un `IntNum` pour les objectifs entiers) : on caste en `IntNum` puis `.Int64` pour la valeur.
 
 ### Exemple : maximiser le revenu, puis minimiser le cout
 
-Une entreprise choisit combien d'unites produire (`q`, entier). Chaque unite generee un revenu de 8 EUR mais coute 3 EUR en production. La capacite est limitee a 15 unites. On veut **maximiser le revenu** (priorite 1), puis **minimiser le cout** (priorite 2).",,,,,,,,efd5ad840dde5279,,,,,,,
+Une entreprise choisit combien d'unites produire (`q`, entier). Chaque unite generee un revenu de 8 EUR mais coute 3 EUR en production. La capacite est limitee a 15 unites. On veut **maximiser le revenu** (priorite 1), puis **minimiser le cout** (priorite 2).",,,,,,,,824ca59e10471ea8,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,c97b3a33,code,fr,a638d527d751fa38,"// Optimisation multi-objectif lexicographique.
 // Objectif 1 (priorite haute) : maximiser le revenu = 8 * q
 // Objectif 2 (priorite basse) : minimiser le cout = 3 * q
@@ -3911,11 +3911,11 @@ if (opt2.Check() == Status.SATISFIABLE) {
     Console.WriteLine(""\nDans cet exemple les deux approches convergent (profit croissant en q),"");
     Console.WriteLine(""mais en general lexicographique != somme ponderee."");
 }",,,,,,,,a638d527d751fa38,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,3c2e899c,markdown,fr,425575b48e4fd1f2,"### Interpretation : lexicographique vs pondere
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,3c2e899c,markdown,fr,47fffb452224fde2,"### Interpretation : lexicographique vs pondere
 
-**Sortie obtenue** : Z3 trouve `q = 15` (capacite maximale), ce qui maximise le revenu. Le cout est ensuite minimise, mais comme `cout = 3 * q` et que `q` est deja fixe par la maximisation du revenu, le cout ne peut pas etre reduit independamment.
+**Sortie obtenue** : Z3 trouve `q = 15` (capacite maximale), ce qui maximise le revenu. Le cout est ensuite minimise, mais comme `cout = 3 * q` et que `q` est déjà fixe par la maximisation du revenu, le cout ne peut pas etre reduit independamment.
 
-| Strategie | Comment ca marche | Quand l'utiliser |
+| Stratégie | Comment ca marche | Quand l'utiliser |
 |-----------|-------------------|------------------|
 | **Lexicographique** | Optimise les objectifs dans l'ordre de declaration | Priorites claires et strictes (A domine B) |
 | **Ponderee** (section 2) | Minimise la somme ponderee des violations | Compromis souhaites entre objectifs |
@@ -3923,15 +3923,15 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Cshar
 
 **Points cles** :
 1. `handle.Upper` donne la valeur optimale d'un objectif `MkMaximize` ; `handle.Lower` pour `MkMinimize` (caster le `Expr` retourne en `IntNum`).
-2. L'ordre de declaration des `MkMaximize`/`MkMinimize` definit la **priorite lexicographique**.
-3. L'approche lexicographique n'est **pas equivalente** a maximiser une somme ponderee : elle impose une hierarchie stricte.
+2. L'ordre de declaration des `MkMaximize`/`MkMinimize` définit la **priorite lexicographique**.
+3. L'approche lexicographique n'est **pas equivalente** a maximiser une somme ponderee : elle impose une hiérarchie stricte.
 
-> **Note technique** : L'optimisation multi-objectif lexicographique de Z3 suit le schema Box/Wilson : optimiser l'objectif 1, fixer sa valeur optimale comme contrainte, puis optimiser l'objectif 2, et ainsi de suite.",,,,,,,,425575b48e4fd1f2,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,cb0822d5,markdown,fr,008043b40e7957e3,"## 4. Front de Pareto -- explorer les compromis
+> **Note technique** : L'optimisation multi-objectif lexicographique de Z3 suit le schema Box/Wilson : optimiser l'objectif 1, fixer sa valeur optimale comme contrainte, puis optimiser l'objectif 2, et ainsi de suite.",,,,,,,,47fffb452224fde2,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,cb0822d5,markdown,fr,846978ede440b3b4,"## 4. Front de Pareto -- explorer les compromis
 
 Quand deux objectifs sont contradictoires et qu'aucune priorite naturelle n'existe, la notion de front de Pareto est pertinente. Une solution est dite **Pareto-optimale** si aucune autre solution ne l'ameliore sur un objectif sans la degrader sur l'autre. Le front de Pareto est l'ensemble de toutes ces solutions optimales.
 
-### Methode d'enumeration
+### Méthode d'enumeration
 
 Pour construire le front de Pareto entre maximiser $A$ et minimiser $B$ :
 
@@ -3944,7 +3944,7 @@ On obtient ainsi une suite de points $(A_1, B_1), (A_2, B_2), \ldots$ ou le cout
 
 ### Exemple : qualite vs cout
 
-On choisit un niveau de qualite `q` (0 a 10) et un niveau de cout `c`. Les deux sont lies : une qualite elevee implique un cout minimal, mais le cout peut aussi augmenter pour d'autres raisons. On cherche tous les compromis optimaux (qualite maximale, cout minimal).",,,,,,,,008043b40e7957e3,,,,,,,
+On choisit un niveau de qualite `q` (0 a 10) et un niveau de cout `c`. Les deux sont lies : une qualite elevee implique un cout minimal, mais le cout peut aussi augmenter pour d'autres raisons. On cherche tous les compromis optimaux (qualite maximale, cout minimal).",,,,,,,,846978ede440b3b4,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,4be06c6d,code,fr,f4afe24f020f29bd,"// Enumeration du front de Pareto : maximiser qualite (0-10), minimiser cout.
 // Relation : une qualite q exige un cout minimal de q * 2.
 List<(long qualite, long cout)> EnumererFrontPareto(Context ctx, int maxIter = 15) {
@@ -3991,11 +3991,11 @@ for (int i = 0; i < front.Count; i++) {
 Console.WriteLine($""\n{front.Count} points Pareto-optimaux trouves (qualites distinctes)."");
 Console.WriteLine(""Chaque point est un compromis : pour baisser le cout, il faut"");
 Console.WriteLine(""sacrifier de la qualite (puisque cout_min = 2 * qualite)."");",,,,,,,,f4afe24f020f29bd,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,db8cd9f9,markdown,fr,cc88108996c0053c,"### Visualiser le front de Pareto
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,db8cd9f9,markdown,fr,a90376bdfb2c4d27,"### Visualiser le front de Pareto
 
-Un tableau de nombres ne rend pas justice au concept de **compromis**. En projetant chaque point Pareto-optimal dans le plan (qualite, cout), le front devient une courbe descendante : chaque pas vers un cout plus bas coute de la qualite. La droite `cout_min = 2 * qualite` (la frontiere de faisabilite imposee par le modele) apparait en pointille : on voit immediatement que certains points Pareto-optimaux sont *strictement au-dessus* de cette borne minimale -- Z3 les a choisis parce qu'a qualite fixee, plusieurs couts sont Pareto-equivalents, et le solveur en echantillonne un. C'est precisement ce que le front de Pareto revele qu'un simple « minimiser le cout » cacherait.
+Un tableau de nombres ne rend pas justice au concept de **compromis**. En projetant chaque point Pareto-optimal dans le plan (qualite, cout), le front devient une courbe descendante : chaque pas vers un cout plus bas coute de la qualite. La droite `cout_min = 2 * qualite` (la frontiere de faisabilite imposee par le modèle) apparait en pointille : on voit immediatement que certains points Pareto-optimaux sont *strictement au-dessus* de cette borne minimale -- Z3 les a choisis parce qu'a qualite fixee, plusieurs couts sont Pareto-equivalents, et le solveur en echantillonne un. C'est précisément ce que le front de Pareto revele qu'un simple « minimiser le cout » cacherait.
 
-> Le twin Python trace cette courbe avec **matplotlib** (rendu PNG). Le twin C# utilise **SVG inline** (rendu statique zero-dependance via le helper SvgChartHelper, visible sur GitHub/nbviewer/offline) -- les deux twins offrent maintenant une vraie courbe, pas un tableau de nombres.",,,,,,,,cc88108996c0053c,,,,,,,
+> Le twin Python trace cette courbe avec **matplotlib** (rendu PNG). Le twin C# utilise **SVG inline** (rendu statique zero-dépendance via le helper SvgChartHelper, visible sur GitHub/nbviewer/offline) -- les deux twins offrent maintenant une vraie courbe, pas un tableau de nombres.",,,,,,,,a90376bdfb2c4d27,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,e3af6499,code,fr,c2ab4bb72db36183,"// Visualisation SVG inline du front de Pareto : qualite (x) vs cout (y).
 // Prong-A (#3801, #6927) : rendu SVG statique zero-dependance (rend sur GitHub/nbviewer/offline).
 // Remplace le chart Plotly-CDN (#6856) dont le script externe rendait BLANC en consultation statique.
@@ -4017,11 +4017,11 @@ var series = new SvgSeries[]
 };
 display(SvgChartHelper.Overlay(""Front de Pareto : qualite vs cout"", ""qualite"", ""cout"", series));
 ",,,,,,,,c2ab4bb72db36183,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,ce51dd89,markdown,fr,1f0b0c5a0b3dbe03,"### Interpretation : front de Pareto
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,ce51dd89,markdown,fr,245e19414bcac01c,"### Interpretation : front de Pareto
 
 **Sortie obtenue** : une liste de points `(qualite, cout)` tries par cout decroissant. Chaque point est Pareto-optimal : on ne peut pas ameliorer un objectif sans degrader l'autre.
 
-| Etape | Action | Resultat |
+| Étape | Action | Résultat |
 |-------|--------|----------|
 | 1 | `opt.MkMaximize(qualite)` sans contrainte de cout | Point avec qualite maximale |
 | 2 | Ajouter `cout < cout_precedent`, re-maximiser | Point avec cout plus bas |
@@ -4030,10 +4030,10 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Cshar
 **Points cles** :
 1. Le front de Pareto contient les **compromis optimaux** : aucun point n'est domine par un autre.
 2. Le nombre de points est fini (domains entiers petits), mais peut etre grand si les ranges sont larges.
-3. Cette methode d'enumeration par exclusion successive est simple mais couteuse : a chaque iteration, on ajoute une contrainte. Pour de grands fronts, on prefere des algorithmes specialises.
+3. Cette méthode d'enumeration par exclusion successive est simple mais couteuse : a chaque itération, on ajoute une contrainte. Pour de grands fronts, on prefere des algorithmes specialises.
 
-> **Note technique** : On maintient les domains entiers **petits** (0-10 pour la qualite, 0-20 pour le cout) pour garantir que chaque appel a `opt.Check()` est quasi instantane. Avec de larges ranges de `Real`, l'enumeration du front de Pareto peut devenir prohibitive.",,,,,,,,1f0b0c5a0b3dbe03,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,38f34e16,markdown,fr,4779a05219c7141d,"## Exercice 1 : Construire un front de Pareto
+> **Note technique** : On maintient les domains entiers **petits** (0-10 pour la qualite, 0-20 pour le cout) pour garantir que chaque appel a `opt.Check()` est quasi instantane. Avec de larges ranges de `Real`, l'enumeration du front de Pareto peut devenir prohibitive.",,,,,,,,245e19414bcac01c,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,38f34e16,markdown,fr,e1bc05a80d0dd653,"## Exercice 1 : Construire un front de Pareto
 
 ### Enonce
 
@@ -4043,12 +4043,12 @@ La fonction doit retourner une liste de couples `(qualite, cout)` representant t
 
 ### Indices
 
-- `# Indice` : a chaque iteration, creez un nouvel `Optimize`, maximisez `qualite`, puis ajoutez `cout < cout_dernier_point` comme contrainte pour la prochaine iteration.
-- `# Etape 1` : initialiser `front = new List<(long,long)>()` et boucler (`for (int it = 0; it < maxIter; it++)`).
-- `# Etape 2` : dans la boucle, creer `ctx.MkOptimize()`, declarer `qualite` et `cout` avec leurs bornes.
-- `# Etape 3` : ajouter `cout >= qualite * 2` et, pour chaque point precedent, `cout < cout_prec`.
-- `# Etape 4` : `opt.MkMaximize(qualite)` puis `opt.Check()` ; si `UNSATISFIABLE`, `break`.
-- `# Etape 5` : extraire les valeurs et les ajouter a `front`.",,,,,,,,4779a05219c7141d,,,,,,,
+- `# Indice` : a chaque itération, créez un nouvel `Optimize`, maximisez `qualite`, puis ajoutez `cout < cout_dernier_point` comme contrainte pour la prochaine itération.
+- `# Étape 1` : initialiser `front = new List<(long,long)>()` et boucler (`for (int it = 0; it < maxIter; it++)`).
+- `# Étape 2` : dans la boucle, créer `ctx.MkOptimize()`, declarer `qualite` et `cout` avec leurs bornes.
+- `# Étape 3` : ajouter `cout >= qualite * 2` et, pour chaque point précédent, `cout < cout_prec`.
+- `# Étape 4` : `opt.MkMaximize(qualite)` puis `opt.Check()` ; si `UNSATISFIABLE`, `break`.
+- `# Étape 5` : extraire les valeurs et les ajouter a `front`.",,,,,,,,e1bc05a80d0dd653,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,c4028a48,code,fr,3c841ebd259164c3,"// EXERCICE 1 : Enumerer le front de Pareto (qualite vs cout).
 List<(long qualite, long cout)> ConstruireFrontPareto(Context ctx, int maxIter = 15) {
     Console.WriteLine(""Exercice 1 - a completer"");
@@ -4065,9 +4065,9 @@ List<(long qualite, long cout)> ConstruireFrontPareto(Context ctx, int maxIter =
 
 var frontEx1 = ConstruireFrontPareto(ctx);
 Console.WriteLine($""Front de Pareto : {(frontEx1 == null ? ""(a completer)"" : string.Join("", "", frontEx1))}"");",,,,,,,,3c841ebd259164c3,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,24ff66f0,markdown,fr,29ab667d3aa0097e,"## 5. Contraintes souples (soft constraints) et MaxSAT
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,24ff66f0,markdown,fr,d6e80cba81dbc7df,"## 5. Contraintes souples (soft constraints) et MaxSAT
 
-Le probleme **MaxSAT** consiste a satisfaire un **maximum** de contraintes souples quand toutes ne peuvent l'etre simultanement. C'est un cas particulier de l'approche ponderee de la section 2, ou toutes les contraintes ont le meme poids (on compte simplement le nombre de violations).
+Le problème **MaxSAT** consiste a satisfaire un **maximum** de contraintes souples quand toutes ne peuvent l'etre simultanement. C'est un cas particulier de l'approche ponderee de la section 2, ou toutes les contraintes ont le même poids (on compte simplement le nombre de violations).
 
 ### Formalisation
 
@@ -4077,9 +4077,9 @@ $$\sum_{i=1}^{k} r_i$$
 
 La valeur optimale donne le **nombre minimum de contraintes violees**.
 
-### Exemple : assignation de salles avec preferences
+### Exemple : assignation de salles avec préférences
 
-Quatre etudiants doivent etre assignes a quatre salles (une chacun). Chaque etudiant a des preferences (salle preferee). Toutes les preferences ne sont pas compatibles (deux etudiants peuvent preferer la meme salle). On veut satisfaire un **maximum** de preferences.",,,,,,,,29ab667d3aa0097e,,,,,,,
+Quatre etudiants doivent etre assignes a quatre salles (une chacun). Chaque etudiant a des préférences (salle preferee). Toutes les préférences ne sont pas compatibles (deux etudiants peuvent preferer la même salle). On veut satisfaire un **maximum** de préférences.",,,,,,,,d6e80cba81dbc7df,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,557b4e25,code,fr,74444fede50f1946,"// MaxSAT : satisfaire un maximum de preferences d'assignation de salles.
 // 4 etudiants (E0..E3), 4 salles (S0..S3). Assignation bijective.
 // Preferences (potentiellement conflictuelles) :
@@ -4132,45 +4132,45 @@ if (optMax.Check() == Status.SATISFIABLE) {
 // Variante .NET idiomatic : opt.AssertSoft(c, weight, group) automatise le schema.
 // Exemple (commente) equivalent pour E0 -> S0 :
 //   optMax.AssertSoft(ctx.MkEq(salle[0], ctx.MkInt(0)), 1u, ""prefs"");",,,,,,,,74444fede50f1946,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,4bd77675,markdown,fr,ec2901d8abddf716,"### Interpretation : MaxSAT et variables de relaxation
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,4bd77675,markdown,fr,81797ddca5c67307,"### Interpretation : MaxSAT et variables de relaxation
 
-**Sortie obtenue** : Z3 trouve une assignation qui satisfait 3 des 4 preferences. La seule violation est inevitable car E0 et E1 preferent la meme salle S0.
+**Sortie obtenue** : Z3 trouve une assignation qui satisfait 3 des 4 préférences. La seule violation est inevitable car E0 et E1 preferent la même salle S0.
 
-| Element | Implementation | Role |
+| Élément | Implementation | Rôle |
 |---------|----------------|------|
 | Contrainte dure | `ctx.MkDistinct(salle)` | Une salle par etudiant, pas de doublon |
-| Contrainte souple | `ctx.MkOr(salle[i] == pref, r_i)` | Preference violable si `r_i = True` |
+| Contrainte souple | `ctx.MkOr(salle[i] == pref, r_i)` | Préférence violable si `r_i = True` |
 | Compteur | `ctx.MkITE(r_i, 1, 0)` | Contribution unitaire au nombre de violations |
-| Objectif | `opt.MkMinimize(nb_violations)` | Maximiser le nombre de preferences satisfaites |
+| Objectif | `opt.MkMinimize(nb_violations)` | Maximiser le nombre de préférences satisfaites |
 
 **Points cles** :
-1. Le probleme MaxSAT est un cas particulier d'optimisation ponderee ou tous les poids sont egaux a 1.
+1. Le problème MaxSAT est un cas particulier d'optimisation ponderee ou tous les poids sont egaux a 1.
 2. Les variables de relaxation `Bool` sont l'outil central : elles « absorbent » les violations impossibles a eviter.
 3. `ctx.MkDistinct` impose que toutes les valeurs soient distinctes (equivalent AllDifferent).
-4. Si on avait donne des **poids differents** aux preferences, Z3 aurait privilege les preferences a poids eleve (retour a la section 2).
+4. Si on avait donne des **poids différents** aux préférences, Z3 aurait privilege les préférences a poids eleve (retour a la section 2).
 
-> **Note technique (.NET)** : `opt.AssertSoft(BoolExpr c, uint weight, string group)` est la forme native du MaxSAT pondere dans Microsoft.Z3 : les contraintes d'un meme `group` s'agregent, et Z3 minimise la somme ponderee des violations. Le codage manuel ci-dessus reste transparent ; `AssertSoft` est le raccourci idiomatique. MaxSAT est un domaine de recherche actif : Z3 utilise un algorithme de recherche dichotomique sur le nombre de violations pour converger rapidement vers l'optimum.",,,,,,,,ec2901d8abddf716,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,65befd29,markdown,fr,c189c1443efe1379,"## Exercice 2 : Satisfaire des preferences (MaxSAT)
+> **Note technique (.NET)** : `opt.AssertSoft(BoolExpr c, uint weight, string group)` est la forme native du MaxSAT pondere dans Microsoft.Z3 : les contraintes d'un même `group` s'agregent, et Z3 minimise la somme ponderee des violations. Le codage manuel ci-dessus reste transparent ; `AssertSoft` est le raccourci idiomatique. MaxSAT est un domaine de recherche actif : Z3 utilise un algorithme de recherche dichotomique sur le nombre de violations pour converger rapidement vers l'optimum.",,,,,,,,81797ddca5c67307,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,65befd29,markdown,fr,e25fd7836cf59a38,"## Exercice 2 : Satisfaire des préférences (MaxSAT)
 
 ### Enonce
 
-Ecrivez une fonction `SatisfairePreferences` qui assigne `nItems` items a `nSlots` creneaux (assignation injective : au plus un item par creneau) de facon a **maximiser** le nombre de preferences satisfaites.
+Ecrivez une fonction `SatisfairePreferences` qui assigne `nItems` items a `nSlots` creneaux (assignation injective : au plus un item par creneau) de facon a **maximiser** le nombre de préférences satisfaites.
 
-Parametres :
+Paramètres :
 - `nItems` : nombre d'items (entiers)
 - `nSlots` : nombre de creneaux disponibles
-- `preferences` : liste de couples `(item, slot_prefere)`
+- `préférences` : liste de couples `(item, slot_prefere)`
 
-Retour attendu : un couple `(assignation, nb_satisfaites)` ou `assignation` est une chaine decrivant l'assignation.
+Retour attendu : un couple `(assignation, nb_satisfaites)` ou `assignation` est une chaîne decrivant l'assignation.
 
 ### Indices
 
-- `# Indice` : pour chaque preference, creez une variable de relaxation `Bool` et ajoutez `ctx.MkOr(slot[item] == slot_pref, r)`.
-- `# Etape 1` : declarer `slot = new IntExpr[nItems]` avec bornes `[0, nSlots-1]`.
-- `# Etape 2` : contrainte dure d'injectivite : `ctx.MkDistinct(slot)` (ou equivalent si `nItems < nSlots`).
-- `# Etape 3` : pour chaque `(item, pref)`, creer `r = ctx.MkBoolConst(...)`, ajouter `ctx.MkOr(ctx.MkEq(slot[item], ctx.MkInt(pref)), r)`.
-- `# Etape 4` : minimiser la somme des `ctx.MkITE(r, 1, 0)`.
-- `# Etape 5` : extraire l'assignation et le nombre de preferences satisfaites.",,,,,,,,c189c1443efe1379,,,,,,,
+- `# Indice` : pour chaque préférence, créez une variable de relaxation `Bool` et ajoutez `ctx.MkOr(slot[item] == slot_pref, r)`.
+- `# Étape 1` : declarer `slot = new IntExpr[nItems]` avec bornes `[0, nSlots-1]`.
+- `# Étape 2` : contrainte dure d'injectivite : `ctx.MkDistinct(slot)` (ou equivalent si `nItems < nSlots`).
+- `# Étape 3` : pour chaque `(item, pref)`, créer `r = ctx.MkBoolConst(...)`, ajouter `ctx.MkOr(ctx.MkEq(slot[item], ctx.MkInt(pref)), r)`.
+- `# Étape 4` : minimiser la somme des `ctx.MkITE(r, 1, 0)`.
+- `# Étape 5` : extraire l'assignation et le nombre de préférences satisfaites.",,,,,,,,e25fd7836cf59a38,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,80b109ec,code,fr,04c6bc436d2144cb,"// EXERCICE 2 : MaxSAT - assignation d'items maximisant les preferences.
 (string assignation, int nbSatisfaites) SatisfairePreferences(Context ctx, int nItems, int nSlots, List<(int item, int slot)> preferences) {
     Console.WriteLine(""Exercice 2 - a completer"");
@@ -4187,11 +4187,11 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Cshar
 var prefsTest = new List<(int, int)> { (0, 0), (1, 0), (2, 1), (3, 1) };
 var resultat = SatisfairePreferences(ctx, 4, 4, prefsTest);
 Console.WriteLine($""Resultat MaxSAT : assignation = {resultat.assignation}, nb_satisfaites = {resultat.nbSatisfaites}"");",,,,,,,,04c6bc436d2144cb,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,b6ae0e95,markdown,fr,19b4711183b1fa7c,"## 6. Cas pratique -- allocation de budget
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,b6ae0e95,markdown,fr,5852fbdea0a6fac9,"## 6. Cas pratique -- allocation de budget
 
 Synthesisons les techniques vues (contraintes dures, contraintes souples ponderees, optimisation multi-objectif) sur un cas concret d'**allocation de budget**.
 
-### Scenario
+### Scénario
 
 Une organisation dispose d'un budget de **100 unites** a repartir entre 5 projets. Chaque projet $i$ a :
 - une **valeur unitaire** $v_i$ (gain par unite investie)
@@ -4201,7 +4201,7 @@ Une organisation dispose d'un budget de **100 unites** a repartir entre 5 projet
 Objectifs :
 1. **(Dur)** Respecter le budget total et les minimums de financement.
 2. **(Souple, pondere)** Preferer financer les projets haute priorite au-dela de leur minimum.
-3. **(Principal)** Maximiser la valeur totale.",,,,,,,,19b4711183b1fa7c,,,,,,,
+3. **(Principal)** Maximiser la valeur totale.",,,,,,,,5852fbdea0a6fac9,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,911f07e9,code,fr,9807eb86478db487,"// Allocation de budget multi-projets avec contraintes dures, souples et objectif principal.
 var optB = ctx.MkOptimize();
 // Donnees : 5 projets (nom, valeur unitaire, financement minimum, priorite)
@@ -4267,11 +4267,11 @@ if (optB.Check() == Status.SATISFIABLE) {
     Console.WriteLine($""\nCout des violations souples : {((IntNum)m.Evaluate(coutViolations)).Int64}"");
     Console.WriteLine($""Budget non utilise : {budgetTotal - totalAlloue}"");
 }",,,,,,,,9807eb86478db487,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,b138a368,markdown,fr,4dd5e4c0a1cad46d,"### Interpretation : allocation multi-objectif complete
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,b138a368,markdown,fr,0d8a06d5b219e935,"### Interpretation : allocation multi-objectif complete
 
 **Sortie obtenue** : Z3 produit une allocation qui respecte tous les minimums de financement (contraintes dures), minimise les violations de bonus prioritaire (contraintes souples), puis maximise la valeur totale. Avec 5 projets et un budget de 100, la solution minimisant les violations donne 20 unites a chaque projet (cout de violations nul).
 
-| Type de contrainte | Mecanisme Microsoft.Z3 | Effet sur la solution |
+| Type de contrainte | Mécanisme Microsoft.Z3 | Effet sur la solution |
 |--------------------|------------------------|----------------------|
 | Budget total | `ctx.MkAdd(alloc) <= 100` | Contrainte dure absolue |
 | Minimum par projet | `alloc[i] >= fin_min` | Chaque projet viable |
@@ -4280,31 +4280,31 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Cshar
 
 **Points cles** :
 1. Les contraintes dures garantissent la **faisabilite** (budget, minimums).
-2. Les contraintes souples hierarchisent les **preferences** (favoriser les projets prioritaires).
-3. L'objectif principal maximise la **valeur** une fois les preferences honorees.
+2. Les contraintes souples hierarchisent les **préférences** (favoriser les projets prioritaires).
+3. L'objectif principal maximise la **valeur** une fois les préférences honorees.
 4. L'ordre `MkMinimize` puis `MkMaximize` impose la lexicographie : les violations sont eliminees en priorite, puis la valeur est maximisee.
 
-> **Note technique** : Ce cas pratique combine les trois techniques du notebook : relaxation booleenne (section 2/5), lexicographie (section 3) et contraintes dures (NB01). C'est le pattern typique des problemes d'allocation de ressources reels.",,,,,,,,4dd5e4c0a1cad46d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,04fb99d7,markdown,fr,33dfb0903ca129e2,"## Exercice 3 : Allocation de budget avec priorites
+> **Note technique** : Ce cas pratique combine les trois techniques du notebook : relaxation booleenne (section 2/5), lexicographie (section 3) et contraintes dures (NB01). C'est le pattern typique des problemes d'allocation de ressources reels.",,,,,,,,0d8a06d5b219e935,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,04fb99d7,markdown,fr,1d5b6bd3d787b7b1,"## Exercice 3 : Allocation de budget avec priorites
 
 ### Enonce
 
 Ecrivez une fonction `AllouerBudget` qui alloue un budget fixe entre plusieurs projets pour maximiser la valeur totale, tout en respectant des contraintes de financement minimum et de priorite.
 
-Parametres :
+Paramètres :
 - `budgetTotal` : entier, budget disponible
 - `projets` : liste de tuples `(nom, valeur_unitaire, financement_min, priorite)` ou priorite 1 = haute, 2 = moyenne, 3 = basse
 
-Retour attendu : un couple `(allocations, valeur_totale)` ou `allocations` est une chaine decrivant les montants.
+Retour attendu : un couple `(allocations, valeur_totale)` ou `allocations` est une chaîne decrivant les montants.
 
 ### Indices
 
 - `# Indice` : utilisez `ctx.MkOptimize()` avec `opt.MkMaximize(valeur_totale)` et des contraintes de minimum.
-- `# Etape 1` : declarer une variable `Int` par projet avec bornes `[financement_min, budget_total]`.
-- `# Etape 2` : contrainte dure `ctx.MkAdd(allocations) <= budget_total`.
-- `# Etape 3` : (optionnel) contraintes souples : `ctx.MkOr(alloc[i] >= seuil_priorite, r_i)` avec poids selon la priorite.
-- `# Etape 4` : `valeur_totale = ctx.MkAdd(valeur_unitaire[i] * alloc[i])`, puis `opt.MkMaximize(valeur_totale)`.
-- `# Etape 5` : extraire les allocations et calculer la valeur totale.",,,,,,,,33dfb0903ca129e2,,,,,,,
+- `# Étape 1` : declarer une variable `Int` par projet avec bornes `[financement_min, budget_total]`.
+- `# Étape 2` : contrainte dure `ctx.MkAdd(allocations) <= budget_total`.
+- `# Étape 3` : (optionnel) contraintes souples : `ctx.MkOr(alloc[i] >= seuil_priorite, r_i)` avec poids selon la priorite.
+- `# Étape 4` : `valeur_totale = ctx.MkAdd(valeur_unitaire[i] * alloc[i])`, puis `opt.MkMaximize(valeur_totale)`.
+- `# Étape 5` : extraire les allocations et calculer la valeur totale.",,,,,,,,1d5b6bd3d787b7b1,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,e2c4f6f2,code,fr,c76efd73822048ac,"// EXERCICE 3 : Allocation de budget avec priorites.
 (string allocations, long valeurTotale) AllouerBudget(Context ctx, long budgetTotal, List<(string nom, int val, int finMin, int prio)> projets) {
     Console.WriteLine(""Exercice 3 - a completer"");
@@ -4323,31 +4323,31 @@ var projetsTest = new List<(string, int, int, int)> {
 };
 var resultatBudget = AllouerBudget(ctx, 80, projetsTest);
 Console.WriteLine($""Allocation optimale : {resultatBudget.allocations}, valeur = {resultatBudget.valeurTotale}"");",,,,,,,,c76efd73822048ac,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,e5fe738a,markdown,fr,7ab63e94e4cb4f91,"## Recapitulatif
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,e5fe738a,markdown,fr,4b75d9853d44436d,"## Recapitulatif
 
 Ce notebook a explore les techniques d'optimisation avancee de Z3 au-dela du simple `MkMaximize`/`MkMinimize` d'un seul objectif :
 
 | Technique | API Microsoft.Z3 | Quand l'utiliser |
 |-----------|------------------|------------------|
-| **Priorites hierarchiques** | relaxation `Bool` + `MkITE(r, poids, 0)` + `MkMinimize` | Contraintes souples avec importance differente |
+| **Priorites hiérarchiques** | relaxation `Bool` + `MkITE(r, poids, 0)` + `MkMinimize` | Contraintes souples avec importance différente |
 | **Objectifs multiples lexicographiques** | `opt.MkMaximize` puis `opt.MkMinimize` (ordre de declaration) | Priorites strictes entre objectifs (A domine B) |
 | **Front de Pareto** | Boucle `MkMaximize` + exclusion successive | Explorer tous les compromis optimaux |
-| **MaxSAT uniforme** | relaxation `Bool` + `MkMinimize(Sum(MkITE(r,1,0)))` -- ou `AssertSoft` | Satisfaire un maximum de preferences equiponderees |
+| **MaxSAT uniforme** | relaxation `Bool` + `MkMinimize(Sum(MkITE(r,1,0)))` -- ou `AssertSoft` | Satisfaire un maximum de préférences equiponderees |
 
 **Points essentiels a retenir** :
 
 1. **Variables de relaxation `Bool`** : c'est l'outil universel pour les contraintes souples. Une contrainte `ctx.MkOr(c, r)` peut etre violee si `r = True`, et on penalise cette violation dans l'objectif.
-2. **Lexicographique vs pondere** : l'optimisation lexicographique (ordre des `MkMaximize`/`MkMinimize`) impose une hierarchie stricte ; la somme ponderee permet des compromis nuances.
+2. **Lexicographique vs pondere** : l'optimisation lexicographique (ordre des `MkMaximize`/`MkMinimize`) impose une hiérarchie stricte ; la somme ponderee permet des compromis nuances.
 3. **Front de Pareto** : indispensable quand aucun ordre naturel n'existe entre objectifs. On l'enumere par exclusion successive (forcer l'autre objectif a s'ameliorer a chaque tour).
 4. **Domains petits** : pour l'enumeration du front de Pareto et les boucles d'optimisation, garder des domains entiers petits (0-20) garantit des temps de calcul raisonnables.
 5. **Pattern d'allocation** : le cas pratique (section 6) combine tous ces outils : contraintes dures (budget), contraintes souples (priorites), objectif principal (valeur). C'est le squelette de la plupart des problemes d'allocation de ressources reels.
 
-Ces techniques font de Z3 un outil puissant non seulement pour la **satisfaction** de contraintes, mais aussi pour l'**optimisation multi-criteres** -- un domaine ou la modelisation declarative brille face aux approches ad-hoc.
+Ces techniques font de Z3 un outil puissant non seulement pour la **satisfaction** de contraintes, mais aussi pour l'**optimisation multi-critères** -- un domaine ou la modelisation declarative brille face aux approches ad-hoc.
 
 ---
 
-**Parite .NET** : ce twin C# reproduit fidelement le notebook Python [Z3-Python-06-Advanced-Optimization.ipynb](Z3-Python-06-Advanced-Optimization.ipynb) avec le **meme moteur** C++ sous-jacent (Microsoft.Z3 / z3-solver). Les differences sont purement d'API : `Optimize()` -> `ctx.MkOptimize()`, `opt.add()` -> `opt.Assert()`, `opt.maximize/minimize` -> `opt.MkMaximize/MkMinimize` (retournent un `Handle` dont `.Upper`/`.Lower` donnent les bornes), et la visualisation matplotlib est remplacee par un rendu ASCII autonome. La serie Z3-Python-Csharp est maintenant complete (6/6).",,,,,,,,7ab63e94e4cb4f91,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb,nb06-title,markdown,fr,2fecd62d0e325ce7,"# Z3-Python 06 — Optimisation avancee
+**Parite .NET** : ce twin C# reproduit fidelement le notebook Python [Z3-Python-06-Advanced-Optimization.ipynb](Z3-Python-06-Advanced-Optimization.ipynb) avec le **même moteur** C++ sous-jacent (Microsoft.Z3 / z3-solver). Les différences sont purement d'API : `Optimize()` -> `ctx.MkOptimize()`, `opt.add()` -> `opt.Assert()`, `opt.maximize/minimize` -> `opt.MkMaximize/MkMinimize` (retournent un `Handle` dont `.Upper`/`.Lower` donnent les bornes), et la visualisation matplotlib est remplacée par un rendu ASCII autonome. La serie Z3-Python-Csharp est maintenant complete (6/6).",,,,,,,,4b75d9853d44436d,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb,nb06-title,markdown,fr,f670d77e1f0858be,"# Z3-Python 06 — Optimisation avancee
 
 **Navigation** : [Index](README.md) | [Index SMT](../README.md) | [Index SymbolicAI](../../README.md) | [Serie Z3 C#](../Z3-Linq2Z3/README.md) | [<< Z3-Python-03 Tactiques](Z3-Python-03-Tactics.ipynb)
 
@@ -4369,9 +4369,9 @@ A la fin de ce notebook, vous saurez :
 
 ---
 
-**Ce notebook** poursuit l'exploration de la classe `Optimize` au-dela du cas elementaire (un seul objectif vu en NB01). Les problemes reels comportent presque toujours **plusieurs objectifs contradictoires** : maximiser la qualite tout en minimisant le cout, ou satisfaire un maximum de preferences quand toutes ne peuvent l'etre simultanement. Z3 fournit pour cela les contraintes ponderees, l'optimisation multi-objectif lexicographique, et l'enumeration du front de Pareto.
+**Ce notebook** poursuit l'exploration de la classe `Optimize` au-dela du cas elementaire (un seul objectif vu en NB01). Les problemes reels comportent presque toujours **plusieurs objectifs contradictoires** : maximiser la qualite tout en minimisant le cout, ou satisfaire un maximum de préférences quand toutes ne peuvent l'etre simultanement. Z3 fournit pour cela les contraintes ponderees, l'optimisation multi-objectif lexicographique, et l'enumeration du front de Pareto.
 
-> **Kernel** : `python3` (conda Python 3 standard). Aucun kernel WSL requis.",,,,,,,,2fecd62d0e325ce7,,,,,,,
+> **Kernel** : `python3` (conda Python 3 standard). Aucun kernel WSL requis.",,,,,,,,f670d77e1f0858be,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb,nb06-imports,code,fr,0c0c357a385d26b7,"# Imports et verification de l'environnement
 # Le package pip s'appelle 'z3-solver' (et non 'z3').
 # !pip install z3-solver
@@ -4379,7 +4379,7 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb
 from z3 import *
 
 print(f""Imports OK : z3-solver version {get_version_string()}"")",,,,,,,,0c0c357a385d26b7,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb,nb06-s1-intro,markdown,fr,4b6798cc404baf0e,"## 1. Rappel et motivation — au-dela d'un seul objectif
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb,nb06-s1-intro,markdown,fr,c723ec8c482ca0ab,"## 1. Rappel et motivation — au-dela d'un seul objectif
 
 Le notebook 01 a introduit `Optimize` avec **un** objectif unique : maximiser la valeur d'un sac a dos, ou minimiser le temps de fin d'un ordonnancement. Le patron etait simple :
 
@@ -4398,27 +4398,27 @@ Dans la vraie vie, les problemes comportent plusieurs objectifs **contradictoire
 |---------|----------------------|----------------------|
 | Logistique | Qualite de service | Cout de transport |
 | Finance | Rendement | Risque |
-| Planification | Satisfaction des preferences | Cout horaire |
+| Planification | Satisfaction des préférences | Cout horaire |
 | ingenierie | Performance | Consommation energetique |
 
-On ne peut pas « maximiser A et minimiser B » simultanement de facon absolue : il faut choisir une strategie de compromis. Z3 offre trois approches complementaires :
+On ne peut pas « maximiser A et minimiser B » simultanement de facon absolue : il faut choisir une stratégie de compromis. Z3 offre trois approches complementaires :
 
-1. **Priorites hierarchiques** (section 2) : chaque contrainte souple a un poids, on minimise la somme ponderee des violations.
-2. **Objectifs multiples lexicographiques** (section 3) : on optimise les objectifs les uns apres les autres, par ordre de priorite.
+1. **Priorites hiérarchiques** (section 2) : chaque contrainte souple a un poids, on minimise la somme ponderee des violations.
+2. **Objectifs multiples lexicographiques** (section 3) : on optimise les objectifs les uns après les autres, par ordre de priorite.
 3. **Front de Pareto** (section 4) : on enumere tous les compromis optimaux pour laisser un humain decider.
 
 Le vocabulaire utile pour la suite :
 
 | Terme | Definition |
 |-------|------------|
-| **Contrainte dure** (*hard constraint*) | Doit etre satisfaite ; si impossible, le probleme est `unsat`. |
+| **Contrainte dure** (*hard constraint*) | Doit etre satisfaite ; si impossible, le problème est `unsat`. |
 | **Contrainte souple** (*soft constraint*) | Devrait etre satisfaite, mais une violation est toleree moyennant une penalite. |
-| **Poids** (*weight*) | Cout numerique attribue a la violation d'une contrainte souple. Plus le poids est eleve, plus Z3 tente de la satisfaire. |
+| **Poids** (*weight*) | Cout numérique attribue a la violation d'une contrainte souple. Plus le poids est eleve, plus Z3 tente de la satisfaire. |
 | **Solution dominee** | Il existe une autre solution strictement meilleure sur au moins un objectif, sans etre pire sur aucun autre. |
-| **Front de Pareto** | Ensemble des solutions non-dominees : les compromis optimaux. |",,,,,,,,4b6798cc404baf0e,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb,nb06-s2-intro,markdown,fr,d96f60dc7f53e1a1,"## 2. Objectifs hierarchiques avec `Optimize` et priorites
+| **Front de Pareto** | Ensemble des solutions non-dominees : les compromis optimaux. |",,,,,,,,c723ec8c482ca0ab,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb,nb06-s2-intro,markdown,fr,31f38bc3f29e867e,"## 2. Objectifs hiérarchiques avec `Optimize` et priorites
 
-La technique la plus directe pour gerer des contraintes de priorite variable consiste a introduire des **variables de relaxation booleennes**. Pour chaque contrainte souple `c_i`, on cree une variable `r_i` (un `Bool`) et on ajoute `Or(c_i, r_i)` : la contrainte peut etre violee, mais seulement si `r_i` vaut `True`. On minimise ensuite la somme ponderee des `r_i`.
+La technique la plus directe pour gerer des contraintes de priorite variable consiste a introduire des **variables de relaxation booleennes**. Pour chaque contrainte souple `c_i`, on créé une variable `r_i` (un `Bool`) et on ajoute `Or(c_i, r_i)` : la contrainte peut etre violee, mais seulement si `r_i` vaut `True`. On minimise ensuite la somme ponderee des `r_i`.
 
 ### Principe
 
@@ -4434,7 +4434,7 @@ En Z3, la fonction `If(r_i, weight_i, 0)` construit exactement l'indicateur $w_i
 
 ### Exemple : ordonnanceur avec contraintes dures et souples
 
-Trois taches doivent etre planifiees dans des fenetres temporelles. Certaines contraintes sont **imperatives** (dures), d'autres sont **souhaitees** (souples) avec des poids differents : une priorite elevee signifie que Z3 fera de son mieux pour la satisfaire.",,,,,,,,d96f60dc7f53e1a1,,,,,,,
+Trois tâches doivent etre planifiees dans des fenêtres temporelles. Certaines contraintes sont **imperatives** (dures), d'autres sont **souhaitees** (souples) avec des poids différents : une priorite elevee signifie que Z3 fera de son mieux pour la satisfaire.",,,,,,,,31f38bc3f29e867e,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb,nb06-s2-code,code,fr,bae55deefe303fb5,"# Ordonnanceur hierarchique : contraintes dures + contraintes souples ponderees.
 # Trois taches T0, T1, T2. Chaque tache i demarre a debut_i (entier >= 0)
 # et dure 1 unite de temps. Deux taches ne peuvent s'executer au meme instant.
@@ -4495,11 +4495,11 @@ if opt.check() == sat:
         statut = ""VIOLEE"" if violee else ""satisfaite""
         print(f""  [{statut:9s}] (poids {poids:2d}) {desc}"")
     print(f""\nCout total des violations : {m[cout_total].as_long()}"")",,,,,,,,bae55deefe303fb5,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb,nb06-s2-interp,markdown,fr,428043c927eeb3ac,"### Interpretation : hierarchie ponderee
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb,nb06-s2-interp,markdown,fr,c8a17f451cc2c2d6,"### Interpretation : hiérarchie ponderee
 
 **Sortie obtenue** : Z3 trouve un planning qui satisfait toutes les contraintes dures et minimise la somme ponderee des violations des contraintes souples.
 
-| Mecanisme | API Z3 | Role |
+| Mécanisme | API Z3 | Rôle |
 |-----------|--------|------|
 | Variable de relaxation | `Bool(f'r_{i}')` | Vaut `True` si la contrainte souple est violee |
 | Contrainte relachee | `Or(contrainte, r_i)` | Permet la violation via `r_i` |
@@ -4511,21 +4511,21 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb
 2. Toutes les contraintes dures sont satisfaites par construction (elles sont ajoutees avec `opt.add` sans relaxation).
 3. Le cout total obtenu est le **minimum** : aucune autre assignation ne donne une somme ponderee de violations inferieure.
 
-> **Note technique** : Le choix des poids est decisive. Un ecart de 1 entre deux poids peut basculer la solution. En pratique, on utilise souvent une echelle exponentielle (1, 2, 4, 8...) pour garantir une veritable hierarchie lexicographique approximative.",,,,,,,,428043c927eeb3ac,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb,nb06-s3-intro,markdown,fr,08be429e879a5b86,"## 3. Objectifs multiples — `maximize` vs `minimize` simultanes
+> **Note technique** : Le choix des poids est decisive. Un ecart de 1 entre deux poids peut basculer la solution. En pratique, on utilise souvent une echelle exponentielle (1, 2, 4, 8...) pour garantir une veritable hiérarchie lexicographique approximative.",,,,,,,,c8a17f451cc2c2d6,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb,nb06-s3-intro,markdown,fr,24617ec09cacbe9a,"## 3. Objectifs multiples — `maximize` vs `minimize` simultanes
 
 Un `Optimize` peut contenir **plusieurs objectifs** declares via `o.maximize(...)` et `o.minimize(...)`. Z3 resout ces objectifs de maniere **lexicographique** (par ordre de declaration) lorsqu'ils sont declares successivement : le premier objectif est optimise en priorite, puis le second est optimise sous la contrainte que le premier reste optimal.
 
 ### Lecture des bornes
 
-Chaque appel a `o.maximize(expr)` ou `o.minimize(expr)` renvoie un **handle** (un objet `Objective`). Apres `o.check()`, on peut interroger :
+Chaque appel a `o.maximize(expr)` ou `o.minimize(expr)` renvoie un **handle** (un objet `Objective`). Après `o.check()`, on peut interroger :
 
-- `o.upper(handle)` : borne superieure de l'objectif (utile apres `maximize`).
-- `o.lower(handle)` : borne inferieure de l'objectif (utile apres `minimize`).
+- `o.upper(handle)` : borne superieure de l'objectif (utile après `maximize`).
+- `o.lower(handle)` : borne inferieure de l'objectif (utile après `minimize`).
 
 ### Exemple : maximiser le revenu, puis minimiser le cout
 
-Une entreprise choisit combien d'unites produire (`q`, entier). Chaque unite generee un revenu de 8 EUR mais coute 3 EUR en production. La capacite est limitee a 15 unites. On veut **maximiser le revenu** (priorite 1), puis **minimiser le cout** (priorite 2).",,,,,,,,08be429e879a5b86,,,,,,,
+Une entreprise choisit combien d'unites produire (`q`, entier). Chaque unite generee un revenu de 8 EUR mais coute 3 EUR en production. La capacite est limitee a 15 unites. On veut **maximiser le revenu** (priorite 1), puis **minimiser le cout** (priorite 2).",,,,,,,,24617ec09cacbe9a,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb,nb06-s3-code,code,fr,93f376b586077a14,"# Optimisation multi-objectif lexicographique.
 # Objectif 1 (priorite haute) : maximiser le revenu = 8 * q
 # Objectif 2 (priorite basse) : minimiser le cout = 3 * q
@@ -4565,11 +4565,11 @@ if opt2.check() == sat:
     print(f""  q = {m2[q2].as_long()}, profit = {5 * m2[q2].as_long()} EUR"")
     print(""\nDans cet exemple les deux approches convergent (profit croissant en q),"")
     print(""mais en general lexicographique != somme ponderee."")",,,,,,,,93f376b586077a14,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb,nb06-s3-interp,markdown,fr,8fe14f964ff7147c,"### Interpretation : lexicographique vs pondere
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb,nb06-s3-interp,markdown,fr,edf8b37a2c828018,"### Interpretation : lexicographique vs pondere
 
-**Sortie obtenue** : Z3 trouve `q = 15` (capacite maximale), ce qui maximise le revenu. Le cout est ensuite minimise, mais comme `cout = 3 * q` et que `q` est deja fixe par la maximisation du revenu, le cout ne peut pas etre reduit independamment.
+**Sortie obtenue** : Z3 trouve `q = 15` (capacite maximale), ce qui maximise le revenu. Le cout est ensuite minimise, mais comme `cout = 3 * q` et que `q` est déjà fixe par la maximisation du revenu, le cout ne peut pas etre reduit independamment.
 
-| Strategie | Comment ca marche | Quand l'utiliser |
+| Stratégie | Comment ca marche | Quand l'utiliser |
 |-----------|-------------------|------------------|
 | **Lexicographique** | Optimise les objectifs dans l'ordre de declaration | Priorites claires et strictes (A domine B) |
 | **Ponderee** (section 2) | Minimise la somme ponderee des violations | Compromis souhaites entre objectifs |
@@ -4577,15 +4577,15 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb
 
 **Points cles** :
 1. `opt.upper(handle)` donne la valeur optimale d'un objectif `maximize` ; `opt.lower(handle)` pour `minimize`.
-2. L'ordre de declaration des `maximize`/`minimize` definit la **priorite lexicographique**.
-3. L'approche lexicographique n'est **pas equivalente** a maximiser une somme ponderee : elle impose une hierarchie stricte.
+2. L'ordre de declaration des `maximize`/`minimize` définit la **priorite lexicographique**.
+3. L'approche lexicographique n'est **pas equivalente** a maximiser une somme ponderee : elle impose une hiérarchie stricte.
 
-> **Note technique** : L'optimisation multi-objectif lexicographique de Z3 suit le schema Box/Wilson : optimiser l'objectif 1, fixer sa valeur optimale comme contrainte, puis optimiser l'objectif 2, et ainsi de suite.",,,,,,,,8fe14f964ff7147c,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb,nb06-s4-intro,markdown,fr,cfed192e6b065974,"## 4. Front de Pareto — explorer les compromis
+> **Note technique** : L'optimisation multi-objectif lexicographique de Z3 suit le schema Box/Wilson : optimiser l'objectif 1, fixer sa valeur optimale comme contrainte, puis optimiser l'objectif 2, et ainsi de suite.",,,,,,,,edf8b37a2c828018,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb,nb06-s4-intro,markdown,fr,683c7184df713761,"## 4. Front de Pareto — explorer les compromis
 
 Quand deux objectifs sont contradictoires et qu'aucune priorite naturelle n'existe, la notion de front de Pareto est pertinente. Une solution est dite **Pareto-optimale** si aucune autre solution ne l'ameliore sur un objectif sans la degrader sur l'autre. Le front de Pareto est l'ensemble de toutes ces solutions optimales.
 
-### Methode d'enumeration
+### Méthode d'enumeration
 
 Pour construire le front de Pareto entre maximiser $A$ et minimiser $B$ :
 
@@ -4598,7 +4598,7 @@ On obtient ainsi une suite de points $(A_1, B_1), (A_2, B_2), \ldots$ ou le cout
 
 ### Exemple : qualite vs cout
 
-On choisit un niveau de qualite `q` (0 a 10) et un niveau de cout `c`. Les deux sont lies : une qualite elevee implique un cout minimal, mais le cout peut aussi augmenter pour d'autres raisons. On cherche tous les compromis optimaux (qualite maximale, cout minimal).",,,,,,,,cfed192e6b065974,,,,,,,
+On choisit un niveau de qualite `q` (0 a 10) et un niveau de cout `c`. Les deux sont lies : une qualite elevee implique un cout minimal, mais le cout peut aussi augmenter pour d'autres raisons. On cherche tous les compromis optimaux (qualite maximale, cout minimal).",,,,,,,,683c7184df713761,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb,nb06-s4-code,code,fr,367c02cd5ab95ddb,"# Enumeration du front de Pareto : maximiser qualite (0-10), minimiser cout.
 # Modele : qualite et cout sont des entiers lies par une relation lineaire.
 # Une qualite elevee exige un cout minimal, mais le cout peut depasser ce minimum.
@@ -4699,11 +4699,11 @@ plt.show()
 
 print(f""Le front comporte {len(front)} compromis Pareto-optimaux."")
 print(""La pente descendante illustre le trade-off : baisser le coût dégrade la qualité."")",,,,,,,,62da6eba65d33ef4,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb,nb06-s4-interp,markdown,fr,5b5c330e838a45b7,"### Interpretation : front de Pareto
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb,nb06-s4-interp,markdown,fr,71c4b47d9ef0f9ba,"### Interpretation : front de Pareto
 
 **Sortie obtenue** : une liste de points `(qualite, cout)` tries par cout decroissant. Chaque point est Pareto-optimal : on ne peut pas ameliorer un objectif sans degrader l'autre.
 
-| Etape | Action | Resultat |
+| Étape | Action | Résultat |
 |-------|--------|----------|
 | 1 | `opt.maximize(qualite)` sans contrainte de cout | Point avec qualite maximale |
 | 2 | Ajouter `cout < cout_precedent`, re-maximiser | Point avec cout plus bas |
@@ -4712,10 +4712,10 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb
 **Points cles** :
 1. Le front de Pareto contient les **compromis optimaux** : aucun point n'est domine par un autre.
 2. Le nombre de points est fini (domains entiers petits), mais peut etre grand si les ranges sont larges.
-3. Cette methode d'enumeration par exclusion successive est simple mais couteuse : a chaque iteration, on ajoute une contrainte. Pour de grands fronts, on prefere des algorithmes specialises.
+3. Cette méthode d'enumeration par exclusion successive est simple mais couteuse : a chaque itération, on ajoute une contrainte. Pour de grands fronts, on prefere des algorithmes specialises.
 
-> **Note technique** : On maintient les domains entiers **petits** (0-10 pour la qualite, 0-20 pour le cout) pour garantir que chaque appel a `opt.check()` est quasi instantane. Avec de larges ranges de `Real`, l'enumeration du front de Pareto peut devenir prohibitif.",,,,,,,,5b5c330e838a45b7,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb,nb06-ex1-intro,markdown,fr,ab7772b77f4c5005,"## Exercice 1 : Construire un front de Pareto
+> **Note technique** : On maintient les domains entiers **petits** (0-10 pour la qualite, 0-20 pour le cout) pour garantir que chaque appel a `opt.check()` est quasi instantane. Avec de larges ranges de `Real`, l'enumeration du front de Pareto peut devenir prohibitif.",,,,,,,,71c4b47d9ef0f9ba,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb,nb06-ex1-intro,markdown,fr,acfe400d0bd0fb1b,"## Exercice 1 : Construire un front de Pareto
 
 ### Enonce
 
@@ -4725,12 +4725,12 @@ La fonction doit retourner une liste de couples `(qualite, cout)` representant t
 
 ### Indices
 
-- `# Indice` : a chaque iteration, creez un nouvel `Optimize`, maximisez `qualite`, puis ajoutez `cout < cout_dernier_point` comme contrainte pour la prochaine iteration.
-- `# Etape 1` : initialiser `front = []` et boucler (par exemple `for _ in range(15)`).
-- `# Etape 2` : dans la boucle, creer `opt = Optimize()`, declarer `qualite` et `cout` avec leurs bornes.
-- `# Etape 3` : ajouter `cout >= qualite * 2` et, pour chaque point precedent, `cout < cout_prec`.
-- `# Etape 4` : `opt.maximize(qualite)` puis `opt.check()` ; si `unsat`, break.
-- `# Etape 5` : extraire les valeurs et les ajouter a `front`.",,,,,,,,ab7772b77f4c5005,,,,,,,
+- `# Indice` : a chaque itération, créez un nouvel `Optimize`, maximisez `qualite`, puis ajoutez `cout < cout_dernier_point` comme contrainte pour la prochaine itération.
+- `# Étape 1` : initialiser `front = []` et boucler (par exemple `for _ in range(15)`).
+- `# Étape 2` : dans la boucle, créer `opt = Optimize()`, declarer `qualite` et `cout` avec leurs bornes.
+- `# Étape 3` : ajouter `cout >= qualite * 2` et, pour chaque point précédent, `cout < cout_prec`.
+- `# Étape 4` : `opt.maximize(qualite)` puis `opt.check()` ; si `unsat`, break.
+- `# Étape 5` : extraire les valeurs et les ajouter a `front`.",,,,,,,,acfe400d0bd0fb1b,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb,nb06-ex1-code,code,fr,4ce6030157a50aaf,"# EXERCICE 1 : Enumerer le front de Pareto (qualite vs cout).
 
 def construire_front_pareto(max_iter: int = 15) -> list:
@@ -4758,9 +4758,9 @@ def construire_front_pareto(max_iter: int = 15) -> list:
 
 front = construire_front_pareto()
 print(""Front de Pareto :"", front)",,,,,,,,4ce6030157a50aaf,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb,nb06-s5-intro,markdown,fr,47734d14f54436be,"## 5. Contraintes souples (soft constraints) et MaxSAT
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb,nb06-s5-intro,markdown,fr,ca47ff6748c2098b,"## 5. Contraintes souples (soft constraints) et MaxSAT
 
-Le probleme **MaxSAT** consiste a satisfaire un **maximum** de contraintes souples quand toutes ne peuvent l'etre simultanement. C'est un cas particulier de l'approche ponderee de la section 2, ou toutes les contraintes ont le meme poids (on compte simplement le nombre de violations).
+Le problème **MaxSAT** consiste a satisfaire un **maximum** de contraintes souples quand toutes ne peuvent l'etre simultanement. C'est un cas particulier de l'approche ponderee de la section 2, ou toutes les contraintes ont le même poids (on compte simplement le nombre de violations).
 
 ### Formalisation
 
@@ -4770,9 +4770,9 @@ $$\sum_{i=1}^{k} r_i$$
 
 La valeur optimale donne le **nombre minimum de contraintes violees**.
 
-### Exemple : assignation de salles avec preferences
+### Exemple : assignation de salles avec préférences
 
-Quatre etudiants doivent etre assignes a quatre salles (une each). Chaque etudiant a des preferences (salle preferee). Toutes les preferences ne sont pas compatibles (deux etudiants peuvent preferer la meme salle). On veut satisfaire un **maximum** de preferences.",,,,,,,,47734d14f54436be,,,,,,,
+Quatre etudiants doivent etre assignes a quatre salles (une each). Chaque etudiant a des préférences (salle preferee). Toutes les préférences ne sont pas compatibles (deux etudiants peuvent preferer la même salle). On veut satisfaire un **maximum** de préférences.",,,,,,,,ca47ff6748c2098b,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb,nb06-s5-code,code,fr,487661fac6e271c8,"# MaxSAT : satisfaire un maximum de preferences d'assignation de salles.
 # 4 etudiants (E0..E3), 4 salles (S0..S3). Assignation bijective.
 # Preferences (potentiellement conflictuelles) :
@@ -4828,45 +4828,45 @@ if opt.check() == sat:
     print(f""Violations minimales : {m[nb_violations].as_long()}"")
     print(""\nZ3 ne pouvait pas satisfaire E0 et E1 simultanement (meme preference S0)."")
     print(""Il a choisit d'en satisfaire un et sacrifie l'autre (1 violation minimum)."")",,,,,,,,487661fac6e271c8,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb,nb06-s5-interp,markdown,fr,340502a5226032c2,"### Interpretation : MaxSAT et variables de relaxation
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb,nb06-s5-interp,markdown,fr,49ff08c4e204a920,"### Interpretation : MaxSAT et variables de relaxation
 
-**Sortie obtenue** : Z3 trouve une assignation qui satisfait 3 des 4 preferences. La seule violation est inevitable car E0 et E1 prefèrent la meme salle S0.
+**Sortie obtenue** : Z3 trouve une assignation qui satisfait 3 des 4 préférences. La seule violation est inevitable car E0 et E1 prefèrent la même salle S0.
 
-| Element | Implementation | Role |
+| Élément | Implementation | Rôle |
 |---------|----------------|------|
 | Contrainte dure | `Distinct(salle)` | Une salle par etudiant, pas de doublon |
-| Contrainte souple | `Or(salle[i] == pref, r_i)` | Preference violable si `r_i = True` |
+| Contrainte souple | `Or(salle[i] == pref, r_i)` | Préférence violable si `r_i = True` |
 | Compteur | `If(r_i, 1, 0)` | Contribution unitaire au nombre de violations |
-| Objectif | `opt.minimize(nb_violations)` | Maximiser le nombre de preferences satisfaites |
+| Objectif | `opt.minimize(nb_violations)` | Maximiser le nombre de préférences satisfaites |
 
 **Points cles** :
-1. Le probleme MaxSAT est un cas particulier d'optimisation ponderee ou tous les poids sont egaux a 1.
+1. Le problème MaxSAT est un cas particulier d'optimisation ponderee ou tous les poids sont egaux a 1.
 2. Les variables de relaxation `Bool` sont l'outil central : elles « absorbent » les violations impossibles a eviter.
 3. `Distinct` est un sucre syntaxique pour `AllDifferent` : toutes les valeurs doivent etre distinctes.
-4. Si on avait donne des **poids differents** aux preferences, Z3 aurait privilege les preferences a poids eleve (retour a la section 2).
+4. Si on avait donne des **poids différents** aux préférences, Z3 aurait privilege les préférences a poids eleve (retour a la section 2).
 
-> **Note technique** : MaxSAT est un domaine de recherche actif. Z3 utilise un algorithme de recherche dichotomique sur le nombre de violations pour converger rapidement vers l'optimum.",,,,,,,,340502a5226032c2,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb,nb06-ex2-intro,markdown,fr,f994989ebbb63ee8,"## Exercice 2 : Satisfaire des preferences (MaxSAT)
+> **Note technique** : MaxSAT est un domaine de recherche actif. Z3 utilise un algorithme de recherche dichotomique sur le nombre de violations pour converger rapidement vers l'optimum.",,,,,,,,49ff08c4e204a920,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb,nb06-ex2-intro,markdown,fr,223c2f364af87b6e,"## Exercice 2 : Satisfaire des préférences (MaxSAT)
 
 ### Enonce
 
-Ecrivez une fonction `satisfaire_preferences(n_items, n_slots, preferences)` qui assigne `n_items` items a `n_slots` creneaux (assignation injective : au plus un item par creneau) de facon a **maximiser** le nombre de preferences satisfaites.
+Ecrivez une fonction `satisfaire_preferences(n_items, n_slots, préférences)` qui assigne `n_items` items a `n_slots` creneaux (assignation injective : au plus un item par creneau) de facon a **maximiser** le nombre de préférences satisfaites.
 
-Parametres :
+Paramètres :
 - `n_items` : nombre d'items (entiers)
 - `n_slots` : nombre de creneaux disponibles
-- `preferences` : liste de couples `(item, slot_prefere)`
+- `préférences` : liste de couples `(item, slot_prefere)`
 
 Retour attendu : un dictionnaire `{'assignation': {item: slot, ...}, 'nb_satisfaites': int}`.
 
 ### Indices
 
-- `# Indice` : pour chaque preference, creez une variable de relaxation `Bool` et ajoutez `Or(slot[item] == slot_pref, r)`.
-- `# Etape 1` : declarer `slot = [Int(f'slot_{i}') for i in range(n_items)]` avec bornes `[0, n_slots-1]`.
-- `# Etape 2` : contrainte dure d'injectivite : `Distinct(slot)` (ou equivalent si `n_items < n_slots`).
-- `# Etape 3` : pour chaque `(item, pref)`, creer `r = Bool(...)`, ajouter `Or(slot[item] == pref, r)`.
-- `# Etape 4` : minimiser la somme des `If(r, 1, 0)`.
-- `# Etape 5` : extraire l'assignation et le nombre de preferences satisfaites.",,,,,,,,f994989ebbb63ee8,,,,,,,
+- `# Indice` : pour chaque préférence, créez une variable de relaxation `Bool` et ajoutez `Or(slot[item] == slot_pref, r)`.
+- `# Étape 1` : declarer `slot = [Int(f'slot_{i}') for i in range(n_items)]` avec bornes `[0, n_slots-1]`.
+- `# Étape 2` : contrainte dure d'injectivite : `Distinct(slot)` (ou equivalent si `n_items < n_slots`).
+- `# Étape 3` : pour chaque `(item, pref)`, créer `r = Bool(...)`, ajouter `Or(slot[item] == pref, r)`.
+- `# Étape 4` : minimiser la somme des `If(r, 1, 0)`.
+- `# Étape 5` : extraire l'assignation et le nombre de préférences satisfaites.",,,,,,,,223c2f364af87b6e,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb,nb06-ex2-code,code,fr,7572d7125b0682f4,"# EXERCICE 2 : MaxSAT - assignation d'items maximisant les preferences.
 
 def satisfaire_preferences(n_items: int, n_slots: int, preferences: list) -> dict:
@@ -4890,11 +4890,11 @@ def satisfaire_preferences(n_items: int, n_slots: int, preferences: list) -> dic
 prefs_test = [(0, 0), (1, 0), (2, 1), (3, 1)]
 resultat = satisfaire_preferences(4, 4, prefs_test)
 print(""Resultat MaxSAT :"", resultat)",,,,,,,,7572d7125b0682f4,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb,nb06-s6-intro,markdown,fr,26bb69e5a3497ed4,"## 6. Cas pratique — allocation de budget
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb,nb06-s6-intro,markdown,fr,4a9ebbc4fda9004b,"## 6. Cas pratique — allocation de budget
 
 Synthesisons les techniques vues (contraintes dures, contraintes souples ponderees, optimisation multi-objectif) sur un cas concret d'**allocation de budget**.
 
-### Scenario
+### Scénario
 
 Une organisation dispose d'un budget de **100 unites** a repartir entre 5 projets. Chaque projet $i$ a :
 - une **valeur unitaire** $v_i$ (gain par unite investie)
@@ -4904,7 +4904,7 @@ Une organisation dispose d'un budget de **100 unites** a repartir entre 5 projet
 Objectifs :
 1. **(Dur)** Respecter le budget total et les minimums de financement.
 2. **(Souple, pondere)** Preferer financert les projets haute priorite au-dela de leur minimum.
-3. **(Principal)** Maximiser la valeur totale.",,,,,,,,26bb69e5a3497ed4,,,,,,,
+3. **(Principal)** Maximiser la valeur totale.",,,,,,,,4a9ebbc4fda9004b,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb,nb06-s6-code,code,fr,2c5b7cf421a63f6c,"# Allocation de budget multi-projets avec contraintes dures, souples et objectif principal.
 
 opt = Optimize()
@@ -4981,11 +4981,11 @@ if opt.check() == sat:
     print(f""{'TOTAL':>8} | {'':>5} | {'':>4} | {'':>4} | {total_alloue:>6} | {total_valeur:>7}"")
     print(f""\nCout des violations souples : {m[cout_violations].as_long()}"")
     print(f""Budget non utilise : {budget_total - total_alloue}"")",,,,,,,,2c5b7cf421a63f6c,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb,nb06-s6-interp,markdown,fr,df1d72ec252141fe,"### Interpretation : allocation multi-objectif complete
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb,nb06-s6-interp,markdown,fr,756fa4ec59242f29,"### Interpretation : allocation multi-objectif complete
 
 **Sortie obtenue** : Z3 produit une allocation qui respecte tous les minimums de financement (contraintes dures), minimise les violations de bonus prioritaire (contraintes souples), puis maximise la valeur totale.
 
-| Type de contrainte | Mecanisme Z3 | Effet sur la solution |
+| Type de contrainte | Mécanisme Z3 | Effet sur la solution |
 |--------------------|-------------|----------------------|
 | Budget total | `somme_alloc <= 100` | Contrainte dure absolue |
 | Minimum par projet | `alloc[i] >= fin_min` | Chaque projet viable |
@@ -4994,18 +4994,18 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb
 
 **Points cles** :
 1. Les contraintes dures garantissent la **faisabilite** (budget, minimums).
-2. Les contraintes souples hierarchisent les **preferences** (favoriser les projets prioritaires).
-3. L'objectif principal maximise la **valeur** une fois les preferences honorées.
+2. Les contraintes souples hierarchisent les **préférences** (favoriser les projets prioritaires).
+3. L'objectif principal maximise la **valeur** une fois les préférences honorées.
 4. L'ordre `minimize` puis `maximize` impose la lexicographie : les violations sont eliminees en priorite, puis la valeur est maximisee.
 
-> **Note technique** : Ce cas pratique combine les trois techniques du notebook : relaxation booleenne (section 2/5), lexicographie (section 3) et contraintes dures (NB01). C'est le pattern typique des problemes d'allocation de ressources reels.",,,,,,,,df1d72ec252141fe,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb,nb06-ex3-intro,markdown,fr,c7aa29c0e440cd5d,"## Exercice 3 : Allocation de budget avec priorites
+> **Note technique** : Ce cas pratique combine les trois techniques du notebook : relaxation booleenne (section 2/5), lexicographie (section 3) et contraintes dures (NB01). C'est le pattern typique des problemes d'allocation de ressources reels.",,,,,,,,756fa4ec59242f29,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb,nb06-ex3-intro,markdown,fr,2ee30202c37e3f79,"## Exercice 3 : Allocation de budget avec priorites
 
 ### Enonce
 
 Ecrivez une fonction `allouer_budget(budget_total, projets)` qui alloue un budget fixe entre plusieurs projets pour maximiser la valeur totale, tout en respectant des contraintes de financement minimum et de priorite.
 
-Parametres :
+Paramètres :
 - `budget_total` : entier, budget disponible
 - `projets` : liste de tuples `(nom, valeur_unitaire, financement_min, priorite)` ou priorite 1 = haute, 2 = moyenne, 3 = basse
 
@@ -5014,11 +5014,11 @@ Retour attendu : `{'allocations': {nom: montant}, 'valeur_totale': int}`.
 ### Indices
 
 - `# Indice` : utilisez `Optimize` avec `maximize(valeur_totale)` et des contraintes de minimum.
-- `# Etape 1` : declarer une variable `Int` par projet avec bornes `[financement_min, budget_total]`.
-- `# Etape 2` : contrainte dure `Sum(allocations) <= budget_total`.
-- `# Etape 3` : (optionnel) contraintes souples : `Or(alloc[i] >= seuil_priorite, r_i)` avec poids selon la priorite.
-- `# Etape 4` : `valeur_totale = Sum(valeur_unitaire[i] * alloc[i])`, puis `opt.maximize(valeur_totale)`.
-- `# Etape 5` : extraire les allocations et calculer la valeur totale.",,,,,,,,c7aa29c0e440cd5d,,,,,,,
+- `# Étape 1` : declarer une variable `Int` par projet avec bornes `[financement_min, budget_total]`.
+- `# Étape 2` : contrainte dure `Sum(allocations) <= budget_total`.
+- `# Étape 3` : (optionnel) contraintes souples : `Or(alloc[i] >= seuil_priorite, r_i)` avec poids selon la priorite.
+- `# Étape 4` : `valeur_totale = Sum(valeur_unitaire[i] * alloc[i])`, puis `opt.maximize(valeur_totale)`.
+- `# Étape 5` : extraire les allocations et calculer la valeur totale.",,,,,,,,2ee30202c37e3f79,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb,nb06-ex3-code,code,fr,d76448be3bda0266,"# EXERCICE 3 : Allocation de budget avec priorites.
 
 def allouer_budget(budget_total: int, projets: list) -> dict:
@@ -5049,27 +5049,27 @@ projets_test = [
 ]
 resultat = allouer_budget(80, projets_test)
 print(""Allocation optimale :"", resultat)",,,,,,,,d76448be3bda0266,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb,nb06-conclusion,markdown,fr,72320c3cac61904c,"## Recapitulatif
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb,nb06-conclusion,markdown,fr,d2bd2e8ae323d929,"## Recapitulatif
 
 Ce notebook a explore les techniques d'optimisation avancee de Z3 au-dela du simple `maximize`/`minimize` d'un seul objectif :
 
 | Technique | API Z3 | Quand l'utiliser |
 |-----------|--------|------------------|
-| **Priorites hierarchiques** | `Bool` relaxation + `If(r, poids, 0)` + `minimize` | Contraintes souples avec importance differente |
+| **Priorites hiérarchiques** | `Bool` relaxation + `If(r, poids, 0)` + `minimize` | Contraintes souples avec importance différente |
 | **Objectifs multiples lexicographiques** | `opt.maximize` puis `opt.minimize` (ordre de declaration) | Priorites strictes entre objectifs (A domine B) |
 | **Front de Pareto** | Boucle `maximize` + exclusion successive | Explorer tous les compromis optimaux |
-| **MaxSAT uniforme** | Relaxation `Bool` + `minimize(Sum(If(r,1,0)))` | Satisfaire un maximum de preferences equiponderees |
+| **MaxSAT uniforme** | Relaxation `Bool` + `minimize(Sum(If(r,1,0)))` | Satisfaire un maximum de préférences equiponderees |
 
 **Points essentiels a retenir** :
 
 1. **Variables de relaxation `Bool`** : c'est l'outil universel pour les contraintes souples. Une contrainte `Or(c, r)` peut etre violee si `r = True`, et on penalise cette violation dans l'objectif.
-2. **Lexicographique vs pondere** : l'optimisation lexicographique (ordre des `maximize`/`minimize`) impose une hierarchie stricte ; la somme ponderee permet des compromis nuances.
+2. **Lexicographique vs pondere** : l'optimisation lexicographique (ordre des `maximize`/`minimize`) impose une hiérarchie stricte ; la somme ponderee permet des compromis nuances.
 3. **Front de Pareto** : indispensable quand aucun ordre naturel n'existe entre objectifs. On l'enumere par exclusion successive (forcer l'autre objectif a s'ameliorer a chaque tour).
 4. **Domains petits** : pour l'enumeration du front de Pareto et les boucles d'optimisation, garder des domains entiers petits (0-20) garantit des temps de calcul raisonnables.
 5. **Pattern d'allocation** : le cas pratique (section 6) combine tous ces outils : contraintes dures (budget), contraintes souples (priorites), objectif principal (valeur). C'est le squelette de la plupart des problemes d'allocation de ressources reels.
 
-Ces techniques font de Z3 un outil puissant non seulement pour la **satisfaction** de contraintes, mais aussi pour l'**optimisation multi-criteres** — un domaine ou la modelisation declarative brille face aux approches ad-hoc.",,,,,,,,72320c3cac61904c,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-07-Style-Declaratif-Linq.ipynb,c01,markdown,fr,d0e47fe9daadd95d,"# Z3-Python 07 — Du style declaratif LINQ au solveur Z3 en Python
+Ces techniques font de Z3 un outil puissant non seulement pour la **satisfaction** de contraintes, mais aussi pour l'**optimisation multi-critères** — un domaine ou la modelisation declarative brille face aux approches ad-hoc.",,,,,,,,d2bd2e8ae323d929,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-07-Style-Declaratif-Linq.ipynb,c01,markdown,fr,53c497c1fbd8378e,"# Z3-Python 07 — Du style declaratif LINQ au solveur Z3 en Python
 
 **Navigation** : [Z3-Python-06 >>](Z3-Python-06-Advanced-Optimization.ipynb) | [Index](README.md) | [Z3 C# (Z3.Linq) ->](../Z3-Linq2Z3/README.md)
 
@@ -5079,21 +5079,21 @@ A la fin de ce notebook, vous saurez :
 1. **Reconaitre** le style declaratif de specification de contraintes (idiome LINQ `Where` / `from ... where ... select`) utilise par la serie soueur C# Z3.Linq
 2. **Traduire** cet idiome declaratif en appels imperatifs a l'API z3-py (`Solver()`, `s.add(...)`, `s.check()`, `s.model()`)
 3. **Diagnostiquer** l'insatisfiabilite (`unsat`) et extraire un **noyau d'insatisfiabilite** (unsat core) pour identifier les contraintes en conflit
-4. **Modeliser** un probleme combinatoire non-trivial (coloration de graphe) ou la puissance declarative du solveur surpasse l'ecriture manuelle d'un backtracking
+4. **Modeliser** un problème combinatoire non-trivial (coloration de graphe) ou la puissance declarative du solveur surpasse l'ecriture manuelle d'un backtracking
 
 ## Positionnement
 
-Cette serie ([Z3-Python](README.md)) utilise z3-py, le binding Python direct, en style **imperatif-symbolique** : on cree un `Solver`, on ajoute des contraintes, on appelle `check`. La serie soeur [Z3 C# (Z3.Linq)](../Z3-Linq2Z3/README.md) expose une couche **declarative** : les contraintes s'ecrivent comme des predicats LINQ, traduits automatiquement en formules SMT.
+Cette serie ([Z3-Python](README.md)) utilise z3-py, le binding Python direct, en style **imperatif-symbolique** : on créé un `Solver`, on ajoute des contraintes, on appelle `check`. La serie soeur [Z3 C# (Z3.Linq)](../Z3-Linq2Z3/README.md) expose une couche **declarative** : les contraintes s'ecrivent comme des predicats LINQ, traduits automatiquement en formules SMT.
 
-Ce notebook fait le pont : il montre que les **deux styles expriment la meme intention declarative** (decrire le QUOI, pas le COMMENT), et comment retrouver en Python la lisibilite du DSL C# sans perdre l'acces a l'API complete.",,,,,,,,d0e47fe9daadd95d,,,,,,,
+Ce notebook fait le pont : il montre que les **deux styles expriment la même intention declarative** (decrire le QUOI, pas le COMMENT), et comment retrouver en Python la lisibilite du DSL C# sans perdre l'acces a l'API complete.",,,,,,,,53c497c1fbd8378e,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-07-Style-Declaratif-Linq.ipynb,c02,code,fr,7c7c2528b90a0cc5,"# Imports et verification de l'environnement
 from z3 import *
 
 print(""Imports OK : z3-solver v"" + get_version_string())
 print(""API disponible : Solver, Optimize, Int, Bool, unsat_core, ..."")",,,,,,,,7c7c2528b90a0cc5,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-07-Style-Declaratif-Linq.ipynb,c03,markdown,fr,e26d22c74f24b086,"## 1. L'idiome declaratif LINQ (C# Z3.Linq) — reference
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-07-Style-Declaratif-Linq.ipynb,c03,markdown,fr,6d182fb6090df337,"## 1. L'idiome declaratif LINQ (C# Z3.Linq) — reference
 
-La serie C# Z3.Linq permet d'ecrire un theoreme comme une requete LINQ. Voici un exemple representatif (cellule de reference, executee dans le notebook C# `01_Linq2Z3_Intro.ipynb`) :
+La serie C# Z3.Linq permet d'ecrire un theoreme comme une requête LINQ. Voici un exemple representatif (cellule de reference, executee dans le notebook C# `01_Linq2Z3_Intro.ipynb`) :
 
 ```csharp
 using (var ctx = new Z3Context())
@@ -5110,15 +5110,15 @@ using (var ctx = new Z3Context())
 
 **Ce qui compte pedagogiquement** : chaque clause `where` est une **contrainte**. L'ordre n'importe pas, la facon dont le solveur resout n'apparait pas. C'est l'essence du **declaratif** : on decrit les relations que doivent satisfaire les inconnues, pas l'algorithme de recherche.
 
-En Python, z3-py n'a pas de sucre syntaxique equivalent au compilateur d'arbres d'expressions LINQ. On exprime donc les memes contraintes par des appels explicites a `s.add(...)`. C'est legerement plus verbeux mais tout aussi declaratif sur le fond — et on garde l'acces a l'API complete (tactiques, `Optimize`, theories avancees).",,,,,,,,e26d22c74f24b086,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-07-Style-Declaratif-Linq.ipynb,c04,markdown,fr,df3b6ebd1941b94d,"## 2. Traduction en pyz3 : un systeme SAT
+En Python, z3-py n'a pas de sucre syntaxique equivalent au compilateur d'arbres d'expressions LINQ. On exprime donc les mêmes contraintes par des appels explicites a `s.add(...)`. C'est legerement plus verbeux mais tout aussi declaratif sur le fond — et on garde l'acces a l'API complete (tactiques, `Optimize`, théories avancees).",,,,,,,,6d182fb6090df337,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-07-Style-Declaratif-Linq.ipynb,c04,markdown,fr,007055022dce5b0a,"## 2. Traduction en pyz3 : un système SAT
 
 Reproduisons en Python le theoreme ci-dessus (5 entiers `X1..X5`, 4 contraintes). Le patron d'usage z3-py :
 
-1. **Creer** un `Solver()`
+1. **Créer** un `Solver()`
 2. **Declarer** les variables typees (`Int`)
 3. **Ajouter** chaque contrainte avec `s.add(...)`
-4. **Verifier** avec `s.check()`, puis `s.model()` pour extraire un modele",,,,,,,,df3b6ebd1941b94d,,,,,,,
+4. **Verifier** avec `s.check()`, puis `s.model()` pour extraire un modèle",,,,,,,,007055022dce5b0a,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-07-Style-Declaratif-Linq.ipynb,c05,code,fr,7949e0d60e5b7622,"# Exemple 1 : theoreme a 5 entiers, 4 contraintes (port direct du theoreme LINQ ci-dessus)
 s = Solver()
 X1, X2, X3, X4, X5 = Ints('X1 X2 X3 X4 X5')
@@ -5139,7 +5139,7 @@ if resultat == sat:
         print(""  %s = %s"" % (v, val if val is not None else ""(libre, non assignee par le solveur)""))
     # X4 est libre (aucune contrainte) : le solveur ne l'assigne pas dans le modele
     print(""\nNote : X4 n'apparait dans aucune contrainte -> le modele le laisse non assigne (None)."")",,,,,,,,7949e0d60e5b7622,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-07-Style-Declaratif-Linq.ipynb,c06,markdown,fr,5aa8e04ab914135f,"### Interpretation : correspondance LINQ <-> pyz3
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-07-Style-Declaratif-Linq.ipynb,c06,markdown,fr,ff8eb941d3735551,"### Interpretation : correspondance LINQ <-> pyz3
 
 | C# Z3.Linq (declaratif) | Python z3-py (imperatif-symbolique) |
 |-------------------------|--------------------------------------|
@@ -5148,12 +5148,12 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-07-Style-Declaratif-Linq.ipynb
 | `theorem.Solve()` | `s.check()` + `s.model()` |
 | `solution.X1` | `m[X1]` |
 
-Le **contenu logique est identique** : les deux formulations declarent les memes 4 contraintes. La difference est purement syntaxique — le compilateur C# traduit l'arbre d'expression LINQ, tandis qu'en Python on ecrit les appels `s.add` explicitement. En contrepartie, z3-py nous donne acces aux tactiques, a `Optimize`, et aux theories de bas niveau que la couche LINQ n'expose pas.",,,,,,,,5aa8e04ab914135f,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-07-Style-Declaratif-Linq.ipynb,c07,markdown,fr,318b4c4ac8433053,"## 3. Diagnostiquer l'insatisfiabilite : unsat et noyau
+Le **contenu logique est identique** : les deux formulations declarent les mêmes 4 contraintes. La différence est purement syntaxique — le compilateur C# traduit l'arbre d'expression LINQ, tandis qu'en Python on ecrit les appels `s.add` explicitement. En contrepartie, z3-py nous donne acces aux tactiques, a `Optimize`, et aux théories de bas niveau que la couche LINQ n'expose pas.",,,,,,,,ff8eb941d3735551,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-07-Style-Declaratif-Linq.ipynb,c07,markdown,fr,4ee2882105b509ed,"## 3. Diagnostiquer l'insatisfiabilite : unsat et noyau
 
-Cas d'ecole : une variable doit etre a la fois `> 5` et `< 3` — c'est impossible. Le solveur repond `unsat`. Le **noyau d'insatisfiabilite** (`unsat_core`) identifie quelles contraintes, parmi un ensemble etiquete, sont responsables du conflit : c'est un outil de diagnostic indispensable sur de gros modeles.
+Cas d'école : une variable doit etre a la fois `> 5` et `< 3` — c'est impossible. Le solveur repond `unsat`. Le **noyau d'insatisfiabilite** (`unsat_core`) identifie quelles contraintes, parmi un ensemble etiquete, sont responsables du conflit : c'est un outil de diagnostic indispensable sur de gros modèles.
 
-Pour obtenir un noyau, on etiquete chaque contrainte avec un `Bool` et on utilise `assert_and_track` au lieu de `add`.",,,,,,,,318b4c4ac8433053,,,,,,,
+Pour obtenir un noyau, on etiquete chaque contrainte avec un `Bool` et on utilise `assert_and_track` au lieu de `add`.",,,,,,,,4ee2882105b509ed,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-07-Style-Declaratif-Linq.ipynb,c08,code,fr,1908554cbd5cc58a,"# Exemple 2 : systeme UNSAT + extraction du noyau d'insatisfiabilite
 s2 = Solver()
 x = Int('x')
@@ -5171,20 +5171,20 @@ if resultat == unsat:
     print(""Noyau d'insatisfiabilite :"", noyau)
     print(""-> Les contraintes etiquetees"", [str(b) for b in noyau],
           ""sont conjointement incompatibles."")",,,,,,,,1908554cbd5cc58a,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-07-Style-Declaratif-Linq.ipynb,c09,markdown,fr,6bce9ba40a593383,"### Interpretation : sat vs unsat vs unknown
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-07-Style-Declaratif-Linq.ipynb,c09,markdown,fr,7f80593f3fc5d1c2,"### Interpretation : sat vs unsat vs unknown
 
 | Reponse | Sens | Utilite du noyau |
 |---------|------|------------------|
 | `sat` | Au moins une assignation satisfait tout | `s.model()` donne un exemple |
 | `unsat` | Aucune assignation possible | `unsat_core()` localise les contraintes fautives |
-| `unknown` | Le solveur n'a pas tranche (trop dur / timeout) | Pas de noyau ; affiner le modele ou augmenter le budget |
+| `unknown` | Le solveur n'a pas tranche (trop dur / timeout) | Pas de noyau ; affiner le modèle ou augmenter le budget |
 
-Le noyau d'insatisfiabilite est l'equivalent logique d'un **message d'erreur precis** : au lieu de dire « votre modele est impossible », il pointe les contraintes (parfois 2 ou 3 parmi des centaines) qui se contredisent. Sur un probleme industriel (planning, verification), c'est ce qui rend le debuggage envisageable.",,,,,,,,6bce9ba40a593383,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-07-Style-Declaratif-Linq.ipynb,c10,markdown,fr,0c3a8a376b9632be,"## 4. Un probleme combinatoire non-trivial : coloration de graphe
+Le noyau d'insatisfiabilite est l'equivalent logique d'un **message d'erreur précis** : au lieu de dire « votre modèle est impossible », il pointe les contraintes (parfois 2 ou 3 parmi des centaines) qui se contredisent. Sur un problème industriel (planning, verification), c'est ce qui rend le debuggage envisageable.",,,,,,,,7f80593f3fc5d1c2,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-07-Style-Declaratif-Linq.ipynb,c10,markdown,fr,d0fbb3a37aae8f1f,"## 4. Un problème combinatoire non-trivial : coloration de graphe
 
-Pour montrer ou le paradigme declaratif prend tout son sens, modelisons un **vrai** probleme combinatoire : la **coloration de carte** (combien de couleurs suffisent pour que deux regions frontieres aient des couleurs differentes ?). C'est le coeur du theoreme des 4 couleurs.
+Pour montrer ou le paradigme declaratif prend tout son sens, modelisons un **vrai** problème combinatoire : la **coloration de carte** (combien de couleurs suffisent pour que deux regions frontieres aient des couleurs différentes ?). C'est le coeur du theoreme des 4 couleurs.
 
-Nous colorions la carte de l'Australie (6 etats continentaux contigus) avec **3 couleurs**. Construire un backtracking manuel pour ce probleme est fastidieux (gestion des conflits, ordre d'affectation, retour-arriere). En z3-py, on se contente de **declarer l'adjacence** et le solveur trouve une coloration valide.
+Nous colorions la carte de l'Australie (6 etats continentaux contigus) avec **3 couleurs**. Construire un backtracking manuel pour ce problème est fastidieux (gestion des conflits, ordre d'affectation, retour-arriere). En z3-py, on se contente de **declarer l'adjacence** et le solveur trouve une coloration valide.
 
 **Adjacences** (frontieres terrestres) :
 - Australie-Occidentale (WA) : NT, SA
@@ -5194,7 +5194,7 @@ Nous colorions la carte de l'Australie (6 etats continentaux contigus) avec **3 
 - Nouvelle-Galles du Sud (NSW) : SA, Q, V
 - Victoria (V) : SA, NSW
 
-(Tasmanie est insulaire, hors du graphe continental.)",,,,,,,,0c3a8a376b9632be,,,,,,,
+(Tasmanie est insulaire, hors du graphe continental.)",,,,,,,,d0fbb3a37aae8f1f,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-07-Style-Declaratif-Linq.ipynb,c11,code,fr,44a58213a10756ac,"# Exemple 3 : coloration de la carte d'Australie avec 3 couleurs
 couleurs = ['rouge', 'vert', 'bleu']                # 3 couleurs
 etats = ['WA', 'NT', 'SA', 'Q', 'NSW', 'V']
@@ -5223,16 +5223,16 @@ if resultat == sat:
     # Verification automatique : aucune paire adjacente n'a la meme couleur
     conflits = [(a, b) for a, b in adjacences if m[c[a]].as_long() == m[c[b]].as_long()]
     print(""\nVerification : %d conflit(s) adjacent(s) -> %s"" % (len(conflits), 'OK' if not conflits else 'BUG'))",,,,,,,,44a58213a10756ac,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-07-Style-Declaratif-Linq.ipynb,c12,markdown,fr,91f0225df71cf46d,"### Interpretation : pourquoi le declaratif gagne ici
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-07-Style-Declaratif-Linq.ipynb,c12,markdown,fr,c766d8fa0b7a5183,"### Interpretation : pourquoi le declaratif gagne ici
 
 Essayez d'imaginer le code **imperatif** equivalent : il faudrait choisir un ordre d'affectation des 6 etats, implementer un backtracking avec detection de conflit, gerer l'expiration des branches mortes, et esperer que l'heuristique d'ordre soit bonne. Pour 6 etats c'est faisable ; pour 60 (carte d'un grand pays avec toutes ses subdivisions), c'est un enfer de maintenance.
 
-Avec z3-py, le **meme patron** (declarer le domaine + declarer l'adjacence + `check`) resout n'importe quelle taille d'instance. Ajouter un etat = ajouter une variable et quelques contraintes d'adjacence ; l'algorithme de resolution, lui, ne change jamais. C'est le gain fondamental du paradigme declaratif : la **complexite algorithmique est deleguee au solveur**, le modele exprime seulement la structure du probleme.
+Avec z3-py, le **même patron** (declarer le domaine + declarer l'adjacence + `check`) resout n'importe quelle taille d'instance. Ajouter un etat = ajouter une variable et quelques contraintes d'adjacence ; l'algorithme de resolution, lui, ne change jamais. C'est le gain fondamental du paradigme declaratif : la **complexite algorithmique est deleguee au solveur**, le modèle exprime seulement la structure du problème.
 
-> **Lecon** : le seuil ou le declaratif surpasse l'imperatif n'est pas le nombre de variables, mais la **richesse des contraintes**. Des qu'apparait une combinaison de contraintes (adjacence + cardinalite + optimisation), ecrire un backtracking correct devient plus difficile que de declarer les contraintes.",,,,,,,,91f0225df71cf46d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-07-Style-Declaratif-Linq.ipynb,c13,markdown,fr,2158440b2f3efb89,"## 5. Exercices
+> **Lecon** : le seuil ou le declaratif surpasse l'imperatif n'est pas le nombre de variables, mais la **richesse des contraintes**. Des qu'apparait une combinaison de contraintes (adjacence + cardinalite + optimisation), ecrire un backtracking correct devient plus difficile que de declarer les contraintes.",,,,,,,,c766d8fa0b7a5183,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-07-Style-Declaratif-Linq.ipynb,c13,markdown,fr,ce912c208101c8d9,"## 5. Exercices
 
-Les trois exercices suivent les exemples ci-dessus. Chaque stub est incomplet (marque `# TODO etudiant`) : a vous d'ecrire les contraintes. Les cellules s'executent sans erreur meme non completees (elles affichent un message d'attente).
+Les trois exercices suivent les exemples ci-dessus. Chaque stub est incomplet (marque `# TODO etudiant`) : a vous d'ecrire les contraintes. Les cellules s'executent sans erreur même non completees (elles affichent un message d'attente).
 
 ### Exercice 1 — Traduire un theoreme LINQ en pyz3
 
@@ -5242,7 +5242,7 @@ where t.X1 + t.X2 == t.X3
 where t.X3 == t.X4 * 2
 where t.X1 >= 1
 ```
-**Indice** : 4 appels `s.add(...)`. N'oubliez pas les declarations `Ints(...)`. Verifiez avec `s.check()` puis affichez le modele.",,,,,,,,2158440b2f3efb89,,,,,,,
+**Indice** : 4 appels `s.add(...)`. N'oubliez pas les declarations `Ints(...)`. Verifiez avec `s.check()` puis affichez le modèle.",,,,,,,,ce912c208101c8d9,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-07-Style-Declaratif-Linq.ipynb,c14,code,fr,19f082af3f4d4c93,"# Exercice 1 : traduire le theoreme LINQ en pyz3 (etudiant)
 s_ex1 = Solver()
 # X1, X2, X3, X4 = Ints('X1 X2 X3 X4')    # TODO etudiant : declarer les variables
@@ -5250,7 +5250,7 @@ s_ex1 = Solver()
 # TODO etudiant : verifier (s_ex1.check()) et afficher le modele
 
 print(""Exercice 1 a completer : retirez les commentaires TODO et ajoutez vos contraintes."")",,,,,,,,19f082af3f4d4c93,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-07-Style-Declaratif-Linq.ipynb,c15,markdown,fr,da7df7f56891d9fe,"### Exercice 2 — Detecter un UNSAT et extraire le noyau
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-07-Style-Declaratif-Linq.ipynb,c15,markdown,fr,d9926987b4f72702,"### Exercice 2 — Detecter un UNSAT et extraire le noyau
 
 Trois contraintes sur un entier `n` :
 1. `n` est pair (`n % 2 == 0`)
@@ -5259,7 +5259,7 @@ Trois contraintes sur un entier `n` :
 
 **Indice** : ces contraintes sont conjointement insatisfiables. Utilisez `assert_and_track` avec 3 etiquettes `Bool`, puis affichez le `unsat_core`. Lequel des trois le solveur pointe-t-il (en pratique, le noyau minimal peut contenir 2 des 3 etiquettes) ?
 
-**Etape 1** : ecrivez la parite `n % 2 == 0` en arithmetique entiere Z3 (pensez a `n - 2*(n/2) == 0` ou `n % 2`).",,,,,,,,da7df7f56891d9fe,,,,,,,
+**Étape 1** : ecrivez la parite `n % 2 == 0` en arithmetique entiere Z3 (pensez a `n - 2*(n/2) == 0` ou `n % 2`).",,,,,,,,d9926987b4f72702,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-07-Style-Declaratif-Linq.ipynb,c16,code,fr,b0be630cd58e2616,"# Exercice 2 : UNSAT + noyau (etudiant)
 s_ex2 = Solver()
 # n = Int('n')                              # TODO etudiant
@@ -5270,13 +5270,13 @@ s_ex2 = Solver()
 # TODO etudiant : s_ex2.check() + s_ex2.unsat_core()
 
 print(""Exercice 2 a completer : retirez les commentaires TODO et ajoutez vos contraintes + extraction du noyau."")",,,,,,,,b0be630cd58e2616,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-07-Style-Declaratif-Linq.ipynb,c17,markdown,fr,70b49cad3cb68159,"### Exercice 3 — Complexifier le graphe (2 couleurs, instance plus petite)
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-07-Style-Declaratif-Linq.ipynb,c17,markdown,fr,70aa0cb301315c0f,"### Exercice 3 — Complexifier le graphe (2 couleurs, instance plus petite)
 
-Reprenez le modele de coloration (section 4) et repondez a la question : **la carte d'Australie est-elle 2-coloriable ?** (i.e. existe-t-il une coloration valide avec seulement 2 couleurs ?)
+Reprenez le modèle de coloration (section 4) et repondez a la question : **la carte d'Australie est-elle 2-coloriable ?** (i.e. existe-t-il une coloration valide avec seulement 2 couleurs ?)
 
-**Indice** : c'est une question de decision. Changez le domaine `{0,1,2}` en `{0,1}` et relancez `check`. Le resultat (`sat` ou `unsat`) est la reponse. Si `unsat`, cela prouve que 2 couleurs ne suffisent pas (il en faut au moins 3).
+**Indice** : c'est une question de decision. Changez le domaine `{0,1,2}` en `{0,1}` et relancez `check`. Le résultat (`sat` ou `unsat`) est la reponse. Si `unsat`, cela prouve que 2 couleurs ne suffisent pas (il en faut au moins 3).
 
-**Etape 1** : copiez la cellule de l'exemple 3, reduisez le domaine, et interpretez le verdict du solveur.",,,,,,,,70b49cad3cb68159,,,,,,,
+**Étape 1** : copiez la cellule de l'exemple 3, reduisez le domaine, et interpretez le verdict du solveur.",,,,,,,,70aa0cb301315c0f,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-07-Style-Declaratif-Linq.ipynb,c18,code,fr,d68b7a86fd676236,"# Exercice 3 : la carte d'Australie est-elle 2-coloriable ? (etudiant)
 s_ex3 = Solver()
 # c = {e: Int(e) for e in ['WA','NT','SA','Q','NSW','V']}   # TODO etudiant
@@ -5285,25 +5285,25 @@ s_ex3 = Solver()
 # TODO etudiant : s_ex3.check() et interpreter sat/unsat
 
 print(""Exercice 3 a completer : retirez les commentaires TODO, reduisez le domaine a 2 couleurs et interpretez le verdict."")",,,,,,,,d68b7a86fd676236,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-07-Style-Declaratif-Linq.ipynb,c19,markdown,fr,e8c43ddeb4a732f5,"## 6. Synthese
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-07-Style-Declaratif-Linq.ipynb,c19,markdown,fr,60a537759404bd2a,"## 6. Synthese
 
 | Concept | Cote C# (Z3.Linq) | Cote Python (z3-py) |
 |---------|-------------------|---------------------|
 | **Style** | Declaratif (LINQ `Where`/`from`) | Imperatif-symbolique (`Solver.add`) |
 | **Specification** | Arbres d'expressions compiles | Appels `s.add` explicites |
-| **Avantage** | Lisibilite proche du pseudo-code | Acces complet (tactiques, Optimize, theories) |
+| **Avantage** | Lisibilite proche du pseudo-code | Acces complet (tactiques, Optimize, théories) |
 | **Insatisfiabilite** | `theorem.Solve()` leve / retourne | `check() == unsat` + `unsat_core()` |
 
 **Ce qu'il faut retenir** :
-- Les deux styles sont **equivalents en expressivite** sur les problemes de satisfaction ; le choix est une question de lisibilite vs controle.
-- Le **noyau d'insatisfiabilite** (`unsat_core`) est l'outil de debuggage essentiel : il localise les contraintes fautives dans un modele.
+- Les deux styles sont **equivalents en expressivite** sur les problemes de satisfaction ; le choix est une question de lisibilite vs contrôle.
+- Le **noyau d'insatisfiabilite** (`unsat_core`) est l'outil de debuggage essentiel : il localise les contraintes fautives dans un modèle.
 - Le paradigme declaratif prend tout son sens sur les **problemes combinatoires** (coloration, planning, allocation) : on declare la structure, le solveur resout. La taille de l'instance n'affecte que les performances, jamais la structure du code.
 
 **Pour aller plus loin** :
 - [Z3-Python-06 — Optimisation avancee](Z3-Python-06-Advanced-Optimization.ipynb) : `Optimize`, `maximize`/`minimize`, quand la satisfaction devient optimisation sous objectifs.
 - [Z3 C# (Z3.Linq)](../Z3-Linq2Z3/README.md) : la serie soeur declarative, pour comparer les idiomes dans leur contexte natif.
-- La documentation [z3-solver (pyz3)](https://z3prover.github.io/api/html/namespacez3py.html) pour l'API complete.",,,,,,,,e8c43ddeb4a732f5,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-08-Ordonnancement.ipynb,c0,markdown,fr,b06174265d126068,"# Z3-Python-08 : Ordonnancement de taches (Job-Shop Scheduling)
+- La documentation [z3-solver (pyz3)](https://z3prover.github.io/api/html/namespacez3py.html) pour l'API complete.",,,,,,,,60a537759404bd2a,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-08-Ordonnancement.ipynb,c0,markdown,fr,9954101571ed9204,"# Z3-Python-08 : Ordonnancement de tâches (Job-Shop Scheduling)
 
 
 
@@ -5311,27 +5311,27 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-08-Ordonnancement.ipynb,c0,mar
 
 
 
-## Le probleme
+## Le problème
 
 
 
-Le **job-shop scheduling** est un probleme canonique d'optimisation combinatoire : on dispose de $m$ machines et de $n$ jobs, chaque job etant une **sequence d'operations** (une par machine) de durees donnees. On veut trouver un ordonnancement (date de debut de chaque operation) qui :
+Le **job-shop scheduling** est un problème canonique d'optimisation combinatoire : on dispose de $m$ machines et de $n$ jobs, chaque job etant une **sequence d'opérations** (une par machine) de durees données. On veut trouver un ordonnancement (date de debut de chaque opération) qui :
 
 
 
-1. **respecte l'ordre** des operations de chaque job (precedence),
+1. **respecte l'ordre** des opérations de chaque job (precedence),
 
 2. **n'utilise chaque machine qu'une fois a la fois** (exclusion disjonctive),
 
-3. **minimise le makespan** $C_{\max}$ (la date de fin de la derniere operation).
+3. **minimise le makespan** $C_{\max}$ (la date de fin de la dernière opération).
 
 
 
-Ce probleme est **NP-difficile** : il n'existe pas d'algorithme polynomial connu, et une approche gloutonne (heuristique) rate souvent l'optimum. C'est typiquement la ou un solveur SMT comme Z3 **brille** : on decrit les contraintes (precedence + exclusion) et l'objectif (minimiser $C_{\max}$), et `Optimize` trouve l'ordonnancement optimal.
+Ce problème est **NP-difficile** : il n'existe pas d'algorithme polynomial connu, et une approche gloutonne (heuristique) rate souvent l'optimum. C'est typiquement la ou un solveur SMT comme Z3 **brille** : on decrit les contraintes (precedence + exclusion) et l'objectif (minimiser $C_{\max}$), et `Optimize` trouve l'ordonnancement optimal.
 
 
 
-**Ce notebook montre** : (a) une heuristique gloutonne FIFO sous-optimale, (b) la modelisation Z3 avec la contrainte disjonctive `Or(... , ...)`, (c) l'optimum trouve par `Optimize.minimize`, et (d) un diagramme de Gantt comparant les deux. Il porte en Python l'exemple C# [11_Job_Shop_Scheduling](../Z3-Linq2Z3/11_Job_Shop_Scheduling.ipynb) de la serie sœur Z3.Linq.",,,,,,,,b06174265d126068,,,,,,,
+**Ce notebook montre** : (a) une heuristique gloutonne FIFO sous-optimale, (b) la modelisation Z3 avec la contrainte disjonctive `Or(... , ...)`, (c) l'optimum trouve par `Optimize.minimize`, et (d) un diagramme de Gantt comparant les deux. Il porte en Python l'exemple C# [11_Job_Shop_Scheduling](../Z3-Linq2Z3/11_Job_Shop_Scheduling.ipynb) de la serie sœur Z3.Linq.",,,,,,,,9954101571ed9204,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-08-Ordonnancement.ipynb,c1,code,fr,c6aea714fa823775,"# Imports : z3 (solveur SMT) + matplotlib (diagramme de Gantt).
 
 import os
@@ -5357,15 +5357,15 @@ if BATCH_MODE:
 
 
 print(""z3 version :"", z3.get_version_string())",,,,,,,,c6aea714fa823775,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-08-Ordonnancement.ipynb,c2,markdown,fr,3c9ce63954dd7926,"## Instance de reference : 3 jobs x 2 machines
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-08-Ordonnancement.ipynb,c2,markdown,fr,975aab6a7655caa7,"## Instance de reference : 3 jobs x 2 machines
 
 
 
-On encode l'instance comme un dictionnaire : chaque job est la liste ordonnee de ses operations, chaque operation etant un couple `(machine, duree)`.
+On encode l'instance comme un dictionnaire : chaque job est la liste ordonnee de ses opérations, chaque opération etant un couple `(machine, duree)`.
 
 
 
-| Job | Operation 1 | Operation 2 |
+| Job | Opération 1 | Opération 2 |
 
 |-----|-------------|-------------|
 
@@ -5377,7 +5377,7 @@ On encode l'instance comme un dictionnaire : chaque job est la liste ordonnee de
 
 
 
-Notez que J0 et J2 commencent par M0, mais J1 commence par M1 : les jobs n'ont pas tous le meme parcours.",,,,,,,,3c9ce63954dd7926,,,,,,,
+Notez que J0 et J2 commencent par M0, mais J1 commence par M1 : les jobs n'ont pas tous le même parcours.",,,,,,,,975aab6a7655caa7,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-08-Ordonnancement.ipynb,c3,code,fr,0d4ef686e9216297,"# Instance : 3 jobs x 2 machines (M0, M1).
 
 # Format : jobs[j] = [(machine, duree), (machine, duree)] dans l'ordre des operations.
@@ -5405,15 +5405,15 @@ for j in JOB_NAMES:
     parcours = "" puis "".join(f""{m}({d}h)"" for m, d in jobs[j])
 
     print(f""  {j} : {parcours}"")",,,,,,,,0d4ef686e9216297,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-08-Ordonnancement.ipynb,c4,markdown,fr,8f42edf25f416450,"## Approche gloutonne : ordonnancement FIFO
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-08-Ordonnancement.ipynb,c4,markdown,fr,79de4fd14c7cd32f,"## Approche gloutonne : ordonnancement FIFO
 
 
 
-Avant Z3, essayons une **heuristique simple** : on schedule les jobs dans l'ordre (J0, puis J1, puis J2), et pour chaque job on place chaque operation **le plus tot possible** (des que la machine est libre et que l'operation precedente du job est terminee).
+Avant Z3, essayons une **heuristique simple** : on schedule les jobs dans l'ordre (J0, puis J1, puis J2), et pour chaque job on place chaque opération **le plus tot possible** (des que la machine est libre et que l'opération précédente du job est terminee).
 
 
 
-Cette strategie FIFO est rapide mais **myope** : elle ne regarde pas plus loin que le job courant, et peut laisser une machine inutilisee la ou un autre ordre aurait mieux equilibre la charge.",,,,,,,,8f42edf25f416450,,,,,,,
+Cette stratégie FIFO est rapide mais **myope** : elle ne regarde pas plus loin que le job courant, et peut laisser une machine inutilisee la ou un autre ordre aurait mieux equilibre la charge.",,,,,,,,79de4fd14c7cd32f,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-08-Ordonnancement.ipynb,c5,code,fr,615d7fa3cf33d6b8,"def greedy_fifo(jobs, machine_names):
 
     """"""Ordonnancement glouton : schedule chaque job dans l'ordre, chaque operation ASAP.""""""
@@ -5451,23 +5451,23 @@ for j in JOB_NAMES:
     ops = "", "".join(f""{m}[{s},{s+d}]"" for m, s, d in greedy_schedule[j])
 
     print(f""  {j} : {ops}"")",,,,,,,,615d7fa3cf33d6b8,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-08-Ordonnancement.ipynb,c6,markdown,fr,57932f2dc4f8334d,"## Modelisation Z3 : variables et contraintes
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-08-Ordonnancement.ipynb,c6,markdown,fr,a18d8b20349e7e6f,"## Modelisation Z3 : variables et contraintes
 
 
 
-Le passage au declaratif. On introduit une variable entiere $s_{j,k}$ = date de debut de l'operation $k$ du job $j$, plus une variable $C_{\max}$ pour le makespan. Les contraintes se traduisent directement :
+Le passage au declaratif. On introduit une variable entiere $s_{j,k}$ = date de debut de l'opération $k$ du job $j$, plus une variable $C_{\max}$ pour le makespan. Les contraintes se traduisent directement :
 
 
 
-1. **Precedence intra-job** : l'operation $k$ commence apres la fin de l'operation $k{-}1$ :  $s_{j,k} \ge s_{j,k-1} + d_{j,k-1}$.
+1. **Precedence intra-job** : l'opération $k$ commence après la fin de l'opération $k{-}1$ :  $s_{j,k} \ge s_{j,k-1} + d_{j,k-1}$.
 
-2. **Exclusion disjonctive** (le coeur du modele) : pour deux operations $a$ et $b$ sur la **meme** machine, l'une doit finir avant que l'autre commence :  $s_a + d_a \le s_b$ **OU** $s_b + d_b \le s_a$. C'est cette disjonction `Or(...)` (non-lineaire, difficile pour un simple parcours) qui fait toute la valeur du solveur.
+2. **Exclusion disjonctive** (le coeur du modèle) : pour deux opérations $a$ et $b$ sur la **même** machine, l'une doit finir avant que l'autre commence :  $s_a + d_a \le s_b$ **OU** $s_b + d_b \le s_a$. C'est cette disjonction `Or(...)` (non-lineaire, difficile pour un simple parcours) qui fait toute la valeur du solveur.
 
 3. **Objectif** : minimiser $C_{\max} = \max_{j,k}(s_{j,k} + d_{j,k})$, via `Optimize.minimize`.
 
 
 
-La borne superieure sure $C_{\max} \le$ somme de toutes les durees (cas ou tout serait sequentialise) garantit un domaine fini au solveur.",,,,,,,,57932f2dc4f8334d,,,,,,,
+La borne superieure sure $C_{\max} \le$ somme de toutes les durees (cas ou tout serait sequentialise) garantit un domaine fini au solveur.",,,,,,,,a18d8b20349e7e6f,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-08-Ordonnancement.ipynb,c7,code,fr,6b7fe331ea5d8217,"def solve_jobshop(jobs, machine_names):
 
     """"""Modelise le job-shop en Z3 et minimise le makespan (Cmax).""""""
@@ -5551,11 +5551,11 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-08-Ordonnancement.ipynb,c7,cod
 opt_schedule, opt_cmax = solve_jobshop(jobs, MACHINES)
 
 print(f""Z3 optimal : Cmax = {opt_cmax}h  (glouton = {greedy_cmax}h, gain = {greedy_cmax - opt_cmax}h)"")",,,,,,,,6b7fe331ea5d8217,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-08-Ordonnancement.ipynb,c8,markdown,fr,7790c1478843c961,"## Resultat optimal
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-08-Ordonnancement.ipynb,c8,markdown,fr,3e4ce5907c996412,"## Résultat optimal
 
 
 
-Le solveur trouve l'ordonnancement de makespan **minimal**. Comparons le detail op par op : la ou le glouton sequentialisait trop, Z3 entrelace les jobs (une operation d'un job pendant le creux d'un autre) pour reduire le temps total.",,,,,,,,7790c1478843c961,,,,,,,
+Le solveur trouve l'ordonnancement de makespan **minimal**. Comparons le detail op par op : la ou le glouton sequentialisait trop, Z3 entrelace les jobs (une opération d'un job pendant le creux d'un autre) pour reduire le temps total.",,,,,,,,3e4ce5907c996412,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-08-Ordonnancement.ipynb,c9,code,fr,660b8243af5a2605,"print(""Comparaison glouton vs Z3 optimal :\n"")
 
 for j in JOB_NAMES:
@@ -5571,11 +5571,11 @@ for j in JOB_NAMES:
     print(f""    optimal : {o}"")
 
 print(f""\nMakespan : glouton {greedy_cmax}h -> optimal {opt_cmax}h (gain de {greedy_cmax - opt_cmax}h, {100*(greedy_cmax-opt_cmax)/greedy_cmax:.0f}%)"")",,,,,,,,660b8243af5a2605,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-08-Ordonnancement.ipynb,c10,markdown,fr,84206eaa7b87c292,"## Visualisation : diagramme de Gantt
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-08-Ordonnancement.ipynb,c10,markdown,fr,122722ef11b66cd6,"## Visualisation : diagramme de Gantt
 
 
 
-Le diagramme de Gantt rend visible la difference : chaque ligne est une machine, chaque barre coloree une operation. Le glouton (haut) laisse des trous ; l'optimal Z3 (bas) tasse les operations pour finir plus tot.",,,,,,,,84206eaa7b87c292,,,,,,,
+Le diagramme de Gantt rend visible la différence : chaque ligne est une machine, chaque barre coloree une opération. Le glouton (haut) laisse des trous ; l'optimal Z3 (bas) tasse les opérations pour finir plus tot.",,,,,,,,122722ef11b66cd6,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-08-Ordonnancement.ipynb,c11,code,fr,38a70d996c312d52,"COLORS = {""J0"": ""#4C72B0"", ""J1"": ""#DD8452"", ""J2"": ""#55A868"", ""J3"": ""#C44E52""}
 
 
@@ -5625,20 +5625,20 @@ fig.tight_layout()
 plt.show()
 
 print(""Diagramme de Gantt : glouton (haut) vs optimal (bas)."")",,,,,,,,38a70d996c312d52,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-08-Ordonnancement.ipynb,c12,markdown,fr,91bf578f6c89277d,"## Exercices
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-08-Ordonnancement.ipynb,c12,markdown,fr,8ffe6274be2de377,"## Exercices
 
 
 
-Les trois exercices suivants vous font manipuler le modele : etendre l'instance (1), ajouter une contrainte metier de deadline (2), et monter en dimension avec une troisieme machine (3). Chaque stub reutilise `solve_jobshop` defini plus haut.",,,,,,,,91bf578f6c89277d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-08-Ordonnancement.ipynb,c13,markdown,fr,e24bfafc3890e640,"### Exercice 1 -- Ajout d'un quatrieme job
+Les trois exercices suivants vous font manipuler le modèle : etendre l'instance (1), ajouter une contrainte metier de deadline (2), et monter en dimension avec une troisieme machine (3). Chaque stub reutilise `solve_jobshop` défini plus haut.",,,,,,,,8ffe6274be2de377,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-08-Ordonnancement.ipynb,c13,markdown,fr,89c9fd8f170fca44,"### Exercice 1 -- Ajout d'un quatrieme job
 
 
 
-**Objectif** : ajouter un job `J3 = [(""M1"", 1), (""M0"", 3)]` (1h sur M1 puis 3h sur M0) et re-resoudre. Observez comment le makespan optimal augmente (ou non) et comment Z3 re-entrelace les operations.
+**Objectif** : ajouter un job `J3 = [(""M1"", 1), (""M0"", 3)]` (1h sur M1 puis 3h sur M0) et re-resoudre. Observez comment le makespan optimal augmente (ou non) et comment Z3 re-entrelace les opérations.
 
 
 
-**Indices** : copiez le dict `jobs` dans `jobs_4` avec l'entree J3 supplementaire ; appelez `solve_jobshop(jobs_4, MACHINES)`.",,,,,,,,e24bfafc3890e640,,,,,,,
+**Indices** : copiez le dict `jobs` dans `jobs_4` avec l'entree J3 supplementaire ; appelez `solve_jobshop(jobs_4, MACHINES)`.",,,,,,,,89c9fd8f170fca44,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-08-Ordonnancement.ipynb,c14,code,fr,6c5e9cb82f2c1e31,"# Exercice 1 : ajoutez un quatrieme job J3 et re-resolvez.
 
 # Etape 1 : definissez jobs_4 = dict(jobs) puis jobs_4[""J3""] = [(""M1"", 1), (""M0"", 3)].
@@ -5660,15 +5660,15 @@ def resoudre_4_jobs():
 
 
 print(""Exercice 1 a completer : ajouter un 4eme job et mesurer le nouveau Cmax optimal."")",,,,,,,,6c5e9cb82f2c1e31,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-08-Ordonnancement.ipynb,c15,markdown,fr,1dd45cbd78a01ea6,"### Exercice 2 -- Contrainte d'urgence (deadline)
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-08-Ordonnancement.ipynb,c15,markdown,fr,cddc3aea966debc9,"### Exercice 2 -- Contrainte d'urgence (deadline)
 
 
 
-**Objectif** : imposer que le job `J0` termine avant $t = 7$ (deadline). Ajoutez cette contrainte au modele et verifyez que le makespan optimal augmente (la deadline force un ordonnancement moins efficace).
+**Objectif** : imposer que le job `J0` termine avant $t = 7$ (deadline). Ajoutez cette contrainte au modèle et verifyez que le makespan optimal augmente (la deadline force un ordonnancement moins efficace).
 
 
 
-**Indices** : la fin de J0 est `start[""J0""][-1] + duree_derniere_op` ; ajoutez `opt.add(... <= 7)` avant `opt.minimize`. Modifiez `solve_jobshop` ou creez une variante.",,,,,,,,1dd45cbd78a01ea6,,,,,,,
+**Indices** : la fin de J0 est `start[""J0""][-1] + duree_derniere_op` ; ajoutez `opt.add(... <= 7)` avant `opt.minimize`. Modifiez `solve_jobshop` ou créez une variante.",,,,,,,,cddc3aea966debc9,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-08-Ordonnancement.ipynb,c16,code,fr,cea8e01de160129c,"# Exercice 2 : ajoutez une deadline (J0 doit terminer avant t=7).
 
 # Indice : opt.add(start[""J0""][-1] + jobs[""J0""][-1][1] <= 7) avant opt.minimize.
@@ -5690,15 +5690,15 @@ def solve_jobshop_deadline(jobs, machine_names, deadline_j0=7):
 
 
 print(""Exercice 2 a completer : mesurer le surcout d'une deadline sur J0."")",,,,,,,,cea8e01de160129c,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-08-Ordonnancement.ipynb,c17,markdown,fr,8779e26240403b55,"### Exercice 3 -- Extension a 3 machines
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-08-Ordonnancement.ipynb,c17,markdown,fr,9982b1cd232605f3,"### Exercice 3 -- Extension a 3 machines
 
 
 
-**Objectif** : etendre l'instance a 3 machines (M0, M1, M2) avec des jobs a 3 operations chacun, et verifyez que `solve_jobshop` generalize sans modification de code (le modele est parametre par les donnees).
+**Objectif** : etendre l'instance a 3 machines (M0, M1, M2) avec des jobs a 3 opérations chacun, et verifyez que `solve_jobshop` generalize sans modification de code (le modèle est paramètre par les données).
 
 
 
-**Indices** : definissez `MACHINES_3 = [""M0"", ""M1"", ""M2""]` et des `jobs_3` ou chaque job a 3 operations sur des machines distinctes ; la fonction `solve_jobshop` gere deja le cas general.",,,,,,,,8779e26240403b55,,,,,,,
+**Indices** : definissez `MACHINES_3 = [""M0"", ""M1"", ""M2""]` et des `jobs_3` ou chaque job a 3 opérations sur des machines distinctes ; la fonction `solve_jobshop` gere déjà le cas general.",,,,,,,,9982b1cd232605f3,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-08-Ordonnancement.ipynb,c18,code,fr,eb21913c8f27705b,"# Exercice 3 : etendez l'instance a 3 machines, 3 operations par job.
 
 # Indice : MACHINES_3 = [""M0"", ""M1"", ""M2""], jobs_3 = {j: [(m1,d1),(m2,d2),(m3,d3)], ...}.
@@ -5722,7 +5722,7 @@ def resoudre_3_machines():
 
 
 print(""Exercice 3 a completer : generaliser a 3 machines et observer le temps de resolution."")",,,,,,,,eb21913c8f27705b,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-08-Ordonnancement.ipynb,c19,markdown,fr,2b22ec74d9ae7351,"## Conclusion
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-08-Ordonnancement.ipynb,c19,markdown,fr,b14a1845a89bfa8c,"## Conclusion
 
 
 
@@ -5734,16 +5734,16 @@ Le job-shop scheduling illustre le gain du **declaratif** sur une classe de prob
 
 - `Optimize.minimize` trouve le makespan **optimal** (prouvablement minimal), la ou FIFO se contente d'un ordonnancement realisable mais myope.
 
-- Le modele est **parametre par les donnees** : ajouter un job, une machine ou une deadline se fait en modifiant l'instance ou en ajoutant une contrainte, sans re-ecrire l'algorithme de resolution.
+- Le modèle est **paramètre par les données** : ajouter un job, une machine ou une deadline se fait en modifiant l'instance ou en ajoutant une contrainte, sans re-ecrire l'algorithme de resolution.
 
 
 
-**Limites** : sur de tres grandes instances (dizaines de jobs x dizaines de machines), le solveur peut devenir lent — c'est le prix de l'optimalite garantie. Dans ce cas, on combine souvent Z3 avec des heuristiques (fournir un ordonnancement glouton comme borne superieure aide le solveur a pruner).
+**Limites** : sur de très grandes instances (dizaines de jobs x dizaines de machines), le solveur peut devenir lent — c'est le prix de l'optimalite garantie. Dans ce cas, on combine souvent Z3 avec des heuristiques (fournir un ordonnancement glouton comme borne superieure aide le solveur a pruner).
 
 
 
-Suite logique : retour a la [serie Z3-Python](README.md), ou explorez la version C# [Z3.Linq](../Z3-Linq2Z3/README.md) qui aborde le meme probleme via une couche declarative LINQ.",,,,,,,,2b22ec74d9ae7351,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-09-Enigme-Einstein.ipynb,c0,markdown,fr,677e00e2a5bc68a6,"# Z3-Python-09 : L'enigme d'Einstein (Zebra puzzle)
+Suite logique : retour a la [serie Z3-Python](README.md), ou explorez la version C# [Z3.Linq](../Z3-Linq2Z3/README.md) qui aborde le même problème via une couche declarative LINQ.",,,,,,,,b14a1845a89bfa8c,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-09-Enigme-Einstein.ipynb,c0,markdown,fr,1fbe9edcfc11efff,"# Z3-Python-09 : L'enigme d'Einstein (Zebra puzzle)
 
 
 
@@ -5751,11 +5751,11 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-09-Enigme-Einstein.ipynb,c0,ma
 
 
 
-## Le probleme
+## Le problème
 
 
 
-L'**enigme d'Einstein** (ou *Zebra puzzle*) est un classique de logique : 5 maisons alignees, chacune habitee par une personne de nationalite, couleur, boisson, cigarette et animal differents. On dispose de **15 indices** (le Britannique vit dans la rouge, le Danois boit du the, la verte est a gauche de la blanche, etc.) et la question est : **qui possede le poisson ?**
+L'**enigme d'Einstein** (ou *Zebra puzzle*) est un classique de logique : 5 maisons alignees, chacune habitee par une personne de nationalite, couleur, boisson, cigarette et animal différents. On dispose de **15 indices** (le Britannique vit dans la rouge, le Danois boit du the, la verte est a gauche de la blanche, etc.) et la question est : **qui possede le poisson ?**
 
 
 
@@ -5763,7 +5763,7 @@ A la main, la resolution procede par deductions progressives sur un tableau - c'
 
 
 
-C'est typiquement la ou un solveur SMT comme Z3 **fait la difference** : on decrit les 25 variables (position de chaque valeur), le domaine, les 5 contraintes de permutation (`Distinct`) et les 15 indices, et `Solver` trouve l'unique solution en **quelques millisecondes**. Ce notebook porte en Python l'exemple C# [18_Einsteins_Riddle](../Z3-Linq2Z3/18_Einsteins_Riddle.ipynb) de la serie sœur Z3.Linq.",,,,,,,,677e00e2a5bc68a6,,,,,,,
+C'est typiquement la ou un solveur SMT comme Z3 **fait la différence** : on decrit les 25 variables (position de chaque valeur), le domaine, les 5 contraintes de permutation (`Distinct`) et les 15 indices, et `Solver` trouve l'unique solution en **quelques millisecondes**. Ce notebook porte en Python l'exemple C# [18_Einsteins_Riddle](../Z3-Linq2Z3/18_Einsteins_Riddle.ipynb) de la serie sœur Z3.Linq.",,,,,,,,1fbe9edcfc11efff,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-09-Enigme-Einstein.ipynb,c1,code,fr,f8f76161e42c177c,"# Imports : z3 (solveur SMT) + time (benchmark).
 
 import time
@@ -5773,11 +5773,11 @@ import z3
 
 
 print(""z3 version :"", z3.get_version_string())",,,,,,,,f8f76161e42c177c,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-09-Enigme-Einstein.ipynb,c2,markdown,fr,af7031c6fe1fbb14,"## Modelisation : l'encodage par position
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-09-Enigme-Einstein.ipynb,c2,markdown,fr,0a4f485945b918df,"## Modelisation : l'encodage par position
 
 
 
-L'astuce centrale consiste a **inverser le point de vue**. Au lieu de demander « quelle couleur a la maison *k* ? », on definit pour chaque valeur d'attribut une variable entiere egale a la **position** (numero de maison 0..4) ou elle se trouve :
+L'astuce centrale consiste a **inverser le point de vue**. Au lieu de demander « quelle couleur a la maison *k* ? », on définit pour chaque valeur d'attribut une variable entiere egale a la **position** (numéro de maison 0..4) ou elle se trouve :
 
 
 
@@ -5793,15 +5793,15 @@ L'astuce centrale consiste a **inverser le point de vue**. Au lieu de demander �
 
 
 
-Soit **25 variables entieres**. Les contraintes se traduisent alors tres naturellement :
+Soit **25 variables entieres**. Les contraintes se traduisent alors très naturellement :
 
 
 
 1. **Domaine** : chaque variable $\in \{0,1,2,3,4\}$.
 
-2. **Permutation** : dans chaque groupe d'attributs, les 5 positions sont deux a deux distinctes (`Distinct`) - chaque valeur occupe une maison differente.
+2. **Permutation** : dans chaque groupe d'attributs, les 5 positions sont deux a deux distinctes (`Distinct`) - chaque valeur occupe une maison différente.
 
-3. **Les 15 indices** : des egalites de position (`Brit == Red` : le Britannique et la rouge sont dans la meme maison) ou des **adjacences** (`|Blend - Cat| == 1` : le fumeur de Blend est voisin du Chat).",,,,,,,,af7031c6fe1fbb14,,,,,,,
+3. **Les 15 indices** : des egalites de position (`Brit == Red` : le Britannique et la rouge sont dans la même maison) ou des **adjacences** (`|Blend - Cat| == 1` : le fumeur de Blend est voisin du Chat).",,,,,,,,0a4f485945b918df,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-09-Enigme-Einstein.ipynb,c3,code,fr,03066141431cc50d,"def build_einstein_solver():
 
     """"""Construit le solveur Z3 de l'enigme d'Einstein (25 vars de position, 15 indices).
@@ -5883,11 +5883,11 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-09-Enigme-Einstein.ipynb,c3,co
 
 
 print(""Modele encode : 25 variables de position, 5 groupes Distinct, 15 indices."")",,,,,,,,03066141431cc50d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-09-Enigme-Einstein.ipynb,c4,markdown,fr,a2cab0431ee9a2ae,"## Resolution et temoin
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-09-Enigme-Einstein.ipynb,c4,markdown,fr,3a2c2e524f694e60,"## Resolution et temoin
 
 
 
-On appelle `s.check()` : si `sat`, on extrait le modele puis on **inverse** l'encodage par position - pour chaque maison $h \in \{0..4\}$, on cherche quelle valeur de chaque attribut y se trouve (la valeur dont la position vaut $h$). Cela reconstitue le tableau classique de la solution.",,,,,,,,a2cab0431ee9a2ae,,,,,,,
+On appelle `s.check()` : si `sat`, on extrait le modèle puis on **inverse** l'encodage par position - pour chaque maison $h \in \{0..4\}$, on cherche quelle valeur de chaque attribut y se trouve (la valeur dont la position vaut $h$). Cela reconstitue le tableau classique de la solution.",,,,,,,,3a2c2e524f694e60,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-09-Enigme-Einstein.ipynb,c5,code,fr,fb11578ccdd3a757,"# Labels francais pour l'affichage (associes au nom de variable).
 
 LABELS_FR = {
@@ -5957,15 +5957,15 @@ def solve_and_display():
 
 
 solution_model, solution_vars = solve_and_display()",,,,,,,,fb11578ccdd3a757,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-09-Enigme-Einstein.ipynb,c6,markdown,fr,4a5ae6207fbe9257,"## Interpretation
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-09-Enigme-Einstein.ipynb,c6,markdown,fr,713e5513375c67d0,"## Interpretation
 
 
 
-Z3 trouve l'unique solution en quelques millisecondes. La resolution humaine procederait par deductions progressives - on place le Norvegien en 1 (`Norwegian == 0`), le lait en 3 (`Milk == 2`), puis on propage les egalites et adjacences - mais c'est precisement ce travail de **propagation de contraintes** que le solveur automatise, sans erreur ni oubli.
+Z3 trouve l'unique solution en quelques millisecondes. La resolution humaine procederait par deductions progressives - on place le Norvegien en 1 (`Norwegian == 0`), le lait en 3 (`Milk == 2`), puis on propage les egalites et adjacences - mais c'est précisément ce travail de **propagation de contraintes** que le solveur automatise, sans erreur ni oubli.
 
 
 
-La reponse a la question « qui possede le poisson ? » tombe directement du modele extrait. Notons qu'**aucun indice ne parle du poisson** : c'est par elimination (les 4 autres animaux sont localises par les indices) que sa position se deduit.",,,,,,,,4a5ae6207fbe9257,,,,,,,
+La reponse a la question « qui possede le poisson ? » tombe directement du modèle extrait. Notons qu'**aucun indice ne parle du poisson** : c'est par elimination (les 4 autres animaux sont localises par les indices) que sa position se deduit.",,,,,,,,713e5513375c67d0,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-09-Enigme-Einstein.ipynb,c7,markdown,fr,8bdea66954b73fea,"## Approche naive vs solveur : mesurer l'ecart
 
 
@@ -6016,29 +6016,29 @@ print(f""Z3 solve temps                 : {z3_ms:.1f} ms"")
 print(f""Solution unique (UNSAT si nie) : {unique}"")
 
 print(f"" -> Z3 resout en millisecondes un espace de 2,5 milliards, et prouve l'unicite sans enumeration."")",,,,,,,,80b257c5e7198c8c,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-09-Enigme-Einstein.ipynb,c9,markdown,fr,8511ec5d43f3eb5c,"## Lecture du benchmark
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-09-Enigme-Einstein.ipynb,c9,markdown,fr,377c1959741e19eb,"## Lecture du benchmark
 
 
 
-Sur cette enigme, l'ecart est **frappant** : Z3 resout les 25 variables entrelacees en quelques millisecondes, alors que la brute force doit affronter **2,5 milliards** de combinaisons (soit plusieurs minutes meme a cadence elevee, et bien plus avec le test des 15 indices a chaque candidat).
+Sur cette enigme, l'ecart est **frappant** : Z3 resout les 25 variables entrelacees en quelques millisecondes, alors que la brute force doit affronter **2,5 milliards** de combinaisons (soit plusieurs minutes même a cadence elevee, et bien plus avec le test des 15 indices a chaque candidat).
 
 
 
-La **propagation** fait tout le travail : `Norwegian == 0` et `Milk == 2` sont des ancres imposees par les indices 9 et 8, puis les egalites de position et les adjacences reduisent les domaines restants jusqu'a ce qu'il ne reste qu'une seule combinaison coherente. C'est exactement la mecanique qu'un humain deployerait a la main sur le tableau - mais le solveur la realise sans erreur et la **prouve complete** (unicite via `unsat` sur la negation).",,,,,,,,8511ec5d43f3eb5c,,,,,,,
+La **propagation** fait tout le travail : `Norwegian == 0` et `Milk == 2` sont des ancres imposees par les indices 9 et 8, puis les egalites de position et les adjacences reduisent les domaines restants jusqu'a ce qu'il ne reste qu'une seule combinaison coherente. C'est exactement la mecanique qu'un humain deployerait a la main sur le tableau - mais le solveur la realise sans erreur et la **prouve complete** (unicite via `unsat` sur la negation).",,,,,,,,377c1959741e19eb,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-09-Enigme-Einstein.ipynb,c10,markdown,fr,6fc051499651d077,"## Exercices
 
 
 
 Les trois exercices suivants vous font reutiliser l'encodage par position et la fonction `build_einstein_solver`. Chaque stub est self-contained : redefinissez le solveur, ajustez les contraintes, puis `check()`.",,,,,,,,6fc051499651d077,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-09-Enigme-Einstein.ipynb,c11,markdown,fr,f44d24ad988e6a3c,"### Exercice 1 -- Un 16e indice : le Chat boit de l'Eau
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-09-Enigme-Einstein.ipynb,c11,markdown,fr,2153d8d9d513872c,"### Exercice 1 -- Un 16e indice : le Chat boit de l'Eau
 
 
 
-**Objectif** : ajouter l'indice `Cat == Water` (le Chat et l'Eau sont dans la meme maison) et observer si l'enigme reste satisfaisable (`sat`) ou devient contradictoire (`unsat`).
+**Objectif** : ajouter l'indice `Cat == Water` (le Chat et l'Eau sont dans la même maison) et observer si l'enigme reste satisfaisable (`sat`) ou devient contradictoire (`unsat`).
 
 
 
-**Indices** : reprenez `build_einstein_solver()`, ajoutez `s.add(v[""Cat""] == v[""Water""])` avant `check()`. Que se passe-t-il ? (Pensez a comparer avec la solution trouvee plus haut : le Chat et l'Eau y sont-ils dans la meme maison ?)",,,,,,,,f44d24ad988e6a3c,,,,,,,
+**Indices** : reprenez `build_einstein_solver()`, ajoutez `s.add(v[""Cat""] == v[""Water""])` avant `check()`. Que se passe-t-il ? (Pensez a comparer avec la solution trouvee plus haut : le Chat et l'Eau y sont-ils dans la même maison ?)",,,,,,,,2153d8d9d513872c,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-09-Enigme-Einstein.ipynb,c12,code,fr,06f33b8548fcde64,"# Exercice 1 : ajoutez l'indice Cat == Water et testez la satisfiabilite.
 
 # Etape 1 : reprenez build_einstein_solver() -> s, v, _.
@@ -6060,7 +6060,7 @@ def tester_chat_eau():
 
 
 print(""Exercice 1 a completer : ajoutez Cat == Water et testez la satisfiabilite."")",,,,,,,,06f33b8548fcde64,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-09-Enigme-Einstein.ipynb,c13,markdown,fr,a2dfb5867e19c7bb,"### Exercice 2 -- Enumerer toutes les solutions
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-09-Enigme-Einstein.ipynb,c13,markdown,fr,666df7e994079d2a,"### Exercice 2 -- Enumerer toutes les solutions
 
 
 
@@ -6068,7 +6068,7 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-09-Enigme-Einstein.ipynb,c13,m
 
 
 
-**Indices** : boucle `while s.check() == z3.sat` ; a chaque tour, comptez++, puis `s.add(z3.Or([v[n] != m[v[n]].as_long() for n in v]))` pour interdire le temoin courant et forcer une solution differente au tour suivant.",,,,,,,,a2dfb5867e19c7bb,,,,,,,
+**Indices** : boucle `while s.check() == z3.sat` ; a chaque tour, comptez++, puis `s.add(z3.Or([v[n] != m[v[n]].as_long() for n in v]))` pour interdire le temoin courant et forcer une solution différente au tour suivant.",,,,,,,,666df7e994079d2a,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-09-Enigme-Einstein.ipynb,c14,code,fr,58e873f52ed6ddf8,"# Exercice 2 : enumerer toutes les solutions par blocage iteratif.
 
 # Etape 1 : s, v, _ = build_einstein_solver().
@@ -6090,15 +6090,15 @@ def compter_solutions():
 
 
 print(""Exercice 2 a completer : enumerer toutes les solutions par blocage iteratif."")",,,,,,,,58e873f52ed6ddf8,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-09-Enigme-Einstein.ipynb,c15,markdown,fr,c7c5d9220982de51,"### Exercice 3 -- Mini-Zebra a 4 maisons / 4 attributs
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-09-Enigme-Einstein.ipynb,c15,markdown,fr,d4daecde03ab0eee,"### Exercice 3 -- Mini-Zebra a 4 maisons / 4 attributs
 
 
 
-**Objectif** : modeliser une **mini-enigme** a 4 maisons et 4 attributs (4 nationalites, 4 couleurs, 4 animaux) avec 8 indices de votre choix, et verifyez que `build_einstein_solver` se generalise (le modele est parametre par les donnees).
+**Objectif** : modeliser une **mini-enigme** a 4 maisons et 4 attributs (4 nationalites, 4 couleurs, 4 animaux) avec 8 indices de votre choix, et verifyez que `build_einstein_solver` se generalise (le modèle est paramètre par les données).
 
 
 
-**Indices** : definissez `groups_4` avec 4 valeurs par attribut, domaine `0..3`, 3 groupes `Distinct`, puis 8 indices (identites de position + adjacences) inventes. Inspirez-vous de la structure de `build_einstein_solver`.",,,,,,,,c7c5d9220982de51,,,,,,,
+**Indices** : definissez `groups_4` avec 4 valeurs par attribut, domaine `0..3`, 3 groupes `Distinct`, puis 8 indices (identites de position + adjacences) inventes. Inspirez-vous de la structure de `build_einstein_solver`.",,,,,,,,d4daecde03ab0eee,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-09-Enigme-Einstein.ipynb,c16,code,fr,8510f5cc66f6ad39,"# Exercice 3 : modelisez un mini-Zebra a 4 maisons / 4 attributs.
 
 # Indice : groups_4 = {""Nat"": [...4...], ""Couleur"": [...4...], ""Animal"": [...4...]}, domaine 0..3.
@@ -6122,7 +6122,7 @@ def resoudre_mini_zebra():
 
 
 print(""Exercice 3 a completer : modelisez un mini-Zebra a 4 maisons / 4 attributs."")",,,,,,,,8510f5cc66f6ad39,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-09-Enigme-Einstein.ipynb,c17,markdown,fr,71df149218577f56,"## Conclusion
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-09-Enigme-Einstein.ipynb,c17,markdown,fr,f97a802ac873d73e,"## Conclusion
 
 
 
@@ -6130,11 +6130,11 @@ L'enigme d'Einstein illustre le gain du **declaratif** sur une classe de problem
 
 
 
-- L'**encodage par position** (une variable entiere = position de chaque valeur) transforme un puzzle apparemment qualitatif en un systeme de contraintes arithmetiques : egalites (`Brit == Red`), adjacences (`|Blend - Cat| == 1`), permutations (`Distinct`).
+- L'**encodage par position** (une variable entiere = position de chaque valeur) transforme un puzzle apparemment qualitatif en un système de contraintes arithmetiques : egalites (`Brit == Red`), adjacences (`|Blend - Cat| == 1`), permutations (`Distinct`).
 
 - La **propagation de contraintes** resout les 25 variables entrelacees en millisecondes la ou la brute force affronte 2,5 milliards de combinaisons ; le solveur **prouve l'unicite** en niant le temoin et en observant `unsat`.
 
-- Le modele est **parametre par les donnees** : ajouter un indice, un attribut ou une maison se fait en modifiant l'instance, sans re-ecrire l'algorithme de resolution.
+- Le modèle est **paramètre par les données** : ajouter un indice, un attribut ou une maison se fait en modifiant l'instance, sans re-ecrire l'algorithme de resolution.
 
 
 
@@ -6142,7 +6142,7 @@ L'enigme d'Einstein illustre le gain du **declaratif** sur une classe de problem
 
 
 
-Suite logique : retour a la [serie Z3-Python](README.md), ou explorez la version C# [Z3.Linq](../Z3-Linq2Z3/README.md) qui aborde la meme enigme via la couche declarative LINQ.",,,,,,,,71df149218577f56,,,,,,,
+Suite logique : retour a la [serie Z3-Python](README.md), ou explorez la version C# [Z3.Linq](../Z3-Linq2Z3/README.md) qui aborde la même enigme via la couche declarative LINQ.",,,,,,,,f97a802ac873d73e,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-10-Cryptarithmetic.ipynb,90651222,markdown,fr,888a557ccd189ba4,"← [09 - Enigme d'Einstein](Z3-Python-09-Enigme-Einstein.ipynb) | [README Z3-Python](README.md)
 
 # 10. Cryptarithmes (SEND + MORE = MONEY)
@@ -6156,7 +6156,7 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-10-Cryptarithmetic.ipynb,09708
 import time
 print(""Imports OK : z3-solver (pyz3)"")
 ",,,,,,,,2beecb57800803ac,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-10-Cryptarithmetic.ipynb,85bdb816,markdown,fr,d2f961f72308f1b6,"## Modelisation : SEND + MORE = MONEY
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-10-Cryptarithmetic.ipynb,85bdb816,markdown,fr,912db3f0a8010042,"## Modelisation : SEND + MORE = MONEY
 
 On encode chaque lettre comme un entier `Int` dans `{0..9}`, on impose la **distinction globale** (`Distinct`), les têtes non nulles (`S > 0`, `M > 0`), puis l'**equation positionnelle** :
 
@@ -6166,7 +6166,7 @@ On encode chaque lettre comme un entier `Int` dans `{0..9}`, on impose la **dist
 = 10000*M + 1000*O + 100*N + 10*E + Y   (MONEY)
 ```
 
-Z3 propage ces contraintes et renvoie l'unique modele.",,,,,,,,d2f961f72308f1b6,,,,,,,
+Z3 propage ces contraintes et renvoie l'unique modèle.",,,,,,,,912db3f0a8010042,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-10-Cryptarithmetic.ipynb,7f055ad6,code,fr,074b999004feedf6,"# Cryptarithme classique : SEND + MORE = MONEY
 s = Solver()
 S, E, N, D, M, O, R, Y = Ints('S E N D M O R Y')
@@ -6200,12 +6200,12 @@ else:
     print(""  -------"")
     print(""  %5d    (%d + %d = %d, verifie = %s)"" % (money, send, more, money, send + more == money))
 ",,,,,,,,074b999004feedf6,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-10-Cryptarithmetic.ipynb,3fbc1232,markdown,fr,9f15319ee8a09fdd,"## Interpretation
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-10-Cryptarithmetic.ipynb,3fbc1232,markdown,fr,4584b2f50c06365e,"## Interpretation
 
-La solution unique est `S=9 E=5 N=6 D=7 M=1 O=0 R=8 Y=2`, soit `9567 + 1085 = 10652`. Notez le role de la **retenue** : ce n'est pas evident a l'oeil, c'est la propagation arithmetique du solveur qui la deduit automatiquement a partir de l'equation positionnelle. Aucune boucle explicite sur les retenues n'est necessaire : c'est precisement ce que Z3 fait mieux qu'un code imperatif.",,,,,,,,9f15319ee8a09fdd,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-10-Cryptarithmetic.ipynb,7f052d29,markdown,fr,600a6fd041a1f89a,"## Approche naive vs solveur : que fait la propagation ?
+La solution unique est `S=9 E=5 N=6 D=7 M=1 O=0 R=8 Y=2`, soit `9567 + 1085 = 10652`. Notez le rôle de la **retenue** : ce n'est pas evident a l'oeil, c'est la propagation arithmetique du solveur qui la deduit automatiquement a partir de l'equation positionnelle. Aucune boucle explicite sur les retenues n'est necessaire : c'est précisément ce que Z3 fait mieux qu'un code imperatif.",,,,,,,,4584b2f50c06365e,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-10-Cryptarithmetic.ipynb,7f052d29,markdown,fr,ce1e51c4b4b2516e,"## Approche naive vs solveur : que fait la propagation ?
 
-La brute force enumere tous les **arrangements** `P(10, 8) = 10!/(10-8)! = 1 814 400` candidats (8 lettres distinctes prises parmi 10 chiffres), puis teste l'equation pour chacun. Le solveur, lui, **propage** les contraintes (distinction, domaines, equation) pour eliminer en bloc des familles entieres d'affectations impossibles avant meme de les tester. Mesurons l'ecart.",,,,,,,,600a6fd041a1f89a,,,,,,,
+La brute force enumere tous les **arrangements** `P(10, 8) = 10!/(10-8)! = 1 814 400` candidats (8 lettres distinctes prises parmi 10 chiffres), puis teste l'equation pour chacun. Le solveur, lui, **propage** les contraintes (distinction, domaines, equation) pour eliminer en bloc des familles entieres d'affectations impossibles avant même de les tester. Mesurons l'ecart.",,,,,,,,ce1e51c4b4b2516e,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-10-Cryptarithmetic.ipynb,9220583f,code,fr,45d497cd51d0a7eb,"# (1) Brute force : 8 boucles imbriquees, on saute des que deux lettres coincident
 #     P(10,8) = 1 814 400 candidats distincts testes.
 nb_brute = 0
@@ -6252,12 +6252,12 @@ print(""Brute force : %d solution(s) en %.1f ms  (1 814 400 candidats testes)"" 
 print(""Z3 solve    : %d solution(s) en %.1f ms  (propagation de contraintes)"" % (nb_z3, t_z3 * 1000))
 print("" -> meme resultat (%s), strategies differentes."" % (nb_brute == nb_z3))
 ",,,,,,,,45d497cd51d0a7eb,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-10-Cryptarithmetic.ipynb,b72a6b7a,markdown,fr,ca65fb49678dfec6,"## Lecture du benchmark
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-10-Cryptarithmetic.ipynb,b72a6b7a,markdown,fr,c586901cac5785d6,"## Lecture du benchmark
 
-L'ecart est net : la brute force teste **1 814 400** affectations pour trouver l'unique solution, tandis que Z3 la trouve en quelques millisecondes via propagation. Ce n'est pas une question de vitesse brute du langage : c'est la **nature de la recherche**. Le solveur ne << teste >> pas, il **deduit** - les contraintes `Distinct` et l'equation positionnelle reduisent l'espace avant tout branchement. C'est l'interet pedagogique central : sur un probleme combinatoire, declarer les contraintes bat l'enumeration imperative.",,,,,,,,ca65fb49678dfec6,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-10-Cryptarithmetic.ipynb,6743519e,markdown,fr,dbf81171f79fd5ee,"## Variante : CROSS + ROADS = DANGER (9 lettres distinctes)
+L'ecart est net : la brute force teste **1 814 400** affectations pour trouver l'unique solution, tandis que Z3 la trouve en quelques millisecondes via propagation. Ce n'est pas une question de vitesse brute du langage : c'est la **nature de la recherche**. Le solveur ne << teste >> pas, il **deduit** - les contraintes `Distinct` et l'equation positionnelle reduisent l'espace avant tout branchement. C'est l'intérêt pedagogique central : sur un problème combinatoire, declarer les contraintes bat l'enumeration imperative.",,,,,,,,c586901cac5785d6,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-10-Cryptarithmetic.ipynb,6743519e,markdown,fr,2b9651c2b6eaf981,"## Variante : CROSS + ROADS = DANGER (9 lettres distinctes)
 
-On complique : 9 lettres distinctes (`C, R, O, S, A, D, N, G, E`), trois têtes non nulles (`C`, `R`, `D`), et une equation a 6 chiffres en resultats. La brute force devrait enumerer `P(10, 9) = 3 628 800` candidats - le solveur reste instantane.",,,,,,,,dbf81171f79fd5ee,,,,,,,
+On complique : 9 lettres distinctes (`C, R, O, S, A, D, N, G, E`), trois têtes non nulles (`C`, `R`, `D`), et une equation a 6 chiffres en résultats. La brute force devrait enumerer `P(10, 9) = 3 628 800` candidats - le solveur reste instantane.",,,,,,,,2b9651c2b6eaf981,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-10-Cryptarithmetic.ipynb,8c126054,code,fr,e1423de6e2d7f2b2,"# Variante : CROSS + ROADS = DANGER (9 lettres distinctes)
 s3 = Solver()
 C, R, O, S, A, D, N, G, E = Ints('C R O S A D N G E')
@@ -6290,16 +6290,16 @@ else:
     print(""CROSS=%d  ROADS=%d  DANGER=%d   (%d + %d = %d, egal a DANGER = %d : %s)"" %
           (cross, roads, danger, cross, roads, cross + roads, danger, cross + roads == danger))
 ",,,,,,,,e1423de6e2d7f2b2,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-10-Cryptarithmetic.ipynb,c87f83f3,markdown,fr,bc8c217070fb4734,"## Exercices
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-10-Cryptarithmetic.ipynb,c87f83f3,markdown,fr,f3d31166e61a1fb9,"## Exercices
 
-Les trois exercices ci-dessous vous font manipuler l'encodage des cryptarithmes (domaine, distinction, equation positionnelle) sur des variantes classiques. Ils progressent du modelisation d'une nouvelle equation (1), a l'enumeration complete des solutions (2), puis a la generalisation a la multiplication (3). Chaque stub est self-contained : les fonctions utilitaires (`Solver`, `Ints`, `Distinct`) sont definies dans les sections precedentes.",,,,,,,,bc8c217070fb4734,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-10-Cryptarithmetic.ipynb,868d2a3a,markdown,fr,2066d85fa17bc362,"### Exercice 1 - DONALD + GERALD = ROBERT
+Les trois exercices ci-dessous vous font manipuler l'encodage des cryptarithmes (domaine, distinction, equation positionnelle) sur des variantes classiques. Ils progressent du modelisation d'une nouvelle equation (1), a l'enumeration complete des solutions (2), puis a la generalisation a la multiplication (3). Chaque stub est self-contained : les fonctions utilitaires (`Solver`, `Ints`, `Distinct`) sont définies dans les sections précédentes.",,,,,,,,f3d31166e61a1fb9,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-10-Cryptarithmetic.ipynb,868d2a3a,markdown,fr,96f07e97777ac772,"### Exercice 1 - DONALD + GERALD = ROBERT
 
 Modelisez le cryptarithme `DONALD + GERALD = ROBERT` (10 lettres distinctes : D, O, N, A, L, G, E, R, B, T).
 
 
 
-**Etapes** :
+**Étapes** :
 
 1. Variables `Ints` pour les 10 lettres, domaine `{0..9}`.
 
@@ -6317,7 +6317,7 @@ Modelisez le cryptarithme `DONALD + GERALD = ROBERT` (10 lettres distinctes : D,
 
 
 
-**Indice** : notez que `L` apparait deux fois dans DONALD (unite et dizaine) et `R` deux fois dans ROBERT - le solveur s'en occupe, il suffit d'ecrire l'equation positionnelle correcte.",,,,,,,,2066d85fa17bc362,,,,,,,
+**Indice** : notez que `L` apparait deux fois dans DONALD (unite et dizaine) et `R` deux fois dans ROBERT - le solveur s'en occupe, il suffit d'ecrire l'equation positionnelle correcte.",,,,,,,,96f07e97777ac772,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-10-Cryptarithmetic.ipynb,377db765,code,fr,ac568c35c32fa60c,"# Exercice 1 : DONALD + GERALD = ROBERT
 # TODO etudiant :
 # Etape 1 : D, O, N, A, L, G, E, R, B, T = Ints('D O N A L G E R B T')
@@ -6328,20 +6328,20 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-10-Cryptarithmetic.ipynb,377db
 result = None  # TODO etudiant
 print(""Exercice 1 a completer : modelisez DONALD + GERALD = ROBERT avec Z3"")
 ",,,,,,,,ac568c35c32fa60c,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-10-Cryptarithmetic.ipynb,486d7848,markdown,fr,ca4d3e9e0731d8b9,"### Exercice 2 - Verifier l'unicite de la solution
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-10-Cryptarithmetic.ipynb,486d7848,markdown,fr,6899357953d69961,"### Exercice 2 - Verifier l'unicite de la solution
 
 Combien de solutions admet `SEND + MORE = MONEY` ? On sait qu'il y en a au moins une (cellule 3). Pour **prouver l'unicite**, on ajoute une contrainte qui **nie** la solution trouvee et on re-teste : si `unsat`, la solution etait unique.
 
 
 
-**Etapes** :
+**Étapes** :
 
-1. Re-resoudre `SEND + MORE = MONEY`, recupere le modele `m`.
+1. Re-resoudre `SEND + MORE = MONEY`, recupere le modèle `m`.
 
 2. Ajouter la contrainte de negation : `Or(S != m[S], E != m[E], ...)` (au moins une lettre differe).
 
-3. Re-checker : si `unsat` -> unique ; si `sat` -> il existe une autre solution (compter par iteration).
-",,,,,,,,ca4d3e9e0731d8b9,,,,,,,
+3. Re-checker : si `unsat` -> unique ; si `sat` -> il existe une autre solution (compter par itération).
+",,,,,,,,6899357953d69961,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-10-Cryptarithmetic.ipynb,14722545,code,fr,93e7598e0a7e5f75,"# Exercice 2 : prouver l'unicite de SEND + MORE = MONEY
 # TODO etudiant :
 # 1. Re-resoudre, recuperer le modele m
@@ -6350,13 +6350,13 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-10-Cryptarithmetic.ipynb,14722
 nb_solutions = None  # TODO etudiant
 print(""Exercice 2 a completer : prouvez l'unicite (ou enumerez toutes les solutions)"")
 ",,,,,,,,93e7598e0a7e5f75,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-10-Cryptarithmetic.ipynb,c0e4fef0,markdown,fr,32a73049ba760a55,"### Exercice 3 - Cryptarithme avec produit (multiplication)
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-10-Cryptarithmetic.ipynb,c0e4fef0,markdown,fr,d37e65dcc2743270,"### Exercice 3 - Cryptarithme avec produit (multiplication)
 
 Generalisez a la **multiplication** : `ABC * D = DBC`, ou `ABC = 100*A + 10*B + C` et `DBC = 100*D + 10*B + C`.
 
 
 
-**Etapes** :
+**Étapes** :
 
 1. Variables `A, B, C, D = Ints('A B C D')`, domaine `{0..9}`.
 
@@ -6366,7 +6366,7 @@ Generalisez a la **multiplication** : `ABC * D = DBC`, ou `ABC = 100*A + 10*B + 
 
 
 
-**Indice** : c'est la meme structure que l'addition, mais l'operateur `*` remplace `+`. Z3 traite les deux aussi bien (theorie arithmetique lineaire + non-lineaire).",,,,,,,,32a73049ba760a55,,,,,,,
+**Indice** : c'est la même structure que l'addition, mais l'opérateur `*` remplace `+`. Z3 traite les deux aussi bien (théorie arithmetique lineaire + non-lineaire).",,,,,,,,d37e65dcc2743270,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-10-Cryptarithmetic.ipynb,2cc43e56,code,fr,a925754655ed2fa4,"# Exercice 3 : ABC * D = DBC (multiplication)
 # TODO etudiant :
 # 1. A, B, C, D = Ints('A B C D'), domaine 0..9
@@ -6375,22 +6375,22 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-10-Cryptarithmetic.ipynb,2cc43
 result = None  # TODO etudiant
 print(""Exercice 3 a completer : modelisez ABC * D = DBC"")
 ",,,,,,,,a925754655ed2fa4,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-10-Cryptarithmetic.ipynb,b2c87944,markdown,fr,6ac6b88297f00f0a,"## Conclusion
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-10-Cryptarithmetic.ipynb,b2c87944,markdown,fr,da08c5e7cc89af9c,"## Conclusion
 
 Les cryptarithmes illustrent un avantage central du **paradigme declaretif** : on exprime ce qu'on cherche (une affectation de chiffres distincts satisfaisant une equation positionnelle), pas **comment** le chercher. Le solveur Z3 se charge de la recherche via propagation de contraintes - instantanement la ou la brute force enumere des millions de candidats.
 
 
 
-Cette serie Z3-Python (notebooks 01 a 10) couvre maintenant le spectre complet : satisfaction de contraintes (01, 02), tactiques (03), chaines/regex (04), quantificateurs (05), optimisation avancee (06), style declaratif (07), ordonnancement NP-difficile (08), CSP logique (09), et ici l'**arithmetique symbolique** sur entiers (10). Le pont avec la serie sœur Z3.Linq (C#) se fait via les memes exemples portes entre Microsoft.Z3 et pyz3.",,,,,,,,6ac6b88297f00f0a,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-11-Graph-Coloring.ipynb,e0776896,markdown,fr,cc709516d7f727bd,"← [10 - Cryptarithmes](Z3-Python-10-Cryptarithmetic.ipynb) | [README Z3-Python](README.md)
+Cette serie Z3-Python (notebooks 01 a 10) couvre maintenant le spectre complet : satisfaction de contraintes (01, 02), tactiques (03), chaînes/regex (04), quantificateurs (05), optimisation avancee (06), style declaratif (07), ordonnancement NP-difficile (08), CSP logique (09), et ici l'**arithmetique symbolique** sur entiers (10). Le pont avec la serie sœur Z3.Linq (C#) se fait via les mêmes exemples portes entre Microsoft.Z3 et pyz3.",,,,,,,,da08c5e7cc89af9c,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-11-Graph-Coloring.ipynb,e0776896,markdown,fr,2fc34cae5b6f3c6b,"← [10 - Cryptarithmes](Z3-Python-10-Cryptarithmetic.ipynb) | [README Z3-Python](README.md)
 
 # 11. Coloration de graphe : le graphe de Petersen
 
-La **coloration de graphe** consiste a attribuer une couleur a chaque sommet telle que deux sommets relies par une arete portent des couleurs differentes. Le **nombre chromatique** `chi(G)` est le nombre minimal de couleurs necessaires. Probleme **NP-complet** : il n'existe pas d'algorithme polynomial connu pour le resoudre en general.
+La **coloration de graphe** consiste a attribuer une couleur a chaque sommet telle que deux sommets relies par une arete portent des couleurs différentes. Le **nombre chromatique** `chi(G)` est le nombre minimal de couleurs necessaires. Problème **NP-complet** : il n'existe pas d'algorithme polynomial connu pour le resoudre en general.
 
 Le **graphe de Petersen** (10 sommets, 15 aretes) est un cas canonique : son nombre chromatique est `chi = 3` (ni biparti `chi=2`, ni trivial). La **recherche lineaire sur k** combinee a Z3 ne se contente pas de *trouver* 3 couleurs - elle **prouve** que 2 sont impossibles (`unsat`), ce qu'une heuristique gloutonne ne peut jamis affirmer.
 
-> Port pyz3 du notebook C# [`12_Graph_Coloring_Petersen.ipynb`](../Z3-Linq2Z3/12_Graph_Coloring_Petersen.ipynb). EPIC #1206, Prong B. (La section B2 MkIte du C#, specifique au DSL Z3.Linq, n'est pas portee.)",,,,,,,,cc709516d7f727bd,,,,,,,
+> Port pyz3 du notebook C# [`12_Graph_Coloring_Petersen.ipynb`](../Z3-Linq2Z3/12_Graph_Coloring_Petersen.ipynb). EPIC #1206, Prong B. (La section B2 MkIte du C#, spécifique au DSL Z3.Linq, n'est pas portee.)",,,,,,,,2fc34cae5b6f3c6b,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-11-Graph-Coloring.ipynb,f92c4d14,code,fr,ea01c0d4e0c636c2,"from z3 import *
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
@@ -6398,9 +6398,9 @@ import time
 plt.ioff()  # batch mode
 print(""Imports OK : z3-solver, matplotlib"")
 ",,,,,,,,ea01c0d4e0c636c2,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-11-Graph-Coloring.ipynb,e1f6f1f0,markdown,fr,b2107d0a0026cf6f,"## 1. Le graphe de Petersen
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-11-Graph-Coloring.ipynb,e1f6f1f0,markdown,fr,e3395e6e0313594a,"## 1. Le graphe de Petersen
 
-Le graphe de Petersen a 10 sommets (0 a 9) et 15 aretes organisees en trois structures : le **pentagone externe** (0-1-2-3-4-0), les **rayons** (0-5, 1-6, ...) et le **pentagramme interne** (5-7-9-6-8-5). C'est un exemple celebre en theorie des graphes : 3-regulier, non hamiltonien, et son nombre chromatique est exactement 3.",,,,,,,,b2107d0a0026cf6f,,,,,,,
+Le graphe de Petersen a 10 sommets (0 a 9) et 15 aretes organisees en trois structures : le **pentagone externe** (0-1-2-3-4-0), les **rayons** (0-5, 1-6, ...) et le **pentagramme interne** (5-7-9-6-8-5). C'est un exemple celebre en théorie des graphes : 3-regulier, non hamiltonien, et son nombre chromatique est exactement 3.",,,,,,,,e3395e6e0313594a,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-11-Graph-Coloring.ipynb,666f28c3,code,fr,be9392bf71952c0a,"# Graphe de Petersen : 10 sommets (0..9), 15 aretes
 N = 10
 edges = [
@@ -6428,9 +6428,9 @@ def display_coloring(color, title):
 
 print(""Graphe de Petersen charge : %d sommets, %d aretes."" % (N, len(edges)))
 ",,,,,,,,be9392bf71952c0a,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-11-Graph-Coloring.ipynb,ad1efd7e,markdown,fr,badcaa543f310c89,"## 2. Approche 1 : heuristique gloutonne (first-fit)
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-11-Graph-Coloring.ipynb,ad1efd7e,markdown,fr,1496e1553cbe12bf,"## 2. Approche 1 : heuristique gloutonne (first-fit)
 
-L'heuristique **first-fit** parcourt les sommets dans un ordre donne et assigne a chacun la plus petite couleur non utilisee par ses voisins deja colores. Simple et rapide, mais **le resultat depend de l'ordre** : un ordre defavorable gaspille des couleurs. Et surtout, le glouton ne peut jamais **prouver** qu'il a atteint l'optimum - il ne fait que constater ce qu'il a trouve.",,,,,,,,badcaa543f310c89,,,,,,,
+L'heuristique **first-fit** parcourt les sommets dans un ordre donne et assigne a chacun la plus petite couleur non utilisee par ses voisins déjà colores. Simple et rapide, mais **le résultat depend de l'ordre** : un ordre defavorable gaspille des couleurs. Et surtout, le glouton ne peut jamais **prouver** qu'il a atteint l'optimum - il ne fait que constater ce qu'il a trouve.",,,,,,,,1496e1553cbe12bf,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-11-Graph-Coloring.ipynb,f5b858a9,code,fr,f5cb2a7645326e01,"# Coloration gloutonne first-fit selon un ordre de parcours donne
 def greedy_coloring(n, adjacency, order):
     color = [-1] * n
@@ -6460,9 +6460,9 @@ display_coloring(greedy_bad, ""First-fit, ordre defavorable %s :"" % bad_order)
 print()
 print(""Meme graphe, meme algorithme : %d couleurs vs %d couleurs selon l'ordre."" % (greedy_natural_colors, greedy_bad_colors))
 ",,,,,,,,f5cb2a7645326e01,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-11-Graph-Coloring.ipynb,b55c722a,markdown,fr,53607ad7e5c84ee4,"## Interpretation
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-11-Graph-Coloring.ipynb,b55c722a,markdown,fr,1cec104b3ce99d5b,"## Interpretation
 
-Le glouton trouve **3 couleurs** dans le bon ordre mais **4 dans l'ordre defavorable** - alors que l'optimum est toujours 3. C'est le piege des heuristiques : sans recherche exhaustive, impossible de savoir si le resultat est optimal. Le solveur, lui, va **prouver** l'optimalite.",,,,,,,,53607ad7e5c84ee4,,,,,,,
+Le glouton trouve **3 couleurs** dans le bon ordre mais **4 dans l'ordre defavorable** - alors que l'optimum est toujours 3. C'est le piege des heuristiques : sans recherche exhaustive, impossible de savoir si le résultat est optimal. Le solveur, lui, va **prouver** l'optimalite.",,,,,,,,1cec104b3ce99d5b,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-11-Graph-Coloring.ipynb,0521907b,markdown,fr,c7d4b32536902d5e,"## 3. Approche 2 : modelisation Z3
 
 On encode une variable entiere `C_v` par sommet (couleur de v), on borne les couleurs a `[0, k)`, on fixe `C_0 = 0` (brisure de symetrie - evite l'explosion par permutation de couleurs), et pour chaque arete `(a,b)` on impose `C_a != C_b`.",,,,,,,,c7d4b32536902d5e,,,,,,,
@@ -6470,16 +6470,16 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-11-Graph-Coloring.ipynb,b5d800
 Color = [Int('C%d' % v) for v in range(N)]
 print(""Modele defini : %d variables de couleur entieres C0..C9."" % N)
 ",,,,,,,,c033dd3962be6926,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-11-Graph-Coloring.ipynb,7d5ec0de,markdown,fr,a6dcbc4809300d5c,"## 4. Recherche du nombre chromatique
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-11-Graph-Coloring.ipynb,7d5ec0de,markdown,fr,35e7a420853a6a19,"## 4. Recherche du nombre chromatique
 
-On cherche le plus petit `k` tel que le graphe soit `k`-colorable. Pour chaque `k`, on instancie le modele (domaine `[0,k)`, brisure de symetrie, contraintes d'aretes) et on teste la **satisfiabilite** :
-- `sat` -> `k` couleurs suffisent, le nombre chromatique est `k` (car les `k-1` precedents etaient `unsat`).
+On cherche le plus petit `k` tel que le graphe soit `k`-colorable. Pour chaque `k`, on instancie le modèle (domaine `[0,k)`, brisure de symetrie, contraintes d'aretes) et on teste la **satisfiabilite** :
+- `sat` -> `k` couleurs suffisent, le nombre chromatique est `k` (car les `k-1` précédents etaient `unsat`).
 
 - `unsat` -> `k` couleurs ne suffisent pas, on essaie `k+1`.
 
 
 
-C'est cette double nature (trouver ET prouver l'impossibilite) qui fait la force du solveur face au glouton.",,,,,,,,a6dcbc4809300d5c,,,,,,,
+C'est cette double nature (trouver ET prouver l'impossibilite) qui fait la force du solveur face au glouton.",,,,,,,,35e7a420853a6a19,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-11-Graph-Coloring.ipynb,8ac54224,code,fr,d05a15e8d0cd3148,"# Recherche lineaire du nombre chromatique
 optimal_color = None
 chromatic = -1
@@ -6548,24 +6548,24 @@ ax.legend(handles=handles, loc='upper right', framealpha=0.9)
 plt.tight_layout()
 plt.show()
 ",,,,,,,,375db7d34018e8c6,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-11-Graph-Coloring.ipynb,e1d52c8c,markdown,fr,0f012f57c52c141c,"## 5. Glouton vs solveur : ce que demontre Petersen
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-11-Graph-Coloring.ipynb,e1d52c8c,markdown,fr,665c25d8c348b8bf,"## 5. Glouton vs solveur : ce que demontre Petersen
 
 Le graphe de Petersen illustre trois lecons :
-1. **L'heuristique est sensible a l'ordre** - 3 ou 4 couleurs selon comment on parcourt les sommets, pour le meme graphe.
+1. **L'heuristique est sensible a l'ordre** - 3 ou 4 couleurs selon comment on parcourt les sommets, pour le même graphe.
 
 2. **Seul le solveur prouve l'optimalite** - le `unsat` a `k=2` est une preuve formelle d'impossibilite, pas un constat d'echec.
 
-3. **La recherche lineaire sur k est efficace** - on ne resout pas un seul gros probleme mais une suite de decisions `sat`/`unsat`, chacune rapide par propagation.",,,,,,,,0f012f57c52c141c,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-11-Graph-Coloring.ipynb,8467425b,markdown,fr,97574890ad8d3d5e,"## Exercices
+3. **La recherche lineaire sur k est efficace** - on ne resout pas un seul gros problème mais une suite de decisions `sat`/`unsat`, chacune rapide par propagation.",,,,,,,,665c25d8c348b8bf,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-11-Graph-Coloring.ipynb,8467425b,markdown,fr,c047a3792d0679ac,"## Exercices
 
-Les trois exercices ci-dessous generalisent la coloration a des variantes : forcer un nombre chromatique plus eleve (1), appliquer la coloration a un probleme concret de planification (2), et enumerer toutes les colorations possibles (3). Chaque stub est self-contained : les fonctions utilitaires (`edges`, `adj`, modele Z3) sont definies dans les sections precedentes.",,,,,,,,97574890ad8d3d5e,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-11-Graph-Coloring.ipynb,f5eb3062,markdown,fr,7cc9ed38554844a1,"### Exercice 1 - Forcer une quatrieme couleur
+Les trois exercices ci-dessous generalisent la coloration a des variantes : forcer un nombre chromatique plus eleve (1), appliquer la coloration a un problème concret de planification (2), et enumerer toutes les colorations possibles (3). Chaque stub est self-contained : les fonctions utilitaires (`edges`, `adj`, modèle Z3) sont définies dans les sections précédentes.",,,,,,,,c047a3792d0679ac,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-11-Graph-Coloring.ipynb,f5eb3062,markdown,fr,10d9492f6e9e2875,"### Exercice 1 - Forcer une quatrieme couleur
 
-Ajoutez une arete au graphe de Petersen de maniere a creer une **clique de taille 4** (4 sommets tous relies deux a deux), puis recalculez le nombre chromatique. Une clique de taille `n` impose `chi >= n` (chaque sommet d'une clique doit avoir une couleur distincte).
+Ajoutez une arete au graphe de Petersen de maniere a créer une **clique de taille 4** (4 sommets tous relies deux a deux), puis recalculez le nombre chromatique. Une clique de taille `n` impose `chi >= n` (chaque sommet d'une clique doit avoir une couleur distincte).
 
 
 
-**Etapes** : choisir 4 sommets, lister les aretes manquantes pour qu'ils forment une clique, construire un nouveau modele avec les aretes supplementaires, relancer la recherche lineaire et verifier `chi == 4`.",,,,,,,,7cc9ed38554844a1,,,,,,,
+**Étapes** : choisir 4 sommets, lister les aretes manquantes pour qu'ils forment une clique, construire un nouveau modèle avec les aretes supplementaires, relancer la recherche lineaire et verifier `chi == 4`.",,,,,,,,10d9492f6e9e2875,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-11-Graph-Coloring.ipynb,81ee4a75,code,fr,b11c9c7dedee9642,"# Exercice 1 : ajouter une arete creant une clique de taille 4, recalculer chi
 # TODO etudiant :
 # Etape 1 : choisir 4 sommets et lister les aretes a ajouter pour qu'ils forment une clique
@@ -6574,13 +6574,13 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-11-Graph-Coloring.ipynb,81ee4a
 result = None  # TODO etudiant
 print(""Exercice 1 a completer : forcez chi = 4 en ajoutant une clique de taille 4"")
 ",,,,,,,,b11c9c7dedee9642,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-11-Graph-Coloring.ipynb,460bcc21,markdown,fr,722cecf079e8a9e0,"### Exercice 2 - Planification d'examens
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-11-Graph-Coloring.ipynb,460bcc21,markdown,fr,a07decbe6e2e505f,"### Exercice 2 - Planification d'examens
 
 La planification d'examens est une **coloration deguisee** : les sommets sont les examens, les aretes relient deux examens partageant au moins un etudiant (conflit), et les couleurs sont les creneaux horaires. Le nombre chromatique donne le nombre minimal de creneaux sans conflit.
 
 
 
-**Etapes** : definir un graphe de conflits (5-6 examens avec des chevauchements d'etudiants), trouver le nombre minimal de creneaux via la recherche lineaire, afficher l'emploi du temps par creneau.",,,,,,,,722cecf079e8a9e0,,,,,,,
+**Étapes** : définir un graphe de conflits (5-6 examens avec des chevauchements d'etudiants), trouver le nombre minimal de creneaux via la recherche lineaire, afficher l'emploi du temps par creneau.",,,,,,,,a07decbe6e2e505f,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-11-Graph-Coloring.ipynb,48da44b7,code,fr,ec511eefc445bb91,"# Exercice 2 : planification d'examens (coloration deguisee)
 # TODO etudiant :
 # Etape 1 : definir votre graphe de conflits (sommets = examens, aretes = etudiants communs)
@@ -6589,13 +6589,13 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-11-Graph-Coloring.ipynb,48da44
 result = None  # TODO etudiant
 print(""Exercice 2 a completer : planifiez les examens par coloration de graphe"")
 ",,,,,,,,ec511eefc445bb91,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-11-Graph-Coloring.ipynb,fdbc9cb7,markdown,fr,7a88a3f91d9818f9,"### Exercice 3 - Compter les 3-colorations
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-11-Graph-Coloring.ipynb,fdbc9cb7,markdown,fr,a7d102ef698c52fd,"### Exercice 3 - Compter les 3-colorations
 
 Combien de colorations distinctes a 3 couleurs admet le graphe de Petersen ? On enumere les solutions en ajoutant a chaque fois une contrainte d'exclusion de la solution trouvee, jusqu'a `unsat`.
 
 
 
-**Etapes** : boucle qui resout, compte la solution, puis l'exclut (`Or(C[v] != sol[v])`) jusqu'a `unsat` ; comparer au resultat attendu **120** ; diviser par `3! = 6` pour obtenir le nombre de colorations a permutation de couleurs pres.",,,,,,,,7a88a3f91d9818f9,,,,,,,
+**Étapes** : boucle qui resout, compte la solution, puis l'exclut (`Or(C[v] != sol[v])`) jusqu'a `unsat` ; comparer au résultat attendu **120** ; diviser par `3! = 6` pour obtenir le nombre de colorations a permutation de couleurs pres.",,,,,,,,a7d102ef698c52fd,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-11-Graph-Coloring.ipynb,a178f6c2,code,fr,4901900530b70932,"# Exercice 3 : compter les 3-colorations en enumerant les solutions
 # TODO etudiant :
 # Etape 1 : boucle qui resout, puis exclut la solution trouvee, jusqu'a UNSAT
@@ -6604,31 +6604,31 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-11-Graph-Coloring.ipynb,a178f6
 nb_colorations = None  # TODO etudiant
 print(""Exercice 3 a completer : enumerez les 3-colorations (attendu : 120 total, 20 a permutation pres)"")
 ",,,,,,,,4901900530b70932,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-11-Graph-Coloring.ipynb,8d1e30c1,markdown,fr,08280a16006ab1c8,"## Conclusion
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-11-Graph-Coloring.ipynb,8d1e30c1,markdown,fr,1682dd921c75dde9,"## Conclusion
 
-La coloration de graphe cristallise la difference entre **heuristique** et **preuve**. Le glouton first-fit est rapide mais myope : il offre 3 ou 4 couleurs selon l'ordre, sans jamais certifier l'optimum. Z3, par la **recherche lineaire sur k** combinee aux verdicts `sat`/`unsat`, trouve le nombre chromatique `chi = 3` **et prouve qu'il est minimal** (`k=2` unsat).
+La coloration de graphe cristallise la différence entre **heuristique** et **preuve**. Le glouton first-fit est rapide mais myope : il offre 3 ou 4 couleurs selon l'ordre, sans jamais certifier l'optimum. Z3, par la **recherche lineaire sur k** combinee aux verdicts `sat`/`unsat`, trouve le nombre chromatique `chi = 3` **et prouve qu'il est minimal** (`k=2` unsat).
 
 
 
-Cette double capacity - trouver une solution **et** certifier l'impossibilite de faire mieux - est le coeur de l'apport SMT. Elle se generalize a tous les problemes d'optimisation combinatoire ou l'on veut non pas une bonne solution, mais la **meilleure prouvee**.",,,,,,,,08280a16006ab1c8,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-12-Real-Arithmetic.ipynb,e3ec7b6a,markdown,fr,15eda683c698f4d1,"← [11 - Coloration de graphe](Z3-Python-11-Graph-Coloring.ipynb) | [README Z3-Python](README.md)
+Cette double capacity - trouver une solution **et** certifier l'impossibilite de faire mieux - est le coeur de l'apport SMT. Elle se generalize a tous les problemes d'optimisation combinatoire ou l'on veut non pas une bonne solution, mais la **meilleure prouvee**.",,,,,,,,1682dd921c75dde9,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-12-Real-Arithmetic.ipynb,e3ec7b6a,markdown,fr,7048674c51f7789b,"← [11 - Coloration de graphe](Z3-Python-11-Graph-Coloring.ipynb) | [README Z3-Python](README.md)
 
 # 12. Arithmetique reelle : raisonner sur les irrationnels exacts
 
-Jusqu'ici nous avons raisonne sur des **entiers** (coloration de graphe, cryptarithmes, ordonnancement). Z3 sait aussi raisonner sur les **reels** via la theorie `Real` (SMT-LIB `Reals`). C'est une capacite profondement differente : les solutions peuvent etre **rationnelles exactes** (pas d'arrondi flottant), des **irrationnels algebriques** (racine carree de 2 representee comme racine d'un polynome, pas comme 1.4142...), et l'absence de solution peut etre **prouvee** (`unsat`) sur le corps des reels tout entier.
+Jusqu'ici nous avons raisonne sur des **entiers** (coloration de graphe, cryptarithmes, ordonnancement). Z3 sait aussi raisonner sur les **reels** via la théorie `Real` (SMT-LIB `Reals`). C'est une capacite profondement différente : les solutions peuvent etre **rationnelles exactes** (pas d'arrondi flottant), des **irrationnels algebriques** (racine carree de 2 representee comme racine d'un polynome, pas comme 1.4142...), et l'absence de solution peut etre **prouvee** (`unsat`) sur le corps des reels tout entier.
 
 Ce notebook explore les trois postures : arithmetique lineaire (solution rationnelle exacte), non-lineaire (irrationnel algebrique), et preuve d'impossibilite sur R. Aucun `float`, aucun `sqrt()` approche : tout est symbolique.
 
-> Port pyz3 du notebook C# [`16_RealArithmetic.ipynb`](../Z3-Linq2Z3/16_RealArithmetic.ipynb). EPIC #1206, Prong B. (La section B7 Rational du C#, specifique au DSL Z3.Linq, n'est pas portee.)",,,,,,,,15eda683c698f4d1,,,,,,,
+> Port pyz3 du notebook C# [`16_RealArithmetic.ipynb`](../Z3-Linq2Z3/16_RealArithmetic.ipynb). EPIC #1206, Prong B. (La section B7 Rational du C#, spécifique au DSL Z3.Linq, n'est pas portee.)",,,,,,,,7048674c51f7789b,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-12-Real-Arithmetic.ipynb,f066c472,code,fr,287da594bc74f1be,"from z3 import *
 print(""Imports OK : z3-solver (theorie Real)"")
 ",,,,,,,,287da594bc74f1be,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-12-Real-Arithmetic.ipynb,ec9c4659,markdown,fr,aa3f3860e716344b,"## 1. La theorie des reels (SMT-LIB `Real`)
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-12-Real-Arithmetic.ipynb,ec9c4659,markdown,fr,5729bdb7c466c0fa,"## 1. La théorie des reels (SMT-LIB `Real`)
 
-En pyz3, `Real('x')` cree une variable reelle (theorie des rationnels etant donne que Z3 represente les reels comme des rationnels ou des racines algebriques). Les operations `+`, `*`, comparaisons `>=` et egalites `==` s'appliquent. Le solveur decide la satisfiabilite sur cette theorie via des procedure de decision (arithmetique reelle lineaire = simplex ; non-lineaire = methodes de cylindres algebriques).",,,,,,,,aa3f3860e716344b,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-12-Real-Arithmetic.ipynb,64220833,markdown,fr,d7e68907d5833f07,"## 2. Arithmetique reelle lineaire : solution rationnelle exacte
+En pyz3, `Real('x')` créé une variable reelle (théorie des rationnels etant donne que Z3 represente les reels comme des rationnels ou des racines algebriques). Les opérations `+`, `*`, comparaisons `>=` et egalites `==` s'appliquent. Le solveur decide la satisfiabilite sur cette théorie via des procedure de decision (arithmetique reelle lineaire = simplex ; non-lineaire = méthodes de cylindres algebriques).",,,,,,,,5729bdb7c466c0fa,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-12-Real-Arithmetic.ipynb,64220833,markdown,fr,b038b1ad55923345,"## 2. Arithmetique reelle lineaire : solution rationnelle exacte
 
-Systeme lineaire `x + y = 1`, `x - y = 3`. Solution `x = 2`, `y = -1`. Ce sont des **rationnels exacts**, pas des flottants : Z3 ne fait jamais d'arrondi. Tout le raisonnement est symbolique.",,,,,,,,d7e68907d5833f07,,,,,,,
+Système lineaire `x + y = 1`, `x - y = 3`. Solution `x = 2`, `y = -1`. Ce sont des **rationnels exacts**, pas des flottants : Z3 ne fait jamais d'arrondi. Tout le raisonnement est symbolique.",,,,,,,,b038b1ad55923345,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-12-Real-Arithmetic.ipynb,2e54e434,code,fr,53c218db428f9024,"# Systeme lineaire x+y=1, x-y=3 : solution rationnelle EXACTE
 x, y = Reals('x y')
 s1 = Solver()
@@ -6642,9 +6642,9 @@ if st1 == sat:
     print(""  y = %s"" % m[y])
 print(""-> Solution rationnelle EXACTE (pas d'arrondi flottant)."")
 ",,,,,,,,53c218db428f9024,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-12-Real-Arithmetic.ipynb,8de9b5bc,markdown,fr,710888bc605acc48,"## 3. Non-lineaire : trouver un irrationnel exact (racine de 2)
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-12-Real-Arithmetic.ipynb,8de9b5bc,markdown,fr,749b3bf2e298877a,"## 3. Non-lineaire : trouver un irrationnel exact (racine de 2)
 
-Trouvons `xs` tel que `xs^2 = 2`, avec `xs > 0` (la racine positive). La solution n'est PAS le flottant `1.41421356...` : Z3 renvoie une **racine algebrique exacte** (un `root-obj` = k-ieme racine d'un polynome a coefficients rationnels), affichee ici en notation decimale avec un `?` final qui signale ""representation approchee d'un nombre exact"".",,,,,,,,710888bc605acc48,,,,,,,
+Trouvons `xs` tel que `xs^2 = 2`, avec `xs > 0` (la racine positive). La solution n'est PAS le flottant `1.41421356...` : Z3 renvoie une **racine algebrique exacte** (un `root-obj` = k-ieme racine d'un polynome a coefficients rationnels), affichée ici en notation decimale avec un `?` final qui signale ""representation approchee d'un nombre exact"".",,,,,,,,749b3bf2e298877a,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-12-Real-Arithmetic.ipynb,13915e24,code,fr,f05ac9278fc9a61a,"# Trouver xs tel que xs^2 = 2, xs > 0 (l'irrationnel sqrt(2))
 xs = Real('xs')
 s2 = Solver()
@@ -6659,9 +6659,9 @@ if st2 == sat:
     print(""  -> Ce n'est PAS 1.4142... mais une RACINE ALGEBRIQUE exacte."")
     print(""     (le suffixe '?' = affichage approche d'un root-obj exact ; x^2 - 2 = 0)"")
 ",,,,,,,,f05ac9278fc9a61a,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-12-Real-Arithmetic.ipynb,1d4ae8f8,markdown,fr,d4907607730c554f,"## 4. Prouver l'absence de racine reelle (UNSAT)
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-12-Real-Arithmetic.ipynb,1d4ae8f8,markdown,fr,987eba23810dd0a0,"## 4. Prouver l'absence de racine reelle (UNSAT)
 
-`xn^2 + 1 = 0` n'a pas de solution reelle (le discriminant est negatif, les racines sont imaginaires `+/-i`). Z3 le **prouve** : `unsat`. C'est une preuve sur le corps des reels tout entier - il n'existe AUCUN reel satisfaisant cette equation. Aucune approche numerique (essayer des valeurs, echantillonner) ne peut etablir cette absence ; seule la decision algebrique le peut.",,,,,,,,d4907607730c554f,,,,,,,
+`xn^2 + 1 = 0` n'a pas de solution reelle (le discriminant est negatif, les racines sont imaginaires `+/-i`). Z3 le **prouve** : `unsat`. C'est une preuve sur le corps des reels tout entier - il n'existe AUCUN reel satisfaisant cette equation. Aucune approche numérique (essayer des valeurs, echantillonner) ne peut etablir cette absence ; seule la decision algebrique le peut.",,,,,,,,987eba23810dd0a0,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-12-Real-Arithmetic.ipynb,80f3a454,code,fr,9403a19eee97555d,"# Prouver que xn^2 + 1 = 0 n'a PAS de solution reelle
 xn = Real('xn')
 s3 = Solver()
@@ -6673,9 +6673,9 @@ if st3 == unsat:
 else:
     print(""  -> inattendu (devrait etre impossible sur R)."")
 ",,,,,,,,9403a19eee97555d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-12-Real-Arithmetic.ipynb,9bae86e3,markdown,fr,d9a667674b63439a,"## 5. Application geometrique : l'inegalite triangulaire
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-12-Real-Arithmetic.ipynb,9bae86e3,markdown,fr,3288643c5aff17cb,"## 5. Application geometrique : l'inegalite triangulaire
 
-Trois longueurs `a, b, c` forment un triangle ssi chacune est <= la somme des deux autres (`a + b >= c`, etc.). Pour `(3, 4, 5)` c'est SAT (triangle rectangle canonique) ; pour `(1, 2, 5)` c'est UNSAT (1 + 2 = 3 < 5, le plus long cote est trop long). La preuve est exacte, pas une verification numerique.",,,,,,,,d9a667674b63439a,,,,,,,
+Trois longueurs `a, b, c` forment un triangle ssi chacune est <= la somme des deux autres (`a + b >= c`, etc.). Pour `(3, 4, 5)` c'est SAT (triangle rectangle canonique) ; pour `(1, 2, 5)` c'est UNSAT (1 + 2 = 3 < 5, le plus long cote est trop long). La preuve est exacte, pas une verification numérique.",,,,,,,,3288643c5aff17cb,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-12-Real-Arithmetic.ipynb,312ec23e,code,fr,3d78521ce0c461f6,"# Trois longueurs forment-elles un triangle ? (inegalite triangulaire)
 a, b, c = Reals('a b c')
 def triangle(va, vb, vc):
@@ -6694,9 +6694,9 @@ print(""Triangle(1, 2, 5) : %s"" % stB)
 if stB == unsat:
     print(""  -> UNSAT : impossible (1 + 2 = 3 < 5, le plus long cote est trop long)."")
 ",,,,,,,,3d78521ce0c461f6,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-12-Real-Arithmetic.ipynb,56a96676,markdown,fr,dc18a983187b0dbe,"## 6. Ce que ce notebook a demontre
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-12-Real-Arithmetic.ipynb,56a96676,markdown,fr,5af34895e67c3786,"## 6. Ce que ce notebook a demontre
 
-Trois capacites distinctes de la theorie des reels :
+Trois capacites distinctes de la théorie des reels :
 1. **Solution rationnelle exacte** (linearite) - pas de flottant, pas d'arrondi.
 
 2. **Irrationnel algebrique exact** (non-lineaire) - racine de 2 comme `root-obj`, pas comme decimal tronque.
@@ -6705,17 +6705,17 @@ Trois capacites distinctes de la theorie des reels :
 
 
 
-Ces trois postures sont inaccessibles au calcul numerique classique (float, `math.sqrt`). Elles illustrent pourquoi la theorie SMT des reels est un outil de raisonnement, pas juste de calcul.",,,,,,,,dc18a983187b0dbe,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-12-Real-Arithmetic.ipynb,4f3daadf,markdown,fr,28b6cc50d3415bf0,"## 7. Exercices
+Ces trois postures sont inaccessibles au calcul numérique classique (float, `math.sqrt`). Elles illustrent pourquoi la théorie SMT des reels est un outil de raisonnement, pas juste de calcul.",,,,,,,,5af34895e67c3786,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-12-Real-Arithmetic.ipynb,4f3daadf,markdown,fr,a17fb106b5fd614e,"## 7. Exercices
 
-Les trois exercices ci-dessous vous font manipuler la theorie des reels sur des variantes : racine cubique (1), discriminant d'un trinome (2), optimisation sur les reels (3). Chaque stub est self-contained : les fonctions (`Real`, `Reals`, `Solver`) sont definies dans les sections precedentes.",,,,,,,,28b6cc50d3415bf0,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-12-Real-Arithmetic.ipynb,d9136f17,markdown,fr,b97ecbb2b1e8d722,"### Exercice 1 - Racine cubique de 2
+Les trois exercices ci-dessous vous font manipuler la théorie des reels sur des variantes : racine cubique (1), discriminant d'un trinome (2), optimisation sur les reels (3). Chaque stub est self-contained : les fonctions (`Real`, `Reals`, `Solver`) sont définies dans les sections précédentes.",,,,,,,,a17fb106b5fd614e,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-12-Real-Arithmetic.ipynb,d9136f17,markdown,fr,671254c2cb4c429c,"### Exercice 1 - Racine cubique de 2
 
-Trouvez `c` tel que `c^3 = 2`, avec `c > 0`. La racine cubique de 2 est aussi un irrationnel algebrique, mais de **degre 3** (vs degre 2 pour la racine carree). Affichez le temoin et comparez la notation.
+Trouvez `c` tel que `c^3 = 2`, avec `c > 0`. La racine cubique de 2 est aussi un irrationnel algebrique, mais de **degré 3** (vs degré 2 pour la racine carree). Affichez le temoin et comparez la notation.
 
 
 
-**Etapes** : `c = Real('c')`, ajouter `c * c * c == 2` et `c > 0`, checker, afficher le modele.",,,,,,,,b97ecbb2b1e8d722,,,,,,,
+**Étapes** : `c = Real('c')`, ajouter `c * c * c == 2` et `c > 0`, checker, afficher le modèle.",,,,,,,,671254c2cb4c429c,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-12-Real-Arithmetic.ipynb,26df7709,code,fr,3db916ba8f6b8661,"# Exercice 1 : trouver c tel que c^3 = 2 (racine cubique de 2)
 # TODO etudiant :
 # Etape 1 : c = Real('c')
@@ -6724,7 +6724,7 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-12-Real-Arithmetic.ipynb,26df7
 result = None  # TODO etudiant
 print(""Exercice 1 a completer : trouvez la racine cubique exacte de 2"")
 ",,,,,,,,3db916ba8f6b8661,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-12-Real-Arithmetic.ipynb,a79d71ce,markdown,fr,c0efdb8456f0b141,"### Exercice 2 - Discriminant et nombre de racines
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-12-Real-Arithmetic.ipynb,a79d71ce,markdown,fr,6cb464e9009865d6,"### Exercice 2 - Discriminant et nombre de racines
 
 Un trinome `q^2 + bq + c = 0` a des racines reelles ssi son **discriminant** `D = b^2 - 4c >= 0`.
 
@@ -6734,7 +6734,7 @@ Un trinome `q^2 + bq + c = 0` a des racines reelles ssi son **discriminant** `D 
 
 
 
-**Etapes** : pour chaque polynome, encoder `= 0` et checker. Le verdict `sat`/`unsat` confirme le signe du discriminant.",,,,,,,,c0efdb8456f0b141,,,,,,,
+**Étapes** : pour chaque polynome, encoder `= 0` et checker. Le verdict `sat`/`unsat` confirme le signe du discriminant.",,,,,,,,6cb464e9009865d6,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-12-Real-Arithmetic.ipynb,dc5cd871,code,fr,c650d1778c2beeb3,"# Exercice 2 : discriminant et racines reelles
 # TODO etudiant :
 # (a) q^2 - 3q + 2 = 0 a une racine reelle (SAT, deux racines 1 et 2)
@@ -6744,13 +6744,13 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-12-Real-Arithmetic.ipynb,dc5cd
 result = None  # TODO etudiant
 print(""Exercice 2 a completer : discriminez les trinomes (SAT vs UNSAT)"")
 ",,,,,,,,c650d1778c2beeb3,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-12-Real-Arithmetic.ipynb,82b65e00,markdown,fr,8e189c18fb63a500,"### Exercice 3 - Distance minimale (optimisation sur les reels)
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-12-Real-Arithmetic.ipynb,82b65e00,markdown,fr,70f89faf3b3deb00,"### Exercice 3 - Distance minimale (optimisation sur les reels)
 
 Minimisez `px^2 + py^2` sous la contrainte `px + py = 4` (point de la droite le plus proche de l'origine). La solution exacte est `px = py = 2`, distance minimale `sqrt(8)`.
 
 
 
-**Indice** : utilisez `Optimize()` avec `.minimize(px*px + py*py)`. **Note** : l'optimisation non-lineaire sur les reels est delicate (Z3 peut renvoyer un point sous-optimal) ; si le minimum trouve n'est pas 8, reflechissez a pourquoi (la theorie non-lineaire reelle est decidable mais l'optimisation globale reste dure).",,,,,,,,8e189c18fb63a500,,,,,,,
+**Indice** : utilisez `Optimize()` avec `.minimize(px*px + py*py)`. **Note** : l'optimisation non-lineaire sur les reels est delicate (Z3 peut renvoyer un point sous-optimal) ; si le minimum trouve n'est pas 8, reflechissez a pourquoi (la théorie non-lineaire reelle est decidable mais l'optimisation globale reste dure).",,,,,,,,70f89faf3b3deb00,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-12-Real-Arithmetic.ipynb,734f8a7a,code,fr,d8c39507a9e45a0b,"# Exercice 3 : minimiser px^2 + py^2 sous px + py = 4 (point le plus proche de l'origine)
 # TODO etudiant :
 # Etape 1 : px, py = Reals('px py')
@@ -6760,28 +6760,28 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-12-Real-Arithmetic.ipynb,734f8
 result = None  # TODO etudiant
 print(""Exercice 3 a completer : minimisez x^2 + y^2 sous x + y = 4"")
 ",,,,,,,,d8c39507a9e45a0b,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-12-Real-Arithmetic.ipynb,47ab358a,markdown,fr,a8f3609ff4f383b3,"## Conclusion
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-12-Real-Arithmetic.ipynb,47ab358a,markdown,fr,3682a8cf02212015,"## Conclusion
 
-La theorie des reels de Z3 transforme le solveur en outil de **raisonnement algebrique exact**. La ou le calcul numerique flottant (`float`, `math.sqrt`) introduit des erreurs d'arrondi et ne peut jamais prouver une absence de solution, la theorie SMT `Real` offre : solutions rationnelles exactes, irrationnels algebriques (racine de 2 comme `root-obj`), et preuves d'impossibilite sur R tout entier (`unsat` pour `x^2 + 1 = 0`).
+La théorie des reels de Z3 transforme le solveur en outil de **raisonnement algebrique exact**. La ou le calcul numérique flottant (`float`, `math.sqrt`) introduit des erreurs d'arrondi et ne peut jamais prouver une absence de solution, la théorie SMT `Real` offre : solutions rationnelles exactes, irrationnels algebriques (racine de 2 comme `root-obj`), et preuves d'impossibilite sur R tout entier (`unsat` pour `x^2 + 1 = 0`).
 
 
 
-Cette serie Z3-Python (notebooks 01 a 12) couvre maintenant l'eventail complet : entiers (01-06, 10, 11), satisfaction de contraintes (08 ordonnancement, 09 CSP logique, 11 graphes), tactiques (03), et ici l'**arithmetique reelle exacte** (12). Le pont avec la serie souer Z3.Linq (C#) se fait via les memes exemples portes entre Microsoft.Z3 et pyz3.",,,,,,,,a8f3609ff4f383b3,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-13-UnsatCores.ipynb,de430bb4,markdown,fr,caf2bd2d0f17131c,"← [12 - Arithmetique reelle](Z3-Python-12-Real-Arithmetic.ipynb) | [README Z3-Python](README.md)
+Cette serie Z3-Python (notebooks 01 a 12) couvre maintenant l'eventail complet : entiers (01-06, 10, 11), satisfaction de contraintes (08 ordonnancement, 09 CSP logique, 11 graphes), tactiques (03), et ici l'**arithmetique reelle exacte** (12). Le pont avec la serie souer Z3.Linq (C#) se fait via les mêmes exemples portes entre Microsoft.Z3 et pyz3.",,,,,,,,3682a8cf02212015,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-13-UnsatCores.ipynb,de430bb4,markdown,fr,1101b3dd7253bf2e,"← [12 - Arithmetique reelle](Z3-Python-12-Real-Arithmetic.ipynb) | [README Z3-Python](README.md)
 
 # 13. UNSAT cores : expliquer l'insatisfiabilite (le ' pourquoi ')
 
-Jusqu'ici, le solveur repondait a une question binaire : *ce systeme a-t-il une solution ?* -> **SAT** (oui, voici un temoin) ou **UNSAT** (non, prouve impossible). C'est un **verdict**, pas une **explication**.
+Jusqu'ici, le solveur repondait a une question binaire : *ce système a-t-il une solution ?* -> **SAT** (oui, voici un temoin) ou **UNSAT** (non, prouve impossible). C'est un **verdict**, pas une **explication**.
 
-Pour un ingenieur qui **ecrit** la specification, UNSAT est souvent un bug de modelisation : une contrainte trop forte, ou deux contraintes incompatibles. La reponse ' impossible ' ne suffit pas - il faut savoir **lesquelles** des contraintes se contredisent. C'est le role du **noyau d'insatisfiabilite** (UNSAT core) : le sous-ensemble **minimal** de contraintes responsable du conflit. Z3 passe du diagnostic binaire au diagnostic chirurgical.
+Pour un ingenieur qui **ecrit** la specification, UNSAT est souvent un bug de modelisation : une contrainte trop forte, ou deux contraintes incompatibles. La reponse ' impossible ' ne suffit pas - il faut savoir **lesquelles** des contraintes se contredisent. C'est le rôle du **noyau d'insatisfiabilite** (UNSAT core) : le sous-ensemble **minimal** de contraintes responsable du conflit. Z3 passe du diagnostic binaire au diagnostic chirurgical.
 
-> Port pyz3 du notebook C# [`17_UnsatCores.ipynb`](../Z3-Linq2Z3/17_UnsatCores.ipynb). EPIC #1206, Prong B. (Le bloc DSL `Explain()` du C#, specifique a Z3.Linq, n'est pas porte ; l'API brute `assert_and_track` + `unsat_core` de pyz3 fait le meme travail.)",,,,,,,,caf2bd2d0f17131c,,,,,,,
+> Port pyz3 du notebook C# [`17_UnsatCores.ipynb`](../Z3-Linq2Z3/17_UnsatCores.ipynb). EPIC #1206, Prong B. (Le bloc DSL `Explain()` du C#, spécifique a Z3.Linq, n'est pas porte ; l'API brute `assert_and_track` + `unsat_core` de pyz3 fait le même travail.)",,,,,,,,1101b3dd7253bf2e,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-13-UnsatCores.ipynb,71e1306a,code,fr,2d36fb6ac814810b,"from z3 import *
 print(""Imports OK : z3-solver (UNSAT cores via assert_and_track)"")
 ",,,,,,,,2d36fb6ac814810b,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-13-UnsatCores.ipynb,95e47844,markdown,fr,499048700149b4ff,"## 1. Du verdict a l'explication
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-13-UnsatCores.ipynb,95e47844,markdown,fr,f75e7d594700e44d,"## 1. Du verdict a l'explication
 
-Commencons par un systeme trivialement contradictoire. Le solveur dit **UNSAT** - mais ne dit pas (encore) POURQUOI. C'est le verdict brut.",,,,,,,,499048700149b4ff,,,,,,,
+Commencons par un système trivialement contradictoire. Le solveur dit **UNSAT** - mais ne dit pas (encore) POURQUOI. C'est le verdict brut.",,,,,,,,f75e7d594700e44d,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-13-UnsatCores.ipynb,53ee7428,code,fr,96bff9b46b4e6658,"# Rappel : un systeme contradictoire est UNSAT (verdict, sans explication)
 a, b = Bools('a b')
 s0 = Solver()
@@ -6791,11 +6791,11 @@ s0.add(Not(b))          # not b  (contredit a -> b)
 print(""' a->b, a, !b ' : %s  (verdict : impossible)"" % s0.check())
 print(""-> Z3 dit NON, mais ne dit pas (encore) POURQUOI."")
 ",,,,,,,,96bff9b46b4e6658,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-13-UnsatCores.ipynb,58f66f80,markdown,fr,4c0867a7e673bbaa,"## 2. L'API `assert_and_track` : etiqueter chaque contrainte
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-13-UnsatCores.ipynb,58f66f80,markdown,fr,d4cb39207829c5d1,"## 2. L'API `assert_and_track` : etiqueter chaque contrainte
 
-Pour obtenir une explication, on fournit les contraintes comme des **hypothese traceables** : `s.assert_and_track(formule, etiquette)` ou `etiquette` est un `Bool` servant de nom. Apres un `unsat`, `s.unsat_core()` renvoie le sous-ensemble **minimal** d'etiquettes responsable du conflit.
+Pour obtenir une explication, on fournit les contraintes comme des **hypothese traceables** : `s.assert_and_track(formule, etiquette)` ou `etiquette` est un `Bool` servant de nom. Après un `unsat`, `s.unsat_core()` renvoie le sous-ensemble **minimal** d'etiquettes responsable du conflit.
 
-Trois contraintes sur `x` : `x >= 3`, `x <= 5`, `x = 10`. Lesquelles se contredisent ?",,,,,,,,4c0867a7e673bbaa,,,,,,,
+Trois contraintes sur `x` : `x >= 3`, `x <= 5`, `x = 10`. Lesquelles se contredisent ?",,,,,,,,d4cb39207829c5d1,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-13-UnsatCores.ipynb,cdd127a9,code,fr,8992e61603416d8b,"# Trois contraintes sur x : lesquelles se contredisent ?
 x = Int('x')
 s1 = Solver()
@@ -6815,9 +6815,9 @@ if st1 == unsat:
         print(""  - %s"" % c)
     print(""-> Z3 ecarte 'x>=3' du core : cette contrainte est irrelevant pour le conflit."")
 ",,,,,,,,8992e61603416d8b,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-13-UnsatCores.ipynb,09c603eb,markdown,fr,edfc5aeaa34d8b5d,"## 3. Minimalite du core : verifier que la paire suffit
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-13-UnsatCores.ipynb,09c603eb,markdown,fr,dda41bbb60402857,"## 3. Minimalite du core : verifier que la paire suffit
 
-Le core est **minimal** : retirer une seule contrainte du core le rend satisfiable. Verifions que la paire `{x<=5, x=10}` (sans `x>=3`) est **deja** UNSAT - ce qui confirme que Z3 avait raison d'exclure `x>=3`.",,,,,,,,edfc5aeaa34d8b5d,,,,,,,
+Le core est **minimal** : retirer une seule contrainte du core le rend satisfiable. Verifions que la paire `{x<=5, x=10}` (sans `x>=3`) est **déjà** UNSAT - ce qui confirme que Z3 avait raison d'exclure `x>=3`.",,,,,,,,dda41bbb60402857,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-13-UnsatCores.ipynb,a6875fcb,code,fr,1bdec846adcdbfb0,"# Verifions : {x<=5, x=10} SEUL (sans x>=3) est-il deja UNSAT ?
 y = Int('y')
 s2 = Solver()
@@ -6862,11 +6862,11 @@ if st3 == unsat:
     print(""   Les autres (h>=9, h<=17, h>=9 redondant) sont COMPATIBLES -> Z3 les ignore."")
     print(""   Action : relacher la contrainte 'h=12' (animateur) OU 'h!=12' (pause)."")
 ",,,,,,,,b715e1d011115060,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-13-UnsatCores.ipynb,a578ceff,markdown,fr,2787306e8590cefe,"## 5. Innocence prouvee : une contrainte non impliquee ecartee du core
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-13-UnsatCores.ipynb,a578ceff,markdown,fr,199432fb30851a89,"## 5. Innocence prouvee : une contrainte non impliquee ecartee du core
 
-Un dernier temoin de la minimalite : sur un systeme a 3 contraintes (`x == 1`, `x >= 0` innocente, `x == 2`), le core minimal est `{x==1, x==2}`. La contrainte `x >= 0` est **compatible** avec les deux (un x valant 1 ou 2 verifie x >= 0) - elle n'est pas impliquee dans le conflit, donc Z3 l'ecarte du core. C'est ce qui distingue le core d'une simple liste de contraintes : il isole la **cause**, pas le contexte.
+Un dernier temoin de la minimalite : sur un système a 3 contraintes (`x == 1`, `x >= 0` innocente, `x == 2`), le core minimal est `{x==1, x==2}`. La contrainte `x >= 0` est **compatible** avec les deux (un x valant 1 ou 2 verifie x >= 0) - elle n'est pas impliquee dans le conflit, donc Z3 l'ecarte du core. C'est ce qui distingue le core d'une simple liste de contraintes : il isole la **cause**, pas le contexte.
 
-> Note port : le notebook C# original compare ici l'API brute (`Check(assumptions)` + `UnsatCore`) avec le DSL Z3.Linq (`Explain()`). Le DSL n'existe pas en pyz3 - l'API brute `assert_and_track` + `unsat_core` est l'equivalent direct, et c'est elle que cette section demontre.",,,,,,,,2787306e8590cefe,,,,,,,
+> Note port : le notebook C# original compare ici l'API brute (`Check(assumptions)` + `UnsatCore`) avec le DSL Z3.Linq (`Explain()`). Le DSL n'existe pas en pyz3 - l'API brute `assert_and_track` + `unsat_core` est l'equivalent direct, et c'est elle que cette section demontre.",,,,,,,,199432fb30851a89,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-13-UnsatCores.ipynb,fce97350,code,fr,2ac6415d7f43d26e,"# Core minimal : {x==1, x==2} ecarte x>=0 (innocente, non impliquee)
 w = Int('w')
 s4 = Solver()
@@ -6881,28 +6881,28 @@ print(""Check(assumptions) : %s"" % s4.check())
 core = s4.unsat_core()
 print(""UnsatCore = { %s }   (x>=0 exclu du core)"" % '  '.join(str(c) for c in core))
 ",,,,,,,,2ac6415d7f43d26e,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-13-UnsatCores.ipynb,f30db165,markdown,fr,63be1a6dd6594588,"## 6. Ce que ce notebook a demontre
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-13-UnsatCores.ipynb,f30db165,markdown,fr,2995dfc9ef1605a1,"## 6. Ce que ce notebook a demontre
 
 Trois lecons sur le noyau d'insatisfiabilite :
 1. **Du verdict a l'explication** - `unsat` dit *qu'il n'y a pas* de solution ; `unsat_core()` dit *pourquoi* (lesquelles contraintes conflictuent).
 
-2. **Minimalite** - le core est le sous-ensemble **minimal** responsable : retirer un seul element le rend satisfiable. Les contraintes irrelevant (compatibles, redondantes) sont ecartees.
+2. **Minimalite** - le core est le sous-ensemble **minimal** responsable : retirer un seul élément le rend satisfiable. Les contraintes irrelevant (compatibles, redondantes) sont ecartees.
 
 3. **Actionnable** - sur une specification surcontrainte, le core pointe exactement la (ou les) contrainte(s) a relacher, transformant un echec de modelisation en diagnostic chirurgical.
 
 
 
-Cette capacite d'explication distingue un solveur d'un simple oracle booleen : il ne dit pas seulement *non*, il dit *a cause de quoi*.",,,,,,,,63be1a6dd6594588,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-13-UnsatCores.ipynb,0a3b9d82,markdown,fr,0b7dcc8651bac1de,"## 7. Exercices
+Cette capacite d'explication distingue un solveur d'un simple oracle booléen : il ne dit pas seulement *non*, il dit *a cause de quoi*.",,,,,,,,2995dfc9ef1605a1,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-13-UnsatCores.ipynb,0a3b9d82,markdown,fr,71f51d8d8a05acc3,"## 7. Exercices
 
-Les trois exercices ci-dessous vous font manipuler le UNSAT core sur des variantes : conflit cache parmi 4 contraintes (1), planning avec relachement (2), core minimal parmi 10 (3). Chaque stub est self-contained : les fonctions (`Int`, `Bool`, `Solver`, `assert_and_track`) sont definies dans les sections precedentes.",,,,,,,,0b7dcc8651bac1de,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-13-UnsatCores.ipynb,b2f2760f,markdown,fr,aa4c88a2893573df,"### Exercice 1 - Core sur un conflit cache (2 coupables parmi 4)
+Les trois exercices ci-dessous vous font manipuler le UNSAT core sur des variantes : conflit cache parmi 4 contraintes (1), planning avec relachement (2), core minimal parmi 10 (3). Chaque stub est self-contained : les fonctions (`Int`, `Bool`, `Solver`, `assert_and_track`) sont définies dans les sections précédentes.",,,,,,,,71f51d8d8a05acc3,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-13-UnsatCores.ipynb,b2f2760f,markdown,fr,3765c4ece7e53e5f,"### Exercice 1 - Core sur un conflit cache (2 coupables parmi 4)
 
 Construisez 4 contraintes sur `z` dont 2 sont compatibles et 2 en conflit (ex : `z <= 3`, `z >= 0`, `z == 7`, `z != 9`). Obtenez le core et verifiez qu'il ne contient **que** les 2 coupables.
 
 
 
-**Etapes** : `z = Int('z')`, 4 `assert_and_track` etiquetes, `check()`, afficher `unsat_core()` (doit exclure les 2 compatibles).",,,,,,,,aa4c88a2893573df,,,,,,,
+**Étapes** : `z = Int('z')`, 4 `assert_and_track` etiquetes, `check()`, afficher `unsat_core()` (doit exclure les 2 compatibles).",,,,,,,,3765c4ece7e53e5f,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-13-UnsatCores.ipynb,0ce4d320,code,fr,ca1daa42a89aadbf,"# Exercice 1 : core sur un conflit cache (2 coupables parmi 4)
 # TODO etudiant :
 # Etape 1 : z = Int('z') ; 4 contraintes etiquetees (2 compatibles, 2 en conflit)
@@ -6911,13 +6911,13 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-13-UnsatCores.ipynb,0ce4d320,c
 result = None  # TODO etudiant
 print(""Exercice 1 a completer : isolez les 2 contraintes coupables parmi 4"")
 ",,,,,,,,ca1daa42a89aadbf,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-13-UnsatCores.ipynb,c5ee334f,markdown,fr,261ff0e85b279aa7,"### Exercice 2 - Planning : identifier puis relacher la coupable
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-13-UnsatCores.ipynb,c5ee334f,markdown,fr,0406c66576239530,"### Exercice 2 - Planning : identifier puis relacher la coupable
 
-Encodez un planning sur `j` : (a) `j >= 8`, (b) `j <= 18`, (c) `j != 3`, (d) `j == 3`. Obtenez le core, identifiez la coupable, puis **relachez-la** (re-checkez le sous-ensemble sans elle) -> le systeme devient SATISFIABLE.
+Encodez un planning sur `j` : (a) `j >= 8`, (b) `j <= 18`, (c) `j != 3`, (d) `j == 3`. Obtenez le core, identifiez la coupable, puis **relachez-la** (re-checkez le sous-ensemble sans elle) -> le système devient SATISFIABLE.
 
 
 
-**Etapes** : core = {j!=3, j=3} ; retirer l'une des deux du solver ; re-`check()` -> `sat`.",,,,,,,,261ff0e85b279aa7,,,,,,,
+**Étapes** : core = {j!=3, j=3} ; retirer l'une des deux du solver ; re-`check()` -> `sat`.",,,,,,,,0406c66576239530,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-13-UnsatCores.ipynb,b81d82df,code,fr,ed282e8f0606c705,"# Exercice 2 : planning, identifier puis relacher la contrainte coupable
 # TODO etudiant :
 # Etape 1 : encoder (a)(b)(c)(d) sur j, obtenir le core
@@ -6926,13 +6926,13 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-13-UnsatCores.ipynb,b81d82df,c
 result = None  # TODO etudiant
 print(""Exercice 2 a completer : identifiez et relachez la contrainte coupable"")
 ",,,,,,,,ed282e8f0606c705,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-13-UnsatCores.ipynb,7a7d11cd,markdown,fr,9a15a908f48ea670,"### Exercice 3 - Core minimal parmi 10 contraintes
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-13-UnsatCores.ipynb,7a7d11cd,markdown,fr,640f31ad38479dd7,"### Exercice 3 - Core minimal parmi 10 contraintes
 
 Construisez 10 contraintes sur `k` : 3 conflictuelles (`k == 1`, `k == 2`, `k == 3`) + 7 compatibles (`k >= 0`, `k <= 100`, etc.). Le core doit valoir exactement **3** (les 3 incompatibles), les 7 compatibles etant ecartees.
 
 
 
-**Etapes** : 10 `assert_and_track` ; `check()` ; compter `len(unsat_core())` -> attendu 3.",,,,,,,,9a15a908f48ea670,,,,,,,
+**Étapes** : 10 `assert_and_track` ; `check()` ; compter `len(unsat_core())` -> attendu 3.",,,,,,,,640f31ad38479dd7,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-13-UnsatCores.ipynb,784a1255,code,fr,2aba8920eb79c644,"# Exercice 3 : core minimal parmi 10 contraintes
 # TODO etudiant :
 # Etape 1 : k = Int('k') ; 10 contraintes (3 k==n incompatibles + 7 compatibles)
@@ -6941,33 +6941,33 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-13-UnsatCores.ipynb,784a1255,c
 nb_coupables = None  # TODO etudiant
 print(""Exercice 3 a completer : mesurer |core| parmi 10 contraintes (attendu : 3)"")
 ",,,,,,,,2aba8920eb79c644,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-13-UnsatCores.ipynb,c1c75dde,markdown,fr,c85d9058eeab3e63,"## Conclusion
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-13-UnsatCores.ipynb,c1c75dde,markdown,fr,ab8544bb49c676a9,"## Conclusion
 
 Le UNSAT core transforme le solveur d'oracle binaire en **outil de diagnostic**. La ou `unsat` dit seulement ' impossible ', `unsat_core()` dit ' impossible **a cause de ces contraintes-la** ' - le sous-ensemble minimal responsible du conflit. Sur une specification surcontrainte, ce diagnostic est directement actionnable : il pointe la contrainte a relacher.
 
 
 
-Cette serie Z3-Python (notebooks 01 a 13) couvre maintenant les **trois postures** du solveur : **decider** (sat/unsat, 01-11), **optimiser** (Optimize, 06/08), et ici **expliquer** (unsat_core, 13). La ou l'ingenieur classique debug a l'aveugle un systeme insatisfiable, le solveur SMT isole chirurgicalement la cause - la difference entre un oracle et un partenaire de raisonnement.",,,,,,,,c85d9058eeab3e63,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-14-BitVectors-Overflow.ipynb,af607fd1,markdown,fr,cdd9d24fb33c5dcc,"← [13 - UNSAT cores](Z3-Python-13-UnsatCores.ipynb) | [README Z3-Python](README.md)
+Cette serie Z3-Python (notebooks 01 a 13) couvre maintenant les **trois postures** du solveur : **decider** (sat/unsat, 01-11), **optimiser** (Optimize, 06/08), et ici **expliquer** (unsat_core, 13). La ou l'ingenieur classique debug a l'aveugle un système insatisfiable, le solveur SMT isole chirurgicalement la cause - la différence entre un oracle et un partenaire de raisonnement.",,,,,,,,ab8544bb49c676a9,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-14-BitVectors-Overflow.ipynb,af607fd1,markdown,fr,fe5ddd90faccf7e0,"← [13 - UNSAT cores](Z3-Python-13-UnsatCores.ipynb) | [README Z3-Python](README.md)
 
 # 14. Bit-vectors : verifier le debordement arithmetique
 
 Jusqu'ici nous avons raisonne sur des **entiers non bornes** (`Int`) ou des **reels exacts** (`Real`). Mais un ordinateur calcule sur des **entiers bornes** : un `uint32` ne peut pas depasser `2^32 - 1`, et l'addition **enveloppe** (wraps) modulo `2^32` quand la somme depasse. Ce debordement (overflow) est la source de bugs legendaires (Ariane 5, OpenSSL, Pac-Man) et la cible centrale de la **verification formelle** de code.
 
-Z3 traite les entiers machines via la theorie des **bit-vectors** (`BitVec`, SMT-LIB `BV`) : un vecteur de *n* bits interprete comme un entier modulo 2^n, avec addition/multiplication/comparaisons/bit-a-bit **tous decidables**. Ce notebook demontre la capacite distinctive de cette theorie : **prouver** qu'un debordement est inevitable (ou impossible) sur le domaine machine tout entier - pas seulement le constater sur des valeurs fixes.
+Z3 traite les entiers machines via la théorie des **bit-vectors** (`BitVec`, SMT-LIB `BV`) : un vecteur de *n* bits interprete comme un entier modulo 2^n, avec addition/multiplication/comparaisons/bit-a-bit **tous decidables**. Ce notebook demontre la capacite distinctive de cette théorie : **prouver** qu'un debordement est inevitable (ou impossible) sur le domaine machine tout entier - pas seulement le constater sur des valeurs fixes.
 
-> Port pyz3 du notebook C# [`15_BitVectors_Overflow.ipynb`](../Z3-Linq2Z3/15_BitVectors_Overflow.ipynb). EPIC #1206, Prong B. (Le bloc DSL `[BitVecWidth(n)]` du C#, specifique a Z3.Linq, n'est pas porte ; l'API brute pyz3 `BitVec` fait le meme travail.)",,,,,,,,cdd9d24fb33c5dcc,,,,,,,
+> Port pyz3 du notebook C# [`15_BitVectors_Overflow.ipynb`](../Z3-Linq2Z3/15_BitVectors_Overflow.ipynb). EPIC #1206, Prong B. (Le bloc DSL `[BitVecWidth(n)]` du C#, spécifique a Z3.Linq, n'est pas porte ; l'API brute pyz3 `BitVec` fait le même travail.)",,,,,,,,fe5ddd90faccf7e0,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-14-BitVectors-Overflow.ipynb,82cdf549,code,fr,c33dd8a0d2fa0ac6,"from z3 import *
 print(""Imports OK : z3-solver (theorie BitVec)"")
 ",,,,,,,,c33dd8a0d2fa0ac6,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-14-BitVectors-Overflow.ipynb,49849769,markdown,fr,5e6b52ab3999d678,"## 1. La theorie des bit-vectors (SMT-LIB `BitVec`)
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-14-BitVectors-Overflow.ipynb,49849769,markdown,fr,9fd183b6943cd587,"## 1. La théorie des bit-vectors (SMT-LIB `BitVec`)
 
-Un **bit-vector** est une suite de *n* bits interpretee comme un entier modulo 2^n. Z3 en fait une **theorie de decision** (pas une approximation) : l'addition, la multiplication, les comparaisons et les operations bit-a-bit sont definies modulo 2^n et decidables. En pyz3, `BitVec('x', 32)` cree un vecteur de 32 bits, `BitVecVal(v, 32)` une valeur, `ULT`/`UGE` les comparaisons **non signees**, `Extract(hi, lo, x)` l'extraction de champ.
+Un **bit-vector** est une suite de *n* bits interpretee comme un entier modulo 2^n. Z3 en fait une **théorie de decision** (pas une approximation) : l'addition, la multiplication, les comparaisons et les opérations bit-a-bit sont définies modulo 2^n et decidables. En pyz3, `BitVec('x', 32)` créé un vecteur de 32 bits, `BitVecVal(v, 32)` une valeur, `ULT`/`UGE` les comparaisons **non signees**, `Extract(hi, lo, x)` l'extraction de champ.
 
-La distinction cle : `Int` (non borne, `a + b >= a` toujours vrai pour `b >= 0`) vs `BitVec` (borne, `a + b` peut envelopper et devenir `< a`). C'est cette borne fixe qui rend le **debordement expressible** - et decidable.",,,,,,,,5e6b52ab3999d678,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-14-BitVectors-Overflow.ipynb,1a1b97f0,markdown,fr,80bc1cd81fae3235,"## 2. Le debordement se produit (et Z3 le calcule)
+La distinction cle : `Int` (non borne, `a + b >= a` toujours vrai pour `b >= 0`) vs `BitVec` (borne, `a + b` peut envelopper et devenir `< a`). C'est cette borne fixe qui rend le **debordement expressible** - et decidable.",,,,,,,,9fd183b6943cd587,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-14-BitVectors-Overflow.ipynb,1a1b97f0,markdown,fr,dd6e4ac97ef84f50,"## 2. Le debordement se produit (et Z3 le calcule)
 
-Additionnons deux valeurs dont la somme mathematique **depasse 2^32**. En `uint32`, `3 000 000 000 + 1 500 000 000 = 4 500 000 000` mathematiquement, mais la valeur machine **enveloppe** (retranche 2^32). Z3 calcule la valeur exacte apres enveloppement.",,,,,,,,80bc1cd81fae3235,,,,,,,
+Additionnons deux valeurs dont la somme mathematique **depasse 2^32**. En `uint32`, `3 000 000 000 + 1 500 000 000 = 4 500 000 000` mathematiquement, mais la valeur machine **enveloppe** (retranche 2^32). Z3 calcule la valeur exacte après enveloppement.",,,,,,,,dd6e4ac97ef84f50,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-14-BitVectors-Overflow.ipynb,d53f88dc,code,fr,5f6972e10922eb56,"# Deux valeurs dont la somme depasse 2^32 = 4 294 967 296
 a = BitVecVal(3000000000, 32)   # 3 milliards : tient en uint32
 b = BitVecVal(1500000000, 32)   # 1,5 milliard
@@ -6989,11 +6989,11 @@ print(""Requete 'somme < a' pour a=3e9, b=1.5e9 : %s"" % st)
 if st == sat:
     print(""-> SAT : ULT(somme, a) tient, le debordement est confirme."")
 ",,,,,,,,c671838aa5e64242,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-14-BitVectors-Overflow.ipynb,e339ddba,markdown,fr,69c3ed3d2bcdf196,"## 4. Prouve symbolique : `x, y >= 2^31` implique `x + y` deborde
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-14-BitVectors-Overflow.ipynb,e339ddba,markdown,fr,01b72df05d0767ed,"## 4. Prouve symbolique : `x, y >= 2^31` implique `x + y` deborde
 
-Le vrai pouvoir de la theorie BitVec n'est pas de constater un debordement sur des valeurs fixes, mais de **prouver** qu'il est inevitable pour toute une classe d'entrees. Prouvons : pour tout `x, y >= 2^31` (la moitie superieure de l'intervalle uint32), `x + y` deborde.
+Le vrai pouvoir de la théorie BitVec n'est pas de constater un debordement sur des valeurs fixes, mais de **prouver** qu'il est inevitable pour toute une classe d'entrees. Prouvons : pour tout `x, y >= 2^31` (la moitie superieure de l'intervalle uint32), `x + y` deborde.
 
-Technique : par **refutation**. Si la propriete etait fausse, il existerait `x, y >= 2^31` avec `somme >= x` (pas de debordement). On demande au solveur un tel contre-exemple - s'il repond `unsat`, la propriete est **prouvee**.",,,,,,,,69c3ed3d2bcdf196,,,,,,,
+Technique : par **refutation**. Si la propriete etait fausse, il existerait `x, y >= 2^31` avec `somme >= x` (pas de debordement). On demande au solveur un tel contre-exemple - s'il repond `unsat`, la propriete est **prouvee**.",,,,,,,,01b72df05d0767ed,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-14-BitVectors-Overflow.ipynb,3b33ca14,code,fr,6e71853f4c3e56b8,"# Pour x, y SYMBOLES (quelconques), prouvons : x,y >= 2^31  =>  x+y deborde
 x = BitVec('x', 32)
 y = BitVec('y', 32)
@@ -7016,9 +7016,9 @@ if st2 == unsat:
 else:
     print(""  -> SAT : contre-exemple trouve (le theoreme est faux)."")
 ",,,,,,,,6e71853f4c3e56b8,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-14-BitVectors-Overflow.ipynb,99f1a62d,markdown,fr,050740e0496a2e61,"## 5. Prouve de surete : `p, q < 1000` implique `p + q` ne deborde pas
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-14-BitVectors-Overflow.ipynb,99f1a62d,markdown,fr,fc2b3d9bd863f630,"## 5. Prouve de surete : `p, q < 1000` implique `p + q` ne deborde pas
 
-Symetrique du precedent : prouvons une **garantie de surete**. Pour tout `p, q < 1000`, l'addition uint32 ne deborde jamais. Meme technique par refutation : s'il existait `p, q < 1000` avec debordement, le solveur les trouverait ; `unsat` prouve la surete.",,,,,,,,050740e0496a2e61,,,,,,,
+Symetrique du précédent : prouvons une **garantie de surete**. Pour tout `p, q < 1000`, l'addition uint32 ne deborde jamais. Même technique par refutation : s'il existait `p, q < 1000` avec debordement, le solveur les trouverait ; `unsat` prouve la surete.",,,,,,,,fc2b3d9bd863f630,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-14-BitVectors-Overflow.ipynb,40d86794,code,fr,d3d70d5a783c96ae,"# Propriete : si p < 1000 ET q < 1000, alors p+q ne deborde pas (somme >= p)
 p = BitVec('p', 32)
 q = BitVec('q', 32)
@@ -7041,9 +7041,9 @@ if st3 == unsat:
 else:
     print(""  -> SAT : contre-exemple trouve (improbable)."")
 ",,,,,,,,d3d70d5a783c96ae,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-14-BitVectors-Overflow.ipynb,a3796f01,markdown,fr,dd587040d0034f36,"## 6. Combiner arithmetique et bit-a-bit : extraction de champ
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-14-BitVectors-Overflow.ipynb,a3796f01,markdown,fr,b80739204a39d58a,"## 6. Combiner arithmetique et bit-a-bit : extraction de champ
 
-La theorie BitVec ne se limite pas a l'arithmetique : elle raisonne aussi au **niveau bit**. `Extract(hi, lo, n)` extrait les bits `lo` a `hi` d'un vecteur. Question : existe-t-il un `n` non nul dont les deux octets de poids faible sont egaux ? Z3 produit un **temoin** concret.",,,,,,,,dd587040d0034f36,,,,,,,
+La théorie BitVec ne se limite pas a l'arithmetique : elle raisonne aussi au **niveau bit**. `Extract(hi, lo, n)` extrait les bits `lo` a `hi` d'un vecteur. Question : existe-t-il un `n` non nul dont les deux octets de poids faible sont egaux ? Z3 produit un **temoin** concret.",,,,,,,,b80739204a39d58a,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-14-BitVectors-Overflow.ipynb,d9cb4a4e,code,fr,6d2ad2a494618dfc,"# Combiner arithmetique et bit-a-bit : extraction de champ
 n = BitVec('n', 32)
 
@@ -7066,7 +7066,7 @@ if st4 == sat:
 print()
 print(""-> Extract + egalite = raisonnement au niveau champ binaire (protocoles, formats)."")
 ",,,,,,,,6d2ad2a494618dfc,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-14-BitVectors-Overflow.ipynb,db8bc537,markdown,fr,f0ffaa48b7114fc4,"## 7. Pourquoi la largeur fixe : BitVec vs Int
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-14-BitVectors-Overflow.ipynb,db8bc537,markdown,fr,bb0855d6a2ccbcb3,"## 7. Pourquoi la largeur fixe : BitVec vs Int
 
 Le predicat non-trivial `a + b < a` avec `b >= 1` illustre ce que la **largeur fixe** achete :
 - Sur des **bit-vectors 4 bits** (modulo 16), `a + b` peut envelopper et devenir `< a` -> le solveur trouve un temoin (`sat`).
@@ -7075,7 +7075,7 @@ Le predicat non-trivial `a + b < a` avec `b >= 1` illustre ce que la **largeur f
 
 
 
-Ce contraste EST la semantique de la theorie BitVec : sans la largeur fixe, le debordement est **inexpressible**. C'est pourquoi la verification de code machine (entiers bornes) exige BitVec, pas Int.",,,,,,,,f0ffaa48b7114fc4,,,,,,,
+Ce contraste EST la sémantique de la théorie BitVec : sans la largeur fixe, le debordement est **inexpressible**. C'est pourquoi la verification de code machine (entiers bornes) exige BitVec, pas Int.",,,,,,,,bb0855d6a2ccbcb3,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-14-BitVectors-Overflow.ipynb,5041db91,code,fr,15fbfc2b5f3dabd4,"# Le meme predicat ' a + b < a, b >= 1 ' sur BitVec 4 bits vs entiers non bornes
 
 # (a) BitVec 4 bits : l'addition enveloppe modulo 16 -> temoin possible
@@ -7100,10 +7100,10 @@ sInt.add(ib >= 1)
 sInt.add(ia + ib < ia)               # a + b < a  sur les entiers
 print(""Int : meme predicat sur entiers non bornes -> %s  (aucun debordement)"" % sInt.check())
 ",,,,,,,,15fbfc2b5f3dabd4,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-14-BitVectors-Overflow.ipynb,9d87536f,markdown,fr,767eec4258f88ff5,"## 8. Ce que ce notebook a demontre
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-14-BitVectors-Overflow.ipynb,9d87536f,markdown,fr,668d9c33f86afa49,"## 8. Ce que ce notebook a demontre
 
-Quatre capacites de la theorie BitVec, inaccessibles a `Int` (non borne) ou au calcul numerique classique :
-1. **Calcul exact apres enveloppement** - la valeur machine reelle (3e9+1.5e9 = 205032704 apres wrap), pas une approximation.
+Quatre capacites de la théorie BitVec, inaccessibles a `Int` (non borne) ou au calcul numérique classique :
+1. **Calcul exact après enveloppement** - la valeur machine reelle (3e9+1.5e9 = 205032704 après wrap), pas une approximation.
 
 2. **Preuve d'inevitabilite** (`unsat`) - pour toute entree `x,y >= 2^31`, le debordement est force, prouve sur tout le domaine.
 
@@ -7113,17 +7113,17 @@ Quatre capacites de la theorie BitVec, inaccessibles a `Int` (non borne) ou au c
 
 
 
-Ces quatre postures font de BitVec la theorie canonique de la **verification formelle** : prouver qu'un code (compilateur, crypto, protocole) respecte ses bornes sur toutes les entrees possibles, pas seulement sur les cas testes.",,,,,,,,767eec4258f88ff5,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-14-BitVectors-Overflow.ipynb,bf91ac0d,markdown,fr,1eb45e0495a1663d,"## 9. Exercices
+Ces quatre postures font de BitVec la théorie canonique de la **verification formelle** : prouver qu'un code (compilateur, crypto, protocole) respecte ses bornes sur toutes les entrees possibles, pas seulement sur les cas testes.",,,,,,,,668d9c33f86afa49,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-14-BitVectors-Overflow.ipynb,bf91ac0d,markdown,fr,efaa7b909c7c934d,"## 9. Exercices
 
-Les trois exercices ci-dessous vous font manipuler BitVec sur des variantes : debordement signe vs non signe (1), borne exacte du debordement pour `t + t` (2), produit qui deborde (3). Chaque stub est self-contained : les fonctions (`BitVec`, `BitVecVal`, `ULT`/`UGE`, `Solver`) sont definies dans les sections precedentes.",,,,,,,,1eb45e0495a1663d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-14-BitVectors-Overflow.ipynb,0f5a7782,markdown,fr,d14ba220ef797843,"### Exercice 1 - Deborde signe mais pas non signe
+Les trois exercices ci-dessous vous font manipuler BitVec sur des variantes : debordement signe vs non signe (1), borne exacte du debordement pour `t + t` (2), produit qui deborde (3). Chaque stub est self-contained : les fonctions (`BitVec`, `BitVecVal`, `ULT`/`UGE`, `Solver`) sont définies dans les sections précédentes.",,,,,,,,efaa7b909c7c934d,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-14-BitVectors-Overflow.ipynb,0f5a7782,markdown,fr,6b18d43ef535f1d2,"### Exercice 1 - Deborde signe mais pas non signe
 
 Trouvez `a, b` tels que `a + b` deborde en **signe** (la somme devient negative, `somme < 0` signed) mais PAS en non signe (`somme >= a` unsigned reste vrai). Indice : choisissez `a, b` proches de `2^31 - 1` (la limite positive d'un int32 signe).
 
 
 
-**Etapes** : `a, b = BitVecVal(..., 32)` ; verifier `UGE(somme, a)` vrai (pas de debord non signe) MAIS `simplify(somme < 0)` ... attention, `< 0` en pyz3 sur BitVec est signe par defaut.",,,,,,,,d14ba220ef797843,,,,,,,
+**Étapes** : `a, b = BitVecVal(..., 32)` ; verifier `UGE(somme, a)` vrai (pas de debord non signe) MAIS `simplify(somme < 0)` ... attention, `< 0` en pyz3 sur BitVec est signe par defaut.",,,,,,,,6b18d43ef535f1d2,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-14-BitVectors-Overflow.ipynb,56584e40,code,fr,06c149de66e73441,"# Exercice 1 : a+b deborde en SIGNE mais pas en non signe
 # TODO etudiant :
 # Etape 1 : a, b proches de 2^31 - 1 (int32 max signe)
@@ -7132,13 +7132,13 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-14-BitVectors-Overflow.ipynb,5
 result = None  # TODO etudiant
 print(""Exercice 1 a completer : debordement signe vs non signe"")
 ",,,,,,,,06c149de66e73441,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-14-BitVectors-Overflow.ipynb,c5a729d6,markdown,fr,b74e72c90a01cb7b,"### Exercice 2 - Borne exacte du debordement pour `t + t`
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-14-BitVectors-Overflow.ipynb,c5a729d6,markdown,fr,4a7878f676ac6639,"### Exercice 2 - Borne exacte du debordement pour `t + t`
 
 Pour `a = b = t`, a partir de quelle plus petite valeur de `t` l'addition `t + t` deborde-t-elle (en unsigned) ? Prouvez que `t >= 2^31` implique debordement, et que `t = 2^31 - 1` ne deborde pas.
 
 
 
-**Etapes** : `tt = t + t` ; `debord = ULT(tt, t)` ; solver avec `t >= 2^31` -> `sat` ; avec `t == 2^31 - 1` -> pas de debord.",,,,,,,,b74e72c90a01cb7b,,,,,,,
+**Étapes** : `tt = t + t` ; `debord = ULT(tt, t)` ; solver avec `t >= 2^31` -> `sat` ; avec `t == 2^31 - 1` -> pas de debord.",,,,,,,,4a7878f676ac6639,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-14-BitVectors-Overflow.ipynb,b6e44490,code,fr,cf8aec09cd3e152c,"# Exercice 2 : borne exacte du debordement pour a=b=t
 # TODO etudiant :
 # Etape 1 : t = BitVec('t', 32) ; tt = t + t ; debord = ULT(tt, t)
@@ -7147,13 +7147,13 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-14-BitVectors-Overflow.ipynb,b
 result = None  # TODO etudiant
 print(""Exercice 2 a completer : borne exacte du debordement pour t+t"")
 ",,,,,,,,cf8aec09cd3e152c,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-14-BitVectors-Overflow.ipynb,59263542,markdown,fr,290237337b632568,"### Exercice 3 - Prouver que `65536 * 65536` deborde en BV32
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-14-BitVectors-Overflow.ipynb,59263542,markdown,fr,cb5edecced68d22e,"### Exercice 3 - Prouver que `65536 * 65536` deborde en BV32
 
 `65536 = 2^16`, donc `65536 * 65536 = 2^32`, qui en uint32 vaut exactement `0` (enveloppe complet). Prouvez que le produit deborde : `produit < 65536` (unsigned), ou directement `produit == 0`.
 
 
 
-**Etapes** : `m1 = m2 = BitVecVal(65536, 32)` ; `produit = m1 * m2` ; `solver.add(produit == 0)` -> `sat` (preuve que le produit enveloppe a 0).",,,,,,,,290237337b632568,,,,,,,
+**Étapes** : `m1 = m2 = BitVecVal(65536, 32)` ; `produit = m1 * m2` ; `solver.add(produit == 0)` -> `sat` (preuve que le produit enveloppe a 0).",,,,,,,,cb5edecced68d22e,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-14-BitVectors-Overflow.ipynb,c559cf3b,code,fr,f39e7ee3ca546f50,"# Exercice 3 : prouver que 65536 * 65536 deborde en BV32
 # TODO etudiant :
 # Etape 1 : m1 = BitVecVal(65536, 32) ; m2 = BitVecVal(65536, 32)
@@ -7162,13 +7162,13 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-14-BitVectors-Overflow.ipynb,c
 result = None  # TODO etudiant
 print(""Exercice 3 a completer : prouvez que 65536 * 65536 = 0 en BV32"")
 ",,,,,,,,f39e7ee3ca546f50,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-14-BitVectors-Overflow.ipynb,57726c37,markdown,fr,72c28870be8a7590,"## Conclusion
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-14-BitVectors-Overflow.ipynb,57726c37,markdown,fr,8171e4cdc09cc20a,"## Conclusion
 
-La theorie des bit-vectors de Z3 est l'outil canonique de la **verification formelle de code**. La ou `Int` (entiers non bornes) rend le debordement inexpressible, `BitVec` modelise l'arithmetique machine exacte (modulo 2^n) et permet de **prouver** des proprietes de surete ou d'inevitabilite sur tout le domaine des entrees.
+La théorie des bit-vectors de Z3 est l'outil canonique de la **verification formelle de code**. La ou `Int` (entiers non bornes) rend le debordement inexpressible, `BitVec` modelise l'arithmetique machine exacte (modulo 2^n) et permet de **prouver** des proprietes de surete ou d'inevitabilite sur tout le domaine des entrees.
 
 
 
-Cette serie Z3-Python (notebooks 01 a 14) couvre maintenant les grandes theories du solveur : entiers et optimisation (01-11), reels exacts (12), diagnostic par UNSAT cores (13), et ici l'**arithmetique machine bornee** (14). Chacune exerce une capacite distincte qu'aucune approche numerique classique ne peut reproduire : decision exacte, non pas approximation.",,,,,,,,72c28870be8a7590,,,,,,,
+Cette serie Z3-Python (notebooks 01 a 14) couvre maintenant les grandes théories du solveur : entiers et optimisation (01-11), reels exacts (12), diagnostic par UNSAT cores (13), et ici l'**arithmetique machine bornee** (14). Chacune exerce une capacite distincte qu'aucune approche numérique classique ne peut reproduire : decision exacte, non pas approximation.",,,,,,,,8171e4cdc09cc20a,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-15-Nested-Arrays-2D.ipynb,197090c5,markdown,fr,bcfe96f38d511459,"← [11 - Coloration de graphe](Z3-Python-11-Graph-Coloring.ipynb) | [README Z3-Python](README.md)
 
 # 15. Tableaux imbriqués et grilles 2D : carrés latins, Sudoku 4×4, carré magique

--- a/translations/smt/z3-linq2z3.csv
+++ b/translations/smt/z3-linq2z3.csv
@@ -28,11 +28,11 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,af777fe7,code
 #r ""../Z3.Linq/.deploy/Z3.Linq.dll""
 using Z3.Linq; using Microsoft.Z3; using System; using System.Text; using System.Diagnostics; using System.Linq;
 Console.WriteLine(""Imports OK : Z3.Linq (.deploy fork), Microsoft.Z3, System.Linq"");",,,,,,,,ab6444dce2e770a0,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,aa11516a,markdown,fr,ecbaf9fa7bdee44f,"### Qu'est-ce que Z3.Linq ?
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,aa11516a,markdown,fr,93ca0bc787e13c10,"### Qu'est-ce que Z3.Linq ?
 
 **Z3.Linq** est une bibliothèque qui combine deux technologies puissantes:
 
-1. **Z3**: Un solveur SMT (Satisfiability Modulo Theories) développé par Microsoft Research
+1. **Z3**: Un solveur SMT (Satisfiability Modulo Théories) développé par Microsoft Research
    - Résout des problèmes de satisfaction de contraintes
    - Supporte les entiers, réels, tableaux, structures de données, etc.
 
@@ -47,7 +47,7 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,aa11516a,mark
 - Problèmes de planification et d'ordonnancement
 - Vérification formelle
 - Puzzles logiques (Sudoku, n-Queens, etc.)
-",,,,,,,,ecbaf9fa7bdee44f,,,,,,,
+",,,,,,,,93ca0bc787e13c10,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,a1b2c3d4,markdown,fr,923ed39149f6455e,"### Architecture de la pipeline Z3.Linq
 
 Le diagramme ci-dessous illustre le chemin complet d'une contrainte LINQ jusqu'à l'objet C# résultat :
@@ -79,7 +79,7 @@ var solution = theorem.Solve();
 Console.WriteLine(""X1 = {0}, X2 = {1}, X3 = {2}, X4 = {3}, X5 = {4}"", solution.X1, solution.X2, solution.X3, solution.X4, solution.X5);
 
 }",,,,,,,,60c3ffc5562dc09b,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,83a2c736,markdown,fr,4de17853a7677863,"### Analyse de l'exemple
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,83a2c736,markdown,fr,fbcf9f0c469be1f9,"### Analyse de l'exemple
 
 **Ce que fait le code:**
 
@@ -102,7 +102,7 @@ X2 = 6·X4
 Le solveur Z3 trouve une solution (il peut y en avoir plusieurs). L'exécution ci-dessus donne par exemple :
 - Une affectation valide : X1 = 3, X2 = 0, X3 = 1, X4 = 0, X5 = 1
 
-> **Note**: Z3 est un solveur SMT (Satisfiability Modulo Theories) capable de résoudre des contraintes sur des entiers, des réels, des tableaux, etc. LINQ To Z3 offre une interface C# naturelle pour exprimer ces contraintes. Pour les fondements théoriques de la résolution SMT (DPLL(T)) et la présentation du solveur Z3 lui-même, voir de Moura & Bjørner, *Z3: An Efficient SMT Solver* (TACAS 2008) et Nieuwenhuis, Oliveras & Tinelli, *Solving SAT and SAT Modulo Theories: From an Abstract DPLL Procedure to DPLL(T)* (JACM 2006) ; la théorie des tableaux (notebook 4) et le standard SMT-LIB (notebooks 4, 10) sont ancrés dans la section Références du README.",,,,,,,,4de17853a7677863,,,,,,,
+> **Note**: Z3 est un solveur SMT (Satisfiability Modulo Théories) capable de résoudre des contraintes sur des entiers, des réels, des tableaux, etc. LINQ To Z3 offre une interface C# naturelle pour exprimer ces contraintes. Pour les fondements théoriques de la résolution SMT (DPLL(T)) et la présentation du solveur Z3 lui-même, voir de Moura & Bjørner, *Z3: An Efficient SMT Solver* (TACAS 2008) et Nieuwenhuis, Oliveras & Tinelli, *Solving SAT and SAT Modulo Théories: From an Abstract DPLL Procedure to DPLL(T)* (JACM 2006) ; la théorie des tableaux (notebook 4) et le standard SMT-LIB (notebooks 4, 10) sont ancrés dans la section Références du README.",,,,,,,,fbcf9f0c469be1f9,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,9c55885b,markdown,fr,228823198868b81f,"### SAT et UNSAT — le concept fondateur d'un solveur
 
 Jusqu'ici, chaque appel à `Solve()` a renvoyé une solution. Mais la question fondamentale que tranche un solveur SMT n'est pas « quelle est la solution ? » — c'est **« une solution existe-t-elle ? »**. C'est ce que désigne le **S** de SMT : *Satisfiability*.
@@ -341,17 +341,17 @@ Le code ci-dessus résout le problème classique des **3 missionnaires et 3 cann
 
 > **Note**: La méthode `Solve()` trouve **une** solution satisfaisant les contraintes, mais pas nécessairement la plus courte. Pour obtenir la solution optimale, il faut utiliser `Optimize()` (voir section suivante).
 ",,,,,,,,01e970dbf43f3d68,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,b81a1e52,markdown,fr,6ae25a028bcc2861,"### Exercice 2 : Probleme de dimensionnement (n-Queens lite)
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,b81a1e52,markdown,fr,d38681429e986d03,"### Exercice 2 : Problème de dimensionnement (n-Queens lite)
 
-Il s'agit de placer N reines sur un echiquier NxN de sorte qu'aucune ne soit sur la meme ligne, colonne ou diagonale qu'une autre.
+Il s'agit de placer N reines sur un echiquier NxN de sorte qu'aucune ne soit sur la même ligne, colonne ou diagonale qu'une autre.
 
 **Objectif** : Modelisez un echiquier 4x4 avec Z3.Linq. Chaque variable represente la colonne de la reine sur la ligne correspondante.
 
 **Indices** :
 - Utilisez `Symbols<int, int, int, int>` pour un echiquier 4x4
-- Contrainte 1 : toutes les colonnes differentes (Q1 != Q2 != Q3 != Q4)
+- Contrainte 1 : toutes les colonnes différentes (Q1 != Q2 != Q3 != Q4)
 - Contrainte 2 : pas de diagonale => |Qi - Qj| != |i - j|
-- Utilisez `Math.Abs` pour la valeur absolue des differences",,,,,,,,6ae25a028bcc2861,,,,,,,
+- Utilisez `Math.Abs` pour la valeur absolue des différences",,,,,,,,d38681429e986d03,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,26bfd605,code,fr,e16eaf1cd86a9e31,"// Exercice 2 : n-Queens 4x4 avec Z3.Linq
 // TODO etudiant : placez 4 reines sur un echiquier 4x4
 // Etape 1 : definissez un theoreme avec 4 variables (Q1, Q2, Q3, Q4)
@@ -434,17 +434,17 @@ var stopWatch = new Stopwatch();
 
 
 ",,,,,,,,092a50335aaf5191,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,b6cb8246,markdown,fr,edbbb37d103d211b,"### Exercice 3 : Variante du probleme - Loups, Chevres et Choux
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,b6cb8246,markdown,fr,65e33642b6a0e544,"### Exercice 3 : Variante du problème - Loups, Chevres et Choux
 
-Generalisez le modele des missionnaires-cannibales pour resoudre un probleme voisin : un fermier doit traverser une riviere avec un loup, une chevre et un chou. La barque ne peut transporter que le fermier plus un seul item. Le loup mange la chevre et la chevre mange le chou s'ils restent seuls ensemble.
+Generalisez le modèle des missionnaires-cannibales pour resoudre un problème voisin : un fermier doit traverser une riviere avec un loup, une chevre et un chou. La barque ne peut transporter que le fermier plus un seul item. Le loup mange la chevre et la chevre mange le chou s'ils restent seuls ensemble.
 
-**Objectif** : Adaptez la classe `CanibalsAndMissionaries` ou creez un nouveau modele Z3.Linq pour ce probleme.
+**Objectif** : Adaptez la classe `CanibalsAndMissionaries` ou créez un nouveau modèle Z3.Linq pour ce problème.
 
 **Indices** :
 - Le fermier est toujours dans la barque (pas besoin de variable separree, il est implicite)
 - 3 items a transporter : L (loup), C (chevre), X (chou)
 - Invariant : le fermier ne peut pas laisser (L+C) ou (C+X) seuls sur une rive
-- Utilisez un codage similaire avec des tableaux pour les positions a chaque etape",,,,,,,,edbbb37d103d211b,,,,,,,
+- Utilisez un codage similaire avec des tableaux pour les positions a chaque étape",,,,,,,,65e33642b6a0e544,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,1ba631d6,code,fr,84e038c7d6d9b98e,"// Exercice 3 : Loups, Chevres et Choux avec Z3.Linq
 // TODO etudiant : modelisez le probleme du fermier, loup, chevre et chou
 // Etape 1 : definissez les variables d'etat (positions de chaque item par etape)
@@ -459,15 +459,15 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,1ba631d6,code
 // using (var ctx = new Z3Context()) { ... }
 
 Console.WriteLine(""Exercice a completer : loups, chevres et choux avec Z3.Linq"");",,,,,,,,84e038c7d6d9b98e,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,af7cac81,markdown,fr,f4872f8badf4f803,"## B9 - Environnements `record` positionnels (DSL `NewTheorem<PositionalRecord>`)
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,af7cac81,markdown,fr,68bb8ea4c490f7f6,"## B9 - Environnements `record` positionnels (DSL `NewTheorem<PositionalRecord>`)
 
-L'environnement d'un théorème (le type `T` passe a `NewTheorem<T>`) peut etre un **record positionnel** C# -- par exemple `record Point(int X, int Y)` -- et non une `class` mutable. La reconstruction de la solution passe alors par une branche dediee du solveur ([`Theorem.cs:993-1099`](../Z3.Linq/solutions/Z3.Linq/Theorem.cs#L993)) qui selectionne le *primary constructor* du record, evalue chaque parametre depuis le modele Z3, puis invoque `Activator.CreateInstance(t, args)` avec les valeurs positionnelles -- l'ancienne branche `Activator.CreateInstance(t)` throw sur un record sans constructeur sans parametre (un positional record n'expose que des `init`-only setters).
+L'environnement d'un théorème (le type `T` passe a `NewTheorem<T>`) peut etre un **record positionnel** C# -- par exemple `record Point(int X, int Y)` -- et non une `class` mutable. La reconstruction de la solution passe alors par une branche dediee du solveur ([`Theorem.cs:993-1099`](../Z3.Linq/solutions/Z3.Linq/Theorem.cs#L993)) qui selectionne le *primary constructor* du record, evalue chaque paramètre depuis le modèle Z3, puis invoque `Activator.CreateInstance(t, args)` avec les valeurs positionnelles -- l'ancienne branche `Activator.CreateInstance(t)` throw sur un record sans constructeur sans paramètre (un positional record n'expose que des `init`-only setters).
 
-Le mini-probleme : sur un point `(X, Y)` dans le plan, trouver le point satisfaisant `X + Y = 12` **et** `X = 2·Y` (solution unique attendue : `X = 8, Y = 4`).
+Le mini-problème : sur un point `(X, Y)` dans le plan, trouver le point satisfaisant `X + Y = 12` **et** `X = 2·Y` (solution unique attendue : `X = 8, Y = 4`).
 
 > **Stack : A+B** -- le raw doit gerer manuellement la reconstruction via `Model.Eval` sur chaque `IntExpr`, tandis que le DSL `NewTheorem<Point>().Where(...)` invoque la branche `ConstructFromModel` automatiquement ; l'objet rendu (`Point { X = 8, Y = 4 }`) est type C#, pas une paire de `IntNum`.
 
-**Ancre fork** : `Theorem.cs:993-1099` (branche `ConstructFromModel`), tests `Z3.Linq.Tests/RecordEnvTheoryTests.cs:18-91` (4 cas : positional standard, scalaires mixtes int+bool, trois parametres, UNSAT). La feature etait listee dans le backlog `B9` d'[#4688](https://github.com/jsboige/CoursIA/issues/4688) avec une ancre « a confirmer » -- le grep la trouve dans la branche reconstruction, **pas** dans la declaration de type (qui est du C# standard).",,,,,,,,f4872f8badf4f803,,,,,,,
+**Ancre fork** : `Theorem.cs:993-1099` (branche `ConstructFromModel`), tests `Z3.Linq.Tests/RecordEnvTheoryTests.cs:18-91` (4 cas : positional standard, scalaires mixtes int+bool, trois paramètres, UNSAT). La feature etait listee dans le backlog `B9` d'[#4688](https://github.com/jsboige/CoursIA/issues/4688) avec une ancre « a confirmer » -- le grep la trouve dans la branche reconstruction, **pas** dans la declaration de type (qui est du C# standard).",,,,,,,,68bb8ea4c490f7f6,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,999c4775,code,fr,1642dddcb8763e73,"// B9 - Record positionnel ""deux stacks"" sur le meme probleme (X+Y=12, X=2Y).
 //   Un point (X, Y) dans le plan, soumis a 2 contraintes lineaires.
 //   Solution unique attendue : X=8, Y=4.
@@ -528,9 +528,9 @@ public record PointRecord(int X, int Y) { }
     sUn.Assert(z3.MkLt(x, z3.MkInt(0)));
     Console.WriteLine($""[RAW]   X>=0 et X<0 : {sUn.Check()}   (aucune affectation)"");
 }",,,,,,,,1642dddcb8763e73,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,4ab72a78,markdown,fr,62aaa153f8fada23,"### Lecture B9 - deux ecritures d'un meme record, un meme resultat
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,4ab72a78,markdown,fr,a2979cc9c4ff412c,"### Lecture B9 - deux ecritures d'un même record, un même résultat
 
-Les deux ecritures resolvent **le meme systeme** (`X + Y = 12`, `X = 2·Y`) et produisent **le meme temoin** (`X = 8, Y = 4`), mais leur cout d'ecriture est asymetrique :
+Les deux ecritures resolvent **le même système** (`X + Y = 12`, `X = 2·Y`) et produisent **le même temoin** (`X = 8, Y = 4`), mais leur cout d'ecriture est asymetrique :
 
 | Aspect | Stack B (raw Microsoft.Z3) | Stack A (DSL Z3.Linq) |
 |--------|----------------------------|------------------------|
@@ -539,16 +539,16 @@ Les deux ecritures resolvent **le meme systeme** (`X + Y = 12`, `X = 2·Y`) et p
 | Verification | `MkSolver().Assert(...).Check()` + cast `IntNum`/parse dans le Model | `.Solve()` typé C# |
 | Reconstruction | `model.Eval(x, true).ToString()` + cast manuel + reconstruction `(x, y)` a la main | un simple `Point { X = 8, Y = 4 }` -- le binding a fait le reste |
 | Surface code | ~10 lignes significatives + risque d'erreur de typage des `IntNum` | 3 lignes de contraintes |
-| Constructeur sans parametre | non requis (le raw n'instancie jamais d'objet C#) | **necessaire dans le cas d'une `class` mutable**, **interdit dans le cas d'un record** (l'ancienne branche `Activator.CreateInstance(t)` throw) |
+| Constructeur sans paramètre | non requis (le raw n'instancie jamais d'objet C#) | **necessaire dans le cas d'une `class` mutable**, **interdit dans le cas d'un record** (l'ancienne branche `Activator.CreateInstance(t)` throw) |
 
-> **Ligne de contraste** : la valeur ajoutee du DSL ici n'est pas une fecondation d'expression (comme `Sum` qui replie N termes en un seul `MkAdd`), mais le **routage de reconstruction** -- la detection du type d'environnement (`class` mutable avec setter vs `record` positionnel vs type anonyme) et l'invocation de la bonne branche de [`Theorem.cs:993-1099`](../Z3.Linq/solutions/Z3.Linq/Theorem.cs#L993). Cote raw, c'est au chercheur de coder la reconstruction -- cote DSL, elle est *incluse par defaut* dans `NewTheorem<T>()`. Les tests unitaires `RecordEnvTheoryTests` (4 cas) verifient que la branche positionnelle couvre records a 2-3 params, scalaires mixtes (int + bool), et le retour `null` sur UNSAT.",,,,,,,,62aaa153f8fada23,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,68738069,markdown,fr,f49117462f86284b,"### Exercice 4 : record positionnel a 3 parametres (stability of constructor order)
+> **Ligne de contraste** : la valeur ajoutee du DSL ici n'est pas une fecondation d'expression (comme `Sum` qui replie N termes en un seul `MkAdd`), mais le **routage de reconstruction** -- la detection du type d'environnement (`class` mutable avec setter vs `record` positionnel vs type anonyme) et l'invocation de la bonne branche de [`Theorem.cs:993-1099`](../Z3.Linq/solutions/Z3.Linq/Theorem.cs#L993). Cote raw, c'est au chercheur de coder la reconstruction -- cote DSL, elle est *incluse par defaut* dans `NewTheorem<T>()`. Les tests unitaires `RecordEnvTheoryTests` (4 cas) verifient que la branche positionnelle couvre records a 2-3 params, scalaires mixtes (int + bool), et le retour `null` sur UNSAT.",,,,,,,,a2979cc9c4ff412c,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,68738069,markdown,fr,14c938d613183429,"### Exercice 4 : record positionnel a 3 paramètres (stability of constructor order)
 
-Reproduisez la demarche ci-dessus avec un record a **trois** parametres -- par exemple `record Triple(int A, int B, int C)` -- et trois contraintes scalaires (par exemple `A == 1, B == 2, C == 3`). Le solveur doit rendre un `Triple { A = 1, B = 2, C = 3 }`.
+Reproduisez la demarche ci-dessus avec un record a **trois** paramètres -- par exemple `record Triple(int A, int B, int C)` -- et trois contraintes scalaires (par exemple `A == 1, B == 2, C == 3`). Le solveur doit rendre un `Triple { A = 1, B = 2, C = 3 }`.
 
-**Variante discriminante** : declarez les contraintes dans un ordre different (par exemple `B == 2, C == 3, A == 1`). La solution reste-t-elle la meme ? Le matching des arguments du constructeur se fait-il par nom ou par position dans le `.Where` ?
+**Variante discriminante** : declarez les contraintes dans un ordre différent (par exemple `B == 2, C == 3, A == 1`). La solution reste-t-elle la même ? Le matching des arguments du constructeur se fait-il par nom ou par position dans le `.Where` ?
 
-**Indice** : voir [Theorem.cs:1076](..%2F..%2FZ3.Linq%2Fsolutions%2FZ3.Linq%2FTheorem.cs#L1076) -- la reconstruction selectionne le constructeur dont tous les parametres sont dans l'environnement, puis passe les args **positionnellement**.",,,,,,,,f49117462f86284b,,,,,,,
+**Indice** : voir [Theorem.cs:1076](..%2F..%2FZ3.Linq%2Fsolutions%2FZ3.Linq%2FTheorem.cs#L1076) -- la reconstruction selectionne le constructeur dont tous les paramètres sont dans l'environnement, puis passe les args **positionnellement**.",,,,,,,,14c938d613183429,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,851f1272,code,fr,873a5b11d9450446,"// Exercice 4 : record positionnel a 3 parametres avec Z3.Linq
 // TODO etudiant : modelisez un record Triple(int A, int B, int C) puis :
 // Etape 1 : declarez record Triple(int A, int B, int C) au niveau de la cellule
@@ -631,7 +631,7 @@ public class PlanningProblem
 // var solution = theorem.Optimize(...);
 
 Console.WriteLine(""Exercice a completer : modeliser un probleme de planification avec Z3.Linq"");",,,,,,,,e1275576fe8691fb,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,a1b2c3d4,markdown,fr,0dd4e57eb761e6c3,"# Sudoku : Théorème Explicite vs Modèle Implicite par Arrays
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,a1b2c3d4,markdown,fr,80f7a1b8417ea3a7,"# Sudoku : Théorème Explicite vs Modèle Implicite par Arrays
 
 **Navigation** : [Index SymbolicAI](../../README.md) | [Serie Z3](README.md) | [<< Introduction Linq2Z3](01_Linq2Z3_Intro.ipynb)
 
@@ -640,7 +640,7 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,a1b
 A la fin de ce notebook, vous saurez :
 1. Modeliser un Sudoku avec 81 proprietes explicites (approche naive)
 2. Modeliser un Sudoku avec une seule `List<int>` indexee par lambdas (approche implicite)
-3. Comprendre le mecanisme de capture de closure en C# et son role dans Z3.Linq
+3. Comprendre le mécanisme de capture de closure en C# et son rôle dans Z3.Linq
 4. Ajouter des indices (hints) pour resoudre un puzzle reel
 
 ### Prerequis
@@ -656,12 +656,12 @@ Ce notebook presente la **transition pedagogique cle** entre deux approches de m
 
 1. **L'approche explicite** : 81 proprietes nommees (`Cell11`, `Cell12`, ..., `Cell99`), chacune contrainte individuellement. Verbeuse mais pedagogiquement claire.
 
-2. **Le modèle implicite par arrays** : une seule propriete `List<int> Cells` de 81 elements, indexes par des expressions lambda avec closures. Compacte, generalisable, et extensible.
+2. **Le modèle implicite par arrays** : une seule propriete `List<int> Cells` de 81 éléments, indexes par des expressions lambda avec closures. Compacte, generalisable, et extensible.
 
 Cette transition illustre l'innovation apportee par la branche EPFdevelopment du fork Z3.Linq : la capacite d'utiliser des indexeurs de collection dans les expressions lambda traduites en formules SMT.
 
-> **Contexte** : Le modèle implicite par arrays est la base de tous les notebooks Sudoku avances de cette serie. Le comprendre en profondeur est essentiel pour la suite.",,,,,,,,0dd4e57eb761e6c3,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,360fa043,markdown,fr,bee4850a4f75828d,"### Vue d'ensemble : deux strategies de modelisation du meme Sudoku
+> **Contexte** : Le modèle implicite par arrays est la base de tous les notebooks Sudoku avances de cette serie. Le comprendre en profondeur est essentiel pour la suite.",,,,,,,,80f7a1b8417ea3a7,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,360fa043,markdown,fr,3330d8e22ecd839c,"### Vue d'ensemble : deux stratégies de modelisation du même Sudoku
 
 ```mermaid
 flowchart TB
@@ -681,9 +681,9 @@ flowchart TB
     style E fill:#f7e3c5
 ```
 
-Les deux approches produisent **le meme resultat**, mais le **modèle implicite** (en vert)
+Les deux approches produisent **le même résultat**, mais le **modèle implicite** (en vert)
 est celui qui se generalise — il fonde tous les notebooks Sudoku avances de la serie.
-L'enjeu pedagogique de ce notebook est la **transition** de l'une vers l'autre.",,,,,,,,bee4850a4f75828d,,,,,,,
+L'enjeu pedagogique de ce notebook est la **transition** de l'une vers l'autre.",,,,,,,,3330d8e22ecd839c,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,setup-markdown-intro,markdown,fr,72398f7293ab0e42,"### Configuration de l'environnement
 
 Chargement du fork Z3.Linq (`.deploy/`) et des espaces de noms nécessaires pour ce notebook.",,,,,,,,72398f7293ab0e42,,,,,,,
@@ -806,9 +806,9 @@ Console.WriteLine(""Approche explicite : chaque contrainte enumere les cellules 
 Console.WriteLine(""Pour un Sudoku complet, il faut 81 + 9 + 9 + 9 = 108 contraintes explicites."");
 Console.WriteLine(""(Ici, seules 11 contraintes sont posees pour illustration."");
 Console.WriteLine("" Ce theoreme partiel ne produit PAS une solution Sudoku valide.)"");",,,,,,,,fc0ddb6e9e75665e,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,d0e1f2a3,markdown,fr,834779f75205fed3,"### Limites de l'approche explicite
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,d0e1f2a3,markdown,fr,d48eee67bdba93dc,"### Limites de l'approche explicite
 
-| Aspect | Probleme |
+| Aspect | Problème |
 |--------|----------|
 | **Verbosite** | 81 proprietes + 108 contraintes a ecrire à la main |
 | **Erreur-prone** | Facile d'oublier ou de dupliquer une cellule dans une contrainte |
@@ -816,8 +816,8 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,d0e
 | **Maintenance** | Ajouter un indice (hint) necessite de connaitre le nom exact de la propriete |
 | **Lisibilite** | Les contraintes de boite sont illisibles (9 noms de proprietes melanges) |
 
-> **Conclusion** : l'approche explicite est pedagogiquement utile pour comprendre ce que Z3 fait, mais elle ne passe pas a l'echelle. C'est ce qui motive le modèle implicite par arrays.",,,,,,,,834779f75205fed3,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,e1f2a3b4,markdown,fr,a914e42df66d36c4,"## 3. Approche 2 : Modèle implicite par arrays
+> **Conclusion** : l'approche explicite est pedagogiquement utile pour comprendre ce que Z3 fait, mais elle ne passe pas a l'echelle. C'est ce qui motive le modèle implicite par arrays.",,,,,,,,d48eee67bdba93dc,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,e1f2a3b4,markdown,fr,d6a02e5e8c84aee3,"## 3. Approche 2 : Modèle implicite par arrays
 
 L'approche par arrays exploite une capacite fondamentale de Z3.Linq : la traduction d'**indexeurs de collection** (`list[i]`) en variables de decision SMT. Au lieu de 81 proprietes nommees, on utilise une seule propriete `List<int> Cells` de taille 81.
 
@@ -832,16 +832,16 @@ for (int i = 0; i < 9; i++) {
 }
 ```
 
-La variable `i1` est une **copie locale** qui capture la valeur de `i` a chaque iteration. Sans cette copie, toutes les expressions lambda partageraient la meme reference vers `i`, qui vaudrait 9 en sortie de boucle. C'est le mecanisme standard de closure en C#, applique ici aux expressions traduites en SMT.
+La variable `i1` est une **copie locale** qui capture la valeur de `i` a chaque itération. Sans cette copie, toutes les expressions lambda partageraient la même reference vers `i`, qui vaudrait 9 en sortie de boucle. C'est le mécanisme standard de closure en C#, applique ici aux expressions traduites en SMT.
 
-### Classe du modèle implicite",,,,,,,,a914e42df66d36c4,,,,,,,
+### Classe du modèle implicite",,,,,,,,d6a02e5e8c84aee3,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,f2a3b4c5,code,fr,273975dca2219d0f,"public class SudokuArray
 {
     public List<int> Cells { get; set; } = Enumerable.Repeat(0, 81).ToList();
 }
 
 Console.WriteLine(""Classe SudokuArray definie : 1 propriete Cells (List<int> de 81 elements)"");",,,,,,,,273975dca2219d0f,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,a3b4c5d6,markdown,fr,279ee73a54a15193,"### Construction du théorème avec boucles et closures
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,a3b4c5d6,markdown,fr,e1538f77f8a36632,"### Construction du théorème avec boucles et closures
 
 Le théorème se construit en trois étapes, chacune utilisant des boucles `for` au lieu d'enumerations explicites :
 
@@ -849,7 +849,7 @@ Le théorème se construit en trois étapes, chacune utilisant des boucles `for`
 2. **Contraintes structurelles** : lignes, colonnes, boites (27 contraintes au total)
 3. **Contraintes d'indices** : les cellules pre-remplies du puzzle sont fixees
 
-**Point cle a observer** : la variable `var i1 = i;` dans chaque boucle. C'est la capture de closure. Sans elle, toutes les expressions lambda referenceraient la meme variable `i` (qui vaudrait sa valeur finale en sortie de boucle), et Z3 resoudrait un probleme incorrect.",,,,,,,,279ee73a54a15193,,,,,,,
+**Point cle a observer** : la variable `var i1 = i;` dans chaque boucle. C'est la capture de closure. Sans elle, toutes les expressions lambda referenceraient la même variable `i` (qui vaudrait sa valeur finale en sortie de boucle), et Z3 resoudrait un problème incorrect.",,,,,,,,e1538f77f8a36632,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,b4c5d6e7,code,fr,123f296f273e8507,"var ctx2 = new Z3Context();
 var theorem2 = ctx2.NewTheorem<SudokuArray>();
 var indices = Enumerable.Range(0, 9).ToArray();
@@ -914,7 +914,7 @@ sw.Stop();
 
 Console.WriteLine($""Resolution en {sw.ElapsedMilliseconds} ms"");
 DisplaySudoku(solution.Cells, ""Solution Sudoku (sans indices)"");",,,,,,,,9b3b3cec5419e34c,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,e7f8a9b0,markdown,fr,16271bac8b6ee15b,"### Interpretation : Sudoku vide
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,e7f8a9b0,markdown,fr,c4038672d918f32e,"### Interpretation : Sudoku vide
 
 Le solveur produit une grille Sudoku valide (chaque ligne, colonne et boite 3x3 contient les chiffres 1 a 9 exactement une fois). Ce n'est pas un Sudoku ""interessant"" (pas de puzzle a resoudre), mais il demontre que **toutes les contraintes structurelles sont correctes**.
 
@@ -926,7 +926,7 @@ Le solveur produit une grille Sudoku valide (chaque ligne, colonne et boite 3x3 
 | Contraintes de boites | 9 | Une par boite 3x3 |
 | Total | 108 | Identique a l'approche explicite, mais genere par boucles |
 
-> **Note technique** : le modèle implicite genere exactement le meme ensemble de contraintes SMT que le modèle explicite. La difference est purement syntaxique (C#), pas semantique (Z3).",,,,,,,,16271bac8b6ee15b,,,,,,,
+> **Note technique** : le modèle implicite genere exactement le même ensemble de contraintes SMT que le modèle explicite. La différence est purement syntaxique (C#), pas sémantique (Z3).",,,,,,,,c4038672d918f32e,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,223a2311,markdown,fr,de6b2825c3f1cfb0,"### Précision de vocabulaire — « array » C# vs « Array » SMT
 
 Puisque nous venons d'évoquer le **niveau SMT**, il faut clarifier un point de vocabulaire qui sinon prête à confusion : le mot **« array »** dans ce notebook ne désigne **pas** la théorie des tableaux de Z3.
@@ -961,9 +961,9 @@ var puzzle = new SudokuArray {
 int givenCount = puzzle.Cells.Count(c => c != 0);
 Console.WriteLine($""Puzzle charge : {givenCount} indices sur 81 cellules"");
 DisplaySudoku(puzzle.Cells, ""Puzzle initial"");",,,,,,,,6e9eeca77499cbce,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,b0c1d2e3,markdown,fr,f5ab412f276daa18,"### Construction du théorème avec indices
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,b0c1d2e3,markdown,fr,e4bba60bc72177e8,"### Construction du théorème avec indices
 
-Le théorème combine les memes contraintes structurelles que precedemment, plus une contrainte par cellule pre-remplie. Remarquez la troisieme boucle `for` : elle parcourt les 81 cellules et fixe uniquement les valeurs non-nulles.",,,,,,,,f5ab412f276daa18,,,,,,,
+Le théorème combine les mêmes contraintes structurelles que precedemment, plus une contrainte par cellule pre-remplie. Remarquez la troisieme boucle `for` : elle parcourt les 81 cellules et fixe uniquement les valeurs non-nulles.",,,,,,,,e4bba60bc72177e8,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,c1d2e3f4,code,fr,e8593d9c81ff8f1f,"var ctx3 = new Z3Context();
 var puzzleTheorem = ctx3.NewTheorem<SudokuArray>();
 
@@ -1020,24 +1020,24 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,d2e
 var solved = puzzleTheorem.Solve();
 sw.Stop();
 DisplaySudoku(solved.Cells, $""Solution (en {sw.ElapsedMilliseconds} ms)"");",,,,,,,,4641461eb2db5812,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,e3f4a5b6,markdown,fr,23aaccc35d251857,"### Interpretation : puzzle resolu
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,e3f4a5b6,markdown,fr,6ee5c390a8449a65,"### Interpretation : puzzle resolu
 
 Le solveur Z3 trouve la solution unique du puzzle en quelques millisecondes. Chaque cellule vide a ete completee de maniere a satisfaire toutes les contraintes.
 
 | Aspect | Valeur | Signification |
 |--------|--------|---------------|
-| Cellules pre-remplies | 30 | Donnees du puzzle |
+| Cellules pre-remplies | 30 | Données du puzzle |
 | Cellules a determiner | 51 | Trouvees par Z3 |
-| Temps de résolution | variable | Generalement < 100 ms |
+| Temps de résolution | variable | Généralement < 100 ms |
 | Solutions possibles | 1 | Le puzzle a une solution unique |
 
-> **Note** : le modèle implicite rend l'ajout d'indices trivial (une boucle). Avec l'approche explicite, il faudrait ecrire 30 contraintes individuelles `Where(t => t.CellXY == val)`, en connaissant le mapping position -> nom de propriete.",,,,,,,,23aaccc35d251857,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,f4a5b6c7,markdown,fr,ca020b497ee97123,"## 5. Tableau comparatif des deux approches
+> **Note** : le modèle implicite rend l'ajout d'indices trivial (une boucle). Avec l'approche explicite, il faudrait ecrire 30 contraintes individuelles `Where(t => t.CellXY == val)`, en connaissant le mapping position -> nom de propriete.",,,,,,,,6ee5c390a8449a65,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,f4a5b6c7,markdown,fr,f43579f71c9b8a16,"## 5. Tableau comparatif des deux approches
 
 | Aspect | Approche explicite (81 proprietes) | Modèle implicite (List<int>) |
 |--------|-------------------------------------|-------------------------------|
 | Nombre de proprietes | 81 (Cell11...Cell99) | 1 (Cells) |
-| Contraintes de domaine | 81 expressions `Where(t => t.CellXY >= 1)` | Boucle `for` 81 iterations |
+| Contraintes de domaine | 81 expressions `Where(t => t.CellXY >= 1)` | Boucle `for` 81 itérations |
 | Contraintes de ligne | 9 lambdas enumerant 9 cellules chacune | 1 boucle `for` avec `Z3Methods.Distinct` |
 | Contraintes de boite | 9 lambdas enumerant 9 cellules chacune | 1 boucle `for` avec arithmetique d'index |
 | Ajout d'indices | Copier-coller + edition manuelle | Boucle sur les cellules non-nulles |
@@ -1045,11 +1045,11 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,f4a
 | Capture de closure | Non applicable | `var i1 = i;` indispensable |
 | Code total (lignes) | ~200+ | ~50 |
 
-**Conclusion** : le modèle implicite par arrays est superieur sur tous les plans, sauf la **transparence initiale**. L'approche explicite reste utile comme étape pedagogique pour comprendre que Z3 cree bien une variable de decision par cellule.",,,,,,,,ca020b497ee97123,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,a5b6c7d8,markdown,fr,455a7ac9384569da,"## 6. Exercice 1 : Sudoku 16x16
+**Conclusion** : le modèle implicite par arrays est superieur sur tous les plans, sauf la **transparence initiale**. L'approche explicite reste utile comme étape pedagogique pour comprendre que Z3 créé bien une variable de decision par cellule.",,,,,,,,f43579f71c9b8a16,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,a5b6c7d8,markdown,fr,996794524acd68d1,"## 6. Exercice 1 : Sudoku 16x16
 
 Adaptez le modèle implicite pour un **Sudoku 16x16** :
-- `Cells` contient 256 elements (16x16)
+- `Cells` contient 256 éléments (16x16)
 - Domaine : chaque cellule entre 1 et 16
 - Rangees : 16 contraintes de 16 valeurs distinctes
 - Colonnes : 16 contraintes de 16 valeurs distinctes
@@ -1058,7 +1058,7 @@ Adaptez le modèle implicite pour un **Sudoku 16x16** :
 **Indices** :
 - Modifier les boucles pour `n = 16` et `blockSize = 4`
 - L'arithmetique d'index pour les boites utilise `b / 4` et `b % 4` (au lieu de `b / 3` et `b % 3`)
-- L'offset entre lignes dans une boite passe de 9 a 16",,,,,,,,455a7ac9384569da,,,,,,,
+- L'offset entre lignes dans une boite passe de 9 a 16",,,,,,,,996794524acd68d1,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,b6c7d8e9,code,fr,f60ff758769cd331,"// Exercice : adapter le modele implicite pour un Sudoku 16x16
 // - Cells contient 256 elements (16x16)
 // - Domaine : chaque cellule entre 1 et 16
@@ -1076,17 +1076,17 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,b6c
 // var solution16 = theorem16.Solve();
 
 Console.WriteLine(""Exercice a completer : Sudoku 16x16"");",,,,,,,,f60ff758769cd331,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,c7d8e9f0,markdown,fr,b3bfa255dad5c447,"## 7. Exercice 2 : Mesurer le temps de résolution en fonction de la difficulte
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,c7d8e9f0,markdown,fr,3f9a2365ac75c442,"## 7. Exercice 2 : Mesurer le temps de résolution en fonction de la difficulte
 
-Generez des puzzles avec un nombre variable d'indices (de 17, le minimum theorique, a 40) et mesurez le temps de résolution par Z3.
+Generez des puzzles avec un nombre variable d'indices (de 17, le minimum théorique, a 40) et mesurez le temps de résolution par Z3.
 
 **Objectif** : comprendre comment la difficulte du puzzle (nombre d'indices) influence le temps de résolution.
 
 **Indices** :
 - Partir d'une solution complete ( utilisez le théorème sans indices)
-- Supprimer progressivement des cellules aleatoirement pour creer des puzzles de difficulte croissante
+- Supprimer progressivement des cellules aleatoirement pour créer des puzzles de difficulte croissante
 - Chronometrer `theorem.Solve()` pour chaque puzzle
-- Afficher un tableau recapitulatif : nombre d'indices | temps (ms) | statut",,,,,,,,b3bfa255dad5c447,,,,,,,
+- Afficher un tableau recapitulatif : nombre d'indices | temps (ms) | statut",,,,,,,,3f9a2365ac75c442,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,d8e9f0a1,code,fr,15df89bfa462f26c,"// Exercice : mesurer le temps de resolution pour des puzzles de difficulte croissante
 // 1. Partir d'une solution complete (theoreme sans indices)
 // 2. Supprimer progressivement des cellules (ou utiliser des puzzles connus)
@@ -1099,18 +1099,18 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,d8e
 
 // TODO etudiant : implementer le benchmark
 Console.WriteLine(""Exercice a completer : benchmark difficulte"");",,,,,,,,15df89bfa462f26c,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,e9f0a1b2,markdown,fr,3d52971638e17eea,"## 8. Exercice 3 : Generer plusieurs solutions
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,e9f0a1b2,markdown,fr,98c55de960013e82,"## 8. Exercice 3 : Generer plusieurs solutions
 
 Un Sudoku bien pose a une **solution unique**. Mais si le puzzle est sous-contraint (trop peu d'indices), il peut avoir plusieurs solutions. Le but de cet exercice est de trouver et denombrer ces solutions.
 
 **Objectif** : modifier le théorème pour trouver plusieurs solutions distinctes et verifier l'ununicite.
 
 **Indices** :
-- Resoudre le puzzle une premiere fois
+- Resoudre le puzzle une première fois
 - Ajouter une contrainte excluant la solution trouvee : au moins une cellule doit differer
 - Re-resoudre pour trouver la solution suivante
 - Repeter jusqu'a ce qu'il n'y ait plus de solution
-- Pour exclure : `Where(s => s.Cells[0] != sol.Cells[0] || s.Cells[1] != sol.Cells[1] || ...)`",,,,,,,,3d52971638e17eea,,,,,,,
+- Pour exclure : `Where(s => s.Cells[0] != sol.Cells[0] || s.Cells[1] != sol.Cells[1] || ...)`",,,,,,,,98c55de960013e82,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,f0a1b2c3,code,fr,69868c45981f4188,"// Exercice : trouver toutes les solutions d'un puzzle incomplet
 // 1. Resoudre le puzzle
 // 2. Ajouter une contrainte excluant la solution trouvee
@@ -1120,11 +1120,11 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,f0a
 
 // TODO etudiant : implementer la recherche multi-solutions
 Console.WriteLine(""Exercice a completer : solutions multiples"");",,,,,,,,69868c45981f4188,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,b8-quant-intro,markdown,fr,0c30a005a99954c6,"## B8 - Quantificateurs bornes (DSL `Z3Methods.ForAll` / `Exists`)
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,b8-quant-intro,markdown,fr,22dc33be87e52dfc,"## B8 - Quantificateurs bornes (DSL `Z3Methods.ForAll` / `Exists`)
 
-La section 3 de ce notebook **deroule à la main** les contraintes de cellule : une boucle C# emet une propriete par index (« chaque cellule dans [1,9] », les lignes/colonnes/blocs `Distinct`). C'est le pain quotidien de la modelisation par tableau - mais la boucle **grandit avec la taille** et melange la logique du modèle et la mecanique du deroulage. Le binding ajoute deux quantificateurs **bornes** : [`Z3Methods.ForAll(domaine, i => predicat)`](../Z3.Linq/solutions/Z3.Linq/Z3Methods.cs#L57) et [`Z3Methods.Exists(domaine, i => predicat)`](../Z3.Linq/solutions/Z3.Linq/Z3Methods.cs#L77). Le domaine est **evalue dans l'hote** (un `IEnumerable` C#) et le predicat est **deroule** en une conjonction (`ForAll` -> `MkAnd`) ou une disjonction (`Exists` -> `MkOr`) sur chaque element. Une seule `.Where(...)` exprime alors ce qui exigeait une boucle emettant un `.Where` par index. Ce sont des quantificateurs **finis** : pas les quantificateurs SMT sur un sort non borne (`MkForall`), mais un deroulage statique sur un index enumerable.
+La section 3 de ce notebook **deroule à la main** les contraintes de cellule : une boucle C# emet une propriete par index (« chaque cellule dans [1,9] », les lignes/colonnes/blocs `Distinct`). C'est le pain quotidien de la modelisation par tableau - mais la boucle **grandit avec la taille** et melange la logique du modèle et la mecanique du deroulage. Le binding ajoute deux quantificateurs **bornes** : [`Z3Methods.ForAll(domaine, i => predicat)`](../Z3.Linq/solutions/Z3.Linq/Z3Methods.cs#L57) et [`Z3Methods.Exists(domaine, i => predicat)`](../Z3.Linq/solutions/Z3.Linq/Z3Methods.cs#L77). Le domaine est **evalue dans l'hote** (un `IEnumerable` C#) et le predicat est **deroule** en une conjonction (`ForAll` -> `MkAnd`) ou une disjonction (`Exists` -> `MkOr`) sur chaque élément. Une seule `.Where(...)` exprime alors ce qui exigeait une boucle emettant un `.Where` par index. Ce sont des quantificateurs **finis** : pas les quantificateurs SMT sur un sort non borne (`MkForall`), mais un deroulage statique sur un index enumerable.
 
-> **Stack : A + B - pourquoi**. On modelise une **rangee** de 4 cellules (un mini-Sudoku 1D), palette `{1,2,3,4}`. Deux contraintes quantifiees : **universelle** « chaque cellule dans [1,4] » et **existentielle** « au moins une cellule vaut 4 » (le maximum apparait). Cote raw, on **deroule à la main** : une boucle construit la conjonction `MkAnd` des bornes et une autre la disjonction `MkOr` des egalites a 4. Cote DSL, les **memes** quantificateurs s'ecrivent en une ligne : `Z3Methods.ForAll(Enumerable.Range(0, N), i => ...)` et `Z3Methods.Exists(...)`. Le contraste : le systeme est **SAT** avec témoin ; puis, en reduisant les bornes a [1,3], « une cellule vaut 4 » devient **UNSAT** (aucun 4 possible sous 3) - obtenu des deux cotes sur le meme modèle.",,,,,,,,0c30a005a99954c6,,,,,,,
+> **Stack : A + B - pourquoi**. On modelise une **rangee** de 4 cellules (un mini-Sudoku 1D), palette `{1,2,3,4}`. Deux contraintes quantifiees : **universelle** « chaque cellule dans [1,4] » et **existentielle** « au moins une cellule vaut 4 » (le maximum apparait). Cote raw, on **deroule à la main** : une boucle construit la conjonction `MkAnd` des bornes et une autre la disjonction `MkOr` des egalites a 4. Cote DSL, les **mêmes** quantificateurs s'ecrivent en une ligne : `Z3Methods.ForAll(Enumerable.Range(0, N), i => ...)` et `Z3Methods.Exists(...)`. Le contraste : le système est **SAT** avec témoin ; puis, en reduisant les bornes a [1,3], « une cellule vaut 4 » devient **UNSAT** (aucun 4 possible sous 3) - obtenu des deux cotes sur le même modèle.",,,,,,,,22dc33be87e52dfc,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,b8-quant-code,code,fr,8a64b8b886bf26dd,"// B8 - Quantificateurs bornes ""ForAll/Exists"" : deux stacks sur une MEME rangee de cellules.
 //   Une rangee de 4 cellules (mini-Sudoku 1D). Palette : {1,2,3,4}.
 //   Universel : chaque cellule dans [1,4].   Existentiel : au moins une cellule vaut 4 (le max apparait).
@@ -1199,20 +1199,20 @@ public class Row { public int[] Cells { get; set; } = new int[N]; }
         .Solve();
     Console.WriteLine($""[DSL] ForAll(domaine vide, predicat faux) : {(vac == null ? ""UNSAT"" : ""SAT"")}   (universel vide = vrai par vacuite)"");
 }",,,,,,,,8a64b8b886bf26dd,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,b8-quant-lecture,markdown,fr,42dd45a43174a9d0,"### Lecture B8 - deux ecritures d'un quantificateur borne, un meme deroulage
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,b8-quant-lecture,markdown,fr,cbe76e6327f76229,"### Lecture B8 - deux ecritures d'un quantificateur borne, un même deroulage
 
-Les deux stacks contraignent la **meme rangee** avec les **memes quantificateurs** - universel « tout dans [1,4] », existentiel « un 4 apparait » - et donnent les **memes verdicts** : SAT avec témoin, puis UNSAT des que les bornes tombent a [1,3]. La difference est **comment** on ecrit le deroulage :
+Les deux stacks contraignent la **même rangee** avec les **mêmes quantificateurs** - universel « tout dans [1,4] », existentiel « un 4 apparait » - et donnent les **mêmes verdicts** : SAT avec témoin, puis UNSAT des que les bornes tombent a [1,3]. La différence est **comment** on ecrit le deroulage :
 
 | Aspect | RAW (boucle + `MkAnd`/`MkOr`) | DSL (`ForAll`/`Exists` sur `Range`) |
 |---|---|---|
 | Universel | boucle C# -> `MkAnd(bounds.ToArray())` | `Z3Methods.ForAll(Enumerable.Range(0, N), i => ...)` |
 | Existentiel | boucle C# -> `MkOr(disj.ToArray())` | `Z3Methods.Exists(Enumerable.Range(0, N), i => ...)` |
 | Taille du code | croit avec le nombre d'index (une boucle explicite) | constante : une `.Where` quel que soit `N` |
-| Domaine vide | a gerer soi-meme | `ForAll` vide = vrai, `Exists` vide = faux (vacuite classique) |
+| Domaine vide | a gerer soi-même | `ForAll` vide = vrai, `Exists` vide = faux (vacuite classique) |
 
-> **Ligne de contraste (a retenir)** : *le raw materialise le deroulage* - une boucle C# assemble la conjonction (`MkAnd`) ou la disjonction (`MkOr`) index par index ; *le DSL le declare* - `ForAll`/`Exists` sur un `Enumerable.Range` deroulent en interne vers exactement le meme `MkAnd`/`MkOr`. **Meme deroulage, meme verdict**, mais la logique du modèle ne se noie plus dans la mecanique de la boucle. Attention : ce sont des quantificateurs **finis** (le domaine est un `IEnumerable` C# evalue dans l'hote), pas les quantificateurs SMT sur un sort non borne.
+> **Ligne de contraste (a retenir)** : *le raw materialise le deroulage* - une boucle C# assemble la conjonction (`MkAnd`) ou la disjonction (`MkOr`) index par index ; *le DSL le declare* - `ForAll`/`Exists` sur un `Enumerable.Range` deroulent en interne vers exactement le même `MkAnd`/`MkOr`. **Même deroulage, même verdict**, mais la logique du modèle ne se noie plus dans la mecanique de la boucle. Attention : ce sont des quantificateurs **finis** (le domaine est un `IEnumerable` C# evalue dans l'hote), pas les quantificateurs SMT sur un sort non borne.
 
-**Cas d'usage** : les quantificateurs bornes sont l'idiome des **grilles et tableaux** - rangees de Sudoku, N-reines, fenetres d'ordonnancement - partout ou une contrainte s'applique « pour tout / il existe » sur un index enumerable. Ils remplacent la boucle emettant un `.Where` par index (section 3 de ce notebook). On garde le deroulage manuel quand le domaine **n'est pas statiquement enumerable** (il depend du modèle) ou quand il faut un **vrai quantificateur SMT** non borne (`MkForall`/`MkExists`), hors de portee du deroulage fini.",,,,,,,,42dd45a43174a9d0,,,,,,,
+**Cas d'usage** : les quantificateurs bornes sont l'idiome des **grilles et tableaux** - rangees de Sudoku, N-reines, fenêtres d'ordonnancement - partout ou une contrainte s'applique « pour tout / il existe » sur un index enumerable. Ils remplacent la boucle emettant un `.Where` par index (section 3 de ce notebook). On garde le deroulage manuel quand le domaine **n'est pas statiquement enumerable** (il depend du modèle) ou quand il faut un **vrai quantificateur SMT** non borne (`MkForall`/`MkExists`), hors de portee du deroulage fini.",,,,,,,,cbe76e6327f76229,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,conclusion-cell-z3,markdown,fr,81de197076290a88,"## Conclusion
 
 Ce notebook a illustre la **transition fondamentale** entre deux paradigmes de modelisation Sudoku avec Z3.Linq :
@@ -1252,14 +1252,14 @@ Ce notebook démontre les **deux modes de modélisation des collections** offert
 | **`Constants`** | Un constant Z3 par élément (`Cells_0_0`, `Cells_0_1`, …) | Modèle « un symbole = une inconnue », proche du raisonnement humain, lisible dans le solver |
 
 Les deux modes produisent une solution valide ; le choix est **pédagogique** et dépend de ce qu'on veut illustrer.",,,,,,,,48640cefc78d4033,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/03_Sudoku_Modes_Comparison.ipynb,bd398b0e,markdown,fr,7036f00fddb3cf4a,"### Vue d'ensemble : un meme Sudoku, deux modes d'encodage des collections
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/03_Sudoku_Modes_Comparison.ipynb,bd398b0e,markdown,fr,f8f0449b0ed80a60,"### Vue d'ensemble : un même Sudoku, deux modes d'encodage des collections
 
 ```mermaid
 flowchart TB
-    G[""Meme grille Sudoku 4x4\n(int de int)""]
+    G[""Même grille Sudoku 4x4\n(int de int)""]
     G --> M1[""Mode Array (defaut)""]
     G --> M2[""Mode Constants""]
-    M1 --> A1[""1 seule ArrayExpr Z3\n+ Select / Store\n(theorie des tableaux)""]
+    M1 --> A1[""1 seule ArrayExpr Z3\n+ Select / Store\n(théorie des tableaux)""]
     M2 --> C1[""1 constant Z3 par cellule\nCells_0_0, Cells_0_1, ...""]
     A1 --> S[""Solution valide\n(carre latin)""]
     C1 --> S
@@ -1270,10 +1270,10 @@ flowchart TB
     style C1 fill:#cfe3ff
 ```
 
-Les **deux modes** resolvent le **meme** `int[][]` et convergent vers une solution valide.
+Les **deux modes** resolvent le **même** `int[][]` et convergent vers une solution valide.
 Le mode `Array` (vert) encode la grille avec une seule `ArrayExpr` ; le mode `Constants` (bleu)
-cree un symbole Z3 par cellule. C'est la demonstration directe que l'enum `CollectionHandling`
-est desormais **vivante** et fonctionnelle.",,,,,,,,7036f00fddb3cf4a,,,,,,,
+créé un symbole Z3 par cellule. C'est la demonstration directe que l'enum `CollectionHandling`
+est desormais **vivante** et fonctionnelle.",,,,,,,,f8f0449b0ed80a60,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/03_Sudoku_Modes_Comparison.ipynb,62647528,markdown,fr,87f0d7d195b03130,"### Configuration de l'environnement
 
 Chargement du **fork Z3.Linq** (avec `CollectionHandling` câblé) depuis le sous-module local. Les DLL sont produites par le script `scripts/environment/z3-build-deploy.ps1` (décision ai-01 2026-06-13, option b).",,,,,,,,87f0d7d195b03130,,,,,,,
@@ -2909,27 +2909,27 @@ Lorsque le fork sera publié sur NuGet (version ≥ 2.0.2 avec `int[][]`), ce no
 ---
 
 **Navigation** : [Index SymbolicAI](../../README.md) | [Série Z3](README.md) | [<< Array Theory](04_Array_Theory.ipynb) | [Meal Planner >>](06_Meal_Planner_Modelisation.ipynb)",,,,,,,,db68302cd6879efb,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,1c6a7f3f,markdown,fr,d52a6fe55036ef51,"# Notebook 06 — Meal-Planner declaratif : du modele Z3 au plan hebdomadaire visualise
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,1c6a7f3f,markdown,fr,528f854c469121fe,"# Notebook 06 — Meal-Planner declaratif : du modèle Z3 au plan hebdomadaire visualise
 
-**Navigation** : [Index Z3](./README.md) | [Index SymbolicAI](../../README.md) | [Index general](../../../README.md) | [Notebook precedent (Nested Arrays)](05_Nested_Arrays_2D.ipynb)
+**Navigation** : [Index Z3](./README.md) | [Index SymbolicAI](../../README.md) | [Index general](../../../README.md) | [Notebook précédent (Nested Arrays)](05_Nested_Arrays_2D.ipynb)
 
 Ce notebook consolide en une seule histoire coherente la **modelisation declarative** d'un planificateur de repas avec `Z3.Linq` et l'API `Microsoft.Z3`, du menu d'un jour au plan hebdomadaire visualise. Il est organise en trois parties :
 
-- **Partie A — Modelisation declarative** : construire le probleme du menu equilibre selon plusieurs paradigmes (selection par index, enumeration, variables booleennes, theoreme hierarchique `int[][]`), et faire emerger la feature `CollectionHandling`.
-- **Partie B — Couplage hebdomadaire** : passer d'un repas a une **semaine** — matrice booleenne jours x plats, fenetre nutritionnelle par jour, variete globale, et comparaison solveur vs glouton.
+- **Partie A — Modelisation declarative** : construire le problème du menu equilibre selon plusieurs paradigmes (sélection par index, enumeration, variables booleennes, theoreme hiérarchique `int[][]`), et faire emerger la feature `CollectionHandling`.
+- **Partie B — Couplage hebdomadaire** : passer d'un repas a une **semaine** — matrice booleenne jours x plats, fenêtre nutritionnelle par jour, variete globale, et comparaison solveur vs glouton.
 - **Partie C — Visualisation HTML** : rendre les solutions du solveur **lisibles par un humain** (cartes colorees, grilles, front de Pareto) via `display(HTML(...))`, en demontrant le decouplage solveur / presentation.
 
-Le corpus nutritionnel detaille (RecipeML x Ciqual, quantites en grammes) est prepare dans le **notebook de donnees 07** ; ici on se concentre sur la **modelisation** et sa restitution.
+Le corpus nutritionnel detaille (RecipeML x Ciqual, quantites en grammes) est prepare dans le **notebook de données 07** ; ici on se concentre sur la **modelisation** et sa restitution.
 
 ```mermaid
 flowchart LR
-    A[""Partie A\nModele declaratif\n(index / bool / int[][])""] --> B[""Partie B\nCouplage hebdomadaire\n(fenetre kcal/jour, variete)""]
+    A[""Partie A\nModele declaratif\n(index / bool / int[][])""] --> B[""Partie B\nCouplage hebdomadaire\n(fenêtre kcal/jour, variete)""]
     B --> C[""Partie C\nVisualisation HTML\n(cartes, grille, Pareto)""]
     style A fill:#cfe3ff
     style B fill:#ffe9c7
     style C fill:#c8f7c5
 ```
-",,,,,,,,d52a6fe55036ef51,,,,,,,
+",,,,,,,,528f854c469121fe,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,324e2277,code,fr,267e18dd4f75101d,"#r ""../Z3.Linq/.deploy/Microsoft.Z3.dll""
 #r ""../Z3.Linq/.deploy/ExpressionUtils.dll""
 #r ""../Z3.Linq/.deploy/Z3.Linq.dll""
@@ -2943,9 +2943,9 @@ using System.Linq;
 using System.Text;
 using System.Xml.Linq;
 Console.WriteLine(""Imports OK : Z3.Linq (.deploy, CollectionHandling cable), Microsoft.Z3, Microsoft.DotNet.Interactive (display/HTML), System.Linq/Text/Xml.Linq/Diagnostics"");",,,,,,,,267e18dd4f75101d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,7c3e0ddf,markdown,fr,57bddab6a8c0b4e5,"## Partie A — Modelisation declarative
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,7c3e0ddf,markdown,fr,98b0ab1e14bc28ca,"## Partie A — Modelisation declarative
 
-De la base de donnees nutritionnelle au **theoreme hierarchique** `int[][]` : on modelise le meme probleme de menu equilibre selon plusieurs paradigmes Z3 (selection par index, enumeration, variables booleennes, optimisation par dichotomie), puis on montre comment `CollectionHandling` structure un plan multi-jours en pur LINQ.",,,,,,,,57bddab6a8c0b4e5,,,,,,,
+De la base de données nutritionnelle au **theoreme hiérarchique** `int[][]` : on modelise le même problème de menu equilibre selon plusieurs paradigmes Z3 (sélection par index, enumeration, variables booleennes, optimisation par dichotomie), puis on montre comment `CollectionHandling` structure un plan multi-jours en pur LINQ.",,,,,,,,98b0ab1e14bc28ca,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,56283978,markdown,fr,0790540207bf0949,"---
 
 ### 1. Contexte : Le théorème hiérarchique
@@ -3048,11 +3048,11 @@ using (var ctx = new Z3Context())
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,9f7d6d3c,markdown,fr,01df6b6934e01a49,"#### Interpretation
 
 Sans contraintes nutritionnelles, le solveur trouve la première combinaison valide (index 0, 0, 0). Le résultat est trivialement la première entree, le premier plat et le premier dessert de la base. Nous devons ajouter des contraintes pour obtenir un menu équilibré.",,,,,,,,01df6b6934e01a49,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,76ee2467,markdown,fr,e142a21d6aeae50f,"### 4. Approche 2 : Contraintes nutritionnelles avec énumération
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,76ee2467,markdown,fr,6edb39ad46fdec72,"### 4. Approche 2 : Contraintes nutritionnelles avec énumération
 
 La contrainte Z3.Linq fonctionne avec des expressions lineaires. Pour injecter les données nutritionnelles, nous énumérons les combinaisons possibles et posons des contraintes sur les totaux.
 
-**Strategie** : generer toutes les combinaisons possibles, puis filtrer avec Z3 sur les contraintes globales (calories, proteines, budget).",,,,,,,,e142a21d6aeae50f,,,,,,,
+**Stratégie** : generer toutes les combinaisons possibles, puis filtrer avec Z3 sur les contraintes globales (calories, proteines, budget).",,,,,,,,6edb39ad46fdec72,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,e6627bc3,code,fr,62cfe09bdcca7f04,"// Approche par énumération + filtrage Z3
 // Objectif : trouver un menu avec 600-900 kcal, >= 25g proteines, cout <= 12 euros
 
@@ -3175,16 +3175,16 @@ using (var z3ctx = new Context())
         Console.WriteLine(""Aucun menu ne satisfait les contraintes."");
     }
 }",,,,,,,,4ead52f07cb39973,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,0bf4d442,markdown,fr,f5a634b93d86b704,"#### Interpretation
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,0bf4d442,markdown,fr,343a616cbb10fc07,"#### Interpretation
 
 L'approche booléenne utilisé **`MkITE` (If-Then-Else)** pour conditionnellement ajouter la contribution nutritionnelle de chaque aliment. C'est la clé technique de la **data fusion** : les données statiques (calories, proteines, cout) sont injectees dans les expressions Z3 via `MkITE`.
 
-| Technique | Role |
+| Technique | Rôle |
 |-----------|------|
 | `BoolExpr` par aliment | Sélection binaire |
 | `MkOr` + exclusion mutuelle | Exactement 1 par catégorie |
 | `MkITE(sel, valeur, 0)` | Contribution conditionnelle |
-| Somme des `MkITE` | Total nutritionnel global |",,,,,,,,f5a634b93d86b704,,,,,,,
+| Somme des `MkITE` | Total nutritionnel global |",,,,,,,,343a616cbb10fc07,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,352a219e,markdown,fr,a349b621cae98e77,"### 6. Optimisation : menu le moins cher (dichotomie)
 
 Le solveur Z3 (`MkSolver`) trouve une solution satisfaisante, mais pas forcement optimale. Pour trouver le menu **le moins cher**, nous utilisons une **recherche par dichotomie** :
@@ -3459,16 +3459,16 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,a
 | Dichotomie | `Push/Pop` + binary search | Optimisation stable | O(log n) appels solver |
 | **Hiérarchique `int[][]`** | `NewTheorem<WeeklyPlan>` + ordre strict `<` | **Structure pure LINQ, 2D** | Contraintes linéaires seulement |
 | **Permutation hiérarchique** | `CollectionHandling.Array` + `Z3Methods.Distinct` | **Contrainte globale SMT, mode explicite** | Contraintes linéaires seulement |",,,,,,,,95015351d812bfed,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,46e98e84,markdown,fr,38b9c4bc35f2e1c9,"### 9. La feature ressuscitée : `CollectionHandling` (mode Array vs Constants)
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,46e98e84,markdown,fr,9377d3d006ba2730,"### 9. La feature ressuscitée : `CollectionHandling` (mode Array vs Constants)
 
 Jusqu'ici, ce notebook utilisait le fork `Z3.Linq` charge depuis NuGet. Depuis le **14/06/2026**, le fork embarque une enum `CollectionHandling` qui était **définie mais jamais câblée** (dead code). Elle est désormais **vivante** : le même code LINQ peut résoudre un CSP en modélisant les collections de deux façons différentes.
 
 | Mode | Modélisation Z3 | Avantage pédagogique |
 |------|----------------|----------------------|
 | **`Array`** (défaut) | Une seule `ArrayExpr` Z3 + `Select`/`Store` (théorie des tableaux) | Compact, supporte les index symboliques |
-| **`Constants`** | Un constant Z3 par element (`TotalCal_0`, `TotalCal_1`, ...) | « un symbole = une inconnue », lisible dans le modèle |
+| **`Constants`** | Un constant Z3 par élément (`TotalCal_0`, `TotalCal_1`, ...) | « un symbole = une inconnue », lisible dans le modèle |
 
-Pour illustrer concretement, modelisons une **assiette de 3 plats** (entree, plat, dessert) comme un `int[]` de couts, et resolvons un mini-théorème dans les **deux modes** avec le **même** code. C'est la preuve que `CollectionHandling` est fonctionnelle bout-en-bout.",,,,,,,,38b9c4bc35f2e1c9,,,,,,,
+Pour illustrer concretement, modelisons une **assiette de 3 plats** (entree, plat, dessert) comme un `int[]` de couts, et resolvons un mini-théorème dans les **deux modes** avec le **même** code. C'est la preuve que `CollectionHandling` est fonctionnelle bout-en-bout.",,,,,,,,9377d3d006ba2730,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,b6203e70,code,fr,e8bd77e5519f8d7c,"// Demonstration CollectionHandling : un même théorème résolu en mode Array puis Constants.
 // Plate = assiette de 3 couts (entree, plat, dessert). On impose : chaque cout dans [100, 800],
 // et les 3 couts distincts (un menu varie ne repet pas le même prix).
@@ -3502,23 +3502,23 @@ var solConst = BuildPlate(ctxConst).Solve();
 
 Console.WriteLine(""\nSolution (mode Array)     : "" + string.Join("", "", solArray.Costs));
 Console.WriteLine(""Solution (mode Constants) : "" + string.Join("", "", solConst.Costs));",,,,,,,,e8bd77e5519f8d7c,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,800c9569,markdown,fr,4da90231fbe25dec,"#### Interpretation — dead code ressuscite
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,800c9569,markdown,fr,7c9cf65ce7805c90,"#### Interpretation — dead code ressuscite
 
 Le **même** code `BuildPlate` résout le CSP dans les deux modes. La seule différence est la configuration du `Z3Context` :
 
 - **Mode Array** : `Cells`/`Costs` est une seule `ArrayExpr` Z3. L'acces `Costs[i]` genere un `Select(arr, i)`. Compact.
-- **Mode Constants** : chaque element `Costs[i]` est un constant Z3 nomme (`Costs_0`, `Costs_1`, `Costs_2`). Si on inspectait le modèle Z3, on verrait ces 3 symboles explicites = modèle « humain ».
+- **Mode Constants** : chaque élément `Costs[i]` est un constant Z3 nomme (`Costs_0`, `Costs_1`, `Costs_2`). Si on inspectait le modèle Z3, on verrait ces 3 symboles explicites = modèle « humain ».
 
 | Aspect | Array | Constants |
 |--------|-------|-----------|
-| Symboles Z3 créés | 1 (l'array) | N (1 par element) |
+| Symboles Z3 créés | 1 (l'array) | N (1 par élément) |
 | Index symbolique | supporte | non (taille fixe) |
 | Lisibilite modèle | - | « un symbole = une inconnue » |
 
-C'est la preuve directe que l'enum `CollectionHandling` — historiquement du dead code défini mais jamais câble — est désormais **fonctionnelle bout-en-bout** (construction d'environnement → visite des contraintes → extraction du modèle) dans les deux modes.",,,,,,,,4da90231fbe25dec,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,df2afa5c,markdown,fr,00e0f47f6e17c1cd,"---
+C'est la preuve directe que l'enum `CollectionHandling` — historiquement du dead code défini mais jamais câble — est désormais **fonctionnelle bout-en-bout** (construction d'environnement → visite des contraintes → extraction du modèle) dans les deux modes.",,,,,,,,7c9cf65ce7805c90,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,df2afa5c,markdown,fr,080dadc9c3ea79e1,"---
 
-## Partie B — Couplage hebdomadaire : fenetre nutritionnelle par jour et variete globale
+## Partie B — Couplage hebdomadaire : fenêtre nutritionnelle par jour et variete globale
 
 ### Objectifs d'apprentissage
 
@@ -3532,7 +3532,7 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,d
 - [Notebook 05](05_Nested_Arrays_2D.ipynb) : tableaux imbriqués `int[][]`, `Theorem<Grid>`.
 - **Partie A §5** : variables booléennes de sélection + agrégation conditionnelle.
 - **Partie A §7** : plan hebdomadaire en grille d'index (le modèle complémentaire de celui-ci).
-- **Partie A §7** (non-repetition `Distinct` sur `int[][]`) : non-répétition `Z3Methods.Distinct` sur `int[][]`.",,,,,,,,00e0f47f6e17c1cd,,,,,,,
+- **Partie A §7** (non-repetition `Distinct` sur `int[][]`) : non-répétition `Z3Methods.Distinct` sur `int[][]`.",,,,,,,,080dadc9c3ea79e1,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,d4de98aa,markdown,fr,f2deed162fae82fa,"---
 
 ### 1. Le corpus de plats
@@ -3759,12 +3759,12 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,0
 - Concepts : `XDocument`, interpolation de chaînes C#, HTML/CSS inline
 
 **Durée estimée** : 40-50 minutes",,,,,,,,5fa292b76fbc2ed8,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,4feb813b,markdown,fr,ad46c1e8b1066544,"#### Vue d'ensemble : du modele Z3 a la carte lisible par un humain
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,4feb813b,markdown,fr,9bfbc7f844142773,"#### Vue d'ensemble : du modèle Z3 a la carte lisible par un humain
 
 ```mermaid
 flowchart LR
-    Z[""Solveur Z3\n(modele Parties A-B inchange)""]
-    Z --> M[""Solution brute\nbool de selection, plan int de int""]
+    Z[""Solveur Z3\n(modèle Parties A-B inchange)""]
+    Z --> M[""Solution brute\nbool de sélection, plan int de int""]
     M --> P[""Couche de presentation C#\n(seule partie qui change)""]
     P --> H[""display(HTML(...))\nMicrosoft.DotNet.Interactive""]
     H --> R[""Cartes HTML\ntableaux colores, badges,\nbarres de progression""]
@@ -3775,7 +3775,7 @@ flowchart LR
 
 Le **solveur reste identique** a celui des Parties A-B ; seule la **couche de presentation** (en vert)
 change. L'idee cle : une solution Z3 n'a de valeur operationnelle que si elle est **lisible par un humain** —
-le rendu HTML transforme une assignation brute en carte de menu interpretable.",,,,,,,,ad46c1e8b1066544,,,,,,,
+le rendu HTML transforme une assignation brute en carte de menu interpretable.",,,,,,,,9bfbc7f844142773,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,intro-gap,markdown,fr,c6c94d5e8ed13972,"---
 
 ### Introduction : la frontière solveur / communication
@@ -4264,15 +4264,15 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,2
 // optimizer.Add(z3ctx.MkLe(totalCarbs, z3ctx.MkInt(maxCarbs)));
 
 Console.WriteLine(""Exercice a completer : contrainte de glucides"");",,,,,,,,0e1dd5b072cb582a,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,3f97eb17,markdown,fr,4ce4bf3fea880295,"#### Exercice 2 : Planificateur de repas multi-jours
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,3f97eb17,markdown,fr,c27c07c663671365,"#### Exercice 2 : Planificateur de repas multi-jours
 
 Etendez le modèle pour planifier un menu sur **2 jours** (6 repas : 2 entrees, 2 plats, 2 desserts) sans répétition. Contrainte : chaque aliment ne peut etre sélectionné qu'**au maximum 1 fois**.
 
-**Etape 1** : Creez 6 groupes de variables booléennes (ou utilisez des paires jour/catégorie).
+**Étape 1** : Créez 6 groupes de variables booléennes (ou utilisez des paires jour/catégorie).
 
-**Etape 2** : Ajoutez la contrainte de non-répétition (un aliment ne peut pas etre vrai dans 2 groupes différents).
+**Étape 2** : Ajoutez la contrainte de non-répétition (un aliment ne peut pas etre vrai dans 2 groupes différents).
 
-**Indice** : Pour chaque aliment, la somme de ses apparitions dans les différents repas doit etre <= 1.",,,,,,,,4ce4bf3fea880295,,,,,,,
+**Indice** : Pour chaque aliment, la somme de ses apparitions dans les différents repas doit etre <= 1.",,,,,,,,c27c07c663671365,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,3b5286f9,code,fr,dc395c1187dada4a,"// Exercice 2 : planificateur multi-jours sans répétition
 
 // TODO etudiant : créer les variables pour 2 jours de menus
@@ -4280,15 +4280,15 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,3
 // Pour la non-répétition : pour chaque aliment, sum(apparitions) <= 1
 
 Console.WriteLine(""Exercice a completer : planificateur multi-jours"");",,,,,,,,dc395c1187dada4a,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,0e611287,markdown,fr,941e5b7d814a21c8,"#### Exercice 3 : Ajout d'un plat supplementaire (boisson)
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,0e611287,markdown,fr,e031a6fcaa42254b,"#### Exercice 3 : Ajout d'un plat supplementaire (boisson)
 
 Ajoutez une catégorie **""boisson""** a la base de données (3 boissons) et modifiez le modèle d'optimisation pour inclure exactement 1 boisson par repas. Verifiez que les contraintes nutritionnelles sont toujours satisfaites.
 
-**Etape 1** : Ajoutez 3 boissons a `foodDatabase`.
+**Étape 1** : Ajoutez 3 boissons a `foodDatabase`.
 
-**Etape 2** : Ajoutez le groupe ""boisson"" dans les contraintes `ExactlyOne`.
+**Étape 2** : Ajoutez le groupe ""boisson"" dans les contraintes `ExactlyOne`.
 
-**Etape 3** : Re-executez l'optimisation et comparez le nouveau menu optimal.",,,,,,,,941e5b7d814a21c8,,,,,,,
+**Étape 3** : Re-executez l'optimisation et comparez le nouveau menu optimal.",,,,,,,,e031a6fcaa42254b,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,3b1388df,code,fr,72d3498c22ea4739,"// Exercice 3 : ajout d'une catégorie boisson
 
 // TODO etudiant : ajouter 3 boissons a foodDatabase
@@ -4322,7 +4322,7 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,a
 
 Console.WriteLine(""Exercice a completer : modele hierarchique combine"");",,,,,,,,5a4622af6b032be3,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,899bec67,markdown,fr,a0329579ddc220f5,### Exercices — Partie B : Couplage hebdomadaire,,,,,,,,a0329579ddc220f5,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,21e32d08,markdown,fr,b84b966d0c075740,#### Exercice 1 : Fenetre de proteines par jour,,,,,,,,b84b966d0c075740,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,21e32d08,markdown,fr,f75e46e672bed449,#### Exercice 1 : Fenêtre de proteines par jour,,,,,,,,f75e46e672bed449,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,5e05978d,code,fr,2568350f4b2565c8,"// Exercice 1 : Fenetre de proteines par jour.
 // Ajoutez une contrainte : pour chaque jour, la somme des proteines des plats choisis est >= PROTEIN_MIN (ex: 60 g).
 // Indice : meme structure que la fenetre kcal, mais avec proteinArr au lieu de kcalArr (somme inline sur les 18 plats).
@@ -4343,14 +4343,14 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,6
 // Indice : pour chaque paire (j, j+1), ajouter Sel[j][i] + Sel[j+1][i] <= 1 sur la categorie cible (indices 12-17).
 Console.WriteLine(""Exercice 3 a completer : variete renforcee sur jours consecutifs."");",,,,,,,,6033adf10d88f7f9,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,4889cc0f,markdown,fr,b3d4c75d1c649197,### Exercices — Partie C : Visualisation HTML,,,,,,,,b3d4c75d1c649197,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,exo1-title,markdown,fr,60d9e1765c251d62,"#### Exercice 1 : Badge végétarien dans la carte de menu
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,exo1-title,markdown,fr,f29bb78d49c50551,"#### Exercice 1 : Badge végétarien dans la carte de menu
 
 Ajoutez à la fonction `RenderMenuCard` un **badge végétarien** global (en haut de la carte) : vert si **toutes** les recettes du menu sont végétariennes, rouge sinon. On considère comme non-végétariennes les recettes dont le nom contient `""Poulet""`, `""boeuf""` ou `""Lasagnes""`.
 
 **Indices** :
-- `# Etape 1` : écrivez un prédicat `bool IsVegetarian(Recipe r)` qui renvoie `false` si `r.Name` contient l'un des marqueurs.
-- `# Etape 2` : dans `RenderMenuCard`, calculez `bool allVeg = list.All(IsVegetarian)`.
-- `# Etape 3` : insérez dans l'en-tête de la carte un badge : vert ""100% vegetarien"" si `allVeg`, rouge ""contient de la viande"" sinon.",,,,,,,,60d9e1765c251d62,,,,,,,
+- `# Étape 1` : écrivez un prédicat `bool IsVegetarian(Recipe r)` qui renvoie `false` si `r.Name` contient l'un des marqueurs.
+- `# Étape 2` : dans `RenderMenuCard`, calculez `bool allVeg = list.All(IsVegetarian)`.
+- `# Étape 3` : insérez dans l'en-tête de la carte un badge : vert ""100% vegetarien"" si `allVeg`, rouge ""contient de la viande"" sinon.",,,,,,,,f29bb78d49c50551,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,exo1-stub,code,fr,d55a567a2161ed53,"// Exercice 1 : badge vegetarien global dans RenderMenuCard.
 // TODO etudiant : modifier RenderMenuCard pour afficher un badge vegetarien en tete de carte.
 
@@ -4367,14 +4367,14 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,e
 //          $""{(allVeg ? ""100% vegetarien"" : ""contient de la viande"")}</span></div>"");
 
 Console.WriteLine(""Exercice a completer : badge vegetarien dans la carte de menu"");",,,,,,,,d55a567a2161ed53,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,exo2-title,markdown,fr,2d9414192712eaef,"#### Exercice 2 : Total kcal par jour dans la grille hebdomadaire
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,exo2-title,markdown,fr,823a66e0883a38fa,"#### Exercice 2 : Total kcal par jour dans la grille hebdomadaire
 
 Modifiez `RenderWeeklyGrid` pour ajouter une **ligne finale ""Total/jour""** qui affiche la somme des kcal de toutes les recettes de chaque journée, avec un code couleur (`KcalColor`).
 
 **Indices** :
-- `# Etape 1` : pour chaque jour `d`, calculez `int dayKcal = Enumerable.Range(0, slots).Sum(s => corpus[plan[d][s]].Kcal);`
-- `# Etape 2` : après la boucle des jours, ajoutez une ligne `<tr>` avec une cellule ""Total kcal"" et une cellule par jour contenant le total coloré.
-- `# Etape 3` : appelez `KcalColor(dayKcal)` pour la couleur du total.",,,,,,,,2d9414192712eaef,,,,,,,
+- `# Étape 1` : pour chaque jour `d`, calculez `int dayKcal = Enumerable.Range(0, slots).Sum(s => corpus[plan[d][s]].Kcal);`
+- `# Étape 2` : après la boucle des jours, ajoutez une ligne `<tr>` avec une cellule ""Total kcal"" et une cellule par jour contenant le total coloré.
+- `# Étape 3` : appelez `KcalColor(dayKcal)` pour la couleur du total.",,,,,,,,823a66e0883a38fa,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,exo2-stub,code,fr,db274e88c14b0625,"// Exercice 2 : ligne ""Total kcal / jour"" dans la grille hebdomadaire.
 // TODO etudiant : modifier RenderWeeklyGrid pour ajouter une ligne de totaux par jour.
 
@@ -4388,14 +4388,14 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,e
 // h.Append(""</tr>"");
 
 Console.WriteLine(""Exercice a completer : total kcal par jour dans la grille hebdomadaire"");",,,,,,,,db274e88c14b0625,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,exo3-title,markdown,fr,8eea6fcc39be041a,"#### Exercice 3 : Front de Pareto 2D (budget × plancher protéines) rendu en heatmap
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,exo3-title,markdown,fr,66b9683677b1c85f,"#### Exercice 3 : Front de Pareto 2D (budget × plancher protéines) rendu en heatmap
 
 Étendez la section 5 en faisant varier **simultanément** le budget (800..2000) **et** le plancher de protéines (10..50 g). Pour chaque couple `(budget, protFloor)`, résolvez et stockez le kcal atteint. Rendez le tout comme une **heatmap HTML 2D** : lignes = budgets, colonnes = planchers protéiques, couleur de la cellule = kcal atteint (vert = haut, rouge = bas/irréalisable).
 
 **Indices** :
-- `# Etape 1` : construisez une double boucle `foreach (budget ...) foreach (protFloor ...)` qui appelle le solveur et remplit un `int[,] heatmap`.
-- `# Etape 2` : pour la couleur, normalisez le kcal sur la plage observée (`intensity = (kcal - minKcal) / (maxKcal - minKcal)`) et mappez sur un dégradé vert→jaune→rouge (utilisez `System.Drawing.Color` ou un palette CSS).
-- `# Etape 3` : générez un `<table>` HTML où chaque `<td>` a un `style='background:rgb(...)'` calculé depuis l'intensité, et contient la valeur kcal.",,,,,,,,8eea6fcc39be041a,,,,,,,
+- `# Étape 1` : construisez une double boucle `foreach (budget ...) foreach (protFloor ...)` qui appelle le solveur et remplit un `int[,] heatmap`.
+- `# Étape 2` : pour la couleur, normalisez le kcal sur la plage observée (`intensity = (kcal - minKcal) / (maxKcal - minKcal)`) et mappez sur un dégradé vert→jaune→rouge (utilisez `System.Drawing.Color` ou un palette CSS).
+- `# Étape 3` : générez un `<table>` HTML où chaque `<td>` a un `style='background:rgb(...)'` calculé depuis l'intensité, et contient la valeur kcal.",,,,,,,,66b9683677b1c85f,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,exo3-stub,code,fr,595ef9f7f785e755,"// Exercice 3 : heatmap 2D budget x plancher proteines (kcal atteint par cellule).
 // TODO etudiant : double boucle de solve, stockage dans int[,], rendu heatmap HTML.
 
@@ -4407,7 +4407,7 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,e
 // ... rendu : <table> avec background calcule depuis l'intensite normalisee
 
 Console.WriteLine(""Exercice a completer : heatmap 2D du front de Pareto budget x proteines"");",,,,,,,,595ef9f7f785e755,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,f71ae7c0,markdown,fr,ec6f3e11a538be5c,"---
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,f71ae7c0,markdown,fr,e7a0cd644fac83e3,"---
 
 ### Conclusion
 
@@ -4417,20 +4417,20 @@ Ce notebook a parcouru la **modelisation declarative** d'un planificateur de rep
 
 | Concept | Ou | Implementation |
 |---------|-----|----------------|
-| Selection booleenne + agregation | Partie A §5 | une `BoolExpr` par item, cardinalite, `MkITE` sur les apports |
+| Sélection booleenne + agregation | Partie A §5 | une `BoolExpr` par item, cardinalite, `MkITE` sur les apports |
 | Optimisation par dichotomie | Partie A §6 | recherche binaire sur le budget, borne prouvee |
-| Theoreme hierarchique `int[][]` | Partie A §7 | `NewTheorem<WeeklyPlan>`, `Z3Methods.Distinct` cross-row, pur LINQ |
-| `CollectionHandling` (Array vs Constants) | Partie A §9 | meme theoreme, deux modes d'encodage du tableau |
-| Couplage hebdomadaire | Partie B | matrice booleenne jours x plats, fenetre kcal/jour, variete globale |
+| Theoreme hiérarchique `int[][]` | Partie A §7 | `NewTheorem<WeeklyPlan>`, `Z3Methods.Distinct` cross-row, pur LINQ |
+| `CollectionHandling` (Array vs Constants) | Partie A §9 | même theoreme, deux modes d'encodage du tableau |
+| Couplage hebdomadaire | Partie B | matrice booleenne jours x plats, fenêtre kcal/jour, variete globale |
 | Solveur vs glouton | Partie B | le glouton echoue la ou le solveur prouve la faisabilite |
 | Decouplage solveur / rendu | Partie C | `display(HTML(...))` = fonction pure des objets du domaine |
 | Exploration parametrique | Partie C | boucle de solves sous budgets varies -> front de Pareto rendu |
 
 #### Perspective
 
-Les techniques vues ici se generalisent a tout solveur produisant des objets structures : planification de personnel (grille par equipe), allocation de ressources (heatmap de charge), ordonnancement (frise temporelle). Le principe reste le meme : **le solveur produit des objets du domaine, le reste est une fonction pure de ces sorties.** Le corpus de donnees a l'echelle (matching RecipeML x Ciqual) est traite dans le notebook de donnees 07 ; la variante « deux stacks » (DSL `Z3.Linq` vs API brute `Microsoft.Z3`) est developpee plus loin dans la serie.
+Les techniques vues ici se generalisent a tout solveur produisant des objets structures : planification de personnel (grille par équipe), allocation de ressources (heatmap de charge), ordonnancement (frise temporelle). Le principe reste le même : **le solveur produit des objets du domaine, le reste est une fonction pure de ces sorties.** Le corpus de données a l'echelle (matching RecipeML x Ciqual) est traite dans le notebook de données 07 ; la variante « deux stacks » (DSL `Z3.Linq` vs API brute `Microsoft.Z3`) est developpee plus loin dans la serie.
 
-**Navigation** : [Index Z3](./README.md) | [Notebook precedent (Nested Arrays)](05_Nested_Arrays_2D.ipynb)",,,,,,,,ec6f3e11a538be5c,,,,,,,
+**Navigation** : [Index Z3](./README.md) | [Notebook précédent (Nested Arrays)](05_Nested_Arrays_2D.ipynb)",,,,,,,,e7a0cd644fac83e3,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/07_Meal_Planner_Data_External.ipynb,4a6c161c,markdown,fr,86bac8dd5eea753d,"# 07 — Données réelles & externe : Ciqual × RecipeML (couche de données, 0 Z3)
 
 > **Bloc meal-planner — notebook « Données & externe »** ([Epic #4677](https://github.com/jsboige/CoursIA/issues/4677)). Il porte à l'échelle réelle — Ciqual complet × plusieurs milliers de recettes **RecipeML** — la couche **données** du planificateur. La modélisation Z3 vit ailleurs : [06](06_Meal_Planner_Modelisation.ipynb) la pose sur un corpus jouet, [09](09_Meal_Planner_Convergence_Scale.ipynb) la résout à l'échelle sur le cache produit ici.
@@ -4958,7 +4958,7 @@ La leçon transverse est celle du **data-engineering** : les données réelles a
 - **Modélisation déclarative** ([06](06_Meal_Planner_Modelisation.ipynb)) — index/booléens, `MkITE`, exclusion d'allergène, théorème hiérarchique ;
 - **Capstone patient** ([08](08_Meal_Planner_Patient_Capstone.ipynb)) — théorème 4 niveaux + restrictions `Min`/`Max` ;
 - **Convergence à l'échelle** ([09](09_Meal_Planner_Convergence_Scale.ipynb)) — garder Z3 tractable quand le sous-ensemble grandit.",,,,,,,,738ea79b164f1c3a,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,63d594d6,markdown,fr,a0bb19a345212e85,"# 08 — Capstone hiérarchique : du squelette `int[][]` réel aux restrictions patient (port fidèle)
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,63d594d6,markdown,fr,396c6849e18e666e,"# 08 — Capstone hiérarchique : du squelette `int[][]` réel aux restrictions patient (port fidèle)
 
 [< Série Z3](README.md) | Capstone MealPlanner capstone (*Part of* #4617, *See* #1206)
 
@@ -4966,7 +4966,7 @@ Ce notebook est le **cœur solveur** du capstone MealPlanner. Il porte **fidèle
 `PlanificateurDeMenus.Create` du Demo2 d'origine
 ([fork Z3.Linq, branche `EPFdevelopment`](https://github.com/MyIntelligenceAgency/Z3.LinqBinding)),
 et le construit en **deux mouvements** sur le **corpus réel** Ciqual ANSES 2025 × Recettes
-(`mealplan_cache.json`, produit par la [couche de donnees 07] — [07](07_Meal_Planner_Data_External.ipynb)) :
+(`mealplan_cache.json`, produit par la [couche de données 07] — [07](07_Meal_Planner_Data_External.ipynb)) :
 
 - **Mouvement 1 — le squelette structurel `int[][]` sur les recettes reelles du cache.** Bornes de créneau par
   rôle (entrée, plat, accompagnement…), montée en gamme, permutation totale (`Distinct` cross-row en
@@ -4997,15 +4997,15 @@ constituant (ex : énergie dans une fenêtre kJ, lipides plafonnées) — exacte
 > **Note de consolidation.** Ce notebook réunit le squelette structurel à l'échelle réelle (Mouvement 1)
 > et le théorème nutritionnel fidèle (Mouvement 2), auparavant éclatés en deux notebooks. La leçon est
 > séquentielle : la *structure* passe à l'échelle sans effort, c'est l'ajout de la *nutrition fidèle*
-> (le linking) qui fait exploser l'instance et impose de **curer** un sous-ensemble (cf Mouvement 2).",,,,,,,,a0bb19a345212e85,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,38ab910e,markdown,fr,24bd3db6b12b774e,"## 0. Dependances et corpus
+> (le linking) qui fait exploser l'instance et impose de **curer** un sous-ensemble (cf Mouvement 2).",,,,,,,,396c6849e18e666e,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,38ab910e,markdown,fr,2c345e674d9fb091,"## 0. Dependances et corpus
 
 Le notebook charge le cache `mealplan_cache.json` produit par [07(07_Meal_Planner_Data_External.ipynb)).
 Si le cache est absent : executer 07 (ou `python download_meal_data.py` puis 07). **Echec bruyant**, pas
-de corpus de substitution (regle SOTA : on raisonne sur les vraies donnees nutritionnelles).
+de corpus de substitution (règle SOTA : on raisonne sur les vraies données nutritionnelles).
 
-Le fork Z3.Linq est charge depuis `.deploy/` (script de build unique, cf README) — meme build que
-toute la serie, incluant le support `int[][]` et `CollectionHandling.Array`.",,,,,,,,24bd3db6b12b774e,,,,,,,
+Le fork Z3.Linq est charge depuis `.deploy/` (script de build unique, cf README) — même build que
+toute la serie, incluant le support `int[][]` et `CollectionHandling.Array`.",,,,,,,,2c345e674d9fb091,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,350f2193,code,fr,7e397bb2764dda1a,"#r ""../Z3.Linq/.deploy/Microsoft.Z3.dll""
 #r ""../Z3.Linq/.deploy/ExpressionUtils.dll""
 #r ""../Z3.Linq/.deploy/Z3.Linq.dll""
@@ -5074,11 +5074,11 @@ un plan de 7 jours qui respecte le **rôle de chaque créneau** et la **diversit
 sur un `int[][]`. C'est le théorème hiérarchique du notebook [06](06_Meal_Planner_Modelisation.ipynb)
 (corpus jouet) porté **sans modification** à l'échelle réelle, en deux variantes : *montée en gamme* et
 *permutation totale*. Aucune teneur nutritionnelle n'intervient encore — uniquement les index de plats.",,,,,,,,22d504007cc9dc4f,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,cbef5234,markdown,fr,c75122ca2c56377c,"### 1.1 Le corpus réel et sa structure en créneaux
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,cbef5234,markdown,fr,e75ef58e981e0550,"### 1.1 Le corpus réel et sa structure en créneaux
 
-Chaque plat porte un **creneau** (`Ordre`, de 1 a 7) : entree, plat principal, accompagnement, laitage/fromage, dessert, etc. C'est cette structure qui rend le probleme *hierarchique* — un plan de repas n'est pas un sac de plats interchangeables, chaque jour doit servir **un plat par creneau, du bon type**.
+Chaque plat porte un **creneau** (`Ordre`, de 1 a 7) : entree, plat principal, accompagnement, laitage/fromage, dessert, etc. C'est cette structure qui rend le problème *hiérarchique* — un plan de repas n'est pas un sac de plats interchangeables, chaque jour doit servir **un plat par creneau, du bon type**.
 
-Pour rendre chaque creneau adressable par une **plage d'index contigue** (exactement comme les bornes de categorie `[entLo, entHi]` du notebook 06 jouet), on **trie les plats par creneau**. On se restreint aux creneaux 1 a 5 (les plus garnis), suffisants pour un plan equilibre de 7 jours.",,,,,,,,c75122ca2c56377c,,,,,,,
+Pour rendre chaque creneau adressable par une **plage d'index contigue** (exactement comme les bornes de catégorie `[entLo, entHi]` du notebook 06 jouet), on **trie les plats par creneau**. On se restreint aux creneaux 1 a 5 (les plus garnis), suffisants pour un plan equilibre de 7 jours.",,,,,,,,e75ef58e981e0550,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,f34e9f2f,code,fr,6711f3af1ae54756,"const int Jours = 7;
 const int Creneaux = 5;   // ordres 1..5
 
@@ -5098,14 +5098,14 @@ for (int o = 1; o <= Creneaux; o++)
 Console.WriteLine($""\nTotal exploitable : {plats.Count} plats sur {Creneaux} creneaux."");
 Console.WriteLine(""\nExemples (creneau 1) : "" + string.Join("", "",
     plats.Where(p => p.Ordre == 1).Take(4).Select(p => p.Nom.Trim())));",,,,,,,,6711f3af1ae54756,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,b7dffde0,markdown,fr,e3a77de2b1f73baf,"### 1.2 Le théorème hiérarchique `int[][]`
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,b7dffde0,markdown,fr,fa76731e8ab2c7c4,"### 1.2 Le théorème hiérarchique `int[][]`
 
-On modelise le plan hebdomadaire comme un **tableau en escalier** `int[][]` : `Plan[j][c]` = l'index (dans la liste triee `plats`) du plat servi le jour `j` au creneau `c`. C'est la **meme structure** que le notebook 06 jouet, mais a l'echelle reelle.
+On modelise le plan hebdomadaire comme un **tableau en escalier** `int[][]` : `Plan[j][c]` = l'index (dans la liste triee `plats`) du plat servi le jour `j` au creneau `c`. C'est la **même structure** que le notebook 06 jouet, mais a l'echelle reelle.
 
-Les helpers sont definis dans une **classe statique** (`Menu`) : dans un noyau .NET Interactive, une classe statique **persiste d'une cellule a l'autre**, contrairement a une fonction locale. Le theoreme et les exercices la reutilisent.
+Les helpers sont définis dans une **classe statique** (`Menu`) : dans un noyau .NET Interactive, une classe statique **persiste d'une cellule a l'autre**, contrairement a une fonction locale. Le theoreme et les exercices la reutilisent.
 
-- `WithBounds` impose, pour chaque jour et chaque creneau, que l'index reste dans la plage du bon creneau (`Plan[j][c] in [lo[c+1], hi[c+1]]`). C'est la contrainte de categorie, exprimee une fois pour les `7 x 5 = 35` cases.
-- `PrintPlan` affiche le plan resolu en remontant des index aux noms de plats.",,,,,,,,e3a77de2b1f73baf,,,,,,,
+- `WithBounds` impose, pour chaque jour et chaque creneau, que l'index reste dans la plage du bon creneau (`Plan[j][c] in [lo[c+1], hi[c+1]]`). C'est la contrainte de catégorie, exprimee une fois pour les `7 x 5 = 35` cases.
+- `PrintPlan` affiche le plan resolu en remontant des index aux noms de plats.",,,,,,,,fa76731e8ab2c7c4,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,df322ccc,code,fr,22e0921cbf7773a3,"// Plan hebdomadaire : 7 jours x 5 creneaux, modelise comme int[][] (jagged).
 public class WeeklyMenuPlan
 {
@@ -5168,9 +5168,9 @@ using (var ctx = new Z3Context())
     Console.WriteLine($""[A] Montee en gamme resolue en {sw.Elapsed.TotalMilliseconds:F0} ms :\n"");
     if (plan != null) Menu.PrintPlan(plan, plats); else Console.WriteLine(""  UNSAT"");
 }",,,,,,,,e5a608c0bf040999,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,e145377e,markdown,fr,b672946a6142e284,"### Interpretation — variante A
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,e145377e,markdown,fr,ead795714ea9816f,"### Interpretation — variante A
 
-La contrainte de montee en gamme (`Plan[j][c] < Plan[j+1][c]`) force, pour chaque creneau, une **suite d'index strictement croissante** sur les 7 jours. Comme les plats sont tries par creneau, cela revient a parcourir le catalogue dans l'ordre, sans jamais reservir le meme plat. Z3.Linq traduit le `int[][]` en variables entieres et resout en LINQ pur, sans expansion manuelle des paires.",,,,,,,,b672946a6142e284,,,,,,,
+La contrainte de montee en gamme (`Plan[j][c] < Plan[j+1][c]`) force, pour chaque creneau, une **suite d'index strictement croissante** sur les 7 jours. Comme les plats sont tries par creneau, cela revient a parcourir le catalogue dans l'ordre, sans jamais reservir le même plat. Z3.Linq traduit le `int[][]` en variables entieres et resout en LINQ pur, sans expansion manuelle des paires.",,,,,,,,ead795714ea9816f,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,f9db8d5c,code,fr,436192c2033f186a,"// --- Variante B : permutation totale (CollectionHandling.Array EXPLICITE, Distinct cross-row) ---
 // Chaque creneau est servi 7 fois dans la semaine, sans aucune repetition :
 // Z3Methods.Distinct s'applique directement aux acces cross-row d'un int[][]
@@ -5191,11 +5191,11 @@ using (var ctxPerm = new Z3Context { DefaultCollectionHandling = CollectionHandl
     Console.WriteLine($""[B] Permutation totale (Distinct cross-row) resolue en {sw.Elapsed.TotalMilliseconds:F0} ms :\n"");
     if (planPerm != null) Menu.PrintPlan(planPerm, plats); else Console.WriteLine(""  UNSAT"");
 }",,,,,,,,436192c2033f186a,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,f945ba3b,markdown,fr,15cb6de62f19a776,"### Interpretation — variante B
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,f945ba3b,markdown,fr,044c683134184e00,"### Interpretation — variante B
 
-La variante B n'impose plus d'ordre, seulement la **diversite** : chaque creneau est servi sans repetition sur la semaine. `Z3Methods.Distinct` appliquee aux acces *cross-row* d'un `int[][]` produit **une seule contrainte SMT globale** par creneau (et non `C(7,2)` inegalites deux-a-deux) — exactement le mecanisme qui modelise les colonnes d'un Sudoku.
+La variante B n'impose plus d'ordre, seulement la **diversite** : chaque creneau est servi sans repetition sur la semaine. `Z3Methods.Distinct` appliquee aux acces *cross-row* d'un `int[][]` produit **une seule contrainte SMT globale** par creneau (et non `C(7,2)` inegalites deux-a-deux) — exactement le mécanisme qui modelise les colonnes d'un Sudoku.
 
-Le mode `CollectionHandling.Array` est ici **explicite** : il indique a Z3.Linq de reifier le tableau comme un tableau SMT, ce qui rend les acces cross-row adressables par `Distinct`. C'est le levier qui fait passer le `int[][]` du statut de simple structure de donnees a celui de **variable de decision hierarchique**.",,,,,,,,15cb6de62f19a776,,,,,,,
+Le mode `CollectionHandling.Array` est ici **explicite** : il indique a Z3.Linq de reifier le tableau comme un tableau SMT, ce qui rend les acces cross-row adressables par `Distinct`. C'est le levier qui fait passer le `int[][]` du statut de simple structure de données a celui de **variable de decision hiérarchique**.",,,,,,,,044c683134184e00,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,a19e7e62,markdown,fr,9a9af61528125f9e,"## Mouvement 2 — La nutrition *fidèle* force la curation
 
 Le squelette structurel passe à l'échelle réelle sans effort (Z3 résout les deux variantes en quelques
@@ -5205,16 +5205,16 @@ Demo2 : le **linking de composition** (la variable de teneur liée au plat réel
 `7 × 5 × R × C` assertions (R recettes, C constituants) — l'instance **explose**. On **cure** donc d'abord un
 sous-ensemble tractable, en préservant la **structure** du théorème (port fidèle de
 `PlanificateurDeMenus.Create`).",,,,,,,,9a9af61528125f9e,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,0c508613,markdown,fr,f9457410196e5dee,"### 2.1 Curation d'un sous-ensemble tractable
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,0c508613,markdown,fr,c720c6817c7acad6,"### 2.1 Curation d'un sous-ensemble tractable
 
 La source pose le theoreme sur plusieurs centaines de recettes x 5 constituants x 7 menus x 5 creneaux. Le linking de
 composition genere alors `7 x 5 x R x C` (R recettes, C constituants) assertions — l'instance **explose** (c'est
-precisement le probleme de *convergence a l'echelle*, objet de [09 (convergence a l'echelle)](09_Meal_Planner_Convergence_Scale.ipynb)). Le corps de l'issue
+précisément le problème de *convergence a l'echelle*, objet de [09 (convergence a l'echelle)](09_Meal_Planner_Convergence_Scale.ipynb)). Le corps de l'issue
 #4617 le prevoit : **on cure d'abord un sous-ensemble**.
 
 On reduit donc a **2 menus x 3 creneaux**, **5 candidats par creneau**, et **3 constituants cles**
 (energie kJ, proteines, lipides). Le theoreme reste **fidele dans sa structure** ; seules les
-*dimensions* sont reduites pour rester pedagogiquement lisible et resoluble en quelques secondes.",,,,,,,,f9457410196e5dee,,,,,,,
+*dimensions* sont reduites pour rester pedagogiquement lisible et resoluble en quelques secondes.",,,,,,,,c720c6817c7acad6,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,3115b835,code,fr,bc276b38324cba61,"// --- Parametres du sous-ensemble cure ---
 const int NbMenus = 2;          // 2 jours
 const int NbPlats = 3;          // 3 creneaux (ordre 1, 2, 3)
@@ -5244,14 +5244,14 @@ for (int p = 0; p < NbPlats; p++) {
         .Select(i => $""{pool[i].Nom.Trim()}({Teneur(i, cEnergie)})"");
     Console.WriteLine($""  creneau {p+1} : "" + string.Join("", "", noms));
 }",,,,,,,,bc276b38324cba61,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,cf93b03d,markdown,fr,a74cce1a06dab1e2,"### 2.2 Le modèle : 3 tableaux `int[][]`
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,cf93b03d,markdown,fr,bf6db645cd00cfcd,"### 2.2 Le modèle : 3 tableaux `int[][]`
 
 Le Demo2 d'origine modelise un **graphe d'objets** (`Menu[]` contenant `Plat[]` contenant `PlatId` +
 `Compositions[]`). Le binding Z3.Linq de la serie expose, lui, des **tableaux `int[][]`** (cf 05) :
-c'est l'encodage *index* que le fork resout en notebook. On reproduit donc la **semantique** de la
+c'est l'encodage *index* que le fork resout en notebook. On reproduit donc la **sémantique** de la
 source avec trois `int[][]` :
 
-| Tableau | Forme | Role |
+| Tableau | Forme | Rôle |
 |---------|-------|------|
 | `PlatId[m][p]`  | `[NbMenus][NbPlats]`          | index (dans la pool) du plat choisi au creneau (m, p) |
 | `Comp[slot][k]` | `[NbMenus*NbPlats][3]`        | composition du plat choisi a ce slot (variable liee par disjonction) |
@@ -5259,7 +5259,7 @@ source avec trois `int[][]` :
 
 `Comp` est l'**aux variable** qui resout l'impossibilite d'indexer un tableau C# par une variable Z3
 (on ne peut pas ecrire `Plats[PlatId[m][p]]`) : on la **lie** au bon plat par une disjonction
-(section 3.3), exactement la technique de la source.",,,,,,,,a74cce1a06dab1e2,,,,,,,
+(section 3.3), exactement la technique de la source.",,,,,,,,bf6db645cd00cfcd,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,dd05ae3f,code,fr,d21828c57aae7b33,"public class PlanRepas {
     public int[][] PlatId  { get; set; }   // [NbMenus][NbPlats]      : plat choisi par creneau
     public int[][] Comp    { get; set; }   // [NbMenus*NbPlats][3]    : composition liee du slot
@@ -5272,11 +5272,11 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipy
 }
 Console.WriteLine(""Modele PlanRepas defini (PlatId, Comp, MenuNut)."");
 ",,,,,,,,d21828c57aae7b33,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,78ce72f9,markdown,fr,bd777ff45073bba2,"### 2.3 Le patient et ses restrictions
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,78ce72f9,markdown,fr,2b4a0323e36c5af3,"### 2.3 Le patient et ses restrictions
 
 Fidele a la classe `Patient { Restriction[] Restrictions }` du source : chaque restriction porte un
-`Min` et un `Max` par constituant (`-1` = pas de borne). Ici, le patient impose une **fenetre
-energetique** par menu et un **plafond de lipides**.",,,,,,,,bd777ff45073bba2,,,,,,,
+`Min` et un `Max` par constituant (`-1` = pas de borne). Ici, le patient impose une **fenêtre
+energetique** par menu et un **plafond de lipides**.",,,,,,,,2b4a0323e36c5af3,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,12060328,code,fr,3983a26d9aa29f53,"// Restrictions patient (fidele a Restriction { Min, Max }, -1 = pas de borne), par MENU.
 // Echelle : cache 07 en kJ/100 g (Energie Ciqual) sommees sur les 3 plats du menu.
 // ( bornes rescalees de kcal -> kJ lors du rewire sur le cache 07 : x4,184 )
@@ -5286,18 +5286,18 @@ int protMin    = 30;     // proteines minimum par menu (g)
 int lipMax     = 600;    // lipides maximum par menu (g)
 Console.WriteLine($""Patient : energie in [{energieMin}, {energieMax}] kJ, proteines >= {protMin} g, lipides <= {lipMax} g (par menu)"");
 ",,,,,,,,3983a26d9aa29f53,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,0af45f83,markdown,fr,876193c4f558eb0c,"### 3.1 -> 3.5 Construction du theoreme (port fidele de `Create`)
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,0af45f83,markdown,fr,24d2d5565efc3cb7,"### 3.1 -> 3.5 Construction du theoreme (port fidele de `Create`)
 
 Les cinq familles de contraintes reproduisent `PlanificateurDeMenus.Create` (source lignes 38-101) :
 
 1. **Bornes = ordre** : `PlatId[m][p]` indexe un plat du creneau (p+1) — la source impose
    `allPlats[rid].Ordre == p+1` ; ici la partition de la pool par ordre l'encode dans les bornes.
-2. **Variete** : `Z3Methods.Distinct(...)` sur tous les slots — *pas deux fois le meme plat*
+2. **Variete** : `Z3Methods.Distinct(...)` sur tous les slots — *pas deux fois le même plat*
    (source : `Distinct` sur la grille des `PlatId`).
 3. **Linking composition** : `PlatId[m][p] != cand || Comp[slot][k] == teneur(cand, k)` — lie la
    variable de composition au plat reellement choisi (source lignes 71-74).
 4. **Somme par menu** : `MenuNut[m][k] == somme_p Comp[slot(m,p)][k]` (source lignes 84-85).
-5. **Restrictions patient** : `Min < MenuNut[m][k] < Max` selon les bornes du patient (source lignes 90-99).",,,,,,,,876193c4f558eb0c,,,,,,,
+5. **Restrictions patient** : `Min < MenuNut[m][k] < Max` selon les bornes du patient (source lignes 90-99).",,,,,,,,24d2d5565efc3cb7,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,75a666b7,code,fr,6b94e5943fca3d43,"var sw = Stopwatch.StartNew();
 PlanRepas sol = null;
 using (var ctx = new Z3Context { DefaultCollectionHandling = CollectionHandling.Array })
@@ -5359,11 +5359,11 @@ if (sol == null) {
     }
 }
 ",,,,,,,,6b94e5943fca3d43,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,9f874047,markdown,fr,7b36febf63056bc6,"### 2.4 Vérification : les restrictions sont-elles vraiment respectées ?
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,9f874047,markdown,fr,a688f40b1571fcef,"### 2.4 Vérification : les restrictions sont-elles vraiment respectées ?
 
 Un solveur **garantit** les contraintes par construction — mais on **verifie** independamment
-(re-calcul hors Z3) que chaque menu respecte la fenetre du patient. C'est la difference entre *croire*
-le solveur et *prouver* le resultat.",,,,,,,,7b36febf63056bc6,,,,,,,
+(re-calcul hors Z3) que chaque menu respecte la fenêtre du patient. C'est la différence entre *croire*
+le solveur et *prouver* le résultat.",,,,,,,,a688f40b1571fcef,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,369a86be,code,fr,bcd10ff436953da7,"if (sol == null) {
     Console.WriteLine(""Pas de solution a verifier (UNSAT)."");
 } else {
@@ -5409,13 +5409,13 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipy
 //
 // TODO etudiant : completez ci-dessous.
 Console.WriteLine(""Exercice 1 a completer : diversite des entrees sur jours consecutifs."");",,,,,,,,31f84064f588a87f,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,b735bf7e,markdown,fr,534e99f960aa0020,"### Exercice 2 — Une restriction qui rend le probleme insatisfiable
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,b735bf7e,markdown,fr,3f988efe365f8d46,"### Exercice 2 — Une restriction qui rend le problème insatisfiable
 
 Le patient devient diabetique : imposez un **plafond energetique strict** par menu (ex. `energieMax = 1500`)
 et reconstruisez le theoreme. Observez si Z3 trouve encore un plan ou repond **UNSAT**, et expliquez
 *pourquoi* (quel creneau porte l'essentiel de l'energie kJ ?).
 
-*Indice* : recopiez le bloc de la section 3.5 en changeant `energieMax`, ou parametrez-le.",,,,,,,,534e99f960aa0020,,,,,,,
+*Indice* : recopiez le bloc de la section 3.5 en changeant `energieMax`, ou parametrez-le.",,,,,,,,3f988efe365f8d46,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,93574677,code,fr,bde26de98254ba54,"// Exercice 2 : trouver le plafond energetique qui bascule SAT -> UNSAT.
 // TODO etudiant : reconstruire le theoreme avec un energieMax plus strict et reporter le verdict.
 int ExerciceUnsatThreshold()
@@ -5429,14 +5429,14 @@ int ExerciceUnsatThreshold()
 }
 ExerciceUnsatThreshold();
 ",,,,,,,,bde26de98254ba54,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,6bd5be84,markdown,fr,c16b609952f1456e,"### Exercice 3 — Passer a 3 menus (tractabilite)
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,6bd5be84,markdown,fr,be835150b2f52396,"### Exercice 3 — Passer a 3 menus (tractabilite)
 
-Portez `NbMenus` de 2 a **3** (3 jours). Adaptez la taille des tableaux du modele `PlanRepas`
+Portez `NbMenus` de 2 a **3** (3 jours). Adaptez la taille des tableaux du modèle `PlanRepas`
 (`PlatId` `[3][3]`, `Comp` `[9][3]`, `MenuNut` `[3][3]`) et le `Distinct` (9 slots). Mesurez le temps
 de resolution : reste-t-il de l'ordre de la seconde ? C'est un premier pas vers [09 (convergence a l'echelle)](09_Meal_Planner_Convergence_Scale.ipynb)
 (convergence a l'echelle).
 
-*Indice* : `Z3Methods.Distinct` accepte une liste d'arguments ; enumerez les 9 `PlatId[m][p]`.",,,,,,,,c16b609952f1456e,,,,,,,
+*Indice* : `Z3Methods.Distinct` accepte une liste d'arguments ; enumerez les 9 `PlatId[m][p]`.",,,,,,,,be835150b2f52396,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,6b204fc2,code,fr,a1f4f77f8bf30596,"// Exercice 3 : etendre a NbMenus = 3 et mesurer le temps de resolution.
 // TODO etudiant : adapter le modele (tailles), le Distinct (9 slots) et resoudre.
 double ExerciceTroisMenus()
@@ -5468,11 +5468,11 @@ int ExerciceConstituantSel()
 }
 ExerciceConstituantSel();
 ",,,,,,,,61c72c1c909bb1c3,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,0a278a03,markdown,fr,69a08b49c26e9a52,"## Conclusion
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,0a278a03,markdown,fr,ff01753b9bed54db,"## Conclusion
 
 Ce notebook a porté **fidèlement** le cœur solveur du Demo2 (`PlanificateurDeMenus.Create`) en deux
 mouvements sur le **corpus réel** Ciqual × Recettes construit par
-[07 (couche de donnees)](07_Meal_Planner_Data_External.ipynb) :
+[07 (couche de données)](07_Meal_Planner_Data_External.ipynb) :
 
 - **Mouvement 1 — la structure prime sur l'échelle.** Le même `int[][]` modélise un plan de 7 jours sur
   un vrai catalogue de plusieurs centaines de plats ; c'est la *structure en créneaux* (et non le nombre de plats) qui fait
@@ -5502,7 +5502,7 @@ disjonction-liée naïve explose dès la construction).
 
 ---
 
-*Série SMT / Z3.Linq — voir le [README](README.md) pour le parcours complet.*",,,,,,,,69a08b49c26e9a52,,,,,,,
+*Série SMT / Z3.Linq — voir le [README](README.md) pour le parcours complet.*",,,,,,,,ff01753b9bed54db,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,a6f26a1c,markdown,fr,aaf38f03f7c038b2,"# 09 — Convergence à l'échelle : l'encodage décide de la tractabilité
 
 **Clôture du bloc meal-planner (Epic #4677).** La modélisation déclarative ([06](06_Meal_Planner_Modelisation.ipynb)) a posé les modèles du planificateur sur un corpus jouet ; la couche de données ([07](07_Meal_Planner_Data_External.ipynb)) a construit le corpus réel — recettes RecipeML appariées à Ciqual ANSES 2025 **sans faux positifs** et agrégées **pondérées par la masse**. Ce notebook branche enfin le solveur sur ces données réelles, et y rencontre le problème que les corpus jouets masquaient : à l'échelle, l'encodage naïf explose dès la **construction**, l'encodage le plus **compact** (théorie des tableaux) devient **insoluble**, et seul l'encodage **one-hot pseudo-booléen** se construit instantanément et se résout.
@@ -5594,17 +5594,17 @@ var restr = new (int c, int lo, int hi)[] { (0, loE, hiE), (1, loP, -1), (4, -1,
 Console.WriteLine($""Theoreme : {NMENUS} menus x {NPLATS} plats, sur R={R} recettes (vecteurs recette entiere)."");
 Console.WriteLine($""   energie/menu in [{loE},{hiE}] kJ, proteines/menu >= {loP} g, sel/menu <= {hiS} g."");
 ",,,,,,,,d6a30af6068fe248,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,ea3a8f3b,markdown,fr,20fe57b52eefbbdd,"## 3. Trois encodages du meme theoreme, trois comportements
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,ea3a8f3b,markdown,fr,a83981980d71df45,"## 3. Trois encodages du même theoreme, trois comportements
 
 Le theoreme est fixe : **7 menus x 5 plats**, chaque plat **distinct** sur la semaine (variete), chaque
-menu dans une **fenetre nutritionnelle**. Seul l'**encodage** SMT change. On va voir trois comportements
-radicalement differents sur le **meme** corpus reel.
+menu dans une **fenêtre nutritionnelle**. Seul l'**encodage** SMT change. On va voir trois comportements
+radicalement différents sur le **même** corpus reel.
 
 ### 3.1 Encodage naif (disjonction) -- explose des la construction
 
 L'encodage naif (celui du `Create` original) introduit une variable de nutrition par creneau et, pour
 **chaque recette**, la disjonction `creneau != r OU nutrition == ligne[r]`. Le nombre d'assertions croit
-en `menus x plats x R x constituants` : on ne mesure meme pas la resolution, juste la **construction**.",,,,,,,,20fe57b52eefbbdd,,,,,,,
+en `menus x plats x R x constituants` : on ne mesure même pas la resolution, juste la **construction**.",,,,,,,,a83981980d71df45,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,ed45a410,code,fr,750e37fe5742b55c,"// ---- naif : sonde de temps de CONSTRUCTION (la resolution ne demarre meme pas a l'echelle) ----
 long BuildNaive(int rcap)
 {
@@ -5633,12 +5633,12 @@ long BuildNaive(int rcap)
 foreach (var rcap in new[] { 100, 300, Math.Min(R, 1000) }) BuildNaive(rcap);
 Console.WriteLine(""  -> le cout de construction croit lineairement en R x menus x plats x contraintes :"");
 Console.WriteLine(""     a l'echelle reelle, le solveur n'a meme pas commence a chercher une solution."");",,,,,,,,750e37fe5742b55c,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,2193688c,markdown,fr,58c3e88b2b75a09c,"### 3.2 Theorie des tableaux -- compacte a ecrire, mais insoluble
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,2193688c,markdown,fr,c4b6bb5412a3cab2,"### 3.2 Théorie des tableaux -- compacte a ecrire, mais insoluble
 
-L'encodage par **theorie des tableaux** (notebook 04) est **compact** : un `Array` par constituant
-(chaine de `Store` sur les R valeurs), un index entier par creneau, et `Select(arr, index)` pour lire la
-valeur. Le nombre de **contraintes** devient independant de R. Surprise : Z3 retourne **`unknown`** -- il
-ne sait pas resoudre les longues chaines de `Store` **symboliques**. *Compacite d'ecriture != resolubilite.*",,,,,,,,58c3e88b2b75a09c,,,,,,,
+L'encodage par **théorie des tableaux** (notebook 04) est **compact** : un `Array` par constituant
+(chaîne de `Store` sur les R valeurs), un index entier par creneau, et `Select(arr, index)` pour lire la
+valeur. Le nombre de **contraintes** devient indépendant de R. Surprise : Z3 retourne **`unknown`** -- il
+ne sait pas resoudre les longues chaînes de `Store` **symboliques**. *Compacite d'ecriture != resolubilite.*",,,,,,,,c4b6bb5412a3cab2,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,4ad56a35,code,fr,4ab7dc57a8498fa8,"// ---- theorie des tableaux : compact, mais Z3 -> unknown sur de longues chaines de Store symboliques ----
 {
     using var c = new Context();
@@ -5669,19 +5669,19 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ip
     Console.WriteLine($""theorie des tableaux ({NMENUS * NPLATS} index, chaines de Store de longueur {R}) : {rr} en {sw2.Elapsed.TotalSeconds:F1}s"");
     Console.WriteLine(""  -> compact a ECRIRE, mais insoluble : Z3 ne tranche pas les Store symboliques empiles. Compacite != resolubilite."");
 }",,,,,,,,4ab7dc57a8498fa8,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,9fe99f47,markdown,fr,9cdbe363a107a0d8,"### 3.3 One-hot pseudo-booleen -- l'encodage qui passe a l'echelle
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,9fe99f47,markdown,fr,8ef1a6548e6ca7dc,"### 3.3 One-hot pseudo-booléen -- l'encodage qui passe a l'echelle
 
-L'encodage **one-hot** introduit un booleen `sel[m][p][r]` (""la recette r occupe le creneau p du menu m"").
+L'encodage **one-hot** introduit un booléen `sel[m][p][r]` (""la recette r occupe le creneau p du menu m"").
 Trois familles de contraintes, toutes **pseudo-booleennes natives** de Z3 :
 
 - `MkPBEq(.,1)` par creneau : **exactement une** recette par creneau.
 - `MkPBLe(.,1)` par recette sur toute la semaine : chaque recette **au plus une fois** (= variete / `Distinct`).
-- `MkPBGe` / `MkPBLe` **ponderes** par menu et par constituant : la fenetre nutritionnelle devient une
-  **somme ponderee de booleens** (coefficient = valeur de la recette), traitee par le **solveur
-  pseudo-booleen** de Z3 -- pas par l'arithmetique lineaire generale.
+- `MkPBGe` / `MkPBLe` **ponderes** par menu et par constituant : la fenêtre nutritionnelle devient une
+  **somme ponderee de booléens** (coefficient = valeur de la recette), traitee par le **solveur
+  pseudo-booléen** de Z3 -- pas par l'arithmetique lineaire générale.
 
 C'est cet encodage qui passe a l'echelle : les recettes sont des **contraintes enablantes**, le solveur
-trouve un modele sans enumerer. La **construction** est quasi instantanee meme a R~1000.",,,,,,,,9cdbe363a107a0d8,,,,,,,
+trouve un modèle sans enumerer. La **construction** est quasi instantanee même a R~1000.",,,,,,,,8ef1a6548e6ca7dc,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,178d2e41,code,fr,845977731c8d85bc,"// ---- one-hot pseudo-booleen : exactly-one + variete + bandes ponderees (MkPBGe / MkPBLe) ----
 var ctx = new Context();
 var s = ctx.MkSolver();
@@ -5713,41 +5713,41 @@ if (res == Status.SATISFIABLE)
         Console.WriteLine($""  Menu {m + 1} : "" + string.Join(""  |  "", names.Select(n => n.Length > 18 ? n.Substring(0, 18) : n)));
     }
 }",,,,,,,,845977731c8d85bc,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,f2a65bc2,markdown,fr,96717169fa8498f3,"### Interpretation : la compacite ne fait pas la resolubilite
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,f2a65bc2,markdown,fr,5a4aa89d7985a361,"### Interpretation : la compacite ne fait pas la resolubilite
 
 Trois encodages, un seul corpus :
 
 | Encodage | Taille | Comportement a R~1000 |
 |---|---|---|
 | **Naif (disjonction)** | `menus x plats x R x C` assertions | **explose a la construction** |
-| **Theorie des tableaux** | compact (R-independant) | **`unknown`** -- Store symboliques insolubles |
-| **One-hot pseudo-booleen** | `menus x plats x R` booleens | **construction quasi-immediate + resolu** |
+| **Théorie des tableaux** | compact (R-indépendant) | **`unknown`** -- Store symboliques insolubles |
+| **One-hot pseudo-booléen** | `menus x plats x R` booléens | **construction quasi-immediate + resolu** |
 
-La lecon centrale : a l'echelle, **l'encodage prime sur la compacite**. L'encodage one-hot pseudo-booleen
-repond a ""plus de donnees"" par ""plus de modeles a trouver"", pas ""plus de cas a enumerer"" -- c'est la
+La lecon centrale : a l'echelle, **l'encodage prime sur la compacite**. L'encodage one-hot pseudo-booléen
+repond a ""plus de données"" par ""plus de modèles a trouver"", pas ""plus de cas a enumerer"" -- c'est la
 traduction concrete de ""les recettes sont des contraintes enablantes"".
 
-> **Nuance (jusqu'au choix de la contrainte).** Meme **au sein** du one-hot, le detail compte : exprimer la
-> fenetre nutritionnelle comme une **contrainte pseudo-booleenne native** (`MkPBGe` / `MkPBLe`, somme ponderee
-> de booleens, traitee par le solveur PB) plutot que comme une **somme d'`ITE`** routee vers l'arithmetique
-> lineaire generale change la resolution d'un facteur **~150x** (mesure lors d'une iteration precedente a ~1 000 recettes : ~0,7 s contre ~110 s).
-> Le bon outil SMT pour une somme ponderee de booleens est le solveur pseudo-booleen, pas le solveur LIA.",,,,,,,,96717169fa8498f3,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,02b0fd5b,markdown,fr,8f3802b5fb0274b4,"## 4. Partitionnement par categorie : reduire R par creneau
+> **Nuance (jusqu'au choix de la contrainte).** Même **au sein** du one-hot, le detail compte : exprimer la
+> fenêtre nutritionnelle comme une **contrainte pseudo-booleenne native** (`MkPBGe` / `MkPBLe`, somme ponderee
+> de booléens, traitee par le solveur PB) plutot que comme une **somme d'`ITE`** routee vers l'arithmetique
+> lineaire générale change la resolution d'un facteur **~150x** (mesure lors d'une itération précédente a ~1 000 recettes : ~0,7 s contre ~110 s).
+> Le bon outil SMT pour une somme ponderee de booléens est le solveur pseudo-booléen, pas le solveur LIA.",,,,,,,,5a4aa89d7985a361,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,02b0fd5b,markdown,fr,df70cfe6a84700f1,"## 4. Partitionnement par catégorie : reduire R par creneau
 
 Le one-hot plat traite les cinq creneaux de chaque menu de facon identique : chacun peut tirer dans les
-**R** recettes. Or RecipeML porte `<categories><cat>` (Appetizers / Main dish / Desserts / ...). En
+**R** recettes. Or RecipeML porte `<catégories><cat>` (Appetizers / Main dish / Desserts / ...). En
 affectant **un pool par creneau** -- le creneau 1 ne tire que dans les entrees, le creneau 5 que dans les
 desserts -- chaque creneau ne choisit plus que dans un **sous-ensemble** (R/creneau plus petit). Deux gains :
 
-1. **Moins de booleens** : `sum_p |pool[p]| x menus` au lieu de `menus x plats x R` -- le solveur a
+1. **Moins de booléens** : `sum_p |pool[p]| x menus` au lieu de `menus x plats x R` -- le solveur a
    structurellement moins de variables a poser.
 2. **Fidelite a la contrainte d'ordre** du notebook 06 (entree -> plat -> dessert) : la structure du
    menu n'est plus emergente mais **imposee par construction**, et les menus produits sont coherents
    (une entree, un plat, un accompagnement, un pain, un dessert) au lieu de cinq desserts.
 
-On reutilise le solveur **pseudo-booleen pondere** de la section 3.3, applique aux pools. C'est le pont
+On reutilise le solveur **pseudo-booléen pondere** de la section 3.3, applique aux pools. C'est le pont
 vers un planificateur a l'echelle du corpus complet (5 215 recettes brutes, ou le one-hot plat atteindrait
-~183 000 booleens).",,,,,,,,8f3802b5fb0274b4,,,,,,,
+~183 000 booléens).",,,,,,,,df70cfe6a84700f1,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,1a88ab4b,code,fr,b369a7b975dc5c80,"// ---- partitionnement par categorie : un pool de recettes par creneau ----
 string[] COURSES = { ""Entree"", ""Plat principal"", ""Accompagnement"", ""Pain"", ""Dessert"" };
 var COURSE_CATS = new[]
@@ -5806,26 +5806,26 @@ if (res3 == Status.SATISFIABLE)
         Console.WriteLine($""  Menu {m + 1} -> "" + string.Join(""  |  "", names.Select(n => n.Length > 30 ? n.Substring(0, 30) : n)));
     }
 }",,,,,,,,b369a7b975dc5c80,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,fb3cfd17,markdown,fr,3b7787ea9cd853d1,"### Interpretation : la structure imposee aide le solveur
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,fb3cfd17,markdown,fr,b71b58ccd4af3284,"### Interpretation : la structure imposee aide le solveur
 
-Le partitionnement divise le nombre de booleens (chaque creneau ne voit que son pool, pas tout le corpus)
+Le partitionnement divise le nombre de booléens (chaque creneau ne voit que son pool, pas tout le corpus)
 **et** garantit des menus structures -- chaque ligne ci-dessus est bien *entree / plat / accompagnement /
-pain / dessert*, la ou le one-hot plat de la section 3.3 pouvait empiler cinq desserts. La meme machinerie
+pain / dessert*, la ou le one-hot plat de la section 3.3 pouvait empiler cinq desserts. La même machinerie
 pseudo-booleenne (`MkPBEq` / `MkPBLe` / `MkPBGe`) s'applique aux pools sans changement : c'est l'espace
 d'indices qui retrecit, pas l'encodage. A l'echelle du corpus complet, on partitionnerait plus finement
-(sous-categories, equilibrage des pools) -- mais le principe ""un pool par creneau"" suffit a casser la
-croissance en `plats x R` en une croissance par pool.",,,,,,,,3b7787ea9cd853d1,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,86b7989c,markdown,fr,1c95e7c68809b408,"## 5. Restriction patient : un menu vegetarien
+(sous-catégories, equilibrage des pools) -- mais le principe ""un pool par creneau"" suffit a casser la
+croissance en `plats x R` en une croissance par pool.",,,,,,,,b71b58ccd4af3284,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,86b7989c,markdown,fr,9919afe645a3a42e,"## 5. Restriction patient : un menu vegetarien
 
 L'utilisateur a observe que les recettes sont des **contraintes enablantes** : plus de recettes = plus de
 solutions, le solveur converge plus facilement. Une **restriction patient** (regime, allergie, intolerance)
-joue le role inverse -- elle *retrecit* l'espace des solutions sans en changer la taille d'encodage. On le
+joue le rôle inverse -- elle *retrecit* l'espace des solutions sans en changer la taille d'encodage. On le
 montre ici avec un **menu vegetarien** : il suffit d'interdire toute recette dont une `<cat>` RecipeML est une
-categorie viande/poisson (`Meats`, `Beef`, `Poultry`, `Seafood`, `Fish`, `Pork`, `Chicken`, `Stews`), exactement
-comme l'exclusion d'allergene -- une clause unaire `MkNot(sel...)` par booleen concerne. Aucune bande
+catégorie viande/poisson (`Meats`, `Beef`, `Poultry`, `Seafood`, `Fish`, `Pork`, `Chicken`, `Stews`), exactement
+comme l'exclusion d'allergene -- une clause unaire `MkNot(sel...)` par booléen concerne. Aucune bande
 nutritionnelle n'est touchee : l'encodage par pools de la section 4 est reutilise tel quel, on ajoute seulement
 des contraintes negatives. Le corpus reste assez riche (pool *plat principal* a des centaines de recettes
-non carnees : `Main dish`, `Pasta`, `Casseroles`...) pour que le probleme demeure SATISFIABLE.",,,,,,,,1c95e7c68809b408,,,,,,,
+non carnees : `Main dish`, `Pasta`, `Casseroles`...) pour que le problème demeure SATISFIABLE.",,,,,,,,9919afe645a3a42e,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,90c3a545,code,fr,1c85bb6625d135ab,"// ---- restriction patient : menu vegetarien (exclusion categorielle sur les memes pools qu'en section 4) ----
 var BANNED_VEG = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
     { ""Meats"", ""Beef"", ""Poultry"", ""Seafood"", ""Fish"", ""Pork"", ""Chicken"", ""Stews"" };
@@ -5881,9 +5881,9 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ip
 // Etape 2 : boucler sur les seuils, reperer la bascule SAT -> UNSAT.
 Console.WriteLine(""Exercice 1 a completer : seuil UNSAT de la fenetre energetique."");
 ",,,,,,,,e55aeb619406563f,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,6f0dbcc8,markdown,fr,12bbba268aebd412,"### Exercice 2 : plancher de glucides par menu
-Ajoutez une **borne basse** sur les glucides (constituant d'index 2) de chaque menu, sur le modele one-hot
-de la section 3.3.",,,,,,,,12bbba268aebd412,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,6f0dbcc8,markdown,fr,837fc91fcaa80418,"### Exercice 2 : plancher de glucides par menu
+Ajoutez une **borne basse** sur les glucides (constituant d'index 2) de chaque menu, sur le modèle one-hot
+de la section 3.3.",,,,,,,,837fc91fcaa80418,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,7231d359,code,fr,a755826cb09d8634,"// Exercice 2 : plancher de glucides par menu (constituant index 2).
 // Indice : meme patron que la bande proteines. Avec l'encodage PB pondere :
 //   var bools = (from p in Enumerable.Range(0,NPLATS) from r in Enumerable.Range(0,R) select sel[m][p][r]).ToArray();
@@ -6179,18 +6179,18 @@ using (var ctx = new Context())
     string t30 = ResoudreSMT(ctx, smt30);
     Console.WriteLine($""  [a-z]{{30}}        → témoin Z3 (len={t30?.Length}) re-vérifié(RE#)={Regex.IsMatch(t30, ""^[a-z]{30}$"")}"");
 }",,,,,,,,da4e7c5d7be63150,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,veanes-z3-monadic,markdown,fr,6bc9c4691af69406,"## 7c. Quand `re.inter` tient l'echelle - la decomposition monadique
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,veanes-z3-monadic,markdown,fr,e7f88d97b926aba8,"## 7c. Quand `re.inter` tient l'echelle - la decomposition monadique
 
-Le 7b resout `A & ~B` sur de **petits** langages (un caractere, une trentaine). Mais `re.inter` **materialise l'espace croise** des langages intersectes, et cet espace **explose** quand les contraintes se chevauchent. Le notebook [Sudoku-13](../../../Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb) le mesure : l'intersection 10-way d'une ligne, emise en `re.inter` *fondu*, fait `unknown` ; la **meme** contrainte eclatee en `str.contains` par chiffre **atterrit** la grille 9x9.
+Le 7b resout `A & ~B` sur de **petits** langages (un caractère, une trentaine). Mais `re.inter` **materialise l'espace croise** des langages intersectes, et cet espace **explose** quand les contraintes se chevauchent. Le notebook [Sudoku-13](../../../Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb) le mesure : l'intersection 10-way d'une ligne, emise en `re.inter` *fondu*, fait `unknown` ; la **même** contrainte eclatee en `str.contains` par chiffre **atterrit** la grille 9x9.
 
-La theorie qui tranche est la **decomposition monadique** de Veanes (*Monadic Decomposition*, CAV 2014). Une formule a plusieurs variables est **monadiquement decomposable** si elle equivaut a une combinaison booleenne de predicats a **une seule variable**. Quand elle l'est, on remplace le produit (`re.inter`) par une **conjonction de tests independants** - sans jamais construire l'automate croise.
+La théorie qui tranche est la **decomposition monadique** de Veanes (*Monadic Decomposition*, CAV 2014). Une formule a plusieurs variables est **monadiquement decomposable** si elle equivaut a une combinaison booleenne de predicats a **une seule variable**. Quand elle l'est, on remplace le produit (`re.inter`) par une **conjonction de tests independants** - sans jamais construire l'automate croise.
 
 | Forme emise | Ce que fait le solveur | Echelle |
 |-------------|------------------------|---------|
 | `re.inter` (intersection **fondue**) | materialise le produit des langages | sature des que les contraintes se chevauchent |
 | conjonction de predicats **monadiques** (`str.contains`) | tests independants, pas de produit | atterrit |
 
-> **La lecon, des deux cotes.** Ce notebook montre `A & ~B` la ou `re.inter` est **rapide** (peu de chevauchement) ; Sudoku-13 montre l'echelle ou il faut **decomposer**. Le bon critere n'est pas "" Z3 sait-il faire ? "" mais "" la conjonction est-elle monadiquement decomposable ? "". Veanes donne le verdict exact : un tous-distincts l'est (eclatable par chiffre), un ordre `x < y` ne l'est **pas** (aucune decomposition finie).",,,,,,,,6bc9c4691af69406,,,,,,,
+> **La lecon, des deux cotes.** Ce notebook montre `A & ~B` la ou `re.inter` est **rapide** (peu de chevauchement) ; Sudoku-13 montre l'echelle ou il faut **decomposer**. Le bon critere n'est pas "" Z3 sait-il faire ? "" mais "" la conjonction est-elle monadiquement decomposable ? "". Veanes donne le verdict exact : un tous-distincts l'est (eclatable par chiffre), un ordre `x < y` ne l'est **pas** (aucune decomposition finie).",,,,,,,,e7f88d97b926aba8,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,ba38e2c5,markdown,fr,c94930422a92d9d2,"## 8. Le payoff — générer un mot de passe `politique & ~faibles`
 
 Voici le motif `A & ~B` à pleine puissance, sur un cas réel : **fabriquer un mot de passe conforme à une politique tout en évitant les motifs faibles connus**.
@@ -6233,13 +6233,13 @@ Console.WriteLine($""  temps      = {sw.Elapsed.TotalMilliseconds:F1} ms"");",,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,cbad4641,markdown,fr,1a13cad7c96e2210,"## Exercices
 
 Trois exercices pour pratiquer le motif `A & ~B` et la génération de témoin. Les cellules sont des **squelettes à compléter** : remplacez les `// TODO etudiant` puis exécutez. Un vérificateur indépendant est fourni à chaque fois.",,,,,,,,1a13cad7c96e2210,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,078db832,markdown,fr,df5f0ddc061710f1,"### Exercice 1 — Une adresse e-mail valide mais pas `@spam.com`
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,078db832,markdown,fr,270737dd8fcb3b08,"### Exercice 1 — Une adresse e-mail valide mais pas `@spam.com`
 
 Générez un témoin pour le motif `A & ~B` où :
 - **A** = une adresse e-mail simple, p. ex. `^[a-z]+@[a-z]+\.[a-z]+$` ;
 - **~B** = qui **ne se termine pas** par `@spam.com` → `~(.*@spam\.com$)`.
 
-`# Indice` : pensez à **parenthéser** le `~(…)` (cf §4). `# Etape 1` : construisez l'automate via `engine.CreateFromRegexes`. `# Etape 2` : générez et vérifiez le témoin.",,,,,,,,df5f0ddc061710f1,,,,,,,
+`# Indice` : pensez à **parenthéser** le `~(…)` (cf §4). `# Étape 1` : construisez l'automate via `engine.CreateFromRegexes`. `# Étape 2` : générez et vérifiez le témoin.",,,,,,,,270737dd8fcb3b08,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,8d8ed423,code,fr,ac88c71ecad6b485,"// Exercice 1 : e-mail valide, mais pas @spam.com.
 // Etape 1 : composez le motif A & ~B (A = email simple, ~B = pas @spam.com).
 string motifEmail = null;  // TODO etudiant : ""^[a-z]+@[a-z]+\\.[a-z]+$&~(.*@spam\\.com$)""
@@ -6256,11 +6256,11 @@ else
     bool pasSpam = !temoin.EndsWith(""@spam.com"");
     Console.WriteLine($""temoin=\""{temoin}\""  pasSpam={pasSpam}"");
 }",,,,,,,,ac88c71ecad6b485,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,90f7ee76,markdown,fr,e84147875d6f38e6,"### Exercice 2 — Diagnostiquer et corriger le piège du solveur croisé
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,90f7ee76,markdown,fr,5d2fdc7556ae6159,"### Exercice 2 — Diagnostiquer et corriger le piège du solveur croisé
 
 Le code ci-dessous **échoue** : il construit l'automate avec un `CharSetSolver` local puis demande le témoin à un `RexEngine` distinct (le piège du §6). **Diagnostiquez** l'exception attendue, puis **corrigez** en utilisant le chemin sûr.
 
-`# Indice` : relisez le §6 — l'automate doit partager l'**algèbre** du moteur. `# Etape 1` : remplacez la construction par `engine.CreateFromRegexes(...)`.",,,,,,,,e84147875d6f38e6,,,,,,,
+`# Indice` : relisez le §6 — l'automate doit partager l'**algèbre** du moteur. `# Étape 1` : remplacez la construction par `engine.CreateFromRegexes(...)`.",,,,,,,,5d2fdc7556ae6159,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,9b80eed1,code,fr,361cde1e0d4916ee,"// Exercice 2 : corriger le piège du solveur croisé.
 var solveurLocal = new CharSetSolver(BitWidth.BV7);
 var moteurEx2 = new RexEngine(BitWidth.BV7);
@@ -6278,13 +6278,13 @@ else
     string temoin = moteurEx2.GenerateMember(autEx2);
     Console.WriteLine($""temoin=\""{temoin}\""  accepte={moteurEx2.Solver.Accepts(autEx2, temoin)}"");
 }",,,,,,,,361cde1e0d4916ee,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,0feeceac,markdown,fr,7f94284e169f9f2b,"### Exercice 3 — Un numéro de test à 10 chiffres, non déjà utilisé
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,0feeceac,markdown,fr,a57db406108aa333,"### Exercice 3 — Un numéro de test à 10 chiffres, non déjà utilisé
 
 Classique de la génération de test : produire un identifiant **valide** mais **pas dans une liste déjà utilisée**. Motif `A & ~B` :
 - **A** = `^[0-9]{10}$` — dix chiffres ;
 - **~B** = ne commence pas par un préfixe réservé connu, p. ex. `~(^0000.*$)`.
 
-`# Indice` : même schéma qu'au §8. `# Etape 1` : composez le motif. `# Etape 2` : générez plusieurs témoins et vérifiez qu'aucun ne commence par `0000`.",,,,,,,,7f94284e169f9f2b,,,,,,,
+`# Indice` : même schéma qu'au §8. `# Étape 1` : composez le motif. `# Étape 2` : générez plusieurs témoins et vérifiez qu'aucun ne commence par `0000`.",,,,,,,,a57db406108aa333,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,e0fc9b03,code,fr,96445b0e5a779d0b,"// Exercice 3 : numero de test a 10 chiffres, ne commencant pas par 0000.
 string motifNumero = null;  // TODO etudiant : ""^[0-9]{10}$&~(^0000.*$)""
 
@@ -6821,11 +6821,11 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/11_Job_Shop_Scheduling.ipynb,eea838b
 // public class JobShopSchedule3M { /* TODO */ }
 
 Console.WriteLine(""Exercice 3 a completer : extension 3×3 (Machines A, B, C)"");",,,,,,,,ae38bb35b70d9aaa,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/11_Job_Shop_Scheduling.ipynb,b5-witness-intro,markdown,fr,2c2ff4064d63e885,"## B5 - Témoin d'une quantite dérivée (DSL `Solve(inspect)` / `Eval`)
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/11_Job_Shop_Scheduling.ipynb,b5-witness-intro,markdown,fr,258f919d6bf30450,"## B5 - Témoin d'une quantite dérivée (DSL `Solve(inspect)` / `Eval`)
 
-Ce notebook lit le `Cmax` optimal, membre direct du type resultat. Mais une fois une solution trouvee, on veut souvent lire une quantite **dérivée** qui n'est **pas** un membre du type - la fin d'un job (`start + duree`), le temps mort d'une machine, ou un **fait relationnel** (« J1 commence-t-il bien après la fin de J0 ? »). Le `.Solve()` de base calcule un modèle Z3 puis **le jette** après avoir peuple l'objet resultat : impossible de rejouer une sous-expression. Le binding ajoute [`Theorem<T>.Solve(inspect)`](../Z3.Linq/solutions/Z3.Linq/Theorem.cs) : un callback qui **fait ressortir le modèle vivant** via un témoin `w.Eval(lambda)`, evalue sous **le meme modèle** que celui qui a produit la solution. Le callback **n'est pas invoque** si le théorème est UNSAT (aucun modèle a temoigner).
+Ce notebook lit le `Cmax` optimal, membre direct du type résultat. Mais une fois une solution trouvee, on veut souvent lire une quantite **dérivée** qui n'est **pas** un membre du type - la fin d'un job (`start + duree`), le temps mort d'une machine, ou un **fait relationnel** (« J1 commence-t-il bien après la fin de J0 ? »). Le `.Solve()` de base calcule un modèle Z3 puis **le jette** après avoir peuple l'objet résultat : impossible de rejouer une sous-expression. Le binding ajoute [`Theorem<T>.Solve(inspect)`](../Z3.Linq/solutions/Z3.Linq/Theorem.cs) : un callback qui **fait ressortir le modèle vivant** via un témoin `w.Eval(lambda)`, evalue sous **le même modèle** que celui qui a produit la solution. Le callback **n'est pas invoque** si le théorème est UNSAT (aucun modèle a temoigner).
 
-> **Stack : A + B - pourquoi**. Cote raw, le témoin est manuel : on garde le `Model`, on **re-exprime** la quantite dérivée en termes Z3 (`MkAdd(s0, d0)`) et on appelle `model.Eval(expr, true)`. Cote DSL, `Solve(w => w.Eval(x => x.S0 + d0))` evalue la **meme quantite dérivée** ecrite en lambda C# typee sur le resultat, sans jamais toucher a l'API Z3. Le contraste est la **meme valeur** (la fin de job, le makespan, le fait de non-chevauchement) obtenue des deux cotes sous le meme modèle - mais le DSL la lit dans le vocabulaire du modèle-objet, pas dans celui des termes Z3.",,,,,,,,2c2ff4064d63e885,,,,,,,
+> **Stack : A + B - pourquoi**. Cote raw, le témoin est manuel : on garde le `Model`, on **re-exprime** la quantite dérivée en termes Z3 (`MkAdd(s0, d0)`) et on appelle `model.Eval(expr, true)`. Cote DSL, `Solve(w => w.Eval(x => x.S0 + d0))` evalue la **même quantite dérivée** ecrite en lambda C# typee sur le résultat, sans jamais toucher a l'API Z3. Le contraste est la **même valeur** (la fin de job, le makespan, le fait de non-chevauchement) obtenue des deux cotes sous le même modèle - mais le DSL la lit dans le vocabulaire du modèle-objet, pas dans celui des termes Z3.",,,,,,,,258f919d6bf30450,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/11_Job_Shop_Scheduling.ipynb,b5-witness-code,code,fr,0e0c938d4f7f01f6,"// B5 - Temoin d'une quantite derivee ""Solve(inspect)"" : deux stacks sur le MEME mini-ordonnancement.
 //   Deux jobs sur une machine : J0 (duree 3), J1 (duree 2). Contraintes : S0 in [0,2], S1 >= S0+3, S1 <= 10.
 //   Quantites DERIVEES (non membres du type resultat) : fin0 = S0+3, makespan = S1+2, fait ""S1 >= fin0"".
@@ -6892,9 +6892,9 @@ public class Sched { public int S0 { get; set; }  public int S1 { get; set; } }
         .Solve(_ => invoked = true);
     Console.WriteLine($""[DSL] UNSAT : solution={(contradiction == null ? ""null"" : ""?"")}, callback invoque={invoked}  (pas de temoin sans modele)"");
 }",,,,,,,,0e0c938d4f7f01f6,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/11_Job_Shop_Scheduling.ipynb,b5-witness-lecture,markdown,fr,0d92846e93af5049,"### Lecture B5 - deux facons de temoigner, un meme modèle
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/11_Job_Shop_Scheduling.ipynb,b5-witness-lecture,markdown,fr,8c090e8ca1553ebf,"### Lecture B5 - deux facons de temoigner, un même modèle
 
-Les deux stacks resolvent le **meme mini-ordonnancement** et lisent les **memes quantites dérivées** - fin de J0, makespan, fait de non-chevauchement - **sous le meme modèle** qui a produit la solution. La difference est **comment** on rejoue une sous-expression après la résolution :
+Les deux stacks resolvent le **même mini-ordonnancement** et lisent les **mêmes quantites dérivées** - fin de J0, makespan, fait de non-chevauchement - **sous le même modèle** qui a produit la solution. La différence est **comment** on rejoue une sous-expression après la résolution :
 
 | Aspect | RAW (`Model.Eval`) | DSL (`Solve(inspect)` / `w.Eval`) |
 |---|---|---|
@@ -6903,9 +6903,9 @@ Les deux stacks resolvent le **meme mini-ordonnancement** et lisent les **memes 
 | Type de retour | `Expr` a caster (`IntNum`, `BoolExpr`) | Valeur CLR directe (`int`, `bool`) |
 | Sur UNSAT | `Model` inexistant (exception si on force) | Callback **non invoque**, `Solve` renvoie `null` |
 
-> **Ligne de contraste (a retenir)** : *le raw expose le `Model` Z3 et laisse l'utilisateur re-exprimer chaque quantite dérivée en termes du solveur* ; *le DSL fait ressortir le modèle par un callback type* - `w.Eval(x => x.S0 + d0)` lit la meme dérivée dans le vocabulaire du modèle-objet, sous exactement le meme modèle, et se tait proprement sur UNSAT. **Meme modèle, meme valeur**, deux vocabulaires pour interroger la solution après coup.
+> **Ligne de contraste (a retenir)** : *le raw expose le `Model` Z3 et laisse l'utilisateur re-exprimer chaque quantite dérivée en termes du solveur* ; *le DSL fait ressortir le modèle par un callback type* - `w.Eval(x => x.S0 + d0)` lit la même dérivée dans le vocabulaire du modèle-objet, sous exactement le même modèle, et se tait proprement sur UNSAT. **Même modèle, même valeur**, deux vocabulaires pour interroger la solution après coup.
 
-**Cas d'usage** : `Solve(inspect)` est l'outil des **metriques post-solution** - quand la solution optimale (le `Cmax` de ce notebook) ne suffit pas et qu'on veut lire des grandeurs dérivées (temps morts, marges, indicateurs relationnels) sans les reifier en membres du type resultat. On bascule en raw quand on a besoin d'evaluer des **termes Z3 arbitraires** hors du schema du modèle-objet (ex. une fonction non-interpretee, un tableau).",,,,,,,,0d92846e93af5049,,,,,,,
+**Cas d'usage** : `Solve(inspect)` est l'outil des **metriques post-solution** - quand la solution optimale (le `Cmax` de ce notebook) ne suffit pas et qu'on veut lire des grandeurs dérivées (temps morts, marges, indicateurs relationnels) sans les reifier en membres du type résultat. On bascule en raw quand on a besoin d'evaluer des **termes Z3 arbitraires** hors du schema du modèle-objet (ex. une fonction non-interpretee, un tableau).",,,,,,,,8c090e8ca1553ebf,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/11_Job_Shop_Scheduling.ipynb,bae1c09f,markdown,fr,f0aae1ad1d679b44,"## Conclusion
 
 Le **Job Shop Scheduling** est un problème NP-difficile en général. Sur notre instance 3×2 :
@@ -6945,13 +6945,13 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/12_Graph_Coloring_Petersen.ipynb,fe1
 La **coloration de graphe** est un problème NP-difficile classique : étant donné un graphe, attribuer une couleur à chaque sommet de sorte que deux sommets reliés par une arête aient des couleurs différentes, en minimisant le nombre de couleurs. Ses applications sont nombreuses : planification d'examens (sommet = examen, arête = étudiant commun, couleur = créneau horaire), allocation de registres dans un compilateur, attribution de fréquences radio, etc.
 
 Ce notebook le démontre sur le **graphe de Petersen**, un graphe à 10 sommets et 15 arêtes, célèbre parce qu'il sert de contre-exemple à de nombreuses conjectures. Son nombre chromatique vaut `χ = 3` — mais une lecture naïve pourrait en suggérer davantage, et une heuristique gloutonne s'y trompe. C'est exactement le terrain où le solveur fait la différence.",,,,,,,,af22cec1e5874e2f,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/12_Graph_Coloring_Petersen.ipynb,c03d60a1,markdown,fr,a0bed3fbd4526156,"### Vue d'ensemble : du graphe à sa coloration optimale
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/12_Graph_Coloring_Petersen.ipynb,c03d60a1,markdown,fr,ac106606050c1e10,"### Vue d'ensemble : du graphe à sa coloration optimale
 
 ```mermaid
 flowchart LR
     G[""Graphe de Petersen\n(10 sommets, 15 aretes)""]
     G --> GR[""Heuristique gloutonne\nfirst-fit (ordre 0..9)""]
-    G --> Z[""Modele Z3.Linq\n1 couleur par sommet\nCi != Cj sur chaque arete""]
+    G --> Z[""Modèle Z3.Linq\n1 couleur par sommet\nCi != Cj sur chaque arete""]
     GR --> KG[""3 ou 4 couleurs\nselon l'ordre de parcours\n(aucune garantie)""]
     Z --> RL[""Recherche lineaire\nk = 1, 2, 3, ...\npremier SAT = chi(G)""]
     RL --> CHI[""chi(G) = 3\n(optimum PROUVE,\n2 couleurs = UNSAT)""]
@@ -6961,7 +6961,7 @@ flowchart LR
     style KG fill:#f7d5c5
 ```
 
-Les deux voies partent du même graphe. Le **glouton** colore les sommets dans l'ordre, sans anticiper : selon l'ordre, il trouve 3 couleurs (chanceux) ou 4 (malchanceux), **sans jamais le savoir**. Le **solveur** explore globalement l'espace des colorations, atteint `χ = 3` **et le prouve** (il démontre que 2 couleurs sont impossibles). Le payoff pédagogique : non pas « le glouton se trompe toujours », mais « le glouton ne garantit ni l'optimum ni la preuve », là où Z3 fait les deux.",,,,,,,,a0bed3fbd4526156,,,,,,,
+Les deux voies partent du même graphe. Le **glouton** colore les sommets dans l'ordre, sans anticiper : selon l'ordre, il trouve 3 couleurs (chanceux) ou 4 (malchanceux), **sans jamais le savoir**. Le **solveur** explore globalement l'espace des colorations, atteint `χ = 3` **et le prouve** (il démontre que 2 couleurs sont impossibles). Le payoff pédagogique : non pas « le glouton se trompe toujours », mais « le glouton ne garantit ni l'optimum ni la preuve », là où Z3 fait les deux.",,,,,,,,ac106606050c1e10,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/12_Graph_Coloring_Petersen.ipynb,542624c9,code,fr,36a8cf47c83a3682,"#r ""../Z3.Linq/.deploy/Microsoft.Z3.dll""
 #r ""../Z3.Linq/.deploy/ExpressionUtils.dll""
 #r ""../Z3.Linq/.deploy/Z3.Linq.dll""
@@ -7210,13 +7210,13 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/12_Graph_Coloring_Petersen.ipynb,117
 
 // Votre code ici
 Console.WriteLine(""Exercice 3 a completer"");",,,,,,,,b61c9d92f0a88a86,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/12_Graph_Coloring_Petersen.ipynb,b2-ite-intro,markdown,fr,3434d18276d0be40,"## B2 - Indicateurs conditionnels (DSL ternaire `? :` -> `MkIte`)
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/12_Graph_Coloring_Petersen.ipynb,b2-ite-intro,markdown,fr,401b4e2c1381f357,"## B2 - Indicateurs conditionnels (DSL ternaire `? :` -> `MkIte`)
 
-Ce notebook colore le graphe sous une contrainte **dure** : deux sommets adjacents ont des couleurs differentes. Mais une technique de modelisation fondamentale consiste a **reifier** une condition en un indicateur 0/1 - `condition ? 1 : 0` - pour la **compter** au lieu de l'interdire. On passe alors d'un « aucune arete n'est monochrome » (dur) a un « **au plus** k aretes monochromes » (souple), en **sommant** les indicateurs de conflit. C'est le bloc de base des penalites MaxSAT et de tout comptage de contraintes.
+Ce notebook colore le graphe sous une contrainte **dure** : deux sommets adjacents ont des couleurs différentes. Mais une technique de modelisation fondamentale consiste a **reifier** une condition en un indicateur 0/1 - `condition ? 1 : 0` - pour la **compter** au lieu de l'interdire. On passe alors d'un « aucune arete n'est monochrome » (dur) a un « **au plus** k aretes monochromes » (souple), en **sommant** les indicateurs de conflit. C'est le bloc de base des penalites MaxSAT et de tout comptage de contraintes.
 
-Cote DSL, une telle reification n'etait pas exprimable avant le binding [B2](../Z3.Linq/solutions/Z3.Linq/ExpressionVisitor.cs#L107) : un ternaire C# dans un `.Where(...)` levait `NotSupportedException` (le visiteur n'avait pas de cas `Conditional`). Le binding ajoute [`VisitConditional`](../Z3.Linq/solutions/Z3.Linq/ExpressionVisitor.cs#L212) qui traduit `cond ? a : b` en [`MkITE(test, ifTrue, ifFalse)`](../Z3.Linq/solutions/Z3.Linq/ExpressionVisitor.cs#L218) - le ternaire devient un indicateur Z3 de premiere classe.
+Cote DSL, une telle reification n'etait pas exprimable avant le binding [B2](../Z3.Linq/solutions/Z3.Linq/ExpressionVisitor.cs#L107) : un ternaire C# dans un `.Where(...)` levait `NotSupportedException` (le visiteur n'avait pas de cas `Conditional`). Le binding ajoute [`VisitConditional`](../Z3.Linq/solutions/Z3.Linq/ExpressionVisitor.cs#L212) qui traduit `cond ? a : b` en [`MkITE(test, ifTrue, ifFalse)`](../Z3.Linq/solutions/Z3.Linq/ExpressionVisitor.cs#L218) - le ternaire devient un indicateur Z3 de première classe.
 
-> **Stack : A + B - pourquoi**. On modelise un **triangle** (3 sommets tous adjacents) avec **2 couleurs seulement** : un 2-coloriage propre est **impossible** (un triangle exige 3 couleurs). Plutot que de constater l'insatisfiabilite, on **compte les conflits** : pour chaque arete `(u,v)`, l'indicateur de conflit est `cu == cv ? 1 : 0`. Cote raw, on reifie a la main chaque conflit en `MkITE(MkEq(cu,cv), MkInt(1), MkInt(0))` puis on somme via `MkAdd`. Cote DSL, la **meme** reification s'ecrit en ternaire C# naturel `(cu == cv ? 1 : 0)` dans le lambda. Le contraste : `somme <= 1` est **SAT** (un triangle bicolore a toujours au moins 1 conflit), `somme == 0` est **UNSAT** (preuve que le nombre chromatique depasse 2) - obtenu des deux cotes sur le meme modele.",,,,,,,,3434d18276d0be40,,,,,,,
+> **Stack : A + B - pourquoi**. On modelise un **triangle** (3 sommets tous adjacents) avec **2 couleurs seulement** : un 2-coloriage propre est **impossible** (un triangle exige 3 couleurs). Plutot que de constater l'insatisfiabilite, on **compte les conflits** : pour chaque arete `(u,v)`, l'indicateur de conflit est `cu == cv ? 1 : 0`. Cote raw, on reifie a la main chaque conflit en `MkITE(MkEq(cu,cv), MkInt(1), MkInt(0))` puis on somme via `MkAdd`. Cote DSL, la **même** reification s'ecrit en ternaire C# naturel `(cu == cv ? 1 : 0)` dans le lambda. Le contraste : `somme <= 1` est **SAT** (un triangle bicolore a toujours au moins 1 conflit), `somme == 0` est **UNSAT** (preuve que le nombre chromatique depasse 2) - obtenu des deux cotes sur le même modèle.",,,,,,,,401b4e2c1381f357,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/12_Graph_Coloring_Petersen.ipynb,b2-ite-code,code,fr,912a9f31ff4b7f53,"// B2 - Indicateurs conditionnels ""MkIte"" : deux stacks sur le MEME triangle sous-colore.
 //   Triangle : sommets A, B, C tous adjacents (aretes A-B, B-C, A-C). Palette : 2 couleurs {0, 1}.
 //   Un 2-coloriage PROPRE est impossible (triangle => chi = 3). On COMPTE les conflits au lieu de les interdire :
@@ -7287,9 +7287,9 @@ public class TriColor2 { public int A { get; set; }  public int B { get; set; } 
         .Solve();
     Console.WriteLine($""[DSL] conflits == 0 : {(hard == null ? ""UNSAT"" : ""SAT?!"")}   -> 2 couleurs insuffisantes, chi(triangle) = 3"");
 }",,,,,,,,912a9f31ff4b7f53,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/12_Graph_Coloring_Petersen.ipynb,b2-ite-lecture,markdown,fr,b1d1d0ceee1091da,"### Lecture B2 - deux ecritures d'un indicateur, un meme comptage
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/12_Graph_Coloring_Petersen.ipynb,b2-ite-lecture,markdown,fr,8302a7b9e0779d57,"### Lecture B2 - deux ecritures d'un indicateur, un même comptage
 
-Les deux stacks modelisent le **meme triangle sous-colore** et comptent les **memes conflits** via des indicateurs `cu == cv ? 1 : 0`. Les deux verdicts coincident : `somme <= 1` **SAT** (un triangle bicolore a au moins un conflit) et `somme == 0` **UNSAT** (donc `chi > 2`). La difference est **comment** on ecrit l'indicateur :
+Les deux stacks modelisent le **même triangle sous-colore** et comptent les **mêmes conflits** via des indicateurs `cu == cv ? 1 : 0`. Les deux verdicts coincident : `somme <= 1` **SAT** (un triangle bicolore a au moins un conflit) et `somme == 0` **UNSAT** (donc `chi > 2`). La différence est **comment** on ecrit l'indicateur :
 
 | Aspect | RAW (`MkITE`) | DSL (ternaire `? :`) |
 |---|---|---|
@@ -7298,9 +7298,9 @@ Les deux stacks modelisent le **meme triangle sous-colore** et comptent les **me
 | Somme | `MkAdd(iAB, iBC, iAC)` | `+` C# natif |
 | Avant B2 | (toujours disponible en raw) | `NotSupportedException` sur le `Conditional` |
 
-> **Ligne de contraste (a retenir)** : *le raw construit l'indicateur comme un terme Z3 explicite* (`MkITE` + cast + `MkAdd`) ; *le DSL laisse ecrire l'indicateur comme un ternaire C# ordinaire* - `(cu == cv ? 1 : 0)` - que [`VisitConditional`](../Z3.Linq/solutions/Z3.Linq/ExpressionVisitor.cs#L212) traduit en `MkITE`. **Meme comptage de conflits**, deux notations : termes Z3 d'un cote, expression C# de l'autre. L'indicateur reifie est ce qui fait passer d'un modele **dur** (interdire) a un modele **souple** (compter et borner).
+> **Ligne de contraste (a retenir)** : *le raw construit l'indicateur comme un terme Z3 explicite* (`MkITE` + cast + `MkAdd`) ; *le DSL laisse ecrire l'indicateur comme un ternaire C# ordinaire* - `(cu == cv ? 1 : 0)` - que [`VisitConditional`](../Z3.Linq/solutions/Z3.Linq/ExpressionVisitor.cs#L212) traduit en `MkITE`. **Même comptage de conflits**, deux notations : termes Z3 d'un cote, expression C# de l'autre. L'indicateur reifie est ce qui fait passer d'un modèle **dur** (interdire) a un modèle **souple** (compter et borner).
 
-**Cas d'usage** : la reification `cond ? 1 : 0` est le bloc de base des **contraintes de cardinalite** (« au plus / au moins k parmi ces conditions ») et des **penalites souples** (MaxSAT via Optimize). Dans la coloration, elle transforme le coloriage propre (dur, parfois UNSAT) en minimisation de conflits (toujours SAT). On garde le raw pour un `MkITE` dont les branches sont des **termes Z3 arbitraires** (tableaux, fonctions non-interpretees) hors du schema du modele-objet.",,,,,,,,b1d1d0ceee1091da,,,,,,,
+**Cas d'usage** : la reification `cond ? 1 : 0` est le bloc de base des **contraintes de cardinalite** (« au plus / au moins k parmi ces conditions ») et des **penalites souples** (MaxSAT via Optimize). Dans la coloration, elle transforme le coloriage propre (dur, parfois UNSAT) en minimisation de conflits (toujours SAT). On garde le raw pour un `MkITE` dont les branches sont des **termes Z3 arbitraires** (tableaux, fonctions non-interpretees) hors du schema du modèle-objet.",,,,,,,,8302a7b9e0779d57,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/12_Graph_Coloring_Petersen.ipynb,a6e72692,markdown,fr,d855ce796287d4f5,"## Conclusion
 
 Ce notebook a transposé le paradigme déclaratif de Z3.Linq à une **structure de graphe irrégulière** — un terrain différent des grilles (Sudoku) et des ordonnancements linéaires (job shop). Trois enseignements :
@@ -8226,11 +8226,11 @@ if (st4 == Status.SATISFIABLE) {
 }
 Console.WriteLine();
 Console.WriteLine(""-> MkExtract + égalité = raisonnement au niveau champ binaire (protocoles, formats)."");",,,,,,,,84becac41eb3aa45,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/15_BitVectors_Overflow.ipynb,b4-bitvecwidth-intro,markdown,fr,0d9e9a6db9c5bd2e,"## B4 - Largeur de bit-vector declarative (DSL `[BitVecWidth(n)]`)
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/15_BitVectors_Overflow.ipynb,b4-bitvecwidth-intro,markdown,fr,e6b22ed0d8cf1987,"## B4 - Largeur de bit-vector declarative (DSL `[BitVecWidth(n)]`)
 
-Tout le notebook jusqu'ici cable la sorte `BitVec` a la main (`ctx.MkBitVecSort(32)`, `MkBVAdd`, `MkBVULT`). Cote DSL, le binding Z3.Linq laisse **declarer la largeur par un attribut C#** - [`[BitVecWidth(n)]`](../Z3.Linq/solutions/Z3.Linq/BitVecWidthAttribute.cs#L21) sur une propriete entiere d'une classe ordinaire - et **route automatiquement** `+`/`-`/`*` vers les operateurs modulaires et les comparaisons vers l'ordre non signe ([`ExpressionVisitor.cs:120`](../Z3.Linq/solutions/Z3.Linq/ExpressionVisitor.cs#L120), largeur lue en [`Theorem.cs:548`](../Z3.Linq/solutions/Z3.Linq/Theorem.cs#L548)). Sans cet attribut, toute variable entiere d'un theoreme Z3.Linq est un **entier mathematique non borne** - et le debordement, coeur de ce notebook, devient **inexprimable**.
+Tout le notebook jusqu'ici cable la sorte `BitVec` a la main (`ctx.MkBitVecSort(32)`, `MkBVAdd`, `MkBVULT`). Cote DSL, le binding Z3.Linq laisse **declarer la largeur par un attribut C#** - [`[BitVecWidth(n)]`](../Z3.Linq/solutions/Z3.Linq/BitVecWidthAttribute.cs#L21) sur une propriete entiere d'une classe ordinaire - et **route automatiquement** `+`/`-`/`*` vers les opérateurs modulaires et les comparaisons vers l'ordre non signe ([`ExpressionVisitor.cs:120`](../Z3.Linq/solutions/Z3.Linq/ExpressionVisitor.cs#L120), largeur lue en [`Theorem.cs:548`](../Z3.Linq/solutions/Z3.Linq/Theorem.cs#L548)). Sans cet attribut, toute variable entiere d'un theoreme Z3.Linq est un **entier mathematique non borne** - et le debordement, coeur de ce notebook, devient **inexprimable**.
 
-> **Stack : A + B - pourquoi**. Ce bloc appartient a la famille ""theorie cachee"" (comme les reels ou les UNSAT cores) : l'attribut `[BitVecWidth(n)]` **encode une semantique** (l'arithmetique modulo 2^n) qu'aucune ligne de code n'affiche - elle vit dans le type. Le raw `MkBitVecSort + MkBVAdd + MkBVULT` **materialise** cette meme semantique en appels Z3 explicites. Le contraste rend visible ce que la largeur fixe achete : le predicat `a + b < a` (debordement) est **SAT en 4 bits** mais **UNSAT sur les entiers** - meme requete, deux theories.",,,,,,,,0d9e9a6db9c5bd2e,,,,,,,
+> **Stack : A + B - pourquoi**. Ce bloc appartient a la famille ""théorie cachee"" (comme les reels ou les UNSAT cores) : l'attribut `[BitVecWidth(n)]` **encode une sémantique** (l'arithmetique modulo 2^n) qu'aucune ligne de code n'affiche - elle vit dans le type. Le raw `MkBitVecSort + MkBVAdd + MkBVULT` **materialise** cette même sémantique en appels Z3 explicites. Le contraste rend visible ce que la largeur fixe achete : le predicat `a + b < a` (debordement) est **SAT en 4 bits** mais **UNSAT sur les entiers** - même requête, deux théories.",,,,,,,,e6b22ed0d8cf1987,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/15_BitVectors_Overflow.ipynb,b4-bitvecwidth-code,code,fr,77c7c66a10448354,"// B4 - Largeur de bit-vector declarative ""[BitVecWidth(n)]"" : deux stacks sur le MEME predicat de debordement.
 // Predicat non-trivial : ""a + b < a"" avec b >= 1
 //   - SAT   sur bit-vectors 4 bits (la somme enveloppe modulo 16, sous a)   <- theorie BitVec
@@ -8298,21 +8298,21 @@ public class PlainPair { public int A { get; set; }  public int B { get; set; } 
         ? ""[DSL]   -> UNSAT : sans largeur fixe, \"" a+b < a \"" est impossible. L'attribut EST la semantique.""
         : ""[DSL]   -> inattendu."");
 }",,,,,,,,77c7c66a10448354,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/15_BitVectors_Overflow.ipynb,b4-bitvecwidth-lecture,markdown,fr,d62ac9120cfdc3da,"### Lecture B4 - l'attribut porte la theorie
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/15_BitVectors_Overflow.ipynb,b4-bitvecwidth-lecture,markdown,fr,32da328150b8ef97,"### Lecture B4 - l'attribut porte la théorie
 
-Les deux stacks posent **le meme predicat non-trivial** - `a + b < a` avec `b >= 1` - et arrivent au **meme double verdict** : **SAT** sur 4 bits (la somme enveloppe sous `a`), **UNSAT** sur les entiers non bornes (une somme a addend positif ne decroit jamais). La difference est **ou vit la largeur** :
+Les deux stacks posent **le même predicat non-trivial** - `a + b < a` avec `b >= 1` - et arrivent au **même double verdict** : **SAT** sur 4 bits (la somme enveloppe sous `a`), **UNSAT** sur les entiers non bornes (une somme a addend positif ne decroit jamais). La différence est **ou vit la largeur** :
 
 | Aspect | RAW (`MkBitVecSort + MkBV*`) | DSL (`[BitVecWidth(n)]` + `Solve`) |
 |---|---|---|
 | Declaration de la largeur | Imperative : `MkBitVecSort(4)` a chaque variable | Declarative : attribut sur la propriete |
-| Choix des operateurs | Explicite : `MkBVAdd`, `MkBVULT` (l'utilisateur sait que c'est modulaire) | Implicite : `+` et `<` routes vers les variantes BV (ExpressionVisitor.cs:120) |
+| Choix des opérateurs | Explicite : `MkBVAdd`, `MkBVULT` (l'utilisateur sait que c'est modulaire) | Implicite : `+` et `<` routes vers les variantes BV (ExpressionVisitor.cs:120) |
 | Lisibilite du predicat | `MkBVULT(MkBVAdd(a,b), a)` | `r.A + r.B < r.A` (arithmetique C# naturelle) |
 | Risque d'erreur | Confondre `MkBVSLT` (signe) et `MkBVULT` (non signe) | Le routage non signe est fixe par le binding |
 | Sans largeur | (choix impossible a oublier) | Entier non borne : debordement inexprimable (UNSAT) |
 
-> **Ligne de contraste (a retenir)** : *le raw expose la sorte et les operateurs modulaires* (controle total : signe vs non signe, largeurs mixtes) ; *le DSL deplace la largeur dans le type* - l'attribut `[BitVecWidth(4)]` **est** la declaration que ""ces entiers sont des registres 4 bits"", et le debordement en decoule sans un seul appel Z3 ecrit a la main. **Meme theorie SMT** (`(_ BitVec 4)` dans les deux), **deux endroits ou la largeur est ecrite**.
+> **Ligne de contraste (a retenir)** : *le raw expose la sorte et les opérateurs modulaires* (contrôle total : signe vs non signe, largeurs mixtes) ; *le DSL deplace la largeur dans le type* - l'attribut `[BitVecWidth(4)]` **est** la declaration que ""ces entiers sont des registres 4 bits"", et le debordement en decoule sans un seul appel Z3 ecrit a la main. **Même théorie SMT** (`(_ BitVec 4)` dans les deux), **deux endroits ou la largeur est ecrite**.
 
-**Cas d'usage** : on prefere le DSL quand le modele a des **champs de largeur fixe naturels** (registres, octets de protocole, compteurs qui enveloppent) - la largeur devient une propriete du type, pas un parametre repete. On bascule en raw pour les **largeurs dynamiques**, l'arithmetique **signee**, ou l'`Extract`/`Concat` au niveau bit (cf section 5) que l'attribut ne couvre pas.",,,,,,,,d62ac9120cfdc3da,,,,,,,
+**Cas d'usage** : on prefere le DSL quand le modèle a des **champs de largeur fixe naturels** (registres, octets de protocole, compteurs qui enveloppent) - la largeur devient une propriete du type, pas un paramètre repete. On bascule en raw pour les **largeurs dynamiques**, l'arithmetique **signee**, ou l'`Extract`/`Concat` au niveau bit (cf section 5) que l'attribut ne couvre pas.",,,,,,,,32da328150b8ef97,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/15_BitVectors_Overflow.ipynb,87b83359,markdown,fr,30c9cca6ce1d7797,"## 6. Ce que ce notebook a démontré
 
 Le débordement arithmétique est **impossible sur les entiers non bornés** (par construction
@@ -9020,7 +9020,7 @@ IntExpr k = ctx.MkIntConst(""k"");
 // Etape 2 : solver.Check((IEnumerable<BoolExpr>)ten)
 // Etape 3 : compter solver.UnsatCore -> doit valoir 3 (les 3 k==n incompatibles)
 Console.WriteLine(""Exercice 3 à compléter."");",,,,,,,,eb45cac2007ea4d9,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/18_Einsteins_Riddle.ipynb,dc7a6d82,markdown,fr,9f1bdc8c717deb8f,"<- [17 - Unsat Cores](17_UnsatCores.ipynb) | [README Z3](README.md)
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/18_Einsteins_Riddle.ipynb,dc7a6d82,markdown,fr,7b2225df598993e0,"<- [17 - Unsat Cores](17_UnsatCores.ipynb) | [README Z3](README.md)
 
 ---
 
@@ -9030,7 +9030,7 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/18_Einsteins_Riddle.ipynb,dc7a6d82,m
 
 ## Objectifs d'apprentissage
 
-- Modeliser une **enigme logique a attributs croises** (le *Zebra puzzle*, dite ""enigme d'Einstein"") comme un probleme de satisfaction de contraintes sur des entiers
+- Modeliser une **enigme logique a attributs croises** (le *Zebra puzzle*, dite ""enigme d'Einstein"") comme un problème de satisfaction de contraintes sur des entiers
 - Maitriser l'**encodage par position** : pour chaque couple (attribut, valeur), une variable entiere encode la maison (0..4) ou cette valeur apparait
 - Traduire des indices **relationnels** (identite, ""a gauche de"", ""voisin de"") en contraintes lineaires et en disjonctions
 - Comprendre pourquoi un puzzle qu'un humain resout en une trentaine de minutes de deduction tombe en quelques millisecondes pour Z3
@@ -9044,9 +9044,9 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/18_Einsteins_Riddle.ipynb,dc7a6d82,m
 
 ---
 
-L'**enigme d'Einstein** (ou *Zebra puzzle*) est un probleme de logique attribue - probablement a tort - a Albert Einstein. Cinq maisons alignees, cinq nationalites, cinq couleurs, cinq boissons, cinq cigarettes, cinq animaux. A partir de quinze indices, determiner la disposition complete et, surtout : **a qui appartient le poisson ?**
+L'**enigme d'Einstein** (ou *Zebra puzzle*) est un problème de logique attribue - probablement a tort - a Albert Einstein. Cinq maisons alignees, cinq nationalites, cinq couleurs, cinq boissons, cinq cigarettes, cinq animaux. A partir de quinze indices, determiner la disposition complete et, surtout : **a qui appartient le poisson ?**
 
-L'espace de recherche est colossal : 5 attributs x 5! permutations chacun = (120)^5 de l'ordre de **2,5 milliards** de combinaisons. La resolution humaine procede par deduction pas-a-pas (remplir un tableau en propageant les indices). C'est le terrain ideal pour montrer comment un solveur SMT **propage globalement** des contraintes entrelacees plutot que d'enumerer.",,,,,,,,9f1bdc8c717deb8f,,,,,,,
+L'espace de recherche est colossal : 5 attributs x 5! permutations chacun = (120)^5 de l'ordre de **2,5 milliards** de combinaisons. La resolution humaine procede par deduction pas-a-pas (remplir un tableau en propageant les indices). C'est le terrain ideal pour montrer comment un solveur SMT **propage globalement** des contraintes entrelacees plutot que d'enumerer.",,,,,,,,7b2225df598993e0,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/18_Einsteins_Riddle.ipynb,4fd7735c,code,fr,36a8cf47c83a3682,"#r ""../Z3.Linq/.deploy/Microsoft.Z3.dll""
 #r ""../Z3.Linq/.deploy/ExpressionUtils.dll""
 #r ""../Z3.Linq/.deploy/Z3.Linq.dll""
@@ -9057,9 +9057,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 Console.WriteLine(""Imports OK : Z3.Linq (.deploy), Microsoft.Z3, System.Linq"");",,,,,,,,36a8cf47c83a3682,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/18_Einsteins_Riddle.ipynb,f5973ca6,markdown,fr,d416b56309afa745,"## Modelisation : l'encodage par position
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/18_Einsteins_Riddle.ipynb,f5973ca6,markdown,fr,4cee57afb6195e03,"## Modelisation : l'encodage par position
 
-L'astuce centrale consiste a **inverser le point de vue**. Au lieu de demander ""quelle couleur a la maison *k* ?"", on definit pour chaque valeur d'attribut une variable entiere egale a la **position** (numero de maison 0..4) ou elle se trouve :
+L'astuce centrale consiste a **inverser le point de vue**. Au lieu de demander ""quelle couleur a la maison *k* ?"", on définit pour chaque valeur d'attribut une variable entiere egale a la **position** (numéro de maison 0..4) ou elle se trouve :
 
 - `Brit`, `Swede`, `Dane`, `Norwegian`, `German` : position de chaque nationalite
 - `Red`, `Green`, `White`, `Yellow`, `Blue` : position de chaque couleur
@@ -9070,10 +9070,10 @@ L'astuce centrale consiste a **inverser le point de vue**. Au lieu de demander "
 Soit **25 variables entieres**, chacune dans `{0, 1, 2, 3, 4}`. Trois familles de contraintes :
 
 1. **Domaine** : chaque variable est dans `{0..4}` (une position valide).
-2. **Permutation** : au sein de chaque attribut, les 5 valeurs occupent des positions **deux a deux distinctes** (contrainte globale `Z3Methods.Distinct`) - chaque nationalite est dans une maison differente.
+2. **Permutation** : au sein de chaque attribut, les 5 valeurs occupent des positions **deux a deux distinctes** (contrainte globale `Z3Methods.Distinct`) - chaque nationalite est dans une maison différente.
 3. **Les 15 indices** : des **egalites de position** (""le Britannique vit dans la maison rouge"" se code `Brit == Red`), des **decalages** (""la verte est juste a gauche de la blanche"" se code `Green == White - 1`), et des **adjacences** (""voisin de"" se code `|X - Y| == 1`, c'est-a-dire la disjonction `(X - Y == 1) || (Y - X == 1)`).
 
-Cet encodage transforme un puzzle de logique en un CSP sur les entiers : tous les indices deviennent des contraintes lineaires ou des disjonctions que le solveur propage.",,,,,,,,d416b56309afa745,,,,,,,
+Cet encodage transforme un puzzle de logique en un CSP sur les entiers : tous les indices deviennent des contraintes lineaires ou des disjonctions que le solveur propage.",,,,,,,,4cee57afb6195e03,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/18_Einsteins_Riddle.ipynb,fd901199,code,fr,7aa9d4a1071cc677,"// L'enigme d'Einstein : 5 maisons, 5 attributs, 15 indices.
 // Encodage par position : chaque champ = numero de maison (0..4) ou la valeur apparait.
 public class Einstein
@@ -9147,7 +9147,7 @@ using (var ctx = new Z3Context())
         Console.WriteLine($"">>> Reponse : le {Val(nat, sol.Fish)} possede le Poisson (maison {sol.Fish+1})."");
     }
 }",,,,,,,,7aa9d4a1071cc677,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/18_Einsteins_Riddle.ipynb,b25f2858,markdown,fr,c4e8cf0e1b7de647,"## Interpretation
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/18_Einsteins_Riddle.ipynb,b25f2858,markdown,fr,8a744ffcf2a2e44f,"## Interpretation
 
 Z3 trouve la solution unique en quelques millisecondes :
 
@@ -9159,17 +9159,17 @@ Z3 trouve la solution unique en quelques millisecondes :
 
 **Reponse : c'est l'Allemand qui possede le poisson.**
 
-**Pourquoi le solveur fait la difference** (Prong-B) : la resolution humaine procede par deduction progressive - on place le Norvegien en 1 (`Norwegian == 0`), le lait en 3 (`Milk == 2`), on deduit la bleue en 2 (voisin du Norvegien), puis on enchaine les croisements. C'est fastidieux et erreur-prone. Le solveur, lui, **propage simultanement** les 15 indices : `Norwegian == 0` et `Milk == 2` fixent deux ancres, puis les egalites de position (`Brit == Red`, `German == Prince`...) et les adjacences reduisent les domaines en cascade jusqu'a la solution unique. Aucune enumeration des 2,5 milliards de combinaisons.
+**Pourquoi le solveur fait la différence** (Prong-B) : la resolution humaine procede par deduction progressive - on place le Norvegien en 1 (`Norwegian == 0`), le lait en 3 (`Milk == 2`), on deduit la bleue en 2 (voisin du Norvegien), puis on enchaine les croisements. C'est fastidieux et erreur-prone. Le solveur, lui, **propage simultanement** les 15 indices : `Norwegian == 0` et `Milk == 2` fixent deux ancres, puis les egalites de position (`Brit == Red`, `German == Prince`...) et les adjacences reduisent les domaines en cascade jusqu'a la solution unique. Aucune enumeration des 2,5 milliards de combinaisons.
 
-C'est aussi un exemple ou l'**encodage** est decisif : traduire ""voisin de"" en `|X - Y| == 1` (une disjonction lineaire) rend l'adjacence directement exploitable par le solveur, la ou une enumeration devrait tester chaque paire de positions.",,,,,,,,c4e8cf0e1b7de647,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/18_Einsteins_Riddle.ipynb,9e5313fd,markdown,fr,e2897b0c632ec7b4,"## Approche nave vs solveur : mesurer l'ecart
+C'est aussi un exemple ou l'**encodage** est decisif : traduire ""voisin de"" en `|X - Y| == 1` (une disjonction lineaire) rend l'adjacence directement exploitable par le solveur, la ou une enumeration devrait tester chaque paire de positions.",,,,,,,,8a744ffcf2a2e44f,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/18_Einsteins_Riddle.ipynb,9e5313fd,markdown,fr,ea4d053c6fb7bc54,"## Approche nave vs solveur : mesurer l'ecart
 
 Pour **mesurer** l'ecart (plutot que l'affirmer), comparons la taille de l'espace de recherche a ce que fait Z3 :
 
 - **Brute force** : enumerer toutes les permutations de chaque attribut, soit `(5!)^5 = 120^5 = 24 883 200 000` combinaisons, puis tester les 15 indices pour chacune. A raison de ~100 millions de tests par seconde en C# natif, cela represente de l'ordre de **4 minutes** de calcul - et le test des 15 indices rend chaque candidat nettement plus lent en pratique.
 - **Z3** : formuler les 25 variables + domaine + 5 `Distinct` + 15 indices, et laisser le solveur propager. La propagation fixe `Norwegian = 0` et `Milk = 2` sans aucun essai, puis reduit les domaines jusqu'a la solution unique.
 
-Mesurons egalement si la solution est **unique** : ajoutons une contrainte niant la solution trouvee (au moins un attribut different) et re-solvons. Si Z3 repond UNSAT, la solution est prouvee unique.",,,,,,,,e2897b0c632ec7b4,,,,,,,
+Mesurons également si la solution est **unique** : ajoutons une contrainte niant la solution trouvee (au moins un attribut différent) et re-solvons. Si Z3 repond UNSAT, la solution est prouvee unique.",,,,,,,,ea4d053c6fb7bc54,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/18_Einsteins_Riddle.ipynb,8e1ce164,code,fr,0fbdd6e0b16205c1,"using System.Diagnostics;
 
 // (1) Z3 resout l'enigme complete - mesure du temps
@@ -9244,39 +9244,39 @@ Console.WriteLine($""Z3 solve temps                 : {sw.Elapsed.TotalMilliseco
 Console.WriteLine($""Solution trouvee               : {(sol != null ? ""OUI"" : ""NON"")}"");
 Console.WriteLine($""Solution unique (UNSAT si nie) : {unique}"");
 Console.WriteLine($"" -> Z3 resout en millisecondes un espace de 2,5 milliards, et prouve l'unicite sans enumeration."");",,,,,,,,0fbdd6e0b16205c1,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/18_Einsteins_Riddle.ipynb,fb8fa6c4,markdown,fr,fbd9d5f8ed279333,"## Lecture du benchmark
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/18_Einsteins_Riddle.ipynb,fb8fa6c4,markdown,fr,5942b158660dad14,"## Lecture du benchmark
 
-Sur cette enigme, l'ecart est **frappant** et non plus de ""meme ordre de grandeur"" comme sur le cryptarithme a 8 lettres :
+Sur cette enigme, l'ecart est **frappant** et non plus de ""même ordre de grandeur"" comme sur le cryptarithme a 8 lettres :
 
-- Z3 resout les **25 variables entrelacees** en quelques **millisecondes**, alors que la brute force doit affronter **2,5 milliards** de combinaisons (soit plusieurs minutes meme a cadence elevee, et bien plus avec le test des 15 indices a chaque candidat).
+- Z3 resout les **25 variables entrelacees** en quelques **millisecondes**, alors que la brute force doit affronter **2,5 milliards** de combinaisons (soit plusieurs minutes même a cadence elevee, et bien plus avec le test des 15 indices a chaque candidat).
 - La **propagation** fait tout le travail : `Norwegian == 0` et `Milk == 2` sont des ancres imposees par les indices 9 et 8, puis les egalites de position et les adjacences reduisent les domaines en cascade. Aucune enumeration.
 - La **preuve d'unicite** est obtenue gratuitement : il suffit d'ajouter une contrainte niant la solution trouvee, et Z3 repond UNSAT en un nouvel appel - ce qui serait, en brute force, une nouvelle exploration complete de l'espace.
 
-C'est l'illustration la plus nette du **Prong-B** : un probleme ou le moteur SMT exerce pleinement sa capacite distinctive - **reduire un espace combinatoire gigantesque par propagation de contraintes globales**, plutot que l'enumerer. La regression (un simple `if` ou une table de hachage) ne peut pas resoudre ce probleme ; le solveur SMT, si.",,,,,,,,fbd9d5f8ed279333,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/18_Einsteins_Riddle.ipynb,92525bdb,markdown,fr,403d9e9f9eac35b6,"## Exercices
+C'est l'illustration la plus nette du **Prong-B** : un problème ou le moteur SMT exerce pleinement sa capacite distinctive - **reduire un espace combinatoire gigantesque par propagation de contraintes globales**, plutot que l'enumerer. La regression (un simple `if` ou une table de hachage) ne peut pas resoudre ce problème ; le solveur SMT, si.",,,,,,,,5942b158660dad14,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/18_Einsteins_Riddle.ipynb,92525bdb,markdown,fr,aea5e1c1411644ff,"## Exercices
 
-Les trois exercices ci-dessous vous font reutiliser l'encodage par position. Chaque exercice suit le meme squelette : redefinir le theoreme, ajuster les contraintes, puis `Solve()`.
+Les trois exercices ci-dessous vous font reutiliser l'encodage par position. Chaque exercice suit le même squelette : redefinir le theoreme, ajuster les contraintes, puis `Solve()`.
 
-**Rappel C.1** : les stubs ne levent **jamais** d'erreur - ils utilisent `Console.WriteLine(""Exercice a completer"")`. Le notebook s'execute de bout en bout meme exercices non resolus.",,,,,,,,403d9e9f9eac35b6,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/18_Einsteins_Riddle.ipynb,4c7d538c,markdown,fr,f2b259ccf81f3731,"### Exercice 1 - Une 16e contrainte : le Chat boit de l'Eau
+**Rappel C.1** : les stubs ne levent **jamais** d'erreur - ils utilisent `Console.WriteLine(""Exercice a completer"")`. Le notebook s'execute de bout en bout même exercices non resolus.",,,,,,,,aea5e1c1411644ff,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/18_Einsteins_Riddle.ipynb,4c7d538c,markdown,fr,632ce0d4ec52d83b,"### Exercice 1 - Une 16e contrainte : le Chat boit de l'Eau
 
 Ajoutez l'indice supplementaire ""le proprietaire du chat boit de l'eau"" (soit `Cat == Water`) **en plus** des 15 indices existants. Le puzzle reste-t-il satisfiable ? Si non, que prouve Z3 ?
 
-**Etapes** :
+**Étapes** :
 1. Reprenez le theoreme de la cellule 3 avec les 15 indices.
 2. Ajoutez une 16e contrainte `.Where(t => t.Cat == t.Water)`.
-3. Appelez `Solve()` et observez le resultat (solution ou `null`).",,,,,,,,f2b259ccf81f3731,,,,,,,
+3. Appelez `Solve()` et observez le résultat (solution ou `null`).",,,,,,,,632ce0d4ec52d83b,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/18_Einsteins_Riddle.ipynb,75b650be,code,fr,214a0e2cc1293fc1,"// Exercice 1 : ajouter l'indice ""le Chat boit de l'Eau"" (Cat == Water)
 // TODO etudiant :
 // Etape 1 : reprendre le theoreme Einstein (domaine + 5 Distinct + 15 indices)
 // Etape 2 : ajouter .Where(t => t.Cat == t.Water)
 // Etape 3 : Solve() -> la solution reste-t-elle SAT, ou devient-elle UNSAT ?
 Console.WriteLine(""Exercice 1 a completer : ajoutez l'indice Cat == Water et testez la satisfiabilite"");",,,,,,,,214a0e2cc1293fc1,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/18_Einsteins_Riddle.ipynb,1e73780f,markdown,fr,a92aa5d5ae9d6875,"### Exercice 2 - Qui boit de l'Eau ? Qui eleve le Poisson ?
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/18_Einsteins_Riddle.ipynb,1e73780f,markdown,fr,4ea43402e15ec88a,"### Exercice 2 - Qui boit de l'Eau ? Qui eleve le Poisson ?
 
-La cellule 6 demontre l'unicite en niant la solution sur 5 attributs. Generalisez : ecrivez une boucle qui, apres avoir trouve la solution, **enumere toutes les solutions** (methode du blocage iteratif - bloquer la solution trouvee, re-solve, jusqu'a UNSAT) et affiche combien il y en a.
+La cellule 6 demontre l'unicite en niant la solution sur 5 attributs. Generalisez : ecrivez une boucle qui, après avoir trouve la solution, **enumere toutes les solutions** (méthode du blocage iteratif - bloquer la solution trouvee, re-solve, jusqu'a UNSAT) et affiche combien il y en a.
 
-**Indice** : a chaque iteration, ajoutez une contrainte ""au moins un attribut != solution courante"" et re-solvez. Comptez les iterations. Vous devez trouver **1** (solution unique).",,,,,,,,a92aa5d5ae9d6875,,,,,,,
+**Indice** : a chaque itération, ajoutez une contrainte ""au moins un attribut != solution courante"" et re-solvez. Comptez les itérations. Vous devez trouver **1** (solution unique).",,,,,,,,4ea43402e15ec88a,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/18_Einsteins_Riddle.ipynb,d9cb000f,code,fr,770d3dbbb33b21e0,"// Exercice 2 : enumerer toutes les solutions de l'enigme (boucle de blocage iteratif)
 // TODO etudiant :
 // 1. Solve() -> si sol != null, compter++, ajouter contrainte (au moins un attribut != sol)
@@ -9295,7 +9295,7 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/18_Einsteins_Riddle.ipynb,9991065a,c
 // 3. 8 indices (identites + adjacences) de votre choix
 // 4. Solve() -> solution unique ?
 Console.WriteLine(""Exercice 3 a completer : modelisez un mini-Zebra a 4 maisons / 4 attributs"");",,,,,,,,67c68c83403ddae3,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/18_Einsteins_Riddle.ipynb,d8661373,markdown,fr,9a2457047f9d97f9,"## Conclusion
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/18_Einsteins_Riddle.ipynb,d8661373,markdown,fr,5a070ee99cf589bf,"## Conclusion
 
 L'**enigme d'Einstein** est le terrain le plus complet pour apprehender la modelisation d'un **puzzle de logique** comme un CSP :
 
@@ -9306,6 +9306,6 @@ L'**enigme d'Einstein** est le terrain le plus complet pour apprehender la model
 **Points cles** :
 - Un puzzle qu'un humain resout en une trentaine de minutes tombe en **millisecondes** : la propagation globale ecrase la deduction pas-a-pas.
 - L'**encodage** est decisif : ""voisin de"" devient `|X - Y| == 1`, une disjonction lineaire directement exploitable.
-- Le meme schema (domaine + `Distinct` + egalites/adjacences) s'adapte a **tout puzzle de logique a attributs croises**, quelle que soit sa taille.
+- Le même schema (domaine + `Distinct` + egalites/adjacences) s'adapte a **tout puzzle de logique a attributs croises**, quelle que soit sa taille.
 
-**Reference** : le *Zebra puzzle* publie par Michael K. Albert et [popularise par Life International (1962)](https://en.wikipedia.org/wiki/Zebra_Puzzle). L'attribution a Einstein est une legende urbaine - le puzzle est vraisemblablement de la presse americaine des annees 1960.",,,,,,,,9a2457047f9d97f9,,,,,,,
+**Reference** : le *Zebra puzzle* publie par Michael K. Albert et [popularise par Life International (1962)](https://en.wikipedia.org/wiki/Zebra_Puzzle). L'attribution a Einstein est une legende urbaine - le puzzle est vraisemblablement de la presse americaine des annees 1960.",,,,,,,,5a070ee99cf589bf,,,,,,,


### PR DESCRIPTION
## SMT family translation drift resync (T2 vein, EPIC #4957)

Post-accent-campaign #7272/#7273/#7277/#7267 (~15000 cures repo-wide) made notebook sources accented while the CSV `text_fr` stayed ASCII pre-campaign → mass SRC_DRIFT. This PR resyncs the **SymbolicAI/SMT** family.

### Changes
- `translations/smt/z3-api.csv`: **221 rows refreshed** (24 Z3-Python notebooks, .NET C# + Python twins)
- `translations/smt/z3-linq2z3.csv`: **79 rows refreshed** (18 Linq2Z3 notebooks)
- **Total: 300 drift → 0**

### Method (deterministic, source-only, no-collision)
```
python scripts/translation/extract_cells_to_csv.py <notebooks> --update translations/smt/<csv>
```
`--update` refreshes pivot fields (`src_hash`, `text_fr`, `hash_fr`, `src_lang`, `cell_type`) for input notebooks only, preserves other-notebook rows + target translation columns.

### Verification
| Check | Result |
|-------|--------|
| `check_translation_sync.py` post-resync | **0 anomalies** both CSVs (was 300) |
| Row counts vs `origin/main` | **541 + 525 SAME** (0 added / 0 orphan) |
| Diff scope | pivot fields only (`src_hash`, `text_fr`); 7 target cols untouched |
| Target translations | T3 not yet run on SMT (all empty) → 0 risk of loss |
| `COURSE_CATALOG.generated.*` | byte-identical to main |

### Scope
Single family (SymbolicAI/SMT), 2 CSVs, one subject. Continues the T2 drift-resync vein (#7317 casestudies / #7319 audio / #7320 semanticweb / #7321 search-applications).

See #4957

🤖 Generated with [Claude Code](https://claude.com/claude-code)