### PR TITLE
test(tweety): cover validate_syntax.py notebook syntax validator (0->19)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/scripts/test_validate_syntax.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/scripts/test_validate_syntax.py
@@ -1,0 +1,184 @@
+"""Tests pour le module ``validate_syntax`` (syntax-validation des notebooks Tweety).
+
+Run with: pytest Tweety/scripts/test_validate_syntax.py -v
+
+Module couvert : ``Tweety/scripts/validate_syntax.py`` — validateur de syntaxe
+Python (ast.parse) des cellules code des notebooks Tweety. 0 test Python avant
+cette PR → garde-fou anti-régression. Le script distingue les cellules code des
+markdown, gère la source en liste OU string, skip les cellules vides, truncate
+la first-line à 60 chars, et fallback cell_id si absent.
+
+Bug-hunt firsthand (po-2023 marco.py lesson : exercer, pas juste lire) :
+0 bug fonctionnel forçable. La précédence de l'opérateur ternaire L87
+(``a + b if cond else c``) est correcte ``(a+b) if cond else c``.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import validate_syntax as vs  # noqa: E402
+
+
+# --- validate_python_syntax -------------------------------------------------
+
+def test_validate_python_syntax_valid():
+    assert vs.validate_python_syntax("x = 1\nprint(x)") == (True, "")
+
+
+def test_validate_python_syntax_empty_string_is_valid():
+    """ast.parse('') succeeds — empty cells are valid syntax."""
+    assert vs.validate_python_syntax("") == (True, "")
+
+
+def test_validate_python_syntax_whitespace_only_is_valid():
+    assert vs.validate_python_syntax("   \n\t\n") == (True, "")
+
+
+def test_validate_python_syntax_invalid_returns_line_and_msg():
+    ok, msg = vs.validate_python_syntax("def f(:\n  pass")
+    assert ok is False
+    assert "Line 1" in msg
+
+
+def test_validate_python_syntax_reports_correct_line_number():
+    ok, msg = vs.validate_python_syntax("x = 1\ny = 2\nz = (")  # error on line 3
+    assert ok is False
+    assert "Line 3" in msg
+
+
+def test_validate_python_syntax_complex_valid_program():
+    code = (
+        "import json\n"
+        "def f(x):\n"
+        "    return x * 2\n"
+        "print(f(21))\n"
+    )
+    assert vs.validate_python_syntax(code) == (True, "")
+
+
+# --- validate_notebook ------------------------------------------------------
+
+def _write_nb(tmp_path: Path, name: str, cells: list) -> Path:
+    p = tmp_path / name
+    p.write_text(json.dumps({"cells": cells}), encoding="utf-8")
+    return p
+
+
+def test_validate_notebook_clean_returns_no_errors(tmp_path):
+    p = _write_nb(tmp_path, "ok.ipynb", [
+        {"cell_type": "code", "source": ["x = 1"]},
+        {"cell_type": "markdown", "source": ["# title"]},
+    ])
+    assert vs.validate_notebook(p) == []
+
+
+def test_validate_notebook_detects_syntax_error_in_code_cell(tmp_path):
+    p = _write_nb(tmp_path, "bad.ipynb", [
+        {"cell_type": "code", "source": ["def bad(:"], "id": "c0"},
+    ])
+    errs = vs.validate_notebook(p)
+    assert len(errs) == 1
+    assert errs[0]["cell_index"] == 0
+    assert errs[0]["cell_id"] == "c0"
+    assert "Line" in errs[0]["error"]
+
+
+def test_validate_notebook_skips_markdown_cells(tmp_path):
+    """Markdown cells must never be parsed as Python."""
+    p = _write_nb(tmp_path, "md.ipynb", [
+        {"cell_type": "markdown", "source": ["def f(:  # this is prose, not code"]},
+    ])
+    assert vs.validate_notebook(p) == []
+
+
+def test_validate_notebook_skips_empty_code_cells(tmp_path):
+    p = _write_nb(tmp_path, "empty.ipynb", [
+        {"cell_type": "code", "source": ["   \n\t"]},
+        {"cell_type": "code", "source": []},
+    ])
+    assert vs.validate_notebook(p) == []
+
+
+def test_validate_notebook_accepts_source_as_string(tmp_path):
+    """nbformat source may be a single string, not a list."""
+    p = _write_nb(tmp_path, "str.ipynb", [
+        {"cell_type": "code", "source": "def bad(:\n  pass"},
+    ])
+    errs = vs.validate_notebook(p)
+    assert len(errs) == 1
+
+
+def test_validate_notebook_cell_id_fallback_to_cell_index(tmp_path):
+    """A code cell without an explicit id falls back to f'cell_{i}'."""
+    p = _write_nb(tmp_path, "noid.ipynb", [
+        {"cell_type": "code", "source": ["z = ("]},
+    ])
+    errs = vs.validate_notebook(p)
+    assert errs[0]["cell_id"] == "cell_0"
+
+
+def test_validate_notebook_first_line_truncation(tmp_path):
+    """first_line is truncated to 60 chars + '...' when longer."""
+    long_line = "x = " + "a" * 70  # 74 chars
+    p = _write_nb(tmp_path, "long.ipynb", [
+        {"cell_type": "code", "source": [long_line + "\nbad_syntax ("]},
+    ])
+    errs = vs.validate_notebook(p)
+    fl = errs[0]["first_line"]
+    assert fl.endswith("...")
+    assert len(fl) == 63  # 60 + len("...")
+
+
+def test_validate_notebook_first_line_not_truncated_under_60(tmp_path):
+    short = "short bad syntax ("
+    p = _write_nb(tmp_path, "short.ipynb", [
+        {"cell_type": "code", "source": [short]},
+    ])
+    errs = vs.validate_notebook(p)
+    assert errs[0]["first_line"] == short
+    assert "..." not in errs[0]["first_line"]
+
+
+def test_validate_notebook_missing_file_returns_error_dict(tmp_path):
+    errs = vs.validate_notebook(tmp_path / "does_not_exist.ipynb")
+    assert len(errs) == 1
+    assert errs[0]["error"] == "File not found"
+    assert errs[0]["notebook"] == "does_not_exist.ipynb"
+
+
+def test_validate_notebook_invalid_json_returns_error(tmp_path):
+    p = tmp_path / "broken.ipynb"
+    p.write_text("{not valid json", encoding="utf-8")
+    errs = vs.validate_notebook(p)
+    assert len(errs) == 1
+    assert "Invalid JSON" in errs[0]["error"]
+
+
+def test_validate_notebook_multiple_errors_all_collected(tmp_path):
+    p = _write_nb(tmp_path, "multi.ipynb", [
+        {"cell_type": "code", "source": ["bad1 ("], "id": "a"},
+        {"cell_type": "code", "source": ["x = 1"]},          # valid, skipped
+        {"cell_type": "code", "source": ["bad2 ("], "id": "c"},
+    ])
+    errs = vs.validate_notebook(p)
+    assert len(errs) == 2
+    assert {e["cell_id"] for e in errs} == {"a", "c"}
+
+
+def test_validate_notebook_no_cells_key_returns_empty(tmp_path):
+    """A notebook dict without 'cells' is handled (empty iteration)."""
+    p = tmp_path / "nocells.ipynb"
+    p.write_text(json.dumps({"metadata": {}}), encoding="utf-8")
+    assert vs.validate_notebook(p) == []
+
+
+# --- TWEETY_NOTEBOOKS list sanity -------------------------------------------
+
+def test_tweety_notebooks_list_nonempty_and_ipynb():
+    assert len(vs.TWEETY_NOTEBOOKS) >= 1
+    assert all(name.endswith(".ipynb") for name in vs.TWEETY_NOTEBOOKS)


### PR DESCRIPTION
## Summary

`Tweety/scripts/validate_syntax.py` (135L) valide la syntaxe Python (`ast.parse`) de toutes les cellules code des 9 notebooks Tweety, rapportant les erreurs avec cell index, cell id, et first-line tronquée. **C'est un garde-fou anti-régression réel** (détecte les cellules cassées avant exécution notebook) mais avait **0 test dédié**. Cette PR ajoute **19 tests** (CPU-only, stdlib only).

## Module couvert

`validate_syntax.py` :
- `validate_python_syntax(code)` → `(is_valid, error_msg)` via `ast.parse`.
- `validate_notebook(path)` → liste d'erreurs (cell_type==code seulement, source list OU string, skip vide, cell_id fallback `cell_{i}`, first-line truncation 60 chars, missing-file/invalid-JSON gérés).
- `TWEETY_NOTEBOOKS` = liste des 9 notebooks à valider.

## 19 tests (0.6s, stdlib only)

| Bloc | Tests | Couverture |
|------|-------|------------|
| `validate_python_syntax` | 6 | valid/empty/whitespace → `(True,"")` ; invalid → `"Line N: msg"` ; **correct line number reported** ; complex valid program |
| `validate_notebook` | 12 | clean → `[]` ; détecte erreur code cell ; **SKIP markdown** (jamais parsé) ; skip empty/whitespace ; **source list OU string** (nbformat both) ; **cell_id fallback** `cell_{i}` ; **first-line truncation** 60+"..." / intact sous 60 ; missing-file → `{"error":"File not found"}` ; invalid JSON → `"Invalid JSON"` ; **multiple errors all collected** ; no `cells` key → `[]` |
| `TWEETY_NOTEBOOKS` | 1 | non-empty, tous `.ipynb` |

## Bug-hunt firsthand avant tests (G.9 — leçon marco.py)

Application de la leçon po-2023 marco.py (**exercer les edge-cases, pas juste lire**) : 7 edge-cases exercés firsthand AVANT d'écrire les tests. **0 bug fonctionnel forçable**. En particulier, la précédence de l'opérateur ternaire L87 :
```python
code.split('\n')[0][:60] + "..." if len(...) > 60 else code.split('\n')[0]
```
se parse correctement comme `(prefix + "...") if cond else raw` (le ternaire a précédence inférieure à `+`) — **pinné par `test_validate_notebook_first_line_truncation`** (assert `len(fl) == 63` = 60+3, et `endswith("...")`). Pas de bug fabriqué.

## Validation H.1

```
$ python -m pytest Tweety/scripts/test_validate_syntax.py -q
19 passed in 0.6s
```

## Hygiène

- **Test-only PR** : 0 fichier `.py` source modifié, 0 notebook touché (**pas d'implication C.2**).
- Three-dot diff vs `origin/main` = **1 fichier, +184/−0** (nouveau test).
- **0 CRLF** (LF, byte-aligned avec origin/main, `core.autocrlf=false`).
- **Catalogue byte-identique** (HARD 1).
- Worktree frais `CoursIA-tweety-validate` off `origin/main` `9f5abb7da`.

## Scope

1 nouveau fichier test. **SymbolicAI/Tweety scripts**. Module consommé par la série notebooks Tweety (sanity-check syntaxique invoqué depuis Tweety-1-Setup maintenance / CI). Aucune PR ouverte ne touche `validate_syntax.py`. `See` aucune issue (module non-testé ; couverture fermée comme garde-fou anti-régression).

## R6 transparence

1ère PR sur `Tweety/scripts` pour cette lane ce cycle-day. Genre **test-coverage** (rotate de c.533/c.534 bug-fix). Famille **SymbolicAI/Tweety** (distinct de ext_tools c.533 et Search c.534). R6 doc/cleanup caps non-touchés (test-coverage = substance, pas cleanup/doc).

Co-Authored-By: Claude <noreply@anthropic.com>
