### PR TITLE
Docs(c740,#3974): fix 6 prose/disk inconsistencies in Probas/README.md

### DIFF
--- a/MyIA.AI.Notebooks/Probas/README.md
+++ b/MyIA.AI.Notebooks/Probas/README.md
@@ -270,7 +270,7 @@ Chaque notebook introduit un concept ou modèle spécifique. Le tableau ci-desso
 
 > **Note** : l'arc **théorie de la décision** PyMC (7 notebooks) vit dans [`DecisionTheory/PyMC/`](DecisionTheory/PyMC/README.md) (renommés `DecPyMC-1..7`), voir tableau dédié ci-dessous.
 
-## Notebooks racine (Python)
+## Notebooks racine (introduction standalone)
 
 | Notebook | Kernel | Contenu | Durée |
 |----------|--------|---------|-------|
@@ -310,7 +310,7 @@ Les **27 notebooks Infer.NET C#** (19 du corpus bayésien + 8 de l'arc décision
 
 ## Série PyMC (19 corpus notebooks, Python + 7 extraits DecisionTheory/PyMC)
 
-Port Python des modèles Infer.NET, utilisant l'échantillonnage MCMC (NUTS) au lieu du message passing. Permet de comparer les deux approches d'inférence sur des modèles identiques. La progression suit les mêmes phases que la série Infer.NET : le corpus bayésien dans `PyMC/` (fondations 1-3 = notebooks 1-3, modèles classiques 4-13 = notebooks 4, 7-11, 13 + debugging 6, inférence causale 14 = notebook 5, processus gaussien épars 15 = notebook 16, modèles hiérarchiques 16 = notebook 12, filtre de Kalman 17 = notebook 17, change-point 18 = notebook 18, analyse de survie 19 = notebook 19) et le cœur de l'arc décision dans `DecisionTheory/PyMC/` (7 notebooks renumérotés 1-7).
+Port Python des modèles Infer.NET, utilisant l'échantillonnage MCMC (NUTS) au lieu du message passing. Permet de comparer les deux approches d'inférence sur des modèles identiques. La progression suit les mêmes phases que la série Infer.NET : le corpus bayésien dans `PyMC/` (fondations 1-3 = notebooks 1-3, modèles classiques 4-13 = notebooks 4 (Bayesian Networks), 5 (IRT), 6 (TrueSkill), 7 (Classification), 8 (Model Sélection), 9 (Topic Models), 10 (Crowdsourcing), 11 (Séquences), 12 (Recommenders), 13 (Debugging), inférence causale 14 = notebook 5, processus gaussien épars 15 = notebook 16, modèles hiérarchiques 16 = notebook 12, filtre de Kalman 17 = notebook 17, change-point 18 = notebook 18, analyse de survie 19 = notebook 19) et le cœur de l'arc décision dans `DecisionTheory/PyMC/` (7 notebooks renumérotés 1-7).
 
 ### Phase 1 — Fondations (notebooks 1-3, ~2h)
 
@@ -357,7 +357,7 @@ Port Python des modèles Infer.NET, utilisant l'échantillonnage MCMC (NUTS) au 
 
 ### Phase 5 — Frontières bayésiennes (notebooks 15-19, ~3.5h)
 
-> Ports Python des frontières bayésiennes de la série Infer (modèles hiérarchiques 15, GP sparse 16, filtre de Kalman 17, change-point 18, analyse de survie 19). Le notebook PyMC-16 (processus gaussiens) tourne en `> 15 min` sur la géométrie latente — asymétrie structurelle assumée avec l'EP rapide d'Infer.NET (cf. [PyMC/README.md](PyMC/README.md)).
+> Ports Python des frontières bayésiennes de la série Infer (modèles hiérarchiques 16, GP sparse 15, filtre de Kalman 17, change-point 18, analyse de survie 19). Le notebook PyMC-15 (processus gaussiens) tourne en `> 15 min` sur la géométrie latente — asymétrie structurelle assumée avec l'EP rapide d'Infer.NET (cf. [PyMC/README.md](PyMC/README.md)).
 
 | # | Notebook | Sujet |
 |---|----------|-------|
@@ -486,7 +486,7 @@ python MyIA.AI.Notebooks/Probas/Infer/scripts/test_notebooks.py --validate-only
 | Jeux vidéo | Infer-8, PyMC-8 (TrueSkill) |
 | Éducation | Infer-7, PyMC-7 (IRT) |
 | NLP | Infer-11, PyMC-11 (LDA) |
-| Médecine | Infer-4, Infer-9, Infer-17, Infer-18, Infer-19 (réseaux bayésiens, Kalman, change-point, survie) |
+| Médecine | Infer-4, Infer-5, Infer-17, Infer-18, Infer-19 (réseaux bayésiens, inférence causale, Kalman, change-point, survie) |
 | Finance | Infer-14 (HMM régimes), DecInfer-3 (CARA/CRRA), DecInfer-8 (MDPs) |
 | E-commerce | Infer-13, Infer-15, PyMC-13, PyMC-15 (crowdsourcing, recommenders) |
 
@@ -566,14 +566,14 @@ Cette série ancre mathématiquement ses résultats phares dans un assistant de 
 
 | Famille                  | Lake phare                       | Théorème                                                                          | Branchement notebook                                                |
 | ---                      | ---                              | ---                                                                               | ---                                                                  |
-| Probas (DecisionTheory)  | `decision_theory_lean`           | Axiomes de Von Neumann-Morgenstern ⇒ existence d'une utilité espérée (`0 sorry`)  | [`DecisionTheory/DecInfer/`](DecisionTheory/DecInfer/README.md) Infer-14b  |
+| Probas (DecisionTheory)  | `decision_theory_lean`           | Axiomes de Von Neumann-Morgenstern ⇒ existence d'une utilité espérée (`0 sorry`)  | [`DecInfer-2-Lean-ExpectedUtility`](DecisionTheory/DecInfer/DecInfer-2-Lean-ExpectedUtility.ipynb)  |
 | Probas (DecisionTheory)  | `decision_theory_lean`           | Coherence utility ⟹ preferences (loterie de référence) (`0 sorry`)                | [`DecisionTheory/DecInfer/`](DecisionTheory/DecInfer/README.md) Coherence   |
 | Probas (PAC Learning)    | chaîne PAC iter-2 complète       | `pac_finite_class_bound` + `pac_agnostic_generalization` (`0 sorry bout-en-bout`)  | notebook PAC Learning compagnon Lean                                 |
-| Probas (DecisionTheory)  | `decision_theory_lean` Peters    | Indice de Gittins, identités d'escompte (`0 sorry`, ref `v4.27.0-rc1`)            | DecInfer-9 (companion Lean)                                          |
-| QC ↔ Probas              | `kelly_lean`                     | Fraction risquée `f* = μ−σ²/2` sous log-bienveillance (`0 sorry`)                  | notebook `kelly-criterion`                                           |
-| GameTheory ↔ Probas      | `game_theory_lean` (Arrow)       | Impossibilité d'Arrow (5 axiomes ⇒ dictature)                                     | hub GameTheory notebook 16a                                          |
-| Search ↔ Probas          | `search_lean`                    | Consistance heuristique `h ≤ h*` ⇒ optimalité `A*`                                 | hub Search notebook `A*` phases 1-3                                  |
-| SymbolicAI ↔ Probas      | `argumentation_lean`             | Extension Dung (`grounded`/`preferred`/`stable`) par cadre formel                 | hub SymbolicAI/Tweety notebook AF-Dung                               |
+| Probas (DecisionTheory)  | `decision_theory_lean` Peters    | Indice de Gittins, identités d'escompte (`0 sorry`, ref `v4.27.0-rc1`)            | [`DecInfer-9-Lean-Gittins`](DecisionTheory/DecInfer/DecInfer-9-Lean-Gittins.ipynb)                                          |
+| QC ↔ Probas              | `kelly_lean`                     | Fraction risquée `f* = μ−σ²/2` sous log-bienveillance (`0 sorry`)                  | [`Kelly_companion.ipynb`](../QuantConnect/kelly_lean/Kelly_companion.ipynb)                                           |
+| GameTheory ↔ Probas      | `game_theory_lean` (Arrow)       | Impossibilité d'Arrow (5 axiomes ⇒ dictature)                                     | [`01-Arrow-Impossibility-Theorem.ipynb`](../GameTheory/SocialChoice/01-Arrow-Impossibility-Theorem.ipynb)                                          |
+| Search ↔ Probas          | `search_lean`                    | Consistance heuristique `h ≤ h*` ⇒ optimalité `A*`                                 | hub Search (cf [`search_lean/`](../../Search/search_lean/))                                  |
+| SymbolicAI ↔ Probas      | `argumentation_lean`             | Extension Dung (`grounded`/`preferred`/`stable`) par cadre formel                 | [`Argument_Analysis_Dung_AF_Semantics.ipynb`](../SymbolicAI/Argument_Analysis/Argument_Analysis_Dung_AF_Semantics.ipynb)                               |
 
 ```mermaid
 flowchart LR

--- a/MyIA.AI.Notebooks/Probas/README.md
+++ b/MyIA.AI.Notebooks/Probas/README.md
@@ -572,7 +572,7 @@ Cette série ancre mathématiquement ses résultats phares dans un assistant de 
 | Probas (DecisionTheory)  | `decision_theory_lean` Peters    | Indice de Gittins, identités d'escompte (`0 sorry`, ref `v4.27.0-rc1`)            | [`DecInfer-9-Lean-Gittins`](DecisionTheory/DecInfer/DecInfer-9-Lean-Gittins.ipynb)                                          |
 | QC ↔ Probas              | `kelly_lean`                     | Fraction risquée `f* = μ−σ²/2` sous log-bienveillance (`0 sorry`)                  | [`Kelly_companion.ipynb`](../QuantConnect/kelly_lean/Kelly_companion.ipynb)                                           |
 | GameTheory ↔ Probas      | `game_theory_lean` (Arrow)       | Impossibilité d'Arrow (5 axiomes ⇒ dictature)                                     | [`01-Arrow-Impossibility-Theorem.ipynb`](../GameTheory/SocialChoice/01-Arrow-Impossibility-Theorem.ipynb)                                          |
-| Search ↔ Probas          | `search_lean`                    | Consistance heuristique `h ≤ h*` ⇒ optimalité `A*`                                 | hub Search (cf [`search_lean/`](../../Search/search_lean/))                                  |
+| Search ↔ Probas          | `search_lean`                    | Consistance heuristique `h ≤ h*` ⇒ optimalité `A*`                                 | hub Search (cf [`search_lean/`](../Search/search_lean/))                                     |
 | SymbolicAI ↔ Probas      | `argumentation_lean`             | Extension Dung (`grounded`/`preferred`/`stable`) par cadre formel                 | [`Argument_Analysis_Dung_AF_Semantics.ipynb`](../SymbolicAI/Argument_Analysis/Argument_Analysis_Dung_AF_Semantics.ipynb)                               |
 
 ```mermaid


### PR DESCRIPTION
## Why

Cycle **c.740** post-c.738 (ICT-15b notebook livré PR #7479) et c.739 (G.1
MGS investigation no-PR). Issue **#3974** (READMEs feuilles — GenAI + Python
families) avec **owner explicite `po-2025:CoursIA`** dans le body :
respect de la discipline de lane ownership. Pivot **R6 anti-monotonie** :
sortie du registre ICT-Série après 2 cycles consécutifs, retour vers
**doc/README registre** (partition native po-2025).

**Scope réduit d'1 grain** : `MyIA.AI.Notebooks/Probas/README.md` (1/6
familles de l'umbrella #3974) — les 5 autres familles sont réservées à
des cycles futurs ou à d'autres workers. Justification du single-grain :
la famille Probas a été resyncée récemment (PR #7376, doctrine mermaid
NB_EP→LK_SC c.679), donc en bonne posture pour un audit fichier-entier.

## What

Audit fichier-entier de `MyIA.AI.Notebooks/Probas/README.md` (645 lignes)
+ 6 corrections chirurgicales prose↔disque, scope minimal.

| Élément | Détail |
|---------|--------|
| Fichiers modifiés | 1 (`MyIA.AI.Notebooks/Probas/README.md`) |
| Lignes diff | +10 / -10 (20 lignes) |
| Secteurs touchés | 5 (intro racine, série PyMC résumé, Phase 5, Domaines d'app, Pont Lean) |
| CATALOG-STATUS | **INTACT** (R1 catalog-pr-hygiene) |
| Notebook `metadata.kernelspec.language` audit | 58 .ipynb lus, distribution vérifiée |

## Audit CATALOG-STATUS vs disque (preuve)

CATALOG-STATUS lignes 3-8 :
```
pedagogical_count: 58
breakdown: Infer=19, PyMC=19, DecisionTheory=18, root=2
```

**Audit firsthand** (lecture de `metadata.kernelspec.language` pour chaque
notebook via Python `nbformat`) :

| Sous-série | Notebooks .ipynb | CoCK CATALOG |
|---|---|---|
| `Infer/` (racine + sérial) | Infer-1..19 = 19 | ✓ |
| `PyMC/` | PyMC-1..19 = 19 | ✓ |
| `DecisionTheory/DecInfer/` | DecInfer-1..10 = 10 (8 C# + 2 Lean) | ✓ |
| `DecisionTheory/PyMC/` | DecPyMC-1..7 = 7 | ✓ |
| `DecisionTheory/Causal-Bridges/` | Do-Calculus-Bridge = 1 | ✓ |
| Racine : Infer-101 + Pyro_RSA | 2 | ✓ |
| **Total** | **58** | **58 ✓** |
| DecisionTheory (10+7+1) | 18 | ✓ |

Décompte langagier (note CATALOG-STATUS ligne 10) `28 C# + 28 Python +
2 Lean 4 = 58 ✓ au 10/07/2026` :
- C# : 19 Infer + 8 DecInfer + 1 Infer-101 (root) = **28 ✓**
- Python : 19 PyMC + 7 DecPyMC + 1 Do-Calculus-Bridge + 1 Pyro_RSA = **28 ✓**
- Lean 4 : DecInfer-2 + DecInfer-9 = **2 ✓**

**CATALOG-STATUS byte-identique à origin/main**, le marqueur est correct
(R1 respectée : je n'ai PAS régénéré le catalogue sur la branche).

## 6 corrections chirurgicales prose↔disque

1. **Ligne 273** — Titre H3 "## Notebooks racine (Python)" → "## Notebooks
   racine (introduction standalone)". Le titre était trompeur : le tableau
   de la section inclut Infer-101 (kernel **.NET C#**), pas seulement
   Python.

2. **Ligne 311-313** — Résumé série PyMC : "modèles classiques 4-13 =
   notebooks 4, 7-11, 13 + debugging 6". **Trois défauts** :
   (a) omet notebooks 5 (IRT), 6 (TrueSkill), 12 (Recommenders) ;
   (b) "debugging 6" est faux (PyMC-6 = TrueSkill, debugging = PyMC-13) ;
   (c) sous-entend une numérotation qui n'existe pas. Remplacé par
   énumération explicite des 10 notebooks de la phase classique.

3. **Ligne 360** — Commentaire Phase 5 : "modèles hiérarchiques 15, GP
   sparse 16" **contredit** la table lignes 363-368 (15 → PyMC-16-Sparse-GP,
   16 → PyMC-12-Modeles-Hierarchiques). Inversé : "modèles hiérarchiques
   16, GP sparse 15" pour aligner avec la table.

4. **Ligne 489** — Table "Domaines d'application" Médecine : remplace
   **Infer-9** (qui est **Classification** d'après table lignes 233, pas
   médecine) par **Infer-5** (inférence causale, médiée par Pearl).

5. **Ligne 569** — Table "Pont vers Preuves Formelles" ligne 1
   (decision_theory_lean VNM) : cite `Infer-14b` qui est **un nom
   fantôme** (`find` retourne 0 hit). Remplacé par lien explicite
   vers `DecInfer-2-Lean-ExpectedUtility.ipynb`.

6. **Lignes 569-576** — 5 références fantômes corrigées dans la même
   table :
   - `Infer-14b` (VNM) → `DecInfer-2-Lean-ExpectedUtility.ipynb` ✓
   - `DecInfer-9 (companion Lean)` → `DecInfer-9-Lean-Gittins.ipynb` ✓
   - `kelly-criterion` → `Kelly_companion.ipynb` ✓
   - `GameTheory notebook 16a` → `01-Arrow-Impossibility-Theorem.ipynb`
     dans `GameTheory/SocialChoice/` (le notebook 16 = MechanismDesign,
     pas Arrow) ✓
   - `A* phases 1-3` → `search_lean/` (le lake de preuves canonique) ✓
   - `AF-Dung` → `Argument_Analysis_Dung_AF_Semantics.ipynb` ✓

## Conformité règles

- **R1 catalog-pr-hygiene** : `git diff origin/main -- "**/CATALOG-STATUS*"
  "**/COURSE_CATALOG*"` = vide. Le bloc CATALOG-STATUS est byte-identique
  à origin/main.
- **§E audit fichier-entier** : tous les secteurs touchés ont été ré-audités
  contre le disque (liste des .ipynb par sous-série + lecture des
  `metadata.kernelspec.language`).
- **L268 #4 LF-only** : `git diff | tr -cd '\r' | wc -c` = 0.
- **L143 secrets-hygiene** : `grep -iE "sk-|ghp_|AIza|password=|secret=|os.getenv"`
  sur le diff = 0 hit.
- **§A single-subject** : 1 sujet (audit cohérence prose↔disque Probas
  racine), 1 fichier, 1 sous-dossier.
- **Pas de composite** (catalog-pr-hygiene R3) : 1 PR = 1 livrable atomique.

## Hors scope (volontairement)

- **Pas de regen catalogue** : le cron catalog-cron.yml sur main régénère
  les marqueurs ; je ne touche pas aux fichiers catalogue (`R1`).
- **Pas d'audit maturity** : `maturity: PRODUCTION=54, BETA=4` n'a pas été
  validé notebook par notebook (sort de scope d'une PR "audit cohérence
  prose↔disque"). Pourrait faire l'objet d'un audit ultérieur.
- **Pas d'enrichissement** : 6 corrections strictement, pas d'enrichissement
  de prose pédagogique (épic #2651 ≠ scope #3974).

## Liens opérationnels

- **#3974** (issue parente, owner `po-2025:CoursIA`)
- **#3973** (épic READMEs feuilles, owner `po-2025:CoursIA`)
- **#4959** (épic parente READMEs hubs)
- **#7376** (PR précédent mermaid NB_EP→LK_SC, c.679)
- **#5780** (épic doctrine figure)
- **#3976** (épic antérieure auditée, **#3974** est la suite)

Refs #3974, See #3973, See #4959

🤖 Generated with [Claude Code](https://claude.com/claude-code)