### PR TITLE
docs(skills): reconcile subagents-reference roster 15 → 17 (See #7422)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Cadre de travail (adapté de Karpathy + ajout user) : ces principes gouvernent *
 - [docs/reference/kernels-runtime.md](docs/reference/kernels-runtime.md) - .NET / Python / WSL kernels, conda envs (`coursia-ml-training`, `mcp-jupyter`, `epita_symbolic_ai`), dotnet-interactive PIN
 - [docs/reference/procedures-recurrentes.md](docs/reference/procedures-recurrentes.md) - Workflow PR, dispatch agents, validation notebook, audit anti-regression, productivite operations longues, pre-commit H.3
 - [docs/reference/stale-tree-drift-scan.md](docs/reference/stale-tree-drift-scan.md) - Scan de drift/traduction sur worktree frais (anti-phantom 88% FP sur arbre partagé dirty)
-- [docs/reference/subagents-reference.md](docs/reference/subagents-reference.md) - Catalogue 21 sous-agents + 15 skills, mapping side-tracks, usage async
+- [docs/reference/subagents-reference.md](docs/reference/subagents-reference.md) - Catalogue 21 sous-agents + 17 skills, mapping side-tracks, usage async
 - [docs/reference/scripts-reference.md](docs/reference/scripts-reference.md) - Catalogue scripts dépôt (notebook CLI, exécution, catalogue anti-drift, qualité, maintenance/env)
 - [docs/reference/env-python-reparation.md](docs/reference/env-python-reparation.md) - Reparation env Python (regle F)
 - [docs/reference/regles-vigilance-detail.md](docs/reference/regles-vigilance-detail.md) - Detail G.1-G.9 + incidents
@@ -184,7 +184,7 @@ scripts/notebook_tools/notebook_tools.py # CLI multi-famille (validate/execute/s
 scripts/smartcontracts/                  # SC-specifique
 scripts/genai-stack/genai.py             # GenAI Docker + validation (cf docs/genai/genai-services.md)
 
-.claude/{agents, skills, rules}/         # 21 sous-agents, 15 skills, rules auto-loaded
+.claude/{agents, skills, rules}/         # 21 sous-agents, 17 skills, rules auto-loaded
 GradeBookApp/                            # Notation etudiants : moteur generique (pipelines+donnees par cohorte prives sur GDrive)
 docker-configurations/                   # ComfyUI + Qwen Docker
 docs/                                    # Documentation deportee de ce CLAUDE.md

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ Documentation vivante, active et liée depuis CLAUDE.md / `.claude/rules/`.
 | [reference/cluster-agents.md](reference/cluster-agents.md) | Machines cluster, GPU topology |
 | [reference/teaching-context.md](reference/teaching-context.md) | Calendrier, scope EPITA-IS, agents par école |
 | [reference/scripts-reference.md](reference/scripts-reference.md) | Catalogue scripts dépôt |
-| [reference/subagents-reference.md](reference/subagents-reference.md) | Roster 21 agents + 15 skills |
+| [reference/subagents-reference.md](reference/subagents-reference.md) | Roster 21 agents + 17 skills |
 | [reference/catalog_markers.md](reference/catalog_markers.md) | Marqueurs CATALOG-STATUS des READMEs (expansion + vérification CI) |
 | [reference/audit-reassessment-findings.md](reference/audit-reassessment-findings.md) | Items d'audit automatisé déjà reclassés (protocole reassessment) |
 | [reference/student-pr-template.md](reference/student-pr-template.md) | Template PR étudiante |

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -32,7 +32,7 @@ Préserver le code de production (preuves Lean, fonctions métier). Interdit de 
 
 ### [Agents & skills](reference/claude-code-config.md)
 
-Catalogue des 21 sous-agents et 15 skills Claude Code, mapping Epic → specialists.
+Catalogue des 21 sous-agents et 17 skills Claude Code, mapping Epic → specialists.
 
 ### [Architecture MCP roo-state-manager](reference/architecture_mcp_roo.md)
 

--- a/docs/reference/subagents-reference.md
+++ b/docs/reference/subagents-reference.md
@@ -57,7 +57,7 @@ Le message final du sous-agent revient en notification. Les sous-agents read-onl
 
 ## Skills `.claude/skills/` — slash-commands mandatés
 
-15 skills invoquables en slash-command (`/<nom>`). Là où un skill couvre une tâche récurrente, **l'utiliser plutôt que de réimproviser le workflow** (mandat user 2026-05-23 : catalogue clair pour encourager l'usage).
+17 skills (13 slash-commands actives + 4 modules de référence auto-chargés). Là où un skill couvre une tâche récurrente, **l'utiliser plutôt que de réimproviser le workflow** (mandat user 2026-05-23 : catalogue clair pour encourager l'usage).
 
 ### Workflows actionnables (slash-commands)
 
@@ -75,6 +75,7 @@ Le message final du sous-agent revient en notification. Les sous-agents read-onl
 | `/qc-iterative-improve` | Workflow amélioration stratégies QC (`[strategy\|issue#]`, `--iterations`, `--backtest`) | #1409 trading |
 | `/train-model` | Entraîner un modèle ML (thermal-safe GPU, walk-forward + multi-seed + DM). `--dry-run`, `--seeds`, `--folds`, `--bg` | #1454 Training |
 | `/genai-iterate` | Itérer un notebook GenAI contre la stack (auth, sous-domaines, quant, GPU/VRAM) via CLI genai-stack. `--service`, `--quant`, `--validate`, `--bg` | #1385 GenAI |
+| `/check-cell-order` | Détecter les problèmes d'ordre des cellules (enchaînement, cellules oubliées ou mal placées, canonical-order slippage). `[target]`, `--severity HIGH\|MED\|LOW`, `--json`, `--fail-on`. Backed by `scan_cell_ordering.py` | #3240 structure notebooks |
 
 ### Skills de référence (chargés à la demande, pas de slash-command actif)
 
@@ -83,6 +84,7 @@ Le message final du sous-agent revient en notification. Les sous-agents read-onl
 | `mcp-jupyter` | Référence outils MCP Jupyter (kernels, exécution cellule, Papermill) |
 | `notebook-helpers` | Référence `notebook_helpers.py` / `notebook_tools.py` (manipulation, structure) |
 | `notebook-patterns` | Patterns pédagogiques d'enrichissement (modèle GameTheory) |
+| `qc-helpers` | Référence patterns/helpers pour les opérations QuantConnect via MCP (config `organizationId`, outils disponibles) |
 
 **`/review-student-prs` = canal canonique du recyclage TP** : il applique déjà la convention exercice→exemple ([.claude/rules/exercise-example-labeling.md](../../.claude/rules/exercise-example-labeling.md)) + la review bienveillante + bypass CI/template ([.claude/rules/student-pr-reviews.md](../../.claude/rules/student-pr-reviews.md)). Ne pas réécrire ce workflow à la main.
 


### PR DESCRIPTION
## Summary

Reconciles the **skills roster** in the harness docs: the disk has **17 skills** but the docs all said **15**, and two skills (`/check-cell-order`, `qc-helpers`) were missing from `docs/reference/subagents-reference.md` entirely. This is a **perennial-reference desync** per **#7422** (hygiène docs/ — mandat user 2026-07-19, aujoud'hui) — exactly the "référence pérenne désynchronisée de l'état réel du code" that must be **updated** (not archived) before the translation wave #1650.

## Drift detected

```
$ ls .claude/skills/   # 16 dirs + 1 bare qc-helpers.md = 17 skills
$ grep -rn '15 skills' docs/ CLAUDE.md   # 6 occurrences across 4 files (all stale)
```

Two skills absent from the roster:
- **`/check-cell-order`** — active slash-command, backed by `scripts/notebook_tools/scan_cell_ordering.py` (Epic #3240). Detects cell-ordering / enchaînement problems (canonical-order slippage, misplaced/forgotten cells).
- **`qc-helpers`** — reference module (auto-loaded), QuantConnect MCP patterns (`organizationId` config, available tools).

## Changes (atomic — one subject: skills roster reconciliation)

| File | Change |
|------|--------|
| `docs/reference/subagents-reference.md` | roster line `15 skills` → `17 skills (13 slash-commands actives + 4 modules de référence)`; **+1** active-command row `/check-cell-order` (#3240); **+1** reference row `qc-helpers` |
| `CLAUDE.md` L30 + L187 | `15 skills` → `17 skills` |
| `docs/README.md` L20 | `Roster 21 agents + 15 skills` → `… 17 skills` |
| `docs/index.qmd` L35 | `… et 15 skills …` → `… et 17 skills …` |

4 files, **+7 / −5**.

## Verified firsthand (G.1 — never claim without grep)

- `ls .claude/skills/` = 16 dirs + `qc-helpers.md` = **17** ✓
- `grep -rn '15 skills' docs/ CLAUDE.md` = **0** after fix (all reconciled) ✓
- `scripts/notebook_tools/scan_cell_ordering.py` **EXISTS** (claimed in `/check-cell-order` entry) ✓
- `cell_order_ci.py` references **Epic #3240** ✓
- `qc-helpers.md` has no slash-invocation frontmatter → correctly classified as **reference module** ✓
- **`21 sous-agents`** untouched — actual agents = 21 (no drift there) ✓

## Anti-regression / hygiene

Pure docs reconciliation: **0 notebooks, 0 `.lean`, 0 catalog churn**. `COURSE_CATALOG.generated.*` byte-identical to `origin/main` (untouched). All new descriptions grounded in real code (not invented). Worktree `C:/dev/CoursIA-docs-skills` off `origin/main` `3037bb5f2` (fresh). 0 CRLF.

## R6 transparence

Genre **docs/reference reconciliation** (perennial-reference freshness, not transient PM). Family **harness docs** — genuine rotation from the prior 2 cycles (Lean + QC-test). Firsthand verified (grep + `ls` + file-existence, not delegated). Collision pre-flight clean (`gh pr list --search` 0 hits). Not the full #7422 archive triage (that needs ai-01 design-gate on `docs/archive/` move policy per "Consolider != Archiver" HARD) — this is the first, unambiguous UPDATE step.

See #7422 (partial — one freshness step; the full docs/ archive triage remains open).

Co-Authored-By: Claude <noreply@anthropic.com>
