### PR TITLE
fix(gametheory): correct off-diagonal B-encoding in create_ordinal_game

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/examples/topology_2x2_periodic_table.py
+++ b/MyIA.AI.Notebooks/GameTheory/examples/topology_2x2_periodic_table.py
@@ -35,12 +35,19 @@ def create_ordinal_game(p1_ranks: Tuple[int, int, int, int],
         Tuple of (A, B) payoff matrices
     """
     A = np.array([
-        [p1_ranks[0], p1_ranks[1]],  # Row player Cooperate
-        [p1_ranks[2], p1_ranks[3]]   # Row player Defect
+        [p1_ranks[0], p1_ranks[1]],  # Row player Cooperate: CC, CD
+        [p1_ranks[2], p1_ranks[3]]   # Row player Defect:  DC, DD
     ])
+    # B is indexed [row_action, col_action] exactly like A, so B[i, j] is the
+    # column player's payoff in the SAME situation (row i, col j) as A[i, j].
+    # Both ``p1_ranks`` and ``p2_ranks`` are listed in the same outcome order
+    # (CC, CD, DC, DD) -- see NAMED_GAMES where p1 is (R, S, T, P) and p2 is
+    # (R, T, S, P) -- so B mirrors A's structure. The earlier
+    # ``[[p2[0], p2[2]], [p2[1], p2[3]]]`` swapped the off-diagonal entries and
+    # made every NAMED_GAMES model except Matching Pennies misclassify.
     B = np.array([
-        [p2_ranks[0], p2_ranks[2]],  # Column player Cooperate
-        [p2_ranks[1], p2_ranks[3]]   # Column player Defect
+        [p2_ranks[0], p2_ranks[1]],  # Row player Cooperate: CC, CD
+        [p2_ranks[2], p2_ranks[3]]   # Row player Defect:  DC, DD
     ])
     return A, B
 

--- a/MyIA.AI.Notebooks/GameTheory/tests/test_topology_2x2.py
+++ b/MyIA.AI.Notebooks/GameTheory/tests/test_topology_2x2.py
@@ -23,12 +23,14 @@ seulement l'absence de crash :
   - **Enumeration exhaustive des 576 jeux ordinaux stricts** (24 x 24 permutations
     de {1,2,3,4}) : aucun crash, le classifieur partitionne l'espace tout entier
     de maniere deterministe, et les comptes par type sont stables.
-  - **Incoherence documentee (xfail)** : les modeles NAMED_GAMES du module ne
-    font PAS de aller-retour via son propre encodeur create_ordinal_game
-    (seul Matching Pennies passe). L'encodage de la matrice B (joueur colonne)
-    est incoherent avec l'ordre des tuples des modeles. Surfacage honest d'un
-    bug reel, sans le consecrer : les assertions expriment le comportement
-    CORRECT attendu, et echouent (xfail) tant que le bug n'est pas corrige.
+  - **Incoherence documentee (xfail)** : HISTORIQUEMENT les modeles NAMED_GAMES
+    du module ne faisaient PAS l'aller-retour via son propre encodeur
+    create_ordinal_game (seul Matching Pennies passait). L'encodage de la
+    matrice B (B = [[p2[0],p2[2]],[p2[1],p2[3]]]) inversait les entrees
+    hors-diagonale. CORRIGE : B est desormais row-major comme A, et PD / Stag
+    Hunt / Chicken / Matching Pennies font l'aller-retour correctement (tests
+    passants). Battle of the Sexes reste xfail pour une raison SEPARABLE (limite
+    du classifieur, pas de l'encodage : voir test_named_battle_of_the_sexes).
 
 Run with: pytest tests/test_topology_2x2.py -v
 """
@@ -103,14 +105,17 @@ class TestCreateOrdinalGame:
         A, _ = topo.create_ordinal_game((3, 1, 4, 2), (1, 2, 3, 4))
         np.testing.assert_array_equal(A, np.array([[3, 1], [4, 2]]))
 
-    def test_B_column_major_encoding(self):
-        """B utilise la formule documentee B = [[p2[0],p2[2]],[p2[1],p2[3]]].
+    def test_B_row_major_encoding(self):
+        """B est construite en row-major comme A : B = [[p2[0],p2[1]],[p2[2],p2[3]]].
 
-        C'est le comportement REEL du module (que l'on fige ici). Cette formule
-        est la source de l'incoherence avec NAMED_GAMES (voir TestNamedGamesRoundTrip).
+        Les deux tuples sont dans le meme ordre d'issues (CC, CD, DC, DD), donc
+        B[i, j] est le gain du joueur colonne dans la meme situation (row i,
+        col j) que A[i, j]. L'ancienne formule ``[[p2[0],p2[2]],[p2[1],p2[3]]]``
+        inversait les entrees hors-diagonale et faisait mal classer tous les
+        modeles NAMED_GAMES sauf Matching Pennies (voir TestNamedGamesRoundTrip).
         """
         _, B = topo.create_ordinal_game((1, 2, 3, 4), (3, 1, 4, 2))
-        np.testing.assert_array_equal(B, np.array([[3, 4], [1, 2]]))
+        np.testing.assert_array_equal(B, np.array([[3, 1], [4, 2]]))
 
     def test_deterministic(self):
         a = topo.create_ordinal_game((1, 2, 3, 4), (4, 3, 2, 1))
@@ -344,53 +349,35 @@ class TestExhaustiveEnumeration:
 
 
 # ----------------------------------------------------------------------------
-# NAMED_GAMES round-trip : INCOHERENCE DOCUMENTEE (xfail honest).
+# NAMED_GAMES round-trip : l'encodeur (desormais corrige) rend chaque modele
+# a son type canonique, SAUF Battle of the Sexes.
 #
-# Les modeles NAMED_GAMES du module ne font PAS l'aller-retour via son propre
-# encodeur create_ordinal_game : seul Matching Pennies est correctement
-# reconnu. Les autres modeles (PD, Stag Hunt, Chicken, BoS) sont mal classes
-# parce que l'encodage de la matrice B (B = [[p2[0],p2[2]],[p2[1],p2[3]]]) est
-# incoherent avec l'ordre des tuples des modeles (qui semblent lister les gains
-# P2 en ordre row-major (CC,CD,DC,DD), comme P1, alors que la formule B les
-    # consomme en ordre column-major).
+# Historiquement l'encodage de B (B = [[p2[0],p2[2]],[p2[1],p2[3]]]) inversait
+# les entrees hors-diagonale et faisait mal classer tous les modeles sauf
+# Matching Pennies. La correction (B = [[p2[0],p2[1]],[p2[2],p2[3]]], meme
+# structure row-major que A) rend PD / Stag Hunt / Chicken / Matching Pennies
+# a leur type canonique : ce sont maintenant des tests PASSANTS normaux.
 #
-# Ces tests xfail expriment le COMPORTEMENT CORRECT attendu (le modele PD doit
-# etre classifie "Prisoner's Dilemma"). Ils echouent aujourd'hui (bug) et
-# passeront (xpass) quand l'encodage sera corrige dans une PR dediee (un sujet
-# par PR ; ce fichier est test-only). strict=False pour ne pas casser CI quand
-# le bug sera corrige.
+# Battle of the Sexes reste XFAIL : c'est une limite SEPARABLE du classifieur
+# (pas l'encodage). Les deux equilibres diagonaux de BoS ont des sommes egales
+# ((4,3)=7 et (3,4)=7), donc classify_game les classe "Coordination Game"
+# (branche somme-egale) plutot que "Battle of the Sexes" (branche jamais
+# atteinte en 2x2 ou les 2 Nash purs sont soit tous diagonaux, soit tous
+# anti-diagonaux). strict=False pour ne pas casser CI.
 # ----------------------------------------------------------------------------
 
-@pytest.mark.xfail(
-    reason="create_ordinal_game B-encoding incoherent avec NAMED_GAMES: "
-           "le modele PD est classe 'Dominant Strategy' au lieu de "
-           "'Prisoner's Dilemma'. Bug a corriger dans une PR dediee.",
-    strict=False,
-)
 def test_named_prisoners_dilemma_round_trips():
-    A, B = topo.create_ordinal_game(**{k: topo.NAMED_GAMES["Prisoner's Dilemma"][k]
-                                       for k in ("p1", "p2")})
+    data = topo.NAMED_GAMES["Prisoner's Dilemma"]
+    A, B = topo.create_ordinal_game(data["p1"], data["p2"])
     assert topo.classify_game(A, B) == "Prisoner's Dilemma"
 
 
-@pytest.mark.xfail(
-    reason="create_ordinal_game B-encoding incoherent : le modele Stag Hunt "
-           "est classe 'Other' au lieu de 'Stag Hunt'. Bug a corriger dans une "
-           "PR dediee.",
-    strict=False,
-)
 def test_named_stag_hunt_round_trips():
     data = topo.NAMED_GAMES["Stag Hunt"]
     A, B = topo.create_ordinal_game(data["p1"], data["p2"])
     assert topo.classify_game(A, B) == "Stag Hunt"
 
 
-@pytest.mark.xfail(
-    reason="create_ordinal_game B-encoding incoherent : le modele Chicken "
-           "est classe 'Other' au lieu de 'Chicken/Hawk-Dove'. Bug a corriger "
-           "dans une PR dediee.",
-    strict=False,
-)
 def test_named_chicken_round_trips():
     data = topo.NAMED_GAMES["Chicken"]
     A, B = topo.create_ordinal_game(data["p1"], data["p2"])
@@ -398,9 +385,11 @@ def test_named_chicken_round_trips():
 
 
 @pytest.mark.xfail(
-    reason="create_ordinal_game B-encoding incoherent : le modele Battle of "
-           "the Sexes est classe 'Coordination Game'. Bug a corriger dans une "
-           "PR dediee.",
+    reason="Limite SEPARABLE du classifieur (pas l'encodage B, desormais corrige) : "
+           "les deux Nash diagonaux de BoS ont somme egale ((4,3) et (3,4) = 7), "
+           "donc classify_game renvoie 'Coordination Game'. La branche "
+           "'Battle of the Sexes' n'est jamais atteinte en 2x2 (les 2 Nash purs "
+           "sont soit tous diagonaux, soit tous anti-diagonaux).",
     strict=False,
 )
 def test_named_battle_of_the_sexes_round_trips():


### PR DESCRIPTION
## Summary

`create_ordinal_game` built the column-player payoff matrix `B` as `[[p2[0],p2[2]],[p2[1],p2[3]]]`, swapping the off-diagonal entries. Since `p1_ranks` and `p2_ranks` are both listed in the **same outcome order (CC, CD, DC, DD)** — see `NAMED_GAMES`: `p1 = (R,S,T,P)`, `p2 = (R,T,S,P)` — `B` must mirror `A`'s row-major structure: `B[i,j]` is the column player's payoff in the **same situation** (row `i`, col `j`) as `A[i,j]`.

After the fix, the module's own `NAMED_GAMES` models round-trip correctly through its encoder.

## Impact (reproduced before the fix)

| Named game | Before fix | After fix |
|---|---|---|
| Prisoner's Dilemma | "Dominant Strategy" (`B==A`, common-interest) | **"Prisoner's Dilemma"** |
| Stag Hunt | "Other" | **"Stag Hunt"** |
| Chicken | "Other" | **"Chicken/Hawk-Dove"** |
| Matching Pennies | "Matching Pennies" (correct) | **"Matching Pennies"** |
| Battle of the Sexes | "Coordination Game" | "Coordination Game" (separate limitation, see below) |

Only Matching Pennies was correct before (its `p2` happens to be invariant under the off-diagonal swap).

## Why Battle of the Sexes is NOT fixed by this PR

BoS stays **xfailed** because of a **separate, separable classifier limitation** (not the B-encoding): its two diagonal Nash equilibria have **equal payoff sums** — `(4,3)=7` and `(3,4)=7` — so `classify_game` returns `"Coordination Game"` (the equal-sum-diagonal branch). The `"Battle of the Sexes"` branch is unreachable in 2x2, where 2 pure NE are always either both-diagonal or both-anti-diagonal. The xfail reason was updated to document this rather than misattribute it to the B-encoding.

## Partition invariance (G.9 self-check)

The 576 strict-ordinal game partition is **invariant under this fix**: the off-diagonal swap is a bijection on the `permutations({1,2,3,4}) x permutations({1,2,3,4})` space, so the multiset of generated bimatrices is unchanged — only which `(p1,p2)` maps to which game changes. The aggregate classification counts (`Other 288 / Dominant Strategy 140 / Matching Pennies 72 / Chicken-Hawk-Dove 36 / Stag Hunt 26 / Coordination Game 10 / Prisoner's Dilemma 4`) are identical pre/post, so no downstream classifier-count assertion is affected.

## Test consequences

All four changes below are what the test author intended — `test_topology_2x2.py` had **4 `xfail` tests explicitly waiting for this fix** ("passeront (xpass) quand l'encodage sera corrige dans une PR dediee"):

- `test_B_column_major_encoding` -> renamed `test_B_row_major_encoding`, asserts the **corrected** formula. (The old test pinned the buggy behavior; its docstring admitted "Cette formule est la source de l'incoherence".)
- `test_named_prisoners_dilemma` / `stag_hunt` / `chicken` round-trips: `xfail` removed -> now pass. (Also fixed a latent kwarg bug in the PD test: it used `p1=`/`p2=` kwargs but the signature is `p1_ranks`/`p2_ranks` -> `TypeError`; switched to positional like the sibling tests.)
- `test_named_battle_of_the_sexes`: `xfail` **kept**, reason updated (documented classifier limitation, not the B-encoding).
- Section header docstring updated from "Incoherence documentee (xfail)" to "CORRIGE".

## Validation

- `MyIA.AI.Notebooks/GameTheory/tests/` full suite: **295 passed, 1 xfailed** (BoS).
- `test_topology_2x2.py`: **37 passed, 1 xfailed**.
- No notebook / no other `.py` consumer of `create_ordinal_game` outside the module's `main()` demo and this test file — verified by repo-wide grep (no C.2 implication).
- Catalogue byte-identical to `origin/main` (untouched, no notebook changed).

## Files

- `MyIA.AI.Notebooks/GameTheory/examples/topology_2x2_periodic_table.py` — B-matrix fix + explanatory comment.
- `MyIA.AI.Notebooks/GameTheory/tests/test_topology_2x2.py` — test updates described above.

See GameTheory-3-Topology2x2.ipynb.