### PR TITLE
fix(gametheory,#7385): remove stale xfail-strict on Stackelberg asymmetric follower test

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/tests/test_stackelberg.py
+++ b/MyIA.AI.Notebooks/GameTheory/tests/test_stackelberg.py
@@ -135,23 +135,13 @@ class TestStackelbergEquilibrium:
 
     def test_follower_higher_cost_produces_less(self):
         # Suiveur avec cout superieur -> q_F plus basse qu'en symetrique (22.5).
-        # Invariant de direction (valide que la forme close follower soit
-        # correcte ou non) : on n'epingle pas la valeur exacte, seulement la
-        # propriete economique (voir test_asymmetric_follower_equals_reaction_curve
-        # pour l'invariant exact, xfail en attendant #7385).
+        # Invariant de direction : la forme close follower est correcte post-#7385
+        # (voir test_asymmetric_follower_equals_reaction_curve pour l'invariant
+        # exact, et tests/test_stackelberg_asymmetric.py pour la couverture
+        # parametree sur 5 paires asymetriques).
         _, q_F = stackelberg_equilibrium(100, 5, 15)
         assert q_F < 22.5
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "Stackelberg asymmetric follower uses the wrong closed form "
-            "(a + c_L - 2 c_F)/4, which only equals the Cournot reaction curve "
-            "(a - c_F - q_L)/2 when c_L == c_F. Fixed to the reaction curve in "
-            "#7385. xfail-strict flips to xpass-fail once #7385 lands, prompting "
-            "removal of this marker (the follower then best-responds correctly)."
-        ),
-    )
     def test_asymmetric_follower_equals_reaction_curve(self):
         """Le suiveur doit best-responder a la quantite du leader.
 


### PR DESCRIPTION
# fix(gametheory,#7385): remove stale xfail-strict on Stackelberg asymmetric follower test

## Contexte

PR #7385 (MERGED 2026-07-19 sur `831ca9c21`) a corrigé la **closed-form follower quantity** du module Stackelberg pour coûts asymétriques : passage de `(a + c_L - 2 c_F) / 4` (incorrect sauf `c_L == c_F`) à la courbe de réaction de Cournot `(a - c_F - q_L) / 2`.

Le test `test_asymmetric_follower_equals_reaction_curve` dans `tests/test_stackelberg.py` portait **un marqueur `@pytest.mark.xfail(strict=True, ...)`** ajouté en c.617 comme **pin d'attente** documentant que le test était attendu xfail jusqu'au fix #7385. Une fois #7385 mergé, ce marqueur est devenu inapplicable : le test passe naturellement, et `xfail-strict` le transforme en `xpass` qui **flips to FAIL sur CI** (incident cross-lane L723-L2 ★★ documenté par po-2024 c.723 PR #7406 et po-2025 c.630 PR #7412).

## G.1 firsthand scan (L808-L1 ★★★)

```
$ git grep -nE 'xfail\(strict=True\)|@pytest\.mark\.xfail\(.*strict' origin/main \
    -- 'MyIA.AI.Notebooks/GameTheory/'
(0 résultats — UNIQUE cible : tests/test_stackelberg.py:145)

$ git ls-tree -r origin/main --name-only | grep stackelberg
MyIA.AI.Notebooks/GameTheory/examples/stackelberg_leader_follower.py
MyIA.AI.Notebooks/GameTheory/tests/test_stackelberg.py
MyIA.AI.Notebooks/GameTheory/tests/test_stackelberg_asymmetric.py
```

`test_stackelberg_asymmetric.py` (post-#7385) couvre l'invariant follower avec 5 paires parametrize — donc la couverture est préservée même après retrait du décorateur xfail.

## Changement

**Une seule modification dans 1 fichier** :

### `tests/test_stackelberg.py` — retirer le décorateur `@pytest.mark.xfail(strict=True, ...)` devenu inapplicable

```diff
 def test_follower_higher_cost_produces_less(self):
     # Suiveur avec cout superieur -> q_F plus basse qu'en symetrique (22.5).
-    # Invariant de direction (valide que la forme close follower soit
-    # correcte ou non) : on n'epingle pas la valeur exacte, seulement la
-    # propriete economique (voir test_asymmetric_follower_equals_reaction_curve
-    # pour l'invariant exact, xfail en attendant #7385).
+    # Invariant de direction : la forme close follower est correcte post-#7385
+    # (voir test_asymmetric_follower_equals_reaction_curve pour l'invariant
+    # exact, et tests/test_stackelberg_asymmetric.py pour la couverture
+    # parametree sur 5 paires asymetriques).
     _, q_F = stackelberg_equilibrium(100, 5, 15)
     assert q_F < 22.5

-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Stackelberg asymmetric follower uses the wrong closed form "
-        "(a + c_L - 2 c_F)/4, which only equals the Cournot reaction curve "
-        "(a - c_F - q_L)/2 when c_L == c_F. Fixed to the reaction curve in "
-        "#7385. xfail-strict flips to xpass-fail once #7385 lands, prompting "
-        "removal of this marker (the follower then best-responds correctly)."
-    ),
-)
 def test_asymmetric_follower_equals_reaction_curve(self):
```

**Anti-régression §D respectée** : on ne **supprime pas** le test — on retire uniquement le décorateur `xfail-strict` qui était un pin d'attente. Le test continue de s'exécuter et passe naturellement post-#7385 merge. La couverture originale est préservée ; la couverture renforcée est dans `test_stackelberg_asymmetric.py` (5 paires parametrize).

## Preuve d'exécution locale (L721-L1 ★★★ — pas de claim sans preuve)

| Suite | Résultat |
|-------|----------|
| `tests/test_stackelberg.py` ciblé | **33/33 PASSED in 0.69s** |
| `tests/` (full GameTheory) | **412 passed, 1 xfailed in 13.28s** (le xfail restant = `test_named_battle_of_the_sexes_round_trips` dans `test_topology_2x2.py`, non-strict, hors scope) |
| `scripts/notebook_tools/tests/` (anti-régression cross-suite) | **2762/2762 PASSED in 37.61s** |

**Confirmé** : `test_asymmetric_follower_equals_reaction_curve` PASSED (était sous `xfail-strict`, maintenant exécuté normalement).

## Cross-lane coordination

- **po-2024 c.723 PR #7406** : contamination L723-L2 ★★ détectée sur `test_stackelberg` XPASS(strict). Owner-dispatch demandé à po-2026.
- **po-2025 c.630 PR #7412** : contamination identique même fichier, owner-dispatch demandé à po-2026.
- **ai-01 dispatch DM** : owner-dispatch GameTheory cleanup à po-2026 confirmé.
- **Ce PR = résolution de la contamination cross-lane** : après merge, les CI des PRs #7406 (po-2024) et #7412 (po-2025) passeront propres.

## Preuve pure-change (catalogue-pr-hygiene + R3 atomicité)

| Critère | Vérification |
|---------|--------------|
| Fichiers modifiés | 1 (`tests/test_stackelberg.py`) |
| Lignes | **+4 / -14** (R3 atomic, 1 motif) |
| Code production touché | 0 (purement retire un pin d'attente sur test) |
| Marqueurs `CATALOG-STATUS` touchés | 0 (fichier test dans `tests/`, pas de marqueur catalogue) |
| 0 image touchée | ✅ |
| 0 MANIFEST touché | ✅ |
| Encodage | UTF-8 no-BOM (premier octet `0x23` `#`) |
| Branche | `fix/c679-stackelberg-xfail-cleanup` from `origin/main@c76d8b8f2` |
| Divergence vs main | 0 behind / 1 ahead |
| catalog-pr-hygiene R1/R3/R4 | R3 atomic OK, R4 `Closes #7385` (anti-regression résolue intégralement par ce fix) |

## Doctrine respectée

- **#7385** (Stackelberg fix) : alignement — le pin d'attente du fix est retiré maintenant qu'il est mergé.
- **anti-regression §D** : on NE supprime pas le test, on retire uniquement le décorateur xfail-strict qui était un pin d'attente (la logique du test reste intacte, elle vérifie le même invariant).
- **L1502** : worker (po-2026) ne merge pas, ne lance pas `/coordinate`, ne fait pas `gh auth switch`.
- **L515-L1 ★★** : pas de `ScheduleWakeup` (cron-driven cadence).
- **L723-L2 ★★** : résout la contamination cross-lane affectant po-2024 PR #7406 + po-2025 PR #7412.

## Reste doctrine #4365 cleanup P3 (c.678 follow-up)

Doctrine #4365 cleanup P3 prose-anchored backlog ~12 fichiers toujours pending (cf [cycle-c678-prover-session-state-stale-path.md](./cycle-c678-prover-session-state-stale-path.md)) :
- SymbolicAI batch : Tweety + SmartContracts (×2) + Argument_Analysis
- cross-series batch : README + i18n + matching-cv
- GameTheory/SocialChoice batch : SocialChoice/README.md

À dispatcher c.680+ par pivot R6 anti-monotonie.

## G.1 firsthand verify (anti-hallu)

- ✅ `git grep -nE 'xfail\(strict=True\)' origin/main -- 'MyIA.AI.Notebooks/GameTheory/'` = **0 résultat** après edit (vérifié dans worktree).
- ✅ `python -m pytest tests/test_stackelberg.py -v` = 33/33 PASSED.
- ✅ `python -m pytest tests/ -v` (full GameTheory) = 412 passed, 1 xfailed (unrelated).
- ✅ `python -m pytest scripts/notebook_tools/tests/` (anti-régression cross-suite) = 2762/2762 PASSED.
- ✅ `gh pr view 7385 --json state` = `"state": "MERGED"` confirmé.
- ✅ Pas de marqueur `CATALOG-STATUS` modifié (fichier test dans `tests/`, pas de marqueur catalogue).
