### PR TITLE
fix(translation): resync sudoku.csv (302 SRC_DRIFT → 0, accent campaign) (#4957)

### DIFF
--- a/translations/sudoku/sudoku.csv
+++ b/translations/sudoku/sudoku.csv
@@ -262,7 +262,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-0-Environment-Csharp.ipynb,6f36e204,code,fr,16e4
 
 Console.WriteLine(""ISudokuSolver defini."");
 ",,,,,,,,16e43a83e89fb581,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-0-Environment-Csharp.ipynb,bb9446a7,markdown,fr,c6eb529251aaf985,"### Interprétation : Interface de stratégie
+MyIA.AI.Notebooks/Sudoku/Sudoku-0-Environment-Csharp.ipynb,bb9446a7,markdown,fr,d652f397414fb0ad,"### Interprétation : Interface de stratégie
 
 **Sortie obtenue** : L'interface `ISudokuSolver` définit le contrat que tous les solveurs doivent respecter.
 
@@ -273,11 +273,11 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-0-Environment-Csharp.ipynb,bb9446a7,markdown,fr,
 
 **Points clés** :
 1. **Simplicité** : Une seule méthode `Solve` prenant une grille et retournant une grille résolue
-2. **Flexibilité** : N'importe quel algorithme (backtracking, CSP, metaheuristique) peut implémenter cette interface
+2. **Flexibilité** : N'importe quel algorithme (backtracking, CSP, métaheuristique) peut implémenter cette interface
 3. **Composabilité** : Les solveurs peuvent être passés en paramètre, stockés dans des listes, testés unitairement
 4. **Extensibilité** : Ajouter un nouveau solver ne nécessite que d'implémenter l'interface
 
-> **Note technique** : Ce design pattern permet à `SudokuHelper.TestSolvers` d'accepter une liste de `(string, ISudokuSolver)` pour comparer tous les algorithmes avec le même code de test.",,,,,,,,c6eb529251aaf985,,,,,,,
+> **Note technique** : Ce design pattern permet à `SudokuHelper.TestSolvers` d'accepter une liste de `(string, ISudokuSolver)` pour comparer tous les algorithmes avec le même code de test.",,,,,,,,d652f397414fb0ad,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-0-Environment-Csharp.ipynb,f8ecaba7,markdown,fr,e4b0a862d4a5433f,"## Définition de la classe SudokuHelper
 
 Nous ajoutons ici la classe SudokuHelper qui contient des méthodes utilitaires pour charger  des grilles de Sudoku et tester des solvers.
@@ -560,7 +560,7 @@ display($""Puzzle Moyen:\n{mediumSudoku}"");
 // Chargement et affichage d'un puzzle difficile
 var hardSudoku = SudokuHelper.GetSudokus(SudokuDifficulty.Hard).FirstOrDefault();
 display($""Puzzle Difficile:\n{hardSudoku}"");",,,,,,,,d3633b87cb80b964,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Csharp.ipynb,54e213c3,markdown,fr,528703fc9d5514da,"### Interprétation : Structure des Puzzles Sudoku
+MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Csharp.ipynb,54e213c3,markdown,fr,b4f4d021ba61f014,"### Interprétation : Structure des Puzzles Sudoku
 
 **Sortie obtenue** : Trois puzzles de difficulté croissante ont été chargés et affichés. La différence de complexité se voit visuellement par le nombre de cases pré-remplies.
 
@@ -573,12 +573,12 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Csharp.ipynb,54e213c3,markdown,fr
 **Points clés** :
 1. **Échantillonnage représentatif** : La méthode `GetSudokus().FirstOrDefault()` retourne le premier puzzle disponible de chaque niveau, ce qui permet une comparaison consistante.
 2. **Corrélation difficulté/densité** : Plus le puzzle a de cases vides, plus l'espace de recherche est grand et plus le backtracking devra explorer de combinaisons.
-3. **Regles du jeu respectees** : Chaque puzzle respecte les contraintes du Sudoku (uniques chiffres 1-9 par ligne, colonne, bloc 3x3).
+3. **Règles du jeu respectees** : Chaque puzzle respecte les contraintes du Sudoku (uniques chiffres 1-9 par ligne, colonne, bloc 3x3).
 4. **Preparation aux tests** : Ces trois puzzles serviront de base pour évaluer les performances du solveur de backtracking.
 
 > **Note technique** : Les puzzles sont générés algorithmiquement pour garantir qu'ils ont exactement une solution unique. Cette propriété est cruciale pour évaluer la complétude de l'algorithme de backtracking.
 
-**Impact sur la performance** : Le nombre de cases vides determine directement la taille de l'arbre de recherche du backtracking. Avec 60 cases vides, le pire cas théorique est 9^60 possibilités, mais les contraintes reduisent drastiquement ce nombre en pratique.",,,,,,,,528703fc9d5514da,,,,,,,
+**Impact sur la performance** : Le nombre de cases vides determine directement la taille de l'arbre de recherche du backtracking. Avec 60 cases vides, le pire cas théorique est 9^60 possibilités, mais les contraintes reduisent drastiquement ce nombre en pratique.",,,,,,,,b4f4d021ba61f014,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Csharp.ipynb,ef6a308c,markdown,fr,78364832aa288543,"## Code du solver en C#
 
 Nous allons maintenant implémenter ce solveur en C#.
@@ -2437,7 +2437,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb,4b8e695f,markdown,fr,423
 - [CSP-1-Fondamentaux](../Search/Part2-CSP/CSP-1-Fundamentals.ipynb) - Fondamentaux CSP
 - [CSP-2-Consistance](../Search/Part2-CSP/CSP-2-Consistency.ipynb) - Propagation de contraintes
 - [App-1-NQueens](../Search/Applications/CSP/App-1-NQueens.ipynb) - Autre application CSP",,,,,,,,423169cb29a19105,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb,2455ea10,markdown,fr,f5c5a03658546309,"# Sudoku-10-ORTools-Python : OR-Tools CP-SAT (Python)
+MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb,2455ea10,markdown,fr,a650713ee578409a,"# Sudoku-10-ORTools-Python : OR-Tools CP-SAT (Python)
 
 **Navigation** : [<< Python Backtracking](Sudoku-1-Backtracking-Python.ipynb) | [Index](README.md) | [Z3 Python >>](Sudoku-12-Z3-Python.ipynb)
 
@@ -2445,7 +2445,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb,2455ea10,markdown,fr,f5c
 
 A la fin de ce notebook, vous saurez :
 1. Modeliser le Sudoku avec un solveur de programmation par contraintes (OR-Tools CP-SAT)
-2. Comprendre la difference entre approche imperative et declarative
+2. Comprendre la différence entre approche imperative et declarative
 3. Comparer les performances d'un solveur industriel avec le backtracking
 4. Utiliser la contrainte AllDifferent pour modéliser des problèmes combinatoires
 
@@ -2465,21 +2465,21 @@ Cette approche est equivalente au notebook C# `Sudoku-10-ORTools-Csharp.ipynb`.
 |--------|--------------------------|---------------------|
 | **Comment resoudre** | On programme l'algorithme | On decrit les contraintes |
 | **Optimisations** | Manuelles (MRV, etc.) | Automatiques par le solveur |
-| **Expressivite** | Code specifique au probleme | Modele generique reutilisable |
+| **Expressivite** | Code spécifique au problème | Modèle generique reutilisable |
 | **Maintenance** | Algorithme a maintenir | Seulement les contraintes |
 
 ## Avantages de CP-SAT
 
 1. **Annees d'optimisation** : CP-SAT integre des decennies de recherche en optimisation
 2. **Propagation de contraintes** : Reduction automatique des domaines
-3. **Apprentissage de conflits** : Evite de repeter les memes erreurs (CDCL)
+3. **Apprentissage de conflits** : Evite de repeter les mêmes erreurs (CDCL)
 4. **Parallelisation** : Exploitation automatique du multi-core
 
 ## Installation
 
 ```bash
 pip install ortools
-```",,,,,,,,f5c5a03658546309,,,,,,,
+```",,,,,,,,a650713ee578409a,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb,31f3025f-f1c7-4b39-bbcc-fe29c9da0ea2,code,fr,dbe9fd17045d77d5,"# Installation silencieuse d'OR-Tools (uniquement si absent de l'environnement)
 import subprocess, sys
 try:
@@ -2572,19 +2572,19 @@ def load_puzzles(filepath: str, max_puzzles: int = None) -> List[str]:
 easy_puzzles = load_puzzles(str(PUZZLES_DIR / 'Sudoku_Easy51.txt'), max_puzzles=10)
 hard_puzzles = load_puzzles(str(PUZZLES_DIR / 'Sudoku_hardest.txt'))
 print(f""Puzzles chargés: {len(easy_puzzles)} faciles, {len(hard_puzzles)} difficiles"")",,,,,,,,5fd28458ec828abf,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb,4769e092,markdown,fr,31ff7c5d08cdb9ec,"### Exercice 1 : Compter les contraintes initiales
+MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb,4769e092,markdown,fr,c4c06c04c564601c,"### Exercice 1 : Compter les contraintes initiales
 
-**Objectif** : Ecrire une fonction qui analyse une grille de Sudoku et compte les contraintes deja imposees par les valeurs initiales.
+**Objectif** : Ecrire une fonction qui analyse une grille de Sudoku et compte les contraintes déjà imposees par les valeurs initiales.
 
-**Contexte** : Avant de lancer un solveur, il est utile de savoir combien de contraintes sont deja fixees. Chaque cellule non vide impose une exclusion sur ses 20 voisins dans le graphe de contraintes (ligne + colonne + bloc). Le nombre de cellules fixees et le nombre total de contraintes d'exclusion donnent une idee de la difficulte du puzzle.
+**Contexte** : Avant de lancer un solveur, il est utile de savoir combien de contraintes sont déjà fixees. Chaque cellule non vide impose une exclusion sur ses 20 voisins dans le graphe de contraintes (ligne + colonne + bloc). Le nombre de cellules fixees et le nombre total de contraintes d'exclusion donnent une idee de la difficulte du puzzle.
 
-**Etapes** :
+**Étapes** :
 1. Parcourir les 81 cellules de la grille
 2. Compter le nombre de cellules non nulles (valeurs fixees)
 3. Pour chaque cellule fixee, compter ses voisins non nuls (contraintes binaires imposées)
 4. Retourner un dictionnaire avec `fixed_cells`, `total_constraints` et `empty_cells`
 
-**Indice** : Deux cellules sont en contrainte binaire si elles sont dans la meme ligne, colonne ou bloc. Attention a ne pas compter les doublons (pair A-B = pair B-A).",,,,,,,,31ff7c5d08cdb9ec,,,,,,,
+**Indice** : Deux cellules sont en contrainte binaire si elles sont dans la même ligne, colonne ou bloc. Attention a ne pas compter les doublons (pair A-B = pair B-A).",,,,,,,,c4c06c04c564601c,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb,5ca77913,code,fr,fddae4e291a3376e,"def count_initial_constraints(grid: SudokuGrid) -> dict:
     """"""
     Analyse les contraintes initiales d'une grille de Sudoku.
@@ -2706,19 +2706,19 @@ elapsed = (time.time() - start) * 1000
 print(f""\nRésolu: {solved} en {elapsed:.2f} ms"")
 print(""\nSolution:"")
 print(test_grid)",,,,,,,,8ce2c3097559ebd0,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb,1dfb84ca,markdown,fr,c255217295ef5fa7,"### Exercice 2 : Verifier la validite d'une solution avec OR-Tools
+MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb,1dfb84ca,markdown,fr,c1a2cac38df3de0e,"### Exercice 2 : Verifier la validite d'une solution avec OR-Tools
 
 **Objectif** : Ecrire une fonction qui utilise OR-Tools CP-SAT pour verifier qu'une grille Sudoku completée est valide.
 
-**Contexte** : Apres avoir resolu un puzzle, il est important de verifier que la solution respecte toutes les contraintes. Avec OR-Tools, on peut construire un modele qui encode la solution proposee et verifier si elle satisfait toutes les contraintes `AllDifferent`.
+**Contexte** : Après avoir resolu un puzzle, il est important de verifier que la solution respecte toutes les contraintes. Avec OR-Tools, on peut construire un modèle qui encode la solution proposee et verifier si elle satisfait toutes les contraintes `AllDifferent`.
 
-**Etapes** :
-1. Construire le modele CP-SAT avec les 81 variables
+**Étapes** :
+1. Construire le modèle CP-SAT avec les 81 variables
 2. Fixer chaque variable a la valeur de la grille proposee (utiliser `NewConstant`)
 3. Ajouter les 27 contraintes `AllDifferent` (9 lignes + 9 colonnes + 9 blocs)
-4. Resolver : si le modele est faisable, la solution est valide
+4. Resolver : si le modèle est faisable, la solution est valide
 
-**Indice** : Si la grille est valide, le solveur trouvera une solution immediatement. Si une contrainte est violee, le solveur retournerai `INFEASIBLE`. Cette methode est plus robuste qu'une verification manuelle car elle teste toutes les contraintes en un seul appel.",,,,,,,,c255217295ef5fa7,,,,,,,
+**Indice** : Si la grille est valide, le solveur trouvera une solution immediatement. Si une contrainte est violee, le solveur retournerai `INFEASIBLE`. Cette méthode est plus robuste qu'une verification manuelle car elle teste toutes les contraintes en un seul appel.",,,,,,,,c1a2cac38df3de0e,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb,bdea3db5,code,fr,40b00e3518836ffd,"def verify_solution_with_ortools(grid: SudokuGrid) -> bool:
     """"""
     Verifie qu'une grille Sudoku completee est valide en utilisant OR-Tools CP-SAT.
@@ -2743,7 +2743,7 @@ ortools_solver.solve(test_verify)  # Resoudre d'abord
 is_valid = verify_solution_with_ortools(test_verify)
 print(f""Solution valide : {is_valid}"")
 print(""Exercice a completer"")",,,,,,,,40b00e3518836ffd,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb,5llfojb1uvw,markdown,fr,c4171be77f3a9ccc,"### Interpretation : Resultat OR-Tools CP-SAT
+MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb,5llfojb1uvw,markdown,fr,97fd9aa3e73cdbe9,"### Interpretation : Résultat OR-Tools CP-SAT
 
 Le solveur OR-Tools a resolu un puzzle difficile en seulement 79.56 ms.
 
@@ -2751,15 +2751,15 @@ Le solveur OR-Tools a resolu un puzzle difficile en seulement 79.56 ms.
 |--------|--------|---------------|
 | **Temps de resolution** | 79.56 ms | Performance excellente |
 | **Statut** | FEASIBLE | Solution trouvee |
-| **Approche** | Declarative | Modele de contraintes, pas d'algorithme a ecrire |
+| **Approche** | Declarative | Modèle de contraintes, pas d'algorithme a ecrire |
 
 **Points cles** :
-1. **Simplicite du code** : Seuls 30 lignes pour definir le modele complet
-2. **Contrainte AllDifferent** : OR-Tools l'implemente de maniere tres efficace
-3. **Pas de parametrage** : L'heuristique par defaut fonctionne tres bien
+1. **Simplicite du code** : Seuls 30 lignes pour définir le modèle complet
+2. **Contrainte AllDifferent** : OR-Tools l'implemente de maniere très efficace
+3. **Pas de parametrage** : L'heuristique par defaut fonctionne très bien
 
-> **Note technique** : CP-SAT utilise la propagation de contraintes et l'apprentissage de conflits (CDCL) pour reduire rapidement l'espace de recherche.",,,,,,,,c4171be77f3a9ccc,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb,95rtxz9u43,markdown,fr,7395a8b0e6c64930,"## 3. Benchmark OR-Tools CP-SAT
+> **Note technique** : CP-SAT utilise la propagation de contraintes et l'apprentissage de conflits (CDCL) pour reduire rapidement l'espace de recherche.",,,,,,,,97fd9aa3e73cdbe9,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb,95rtxz9u43,markdown,fr,6282921d5add1cc8,"## 3. Benchmark OR-Tools CP-SAT
 
 Le benchmark evalue les performances du solveur OR-Tools CP-SAT sur des puzzles faciles et difficiles.
 
@@ -2769,7 +2769,7 @@ Le benchmark evalue les performances du solveur OR-Tools CP-SAT sur des puzzles 
 - **Temps moyen par puzzle** : Indicateur de la complexite moyenne
 - **Taux de resolution** : Devrait etre 100% (le solveur est complet)
 
-### Ce qu'on observe generalement
+### Ce qu'on observe généralement
 
 | Aspect | Performance |
 |--------|-------------|
@@ -2778,7 +2778,7 @@ Le benchmark evalue les performances du solveur OR-Tools CP-SAT sur des puzzles 
 | **Temps d'initialisation** : Negligeable |
 | **Overhead par puzzle** : Minimal |
 
-Le solveur OR-Tools est considerablement plus rapide que le backtracking simple. Son avantage principal est la **simplicite du code** et la **garantie de performance** meme sur des problemes plus complexes que le Sudoku standard.",,,,,,,,7395a8b0e6c64930,,,,,,,
+Le solveur OR-Tools est considerablement plus rapide que le backtracking simple. Son avantage principal est la **simplicite du code** et la **garantie de performance** même sur des problemes plus complexes que le Sudoku standard.",,,,,,,,6282921d5add1cc8,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb,322xetmzp7c,code,fr,00a17df893fefd94,"def benchmark_ortools(puzzles: List[str], name: str):
     """"""Evalue les performances du solveur OR-Tools CP-SAT.""""""
     print(f""\n{'='*60}"")
@@ -2813,17 +2813,17 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb,322xetmzp7c,code,fr,00a1
 # Benchmark
 benchmark_ortools(easy_puzzles, ""Puzzles Faciles"")
 benchmark_ortools(hard_puzzles, ""Puzzles Difficiles (Top 11)"")",,,,,,,,00a17df893fefd94,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb,gs8555282sd,markdown,fr,fbf6aa5c0fe1c80d,"## Exemple : Solveur OR-Tools CP-SAT pour le probleme des N-Reines
+MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb,gs8555282sd,markdown,fr,cf311c6afa8e051c,"## Exemple : Solveur OR-Tools CP-SAT pour le problème des N-Reines
 
-Cet exemple montre comment adapter la modelisation OR-Tools CP-SAT du Sudoku pour resoudre un probleme combinatoire classique : les N-Reines. L'objectif est de placer N reines sur un echiquier NxN sans qu'aucune ne puisse en capturer une autre, puis de compter toutes les solutions.
+Cet exemple montre comment adapter la modelisation OR-Tools CP-SAT du Sudoku pour resoudre un problème combinatoire classique : les N-Reines. L'objectif est de placer N reines sur un echiquier NxN sans qu'aucune ne puisse en capturer une autre, puis de compter toutes les solutions.
 
 ### Technique utilisee
 
 1. N variables `queen[i]` representant la colonne de la reine de la ligne i
 2. Contrainte `AddAllDifferent` pour les colonnes (une seule reine par colonne)
-3. Contraintes de diagonales via des variables auxiliaires : les diagonales montantes (`queen[i] - i`) et descendantes (`queen[i] + i`) doivent aussi etre toutes differentes
+3. Contraintes de diagonales via des variables auxiliaires : les diagonales montantes (`queen[i] - i`) et descendantes (`queen[i] + i`) doivent aussi etre toutes différentes
 4. Un `CpSolverSolutionCallback` pour compter et stocker toutes les solutions
-5. Verification : le solveur trouve bien 92 solutions pour N=8",,,,,,,,fbf6aa5c0fe1c80d,,,,,,,
+5. Verification : le solveur trouve bien 92 solutions pour N=8",,,,,,,,cf311c6afa8e051c,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb,obch45ox3ca,code,fr,a0a7546995a843a9,"from ortools.sat.python import cp_model
 
 class NQueensSolutionCounter(cp_model.CpSolverSolutionCallback):
@@ -2881,27 +2881,27 @@ for n in [4, 5, 6, 7, 8]:
     count = solve_n_queens(n)
     print(f""  N={n}: {count} solutions"")
 print(f""\nAttendus: N=4->2, N=5->10, N=6->4, N=7->40, N=8->92"")",,,,,,,,a0a7546995a843a9,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb,631a94a7,markdown,fr,7f9cc866b1814ba1,"## Exercice : Carre latin avec OR-Tools CP-SAT
+MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb,631a94a7,markdown,fr,5ba513df59cdacec,"## Exercice : Carre latin avec OR-Tools CP-SAT
 
 ### Enonce
 
 En vous inspirant de l'exemple des N-Reines ci-dessus, implementez un solveur de **carre latin** avec OR-Tools CP-SAT.
 
-Un carre latin de taille N est une grille NxN remplie avec les nombres de 1 a N, ou chaque nombre apparait **exactement une fois** dans chaque ligne et chaque colonne. C'est un probleme plus simple que le Sudoku (pas de contraintes de sous-blocs).
+Un carre latin de taille N est une grille NxN remplie avec les nombres de 1 a N, ou chaque nombre apparait **exactement une fois** dans chaque ligne et chaque colonne. C'est un problème plus simple que le Sudoku (pas de contraintes de sous-blocs).
 
-### Etapes a suivre
+### Étapes a suivre
 
-1. Creez un modele CP-SAT avec N x N variables entieres dans le domaine {1, ..., N}
+1. Créez un modèle CP-SAT avec N x N variables entieres dans le domaine {1, ..., N}
 2. Ajoutez la contrainte `AddAllDifferent` pour chaque ligne
 3. Ajoutez la contrainte `AddAllDifferent` pour chaque colonne
-4. Resolver le modele et extraire la solution
+4. Resolver le modèle et extraire la solution
 
 ### Indices
 
 - La modelisation est similaire au Sudoku, mais sans les contraintes de blocs 3x3
 - Utilisez `model.NewIntVar(1, n, ...)` pour les variables de la grille
 - Pour verifier : un carre latin 3x3 existe toujours (par exemple, une permutation cyclique des lignes)
-- Le nombre de carres latins croit tres rapidement avec N : 1, 1, 12, 576, 161280...",,,,,,,,7f9cc866b1814ba1,,,,,,,
+- Le nombre de carres latins croit très rapidement avec N : 1, 1, 12, 576, 161280...",,,,,,,,5ba513df59cdacec,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb,d32b39fe,code,fr,b0c3b2944f09d125,"def solve_latin_square(n: int) -> Optional[List[List[int]]]:
     """"""Resout le probleme du carre latin de taille NxN avec OR-Tools CP-SAT.
     
@@ -2942,9 +2942,9 @@ for n in [3, 4, 5, 6, 7]:
                 print(f""    {row}"")
     else:
         print(f""  N={n}: Aucune solution trouvee"")",,,,,,,,b0c3b2944f09d125,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb,rnozjwu8rs,markdown,fr,771b6ef485d875a8,"### Interpretation : Benchmark OR-Tools CP-SAT
+MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb,rnozjwu8rs,markdown,fr,2cc48f7ca64648f5,"### Interpretation : Benchmark OR-Tools CP-SAT
 
-Les resultats du benchmark montrent que OR-Tools CP-SAT resout tous les puzzles avec des temps excellents.
+Les résultats du benchmark montrent que OR-Tools CP-SAT resout tous les puzzles avec des temps excellents.
 
 | Aspect | Performance | Analyse |
 |--------|-------------|---------|
@@ -2970,7 +2970,7 @@ Ce notebook a presente l'approche declarative pour la resolution de Sudoku avec 
 | Approche | Type | Avantages | Inconvenients |
 |----------|------|-----------|---------------|
 | **Backtracking** | Imperatif | Simple, pedagogique | Lent sur puzzles difficiles |
-| **OR-Tools CP-SAT** | Declaratif | Tres rapide, API claire | Dependance externe |
+| **OR-Tools CP-SAT** | Declaratif | Très rapide, API claire | Dépendance externe |
 
 ### Recommandations
 
@@ -2986,11 +2986,11 @@ OR-Tools peut resoudre une grande variete de problemes :
 - Bin packing et cutting stock
 - Emploi du temps et allocation de ressources
 
-Le Sudoku est un excellent probleme pedagogique car il est facile a comprendre mais assez complexe pour illustrer les concepts cles de la programmation par contraintes.
+Le Sudoku est un excellent problème pedagogique car il est facile a comprendre mais assez complexe pour illustrer les concepts cles de la programmation par contraintes.
 
 ---
 
-**Navigation** : [<< Python Backtracking](Sudoku-1-Backtracking-Python.ipynb) | [Index](README.md) | [Z3 Python >>](Sudoku-12-Z3-Python.ipynb)",,,,,,,,771b6ef485d875a8,,,,,,,
+**Navigation** : [<< Python Backtracking](Sudoku-1-Backtracking-Python.ipynb) | [Index](README.md) | [Z3 Python >>](Sudoku-12-Z3-Python.ipynb)",,,,,,,,2cc48f7ca64648f5,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Csharp.ipynb,09f280ec,markdown,fr,3c701e1e92c3ec3e,"# Sudoku-11-Choco-Csharp : Solveur Choco via IKVM
 
 **Navigation** : [<< OR-Tools](Sudoku-10-ORTools-Csharp.ipynb) | [Index](README.md) | [Z3 >>](Sudoku-12-Z3-Csharp.ipynb)
@@ -3544,7 +3544,7 @@ stopwatch.Stop();
 
 Console.WriteLine($""\nSolution trouvee en {stopwatch.ElapsedMilliseconds} ms:"");
 Console.WriteLine(solution);",,,,,,,,cc0df62e8a5df296,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Csharp.ipynb,8ce31cbf,markdown,fr,3c454bfd7eee7308,"## 4. Comparaison des Stratégies
+MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Csharp.ipynb,8ce31cbf,markdown,fr,c58d618d5bd83ff3,"## 4. Comparaison des Stratégies
 
 ### Heuristiques de Choix de Variables
 
@@ -3552,7 +3552,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Csharp.ipynb,8ce31cbf,markdown,fr,3c454
 |-----------|-------------|------------|
 | **InputOrder** | Ordre de déclaration | O(1) |
 | **FirstFail** | Domaine minimum (MRV) | O(n) |
-| **DomOverWDeg** | Domaine / Degre pondere | O(n * d) |
+| **DomOverWDeg** | Domaine / Degré pondere | O(n * d) |
 | **ConflictHistory** | Historique des conflits | O(n * log n) |
 
 ### Heuristiques de Choix de Valeurs
@@ -3562,7 +3562,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Csharp.ipynb,8ce31cbf,markdown,fr,3c454
 | **IntDomainMin** | Plus petite valeur |
 | **IntDomainMax** | Plus grande valeur |
 | **IntDomainRandom** | Valeur aleatoire |
-| **IntDomainMiddle** | Valeur mediane |",,,,,,,,3c454bfd7eee7308,,,,,,,
+| **IntDomainMiddle** | Valeur mediane |",,,,,,,,c58d618d5bd83ff3,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Csharp.ipynb,45bbc7a1,markdown,fr,4b78316fcd036530,"## Exercice : Comptage de solutions avec Choco
 
 **Objectif :**
@@ -3682,11 +3682,11 @@ A la fin de ce notebook, vous saurez :
 **Durée estimée** : 30-40 minutes
 **Prérequis** : Aucun connaissance de Java requise (interface Python via JPype)
 **Langage** : Python 3 avec JPype pour Choco",,,,,,,,b0e3000ed09a3d0c,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Python.ipynb,intro-choco,markdown,fr,5961a7a991d540ca,"## Introduction : Qu'est-ce que Choco-solver?
+MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Python.ipynb,intro-choco,markdown,fr,6b56dd880c7e46f7,"## Introduction : Qu'est-ce que Choco-solver?
 
 [Choco-solver](https://github.com/chocoteam/choco-solver) est une librairie open-source **Java** de résolution de problèmes de Programmation par Contraintes (CP), développée par l'équipe **TASC** (Constraint Programming) de l'Université de Nantes.
 
-### Historique et Caracteristiques
+### Historique et Caractéristiques
 
 - **1999** : Première version développée a l'Université de Nantes
 - **2008-2015** : Version 3 avec architecture modulaire
@@ -3700,7 +3700,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Python.ipynb,intro-choco,markdown,fr,59
 | **Variables** | Entières (IntVar), Booléennes (BoolVar), Ensembles (SetVar), Graphes (GraphVar) |
 | **Contraintes** | allDifferent, arithmétiques, logiques, globales, table, etc. |
 | **Propagation** | AC-3, AC-2001, Bound Consistency |
-| **Strategies** | Heuristiques de choix de variables et de valeurs |
+| **Stratégies** | Heuristiques de choix de variables et de valeurs |
 | **Explications** : Conflict-Based Backjumping (CBJ), Dynamic Backtracking |
 
 ### Choco vs Autres Solveurs
@@ -3717,7 +3717,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Python.ipynb,intro-choco,markdown,fr,59
 Le Sudoku est un **problème de référence** pour Choco car :
 - Il utilise massivement la contrainte `allDifferent` (27 fois)
 - Les stratégies de choix de variables ont un impact majeur
-- C'est un problème purement combinatoire (pas de fonction objectif)",,,,,,,,5961a7a991d540ca,,,,,,,
+- C'est un problème purement combinatoire (pas de fonction objectif)",,,,,,,,6b56dd880c7e46f7,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Python.ipynb,imports,code,fr,5e87bce0b04ae3b7,"# Installation des dépendances
 import sys
 import subprocess
@@ -3976,11 +3976,11 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Python.ipynb,75b45d38,markdown,fr,8de38
 4. Les puzzles proviennent de sources différentes : Easy51 (faciles), hardest (Arto Inkala)
 
 > **Note technique** : Les fichiers de puzzles utilisent le caractère `0` ou `.` pour les cases vides. La conversion en grille 9x9 remplace ces caractères par 0 pour faciliter le traitement algorithmique (0 = ""pas de valeur"").",,,,,,,,8de38b0692a130d4,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Python.ipynb,modelisation,markdown,fr,71b8d283867d716e,"## Modelisation du Sudoku comme CSP avec Choco
+MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Python.ipynb,modelisation,markdown,fr,75763317fea2152c,"## Modelisation du Sudoku comme CSP avec Choco
 
 ### Définition du Problème
 
-Un Sudoku est un problème de Satisfaction de Contraintes (CSP) defini par :
+Un Sudoku est un problème de Satisfaction de Contraintes (CSP) défini par :
 
 1. **Variables** : 81 variables $X_{i,j}$ pour chaque case (i,j) de la grille
 2. **Domaines** : $D_{i,j} = \{1, ..., 9\}$ pour chaque variable (ou $\{v\}$ si la case est pre-remplie)
@@ -3993,7 +3993,7 @@ Un Sudoku est un problème de Satisfaction de Contraintes (CSP) defini par :
 
 - **Contrainte `allDifferent` globale** : Plus efficace que $\binom{9}{2} = 36$ contraintes binaires $x_i \neq x_j$
 - **Propagation automatique** : Reduction des domaines lors de l'assignation
-- **Strategies configurables** : Heuristiques de choix de variables/valeurs",,,,,,,,71b8d283867d716e,,,,,,,
+- **Stratégies configurables** : Heuristiques de choix de variables/valeurs",,,,,,,,75763317fea2152c,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Python.ipynb,choco-solver-class,code,fr,6e677a67f0351f3c,"import time
 from typing import List, Optional
 
@@ -4108,9 +4108,9 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Python.ipynb,0434737d,markdown,fr,d3cba
 4. La méthode `getValue()` extrait les valeurs des variables Choco vers Python
 
 > **Note technique** : La modélisation utilise 27 contraintes `allDifferent` au lieu de 972 contraintes binaires $x_i \neq x_j$. Cette contrainte globale est implémentée de facon optimisee dans Choco avec un algorithme de propagation de complexite $O(n)$ au lieu de $O(n^2)$.",,,,,,,,d3cbae926d79ff4d,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Python.ipynb,7acb4b52,markdown,fr,fd8fb7d3d1607af2,"### Exercice : Génération d'une grille de Sudoku valide
+MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Python.ipynb,7acb4b52,markdown,fr,b5249ac01faaae94,"### Exercice : Génération d'une grille de Sudoku valide
 
-Tous les exemples précédents partent d'une grille pre-remplie a résoudre. Mais comment les grilles de Sudoku sont-elles creees en premier lieu ? L'objectif de cet exercice est de **générer** une grille de Sudoku complète et valide, puis de la transformer en puzzle en retirant des valeurs.
+Tous les exemples précédents partent d'une grille pre-remplie a résoudre. Mais comment les grilles de Sudoku sont-elles créées en premier lieu ? L'objectif de cet exercice est de **générer** une grille de Sudoku complète et valide, puis de la transformer en puzzle en retirant des valeurs.
 
 **Principe** : un Sudoku complet n'est qu'une solution particuliere d'un CSP sans valeurs initiales. Choco peut donc en générer un simplement en resolvant un modèle vide (81 variables libres + 27 contraintes allDifferent, sans aucune valeur fixee).
 
@@ -4123,7 +4123,7 @@ Tous les exemples précédents partent d'une grille pre-remplie a résoudre. Mai
 **Indices** :
 - L'étape 1 réutilise exactement le même schéma que `ChocoSudokuSolver.solve()`, mais sans la boucle qui fixe les valeurs initiales
 - Pour l'étape 3, utiliser `random.sample(range(81), 81 - n_clues)` pour choisir les positions a vider
-- Pour l'étape 4, résoudre le puzzle puis chercher une seconde solution ; s'il n'y en a qu'une, le puzzle est valide",,,,,,,,fd8fb7d3d1607af2,,,,,,,
+- Pour l'étape 4, résoudre le puzzle puis chercher une seconde solution ; s'il n'y en a qu'une, le puzzle est valide",,,,,,,,b5249ac01faaae94,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Python.ipynb,ae43e874,code,fr,c632663fb922eeee,"import random
 
 def generate_sudoku(n_clues: int = 30, seed: int = 42) -> tuple:
@@ -4156,7 +4156,7 @@ def generate_sudoku(n_clues: int = 30, seed: int = 42) -> tuple:
     return (None, None)  # TODO étudiant : remplacer
 
 print(""Exercice a completer : generation de Sudoku"")",,,,,,,,c632663fb922eeee,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Python.ipynb,strategies,markdown,fr,4151afd26cc8ddf3,"## Strategies de Recherche dans Choco
+MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Python.ipynb,strategies,markdown,fr,7b8bc932799bd1e5,"## Stratégies de Recherche dans Choco
 
 La performance d'un solveur CP dépend grandement de la stratégie de choix de variables et de valeurs. Choco propose plusieurs heuristiques eprouvees.
 
@@ -4164,7 +4164,7 @@ La performance d'un solveur CP dépend grandement de la stratégie de choix de v
 
 | Stratégie | Description | Avantages | Inconvenients |
 |-----------|-------------|-----------|---------------|
-| **InputOrder** | Ordre d'entrée des variables | Simple, deterministe | Ignore la structure du problème |
+| **InputOrder** | Ordre d'entrée des variables | Simple, déterministe | Ignore la structure du problème |
 | **DomOverWDeg** | Domaine minimum sur degré maximum | Excellent pour Sudoku, adapte l'ordre | Plus complexe |
 | **Impact** | Basé sur l'impact historique | S'adapte pendant la recherche | Cout de calcul initial |
 | **CBC** (Conflict-Based) | Choix basé sur les conflits | Evite les répétitions | Necessite historique |
@@ -4177,7 +4177,7 @@ La performance d'un solveur CP dépend grandement de la stratégie de choix de v
 
 Cette stratégie est particulièrement efficace pour Sudoku car :
 - Les cases avec peu de valeurs possibles sont traitees en premier (MRV)
-- Les cases impliquees dans beaucoup de contraintes violées sont prioritaires",,,,,,,,4151afd26cc8ddf3,,,,,,,
+- Les cases impliquees dans beaucoup de contraintes violées sont prioritaires",,,,,,,,7b8bc932799bd1e5,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Python.ipynb,strategy-comparison,code,fr,d13992ec9e8ea95b,"def benchmark_strategies(puzzles, limit=5):
     """"""Compare differentes executions de Choco.""""""
     results = {
@@ -4344,11 +4344,11 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Python.ipynb,37cc50e5,code,fr,5a2bdd057
     return {""solution"": None, ""time_ms"": 0.0, ""timeout_reached"": False}  # TODO etudiant : remplacer
 
 print(""Exercice a completer : resolution avec timeout"")",,,,,,,,5a2bdd057fa8da4b,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Python.ipynb,comparison,markdown,fr,b84c822a85ada3d2,"## Comparaison : Choco vs OR-Tools vs python-constraint
+MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Python.ipynb,comparison,markdown,fr,fb08d281518a8253,"## Comparaison : Choco vs OR-Tools vs python-constraint
 
 ### Tableau Comparatif
 
-| Caracteristique | Choco | OR-Tools CP-SAT | python-constraint |
+| Caractéristique | Choco | OR-Tools CP-SAT | python-constraint |
 |-----------------|-------|-----------------|-------------------|
 | **Langage** | Java (+JPype pour Python) | C++ (Python wrapper) | Python natif |
 | **Contrainte allDifferent** | Oui (optimisee) | Oui | Oui |
@@ -4372,7 +4372,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Python.ipynb,comparison,markdown,fr,b84
 | Facile | ~50 ms | ~10 ms | ~500 ms |
 | Moyen | ~200 ms | ~50 ms | ~5000 ms |
 | Difficile | ~1000 ms | ~200 ms | Timeout |
-| Hardest | ~5000 ms | ~1000 ms | Echec |",,,,,,,,b84c822a85ada3d2,,,,,,,
+| Hardest | ~5000 ms | ~1000 ms | Echec |",,,,,,,,fb08d281518a8253,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Python.ipynb,visualization,code,fr,b44d7281cd109298,"# Visualisation d une solution avec matplotlib
 import matplotlib.pyplot as plt
 import matplotlib.patches as patches
@@ -4538,7 +4538,7 @@ class ChocoSudokuDiagonalSolver:
 # print(f""Solution avec diagonales : {diagonal_solution is not None}"")
 
 print(""Exercice Choco a implementer !"")",,,,,,,,af15e0676eb0b809,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Python.ipynb,conclusion,markdown,fr,307de36a99ad6cc5,"## Conclusion
+MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Python.ipynb,conclusion,markdown,fr,fb4ac436b4315e9f,"## Conclusion
 
 Dans ce notebook, nous avons :
 
@@ -4567,7 +4567,7 @@ Dans ce notebook, nous avons :
 | [Sudoku-10-ORTools](./Sudoku-10-ORTools-Python.ipynb) | CP-SAT vs Choco: deux approches CP différentes |
 | [Sudoku-6-AIMA-CSP](./Sudoku-6-AIMA-CSP-Python.ipynb) | Théorie des CSP et backtracking |
 | [Sudoku-12-Z3](./Sudoku-12-Z3-Python.ipynb) | SMT solving vs Constraint Programming |
-| [CSP-1-Fondamentaux](../Search/Part2-CSP/CSP-1-Fundamentals.ipynb) | Fondements theoriques des CSP |
+| [CSP-1-Fondamentaux](../Search/Part2-CSP/CSP-1-Fundamentals.ipynb) | Fondements théoriques des CSP |
 
 ---
 
@@ -4580,8 +4580,8 @@ Dans ce notebook, nous avons :
 ---
 
 **Retour au sommaire** : [Index Sudoku](README.md)
-",,,,,,,,307de36a99ad6cc5,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb,89962877,markdown,fr,1cf51b1411cfe83a,"# Sudoku-12 : Résolution avec Z3 SMT Solver (C#)
+",,,,,,,,fb4ac436b4315e9f,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb,89962877,markdown,fr,a0c5828c4153fffa,"# Sudoku-12 : Résolution avec Z3 SMT Solver (C#)
 
 **Navigation** : [<< Sudoku-11 Choco C#](Sudoku-11-Choco-Csharp.ipynb) | [Index](README.md) | [Sudoku-13 Symbolic Automata C# >>](Sudoku-13-SymbolicAutomata-Csharp.ipynb)
 
@@ -4607,7 +4607,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb,89962877,markdown,fr,1cf51b14
 
 ## Introduction à Z3
 
-Z3 est un SMT solver (Satisfiability Modulo Theories) qui peut être utilisé pour résoudre des problèmes de logique du premier ordre. Il permet de vérifier la satisfiabilité d'une formule logique sous certaines contraintes et est particulièrement efficace pour résoudre des problèmes impliquant des contraintes complexes, comme les puzzles de Sudoku.
+Z3 est un SMT solver (Satisfiability Modulo Théories) qui peut être utilisé pour résoudre des problèmes de logique du premier ordre. Il permet de vérifier la satisfiabilité d'une formule logique sous certaines contraintes et est particulièrement efficace pour résoudre des problèmes impliquant des contraintes complexes, comme les puzzles de Sudoku.
 
 Un SMT solver combine des techniques de résolution SAT (Satisfiability) avec des théories comme l'arithmétique, les tableaux, les bit-vectors, etc., permettant ainsi de résoudre des problèmes logiques beaucoup plus riches.
 
@@ -4616,7 +4616,7 @@ Un SMT solver combine des techniques de résolution SAT (Satisfiability) avec de
 - [Programming Z3](https://theory.stanford.edu/~nikolaj/programmingz3.html)
 - [Z3Py Guide Examples](https://ericpony.github.io/z3py-tutorial/guide-examples.htm) en Python
 
-## Configuration de l'environnement",,,,,,,,1cf51b1411cfe83a,,,,,,,
+## Configuration de l'environnement",,,,,,,,a0c5828c4153fffa,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb,9016b055,code,fr,56f6be7ee3fa2ca0,"#r ""nuget: Microsoft.Z3""",,,,,,,,56f6be7ee3fa2ca0,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb,5f811f2c,markdown,fr,03bf47fc69a84cef,"## Importation des Classes de Base
 
@@ -5395,7 +5395,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb,f1929938,markdown,fr,a650eb78
 **Voir aussi** : 
 - [CSP-3-Avance](../Search/Part2-CSP/CSP-3-Advanced.ipynb) - Contraintes globales avancees
 - [SymbolicAI](../SymbolicAI/README.md) - Série sur l'IA symbolique et Z3",,,,,,,,a650eb784475de6b,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb,z3-header,markdown,fr,22fa6401e8975cd1,"# Sudoku-12-Z3-Python : Z3 SMT Solver (Python)
+MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb,z3-header,markdown,fr,23fb25095e0813bb,"# Sudoku-12-Z3-Python : Z3 SMT Solver (Python)
 
 **Navigation** : [<< OR-Tools Python](Sudoku-10-ORTools-Python.ipynb) | [Index](README.md) | [Infer Python >>](Sudoku-15-Infer-Python.ipynb)
 
@@ -5403,7 +5403,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb,z3-header,markdown,fr,22fa640
 
 A la fin de ce notebook, vous saurez :
 1. Modeliser le Sudoku avec un solveur SMT (Z3)
-2. Comprendre la difference entre SAT et SMT
+2. Comprendre la différence entre SAT et SMT
 3. Utiliser des BitVectors pour optimiser les representations
 4. Comparer Z3 Int avec Z3 BitVector
 
@@ -5411,7 +5411,7 @@ A la fin de ce notebook, vous saurez :
 
 ---
 
-Ce notebook implemente un solveur de Sudoku utilisant **Microsoft Z3**, un solveur **SMT** (Satisfiability Modulo Theories).
+Ce notebook implemente un solveur de Sudoku utilisant **Microsoft Z3**, un solveur **SMT** (Satisfiability Modulo Théories).
 
 Cette approche est equivalente au notebook C# `Sudoku-12-Z3-Csharp.ipynb`.
 
@@ -5419,7 +5419,7 @@ Cette approche est equivalente au notebook C# `Sudoku-12-Z3-Csharp.ipynb`.
 
 ```bash
 pip install z3-solver
-```",,,,,,,,22fa6401e8975cd1,,,,,,,
+```",,,,,,,,23fb25095e0813bb,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb,ce562fc7,code,fr,be31ad7303a368af,"# Imports
 import time
 from typing import List, Optional, Tuple
@@ -5431,7 +5431,7 @@ try:
     print(f""Z3 importe avec succes"")
 except ImportError:
     print(""Z3 non installe. Executez: pip install z3-solver"")",,,,,,,,be31ad7303a368af,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb,z3-intro,markdown,fr,c72fc8ad43485023,"## 1. Solveur Z3 SMT**Microsoft Z3** est un solveur **SMT** (Satisfiability Modulo Theories) - il combine la puissance des solveurs SAT avec des théories mathématiques (arithmétique, tableaux, bitvectors, etc.).",,,,,,,,c72fc8ad43485023,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb,z3-intro,markdown,fr,b9d2629e94565f88,"## 1. Solveur Z3 SMT**Microsoft Z3** est un solveur **SMT** (Satisfiability Modulo Théories) - il combine la puissance des solveurs SAT avec des théories mathématiques (arithmétique, tableaux, bitvectors, etc.).",,,,,,,,b9d2629e94565f88,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb,z3-theory,markdown,fr,b59bfef6e27b7852,"### Différence entre SAT et SMT
 
 | SAT | SMT |
@@ -5455,14 +5455,14 @@ if PUZZLES_DIR.exists():
 else:
     print(f""ATTENTION: Dossier Puzzles non trouve a {PUZZLES_DIR}"")
     PUZZLES_DIR = Path(os.getcwd()) / ""Puzzles""",,,,,,,,9fd2e4b925dc2904,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb,f6997cbf,markdown,fr,c1bb394ee84b4f31,"## 3. Solveurs Z3 : Int et BitVector
+MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb,f6997cbf,markdown,fr,56ccee2d2564988d,"## 3. Solveurs Z3 : Int et BitVector
 
 Nous presentons deux approches pour encoder le Sudoku avec Z3 :
 
 - **Z3 Int** : variables entieres symboliques (Int), encodage classique.
 - **Z3 BitVector** : variables BitVec 4 bits, optimisation pour plages bornees.
 
-Nous definissons d'abord une representation de la grille, puis comparons les deux encodages sur les memes puzzles.",,,,,,,,c1bb394ee84b4f31,,,,,,,
+Nous definissons d'abord une representation de la grille, puis comparons les deux encodages sur les mêmes puzzles.",,,,,,,,56ccee2d2564988d,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb,c0d8af3c2d9b36c,markdown,fr,c9ff410d4da5136e,Representation de la grille Sudoku avec fonctions de chargement.,,,,,,,,c9ff410d4da5136e,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb,b26eb748,code,fr,5fd28458ec828abf,"class SudokuGrid:
     """"""Représentation d'une grille de Sudoku 9x9.""""""
@@ -5577,7 +5577,7 @@ elapsed = (time.time() - start) * 1000
 print(f""\nRésolu: {solved} en {elapsed:.2f} ms"")
 print(""\nSolution:"")
 print(test_grid)",,,,,,,,7e27b916479e00e9,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb,2uoak5nyx4b,markdown,fr,3e78a48c98d0aee0,"### Interpretation : Resultat Z3 Int
+MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb,2uoak5nyx4b,markdown,fr,c4824211dfc2ffac,"### Interpretation : Résultat Z3 Int
 
 Le solveur Z3 avec des entiers a resolu le puzzle difficile en 340.86 ms.
 
@@ -5588,14 +5588,14 @@ Le solveur Z3 avec des entiers a resolu le puzzle difficile en 340.86 ms.
 | **Type de variables** | Int | Entiers symboliques |
 
 **Points cles** :
-1. **API simple** : La contrainte `Distinct` est tres expressive
-2. **Theorie des entiers** : Z3 utilise QF_LIA (Linear Integer Arithmetic)
-3. **Flexibilite** : Z3 peut facilement etendre le modele avec d'autres contraintes
+1. **API simple** : La contrainte `Distinct` est très expressive
+2. **Théorie des entiers** : Z3 utilise QF_LIA (Linear Integer Arithmetic)
+3. **Flexibilite** : Z3 peut facilement etendre le modèle avec d'autres contraintes
 
-> **Note technique** : La contrainte `Distinct` de Z3 est plus puissante que l'inegalite binaire car elle permet au solveur d'utiliser des algorithmes specialised pour la propagation.",,,,,,,,3e78a48c98d0aee0,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb,923c65fa,markdown,fr,e66d8c135fa6586b,"### Exercice : Contrainte de somme sur un bloc (Killer Sudoku)
+> **Note technique** : La contrainte `Distinct` de Z3 est plus puissante que l'inegalite binaire car elle permet au solveur d'utiliser des algorithmes specialised pour la propagation.",,,,,,,,c4824211dfc2ffac,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb,923c65fa,markdown,fr,1ee7fbf4ad07198b,"### Exercice : Contrainte de somme sur un bloc (Killer Sudoku)
 
-Le solveur Z3 avec `Int` permet d'ajouter facilement des contraintes arithmetiques. Le **Killer Sudoku** est une variante ou des groupes de cellules doivent satisfaire une somme cible. Implementez un solveur qui ajoute une contrainte `Sum(valeurs du bloc) == target_sum` sur un bloc 3x3 specifique. La somme naturelle d'un bloc est 1+2+...+9 = 45.",,,,,,,,e66d8c135fa6586b,,,,,,,
+Le solveur Z3 avec `Int` permet d'ajouter facilement des contraintes arithmetiques. Le **Killer Sudoku** est une variante ou des groupes de cellules doivent satisfaire une somme cible. Implementez un solveur qui ajoute une contrainte `Sum(valeurs du bloc) == target_sum` sur un bloc 3x3 spécifique. La somme naturelle d'un bloc est 1+2+...+9 = 45.",,,,,,,,1ee7fbf4ad07198b,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb,7abaad82,code,fr,b9bc10f4d3aeec0a,"def solve_with_sum_constraint(grid: SudokuGrid, block_row: int, block_col: int, target_sum: int) -> bool:
     """"""
     Resout un Sudoku avec une contrainte supplementaire de somme sur un bloc 3x3.
@@ -5695,7 +5695,7 @@ for i, puzzle_str in enumerate(hard_puzzles[:5]):
     
     print(f""  Z3 Int:      {t1:>8.2f} ms"")
     print(f""  Z3 BitVec:   {t2:>8.2f} ms"")",,,,,,,,8d57cec94297f430,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb,imahujoijal,markdown,fr,a3211e0add82af67,"### Interpretation : Z3 Int vs BitVector
+MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb,imahujoijal,markdown,fr,09d3a30edfaee4c1,"### Interpretation : Z3 Int vs BitVector
 
 La comparaison montre que l'utilisation de **BitVectors 4 bits** est significativement plus rapide que les entiers.
 
@@ -5708,12 +5708,12 @@ La comparaison montre que l'utilisation de **BitVectors 4 bits** est significati
 | Puzzle 5 | 237.59 ms | 105.18 ms | **2.3x plus rapide** |
 
 **Points cles** :
-1. **BitVectors sont plus proches du hardware** : Z3 peut utiliser des operations bit-level
+1. **BitVectors sont plus proches du hardware** : Z3 peut utiliser des opérations bit-level
 2. **Domaine restreint** : 4 bits = 16 valeurs, exactement ce qu'il faut pour 1-9
 3. **Propagation plus efficace** : Les contraintes bit-level sont plus simples a propager
 
-> **Note technique** : Les BitVectors sont representes en precision fixe (4 bits ici), ce qui permet a Z3 d'utiliser des algorithmes de propagation plus efficaces. Les entiers symboliques en Z3 ont une precision arbitraire, ce qui ajoute de la complexite.",,,,,,,,a3211e0add82af67,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb,64d13639,markdown,fr,387b1096c5206eae,"## 4. Resume et conclusions
+> **Note technique** : Les BitVectors sont representes en precision fixe (4 bits ici), ce qui permet a Z3 d'utiliser des algorithmes de propagation plus efficaces. Les entiers symboliques en Z3 ont une precision arbitraire, ce qui ajoute de la complexite.",,,,,,,,09d3a30edfaee4c1,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb,64d13639,markdown,fr,0fcb633ab9e5243c,"## 4. Resume et conclusions
 
 Ce notebook a presente deux approches Z3 pour resoudre le Sudoku : avec des entiers symboliques et avec des BitVectors.
 
@@ -5728,7 +5728,7 @@ Ce notebook a presente deux approches Z3 pour resoudre le Sudoku : avec des enti
 
 - **Simplicite** : Z3 Int avec la contrainte `Distinct`
 - **Performance** : Z3 BitVec pour les domaines restreints
-- **Flexibilite** : Z3 supporte de nombreuses theories (arithmetique, tableaux, etc.)
+- **Flexibilite** : Z3 supporte de nombreuses théories (arithmetique, tableaux, etc.)
 
 ### Au-dela du Sudoku
 
@@ -5738,11 +5738,11 @@ Z3 peut resoudre une grande variete de problemes :
 - Synthese de code
 - Theoremes de logique
 
-Le Sudoku est un excellent probleme pedagogique pour comprendre la difference entre SAT (propositionnel) et SMT (theories).
+Le Sudoku est un excellent problème pedagogique pour comprendre la différence entre SAT (propositionnel) et SMT (théories).
 
 ---
 
-**Navigation** : [<< OR-Tools Python](Sudoku-10-ORTools-Python.ipynb) | [Index](README.md) | [Infer Python >>](Sudoku-15-Infer-Python.ipynb)",,,,,,,,387b1096c5206eae,,,,,,,
+**Navigation** : [<< OR-Tools Python](Sudoku-10-ORTools-Python.ipynb) | [Index](README.md) | [Infer Python >>](Sudoku-15-Infer-Python.ipynb)",,,,,,,,0fcb633ab9e5243c,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb,tkp1ie77lp,markdown,fr,07b0c3b277443199,"## 5. Exercices et exemples guides
 
 Cette section contient :
@@ -5753,14 +5753,14 @@ Cette section contient :
 
 Chaque bloc est clairement marque comme ""exercice"" (a completer) ou ""exemple"" (solution complete).
 ",,,,,,,,07b0c3b277443199,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb,e023cbf7,markdown,fr,593337a5062140d3,"### Exercice 1 : Compter le nombre de solutions
+MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb,e023cbf7,markdown,fr,14a56c6fe572c211,"### Exercice 1 : Compter le nombre de solutions
 
 Implementez un solveur Z3 qui compte le nombre total de solutions d'une grille de Sudoku.
 
 **Indices** :
 - Utiliser `Solver()` et ajouter les contraintes classiques
-- Apres chaque `s.check() == sat`, ajouter une contrainte excluant le modele trouve (`s.add(Not(And([cells[r][c] == m.evaluate(cells[r][c]) for r in range(9) for c in range(9)])))`)
-- Compter les iterations jusqu'a `unsat`",,,,,,,,593337a5062140d3,,,,,,,
+- Après chaque `s.check() == sat`, ajouter une contrainte excluant le modèle trouve (`s.add(Not(And([cells[r][c] == m.evaluate(cells[r][c]) for r in range(9) for c in range(9)])))`)
+- Compter les itérations jusqu'a `unsat`",,,,,,,,14a56c6fe572c211,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb,1a64a347a19917fb,code,fr,f43f2e5b6726f1a3,"# TODO: Implementer Z3SolutionCounter
 #
 # Probleme : compter le nombre de solutions d'une grille Sudoku
@@ -5891,24 +5891,24 @@ if diagonal_solver.solve(diag_grid):
     print(f""Diagonale secondaire : {diag2} — tous distincts : {len(set(diag2)) == 9}"")
 else:
     print(""Pas de solution"")",,,,,,,,68baf6207291d252,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb,96e575c4,markdown,fr,3c15d460217259ff,"### Exercice 2 : Coloration de graphe avec Z3
+MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb,96e575c4,markdown,fr,3d8fb7ce4b7d65ad,"### Exercice 2 : Coloration de graphe avec Z3
 
 Z3 n'est pas limite au Sudoku ! Il peut resoudre de nombreux problemes de satisfaction de contraintes.
 
 **Objectif** : Implementer un solveur de **coloration de graphe** (graph coloring) avec Z3.
 
-Le probleme consiste a colorier une carte de regions avec un nombre minimum de couleurs,
-de sorte que deux regions voisines (partageant une frontiere) n'aient jamais la meme couleur.
+Le problème consiste a colorier une carte de regions avec un nombre minimum de couleurs,
+de sorte que deux regions voisines (partageant une frontiere) n'aient jamais la même couleur.
 
 **Theoreme des 4 couleurs** : toute carte plane peut etre coloriee avec au plus 4 couleurs.
 
-**Etapes** :
+**Étapes** :
 1. Modeliser chaque region par une variable entiere `Int` representant sa couleur (0 a 3)
 2. Ajouter les contraintes de domaine : `0 <= couleur <= 3`
 3. Pour chaque paire de regions voisines, ajouter la contrainte `couleur_i != couleur_j`
 4. Resoudre avec `solver.check() == sat` et extraire la coloration
 
-> **Code a completer dans la cellule suivante**",,,,,,,,3c15d460217259ff,,,,,,,
+> **Code a completer dans la cellule suivante**",,,,,,,,3d8fb7ce4b7d65ad,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb,4a506113,code,fr,7c3cdd926448bbac,"# TODO: Implementer un solveur de coloration de graphe avec Z3
 #
 # Probleme : colorier les regions de la carte de France metropolitaine
@@ -6059,7 +6059,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb,a3163cc0,markdo
 Ce monstre démontre par l'absurde que **détourner le backtracking d'un moteur regex pour faire de la recherche** conduit à une représentation illisible. La contrainte d'unicité Sudoku n'est *pas* naturelle en PCRE : elle s'exprime en empilant des lookaheads négatifs sur les cellules déjà posées. La forme déroulée *tourne* (section 8) mais reste illisible et, on le verra, non portable d'un moteur à l'autre ; la forme récursive `(?R)` ne tourne même pas en .NET.
 
 La bonne représentation, c'est l'**intersection déclarative** de contraintes (`Ligne & Colonne & Bloc`) - portée proprement par RE# pour la reconnaissance (sections 4-5) et par Z3 pour la production du témoin (section 6). C'est exactement ce que cherchait l'approche 2020.",,,,,,,,70f07bd4deacf583,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb,e1d5ed3a,markdown,fr,f94167f97bff06eb,"## 3. Barreau 2 - La tentative 2020 : BREX, Rex et le mur
+MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb,e1d5ed3a,markdown,fr,e35ba261caeca6fa,"## 3. Barreau 2 - La tentative 2020 : BREX, Rex et le mur
 
 En 2020, l'auteur s'appuie sur la chaîne d'outils symboliques de Margus Veanes (**AutomataDotNet**) pour réaliser l'intersection déclarative. Deux briques existaient, vérifiées par lecture du source au commit `0242132f` :
 
@@ -6069,7 +6069,7 @@ En 2020, l'auteur s'appuie sur la chaîne d'outils symboliques de Margus Veanes 
 var man  = new BREXManager();
 var like1 = man.MkLike(@""%[ab]_____"");
 var like2 = man.MkLike(@""%[bc]_____"");
-var and   = man.MkAnd(like1, like2);   // l'intersection : une METHODE, pas un '&' dans la chaîne
+var and   = man.MkAnd(like1, like2);   // l'intersection : une MÉTHODE, pas un '&' dans la chaîne
 var dfa   = and.Optimize();
 ```
 
@@ -6082,7 +6082,7 @@ var dfa   = and.Optimize();
 | **Explosion d'états** | `BREXTests.cs` porte les commentaires `//fails due to timeout` et `//fails due to too many states` - l'intersection de deux `MkLike` de **8-9 underscores seulement** fait exploser le DFA via `Optimize()` | L'intersection symbolique est trop chère à déterminiser |
 | **Cap du témoin à 21 caractères** | Issue upstream [AutomataDotNet/Automata#6](https://github.com/AutomataDotNet/Automata/issues/6) (créée le 2020-12-07, **toujours 0 réponse**) : le chemin SFAz3+Z3 tronque le modèle | On ne peut pas produire une grille-témoin完整e |
 
-Le bloc C# ci-dessus illustre la *forme* de l'approche 2020 : un spaghetti de builders (`MkAnd(MkLike(...), ...)`) et de strings, pas encore la chaîne monolithique élégante - et, surtout, barre par les deux murs ci-dessus. Le notebook ne *rejoue* pas ce code (AutomataDotNet est un projet Microsoft abandonné) : il en montre le squelette, puis passe au fork moderne (section 6b) qui, lui, *exécute* la voie regex -> théorie des chaînes.",,,,,,,,f94167f97bff06eb,,,,,,,
+Le bloc C# ci-dessus illustre la *forme* de l'approche 2020 : un spaghetti de builders (`MkAnd(MkLike(...), ...)`) et de strings, pas encore la chaîne monolithique élégante - et, surtout, barre par les deux murs ci-dessus. Le notebook ne *rejoue* pas ce code (AutomataDotNet est un projet Microsoft abandonné) : il en montre le squelette, puis passe au fork moderne (section 6b) qui, lui, *exécute* la voie regex -> théorie des chaînes.",,,,,,,,e35ba261caeca6fa,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb,c2b59190,markdown,fr,eb96804b8abef121,"### Interprétation : deux murs, tous deux des murs de l'automate
 
 L'approche 2020 n'était pas le folklore PCRE : l'intuition déclarative par intersection était **fondue et contemporaine** des travaux de Veanes. Mais la **forme** (builder C# `MkAnd(MkLike(...), MkLike(...))`) était un spaghetti, et **deux murs réels** l'ont bloquée :
@@ -9762,9 +9762,9 @@ foreach (var solver in solvers)
     }
 
 }",,,,,,,,8d57fad29ba7a256,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Csharp.ipynb,273eae98,markdown,fr,80f581f0d21d96c6,"### Interprétation : Limites du solver robuste sur les grilles moyennes
+MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Csharp.ipynb,273eae98,markdown,fr,64ad949ad748877f,"### Interprétation : Limites du solver robuste sur les grilles moyennes
 
-La cellule de test du solveur robuste sur Medium (cellule `17e91a97`, ec=5) rapporte **0 erreur** sur les 5 grilles testées, conformément à la capacité du modèle Dirichlet+compilation unique à converger pour les difficultés Easy. Sur les grilles Medium, le comportement observé dans les notebooks antérieurs est que Expectation Propagation peut **converger vers un optimum local** qui satisfait partiellement les contraintes all-different sans garantir la cohérence globale (certains chiffres sont à 0 alors que d'autres cellules portent une distribution multimodale). Les chiffres d'erreurs ci-dessous constituent un **instantané extrait des exécutions antérieures** et dépendent du seed EP ; ils ne sont pas reproduits par la cellule de test ci-dessus (qui reste 0-erreur). Pour une mesure stable, voir la section *Solveur itératif* (cellule `204c7e88`) qui reimpose les cellules les plus confiantes comme priors.
+La cellule de test du solveur robuste sur Medium (cellule `17e91a97`, ec=5) rapporte **0 erreur** sur les 5 grilles testées, conformément à la capacité du modèle Dirichlet+compilation unique à converger pour les difficultés Easy. Sur les grilles Medium, le comportement observé dans les notebooks antérieurs est que Expectation Propagation peut **converger vers un optimum local** qui satisfait partiellement les contraintes all-différent sans garantir la cohérence globale (certains chiffres sont à 0 alors que d'autres cellules portent une distribution multimodale). Les chiffres d'erreurs ci-dessous constituent un **instantané extrait des exécutions antérieures** et dépendent du seed EP ; ils ne sont pas reproduits par la cellule de test ci-dessus (qui reste 0-erreur). Pour une mesure stable, voir la section *Solveur itératif* (cellule `204c7e88`) qui reimpose les cellules les plus confiantes comme priors.
 
 Le test sur une grille de difficulté moyenne révèle les limites de l'approche probabiliste :
 
@@ -9772,14 +9772,14 @@ Le test sur une grille de difficulté moyenne révèle les limites de l'approche
 |--------|-------------|---------------|
 | Comportement EP sur Medium | Convergence locale possible | Le solver ne garantit pas une solution globalement valide |
 | Inférence | Rapide (millisecondes) | Le coût de calcul n'est pas le facteur limitant |
-| Garantie all-different | Partielle | EP approxime, elle ne vérifie pas formellement |
+| Garantie all-différent | Partielle | EP approxime, elle ne vérifie pas formellement |
 
 **Points clés** :
 1. L'algorithme **Expectation Propagation** peut converger vers des optima locaux (limitation méthodologique de l'inférence approximative, pas un bug)
 2. Les distributions de Dirichlet ne garantissent pas l'unicité de la solution -- elles modélisent une incertitude, pas une contrainte dure
-3. Les contraintes ""all-different"" sont bien exprimées dans le modèle (via `ConstrainFalse`) mais leur propagation EP est imparfaite sur les grilles complexes
+3. Les contraintes ""all-différent"" sont bien exprimées dans le modèle (via `ConstrainFalse`) mais leur propagation EP est imparfaite sur les grilles complexes
 
-> **Note méthodologique** : L'échec sur les grilles moyennes est une limitation structurelle de l'inférence EP pure. C'est précisément ce qui motive l'approche itérative (section suivante) qui combine EP + réinjection des cellules les plus confiantes comme nouveaux priors.",,,,,,,,80f581f0d21d96c6,,,,,,,
+> **Note méthodologique** : L'échec sur les grilles moyennes est une limitation structurelle de l'inférence EP pure. C'est précisément ce qui motive l'approche itérative (section suivante) qui combine EP + réinjection des cellules les plus confiantes comme nouveaux priors.",,,,,,,,64ad949ad748877f,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Csharp.ipynb,d9fc4c4d,markdown,fr,12d81445555a188f,"#### Conclusion sur la Résolution des Sudokus de Difficulté Moyenne
 
 Les solveurs probabilistes `NaiveProbabilisticSolver` et `RobustProbabilisticSolver` n'ont pas réussi à résoudre les Sudokus de difficulté moyenne. Les solveurs probabilistes actuels montrent une bonne performance sur les grilles faciles mais échouent sur les grilles plus complexes. Cette limitation met en évidence le besoin d'améliorer les modèles probabilistes, notamment en utilisant des techniques d'inférence itérative.
@@ -9902,7 +9902,7 @@ public class IterativeProbabilisticSolver : ISudokuSolver
 }
 ",,,,,,,,e72ef11033f7e5b7,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Csharp.ipynb,53bd72a2,markdown,fr,3370c4f824dc7eb0,#### Test sur un Sudoku simple,,,,,,,,3370c4f824dc7eb0,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Csharp.ipynb,2e053fcd,markdown,fr,8a5aa38038c77c58,"### Interprétation : Performance du solver itératif sur les grilles faciles
+MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Csharp.ipynb,2e053fcd,markdown,fr,bee732f5c205364e,"### Interprétation : Performance du solver itératif sur les grilles faciles
 
 Le solver itératif resout avec succès les grilles faciles mais avec un temps nettement supérieur :
 
@@ -9915,10 +9915,10 @@ Le solver itératif resout avec succès les grilles faciles mais avec un temps n
 
 **Points clés** :
 1. Le paramètre `NbIterationCells = 2` signifie qu'on fixe 2 cellules par itération
-2. La premiere résolution inclut le temps de compilation du modèle (~3 minutes)
+2. La première résolution inclut le temps de compilation du modèle (~3 minutes)
 3. Les résolutions subsequentes sont beaucoup plus rapides
 
-> **Note technique** : Le nombre important d'itérations EP (1250 au total pour une grille facile) s'explique par la réexécution de l'algorithme après chaque fixation de cellule. Cette approche est coûteuse mais permet de propager les contraintes progressivement.",,,,,,,,8a5aa38038c77c58,,,,,,,
+> **Note technique** : Le nombre important d'itérations EP (1250 au total pour une grille facile) s'explique par la réexécution de l'algorithme après chaque fixation de cellule. Cette approche est coûteuse mais permet de propager les contraintes progressivement.",,,,,,,,bee732f5c205364e,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Csharp.ipynb,96b6b947,code,fr,546d49d0fb332144,"// Tester le solver itératif sur un Sudoku de difficulté facile
 var iterativeSolver = new IterativeProbabilisticSolver();
 var easySudokus = SudokuHelper.GetSudokus(SudokuDifficulty.Easy).Take(2).ToList();
@@ -10305,7 +10305,7 @@ public class ImprovedIterativeSolver : ISudokuSolver
 // Test
 var improvedSolver = new ImprovedIterativeSolver();
 // var result = SudokuHelper.SolveSudoku(testGrid, improvedSolver);",,,,,,,,b68ada169c0154a2,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Csharp.ipynb,9d6818e7,markdown,fr,fbaac1b162cd2bd9,"---
+MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Csharp.ipynb,9d6818e7,markdown,fr,edd2e60f9b750a5c,"---
 
 ## Conclusion
 
@@ -10327,13 +10327,13 @@ Ce notebook a exploré la **programmation probabiliste** appliquée au Sudoku vi
 1. **L'inférence probabiliste (EP) tend à converger pour les grilles Easy** : les tests sur 5 échantillons Easy donnent 0 erreur pour les trois solveurs probabalistes. La garantie formelle reste le domaine des solveurs déterministes, mais EP est suffisante en pratique sur la majorité des grilles aléatoires de difficulté modérée.
 2. **L'approche itérative est plus stable** sur les grilles plus complexes grâce à la réinjection des priors, au prix d'un coût computationnel plus élevé (~1250 itérations EP).
 3. **La précompilation Roslyn** élimine le coût de compilation initial (~30-60 s du solveur naïf) en chargeant directement la DLL compilée -- intéressant pour les déploiements en production.
-4. **Les solveurs déterministes (CSP, SAT, MIP)** des notebooks precedents restent supérieurs en termes de garantie : un hybride probabiliste + propagation de contraintes est la voie prometteuse exploree en exercice.
+4. **Les solveurs déterministes (CSP, SAT, MIP)** des notebooks précédents restent supérieurs en termes de garantie : un hybride probabiliste + propagation de contraintes est la voie prometteuse exploree en exercice.
 
 ### Liens avec les autres approches
 
 - Les solveurs CSP (Sudoku-10 OR-Tools, Sudoku-11 Choco) garantissent la solution mais sans modélisation probabiliste.
 - Z3 (Sudoku-12) offre la vérification formelle la plus robuste.
-- L'approche hybride probabiliste + contraintes est explorée dans les exercices de ce notebook.",,,,,,,,fbaac1b162cd2bd9,,,,,,,
+- L'approche hybride probabiliste + contraintes est explorée dans les exercices de ce notebook.",,,,,,,,edd2e60f9b750a5c,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Csharp.ipynb,51643391,markdown,fr,14ebfaefc856b555,"Implementation d'un solveur hybride combinant inférence probabiliste et propagation de contraintes.
 
 ---
@@ -10367,10 +10367,10 @@ public class HybridProbabilisticSolver : ISudokuSolver
 // var hybridSolver = new HybridProbabilisticSolver();
 // var testGrid = SudokuHelper.GetSudokus(SudokuDifficulty.Medium).First();
 // SudokuHelper.SolveSudoku(testGrid, hybridSolver);",,,,,,,,5a9e7ab0211b6f40,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Csharp.ipynb,p3-grid-display-intro-c823e9df,markdown,fr,27b8376bc2cd7ce4,"### Visualisation : grille avant/après pour le solveur itératif
+MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Csharp.ipynb,p3-grid-display-intro-c823e9df,markdown,fr,057c4495fec4594d,"### Visualisation : grille avant/après pour le solveur itératif
 
-La cellule `ea382a18` (ec=9) ci-dessus execute le solveur itératif sur deux grilles Easy mais son `output` ne contient que le message console `Solver itératif configure.` -- les affichages `display(...)` produits par `SudokuHelper.SolveSudoku` ont ete perdus lors d'un nettoyage antérieur du notebook (le format `display_data` n'est pas preserve par tous les outils de réexécution). Cette section réafficher la grille résolue en passant par `Console.WriteLine(solvedSudoku.ToString())` (le `ToString()` de `SudokuGrid` est defini dans le notebook d'environnement).
-",,,,,,,,27b8376bc2cd7ce4,,,,,,,
+La cellule `ea382a18` (ec=9) ci-dessus execute le solveur itératif sur deux grilles Easy mais son `output` ne contient que le message console `Solver itératif configure.` -- les affichages `display(...)` produits par `SudokuHelper.SolveSudoku` ont ete perdus lors d'un nettoyage antérieur du notebook (le format `display_data` n'est pas preserve par tous les outils de réexécution). Cette section réafficher la grille résolue en passant par `Console.WriteLine(solvedSudoku.ToString())` (le `ToString()` de `SudokuGrid` est défini dans le notebook d'environnement).
+",,,,,,,,057c4495fec4594d,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Csharp.ipynb,p3-grid-display-exec-876a128c,code,fr,3ea230bdf9c61b7d,"// P3 fix : réaffichage explicite de la grille résolue
 //
 // Note méthodologique (exécution réelle, capturée dans le mini-notebook standalone p3_standalone.ipynb
@@ -10441,7 +10441,7 @@ Console.WriteLine(solved.ToString());
 Console.WriteLine($""Erreurs restantes vs grille initiale: {solved.NbErrors(easySudoku)}"");
 Console.WriteLine($""Temps de resolution: {startTime.Elapsed.TotalMilliseconds:F1} ms"");
 ",,,,,,,,3ea230bdf9c61b7d,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,ef5ff599,markdown,fr,c647e42667ee7793,"# Sudoku-15-Infer-Python : Resolution Probabiliste avec NumPyro
+MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,ef5ff599,markdown,fr,bee3ca12442502f9,"# Sudoku-15-Infer-Python : Resolution Probabiliste avec NumPyro
 
 **Navigation** : [<< Choco](Sudoku-11-Choco-Python.ipynb) | [Index](README.md) | [Neural Network >>](Sudoku-16-NeuralNetwork-Python.ipynb)
 
@@ -10449,7 +10449,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,ef5ff599,markdown,fr,c647e
 
 A la fin de ce notebook, vous saurez :
 1. **Comprendre** les capacites et limites de NumPyro pour les problemes discrets
-2. **Implementer** un modele probabiliste avec distributions Dirichlet et contraintes douces
+2. **Implementer** un modèle probabiliste avec distributions Dirichlet et contraintes douces
 3. **Utiliser** SVI (Stochastic Variational Inference) pour l'inference
 4. **Comparer** avec l'approche Infer.NET RobustProbabilisticSolver du notebook C#
 
@@ -10468,8 +10468,8 @@ Ce notebook implemente l'equivalent Python du **RobustProbabilisticSolver** du n
 | **Algorithme** | Expectation Propagation | SVI (Variational Inference) |
 | **Contraintes** | Dures (`ConstrainFalse`) | Douces (`numpyro.factor`) |
 | **Variables** | `VariableArray<int>` | Dirichlet (continu) |
-| **Iterations** | 50 EP iterations | 300+ SVI iterations |
-| **Performance (Easy)** | ~33ms (modele compile) | ~5-6s (CPU) |",,,,,,,,c647e42667ee7793,,,,,,,
+| **Itérations** | 50 EP itérations | 300+ SVI itérations |
+| **Performance (Easy)** | ~33ms (modèle compile) | ~5-6s (CPU) |",,,,,,,,bee3ca12442502f9,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,6572477a,markdown,fr,85a7482a5bcb5d3c,## 1. Installation et Imports,,,,,,,,85a7482a5bcb5d3c,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,7cf1c89c,code,fr,f7b485ee2bab031e,"import numpy as np
 import time
@@ -10495,23 +10495,23 @@ except ModuleNotFoundError as e:
     print(""JAX requis pour ce notebook : pip install jax jaxlib numpyro"")
     print(""Les cellules de calcul seront ignorees avec un message d'information."")
 ",,,,,,,,f7b485ee2bab031e,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,e0ca3e38,markdown,fr,0277ab27d9d92db2,"### Interpretation : Environnement NumPyro/JAX
+MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,e0ca3e38,markdown,fr,dfb82049b5597c29,"### Interpretation : Environnement NumPyro/JAX
 
-**Resultats obtenus** : L'environnement est correctement configure avec JAX 0.6.2 et NumPyro 0.19.0 sur CPU.
+**Résultats obtenus** : L'environnement est correctement configure avec JAX 0.6.2 et NumPyro 0.19.0 sur CPU.
 
-| Composant | Version | Backend | Role |
+| Composant | Version | Backend | Rôle |
 |-----------|---------|---------|------|
 | JAX | 0.6.2 | CpuDevice(id=0) | Calcul differenciable et compilation JIT |
 | NumPyro | 0.19.0 | - | Programmation probabiliste sur JAX |
-| Device | CPU | - | Execution sur CPU (pas de GPU requis) |
+| Device | CPU | - | Exécution sur CPU (pas de GPU requis) |
 
 **Points cles** :
 1. **JAX comme backend** : JAX fournit la differenciation automatique et la compilation JIT necessaires a NumPyro
-2. **Execution CPU** : Ce notebook fonctionne sur CPU, pas besoin de GPU (contrairement au Deep Learning)
+2. **Exécution CPU** : Ce notebook fonctionne sur CPU, pas besoin de GPU (contrairement au Deep Learning)
 3. **Version recente** : NumPyro 0.19.0 est une version stable avec SVI bien optimise
 4. **Compatibilite** : Ces versions sont compatibles avec les algorithmes EP/VI presentes dans ce notebook
 
-> **Note technique** : JAX est une bibliotheque de calcul numerique qui combine NumPy avec la differenciation automatique et la compilation JIT (Just-In-Time). NumPyro s'appuie sur JAX pour implementer des algorithmes d'inference probabiliste comme MCMC (NUTS) et VI (SVI). La distinction CPU/GPU est importante : JAX peut utiliser les GPU pour accelerer les calculs, mais les algorithmes SVI pour les CSP de petite taille comme Sudoku ne beneficient pas beaucoup du GPU (surcout de transfert de donnees).",,,,,,,,0277ab27d9d92db2,,,,,,,
+> **Note technique** : JAX est une bibliotheque de calcul numérique qui combine NumPy avec la differenciation automatique et la compilation JIT (Just-In-Time). NumPyro s'appuie sur JAX pour implementer des algorithmes d'inference probabiliste comme MCMC (NUTS) et VI (SVI). La distinction CPU/GPU est importante : JAX peut utiliser les GPU pour accelerer les calculs, mais les algorithmes SVI pour les CSP de petite taille comme Sudoku ne beneficient pas beaucoup du GPU (surcout de transfert de données).",,,,,,,,dfb82049b5597c29,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,7e052680,markdown,fr,4075c751ae50bd95,## 2. Utilitaires,,,,,,,,4075c751ae50bd95,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,ef0ada77,code,fr,a0d6cc618e78e472,"def load_puzzles(filepath: str, max_puzzles: int = None) -> List[str]:
     puzzles = []
@@ -10616,32 +10616,32 @@ if not puzzles:
     puzzles = [test_puzzle_str]
     print(""Utilisation d'un puzzle de test par defaut"")
 ",,,,,,,,a0d6cc618e78e472,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,6a898168,markdown,fr,409a1017d5593dda,"### Interpretation : Chargement des Puzzles
+MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,6a898168,markdown,fr,e03d1ee4ceaf55c0,"### Interpretation : Chargement des Puzzles
 
-**Resultats obtenus** : 5 puzzles Easy charges depuis le fichier `Sudoku_Easy51.txt` avec succes.
+**Résultats obtenus** : 5 puzzles Easy charges depuis le fichier `Sudoku_Easy51.txt` avec succes.
 
 | Aspect | Valeur | Signification |
 |--------|--------|---------------|
 | Puzzles charges | 5 | Limite arbitraire pour les tests (max_puzzles=5) |
 | Source | Sudoku_Easy51.txt | Fichier de 51 puzzles Easy (difficulte faible) |
-| Format | 81 caracteres | Chaque puzzle est une ligne de 81 chiffres (0-9) |
+| Format | 81 caractères | Chaque puzzle est une ligne de 81 chiffres (0-9) |
 | Cellules initiales | ~25-35 | Puzzles Easy ont ~30% de cases pre-remplies |
 | Encodage | Chiffres 0-9 | 0 = vide, 1-9 = valeurs connues |
 
 **Points cles** :
-1. **Strategie de chargement robuste** : Le code essaie deux chemins possibles (relatif et absolu)
+1. **Stratégie de chargement robuste** : Le code essaie deux chemins possibles (relatif et absolu)
 2. **Fallback** : Si aucun fichier n'est trouve, un puzzle de test par defaut est utilise
-3. **Format compact** : 81 caracteres suffisent pour representer un grille 9x9
-4. **Conversion automatique** : La fonction `puzzle_to_grid` convertit la chaine en grille 2D (liste de listes)
+3. **Format compact** : 81 caractères suffisent pour representer un grille 9x9
+4. **Conversion automatique** : La fonction `puzzle_to_grid` convertit la chaîne en grille 2D (liste de listes)
 
-> **Note technique** : Le format ""one-line"" est standard pour les puzzles Sudoku : chaque ligne de 81 caracteres represente la grille aplatie ligne par ligne. Les zeros representent les cases vides. Ce format est compact et facilite le chargement depuis des fichiers texte ou des bases de donnees.",,,,,,,,409a1017d5593dda,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,074bd1c4,markdown,fr,a917a04c32403db3,"## 3. Modele NumPyro avec Dirichlet (Equivalent RobustProbabilisticSolver)
+> **Note technique** : Le format ""one-line"" est standard pour les puzzles Sudoku : chaque ligne de 81 caractères represente la grille aplatie ligne par ligne. Les zeros representent les cases vides. Ce format est compact et facilite le chargement depuis des fichiers texte ou des bases de données.",,,,,,,,e03d1ee4ceaf55c0,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,074bd1c4,markdown,fr,c261844aaf3f7535,"## 3. Modèle NumPyro avec Dirichlet (Equivalent RobustProbabilisticSolver)
 
-Ce modele est l'equivalent Python du `RobustSudokuModel` du notebook C# Infer.NET. Il utilise :
+Ce modèle est l'equivalent Python du `RobustSudokuModel` du notebook C# Infer.NET. Il utilise :
 
 1. **Distributions Dirichlet** pour les probabilites des cellules (comme Infer.NET)
 2. **Contraintes douces** via `numpyro.factor` (au lieu de `ConstrainFalse`)
-3. **SVI** pour l'inference (au lieu d'Expectation Propagation)",,,,,,,,a917a04c32403db3,,,,,,,
+3. **SVI** pour l'inference (au lieu d'Expectation Propagation)",,,,,,,,c261844aaf3f7535,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,36e448cf,code,fr,7fd6c4fd5baf1a23,"if JAX_AVAILABLE:
     def compute_constraint_penalty(cell_probs):
         """"""
@@ -10719,12 +10719,12 @@ else:
     print(""JAX requis : pip install jax jaxlib numpyro"")
     print(""Les modeles NumPyro (compute_constraint_penalty, dirichlet_sudoku_model, dirichlet_sudoku_guide) ne sont pas disponibles."")
 ",,,,,,,,7fd6c4fd5baf1a23,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,33e976ac,markdown,fr,d465aeb0b261391c,"## 4. Solveur Probabiliste Pur (Equivalent RobustProbabilisticSolver)
+MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,33e976ac,markdown,fr,353c8b92d02b6e6f,"## 4. Solveur Probabiliste Pur (Equivalent RobustProbabilisticSolver)
 
 Ce solveur est l'equivalent Python direct du `RobustProbabilisticSolver` C# :
 - Une seule passe d'inference
 - Recupere le mode de chaque distribution Dirichlet
-- Pas de propagation deterministe",,,,,,,,d465aeb0b261391c,,,,,,,
+- Pas de propagation déterministe",,,,,,,,353c8b92d02b6e6f,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,d612595c,code,fr,282b15b981ffbc6d,"if JAX_AVAILABLE:
     class RobustProbabilisticSolverPy:
         """"""
@@ -10799,13 +10799,13 @@ else:
     print(""JAX requis : pip install jax jaxlib numpyro"")
     print(""Test du solveur probabiliste ignore. Installez JAX pour executer cette cellule."")
 ",,,,,,,,14c30de086f88dd8,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,a7db79c3,markdown,fr,dcf5801e40e23bf2,"### Interpretation : Solveur Probabiliste Pur (RobustProbabilisticSolver)
+MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,a7db79c3,markdown,fr,4c3a267e39547380,"### Interpretation : Solveur Probabiliste Pur (RobustProbabilisticSolver)
 
-**Resultats obtenus** : Une seule passe d'inference SVI (300 iterations) suffit pour resoudre ce puzzle Easy avec succes.
+**Résultats obtenus** : Une seule passe d'inference SVI (300 itérations) suffit pour resoudre ce puzzle Easy avec succes.
 
 | Metrique | Valeur | Analyse |
 |----------|--------|---------|
-| Iterations SVI | 300 | Equivalent a ~50 EP iterations Infer.NET |
+| Itérations SVI | 300 | Equivalent a ~50 EP itérations Infer.NET |
 | Temps inference | 6.2s | ~180x plus lent que C# (~34ms) |
 | Convergence | True | Solution valide obtenue |
 | Erreurs | 0 | Toutes les contraintes respectees |
@@ -10817,25 +10817,25 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,a7db79c3,markdown,fr,dcf58
 3. **Performance acceptable** : 6 secondes pour un puzzle Easy est raisonnable pour un prototype pedagogique
 4. **Limitation evidente** : Ce solveur echoue sur les puzzles Medium/Hard (voir benchmark plus loin)
 
-> **Note technique** : La distribution Dirichlet de dimension 9 modelise la probabilite de chaque valeur (1-9) pour chaque cellule. Le parametre de concentration `alpha` est appris par SVI. Les cellules connues sont fixees avec `alpha = 1000` (quasi-certain), les inconnues commencent avec `alpha = 1` (uniforme). L'inference ajuste progressivement ces concentrations pour maximiser la vraisemblance tout en respectant les contraintes (via `compute_constraint_penalty`).",,,,,,,,dcf5801e40e23bf2,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,0df3f512,markdown,fr,90a1096c129fa4c4,"### Exercice : Analyser la confiance du modele probabiliste par cellule
+> **Note technique** : La distribution Dirichlet de dimension 9 modelise la probabilite de chaque valeur (1-9) pour chaque cellule. Le paramètre de concentration `alpha` est appris par SVI. Les cellules connues sont fixees avec `alpha = 1000` (quasi-certain), les inconnues commencent avec `alpha = 1` (uniforme). L'inference ajuste progressivement ces concentrations pour maximiser la vraisemblance tout en respectant les contraintes (via `compute_constraint_penalty`).",,,,,,,,4c3a267e39547380,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,0df3f512,markdown,fr,a5dd7946f6002b9d,"### Exercice : Analyser la confiance du modèle probabiliste par cellule
 
-Le solveur probabiliste produit pour chaque cellule une **distribution de probabilites** sur les 9 valeurs possibles (1-9). Certaines cellules ont une distribution tres pointue (haute confiance) tandis que d'autres sont plus incertaines.
+Le solveur probabiliste produit pour chaque cellule une **distribution de probabilites** sur les 9 valeurs possibles (1-9). Certaines cellules ont une distribution très pointue (haute confiance) tandis que d'autres sont plus incertaines.
 
-**Objectif** : Implementez deux fonctions pour analyser la confiance du modele :
+**Objectif** : Implementez deux fonctions pour analyser la confiance du modèle :
 1. `entropy(probs)` : calculer l'entropie d'une distribution (mesure d'incertitude)
 2. `analyze_confidence(grid, probs)` : identifier les cellules les plus certaines et les plus incertaines
 
 **Concepts cles** :
-- **Entropie** : quantifie l'incertitude d'une distribution. Valeur faible = modele certain, valeur elevee = modele hesitant
+- **Entropie** : quantifie l'incertitude d'une distribution. Valeur faible = modèle certain, valeur elevee = modèle hesitant
 - **Confiance** : probabilite maximale de la distribution pour une cellule
 - **Distribution uniforme** : 9 valeurs equiprobables, entropie = ln(9) ~ 2.20 nats
 
 **Indices** :
-- Etape 1 : Implementez `entropy(probs)` avec la formule `-sum(p * log(p))` en ignorant les valeurs nulles
-- Etape 2 : Pour chaque cellule vide de la grille, extrayez confiance et entropie depuis la distribution
-- Etape 3 : Triez les resultats et affichez les extremes
-- Indice : `np.log` et un filtre `probs > 0` pour eviter `log(0)`",,,,,,,,90a1096c129fa4c4,,,,,,,
+- Étape 1 : Implementez `entropy(probs)` avec la formule `-sum(p * log(p))` en ignorant les valeurs nulles
+- Étape 2 : Pour chaque cellule vide de la grille, extrayez confiance et entropie depuis la distribution
+- Étape 3 : Triez les résultats et affichez les extremes
+- Indice : `np.log` et un filtre `probs > 0` pour eviter `log(0)`",,,,,,,,a5dd7946f6002b9d,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,8449e4d7,code,fr,2d2a9fceda81e922,"# EXERCICE : Analyser la confiance du modele probabiliste par cellule
 #
 # Indications :
@@ -10915,7 +10915,7 @@ if analysis:
         print(f""  ({row},{col}) : confiance={conf:.3f}, entropie={ent:.3f}, valeur={val}"")
 else:
     print(""Analyse a completer : implementez analyze_confidence()"")",,,,,,,,2d2a9fceda81e922,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,ex-count-candidates,markdown,fr,4e6c6f5a0875be68,"## Exercice : Compter les candidats possibles par case
+MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,ex-count-candidates,markdown,fr,a5380ebd32139421,"## Exercice : Compter les candidats possibles par case
 
 ### Enonce
 
@@ -10925,11 +10925,11 @@ Implementez `count_candidates(grid)` qui retourne une matrice 9x9 du nombre de c
 
 ### Indices
 
-- Etape 1 : Pour chaque case vide (valeur 0), determinez quels chiffres 1-9 sont absents de sa ligne
-- Etape 2 : Eliminez les chiffres presents dans sa colonne
-- Etape 3 : Eliminez les chiffres presents dans son bloc 3x3
-- Etape 4 : Comptez les candidats restants pour cette case
-",,,,,,,,4e6c6f5a0875be68,,,,,,,
+- Étape 1 : Pour chaque case vide (valeur 0), determinez quels chiffres 1-9 sont absents de sa ligne
+- Étape 2 : Eliminez les chiffres presents dans sa colonne
+- Étape 3 : Eliminez les chiffres presents dans son bloc 3x3
+- Étape 4 : Comptez les candidats restants pour cette case
+",,,,,,,,a5380ebd32139421,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,ex-count-candidates-code,code,fr,d73de58791450750,"# EXERCICE : Compter les candidats possibles par case
 #
 # Indications :
@@ -11064,41 +11064,41 @@ else:
     print(""JAX requis : pip install jax jaxlib numpyro"")
     print(""Test du solveur iteratif ignore. Installez JAX pour executer cette cellule."")
 ",,,,,,,,fbd08cdb030e63f6,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,44d951b2,markdown,fr,15133a2b9cf4cdc2,"### Interpretation : Solveur Iteratif Probabiliste
+MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,44d951b2,markdown,fr,58dfdbdee8132033,"### Interpretation : Solveur Iteratif Probabiliste
 
-**Resultats obtenus** : Le solveur iteratif fixe progressivement les cellules avec une confiance superieure au seuil de 0.25, en re-injectant les valeurs fixees dans le modele.
+**Résultats obtenus** : Le solveur iteratif fixe progressivement les cellules avec une confiance superieure au seuil de 0.25, en re-injectant les valeurs fixees dans le modèle.
 
 | Metrique | Puzzle 1 | Puzzle 2 | Moyenne |
 |----------|----------|----------|---------|
-| Etapes requises | 36 | 49 | 42.5 |
+| Étapes requises | 36 | 49 | 42.5 |
 | Cellules fixees | 36 | 49 | 42.5 |
 | Temps inference cumule | 157.0s | 216.5s | 186.8s |
 | Temps total | 169.1s | 231.7s | 200.4s |
-| Temps par etape | 4.7s | 4.7s | 4.7s |
+| Temps par étape | 4.7s | 4.7s | 4.7s |
 | Statut final | OK | OK | 100% succes |
 
 **Points cles** :
-1. **Processus iteratif** : Chaque etape fixe 1 cellule (parametre `cells_per_iteration=1`) et relance l'inference
+1. **Processus iteratif** : Chaque étape fixe 1 cellule (paramètre `cells_per_iteration=1`) et relance l'inference
 2. **Convergence garantie** : Les deux puzzles convergent vers une solution valide, contrairement au solveur robuste
 3. **Cout temporel** : ~200 secondes par puzzle, soit ~30x plus lent que le solveur robuste (6.2s)
 4. **Seuil de confiance** : 0.25 permet de fixer des cellules avec une confiance moderee mais suffisante
 
-> **Note technique** : L'approche iterative est plus robuste car chaque fixation reduit l'espace de recherche pour les etapes suivantes. Cependant, elle necessite de multiples passages d'inference (36-49 vs 1), ce qui explique le cout eleve. Le parametre `confidence_threshold` est critique : trop eleve (>0.5), aucune cellule n'est fixee ; trop bas (<0.1), des erreurs s'accumulent.",,,,,,,,15133a2b9cf4cdc2,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,ex-verify-deterministic,markdown,fr,1d911ca8402836da,"## Exercice : Verifier la reproductibilite d'un solveur
+> **Note technique** : L'approche iterative est plus robuste car chaque fixation reduit l'espace de recherche pour les étapes suivantes. Cependant, elle necessite de multiples passages d'inference (36-49 vs 1), ce qui explique le cout eleve. Le paramètre `confidence_threshold` est critique : trop eleve (>0.5), aucune cellule n'est fixee ; trop bas (<0.1), des erreurs s'accumulent.",,,,,,,,58dfdbdee8132033,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,ex-verify-deterministic,markdown,fr,917c2cd9d9460bbe,"## Exercice : Verifier la reproductibilite d'un solveur
 
 ### Enonce
 
-Les solveurs probabilistes comme le solveur iteratif peuvent produire des resultats **non deterministes** (differentes executions donnent des resultats differents). Il est important de mesurer cette variabilite.
+Les solveurs probabilistes comme le solveur iteratif peuvent produire des résultats **non déterministes** (différentes exécutions donnent des résultats différents). Il est important de mesurer cette variabilite.
 
 Implementez `measure_reproducibility(solve_func, puzzle, n_runs=5)` qui execute un solveur plusieurs fois et retourne le nombre de solutions uniques trouvees et le taux de succes.
 
 ### Indices
 
-- Etape 1 : Appelez `solve_func(puzzle)` dans une boucle de `n_runs` iterations
-- Etape 2 : Stockez chaque solution (ou None si echec) dans une liste
-- Etape 3 : Utilisez un set de tuples pour compter les solutions uniques
-- Etape 4 : Retournez `{""success_rate"": float, ""unique_solutions"": int, ""results"": list}`
-",,,,,,,,1d911ca8402836da,,,,,,,
+- Étape 1 : Appelez `solve_func(puzzle)` dans une boucle de `n_runs` itérations
+- Étape 2 : Stockez chaque solution (ou None si echec) dans une liste
+- Étape 3 : Utilisez un set de tuples pour compter les solutions uniques
+- Étape 4 : Retournez `{""success_rate"": float, ""unique_solutions"": int, ""results"": list}`
+",,,,,,,,917c2cd9d9460bbe,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,ex-verify-deterministic-code,code,fr,9376582682486085,"# EXERCICE : Verifier la reproductibilite d'un solveur
 #
 # Indications :
@@ -11162,17 +11162,17 @@ success_rate = result[""success_rate""]
 unique_solutions = result[""unique_solutions""]
 print(f""Taux de succes : {success_rate:.1%}"")
 print(f""Solutions uniques : {unique_solutions}"")",,,,,,,,9376582682486085,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,e2d986e1,markdown,fr,263a6f0cd87c06f9,"## 6. Comparaison avec Infer.NET RobustProbabilisticSolver (C#)
+MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,e2d986e1,markdown,fr,7a83eaee03786856,"## 6. Comparaison avec Infer.NET RobustProbabilisticSolver (C#)
 
-Le notebook C# `Sudoku-15-Infer-Csharp.ipynb` montre les resultats suivants pour le **RobustProbabilisticSolver** :
+Le notebook C# `Sudoku-15-Infer-Csharp.ipynb` montre les résultats suivants pour le **RobustProbabilisticSolver** :
 
 | Puzzle | Temps C# | Statut C# |
 |--------|----------|-----------|
-| Easy #1 | ~33ms (modele compile) | Resolu |
+| Easy #1 | ~33ms (modèle compile) | Resolu |
 | Easy #2 | ~34ms | Resolu |
 | Medium | ~56ms | 37 erreurs |
 
-### Benchmark comparatif Python vs C#",,,,,,,,263a6f0cd87c06f9,,,,,,,
+### Benchmark comparatif Python vs C#",,,,,,,,7a83eaee03786856,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,1163cd1d,code,fr,e6f5bfd8258ad1c4,"if JAX_AVAILABLE:
     def benchmark_comparison(puzzles: List[str], limit: int = 3):
         """"""Compare les solveurs Python avec les resultats C# Infer.NET.""""""
@@ -11223,9 +11223,9 @@ else:
     print(""  - Easy #2 : ~34ms, Resolu"")
     print(""  - Medium  : ~56ms, 37 erreurs"")
 ",,,,,,,,e6f5bfd8258ad1c4,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,6e447ffa,markdown,fr,2923ad8491a622d2,"### Interpretation : Comparaison Python vs C#
+MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,6e447ffa,markdown,fr,bea509b7043d9db9,"### Interpretation : Comparaison Python vs C#
 
-**Resultats obtenus** : Le benchmark montre un ecart de performance significatif entre Infer.NET (C#) et NumPyro (Python).
+**Résultats obtenus** : Le benchmark montre un ecart de performance significatif entre Infer.NET (C#) et NumPyro (Python).
 
 | Aspect | Infer.NET (C#) | NumPyro (Python) | Facteur |
 |--------|----------------|------------------|---------|
@@ -11240,12 +11240,12 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,6e447ffa,markdown,fr,2923a
 1. **Performance** : Infer.NET est ~100x plus rapide grace a la precompilation et Expectation Propagation
 2. **Qualite de solution** : Infer.NET reussit mieux les puzzles Easy (100% vs 50%), mais les deux echouent sur Medium
 3. **Contraintes** : Les contraintes dures d'Infer.NET (`ConstrainFalse`) sont plus efficaces que les contraintes douces de NumPyro
-4. **Variabilite** : Les resultats Python varient plus (8 erreurs vs 0 pour Easy #2, 8 vs 37 pour Medium)
+4. **Variabilite** : Les résultats Python varient plus (8 erreurs vs 0 pour Easy #2, 8 vs 37 pour Medium)
 
 > **Note technique** : L'ecart de performance s'explique par trois facteurs :
 > - **EP vs SVI** : Expectation Propagation est specialement concu pour les CSP, SVI est un algorithme generaliste
 > - **Contraintes** : `ConstrainFalse` elimine directement les valeurs impossibles, alors que `numpyro.factor` ajoute seulement une penalite
-> - **Compilation** : Infer.NET genere une DLL compilee une seule fois, alors que JAX recompile a chaque execution",,,,,,,,2923ad8491a622d2,,,,,,,
+> - **Compilation** : Infer.NET genere une DLL compilee une seule fois, alors que JAX recompile a chaque exécution",,,,,,,,bea509b7043d9db9,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,543d230f,markdown,fr,1dde786cff21fdd8,## 7. Tableau comparatif final,,,,,,,,1dde786cff21fdd8,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,9518beb1,code,fr,1e8541078061be44,"import pandas as pd
 
@@ -11303,14 +11303,14 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,ee942928,markdown,fr,bb979
 3. **Les deux echouent sur les puzzles Medium** : Necessite une approche hybride ou un vrai solveur CSP
 
 > **Recommandation** : Pour resoudre des Sudokus en production, utiliser OR-Tools, Z3 ou Choco. La programmation probabiliste est un outil pedagogique pour comprendre l'inference bayesienne.",,,,,,,,bb979588607ec3dc,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,ql41ouqadip,markdown,fr,6f75909047051c5c,"## Exercice : Solveur Hybride Probabiliste + Deterministe
+MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,ql41ouqadip,markdown,fr,436e74256bbd4b31,"## Exercice : Solveur Hybride Probabiliste + Déterministe
 
 ## Enonce
 
 Le solveur probabiliste pur echoue souvent sur les puzzles Medium et Hard car l'inference SVI ne converge pas vers une solution exacte. Implementez un **solveur hybride** qui combine :
 
 1. **Phase probabiliste** : utiliser `RobustProbabilisticSolverPy` pour fixer les cellules avec une confiance superieure a `threshold` (ex : 0.90)
-2. **Phase deterministe** : appliquer un backtracking simple sur les cellules restantes
+2. **Phase déterministe** : appliquer un backtracking simple sur les cellules restantes
 
 Structure a implementer :
 
@@ -11333,7 +11333,7 @@ class HybridProbabilisticSolver:
 
 **Indice**
 
-Pour la phase probabiliste, utilisez `np.max(probs[idx])` comme mesure de confiance. Pour le backtracking, vous pouvez reutiliser la logique de `_backtrack` du notebook Sudoku-1-Backtracking-Python.",,,,,,,,6f75909047051c5c,,,,,,,
+Pour la phase probabiliste, utilisez `np.max(probs[idx])` comme mesure de confiance. Pour le backtracking, vous pouvez reutiliser la logique de `_backtrack` du notebook Sudoku-1-Backtracking-Python.",,,,,,,,436e74256bbd4b31,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,icemgf35orf,code,fr,4d79dbee9343fcb3,"class HybridProbabilisticSolver:
     """"""
     Solveur hybride : inference probabiliste (NumPyro) + backtracking deterministe.
@@ -11425,13 +11425,13 @@ A la fin de ce notebook, vous saurez :
 
 ### Contexte
 Ce notebook s'inspire du projet [jsboigeEpita/2024-EPITA-SCIA-PPC-Sudoku-CV](https://github.com/jsboigeEpita/2024-EPITA-SCIA-PPC-Sudoku-CV) (module `Sudoku.NeuralNetwork`) qui explore 4 architectures de réseaux de neurones entraînés sur 17 millions de puzzles. Ici, nous reproduisons les idées clés sur un dataset réduit pour rester exécutable en quelques minutes.",,,,,,,,15b7fc36505ebcc6,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,intro-section,markdown,fr,fe8742103d5ff358,"## 1. Introduction : le Sudoku vu comme un problème de reconnaissance de motifs
+MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,intro-section,markdown,fr,c6e436a6ff6f2783,"## 1. Introduction : le Sudoku vu comme un problème de reconnaissance de motifs
 
-Les notebooks precedents de cette serie resolvent le Sudoku par des approches algorithmiques : backtracking, programmation par contraintes, recherche locale. Mais peut-on **apprendre** a resoudre un Sudoku ?
+Les notebooks précédents de cette serie resolvent le Sudoku par des approches algorithmiques : backtracking, programmation par contraintes, recherche locale. Mais peut-on **apprendre** a resoudre un Sudoku ?
 
 ### Pourquoi un réseau de neurones ?
 
-Un réseau de neurones ne ""comprend"" pas les règles du Sudoku. Il apprend des **correlations statistiques** entre les grilles partielles et leurs solutions a partir de milliers d'exemples. C'est une approche fondamentalement differente :
+Un réseau de neurones ne ""comprend"" pas les règles du Sudoku. Il apprend des **correlations statistiques** entre les grilles partielles et leurs solutions a partir de milliers d'exemples. C'est une approche fondamentalement différente :
 
 | Approche | mécanisme | Garantie de solution valide |
 |----------|-----------|-----------------------------|
@@ -11452,7 +11452,7 @@ Grille brute :     Tenseur one-hot (9x9x10) :
                     etc.
 ```
 
-L'idee cle est que le réseau apprend a ""deviner"" le bon chiffre pour chaque case en s'appuyant sur le contexte spatial (ligne, colonne, bloc 3x3).",,,,,,,,fe8742103d5ff358,,,,,,,
+L'idee cle est que le réseau apprend a ""deviner"" le bon chiffre pour chaque case en s'appuyant sur le contexte spatial (ligne, colonne, bloc 3x3).",,,,,,,,c6e436a6ff6f2783,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,imports,code,fr,acbbb80c99401574,"import numpy as np
 import matplotlib.pyplot as plt
 import time
@@ -11476,22 +11476,22 @@ device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 print(f""PyTorch {torch.__version__}"")
 print(f""Device : {device}"")
 print(f""BATCH_MODE : {BATCH_MODE}"")",,,,,,,,acbbb80c99401574,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,data-section,markdown,fr,41822a62d6acb149,"## 2. Preparation des données
+MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,data-section,markdown,fr,9581b6d63be99abd,"## 2. Preparation des données
 
 Pour entrainer un réseau de neurones, il faut un **dataset** de paires (puzzle, solution). Plutot que de telecharger un fichier externe, nous générons nos données de maniere programmatique grace a un solveur par backtracking.
 
 ### Stratégie de génération
 
 1. **générer une grille complete valide** : remplir une grille vide par backtracking avec un ordre aléatoire des chiffres
-2. **Creer le puzzle** : retirer aleatoirement entre 40 et 55 cases
+2. **Créer le puzzle** : retirer aleatoirement entre 40 et 55 cases
 3. **Stocker la paire** : (puzzle, solution_complete)
 
 ### Taille du dataset
 
-Le projet de référence utilise 17 millions de puzzles. Ici, nous travaillons avec **50 000 puzzles** (40 000 train / 10 000 test), un compromis entre qualite d'apprentissage et temps d'entrainement raisonnable (~5-15 min selon l'architecture). La littérature (Park 2018) montre que 50K-100K exemples suffisent pour atteindre >99% de precision par case avec un CNN profond.",,,,,,,,41822a62d6acb149,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,generator-intro,markdown,fr,570d3851f2cd2f61,"### 2.1 Générateur de puzzles
+Le projet de référence utilise 17 millions de puzzles. Ici, nous travaillons avec **50 000 puzzles** (40 000 train / 10 000 test), un compromis entre qualite d'apprentissage et temps d'entrainement raisonnable (~5-15 min selon l'architecture). La littérature (Park 2018) montre que 50K-100K exemples suffisent pour atteindre >99% de precision par case avec un CNN profond.",,,,,,,,9581b6d63be99abd,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,generator-intro,markdown,fr,c1d069afde8b0415,"### 2.1 Générateur de puzzles
 
-Le générateur utilise un backtracking classique avec une astuce : les chiffres sont testes dans un **ordre aléatoire** a chaque appel, ce qui produit une grille complete differente a chaque execution.",,,,,,,,570d3851f2cd2f61,,,,,,,
+Le générateur utilise un backtracking classique avec une astuce : les chiffres sont testes dans un **ordre aléatoire** a chaque appel, ce qui produit une grille complete différente a chaque exécution.",,,,,,,,c1d069afde8b0415,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,generator,code,fr,d6c076d1277b0ea3,"def is_valid(grid: np.ndarray, row: int, col: int, num: int) -> bool:
     """"""Verifie si placer num a (row, col) est valide.""""""
     # Ligne
@@ -11552,7 +11552,7 @@ print(""\nPuzzle :"")
 print(test_puzzle)
 print(""\nSolution :"")
 print(test_solution)",,,,,,,,d6c076d1277b0ea3,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,dataset-intro,markdown,fr,b967627fabfcf8d4,"### 2.2 Construction du dataset
+MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,dataset-intro,markdown,fr,af39dd37ddb30b34,"### 2.2 Construction du dataset
 
 Nous générons **50 000 puzzles** et les separons en 40 000 pour l'entrainement et 10 000 pour le test.
 
@@ -11561,9 +11561,9 @@ Nous générons **50 000 puzzles** et les separons en 40 000 pour l'entrainement
 **Encodage one-hot** :
 - **Puzzle** : tenseur `(9, 9, 10)` -- le canal 0 represente ""case vide"", les canaux 1-9 representent les chiffres
 - **Solution** : tenseur `(9, 9)` avec les chiffres 1-9 decales en indices 0-8 pour la cross-entropy
-- **Masque** : tenseur `(9, 9)` booleen -- True pour les cases vides (a prédire), False pour les cases données
+- **Masque** : tenseur `(9, 9)` booléen -- True pour les cases vides (a prédire), False pour les cases données
 
-Le masque permet de calculer la loss **uniquement sur les cases a prédire**, evitant que le modèle apprenne a recopier les indices fournis plutot qu'a raisonner sur le puzzle.",,,,,,,,b967627fabfcf8d4,,,,,,,
+Le masque permet de calculer la loss **uniquement sur les cases a prédire**, evitant que le modèle apprenne a recopier les indices fournis plutot qu'a raisonner sur le puzzle.",,,,,,,,af39dd37ddb30b34,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,dataset-generation,code,fr,428da4e38058fcc2,"def encode_puzzle(puzzle: np.ndarray) -> np.ndarray:
     """"""Encode un puzzle en one-hot (9, 9, 10).
     Canal 0 = case vide, canaux 1-9 = chiffres.""""""
@@ -11624,15 +11624,15 @@ print(f""  Test  : {X_test.shape[0]} puzzles"")
 print(f""  X shape : {X_train.shape}"")
 print(f""  y shape : {y_train.shape}"")
 print(f""  masks   : {masks_train.shape} ({masks_train.sum()/masks_train.size:.1%} de cases vides)"")",,,,,,,,428da4e38058fcc2,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,dataset-interp,markdown,fr,f5122f30b2b95b05,"### Interpretation : encodage des données
+MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,dataset-interp,markdown,fr,b3ae1cdf31218cd1,"### Interpretation : encodage des données
 
-| Element | Shape | Description |
+| Élément | Shape | Description |
 |---------|-------|-------------|
 | Puzzle brut | `(9, 9)` | Entiers 0-9, 0 = case vide |
 | Puzzle encode | `(9, 9, 10)` | One-hot, canal 0 = vide |
 | Solution cible | `(9, 9)` | Indices 0-8 (chiffre - 1) |
 
-Le one-hot encoding est essentiel : sans lui, le réseau traiterait les chiffres comme des valeurs ordonnees (5 > 3) alors qu'en Sudoku ils sont simplement des **etiquettes** sans relation d'ordre.",,,,,,,,f5122f30b2b95b05,,,,,,,
+Le one-hot encoding est essentiel : sans lui, le réseau traiterait les chiffres comme des valeurs ordonnees (5 > 3) alors qu'en Sudoku ils sont simplement des **etiquettes** sans relation d'ordre.",,,,,,,,b3ae1cdf31218cd1,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,torch-dataset,code,fr,4d630fbd8ee0953e,"class SudokuDataset(Dataset):
     """"""Dataset PyTorch pour les puzzles de Sudoku.
     
@@ -12027,7 +12027,7 @@ cnn_time = time.time() - start
 
 print(f""\nTemps d'entrainement : {cnn_time:.1f}s"")
 plot_history(cnn_history, ""Reseau Convolutif (CNN)"")",,,,,,,,5f3cba0a4e0053eb,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,cnn-interp,markdown,fr,c7b04c496a453ad7,"### Interpretation : CNN vs MLP
+MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,cnn-interp,markdown,fr,aa5d4f8ff1ab3451,"### Interpretation : CNN vs MLP
 
 **Comparaison attendue (50K puzzles, 20 epochs)** :
 
@@ -12043,10 +12043,10 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,cnn-interp,markdow
 3. La precision par case augmente significativement, mais la grille complete reste difficile (1 erreur sur 81 = grille fausse)
 4. **Ecart train/test** : observez les courbes de loss pour voir si le CNN sur-apprend (courbes qui divergent)
 
-**Transition** : le CNN 5 couches est deja performant, mais la littérature montre qu'un CNN plus profond avec connexions residuelles atteint >99% par case. C'est l'architecture ResCNN de la section suivante.",,,,,,,,c7b04c496a453ad7,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,2b19266e,markdown,fr,851032d783aa55f9,"## 5. Architecture 3 : CNN Profond avec Connexions Residuelles
+**Transition** : le CNN 5 couches est déjà performant, mais la littérature montre qu'un CNN plus profond avec connexions residuelles atteint >99% par case. C'est l'architecture ResCNN de la section suivante.",,,,,,,,aa5d4f8ff1ab3451,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,2b19266e,markdown,fr,ec188f6bf4431a6a,"## 5. Architecture 3 : CNN Profond avec Connexions Residuelles
 
-Les architectures precedentes (MLP et CNN 5 couches) sont limitees par leur profondeur. La littérature (Park 2018, Palm 2018) montre qu'un CNN plus profond avec des **connexions residuelles** atteint des precisions par case superieures a 99%.
+Les architectures précédentes (MLP et CNN 5 couches) sont limitees par leur profondeur. La littérature (Park 2018, Palm 2018) montre qu'un CNN plus profond avec des **connexions residuelles** atteint des precisions par case superieures a 99%.
 
 ### Principe des connexions residuelles
 
@@ -12073,7 +12073,7 @@ Input(10, 9, 9)
 Output(9, 9, 9)
 ```
 
-Total : 14 couches convolutionnelles (1 entree + 12 residuelles + 1 sortie) avec mécanisme de **gating** pour ponderer la contribution de chaque bloc.",,,,,,,,851032d783aa55f9,,,,,,,
+Total : 14 couches convolutionnelles (1 entree + 12 residuelles + 1 sortie) avec mécanisme de **gating** pour ponderer la contribution de chaque bloc.",,,,,,,,ec188f6bf4431a6a,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,7ee289b8,code,fr,c27371c0d03c73b3,"class ResidualBlock(nn.Module):
     """"""Bloc residual avec gating pour Sudoku.
     
@@ -12137,9 +12137,9 @@ res_cnn_model = ResCNN(n_blocks=6, channels=128).to(device)
 n_params = sum(p.numel() for p in res_cnn_model.parameters())
 print(f""ResCNN : {n_params:,} parametres"")
 print(res_cnn_model)",,,,,,,,c27371c0d03c73b3,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,7f6cf9a4,markdown,fr,d195d56cc7af0c9a,"### Entrainement du ResCNN
+MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,7f6cf9a4,markdown,fr,2a3763ffba79e1da,"### Entrainement du ResCNN
 
-Le ResCNN est entraine plus longtemps (40 epochs) car sa profondeur necessite plus d'iterations pour converger. Le early stopping (patience=12) evite le sur-apprentissage en restaurant les poids du meilleur checkpoint.",,,,,,,,d195d56cc7af0c9a,,,,,,,
+Le ResCNN est entraine plus longtemps (40 epochs) car sa profondeur necessite plus d'itérations pour converger. Le early stopping (patience=12) evite le sur-apprentissage en restaurant les poids du meilleur checkpoint.",,,,,,,,2a3763ffba79e1da,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,e599559b,code,fr,4cf232232a820c5f,"print(""=== Entrainement du ResCNN (connexions residuelles) ==="")
 res_cnn_model = ResCNN(n_blocks=6, channels=128).to(device)
 
@@ -12150,7 +12150,7 @@ res_cnn_time = time.time() - start
 
 print(f""\nTemps d'entrainement : {res_cnn_time:.1f}s"")
 plot_history(res_cnn_history, ""ResCNN (connexions residuelles)"")",,,,,,,,4cf232232a820c5f,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,efd3a877,markdown,fr,c31a0ab835cd5112,"### Interpretation : impact des connexions residuelles
+MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,efd3a877,markdown,fr,3a234561a7083120,"### Interpretation : impact des connexions residuelles
 
 **Points cles** :
 1. Le ResCNN atteint une precision par case nettement supérieure au CNN simple grace a sa profondeur (14 couches vs 5)
@@ -12158,8 +12158,8 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,efd3a877,markdown,
 3. Le mécanisme de gating permet a chaque bloc de decider dans quelle mesure sa contribution est utile
 4. Le early stopping détecte automatiquement le moment optimal pour arreter l'entrainement
 
-**Comparaison des architectures** : le ResCNN illustre un principe fondamental du deep learning -- avec suffisamment de données et une architecture adaptee, les réseaux de neurones peuvent apprendre des taches complexes comme le Sudoku.",,,,,,,,c31a0ab835cd5112,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,5fb9732b,markdown,fr,305ff8ae569f36fb,"## 6. Architecture 4 : Réseau Relationnel Recurrent (RRN)Les architectures precedentes (MLP, CNN, ResCNN) traitent la grille comme une image 2D. Mais le Sudoku a une structure **relationnelle** : chaque case est en interaction avec exactement 20 voisins de contrainte (8 dans la même ligne, 8 dans la même colonne, 4 supplementaires dans le bloc 3x3, sans compter les doublons).### Le modèle de Palm et al. (2018)Le **Recurrent Relational Network** (RRN) exploite directement cette structure sous forme de graphe. Au lieu de convolutions 2D, il utilise un **passage de messages** (message passing) entre les cases connectees par les règles du Sudoku.### Principe```Pour chaque étape de raisonnement (1 a N) :  1. Chaque case envoie un message a ses 20 voisins  2. Chaque case agrege les messages recus  3. Un GRU met a jour l'etat cache de chaque case  4. Une couche lineaire prédit les logits (9 classes) depuis l'etat cache```**Pourquoi c'est puissant** :1. **Structure relationnelle explicite** : contrairement au CNN qui apprend les interactions par convolution, le RRN injecte directement le graphe de contraintes du Sudoku2. **Raisonnement iteratif** : a chaque étape, les cases echangent des informations et affinent leurs predictions3. **Partage de poids** : le même mécanisme de message-passing est reutilise a chaque étape (poids partages), comme un RNN classique### Architecture detaillee```Input (batch, 81, 10)     # 81 cases, 10 features (one-hot + masque)  |  +-> Embedding (Linear 10 -> hidden_dim) + Positional Encoding  |  |  Pour chaque étape t = 1..T :  |    |  |    +-> Message MLP : concat(h_i, h_j) -> message m_ij  |    +-> Agregation  : sum des messages recus pour chaque case  |    +-> GRU Cell    : (message_agrege, h_t) -> h_{t+1}  |    +-> LayerNorm  |    +-> Prediction  : Linear(hidden_dim -> 9) -> logits  |  vOutput : liste de (batch, 81, 9) logits pour chaque étape```Le graphe de contraintes contient exactement **1 620 aretes orientees** (81 cases x 20 voisins). Chaque arete represente une contrainte Sudoku (même ligne, colonne ou bloc).### Implementation simplifieeVoici une version simplifiee du modèle RRN. La version complete utilisee pour l'entrainement GPU est dans `scripts/sudoku/core/models.py`.",,,,,,,,305ff8ae569f36fb,,,,,,,
+**Comparaison des architectures** : le ResCNN illustre un principe fondamental du deep learning -- avec suffisamment de données et une architecture adaptee, les réseaux de neurones peuvent apprendre des tâches complexes comme le Sudoku.",,,,,,,,3a234561a7083120,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,5fb9732b,markdown,fr,bbf8577ba5ce889c,"## 6. Architecture 4 : Réseau Relationnel Recurrent (RRN)Les architectures précédentes (MLP, CNN, ResCNN) traitent la grille comme une image 2D. Mais le Sudoku a une structure **relationnelle** : chaque case est en interaction avec exactement 20 voisins de contrainte (8 dans la même ligne, 8 dans la même colonne, 4 supplementaires dans le bloc 3x3, sans compter les doublons).### Le modèle de Palm et al. (2018)Le **Recurrent Relational Network** (RRN) exploite directement cette structure sous forme de graphe. Au lieu de convolutions 2D, il utilise un **passage de messages** (message passing) entre les cases connectees par les règles du Sudoku.### Principe```Pour chaque étape de raisonnement (1 a N) :  1. Chaque case envoie un message a ses 20 voisins  2. Chaque case agrege les messages recus  3. Un GRU met a jour l'etat cache de chaque case  4. Une couche lineaire prédit les logits (9 classes) depuis l'etat cache```**Pourquoi c'est puissant** :1. **Structure relationnelle explicite** : contrairement au CNN qui apprend les interactions par convolution, le RRN injecte directement le graphe de contraintes du Sudoku2. **Raisonnement iteratif** : a chaque étape, les cases echangent des informations et affinent leurs predictions3. **Partage de poids** : le même mécanisme de message-passing est reutilise a chaque étape (poids partages), comme un RNN classique### Architecture detaillee```Input (batch, 81, 10)     # 81 cases, 10 features (one-hot + masque)  |  +-> Embedding (Linear 10 -> hidden_dim) + Positional Encoding  |  |  Pour chaque étape t = 1..T :  |    |  |    +-> Message MLP : concat(h_i, h_j) -> message m_ij  |    +-> Agregation  : sum des messages recus pour chaque case  |    +-> GRU Cell    : (message_agrege, h_t) -> h_{t+1}  |    +-> LayerNorm  |    +-> Prediction  : Linear(hidden_dim -> 9) -> logits  |  vOutput : liste de (batch, 81, 9) logits pour chaque étape```Le graphe de contraintes contient exactement **1 620 aretes orientees** (81 cases x 20 voisins). Chaque arete represente une contrainte Sudoku (même ligne, colonne ou bloc).### Implementation simplifieeVoici une version simplifiee du modèle RRN. La version complete utilisee pour l'entrainement GPU est dans `scripts/sudoku/core/models.py`.",,,,,,,,bbf8577ba5ce889c,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,258b8406,code,fr,94e483cb4e073c19,"def build_sudoku_graph():
     """"""Construit le graphe de contraintes du Sudoku.
     
@@ -12291,9 +12291,9 @@ print(f""  SimpleRRN (pedagogique) : {n_params_rrn:>8,} params"")
 print(f""  RRN h128_s16            :   161,929 params"")
 print(f""  RRN h192_s16            :   353,481 params"")
 print(f""  RRN h256_s16            :   618,761 params"")",,,,,,,,94e483cb4e073c19,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,120a8ea9,markdown,fr,20c645c64cb5beac,"### Interpretation : architecture du Réseau Relationnel Recurrent
+MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,120a8ea9,markdown,fr,a5b55b10b943b1c3,"### Interpretation : architecture du Réseau Relationnel Recurrent
 
-Le RRN de Palm et al. (2018) aborde le Sudoku sous un angle fondamentalement different des modèles precedents :
+Le RRN de Palm et al. (2018) aborde le Sudoku sous un angle fondamentalement différent des modèles précédents :
 
 **1. Structure relationnelle** : Plutot que de traiter la grille comme une image (CNN) ou un vecteur plat (MLP), le RRN modelise explicitement les **contraintes du Sudoku** sous forme de graphe. Chaque cellule est un noeud connectee a ses 20 voisins (8 lignes + 8 colonnes + 4 bloc). Cette structure encode directement les règles du jeu.
 
@@ -12311,8 +12311,34 @@ Le RRN de Palm et al. (2018) aborde le Sudoku sous un angle fondamentalement dif
 
 Le RRN atteint la meilleure precision par grille avec **environ 3 fois moins de paramètres** que le CNN, grace a l'inductive bias de la structure relationnelle.
 
-**4. Avantage cle** : Le RRN génère une prediction a **chaque étape de raisonnement**, permettant d'observer comment la solution se raffine iterativement. Les modèles de production (h=192, 24 étapes) entraines sur GPU avec 400K puzzles et un apprentissage progressif (curriculum learning) atteignent **83.5% de grilles correctes en une seule passe** -- un resultat bien supérieur au ResCNN entraine sur le même dataset.",,,,,,,,20c645c64cb5beac,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,5eb1e7bf,markdown,fr,dd43d0cb30d33ef6,"## 7. Modèles entraines sur GPU : Resultats et analyseLes modèles entraines dans les sections precedentes utilisent un petit dataset (50K puzzles générés localement) et s'executent sur CPU. Pour atteindre des performances elevees, nous avons entraine des RRN sur GPU (RTX 3070, 8.6GB VRAM) avec un dataset massif.### Configuration d'entrainement GPU| paramètre | Valeur ||-----------|--------|| Dataset | 300K puzzles faciles (HF) + 100K puzzles difficiles || Split | 280K train / 60K val / 60K test || Optimiseur | AdamW (lr=1e-4, OneCycleLR) || Curriculum | Progression easy/medium/hard sur 18 epochs || GPU | NVIDIA RTX 3070 Laptop (8.6 GB VRAM) || Duree | ~17 min/epoch pour h192_s24 |### Apprentissage progressif (curriculum learning)Le dataset contient des puzzles de difficultes variees (17 a 37 indices donnes). Plutot que de presenter toutes les difficultes des le debut, le curriculum learning introduit progressivement les puzzles les plus durs :| Phase | Epochs | Easy (33+ indices) | Medium (25-32) | Hard (<25) ||-------|--------|--------------------|-----------------|------------|| 1 | 1-5 | 50% | 30% | 10% || 2 | 6-11 | 75% | 60% | 40% || 3 | 12-17 | 90% | 80% | 70% || 4 | 18+ | 100% | 100% | 100% |Cette stratégie permet au modèle d'apprendre d'abord les patterns simples avant de s'attaquer aux puzzles les plus difficiles.",,,,,,,,dd43d0cb30d33ef6,,,,,,,
+**4. Avantage cle** : Le RRN génère une prediction a **chaque étape de raisonnement**, permettant d'observer comment la solution se raffine iterativement. Les modèles de production (h=192, 24 étapes) entraines sur GPU avec 400K puzzles et un apprentissage progressif (curriculum learning) atteignent **83.5% de grilles correctes en une seule passe** -- un résultat bien supérieur au ResCNN entraine sur le même dataset.",,,,,,,,a5b55b10b943b1c3,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,5eb1e7bf,markdown,fr,20bb7850d1e05728,"## 7. Modèles entraines sur GPU : Résultats et analyse
+
+Les modèles entraines dans les sections précédentes utilisent un petit dataset (50K puzzles générés localement) et s'executent sur CPU. Pour atteindre des performances elevees, nous avons entraine des RRN sur GPU (RTX 3070, 8.6GB VRAM) avec un dataset massif.
+
+### Configuration d'entrainement GPU
+
+| paramètre | Valeur |
+|-----------|--------|
+| Dataset | 300K puzzles faciles (HF) + 100K puzzles difficiles |
+| Split | 280K train / 60K val / 60K test |
+| Optimiseur | AdamW (lr=1e-4, OneCycleLR) |
+| Curriculum | Progression easy/medium/hard sur 18 epochs |
+| GPU | NVIDIA RTX 3070 Laptop (8.6 GB VRAM) |
+| Duree | ~17 min/epoch pour h192_s24 |
+
+### Apprentissage progressif (curriculum learning)
+
+Le dataset contient des puzzles de difficultes variees (17 a 37 indices donnes). Plutot que de presenter toutes les difficultes des le debut, le curriculum learning introduit progressivement les puzzles les plus durs :
+
+| Phase | Epochs | Easy (33+ indices) | Medium (25-32) | Hard (<25) |
+|-------|--------|--------------------|-----------------|------------|
+| 1 | 1-5 | 50% | 30% | 10% |
+| 2 | 6-11 | 75% | 60% | 40% |
+| 3 | 12-17 | 90% | 80% | 70% |
+| 4 | 18+ | 100% | 100% | 100% |
+
+Cette stratégie permet au modèle d'apprendre d'abord les patterns simples avant de s'attaquer aux puzzles les plus difficiles.",,,,,,,,20bb7850d1e05728,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,a97e24fc,code,fr,2e93fe49e61ad5a4,"# Resultats des modeles RRN et baselines CNN/MLP entraines sur GPU
 # Charge depuis les fichiers JSON de resultats (reproductible)
 
@@ -12428,22 +12454,22 @@ fig.legend(handles=legend_elements, loc=""lower center"", ncol=4, fontsize=9, bb
 plt.tight_layout()
 plt.subplots_adjust(bottom=0.22)
 plt.show()",,,,,,,,2e93fe49e61ad5a4,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,6a8b41a3,markdown,fr,4317ec6186ca3aef,"### Interpretation : facteurs cles de performance
+MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,6a8b41a3,markdown,fr,da89ffb3eb33669f,"### Interpretation : facteurs cles de performance
 
 **1. Impact du dataset et du curriculum** : Le saut de performance le plus significatif (x2.5 sur la grid accuracy) provient du passage de 200K a 400K puzzles avec un apprentissage progressif. Le curriculum learning permet au modèle d'abord de maitriser les puzzles faciles (33+ indices) avant d'apprendre les puzzles difficiles (17-24 indices).
 
 **2. Taille du modèle vs performance** :
 - h128 (162K params) a h256 (619K params) : les modèles de base ont des performances quasi-identiques (~62.5% cell, ~33.5% grid)
-- Apres fine-tuning : h192 (353K) et h256 (619K) atteignent des performances similaires (~89.7% cell, ~83.5% grid)
+- Après fine-tuning : h192 (353K) et h256 (619K) atteignent des performances similaires (~89.7% cell, ~83.5% grid)
 - h192 avec 16 ou 24 étapes de raisonnement : quasiment identique (83.48% vs 83.51% grid)
 - **Conclusion** : la taille du modèle importe moins que la stratégie d'entrainement (dataset, curriculum, scheduling). Augmenter les étapes de raisonnement au-dela de 16 n'apporte pas de gain significatif pour hidden_dim=192.
 
 **3. Zero-shot vs prediction iterative** : Les 83.5% de grid accuracy sont obtenus en **une seule passe forward** (zero-shot). Avec la prediction iterative (section suivante), les performances seraient encore superieures car chaque case remplie enrichit le contexte.
 
-**4. Avantage de la structure de graphe (RRN vs CNN/MLP)** : Les baselines CNN et MLP, avec un nombre comparable de paramètres (~300-400K), entraines sur le même dataset (208K puzzles) sans curriculum, obtiennent des resultats radicalement inferieurs : **~44% cell accuracy et 0% grid accuracy** pour le meilleur CNN, ~36% cell accuracy pour le MLP. Cela demontre que la structure de graphe du RRN (message passing entre cellules liees par les contraintes Sudoku) est le facteur déterminant, pas simplement la taille du modèle ou le volume de données. Le MLP, sans aucune notion de structure spatiale, performe le moins bien. Le CNN, qui capture des motifs locaux, fait mieux mais reste loin du RRN qui modelise explicitement les relations entre cases.
+**4. Avantage de la structure de graphe (RRN vs CNN/MLP)** : Les baselines CNN et MLP, avec un nombre comparable de paramètres (~300-400K), entraines sur le même dataset (208K puzzles) sans curriculum, obtiennent des résultats radicalement inferieurs : **~44% cell accuracy et 0% grid accuracy** pour le meilleur CNN, ~36% cell accuracy pour le MLP. Cela demontre que la structure de graphe du RRN (message passing entre cellules liees par les contraintes Sudoku) est le facteur déterminant, pas simplement la taille du modèle ou le volume de données. Le MLP, sans aucune notion de structure spatiale, performe le moins bien. Le CNN, qui capture des motifs locaux, fait mieux mais reste loin du RRN qui modelise explicitement les relations entre cases.
 
-**5. Limites atteintes** : Les modèles actuels puissent sur les puzzles très difficiles (17-22 indices). La littérature (Palm 2018) montre que des modèles plus profonds (h=512, 32 étapes) sur des datasets massifs (1M+) atteignent >95% grid accuracy en zero-shot.",,,,,,,,4317ec6186ca3aef,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,iterative-section,markdown,fr,216a6039025ee50e,"## 8. Prediction iterative : resoudre case par case
+**5. Limites atteintes** : Les modèles actuels puissent sur les puzzles très difficiles (17-22 indices). La littérature (Palm 2018) montre que des modèles plus profonds (h=512, 32 étapes) sur des datasets massifs (1M+) atteignent >95% grid accuracy en zero-shot.",,,,,,,,da89ffb3eb33669f,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,iterative-section,markdown,fr,c3d413cd763b031f,"## 8. Prediction iterative : resoudre case par case
 
 L'idee cle pour ameliorer drastiquement la precision est d'imiter la stratégie humaine : **prédire la case la plus certaine, la remplir, puis re-prédire**.
 
@@ -12462,13 +12488,13 @@ Au lieu de prédire les 81 cases d'un coup, on procede iterativement :
 Chaque case remplie fournit un **indice supplementaire** au réseau pour les cases restantes. C'est un mécanisme d'auto-regression : les predictions les plus sures servent de base pour les predictions suivantes.
 
 ```
-Iteration 1 : 45 cases vides -> prédire la plus certaine (confiance 99%)
-Iteration 2 : 44 cases vides -> plus d'indices, predictions plus sures
+Itération 1 : 45 cases vides -> prédire la plus certaine (confiance 99%)
+Itération 2 : 44 cases vides -> plus d'indices, predictions plus sures
 ...
-Iteration 45 : 1 case vide -> presque triviale
+Itération 45 : 1 case vide -> presque triviale
 ```
 
-**Risque** : si une prediction intermediaire est fausse, les erreurs se propagent. Le seuil de confiance peut attenuer ce risque.",,,,,,,,216a6039025ee50e,,,,,,,
+**Risque** : si une prediction intermediaire est fausse, les erreurs se propagent. Le seuil de confiance peut attenuer ce risque.",,,,,,,,c3d413cd763b031f,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,iterative-predict,code,fr,d324b856d8ef9b3b,"def iterative_predict(model, puzzle: np.ndarray, verbose: bool = False) -> np.ndarray:
     """"""Prediction iterative : remplir une case a la fois.
     
@@ -12553,22 +12579,22 @@ for i in range(3):
     print(f""  Directe   : {direct_correct}/81 cases correctes ({direct_correct == 81})"")
     print(f""  Iterative : {iter_correct}/81 cases correctes ({iter_correct == 81})"")
     print()",,,,,,,,d324b856d8ef9b3b,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,iterative-interp,markdown,fr,03de88142bf3bd32,"### Interpretation : impact de la prediction iterative
+MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,iterative-interp,markdown,fr,2c5975e6487a1791,"### Interpretation : impact de la prediction iterative
 
-La prediction iterative ameliore considerablement les resultats car :
+La prediction iterative ameliore considerablement les résultats car :
 
 | Aspect | Prediction directe | Prediction iterative |
 |--------|-------------------|---------------------|
-| Contexte utilise | Uniquement les indices initiaux | Indices + cases deja remplies |
-| Risque d'erreur | Independant par case | Risque de propagation d'erreurs |
+| Contexte utilise | Uniquement les indices initiaux | Indices + cases déjà remplies |
+| Risque d'erreur | Indépendant par case | Risque de propagation d'erreurs |
 | Precision par grille | Faible | Nettement supérieure |
 
 **Points cles** :
 1. La confiance du réseau est un bon indicateur : les premières cases remplies sont souvent correctes
-2. L'amelioration est d'autant plus forte que le modèle est precis par case
+2. L'amelioration est d'autant plus forte que le modèle est précis par case
 3. C'est exactement le mécanisme utilise par les humains : resoudre d'abord les cases evidentes
 
-> **Note technique** : cette approche est similaire aux modèles auto-regressifs en NLP (GPT) qui génèrent un token a la fois en conditionnant sur les tokens precedents.",,,,,,,,03de88142bf3bd32,,,,,,,
+> **Note technique** : cette approche est similaire aux modèles auto-regressifs en NLP (GPT) qui génèrent un token a la fois en conditionnant sur les tokens précédents.",,,,,,,,2c5975e6487a1791,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,eval-section,markdown,fr,316126915a0eefb6,"## 9. Évaluation comparative et analyse
 
 Evaluons systematiquement les deux architectures (MLP et CNN) avec les deux stratégies de prediction (directe et iterative) sur le jeu de test complet.",,,,,,,,316126915a0eefb6,,,,,,,
@@ -12657,9 +12683,9 @@ print(""-"" * 70)
 for name, r in results.items():
     iter_label = "" (200)"" if 'iteratif' in name else f"" ({len(puzzles_test)})""
     print(f""{name:<20} {r['cell_acc']:>14.1%} {r['grid_acc']:>17.1%} {r['correct_grids']:>5}/{r['total']}"")",,,,,,,,7f1de15ef5e1d686,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,eval-interp,markdown,fr,c770706701678130,"### Interpretation : tableau comparatif
+MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,eval-interp,markdown,fr,05adf6b2934e8125,"### Interpretation : tableau comparatif
 
-**Resultats attendus (50K puzzles, loss masquee, early stopping)** :
+**Résultats attendus (50K puzzles, loss masquee, early stopping)** :
 
 | Configuration | Precision/case (vides) | Precision/grille | Observation |
 |---------------|----------------------|-----------------|-------------|
@@ -12668,7 +12694,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,eval-interp,markdo
 | CNN direct | ~70-85% | 5-30% | Filtres spatiaux |
 | CNN iteratif | ~80-95% | 20-50% | Amelioration significative |
 | ResCNN direct | ~90-99% | 30-60% | Architecture profonde |
-| ResCNN iteratif | ~95-99%+ | 50-90%+ | Combine profondeur + iteration |
+| ResCNN iteratif | ~95-99%+ | 50-90%+ | Combine profondeur + itération |
 | NeuroConstraint | -- | 22% (11/50) | Impl. pedagogique limitee par le ResCNN 50K |
 
 **Points cles** :
@@ -12677,7 +12703,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,eval-interp,markdo
 3. **L'approche hybride NeuroConstraint** : le NN propose des valeurs probables, les contraintes filtrent les impossibles, le backtracking corrige les erreurs. Sur 50 puzzles de test, l'implementation pedagogique (ResCNN entraine sur 50K) resout **22% (11/50)** des grilles : la phase de prediction greedy peut completer une grille valide mais incorrecte
 4. **L'ecart entre cell_acc et grid_acc** illustre un principe fondamental : 99% par case ne signifie PAS 99% par grille (0.99^45 ~ 63% pour 45 cases vides)
 
-**Comparaison avec les solveurs algorithmiques** : le NeuroConstraint combine le meilleur des deux mondes -- la rapidite du NN pour proposer des candidats ordonnes par pertinence, et la garantie du backtracking pour corriger les erreurs.",,,,,,,,c770706701678130,,,,,,,
+**Comparaison avec les solveurs algorithmiques** : le NeuroConstraint combine le meilleur des deux mondes -- la rapidite du NN pour proposer des candidats ordonnes par pertinence, et la garantie du backtracking pour corriger les erreurs.",,,,,,,,05adf6b2934e8125,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,visualization,code,fr,cd8c2d8e69d16f25,"# Visualisation : grille predite vs solution
 def plot_sudoku_comparison(puzzle, prediction, solution, title=""""):
     """"""Affiche puzzle, prediction et solution cote a cote.""""""
@@ -12789,7 +12815,7 @@ La heatmap revele les positions ou le réseau commet le plus d'erreurs :
 | Propagation d'erreurs | Erreur precoce = grille fausse | Seuil de confiance + backtrack |
 
 > **Vers une approche hybride** : combiner la prediction neuronale avec un verificateur de contraintes permet de garantir la validite. Le réseau propose, le solveur dispose.",,,,,,,,95893475e175d8b8,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,exercises-section,markdown,fr,aa2955716f97133d,"---
+MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,exercises-section,markdown,fr,bd7a3dd4dbfdb4b6,"---
 
 ## Exercice : Experimentations avec les Réseaux de Neurones
 
@@ -12798,9 +12824,9 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,exercises-section,
 Modifiez l'architecture du CNN pour observer l'impact :
 - Ajouter ou retirer des couches de convolution
 - Modifier le nombre de filtres (32, 64, 128, 256)
-- Tester des kernel sizes differents (1x1, 3x3, 5x5)
+- Tester des kernel sizes différents (1x1, 3x3, 5x5)
 
-**Question** : quel est le nombre minimal de couches pour atteindre un champ receptif couvrant toute la grille 9x9 avec des filtres 3x3 ?",,,,,,,,aa2955716f97133d,,,,,,,
+**Question** : quel est le nombre minimal de couches pour atteindre un champ receptif couvrant toute la grille 9x9 avec des filtres 3x3 ?",,,,,,,,bd7a3dd4dbfdb4b6,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,exercise-1,code,fr,603b47a3c890320d,"# Exercice 1 : Experimentez avec l'architecture CNN
 # Indice : le champ receptif d'un filtre 3x3 apres n couches est (2n+1) x (2n+1)
 # Pour couvrir 9x9, il faut 2n+1 >= 9, soit n >= 4 couches
@@ -12897,7 +12923,7 @@ def hybrid_solve(model, puzzle: np.ndarray, confidence_threshold: float = 0.95) 
 #     print(f""Puzzle {i}: {'OK' if correct else 'ERREUR'}"")
 print(""Exercice a completer - implementez hybrid_solve"")
 ",,,,,,,,be8856a30c053a75,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,conclusion-section,markdown,fr,1cc19316a80e2183,"## Conclusion
+MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,conclusion-section,markdown,fr,6798ca225fe8231c,"## Conclusion
 
 ### Recapitulatif des architectures etudiees
 
@@ -12927,7 +12953,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,conclusion-section
 
 ### Ce que nous avons appris
 
-1. **Les données sont essentielles** : passer de 1K a 50K puzzles transforme les resultats (sur-apprentissage massif vs généralisation correcte)
+1. **Les données sont essentielles** : passer de 1K a 50K puzzles transforme les résultats (sur-apprentissage massif vs généralisation correcte)
 2. **La structure spatiale compte** : le CNN surpasse le MLP, le ResCNN surpasse le CNN, et le RRN les surpasse tous en exploitant la structure de graphe du Sudoku
 3. **La structure de graphe est déterminante** : avec ~350K paramètres, le RRN atteint 83.5% grid accuracy tandis que les baselines CNN/MLP n'atteignent même pas 1%. Le message passing entre cellules contraintes est bien plus informatif que les convolutions locales
 4. **La loss masquee est cruciale** : ne calculer la loss que sur les cases a prédire empeche le réseau de ""tricher"" en recopiant les indices fournis
@@ -12943,7 +12969,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,conclusion-section
 | OR-Tools/Z3 | Contraintes | 100% | très rapide |
 | Dancing Links | Couverture exacte | 100% | Optimal |
 | Norvig | Propagation + BT | 100% | Rapide |
-| Genetique | Metaheuristique | ~50% | Lent |
+| Génétique | Métaheuristique | ~50% | Lent |
 | MLP (GPU, baseline) | Apprentissage | **0% grille** | Rapide |
 | CNN (GPU, baseline) | Apprentissage | **0% grille** | Rapide |
 | ResCNN (pur, CPU) | Apprentissage | 30-60% grille | Rapide |
@@ -12952,14 +12978,14 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,conclusion-section
 
 **Conclusion** : les réseaux de neurones purs ne garantissent pas la validite, mais combinent aux contraintes algorithmiques, ils produisent un solveur a la fois rapide et fiable. Le NN agit comme un **heuristique intelligent** qui guide le solveur vers les valeurs les plus probables, accelerant considerablement la recherche par rapport au backtracking seul.
 
-Le RRN avec curriculum learning atteint 83.5% de grilles correctes en zero-shot, un resultat notable pour une approche purement neuronale. Les baselines CNN/MLP avec le même nombre de paramètres echouent completement (0% grid accuracy), demontrant que la structure de graphe du RRN est le facteur cle de succes. En prediction iterative (remplissage case par case avec re-inference), ce score serait significativement plus élevé. La littérature (Palm et al., 2018) rapporte des scores superieurs a 95% avec des modèles plus profonds et des datasets plus vastes.
+Le RRN avec curriculum learning atteint 83.5% de grilles correctes en zero-shot, un résultat notable pour une approche purement neuronale. Les baselines CNN/MLP avec le même nombre de paramètres echouent completement (0% grid accuracy), demontrant que la structure de graphe du RRN est le facteur cle de succes. En prediction iterative (remplissage case par case avec re-inference), ce score serait significativement plus élevé. La littérature (Palm et al., 2018) rapporte des scores superieurs a 95% avec des modèles plus profonds et des datasets plus vastes.
 
 ### Pour aller plus loin
 
 - [Projet de référence : 4 architectures sur 17M puzzles](https://github.com/jsboigeEpita/2024-EPITA-SCIA-PPC-Sudoku-CV) - architectures plus profondes
 - [Palm et al. (2018) : Recurrent Relational Network for Sudoku](https://arxiv.org/abs/1711.08028) - ~97% grille sur dataset massif
 - [Graph Neural Networks for combinatorial optimization](https://arxiv.org/abs/2012.01806)
-- Approches par reinforcement learning : apprendre a resoudre par essai-erreur",,,,,,,,1cc19316a80e2183,,,,,,,
+- Approches par reinforcement learning : apprendre a resoudre par essai-erreur",,,,,,,,6798ca225fe8231c,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,f1mjsh2116i,code,fr,186e3fcb6bbb9cc9,"class NeuroConstraintSolver:
     """"""Solveur hybride combinant prediction neuronale et contraintes Sudoku.
     
@@ -13178,7 +13204,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,footer-nav,markdow
 - [Sudoku-Python-Backtracking](Sudoku-1-Backtracking-Python.ipynb) : backtracking en Python (même SudokuGrid)
 - [Sudoku-7-Norvig](Sudoku-7-Norvig-Python.ipynb) : propagation de contraintes
 - [Sudoku-Python-Genetic](Sudoku-3-Genetic-Python.ipynb) : autre approche non-déterministe",,,,,,,,89c56a76f34c64bb,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,intro,markdown,fr,f43fdefbd6be133c,"**Navigation** : [Index](README.md) | [<< Sudoku-16 Python](Sudoku-16-NeuralNetwork-Python.ipynb) | [Sudoku-18 >>](Sudoku-18-Comparison-Python.ipynb)
+MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,intro,markdown,fr,fea2510bf0c9cc92,"**Navigation** : [Index](README.md) | [<< Sudoku-16 Python](Sudoku-16-NeuralNetwork-Python.ipynb) | [Sudoku-18 >>](Sudoku-18-Comparison-Python.ipynb)
 
 # Notebook 17: Resolution de Sudoku avec Large Language Models (LLM)
 
@@ -13186,13 +13212,13 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,intro,markdown,fr,f43fdefbd6
 
 A la fin de ce notebook, vous saurez :
 - **Comprendre** les capacites et limites des LLM pour la resolution de Sudoku
-- **Implementer** differentes approches : Zero-shot, Few-shot, Chain-of-Thought
-- **Utiliser** le LLM comme generateur de code (code interpreter)
+- **Implementer** différentes approches : Zero-shot, Few-shot, Chain-of-Thought
+- **Utiliser** le LLM comme générateur de code (code interpreter)
 - **Evaluer** la performance des LLM vs solveurs algorithmiques
 
 **Duree estimee** : 30-40 minutes
 **Prerequis** : Aucun, connaissance basique des LLM recommandee
-**API requise** : OpenAI API ou compatible",,,,,,,,f43fdefbd6be133c,,,,,,,
+**API requise** : OpenAI API ou compatible",,,,,,,,fea2510bf0c9cc92,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,f166be80-7bf6-408f-b027-031f96c338ff,code,fr,5a714e8982d8495e,"try:
     import dotenv
     import os
@@ -13202,19 +13228,19 @@ except ImportError:
     DOTENV_AVAILABLE = False
     print(""python-dotenv non disponible. Utilisez les variables d'environnement directement."")
 print(f""Environnement charge : dotenv={'OK' if DOTENV_AVAILABLE else 'absent'}"")",,,,,,,,5a714e8982d8495e,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,intro-llm,markdown,fr,c1d93ff4d7fd2052,"## Introduction : LLM et Resolution de Problemes Combinatoires
+MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,intro-llm,markdown,fr,d226c6ce02c55f83,"## Introduction : LLM et Resolution de Problemes Combinatoires
 
 ### Pourquoi utiliser un LLM pour Sudoku ?
 
-Le Sudoku est un probleme **combinatoire** qui demande :
+Le Sudoku est un problème **combinatoire** qui demande :
 - **Raisonnement logique** : Deduction et propagation de contraintes
-- **Explosion combinatoire** : 9^81 possibilites theoriques
+- **Explosion combinatoire** : 9^81 possibilites théoriques
 - **Precision** : Une seule erreur invalide toute la solution
 
 Les LLM (GPT-4, Claude, etc.) sont :
 - **Entraînes sur du code** : Connaissent les algorithmes de Sudoku
-- **Capables de raisonnement** : Peuvent suivre des etapes logiques
-- **Generatifs** : Peuvent ecrire du code pour resoudre le probleme
+- **Capables de raisonnement** : Peuvent suivre des étapes logiques
+- **Generatifs** : Peuvent ecrire du code pour resoudre le problème
 
 ### Approches LLM pour Sudoku
 
@@ -13223,7 +13249,7 @@ Les LLM (GPT-4, Claude, etc.) sont :
 | **Zero-shot** | Donner la grille et demander la solution | Simple | Taux d'echec eleve |
 | **Few-shot** | Donner des exemples resolus | Meilleure performance | Consomme des tokens |
 | **Chain-of-Thought** | Demander au LLM d'expliquer sa démarche | Meilleure raisonnement | Plus lent |
-| **Code Interpreter** | Le LLM écrit et execute du code Python | Tres fiable | Necessite execution |
+| **Code Interpreter** | Le LLM écrit et execute du code Python | Très fiable | Necessite exécution |
 
 ### Performance attendue
 
@@ -13232,7 +13258,7 @@ Selon les études récentes (2023-2025) :
 - **Claude 3.5 Sonnet** : ~40-60% de réussite
 - **Code Interpreter** : ~99% de réussite (genere du code valide)
 
-Les solveurs algorithmiques (backtracking, OR-Tools, Z3) restent **superieurs** en performance et fiabilité.",,,,,,,,c1d93ff4d7fd2052,,,,,,,
+Les solveurs algorithmiques (backtracking, OR-Tools, Z3) restent **superieurs** en performance et fiabilité.",,,,,,,,d226c6ce02c55f83,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,imports,code,fr,442839275772307f,"# Imports et configuration
 import os
 import json
@@ -13326,20 +13352,20 @@ print(f""Puzzles difficiles charges: {len(hard_puzzles)}"")
 example_grid = puzzle_to_grid(easy_puzzles[0])
 print(""\nExemple de puzzle facile:"")
 print_grid(example_grid)",,,,,,,,051da077818d8d6f,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,6e41d8bb,markdown,fr,489d3c38c30d20b3,"### Interpretation du Chargement des Puzzles
+MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,6e41d8bb,markdown,fr,ef8254d034906f2a,"### Interpretation du Chargement des Puzzles
 
-Les donnees ont ete chargees correctement et nous disposons maintenant de puzzles de differents niveaux de difficulte pour tester les approches LLM.
+Les données ont ete chargees correctement et nous disposons maintenant de puzzles de différents niveaux de difficulte pour tester les approches LLM.
 
 | Aspect | Valeur | Signification |
 |--------|--------|---------------|
 | **Puzzles faciles** | 5 charges | Sous-ensemble de `Sudoku_Easy51.txt` pour tests rapides |
 | **Puzzles difficiles** | 11 charges | Collection `Sudoku_hardest.txt` pour evaluation finale |
 | **Puzzle exemple** | 45 indices | Niveau de difficulte facile (environ 56% de cases remplies) |
-| **Format de stockage** | Chaine 81 caracteres | Representation compacte (0 pour vide, 1-9 pour valeurs) |
+| **Format de stockage** | Chaîne 81 caractères | Representation compacte (0 pour vide, 1-9 pour valeurs) |
 
 **Points cles** :
 1. **Strategy d'echantillonnage** : `max_puzzles=5` limite les puzzles faciles pour des tests plus rapides
-2. **Conversion automatique** : La fonction `puzzle_to_grid()` transforme les chaines en matrices 9x9
+2. **Conversion automatique** : La fonction `puzzle_to_grid()` transforme les chaînes en matrices 9x9
 3. **Affichage structure** : La fonction `print_grid()` ajoute des separateurs visuels pour les blocs 3x3
 4. **Fichiers disponibles** : Trois fichiers de difficultes croissantes (Easy51, hardest, top95)
 
@@ -13353,8 +13379,8 @@ Les donnees ont ete chargees correctement et nous disposons maintenant de puzzle
 > 1. Preservation des valeurs originales
 > 2. Unicite des valeurs dans chaque ligne
 > 3. Unicite des valeurs dans chaque colonne
-> 4. Unicite des valeurs dans chaque bloc 3x3",,,,,,,,489d3c38c30d20b3,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,api-setup,markdown,fr,f3b5110b419067ab,"## Configuration de l'API LLM
+> 4. Unicite des valeurs dans chaque bloc 3x3",,,,,,,,ef8254d034906f2a,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,api-setup,markdown,fr,57619cfb5db9be21,"## Configuration de l'API LLM
 
 Ce notebook supporte plusieurs providers LLM via OpenAI ou des APIs compatibles.
 
@@ -13369,11 +13395,11 @@ Ce notebook supporte plusieurs providers LLM via OpenAI ou des APIs compatibles.
 
 ### Configuration des variables d'environnement
 
-Creer un fichier `.env` dans le dossier `GenAI/` avec :
+Créer un fichier `.env` dans le dossier `GenAI/` avec :
 ```bash
 OPENAI_API_KEY=sk-...
 OPENAI_BASE_URL=https://api.openai.com/v1  # Optionnel
-```",,,,,,,,f3b5110b419067ab,,,,,,,
+```",,,,,,,,57619cfb5db9be21,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,171c8f00-f501-4be4-9130-b4422d35c895,code,fr,a5efa43e93a45b68,"# Installation silencieuse d'OpenAI (uniquement si absent de l'environnement)
 import subprocess, sys
 try:
@@ -13381,14 +13407,14 @@ try:
 except ImportError:
     subprocess.check_call([sys.executable, '-m', 'pip', 'install', 'openai'])
 ",,,,,,,,a5efa43e93a45b68,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,cc3b5572,markdown,fr,a6844c1e5010a11b,"### Configuration du client LLM
+MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,cc3b5572,markdown,fr,02eccfef4a3671a9,"### Configuration du client LLM
 
-La bibliotheque `openai` etant installee, nous pouvons maintenant configurer un client generique qui permet d'appeler differents modeles LLM. Ce client supporte :
+La bibliotheque `openai` etant installee, nous pouvons maintenant configurer un client generique qui permet d'appeler différents modèles LLM. Ce client supporte :
 
 - **Mode simulation** (par defaut) : Pour executer le notebook sans cle API, avec des reponses predefinies
-- **Mode API reelle** : Pour tester avec GPT-4, Claude ou tout modele compatible OpenAI
+- **Mode API reelle** : Pour tester avec GPT-4, Claude ou tout modèle compatible OpenAI
 
-Cette abstraction nous permettra de comparer facilement les approches sans nous soucier de l'infrastructure d'appel.",,,,,,,,a6844c1e5010a11b,,,,,,,
+Cette abstraction nous permettra de comparer facilement les approches sans nous soucier de l'infrastructure d'appel.",,,,,,,,02eccfef4a3671a9,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,llm-client,code,fr,52ceb7becf6091fa,"# Configuration du client LLM
 # Pour ce notebook pedagogique, nous utilisons le mode simulation par defaut
 # pour eviter d'appeler l'API OpenAI lors de l'execution.
@@ -13523,15 +13549,15 @@ def solve_sudoku(grid):
 client = LLMClient()
 print(f""Client LLM initialise: {client.provider}"")
 print(f""Mode simulation: {client.simulation_mode}"")",,,,,,,,52ceb7becf6091fa,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,approach-1-zero-shot,markdown,fr,f630160b58b47972,"## Approche 1 : Zero-Shot Prompting
+MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,approach-1-zero-shot,markdown,fr,d963306648438f27,"## Approche 1 : Zero-Shot Prompting
 
-La methode la plus simple consiste a donner la grille au LLM et lui demander de la resoudre directement.
+La méthode la plus simple consiste a donner la grille au LLM et lui demander de la resoudre directement.
 
 ### Prompt Zero-Shot
 
 ```
 Voici une grille de Sudoku. Les cases vides sont representees par des points (.).
-Complete la grille en respectant les regles du Sudoku (chaque ligne, colonne et bloc 3x3
+Complete la grille en respectant les règles du Sudoku (chaque ligne, colonne et bloc 3x3
 doit contenir les chiffres 1-9 exactement une fois).
 
 Grille:
@@ -13545,7 +13571,7 @@ Grille:
 ...419..5
 ....8..79
 
-Reponds uniquement avec la grille completee, au meme format.
+Reponds uniquement avec la grille completee, au même format.
 ```
 
 ### Avantages et Inconvenients
@@ -13554,7 +13580,7 @@ Reponds uniquement avec la grille completee, au meme format.
 - **Inconvenients** :
   - Taux d'echec eleve (~50-70%)
   - Erurs frequentes dans les grilles difficiles
-  - Le LLM peut ""halluciner"" des solutions invalides",,,,,,,,f630160b58b47972,,,,,,,
+  - Le LLM peut ""halluciner"" des solutions invalides",,,,,,,,d963306648438f27,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,zero-shot-solver,code,fr,fc02bb8ee35823f3,"def grid_to_string_format(grid: List[List[int]]) -> str:
     """"""Convertit une grille en format texte pour le prompt.""""""
     lines = []
@@ -13617,9 +13643,9 @@ if solution:
     print(f""Temps: {elapsed:.2f} secondes"")
 else:
     print(""Impossible de parser la reponse du LLM."")",,,,,,,,fc02bb8ee35823f3,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,1b1995fd,markdown,fr,d28b2198d90d9e08,"### Interpretation du Test Zero-Shot
+MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,1b1995fd,markdown,fr,5a89e7f186d35f75,"### Interpretation du Test Zero-Shot
 
-L'approche zero-shot a echoue a resoudre le puzzle, ce qui est typique pour cette methode sans exemple d'apprentissage.
+L'approche zero-shot a echoue a resoudre le puzzle, ce qui est typique pour cette méthode sans exemple d'apprentissage.
 
 | Aspect | Valeur | Signification |
 |--------|--------|---------------|
@@ -13631,14 +13657,14 @@ L'approche zero-shot a echoue a resoudre le puzzle, ce qui est typique pour cett
 1. **Mode simulation** : La grille retournee est une reponse predefinie (`534678912...`) qui ne correspond PAS au puzzle teste
 2. **Parsing reussi** : La fonction `parse_llm_response()` a correctement extrait la grille du texte du LLM
 3. **Validation essentielle** : La fonction `validate_solution()` a detecte que la solution est invalide
-4. **Limite du zero-shot** : Sans exemples ni raisonnement etape par etape, le LLM ne peut pas resoudre des puzzles non triviaux
+4. **Limite du zero-shot** : Sans exemples ni raisonnement étape par étape, le LLM ne peut pas resoudre des puzzles non triviaux
 
-> **Note technique** : Le zero-shot prompting est la methode la plus simple mais aussi la moins fiable :
+> **Note technique** : Le zero-shot prompting est la méthode la plus simple mais aussi la moins fiable :
 > - Taux de succes typique : 30-50% sur Sudokus faciles avec GPT-4
 > - Echoue souvent sur les puzzles difficiles (peu d'indices)
 > - Le LLM peut ""halluciner"" des solutions qui semblent valides mais ne respectent pas toutes les contraintes
 
-> **Comportement avec vrai LLM** : Avec une API GPT-4 ou Claude reelle, le zero-shot aurait un taux d'echec similaire sur les puzzles difficiles, mais pourrait reussir sur des puzzles tres faciles (beaucoup d'indices).",,,,,,,,d28b2198d90d9e08,,,,,,,
+> **Comportement avec vrai LLM** : Avec une API GPT-4 ou Claude reelle, le zero-shot aurait un taux d'echec similaire sur les puzzles difficiles, mais pourrait reussir sur des puzzles très faciles (beaucoup d'indices).",,,,,,,,5a89e7f186d35f75,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,approach-2-few-shot,markdown,fr,a5244756548041e4,"## Approche 2 : Few-Shot Prompting
 
 Le few-shot prompting donne au LLM des exemples de puzzles resolus pour improve la performance.
@@ -13761,9 +13787,9 @@ if solution:
     print(f""Temps: {elapsed:.2f} secondes"")
 else:
     print(""Impossible de parser la reponse du LLM."")",,,,,,,,6a2fc5ee756aa93d,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,dec74b42,markdown,fr,f36094a159666fe7,"### Interpretation du Test Few-Shot
+MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,dec74b42,markdown,fr,cc4d19c2899dff1a,"### Interpretation du Test Few-Shot
 
-L'approche few-shot montre les memes limites que le zero-shot dans ce mode simulation.
+L'approche few-shot montre les mêmes limites que le zero-shot dans ce mode simulation.
 
 | Aspect | Valeur | Signification |
 |--------|--------|---------------|
@@ -13773,17 +13799,17 @@ L'approche few-shot montre les memes limites que le zero-shot dans ce mode simul
 
 **Points cles** :
 1. **Exemples non utilises** : En mode simulation, les exemples few-shot ne sont pas vraiment utilises par le LLM
-2. **Meme reponse que zero-shot** : La grille retournee est identique a celle du zero-shot (grille predefinie)
+2. **Même reponse que zero-shot** : La grille retournee est identique a celle du zero-shot (grille predefinie)
 3. **Parsing correct** : La fonction `parse_llm_response()` a reussi a extraire la grille du texte
-4. **Limitation pedagogique** : Ce notebook illustre le principe du few-shot, mais la vraie difference ne se voit qu'avec une API LLM reelle
+4. **Limitation pedagogique** : Ce notebook illustre le principe du few-shot, mais la vraie différence ne se voit qu'avec une API LLM reelle
 
 > **Note technique** : Le few-shot prompting est plus efficace que le zero-shot car :
 > - Le LLM comprend mieux le format attendu (input/output)
 > - Les exemples guident le raisonnement
 > - Le taux de succes typique passe de ~30-50% (zero-shot) a ~50-70% (few-shot)
 
-> **Avec une vraie API** : En production avec GPT-4 ou Claude, le few-shot montrerait une amelioration significative par rapport au zero-shot, avec moins d'erreurs sur les cases difficiles.",,,,,,,,f36094a159666fe7,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,approach-3-code-interpreter,markdown,fr,ce271cc45d3ecd35,"## Approche 3 : Code Interpreter (Generation de Code)
+> **Avec une vraie API** : En production avec GPT-4 ou Claude, le few-shot montrerait une amelioration significative par rapport au zero-shot, avec moins d'erreurs sur les cases difficiles.",,,,,,,,cc4d19c2899dff1a,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,approach-3-code-interpreter,markdown,fr,a7af72244671abc3,"## Approche 3 : Code Interpreter (Generation de Code)
 
 L'approche la plus fiable consiste a demander au LLM de **generer du code Python** qui resout le Sudoku, puis d'executer ce code.
 
@@ -13809,8 +13835,8 @@ Reponds uniquement avec le code Python, sans explication.
   - Fonctionne sur tous les types de puzzles
 - **Inconvenients** :
   - Necessite d'executer du code (risque de securite)
-  - Plus lent (generation + execution)
-  - Depend de la capacite du LLM a ecrire du code valide",,,,,,,,ce271cc45d3ecd35,,,,,,,
+  - Plus lent (generation + exécution)
+  - Depend de la capacite du LLM a ecrire du code valide",,,,,,,,a7af72244671abc3,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,code-interpreter,code,fr,64280310eb0a7916,"def code_interpreter_solve(grid: List[List[int]], client: LLMClient) -> Optional[List[List[int]]]:
     """"""Utilise le LLM pour generer du code Python qui resout le Sudoku.""""""
     
@@ -13875,7 +13901,7 @@ if solution:
     print(f""Temps: {elapsed:.2f} secondes"")
 else:
     print(""Echec de la resolution par code interpreter."")",,,,,,,,64280310eb0a7916,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,a197dc35,markdown,fr,c23970fadc193e80,"### Interpretation du Test Code Interpreter
+MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,a197dc35,markdown,fr,7c3876bec551d8ec,"### Interpretation du Test Code Interpreter
 
 Le code interpreter a reussi a resoudre le puzzle avec une solution valide, contrairement aux approches zero-shot et few-shot.
 
@@ -13889,19 +13915,19 @@ Le code interpreter a reussi a resoudre le puzzle avec une solution valide, cont
 1. **Code backtracking correct** : Le LLM a genere un solveur avec backtracking, l'algorithme classique pour Sudoku
 2. **Validation automatique** : La fonction `validate_solution()` a verifie que la grille originale est preservee et que toutes les contraintes sont respectees
 3. **Environnement securise** : Le code est execute dans un environnement restreint (`exec_globals` ne contient que les fonctions necessaires)
-4. **Portabilite** : Le meme code fonctionnerait avec n'importe quel puzzle Sudoku
+4. **Portabilite** : Le même code fonctionnerait avec n'importe quel puzzle Sudoku
 
-> **Note technique** : Le code genere par le LLM utilise une approche recursive classique :
+> **Note technique** : Le code genere par le LLM utilise une approche récursive classique :
 > - Parcourir la grille case par case
 > - Pour chaque case vide, essayer les valeurs 1-9
 > - Verifier si la valeur est valide (ligne, colonne, bloc)
 > - Si valide, placer la valeur et recursivement continuer
 > - Si echec, backtracker (retirer la valeur et essayer la suivante)
 
-> **Comparaison avec vrai LLM** : Avec GPT-4 ou Claude 3.5, le code interpreter serait aussi fiable mais prendrait 15-30 secondes (generation + execution). La version simulation est instantanee car le code est predefini.",,,,,,,,c23970fadc193e80,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,benchmark,markdown,fr,ed84b7f2c7fad329,"## Benchmark : Comparaison des Approches LLM
+> **Comparaison avec vrai LLM** : Avec GPT-4 ou Claude 3.5, le code interpreter serait aussi fiable mais prendrait 15-30 secondes (generation + exécution). La version simulation est instantanee car le code est predefini.",,,,,,,,7c3876bec551d8ec,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,benchmark,markdown,fr,68aedd37132eabd0,"## Benchmark : Comparaison des Approches LLM
 
-Comparons les trois approches sur differents niveaux de difficulte.",,,,,,,,ed84b7f2c7fad329,,,,,,,
+Comparons les trois approches sur différents niveaux de difficulte.",,,,,,,,68aedd37132eabd0,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,benchmark-llm,code,fr,6e01a4b056eb93e9,"def benchmark_llm_approaches(puzzles: List[str], client: LLMClient, limit: int = 3) -> Dict:
     """"""Compare les differentes approches LLM.""""""
     results = {
@@ -13971,31 +13997,31 @@ for approach, data in benchmark_results.items():
     rate = (valid / total * 100) if total > 0 else 0
     avg_time = data[""total_time""] / total if total > 0 else 0
     print(f""| {approach:20} | {valid:3} / {total:3} | {rate:14.1f}% | {avg_time:10.2f}s |"")",,,,,,,,6e01a4b056eb93e9,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,fd98ca7b,markdown,fr,f6628d730bc405d5,"### Interpretation des Resultats du Benchmark
+MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,fd98ca7b,markdown,fr,1759fd5ee399a94b,"### Interpretation des Résultats du Benchmark
 
-Les resultats du benchmark confirment les tendances attendues dans la litterature sur les LLM pour la resolution de Sudoku.
+Les résultats du benchmark confirment les tendances attendues dans la litterature sur les LLM pour la resolution de Sudoku.
 
 | Approche | Taux de succes | Performance | Observations |
 |----------|----------------|-------------|--------------|
 | **Zero-shot** | 0% | Echec total | Le mode simulation retourne une grille predefinie qui ne correspond pas au puzzle |
-| **Few-shot** | 0% | Echec total | Memes limites que zero-shot dans ce mode simulation |
+| **Few-shot** | 0% | Echec total | Mêmes limites que zero-shot dans ce mode simulation |
 | **Code Interpreter** | 100% | Parfait | Le code genere est correct et resout tous les puzzles |
 
 **Points cles** :
 1. **Mode simulation** : Les reponses zero-shot et few-shot sont des grilles predefinies qui ne correspondent pas aux puzzles testes, ce qui explique le taux d'echec de 0%
-2. **Code interpreter fiable** : Meme en mode simulation, le code Python genere est correct et produit des solutions valides
+2. **Code interpreter fiable** : Même en mode simulation, le code Python genere est correct et produit des solutions valides
 3. **Validation critique** : La fonction `validate_solution()` est essentielle pour detecter les erreurs du LLM
 4. **Temps negligeable** : En mode simulation, tous les temps sont a 0.00s (pas d'appels API reels)
 
 > **Note technique** : Avec une vraie API LLM (GPT-4, Claude), les taux typiques seraient : zero-shot ~30-50%, few-shot ~50-70%, code interpreter ~95-99%. Les temps reels seraient de 5-30 secondes par puzzle selon l'approche.
 
-> **Note sur la simulation** : Ce notebook utilise le mode simulation pour eviter les couts d'API. Pour tester avec de vrais appels LLM, modifier `simulation_mode = False` dans la classe `LLMClient` et configurer une cle API valide.",,,,,,,,f6628d730bc405d5,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,analysis,markdown,fr,9cb022d18c715a73,"## Analyse des Resultats
+> **Note sur la simulation** : Ce notebook utilise le mode simulation pour eviter les couts d'API. Pour tester avec de vrais appels LLM, modifier `simulation_mode = False` dans la classe `LLMClient` et configurer une cle API valide.",,,,,,,,1759fd5ee399a94b,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,analysis,markdown,fr,d256893e9a58314a,"## Analyse des Résultats
 
 ### Observations typiques
 
 1. **Zero-shot** :
-   - Reussit sur les puzzles tres faciles (beaucoup d'indices)
+   - Reussit sur les puzzles très faciles (beaucoup d'indices)
    - Echoue souvent sur les puzzles difficiles
    - Parfois produit des solutions invalides (contraintes violees)
 
@@ -14006,16 +14032,16 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,analysis,markdown,fr,9cb022d
 
 3. **Code Interpreter** :
    - Taux de succes le plus eleve (>95%)
-   - Plus lent (generation + execution du code)
+   - Plus lent (generation + exécution du code)
    - Plus fiable car le code peut etre verifie
 
 ### LLM vs Solveurs Algorithmiques
 
-| Methode | Taux de succes | Temps (moyen) | Avantages |
+| Méthode | Taux de succes | Temps (moyen) | Avantages |
 |---------|----------------|---------------|-----------|
 | **LLM Zero-shot** | ~30-50% | 5-10s | Simple, intuitif |
 | **LLM Few-shot** | ~50-70% | 10-20s | Meilleure performance |
-| **LLM Code Gen** | ~95-99% | 15-30s | Tres fiable |
+| **LLM Code Gen** | ~95-99% | 15-30s | Très fiable |
 | **Backtracking** | 100% | 0.01-0.1s | Rapide, garantie |
 | **OR-Tools** | 100% | 0.001-0.01s | Optimal |
 
@@ -14023,21 +14049,21 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,analysis,markdown,fr,9cb022d
 
 Malgré leur performance inferieure, les LLM ont des cas d'usage legitimes :
 
-1. **Education** : Expliquer les etapes de resolution
-2. **Generation** : Creer de nouveaux puzzles valides
+1. **Education** : Expliquer les étapes de resolution
+2. **Generation** : Créer de nouveaux puzzles valides
 3. **Aide a la resolution** : Suggere les prochaines cases a remplir
 4. **Verification** : Verifier si une solution est correcte
-5. **Interface naturelle** : Resolution vocale ou textuelle",,,,,,,,9cb022d18c715a73,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,exercises,markdown,fr,d2f4b083623a31ba,"---
+5. **Interface naturelle** : Resolution vocale ou textuelle",,,,,,,,d256893e9a58314a,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,exercises,markdown,fr,a9950d4e282168ae,"---
 
 ## Exemple guide : Approches LLM pour Sudoku
 
 ### Exemple guide 1 : Ameliorer le Prompt Zero-Shot
 
-Modifier le prompt zero-shot pour inclure des instructions plus specifiques :
+Modifier le prompt zero-shot pour inclure des instructions plus spécifiques :
 - Demander au LLM de verifier sa solution
 - Specifier que chaque ligne/colonne/bloc doit contenir 1-9
-- Demander de reflechir etape par etape (Chain-of-Thought)
+- Demander de reflechir étape par étape (Chain-of-Thought)
 
 ### Exemple guide 2 : Approche Hybride
 
@@ -14049,9 +14075,9 @@ Implementer une approche hybride :
 ### Exemple guide 3 : Generation de Sudokus
 
 Utiliser le LLM pour generer de nouveaux Sudokus :
-- Demander de creer une grille complete valide
-- Puis demander de retirer des cases pour creer le puzzle
-- Verifier que le puzzle a une solution unique",,,,,,,,d2f4b083623a31ba,,,,,,,
+- Demander de créer une grille complete valide
+- Puis demander de retirer des cases pour créer le puzzle
+- Verifier que le puzzle a une solution unique",,,,,,,,a9950d4e282168ae,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,avt0s3bqehi,code,fr,3a4f3cc378efafed,"# Exemple resolu : Solveur LLM avec Chain-of-Thought et validation iterative
 # Ce code sert de reference pour comprendre l'approche CoT.
 # Ne pas modifier - implementez votre propre version dans l'exercice ci-dessous.
@@ -14188,19 +14214,19 @@ if solution:
     print(f""Valide : {validate_solution(solution, example_grid)}"")
 else:
     print(""Echec de la resolution"")",,,,,,,,3a4f3cc378efafed,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,10dc39c1,markdown,fr,09d00941afe6e4c8,"---
+MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,10dc39c1,markdown,fr,d9abf7e810601956,"---
 
 ### Exemple guide variant : Solveur LLM sans backtracking
 
-L'exemple resolu ci-dessus utilise un mecanisme de backtracking (pile d'affectations + retour en arriere). Implementez une version simplifiee sans backtracking :
+L'exemple resolu ci-dessus utilise un mécanisme de backtracking (pile d'affectations + retour en arriere). Implementez une version simplifiee sans backtracking :
 
-**Principe** : A chaque iteration, demandez au LLM une seule affectation. Si elle est valide, appliquez-la. Si elle est invalide, relancez la demande en precisant la contrainte violee, sans annuler les affectations precedentes.
+**Principe** : A chaque itération, demandez au LLM une seule affectation. Si elle est valide, appliquez-la. Si elle est invalide, relancez la demande en precisant la contrainte violee, sans annuler les affectations précédentes.
 
 **Consignes** :
-1. Implementez `build_single_cell_prompt(grid, failed_attempt)` qui construit un prompt different de l'exemple
+1. Implementez `build_single_cell_prompt(grid, failed_attempt)` qui construit un prompt différent de l'exemple
 2. Implementez `solve(puzzle)` avec une boucle simple (pas de pile, pas de retour arriere)
-3. Ajoutez un compteur de tentatives consecutives echouees ; apres 5 echecs, arreter proprement
-4. Testez sur `easy_puzzles[1]`",,,,,,,,09d00941afe6e4c8,,,,,,,
+3. Ajoutez un compteur de tentatives consecutives echouees ; après 5 echecs, arreter proprement
+4. Testez sur `easy_puzzles[1]`",,,,,,,,d9abf7e810601956,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,35ffea28,code,fr,bd902ee605003640,"# Exemple guide variant : Solveur LLM sans backtracking
 
 class SinglePassLLMSolver:
@@ -14247,22 +14273,22 @@ if sp_solution:
     print(f""Valide : {validate_solution(sp_solution, test_grid)}"")
 else:
     print(""Echec de la resolution"")",,,,,,,,bd902ee605003640,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,2abed6d2,markdown,fr,28bab3b0801365bb,"### Affichage de la grille de reference
+MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,2abed6d2,markdown,fr,e9cdb423b81722ae,"### Affichage de la grille de reference
 
-Le solveur `SinglePassLLMSolver` est maintenant defini. Verifions l'etat de notre grille exemple avant de l'utiliser :",,,,,,,,28bab3b0801365bb,,,,,,,
+Le solveur `SinglePassLLMSolver` est maintenant défini. Verifions l'etat de notre grille exemple avant de l'utiliser :",,,,,,,,e9cdb423b81722ae,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,d68e18a5-c358-4804-b906-ef0ee0cc4f12,code,fr,664b8b0bf6ccfaad,print_grid(example_grid),,,,,,,,664b8b0bf6ccfaad,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,fefd8a4a,markdown,fr,7f0cce91404272d4,"### Verification de l'etat de la grille
+MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,fefd8a4a,markdown,fr,72bdffc1ce0be98d,"### Verification de l'etat de la grille
 
-Avant de passer aux exercices suivants, verifions que la grille exemple est toujours dans son etat original (non modifiee par les tentatives de resolution precedentes). Cette verification est essentielle quand on enchaine plusieurs solveurs sur la meme grille.",,,,,,,,7f0cce91404272d4,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,99q8jpxuu94,markdown,fr,af109dc9fb137467,"---
+Avant de passer aux exercices suivants, verifions que la grille exemple est toujours dans son etat original (non modifiée par les tentatives de resolution précédentes). Cette verification est essentielle quand on enchaine plusieurs solveurs sur la même grille.",,,,,,,,72bdffc1ce0be98d,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,99q8jpxuu94,markdown,fr,d5e04c015452eeee,"---
 
 ## Exemple resolu : Solveur LLM avec Chain-of-Thought et Validation
 
 ### Objectif
 
 Les LLM commettent souvent des erreurs lorsqu'on leur demande de resoudre directement un Sudoku. Une approche plus prometteuse est de combiner :
-1. **Chain-of-Thought** : Le LLM explique son raisonnement etape par etape
-2. **Validation locale** : A chaque etape, verifier que l'affectation proposee est valide
+1. **Chain-of-Thought** : Le LLM explique son raisonnement étape par étape
+2. **Validation locale** : A chaque étape, verifier que l'affectation proposee est valide
 3. **Correction interactive** : Si une erreur est detectee, demander au LLM de se corriger
 
 ### Solution de reference
@@ -14272,41 +14298,41 @@ La classe `ChainOfThoughtSudokuSolver` ci-dessous illustre une implementation co
 1. **Prompt CoT** : Le prompt demande au LLM d'identifier la case la plus contrainte et d'expliquer son choix
 2. **Parser** : Extraction de l'affectation `(row, col) = value` depuis la reponse du LLM
 3. **Validation** : Chaque affectation est verifiee avant d'etre appliquee a la grille
-4. **Mecanisme de retour** : En cas d'echecs repetes, la derniere affectation est annulee (backtracking local)
+4. **Mécanisme de retour** : En cas d'echecs repetes, la dernière affectation est annulee (backtracking local)
 
 ### Contrainte
 
-Utiliser uniquement le client LLM fourni (compatible mode simulation et mode API).",,,,,,,,af109dc9fb137467,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,78722786,markdown,fr,d30db829eca8b082,"---
+Utiliser uniquement le client LLM fourni (compatible mode simulation et mode API).",,,,,,,,d5e04c015452eeee,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,78722786,markdown,fr,38ececba8f3b69c7,"---
 
 ## Exercice : Few-Shot avec raisonnement guide pour Sudoku
 
 ### Objectif
 
-L'approche Chain-of-Thought de l'exemple precedent demande au LLM d'identifier une seule case a la fois. Une strategie alternative consiste a fournir au LLM des **exemples de raisonnement complet** (few-shot avec explications), puis de lui demander de resoudre le puzzle en suivant le meme patron de raisonnement.
+L'approche Chain-of-Thought de l'exemple précédent demande au LLM d'identifier une seule case a la fois. Une stratégie alternative consiste a fournir au LLM des **exemples de raisonnement complet** (few-shot avec explications), puis de lui demander de resoudre le puzzle en suivant le même patron de raisonnement.
 
 ### Principe
 
 Le few-shot avec raisonnement guide combine deux idees :
-1. **Few-shot** : Fournir un ou plusieurs exemples de grille partiellement resolue avec les etapes de deduction
+1. **Few-shot** : Fournir un ou plusieurs exemples de grille partiellement resolue avec les étapes de deduction
 2. **Raisonnement structure** : Chaque exemple montre le raisonnementlogique (elimination des candidats, identification des valeurs forcees)
-3. **Application** : Demander au LLM d'appliquer le meme type de raisonnement sur une nouvelle grille
+3. **Application** : Demander au LLM d'appliquer le même type de raisonnement sur une nouvelle grille
 
 ### Travau demande
 
 Implementer la classe `FewShotReasoningSolver` avec :
 
-1. **Construire les exemples** : Formater un ou deux exemples de resolution partielle (3-4 etapes) avec les explications de deduction pour chaque etape
-2. **Construire le prompt** : Assembler les exemples + la grille a resoudre + une instruction demandant de suivre le meme format
+1. **Construire les exemples** : Formater un ou deux exemples de resolution partielle (3-4 étapes) avec les explications de deduction pour chaque étape
+2. **Construire le prompt** : Assembler les exemples + la grille a resoudre + une instruction demandant de suivre le même format
 3. **Parser la reponse** : Extraire les affectations `(row, col) = value` depuis le texte du LLM, qui contient maintenant du raisonnement melange aux affectations
 4. **Valider et appliquer** : Verifier chaque affectation et l'appliquer si elle est valide
 
 ### Contraintes
 
-- Utiliser le client LLM fourni (`client` defini plus haut)
-- Les exemples few-shot doivent contenir au moins 3 etapes de deduction avec explication
-- Le format de sortie attendu doit etre : `Etape N : (row, col) = valeur -- [explication]`
-- Gerer le cas ou le LLM ne respecte pas le format demande",,,,,,,,d30db829eca8b082,,,,,,,
+- Utiliser le client LLM fourni (`client` défini plus haut)
+- Les exemples few-shot doivent contenir au moins 3 étapes de deduction avec explication
+- Le format de sortie attendu doit etre : `Étape N : (row, col) = valeur -- [explication]`
+- Gerer le cas ou le LLM ne respecte pas le format demande",,,,,,,,38ececba8f3b69c7,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,3c6c33f4,code,fr,20250f58c765f9b7,"# EXERCICE : Solveur LLM avec Few-Shot raisonne
 
 class FewShotReasoningSolver:
@@ -14366,7 +14392,7 @@ if fs_solution:
     print(f""Valide : {validate_solution(fs_solution, test_grid)}"")
 else:
     print(""Echec de la resolution"")",,,,,,,,20250f58c765f9b7,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,conclusion,markdown,fr,1ddd94e0f48fd54f,"## Conclusion
+MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,conclusion,markdown,fr,128b3b8d2aa5492d,"## Conclusion
 
 Dans ce notebook, nous avons explore l'utilisation des **Large Language Models** pour la resolution de Sudoku :
 
@@ -14390,7 +14416,7 @@ Dans ce notebook, nous avons explore l'utilisation des **Large Language Models**
 Les LLM s'amelieorent rapidement :
 - **GPT-4 (2023)** : ~30-50% succes zero-shot
 - **Claude 3.5 (2024)** : ~40-60% succes zero-shot
-- **Modeles futurs** : Potentiellement 80-90%+ succes
+- **Modèles futurs** : Potentiellement 80-90%+ succes
 
 Cependant, pour les problemes combinatoires comme Sudoku, **les solveurs dedies resteront probablement superieurs** en raison de leur garantie de correction et de leur performance optimale.
 
@@ -14415,8 +14441,8 @@ Cependant, pour les problemes combinatoires comme Sudoku, **les solveurs dedies 
 ---
 
 **Retour au sommaire** : [Index Sudoku](README.md)
-",,,,,,,,1ddd94e0f48fd54f,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,10722324,markdown,fr,fc1a5b141a1c0b64,"**Navigation** : [Index](README.md) | [<< Sudoku-17 Python](Sudoku-17-LLM-Python.ipynb) | [Fin de serie >>]
+",,,,,,,,128b3b8d2aa5492d,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,10722324,markdown,fr,810125e03c5f3680,"**Navigation** : [Index](README.md) | [<< Sudoku-17 Python](Sudoku-17-LLM-Python.ipynb) | [Fin de serie >>]
 
 # Comparaison des Solveurs de Sudoku
 
@@ -14425,35 +14451,35 @@ Voir aussi : [Search Foundations](../Search/Part1-Foundations/) pour les algorit
 ## Objectifs d'apprentissage
 
 A la fin de ce notebook, vous saurez :
-1. Classifier les differentes approches de resolution de Sudoku par categorie (exacte, heuristique, propagation, apprentissage)
+1. Classifier les différentes approches de resolution de Sudoku par catégorie (exacte, heuristique, propagation, apprentissage)
 2. Comparer objectivement les performances de 4 solveurs Python sur des puzzles de difficulte variee
-3. Analyser les forces et faiblesses de chaque approche selon plusieurs criteres (vitesse, fiabilite, scalabilite, simplicite)
+3. Analyser les forces et faiblesses de chaque approche selon plusieurs critères (vitesse, fiabilite, scalabilite, simplicite)
 4. Choisir le bon solveur en fonction du contexte d'utilisation
 
 ### Prerequis
 - Avoir lu au moins 3-4 notebooks de la serie Sudoku (Backtracking, OR-Tools, Norvig, un autre au choix)
 - Python 3.10+ avec numpy, matplotlib, ortools
 
-### Duree estimee : 35 minutes",,,,,,,,fc1a5b141a1c0b64,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,5ed20fef,markdown,fr,4125c280fcfdee96,"## 1. Introduction
+### Duree estimee : 35 minutes",,,,,,,,810125e03c5f3680,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,5ed20fef,markdown,fr,04ba6f75b16fad38,"## 1. Introduction
 
-Au fil de cette serie de notebooks, nous avons explore **9 approches differentes** pour resoudre le Sudoku. Chacune incarne une philosophie algorithmique distincte :
+Au fil de cette serie de notebooks, nous avons explore **9 approches différentes** pour resoudre le Sudoku. Chacune incarne une philosophie algorithmique distincte :
 
 | # | Notebook | Approche | Philosophie |
 |---|----------|----------|-------------|
 | 1 | [Backtracking](Sudoku-1-Backtracking-Python.ipynb) | Recherche exhaustive | Explorer systematiquement toutes les possibilites |
-| 2 | [Genetic](Sudoku-3-Genetic-Python.ipynb) | Metaheuristique | Faire evoluer une population de solutions candidates |
+| 2 | [Genetic](Sudoku-3-Genetic-Python.ipynb) | métaheuristique | Faire evoluer une population de solutions candidates |
 | 3 | [OR-Tools](Sudoku-10-ORTools-Python.ipynb) | Programmation par contraintes | Declarer les contraintes, laisser le solveur chercher |
 | 4 | [Z3](Sudoku-12-Z3-Python.ipynb) | Satisfiabilite (SMT) | Prouver l'existence d'une solution satisfaisant des formules logiques |
-| 5 | [Dancing Links](Sudoku-2-DancingLinks-Python.ipynb) | Couverture exacte | Reduire a un probleme de selection de sous-ensembles |
+| 5 | [Dancing Links](Sudoku-2-DancingLinks-Python.ipynb) | Couverture exacte | Reduire a un problème de sélection de sous-ensembles |
 | 6 | [Infer.NET](Sudoku-15-Infer-Python.ipynb) | Inference probabiliste | Propager des distributions de probabilite |
 | 7 | [Norvig](Sudoku-7-Norvig-Python.ipynb) | Propagation de contraintes | Eliminer les impossibilites avant de chercher |
 | 8 | Simulated Annealing | Recuit simule | Optimiser par perturbations aleatoires avec refroidissement |
 | 10 | Neural Network | Apprentissage profond | Apprendre les motifs de resolution a partir d'exemples |
 
-Ce notebook final propose une **comparaison systematique** de ces approches selon plusieurs dimensions : vitesse, fiabilite, elegance du code et scalabilite. Nous implementerons 4 solveurs Python representatifs et les testerons sur un benchmark commun.
+Ce notebook final propose une **comparaison systématique** de ces approches selon plusieurs dimensions : vitesse, fiabilite, elegance du code et scalabilite. Nous implementerons 4 solveurs Python representatifs et les testerons sur un benchmark commun.
 
-> **Twin C# .NET de `Sudoku-18-Comparison-Python.ipynb`** (marathon parité #4956). Kernel `.net-csharp`. Solveurs Backtracking / MRV / Norvig / Norvig-FC / Simulated-Annealing réimplémentés **from-scratch** (BCL .NET seule, Prong B) ; OR-Tools CP-SAT utilise le **vrai moteur industriel** via `#r ""nuget: Google.OrTools""` (Prong A, même solveur que le twin Python). Graphiques matplotlib remplacés par un rendu ASCII autonome.",,,,,,,,4125c280fcfdee96,,,,,,,
+> **Twin C# .NET de `Sudoku-18-Comparison-Python.ipynb`** (marathon parité #4956). Kernel `.net-csharp`. Solveurs Backtracking / MRV / Norvig / Norvig-FC / Simulated-Annealing réimplémentés **from-scratch** (BCL .NET seule, Prong B) ; OR-Tools CP-SAT utilise le **vrai moteur industriel** via `#r ""nuget: Google.OrTools""` (Prong A, même solveur que le twin Python). Graphiques matplotlib remplacés par un rendu ASCII autonome.",,,,,,,,04ba6f75b16fad38,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,24a731fc,code,fr,84e0ac0c62e0cf07,"// Imports et environnement
 // Prong A : Google.OrTools (vrai CP-SAT industriel, meme moteur que le twin Python)
 #r ""nuget: Google.OrTools""
@@ -14478,73 +14504,73 @@ Console.WriteLine(""Environnement charge."");
 Console.WriteLine(""  .NET "" + Environment.Version);
 Console.WriteLine(""  Google.OrTools CP-SAT importe"");
 ",,,,,,,,84e0ac0c62e0cf07,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,466f92a0,markdown,fr,523a0655a177b88f,"### Interpretation : Environnement et dependances
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,466f92a0,markdown,fr,3d511d6a153061e2,"### Interpretation : Environnement et dependances
 
 **Bibliotheques utilisees** :
 
-| Bibliotheque | Version | Role dans ce notebook |
+| Bibliotheque | Version | rôle dans ce notebook |
 |-------------|---------|----------------------|
-| numpy | 2.4.2 | Calculs numeriques, statistiques (medianne, moyennes) |
+| numpy | 2.4.2 | Calculs numériques, statistiques (medianne, moyennes) |
 | matplotlib | - | Visualisations (barres, boxplots, radar) |
 | ortools | - | Solveur CP-SAT industriel (4e solveur du benchmark) |
-| time | - | Mesure des temps d'execution |
+| time | - | Mesure des temps d'exécution |
 
 **Pourquoi ces choix** :
 - **OR-Tools CP-SAT** est le seul solveur externe necessaire. Les trois autres solveurs sont implementes en Python pur pour illustrer les algorithmes
 - **numpy** est utilise pour les statistiques du benchmark (medianne des temps)
 - **matplotlib** genere les graphiques comparatifs (barres, boxplots, radar)
 
-> **Note** : Aucune dependance lourde (pas de tensorflow, pytorch, etc.). Ce notebook reste leger et s'execute sur n'importe quel environnement Python standard.",,,,,,,,523a0655a177b88f,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,58e50755,markdown,fr,a6eb089a7421bff6,"## 2. Categories d'approches
+> **Note** : Aucune dépendance lourde (pas de tensorflow, pytorch, etc.). Ce notebook reste leger et s'execute sur n'importe quel environnement Python standard.",,,,,,,,3d511d6a153061e2,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,58e50755,markdown,fr,b9275887727ba664,"## 2. catégories d'approches
 
-Les 9 approches etudiees se regroupent naturellement en **5 grandes categories**, chacune correspondant a un paradigme algorithmique fondamental.
+Les 9 approches etudiees se regroupent naturellement en **5 grandes catégories**, chacune correspondant a un paradigme algorithmique fondamental.
 
-### 2.1 Methodes exactes (garantie de solution)
+### 2.1 méthodes exactes (garantie de solution)
 
-Ces methodes explorent l'espace de recherche de maniere systematique et **trouvent toujours une solution** si elle existe.
+Ces méthodes explorent l'espace de recherche de maniere systématique et **trouvent toujours une solution** si elle existe.
 
-| Methode | Principe | Complexite pratique | Notebook |
+| méthode | Principe | Complexite pratique | Notebook |
 |---------|----------|---------------------|----------|
 | **Backtracking** | DFS + validation | Rapide (facile), lent (difficile) | [Sudoku-1](Sudoku-1-Backtracking-Python.ipynb) |
-| **Backtracking + MRV** | DFS + heuristique MRV | Rapide meme sur puzzles difficiles | [Sudoku-Python-BT](Sudoku-1-Backtracking-Python.ipynb) |
+| **Backtracking + MRV** | DFS + heuristique MRV | Rapide même sur puzzles difficiles | [Sudoku-Python-BT](Sudoku-1-Backtracking-Python.ipynb) |
 | **Dancing Links** | Couverture exacte (Algorithm X) | Optimal pour les problemes de couverture | [Sudoku-5](Sudoku-2-DancingLinks-Python.ipynb) |
-| **OR-Tools CP-SAT** | CP + SAT + CDCL | Tres rapide, constant | [Sudoku-3](Sudoku-10-ORTools-Python.ipynb) |
-| **Z3 SMT** | Satisfiabilite Modulo Theories | Rapide, overhead d'initialisation | [Sudoku-4](Sudoku-12-Z3-Python.ipynb) |
+| **OR-Tools CP-SAT** | CP + SAT + CDCL | très rapide, constant | [Sudoku-3](Sudoku-10-ORTools-Python.ipynb) |
+| **Z3 SMT** | Satisfiabilite Modulo théories | Rapide, overhead d'initialisation | [Sudoku-4](Sudoku-12-Z3-Python.ipynb) |
 
-### 2.2 Methodes de propagation
+### 2.2 méthodes de propagation
 
-Ces methodes **reduisent l'espace de recherche** en eliminant les valeurs impossibles avant (ou a la place de) la recherche.
+Ces méthodes **reduisent l'espace de recherche** en eliminant les valeurs impossibles avant (ou a la place de) la recherche.
 
-| Methode | Principe | Completude | Notebook |
+| méthode | Principe | Completude | Notebook |
 |---------|----------|------------|----------|
 | **Norvig** | Elimination + naked singles + DFS de secours | Complet (avec fallback recherche) | [Sudoku-7](Sudoku-7-Norvig-Python.ipynb) |
-| **Strategies humaines** | Regles logiques (naked pairs, X-Wing, etc.) | Incomplet sans recherche | (integre dans divers notebooks) |
+| **stratégies humaines** | règles logiques (naked pairs, X-Wing, etc.) | Incomplet sans recherche | (integre dans divers notebooks) |
 
-### 2.3 Methodes heuristiques (pas de garantie)
+### 2.3 méthodes heuristiques (pas de garantie)
 
-Ces methodes utilisent des **mecanismes d'optimisation stochastique** et ne garantissent pas de trouver une solution.
+Ces méthodes utilisent des **mécanismes d'optimisation stochastique** et ne garantissent pas de trouver une solution.
 
-| Methode | Principe | Fiabilite | Notebook |
+| méthode | Principe | Fiabilite | Notebook |
 |---------|----------|-----------|----------|
-| **Algorithme genetique** | Evolution de populations | Faible sur puzzles difficiles | [Sudoku-2](Sudoku-3-Genetic-Python.ipynb) |
+| **Algorithme génétique** | Evolution de populations | Faible sur puzzles difficiles | [Sudoku-2](Sudoku-3-Genetic-Python.ipynb) |
 | **Recuit simule** | Perturbations + refroidissement | Moyenne | Sudoku-8 |
 
-### 2.4 Methodes d'apprentissage
+### 2.4 méthodes d'apprentissage
 
-| Methode | Principe | Fiabilite | Notebook |
+| méthode | Principe | Fiabilite | Notebook |
 |---------|----------|-----------|----------|
-| **Reseau de neurones** | Apprentissage supervise | Approximation, necessite donnees | Sudoku-10 |
+| **Reseau de neurones** | Apprentissage supervise | Approximation, necessite données | Sudoku-10 |
 
-### 2.5 Methodes probabilistes
+### 2.5 méthodes probabilistes
 
-| Methode | Principe | Fiabilite | Notebook |
+| méthode | Principe | Fiabilite | Notebook |
 |---------|----------|-----------|----------|
-| **Infer.NET** | Graphe de facteurs, inference bayesienne | Experimentale | [Sudoku-6](Sudoku-15-Infer-Python.ipynb) |",,,,,,,,a6eb089a7421bff6,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,03d53a67,markdown,fr,2abf2c17e215cc3e,"## 3. Implementations Python des solveurs
+| **Infer.NET** | Graphe de facteurs, inference bayesienne | Experimentale | [Sudoku-6](Sudoku-15-Infer-Python.ipynb) |",,,,,,,,b9275887727ba664,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,03d53a67,markdown,fr,d22600ec31f08242,"## 3. Implementations Python des solveurs
 
-Pour une comparaison equitable, nous implementons **4 solveurs representatifs** dans le meme environnement Python. Chaque solveur represente une categorie differente.
+Pour une comparaison equitable, nous implementons **4 solveurs representatifs** dans le même environnement Python. Chaque solveur represente une catégorie différente.
 
-| Solveur | Categorie | Pourquoi ce choix |
+| Solveur | catégorie | Pourquoi ce choix |
 |---------|-----------|-------------------|
 | **Backtracking simple** | Recherche exhaustive | Baseline naive, reference de comparaison |
 | **Backtracking + MRV** | Recherche avec heuristique | Amelioration classique, montre l'impact des heuristiques |
@@ -14553,7 +14579,7 @@ Pour une comparaison equitable, nous implementons **4 solveurs representatifs** 
 
 ### Classe SudokuGrid commune
 
-Tous les solveurs utilisent la meme representation de grille pour garantir une comparaison equitable.",,,,,,,,2abf2c17e215cc3e,,,,,,,
+Tous les solveurs utilisent la même representation de grille pour garantir une comparaison equitable.",,,,,,,,d22600ec31f08242,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,00f6d107,code,fr,a6f2b6cdc101dfaf,"// Representation d'une grille de Sudoku 9x9
 public class SudokuGrid
 {
@@ -14645,24 +14671,24 @@ Console.WriteLine(""Grille de test:"");
 Console.WriteLine(test);
 Console.WriteLine($""Cases vides: {test.CountEmpty()}"");
 ",,,,,,,,a6f2b6cdc101dfaf,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,10f6daa2,markdown,fr,1f39069a9f4d1af2,"### Interpretation : Classe SudokuGrid - Representation commune
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,10f6daa2,markdown,fr,7a44fb5937b09049,"### Interpretation : Classe SudokuGrid - Representation commune
 
 **Fonctionnalites de la classe** :
 
-| Methode | Role | Utilite pour les solveurs |
+| méthode | rôle | Utilite pour les solveurs |
 |---------|------|--------------------------|
-| `from_string` | Cree une grille depuis 81 caracteres | Format universel pour les benchmarks |
+| `from_string` | créé une grille depuis 81 caractères | Format universel pour les benchmarks |
 | `clone` | Copie independante | Evite les interferences entre solveurs |
 | `is_valid_placement` | Valide un placement (ligne/colonne/bloc) | Utilisee par le backtracking |
-| `find_empty` | Trouve la premiere case vide | Parcours naive pour le backtracking simple |
+| `find_empty` | Trouve la première case vide | Parcours naive pour le backtracking simple |
 | `count_empty` | Compte les cases vides | Metrique de difficulte |
-| `to_string` | Convertit en chaine | Interface avec le solveur Norvig |
+| `to_string` | Convertit en chaîne | Interface avec le solveur Norvig |
 
 **Grille de test** : 49 cases vides sur 81 (60% de la grille). C'est un puzzle de difficulte moyenne-facile qui servira de validation rapide pour chaque solveur.
 
-**Design choisi** : La classe est volontairement simple (liste de listes 9x9) pour ne pas avantager un solveur particulier. Le solveur Norvig utilise sa propre representation interne (dictionnaire de chaines) mais convertit vers/depuis SudokuGrid pour l'interface.
+**Design choisi** : La classe est volontairement simple (liste de listes 9x9) pour ne pas avantager un solveur particulier. Le solveur Norvig utilise sa propre representation interne (dictionnaire de chaînes) mais convertit vers/depuis SudokuGrid pour l'interface.
 
-> **Point architecture** : Tous les solveurs implementent la meme interface `solve(grid: SudokuGrid) -> bool`, ce qui permet de les comparer equitablement et de les utiliser de maniere interchangeable dans le benchmark.",,,,,,,,1f39069a9f4d1af2,,,,,,,
+> **Point architecture** : Tous les solveurs implementent la même interface `solve(grid: SudokuGrid) -> bool`, ce qui permet de les comparer equitablement et de les utiliser de maniere interchangeable dans le benchmark.",,,,,,,,7a44fb5937b09049,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,a0a8833a,markdown,fr,0ec942a8c04d4e49,"### 3.1 Solveur 1 : Backtracking simple
 
 L'algorithme le plus intuitif : essayer chaque valeur dans chaque case vide, revenir en arriere si on atteint une impasse. C'est notre **baseline** -- le solveur le plus simple possible.
@@ -14708,15 +14734,15 @@ bool solved = solverBt.Solve(g);
 sw.Stop();
 Console.WriteLine($""Backtracking simple: resolu={solved}, {solverBt.CallCount} appels, {sw.Elapsed.TotalMilliseconds:F2} ms"");
 ",,,,,,,,562200b778fe6be6,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,412a107e,markdown,fr,2afc1e15a22ee642,"### Interpretation : Solveur Backtracking simple
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,412a107e,markdown,fr,2c0cf5aa4ee725c0,"### Interpretation : Solveur Backtracking simple
 
-**Resultat** : Le backtracking simple resout le puzzle de test en 201 appels recursifs et 1.22 ms.
+**résultat** : Le backtracking simple resout le puzzle de test en 201 appels recursifs et 1.22 ms.
 
 | Metrique | Valeur | Contexte |
 |----------|--------|----------|
 | Appels recursifs | 201 | Nombre d'entrees dans `_backtrack` |
 | Temps | 1.22 ms | Rapide pour ce puzzle facile |
-| Resultat | Succes | Solution trouvee |
+| résultat | Succes | Solution trouvee |
 
 **Analyse** :
 
@@ -14724,10 +14750,10 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,412a107e,markdown,fr,
 
 2. **Pourquoi ce sera lent sur les puzzles difficiles** : Sans heuristique, le solveur essaie les cases dans l'ordre (ligne par ligne, de gauche a droite) avec les valeurs 1 a 9. Sur un puzzle difficile avec 60+ cases vides, l'arbre de recherche peut atteindre des milliards de noeuds.
 
-3. **Role de baseline** : Ce solveur sert de reference pour mesurer l'impact des ameliorations. Toute optimisation (MRV, propagation, etc.) sera comparee a cette baseline.
+3. **rôle de baseline** : Ce solveur sert de reference pour mesurer l'impact des ameliorations. Toute optimisation (MRV, propagation, etc.) sera comparee a cette baseline.
 
-> **Comparaison a venir** : Le solveur MRV suivant fera seulement 50 appels sur ce meme puzzle -- deja 4x moins. La difference sera beaucoup plus marquee sur les puzzles Medium et Hard.",,,,,,,,2afc1e15a22ee642,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,405f9279,markdown,fr,fc48974dc30bdcb7,"## Exercice : Propagation des singletons (Naked Singles)
+> **Comparaison a venir** : Le solveur MRV suivant fera seulement 50 appels sur ce même puzzle -- déjà 4x moins. La différence sera beaucoup plus marquee sur les puzzles Medium et Hard.",,,,,,,,2c0cf5aa4ee725c0,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,405f9279,markdown,fr,b33e06bb15554cf6,"## Exercice : Propagation des singletons (Naked Singles)
 
 ### Enonce
 
@@ -14737,11 +14763,11 @@ Implementez `propagate_naked_singles(grid)` qui remplit recursivement toutes les
 
 ### Indices
 
-- Etape 1 : Pour chaque case vide, calculez les candidats (absents de ligne + colonne + bloc)
-- Etape 2 : Si exactement 1 candidat, remplissez la case
-- Etape 3 : Repetez tant qu'au moins une case a ete remplie (propagation en cascade)
-- Etape 4 : Retournez le nombre de cases remplies et la grille modifiee
-",,,,,,,,fc48974dc30bdcb7,,,,,,,
+- étape 1 : Pour chaque case vide, calculez les candidats (absents de ligne + colonne + bloc)
+- étape 2 : Si exactement 1 candidat, remplissez la case
+- étape 3 : Repetez tant qu'au moins une case a ete remplie (propagation en cascade)
+- étape 4 : Retournez le nombre de cases remplies et la grille modifiée
+",,,,,,,,b33e06bb15554cf6,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,6b9322a1,code,fr,022dc5a029369947,"// EXERCICE : Propagation des singletons (Naked Singles)
 //   - Identifiez les cases avec exactement 1 candidat
 //   - Remplissez-les et repetez (propagation en cascade)
@@ -14844,9 +14870,9 @@ solved = solverMrv.Solve(g);
 sw.Stop();
 Console.WriteLine($""Backtracking MRV: resolu={solved}, {solverMrv.CallCount} appels, {sw.Elapsed.TotalMilliseconds:F2} ms"");
 ",,,,,,,,a71c53e23059c71c,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,0085d323,markdown,fr,eea38636f458fbe8,"### Interpretation : Solveur Backtracking avec MRV
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,0085d323,markdown,fr,11e391ea6749656b,"### Interpretation : Solveur Backtracking avec MRV
 
-**Resultat** : Le backtracking avec MRV resout le puzzle en 50 appels recursifs et 2.62 ms.
+**résultat** : Le backtracking avec MRV resout le puzzle en 50 appels recursifs et 2.62 ms.
 
 | Metrique | Backtracking simple | BT + MRV | Amelioration |
 |----------|--------------------|---------|-------------|
@@ -14855,23 +14881,23 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,0085d323,markdown,fr,
 
 **Paradoxe apparent** : MRV fait moins d'appels mais prend plus de temps. Cela s'explique par le cout de l'heuristique :
 
-- **Backtracking simple** : Chaque appel est tres rapide (trouver la premiere case vide, essayer 1-9)
+- **Backtracking simple** : Chaque appel est très rapide (trouver la première case vide, essayer 1-9)
 - **BT + MRV** : Chaque appel necessite de calculer les candidats de toutes les cases vides et de trouver celle avec le minimum
 
-**Pourquoi MRV est quand meme preferable** :
-1. Sur les puzzles faciles, la difference de temps est negligeable (millisecondes)
+**Pourquoi MRV est quand même preferable** :
+1. Sur les puzzles faciles, la différence de temps est negligeable (millisecondes)
 2. Sur les puzzles difficiles, MRV reduit l'arbre de recherche de plusieurs ordres de grandeur
 3. Le surcout par appel est constant, mais le nombre d'appels evites croit exponentiellement avec la difficulte
 
-> **Principe MRV** : Toujours choisir la variable la plus contrainte (""fail-first""). En traitant d'abord les cases avec peu de candidats, on detecte les impasses plus tot et on evite d'explorer des sous-arbres inutiles.",,,,,,,,eea38636f458fbe8,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,b0693e8f,markdown,fr,a626fc131595f8b9,"### 3.3 Solveur 3 : Propagation de contraintes (Norvig)
+> **Principe MRV** : Toujours choisir la variable la plus contrainte (""fail-first""). En traitant d'abord les cases avec peu de candidats, on detecte les impasses plus tot et on evite d'explorer des sous-arbres inutiles.",,,,,,,,11e391ea6749656b,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,b0693e8f,markdown,fr,6061c93fb4e4829e,"### 3.3 Solveur 3 : Propagation de contraintes (Norvig)
 
-L'approche de Peter Norvig combine deux strategies de propagation :
+L'approche de Peter Norvig combine deux stratégies de propagation :
 
-1. **Elimination** : quand une case recoit une valeur, on retire cette valeur des candidats de tous ses voisins (meme ligne, colonne, bloc)
+1. **Elimination** : quand une case recoit une valeur, on retire cette valeur des candidats de tous ses voisins (même ligne, colonne, bloc)
 2. **Naked single** : quand une valeur n'a qu'un seul emplacement possible dans une unite, on l'y assigne
 
-Si la propagation seule ne suffit pas, un **backtracking avec MRV** prend le relais. En pratique, la propagation resout la majorite des puzzles faciles/moyens sans aucune recherche.",,,,,,,,a626fc131595f8b9,,,,,,,
+Si la propagation seule ne suffit pas, un **backtracking avec MRV** prend le relais. En pratique, la propagation resout la majorite des puzzles faciles/moyens sans aucune recherche.",,,,,,,,6061c93fb4e4829e,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,9d2dcedb,code,fr,5121926488047c02,"// Solveur par propagation de contraintes (style Peter Norvig).
 // Reference : http://norvig.com/sudoku.html
 public class NorvigSolver
@@ -14986,9 +15012,9 @@ solved = solverNorvig.Solve(g);
 sw.Stop();
 Console.WriteLine($""Norvig: resolu={solved}, {solverNorvig.CallCount} appels, {sw.Elapsed.TotalMilliseconds:F2} ms"");
 ",,,,,,,,5121926488047c02,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,811aaf8a,markdown,fr,eda9f165097751d3,"### Interpretation : Solveur Norvig (propagation de contraintes)
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,811aaf8a,markdown,fr,59ba8a32682c6c86,"### Interpretation : Solveur Norvig (propagation de contraintes)
 
-**Resultat** : Norvig resout le puzzle en **1 appel recursif** et 2.34 ms.
+**résultat** : Norvig resout le puzzle en **1 appel récursif** et 2.34 ms.
 
 | Metrique | Valeur | Observation |
 |----------|--------|-------------|
@@ -14999,23 +15025,23 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,811aaf8a,markdown,fr,
 
 La propagation de contraintes (elimination + naked singles) a entierement resolu le puzzle sans qu'aucun backtracking ne soit necessaire. C'est le cas pour la plupart des puzzles faciles/moyens.
 
-**Mecanismes de propagation** :
+**mécanismes de propagation** :
 1. **Elimination** : Quand une valeur est assignee a une case, elle est retiree des candidats de tous ses voisins (ligne, colonne, bloc)
 2. **Naked single** : Si une valeur ne peut aller que dans une seule case d'une unite, on l'y assigne
-3. **Cascade** : Chaque assignation declenche une nouvelle propagation, qui peut elle-meme declencher d'autres assignations
+3. **Cascade** : Chaque assignation declenche une nouvelle propagation, qui peut elle-même declencher d'autres assignations
 
-**Comparaison avec le backtracking** : Le solveur simple a necessite 201 appels recursifs pour le meme puzzle. Norvig atteint la meme solution en un seul appel grace a la propagation qui elimine les branches inutiles avant meme de les explorer.
+**Comparaison avec le backtracking** : Le solveur simple a necessite 201 appels recursifs pour le même puzzle. Norvig atteint la même solution en un seul appel grace a la propagation qui elimine les branches inutiles avant même de les explorer.
 
-> **Point cle** : La force de Norvig n'est pas la vitesse pure, mais la capacite a resoudre sans recherche. Sur des puzzles plus difficiles, le backtracking MRV prend le relais avec un espace de recherche deja drastiquement reduit.",,,,,,,,eda9f165097751d3,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,17fc7b2b,markdown,fr,c2b79055528b9637,"### 3.4 Solveur 4 : OR-Tools CP-SAT
+> **Point cle** : La force de Norvig n'est pas la vitesse pure, mais la capacite a resoudre sans recherche. Sur des puzzles plus difficiles, le backtracking MRV prend le relais avec un espace de recherche déjà drastiquement reduit.",,,,,,,,59ba8a32682c6c86,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,17fc7b2b,markdown,fr,15842e3902ec2384,"### 3.4 Solveur 4 : OR-Tools CP-SAT
 
 Google OR-Tools est un solveur **industriel** de programmation par contraintes. Au lieu de programmer un algorithme de recherche, on **declare** les contraintes et le solveur fait le reste.
 
-Le modele Sudoku se resume a :
+Le modèle Sudoku se resume a :
 - 81 variables entieres dans {1..9}
 - 27 contraintes `AllDifferent` (9 lignes + 9 colonnes + 9 blocs)
 
-C'est l'approche la plus concise et generalement la plus performante.",,,,,,,,c2b79055528b9637,,,,,,,
+C'est l'approche la plus concise et généralement la plus performante.",,,,,,,,15842e3902ec2384,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,1724f011,code,fr,04c7444dc17ee266,"// Solveur utilisant Google OR-Tools CP-SAT (Prong A : vrai moteur industriel)
 public class OrToolsCpSatSolver
 {
@@ -15064,9 +15090,9 @@ solved = solverCpsat.Solve(g);
 sw.Stop();
 Console.WriteLine($""OR-Tools CP-SAT: resolu={solved}, {sw.Elapsed.TotalMilliseconds:F2} ms"");
 ",,,,,,,,04c7444dc17ee266,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,f929b306,markdown,fr,731532320ad707a1,"### Interpretation : Solveur OR-Tools CP-SAT
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,f929b306,markdown,fr,41da7cf32e9fd034,"### Interpretation : Solveur OR-Tools CP-SAT
 
-**Resultat** : OR-Tools resout le puzzle en 63.21 ms avec succes.
+**résultat** : OR-Tools resout le puzzle en 63.21 ms avec succes.
 
 | Metrique | Valeur | Observation |
 |----------|--------|-------------|
@@ -15075,14 +15101,14 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,f929b306,markdown,fr,
 
 **Analyse** :
 
-1. **Overhead de modelisation** : Le temps inclut la construction du modele (81 variables, 27 contraintes AllDifferent) et l'initialisation du solveur. Pour un seul puzzle, cet overhead est significatif.
+1. **Overhead de modelisation** : Le temps inclut la construction du modèle (81 variables, 27 contraintes AllDifferent) et l'initialisation du solveur. Pour un seul puzzle, cet overhead est significatif.
 
 2. **Avantage sur les grands problemes** : Contrairement aux solveurs Python purs, OR-Tools est compile en C++ et optimise pour des problemes avec des milliers de variables. Le temps de resolution reste quasi-constant quelle que soit la difficulte du puzzle.
 
 3. **Declaratif vs imperatif** : Le code ne contient **aucune logique de recherche** -- on declare les contraintes et le solveur trouve la solution. C'est l'approche la plus concise (~15 lignes utiles).
 
-> **Quand utiliser OR-Tools** : Quand la robustesse et la previsibilite sont plus importantes que la vitesse brute, ou quand le probleme est trop complexe pour un solveur maison.",,,,,,,,731532320ad707a1,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,65f5c85d,markdown,fr,b9cdd0814707be99,"## Exercice : Verifier l'unicite de la solution avec OR-Tools
+> **Quand utiliser OR-Tools** : Quand la robustesse et la previsibilite sont plus importantes que la vitesse brute, ou quand le problème est trop complexe pour un solveur maison.",,,,,,,,41da7cf32e9fd034,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,65f5c85d,markdown,fr,1480c75317f2225a,"## Exercice : Verifier l'unicite de la solution avec OR-Tools
 
 ### Enonce
 
@@ -15090,11 +15116,11 @@ Un Sudoku bien pose possede exactement **une** solution. Avec OR-Tools CP-SAT, o
 
 ### Indices
 
-- Etape 1 : Modelisez le Sudoku comme dans `ORToolsCPSATSolver` (variables 1-9, allDifferent)
-- Etape 2 : Appelez `solver.solve(model)` une premiere fois
-- Etape 3 : Si solution trouvee, ajoutez une contrainte interdisant cette solution (au moins une case differente)
-- Etape 4 : Appelez `solver.solve(model)` a nouveau. Si pas de solution = unique
-",,,,,,,,b9cdd0814707be99,,,,,,,
+- étape 1 : Modelisez le Sudoku comme dans `ORToolsCPSATSolver` (variables 1-9, allDifferent)
+- étape 2 : Appelez `solver.solve(model)` une première fois
+- étape 3 : Si solution trouvee, ajoutez une contrainte interdisant cette solution (au moins une case différente)
+- étape 4 : Appelez `solver.solve(model)` a nouveau. Si pas de solution = unique
+",,,,,,,,1480c75317f2225a,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,b756d9ab,code,fr,026c6ee9cd2e3ab0,"// EXERCICE : Verifier l'unicite de la solution avec OR-Tools
 //   - Resoudre une premiere fois
 //   - Ajouter une contrainte interdisant cette solution
@@ -15119,18 +15145,18 @@ for (int i = 0; i < 81; i++) gridEasy[i / 9][i % 9] = easy[i];
 bool unique = HasUniqueSolution(gridEasy);
 Console.WriteLine($""Solution unique : {unique}"");
 ",,,,,,,,026c6ee9cd2e3ab0,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,f5e64253,markdown,fr,1fe19fe9a61552f2,"## 4. Benchmark
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,f5e64253,markdown,fr,a6436c229f37dc57,"## 4. Benchmark
 
-Nous testons les 4 solveurs sur **4 niveaux de difficulte** avec 10 puzzles chacun. Tous les puzzles sont codes en dur ci-dessous pour garantir la reproductibilite (pas de dependance a des fichiers externes).
+Nous testons les 4 solveurs sur **4 niveaux de difficulte** avec 10 puzzles chacun. Tous les puzzles sont codes en dur ci-dessous pour garantir la reproductibilite (pas de dépendance a des fichiers externes).
 
 ### Jeux de test
 
-| Difficulte | Caracteristiques | Nombre de cases vides |
+| Difficulte | caractéristiques | Nombre de cases vides |
 |------------|------------------|-----------------------|
 | **Easy** | Beaucoup d'indices, propagation simple suffit | ~35-45 |
 | **Medium** | Indices reduits, necessite un peu de recherche | ~45-55 |
-| **Hard** | Tres peu d'indices, cas extremes connus | ~55-60 |
-| **Expert** | Regime 17-24 indices : les solveurs exacts (backtracking) timeout, les metaheuristiques (recuit simule, genetique) n'ont aucune garantie de convergence | ~57-64 |",,,,,,,,1fe19fe9a61552f2,,,,,,,
+| **Hard** | très peu d'indices, cas extremes connus | ~55-60 |
+| **Expert** | Regime 17-24 indices : les solveurs exacts (backtracking) timeout, les métaheuristiques (recuit simule, génétique) n'ont aucune garantie de convergence | ~57-64 |",,,,,,,,a6436c229f37dc57,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,b0ae1603,code,fr,ffcb61756c00473f,"// -- Jeux de test codes en dur --
 // Source : Sudoku_Easy51 / top95 / hardest / expert
 static readonly string[] EASY_PUZZLES = {
@@ -15187,7 +15213,7 @@ foreach (var kv in new (string Name, string[] Puzzles)[] {
     Console.WriteLine($""  {kv.Name}: {empties.Min()}-{empties.Max()} cases vides (moy: {empties.Average():F1})"");
 }
 ",,,,,,,,ffcb61756c00473f,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,2d71dd3a,markdown,fr,59a2f1c051b18a94,"### Interpretation : Jeux de test et profil des puzzles
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,2d71dd3a,markdown,fr,65201658bef6de7f,"### Interpretation : Jeux de test et profil des puzzles
 
 **Repartition des jeux de test** :
 
@@ -15197,16 +15223,16 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,2d71dd3a,markdown,fr,
 | Medium | 10 | 64 | 64.0 |
 | Hard | 11 | 53-59 | 56.5 |
 
-**Observation contre-intuitive** : Les puzzles Medium ont en moyenne **plus de cases vides** (64) que les puzzles Hard (56.5). Cela s'explique par la provenance des donnees :
+**Observation contre-intuitive** : Les puzzles Medium ont en moyenne **plus de cases vides** (64) que les puzzles Hard (56.5). Cela s'explique par la provenance des données :
 
-- **Easy** : Grilles classiques avec beaucoup d'indices, la propagation suffit generalement
+- **Easy** : Grilles classiques avec beaucoup d'indices, la propagation suffit généralement
 - **Medium** : Puzzles ""top95"" avec peu d'indices (presque toutes les cases vides), ce qui crée un espace de recherche immense
 - **Hard** : Puzzles ""hardest"" connus pour leur difficulte logique, mais qui ont parfois plus d'indices que les Medium
 
-> **Lecon** : La difficulte algorithmique ne depend pas seulement du nombre de cases vides, mais surtout de la **structure des contraintes**. Un puzzle avec 53 cases vides bien placees peut etre plus resistant qu'un puzzle avec 64 cases vides mal reparties.",,,,,,,,59a2f1c051b18a94,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,d664416f,markdown,fr,8162ba64d2d04d65,"### Execution du benchmark
+> **Lecon** : La difficulte algorithmique ne depend pas seulement du nombre de cases vides, mais surtout de la **structure des contraintes**. Un puzzle avec 53 cases vides bien placees peut etre plus resistant qu'un puzzle avec 64 cases vides mal reparties.",,,,,,,,65201658bef6de7f,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,d664416f,markdown,fr,508722e904825b78,"### exécution du benchmark
 
-La fonction `run_benchmark` teste chaque solveur sur chaque ensemble de puzzles et collecte les temps de resolution et le taux de succes. Chaque puzzle est resolu sur une **copie** de la grille pour eviter toute interference entre solveurs.",,,,,,,,8162ba64d2d04d65,,,,,,,
+La fonction `run_benchmark` teste chaque solveur sur chaque ensemble de puzzles et collecte les temps de resolution et le taux de succes. Chaque puzzle est resolu sur une **copie** de la grille pour eviter toute interference entre solveurs.",,,,,,,,508722e904825b78,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,03ad4f8a,code,fr,6f0f53fb0883fdee,"// Sonde de solveur uniforme : capture Solve + lecture du compteur d'appels.
 public record SolverProbe(Func<SudokuGrid, bool> Solve, Func<int> Count);
 
@@ -15233,9 +15259,9 @@ var puzzleSets = new Dictionary<string, string[]>()
 Console.WriteLine($""Solveurs configures : {string.Join("", "", solverFactoriesBench.Keys)}"");
 Console.WriteLine($""Puzzles disponibles : {string.Join("", "", puzzleSets.Keys)}"");
 ",,,,,,,,6f0f53fb0883fdee,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,f1ac6593,markdown,fr,178d68b87d49433a,"### Configuration du benchmark
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,f1ac6593,markdown,fr,9b7b8e26c32852c9,"### Configuration du benchmark
 
-Les 4 solveurs et 3 niveaux de difficulte sont organises en dictionnaires pour permettre une iteration systematique. La fonction `run_benchmark` definie ci-dessous encapsule la logique de test avec gestion des timeouts.",,,,,,,,178d68b87d49433a,,,,,,,
+Les 4 solveurs et 3 niveaux de difficulte sont organises en dictionnaires pour permettre une itération systématique. La fonction `run_benchmark` définie ci-dessous encapsule la logique de test avec gestion des timeouts.",,,,,,,,9b7b8e26c32852c9,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,9d2a4ec5,code,fr,4777e3d488c49513,"// Execute chaque solveur sur chaque ensemble de puzzles et collecte les temps.
 public class BenchResult
 {
@@ -15297,11 +15323,11 @@ Console.WriteLine(""Benchmark en cours (1 puzzle par difficulte, timeout 10s)...
 var results = RunBenchmark(solverFactoriesBench, puzzleSets, maxPuzzles: 1, timeoutMs: 10000);
 Console.WriteLine(""Termine."");
 ",,,,,,,,f082ed78d687ea23,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,17767b6e,markdown,fr,46375f5256eb4ee8,"### Tableau recapitulatif des resultats
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,17767b6e,markdown,fr,4cece1d10d3e9e9a,"### Tableau recapitulatif des résultats
 
-Affichons les resultats sous forme de tableau synthetique, puis sous forme graphique.
+Affichons les résultats sous forme de tableau synthetique, puis sous forme graphique.
 
-> **Note** : Le benchmark utilise 1 puzzle par niveau de difficulte avec un timeout de 30s par puzzle pour garantir une execution rapide tout en montrant les differences de performance entre solveurs.",,,,,,,,46375f5256eb4ee8,,,,,,,
+> **Note** : Le benchmark utilise 1 puzzle par niveau de difficulte avec un timeout de 30s par puzzle pour garantir une exécution rapide tout en montrant les différences de performance entre solveurs.",,,,,,,,4cece1d10d3e9e9a,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,a2b96f5e,code,fr,2f39f2a045bfba06,"// Affiche un tableau formate des resultats du benchmark.
 public static void PrintBenchmarkTable(Dictionary<string, Dictionary<string, BenchResult>> results)
 {
@@ -15359,9 +15385,9 @@ public static Dictionary<string, Dictionary<int, double>> MeasureRobustness(
     return result;
 }
 ",,,,,,,,c22031c0d980135b,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,04ab291e,markdown,fr,909f58622d8df979,"### Interpretation : Resultats du benchmark
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,04ab291e,markdown,fr,a6a7cec0d501cf56,"### Interpretation : résultats du benchmark
 
-**Resultats cles du tableau** :
+**résultats cles du tableau** :
 
 1. **Backtracking simple** echoue sur le puzzle Medium (timeout : 58770 ms) mais resout Easy (1.87 ms) et Hard (1862 ms) -- 2/3 resolus. Sans heuristique, l'arbre de recherche explose quand le nombre de cases vides depasse ~60.
 
@@ -15369,12 +15395,12 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,04ab291e,markdown,fr,
 
 3. **Norvig** est le champion absolu : 3/3 resolus, avec un temps moyen global de 3.25 ms/puzzle. La propagation de contraintes elimine la quasi-totalite de l'exploration.
 
-4. **OR-Tools CP-SAT** est egalement 3/3 fiable a ~22 ms/puzzle (21.65). Legerement plus lent que Norvig sur ce probleme en raison de l'overhead de construction du modele, mais plus robuste a la mise a l'echelle.
+4. **OR-Tools CP-SAT** est également 3/3 fiable a ~22 ms/puzzle (21.65). Legerement plus lent que Norvig sur ce problème en raison de l'overhead de construction du modèle, mais plus robuste a la mise a l'echelle.
 
-**Surprise** : Les puzzles Hard ne sont pas les plus lents pour le backtracking simple. Cela s'explique par le fait que la difficulte humaine (nombre de techniques logiques necessaires) ne correspond pas toujours a la difficulte algorithmique (taille de l'arbre de recherche).",,,,,,,,909f58622d8df979,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,5eeab716,markdown,fr,e45104b2301e841d,"### Visualisation : temps moyen par difficulte
+**Surprise** : Les puzzles Hard ne sont pas les plus lents pour le backtracking simple. Cela s'explique par le fait que la difficulte humaine (nombre de techniques logiques necessaires) ne correspond pas toujours a la difficulte algorithmique (taille de l'arbre de recherche).",,,,,,,,a6a7cec0d501cf56,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,5eeab716,markdown,fr,81bd4fe0bd4146db,"### Visualisation : temps moyen par difficulte
 
-Le graphique en barres groupees montre le temps moyen de resolution pour chaque solveur sur chaque niveau de difficulte. L'echelle logarithmique permet de comparer des ordres de grandeur tres differents.",,,,,,,,e45104b2301e841d,,,,,,,
+Le graphique en barres groupees montre le temps moyen de resolution pour chaque solveur sur chaque niveau de difficulte. L'echelle logarithmique permet de comparer des ordres de grandeur très différents.",,,,,,,,81bd4fe0bd4146db,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,dc4ecdb4,code,fr,9d81297184116076,"// Graphique en barres groupees (rendu SVG inline via SvgChartHelper) : temps moyen par
 // difficulte et solveur, axe Y en echelle logarithmique (necessaire : les temps varient
 // de ~3 ms (Norvig) a ~8000 ms (Backtracking sur Medium) -- 4 ordres de grandeur).
@@ -15402,9 +15428,9 @@ Console.WriteLine(""Fonction definie : PlotBenchmarkBarsSvg (SvgChartHelper.Grou
 
 PlotBenchmarkBarsSvg(results, ""Benchmark : temps moyen (ms) par difficulte et solveur (axe Y log)"");
 ",,,,,,,,9d81297184116076,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,d0a4ff6c,markdown,fr,3de96d967864e778,"### Interpretation : Ecarts de performance entre solveurs
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,d0a4ff6c,markdown,fr,fb020a6fd47627a7,"### Interpretation : Ecarts de performance entre solveurs
 
-Le graphique en barres (echelle logarithmique) rend compte de l'ampleur des differences :
+Le graphique en barres (echelle logarithmique) rend compte de l'ampleur des différences :
 
 | Comparaison | Facteur | Observation |
 |-------------|---------|-------------|
@@ -15412,7 +15438,7 @@ Le graphique en barres (echelle logarithmique) rend compte de l'ampleur des diff
 | BT + MRV vs BT simple | ~1500x sur Medium | L'heuristique MRV seule apporte un gain massif |
 | Norvig vs OR-Tools | ~7x | Performance comparable, Norvig legerement plus rapide sur Python pur |
 
-**Point remarquable** : Les puzzles Medium sont les plus discriminants. Ils ont suffisamment de cases vides (64 en moyenne) pour pieger les solveurs naifs, mais restent solvables en un temps raisonnable pour tous les solveurs informes. Les puzzles Hard, paradoxalement, ne sont pas les plus lents car ils ont parfois moins de cases vides mais des contraintes plus serrees qui guident mieux la propagation.",,,,,,,,3de96d967864e778,,,,,,,
+**Point remarquable** : Les puzzles Medium sont les plus discriminants. Ils ont suffisamment de cases vides (64 en moyenne) pour pieger les solveurs naifs, mais restent solvables en un temps raisonnable pour tous les solveurs informes. Les puzzles Hard, paradoxalement, ne sont pas les plus lents car ils ont parfois moins de cases vides mais des contraintes plus serrees qui guident mieux la propagation.",,,,,,,,fb020a6fd47627a7,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,f0ba5897,markdown,fr,3aba61bd9db46f4d,"### Visualisation : distribution des temps par solveur
 
 Les boites a moustaches (boxplots) montrent la **variabilite** des temps de resolution. Un solveur avec une boite etroite est plus **previsible** dans ses performances.",,,,,,,,3aba61bd9db46f4d,,,,,,,
@@ -15446,19 +15472,19 @@ static void PlotBoxPlotSvg(Dictionary<string, Dictionary<string, BenchResult>> r
 
 PlotBoxPlotSvg(results);
 ",,,,,,,,2b2be57a092b7de3,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,41590dbb,markdown,fr,199e6ea84f43861d,"### Interpretation : Variabilite et previsibilite des solveurs
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,41590dbb,markdown,fr,6131b9de0e09d4b4,"### Interpretation : Variabilite et previsibilite des solveurs
 
 Les boxplots revelent un aspect crucial souvent neglige : la **previsibilite** des performances.
 
 | Solveur | Variabilite | Explication |
 |---------|-------------|-------------|
-| **Backtracking simple** | Tres forte | Certains puzzles faciles se resolvent en 1 ms, d'autres en 200+ secondes |
+| **Backtracking simple** | très forte | Certains puzzles faciles se resolvent en 1 ms, d'autres en 200+ secondes |
 | **BT + MRV** | Forte | L'heuristique reduit l'arbre mais reste sensible a la structure du puzzle |
-| **Norvig** | Tres faible | La propagation elimine la plupart de l'alea, temps quasi-constant |
+| **Norvig** | très faible | La propagation elimine la plupart de l'alea, temps quasi-constant |
 | **OR-Tools CP-SAT** | Negligeable | Le solveur industriel est optimise pour des performances predictibles |
 
-**Lecon pratique** : Dans un contexte de production, la previsibilite est souvent plus importante que la vitesse moyenne. Un solveur qui resout 99% des puzzles en moins de 20 ms est preferable a un solveur qui resout 99.9% en 1 ms mais explose sur les 0.1% restants.",,,,,,,,199e6ea84f43861d,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,1da65893,markdown,fr,e200d09cc01a7e0b,"### Visualisation : radar multi-criteres
+**Lecon pratique** : Dans un contexte de production, la previsibilite est souvent plus importante que la vitesse moyenne. Un solveur qui resout 99% des puzzles en moins de 20 ms est preferable a un solveur qui resout 99.9% en 1 ms mais explose sur les 0.1% restants.",,,,,,,,6131b9de0e09d4b4,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,1da65893,markdown,fr,e1f8145c363deb03,"### Visualisation : radar multi-critères
 
 Le graphique radar compare les solveurs sur **5 dimensions** qualitatives. Les scores sont normalises de 1 (faible) a 5 (excellent) pour permettre une vue d'ensemble.
 
@@ -15468,22 +15494,22 @@ Le graphique radar compare les solveurs sur **5 dimensions** qualitatives. Les s
 | **Fiabilite** | Taux de resolution sur tous les niveaux |
 | **Scalabilite** | Robustesse face a la difficulte croissante |
 | **Simplicite** | Nombre de lignes de code, facilite de comprehension |
-| **Generalite** | Capacite a s'adapter a d'autres problemes que le Sudoku |",,,,,,,,e200d09cc01a7e0b,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,4504da27,markdown,fr,635e3aacafb32d8f,"## Exemple : Ajouter un Solveur et Etendre le Benchmark
+| **Generalite** | Capacite a s'adapter a d'autres problemes que le Sudoku |",,,,,,,,e1f8145c363deb03,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,4504da27,markdown,fr,2a45176000fdd780,"## Exemple : Ajouter un Solveur et Etendre le Benchmark
 
 Cet exemple montre comment etendre le benchmark en ajoutant un cinquieme solveur. Nous implementons ici une variante du solveur Norvig avec du **forward checking explicite**.
 
 ### Principe du forward checking
 
-Apres chaque assignation tentative dans le backtracking, on verifie immediatement que toutes les cases vides ont encore au moins un candidat valide. Si une case a un domaine vide, la branche est coupee sans appel recursif supplementaire.
+après chaque assignation tentative dans le backtracking, on verifie immediatement que toutes les cases vides ont encore au moins un candidat valide. Si une case a un domaine vide, la branche est coupee sans appel récursif supplementaire.
 
 ### Implementation
 
 Le solveur `NorvigForwardCheckingSolver` etend le solveur Norvig standard en ajoutant :
-- Une methode `_forward_check` qui parcourt toutes les cases et detecte les domaines vides
-- Un appel a `_forward_check` dans `_search` juste apres `_assign`, avant de recurser
+- Une méthode `_forward_check` qui parcourt toutes les cases et detecte les domaines vides
+- Un appel a `_forward_check` dans `_search` juste après `_assign`, avant de recurser
 - Un compteur `fc_cuts` pour mesurer combien de branches sont coupees par le forward checking
-",,,,,,,,635e3aacafb32d8f,,,,,,,
+",,,,,,,,2a45176000fdd780,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,4864eb97,code,fr,4644dd43513fd88a,"// Solveur Norvig etendu avec forward checking explicite.
 // Apres chaque assignation, on verifie que toutes les cases vides ont encore
 // au moins un candidat ; si un domaine est vide, on echoue sans recurser.
@@ -15539,22 +15565,22 @@ bool solvedFc = solverNfc.SolveFc(g);
 sw.Stop();
 Console.WriteLine($""Norvig + Forward Checking: resolu={solvedFc}, {solverNfc.CallCount} appels, {solverNfc.FcCuts} coupes FC, {sw.Elapsed.TotalMilliseconds:F2} ms"");
 ",,,,,,,,4644dd43513fd88a,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,6546d6fe,markdown,fr,fc1142331344b481,"### Exemple : Solveur metaheuristique (recuit simule)
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,6546d6fe,markdown,fr,9a82de842f3a9ef6,"### Exemple : Solveur métaheuristique (recuit simule)
 
 Pour completer l'eventail des paradigmes, nous implementons un **sixime solveur** base sur le **recuit simule** (Simulated Annealing). Cette approche est particulierement interessante pour le regime Expert illustre par l'EPIC #3801 :
 
-- **Aucune garantie** de trouver la solution (c'est une metaheuristique stochastique)
+- **Aucune garantie** de trouver la solution (c'est une métaheuristique stochastique)
 - **Parametrable** par une temperature initiale et un facteur de refroidissement
-- **Souvent rapide sur les premiers echelons**, mais peine sur les regimes tres contraints
+- **Souvent rapide sur les premiers echelons**, mais peine sur les regimes très contraints
 
 L'objectif ici n'est PAS de battre Norvig/CP-SAT sur les puzzles faciles : c'est de demontrer concretement qu'une approche *sans garantie* se distingue d'une approche *avec garantie* sur le regime Expert -- le moteur est mis en valeur (il fait quelque chose qui distingue garanties vs heuristiques dans un cas non-trivial), pas contourne.
 
 ### Implementation
 
-Le solveur demarre par un **pre-remplissage structure** : chaque ligne est completee par une permutation aleatoire des chiffres qui lui manquent, de sorte que chaque ligne soit valide (permutation de 1..9) des le depart -- les conflits ne residuent plus que dans les colonnes et les blocs. Ensuite, a chaque pas, le solveur **echange (swap)** les valeurs de deux cases non-verrouillees prises dans une MEME ligne : ce move preserve la validite de la ligne, seuls les conflits de colonnes et de blocs peuvent changer. L'acceptation d'un move degradeur suit le critere de Metropolis (probabilite exp(-delta/T) qui decroit avec la ""temperature"" T). Le succes est obtenu quand le score (nombre de doublons sur les 9 colonnes et 9 blocs) tombe a 0.
+Le solveur demarre par un **pre-remplissage structure** : chaque ligne est completee par une permutation aleatoire des chiffres qui lui manquent, de sorte que chaque ligne soit valide (permutation de 1..9) des le depart -- les conflits ne residuent plus que dans les colonnes et les blocs. Ensuite, a chaque pas, le solveur **echange (swap)** les valeurs de deux cases non-verrouillees prises dans une même ligne : ce move preserve la validite de la ligne, seuls les conflits de colonnes et de blocs peuvent changer. L'acceptation d'un move degradeur suit le critere de Metropolis (probabilite exp(-delta/T) qui decroit avec la ""temperature"" T). Le succes est obtenu quand le score (nombre de doublons sur les 9 colonnes et 9 blocs) tombe a 0.
 
 
-> **Note de parite (graine RNG).** Le recuit simule est stochastique : la convergence depend de la sequence pseudo-aleatoire. Le twin Python resout le puzzle facile avec `seed=42` (981 iterations), car `random.seed(42)` produit une sequence qui converge tôt. Ce twin C# utilise `seed=51` : `System.Random(42)` produit une **sequence differente** qui reste bloquee dans un minimum local (score residual 2), tandis que `Random(51)` converge en ~1274 iterations. L'algorithme (init par permutation de ligne, swap intra-ligne, critere de Metropolis, refroidissement geometrique alpha=0.999) est **identique** au twin Python -- seule la sequence RNG differe, ce qui est intrinseque a l'ecart `System.Random` vs Mersenne Twister de Python. Sur 600 graines C# testees, ~3% convergent en <4000 iterations (ratio similaire a Python). C'est precisement le message pedagogique du Prong B (#3801) : une metaheuristique n'a **aucune garantie** de convergence.",,,,,,,,fc1142331344b481,,,,,,,
+> **Note de parite (graine RNG).** Le recuit simule est stochastique : la convergence depend de la sequence pseudo-aleatoire. Le twin Python resout le puzzle facile avec `seed=42` (981 itérations), car `random.seed(42)` produit une sequence qui converge tôt. Ce twin C# utilise `seed=51` : `System.Random(42)` produit une **sequence différente** qui reste bloquee dans un minimum local (score residual 2), tandis que `Random(51)` converge en ~1274 itérations. L'algorithme (init par permutation de ligne, swap intra-ligne, critere de Metropolis, refroidissement geometrique alpha=0.999) est **identique** au twin Python -- seule la sequence RNG differe, ce qui est intrinseque a l'ecart `System.Random` vs Mersenne Twister de Python. Sur 600 graines C# testees, ~3% convergent en <4000 itérations (ratio similaire a Python). C'est précisément le message pedagogique du Prong B (#3801) : une métaheuristique n'a **aucune garantie** de convergence.",,,,,,,,9a82de842f3a9ef6,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,80d91159,code,fr,2ce4cd8ef2847849,"// Solveur par recuit simule (Simulated Annealing) pour Sudoku.
 // Metaheuristique stochastique SANS GARANTIE de trouver la solution.
 // Illustre l'EPIC #3801 sur le regime Expert 17-24 indices.
@@ -15669,28 +15695,28 @@ bool solvedSa = solverSa.Solve(g);
 sw.Stop();
 Console.WriteLine($""Simulated Annealing: resolu={solvedSa}, {solverSa.CallCount} iterations, {solverSa.AcceptedCount} acceptees, {sw.Elapsed.TotalMilliseconds:F2} ms"");
 ",,,,,,,,2ce4cd8ef2847849,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,56ca7ea0,markdown,fr,f6d95cb3f60cae16,"### Interpretation : Exercice AC-3 et propagation de contraintes
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,56ca7ea0,markdown,fr,fb1d52bddeb601ea,"### Interpretation : Exercice AC-3 et propagation de contraintes
 
 L'exercice propose d'implementer **AC-3** (Arc Consistency 3), l'un des algorithmes de propagation de contraintes les plus fondamentaux en IA.
 
 **Pourquoi AC-3 est important** :
 1. C'est la base de nombreux solveurs CSP professionnels
 2. Il reduit les domaines de chaque variable en eliminant les valeurs impossibles
-3. Combine avec le backtracking MRV, il forme un solveur tres competitif
+3. Combine avec le backtracking MRV, il forme un solveur très competitif
 
-**Performance attendue** : Un solveur BT + AC-3 bien implemente devrait se rapprocher des performances du solveur Norvig, puisque la propagation de Norvig est une variante simplifiee de la coherence d'arc. La difference principale est qu'AC-3 verifie explicitement chaque paire de contraintes, tandis que Norvig utilise des strategies de propagation plus ciblees (elimination + naked singles).",,,,,,,,f6d95cb3f60cae16,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,e3665aa6,markdown,fr,ffec48b0a69c656c,"### Interpretation : Norvig + Forward Checking (Option B)
+**Performance attendue** : Un solveur BT + AC-3 bien implemente devrait se rapprocher des performances du solveur Norvig, puisque la propagation de Norvig est une variante simplifiee de la coherence d'arc. La différence principale est qu'AC-3 verifie explicitement chaque paire de contraintes, tandis que Norvig utilise des stratégies de propagation plus ciblees (elimination + naked singles).",,,,,,,,fb1d52bddeb601ea,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,e3665aa6,markdown,fr,cc6d4a2f8daa3473,"### Interpretation : Norvig + Forward Checking (Option B)
 
-L'idee du **forward checking** : apres chaque assignation tentative dans le backtracking, on verifie immediatement que toutes les cases vides ont encore au moins un candidat. Si une case a un domaine vide, la branche est coupee sans appel recursif supplementaire.
+L'idee du **forward checking** : après chaque assignation tentative dans le backtracking, on verifie immediatement que toutes les cases vides ont encore au moins un candidat. Si une case a un domaine vide, la branche est coupee sans appel récursif supplementaire.
 
 **Ce que j'ai ajoute par rapport a Norvig standard** :
-- Une methode `_forward_check` qui parcourt toutes les cases et detecte les domaines vides
-- Un appel a `_forward_check` dans `_search` juste apres `_assign`, avant de recurser
+- Une méthode `_forward_check` qui parcourt toutes les cases et detecte les domaines vides
+- Un appel a `_forward_check` dans `_search` juste après `_assign`, avant de recurser
 - Un compteur `fc_cuts` pour mesurer combien de branches sont coupees par le forward checking
 
 ### Mise a jour du benchmark
 
-On integre le nouveau solveur dans le dictionnaire `solvers`, on relance `run_benchmark`, puis on met a jour le graphique.",,,,,,,,ffec48b0a69c656c,,,,,,,
+On integre le nouveau solveur dans le dictionnaire `solvers`, on relance `run_benchmark`, puis on met a jour le graphique.",,,,,,,,cc6d4a2f8daa3473,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,8642cf81,code,fr,9bdef3601180babb,"// Solveurs etendus : les 4 originaux + Norvig + Forward Checking + Simulated Annealing
 // Surcharges Probe pour les types definis dans les cellules 16-17 (forward decl impossible cross-cell)
 public static SolverProbe Probe(NorvigForwardCheckingSolver s) => new SolverProbe(s.SolveFc, () => s.CallCount);
@@ -15711,20 +15737,20 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,e692ea3b,code,fr,279d
 var resultsExtended = RunBenchmark(solverFactoriesExtended, puzzleSets, maxPuzzles: 1, timeoutMs: 10000);
 Console.WriteLine(""Termine.\n"");
 ",,,,,,,,279d8c363f565f6b,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,31926d52,markdown,fr,2e5c917a66440ab7,"### Execution du benchmark etendu
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,31926d52,markdown,fr,da4afc07e5820f11,"### exécution du benchmark etendu
 
-Nous relancons le benchmark avec les 5 solveurs (les 4 originaux + Norvig + Forward Checking) pour mesurer l'impact du forward checking sur les performances.",,,,,,,,2e5c917a66440ab7,,,,,,,
+Nous relancons le benchmark avec les 5 solveurs (les 4 originaux + Norvig + Forward Checking) pour mesurer l'impact du forward checking sur les performances.",,,,,,,,da4afc07e5820f11,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,a091a298,code,fr,a56bf6fd0a19e27f,"// Graphique etendu (SVG inline via SvgChartHelper.GroupedBar) : Norvig+FC + Recuit Simule
 // (Prong B #3801 -- la metaheuristique n'a aucune garantie de convergence, visible sur Expert).
 // EPIC #6927 : migration Plotly-CDN -> SVG inline. Meme helper canon que la cellule 39.
 PlotBenchmarkBarsSvg(resultsExtended, ""Benchmark etendu : Norvig+FC + recuit simule (Prong B #3801, axe Y log)"");
 Console.WriteLine(""\n(Prong B #3801 : le recuit simule n'a aucune garantie de convergence)"");
 ",,,,,,,,a56bf6fd0a19e27f,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,c43989c3,markdown,fr,e3fc03e9309fb329,"### Analyse : le solveur Norvig + FC est-il competitif ?
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,c43989c3,markdown,fr,67a35a82f897f07e,"### Analyse : le solveur Norvig + FC est-il competitif ?
 
 **Reponse courte** : oui, il est competitif avec Norvig standard, mais il n'apporte pas de gain significatif sur ce benchmark.
 
-**Resultats obtenus** :
+**résultats obtenus** :
 
 | Solveur | Temps (puzzle de test) | Appels recursifs | Coupes FC |
 |---------|------------------------|------------------|-----------|
@@ -15733,54 +15759,54 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,c43989c3,markdown,fr,
 
 **Explications** :
 
-1. **Performances quasi identiques a Norvig**. Sur le puzzle de test, Norvig + FC resout en 2.39 ms (vs 2.34 ms pour Norvig pur), avec 0 coupe FC. Normal : la propagation `_eliminate` deja presente dans Norvig detecte les domaines vides a la source. Le forward check explicite ne coupe en pratique aucune branche additionnelle (`fc_cuts` = 0).
+1. **Performances quasi identiques a Norvig**. Sur le puzzle de test, Norvig + FC resout en 2.39 ms (vs 2.34 ms pour Norvig pur), avec 0 coupe FC. Normal : la propagation `_eliminate` déjà presente dans Norvig detecte les domaines vides a la source. Le forward check explicite ne coupe en pratique aucune branche additionnelle (`fc_cuts` = 0).
 
-2. **Legere surcharge par appel**. Le forward check parcourt les 81 cases a chaque descente recursive, ce qui ajoute un cout lineaire par appel. Sur un puzzle ou peu de branches sont coupees, ce cout n'est pas amorti et on peut meme etre un peu plus lent que Norvig standard.
+2. **Legere surcharge par appel**. Le forward check parcourt les 81 cases a chaque descente récursive, ce qui ajoute un cout lineaire par appel. Sur un puzzle ou peu de branches sont coupees, ce cout n'est pas amorti et on peut même etre un peu plus lent que Norvig standard.
 
-3. **Ou le forward checking brille reellement**. Si on retirait la propagation puissante de Norvig (elimination + naked singles) et qu'on gardait uniquement un backtracking MRV + forward checking, l'impact du FC serait beaucoup plus visible : il servirait de principal mecanisme d'elagage. Ici, la propagation fait deja l'essentiel du travail.
+3. **Ou le forward checking brille reellement**. Si on retirait la propagation puissante de Norvig (elimination + naked singles) et qu'on gardait uniquement un backtracking MRV + forward checking, l'impact du FC serait beaucoup plus visible : il servirait de principal mécanisme d'elagage. Ici, la propagation fait déjà l'essentiel du travail.
 
-**Conclusion** : Le forward checking est une **technique fondamentale** en CSP, mais son utilite depend du solveur dans lequel on l'integre. Sur un solveur deja fortement propage comme Norvig, il est redondant ; sur un backtracking naif, il apporte un gain enorme. C'est un bon exemple du principe **""la somme des ameliorations n'est pas toujours additive""** : certaines techniques se recouvrent.
-",,,,,,,,e3fc03e9309fb329,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,9faf42d3,markdown,fr,35b2d4f28fcac868,"## Exemple guide : Comparaison de Profils de Resolution
+**Conclusion** : Le forward checking est une **technique fondamentale** en CSP, mais son utilite depend du solveur dans lequel on l'integre. Sur un solveur déjà fortement propage comme Norvig, il est redondant ; sur un backtracking naif, il apporte un gain enorme. C'est un bon exemple du principe **""la somme des ameliorations n'est pas toujours additive""** : certaines techniques se recouvrent.
+",,,,,,,,67a35a82f897f07e,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,9faf42d3,markdown,fr,2fbece9898adf62a,"## Exemple guide : Comparaison de Profils de Resolution
 
-Dans cet exercice, vous allez analyser finement les comportements de resolution des differents solveurs pour comprendre **pourquoi** certains sont plus efficaces que d'autres.
+Dans cet exercice, vous allez analyser finement les comportements de resolution des différents solveurs pour comprendre **pourquoi** certains sont plus efficaces que d'autres.
 
 ### Objectif
 
-Implementer un outil de profilage qui mesure, pour chaque solveur et chaque puzzle, non seulement le temps de resolution, mais aussi le **nombre d'operations effectuees** (appels recursifs, eliminations, propagations).
+Implementer un outil de profilage qui mesure, pour chaque solveur et chaque puzzle, non seulement le temps de resolution, mais aussi le **nombre d'opérations effectuees** (appels recursifs, eliminations, propagations).
 
 ### Travaux demandes
 
-1. **Etendre les solveurs** pour qu'ils comptent leurs operations internes. Pour Norvig, **creer une sous-classe `ProfiledNorvigSolver(NorvigSolver)`** qui ajoute un compteur d'eliminations (ne pas modifier la classe `NorvigSolver` d'origine) :
-   - `BacktrackingSolver` : deja compte les appels recursifs
-   - `MRVBacktrackingSolver` : deja compte les appels recursifs
+1. **Etendre les solveurs** pour qu'ils comptent leurs opérations internes. Pour Norvig, **créer une sous-classe `ProfiledNorvigSolver(NorvigSolver)`** qui ajoute un compteur d'eliminations (ne pas modifier la classe `NorvigSolver` d'origine) :
+   - `BacktrackingSolver` : déjà compte les appels recursifs
+   - `MRVBacktrackingSolver` : déjà compte les appels recursifs
    - `ProfiledNorvigSolver` : sous-classe de `NorvigSolver`, compte les appels recursifs + nombre d'eliminations
    - `ORToolsCPSATSolver` : compte le nombre de variables et contraintes
 
 2. **Completer la fonction `profile_solver(solver, grid)`** (scaffold fourni ci-dessous) qui :
    - Resout le puzzle en mesurant le temps avec `time.perf_counter()`
-   - Retourne un dictionnaire `{""time_ms"": ..., ""operations"": ..., ""success"": ...}`
+   - Retourne un dictionnaire `{""time_ms"": ..., ""opérations"": ..., ""success"": ...}`
 
-3. **Lancer un profilage sur 5 puzzles de chaque niveau** (Easy, Medium, Hard) et stocker les resultats dans une structure de donnees appropriee (la boucle est esquissee ci-dessous)
+3. **Lancer un profilage sur 5 puzzles de chaque niveau** (Easy, Medium, Hard) et stocker les résultats dans une structure de données appropriee (la boucle est esquissee ci-dessous)
 
 4. **Completer la visualisation comparative** :
-   - Un scatter plot : temps (x) vs operations (y), un point par solveur/puzzle
+   - Un scatter plot : temps (x) vs opérations (y), un point par solveur/puzzle
    - Colorer les points par niveau de difficulte (Easy=vert, Medium=orange, Hard=rouge)
    - Ajouter une legende et des labels clairs (squelette fourni)
 
 5. **Analyser et interpreter** :
-   - Quels solveurs ont le meilleur ratio temps/operations ?
-   - Y a-t-il des puzzles ou un solveur ""explose"" en operations meme s'il est rapide ?
-   - Le nombre d'operations est-il un bon predicteur du temps de resolution ?
+   - Quels solveurs ont le meilleur ratio temps/opérations ?
+   - Y a-t-il des puzzles ou un solveur ""explose"" en opérations même s'il est rapide ?
+   - Le nombre d'opérations est-il un bon predicteur du temps de resolution ?
 
 **Indice pour le comptage des eliminations Norvig :**
 
-Dans `ProfiledNorvigSolver._eliminate`, incrementez `self.elimination_count` au debut de la methode (apres avoir initialise ce compteur dans `__init__`). Le comptage doit inclure les appels no-op.
+Dans `ProfiledNorvigSolver._eliminate`, incrementez `self.elimination_count` au debut de la méthode (après avoir initialise ce compteur dans `__init__`). Le comptage doit inclure les appels no-op.
 
-### Resultat attendu
+### résultat attendu
 
-Un notebook avec un scatter plot montrant la correlation (ou l'absence de correlation) entre le nombre d'operations et le temps de resolution, accompagne d'une interpretation en 3-4 paragraphes.
-",,,,,,,,35b2d4f28fcac868,,,,,,,
+Un notebook avec un scatter plot montrant la correlation (ou l'absence de correlation) entre le nombre d'opérations et le temps de resolution, accompagne d'une interpretation en 3-4 paragraphes.
+",,,,,,,,2fbece9898adf62a,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,7c230215,code,fr,5b04561904dd4066,"// EXERCICE : Profilage d'un solveur sur une grille
 public static Dictionary<string, object> ProfileSolver(SolverProbe probe, SudokuGrid grid)
 {
@@ -15801,12 +15827,12 @@ public static Dictionary<string, object> ProfileSolver(SolverProbe probe, Sudoku
 
 Console.WriteLine(""Exercice a completer : profilage d un solveur"");
 ",,,,,,,,5b04561904dd4066,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,1a72ccab,markdown,fr,514978b17c57b251,"#### Solveur Norvig profile
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,1a72ccab,markdown,fr,8d0ead465fb25001,"#### Solveur Norvig profile
 
 Pour compter les eliminations de Norvig sans modifier la classe d'origine,
-creez une sous-classe qui surcharge `_eliminate` en incrementant un compteur
-avant de deleguer a la methode parente.
-",,,,,,,,514978b17c57b251,,,,,,,
+créez une sous-classe qui surcharge `_eliminate` en incrementant un compteur
+avant de deleguer a la méthode parente.
+",,,,,,,,8d0ead465fb25001,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,7af6d43b,code,fr,697574954d5edf3a,"// EXERCICE : ProfiledNorvigSolver instrumente
 // Herite de NorvigSolver et surcharge Eliminate pour ajouter un compteur.
 public class ProfiledNorvigSolver : NorvigSolver
@@ -15818,14 +15844,14 @@ public class ProfiledNorvigSolver : NorvigSolver
 
 Console.WriteLine(""Exercice a completer : ProfiledNorvigSolver instrumente"");
 ",,,,,,,,697574954d5edf3a,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,2d09808f,markdown,fr,a6db818ab0d82e98,"### Execution du profilage
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,2d09808f,markdown,fr,3fbf3508e91f2e74,"### exécution du profilage
 
 Utilisez `profile_solver` pour tester chaque solveur sur 5 puzzles de chaque niveau.
 La structure de la boucle est esquissee ci-dessous -- completez les parties manquantes.
 
 **Attention** : le solveur Backtracking peut mettre plus de 30s sur les puzzles Medium.
 Pour un premier test, commencez avec `max_puzzles=2` et augmentez ensuite.
-",,,,,,,,a6db818ab0d82e98,,,,,,,
+",,,,,,,,3fbf3508e91f2e74,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,461a17c9,code,fr,cd0982ccbf17cbe0,"// Solveurs a profiler (exercice guide : completer la boucle de profilage)
 var solverFactoriesProfile = new Dictionary<string, Func<SolverProbe>>()
 {
@@ -15856,12 +15882,12 @@ var profilingResults = new List<Dictionary<string, object>>();
 
 Console.WriteLine($""Resultats collectes : {profilingResults.Count} mesures"");
 ",,,,,,,,cd0982ccbf17cbe0,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,bd65ed1a,markdown,fr,a19ac7565cf7b6c2,"### Visualisation : scatter plot temps vs operations
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,bd65ed1a,markdown,fr,4abc1c2e1cc1535b,"### Visualisation : scatter plot temps vs opérations
 
 Completez le scatter plot ci-dessous pour afficher le temps (axe x) vs le nombre
-d'operations (axe y) pour chaque solveur/puzzle. Utilisez une couleur par niveau de
+d'opérations (axe y) pour chaque solveur/puzzle. Utilisez une couleur par niveau de
 difficulte et une echelle logarithmique sur les deux axes.
-",,,,,,,,a19ac7565cf7b6c2,,,,,,,
+",,,,,,,,4abc1c2e1cc1535b,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,2d0e1768,code,fr,f6e4cff06d31c2ca,"// Exemple guide : Completer le scatter plot (ASCII) a partir de profilingResults
 var difficultyColors = new Dictionary<string, string>
 {
@@ -15874,22 +15900,22 @@ var difficultyColors = new Dictionary<string, string>
 
 Console.WriteLine(""Scatter plot a completer ci-dessus"");
 ",,,,,,,,f6e4cff06d31c2ca,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,afa74e18,markdown,fr,ed41c48a0ea59b68,"### Votre analyse
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,afa74e18,markdown,fr,ab3fb053d2f027d4,"### Votre analyse
 
 *Redigez 3-4 paragraphes en repondant aux questions suivantes :*
 
-1. **Ratio temps/operations** : Quels solveurs ont le meilleur ratio ?
-   Un solveur qui fait peu d'operations est-il toujours le plus rapide ?
+1. **Ratio temps/opérations** : Quels solveurs ont le meilleur ratio ?
+   Un solveur qui fait peu d'opérations est-il toujours le plus rapide ?
 
-2. **Explosions d'operations** : Y a-t-il des puzzles ou un solveur ""explose""
-   en operations malgre un temps raisonnable ? Que cela indique-t-il ?
+2. **Explosions d'opérations** : Y a-t-il des puzzles ou un solveur ""explose""
+   en opérations malgre un temps raisonnable ? Que cela indique-t-il ?
 
-3. **Predictibilite** : Le nombre d'operations est-il un bon predicteur du
+3. **Predictibilite** : Le nombre d'opérations est-il un bon predicteur du
    temps de resolution ? Pourquoi ou pourquoi pas ?
 
 *Votre reponse :*
-",,,,,,,,ed41c48a0ea59b68,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,544807af,markdown,fr,9743745302e9f4bc,"## Conclusion
+",,,,,,,,ab3fb053d2f027d4,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,544807af,markdown,fr,2c8e010368cff37f,"## Conclusion
 
 Ce notebook a compare **4 solveurs Python** representatifs de paradigmes algorithmiques distincts pour la resolution du Sudoku.
 
@@ -15901,14 +15927,14 @@ Ce notebook a compare **4 solveurs Python** representatifs de paradigmes algorit
 | Heuristique MRV | BT + MRV | Choisir la variable la plus contrainte pour detecter les impasses plus tot |
 | Propagation de contraintes | Norvig | Eliminer les valeurs impossibles avant la recherche |
 | Programmation par contraintes | OR-Tools CP-SAT | Declarer les contraintes, laisser le solveur trouver la solution |
-| Forward checking | Norvig + FC | Verifier la coherence des domaines apres chaque assignation |
+| Forward checking | Norvig + FC | Verifier la coherence des domaines après chaque assignation |
 
 ### Enseignements principaux
 
 1. **La propagation domine** : le solveur Norvig resout la majorite des puzzles sans aucun backtracking, confirmant que reduire l'espace de recherche est plus efficace que d'explorer plus intelligemment.
 2. **Les heuristiques comptent** : MRV divise le nombre d'appels recursifs par 4 a 1000x selon la difficulte du puzzle, pour un surcout constant par appel.
 3. **La previsibilite est cruciale** : en production, un solveur rapide mais imprevisible (backtracking) est souvent moins desirable qu'un solveur legerement plus lent mais constant (CP-SAT).
-4. **La difficulte n'est pas monotone** : le nombre de cases vides ne predit pas la difficulte algorithmique. La structure des contraintes importe davantage.",,,,,,,,9743745302e9f4bc,,,,,,,
+4. **La difficulte n'est pas monotone** : le nombre de cases vides ne predit pas la difficulte algorithmique. La structure des contraintes importe davantage.",,,,,,,,2c8e010368cff37f,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,1fabc7b9,markdown,fr,30322087225f4cf7,"---
 
 ---
@@ -15921,7 +15947,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb,1fabc7b9,markdown,fr,
 
 **Retour au sommaire** : [Index Sudoku](README.md)
 ",,,,,,,,30322087225f4cf7,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,x4t390o1d,markdown,fr,fc1a5b141a1c0b64,"**Navigation** : [Index](README.md) | [<< Sudoku-17 Python](Sudoku-17-LLM-Python.ipynb) | [Fin de serie >>]
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,x4t390o1d,markdown,fr,9980a313ad2560f4,"**Navigation** : [Index](README.md) | [<< Sudoku-17 Python](Sudoku-17-LLM-Python.ipynb) | [Fin de serie >>]
 
 # Comparaison des Solveurs de Sudoku
 
@@ -15930,33 +15956,33 @@ Voir aussi : [Search Foundations](../Search/Part1-Foundations/) pour les algorit
 ## Objectifs d'apprentissage
 
 A la fin de ce notebook, vous saurez :
-1. Classifier les differentes approches de resolution de Sudoku par categorie (exacte, heuristique, propagation, apprentissage)
-2. Comparer objectivement les performances de 4 solveurs Python sur des puzzles de difficulte variee
-3. Analyser les forces et faiblesses de chaque approche selon plusieurs criteres (vitesse, fiabilite, scalabilite, simplicite)
+1. Classifier les différentes approches de résolution de Sudoku par catégorie (exacte, heuristique, propagation, apprentissage)
+2. Comparer objectivement les performances de 4 solveurs Python sur des puzzles de difficulté variee
+3. Analyser les forces et faiblesses de chaque approche selon plusieurs critères (vitesse, fiabilite, scalabilite, simplicite)
 4. Choisir le bon solveur en fonction du contexte d'utilisation
 
 ### Prerequis
 - Avoir lu au moins 3-4 notebooks de la serie Sudoku (Backtracking, OR-Tools, Norvig, un autre au choix)
 - Python 3.10+ avec numpy, matplotlib, ortools
 
-### Duree estimee : 35 minutes",,,,,,,,fc1a5b141a1c0b64,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,u6m3zst9zqh,markdown,fr,2a7628b0a9cd4b4b,"## 1. Introduction
+### Duree estimee : 35 minutes",,,,,,,,9980a313ad2560f4,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,u6m3zst9zqh,markdown,fr,af51e1b931cb82e2,"## 1. Introduction
 
-Au fil de cette serie de notebooks, nous avons explore **9 approches differentes** pour resoudre le Sudoku. Chacune incarne une philosophie algorithmique distincte :
+Au fil de cette serie de notebooks, nous avons explore **9 approches différentes** pour résoudre le Sudoku. Chacune incarne une philosophie algorithmique distincte :
 
 | # | Notebook | Approche | Philosophie |
 |---|----------|----------|-------------|
-| 1 | [Backtracking](Sudoku-1-Backtracking-Python.ipynb) | Recherche exhaustive | Explorer systematiquement toutes les possibilites |
-| 2 | [Genetic](Sudoku-3-Genetic-Python.ipynb) | Metaheuristique | Faire evoluer une population de solutions candidates |
+| 1 | [Backtracking](Sudoku-1-Backtracking-Python.ipynb) | Recherche exhaustive | Explorer systématiquement toutes les possibilites |
+| 2 | [Genetic](Sudoku-3-Genetic-Python.ipynb) | Métaheuristique | Faire evoluer une population de solutions candidates |
 | 3 | [OR-Tools](Sudoku-10-ORTools-Python.ipynb) | Programmation par contraintes | Declarer les contraintes, laisser le solveur chercher |
 | 4 | [Z3](Sudoku-12-Z3-Python.ipynb) | Satisfiabilite (SMT) | Prouver l'existence d'une solution satisfaisant des formules logiques |
-| 5 | [Dancing Links](Sudoku-2-DancingLinks-Python.ipynb) | Couverture exacte | Reduire a un probleme de selection de sous-ensembles |
-| 6 | [Infer.NET](Sudoku-15-Infer-Python.ipynb) | Inference probabiliste | Propager des distributions de probabilite |
+| 5 | [Dancing Links](Sudoku-2-DancingLinks-Python.ipynb) | Couverture exacte | Reduire a un problème de sélection de sous-ensembles |
+| 6 | [Infer.NET](Sudoku-15-Infer-Python.ipynb) | Inference probabiliste | Propager des distributions de probabilité |
 | 7 | [Norvig](Sudoku-7-Norvig-Python.ipynb) | Propagation de contraintes | Eliminer les impossibilites avant de chercher |
-| 8 | Simulated Annealing | Recuit simule | Optimiser par perturbations aleatoires avec refroidissement |
-| 10 | Neural Network | Apprentissage profond | Apprendre les motifs de resolution a partir d'exemples |
+| 8 | Simulated Annealing | Recuit simule | Optimiser par perturbations aléatoires avec refroidissement |
+| 10 | Neural Network | Apprentissage profond | Apprendre les motifs de résolution a partir d'exemples |
 
-Ce notebook final propose une **comparaison systematique** de ces approches selon plusieurs dimensions : vitesse, fiabilite, elegance du code et scalabilite. Nous implementerons 4 solveurs Python representatifs et les testerons sur un benchmark commun.",,,,,,,,2a7628b0a9cd4b4b,,,,,,,
+Ce notebook final propose une **comparaison systématique** de ces approches selon plusieurs dimensions : vitesse, fiabilite, elegance du code et scalabilite. Nous implementerons 4 solveurs Python représentatifs et les testerons sur un benchmark commun.",,,,,,,,af51e1b931cb82e2,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,ncy5d3t7ch,code,fr,d04a9033bed00314,"# Imports
 import time
 from typing import List, Optional, Tuple, Dict
@@ -15988,82 +16014,82 @@ if NUMPY_AVAILABLE:
 if ORTOOLS_AVAILABLE:
     print(""  ortools importe"")
 ",,,,,,,,d04a9033bed00314,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,e63ed6bc,markdown,fr,523a0655a177b88f,"### Interpretation : Environnement et dependances
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,e63ed6bc,markdown,fr,1a15f52edbb4e1cf,"### Interpretation : Environnement et dependances
 
 **Bibliotheques utilisees** :
 
-| Bibliotheque | Version | Role dans ce notebook |
+| Bibliotheque | Version | Rôle dans ce notebook |
 |-------------|---------|----------------------|
-| numpy | 2.4.2 | Calculs numeriques, statistiques (medianne, moyennes) |
+| numpy | 2.4.2 | Calculs numériques, statistiques (medianne, moyennes) |
 | matplotlib | - | Visualisations (barres, boxplots, radar) |
 | ortools | - | Solveur CP-SAT industriel (4e solveur du benchmark) |
-| time | - | Mesure des temps d'execution |
+| time | - | Mesure des temps d'exécution |
 
 **Pourquoi ces choix** :
-- **OR-Tools CP-SAT** est le seul solveur externe necessaire. Les trois autres solveurs sont implementes en Python pur pour illustrer les algorithmes
+- **OR-Tools CP-SAT** est le seul solveur externe nécessaire. Les trois autrès solveurs sont implementes en Python pur pour illustrer les algorithmes
 - **numpy** est utilise pour les statistiques du benchmark (medianne des temps)
-- **matplotlib** genere les graphiques comparatifs (barres, boxplots, radar)
+- **matplotlib** génère les graphiques comparatifs (barres, boxplots, radar)
 
-> **Note** : Aucune dependance lourde (pas de tensorflow, pytorch, etc.). Ce notebook reste leger et s'execute sur n'importe quel environnement Python standard.",,,,,,,,523a0655a177b88f,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,hab7larz16t,markdown,fr,a6eb089a7421bff6,"## 2. Categories d'approches
+> **Note** : Aucune dépendance lourde (pas de tensorflow, pytorch, etc.). Ce notebook reste léger et s'exécute sur n'importe quel environnement Python standard.",,,,,,,,1a15f52edbb4e1cf,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,hab7larz16t,markdown,fr,96ab7ce4794e4ed7,"## 2. Catégories d'approches
 
-Les 9 approches etudiees se regroupent naturellement en **5 grandes categories**, chacune correspondant a un paradigme algorithmique fondamental.
+Les 9 approches etudiees se regroupent naturellement en **5 grandes catégories**, chacune correspondant a un paradigme algorithmique fondamental.
 
-### 2.1 Methodes exactes (garantie de solution)
+### 2.1 Méthodes exactes (garantie de solution)
 
-Ces methodes explorent l'espace de recherche de maniere systematique et **trouvent toujours une solution** si elle existe.
+Ces méthodes explorent l'espace de recherche de manière systématique et **trouvent toujours une solution** si elle existe.
 
-| Methode | Principe | Complexite pratique | Notebook |
+| Méthode | Principe | Complexite pratique | Notebook |
 |---------|----------|---------------------|----------|
 | **Backtracking** | DFS + validation | Rapide (facile), lent (difficile) | [Sudoku-1](Sudoku-1-Backtracking-Python.ipynb) |
-| **Backtracking + MRV** | DFS + heuristique MRV | Rapide meme sur puzzles difficiles | [Sudoku-Python-BT](Sudoku-1-Backtracking-Python.ipynb) |
-| **Dancing Links** | Couverture exacte (Algorithm X) | Optimal pour les problemes de couverture | [Sudoku-5](Sudoku-2-DancingLinks-Python.ipynb) |
-| **OR-Tools CP-SAT** | CP + SAT + CDCL | Tres rapide, constant | [Sudoku-3](Sudoku-10-ORTools-Python.ipynb) |
-| **Z3 SMT** | Satisfiabilite Modulo Theories | Rapide, overhead d'initialisation | [Sudoku-4](Sudoku-12-Z3-Python.ipynb) |
+| **Backtracking + MRV** | DFS + heuristique MRV | Rapide même sur puzzles difficiles | [Sudoku-Python-BT](Sudoku-1-Backtracking-Python.ipynb) |
+| **Dancing Links** | Couverture exacte (Algorithm X) | Optimal pour les problèmes de couverture | [Sudoku-5](Sudoku-2-DancingLinks-Python.ipynb) |
+| **OR-Tools CP-SAT** | CP + SAT + CDCL | Très rapide, constant | [Sudoku-3](Sudoku-10-ORTools-Python.ipynb) |
+| **Z3 SMT** | Satisfiabilite Modulo Théories | Rapide, overhead d'initialisation | [Sudoku-4](Sudoku-12-Z3-Python.ipynb) |
 
-### 2.2 Methodes de propagation
+### 2.2 Méthodes de propagation
 
-Ces methodes **reduisent l'espace de recherche** en eliminant les valeurs impossibles avant (ou a la place de) la recherche.
+Ces méthodes **reduisent l'espace de recherche** en eliminant les valeurs impossibles avant (ou a la place de) la recherche.
 
-| Methode | Principe | Completude | Notebook |
+| Méthode | Principe | Completude | Notebook |
 |---------|----------|------------|----------|
 | **Norvig** | Elimination + naked singles + DFS de secours | Complet (avec fallback recherche) | [Sudoku-7](Sudoku-7-Norvig-Python.ipynb) |
-| **Strategies humaines** | Regles logiques (naked pairs, X-Wing, etc.) | Incomplet sans recherche | (integre dans divers notebooks) |
+| **Stratégies humaines** | Règles logiques (naked pairs, X-Wing, etc.) | Incomplet sans recherche | (integre dans divers notebooks) |
 
-### 2.3 Methodes heuristiques (pas de garantie)
+### 2.3 Méthodes heuristiques (pas de garantie)
 
-Ces methodes utilisent des **mecanismes d'optimisation stochastique** et ne garantissent pas de trouver une solution.
+Ces méthodes utilisent des **mécanismes d'optimisation stochastique** et ne garantissent pas de trouver une solution.
 
-| Methode | Principe | Fiabilite | Notebook |
+| Méthode | Principe | Fiabilite | Notebook |
 |---------|----------|-----------|----------|
-| **Algorithme genetique** | Evolution de populations | Faible sur puzzles difficiles | [Sudoku-2](Sudoku-3-Genetic-Python.ipynb) |
+| **Algorithme génétique** | Evolution de populations | Faible sur puzzles difficiles | [Sudoku-2](Sudoku-3-Genetic-Python.ipynb) |
 | **Recuit simule** | Perturbations + refroidissement | Moyenne | Sudoku-8 |
 
-### 2.4 Methodes d'apprentissage
+### 2.4 Méthodes d'apprentissage
 
-| Methode | Principe | Fiabilite | Notebook |
+| Méthode | Principe | Fiabilite | Notebook |
 |---------|----------|-----------|----------|
-| **Reseau de neurones** | Apprentissage supervise | Approximation, necessite donnees | Sudoku-10 |
+| **Reseau de neurones** | Apprentissage supervise | Approximation, necessite données | Sudoku-10 |
 
-### 2.5 Methodes probabilistes
+### 2.5 Méthodes probabilistes
 
-| Methode | Principe | Fiabilite | Notebook |
+| Méthode | Principe | Fiabilite | Notebook |
 |---------|----------|-----------|----------|
-| **Infer.NET** | Graphe de facteurs, inference bayesienne | Experimentale | [Sudoku-6](Sudoku-15-Infer-Python.ipynb) |",,,,,,,,a6eb089a7421bff6,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,kcu1ir5104,markdown,fr,2abf2c17e215cc3e,"## 3. Implementations Python des solveurs
+| **Infer.NET** | Graphe de facteurs, inference bayesienne | Experimentale | [Sudoku-6](Sudoku-15-Infer-Python.ipynb) |",,,,,,,,96ab7ce4794e4ed7,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,kcu1ir5104,markdown,fr,8007f4ec99d5f33d,"## 3. Implementations Python des solveurs
 
-Pour une comparaison equitable, nous implementons **4 solveurs representatifs** dans le meme environnement Python. Chaque solveur represente une categorie differente.
+Pour une comparaison equitable, nous implementons **4 solveurs représentatifs** dans le même environnement Python. Chaque solveur représente une catégorie différente.
 
-| Solveur | Categorie | Pourquoi ce choix |
+| Solveur | Catégorie | Pourquoi ce choix |
 |---------|-----------|-------------------|
-| **Backtracking simple** | Recherche exhaustive | Baseline naive, reference de comparaison |
+| **Backtracking simple** | Recherche exhaustive | Baseline naive, référence de comparaison |
 | **Backtracking + MRV** | Recherche avec heuristique | Amelioration classique, montre l'impact des heuristiques |
 | **Norvig (propagation)** | Propagation de contraintes | Approche elegante, souvent suffisante sans recherche |
-| **OR-Tools CP-SAT** | Solveur industriel | Etat de l'art, reference de performance |
+| **OR-Tools CP-SAT** | Solveur industriel | Etat de l'art, référence de performance |
 
 ### Classe SudokuGrid commune
 
-Tous les solveurs utilisent la meme representation de grille pour garantir une comparaison equitable.",,,,,,,,2abf2c17e215cc3e,,,,,,,
+Tous les solveurs utilisent la même représentation de grille pour garantir une comparaison equitable.",,,,,,,,8007f4ec99d5f33d,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,hqzq1vpifn7,code,fr,a256f6a595a6eea5,"class SudokuGrid:
     """"""Representation d'une grille de Sudoku 9x9.""""""
 
@@ -16133,24 +16159,24 @@ test = SudokuGrid.from_string(""003020600900305001001806400008102900700000008006
 print(""Grille de test:"")
 print(test)
 print(f""Cases vides: {test.count_empty()}"")",,,,,,,,a256f6a595a6eea5,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,3cc009b5,markdown,fr,1f39069a9f4d1af2,"### Interpretation : Classe SudokuGrid - Representation commune
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,3cc009b5,markdown,fr,d110239634acfe3f,"### Interpretation : Classe SudokuGrid - Représentation commune
 
 **Fonctionnalites de la classe** :
 
-| Methode | Role | Utilite pour les solveurs |
+| Méthode | Rôle | Utilite pour les solveurs |
 |---------|------|--------------------------|
-| `from_string` | Cree une grille depuis 81 caracteres | Format universel pour les benchmarks |
+| `from_string` | Créé une grille depuis 81 caractères | Format universel pour les benchmarks |
 | `clone` | Copie independante | Evite les interferences entre solveurs |
 | `is_valid_placement` | Valide un placement (ligne/colonne/bloc) | Utilisee par le backtracking |
-| `find_empty` | Trouve la premiere case vide | Parcours naive pour le backtracking simple |
-| `count_empty` | Compte les cases vides | Metrique de difficulte |
-| `to_string` | Convertit en chaine | Interface avec le solveur Norvig |
+| `find_empty` | Trouve la première case vide | Parcours naive pour le backtracking simple |
+| `count_empty` | Compte les cases vides | Metrique de difficulté |
+| `to_string` | Convertit en chaîne | Interface avec le solveur Norvig |
 
-**Grille de test** : 49 cases vides sur 81 (60% de la grille). C'est un puzzle de difficulte moyenne-facile qui servira de validation rapide pour chaque solveur.
+**Grille de test** : 49 cases vides sur 81 (60% de la grille). C'est un puzzle de difficulté moyenne-facile qui servira de validation rapide pour chaque solveur.
 
-**Design choisi** : La classe est volontairement simple (liste de listes 9x9) pour ne pas avantager un solveur particulier. Le solveur Norvig utilise sa propre representation interne (dictionnaire de chaines) mais convertit vers/depuis SudokuGrid pour l'interface.
+**Design choisi** : La classe est volontairement simple (liste de listes 9x9) pour ne pas avantager un solveur particulier. Le solveur Norvig utilise sa propre représentation interne (dictionnaire de chaînes) mais convertit vers/depuis SudokuGrid pour l'interface.
 
-> **Point architecture** : Tous les solveurs implementent la meme interface `solve(grid: SudokuGrid) -> bool`, ce qui permet de les comparer equitablement et de les utiliser de maniere interchangeable dans le benchmark.",,,,,,,,1f39069a9f4d1af2,,,,,,,
+> **Point architecture** : Tous les solveurs implementent la même interface `solve(grid: SudokuGrid) -> bool`, ce qui permet de les comparer equitablement et de les utiliser de manière interchangeable dans le benchmark.",,,,,,,,d110239634acfe3f,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,060utfnbqhil,markdown,fr,0ec942a8c04d4e49,"### 3.1 Solveur 1 : Backtracking simple
 
 L'algorithme le plus intuitif : essayer chaque valeur dans chaque case vide, revenir en arriere si on atteint une impasse. C'est notre **baseline** -- le solveur le plus simple possible.
@@ -16188,15 +16214,15 @@ start = time.time()
 solved = solver_bt.solve(g)
 elapsed_ms = (time.time() - start) * 1000
 print(f""Backtracking simple: resolu={solved}, {solver_bt.call_count} appels, {elapsed_ms:.2f} ms"")",,,,,,,,4354460f7365b122,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,da3e4425,markdown,fr,2afc1e15a22ee642,"### Interpretation : Solveur Backtracking simple
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,da3e4425,markdown,fr,78b0459d1507ae66,"### Interpretation : Solveur Backtracking simple
 
-**Resultat** : Le backtracking simple resout le puzzle de test en 201 appels recursifs et 1.22 ms.
+**Résultat** : Le backtracking simple resout le puzzle de test en 201 appels recursifs et 1.22 ms.
 
 | Metrique | Valeur | Contexte |
 |----------|--------|----------|
 | Appels recursifs | 201 | Nombre d'entrees dans `_backtrack` |
 | Temps | 1.22 ms | Rapide pour ce puzzle facile |
-| Resultat | Succes | Solution trouvee |
+| Résultat | Succes | Solution trouvee |
 
 **Analyse** :
 
@@ -16204,24 +16230,24 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,da3e4425,markdown,fr,
 
 2. **Pourquoi ce sera lent sur les puzzles difficiles** : Sans heuristique, le solveur essaie les cases dans l'ordre (ligne par ligne, de gauche a droite) avec les valeurs 1 a 9. Sur un puzzle difficile avec 60+ cases vides, l'arbre de recherche peut atteindre des milliards de noeuds.
 
-3. **Role de baseline** : Ce solveur sert de reference pour mesurer l'impact des ameliorations. Toute optimisation (MRV, propagation, etc.) sera comparee a cette baseline.
+3. **Rôle de baseline** : Ce solveur sert de référence pour mesurer l'impact des améliorations. Toute optimisation (MRV, propagation, etc.) sera comparee a cette baseline.
 
-> **Comparaison a venir** : Le solveur MRV suivant fera seulement 50 appels sur ce meme puzzle -- deja 4x moins. La difference sera beaucoup plus marquee sur les puzzles Medium et Hard.",,,,,,,,2afc1e15a22ee642,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,ex-propagate-singles,markdown,fr,fc48974dc30bdcb7,"## Exercice : Propagation des singletons (Naked Singles)
+> **Comparaison a venir** : Le solveur MRV suivant fera seulement 50 appels sur ce même puzzle -- déjà 4x moins. La différence sera beaucoup plus marquee sur les puzzles Medium et Hard.",,,,,,,,78b0459d1507ae66,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,ex-propagate-singles,markdown,fr,573599ef8b438e82,"## Exercice : Propagation des singletons (Naked Singles)
 
 ### Enonce
 
-Le solveur Backtracking simple essaie les valeurs 1-9 sequentiellement. Mais avant de lancer le backtracking, on peut **propager** les deductions evidentes : les cases qui n'ont qu'un seul candidat possible.
+Le solveur Backtracking simple essaie les valeurs 1-9 séquentiellement. Mais avant de lancer le backtracking, on peut **propager** les deductions evidentes : les cases qui n'ont qu'un seul candidat possible.
 
 Implementez `propagate_naked_singles(grid)` qui remplit recursivement toutes les cases ayant exactement 1 candidat, jusqu'a ce qu'aucune propagation ne soit possible.
 
 ### Indices
 
-- Etape 1 : Pour chaque case vide, calculez les candidats (absents de ligne + colonne + bloc)
-- Etape 2 : Si exactement 1 candidat, remplissez la case
-- Etape 3 : Repetez tant qu'au moins une case a ete remplie (propagation en cascade)
-- Etape 4 : Retournez le nombre de cases remplies et la grille modifiee
-",,,,,,,,fc48974dc30bdcb7,,,,,,,
+- Étape 1 : Pour chaque case vide, calculez les candidats (absents de ligne + colonne + bloc)
+- Étape 2 : Si exactement 1 candidat, remplissez la case
+- Étape 3 : Repetez tant qu'au moins une case a ete remplie (propagation en cascade)
+- Étape 4 : Retournez le nombre de cases remplies et la grille modifiée
+",,,,,,,,573599ef8b438e82,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,ex-propagate-singles-code,code,fr,7928e8a7ba2a0712,"# EXERCICE : Propagation des singletons (Naked Singles)
 #
 # Indications :
@@ -16260,11 +16286,11 @@ print(f""Cases remplies par propagation : {n_filled}"")
 for row in test_grid_18:
     print(row)
 ",,,,,,,,7928e8a7ba2a0712,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,b2ol6bfz6cb,markdown,fr,ba40ab91408e23e3,"### 3.2 Solveur 2 : Backtracking avec MRV
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,b2ol6bfz6cb,markdown,fr,31fc95f124a1e186,"### 3.2 Solveur 2 : Backtracking avec MRV
 
 L'heuristique **MRV** (Minimum Remaining Values) selectionne toujours la case ayant le **moins de valeurs possibles**. Cela detecte les impasses plus tot et reduit drastiquement l'arbre de recherche.
 
-L'amelioration est souvent spectaculaire : de 100x a 1000x moins d'appels recursifs sur les puzzles difficiles.",,,,,,,,ba40ab91408e23e3,,,,,,,
+L'amélioration est souvent spectaculaire : de 100x a 1000x moins d'appels recursifs sur les puzzles difficiles.",,,,,,,,31fc95f124a1e186,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,wyb5wglub,code,fr,544e3bc51b812969,"class MRVBacktrackingSolver:
     """"""Solveur par backtracking avec heuristique MRV (Minimum Remaining Values).""""""
 
@@ -16325,9 +16351,9 @@ start = time.time()
 solved = solver_mrv.solve(g)
 elapsed_ms = (time.time() - start) * 1000
 print(f""Backtracking MRV: resolu={solved}, {solver_mrv.call_count} appels, {elapsed_ms:.2f} ms"")",,,,,,,,544e3bc51b812969,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,7bc5a527,markdown,fr,eea38636f458fbe8,"### Interpretation : Solveur Backtracking avec MRV
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,7bc5a527,markdown,fr,d5742ee9bd2616a4,"### Interpretation : Solveur Backtracking avec MRV
 
-**Resultat** : Le backtracking avec MRV resout le puzzle en 50 appels recursifs et 2.62 ms.
+**Résultat** : Le backtracking avec MRV resout le puzzle en 50 appels recursifs et 2.62 ms.
 
 | Metrique | Backtracking simple | BT + MRV | Amelioration |
 |----------|--------------------|---------|-------------|
@@ -16336,23 +16362,23 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,7bc5a527,markdown,fr,
 
 **Paradoxe apparent** : MRV fait moins d'appels mais prend plus de temps. Cela s'explique par le cout de l'heuristique :
 
-- **Backtracking simple** : Chaque appel est tres rapide (trouver la premiere case vide, essayer 1-9)
+- **Backtracking simple** : Chaque appel est très rapide (trouver la première case vide, essayer 1-9)
 - **BT + MRV** : Chaque appel necessite de calculer les candidats de toutes les cases vides et de trouver celle avec le minimum
 
-**Pourquoi MRV est quand meme preferable** :
-1. Sur les puzzles faciles, la difference de temps est negligeable (millisecondes)
+**Pourquoi MRV est quand même préférable** :
+1. Sur les puzzles faciles, la différence de temps est negligeable (millisecondes)
 2. Sur les puzzles difficiles, MRV reduit l'arbre de recherche de plusieurs ordres de grandeur
-3. Le surcout par appel est constant, mais le nombre d'appels evites croit exponentiellement avec la difficulte
+3. Le surcout par appel est constant, mais le nombre d'appels evites croit exponentiellement avec la difficulté
 
-> **Principe MRV** : Toujours choisir la variable la plus contrainte (""fail-first""). En traitant d'abord les cases avec peu de candidats, on detecte les impasses plus tot et on evite d'explorer des sous-arbres inutiles.",,,,,,,,eea38636f458fbe8,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,clmlmdoxx3f,markdown,fr,a626fc131595f8b9,"### 3.3 Solveur 3 : Propagation de contraintes (Norvig)
+> **Principe MRV** : Toujours choisir la variable la plus contrainte (""fail-first""). En traitant d'abord les cases avec peu de candidats, on detecte les impasses plus tot et on evite d'explorer des sous-arbres inutiles.",,,,,,,,d5742ee9bd2616a4,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,clmlmdoxx3f,markdown,fr,6061c93fb4e4829e,"### 3.3 Solveur 3 : Propagation de contraintes (Norvig)
 
-L'approche de Peter Norvig combine deux strategies de propagation :
+L'approche de Peter Norvig combine deux stratégies de propagation :
 
-1. **Elimination** : quand une case recoit une valeur, on retire cette valeur des candidats de tous ses voisins (meme ligne, colonne, bloc)
+1. **Elimination** : quand une case recoit une valeur, on retire cette valeur des candidats de tous ses voisins (même ligne, colonne, bloc)
 2. **Naked single** : quand une valeur n'a qu'un seul emplacement possible dans une unite, on l'y assigne
 
-Si la propagation seule ne suffit pas, un **backtracking avec MRV** prend le relais. En pratique, la propagation resout la majorite des puzzles faciles/moyens sans aucune recherche.",,,,,,,,a626fc131595f8b9,,,,,,,
+Si la propagation seule ne suffit pas, un **backtracking avec MRV** prend le relais. En pratique, la propagation resout la majorite des puzzles faciles/moyens sans aucune recherche.",,,,,,,,6061c93fb4e4829e,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,idu3zp7466f,code,fr,091629408851aef1,"class NorvigSolver:
     """"""Solveur par propagation de contraintes (style Peter Norvig).
 
@@ -16458,36 +16484,36 @@ start = time.time()
 solved = solver_norvig.solve(g)
 elapsed_ms = (time.time() - start) * 1000
 print(f""Norvig: resolu={solved}, {solver_norvig.call_count} appels, {elapsed_ms:.2f} ms"")",,,,,,,,091629408851aef1,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,879a235b,markdown,fr,eda9f165097751d3,"### Interpretation : Solveur Norvig (propagation de contraintes)
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,879a235b,markdown,fr,64095ba2837bda6e,"### Interpretation : Solveur Norvig (propagation de contraintes)
 
-**Resultat** : Norvig resout le puzzle en **1 appel recursif** et 2.34 ms.
+**Résultat** : Norvig resout le puzzle en **1 appel récursif** et 2.34 ms.
 
 | Metrique | Valeur | Observation |
 |----------|--------|-------------|
-| Appels recursifs | 1 | Aucune recherche necessaire |
+| Appels recursifs | 1 | Aucune recherche nécessaire |
 | Temps | 2.34 ms | Le plus rapide sur ce puzzle |
 
 **Pourquoi un seul appel ?**
 
-La propagation de contraintes (elimination + naked singles) a entierement resolu le puzzle sans qu'aucun backtracking ne soit necessaire. C'est le cas pour la plupart des puzzles faciles/moyens.
+La propagation de contraintes (elimination + naked singles) a entierement résolu le puzzle sans qu'aucun backtracking ne soit nécessaire. C'est le cas pour la plupart des puzzles faciles/moyens.
 
-**Mecanismes de propagation** :
+**Mécanismes de propagation** :
 1. **Elimination** : Quand une valeur est assignee a une case, elle est retiree des candidats de tous ses voisins (ligne, colonne, bloc)
 2. **Naked single** : Si une valeur ne peut aller que dans une seule case d'une unite, on l'y assigne
-3. **Cascade** : Chaque assignation declenche une nouvelle propagation, qui peut elle-meme declencher d'autres assignations
+3. **Cascade** : Chaque assignation declenche une nouvelle propagation, qui peut elle-même declencher d'autrès assignations
 
-**Comparaison avec le backtracking** : Le solveur simple a necessite 201 appels recursifs pour le meme puzzle. Norvig atteint la meme solution en un seul appel grace a la propagation qui elimine les branches inutiles avant meme de les explorer.
+**Comparaison avec le backtracking** : Le solveur simple a necessite 201 appels recursifs pour le même puzzle. Norvig atteint la même solution en un seul appel grâce a la propagation qui elimine les branches inutiles avant même de les explorer.
 
-> **Point cle** : La force de Norvig n'est pas la vitesse pure, mais la capacite a resoudre sans recherche. Sur des puzzles plus difficiles, le backtracking MRV prend le relais avec un espace de recherche deja drastiquement reduit.",,,,,,,,eda9f165097751d3,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,baivdbryng8,markdown,fr,c2b79055528b9637,"### 3.4 Solveur 4 : OR-Tools CP-SAT
+> **Point cle** : La force de Norvig n'est pas la vitesse pure, mais la capacite a résoudre sans recherche. Sur des puzzles plus difficiles, le backtracking MRV prend le relais avec un espace de recherche déjà drastiquement reduit.",,,,,,,,64095ba2837bda6e,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,baivdbryng8,markdown,fr,15842e3902ec2384,"### 3.4 Solveur 4 : OR-Tools CP-SAT
 
 Google OR-Tools est un solveur **industriel** de programmation par contraintes. Au lieu de programmer un algorithme de recherche, on **declare** les contraintes et le solveur fait le reste.
 
-Le modele Sudoku se resume a :
+Le modèle Sudoku se resume a :
 - 81 variables entieres dans {1..9}
 - 27 contraintes `AllDifferent` (9 lignes + 9 colonnes + 9 blocs)
 
-C'est l'approche la plus concise et generalement la plus performante.",,,,,,,,c2b79055528b9637,,,,,,,
+C'est l'approche la plus concise et généralement la plus performante.",,,,,,,,15842e3902ec2384,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,kxsgcx2c29j,code,fr,40f78ae3c5996983,"class ORToolsCPSATSolver:
     """"""Solveur utilisant Google OR-Tools CP-SAT.""""""
 
@@ -16541,9 +16567,9 @@ start = time.time()
 solved = solver_cpsat.solve(g)
 elapsed_ms = (time.time() - start) * 1000
 print(f""OR-Tools CP-SAT: resolu={solved}, {elapsed_ms:.2f} ms"")",,,,,,,,40f78ae3c5996983,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,f50bd4d7,markdown,fr,731532320ad707a1,"### Interpretation : Solveur OR-Tools CP-SAT
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,f50bd4d7,markdown,fr,9b06bf2a445b91aa,"### Interpretation : Solveur OR-Tools CP-SAT
 
-**Resultat** : OR-Tools resout le puzzle en 63.21 ms avec succes.
+**Résultat** : OR-Tools resout le puzzle en 63.21 ms avec succès.
 
 | Metrique | Valeur | Observation |
 |----------|--------|-------------|
@@ -16552,26 +16578,26 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,f50bd4d7,markdown,fr,
 
 **Analyse** :
 
-1. **Overhead de modelisation** : Le temps inclut la construction du modele (81 variables, 27 contraintes AllDifferent) et l'initialisation du solveur. Pour un seul puzzle, cet overhead est significatif.
+1. **Overhead de modelisation** : Le temps inclut la construction du modèle (81 variables, 27 contraintes AllDifferent) et l'initialisation du solveur. Pour un seul puzzle, cet overhead est significatif.
 
-2. **Avantage sur les grands problemes** : Contrairement aux solveurs Python purs, OR-Tools est compile en C++ et optimise pour des problemes avec des milliers de variables. Le temps de resolution reste quasi-constant quelle que soit la difficulte du puzzle.
+2. **Avantage sur les grands problèmes** : Contrairement aux solveurs Python purs, OR-Tools est compile en C++ et optimise pour des problèmes avec des milliers de variables. Le temps de résolution reste quasi-constant quelle que soit la difficulté du puzzle.
 
 3. **Declaratif vs imperatif** : Le code ne contient **aucune logique de recherche** -- on declare les contraintes et le solveur trouve la solution. C'est l'approche la plus concise (~15 lignes utiles).
 
-> **Quand utiliser OR-Tools** : Quand la robustesse et la previsibilite sont plus importantes que la vitesse brute, ou quand le probleme est trop complexe pour un solveur maison.",,,,,,,,731532320ad707a1,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,ex-ortools-count,markdown,fr,b9cdd0814707be99,"## Exercice : Verifier l'unicite de la solution avec OR-Tools
+> **Quand utiliser OR-Tools** : Quand la robustesse et la previsibilite sont plus importantes que la vitesse brute, ou quand le problème est trop complexe pour un solveur maison.",,,,,,,,9b06bf2a445b91aa,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,ex-ortools-count,markdown,fr,745772f0d92563ea,"## Exercice : Verifier l'unicite de la solution avec OR-Tools
 
 ### Enonce
 
-Un Sudoku bien pose possede exactement **une** solution. Avec OR-Tools CP-SAT, on peut le verifier en cherchant une deuxieme solution. Implementez `has_unique_solution(grid)` qui retourne True si le puzzle a exactement 1 solution.
+Un Sudoku bien pose possede exactement **une** solution. Avec OR-Tools CP-SAT, on peut le vérifier en cherchant une deuxieme solution. Implementez `has_unique_solution(grid)` qui retourne True si le puzzle a exactement 1 solution.
 
 ### Indices
 
-- Etape 1 : Modelisez le Sudoku comme dans `ORToolsCPSATSolver` (variables 1-9, allDifferent)
-- Etape 2 : Appelez `solver.solve(model)` une premiere fois
-- Etape 3 : Si solution trouvee, ajoutez une contrainte interdisant cette solution (au moins une case differente)
-- Etape 4 : Appelez `solver.solve(model)` a nouveau. Si pas de solution = unique
-",,,,,,,,b9cdd0814707be99,,,,,,,
+- Étape 1 : Modelisez le Sudoku comme dans `ORToolsCPSATSolver` (variables 1-9, allDifferent)
+- Étape 2 : Appelez `solver.solve(model)` une première fois
+- Étape 3 : Si solution trouvee, ajoutez une contrainte interdisant cette solution (au moins une case différente)
+- Étape 4 : Appelez `solver.solve(model)` a nouveau. Si pas de solution = unique
+",,,,,,,,745772f0d92563ea,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,ex-ortools-count-code,code,fr,1289e827e4aaf40b,"# EXERCICE : Verifier l'unicite de la solution avec OR-Tools
 #
 # Indications :
@@ -16612,18 +16638,18 @@ if ORTTOOLS_AVAILABLE:
     unique = has_unique_solution(grid_9x9)
     print(f""Solution unique : {unique}"")
 ",,,,,,,,1289e827e4aaf40b,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,usisfjw8mak,markdown,fr,1fe19fe9a61552f2,"## 4. Benchmark
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,usisfjw8mak,markdown,fr,a785a524b606acad,"## 4. Benchmark
 
-Nous testons les 4 solveurs sur **4 niveaux de difficulte** avec 10 puzzles chacun. Tous les puzzles sont codes en dur ci-dessous pour garantir la reproductibilite (pas de dependance a des fichiers externes).
+Nous testons les 4 solveurs sur **4 niveaux de difficulté** avec 10 puzzles chacun. Tous les puzzles sont codes en dur ci-dessous pour garantir la reproductibilite (pas de dépendance a des fichiers externes).
 
 ### Jeux de test
 
-| Difficulte | Caracteristiques | Nombre de cases vides |
+| Difficulte | Caractéristiques | Nombre de cases vides |
 |------------|------------------|-----------------------|
 | **Easy** | Beaucoup d'indices, propagation simple suffit | ~35-45 |
 | **Medium** | Indices reduits, necessite un peu de recherche | ~45-55 |
-| **Hard** | Tres peu d'indices, cas extremes connus | ~55-60 |
-| **Expert** | Regime 17-24 indices : les solveurs exacts (backtracking) timeout, les metaheuristiques (recuit simule, genetique) n'ont aucune garantie de convergence | ~57-64 |",,,,,,,,1fe19fe9a61552f2,,,,,,,
+| **Hard** | Très peu d'indices, cas extrêmes connus | ~55-60 |
+| **Expert** | Regime 17-24 indices : les solveurs exacts (backtracking) timeout, les métaheuristiques (recuit simule, génétique) n'ont aucune garantie de convergence | ~57-64 |",,,,,,,,a785a524b606acad,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,tttk3uk4pcd,code,fr,6cdaaf98903ade6a,"# -- Jeux de test codes en dur --
 # Source : Sudoku_Easy51.txt (10 premiers)
 EASY_PUZZLES = [
@@ -16685,7 +16711,7 @@ print(f""  Expert: {len(EXPERT_PUZZLES)} puzzles"")
 for name, puzzles in [(""Easy"", EASY_PUZZLES), (""Medium"", MEDIUM_PUZZLES), (""Hard"", HARD_PUZZLES), (""Expert"", EXPERT_PUZZLES)]:
     empties = [SudokuGrid.from_string(p).count_empty() for p in puzzles]
     print(f""  {name}: {min(empties)}-{max(empties)} cases vides (moy: {np.mean(empties):.1f})"")",,,,,,,,6cdaaf98903ade6a,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,c9aa8ba7,markdown,fr,59a2f1c051b18a94,"### Interpretation : Jeux de test et profil des puzzles
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,c9aa8ba7,markdown,fr,6378c992dc8f60f3,"### Interpretation : Jeux de test et profil des puzzles
 
 **Repartition des jeux de test** :
 
@@ -16695,16 +16721,16 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,c9aa8ba7,markdown,fr,
 | Medium | 10 | 64 | 64.0 |
 | Hard | 11 | 53-59 | 56.5 |
 
-**Observation contre-intuitive** : Les puzzles Medium ont en moyenne **plus de cases vides** (64) que les puzzles Hard (56.5). Cela s'explique par la provenance des donnees :
+**Observation contre-intuitive** : Les puzzles Medium ont en moyenne **plus de cases vides** (64) que les puzzles Hard (56.5). Cela s'explique par la provenance des données :
 
-- **Easy** : Grilles classiques avec beaucoup d'indices, la propagation suffit generalement
+- **Easy** : Grilles classiques avec beaucoup d'indices, la propagation suffit généralement
 - **Medium** : Puzzles ""top95"" avec peu d'indices (presque toutes les cases vides), ce qui crée un espace de recherche immense
-- **Hard** : Puzzles ""hardest"" connus pour leur difficulte logique, mais qui ont parfois plus d'indices que les Medium
+- **Hard** : Puzzles ""hardest"" connus pour leur difficulté logique, mais qui ont parfois plus d'indices que les Medium
 
-> **Lecon** : La difficulte algorithmique ne depend pas seulement du nombre de cases vides, mais surtout de la **structure des contraintes**. Un puzzle avec 53 cases vides bien placees peut etre plus resistant qu'un puzzle avec 64 cases vides mal reparties.",,,,,,,,59a2f1c051b18a94,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,n2qp3pw5eo9,markdown,fr,8162ba64d2d04d65,"### Execution du benchmark
+> **Lecon** : La difficulté algorithmique ne depend pas seulement du nombre de cases vides, mais surtout de la **structure des contraintes**. Un puzzle avec 53 cases vides bien placees peut etre plus resistant qu'un puzzle avec 64 cases vides mal reparties.",,,,,,,,6378c992dc8f60f3,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,n2qp3pw5eo9,markdown,fr,4eebfa9caeb15d78,"### Exécution du benchmark
 
-La fonction `run_benchmark` teste chaque solveur sur chaque ensemble de puzzles et collecte les temps de resolution et le taux de succes. Chaque puzzle est resolu sur une **copie** de la grille pour eviter toute interference entre solveurs.",,,,,,,,8162ba64d2d04d65,,,,,,,
+La fonction `run_benchmark` teste chaque solveur sur chaque ensemble de puzzles et collecte les temps de résolution et le taux de succès. Chaque puzzle est résolu sur une **copie** de la grille pour eviter toute interference entre solveurs.",,,,,,,,4eebfa9caeb15d78,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,5e491ba8,code,fr,3a230f80ec8fca22,"# Dictionnaires de solveurs et de puzzles pour le benchmark
 solvers = {
     'Backtracking': BacktrackingSolver(),
@@ -16722,9 +16748,9 @@ puzzle_sets = {
 
 print(f""Solveurs configures : {list(solvers.keys())}"")
 print(f""Puzzles disponibles : {list(puzzle_sets.keys())}"")",,,,,,,,3a230f80ec8fca22,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,b00cda07,markdown,fr,178d68b87d49433a,"### Configuration du benchmark
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,b00cda07,markdown,fr,e1a6249496d4d569,"### Configuration du benchmark
 
-Les 4 solveurs et 3 niveaux de difficulte sont organises en dictionnaires pour permettre une iteration systematique. La fonction `run_benchmark` definie ci-dessous encapsule la logique de test avec gestion des timeouts.",,,,,,,,178d68b87d49433a,,,,,,,
+Les 4 solveurs et 3 niveaux de difficulté sont organises en dictionnaires pour permettre une itération systématique. La fonction `run_benchmark` définie ci-dessous encapsule la logique de test avec gestion des timeouts.",,,,,,,,e1a6249496d4d569,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,dce1f3bc,code,fr,15802b29efb8e576,"import concurrent.futures
 
 def run_benchmark(solvers, puzzle_sets, max_puzzles=3, timeout_s=30):
@@ -16765,18 +16791,18 @@ def run_benchmark(solvers, puzzle_sets, max_puzzles=3, timeout_s=30):
 
 print(""Fonction definie : run_benchmark"")
 ",,,,,,,,15802b29efb8e576,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,9a3b1dd3,markdown,fr,ddcdbe5088c0770f,"### Lancement du benchmark
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,9a3b1dd3,markdown,fr,6b943b3b20bb297d,"### Lancement du benchmark
 
-Nous executons le benchmark avec un timeout de 30 secondes par puzzle pour eviter que le backtracking simple ne bloque indefiniment sur les puzzles difficiles.",,,,,,,,ddcdbe5088c0770f,,,,,,,
+Nous executons le benchmark avec un timeout de 30 secondes par puzzle pour eviter que le backtracking simple ne bloque indéfiniment sur les puzzles difficiles.",,,,,,,,6b943b3b20bb297d,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,botkz7y23fu,code,fr,043da5198a5cf441,"# Lancer le benchmark (1 puzzle par difficulte, timeout 30s par puzzle)
 print(""Benchmark en cours (1 puzzle par difficulte, timeout 30s)..."")
 results = run_benchmark(solvers, puzzle_sets, max_puzzles=1, timeout_s=30)
 print(""Termine."")",,,,,,,,043da5198a5cf441,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,kwgsj7pige,markdown,fr,46375f5256eb4ee8,"### Tableau recapitulatif des resultats
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,kwgsj7pige,markdown,fr,df84907ef0492f80,"### Tableau recapitulatif des résultats
 
-Affichons les resultats sous forme de tableau synthetique, puis sous forme graphique.
+Affichons les résultats sous forme de tableau synthetique, puis sous forme graphique.
 
-> **Note** : Le benchmark utilise 1 puzzle par niveau de difficulte avec un timeout de 30s par puzzle pour garantir une execution rapide tout en montrant les differences de performance entre solveurs.",,,,,,,,46375f5256eb4ee8,,,,,,,
+> **Note** : Le benchmark utilise 1 puzzle par niveau de difficulté avec un timeout de 30s par puzzle pour garantir une exécution rapide tout en montrant les différences de performance entre solveurs.",,,,,,,,df84907ef0492f80,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,6scfch0eiy4,code,fr,d294cc658734b67b,"def print_benchmark_table(results: Dict):
     """"""Affiche un tableau formatee des resultats du benchmark.""""""
     difficulties = ['Easy', 'Medium', 'Hard', 'Expert']
@@ -16810,16 +16836,16 @@ for solver_name in results:
     total_solved = sum(results[solver_name][d]['solved'] for d in ['Easy', 'Medium', 'Hard', 'Expert'])
     print(f""  {solver_name:<18}: {total_ms/total_puzzles:>8.2f} ms/puzzle, ""
           f""{total_solved}/{total_puzzles} resolus"")",,,,,,,,d294cc658734b67b,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,e9c8eea8,markdown,fr,c87839dedd39cf78,"## Exercice : Analyser la robustesse des solveurs face aux puzzles partiels
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,e9c8eea8,markdown,fr,cb6cabce00060578,"## Exercice : Analyser la robustesse des solveurs face aux puzzles partiels
 
 **Objectif**
 Testez comment chaque solveur se comporte quand on augmente progressivement
 le nombre de cases vides dans un puzzle (de 30 a 55 cases vides).
 
 **Indice**
-Partez d'un puzzle resolu et supprimez aleatoirement un nombre croissant de valeurs.
-Mesurez le temps de resolution pour chaque niveau de difficulte artificielle.
-",,,,,,,,c87839dedd39cf78,,,,,,,
+Partez d'un puzzle résolu et supprimez aléatoirement un nombre croissant de valeurs.
+Mesurez le temps de résolution pour chaque niveau de difficulté artificielle.
+",,,,,,,,cb6cabce00060578,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,9641d4a2,code,fr,dacbd4a126e3458d,"# EXERCICE : Analyser la robustesse des solveurs face aux puzzles partiels
 def measure_robustness(solvers: dict, base_puzzle: str, removal_counts: List[int]) -> dict:
     # TODO: Pour chaque nombre de suppressions, creez un puzzle partiel
@@ -16827,22 +16853,22 @@ def measure_robustness(solvers: dict, base_puzzle: str, removal_counts: List[int
     result = {}  # TODO etudiant
     return result
 ",,,,,,,,dacbd4a126e3458d,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,c7ed8a0e,markdown,fr,909f58622d8df979,"### Interpretation : Resultats du benchmark
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,c7ed8a0e,markdown,fr,3908948f06800255,"### Interpretation : Résultats du benchmark
 
-**Resultats cles du tableau** :
+**Résultats cles du tableau** :
 
-1. **Backtracking simple** echoue sur le puzzle Medium (timeout : 58770 ms) mais resout Easy (1.87 ms) et Hard (1862 ms) -- 2/3 resolus. Sans heuristique, l'arbre de recherche explose quand le nombre de cases vides depasse ~60.
+1. **Backtracking simple** echoue sur le puzzle Medium (timeout : 58770 ms) mais resout Easy (1.87 ms) et Hard (1862 ms) -- 2/3 résolus. Sans heuristique, l'arbre de recherche explose quand le nombre de cases vides depasse ~60.
 
-2. **BT + MRV** resout les 3 puzzles (3/3), y compris le Medium en 37.58 ms la ou le backtracking simple explose. L'heuristique MRV aide enormement, mais reste plus lent que la propagation (313 ms sur le puzzle Hard).
+2. **BT + MRV** resout les 3 puzzles (3/3), y compris le Medium en 37.58 ms la ou le backtracking simple explose. L'heuristique MRV aide enormêment, mais reste plus lent que la propagation (313 ms sur le puzzle Hard).
 
-3. **Norvig** est le champion absolu : 3/3 resolus, avec un temps moyen global de 3.25 ms/puzzle. La propagation de contraintes elimine la quasi-totalite de l'exploration.
+3. **Norvig** est le champion absolu : 3/3 résolus, avec un temps moyen global de 3.25 ms/puzzle. La propagation de contraintes elimine la quasi-totalite de l'exploration.
 
-4. **OR-Tools CP-SAT** est egalement 3/3 fiable a ~22 ms/puzzle (21.65). Legerement plus lent que Norvig sur ce probleme en raison de l'overhead de construction du modele, mais plus robuste a la mise a l'echelle.
+4. **OR-Tools CP-SAT** est également 3/3 fiable a ~22 ms/puzzle (21.65). Legerement plus lent que Norvig sur ce problème en raison de l'overhead de construction du modèle, mais plus robuste a la mise a l'échelle.
 
-**Surprise** : Les puzzles Hard ne sont pas les plus lents pour le backtracking simple. Cela s'explique par le fait que la difficulte humaine (nombre de techniques logiques necessaires) ne correspond pas toujours a la difficulte algorithmique (taille de l'arbre de recherche).",,,,,,,,909f58622d8df979,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,1kk61ilsuxw,markdown,fr,e45104b2301e841d,"### Visualisation : temps moyen par difficulte
+**Surprise** : Les puzzles Hard ne sont pas les plus lents pour le backtracking simple. Cela s'explique par le fait que la difficulté humaine (nombre de techniques logiques nécessaires) ne correspond pas toujours a la difficulté algorithmique (taille de l'arbre de recherche).",,,,,,,,3908948f06800255,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,1kk61ilsuxw,markdown,fr,2489afe6798b57bf,"### Visualisation : temps moyen par difficulté
 
-Le graphique en barres groupees montre le temps moyen de resolution pour chaque solveur sur chaque niveau de difficulte. L'echelle logarithmique permet de comparer des ordres de grandeur tres differents.",,,,,,,,e45104b2301e841d,,,,,,,
+Le graphique en barres groupees montre le temps moyen de résolution pour chaque solveur sur chaque niveau de difficulté. L'échelle logarithmique permet de comparer des ordres de grandeur très différents.",,,,,,,,2489afe6798b57bf,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,sskreus4iqj,code,fr,fa006e4d4cebcdac,"def plot_benchmark_bars(results: Dict):
     """"""Graphique en barres groupees : temps moyen par difficulte et solveur.""""""
     difficulties = ['Easy', 'Medium', 'Hard', 'Expert']
@@ -16879,20 +16905,20 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,sskreus4iqj,code,fr,f
     plt.show()
 
 plot_benchmark_bars(results)",,,,,,,,fa006e4d4cebcdac,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,d06476aa,markdown,fr,3de96d967864e778,"### Interpretation : Ecarts de performance entre solveurs
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,d06476aa,markdown,fr,269b836e3f89843c,"### Interpretation : Ecarts de performance entre solveurs
 
-Le graphique en barres (echelle logarithmique) rend compte de l'ampleur des differences :
+Le graphique en barres (échelle logarithmique) rend compte de l'ampleur des différences :
 
 | Comparaison | Facteur | Observation |
 |-------------|---------|-------------|
 | BT simple vs Norvig | ~15000x sur Medium | L'absence d'heuristique coute jusqu'a 4 ordres de grandeur |
 | BT + MRV vs BT simple | ~1500x sur Medium | L'heuristique MRV seule apporte un gain massif |
-| Norvig vs OR-Tools | ~7x | Performance comparable, Norvig legerement plus rapide sur Python pur |
+| Norvig vs OR-Tools | ~7x | Performance comparable, Norvig légèrement plus rapide sur Python pur |
 
-**Point remarquable** : Les puzzles Medium sont les plus discriminants. Ils ont suffisamment de cases vides (64 en moyenne) pour pieger les solveurs naifs, mais restent solvables en un temps raisonnable pour tous les solveurs informes. Les puzzles Hard, paradoxalement, ne sont pas les plus lents car ils ont parfois moins de cases vides mais des contraintes plus serrees qui guident mieux la propagation.",,,,,,,,3de96d967864e778,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,h9kdlel5pv7,markdown,fr,3aba61bd9db46f4d,"### Visualisation : distribution des temps par solveur
+**Point remarquable** : Les puzzles Medium sont les plus discriminants. Ils ont suffisamment de cases vides (64 en moyenne) pour pieger les solveurs naifs, mais restent solvables en un temps raisonnable pour tous les solveurs informes. Les puzzles Hard, paradoxalement, ne sont pas les plus lents car ils ont parfois moins de cases vides mais des contraintes plus serrees qui guident mieux la propagation.",,,,,,,,269b836e3f89843c,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,h9kdlel5pv7,markdown,fr,e9a846dc88209c2b,"### Visualisation : distribution des temps par solveur
 
-Les boites a moustaches (boxplots) montrent la **variabilite** des temps de resolution. Un solveur avec une boite etroite est plus **previsible** dans ses performances.",,,,,,,,3aba61bd9db46f4d,,,,,,,
+Les boites a moustaches (boxplots) montrent la **variabilite** des temps de résolution. Un solveur avec une boite etroite est plus **previsible** dans ses performances.",,,,,,,,e9a846dc88209c2b,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,c9jfczgxh3v,code,fr,68e28cf208936b0c,"def plot_boxplots(results: Dict):
     """"""Boxplots de la distribution des temps pour chaque solveur (tous puzzles confondus).""""""
     solver_names = list(results.keys())
@@ -16917,44 +16943,44 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,c9jfczgxh3v,code,fr,6
     plt.show()
 
 plot_boxplots(results)",,,,,,,,68e28cf208936b0c,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,c3e7cf57,markdown,fr,199e6ea84f43861d,"### Interpretation : Variabilite et previsibilite des solveurs
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,c3e7cf57,markdown,fr,cc4c40015a2151b8,"### Interpretation : Variabilite et previsibilite des solveurs
 
-Les boxplots revelent un aspect crucial souvent neglige : la **previsibilite** des performances.
+Les boxplots révèlent un aspect crucial souvent neglige : la **previsibilite** des performances.
 
 | Solveur | Variabilite | Explication |
 |---------|-------------|-------------|
-| **Backtracking simple** | Tres forte | Certains puzzles faciles se resolvent en 1 ms, d'autres en 200+ secondes |
+| **Backtracking simple** | Très forte | Certains puzzles faciles se resolvent en 1 ms, d'autrès en 200+ secondes |
 | **BT + MRV** | Forte | L'heuristique reduit l'arbre mais reste sensible a la structure du puzzle |
-| **Norvig** | Tres faible | La propagation elimine la plupart de l'alea, temps quasi-constant |
+| **Norvig** | Très faible | La propagation elimine la plupart de l'alea, temps quasi-constant |
 | **OR-Tools CP-SAT** | Negligeable | Le solveur industriel est optimise pour des performances predictibles |
 
-**Lecon pratique** : Dans un contexte de production, la previsibilite est souvent plus importante que la vitesse moyenne. Un solveur qui resout 99% des puzzles en moins de 20 ms est preferable a un solveur qui resout 99.9% en 1 ms mais explose sur les 0.1% restants.",,,,,,,,199e6ea84f43861d,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,aqukrd01akn,markdown,fr,e200d09cc01a7e0b,"### Visualisation : radar multi-criteres
+**Lecon pratique** : Dans un contexte de production, la previsibilite est souvent plus importante que la vitesse moyenne. Un solveur qui resout 99% des puzzles en moins de 20 ms est préférable a un solveur qui resout 99.9% en 1 ms mais explose sur les 0.1% restants.",,,,,,,,cc4c40015a2151b8,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,aqukrd01akn,markdown,fr,c51b1ac7e8710cfa,"### Visualisation : radar multi-critères
 
 Le graphique radar compare les solveurs sur **5 dimensions** qualitatives. Les scores sont normalises de 1 (faible) a 5 (excellent) pour permettre une vue d'ensemble.
 
 | Critere | Description |
 |---------|-------------|
-| **Vitesse** | Temps de resolution moyen |
-| **Fiabilite** | Taux de resolution sur tous les niveaux |
-| **Scalabilite** | Robustesse face a la difficulte croissante |
+| **Vitesse** | Temps de résolution moyen |
+| **Fiabilite** | Taux de résolution sur tous les niveaux |
+| **Scalabilite** | Robustesse face a la difficulté croissante |
 | **Simplicite** | Nombre de lignes de code, facilite de comprehension |
-| **Generalite** | Capacite a s'adapter a d'autres problemes que le Sudoku |",,,,,,,,e200d09cc01a7e0b,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,cwdtbcumf8,markdown,fr,635e3aacafb32d8f,"## Exemple : Ajouter un Solveur et Etendre le Benchmark
+| **Generalite** | Capacite a s'adapter a d'autrès problèmes que le Sudoku |",,,,,,,,c51b1ac7e8710cfa,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,cwdtbcumf8,markdown,fr,bcc2b046a04ded59,"## Exemple : Ajouter un Solveur et Etendre le Benchmark
 
 Cet exemple montre comment etendre le benchmark en ajoutant un cinquieme solveur. Nous implementons ici une variante du solveur Norvig avec du **forward checking explicite**.
 
 ### Principe du forward checking
 
-Apres chaque assignation tentative dans le backtracking, on verifie immediatement que toutes les cases vides ont encore au moins un candidat valide. Si une case a un domaine vide, la branche est coupee sans appel recursif supplementaire.
+Après chaque assignation tentative dans le backtracking, on vérifie immédiatement que toutes les cases vides ont encore au moins un candidat valide. Si une case a un domaine vide, la branche est coupee sans appel récursif supplementaire.
 
 ### Implementation
 
 Le solveur `NorvigForwardCheckingSolver` etend le solveur Norvig standard en ajoutant :
-- Une methode `_forward_check` qui parcourt toutes les cases et detecte les domaines vides
-- Un appel a `_forward_check` dans `_search` juste apres `_assign`, avant de recurser
+- Une méthode `_forward_check` qui parcourt toutes les cases et detecte les domaines vides
+- Un appel a `_forward_check` dans `_search` juste après `_assign`, avant de recurser
 - Un compteur `fc_cuts` pour mesurer combien de branches sont coupees par le forward checking
-",,,,,,,,635e3aacafb32d8f,,,,,,,
+",,,,,,,,bcc2b046a04ded59,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,bphx0m8ba4b,code,fr,6c12c2f7030a7567,"class NorvigForwardCheckingSolver:
     """"""
     Solveur Norvig etendu avec forward checking explicite (Option B).
@@ -17073,20 +17099,20 @@ elapsed_ms = (time.time() - start) * 1000
 print(f""Norvig + Forward Checking: resolu={solved}, ""
       f""{solver_nfc.call_count} appels, {solver_nfc.fc_cuts} coupes FC, ""
       f""{elapsed_ms:.2f} ms"")",,,,,,,,6c12c2f7030a7567,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,13658014,markdown,fr,897366acd1a73033,"### Exemple : Solveur metaheuristique (recuit simule)
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,13658014,markdown,fr,0c62c32a4466d909,"### Exemple : Solveur métaheuristique (recuit simule)
 
-Pour completer l'eventail des paradigmes, nous implementons un **sixime solveur** base sur le **recuit simule** (Simulated Annealing). Cette approche est particulierement interessante pour le regime Expert illustre par l'EPIC #3801 :
+Pour complèter l'eventail des paradigmes, nous implementons un **sixime solveur** base sur le **recuit simule** (Simulated Annealing). Cette approche est particulièrement intéressante pour le regime Expert illustre par l'EPIC #3801 :
 
-- **Aucune garantie** de trouver la solution (c'est une metaheuristique stochastique)
-- **Parametrable** par une temperature initiale et un facteur de refroidissement
-- **Souvent rapide sur les premiers echelons**, mais peine sur les regimes tres contraints
+- **Aucune garantie** de trouver la solution (c'est une métaheuristique stochastique)
+- **Parametrable** par une température initiale et un facteur de refroidissement
+- **Souvent rapide sur les premiers echelons**, mais peine sur les regimes très contraints
 
 L'objectif ici n'est PAS de battre Norvig/CP-SAT sur les puzzles faciles : c'est de demontrer concretement qu'une approche *sans garantie* se distingue d'une approche *avec garantie* sur le regime Expert -- le moteur est mis en valeur (il fait quelque chose qui distingue garanties vs heuristiques dans un cas non-trivial), pas contourne.
 
 ### Implementation
 
-Le solveur demarre par un **pre-remplissage structure** : chaque ligne est completee par une permutation aleatoire des chiffres qui lui manquent, de sorte que chaque ligne soit valide (permutation de 1..9) des le depart -- les conflits ne residuent plus que dans les colonnes et les blocs. Ensuite, a chaque pas, le solveur **echange (swap)** les valeurs de deux cases non-verrouillees prises dans une MEME ligne : ce move preserve la validite de la ligne, seuls les conflits de colonnes et de blocs peuvent changer. L'acceptation d'un move degradeur suit le critere de Metropolis (probabilite exp(-delta/T) qui decroit avec la ""temperature"" T). Le succes est obtenu quand le score (nombre de doublons sur les 9 colonnes et 9 blocs) tombe a 0.
-",,,,,,,,897366acd1a73033,,,,,,,
+Le solveur demarre par un **pre-remplissage structure** : chaque ligne est complètee par une permutation aléatoire des chiffres qui lui manquent, de sorte que chaque ligne soit valide (permutation de 1..9) des le depart -- les conflits ne residuent plus que dans les colonnes et les blocs. Ensuite, a chaque pas, le solveur **echange (swap)** les valeurs de deux cases non-verrouillees prises dans une MÊME ligne : ce move preserve la validite de la ligne, seuls les conflits de colonnes et de blocs peuvent changer. L'acceptation d'un move degradeur suit le critère de Metropolis (probabilité exp(-delta/T) qui decroit avec la ""température"" T). Le succès est obtenu quand le score (nombre de doublons sur les 9 colonnes et 9 blocs) tombe a 0.
+",,,,,,,,0c62c32a4466d909,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,ab967873,code,fr,10da989565e6095d,"class SimulatedAnnealingSolver:
     """"""Solveur par recuit simule (Simulated Annealing) pour Sudoku.
 
@@ -17217,28 +17243,28 @@ print(f""Simulated Annealing: resolu={solved}, ""
       f""{solver_sa.accepted_count} acceptees, ""
       f""{elapsed_ms:.2f} ms"")
 ",,,,,,,,10da989565e6095d,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,c42af205,markdown,fr,f6d95cb3f60cae16,"### Interpretation : Exercice AC-3 et propagation de contraintes
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,c42af205,markdown,fr,e91ae79fb56b0ae1,"### Interpretation : Exercice AC-3 et propagation de contraintes
 
 L'exercice propose d'implementer **AC-3** (Arc Consistency 3), l'un des algorithmes de propagation de contraintes les plus fondamentaux en IA.
 
 **Pourquoi AC-3 est important** :
 1. C'est la base de nombreux solveurs CSP professionnels
 2. Il reduit les domaines de chaque variable en eliminant les valeurs impossibles
-3. Combine avec le backtracking MRV, il forme un solveur tres competitif
+3. Combine avec le backtracking MRV, il forme un solveur très competitif
 
-**Performance attendue** : Un solveur BT + AC-3 bien implemente devrait se rapprocher des performances du solveur Norvig, puisque la propagation de Norvig est une variante simplifiee de la coherence d'arc. La difference principale est qu'AC-3 verifie explicitement chaque paire de contraintes, tandis que Norvig utilise des strategies de propagation plus ciblees (elimination + naked singles).",,,,,,,,f6d95cb3f60cae16,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,d39f835d,markdown,fr,ffec48b0a69c656c,"### Interpretation : Norvig + Forward Checking (Option B)
+**Performance attendue** : Un solveur BT + AC-3 bien implemente devrait se rapprocher des performances du solveur Norvig, puisque la propagation de Norvig est une variante simplifiee de la coherence d'arc. La différence principale est qu'AC-3 vérifie explicitement chaque paire de contraintes, tandis que Norvig utilise des stratégies de propagation plus ciblees (elimination + naked singles).",,,,,,,,e91ae79fb56b0ae1,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,d39f835d,markdown,fr,9f2c686466cab8ab,"### Interpretation : Norvig + Forward Checking (Option B)
 
-L'idee du **forward checking** : apres chaque assignation tentative dans le backtracking, on verifie immediatement que toutes les cases vides ont encore au moins un candidat. Si une case a un domaine vide, la branche est coupee sans appel recursif supplementaire.
+L'idee du **forward checking** : après chaque assignation tentative dans le backtracking, on vérifie immédiatement que toutes les cases vides ont encore au moins un candidat. Si une case a un domaine vide, la branche est coupee sans appel récursif supplementaire.
 
 **Ce que j'ai ajoute par rapport a Norvig standard** :
-- Une methode `_forward_check` qui parcourt toutes les cases et detecte les domaines vides
-- Un appel a `_forward_check` dans `_search` juste apres `_assign`, avant de recurser
+- Une méthode `_forward_check` qui parcourt toutes les cases et detecte les domaines vides
+- Un appel a `_forward_check` dans `_search` juste après `_assign`, avant de recurser
 - Un compteur `fc_cuts` pour mesurer combien de branches sont coupees par le forward checking
 
 ### Mise a jour du benchmark
 
-On integre le nouveau solveur dans le dictionnaire `solvers`, on relance `run_benchmark`, puis on met a jour le graphique.",,,,,,,,ffec48b0a69c656c,,,,,,,
+On integre le nouveau solveur dans le dictionnaire `solvers`, on relance `run_benchmark`, puis on met a jour le graphique.",,,,,,,,9f2c686466cab8ab,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,3c963d8b,code,fr,536271dbd3f68b7d,"# Solveurs etendus : les 4 originaux + Norvig + Forward Checking + Simulated Annealing
 # Le SA illustre Prong B (EPIC #3801) : metaheuristique sans garantie, timeout 5s/puzzle.
 solvers_extended = {
@@ -17254,9 +17280,9 @@ Nous ajoutons le solveur Norvig + Forward Checking au dictionnaire des solveurs 
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,dbcf0aa3,code,fr,035c2c49b9f14880,"print(""Benchmark etendu en cours (1 puzzle par difficulte, timeout 30s)..."")
 results_extended = run_benchmark(solvers_extended, puzzle_sets, max_puzzles=1, timeout_s=30)
 print(""Termine.\n"")",,,,,,,,035c2c49b9f14880,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,288ae9f1,markdown,fr,2e5c917a66440ab7,"### Execution du benchmark etendu
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,288ae9f1,markdown,fr,a3ec8428e7667363,"### Exécution du benchmark etendu
 
-Nous relancons le benchmark avec les 5 solveurs (les 4 originaux + Norvig + Forward Checking) pour mesurer l'impact du forward checking sur les performances.",,,,,,,,2e5c917a66440ab7,,,,,,,
+Nous relancons le benchmark avec les 5 solveurs (les 4 originaux + Norvig + Forward Checking) pour mesurer l'impact du forward checking sur les performances.",,,,,,,,a3ec8428e7667363,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,318ea75b,code,fr,551f4f2e6ba676cc,"# Graphique etendu : on reutilise plot_benchmark_bars avec 5 solveurs
 # On ajoute une couleur supplementaire pour le nouveau solveur
 def plot_benchmark_bars_extended(results):
@@ -17291,11 +17317,11 @@ def plot_benchmark_bars_extended(results):
     plt.show()
 
 plot_benchmark_bars_extended(results_extended)",,,,,,,,551f4f2e6ba676cc,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,231d9ce2,markdown,fr,e3fc03e9309fb329,"### Analyse : le solveur Norvig + FC est-il competitif ?
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,231d9ce2,markdown,fr,36e6316bcff52083,"### Analyse : le solveur Norvig + FC est-il competitif ?
 
 **Reponse courte** : oui, il est competitif avec Norvig standard, mais il n'apporte pas de gain significatif sur ce benchmark.
 
-**Resultats obtenus** :
+**Résultats obtenus** :
 
 | Solveur | Temps (puzzle de test) | Appels recursifs | Coupes FC |
 |---------|------------------------|------------------|-----------|
@@ -17304,54 +17330,54 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,231d9ce2,markdown,fr,
 
 **Explications** :
 
-1. **Performances quasi identiques a Norvig**. Sur le puzzle de test, Norvig + FC resout en 2.39 ms (vs 2.34 ms pour Norvig pur), avec 0 coupe FC. Normal : la propagation `_eliminate` deja presente dans Norvig detecte les domaines vides a la source. Le forward check explicite ne coupe en pratique aucune branche additionnelle (`fc_cuts` = 0).
+1. **Performances quasi identiques a Norvig**. Sur le puzzle de test, Norvig + FC resout en 2.39 ms (vs 2.34 ms pour Norvig pur), avec 0 coupe FC. Normal : la propagation `_eliminate` déjà présente dans Norvig detecte les domaines vides a la source. Le forward check explicite ne coupe en pratique aucune branche additionnelle (`fc_cuts` = 0).
 
-2. **Legere surcharge par appel**. Le forward check parcourt les 81 cases a chaque descente recursive, ce qui ajoute un cout lineaire par appel. Sur un puzzle ou peu de branches sont coupees, ce cout n'est pas amorti et on peut meme etre un peu plus lent que Norvig standard.
+2. **Legere surcharge par appel**. Le forward check parcourt les 81 cases a chaque descente récursive, ce qui ajoute un cout lineaire par appel. Sur un puzzle ou peu de branches sont coupees, ce cout n'est pas amorti et on peut même etre un peu plus lent que Norvig standard.
 
-3. **Ou le forward checking brille reellement**. Si on retirait la propagation puissante de Norvig (elimination + naked singles) et qu'on gardait uniquement un backtracking MRV + forward checking, l'impact du FC serait beaucoup plus visible : il servirait de principal mecanisme d'elagage. Ici, la propagation fait deja l'essentiel du travail.
+3. **Ou le forward checking brille réellement**. Si on retirait la propagation puissante de Norvig (elimination + naked singles) et qu'on gardait uniquement un backtracking MRV + forward checking, l'impact du FC serait beaucoup plus visible : il servirait de principal mécanisme d'elagage. Ici, la propagation fait déjà l'essentiel du travail.
 
-**Conclusion** : Le forward checking est une **technique fondamentale** en CSP, mais son utilite depend du solveur dans lequel on l'integre. Sur un solveur deja fortement propage comme Norvig, il est redondant ; sur un backtracking naif, il apporte un gain enorme. C'est un bon exemple du principe **""la somme des ameliorations n'est pas toujours additive""** : certaines techniques se recouvrent.
-",,,,,,,,e3fc03e9309fb329,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,0aa93aef,markdown,fr,35b2d4f28fcac868,"## Exemple guide : Comparaison de Profils de Resolution
+**Conclusion** : Le forward checking est une **technique fondamentale** en CSP, mais son utilite depend du solveur dans lequel on l'integre. Sur un solveur déjà fortement propage comme Norvig, il est redondant ; sur un backtracking naif, il apporte un gain enorme. C'est un bon exemple du principe **""la somme des améliorations n'est pas toujours additive""** : certaines techniques se recouvrent.
+",,,,,,,,36e6316bcff52083,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,0aa93aef,markdown,fr,b5e14a048ee39a5d,"## Exemple guide : Comparaison de Profils de Resolution
 
-Dans cet exercice, vous allez analyser finement les comportements de resolution des differents solveurs pour comprendre **pourquoi** certains sont plus efficaces que d'autres.
+Dans cet exercice, vous allez analyser finement les comportements de résolution des différents solveurs pour comprendre **pourquoi** certains sont plus efficaces que d'autrès.
 
 ### Objectif
 
-Implementer un outil de profilage qui mesure, pour chaque solveur et chaque puzzle, non seulement le temps de resolution, mais aussi le **nombre d'operations effectuees** (appels recursifs, eliminations, propagations).
+Implementer un outil de profilage qui mesure, pour chaque solveur et chaque puzzle, non seulement le temps de résolution, mais aussi le **nombre d'opérations effectuees** (appels recursifs, eliminations, propagations).
 
 ### Travaux demandes
 
-1. **Etendre les solveurs** pour qu'ils comptent leurs operations internes. Pour Norvig, **creer une sous-classe `ProfiledNorvigSolver(NorvigSolver)`** qui ajoute un compteur d'eliminations (ne pas modifier la classe `NorvigSolver` d'origine) :
-   - `BacktrackingSolver` : deja compte les appels recursifs
-   - `MRVBacktrackingSolver` : deja compte les appels recursifs
+1. **Etendre les solveurs** pour qu'ils comptent leurs opérations internes. Pour Norvig, **créer une sous-classe `ProfiledNorvigSolver(NorvigSolver)`** qui ajoute un compteur d'eliminations (ne pas modifier la classe `NorvigSolver` d'origine) :
+   - `BacktrackingSolver` : déjà compte les appels recursifs
+   - `MRVBacktrackingSolver` : déjà compte les appels recursifs
    - `ProfiledNorvigSolver` : sous-classe de `NorvigSolver`, compte les appels recursifs + nombre d'eliminations
    - `ORToolsCPSATSolver` : compte le nombre de variables et contraintes
 
 2. **Completer la fonction `profile_solver(solver, grid)`** (scaffold fourni ci-dessous) qui :
    - Resout le puzzle en mesurant le temps avec `time.perf_counter()`
-   - Retourne un dictionnaire `{""time_ms"": ..., ""operations"": ..., ""success"": ...}`
+   - Retourne un dictionnaire `{""time_ms"": ..., ""opérations"": ..., ""succèss"": ...}`
 
-3. **Lancer un profilage sur 5 puzzles de chaque niveau** (Easy, Medium, Hard) et stocker les resultats dans une structure de donnees appropriee (la boucle est esquissee ci-dessous)
+3. **Lancer un profilage sur 5 puzzles de chaque niveau** (Easy, Medium, Hard) et stocker les résultats dans une structure de données appropriee (la boucle est esquissee ci-dessous)
 
 4. **Completer la visualisation comparative** :
-   - Un scatter plot : temps (x) vs operations (y), un point par solveur/puzzle
-   - Colorer les points par niveau de difficulte (Easy=vert, Medium=orange, Hard=rouge)
+   - Un scatter plot : temps (x) vs opérations (y), un point par solveur/puzzle
+   - Colorer les points par niveau de difficulté (Easy=vert, Medium=orange, Hard=rouge)
    - Ajouter une legende et des labels clairs (squelette fourni)
 
-5. **Analyser et interpreter** :
-   - Quels solveurs ont le meilleur ratio temps/operations ?
-   - Y a-t-il des puzzles ou un solveur ""explose"" en operations meme s'il est rapide ?
-   - Le nombre d'operations est-il un bon predicteur du temps de resolution ?
+5. **Analyser et interprèter** :
+   - Quels solveurs ont le meilleur ratio temps/opérations ?
+   - Y a-t-il des puzzles ou un solveur ""explose"" en opérations même s'il est rapide ?
+   - Le nombre d'opérations est-il un bon predicteur du temps de résolution ?
 
 **Indice pour le comptage des eliminations Norvig :**
 
-Dans `ProfiledNorvigSolver._eliminate`, incrementez `self.elimination_count` au debut de la methode (apres avoir initialise ce compteur dans `__init__`). Le comptage doit inclure les appels no-op.
+Dans `ProfiledNorvigSolver._eliminate`, incrementez `self.elimination_count` au debut de la méthode (après avoir initialise ce compteur dans `__init__`). Le comptage doit inclure les appels no-op.
 
-### Resultat attendu
+### Résultat attendu
 
-Un notebook avec un scatter plot montrant la correlation (ou l'absence de correlation) entre le nombre d'operations et le temps de resolution, accompagne d'une interpretation en 3-4 paragraphes.
-",,,,,,,,35b2d4f28fcac868,,,,,,,
+Un notebook avec un scatter plot montrant la correlation (ou l'absence de correlation) entre le nombre d'opérations et le temps de résolution, accompagne d'une interpretation en 3-4 paragraphes.
+",,,,,,,,b5e14a048ee39a5d,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,s18_ex_profile_solver,code,fr,9fd48744a0ffd5a5,"def profile_solver(solver, grid: SudokuGrid) -> Dict:
     """"""
     Profilage d'un solveur sur une grille.
@@ -17384,12 +17410,12 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,s18_ex_profile_solver
 
 print(""Exercice a completer : profilage d un solveur"")
 ",,,,,,,,9fd48744a0ffd5a5,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,s18_ex_norvig_intro_md,markdown,fr,514978b17c57b251,"#### Solveur Norvig profile
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,s18_ex_norvig_intro_md,markdown,fr,8d0ead465fb25001,"#### Solveur Norvig profile
 
 Pour compter les eliminations de Norvig sans modifier la classe d'origine,
-creez une sous-classe qui surcharge `_eliminate` en incrementant un compteur
-avant de deleguer a la methode parente.
-",,,,,,,,514978b17c57b251,,,,,,,
+créez une sous-classe qui surcharge `_eliminate` en incrementant un compteur
+avant de deleguer a la méthode parente.
+",,,,,,,,8d0ead465fb25001,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,s18_ex_profiled_norvig,code,fr,c25d3c9f82563b38,"class ProfiledNorvigSolver(NorvigSolver):
     """"""Variante instrumentee de NorvigSolver qui compte les eliminations.
 
@@ -17412,14 +17438,14 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,s18_ex_profiled_norvi
 
 print(""Exercice a completer : ProfiledNorvigSolver instrumente"")
 ",,,,,,,,c25d3c9f82563b38,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,s18_ex_profiling_md,markdown,fr,a6db818ab0d82e98,"### Execution du profilage
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,s18_ex_profiling_md,markdown,fr,54c4de773139bacb,"### Exécution du profilage
 
 Utilisez `profile_solver` pour tester chaque solveur sur 5 puzzles de chaque niveau.
-La structure de la boucle est esquissee ci-dessous -- completez les parties manquantes.
+La structure de la boucle est esquissee ci-dessous -- complètez les parties manquantes.
 
 **Attention** : le solveur Backtracking peut mettre plus de 30s sur les puzzles Medium.
 Pour un premier test, commencez avec `max_puzzles=2` et augmentez ensuite.
-",,,,,,,,a6db818ab0d82e98,,,,,,,
+",,,,,,,,54c4de773139bacb,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,s18_ex_profiling_loop,code,fr,d8fdfe1e17b17f7d,"# Solveurs a profiler
 solver_factories = {
     ""Backtracking"": BacktrackingSolver,
@@ -17452,12 +17478,12 @@ profiling_results = []
 
 print(f""Resultats collectes : {len(profiling_results)} mesures"")
 ",,,,,,,,d8fdfe1e17b17f7d,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,s18_ex_scatter_md,markdown,fr,a19ac7565cf7b6c2,"### Visualisation : scatter plot temps vs operations
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,s18_ex_scatter_md,markdown,fr,6b7c95e280c44b31,"### Visualisation : scatter plot temps vs opérations
 
 Completez le scatter plot ci-dessous pour afficher le temps (axe x) vs le nombre
-d'operations (axe y) pour chaque solveur/puzzle. Utilisez une couleur par niveau de
-difficulte et une echelle logarithmique sur les deux axes.
-",,,,,,,,a19ac7565cf7b6c2,,,,,,,
+d'opérations (axe y) pour chaque solveur/puzzle. Utilisez une couleur par niveau de
+difficulté et une échelle logarithmique sur les deux axes.
+",,,,,,,,6b7c95e280c44b31,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,s18_ex_scatter_plot,code,fr,82b985d0f4fc3980,"# Exemple guide: Completer le scatter plot
 # Squelette : decommentez et adaptez les lignes ci-dessous
 
@@ -17478,41 +17504,41 @@ difficulty_colors = {""Easy"": ""tab:green"", ""Medium"": ""tab:orange"",
 # plt.show()
 
 print(""Scatter plot a completer ci-dessus"")",,,,,,,,82b985d0f4fc3980,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,s18_ex_analysis_md,markdown,fr,ed41c48a0ea59b68,"### Votre analyse
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,s18_ex_analysis_md,markdown,fr,0ec09c58cf1669b0,"### Votre analyse
 
 *Redigez 3-4 paragraphes en repondant aux questions suivantes :*
 
-1. **Ratio temps/operations** : Quels solveurs ont le meilleur ratio ?
-   Un solveur qui fait peu d'operations est-il toujours le plus rapide ?
+1. **Ratio temps/opérations** : Quels solveurs ont le meilleur ratio ?
+   Un solveur qui fait peu d'opérations est-il toujours le plus rapide ?
 
-2. **Explosions d'operations** : Y a-t-il des puzzles ou un solveur ""explose""
-   en operations malgre un temps raisonnable ? Que cela indique-t-il ?
+2. **Explosions d'opérations** : Y a-t-il des puzzles ou un solveur ""explose""
+   en opérations malgre un temps raisonnable ? Que cela indique-t-il ?
 
-3. **Predictibilite** : Le nombre d'operations est-il un bon predicteur du
-   temps de resolution ? Pourquoi ou pourquoi pas ?
+3. **Predictibilite** : Le nombre d'opérations est-il un bon predicteur du
+   temps de résolution ? Pourquoi ou pourquoi pas ?
 
 *Votre reponse :*
-",,,,,,,,ed41c48a0ea59b68,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,9754859f,markdown,fr,9743745302e9f4bc,"## Conclusion
+",,,,,,,,0ec09c58cf1669b0,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,9754859f,markdown,fr,d09c3ed0515182be,"## Conclusion
 
-Ce notebook a compare **4 solveurs Python** representatifs de paradigmes algorithmiques distincts pour la resolution du Sudoku.
+Ce notebook a compare **4 solveurs Python** représentatifs de paradigmes algorithmiques distincts pour la résolution du Sudoku.
 
 ### Concepts cles a retenir
 
 | Concept | Solveur(s) concerne(s) | Idee principale |
 |---------|----------------------|-----------------|
-| Recherche exhaustive | Backtracking simple | Explorer systematiquement l'arbre des possibilites |
+| Recherche exhaustive | Backtracking simple | Explorer systématiquement l'arbre des possibilites |
 | Heuristique MRV | BT + MRV | Choisir la variable la plus contrainte pour detecter les impasses plus tot |
 | Propagation de contraintes | Norvig | Eliminer les valeurs impossibles avant la recherche |
 | Programmation par contraintes | OR-Tools CP-SAT | Declarer les contraintes, laisser le solveur trouver la solution |
-| Forward checking | Norvig + FC | Verifier la coherence des domaines apres chaque assignation |
+| Forward checking | Norvig + FC | Verifier la coherence des domaines après chaque assignation |
 
 ### Enseignements principaux
 
 1. **La propagation domine** : le solveur Norvig resout la majorite des puzzles sans aucun backtracking, confirmant que reduire l'espace de recherche est plus efficace que d'explorer plus intelligemment.
-2. **Les heuristiques comptent** : MRV divise le nombre d'appels recursifs par 4 a 1000x selon la difficulte du puzzle, pour un surcout constant par appel.
-3. **La previsibilite est cruciale** : en production, un solveur rapide mais imprevisible (backtracking) est souvent moins desirable qu'un solveur legerement plus lent mais constant (CP-SAT).
-4. **La difficulte n'est pas monotone** : le nombre de cases vides ne predit pas la difficulte algorithmique. La structure des contraintes importe davantage.",,,,,,,,9743745302e9f4bc,,,,,,,
+2. **Les heuristiques comptent** : MRV divise le nombre d'appels recursifs par 4 a 1000x selon la difficulté du puzzle, pour un surcout constant par appel.
+3. **La previsibilite est cruciale** : en production, un solveur rapide mais imprevisible (backtracking) est souvent moins desirable qu'un solveur légèrement plus lent mais constant (CP-SAT).
+4. **La difficulté n'est pas monotone** : le nombre de cases vides ne predit pas la difficulté algorithmique. La structure des contraintes importe davantage.",,,,,,,,d09c3ed0515182be,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb,cc9jfr0kb,markdown,fr,30322087225f4cf7,"---
 
 ---
@@ -18416,16 +18442,16 @@ Ce notebook a présente deux implémentations de l'algorithme Dancing Links (DLX
 Les benchmarks ont révèle un contraste surprenant : l'implémentation personnalisée est environ 30 a 90 fois plus rapide que DlxLib selon la difficulte (de ~33x sur les grilles difficiles a ~91x, soit 2-5 ms contre 160-290 ms). Les deux approches utilisent pourtant le même algorithme (Algorithm X) avec la même heuristique de colonne minimum : l'ecart ne vient donc pas de l'algorithmique mais du cout de construction de la matrice, DlxLib matérialisant une matrice dense de 324 colonnes par ligne la ou l'implémentation personnalisée bâtit directement la structure creuse, sans abstraction superflue. Ces temps murals varient d'une exécution a l'autre ; seul l'ordre de grandeur de l'ecart est significatif. L'exercice sur les N-Reines illustre la généralité de l'approche : tout problème de couverture exacte peut etre resolu par DLX, des pentominos au Picross.
 
 Le notebook [Search-App-11-Picross](../Search/Applications/CSP/App-11-Picross.ipynb) approfondit l'application de Dancing Links au problème du Picross, un autre cas d'usage spectaculaire de la couverture exacte.",,,,,,,,183feb891cb4ef80,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,cell-0,markdown,fr,acc5071501a49a33,"# Sudoku-Python-DancingLinks : Dancing Links / Algorithm X (Python)
+MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,cell-0,markdown,fr,c7de2d3b70f3d2f5,"# Sudoku-Python-DancingLinks : Dancing Links / Algorithm X (Python)
 
 **Navigation** : [<< Sudoku-1 Backtracking Python](Sudoku-1-Backtracking-Python.ipynb) | [Index](README.md) | [Sudoku-3 Genetic Python >>](Sudoku-3-Genetic-Python.ipynb)
 
 ## Objectifs d'apprentissage
 
 A la fin de ce notebook, vous saurez :
-1. Formuler le Sudoku comme un probleme de couverture exacte
+1. Formuler le Sudoku comme un problème de couverture exacte
 2. Implementer l'algorithme Dancing Links de Donald Knuth
-3. Comprendre les structures de donnees de listes doublement chainees circulaires
+3. Comprendre les structures de données de listes doublement chainees circulaires
 4. Comparer les performances de DLX avec d'autres approches
 
 **Duree estimee** : ~13 min | **Prerequis** : [Sudoku-0 Environment](Sudoku-0-Environment-Csharp.ipynb) | **Lien** : Voir aussi [Sudoku-2 DancingLinks C#](Sudoku-2-DancingLinks-Csharp.ipynb)
@@ -18437,9 +18463,9 @@ C'est l'equivalent Python du notebook C# `Sudoku-2-DancingLinks-Csharp.ipynb`.
 
 ## Table des matieres
 
-1. [Introduction theorique](#1-introduction-theorique)
-2. [Le probleme de couverture exacte](#2-le-probleme-de-couverture-exacte)
-3. [Sudoku comme probleme de couverture exacte](#3-sudoku-comme-probleme-de-couverture-exacte)
+1. [Introduction théorique](#1-introduction-theorique)
+2. [Le problème de couverture exacte](#2-le-probleme-de-couverture-exacte)
+3. [Sudoku comme problème de couverture exacte](#3-sudoku-comme-probleme-de-couverture-exacte)
 4. [L'algorithme X de Knuth](#4-lalgorithme-x-de-knuth)
 5. [Implementation Dancing Links](#5-implementation-dancing-links)
 6. [Tests et benchmarks](#6-tests-et-benchmarks)
@@ -18448,15 +18474,15 @@ C'est l'equivalent Python du notebook C# `Sudoku-2-DancingLinks-Csharp.ipynb`.
 
 - [Dancing Links - Donald Knuth (2000)](https://arxiv.org/abs/cs/0011047)
 - [Exact Cover Problem - Wikipedia](https://en.wikipedia.org/wiki/Exact_cover)
-- [Algorithm X - Wikipedia](https://en.wikipedia.org/wiki/Knuth%27s_Algorithm_X)",,,,,,,,acc5071501a49a33,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,cell-1,markdown,fr,b835ddbd650c940d,"## 1. Introduction theorique
+- [Algorithm X - Wikipedia](https://en.wikipedia.org/wiki/Knuth%27s_Algorithm_X)",,,,,,,,c7de2d3b70f3d2f5,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,cell-1,markdown,fr,6121b0622effac05,"## 1. Introduction théorique
 
 ### Qu'est-ce que Dancing Links?
 
 **Dancing Links (DLX)** est une technique elegante inventee par Donald Knuth pour implementer
-efficacement son **Algorithm X**, qui resout le probleme de **couverture exacte**.
+efficacement son **Algorithm X**, qui resout le problème de **couverture exacte**.
 
-Le nom ""Dancing Links"" vient de la facon dont les pointeurs ""dansent"" lors des operations
+Le nom ""Dancing Links"" vient de la facon dont les pointeurs ""dansent"" lors des opérations
 de suppression et restauration dans une liste doublement chainee circulaire.
 
 ### Pourquoi DLX est-il efficace pour Sudoku?
@@ -18465,21 +18491,21 @@ de suppression et restauration dans une liste doublement chainee circulaire.
 |------------|------------|----------|
 | Backtracking simple | O(9^81) pire cas | Simple a implementer |
 | Backtracking + MRV | O(9^m) m=cases vides | Bonne heuristique |
-| **Dancing Links** | O(n) operations par noeud | Optimal pour couverture exacte |
+| **Dancing Links** | O(n) opérations par noeud | Optimal pour couverture exacte |
 
 DLX est particulierement adapte car:
 1. **Suppression/Restauration O(1)** : Grace aux listes doublement chainees
-2. **Pas de copie de donnees** : Les noeuds sont simplement ""deconnectes"" puis ""reconnectes""
-3. **Heuristique MRV integree** : Choix de la colonne avec le moins de 1s",,,,,,,,b835ddbd650c940d,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,cell-2,markdown,fr,d9fa2b5f8e234b61,"## 2. Le probleme de couverture exacte
+2. **Pas de copie de données** : Les noeuds sont simplement ""deconnectes"" puis ""reconnectes""
+3. **Heuristique MRV integree** : Choix de la colonne avec le moins de 1s",,,,,,,,6121b0622effac05,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,cell-2,markdown,fr,f03c1d9cc5764fa5,"## 2. Le problème de couverture exacte
 
 ### Definition
 
 Etant donne:
-- Un ensemble **U** = {1, 2, 3, ..., n} d'elements
+- Un ensemble **U** = {1, 2, 3, ..., n} d'éléments
 - Une collection **S** = {S1, S2, ..., Sm} de sous-ensembles de U
 
-Trouver une **couverture exacte**: une sous-collection S* de S telle que chaque element
+Trouver une **couverture exacte**: une sous-collection S* de S telle que chaque élément
 de U appartient a **exactement un** sous-ensemble de S*.
 
 ### Exemple simple
@@ -18501,14 +18527,14 @@ S = {
 - B couvre {1, 4}
 - D couvre {3, 5, 6}
 - F couvre {2, 7}
-- Union = {1, 2, 3, 4, 5, 6, 7} = U (chaque element exactement une fois)
+- Union = {1, 2, 3, 4, 5, 6, 7} = U (chaque élément exactement une fois)
 
 ### Representation matricielle
 
-On represente le probleme par une matrice binaire:
+On represente le problème par une matrice binaire:
 - Chaque **ligne** = un sous-ensemble
-- Chaque **colonne** = un element de U
-- M[i,j] = 1 si l'element j est dans le sous-ensemble i
+- Chaque **colonne** = un élément de U
+- M[i,j] = 1 si l'élément j est dans le sous-ensemble i
 
 ```
      1  2  3  4  5  6  7
@@ -18520,12 +18546,12 @@ E = [0, 1, 1, 0, 0, 1, 1]
 F = [0, 1, 0, 0, 0, 0, 1]
 ```
 
-Une couverture exacte = selection de lignes ou chaque colonne a exactement un 1.",,,,,,,,d9fa2b5f8e234b61,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,cell-3,markdown,fr,8595d19d8089b2a0,"## 3. Sudoku comme probleme de couverture exacte
+Une couverture exacte = sélection de lignes ou chaque colonne a exactement un 1.",,,,,,,,f03c1d9cc5764fa5,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,cell-3,markdown,fr,07d3ae88aaa35c1e,"## 3. Sudoku comme problème de couverture exacte
 
 ### Les 4 types de contraintes du Sudoku
 
-Un Sudoku 9x9 standard a **324 contraintes** (colonnes) reparties en 4 categories:
+Un Sudoku 9x9 standard a **324 contraintes** (colonnes) reparties en 4 catégories:
 
 | Type | Description | Nombre | Colonnes |
 |------|-------------|--------|----------|
@@ -18572,8 +18598,8 @@ Contrainte Column: colonne 162 + 3*9 + 4 = 193
 Contrainte Box:    colonne 243 + 0*9 + 4 = 247  (bloc 0)
 
 Ligne de la matrice: [0...1...0] avec des 1 aux positions 21, 103, 193, 247
-```",,,,,,,,8595d19d8089b2a0,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,cell-4,markdown,fr,ca977b37c1a6c357,"## 4. L'algorithme X de Knuth
+```",,,,,,,,07d3ae88aaa35c1e,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,cell-4,markdown,fr,27c7483c7c36ee28,"## 4. L'algorithme X de Knuth
 
 ### Pseudo-code
 
@@ -18628,19 +18654,19 @@ x.left.right = x
 x.right.left = x
 ```
 
-C'est cette propriete qui permet un backtracking tres efficace: les noeuds
-""dansent"" en entrant et sortant de la structure sans etre detruits.",,,,,,,,ca977b37c1a6c357,,,,,,,
+C'est cette propriete qui permet un backtracking très efficace: les noeuds
+""dansent"" en entrant et sortant de la structure sans etre detruits.",,,,,,,,27c7483c7c36ee28,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,cell-5,code,fr,61314402896fe5a9,"# Imports
 import time
 from typing import List, Optional, Set, Tuple, Generator
 from dataclasses import dataclass, field
 
 print(""Imports OK"")",,,,,,,,61314402896fe5a9,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,cell-6,markdown,fr,b76b60e52e307d03,"## 5. Implementation Dancing Links
+MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,cell-6,markdown,fr,da7a9f678dcfa410,"## 5. Implementation Dancing Links
 
-### 5.1 Structure de donnees
+### 5.1 Structure de données
 
-La structure DLX utilise des noeuds doublement chaines dans 4 directions:
+La structure DLX utilise des noeuds doublement chaînes dans 4 directions:
 - **left/right**: navigation horizontale dans une ligne
 - **up/down**: navigation verticale dans une colonne
 
@@ -18648,7 +18674,7 @@ Chaque colonne a un noeud special ""header"" qui contient:
 - Le nombre de 1s dans la colonne (pour l'heuristique MRV)
 - Un identifiant de colonne
 
-Tous les headers sont lies horizontalement, avec un noeud ""root"" special.",,,,,,,,b76b60e52e307d03,,,,,,,
+Tous les headers sont lies horizontalement, avec un noeud ""root"" special.",,,,,,,,da7a9f678dcfa410,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,cell-7,code,fr,0ace4993104597e0,"class DancingLinksNode:
     """"""Noeud dans la structure Dancing Links.
     
@@ -18955,10 +18981,10 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,cell-9,code,fr,de396
         return len(self.solutions_found) >= limit
 
 print(""Classe DancingLinks definie"")",,,,,,,,de3968643e1453e9,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,cell-10,markdown,fr,bb087662fc4af97f,"### 5.3 Solveur de Sudoku avec DLX
+MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,cell-10,markdown,fr,f266436c37807c03,"### 5.3 Solveur de Sudoku avec DLX
 
-Cette classe traduit un puzzle Sudoku en probleme de couverture exacte,
-puis utilise DancingLinks pour le resoudre.",,,,,,,,bb087662fc4af97f,,,,,,,
+Cette classe traduit un puzzle Sudoku en problème de couverture exacte,
+puis utilise DancingLinks pour le resoudre.",,,,,,,,f266436c37807c03,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,cell-11,code,fr,450175b53e55dc83,"class SudokuGrid:
     """"""Representation d'une grille de Sudoku 9x9.""""""
     
@@ -19110,11 +19136,11 @@ class DLXSudokuSolver:
 
 
 print(""Classes SudokuGrid et DLXSudokuSolver definies"")",,,,,,,,450175b53e55dc83,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,18a74f95,markdown,fr,e1166cdc0f70fd5d,"### Interpretation : Structure de l'implementation DLX
+MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,18a74f95,markdown,fr,21901db93573af92,"### Interpretation : Structure de l'implementation DLX
 
 L'implementation de Dancing Links pour Sudoku comprend 3 classes principales avec des responsabilites clairement separees.
 
-| Classe | Responsabilite | Methodes cles |
+| Classe | Responsabilite | Méthodes cles |
 |--------|----------------|---------------|
 | **DancingLinksNode** | Noeud de base avec 4 pointeurs | left, right, up, down, column, row_id |
 | **ColumnHeader** | Header de colonne avec compteur | size, name |
@@ -19125,7 +19151,7 @@ L'implementation de Dancing Links pour Sudoku comprend 3 classes principales ave
 **Points cles de l'architecture** :
 1. **Separation des preoccupations** : La structure DLX est independante de Sudoku
 2. **Pattern Builder** : `add_row()` construit la matrice incrementalement
-3. **Operations O(1)** : `cover()` et `uncover()` manipulent uniquement des pointeurs
+3. **Opérations O(1)** : `cover()` et `uncover()` manipulent uniquement des pointeurs
 4. **Traduction explicite** : `_get_columns()` encode les 4 contraintes Sudoku
 
 **Correspondance Sudoku -> Couverture exacte** :
@@ -19133,7 +19159,7 @@ L'implementation de Dancing Links pour Sudoku comprend 3 classes principales ave
 - 729 lignes maximum = 9 positions x 9 valeurs possibles par case
 - Chaque ligne a exactement 4 bits a 1 (une contrainte de chaque type)
 
-> **Note technique** : L'utilisation de `__slots__` dans les classes noeuds reduit la memoire utilisee en evitant la creation de dictionnaires `__dict__`. Pour une grille Sudoku, cela represente des milliers de noeuds, donc l'optimisation est significative.",,,,,,,,e1166cdc0f70fd5d,,,,,,,
+> **Note technique** : L'utilisation de `__slots__` dans les classes noeuds reduit la memoire utilisee en evitant la creation de dictionnaires `__dict__`. Pour une grille Sudoku, cela represente des milliers de noeuds, donc l'optimisation est significative.",,,,,,,,21901db93573af92,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,cell-12,markdown,fr,e4ae7dc4c72ab866,"## 6. Tests et benchmarks
 
 ### 6.1 Test basique",,,,,,,,e4ae7dc4c72ab866,,,,,,,
@@ -19157,13 +19183,13 @@ if solution:
     print(f""\nSolution valide: {solution.is_valid()}"")
 else:
     print(""Pas de solution!"")",,,,,,,,a6e00b05f5b11e4d,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,0279b00f,markdown,fr,051157b420dfe6e6,"### Interpretation : Resolution du puzzle de test
+MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,0279b00f,markdown,fr,d2795797f58b5ad3,"### Interpretation : Resolution du puzzle de test
 
 Le solveur DLX a resolu le puzzle en 3.01 ms, ce qui est excellent.
 
 | Aspect | Valeur | Signification |
 |--------|--------|---------------|
-| **Temps de resolution** | 3.01 ms | Tres rapide, meme pour un puzzle de difficulte moyenne |
+| **Temps de resolution** | 3.01 ms | Très rapide, même pour un puzzle de difficulte moyenne |
 | **Solution valide** | True | L'algorithme a trouve une solution correcte |
 | **Cases vides initiales** | 51 | Puzzle relativement difficile (presque la moitie de la grille) |
 
@@ -19172,7 +19198,7 @@ Le solveur DLX a resolu le puzzle en 3.01 ms, ce qui est excellent.
 2. **Resolution correcte** : La solution respecte toutes les contraintes Sudoku
 3. **Comparaison favorable** : 3.01 ms est largement plus rapide que le backtracking simple sur des puzzles similaires
 
-> **Note technique** : Le temps de resolution inclut la construction de la matrice de couverture exacte (324 colonnes x 729 lignes maximum) et l'execution de l'algorithme X. Malgre cette surcharge initiale, DLX reste extremement rapide car la structure de donnees est optimisee pour ce type de probleme.",,,,,,,,051157b420dfe6e6,,,,,,,
+> **Note technique** : Le temps de resolution inclut la construction de la matrice de couverture exacte (324 colonnes x 729 lignes maximum) et l'exécution de l'algorithme X. Malgre cette surcharge initiale, DLX reste extremement rapide car la structure de données est optimisee pour ce type de problème.",,,,,,,,d2795797f58b5ad3,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,ex-dlx-verify,markdown,fr,0f07cec874a61df6,"## Exercice : Verifier une solution DLX
 
 ### Contexte
@@ -19316,7 +19342,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,cell-17,code,fr,ae20
 # Benchmarks
 benchmark_dlx(easy_puzzles, ""Puzzles Faciles"")
 benchmark_dlx(hard_puzzles, ""Puzzles Difficiles (Top 11)"")",,,,,,,,ae2024315ce0813a,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,1f9378c6,markdown,fr,8f3689d4bc1c7372,"### Interpretation : Benchmark Dancing Links
+MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,1f9378c6,markdown,fr,0585d2c4501162ae,"### Interpretation : Benchmark Dancing Links
 
 Les benchmarks ont ete executes sur les puzzles charges. DLX resout 21/21 puzzles (10 faciles + 11 difficiles) :
 
@@ -19327,12 +19353,12 @@ Les benchmarks ont ete executes sur les puzzles charges. DLX resout 21/21 puzzle
 
 **Points cles** :
 1. **Efficacite exceptionnelle** : DLX est optimise pour les problemes de couverture exacte
-2. **Pas de copie de donnees** : Les operations cover/uncover sont O(1) grace aux pointeurs
+2. **Pas de copie de données** : Les opérations cover/uncover sont O(1) grace aux pointeurs
 3. **Heuristique MRV integree** : Le choix de la colonne avec le moins de 1s est naturel dans DLX
-4. **Backtracking instantane** : La restauration des noeuds est immediate (pointeurs deja memorises)
+4. **Backtracking instantane** : La restauration des noeuds est immediate (pointeurs déjà memorises)
 
-> **Note technique** : La performance de DLX vient de la structure de donnees elle-meme. Contrairement au backtracking qui doit copier des grilles, DLX manipule uniquement des pointeurs dans une liste doublement chainee circulaire. Les operations de suppression et restauration sont donc O(1).",,,,,,,,8f3689d4bc1c7372,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,jnysngyinz,markdown,fr,61a45212bec929d0,"## Exercice : Comptage du nombre de solutions avec Dancing Links
+> **Note technique** : La performance de DLX vient de la structure de données elle-même. Contrairement au backtracking qui doit copier des grilles, DLX manipule uniquement des pointeurs dans une liste doublement chainee circulaire. Les opérations de suppression et restauration sont donc O(1).",,,,,,,,0585d2c4501162ae,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,jnysngyinz,markdown,fr,e26e6691002300c0,"## Exercice : Comptage du nombre de solutions avec Dancing Links
 
 ### Enonce
 
@@ -19340,13 +19366,13 @@ Une grille de Sudoku ""bien construite"" possede exactement une solution. Mais c
 
 Nous avons modifie le solveur Dancing Links pour compter le nombre total de solutions d'une grille donnee :
 
-1. La methode `search2()` de la classe `DancingLinks` permet de chercher plusieurs solutions avec une limite
+1. La méthode `search2()` de la classe `DancingLinks` permet de chercher plusieurs solutions avec une limite
 2. La fonction `count_solutions(puzzle, max_count=10)` construit la matrice DLX et lance la recherche exhaustive
 3. Les tests verifient : une grille a solution unique, une grille sous-contrainte (plusieurs solutions), et une grille invalide (zero solution)
 
 **Indice :**
 
-Pour la grille vide (81 cases vides), le nombre de Sudokus valides est de **6 670 903 752 021 072 936 960**. L'implementation s'arrete rapidement grace au parametre `max_count`.",,,,,,,,61a45212bec929d0,,,,,,,
+Pour la grille vide (81 cases vides), le nombre de Sudokus valides est de **6 670 903 752 021 072 936 960**. L'implementation s'arrete rapidement grace au paramètre `max_count`.",,,,,,,,e26e6691002300c0,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,wdgjyorp0t,code,fr,25a146142c61aa9b,"def count_solutions(puzzle: SudokuGrid, max_count: int = 10) -> int:
     """"""Compte le nombre de solutions d'une grille Sudoku.
 
@@ -19389,15 +19415,15 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,wdgjyorp0t,code,fr,2
 # print(f""  Nombre de solutions trouvees (limite a 3) : {count}"")
 
 print(""Exercice count_solutions a completer - voir les indices ci-dessus"")",,,,,,,,25a146142c61aa9b,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,a3575b81,markdown,fr,7af1b9a9acdfe60f,"## Exercice : Resoudre le probleme des N-Reines avec Dancing Links
+MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,a3575b81,markdown,fr,c7d826d307b21852,"## Exercice : Resoudre le problème des N-Reines avec Dancing Links
 
 ### Enonce
 
-Le probleme des N-Reines est un autre cas classique de couverture exacte. Pour un echiquier N x N, il faut placer N reines de sorte qu'aucune ne puisse en capturer une autre.
+Le problème des N-Reines est un autre cas classique de couverture exacte. Pour un echiquier N x N, il faut placer N reines de sorte qu'aucune ne puisse en capturer une autre.
 
-**Objectif** : Implementez un solveur de N-Reines en reutilisant la classe `DancingLinks` deja definie.
+**Objectif** : Implementez un solveur de N-Reines en reutilisant la classe `DancingLinks` déjà définie.
 
-#### Contraintes du probleme
+#### Contraintes du problème
 
 Pour N reines sur un echiquier N x N, les contraintes sont :
 1. **Ligne** : exactement une reine par ligne (N contraintes)
@@ -19407,15 +19433,15 @@ Pour N reines sur un echiquier N x N, les contraintes sont :
 
 **Attention** : contrairement au Sudoku ou chaque contrainte est ""exactement un"", les diagonales sont des contraintes ""au plus un"". Pour les encoder en couverture exacte, utilisez des colonnes secondaires (optionnelles) -- voyez l'indice ci-dessous.
 
-#### Etapes
+#### Étapes
 
 1. Implementez la fonction `build_nqueens_matrix(n)` qui construit la matrice de couverture exacte pour N reines
 2. Implementez la fonction `solve_nqueens(n)` qui utilise `DancingLinks` pour trouver toutes les solutions
-3. Affichez les solutions pour N = 4, N = 8 et comparez avec les nombres theoriques connus
+3. Affichez les solutions pour N = 4, N = 8 et comparez avec les nombres théoriques connus
 
 **Indice :**
 
-Pour simplifier, commencez par ignorer les diagonales et utilisez uniquement les contraintes de ligne et de colonne (couverture exacte stricte : 2N colonnes, N^2 lignes). Verifiez ensuite que les solutions obtenues respectent aussi les diagonales. Le nombre de solutions pour N=8 est 92 (solutions distinctes), et pour N=4 c'est 2.",,,,,,,,7af1b9a9acdfe60f,,,,,,,
+Pour simplifier, commencez par ignorer les diagonales et utilisez uniquement les contraintes de ligne et de colonne (couverture exacte stricte : 2N colonnes, N^2 lignes). Verifiez ensuite que les solutions obtenues respectent aussi les diagonales. Le nombre de solutions pour N=8 est 92 (solutions distinctes), et pour N=4 c'est 2.",,,,,,,,c7d826d307b21852,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,ab4c4ac6,code,fr,6995e557a3b3e917,"def build_nqueens_matrix(n: int):
     """"""Construit la matrice de couverture exacte pour le probleme des N-Reines.
     
@@ -19465,7 +19491,7 @@ print()
 # Exemple guide: Test N=4 (attendu : 2 solutions)
 # Exemple guide: Test N=8 (attendu : 92 solutions)
 # Exemple guide: Afficher quelques solutions sous forme d'echiquier",,,,,,,,6995e557a3b3e917,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,cell-18,markdown,fr,f9581e472b00bef1,"## Conclusion et comparaison
+MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,cell-18,markdown,fr,c42829c31c724c2a,"## Conclusion et comparaison
 
 ### Performances attendues
 
@@ -19482,18 +19508,18 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,cell-18,markdown,fr,
 ### Avantages de Dancing Links
 
 1. **Extremement rapide** pour les problemes de couverture exacte
-2. **Pas de copie de donnees** lors du backtracking
+2. **Pas de copie de données** lors du backtracking
 3. **Heuristique MRV integree** naturellement
 4. **Implementation elegante** et educative
 
 ### Inconvenients
 
 1. **Complexite d'implementation** plus elevee
-2. **Specifique** aux problemes de couverture exacte
+2. **Spécifique** aux problemes de couverture exacte
 3. **Memoire** utilisee pour les pointeurs
 
 ---
-**Navigation** : [<< Sudoku-1 Backtracking Python](Sudoku-1-Backtracking-Python.ipynb) | [Index](README.md) | [Sudoku-3 Genetic Python >>](Sudoku-3-Genetic-Python.ipynb)",,,,,,,,f9581e472b00bef1,,,,,,,
+**Navigation** : [<< Sudoku-1 Backtracking Python](Sudoku-1-Backtracking-Python.ipynb) | [Index](README.md) | [Sudoku-3 Genetic Python >>](Sudoku-3-Genetic-Python.ipynb)",,,,,,,,c42829c31c724c2a,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Csharp.ipynb,68915230,markdown,fr,58e0437cef8ae276,"# Sudoku-3 : Résolution par Algorithme Génétique (C#)
 
 **Navigation** : [<< Sudoku-2 DancingLinks C#](Sudoku-2-DancingLinks-Csharp.ipynb) | [Index](README.md) | [Sudoku-4 Simulated Annealing C# >>](Sudoku-4-SimulatedAnnealing-Csharp.ipynb)
@@ -19957,14 +19983,14 @@ chromosome = new SudokuPermutationsChromosome(mediumSudoku);
 solver = new SudokuGeneticSolver(chromosome);
 
 SudokuHelper.SolveSudoku(mediumSudoku, solver);",,,,,,,,5d371b59b69bfc67,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Csharp.ipynb,6f705b5b,markdown,fr,47225f419b48b2d4,"### Interprétation des résultats
+MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Csharp.ipynb,6f705b5b,markdown,fr,ccb672e99adac53d,"### Interprétation des résultats
 
 Le solveur génétique base sur les permutations de lignes montre des performances très différentes selon l'encodage et la difficulté. Le tableau ci-dessous résumé le **comportement attendu**, puis la lecture qui suit le confronte a la sortie réellement committee.
 
 | Difficulté | Comportement attendu | Observation sur l'exécution committee |
 |------------|----------------------|----------------------------------------|
 | Facile | Convergence rapide | Resolu en ~39 ms, 0 erreur (encodage par permutations) |
-| Moyen | Convergence plus difficile | Aucune résolution complète affichee (la sortie s'interrompt après l'initialisation) |
+| Moyen | Convergence plus difficile | Aucune résolution complète affichée (la sortie s'interrompt après l'initialisation) |
 
 **Lecture de l'exécution committee** : sur le puzzle facile, l'encodage par permutations de lignes resout la grille en ~39 ms, contre ~2,9 s pour l'encodage par cellules teste precedemment, soit un facteur d'environ 70. La raison est structurelle : en ne manipulant que des permutations de lignes, ce chromosome **pre-satisfait déjà les contraintes de lignes**, ce qui reduit fortement l'espace de recherche laisse a la fonction de fitness (contraintes de colonnes et de blocs uniquement). Sur le puzzle moyen, en revanche, l'exécution committee ne montre pas de résolution complète.
 
@@ -19973,45 +19999,45 @@ Le solveur génétique base sur les permutations de lignes montre des performanc
 2. La fitness negative (nombre d'erreurs) permet de guider l'évolution vers la solution
 3. Le parallelisme accelere l'évaluation de la population
 
-> **Note technique** : les algorithmes génétiques sont des optimiseurs généralistes adaptes aux espaces de recherche trop grands pour une énumération exhaustive. Le Sudoku est toutefois un cas ou ils sont **notoirement peu fiables** : le couplage fort entre les contraintes cree un paysage de fitness trompeur ou l'évolution se piège facilement dans des optima locaux. C'est précisément pourquoi ce notebook a besoin de redémarrages avec doublement de la population, et pourquoi un encodage qui pre-satisfait une famille de contraintes (les permutations de lignes) change radicalement la donne. Re-executez les cellules de test pour observer la variabilité d'une exécution a l'autre.",,,,,,,,47225f419b48b2d4,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,cell-0,markdown,fr,999b023b21d6f9c3,"# Sudoku-Python-Genetic : Algorithme Genetique (Python)
+> **Note technique** : les algorithmes génétiques sont des optimiseurs généralistes adaptes aux espaces de recherche trop grands pour une énumération exhaustive. Le Sudoku est toutefois un cas ou ils sont **notoirement peu fiables** : le couplage fort entre les contraintes créé un paysage de fitness trompeur ou l'évolution se piège facilement dans des optima locaux. C'est précisément pourquoi ce notebook a besoin de redémarrages avec doublement de la population, et pourquoi un encodage qui pre-satisfait une famille de contraintes (les permutations de lignes) change radicalement la donne. Re-executez les cellules de test pour observer la variabilité d'une exécution a l'autre.",,,,,,,,ccb672e99adac53d,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,cell-0,markdown,fr,0722bafd2171ce63,"# Sudoku-Python-Genetic : Algorithme Génétique (Python)
 
 **Navigation** : [<< Python DancingLinks](Sudoku-2-DancingLinks-Python.ipynb) | [Index](README.md) | [Python SimulatedAnnealing >>](Sudoku-4-SimulatedAnnealing-Python.ipynb)
 
 ## Objectifs d'apprentissage
 
 A la fin de ce notebook, vous saurez :
-1. Implementer un algorithme genetique avec PyGAD
-2. Encoder un probleme de contraintes en chromosome
-3. Comprendre pourquoi le Sudoku est difficile pour les algorithmes genetiques
-4. Comparer deux strategies d'encodage : cellules vs permutations
+1. Implementer un algorithme génétique avec PyGAD
+2. Encoder un problème de contraintes en chromosome
+3. Comprendre pourquoi le Sudoku est difficile pour les algorithmes génétiques
+4. Comparer deux stratégies d'encodage : cellules vs permutations
 
 **Duree estimee** : ~10 min | **Prerequis** : [Sudoku-0 Environment](Sudoku-0-Environment-Csharp.ipynb) | **Lien** : Voir [Search-5 GeneticAlgorithms](../Search/Part1-Foundations/Search-5-GeneticAlgorithms.ipynb)
 
 ---
 
-Ce notebook implemente un solveur de Sudoku utilisant un algorithme genetique avec PyGAD.
+Ce notebook implemente un solveur de Sudoku utilisant un algorithme génétique avec PyGAD.
 C'est l'equivalent Python du notebook C# `Sudoku-3-Genetic-Csharp.ipynb`.
 
 ## Introduction
 
-Les algorithmes genetiques (GA) sont des techniques d'optimisation inspirees de la selection naturelle:
+Les algorithmes génétiques (GA) sont des techniques d'optimisation inspirees de la sélection naturelle:
 1. **Population**: Ensemble de solutions candidates (chromosomes)
 2. **Fitness**: Evaluation de la qualite de chaque solution
-3. **Selection**: Choix des meilleurs individus pour la reproduction
-4. **Croisement**: Combinaison de deux parents pour creer des enfants
+3. **Sélection**: Choix des meilleurs individus pour la reproduction
+4. **Croisement**: Combinaison de deux parents pour créer des enfants
 5. **Mutation**: Modification aleatoire pour maintenir la diversite
 
 **Limitation connue**: Le Sudoku est difficile pour les GA car:
 - L'espace de recherche a de nombreux extrema locaux
-- La densite de solutions valides est tres faible
+- La densite de solutions valides est très faible
 - Les contraintes sont difficiles a satisfaire par evolution
 
 ## Installation
 
 ```bash
 pip install pygad numpy matplotlib
-```",,,,,,,,999b023b21d6f9c3,,,,,,,
+```",,,,,,,,0722bafd2171ce63,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,cell-1,code,fr,779003557115b51b,"# Imports
 import numpy as np
 import time
@@ -20130,9 +20156,9 @@ test_grid = SudokuGrid.from_string(easy_puzzles[0])
 print(""\nGrille de test:"")
 print(test_grid)
 print(f""\nErreurs initiales: {test_grid.count_errors()}"")",,,,,,,,37b6e51de7cfb14b,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,5dab677e,markdown,fr,76648cafdef2cdec,"### Interpretation : Structure de Donnees SudokuGrid
+MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,5dab677e,markdown,fr,ad09d81f0f3be9ed,"### Interpretation : Structure de Données SudokuGrid
 
-La classe `SudokuGrid` fournit une representation complete d'une grille de Sudoku avec les methodes essentielles.
+La classe `SudokuGrid` fournit une representation complete d'une grille de Sudoku avec les méthodes essentielles.
 
 | Aspect | Valeur | Signification |
 |--------|--------|---------------|
@@ -20141,7 +20167,7 @@ La classe `SudokuGrid` fournit une representation complete d'une grille de Sudok
 | **Erreurs initiales** | 0 | Le puzzle est valide (aucun conflit) |
 
 **Fonctionnalites cles de la classe** :
-1. **`from_string()`** : Conversion chaine de caracteres -> grille (remplace '.' par 0)
+1. **`from_string()`** : Conversion chaîne de caractères -> grille (remplace '.' par 0)
 2. **`count_errors()`** : Compte les doublons dans lignes, colonnes et blocs 3x3
 3. **`is_solved()`** : Verifie si la grille est complete et sans erreurs
 4. **`get_mask()`** : Identifie les cellules fixes (valeurs > 0)
@@ -20152,8 +20178,8 @@ La classe `SudokuGrid` fournit une representation complete d'une grille de Sudok
 - Les separateurs `---` et `|` delimitent les blocs 3x3
 - Cette representation facilite la lecture humaine de la grille
 
-> **Note technique** : La methode `count_errors()` est cruciale pour les algorithmes genetiques - elle sert de fonction de fitness. Une erreur est comptee pour chaque doublon dans une ligne, colonne ou bloc. Une grille resolue a 0 erreurs.
-",,,,,,,,76648cafdef2cdec,,,,,,,
+> **Note technique** : La méthode `count_errors()` est cruciale pour les algorithmes génétiques - elle sert de fonction de fitness. Une erreur est comptee pour chaque doublon dans une ligne, colonne ou bloc. Une grille resolue a 0 erreurs.
+",,,,,,,,ad09d81f0f3be9ed,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,cell-4,markdown,fr,48ddb7a3984b09eb,"## 2. Approche 1: Chromosome par Cellules
 
 Chaque gene represente une cellule (valeur 1-9).
@@ -20242,9 +20268,9 @@ print(f""Temps: {elapsed:.2f}s"")
 print(f""Generations: {len(solver.best_fitness_history)}"")
 print(""\nResultat:"")
 print(result)",,,,,,,,b159cc93c2683aaf,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,p6g1yllwce,markdown,fr,87a22161a41d7a42,"### Interpretation : Approche par Cellules
+MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,p6g1yllwce,markdown,fr,84e57952cdfee080,"### Interpretation : Approche par Cellules
 
-Le resultat montre que l'approche par cellules **echoue** a resoudre le Sudoku.
+Le résultat montre que l'approche par cellules **echoue** a resoudre le Sudoku.
 
 | Aspect | Valeur | Analyse |
 |--------|--------|---------|
@@ -20253,20 +20279,20 @@ Le resultat montre que l'approche par cellules **echoue** a resoudre le Sudoku.
 | **Generations** | 200 | Limite atteinte sans convergence |
 
 **Pourquoi cela echoue?**
-1. **Trop de degres de liberte** : Chaque cellule peut prendre 9 valeurs
-2. **Contraintes non respectees** : Les croisements et mutations creent des doublons
+1. **Trop de degrés de liberte** : Chaque cellule peut prendre 9 valeurs
+2. **Contraintes non respectees** : Les croisements et mutations créent des doublons
 3. **Espace de recherche immense** : 9^36 possibilites pour ce puzzle
 4. **Extrema locaux** : L'algorithme reste coince dans des configurations sous-optimales
 
-> **Note technique** : Cette approche naive montre pourquoi les algorithmes genetiques ont du mal avec les problemes de satisfaction de contraintes strictes. Les operateurs de croisement/mutation ne preservent pas les contraintes du Sudoku.
-",,,,,,,,87a22161a41d7a42,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,ex-genetic-fitness,markdown,fr,2b2e62634b6ca956,"## Exercice : Fonction de fitness ponderee
+> **Note technique** : Cette approche naive montre pourquoi les algorithmes génétiques ont du mal avec les problemes de satisfaction de contraintes strictes. Les opérateurs de croisement/mutation ne preservent pas les contraintes du Sudoku.
+",,,,,,,,84e57952cdfee080,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,ex-genetic-fitness,markdown,fr,980e8a999548d0a7,"## Exercice : Fonction de fitness ponderee
 
 ### Contexte
-L'approche par cellules echoue car la fitness ne distingue pas les differents types de violations. Une fitness **ponderee** peut donner plus d'importance a certaines contraintes.
+L'approche par cellules echoue car la fitness ne distingue pas les différents types de violations. Une fitness **ponderee** peut donner plus d'importance a certaines contraintes.
 
 ### Objectif
-Implementez la fonction  qui calcule une score de fitness en attribuant des poids differents aux violations de lignes, colonnes et blocs.
+Implementez la fonction  qui calcule une score de fitness en attribuant des poids différents aux violations de lignes, colonnes et blocs.
 
 ### Ce que la fonction doit faire
 1. Compter les doublons dans chaque ligne (pondere par )
@@ -20277,7 +20303,7 @@ Implementez la fonction  qui calcule une score de fitness en attribuant des poid
 ### Indices
 - Utilisez  pour compter les occurrences de chaque valeur 1-9
 - Un doublon =  pour chaque valeur presente plus d'une fois
-- Testez differents poids : , ,  pour voir l'impact",,,,,,,,2b2e62634b6ca956,,,,,,,
+- Testez différents poids : , ,  pour voir l'impact",,,,,,,,980e8a999548d0a7,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,ex-genetic-fitness-code,code,fr,45b437f2b95efd4c,"def weighted_fitness(grid: np.ndarray,
                     w_row: float = 1.0,
                     w_col: float = 1.0,
@@ -20441,7 +20467,7 @@ print(f""Temps: {elapsed:.2f}s"")
 print(f""Generations: {len(solver.best_fitness_history)}"")
 print(""\nResultat:"")
 print(result)",,,,,,,,d2c844c05e45f569,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,t0p26rqwsh,markdown,fr,c6b784947ed3d362,"### Interpretation : Approche par Permutations
+MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,t0p26rqwsh,markdown,fr,e63e500aa687d17c,"### Interpretation : Approche par Permutations
 
 L'approche par permutations **reussit** a resoudre le Sudoku!
 
@@ -20459,13 +20485,13 @@ L'approche par permutations **reussit** a resoudre le Sudoku!
 
 **Comparaison des approches** :
 
-| Approche | Espace de recherche | Contraintes respectees | Resultat |
+| Approche | Espace de recherche | Contraintes respectees | Résultat |
 |----------|---------------------|------------------------|----------|
 | Cellules | 9^36 (enorme) | Aucune | Echec |
 | Permutations | 24^9 (reduit) | Lignes | Succes |
 
-> **Note technique** : Cette approche montre l'importance de l'encodage dans les algorithmes genetiques. En reduisant l'espace de recherche et en preservant les contraintes (ici, les lignes), on augmente dramatiquement les chances de succes.
-",,,,,,,,c6b784947ed3d362,,,,,,,
+> **Note technique** : Cette approche montre l'importance de l'encodage dans les algorithmes génétiques. En reduisant l'espace de recherche et en preservant les contraintes (ici, les lignes), on augmente dramatiquement les chances de succes.
+",,,,,,,,e63e500aa687d17c,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,cell-8,markdown,fr,123ac31501480d2b,## 4. Visualisation de la Convergence,,,,,,,,123ac31501480d2b,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,cell-9,code,fr,d8136362de64badd,"def plot_convergence(fitness_history: List[int], title: str = ""Convergence""):
     """"""Affiche la courbe de convergence.""""""
@@ -20516,9 +20542,9 @@ axes[1].grid(True, alpha=0.3)
 
 plt.tight_layout()
 plt.show()",,,,,,,,d8136362de64badd,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,9b146a0d,markdown,fr,4b71100fd715795a,"### Interpretation : Convergence des Algorithmes
+MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,9b146a0d,markdown,fr,e5690ca6f58db1df,"### Interpretation : Convergence des Algorithmes
 
-Les courbes de convergence illustrent clairement la difference entre les deux approches.
+Les courbes de convergence illustrent clairement la différence entre les deux approches.
 
 | Aspect | Approche Cellules | Approche Permutations |
 |--------|-------------------|----------------------|
@@ -20529,19 +20555,19 @@ Les courbes de convergence illustrent clairement la difference entre les deux ap
 **Observations cles** :
 1. **Cellules (rouge)** : L'erreur stagne rapidement autour de 20-25, indiquant que l'algorithme est coince dans des optima locaux
 2. **Permutations (bleu)** : Decroissance constante jusqu'a 0 erreurs, montrant une exploration efficace de l'espace
-3. **Difference d'echelle** : La courbe bleu atteint 0 tandis que la rouge reste elevee
+3. **Différence d'echelle** : La courbe bleu atteint 0 tandis que la rouge reste elevee
 
 **Analyse du comportement** :
 - L'approche par cellules souffre d'un espace de recherche trop vaste (9^36 possibilites)
 - L'approche par permutations beneficie d'un espace reduit (24^9) et de contraintes respectees
 - La convergence rapide de l'approche cellules est un ""faux positif"" - elle stagne dans une mauvaise solution
 
-> **Note technique** : Cette visualisation met en evidence l'importance de l'encodage dans les algorithmes genetiques. Un bon encodage reduit l'espace de recherche et preserve les contraintes du probleme, permettant a l'algorithme de converger vers une solution valide.
-",,,,,,,,4b71100fd715795a,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,ex-genetic-mutation,markdown,fr,939695b440618775,"## Exercice : Operateur de mutation swap intra-ligne
+> **Note technique** : Cette visualisation met en evidence l'importance de l'encodage dans les algorithmes génétiques. Un bon encodage reduit l'espace de recherche et preserve les contraintes du problème, permettant a l'algorithme de converger vers une solution valide.
+",,,,,,,,e5690ca6f58db1df,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,ex-genetic-mutation,markdown,fr,c2be46213f48563a,"## Exercice : Opérateur de mutation swap intra-ligne
 
 ### Contexte
-La mutation aleatoire standard peut casser les bonnes permutations deja en place. Un operateur de **mutation swap** echange deux valeurs dans une meme ligne, preservant ainsi la propriete de permutation.
+La mutation aleatoire standard peut casser les bonnes permutations déjà en place. Un opérateur de **mutation swap** echange deux valeurs dans une même ligne, preservant ainsi la propriete de permutation.
 
 ### Objectif
 Implementez la fonction  qui selectionne une ligne aleatoire et echange deux valeurs non-fixes dans cette ligne.
@@ -20553,9 +20579,9 @@ Implementez la fonction  qui selectionne une ligne aleatoire et echange deux val
 4. Echanger leurs valeurs
 
 ### Indices
-- Le parametre  est un tableau 9x9 booleen (True = case du puzzle)
+- Le paramètre  est un tableau 9x9 booléen (True = case du puzzle)
 - Utilisez  pour choisir 2 positions sans remise
-- La mutation ne touche que , pas les autres individus",,,,,,,,939695b440618775,,,,,,,
+- La mutation ne touche que , pas les autres individus",,,,,,,,c2be46213f48563a,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,ex-genetic-mutation-code,code,fr,52b94576e6510c5e,"def swap_mutation(offspring, ga_instance):
     """"""Operateur de mutation swap intra-ligne.
 
@@ -20619,9 +20645,9 @@ benchmark_genetic(
     {'num_generations': 500, 'population_size': 200},
     ""Permutations - Puzzles Faciles""
 )",,,,,,,,8ecc1e95c3a092a6,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,2iay85cksiv,markdown,fr,94b26b6880b11f69,"### Interpretation : Benchmark des Algorithmes Genetiques
+MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,2iay85cksiv,markdown,fr,6e1e6e34a0118ee9,"### Interpretation : Benchmark des Algorithmes Génétiques
 
-Les resultats du benchmark confirment les limitations des GA pour le Sudoku.
+Les résultats du benchmark confirment les limitations des GA pour le Sudoku.
 
 | Puzzle | Resolu | Erreurs | Temps | Analyse |
 |--------|--------|---------|-------|---------|
@@ -20635,41 +20661,41 @@ Les resultats du benchmark confirment les limitations des GA pour le Sudoku.
 3. **Temps variables** : 1.67s a 29.53s selon la difficulte
 4. **Incompletude** : L'algorithme n'est pas garanti de trouver une solution
 
-**Comparaison avec d'autres methodes** :
+**Comparaison avec d'autres méthodes** :
 
-| Methode | Taux de succes | Temps (facile) | Garantie |
+| Méthode | Taux de succes | Temps (facile) | Garantie |
 |---------|----------------|----------------|----------|
 | GA (Permutations) | ~33% | 1-30s | Non |
 | Backtracking MRV | 100% | <1ms | Oui |
 | OR-Tools CP-SAT | 100% | ~20ms | Oui |
 
-> **Note technique** : Les algorithmes genetiques sont interesants pour explorer l'espace de recherche mais ne sont pas recommandes pour le Sudoku en production. Ils peuvent etre utiles comme methode de recherche initiale suivie d'un solveur exact.
-",,,,,,,,94b26b6880b11f69,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,cell-12,markdown,fr,6136d00a943a3856,"## Conclusion
+> **Note technique** : Les algorithmes génétiques sont interesants pour explorer l'espace de recherche mais ne sont pas recommandes pour le Sudoku en production. Ils peuvent etre utiles comme méthode de recherche initiale suivie d'un solveur exact.
+",,,,,,,,6e1e6e34a0118ee9,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,cell-12,markdown,fr,71697bef2b1fc88e,"## Conclusion
 
-### Resultats
+### Résultats
 
 | Approche | Avantages | Inconvenients |
 |----------|-----------|---------------|
-| **Cellules** | Simple | Tres inefficace, contraintes non respectees |
+| **Cellules** | Simple | Très inefficace, contraintes non respectees |
 | **Permutations** | Lignes toujours valides | Meilleur mais convergence limitee |
 
 ### Limitations des GA pour Sudoku
 
-Les algorithmes genetiques ne sont **pas adaptes** au Sudoku car:
+Les algorithmes génétiques ne sont **pas adaptes** au Sudoku car:
 1. **Extrema locaux**: L'espace de recherche a de nombreux puits dont il est difficile de sortir
 2. **Contraintes strictes**: Le Sudoku exige une solution exacte, pas une approximation
-3. **Faible densite**: Tres peu de solutions valides parmi toutes les combinaisons
+3. **Faible densite**: Très peu de solutions valides parmi toutes les combinaisons
 
 ### Alternatives recommandees
 
 Pour resoudre efficacement le Sudoku, preferez:
-- **Backtracking avec MRV**: [Sudoku-Python-Backtracking.ipynb](Sudoku-1-Backtracking-Python.ipynb)
-- **OR-Tools CP-SAT**: [Sudoku-Python-ORTools-Z3.ipynb](Sudoku-10-ORTools-Python.ipynb)
+- **Backtracking avec MRV**: [Sudoku-1-Backtracking-Python](Sudoku-1-Backtracking-Python.ipynb)
+- **OR-Tools CP-SAT**: [Sudoku-10-ORTools-Python](Sudoku-10-ORTools-Python.ipynb)
 - **Z3 SMT**: [Sudoku-12-Z3-Python](Sudoku-12-Z3-Python.ipynb)
 
-Ces methodes garantissent de trouver une solution (si elle existe) en un temps raisonnable.",,,,,,,,6136d00a943a3856,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,cgxbmeh06jj,markdown,fr,ed054ace466b69f0,"## Exemple : Chromosome par Permutations de Blocs 3x3
+Ces méthodes garantissent de trouver une solution (si elle existe) en un temps raisonnable.",,,,,,,,71697bef2b1fc88e,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,cgxbmeh06jj,markdown,fr,90116aacf73e26ee,"## Exemple : Chromosome par Permutations de Blocs 3x3
 
 ### Enonce
 
@@ -20678,7 +20704,7 @@ L'approche par permutations de lignes garantit les contraintes de lignes. Voici 
 1. Pour chaque bloc 3x3, on identifie les valeurs fixes et manquantes
 2. Un ""gene"" represente une permutation des valeurs manquantes dans un bloc
 3. La fitness ne compte que les erreurs de lignes et de colonnes (les blocs sont corrects par construction)
-4. On compare les performances avec `PermutationGeneticSolver` sur les memes puzzles
+4. On compare les performances avec `PermutationGeneticSolver` sur les mêmes puzzles
 
 **Indice :**
 
@@ -20686,7 +20712,7 @@ Chaque bloc 3x3 a 9 cellules. Si k cellules sont fixes, il reste (9-k)! permutat
 
 ### Solution
 
-La cellule de code ci-dessous implemente `BlockPermutationGeneticSolver` :",,,,,,,,ed054ace466b69f0,,,,,,,
+La cellule de code ci-dessous implemente `BlockPermutationGeneticSolver` :",,,,,,,,90116aacf73e26ee,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,3pyf7i0ocnm,code,fr,4374bf18a4552ffd,"from itertools import permutations as itr_permutations
 
 
@@ -20809,26 +20835,26 @@ print(f""\nResolu: {solved}, Erreurs: {result.count_errors()}"")
 print(f""Generations: {len(solver.best_fitness_history)}"")
 print(""\nResultat:"")
 print(result)",,,,,,,,4374bf18a4552ffd,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,3e498c55,markdown,fr,cd1a922cf0d9d3d8,"## Exercice : Croisement Uniforme
+MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,3e498c55,markdown,fr,08e4d2c38e944188,"## Exercice : Croisement Uniforme
 
 ### Enonce
 
-Le solveur `PermutationGeneticSolver` utilise un croisement `single_point`. Implementez une variante qui utilise un **operateur de croisement uniforme** a la place du croisement single-point.
+Le solveur `PermutationGeneticSolver` utilise un croisement `single_point`. Implementez une variante qui utilise un **opérateur de croisement uniforme** a la place du croisement single-point.
 
 Dans un croisement uniforme, chaque gene de l'enfant est choisi aleatoirement soit depuis le parent 1, soit depuis le parent 2, avec une probabilite `p=0.5`.
 
-1. Creez une classe `UniformCrossoverSolver` qui herite de `PermutationGeneticSolver`
-2. Surchargez uniquement la methode `solve()` pour remplacer `crossover_type=""single_point""` par un operateur de croisement uniforme personnalise
-3. Lancez le benchmark sur les memes puzzles et comparez avec le solveur original
+1. Créez une classe `UniformCrossoverSolver` qui herite de `PermutationGeneticSolver`
+2. Surchargez uniquement la méthode `solve()` pour remplacer `crossover_type=""single_point""` par un opérateur de croisement uniforme personnalise
+3. Lancez le benchmark sur les mêmes puzzles et comparez avec le solveur original
 4. Affichez les courbes de convergence des deux solveurs cote a cote
 
 **Indice :**
 
-PyGAD permet de definir une fonction de croisement personnalisee via le parametre `crossover_type`. La fonction doit prendre `(parents, offspring_size, ga_instance)` et retourner les enfants. Utilisez `numpy.random.choice([0, 1], size=num_genes)` pour decider quel parent contribue chaque gene.
+PyGAD permet de définir une fonction de croisement personnalisee via le paramètre `crossover_type`. La fonction doit prendre `(parents, offspring_size, ga_instance)` et retourner les enfants. Utilisez `numpy.random.choice([0, 1], size=num_genes)` pour decider quel parent contribue chaque gene.
 
 **TODO :**
 
-Completez la classe ci-dessous :",,,,,,,,cd1a922cf0d9d3d8,,,,,,,
+Completez la classe ci-dessous :",,,,,,,,08e4d2c38e944188,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,0b83e933,code,fr,0e15eac5de2e381c,"# Exercice : Croisement Uniforme
 
 def uniform_crossover(parents, offspring_size, ga_instance):
@@ -20887,14 +20913,14 @@ print(""Exercice a completer - implementez uniform_crossover et UniformCrossover
 MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,929ba7dd,markdown,fr,8dccaccc5c5e4621,"## Conclusion
 
 Ce notebook a démontré les forces et les limites des algorithmes génétiques appliqués au Sudoku. L'approche naïve par cellules échoue complètement (espace de recherche en 9^36, contraintes non respectées), tandis que l'approche par permutations de lignes réussit en réduisant drastiquement l'espace (24^9) et en garantissant les contraintes de lignes par construction. La variante par blocs 3x3 confirme que la qualité de l'**encodage du chromosome** est le facteur déterminant : un bon encodage préserve les contraintes du problème et réduit l'espace exploré. Néanmoins, les taux de succès variables (~33% sur des puzzles de difficulté moyenne) rappellent que les algorithmes génétiques ne sont pas adaptés aux problèmes de satisfaction de contraintes strictes comme le Sudoku, où les méthodes exactes (backtracking MRV, OR-Tools CP-SAT, Z3) garantissent une solution en un temps nettement inférieur.",,,,,,,,8dccaccc5c5e4621,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,cell-13,markdown,fr,174698eaca97d422,"## Navigation
+MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,cell-13,markdown,fr,10495fa5f95f8cd4,"## Navigation
 
 - **Notebook C# equivalent**: [Sudoku-3-Genetic-Csharp](Sudoku-3-Genetic-Csharp.ipynb)
-- **Precedent**: [Sudoku-2-DancingLinks-Python](Sudoku-2-DancingLinks-Python.ipynb)
+- **Précédent**: [Sudoku-2-DancingLinks-Python](Sudoku-2-DancingLinks-Python.ipynb)
 - **Suivant**: [Sudoku-4-SimulatedAnnealing-Python](Sudoku-4-SimulatedAnnealing-Python.ipynb)
 
 ---
-**Navigation** : [<< Python DancingLinks](Sudoku-2-DancingLinks-Python.ipynb) | [Index](README.md) | [Python SimulatedAnnealing >>](Sudoku-4-SimulatedAnnealing-Python.ipynb)",,,,,,,,174698eaca97d422,,,,,,,
+**Navigation** : [<< Python DancingLinks](Sudoku-2-DancingLinks-Python.ipynb) | [Index](README.md) | [Python SimulatedAnnealing >>](Sudoku-4-SimulatedAnnealing-Python.ipynb)",,,,,,,,10495fa5f95f8cd4,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,d84f8ac8,markdown,fr,bb45a8272f171835,"# Résolution de Sudoku par Recuit Simulé
 
 **Navigation** : [Index](README.md) | [<< Sudoku-3-Genetic](Sudoku-3-Genetic-Csharp.ipynb) | [Sudoku-8-HumanStrategies >>](Sudoku-8-HumanStrategies-Csharp.ipynb)
@@ -20918,17 +20944,17 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,d84f8ac8,markd
 
 ### Durée estimée : ~40 minutes
 ",,,,,,,,bb45a8272f171835,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,2c0bd0d3,markdown,fr,cafafba0bee779a4,"## 1. Introduction (~3 min)
+MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,2c0bd0d3,markdown,fr,882a769af2bb7bb6,"## 1. Introduction (~3 min)
 
 ### Le Sudoku comme problème d'optimisation
 
-Contrairement aux solveurs par **backtracking** ou par **satisfaction de contraintes** (OR-Tools, Z3) qui construisent progressivement une solution partielle, le **recuit simulé** (Simulated Annealing, SA) adopte une approche radicalement differente :
+Contrairement aux solveurs par **backtracking** ou par **satisfaction de contraintes** (OR-Tools, Z3) qui construisent progressivement une solution partielle, le **recuit simulé** (Simulated Annealing, SA) adopte une approche radicalement différente :
 
 | Approche | Espace de recherche | Principe |
 |----------|--------------------|---------|
 | Backtracking | États partiels (cellules vides) | Construction incrémentale |
 | CSP (OR-Tools, Z3) | États partiels avec propagation | Réduction de domaine |
-| Algorithme genetique | Population d'états complets | Evolution par selection |
+| Algorithme génétique | Population d'états complets | Evolution par sélection |
 | **Recuit simulé** | **Un seul état complet** | **Perturbation locale avec acceptation probabiliste** |
 
 Le recuit simulé s'inspire du processus metallurgique de **recuit** : un metal est chauffe puis refroidi lentement pour atteindre un état cristallin optimal. Transpose a l'optimisation :
@@ -20948,16 +20974,16 @@ La solution est trouvee quand $E = 0$.
 
 ### Critere d'acceptation de Metropolis
 
-A chaque iteration, on génère un voisin et on decide de l'accepter selon :
+A chaque itération, on génère un voisin et on decide de l'accepter selon :
 
 $$P(\text{accepter}) = \begin{cases} 1 & \text{si } \Delta E \leq 0 \text{ (amélioration)} \\ e^{-\Delta E / T} & \text{si } \Delta E > 0 \text{ (dégradation)} \end{cases}$$
 
 ou $\Delta E = E(\text{voisin}) - E(\text{courant})$ et $T$ est la température courante.
 
-**Sources primaires.** Le critere d'acceptation de Metropolis -- accepter une dégradation avec probabilité $e^{-\Delta E/T}$ -- a ete introduit dans l'etude des equations d'état par simulation de Monte-Carlo (Metropolis, Rosenbluth, Rosenbluth, Teller & Teller, *Journal of Chemical Physics* 21(6):1087-1092, 1953). Son transfert a l'optimisation combinatoire sous le nom de *recuit simulé* est l'apport fondateur de Kirkpatrick, Gelatt & Vecchi, *Science* 220(4598):671-680, 1983.",,,,,,,,cafafba0bee779a4,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,73e8f48c,markdown,fr,df91b9aaad535523,"## 2. Importation de l'environnement
+**Sources primaires.** Le critere d'acceptation de Metropolis -- accepter une dégradation avec probabilité $e^{-\Delta E/T}$ -- a ete introduit dans l'étude des equations d'état par simulation de Monte-Carlo (Metropolis, Rosenbluth, Rosenbluth, Teller & Teller, *Journal of Chemical Physics* 21(6):1087-1092, 1953). Son transfert a l'optimisation combinatoire sous le nom de *recuit simulé* est l'apport fondateur de Kirkpatrick, Gelatt & Vecchi, *Science* 220(4598):671-680, 1983.",,,,,,,,882a769af2bb7bb6,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,73e8f48c,markdown,fr,9fd439577d1a0078,"## 2. Importation de l'environnement
 
-Nous importons les classes de base definies dans le notebook d'environnement : `SudokuGrid`, `ISudokuSolver`, `SudokuHelper`.",,,,,,,,df91b9aaad535523,,,,,,,
+Nous importons les classes de base définies dans le notebook d'environnement : `SudokuGrid`, `ISudokuSolver`, `SudokuHelper`.",,,,,,,,9fd439577d1a0078,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,990b7456,code,fr,eb3d945ae449b902,#!import Sudoku-0-Environment-Csharp.ipynb,,,,,,,,eb3d945ae449b902,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,fd1145fe,markdown,fr,6a6f1f3fe77f8d6b,Import du solver de backtracking pour comparaison de performance.,,,,,,,,6a6f1f3fe77f8d6b,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,irhgn2rrl3,code,fr,854eade82fbb168c,"#!import Sudoku-1-Backtracking-Csharp.ipynb
@@ -21035,11 +21061,11 @@ public static int ComputeEnergy(SudokuGrid grid)
 }
 
 display(""Fonction ComputeEnergy definie."");",,,,,,,,2353c2a9f2061532,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,b493ac79,markdown,fr,446efc71c5adc8a9,"### Initialisation de la grille
+MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,b493ac79,markdown,fr,9d63573c3434e7d1,"### Initialisation de la grille
 
 Pour initialiser l'état, on remplit chaque ligne avec les valeurs manquantes (celles qui ne figurent pas dans les indices) en les placant aleatoirement dans les cellules vides. Cela garantit que chaque ligne est une permutation de 1 à 9.
 
-On conservé egalement un tableau `isFixed` pour identifier les cellules dont la valeur est donnee par l'énoncé et qui ne doivent pas etre modifiées.",,,,,,,,446efc71c5adc8a9,,,,,,,
+On conservé également un tableau `isFixed` pour identifier les cellules dont la valeur est donnee par l'énoncé et qui ne doivent pas etre modifiées.",,,,,,,,9d63573c3434e7d1,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,411aae91,code,fr,bd6cab5800f3ba2a,"/// <summary>
 /// Initialise une grille en remplissant chaque ligne avec une permutation
 /// de 1-9, en respectant les cellules fixes.
@@ -21103,19 +21129,19 @@ La grille initialisee est **complètement remplie** : chaque cellule contient un
 | Objectif | Énergie = 0 | Aucune violation de contrainte |
 
 > **Note technique** : l'initialisation aleatoire des lignes donne une énergie de départ généralement comprise entre 30 et 60. Le recuit simulé devra reduire cette énergie a zero.",,,,,,,,8cda900a86398498,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,86dc6d7f,markdown,fr,f28c4120dbcc60fb,"## 4. Voisinage : échange de cellules (~3 min)
+MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,86dc6d7f,markdown,fr,9e86a573599e82a6,"## 4. Voisinage : échange de cellules (~3 min)
 
 ### Principe
 
-Le **voisinage** definit les mouvements elementaires que l'algorithme peut effectuer. Pour le Sudoku avec permutations par ligne, le mouvement naturel est l'**échange** (swap) de deux cellules non fixes dans une même ligne :
+Le **voisinage** définit les mouvements elementaires que l'algorithme peut effectuer. Pour le Sudoku avec permutations par ligne, le mouvement naturel est l'**échange** (swap) de deux cellules non fixes dans une même ligne :
 
 - On choisit une **ligne** au hasard
 - On choisit **deux cellules non fixes** dans cette ligne
 - On **échange** leurs valeurs
 
-Ce mouvement **préservé la propriete de permutation** de la ligne : puisqu'on ne fait que permuter deux elements, la ligne reste une permutation de 1 à 9.
+Ce mouvement **préservé la propriete de permutation** de la ligne : puisqu'on ne fait que permuter deux éléments, la ligne reste une permutation de 1 à 9.
 
-### Implémentation",,,,,,,,f28c4120dbcc60fb,,,,,,,
+### Implémentation",,,,,,,,9e86a573599e82a6,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,f521bb3b,code,fr,d4d624fc079a8b2c,"/// <summary>
 /// Genere un voisin en echangeant deux cellules non fixes dans une meme ligne.
 /// Retourne la ligne et les deux colonnes echangees pour pouvoir annuler le mouvement.
@@ -21182,17 +21208,17 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,82b3d95c,markd
 | Reversibilite | Oui (swap inverse = même swap) |
 
 > **Point clé** : le voisinage est suffisamment petit pour etre exploré rapidement, mais suffisamment riche pour permettre des transitions significatives.",,,,,,,,139295d542b76723,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,14b058ca,markdown,fr,88e290860967a55d,"## 5. Algorithme de recuit simulé (~5 min)
+MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,14b058ca,markdown,fr,08c6396c9190db7d,"## 5. Algorithme de recuit simulé (~5 min)
 
 ### Paramètres
 
 Le recuit simulé est contrôle par plusieurs hyperparamètres :
 
-| Parametre | Notation | Valeur par defaut | Role |
+| Paramètre | Notation | Valeur par defaut | Rôle |
 |-----------|----------|------------------|------|
 | Température initiale | $T_0$ | 1.0 | Contrôle l'exploration initiale |
 | Taux de refroidissement | $\alpha$ | 0.999 | Vitesse de décroissance de $T$ |
-| Iterations par palier | $N_{iter}$ | 100 | Nombre de tentatives a chaque température |
+| Itérations par palier | $N_{iter}$ | 100 | Nombre de tentatives a chaque température |
 | Température minimale | $T_{min}$ | 0.001 | Arret du refroidissement |
 
 Le programme de refroidissement est **exponentiel** : $T_{k+1} = \alpha \cdot T_k$.
@@ -21211,7 +21237,7 @@ Tant que T > Tmin et E > 0 :
     T <- alpha * T
 ```
 
-### Implémentation du solveur",,,,,,,,88e290860967a55d,,,,,,,
+### Implémentation du solveur",,,,,,,,08c6396c9190db7d,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,3dadbe32,code,fr,fa8e6f1ecddc6787,"using System;
 using System.Diagnostics;
 
@@ -21333,16 +21359,16 @@ var solved = SudokuHelper.SolveSudoku(easySudoku, saSolver);
 
 display($""Iterations totales : {saSolver.LastTotalIterations}"");
 display($""Redemarrages : {saSolver.LastRestarts}"");",,,,,,,,b98ae436a775c98d,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,09d114d4,markdown,fr,a11e53806da44379,"### Interprétation : premier test
+MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,09d114d4,markdown,fr,a39c80d7963e6033,"### Interprétation : premier test
 
 | Aspect | Observation |
 |--------|-------------|
 | Résultat | Le recuit simulé trouve généralement la solution pour les puzzles faciles |
 | Temps | Variable ; ici ~3,4 ms, mais d'autres puzzles faciles demandent plusieurs secondes (cf. test suivant) |
-| Iterations | Très variable selon le puzzle : 733 iterations pour ce run, mais de ~1 000 a plus de 2 millions sur l'echantillon de cellules faciles |
+| Itérations | Très variable selon le puzzle : 733 itérations pour ce run, mais de ~1 000 a plus de 2 millions sur l'echantillon de cellules faciles |
 | Non-determinisme | Chaque exécution peut donner un résultat différent |
 
-> **Point clé** : contrairement au backtracking qui est **déterministe** et **garanti**, le recuit simulé est **probabiliste**. Il peut échouer, notamment sur les puzzles difficiles.",,,,,,,,a11e53806da44379,,,,,,,
+> **Point clé** : contrairement au backtracking qui est **déterministe** et **garanti**, le recuit simulé est **probabiliste**. Il peut échouer, notamment sur les puzzles difficiles.",,,,,,,,a39c80d7963e6033,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,5db6f726,markdown,fr,c76d572374a40151,"## 6. Tests et évaluation (~4 min)
 
 ### Test sur plusieurs puzzles
@@ -21407,7 +21433,7 @@ foreach (var puzzle in mediumPuzzles)
 }
 
 display($""\nTaux de succes (Medium) : {mediumSuccess}/3"");",,,,,,,,fd8af0eeade71be0,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,c1361f55,markdown,fr,30636d3834c3778d,"### Interprétation : résultats des tests
+MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,c1361f55,markdown,fr,29d290d08d5d4ded,"### Interprétation : résultats des tests
 
 Le tableau ci-dessous distingue le **comportement général attendu** du recuit simulé de ce qui a ete **réellement observé dans les sorties committees** de ce notebook. Les deux peuvent diverger fortement car le résultat depend du réglage des hyperparamètres ($T_0$, $\alpha$, $N_{iter}$, redemarrages), qui n'est pas le même d'une cellule de test a l'autre.
 
@@ -21419,8 +21445,8 @@ Le tableau ci-dessous distingue le **comportement général attendu** du recuit 
 
 **Points clés** :
 1. Le recuit simulé **ne garantit pas** de trouver la solution, et son taux de succes **varié enormement** selon les hyperparamètres (de 0 % a 67 % sur Medium selon le réglage).
-2. Un réglage qui augmente le taux de succes (plus d'iterations par palier, refroidissement plus lent, plus de redemarrages) **augmente aussi fortement le temps** : les puzzles Medium résolus le sont en plusieurs dizaines de secondes.
-3. Pour les puzzles difficiles, les solveurs CSP (OR-Tools, Z3) et le backtracking restent bien plus fiables et rapides.",,,,,,,,30636d3834c3778d,,,,,,,
+2. Un réglage qui augmente le taux de succes (plus d'itérations par palier, refroidissement plus lent, plus de redemarrages) **augmente aussi fortement le temps** : les puzzles Medium résolus le sont en plusieurs dizaines de secondes.
+3. Pour les puzzles difficiles, les solveurs CSP (OR-Tools, Z3) et le backtracking restent bien plus fiables et rapides.",,,,,,,,29d290d08d5d4ded,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,12df5254,markdown,fr,28b5ba757c823a2b,"### Comparaison avec les autres solveurs
 
 Utilisons l'infrastructure `SudokuHelper.TestSolvers` pour comparer le recuit simulé avec le backtracking.",,,,,,,,28b5ba757c823a2b,,,,,,,
@@ -21660,7 +21686,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,b4882bf1,code,
 // et calculer ReheatFactor = initialReheatFactor / (1 + reheatCount)
 
 display(""Exercice 2 : implementez le rechauffement adaptatif ci-dessus."");",,,,,,,,863e5089c2327061,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,848804d7,markdown,fr,270dcd0d88e032b8,"## Conclusion
+MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,848804d7,markdown,fr,6e9975d0d9afbfbb,"## Conclusion
 
 ### Récapitulatif
 
@@ -21678,7 +21704,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,848804d7,markd
 | Solveur | Type | Garanti | Performance |
 |---------|------|---------|-------------|
 | Backtracking | Recherche exhaustive | Oui | Rapide (facile), lent (difficile) |
-| Algorithme genetique | Métaheuristique evolutionnaire | Non | Variable |
+| Algorithme génétique | Métaheuristique evolutionnaire | Non | Variable |
 | OR-Tools / Z3 | CSP / SMT | Oui | Très rapide |
 | Dancing Links | Couverture exacte | Oui | Optimal |
 | Infer.NET | Inference probabiliste | Non | Experimental |
@@ -21688,14 +21714,14 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,848804d7,markd
 
 1. Le recuit simulé est une approche **elegante et générale** qui transforme le Sudoku en problème d'optimisation
 2. Il est **moins fiable** que les solveurs CSP pour le Sudoku, car la densite de solutions est très faible
-3. Son interet est principalement **pedagogique** : il illustre comment une métaheuristique peut etre appliquee a un problème combinatoire
-4. Les techniques d'amélioration (réchauffement, restarts) montrent les enjeux generaux de la recherche locale
+3. Son intérêt est principalement **pedagogique** : il illustre comment une métaheuristique peut etre appliquee a un problème combinatoire
+4. Les techniques d'amélioration (réchauffement, restarts) montrent les enjeux généraux de la recherche locale
 
 ### Pour aller plus loin
 
 - Explorer la **recherche tabou** (Tabu Search) sur le Sudoku : voir [Search-4 LocalSearch](../Search/Part1-Foundations/Search-4-LocalSearch.ipynb)
 - Combiner recuit simulé et propagation de contraintes (hybride SA + arc-consistance)
-- Etudier la valeur de Shapley dans les jeux cooperatifs : voir les notebooks de la série [GameTheory](../GameTheory/)",,,,,,,,270dcd0d88e032b8,,,,,,,
+- Etudier la valeur de Shapley dans les jeux cooperatifs : voir les notebooks de la série [GameTheory](../GameTheory/)",,,,,,,,6e9975d0d9afbfbb,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,5917371d,markdown,fr,4f98058003edb47d,"---
 
 **Navigation** : [Index](README.md) | [<< Sudoku-3-Genetic](Sudoku-3-Genetic-Csharp.ipynb) | [Sudoku-8-HumanStrategies >>](Sudoku-8-HumanStrategies-Csharp.ipynb)
@@ -21704,21 +21730,21 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,5917371d,markd
 - [Search-4-LocalSearch](../Search/Part1-Foundations/Search-4-LocalSearch.ipynb) - Théorie du recuit simulé (Hill Climbing, SA, Tabu Search)
 - [Sudoku-Python-SimulatedAnnealing](Sudoku-4-SimulatedAnnealing-Python.ipynb) - Version Python de ce notebook
 ",,,,,,,,4f98058003edb47d,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,42074b14,markdown,fr,51f7b80fd09b258b,"# Sudoku-4 : Recuit Simule (Python)
+MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,42074b14,markdown,fr,10acfa46afd470cd,"# Sudoku-4 : Recuit Simule (Python)
 
-**Niveau** : Metaheuristique | **Duree** : ~20 min | **Prerequis** : Sudoku-0 Environment
+**Niveau** : Métaheuristique | **Duree** : ~20 min | **Prerequis** : Sudoku-0 Environment
 
 ## Navigation
 
-| << Precedent | [Index](README.md) | Suivant >> |
+| << Précédent | [Index](README.md) | Suivant >> |
 |-------------|---------------------|-----------|
 | [Sudoku-3-Genetic-Python](Sudoku-3-Genetic-Python.ipynb) | | [Sudoku-5-PSO-Python](Sudoku-5-PSO-Python.ipynb) |
 
 ## Objectifs d'apprentissage
 
 A la fin de ce notebook, vous saurez :
-1. Formuler la resolution de Sudoku comme un probleme d'optimisation
-2. Definir une fonction d'energie comptant les violations de contraintes
+1. Formuler la resolution de Sudoku comme un problème d'optimisation
+2. Définir une fonction d'energie comptant les violations de contraintes
 3. Construire un voisinage par echange de cellules
 4. Implementer un solveur par recuit simule avec la bibliotheque `simanneal`
 5. Analyser les forces et limites du recuit simule pour le Sudoku
@@ -21730,13 +21756,13 @@ C'est l'equivalent Python du notebook C# `Sudoku-4-SimulatedAnnealing-Csharp.ipy
 
 ## Introduction
 
-Le **recuit simule** (Simulated Annealing, SA) est une metaheuristique inspiree du processus metallurgique de recuit : un metal est chauffe puis refroidi lentement pour atteindre un etat cristallin optimal.
+Le **recuit simule** (Simulated Annealing, SA) est une métaheuristique inspiree du processus metallurgique de recuit : un metal est chauffe puis refroidi lentement pour atteindre un etat cristallin optimal.
 
 ### Principe
 
 - **Etat** : Une grille entierement remplie (potentiellement avec des erreurs)
 - **Energie** : Mesure le nombre de violations de contraintes
-- **Temperature** : Controle l'acceptation de mouvements degradants
+- **Temperature** : Contrôle l'acceptation de mouvements degradants
 - **Refroidissement** : Reduit progressivement la temperature
 
 ### Critere d'acceptation de Metropolis
@@ -21749,7 +21775,7 @@ ou $\Delta E = E(\text{voisin}) - E(\text{courant})$ et $T$ est la temperature c
 
 ```bash
 pip install simanneal numpy matplotlib
-```",,,,,,,,51f7b80fd09b258b,,,,,,,
+```",,,,,,,,10acfa46afd470cd,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,ca015566,code,fr,26524d57083731c3,"# Imports
 import numpy as np
 import time
@@ -21785,9 +21811,9 @@ if PUZZLES_DIR.exists():
 else:
     print(f""ATTENTION: Dossier Puzzles non trouve a {PUZZLES_DIR}"")
     PUZZLES_DIR = Path(os.getcwd()) / ""Puzzles""",,,,,,,,b6f1b765122066ae,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,cee38774,markdown,fr,68ed5dbee25395eb,"## 1. Classe SudokuGrid
+MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,cee38774,markdown,fr,81f67d3ed5a38d91,"## 1. Classe SudokuGrid
 
-Representation d'une grille de Sudoku avec methodes pour calculer l'energie et generer des voisins.",,,,,,,,68ed5dbee25395eb,,,,,,,
+Representation d'une grille de Sudoku avec méthodes pour calculer l'energie et generer des voisins.",,,,,,,,81f67d3ed5a38d91,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,798282b0,code,fr,a861294adeffb253,"class SudokuGrid:
     """"""Representation d'une grille de Sudoku 9x9.""""""
     
@@ -21868,7 +21894,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,69b53f0e,code,
 
 print(""Fonction compute_energy definie."")
 print(f""Energie de la grille de test: {compute_energy(test_grid.cells)}"")",,,,,,,,b9eddc9544817660,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,3d863534,markdown,fr,c5a83127aa73ba42,"### Interpretation : Fonction d'energie
+MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,3d863534,markdown,fr,55b49ead2e6c5ef5,"### Interpretation : Fonction d'energie
 
 | Aspect | Valeur | Signification |
 |--------|--------|---------------|
@@ -21877,7 +21903,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,3d863534,markd
 
 L'objectif est de reduire l'energie a 0 par echanges successifs.
 
-> **Fonction d'energie** : on compte, pour chaque colonne et chaque bloc 3x3, le nombre de doublons (`counts[v] - 1` pour les valeurs presentes, `0` pour les valeurs absentes via `np.maximum(..., 0)`). Les lignes sont valides par construction (permutations de 1-9), donc seules les colonnes et les blocs peuvent porter des violations. L'energie de la grille de test (partiellement remplie) vaut **0** ci-dessus car les cellules fixees par le puzzle ne creent pas encore de conflit ; en revanche, une fois la grille completee par permutations (cellule suivante), l'energie devient positive et le recuit doit la minimiser.",,,,,,,,c5a83127aa73ba42,,,,,,,
+> **Fonction d'energie** : on compte, pour chaque colonne et chaque bloc 3x3, le nombre de doublons (`counts[v] - 1` pour les valeurs presentes, `0` pour les valeurs absentes via `np.maximum(..., 0)`). Les lignes sont valides par construction (permutations de 1-9), donc seules les colonnes et les blocs peuvent porter des violations. L'energie de la grille de test (partiellement remplie) vaut **0** ci-dessus car les cellules fixees par le puzzle ne créent pas encore de conflit ; en revanche, une fois la grille completee par permutations (cellule suivante), l'energie devient positive et le recuit doit la minimiser.",,,,,,,,55b49ead2e6c5ef5,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,38a0f48d,markdown,fr,69144d0b89d00bb7,"## 3. Initialisation de la Grille
 
 Chaque ligne est initialisee comme une permutation de 1-9, en respectant les cellules fixes.",,,,,,,,69144d0b89d00bb7,,,,,,,
@@ -21908,9 +21934,9 @@ print(""Grille initialisee (chaque ligne est une permutation de 1-9):"")
 print(SudokuGrid(init_grid))
 print(f""\nEnergie initiale: {compute_energy(init_grid)}"")
 print(f""Objectif: energie = 0"")",,,,,,,,2c7a0b7e6ef910ee,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,ed755ffd,markdown,fr,9c5b23f74a43be61,"## 4. Voisinage par Echange
+MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,ed755ffd,markdown,fr,986fa79dd874d5e1,"## 4. Voisinage par Echange
 
-Le voisinage est defini par l'echange de deux cellules non fixes dans une meme ligne. Cela preserve la propriete de permutation de la ligne.",,,,,,,,9c5b23f74a43be61,,,,,,,
+Le voisinage est défini par l'echange de deux cellules non fixes dans une même ligne. Cela preserve la propriete de permutation de la ligne.",,,,,,,,986fa79dd874d5e1,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,2bcc4c92,code,fr,ecaf82a96a29c425,"def generate_neighbor(grid: np.ndarray, is_fixed: np.ndarray, rng: random.Random) -> Tuple[int, int, int]:
     """"""Genere un voisin par echange de deux cellules non fixes dans une ligne.
     
@@ -22018,17 +22044,17 @@ if SIMANNEAL_AVAILABLE:
     print(f""Solution valide: {final_energy == 0}"")
 else:
     print(""simanneal non disponible - voir section 7 pour l'implementation manuelle"")",,,,,,,,1fdcef2db3358652,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,a3490f65,markdown,fr,17ea772162f6067f,"### Interpretation : Premier test
+MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,a3490f65,markdown,fr,6bf31c39416e3878,"### Interpretation : Premier test
 
 | Aspect | Observation |
 |--------|-------------|
-| Resultat | Le recuit simule trouve la solution pour ce puzzle facile |
+| Résultat | Le recuit simule trouve la solution pour ce puzzle facile |
 | Dynamique | Energie 29 -> 0 : le solveur explore reellement le paysage |
-| Non-determinisme | Chaque execution peut donner un resultat different |
+| Non-determinisme | Chaque exécution peut donner un résultat différent |
 
 > **Point cle** : contrairement au backtracking, le recuit simule n'est **pas garanti** de trouver la solution.
 >
-> **Lecture de la trace** : l'energie part de **29** (la grille initialisee par permutations viole les contraintes colonnes/blocs), puis fluctue (7, 13, 9, 7, 4, 2, 0...) tandis que la temperature baisse. Les colonnes `Accept` (taux de mouvements acceptes, y compris degradants) et `Improve` (taux de mouvements ameliorants) sont non triviales au debut (Accept ~23%, Improve ~9% a T=0.93) puis s'effondrent quand T devient petit : c'est la signature d'un vrai recuit -- exploration a haute temperature, exploitation a basse temperature. La solution finale `Energie finale: 0` est ici **veritablement valide** (fonction d'energie correcte).",,,,,,,,17ea772162f6067f,,,,,,,
+> **Lecture de la trace** : l'energie part de **29** (la grille initialisee par permutations viole les contraintes colonnes/blocs), puis fluctue (7, 13, 9, 7, 4, 2, 0...) tandis que la temperature baisse. Les colonnes `Accept` (taux de mouvements acceptes, y compris degradants) et `Improve` (taux de mouvements ameliorants) sont non triviales au debut (Accept ~23%, Improve ~9% a T=0.93) puis s'effondrent quand T devient petit : c'est la signature d'un vrai recuit -- exploration a haute temperature, exploitation a basse temperature. La solution finale `Energie finale: 0` est ici **veritablement valide** (fonction d'energie correcte).",,,,,,,,6bf31c39416e3878,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,05f53dff,markdown,fr,6af8c1344aa29951,"## 7. Implementation Manuelle du Recuit Simule
 
 Pour mieux comprendre l'algorithme, implementons-le sans utiliser `simanneal`.",,,,,,,,6af8c1344aa29951,,,,,,,
@@ -22096,7 +22122,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,6c8b05a9,code,
         return best_grid, best_energy == 0
 
 print(""Classe SimulatedAnnealingSolver definie."")",,,,,,,,01df4cc8e8413101,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,c84c1d7c,markdown,fr,0567a8e27035aefc,Test du recuit simule sur un puzzle et affichage du resultat.,,,,,,,,0567a8e27035aefc,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,c84c1d7c,markdown,fr,c0acfa2d0799d0e6,Test du recuit simule sur un puzzle et affichage du résultat.,,,,,,,,c0acfa2d0799d0e6,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,5e5991f2,code,fr,cda29cd80917834a,"# Test
 print(""=== Test : Recuit Simule Manuel ==="")
 puzzle = SudokuGrid.from_string(easy_puzzles[0])
@@ -22153,7 +22179,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,4dd820e2,code,
     return results
 
 benchmark_sa(easy_puzzles, num_puzzles=3)  # Prong B: 3 puzzles = rich demo, bounded runtime",,,,,,,,d432787c7c995c4b,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,a8eb3667,markdown,fr,cc16da306572098f,"### Interpretation : Resultats du benchmark
+MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,a8eb3667,markdown,fr,c730d466218f3733,"### Interpretation : Résultats du benchmark
 
 | Puzzle | Cellules vides | Temps SA | Statut |
 |--------|---------------|----------|--------|
@@ -22161,14 +22187,14 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,a8eb3667,markd
 | 2 | 49 | ~11 s | Resolu |
 | 3 | 51 | ~220 s | Resolu |
 
-**Lecture** : les 3 puzzles faciles sont resolus (3/3), mais le temps de resolution croit fortement avec le nombre de cellules vides (~0.1 s -> ~11 s -> ~220 s). Le recuit simule **finit par trouver** la solution sur ces instances, mais reste considerablement plus lent que le backtracking (qui resout le meme puzzle 3 en ~9 ms, voir la comparaison ci-dessous).
+**Lecture** : les 3 puzzles faciles sont resolus (3/3), mais le temps de resolution croit fortement avec le nombre de cellules vides (~0.1 s -> ~11 s -> ~220 s). Le recuit simule **finit par trouver** la solution sur ces instances, mais reste considerablement plus lent que le backtracking (qui resout le même puzzle 3 en ~9 ms, voir la comparaison ci-dessous).
 
-> **Fourchettes indicatives** (au-dela du benchmark ci-dessus) : Easy 60-100% de succes en quelques secondes ; Medium 10-50% en quelques dizaines de secondes ; Hard < 10% et souvent > 20 s. Ces ordres de grandeur dependent fortement des parametres (T0, alpha, iterations) et de la fonction de voisinage.
+> **Fourchettes indicatives** (au-dela du benchmark ci-dessus) : Easy 60-100% de succes en quelques secondes ; Medium 10-50% en quelques dizaines de secondes ; Hard < 10% et souvent > 20 s. Ces ordres de grandeur dependent fortement des paramètres (T0, alpha, itérations) et de la fonction de voisinage.
 
 **Points cles** :
 1. Le recuit simule **ne garantit pas** de trouver la solution
-2. Les performances dependent fortement du reglage des parametres
-3. Pour les puzzles difficiles, les solveurs CSP (OR-Tools, Z3) restent plus fiables",,,,,,,,cc16da306572098f,,,,,,,
+2. Les performances dependent fortement du reglage des paramètres
+3. Pour les puzzles difficiles, les solveurs CSP (OR-Tools, Z3) restent plus fiables",,,,,,,,c730d466218f3733,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,2ff7b856,markdown,fr,78df213006b875ca,## 9. Comparaison avec Backtracking,,,,,,,,78df213006b875ca,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,fbd14051,code,fr,3dfeb6e03392c652,"# Simple backtracking pour comparaison
 class SimpleBacktracking:
@@ -22233,21 +22259,21 @@ for i, puzzle_str in enumerate(easy_puzzles[:3]):
     t_sa = time.time() - start
     status = ""OK"" if solved else ""Echec""
     print(f""  Recuit Simule: {status}, {t_sa*1000:.0f} ms"")",,,,,,,,3dfeb6e03392c652,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,51c02a71,markdown,fr,97f6942713e6041d,"## 10. Exercices
+MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,51c02a71,markdown,fr,750cc5b52b90b022,"## 10. Exercices
 
 ### Exercice 1 : Rechauffement (Reheating)
 
 Le recuit simule peut rester bloque dans des optima locaux. Le **rechauffement** consiste a remonter la temperature pour relancer l'exploration.
 
-**Objectif** : Etendre `SimulatedAnnealingSolver` pour ajouter un mecanisme de rechauffement.
+**Objectif** : Etendre `SimulatedAnnealingSolver` pour ajouter un mécanisme de rechauffement.
 
 **Indices** :
 1. Suivez l'energie a chaque palier de temperature
 2. Si l'energie ne diminue pas pendant `stagnation_threshold` paliers consecutifs, remontez la temperature
 3. Le facteur `reheat_factor` (ex: 0.5) determine a quel niveau remonter : `T = T0 * reheat_factor`
-4. Apres rechauffement, continuez le refroidissement normal
+4. Après rechauffement, continuez le refroidissement normal
 
-**Verification** : Testez sur un puzzle medium avec et sans rechauffement. Le rechauffement devrait augmenter le taux de succes.",,,,,,,,97f6942713e6041d,,,,,,,
+**Verification** : Testez sur un puzzle medium avec et sans rechauffement. Le rechauffement devrait augmenter le taux de succes.",,,,,,,,750cc5b52b90b022,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,spvcsgm45gn,code,fr,b14db733f3bfb2a3,"class SimulatedAnnealingWithReheatSolver(SimulatedAnnealingSolver):
     """"""Solveur avec rechauffement pour echapper aux optima locaux.""""""
 
@@ -22283,9 +22309,9 @@ puzzle = SudokuGrid.from_string(easy_puzzles[0])
 # result, solved = solver.solve(puzzle)
 # print(f""Resolu: {solved}"")
 print(""TODO: Implementez SimulatedAnnealingWithReheatSolver"")",,,,,,,,b14db733f3bfb2a3,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,i44iitvrsl,markdown,fr,8335878e7c4370cd,"### Exercice 2 : Parametres adaptatifs
+MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,i44iitvrsl,markdown,fr,b3bc8897e047107d,"### Exercice 2 : Paramètres adaptatifs
 
-Le taux de refroidissement optimal depend du puzzle. Un **controle adaptatif** peut ajuster `alpha` dynamiquement selon le comportement du solveur.
+Le taux de refroidissement optimal depend du puzzle. Un **contrôle adaptatif** peut ajuster `alpha` dynamiquement selon le comportement du solveur.
 
 **Objectif** : Adapter `alpha` en fonction du taux d'acceptation des mouvements.
 
@@ -22295,7 +22321,7 @@ Le taux de refroidissement optimal depend du puzzle. Un **controle adaptatif** p
 3. Si le taux est faible (< 0.2), refroidir plus lentement : `alpha = max(0.95, alpha * 0.9999)`
 4. `alpha` reste dans [0.95, 0.9999]
 
-**Verification** : Comparez `alpha` constant vs adaptatif sur 10 puzzles medium. Mesurez le taux de succes moyen.",,,,,,,,8335878e7c4370cd,,,,,,,
+**Verification** : Comparez `alpha` constant vs adaptatif sur 10 puzzles medium. Mesurez le taux de succes moyen.",,,,,,,,b3bc8897e047107d,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,1h772bk4cim,code,fr,89f508b3dbf7a095,"class AdaptiveSimulatedAnnealingSolver(SimulatedAnnealingSolver):
     """"""Solveur avec taux de refroidissement adaptatif.""""""
 
@@ -22344,19 +22370,19 @@ solver = AdaptiveSimulatedAnnealingSolver()
 # result, solved = solver.solve(puzzle)
 # print(f""Resolu: {solved}"")
 print(""TODO: Implementez AdaptiveSimulatedAnnealingSolver"")",,,,,,,,89f508b3dbf7a095,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,rrr4hbaa4ls,markdown,fr,e9e3a1aa6d84d23a,"### Exercice 3 : Voisinage etendu
+MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,rrr4hbaa4ls,markdown,fr,f9e675ee0604b790,"### Exercice 3 : Voisinage etendu
 
 Le voisinage par echange intra-ligne est local. Des mouvements plus globaux peuvent aider a echapper aux optima locaux.
 
 **Objectif** : Implementer un voisinage etendu avec des echanges inter-lignes.
 
 **Indices** :
-1. **Echange intra-ligne** (standard) : echanger deux cellules non fixes dans la meme ligne
+1. **Echange intra-ligne** (standard) : echanger deux cellules non fixes dans la même ligne
 2. **Echange inter-lignes** (etendu) : echanger une cellule non fixe en ligne `row1` avec une cellule non fixe en ligne `row1 + 1`
 3. Avec probabilite `use_extended`, utiliser l'echange inter-lignes; sinon l'echange standard
 4. Retourner `(move_type, params)` pour pouvoir annuler le mouvement
 
-**Verification** : Testez differentes valeurs de `use_extended` (0.1, 0.2, 0.5) sur des puzzles medium.",,,,,,,,e9e3a1aa6d84d23a,,,,,,,
+**Verification** : Testez différentes valeurs de `use_extended` (0.1, 0.2, 0.5) sur des puzzles medium.",,,,,,,,f9e675ee0604b790,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,ad7p1nlulxo,code,fr,61cbbf93106de632,"def generate_extended_neighbor(grid: np.ndarray, is_fixed: np.ndarray,
                                rng: random.Random, use_extended: float = 0.2):
     """"""
@@ -22391,15 +22417,15 @@ print(""TODO: Implementez generate_extended_neighbor et undo_extended_move"")
 # grid_test, is_fixed_test = initialize_grid(SudokuGrid.from_string(easy_puzzles[0]), random.Random(42))
 # move_type, params = generate_extended_neighbor(grid_test, is_fixed_test, random.Random(42), use_extended=1.0)
 # print(f""Mouvement: {move_type}, params: {params}"")",,,,,,,,61cbbf93106de632,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,7eb4d949,markdown,fr,cabf18e6b240ac91,"## Resume
+MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,7eb4d949,markdown,fr,ad962a8ac14e763b,"## Resume
 
 ### Concepts cles
 
 | Concept | Description |
 |---------|-------------|
-| **Recuit simule** | Metaheuristique d'optimisation inspiree de la metallurgie |
+| **Recuit simule** | Métaheuristique d'optimisation inspiree de la metallurgie |
 | **Fonction d'energie** | Nombre de doublons colonnes + blocs |
-| **Voisinage** | Echange de deux cellules non fixes dans une meme ligne |
+| **Voisinage** | Echange de deux cellules non fixes dans une même ligne |
 | **Acceptation de Metropolis** | Accepter les degradations avec probabilite $e^{-\Delta E / T}$ |
 | **Refroidissement** | Reduction progressive de $T$ (programme exponentiel) |
 
@@ -22408,13 +22434,13 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,7eb4d949,markd
 | Aspect | Avantage | Inconvenient |
 |--------|----------|-------------|
 | Garantie | Aucune | Ne trouve pas toujours la solution |
-| Performance | Variable selon parametres | Plus lent que les solveurs CSP |
+| Performance | Variable selon paramètres | Plus lent que les solveurs CSP |
 | Pedagogie | Elegant pour comprendre l'optimisation | Pas adapte aux CSP stricts |
 
 ### Quand l'utiliser
 
 - Puzzles moyens (pas trop difficiles)
-- Quand on veut comprendre les metaheuristiques
+- Quand on veut comprendre les métaheuristiques
 - Pour explorer l'espace de solutions
 
 ### Alternatives recommandees
@@ -22425,23 +22451,23 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,7eb4d949,markd
 
 ---
 
-**Navigation** : [<< Sudoku-3-Genetic](Sudoku-3-Genetic-Python.ipynb) | [Index](README.md) | [Sudoku-5-PSO >>](Sudoku-5-PSO-Python.ipynb)",,,,,,,,cabf18e6b240ac91,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,2bf8d86f,markdown,fr,a13abfa1be44cce6,"## Conclusion
+**Navigation** : [<< Sudoku-3-Genetic](Sudoku-3-Genetic-Python.ipynb) | [Index](README.md) | [Sudoku-5-PSO >>](Sudoku-5-PSO-Python.ipynb)",,,,,,,,ad962a8ac14e763b,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,2bf8d86f,markdown,fr,0853f40395cf1155,"## Conclusion
 
 Ce notebook a applique le **recuit simule (Simulated Annealing)** a la resolution de Sudoku.
 
 ### Formulation SA pour le Sudoku
 
-| Element | Choix |
+| Élément | Choix |
 |---------|-------|
 | **Etat** | Grille 9x9 avec permutations par ligne |
 | **Energie** | Doublons colonnes + blocs 3x3 (lignes valides par construction) |
-| **Voisinage** | Echange de 2 cellules non-fixees dans la meme ligne |
+| **Voisinage** | Echange de 2 cellules non-fixees dans la même ligne |
 | **Refroidissement** | T *= alpha (0.999), T0=1.0, Tmin=0.001 |
 
-### Resultats du benchmark
+### Résultats du benchmark
 
-| Methode | Puzzles | Temps observe |
+| Méthode | Puzzles | Temps observe |
 |---------|---------|---------------|
 | **SA manuel** | 3/3 resolus | ~0.1 s a ~220 s (croit avec le nombre de vides) |
 | **Backtracking** | 3/3 resolus | ~1-9 ms (49-295 appels) |
@@ -22449,11 +22475,11 @@ Ce notebook a applique le **recuit simule (Simulated Annealing)** a la resolutio
 
 ### Lecture comparee
 
-Le backtracking resout ces puzzles faciles en quelques millisecondes ; le recuit simule y parvient aussi mais est **considerablement plus lent** (jusqu'a ~220 s sur 51 cellules vides). La valeur du recuit simule n'est pas dans la vitesse sur ces instances faciles, mais dans sa capacite a **explorer un paysage d'energie** (acceptation de mouvements degradants a haute temperature, exploitation a basse temperature) -- une approche transferable a des problemes d'optimisation ou aucun solveur deterministe n'est disponible.
+Le backtracking resout ces puzzles faciles en quelques millisecondes ; le recuit simule y parvient aussi mais est **considerablement plus lent** (jusqu'a ~220 s sur 51 cellules vides). La valeur du recuit simule n'est pas dans la vitesse sur ces instances faciles, mais dans sa capacite a **explorer un paysage d'energie** (acceptation de mouvements degradants a haute temperature, exploitation a basse temperature) -- une approche transferable a des problemes d'optimisation ou aucun solveur déterministe n'est disponible.
 
-Le recuit simule offre une approche **non-deterministe** sans garantie de completude, adaptee aux problemes d'optimisation combinatoire. Pour le Sudoku, les solveurs CSP (OR-Tools CP-SAT, Z3 SMT) restent plus fiables sur les instances difficiles.
+Le recuit simule offre une approche **non-déterministe** sans garantie de completude, adaptee aux problemes d'optimisation combinatoire. Pour le Sudoku, les solveurs CSP (OR-Tools CP-SAT, Z3 SMT) restent plus fiables sur les instances difficiles.
 
-**Suite** : [Sudoku-5 - PSO](Sudoku-5-PSO-Python.ipynb) | [Sudoku-10 - OR-Tools](Sudoku-10-ORTools-Python.ipynb) | [Retour au sommaire](README.md)",,,,,,,,a13abfa1be44cce6,,,,,,,
+**Suite** : [Sudoku-5 - PSO](Sudoku-5-PSO-Python.ipynb) | [Sudoku-10 - OR-Tools](Sudoku-10-ORTools-Python.ipynb) | [Retour au sommaire](README.md)",,,,,,,,0853f40395cf1155,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb,8d6fb7e6,markdown,fr,9205a6cbabfada26,"# Sudoku-5 : Particle Swarm Optimization (PSO)
 
 **Niveau** : Métaheuristique  
@@ -22471,7 +22497,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb,8d6fb7e6,markdown,fr,9205a6cb
 | << Précédent | [Index](./README.md) | Suivant >> |
 |-------------|---------------------|-----------|
 | [Sudoku-4-SimulatedAnnealing](Sudoku-4-SimulatedAnnealing-Csharp.ipynb) | | [Sudoku-6-AIMA-CSP](Sudoku-6-AIMA-CSP-Csharp.ipynb) |",,,,,,,,9205a6cbabfada26,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb,811602ac,markdown,fr,c904de210928e30a,"## 1. Introduction au PSO
+MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb,811602ac,markdown,fr,12b669e9ed8378fe,"## 1. Introduction au PSO
 
 Le **Particle Swarm Optimization** (PSO) est une métaheuristique inspirée du comportement social des oiseaux et des poissons. Développé par Kennedy et Eberhart en 1995, l'algorithme simule un essaim de particules qui explorent l'espace de recherche.
 
@@ -22493,7 +22519,7 @@ x(t+1) = x(t) + v(t+1)
 ```
 
 Où :
-- `w` : poids d'inertie (impact de la vélocité precedente)
+- `w` : poids d'inertie (impact de la vélocité précédente)
 - `c1`, `c2` : coefficients d'apprentissage (cognitif et social)
 - `r1`, `r2` : nombres aleatoires [0, 1]
 
@@ -22505,7 +22531,7 @@ L'équation de vélocité ci-dessus est définie sur un espace **continu** : add
 - **Explorers** (10%) : repartent d'une grille **aleatoire** complète a chaque itération, pour diversifier la recherche.
 - **Meilleure globale** : l'essaim conserve la meilleure grille rencontree (`bestError` / `bestSolution`), qui est la solution retournee.
 
-> **A retenir** : il n'y a ici ni champ de vélocité, ni mémoire `pBest` par particule, ni coefficients `w`/`c1`/`c2`. Les workers ne sont pas attires par `gBest` au sens de l'équation canonique : chaque worker se compare a sa **propre** erreur courante. C'est un exemple typique de la difficulté a transposer une métaheuristique **continue** (PSO) vers un espace **discret** : on garde l'idée d'essaim (exploration parallèle + mémoire de la meilleure solution), mais le mecanisme de deplacement est entièrement repense (échanges locaux + redémarrages).",,,,,,,,c904de210928e30a,,,,,,,
+> **A retenir** : il n'y a ici ni champ de vélocité, ni mémoire `pBest` par particule, ni coefficients `w`/`c1`/`c2`. Les workers ne sont pas attires par `gBest` au sens de l'équation canonique : chaque worker se compare a sa **propre** erreur courante. C'est un exemple typique de la difficulté a transposer une métaheuristique **continue** (PSO) vers un espace **discret** : on garde l'idée d'essaim (exploration parallèle + mémoire de la meilleure solution), mais le mécanisme de deplacement est entièrement repense (échanges locaux + redémarrages).",,,,,,,,12b669e9ed8378fe,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb,eea78693,code,fr,eb3d945ae449b902,#!import Sudoku-0-Environment-Csharp.ipynb,,,,,,,,eb3d945ae449b902,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb,56ccfa8e,markdown,fr,d0be71f6be982ea8,## 2. Implémentation des classes auxiliaires,,,,,,,,d0be71f6be982ea8,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb,864062f1,code,fr,c40c654acd704695,"// Helper pour la manipulation des matrices Sudoku
@@ -22974,7 +23000,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb,83a342e9,markdown,fr,39fc89ec
 4. **Stagnation typique** : L'erreur reste souvent bloquee a 2-4 (pres de la solution mais bloquee)
 
 > **Note technique** : Cette heuristique d'essaim pour Sudoku souffre de problèmes d'optima locaux. L'erreur reste souvent bloquee a 2-4, ce qui signifie que quelques lignes/colonnes ont des doublons. Les redémarrages et la reinitialisation des workers stagnants ne suffisent pas toujours a échapper a ces optima locaux.",,,,,,,,39fc89ecb30c1db5,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb,ed62b205,markdown,fr,41716c947bc8be84,"## 6. Influence des paramètres
+MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb,ed62b205,markdown,fr,1884f85bf3d1f287,"## 6. Influence des paramètres
 
 ### Paramètres clés
 
@@ -22988,13 +23014,13 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb,ed62b205,markdown,fr,41716c94
 
 ### Comparaison avec GA et SA
 
-| Aspect | PSO | Algorithme Genetique | Recuit Simule |
+| Aspect | PSO | Algorithme Génétique | Recuit Simule |
 |--------|-----|---------------------|---------------|
 | Inspiration | Oiseaux/poissons | Evolution biologique | Thermodynamique |
 | Population | Multiple | Multiple | Unique |
 | Exploration | Workers + Explorers | Mutation | Temperature |
 | Exploitation | Convergence vers gBest | Crossover | Refroidissement |
-| Performance Sudoku | ~1-5s | ~1-10s | ~2-5s |",,,,,,,,41716c947bc8be84,,,,,,,
+| Performance Sudoku | ~1-5s | ~1-10s | ~2-5s |",,,,,,,,1884f85bf3d1f287,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb,30399613,code,fr,941f2c5b71282cbf,"// Test avec differents parametres
 var configurations = new[]
 {
@@ -23100,13 +23126,13 @@ public class HybridPSOSudokuSolver : ISudokuSolver
 }
 
 Console.WriteLine(""HybridPSOSudokuSolver a implementer !"");",,,,,,,,d7fc2f80467f3f0e,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb,efec4e39,markdown,fr,f52dfff4f6bf3a21,"## Résumé et perspectives
+MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb,efec4e39,markdown,fr,ddd659a0adc6d825,"## Résumé et perspectives
 
 Ce notebook a transposé le Particle Swarm Optimization (PSO) en C# pour la résolution de Sudoku, en reprenant l'encodage par blocs et l'architecture Workers/Explorers. Le solveur `PSOSudokuSolver` a démontré une résolution rapide sur les puzzles faciles (61 ms avec 200 organismes), mais aussi une grande variabilité selon l'initialisation : le benchmark sur 5 puzzles a révèle des temps allant de 7 ms a 30 secondes, avec un échec sur un puzzle malgré 10 tentatives. La comparaison des configurations (Conservatif, Standard, Agressif) a confirmé que l'essentiel de la performance depend de la chance de l'initialisation aleatoire.
 
-Le mecanisme de fusion entre le meilleur Worker et le meilleur Explorer, combiné a la reinitialisation des organismes stagnants (age > MaxAge), constitue le coeur de l'adaptation du PSO au Sudoku. L'exercice `HybridPSOSudokuSolver` propose d'ajouter une recherche locale intensive (`LocalSearchImprove`) lorsque la solution stagne, ce qui devrait améliorer significativement la fiabilite en echappant aux optima locaux ou l'erreur reste bloque a 2-4.
+Le mécanisme de fusion entre le meilleur Worker et le meilleur Explorer, combiné a la reinitialisation des organismes stagnants (age > MaxAge), constitue le coeur de l'adaptation du PSO au Sudoku. L'exercice `HybridPSOSudokuSolver` propose d'ajouter une recherche locale intensive (`LocalSearchImprove`) lorsque la solution stagne, ce qui devrait améliorer significativement la fiabilite en echappant aux optima locaux ou l'erreur reste bloque a 2-4.
 
-Le notebook suivant, [Sudoku-6-AIMA-CSP-Csharp](Sudoku-6-AIMA-CSP-Csharp.ipynb), passe des métaheuristiques probabilistes aux méthodes deterministes de résolution par contraintes (CSP), avec les algorithmes Forward Checking, AC-3 et MAC issus du cadre academique AIMA.",,,,,,,,f52dfff4f6bf3a21,,,,,,,
+Le notebook suivant, [Sudoku-6-AIMA-CSP-Csharp](Sudoku-6-AIMA-CSP-Csharp.ipynb), passe des métaheuristiques probabilistes aux méthodes déterministes de résolution par contraintes (CSP), avec les algorithmes Forward Checking, AC-3 et MAC issus du cadre academique AIMA.",,,,,,,,ddd659a0adc6d825,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb,af77878b,markdown,fr,a5aaafd5bb50c744,"### Interprétation : Influence de la configuration
 
 **Sortie obtenue** : Les trois configurations (Conservatif, Standard, Agressif) résolvent ce puzzle en quelques millisecondes avec succès.
@@ -23149,13 +23175,13 @@ Le **Particle Swarm Optimization** est une métaheuristique interessante pour Su
 | << Précédent | [Index](./README.md) | Suivant >> |
 |-------------|---------------------|-----------|
 | [Sudoku-4-SimulatedAnnealing](Sudoku-4-SimulatedAnnealing-Csharp.ipynb) | | [Sudoku-6-AIMA-CSP](Sudoku-6-AIMA-CSP-Csharp.ipynb) |",,,,,,,,8ce25da96cba2b9a,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,4862d5e2,markdown,fr,4f0f12b600f6198a,"# Sudoku-5 : Particle Swarm Optimization (Python)
+MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,4862d5e2,markdown,fr,5498bb6a78ad537e,"# Sudoku-5 : Particle Swarm Optimization (Python)
 
-**Niveau** : Metaheuristique | **Duree** : ~20 min | **Prerequis** : Sudoku-0 Environment
+**Niveau** : Métaheuristique | **Duree** : ~20 min | **Prerequis** : Sudoku-0 Environment
 
 ## Navigation
 
-| << Precedent | [Index](README.md) | Suivant >> |
+| << Précédent | [Index](README.md) | Suivant >> |
 |-------------|---------------------|-----------|
 | [Sudoku-4-SimulatedAnnealing-Python](Sudoku-4-SimulatedAnnealing-Python.ipynb) | | [Sudoku-6-AIMA-CSP-Python](Sudoku-6-AIMA-CSP-Python.ipynb) |
 
@@ -23165,7 +23191,7 @@ A la fin de ce notebook, vous saurez :
 1. Comprendre les principes de l'optimisation par essaim de particules (PSO)
 2. Adapter le PSO a la resolution de Sudoku
 3. Implementer un solveur d'essaim discret (Workers/Explorers) adapte au Sudoku
-4. Comparer les performances avec les autres metaheuristiques
+4. Comparer les performances avec les autres métaheuristiques
 
 ---
 
@@ -23174,7 +23200,7 @@ C'est l'equivalent Python du notebook C# `Sudoku-5-PSO-Csharp.ipynb`.
 
 ## Introduction
 
-Le **Particle Swarm Optimization** (PSO) est une metaheuristique inspiree du comportement social des oiseaux et des poissons. Developpe par Kennedy et Eberhart en 1995, l'algorithme simule un essaim de particules qui explorent l'espace de recherche.
+Le **Particle Swarm Optimization** (PSO) est une métaheuristique inspiree du comportement social des oiseaux et des poissons. Developpe par Kennedy et Eberhart en 1995, l'algorithme simule un essaim de particules qui explorent l'espace de recherche.
 
 ### Principes fondamentaux (PSO canonique)
 
@@ -23190,26 +23216,26 @@ $$v(t+1) = w \cdot v(t) + c_1 \cdot r_1 \cdot (pBest - x(t)) + c_2 \cdot r_2 \cd
 $$x(t+1) = x(t) + v(t+1)$$
 
 Ou :
-- $w$ : poids d'inertie (impact de la vitesse precedente)
+- $w$ : poids d'inertie (impact de la vitesse précédente)
 - $c_1$, $c_2$ : coefficients d'apprentissage (cognitif et social)
 - $r_1$, $r_2$ : nombres aleatoires [0, 1]
 
 ### Adaptation au Sudoku : une variante discrete inspiree de l'essaim
 
-L'equation de vitesse ci-dessus est definie sur un espace **continu** : additionner une vitesse a une position suppose des coordonnees reelles. Le Sudoku est un probleme **combinatoire discret** (permutations de chiffres), ou cette addition n'a pas de sens direct. Ce notebook n'implemente donc **pas** l'equation de vitesse canonique ; il utilise une **heuristique d'essaim discrete** (classe `PSOSudokuSolver`) inspiree du PSO et des colonies d'organismes :
+L'equation de vitesse ci-dessus est définie sur un espace **continu** : additionner une vitesse a une position suppose des coordonnees reelles. Le Sudoku est un problème **combinatoire discret** (permutations de chiffres), ou cette addition n'a pas de sens direct. Ce notebook n'implemente donc **pas** l'equation de vitesse canonique ; il utilise une **heuristique d'essaim discrete** (classe `PSOSudokuSolver`) inspiree du PSO et des colonies d'organismes :
 
-- **Workers** (`worker_ratio = 0.90`) : exploitent leur voisinage par **echange de deux cases dans un meme bloc** (`neighbor_matrix`, recherche locale), en acceptant un voisin s'il reduit l'erreur (ou rarement, via un faible `mutation_rate`). Un worker qui stagne trop longtemps (`age > max_age`) est reinitialise.
-- **Explorers** (10%) : repartent d'une grille **aleatoire** complete (`random_matrix`) a chaque iteration, pour diversifier la recherche.
+- **Workers** (`worker_ratio = 0.90`) : exploitent leur voisinage par **echange de deux cases dans un même bloc** (`neighbor_matrix`, recherche locale), en acceptant un voisin s'il reduit l'erreur (ou rarement, via un faible `mutation_rate`). Un worker qui stagne trop longtemps (`age > max_age`) est reinitialise.
+- **Explorers** (10%) : repartent d'une grille **aleatoire** complete (`random_matrix`) a chaque itération, pour diversifier la recherche.
 - **Fusion** : a chaque epoque, le pire worker est remplace par un croisement par blocs (`merge_matrices`) du meilleur worker et du meilleur explorer.
 - **Meilleure globale** : l'essaim conserve la meilleure grille rencontree (`best_error` / `best_solution`), qui est la solution retournee.
 
-> **A retenir** : il n'y a ici ni champ de vitesse, ni memoire `pBest` par particule, ni coefficients $w$/$c_1$/$c_2$. Les workers ne sont pas attires par `gBest` au sens de l'equation canonique : chaque worker se compare a sa **propre** erreur courante. C'est un exemple typique de la difficulte a transposer une metaheuristique **continue** (PSO) vers un espace **discret** : on garde l'idee d'essaim (exploration parallele + memoire de la meilleure solution), mais le mecanisme de deplacement est entierement repense (echanges locaux + fusion + redemarrages).
+> **A retenir** : il n'y a ici ni champ de vitesse, ni memoire `pBest` par particule, ni coefficients $w$/$c_1$/$c_2$. Les workers ne sont pas attires par `gBest` au sens de l'equation canonique : chaque worker se compare a sa **propre** erreur courante. C'est un exemple typique de la difficulte a transposer une métaheuristique **continue** (PSO) vers un espace **discret** : on garde l'idee d'essaim (exploration parallele + memoire de la meilleure solution), mais le mécanisme de deplacement est entierement repense (echanges locaux + fusion + redemarrages).
 
 ## Installation
 
 ```bash
 pip install mealpy numpy matplotlib
-```",,,,,,,,4f0f12b600f6198a,,,,,,,
+```",,,,,,,,5498bb6a78ad537e,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,83c9d836,code,fr,c6ed7db7af3700be,"# Imports
 import numpy as np
 import time
@@ -23226,7 +23252,7 @@ try:
 except ImportError:
     MEALPY_AVAILABLE = False
     print(""mealpy non installe (optionnel) - ce notebook utilise PSO manuel"")",,,,,,,,c6ed7db7af3700be,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,9c100eda,markdown,fr,1d72c2e073cdc81c,"### Interpretation : Imports et dependances
+MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,9c100eda,markdown,fr,d892d29ec076036a,"### Interpretation : Imports et dependances
 
 **Sortie obtenue** : mealpy non installe (optionnel)
 
@@ -23241,11 +23267,11 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,9c100eda,markdown,fr,1d72c2e0
 | `mealpy` | Optimisation (optionnel) | Implementation manuelle |
 
 **Points cles** :
-1. **Independance** : Ce notebook implemente PSO manuellement (mealpy optionnel)
+1. **Indépendance** : Ce notebook implemente PSO manuellement (mealpy optionnel)
 2. **NumPy** : Essentiel pour la representation matricielle
 3. **Typing** : Annotations de type pour la clarte du code
 
-> **Note technique** : L'implementation manuelle de PSO permet de comprendre l'algorithme en detail. La bibliotheque `mealpy` fournit une implementation generique mais moins adaptee aux specifics du Sudoku (encodage par blocs).",,,,,,,,1d72c2e073cdc81c,,,,,,,
+> **Note technique** : L'implementation manuelle de PSO permet de comprendre l'algorithme en detail. La bibliotheque `mealpy` fournit une implementation generique mais moins adaptee aux specifics du Sudoku (encodage par blocs).",,,,,,,,d892d29ec076036a,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,15a2991d,markdown,fr,381d6e504fce2cab,Configuration du chemin vers les fichiers de puzzles.,,,,,,,,381d6e504fce2cab,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,bc9b88e4,code,fr,b6f1b765122066ae,"# Configuration du chemin vers les puzzles
 import os
@@ -23265,13 +23291,13 @@ if PUZZLES_DIR.exists():
 else:
     print(f""ATTENTION: Dossier Puzzles non trouve a {PUZZLES_DIR}"")
     PUZZLES_DIR = Path(os.getcwd()) / ""Puzzles""",,,,,,,,b6f1b765122066ae,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,ae5bc588,markdown,fr,e542f06e49bd8670,"### Interpretation : Configuration de l'environnement
+MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,ae5bc588,markdown,fr,9385aa705ddd96e6,"### Interpretation : Configuration de l'environnement
 
 **Sortie obtenue** : Dossier Puzzles trouve et chemin affiche
 
 **Structure des fichiers** :
 
-| Element | Chemin | Role |
+| Élément | Chemin | Rôle |
 |---------|--------|------|
 | `NOTEBOOK_DIR` | `D:\Dev\CoursIA\MyIA.AI.Notebooks\Sudoku` | Racine de la serie |
 | `PUZZLES_DIR` | `.../Sudoku/Puzzles` | Conteneur des fichiers de puzzles |
@@ -23281,10 +23307,10 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,ae5bc588,markdown,fr,e542f06e
 2. **Verification** : Test d'existence avant d'acceder aux fichiers
 3. **Fallback** : Si dossier absent, utilise le repertoire courant
 
-> **Note technique** : L'utilisation de `pathlib.Path` est recommandee en Python 3 pour manipuler les chemins de fichiers de maniere orientee objet. Elle gere automatiquement les separateurs (/ ou \) selon l'OS.",,,,,,,,e542f06e49bd8670,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,a3bc36a4,markdown,fr,c3cd949bcd9caf8c,"## 1. Classe SudokuGrid
+> **Note technique** : L'utilisation de `pathlib.Path` est recommandee en Python 3 pour manipuler les chemins de fichiers de maniere orientee objet. Elle gere automatiquement les separateurs (/ ou \) selon l'OS.",,,,,,,,9385aa705ddd96e6,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,a3bc36a4,markdown,fr,ccccd0dc9ff5a9cd,"## 1. Classe SudokuGrid
 
-Representation d'une grille de Sudoku avec methodes pour calculer le nombre d'erreurs.",,,,,,,,c3cd949bcd9caf8c,,,,,,,
+Representation d'une grille de Sudoku avec méthodes pour calculer le nombre d'erreurs.",,,,,,,,ccccd0dc9ff5a9cd,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,7414b376,code,fr,a8c921d4ab174bfe,"class SudokuGrid:
     """"""Representation d'une grille de Sudoku 9x9.""""""
     
@@ -23369,15 +23395,15 @@ print(f""Puzzles charges: {len(easy_puzzles)}"")
 test_grid = SudokuGrid.from_string(easy_puzzles[0])
 print(""\nGrille de test:"")
 print(test_grid)",,,,,,,,a8c921d4ab174bfe,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,ae2304d3,markdown,fr,828f0e94507b826a,"### Interpretation : Structure de donnees Sudoku
+MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,ae2304d3,markdown,fr,de6e1a6db5490f95,"### Interpretation : Structure de données Sudoku
 
-**Sortie obtenue** : 5 puzzles charges, grille de test affichee
+**Sortie obtenue** : 5 puzzles charges, grille de test affichée
 
 **Composants de la classe SudokuGrid** :
 
-| Methode | Role | Complexite |
+| Méthode | Rôle | Complexite |
 |---------|------|------------|
-| `from_string()` | Parse une chaine de 81 caracteres | O(1) |
+| `from_string()` | Parse une chaîne de 81 caractères | O(1) |
 | `count_errors()` | Compte doublons lignes/colonnes/blocs | O(9*9) = O(1) |
 | `is_solved()` | Verifie si grille valide | O(1) |
 | `clone()` | Copie profonde | O(1) |
@@ -23388,11 +23414,11 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,ae2304d3,markdown,fr,828f0e94
 - Cases vides : 36 (sur 81)
 
 **Points cles** :
-1. **Representation compacte** : Chaine de 81 caracteres pour le stockage
+1. **Representation compacte** : Chaîne de 81 caractères pour le stockage
 2. **Validation efficace** : Utilisation de `np.unique` pour detecter les doublons
 3. **Affichage lisible** : Separateurs visuels pour les blocs 3x3
 
-> **Note technique** : La methode `count_errors()` compte les doublons dans chaque ligne, colonne et bloc. Une grille resolue a 0 erreurs. Cette fonction sera la base de notre fonction de fitness pour le PSO.",,,,,,,,828f0e94507b826a,,,,,,,
+> **Note technique** : La méthode `count_errors()` compte les doublons dans chaque ligne, colonne et bloc. Une grille resolue a 0 erreurs. Cette fonction sera la base de notre fonction de fitness pour le PSO.",,,,,,,,de6e1a6db5490f95,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,73e432ea,markdown,fr,c1887779427f06c2,"## 2. Approches PSO pour Sudoku
 
 Il existe plusieurs facons d'encoder un Sudoku pour PSO. Nous allons explorer deux approches :
@@ -23402,9 +23428,9 @@ Chaque particule contient 81 valeurs (1-9) pour chaque cellule.
 
 ### Approche 2 : Encodage par permutations de blocs
 Chaque bloc 3x3 est initialise avec les valeurs correctes, puis PSO melange les permutations.",,,,,,,,c1887779427f06c2,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,a3a457fd,markdown,fr,01c30d069e0745e2,"## 3. Implementation manuelle du PSO
+MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,a3a457fd,markdown,fr,41646630da7633a0,"## 3. Implementation manuelle du PSO
 
-Nous implementons un PSO specifique au Sudoku, sans utiliser mealpy, pour mieux comprendre l'algorithme.",,,,,,,,01c30d069e0745e2,,,,,,,
+Nous implementons un PSO spécifique au Sudoku, sans utiliser mealpy, pour mieux comprendre l'algorithme.",,,,,,,,41646630da7633a0,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,23aa4f00,code,fr,d130b798ef382bc4,"class MatrixHelperPSO:
     """"""Helper pour la manipulation des matrices Sudoku.""""""
     
@@ -23489,13 +23515,13 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,23aa4f00,code,fr,d130b798ef38
         return result
 
 print(""MatrixHelperPSO defini."")",,,,,,,,d130b798ef382bc4,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,3445ed0c,markdown,fr,24ccd4a70bd835bb,"### Interpretation : Helpers matriciels pour PSO
+MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,3445ed0c,markdown,fr,4972df43ea80c7bd,"### Interpretation : Helpers matriciels pour PSO
 
-**Sortie obtenue** : Classe MatrixHelperPSO definie
+**Sortie obtenue** : Classe MatrixHelperPSO définie
 
-**Operations cles** :
+**Opérations cles** :
 
-| Methode | Role | Strategie |
+| Méthode | Rôle | Stratégie |
 |---------|------|-----------|
 | `random_matrix` | Initialisation | Remplit chaque bloc 3x3 avec 1-9 |
 | `neighbor_matrix` | Voisinage | Echange 2 cases dans un bloc |
@@ -23504,9 +23530,9 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,3445ed0c,markdown,fr,24ccd4a7
 **Points cles** :
 1. **Encodage par blocs** : Chaque bloc 3x3 contient toujours 1-9 (pas d'erreur de bloc)
 2. **Respect des contraintes** : Les cases fixes du puzzle ne sont jamais modifiees
-3. **Efficacite** : Operations locales (un bloc) pour limiter les changements
+3. **Efficacite** : Opérations locales (un bloc) pour limiter les changements
 
-> **Note technique** : L'approche par blocs reduit drastiquement l'espace de recherche. Au lieu de 9^81 possibilites, on a (9!)^9 configurations, et chaque bloc est deja valide localement.",,,,,,,,24ccd4a70bd835bb,,,,,,,
+> **Note technique** : L'approche par blocs reduit drastiquement l'espace de recherche. Au lieu de 9^81 possibilites, on a (9!)^9 configurations, et chaque bloc est déjà valide localement.",,,,,,,,4972df43ea80c7bd,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,c52783a9,markdown,fr,d4176486d2516887,Classe PSO principale utilisant les helpers matriciels.,,,,,,,,d4176486d2516887,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,f99d621c,code,fr,b3622516d0bd8a81,"class SudokuPSO:
     """"""Representation d'une grille Sudoku avec calcul d'erreur.""""""
@@ -23538,24 +23564,24 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,f99d621c,code,fr,b3622516d0bd
         return errors
 
 print(""SudokuPSO defini."")",,,,,,,,b3622516d0bd8a81,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,cdab968f,markdown,fr,7971ab8f328d2030,"### Interpretation : Fonction d'evaluation PSO
+MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,cdab968f,markdown,fr,68aacfdffc81ab47,"### Interpretation : Fonction d'evaluation PSO
 
-**Sortie obtenue** : Classe SudokuPSO definie
+**Sortie obtenue** : Classe SudokuPSO définie
 
-**Mecanisme de calcul d'erreur** :
+**Mécanisme de calcul d'erreur** :
 
-| Type de verification | Methode | Erreur comptee |
+| Type de verification | Méthode | Erreur comptee |
 |---------------------|---------|----------------|
 | Lignes | Valeurs manquantes (1-9) | +1 par valeur absente |
 | Colonnes | Valeurs manquantes (1-9) | +1 par valeur absente |
 | Total | Somme lignes + colonnes | 0 a 162 |
 
 **Points cles** :
-1. **Optimisation** : On ne verifie PAS les blocs 3x3 (deja valides par construction)
+1. **Optimisation** : On ne verifie PAS les blocs 3x3 (déjà valides par construction)
 2. **Fitness inverse** : Erreur = 0 signifie solution valide
 3. **Efficacite** : Comptage par tableaux d'occurrences (O(1) par ligne/colonne)
 
-> **Note technique** : Cette fonction d'evaluation est specifique a l'encodage par blocs. Puisque chaque bloc contient exactement les chiffres 1-9, il ne peut pas y avoir d'erreur de bloc. Les seules erreurs possibles sont les conflits entre lignes et colonnes.",,,,,,,,7971ab8f328d2030,,,,,,,
+> **Note technique** : Cette fonction d'evaluation est spécifique a l'encodage par blocs. Puisque chaque bloc contient exactement les chiffres 1-9, il ne peut pas y avoir d'erreur de bloc. Les seules erreurs possibles sont les conflits entre lignes et colonnes.",,,,,,,,68aacfdffc81ab47,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,b48a1859,markdown,fr,85cbc46b7cc2b280,Implementation de l'algorithme PSO avec ses variantes de particules.,,,,,,,,85cbc46b7cc2b280,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,98058902,code,fr,6f3b74ea93a480ac,"from enum import Enum
 
@@ -23573,13 +23599,13 @@ class Organism:
         self.age = age
 
 print(""Classes OrganismType et Organism definies."")",,,,,,,,6f3b74ea93a480ac,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,d31c60ad,markdown,fr,eade684f5a86afab,"### Interpretation : Modelisation des particules
+MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,d31c60ad,markdown,fr,d16b3a58db1ca50e,"### Interpretation : Modelisation des particules
 
-**Sortie obtenue** : Classes OrganismType et Organism definies
+**Sortie obtenue** : Classes OrganismType et Organism définies
 
 **Structure d'une particule** :
 
-| Attribut | Type | Role |
+| Attribut | Type | Rôle |
 |----------|------|------|
 | `type` | OrganismType | WORKER ou EXPLORER |
 | `matrix` | np.ndarray | Grille 9x9 representant la position |
@@ -23587,11 +23613,11 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,d31c60ad,markdown,fr,eade684f
 | `age` | int | Epochs sans amelioration |
 
 **Points cles** :
-1. **Dualite des roles** : Workers exploitent localement, explorers cherchent globalement
+1. **Dualite des rôles** : Workers exploitent localement, explorers cherchent globalement
 2. **Age comme indicateur** : Permet de detecter la stagnation
 3. **Fitness inverse** : On minimise l'erreur (0 = solution valide)
 
-> **Note technique** : Le typage Python avec Enum permet une distinction claire des comportements. Les workers utilisent `neighbor_matrix` (echange dans un bloc), les explorers utilisent `random_matrix` (reinitialisation complete).",,,,,,,,eade684f5a86afab,,,,,,,
+> **Note technique** : Le typage Python avec Enum permet une distinction claire des comportements. Les workers utilisent `neighbor_matrix` (echange dans un bloc), les explorers utilisent `random_matrix` (reinitialisation complete).",,,,,,,,d16b3a58db1ca50e,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,b8212fb8,markdown,fr,ba60aa8d94192e70,## 4. Solveur PSO,,,,,,,,ba60aa8d94192e70,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,6b02a3f6,code,fr,de3c7de66526949d,"import math
 
@@ -23720,13 +23746,13 @@ class PSOSudokuSolver:
         return best_solution
 
 print(""PSOSudokuSolver defini."")",,,,,,,,de3c7de66526949d,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,543b8705,markdown,fr,a6eca64cb16286a5,"### Interpretation : Architecture du solveur PSO
+MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,543b8705,markdown,fr,2102982e7811f7db,"### Interpretation : Architecture du solveur PSO
 
-**Sortie obtenue** : Classe PSOSudokuLoader definie avec succes
+**Sortie obtenue** : Classe PSOSudokuLoader définie avec succes
 
 **Composants principaux** :
 
-| Composant | Role | Parametre cle |
+| Composant | Rôle | Paramètre cle |
 |-----------|------|---------------|
 | **Workers** (90%) | Exploitation locale | Voisinage par echange dans bloc |
 | **Explorers** (10%) | Exploration globale | Reinitialisation aleatoire |
@@ -23734,11 +23760,11 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,543b8705,markdown,fr,a6eca64c
 | **Age** | Detection de stagnation | Reinitialisation si > max_age |
 
 **Points cles** :
-1. **Double strategie** : Workers exploitent, explorers decouvrent
+1. **Double stratégie** : Workers exploitent, explorers decouvrent
 2. **Fusion intelligente** : Le pire worker est remplace par la fusion des meilleurs
 3. **Redemarrages** : Plusieurs tentatives pour eviter les optima locaux
 
-> **Note technique** : La fusion par blocs (50% de probabilite) permet de combiner les bonnes parties de deux solutions sans detruire les blocs corrects. C'est une forme de crossover preserve les blocs 3x3 valides.",,,,,,,,a6eca64cb16286a5,,,,,,,
+> **Note technique** : La fusion par blocs (50% de probabilite) permet de combiner les bonnes parties de deux solutions sans detruire les blocs corrects. C'est une forme de crossover preserve les blocs 3x3 valides.",,,,,,,,2102982e7811f7db,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,7e7ed443,markdown,fr,d6bf9aa11c1a24e5,## 5. Test sur un Puzzle Facile,,,,,,,,d6bf9aa11c1a24e5,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,f1330c9a,code,fr,29a9136d34277361,"print(""=== Test : Puzzle Facile ==="")
 puzzle = SudokuGrid.from_string(easy_puzzles[0])
@@ -23758,15 +23784,15 @@ elapsed = time.time() - start
 print(f""\nSolution trouvee en {elapsed:.2f}s:"")
 print(result)
 print(f""\nSolution valide: {solved}"")",,,,,,,,29a9136d34277361,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,cef4d40c,markdown,fr,40e6bea47f78155c,"### Interpretation : Premier test
+MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,cef4d40c,markdown,fr,dd2f46a3eb1ae253,"### Interpretation : Premier test
 
 | Aspect | Observation |
 |--------|-------------|
-| Resultat | Le PSO peut trouver la solution pour les puzzles faciles |
+| Résultat | Le PSO peut trouver la solution pour les puzzles faciles |
 | Temps | Variable selon la configuration |
 | Workers vs Explorers | Les workers exploitent, les explorers decouvrent |
 
-> **Point cle** : Le PSO combine l'exploitation (convergence vers gBest) avec l'exploration (recherche aleatoire).",,,,,,,,40e6bea47f78155c,,,,,,,
+> **Point cle** : Le PSO combine l'exploitation (convergence vers gBest) avec l'exploration (recherche aleatoire).",,,,,,,,dd2f46a3eb1ae253,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,ex-pso-error-breakdown,markdown,fr,4f2b4e0b97c24914,"## Exercice : Decomposition des erreurs par type
 
 ### Contexte
@@ -23839,9 +23865,9 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,16434222,code,fr,dbbc214b3cbc
     return results
 
 benchmark_pso(easy_puzzles, num_puzzles=2)",,,,,,,,dbbc214b3cbc041d,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,437ee5ea,markdown,fr,e8a4854c07e864e7,"### Interpretation : Benchmark PSO sur plusieurs puzzles
+MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,437ee5ea,markdown,fr,5a9878ba5b107330,"### Interpretation : Benchmark PSO sur plusieurs puzzles
 
-**Sortie obtenue** : Resultats sur 2 puzzles de difficulte croissante
+**Sortie obtenue** : Résultats sur 2 puzzles de difficulte croissante
 
 | Puzzle | Cases vides | Temps | Statut | Redemarrages |
 |--------|-------------|-------|--------|--------------|
@@ -23858,22 +23884,22 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,437ee5ea,markdown,fr,e8a4854c
 2. **Ecart de difficulte** : le puzzle 2 (49 vides) est environ 24x plus lent que le puzzle 1 (36 vides)
 3. **Convergence progressive** : On observe l'erreur descendre (29 -> 4 -> 0)
 
-> **Note technique** : Les messages ""Epoch X, Best error: Y"" montrent que l'algorithme converge souvent vers quelques erreurs (2 a 4) avant d'atteindre 0. Cela correspond a une configuration presque valide ou quelques blocs doivent etre reorganises.",,,,,,,,e8a4854c07e864e7,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,ex-pso-convergence,markdown,fr,94a785db3c5da01c,"## Exercice : Detection de convergence
+> **Note technique** : Les messages ""Epoch X, Best error: Y"" montrent que l'algorithme converge souvent vers quelques erreurs (2 a 4) avant d'atteindre 0. Cela correspond a une configuration presque valide ou quelques blocs doivent etre reorganises.",,,,,,,,5a9878ba5b107330,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,ex-pso-convergence,markdown,fr,341406f4bf1e8047,"## Exercice : Detection de convergence
 
 ### Contexte
-Le PSO s'arrete apres un nombre fixe d'epochs. Mais si la solution stagne, continuer est inutile. Un **critere de convergence** permet d'arreter plus tot.
+Le PSO s'arrete après un nombre fixe d'epochs. Mais si la solution stagne, continuer est inutile. Un **critere de convergence** permet d'arreter plus tot.
 
 ### Objectif
 Implementez la fonction  qui detecte si le PSO a converge, en verifiant que l'erreur n'a pas baisse depuis un nombre donne d'epochs.
 
 ### Ce que la fonction doit verifier
-1. La liste  contient au moins  elements
-2. La difference entre l'erreur la plus recente et celle d'il y a  epochs est inferieure a 
+1. La liste  contient au moins  éléments
+2. La différence entre l'erreur la plus recente et celle d'il y a  epochs est inferieure a 
 
 ### Indices
 - Comparez  avec 
-- Si la liste a moins de  elements, retournez  (pas assez de donnees)",,,,,,,,94a785db3c5da01c,,,,,,,
+- Si la liste a moins de  éléments, retournez  (pas assez de données)",,,,,,,,341406f4bf1e8047,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,ex-pso-convergence-code,code,fr,734b37c6d1c58c8a,"def has_converged(error_history: list, patience: int = 50, threshold: float = 0.01) -> bool:
     """"""Detecte si le PSO a converge.
 
@@ -23893,7 +23919,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,ex-pso-convergence-code,code,
 
 # Testez votre fonction
 print(""Exercice has_converged a completer"")",,,,,,,,734b37c6d1c58c8a,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,1afbd0e5,markdown,fr,b071d6ef984bc3ee,## 7. Comparaison des Parametres,,,,,,,,b071d6ef984bc3ee,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,1afbd0e5,markdown,fr,4ce6cafa60ef76b7,## 7. Comparaison des Paramètres,,,,,,,,4ce6cafa60ef76b7,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,5487473c,code,fr,6c2b66077edd66f3,"print(""=== Test avec differents parametres ==="")
 
 configurations = [
@@ -23917,7 +23943,7 @@ for config in configurations:
     
     status = ""Succes"" if solved else ""Echec""
     print(f""{config['name']}: {elapsed:.2f}s - {status}"")",,,,,,,,6c2b66077edd66f3,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,df657b25,markdown,fr,994b5271b9fb3823,"### Interpretation : Impact des parametres PSO
+MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,df657b25,markdown,fr,960aabf7b2fd166e,"### Interpretation : Impact des paramètres PSO
 
 **Sortie obtenue** : Temps de resolution selon trois configurations
 
@@ -23930,13 +23956,13 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,df657b25,markdown,fr,994b5271
 **Points cles** :
 1. **Configuration conservateur** : Plus rapide pour ce puzzle facile (2.11s)
 2. **Toutes les configurations** reussissent sur les puzzles faciles
-3. **Le temps de resolution** ne croit pas lineairement avec les parametres
+3. **Le temps de resolution** ne croit pas lineairement avec les paramètres
 
-> **Note technique** : Pour les puzzles faciles, une configuration legere suffit. Les parametres agressifs sont utiles pour les puzzles difficiles ou l'essaim peut stagner dans des optima locaux.",,,,,,,,994b5271b9fb3823,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,1a7665c0,markdown,fr,a47674dcaa2f8d58,"## Exercice : Ratio workers/explorers adaptatif
+> **Note technique** : Pour les puzzles faciles, une configuration legere suffit. Les paramètres agressifs sont utiles pour les puzzles difficiles ou l'essaim peut stagner dans des optima locaux.",,,,,,,,960aabf7b2fd166e,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,1a7665c0,markdown,fr,8e872f3c8f526334,"## Exercice : Ratio workers/explorers adaptatif
 
 ### Contexte
-Dans le solveur PSO, le parametre `worker_ratio` fixe la proportion de workers (exploitation) par rapport aux explorers (exploration). Une valeur statique de 0.90 signifie 90% de workers et 10% d'explorers, independamment de la progression de la recherche.
+Dans le solveur PSO, le paramètre `worker_ratio` fixe la proportion de workers (exploitation) par rapport aux explorers (exploration). Une valeur statique de 0.90 signifie 90% de workers et 10% d'explorers, independamment de la progression de la recherche.
 
 Or, les besoins en exploration vs exploitation changent au cours de la resolution :
 - **Debut** : Il faut beaucoup d'exploration pour couvrir l'espace de recherche
@@ -23946,7 +23972,7 @@ Or, les besoins en exploration vs exploitation changent au cours de la resolutio
 ### Objectif
 Implementez la fonction `adaptive_worker_ratio` qui calcule dynamiquement le ratio workers/explorers en fonction de la progression de l'erreur.
 
-### Resultats attendus
+### Résultats attendus
 
 | Situation | current_error | initial_error | worker_ratio attendu |
 |-----------|---------------|---------------|---------------------|
@@ -23956,7 +23982,7 @@ Implementez la fonction `adaptive_worker_ratio` qui calcule dynamiquement le rat
 | Erreur nulle (100%) | 0 | 20 | 0.950 |
 
 **Indice :**
-La formule est un interpolation lineaire : plus l'erreur baisse (bonne progression), plus on augmente le ratio de workers. Utilisez `max()` et `min()` pour borner le resultat.",,,,,,,,a47674dcaa2f8d58,,,,,,,
+La formule est un interpolation lineaire : plus l'erreur baisse (bonne progression), plus on augmente le ratio de workers. Utilisez `max()` et `min()` pour borner le résultat.",,,,,,,,8e872f3c8f526334,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,0b6c97d8,code,fr,0ddab84f46dd1ec3,"def adaptive_worker_ratio(current_error: int, initial_error: int, 
                           min_ratio: float = 0.70, max_ratio: float = 0.95) -> float:
     """"""Calcule un worker_ratio adaptatif en fonction de la progression.
@@ -24008,11 +24034,11 @@ print(""| Exploration | Workers + Explorers | Mutation | Temperature |"")
 print(""| Exploitation | Convergence vers gBest | Crossover | Refroidissement |"")
 print(""| Performance Sudoku | ~1-5s | ~1-10s | ~2-5s |"")
 print(""\n**Note**: Ces valeurs sont approximatives et dependent des parametres."")",,,,,,,,e364dd71bf0be76f,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,b243d8f0,markdown,fr,02a7fa69411c9ac1,"### Interpretation : Comparaison des metaheuristiques
+MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,b243d8f0,markdown,fr,28b5cf1ff860652d,"### Interpretation : Comparaison des métaheuristiques
 
-**Sortie obtenue** : Tableau comparatif des caracteristiques de PSO, GA et SA
+**Sortie obtenue** : Tableau comparatif des caractéristiques de PSO, GA et SA
 
-| Aspect | PSO | Algorithme Genetique | Recuit Simule |
+| Aspect | PSO | Algorithme Génétique | Recuit Simule |
 |--------|-----|---------------------|---------------|
 | **Inspiration** | Oiseaux/poissons | Evolution biologique | Thermodynamique |
 | **Population** | Multiple (essaim) | Multiple (generation) | Unique (solution courante) |
@@ -24022,10 +24048,10 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,b243d8f0,markdown,fr,02a7fa69
 
 **Points cles** :
 1. **PSO** se situe entre GA et SA en termes de performance
-2. L'architecture a double role (workers/explorers) offre un bon equilibre
-3. Le choix de la methode depend du type de puzzle et des contraintes de temps
+2. L'architecture a double rôle (workers/explorers) offre un bon equilibre
+3. Le choix de la méthode depend du type de puzzle et des contraintes de temps
 
-> **Note technique** : PSO est particulierement efficace pour les problemes ou l'espace de recherche peut etre partitionne (ici, par blocs 3x3).",,,,,,,,02a7fa69411c9ac1,,,,,,,
+> **Note technique** : PSO est particulierement efficace pour les problemes ou l'espace de recherche peut etre partitionne (ici, par blocs 3x3).",,,,,,,,28b5cf1ff860652d,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,bf6de260,markdown,fr,b53a5c0e94bbfcf5,"## Exercice : Analyse du PSO
 
 ### Exemple 1 : Analyse de convergence
@@ -24036,7 +24062,7 @@ Implementez une adaptation dynamique de `worker_ratio` qui augmente l'exploratio
 
 ### Exemple 3 : Hybride PSO-SA
 Combinez PSO avec le recuit simule : utilisez SA pour affiner les solutions trouvees par PSO.",,,,,,,,b53a5c0e94bbfcf5,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,uci1dzfatl,markdown,fr,1f27e30d5dda4243,"## Exercice : PSO Hybride avec Recherche Locale
+MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,uci1dzfatl,markdown,fr,5fe6ffad4ff7b545,"## Exercice : PSO Hybride avec Recherche Locale
 
 ### Enonce
 
@@ -24045,13 +24071,13 @@ Implementez un solveur **PSO hybride** qui, lorsque le meilleur organisme stagne
 1. `local_search_improve(matrix, problem, max_attempts)` : Pour chaque bloc, essaye tous les echanges de paires de cases libres et garde le meilleur (descente de gradient)
 2. `HybridPSOSudokuSolver` : Etend `PSOSudokuSolver` en detectant la stagnation et en appelant `local_search_improve`
 
-### Resultats attendus
+### Résultats attendus
 
 Le PSO hybride devrait avoir moins de redemarrages et etre plus fiable sur les puzzles difficiles.
 
 **Indice :**
 
-La stagnation se detecte en comptant les epochs sans amelioration de `best_error`. Lorsque ce compteur depasse `stagnation_limit`, appliquer la recherche locale et reinitialiser le compteur.",,,,,,,,1f27e30d5dda4243,,,,,,,
+La stagnation se detecte en comptant les epochs sans amelioration de `best_error`. Lorsque ce compteur depasse `stagnation_limit`, appliquer la recherche locale et reinitialiser le compteur.",,,,,,,,5fe6ffad4ff7b545,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,wys24hodpo,code,fr,1e337d2d2ff29391,"def local_search_improve(matrix: np.ndarray, problem: np.ndarray, max_attempts: int = 100) -> np.ndarray:
     """"""
     Recherche locale intensive : pour chaque bloc, essaye tous les echanges
@@ -24112,31 +24138,31 @@ class HybridPSOSudokuSolver(PSOSudokuSolver):
 # print(f""Hybride: {solved}"")
 
 print(""Exercice PSO hybride a implementer !"")",,,,,,,,1e337d2d2ff29391,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,c6f15b91,markdown,fr,9a2c05676debeda1,"## Resume et perspectives
+MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,c6f15b91,markdown,fr,d6fdd5caa820e58d,"## Resume et perspectives
 
-Ce notebook a implemente le Particle Swarm Optimization (PSO) pour la resolution de Sudoku, avec un encodage par blocs 3x3 qui garantit la validite locale de chaque bloc. L'architecture a double role (Workers pour l'exploitation locale, Explorers pour l'exploration globale) offre un equilibre entre convergence et diversification. Les benchmarks ont montre une grande variabilite : d'environ 2 secondes pour les puzzles faciles a pres de 47 secondes pour les grilles plus contraintes, avec un taux de succes de 2/2 sur le benchmark execute ici. La stagnation frequente a quelques erreurs (2 a 4) illustre la difficulte des metaheuristiques a echapper aux optima locaux sur les problemes fortement contraints.
+Ce notebook a implemente le Particle Swarm Optimization (PSO) pour la resolution de Sudoku, avec un encodage par blocs 3x3 qui garantit la validite locale de chaque bloc. L'architecture a double rôle (Workers pour l'exploitation locale, Explorers pour l'exploration globale) offre un equilibre entre convergence et diversification. Les benchmarks ont montre une grande variabilite : d'environ 2 secondes pour les puzzles faciles a pres de 47 secondes pour les grilles plus contraintes, avec un taux de succes de 2/2 sur le benchmark execute ici. La stagnation frequente a quelques erreurs (2 a 4) illustre la difficulte des métaheuristiques a echapper aux optima locaux sur les problemes fortement contraints.
 
-L'analyse des parametres (taille de l'essaim, nombre d'epochs, redemarrages) a montre que la configuration ""Conservatrice"" suffit souvent pour les puzzles faciles, tandis que les puzzles difficiles necessitent une configuration ""Agressive"" avec un cout temporel significatif. L'exercice propose sur le PSO hybride avec recherche locale vise precisement a resoudre le probleme de stagnation en combinant l'exploration globale de l'essaim avec une descente de gradient locale.
+L'analyse des paramètres (taille de l'essaim, nombre d'epochs, redemarrages) a montre que la configuration ""Conservatrice"" suffit souvent pour les puzzles faciles, tandis que les puzzles difficiles necessitent une configuration ""Agressive"" avec un cout temporel significatif. L'exercice propose sur le PSO hybride avec recherche locale vise précisément a resoudre le problème de stagnation en combinant l'exploration globale de l'essaim avec une descente de gradient locale.
 
-Le notebook suivant, [Sudoku-6-AIMA-CSP-Python](Sudoku-6-AIMA-CSP-Python.ipynb), aborde une approche deterministe : la programmation par contraintes (CSP) selon le cadre academique AIMA, avec les algorithmes AC-3, Forward Checking et MAC qui garantissent la resolution complete.",,,,,,,,9a2c05676debeda1,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,66458d28,markdown,fr,f666811350cffb7c,"## Resume
+Le notebook suivant, [Sudoku-6-AIMA-CSP-Python](Sudoku-6-AIMA-CSP-Python.ipynb), aborde une approche déterministe : la programmation par contraintes (CSP) selon le cadre academique AIMA, avec les algorithmes AC-3, Forward Checking et MAC qui garantissent la resolution complete.",,,,,,,,d6fdd5caa820e58d,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,66458d28,markdown,fr,e9b2ab169a808bcf,"## Resume
 
 ### Concepts cles
 
 | Concept | Description |
 |---------|-------------|
-| **PSO** | Metaheuristique d'essaim inspiree des oiseaux |
+| **PSO** | Métaheuristique d'essaim inspiree des oiseaux |
 | **Particules** | Solutions candidates avec position et vitesse |
 | **pBest/gBest** | Meilleures positions personnelle et globale |
 | **Workers** | Exploitent leur voisinage (90% de l'essaim) |
 | **Explorers** | Explorent aleatoirement (10% de l'essaim) |
 
-### Parametres cles
+### Paramètres cles
 
-| Parametre | Effet | Valeur recommandee |
+| Paramètre | Effet | Valeur recommandee |
 |-----------|-------|-------------------|
 | NumOrganisms | Taille de l'essaim | 100-300 |
-| MaxEpochs | Iterations par essai | 3000-5000 |
+| MaxEpochs | Itérations par essai | 3000-5000 |
 | MaxRestarts | Redemarrages autorises | 10-20 |
 | WorkerRatio | Proportion de workers | 0.85-0.95 |
 | MaxAge | Age max avant reinit | 500-1000 |
@@ -24147,13 +24173,13 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,66458d28,markdown,fr,f6668113
 |-----------|---------------|
 | Parallelisation naturelle | Pas de garantie de convergence |
 | Equilibre exploration/exploitation | Performance variable selon puzzles |
-| Conceptuellement simple | Parametres a ajuster |
+| Conceptuellement simple | Paramètres a ajuster |
 
 ### Quand l'utiliser
 
 - Puzzles moyens (pas trop difficiles)
 - Quand on veut plusieurs solutions candidates
-- Pour comprendre les metaheuristiques d'essaim
+- Pour comprendre les métaheuristiques d'essaim
 
 ### Alternatives recommandees
 
@@ -24163,7 +24189,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb,66458d28,markdown,fr,f6668113
 
 ---
 
-**Navigation** : [<< Sudoku-4-SimulatedAnnealing](Sudoku-4-SimulatedAnnealing-Python.ipynb) | [Index](README.md) | [Sudoku-6-AIMA-CSP >>](Sudoku-6-AIMA-CSP-Python.ipynb)",,,,,,,,f666811350cffb7c,,,,,,,
+**Navigation** : [<< Sudoku-4-SimulatedAnnealing](Sudoku-4-SimulatedAnnealing-Python.ipynb) | [Index](README.md) | [Sudoku-6-AIMA-CSP >>](Sudoku-6-AIMA-CSP-Python.ipynb)",,,,,,,,e9b2ab169a808bcf,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb,0bdd0851,markdown,fr,b236bb5ce8d98a35,"# Sudoku-6 : Résolution par CSP Académique (AIMA)
 
 **Niveau** : Programmation par Contraintes
@@ -24182,13 +24208,13 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb,0bdd0851,markdown,fr,b23
 | << Précédent | [Index](./README.md) | Suivant >> |
 |-------------|---------------------|-----------|
 | [Sudoku-5-PSO](Sudoku-5-PSO-Csharp.ipynb) | | [Sudoku-7-Norvig-Csharp](Sudoku-7-Norvig-Csharp.ipynb) |",,,,,,,,b236bb5ce8d98a35,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb,15134a98,markdown,fr,add7210bd17f0084,"## 1. Introduction : Le cadre AIMA
+MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb,15134a98,markdown,fr,5567eecf17a5f271,"## 1. Introduction : Le cadre AIMA
 
 Ce notebook présente la résolution de Sudoku selon l'approche académique décrite dans **""Artificial Intelligence: A Modern Approach""** (Russell & Norvig, 4e édition, Chapitre 6).
 
 ### Pourquoi cette approche ?
 
-Contrairement aux bibliothèques industrielles (OR-Tools, Choco) ou aux metaheuristiques (GA, SA, PSO), l'approche AIMA :
+Contrairement aux bibliothèques industrielles (OR-Tools, Choco) ou aux métaheuristiques (GA, SA, PSO), l'approche AIMA :
 - **Est pédagogique** : chaque composant est transparent et compréhensible
 - **Est modulaire** : on peut combiner différentes heuristiques et propagations
 - **Sert de référence** : c'est le standard académique pour comparer les algorithmes
@@ -24209,7 +24235,7 @@ Contrairement aux bibliothèques industrielles (OR-Tools, Choco) ou aux metaheur
 | **Backtracking + MRV** | Heuristique | Variable | Moderee
 | **Forward Checking** | Propagation 1-niveau | $O(n \cdot d^2)$ | Moderee
 | **AC-3** | Arc-consistance | $O(e \cdot d^3)$ | Forte
-| **MAC** | AC-3 + Backtracking | Variable | Très forte",,,,,,,,add7210bd17f0084,,,,,,,
+| **MAC** | AC-3 + Backtracking | Variable | Très forte",,,,,,,,5567eecf17a5f271,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb,edb9f15b,code,fr,eb3d945ae449b902,#!import Sudoku-0-Environment-Csharp.ipynb,,,,,,,,eb3d945ae449b902,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb,89c6543d,markdown,fr,c70901498df35465,"## 2. Classe CSP générique
 
@@ -24859,7 +24885,7 @@ Console.WriteLine($""\nSolution (MAC): {solver.SolveTimeMs}ms, {solver.NumAssign
 display(solution.ToString());
 Console.WriteLine($""\nSolution valide: {solution.IsValid(originalPuzzle)}"");
 ",,,,,,,,f309d35b0ae18bf6,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb,bcf1ae7f,markdown,fr,dae8b518acab1949,"### Demo avant/après : un même puzzle, deux etats
+MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb,bcf1ae7f,markdown,fr,5020de2573deda2b,"### Demo avant/après : un même puzzle, deux etats
 
 Le même puzzle est présente deux fois dans ce notebook, ce qui materialise la transformation par le solveur :
 
@@ -24868,7 +24894,7 @@ Le même puzzle est présente deux fois dans ce notebook, ce qui materialise la 
 | **Avant** (puzzle original) | `eab76f35` | 51 cellules vides sur 81, 30 valeurs imposees -- une grille ""facile"" du dataset AIMA |
 | **Après** (solution MAC) | `8a2e903f` | Grille complète valide (81/81 cellules), `IsValid = True` |
 
-Notez la rapidité de MAC sur ce puzzle isole : **46 ms** et **81 assignations**, **0 backtrack** (sortie de la cellule `8a2e903f` lors de l'execution cell-by-cell par `dotnet_executor.py`). La consistance d'arc a résolu la grille sans aucune impasse : chaque assignation était des le départ la bonne, parce que la propagation AC-3 a éliminé les valeurs incompatibles des domaines avant que le solveur n'ait à les essayer.",,,,,,,,dae8b518acab1949,,,,,,,
+Notez la rapidité de MAC sur ce puzzle isole : **46 ms** et **81 assignations**, **0 backtrack** (sortie de la cellule `8a2e903f` lors de l'exécution cell-by-cell par `dotnet_executor.py`). La consistance d'arc a résolu la grille sans aucune impasse : chaque assignation était des le départ la bonne, parce que la propagation AC-3 a éliminé les valeurs incompatibles des domaines avant que le solveur n'ait à les essayer.",,,,,,,,5020de2573deda2b,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb,552dd8ca,code,fr,fcf8291edcd33452,"// Comparaison des 3 strategies a heuristiques sur 3 puzzles faciles.
 // Backtracking simple est evalue separement ci-dessous (borne a 2 puzzles
 // pour rester sous ~60s/cellule comme specifie par le dispatch #4940).
@@ -25036,13 +25062,13 @@ public static class ConflictBackjumping
 // Console.WriteLine($""CBJ: {solution != null}"");
 
 Console.WriteLine(""ConflictBackjumping à implémenter !"");",,,,,,,,4c794174a250be55,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb,339cfefc,markdown,fr,6e24d074a17069b3,"## Résumé et perspectives
+MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb,339cfefc,markdown,fr,50c4d850e1bf5232,"## Résumé et perspectives
 
 Ce notebook a transposé en C# le cadre académique AIMA pour la résolution de Sudoku par programmation par contraintes. La classe générique `CSP<TVariable, TValue>` a permis d'implémenter quatre algorithmes de complexité croissante : le backtracking simple (~2,9 millions d'assignations sur 2 puzzles bornes), le backtracking améliore MRV+LCV (366 assignations sur 3 puzzles), le Forward Checking (91 assignations) et le MAC (86 assignations, 5 backtracks). Le benchmark borne pour rester sous ~60s/cellule (#4940) confirme que MAC est le plus robuste avec un minimum de retours en arrière, tandis que Forward Checking est le plus rapide sur les instances faciles grâce à son overhead réduit.
 
-L'implementation des heuristiques MRV (sélection de la variable la plus contrainte) et LCV (ordonnancement des valeurs les moins contraignantes) a illustré les principes ""fail-first"" et ""succeed-first"" fondamentaux en recherche combinatoire. L'exercice CBJ (Conflict-Based Backjumping) complète cette étude en proposant d'implémenter un mecanisme de remontee directe vers la variable responsable d'un conflit, evitant ainsi les retours en arrière chronologiques inutiles.
+L'implementation des heuristiques MRV (sélection de la variable la plus contrainte) et LCV (ordonnancement des valeurs les moins contraignantes) a illustré les principes ""fail-first"" et ""succeed-first"" fondamentaux en recherche combinatoire. L'exercice CBJ (Conflict-Based Backjumping) complète cette étude en proposant d'implémenter un mécanisme de remontee directe vers la variable responsable d'un conflit, evitant ainsi les retours en arrière chronologiques inutiles.
 
-Le notebook suivant, [Sudoku-7-Norvig-Csharp](Sudoku-7-Norvig-Csharp.ipynb), présente l'approche de Peter Norvig qui combine propagation de contraintes (naked singles, hidden singles) et recherche pour une résolution élégante et performante.",,,,,,,,6e24d074a17069b3,,,,,,,
+Le notebook suivant, [Sudoku-7-Norvig-Csharp](Sudoku-7-Norvig-Csharp.ipynb), présente l'approche de Peter Norvig qui combine propagation de contraintes (naked singles, hidden singles) et recherche pour une résolution élégante et performante.",,,,,,,,50c4d850e1bf5232,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb,b265202c,markdown,fr,4fe9bcb2b8dc42a2,"## Exercice : Implementer CBJ (Conflict-Based Backjumping)
 
 ### Enonce
@@ -25075,7 +25101,7 @@ public static class ConflictBackjumping
 ### Test attendu
 
 Tester sur les puzzles difficiles : CBJ devrait explorer significativement moins de noeuds que le backtracking MRV+LCV.",,,,,,,,4fe9bcb2b8dc42a2,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb,a4b30559,markdown,fr,92c805cb529b473e,"## Recapitulatif
+MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb,a4b30559,markdown,fr,6caf0ef783ce58d2,"## Recapitulatif
 
 ### Algorithmes implémentés
 
@@ -25088,7 +25114,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb,a4b30559,markdown,fr,92c
 
 ### Heuristiques
 
-| Heuristique | Role | Effet
+| Heuristique | Rôle | Effet
 |-------------|------|------
 | **MRV** | Sélection de variable | Fail-first
 | **LCV** | Ordonnancement valeurs | Succeed-first
@@ -25113,8 +25139,8 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb,a4b30559,markdown,fr,92c
 
 | << Précédent | [Index](./README.md) | Suivant >> |
 |-------------|---------------------|-----------|
-| [Sudoku-5-PSO](Sudoku-5-PSO-Csharp.ipynb) | | [Sudoku-7-Norvig-Csharp](Sudoku-7-Norvig-Csharp.ipynb) |",,,,,,,,92c805cb529b473e,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb,71960cdb,markdown,fr,e797001e0218edb0,"# Sudoku-6 : Résolution par CSP Académique (Python)
+| [Sudoku-5-PSO](Sudoku-5-PSO-Csharp.ipynb) | | [Sudoku-7-Norvig-Csharp](Sudoku-7-Norvig-Csharp.ipynb) |",,,,,,,,6caf0ef783ce58d2,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb,71960cdb,markdown,fr,8881fb575310ce28,"# Sudoku-6 : Résolution par CSP Académique (Python)
 
 **Niveau** : Programmation par Contraintes | **Durée** : ~25 min | **Prérequis** : Sudoku-0 Environment
 
@@ -25138,7 +25164,7 @@ Ce notebook présente la résolution de Sudoku selon l'approche académique déc
 
 ## Introduction
 
-Contrairement aux bibliothèques industrielles (OR-Tools, Choco) ou aux metaheuristiques (GA, SA, PSO), l'approche AIMA :
+Contrairement aux bibliothèques industrielles (OR-Tools, Choco) ou aux métaheuristiques (GA, SA, PSO), l'approche AIMA :
 - **Est pédagogique** : chaque composant est transparent et compréhensible
 - **Est modulaire** : on peut combiner différentes heuristiques et propagations
 - **Sert de référence** : c'est le standard académique pour comparer les algorithmes
@@ -25159,7 +25185,7 @@ Contrairement aux bibliothèques industrielles (OR-Tools, Choco) ou aux metaheur
 | **Backtracking + MRV** | Heuristique | Variable | Moderee |
 | **Forward Checking** | Propagation 1-niveau | $O(n \cdot d^2)$ | Moderee |
 | **AC-3** | Arc-consistance | $O(e \cdot d^3)$ | Forte |
-| **MAC** | AC-3 + Backtracking | Variable | Très forte |",,,,,,,,e797001e0218edb0,,,,,,,
+| **MAC** | AC-3 + Backtracking | Variable | Très forte |",,,,,,,,8881fb575310ce28,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb,537fe538,code,fr,31da0bb98ce803e3,"# Imports
 import numpy as np
 import time
@@ -25631,11 +25657,11 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb,9f95b034,code,fr,d1f9910
         return None
 
 print(""ForwardChecking defini."")",,,,,,,,d1f9910aa9451e98,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb,728b8070,markdown,fr,684154c8548cda4d,"## Exercice : Analyse pas-à-pas de la propagation Forward Checking
+MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb,728b8070,markdown,fr,96ac1b2b11025491,"## Exercice : Analyse pas-à-pas de la propagation Forward Checking
 
 ### Objectif
 
-Implémentez la fonction `analyze_fc_propagation` qui simule et affiche les étapes de reduction de domaine lorsqu'on assigné une valeur à une cellule donnée, en suivant le mecanisme du Forward Checking.
+Implémentez la fonction `analyze_fc_propagation` qui simule et affiche les étapes de reduction de domaine lorsqu'on assigné une valeur à une cellule donnée, en suivant le mécanisme du Forward Checking.
 
 Cet exercice vous permettra de visualiser concretement comment le Forward Checking elague l'espace de recherche : à chaque assignation, les domaines des voisins sont réduits, et les domaines vides signalent un échec précoce.
 
@@ -25652,7 +25678,7 @@ Cet exercice vous permettra de visualiser concretement comment le Forward Checki
 - `ForwardChecking.propagate(csp, var, val, assignment, current_domains)` retourne `(removals, success)`
 - `removals` est une liste de tuples `(neighbor, value_retiree)`
 - Utilisez `defaultdict(list)` pour regrouper les retraits par voisin
-- Comparez la taille des domaines avant et après propagation pour mesurer l'impact",,,,,,,,684154c8548cda4d,,,,,,,
+- Comparez la taille des domaines avant et après propagation pour mesurer l'impact",,,,,,,,96ac1b2b11025491,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb,901f7da3,code,fr,cb5135246093c821,"def analyze_fc_propagation(grid: SudokuGrid, var: Tuple[int, int], val: int) -> None:
     """"""Analyse et affiche la reduction de domaine par Forward Checking.
     
@@ -25934,11 +25960,11 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb,69cef42b,markdown,fr,bde
 1. **MRV** est l'heuristique la plus impactante (reduction souvent > 10x)
 2. **FC** ajoute un gain significatif en détectant les échecs plus tot
 3. **MAC** est optimal mais plus couteux par noeud (AC-3 à chaque pas)",,,,,,,,bde752edc9228082,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb,e34035b8,markdown,fr,14edda6f0995edae,"## Exemple cautionnaire : CBJ (Conflict-Based Backjumping)
+MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb,e34035b8,markdown,fr,c2c805df1609ed49,"## Exemple cautionnaire : CBJ (Conflict-Based Backjumping)
 
 ### Principe
 
-Le **CBJ** (Conflict-Based Backjumping) est un algorithme qui remonte directement au niveau responsable d'un conflit au lieu de faire du backtracking chronologique. En theorie, cette approche devrait accélérer la résolution en evitant d'explorer des branches inutiles.
+Le **CBJ** (Conflict-Based Backjumping) est un algorithme qui remonte directement au niveau responsable d'un conflit au lieu de faire du backtracking chronologique. En théorie, cette approche devrait accélérer la résolution en evitant d'explorer des branches inutiles.
 
 **Attention** : comme nous allons le voir, CBJ illustré un piège classique en IA -- un algorithme theoretiquement superieur qui ne l'est pas toujours en pratique. L'étude de ce cas vous aidera à comprendre pourquoi le choix d'un algorithme dépend fortement du problème.
 
@@ -25954,7 +25980,7 @@ L'implementation ci-dessous illustré les points clés de l'algorithme :
 Sur les puzzles faciles, CBJ avec MRV fonctionne bien (peu d'assignations). Mais sur les puzzles **difficiles**, le backjumping seul ne compense pas l'absence de propagation de contraintes (Forward Checking, AC-3) : c'est une limite connue de CBJ. Le benchmark ci-dessous porte sur des puzzles faciles, ou CBJ converge ; il illustré que **le backjumping seul ne suffit pas** -- il faut le combiner avec des heuristiques de sélection de variable ET de propagation de contraintes.
 
 **Lecon** : ne jugez pas un algorithme seulement sur des instances faciles. Un algorithme qui semble efficace sur des problèmes simples peut echouer sur des instances plus difficiles ou la propagation de contraintes est determinante.
-",,,,,,,,14edda6f0995edae,,,,,,,
+",,,,,,,,c2c805df1609ed49,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb,1850070a,code,fr,e2c8e973032b91f1,"class ConflictBackjumping:
     """"""Conflict-Based Backjumping (CBJ) pedagogique, inspire de Prosser (1993).
 
@@ -26127,13 +26153,13 @@ print(""="" * 80)
 # la sélection MRV statique. MAC et Forward Checking restent superieurs grâce à la
 # propagation. Le vrai gain du CBJ se manifeste sur les CSP non-binaires ou quand
 # les backtracks chronologiques explorent des branches eloignees du vrai conflit.",,,,,,,,644bd79b1780e7da,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb,69fac6e4,markdown,fr,618ae44a1353d59f,"## Exercice : Comparaison Forward Checking vs MAC sur le Coloriage de Graphe
+MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb,69fac6e4,markdown,fr,ee970b9dc947e864,"## Exercice : Comparaison Forward Checking vs MAC sur le Coloriage de Graphe
 
 ### Enonce
 
 Le **coloriage de graphe** est un CSP classique : attribuer une couleur à chaque sommet d'un graphe tel que deux sommets adjacents n'aient jamais la même couleur. C'est un problème fondamental en IA avec des applications en planification, allocation de ressources et registres CPU.
 
-Contrairement au Sudoku (grille structuree), le coloriage de graphe offre des topologies variées qui mettent en evidence les differences entre Forward Checking et MAC de manière plus ou moins prononcée selon la densite du graphe.
+Contrairement au Sudoku (grille structuree), le coloriage de graphe offre des topologies variées qui mettent en evidence les différences entre Forward Checking et MAC de manière plus ou moins prononcée selon la densite du graphe.
 
 ### Objectif
 
@@ -26153,7 +26179,7 @@ Implémentez la fonction `solve_graph_coloring` qui resout un problème de color
 
 - Utilisez la classe `CSP` existante avec `constraint_func = lambda v1, val1, v2, val2: val1 != val2`
 - La méthode `generate_random_graph(n, edge_prob)` génère un graphe aléatoire (modèle Erdos-Renyi)
-- Un graphe avec `edge_prob=0.3` et 15 sommets est un bon point de départ pour 3 couleurs",,,,,,,,618ae44a1353d59f,,,,,,,
+- Un graphe avec `edge_prob=0.3` et 15 sommets est un bon point de départ pour 3 couleurs",,,,,,,,ee970b9dc947e864,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb,6452d7ef,code,fr,b2ba5d09c0a340e1,"import random
 
 def generate_random_graph(n: int, edge_prob: float, seed: int = 42) -> Dict[int, List[int]]:
@@ -26230,7 +26256,7 @@ Ce notebook a formalisé le Sudoku comme un problème de satisfaction de contrai
 L'étude du Conflict-Based Backjumping (CBJ) a fourni un exemple cautionnaire instructif : bien que théoriquement superieur au backtracking chronologique, CBJ sans propagation de contraintes ne surpasse pas Forward Checking ou MAC sur les puzzles difficiles. Cette observation rappelle que le choix d'un algorithme ne se juge pas sur les instances faciles seul. L'exercice sur le coloriage de graphe permet de transferer ces compétences vers un autre CSP classique avec des topologies variees.
 
 Le notebook suivant, [Sudoku-7-Norvig-Python](Sudoku-7-Norvig-Python.ipynb), présente l'approche de Peter Norvig, qui combine la propagation de contraintes (elimination et unique candidat restant) avec une recherche en profondeur pour résoudre efficacement tout Sudoku.",,,,,,,,b83f03bcde6886e7,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb,ebb356b0,markdown,fr,025bf7bcffe85fde,"## Résumé
+MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb,ebb356b0,markdown,fr,a6bb2aefd3ba6839,"## Résumé
 
 ### Algorithmes implémentés
 
@@ -26243,7 +26269,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb,ebb356b0,markdown,fr,025
 
 ### Heuristiques
 
-| Heuristique | Role | Effet |
+| Heuristique | Rôle | Effet |
 |-------------|------|-------|
 | **MRV** | Sélection de variable | Fail-first |
 | **LCV** | Ordonnancement valeurs | Succeed-first |
@@ -26263,7 +26289,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb,ebb356b0,markdown,fr,025
 
 ---
 
-**Navigation** : [<< Sudoku-5-PSO](Sudoku-5-PSO-Python.ipynb) | [Index](README.md) | [Sudoku-7-Norvig >>](Sudoku-7-Norvig-Python.ipynb)",,,,,,,,025bf7bcffe85fde,,,,,,,
+**Navigation** : [<< Sudoku-5-PSO](Sudoku-5-PSO-Python.ipynb) | [Index](README.md) | [Sudoku-7-Norvig >>](Sudoku-7-Norvig-Python.ipynb)",,,,,,,,a6bb2aefd3ba6839,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,4cfgcd822ht,markdown,fr,87d13006d69774c6,"# Sudoku-7 : Résolution par Propagation de Contraintes (Norvig)
 
 **Navigation** : [<< Sudoku-6 AIMA-CSP](Sudoku-6-AIMA-CSP-Csharp.ipynb) | [Index](README.md) | [Sudoku-8 HumanStrategies >>](Sudoku-8-HumanStrategies-Csharp.ipynb)
@@ -26286,15 +26312,15 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,4cfgcd822ht,markdown,fr,87
 - Voir [CSP-2-Consistance](../Search/Part2-CSP/CSP-2-Consistency.ipynb) pour la théorie de la propagation de contraintes
 - [Article original de Peter Norvig (2006)](http://norvig.com/sudoku.html)
 ",,,,,,,,87d13006d69774c6,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,o7i8tiz7apq,markdown,fr,5d1b4edb09cebe7c,"## 1. Introduction
+MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,o7i8tiz7apq,markdown,fr,14837ec221776cf9,"## 1. Introduction
 
 En 2006, Peter Norvig a publié un article devenu célèbre dans lequel il présente un solveur de Sudoku remarquablement concis et performant. L'idée centrale est la suivante : **la propagation de contraintes suffit à résoudre la plupart des grilles de Sudoku sans aucune recherche**.
 
 Le solveur repose sur deux stratégies de propagation :
 
-| Strategie | Description | Equivalent CSP |
+| Stratégie | Description | Equivalent CSP |
 |-----------|-------------|----------------|
-| **Élimination** | Si une cellule a une valeur assignée, retirer cette valeur de tous ses voisins (meme ligne, colonne, boite) | Arc-consistency |
+| **Élimination** | Si une cellule a une valeur assignée, retirer cette valeur de tous ses voisins (même ligne, colonne, boite) | Arc-consistency |
 | **Hidden single** (seul emplacement) | Si dans une unité (ligne, colonne ou boite), une valeur n'a qu'un seul emplacement possible, l'y assigner | Hidden single |
 
 Lorsque la propagation seule ne suffit pas (typiquement sur les grilles difficiles), un mécanisme de **recherche récursive avec backtracking** prend le relais. L'heuristique **MRV** (Minimum Remaining Values) guide le choix de la prochaine cellule à explorer : on choisit celle qui a le moins de candidats, ce qui réduit l'arbre de recherche.
@@ -26302,7 +26328,7 @@ Lorsque la propagation seule ne suffit pas (typiquement sur les grilles difficil
 ### Importation des classes de base
 
 Nous importons les classes définies dans le notebook d'environnement.
-",,,,,,,,5d1b4edb09cebe7c,,,,,,,
+",,,,,,,,14837ec221776cf9,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,zunydfk37jp,code,fr,eb3d945ae449b902,#!import Sudoku-0-Environment-Csharp.ipynb,,,,,,,,eb3d945ae449b902,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,4mpi8aild85,markdown,fr,172d56e9c4f76591,"Verifions que l'environnement est bien charge en affichant un puzzle de chaque difficulte.
 ",,,,,,,,172d56e9c4f76591,,,,,,,
@@ -26837,15 +26863,15 @@ var hard = SudokuHelper.GetSudokus(SudokuDifficulty.Hard).First();
 Console.WriteLine(""\n=== Puzzle Difficile ==="");
 SudokuHelper.SolveSudoku(hard, norvigSolver);
 display($""Appels de recherche : {norvigSolver.SearchCalls}, Resolu par propagation seule : {norvigSolver.PropagationOnlySolved == 1}"");",,,,,,,,fdbc18c79d14decf,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,zgehgizqtgc,markdown,fr,eaf3dfdcc79cd0cd,"### Interpretation : efficacite du solveur Norvig
+MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,zgehgizqtgc,markdown,fr,a9f8bc310d0c4b0f,"### Interpretation : efficacite du solveur Norvig
 
 Le solveur Norvig résout avec succès les grilles de toutes les difficultes. Les points clés à observer :
 
 - **Puzzles faciles** : resolus par propagation seule (0 appels de recherche)
 - **Puzzles difficiles** : la recherche récursive est activee mais avec très peu d'appels grace au MRV et a la propagation qui élague l'arbre
 
-Le nombre d'appels de recherche est généralement de l'ordre de quelques dizaines, meme pour les grilles les plus difficiles, contre des milliers pour le backtracking simple du notebook Sudoku-1.
-",,,,,,,,eaf3dfdcc79cd0cd,,,,,,,
+Le nombre d'appels de recherche est généralement de l'ordre de quelques dizaines, même pour les grilles les plus difficiles, contre des milliers pour le backtracking simple du notebook Sudoku-1.
+",,,,,,,,a9f8bc310d0c4b0f,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,io63xp9eu2c,markdown,fr,0d5e5367be783faf,"## 5. Tests de performance et comparaison
 
 Nous allons maintenant comparer le solveur Norvig avec le solveur par backtracking simple (Sudoku-1) sur l'ensemble des fichiers de puzzles, en utilisant `SudokuHelper.TestSolvers` et `SudokuHelper.DisplayResults`.
@@ -26939,13 +26965,13 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,znkx90fazem,markdown,fr,5c
 
 > **Note** : pour une comparaison avec d'autres approches, voir les notebooks Sudoku-10 (OR-Tools), Sudoku-12 (Z3) et Sudoku-2 (Dancing Links).
 ",,,,,,,,5ccaf8979aa09827,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,i4cpzhzc0qp,markdown,fr,25e5f215d910c4be,"## 6. Exemple guide
+MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,i4cpzhzc0qp,markdown,fr,754da2500589c5c0,"## 6. Exemple guide
 
 ### Exemple guide 1 : Detection des paires nues (naked pairs)
 
 La propagation de Norvig utilise deux stratégies (élimination + naked single). On peut l'ameliorer en ajoutant la detection des **paires nues** (naked pairs) :
 
-> Si deux cellules d'une meme unité ont exactement les memes deux candidats {a, b}, alors a et b peuvent etre retires des candidats de toutes les autres cellules de cette unité.
+> Si deux cellules d'une même unité ont exactement les mêmes deux candidats {a, b}, alors a et b peuvent etre retires des candidats de toutes les autres cellules de cette unité.
 
 **A faire** : modifier la méthode `Eliminate` de `NorvigPropagation` pour ajouter cette troisième règle de propagation. Tester l'impact sur le nombre d'appels de recherche.
 
@@ -26953,7 +26979,7 @@ La propagation de Norvig utilise deux stratégies (élimination + naked single).
 // Indice : dans la méthode Eliminate, après la règle 2, ajouter :
 // Règle 3 : naked pairs
 // Pour chaque unité contenant la cellule :
-//   Chercher les paires de cellules ayant exactement les memes 2 candidats
+//   Chercher les paires de cellules ayant exactement les mêmes 2 candidats
 //   Si trouvee, eliminer ces 2 valeurs des autres cellules de l'unité
 ```
 
@@ -26962,7 +26988,7 @@ La propagation de Norvig utilise deux stratégies (élimination + naked single).
 Ecrire un programme qui parcourt les fichiers de puzzles et compte combien sont resolus par propagation seule (sans aucun appel de recherche).
 
 **A faire** : completer le code ci-dessous.
-",,,,,,,,25e5f215d910c4be,,,,,,,
+",,,,,,,,754da2500589c5c0,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,v9jjp42kq5a,code,fr,200f65d3835243a7,"// Exemple guide 2 : compter les puzzles resolus par propagation seule
 // Completer le code ci-dessous
 
@@ -26984,13 +27010,13 @@ foreach (var difficulty in new[] { SudokuDifficulty.Easy, SudokuDifficulty.Mediu
 
     display($""{difficulty} : {solvedByPropagationOnly}/{totalPuzzles} resolus par propagation seule"");
 }",,,,,,,,200f65d3835243a7,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,qdxuwc0yx2b,markdown,fr,57eae668b408daa6,"## Conclusion
+MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,qdxuwc0yx2b,markdown,fr,d4d8b08bd82068b3,"## Conclusion
 
 Ce notebook a présenté l'approche de Peter Norvig pour la résolution de Sudoku, combinant propagation de contraintes et recherche récursive.
 
 ### Récapitulatif
 
-| Composant | Role | Inspiration théorique |
+| Composant | Rôle | Inspiration théorique |
 |-----------|------|----------------------|
 | Élimination | Retirer les valeurs assignées des voisins | Arc-consistance (CSP) |
 | Hidden single | Assigner une valeur qui n'a qu'un emplacement dans une unité | Consistance de domaine |
@@ -27007,15 +27033,15 @@ Ce notebook a présenté l'approche de Peter Norvig pour la résolution de Sudok
 ### Pour aller plus loin
 
 - **Techniques de propagation avancées** : paires nues, triples nus, X-wing, swordfish (voir Exercice 1)
-- **Theorie de la propagation** : voir [CSP-2-Consistance](../Search/Part2-CSP/CSP-2-Consistency.ipynb) pour une présentation formelle de l'arc-consistance et des algorithmes AC-3, MAC
-- **Comparaison avec les solveurs spécialisés** : OR-Tools (Sudoku-10) et Dancing Links (Sudoku-2) utilisent des mécanismes differents mais reposent aussi sur la propagation de contraintes
+- **Théorie de la propagation** : voir [CSP-2-Consistance](../Search/Part2-CSP/CSP-2-Consistency.ipynb) pour une présentation formelle de l'arc-consistance et des algorithmes AC-3, MAC
+- **Comparaison avec les solveurs spécialisés** : OR-Tools (Sudoku-10) et Dancing Links (Sudoku-2) utilisent des mécanismes différents mais reposent aussi sur la propagation de contraintes
 
 ### Ressources
 
 - [Peter Norvig - Solving Every Sudoku Puzzle (2006)](http://norvig.com/sudoku.html)
 - [Repository de référence : Sudoku.Norvig](https://github.com/jsboigeEpita/2024-EPITA-SCIA-PPC-Sudoku-NLP)
 - Russell & Norvig, *Artificial Intelligence: A Modern Approach*, Chapitre 6 (CSP)
-",,,,,,,,57eae668b408daa6,,,,,,,
+",,,,,,,,d4d8b08bd82068b3,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Python.ipynb,67435a9a,markdown,fr,616b5fec3d13eff8,"# Sudoku-7 : Résolution par Propagation de Contraintes (Norvig) (Python)
 
 **Niveau** : Programmation par contraintes | **Durée** : ~20 min | **Prérequis** : Sudoku-6 AIMA-CSP (Python)
@@ -27265,14 +27291,14 @@ hard = load_puzzles(str(PUZZLES_DIR / 'Sudoku_hardest.txt'))
 
 benchmark(easy, 'Puzzles Faciles')
 benchmark(hard, 'Puzzles Difficiles')",,,,,,,,56e8d81570df0b20,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Python.ipynb,162evydrpdu,markdown,fr,95f8b2bdfcf6c196,"### Interpretation : Benchmark du solveur Norvig
+MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Python.ipynb,162evydrpdu,markdown,fr,028d94c84dc583d1,"### Interpretation : Benchmark du solveur Norvig
 
-Les resultats du benchmark montrent l'efficacite de l'approche de Norvig.
+Les résultats du benchmark montrent l'efficacite de l'approche de Norvig.
 
 | Type de puzzle | Temps moyen | Taux de succes | Analyse |
 |----------------|-------------|----------------|---------|
 | **Faciles** | 2.07 ms | 100% (20/20) | Resolution quasi-instantanee |
-| **Difficiles** | 2.82 ms | 100% (11/11) | Peu de difference faciles/difficiles |
+| **Difficiles** | 2.82 ms | 100% (11/11) | Peu de différence faciles/difficiles |
 
 **Points cles** :
 1. **Performance constante** : La difficulte du puzzle n'impacte que marginalement le temps
@@ -27280,12 +27306,12 @@ Les resultats du benchmark montrent l'efficacite de l'approche de Norvig.
 3. **Code compact** : Environ 80 lignes de Python pour un solveur complet
 
 > **Note technique** : La cle de la performance est la combinaison de la propagation (assign/eliminate) avec le backtracking intelligent (MRV). La propagation resout souvent la majeure partie du puzzle avant que le backtracking ne soit necessaire.
-",,,,,,,,95f8b2bdfcf6c196,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Python.ipynb,ex-hidden-singles,markdown,fr,f798fe8af15dd4bd,"## Exercice : Detection des singletons caches (Hidden Singles)
+",,,,,,,,028d94c84dc583d1,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Python.ipynb,ex-hidden-singles,markdown,fr,be35eee78d104f15,"## Exercice : Detection des singletons caches (Hidden Singles)
 
 ### Enonce
 
-La technique des **singletons caches** (Hidden Singles) est une heuristique de propagation complementaire a l'assign/eliminate de Norvig. Si un chiffre `d` ne peut apparaitre que dans **une seule case** d'une unite (ligne, colonne ou bloc), alors `d` doit etre assigne a cette case, meme si d'autres candidats sont encore possibles.
+La technique des **singletons caches** (Hidden Singles) est une heuristique de propagation complementaire a l'assign/eliminate de Norvig. Si un chiffre `d` ne peut apparaitre que dans **une seule case** d'une unite (ligne, colonne ou bloc), alors `d` doit etre assigne a cette case, même si d'autres candidats sont encore possibles.
 
 **Exemple** : Si dans la ligne A, seul `A3` peut contenir le chiffre `7` (tous les autres `A1, A2, A4...` ont elimine `7`), alors `A3 = 7` est force.
 
@@ -27293,11 +27319,11 @@ Implementez la fonction `hidden_singles(values)` qui parcourt toutes les unites 
 
 ### Indices
 
-- Etape 1 : Pour chaque unite de `unitlist` et chaque chiffre `d` de 1 a 9
-- Etape 2 : Collectez les cases de l'unite ou `d` est encore candidat
-- Etape 3 : Si une seule case peut contenir `d`, assignez `d` a cette case avec `assign(values, s, d)`
-- Etape 4 : Retournez `True` si au moins une assignation, `False` sinon
-",,,,,,,,f798fe8af15dd4bd,,,,,,,
+- Étape 1 : Pour chaque unite de `unitlist` et chaque chiffre `d` de 1 a 9
+- Étape 2 : Collectez les cases de l'unite ou `d` est encore candidat
+- Étape 3 : Si une seule case peut contenir `d`, assignez `d` a cette case avec `assign(values, s, d)`
+- Étape 4 : Retournez `True` si au moins une assignation, `False` sinon
+",,,,,,,,be35eee78d104f15,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Python.ipynb,ex-hidden-singles-code,code,fr,ce188d11dda39af9,"# EXERCICE : Detection des singletons caches (Hidden Singles)
 #
 # Indications :
@@ -27439,11 +27465,11 @@ print(""Puzzle 4x4:"")
 print(display_4x4(parse_grid4(test_4x4)))
 print(""\nSolution 4x4:"")
 print(display_4x4(solution_4x4))",,,,,,,,a8265fdbde00f67d,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Python.ipynb,31556af2,markdown,fr,04fb235b766587d9,"## Exercice : Detection de paires nues (Naked Pairs)
+MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Python.ipynb,31556af2,markdown,fr,0714215934fc5e43,"## Exercice : Detection de paires nues (Naked Pairs)
 
 ### Enonce
 
-La technique des **paires nues** (Naked Pairs) est une heuristique de propagation supplementaire. Si deux cases d'une meme unite ont exactement les memes deux candidats (par exemple `{2, 5}`), alors ces deux valeurs peuvent etre eliminees de toutes les autres cases de cette unite.
+La technique des **paires nues** (Naked Pairs) est une heuristique de propagation supplementaire. Si deux cases d'une même unite ont exactement les mêmes deux candidats (par exemple `{2, 5}`), alors ces deux valeurs peuvent etre eliminees de toutes les autres cases de cette unite.
 
 **Exemple** : Si `A1 = ""25""` et `A4 = ""25""` dans la ligne A, alors `2` et `5` peuvent etre supprimes des candidats de `A2, A3, A5, A6, A7, A8, A9`.
 
@@ -27458,7 +27484,7 @@ Implantez une fonction `naked_pairs(values)` qui :
 - Pour chaque unite, collectez les cases ayant exactement 2 candidats
 - Comparez les ensembles de candidats deux a deux
 - Utilisez la fonction `eliminate` existante pour propager les suppressions
-- Pensez a verifier que la case dont on elimine n'est pas l'une des deux cases de la paire",,,,,,,,04fb235b766587d9,,,,,,,
+- Pensez a verifier que la case dont on elimine n'est pas l'une des deux cases de la paire",,,,,,,,0714215934fc5e43,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Python.ipynb,f183e45e,code,fr,f79cdac3b8d7ca19,"# EXERCICE : Detection de paires nues (Naked Pairs)
 # TODO: Implantez la fonction naked_pairs(values) decrite ci-dessus
 # 
@@ -27521,7 +27547,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Python.ipynb,b00eeb33,markdown,fr,e9493
 
 **Retour au sommaire** : [Index Sudoku](README.md)
 ",,,,,,,,e9493d3d223e6404,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb,5387691e,markdown,fr,2dde313df6fe899c,"**Navigation** : [Index](README.md) | [<< Sudoku-7 C#](Sudoku-7-Norvig-Csharp.ipynb) | [Sudoku-8 Python >>](Sudoku-8-HumanStrategies-Python.ipynb)
+MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb,5387691e,markdown,fr,39303be19c8448fe,"**Navigation** : [Index](README.md) | [<< Sudoku-7 C#](Sudoku-7-Norvig-Csharp.ipynb) | [Sudoku-8 Python >>](Sudoku-8-HumanStrategies-Python.ipynb)
 
 
 # Résolution de Sudoku par Stratégies Humaines
@@ -27538,18 +27564,18 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb,5387691e,markdown
 
 ### Prérequis
 - [Sudoku-0-Environment](Sudoku-0-Environment-Csharp.ipynb) : classes `SudokuGrid`, `ISudokuSolver`, `SudokuHelper`
-- Familiarite avec les regles du Sudoku (lignes, colonnes, blocs 3x3)
+- Familiarite avec les règles du Sudoku (lignes, colonnes, blocs 3x3)
 
-### Durée estimee : 60 minutes",,,,,,,,2dde313df6fe899c,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb,fe408d48,markdown,fr,db558ba79966dee8,"## Importation de l'environnement
+### Durée estimee : 60 minutes",,,,,,,,39303be19c8448fe,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb,fe408d48,markdown,fr,b3e7f29d01b7f7c5,"## Importation de l'environnement
 
-Nous importons les classes de base definies dans le notebook `Sudoku-0-Environment` : `SudokuGrid`, `ISudokuSolver`, `SudokuHelper`.",,,,,,,,db558ba79966dee8,,,,,,,
+Nous importons les classes de base définies dans le notebook `Sudoku-0-Environment` : `SudokuGrid`, `ISudokuSolver`, `SudokuHelper`.",,,,,,,,b3e7f29d01b7f7c5,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb,26c26cc0,code,fr,eb3d945ae449b902,#!import Sudoku-0-Environment-Csharp.ipynb,,,,,,,,eb3d945ae449b902,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb,d916d0fd,markdown,fr,a62b7fcefbde63fa,"## 1. Introduction : Comment les humains résolvent les Sudoku (~3 min)
+MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb,d916d0fd,markdown,fr,2d9877788250d823,"## 1. Introduction : Comment les humains résolvent les Sudoku (~3 min)
 
 Les algorithmes que nous avons vus dans les notebooks précédents (backtracking, OR-Tools, Dancing Links, etc.) résolvent les Sudoku par **force brute** ou par **satisfaction de contraintes** de manière systématique. Un expert humain procède tout autrement : il applique des **techniques de déduction logique** de difficulté croissante, en commencant par les plus simples.
 
-### Hierarchie des techniques
+### Hiérarchie des techniques
 
 Le projet [Sudoku.Human](https://github.com/jsboigeEpita/2024-EPITA-SCIA-PPC-Sudoku-NLP) identifie 13 techniques, classees par difficulté :
 
@@ -27562,7 +27588,7 @@ Le projet [Sudoku.Human](https://github.com/jsboigeEpita/2024-EPITA-SCIA-PPC-Sud
 | **Intermédiaire** | Locked Candidates (Pointing) | Candidats dans un bloc restreints a une seule ligne/colonne |
 | **Intermédiaire** | Locked Candidates (Claiming) | Candidats dans une ligne/colonne restreints a un seul bloc |
 | **Avance** | X-Wing | 2 lignes ou le même candidat est restreint aux mêmes 2 colonnes |
-| **Avance** | Y-Wing | Chaine de 3 cellules avec pattern de candidats spécifique |
+| **Avance** | Y-Wing | Chaîne de 3 cellules avec pattern de candidats spécifique |
 | **Avance** | XYZ-Wing | Extension du Y-Wing a 3 candidats |
 | **Expert** | Swordfish | Extension de X-Wing a 3 lignes/colonnes |
 | **Expert** | Jellyfish | Extension de X-Wing a 4 lignes/colonnes |
@@ -27575,7 +27601,7 @@ Nous allons implémenter les techniques les plus courantes et les combiner dans 
 1. Maintient une grille de **candidats** pour chaque cellule vide
 2. Applique les techniques dans l'ordre de difficulté croissante
 3. Recommence au début a chaque progrès
-4. Utilise le **backtracking** en dernier recours si aucune technique ne fonctionne",,,,,,,,a62b7fcefbde63fa,,,,,,,
+4. Utilise le **backtracking** en dernier recours si aucune technique ne fonctionne",,,,,,,,2d9877788250d823,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb,e0eb174f,markdown,fr,84c35dd4ff2079db,"## 2. Infrastructure : Grille de candidats
 
 Avant d'implémenter les techniques, nous avons besoin d'une structure de données pour gerer les **candidats** de chaque cellule. Pour chaque cellule vide, nous maintenons l'ensemble des valeurs encore possibles.
@@ -27709,18 +27735,18 @@ public class CandidateGrid
 }
 
 Console.WriteLine(""Classe CandidateGrid definie (grille de candidats avec propagation)"");",,,,,,,,ab518511fdee2162,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb,7d21604f,markdown,fr,7e1eb39ca8278b04,"### Interprétation : CandidateGrid
+MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb,7d21604f,markdown,fr,5fab27d73cbc82cb,"### Interprétation : CandidateGrid
 
 La classe `CandidateGrid` est le fondement de toute l'approche humaine. Contrairement au backtracking qui teste les valeurs une a une, ici on maintient en permanence la liste des **valeurs possibles** pour chaque cellule. C'est exactement ce que fait un joueur humain quand il note les petits chiffres au crayon dans les cases.
 
-| Méthode | Role |
+| Méthode | Rôle |
 |---------|------|
 | `PlaceValue` | Place une valeur et propage l'élimination aux voisins |
 | `EliminateCandidate` | Retire un candidat d'une cellule spécifique |
 | `GetUnitCells` | Recupere les cellules non résolues d'une unité (ligne/colonne/bloc) |
 | `IsSolved` | Vérifié si le puzzle est complètement résolu |
 
-Testons cette infrastructure sur un puzzle facile.",,,,,,,,7e1eb39ca8278b04,,,,,,,
+Testons cette infrastructure sur un puzzle facile.",,,,,,,,5fab27d73cbc82cb,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb,3c8a0369,code,fr,aab3940f90f090fa,"// Test de la grille de candidats sur un puzzle facile
 var testGrid = SudokuHelper.GetSudokus(SudokuDifficulty.Easy).First();
 display($""Puzzle initial :\n{testGrid}"");
@@ -28276,9 +28302,9 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb,8ec3403b,code,fr,
 }
 
 Console.WriteLine(""Classe HumanTechniquesAdvanced definie (X-Wing lignes + colonnes)"");",,,,,,,,7ab114ce38e6f9a5,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb,6ec579ad,markdown,fr,32b9f0e3b7a9a9f0,"### Interprétation : X-Wing
+MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb,6ec579ad,markdown,fr,fcd14f11bf4534a6,"### Interprétation : X-Wing
 
-Le X-Wing est la premiere technique qui raisonne sur **plusieurs unités simultanément**. Les techniques precedentes (Naked Singles, Hidden Singles, Naked Pairs, Locked Candidates) raisonnent unité par unité.
+Le X-Wing est la première technique qui raisonne sur **plusieurs unités simultanément**. Les techniques précédentes (Naked Singles, Hidden Singles, Naked Pairs, Locked Candidates) raisonnent unité par unité.
 
 | Technique | Portee | Type de pattern |
 |-----------|--------|----------------|
@@ -28287,7 +28313,7 @@ Le X-Wing est la premiere technique qui raisonne sur **plusieurs unités simulta
 | Locked Candidates | 2 unités (bloc + ligne/col) | Intersection |
 | X-Wing | 2 lignes + 2 colonnes | Rectangle |
 
-> **Pour aller plus loin** : Les techniques Y-Wing et XYZ-Wing forment des chaines de cellules bivalue. Le Y-Wing utilisé 3 cellules avec 2 candidats chacune, formant un ""pivot"" et deux ""pinces"". Toute cellule visible par les deux pinces peut voir ses candidats reduits. Ces techniques sont trop complexes pour être détaillées ici mais suivent le même principe d'élimination par déduction logique.",,,,,,,,32b9f0e3b7a9a9f0,,,,,,,
+> **Pour aller plus loin** : Les techniques Y-Wing et XYZ-Wing forment des chaînes de cellules bivalue. Le Y-Wing utilisé 3 cellules avec 2 candidats chacune, formant un ""pivot"" et deux ""pinces"". Toute cellule visible par les deux pinces peut voir ses candidats reduits. Ces techniques sont trop complexes pour être détaillées ici mais suivent le même principe d'élimination par déduction logique.",,,,,,,,fcd14f11bf4534a6,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb,57010e81,markdown,fr,ef88d19b287b5ac8,"## 6. Techniques expertes (apercu) (~3 min)
 
 Les techniques suivantes sont mentionnees pour référence. Elles sont implementees dans le projet [Sudoku.Human](https://github.com/jsboigeEpita/2024-EPITA-SCIA-PPC-Sudoku-NLP) mais leur complexité dépasse le cadre de ce notebook.
@@ -28607,7 +28633,7 @@ foreach (var result in results)
 {
     display($""{result.SolverName} | {result.Difficulty} | {result.Time:F1} ms | {result.SolvedCount}/10 | {result.Status}"");
 }",,,,,,,,878dc6509df94df3,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb,bdd3ec39,markdown,fr,92cd1b88c5d498c4,"### Interprétation : Comparaison de performance
+MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb,bdd3ec39,markdown,fr,622da738dc7582bd,"### Interprétation : Comparaison de performance
 
 | Solveur | Forces | Faiblesses |
 |---------|--------|------------|
@@ -28616,7 +28642,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb,bdd3ec39,markdown
 
 Contrairement a ce qu'on pourrait croire, le `HumanSolver` est **plus rapide** que ce backtracking de référence sur les puzzles Easy et Medium (cf. benchmark ci-dessus : ~4 ms contre ~101 ms en Easy, ~46 ms contre ~381 ms en Medium) : l'élimination de candidats elague fortement l'arbre de recherche avant tout retour arriere. Sur les puzzles Hard les plus durs, les deux solveurs sont disqualifies (4/10, time-out), le HumanSolver restant tout de même un peu plus rapide. Son avantage majeur n'est cependant pas la vitesse mais le fait que **chaque étape est explicable** : on sait exactement pourquoi une valeur a été placee ou un candidat élimine.
 
-> **Note** : Dans les applications reelles (generateurs de puzzles, tutoriels interactifs), la capacite a tracer le raisonnement est plus importante que la vitesse brute. C'est ce qui permet de classer les puzzles par difficulté et d'aider les joueurs a progresser.",,,,,,,,92cd1b88c5d498c4,,,,,,,
+> **Note** : Dans les applications reelles (générateurs de puzzles, tutoriels interactifs), la capacite a tracer le raisonnement est plus importante que la vitesse brute. C'est ce qui permet de classer les puzzles par difficulté et d'aider les joueurs a progresser.",,,,,,,,622da738dc7582bd,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb,06f82c4b,markdown,fr,b620c785f3461e4f,"### Analyse statistique par difficulté
 
 Analysons plus en détail les techniques utilisees sur un ensemble de puzzles pour comprendre la distribution des techniques necessaires par niveau de difficulté.",,,,,,,,b620c785f3461e4f,,,,,,,
@@ -28659,7 +28685,7 @@ void AnalyzeTechniques(SudokuDifficulty difficulty, int count)
 AnalyzeTechniques(SudokuDifficulty.Easy, 20);
 AnalyzeTechniques(SudokuDifficulty.Medium, 10);
 AnalyzeTechniques(SudokuDifficulty.Hard, 10);",,,,,,,,927a3d348dbe593c,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb,d54e34f1,markdown,fr,dc4cc1e92bacf101,"### Interprétation : Distribution des techniques
+MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb,d54e34f1,markdown,fr,b56b3103db34b0ab,"### Interprétation : Distribution des techniques
 
 Cette analyse révèle la **signature de difficulté** de chaque niveau :
 
@@ -28667,7 +28693,7 @@ Cette analyse révèle la **signature de difficulté** de chaque niveau :
 - **Medium** : Apparition des Naked Pairs et Locked Candidates, en plus des singles. Le backtracking devient fréquent (~70 % des puzzles) faute de techniques plus avancées.
 - **Hard** : Usage intensif des mêmes techniques de base et intermédiaires (Hidden Singles ~280 %, Locked Candidates ~120 %, Naked Pairs ~40 % d'utilisations par puzzle). Le X-Wing n'est presque jamais déclenché (≈5 % sur Easy, 0 % sur Medium/Hard) ; le backtracking reste élevé (~60 %, du même ordre qu'en Medium) car il faudrait des techniques expertes (Swordfish, 3D Medusa) pour l'éviter.
 
-> **Conclusion** : Le nombre et la complexité des techniques necessaires constituent une mesure naturelle de la difficulté d'un puzzle. C'est d'ailleurs ainsi que les generateurs de puzzles classifient leurs grilles.",,,,,,,,dc4cc1e92bacf101,,,,,,,
+> **Conclusion** : Le nombre et la complexité des techniques necessaires constituent une mesure naturelle de la difficulté d'un puzzle. C'est d'ailleurs ainsi que les générateurs de puzzles classifient leurs grilles.",,,,,,,,b56b3103db34b0ab,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb,fa4fca2e,markdown,fr,e3ceed3745523cf1,"---
 
 ## Exercice : Stratégies humaines avancées
@@ -28719,7 +28745,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb,e8881fdd,code,fr,
 }
 
 Console.WriteLine(""Interface IHumanTechniqueExpert definie (Swordfish + Hidden Pairs en blocs)"");",,,,,,,,d21879889c40f9d6,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb,74995405,markdown,fr,ddb767b2ea21169a,"## Conclusion
+MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb,74995405,markdown,fr,ebcb81fe0266ae8d,"## Conclusion
 
 ### Résumé des apprentissages
 
@@ -28737,7 +28763,7 @@ Ce notebook a présenté une approche de résolution de Sudoku basee sur les tec
 
 ### Points clés
 
-1. **Les techniques humaines sont hierarchiques** : on commence par les plus simples et on monte en complexité uniquement quand on est bloque
+1. **Les techniques humaines sont hiérarchiques** : on commence par les plus simples et on monte en complexité uniquement quand on est bloque
 2. **Élimination vs placement** : les techniques avancées eliminent des candidats, ce qui deblocke les techniques basiques
 3. **La difficulté d'un puzzle** se mesure par la technique la plus avancée necessaire pour le résoudre sans backtracking
 4. **Le backtracking comme filet de securite** : un solveur humain incomplet (sans toutes les 13 techniques) peut toujours résoudre en dernier recours via le backtracking
@@ -28757,7 +28783,7 @@ Les techniques humaines offrent un avantage majeur sur la force brute : **chaque
 ---
 
 **Retour au sommaire** : [Index Sudoku](README.md)
-",,,,,,,,ddb767b2ea21169a,,,,,,,
+",,,,,,,,ebcb81fe0266ae8d,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb,y893nvxnrmn,code,fr,73a6e74b57b56596,"// A COMPLETER : Solveur hybride avec techniques expertes
 
 public class ExpertHumanStrategySolver : ISudokuSolver
@@ -28814,13 +28840,13 @@ public class ExpertHumanStrategySolver : ISudokuSolver
 // Console.WriteLine(solved.IsSolved() ? ""Resolu sans backtracking !"" : ""Backtracking utilise"");
 
 Console.WriteLine(""Classe ExpertHumanStrategySolver definie (TODO etudiant : Swordfish + Hidden Pairs + pipeline)"");",,,,,,,,73a6e74b57b56596,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,47ecd0a8,markdown,fr,2f789d4738b7d227,"# Sudoku-8 : Resolution par Strategies Humaines (Python)
+MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,47ecd0a8,markdown,fr,6916b3135f6b9698,"# Sudoku-8 : Resolution par Stratégies Humaines (Python)
 
 **Niveau** : Techniques d'inference | **Duree** : ~40 min | **Prerequis** : Sudoku-0 Environment
 
 ## Navigation
 
-| << Precedent | [Index](README.md) | Suivant >> |
+| << Précédent | [Index](README.md) | Suivant >> |
 |-------------|---------------------|-----------|
 | [Sudoku-7-Norvig-Python](Sudoku-7-Norvig-Python.ipynb) | | [Sudoku-9-GraphColoring-Python](Sudoku-9-GraphColoring-Python.ipynb) |
 
@@ -28840,13 +28866,13 @@ C'est l'equivalent Python du notebook C# `Sudoku-8-HumanStrategies-Csharp.ipynb`
 
 ## Introduction
 
-Les algorithmes que nous avons vus dans les notebooks precedents (backtracking, OR-Tools, Dancing Links, etc.) resolvent les Sudoku par **force brute** ou par **satisfaction de contraintes** de maniere systematique. Un expert humain procede tout autrement : il applique des **techniques de deduction logique** de difficulte croissante, en commencant par les plus simples.
+Les algorithmes que nous avons vus dans les notebooks précédents (backtracking, OR-Tools, Dancing Links, etc.) resolvent les Sudoku par **force brute** ou par **satisfaction de contraintes** de maniere systématique. Un expert humain procede tout autrement : il applique des **techniques de deduction logique** de difficulte croissante, en commencant par les plus simples.
 
-### Hierarchie des techniques
+### Hiérarchie des techniques
 
 1. **Naked Single** : Une case ne peut contenir qu'une seule valeur
 2. **Hidden Single** : Une valeur ne peut aller qu'a une seule case dans une unite (ligne/colonne/bloc)
-3. **Naked Pair** : Deux cases ne contiennent que les memes deux valeurs candidats
+3. **Naked Pair** : Deux cases ne contiennent que les mêmes deux valeurs candidats
 4. **Pointing Pair** : Une valeur dans un bloc est restreinte a une ligne/colonne
 5. **X-Wing** : Une valeur forme un rectangle dans deux lignes/colonnes
 
@@ -28857,7 +28883,7 @@ Les algorithmes que nous avons vus dans les notebooks precedents (backtracking, 
 | Easy | Naked Singles, Hidden Singles |
 | Medium | Naked Pairs, Pointing Pairs |
 | Hard | X-Wing, techniques avancees |
-| Expert | Swordfish, XY-Wing, etc. |",,,,,,,,2f789d4738b7d227,,,,,,,
+| Expert | Swordfish, XY-Wing, etc. |",,,,,,,,6916b3135f6b9698,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,d158f574,code,fr,35e451d9f1b0e444,"# Imports
 import numpy as np
 import time
@@ -28879,9 +28905,9 @@ if PUZZLES_DIR.exists():
 else:
     print(f""ATTENTION: Dossier Puzzles non trouve a {PUZZLES_DIR}"")
     PUZZLES_DIR = Path(os.getcwd()) / ""Puzzles""",,,,,,,,668ece7b83539c90,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,dc4a7002,markdown,fr,5d3e42534776a67e,"## 1. Classe Sudoku avec Candidats
+MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,dc4a7002,markdown,fr,2a7192399d43e0b4,"## 1. Classe Sudoku avec Candidats
 
-Pour les strategies humaines, nous devons suivre non seulement les valeurs placees, mais aussi les candidats possibles pour chaque case.",,,,,,,,5d3e42534776a67e,,,,,,,
+Pour les stratégies humaines, nous devons suivre non seulement les valeurs placees, mais aussi les candidats possibles pour chaque case.",,,,,,,,2a7192399d43e0b4,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,710702db,code,fr,6ca70c7fb42377d7,"@dataclass
 class CandidateInfo:
     """"""Informations sur les candidats d'une case.""""""
@@ -29000,27 +29026,27 @@ print(f""Puzzles charges: {len(easy_puzzles)}"")
 solver = HumanSudokuSolver(easy_puzzles[0])
 print(""\nGrille de test:"")
 print(solver)",,,,,,,,6ca70c7fb42377d7,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,488c850a,markdown,fr,1ecd566ca5d3847a,"### Interpretation : Structure de la classe HumanSudokuSolver
+MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,488c850a,markdown,fr,8eec0f903073a1ef,"### Interpretation : Structure de la classe HumanSudokuSolver
 
-| Composant | Role | Interet |
+| Composant | Rôle | Intérêt |
 |-----------|------|---------|
 | **self.grid** | Grille 9x9 des valeurs placees | Representation standard du Sudoku |
-| **self.candidates** | Liste des candidats pour chaque case | Cle des strategies humaines |
+| **self.candidates** | Liste des candidats pour chaque case | Cle des stratégies humaines |
 | **self.placements** | Historique des placements | Permet le backtrack et l'analyse |
 | **self.strategy_counts** | Compteur d'utilisation des techniques | Benchmark et analyse |
 
-**Structure des donnees** :
+**Structure des données** :
 - `self.candidates[row][col]` = ensemble des valeurs possibles (1-9) pour cette case
 - Initialisation : Pour chaque case vide, calculer les valeurs possibles en eliminant celles de la ligne, colonne et bloc
 - Exemple : Case (0, 1) avec grille contenant {9,2,5,4,3,1,6,2,5,5,8,4,7,6} ne peut contenir que {7}
 
 **Points cles** :
 1. La classe maintient **deux representations** : grille (valeurs placees) et candidats (possibilites)
-2. La methode `_get_possible_values` implemente la regle de base du Sudoku : une valeur doit etre unique dans sa ligne, colonne et bloc
+2. La méthode `_get_possible_values` implemente la règle de base du Sudoku : une valeur doit etre unique dans sa ligne, colonne et bloc
 3. L'affichage avec `__str__` utilise des separateurs visuels (`-` et `|`) pour delimiter les blocs 3x3
 4. Le chargement des puzzles depuis un fichier permet de tester sur de nombreux cas
 
-> **Note technique** : L'utilisation de `set` pour les candidats permet des operations efficaces d'ajout et de suppression (O(1)). La methode `discard` supprime un element si present sans lever d'erreur, ce qui est ideal pour la propagation des contraintes.",,,,,,,,1ecd566ca5d3847a,,,,,,,
+> **Note technique** : L'utilisation de `set` pour les candidats permet des opérations efficaces d'ajout et de suppression (O(1)). La méthode `discard` supprime un élément si present sans lever d'erreur, ce qui est ideal pour la propagation des contraintes.",,,,,,,,8eec0f903073a1ef,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,48301558,markdown,fr,eda757bdafbe550e,"## 2. Technique 1 : Naked Single
 
 Un **Naked Single** (ou ""Singleton"") est une case qui ne contient qu'un seul candidat possible. C'est la technique la plus simple.",,,,,,,,eda757bdafbe550e,,,,,,,
@@ -29092,7 +29118,7 @@ naked_singles = solver.find_naked_singles()
 print(f""Naked Singles trouves: {len(naked_singles)}"")
 for ns in naked_singles[:5]:
     print(f""  ({ns.row}, {ns.col}) = {ns.value}"")",,,,,,,,4d26c4f9a8e95697,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,dafb3cfb,markdown,fr,e99c73b066e739e1,"### Interpretation : Detection des Naked Singles
+MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,dafb3cfb,markdown,fr,1fad531d18b6021d,"### Interpretation : Detection des Naked Singles
 
 | Aspect | Valeur | Signification |
 |--------|--------|---------------|
@@ -29101,20 +29127,20 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,dafb3cfb,markdown
 | **Impact** | Reduction de l'espace de recherche | Chaque placement elimine des candidats voisins |
 
 **Exemples de deductions** :
-- Case (0, 4) = 8 : Apres elimination des valeurs de la ligne 0, colonne 4 et bloc, seul 8 reste possible
-- Case (1, 1) = 7 : La case ne peut contenir que 7 apres propagation des contraintes
+- Case (0, 4) = 8 : Après elimination des valeurs de la ligne 0, colonne 4 et bloc, seul 8 reste possible
+- Case (1, 1) = 7 : La case ne peut contenir que 7 après propagation des contraintes
 - Case (2, 6) = 1 : Un Naked Single typique dans une case contrainte
 
 **Points cles** :
 1. Les Naked Singles sont les deductions **les plus simples** : une case ne contient qu'un candidat
 2. Chaque Naked Single place **elimine des candidats** dans les 20 cases voisines (8 ligne + 8 colonne + 4 bloc)
-3. Cette propagation cree une **reaction en chaîne** : un placement fait apparaître de nouveaux Naked Singles
-4. La methode `_remove_candidate_from_peers` est cruciale pour maintenir la cohérence des candidats
+3. Cette propagation créé une **reaction en chaîne** : un placement fait apparaître de nouveaux Naked Singles
+4. La méthode `_remove_candidate_from_peers` est cruciale pour maintenir la cohérence des candidats
 
-> **Note technique** : Les Naked Singles correspondent aux placements ""evidents"" pour un humain. Quand une case ne peut contenir qu'une seule valeur, on la place immediatement. L'originalite de l'approche humaine est de maintenir explicitement la liste des candidats pour chaque case, ce qui permet de detecter ces singles efficacement.",,,,,,,,e99c73b066e739e1,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,d1749d13,markdown,fr,b78881c1cf79a2f0,"## 3. Technique 2 : Hidden Single
+> **Note technique** : Les Naked Singles correspondent aux placements ""evidents"" pour un humain. Quand une case ne peut contenir qu'une seule valeur, on la place immediatement. L'originalite de l'approche humaine est de maintenir explicitement la liste des candidats pour chaque case, ce qui permet de detecter ces singles efficacement.",,,,,,,,1fad531d18b6021d,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,d1749d13,markdown,fr,1c31e23a945b6fcf,"## 3. Technique 2 : Hidden Single
 
-Un **Hidden Single** est une valeur qui ne peut aller qu'a une seule case dans une unite (ligne, colonne ou bloc), meme si cette case a d'autres candidats.",,,,,,,,b78881c1cf79a2f0,,,,,,,
+Un **Hidden Single** est une valeur qui ne peut aller qu'a une seule case dans une unite (ligne, colonne ou bloc), même si cette case a d'autres candidats.",,,,,,,,1c31e23a945b6fcf,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,08352e75,code,fr,2e53335536e6dba9,"def find_hidden_singles(self) -> List[CandidateInfo]:
     """"""Trouve les Hidden Singles dans les lignes, colonnes et blocs.""""""
     placements = []
@@ -29175,7 +29201,7 @@ print(""Methode Hidden Single ajoutee."")
 solver = HumanSudokuSolver(easy_puzzles[0])
 hidden_singles = solver.find_hidden_singles()
 print(f""Hidden Singles trouves: {len(hidden_singles)}"")",,,,,,,,2e53335536e6dba9,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,8f554bef,markdown,fr,9f6e7089881de6b8,"### Interpretation : Hidden Singles vs Naked Singles
+MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,8f554bef,markdown,fr,8193719a7840f525,"### Interpretation : Hidden Singles vs Naked Singles
 
 | Aspect | Naked Singles | Hidden Singles |
 |--------|---------------|----------------|
@@ -29186,14 +29212,14 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,8f554bef,markdown
 
 **Points cles** :
 1. Les **Hidden Singles sont 4.5x plus frequents** que les Naked Singles dans ce puzzle
-2. Un Hidden Single est une contrainte plus forte : il indique que meme si une case a plusieurs candidats, un d'entre eux est force
+2. Un Hidden Single est une contrainte plus forte : il indique que même si une case a plusieurs candidats, un d'entre eux est force
 3. Les Hidden Singles necessitent de parcourir toute l'unite (ligne/colonne/bloc) pour etre detectes
 4. Combiner les deux techniques maximise le nombre de deductions directes
 
-> **Note technique** : Les Hidden Singles sont cruciaux pour la resolution. Par exemple, si la valeur 7 n'apparait comme candidat que dans une seule case d'une ligne, alors 7 DOIT aller dans cette case, meme si la case contient d'autres candidats (1, 4, 9). C'est une deduction logique forte.",,,,,,,,9f6e7089881de6b8,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,f6967037,markdown,fr,128f3082c881e759,"## 4. Technique 3 : Naked Pair
+> **Note technique** : Les Hidden Singles sont cruciaux pour la resolution. Par exemple, si la valeur 7 n'apparait comme candidat que dans une seule case d'une ligne, alors 7 DOIT aller dans cette case, même si la case contient d'autres candidats (1, 4, 9). C'est une deduction logique forte.",,,,,,,,8193719a7840f525,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,f6967037,markdown,fr,f037834aff2cf92f,"## 4. Technique 3 : Naked Pair
 
-Un **Naked Pair** est deux cases de la meme unite qui contiennent exactement les memes deux candidats. Ces deux candidats peuvent donc etre elimines des autres cases de l'unite.",,,,,,,,128f3082c881e759,,,,,,,
+Un **Naked Pair** est deux cases de la même unite qui contiennent exactement les mêmes deux candidats. Ces deux candidats peuvent donc etre elimines des autres cases de l'unite.",,,,,,,,f037834aff2cf92f,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,272018f7,code,fr,0201dcc3c0b9d3ff,"def find_naked_pairs(self) -> List[Tuple[int, int, int, Set[int], str]]:
     """"""Trouve les Naked Pairs dans les lignes, colonnes et blocs.
     
@@ -29371,9 +29397,9 @@ HumanSudokuSolver.find_pointing_pairs = find_pointing_pairs
 HumanSudokuSolver.apply_pointing_pair = apply_pointing_pair
 
 print(""Methodes Pointing Pair ajoutees."")",,,,,,,,6b18fab32432ddc1,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,6ad47806,markdown,fr,90c6740d79d32d6e,"## 6. Technique 5 : X-Wing
+MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,6ad47806,markdown,fr,ab74d5714c5ddfe4,"## 6. Technique 5 : X-Wing
 
-Un **X-Wing** se produit quand une valeur a exactement deux candidats dans chacune de deux lignes differentes, et ces candidats sont dans les memes deux colonnes. La valeur peut donc etre eliminee des autres cases de ces colonnes.",,,,,,,,90c6740d79d32d6e,,,,,,,
+Un **X-Wing** se produit quand une valeur a exactement deux candidats dans chacune de deux lignes différentes, et ces candidats sont dans les mêmes deux colonnes. La valeur peut donc etre eliminee des autres cases de ces colonnes.",,,,,,,,ab74d5714c5ddfe4,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,99993877,code,fr,76af717e83481052,"def find_x_wings(self) -> List[Tuple[int, int, int, int, int]]:
     """"""Trouve les X-Wings dans les lignes.
     
@@ -29557,15 +29583,15 @@ for strategy, count in solver.strategy_counts.items():
 
 print(""\nSolution:"")
 print(solver)",,,,,,,,755483ec04ce6776,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,d02a2e63,markdown,fr,73f88c612be903de,"### Interpretation : Resultat du solveur
+MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,d02a2e63,markdown,fr,4f6db27168d7b2b4,"### Interpretation : Résultat du solveur
 
 | Aspect | Observation |
 |--------|-------------|
-| Strategies utilisees | Naked Singles et Hidden Singles suffisent pour les puzzles faciles |
+| Stratégies utilisees | Naked Singles et Hidden Singles suffisent pour les puzzles faciles |
 | Temps | Resolution rapide pour les puzzles simples |
-| Fallback backtracking | Utilise si les strategies humaines echouent |
+| Fallback backtracking | Utilise si les stratégies humaines echouent |
 
-> **Point cle** : Les strategies humaines resolvent la plupart des puzzles faciles et moyens sans backtracking.",,,,,,,,73f88c612be903de,,,,,,,
+> **Point cle** : Les stratégies humaines resolvent la plupart des puzzles faciles et moyens sans backtracking.",,,,,,,,4f6db27168d7b2b4,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,966c0fbb,code,fr,d7fe0bd7e885d86a,"# Benchmark sur plusieurs puzzles
 def benchmark_human(puzzles: List[str], num_puzzles: int = 5):
     """"""Benchmark du solveur humain.""""""
@@ -29601,16 +29627,16 @@ def benchmark_human(puzzles: List[str], num_puzzles: int = 5):
         print(f""  {strategy}: {count}"")
 
 benchmark_human(easy_puzzles, num_puzzles=5)",,,,,,,,d7fe0bd7e885d86a,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,13a9c814,markdown,fr,870ba27e77de6305,"### Interpretation : Benchmark des Strategies Humaines
+MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,13a9c814,markdown,fr,4677eb88ced0ec3e,"### Interpretation : Benchmark des Stratégies Humaines
 
 | Metrique | Valeur | Signification |
 |----------|--------|---------------|
 | **Taux de reussite** | 5/5 (100%) | Tous les puzzles faciles resolus |
 | **Temps moyen** | 2.20ms | Performance excellente |
-| **Temps total** | 10.99ms | Meme avec 5 puzzles |
-| **Strategies utilisees** | 5 differentes | Toute la gamme de difficulte |
+| **Temps total** | 10.99ms | Même avec 5 puzzles |
+| **Stratégies utilisees** | 5 différentes | Toute la gamme de difficulte |
 
-**Distribution des strategies** :
+**Distribution des stratégies** :
 - **Hidden Single** : 149 applications (technique la plus frequente)
 - **Naked Single** : 91 applications
 - **Pointing Pair** : 17 applications
@@ -29623,7 +29649,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,13a9c814,markdown
 3. La resolution est **extremement rapide** : moins de 4ms par puzzle en moyenne
 4. Le solveur humain est **complet** : il combine automatiquement les techniques necessaires
 
-> **Note technique** : Les Hidden Singles sont plus nombreux que les Naked Singles car ils detectent des contraintes cachees. Une case peut avoir plusieurs candidats (pas de Naked Single) mais un de ces candidats ne peut aller nulle part ailleurs dans l'unite (Hidden Single).",,,,,,,,870ba27e77de6305,,,,,,,
+> **Note technique** : Les Hidden Singles sont plus nombreux que les Naked Singles car ils detectent des contraintes cachees. Une case peut avoir plusieurs candidats (pas de Naked Single) mais un de ces candidats ne peut aller nulle part ailleurs dans l'unite (Hidden Single).",,,,,,,,4677eb88ced0ec3e,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,834457c2,markdown,fr,754f67f32b3202d6,## 9. Comparaison avec le Backtracking Simple,,,,,,,,754f67f32b3202d6,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,98c678a5,code,fr,82342a6214858362,"class SimpleBacktracking:
     """"""Simple backtracking pour comparaison.""""""
@@ -29683,9 +29709,9 @@ for i, puzzle_str in enumerate(easy_puzzles[:3]):
     
     print(f""  Humain: {solved_h}, {t_h*1000:.2f}ms"")
     print(f""  Backtracking: {solved_bt}, {t_bt*1000:.2f}ms, {bt.call_count} appels"")",,,,,,,,82342a6214858362,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,4a913e27,markdown,fr,4fb2939b8d2d16f0,"### Interpretation : Comparaison Humain vs Backtracking
+MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,4a913e27,markdown,fr,98cb0f8a999ac75c,"### Interpretation : Comparaison Humain vs Backtracking
 
-| Aspect | Strategies Humaines | Backtracking Simple |
+| Aspect | Stratégies Humaines | Backtracking Simple |
 |--------|---------------------|---------------------|
 | **Temps moyen** | 0.57 - 2.66ms | 1.96 - 17.47ms |
 | **Appels recursifs** | 0 (deduction logique) | 49 - 295 appels |
@@ -29693,19 +29719,19 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,4a913e27,markdown
 | **Explicabilite** | Chaîne de deductions claire | Pas de traçabilité |
 
 **Points cles** :
-1. Les strategies humaines sont **2-5x plus rapides** que le backtracking simple pour les puzzles faciles
-2. Le backtracking effectue des appels recursifs inutiles (49-295) alors que les strategies humaines resolvent directement par deduction
-3. La difference de performance s'accroit avec la difficulte du puzzle (puzzle 3 : 2.66ms vs 17.47ms)
-4. Les strategies humaines produisent une solution explicable (chaque placement est justifie par une technique logique)
+1. Les stratégies humaines sont **2-5x plus rapides** que le backtracking simple pour les puzzles faciles
+2. Le backtracking effectue des appels recursifs inutiles (49-295) alors que les stratégies humaines resolvent directement par deduction
+3. La différence de performance s'accroit avec la difficulte du puzzle (puzzle 3 : 2.66ms vs 17.47ms)
+4. Les stratégies humaines produisent une solution explicable (chaque placement est justifie par une technique logique)
 
-> **Note technique** : Le backtracking simple ne profite pas des contraintes pour reduire l'espace de recherche. Il teste toutes les possibilites de 1 a 9 pour chaque case, meme quand une seule est valide. Les strategies humaines identifient directement cette unique possibilite.",,,,,,,,4fb2939b8d2d16f0,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,327671ff,markdown,fr,b7ebd530b7698b09,"### Distinction cle : Naked Pair vs Hidden Pair
+> **Note technique** : Le backtracking simple ne profite pas des contraintes pour reduire l'espace de recherche. Il teste toutes les possibilites de 1 a 9 pour chaque case, même quand une seule est valide. Les stratégies humaines identifient directement cette unique possibilite.",,,,,,,,98cb0f8a999ac75c,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,327671ff,markdown,fr,98fda20bd2bd1c13,"### Distinction cle : Naked Pair vs Hidden Pair
 
-Ces deux techniques sont frequemment confondues. Voici la difference fondamentale :
+Ces deux techniques sont frequemment confondues. Voici la différence fondamentale :
 
 | | **Naked Pair** | **Hidden Pair** |
 |---|---|---|
-| **Observation** | Deux cases contiennent **exactement** les memes 2 candidats {X, Y} | Deux valeurs {X, Y} n'apparaissent comme candidats que dans les memes 2 cases |
+| **Observation** | Deux cases contiennent **exactement** les mêmes 2 candidats {X, Y} | Deux valeurs {X, Y} n'apparaissent comme candidats que dans les mêmes 2 cases |
 | **Condition** | Les 2 cases ont chacune **exactement** {X, Y} comme candidats | Les 2 cases peuvent avoir **plus** de candidats, mais X et Y n'apparaissent nulle part ailleurs |
 | **Action** | Eliminer X et Y des **autres** cases de l'unite | Eliminer les **autres** candidats de ces 2 cases |
 
@@ -29718,10 +29744,10 @@ Case C : candidats {2, 3, 5}
 Case D : candidats {2, 5, 7}
 ```
 
-- **Naked Pair** : A et B ont exactement {3, 7}. On elimine 3 et 7 de C et D. Resultat : C={2, 5}, D={2, 5}.
-- **Hidden Pair** : Si les valeurs 3 et 7 n'apparaissent que dans A et B (pas dans C ou D), on elimine les autres candidats de A et B. Resultat : A={3, 7}, B={3, 7}.
+- **Naked Pair** : A et B ont exactement {3, 7}. On elimine 3 et 7 de C et D. Résultat : C={2, 5}, D={2, 5}.
+- **Hidden Pair** : Si les valeurs 3 et 7 n'apparaissent que dans A et B (pas dans C ou D), on elimine les autres candidats de A et B. Résultat : A={3, 7}, B={3, 7}.
 
-> **Mnemotechnique** : ""Naked"" = les candidats sont **visibles** a nu (les cases montrent clairement {X,Y}). ""Hidden"" = les candidats sont ** caches** parmi d'autres, mais le fait qu'ils n'apparaissent qu'a deux endroits les revele.",,,,,,,,b7ebd530b7698b09,,,,,,,
+> **Mnemotechnique** : ""Naked"" = les candidats sont **visibles** a nu (les cases montrent clairement {X,Y}). ""Hidden"" = les candidats sont ** caches** parmi d'autres, mais le fait qu'ils n'apparaissent qu'a deux endroits les revele.",,,,,,,,98fda20bd2bd1c13,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,1491cac0,markdown,fr,5b5b911cddd66bd2,"## 10. Exemple guide : techniques avancees
 
 Les cellules suivantes contiennent des **exemples resolus** pour trois techniques avancees (Hidden Pair, Swordfish, XY-Wing). Etudiez le code de chaque exemple, puis implementez la variante proposee dans le stub TODO qui suit.
@@ -29813,16 +29839,16 @@ HumanSudokuSolver.apply_hidden_pair = apply_hidden_pair
 
 print(""Methode definie : find_hidden_pairs"")
 ",,,,,,,,cde8a7bc757ffd03,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,08e62f62,markdown,fr,8ff446bf25cd773a,"### Exercice 1b : Hidden Pair dans les blocs
+MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,08e62f62,markdown,fr,6d4aa0d708288d40,"### Exercice 1b : Hidden Pair dans les blocs
 
 **Enonce** : Implementez une fonction `find_hidden_pairs_blocks(self)` qui detecte les Hidden Pairs uniquement dans les 9 blocs 3x3.
 
 **Consignes** :
 1. Parcourez chaque bloc 3x3
-2. Pour chaque paire de valeurs (v1, v2), verifiez si les deux valeurs n'apparaissent comme candidats que dans exactement les 2 memes cases du bloc
+2. Pour chaque paire de valeurs (v1, v2), verifiez si les deux valeurs n'apparaissent comme candidats que dans exactement les 2 mêmes cases du bloc
 3. Si c'est le cas et que ces cases ont d'autres candidats, identifiez le Hidden Pair
 4. Retournez la liste des Hidden Pairs trouves sous forme de tuples `(row1, col1, row2, col2, {v1, v2})`
-5. Validez en filtrant les resultats de `find_hidden_pairs()` avec `unit_type='block'`",,,,,,,,8ff446bf25cd773a,,,,,,,
+5. Validez en filtrant les résultats de `find_hidden_pairs()` avec `unit_type='block'`",,,,,,,,6d4aa0d708288d40,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,d8dacad0,code,fr,298ccb0d7996e874,"# Exemple guide 1b : Hidden Pair dans les blocs
 #
 # TODO: Implementez find_hidden_pairs_blocks(self) qui detecte les Hidden Pairs
@@ -29914,7 +29940,7 @@ HumanSudokuSolver.apply_swordfish = apply_swordfish
 
 print(""Methode definie : find_swordfish"")
 ",,,,,,,,5f6ee4998f93745b,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,a83851d6,markdown,fr,37b7246007828bf2,"### Exercice 2b : Swordfish par colonnes
+MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,a83851d6,markdown,fr,8e43ea72f6ebfc27,"### Exercice 2b : Swordfish par colonnes
 
 **Enonce** : Implementez une fonction `find_swordfish_cols(self)` qui detecte les Swordfish uniquement dans l'orientation colonnes (en ignorant les lignes).
 
@@ -29922,7 +29948,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,a83851d6,markdown
 1. Pour chaque valeur de 1 a 9, identifiez les colonnes ou cette valeur apparait dans 2 ou 3 cases
 2. Pour chaque combinaison de 3 colonnes, verifiez si l'union des lignes fait exactement 3
 3. Retournez la liste des Swordfish trouves sous forme de tuples `(rows, cols, value)`
-4. Validez en comparant les resultats de orientation='col' de `find_swordfish()`",,,,,,,,37b7246007828bf2,,,,,,,
+4. Validez en comparant les résultats de orientation='col' de `find_swordfish()`",,,,,,,,8e43ea72f6ebfc27,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,ffc701dc,code,fr,b4be882556959b1e,"# Exemple guide 2b : Swordfish par colonnes
 #
 # TODO: Implementez find_swordfish_cols(self) qui detecte les Swordfish
@@ -30054,7 +30080,7 @@ HumanSudokuSolver.apply_xy_wing = apply_xy_wing
 
 print(""Methodes definies : _are_peers, find_xy_wings"")
 ",,,,,,,,991b47ac18a576ee,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,d46ade0f,markdown,fr,6d2fa54b434d2692,"### Exercice 3b : XY-Wing pour un pivot donne
+MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,d46ade0f,markdown,fr,923f52959a5bda88,"### Exercice 3b : XY-Wing pour un pivot donne
 
 **Enonce** : Implementez une fonction `find_xy_wings_for_pivot(self, pivot_row, pivot_col)` qui, pour un pivot donne, cherche toutes les paires d'ailes possibles.
 
@@ -30062,7 +30088,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,d46ade0f,markdown
 1. Verifiez que la cellule pivot a exactement 2 candidats {X, Y}
 2. Parmi les peers bi-valuees du pivot, trouvez les paires (aile1, aile2) ou aile1 = {X, Z} et aile2 = {Y, Z}
 3. Retournez la liste des XY-Wings trouves sous forme de tuples `(wing1, wing2, z)`
-4. Comparez votre resultat avec `find_xy_wings()` de l'exemple pour validation",,,,,,,,6d2fa54b434d2692,,,,,,,
+4. Comparez votre résultat avec `find_xy_wings()` de l'exemple pour validation",,,,,,,,923f52959a5bda88,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,b667ffe1,code,fr,524e80fe709ddc35,"# Exemple guide 3b : XY-Wing pour un pivot donne
 #
 # TODO: Implementez find_xy_wings_for_pivot(pivot_row, pivot_col) qui,
@@ -30081,9 +30107,9 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,b667ffe1,code,fr,
 
 print(""Exercice a completer : XY-Wing pour un pivot donne"")
 ",,,,,,,,524e80fe709ddc35,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,dda45ce9,markdown,fr,14ee8926e1a8fa1f,"### Validation des techniques avancees
+MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,dda45ce9,markdown,fr,c20ac8892f3b4c85,"### Validation des techniques avancees
 
-Les trois exemples precedents (Hidden Pair, Swordfish, XY-Wing) sont maintenant integres a la classe `HumanSudokuSolver`. La cellule suivante teste leur detection sur le puzzle de reference, puis realise une resolution complete en combinant toutes les techniques avancees avant de finir avec le fallback backtracking.",,,,,,,,14ee8926e1a8fa1f,,,,,,,
+Les trois exemples précédents (Hidden Pair, Swordfish, XY-Wing) sont maintenant integres a la classe `HumanSudokuSolver`. La cellule suivante teste leur detection sur le puzzle de reference, puis realise une resolution complete en combinant toutes les techniques avancees avant de finir avec le fallback backtracking.",,,,,,,,c20ac8892f3b4c85,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,c78392d0,code,fr,fb86383cfa57422c,"# Test des 3 exemples resolus : Hidden Pair, Swordfish, XY-Wing
 print(""=== Test des techniques avancees (Exemples resolus) ===\n"")
 
@@ -30126,14 +30152,14 @@ for pivot, w1, w2, z in solver2.find_xy_wings():
 solver2.solve()
 print(f""\nResolu: {solver2.is_solved()}"")
 print(solver2)",,,,,,,,fb86383cfa57422c,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,7f7e6a12,markdown,fr,fda7a8dfa0d96f0a,"## Resume et perspectives
+MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,7f7e6a12,markdown,fr,3e73770c04811615,"## Resume et perspectives
 
-Ce notebook a explore la resolution de Sudoku par **deduction logique progressive**, en implementant les techniques utilisees par les experts humains : **Naked Singles** et **Hidden Singles** pour les puzzles faciles, **Naked Pairs** et **Pointing Pairs** pour le niveau intermediaire, et **X-Wing** pour les grilles avancees. Les techniques supplementaires (Hidden Pairs, Swordfish, XY-Wing) ont ete presentees en exemples guides pour illustrer les strategies expert. Le benchmark sur 5 puzzles faciles a montre que les Hidden Singles dominent avec 149 applications (54% des deductions), suivis des Naked Singles (91 occurrences), tandis que les techniques avancees comme X-Wing ne representent que 2% des cas -- confirmant que la majorite des puzzles courants se resolvent par inference directe sans recours au backtracking.
+Ce notebook a explore la resolution de Sudoku par **deduction logique progressive**, en implementant les techniques utilisees par les experts humains : **Naked Singles** et **Hidden Singles** pour les puzzles faciles, **Naked Pairs** et **Pointing Pairs** pour le niveau intermediaire, et **X-Wing** pour les grilles avancees. Les techniques supplementaires (Hidden Pairs, Swordfish, XY-Wing) ont ete presentees en exemples guides pour illustrer les stratégies expert. Le benchmark sur 5 puzzles faciles a montre que les Hidden Singles dominent avec 149 applications (54% des deductions), suivis des Naked Singles (91 occurrences), tandis que les techniques avancees comme X-Wing ne representent que 2% des cas -- confirmant que la majorite des puzzles courants se resolvent par inference directe sans recours au backtracking.
 
-La comparaison avec le backtracking simple a mis en evidence un avantage qualificatif majeur : les strategies humaines produisent une **chaine de deductions explicable**, ou chaque placement est justifie par une technique logique identifiable, tandis que le backtracking procede par essai-erreur opaque. En termes de performance, le solveur humain est 2 a 5 fois plus rapide sur les puzzles faciles et ne necessite aucun appel recursif, la ou le backtracking accumule 49 a 295 appels. Le mecanisme de fallback vers le backtracking garantit toutefois la completude du solveur sur les instances ou les techniques de deduction atteignent leurs limites.
+La comparaison avec le backtracking simple a mis en evidence un avantage qualificatif majeur : les stratégies humaines produisent une **chaîne de deductions explicable**, ou chaque placement est justifie par une technique logique identifiable, tandis que le backtracking procede par essai-erreur opaque. En termes de performance, le solveur humain est 2 a 5 fois plus rapide sur les puzzles faciles et ne necessite aucun appel récursif, la ou le backtracking accumule 49 a 295 appels. Le mécanisme de fallback vers le backtracking garantit toutefois la completude du solveur sur les instances ou les techniques de deduction atteignent leurs limites.
 
-Le prochain notebook, **Sudoku-9-GraphColoring-Python**, change de paradigme en modelisant le Sudoku comme un probleme de **coloration de graphe** avec NetworkX, ou les 81 cellules deviennent des sommets et les contraintes d'exclusion des aretes, permettant de comparer des heuristiques de coloration (MRV, LCV, Welsh-Powell) sur cette structure reguliere.",,,,,,,,fda7a8dfa0d96f0a,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,b1e81497,markdown,fr,cc4c03992e7d278f,"## Resume
+Le prochain notebook, **Sudoku-9-GraphColoring-Python**, change de paradigme en modelisant le Sudoku comme un problème de **coloration de graphe** avec NetworkX, ou les 81 cellules deviennent des sommets et les contraintes d'exclusion des aretes, permettant de comparer des heuristiques de coloration (MRV, LCV, Welsh-Powell) sur cette structure reguliere.",,,,,,,,3e73770c04811615,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,b1e81497,markdown,fr,a760859f9ee05538,"## Resume
 
 ### Techniques implementees
 
@@ -30141,11 +30167,11 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,b1e81497,markdown
 |-----------|-------------|-----------|
 | **Naked Single** | Case avec un seul candidat | Facile |
 | **Hidden Single** | Valeur avec une seule position possible | Facile |
-| **Naked Pair** | Deux cases avec les memes deux candidats | Moyen |
+| **Naked Pair** | Deux cases avec les mêmes deux candidats | Moyen |
 | **Pointing Pair** | Candidats restreints dans un bloc | Moyen |
 | **X-Wing** | Rectangle de candidats | Avance |
 
-### Strategies par difficulte
+### Stratégies par difficulte
 
 | Niveau | Techniques requises |
 |--------|-------------------|
@@ -30154,7 +30180,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,b1e81497,markdown
 | Hard | + X-Wing |
 | Expert | + Swordfish, XY-Wing, etc. |
 
-### Avantages des strategies humaines
+### Avantages des stratégies humaines
 
 1. **Intuitives** : Refletent la facon dont les humains resolvent
 2. **Pedagogiques** : Chaque technique est comprehensible individuellement
@@ -30174,8 +30200,8 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,b1e81497,markdown
 
 ---
 
-**Navigation** : [<< Sudoku-7-Norvig](Sudoku-7-Norvig-Python.ipynb) | [Index](README.md) | [Sudoku-9-GraphColoring >>](Sudoku-9-GraphColoring-Python.ipynb)",,,,,,,,cc4c03992e7d278f,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Csharp.ipynb,9979781e,markdown,fr,b9f47cb259d1e7bd,"**Navigation** : [Index](README.md) | [<< Sudoku-8 C#](Sudoku-8-HumanStrategies-Csharp.ipynb) | [Sudoku-9 Python >>](Sudoku-9-GraphColoring-Python.ipynb)
+**Navigation** : [<< Sudoku-7-Norvig](Sudoku-7-Norvig-Python.ipynb) | [Index](README.md) | [Sudoku-9-GraphColoring >>](Sudoku-9-GraphColoring-Python.ipynb)",,,,,,,,a760859f9ee05538,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Csharp.ipynb,9979781e,markdown,fr,7e0a88d957c8baae,"**Navigation** : [Index](README.md) | [<< Sudoku-8 C#](Sudoku-8-HumanStrategies-Csharp.ipynb) | [Sudoku-9 Python >>](Sudoku-9-GraphColoring-Python.ipynb)
 
 # Notebook 9: Résolution de Sudoku par Coloration de Graphe
 
@@ -30185,10 +30211,10 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Csharp.ipynb,9979781e,markdown,f
 - **Modéliser** un Sudoku comme un problème de coloration de graphe
 - **Comprendre** la théorie des graphes sous-jacente (81 sommets, degré 20)
 - **Implémenter** les algorithmes de coloration (Backtracking, DSATUR)
-- **Comparer** l'efficacite de différentes strategies de coloration
+- **Comparer** l'efficacite de différentes stratégies de coloration
 
 **Durée estimee** : 30-40 minutes
-**Prérequis** : Notebook 0 (Environment), bases de théorie des graphes",,,,,,,,b9f47cb259d1e7bd,,,,,,,
+**Prérequis** : Notebook 0 (Environment), bases de théorie des graphes",,,,,,,,7e0a88d957c8baae,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Csharp.ipynb,3f4413d2,markdown,fr,9f87622c8edf835c,"## Introduction : Sudoku et Théorie des Graphes
 
 Le Sudoku peut être modélisé comme un **problème de coloration de graphe** :
@@ -31446,7 +31472,7 @@ foreach (var r in easyResults)
 {
     Console.WriteLine($""| {r.Name,-20} | {(r.Success ? ""OK"" : ""ECHEC"")} | {r.TimeMs,14:F2} | {r.NodesExplored,6} | {r.Backtracks,10} |"");
 }",,,,,,,,be3b1ef5d510ea45,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Csharp.ipynb,ec99b21e,markdown,fr,963713a59a2cd463,"### Interprétation : Benchmark Sudokus Faciles
+MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Csharp.ipynb,ec99b21e,markdown,fr,2c75547bf6c40c21,"### Interprétation : Benchmark Sudokus Faciles
 
 **Sortie obtenue** : Les trois algorithmes resolvent les Sudokus faciles avec succès, mais avec des performances notablement différentes.
 
@@ -31462,7 +31488,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Csharp.ipynb,ec99b21e,markdown,f
 3. **Backtracking simple acceptable** : Sur les Sudokus faciles, même l'approche naive reste de l'ordre de quelques millisecondes
 4. Toutes les solutions sont valides (100% de succès)
 
-> **Note technique** : Sur les Sudokus faciles, l'heuristique MRV est particulièrement efficace car les nombreuses valeurs initiales creent rapidement des sommets avec une seule couleur disponible (singletons). MRV detecte ces cas immediatement et les propage, reduisant drastiquement l'arbre de recherche. DSATUR a un surcout de calcul (calcul de la saturation a chaque itération) qui est moins justifie sur des instances simples : il reste plus rapide que le backtracking naif mais derriere MRV ici. Cet ordre s'inverse sur les Sudokus difficiles (voir plus bas).",,,,,,,,963713a59a2cd463,,,,,,,
+> **Note technique** : Sur les Sudokus faciles, l'heuristique MRV est particulièrement efficace car les nombreuses valeurs initiales créent rapidement des sommets avec une seule couleur disponible (singletons). MRV detecte ces cas immediatement et les propage, reduisant drastiquement l'arbre de recherche. DSATUR a un surcout de calcul (calcul de la saturation a chaque itération) qui est moins justifie sur des instances simples : il reste plus rapide que le backtracking naif mais derriere MRV ici. Cet ordre s'inverse sur les Sudokus difficiles (voir plus bas).",,,,,,,,2c75547bf6c40c21,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Csharp.ipynb,84981d52,markdown,fr,33586a5cc297805b,Test de la coloration de graphe sur les puzzles Sudoku difficiles.,,,,,,,,33586a5cc297805b,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Csharp.ipynb,5e4200d8,code,fr,a6136d4c24c311d4,"// Test sur Sudokus difficiles
 var hardSudokus = SudokuHelper.GetSudokus(SudokuDifficulty.Hard);
@@ -31590,7 +31616,7 @@ public class GraphColoringWithPropagation : ISudokuSolver
 }
 
 Console.WriteLine(""Exercices de coloration de graphe a implementer !"");",,,,,,,,fa7e7ac30d45b4b0,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Csharp.ipynb,223184fe,markdown,fr,b2d8c07edc29b3f9,"## Conclusion
+MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Csharp.ipynb,223184fe,markdown,fr,a88117224304ca70,"## Conclusion
 
 Dans ce notebook, nous avons :
 
@@ -31607,7 +31633,7 @@ Dans ce notebook, nous avons :
 |----------|-----------------|
 | [Sudoku-6-AIMA-CSP](./Sudoku-6-AIMA-CSP-Csharp.ipynb) | CSP = coloration avec variables/domaines/contraintes |
 | [Sudoku-7-Norvig](./Sudoku-7-Norvig-Csharp.ipynb) | Propagation similaire a la réduction de domaine |
-| [CSP-1-Fondamentaux](../Search/Part2-CSP/CSP-1-Fundamentals.ipynb) | Théorie generale des CSP |
+| [CSP-1-Fondamentaux](../Search/Part2-CSP/CSP-1-Fundamentals.ipynb) | Théorie générale des CSP |
 
 ---
 
@@ -31615,10 +31641,10 @@ Dans ce notebook, nous avons :
 ---
 
 **Retour au sommaire** : [Index Sudoku](README.md)
-",,,,,,,,b2d8c07edc29b3f9,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb,403f4734,markdown,fr,7409aeaa9bb4da7a,"# Sudoku-9 : Coloration de Graphe (Python)
+",,,,,,,,a88117224304ca70,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb,403f4734,markdown,fr,3ee068bf6b97aae1,"# Sudoku-9 : Coloration de Graphe (Python)
 
-**Navigation** : [<< Human Strategies](Sudoku-8-HumanStrategies-Python.ipynb) | [Index](README.md) | [OR-Tools >>](Sudoku-10-ORTools-Python.ipynb)
+**Navigation** : [<< Human Stratégies](Sudoku-8-HumanStrategies-Python.ipynb) | [Index](README.md) | [OR-Tools >>](Sudoku-10-ORTools-Python.ipynb)
 
 ## Objectifs d'apprentissage
 
@@ -31627,14 +31653,14 @@ A la fin de ce notebook, vous saurez :
 1. **Modeliser** un Sudoku comme un problème de coloration de graphe
 2. **Comprendre** la théorie des graphes sous-jacente (81 sommets, degré 20)
 3. **Utiliser** NetworkX pour manipuler des graphes de contraintes
-4. **Comparer** l'efficacite de différentes strategies de coloration
+4. **Comparer** l'efficacite de différentes stratégies de coloration
 
 **Duree estimee** : ~15 min | **Prerequis** : Sudoku-0 Environment
 
 ---
 
 Ce notebook implemente des solveurs de Sudoku utilisant la **coloration de graphe**, une approche classique de la théorie des graphes.
-",,,,,,,,7409aeaa9bb4da7a,,,,,,,
+",,,,,,,,3ee068bf6b97aae1,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb,34a69449,code,fr,d17a5d3aa1865ab3,"# Imports
 import time
 from typing import List, Optional, Tuple
@@ -31705,20 +31731,20 @@ NetworkX a genere automatiquement :
 
 Chaque sommet represente une cellule, et les aretes representent les contraintes d'exclusion.
 ",,,,,,,,a90b9bbcd1bb0d95,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb,ex-cell-constraints,markdown,fr,3b1d5af6cabc0f40,"## Exercice : Compter les contraintes par cellule
+MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb,ex-cell-constraints,markdown,fr,78e95454859b89a4,"## Exercice : Compter les contraintes par cellule
 
 ### Enonce
 
 Dans le graphe de contraintes du Sudoku, chaque arete represente une exclusion mutuelle entre deux cellules. Les cellules les plus contraintes (celles qui ont le plus de voisins non encore resolus) sont les plus difficiles a remplir.
 
-Implementez `count_unassigned_constraints(coloring, G)` qui retourne un dictionnaire `{vertex: count}` indiquant, pour chaque cellule non coloriee, combien de ses voisins sont egalement non colories.
+Implementez `count_unassigned_constraints(coloring, G)` qui retourne un dictionnaire `{vertex: count}` indiquant, pour chaque cellule non coloriee, combien de ses voisins sont également non colories.
 
 ### Indices
 
 - Étape 1 : Identifiez les sommets non colories (`coloring[v] == 0`)
 - Étape 2 : Pour chaque sommet non colorie, comptez ses voisins non colories
 - Étape 3 : Retournez le dictionnaire trie par nombre de contraintes decroissant
-",,,,,,,,3b1d5af6cabc0f40,,,,,,,
+",,,,,,,,78e95454859b89a4,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb,ex-cell-constraints-code,code,fr,ba875c508c021153,"# EXERCICE : Compter les contraintes par cellule
 #
 # Indications :
@@ -31959,7 +31985,7 @@ benchmark(easy_puzzles, ""Puzzles Faciles"", limit=3)
 hard_puzzles = load_puzzles(str(PUZZLES_DIR / ""Sudoku_hardest.txt""))
 benchmark(hard_puzzles, ""Puzzles Difficiles"", limit=2)
 ",,,,,,,,b99dfbfb303e4fbe,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb,9mkm25kzhhd,markdown,fr,5dd0fb7fd28c6e32,"### Interpretation : Benchmark Graph Coloring
+MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb,9mkm25kzhhd,markdown,fr,a2a95ff0d2af86db,"### Interpretation : Benchmark Graph Coloring
 
 Les résultats montrent que l'approche coloration de graphe est efficace mais moins optimale que les solveurs CSP dedies.
 
@@ -31978,8 +32004,8 @@ Les résultats montrent que l'approche coloration de graphe est efficace mais mo
 2. **L'avantage est la flexibilite** : Facile d'experimentation avec d'autres algorithmes de coloration
 3. **Graphe regulier** : Le degré constant (20) aide a comprendre la structure
 
-> **Note technique** : La coloration de graphe est un problème NP-complet. Le Sudoku est un cas particulier avec une structure très reguliere, ce qui permet des optimisations specifiques que NetworkX n'exploite pas.
-",,,,,,,,5dd0fb7fd28c6e32,,,,,,,
+> **Note technique** : La coloration de graphe est un problème NP-complet. Le Sudoku est un cas particulier avec une structure très reguliere, ce qui permet des optimisations spécifiques que NetworkX n'exploite pas.
+",,,,,,,,a2a95ff0d2af86db,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb,ex-valid-coloring,markdown,fr,bdd408b301cdb893,"## Exercice : Verification d'une coloration valide
 
 ### Enonce
@@ -32025,13 +32051,13 @@ if success:
     print(f""Coloration valide : {is_valid_coloring(coloring, nx.sudoku_graph())}"")
 else:
     print(""Pas de solution"")",,,,,,,,1e5155eb032b8751,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb,ytp2bllgm1n,markdown,fr,9fa266332581bf55,"## Exemple : Coloration avec l'Heuristique LCV
+MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb,ytp2bllgm1n,markdown,fr,1c83a601b2be3279,"## Exemple : Coloration avec l'Heuristique LCV
 
 ### Concept
 
 L'heuristique **LCV (Least Constraining Value)** complete MRV en optimisant l'ordre des couleurs : a chaque étape, choisir la couleur qui reduit le moins les domaines des sommets voisins.
 
-### Strategie LCV
+### Stratégie LCV
 
 1. **Choisir le sommet** : MRV (Minimum Remaining Values)
 2. **Ordonner les couleurs** : LCV (Least Constraining Value)
@@ -32045,7 +32071,7 @@ L'heuristique **LCV (Least Constraining Value)** complete MRV en optimisant l'or
 ### Avantage attendu
 
 LCV peut ralentir la recherche (calcul couteux) mais reduit les backtracks sur les puzzles difficiles en maintenant les domaines des voisins plus ouverts.
-",,,,,,,,9fa266332581bf55,,,,,,,
+",,,,,,,,1c83a601b2be3279,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb,dlfjm9oprek,code,fr,f3d349784da016bc,"def get_available_colors(vertex: int, coloring: List[int]) -> set:
     used = set()
     for neighbor in G.neighbors(vertex):
@@ -32162,13 +32188,13 @@ Les résultats montrent un comportement contre-intuitif de LCV sur ce puzzle dif
 
 > **Note technique** : LCV est plus utile sur des graphes avec des degrés heterogenes (certains sommets beaucoup plus contraints que d'autres). Sur le graphe Sudoku regulier (deg. 20 partout), le gain est limite par le cout de calcul.
 ",,,,,,,,096d206a59a9c584,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb,5b18e409,markdown,fr,10394de9219815d2,"## Exemple guide : Heuristique Welsh-Powell
+MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb,5b18e409,markdown,fr,31926d3ccc9b3d85,"## Exemple guide : Heuristique Welsh-Powell
 
 ### Enonce
 
 Implementez un solveur de Sudoku par coloration de graphe avec l'heuristique **Welsh-Powell**, une approche gloutonne qui ordonne les sommets par degré decroissant avant coloration.
 
-### Strategie Welsh-Powell
+### Stratégie Welsh-Powell
 
 L'heuristique Welsh-Powell est une approche gloutonne classique pour la coloration de graphes :
 
@@ -32189,10 +32215,10 @@ L'heuristique Welsh-Powell est une approche gloutonne classique pour la colorati
 
 **Indice :**
 
-Le degré actuel d'un sommet non colorie est le nombre de ses voisins qui sont egalement non colories. Plus ce degré est eleve, plus le sommet est contraint et doit etre colorie prioritairement.
+Le degré actuel d'un sommet non colorie est le nombre de ses voisins qui sont également non colories. Plus ce degré est eleve, plus le sommet est contraint et doit etre colorie prioritairement.
 
 Welsh-Powell est une heuristique gloutonne classique qui performe bien sur les graphes de coloration généraux, mais peut etre moins efficace que MRV sur Sudoku ou la structure est très reguliere.
-",,,,,,,,10394de9219815d2,,,,,,,
+",,,,,,,,31926d3ccc9b3d85,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb,39831a5e,code,fr,a0485217087c33aa,"def sort_vertices_by_degree(coloring: List[int], G) -> List[int]:
     """"""
     Retourne la liste des sommets non colories tries par degré decroissant.
@@ -32275,14 +32301,14 @@ Les résultats sur le même puzzle `easy_puzzles[0]` illustrent clairement les l
 
 > **Note technique** : Sur les puzzles plus difficiles (`Sudoku_hardest.txt`, `Sudoku_top95.txt`), Welsh-Powell peut partir en branches de recherche très profondes. Un `sys.setrecursionlimit(50000)` est alors necessaire pour eviter un `RecursionError`, et sur Windows la taille de stack Python par defaut (1 MB) peut encore limiter ; les benchmarks sur puzzles difficiles sont donc laisses de cote dans ce notebook pour rester reproductible.
 ",,,,,,,,e72e2a75b6bc9ecb,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb,94f0165b,markdown,fr,059ee92ed792987f,"## Resume et perspectives
+MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb,94f0165b,markdown,fr,833bd2af1cb5d5c0,"## Resume et perspectives
 
-Ce notebook a montre comment modeliser le Sudoku comme un **problème de coloration de graphe** en utilisant NetworkX et sa fonction `nx.sudoku_graph()`, qui genere automatiquement un graphe regulier de 81 sommets et 810 aretes (degré 20 par sommet). L'implementation a couvert trois strategies de coloration : le **backtracking avec heuristique MRV** (Minimum Remaining Values), qui s'est revelee la plus efficace avec 0 backtrack sur les puzzles faciles ; l'heuristique **LCV** (Least Constraining Value), qui ordonne les couleurs candidates par impact minimal sur les voisins mais s'est revelee contre-productive sur le graphe regulier du Sudoku ; et l'heuristique **Welsh-Powell** (tri par degré decroissant), inadaptee a la structure reguliere du graphe Sudoku puisque tous les sommets ont un degré identique.
+Ce notebook a montre comment modeliser le Sudoku comme un **problème de coloration de graphe** en utilisant NetworkX et sa fonction `nx.sudoku_graph()`, qui genere automatiquement un graphe regulier de 81 sommets et 810 aretes (degré 20 par sommet). L'implementation a couvert trois stratégies de coloration : le **backtracking avec heuristique MRV** (Minimum Remaining Values), qui s'est revelee la plus efficace avec 0 backtrack sur les puzzles faciles ; l'heuristique **LCV** (Least Constraining Value), qui ordonne les couleurs candidates par impact minimal sur les voisins mais s'est revelee contre-productive sur le graphe regulier du Sudoku ; et l'heuristique **Welsh-Powell** (tri par degré decroissant), inadaptee a la structure reguliere du graphe Sudoku puisque tous les sommets ont un degré identique.
 
 Les benchmarks comparatifs ont permis de quantifier ces différences : MRV resout un puzzle facile en 37 noeuds et 0 backtrack, tandis que Welsh-Powell necessite 992 noeuds et 955 backtracks sur la même instance. Cette expérience illustre un principe fondamental de la resolution de problemes combinatoires : l'efficacite d'une heuristique depend fortement de la structure du graphe sous-jacent. Les heuristiques conques pour des graphes heterogenes (cartes geographiques, allocation de registres) perdent leur avantage sur les graphes reguliers comme celui du Sudoku.
 
-Le prochain notebook, **Sudoku-10-ORTools-Python**, passe a une approche industrielle de la programmation par contraintes avec OR-Tools CP-SAT, un solveur qui combine propagation de contraintes, recherche locale et programmation lineaire pour atteindre des performances nettement superieures sur les instances difficiles.",,,,,,,,059ee92ed792987f,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb,022b15c7,markdown,fr,d5eefab6a96a18fc,"## Resume
+Le prochain notebook, **Sudoku-10-ORTools-Python**, passe a une approche industrielle de la programmation par contraintes avec OR-Tools CP-SAT, un solveur qui combine propagation de contraintes, recherche locale et programmation lineaire pour atteindre des performances nettement superieures sur les instances difficiles.",,,,,,,,833bd2af1cb5d5c0,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb,022b15c7,markdown,fr,7ba5e27b9f9bdd42,"## Resume
 
 ### NetworkX pour Sudoku
 
@@ -32302,8 +32328,8 @@ NetworkX peut resoudre de nombreux problemes de coloration :
 
 ---
 
-**Navigation** : [<< Human Strategies](Sudoku-8-HumanStrategies-Python.ipynb) | [Index](README.md) | [OR-Tools >>](Sudoku-10-ORTools-Python.ipynb)
-",,,,,,,,d5eefab6a96a18fc,,,,,,,
+**Navigation** : [<< Human Stratégies](Sudoku-8-HumanStrategies-Python.ipynb) | [Index](README.md) | [OR-Tools >>](Sudoku-10-ORTools-Python.ipynb)
+",,,,,,,,7ba5e27b9f9bdd42,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Csharp.ipynb,cell-12130bab,markdown,fr,e0b62c3bbc32e31f,"## Exercice : Vérifier qu'une grille est valide
 
 **Objectif :**
@@ -32423,16 +32449,16 @@ public int[,] SolveSudokuX(int[,] puzzle)
     return null; // TODO etudiant
 }
 ",,,,,,,,f3631fad8bb9bb2a,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb,cell-d4e7f3f8,markdown,fr,54df7b10ba20c045,"## Exercice : Ajouter une contrainte d'anti-symetrie
+MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb,cell-d4e7f3f8,markdown,fr,d3bf1c9016a2bb2c,"## Exercice : Ajouter une contrainte d'anti-symetrie
 
 **Objectif**
-Ajoutez au modele OR-Tools une contrainte qui force la premiere ligne
+Ajoutez au modèle OR-Tools une contrainte qui force la première ligne
 a etre strictement croissante (1,2,3,4,5,6,7,8,9), eliminant ainsi
 les solutions symetriques par rotation/reflection.
 
 **Indice**
 Utilisez `model.Add(cells[0][i] == i+1)` pour chaque colonne i de la ligne 0.
-",,,,,,,,54df7b10ba20c045,,,,,,,
+",,,,,,,,d3bf1c9016a2bb2c,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb,cell-d8057ef5,code,fr,0cefc2d3ae0f84a1,"# EXERCICE : Ajouter une contrainte d'anti-symetrie
 def solve_with_anti_symmetry(grid: SudokuGrid) -> dict:
     # TODO: Construisez le modele CP-SAT avec la contrainte supplementaire
@@ -32491,16 +32517,16 @@ public Dictionary<string, (double TimeMs, int NodeCount)> CompareBDDvsMDD(int[,]
     return null; // TODO etudiant
 }
 ",,,,,,,,bf65484470b09cdc,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,ex1-zero-shot-prompt,markdown,fr,6085be4abf2bcb51,"## Exercice : Optimiser le prompt zero-shot
+MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,ex1-zero-shot-prompt,markdown,fr,60c0cd70153270bd,"## Exercice : Optimiser le prompt zero-shot
 
 **Objectif**
 Modifiez le prompt zero-shot pour ameliorer le taux de succes.
-Testez au moins 2 variantes et comparez les resultats.
+Testez au moins 2 variantes et comparez les résultats.
 
 **Indice**
 Ajoutez des instructions plus precises sur le format de sortie attendu.
 Testez avec des puzzles faciles pour mesurer l'impact.
-",,,,,,,,6085be4abf2bcb51,,,,,,,
+",,,,,,,,60c0cd70153270bd,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,ex1-zero-shot-prompt-code,code,fr,5c9d312c4b952b34,"# EXERCICE : Optimiser le prompt zero-shot
 def optimized_zero_shot_solve(grid: List[List[int]], client) -> Optional[List[List[int]]]:
     # TODO: Creez un prompt optimise pour resoudre le Sudoku
@@ -32508,16 +32534,16 @@ def optimized_zero_shot_solve(grid: List[List[int]], client) -> Optional[List[Li
     result = None  # TODO etudiant
     return result
 ",,,,,,,,5c9d312c4b952b34,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,ex2-shot-comparison,markdown,fr,4dda90b37bc64243,"## Exercice : Comparer zero-shot vs few-shot vs code interpreter
+MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,ex2-shot-comparison,markdown,fr,39d9d60f72002990,"## Exercice : Comparer zero-shot vs few-shot vs code interpreter
 
 **Objectif**
-Implementez une fonction qui teste les 3 approches sur les memes puzzles
+Implementez une fonction qui teste les 3 approches sur les mêmes puzzles
 et retourne un tableau comparatif des taux de succes et temps de resolution.
 
 **Indice**
-Utilisez les fonctions deja definies pour chaque approche et mesurez le temps
+Utilisez les fonctions déjà définies pour chaque approche et mesurez le temps
 avec `time.time()`.
-",,,,,,,,4dda90b37bc64243,,,,,,,
+",,,,,,,,39d9d60f72002990,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,ex2-shot-comparison-code,code,fr,bd6c4a2aff7267f3,"# EXERCICE : Comparer zero-shot vs few-shot vs code interpreter
 def compare_llm_approaches(puzzles: List[str], client, limit: int = 3) -> dict:
     # TODO: Testez les 3 approches LLM sur les memes puzzles
@@ -32542,16 +32568,16 @@ def analyze_llm_errors(predicted: List[List[int]], solution: List[List[int]]) ->
     result = {}  # TODO etudiant
     return result
 ",,,,,,,,3afcde2462677301,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Csharp.ipynb,cell-540beb27,markdown,fr,c380b358e037ea11,"## Exercice : Construire la matrice de couverture pour un mini-Sudoku
+MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Csharp.ipynb,cell-540beb27,markdown,fr,4095ac88a4d7b3aa,"## Exercice : Construire la matrice de couverture pour un mini-Sudoku
 
 **Objectif :**
 Construisez manuellement la matrice de couverture exacte pour un Sudoku 4x4
 avec DlxLib.
 
 **Indice :**
-Identifiez les 4 types de contraintes et creez les lignes de la matrice
+Identifiez les 4 types de contraintes et créez les lignes de la matrice
 pour chaque assignation (cellule, valeur) possible.
-",,,,,,,,c380b358e037ea11,,,,,,,
+",,,,,,,,4095ac88a4d7b3aa,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Csharp.ipynb,cell-c74db898,code,fr,8b8591b2c9bcb1f2,"// EXERCICE : Construire la matrice de couverture pour un mini-Sudoku 4x4
 public List<List<int>> BuildMiniSudokuMatrix()
 {
@@ -32594,7 +32620,7 @@ public void CompareDlxVsBacktracking()
     // Affichez les resultats dans un tableau
 }
 ",,,,,,,,729973454496582a,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,cell-8fdeca66,markdown,fr,19e520f094be40bb,"## Exercice : Construire la matrice de couverture exacte pour un mini-Sudoku
+MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,cell-8fdeca66,markdown,fr,535ce53d1f141536,"## Exercice : Construire la matrice de couverture exacte pour un mini-Sudoku
 
 **Objectif**
 Construisez manuellement la matrice de couverture exacte pour un Sudoku 4x4
@@ -32603,9 +32629,9 @@ Construisez manuellement la matrice de couverture exacte pour un Sudoku 4x4
 **Indice**
 Identifiez les 4 types de contraintes (ligne, colonne, bloc, cellule) et
 comptez le nombre de colonnes de la matrice. Pour chaque assignation possible
-(cellule, valeur), creez une ligne dans la matrice avec des 1 aux colonnes
+(cellule, valeur), créez une ligne dans la matrice avec des 1 aux colonnes
 des contraintes satisfaites.
-",,,,,,,,19e520f094be40bb,,,,,,,
+",,,,,,,,535ce53d1f141536,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,cell-9266e872,code,fr,1e58ca16fb787dc3,"# EXERCICE : Construire la matrice de couverture exacte pour un mini-Sudoku 4x4
 def build_mini_sudoku_matrix() -> list:
     # TODO: Construisez la matrice binaire de couverture exacte
@@ -32614,7 +32640,7 @@ def build_mini_sudoku_matrix() -> list:
     result = None  # TODO etudiant
     return result
 ",,,,,,,,1e58ca16fb787dc3,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,cell-53ed2cd1,markdown,fr,92e8aa8d4509c254,"## Exercice : Analyse de complexite de Dancing Links
+MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,cell-53ed2cd1,markdown,fr,3f65bf1bace34bfe,"## Exercice : Analyse de complexite de Dancing Links
 
 **Objectif**
 Analysez le nombre de noeuds explores par DLX en fonction de la difficulte
@@ -32623,8 +32649,8 @@ du puzzle. Mesurez et comparez avec le backtracking simple.
 **Étape 1**
 Ajoutez un compteur de noeuds dans la classe DancingLinks.
 **Étape 2**
-Lancez le benchmark et collectez les donnees.
-",,,,,,,,92e8aa8d4509c254,,,,,,,
+Lancez le benchmark et collectez les données.
+",,,,,,,,3f65bf1bace34bfe,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,cell-ff80d3b2,code,fr,52c6dee9b47eb6e4,"# EXERCICE : Analyse de complexite de Dancing Links
 def count_nodes_explored(puzzle_str: str) -> int:
     # TODO: Resolvez le puzzle avec DLX et retournez
@@ -32632,16 +32658,16 @@ def count_nodes_explored(puzzle_str: str) -> int:
     result = 0  # TODO etudiant
     return result
 ",,,,,,,,52c6dee9b47eb6e4,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Csharp.ipynb,cell-f737f5d7,markdown,fr,e249a20d48ec43d1,"## Exercice : Implémenter une fonction de fitness ponderee
+MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Csharp.ipynb,cell-f737f5d7,markdown,fr,9bcc166d7f01d7b6,"## Exercice : Implémenter une fonction de fitness ponderee
 
 **Objectif :**
-Creez une fonction de fitness qui pondere differemment les conflits
+Créez une fonction de fitness qui pondere differemment les conflits
 de lignes, colonnes et blocs (par exemple, pénaliser plus les conflits de lignes).
 
 **Indice :**
 Au lieu de simplement compter le nombre total de conflits, multipliez chaque
 type par un coefficient et sommez.
-",,,,,,,,e249a20d48ec43d1,,,,,,,
+",,,,,,,,9bcc166d7f01d7b6,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Csharp.ipynb,cell-88ccad50,code,fr,47b1e731af556102,"// EXERCICE : Implementer une fonction de fitness ponderee
 public double WeightedFitness(int[,] grid, double rowWeight = 1.0, double colWeight = 1.0, double blockWeight = 1.0)
 {
@@ -32649,7 +32675,7 @@ public double WeightedFitness(int[,] grid, double rowWeight = 1.0, double colWei
     return 0.0; // TODO etudiant
 }
 ",,,,,,,,47b1e731af556102,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Csharp.ipynb,cell-e87abb30,markdown,fr,351189da8afb0549,"## Exercice : Creer un opérateur de mutation swap intra-ligne
+MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Csharp.ipynb,cell-e87abb30,markdown,fr,1275e7392e2e3a7d,"## Exercice : Créer un opérateur de mutation swap intra-ligne
 
 **Objectif :**
 Implémentez un opérateur de mutation qui echange deux gènes dans la même ligne
@@ -32657,7 +32683,7 @@ du chromosome.
 
 **Indice :**
 Choisissez une ligne aléatoire, puis deux positions dans cette ligne, et echangez-les.
-",,,,,,,,351189da8afb0549,,,,,,,
+",,,,,,,,1275e7392e2e3a7d,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Csharp.ipynb,cell-6c9a0750,code,fr,99293fec2dccab71,"// EXERCICE : Creer un operateur de mutation swap intra-ligne
 public int[] SwapMutation(int[] chromosome, int gridSize = 9)
 {
@@ -32666,15 +32692,15 @@ public int[] SwapMutation(int[] chromosome, int gridSize = 9)
     return null; // TODO etudiant
 }
 ",,,,,,,,99293fec2dccab71,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Csharp.ipynb,cell-65e1775f,markdown,fr,3e8a932d23be1fb4,"## Exercice : Comparer les approches par cellules vs permutations
+MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Csharp.ipynb,cell-65e1775f,markdown,fr,2bd521cccc7eb514,"## Exercice : Comparer les approches par cellules vs permutations
 
 **Objectif :**
 Comparez les performances des deux types de chromosomes
 (cellules vs permutations de lignes) sur les mêmes puzzles.
 
 **Indice :**
-Lancez les deux solveurs avec les mêmes parametres et comparez les taux de succès.
-",,,,,,,,3e8a932d23be1fb4,,,,,,,
+Lancez les deux solveurs avec les mêmes paramètres et comparez les taux de succès.
+",,,,,,,,2bd521cccc7eb514,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Csharp.ipynb,cell-fc30d0aa,code,fr,6841f020d0f88519,"// EXERCICE : Comparer les approches par cellules vs permutations
 public Dictionary<string, double> CompareChromosomeTypes(int[,] puzzle, int runs = 5)
 {
@@ -32683,9 +32709,9 @@ public Dictionary<string, double> CompareChromosomeTypes(int[,] puzzle, int runs
     return null; // TODO etudiant
 }
 ",,,,,,,,6841f020d0f88519,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,cell-74cb985c,markdown,fr,5754664e3321b79e,"## 7. Comparaison quantitative avec solveurs exacts (Prong B #3801)
+MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,cell-74cb985c,markdown,fr,5ab0cb766c2f4b1c,"## 7. Comparaison quantitative avec solveurs exacts (Prong B #3801)
 
-Le benchmark precedent (Section 5) a mesure les algorithmes genetiques sur 3 puzzles faciles (1/3 resolu, ~1-30s par puzzle). Pour situer les GA par rapport aux solveurs exacts, voici une **comparaison quantitative** sur les memes classes de puzzles (Easy / Hard), avec les chiffres reels publies dans les notebooks voisins.
+Le benchmark précédent (Section 5) a mesure les algorithmes génétiques sur 3 puzzles faciles (1/3 resolu, ~1-30s par puzzle). Pour situer les GA par rapport aux solveurs exacts, voici une **comparaison quantitative** sur les mêmes classes de puzzles (Easy / Hard), avec les chiffres reels publies dans les notebooks voisins.
 
 ### Tableau comparatif (chiffres verifies, sources citees)
 
@@ -32698,17 +32724,17 @@ Le benchmark precedent (Section 5) a mesure les algorithmes genetiques sur 3 puz
 
 ### Observations (Prong B illustre)
 
-1. **Ecart de 1 a 3 ordres de grandeur** entre GA et solveurs exacts sur les memes instances :
-   - GA Permutations Easy : ~10 000 ms (estimation d'apres cell 22)
+1. **Ecart de 1 a 3 ordres de grandeur** entre GA et solveurs exacts sur les mêmes instances :
+   - GA Permutations Easy : ~10 000 ms (estimation d'après cell 22)
    - OR-Tools CP-SAT Easy : 14.59 ms moyen
    - **Ratio GA / OR-Tools ~ 700x** sur Easy.
 2. **Taux de succes** : 1/3 (GA) vs 10/10 (Backtracking, OR-Tools) -- les GA sont **non-garantis**, les solveurs exacts sont **complets**.
-3. **Passage a l'echelle** : OR-Tools reste ~24 ms meme sur Top11 (puzzles les plus durs), GA non teste au-dela de Easy mais extrapolation pessimiste.
-4. **Valeur pedagogique des GA** : les algorithmes genetiques ne sont **pas adaptes au Sudoku** mais illustrent une famille de methodes (recherche stochastique, sans garantie) complementaire des solveurs exacts (garantis).
+3. **Passage a l'echelle** : OR-Tools reste ~24 ms même sur Top11 (puzzles les plus durs), GA non teste au-dela de Easy mais extrapolation pessimiste.
+4. **Valeur pedagogique des GA** : les algorithmes génétiques ne sont **pas adaptes au Sudoku** mais illustrent une famille de méthodes (recherche stochastique, sans garantie) complementaire des solveurs exacts (garantis).
 
 > **Note methodologique** : tous les chiffres cites proviennent des cellules de benchmark des notebooks sources (outputs reels, ec != null, 0 erreur). Aucune valeur fabriquee.
-",,,,,,,,5754664e3321b79e,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,cell-bed04ec1,markdown,fr,e3b3c95e0a7f8b50,"## Exercice : Estimer le ratio GA / solveur-exact (Prong B reflexif)
+",,,,,,,,5ab0cb766c2f4b1c,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,cell-bed04ec1,markdown,fr,c86c9d7514f9d096,"## Exercice : Estimer le ratio GA / solveur-exact (Prong B reflexif)
 
 ### Contexte
 
@@ -32716,13 +32742,13 @@ Le tableau ci-dessus compare les GA (mesure : ~1-30s par puzzle) aux solveurs ex
 
 ### Enonce
 
-A partir des **chiffres reels** du tableau comparatif (cellule precedente) :
+A partir des **chiffres reels** du tableau comparatif (cellule précédente) :
 
 1. Calculer le ratio `temps_GA / temps_OR-Tools` sur Easy, en utilisant :
-   - GA : le **pire cas** observe (Puzzle 3 = 29.53 s = 29530 ms, d'apres `Sudoku-3-Genetic-Python` cell 22 du notebook original).
+   - GA : le **pire cas** observe (Puzzle 3 = 29.53 s = 29530 ms, d'après `Sudoku-3-Genetic-Python` cell 22 du notebook original).
    - OR-Tools : le **temps moyen** sur Easy (14.59 ms).
 2. Comparer avec le ratio Backtracking / OR-Tools (143.67 / 14.59).
-3. Conclure sur la **position des GA dans la hierarchie** : efficaces / equivalentes / nettement inferieures / sans commune mesure.
+3. Conclure sur la **position des GA dans la hiérarchie** : efficaces / equivalentes / nettement inferieures / sans commune mesure.
 
 ### Indication
 
@@ -32737,7 +32763,7 @@ ratio_ga_ortools = None  # TODO etudiant
 ratio_bt_ortools = None  # TODO etudiant
 conclusion       = None  # TODO etudiant
 ```
-",,,,,,,,e3b3c95e0a7f8b50,,,,,,,
+",,,,,,,,c86c9d7514f9d096,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,cell-ad5721d2,code,fr,80249dcba928d38d,"# Exercice : Estimer le ratio GA / solveur-exact (Prong B reflexif)
 # Cf. cellule markdown precedente pour l'enonce et les indications.
 
@@ -32812,15 +32838,15 @@ public int ComputePartialEnergy(int[,] grid)
     return 0; // TODO etudiant
 }
 ",,,,,,,,59174b80e03ee072,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,cell-2f739ce6,markdown,fr,90251734ba33e311,"## Exercice : Générer un voisin par échange dans un bloc
+MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,cell-2f739ce6,markdown,fr,3bed86451b2ecbae,"## Exercice : Générer un voisin par échange dans un bloc
 
 **Objectif :**
-Implémentez un operateur de voisinage qui échange deux valeurs non fixees
+Implémentez un opérateur de voisinage qui échange deux valeurs non fixees
 dans le même bloc 3x3 au lieu de la même ligne.
 
 **Indice :**
 Choisissez un bloc aleatoire, puis deux cellules non fixees dans ce bloc.
-",,,,,,,,90251734ba33e311,,,,,,,
+",,,,,,,,3bed86451b2ecbae,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,cell-97f29c0e,code,fr,7fd6526fbbbeaf80,"// EXERCICE : Generer un voisin par echange dans un bloc
 public (int[,] Grid, (int, int) Pos1, (int, int) Pos2) GenerateBlockNeighbor(int[,] grid, bool[,] isFixed, Random rng)
 {
@@ -32861,16 +32887,16 @@ def compute_partial_energy(grid: np.ndarray) -> int:
     return result
 print(""Exercice a completer"")
 ",,,,,,,,6db302a3d1c216c4,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,cell-8e341e75,markdown,fr,63f5841dc07fc7df,"## Exercice : Generer un voisin par echange de bloc
+MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,cell-8e341e75,markdown,fr,cc2d1a26bd30d048,"## Exercice : Generer un voisin par echange de bloc
 
 **Objectif**
-Implementez un operateur de voisinage qui echange deux valeurs non fixees
-dans le meme bloc 3x3 (au lieu de la meme ligne).
+Implementez un opérateur de voisinage qui echange deux valeurs non fixees
+dans le même bloc 3x3 (au lieu de la même ligne).
 
 **Indice**
 Choisissez un bloc aleatoire, puis deux cellules non fixees dans ce bloc,
 et echangez leurs valeurs.
-",,,,,,,,63f5841dc07fc7df,,,,,,,
+",,,,,,,,cc2d1a26bd30d048,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,cell-6e33a250,code,fr,bbcc7da0796f3061,"# EXERCICE : Generer un voisin par echange de bloc
 def generate_block_neighbor(grid: np.ndarray, is_fixed: np.ndarray, rng: random.Random) -> Tuple[np.ndarray, Tuple]:
     # TODO: Echangez deux valeurs non fixees dans un meme bloc 3x3
@@ -32879,16 +32905,16 @@ def generate_block_neighbor(grid: np.ndarray, is_fixed: np.ndarray, rng: random.
     return result
 print(""Exercice a completer"")
 ",,,,,,,,bbcc7da0796f3061,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,cell-053d1c51,markdown,fr,a70528eea669cb36,"## Exercice : Comparer les schemas de refroidissement
+MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,cell-053d1c51,markdown,fr,56634b4e06525776,"## Exercice : Comparer les schemas de refroidissement
 
 **Objectif**
-Comparez le schema de refroidissement lineaire et exponentiel sur les memes puzzles.
+Comparez le schema de refroidissement lineaire et exponentiel sur les mêmes puzzles.
 
 **Étape 1**
 Implementez un schema de refroidissement exponentiel: T = T_init * alpha^step
 **Étape 2**
 Lancez les benchmarks et comparez les taux de succes.
-",,,,,,,,a70528eea669cb36,,,,,,,
+",,,,,,,,56634b4e06525776,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,cell-1facbe74,code,fr,d7dfbb9db24e9674,"# EXERCICE : Comparer les schemas de refroidissement
 def exponential_cooling(T_init: float, T_min: float, alpha: float, steps: int) -> List[float]:
     # TODO: Generez une liste de temperatures selon le schema exponentiel
@@ -32897,9 +32923,9 @@ def exponential_cooling(T_init: float, T_min: float, alpha: float, steps: int) -
     return result
 print(""Exercice a completer"")
 ",,,,,,,,d7dfbb9db24e9674,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,cell-29f37419,markdown,fr,0308ce2b991ff784,"## 11. Comparaison quantitative SA vs Backtracking (Prong B #3801)
+MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,cell-29f37419,markdown,fr,77dcf19bc6a69a38,"## 11. Comparaison quantitative SA vs Backtracking (Prong B #3801)
 
-Le benchmark precedent (Section 8, cell 29) a mesure le recuit simule (SA) sur **3 puzzles faciles** (~36-51 cellules vides) avec un temps culminant a **~221 secondes** sur le puzzle 3 (51 cellules). Pour positionner SA face au solveur exact (Backtracking) sur les memes instances, voici une **comparaison quantitative** avec les chiffres reels publies dans les cellules voisines (cell 29 SA, cell 32 Backtracking).
+Le benchmark précédent (Section 8, cell 29) a mesure le recuit simule (SA) sur **3 puzzles faciles** (~36-51 cellules vides) avec un temps culminant a **~221 secondes** sur le puzzle 3 (51 cellules). Pour positionner SA face au solveur exact (Backtracking) sur les mêmes instances, voici une **comparaison quantitative** avec les chiffres reels publies dans les cellules voisines (cell 29 SA, cell 32 Backtracking).
 
 ### Tableau comparatif (chiffres verifies, sources citees)
 
@@ -32911,33 +32937,33 @@ Le benchmark precedent (Section 8, cell 29) a mesure le recuit simule (SA) sur *
 
 ### Observations (Prong B illustre)
 
-1. **Ecart de 2 a 5 ordres de grandeur** entre SA et Backtracking sur les memes instances. Le ratio explose avec la difficulte (cellules vides) : 131x -> 2 027x -> 24 154x.
+1. **Ecart de 2 a 5 ordres de grandeur** entre SA et Backtracking sur les mêmes instances. Le ratio explose avec la difficulte (cellules vides) : 131x -> 2 027x -> 24 154x.
 2. **Garantie d'exactitude** : Backtracking est **complet** (trouve une solution si elle existe), SA est **non garanti** (les 3 OK ci-dessus dependent du seed et du time budget).
 3. **Cout runtime** : SA depasse la minute sur le puzzle 3 (51 vides), Backtracking reste sous les 10 ms. Pour la production, Backtracking (ou DLX) est systematiquement preferable.
-4. **Valeur pedagogique du SA** : illustre une **famille de methodes** (recherche locale + stochasticite) complementaire des solveurs exacts. Le SA brille sur des problemes ou l'espace de recherche est trop grand pour l'exhaustif et ou une solution ""proche de l'optimal"" suffit (TSP, planning, scheduling). Pour le Sudoku, ce n'est **pas** le cas : backtracking + danse-links (DLX) dominent.
+4. **Valeur pedagogique du SA** : illustre une **famille de méthodes** (recherche locale + stochasticite) complementaire des solveurs exacts. Le SA brille sur des problemes ou l'espace de recherche est trop grand pour l'exhaustif et ou une solution ""proche de l'optimal"" suffit (TSP, planning, scheduling). Pour le Sudoku, ce n'est **pas** le cas : backtracking + danse-links (DLX) dominent.
 
 > **Note methodologique** : tous les chiffres cites proviennent des cellules benchmark du notebook source (outputs reels, ec != null, 0 erreur). Aucune valeur fabriquee. Le recuit simule est execute avec `T0=1.0, alpha=0.999, iterations_per_temp=100, Tmin=0.001, max_restarts=10` (cell 29).
-",,,,,,,,0308ce2b991ff784,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,cell-7c2a3422,markdown,fr,14f10f04da8742c0,"## Exercice : Estimer le ratio SA / Backtracking (Prong B reflexif)
+",,,,,,,,77dcf19bc6a69a38,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,cell-7c2a3422,markdown,fr,6afffdb27abe3d5f,"## Exercice : Estimer le ratio SA / Backtracking (Prong B reflexif)
 
 ### Contexte
 
-Le tableau ci-dessus compare le recuit simule (heuristique stochastique, ~131 ms -> 208 s) au Backtracking (solveur exact, ~1 ms -> 9 ms) sur 3 puzzles Easy du meme fichier. Pour faire toucher du doigt le **ratio de cout** et sa **non-linearite avec la difficulte**, on veut le chiffrer.
+Le tableau ci-dessus compare le recuit simule (heuristique stochastique, ~131 ms -> 208 s) au Backtracking (solveur exact, ~1 ms -> 9 ms) sur 3 puzzles Easy du même fichier. Pour faire toucher du doigt le **ratio de cout** et sa **non-linearite avec la difficulte**, on veut le chiffrer.
 
 ### Enonce
 
-A partir des **chiffres reels** du tableau comparatif (cellule precedente) :
+A partir des **chiffres reels** du tableau comparatif (cellule précédente) :
 
 1. Calculer le ratio `temps_SA / temps_BT` pour chacun des 3 puzzles.
 2. Observer la **non-linearite** : le ratio explose-t-il lineairement avec le nombre de cellules vides, ou exponentiellement ?
-3. Conclure sur la **position du SA dans la hierarchie** : efficace / equivalentes / nettement inferieures / sans commune mesure, sur le cas Sudoku.
+3. Conclure sur la **position du SA dans la hiérarchie** : efficace / equivalentes / nettement inferieures / sans commune mesure, sur le cas Sudoku.
 
 ### Indication
 
 - `ratio_puzzle_X = t_sa_X_ms / t_bt_X_ms`
 - Cellules vides : 36 -> 49 -> 51 (Puzzles 1 -> 2 -> 3)
-- Si `ratio_puzzle_3 / ratio_puzzle_1 > 10`, on a une **croissance super-lineaire** -> methode inadaptee au scaling
-- Suggestion : `conclude_prong_b()` retourne une categorie parmi `""lineaire""`, `""polynomial""`, `""exponentiel""`, `""autre""`
+- Si `ratio_puzzle_3 / ratio_puzzle_1 > 10`, on a une **croissance super-lineaire** -> méthode inadaptee au scaling
+- Suggestion : `conclude_prong_b()` retourne une catégorie parmi `""lineaire""`, `""polynomial""`, `""exponentiel""`, `""autre""`
 
 ### Solution (a completer par l'etudiant)
 
@@ -32947,7 +32973,7 @@ ratio_puzzle_2 = None  # TODO etudiant
 ratio_puzzle_3 = None  # TODO etudiant
 conclusion     = None  # TODO etudiant
 ```
-",,,,,,,,14f10f04da8742c0,,,,,,,
+",,,,,,,,6afffdb27abe3d5f,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,cell-998bfe01,code,fr,67c2e3caf12729f7,"# Exercice : Estimer le ratio SA / Backtracking (Prong B reflexif)
 # Cf. cellule markdown precedente pour l'enonce et les indications.
 
@@ -32997,7 +33023,7 @@ print()
 if r1 is None:
     print("">>> Exercice a completer : implementer compute_ratio_sa_bt() et conclude_prong_b()"")
 ",,,,,,,,67c2e3caf12729f7,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,cell-bc0eceef,markdown,fr,cb0c1c9a8144b4c6,"### References citees dans la section 11 (chiffres verifies)
+MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,cell-bc0eceef,markdown,fr,cef20c1a370f7dbd,"### References citees dans la section 11 (chiffres verifies)
 
 - `MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb` (cell 29 — benchmark SA sur 3 Easy)
 - `MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb` (cell 32 — comparaison BT vs SA sur 3 Easy)
@@ -33008,8 +33034,8 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,cell-bc0eceef,
 - `MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb` (cell 19 — OR-Tools CP-SAT benchmark)
 - `MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb` (cell 22 — Genetic Algorithm benchmark)
 
-> **Note pedagogique** : ces ratios (SA/BT ~131 a ~24 154x) demontrent que **le recuit simule est inadapte au Sudoku en production**, malgre sa richesse theorique. Cf. tableau comparatif dans la Section 7 de Sudoku-3-Genetic-Python (ratio GA/OR-Tools ~700x sur Easy).
-",,,,,,,,cb0c1c9a8144b4c6,,,,,,,
+> **Note pedagogique** : ces ratios (SA/BT ~131 a ~24 154x) demontrent que **le recuit simule est inadapte au Sudoku en production**, malgre sa richesse théorique. Cf. tableau comparatif dans la Section 7 de Sudoku-3-Genetic-Python (ratio GA/OR-Tools ~700x sur Easy).
+",,,,,,,,cef20c1a370f7dbd,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb,cell-49c662b6,markdown,fr,40bd7cf516de14b8,"## Exercice : Mesurer l'impact du nombre de particules
 
 **Objectif :**
@@ -33132,16 +33158,16 @@ public List<(int Row, int Col, int Value)> FindHiddenSingles(Dictionary<(int, in
     return null; // TODO etudiant
 }
 ",,,,,,,,532ba96a86be75c1,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,cell-ba432058,markdown,fr,331d3a06eb69efc0,"## Exercice : Detection de paires nues (Naked Pairs)
+MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,cell-ba432058,markdown,fr,76137cb585cd6997,"## Exercice : Detection de paires nues (Naked Pairs)
 
 **Objectif :**
-Implementez la detection des Naked Pairs : quand deux cellules d'une meme unité
-ont exactement les memes deux candidats, ces valeurs peuvent etre eliminees
+Implementez la detection des Naked Pairs : quand deux cellules d'une même unité
+ont exactement les mêmes deux candidats, ces valeurs peuvent etre eliminees
 des autres cellules de l'unité.
 
 **Indice :**
-Parcourez chaque unité et cherchez des paires de cellules avec les memes 2 candidats.
-",,,,,,,,331d3a06eb69efc0,,,,,,,
+Parcourez chaque unité et cherchez des paires de cellules avec les mêmes 2 candidats.
+",,,,,,,,76137cb585cd6997,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,cell-511956d9,code,fr,0fd9ebd40903db40,"// EXERCICE : Detection de paires nues (Naked Pairs)
 public List<((int, int) Cell1, (int, int) Cell2, HashSet<int> Values)> FindNakedPairs(Dictionary<(int, int), HashSet<int>> candidates)
 {
@@ -33167,7 +33193,7 @@ public Dictionary<string, double> CompareWithAndWithoutPropagation(List<int[,]> 
     return null; // TODO etudiant
 }
 ",,,,,,,,3004752bbb54d78a,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Python.ipynb,cell-c705c6d5,markdown,fr,6557847277864697,"## Exercice : Analyser l'impact de la propagation des contraintes
+MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Python.ipynb,cell-c705c6d5,markdown,fr,a41b67673268cfae,"## Exercice : Analyser l'impact de la propagation des contraintes
 
 **Objectif**
 Desactivez la propagation (eliminate) dans le solveur de Norvig et comparez
@@ -33175,8 +33201,8 @@ le nombre d'appels recursifs et le temps de resolution.
 
 **Indice**
 Modifiez la fonction `solve` pour court-circuiter `eliminate` et mesurer
-la difference de performance sur les puzzles difficiles.
-",,,,,,,,6557847277864697,,,,,,,
+la différence de performance sur les puzzles difficiles.
+",,,,,,,,a41b67673268cfae,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Python.ipynb,cell-e5725826,code,fr,9f79bc02cf4767f4,"# EXERCICE : Analyser l'impact de la propagation des contraintes
 def solve_without_propagation(grid: str) -> Optional[Dict[str, str]]:
     # TODO: Implementez un solveur Norvig sans propagation de contraintes
@@ -33238,16 +33264,16 @@ public Dictionary<string, double> MeasureHumanSolveRate()
     return null; // TODO etudiant
 }
 ",,,,,,,,4d52b2cdab3222ac,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,cell-454955f9,markdown,fr,e6efe0d10a55bef1,"## Exercice : Compter les naked singles par difficulte
+MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,cell-454955f9,markdown,fr,b7fd1ee506781bda,"## Exercice : Compter les naked singles par difficulte
 
 **Objectif**
 Comptez combien de naked singles peuvent etre trouves dans des puzzles
-de differentes difficultes (facile, moyen, difficile).
+de différentes difficultes (facile, moyen, difficile).
 
 **Indice**
 Utilisez `find_naked_singles` sur plusieurs puzzles de chaque difficulte
 et calculez la moyenne.
-",,,,,,,,e6efe0d10a55bef1,,,,,,,
+",,,,,,,,b7fd1ee506781bda,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,cell-a0f67067,code,fr,f13cc195fd132f08,"# EXERCICE : Compter les naked singles par difficulte
 def count_naked_singles_by_difficulty(puzzles: dict) -> dict:
     # TODO: Pour chaque difficulte, chargez les puzzles et comptez
@@ -33255,18 +33281,18 @@ def count_naked_singles_by_difficulty(puzzles: dict) -> dict:
     result = {}  # TODO etudiant
     return result
 ",,,,,,,,f13cc195fd132f08,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,cell-05be24e4,markdown,fr,ef1db1b16af2475d,"## Exercice : Implementer la technique Hidden Pair
+MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,cell-05be24e4,markdown,fr,4157b2019195a601,"## Exercice : Implementer la technique Hidden Pair
 
 **Objectif**
 Implementez la detection des Hidden Pairs : quand deux valeurs n'apparaissent
-que dans deux cellules d'une meme unite (ligne/colonne/bloc), ces deux valeurs
+que dans deux cellules d'une même unite (ligne/colonne/bloc), ces deux valeurs
 peuvent etre eliminees des candidats des autres cellules de l'unite.
 
 **Étape 1**
 Parcourez chaque unite et identifiez les valeurs qui n'apparaissent que 2 fois.
 **Étape 2**
-Verifiez si ces 2 valeurs partagent les memes 2 cellules.
-",,,,,,,,ef1db1b16af2475d,,,,,,,
+Verifiez si ces 2 valeurs partagent les mêmes 2 cellules.
+",,,,,,,,4157b2019195a601,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,cell-fde7c35b,code,fr,3be9772f213efd39,"# EXERCICE : Implementer la technique Hidden Pair
 def find_hidden_pairs(candidates: np.ndarray) -> list:
     # TODO: Trouvez les hidden pairs dans la grille
@@ -33275,16 +33301,16 @@ def find_hidden_pairs(candidates: np.ndarray) -> list:
     result = []  # TODO etudiant
     return result
 ",,,,,,,,3be9772f213efd39,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,cell-b761dae5,markdown,fr,18d6bc380de0fff8,"## Exercice : Mesurer le taux de resolution par strategies humaines seules
+MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,cell-b761dae5,markdown,fr,c2ba2d218681676f,"## Exercice : Mesurer le taux de resolution par stratégies humaines seules
 
 **Objectif**
 Determinez quel pourcentage de puzzles peut etre resolu uniquement par
-strategies humaines (sans backtracking), par difficulte.
+stratégies humaines (sans backtracking), par difficulte.
 
 **Indice**
 Utilisez le solveur `HumanSudokuSolver` et comptez les puzzles ou
 `solve()` retourne True sans utiliser le backtracking de secours.
-",,,,,,,,18d6bc380de0fff8,,,,,,,
+",,,,,,,,c2ba2d218681676f,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,cell-2bc950e1,code,fr,40f230b3c991efae,"# EXERCICE : Mesurer le taux de resolution par strategies humaines seules
 def measure_human_solve_rate(puzzles_by_difficulty: dict) -> dict:
     # TODO: Pour chaque difficulte, testez les puzzles et comptez


### PR DESCRIPTION
## Summary

La campagne accent **#2876** (#7272/#7273/#7277/#7267 + filles, ~15000 cures) a accentué le français ASCII→accents dans les notebooks Sudoku. Le CSV `translations/sudoku/sudoku.csv` (1337 rows, 36 notebooks) était stale : **302 cellules en SRC_DRIFT** (text_fr pre-campagne ASCII vs notebooks accentués post-campagne).

Cette PR resynchronise le CSV → **0 drift**.

## Changement

```
python scripts/translation/extract_cells_to_csv.py \
    MyIA.AI.Notebooks/Sudoku/ --update translations/sudoku/sudoku.csv
```

**Result** : 302 lignes rafraîchies, 1035 déjà in-sync, 0 ajoutée, 0 orpheline. Drift check post-resync : **0 anomalie** sur `sudoku.csv`.

## Validation firsthand (G.1 anti-FP)

2 drifted cells spot-checkés, diff exact = :
- CSV (stale ASCII) : `metaheuristique`
- NB (accentué) : `métahuristique`

Single accent cure, len 1005=1005. Drift réel (accent campaign), pas artefact méthodologique.

## Scope du diff (vérifié par audit programmatique)

Colonnes source+pivot **ONLY** :
| Column | Rows changed |
|--------|-------------|
| `src_hash` | 302 |
| `text_fr` | 302 |
| `hash_fr` | 302 |

**Aucune colonne cible touchée** (`text_en`, `hash_en`, … préservées — T3 engine invariant). LF-only (0 CR). 1 fichier, catalogue byte-identique.

**Régression globale** : 6122 → 5820 anomalies fleet-wide (−302, exactement le sudoku).

## Contexte cluster

- **Genre rotation honnête** : cette PR est un **data-fix resync**, NON test-coverage. Après c.662/c.663 (test-coverage Search + translation), ce cycle pivote vers un registre différent — adresse le flag fleet de po-2026 (msg lk44ya) : la flotte entière tunnelait test-coverage ce cycle-day.
- **R6 cap respecté** : 1er resync/lane/jour.
- **EPIC gates** : les grains EPIC-de-fond (Lean W2-core #6724, QC Cloud #6891, GenAI vision) sont tous gated pour ma stack (text-only/Python/.NET). Resync = meilleur grain non-test autonome disponible (Rule 7 : pas d'idle avec >0 drift).

See **#4957** (Epic translation sync) and **#2876** (accent campaign source).

Co-Authored-By: Claude-Code <noreply@anthropic.com>