### PR TITLE
fix(tweety): surface solver errors instead of masking as TIMEOUT in sat_calibration

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/scripts/sat_calibration.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/scripts/sat_calibration.py
@@ -179,10 +179,17 @@ def benchmark_config(name: str, cnf: CNF, timeout: float = TEST_TIMEOUT) -> dict
         elapsed, sat, timed_out = solve_with_timeout(solver, cnf, timeout)
         short = SOLVER_SHORT[solver]
 
-        if timed_out:
-            times[short] = f"TIMEOUT ({timeout}s)"
-        elif isinstance(timed_out, str):
+        # `solve_with_timeout` returns the third tuple element as one of:
+        #   False            -> solver succeeded (elapsed, sat are valid)
+        #   True             -> solver timed out
+        #   "Error: <msg>"   -> solver raised an exception
+        # Check the error string FIRST: a non-empty error message is truthy,
+        # so the previous `if timed_out:` branch swallowed real exceptions
+        # and reported them as TIMEOUT, silently corrupting the calibration.
+        if isinstance(timed_out, str):
             times[short] = timed_out
+        elif timed_out:
+            times[short] = f"TIMEOUT ({timeout}s)"
         else:
             times[short] = f"{elapsed*1000:.1f}ms"
             results['sat'] = sat

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/scripts/test_sat_calibration.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/scripts/test_sat_calibration.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Pytest suite for `Tweety/scripts/sat_calibration.py` (SAT solver calibration).
+
+Co-located with the module (same convention as `ext_tools/test_sat_solver.py`).
+CPU-only, no network, deterministic. Guards on PySAT availability via
+`importorskip` so the suite is skipped (not errored) on a machine without
+`python-sat`.
+
+The suite pins:
+  * `solve_with_timeout` return contract for the three outcomes (success /
+    timeout / error), and
+  * a regression on `benchmark_config`: an exception raised by a solver used
+    to be masked as a TIMEOUT (the error string is truthy, so the old
+    `if timed_out:` branch swallowed it before the dead
+    `elif isinstance(timed_out, str)` could run). The regression test injects
+    a non-existent solver and asserts the error message surfaces verbatim in
+    the `times` dict rather than being reported as TIMEOUT.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+pysat = pytest.importorskip("pysat")  # noqa: F841 — skip suite if PySAT missing
+CNF = pytest.importorskip("pysat.formula", reason="needs pysat.formula").CNF
+
+# Load the module by path (it lives under scripts/, no package import path).
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+_MODULE_PATH = _SCRIPTS_DIR / "sat_calibration.py"
+_spec = importlib.util.spec_from_file_location("sat_calibration", _MODULE_PATH)
+sat_calibration = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(sat_calibration)
+
+
+def _trivial_cnf() -> "CNF":
+    cnf = CNF()
+    cnf.append([1])
+    cnf.append([2])
+    return cnf
+
+
+# --------------------------------------------------------------------------
+# solve_with_timeout — return contract
+# --------------------------------------------------------------------------
+
+
+def test_solve_with_timeout_success_returns_false_flag():
+    cnf = _trivial_cnf()
+    # cadical195 / glucose42 / minisat22 are the module's configured solvers;
+    # use whichever is actually available on this machine.
+    for name in ("cadical195", "glucose42", "minisat22"):
+        elapsed, sat, flag = sat_calibration.solve_with_timeout(name, cnf, 10)
+        if isinstance(flag, str) and flag.startswith("Error:"):
+            continue  # solver not installed here; try the next
+        assert flag is False, f"{name} should succeed with flag=False, got {flag!r}"
+        assert sat is True, "trivially-SAT CNF (x1) ∧ (x2) must be SAT"
+        assert elapsed >= 0
+        return
+    pytest.skip("none of cadical195/glucose42/minisat22 available locally")
+
+
+def test_solve_with_timeout_error_returns_string_flag():
+    """A non-existent solver must surface as an error STRING, not a timeout.
+
+    The third tuple element is `f"Error: {e}"` (truthy string) on exception,
+    `True` on timeout, `False` on success. The error string MUST be kept
+    distinct from the boolean timeout flag downstream — see the
+    `benchmark_config` regression below.
+    """
+    cnf = _trivial_cnf()
+    elapsed, sat, flag = sat_calibration.solve_with_timeout(
+        "DEFINITELY_NOT_A_SOLVER_XYZ", cnf, 5
+    )
+    assert isinstance(flag, str)
+    assert flag.startswith("Error:")
+    assert sat is None
+    assert elapsed == 0
+
+
+# --------------------------------------------------------------------------
+# benchmark_config — regression: error must not be masked as TIMEOUT
+# --------------------------------------------------------------------------
+
+
+def test_benchmark_config_surfaces_solver_error_not_timeout(monkeypatch):
+    """Regression: an exception raised by a solver must be reported as the
+    error message, NOT silently relabeled as TIMEOUT.
+
+    Before the fix, `benchmark_config` did `if timed_out:` first, which is
+    truthy for both the boolean `True` (real timeout) and a non-empty error
+    string. So a crashing solver appeared to time out, corrupting the
+    calibration. The `elif isinstance(timed_out, str)` branch that was meant
+    to handle errors was dead code.
+    """
+    # Force the only "solver" considered to be a non-existent one so the
+    # exception path is exercised deterministically, regardless of which
+    # real solvers are installed on this machine.
+    monkeypatch.setattr(sat_calibration, "SOLVERS", ["DEFINITELY_NOT_A_SOLVER_XYZ"])
+    monkeypatch.setattr(
+        sat_calibration,
+        "SOLVER_SHORT",
+        {"DEFINITELY_NOT_A_SOLVER_XYZ": "Bogus"},
+    )
+
+    cnf = _trivial_cnf()
+    result = sat_calibration.benchmark_config("repro", cnf, timeout=5)
+
+    bogus_entry = result["times"]["Bogus"]
+    assert isinstance(bogus_entry, str)
+    assert bogus_entry.startswith("Error:"), (
+        f"solver error should surface verbatim, got {bugus_entry!r} "
+        "(would be 'TIMEOUT (5s)' under the buggy branch order)"
+    )
+    assert "TIMEOUT" not in bogus_entry
+    # No winner can be declared from a crashed solver.
+    assert result["winner"] is None
+
+
+def test_benchmark_config_records_vars_and_clauses():
+    cnf = _trivial_cnf()
+    # Use a real solver if any is available, else skip gracefully.
+    for name in ("cadical195", "glucose42", "minisat22"):
+        _e, _s, flag = sat_calibration.solve_with_timeout(name, cnf, 10)
+        if flag is False:
+            monkeypatch_target = None
+            break
+    else:
+        pytest.skip("no configured solver available locally")
+    result = sat_calibration.benchmark_config("meta", cnf, timeout=10)
+    assert result["vars"] == 2
+    assert result["clauses"] == 2
+    assert "times" in result and result["times"]


### PR DESCRIPTION
## What

Fix a reporting bug in **`SymbolicAI/Tweety/scripts/sat_calibration.py`** (SAT solver calibration script, 0 Python test coverage before this PR). Bug-hunt in a family/sub-domain untouched this cycle-day (R6 variety), same reporting-bug vein as #7375 (sat_solver) found this cycle-day.

## Le bug (firsthand reproduit AVANT le fix)

`benchmark_config` (L178-191) consumed the 3rd tuple element of `solve_with_timeout`, which is one of `False` (success) / `True` (timeout) / `"Error: <msg>"` (exception). The branch order was:

```python
if timed_out:                          # truthy for True AND non-empty error string!
    times[short] = f"TIMEOUT ({timeout}s)"
elif isinstance(timed_out, str):       # DEAD CODE — already swallowed above
    times[short] = timed_out
else:
    ...
```

A **non-empty error string is truthy**, so an exception raised by a solver (e.g. solver not available, internal error) was silently reported as `TIMEOUT (10s)` — a lie. The `elif isinstance(timed_out, str)` branch meant to handle errors was **dead code**, never reachable.

For a calibration script whose entire purpose is to compare solvers honestly, masking a crash as a timeout is materially wrong: the user concludes the solver is slow (and might pick it for a benchmark where it will crash again) instead of broken.

**Reproduction** (firsthand, before fix):
```python
solve_with_timeout('NONEXISTENT_SOLVER_XYZ', cnf, 5)
# → (0, None, 'Error: NONEXISTENT_SOLVER_XYZ')   # 3rd elt = truthy string
# benchmark_config then stored: 'TIMEOUT (10s)'  ← LIE
```

## Le fix

Invert the branch order: check `isinstance(timed_out, str)` (error) **before** `if timed_out:` (real boolean timeout). `+10/−3` on `sat_calibration.py`, with a comment documenting the three-state return contract of `solve_with_timeout` to prevent future regression.

## Validation reproductible (post-fix)

```
$ python -m pytest Tweety/scripts/test_sat_calibration.py -q
4 passed in 0.07s
# End-to-end: benchmark_config with a bogus solver now stores
#   times['Bogus'] = 'Error: DEFINITELY_NOT_A_SOLVER_XYZ'   (was 'TIMEOUT (5s)')
```

## Livrable

- **`test_sat_calibration.py`** (co-localisé avec le module dans `scripts/`, convention `ict/tests/` + `ext_tools/test_sat_solver.py`) — **4 tests CPU-only**, 0.07 s, `pytest.importorskip("pysat")`. Couvre :
  - **`solve_with_timeout` return contract** (2) : success → `flag is False` + `sat is True` for a trivially-SAT CNF ; error → `flag` is a string starting with `"Error:"` + `sat is None`.
  - **`benchmark_config` regression** (1) : injects a non-existent solver (deterministic, independent of which real solvers are installed) and asserts the error message surfaces verbatim in `times`, NOT relabeled as TIMEOUT.
  - **`benchmark_config` metadata** (1) : records `vars` and `clauses` counts correctly.

## Honnêteté G.9

- Le bug était **reproduit firsthand** avant le fix (`solve_with_timeout('NONEXISTENT', ...)` → error string → `if timed_out:` truthy → TIMEOUT), pas pattern-matché.
- `sat_comparison_demo.py` (autre script Tweety, inspecté) avait seulement des commentaires inversés (diagonale `/` vs `\` à L74/L84 — les deux familles de diagonales SONT couvertes par `i−j=const` et `i+j=const`, juste les labels sont swappés) → bug cosmétique, pas fonctionnel, pas patché (one-subject-per-PR, et non-fonctionnel).
- Les générateurs de problèmes (`generate_pigeonhole`, `generate_nqueens`, `generate_random_ksat`, `generate_graph_coloring`, `generate_latin_square`) sont **firsthand-verified corrects**.

## Conformité

- Atomique : 1 bug fix + 1 fichier de test, 1 domaine (SymbolicAI/Tweety quality), catalogue byte-identique à main.
- Anti-regression : le fix corrige un reporting erroné (pas de stub/sorry). 0 code métier supprimé.
- Pas de `Closes #N` (bug auto-découvert, pas d'issue dédiée) — contribution standalone à la qualité Tweety scripts.
- Pas de C.2 implication : 0 notebook consumer de `sat_calibration` / `benchmark_config` (grep Tight repo-wide : 0 match `.ipynb`).
- Rebase frais off `origin/main` `2faaee90a`, worktree isolé.
