### PR TITLE
fix(tweety): drain IOPub after cwd setup (cell 0 output no longer lost)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/scripts/test_verify_tweety_iopub.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/scripts/test_verify_tweety_iopub.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for verify_all_tweety.execute_cell_by_cell.
+
+Pins the IOPub-drain fix: after the cwd setup (`os.chdir`), the kernel emits
+status:busy then status:idle on the IOPub channel. get_shell_msg() only drains
+the SHELL reply, leaving those two messages queued. The first cell's collection
+loop then reads the stale status:idle and breaks immediately, silently dropping
+cell 0's real output (which lands in cell 1's loop).
+
+Before the fix this test FAILED firsthand:
+    cell0 preview=''            (its 'HELLO_FROM_CELL_0' was lost)
+    cell1 preview='HELLO_FROM_CELL_0\\n'   (cell 0's orphaned output)
+
+After the fix each cell captures its OWN output.
+
+These tests spin a real python3 kernel via jupyter_client (available on every
+worker per rule F). They are skipped, not failed, if jupyter_client is absent.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import sys
+import tempfile
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+try:
+    import jupyter_client  # noqa: F401
+    HAS_JUPYTER = True
+except Exception:
+    HAS_JUPYTER = False
+
+from verify_all_tweety import execute_cell_by_cell  # noqa: E402
+
+pytestmark = pytest.mark.skipif(not HAS_JUPYTER,
+                                reason="jupyter_client not installed")
+
+
+def _write_notebook(sources: list) -> pathlib.Path:
+    """Write a minimal notebook with the given code-cell sources, return path."""
+    nb = {
+        "cells": [
+            {
+                "cell_type": "code",
+                "source": [s] if isinstance(s, str) else s,
+                "outputs": [],
+                "execution_count": None,
+                "metadata": {},
+            }
+            for s in sources
+        ],
+        "metadata": {
+            "kernelspec": {
+                "name": "python3", "display_name": "Python 3", "language": "python",
+            }
+        },
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+    f = tempfile.NamedTemporaryFile(
+        mode="w", suffix=".ipynb", delete=False, encoding="utf-8"
+    )
+    json.dump(nb, f)
+    f.close()
+    return pathlib.Path(f.name)
+
+
+def test_first_cell_captures_own_output():
+    """cell 0's print output must be captured by cell 0, not shifted to cell 1.
+
+    Regression pin for the IOPub-drain bug: before the fix, cell 0's loop broke
+    on the cwd setup's stale status:idle, so cell 0 preview was empty and cell 1
+    inherited cell 0's output.
+    """
+    nbpath = _write_notebook([
+        'print("HELLO_FROM_CELL_0")',
+        'print("WORLD_FROM_CELL_1")',
+    ])
+    try:
+        results = execute_cell_by_cell(nbpath, timeout=30, verbose=False)
+    finally:
+        os.unlink(nbpath)
+
+    code_results = [r for r in results if r.cell_type == "code"]
+    assert len(code_results) >= 2, f"expected >=2 code results, got {results}"
+
+    cell0, cell1 = code_results[0], code_results[1]
+    # The bug: cell0 preview was '' and cell1 captured 'HELLO_FROM_CELL_0'.
+    assert cell0.output_preview is not None
+    assert "HELLO_FROM_CELL_0" in cell0.output_preview, (
+        f"cell 0 lost its output (bug): cell0={cell0.output_preview!r} "
+        f"cell1={cell1.output_preview!r}"
+    )
+    assert "WORLD_FROM_CELL_1" in cell1.output_preview, (
+        f"cell 1 lost its output: cell1={cell1.output_preview!r}"
+    )

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/scripts/verify_all_tweety.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/scripts/verify_all_tweety.py
@@ -684,6 +684,17 @@ def execute_cell_by_cell(notebook_path: Path, timeout: int = 120, verbose: bool 
         cwd_code = f"import os; os.chdir(r'{notebook_path.parent}')"
         kc.execute(cwd_code)
         kc.get_shell_msg(timeout=10)
+        # Drain the IOPub channel: the cwd setup emits status:busy then
+        # status:idle on IOPub, but get_shell_msg() only consumes the SHELL
+        # reply, leaving those two messages queued. Without draining them, the
+        # first cell's collection loop reads the stale status:idle and breaks
+        # immediately -- silently dropping cell 0's real output (which then
+        # lands in cell 1's loop, shifting every output by one cell).
+        while True:
+            msg = kc.get_iopub_msg(timeout=10)
+            if (msg.get('msg_type') == 'status'
+                    and msg.get('content', {}).get('execution_state') == 'idle'):
+                break
 
         # Execute each code cell
         for i, cell in enumerate(cells):
@@ -1074,6 +1085,17 @@ def execute_missing_cells(notebook_path: Path, timeout: int = 120, verbose: bool
         cwd_code = f"import os; os.chdir(r'{notebook_path.parent}')"
         kc.execute(cwd_code)
         kc.get_shell_msg(timeout=10)
+        # Drain the IOPub channel: the cwd setup emits status:busy then
+        # status:idle on IOPub, but get_shell_msg() only consumes the SHELL
+        # reply, leaving those two messages queued. Without draining them, the
+        # first cell's collection loop reads the stale status:idle and breaks
+        # immediately -- silently dropping cell 0's real output (which then
+        # lands in cell 1's loop, shifting every output by one cell).
+        while True:
+            msg = kc.get_iopub_msg(timeout=10)
+            if (msg.get('msg_type') == 'status'
+                    and msg.get('content', {}).get('execution_state') == 'idle'):
+                break
 
         # Execute ALL code cells in order (to build up state)
         # but only record new outputs for cells_to_execute


### PR DESCRIPTION
## Summary

`execute_cell_by_cell` and `execute_missing_cells` (in `scripts/verify_all_tweety.py`) prime the kernel with a cwd-setup call before running cells:

```python
kc.execute(cwd_code)          # import os; os.chdir(...)
kc.get_shell_msg(timeout=10)  # drains the SHELL reply ONLY
```

`get_shell_msg()` consumes the `execute_reply` on the **SHELL** socket but leaves the cwd setup's **IOPub** messages (`status:busy`, `status:idle`) queued — SHELL and IOPub are separate ZMQ sockets. The first cell's collection loop then reads that stale `status:idle` and breaks immediately, **silently dropping cell 0's real output**, which is subsequently picked up by cell 1's loop. Every output is shifted by one cell across the notebook.

## Reproduced firsthand (G.9)

2-cell notebook, `print("HELLO_FROM_CELL_0")` then `print("WORLD_FROM_CELL_1")`, on the buggy version:

| cell | expected preview | actual (buggy) |
|------|------------------|----------------|
| cell 0 | `HELLO_FROM_CELL_0` | `''` (output **lost**) |
| cell 1 | `WORLD_FROM_CELL_1` | `HELLO_FROM_CELL_0` (cell 0's orphaned output) |

For `execute_missing_cells` this is material beyond reporting: it writes the captured outputs back to the notebook on disk, so the off-by-one assigns each cell's outputs to the **previous** cell — corrupting committed notebooks.

## Fix

After `get_shell_msg()`, drain the IOPub channel until the kernel goes `idle`, consuming the cwd setup's status messages before the first cell's loop starts:

```python
while True:
    msg = kc.get_iopub_msg(timeout=10)
    if (msg.get('msg_type') == 'status'
            and msg.get('content', {}).get('execution_state') == 'idle'):
        break
```

Applied identically to both functions (they share the pattern).

After the fix each cell captures its own output: `cell0 -> 'HELLO_FROM_CELL_0'`, `cell1 -> 'WORLD_FROM_CELL_1'`.

## Test

New `test_verify_tweety_iopub.py` spins a **real python3 kernel** (available on every worker per rule F; `skipif not jupyter_client`) and asserts cell 0 captures its own print output. This regression test would have failed on the buggy version (cell 0 preview was empty).

```
$ cd scripts && python3 -m pytest test_verify_tweety_iopub.py -q
1 passed in 2.92s
```

## Notes

- **No C.2 implication** on committed notebooks: this is a maintenance tool, not a committed notebook, and no notebook consumes `verify_all_tweety.py`.
- **Catalogue byte-identical** to `main` (catalog-guard green).
- Scope: 1 module (+22 lines) + 1 new regression test (~101 lines). One subject, one family (Tweety scripts).

## Checklist
- [x] Real tool (real jupyter_client kernel exec, not a workaround)
- [x] Reproduced bug firsthand before fix (G.9)
- [x] Verified fix resolves it (before/after diff)
- [x] Regression test pins the bug
- [x] Catalogue untouched
- [x] Single subject, single family

Co-Authored-By: Claude-Code <noreply@anthropic.com>