### PR TITLE
fix(notebook-lint,#3801): 1/0 pattern false-positives on decimals + reward-list (twin of #7324)

### DIFF
--- a/scripts/notebook_tools/notebook_lint.py
+++ b/scripts/notebook_tools/notebook_lint.py
@@ -48,7 +48,12 @@ EXCLUDE_PEDAGOGICAL = {"research", "archive", "_output", "partner-course", "exam
 C1_PATTERNS = [
     (r"raise\s+NotImplementedError", "raise NotImplementedError"),
     (r"assert\s+False", "assert False"),
-    (r"(?<!\d)1\s*/\s*0(?!\d)", "1/0"),
+    # Lookbehind/lookahead exclude digit, slash (reward-list delimiters like
+    # `1/0/0` for win/loss/draw), hyphen (`+1/-1/0`), AND the decimal point
+    # (`1/0.5`, `1/0.25`, `0.1/0.5` are rate/scale constants, not
+    # ZeroDivisionError). Harmonised with audit_c1_c3.py (cf PR fix for ICT-7
+    # `echelle caracteristique 1/0.5` FP).
+    (r"(?<![\d/\-])1\s*/\s*0(?![\d/.])", "1/0"),
     (r"throw\s+new\s+(?:System\.)?NotImplementedException\b", "throw new NotImplementedException (C#)"),
 ]
 

--- a/scripts/notebook_tools/tests/test_notebook_lint.py
+++ b/scripts/notebook_tools/tests/test_notebook_lint.py
@@ -161,6 +161,23 @@ class TestScanC1Source:
         hits = scan_c1_source("ratio = 10/0.5")
         assert hits == []
 
+    def test_decimal_fraction_not_flagged(self):
+        """Decimal fractions 1/0.5, 1/0.25, 0.1/0.5 are rate/scale constants,
+        not ZeroDivisionError. Regression for the auditor over-matching `1/0`
+        inside `1/0.5` (cf FP on ICT-7 `echelle caracteristique 1/0.5`).
+        The prior test_fraction_not_flagged (10/0.5) passed by accident — the
+        `1` in `10` is not immediately followed by `/` — so it did not cover
+        the real `1/0.5` FP."""
+        for src in ("echelle = 1/0.5", "r = 1/0.25", "0.1/0.5"):
+            assert scan_c1_source(src) == [], f"decimal FP on: {src}"
+
+    def test_reward_list_not_flagged(self):
+        """Reward-notation slash-lists (win/loss/draw) like 1/0/0 are
+        delimiters, not division. Prior regex over-matched these."""
+        assert scan_c1_source("1/0/0") == []
+        assert scan_c1_source("+1/-1/0") == []
+        assert scan_c1_source("1/-1/0 pour victoire J1/J2/nul") == []
+
     def test_fraction_21_not_flagged(self):
         """21/0 should not be flagged (digit before 1/0)."""
         hits = scan_c1_source("val = 21/0")


### PR DESCRIPTION
## Summary

Corrige un **double false-positive de l'autre validateur C.1** (`notebook_lint.py`, l'outil de validation notebook standalone, **distinct** de l'auditeur `audit_c1_c3.py`) : le pattern `1/0` (ZeroDivisionError) matchait à l'intérieur des fractions décimales (`1/0.5`, `1/0.25`, `0.1/0.5`) ET des listes de récompense slash-délimitées (`1/0/0` win/loss/draw). **Twin du fix audit_c1_c3.py (#7324)** : même classe de FP, deux validateurs indépendants, harmonisés sur une seule regex correcte.

## Défaut (firsthand G.1)

`scripts/notebook_tools/notebook_lint.py` — validateur C.1/C.2/structure/metadata standalone (outil dev manuel, PAS en CI/pre-commit) :

```python
C1_PATTERNS[2]: (r"(?<!\d)1\s*/\s*0(?!\d)", "1/0")
                 lookbehind/lookahead = digit ONLY
```

Contrairement à `audit_c1_c3.py` qui exclut déjà digit+slash+hyphen en lookahead, `notebook_lint.py` n'excluait que `\d`. Conséquences :

- **Decimal FP** : `1/0` dans `1/0.5` matche = fausse violation C.1 (même classe que #7324).
- **Reward-list FP (PIRE qu'audit_c1_c3.py)** : `1/0/0` (win/loss/draw), `+1/-1/0` FALSE-MATCH — `audit_c1_c3.py` exclut déjà ces TNs via `/` dans son lookahead, `notebook_lint.py` ne le faisait pas.

**Impact réel** : le decimal FP reproduit firsthand sur `IIT/ICT-Series/ICT-7-ScaleFreeSignatures.ipynb` cell4 (`sf.sample_exponential(0.5, 1.0, 4000, rng)  # echelle caracteristique 1/0.5`) — `scan_c1_source` renvoie un hit spurieux. Sans ce fix, un futur run de lint (par un worker ou ai-01) re-surface la même investigation gaspillée, voire un faux CHANGES_REQUESTED.

**Le test existant `test_fraction_not_flagged` passait par ACCIDENT** : il teste `10/0.5`, mais le `1` dans `10` n'est pas immédiatement suivi de `/` (un `0` s'intercale), donc la regex ne voit jamais de candidat `1/0`. Le vrai FP `1/0.5` n'était pas couvert.

## Fix (regex harmonisée sur audit_c1_c3.py)

```python
# AVANT:
(r"(?<!\d)1\s*/\s*0(?!\d)", "1/0"),
# APRÈS:
(r"(?<![\d/\-])1\s*/\s*0(?![\d/.])", "1/0"),
```

Byte-identique à `C1_PATTERNS[2]` de `audit_c1_c3.py` (post-#7324). Lookbehind : garde digit + ajoute slash + hyphen. Lookahead : garde digit + slash + ajoute le point décimal. Les deux validateurs partagent maintenant une seule regex correcte au lieu de deux incohérentes.

### ★ G.9 self-catch pendant la validation

Une première tentative « minimale » qui retirait `/` du lookahead a **reintroduit une régression** sur `1/0/0` (TN slash-delimiter correctement non-matché avant, faussement matché après). Le fix correct garde `/` ET ajoute `.` — validé contre tous les TNs existants. Même piège qu'en #7324.

## Validation REELLE (firsthand, règle F + H.1)

Worktree frais `CoursIA-lint-fp` off `origin/main` `11d3971ee`. End-to-end + suite complète :

```
$ python -m pytest tests/test_notebook_lint.py -q
============================== 71 passed in 0.15s ==============================
```
(was 69, +2 regression test methods ; tous les tests existants passent)

End-to-end : `scan_c1_source(ICT-7 cell4)` -> `[]` (FP éliminé).

| Classe | Cases testés | Verdict |
|--------|-------|---------|
| Real TPs (doivent matcher) | `1/0`, `1 / 0` | ✓ matchés |
| Decimal FPs (maintenant droppés) | `1/0.5`, `1/0.25`, `0.1/0.5` | ✓ 0 match |
| Slash/digit TNs (inchangés) | `1/0/0`, `+1/-1/0`, `1/-1/0 pour victoire J1/J2/nul`, `x = 1/2` | ✓ 0 match |

## Hygiène

- Three-dot diff vs `origin/main` = **2 fichiers**, +23/−1 (`notebook_lint.py` +7/−1, `test_notebook_lint.py` +17).
- **Catalogue byte-identique** (HARD 1) : non touché.
- **0 CRLF** (sensible `.py`).
- Worktree frais off `origin/main` (lesson c.505 respectée).

## Scope

1 source file (regex + commentaire) + 1 test file (2 regression test methods). Fix de correction d'outil — twin du `audit_c1_c3.py` fix (#7324), harmonise les deux validateurs C.1 sur une seule regex correcte. Non-Lean, non-R6-capped, non-gated.

See #3801 (SOTA axe-2 tooling / validation), #5261 (C-family comment-awareness context pour ces C.1 patterns), #7324 (le twin fix audit_c1_c3.py), C.1 ([notebook-conventions.md](../../.claude/rules/notebook-conventions.md) — la règle que ce validateur enforce).

Co-Authored-By: Claude <noreply@anthropic.com>
