### PR TITLE
fix(audio,#5780): clarify audio3 4-panel grid + fix audio5 alt-text filename/content mismatch (racine GenAI/Audio)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Audio/README.md
@@ -62,7 +62,7 @@ Une fois le signal compris, les deux briques opérationnelles sont la transcript
 
 <p align="center">
   <a href="01-Foundation/01-3-Basic-Audio-Operations.ipynb"><img src="assets/readme/audio3-stt-tts.png" width="340" alt="Reconnaissance vocale (STT) validée par Whisper large-v3-turbo ; volet TTS non abouti dans l'environnement de test (sous-figures vides)."></a><br>
-  <em>Sortie du notebook <a href="01-Foundation/01-3-Basic-Audio-Operations.ipynb">01-3</a> : grille 2×2 — STT validé (en haut à gauche), volet TTS en attente de re-exécution.</em>
+  <em>Sortie du notebook <a href="01-Foundation/01-3-Basic-Audio-Operations.ipynb">01-3</a> (ré-audit vision c.673 2026-07-19 par <code>myia-po-2023</code> MiniMax-M3, doctrine #5780) : grille 2×2 de 4 panneaux — panneau haut-gauche « Latence STT par modèle » validé (Whisper <code>large-v3-turbo</code> à 0,47 s), panneau haut-droite « Pas de résultats TTS » vide, panneau bas-gauche « Analyse des coûts (USD/heure) » ne portant que les libellés <code>large-v3-turbo</code> et <code>Gratuit</code> sans barres, panneau bas-droite radar « Pas de résultats TTS » vide. Seuls les volets STT (haut-gauche) et coûts (bas-gauche, sans valeurs) ont produit des données ; les deux volets TTS restent à re-exécuter.</em>
 </p>
 
 ### 02-Advanced - Voix, Musique & Séparation

--- a/MyIA.AI.Notebooks/GenAI/Audio/assets/readme/MANIFEST.md
+++ b/MyIA.AI.Notebooks/GenAI/Audio/assets/readme/MANIFEST.md
@@ -44,10 +44,11 @@ Provenance des images de `assets/readme/` (EPIC #5654, source 1 = extraction d'o
 ## audio5-multimodel.png
 
 - **Source** : `01-Foundation/01-3-Basic-Audio-Operations.ipynb` cell[28] out[2] (`# Extraction de caracteristiques`).
-- **Contenu (vision firsthand c.529)** : **4 courbes de features librosa** empilées — Spectral Centroid, Spectral Bandwidth, RMS Energy, Zero-Crossing Rate, axe temps 0–12 s.
+- **Contenu réel vérifié** (ré-audit vision c.673 2026-07-19 par `myia-po-2023` MiniMax-M3, doctrine #5780 — vision eersthand pixel-par-pixel) : figure matplotlib super-titre **« Caracteristiques audio extraites »**, **4 sous-panneaux empilés** (Spectral Centroid en bleu / Spectral Bandwidth en vert / RMS Energy en rouge / Zero-Crossing Rate en violet), axe temps partagé **0–12 s** identique à `audio1-waveform.png` (même échantillon librosa, features extraites). Palette saturée spectral/energy, ambiance d'analyse technique.
 - **Traçage** : cellule brute 172 278 B (md5 `890f2d8a`) → disque 167 756 B (md5 `03e86f25`), ratio **0,97**.
-- **Alt-text (FR)** : Comparaison de modèles audio : plusieurs voies STT/TTS évaluées côte à côte dans un pipeline. — *le nom de slot et l'alt-text historique évoquent une comparaison multi-modèles ; le contenu réel est un panneau de features librosa. Asset orphelin (non inliné), conservé pour traçabilité ; à renommer si un jour réutilisé.*
-- **Verdict** : **SOTA-OK** (contenu réel = features librosa du 01-3). Le c.490 avait correctement identifié la cellule source (cell[28]) tout en la classant à tort « déclassée ».
+- **Alt-text (FR, corrigé c.673)** : Panneau de caractéristiques audio extraites par librosa — quatre signaux empilés (centroïde spectral, largeur spectrale, énergie RMS, taux de passage par zéro), axe temps 0–12 s identique à la forme d'onde audio1.
+- **Filename/content mismatch (doctrine #5780 c.657 doublon-disclosure, famille C672-L2 ★ / C672-L1 ★★)** : **le nom de fichier `audio5-multimodel.png` et l'ancien alt-text « comparaison de modèles audio » décrivaient à tort une comparaison STT/TTS — le contenu réel est un panneau de features librosa mono-fichier.** Pas de régénération (le contenu est correct) ; disclosure obligatoire par doctrine : **« Nom de slot hérité d'une attribution erronée ; figure renommée virtuellement `audio5-features-librosa.png` par cohérence, mais le nom de fichier physique reste `audio5-multimodel.png` pour traçabilité git. Ne pas inliner tant que le slot n'a pas été vidé de la nomenclature. »** Asset orphelin (non inliné dans le README), conservé pour traçabilité.
+- **Verdict** : **SOTA-OK** (contenu réel = features librosa du 01-3). Le c.490 avait correctement identifié la cellule source (cell[28]) tout en la classant à tort « déclassée » ; le c.529 l'avait re-traçé fidèlement ; le c.673 alinhé l'alt-text sur le contenu réel.
 
 ## audio6-tts-benchmark.png
 


### PR DESCRIPTION
# fix(audio,#5780): clarify audio3 4-panel grid + fix audio5 alt-text filename/content mismatch (racine GenAI/Audio)

## Scope

Atome : 2 fichiers, +5/-4. **Aucune** régénération d'image, **aucune** modification de cellule notebook (C.3 strict).

| Fichier | Δ |
|---|---|
| `MyIA.AI.Notebooks/GenAI/Audio/README.md` | caption audio3 inlined ligne 65 : « grille 2×2 — STT validé (en haut à gauche), volet TTS en attente de re-exécution » → description complète des 4 panneaux (STT validé + 2 volets TTS vides + cost sans barres), marqueur audit c.673 |
| `MyIA.AI.Notebooks/GenAI/Audio/assets/readme/MANIFEST.md` | section `audio5-multimodel.png` (lignes 44-51) : alt-text « comparaison de modèles audio » → description réelle du panneau librosa features ; ajout filename/content mismatch disclosure (doctrine #5780 c.657 doublon-disclosure) |

## Defect G.1 firsthand (c.673) — 2 défauts résiduels

L'audit c.529 (2026-07-16, post-c.481/c.490) avait correctement ré-établi la traçabilité des 6 figures audio et corrigé les défauts majeurs (swap audio2↔audio4, attributions cellules audio5/audio6). **Mais 2 défauts résiduels subtils** ont échappé à c.529, identifiés par relecture vision-QA MiniMax-M3 c.673 :

### Defect 1 (mineur, C671-L1 ★★ famille) — caption audio3 README incomplète

L'alt-text in-situ README ligne 65 disait :
> « Sortie du notebook 01-3 : grille 2×2 — STT validé (en haut à gauche), volet TTS en attente de re-exécution. »

La lecture vision c.673 révèle **4 panneaux** :
1. (haut-gauche) **« Latence STT par modèle »** — barplot validé, `large-v3-turbo` à 0,47 s
2. (haut-droite) **« Pas de résultats TTS »** — panneau vide
3. (bas-gauche) **« Analyse des coûts (USD/heure) »** — ne porte QUE les libellés `large-v3-turbo` et `Gratuit`, **aucune barre** rendue
4. (bas-droite) **radar « Pas de résultats TTS »** — vide

Le panel 3 (coûts) est passé sous silence dans la caption. Un lecteur non-voyant qui lit l'alt-text imagine une grille purement STT/TTS — alors qu'il y a un volet coûts (vide) que la caption omet.

**Fix** : description complète des 4 panneaux + mention explicite du volet coûts « sans barres ».

### Defect 2 (majeur, C672-L1 ★★ / C672-L2 ★ famille) — audio5 MANIFEST filename/content mismatch

L'alt-text historique du MANIFEST ligne 49 disait :
> « Comparaison de modèles audio : plusieurs voies STT/TTS évaluées côte à côte dans un pipeline. »

La lecture vision c.673 révèle un **panneau matplotlib super-titre « Caracteristiques audio extraites »** avec **4 sous-panneaux empilés** :
1. Spectral Centroid (bleu)
2. Spectral Bandwidth (vert)
3. RMS Energy (rouge)
4. Zero-Crossing Rate (violet)

Axe temps partagé 0–12 s identique à `audio1-waveform.png` (même échantillon librosa, features extraites).

**Le nom de fichier `audio5-multimodel.png` ET l'ancien alt-text décrivaient à tort une comparaison STT/TTS** — le contenu réel est un panneau de features librosa mono-fichier. C'est exactement le pattern c.671 (énumération erronée 7→8) + c.672 (modèle identité inversée image/notebook), dans une variante `filename/content mismatch`.

**Le c.529 avait honnêtement signalé le mismatch en note de bas de page** (« *le nom de slot et l'alt-text historique évoquent une comparaison multi-modèles ; le contenu réel est un panneau de features librosa* »), mais **n'avait pas corrigé l'alt-text lui-même**. Leçon c.673 : un disclosure qui admet le défaut sans corriger le défaut n'élimine pas le défaut — un lecteur d'écran qui parcourt le MANIFEST ne lira pas la note de bas de page.

**Fix** :
- Alt-text réécrit sur le contenu réel (« Panneau de caractéristiques audio extraites par librosa — quatre signaux empilés (centroïde spectral, largeur spectrale, énergie RMS, taux de passage par zéro), axe temps 0–12 s identique à la forme d'onde audio1 »).
- Disclosure explicite ajoutée en gras (« nom de fichier physique reste `audio5-multimodel.png` pour traçabilité git ; figure renommée virtuellement `audio5-features-librosa.png` par cohérence ; ne pas inliner tant que le slot n'a pas été vidé de la nomenclature »).
- Marqueur audit-trail c.673 (C671-L2 ★) pour traçabilité cross-cycle.

## PR livrée c.673

- **PR (à créer)** : `fix(audio,#5780): clarify audio3 4-panel grid + fix audio5 alt-text filename/content mismatch (racine GenAI/Audio)`
- 2 fichiers, +5/-4, atomique (R3)
- 0 notebook touché (C.3 strict), 0 image régénérée, catalogue byte-identique (R1)
- LF-only (CR=0 vérifié `git diff | grep -c $'\r'`), 0 secret inline (L143)

## Audit c.481 / c.490 / c.529 — leçon cross-cutting

Le MANIFEST racine Audio a déjà été audité **trois fois** :
- c.481 (po-2025, 2026-07-14) : swap `audio3`↔`audio5` au niveau des blobs disque
- c.490 (po-2025, 2026-07-14) : inversion lecture audio2↔audio4, faux claim « 5/6 externes »
- c.529 (po-2026, 2026-07-16) : réconciliation firsthand (vision + git par-blob + nbformat), ré-établissement sources correctes, disclosure honnête du mismatch audio5

**Aucun de ces audits n'a corrigé le défaut audio5 alt-text** — c.529 l'a *documenté* en note de bas de page mais l'a laissé tel quel. Leçon :

> **C673-L1 ★★** : un disclosure qui admet un défaut sans le corriger n'élimine pas le défaut. La note de bas de page du c.529 (« *le nom de slot évoque une comparaison multi-modèles ; le contenu réel est un panneau de features librosa* ») est de l'**honnêteté d'audit** mais pas un **fix**. Un lecteur d'écran qui parcourt le MANIFEST ligne par ligne lit l'alt-text fautif, pas la note. Pour fermer un défaut, **il faut modifier l'alt-text lui-même** (verbatim réel) ET laisser la note de bas de page comme trace historique.

> **C673-L2 ★** : la famille de défauts « filename/content mismatch » (nom de slot trompeur sur contenu réel) est maintenant documentée 3 fois dans le cluster (c.657 bonsai / c.672 dalle3 cover DALL-E 3→gpt-image-1 / c.673 audio5 multimodel→features). Pattern : nom de fichier ou de cellule construit à un moment T0 où le contenu a été mal lu, jamais corrigé ensuite malgré les régénérations. Solution systémique : à chaque audit vision-QA, vérifier **chaque filename** par rapport au **contenu réel** (G.1 firsthand) — pas seulement le contenu réel vs alt-text.

> **C673-L3 ★** : audit-trail marker MANIFEST (C671-L2 ★) cumulé à c.529 + c.673 permet de tracer **quelle passe a vu quoi quand**. Sans ce marqueur, on ne sait pas si un défaut a été identifié puis reporté à un PR ultérieur, ou s'il a été re-manqué à chaque passe.

## Conformité règles

- **§A single-subject** : 1 dossier (racine GenAI/Audio), 2 fichiers (README + MANIFEST), 1 sujet (caption-audit vision-QA).
- **R1 catalog-pr-hygiene** : catalogue byte-identique à main. Aucun `CATALOG-STATUS` ni `COURSE_CATALOG.*` touché.
- **R3 atomique** : +5/-4, 2 fichiers, 1 sujet, 1 dossier.
- **L268 LF-only** : 0 retour chariot (`\r`) dans le diff.
- **L143 secrets-hygiene** : 0 secret inline dans le diff.
- **C.3 strict** : aucune ré-exécution Papermill, aucune cellule notebook touchée.
- **H.1 validation** : audit G.1 firsthand via `Read` PNG c.673 (MiniMax-M3 vision, 6 figures balayées pixel-par-pixel).

## Voir aussi

- Issue #5780 (doctrine MANIFEST obligatoire sur figures lues)
- EPIC #5654 (audit vision-QA transverse)
- PR #7332 (c.671, racine GenAI/Video — pattern frère, défaut 7→8 couleurs)
- PR #7344 (c.672, racine GenAI/Image — pattern frère, défaut DALL-E 3 → gpt-image-1)
- Audit c.529 (corrige swap audio2↔audio4, attribution audio5↔audio6, sans corriger l'alt-text fautif audio5)
- Audit c.490 (lecture inversée audio2↔audio4, faux claim « 5/6 externes »)
- Notebook `01-Foundation/01-3-Basic-Audio-Operations.ipynb` cell[28] (extraction caractéristiques librosa)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
