### PR TITLE
fix(lean-notebook-utils): count_sorry strips comments + skips .lake (#7414)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/lean_notebook_utils.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/lean_notebook_utils.py
@@ -279,56 +279,89 @@ def run_lean_snippet(
 # Sorry counting
 # ---------------------------------------------------------------------------
 
-def count_sorry(project_path: str, subdir: str = "") -> int:
-    """Count sorry occurrences in .lean files (cross-platform).
+_SORRY_TOKEN_RE = re.compile(r"\bsorry\b")
 
-    Excludes sorry in block comments (/- ... -/) and line comments (-- ...).
+
+def _strip_lean_comments(content: str) -> str:
+    """Strip Lean line comments (``--``) and nested block comments (``/- -/``).
+
+    Character-level scan handling nested block comments (Lean allows them).
+    Byte-identical twin of the canonical ``strip_lean_comments`` in
+    ``agent_tests/prover/lean_utils.py`` (FX-6 #1453): kept local here to avoid
+    coupling the notebook utility to the prover harness package. If you edit
+    one, edit the other to keep the two counters from drifting.
+
+    No string-literal awareness: Lean proofs virtually never contain the token
+    ``sorry`` inside a string literal, and over-stripping there cannot create a
+    false token.
+    """
+    out = []
+    i, n, depth = 0, len(content), 0
+    while i < n:
+        two = content[i:i + 2]
+        if depth == 0 and two == "--":
+            j = content.find("\n", i)
+            i = n if j < 0 else j
+            continue
+        if two == "/-":
+            depth += 1
+            i += 2
+            continue
+        if depth > 0 and two == "-/":
+            depth -= 1
+            i += 2
+            continue
+        if depth == 0:
+            out.append(content[i])
+        i += 1
+    return "".join(out)
+
+
+def count_sorry(project_path: str, subdir: str = "") -> int:
+    """Count REAL ``sorry`` tactics in ``.lean`` source (cross-platform).
+
+    Excludes ``sorry`` mentions in block comments (``/- ... -/``) and line
+    comments (``-- ...``), and skips the ``.lake`` build/package cache so only
+    authored source is tallied. Pure-Python (no ``grep``/WSL fork) so the count
+    is identical on every platform.
+
+    Mirrors the canonical ``count_real_sorries`` semantics
+    (``agent_tests/prover/lean_utils.py``, FX-6 #1453): after stripping comments,
+    the word-bounded token catches every real form (``exact sorry``,
+    ``:= by sorry``, bare ``sorry``, ``sorry -- inline``) and ignores prose
+    mentions in docstrings/comments. See issue #7414 for the docstring/impl
+    mismatch this corrects: the previous bare ``grep -rc sorry`` counted every
+    ``sorry`` token (including prose in docstrings/comments and vendored
+    ``.lake`` source), inflating the tally on lakes with sorry-rich prose.
 
     Args:
         project_path: Path to the Lake project.
         subdir: Optional subdirectory to scan (e.g. "Grothendieck/").
 
     Returns:
-        Number of sorry occurrences in production code.
+        Number of real ``sorry`` tactics in production source, or ``-1`` if the
+        project directory cannot be read. ``0`` if the directory exists but has
+        no ``.lean`` source.
     """
     search_dir = os.path.join(project_path, subdir) if subdir else project_path
+    if not os.path.isdir(search_dir):
+        return -1
 
-    if is_native_platform():
-        try:
-            rc, out, _err = _run_capture(["grep", "-rc", "sorry", "--include=*.lean", search_dir], 30)
-            if rc != 0:
-                return 0
-            total = 0
-            for line in out.strip().splitlines():
-                parts = line.split(":")
-                if len(parts) >= 2:
-                    try:
-                        total += int(parts[-1])
-                    except ValueError:
-                        pass
-            return total
-        except (subprocess.TimeoutExpired, FileNotFoundError):
-            return -1
-    else:
-        cmd = (
-            f"cd {project_path} && "
-            f"grep -rc sorry --include='*.lean' {subdir} 2>/dev/null"
-        )
-        try:
-            rc, out, _err = _run_capture(["wsl", "-d", "Ubuntu", "--", "bash", "-lc", cmd], 30)
-            if rc != 0:
-                return 0
-            total = 0
-            for line in out.strip().splitlines():
-                parts = line.split(":")
-                if len(parts) >= 2:
-                    try:
-                        total += int(parts[-1])
-                    except ValueError:
-                        pass
-            return total
-        except (subprocess.TimeoutExpired, FileNotFoundError):
-            return -1
+    total = 0
+    for root, dirs, files in os.walk(search_dir):
+        # Skip the Lake build cache + vendored deps (compiled artifacts and
+        # Mathlib source, not authored content).
+        dirs[:] = [d for d in dirs if d != ".lake"]
+        for name in files:
+            if not name.endswith(".lean"):
+                continue
+            try:
+                with open(os.path.join(root, name), encoding="utf-8") as f:
+                    content = f.read()
+            except OSError:
+                continue
+            total += len(_SORRY_TOKEN_RE.findall(_strip_lean_comments(content)))
+    return total
 
 
 # ---------------------------------------------------------------------------

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/scripts/tests/test_count_sorry.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/scripts/tests/test_count_sorry.py
@@ -1,0 +1,221 @@
+"""Tests for ``lean_notebook_utils.count_sorry`` + ``_strip_lean_comments``.
+
+Regression coverage for the fix to issue #7414: ``count_sorry`` previously ran
+a bare ``grep -rc sorry --include=*.lean`` that counted ``sorry`` everywhere
+(including docstrings ``/- ... -/`` and line comments ``-- ...``), contradicting
+its own docstring which claimed to exclude comments. The fix rewrites it as a
+pure-Python pass that strips comments first (mirroring the canonical
+``agent_tests/prover/lean_utils.py:strip_lean_comments`` FX-6 #1453) then counts
+word-bounded ``sorry``.
+
+These tests are hermetic (synthetic ``.lean`` files in ``tmp_path``); no real
+Lake project is required. CPU-only, stdlib + pytest.
+
+Run with: pytest MyIA.AI.Notebooks/SymbolicAI/Lean/scripts/tests/test_count_sorry.py -v
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# Module under test: SymbolicAI/Lean/lean_notebook_utils.py
+# This test:        SymbolicAI/Lean/scripts/tests/test_count_sorry.py
+# (3 levels up from tests/ -> scripts/ -> Lean/)
+_LEAN_DIR = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(_LEAN_DIR))
+
+import lean_notebook_utils as L  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+#  _strip_lean_comments                                                        #
+# --------------------------------------------------------------------------- #
+
+class TestStripLeanComments:
+    """_strip_lean_comments must mirror the canonical prover strip_lean_comments."""
+
+    def test_line_comment_removed(self):
+        assert L._strip_lean_comments("code -- a sorry comment") == "code "
+
+    def test_block_comment_removed(self):
+        assert L._strip_lean_comments("/- sorry block -/ code") == " code"
+
+    def test_nested_block_comment_removed(self):
+        # Lean allows nested /- -/ blocks.
+        src = "nested /- /- sorry inner -/ sorry outer -/ ok"
+        assert L._strip_lean_comments(src) == "nested  ok"
+
+    def test_multiline_block_comment_removed(self):
+        src = "/- multi\nline sorry block\nhere -/\nsorry"
+        assert L._strip_lean_comments(src) == "\nsorry"
+
+    def test_trailing_inline_comment_keeps_sorry_before_it(self):
+        # `sorry -- comment` : the tactic is real, only the comment is stripped.
+        assert L._strip_lean_comments("sorry -- trailing") == "sorry "
+
+    def test_no_comments_preserved(self):
+        assert L._strip_lean_comments("theorem x : True := by sorry") == \
+            "theorem x : True := by sorry"
+
+    def test_empty(self):
+        assert L._strip_lean_comments("") == ""
+
+    def test_line_comment_keeps_newline(self):
+        # The newline after a -- comment is kept (so line structure survives).
+        assert L._strip_lean_comments("-- a\nsorry") == "\nsorry"
+
+    def test_unclosed_block_comment_strips_to_end(self):
+        # An unterminated /- block swallows the rest (char-scan semantics).
+        assert L._strip_lean_comments("ok /- never closed sorry") == "ok "
+
+
+# --------------------------------------------------------------------------- #
+#  count_sorry — the #7414 fix                                                 #
+# --------------------------------------------------------------------------- #
+
+class TestCountSorry:
+    """count_sorry counts REAL sorry tactics, ignoring prose in comments."""
+
+    def test_one_real_sorry(self, tmp_path):
+        (tmp_path / "A.lean").write_text(
+            "theorem t : True := by sorry\n", encoding="utf-8")
+        assert L.count_sorry(str(tmp_path)) == 1
+
+    def test_sorry_in_block_comment_not_counted(self, tmp_path):
+        (tmp_path / "A.lean").write_text(
+            "/- This docstring mentions sorry as an example. -/\n"
+            "theorem t : True := trivial\n", encoding="utf-8")
+        assert L.count_sorry(str(tmp_path)) == 0
+
+    def test_sorry_in_line_comment_not_counted(self, tmp_path):
+        (tmp_path / "A.lean").write_text(
+            "-- TODO: replace sorry later\n"
+            "theorem t : True := trivial\n", encoding="utf-8")
+        assert L.count_sorry(str(tmp_path)) == 0
+
+    def test_regression_prose_and_real_mixed(self, tmp_path):
+        """The #7414 bug: prose sorry in comments must not inflate the count.
+        Before the fix, grep -rc counted 3 here (docstring + comment + real).
+        After the fix, only the 1 real tactic is counted."""
+        (tmp_path / "A.lean").write_text(
+            "/- module has sorry in its docstring narrative -/\n"
+            "-- the word sorry appears in this comment too\n"
+            "theorem t : True := by sorry\n", encoding="utf-8")
+        assert L.count_sorry(str(tmp_path)) == 1
+
+    def test_multiple_real_sorries_across_files(self, tmp_path):
+        (tmp_path / "A.lean").write_text("theorem a : True := by sorry\n", encoding="utf-8")
+        (tmp_path / "B.lean").write_text(
+            "theorem b : True := by sorry\ntheorem c : True := by sorry\n",
+            encoding="utf-8")
+        assert L.count_sorry(str(tmp_path)) == 3
+
+    def test_all_sorry_forms_caught_after_strip(self, tmp_path):
+        """Word-bounded \\bsorry\\b catches every real tactic form."""
+        (tmp_path / "A.lean").write_text(
+            "theorem a : True := sorry\n"          # bare sorry
+            "theorem b : True := by sorry\n"       # by sorry
+            "theorem c : True := exact sorry\n"    # exact sorry
+            "theorem d : True := sorry -- inline\n",  # sorry + inline comment
+            encoding="utf-8")
+        assert L.count_sorry(str(tmp_path)) == 4
+
+    def test_word_boundary_not_substring(self, tmp_path):
+        # "sorries" / "sorryFree" / "unsorry" must NOT match \bsorry\b on both sides.
+        (tmp_path / "A.lean").write_text(
+            "/- the sorries list -/\n-- unsorry check\n"
+            "def sorryFree := 0\n", encoding="utf-8")
+        assert L.count_sorry(str(tmp_path)) == 0
+
+    def test_non_lean_files_ignored(self, tmp_path):
+        (tmp_path / "A.lean").write_text("theorem t : True := by sorry\n", encoding="utf-8")
+        (tmp_path / "notes.txt").write_text("sorry sorry sorry\n", encoding="utf-8")
+        (tmp_path / "B.py").write_text("sorry = 1\n", encoding="utf-8")
+        assert L.count_sorry(str(tmp_path)) == 1
+
+    def test_empty_directory(self, tmp_path):
+        assert L.count_sorry(str(tmp_path)) == 0
+
+    def test_missing_directory_returns_minus_one(self, tmp_path):
+        missing = str(tmp_path / "does_not_exist")
+        assert L.count_sorry(missing) == -1
+
+    def test_lake_cache_skipped(self, tmp_path):
+        """``.lake`` (build cache / vendored Mathlib source) must not be counted."""
+        (tmp_path / "Real.lean").write_text("theorem r : True := by sorry\n", encoding="utf-8")
+        lake = tmp_path / ".lake" / "packages" / "Mathlib" / "Mathlib"
+        lake.mkdir(parents=True)
+        # 99 "sorry" inside the cache — must be ignored.
+        (lake / "Junk.lean").write_text("sorry " * 99, encoding="utf-8")
+        assert L.count_sorry(str(tmp_path)) == 1
+
+    def test_subdir_scoped(self, tmp_path):
+        (tmp_path / "A.lean").write_text("theorem a : True := by sorry\n", encoding="utf-8")
+        sub = tmp_path / "Sub"
+        sub.mkdir()
+        (sub / "B.lean").write_text(
+            "theorem b : True := by sorry\ntheorem c : True := by sorry\n",
+            encoding="utf-8")
+        # subdir "Sub" -> only B.lean's 2 sorries.
+        assert L.count_sorry(str(tmp_path), "Sub") == 2
+
+    def test_recurses_into_nested_dirs(self, tmp_path):
+        deep = tmp_path / "a" / "b" / "c"
+        deep.mkdir(parents=True)
+        (deep / "Deep.lean").write_text("theorem t : True := by sorry\n", encoding="utf-8")
+        assert L.count_sorry(str(tmp_path)) == 1
+
+
+# --------------------------------------------------------------------------- #
+#  Cross-check against the canonical prover counter (defense against drift)    #
+# --------------------------------------------------------------------------- #
+
+class TestCanonicalParity:
+    """count_sorry must agree with the canonical count_real_sorries semantics.
+
+    If this test fails, the local _strip_lean_comments has drifted from the
+    canonical ``agent_tests/prover/lean_utils.py:strip_lean_comments`` (FX-6).
+    """
+
+    @pytest.fixture
+    def prover(self):
+        prover_path = (_LEAN_DIR / "agent_tests" / "prover" / "lean_utils.py")
+        if not prover_path.is_file():
+            pytest.skip("canonical prover lean_utils.py not present")
+        import importlib.util
+        spec = importlib.util.spec_from_file_location("_prover_lean_utils", prover_path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    @pytest.mark.parametrize("src", [
+        "/- sorry -/ code sorry",
+        "-- sorry\nsorry",
+        "nested /- /- sorry -/ -/ ok",
+        "sorry -- trailing",
+        "no sorry here",
+        "/- multi\nline sorry block -/\nsorry",
+        "theorem x : True := by sorry  -- real",
+    ])
+    def test_strip_identical_to_canonical(self, prover, src):
+        assert L._strip_lean_comments(src) == prover.strip_lean_comments(src)
+
+    def test_count_matches_canonical_on_synthetic_project(self, prover, tmp_path):
+        """count_sorry(project) must equal the sum of count_real_sorries(file)
+        over the project's .lean source — the shared contract."""
+        files = {
+            "A.lean": "/- sorry doc -/\ntheorem a : True := by sorry\n",
+            "B.lean": "-- sorry\ntheorem b : True := sorry\ntheorem c : True := by sorry\n",
+        }
+        for name, content in files.items():
+            (tmp_path / name).write_text(content, encoding="utf-8")
+        expected = sum(prover.count_real_sorries(c) for c in files.values())
+        assert L.count_sorry(str(tmp_path)) == expected
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Fixes the `count_sorry` docstring/implementation mismatch from issue #7414. The docstring promised to exclude `sorry` in block comments (`/- ... -/`) and line comments (`-- ...`), but the implementation was a bare `grep -rc sorry` that counted every `sorry` token — including prose in docstrings/comments and vendored `.lake`/Mathlib source. The function contradicted its own docstring and over-counted on lakes with sorry-rich prose.

The fix is a pure-Python rewrite that **converges** the notebook utility with the canonical prover counter (`count_real_sorries` in `agent_tests/prover/lean_utils.py`, FX-6 #1453) instead of letting the two drift.

## The fix (`lean_notebook_utils.py`)

- **`_strip_lean_comments`** — char-level scan handling nested `/- -/` block comments (Lean allows nesting) and `--` line comments. Byte-identical twin of the canonical `strip_lean_comments` (kept local to avoid coupling the notebook utility to the prover harness package).
- **`count_sorry`** — `os.walk` skipping `.lake`, strip comments, then word-bounded `\bsorry\b` match. No `grep`/WSL fork → identical count on every platform (was previously platform-branched native-grep vs WSL-grep with an empty-`subdir` bug on Windows).
- Missing directory now returns `-1` (the documented sentinel) directly, instead of only on subprocess error.

## Anti-regression protocol

Rule D does **not** apply: no Lean proof or production logic is touched. This is a bug fix to a utility function that makes it *more* correct (the opposite of replacing a proof with `sorry`).

- **Exact defect:** docstring promises comment-exclusion; impl did `grep -rc sorry` (counts prose + vendored source, no `.lake` skip, platform-branched with a Windows empty-arg bug).
- **Tactics tried before rewrite:**
  - **Option A** (fix the `grep` regex to skip comments) — rejected: `grep` cannot strip *nested* Lean block comments (`/- /- -/ -/`) portably.
  - **Option B** (shell out to the canonical prover counter) — rejected: couples the notebook utility to the prover harness package + needs the prover path at runtime.
  - **Option C** (pure-Python rewrite mirroring the canonical semantics) — **retained**: cross-platform, no fork, converges the two counters.

### Before / after on real lakes (firsthand-verified)

Both columns skip `.lake` so the comparison isolates the **comment-exclusion bug** (the actual defect being fixed), not cache-skipping. Measured with the worktree's fixed `count_sorry` against authored source at `origin/main`:

| lake | OLD (bug: counts `sorry` in comments) | NEW (fixed: strips comments) | delta |
|------|------:|------:|------:|
| `conway_lean` | 66 | 4 | −62 |
| `calibration_lean` | 16 | 0 | −16 |
| `grothendieck_lean` | 27 | 0 | −27 |
| `knot_lean` | 26 | 17 | −9 |
| `finiteness_lean` | 0 | 0 | 0 |
| `sensitivity_lean` | 0 | 0 | 0 |

No false positives introduced (lakes with 0 real sorries stay at 0). The NEW column is the true real-sorry count in authored source. (Issue #7414's headline `89 → 8` for conway used the full buggy `grep -rc` *including* `.lake`/vendored Mathlib, hence higher; the authored-source delta here is the honest apples-to-apples measure of the comment-exclusion fix.)

## Test evidence

New `scripts/tests/test_count_sorry.py` — **30 hermetic CPU-only tests** (synthetic `.lean` in `tmp_path`, no real Lake project required):

- `_strip_lean_comments`: line/block/nested/multiline comments, trailing inline comment keeps the real tactic, unclosed block, empty.
- `count_sorry`: 1 real sorry in a comments-heavy file, prose-only → 0, missing dir → `-1`, empty dir → `0`, `.lake` skipped, subdir scope, recursion, word-boundary (`sorryFree`/`unsorry`/`sorries` not matched), all real forms (`exact sorry`, `:= by sorry`, bare `sorry`, `sorry -- inline`), non-`.lean` files ignored.
- **Canonical-parity cross-check** (parametrized + project-level): proves `_strip_lean_comments == prover.strip_lean_comments` across 7 cases AND `count_sorry(project) == Σ count_real_sorries(file)` — the shared contract between the notebook utility and the canonical prover counter.

```
$ python -m pytest MyIA.AI.Notebooks/SymbolicAI/Lean/scripts/tests/test_count_sorry.py -v
============================== 30 passed in 0.30s ==============================
```

## Scope note (no collision with #7413)

This PR is separate from po-2023's #7413 (which adds `test_lean_notebook_utils.py` and **deliberately excluded** `count_sorry`). Per the #7414 acceptance criteria, the real fix gets its own PR with the anti-regression protocol — not slipped into a test PR. The test file here is `test_count_sorry.py` (distinct filename → no merge conflict with #7413).

Closes #7414
