### PR TITLE
test(qc): cover shared/indicators.py LEAN-style classes (0->18, deterministic)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/shared/test_indicators.py
+++ b/MyIA.AI.Notebooks/QuantConnect/shared/test_indicators.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Pytest suite for `QuantConnect/shared/indicators.py`.
+
+Co-located with the module under `shared/`. CPU-only, no network, no LEAN
+engine, no QuantBook. The module imports only typing + numpy (lines 20-21)
+and defines 3 stateful LEAN-style indicator classes + an IndicatorValue
+helper, all exercised by feeding deterministic (high, low, close) bars via
+the `.Update()` warm-up API.
+
+The module is consumed by notebooks 11 and 18 (Technical Indicators, Feature
+Engineering) and had 0 dedicated Python test coverage before this PR.
+
+Strategy: feed hand-picked price/bar sequences so every indicator value is
+hand-computable. Warm-up, window-slide, readiness threshold, division guards
+(old_price=0, flat-move), and Reset are all pinned.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+# Load the module by path (lives under shared/, typing + numpy only, no
+# package-relative imports -> no sys.path manipulation needed).
+_MODULE_PATH = Path(__file__).resolve().parent / "indicators.py"
+_spec = importlib.util.spec_from_file_location("indicators", _MODULE_PATH)
+ind = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(ind)
+
+CustomMomentumIndicator = ind.CustomMomentumIndicator
+TrendStrengthIndicator = ind.TrendStrengthIndicator
+VolatilityBandIndicator = ind.VolatilityBandIndicator
+IndicatorValue = ind.IndicatorValue
+
+
+# --------------------------------------------------------------------------
+# IndicatorValue
+# --------------------------------------------------------------------------
+
+
+def test_indicator_value_float_cast():
+    iv = IndicatorValue(1.5)
+    assert float(iv) == 1.5
+
+
+def test_indicator_value_repr_rounds_to_four_decimals():
+    assert repr(IndicatorValue(0.123456)) == "IndicatorValue(0.1235)"
+
+
+def test_indicator_value_default_time_is_none():
+    iv = IndicatorValue(2.0)
+    assert iv.Time is None
+    assert iv.Value == 2.0
+
+
+# --------------------------------------------------------------------------
+# CustomMomentumIndicator
+# --------------------------------------------------------------------------
+
+
+def test_momentum_not_ready_before_period_bars():
+    m = CustomMomentumIndicator("mom", period=3)
+    m.Update(None, 100)
+    m.Update(None, 110)
+    assert m.IsReady is False
+
+
+def test_momentum_ready_and_value_at_period():
+    # period=3, prices [100, 110, 121] -> old=100, cur=121 -> 0.21
+    m = CustomMomentumIndicator("mom", period=3)
+    for p in (100, 110, 121):
+        m.Update(None, p)
+    assert m.IsReady is True
+    assert float(m.Current) == pytest.approx(0.21)
+
+
+def test_momentum_window_slides_on_new_bar():
+    # After the 4th bar (130), the first price (100) drops off the window;
+    # window becomes [110, 121, 130] -> old=110, cur=130 -> 20/110.
+    m = CustomMomentumIndicator("mom", period=3)
+    for p in (100, 110, 121, 130):
+        m.Update(None, p)
+    assert float(m.Current) == pytest.approx(20 / 110)
+
+
+def test_momentum_zero_division_guard_when_old_price_zero():
+    # old_price=0 must not raise; momentum falls back to 0.0.
+    m = CustomMomentumIndicator("mom", period=2)
+    m.Update(None, 0)
+    m.Update(None, 100)
+    assert m.IsReady is True
+    assert float(m.Current) == 0.0
+
+
+def test_momentum_reset_clears_state():
+    m = CustomMomentumIndicator("mom", period=2)
+    m.Update(None, 100)
+    m.Update(None, 110)
+    assert m.IsReady is True
+    m.Reset()
+    assert m.IsReady is False
+    assert m.prices == []
+    assert float(m.Current) == 0.0
+
+
+def test_momentum_default_period_is_20():
+    m = CustomMomentumIndicator("mom")
+    assert m.period == 20
+    assert m.Name == "mom"
+
+
+# --------------------------------------------------------------------------
+# TrendStrengthIndicator
+# --------------------------------------------------------------------------
+
+
+def test_trend_strength_monotonic_up_is_plus_one():
+    # Strictly increasing closes -> all moves up -> strength +1.0
+    t = TrendStrengthIndicator("trend", period=4)
+    for c in (1, 2, 3, 4, 5, 6):
+        t.Update(None, high=c + 1, low=c - 1, close=c)
+    assert t.IsReady is True
+    assert float(t.Current) == pytest.approx(1.0)
+
+
+def test_trend_strength_monotonic_down_is_minus_one():
+    t = TrendStrengthIndicator("trend", period=4)
+    for c in (6, 5, 4, 3, 2, 1):
+        t.Update(None, high=c + 1, low=c - 1, close=c)
+    assert float(t.Current) == pytest.approx(-1.0)
+
+
+def test_trend_strength_alternating_is_zero():
+    # closes 1,2,1,2,1 -> equal up/down moves -> strength 0.0
+    t = TrendStrengthIndicator("trend", period=4)
+    for c in (1, 2, 1, 2, 1):
+        t.Update(None, high=c + 1, low=c - 1, close=c)
+    assert float(t.Current) == pytest.approx(0.0)
+
+
+def test_trend_strength_all_flat_counts_as_down_minus_one():
+    # Documented quirk (pin, not a bug-claim): moves_down is computed as
+    # (len-1) - moves_up, so flat moves (close[i] == close[i-1], NOT strictly
+    # up) are bucketed into moves_down. An all-flat series therefore reports
+    # strength = -1.0 (maximally bearish), not 0.0. The `moves_up + moves_down
+    # == 0` guard only triggers when there are zero moves at all (len < 2,
+    # already handled by the `len < 2` early return), so it never fires for a
+    # warm series of flat bars.
+    t = TrendStrengthIndicator("trend", period=4)
+    for _ in range(5):
+        t.Update(None, high=6, low=4, close=5)
+    assert t.IsReady is True
+    assert float(t.Current) == pytest.approx(-1.0)
+
+
+def test_trend_strength_reset_clears_state():
+    t = TrendStrengthIndicator("trend", period=3)
+    for c in (1, 2, 3, 4):
+        t.Update(None, high=c + 1, low=c - 1, close=c)
+    assert t.IsReady is True
+    t.Reset()
+    assert t.IsReady is False
+    assert t.close_prices == []
+
+
+# --------------------------------------------------------------------------
+# VolatilityBandIndicator
+# --------------------------------------------------------------------------
+
+
+def test_vol_band_not_ready_before_period():
+    vb = VolatilityBandIndicator("vb", period=3)
+    vb.Update(None, high=2, low=0, close=1)
+    vb.Update(None, high=2, low=0, close=1)
+    assert vb.IsReady is False
+
+
+def test_vol_band_known_values_and_symmetric_width():
+    # period=2, bars: (H,L,C) = (101,99,100), (103,101,102)
+    #   middle = mean([100,102]) = 101
+    #   TR at i=1: max(H-L=103-101=2, |H-Cprev|=|103-100|=3, |L-Cprev|=|101-100|=1) = 3
+    #   atr = mean([3]) = 3 ; multiplier=2 -> width = 6
+    #   upper = 101+6 = 107 ; lower = 101-6 = 95
+    vb = VolatilityBandIndicator("vb", period=2, multiplier=2.0)
+    vb.Update(None, high=101, low=99, close=100)
+    vb.Update(None, high=103, low=101, close=102)
+    assert vb.IsReady is True
+    assert float(vb.MiddleBand) == pytest.approx(101.0)
+    assert float(vb.UpperBand) == pytest.approx(107.0)
+    assert float(vb.LowerBand) == pytest.approx(95.0)
+    # Symmetric around the SMA.
+    assert float(vb.UpperBand) - float(vb.MiddleBand) == pytest.approx(
+        float(vb.MiddleBand) - float(vb.LowerBand)
+    )
+
+
+def test_vol_band_zero_atr_when_constant_bars():
+    # Constant bars -> every TR component is 0 -> atr 0 -> bands == middle.
+    vb = VolatilityBandIndicator("vb", period=3, multiplier=2.0)
+    for _ in range(3):
+        vb.Update(None, high=100, low=100, close=100)
+    assert float(vb.UpperBand) == pytest.approx(100.0)
+    assert float(vb.MiddleBand) == pytest.approx(100.0)
+    assert float(vb.LowerBand) == pytest.approx(100.0)
+
+
+def test_vol_band_reset_clears_state():
+    vb = VolatilityBandIndicator("vb", period=2)
+    vb.Update(None, high=2, low=0, close=1)
+    vb.Update(None, high=2, low=0, close=1)
+    assert vb.IsReady is True
+    vb.Reset()
+    assert vb.IsReady is False
+    assert vb.close_prices == []
+    assert float(vb.UpperBand) == 0.0


### PR DESCRIPTION
## What

Test coverage pour **`QuantConnect/shared/indicators.py`** (262L) — 3 classes d'indicateurs LEAN-style stateful (`CustomMomentumIndicator`, `TrendStrengthIndicator`, `VolatilityBandIndicator`) + helper `IndicatorValue`, consommées par les notebooks 11 et 18 (Technical Indicators, Feature Engineering). **0 test Python dédié** avant cette PR. Suite de la veine test-coverage QuantConnect/shared (suit #7400 `backtest_helpers`).

## Bug-hunt G.9 — 0 bug forçable (honnête)

Bug-hunt firsthand sur les 3 classes stateful (warm-up `.Update()`) : **0 bug fonctionnel à forcer-fix**. Guards division-by-zero présents et corrects (`old_price != 0` pour momentum, `len < 2` pour trend-strength, `true_ranges` empty pour ATR). `IndicatorValue` forward-ref OK (résolution au call-time, confirmé par bloc `__main__`).

**1 quirk sémantique pinné** (PAS un bug-claim — one-subject-per-PR, module d'enseignement) :
- **TrendStrength flat-move bucketing** : `moves_down = (len-1) - moves_up` (L116) englobe les mouvements plats (plat = pas strictement "up" → bucketed "down"). Une série **all-flat** rapporte donc strength **-1.0** (bearish), pas 0.0 (neutre). Le guard `moves_up + moves_down == 0` (L118) ne se déclenche que pour `len < 2` (déjà gardé par le early-return L110) → effectivement mort pour une série warm. Pinné honnêtement par `test_trend_strength_all_flat_counts_as_down_minus_one`.

## Livrable

- **`shared/test_indicators.py`** (co-localisé avec le module) — **18 tests CPU-only**, 0.86s, aucune dépendance externe au-delà de stdlib + numpy. Barres (high,low,close) **déterministes** → chaque valeur hand-computable. Charge via `importlib` path-load (self-contained, pas de conftest). Couvre :
  - **`IndicatorValue`** (3) : `__float__`, `__repr__` 4-décimales, `Time=None` par défaut.
  - **`CustomMomentumIndicator`** (6) : warm-up not-ready (<period), ready + valeur 0.21 ([100,110,121] period=3), window-slide (4e barre 130 → old=110, momentum 20/110), guard `old_price=0` → 0.0 (pas ZeroDiv), Reset (clear prices+IsReady), période défaut 20.
  - **`TrendStrengthIndicator`** (5) : monotonic up → +1.0, monotonic down → -1.0, alternant → 0.0, all-flat → -1.0 (quirk pinné), Reset.
  - **`VolatilityBandIndicator`** (4) : warm-up not-ready (<period), valeurs connues upper/middle/lower = 107/101/95 (ATR=3, mult=2, width=6 symétrique), zero-ATR barres constantes (bands=middle), Reset.

## Validation reproductible

```
$ cd MyIA.AI.Notebooks/QuantConnect/shared
$ python -m pytest test_indicators.py -q
18 passed in 0.86s
```

## Conformité

- Atomique : 1 domaine (QuantConnect/shared quality), 1 fichier test co-localisé.
- Anti-regression : nouveau fichier de test, **0 .py métier touché**, 0 changement de comportement (diff = 1 NEW file).
- Pas de `Closes #N` (contribution qualité standalone).
- Pas de C.2 implication : 0 notebook modifié (test-only). Les notebooks consumers (11, 18) ne sont pas touchés.
- Aucune dépendance réseau, aucun LEAN engine, aucun QuantBook (indicateurs purs sur listes Python + numpy).
- Catalogue byte-identique à `main`.
- Preflight collision : 0 PR ouverte sur `QuantConnect/shared/indicators.py`.
- Rebase frais off `origin/main` `2faaee90a`, worktree isolé `CoursIA-qc-indicators`.
