### PR TITLE
fix(qc): gpu_training.checkpoint_save creates parent dir before torch.save

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/shared/gpu_training.py
+++ b/MyIA.AI.Notebooks/QuantConnect/shared/gpu_training.py
@@ -253,6 +253,12 @@ def checkpoint_save(
     if extra is not None:
         state['extra'] = extra
 
+    # Create the parent directory if missing (parents=True, exist_ok=True) so a
+    # nested path works without the caller pre-creating the output dir. Consistent
+    # with data_cache.get_yf_data and video_helpers.frames_to_video.
+    out_dir = os.path.dirname(path)
+    if out_dir:
+        os.makedirs(out_dir, exist_ok=True)
     torch.save(state, path)
 
 

--- a/MyIA.AI.Notebooks/QuantConnect/shared/test_gpu_training.py
+++ b/MyIA.AI.Notebooks/QuantConnect/shared/test_gpu_training.py
@@ -185,19 +185,18 @@ def test_checkpoint_save_includes_optional_fields_when_provided(tmp_path, tiny_m
     assert state["extra"] == {"note": "run-42"}
 
 
-def test_checkpoint_save_requires_parent_dir_to_exist(tmp_path, tiny_model, tiny_optimizer):
-    # PINNED behavior (quirk, NOT force-fixed here — one-subject-per-PR):
-    # unlike data_cache.get_yf_data and video_helpers.frames_to_video which
-    # mkdir(parents=True) before writing, checkpoint_save calls torch.save
-    # directly and does NOT create the parent dir. A nested missing parent
-    # raises RuntimeError. Callers are responsible for creating the output dir.
+def test_checkpoint_save_creates_nested_parent_dir(tmp_path, tiny_model, tiny_optimizer):
+    # checkpoint_save now creates the parent dir (parents=True, exist_ok=True)
+    # before torch.save, consistent with data_cache.get_yf_data and
+    # video_helpers.frames_to_video. Previously a nested missing parent raised
+    # RuntimeError and the caller had to mkdir first.
     nested = tmp_path / "deep" / "nested" / "ckpt.pt"
-    with pytest.raises(RuntimeError, match="Parent directory"):
-        gt.checkpoint_save(str(nested), epoch=1, model=tiny_model,
-                           optimizer=tiny_optimizer)
-    # After the caller creates the parent, save succeeds.
-    nested.parent.mkdir(parents=True)
+    assert not nested.parent.exists()
     gt.checkpoint_save(str(nested), epoch=1, model=tiny_model,
+                       optimizer=tiny_optimizer)
+    assert nested.exists()
+    # Idempotent: re-saving to the now-existing path still succeeds (exist_ok).
+    gt.checkpoint_save(str(nested), epoch=2, model=tiny_model,
                        optimizer=tiny_optimizer)
     assert nested.exists()
 


### PR DESCRIPTION
## Summary

`shared/gpu_training.py::checkpoint_save` called `torch.save(state, path)` without creating the parent directory, so a nested output path raised `RuntimeError` if the parent didn't exist — inconsistent with the two sibling writers (`data_cache.get_yf_data` L61 and `video_helpers.frames_to_video`) which `mkdir(parents=True, exist_ok=True)` before writing. This PR adds the 1 defensive `os.makedirs(..., exist_ok=True)` call.

## ★ Explicitly handed off by po-2025 (c.542 [DONE])

po-2025 discovered the quirk while writing #7454 and **deliberately did not force-fix it** (one-subject-per-PR), pinning it instead with a test that documented the behavior AND pointed at the fix:

> `Residual finding pour fix PR future : gpu_training.checkpoint_save parent-dir mkdir (1 ligne) — je ne l'ouvre pas ce cycle (overlap avec #7454 test, one-subject-per-PR ; ai-01 ou cycle suivant).`

The pin-test comment itself read:
> `PINNED behavior (quirk, NOT force-fixed here — one-subject-per-PR): unlike data_cache.get_yf_data and video_helpers.frames_to_video which mkdir(parents=True) before writing, checkpoint_save calls torch.save directly and does NOT create the parent dir.`

#7454 has since **merged (18:58:49Z)** → merge-order blocker cleared → this is the deferred follow-up. po-2025's "Callers are responsible" was documenting **current** behavior, not defending it as desired; the sibling reference is the signal that the wanted contract is function-owned.

## Fix (additive, backward-compatible)

```python
out_dir = os.path.dirname(path)
if out_dir:
    os.makedirs(out_dir, exist_ok=True)
torch.save(state, path)
```

- `exist_ok=True` → no-op when the dir exists, so callers that pre-create it (old contract) are unaffected.
- Empty-guard → handles a bare filename where `os.path.dirname` returns `""` (`os.makedirs("")` raises `FileNotFoundError`).
- `os` already imported (L40), no new import.

## Anti-regression

Pure addition on gpu_training.py (**+6 lines, 0 deletions** of existing logic). No `sorry`/stub/`pass`. The test change flips the pin from asserting the buggy `RuntimeError` to asserting the fixed behavior.

## Validation (mcp-jupyter-py310, torch 2.6.0+cu124)

```
17 passed, 1 pre-existing env false-fail
```

The 1 fail = `test_setup_amp_returns_disabled_scaler_on_cpu` (asserts CPU-only `use_amp=False` but this worker machine has CUDA → `use_amp=True`). **CI runners are CPU-only → passes there.** Unrelated to this change: `setup_amp`/L149 is not touched (diff is checkpoint_save + its test only).

New test `test_checkpoint_save_creates_nested_parent_dir` PASSES (asserts nested parent auto-created + idempotent re-save).

## G.9 firsthand verification

- Bug real: `grep mkdir gpu_training.py` = 0 hits vs `data_cache.py:61` `cdir.mkdir(parents=True, exist_ok=True)`.
- Collision pre-flight: `gh pr list --search "checkpoint_save mkdir"` = 0 hits; `gpu_training checkpoint` = 0 open fix PR.
- Lines stable on fresh base `351445967` (origin/main advanced past c76d8b8f2).

## Hygiène

- **One subject**: checkpoint_save mkdir + its pin-test flip. 2 fichiers, +16/−11.
- **0 notebook touched** (no C.2 implication).
- **Catalogue byte-identical** to main (HARD 1).
- **0 CRLF** (LF, matches origin/main).
- Worktree `C:/dev/CoursIA-gpu-ckpt-fix` off `origin/main`.

## R6 transparence

Genre **bug-fix** (fresh vs test-coverage c.539-542). Family **QuantConnect/shared** (sous-domaine gpu-training/checkpointing, distinct de plotting c.540 / features #7407). Pre-flight collision check ran BEFORE work. Firsthand bug-verified (not delegated).

Co-Authored-By: Claude <noreply@anthropic.com>
