### PR TITLE
chore(docs,#7422): automate HEALTH_DASHBOARD.md regen in catalog cron + refresh

### DIFF
--- a/.github/workflows/catalog-cron.yml
+++ b/.github/workflows/catalog-cron.yml
@@ -66,11 +66,15 @@ jobs:
           # --git-tracked-only keeps CI output deterministic (ignores untracked).
           python scripts/notebook_tools/generate_catalog.py --git-tracked-only
           python scripts/notebook_tools/expand_catalog_markers.py
+          # Health dashboard (#4210 acceptance #4): derive
+          # docs/reference/HEALTH_DASHBOARD.md from the freshly-regenerated
+          # catalog so it never drifts again (See #7422).
+          python scripts/notebook_tools/generate_health_dashboard.py
 
       - name: Commit + push to main if the catalog drifted
         run: |
           set -euo pipefail
-          git add COURSE_CATALOG.generated.json COURSE_CATALOG.generated.md
+          git add COURSE_CATALOG.generated.json COURSE_CATALOG.generated.md docs/reference/HEALTH_DASHBOARD.md
           # Stage only README files actually modified by marker expansion.
           mapfile -t changed_readmes < <(git ls-files -m -- '*README.md')
           if [ "${#changed_readmes[@]}" -gt 0 ]; then

--- a/docs/reference/HEALTH_DASHBOARD.md
+++ b/docs/reference/HEALTH_DASHBOARD.md
@@ -1,74 +1,73 @@
 # Tableau de santé du dépôt — snapshot dérivé du catalogue
 
-> Snapshot statique généré depuis `COURSE_CATALOG.generated.json` (date catalogue : **2026-07-03**).
+> Snapshot statique généré depuis `COURSE_CATALOG.generated.json` (date catalogue : **2026-07-19**).
 > Ce fichier **n'est pas maintenu à la main** : il est dérivé du catalogue (acceptance #4 de #4210).
 > Pour le régénérer : `python scripts/notebook_tools/generate_health_dashboard.py`.
 
-**670** notebooks référencés au catalogue.
+**824** notebooks référencés au catalogue.
 
 ## État global
 
 | Statut | Count | % |
 |--------|-------|---|
-| READY | 518 | 77.3% |
-| DEMO | 147 | 21.9% |
-| BROKEN | 5 | 0.7% |
+| READY | 668 | 81.1% |
+| DEMO | 154 | 18.7% |
+| BROKEN | 2 | 0.2% |
 
 ## Exigences d'environnement (badges)
 
 | Exigence | Notebooks concernés |
 |----------|---------------------|
-| **local** (exécutable sans GPU/cloud/WSL) | 369 |
+| **local** (exécutable sans GPU/cloud/WSL) | 512 |
 | WSL requis | 42 |
-| GPU requis | 83 |
+| GPU requis | 93 |
 | Cloud requis (QC / GenAI Docker) | 105 |
-| API key requise | 133 |
+| API key requise | 135 |
 
 ## Distribution par série
 
 | Série | READY | DEMO | BROKEN | Total | % READY |
 |-------|-------|------|--------|-------|---------|
 | CaseStudies | 6 | 0 | 0 | 6 | 100% |
-| GameTheory | 28 | 0 | 0 | 28 | 100% |
-| GenAI | 59 | 80 | 2 | 141 | 42% |
-| IIT | 18 | 0 | 0 | 18 | 100% |
-| ML | 33 | 3 | 1 | 37 | 89% |
-| Probas | 53 | 0 | 0 | 53 | 100% |
+| GameTheory | 50 | 0 | 0 | 50 | 100% |
+| GenAI | 57 | 82 | 2 | 141 | 40% |
+| IIT | 32 | 0 | 0 | 32 | 100% |
+| ML | 44 | 3 | 0 | 47 | 94% |
+| Probas | 58 | 0 | 0 | 58 | 100% |
 | QuantConnect | 48 | 57 | 0 | 105 | 46% |
-| RL | 16 | 0 | 0 | 16 | 100% |
-| Search | 71 | 0 | 0 | 71 | 100% |
-| Sudoku | 30 | 1 | 2 | 33 | 91% |
-| SymbolicAI | 156 | 6 | 0 | 162 | 96% |
+| RL | 16 | 1 | 0 | 17 | 94% |
+| Search | 112 | 0 | 0 | 112 | 100% |
+| Sudoku | 34 | 2 | 0 | 36 | 94% |
+| SymbolicAI | 211 | 9 | 0 | 220 | 96% |
 
 ## Kernels
 
 | Kernel | Count |
 |--------|-------|
-| Python 3 | 486 |
-| .NET (C#) | 117 |
-| Python 3 (ipykernel) | 18 |
+| Python 3 | 530 |
+| .NET (C#) | 224 |
+| Python 3 (ipykernel) | 20 |
 | Lean 4 (WSL) | 17 |
-| Python (GameTheory WSL + OpenSpiel) | 9 |
+| Python (GameTheory WSL + OpenSpiel) | 8 |
 | Python 3 (WSL) | 7 |
 | Python 3 (PyPhi/IIT) | 4 |
 | Lean 4 | 3 |
 | Python 3 (coursia-ml-training) | 2 |
 | .venv | 2 |
 | pyphi | 1 |
+| Python (coursia-ml-training) | 1 |
 | .venv (3.14.3) | 1 |
 | .venv (3.12.3) | 1 |
-| Python (CoursIA SemanticWeb) | 1 |
 | cours-ia | 1 |
+| Python 3 (SC-16 Concrete, WSL) | 1 |
+| Python (difflogic-sl12) | 1 |
 
-## BROKEN (5 — à traiter en priorité)
+## BROKEN (2 — à traiter en priorité)
 
 | Série | Notebook | Maturité | Dernière validation |
 |-------|----------|----------|---------------------|
 | GenAI | Notebook de travail | TEMPLATE | 2026-06-26 |
-| GenAI | Notebook de travail | TEMPLATE | 2026-06-26 |
-| ML | ML-5 : Time Series Forecasting avec ML.NET | DRAFT | 2026-06-24 |
-| Sudoku | Sudoku-10 : Resolution avec OR-Tools (C#) | PRODUCTION | 2026-07-02 |
-| Sudoku | Sudoku-6 : Resolution par CSP Academique (AIMA) | PRODUCTION | 2026-07-02 |
+| GenAI | Notebook de travail | TEMPLATE | 2026-07-18 |
 
 ## Voir aussi
 


### PR DESCRIPTION
## Summary

Delivers a bounded **UPDATE + maintenance-cadence** grain of #7422 (docs/ hygiene, user-mandated 2026-07-19): wire the orphaned, drifting `HEALTH_DASHBOARD.md` into the daily catalog cron so it stops going stale, and refresh the committed snapshot to current.

`docs/reference/HEALTH_DASHBOARD.md` (#4210 acceptance #4) is a **generated** snapshot derived from `COURSE_CATALOG.generated.json`. Unlike the catalog itself, it had **no automation** keeping it fresh, so it had drifted to **670 notebooks / 2026-07-03** while the catalog is at **824 / 2026-07-19**. This is exactly the "référence pérenne désynchronisée" UPDATE category of #7422, plus the maintenance-cadence concern raised in the issue body (« le point "je peine à le maintenir à jour" »).

## Files

- **`.github/workflows/catalog-cron.yml`** — add `generate_health_dashboard.py` to the daily regen run (it reads the just-regenerated catalog, so the dashboard stays in lockstep) and stage `docs/reference/HEALTH_DASHBOARD.md` in the cron's commit step. +5 logical lines.
- **`docs/reference/HEALTH_DASHBOARD.md`** — refresh the committed snapshot to current (generated by the documented script, not hand-edited).

## Firsthand verification (G.1)

Ran the generator locally off `origin/main`:
```
$ python scripts/notebook_tools/generate_health_dashboard.py
=== wrote docs/reference/HEALTH_DASHBOARD.md (2416 bytes, 77 lines) ===
total notebooks: 824 | READY 668 DEMO 154 BROKEN 2
```
Diff headline (stale → current):
- date catalogue: 2026-07-03 → **2026-07-19**
- total: 670 → **824**
- READY: 518 (77.3%) → **668 (81.1%)**
- DEMO: 147 → **154**
- BROKEN: 5 → **2**

Generator is stdlib-only (`json`, `pathlib`, `collections`, `datetime`) — runs clean in the cron's Python 3.11 on `ubuntu-latest`.

## Scope notes (honest)

- **What this does NOT do**: the broader `docs/` triage (#7422 step 1 — inventory every file ARCHIVE/UPDATE/KEEP). I firsthand-spot-checked the obvious archive candidates in `docs/lean/` and all are **heavily-referenced perennial infrastructure** (`stable_marriage_intractable_diagnosis.md` ← prover baselines `intractable_targets.json` + test `test_prover_guards.py`; `prover_iteration_history.md` ← `.claude/agents/prover-forensic.md` + `.claude/rules/lean-merge-discipline.md`; `po2026-local-build-troubleshooting.md` ← `scripts/lean/po2026_recover_build.py`). The `docs/archive/` tree is already disciplined (INDEX.md, dated naming). So #7422's premise is **largely already addressed**; the residual actionable grain was this drifting generated snapshot + the maintenance cadence, which this PR fixes structurally.
- **Catalogue byte-identical to `origin/main`** (catalog-pr-hygiene HARD 1): this PR does **not** touch `COURSE_CATALOG.generated.{json,md}` nor any `CATALOG-STATUS` marker. `HEALTH_DASHBOARD.md` is a separate downstream artifact owned by no automation until this PR wires it in.
- **No CRLF regression**: `catalog-cron.yml` is LF on main, edit preserved LF (diff = 5 logical lines, no whole-file churn); `HEALTH_DASHBOARD.md` is CRLF on main, regenerated file matches (diff = pure content).

## Anti-regression

Pure addition to the cron workflow (+1 script invocation, +1 `git add` arg) + a generated-content refresh. No logic deleted, no proof/code touched, no sorry.

See #7422 (partial — UPDATE + cadence grain; broader triage remains open). Part of #4208 Wave 1.

Co-Authored-By: Claude <noreply@anthropic.com>
