### PR TITLE
fix(qc,#6891): strip fabricated outputs from 8 quantbooks + add strip tool

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/AllWeather/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/AllWeather/quantbook.ipynb
@@ -251,17 +251,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Allocation             Sharpe     CAGR    MaxDD      Vol\n-------------------------------------------------------\nRow 1                        0.590    7.7%  -13.0%   10.3%\nRow 2                        0.690    9.5%  -14.5%   10.9%\nRow 3                        0.770   11.2%  -15.8%   11.3%\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "allocations = {\n",
     "    'Dalio Original': {'SPY': 0.30, 'TLT': 0.40, 'IEF': 0.15, 'GLD': 0.075, 'DBC': 0.075},\n",
@@ -288,6 +280,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> **Sortie strippee** (FABRICATED `Row N` / blank PNG). Re-execution QC Cloud recherche kernel requise -- see #6891.\n",
+    "> Code preserve pour tracabilite. Side A = strip honnete, Side B = re-execution (hors scope ce PR).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Verdict H1: Allocations statiques\n",
     "\n",
     "L'allocation actuelle (v5: SPY30/IEF30/GLD30/XLP10) devrait confirmer sa superiorite.\n",
@@ -306,17 +306,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Rebalancement               Sharpe     CAGR    MaxDD\n--------------------------------------------------\nRow 1                        0.590    7.7%  -13.0%\nRow 2                        0.690    9.5%  -14.5%\nRow 3                        0.770   11.2%  -15.8%\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "best_alloc = {'SPY': 0.30, 'IEF': 0.30, 'GLD': 0.30, 'XLP': 0.10}\n",
     "\n",
@@ -345,6 +337,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> **Sortie strippee** (FABRICATED `Row N` / blank PNG). Re-execution QC Cloud recherche kernel requise -- see #6891.\n",
+    "> Code preserve pour tracabilite. Side A = strip honnete, Side B = re-execution (hors scope ce PR).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Verdict H2: Rebalancement\n",
     "\n",
     "Drift 3% devrait confirmer sa superiorite (règle #8 du backlog).\n",
@@ -363,17 +363,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Config                      Sharpe     CAGR    MaxDD\n--------------------------------------------------\nRow 1                        0.590    7.7%  -13.0%\nRow 2                        0.690    9.5%  -14.5%\nRow 3                        0.770   11.2%  -15.8%\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(f\"{'Config':<25} {'Sharpe':>8} {'CAGR':>8} {'MaxDD':>8}\")\n",
     "print(\"-\" * 50)\n",
@@ -399,6 +391,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> **Sortie strippee** (FABRICATED `Row N` / blank PNG). Re-execution QC Cloud recherche kernel requise -- see #6891.\n",
+    "> Code preserve pour tracabilite. Side A = strip honnete, Side B = re-execution (hors scope ce PR).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Verdict H3: SMA overlay\n",
     "\n",
     "Attention: le backlog règle #8 indique que drift rebalancing > SMA overlay pour\n",
@@ -415,27 +415,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "output_type": "display_data",
-     "data": {
-      "text/plain": [
-       "<Figure size 1600x1000 with 2 Axes>"
-      ],
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
-     },
-     "metadata": {}
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Graphique sauvegarde.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "fig, axes = plt.subplots(1, 3, figsize=(18, 6))\n",
     "\n",
@@ -468,6 +450,14 @@
     "plt.savefig('allweather_quantbook_analysis.png', dpi=150, bbox_inches='tight')\n",
     "plt.show()\n",
     "print(\"Graphique sauvegarde.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Sortie strippee** (FABRICATED `Row N` / blank PNG). Re-execution QC Cloud recherche kernel requise -- see #6891.\n",
+    "> Code preserve pour tracabilite. Side A = strip honnete, Side B = re-execution (hors scope ce PR).\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/QuantConnect/projects/DualMomentum/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/DualMomentum/quantbook.ipynb
@@ -171,16 +171,16 @@
     "\n",
     "print(\"Fonctions definies.\")"
    ],
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Lookback               Sharpe     CAGR    MaxDD\n---------------------------------------------\nRow 1                        0.490    8.9%  -11.5%\nRow 2                        0.570    8.6%  -10.9%\nRow 3                        0.660    8.3%  -15.3%\n"
-     ]
-    }
-   ],
-   "execution_count": 3
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Sortie strippee** (FABRICATED `Row N` / blank PNG). Re-execution QC Cloud recherche kernel requise -- see #6891.\n",
+    "> Code preserve pour tracabilite. Side A = strip honnete, Side B = re-execution (hors scope ce PR).\n"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -462,19 +462,16 @@
     "plt.savefig('dualmomentum_quantbook_analysis.png', dpi=150, bbox_inches='tight')\n",
     "plt.show()"
    ],
-   "outputs": [
-    {
-     "output_type": "display_data",
-     "data": {
-      "text/plain": [
-       "<Figure size 1600x1000 with 2 Axes>"
-      ],
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
-     },
-     "metadata": {}
-    }
-   ],
-   "execution_count": 9
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Sortie strippee** (FABRICATED `Row N` / blank PNG). Re-execution QC Cloud recherche kernel requise -- see #6891.\n",
+    "> Code preserve pour tracabilite. Side A = strip honnete, Side B = re-execution (hors scope ce PR).\n"
+   ]
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/QuantConnect/projects/EMA-Cross-Alpha/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/EMA-Cross-Alpha/quantbook.ipynb
@@ -389,27 +389,9 @@
   {
    "cell_id": "cell-16",
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "output_type": "display_data",
-     "data": {
-      "text/plain": [
-       "<Figure size 1600x500 with 2 Axes>"
-      ],
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
-     },
-     "metadata": {}
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Graphique sauvegardé.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "fig, axes = plt.subplots(1, 2, figsize=(16, 5))\n",
     "\n",
@@ -435,6 +417,14 @@
     "plt.savefig('ema_cross_analysis.png', dpi=150, bbox_inches='tight')\n",
     "plt.show()\n",
     "print(\"Graphique sauvegardé.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Sortie strippee** (FABRICATED `Row N` / blank PNG). Re-execution QC Cloud recherche kernel requise -- see #6891.\n",
+    "> Code preserve pour tracabilite. Side A = strip honnete, Side B = re-execution (hors scope ce PR).\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/QuantConnect/projects/FuturesTrend/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/FuturesTrend/quantbook.ipynb
@@ -248,16 +248,16 @@
     "    results_donchian[name] = r\n",
     "    print(f\"{name:<15} {r['sharpe']:>8.3f} {r['cagr']:>7.1%} {r['max_dd']:>7.1%} {r['n_trades']:>7} {r['win_rate']:>5.0%}\")"
    ],
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Config                      Sharpe     CAGR    MaxDD\n--------------------------------------------------\nRow 1                        0.460    8.7%  -12.3%\nRow 2                        0.530    7.2%  -10.7%\nRow 3                        0.580    7.6%  -10.9%\n"
-     ]
-    }
-   ],
-   "execution_count": 4
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Sortie strippee** (FABRICATED `Row N` / blank PNG). Re-execution QC Cloud recherche kernel requise -- see #6891.\n",
+    "> Code preserve pour tracabilite. Side A = strip honnete, Side B = re-execution (hors scope ce PR).\n"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -293,16 +293,16 @@
     "    results_sma[name] = r\n",
     "    print(f\"{name:<15} {r['sharpe']:>8.3f} {r['cagr']:>7.1%} {r['max_dd']:>7.1%} {r['n_trades']:>7}\")"
    ],
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Config                      Sharpe     CAGR    MaxDD\n--------------------------------------------------\nRow 1                        0.380    8.0%  -11.9%\nRow 2                        0.450    6.6%  -10.2%\nRow 3                        0.500    7.0%  -10.5%\nRow 4                        0.610    9.9%  -13.1%\nRow 5                        0.690    8.5%  -13.5%\n"
-     ]
-    }
-   ],
-   "execution_count": 5
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Sortie strippee** (FABRICATED `Row N` / blank PNG). Re-execution QC Cloud recherche kernel requise -- see #6891.\n",
+    "> Code preserve pour tracabilite. Side A = strip honnete, Side B = re-execution (hors scope ce PR).\n"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -334,16 +334,16 @@
     "    results_pos[name] = r\n",
     "    print(f\"{name:<15} {r['sharpe']:>8.3f} {r['cagr']:>7.1%} {r['max_dd']:>7.1%}\")"
    ],
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Config                      Sharpe     CAGR    MaxDD\n--------------------------------------------------\nRow 1                        0.380    8.0%  -11.9%\nRow 2                        0.450    6.6%  -10.2%\nRow 3                        0.500    7.0%  -10.5%\nRow 4                        0.610    9.9%  -13.1%\n"
-     ]
-    }
-   ],
-   "execution_count": 6
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Sortie strippee** (FABRICATED `Row N` / blank PNG). Re-execution QC Cloud recherche kernel requise -- see #6891.\n",
+    "> Code preserve pour tracabilite. Side A = strip honnete, Side B = re-execution (hors scope ce PR).\n"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -387,16 +387,16 @@
     "    results_univ[name] = r\n",
     "    print(f\"{name:<20} {r['sharpe']:>8.3f} {r['cagr']:>7.1%} {r['max_dd']:>7.1%}\")"
    ],
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Univers                     Sharpe     CAGR    MaxDD\n--------------------------------------------------\nRow 1                        0.460    8.7%  -12.3%\nRow 2                        0.530    7.2%  -10.7%\nRow 3                        0.580    7.6%  -10.9%\n"
-     ]
-    }
-   ],
-   "execution_count": 7
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Sortie strippee** (FABRICATED `Row N` / blank PNG). Re-execution QC Cloud recherche kernel requise -- see #6891.\n",
+    "> Code preserve pour tracabilite. Side A = strip honnete, Side B = re-execution (hors scope ce PR).\n"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -457,19 +457,16 @@
     "plt.savefig('futurestrend_quantbook_analysis.png', dpi=150, bbox_inches='tight')\n",
     "plt.show()"
    ],
-   "outputs": [
-    {
-     "output_type": "display_data",
-     "data": {
-      "text/plain": [
-       "<Figure size 1600x1000 with 2 Axes>"
-      ],
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
-     },
-     "metadata": {}
-    }
-   ],
-   "execution_count": 8
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Sortie strippee** (FABRICATED `Row N` / blank PNG). Re-execution QC Cloud recherche kernel requise -- see #6891.\n",
+    "> Code preserve pour tracabilite. Side A = strip honnete, Side B = re-execution (hors scope ce PR).\n"
+   ]
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/QuantConnect/projects/MomentumStrategy/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/MomentumStrategy/quantbook.ipynb
@@ -194,16 +194,16 @@
     "\n",
     "print(\"Fonctions definies.\")"
    ],
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Lookback               Sharpe     CAGR    MaxDD\n---------------------------------------------\nRow 1                        0.440    7.5%  -11.2%\nRow 2                        0.520    8.2%  -10.6%\nRow 3                        0.580    8.6%  -14.9%\n"
-     ]
-    }
-   ],
-   "execution_count": 3
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Sortie strippee** (FABRICATED `Row N` / blank PNG). Re-execution QC Cloud recherche kernel requise -- see #6891.\n",
+    "> Code preserve pour tracabilite. Side A = strip honnete, Side B = re-execution (hors scope ce PR).\n"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -434,19 +434,16 @@
     "plt.savefig('momentumstrategy_quantbook_analysis.png', dpi=150, bbox_inches='tight')\n",
     "plt.show()"
    ],
-   "outputs": [
-    {
-     "output_type": "display_data",
-     "data": {
-      "text/plain": [
-       "<Figure size 1600x1000 with 2 Axes>"
-      ],
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
-     },
-     "metadata": {}
-    }
-   ],
-   "execution_count": 8
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Sortie strippee** (FABRICATED `Row N` / blank PNG). Re-execution QC Cloud recherche kernel requise -- see #6891.\n",
+    "> Code preserve pour tracabilite. Side A = strip honnete, Side B = re-execution (hors scope ce PR).\n"
+   ]
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/QuantConnect/projects/RiskParity/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/RiskParity/quantbook.ipynb
@@ -302,16 +302,16 @@
     "    results_vol[f'{vw}d'] = r\n",
     "    print(f\"{f'{vw}d':<15} {r['sharpe']:>8.3f} {r['cagr']:>7.1%} {r['max_dd']:>7.1%} {r['vol']:>7.1%}\")"
    ],
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Vol Window        Sharpe     CAGR    MaxDD      Vol\n--------------------------------------------------\nRow 1                        0.600    9.8%  -12.0%\nRow 2                        0.700   10.6%  -14.5%\nRow 3                        0.770    9.2%  -13.9%\nRow 4                        0.850    9.8%  -15.2%\nRow 5                        0.950   12.6%  -12.8%\n"
-     ]
-    }
-   ],
-   "execution_count": 5
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Sortie strippee** (FABRICATED `Row N` / blank PNG). Re-execution QC Cloud recherche kernel requise -- see #6891.\n",
+    "> Code preserve pour tracabilite. Side A = strip honnete, Side B = re-execution (hors scope ce PR).\n"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -351,16 +351,16 @@
     "    results_rebal[name] = r\n",
     "    print(f\"{name:<20} {r['sharpe']:>8.3f} {r['cagr']:>7.1%} {r['max_dd']:>7.1%}\")"
    ],
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Rebalancement               Sharpe     CAGR    MaxDD\n--------------------------------------------------\nRow 1                        0.680   10.4%  -12.4%\nRow 2                        0.780   11.2%  -14.9%\nRow 3                        0.850    9.8%  -14.2%\n"
-     ]
-    }
-   ],
-   "execution_count": 6
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Sortie strippee** (FABRICATED `Row N` / blank PNG). Re-execution QC Cloud recherche kernel requise -- see #6891.\n",
+    "> Code preserve pour tracabilite. Side A = strip honnete, Side B = re-execution (hors scope ce PR).\n"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -405,16 +405,16 @@
     "    results_univ[name] = r\n",
     "    print(f\"{name:<25} {r['sharpe']:>8.3f} {r['cagr']:>7.1%} {r['max_dd']:>7.1%}\")"
    ],
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Univers                     Sharpe     CAGR    MaxDD\n--------------------------------------------------\nRow 1                        0.680   10.4%  -12.4%\nRow 2                        0.780   11.2%  -14.9%\nRow 3                        0.850    9.8%  -14.2%\n"
-     ]
-    }
-   ],
-   "execution_count": 7
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Sortie strippee** (FABRICATED `Row N` / blank PNG). Re-execution QC Cloud recherche kernel requise -- see #6891.\n",
+    "> Code preserve pour tracabilite. Side A = strip honnete, Side B = re-execution (hors scope ce PR).\n"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -467,19 +467,16 @@
     "plt.savefig('riskparity_quantbook_analysis.png', dpi=150, bbox_inches='tight')\n",
     "plt.show()"
    ],
-   "outputs": [
-    {
-     "output_type": "display_data",
-     "data": {
-      "text/plain": [
-       "<Figure size 1600x1000 with 2 Axes>"
-      ],
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
-     },
-     "metadata": {}
-    }
-   ],
-   "execution_count": 8
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Sortie strippee** (FABRICATED `Row N` / blank PNG). Re-execution QC Cloud recherche kernel requise -- see #6891.\n",
+    "> Code preserve pour tracabilite. Side A = strip honnete, Side B = re-execution (hors scope ce PR).\n"
+   ]
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/QuantConnect/projects/SectorMomentum/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/SectorMomentum/quantbook.ipynb
@@ -109,17 +109,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Lookback               Sharpe     CAGR    MaxDD\n---------------------------------------------\nRow 1                        0.410    7.3%  -11.1%\nRow 2                        0.460    8.7%  -11.3%\nRow 3                        0.540    7.3%  -10.7%\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "def compute_momentum(prices, lookback):\n",
     "    return prices / prices.shift(lookback) - 1\n",
@@ -188,6 +180,14 @@
     "            'Sharpe': f'{sharpe:.3f}', 'MaxDD': f'{dd:.1%}'}\n",
     "\n",
     "print(\"Fonctions definies.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Sortie strippee** (FABRICATED `Row N` / blank PNG). Re-execution QC Cloud recherche kernel requise -- see #6891.\n",
+    "> Code preserve pour tracabilite. Side A = strip honnete, Side B = re-execution (hors scope ce PR).\n"
    ]
   },
   {
@@ -354,20 +354,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "output_type": "display_data",
-     "data": {
-      "text/plain": [
-       "<Figure size 1600x1000 with 2 Axes>"
-      ],
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
-     },
-     "metadata": {}
-    }
-   ],
+   "outputs": [],
    "source": [
     "fig, axes = plt.subplots(2, 1, figsize=(14, 10))\n",
     "\n",
@@ -403,6 +392,14 @@
     "plt.tight_layout()\n",
     "plt.savefig('sectormomentum_quantbook_analysis.png', dpi=150, bbox_inches='tight')\n",
     "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Sortie strippee** (FABRICATED `Row N` / blank PNG). Re-execution QC Cloud recherche kernel requise -- see #6891.\n",
+    "> Code preserve pour tracabilite. Side A = strip honnete, Side B = re-execution (hors scope ce PR).\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/QuantConnect/projects/TurnOfMonth/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/TurnOfMonth/quantbook.ipynb
@@ -195,17 +195,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Config                      Sharpe     CAGR    MaxDD\n--------------------------------------------------\nRow 1                        0.530    7.2%  -12.7%\nRow 2                        0.620   10.0%  -15.1%\nRow 3                        0.720    8.8%  -13.6%\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "base_universe = ['SPY', 'QQQ']\n",
     "\n",
@@ -218,6 +210,14 @@
     "    name = f'{before}/{after}'\n",
     "    results_window[name] = r\n",
     "    print(f\"{name:<15} {r['sharpe']:>8.3f} {r['cagr']:>7.1%} {r['max_dd']:>7.1%} {r['pct_time']:>7.0%}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Sortie strippee** (FABRICATED `Row N` / blank PNG). Re-execution QC Cloud recherche kernel requise -- see #6891.\n",
+    "> Code preserve pour tracabilite. Side A = strip honnete, Side B = re-execution (hors scope ce PR).\n"
    ]
   },
   {
@@ -241,17 +241,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Univers                     Sharpe     CAGR    MaxDD\n--------------------------------------------------\nRow 1                        0.530    7.2%  -12.7%\nRow 2                        0.620   10.0%  -15.1%\nRow 3                        0.720    8.8%  -13.6%\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "universes = {\n",
     "    'SPY seul': ['SPY'],\n",
@@ -275,6 +267,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> **Sortie strippee** (FABRICATED `Row N` / blank PNG). Re-execution QC Cloud recherche kernel requise -- see #6891.\n",
+    "> Code preserve pour tracabilite. Side A = strip honnete, Side B = re-execution (hors scope ce PR).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Verdict H2\n",
     "\n",
     "research.ipynb a montre que QQQ est essentiel (tech bull 2015-2026). SPY seul a un\n",
@@ -290,17 +290,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Config                      Sharpe     CAGR    MaxDD\n--------------------------------------------------\nRow 1                        0.450    6.6%  -12.3%\nRow 2                        0.540    9.3%  -14.7%\nRow 3                        0.640    8.1%  -13.2%\nRow 4                        0.690   10.5%  -11.5%\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(f\"{'Leverage':<15} {'Sharpe':>8} {'CAGR':>8} {'MaxDD':>8}\")\n",
     "print(\"-\" * 40)\n",
@@ -311,6 +303,14 @@
     "    name = f'{lev:.2f}x'\n",
     "    results_lev[name] = r\n",
     "    print(f\"{name:<15} {r['sharpe']:>8.3f} {r['cagr']:>7.1%} {r['max_dd']:>7.1%}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Sortie strippee** (FABRICATED `Row N` / blank PNG). Re-execution QC Cloud recherche kernel requise -- see #6891.\n",
+    "> Code preserve pour tracabilite. Side A = strip honnete, Side B = re-execution (hors scope ce PR).\n"
    ]
   },
   {
@@ -332,17 +332,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Config                      Sharpe     CAGR    MaxDD\n--------------------------------------------------\nRow 1                        0.530    7.2%  -12.7%\nRow 2                        0.620   10.0%  -15.1%\nRow 3                        0.720    8.8%  -13.6%\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(f\"{'Regime Filter':<20} {'Sharpe':>8} {'CAGR':>8} {'MaxDD':>8} {'Time%':>8}\")\n",
     "print(\"-\" * 55)\n",
@@ -352,6 +344,14 @@
     "    r = backtest_tom(closes, base_universe, sma_filter=sma)\n",
     "    results_regime[name] = r\n",
     "    print(f\"{name:<20} {r['sharpe']:>8.3f} {r['cagr']:>7.1%} {r['max_dd']:>7.1%} {r['pct_time']:>7.0%}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Sortie strippee** (FABRICATED `Row N` / blank PNG). Re-execution QC Cloud recherche kernel requise -- see #6891.\n",
+    "> Code preserve pour tracabilite. Side A = strip honnete, Side B = re-execution (hors scope ce PR).\n"
    ]
   },
   {
@@ -376,17 +376,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Config                      Sharpe     CAGR    MaxDD\n--------------------------------------------------\nRow 1                        0.530    7.2%  -12.7%\nRow 2                        0.620   10.0%  -15.1%\nRow 3                        0.720    8.8%  -13.6%\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Test par sous-periodes\n",
     "periods = {\n",
@@ -413,25 +405,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> **Sortie strippee** (FABRICATED `Row N` / blank PNG). Re-execution QC Cloud recherche kernel requise -- see #6891.\n",
+    "> Code preserve pour tracabilite. Side A = strip honnete, Side B = re-execution (hors scope ce PR).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## 8. Visualisation"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "output_type": "display_data",
-     "data": {
-      "text/plain": [
-       "<Figure size 1600x1000 with 2 Axes>"
-      ],
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
-     },
-     "metadata": {}
-    }
-   ],
+   "outputs": [],
    "source": [
     "fig, axes = plt.subplots(2, 2, figsize=(16, 10))\n",
     "\n",
@@ -470,6 +459,14 @@
     "plt.tight_layout()\n",
     "plt.savefig('turnofmonth_quantbook_analysis.png', dpi=150, bbox_inches='tight')\n",
     "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Sortie strippee** (FABRICATED `Row N` / blank PNG). Re-execution QC Cloud recherche kernel requise -- see #6891.\n",
+    "> Code preserve pour tracabilite. Side A = strip honnete, Side B = re-execution (hors scope ce PR).\n"
    ]
   },
   {

--- a/scripts/notebook_tools/strip_fabricated_quantbook_outputs.py
+++ b/scripts/notebook_tools/strip_fabricated_quantbook_outputs.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+"""Strip fabricated text/PNG outputs from quantbook.ipynb notebooks (cf #6891, Side A).
+
+Pourquoi cet outil existe
+-------------------------
+Le detecteur `detect_fabricated_outputs.py` (axe 2, registre #3801) identifie
+les cellules code dont les `outputs` contiennent des placeholders fabriques
+(`Row N`) ou des dataframes backtest-entierement-a-0.0. Pour les 8 quantbooks
+QuantConnect de #6891 (AllWeather / DualMomentum / FuturesTrend / TurnOfMonth /
+RiskParity / MomentumStrategy / SectorMomentum / EMA-Cross-Alpha), ces sorties
+sont de la **fabrication documentee** -- le code source de la cellule ne peut
+pas les avoir produites (def pure, plt.subplots sans show, etc.).
+
+Action legitime scope quantbook QC (exception explicite a secrets-hygiene regle
+6 "JAMAIS hand-editer une SORTIE de cellule") parce que :
+
+  1. Les quantbooks QC utilisent l'API QuantBook() (qb.add_equity, qb.history)
+     non-executable via Papermill local (cf [[feedback-qc-cloud-exec-modalities]]).
+  2. Le moteur d'execution canonique = QC Cloud research kernel.
+  3. La fabrication = placeholder commited pour faire croire a un resultat de
+     backtest qui n'a pas eu lieu, ce qui EST la violation C.2 qu'on Stop&Repair.
+
+L'outil :
+
+  - REUTILISE `detect_fabricated_outputs.detect_cell()` (single source of truth)
+  - PRESCORE le SOURCE de la cellule intact (jamais de modification du code)
+  - VIDE les `outputs` des cellules flaggees + met `execution_count` a null
+  - INSERE une cellule markdown **apres** la cellule strippee (ne modifie pas
+    la numerotation des cellules suivantes en inseree AVANT)
+  - DRY-RUN par defaut (--apply pour commiter le strip)
+
+Ce qu'il NE FAIT PAS
+--------------------
+- NE MODIFIE PAS le source des cellules (Stop&Repair : corriger la cause = le
+  detecteur a deja signale la fabrication, et la vraie correction = re-executer
+  dans QC Cloud -- voir Side B planifie, hors scope ce PR).
+- NE TOUCHE PAS aux notebooks non-QuantBook (la fabrication peut etre un faux
+  positif pedagogique, on laisse l'auteur corriger).
+- NE SCRUBBE PAS les notebooks `.ipynb` non-quantbook (cf exceptions explicites
+  dans secrets-hygiene rule 6 : quantbooks QC + metadata.papermill basename).
+
+Usage
+-----
+    python strip_fabricated_quantbook_outputs.py --list                       # liste les 8 quantbooks cibles
+    python strip_fabricated_quantbook_outputs.py --check                      # dry-run + rapport JSON (axe 2 only)
+    python strip_fabricated_quantbook_outputs.py --check --include-blank-png  # dry-run + axe 1 blank PNG aussi
+    python strip_fabricated_quantbook_outputs.py --apply --include-blank-png  # strip effectif + insertion markdown
+    python strip_fabricated_quantbook_outputs.py --nb DualMomentum --apply   # un seul notebook
+
+Sortie stdout (--check) : tableau par notebook (kernel, n cells flagged, n cells will be stripped,
+cells indexes) pour audit. Sortie stderr : warning si 0 quantbook trouve.
+
+Lien
+----
+Issue: https://github.com/jsboige/CoursIA/issues/6891
+Detector: scripts/notebook_tools/detect_fabricated_outputs.py (axe 2 sibling)
+PR initial: split du strip par notebook = 1 PR par quantbook (R3 strict).
+PR groupé : 8 quantbooks = 1 PR (R3 atomicite = 1 type d'action = strip).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# Permettre l'import du détecteur sibling (meme dossier).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import detect_fabricated_outputs as detector  # noqa: E402
+
+# Les 8 quantbooks cibles de #6891 (cf body issue, distribution documentee).
+# EMA-Cross-Alpha est inclus bien que le detecteur ne le flag pas (il porte un
+# blank PNG 96 bytes -- couvert par detect_blank_figures axe 1, pas par ce
+# detecteur-ci). Pour coherence du strip on le traite separement via
+# --include-blank-png (desactive par defaut, le blank PNG est gere par axe 1).
+DEFAULT_TARGETS = [
+    "AllWeather",
+    "DualMomentum",
+    "FuturesTrend",
+    "TurnOfMonth",
+    "RiskParity",
+    "MomentumStrategy",
+    "SectorMomentum",
+    "EMA-Cross-Alpha",
+]
+
+
+def _resolve_quantbook_paths(
+    repo_root: Path,
+    targets: list[str],
+    family: str = "QuantConnect",
+) -> list[Path]:
+    """Resolve <repo>/MyIA.AI.Notebooks/<family>/projects/<target>/quantbook.ipynb."""
+    base = repo_root / "MyIA.AI.Notebooks" / family / "projects"
+    out: list[Path] = []
+    missing: list[str] = []
+    for t in targets:
+        p = base / t / "quantbook.ipynb"
+        if not p.exists():
+            missing.append(str(p))
+            continue
+        out.append(p)
+    if missing:
+        print(
+            f"[WARN] {len(missing)} target(s) not found: {missing}",
+            file=sys.stderr,
+        )
+    return out
+
+
+def _strip_cell_outputs(cell: dict) -> bool:
+    """Vide outputs/execution_count d'une cellule code. Retourne True si modifie.
+
+    Preserve : source, metadata, cell_type. Modifie : outputs -> [], execution_count -> None.
+    """
+    if cell.get("cell_type") != "code":
+        return False
+    changed = False
+    if cell.get("outputs"):
+        cell["outputs"] = []
+        changed = True
+    if cell.get("execution_count") is not None:
+        cell["execution_count"] = None
+        changed = True
+    return changed
+
+
+def _make_warning_cell(note: str) -> dict:
+    """Construit la cellule markdown d'avertissement inseree APRES le strip.
+
+    Format volontairement compact pour minimiser le churn visuel du diff.
+    Format FR (conformite readme-french-first).
+    """
+    return {
+        "cell_type": "markdown",
+        "metadata": {},
+        "source": [
+            f"> **Sortie strippee** (FABRICATED `Row N` / blank PNG). "
+            f"Re-execution QC Cloud recherche kernel requise -- see {note}.\n",
+            "> "
+            "Code preserve pour tracabilite. "
+            "Side A = strip honnete, Side B = re-execution (hors scope ce PR).\n",
+        ],
+    }
+
+
+# Seuil blank PNG (axe 1 sibling `detect_blank_figures.py`) -- un image/png
+# de moins de 200 bytes = matplotlib figure vide, signature canonique d'un
+# plot qui n'a pas eu lieu. Permet de couvrir EMA-Cross-Alpha cell [17] (96b).
+BLANK_PNG_THRESHOLD = 200
+
+
+def _has_blank_png(cell: dict) -> bool:
+    """True si la cellule contient une sortie image/png < BLANK_PNG_THRESHOLD bytes."""
+    for out in cell.get("outputs", []) or []:
+        if not isinstance(out, dict):
+            continue
+        data = out.get("data", {})
+        png = data.get("image/png")
+        if isinstance(png, str) and len(png) < BLANK_PNG_THRESHOLD:
+            return True
+    return False
+
+
+def _plan_strip(nb: dict, include_blank_png: bool = False) -> list[dict]:
+    """Identifie les cellules a stripper et les cellules markdown a inserer.
+
+    Par defaut, ne flag que les cellules avec detections `detect_fabricated_outputs`
+    (axe 2 : Row N + zero_stats_dataframe). Avec `include_blank_png=True`, on
+    inclut aussi les sorties image/png de moins de 200 bytes (axe 1 sibling).
+
+    Retourne une liste de patches, chacun avec :
+        cell_index : index de la cellule code flagged (AVANT insertion)
+        findings   : liste des findings (detecteur axe 2 + axe 1 eventuel)
+        insert_after : True si on doit inserer une cellule markdown apres
+    """
+    plan = []
+    for ci, cell in enumerate(nb.get("cells", [])):
+        if cell.get("cell_type") != "code":
+            continue
+        findings = detector.detect_cell(cell)
+        if include_blank_png and _has_blank_png(cell):
+            findings = findings + [{"signal": "blank_png_axe1"}]
+        if not findings:
+            continue
+        # Strip + insert warning
+        plan.append({
+            "cell_index": ci,
+            "findings": findings,
+            "insert_warning": True,
+        })
+    return plan
+
+
+def _apply_plan(nb: dict, plan: list[dict], note: str) -> dict:
+    """Applique le plan : strip + insertion des cellules warning.
+
+    IMPORTANT: on parcourt le plan en ordre DECROISSANT d'index pour eviter que
+    l'insertion d'une cellule markdown ne decale les indices suivants.
+
+    Retourne un dict avec : n_stripped, n_inserted, modified (bool).
+    """
+    n_stripped = 0
+    n_inserted = 0
+    # Tri decroissant pour stabilite d'index pendant l'insertion.
+    plan_sorted = sorted(plan, key=lambda p: p["cell_index"], reverse=True)
+    for patch in plan_sorted:
+        ci = patch["cell_index"]
+        cell = nb["cells"][ci]
+        if _strip_cell_outputs(cell):
+            n_stripped += 1
+        if patch.get("insert_warning"):
+            warning = _make_warning_cell(note)
+            nb["cells"].insert(ci + 1, warning)
+            n_inserted += 1
+    return {
+        "n_stripped": n_stripped,
+        "n_inserted": n_inserted,
+        "modified": n_stripped > 0 or n_inserted > 0,
+    }
+
+
+def _summarize_plan(path: Path, nb: dict, plan: list[dict], include_blank_png: bool = False) -> dict:
+    """Construit un resume JSON-friendly du plan pour --check."""
+    return {
+        "path": str(path),
+        "kernel": detector._kernel(nb),  # noqa: SLF001 (sibling helper)
+        "n_cells_flagged": len(plan),
+        "include_blank_png": include_blank_png,
+        "cells": [
+            {
+                "cell_index": p["cell_index"],
+                "findings": p["findings"],
+            }
+            for p in plan
+        ],
+    }
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__.split("\n\n")[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument("--root", default=".", help="Repo root (default: cwd)")
+    ap.add_argument(
+        "--family", default="QuantConnect",
+        help="Family directory under MyIA.AI.Notebooks (default: QuantConnect)",
+    )
+    ap.add_argument(
+        "--nb", action="append", default=None,
+        help="Restrict to a single target (can be repeated). Default = 8 quantbooks de #6891.",
+    )
+    ap.add_argument(
+        "--list", action="store_true",
+        help="List the 8 target quantbooks paths and exit.",
+    )
+    ap.add_argument(
+        "--check", action="store_true",
+        help="Dry-run: print plan JSON summary, do not modify files.",
+    )
+    ap.add_argument(
+        "--apply", action="store_true",
+        help="Apply the strip in-place (writes .ipynb back to disk).",
+    )
+    ap.add_argument(
+        "--note", default="#6891",
+        help="Reference note inserted in the warning markdown (default: #6891).",
+    )
+    ap.add_argument(
+        "--include-blank-png", action="store_true",
+        help="Also flag cells with image/png output < 200 bytes (axe 1 sibling "
+             "coverage, e.g. EMA-Cross-Alpha cell [17]).",
+    )
+    args = ap.parse_args(argv)
+
+    if not (args.check or args.apply or args.list):
+        ap.error("specify --check (dry-run) or --apply (write) or --list")
+
+    repo_root = Path(args.root).resolve()
+    targets = args.nb if args.nb else DEFAULT_TARGETS
+
+    paths = _resolve_quantbook_paths(repo_root, targets, args.family)
+    if not paths:
+        print("[ERROR] no quantbook paths resolved -- check --root or --nb", file=sys.stderr)
+        return 2
+
+    if args.list:
+        for p in paths:
+            print(p.relative_to(repo_root))
+        return 0
+
+    if args.check:
+        report = {
+            "issue": args.note,
+            "targets": [p.relative_to(repo_root).as_posix() for p in paths],
+            "notebooks": [],
+        }
+        for p in paths:
+            try:
+                nb = json.loads(p.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError) as exc:
+                report["notebooks"].append({"path": str(p), "error": str(exc)})
+                continue
+            plan = _plan_strip(nb, include_blank_png=args.include_blank_png)
+            report["notebooks"].append(
+                _summarize_plan(p, nb, plan, include_blank_png=args.include_blank_png)
+            )
+        print(json.dumps(report, indent=2, ensure_ascii=False))
+        return 0
+
+    if args.apply:
+        total_stripped = 0
+        total_inserted = 0
+        per_nb = []
+        for p in paths:
+            try:
+                nb = json.loads(p.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError) as exc:
+                print(f"[ERROR] cannot read {p}: {exc}", file=sys.stderr)
+                return 2
+            plan = _plan_strip(nb, include_blank_png=args.include_blank_png)
+            if not plan:
+                per_nb.append({"path": str(p), "modified": False, "n_stripped": 0})
+                continue
+            result = _apply_plan(nb, plan, args.note)
+            total_stripped += result["n_stripped"]
+            total_inserted += result["n_inserted"]
+            # Re-serialize (UTF-8 no-BOM, indent=1 = format jupyter standard).
+            p.write_text(
+                json.dumps(nb, indent=1, ensure_ascii=False) + "\n",
+                encoding="utf-8",
+            )
+            per_nb.append({
+                "path": str(p.relative_to(repo_root)),
+                "modified": result["modified"],
+                "n_stripped": result["n_stripped"],
+                "n_inserted": result["n_inserted"],
+                "cells_flagged": len(plan),
+            })
+        print(json.dumps({
+            "issue": args.note,
+            "total_stripped": total_stripped,
+            "total_inserted": total_inserted,
+            "per_notebook": per_nb,
+        }, indent=2, ensure_ascii=False))
+        return 0
+
+    return 1  # pragma: no cover
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/notebook_tools/tests/test_detect_fabricated_outputs.py
+++ b/scripts/notebook_tools/tests/test_detect_fabricated_outputs.py
@@ -476,8 +476,14 @@ class TestHumanReport:
 )
 class TestIncident6891Baseline:
     """Regression test : on the actual 8 quantbook.ipynb files from incident #6891,
-    the detector must flag at least 7 of 8 with Row N placeholders (EMA-Cross-Alpha
-    is intentionally excluded -- it has only the blank-PNG signal, axis 1).
+    post-strip (cf PR #7439 strip_fabricated_quantbook_outputs), the detector
+    must NOT flag any Row N placeholders (Side A = strip honest, cf #6891).
+
+    Originally (pre-strip commit) the detector flagged >=7/8 quantbooks with
+    Row N placeholders. The 26 fabricated cells were stripped + 26 markdown
+    warnings inserted. The detector must now report zero Row N findings on
+    the 7 Row-N quantbooks (EMA-Cross-Alpha was always Row-N clean, only
+    blank-PNG via axe 1).
     """
 
     TARGETS = [
@@ -493,31 +499,50 @@ class TestIncident6891Baseline:
                 out.append(scan_notebook(nb_path))
         return out
 
-    def test_at_least_7_quantbooks_have_row_n(self):
+    def test_zero_row_n_after_strip(self):
+        """Post-strip : zero Row N findings across all 8 quantbooks."""
         results = self._scan(Path("MyIA.AI.Notebooks"))
         flagged_with_row_n = sum(
             1 for r in results
             if any(h["signal"] == "row_n_placeholder" for h in r["hits"])
         )
-        # 7/8 expected (EMA-Cross-Alpha is the no-Row-N outlier)
-        assert flagged_with_row_n >= 7, f"Expected >=7 Row N flags, got {flagged_with_row_n}"
+        assert flagged_with_row_n == 0, (
+            f"Post-strip should have 0 Row N flags, got {flagged_with_row_n}. "
+            f"This means the strip from PR #7439 was incomplete or reverted. "
+            f"Re-run `python scripts/notebook_tools/strip_fabricated_quantbook_outputs.py --apply --include-blank-png`."
+        )
 
-    def test_total_row_n_hits_matches_6891_evidence(self):
-        # Issue #6891 evidence table : AllWeather 9, DualMomentum 3, FuturesTrend 15,
-        # MomentumStrategy 3, RiskParity 11, SectorMomentum 3, TurnOfMonth 16.
-        expected = {
+    def test_zero_axis2_findings_post_strip(self):
+        """Post-strip : zero axis-2 (text fabrication) findings -- Row N + zero_stats_dataframe.
+        EMA-Cross-Alpha may still carry a blank-PNG signature (axe 1 sibling detector,
+        not covered by this detector)."""
+        results = self._scan(Path("MyIA.AI.Notebooks"))
+        for r in results:
+            axis2_hits = [
+                h for h in r["hits"]
+                if h["signal"] in ("row_n_placeholder", "zero_stats_dataframe")
+            ]
+            assert axis2_hits == [], (
+                f"{r['path']}: residual axis-2 fabrication findings: {axis2_hits}"
+            )
+
+    def test_pre_strip_baseline_evidence_doc(self):
+        """Documentation-only test : the original #6891 Row N evidence counts.
+
+        This is NOT a runtime check (we cannot go back in time). It serves as
+        an audit anchor + reference for verifying post-strip == 0.
+        Issue #6891 evidence table :
+          AllWeather 9, DualMomentum 3, FuturesTrend 15,
+          MomentumStrategy 3, RiskParity 11, SectorMomentum 3, TurnOfMonth 16,
+          EMA-Cross-Alpha 0 (blank-PNG only, axe 1 sibling).
+        Total Row N hits pre-strip = 60.
+        """
+        expected_pre_strip = {
             "AllWeather": 9, "DualMomentum": 3, "FuturesTrend": 15,
             "MomentumStrategy": 3, "RiskParity": 11, "SectorMomentum": 3,
-            "TurnOfMonth": 16,
+            "TurnOfMonth": 16, "EMA-Cross-Alpha": 0,
         }
-        root = Path("MyIA.AI.Notebooks")
-        for proj, want in expected.items():
-            nb_path = root / "QuantConnect" / "projects" / proj / "quantbook.ipynb"
-            if not nb_path.exists():
-                continue
-            result = scan_notebook(nb_path)
-            row_n_counts = [
-                h["count"] for h in result["hits"] if h["signal"] == "row_n_placeholder"
-            ]
-            total = sum(row_n_counts)
-            assert total == want, f"{proj}: expected {want} Row N, got {total}"
+        # Inventory check (sum matches issue body evidence table).
+        assert sum(expected_pre_strip.values()) == 60
+        # EMA-Cross-Alpha explicitly excluded (blank-PNG signature only).
+        assert expected_pre_strip["EMA-Cross-Alpha"] == 0

--- a/scripts/notebook_tools/tests/test_strip_fabricated_quantbook_outputs.py
+++ b/scripts/notebook_tools/tests/test_strip_fabricated_quantbook_outputs.py
@@ -1,0 +1,495 @@
+#!/usr/bin/env python3
+"""Pytest roll-out for strip_fabricated_quantbook_outputs.py (cf #6891, sibling detecteur).
+
+Le script lui-meme est verbatim depuis #7439 (soumis pour review). 8 clusters
+miroirs de la logique de decision documentee dans le module.
+
+Note : on importe le script via importlib (cf L800-L1 ★ -- conftest pre-existant
+ne fait pas de sys.path.insert) pour eviter la collision avec le homonyme
+detecteur importe par strip.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+SCRIPT_PATH = SCRIPTS_DIR / "strip_fabricated_quantbook_outputs.py"
+
+# Charger le module via importlib (cf L800-L1 ★ pattern).
+_spec = importlib.util.spec_from_file_location(
+    "strip_fabricated_quantbook_outputs", SCRIPT_PATH
+)
+strip_mod = importlib.util.module_from_spec(_spec)
+sys.modules["strip_fabricated_quantbook_outputs"] = strip_mod
+_spec.loader.exec_module(strip_mod)
+
+
+# --- Helpers ---------------------------------------------------------------
+
+def _code_cell(source_lines, outputs=None, execution_count=1):
+    """Construit une cellule code avec source (list[str]) + outputs."""
+    return {
+        "cell_type": "code",
+        "metadata": {},
+        "execution_count": execution_count,
+        "outputs": outputs if outputs is not None else [],
+        "source": source_lines,
+    }
+
+
+def _markdown_cell(text):
+    return {
+        "cell_type": "markdown",
+        "metadata": {},
+        "source": text if isinstance(text, list) else [text],
+    }
+
+
+def _row_n_output(n_rows=3):
+    """Sortie 'Row N' placeholder (fabrication signature)."""
+    return {
+        "output_type": "stream",
+        "name": "stdout",
+        "text": [f"Row {i}\n" for i in range(n_rows)],
+    }
+
+
+def _zero_stats_output():
+    """Dataframe stats backtest entierement a 0.0."""
+    return {
+        "output_type": "execute_result",
+        "data": {
+            "text/plain": [
+                "       Sharpe  CAGR  MaxDD  NetProfit\n"
+                "row1    0.0   0.0    0.0        0.0\n"
+            ]
+        },
+    }
+
+
+def _blank_png_output():
+    """Image/png < 200 bytes (axe 1 sibling)."""
+    return {
+        "output_type": "display_data",
+        "data": {"image/png": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="},
+    }
+
+
+def _write_nb(tmp_path, name, cells):
+    """Ecrit un .ipynb avec les cells donnees."""
+    nb = {
+        "cells": cells,
+        "metadata": {
+            "kernelspec": {"name": "python3", "display_name": "Python 3"}
+        },
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+    p = tmp_path / name
+    p.write_text(json.dumps(nb, ensure_ascii=False, indent=1), encoding="utf-8")
+    return p
+
+
+def _make_root(tmp_path, nb_paths_relative):
+    """Construit un mini-repo avec quantbooks/ + notebooks non-cibles.
+
+    Retourne (root, repo_root) ou root contient MyIA.AI.Notebooks/QuantConnect/projects/.
+    """
+    repo_root = tmp_path
+    for rel in nb_paths_relative:
+        full = repo_root / "MyIA.AI.Notebooks" / "QuantConnect" / "projects" / rel
+        full.parent.mkdir(parents=True, exist_ok=True)
+        full.write_text(json.dumps({"cells": [], "metadata": {}, "nbformat": 4}, indent=1), encoding="utf-8")
+    return repo_root
+
+
+# --- Cluster 1 : DEFAULT_TARGETS ------------------------------------------
+
+class TestDefaultTargets:
+    """Les 8 quantbooks de #6891 sont listes par defaut."""
+
+    def test_default_targets_contains_eight_quantbooks(self):
+        assert len(strip_mod.DEFAULT_TARGETS) == 8
+
+    def test_default_targets_includes_dual_momentum(self):
+        assert "DualMomentum" in strip_mod.DEFAULT_TARGETS
+
+    def test_default_targets_includes_all_weather(self):
+        assert "AllWeather" in strip_mod.DEFAULT_TARGETS
+
+    def test_default_targets_includes_ema_cross_alpha(self):
+        assert "EMA-Cross-Alpha" in strip_mod.DEFAULT_TARGETS
+
+    def test_default_targets_excludes_famafrench(self):
+        """FamaFrench est hors scope #6891 (cf detecteur axe 2 le flag, mais
+        n'est pas dans la liste body issue). Il sera traite dans un PR separe."""
+        assert "FamaFrench" not in strip_mod.DEFAULT_TARGETS
+
+
+# --- Cluster 2 : _resolve_quantbook_paths ----------------------------------
+
+class TestResolveQuantbookPaths:
+    """Resolution des paths vers les 8 quantbooks."""
+
+    def test_resolves_existing_quantbook(self, tmp_path):
+        p = tmp_path / "MyIA.AI.Notebooks" / "QuantConnect" / "projects" / "DualMomentum" / "quantbook.ipynb"
+        p.parent.mkdir(parents=True)
+        p.write_text("{}", encoding="utf-8")
+        out = strip_mod._resolve_quantbook_paths(tmp_path, ["DualMomentum"])
+        assert len(out) == 1
+        assert out[0] == p
+
+    def test_missing_quantbook_warns_to_stderr(self, tmp_path, capsys):
+        out = strip_mod._resolve_quantbook_paths(tmp_path, ["Nonexistent"])
+        captured = capsys.readouterr()
+        assert "Nonexistent" in captured.err
+        assert out == []
+
+    def test_returns_empty_when_no_paths(self, tmp_path, capsys):
+        out = strip_mod._resolve_quantbook_paths(tmp_path, [])
+        assert out == []
+
+
+# --- Cluster 3 : _strip_cell_outputs --------------------------------------
+
+class TestStripCellOutputs:
+    """Vidage des outputs + execution_count."""
+
+    def test_strip_code_cell_with_outputs(self):
+        cell = _code_cell(["x = 1"], outputs=[_row_n_output()], execution_count=1)
+        changed = strip_mod._strip_cell_outputs(cell)
+        assert changed is True
+        assert cell["outputs"] == []
+        assert cell["execution_count"] is None
+
+    def test_no_change_when_cell_already_stripped(self):
+        cell = _code_cell(["x = 1"], outputs=[], execution_count=None)
+        changed = strip_mod._strip_cell_outputs(cell)
+        assert changed is False
+
+    def test_non_code_cell_ignored(self):
+        cell = _markdown_cell("hello")
+        changed = strip_mod._strip_cell_outputs(cell)
+        assert changed is False
+
+    def test_preserves_source(self):
+        cell = _code_cell(["def foo():\n    return 42"], outputs=[_row_n_output()])
+        strip_mod._strip_cell_outputs(cell)
+        assert cell["source"] == ["def foo():\n    return 42"]
+
+
+# --- Cluster 4 : _make_warning_cell ---------------------------------------
+
+class TestMakeWarningCell:
+    """Cellule markdown d'avertissement inseree apres le strip."""
+
+    def test_creates_markdown_cell(self):
+        cell = strip_mod._make_warning_cell("#6891")
+        assert cell["cell_type"] == "markdown"
+
+    def test_mentions_issue_reference(self):
+        cell = strip_mod._make_warning_cell("#6891")
+        src = "".join(cell["source"])
+        assert "#6891" in src
+
+    def test_includes_french_warning_text(self):
+        """Conformite readme-french-first."""
+        cell = strip_mod._make_warning_cell("#6891")
+        src = "".join(cell["source"])
+        assert "strippee" in src  # FR "strippee" (avec accent)
+
+
+# --- Cluster 5 : _has_blank_png -------------------------------------------
+
+class TestHasBlankPng:
+    """Detection axe 1 blank PNG (cellule dont image/png < 200 bytes)."""
+
+    def test_blank_png_detected(self):
+        cell = _code_cell(["plt.show()"], outputs=[_blank_png_output()])
+        assert strip_mod._has_blank_png(cell) is True
+
+    def test_real_png_not_detected(self):
+        """Un PNG > 200 bytes n'est pas un blank (axe 1 sibling threshold)."""
+        real_png = "A" * 500  # bytes fictifs
+        cell = _code_cell(["plt.show()"], outputs=[{
+            "output_type": "display_data",
+            "data": {"image/png": real_png},
+        }])
+        assert strip_mod._has_blank_png(cell) is False
+
+    def test_no_image_output(self):
+        cell = _code_cell(["x = 1"], outputs=[_row_n_output()])
+        assert strip_mod._has_blank_png(cell) is False
+
+    def test_threshold_constant_defined(self):
+        """Le seuil 200 bytes est explicite (L728-L2 ★ pattern detector-sanity)."""
+        assert strip_mod.BLANK_PNG_THRESHOLD == 200
+
+
+# --- Cluster 6 : _plan_strip ----------------------------------------------
+
+class TestPlanStrip:
+    """Planification du strip (sans modification)."""
+
+    def test_plan_includes_fabricated_text_cell(self):
+        nb_cells = [_code_cell(["x = 1"], outputs=[_row_n_output()])]
+        nb = {"cells": nb_cells}
+        plan = strip_mod._plan_strip(nb)
+        assert len(plan) == 1
+        assert plan[0]["cell_index"] == 0
+        assert plan[0]["findings"][0]["signal"] == "row_n_placeholder"
+
+    def test_plan_includes_blank_png_when_requested(self):
+        nb_cells = [_code_cell(["plt.show()"], outputs=[_blank_png_output()])]
+        nb = {"cells": nb_cells}
+        plan = strip_mod._plan_strip(nb, include_blank_png=True)
+        assert len(plan) == 1
+        signals = [f["signal"] for f in plan[0]["findings"]]
+        assert "blank_png_axe1" in signals
+
+    def test_plan_excludes_blank_png_by_default(self):
+        """Le blank PNG n'est PAS couvert par defaut (axe 2 strict)."""
+        nb_cells = [_code_cell(["plt.show()"], outputs=[_blank_png_output()])]
+        nb = {"cells": nb_cells}
+        plan = strip_mod._plan_strip(nb)
+        assert plan == []
+
+    def test_plan_includes_zero_stats_dataframe(self):
+        """Mock le detecteur pour simuler un finding axe 2 'zero_stats_dataframe'.
+
+        On teste l'orchestration de _plan_strip (single-source-of-truth = detector).
+        Le detecteur lui-meme a sa propre suite de tests (test_detect_fabricated_outputs).
+        """
+        # Monkeypatch detector.detect_cell pour retourner un finding axe 2
+        original_detect = strip_mod.detector.detect_cell
+
+        def fake_detect(cell):
+            if cell.get("outputs"):
+                return [{"signal": "zero_stats_dataframe"}]
+            return []
+
+        strip_mod.detector.detect_cell = fake_detect
+        try:
+            nb_cells = [_code_cell(["result"], outputs=[_zero_stats_output()])]
+            nb = {"cells": nb_cells}
+            plan = strip_mod._plan_strip(nb)
+            assert len(plan) == 1
+            signals = [f["signal"] for f in plan[0]["findings"]]
+            assert "zero_stats_dataframe" in signals
+        finally:
+            strip_mod.detector.detect_cell = original_detect
+
+    def test_plan_empty_when_clean(self):
+        nb_cells = [_code_cell(["x = 1"], outputs=[])]
+        nb = {"cells": nb_cells}
+        plan = strip_mod._plan_strip(nb, include_blank_png=True)
+        assert plan == []
+
+    def test_plan_skips_markdown_cells(self):
+        nb_cells = [_markdown_cell("# titre"), _code_cell(["x = 1"], outputs=[_row_n_output()])]
+        nb = {"cells": nb_cells}
+        plan = strip_mod._plan_strip(nb)
+        assert len(plan) == 1
+        assert plan[0]["cell_index"] == 1
+
+
+# --- Cluster 7 : _apply_plan ----------------------------------------------
+
+class TestApplyPlan:
+    """Application reelle du plan (strip + insertion markdown)."""
+
+    def test_apply_strips_and_inserts_warning(self):
+        nb = {"cells": [_code_cell(["x = 1"], outputs=[_row_n_output()])]}
+        plan = strip_mod._plan_strip(nb)
+        result = strip_mod._apply_plan(nb, plan, "#6891")
+        assert result["n_stripped"] == 1
+        assert result["n_inserted"] == 1
+        # Cellule code a outputs=[]/execution_count=None
+        assert nb["cells"][0]["outputs"] == []
+        assert nb["cells"][0]["execution_count"] is None
+        # Cellule markdown inseree apres
+        assert nb["cells"][1]["cell_type"] == "markdown"
+
+    def test_apply_with_multiple_cells_preserves_order(self):
+        """L'insertion en ordre decroissant preserve la coherence des indices."""
+        nb = {"cells": [
+            _code_cell(["a = 1"], outputs=[_row_n_output(3)]),
+            _markdown_cell("# section"),
+            _code_cell(["b = 2"], outputs=[_row_n_output(5)]),
+        ]}
+        plan = strip_mod._plan_strip(nb)
+        result = strip_mod._apply_plan(nb, plan, "#6891")
+        assert result["n_stripped"] == 2
+        assert result["n_inserted"] == 2
+        # Cell 0 = code a (striped), Cell 1 = warning, Cell 2 = markdown section,
+        # Cell 3 = code b (striped), Cell 4 = warning
+        assert nb["cells"][0]["cell_type"] == "code"
+        assert nb["cells"][1]["cell_type"] == "markdown"
+        assert nb["cells"][2]["cell_type"] == "markdown"  # section preservee
+        assert nb["cells"][3]["cell_type"] == "code"
+        assert nb["cells"][4]["cell_type"] == "markdown"
+
+    def test_apply_preserves_source_verbatim(self):
+        """Stop&Repair : JAMAIS modifier le source."""
+        nb = {"cells": [_code_cell(["def foo():\n    return 42"], outputs=[_row_n_output()])]}
+        plan = strip_mod._plan_strip(nb)
+        strip_mod._apply_plan(nb, plan, "#6891")
+        assert nb["cells"][0]["source"] == ["def foo():\n    return 42"]
+
+
+# --- Cluster 8 : main() argparse + integration ----------------------------
+
+class TestMainCLI:
+    """Tests CLI via monkeypatch sys.argv (pattern L728-L2 ★ c.728)."""
+
+    def _run_main(self, argv, capsys, root=None):
+        sys_argv_backup = sys.argv
+        sys.argv = ["strip_fabricated_quantbook_outputs.py"] + argv
+        try:
+            rc = strip_mod.main()
+        finally:
+            sys.argv = sys_argv_backup
+        out = capsys.readouterr().out
+        return rc, out
+
+    def test_list_outputs_eight_paths(self, tmp_path, capsys):
+        """--list imprime les 8 paths relatifs et exit 0."""
+        # Mock 8 quantbooks vides (juste pour resoudre les paths)
+        for name in strip_mod.DEFAULT_TARGETS:
+            p = tmp_path / "MyIA.AI.Notebooks" / "QuantConnect" / "projects" / name / "quantbook.ipynb"
+            p.parent.mkdir(parents=True)
+            p.write_text("{}", encoding="utf-8")
+        rc, out = self._run_main(["--list", "--root", str(tmp_path)], capsys)
+        assert rc == 0
+        lines = [l for l in out.splitlines() if l.strip()]
+        assert len(lines) == 8
+        for name in strip_mod.DEFAULT_TARGETS:
+            assert any(name in line for line in lines)
+
+    def test_check_outputs_json_report(self, tmp_path, capsys):
+        """--check produit un rapport JSON structuré."""
+        for name in strip_mod.DEFAULT_TARGETS:
+            cells = []
+            if name == "DualMomentum":
+                cells = [_code_cell(["x = 1"], outputs=[_row_n_output()])]
+            p = tmp_path / "MyIA.AI.Notebooks" / "QuantConnect" / "projects" / name / "quantbook.ipynb"
+            p.parent.mkdir(parents=True)
+            p.write_text(json.dumps({"cells": cells, "metadata": {}, "nbformat": 4}), encoding="utf-8")
+        rc, out = self._run_main(
+            ["--check", "--root", str(tmp_path)],
+            capsys,
+        )
+        assert rc == 0
+        report = json.loads(out)
+        assert report["issue"] == "#6891"
+        assert len(report["notebooks"]) == 8
+        # DualMomentum doit etre flagged (Row N)
+        dm = next(n for n in report["notebooks"] if "DualMomentum" in n["path"])
+        assert dm["n_cells_flagged"] == 1
+
+    def test_check_with_include_blank_png(self, tmp_path, capsys):
+        """--include-blank-png flagge aussi les cellules image/png < 200 bytes."""
+        cells = [_code_cell(["plt.show()"], outputs=[_blank_png_output()])]
+        p = tmp_path / "MyIA.AI.Notebooks" / "QuantConnect" / "projects" / "EMA-Cross-Alpha" / "quantbook.ipynb"
+        p.parent.mkdir(parents=True)
+        p.write_text(json.dumps({"cells": cells, "metadata": {}, "nbformat": 4}), encoding="utf-8")
+        # Stub les autres 7 avec cellules vides pour eviter les faux positifs
+        for name in strip_mod.DEFAULT_TARGETS:
+            if name == "EMA-Cross-Alpha":
+                continue
+            q = tmp_path / "MyIA.AI.Notebooks" / "QuantConnect" / "projects" / name / "quantbook.ipynb"
+            q.parent.mkdir(parents=True)
+            q.write_text(json.dumps({"cells": [], "metadata": {}, "nbformat": 4}), encoding="utf-8")
+        rc, out = self._run_main(
+            ["--check", "--include-blank-png", "--root", str(tmp_path)],
+            capsys,
+        )
+        assert rc == 0
+        report = json.loads(out)
+        ema = next(n for n in report["notebooks"] if "EMA-Cross-Alpha" in n["path"])
+        assert ema["n_cells_flagged"] == 1
+        assert ema["include_blank_png"] is True
+
+    def test_apply_strips_and_writes_files(self, tmp_path, capsys):
+        """--apply ecrit les .ipynb avec outputs vides + warnings inserees."""
+        cells = [_code_cell(["x = 1"], outputs=[_row_n_output()])]
+        p = tmp_path / "MyIA.AI.Notebooks" / "QuantConnect" / "projects" / "DualMomentum" / "quantbook.ipynb"
+        p.parent.mkdir(parents=True)
+        p.write_text(json.dumps({"cells": cells, "metadata": {}, "nbformat": 4}), encoding="utf-8")
+        # Stub les autres 7 (sinon Resolution miss -> warning stderr -> potentiellement fail)
+        for name in strip_mod.DEFAULT_TARGETS:
+            if name == "DualMomentum":
+                continue
+            q = tmp_path / "MyIA.AI.Notebooks" / "QuantConnect" / "projects" / name / "quantbook.ipynb"
+            q.parent.mkdir(parents=True)
+            q.write_text(json.dumps({"cells": [], "metadata": {}, "nbformat": 4}), encoding="utf-8")
+        rc, out = self._run_main(
+            ["--apply", "--root", str(tmp_path)],
+            capsys,
+        )
+        assert rc == 0
+        result = json.loads(out)
+        assert result["total_stripped"] == 1
+        assert result["total_inserted"] == 1
+        # Verifier le contenu ecrit
+        written = json.loads(p.read_text(encoding="utf-8"))
+        assert written["cells"][0]["outputs"] == []
+        assert written["cells"][0]["execution_count"] is None
+        assert written["cells"][1]["cell_type"] == "markdown"
+        assert "#6891" in "".join(written["cells"][1]["source"])
+
+    def test_no_args_returns_error(self, capsys):
+        """Ni --check ni --apply ni --list = argparse.error() -> SystemExit(2)."""
+        sys_argv_backup = sys.argv
+        sys.argv = ["strip_fabricated_quantbook_outputs.py"]
+        try:
+            with pytest.raises(SystemExit) as exc_info:
+                strip_mod.main()
+            assert exc_info.value.code != 0
+        finally:
+            sys.argv = sys_argv_backup
+
+
+# --- Cluster 9 : end-to-end subprocess smoke test --------------------------
+
+class TestEndToEnd:
+    """Subprocess smoke test sur mini-repo synthesized (L728-L2 ★ pattern)."""
+
+    def test_subprocess_check_succeeds(self, tmp_path):
+        """Le script est executable + produit un rapport JSON valide."""
+        for name in strip_mod.DEFAULT_TARGETS:
+            p = tmp_path / "MyIA.AI.Notebooks" / "QuantConnect" / "projects" / name / "quantbook.ipynb"
+            p.parent.mkdir(parents=True)
+            p.write_text(json.dumps({"cells": [], "metadata": {}, "nbformat": 4}), encoding="utf-8")
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH), "--check", "--root", str(tmp_path)],
+            capture_output=True, text=True, timeout=60,
+        )
+        assert result.returncode == 0
+        report = json.loads(result.stdout)
+        assert "notebooks" in report
+        assert len(report["notebooks"]) == 8
+
+    def test_subprocess_list_outputs_eight_paths(self, tmp_path):
+        for name in strip_mod.DEFAULT_TARGETS:
+            p = tmp_path / "MyIA.AI.Notebooks" / "QuantConnect" / "projects" / name / "quantbook.ipynb"
+            p.parent.mkdir(parents=True)
+            p.write_text("{}", encoding="utf-8")
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH), "--list", "--root", str(tmp_path)],
+            capture_output=True, text=True, timeout=60,
+        )
+        assert result.returncode == 0
+        lines = [l for l in result.stdout.splitlines() if l.strip()]
+        assert len(lines) == 8
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
# fix(qc,#6891): strip fabricated outputs from 8 quantbooks + add strip tool

## Why

Incident **#6891** (8 QuantConnect quantbook.ipynb) : chaque notebook
contient des **sorties FABRIQUÉES** committées comme résultats de backtest :
- **Row N placeholders** (axe 2, detecté par `detect_fabricated_outputs.py`)
  simulant un dataframe de résultats qui n'a pas été produit.
- **Dataframes stats backtest à 0.0** (axe 2) — Sharpe/CAGR/MaxDD/NetProfit
  tous nuls, signature d'un backtest qui n'a pas tourné.
- **Blank PNG 70-96 bytes** (axe 1, `detect_blank_figures.py`) — figure
  matplotlib vide émissaire par défaut.

C'est une **violation C.2 + Stop&Repair** : les notebooks sont committés
AVEC outputs, mais ces outputs ne sont pas des preuves d'exécution — c'est
de la fabrication documentaire (cf secrets-hygiene règle 6 + SOTA-not-workaround
Prong-A, mandat user 2026-06-22 : JAMAIS hand-editer une sortie de cellule).

Le moteur canonique d'exécution pour QuantConnect = **QC Cloud research
kernel** (`QuantBook()` API non-exécutable via Papermill local, cf
[[feedback-qc-cloud-exec-modalities]]). Side B planifié = re-exécution QC
Cloud multi-cycle (hors scope ce PR). Side A = strip honnête des fabrications
documentées.

## What

**Tool :** [scripts/notebook_tools/strip_fabricated_quantbook_outputs.py](scripts/notebook_tools/strip_fabricated_quantbook_outputs.py)
(nouveau, ~280 lignes). Sibling de `detect_fabricated_outputs.py` (single source
of truth) : le détecteur signale, le stripper agit. CLI dry-run par défaut +
`--apply` pour commit. Format `--check` JSON-friendly pour CI.

**8 quantbooks modifiés :** 26 cellules FABRIQUÉES strippées + 26 cellules
markdown d'avertissement insérées APRÈS (insertion post-strip = ordre
décroissant d'index pour stabilité). Source code PRÉSERVÉ verbatim
(Stop&Repair : JAMAIS modifier le code, seulement les `outputs`).

| Notebook | Cells stripped | Signaux |
|----------|---------------:|---------|
| AllWeather | 4 | Row N (3) + blank PNG (1) |
| DualMomentum | 2 | Row N (1) + blank PNG (1) |
| EMA-Cross-Alpha | 1 | blank PNG (96 bytes, axe 1) |
| FuturesTrend | 5 | Row N + blank PNG |
| MomentumStrategy | 2 | Row N + blank PNG |
| RiskParity | 4 | Row N + zero_stats_dataframe |
| SectorMomentum | 2 | Row N + blank PNG |
| TurnOfMonth | 6 | Row N + 4 zero_stats_dataframe |
| **Total** | **26** | Row N + blank PNG + zero_stats |

## Preuves vérifiables

- **2798/2798 PASSED** en 23s — anti-régression OK.
- **35 nouveaux tests** pytest roll-out (`test_strip_fabricated_quantbook_outputs.py`)
  groupés en 9 clusters miroirs de la logique documentée :
  TestDefaultTargets · TestResolveQuantbookPaths · TestStripCellOutputs ·
  TestMakeWarningCell · TestHasBlankPng · TestPlanStrip · TestApplyPlan ·
  TestMainCLI · TestEndToEnd (subprocess smoke).
- **Tests baseline inversés** dans `test_detect_fabricated_outputs.py` :
  pre-strip `>=7 Row N` → post-strip `== 0 axis-2 findings`. Plus 1 test
  doc-only ancré sur les comptages `#6891` (audit table : 60 Row N total
  pre-strip, 0 post-strip).
- **Detector was clean (0 bug latent)** : le stripper est byte-clean au
  premier essai, comme attendu (cf L722-L1 ★★ pattern detector-was-clean).
- **Post-strip vérification** :
  `python scripts/notebook_tools/detect_fabricated_outputs.py --family QuantConnect --check`
  → 0 fabrication sur les 8 cibles (reste 2 hors scope : FamaFrench + ForexCarry).
- **Cell [5] DualMomentum inspectée** (cf summary c.729) :
  source `def backtest_dual_momentum(closes, risky_assets, refuge, lookback=252, ...)`
  PRÉSERVÉ. `outputs: []`, `execution_count: None`. + markdown cell [6]
  insérée.

## Décisions techniques notables

1. **EMA-Cross-Alpha sans `Row N`** : 0 placeholder tabulaire, mais 1 blank PNG
   (96 bytes, axe 1 sibling). Le détecteur axe 2 ne le flag pas → ajout du flag
   `--include-blank-png` qui étend le scope à `< 200 bytes` (axe 1 threshold,
   sibling `detect_blank_figures.py`). Cohérence avec body issue "all 8 also
   carry the 70-byte blank PNG".

2. **Insertion markdown APRÈS strip** : `nb["cells"].insert(ci + 1, warning)`,
   tri `reverse=True` par index pour stabilité (insertion 0..N-1 ne décale
   pas les indices suivants). Format markdown volontairement compact (2 lignes)
   pour minimiser le churn visuel du diff.

3. **Sibling detector/fixer pattern** : `strip_mod.detector.detect_cell(cell)`
   = single source of truth. Pas de duplication de la logique de détection.
   `BLANK_PNG_THRESHOLD = 200` constant explicite (cf L728-L2 ★ detector-sanity).

4. **CLI dry-run par défaut** : `--check` pour audit JSON, `--apply` pour
   commit. Pas de write accidentel.

5. **Tests via `importlib.util`** (cf L800-L1 ★ pattern) : le module est
   chargé via `spec_from_file_location` pour éviter collision avec le nom
   Python standard. `sys.modules["strip_fabricated_quantbook_outputs"]` posé
   pour pickling éventuel.

6. **Test mock `detect_cell`** pour `zero_stats_dataframe` : le détecteur
   réel exige ratio zéro ≥ 90% avec ≥3 colonnes canoniques (heuristique
   stricte pour minimiser FP). Le test du stripper mocke le détecteur car
   ce dernier a sa propre suite de tests. Single-responsibility respectée.

## Liens opérationnels

- Issue **#6891** — incident fondateur (8 quantbook.ipynb QC blank-PNG + Row N).
- Detector initial `detect_fabricated_outputs.py` (axe 2) MERGED.
- `detect_blank_figures.py` (axe 1) MERGED.
- Strip tool (cette PR) — Side A = strip honnête.
- Side B (planifié, hors scope) = re-exécution QC Cloud research kernel
  multi-cycle (RECOVERABLE-MACHINE, owner sustained).

## Anti-patterns écartés

- **Pas de modification du code source** (Stop&Repair HARD : JAMAIS scrubber
  la cause — corriger la cause = re-exécuter en QC Cloud, hors scope ce PR).
- **Pas de composite G.4** — 1 sujet = strip 1 outil + 8 quantbooks même type
  d'action. Seuils : 11 fichiers / +1157/-319 / 1 domaine. Dans les limites.
- **Pas de force push** — fresh branch `feature/c729-strip-fabricated-quantbook-outputs`
  depuis `origin/main@c76d8b8f2`.
- **Pas de merge** — worker INTERDIT `gh pr merge` / `gh auth switch` per
  lecon #1502.
- **Body PR HORS worktree** (L677-L4 ★★ c.677g, NTFS case-insensitive safe) :
  body écrit dans `C:/tmp/c729_pr_body.md`, pas dans le worktree.
- **Pas de regen catalogue** (catalog-pr-hygiene Règle HARD 1) — la PR ne
  touche pas `COURSE_CATALOG.generated.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)