### PR TITLE
fix(qc,#6891): strip fabricated outputs from 2 remaining quantbooks (FamaFrench + ForexCarry)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/FamaFrench/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/FamaFrench/quantbook.ipynb
@@ -350,7 +350,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-05-12T16:05:24.574242Z",
@@ -359,23 +359,7 @@
      "shell.execute_reply": "2026-05-12T16:05:24.621003Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Risk-off Asset    Sharpe     CAGR    MaxDD      Vol\n",
-      "--------------------------------------------------\n",
-      "TLT                0.000    0.0%    0.0%    0.0%\n",
-      "Cash               0.000    0.0%    0.0%    0.0%\n",
-      "XLP                0.000    0.0%    0.0%    0.0%\n",
-      "XLU                0.000    0.0%    0.0%    0.0%\n",
-      "USMV               0.000    0.0%    0.0%    0.0%\n",
-      "\n",
-      "Meilleur risk-off: TLT (Sharpe=0.000)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Test Hypothese 1: Risk-off asset\n",
     "print(f\"{'Risk-off Asset':<15} {'Sharpe':>8} {'CAGR':>8} {'MaxDD':>8} {'Vol':>8}\")\n",
@@ -393,6 +377,14 @@
     "\n",
     "best_risk_off = max(results_hyp1.items(), key=lambda x: x[1]['sharpe'])\n",
     "print(f\"\\nMeilleur risk-off: {best_risk_off[0]} (Sharpe={best_risk_off[1]['sharpe']:.3f})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Sortie strippee** (FABRICATED `Row N` / blank PNG). Re-execution QC Cloud recherche kernel requise -- see #6891.\n",
+    "> Code preserve pour tracabilite. Side A = strip honnete, Side B = re-execution (hors scope ce PR).\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ForexCarry/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ForexCarry/quantbook.ipynb
@@ -317,7 +317,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-05-12T16:05:40.283869Z",
@@ -326,18 +326,7 @@
      "shell.execute_reply": "2026-05-12T16:05:40.321314Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Momentum Type               Sharpe     CAGR    MaxDD\n",
-      "--------------------------------------------------\n",
-      "Pure momentum                0.000    0.0%    0.0%\n",
-      "Risk-adjusted (actuel)       0.000    0.0%    0.0%\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "base_universe = ['EURUSD', 'AUDUSD', 'USDJPY', 'USDCAD']\n",
     "\n",
@@ -349,6 +338,14 @@
     "    r = backtest_fx_momentum(closes, base_universe, risk_adjusted=ra)\n",
     "    results_mom[name] = r\n",
     "    print(f\"{name:<25} {r['sharpe']:>8.3f} {r['cagr']:>7.1%} {r['max_dd']:>7.1%}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Sortie strippee** (FABRICATED `Row N` / blank PNG). Re-execution QC Cloud recherche kernel requise -- see #6891.\n",
+    "> Code preserve pour tracabilite. Side A = strip honnete, Side B = re-execution (hors scope ce PR).\n"
    ]
   },
   {


### PR DESCRIPTION
# fix(qc,#6891): strip fabricated outputs from 2 remaining quantbooks (FamaFrench + ForexCarry)

## Why

Issue **#6891** — 8 QuantConnect strategy projects carry a `quantbook.ipynb`
with **fabricated outputs** (Row N placeholders, blank PNGs, zero_stats_dataframe)
presented as genuine backtest results, violating C.2 (outputs = real execution proof)
and Stop&Repair (secrets-hygiene rule 6: never scrub/delete to hide; correct the cause).

**Side A = strip honnête** has already been delivered for the 8 main quantbooks
via PR #7447 (MERGED 2026-07-19). The post-#7447 detector scan revealed **2
remaining quantbooks** with the same `zero_stats_dataframe` signal that the
stripper covers but which were outside the original PR's hardcoded `DEFAULT_TARGETS`
list.

## What

Apply `scripts/notebook_tools/strip_fabricated_quantbook_outputs.py` (the
sibling-of-detector strip tool from PR #7447) to the 2 remaining quantbooks
via the explicit `--nb` path, **without** modifying `DEFAULT_TARGETS` (which
would scope-creep the canonical 8 of #7447):

| Notebook | Cell | Signal | Pre-strip | Post-strip |
|----------|-----:|--------|-----------|------------|
| FamaFrench/quantbook.ipynb | [12] | `zero_stats_dataframe` | Sharpe/CAGR/MaxDD/Vol = 0.000/0.0% across 5 risk-off assets | `outputs: []`, `execution_count: null` |
| ForexCarry/quantbook.ipynb | [9] | `zero_stats_dataframe` | Sharpe/CAGR/MaxDD = 0.000/0.0% across 2 momentum types | `outputs: []`, `execution_count: null` |

For each stripped cell, a markdown warning cell is inserted **after** it
(insertion reverse-indexed for stability, same pattern as #7447):

```
> **Sortie strippee** (FABRICATED `Row N` / blank PNG). Re-execution QC Cloud recherche kernel requise -- see #6891.
> Code preserve pour tracabilite. Side A = strip honnete, Side B = re-execution (hors scope ce PR).
```

**Source code PRÉSERVÉ verbatim** — Stop&Repair HARD: JAMAIS modifier le code,
seulement les `outputs` (le calcul de Sharpe/CAGR/MaxDD reste intact, il
pourra être ré-exécuté quand Side B = re-exécution QC Cloud sera livré).

## Preuves vérifiables

- **Detector post-strip** : `python scripts/notebook_tools/detect_fabricated_outputs.py --family QuantConnect --check` →
  ```
  Notebooks scanned     : 204
  Fabricated outputs   : 0
  Affected notebooks   : 0
  No fabricated text outputs detected (Row N / zero-stats dataframe check).
  ```
  (Pre-strip = 2/204.)
- **Anti-régression** : `python -m pytest scripts/notebook_tools/tests/ -q` →
  **3127 passed in 38.77s** (full `notebook_tools/tests/` suite, aucune régression).
- **Strip dry-run scope visible** : `python scripts/notebook_tools/strip_fabricated_quantbook_outputs.py --nb FamaFrench --nb ForexCarry --apply`
  returns `total_stripped: 2, total_inserted: 2, per_notebook: [FamaFrench: 1/1, ForexCarry: 1/1]`.
- **Tests baseline TestIncident6891Baseline::test_zero_axis2_findings_post_strip** PASSED
  — la baseline post-#7447 reste verte.
- **`TestDefaultTargets::test_default_targets_excludes_famafrench` PASSED** —
  la liste canonique PR #7447 reste intacte (8 quantbooks), les ajouts passent
  par `--nb` explicite.

## Décisions techniques notables

1. **`--nb` explicite plutôt que `DEFAULT_TARGETS` élargi**. Le stripper de
   PR #7447 a une `DEFAULT_TARGETS = [AllWeather, DualMomentum, FuturesTrend,
   TurnOfMonth, RiskParity, MomentumStrategy, SectorMomentum, EMA-Cross-Alpha]`
   codée en dur et testée comme telle (`test_default_targets_contains_eight_quantbooks`,
   `test_default_targets_excludes_famafrench`). Élargir cette liste dans cette
   PR aurait (a) changé le contrat de `TestDefaultTargets::test_default_targets_contains_eight_quantbooks`,
   (b) mélangé un suivi de follow-up dans la PR principale, et (c) fait passer
   `test_default_targets_excludes_famafrench` à FAIL. La voie `--nb` explicite
   respecte la séparation canonique tout en couvrant le scope résiduel.

2. **`zero_stats_dataframe` est l'axe 2 du détecteur** (cf `detect_fabricated_outputs.py`).
   L'heuristique = ratio zéro ≥ 90% sur ≥3 colonnes canoniques
   (Sharpe/CAGR/MaxDD/Vol/NetProfit). Les cellules FamaFrench [12] et ForexCarry
   [9] hit cette heuristique : leurs DataFrames imprimés sont 100% zéros (5/5
   colonnes, 5 lignes pour FamaFrench ; 3/3 colonnes, 2 lignes pour ForexCarry).

3. **Pas de modification de `DEFAULT_TARGETS` ni du détecteur** — la surface du
   stripper ne change pas. La présente PR est **purement data-side** : 2
   fichiers notebook, 2 cellules strippées, 2 cellules warning markdown insérées.

4. **Pas de re-exécution QC Cloud** (Side B, RECOVERABLE-MACHINE). Les
   quantbooks utilisent l'API `QuantBook()` (qb.add_equity, qb.history) non-
   exécutable via Papermill local. La voie Side B = re-exécution QC Cloud
   research kernel, owner sustained (multi-cycle, hors scope ce PR).

5. **Pas de modification du code source**. Le code de `factor_momentum_backtest`
   (FamaFrench) et `backtest_fx_momentum` (ForexCarry) reste intact et pourra
   être ré-exécuté côté QC Cloud quand Side B sera livré.

6. **Pas de composite G.4** — 1 sujet = strip 2 quantbooks du même type
   d'action (zero_stats_dataframe). Seuils : 2 fichiers / +20/-31 / 1 domaine /
   1 feature. Largement dans les limites.

## Liens opérationnels

- Issue **#6891** — incident fondateur.
- PR **#7447** (jsboige) — strip Side A 8 quantbooks principaux.
- PR **#7070** (CLOSED) / **#7066** / **#7072** / **#7074** — premières
  tentatives Side A (toutes fermées : abandonnées au profit du stripper
  généraliste #7447).
- Detector `detect_fabricated_outputs.py` (axe 2 Row N + zero_stats) MERGED.
- Detector `detect_blank_figures.py` (axe 1 blank PNG) MERGED.
- Strip tool `strip_fabricated_quantbook_outputs.py` MERGED (#7447).
- Side B = re-exécution QC Cloud (RECOVERABLE-MACHINE, owner sustained).

## Anti-patterns écartés

- **Pas de modification du code source** (Stop&Repair HARD).
- **Pas de composite G.4** — 1 sujet = 1 type d'action.
- **Pas de force push** — fresh branch `feature/c735-6891-famafrench-forexcarry-stoprepair`
  depuis `origin/main@3037bb5f2`.
- **Pas de merge** — worker INTERDIT `gh pr merge` / `gh auth switch` per
  leçon #1502.
- **Body PR HORS worktree** (L677-L4 ★★ c.677g, NTFS case-insensitive safe) :
  body écrit dans scratchpad, pas dans le worktree.
- **Pas de regen catalogue** (catalog-pr-hygiene Règle HARD 1) — la PR ne
  touche pas `COURSE_CATALOG.generated.json`.
- **Pas d'élargissement de `DEFAULT_TARGETS`** — séparation canonique PR #7447
  préservée.
- **Pas de modification du détecteur** — surface `detect_fabricated_outputs.py`
  inchangée.

## Critères acceptance #6891

| # | Critère | Atteint ? |
|---|---------|-----------|
| 1 | Tous les quantbooks QuantConnect authentifiés | Side A livré (#7447 + cette PR = 10/10 des cibles connues) |
| 2 | 0 fabrication détectée post-strip | ✅ 0/204 (était 2/204) |
| 3 | Anti-régression notebook_tools tests | ✅ 3127/3127 |
| 4 | Source code PRÉSERVÉ (Stop&Repair) | ✅ verbatim sur les 2 cellules |
| 5 | Markdown warning inséré | ✅ 2/2 cellules |
| 6 | Pas de modification de DEFAULT_TARGETS / détecteur / stripper | ✅ surface inchangée |
| 7 | Pas de composite G.4 | ✅ 2 fichiers / 1 domaine / 1 feature |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
