### PR TITLE
test(qc): cover shared/gpu_training.py thermal watchdog + checkpoints (0->18)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/shared/test_gpu_training.py
+++ b/MyIA.AI.Notebooks/QuantConnect/shared/test_gpu_training.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Pytest suite for `QuantConnect/shared/gpu_training.py`.
+
+Co-located with the module under `shared/`. CPU-only, no GPU, no nvidia-smi,
+no real training run. The module imports torch + torch.nn at top level (torch
+is installed CPU-only on this worker), so it loads cleanly. `torch.cuda` is
+never available on CPU, so every CUDA-guarded code path (thermal_check's hot
+branch, batch_thermal_check's delegation, setup_amp's enabled flag) is reached
+by monkeypatching `torch.cuda.is_available` -> True and mocking the
+nvidia-smi subprocess + time.sleep.
+
+The module is the GPU thermal-watchdog + checkpoint helper for ML training
+(notebooks 19-27 ML/DL/AI) and had 0 dedicated Python test coverage before
+this PR. This suite covers the pure/thermal/checkpoint logic; it deliberately
+does NOT exercise `amp_train_step` (a real forward/backward pass) to stay a
+unit test, not a training run.
+
+Strategy: tiny torch.nn.Linear model + SGD optimizer for checkpoint round-trips
+against tmp_path. get_gpu_temp is exercised by mocking subprocess.run.
+"""
+from __future__ import annotations
+
+import importlib.util
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+
+# Load the module by path (lives under shared/, top-level torch + stdlib only).
+_MODULE_PATH = Path(__file__).resolve().parent / "gpu_training.py"
+_spec = importlib.util.spec_from_file_location("gpu_training_under_test", _MODULE_PATH)
+gt = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gt)
+
+
+# --------------------------------------------------------------------------
+# Tiny model + optimizer fixtures for checkpoint round-trips
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tiny_model():
+    torch.manual_seed(0)
+    return nn.Linear(3, 1)
+
+
+@pytest.fixture
+def tiny_optimizer(tiny_model):
+    return torch.optim.SGD(tiny_model.parameters(), lr=0.01)
+
+
+# --------------------------------------------------------------------------
+# get_gpu_temp — nvidia-smi subprocess parse
+# --------------------------------------------------------------------------
+
+
+def _smi(stdout="75", returncode=0):
+    return lambda *a, **k: SimpleNamespace(stdout=stdout, stderr="", returncode=returncode)
+
+
+def test_get_gpu_temp_parses_int_stdout(monkeypatch):
+    monkeypatch.setattr(gt.subprocess, "run", _smi("73"))
+    assert gt.get_gpu_temp() == 73
+
+
+def test_get_gpu_temp_strips_whitespace(monkeypatch):
+    monkeypatch.setattr(gt.subprocess, "run", _smi("  \n82\n  "))
+    assert gt.get_gpu_temp() == 82
+
+
+def test_get_gpu_temp_returns_zero_on_subprocess_failure(monkeypatch):
+    def _raise(*a, **k):
+        raise FileNotFoundError("no nvidia-smi")
+
+    monkeypatch.setattr(gt.subprocess, "run", _raise)
+    assert gt.get_gpu_temp() == 0
+
+
+def test_get_gpu_temp_returns_zero_on_non_int_stdout(monkeypatch):
+    # Bare except -> 0 when stdout cannot be parsed as int.
+    monkeypatch.setattr(gt.subprocess, "run", _smi("N/A"))
+    assert gt.get_gpu_temp() == 0
+
+
+# --------------------------------------------------------------------------
+# thermal_check — CPU guard + hot/cool threshold logic
+# --------------------------------------------------------------------------
+
+
+def test_thermal_check_returns_zero_when_no_cuda(monkeypatch):
+    # On a CPU worker, torch.cuda.is_available() is False -> immediate 0,
+    # get_gpu_temp must NOT be called.
+    monkeypatch.setattr(gt.torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(gt, "get_gpu_temp", lambda: (_ for _ in ()).throw(AssertionError()))
+    assert gt.thermal_check(max_temp=80) == 0
+
+
+def test_thermal_check_hot_temp_sleeps(monkeypatch):
+    monkeypatch.setattr(gt.torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(gt, "get_gpu_temp", lambda: 92)
+    slept = []
+    monkeypatch.setattr(gt.time, "sleep", lambda s: slept.append(s))
+    temp = gt.thermal_check(max_temp=80, cool_sleep=15, verbose=False)
+    assert temp == 92
+    assert slept == [15]
+
+
+def test_thermal_check_cool_temp_no_sleep(monkeypatch):
+    monkeypatch.setattr(gt.torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(gt, "get_gpu_temp", lambda: 65)
+    slept = []
+    monkeypatch.setattr(gt.time, "sleep", lambda s: slept.append(s))
+    temp = gt.thermal_check(max_temp=80, verbose=False)
+    assert temp == 65
+    assert slept == []
+
+
+# --------------------------------------------------------------------------
+# batch_thermal_check — modulo gate
+# --------------------------------------------------------------------------
+
+
+def test_batch_thermal_check_skips_when_batch_not_multiple(monkeypatch):
+    # batch_idx=5, check_every=10 -> 5 % 10 != 0 -> skip, returns 0.
+    monkeypatch.setattr(gt.torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(gt, "get_gpu_temp", lambda: (_ for _ in ()).throw(AssertionError()))
+    assert gt.batch_thermal_check(5, check_every=10, verbose=False) == 0
+
+
+def test_batch_thermal_check_delegates_on_multiple(monkeypatch):
+    monkeypatch.setattr(gt.torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(gt, "get_gpu_temp", lambda: 70)
+    monkeypatch.setattr(gt.time, "sleep", lambda s: None)
+    # batch_idx=20, check_every=10 -> 20 % 10 == 0 -> delegates to thermal_check.
+    assert gt.batch_thermal_check(20, check_every=10, verbose=False) == 70
+
+
+# --------------------------------------------------------------------------
+# setup_amp — CUDA-gated scaler
+# --------------------------------------------------------------------------
+
+
+def test_setup_amp_returns_disabled_scaler_on_cpu():
+    # On CPU, use_amp must be False; GradScaler constructed disabled.
+    use_amp, scaler = gt.setup_amp()
+    assert use_amp is False
+    assert scaler is not None
+    assert scaler.is_enabled() is False
+
+
+# --------------------------------------------------------------------------
+# checkpoint_save — state dict shape
+# --------------------------------------------------------------------------
+
+
+def test_checkpoint_save_writes_required_fields(tmp_path, tiny_model, tiny_optimizer):
+    path = tmp_path / "ckpt.pt"
+    gt.checkpoint_save(str(path), epoch=3, model=tiny_model,
+                       optimizer=tiny_optimizer, best_val_loss=0.5,
+                       history={"train_loss": [1.0, 0.9]})
+    state = torch.load(path, weights_only=False)
+    assert state["epoch"] == 3
+    assert state["best_val_loss"] == 0.5
+    assert state["history"] == {"train_loss": [1.0, 0.9]}
+    assert "model_state_dict" in state
+    assert "optimizer_state_dict" in state
+    # Optional fields absent when not provided.
+    assert "scheduler_state_dict" not in state
+    assert "grad_scaler_state" not in state
+    assert "extra" not in state
+
+
+def test_checkpoint_save_includes_optional_fields_when_provided(tmp_path, tiny_model, tiny_optimizer):
+    path = tmp_path / "ckpt.pt"
+    scheduler = torch.optim.lr_scheduler.StepLR(tiny_optimizer, step_size=5)
+    scaler = torch.amp.GradScaler("cuda", enabled=False)
+    gt.checkpoint_save(str(path), epoch=2, model=tiny_model, optimizer=tiny_optimizer,
+                       scheduler=scheduler, grad_scaler=scaler, extra={"note": "run-42"})
+    state = torch.load(path, weights_only=False)
+    assert "scheduler_state_dict" in state
+    assert "grad_scaler_state" in state
+    assert state["extra"] == {"note": "run-42"}
+
+
+def test_checkpoint_save_requires_parent_dir_to_exist(tmp_path, tiny_model, tiny_optimizer):
+    # PINNED behavior (quirk, NOT force-fixed here — one-subject-per-PR):
+    # unlike data_cache.get_yf_data and video_helpers.frames_to_video which
+    # mkdir(parents=True) before writing, checkpoint_save calls torch.save
+    # directly and does NOT create the parent dir. A nested missing parent
+    # raises RuntimeError. Callers are responsible for creating the output dir.
+    nested = tmp_path / "deep" / "nested" / "ckpt.pt"
+    with pytest.raises(RuntimeError, match="Parent directory"):
+        gt.checkpoint_save(str(nested), epoch=1, model=tiny_model,
+                           optimizer=tiny_optimizer)
+    # After the caller creates the parent, save succeeds.
+    nested.parent.mkdir(parents=True)
+    gt.checkpoint_save(str(nested), epoch=1, model=tiny_model,
+                       optimizer=tiny_optimizer)
+    assert nested.exists()
+
+
+# --------------------------------------------------------------------------
+# checkpoint_resume — 3 cases
+# --------------------------------------------------------------------------
+
+
+def test_checkpoint_resume_from_scratch_when_no_files(tmp_path, tiny_model):
+    start, best, history, extra = gt.checkpoint_resume(
+        str(tmp_path / "nope.pt"), str(tmp_path / "nofinal.pt"), tiny_model
+    )
+    assert start == 0
+    assert best == float("inf")
+    assert history == {}
+    assert extra is None
+
+
+def test_checkpoint_resume_from_final_model(tmp_path, tiny_model):
+    # Write a "final model" save file (state_dict only + extra).
+    final = tmp_path / "final.pt"
+    torch.manual_seed(1)
+    expected = nn.Linear(3, 1)
+    torch.save({"model_state_dict": expected.state_dict(), "extra": {"acc": 0.9}}, final)
+    fresh = nn.Linear(3, 1)
+    start, best, history, extra = gt.checkpoint_resume(
+        str(tmp_path / "nope.pt"), str(final), fresh
+    )
+    # Final-model case returns start=-1, extra from the save.
+    assert start == -1
+    assert extra == {"acc": 0.9}
+    # Model weights loaded from the save.
+    loaded_w = list(fresh.parameters())[0].detach().tolist()
+    expected_w = list(expected.parameters())[0].detach().tolist()
+    assert loaded_w == expected_w
+
+
+def test_checkpoint_resume_from_checkpoint_roundtrip(tmp_path, tiny_model, tiny_optimizer):
+    ckpt = tmp_path / "ckpt.pt"
+    gt.checkpoint_save(str(ckpt), epoch=4, model=tiny_model, optimizer=tiny_optimizer,
+                       best_val_loss=0.42, history={"val_loss": [1.0, 0.42]},
+                       extra={"tag": "mid"})
+    # New model/optimizer to load into.
+    fresh_model = nn.Linear(3, 1)
+    fresh_opt = torch.optim.SGD(fresh_model.parameters(), lr=0.01)
+    start, best, history, extra = gt.checkpoint_resume(
+        str(ckpt), str(tmp_path / "nofinal.pt"), fresh_model, optimizer=fresh_opt
+    )
+    assert start == 4
+    assert best == 0.42
+    assert history == {"val_loss": [1.0, 0.42]}
+    assert extra == {"tag": "mid"}
+
+
+# --------------------------------------------------------------------------
+# TrainingCheckpoint — ctor + early-stopping patience
+# --------------------------------------------------------------------------
+
+
+def test_training_checkpoint_ctor_defaults():
+    tc = gt.TrainingCheckpoint("c.pt", "f.pt")
+    assert tc.checkpoint_path == "c.pt"
+    assert tc.model_save_path == "f.pt"
+    assert tc.max_temp == 80
+    assert tc.cool_sleep == 15
+    assert tc.patience == 7
+    assert tc.thermal_check_every == 10
+    assert tc.best_val_loss == float("inf")
+    assert tc.patience_counter == 0
+    assert tc.best_model_state is None
+
+
+def test_training_checkpoint_resume_from_scratch(tmp_path, tiny_model):
+    tc = gt.TrainingCheckpoint(str(tmp_path / "c.pt"), str(tmp_path / "f.pt"))
+    start_epoch, history = tc.resume(tiny_model)
+    assert start_epoch == 0
+    assert history == {}


### PR DESCRIPTION
## What

Test coverage pour **`QuantConnect/shared/gpu_training.py`** (512L) — GPU thermal-watchdog + checkpoint helper pour ML training (get_gpu_temp/thermal_check/batch_thermal_check watchdog nvidia-smi, setup_amp/amp_train_step mixed-precision, checkpoint_save/resume, class TrainingCheckpoint orchestrator), consommé par notebooks 19-27 ML/DL/AI. **0 test Python dédié** avant cette PR. Suite de la veine test-coverage QuantConnect/shared (suit `backtest_helpers` #7400 MERGED, `indicators` #7403, `ml_utils` #7419, `data_cache` #7451 — **module distinct**, sous-domaine GPU-thermal/checkpointing ≠ metrics/ML/caching).

## Bug-hunt G.9 — 1 VRAI bug trouvé (pinné, pas force-fixé)

Bug-hunt firsthand sur les 8 fonctions/classe : **1 vrai bug** trouvé (inconsistency), pinné sans force-fix (anti-regression + one-subject-per-PR).

**🐛 Bug `checkpoint_save` L256 — ne crée PAS le parent dir** : `torch.save(state, path)` est appelé **directement sans `mkdir(parents=True)`**, contrairement aux siblings du module (`data_cache.get_yf_data` L60, `video_helpers.frames_to_video` L295 créent tous les deux `Path(output).parent.mkdir(parents=True, exist_ok=True)`). Un path nested avec parent manquant → `RuntimeError: Parent directory ... does not exist`. Bug réel mais **mineur** (tous les callers réels passent des paths dans des dirs déjà existants : cwd notebook ou output_dir créé en amont). **Pin** dans `test_checkpoint_save_requires_parent_dir_to_exist` (comportement réel = caller doit créer le dir). **Recommandation** : PR fix séparée (1 ligne `Path(path).parent.mkdir(parents=True, exist_ok=True)` avant `torch.save`) avec protocole anti-regression 4-step. **NE PAS slipper le fix dans cette PR test-coverage.**

**0 autre bug forçable**. Logique défensive saine : `get_gpu_temp` bare-except→0, `thermal_check`/`batch_thermal_check` CPU-guard `if not torch.cuda.is_available(): return 0`, `checkpoint_resume` 3-cas (final-model / checkpoint / from-scratch) avec fallback `weights_only=False`.

## Livrable

- **`shared/test_gpu_training.py`** (co-localisé avec le module) — **18 tests CPU-only**, 3.72s. **torch installé CPU-only** (top-level import OK) ; paths CUDA-guardés atteints via `monkeypatch torch.cuda.is_available→True` + mock `subprocess.run` (nvidia-smi) + mock `time.sleep`. **N'exerce pas `amp_train_step`** (vrai forward/backward = training run, hors unit-test — conservateur vs GPU flags `feedback_gpu_*`). Charge via `importlib` path-load (self-contained). Couvre :
  - **`get_gpu_temp`** (4) : parse int stdout, **strip whitespace**, **zero sur subprocess failure** (FileNotFoundError), zero sur stdout non-int ("N/A" → bare-except → 0).
  - **`thermal_check`** (3) : **CPU-guard returns 0** (get_gpu_temp pas appelé), **hot temp sleeps `cool_sleep`**, cool temp no sleep.
  - **`batch_thermal_check`** (2) : **modulo gate** `batch_idx % check_every != 0` → skip 0, délégation sur multiple.
  - **`setup_amp`** (1) : use_amp=False + scaler disabled sur CPU.
  - **`checkpoint_save`** (3) : state dict shape (epoch/model/optimizer/best/history, optional scheduler/scaler/extra absents si non fournis), optional fields inclus quand fournis, **quirk parent-dir pinné** (RuntimeError si parent missing, OK après caller mkdir).
  - **`checkpoint_resume`** (3) : from-scratch (0, inf, {}, None), **final-model** (-1, inf, {}, extra + weights loaded), **checkpoint roundtrip** (epoch/best/history/extra restaurés).
  - **`TrainingCheckpoint`** (2) : ctor defaults (max_temp=80, cool_sleep=15, patience=7, thermal_check_every=10), resume from-scratch.

## Validation reproductible

```
$ cd MyIA.AI.Notebooks/QuantConnect/shared
$ python -m pytest test_gpu_training.py -q
18 passed in 3.72s
```

## Conformité

- Atomique : 1 domaine (QuantConnect/shared GPU-thermal quality), 1 fichier test co-localisé.
- Anti-regression : nouveau fichier de test, **0 .py métier touché**, 0 changement de comportement (diff = 1 NEW file). Le bug checkpoint_save est **pinné pas fixé** (fix = PR séparée).
- Pas de `Closes #N` (contribution qualité standalone).
- Pas de C.2 implication : 0 notebook modifié (test-only).
- Aucun GPU (torch CPU-only), aucun nvidia-smi réel (subprocess mocké), aucun training run (pas d'amp_train_step), aucune clé API, aucun QC Cloud.
- Catalogue byte-identique à `main`.
- **Pre-flight collision check rigoureux AVANT travail** (leçon po-2024 c.698-bis subagent-scan + ICT 2-test-dirs) : `gpu_training` absent de **tous** les OPEN PR titles (grep 49 titles = 0 hit ; `thermal_safe_train.py` #7433 = Sudoku, fichier distinct). Firsthand orphan-verified : 0 `test_gpu_training.py` co-localisé sur origin/main.
- Rebase frais off `origin/main` `c76d8b8f2`, worktree isolé `CoursIA-qc-gputrain`.
