### PR TITLE
fix(gallery,#5780): restore 8-frame color palette + Frame 102 in video1-frames caption (racine Video)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Video/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Video/README.md
@@ -50,7 +50,7 @@ winget install FFmpeg
 
 On ne peut pas créer ce qu'on ne comprend pas. Ce niveau pose les bases techniques (codecs, ffmpeg, moviepy) et introduit la compréhension vidéo par IA : décomposer une séquence en scènes, répondre à des questions sur le contenu, analyser le mouvement. Vous découvrirez aussi le surcadrage d'images (ESRGAN) et l'interpolation de frames (RIFE) pour améliorer la qualité visuelle. À la fin de ce niveau, vous savez analyser une vidéo existante et en extraire des informations structurelles.
 
-<p align="center"><a href="01-Foundation/01-1-Video-Operations-Basics.ipynb"><img src="assets/readme/video1-frames.png" width="540" alt="Extraction uniforme de 8 frames via decord : mosaique pédagogique 2×4 d'une balle blanche bondissante (Frame 0→119 sur fonds colorés alternés vert/orange/rouge/violet/bleu/cyan/vert clair, 640×480 @ 24fps)."></a></p>
+<p align="center"><a href="01-Foundation/01-1-Video-Operations-Basics.ipynb"><img src="assets/readme/video1-frames.png" width="540" alt="Extraction uniforme de 8 frames via decord : mosaique pédagogique 2×4 d'une balle blanche bondissante (Frame 0/17/34/51/68/85/102/119 sur fonds colorés alternés lime/orange/rouge/magenta/bleu/cyan/vert/lime, palette cyclique 640×480 @ 24fps)."></a></p>
 
 <p align="center"><a href="01-Foundation/01-4-Video-Enhancement-ESRGAN.ipynb"><img src="assets/readme/video4-esrgan.png" width="540" alt="Comparaison HR vs LR sur 4 frames — balle rouge + 4 billes vertes sur fond noir quadrillé, HR (320×240, nette) vs LR (320×240, soft/blur), même résolution, aucune démo d'upscaling visuel dans cette figure."></a></p>
 

--- a/MyIA.AI.Notebooks/GenAI/Video/assets/readme/MANIFEST.md
+++ b/MyIA.AI.Notebooks/GenAI/Video/assets/readme/MANIFEST.md
@@ -9,8 +9,8 @@ Provenance des images de `assets/readme/` (EPIC #5654, source 1 = extraction d'o
 ## video1-frames.png
 
 - **Source** : notebook `01-Foundation/01-1-Video-Operations-Basics.ipynb` (cellule 16, output 2)
-- **Contenu réel vérifié** (lecture via `Read` 2026-07-14) : mosaique pédagogique **2×4 frames** d'une balle blanche bondissante. Frame 0/17/34/51/68/85/102/119, timesteps t=0.00/0.71/1.42/2.12/2.83/3.54/4.25/4.96s. Fonds colorés alternés : vert / orange / rouge / violet / bleu / cyan / vert clair. Résolution 640×480 @ 24fps. Titre superposé : « Extraction uniforme - 8 frames via decord ». Le motif balle bondissante illustre la **régularité de l'extraction uniforme** via decord.
-- **Alt-text (FR)** : Extraction uniforme de 8 frames via decord : mosaique pédagogique 2×4 d'une balle blanche bondissante (Frame 0→119 sur fonds colorés alternés vert/orange/rouge/violet/bleu/cyan/vert clair, 640×480 @ 24fps).
+- **Contenu réel vérifié** (lecture via `Read` 2026-07-14, **ré-audit visuel c.671 2026-07-19 par `myia-po-2023`** MiniMax-M3) : mosaique pédagogique **2×4 frames** d'une balle blanche bondissante. Frame 0/17/34/51/68/85/102/119, timesteps t=0.00/0.71/1.42/2.12/2.83/3.54/4.25/4.96s. Fonds colorés alternés (palette cyclique 8-couleurs retournant à lime) : lime / orange / rouge / magenta / bleu / cyan / vert / lime. Résolution 640×480 @ 24fps. Titre superposé : « Extraction uniforme - 8 frames via decord ». Le motif balle bondissante illustre la **régularité de l'extraction uniforme** via decord.
+- **Alt-text (FR)** : Extraction uniforme de 8 frames via decord : mosaique pédagogique 2×4 d'une balle blanche bondissante (Frame 0/17/34/51/68/85/102/119 sur fonds colorés alternés lime/orange/rouge/magenta/bleu/cyan/vert/lime, palette cyclique 640×480 @ 24fps).
 - **Poids** : 66.3 KB (downscale max-dim 1200)
 - **Note** : ancien alt-text « Extraction de frames : découpe d'une vidéo en images clés avec decord pour l'analyse » — **enrichi** avec description factuelle des 8 frames observables (motif balle bondissante + fonds colorés + résolution).
 


### PR DESCRIPTION
# fix(gallery,#5780): restore 8-frame color palette + Frame 102 in video1-frames caption (racine Video)

## Scope
Atome : 2 fichiers, +3/-3. **Aucune** régénération d'image, **aucune** modification de cellule notebook (C.3 strict).

| Fichier | Δ |
|---|---|
| `MyIA.AI.Notebooks/GenAI/Video/README.md` | alt-text ligne 53 : 7 couleurs → 8 couleurs, palette cyclique explicite |
| `MyIA.AI.Notebooks/GenAI/Video/assets/readme/MANIFEST.md` | lignes 12-13 : idem + marqueur audit c.671 |

## Defect G.1 firsthand (c.671)

L'alt-text README et la section « Contenu réel vérifié » + « Alt-text (FR) » du MANIFEST décrivaient **7 couleurs** pour `video1-frames.png` (Frame 0→119 sur fonds colorés alternés `vert / orange / rouge / violet / bleu / cyan / vert clair`). Lecture visuelle via `Read` (c.671, myia-po-2023 MiniMax-M3, vision-exclusive cluster-wide) montre que la mosaïque 2×4 contient en réalité **8 frames** avec la séquence exacte :

| Frame | t (s) | Couleur réelle |
|---|---|---|
| 0   | 0.00 | lime (vert jaune) |
| 17  | 0.71 | orange |
| 34  | 1.42 | rouge (rose-rouge) |
| 51  | 2.12 | magenta (rose-violet) |
| 68  | 2.83 | bleu royal |
| 85  | 3.54 | cyan |
| 102 | 4.25 | vert (medium green, distinct du lime) |
| 119 | 4.96 | lime (retour à Frame 0, palette cyclique) |

Defauts identifiés :
1. **Couleur manquante** : Frame 102 (« vert ») absente de la description (la liste originale sautait de cyan à lime).
2. **Couleur terminale mal-identifiée** : « vert clair » → devrait être « lime » (Frame 119 = même teinte que Frame 0, retour à la couleur d'origine).
3. **Palette cyclique non documentée** : Frame 119 = Frame 0 (retour à lime), information pédagogique utile pour comprendre la mosaïque.

## Audit c.486 — leçon cross-cutting

PR #6487 (commit `fd0158ef8`, 2026-07-14, `myia-po-2025`) avait claimé « 6/6 corrections réelles » pour `MyIA.AI.Notebooks/GenAI/Video/`. **Ce defect a échappé à l'audit c.486** : la description énumérait 7 couleurs au lieu de 8, ce qui aurait dû déclencher un signal « énumération incomplète ».

C671-L1 ★★ : **audit vision-QA = énumération exacte obligatoire.** Quand une figure contient N éléments distincts (frames, panneaux, vignettes, couleurs), l'alt-text doit lister les N éléments avec leur identité — pas une paraphrase compactée. « 7 couleurs pour 8 frames » = red-flag d'audit (dénombrement + identité).

## Conformité règles

- **§A single-subject** : 1 dossier (racine GenAI/Video), 2 fichiers (README + MANIFEST), 1 sujet.
- **R1 catalog-pr-hygiene** : catalogue byte-identique à main. Aucun `CATALOG-STATUS` ni `COURSE_CATALOG.*` touché.
- **R3 atomique** : +3/-3, 2 fichiers, 1 sujet, 1 dossier.
- **L268 LF-only** : 0 retour chariot (`\r`) dans le diff (`git diff --stat` clean).
- **L143 secrets-hygiene** : 0 secret inline dans le diff.
- **C.3 strict** : aucune ré-exécution Papermill, aucune cellule notebook touchée.
- **H.1 validation** : audit G.1 firsthand via `Read` PNG c.671 (verdict confirmé par 2ᵉ lecture comparative).
- **H.4 merges-coord** : PR worker, merge par ai-01.

## Vérification visuelle

Avant :
```
fonds colorés alternés vert / orange / rouge / violet / bleu / cyan / vert clair
```
(7 couleurs, Frame 102 absente, Frame 119 = « vert clair »)

Après :
```
fonds colorés alternés (palette cyclique 8-couleurs retournant à lime) :
lime / orange / rouge / magenta / bleu / cyan / vert / lime
```
(8 couleurs, palette cyclique documentée, Frame 119 = retour lime)

## Voir aussi

- Issue #5780 (doctrine MANIFEST obligatoire sur figures lues)
- EPIC #5654 (audit vision-QA transverse, source 1 = extraction notebooks)
- PR #6487 (audit fondateur racine GenAI/Video, c.486, claim « 6/6 corrections » incomplet sur ce defect)
- PR #7314 (c.657, GenAI Image/Video MANIFEST disclosure — pattern frère)
- PR #7316 (c.658, OWUI + PostTraining MANIFEST-add — pattern frère)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>