### PR TITLE
fix(gametheory): Stackelberg follower quantity for asymmetric costs

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/examples/stackelberg_leader_follower.py
+++ b/MyIA.AI.Notebooks/GameTheory/examples/stackelberg_leader_follower.py
@@ -60,13 +60,24 @@ def stackelberg_equilibrium(demand_intercept: float = 100,
 
     Solution:
     q_L = (a - 2*c_L + c_F) / 2
-    q_F = (a - 2*c_F + c_L) / 4
+    q_F = (a - 3*c_F + 2*c_L) / 4   [= (a - c_F - q_L) / 2, the follower reaction]
+
+    The follower closed form is the reaction curve q_F = (a - c_F - q_L)/2 evaluated
+    at the leader quantity q_L = (a - 2*c_L + c_F)/2. Expanding:
+        q_F = (a - c_F)/2 - q_L/2 = (a + 2*c_L - 3*c_F) / 4.
+    Note the coefficients 2*c_L and -3*c_F (NOT c_L and -2*c_F): the previous
+    formula (a + c_L - 2*c_F)/4 was correct only in the symmetric case c_L == c_F
+    (where it collapses to (a - c)/4) and diverged from the reaction curve for
+    any cost asymmetry -- verified against the follower best response directly.
     """
     a = demand_intercept
     c_L, c_F = cost_leader, cost_follower
 
     q_leader = (a - 2 * c_L + c_F) / 2
-    q_follower = (a + c_L - 2 * c_F) / 4
+    # Follower = reaction curve at the leader's equilibrium quantity. Kept in this
+    # (a - c_F - q_L)/2 form rather than the expanded closed form so the link to
+    # the follower's best response stays explicit and self-checking.
+    q_follower = (a - c_F - q_leader) / 2
 
     return max(0, q_leader), max(0, q_follower)
 

--- a/MyIA.AI.Notebooks/GameTheory/tests/test_stackelberg_asymmetric.py
+++ b/MyIA.AI.Notebooks/GameTheory/tests/test_stackelberg_asymmetric.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for examples/stackelberg_leader_follower.py.
+
+Pins the asymmetric-cost follower-quantity fix. The follower's Stackelberg
+quantity is its Cournot reaction curve evaluated at the leader's equilibrium
+quantity: q_F = (a - c_F - q_L) / 2, with q_L = (a - 2*c_L + c_F) / 2.
+
+The previous closed form ``(a + c_L - 2*c_F) / 4`` was correct ONLY in the
+symmetric case c_L == c_F (where it collapses to (a - c)/4) and diverged from
+the reaction curve for any cost asymmetry. For example with (a, c_L, c_F) =
+(100, 10, 20): q_L = 50, the follower's true best response is 15, but the old
+formula returned 17.5.
+
+These tests assert the INVARIANT (follower best-responds to the leader
+quantity) for several asymmetric cost pairs, so they would have failed on the
+buggy version and are robust to the exact closed-form expression chosen.
+
+Run with: pytest tests/test_stackelberg_asymmetric.py -v
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from examples.stackelberg_leader_follower import (  # noqa: E402
+    stackelberg_equilibrium,
+    cournot_reaction_curve,
+)
+
+
+# ----------------------------------------------------------------------------
+# Symmetric costs (textbook Stackelberg): q_L = (a-c)/2, q_F = (a-c)/4.
+# ----------------------------------------------------------------------------
+
+class TestSymmetricStackelberg:
+    """Symmetric-cost Stackelberg matches the textbook closed forms."""
+
+    def test_symmetric_leader_is_half(self):
+        qL, qF = stackelberg_equilibrium(100, 10, 10)
+        assert qL == pytest.approx((100 - 10) / 2)  # 45.0
+
+    def test_symmetric_follower_is_quarter(self):
+        qL, qF = stackelberg_equilibrium(100, 10, 10)
+        assert qF == pytest.approx((100 - 10) / 4)  # 22.5
+
+    def test_leader_produces_more_than_follower(self):
+        """First-mover advantage: the leader sells more than the follower."""
+        qL, qF = stackelberg_equilibrium(100, 10, 10)
+        assert qL > qF
+
+
+# ----------------------------------------------------------------------------
+# Asymmetric costs: the follower MUST best-respond to the leader quantity.
+# This is the regression pin -- the buggy closed form failed here.
+# ----------------------------------------------------------------------------
+
+class TestAsymmetricFollowerBestResponds:
+    """q_F must equal the Cournot reaction curve at the leader quantity."""
+
+    @pytest.mark.parametrize("a,cL,cF", [
+        (100, 10, 20),   # follower costlier -> smaller q_F (bug gave 17.5, true 15)
+        (100, 20, 10),   # leader costlier -> larger q_F (bug gave 25.0, true 27.5)
+        (100, 5, 30),    # strong asymmetry (bug gave 11.25, true 5.0)
+        (100, 30, 5),    # reversed asymmetry (bug gave 30.0, true 36.25)
+        (120, 8, 16),
+    ])
+    def test_follower_equals_reaction_curve(self, a, cL, cF):
+        qL, qF = stackelberg_equilibrium(a, cL, cF)
+        # Ground truth: the follower's best response to the leader quantity.
+        reaction = cournot_reaction_curve(qL, demand_intercept=a, marginal_cost=cF)
+        assert qF == pytest.approx(reaction), (
+            f"asymmetric a={a},cL={cL},cF={cF}: follower qF={qF} != reaction {reaction} "
+            f"at leader qL={qL}"
+        )
+
+    def test_asymmetric_diverges_from_buggy_formula(self):
+        """Explicit pin: the old (a + cL - 2cF)/4 is NOT what we return."""
+        a, cL, cF = 100, 10, 20
+        qL, qF = stackelberg_equilibrium(a, cL, cF)
+        buggy = (a + cL - 2 * cF) / 4  # 17.5 -- the previous (wrong) closed form
+        assert qF != pytest.approx(buggy)
+        assert qF == pytest.approx(15.0)  # true reaction-curve value
+
+
+# ----------------------------------------------------------------------------
+# Leader quantity closed form (was already correct; pinned for completeness).
+# ----------------------------------------------------------------------------
+
+class TestLeaderClosedForm:
+    """q_L = (a - 2*c_L + c_F) / 2 for the general asymmetric case."""
+
+    @pytest.mark.parametrize("a,cL,cF,expected", [
+        (100, 10, 10, 45.0),
+        (100, 10, 20, 50.0),
+        (100, 20, 10, 35.0),
+    ])
+    def test_leader_closed_form(self, a, cL, cF, expected):
+        qL, _ = stackelberg_equilibrium(a, cL, cF)
+        assert qL == pytest.approx(expected)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

`stackelberg_equilibrium()` in `examples/stackelberg_leader_follower.py` computed the follower quantity with a closed form that was **only correct for symmetric costs** and diverged from the follower's actual Cournot reaction curve for any cost asymmetry.

```python
# OLD (buggy for c_L != c_F):
q_follower = (a + c_L - 2 * c_F) / 4
```

For `c_L == c_F == c` this collapses to the textbook `(a-c)/4`, so the default pedagogical paths (`compare_equilibria`, `plot_equilibria`, both calling `stackelberg_equilibrium(a, c, c)`) were unaffected — which is why the latent bug survived. But the function is a public API accepting asymmetric costs, and its docstring documented the wrong formula.

## Reproduced firsthand (G.9) against the reaction curve — ground truth

The follower's true quantity is its Cournot reaction evaluated at the leader quantity: `q_F = (a - c_F - q_L) / 2`.

| (a, c_L, c_F) | q_L | **reaction (true)** | OLD code | gap |
|---------------|-----|---------------------|----------|-----|
| (100, 10, 20) | 50  | **15.0**  | 17.5  | +2.5 |
| (100, 20, 10) | 35  | **27.5**  | 25.0  | −2.5 |
| (100, 5, 30)  | 60  | **5.0**   | 11.25 | +6.25 |
| (100, 30, 5)  | 22.5| **36.25** | 30.0  | −6.25 |

## Fix

Express the follower directly as its reaction curve at the leader quantity — self-checking and obviously correct:

```python
q_leader   = (a - 2 * c_L + c_F) / 2          # unchanged (was already correct)
q_follower = (a - c_F - q_leader) / 2         # reaction curve at q_L
```

The expanded closed form `(a + 2*c_L - 3*c_F)/4` and its derivation are recorded in the docstring so the coefficients cannot silently revert.

## Test

New `tests/test_stackelberg_asymmetric.py` (12 cases, all pass):
- `TestAsymmetricFollowerBestResponds` — asserts `q_F == cournot_reaction_curve(q_L, ...)` for **5 asymmetric cost pairs**. Would have failed on the buggy version.
- `test_asymmetric_diverges_from_buggy_formula` — explicit pin that the old `(a + c_L - 2c_F)/4` is NOT what we return.
- `TestSymmetricStackelberg` — pins the textbook `q_L=(a-c)/2`, `q_F=(a-c)/4`.
- `TestLeaderClosedForm` — pins the (already-correct) leader formula.

```
$ python3 -m pytest tests/test_stackelberg_asymmetric.py -q
12 passed in 1.90s
```

## Notes
- **Default path unchanged**: symmetric defaults still give `qL=45, qF=22.5, πL=1012.5, πF=506.25` (textbook Stackelberg, first-mover advantage intact).
- **Catalogue byte-identical** to `main`.
- **No notebook consumes this example directly** (no C.2 implication).
- Scope: 1 module (+13/−2) + 1 new regression test (~106 lines). One subject, one family.

## Checklist
- [x] Bug reproduced firsthand before fix (G.9 — reaction-curve ground truth)
- [x] Fix verified resolves it (12/12 tests pass)
- [x] Regression test pins the invariant (not the literal buggy value)
- [x] Default/symmetric paths confirmed unaffected
- [x] Catalogue untouched
- [x] Single subject, single family

Co-Authored-By: Claude-Code <noreply@anthropic.com>