### PR TITLE
fix(gametheory): guard kuhn_poker_cfr.train(iterations<=0) — ZeroDivisionError + silent -0.0

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/examples/kuhn_poker_cfr.py
+++ b/MyIA.AI.Notebooks/GameTheory/examples/kuhn_poker_cfr.py
@@ -144,6 +144,10 @@ class KuhnPoker:
 
     def train(self, iterations: int = 10000) -> float:
         """Train the CFR algorithm."""
+        if iterations <= 0:
+            raise ValueError(
+                f"iterations must be positive, got {iterations}"
+            )
         util = 0
         cards_list = [(i, j) for i in range(3) for j in range(3) if i != j]
 

--- a/MyIA.AI.Notebooks/GameTheory/tests/test_kuhn_poker_cfr.py
+++ b/MyIA.AI.Notebooks/GameTheory/tests/test_kuhn_poker_cfr.py
@@ -319,5 +319,43 @@ class TestConstants:
         assert FOLD != CALL
 
 
+# ----------------------------------------------------------------------------
+# Garde iterations <= 0 (regression : ZeroDivisionError + NaN silencieux).
+# ----------------------------------------------------------------------------
+
+class TestTrainIterationsGuard:
+    """iterations <= 0 doit echouer explicitement (ValueError), pas crasher
+    (``util / 0`` -> ZeroDivisionError "division by zero") ni retourner un
+    resultat silencieusement faux (``0 / -5`` -> ``-0.0``).
+
+    La garde unifie le contrat : ``get_strategy`` (L51) et
+    ``get_average_strategy`` (L162) defensent deja le cas degenerescent
+    (somme des regrets nulle -> uniforme), mais ``train`` divisait sans
+    verifier qu'au moins une iteration avait tourne. Meme classe de bug que
+    ``shapley_value_monte_carlo(n_samples<=0)`` (#7481) et
+    ``catalog_coverage`` missing-serie (#7473) : un input degenerescent admis
+    ailleurs fait crasher/NaN-er la fonction qui ne le defens pas.
+    """
+
+    def test_train_zero_iterations_raises(self, fresh_game):
+        """iterations=0 -> division par zero avant fix ; ValueError propre apres."""
+        with pytest.raises(ValueError, match="iterations must be positive"):
+            fresh_game.train(0)
+
+    def test_train_negative_iterations_raises(self, fresh_game):
+        """iterations<0 -> ``range(neg)`` vide + ``0 / -5`` = -0.0 silencieux avant fix."""
+        with pytest.raises(ValueError, match="iterations must be positive"):
+            fresh_game.train(-5)
+
+    def test_positive_iterations_unaffected(self, fresh_game):
+        """La garde n'impacte pas le chemin normal (reproductibilite preservee)."""
+        random.seed(123)
+        u1 = KuhnPoker().train(300)
+        random.seed(123)
+        u2 = KuhnPoker().train(300)
+        assert u1 == u2  # determinisme intact
+        assert isinstance(u1, float)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

`KuhnPoker.train` divided `util` by `iterations` without checking that at least one iteration had run. Same degenerate-input guard class as #7481 (shapley `n_samples<=0`) and #7473 (catalog_coverage missing-serie).

### Bug — 2 failure modes (firsthand-reproduced)

```python
>>> KuhnPoker().train(0)    # ZeroDivisionError: division by zero (util / 0)
>>> KuhnPoker().train(-5)   # -0.0  (range(-5) empty, 0 / -5 = silent wrong result)
```

The module **already defends** the degenerate zero-total division everywhere else:
- `get_strategy` L51: `if total > 0: ... else: uniform` (regret-matching)
- `get_average_strategy` L162: `if total > 0: ... else: uniform`

`train` was the lone function that divided without the guard — the author was careful about div-by-zero in regret-matching but forgot the train loop's final average.

## Fix

`raise ValueError("iterations must be positive")` at the top of `train`. Pure additive (+4 lines), mirrors the module's own defensive style + the `n_samples` guard in sibling `cooperative_games/shapley.py` (#7481). 0 business logic touched.

## Validation

- **G.9 non-vacuous proven**: on the unpatched module, `test_train_zero_iterations_raises` FAILS with `ZeroDivisionError` (the actual bug) and `test_train_negative_iterations_raises` FAILS with `DID NOT RAISE` (the silent `-0.0`). On patched: 3/3 pass.
- **29/29 tests pass** (26 existing + 3 new in `TestTrainIterationsGuard`), 5.54s. 0 regression on seeded-determinism / equilibrium-structure / game-value invariants.

## Anti-regression (section D)

+42/−0 (pure addition: +4 source guard, +38 tests). 0 sorry/stub, 0 business logic removed. No notebook touched (pure `.py`). Catalogue byte-identical to main.

See #7481 (shapley, same bug-class) — this is the 3rd instance of the degenerate-input-guard inconsistency pattern this session-segment.

Co-Authored-By: Claude-Code <noreply@anthropic.com>