### PR TITLE
fix(gt/topology): classify Battle of the Sexes instead of Coordination Game

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/examples/topology_2x2_periodic_table.py
+++ b/MyIA.AI.Notebooks/GameTheory/examples/topology_2x2_periodic_table.py
@@ -127,14 +127,21 @@ def classify_game(A: np.ndarray, B: np.ndarray) -> str:
     if len(nash_eq) == 2:
         (i1, j1), (i2, j2) = nash_eq
 
-        # Both on diagonal: Coordination game
+        # Both on diagonal: coordination family
         if (i1 == j1) and (i2 == j2):
-            # Check for Stag Hunt pattern: one Nash is Pareto dominant
+            # Stag Hunt: one Nash is Pareto dominant (unequal welfare sums)
             p1 = A[i1, j1] + B[i1, j1]
             p2 = A[i2, j2] + B[i2, j2]
             if p1 != p2:
                 return "Stag Hunt"
-            return "Coordination Game"
+            # Equal welfare sums: distinguish pure coordination from
+            # Battle of the Sexes. With equal sums, if P1's payoff is the same
+            # at both equilibria then (by equal sums) P2's is too, so both
+            # players are indifferent -> pure Coordination. Otherwise each
+            # player prefers a different equilibrium -> Battle of the Sexes.
+            if A[i1, j1] == A[i2, j2]:
+                return "Coordination Game"
+            return "Battle of the Sexes"
 
         # Anti-coordination: Chicken/Hawk-Dove
         if (i1 != j1) and (i2 != j2):

--- a/MyIA.AI.Notebooks/GameTheory/tests/test_topology_2x2.py
+++ b/MyIA.AI.Notebooks/GameTheory/tests/test_topology_2x2.py
@@ -29,8 +29,10 @@ seulement l'absence de crash :
     matrice B (B = [[p2[0],p2[2]],[p2[1],p2[3]]]) inversait les entrees
     hors-diagonale. CORRIGE : B est desormais row-major comme A, et PD / Stag
     Hunt / Chicken / Matching Pennies font l'aller-retour correctement (tests
-    passants). Battle of the Sexes reste xfail pour une raison SEPARABLE (limite
-    du classifieur, pas de l'encodage : voir test_named_battle_of_the_sexes).
+    passants). Battle of the Sexes restait xfail pour une raison SEPARABLE
+    (limite du classifieur, pas de l'encodage) : CORRIGE -- classify_game
+    distingue desormais, a somme de welfare egale sur deux Nash diagonaux, la
+    coordination pure (joueurs indifferents) de BoS (preferences conflictuelles).
 
 Run with: pytest tests/test_topology_2x2.py -v
 """
@@ -283,8 +285,15 @@ CLASSIFICATION_COUNTS = {
     "Matching Pennies": 72,
     "Chicken/Hawk-Dove": 36,
     "Stag Hunt": 26,
-    "Coordination Game": 10,
+    "Battle of the Sexes": 10,
     "Prisoner's Dilemma": 4,
+    # "Coordination Game" : 0 sur les ordinaux stricts. Les jeux ordinaux
+    # stricts (rangs distincts 1-4) ne peuvent pas etre de coordination pure
+    # (les deux joueurs indifferents entre deux Nash diagonaux exige des gains
+    # egaux, impossibles avec des rangs distincts) -- les 10 anciens
+    # "Coordination Game" etaient en fait des BoS (prefs conflictuelles). La
+    # coordination pure reste classifiable sur des entrees non-strictes
+    # (ex. COORD_A = [[1,0],[0,1]], voir test_pure_coordination).
 }
 
 VALID_TYPES = {
@@ -384,15 +393,13 @@ def test_named_chicken_round_trips():
     assert topo.classify_game(A, B) in ("Chicken/Hawk-Dove", "Chicken")
 
 
-@pytest.mark.xfail(
-    reason="Limite SEPARABLE du classifieur (pas l'encodage B, desormais corrige) : "
-           "les deux Nash diagonaux de BoS ont somme egale ((4,3) et (3,4) = 7), "
-           "donc classify_game renvoie 'Coordination Game'. La branche "
-           "'Battle of the Sexes' n'est jamais atteinte en 2x2 (les 2 Nash purs "
-           "sont soit tous diagonaux, soit tous anti-diagonaux).",
-    strict=False,
-)
 def test_named_battle_of_the_sexes_round_trips():
+    # Previously xfail (limite SEPARABLE du classifieur, pas l'encodage B) :
+    # les deux Nash diagonaux de BoS ont somme egale ((4,3) et (3,4) = 7), donc
+    # classify_game renvoyait 'Coordination Game' et la branche BoS n'etait
+    # jamais atteinte. Le classifieur distingue desormais, a sommes egales, la
+    # coordination pure (joueurs indifferents) de BoS (preferences conflictuelles)
+    # via l'egalite des gains de P1 entre les deux equilibres.
     data = topo.NAMED_GAMES["Battle of the Sexes"]
     A, B = topo.create_ordinal_game(data["p1"], data["p2"])
     assert topo.classify_game(A, B) == "Battle of the Sexes"


### PR DESCRIPTION
## What

Bug-fix dans **`GameTheory/examples/topology_2x2_periodic_table.py`** `classify_game` — Battle of the Sexes (BoS) etait classifie "Coordination Game" au lieu de "Battle of the Sexes". **Limite connue/documentee** (xfail `strict=False` sur `test_named_battle_of_the_sexes_round_trips`, reason "limite SEPARABLE du classifieur"). Ce fix **leve le xfail**. Genre = bug-fix (variety vs test-coverage), sous-domaine fresh (GameTheory topology ≠ QC/GenAI faits ce session), CPU-only, 1 sujet.

## Bug (re-verifie firsthand sur origin/main `3037bb5f2`)

`NAMED_GAMES["Battle of the Sexes"]` : p1=(4,1,2,3), p2=(3,2,1,4) → A=`[[4,1],[2,3]]`, B=`[[3,2],[1,4]]`. Nash purs = `[(0,0),(1,1)]` (tous deux diagonaux). Sommes de welfare : (0,0)=4+3=7, (1,1)=3+4=7 → **egales**. Le code renvoyait `"Coordination Game"` pour toute somme-egale-2-Nash-diagonaux, donc BoS n'etait JAMAIS detecte (la branche `return "Battle of the Sexes"` etait unreachable en 2x2, comme documente dans le xfail).

L'auteur avait diagnostique exactement : *"les deux Nash diagonaux de BoS ont somme egale ((4,3) et (3,4) = 7), donc classify_game renvoie 'Coordination Game'. La branche 'Battle of the Sexes' n'est jamais atteinte"*.

## Fix (root cause, pas band-aid)

Dans la sous-branche 2-Nash-diagonaux-a-somme-egale, discriminer par le gain de P1 entre les deux equilibres :

```python
if A[i1, j1] == A[i2, j2]:
    return "Coordination Game"   # P1 indifferent => P2 aussi (sommes egales) => coordination pure
return "Battle of the Sexes"     # prefs conflictuelles : chaque joueur prefere un equilibre different
```

**Pourquoi A-egalite suffit** : avec sommes egales, `A[i1,j1]+B[i1,j1] == A[i2,j2]+B[i2,j2]`. Si `A[i1,j1]==A[i2,j2]` alors `B[i1,j1]==B[i2,j2]` aussi (les deux joueurs indifferents = coordination pure). Sinon, un joueur prefere Nash1 et l'autre Nash2 = BoS.

## Verite structurelle revelee

Sur les 576 jeux ordinaux **stricts** (rangs distincts 1-4), la **coordination pure est impossible** (joueurs indifferents exige des gains egaux = rangs dupliques, impossibles en stricte). Donc les 10 jeux anciennement "Coordination Game" sont TOUS des BoS. La coordination pure reste classifiable sur entrees non-strictes (`COORD_A=[[1,0],[0,1]]`, `test_pure_coordination` inchange passant).

## Anti-regression protocole 4 etapes (CLAUDE.md section D)

1. **Bug exact** : BoS → "Coordination Game" (xfail documente "limite du classifieur").
2. **3 tactiques** : (a) discriminer par A-egalite a sommes egales **[choisie, root cause]** ; (b) toujours retourner BoS a sommes egales **[rejetee, casse la coordination pure COORD]** ; (c) check explicite per-player preference-direction **[rejetee, A-egalite est equivalent et plus simple].
3. **Diff coherent** : +10/-3 logique source + commentaires ; xfail leve + CLASSIFICATION_COUNTS maj (Coordination 10→0, BoS 0→10) + docstrings rafraichis. **38/38 pass 0.26s**. Pas de deletion > insertion sur logique.
4. **Consumers verified firsthand** : `GameTheory-3-Topology2x2.ipynb` utilise sa PROPRE classe `OrdinalGame` + `classify_game_family` (cells 27/37/39 inline), **0 import de `topology_2x2_periodic_table`**. Aucun output commite de notebook ne depend de l'ancienne classification → C.2 safe (0 notebook modifie).

## Validation reproductible

```
$ cd MyIA.AI.Notebooks/GameTheory/tests
$ python -m pytest test_topology_2x2.py -q
38 passed in 0.26s
```

- `test_named_battle_of_the_sexes_round_trips` : xfail → **passing** (BoS now classifies correctly).
- `test_pure_coordination` (COORD_A=[[1,0],[0,1]]) : **unchanged passing** (still "Coordination Game").
- `test_counts_match_reference_partition` : counts updated (BoS 0→10, Coordination 10→0), total 576 inchange.
- 4 autres NAMED_GAMES (PD/StagHunt/Chicken/MatchingPennies) : **unchanged passing** (blast-radius confirme).

## Conformite

- Atomique : 1 domaine (GameTheory topology classification quality), 1 bug, 1 fix root-cause.
- **Pas de `Closes #N`** (contribution qualite standalone, pas d'issue associee — le xfail etait interne au test).
- Pas de C.2 implication : 0 notebook modifie (module + test only, consumer-verified C.2 safe).
- Catalogue byte-identique a `main` (0 changement catalogue).
- Rebase frais off `origin/main` `3037bb5f2`, worktree isole `CoursIA-topology-bos`.
- **Pre-flight collision check** : `gh pr list --search topology OR battle_of_the_sexes` = 0 OPEN PR touchant topology_2x2. 0 merged history de fix BoS. Le xfail etait le trace de la limite connue.
