### PR TITLE
fix(gametheory): guard n_samples <= 0 in Shapley MC estimators (crash/NaN)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games/shapley.py
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games/shapley.py
@@ -136,6 +136,8 @@ def shapley_value_monte_carlo(
         >>> game = WeightedVotingGame([10, 5, 3, 2], quota=11)
         >>> shapley = shapley_value_monte_carlo(game, n_samples=50000)
     """
+    if n_samples <= 0:
+        raise ValueError(f"n_samples must be positive, got {n_samples}")
     if seed is not None:
         np.random.seed(seed)
 
@@ -169,6 +171,8 @@ def shapley_value_with_variance(
     Returns:
         Tuple of (shapley_values, standard_errors)
     """
+    if n_samples <= 0:
+        raise ValueError(f"n_samples must be positive, got {n_samples}")
     if seed is not None:
         np.random.seed(seed)
 

--- a/MyIA.AI.Notebooks/GameTheory/tests/test_shapley.py
+++ b/MyIA.AI.Notebooks/GameTheory/tests/test_shapley.py
@@ -254,6 +254,54 @@ class TestMonteCarlo:
 
 
 # ----------------------------------------------------------------------------
+# Monte Carlo : garde n_samples <= 0 (regression : NaN + crash negatif).
+# ----------------------------------------------------------------------------
+
+class TestMonteCarloNsamplesGuard:
+    """n_samples <= 0 doit echouer explicitement (ValueError), pas crasher
+    (np.zeros((neg, n)) -> ValueError "negative dimensions"), ni propager du
+    NaN (shapley / 0 -> RuntimeWarning invalid value) ni retourner un resultat
+    silencieusement faux ([-0. -0.]). La garde deleguee protege aussi
+    ShapleyCalculator, qui passe n_samples tel quel aux fonctions MC.
+    """
+
+    def test_monte_carlo_zero_samples_raises(self):
+        game = majority_game(3)
+        with pytest.raises(ValueError, match="n_samples must be positive"):
+            shapley_value_monte_carlo(game, n_samples=0, seed=1)
+
+    def test_monte_carlo_negative_samples_raises(self):
+        game = majority_game(3)
+        with pytest.raises(ValueError, match="n_samples must be positive"):
+            shapley_value_monte_carlo(game, n_samples=-5, seed=1)
+
+    def test_with_variance_zero_samples_raises(self):
+        game = majority_game(3)
+        with pytest.raises(ValueError, match="n_samples must be positive"):
+            shapley_value_with_variance(game, n_samples=0, seed=1)
+
+    def test_with_variance_negative_samples_raises(self):
+        game = majority_game(3)
+        # Pre-fix: np.zeros((-5, n)) -> ValueError "negative dimensions" (crash
+        # different de celui voulu). Post-fix: ValueError "n_samples" propre.
+        with pytest.raises(ValueError, match="n_samples must be positive"):
+            shapley_value_with_variance(game, n_samples=-5, seed=1)
+
+    def test_calculator_delegates_guard(self):
+        """ShapleyCalculator (methode MC) delegue n_samples -> garde activee."""
+        game = majority_game(3)
+        calc = ShapleyCalculator(game, method='monte_carlo', n_samples=0, seed=1)
+        with pytest.raises(ValueError, match="n_samples must be positive"):
+            calc.compute()
+
+    def test_positive_n_samples_unaffected(self):
+        """La garde n'impacte pas le chemin normal (efficiency preservee)."""
+        game = WeightedVotingGame([4, 3, 2, 1], quota=6)
+        mc = shapley_value_monte_carlo(game, n_samples=1000, seed=0)
+        assert np.isclose(mc.sum(), game.grand_coalition_value())
+
+
+# ----------------------------------------------------------------------------
 # ShapleyCalculator : interface unifiee + selection auto de methode.
 # ----------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Robustness fix in `GameTheory/cooperative_games/shapley.py` — the Monte Carlo Shapley estimators. **3 distinct failure modes for the same invalid input (`n_samples <= 0`)**, none handled cleanly.

## Bugs (reproduced firsthand, pre-fix)

| Input | Function | Symptom |
|-------|----------|---------|
| `n_samples < 0` | `shapley_value_with_variance` | **ValueError: negative dimensions** (`np.zeros((-5, n))` allocation) — crash |
| `n_samples = 0` | `shapley_value_with_variance` | **NaN** (Mean of empty slice + `/sqrt(0)`) |
| `n_samples = 0` | `shapley_value_monte_carlo` | **NaN** (`shapley / 0` → RuntimeWarning invalid value) |
| `n_samples < 0` | `shapley_value_monte_carlo` | **silent `[-0. -0.]`** (wrong result, no error) |

Default `n_samples=10000` masks it, but `n_samples <= 0` is reachable via the public API, and the module's own `ShapleyCalculator` delegates `n_samples` straight through — so any caller passing 0/negative got a crash, NaN, or silent garbage instead of a clear error.

## Fix
Validate `n_samples > 0` at the top of both MC estimators (`ValueError`), mirroring the module's existing validation style (ValueError for unknown method L258, `v(∅)≠0` in `CoalitionGame` L70). `ShapleyCalculator` is protected transitively. Same bug-class as backtest_helpers #7463 and catalog_coverage #7473 (guard the degenerate input the function does not handle cleanly).

## Anti-regression audit
- **+4/−0 source**: pure additive guard (2 lines per function), no business logic touched.
- No `sorry`/stub/`pass` replacing code.
- Backward-compatible: 30 existing tests pass unchanged (efficiency `sum == v(N)` holds for normal `n_samples`).

## Tests — 36/36 pass (1.02s, CPU-only)
30 existing + **6 new guard tests** (`TestMonteCarloNsamplesGuard`). **Verified non-vacuous**: 5 guard tests FAIL on unpatched code (crash/NaN/silent-wrong), the 6th (`test_positive_n_samples_unaffected`) documents unchanged normal behavior.

## Genre / steer alignment
- **Famille = GameTheory/cooperative_games** (fresh — 3rd distinct family this session after QC/shared #7463 and catalog tooling #7473, R6 family rotation honorée).
- Genre = bug-fix (consistent with #7463/#7473 degenerate-input-guard class). Forensic discovery by reading the source + exercising edge cases (marco.py: \"algorithm-structure-correct ≠ no bug\").

See #7463 + #7473 (same bug-class, sibling fixes).