### PR TITLE
fix(myia-shared,#7265): make broken csproj skeleton compile (net9.0 + drop stale HintPaths)

### DIFF
--- a/MyIA.AI.Shared/MyIA.AI.Shared.csproj
+++ b/MyIA.AI.Shared/MyIA.AI.Shared.csproj
@@ -1,7 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <!-- MyIA.AI.Shared — socle partage .NET pour la pompe patrimoine Aricie (#7265).
+       Skeleton initial (506f7ae93, 02/07/2026) net6.0 + HintPaths vers DLLs externes
+       Aricie (external/AIMA/aima-core.dll, external/IKVM/IKVM.OpenJDK.Core.dll) qui ne
+       sont PAS dans ce repo (0 .cs dans le projet, HintPaths casses => ne compilait pas).
+       Fix : alignement net9.0 (convention repo, cf GradeBookApp/MyIA.AI.Notebooks) +
+       HintPaths casses deplaces en commentaire (ils ciblent du patrimoine a recuperer
+       via #7265 B1-AIMA / IKVM Java-bridge, pas des refs vivantes). Les modules A-E
+       ameneront leurs propres refs quand ils atterrissent (cf #7265 ordre A->E).
+       PackageReferences Flee 2.0.0 + Newtonsoft.Json 13.0.3 = NuGet vivants, conserves. -->
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>MyIA.AI</RootNamespace>
@@ -12,13 +21,12 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Reference Include="aima-core">
-      <HintPath>..\external\AIMA\aima-core.dll</HintPath>
-    </Reference>
-    <Reference Include="IKVM.OpenJDK.Core">
-      <HintPath>..\external\IKVM\IKVM.OpenJDK.Core.dll</HintPath>
-    </Reference>
-  </ItemGroup>
+  <!-- References externes patrimoine Aricie (a recuperer via #7265) :
+       <Reference Include="aima-core">
+         <HintPath>..\external\AIMA\aima-core.dll</HintPath>
+       </Reference>
+       <Reference Include="IKVM.OpenJDK.Core">
+         <HintPath>..\external\IKVM\IKVM.OpenJDK.Core.dll</HintPath>
+       </Reference> -->
 
 </Project>


### PR DESCRIPTION
## Summary

Répare le squelette `.csproj` cassé qui sert de fondation .NET à l'Epic patrimoine Aricie #7265 (`MyIA.AI.Shared/`). Le skeleton initial (`506f7ae93`, 02/07/2026) **ne compilait pas par construction** — empêchant toute tâche de récupération A-E de l'Epic de démarrer sur une base saine.

Pivot substance non-Lean (R6 monotony exit) : grain .NET borné, non-R6-capped, non-bloqué. `[CLAIMED]` sur dashboard workspace avant exécution.

## Défaut (firsthand G.1)

`MyIA.AI.Shared/MyIA.AI.Shared.csproj` :

| Défaut | Diagnostic firsthand |
|--------|---------------------|
| `<TargetFramework>net6.0</TargetFramework>` | Stale — convention repo = **net9.0** (5 csproj vérifiés : GradeBookApp, GradeBookApp.Tests, MyIA.AI.Notebooks, 2 DatasetUpdater) |
| `<Reference HintPath>..\external\AIMA\aima-core.dll</Reference>` | **ABSENT** du repo (`git cat-file -e origin/main:external/AIMA/aima-core.dll` = does not exist) |
| `<Reference HintPath>..\external\IKVM\IKVM.OpenJDK.Core.dll</Reference>` | **ABSENT** du repo (idem) |
| 0 fichier `.cs` dans le projet | Les HintPaths ne résolvent rien → restore/compile FAIL par construction |

Avec 0 `.cs` et 2 HintPaths cassés, `dotnet build` ne pouvait pas réussir — la fondation n'existait pas fonctionnellement.

## Fix (foundation repair sûr, présume rien de l'architecture)

1. **net6.0 → net9.0** : aligne la convention repo.
2. **HintPaths cassés déplacés en commentaire XML** documentant qu'ils ciblent du patrimoine à récupérer via #7265 (B1 AIMA via IKVM Java-bridge) — **pas de suppression silencieuse de l'intention**. Les modules A-E amèneront leurs propres refs quand ils atterrissent.
3. **PackageReferences NuGet vivants conservés** (Flee 2.0.0, Newtonsoft.Json 13.0.3) — ils résolvent proprement.

## Validation REELLE (firsthand, règle F + H.1/H.4 — pas de claim sans build)

Worktree frais `CoursIA-shared-csproj` off `origin/main` `11d3971ee` :

```
$ dotnet build MyIA.AI.Shared.csproj -c Release
  Restauration effectuée de ... MyIA.AI.Shared.csproj (en 512 ms).
  MyIA.AI.Shared -> .../bin/Release/net9.0/MyIA.AI.Shared.dll
La génération a réussi.
    0 Avertissement(s)
    0 Erreur(s)
Temps écoulé 00:00:04.77
```

NuGet restore OK, `MyIA.AI.Shared.dll` générée, 0 HintPath cassé.

## Hygiène

- Three-dot diff vs `origin/main` = **1 fichier**, +14/−2 (+17/−9 avec le commentaire).
- **Catalogue byte-identique** (HARD 1 catalog-pr-hygiene) : `COURSE_CATALOG.generated.{json,md}` non touché.
- **0 CRLF** (sensible `.csproj`).
- Base clean (lesson c.505) : `git diff origin/main...HEAD --stat` vide avant édition, worktree off `origin/main` frais.

## Scope

Réparation de fondation uniquement — **n'ajoute/récupère aucun module Aricie** (ce sont les tâches A-E de l'Epic, owner ai-01/user per #7265 « grignotage opportuniste au fil de l'eau »). Rend simplement la fondation saine pour que la pompe puisse démarrer.

See #7265 (Epic patrimoine Aricie — backbone index), #4363 (contexte mutualisation — `MyIA.AI.Shared` créé pendant la migration SK console-app).

Co-Authored-By: Claude <noreply@anthropic.com>
