### PR TITLE
fix(llm_client): forward max_tokens=0 to litellm instead of swallowing it

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/utils/llm_client.py
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/utils/llm_client.py
@@ -78,7 +78,7 @@ class LLMClient:
         if self.config.api_key:
             call_kwargs["api_key"] = self.config.api_key
 
-        if max_tokens:
+        if max_tokens is not None:
             call_kwargs["max_tokens"] = max_tokens
 
         call_kwargs.update(kwargs)


### PR DESCRIPTION
## What

Bug fix one-line sur **`ML/DataScienceWithAgents/AgenticDataScience/utils/llm_client.py`** (L81) — le client LLM unifié consommé par 10 Lab notebooks.

## Le bug (reproduit firsthand)

`LLMClient.generate()` construisait `call_kwargs` avec :

```python
if max_tokens:                       # L81 — BUG
    call_kwargs["max_tokens"] = max_tokens
```

`if max_tokens:` traite **0 comme falsy** → `max_tokens=0` est **silencieusement avalé** au lieu d'être transmis à `litellm.completion`. Or `0` est un `int` valide signifiant « générer zéro token », documenté par la docstring (`max_tokens: Limite de tokens`). Même pattern truthy/falsy que `sat_calibration.py` corrigé en #7379.

## Le fix

One-line, `+1/−1` :

```python
if max_tokens is not None:           # 0 forwardé, seul None est omis
    call_kwargs["max_tokens"] = max_tokens
```

`max_tokens=None` (défaut) reste omis (comportement inchangé) ; `max_tokens=0` est désormais correctement transmis.

## Note collision — dédoublonnage avec #7389

J'ai d'abord ouvert #7393 (test coverage 0→19 + ce fix), mais G.1-verify a révélé que **po-2023 avait déjà #7389 ouvert** (`test(dsa): cover utils/llm_client.py LLM wrapper (0->20)`, même file set `conftest.py` + `utils/test_llm_client.py`). #7389 est test-**only** et ne touche pas `llm_client.py` (donc ne contient pas ce fix). J'ai **fermé #7393** (duplicait les tests de #7389) et je **differ les tests à po-2023**, en ne livrant ici que le **surplus non-couvert** : ce bug fix. Coordinator peut merger #7389 (tests) + ce fix indépendamment. Les tests de #7389 (`test_generate_max_tokens_conditional`) ne testent pas `max_tokens=0` et passent avant/après ce fix (compatibles).

## Validation reproductible

Reproduit firsthand avant fix : appel `LLMClient(config).generate("hi", max_tokens=0)` avec `litellm.completion` mocké → `call_kwargs` ne contenait PAS `max_tokens` (avalé). Après fix : `call_kwargs["max_tokens"] == 0`. (Test moqué retiré de ce PR pour ne pas dupliquer #7389 ; reproductible via le snippet du paragraphe précédent.)

## Conformité

- Atomique : 1 domaine (ML/llm_client bug fix), 1 fichier, `+1/−1`.
- Anti-regression : bug fix, 0 stub, 0 `sorry`, 0 suppression de logique. Diff cohérent.
- Pas de `Closes #N` (contribution standalone).
- Pas de C.2 implication : 0 notebook modifié. Les 10 notebooks consumers ne sont pas touchés (seul le chemin `max_tokens=0` change, qui n'est pas utilisé par défaut).
- Catalogue byte-identique à `main`.
- Rebase frais off `origin/main` `2faaee90a`, worktree isolé, branche renommée `fix/llm-client-max-tokens-zero`.
