### PR TITLE
fix(smartcontracts,#4365): point Arrow/Voting refs to canonical game_theory_lean/SocialChoice

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/README.md
@@ -72,7 +72,7 @@ Le LLM comme outil de développeur Solidity : **prompting** efficace pour smart 
 | [SmartContracts (parent)](../README.md) | Vue d'ensemble | Contexte, parcours global, glossaire |
 | [01-Solidity-Foundation](../01-Solidity-Foundation/SC-3-Solidity-Basics.ipynb) | Prérequis | SC-3..6 (syntaxe, types, fonctions, héritage, errors/events) |
 | [03-Foundry-Testing](../03-Foundry-Testing/) | Suite | SC-12+ (tests Foundry, fuzzing, vérification formelle) |
-| [GameTheory](../../../GameTheory/) | SC-9 (DAO) | Théorème d'Arrow : limites des systèmes de vote on-chain (cf `social_choice_lean/Arrow.lean`) |
+| [GameTheory](../../../GameTheory/) | SC-9 (DAO) | Théorème d'Arrow : limites des systèmes de vote on-chain (cf `game_theory_lean/SocialChoice/Arrow.lean`) |
 | [SymbolicAI/Lean](../../Lean/) | SC-11 (LLM) | Meme paradigme d'assistance LLM (Lean-7/8/9) applique a la preuve formelle |
 
 ---

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/README.md
@@ -414,8 +414,8 @@ Les techniques de vérification formelle présentées dans cette série (SC-14, 
 
 Les mécanismes de vote et de gouvernance on-chain (SC-9, SC-17) sont des instances concrètes des résultats formels de la série GameTheory :
 
-- **SC-9 DAO Governance** : les systèmes de vote on-chain sont soumis aux mêmes limitations que le **théorème d'Arrow** (formalisé dans `social_choice_lean/Arrow.lean`, 0 sorry).
-- **SC-17 E2E Verifiable Voting** : les propriétés des systèmes de vote (Banks sets, monotonie STV) sont étudiées formellement dans `social_choice_lean/Voting.lean`. Le chiffrement homomorphique (SC-16) et les ZKP (SC-15) sont les briques cryptographiques qui rendent le vote E2E possible.
+- **SC-9 DAO Governance** : les systèmes de vote on-chain sont soumis aux mêmes limitations que le **théorème d'Arrow** (formalisé dans `game_theory_lean/SocialChoice/Arrow.lean`, 0 sorry).
+- **SC-17 E2E Verifiable Voting** : les propriétés des systèmes de vote (Banks sets, monotonie STV) sont étudiées formellement dans `game_theory_lean/SocialChoice/Voting.lean`. Le chiffrement homomorphique (SC-16) et les ZKP (SC-15) sont les briques cryptographiques qui rendent le vote E2E possible.
 
 ### SmartContracts et Décision sous Incertitude (Probas)
 
@@ -629,7 +629,7 @@ maturity: PRODUCTION=27
 | Notebook SmartContracts | Série parente | Pont conceptuel |
 |------------------------|---------------|-----------------|
 | `SC-12 Foundry Testing` | [Lean](../Lean/) (types dépendants, Curry-Howard) | Vérification formelle = même ambition (prouver la correction), deux faces : SMT automatique (SMTChecker) vs interactif expressif (Lean 4) |
-| `SC-14 Formal Verification` | [Lean](../Lean/) + [GameTheory](../../GameTheory/) (`social_choice_lean/`) | Pont vérification : Certora/SMTChecker prouvent les invariants Solidity ; Lean 4 prouve les théorèmes économiques (Arrow, Voting). Même méthodologie, deux domaines |
+| `SC-14 Formal Verification` | [Lean](../Lean/) + [GameTheory](../../GameTheory/) (`game_theory_lean/SocialChoice/`) | Pont vérification : Certora/SMTChecker prouvent les invariants Solidity ; Lean 4 prouve les théorèmes économiques (Arrow, Voting). Même méthodologie, deux domaines |
 | `SC-15 ZKP / SC-16 HE / SC-17 E2E Voting` | [Lean](../Lean/) + [Tweety](../Tweety/) (cryptographic protocols argumentation) | Cryptographie avancée : ZKP = preuve sans divulgation ; HE = calcul sur chiffré ; vote E2E = anonymat + vérifiabilité. Tweety argumente formellement ces protocoles |
 | `SC-11 LLM-Assisted Contracts` | [Argument_Analysis](../Argument_Analysis/) (Semantic Kernel) | LLM generates Solidity contracts via SK : prompting structuré → code Solidity → validation Foundry |
 | `SC-9 DAO Governance / SC-17 E2E Voting` | [GameTheory](../../GameTheory/) (Arrow.lean, Voting.lean) | Vote on-chain = instance concrète du théorème d'Arrow (impossibilité) ; vote E2E = instance des Banks sets + monotonie STV |


### PR DESCRIPTION
## What

Fix 4 stale file-path references in 2 SmartContracts READMEs that point to source files **absent from the tree** since the doctrine #4365 lake absorption. Follow-up to the deferred c.678 cleanup documented in PR #7405 body ("à fixer (futur PR").

## Le bug (firsthand vérifié AVANT le fix)

`SmartContracts/README.md` L417/418/632 + `02-Solidity-Advanced/README.md` L75 referenced `social_choice_lean/Arrow.lean` and `social_choice_lean/Voting.lean` as LIVE source paths. But:

```bash
$ git ls-tree -r origin/main --name-only | grep "social_choice_lean/" | grep "\.lean$"
GameTheory/social_choice_lean/lakefile.lean          # ONLY a tombstone wrapper — no source
```

The `social_choice_lean/` directory is a **tombstone** since PR #5902/#5913 absorbed Arrow+Voting into the canonical `game_theory_lean/SocialChoice/` lake. A reader following "Arrow est formalisé dans `social_choice_lean/Arrow.lean`" hits a dead path.

## G.1 firsthand verification

| Check | Result |
|-------|--------|
| `social_choice_lean/Arrow.lean` exists? | **NO** (stale) |
| `social_choice_lean/Voting.lean` exists? | **NO** (stale) |
| Canonical `game_theory_lean/SocialChoice/Arrow.lean` exists? | **YES** ✓ |
| Canonical `game_theory_lean/SocialChoice/Voting.lean` exists? | **YES** ✓ |
| Collision (file-set inspection across OPEN PRs)? | **0 PR touches these files** ✓ |

## Changement

4 path swaps, 2 files, pure prose:

| File | Line | Old (dead) | New (canonical) |
|------|------|-----------|-----------------|
| `SmartContracts/README.md` | L417 | `social_choice_lean/Arrow.lean` | `game_theory_lean/SocialChoice/Arrow.lean` |
| `SmartContracts/README.md` | L418 | `social_choice_lean/Voting.lean` | `game_theory_lean/SocialChoice/Voting.lean` |
| `SmartContracts/README.md` | L632 | `social_choice_lean/` | `game_theory_lean/SocialChoice/` |
| `02-Solidity-Advanced/README.md` | L75 | `social_choice_lean/Arrow.lean` | `game_theory_lean/SocialChoice/Arrow.lean` |

## Preuve pure-change

- **+4 / −4** symétrique strict (R3 atomic, bien sous seuils).
- 0 production code touched (pure markdown prose).
- CATALOG-STATUS markers byte-identiques (aucun dans le diff).
- Branche `fix/sc-social-choice-stale-paths` from `origin/main@c76d8b8f2`, worktree isolé.

## Scope boundary (excluded)

`docs/ledgers/3801-sota-axe2.md` contient aussi des refs `social_choice_lean/Arrow.lean` (L833, L906, L2042, L2123...) **mais c'est un ledger d'audit cumulatif** (header "Entry de ledger cumulatif") qui enregistre l'état des lakes au moment de l'audit. Modifier ces refs = altérer l'historique d'audit = separate concern (hors scope de cette PR prose-only). Le propriétaire du ledger (po-2025) peut décider si ces refs historiques doivent être annotées.

## Conformité

- Atomique : 1 sujet (SmartContracts stale-path cleanup, doctrine #4365), 2 fichiers, 1 domaine.
- Anti-regression : corrige des refs cassées (pointe vers des fichiers réels), 0 code métier touché.
- `See #4365` (contribution partielle à la doctrine cleanup epic, ne clôt pas l'epic).
- Catalogue byte-identique à main.
