### PR TITLE
fix(gametheory): correct cbc terminal frame in Kuhn Poker CFR

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/examples/kuhn_poker_cfr.py
+++ b/MyIA.AI.Notebooks/GameTheory/examples/kuhn_poker_cfr.py
@@ -70,19 +70,27 @@ class KuhnPoker:
         player = len(history) % 2
         opponent = 1 - player
 
-        # Terminal state checks
+        # Terminal state checks.
+        # Convention: each terminal returns the utility of the CURRENT player
+        # (player = len(history) % 2) -- not always player 0. The recursion
+        # negates child values (``-self.cfr(...)``) to flip the frame between
+        # players, and regrets are accumulated in the current player's frame, so
+        # a terminal at odd length (player 1 = P2) MUST return P2's utility.
+        # Length-2 terminals (cc/bf/bc) are P0's frame; length-3 terminals
+        # (cbf/cbc) are P1's frame.
         if len(history) >= 2:
-            # Check-Check: showdown
+            # Check-Check: showdown (len 2, P0 frame)
             if history == "cc":
                 return 1 if cards[0] > cards[1] else -1
 
-            # Check-Bet-Fold
+            # Check-Bet-Fold: P0 folded -> P1 wins (len 3, P1 frame)
             if history == "cbf":
-                return 1  # Player 0 wins pot
+                return 1
 
-            # Check-Bet-Call: showdown for pot of 4
+            # Check-Bet-Call: showdown for pot of 4 (len 3, P1 frame).
+            # P1 wins the pot when P1's card is higher.
             if history == "cbc":
-                return 2 if cards[0] > cards[1] else -2
+                return 2 if cards[1] > cards[0] else -2
 
             # Bet-Fold
             if history == "bf":

--- a/MyIA.AI.Notebooks/GameTheory/tests/test_kuhn_poker_cfr.py
+++ b/MyIA.AI.Notebooks/GameTheory/tests/test_kuhn_poker_cfr.py
@@ -99,9 +99,17 @@ class TestTerminalUtilities:
         assert fresh_game.cfr([JACK, KING], "cbf", 1.0, 1.0) == 1
 
     def test_check_bet_call_showdown(self, fresh_game):
-        """cbc : les deux misent, pot de 2 -> showdown +/-2."""
-        assert fresh_game.cfr([KING, QUEEN], "cbc", 1.0, 1.0) == 2
-        assert fresh_game.cfr([QUEEN, KING], "cbc", 1.0, 1.0) == -2
+        """cbc : les deux misent, pot de 2 -> showdown +/-2 (len 3, frame P1).
+
+        cfr() renvoie l'utilite du joueur courant a la feuille
+        (player = len(history) % 2), que la recursion negue pour basculer
+        de frame entre joueurs. A "cbc" (len 3) le joueur courant est P1
+        (le relanceur) : P1 gagne donc le pot lorsque cards[1] > cards[0].
+        Avec [K,Q] P1 tient la Dame et perd -> -2 ; avec [Q,K] P1 tient le
+        Roi et gagne -> +2.
+        """
+        assert fresh_game.cfr([KING, QUEEN], "cbc", 1.0, 1.0) == -2
+        assert fresh_game.cfr([QUEEN, KING], "cbc", 1.0, 1.0) == 2
 
     def test_bet_fold(self, fresh_game):
         """bf : P0 mise, P2 se couche -> P0 gagne +1."""


### PR DESCRIPTION
## Summary

The `"cbc"` (check-bet-call) terminal in `examples/kuhn_poker_cfr.py` returned `2 if cards[0] > cards[1] else -2` — i.e. **player 0's utility**. But this module's CFR convention is **current-player-relative**: each terminal returns the utility of the player to act at that leaf (`player = len(history) % 2`), the recursion negates child values (`-self.cfr(...)`) to flip the frame between players, and regrets are accumulated in the current player's frame. At `"cbc"` (len 3) the current player is **P1**, so the terminal must return P1's utility: `2 if cards[1] > cards[0] else -2`. All other terminals are correct (`cc`/`bf`/`bc` at len 2 = P0 frame; `cbf` at len 3 = P1 frame).

## Proof of the bug (reproduce-before-claim)

Vanilla CFR is **guaranteed to converge to a Nash equilibrium** in 2-player zero-sum games (Zinkevich et al. 2007), and Kuhn poker's game value is the known constant **-1/18 = -0.0556** (Kuhn 1950).

| | Empirical game value (200k iters, seed 7) | vs Nash -0.0556 |
|---|---|---|
| **Buggy** (`cards[0]>cards[1]`) | **-0.1145** | ~2x off — impossible for correct CFR |
| **Fixed** (`cards[1]>cards[0]`) | **-0.0555** | diff 0.0001 (sampling noise) |

The converged strategy also matches the known Nash structure **only after the fix**:

| Info set | Nash | Buggy | Fixed |
|---|---|---|---|
| Q (P1 Queen) | bet ~0 | bet ~1.0 | bet ~0.0001 |
| K (P1 King) | bet ~1 | bet ~1.0 | bet 0.72 |
| J (P1 Jack) | bet <=1/3 | bet 0.335 | bet 0.238 |
| Kcb (P1 K face bet) | call ~1 | call 0.50 | call 1.0 |
| Jcb (P1 J face bet) | fold ~1 | fold 1.0 | fold 1.0 |
| K-bet / J-bet ratio | ~3x | ~3x | ~3x (0.72/0.238) |

Under the buggy terminal, Queen bet ~100% and Kcb called only 50% — both violate the Nash family.

## Test consequence

`test_check_bet_call_showdown` **pinned the buggy value** (`cfr([KING,QUEEN],"cbc",1,1) == 2`). Updated to the correct P1-frame values (-2 when P1 holds the lower card, +2 when higher) with a docstring documenting the current-player-relative convention. The other 24 kuhn tests pass **unchanged** — their qualitative equilibrium invariants (King bets more than Jack, P2 folds Jack / calls King to a bet) hold under both buggy and fixed code, which is why the wrong value went undetected. Added a convention comment at the terminal block to prevent regression.

## Scope / no C.2 implication

The related notebook `GameTheory-13-ImperfectInfo-CFR.ipynb` has its **own inline CFR implementation** (it does not import this module), so this fix does **not** change any committed notebook output. The notebook's inline CFR should be audited separately for the same convention bug — **flagged here, not fixed** (out of scope, one subject per PR).

## Validation

- `tests/test_kuhn_poker_cfr.py`: **26 passed**.
- Full `GameTheory/tests/` suite: **290 passed, 4 xfailed**, 2 pre-existing env failures in `test_lean_definitions.py` (hardcoded WSL path `/home/jesse/lean-projects` from another machine — unrelated to this Python change; that test file is not touched by this PR).
- Catalogue byte-identical (no notebook changed).

## Files

- `MyIA.AI.Notebooks/GameTheory/examples/kuhn_poker_cfr.py` — `"cbc"` terminal fix + convention comment.
- `MyIA.AI.Notebooks/GameTheory/tests/test_kuhn_poker_cfr.py` — `test_check_bet_call_showdown` corrected + docstring.

See GameTheory-13-ImperfectInfo-CFR.ipynb.