### PR TITLE
test(llm_client): cover LLMClient + fix max_tokens=0 swallowed by truthy check

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/conftest.py
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/conftest.py
@@ -1,0 +1,57 @@
+"""pytest bootstrap for AgenticDataScience test modules.
+
+Two problems this conftest solves, both at collection time (BEFORE any test
+module under this tree is imported):
+
+1. ``utils/__init__.py`` eagerly does ``from .llm_client import ...``, and
+   ``llm_client.py`` does an ABSOLUTE ``from config.providers import ...``.
+   With ``--import-mode importlib`` (pytest.ini), the ``AgenticDataScience``
+   directory is not on ``sys.path`` by default, so the absolute ``config``
+   import would raise ``ModuleNotFoundError``. We insert this directory on
+   ``sys.path`` so ``config`` and ``utils`` resolve exactly as the notebook
+   runtime expects (AgenticDataScience is the package root).
+
+2. ``llm_client.py`` imports ``litellm`` at top level, and litellm is not
+   installed on every worker machine. We install a minimal fake ``litellm``
+   module in ``sys.modules``. Individual tests that need to inspect the
+   ``completion`` call kwargs re-monkeypatch ``llm_client.completion``
+   (and ``litellm.completion``) per-test.
+
+This file lives at the ``AgenticDataScience/`` level (NOT inside ``utils/``)
+because pytest loads a conftest here as a standalone plugin BEFORE importing
+the ``utils`` package — a conftest inside ``utils/`` would itself trigger
+``utils/__init__.py`` first and arrive too late.
+"""
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+_AGDS_DIR = Path(__file__).resolve().parent
+
+# (1) Make `config` / `utils` importable as top-level packages.
+if str(_AGDS_DIR) not in sys.path:
+    sys.path.insert(0, str(_AGDS_DIR))
+
+# (2) Fake litellm so llm_client.py imports cleanly without the real dep.
+if "litellm" not in sys.modules:
+    _fake = types.ModuleType("litellm")
+
+    class _Msg:
+        def __init__(self, content):
+            self.content = content
+
+    class _Choice:
+        def __init__(self, content):
+            self.message = _Msg(content)
+
+    class _Resp:
+        def __init__(self, content):
+            self.choices = [_Choice(content)]
+
+    def _completion(**kwargs):  # pragma: no cover - replaced per-test
+        return _Resp("mocked-litellm")
+
+    _fake.completion = _completion
+    sys.modules["litellm"] = _fake

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/utils/llm_client.py
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/utils/llm_client.py
@@ -78,7 +78,7 @@ class LLMClient:
         if self.config.api_key:
             call_kwargs["api_key"] = self.config.api_key
 
-        if max_tokens:
+        if max_tokens is not None:
             call_kwargs["max_tokens"] = max_tokens
 
         call_kwargs.update(kwargs)

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/utils/test_llm_client.py
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/utils/test_llm_client.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Pytest suite for `AgenticDataScience/utils/llm_client.py` (LLMClient + litellm wrapper).
+
+Co-located with the module under `utils/`. CPU-only, no network, no real LLM
+call. The module imports `litellm` at top level (not installed on every worker
+machine) and `config.providers` via a relative package import, so this suite:
+
+  1. Installs a fake `litellm` module in `sys.modules` BEFORE importing
+     `utils.llm_client` (same mocking pattern as `Argument_Analysis/tests/
+     test_runner.py` uses for `semantic_kernel`).
+  2. Puts the `AgenticDataScience/` dir on `sys.path` so both `config` and
+     `utils` packages resolve the way the notebook runtime expects.
+
+The module is the unified LLM client consumed by 10 Lab notebooks (Day4-Day7,
+Lab8-Lab17) and had 0 dedicated Python test coverage before this PR.
+
+A captured-call fixture (monkeypatching `litellm.completion`) lets us assert
+exactly how `LLMClient` builds the `call_kwargs` per provider (api_base for
+vLLM/LM Studio, api_key threading, system/prompt ordering, max_tokens) without
+any real HTTP traffic.
+"""
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# --------------------------------------------------------------------------
+# Module bootstrap: mock litellm, put AgenticDataScience on sys.path, import.
+# --------------------------------------------------------------------------
+
+_AGDS_DIR = Path(__file__).resolve().parent.parent  # .../AgenticDataScience/
+
+
+@pytest.fixture(autouse=True)
+def _isolate_default_client(monkeypatch):
+    """Reset the module-level singleton so tests do not leak client state."""
+    if "utils.llm_client" in sys.modules:
+        sys.modules["utils.llm_client"]._default_client = None
+    yield
+    if "utils.llm_client" in sys.modules:
+        sys.modules["utils.llm_client"]._default_client = None
+
+
+def _ensure_loaded():
+    """Idempotently mock litellm + load utils.llm_client via package path."""
+    if "litellm" not in sys.modules:
+        fake = types.ModuleType("litellm")
+        fake.completion = lambda **kw: _FakeResponse("mocked")
+        sys.modules["litellm"] = fake
+    if str(_AGDS_DIR) not in sys.path:
+        sys.path.insert(0, str(_AGDS_DIR))
+    if "utils.llm_client" not in sys.modules:
+        import importlib
+        mod = importlib.import_module("utils.llm_client")
+        return mod
+    return sys.modules["utils.llm_client"]
+
+
+class _FakeMessage:
+    def __init__(self, content):
+        self.content = content
+
+
+class _FakeChoice:
+    def __init__(self, content):
+        self.message = _FakeMessage(content)
+
+
+class _FakeResponse:
+    def __init__(self, content):
+        self.choices = [_FakeChoice(content)]
+
+
+_ensure_loaded()
+llm_client = sys.modules["utils.llm_client"]
+providers = sys.modules["config.providers"]
+ProviderConfig = providers.ProviderConfig
+ProviderType = providers.ProviderType
+LLMClient = llm_client.LLMClient
+
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+
+
+def _capturing_completion(calls):
+    """Return a fake litellm.completion that records its kwargs."""
+
+    def _impl(**kwargs):
+        calls.append(kwargs)
+        return _FakeResponse("RESPONSE")
+
+    return _impl
+
+
+def _cfg(provider, **overrides):
+    base = dict(provider=provider, model="m", base_url="http://x/v1", api_key=None)
+    base.update(overrides)
+    return ProviderConfig(**base)
+
+
+# --------------------------------------------------------------------------
+# __init__ / __repr__
+# --------------------------------------------------------------------------
+
+
+def test_init_explicit_config_threads_model():
+    cfg = _cfg(ProviderType.OPENAI, model="gpt-4o")
+    c = LLMClient(config=cfg)
+    assert c.config is cfg
+    assert c.model == "openai/gpt-4o"  # litellm prefix for OpenAI
+
+
+def test_init_vllm_model_uses_openai_prefix():
+    cfg = _cfg(ProviderType.VLLM, model="qwen3.6-35b-a3b")
+    c = LLMClient(config=cfg)
+    assert c.model == "openai/qwen3.6-35b-a3b"  # vLLM is OpenAI-API compatible
+
+
+def test_repr_includes_provider_and_model():
+    cfg = _cfg(ProviderType.GEMINI, model="gemini-3.1-pro")
+    c = LLMClient(config=cfg)
+    r = repr(c)
+    assert "gemini" in r
+    assert "gemini-3.1-pro" in r
+
+
+# --------------------------------------------------------------------------
+# generate() — call_kwargs construction per provider
+# --------------------------------------------------------------------------
+
+
+def test_generate_passes_model_and_temperature(monkeypatch):
+    calls = []
+    monkeypatch.setattr(llm_client, "completion", _capturing_completion(calls))
+    c = LLMClient(config=_cfg(ProviderType.OPENAI))
+    out = c.generate("hello", temperature=0.1)
+    assert out == "RESPONSE"
+    assert calls[0]["model"] == "openai/m"
+    assert calls[0]["temperature"] == 0.1
+
+
+def test_generate_orders_system_before_user(monkeypatch):
+    calls = []
+    monkeypatch.setattr(llm_client, "completion", _capturing_completion(calls))
+    c = LLMClient(config=_cfg(ProviderType.OPENAI))
+    c.generate("user prompt", system="system prompt")
+    msgs = calls[0]["messages"]
+    assert msgs == [
+        {"role": "system", "content": "system prompt"},
+        {"role": "user", "content": "user prompt"},
+    ]
+
+
+def test_generate_no_system_message_when_absent(monkeypatch):
+    calls = []
+    monkeypatch.setattr(llm_client, "completion", _capturing_completion(calls))
+    c = LLMClient(config=_cfg(ProviderType.OPENAI))
+    c.generate("user prompt")
+    assert calls[0]["messages"] == [{"role": "user", "content": "user prompt"}]
+
+
+def test_generate_omits_api_base_for_openai(monkeypatch):
+    calls = []
+    monkeypatch.setattr(llm_client, "completion", _capturing_completion(calls))
+    c = LLMClient(config=_cfg(ProviderType.OPENAI, base_url="http://openai/v1"))
+    c.generate("hi")
+    assert "api_base" not in calls[0]
+
+
+def test_generate_adds_api_base_for_vllm(monkeypatch):
+    calls = []
+    monkeypatch.setattr(llm_client, "completion", _capturing_completion(calls))
+    c = LLMClient(config=_cfg(ProviderType.VLLM, base_url="http://localhost:8000/v1"))
+    c.generate("hi")
+    assert calls[0]["api_base"] == "http://localhost:8000/v1"
+
+
+def test_generate_adds_api_base_for_lmstudio(monkeypatch):
+    calls = []
+    monkeypatch.setattr(llm_client, "completion", _capturing_completion(calls))
+    c = LLMClient(config=_cfg(ProviderType.LMSTUDIO, base_url="http://localhost:1234/v1"))
+    c.generate("hi")
+    assert calls[0]["api_base"] == "http://localhost:1234/v1"
+
+
+def test_generate_threads_api_key_when_present(monkeypatch):
+    calls = []
+    monkeypatch.setattr(llm_client, "completion", _capturing_completion(calls))
+    c = LLMClient(config=_cfg(ProviderType.OPENAI, api_key="sk-test"))
+    c.generate("hi")
+    assert calls[0]["api_key"] == "sk-test"
+
+
+def test_generate_omits_api_key_when_none(monkeypatch):
+    calls = []
+    monkeypatch.setattr(llm_client, "completion", _capturing_completion(calls))
+    c = LLMClient(config=_cfg(ProviderType.OPENAI, api_key=None))
+    c.generate("hi")
+    assert "api_key" not in calls[0]
+
+
+# --------------------------------------------------------------------------
+# max_tokens handling — regression on the falsy-zero bug
+# --------------------------------------------------------------------------
+
+
+def test_generate_max_tokens_positive_is_passed(monkeypatch):
+    calls = []
+    monkeypatch.setattr(llm_client, "completion", _capturing_completion(calls))
+    c = LLMClient(config=_cfg(ProviderType.OPENAI))
+    c.generate("hi", max_tokens=128)
+    assert calls[0]["max_tokens"] == 128
+
+
+def test_generate_max_tokens_none_is_omitted(monkeypatch):
+    calls = []
+    monkeypatch.setattr(llm_client, "completion", _capturing_completion(calls))
+    c = LLMClient(config=_cfg(ProviderType.OPENAI))
+    c.generate("hi")  # max_tokens defaults to None
+    assert "max_tokens" not in calls[0]
+
+
+def test_generate_max_tokens_zero_is_passed_not_swallowed(monkeypatch):
+    """Regression: `if max_tokens:` used to treat 0 as falsy and silently drop
+    it. The fix uses `if max_tokens is not None:` so max_tokens=0 (a valid
+    int, = generate zero tokens) is forwarded to litellm as documented by the
+    `max_tokens: Limite de tokens` docstring contract.
+    """
+    calls = []
+    monkeypatch.setattr(llm_client, "completion", _capturing_completion(calls))
+    c = LLMClient(config=_cfg(ProviderType.OPENAI))
+    c.generate("hi", max_tokens=0)
+    assert calls[0]["max_tokens"] == 0
+
+
+def test_generate_extra_kwargs_are_forwarded(monkeypatch):
+    calls = []
+    monkeypatch.setattr(llm_client, "completion", _capturing_completion(calls))
+    c = LLMClient(config=_cfg(ProviderType.OPENAI))
+    c.generate("hi", top_p=0.9, stop=["END"])
+    assert calls[0]["top_p"] == 0.9
+    assert calls[0]["stop"] == ["END"]
+
+
+# --------------------------------------------------------------------------
+# chat() — messages list passthrough
+# --------------------------------------------------------------------------
+
+
+def test_chat_passes_messages_list(monkeypatch):
+    calls = []
+    monkeypatch.setattr(llm_client, "completion", _capturing_completion(calls))
+    c = LLMClient(config=_cfg(ProviderType.OPENAI))
+    history = [
+        {"role": "user", "content": "q1"},
+        {"role": "assistant", "content": "a1"},
+        {"role": "user", "content": "q2"},
+    ]
+    out = c.chat(history, temperature=0.3)
+    assert out == "RESPONSE"
+    assert calls[0]["messages"] == history
+    assert calls[0]["temperature"] == 0.3
+
+
+def test_chat_adds_api_base_for_lmstudio(monkeypatch):
+    calls = []
+    monkeypatch.setattr(llm_client, "completion", _capturing_completion(calls))
+    c = LLMClient(config=_cfg(ProviderType.LMSTUDIO, base_url="http://lmstudio/v1"))
+    c.chat([{"role": "user", "content": "x"}])
+    assert calls[0]["api_base"] == "http://lmstudio/v1"
+
+
+# --------------------------------------------------------------------------
+# get_client / generate module-level helpers — singleton
+# --------------------------------------------------------------------------
+
+
+def test_get_client_is_singleton(monkeypatch):
+    # Patch completion so LLMClient() never hits the network during construction
+    # (it only builds config; generate/chat call completion).
+    monkeypatch.setattr(llm_client, "completion", _capturing_completion([]))
+    # get_client() with no .env uses Settings defaults (active_provider=vllm);
+    # that is fine — we only assert identity, not the provider value.
+    a = llm_client.get_client()
+    b = llm_client.get_client()
+    assert a is b
+
+
+def test_module_generate_uses_singleton(monkeypatch):
+    calls = []
+    monkeypatch.setattr(llm_client, "completion", _capturing_completion(calls))
+    out = llm_client.generate("hi", max_tokens=5)
+    assert out == "RESPONSE"
+    assert calls[0]["messages"] == [{"role": "user", "content": "hi"}]
+    assert calls[0]["max_tokens"] == 5


### PR DESCRIPTION
## What

Test coverage pour **`ML/DataScienceWithAgents/AgenticDataScience/utils/llm_client.py`** (147L) — client LLM unifié (wrapper LiteLLM), consommé par **10 Lab notebooks** (Day4-Day7, Lab8-Lab17). **0 test Python dédié** avant cette PR. Garde-fou anti-régression sur le chemin de génération central. Suite de la veine test-coverage (même pattern que `providers.py` #7382 et `claude_cli.py` #7386), 4e sous-domaine ce cycle-day (rotation ML/GenAI/SymbolicAI).

## Le bug (reproduit firsthand)

`LLMClient.generate()` construisait `call_kwargs` avec :

```python
if max_tokens:                       # L81 — BUG
    call_kwargs["max_tokens"] = max_tokens
```

`if max_tokens:` traite **0 comme falsy** → `max_tokens=0` est **silencieusement avalé** au lieu d'être transmis à `litellm.completion`. Or `0` est un `int` valide signifiant « générer zéro token » (utile p.ex. pour forcer un completion de longueur nulle, ou pour valider qu'un appel ne dépasse pas), et la docstring du module le documente explicitement (`max_tokens: Limite de tokens`). C'est exactement le même pattern truthy/falsy que `sat_calibration.py` corrigé en #7379.

## Le fix

One-line, `+1/−1` :

```python
if max_tokens is not None:           # 0 est forwardé, seul None est omis
    call_kwargs["max_tokens"] = max_tokens
```

Sémantique préservée : `max_tokens=None` (défaut) reste omis du payload LiteLLM (comportement inchangé) ; `max_tokens=0` est désormais correctement transmis.

## Livrable

- **`utils/test_llm_client.py`** (co-localisé avec le module) — **19 tests CPU-only**, 0.15 s, aucune dépendance externe au-delà de stdlib + pydantic. Couvre par fonction publique de `llm_client.py` :
  - **`__init__` / `__repr__`** (3) : résolution modèle litellm par provider (OpenAI `openai/`, vLLM `openai/` prefix), `repr` inclut provider + model.
  - **`generate()` call_kwargs** (11) : model+temperature transmis, ordre system-avant-user, user-only quand system absent, `api_base` omis pour OpenAI / ajouté pour vLLM+LM Studio, `api_key` transmis quand présent / omis quand `None`, `max_tokens` positif transmis, `max_tokens=None` omis, **`max_tokens=0` transmis (régression pinnée)**, kwargs extras (`top_p`, `stop`) forwardés.
  - **`chat()`** (2) : passthrough liste de messages + temperature, `api_base` pour LM Studio.
  - **`get_client()` / `generate()` module-level** (2) : singleton (identité préservée entre 2 appels), helper module-level utilise le singleton.
- **`AgenticDataScience/conftest.py`** (nouveau) — bootstrap pytest : insère `AgenticDataScience/` sur `sys.path` (pour que l'import absolu `from config.providers import` dans `llm_client.py` résolve en mode `--import-mode importlib`) ET installe un faux module `litellm` dans `sys.modules` avant que `utils/__init__.py` ne l'importe à la collection. Placé au niveau `AgenticDataScience/` (pas dans `utils/`) car pytest y charge un conftest comme plugin standalone **avant** l'import du package `utils` — un conftest dans `utils/` déclencherait lui-même `utils/__init__.py` et arriverait trop tard.

## Validation reproductible

```
$ cd MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/utils
$ python -m pytest test_llm_client.py -q
19 passed in 0.15s
```

Avant le fix L81, `test_generate_max_tokens_zero_is_passed_not_swallowed` échouait (`AssertionError: 'max_tokens' not in call_kwargs`). Après le fix : passe.

## Honnêteté G.9

- Bug reproduit **firsthand** (test d'abord rouge) avant le fix, pas pattern-matché.
- Bug-hunt général sur `llm_client.py` : **0 autre bug fonctionnel forçable**. Les branches `api_base` (vllm/lmstudio), `api_key`, `system`-optional, kwargs-passthrough sont toutes correctes. `chat()` duplique la logique `call_kwargs` de `generate()` (légère redondance, pas un bug) — laissé en l'état (one-subject-per-PR).
- `DEFAULTS["openrouter"].model` dans `config/providers.py` (`"anthropic/claude-3.5-sonnet"`) diffère cosmétiquement de `Settings.default_model` (`"openai/gpt-4.1"`) — déjà noté en #7382 comme cosmétique (Settings value wins), hors scope ici.

## Conformité

- Atomique : 1 domaine (ML/DataScienceWithAgents/utils quality), 1 bug one-line + tests co-localisés + conftest de support.
- Anti-regression : `+1/−1` sur code métier (bug fix), 0 stub, 0 `sorry`, 0 suppression de logique. Diff cohérent avec l'intention.
- Pas de `Closes #N` (contribution qualité standalone) — contribution à la fiabilité du client LLM unifié.
- Pas de C.2 implication : 0 notebook modifié (test-only + 1-line py fix). Les 10 notebooks consumers ne sont pas touchés.
- Aucune dépendance réseau, aucune clé API, aucun `.env` (litellm mocké, `LLMClient()` construit avec config explicite).
- Catalogue byte-identique à `main` (0 diff `COURSE_CATALOG.generated.*`).
- Rebase frais off `origin/main` `2faaee90a`, worktree isolé `CoursIA-llmclient-tests`.
