### PR TITLE
feat(notebook-tools,#6891): add detect_fabricated_outputs.py — sibling of detect_blank_figures covering text-output fabrication (Row N + zero-stats dataframe)

### DIFF
--- a/scripts/notebook_tools/README.md
+++ b/scripts/notebook_tools/README.md
@@ -15,7 +15,7 @@ complement. L'inventaire ci-dessous remplace la lecture en aveugle de
 
 | Categorie | Scripts | Role |
 |-----------|---------|------|
-| **Detecteurs anti-regression** | `detect_blank_figures.py`, `detect_svg_decimal_commas.py`, `detect_svg_empty_display.py`, `detect_ascii_workaround.py`, `detect_accent_stripping.py`, `detect_solution_leaks.py` | Flags deterministes par regle C.1 / H.1 / SOTA / #2876 / #3801 / #4970 / **#6927** (SVG inline rollout) |
+| **Detecteurs anti-regression** | `detect_blank_figures.py`, `detect_fabricated_outputs.py`, `detect_svg_decimal_commas.py`, `detect_svg_empty_display.py`, `detect_ascii_workaround.py`, `detect_accent_stripping.py`, `detect_solution_leaks.py` | Flags deterministes par regle C.1 / H.1 / SOTA / #2876 / #3801 / #4970 / **#6927** (SVG inline rollout) / **#6891 axe-2 fabrication textuelle** (sibling detector) |
 | **Validateurs CI** | `validate_pr_notebooks.py`, `check_c2_compliance.py`, `check_notebook_navlinks.py`, `check_plotly_static_risk.py` | Gates pre-merge, `--check` exit-code CI-ready |
 | **Scanners structurels** | `scan_cell_ordering.py`, `scan_md_hierarchy.py` | Audit hierarchie markdown + ordre cellules pedagogiques |
 | **Execution kernels** | `dotnet_executor.py`, `exec_dotnet_persist.py`, `exec_single_cell.py`, `batch_reexecute.py`, `wsl_papermill.py` | .NET Interactive + Python Papermill via WSL |
@@ -34,7 +34,7 @@ Tests unitaires dans `scripts/notebook_tools/tests/`.
 
 ## Detecteurs anti-regression (l'axe **DETECT**, jamais scrub)
 
-Les 6 detecteurs implementent le **Prong A** de
+Les 7 detecteurs implementent le **Prong A** de
 [`.claude/rules/sota-not-workaround.md`](../../.claude/rules/sota-not-workaround.md) :
 detecter les sorties degradees qu'un notebook commit sans avoir execute le
 vrai outil SOTA. Chaque detecteur a un **verdict deterministe** (zero faux
@@ -53,6 +53,39 @@ python scripts/notebook_tools/detect_blank_figures.py NB.ipynb --check
 
 **Owner** : QC-session pour les quantbooks (issue #6891) ; partition-mienne
 pour les GenAI/Image.
+
+### `detect_fabricated_outputs.py` (#6891, axe-2 sibling)
+
+Sibling textuel de `detect_blank_figures.py` : meme incident fondateur
+(#6891, 8 quantbook.ipynb QC avec sorties fabriquees), mais sur
+l'**axe 2** — les sorties `text/plain` / `text/html` fabriquees en lieu
+et place d'un vrai backtest. Deux signaux deterministes isoles :
+
+- **`row_n_placeholder`** : pattern `^\s*Row\s+\d+(?=\s|$)` (placeholders
+  Pandas dataframe par defaut — un backtest qui n'a pas tourne exhibe
+  litteralement `Row 0`, `Row 1`, … quand aucun index n'a ete nomme).
+- **`zero_stats_dataframe`** : minidataframe "resultat backtest" presentant
+  au moins 3 des 4 colonnes canoniques (Sharpe/CAGR/MaxDD/NetProfit) ET
+  >= 90 % des tokens numeriques a zero (signature d'un moteur appele
+  avec des donnees absentes).
+
+Calibration sur les 8 quantbooks de #6891 : 7/8 notebooks avec `Row N`,
+3/8 avec dataframe stats 0.0. Aucun ML ni heuristique floue.
+
+```bash
+python scripts/notebook_tools/detect_fabricated_outputs.py NB.ipynb --check
+python scripts/notebook_tools/detect_fabricated_outputs.py --family QuantConnect --check
+# exit 1 si defaut, CI-ready
+```
+
+**Owner** : QC-session pour les quantbooks (#6891 axe-2) ; partition-mienne
+pour les notebooks pedagogiques (GenAI/Texte, Search-Py, Probas, ML).
+
+**Blind spots documentes** (le verdict = SIGNAL, pas VERITE) :
+sortie partiellement fabriquee (1 ligne `Row N` parmi 50 legitimes ->
+flag au niveau cellule), valeurs legitimes nulles (algo buy-and-hold
+cash), texte autre langue (colonnes FR non matchees par les noms
+anglais canoniques). Cf docstring du detecteur pour le triage complet.
 
 ### `detect_svg_decimal_commas.py` (#3801, EPIC #6927)
 

--- a/scripts/notebook_tools/detect_fabricated_outputs.py
+++ b/scripts/notebook_tools/detect_fabricated_outputs.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""Detecte les sorties textuelles FABRIQUEES committes comme resultats d'execution (Prong-A, registre #3801).
+
+Pourquoi cet outil existe
+-------------------------
+Le sweep Prong-A (#3801) traque les sorties FABRIQUEES : une cellule code qui
+pretend avoir execute mais commit un placeholder textuel en lieu et place du
+vrai resultat. `detect_blank_figures.py` couvre les images degeneres (axe 1 :
+le PNG 1x1 de 70 octets emis par matplotlib quand la figure est vide).
+Cet outil couvre l'AXE 2 : les sorties TEXTUELLES fabriquees -- dataframes de
+backtest avec stats a 0.0 simulant un backtest qui n'a pas tourne, lignes
+`Row N` placeholders, listes d'allocations vides.
+
+Incident fondateur #6891 : 8 quantbook.ipynb QuantConnect committes chacun avec
+(a) un unique PNG 1x1 de 70 octets (axe 1, deja couvert par detect_blank_figures)
+ET (b) des sorties textuelles fabriquees -- `Row N` placeholders simulant un
+tableau de resultats (axe 2, ce detecteur). Distribution observee sur les 8 :
+
+    AllWeather       9 lignes "Row N"     + 1 dataframe stats 0.0
+    DualMomentum     3 lignes "Row N"
+    EMA-Cross-Alpha  0 (uniquement axe 1, blank PNG)
+    FuturesTrend    15 lignes "Row N"
+    MomentumStrategy 3 lignes "Row N"
+    RiskParity      11 lignes "Row N"     + 1 dataframe stats 0.0
+    SectorMomentum   3 lignes "Row N"
+    TurnOfMonth     16 lignes "Row N"     + 4 dataframes stats 0.0
+
+La fabrication textuelle est un signal complementaire au blank-PNG : un notebook
+peut avoir des images legitimes ET du texte fabrique (cas rare mais possible),
+ou uniquement du texte fabrique (cas frequent quand le kernel est juste non
+disponible et que l'auteur a rempli `outputs` a la main).
+
+Il DETECTE, il ne CORRIGE PAS. La correction = re-executer la cellule dans le
+vrai environnement (QC Cloud research pour QuantBook, kernel local pour
+matplotlib) et committer la vraie sortie -- Stop&Repair, JAMAIS scrubber ni
+supprimer pour cacher (regle secrets-hygiene 6 + sota-not-workaround Prong-A).
+
+Ce qui est flagge (DETERMINISTE)
+--------------------------------
+Une sortie `text/plain` (ou `text/html` simplifie) d'une cellule code est
+FABRIQUEE si elle contient :
+
+  - le pattern "Row N" ou "Row {N}" (placeholder classique de resultat
+    tabulaire qui n'a pas ete rempli -- litteral "Row " suivi d'un nombre)
+  - un mini-dataframe "resultat backtest" presentant au moins 3 des 4 colonnes
+    {Sharpe, CAGR, MaxDD, NetProfit} ET des valeurs entierement a 0.0
+    (signature d'un backtest qui n'a pas tourne : moteur appele, donnees
+    absentes, stats nulles)
+
+Les seuils sont explicites (pas de ML, pas d'heuristique floue). La calibration
+sur les 8 quantbooks de #6891 donne un signal deterministic :
+    - 7/8 notebooks avec "Row N"  : AllWeather/DualMomentum/FuturesTrend/
+                                    MomentumStrategy/RiskParity/SectorMomentum/
+                                    TurnOfMonth
+    - 3/8 avec dataframe all-zero  : AllWeather/RiskParity/TurnOfMonth
+
+Known blind spots (hors scope par design)
+-----------------------------------------
+- SORTIE PARTIELLEMENT FABRIQUEE : une cellule peut avoir 1 ligne "Row N" dans
+  50 lignes legitimes. On flagge la cellule au niveau 1 (presence du pattern),
+  pas au niveau granularite (ratio). Ca pourrait produire des faux positifs
+  sur un notebook pedagogique qui explique litteralement le pattern "Row N"
+  dans un exemple. Mitigation : false-positive checking a la main sur le
+  notebook flagge (l'outil est read-only, comme detect_blank_figures).
+- VALEURS LEGITIMES NULLES : un backtest qui affiche reellement des stats a 0
+  (algo = buy-and-hold cash, pas de trades, etc.). Le pattern exige les 3
+  colonnes statistiques canoniques + 0.0 + structure dataframe -- combinaison
+  rare mais possible. Mitigation : verification a la main, meme approche que
+  pour detect_blank_figures (le verdict est un SIGNAL, pas une VERITE).
+- TEXTE AUTRE LANGUE : on matche uniquement les noms de colonnes anglais
+  (Sharpe/CAGR/MaxDD/NetProfit). Un notebook Francais avec "Ratio de Sharpe"
+  ne sera pas detecte -- hors scope pour cette premiere passe (la majorite
+  des quantbooks committes sont en anglais/keyword anglais meme dans un
+  notebook Francais).
+
+Usage
+-----
+    python detect_fabricated_outputs.py NB.ipynb                  # un notebook
+    python detect_fabricated_outputs.py --family QuantConnect     # une famille
+    python detect_fabricated_outputs.py                           # tous les notebooks
+    python detect_fabricated_outputs.py NB.ipynb --json           # sortie machine
+    python detect_fabricated_outputs.py NB.ipynb --check          # exit 1 si fabrication (CI-ready)
+    python detect_fabricated_outputs.py --family QuantConnect --check  # CI pre-commit
+
+Exit codes
+----------
+    0 -- aucune sortie fabriquee (ou mode non --check)
+    1 -- une ou plusieurs sorties fabriquees (--check seulement)
+    2 -- erreur (notebook illisible, famille introuvable)
+
+Voir aussi
+----------
+- `detect_blank_figures.py` (#6918 MERGED) -- axe 1 : images degeneres
+- `detect_ascii_workaround.py` (#3801) -- moitie ASCII du sweep Prong-A
+- `.claude/rules/sota-not-workaround.md` -- Prong-A : vrai outil, pas workaround
+- `.claude/rules/secrets-hygiene.md` regle 6 -- Stop&Repair : re-executer
+- #6891 -- incident fondateur (8 quantbook.ipynb QC blank-PNG + Row N)
+
+Part of #3801 (EPIC SOTA axe-2).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+# Pattern "Row N" : placeholder Pandas dataframe par defaut.
+# Pandas nomme les lignes d'un dataframe sans index explicite comme "Row 0",
+# "Row 1", etc. Quand un notebook committe une sortie dataframe SANS avoir
+# defini d'index nomme, on obtient litteralement ces lignes en premiere colonne.
+# C'est un signal FORTE de fabrication : un vrai backtest nomme ses indices
+# (date, ticker, symbol...) -- "Row N" = index par defaut = dataframe bidon.
+#
+# On matche `Row N` en DEBUT de ligne (apres whitespace), suivi d'un nombre,
+# suivi d'espace ou fin de ligne (pour eviter "Row 123" en milieu de phrase).
+ROW_N_RE = re.compile(r"(?m)^\s*Row\s+\d+(?=\s|$)")
+
+# Noms de colonnes canoniques d'un dataframe "resultat backtest".
+# Si au moins 3 de ces 4 apparaissent dans la sortie ET que les valeurs sont
+# toutes a 0.0 / 0 (dataframe present mais stats nulles = backtest pas tourne).
+BACKTEST_STATS = ("Sharpe", "CAGR", "MaxDD", "NetProfit")
+MIN_STATS_HIT = 3  # au moins 3 colonnes parmi 4 = signal dataframe resultat
+
+# Pattern valeur numerique nulle : 0.0, 0, -0.0, +0.0, 0.00, etc.
+ZERO_VALUE_RE = re.compile(r"^\s*[+\-]?0+(?:\.0+)?\s*$")
+
+
+def _cell_text_outputs(cell: dict) -> list[str]:
+    """Return concatenated text/plain content of all cell outputs as a list of lines."""
+    lines = []
+    for out in cell.get("outputs", []) or []:
+        if not isinstance(out, dict):
+            continue
+        data = out.get("data", {}) if "data" in out else {}
+        # text/plain est l'output standard d'un print() ou d'un display(...)
+        for mime in ("text/plain", "text/html"):
+            payload = data.get(mime)
+            if payload is None:
+                continue
+            if isinstance(payload, list):
+                payload = "".join(str(x) for x in payload)
+            if not isinstance(payload, str):
+                payload = str(payload)
+            lines.extend(payload.splitlines())
+        # stdout stream
+        text = out.get("text")
+        if isinstance(text, list):
+            text = "".join(str(x) for x in text)
+        if isinstance(text, str):
+            lines.extend(text.splitlines())
+    return lines
+
+
+def _has_row_n(lines: list[str]) -> bool:
+    """True if any line is a 'Row N' placeholder (litteral row not filled)."""
+    blob = "\n".join(lines)
+    return bool(ROW_N_RE.search(blob))
+
+
+def _has_zero_stats_dataframe(lines: list[str]) -> bool:
+    """True if the output looks like a backtest-stats dataframe with all-zero values.
+
+    Heuristique stricte : au moins MIN_STATS_HIT noms de colonnes canoniques
+    (Sharpe/CAGR/MaxDD/NetProfit) apparait dans les lignes, ET une proportion
+    significative de valeurs numeriques dans le blob est a zero.
+
+    Concu pour minimiser les FP sur les notebooks pedagogiques qui MENTIONNENT
+    ces colonnes sans les FABRIQUER (ex: "the Sharpe ratio measures..."
+    ne match pas car ce n'est pas un pattern tabulaire).
+    """
+    blob = "\n".join(lines)
+    # Localiser la ou les lignes header qui contiennent les noms de colonnes.
+    # Une header matche AU MOINS MIN_STATS_HIT colonnes canoniques.
+    # Pour chaque header, examiner la section de donnees qui suit immediatement
+    # jusqu'au prochain header (ou fin du blob). Si une section est entierement
+    # a zero, c'est une fabrication.
+    header_idxs = [
+        i for i, ln in enumerate(lines)
+        if sum(1 for s in BACKTEST_STATS if s in ln) >= MIN_STATS_HIT
+    ]
+    if not header_idxs:
+        return False
+    # Examiner les sections data associees a chaque header.
+    sections_to_check = []
+    for k, h_idx in enumerate(header_idxs):
+        next_h = header_idxs[k + 1] if k + 1 < len(header_idxs) else len(lines)
+        sections_to_check.append(lines[h_idx + 1:next_h])
+    data_lines = [ln for section in sections_to_check for ln in section if ln.strip()]
+    if not data_lines:
+        return False
+    # Compter combien de ces lignes ont TOUTES leurs valeurs numeriques a zero.
+    # Approximation : on regarde le ratio de tokens numeriques a zero dans le blob
+    # filtre. Si le ratio est eleve (>=0.5) ET qu'on a assez de colonnes matchees,
+    # on flagge.
+    zero_tokens = 0
+    total_tokens = 0
+    for ln in data_lines:
+        for tok in re.findall(r"[+\-]?\d+(?:\.\d+)?", ln):
+            total_tokens += 1
+            if ZERO_VALUE_RE.match(tok):
+                zero_tokens += 1
+    if total_tokens < 3:
+        # Pas assez de valeurs numeriques pour etablir un signal -- on laisse
+        return False
+    # Seuil eleve : un dataframe "resultat backtest" avec une seule vraie valeur
+    # parmi des zeros = PAS une fabrication (backtest partiellement execute).
+    # Le pattern #6891 = TOUTES les valeurs a 0.0 (backtest pas du tout execute).
+    return (zero_tokens / total_tokens) >= 0.9
+
+
+def detect_cell(cell: dict) -> list[dict]:
+    """Return findings (one per fabrication signal) for a code cell."""
+    if cell.get("cell_type") != "code":
+        return []
+    findings = []
+    lines = _cell_text_outputs(cell)
+    if not lines:
+        return findings
+    if _has_row_n(lines):
+        # Compter les Row N pour contexte (un seul vs plusieurs).
+        n_rows = sum(1 for ln in lines if ROW_N_RE.match(ln))
+        findings.append({"signal": "row_n_placeholder", "count": n_rows})
+    if _has_zero_stats_dataframe(lines):
+        findings.append({"signal": "zero_stats_dataframe"})
+    return findings
+
+
+def scan_notebook(path: Path) -> dict:
+    """Return a result dict for one notebook: path, hits[], error."""
+    try:
+        with open(path, encoding="utf-8") as f:
+            nb = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        return {"path": str(path), "error": str(exc), "hits": []}
+
+    hits = []
+    for ci, cell in enumerate(nb.get("cells", [])):
+        for finding in detect_cell(cell):
+            hits.append({"cell_index": ci, **finding})
+    return {"path": str(path), "kernel": _kernel(nb), "hits": hits, "error": None}
+
+
+def _kernel(nb: dict) -> str:
+    return nb.get("metadata", {}).get("kernelspec", {}).get("name", "?")
+
+
+# Dossiers a ignorer (alignes sur detect_blank_figures.py).
+SKIP_DIRS = {
+    ".lake", ".git", "__pycache__", "_archives", "archive", "_archive",
+    ".ipynb_checkpoints", ".pytest_cache", "worktrees",
+    "foundry-lib",  # lib vendored tierce, pas a nous a fixer
+}
+
+# Artefacts papermill (*_output.ipynb) : la source canonique est le livrable.
+_OUTPUT_SUFFIX = "_output.ipynb"
+
+
+def _should_skip(rel: Path) -> bool:
+    if any(part in SKIP_DIRS for part in rel.parts):
+        return True
+    return rel.name.endswith(_OUTPUT_SUFFIX)
+
+
+def _iter_notebooks(root: Path, family: str | None):
+    base = root / "MyIA.AI.Notebooks"
+    if family:
+        base = base / family
+    if not base.exists():
+        return
+    for nb in sorted(base.rglob("*.ipynb")):
+        if _should_skip(nb.relative_to(base)):
+            continue
+        yield nb
+
+
+def _human_report(results: list[dict]) -> str:
+    total_hits = sum(len(r["hits"]) for r in results)
+    affected = [r for r in results if r["hits"]]
+    errored = [r for r in results if r.get("error")]
+    lines = [
+        f"Notebooks scanned     : {len(results)}",
+        f"Fabricated outputs   : {total_hits}",
+        f"Affected notebooks   : {len(affected)}",
+        "",
+    ]
+    if not affected:
+        lines.append("No fabricated text outputs detected (Row N / zero-stats dataframe check).")
+        if errored:
+            lines.append("")
+            lines.append(f"NOTE: {len(errored)} notebook(s) unreadable (see --json for details).")
+        return "\n".join(lines)
+    for r in affected:
+        short = r["path"].split("MyIA.AI.Notebooks")[-1].lstrip("\\/")
+        lines.append(f"## {short}  [{r['kernel']}]")
+        for h in r["hits"]:
+            extra = ""
+            if "count" in h:
+                extra = f" x{h['count']}"
+            lines.append(f"  - cell [{h['cell_index']}] signal: {h['signal']}{extra}")
+        lines.append("")
+    lines.append(
+        "FIX: re-execute the cell in the real environment (QC Cloud research for "
+        "QuantBook, local kernel for matplotlib) and commit the real output -- "
+        "Stop&Repair, never scrub/delete to hide (secrets-hygiene rule 6)."
+    )
+    return "\n".join(lines)
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__.split("\n\n")[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("notebook", nargs="?", help="Notebook to scan (default: all pedagogical)")
+    parser.add_argument("--family", help="Top-level family under MyIA.AI.Notebooks/ (e.g. QuantConnect)")
+    parser.add_argument("--root", default=".", help="Repo root (default: cwd)")
+    parser.add_argument("--json", action="store_true", help="Machine-readable JSON output")
+    parser.add_argument("--check", action="store_true", help="Exit 1 if any fabrication (CI-ready)")
+    args = parser.parse_args(argv)
+
+    root = Path(args.root).resolve()
+    if args.notebook:
+        paths = [Path(args.notebook)]
+        if not paths[0].is_absolute():
+            paths[0] = root / paths[0]
+        if not paths[0].exists():
+            print(f"error: notebook not found: {paths[0]}", file=sys.stderr)
+            return 2
+    else:
+        paths = list(_iter_notebooks(root, args.family))
+        if args.family and not paths:
+            print(f"error: family not found: {args.family}", file=sys.stderr)
+            return 2
+
+    results = [scan_notebook(p) for p in paths]
+    total_hits = sum(len(r["hits"]) for r in results)
+
+    if args.json:
+        payload = {"notebooks_scanned": len(results), "total_hits": total_hits, "results": results}
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+    else:
+        print(_human_report(results))
+
+    if args.check and total_hits > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/notebook_tools/tests/test_detect_fabricated_outputs.py
+++ b/scripts/notebook_tools/tests/test_detect_fabricated_outputs.py
@@ -1,0 +1,523 @@
+"""Tests for scripts/notebook_tools/detect_fabricated_outputs.py — fabricated text output detector.
+
+Why this test file exists
+-------------------------
+`detect_fabricated_outputs.py` (registre #3801, Prong-A sweep, axe-2 SOTA) is
+the TEXT sibling of `detect_blank_figures.py` (#6918 MERGED, axe-1). It detects
+fabricated textual outputs in pedagogical notebooks:
+
+  - `Row N` placeholders (Pandas default dataframe index, signature d'un
+    dataframe bidon qui n'a pas eu d'index nommé par le vrai code)
+  - Zero-stats dataframes (Sharpe/CAGR/MaxDD/NetProfit toutes à 0.0 = backtest
+    qui n'a pas tourné)
+
+Founding incident #6891 (8 quantbook.ipynb files, 7/8 avec Row N placeholders
++ 3/8 avec zero-stats dataframes, + 8/8 avec blank PNG — axe 1). Ces deux
+détecteurs sont SIBLINGS : axe 1 (images) + axe 2 (texte) = couverture complète
+du pattern fabrication. Un notebook peut être flaggé par l'un sans l'autre
+(cas QC-Py-15 = axe 2 uniquement, EMA-Cross-Alpha = axe 1 uniquement).
+
+Sept clusters mirroring the detector's documented decision logic :
+
+  1. TestRowNRegex            -- regex compilation, start-of-line, end-of-line/space
+  2. TestZeroValueRegex       -- numeric zero token parsing (0, 0.0, 0.00, -0.0)
+  3. TestHasRowN              -- positive (single/multiple Row N), negative (real index)
+  4. TestHasZeroStatsDataframe-- positive (3+ cols + zeros), negative (real values, partial)
+  5. TestDetectCell           -- code-cell routing, multi-signal stacking, output capture
+  6. TestScanNotebook         -- end-to-end dict contract, kernel extraction, error handling
+  7. TestMainExitCodes        -- CLI: --check / --json / missing-notebook / family-not-found
+
+Test data design : minimal in-memory notebook JSON, no fixture files. The
+detector is pure-Python and operates on `cells[]` dicts, so we synthesize the
+exact structures that Jupyter produces. Each test isolates one conjunct of the
+decision so a regression in any conjunct surfaces as a single failure.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from detect_fabricated_outputs import (  # noqa: E402
+    BACKTEST_STATS,
+    MIN_STATS_HIT,
+    ROW_N_RE,
+    ZERO_VALUE_RE,
+    _cell_text_outputs,
+    _has_row_n,
+    _has_zero_stats_dataframe,
+    _human_report,
+    _iter_notebooks,
+    _kernel,
+    _should_skip,
+    detect_cell,
+    main,
+    scan_notebook,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers -- minimal notebook cell factories
+# ---------------------------------------------------------------------------
+
+def code_cell(source: str = "", outputs: list | None = None, execution_count: int | None = 1) -> dict:
+    """Build a minimal code cell dict mimicking nbformat v4."""
+    return {
+        "cell_type": "code",
+        "execution_count": execution_count,
+        "metadata": {},
+        "outputs": outputs or [],
+        "source": source,
+    }
+
+
+def text_output(text: str) -> dict:
+    """Build a stdout stream output (like print())."""
+    return {"output_type": "stream", "name": "stdout", "text": text}
+
+
+def display_data_output(text: str) -> dict:
+    """Build a display_data output with text/plain (like display() or repr)."""
+    return {"output_type": "display_data", "data": {"text/plain": text}, "metadata": {}}
+
+
+# ---------------------------------------------------------------------------
+# 1. TestRowNRegex -- the row_N regex itself
+# ---------------------------------------------------------------------------
+
+class TestRowNRegex:
+    """The regex is the core detector -- anchor semantics matter."""
+
+    def test_matches_single_row_n(self):
+        assert ROW_N_RE.search("Row 1")
+
+    def test_matches_multi_digit_row_n(self):
+        assert ROW_N_RE.search("Row 42")
+        assert ROW_N_RE.search("Row 123")
+
+    def test_matches_with_leading_whitespace(self):
+        assert ROW_N_RE.search("    Row 5")
+        assert ROW_N_RE.search("\tRow 7")
+
+    def test_matches_in_multiline_context(self):
+        blob = "header\n  Sharpe  CAGR\nRow 1     0.5   0.1\nRow 2     0.6   0.2\nfooter"
+        assert ROW_N_RE.search(blob)
+        assert len(ROW_N_RE.findall(blob)) == 2
+
+    def test_does_not_match_no_space_after_number(self):
+        # "Row 123abc" -- word boundary should prevent this (Row prefix only)
+        assert not ROW_N_RE.search("Row 123abc")
+
+    def test_does_not_match_real_index_named(self):
+        # Real backtests use named indices like "2020-01-01", "SPY", "Strategy_A"
+        assert not ROW_N_RE.search("2020-01-01  0.5  0.1")
+        assert not ROW_N_RE.search("SPY       0.5  0.1")
+        assert not ROW_N_RE.search("Strategy_A   0.5  0.1")
+
+    def test_does_not_match_row_in_middle_of_word(self):
+        # "Borrow" or "Rowing" should not match (Row is followed by space + digit)
+        assert not ROW_N_RE.search("Borrow 100")
+        assert not ROW_N_RE.search("Rowing club")
+
+
+# ---------------------------------------------------------------------------
+# 2. TestZeroValueRegex -- numeric zero token parsing
+# ---------------------------------------------------------------------------
+
+class TestZeroValueRegex:
+    """Zero-value detection -- used by the dataframe check."""
+
+    def test_matches_integer_zero(self):
+        assert ZERO_VALUE_RE.match("0")
+
+    def test_matches_float_zero(self):
+        assert ZERO_VALUE_RE.match("0.0")
+        assert ZERO_VALUE_RE.match("0.00")
+        assert ZERO_VALUE_RE.match("0.000")
+
+    def test_matches_signed_zero(self):
+        assert ZERO_VALUE_RE.match("-0")
+        assert ZERO_VALUE_RE.match("+0")
+        assert ZERO_VALUE_RE.match("-0.0")
+        assert ZERO_VALUE_RE.match("+0.00")
+
+    def test_does_not_match_nonzero(self):
+        assert not ZERO_VALUE_RE.match("0.5")
+        assert not ZERO_VALUE_RE.match("1")
+        assert not ZERO_VALUE_RE.match("-0.5")
+        assert not ZERO_VALUE_RE.match("100")
+
+    def test_does_not_match_nonnumeric_token(self):
+        # The regex only matches actual numeric zero forms, not arbitrary tokens
+        assert not ZERO_VALUE_RE.match("zero")
+        assert not ZERO_VALUE_RE.match("abc")
+        assert not ZERO_VALUE_RE.match("null")
+
+
+# ---------------------------------------------------------------------------
+# 3. TestHasRowN -- the Row N detection on cell lines
+# ---------------------------------------------------------------------------
+
+class TestHasRowN:
+    """`_has_row_n(lines)` returns True when Row N placeholders are present."""
+
+    def test_single_row_n_detected(self):
+        assert _has_row_n(["Row 1     0.5   0.1"])
+
+    def test_multiple_row_n_detected(self):
+        assert _has_row_n(
+            ["Row 1     0.5   0.1", "Row 2     0.6   0.2", "Row 3     0.4   0.05"]
+        )
+
+    def test_real_index_named_not_detected(self):
+        # Real dataframe with named indices like dates or tickers -- not Row N
+        assert not _has_row_n(
+            ["2020-01-01  0.5  0.1", "2020-02-01  0.6  0.2"]
+        )
+
+    def test_empty_lines_not_detected(self):
+        assert not _has_row_n([])
+
+    def test_unrelated_text_not_detected(self):
+        assert not _has_row_n(["Some output", "More output", "Even more"])
+
+    def test_count_attribute_in_detect_cell(self):
+        # detect_cell should record the count of Row N placeholders.
+        cell = code_cell(outputs=[
+            display_data_output("\n".join([
+                "Sharpe  CAGR",
+                "Row 1   0.5  0.1",
+                "Row 2   0.6  0.2",
+                "Row 3   0.4  0.05",
+            ])),
+        ])
+        findings = detect_cell(cell)
+        row_findings = [f for f in findings if f["signal"] == "row_n_placeholder"]
+        assert len(row_findings) == 1
+        assert row_findings[0]["count"] == 3
+
+
+# ---------------------------------------------------------------------------
+# 4. TestHasZeroStatsDataframe -- dataframe fabrication with zero stats
+# ---------------------------------------------------------------------------
+
+class TestHasZeroStatsDataframe:
+    """`_has_zero_stats_dataframe` -- dataframe avec 3+ colonnes canoniques et valeurs nulles."""
+
+    def test_canonical_backtest_zero_stats_detected(self):
+        # AllWeather pattern : 3 colonnes (Sharpe, CAGR, MaxDD), toutes 0.0
+        assert _has_zero_stats_dataframe([
+            "       Sharpe  CAGR  MaxDD",
+            "A        0.0   0.0   0.0",
+            "B        0.0   0.0   0.0",
+        ])
+
+    def test_all_four_columns_zero_stats_detected(self):
+        # RiskParity pattern : 4 colonnes, toutes 0.0
+        assert _has_zero_stats_dataframe([
+            "       Sharpe  CAGR  MaxDD  NetProfit",
+            "A        0.0   0.0   0.0      0.0",
+            "B        0.0   0.0   0.0      0.0",
+        ])
+
+    def test_real_nonzero_values_not_detected(self):
+        # Real backtest with non-zero values -- the dataframe has structure but
+        # the values are NOT all zero (backtest did run).
+        assert not _has_zero_stats_dataframe([
+            "       Sharpe  CAGR  MaxDD",
+            "A       0.78  0.12  -0.18",
+            "B       0.65  0.09  -0.22",
+        ])
+
+    def test_partial_columns_not_detected(self):
+        # Only 2 of 4 canonical columns = not enough signal to claim "backtest result"
+        assert not _has_zero_stats_dataframe([
+            "       Sharpe  CAGR",
+            "A        0.0   0.0",
+        ])
+
+    def test_unrelated_dataframe_not_detected(self):
+        # Dataframe without backtest-stat columns = not in our pattern
+        assert not _has_zero_stats_dataframe([
+            "       name    age   city",
+            "A      Alice   30    NYC",
+            "B      Bob     25    LA",
+        ])
+
+    def test_mostly_zero_with_one_nonzero_not_detected(self):
+        # 1 value nonzero out of 4 = below 0.5 threshold, no fabrication
+        assert not _has_zero_stats_dataframe([
+            "       Sharpe  CAGR  MaxDD",
+            "A        0.0   0.0   0.0",
+            "B        0.5   0.0   0.0",  # 1/6 zeros != all-zero
+        ])
+
+    def test_empty_input_not_detected(self):
+        assert not _has_zero_stats_dataframe([])
+
+
+# ---------------------------------------------------------------------------
+# 5. TestDetectCell -- cell-level routing + signal stacking
+# ---------------------------------------------------------------------------
+
+class TestDetectCell:
+    """`detect_cell` -- code-cell routing + multi-signal stacking per cell."""
+
+    def test_markdown_cell_returns_empty(self):
+        cell = {"cell_type": "markdown", "source": "Row 1 0.5", "metadata": {}}
+        assert detect_cell(cell) == []
+
+    def test_code_cell_no_outputs_returns_empty(self):
+        cell = code_cell(outputs=[])
+        assert detect_cell(cell) == []
+
+    def test_code_cell_with_clean_outputs_returns_empty(self):
+        cell = code_cell(outputs=[
+            display_data_output("Result: Sharpe = 0.78, CAGR = 0.12"),
+        ])
+        assert detect_cell(cell) == []
+
+    def test_code_cell_with_row_n_returns_finding(self):
+        cell = code_cell(outputs=[
+            display_data_output("Row 1     0.530    7.2%  -12.7%"),
+        ])
+        findings = detect_cell(cell)
+        assert len(findings) == 1
+        assert findings[0]["signal"] == "row_n_placeholder"
+
+    def test_code_cell_with_zero_stats_returns_finding(self):
+        cell = code_cell(outputs=[
+            display_data_output("\n".join([
+                "Sharpe  CAGR  MaxDD",
+                "0.0     0.0   0.0",
+            ])),
+        ])
+        findings = detect_cell(cell)
+        assert any(f["signal"] == "zero_stats_dataframe" for f in findings)
+
+    def test_cell_can_have_both_signals(self):
+        # Row N + zero stats in same cell -- should stack both findings.
+        # Header separation matters : a multi-section dataframe output where the
+        # header for the zero-stats section appears LATER (after a Row N block)
+        # is detected as zero_stats because we scan the LAST header, not the first.
+        cell = code_cell(outputs=[
+            display_data_output("\n".join([
+                "Row 1   0.530    7.2%  -12.7%",
+                "Row 2   0.612    8.1%  -15.3%",
+                "",
+                "       Sharpe  CAGR  MaxDD",
+                "A       0.0    0.0   0.0",
+                "B       0.0    0.0   0.0",
+            ])),
+        ])
+        findings = detect_cell(cell)
+        signals = {f["signal"] for f in findings}
+        assert "row_n_placeholder" in signals
+        assert "zero_stats_dataframe" in signals
+
+
+# ---------------------------------------------------------------------------
+# 6. TestScanNotebook -- end-to-end dict contract
+# ---------------------------------------------------------------------------
+
+class TestScanNotebook:
+    """`scan_notebook` -- file loading + per-cell aggregation + error handling."""
+
+    def test_missing_file_returns_error_dict(self, tmp_path):
+        result = scan_notebook(tmp_path / "missing.ipynb")
+        assert result["error"] is not None
+        assert result["hits"] == []
+
+    def test_clean_notebook_returns_no_hits(self, tmp_path):
+        nb = {
+            "cells": [
+                {"cell_type": "markdown", "source": "# Title", "metadata": {}},
+                code_cell(outputs=[display_data_output("OK result: Sharpe = 0.78")]),
+            ],
+            "metadata": {"kernelspec": {"name": "python3"}},
+        }
+        nb_path = tmp_path / "clean.ipynb"
+        nb_path.write_text(json.dumps(nb), encoding="utf-8")
+        result = scan_notebook(nb_path)
+        assert result["error"] is None
+        assert result["hits"] == []
+        assert result["kernel"] == "python3"
+
+    def test_fabricated_notebook_returns_hits(self, tmp_path):
+        nb = {
+            "cells": [
+                code_cell(outputs=[display_data_output("Row 1     0.530    7.2%")]),
+                code_cell(outputs=[display_data_output("\n".join([
+                    "Sharpe  CAGR  MaxDD",
+                    "0.0     0.0   0.0",
+                ]))]),
+            ],
+            "metadata": {"kernelspec": {"name": "python3"}},
+        }
+        nb_path = tmp_path / "fab.ipynb"
+        nb_path.write_text(json.dumps(nb), encoding="utf-8")
+        result = scan_notebook(nb_path)
+        assert len(result["hits"]) == 2
+        signals = [h["signal"] for h in result["hits"]]
+        assert "row_n_placeholder" in signals
+        assert "zero_stats_dataframe" in signals
+
+    def test_kernel_extraction_handles_missing_kernelspec(self, tmp_path):
+        nb = {"cells": [], "metadata": {}}
+        nb_path = tmp_path / "no_kernel.ipynb"
+        nb_path.write_text(json.dumps(nb), encoding="utf-8")
+        result = scan_notebook(nb_path)
+        assert result["kernel"] == "?"
+
+
+# ---------------------------------------------------------------------------
+# 7. TestMainExitCodes -- CLI contract
+# ---------------------------------------------------------------------------
+
+class TestMainExitCodes:
+    """`main` -- CLI exit codes + JSON output + family scan."""
+
+    def test_missing_notebook_returns_2(self, tmp_path, capsys):
+        result = main(["--root", str(tmp_path), "does_not_exist.ipynb"])
+        assert result == 2
+        captured = capsys.readouterr()
+        assert "not found" in captured.err.lower()
+
+    def test_missing_family_returns_2(self, tmp_path, capsys):
+        result = main(["--root", str(tmp_path), "--family", "NoSuchFamily"])
+        assert result == 2
+        captured = capsys.readouterr()
+        assert "not found" in captured.err.lower()
+
+    def test_clean_notebook_exit_0(self, tmp_path):
+        nb = {"cells": [code_cell(outputs=[display_data_output("OK")])], "metadata": {"kernelspec": {"name": "python3"}}}
+        nb_path = tmp_path / "clean.ipynb"
+        nb_path.write_text(json.dumps(nb), encoding="utf-8")
+        result = main(["--root", str(tmp_path), str(nb_path)])
+        assert result == 0
+
+    def test_fabricated_notebook_check_exit_1(self, tmp_path):
+        nb = {"cells": [code_cell(outputs=[display_data_output("Row 1     0.530")])], "metadata": {"kernelspec": {"name": "python3"}}}
+        nb_path = tmp_path / "fab.ipynb"
+        nb_path.write_text(json.dumps(nb), encoding="utf-8")
+        result = main(["--root", str(tmp_path), "--check", str(nb_path)])
+        assert result == 1
+
+    def test_json_output_is_machine_readable(self, tmp_path, capsys):
+        nb = {"cells": [code_cell(outputs=[display_data_output("Row 1     0.530")])], "metadata": {"kernelspec": {"name": "python3"}}}
+        nb_path = tmp_path / "fab.ipynb"
+        nb_path.write_text(json.dumps(nb), encoding="utf-8")
+        main(["--root", str(tmp_path), "--json", str(nb_path)])
+        captured = capsys.readouterr()
+        payload = json.loads(captured.out)
+        assert "results" in payload
+        assert "total_hits" in payload
+        assert payload["total_hits"] == 1
+
+
+# ---------------------------------------------------------------------------
+# 8. TestShouldSkip -- SKIP_DIRS + _output.ipynb suffix logic
+# ---------------------------------------------------------------------------
+
+class TestShouldSkip:
+    """`_should_skip` -- SKIP_DIRS + _output suffix matching the sibling detector."""
+
+    def test_skips_lake_packages(self):
+        from detect_blank_figures import SKIP_DIRS  # reference sibling
+        assert SKIP_DIRS  # ensure sibling still uses these names
+        assert _should_skip(Path(".lake/packages/some/file.ipynb"))
+
+    def test_skips_git_dir(self):
+        assert _should_skip(Path(".git/hooks/file.ipynb"))
+
+    def test_skips_output_suffix(self):
+        assert _should_skip(Path("MyIA.AI.Notebooks/foo/_output.ipynb"))
+
+    def test_keeps_canonical_notebook(self):
+        assert not _should_skip(Path("MyIA.AI.Notebooks/QuantConnect/projects/TurnOfMonth/quantbook.ipynb"))
+
+
+# ---------------------------------------------------------------------------
+# 9. TestHumanReport -- formatting
+# ---------------------------------------------------------------------------
+
+class TestHumanReport:
+    """`_human_report` -- summary + per-notebook section + fix footer."""
+
+    def test_empty_results_show_no_fabrication_message(self):
+        report = _human_report([])
+        assert "0" in report or "No fabricated" in report
+
+    def test_affected_notebook_section_present(self):
+        result = {"path": "foo/bar.ipynb", "kernel": "python3", "hits": [{"cell_index": 5, "signal": "row_n_placeholder", "count": 2}]}
+        report = _human_report([result])
+        assert "bar.ipynb" in report
+        assert "cell [5]" in report
+        assert "row_n_placeholder" in report
+        assert "x2" in report
+
+    def test_fix_message_present(self):
+        result = {"path": "foo.ipynb", "kernel": "python3", "hits": [{"cell_index": 5, "signal": "row_n_placeholder"}]}
+        report = _human_report([result])
+        assert "re-execute" in report.lower()
+        assert "stop&repair" in report.lower() or "stop and repair" in report.lower() or "stop&repair" in report.lower()
+
+
+# ---------------------------------------------------------------------------
+# 10. TestIncident6891Baseline -- regression test on the actual 8 quantbooks
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(
+    not Path("MyIA.AI.Notebooks/QuantConnect/projects").exists(),
+    reason="Run from repo root with QuantConnect family present",
+)
+class TestIncident6891Baseline:
+    """Regression test : on the actual 8 quantbook.ipynb files from incident #6891,
+    the detector must flag at least 7 of 8 with Row N placeholders (EMA-Cross-Alpha
+    is intentionally excluded -- it has only the blank-PNG signal, axis 1).
+    """
+
+    TARGETS = [
+        "AllWeather", "DualMomentum", "EMA-Cross-Alpha", "FuturesTrend",
+        "MomentumStrategy", "RiskParity", "SectorMomentum", "TurnOfMonth",
+    ]
+
+    def _scan(self, root):
+        out = []
+        for proj in self.TARGETS:
+            nb_path = root / "QuantConnect" / "projects" / proj / "quantbook.ipynb"
+            if nb_path.exists():
+                out.append(scan_notebook(nb_path))
+        return out
+
+    def test_at_least_7_quantbooks_have_row_n(self):
+        results = self._scan(Path("MyIA.AI.Notebooks"))
+        flagged_with_row_n = sum(
+            1 for r in results
+            if any(h["signal"] == "row_n_placeholder" for h in r["hits"])
+        )
+        # 7/8 expected (EMA-Cross-Alpha is the no-Row-N outlier)
+        assert flagged_with_row_n >= 7, f"Expected >=7 Row N flags, got {flagged_with_row_n}"
+
+    def test_total_row_n_hits_matches_6891_evidence(self):
+        # Issue #6891 evidence table : AllWeather 9, DualMomentum 3, FuturesTrend 15,
+        # MomentumStrategy 3, RiskParity 11, SectorMomentum 3, TurnOfMonth 16.
+        expected = {
+            "AllWeather": 9, "DualMomentum": 3, "FuturesTrend": 15,
+            "MomentumStrategy": 3, "RiskParity": 11, "SectorMomentum": 3,
+            "TurnOfMonth": 16,
+        }
+        root = Path("MyIA.AI.Notebooks")
+        for proj, want in expected.items():
+            nb_path = root / "QuantConnect" / "projects" / proj / "quantbook.ipynb"
+            if not nb_path.exists():
+                continue
+            result = scan_notebook(nb_path)
+            row_n_counts = [
+                h["count"] for h in result["hits"] if h["signal"] == "row_n_placeholder"
+            ]
+            total = sum(row_n_counts)
+            assert total == want, f"{proj}: expected {want} Row N, got {total}"


### PR DESCRIPTION
# feat(notebook-tools,#6891): add detect_fabricated_outputs.py — text-output fabrication sibling of detect_blank_figures

## Why

Prong-A sweep #3801 (axe-2 SOTA) needs to detect **committed textual fabrication** in notebook cell outputs. The existing `detect_blank_figures.py` (#6918 MERGED) covers the IMAGE axis (PNG 1x1 / 70 bytes — the matplotlib empty-figure placeholder). This PR covers the TEXT axis sibling: dataframes with fabricated structure (Row N placeholder, zero-stats dataframe).

Incident fondateur **#6891** : 8 quantbook.ipynb files committed with FABRICATED outputs (kernel never ran, manually filled `outputs` to look like real backtests). Each had:
- a 70-byte blank PNG (axe 1 — already covered)
- `Row N` placeholders (Pandas default dataframe index, signal fort de dataframe bidon)
- zero-stats dataframes (Sharpe/CAGR/MaxDD toutes à 0.0 = backtest qui n'a pas tourné)

Calibration on the 8 quantbooks :
- 7/8 avec Row N (AllWeather 9, DualMomentum 3, FuturesTrend 15, MomentumStrategy 3, RiskParity 11, SectorMomentum 3, TurnOfMonth 16)
- 3/8 avec dataframe all-zero (AllWeather, RiskParity, TurnOfMonth)

EMA-Cross-Alpha = axe 1 ONLY (blank PNG, no Row N). The two detectors are SIBLINGS — one notebook may be flagged by either, neither, or both.

## What it does

`scripts/notebook_tools/detect_fabricated_outputs.py` — pure-Python detector, mirror architecture of `detect_blank_figures.py`:

- `ROW_N_RE = re.compile(r"(?m)^\s*Row\s+\d+(?=\s|$)")` — Pandas default dataframe index appearing in committed text output
- `_has_zero_stats_dataframe(lines)` — finds a header line with 3+ canonical backtest columns (Sharpe, CAGR, MaxDD, NetProfit) and checks if 90%+ of numeric tokens in the data section are zero
- `detect_cell(cell)` — per-code-cell routing + multi-signal stacking (Row N + zero-stats in same cell)
- `scan_notebook(path)` — end-to-end dict contract with kernel extraction and error handling
- CLI: `--check` (exit 1 if fabrication), `--json` (machine-readable), `--family`, `--root`
- Exit codes: 0 (clean), 1 (--check failure), 2 (error)
- `SKIP_DIRS` aligned with sibling detector (.lake, .git, __pycache__, _output.ipynb suffix, etc.)

## Smoke test

```
$ python scripts/notebook_tools/detect_fabricated_outputs.py --family QuantConnect --root .
Notebooks scanned     : 204
Fabricated outputs   : 20
Affected notebooks   : 9
```

9 affected : 7 Row N + 2 zero-stats bonus (FamaFrench, ForexCarry — beyond #6891 calibration, evidence the detector generalizes).

## Tests

`scripts/notebook_tools/tests/test_detect_fabricated_outputs.py` — **49 pytest tests** across 10 clusters:

1. TestRowNRegex (7 tests) — anchor semantics, whitespace, word boundary
2. TestZeroValueRegex (5 tests) — 0, 0.0, signed zero
3. TestHasRowN (6 tests) — positive (single/multiple), negative (real indices)
4. TestHasZeroStatsDataframe (7 tests) — canonical 3/4 cols, all-zero, partial cols, unrelated
5. TestDetectCell (7 tests) — markdown routing, multi-signal stacking, output capture
6. TestScanNotebook (4 tests) — file loading, kernel extraction, error dict
7. TestMainExitCodes (5 tests) — CLI exit codes 0/1/2, JSON contract
8. TestShouldSkip (4 tests) — SKIP_DIRS alignment with sibling
9. TestHumanReport (3 tests) — formatting, fix footer
10. TestIncident6891Baseline (2 tests) — REGRESSION test on actual 8 quantbooks asserting exact Row N counts from #6891 evidence table

**100% pass** (49/49 in 0.30s).

## README propagation (c.719 amend)

This PR was amended at SHA `048803dbc` to also propagate the detector in `scripts/notebook_tools/README.md` (G.6 audit cascade — every detector-PR must update the README at merge time). Specifically:

- Tableau "Detecteurs anti-regression" ligne 18 : ajout `detect_fabricated_outputs.py` + role **#6891 axe-2 fabrication textuelle (sibling detector)**
- Section `### detect_fabricated_outputs.py (#6891, axe-2 sibling)` ajoutée après `detect_blank_figures.py` (sibling logique), documentant les 2 signaux (row_n_placeholder + zero_stats_dataframe), calibration 7/8 + 3/8, exemples CLI, owner, blind spots
- Décompte `Les 6 detecteurs` → `Les 7 detecteurs` (axe-2 incrément)

Sub-scope atomicité : cet amend ne touche **que** axe-2 ; les autres axes (axe-3 link-target #7210, axe accent #6806, axe-3 SVG offscreen/empty-display/etc.) restent à leurs PRs respectifs (leurs workers le feront au merge time).

## Scope (HARD)

The actual re-execution of the 8 quantbooks (re-running the kernels via QC Cloud research to commit REAL outputs instead of the fabricated ones) is **RECOVERABLE-MACHINE infra-heavy**:
- QC Cloud research kernel setup
- lean-cli PATH shadow Elan
- Playwright 5000ms timeout

Traced for a dedicated cycle. **This PR is the guard detector** — it does NOT touch the 8 quantbooks themselves (Stop&Repair = correct the cause, not the detector of the cause). The detector will catch the same fabrication pattern in any future notebook.

## Preuves vérifiables

- Smoke test: 9 affected notebooks detected across 204 scanned (#6891 baseline 7/8 + 2 bonus)
- pytest: 49/49 PASSED in 0.30s
- 3 files / +911/-2 (atomique — détecteur + tests + README propagation)
- No secrets (pre-commit grep clean)
- No force push on main; `--force-with-lease` on feature branch amend (single-worker, no concurrency)
- Single subject per PR, base fresh (origin/main @ 2faaee90a)

## Liens opérationnels

- `detect_blank_figures.py` (#6918 MERGED) — axe-1 sibling
- `detect_ascii_workaround.py` (#3801) — ASCII half of the sweep
- `.claude/rules/sota-not-workaround.md` — Prong-A: vrai outil, pas workaround/fabrication
- `.claude/rules/secrets-hygiene.md` rule 6 — Stop&Repair: re-execute, jamais scrubber
- `.claude/rules/catalog-pr-hygiene.md` Règle 1 — README propagé at merge time, JAMAIS régén catalogue
- #6891 — incident fondateur (8 quantbook.ipynb fabrication)
- #3801 — EPIC SOTA axe-2

Part of #3801 (EPIC SOTA axe-2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)