### PR TITLE
docs(conway-lean,#1650): francize patterns/ README (Phase 0.5, preserve .en.md)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/patterns/README.en.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/patterns/README.en.md
@@ -1,0 +1,41 @@
+# Conway's Game of Life — RLE Pattern Archive
+
+Source: [copy.sh/life](https://copy.sh/life/) mirror of [LifeWiki](https://conwaylife.com/wiki/Main_Page) patterns.
+
+## Patterns
+
+| File | Pattern | Author | Size | Grid | Period |
+|------|---------|--------|------|------|--------|
+| `otcametapixel.rle` | OTCA Metapixel | Brice Due (2006) | 165 KB | 2058x2058 | 35 328 |
+| `turingmachine.rle` | Turing Machine | Paul Rendell (2000) | 104 KB | variable | N/A |
+| `p5760unitlifecell.rle` | p5760 Unit Life Cell | David Bell | 15 KB | 499x499 | 5 760 |
+| `gemini.rle` | Gemini self-replicator | Andrew Wade (2010) | 5.3 MB | huge | 33 699 586 |
+
+## Pillars.lean mapping
+
+These RLE files correspond to the witness theorems scaffolded in
+`Conway.Life.Pillars`:
+
+| Pillar theorem | RLE file | Generation count |
+|----------------|----------|-----------------|
+| `otca_metapixel_witness` | `otcametapixel.rle` | 35 328 |
+| `unitcell_witness` | `p5760unitlifecell.rle` (closest available) | 4 096 |
+| `gemini_witness` | `gemini.rle` | 33 699 586 |
+| `cpu_witness` | not yet available | 1 048 576 |
+
+## Download
+
+```bash
+# From copy.sh mirror (accessible without bot detection)
+MIRROR="https://copy.sh/life/examples"
+curl -L -A "Mozilla/5.0" "$MIRROR/otcametapixel.rle" -o otcametapixel.rle
+curl -L -A "Mozilla/5.0" "$MIRROR/gemini.rle" -o gemini.rle
+curl -L -A "Mozilla/5.0" "$MIRROR/turingmachine.rle" -o turingmachine.rle
+curl -L -A "Mozilla/5.0" "$MIRROR/p5760unitlifecell.rle" -o p5760unitlifecell.rle
+```
+
+## Note on Gemini
+
+`gemini.rle` (5.3 MB) is gitignored due to size. It can be re-downloaded
+from the copy.sh mirror using the command above. The notebook's `fetch_rle()`
+function handles this gracefully with disk caching.

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/patterns/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/patterns/README.md
@@ -1,32 +1,32 @@
-# Conway's Game of Life — RLE Pattern Archive
+# Le Jeu de la Vie de Conway — Archive de Motifs RLE
 
-Source: [copy.sh/life](https://copy.sh/life/) mirror of [LifeWiki](https://conwaylife.com/wiki/Main_Page) patterns.
+Source : miroir [copy.sh/life](https://copy.sh/life/) des motifs de [LifeWiki](https://conwaylife.com/wiki/Main_Page).
 
-## Patterns
+## Motifs
 
-| File | Pattern | Author | Size | Grid | Period |
-|------|---------|--------|------|------|--------|
+| Fichier | Motif | Auteur | Taille | Grille | Période |
+|---------|-------|--------|--------|--------|---------|
 | `otcametapixel.rle` | OTCA Metapixel | Brice Due (2006) | 165 KB | 2058x2058 | 35 328 |
-| `turingmachine.rle` | Turing Machine | Paul Rendell (2000) | 104 KB | variable | N/A |
-| `p5760unitlifecell.rle` | p5760 Unit Life Cell | David Bell | 15 KB | 499x499 | 5 760 |
-| `gemini.rle` | Gemini self-replicator | Andrew Wade (2010) | 5.3 MB | huge | 33 699 586 |
+| `turingmachine.rle` | Machine de Turing | Paul Rendell (2000) | 104 KB | variable | N/A |
+| `p5760unitlifecell.rle` | Cellule de Vie unitaire p5760 | David Bell | 15 KB | 499x499 | 5 760 |
+| `gemini.rle` | Auto-réplicateur Gemini | Andrew Wade (2010) | 5,3 MB | immense | 33 699 586 |
 
-## Pillars.lean mapping
+## Correspondance avec Pillars.lean
 
-These RLE files correspond to the witness theorems scaffolded in
-`Conway.Life.Pillars`:
+Ces fichiers RLE correspondent aux théorèmes témoins échafaudés dans
+`Conway.Life.Pillars` :
 
-| Pillar theorem | RLE file | Generation count |
-|----------------|----------|-----------------|
+| Théorème pilier | Fichier RLE | Nombre de générations |
+|-----------------|-------------|------------------------|
 | `otca_metapixel_witness` | `otcametapixel.rle` | 35 328 |
-| `unitcell_witness` | `p5760unitlifecell.rle` (closest available) | 4 096 |
+| `unitcell_witness` | `p5760unitlifecell.rle` (le plus proche disponible) | 4 096 |
 | `gemini_witness` | `gemini.rle` | 33 699 586 |
-| `cpu_witness` | not yet available | 1 048 576 |
+| `cpu_witness` | pas encore disponible | 1 048 576 |
 
-## Download
+## Téléchargement
 
 ```bash
-# From copy.sh mirror (accessible without bot detection)
+# Depuis le miroir copy.sh (accessible sans détection de bot)
 MIRROR="https://copy.sh/life/examples"
 curl -L -A "Mozilla/5.0" "$MIRROR/otcametapixel.rle" -o otcametapixel.rle
 curl -L -A "Mozilla/5.0" "$MIRROR/gemini.rle" -o gemini.rle
@@ -34,8 +34,8 @@ curl -L -A "Mozilla/5.0" "$MIRROR/turingmachine.rle" -o turingmachine.rle
 curl -L -A "Mozilla/5.0" "$MIRROR/p5760unitlifecell.rle" -o p5760unitlifecell.rle
 ```
 
-## Note on Gemini
+## Note sur Gemini
 
-`gemini.rle` (5.3 MB) is gitignored due to size. It can be re-downloaded
-from the copy.sh mirror using the command above. The notebook's `fetch_rle()`
-function handles this gracefully with disk caching.
+`gemini.rle` (5,3 Mo) est gitignoré en raison de sa taille. Il peut être
+re-téléchargé depuis le miroir copy.sh avec la commande ci-dessus. La fonction
+`fetch_rle()` du notebook gère ce cas gracieusement via un cache disque.


### PR DESCRIPTION
## What

FR-first backfill (**#1650 Phase 0.5**) : `conway_lean/patterns/README.md` était encore en anglais — un README sous-répertoire manqué lors du passage FR principal de `conway_lean/` (qui a déjà son `.en.md`). EPIC traduction multilingue #1650 Phase 0.5, mandat user 2026-06-21 (« c'est dommage de continuer à créer du contenu anglais qui aura vocation à être traduit »). Grain docs FR, CPU/text, 1 domaine, 1 sujet.

## Firsthand verification (readme-french-first HARD : vérifier EN AVANT git mv)

Scan firsthand `find *_lean -name README.md` : tous les READMEs de série substantiels (Probas 981L, Sudoku 811L, SymbolicAI 753L, Search 752L, ML 412L, IIT 404L, GenAI 384L…) sont **DÉJÀ FR-first**. `game_theory_lean/README.md` body **déjà FR** (H1 = nom du lake seulement). Le **seul** résiduel anglais genuine dans les `*_lean` = ce `conway_lean/patterns/README.md` (archive de motifs, 42L, contenu pédagogique : table motifs RLE + correspondance théorèmes témoins `Pillars.lean` + instructions téléchargement). `conway_lean/scripts/README.md` = hors scope (README de scripts/build à faible valeur, cf readme-french-first §Périmètre).

## Fix (readme-french-first HARD 2 : préserver l'original)

- `git mv README.md README.en.md` — l'original anglais est préservé **byte-identique** (golden set futur + preuve de préservation). Vérifié : `git diff origin/main:...README.md -- README.en.md` = exit 0 (0 changement).
- Nouveau `README.md` en **français**, même structure que l'original :
  - **Parité structurelle vérifiée** : 12 lignes-table / 4 H2 / 2 marques code-fence dans EN **et** FR (identique).
  - **Liens préservés verbatim** : `copy.sh/live/`, `conwaylife.com/wiki/Main_Page`, `copy.sh/life/examples` — 3 URL identiques EN ↔ FR.
  - **Marqueurs `CATALOG-STATUS`** : 0 dans l'original → rien à préserver (catalog-pr-hygiene OK).
  - **Ancres/liens internes** : 0 inbound link vers `patterns/README` (grep `conway_lean/`), et le nom de fichier `README.md` est inchangé → aucune rupture de lien.
  - Noms de fichiers `.rle` et commandes `curl` inchangés (code = pas de la prose à traduire).

## Conformité

- Atomique : 1 domaine (docs FR-first `conway_lean/patterns`), 1 fichier README + préservation `.en.md`.
- **`See #1650`** (Phase 0.5 d'un EPIC au long cours, contribution partielle). Pas de `Closes`.
- readme-french-first : separator `.` (`README.en.md`, standard i18n cohérent Phase 3 #1650), original préservé (anti-traduction-destructive, « Consolider != Archiver »).
- Pas de C.2 implication : 0 notebook modifié (markdown only).
- Catalogue byte-identique à `main` (0 changement catalogue — le fichier n'est pas un marqueur CATALOG).
- Rebase frais off `origin/main` `fdbdac5d2`, worktree isolé `CoursIA-conway-patterns-fr`.
- **Pre-flight collision check** : `gh pr list --state all --search "conway patterns OR README.en OR french-first"` = 0 PR touchant `conway_lean/patterns/README`. Les PR FR-first précédents (#3872/#3874/#3877 QC partner-course, #3876/#3879 Lean, #3881 ML-Training) sont par jsboige sur d'autres séries.
- Aucune clé API, aucun QC Cloud, aucun GPU, aucun Lean build, aucun LLM call (markdown translation only).
