### PR TITLE
fix(ext_tools): resolve infinite loop in marco.py on duplicate clauses

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/ext_tools/marco.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/ext_tools/marco.py
@@ -37,7 +37,13 @@ class SubsetSolver:
     def c_var(self, i):
         """Get control variable for constraint i"""
         if i not in self.varcache:
-            v = Bool(str(self.constraints[abs(i)]))
+            # Name the control variable after the constraint INDEX, not its
+            # string representation: duplicate clauses (legal in DIMACS) or
+            # unit clauses whose text matches a propositional variable name
+            # would otherwise collapse to a single Z3 constant, corrupting the
+            # Map solver's blocking and sending enumerate_sets into an infinite
+            # loop on valid input.
+            v = Bool(f"__c{abs(i)}")
             self.idcache[get_id(v)] = abs(i)
             if i >= 0:
                 self.varcache[i] = v

--- a/MyIA.AI.Notebooks/SymbolicAI/ext_tools/test_marco.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/ext_tools/test_marco.py
@@ -1,0 +1,148 @@
+"""Regression tests for ext_tools/marco.py (MARCO MUS/MSS enumerator).
+
+Pins the duplicate-clause hang bug: control variables were named after the
+constraint's string representation (`Bool(str(constraint))`), so two clauses
+with identical text (e.g. duplicate unit clauses, legal in DIMACS) collided
+to a single Z3 control variable. This corrupted the Map solver's blocking
+logic and sent `enumerate_sets` into an infinite loop on valid input.
+
+The fix names control variables after the constraint INDEX (`Bool(f"__c{i}")`),
+guaranteeing one distinct control variable per clause regardless of content.
+
+These tests run marco.py as a subprocess with a hard timeout: the buggy
+version hangs (timeout => fail), the fixed version terminates with correct
+MUS/MSS output.
+"""
+import os
+import re
+import subprocess
+import sys
+import textwrap
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+MARCO = os.path.join(HERE, "marco.py")
+TIMEOUT_S = 30  # buggy version loops forever; 30s is generous for fixed version on these tiny CNFs
+
+
+def _run_marco(cnf_text: str, *extra):
+    """Write CNF to a temp file and run marco.py. Returns (rc, stdout)."""
+    import tempfile
+
+    cnf = tempfile.NamedTemporaryFile("w", suffix=".cnf", delete=False, encoding="utf-8")
+    cnf.write(textwrap.dedent(cnf_text).lstrip())
+    cnf.close()
+    try:
+        proc = subprocess.run(
+            [sys.executable, MARCO, cnf.name, *extra],
+            capture_output=True, text=True, timeout=TIMEOUT_S,
+        )
+        return proc.returncode, proc.stdout
+    finally:
+        os.unlink(cnf.name)
+
+
+def _parse(output: str):
+    """Return (mus_list, mss_list) parsed from marco verbose output."""
+    mus, mss = [], []
+    for line in output.splitlines():
+        line = line.strip()
+        if line.startswith("U "):
+            mus.append(sorted(int(x) for x in re.findall(r"\d+", line)))
+        elif line.startswith("S "):
+            mss.append(sorted(int(x) for x in re.findall(r"\d+", line)))
+    return sorted(mus), sorted(mss)
+
+
+def test_simple_mus_and_mss():
+    """(x1)(¬x1)(x2): MUS={0,1}, MSS={0,2} and {1,2}."""
+    rc, out = _run_marco("""
+        p cnf 2 3
+        1 0
+        -1 0
+        2 0
+    """, "-v")
+    assert rc == 0, f"marco exited {rc}: {out}"
+    mus, mss = _parse(out)
+    assert mus == [[0, 1]], mus
+    assert mss == [[0, 2], [1, 2]], mss
+
+
+def test_two_independent_muses():
+    """(x1)(¬x1)(x2)(¬x2): two MUSes {0,1},{2,3} and 4 MSS (one from each pair)."""
+    rc, out = _run_marco("""
+        p cnf 2 4
+        1 0
+        -1 0
+        2 0
+        -2 0
+    """, "-v")
+    assert rc == 0, f"marco exited {rc}: {out}"
+    mus, mss = _parse(out)
+    assert mus == [[0, 1], [2, 3]], mus
+    assert len(mss) == 4, mss
+
+
+def test_duplicate_clause_does_not_hang():
+    """REGRESSION PIN: duplicate unit clause must terminate with DISTINCT MUSes.
+
+    Buggy version: c0=(x1) and c1=(x1) share control var Bool("x1") ->
+    infinite loop in enumerate_sets (timeout => subprocess.TimeoutExpired -> fail).
+
+    Fixed version: distinct index-named control vars -> MUSes {0,2} and {1,2}
+    (each duplicate paired with the negation c2=(¬x1) is independently minimal
+    unsatisfiable).
+    """
+    rc, out = _run_marco("""
+        p cnf 2 4
+        1 0
+        1 0
+        -1 0
+        2 0
+    """, "-v")  # subprocess.run raises TimeoutExpired if it hangs -> test fails
+    assert rc == 0, f"marco exited {rc}: {out}"
+    mus, mss = _parse(out)
+    # Both duplicates form their own minimal UNSAT subset with the negation.
+    assert [0, 2] in mus and [1, 2] in mus, mus
+
+
+def test_duplicate_disjunction_terminates():
+    """Same collision class: duplicate non-unit clause (x1∨x2)."""
+    rc, out = _run_marco("""
+        p cnf 2 4
+        1 2 0
+        1 2 0
+        -1 0
+        -2 0
+    """, "-v")
+    assert rc == 0, f"marco exited {rc}: {out}"
+    mus, _ = _parse(out)
+    # {0,2,3} and {1,2,3}: each duplicate (x1∨x2) with (¬x1)(¬x2) is minimally UNSAT.
+    assert [0, 2, 3] in mus and [1, 2, 3] in mus, mus
+
+
+def test_mus_only_flag():
+    """--mus-only enumerates only MUS lines."""
+    rc, out = _run_marco("""
+        p cnf 2 3
+        1 0
+        -1 0
+        2 0
+    """, "--mus-only", "-v")
+    assert rc == 0
+    mus, mss = _parse(out)
+    assert mus == [[0, 1]], mus
+    assert mss == [], mss
+
+
+def test_mss_only_flag():
+    """--mss-only enumerates only MSS lines."""
+    rc, out = _run_marco("""
+        p cnf 2 3
+        1 0
+        -1 0
+        2 0
+    """, "--mss-only", "-v")
+    assert rc == 0
+    mus, mss = _parse(out)
+    assert mus == [], mus
+    assert mss == [[0, 2], [1, 2]], mss


### PR DESCRIPTION
## Summary

`marco.py` (MARCO MUS/MSS enumerator) entered an **infinite loop** on valid DIMACS input containing duplicate clauses. Root cause: `SubsetSolver.c_var` named each constraint control variable after the constraint string representation `Bool(str(constraint))`, so two clauses with identical text (duplicate clauses, or unit clauses whose `str()` matches a propositional variable name) collapsed to a single Z3 constant — corrupting the Map solver blocking logic.

**Fix** (+7/-1): name control variables after the constraint **INDEX** (`Bool(f"__c{i}")`), guaranteeing one distinct control variable per clause regardless of content.

## Reproduced firsthand (G.9 reproduce-before-claim)

| CNF | Pre-fix | Post-fix |
|---|---|---|
| `(x1)(¬x1)(x2)` | MUS=[0,1] MSS=[[0,2],[1,2]] | **unchanged** |
| `(x1)(¬x1)(x2)(¬x2)` | 2 MUS + 4 MSS | **unchanged** |
| `(x1)(x1)(¬x1)(x2)` duplicate | **HANGS (infinite loop)** | terminates: MUS=[0,2],[1,2] MSS=[0,1,3],[2,3] |

Duplicate clauses are valid DIMACS — a MUS/MSS enumerator must not hang on them.

## Validation (H.1)

```
$ python -m pytest ext_tools/test_marco.py -q
6 passed in 0.86s
```

6 regression tests incl. `test_duplicate_clause_does_not_hang` (subprocess + 30s timeout — the buggy version raises `TimeoutExpired`, failing the test; fixed version terminates with correct distinct MUSes). Also pins `--mus-only` / `--mss-only` flags and multi-MUS case.

## No C.2 implication

0 active consumer depends on the buggy behavior:
- `Tweety/Tweety-1-Setup.ipynb` → file-exists detection only (`OK MARCO trouve: ...marco.py`)
- `archive/Tweety.ipynb` → `MarcoMusEnumerator` reference is commented out
- `GenAI/Texte/5_RAG_Modern.ipynb` → `ms-marco-MiniLM` is an unrelated reranker model name

## Context

Same reporting/robustness bug family as #7368 / #7371 / #7375 this cycle-day (po-2024/po-2025/po-2026): standalone solver modules where internal logic is correct but a specific input class triggers wrong/contradictory output. Bug-hunt on `ext_tools/marco.py` — untouched this cycle-day (po-2025 c.532 fixed sibling `sat_solver.py`, c.530 verified `maxsat_solver.py` correct).

Catalogue byte-identical to main. See #3801