### PR TITLE
fix(search): coerce non-numeric metrics in plot_benchmark (crash on timed-out runs)

### DIFF
--- a/MyIA.AI.Notebooks/Search/search_helpers.py
+++ b/MyIA.AI.Notebooks/Search/search_helpers.py
@@ -253,12 +253,28 @@ def benchmark_table(results: list[dict], title: str = "Comparaison des algorithm
     print(f"{'=' * 70}\n")
 
 
+def _as_metric_value(v):
+    """Coerce a metric value for plotting into a float.
+
+    Numeric values are returned as float. Non-numeric values (None for a
+    timed-out run that never measured the metric, '?' or 'N/A' for an
+    unknown) cannot be a bar height and are returned as NaN: matplotlib
+    renders a gap and the annotation reads 'nan'. This mirrors the
+    defensiveness of ``benchmark_table``, which renders the same values as
+    text -- without it, ``plot_benchmark`` crashes (TypeError on the
+    matplotlib bar / ValueError on the f-string annotation).
+    """
+    if isinstance(v, bool):
+        return float('nan')
+    return float(v) if isinstance(v, (int, float)) else float('nan')
+
+
 def plot_benchmark(results: list[dict], metric: str = 'time_ms',
                    title: str = "Comparaison des performances",
                    figsize: tuple = (10, 6)):
     """Graphique en barres pour comparer les performances."""
     algos = [r.get('algorithm', '?') for r in results]
-    values = [r.get(metric, 0) for r in results]
+    values = [_as_metric_value(r.get(metric, 0)) for r in results]
 
     fig, ax = plt.subplots(1, 1, figsize=figsize)
     bars = ax.bar(range(len(algos)), values, color='steelblue', edgecolor='black')

--- a/MyIA.AI.Notebooks/Search/tests/test_search_helpers.py
+++ b/MyIA.AI.Notebooks/Search/tests/test_search_helpers.py
@@ -1,0 +1,156 @@
+"""Tests pour le module ``search_helpers`` (visualisation + benchmarking).
+
+Run with: pytest Search/tests/test_search_helpers.py -v
+
+Pinned bug: ``plot_benchmark`` crashed (TypeError on the matplotlib bar,
+ValueError on the ``f'{val:.1f}'`` annotation) when a result dict carried a
+non-numeric metric value -- e.g. ``{'algorithm': 'CMA-ES', 'time_ms': None}``
+for a timed-out run, or ``'?'`` / ``'N/A'`` for an unknown. The sibling
+``benchmark_table`` renders the same values as text without crashing, so the
+inconsistency was a real defect on realistic benchmark data. ``plot_benchmark``
+now coerces non-numeric values to NaN (matplotlib renders a gap, annotation
+reads 'nan') via ``_as_metric_value``.
+"""
+
+import io
+import math
+import sys
+import contextlib
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")  # headless before pyplot import
+
+import pytest  # noqa: E402
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import search_helpers as sh  # noqa: E402
+
+
+# --- _as_metric_value (the coercion helper) ---------------------------------
+
+def test_as_metric_value_numeric():
+    assert sh._as_metric_value(10.0) == 10.0
+    assert sh._as_metric_value(5) == 5.0
+    assert sh._as_metric_value(0) == 0.0
+
+
+@pytest.mark.parametrize("v", [None, "N/A", "?", "missing", True, False, []])
+def test_as_metric_value_non_numeric_is_nan(v):
+    out = sh._as_metric_value(v)
+    assert math.isnan(out), f"expected NaN for {v!r}, got {out!r}"
+
+
+# --- Regression pin: the bug this file exists for ---------------------------
+
+def test_plot_benchmark_none_metric_does_not_crash():
+    """A timed-out run (time_ms=None) must not crash plot_benchmark.
+
+    Before the fix this raised TypeError (matplotlib bar with None) then
+    ValueError (f-string annotation).
+    """
+    results = [
+        {"algorithm": "A", "time_ms": 10.0},
+        {"algorithm": "B (timeout)", "time_ms": None},
+        {"algorithm": "C", "time_ms": 5.0},
+    ]
+    fig = sh.plot_benchmark(results, metric="time_ms")
+    assert fig is not None
+
+
+def test_plot_benchmark_string_metric_does_not_crash():
+    """A '?' / 'N/A' metric value must not crash the annotation."""
+    results = [
+        {"algorithm": "A", "time_ms": 10.0},
+        {"algorithm": "B", "time_ms": "N/A"},
+    ]
+    fig = sh.plot_benchmark(results, metric="time_ms")
+    assert fig is not None
+
+
+def test_plot_benchmark_non_numeric_coerced_to_nan_not_zero():
+    """Non-numeric metrics must be NaN (gap), not a misleading 0.0 bar."""
+    results = [{"algorithm": "A", "time_ms": 10.0}, {"algorithm": "B", "time_ms": None}]
+    # Re-derive values the same way plot_benchmark does, to assert the contract.
+    values = [sh._as_metric_value(r.get("time_ms", 0)) for r in results]
+    assert values[0] == 10.0
+    assert math.isnan(values[1])
+
+
+# --- Normal-path preservation -----------------------------------------------
+
+def test_plot_benchmark_all_numeric_path_preserved():
+    results = [
+        {"algorithm": "DFS", "time_ms": 12.3},
+        {"algorithm": "BFS", "time_ms": 8.1},
+        {"algorithm": "A*", "time_ms": 5.5},
+    ]
+    fig = sh.plot_benchmark(results, metric="time_ms")
+    assert fig is not None
+
+
+def test_plot_benchmark_missing_key_defaults_to_zero():
+    """Missing metric key keeps the pre-fix default-0 behavior (not changed)."""
+    results = [{"algorithm": "A"}, {"algorithm": "B", "time_ms": 5}]
+    values = [sh._as_metric_value(r.get("time_ms", 0)) for r in results]
+    assert values == [0.0, 5.0]
+    fig = sh.plot_benchmark(results, metric="time_ms")
+    assert fig is not None
+
+
+def test_plot_benchmark_alternate_metric_nodes_expanded():
+    results = [
+        {"algorithm": "A", "time_ms": 10.0, "nodes_expanded": 42},
+        {"algorithm": "B", "time_ms": 5.0, "nodes_expanded": 100},
+    ]
+    fig = sh.plot_benchmark(results, metric="nodes_expanded")
+    assert fig is not None
+
+
+# --- benchmark_table (sibling, defensive) ------------------------------------
+
+def test_benchmark_table_handles_none_and_missing_fields():
+    """benchmark_table must render None/missing fields without crashing."""
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        sh.benchmark_table([
+            {"algorithm": "A", "time_ms": None},
+            {"algorithm": "B"},  # missing time_ms / nodes / etc.
+        ])
+    out = buf.getvalue()
+    assert "A" in out and "B" in out
+    assert "Comparaison" in out
+
+
+# --- SearchTreeNode + _find_solution_path -----------------------------------
+
+def test_search_tree_node_add_child_accumulates_cost():
+    root = sh.SearchTreeNode("root", cost=0)
+    child = root.add_child("c1", cost=5)
+    grandchild = child.add_child("c2", cost=3)
+    assert child.cost == 5
+    assert grandchild.cost == 8
+    assert child.depth == 1
+    assert grandchild.depth == 2
+
+
+def test_find_solution_path_returns_none_when_no_solution():
+    root = sh.SearchTreeNode("r")
+    root.add_child("c1")
+    assert sh._find_solution_path(root) is None
+
+
+def test_find_solution_path_returns_chain_to_solution():
+    root = sh.SearchTreeNode("r")
+    child = root.add_child("c1")
+    grand = child.add_child("c2")
+    grand.is_solution = True
+    path = sh._find_solution_path(root)
+    assert path == [root, child, grand]
+
+
+def test_draw_search_tree_single_node():
+    fig = sh.draw_search_tree(sh.SearchTreeNode("only"))
+    assert fig is not None


### PR DESCRIPTION
## Summary

`Search/search_helpers.py` `plot_benchmark` **crashed** when a benchmark result carried a non-numeric metric value (TypeError on the matplotlib bar with None, ValueError on the `f'{val:.1f}'` annotation with a string). Reachable with realistic benchmark data (a timed-out run → `{'algorithm': 'CMA-ES', 'time_ms': None}`), and the sibling `benchmark_table` — consuming the exact same results list — renders those values as text without crashing. **Defensiveness inconsistency between two sibling helpers on valid input.**

## Le bug (firsthand, reproduit avant fix)

`plot_benchmark` L260-261 + L272-274:
```python
values = [r.get(metric, 0) for r in results]          # None / 'N/A' passes through
bars = ax.bar(range(len(algos)), values, ...)         # TypeError if None in values
for bar, val in zip(bars, values):
    ax.text(..., f'{val:.1f}', ...)                    # ValueError if val is a string
```
Sibling `benchmark_table` L248-249: `r.get('time_ms', '?')` then `str(...)` — renders None→'None', '?'→'?' (no crash). **One helper defensive, the other crashes on the same input.**

**Reproduced firsthand** (mcp-jupyter-py310, règle H.1):
```
$ # timed-out run = None metric
plot_benchmark([{'algorithm':'A','time_ms':10.0},{'algorithm':'B','time_ms':None}])
-> TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'
$ # unknown = string metric
plot_benchmark([{'algorithm':'A','time_ms':'N/A'}])
-> ValueError: Unknown format code 'f' for object of type 'str'
```

## Le fix (+17/−1 borné)

New helper `_as_metric_value(v)`: returns `float(v)` for numeric, `NaN` otherwise (bool excluded — `isinstance(True, int)` is True in Python). Coerce the metric column through it:

```python
values = [_as_metric_value(r.get(metric, 0)) for r in results]
```

**NaN renders as a visual gap** in the bar chart (honest "no data") rather than a misleading `0.0` bar that would imply a timed-out algorithm was the fastest. Missing-key behavior (default 0) **unchanged** — fix targets only present-but-non-numeric values.

**Sortie APRÈS** : both calls return a `Figure`, None/'N/A' rendered as a gap, annotation 'nan'.

## Validation RÉELLE (firsthand, règle H.1)

Env `mcp-jupyter-py310`. Repro AVANT confirmé (TypeError + ValueError). APRÈS fix (module chargé depuis worktree `C:\dev\CoursIA-search-helpers`) : 4 scénarios reviewés (None, string, all-numeric preserved, missing-key preserved) + `_as_metric_value` unit (10.0→10.0, None→nan, 'N/A'→nan, True→nan, 0→0.0).

**Tests** : nouveau `Search/tests/test_search_helpers.py` (**19 tests, 0.56s**). Pins de régression :
- `test_plot_benchmark_none_metric_does_not_crash` + `..._string_metric_...` (les crashes pinned)
- `test_plot_benchmark_non_numeric_coerced_to_nan_not_zero` (garde contre un fix plus faible qui coercerait à 0)
- Normal paths préservés (all-numeric, missing-key default 0, alternate metric nodes_expanded)
- `benchmark_table` sibling défensif pinned
- `SearchTreeNode` cost-accumulation + `_find_solution_path` units

## Hygiène

- Three-dot diff vs `origin/main` = **2 fichiers, +173/−1** (numstat `17 1` / `156 0` = **1 seule deletion, pas de churn**).
- **0 CRLF** (LF, byte-aligned avec origin/main qui stocke ces .py en LF, `core.autocrlf=false`).
- **Catalogue byte-identique** (HARD 1).
- Worktree frais `CoursIA-search-helpers` off `origin/main` `9f5abb7da`.

## Scope

1 fichier logique modifié (`search_helpers.py`) + 1 fichier test. **Search/search_helpers** (helpers partagés visualization/benchmarking pour la série Search). Utilisé par `Search-4-LocalSearch.ipynb` (`bench_results` avec `avg_time_ms`, toujours numérique aujourd'hui) + 5 autres notebooks important les helpers. Aucune PR ouverte ne touche `search_helpers.py`. `See` aucune issue (bug découvert via exercise firsthand edge-cases — **application de la leçon marco.py** : les verdicts read-only « semble correct » manquent les bugs que l'exercice révèle).

## R6 transparence

1ère PR sur `Search/search_helpers` pour cette lane ce cycle-day (c.531 a vérifié `wfc_cpsat` correct dans un autre sous-module Search). Genre **robustness/bug-fix** (rotate de c.533 maxsat). Même pattern sibling-bug que #7375/#7379/#7380 (po-2025/po-2025/moi : un sibling défensif, l'autre non) mais **fichier distinct** (`search_helpers.py`).

## G.9 note (honnêteté)

Bug initialement dismissé comme « invalid input (present-None = programmer error) ». Re-considération : un run timed-out produisant `time_ms=None` est une **donnée de benchmark réaliste et valide**, et le sibling `benchmark_table` le gère — donc le crash de `plot_benchmark` est un vrai defect sur entrée valide, pas une erreur programmeur. Leçon appliquée : ne pas dismiss un crash sans vérifier si l'input est réaliste (cf marco.py c.533 où j'avais à tort déclaré « textbook-correct » en lisant sans exercer).

Co-Authored-By: Claude <noreply@anthropic.com>
