### PR TITLE
fix(prover,#7477): launcher DO NOT TARGET guard — refuse/redirect before workflow (P2b)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/run_prover_bg.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/run_prover_bg.py
@@ -15,7 +15,12 @@ Output format (parseable by harvest scripts):
     [BG] TRACE_PATH=<absolute path>
     [BG] TREE_LOCK <path>          (advisory lock taken, See #6790)
     [BG] LOCKED <reason>           (another prover holds the tree -> exit 3)
+    [BG] DO_NOT_TARGET_REDIRECT requested_line=N -> M   (--line hit a DO NOT TARGET region; auto-redirected to CURRENT TARGET)
+    [BG] DO_NOT_TARGET_REFUSED requested_line=N ...      (no safe CURRENT TARGET -> exit 4, workflow never launched)
     [BG] EXIT code=<rc>            (always printed, even on exception path)
+
+Exit codes: 0 success, 2 bad demo_id, 3 tree locked (#6790), 4 target refused
+(DO NOT TARGET, #7477 P2b), 130 died before returning (#6790).
 
 Launch WITHOUT piping through `tail`/`head`: `... | tee log | tail -30`
 makes the task exit code tail's (0) and loses python's real one (run-6
@@ -44,6 +49,9 @@ faulthandler.enable()
 
 PROVER_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(PROVER_DIR))
+# target_guard.py lives one level up (agent_tests/, alongside this launcher);
+# make it importable regardless of cwd.
+sys.path.insert(0, str(PROVER_DIR.parent))
 
 # Force LEAN_PROJECT before importing prover modules so they see it.
 DEFAULT_LEAN_PROJECT = (
@@ -51,6 +59,10 @@ DEFAULT_LEAN_PROJECT = (
 ).resolve()
 os.environ.setdefault("LEAN_PROJECT", str(DEFAULT_LEAN_PROJECT))
 
+from target_guard import (  # noqa: E402
+    DO_NOT_TARGET_EXIT,
+    resolve_target_line,
+)
 from prover.config import DEMOS  # noqa: E402
 from prover.provers import MultiAgentSorryProver  # noqa: E402
 from prover.trace import TraceLogger  # noqa: E402
@@ -78,6 +90,36 @@ async def main(args: argparse.Namespace) -> int:
     if demo is None:
         _bg(f"ERROR demo_id={args.demo_id} not in DEMOS")
         return 2
+
+    # #7477 P2b: enforce the DEMO's DO NOT TARGET markers BEFORE launching the
+    # workflow. A locus the description marks DO NOT TARGET (founder case:
+    # DEMO 62 NW L2970, already factored into p4_nw_shift_lemma #6869) is
+    # auto-redirected to the DEMO's CURRENT TARGET (its default `line`), or
+    # refused if no safe target exists. Forensic: a baseline aimed at such a
+    # locus was correctly refused 4x by the agent but still scored
+    # `no_progress` and burned to iteration_cap.
+    effective_line, target_status = resolve_target_line(
+        demo, getattr(args, "line", None)
+    )
+    if target_status == "refused":
+        _requested = getattr(args, "line", None)
+        _bg(
+            f"DO_NOT_TARGET_REFUSED requested_line="
+            f"{_requested if _requested is not None else demo.get('line')} is "
+            f"marked DO NOT TARGET in the DEMO body and no safe CURRENT TARGET "
+            f"exists; aborting before workflow."
+        )
+        return DO_NOT_TARGET_EXIT
+    if target_status == "redirected":
+        _bg(
+            f"DO_NOT_TARGET_REDIRECT requested_line="
+            f"{getattr(args, 'line', None)} -> {effective_line} "
+            f"(CURRENT TARGET; requested line marked DO NOT TARGET in DEMO body)."
+        )
+        demo = {**demo, "line": effective_line}
+    elif effective_line is not None and demo.get("line") != effective_line:
+        _bg(f"LINE_OVERRIDE {demo.get('line')} -> {effective_line} (--line)")
+        demo = {**demo, "line": effective_line}
 
     file_target = demo.get("file") or "(no file — synthetic theorem demo)"
     _bg(f"START demo_id={args.demo_id} name={demo['name']}")
@@ -172,6 +214,12 @@ async def _run_locked(
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser()
     p.add_argument("demo_id", type=int, help="Index in DEMOS dict (e.g. 9 for L325)")
+    p.add_argument("--line", type=int, default=None,
+                   help="Override the DEMO's target line. #7477 P2b: if the "
+                        "requested line falls in a region the DEMO description "
+                        "marks DO NOT TARGET, the launcher auto-redirects to the "
+                        "DEMO's CURRENT TARGET (its default line), or refuses "
+                        "(exit 4) if no safe target exists.")
     p.add_argument("--provider", default="local",
                    help="reasoning provider (local|zai|openai)")
     p.add_argument("--local-provider", default="local",

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/target_guard.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/target_guard.py
@@ -1,0 +1,118 @@
+"""Target-line guard for the prover launcher — DO NOT TARGET enforcement.
+
+#7477 P2b (forensic, child of #1453). The DEMO descriptions that guide the
+multi-agent prover sometimes mark a sorry locus as ``DO NOT TARGET`` because
+it has already been factored into a private lemma (founder case: DEMO 62
+marks the NW quadrant ``DO NOT TARGET NW`` — the residual sorry was consumed
+by ``p4_nw_shift_lemma``, #6869). A baseline run that nonetheless aimed at
+that locus was correctly refused 4x by the agent but still scored
+``no_progress`` and burned to ``iteration_cap`` — the launcher fed it a
+target the description itself forbade.
+
+This module parses the ``DO NOT TARGET`` markers out of a DEMO description
+and resolves the effective target line so the launcher can refuse (or
+auto-redirect to the DEMO's CURRENT TARGET) BEFORE launching the workflow.
+Pure stdlib (``re`` only) so it is unit-testable with no prover runtime.
+
+Scope (#7477 P2b): target resolution only. Does NOT touch retry
+classification (P1b) or heartbeat diagnostics (P5).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+# Exit code the launcher uses when a target line is refused (distinct from
+# 2 = bad demo_id, 3 = tree locked, 130 = died). Harvest scripts can tell a
+# DO_NOT_TARGET refusal from a real prover failure.
+DO_NOT_TARGET_EXIT = 4
+
+# Compass-quadrant region tokens used by the hashlife / quadrant-lemma
+# convention (DEMO 62: nw/ne/sw/se). Extend if a future DEMO names other
+# regions (e.g. mpr) as DO NOT TARGET.
+_REGION_TOKENS = r"(?:nw|ne|sw|se)"
+
+# Quadrant -> line map, e.g. "nw L2970", "ne L2973". The DEMO body lists the
+# quadrant sorry-loci with their line numbers; the DO NOT TARGET marker then
+# names the forbidden quadrant.
+_REGION_LINE_RE = re.compile(rf"\b({_REGION_TOKENS})\s+L(\d+)\b", re.IGNORECASE)
+
+# "DO NOT TARGET <region>" — names the forbidden quadrant.
+_DO_NOT_TARGET_REGION_RE = re.compile(
+    rf"do not target\s+({_REGION_TOKENS})\b", re.IGNORECASE
+)
+
+# Direct form: "DO NOT TARGET L1234" (line named right after the marker, no
+# region token). Generalises beyond the quadrant convention.
+_DO_NOT_TARGET_LINE_RE = re.compile(r"do not target\s+L(\d+)\b", re.IGNORECASE)
+
+
+def parse_do_not_target_lines(description: Optional[str]) -> set[int]:
+    """Return the line numbers the DEMO ``description`` marks DO NOT TARGET.
+
+    Handles two conventions (both present-then-resolved in DEMO 62):
+
+    1. Region form — a quadrant->line map (``nw L2970, ne L2973``) plus a
+       ``DO NOT TARGET <region>`` declaration. The forbidden region's mapped
+       line is returned.
+    2. Direct form — ``DO NOT TARGET L<digits>`` names the forbidden line
+       inline.
+
+    Returns an empty set when the description is absent or declares nothing.
+    """
+    if not description:
+        return set()
+    region_to_line: dict[str, int] = {}
+    for m in _REGION_LINE_RE.finditer(description):
+        region_to_line[m.group(1).lower()] = int(m.group(2))
+    forbidden: set[int] = set()
+    for m in _DO_NOT_TARGET_REGION_RE.finditer(description):
+        region = m.group(1).lower()
+        if region in region_to_line:
+            forbidden.add(region_to_line[region])
+    for m in _DO_NOT_TARGET_LINE_RE.finditer(description):
+        forbidden.add(int(m.group(1)))
+    return forbidden
+
+
+def resolve_target_line(
+    demo: dict, override: Optional[int] = None
+) -> tuple[Optional[int], str]:
+    """Resolve the effective target line, enforcing DO NOT TARGET.
+
+    Parameters
+    ----------
+    demo : dict
+        A DEMO entry (needs ``line`` and ``description`` keys).
+    override : int, optional
+        A ``--line`` CLI override. ``None`` means use the DEMO default.
+
+    Returns
+    -------
+    (line, status) where status is one of:
+      - ``"ok"``         — the requested line is allowed (or no DO NOT TARGET
+                           declaration exists); ``line`` is what to aim at.
+      - ``"redirected"`` — the requested line is forbidden; auto-redirected
+                           to the DEMO's CURRENT TARGET (its default ``line``).
+      - ``"refused"``    — the requested line is forbidden AND no safe
+                           CURRENT TARGET exists (the default is itself
+                           forbidden, absent, or identical); ``line`` is None
+                           and the launcher should exit ``DO_NOT_TARGET_EXIT``.
+    """
+    forbidden = parse_do_not_target_lines(demo.get("description"))
+    default = demo.get("line")
+    requested = override if override is not None else default
+    if requested is None:
+        return None, "ok"
+    if not forbidden or requested not in forbidden:
+        return requested, "ok"
+    # Requested line is forbidden — try to fall back to the DEMO's CURRENT
+    # TARGET (its default line), provided that default is itself safe.
+    if (
+        default is not None
+        and default != requested
+        and default not in forbidden
+    ):
+        return default, "redirected"
+    return None, "refused"

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/test_target_guard.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/test_target_guard.py
@@ -1,0 +1,168 @@
+"""Unit tests for the launcher DO-NOT-TARGET guard (#7477 P2b, child of #1453).
+
+Covers the two acceptance criteria from the forensic dispatch:
+  1. The launcher rejects (or redirects+logs) a target line that falls in a
+     region the DEMO description marks ``DO NOT TARGET`` — before launching.
+  2. A target outside the region passes.
+
+Pure-stdlib module (``re`` only), loaded self-contained via importlib — no
+prover runtime / agent_framework needed.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_DIR = Path(__file__).resolve().parent
+_spec = importlib.util.spec_from_file_location("target_guard", _DIR / "target_guard.py")
+target_guard = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(target_guard)
+
+parse_do_not_target_lines = target_guard.parse_do_not_target_lines
+resolve_target_line = target_guard.resolve_target_line
+DO_NOT_TARGET_EXIT = target_guard.DO_NOT_TARGET_EXIT
+
+
+# Faithful excerpt of DEMO 62's description body (config.py), the founder
+# case: a quadrant->line map + a DO NOT TARGET NW declaration + a CURRENT
+# TARGET. L2970 (NW) is forbidden; L2973 (NE) is the current target.
+DEMO_62_DESCRIPTION = (
+    "BG-prover target: the p4_succ_membership decomposition = 5 named "
+    "sub-sorries. Post-#6869 line numbers: 4 mp quadrant cases "
+    "(nw L2970, ne L2973, sw L2975, se L2977) + 1 mpr routing case (L2982).\n"
+    "NW STATUS — DO NOT TARGET NW: steps 3-5 are FACTORED as the "
+    "sorry-free private theorem p4_nw_shift_lemma (L2846). The nw residual "
+    "sorry (L2970) = the G3 bridge consumption, handled on the po-2026 "
+    "manual track.\n"
+    "CURRENT TARGET = ne quadrant (L2973): prove the RHS membership "
+    "disjunct. When the ne case is proved, re-point to sw (L2975), se "
+    "(L2977), then mpr (L2982)."
+)
+
+
+# ══════════════════════════════════════════════════════════════════════
+# parse_do_not_target_lines
+# ══════════════════════════════════════════════════════════════════════
+
+class TestParseDoNotTargetLines:
+    def test_demo62_finds_nw_forbidden_line(self):
+        # The founder case: NW is marked DO NOT TARGET; NW maps to L2970.
+        assert parse_do_not_target_lines(DEMO_62_DESCRIPTION) == {2970}
+
+    def test_demo62_does_not_collect_current_target_or_siblings(self):
+        forbidden = parse_do_not_target_lines(DEMO_62_DESCRIPTION)
+        # NE (current target), SW, SE, MPR are NOT forbidden — only NW.
+        assert 2973 not in forbidden
+        assert 2975 not in forbidden
+        assert 2977 not in forbidden
+        assert 2982 not in forbidden
+
+    def test_demo62_does_not_collect_factored_lemma_line(self):
+        # L2846 (the factored lemma location, mentioned in the DO NOT TARGET
+        # NW block) is NOT a target locus — it must not be flagged. This is
+        # the precision guard against over-collecting from the prose block.
+        forbidden = parse_do_not_target_lines(DEMO_62_DESCRIPTION)
+        assert 2846 not in forbidden
+
+    def test_direct_form_do_not_target_l(self):
+        # A DEMO that names the forbidden line inline (no quadrant map).
+        desc = "The sorry at DO NOT TARGET L1234 was already discharged."
+        assert parse_do_not_target_lines(desc) == {1234}
+
+    def test_region_form_multiple_forbidden(self):
+        desc = (
+            "cases (nw L10, ne L20, sw L30). "
+            "DO NOT TARGET nw. DO NOT TARGET sw."
+        )
+        assert parse_do_not_target_lines(desc) == {10, 30}
+
+    def test_quadrant_map_without_do_not_target_marker_forbids_nothing(self):
+        # A quadrant->line map alone declares loci but forbids none.
+        desc = "cases (nw L10, ne L20). No restriction declared."
+        assert parse_do_not_target_lines(desc) == set()
+
+    def test_empty_or_none_description(self):
+        assert parse_do_not_target_lines("") == set()
+        assert parse_do_not_target_lines(None) == set()
+
+    def test_case_insensitive_marker(self):
+        # The direct form is matched case-insensitively (lowercase marker).
+        desc = "do not target L500."
+        assert parse_do_not_target_lines(desc) == {500}
+
+
+# ══════════════════════════════════════════════════════════════════════
+# resolve_target_line
+# ══════════════════════════════════════════════════════════════════════
+
+def _demo62():
+    """A DEMO 62-shaped dict for resolve_target_line tests."""
+    return {"line": 2973, "description": DEMO_62_DESCRIPTION}
+
+
+class TestResolveTargetLine:
+    def test_demo62_default_line_is_ok(self):
+        # The DEMO's own CURRENT TARGET (NE L2973) is allowed.
+        line, status = resolve_target_line(_demo62())
+        assert status == "ok"
+        assert line == 2973
+
+    def test_demo62_override_to_current_target_ok(self):
+        line, status = resolve_target_line(_demo62(), override=2973)
+        assert status == "ok"
+        assert line == 2973
+
+    def test_demo62_override_into_forbidden_redirects(self):
+        # Founder case: baseline aimed NW L2970 (forbidden) -> redirected to
+        # the DEMO's CURRENT TARGET (NE L2973).
+        line, status = resolve_target_line(_demo62(), override=2970)
+        assert status == "redirected"
+        assert line == 2973
+
+    def test_demo62_override_to_unrelated_line_ok(self):
+        # A line that is neither forbidden nor the default passes through.
+        line, status = resolve_target_line(_demo62(), override=4000)
+        assert status == "ok"
+        assert line == 4000
+
+    def test_no_forbidden_declaration_override_passes(self):
+        demo = {"line": 100, "description": "Nothing forbidden here."}
+        line, status = resolve_target_line(demo, override=999)
+        assert status == "ok"
+        assert line == 999
+
+    def test_refused_when_default_itself_is_forbidden(self):
+        # Config drift: the DEMO default line IS the forbidden locus (the
+        # description marks it DO NOT TARGET but the `line` field still
+        # points there). No safe CURRENT TARGET -> refuse.
+        demo = {"line": 1234, "description": "DO NOT TARGET L1234."}
+        line, status = resolve_target_line(demo)
+        assert status == "refused"
+        assert line is None
+
+    def test_refused_when_override_forbidden_and_no_safe_default(self):
+        # Both the override target AND the DEMO default are forbidden -> no
+        # safe CURRENT TARGET exists -> refuse. Two regions declared via the
+        # quadrant-map + DO-NOT-TARGET convention.
+        demo = {
+            "line": 1234,
+            "description": "cases (nw L1234, ne L999). DO NOT TARGET nw. DO NOT TARGET ne.",
+        }
+        line, status = resolve_target_line(demo, override=999)
+        assert status == "refused"
+        assert line is None
+
+    def test_no_line_at_all_is_ok_none(self):
+        # A synthetic demo with no target line (synthetic theorem): nothing
+        # to enforce, the launcher proceeds with line=None.
+        demo = {"description": "DO NOT TARGET L1."}
+        line, status = resolve_target_line(demo)
+        assert status == "ok"
+        assert line is None
+
+    def test_exit_code_sentinel_distinct(self):
+        # The refusal exit code must not collide with the launcher's other
+        # sentinels (2 bad demo, 3 locked, 130 died).
+        assert DO_NOT_TARGET_EXIT == 4
+        assert DO_NOT_TARGET_EXIT not in (0, 2, 3, 130)


### PR DESCRIPTION
## What

Bug-fix dans le launcher du harnais prover (**`agent_tests/run_prover_bg.py`** + nouveau **`agent_tests/target_guard.py`**) — le launcher visait une région de sorry que le DEMO body lui-même marque `DO NOT TARGET`, gaspillant le budget itération. **#7477 P2b** (forensic, See #7477 + Epic parent #1453). Grain DEEP dispatché par ai-01 (msg-...214930) après reconciliation de collision (mon #7486 P1 était duplicate du #7482 merged de po-2024 → closed, pivot P2b). 1 domaine, 1 sujet, **zéro overlap P1b (retry classification, terrain ai-01) / P5 (heartbeat)**.

## Bug (re-verifié firsthand sur origin/main `fdbdac5d2`)

`run_prover_bg.py <demo_id>` récupère `demo["line"]` et le passe au workflow **sans aucune vérification** contre les marqueurs `DO NOT TARGET` du DEMO body. Cas fondateur (DEMO 62 `HASHLIFE_P4_SUCC_MEMBERSHIP`, `config.py:1843`) : la description declare `DO NOT TARGET NW` (le quadrant NW L2970 est FACTORED en le théorème privé `p4_nw_shift_lemma`, PR #6869 merged 2026-07-16) + une map quadrant→ligne `(nw L2970, ne L2973, sw L2975, se L2977)` + `CURRENT TARGET = ne quadrant (L2973)`. Un baseline qui a visé L2970/NW a été **correctement refusé 4× par l'agent** (`intractable_blocked`) mais le run a scoré `no_progress` et brûlé jusqu'à `iteration_cap` — le launcher a nourri le workflow une cible que la description interdisait. Aucun `--line` override n'existait non plus (la seule façon de retarget était d'éditer `config.py`).

## Fix (root cause, pas band-aid) — target resolution + guard avant workflow

**Nouveau `target_guard.py` (pure stdlib `re`, indépendamment testable).** Deux fonctions :
- `parse_do_not_target_lines(description)` : parse le DEMO body. Gère 2 conventions : (1) **region form** — une map quadrant→ligne `nw L2970, ne L2973` + une declaration `DO NOT TARGET <region>` → la ligne du quadrant interdit ; (2) **direct form** — `DO NOT TARGET L<digits>`. Pour DEMO 62 → `{2970}` (NW), sans collecter L2846 (le lemme factorisé, mentionné dans le bloc DO-NOT-TARGET mais qui n'est pas un locus cible — **precision guard contre l'over-collection prose**).
- `resolve_target_line(demo, override)` : résout la ligne effective. Retourne `(line, status)` avec status ∈ `{"ok", "redirected", "refused"}`. Si la ligne demandée est interdite et le CURRENT TARGET (default `line`) est safe → **redirect** ; si même le default est interdit/absent → **refuse**.

**`run_prover_bg.py`** — 3 changements bornés :
1. `--line N` arg (override de la cible ; rend le guard exercable + utile pour re-target sans éditer config.py).
2. `main()` appelle `resolve_target_line` APRÈS le None-check du DEMO, AVANT le tree-lock + workflow :
   - `refused` → log `[BG] DO_NOT_TARGET_REFUSED` + `return DO_NOT_TARGET_EXIT` (=4) — workflow jamais lancé.
   - `redirected` → log `[BG] DO_NOT_TARGET_REDIRECT requested -> M (CURRENT TARGET)` + `demo = {**demo, "line": M}`.
   - `ok` + override → log `[BG] LINE_OVERRIDE` + applique.
3. Exit code 4 documenté (sentinel distinct de 2/3/130) + 2 nouveaux markers `[BG]` dans la docstring output-format.

## Anti-regression protocole 4 étapes (CLAUDE.md section D)

1. **Bug exact** : launcher visait L2970/NW (DO NOT TARGET) → 4× refus agent mais `no_progress` jusqu'à `iteration_cap`.
2. **3 tactiques** : (a) guard parser + resolver dans module separé + launcher `--line`/redirect/refuse **[choisie, root cause]** ; (b) champ structuré `do_not_target` dans le DEMO dict **[rejetée, ai-01 a specifié "parsing DEMO body" prose, et éviter de toucher prover/ terrain P1b actif de ai-01]** ; (c) refuse-only sans redirect **[rejetée, moins utile pour runs BG autonomes]**.
3. **Diff coherent** : +1 nouveau module pure-stdlib (107L), launcher +48/−0 (0 deletion), +1 nouveau test (172L). **0 deletion sur code métier.** Pas de sorry/stub/`return None` sur code existant.
4. **Consumers verified firsthand** : `tests/test_bg_tree_lock.py` importe `run_prover_bg` (L273 `importlib.import_module("run_prover_bg")`) + parse_args (L277 `["run_prover_bg.py", "62", "--force-lock"]`). Mon `--line` (default None) **ne casse pas** les assertions `args.force_lock` existantes. Le module-top `from target_guard import` résout (sys.path.insert parent + target_guard.py livré dans la même PR). `test_bg_tree_lock.py` sur po-2025 : **14 passed, 3 skipped** (importorskip LLM stack) — pas de régression.

## Validation reproductible

```
$ cd MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests
$ python -m pytest test_target_guard.py -q
17 passed in 0.06s
$ python -m pytest tests/test_bg_tree_lock.py -q
14 passed, 3 skipped in 0.37s
```

17 tests CPU-only self-contained (importlib path-load ; target_guard = pure stdlib, **0 stub needed**). Couvrent :
- **`parse_do_not_target_lines`** (8) : DEMO 62 excerpt → `{2970}` (founder case), ne collecte PAS L2846 (lemme factorisé, precision guard), ne collecte PAS NE/SW/SE/MPR (siblings), direct form `DO NOT TARGET L1234`, region form multiple, map-seule n'interdit rien, empty/None, case-insensitive.
- **`resolve_target_line`** (8) : DEMO 62 default ok (2973), override→current-target ok, **override into forbidden → redirected (founder case 2970→2973)**, override unrelated ok, no-forbidden passes, **refused quand default lui-même interdit** (config drift), refused quand override+default interdits, no-line → ok(None), exit sentinel distinct (4 ∉ {0,2,3,130}).

## Conformité

- Atomique : 1 domaine (prover launcher target-consistency), 1 bug, fix root-cause.
- **`See #7477 (partial: P2b)`** + **`See #1453`** (Epic parent). Pas de `Closes` (P2b est 1 part d'un forensic multi-part P1a/P1b/P2a/P2b/P5 ; ai-01 garde P1b, P2a correctly_refused non assigné).
- Anti-regression : 0 preuve/implémentation remplacée par sorry/stub ; 4-step documenté.
- **Zero overlap P1b (retry classification, ai-01 terrain) / P5 (heartbeat)** — scope strict target-resolution.
- Pas de C.2 implication : 0 notebook modifié (Python source + test only).
- Catalogue byte-identique à `main` (0 changement catalogue).
- Rebase frais off `origin/main` `fdbdac5d2` (inclut po-2024 P1a #7482 merged), worktree isolé `CoursIA-prover-p2b`.
- **Pre-flight collision check** : `target_guard` absent du repo (0 collision de nom). `gh pr list --state all --search "DO NOT TARGET OR target_guard OR launcher"` = 0 PR touchant le launcher target-resolution. P2b non-SOTA-mooted (#7477 body).
- Aucune clé API, aucun QC Cloud, aucun GPU, aucun Lean build, aucun LLM call (guard pur parsing, testé offline).
