### PR TITLE
fix(notebook_tools): dotnet_executor parent_msg_id filter + interrupt/drain on timeout

### DIFF
--- a/scripts/notebook_tools/dotnet_executor.py
+++ b/scripts/notebook_tools/dotnet_executor.py
@@ -18,6 +18,29 @@ from pathlib import Path
 import jupyter_client
 
 
+def _drain_iopub(kc, parent_msg_id, deadline_s=5):
+    """Best-effort drain of iopub messages until the kernel goes idle or a
+    short deadline passes.
+
+    Used after ``interrupt_kernel()`` on a cell timeout to discard the
+    interrupted request's trailing messages so they do not leak into the next
+    cell's iopub loop. Only messages whose ``parent_header.msg_id`` matches
+    ``parent_msg_id`` are inspected; unrelated messages are left in the queue
+    for their owner. Returns silently on any error (drain is best-effort).
+    """
+    deadline = time.time() + deadline_s
+    while time.time() < deadline:
+        try:
+            msg = kc.get_iopub_msg(timeout=1)
+        except Exception:
+            return
+        if msg.get("parent_header", {}).get("msg_id") != parent_msg_id:
+            continue
+        if (msg.get("msg_type") == "status"
+                and msg.get("content", {}).get("execution_state") == "idle"):
+            return
+
+
 def execute_notebook(notebook_path, kernel_name=".net-csharp", cell_timeout=120,
                      verbose=False, dry_run=False):
     """Execute a .NET notebook cell-by-cell and update outputs.
@@ -76,6 +99,15 @@ def execute_notebook(notebook_path, kernel_name=".net-csharp", cell_timeout=120,
                 except Exception:
                     continue
 
+                # Only consume iopub messages belonging to THIS cell's execute
+                # request. Without this filter, stale output or a stray idle
+                # status emitted for a PRIOR cell can pollute this cell's outputs
+                # or break the loop early. Messages lacking a parent_header
+                # (some kernel broadcasts) are kept for forward-compatibility.
+                parent_id = msg.get("parent_header", {}).get("msg_id")
+                if parent_id is not None and parent_id != msg_id:
+                    continue
+
                 msg_type = msg["msg_type"]
                 content = msg["content"]
 
@@ -119,6 +151,16 @@ def execute_notebook(notebook_path, kernel_name=".net-csharp", cell_timeout=120,
 
             if time.time() >= deadline:
                 print(f"    TIMEOUT [{exec_counter}] after {cell_timeout}s")
+                # Interrupt the stuck execution so the next cell is not queued
+                # behind it, then drain this request's trailing iopub messages
+                # so they do not consume the next cell's loop budget. Both are
+                # defensive: wrapped against kernel managers that do not support
+                # interrupt or have nothing left to drain.
+                try:
+                    km.interrupt_kernel()
+                except Exception:
+                    pass
+                _drain_iopub(kc, msg_id)
                 outputs.append({
                     "output_type": "stream",
                     "name": "stderr",

--- a/scripts/notebook_tools/tests/test_dotnet_executor.py
+++ b/scripts/notebook_tools/tests/test_dotnet_executor.py
@@ -34,8 +34,14 @@ def _code_cell(source):
     return {"cell_type": "code", "source": src, "execution_count": None, "outputs": []}
 
 
-def _msg(msg_type, **content):
-    return {"msg_type": msg_type, "content": content}
+def _msg(msg_type, parent=None, **content):
+    """Build an iopub message. ``parent`` (optional) sets parent_header.msg_id,
+    used to exercise the parent_msg_id filter (Fix A). Messages without it mimic
+    parentless kernel broadcasts, which the conservative filter keeps."""
+    msg = {"msg_type": msg_type, "content": content}
+    if parent is not None:
+        msg["parent_header"] = {"msg_id": parent}
+    return msg
 
 
 def _fake_kernel(message_seq_by_cell):
@@ -290,3 +296,99 @@ def test_batch_execute_skipped_notebooks_marked(tmp_path, _patch_kernelmanager):
     results = dotnet_executor.batch_execute(str(tmp_path), pattern="*.ipynb")
     assert results["empty.ipynb"]["skipped"] is True
     assert results["empty.ipynb"]["total"] == 0
+
+
+# --- Fix A: parent_msg_id filter (cross-cell pollution guard) ----------------
+
+def test_mismatched_parent_msg_id_is_skipped(tmp_path, _patch_kernelmanager):
+    """Fix A: an iopub message whose parent_header.msg_id names a DIFFERENT
+    request must not be collected into this cell's outputs. The fake kernel's
+    execute() returns ``msg-1`` for the first cell, so a stream tagged
+    ``parent="stale-..."`` is dropped while ``parent="msg-1"`` is kept."""
+    nb = _write_nb(tmp_path / "n.ipynb", [_code_cell("x")])
+    _patch_kernelmanager([[
+        _msg("status", execution_state="busy"),
+        _msg("stream", parent="stale-from-prior-cell", name="stdout", text="leftover\n"),
+        _msg("stream", parent="msg-1", name="stdout", text="ours\n"),
+        _msg("status", execution_state="idle"),
+    ]])
+    dotnet_executor.execute_notebook(nb)
+    out = json.loads(nb.read_text(encoding="utf-8"))["cells"][0]["outputs"]
+    texts = [o["text"] for o in out if o["output_type"] == "stream"]
+    assert "ours\n" in texts
+    assert "leftover\n" not in texts  # cross-cell pollution dropped
+
+
+def test_stray_idle_from_other_request_does_not_break_loop(tmp_path, _patch_kernelmanager):
+    """Fix A: a stray idle status bearing a DIFFERENT parent must NOT terminate
+    this cell's iopub loop before its own output arrives. Without the filter a
+    late idle from the prior cell would break early and lose ``real-output``."""
+    nb = _write_nb(tmp_path / "n.ipynb", [_code_cell("x")])
+    _patch_kernelmanager([[
+        _msg("status", execution_state="busy"),
+        _msg("status", parent="someone-else", execution_state="idle"),  # stray, must NOT break
+        _msg("stream", name="stdout", text="real-output\n"),
+        _msg("status", execution_state="idle"),  # ours (parentless) -> breaks
+    ]])
+    dotnet_executor.execute_notebook(nb)
+    out = json.loads(nb.read_text(encoding="utf-8"))["cells"][0]["outputs"]
+    texts = [o["text"] for o in out if o["output_type"] == "stream"]
+    assert texts == ["real-output\n"]  # loop survived the stray idle
+
+
+def test_parentless_message_is_still_kept(tmp_path, _patch_kernelmanager):
+    """Fix A conservative design: messages with NO parent_header (kernel
+    broadcasts) are kept, not dropped — pins forward-compatibility."""
+    nb = _write_nb(tmp_path / "n.ipynb", [_code_cell("x")])
+    _patch_kernelmanager([[
+        _msg("stream", name="stdout", text="broadcast\n"),  # no parent_header
+        _msg("status", execution_state="idle"),
+    ]])
+    dotnet_executor.execute_notebook(nb)
+    out = json.loads(nb.read_text(encoding="utf-8"))["cells"][0]["outputs"]
+    assert out[0]["text"] == "broadcast\n"  # parentless message kept
+
+
+# --- Fix B: interrupt + drain on timeout ------------------------------------
+
+def test_interrupt_kernel_called_on_timeout(tmp_path, _patch_kernelmanager):
+    """Fix B: on timeout the kernel manager is interrupted so the next cell is
+    not queued behind the stuck execution."""
+    nb = _write_nb(tmp_path / "n.ipynb", [_code_cell("while(true);")])
+    km, _ = _patch_kernelmanager([[]])
+    dotnet_executor.execute_notebook(nb, cell_timeout=0)
+    km.interrupt_kernel.assert_called_once()
+
+
+def test_interrupt_failure_does_not_crash(tmp_path, _patch_kernelmanager):
+    """Fix B: if interrupt_kernel() raises (unsupported kernel), the executor
+    must swallow it and still emit the TIMEOUT stderr + count the cell."""
+    nb = _write_nb(tmp_path / "n.ipynb", [_code_cell("x")])
+    km, _ = _patch_kernelmanager([[]])
+    km.interrupt_kernel.side_effect = RuntimeError("interrupt not supported")
+    stats = dotnet_executor.execute_notebook(nb, cell_timeout=0)
+    assert stats["executed"] == 1
+    out = json.loads(nb.read_text(encoding="utf-8"))["cells"][0]["outputs"][0]
+    assert out["output_type"] == "stream"
+    assert "TIMEOUT" in out["text"]
+
+
+def test_drain_after_timeout_consumes_interrupted_idle(tmp_path, _patch_kernelmanager):
+    """Fix B: after interrupt, _drain_iopub consumes the interrupted request's
+    trailing idle (matching parent) and then returns, so the next cell starts
+    clean. The drain recognizes ``msg-1`` (cell 1's id) as the parent to sweep."""
+    nb = _write_nb(tmp_path / "n.ipynb", [_code_cell("a"), _code_cell("b")])
+    _patch_kernelmanager([
+        # cell 1: timeout branch drains this idle (parent=msg-1 -> matched -> return)
+        [_msg("status", parent="msg-1", execution_state="idle")],
+        # cell 2: also times out (cell_timeout=0); its drain finds only a parentless
+        # idle (unmatched -> continue) then queue.Empty -> best-effort return.
+        [_msg("status", execution_state="idle")],
+    ])
+    stats = dotnet_executor.execute_notebook(nb, cell_timeout=0)
+    assert stats["executed"] == 2  # both cells ran despite cell-1 timeout
+    cells = json.loads(nb.read_text(encoding="utf-8"))["cells"]
+    assert cells[0]["execution_count"] == 1
+    assert cells[1]["execution_count"] == 2
+    assert any("TIMEOUT" in o.get("text", "") for o in cells[0]["outputs"])
+    assert any("TIMEOUT" in o.get("text", "") for o in cells[1]["outputs"])


### PR DESCRIPTION
## Summary

Two robustness fixes in `scripts/notebook_tools/dotnet_executor.py` — the .NET Interactive cell-by-cell executor that gives every .NET notebook (Probas/Infer, Sudoku, Search, GameTheory) real `execution_count` and outputs. These are the **forensic findings first documented during #7420** (test coverage), now turned into actual fixes.

### Fix A — iopub `parent_msg_id` filter
The iopub loop consumed **every** message regardless of `parent_header.msg_id`. Stale output or a stray `idle` status emitted for a **prior** cell could:
- pollute this cell's outputs (leftover stream from the previous cell), or
- break this cell's loop early (a late `idle` from the prior cell terminates it before its own output arrives).

**Fix**: skip messages whose `parent_header.msg_id` names a different request than this cell's `kc.execute()` id. Parentless messages (kernel broadcasts) are **kept** — conservative, forward-compatible, and the canonical `jupyter_client` pattern.

### Fix B — interrupt + drain on timeout
The timeout branch only appended a `[TIMEOUT]` stderr note and moved on **while the kernel kept executing the stuck cell** — so the next `kc.execute()` queued behind it (cascading hang).

**Fix**: call `km.interrupt_kernel()` (wrapped `try/except` for kernel managers without interrupt support), then `_drain_iopub(kc, msg_id)` to discard this request's trailing messages so they don't consume the next cell's loop budget.

## Anti-regression audit
- **Pure addition**: `+42 lines, 0 deletions` on `dotnet_executor.py`. No existing logic removed/replaced.
- **No `sorry`/stub/`pass` replacing code** — only new guards added.
- **Consumers**: `dotnet_executor` is a standalone CLI (no Python `import` consumers — `notebook_helpers.py:1058` and `detect_bare_cross_dir_load.py:55` reference it in comments only). Fix A/B affect only the executor's own iopub loop.
- **Backward-compat**: conservative parent-filter keeps parentless messages, so the prior behavior for real kernels (where iopub messages carry matching `parent_header`) is unchanged on the happy path.

## Tests — 21/21 pass (0.67s, mocked KernelManager, no live kernel)
Supersedes #7420: includes its full 15-test suite verbatim + the `_msg` helper `parent_header` param + **6 new tests** pinning both fixes:
- `test_mismatched_parent_msg_id_is_skipped` — cross-cell stream dropped, ours kept (Fix A)
- `test_stray_idle_from_other_request_does_not_break_loop` — stray idle filtered, loop survives (Fix A)
- `test_parentless_message_is_still_kept` — conservative design pinned (Fix A)
- `test_interrupt_kernel_called_on_timeout` — interrupt invoked (Fix B)
- `test_interrupt_failure_does_not_crash` — interrupt raising still emits TIMEOUT stderr (Fix B)
- `test_drain_after_timeout_consumes_interrupted_idle` — drain sweeps interrupted request (Fix B)

```
21 passed in 0.67s
```

## Supersedes #7420
#7420 (test-only, 15 tests) is still OPEN and not yet merged. This PR includes its entire test suite verbatim + the fix + 6 new tests. **If merging this, please close #7420 as superseded.** If #7420 merges first, this branch rebases cleanly (only the `_msg` helper edit + appended tests overlap).

Forensic-floor contribution (dashboard guidance: standalone-Python pool saturated for CPU/text-only lanes; highest-substance untested critical infra = the productive vein). `dotnet_executor` is critical .NET infra (680L-class robustness gap closed).

See #7420