### PR TITLE
feat(lean): Grothendieck Part 25 — Adjunction module (FR + EN sibling, See #2159)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck.lean
@@ -197,3 +197,4 @@ import Grothendieck.MayerVietorisSquare
 import Grothendieck.SheafCohomology.MayerVietoris
 import Grothendieck.SheafCohomology.Cech
 import Grothendieck.YonedaLemma
+import Grothendieck.Adjunction

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Adjunction.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Adjunction.lean
@@ -1,0 +1,168 @@
+/-
+Grothendieck Partie 25 — Foncteurs adjoints
+
+Alexandre Grothendieck (1928-2014).
+
+Extension Phase 2+ (#2159, Epic #1646).
+
+Les foncteurs adjoints sont, avec le lemme de Yoneda, l'outil catégorique le
+plus universel de la géométrie algébrique grothendieckienne. Grothendieck les
+utilise partout : l'adjonction Spec ⊣ Γ (géométrie ↔ algèbre), l'adjonction
+faisceautisation ⊣ inclusion (préfaisceaux ↔ faisceaux), l'adjonction fibre ⊣
+faisceau gratte-ciel (points ↔ faisceaux), et les foncteurs dérivés adjoints
+de la cohomologie.
+
+Une adjonction L ⊣ R entre deux catégories est une équivalence naturelle
+`Hom_D(L X, Y) ≃ Hom_C(X, R Y)`. Elle équilibre deux points de vue
+duaux : « résoudre à gauche » (L construit les objets libres) et
+« oublier à droite » (R ramène dans la catégorie de base). Toute construction
+universelle (limites, colimites, objets libres) s'exprime comme une adjonction.
+
+Mathlib 4 formalise toute cette infrastructure dans `Mathlib.CategoryTheory.Adjunction` :
+  - `CategoryTheory.Adjunction : C ⥤ D → Type*` — la structure d'adjonction L ⊣ R
+  - `CategoryTheory.Adjunction.homEquiv` — l'équivalence Hom naturelle
+  - `CategoryTheory.Adjunction.unit` / `counit` — les transformations naturelles
+  - `CategoryTheory.Adjunction.left_triangle` / `right_triangle` — identités triangulaires
+  - `CategoryTheory.IsLeftAdjoint` — propriété d'avoir un adjoint à droite
+  - `CategoryTheory.Adjunction.fullyFaithfulLOfIsIsoUnit` — pleine fidélité via l'unité
+
+Ce module ré-expose ces faits comme un parcours pédagogique organisé, pour
+des apprenants découvrant les adjonctions pour la première fois.
+
+Epic #1646, See #2159. Tous les `sorry` éliminés à la création.
+
+### i18n — convention #4980 ratifiée 2026-07-04
+
+Ce module est jumelé avec sa version anglaise canonique dans le fichier
+sibling `Adjunction_en.lean`. Les énoncés de théorèmes, les noms de lemmes,
+les tactiques Lean et les références Mathlib restent en anglais. Seules les
+**docstrings `/-- ... -/`** et les **commentaires `-- ...`** diffèrent entre
+les deux fichiers. Anti-§D byte-identity garanti.
+-/
+
+import Mathlib.CategoryTheory.Adjunction.Basic
+import Mathlib.CategoryTheory.Adjunction.Limits
+import Mathlib.CategoryTheory.Adjunction.FullyFaithful
+
+universe v₁ v₂ u₁ u₂
+
+namespace Grothendieck.Adjunction
+
+open CategoryTheory Limits
+
+variable {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D]
+
+/-!
+## 1. La structure d'adjonction
+
+Une adjonction `L ⊣ R` entre un foncteur `L : C ⥤ D` (adjoint à gauche) et
+`R : D ⥤ C` (adjoint à droite) est l'équivalence naturelle en les deux
+variables : `Hom_D(L X, Y) ≃ Hom_C(X, R Y)`.
+-/
+
+-- La structure d'adjonction L ⊣ R entre deux foncteurs.
+#check @CategoryTheory.Adjunction
+
+-- L'équivalence Hom naturelle Hom_D(L X, Y) ≃ Hom_C(X, R Y).
+#check @CategoryTheory.Adjunction.homEquiv
+
+-- La notation `L ⊣ R` dénote `Adjunction L R` (L adjoint à gauche de R).
+#check @CategoryTheory.Adjunction
+
+/-!
+## 2. L'unité et la coïnité, identités triangulaires
+
+Toute adjonction `L ⊣ R` détermine l'unité `η : 𝟭 C ⟶ R ⋙ L` et la coïnité
+`ε : L ⋙ R ⟶ 𝟭 D`, satisfaisant les identités triangulaires. Les composantes
+en un objet s'obtiennent par `h.unit.app X` et `h.counit.app Y` (application
+d'une transformation naturelle).
+-/
+
+-- L'unité η : 𝟭 C ⟶ R ⋙ L de l'adjonction.
+#check @CategoryTheory.Adjunction.unit
+
+-- La coïnité ε : L ⋙ R ⟶ 𝟭 D de l'adjonction.
+#check @CategoryTheory.Adjunction.counit
+
+-- Première identité triangulaire (coïnité après L de l'unité = identité).
+#check @CategoryTheory.Adjunction.left_triangle
+
+-- Seconde identité triangulaire (unité après R de la coïnité = identité).
+#check @CategoryTheory.Adjunction.right_triangle
+
+/-!
+## 3. Existence d'un adjoint
+
+Un foncteur qui a un adjoint à droite est un « adjoint à gauche »
+(`CategoryTheory.Functor.IsLeftAdjoint`). C'est une classe de proposition :
+elle enregistre l'existence d'un `R` avec `L ⊣ R`.
+-/
+
+-- La propriété pour un foncteur d'être adjoint à gauche (avoir un R avec L ⊣ R).
+#check @CategoryTheory.Functor.IsLeftAdjoint
+
+/-!
+## 4. Conservation des limites et colimites
+
+Théorème pratique : un adjoint à droite préserve les limites, un adjoint à
+gauche préserve les colimites.
+-/
+
+-- Un adjoint à droite préserve les limites.
+#check @CategoryTheory.Adjunction.rightAdjoint_preservesLimits
+
+-- Un adjoint à gauche préserve les colimites.
+#check @CategoryTheory.Adjunction.leftAdjoint_preservesColimits
+
+/-!
+## 5. Pleine fidélité d'un adjoint
+
+L'unité est un isomorphisme naturel ssi l'adjoint à gauche est pleinement
+fidèle ; symétriquement pour la coïnité et l'adjoint à droite.
+-/
+
+-- L'adjoint à gauche est pleinement fidèle si l'unité est un isomorphisme.
+#check @CategoryTheory.Adjunction.fullyFaithfulLOfIsIsoUnit
+
+-- L'adjoint à droite est pleinement fidèle si la coïnité est un isomorphisme.
+#check @CategoryTheory.Adjunction.fullyFaithfulROfIsIsoCounit
+
+/-!
+## 6. Théorèmes ponts
+
+Reformulations dans l'espace de noms du projet, pontant les faits Mathlib.
+-/
+
+/-- Pont : l'hom-équivalence d'une adjonction L ⊣ R, vue comme famille
+    naturelle en X et Y. C'est la donnée qui fait d'une adjonction une
+    bijection naturelle, pas juste ponctuelle. -/
+def homEquiv_family {L : C ⥤ D} {R : D ⥤ C} (h : L ⊣ R) :
+    (X : C) → (Y : D) → (L.obj X ⟶ Y) ≃ (X ⟶ R.obj Y) :=
+  fun X Y ↦ h.homEquiv X Y
+
+/-- Pont : un adjoint à gauche préserve les colimites. Fait structurel le plus
+    utilisé en géométrie algébrique pour transporter les colimites le long des
+    foncteurs « libres » (faisceautisation, tensorisation, image inverse). -/
+theorem leftAdjoint_preserves_colimits {L : C ⥤ D} {R : D ⥤ C} (h : L ⊣ R) :
+    PreservesColimitsOfSize L :=
+  h.leftAdjoint_preservesColimits
+
+/-- Pont : un adjoint à droite préserve les limites. -/
+theorem rightAdjoint_preserves_limits {L : C ⥤ D} {R : D ⥤ C} (h : L ⊣ R) :
+    PreservesLimitsOfSize R :=
+  h.rightAdjoint_preservesLimits
+
+/-- Pont : dans une adjonction L ⊣ R, si l'unité est un isomorphisme naturel
+    alors l'adjoint à gauche L est pleinement fidèle (critère de réflexion
+    pleine). -/
+noncomputable def fully_faithful_of_unit_iso {L : C ⥤ D} {R : D ⥤ C} (h : L ⊣ R)
+    [IsIso h.unit] : L.FullyFaithful :=
+  h.fullyFaithfulLOfIsIsoUnit
+
+/-- Pont : dans une adjonction L ⊣ R, si la coïnité est un isomorphisme naturel
+    alors l'adjoint à droite R est pleinement fidèle. -/
+noncomputable def fully_faithful_of_counit_iso {L : C ⥤ D} {R : D ⥤ C} (h : L ⊣ R)
+    [IsIso h.counit] : R.FullyFaithful :=
+  h.fullyFaithfulROfIsIsoCounit
+
+end Grothendieck.Adjunction

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Adjunction_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Adjunction_en.lean
@@ -1,0 +1,166 @@
+/-
+Grothendieck Part 25 — Adjunctions (English mirror of Adjunction.lean)
+
+Alexander Grothendieck (1928-2014).
+
+Extension Phase 2+ (#2159, Epic #1646).
+
+Alongside the Yoneda lemma, adjoint functors are the most universal
+categorical tool of Grothendieck-style algebraic geometry. Grothendieck uses
+them everywhere: the Spec ⊣ Γ adjunction (geometry ↔ algebra), the
+sheafification ⊣ inclusion adjunction (presheaves ↔ sheaves), the fiber ⊣
+skyscraper-sheaf adjunction (points ↔ sheaves), and the adjoint derived
+functors of cohomology.
+
+An adjunction L ⊣ R between two categories is a natural equivalence
+`Hom_D(L X, Y) ≃ Hom_C(X, R Y)`. It balances two dual viewpoints:
+"resolve on the left" (L builds free objects) and "forget on the right"
+(R returns to the base category). Every universal construction (limits,
+colimits, free objects) is expressible as an adjunction.
+
+Mathlib 4 formalises all of this infrastructure in
+`Mathlib.CategoryTheory.Adjunction`:
+  - `CategoryTheory.Adjunction : C ⥤ D → Type*` — the L ⊣ R structure
+  - `CategoryTheory.Adjunction.homEquiv` — the natural Hom equivalence
+  - `CategoryTheory.Adjunction.unit` / `counit` — the natural transformations
+  - `CategoryTheory.Adjunction.left_triangle` / `right_triangle` — triangle identities
+  - `CategoryTheory.IsLeftAdjoint` — the property of having a right adjoint
+  - `CategoryTheory.Adjunction.fullyFaithfulLOfIsIsoUnit` — full faithfulness via the unit
+
+This module re-exposes these facts as an organised pedagogical tour.
+
+Epic #1646, See #2159. No `sorry` at creation.
+
+### i18n — convention #4980 ratified 2026-07-04
+
+This module is the English mirror of `Adjunction.lean`. Theorem statements,
+lemma names, Lean tactics and Mathlib references stay in English. Only the
+**docstrings `/-- ... -/`** and **comments `-- ...`** differ between the two
+files. Anti-§D byte-identity guaranteed.
+-/
+
+import Mathlib.CategoryTheory.Adjunction.Basic
+import Mathlib.CategoryTheory.Adjunction.Limits
+import Mathlib.CategoryTheory.Adjunction.FullyFaithful
+
+universe v₁ v₂ u₁ u₂
+
+namespace Grothendieck.Adjunction_en
+
+open CategoryTheory Limits
+
+variable {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D]
+
+/-!
+## 1. The adjunction structure
+
+An adjunction `L ⊣ R` between a functor `L : C ⥤ D` (left adjoint) and
+`R : D ⥤ C` (right adjoint) is the natural equivalence in both variables:
+`Hom_D(L X, Y) ≃ Hom_C(X, R Y)`.
+-/
+
+-- The L ⊣ R adjunction structure between two functors.
+#check @CategoryTheory.Adjunction
+
+-- The natural Hom equivalence Hom_D(L X, Y) ≃ Hom_C(X, R Y).
+#check @CategoryTheory.Adjunction.homEquiv
+
+-- The notation `L ⊣ R` denotes `Adjunction L R` (L left adjoint to R).
+#check @CategoryTheory.Adjunction
+
+/-!
+## 2. The unit and counit, triangle identities
+
+Every adjunction `L ⊣ R` determines the unit `η : 𝟭 C ⟶ R ⋙ L` and the
+counit `ε : L ⋙ R ⟶ 𝟭 D`, satisfying the triangle identities. Components at
+an object are obtained via `h.unit.app X` and `h.counit.app Y` (natural
+transformation application).
+-/
+
+-- The unit η : 𝟭 C ⟶ R ⋙ L of the adjunction.
+#check @CategoryTheory.Adjunction.unit
+
+-- The counit ε : L ⋙ R ⟶ 𝟭 D of the adjunction.
+#check @CategoryTheory.Adjunction.counit
+
+-- First triangle identity (counit after L of the unit = identity).
+#check @CategoryTheory.Adjunction.left_triangle
+
+-- Second triangle identity (unit after R of the counit = identity).
+#check @CategoryTheory.Adjunction.right_triangle
+
+/-!
+## 3. Existence of an adjoint
+
+A functor with a right adjoint is a "left adjoint"
+(`CategoryTheory.Functor.IsLeftAdjoint`). This is a Prop-class recording the
+existence of an `R` with `L ⊣ R`.
+-/
+
+-- The property of a functor being a left adjoint (having an R with L ⊣ R).
+#check @CategoryTheory.Functor.IsLeftAdjoint
+
+/-!
+## 4. Preservation of limits and colimits
+
+Practical theorem: a right adjoint preserves limits, a left adjoint preserves
+colimits.
+-/
+
+-- A right adjoint preserves limits.
+#check @CategoryTheory.Adjunction.rightAdjoint_preservesLimits
+
+-- A left adjoint preserves colimits.
+#check @CategoryTheory.Adjunction.leftAdjoint_preservesColimits
+
+/-!
+## 5. Full faithfulness of an adjoint
+
+The unit is a natural isomorphism iff the left adjoint is fully faithful;
+symmetrically for the counit and the right adjoint.
+-/
+
+-- The left adjoint is fully faithful if the unit is an isomorphism.
+#check @CategoryTheory.Adjunction.fullyFaithfulLOfIsIsoUnit
+
+-- The right adjoint is fully faithful if the counit is an isomorphism.
+#check @CategoryTheory.Adjunction.fullyFaithfulROfIsIsoCounit
+
+/-!
+## 6. Bridge theorems
+
+Reformulations in the project namespace, bridging the Mathlib facts.
+-/
+
+/-- Bridge: the hom-equivalence of an adjunction L ⊣ R, viewed as a family
+    natural in X and Y. This is the datum that makes an adjunction a natural
+    bijection, not just a pointwise one. -/
+def homEquiv_family {L : C ⥤ D} {R : D ⥤ C} (h : L ⊣ R) :
+    (X : C) → (Y : D) → (L.obj X ⟶ Y) ≃ (X ⟶ R.obj Y) :=
+  fun X Y ↦ h.homEquiv X Y
+
+/-- Bridge: a left adjoint preserves colimits. The structural fact most used in
+    algebraic geometry to transport colimits along "free" functors
+    (sheafification, tensoring, inverse image). -/
+theorem leftAdjoint_preserves_colimits {L : C ⥤ D} {R : D ⥤ C} (h : L ⊣ R) :
+    PreservesColimitsOfSize L :=
+  h.leftAdjoint_preservesColimits
+
+/-- Bridge: a right adjoint preserves limits. -/
+theorem rightAdjoint_preserves_limits {L : C ⥤ D} {R : D ⥤ C} (h : L ⊣ R) :
+    PreservesLimitsOfSize R :=
+  h.rightAdjoint_preservesLimits
+
+/-- Bridge: in an adjunction L ⊣ R, if the unit is a natural isomorphism then
+    the left adjoint L is fully faithful (full reflection criterion). -/
+noncomputable def fully_faithful_of_unit_iso {L : C ⥤ D} {R : D ⥤ C} (h : L ⊣ R)
+    [IsIso h.unit] : L.FullyFaithful :=
+  h.fullyFaithfulLOfIsIsoUnit
+
+/-- Bridge: in an adjunction L ⊣ R, if the counit is a natural isomorphism
+    then the right adjoint R is fully faithful. -/
+noncomputable def fully_faithful_of_counit_iso {L : C ⥤ D} {R : D ⥤ C} (h : L ⊣ R)
+    [IsIso h.counit] : R.FullyFaithful :=
+  h.fullyFaithfulROfIsIsoCounit
+
+end Grothendieck.Adjunction_en


### PR DESCRIPTION
## Summary

Adds **Part 25 — Adjunctions** to the Grothendieck pedagogical Lean tour as a FR + EN sibling pair (i18n convention #4980). This is a `See #2159` partial delivery (one more module of the extension Epic #1646, Phase 2+), per ai-01's `[STEER VARIETE]` DM directing po-2026 to take a Lean main-track grain (#2159 / #2874) for cycle variety (test-coverage capped, GPU down).

## Files

- **`Grothendieck/Adjunction.lean`** (NEW, FR, namespace `Grothendieck.Adjunction`)
- **`Grothendieck/Adjunction_en.lean`** (NEW, EN, namespace `Grothendieck.Adjunction_en`)
- **`Grothendieck.lean`** root aggregator: `+1 import Grothendieck.Adjunction` (slots after `YonedaLemma`, matching its docstring positioning "alongside the Yoneda lemma")

## Content — 6 sections, pure Mathlib re-exposure tour

1. The adjunction structure `L ⊣ R` + `homEquiv`
2. Unit / counit + triangle identities (`h.unit.app X`, `h.counit.app Y`)
3. `CategoryTheory.Functor.IsLeftAdjoint` (existence)
4. Right adjoint preserves limits / left adjoint preserves colimits
5. Full faithfulness via unit/counit natural isomorphism
6. Four bridge theorems in the project namespace: `homEquiv_family`, `leftAdjoint_preserves_colimits`, `rightAdjoint_preserves_limits`, `fully_faithful_of_unit_iso`, `fully_faithful_of_counit_iso`

Pure `#check` tour + `noncomputable def` bridges delegating to Mathlib — **no new proofs, no `sorry`**.

## Mathlib API names verified firsthand (grep in `.lake/packages/mathlib`, c.404 lesson — never guess)

`homEquiv` (Basic.lean:161), `unit`/`counit` (fields), `left_triangle`/`right_triangle`, `CategoryTheory.Functor.IsLeftAdjoint` (Basic.lean:127, nested namespace), `rightAdjoint_preservesLimits` / `leftAdjoint_preservesColimits` (Limits.lean, snake_case), `fullyFaithfulLOfIsIsoUnit` (FullyFaithful.lean:147) / `fullyFaithfulROfIsIsoCounit` (:170), `L.FullyFaithful` (dot notation), `PreservesColimitsOfSize` / `PreservesLimitsOfSize` (`open Limits`).

**Avoided non-existent names** (caught by `lake build` iteration, fixed before commit): `.left`/`.right` accessors, `unitApp`/`counitApp` constants, `CategoryTheory.IsLeftAdjoint` (wrong namespace — it's `CategoryTheory.Functor.IsLeftAdjoint`), `leftAdjointUnique`/`rightAdjointUnique`.

## i18n #4980 byte-identity

FR and EN differ **only** in docstrings `/-- ... -/`, comments `-- ...`, and the documented `_en` namespace suffix. Pure code (imports, `universe`, `open`, `variable`, `#check`, `def`/`theorem` signatures and bodies, `end`) is **byte-identical** between the two files (verified by diff stripping all comments/docstrings — only prose + namespace suffix remain).

## Build (lean-merge-discipline, `lake.exe` Windows-native, toolchain `leanprover/lean4:v4.31.0-rc1`)

```
$ lake build Grothendieck.Adjunction Grothendieck.Adjunction_en
Build completed successfully (638 jobs)        [rc=0]

$ lake build Grothendieck                       [full library via root aggregator]
Build completed successfully (2759 jobs)        [rc=0]
```

`sorry` count: `grep -cE sorry` = **0** on both files (the only `sorry` tokens are prose mentions in the i18n docstring notes — "Tous les `sorry` éliminés à la création" / "No `sorry` at creation").

> One transient full-lib failure was observed mid-iteration (Windows Lean compiler exit `3221226505` = `0xC0000409` stack-buffer-overrun under parallel load, on pre-existing modules I did not touch). Retry built clean (2759 jobs) — flaky Windows compiler crash, not a code error.

## Anti-regression

Pure addition: **+2 new files, +1 import line, 0 deletions** of existing logic. No `sorry`/stub/`pass`. Catalog byte-identical to `origin/main` (no notebook / no `COURSE_CATALOG` touched).

## R6 transparence

Genre **Lean formalisation** (fresh module, not test-coverage c.539-542). Family **SymbolicAI/Lean** (`grothendieck_lean` lake, Epic #1646/#2159). Firsthand Mathlib-name-verified + firsthand build-verified (not delegated). Target build green; full-lib build green on retry.

See #2159 (partial — one more module of the tour; Epic #1646 Phase 2+ remains open).

Co-Authored-By: Claude <noreply@anthropic.com>
