### PR TITLE
Docs(c679,#5780): enrich 2 inline README alt-texts in GenAI/Audio/01-Foundation (TITLES-driven -> CONTENT-driven)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/README.md
@@ -30,7 +30,7 @@ Ce module couvre les fondamentaux du traitement audio par IA : reconnaissance vo
 **Étape 1 — Forme d'onde.** Le point de départ : l'amplitude du signal échantillonnée dans le temps. On y lit directement la structure alternée de silence et de parole :
 
 <p align="center">
-  <a href="01-3-Basic-Audio-Operations.ipynb"><img src="assets/readme/aud1-waveform.png" alt="Forme d'onde (waveform) du signal audio" width="480"/></a><br>
+  <a href="01-3-Basic-Audio-Operations.ipynb"><img src="assets/readme/aud1-waveform.png" alt="Forme d'onde d'un échantillon audio — courbe matplotlib unique 'Forme d'onde - Echantillon de test' (axe Y amplitude ±0,4, axe X temps 0-12 s) ; sept alternances parole/silence révélant la structure du signal échantillonné." width="480"/></a><br>
   <em>Sortie du notebook <a href="01-3-Basic-Audio-Operations.ipynb">01-3</a> (cellule 12) : forme d'onde — l'amplitude en fonction du temps.</em>
 </p>
 
@@ -44,7 +44,7 @@ Ce module couvre les fondamentaux du traitement audio par IA : reconnaissance vo
 **Étape 3 — MFCC.** Les coefficients cepstraux dans l'échelle mel (MFCC) condensent le spectrogramme en un petit nombre de coefficients qui captent le timbre perceptuel — la représentation de référence pour STT et classification audio. Deux vues complémentaires : la courbe des coefficients et la carte de chaleur :
 
 <p align="center">
-  <a href="01-3-Basic-Audio-Operations.ipynb"><img src="assets/readme/aud1-mfcc.png" alt="MFCC — coefficients cepstraux mel" width="460"/></a><br>
+  <a href="01-3-Basic-Audio-Operations.ipynb"><img src="assets/readme/aud1-mfcc.png" alt="Heatmap MFCC — matplotlib 'MFCC - Echantillon de test' (axe Y Coefficient MFCC, axe X Time 0-12 s, colorbar -500 à 200) ; coefficients bas = énergie rouge/orange concentrée (formants), coefficients élevés = bleus négatifs — révèle l'enveloppe spectrale du signal." width="460"/></a><br>
   <em>Sortie du notebook <a href="01-3-Basic-Audio-Operations.ipynb">01-3</a> (cellule 20, sortie 1) : MFCC — coefficients cepstraux mel.</em>
 </p>
 


### PR DESCRIPTION
# Docs(c679,#5780): enrich 2 inline README alt-texts in GenAI/Audio/01-Foundation

## Scope

c.679 atomic leaf — poursuite du rollout **#5780 doctrine** sur les alts-texts inline README. Spin-off du pilote MERGED c.445 (#6635) qui avait audité 5 figures MANIFEST-level + enrichi 2 alts (spectrogram + mfcc2) ; restait **2 figures inline encore TITLES-driven** dans `GenAI/Audio/01-Foundation/README.md`.

| Action | Fichier | Δ | Nature |
|---|---|---|---|
| `git add` | `MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/README.md` | +2/-2 | 2 alts-texts TITLES-driven → CONTENT-driven |

## Cible (audience : humains lisant le README, lecteurs d'écran, robots QA vision)

| Figure | Alt AVANT (TITLES-driven) | Alt APRÈS (CONTENT-driven, vision-firsthand MiniMax-M3) |
|---|---|---|
| `aud1-waveform.png` | "Forme d'onde (waveform) du signal audio" | Courbe matplotlib unique "Forme d'onde - Echantillon de test" (axe Y amplitude ±0,4, axe X temps 0-12 s) ; sept alternances parole/silence révélant la structure du signal échantillonné |
| `aud1-mfcc.png` | "MFCC — coefficients cepstraux mel" | Heatmap MFCC "MFCC - Echantillon de test" (axe Y Coefficient MFCC, axe X Time 0-12 s, colorbar -500 à +200) ; coefficients bas = énergie rouge/orange concentrée (formants), coefficients élevés = bleus négatifs — révèle l'enveloppe spectrale |

**Lecture inverse (clarté) :** chaque nouvelle description ouvre par le **type de figure** (courbe / heatmap) et le **titre matplotlib exact**, puis donne **axes + ranges mesurés à l'œil** sur le PNG, puis **pattern visible** (alternances, zones d'énergie, distribution colorimétrique). Tout est vérifiable au pixel près par re-render du notebook `01-3-Basic-Audio-Operations.ipynb` cellules 12 et 20.

## Pourquoi ce PR a de la valeur (R5.4b PIVOT sustained)

- **Veine test-coverage GenAI/shared/helpers/ DRAINED** (c.678, PR #7455 MERGED-pending). R6 anti-monotonie : c.679+ doit pivoter registre/famille.
- **STEER ai-01 verbatim 2026-07-19** : « casser les vagues monothématiques ; lanes VISION (MiniMax) jouent la carte que les lanes GLM n'ont pas → **QA visuel** #3966 (figures cassées/blanches/placeholder) OU #5780 (narratif figures README), read-only, ComfyUI-DOWN-proof. »
- Ce PR est la **carte MiniMax-M3 vision** : j'ai lu les 2 PNG via `Read` (image) — la lecture text-only GLM n'aurait rien vu. Pas de code production, pas de GPU, pas de ComfyUI — purely VISION discipline. **ComfyUI-DOWN-proof**.

## C.679 enrichit 2 figures seulement (pas 5) — pourquoi

Sur les 5 figures inline du README :
- **3 déjà CONTENT-driven** : `aud1-spectrogram.webp`, `aud1-mfcc2.png`, `aud1-features.png` (alt-texts à 3 panneaux détaillés avec ranges, hérités de la vague c.445 / propagation #6767). **Pas touchés** — anti-régression sur le travail c.445 MERGED.
- **2 encore TITLES-driven** : `aud1-waveform.png`, `aud1-mfcc.png` (alt = titre du chapitre, pas du contenu visuel). **Cibles du PR**.

**Atomicité respectée** : 1 fichier, 1 feature (enrichissement alts), 1 sous-dossier (Audio/01-Foundation), 1 registre (#5780 doctrine prose-figures). 2 substitutions seulement = diff minimal et propre.

## Conformité règles

- **R1 catalog-pr-hygiene** : aucun fichier catalogue touché (`COURSE_CATALOG.*`, `CATALOG-STATUS`, README inchangés en termes de structure).
- **R2 fresh base** : `origin/main@415e00070` 2026-07-19 = base fraîche (≤1 jour).
- **R3 atomique** : 1 fichier, 1 feature (enrichissement alts), 1 sous-dossier (Audio/01-Foundation), +2/-2 ≪ 3000 lignes. ✅
- **R4 See vs Closes** : `See #5780` (Epic audit vision général). Ne **close pas** l'epic — il reste les autres READMEs à traiter.
- **L268 LF-only** : CR=0 vérifié (`git diff | grep -c $'\r' = 0`).
- **L143 secrets-hygiene** : 0 secret inline dans le diff (regex `sk-/ghp_/AIza` = 0 hit). Aucun mot de passe, aucune URL avec credentials.
- **G.4 composite** : 1 feature (audit prose-figures README) = pas de split.
- **C.3 strict** : 0 notebook touché (pixel-perfect preservation).
- **G.1 firsthand AVANT dashboard-report** : 2 PNG lus via `Read` tool (MiniMax-M3 vision) AVANT rédaction des alt-texts — descriptions factuelles basées sur l'image rendue, pas inventées.
- **H.1 validation** : changements purement markdown (2 lignes), pas d'exécution notebook requise.
- **R5.4b PIVOT sustain** : c.679 = même registre #5780 doctrine qu'c.671/c.672/c.673/c.445 MAIS nouvelle figure + nouveau dossier enfant = monotonie évitée (R6 OK).
- **R7 outcome-based** : substance PR = 2 descriptions alts enrichies, vérifiables au pixel près, valeur ajoutée réelle pour accessibilité + QA vision.
- **L420-L1 ★★ anti-contamination** : PR sur GenAI/Audio/01-Foundation UNIQUEMENT. Aucun notebook production ni code de production modifié. Pas de scope Lean/QC/.NET.
- **L677-L3 ★★** : `PR_BODY.md` écrit HORS worktree (`C:/Users/.../scratchpad/PR_BODY_c679.md`, NTFS case-insensitive safe) + `gh pr create --body-file` (jamais `--body`).
- **L529-push-L1 ★** : push identité = `jsboige`.
- **C633-L1 ★★** : pre-push collision scan `gh pr list --search "audio alt-text sweep"` = 0 collision sur OPEN (seuls MERGED : #6635 c.445 sur spectrogram+mfcc2 distincts, #6767 propagation). **Aucune collision** sur `aud1-waveform` ou `aud1-mfcc`.
- **C664-L1 ★★** : cleanup worktree c.679 GATED sur merge-pass effectif post-merge. Pas de cleanup spéculatif.
- **L808-L1 ★★★** : `git ls-files GenAI/Audio/01-Foundation/README.md` confirme existence du fichier, audit ciblé sur ce seul README.

## Méthodologie vision (pour traçabilité)

1. **G.1 firsthand** : `Read` tool sur chaque PNG cible → contenu visuel réel (titre matplotlib, axes, ranges, palette, structure).
2. **Cross-check** avec **MANIFEST sub-folder** c.445 (déjà audité) : confirme attributions cellule×output restent valides.
3. **Anti-sur-vente** (doctrine c.479) : décrire ce que le PNG **montre réellement**, pas ce que la section de chapitre **prétend** qu'il montre. La waveform montre 7 alternances, pas "plusieurs" (chiffre vérifié à l'œil). Le MFCC heatmap a coefficients bas rouges ET coefficients élevés bleus, pas seulement "rouge" (ce qui serait une sur-vente).
4. **Pas de pixel modif** : seules les chaînes `alt="..."` HTML sont changées ; les PNG eux-mêmes restent byte-identiques (asset integrity preserved).

## Validation locale

```
$ git diff MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/README.md | grep -c $'\r'
0

$ git diff --stat MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/README.md
 .../GenAI/Audio/01-Foundation/README.md | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)

$ git diff MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/README.md | grep -ciE 'sk-[a-z0-9]{20,}|ghp_[a-z0-9]{20,}|AIza[a-zA-Z0-9]{20,}'
0
```

**2/2 PASSED** : LF-only OK + 0 secret inline.

## Leçons c.679

| Leçon | Level | Contenu |
|---|---|---|
| **C679-L1 ★** | Sub-folder MANIFEST audité ≠ README inline audité | c.445 (#6635) a audité 5 figures MANIFEST-level pour Audio/01-Foundation mais le README inline référençait 5 figures dont 3 avec alts encore TITLES-driven. Le périmètre c.445 = cohérence asset↔cellule ; le périmètre c.679 = cohérence prose-figures. **Deux périmètres distincts**, ne PAS les fusionner. |
| **C679-L2 ★★** | Vision lane-routing = VISION content, pas text-only | MiniMax-M3 (CoursIA-2) lit les PNG via `Read` ; les lanes GLM (CoursIA) ne voient pas (incident fondateur `workflow-orchestration.png` 2026-07-11). Routage capability-driven : ce PR est MiniMax-par-essence, jamais GLM. |
| **C679-L3 ★** | Atomic = 2 figures, pas 5 | 3 figures déjà CONTENT-driven (anti-régression c.445 / #6767) → 2 cibles restantes. Atomic = subset minimal qui ajoute de la valeur. Évite de re-toucher ce qui marche déjà (incident fondateur `simplify` c.524 #7333 strippant trop). |

## Résiduel c.679 → c.680+

- **#5780 doctrine en cours** : 26 READMEs GenAI restent à passer au peigne vision-QA. **Rollout READMEs** atomic par sous-dossier : ce PR = 1 sous-dossier (Audio/01-Foundation, 2 alts sur 5) — restent potentiellement Texte/Vidéo/Image/02-Advanced/03-Orchestration à scanner.
- **Audit vision sibling post-c.679** : 26 READMEs avec figures inline, pattern reproductible = **c.680+ candidates directes** par cluster de 1-2 READMEs (registre sustained, R6 OK si on alterne sous-dossiers).
- **Veine test-coverage DRAINED** : c.678 PR #7455 MERGED-pending. Pool cross-lane ~48 OPEN sustained.
- **Worktree c.679** `D:/Dev/CoursIA-c679-audio-01f-alt-text` : eligible cleanup post-merge (#7455 MERGED + ce PR MERGED), C664-L1 ★★.

## Liens

- **#5780** — Epic doctrine prose-figures (audit vision + enrichissement alts).
- **#6635** (c.445) — audit fondateur MANIFEST-level Audio/01-Foundation 5/5 + 2 corrections réelles (spectrogram + mfcc2) MERGED.
- **#6767** — propagation c.445 vetted alts to README (3 figures) MERGED.
- **#7333** — strip 7 orphan "Aperçu — … en images" sections MERGED.
- **#5654** — Epic sœur illustrer READMEs (figures ajoutées aux READMEs).
- **Issue ai-01 STEER 2026-07-19** : « QA visuel #3966 OU #5780, lanes VISION MiniMax ».
- `MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/README.md` (5 figures inline, 2 alts enrichis dans ce PR).
- `MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/assets/readme/MANIFEST.md` (audité c.445, attributions cellule×output confirmées).
- `MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-3-Basic-Audio-Operations.ipynb` (cellules 12, 15, 20, 28 produisant les 5 figures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>