### PR TITLE
test(qc): cover shared/backtest_helpers.py metrics (0->28, deterministic)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/shared/test_backtest_helpers.py
+++ b/MyIA.AI.Notebooks/QuantConnect/shared/test_backtest_helpers.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Pytest suite for `QuantConnect/shared/backtest_helpers.py`.
+
+Co-located with the module under `shared/`. CPU-only, no network, no
+QuantBook/QC Cloud. The module imports only stdlib + pandas + numpy (lines
+20-23) and performs pure computation on equity/return Series, so it is fully
+exercisable deterministically.
+
+The module is the shared backtest-metrics helper consumed by the QuantConnect
+notebook series (Sharpe/Sortino/Calmar/Max-Drawdown/Alpha-Beta) and had 0
+dedicated Python test coverage before this PR.
+
+Strategy: deterministic equity curves (no RNG) so every metric is
+hand-computable or formula-pinned. Edge cases (flat equity, no negative
+returns, constant benchmark) exercise the division guards.
+"""
+from __future__ import annotations
+
+import importlib.util
+from datetime import datetime
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+# Load the module by path (it lives under shared/, stdlib + pandas + numpy
+# only, no package-relative imports -> no sys.path manipulation needed).
+_MODULE_PATH = Path(__file__).resolve().parent / "backtest_helpers.py"
+_spec = importlib.util.spec_from_file_location("backtest_helpers", _MODULE_PATH)
+bt = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(bt)
+
+
+# --------------------------------------------------------------------------
+# Deterministic fixtures
+# --------------------------------------------------------------------------
+
+
+def _equity(values, start="2020-01-01"):
+    """Build a dated equity Series from a plain list of levels."""
+    idx = pd.date_range(start, periods=len(values), freq="D")
+    return pd.Series(values, index=idx, dtype=float)
+
+
+# --------------------------------------------------------------------------
+# default_backtest_config
+# --------------------------------------------------------------------------
+
+
+def test_default_backtest_config_defaults():
+    cfg = bt.default_backtest_config()
+    assert cfg["start_date"] == "2020-01-01"
+    assert cfg["end_date"] == "2023-12-31"
+    assert cfg["initial_capital"] == 100000
+    assert cfg["resolution"] == "Daily"
+
+
+def test_default_backtest_config_keys():
+    cfg = bt.default_backtest_config()
+    for key in (
+        "start_date", "end_date", "initial_capital", "resolution",
+        "brokerage_model", "slippage_model", "fill_model", "fee_model",
+        "benchmark",
+    ):
+        assert key in cfg
+
+
+def test_default_backtest_config_overrides_propagate():
+    cfg = bt.default_backtest_config(
+        start="2021-06-01", end="2022-06-01",
+        initial_capital=50000, resolution="Minute",
+    )
+    assert cfg["start_date"] == "2021-06-01"
+    assert cfg["end_date"] == "2022-06-01"
+    assert cfg["initial_capital"] == 50000
+    assert cfg["resolution"] == "Minute"
+    # Untouched defaults remain.
+    assert cfg["benchmark"] == "SPY"
+
+
+# --------------------------------------------------------------------------
+# calculate_metrics — basic structure + hand-computed values
+# --------------------------------------------------------------------------
+
+
+def test_calculate_metrics_keys_present():
+    m = bt.calculate_metrics(_equity([100, 110, 121]))
+    for key in (
+        "total_return", "annualized_return", "volatility", "sharpe_ratio",
+        "sortino_ratio", "max_drawdown", "calmar_ratio", "win_rate",
+        "alpha", "beta", "total_trades",
+    ):
+        assert key in m
+
+
+def test_calculate_metrics_total_return_known():
+    # equity [100, 110, 121] -> total return = 21/100 = 0.21
+    m = bt.calculate_metrics(_equity([100, 110, 121]))
+    assert m["total_return"] == pytest.approx(0.21)
+
+
+def test_calculate_metrics_flat_equity_zero_total_return():
+    m = bt.calculate_metrics(_equity([100.0, 100.0, 100.0, 100.0]))
+    assert m["total_return"] == pytest.approx(0.0)
+
+
+def test_calculate_metrics_flat_equity_zero_volatility_sharpe():
+    # Constant equity -> all returns 0 -> volatility 0 -> Sharpe guard -> 0.0
+    m = bt.calculate_metrics(_equity([100.0, 100.0, 100.0, 100.0]))
+    assert m["volatility"] == pytest.approx(0.0)
+    assert m["sharpe_ratio"] == 0.0
+
+
+def test_calculate_metrics_max_drawdown_value_and_negative_sign():
+    # equity [100, 120, 90]: peak 120 then 90 -> drawdown to -25%
+    #   returns = [0.2, -0.25]; cumulative = [1.2, 0.9]; drawdown = [0, -0.25]
+    m = bt.calculate_metrics(_equity([100, 120, 90]))
+    assert m["max_drawdown"] <= 0  # drawdown reported as negative depth
+    assert m["max_drawdown"] == pytest.approx(-0.25)
+
+
+def test_calculate_metrics_win_rate_half():
+    # equity [100, 110, 100]: returns = [+0.1, ~-0.0909] -> 1 of 2 positive
+    m = bt.calculate_metrics(_equity([100, 110, 100]))
+    assert m["win_rate"] == pytest.approx(0.5)
+
+
+def test_calculate_metrics_calmar_uses_abs_max_drawdown():
+    # Calmar = annualized_return / abs(max_drawdown) -> positive when positive
+    # annualized return and a real drawdown.
+    m = bt.calculate_metrics(_equity([100, 120, 110]))
+    assert m["max_drawdown"] < 0
+    assert m["calmar_ratio"] >= 0
+
+
+def test_calculate_metrics_no_negative_returns_sortino_zero():
+    # Strictly increasing equity -> all positive returns -> no downside -> the
+    # std-of-empty is NaN -> guard (NaN > 0 is False) -> Sortino 0.0.
+    m = bt.calculate_metrics(_equity([100, 101, 102, 103]))
+    assert m["sortino_ratio"] == 0.0
+
+
+def test_calculate_metrics_sharpe_positive_on_monotonic_growth():
+    m = bt.calculate_metrics(_equity([100, 110, 121, 133]))
+    # Positive excess return with finite volatility -> positive Sharpe.
+    assert m["sharpe_ratio"] > 0
+    assert np.isfinite(m["sharpe_ratio"])
+
+
+# --------------------------------------------------------------------------
+# calculate_metrics — alpha/beta with benchmark
+# --------------------------------------------------------------------------
+
+
+def test_calculate_metrics_with_benchmark_returns_finite_alpha_beta():
+    equity = _equity([100, 102, 101, 105, 108])
+    benchmark = _equity([100, 101, 103, 102, 106])
+    m = bt.calculate_metrics(equity, benchmark=benchmark)
+    assert np.isfinite(m["beta"])
+    assert np.isfinite(m["alpha"])
+
+
+def test_calculate_metrics_constant_benchmark_beta_defaults_to_one():
+    # Constant benchmark -> zero variance -> beta guard -> 1.0 default.
+    equity = _equity([100, 110, 105])
+    benchmark = _equity([100.0, 100.0, 100.0])
+    m = bt.calculate_metrics(equity, benchmark=benchmark)
+    assert m["beta"] == 1.0
+
+
+def test_calculate_metrics_without_benchmark_alpha_beta_defaults():
+    m = bt.calculate_metrics(_equity([100, 110, 121]))
+    # No benchmark -> alpha 0.0, beta 1.0 (initial defaults, unchanged).
+    assert m["alpha"] == 0.0
+    assert m["beta"] == 1.0
+
+
+# --------------------------------------------------------------------------
+# format_backtest_summary
+# --------------------------------------------------------------------------
+
+
+def test_format_backtest_summary_contains_strategy_name():
+    summary = bt.format_backtest_summary(
+        {"total_return": 0.25, "sharpe_ratio": 1.5}, "Alpha Strat"
+    )
+    assert "Alpha Strat" in summary
+
+
+def test_format_backtest_summary_formats_percentages():
+    summary = bt.format_backtest_summary(
+        {"total_return": 0.25, "sharpe_ratio": 1.5,
+         "max_drawdown": -0.15, "win_rate": 0.55}, "S"
+    )
+    assert "25.00%" in summary
+    assert "-15.00%" in summary
+    assert "55.00%" in summary
+
+
+def test_format_backtest_summary_handles_missing_keys():
+    # Missing metrics default to 0 via .get(..., 0) -> no KeyError, still a str.
+    summary = bt.format_backtest_summary({}, "Empty")
+    assert isinstance(summary, str)
+    assert "Empty" in summary
+
+
+# --------------------------------------------------------------------------
+# compare_strategies
+# --------------------------------------------------------------------------
+
+
+def test_compare_strategies_indexes_by_name_and_length():
+    s1 = _equity([100, 110, 121])
+    s2 = _equity([100, 105, 100])
+    df = bt.compare_strategies({"A": s1, "B": s2})
+    assert list(df.index) == ["A", "B"]
+    assert len(df) == 2
+
+
+def test_compare_strategies_default_columns():
+    df = bt.compare_strategies({"A": _equity([100, 110, 121])})
+    for col in ("total_return", "sharpe_ratio", "max_drawdown",
+                "volatility", "win_rate"):
+        assert col in df.columns
+
+
+def test_compare_strategies_custom_metrics_respected():
+    df = bt.compare_strategies(
+        {"A": _equity([100, 110, 121])},
+        metrics_to_compare=["total_return", "win_rate"],
+    )
+    assert list(df.columns) == ["total_return", "win_rate"]
+
+
+# --------------------------------------------------------------------------
+# is_trading_day
+# --------------------------------------------------------------------------
+
+
+def test_is_trading_day_weekday_true():
+    # 2023-01-02 is a Monday.
+    assert bt.is_trading_day(datetime(2023, 1, 2)) is True
+
+
+@pytest.mark.parametrize("dt,expected", [
+    (datetime(2023, 1, 7), False),  # Saturday
+    (datetime(2023, 1, 8), False),  # Sunday
+])
+def test_is_trading_day_weekend_false(dt, expected):
+    assert bt.is_trading_day(dt) is expected
+
+
+# --------------------------------------------------------------------------
+# annualized_sharpe
+# --------------------------------------------------------------------------
+
+
+def test_annualized_sharpe_matches_formula():
+    # Pin the documented arithmetic formula: (mean*252 - rf) / (std*sqrt(252)).
+    returns = pd.Series([0.01, 0.005, -0.002, 0.012, 0.008, -0.003])
+    rf = 0.02
+    expected = (returns.mean() * 252 - rf) / (returns.std() * np.sqrt(252))
+    assert bt.annualized_sharpe(returns, rf) == pytest.approx(expected)
+
+
+def test_annualized_sharpe_empty_returns_zero():
+    assert bt.annualized_sharpe(pd.Series([], dtype=float)) == 0.0
+
+
+def test_annualized_sharpe_zero_std_returns_zero():
+    # Constant returns -> std 0 -> guard -> 0.0
+    assert bt.annualized_sharpe(pd.Series([0.01, 0.01, 0.01])) == 0.0
+
+
+def test_annualized_sharpe_returns_float():
+    out = bt.annualized_sharpe(pd.Series([0.01, 0.02, -0.005]))
+    assert isinstance(out, float)


### PR DESCRIPTION
## What

Test coverage pour **`QuantConnect/shared/backtest_helpers.py`** (334L) — helper partagé de métriques de backtest (Sharpe/Sortino/Calmar/Max-Drawdown/Alpha-Beta), consommé par tous les notebooks QuantConnect. **0 test Python dédié** avant cette PR. Nouvelle famille ce cycle-day (QuantConnect, ≠ SymbolicAI/ML/GenAI déjà touchés) — rotation R6 honorée. Suite de la veine test-coverage (même pattern que `providers.py` #7382, `claude_cli.py` #7386, `validate_syntax.py` #7390).

## Bug-hunt G.9 — 0 bug forçable (honnête)

Bug-hunt firsthand sur toute la math financière : **0 bug fonctionnel à forcer-fix**. Les calculs de base sont défendables :
- `total_return`, `annualized_return` (CAGR géométrique `(1+total)^(252/N)` avec `N=len(returns)` = nb de périodes de rendement), `volatility` (std annualisée), `max_drawdown` (ratio sur cumulative-unit, signe négatif = profondeur), `calmar` (guard `abs(max_drawdown)`), `win_rate`, `alpha`/`beta` (CAPM, beta = cov/var avec guard `var>0→1.0`).
- Guards division-by-zero présents et corrects : `volatility > 0` (Sharpe), `downside_std > 0` (Sortino, gère aussi le NaN de std-of-empty), `max_drawdown != 0` (Calmar), `benchmark_variance > 0` (Beta), `len(returns) > 0` (win_rate).

**2 simplifications pédagogiques documentées** (pinnées comme comportements, **PAS** bug-claims — module d'enseignement, one-subject-per-PR) :
1. **Sortino** (L98-100) utilise `std` des *rendements négatifs uniquement* (shortcut courant en pédagogie), pas la formule canonique downside-deviation `sqrt(mean(min(0, r-target)^2))`. Pinné par `test_calculate_metrics_no_negative_returns_sortino_zero` (rendements tous positifs → downside vide → sortino 0.0 via le guard NaN>0=False).
2. **Inconsistance annualization alpha** : `annualized_return` stratégique (L88) est géométrique CAGR, mais `benchmark_return` (L129) est arithmétique `(1+mean_daily)^252`. Pour un CAPM alpha strict, les 2 méthodes devraient coïncider. Inconsistance mineure sur l'alpha, défendable en pédagogie, non touchée.

## Livrable

- **`shared/test_backtest_helpers.py`** (co-localisé avec le module) — **28 tests CPU-only**, 0.90s, aucune dépendance externe au-delà de stdlib + pandas + numpy. Equity curves **déterministes** (pas de RNG) → chaque métrique est hand-computable ou formula-pinned. Charge via `importlib` path-load (self-contained, pas de conftest, pattern #7386). Couvre les 6 fonctions publiques :
  - **`default_backtest_config`** (3) : defaults, clés attendues, overrides propagent + défauts intacts.
  - **`calculate_metrics`** (14) : clés présentes, `total_return=0.21` (équity [100,110,121]), flat-equity → total_return 0 + volatility 0 + Sharpe 0 (guard), `max_drawdown=-0.25` valeur+signe (équity [100,120,90]), `win_rate=0.5`, Calmar via `abs(max_drawdown)`, no-negative-returns → Sortino 0 (guard NaN), Sharpe positif sur croissance monotone, benchmark réel → alpha/beta finis, benchmark constant → beta=1 (guard var=0), sans benchmark → alpha=0/beta=1.
  - **`format_backtest_summary`** (3) : nom stratégie présent, pourcentages formatées (`25.00%`, `-15.00%`, `55.00%`), missing-keys via `.get(...,0)` (no KeyError).
  - **`compare_strategies`** (3) : indexé par nom + longueur, colonnes défaut, `metrics_to_compare` custom respecté.
  - **`is_trading_day`** (2 paramétrés) : weekday True, samedi/dimanche False.
  - **`annualized_sharpe`** (4) : pin formule arithmétique `(mean*252-rf)/(std*sqrt(252))`, empty → 0, zero-std → 0, retourne float.

## Validation reproductible

```
$ cd MyIA.AI.Notebooks/QuantConnect/shared
$ python -m pytest test_backtest_helpers.py -q
28 passed in 0.90s
```

## Conformité

- Atomique : 1 domaine (QuantConnect/shared quality), 1 fichier test co-localisé.
- Anti-regression : nouveau fichier de test, **0 .py métier touché**, 0 changement de comportement (diff = 1 NEW file). `grep -c sorry` N/A (Python).
- Pas de `Closes #N` (contribution qualité standalone) — contribution à la fiabilité des métriques de backtest.
- Pas de C.2 implication : 0 notebook modifié (test-only PR). Les notebooks consumers ne sont pas touchés.
- Aucune dépendance réseau, aucun QuantBook, aucune clé API, aucun QC Cloud (métriques pures sur Series pandas).
- Catalogue byte-identique à `main` (0 diff `COURSE_CATALOG.generated.*`).
- Preflight collision : 0 PR ouverte sur `QuantConnect/shared/` (QC PRs ouverts = tranches docs `#7366-7373` sur `projects/`+docs, pas `shared/`).
- Rebase frais off `origin/main` `2faaee90a`, worktree isolé `CoursIA-qc-backtest`.
