### PR TITLE
fix(gametheory): use separate instances for self-play in IPD Tournament

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/tests/test_trust_simulation.py
+++ b/MyIA.AI.Notebooks/GameTheory/tests/test_trust_simulation.py
@@ -448,6 +448,27 @@ class TestTournament:
         if allc in t.results.scores:
             assert t.results.scores[allc] - offdiag[allc] == pytest.approx(3 * 50)
 
+    def test_self_play_uses_separate_instances(self):
+        """Self-play doit utiliser des instances SEPUREES, pas le meme objet.
+
+        Regression pin : passer le meme objet comme player1 ET player2 corrompt
+        les strategies stateful (choose() appele deux fois avec historique stale,
+        record() double-appende). Detective self-play score=16 (casse) vs 34
+        (instances separees, correct) sur 12 tours. Ce test aurait attrape le bug.
+        """
+        rounds = 12
+        # Self-play via Tournament (i==j) doit egaler un match 2-instances propre.
+        results = Tournament(strategies=[Detective], rounds_per_match=rounds).run()
+        detective_name = Detective().name
+        self_play_via_tournament = results.scores[detective_name]
+
+        proper = play_match(Detective(), Detective(), rounds=rounds)
+        self_play_proper = proper["score1"]
+
+        assert self_play_via_tournament == pytest.approx(self_play_proper)
+        # Sanity : le score casse (16) ne doit plus revenir.
+        assert self_play_via_tournament > 20
+
 
 # ============================================================================
 # run_axelrod_tournament (convenience wrapper).

--- a/MyIA.AI.Notebooks/GameTheory/trust_simulation/tournament.py
+++ b/MyIA.AI.Notebooks/GameTheory/trust_simulation/tournament.py
@@ -94,10 +94,19 @@ class Tournament:
             for j in range(n):  # Include self-play
                 total1, total2 = 0.0, 0.0
 
+                # Self-play (i == j) MUST use a SEPARATE instance for player 2.
+                # Passing the same object as both players corrupts stateful
+                # strategies: choose() is called twice per round with stale
+                # history (the second call sees no record yet), and record()
+                # double-appends to the shared history. This silently halves
+                # the self-play score of any stateful strategy (Detective,
+                # Grudger, Pavlov, Copykitten) and skews the ranking.
+                player2 = strategies[j] if i != j else type(strategies[i])()
+
                 for _ in range(self.repetitions):
                     result = play_match(
                         strategies[i],
-                        strategies[j],
+                        player2,
                         rounds=self.rounds_per_match
                     )
                     total1 += result["score1"]


### PR DESCRIPTION
## Summary

`Tournament.run()` passed `strategies[i]` as **both** players when `i == j` (self-play): `play_match(strategies[i], strategies[i], ...)`. For any **stateful** strategy this corrupts the match — `choose()` is called twice per round with stale history (the second call sees no `record()` yet), and `record()` double-appends to the single shared history. The net effect silently understates the self-play score.

## Proof of the bug (reproduce-before-claim)

Detective self-play over 12 rounds:

| | Score |
|---|---|
| Via `Tournament` (same instance) | **16** |
| Proper two-instance match | **34** |

A 2x gap. TitForTat is invariant (it always cooperates with itself regardless of instance), which is why the bug went undetected. `DETERMINISTIC` includes Detective, Grudger, Pavlov and Copykitten — **all stateful, all skewed** — so the bug materially distorts the round-robin ranking.

## Fix

Instantiate a fresh opponent for player 2 in the self-play branch (`type(strategies[i])()`), leaving the cross-play path unchanged. Minimal, clear, no semantic change to cross-play.

## Test consequence

`TestTournament` used **robust invariants**, not pinned buggy values:
- `scores[name] >= offdiag[name]` (inequality — true before and after)
- exact self-play assertion only on **AlwaysCooperate** (stateless, invariant to the bug)

So **no existing test pinned the buggy value** — the fix breaks nothing (verified: 54 → 55 passing). Added `test_self_play_uses_separate_instances` as a regression pin: Detective self-play via `Tournament` must equal a proper two-instance match, and must exceed the buggy-16 floor.

## No C.2 implication

No Python notebook consumes the `Tournament` class:
- `GameTheory-6-EvolutionTrust.ipynb` uses the **Axelrod library** (`import ax`), not this module.
- `GameTheory-6-EvolutionTrust-Csharp.ipynb` has its own **inline C#** `RunTournament`.

So the score change does not alter any committed notebook output.

## Validation

- `tests/test_trust_simulation.py`: **55 passed** (incl. new regression pin).
- Full `GameTheory/tests/` suite: **284 passed, 4 xfailed** (`test_lean_definitions.py` ignored: pre-existing env failure — hardcoded WSL `/home/jesse` path, file untouched by this PR).
- Catalogue byte-identical.

## Files

- `MyIA.AI.Notebooks/GameTheory/trust_simulation/tournament.py` — self-play separate-instance fix + explanatory comment.
- `MyIA.AI.Notebooks/GameTheory/tests/test_trust_simulation.py` — `test_self_play_uses_separate_instances` regression pin.

See GameTheory-6-EvolutionTrust.ipynb.