### PR TITLE
test(notebook_tools): unit coverage for dotnet_executor (0->15 tests)

### DIFF
--- a/scripts/notebook_tools/tests/test_dotnet_executor.py
+++ b/scripts/notebook_tools/tests/test_dotnet_executor.py
@@ -1,0 +1,292 @@
+"""Tests for scripts/notebook_tools/dotnet_executor.py — .NET Interactive executor.
+
+The module executes .NET notebooks cell-by-cell via ``jupyter_client`` and is
+consumed by ``notebook_helpers.py`` (the pipeline that gives notebooks real
+``execution_count`` / outputs). It was a **test orphan**: 0 ``test_`` importers
+repo-wide. This suite pins its logic without a live kernel by mocking
+``jupyter_client.KernelManager`` — covering the dry-run / no-cells pure paths,
+the iopub message-routing (stream / execute_result / display_data / error /
+idle), the timeout branch, and ``batch_execute`` glob/skip handling.
+
+No live kernel, no network, no .NET runtime. Fast (``time.sleep`` is patched out).
+"""
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import dotnet_executor  # noqa: E402
+
+
+# --- fixtures ---------------------------------------------------------------
+
+def _write_nb(path: Path, cells):
+    """Write a notebook with the given cells (list of dicts)."""
+    path.write_text(json.dumps({"cells": cells, "metadata": {}}), encoding="utf-8")
+    return path
+
+
+def _code_cell(source):
+    src = source if isinstance(source, list) else [source]
+    return {"cell_type": "code", "source": src, "execution_count": None, "outputs": []}
+
+
+def _msg(msg_type, **content):
+    return {"msg_type": msg_type, "content": content}
+
+
+def _fake_kernel(message_seq_by_cell):
+    """Build a KernelManager mock whose client yields the given per-cell messages.
+
+    ``message_seq_by_cell`` is a list of lists: each inner list is the iopub
+    message sequence for one cell execution. The fake ``get_iopub_msg`` drains
+    the current cell's list, then raises ``queue.Empty`` so the caller's
+    ``except Exception: continue`` re-checks the deadline without consuming more.
+    """
+    import queue
+
+    # exec_count = number of kc.execute() calls; the messages for the cell
+    # currently executing live at seqs[exec_count - 1]. pos is the cursor
+    # within that cell's sequence. execute() is called BEFORE the iopub loop,
+    # so it sets up the index the loop then drains.
+    state = {"exec_count": 0, "pos": 0}
+
+    def get_iopub_msg(timeout=5):
+        idx = state["exec_count"] - 1  # 0-indexed current cell
+        if idx < 0 or idx >= len(message_seq_by_cell):
+            raise queue.Empty
+        seq = message_seq_by_cell[idx]
+        if state["pos"] >= len(seq):
+            raise queue.Empty
+        msg = seq[state["pos"]]
+        state["pos"] += 1
+        return msg
+
+    def execute(source):
+        state["exec_count"] += 1
+        state["pos"] = 0
+        return f"msg-{state['exec_count']}"
+
+    kc = MagicMock()
+    kc.execute.side_effect = execute
+    kc.get_iopub_msg.side_effect = get_iopub_msg
+
+    km = MagicMock()
+    km.client.return_value = kc
+    return km, kc
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep():
+    """The executor sleeps 3s waiting for kernel-ready; patch it out for speed."""
+    with patch.object(dotnet_executor.time, "sleep", return_value=None):
+        yield
+
+
+@pytest.fixture
+def _patch_kernelmanager():
+    """Yield a setter that installs the fake KernelManager."""
+    holder = {}
+
+    def install(message_seq_by_cell):
+        km, kc = _fake_kernel(message_seq_by_cell)
+        holder["km"] = km
+        holder["kc"] = kc
+        return km, kc
+
+    with patch.object(dotnet_executor.jupyter_client, "KernelManager") as MockKM:
+        # KernelManager(kernel_name=...) returns the instance we install.
+        def factory(kernel_name=None):
+            return holder["km"]
+        MockKM.side_effect = factory
+        yield install
+
+
+# --- pure paths (no kernel) -------------------------------------------------
+
+def test_no_code_cells_returns_skipped(tmp_path):
+    nb = _write_nb(tmp_path / "n.ipynb", [
+        {"cell_type": "markdown", "source": ["# hi"]},
+    ])
+    stats = dotnet_executor.execute_notebook(nb)
+    assert stats == {"total": 0, "executed": 0, "errors": 0, "skipped": True}
+    # Notebook left untouched (no code cells to update).
+    assert json.loads(nb.read_text(encoding="utf-8"))["cells"][0]["cell_type"] == "markdown"
+
+
+def test_dry_run_counts_executed_without_kernel(tmp_path):
+    nb = _write_nb(tmp_path / "n.ipynb", [
+        _code_cell("var a = 1;"),
+        _code_cell("Console.WriteLine(a);"),  # already executed marker set below
+        _code_cell("var b = 2;"),
+    ])
+    # Mark the 2nd cell as already executed.
+    data = json.loads(nb.read_text(encoding="utf-8"))
+    data["cells"][1]["execution_count"] = 1
+    nb.write_text(json.dumps(data), encoding="utf-8")
+
+    stats = dotnet_executor.execute_notebook(nb, dry_run=True)
+    assert stats["skipped"] is True
+    assert stats["total"] == 3
+    assert stats["executed"] == 1
+    assert stats["errors"] == 0
+
+
+def test_dry_run_zero_executed(tmp_path):
+    nb = _write_nb(tmp_path / "n.ipynb", [_code_cell("x"), _code_cell("y")])
+    stats = dotnet_executor.execute_notebook(nb, dry_run=True)
+    assert stats["executed"] == 0
+    assert stats["total"] == 2
+
+
+def test_dry_run_does_not_start_kernel(tmp_path, _patch_kernelmanager):
+    """dry_run must short-circuit before KernelManager is constructed."""
+    nb = _write_nb(tmp_path / "n.ipynb", [_code_cell("x")])
+    dotnet_executor.execute_notebook(nb, dry_run=True)
+    # KernelManager factory was never invoked (no install happened).
+    assert dotnet_executor.jupyter_client.KernelManager.call_count == 0
+
+
+# --- message routing (kernel mocked) ----------------------------------------
+
+def test_stream_and_execute_result_routed(tmp_path, _patch_kernelmanager):
+    nb = _write_nb(tmp_path / "n.ipynb", [_code_cell("Console.WriteLine(42);")])
+    km, kc = _patch_kernelmanager([[
+        _msg("status", execution_state="busy"),
+        _msg("stream", name="stdout", text="42\n"),
+        _msg("execute_result", data={"text/plain": "43"}),
+        _msg("status", execution_state="idle"),
+    ]])
+    stats = dotnet_executor.execute_notebook(nb)
+
+    assert stats["executed"] == 1
+    assert stats["errors"] == 0
+    cell = json.loads(nb.read_text(encoding="utf-8"))["cells"][0]
+    assert cell["execution_count"] == 1
+    types = [o["output_type"] for o in cell["outputs"]]
+    assert types == ["stream", "execute_result"]
+    assert cell["outputs"][0]["text"] == "42\n"
+    assert cell["outputs"][1]["data"] == {"text/plain": "43"}
+    assert cell["outputs"][1]["execution_count"] == 1
+    km.shutdown_kernel.assert_called_once()
+
+
+def test_display_data_routed_without_execution_count(tmp_path, _patch_kernelmanager):
+    nb = _write_nb(tmp_path / "n.ipynb", [_code_cell("x.Display();")])
+    _patch_kernelmanager([[
+        _msg("status", execution_state="busy"),
+        _msg("display_data", data={"text/html": "<b>hi</b>"}),
+        _msg("status", execution_state="idle"),
+    ]])
+    dotnet_executor.execute_notebook(nb)
+    out = json.loads(nb.read_text(encoding="utf-8"))["cells"][0]["outputs"][0]
+    assert out["output_type"] == "display_data"
+    assert out["data"] == {"text/html": "<b>hi</b>"}
+    # display_data carries no execution_count (unlike execute_result).
+    assert "execution_count" not in out
+
+
+def test_error_output_increments_errors(tmp_path, _patch_kernelmanager):
+    nb = _write_nb(tmp_path / "n.ipynb", [_code_cell("1/0;")])
+    _patch_kernelmanager([[
+        _msg("status", execution_state="busy"),
+        _msg("error", ename="DivideByZero", evalue="division", traceback=["tb1", "tb2"]),
+        _msg("status", execution_state="idle"),
+    ]])
+    stats = dotnet_executor.execute_notebook(nb)
+    assert stats["errors"] == 1
+    assert stats["executed"] == 1
+    out = json.loads(nb.read_text(encoding="utf-8"))["cells"][0]["outputs"][0]
+    assert out["output_type"] == "error"
+    assert out["ename"] == "DivideByZero"
+    assert out["traceback"] == ["tb1", "tb2"]
+
+
+def test_execution_count_increments_across_cells(tmp_path, _patch_kernelmanager):
+    nb = _write_nb(tmp_path / "n.ipynb", [_code_cell("a"), _code_cell("b"), _code_cell("c")])
+    _patch_kernelmanager([
+        [_msg("status", execution_state="idle")],
+        [_msg("status", execution_state="idle")],
+        [_msg("status", execution_state="idle")],
+    ])
+    stats = dotnet_executor.execute_notebook(nb)
+    assert stats["executed"] == 3
+    cells = json.loads(nb.read_text(encoding="utf-8"))["cells"]
+    assert [c["execution_count"] for c in cells] == [1, 2, 3]
+
+
+def test_timeout_branch_emits_stderr_and_counts_executed(tmp_path, _patch_kernelmanager):
+    """cell_timeout=0 → while-loop skipped → TIMEOUT stderr appended, still 'executed'."""
+    nb = _write_nb(tmp_path / "n.ipynb", [_code_cell("while(true);")])
+    _patch_kernelmanager([[]])  # no messages needed; loop never runs
+    stats = dotnet_executor.execute_notebook(nb, cell_timeout=0)
+    assert stats["executed"] == 1
+    out = json.loads(nb.read_text(encoding="utf-8"))["cells"][0]["outputs"][0]
+    assert out["output_type"] == "stream"
+    assert out["name"] == "stderr"
+    assert "TIMEOUT" in out["text"]
+
+
+def test_kernel_shutdown_on_success(tmp_path, _patch_kernelmanager):
+    nb = _write_nb(tmp_path / "n.ipynb", [_code_cell("x")])
+    km, _ = _patch_kernelmanager([[_msg("status", execution_state="idle")]])
+    dotnet_executor.execute_notebook(nb)
+    km.shutdown_kernel.assert_called_once()
+
+
+def test_kernel_shutdown_on_error(tmp_path, _patch_kernelmanager):
+    nb = _write_nb(tmp_path / "n.ipynb", [_code_cell("bad")])
+    km, _ = _patch_kernelmanager([[
+        _msg("error", ename="E", evalue="v", traceback=[]),
+        _msg("status", execution_state="idle"),
+    ]])
+    dotnet_executor.execute_notebook(nb)
+    # finally-block still shuts the kernel down even when a cell errored.
+    km.shutdown_kernel.assert_called_once()
+
+
+def test_missing_output_fields_use_defaults(tmp_path, _patch_kernelmanager):
+    """An error message with no ename/evalue/traceback falls back to defaults."""
+    nb = _write_nb(tmp_path / "n.ipynb", [_code_cell("x")])
+    _patch_kernelmanager([[
+        _msg("error"),  # empty content
+        _msg("status", execution_state="idle"),
+    ]])
+    dotnet_executor.execute_notebook(nb)
+    out = json.loads(nb.read_text(encoding="utf-8"))["cells"][0]["outputs"][0]
+    assert out["ename"] == "Error"  # default
+    assert out["evalue"] == ""
+    assert out["traceback"] == []
+
+
+# --- batch_execute ----------------------------------------------------------
+
+def test_batch_execute_collects_results(tmp_path, _patch_kernelmanager):
+    _write_nb(tmp_path / "a.ipynb", [_code_cell("x")])
+    _write_nb(tmp_path / "b.ipynb", [_code_cell("y")])
+    _patch_kernelmanager([
+        [_msg("status", execution_state="idle")],
+        [_msg("status", execution_state="idle")],
+    ])
+    results = dotnet_executor.batch_execute(str(tmp_path), pattern="*.ipynb")
+    assert set(results.keys()) == {"a.ipynb", "b.ipynb"}
+    assert all(r["executed"] == 1 for r in results.values())
+
+
+def test_batch_execute_respects_pattern(tmp_path, _patch_kernelmanager):
+    _write_nb(tmp_path / "match.ipynb", [_code_cell("x")])
+    _write_nb(tmp_path / "skip.txt", [_code_cell("x")])  # not .ipynb
+    _patch_kernelmanager([[_msg("status", execution_state="idle")]])
+    results = dotnet_executor.batch_execute(str(tmp_path), pattern="*.ipynb")
+    assert list(results.keys()) == ["match.ipynb"]
+
+
+def test_batch_execute_skipped_notebooks_marked(tmp_path, _patch_kernelmanager):
+    _write_nb(tmp_path / "empty.ipynb", [{"cell_type": "markdown", "source": ["# md"]}])
+    _patch_kernelmanager([])  # kernel never used
+    results = dotnet_executor.batch_execute(str(tmp_path), pattern="*.ipynb")
+    assert results["empty.ipynb"]["skipped"] is True
+    assert results["empty.ipynb"]["total"] == 0


### PR DESCRIPTION
## Summary

Unit test coverage for `scripts/notebook_tools/dotnet_executor.py` — the .NET Interactive cell-by-cell executor (the bridge that gives .NET notebooks real `execution_count` + outputs), consumed by `notebook_helpers.py`. It was a **test orphan**: 0 `test_` importers repo-wide. This suite pins its message-routing logic without a live kernel by mocking `jupyter_client.KernelManager`.

Auto-served from the global pool (Rule 7). Forensic-floor vein — CPU-only, no EPIC gate. Critical untested infra (not another small helper).

## What — 15 tests, CPU-only (0.82s, no .NET runtime / network)

```shell
cd scripts/notebook_tools/tests && python -m pytest test_dotnet_executor.py -q
# 15 passed in 0.82s
```

- **Pure paths:** no-code-cells early return (`skipped=True`); `dry_run` counts already-executed cells **without** constructing `KernelManager` (verified the factory is never called).
- **Message routing (iopub):** `stream` / `execute_result` (carries `execution_count`) / `display_data` (no `execution_count`) / `error` (`ename`/`evalue`/`traceback` with default fallbacks) routed to the right cell; `execution_count` increments `1..N` across cells; an error cell increments `stats['errors']`.
- **Lifecycle:** kernel `shutdown_kernel()` called on both success AND cell-error (`finally` block).
- **Timeout branch:** `cell_timeout=0` → while-loop skipped → `TIMEOUT` stderr appended, cell still counted as executed.
- **`batch_execute`:** glob `*.ipynb`, pattern respected, skipped (no-code-cells) notebooks marked.

The fake kernel feeds scripted iopub message sequences per cell and raises `queue.Empty` after each sequence (so the executor's `except Exception: continue` re-checks the deadline). `time.sleep` (3s kernel-ready wait) is patched out for speed.

## Forensic findings — 2 robustness gaps documented (NOT fixed here)

While reading the module I found two behaviors worth flagging. **Not fixed in this PR** — both are behavior changes on execution infra and would need their own scoped PR with end-to-end verification against a real .NET kernel (which I can't run here):

1. **iopub loop does not filter by `parent_msg_id`.** `kc.get_iopub_msg()` returns *all* iopub messages; the loop consumes whatever's on the channel without checking `msg['parent_header']['msg_id'] == msg_id`. For strict sequential execution this is *mostly* fine, but a stale `status:idle` left in the queue from kernel startup (after the 3s sleep) could make the **first cell break its loop immediately, capturing no outputs**. Canonical jupyter_client usage filters by parent msg_id.

2. **No `interrupt_kernel()` on timeout.** When the per-cell deadline fires, a `TIMEOUT` stderr is appended but the kernel keeps executing the stuck cell — so `kc.execute()` for the *next* cell queues behind it, and **one slow cell effectively hangs all subsequent cells**. A `km.interrupt_kernel()` on the timeout branch would unblock the pipeline.

Either could be its own PR; flagging here for a follow-up.

## Validation

- `pytest` 15 passed (0.82s).
- No live kernel / .NET runtime / network — fully mocked.
- Collision check: file absent on `origin/main`; `gh pr list --state all --search dotnet_executor` = 7 PRs, all about `#load` paths / CSP features / warmup, **none added this test**.

Co-Authored-By: Claude-Code <noreply@anthropic.com>