### PR TITLE
test(gametheory): drop xfail-strict on Stackelberg follower invariant now that #7385 landed

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/tests/test_stackelberg.py
+++ b/MyIA.AI.Notebooks/GameTheory/tests/test_stackelberg.py
@@ -138,28 +138,19 @@ class TestStackelbergEquilibrium:
         # Invariant de direction (valide que la forme close follower soit
         # correcte ou non) : on n'epingle pas la valeur exacte, seulement la
         # propriete economique (voir test_asymmetric_follower_equals_reaction_curve
-        # pour l'invariant exact, xfail en attendant #7385).
+        # pour l'invariant exact, verifie depuis #7385).
         _, q_F = stackelberg_equilibrium(100, 5, 15)
         assert q_F < 22.5
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "Stackelberg asymmetric follower uses the wrong closed form "
-            "(a + c_L - 2 c_F)/4, which only equals the Cournot reaction curve "
-            "(a - c_F - q_L)/2 when c_L == c_F. Fixed to the reaction curve in "
-            "#7385. xfail-strict flips to xpass-fail once #7385 lands, prompting "
-            "removal of this marker (the follower then best-responds correctly)."
-        ),
-    )
     def test_asymmetric_follower_equals_reaction_curve(self):
         """Le suiveur doit best-responder a la quantite du leader.
 
         Par definition de Stackelberg, q_F = (a - c_F - q_L) / 2 (courbe de
-        reaction de Cournot evaluee au q_L d'equilibre). Le module courant
-        utilise (a + c_L - 2 c_F) / 4, egale a la courbe de reaction seulement
-        quand c_L == c_F ; corrige dans #7385. Avec (100, 5, 15) : q_L = 52.5
-        (leader, deja correct), q_F vraie = 16.25, q_F buggy = 18.75.
+        reaction de Cournot evaluee au q_L d'equilibre). Avant #7385, le module
+        utilisait la forme close (a + c_L - 2 c_F) / 4, egale a la courbe de
+        reaction seulement quand c_L == c_F ; #7385 a aligne le suiveur sur sa
+        courbe de reaction. Avec (100, 5, 15) : q_L = 52.5 (leader, deja
+        correct), q_F = 16.25.
         """
         a, c_L, c_F = 100, 5, 15
         q_L, q_F = stackelberg_equilibrium(a, c_L, c_F)


### PR DESCRIPTION
## Summary

`test_stackelberg.py::test_asymmetric_follower_equals_reaction_curve` épingle `q_F == (a - c_F - q_L)/2 = 16.25` (la courbe de réaction de Cournot) sous un `@pytest.mark.xfail(strict=True)` qui s'attendait à ce que le test **échoue** tant que la forme close follower n'était pas corrigée. Ce fix a été livré dans **#7385** (Stackelberg asymmetric follower quantity), **MERGED sur main**. Le marker xfail-strict a donc flippé en XPASS-strict → le test **FAIL en CI** maintenant (CI rouge).

Cette PR supprime le marker et laisse l'invariant s'asserter inconditionnellement. C'est le **follow-up exact prévu par le design du marker** (leçon c.535 : `xfail(strict=True)` signale le moment précis où un bug latent fixé atterrit, merge-order-independent).

## Preuve firsthand (G.1)

Reproduit sur worktree frais `origin/main` (`c76d8b8f2`) :

```
$ pytest test_stackelberg.py::TestStackelbergEquilibrium::test_asymmetric_follower_equals_reaction_curve
FAILED ... [XPASS(strict)] Stackelberg asymmetric follower uses the wrong
closed form ... Fixed to the reaction curve in #7385. xfail-strict flips
to xpass-fail once #7385 lands, prompting removal of this marker.
1 failed in 0.36s
```

Après suppression du marker :
```
$ pytest test_stackelberg.py -v
33 passed in 0.58s
```
(Le test anciennement xfailé maintenant PASSED, 32 autres verts.)

## État des PRs liées (firsthand)

- **#7351** (mon PR Stackelberg invariant, porteur du marker) : MERGED 2026-07-19T16:20:08Z.
- **#7385** (po-2024 fix follower quantity) : MERGED 2026-07-19T16:23:14Z.

## Changement

- Suppression du décorateur `@pytest.mark.xfail(strict=True, ...)` (9 lignes).
- Docstring + commentaires mis au passé (« avant #7385 le module utilisait... » / « vérifié depuis #7385 ») au lieu du présent conditionnel (« corrige dans #7385 » / « xfail en attendant #7385 »).
- **Aucun changement de logique de test** au-delà du retrait du décorateur.

## Hygiène

- Three-dot diff vs `origin/main` = **1 fichier, +6/−15**.
- **0 CRLF** (LF, byte-aligned avec origin/main).
- **Catalogue byte-identique** (HARD 1).
- Worktree frais `C:/dev/CoursIA-stackelberg-xfail` off `origin/main`.

## Origine du signal

Signalé par **po-2024 c.696** [ASK po-2026] : son PR #7427 (french_politics coverage) a observé le XPASS-strict en side-finding et déféré vers po-2026 (owner de #7351 Stackelberg invariant). `See #7385`.

## R6 transparence

Genre **correction-follow-up** (CI rouge → vert, signalé cross-worker, owner = po-2026). Famille GameTheory/Stackelberg (touchée c.535 par mon invariant pin — c'est précisément parce que c'est MON PR que ce follow-up me revient). Pas une 6e entrée monotonique : un cleanup ciblé one-off en réponse à un signal concret, pas du tunnelizing. R6 caps cleanup/doc non concernés (correction, pas nettoyage).

Co-Authored-By: Claude <noreply@anthropic.com>
