### PR TITLE
fix(qc/shared): TrendStrengthIndicator class flat moves as neutral not down

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/shared/indicators.py
+++ b/MyIA.AI.Notebooks/QuantConnect/shared/indicators.py
@@ -110,12 +110,16 @@ class TrendStrengthIndicator:
         if len(self.close_prices) < 2:
             return 0.0
 
-        # Direction moyenne
+        # Direction moyenne. Les moves flat (close[i] == close[i-1]) sont
+        # exclus de up ET de down -> ils restent neutres (range/consolidation),
+        # conformement a l'interpretation documentee (0.0 = range).
         moves_up = sum(1 for i in range(1, len(self.close_prices))
                       if self.close_prices[i] > self.close_prices[i-1])
-        moves_down = len(self.close_prices) - 1 - moves_up
+        moves_down = sum(1 for i in range(1, len(self.close_prices))
+                         if self.close_prices[i] < self.close_prices[i-1])
 
         if moves_up + moves_down == 0:
+            # Aucun move directionnel (serie completement flat) -> neutre.
             return 0.0
 
         # Score -1 (downtrend fort) à +1 (uptrend fort)

--- a/MyIA.AI.Notebooks/QuantConnect/shared/test_indicators.py
+++ b/MyIA.AI.Notebooks/QuantConnect/shared/test_indicators.py
@@ -139,19 +139,33 @@ def test_trend_strength_alternating_is_zero():
     assert float(t.Current) == pytest.approx(0.0)
 
 
-def test_trend_strength_all_flat_counts_as_down_minus_one():
-    # Documented quirk (pin, not a bug-claim): moves_down is computed as
-    # (len-1) - moves_up, so flat moves (close[i] == close[i-1], NOT strictly
-    # up) are bucketed into moves_down. An all-flat series therefore reports
-    # strength = -1.0 (maximally bearish), not 0.0. The `moves_up + moves_down
-    # == 0` guard only triggers when there are zero moves at all (len < 2,
-    # already handled by the `len < 2` early return), so it never fires for a
-    # warm series of flat bars.
+def test_trend_strength_all_flat_is_neutral_zero():
+    # Regression guard: previously `moves_down = (len-1) - moves_up` bucketed
+    # flat moves (close[i] == close[i-1]) as "down", so an all-flat series
+    # reported strength = -1.0 (maximally bearish) for a flat market -- and the
+    # `moves_up + moves_down == 0` guard was dead (sum == len-1 for len >= 2).
+    # Now moves_down is counted explicitly with `<`, flat moves are excluded
+    # from both buckets, and the guard fires for all-flat -> 0.0 (neutral
+    # range/consolidation), matching the interpretation documented in the
+    # notebook ("0.0 : Range/consolidation").
     t = TrendStrengthIndicator("trend", period=4)
     for _ in range(5):
         t.Update(None, high=6, low=4, close=5)
     assert t.IsReady is True
-    assert float(t.Current) == pytest.approx(-1.0)
+    assert float(t.Current) == pytest.approx(0.0)
+
+
+def test_trend_strength_mixed_with_flat_excludes_flat():
+    # Series [1, 2, 2, 2, 3]: moves up = 2 (1->2, 2->3), moves down = 0, flat
+    # moves = 2. Previously the 2 flat moves were bucketed as down, dragging
+    # strength to (2 - 2) / 4 = 0.0 (falsely "range"). Now flat moves are
+    # excluded -> (2 - 0) / 2 = 1.0 (correctly strong uptrend: price rose, no
+    # down bars). This is the broader blast radius of the flat-bucketing fix.
+    t = TrendStrengthIndicator("trend", period=4)
+    for c in (1, 2, 2, 2, 3):
+        t.Update(None, high=c + 1, low=c - 1, close=c)
+    assert t.IsReady is True
+    assert float(t.Current) == pytest.approx(1.0)
 
 
 def test_trend_strength_reset_clears_state():


### PR DESCRIPTION
## What

Bug-fix dans **`QuantConnect/shared/indicators.py`** — `TrendStrengthIndicator._calculate_trend_strength` classait les **moves flat** (`close[i] == close[i-1]`) comme des moves **down**, ce qui produisait des valeurs de force de tendance trompeuses. Genre = **bug-fix** (flip vs la veine test-coverage #7403/#7419/#7439/#7451/#7454 que j'ai livrée — ai-06 STEER VARIETE : 9e cycle consecutif test-coverage a casser). Substance QC, 1 domaine, 1 sujet.

## Bug (re-verifie firsthand sur origin/main `3037bb5f2`)

```python
moves_up   = sum(... if close[i] > close[i-1])
moves_down = len(self.close_prices) - 1 - moves_up   # flat = "down"
```

Deux effets :

1. **All-flat series** `[5,5,5,5,5]` → `moves_up=0`, `moves_down=4` → `strength = (0-4)/4 = **-1.0 (maximalement bearish)**` pour un marche plat. Le garde `if moves_up + moves_down == 0` etait **dead** (somme = `len-1 >= 1` pour `len>=2`, jamais 0).
2. **Series mixed avec flat** `[1,2,2,2,3]` → `moves_up=2`, `moves_down=2` (les 2 flats bucketed down) → `strength = 0.0` faussement "range" alors que le prix a monte et aucun down bar n'existe. Valeur correcte : `(2-0)/2 = 1.0` (uptrend fort).

## Fix (root cause, pas band-aid)

Compter `moves_down` explicitement avec `<`, excluant les moves flat des **deux** buckets :

```python
moves_up   = sum(... if close[i] > close[i-1])
moves_down = sum(... if close[i] < close[i-1])   # flat exclus de up ET down
```

- Les moves flat deviennent **neutres** (range/consolidation).
- Le garde devient **LIVE** pour all-flat → retourne `0.0` (neutre).
- Les series mixed refletent uniquement les moves directionnels.
- **Aligne le code avec l'interpretation documentee** dans `QC-Py-11-Technical-Indicators.ipynb` (cell 32 markdown) : « 0.0 : Range/consolidation ».

## Anti-regression protocole 4 etapes (CLAUDE.md section D)

1. **Bug exact** : flat moves (`close[i] == close[i-1]`) misclassified comme down via `moves_down = len-1 - moves_up`. Voir exemples ci-dessus.
2. **3 tactiques** : (a) count `moves_down` avec `<` **[choisie, root cause]** ; (b) special-case all-flat uniquement **[rejetee, laisse la misclassification pour series mixed]** ; (c) troisieme bucket "neutre" dans le denominateur **[rejetee, change le denom pour toutes les series inutilement]**.
3. **Diff coherent** : 1 ligne fonctionnelle + commentaires dans `indicators.py` (+6/-1) ; test passe de pin(-1.0) a assert(0.0) + nouveau regression test mixed-flat dans `test_indicators.py` (+23/-10). **Pas de deletion > insertion sur code metier.**
4. **Consumers verified firsthand** : seul `QC-Py-11-Technical-Indicators.ipynb` consomme `TrendStrength` (grep `origin/main`). **Aucun output commite ne depend de la valeur -1.0-flat** : cells 35 et 37 outputs = legend d'interpretation (print statique `+1.0/0.0/-1.0`) + confirmation d'import. Le bug etait latent (pas de notebook feedant des donnees flat a TrendStrength et committant un resultat numerique).

## Validation reproductible

```
$ cd MyIA.AI.Notebooks/QuantConnect/shared
$ python -m pytest test_indicators.py -q
19 passed in 0.80s
```

3 tests monotonic/alternating **unchanged** (aucun flat move dans leurs series, comportement identique pre/post fix — confirme blast-radius analysis). 1 test all-flat mis a jour (pin -1.0 → assert 0.0). 1 nouveau test mixed-flat regression guard.

## Conformite

- Atomique : 1 domaine (QuantConnect/shared indicators quality), 1 bug, 1 fix root-cause.
- **Pas de `Closes #N`** (contribution qualite standalone, pas d'issue associee).
- Pas de C.2 implication : 0 notebook modifie (fix source-only ; aucun output notebook dependant sur le -1.0-flat, verifie firsthand).
- Catalogue byte-identique a `main` (0 changement catalogue).
- Rebase frais off `origin/main` `3037bb5f2` (worktree initial `c76d8b8f2` etait 46 commits stale → teardown + recreate frais).
- **Pre-flight collision check** : `gh pr list --state all --search "TrendStrength OR trend_strength OR indicators"` = 0 PR touchant la logique flat-move (mon #7403 test-only merged, `test_indicators.py` documentait le buggy -1.0 en quirk pin ; personne n'a fix le source).
