### PR TITLE
feat(smartcontracts,#2161): add 2 exercises to SC-2-Setup-Web3py (1/3 -> 3/3)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/SC-2-Setup-Web3py.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/SC-2-Setup-Web3py.ipynb
@@ -1130,6 +1130,111 @@
   },
   {
    "cell_type": "markdown",
+   "id": "exo2-reentrancy-consigne",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "### Exercice (a completer) : Protection anti-reentrance sur le contrat Vault\n",
+    "\n",
+    "Le contrat `Vault` de l'exemple guide (cellule precedente) presente une **faille classique de\n",
+    "reentrance** : dans `withdraw()`, le transfert ETH vers l'appelant (`payable(...).transfer(amount)`)\n",
+    "intervient *avant* la mise a jour du solde, ce qui permet a un contrat malveillant de rappeler\n",
+    "`withdraw()` pendant le transfert et de vider les fonds.\n",
+    "\n",
+    "Objectif : appliquer le pattern **Checks-Effects-Interactions** via un *guard* de reentrance.\n",
+    "\n",
+    "1. Ajoutez une variable d'etat `bool public locked;` (initialement `false`).\n",
+    "2. Definissez un modifier `nonReentrant` qui reverte si `locked` est `true`, pose le verrou avant\n",
+    "   l'effet, et le relache apres : `require(!locked, \"Reentrant\"); locked = true; _; locked = false;`.\n",
+    "3. Appliquez `nonReentrant` a `deposit()` et `withdraw()`.\n",
+    "4. Redeployez avec `compile_and_deploy(w3, VAULT_REENTRANCY_SOL, deployer)` puis verifiez qu'une\n",
+    "   deuxieme appel imbrique est bien bloque (scenario de test).\n",
+    "\n",
+    "**Indice** : l'ordre Checks -> Effects (mise a jour de `balances`) -> Interactions (`transfer`)\n",
+    "est tout aussi important que le guard lui-meme ; le modifier protege, l'ordre elimine la race.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "exo2-reentrancy-stub",
+   "metadata": {},
+   "execution_count": 11,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice : Protection anti-reentrance sur le contrat Vault\n",
+    "# TODO etudiant :\n",
+    "#   Etape 1 : copier VAULT_PLAFOND_SOL (ou VAULT_SOL) et ajouter un guard de reentrance\n",
+    "#             - variable d'etat bool locked (init a false)\n",
+    "#             - modifier nonReentrant { require(!locked, \"Reentrant\"); locked = true; _; locked = false; }\n",
+    "#             - appliquer nonReentrant a deposit() et withdraw()\n",
+    "#   Etape 2 : recompiler et redeployer avec compile_and_deploy(w3, VAULT_REENTRANCY_SOL, deployer)\n",
+    "#   Etape 3 : verifier que le guard bloque une tentative de reentrance (scenario de test)\n",
+    "print(\"Exercice a completer\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "exo3-calltransact-consigne",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "### Exercice (a completer) : `call()` vs `transact()` -- lecture vs ecriture\n",
+    "\n",
+    "Web3.py distingue deux modes d'interaction avec un contrat deploye, et la confusion entre les deux\n",
+    "est une source frequentes de bugs. Cet exercice vise a bien ancrer la difference.\n",
+    "\n",
+    "1. Ecrivez un contrat `LectureEcriture` qui stocke un `uint256 public valeur;` et expose :\n",
+    "   - une fonction **view** `getValeur() returns (uint256)` (lecture seule, hors frais),\n",
+    "   - une fonction **write** `setValeur(uint256 v)` (modifie l'etat, coute du gas).\n",
+    "2. Deployez avec `compile_and_deploy(w3, LECTURE_ECRITURE_SOL, deployer)`.\n",
+    "3. Lisez la valeur initiale via `.call()` (transaction simulee, **pas de gas**, pas de modification\n",
+    "   d'etat -- c'est l'equivalent d'un `eth_call`).\n",
+    "4. Modifiez la valeur via `.transact()` (transaction reelle minee, **coute du gas**, modifie\n",
+    "   l'etat -- equivalent d'un `eth_sendTransaction`).\n",
+    "5. Relisez via `.call()` pour confirmer que l'etat a change.\n",
+    "\n",
+    "**Indice** : une fonction marquee `view` ou `pure` en Solidity peut etre appelee gratuitement via\n",
+    "`.call()` ; toute fonction qui ecrit ne peut l'etre que via `.transact()`. Confondre les deux sur\n",
+    "une fonction d'ecriture = la transaction echoue silencieusement (pas d'effet) ou est rejectee.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "exo3-calltransact-stub",
+   "metadata": {},
+   "execution_count": 12,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice : call() vs transact() -- lecture (view) vs ecriture (state change)\n",
+    "# TODO etudiant :\n",
+    "#   Etape 1 : ecrire un contrat LectureEcriture avec une fonction view getValeur() et une fonction setValeur(uint256 v)\n",
+    "#   Etape 2 : deployer via compile_and_deploy(w3, LECTURE_ECRITURE_SOL, deployer)\n",
+    "#   Etape 3 : lire la valeur initiale avec .call() (pas de gas, pas de modification d'etat)\n",
+    "#   Etape 4 : modifier la valeur avec .transact() (coute du gas, modifie l'etat)\n",
+    "#   Etape 5 : relire via .call() pour confirmer le changement d'etat\n",
+    "print(\"Exercice a completer\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "summary",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
## Contexte

`SC-2-Setup-Web3py.ipynb` n'avait qu'**1 exercice stub** (cellule 26 : événements + plafond de dépôt), soit **1/3** sous le seuil de la convention [#2161](https://github.com/jsboige/CoursIA/issues/2161) (≥ 3 exercices par notebook pédagogique).

Le nom "Setup" est trompeur : le notebook est **pédagogique substantiel** (dossier `00-Foundations`), il enseigne la compilation Solidity via `py-solc-x`, le déploiement via `web3.py`/`anvil`, et les interactions `call`/`transact` — pas une simple config d'environnement.

## Livrable

Ajout de **2 exercices stub** pédagogiquement cohérents avec le contenu (le contrat `Vault` de l'exemple guide + le helper `compile_and_deploy`), insérés avant le résumé :

1. **Protection anti-reentrance sur le `Vault`** — pattern *Checks-Effects-Interactions* via un modifier `nonReentrant` + flag `locked`. Concept de sécurité classique et non-trivial en Smart Contracts (la faille de réentrance du `withdraw()` de l'exemple guide).
2. **`call()` vs `transact()`** — lecture (`view`, gratuit, pas de modification d'état) vs écriture (coûte du gas, mute l'état). Distinction fondamentale Web3.py.

Les consignes détaillent les étapes + un indice pédagogique.

## Validation (preuves vérifiables)

- **C.1** : `grep -nE "raise NotImplementedError|assert False|1/0"` (regex corrigée #7324 excluant les fractions décimales) sur le notebook = **0 hit**. Stubs conformes : `# TODO etudiant` + `print("Exercice a completer")`.
- **C.2 / H.3** : les 2 nouvelles cellules code portent `execution_count: 11` et `12` avec **outputs réels** (stdout `Exercice a completer\n`) capturés via exécution réelle sur kernel `python3` (MCP jupyter, `execute_on_kernel`). **Pas de hand-injection** (règle secrets-hygiene #6) — le code exécuté est exactement le code du stub.
- **`count_exercises.py`** : `1 notebook, 3 exercices, 0 sub-threshold` → **3/3 conforme**.
- **Diff** : `+105/-0` sur 1 fichier, **0 churn** sur les cellules existantes (insertion pure avant le séparateur de résumé).
- **nbformat validate** : OK (4.5, cell IDs uniques).
- **Scope strict C.3** : aucune cellule source existante modifiée → outputs existants préservés.

## SOTA / Prong-B (#3801)

Les exercices sont des **exercices** (stubs à compléter), pas un workaround. Le notebook démontre le **vrai Web3.py + Solidity** (compilation `py-solc-x`, déploiement `anvil`) dans ses cellules exemple-guide existantes ; les exercices demandent à l'étudiant d'appliquer ces outils sur des problèmes non-triviaux (réentrance = faille de sécurité réelle, pas un cas dégénéré).

## Scope

`See #2161` (convention ≥ 3 exercices) — issue non entièrement résolue (d'autres familles restent à couvrir, mais celles accessibles à cette lane sont drained).
