### PR TITLE
fix(check-c2,#3801): skip C# //-comment-only cells (Python-only comment blindspot, twin of #7326)

### DIFF
--- a/scripts/notebook_tools/check_c2_compliance.py
+++ b/scripts/notebook_tools/check_c2_compliance.py
@@ -60,9 +60,15 @@ def check_notebook(nb_path: Path) -> dict:
         if not source.strip():
             continue
 
-        # Skip cells that are only markdown-like comments
+        # Skip cells that are only markdown-like comments. Both Python `#` and
+        # C-family `//` (C#/.NET Interactive, JS, Java) are recognised — a `.net
+        # -csharp` cell whose body is all `//` comments is a non-executable
+        # transition/explanation cell, the C# mirror of a Python `#`-comment-only
+        # cell, and must be skipped on the same grounds (C.2 targets executable
+        # code cells, not prose). Harmonised with notebook_lint.scan_c1_source
+        # and audit_c1_c3.py (cf #5261 C-family comment-awareness).
         lines = [l.strip() for l in source.split("\n") if l.strip()]
-        if all(l.startswith("#") for l in lines):
+        if all(l.startswith(("#", "//")) for l in lines):
             continue
 
         # Check execution_count

--- a/scripts/notebook_tools/tests/test_check_c2_compliance.py
+++ b/scripts/notebook_tools/tests/test_check_c2_compliance.py
@@ -227,6 +227,40 @@ class TestSkippingRules:
         result = check_notebook(nb_path)
         assert result["violations"] == []
 
+    def test_csharp_comment_only_skipped(self, tmp_path):
+        """C# (.NET Interactive) `//`-comment-only cell -> skipped, like Python `#`.
+
+        A `.net-csharp` cell whose body is all `//` comments is a non-executable
+        transition/explanation cell — the C# mirror of a Python `#`-comment-only
+        cell. C.2 targets executable code, so it must be skipped on the same
+        grounds (the prior Python-only check flagged it "missing execution_count").
+        """
+        nb_path = _write_nb(tmp_path / "cs_comment.ipynb", [
+            _code("// Cellule de transition pedagogique\n"
+                  "// Explique le prochain concept sans executer de code",
+                  exec_count=None),
+        ])
+        result = check_notebook(nb_path)
+        assert result["violations"] == []
+
+    def test_csharp_multiline_comment_only_skipped(self, tmp_path):
+        """C# `//`-comment-only cell with exec_count set and no outputs -> skipped.
+
+        The common real-world case: dotnet-interactive runs the (comment-only)
+        cell, sets exec_count, produces no stdout. Without the C# comment skip
+        this falls through to the has_output_statement check and, if any comment
+        mentions `=`/`return `/`print(`, is falsely flagged "execution_count set
+        but no outputs". Skipping comment-only C# cells upstream avoids the FP.
+        """
+        nb_path = _write_nb(tmp_path / "cs_multi.ipynb", [
+            _code("// Section: analyse du resultat\n"
+                  "// (note: x = valeur attendue, cf. plus bas)\n"
+                  "// Suite de l'explication",
+                  exec_count=3),
+        ])
+        result = check_notebook(nb_path)
+        assert result["violations"] == []
+
     def test_markdown_cells_ignored(self, tmp_path):
         """Markdown cells are not counted as code cells."""
         nb_path = _write_nb(tmp_path / "md.ipynb", [


### PR DESCRIPTION
## Summary

Corrige un **false-positive latent du checker C.2** : `check_c2_compliance.py` skip les cellules comment-only pour Python `#` MAIS PAS pour C-family `//`. Une cellule `.net-csharp` dont tout le corps est des commentaires `//` est un miroir C# de la cellule Python `#`-comment-only, et doit être skippée pour les mêmes raisons (C.2 cible le code exécutable). **Twin du fix notebook_lint (#7326)** — même classe de comment-blindspot, harmonise le 3ᵉ validateur C-family.

## Défaut (firsthand G.1)

`scripts/notebook_tools/check_c2_compliance.py` — checker C.2 (référencé dans `.github/workflows/notebook-validation.yml`, suite de 32 tests) :

```python
# line 65 (prior):
if all(l.startswith("#") for l in lines):   # Python comment marker ONLY
    continue
```

Une cellule `.net-csharp` toute en commentaires `//` (cellule de transition/explication pédagogique, pattern naturel en .NET Interactive) est le miroir C# d'une cellule Python `#`-comment-only. Le check Python-only la flaggait comme violation C.2 :
- si `exec_count=None` → "missing execution_count"
- si dotnet-interactive l'a exécutée (`exec_count` set, pas de stdout) → la `has_output_statement` heuristic la flagge "execution_count set but no outputs" quand un commentaire mentionne `=`/`return `/`print(`.

## ★ G.9 — deux FPs investigués, UN seul réel

- **FP1 (réel, cette PR)** : cellule C# `//`-comment-only non skippée → faux flag C.2.
- **FP2 (investigué, INVALIDE)** : la `has_output_statement` heuristic inclut `=`, donc les cellules d'assignation sans output sont flaggées. J'ai envisagé retirer `=` — MAIS `test_assignment_no_output_flagged` (~L157) ASSERT que ce comportement est intentionnel (`x = compute_value()` sans output EST une violation C.2 per policy projet). Retirer `=` casserait ce test = régression. Correctement laissé intact.

## Fix (1 ligne, harmonisée C-family)

```python
# AVANT:
if all(l.startswith("#") for l in lines):
# APRÈS:
if all(l.startswith(("#", "//")) for l in lines):
```

Reconnait les deux marqueurs (Python `#` + C-family `//`). Harmonise `check_c2_compliance.py` avec `notebook_lint.scan_c1_source` (#7326) et `audit_c1_c3.py` — les 3 validateurs C-family reconnaissent `//` de façon cohérente.

## Impact réel — LATENT (honnête)

Scan firsthand de **142 notebooks C#** sur `origin/main` : **0 cellules `//`-comment-only** actuellement. Ce FP est **latent** (pas de gaspillage actif aujourd'hui), contrairement au FP `1/0` d'ICT-7 (#7324) qui hit firsthand. Le fix est une **garde de cohérence/correction** : au fur et à mesure que les notebooks .NET ajoutent des cellules de transition `//`-comment-only (pattern naturel), elles sont maintenant skippées comme les cellules Python `#`-comment-only au lieu de risquer un faux flag C.2.

## Tests de regression (dans test_check_c2_compliance.py, à côté des tests Python existants)

- `test_csharp_comment_only_skipped` : cellule `//`-comment-only seule, `exec_count=None`.
- `test_csharp_multiline_comment_only_skipped` : le cas réel courant — commentaires `//` multiline avec `exec_count` SET et un commentaire mentionnant `=` (tomberait dans `has_output_statement` et false-flag sans le skip amont).

## Validation REELLE (firsthand, règle H.1)

Worktree frais `CoursIA-c2-fp` off `origin/main` `2f43f1856`.

```
$ python -m pytest scripts/notebook_tools/tests/test_check_c2_compliance.py -q
============================== 34 passed in 0.15s ==============================
```
(was 32, +2 tests regression ; tous les tests existants passent)

End-to-end : reproduction synthétique FP1 (cellule `//` comment-only C#) → **0 violations** (était flaggée).
Notebook réel (Sudoku-1-Backtracking-Csharp) → toujours 1/1 compliant (0 régression).

## Hygiène

- Three-dot diff vs `origin/main` = **2 fichiers**, +42/−2 (`check_c2_compliance.py` +8/−2 incl. commentaire, `test_check_c2_compliance.py` +34).
- **Catalogue byte-identique** (HARD 1) : non touché.
- **0 CRLF** (sensible `.py`).
- Worktree frais off `origin/main`.

## Scope

1 source file (comment-skip + commentaire) + 1 test file (2 regression tests). Tooling correctness — C-family comment-awareness twin de #7326 (notebook_lint) / #7324 (audit_c1_c3), harmonise les 3 validateurs C.1/C.2. Non-Lean, non-R6-capped, non-gated. **Latent FP (0 hits actuels) — transparent sur l'impact.**

See #3801 (SOTA axe-2 tooling), #5261 (C-family comment-awareness context), #7326 (notebook_lint twin), #7324 (audit_c1_c3 twin).

Co-Authored-By: Claude <noreply@anthropic.com>
