### PR TITLE
fix(gametheory): invert inverted sign on RN "perte" in barrage analysis

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games/french_politics.py
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games/french_politics.py
@@ -806,7 +806,7 @@ def analyze_barrage_effect() -> str:
         f"  Ensemble: {SECOND_ROUND_RESULTS['Ensemble']['seats']} sieges "
         f"(~{ensemble_without_barrage} sans barrage, gain: +{SECOND_ROUND_RESULTS['Ensemble']['seats'] - ensemble_without_barrage})",
         f"  RN:       {SECOND_ROUND_RESULTS['RN']['seats']} sieges "
-        f"(~{rn_without_barrage} sans barrage, perte: {SECOND_ROUND_RESULTS['RN']['seats'] - rn_without_barrage})",
+        f"(~{rn_without_barrage} sans barrage, perte: {rn_without_barrage - SECOND_ROUND_RESULTS['RN']['seats']})",
         "",
         "INTERPRETATION POUR LE SHAPLEY:",
         "-" * 50,


### PR DESCRIPTION
## Summary

`cooperative_games/french_politics.py` `analyze_barrage_effect()` affichait un **« perte: -21 »** auto-contradictoire (une perte négative se lit comme un gain) pour le Rassemblement National, contredisant l'intention de l'analyse : le barrage républicain a **coûté** des sièges au RN. Correctif **1 ligne** (bug-fix, rotation de genre R6 après 3 PRs test-coverage ce cycle-day).

## Le bug (firsthand, reproduit avant fix)

Le calcul de la perte RN était :
```python
perte = SECOND_ROUND_RESULTS['RN']['seats'] - rn_without_barrage
      = 143 - 164 = -21
```
Or le contrefactuel `rn_without_barrage = 143 - int(143 × -0.15) = 143 + 21 = 164` est **supérieur** au réel 143 (le barrage a nui au RN : sans barrage 164, avec barrage 143). La magnitude de la perte est donc `164 - 143 = +21`, pas `-21`.

Le label affiché est **« perte »** (une perte), qui dénote conventionnellement une **magnitude positive**. NFP et Ensemble utilisent **« gain: +X »** avec valeurs positives cohérentes (NFP 161→182 gain +21, Ensemble 155→168 gain +13 — tous deux bénéficiaires du barrage). Le RN est le **seul** bloc que le barrage a nui → sa `perte` doit être la magnitude positive 21, parallèle aux gains ci-dessus.

**Sortie AVANT** (auto-contradictoire — une perte négative = un gain) :
```
NFP:      182 sieges (~161 sans barrage, gain: +21)
Ensemble: 168 sieges (~155 sans barrage, gain: +13)
RN:       143 sieges (~164 sans barrage, perte: -21)   ← bug
```

## Le fix (1 ligne)

Inverser la soustraction : `rn_without_barrage - SECOND_ROUND_RESULTS['RN']['seats']` → `perte: 21`.

**Sortie APRÈS** (cohérente) :
```
NFP:      182 sieges (~161 sans barrage, gain: +21)
Ensemble: 168 sieges (~155 sans barrage, gain: +13)
RN:       143 sieges (~164 sans barrage, perte: 21)    ← corrigé
```

## Validation RÉELLE (firsthand, règle H.1)

Env `mcp-jupyter-py310`. Reproduction AVANT fix via `from cooperative_games.french_politics import analyze_barrage_effect` → ligne RN confirmée `perte: -21`. APRÈS fix (module chargé depuis le worktree, path vérifié `LOADED FROM`) → `perte: 21`. Module importe propre, sortie complète `analyze_barrage_effect()` reviewée.

Régression **GameTheory/tests complète : 292 passed, 4 xfailed** (10.96s, 0 breakage).

## Hygiène

- Three-dot diff vs `origin/main` = **1 fichier, +1/−1** (single-line logic fix).
- **Catalogue byte-identique** (HARD 1) : non touché.
- **0 CRLF** sur le fichier modifié.
- Worktree frais `CoursIA-bughunt` off `origin/main` `9f5abb7da`.

## Scope

1 fichier, 1 ligne. **GameTheory cooperative_games** (analyse barrage élections législatives françaises 2024). Module **live** : exporté par `cooperative_games/__init__.py`, importé par `GameTheory-15-CooperativeGames.ipynb`. Aucune PR ouverte ne le touche. Histoire établie de bug-fixes (60954dbec « correct French politics Shapley model »).

Pure bug-fix, non-Lean, non-gated, non-R6-capped. `See` aucune issue (bug découvert via bug-hunt, rotation de genre R6 — bug-fix ≠ test-coverage des 3 PRs précédentes #7346/#7351/#7358).

## R6 transparence

4e PR ce cycle-day mais **1ère du genre bug-fix** (rotation de genre honorée, mandat 2026-07-06). Les 3 PRs précédentes (#7346 ML, #7351 Stackelberg, #7358 assistance) étaient test-coverage ; celle-ci corrige un bug de signe dans du code de production live. Engagement c.528 (« rotate genre si grain non-test devient disponible ») tenu : grain non-test trouvé via bug-hunt dans GameTheory cooperative_games (centipede/prisoners_dilemma lus et corrects ; french_politics avait le bug de signe).

Co-Authored-By: Claude <noreply@anthropic.com>
