### PR TITLE
fix(probas,#4959): remove semantically-incoherent mermaid link NB_EP -> LK_SC (extension Dung)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/README.md
+++ b/MyIA.AI.Notebooks/Probas/README.md
@@ -598,7 +598,9 @@ flowchart LR
     NB_PAC -. "uniform_concentration ⟹ erm_error_bound" .-> LK_PAC
     NB_GIT -. "identités d'escompte ⟹ indice Gittins" .-> LK_GIT
     NB_MCMC -. "log-bienveillance ⟹ f* = μ−σ²/2" .-> LK_KELLY
-    NB_EP -. "extension Dung ⟹ cadre formel" .-> LK_SC
+    %% NB_EP (Infer.NET EP / VMP) = inférence bayésienne approximative ;
+    %% la passerelle Dung ↔ argumentation_lean est couverte par le tableau §E ci-dessus (ligne SymbolicAI ↔ Probas),
+    %% pas par un lien direct depuis ce nœud de simulation.
     style LK_DT fill:#e8f5e9,stroke:#2e7d32
     style LK_CO fill:#e8f5e9,stroke:#2e7d32
     style LK_PAC fill:#e8f5e9,stroke:#2e7d32


### PR DESCRIPTION
# fix(probas,#4959): remove semantically-incoherent mermaid link NB_EP -> LK_SC (extension Dung)

## Contexte

Le rapport c.674 (PR [#7362](https://github.com/jsboige/CoursIA/pull/7362)) a corrigé 4 références textuelles stale (`social_choice_lean` → `game_theory_lean`) dans `MyIA.AI.Notebooks/Probas/README.md` §E — table L574, prose L565, mermaid L594 (LK_SC), footer L612. Le rapport c.674 a explicitement **tracé le résidu** suivant comme follow-up hors-scope de #7362 :

> *résiduel hors-scope tracé : mermaid L601 `NB_EP -.-> LK_SC "extension Dung"` incohérent (Dung vit dans `argumentation_lean`, pas game_theory_lean) — diagramme-accuracy issue séparée, follow-up #4959.*

**G.1 vérification c.676** : le lien L601 était **doublement incohérent** :
1. **Label** : `"extension Dung ⟹ cadre formel"` ne correspond pas à la sémantique de `NB_EP` (`Infer.NET EP / VMP` = inférence bayésienne approximative via Expectation-Propagation / Variational Message Passing — aucun lien avec la sémantique Dung « extension d'argumentation »).
2. **Cible** : `LK_SC` (= `social_choice_lean` / Arrow — devient `game_theory_lean (Arrow)` post-#7362) — Dung vit dans `MyIA.AI.Notebooks/SymbolicAI/Tweety/argumentation_lean/` (Argumentation Framework), pas dans GameTheory/Arrow.

Le lien était un **artefact de conception** (probablement brouillon pédagogique abandonné ou copier-coller erroné) qui n'a jamais été nettoyé. PR #7362 ne l'a pas corrigé car le scope strict #4365 sweep ne visait que les noms de lakes standalone, pas les liens mermaid sémantiquement incohérents.

## Changement

**Une seule modification** dans `MyIA.AI.Notebooks/Probas/README.md` :

```diff
     NB_MCMC -. "log-bienveillance ⟹ f* = μ−σ²/2" .-> LK_KELLY
-    NB_EP -. "extension Dung ⟹ cadre formel" .-> LK_SC
+    %% NB_EP (Infer.NET EP / VMP) = inférence bayésienne approximative ;
+    %% la passerelle Dung ↔ argumentation_lean est couverte par le tableau §E ci-dessus (ligne SymbolicAI ↔ Probas),
+    %% pas par un lien direct depuis ce nœud de simulation.
     style LK_DT fill:#e8f5e9,stroke:#2e7d32
```

**Justification de l'approche** : **suppression** du lien erroné (pas recréation). La passerelle réelle `Dung ↔ argumentation_lean` est déjà **explicitement couverte** dans la table §E du même README à la ligne :

```
| SymbolicAI ↔ Probas      | `argumentation_lean`             | Extension Dung (`grounded`/`preferred`/`stable`) par cadre formel                 | hub SymbolicAI/Tweety notebook AF-Dung                               |
```

Un commentaire mermaid documente la raison (transparence : pas de trou silencieux), sans inventer un nouveau lien NB_EP → X qui n'existait pas dans la conception originelle.

### Pourquoi ne pas recréer un lien NB_EP → LK_KELLY ?

NB_EP (`Infer.NET EP / VMP`) traite d'optimisation convexe pour approximation bayésienne, et `LK_KELLY` (`kelly_lean` = Kelly criterion sous log-bienveillance) est une théorie de la fraction risquée optimale. La connexion mathématique est **lointaine** et non-directe — mieux vaut omettre que suggérer une passerelle non-pédagogiquement centrale.

## Preuve pure-change (conformité R3 atomicité + doctrine README #3973)

| Critère | Vérification |
|---------|--------------|
| Fichiers modifiés | 1 (`MyIA.AI.Notebooks/Probas/README.md`) |
| Lignes | +3 / -1 (R3 atomic, **bien sous les seuils** > 3000 lignes / > 15 fichiers / > 4 features / > 1 domaine) |
| Code de production touché | 0 (purement mermaid markdown dans README) |
| Marqueurs CATALOG-STATUS byte-identiques | ✅ (3 marqueurs présents, inchangés) |
| 0 image touchée | ✅ |
| 0 MANIFEST touché | ✅ |
| Encodage | UTF-8 no-BOM, 0 CRLF (`file` reports "UTF-8 Unicode text") |
| Branche | `fix/c676-probas-mermaid-nb-ep-stale-link` from `origin/main@2faaee90a` |
| Divergence vs main | 0 derrière (`git rev-list --left-right --count origin/main...HEAD` = 0 0) |

## PRs historiques de référence (G.1 mandated)

- **PR #7312** (MERGED) `fix(game-theory,#4365): retire standalone lakes dans GameTheory/README.md` — a corrigé les références dans le **hub** GameTheory/README.md.
- **PR #7313** (MERGED) `fix(game-theory,#4365): arrow.phantom retire` — fix de cohérence hub post-#7312.
- **PR #7360** (OPEN, ai-01 merge pending) — note méthodologique cross-famille.
- **PR #7362** (OPEN, c.674) `docs(probas,#4959): stale social_choice_lean refs in Probas/README.md §E (post-#4365)` — a corrigé les références textuelles Probas, MAIS PAS le lien mermaid L601 (explicitement tracé comme résidu hors-scope).
- **PR #7369** (OPEN, c.675) `fix(lean,#4365): generalize L674 stale-lake-ref sweep to ML/Search/SymbolicAI Lean READMEs` — doctrine #4365 cleanup sweep **DRAINED** sur 4 cross-series hubs (Probas #7362 + SymbolicAI/Lean+Search+ML #7369).

## Conformité §E (audit-fichier-entier obligatoire, mandat user 2026-07-04)

- `ls`/`find` count par sous-dossier cité : N/A (c.676 = mermaid interne à 1 section, pas une table de notebooks)
- Réconciliation disque ↔ CATALOG-STATUS ↔ prose : cohérente (aucune modification prose ou table, mermaid uniquement)
- Confirmation que listes de notebooks / arbres de structure / breakdowns par sous-série sont à jour : N/A (scope strictement mermaid)

## Doctrine respectée

- **#5780** (mosaic dissolve + légendes fidèles) : N/A (lecture pure mermaid dans hub probas, pas de figure/image).
- **#4365** (cleanup lakes standalone absorbés) : **alignement** — le mermaid devient cohérent avec la doctrine post-PR #7362 (L594 LK_SC = `game_theory_lean (Arrow)` post-merge #7362).
- **#4959** (README hubs cohérence) : alignement — fix mermaid accuracy contribue à la cohérence inter-hubs (NB_EP correctement non-routé vers argumentation_lean qui est ailleurs).
- **#3973** (README ascendant) : alignement — fix mermaid interne n'introduit aucune incohérence dans la hiérarchie hubs/feuilles.

## G.1 firsthand verify (anti-hallu)

- ✅ `git log --diff-filter=A -- MyIA.AI.Notebooks/SymbolicAI/Tweety/argumentation_lean/` confirme que Dung vit dans **SymbolicAI/Tweety**, pas dans GameTheory/social_choice_lean.
- ✅ `grep -n 'NB_EP' MyIA.AI.Notebooks/Probas/README.md` confirme que NB_EP = `Infer.NET EP / VMP` (algorithme d'inférence bayésienne approximative).
- ✅ `grep -n 'extension Dung' MyIA.AI.Notebooks/Probas/README.md` confirme que le seul autre match dans le README est le tableau §E ligne L576 qui couvre correctement la passerelle Dung ↔ argumentation_lean (donc notre suppression ne crée PAS de perte d'information).
- ✅ `git diff origin/main..HEAD` = **+3/-1 strict symétrique sur 1 fichier** (atomicité R3 parfaite).
- ✅ `gh pr list --state open --search "Probas"` cross-check : PR #7362 (c.674) sur table+prose, PR #7369 (c.675) sur 3 autres hubs — **0 collision** sur le grain mermaid L601.

## R6 anti-monotonie + plafond L666-L2 ★★

- c.674 + c.675 = même registre §E stale-lake-ref textuel (3 familles distinctes c.675 = Probas → SymbolicAI+Search+ML : pivot cross-famille légitime).
- **c.676 = grain DIFFÉRENT** du même écosystème doctrinal : mermaid link accuracy (pas stale-name textuel). Pas de monotonie.

## Critère §B (anti-régression Lean) — N/A

Aucun fichier `*.lean` ni `agent_tests/prover/` touché. Le seul lake référencé (LK_SC → `game_theory_lean (Arrow)` post-#7362) reste inchangé localement (PR #7362 gère la migration textuelle séparément).

## Critère §H (Stop & Repair canon) — respecté

Aucune sortie de cellule committee touchée (purement README markdown). Aucune fabrication de résultat.

## Suite suggérée

- **Court terme** : merge post-ai-01 review (mermaid accuracy fix, doctrinally aligned).
- **Moyen terme** : PR #7362 (c.674) merge en premier, puis PR c.676 peut être re-rebasée pour cohérence (la cible LK_SC du footer mermaid devient `game_theory_lean (Arrow)` après merge #7362, mais c.676 ne touche PAS le LK_SC lui-même, juste le lien sémantiquement incohérent, donc merge order n'affecte pas c.676).
