### PR TITLE
fix(prover,#7477): bound deadline wall-clock — per-provider max_retries + typed timeout skip

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/conftest.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/conftest.py
@@ -1,0 +1,84 @@
+"""Conditional pytest conftest for ``agent_tests/``.
+
+The ``prover/`` package is a real runtime package whose ``__init__.py``
+cascades into ``provers.py`` (111KB) + ``tools.py`` (145KB), pulling in
+``agent_framework`` / ``agent_framework_openai`` / ``openai`` / ``httpx``.
+Those are installed only on the Lean/prover-runtime machine; a CPU-only
+worker (e.g. po-2025) has none of them.
+
+This conftest lets the lightweight deadline tests
+(``prover/test_prover_deadline.py``) run on a CPU-only worker by installing
+permissive stubs and preempting the ``prover`` package in ``sys.modules``
+BEFORE pytest collects it. Crucially the stubbing is **conditional**: when
+``agent_framework`` is genuinely importable (the prover-runtime machine),
+the stubs are skipped and the REAL ``prover`` package + the real
+``tests/test_prover_*.py`` run unchanged — no regression on the machine
+that owns this code.
+
+The mechanism:
+- This file lives in ``agent_tests/`` (no ``__init__.py`` here), so pytest
+  imports it as a standalone conftest during its downward collection walk,
+  BEFORE descending into the ``prover/`` package.
+- Installing ``sys.modules["prover"]`` (empty stub) here makes Python skip
+  the real ``prover/__init__.py`` when it later resolves ``prover.<x>``.
+"""
+
+import importlib.util
+import sys
+import types
+
+
+def _is_importable(name: str) -> bool:
+    """True iff ``name`` resolves to an installed module spec."""
+    try:
+        return importlib.util.find_spec(name) is not None
+    except (ImportError, ModuleNotFoundError, ValueError):
+        return False
+
+
+def _permissive_module(name: str) -> types.ModuleType:
+    """A module whose PEP 562 ``__getattr__`` returns a permissive stand-in
+    for ANY attribute, so ``from <name> import AnythingAtAll`` always
+    succeeds. The stand-in is subclassable, callable, and any attribute
+    access on it yields another stand-in."""
+    mod = types.ModuleType(name)
+
+    class _Any:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __call__(self, *args, **kwargs):
+            return _Any()
+
+        def __getattr__(self, attr):
+            return _Any()
+
+        # Support subscription used in type hints, e.g.
+        # `WorkflowContext[ProofMessage]` (PEP 560 / 585).
+        def __class_getitem__(cls, item):
+            return cls
+
+    def __getattr__(attr):  # module-level (PEP 562)
+        return _Any
+
+    mod.__getattr__ = __getattr__
+    sys.modules[name] = mod
+    return mod
+
+
+# Only stub when the prover runtime is genuinely absent — a no-op on the
+# machine that owns this code (agent_framework installed there).
+if not _is_importable("agent_framework"):
+    _permissive_module("agent_framework")
+    _permissive_module("agent_framework_openai")
+    _dotenv = _permissive_module("dotenv")
+    _dotenv.load_dotenv = lambda *args, **kwargs: False
+    _permissive_module("httpx")
+    _permissive_module("openai")
+
+    # Preempt the real `prover` package so its `__init__.py` (which imports
+    # the 111KB provers.py cascade) never runs on a CPU-only worker. Marked
+    # as a package (__path__) so `prover.workflow` / `prover.state` resolve.
+    _prover_stub = types.ModuleType("prover")
+    _prover_stub.__path__ = []
+    sys.modules["prover"] = _prover_stub

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
@@ -62,7 +62,17 @@ PROVIDERS = {
         "models": {
             "reasoning": os.getenv("LOCAL_LLM_MODEL_ID", "qwen3.6-35b-a3b"),
             "fast": os.getenv("LOCAL_LLM_MODEL_ID", "qwen3.6-35b-a3b"),
-        }
+        },
+        # #7477 P1: a local server (vLLM/Ollama qwen3.6) either answers fast
+        # or HANGS — it has no "intermittent 5xx blip" profile like the
+        # remote providers. The OpenAI SDK retries a transient failure
+        # `max_retries` times, each waiting the FULL `request_timeout_s`
+        # (240s). For a hang that burns 240x5 = 1200s per call (forensic
+        # span `chat qwen3.6 1206.9s`). max_retries=1 caps a hang at
+        # 2xtimeout (480s) and lets the harness PROVIDER_OUTAGE_BREAKER
+        # (workflow.py) terminate the run cleanly. Remote 5xx-prone
+        # providers keep the create_client default max_retries=4.
+        "max_retries": 1,
     },
     "openrouter": {
         # OpenRouter is the "powerful provider" lane: the DirectorAgent runs
@@ -303,14 +313,23 @@ def create_client(provider: str = "zai", model_key: str = "reasoning",
     max_retries=1 a single transient blip terminated the BG run; OpenAI
     SDK uses exponential backoff internally so 4 retries adds at most
     ~30s wall-clock for legitimately recoverable failures.
+
+    Per-provider override (#7477 P1): a provider entry may set its own
+    ``max_retries`` to override the function default. The ``local`` provider
+    sets max_retries=1 because a local server hangs (no fast 5xx blips to
+    recover from), so 4 SDK retries would burn 240x5 = 1200s per call on a
+    dead endpoint. The override keeps remote 5xx-prone providers on the
+    resilient default while capping the hanging provider.
     """
     from openai import AsyncOpenAI
     cfg = PROVIDERS[provider]
+    # #7477 P1: per-provider max_retries wins; absent key = function default.
+    effective_retries = cfg.get("max_retries", max_retries)
     async_client = AsyncOpenAI(
         api_key=cfg["api_key"],
         base_url=cfg["base_url"],
         timeout=request_timeout_s,
-        max_retries=max_retries,
+        max_retries=effective_retries,
     )
     return OpenAIChatCompletionClient(
         model=cfg["models"][model_key],

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/test_prover_deadline.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/test_prover_deadline.py
@@ -1,0 +1,235 @@
+"""Unit tests for the prover deadline / retry-bounding fix (#7477 P1, #1453).
+
+Covers TWO independent wall-clock multipliers that turned a single hanging
+LLM endpoint into a 1200s+ (SDK) or 2300s+ (SDK + harness) burn per call:
+
+1. config.py `create_client` passed `max_retries=4` universally to the
+   OpenAI SDK. The SDK retries a transient failure `max_retries` times,
+   each waiting the FULL `request_timeout_s` (240s) — so a hanging `local`
+   endpoint burned 240x5 = 1200s per call (forensic span
+   `chat qwen3.6 1206.9s`). Fix: a per-provider `max_retries` override;
+   the `local` provider sets 1 (a local server hangs, it does not blip).
+
+2. workflow.py `_is_transient_error` classified read/connect timeouts as
+   transient, so once the SDK finally surfaced a TimeoutError the harness
+   `_is_transient_error` retry loop re-invoked `agent.run` up to
+   TRANSIENT_RETRY_MAX (5) more times — each call burning another full SDK
+   retry chain (forensic span `invoke_agent SearchAgent 2299.7s`). Fix: a
+   dedicated `_is_timeout_error` routes timeouts to the provider-failure
+   path (counted toward PROVIDER_OUTAGE_BREAKER) instead of the retry loop.
+
+Self-contained: the heavy deps (`agent_framework` / `agent_framework_openai`
+/ `dotenv` / `openai`) and the real `prover` package are stubbed in
+`conftest.py` BEFORE collection. This module loads `config.py` /
+`workflow.py` directly by file path via importlib.
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+_PROVER_DIR = Path(__file__).resolve().parent
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Submodule stubs for workflow.py's relative imports (.state / .trace /
+# .knowledge / .lean_utils). conftest.py already preempted the `prover`
+# package and stubbed the top-level heavy deps.
+# ──────────────────────────────────────────────────────────────────────
+
+class _GenericBase:
+    """Permissive base class / callable for any stubbed symbol."""
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+def _stub_submodule(name: str, **attrs) -> types.ModuleType:
+    mod = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(mod, key, value)
+    sys.modules[name] = mod
+    return mod
+
+
+# workflow.py: `from .state import SorryContext` etc. — resolve against the
+# conftest-preempted `prover` package.
+_stub_submodule("prover.state", SorryContext=_GenericBase)
+_stub_submodule("prover.trace", TraceLogger=_GenericBase)
+_stub_submodule("prover.knowledge", ProofKnowledgeBase=_GenericBase)
+_stub_submodule("prover.lean_utils", count_real_sorries=lambda *a, **kw: 0)
+
+
+def _load_module(name: str, path: Path):
+    """importlib path-load (self-contained, no sys.path mutation)."""
+    spec = importlib.util.spec_from_file_location(name, str(path))
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# config.py has no relative imports → load as a top-level module.
+config = _load_module("prover_deadline_config", _PROVER_DIR / "config.py")
+# workflow.py uses relative imports (.state / .trace / ...) → load as
+# `prover.workflow` so they resolve against the stubbed `prover` package.
+workflow = _load_module("prover.workflow", _PROVER_DIR / "workflow.py")
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Fake OpenAI AsyncOpenAI — records the kwargs create_client passes.
+# conftest made `openai` a permissive stub; we OVERRIDE AsyncOpenAI on it
+# so `from openai import AsyncOpenAI` (inside create_client) gets our fake.
+# ──────────────────────────────────────────────────────────────────────
+
+class _FakeAsyncOpenAI:
+    """Records the last ctor kwargs; installed as `openai.AsyncOpenAI`."""
+    last_kwargs = None
+
+    def __init__(self, **kwargs):
+        _FakeAsyncOpenAI.last_kwargs = dict(kwargs)
+
+
+def _install_fake_async_openai():
+    # Normal attribute set wins over the conftest permissive __getattr__
+    # (PEP 562: __getattr__ fires only when normal lookup misses).
+    sys.modules["openai"].AsyncOpenAI = _FakeAsyncOpenAI
+    _FakeAsyncOpenAI.last_kwargs = None
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Fix 1 — config.py create_client per-provider max_retries
+# ══════════════════════════════════════════════════════════════════════
+
+class TestCreateClientMaxRetries:
+    """The `local` provider override (max_retries=1) must reach the SDK so a
+    hanging local endpoint fails fast instead of burning 240s x 5."""
+
+    def setup_method(self):
+        _install_fake_async_openai()
+
+    def test_local_provider_uses_override_max_retries_1(self):
+        # The per-provider override caps a hang at 2xtimeout (480s), not 5x.
+        config.create_client("local")
+        assert _FakeAsyncOpenAI.last_kwargs is not None
+        assert _FakeAsyncOpenAI.last_kwargs["max_retries"] == 1
+
+    def test_remote_provider_keeps_default_max_retries_4(self):
+        # zai has no `max_retries` key → function default (4) applies.
+        config.create_client("zai")
+        assert _FakeAsyncOpenAI.last_kwargs["max_retries"] == 4
+
+    def test_explicit_arg_respected_when_no_provider_override(self):
+        # mistral has no override → an explicit max_retries arg wins.
+        config.create_client("mistral", max_retries=2)
+        assert _FakeAsyncOpenAI.last_kwargs["max_retries"] == 2
+
+    def test_provider_override_wins_over_function_arg(self):
+        # The override is authoritative: even an explicit max_retries=4 cannot
+        # re-introduce the 1200s hang on the local provider.
+        config.create_client("local", max_retries=4)
+        assert _FakeAsyncOpenAI.last_kwargs["max_retries"] == 1
+
+    def test_timeout_passed_through_unchanged(self):
+        # The fix changes only max_retries, NOT the per-call timeout (legit
+        # deep reasoning still gets the full 240s).
+        config.create_client("local", request_timeout_s=240.0)
+        assert _FakeAsyncOpenAI.last_kwargs["timeout"] == 240.0
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Fix 2a — workflow.py _is_timeout_error classifies sustained hangs
+# ══════════════════════════════════════════════════════════════════════
+
+class TestIsTimeoutError:
+    """A timeout surfacing at the harness layer has already been retried by
+    the SDK — `_is_timeout_error` must recognise it so it is NOT re-retried."""
+
+    @pytest.mark.parametrize("message", [
+        "ReadTimeout",
+        "connect timeout",
+        "ReadTimeoutError: timed out",
+        "PoolTimeout: Pool exhausted",
+        "Request timed out",
+    ])
+    def test_matches_timeout_markers(self, message):
+        class _Exc(Exception):
+            pass
+        assert workflow._is_timeout_error(_Exc(message)) is True
+
+    @pytest.mark.parametrize("message", [
+        "internal server error",
+        "connection reset by peer",
+        "Not Found",
+        "unauthorized",
+    ])
+    def test_does_not_match_non_timeout(self, message):
+        class _Exc(Exception):
+            pass
+        assert workflow._is_timeout_error(_Exc(message)) is False
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Fix 2b — workflow.py _is_transient_error no longer retries timeouts
+# ══════════════════════════════════════════════════════════════════════
+
+class TestTransientErrorExcludesTimeouts:
+    """Regression guard: timeouts must NOT be classified transient (else the
+    harness retry loop multiplies the SDK hang)."""
+
+    def test_still_matches_5xx_status(self):
+        class _Exc(Exception):
+            status_code = 503
+        assert workflow._is_transient_error(_Exc()) is True
+
+    def test_still_matches_connection_reset(self):
+        class _Exc(Exception):
+            pass
+        assert workflow._is_transient_error(
+            _Exc("Connection reset by peer")
+        ) is True
+
+    def test_still_excludes_404(self):
+        # A 404 is a config bug (bad model_id) — must never be retried.
+        class _Exc(Exception):
+            status_code = 404
+        assert workflow._is_transient_error(_Exc()) is False
+
+    @pytest.mark.parametrize("message", [
+        "ReadTimeout",
+        "connect timeout",
+        "Request timed out",
+    ])
+    def test_no_longer_classifies_timeout_as_transient(self, message):
+        # THE FIX (was True before #7477 P1): a timeout has already been
+        # retried by the SDK; the harness must not re-retry it.
+        class _Exc(Exception):
+            pass
+        assert workflow._is_transient_error(_Exc(message)) is False
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Routing invariant — timeout and transient are mutually exclusive
+# ══════════════════════════════════════════════════════════════════════
+
+class TestTimeoutTransientMutualExclusion:
+    """A timeout routes to provider_failed (skip harness retry); a 5xx /
+    connection-reset routes to the retry loop. The two never overlap, so the
+    AgentExecutor `elif _is_timeout_error` / `elif _is_transient_error`
+    branches are unambiguous."""
+
+    def test_timeout_is_only_timeout_not_transient(self):
+        class _Exc(Exception):
+            pass
+        exc = _Exc("ReadTimeout: timed out")
+        assert workflow._is_timeout_error(exc) is True
+        assert workflow._is_transient_error(exc) is False
+
+    def test_5xx_is_only_transient_not_timeout(self):
+        class _Exc(Exception):
+            status_code = 502
+        exc = _Exc()
+        assert workflow._is_transient_error(exc) is True
+        assert workflow._is_timeout_error(exc) is False

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py
@@ -104,18 +104,53 @@ def _transient_backoff_s(attempt: int) -> float:
     return min(2.0 ** (attempt - 1), TRANSIENT_RETRY_BACKOFF_CAP_S)
 
 
+def _is_timeout_error(exc: BaseException) -> bool:
+    """Return True if `exc` is a read/connect timeout (sustained hang).
+
+    #7477 P1. Distinct from `_is_transient_error`: the OpenAI SDK already
+    retries a timeout `max_retries` times internally (config.py
+    `create_client`), so by the time the exception surfaces here it is a
+    SUSTAINED endpoint hang, not a transient network blip. The SDK burns
+    `request_timeout_s` (240s) on every attempt — for the `local` provider
+    that is 240x2 = 480s, for a max_retries=4 remote 240x5 = 1200s (forensic
+    span `chat qwen3.6 1206.9s`).
+
+    Retrying a sustained hang AGAIN at the harness layer (the
+    `_is_transient_error` loop below) would multiply that wall-clock up to
+    6x more (TRANSIENT_RETRY_MAX). `_is_timeout_error` routes the exception
+    to the provider-failure path instead, counted toward
+    `PROVIDER_OUTAGE_BREAKER` so a dead endpoint terminates the run cleanly
+    with the `provider_outage` verdict rather than spinning.
+
+    httpx/openai name their timeout exceptions `ReadTimeout` / `ConnectTimeout`
+    / `PoolTimeout`; `agent_framework` wraps them but the message retains the
+    marker, so we probe the stringified message defensively.
+    """
+    msg = str(exc).lower()
+    return any(marker in msg for marker in (
+        "read timeout", "connect timeout", "pool timeout",
+        "timed out", "timeout",
+    ))
+
+
 def _is_transient_error(exc: BaseException) -> bool:
     """Return True if `exc` looks like a transient provider/network error.
 
     Matches ONLY conditions worth retrying:
       - HTTP 5xx server errors (500, 502, 503, 504),
-      - connection reset / aborted / refused,
-      - read / connect timeouts.
+      - connection reset / aborted / refused.
 
-    Explicitly EXCLUDES 404 (bad/missing model_id — a config bug, retrying just
-    wastes time) and other 4xx client errors (401/403/422). `agent_framework`
-    may wrap the underlying httpx / openai error, so we probe both the
-    `status_code` attribute and the stringified message defensively.
+    Explicitly EXCLUDES:
+      - 404 (bad/missing model_id — a config bug, retrying just wastes time)
+        and other 4xx client errors (401/403/422);
+      - read / connect timeouts — those are routed to `_is_timeout_error`
+        (#7477 P1). A timeout surfacing here has ALREADY been retried
+        `max_retries` times by the OpenAI SDK, so it is a sustained hang,
+        not a blip; harness-retrying it would multiply the 240s wall-clock.
+
+    `agent_framework` may wrap the underlying httpx / openai error, so we
+    probe both the `status_code` attribute and the stringified message
+    defensively.
     """
     # 1. Structured HTTP status code, if the provider exposed one. Checked on
     #    the exception and a common nested `.response` (httpx-style) attribute.
@@ -150,7 +185,9 @@ def _is_transient_error(exc: BaseException) -> bool:
         "service failed",
         "connection reset", "connection aborted", "connection refused",
         "connectionreset", "connectionerror",
-        "read timeout", "connect timeout", "timed out", "timeout",
+        # #7477 P1: timeout markers moved to `_is_timeout_error`. A timeout
+        # reaching this layer has already exhausted the SDK's own retries
+        # (config.py max_retries) — re-retrying it here multiplies the hang.
         "temporarily unavailable", "remote end closed",
     )
     return any(marker in msg for marker in transient_markers)
@@ -459,14 +496,38 @@ class AgentExecutor(Executor):
                             agent=self._agent.name, role="error_retry_failed",
                             content=str(e2)[:200],
                         )
+            elif _is_timeout_error(e):
+                # #7477 P1: a timeout surfacing here has ALREADY been
+                # retried `max_retries` times by the OpenAI SDK (config.py
+                # create_client) — it is a sustained endpoint hang, not a
+                # transient blip. Do NOT route to the `_is_transient_error`
+                # retry loop below: that would re-invoke `agent.run` up to
+                # TRANSIENT_RETRY_MAX more times, each burning another
+                # 240sx(max_retries+1) of wall-clock (forensic span
+                # `invoke_agent SearchAgent 2299.7s` = SDK + harness both
+                # retrying the same hang). Count it as a provider failure
+                # so PROVIDER_OUTAGE_BREAKER terminates the run cleanly
+                # with the `provider_outage` verdict instead of spinning.
+                _provider_failed = True
+                response_text = (
+                    f"[harness] Agent timeout (sustained hang after SDK "
+                    f"retries): {str(e)[:200]}"
+                )
+                if self._trace:
+                    self._trace.log(
+                        agent=self._agent.name, role="provider_timeout",
+                        content=str(e)[:200],
+                    )
             elif _is_transient_error(e):
                 # Transient provider/network error (HTTP 5xx, connection
-                # reset/aborted, read/connect timeout). Forensic: several
-                # iterations were lost when an agent crashed mid-run on a
-                # transient error with no retry. Retry the SAME invocation,
-                # bounded (TRANSIENT_RETRY_MAX) with short exponential backoff.
-                # A 404 / other 4xx never reaches here (_is_transient_error
-                # excludes them — those are config bugs, not worth retrying).
+                # reset/aborted). Forensic: several iterations were lost
+                # when an agent crashed mid-run on a transient error with
+                # no retry. Retry the SAME invocation, bounded
+                # (TRANSIENT_RETRY_MAX) with short exponential backoff. A
+                # 404 / other 4xx never reaches here (`_is_transient_error`
+                # excludes them — config bugs, not worth retrying), and a
+                # timeout never reaches here either (`_is_timeout_error`
+                # above catches it — the SDK already retried it).
                 response_text = None
                 _last_exc = e
                 for _attempt in range(1, TRANSIENT_RETRY_MAX + 1):


### PR DESCRIPTION
## What

Bug-fix dans le harnais multi-agent Lean prover (**`agent_tests/prover/{config,workflow}.py`**) — un endpoint LLM qui HANG brûlait jusqu'à **1200s/call (SDK seul)** ou **2300s+ (SDK × harness)** au lieu de fail-fast. Grain DEEP P1 dispatché par ai-01 (msg-...213318), See #7477 (forensic multi-part) + Epic parent #1453. Substance prover-runtime, 1 domaine, 1 sujet.

## Bug — deux multipliers wall-clock indépendants (re-verifiés firsthand sur origin/main `fb52e2954`)

**Multiplier 1 — SDK (config.py `create_client` L289-318).** `max_retries=4` universel passé à `AsyncOpenAI`. Le SDK retry une failure `max_retries` × en attendant le FULL `request_timeout_s` (240s) à chaque tentative. Pour le provider `local` (qwen3.6-35b-a3b) qui HANG au lieu de répondre en 5xx-blip → **240×5 = 1200s/call** (forensic span observé `chat qwen3.6 1206.9s`). Le docstring du `max_retries=4` (bump 2026-05-12) justifiait « ~30s ajoutés pour 5xx intermittents z.ai » — vrai pour des failures RAPIDES, faux pour un hang où chaque retry attend le timeout complet.

**Multiplier 2 — harness (workflow.py `_is_transient_error` + AgentExecutor L462-505).** `_is_transient_error` classait `read timeout`/`connect timeout`/`timed out`/`timeout` comme **transient** → la retry-loop harness ré-invoquait `agent.run` jusqu'à `TRANSIENT_RETRY_MAX=5` × supplémentaires, chaque call relançant la chaîne SDK complète. Une fois le timeout finally sur-faced par le SDK, le harness le re-retryait → **forensic span `invoke_agent SearchAgent 2299.7s`** (SDK + harness multipliant le même hang).

## Fix — root cause pour chaque multiplier, pas band-aid

**Fix 1 (config.py) — per-provider `max_retries` override.** Le provider `local` (vLLM/Ollama) n'a pas de profil « 5xx intermittent » comme les remotes (zai/openrouter/mistral) : il répond vite ou il HANG. Override `"max_retries": 1` borne un hang à **2×timeout (480s)** au lieu de 5× (1200s), et laisse le `PROVIDER_OUTAGE_BREAKER` (workflow.py) terminer le run proprement. `create_client` utilise `cfg.get("max_retries", max_retries)` : l'override provider gagne, absent = default fonction (4) — préserve la résilience 5xx des remotes.

```python
# config.py PROVIDERS["local"]
"max_retries": 1,
# config.py create_client
effective_retries = cfg.get("max_retries", max_retries)
... max_retries=effective_retries ...
```

**Fix 2 (workflow.py) — typed `_is_timeout_error` route les timeouts VERS provider_failed (skip retry-loop).** Nouveau discriminant `_is_timeout_error` (read/connect/pool timeout, timed out). Les 4 marqueurs timeout sont **retirés** de `_is_transient_error` (un timeout reaching cette couche a DÉJÀ été retry `max_retries` × par le SDK = hang soutenu, pas blip). L'AgentExecutor gagne un `elif _is_timeout_error(e):` branch AVANT le transient branch → le timeout est compté comme `provider_failure` (trace role typé `provider_timeout`), nourrissant `PROVIDER_OUTAGE_BREAKER=3` → terminaison propre verdict `provider_outage` au lieu de spinner. Les 5xx/connection-reset restent retryés (failures rapides où le retry aide).

## Anti-regression protocole 4 étapes (CLAUDE.md section D)

1. **Bug exact** : 2 multipliers ci-dessus (1200s SDK + ×5 harness sur un hang `local`).
2. **3 tactiques** : (a) per-provider max_retries + typed timeout skip **[choisie, root cause]** ; (b) deadline cumulative `timeout/(retries+1)` pour TOUS providers **[rejetée, réduit le per-attempt timeout à 48s = coupe le deep reasoning legit 30-90s]** ; (c) retirer max_retries universellement à 1 **[rejetée, casse la résilience 5xx zai/openrouter]**.
3. **Diff coherent** : config.py +23/-2 (override + docstring), workflow.py +89/-16 (nouvelle fonction `_is_timeout_error`, markers déplacés, branch typé, commentaires). **Insertions ≫ deletions sur logique métier.** Pas de sorry/stub/`return None` sur code existant.
4. **Consumers verified firsthand** : `tests/test_prover_guards.py` importe `_is_transient_error` (L2424, L2434) — ses 2 assertions (`"service failed: 503"`→True, status 404→False) **n'utilisent aucun marqueur timeout** → backward-compatible, toujours passantes sur la machine prover-runtime. Grep timeout-assertions dans tout `test_prover_guards.py` (13 hits) : aucun n'asserte `_is_transient_error(timeout)`. 8 call-sites `create_client` (provers.py:1324, agents.py ×6) ne passent pas max_retries → héritent du default/override, comportement inchangé pour les remotes.

## Validation reproductible

```
$ cd MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover
$ python -m pytest test_prover_deadline.py -q
22 passed in 0.06s
```

22 tests CPU-only self-contained (sys.modules-stub + importlib path-load via `agent_tests/conftest.py` conditionnel — no-op où `agent_framework` est installé, donc repo-safe pour la machine prover-runtime). Couvrent :
- **Fix 1 `create_client`** (5) : `local`→max_retries=1 (override), `zai`→4 (default), `mistral`+arg explicite→2, override WINS sur arg explicite (`local`+max_retries=4→1), timeout passed-through inchangé.
- **Fix 2a `_is_timeout_error`** (10) : matches ReadTimeout/ConnectTimeout/PoolTimeout/timed-out ; excludes non-timeout.
- **Fix 2b `_is_transient_error` regression guard** (5) : still 5xx→True, connection-reset→True, 404→False ; **no-longer timeouts→False** (was True avant fix — le test échouerait sur le code pré-fix).
- **Mutual exclusion** (2) : timeout = only-timeout-not-transient ; 5xx = only-transient-not-timeout.

## Conformité

- Atomique : 1 domaine (prover harness deadline/retry-bounding), 1 bug (2 multipliers d'un même symptôme), fix root-cause.
- **`See #7477`** (P1 d'un forensic multi-part, ai-01 a nommé d'autres parts) + **`See #1453`** (Epic parent). Pas de `Closes` (contribution partielle à epic au long cours).
- Anti-regression : pas de preuve/implémentation remplacée par sorry/stub ; 4-step documenté ci-dessus.
- Pas de C.2 implication : 0 notebook modifié (Python source + test only).
- Catalogue byte-identique à `main` (0 changement catalogue).
- Rebase frais off `origin/main` `fb52e2954`, worktree isolé `CoursIA-prover-deadline`.
- **Pre-flight collision check** : `gh pr list --state all --search "prover deadline OR max_retries OR timeout"` = 0 PR touchant `create_client`/`_is_transient_error` deadline logic. #5869 (transient retry ADD) et le forensic #7477 sont les traces ; personne n'a capped le multiplier.
- Aucune clé API (PROVIDERS lit `os.getenv` sans default littelal), aucun QC Cloud, aucun GPU, aucun Lean build.
