### PR TITLE
docs(probas,#4959): fix stale social_choice_lean refs in Probas/README.md §E (post-#4365)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/README.md
+++ b/MyIA.AI.Notebooks/Probas/README.md
@@ -562,7 +562,7 @@ Le notebook `Infer-101.ipynb` est le seul à mélanger les deux kernels. Il util
 
 ### Pont vers les Preuves Formelles (Lean 4) — différenciant CoursIA
 
-Cette série ancre mathématiquement ses résultats phares dans un assistant de preuve, en partenariat avec les autres familles du dépôt. La programmation probabiliste ne se contente pas de **calculer** des densités, des utilités espérées et des bornes de généralisation — elle les **prouve**. Le tableau ci-dessous croise les notebooks Probas avec les **lakes Lean 4** qui certifient leurs théorèmes, et signale les passerelles vers les autres hubs (`QC` ↔ `kelly_lean`, `GameTheory` ↔ `social_choice_lean` Arrow, `Search` ↔ `search_lean`, `SymbolicAI` ↔ `argumentation_lean`).
+Cette série ancre mathématiquement ses résultats phares dans un assistant de preuve, en partenariat avec les autres familles du dépôt. La programmation probabiliste ne se contente pas de **calculer** des densités, des utilités espérées et des bornes de généralisation — elle les **prouve**. Le tableau ci-dessous croise les notebooks Probas avec les **lakes Lean 4** qui certifient leurs théorèmes, et signale les passerelles vers les autres hubs (`QC` ↔ `kelly_lean`, `GameTheory` ↔ `game_theory_lean` (Arrow), `Search` ↔ `search_lean`, `SymbolicAI` ↔ `argumentation_lean`).
 
 | Famille                  | Lake phare                       | Théorème                                                                          | Branchement notebook                                                |
 | ---                      | ---                              | ---                                                                               | ---                                                                  |
@@ -571,7 +571,7 @@ Cette série ancre mathématiquement ses résultats phares dans un assistant de 
 | Probas (PAC Learning)    | chaîne PAC iter-2 complète       | `pac_finite_class_bound` + `pac_agnostic_generalization` (`0 sorry bout-en-bout`)  | notebook PAC Learning compagnon Lean                                 |
 | Probas (DecisionTheory)  | `decision_theory_lean` Peters    | Indice de Gittins, identités d'escompte (`0 sorry`, ref `v4.27.0-rc1`)            | DecInfer-9 (companion Lean)                                          |
 | QC ↔ Probas              | `kelly_lean`                     | Fraction risquée `f* = μ−σ²/2` sous log-bienveillance (`0 sorry`)                  | notebook `kelly-criterion`                                           |
-| GameTheory ↔ Probas      | `social_choice_lean`             | Impossibilité d'Arrow (5 axiomes ⇒ dictature)                                     | hub GameTheory notebook 16a                                          |
+| GameTheory ↔ Probas      | `game_theory_lean` (Arrow)       | Impossibilité d'Arrow (5 axiomes ⇒ dictature)                                     | hub GameTheory notebook 16a                                          |
 | Search ↔ Probas          | `search_lean`                    | Consistance heuristique `h ≤ h*` ⇒ optimalité `A*`                                 | hub Search notebook `A*` phases 1-3                                  |
 | SymbolicAI ↔ Probas      | `argumentation_lean`             | Extension Dung (`grounded`/`preferred`/`stable`) par cadre formel                 | hub SymbolicAI/Tweety notebook AF-Dung                               |
 
@@ -591,7 +591,7 @@ flowchart LR
         LK_PAC["PAC chain uniform_concentration"]
         LK_GIT["decision_theory_lean Peters Gittins"]
         LK_KELLY["kelly_lean"]
-        LK_SC["social_choice_lean"]
+        LK_SC["game_theory_lean (Arrow)"]
     end
     NB_DT -. "axiomes vNM ⟹ utilité espérée" .-> LK_DT
     NB_CO -. "coherence ⟹ preferences" .-> LK_CO
@@ -609,7 +609,7 @@ flowchart LR
 
 La double culture Probas tient en deux gestes complémentaires. D'un côté, **simuler** : PyMC fait tourner NUTS/HMC sur des modèles hiérarchiques, Infer.NET propage des messages EP/VMP sur des graphes factoriels, et les notebooks PAC entraînent des hypothèses parERM. De l'autre, **prouver** : `decision_theory_lean` (VNM et Coherence certifiés, `0 sorry`) certifie que les axiomes de rationalité impliquent l'existence d'une utilité espérée, et la chaîne PAC iter-2 démontre `pac_agnostic_generalization` de bout en bout sans `sorry`. Les deux faces du même raisonnement bayésien et décisionnel — l'une touche l'intuition numérique, l'autre ancre la garantie formelle.
 
-EPIC [#4038](https://github.com/jsboige/CoursIA/issues/4038) (Roadmap Lean) · cross-ref hubs [`QC` ↔ `kelly_lean`](../QuantConnect/README.md), [central P0](../README.md), [`GameTheory` ↔ `social_choice_lean`](../GameTheory/README.md), [`SymbolicAI/Lean`](../SymbolicAI/Lean/README.md).
+EPIC [#4038](https://github.com/jsboige/CoursIA/issues/4038) (Roadmap Lean) · cross-ref hubs [`QC` ↔ `kelly_lean`](../QuantConnect/README.md), [central P0](../README.md), [`GameTheory` ↔ `game_theory_lean`](../GameTheory/README.md), [`SymbolicAI/Lean`](../SymbolicAI/Lean/README.md).
 
 ## Conclusion / Prochaines étapes
 


### PR DESCRIPTION
## Summary

Corrige **4 références stale** au lake Lean `social_choice_lean` dans `MyIA.AI.Notebooks/Probas/README.md` §E (L565, L574, L594, L612) — toutes obsolètes post-EPIC #4365 (GT 6→2 absorption). Toutes vérifiées firsthand contre origin/main dans un worktree frais.

## Défauts corrigés (G.1 firsthand)

| Ligne | État (stale) | Réalité sur origin/main |
|-------|-------------|------------------------|
| L565 (intro §E) | `GameTheory ↔ social_choice_lean` Arrow | Arrow vit dans `game_theory_lean/SocialChoice/Arrow.lean` (GameTheory, absorbé sous #4365) |
| L574 (row table) | `social_choice_lean` (Arrow) | idem — `game_theory_lean` (Arrow) |
| L594 (mermaid LK_SC) | `LK_SC["social_choice_lean"]` | idem — `LK_SC["game_theory_lean (Arrow)"]` |
| L612 (cross-ref EPIC) | `GameTheory ↔ social_choice_lean` | idem — `GameTheory ↔ game_theory_lean` |

Vérification find : `MyIA.AI.Notebooks/social_choice_lean/` = 0 fichiers .lean ; tout le namespace SocialChoice (Arrow.lean, Basic.lean, Framework.lean, MechanismDesign.lean, Sen.lean, Voting.lean, SortedListCounting.lean, _SmokeTest.lean) vit sous `game_theory_lean/SocialChoice/` per PR #5902 (`feat(lean): game_theory_lean skeleton — target lake for #4365 regroupement`).

## Miroir de PR #7312 (hub README fix)

PR #7312 a corrigé le hub central `MyIA.AI.Notebooks/README.md` §E (L276-284 + L129 + L133) mais **n'a pas touché Probas/README.md**. Cette PR = le fix feuille symétrique pour la cartographie hub-Probas introduite par PR #5053 (`docs(probas): hub Probas - cartographie Lean 4 inter-familles, See #4959, See #4038`) — c'est PR #5053 qui a écrit les refs `social_choice_lean` originales post #4365. Même scope (4 edits, +4/-4), même pattern de vérification, même discipline no-proof-no-code.

## Audit fichier-entier (§E règle E, L628 ★)

Audit complet de TOUTES les refs `*_lean` dans Probas/README.md (8 occurrences L563-612) : tous les autres noms de lake (`decision_theory_lean`, `kelly_lean`, `search_lean`, `argumentation_lean`) sont **accurate et vérifiés présents sur disque**. Seules les 4 refs stale ci-dessus ont été corrigées. Bloc CATALOG-STATUS (L1-7) **byte-identique à origin/main** (HARD 1 catalog-pr-hygiene vérifié).

## Résiduel (hors-scope, tracé)

Le subgraph mermaid L588-608 porte des incohérences additionnelles entre labels de nœuds et sémantique des flèches (ex. L601 `NB_EP -.-> LK_SC` labellé "extension Dung" mais Dung vit dans `argumentation_lean`, pas dans `game_theory_lean/SocialChoice/`). Ce sont des **diagramme accuracy** issues, pas des **stale-ref** issues, et nécessitent un audit séparé. Tracé sous #4959 (probas hub cartography) follow-up.

## Validation

- Fresh worktree from origin/main (pas de risque composite, cf leçon `worktree-checkout-b`)
- `find` firsthand : `social_choice_lean/` standalone = 0 résultat ; Arrow → `game_theory_lean/SocialChoice/Arrow.lean`
- `MyIA.AI.Notebooks/Probas/assets/readme/MANIFEST.md` byte-identique à origin/main (0 fichier modifié hors README)
- CRLF=0 dans le fichier modifié (LF-only vérifié)
- 0 image touchée (`git diff --name-only | grep -E '\.(png|jpg|webp|svg)$'` = 0)

## Scope (1 fichier, 4 edits, +4/-4)

Documentation pure (0 `.lean`, 0 preuve, 0 code). Cohérent avec PR #7312 (4 edits, +4/-4).

See #4959 (probas hub cartography), #4365 (GT 6→2 absorption qui a rendu ces refs stale), #7312 (hub README mirror fix), #5053 (PR originale qui a écrit les refs stale), #4038 (Roadmap Lean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)