### PR TITLE
fix(gametheory): guard replicator_dynamics degenerate input (crash/NaN)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/game_theory_utils.py
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_utils.py
@@ -548,7 +548,17 @@ def replicator_dynamics(M: np.ndarray, x0: np.ndarray,
         x = x + dx
 
         x = np.maximum(x, 0)
-        x = x / np.sum(x)
+        # Guard against sum == 0 (degenerate x0 = np.zeros(n), or all
+        # components zeroed by the clamp mid-trajectory): a bare
+        # `x / np.sum(x)` divides by 0.0 and propagates NaN through the
+        # rest of the trajectory. Mirror the CFRSolver.get_strategy /
+        # get_average_strategy siblings in this module (uniform fallback when
+        # the normalizing sum is non-positive) and the cross-module
+        # corroborator ict.strategic_morphodynamics.replicator_trajectory
+        # (1e-12 threshold): renormalize when the sum is positive, else reset
+        # to a uniform distribution.
+        s = np.sum(x)
+        x = x / s if s > 1e-12 else np.ones(n) / n
 
     return trajectory
 

--- a/MyIA.AI.Notebooks/GameTheory/tests/test_strategies.py
+++ b/MyIA.AI.Notebooks/GameTheory/tests/test_strategies.py
@@ -239,6 +239,42 @@ class TestReplicatorDynamics:
         for t in range(100):
             assert abs(np.sum(trajectory[t]) - 1.0) < 1e-6
 
+    def test_replicator_degenerate_zero_x0_no_nan(self):
+        """A degenerate x0 = zeros(n) must not propagate NaN through the
+        trajectory. Before the normalization guard, x / np.sum(x) divided by
+        0.0 and NaN-ed every row from t=1 onward (RuntimeWarning: invalid
+        value encountered in divide). The guard falls back to a uniform
+        distribution, so the dynamics resume from a valid simplex point."""
+        M = np.array([[3.0, 0.0], [5.0, 1.0]])
+        trajectory = replicator_dynamics(M, np.zeros(2), T=50, dt=0.1)
+
+        assert not np.isnan(trajectory).any()
+        # Row 0 records the given (degenerate) initial state; every subsequent
+        # row must be a valid population distribution (non-negative, sums to 1).
+        for t in range(1, 50):
+            assert abs(np.sum(trajectory[t]) - 1.0) < 1e-9
+            assert (trajectory[t] >= 0).all()
+
+    def test_replicator_degenerate_zero_x0_falls_back_to_uniform(self):
+        """After a degenerate x0 = zeros, the next iterate is the uniform
+        distribution (the documented sibling-fallback, mirroring
+        CFRSolver.get_strategy in the same module)."""
+        M = np.array([[3.0, 0.0], [5.0, 1.0]])
+        trajectory = replicator_dynamics(M, np.zeros(2), T=5, dt=0.1)
+
+        np.testing.assert_allclose(trajectory[1], np.array([0.5, 0.5]))
+
+    def test_replicator_negative_x0_clamped_without_nan(self):
+        """A negative x0 (out-of-simplex) gets clamped by np.maximum(x, 0);
+        the resulting all-zero row would also NaN without the guard. The fix
+        keeps the trajectory finite for every iterate after the first."""
+        M = np.array([[3.0, 0.0], [5.0, 1.0]])
+        trajectory = replicator_dynamics(M, np.array([-0.2, -0.1]), T=20, dt=0.1)
+
+        assert not np.isnan(trajectory).any()
+        for t in range(1, 20):
+            assert abs(np.sum(trajectory[t]) - 1.0) < 1e-9
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## What

Bug-fix in `GameTheory/game_theory_utils.py:replicator_dynamics` — the normalization step `x / np.sum(x)` was unguarded, so a degenerate `x0` (or a trajectory that the clamp zeroes mid-run) divided by `0.0` and propagated `NaN` through every subsequent row. **Same degenerate-input guard bug-class as #7481 (shapley `n_samples<=0`) and #7489 (kuhn_poker `iterations<=0`)** — both MERGED. See #7481 (bug-class contribution; no tracking issue for this specific locus).

## Bug (reproduced firsthand)

`replicator_dynamics(M, x0, T, dt)` simulates `dx_i/dt = x_i*(fitness_i - avg_fitness)`, renormalizing each iterate. At L551 a bare `x = x / np.sum(x)`:

```python
>>> import numpy as np
>>> from game_theory_utils import replicator_dynamics
>>> M = np.array([[3.0, 0.0], [5.0, 1.0]])
>>> traj = replicator_dynamics(M, np.zeros(2), T=5, dt=0.1)
RuntimeWarning: invalid value encountered in divide
>>> traj
array([[0. , 0. ],                     # row 0 = raw degenerate input
       [nan, nan],                      # NaN from t=1 onward
       [nan, nan],
       [nan, nan],
       [nan, nan]])
```

Two degenerate inputs trigger it:
- **`x0 = np.zeros(n)`** (caller passes an all-zero start) → first iterate `x = zeros + 0*dx = zeros`, `np.sum(x) = 0.0`, divide-by-zero.
- **Out-of-simplex `x0` with negative components** → clamped to zeros by `np.maximum(x, 0)` mid-trajectory → same divide-by-zero.

## Fix (root cause, sibling-guarded — not a one-off band-aid)

```python
x = np.maximum(x, 0)
s = np.sum(x)
x = x / s if s > 1e-12 else np.ones(n) / n
```

This mirrors the **two existing guards for the exact same degenerate zero-total division** already in the codebase:

1. **`CFRSolver.get_strategy` / `get_average_strategy`** in this same module (`game_theory_utils.py`) — uniform fallback when the normalizing sum is non-positive:
   ```python
   if normalizing_sum > 0: return regrets / normalizing_sum
   else: return np.ones(num_actions) / num_actions
   ```
2. **Cross-module corroborator** `ict.strategic_morphodynamics.replicator_trajectory` (the ICT port of the same dynamics) — `1e-12` threshold then uniform fallback.

So the fix closes a guard-consistency gap: every sibling already defended this division, `replicator_dynamics` was the lone unguarded instance. The fallback (uniform distribution) is the documented recovery in both siblings — it lets the dynamics resume from a valid simplex point instead of NaN-ing forever.

## Anti-regression protocol (CLAUDE.md section D)

1. **Exact failure**: `RuntimeWarning: invalid value encountered in divide` + `trajectory[1:]` all `NaN` for `x0 = np.zeros(n)` (reproduced firsthand above).
2. **3 tactics**: (a) sibling-guard `s > 1e-12 ? x/s : uniform` **[chosen, root cause — matches CFRSolver + ict corroborator]**; (b) `np.divide(x, s, out=np.ones(n)/n, where=s>1e-12)` **[rejected — less readable, same semantics]**; (c) validate `x0` at entry and raise **[rejected — hostile to callers; the clamp already mutates x mid-trajectory, so an entry check alone wouldn't cover the mid-run zeroing]**.
3. **Coherent diff**: `game_theory_utils.py` +12/-1 (guard + comment, 0 deletion on existing logic), `tests/test_strategies.py` +36 (3 new regression tests). **0 deletion on production code.** No `sorry`/stub/`return None` on existing logic.
4. **Consumers verified**: `grep -rn "replicator_dynamics" MyIA.AI.Notebooks/GameTheory/` → only `game_theory_utils.py` (def) + `tests/test_strategies.py` (tests). The `ict.strategic_morphodynamics.replicator_trajectory` corroborator is a separate implementation (own guard). No caller depends on the old NaN behavior.

## Validation (reproducible, CPU-only)

```
$ cd MyIA.AI.Notebooks/GameTheory
$ python -m pytest tests/test_strategies.py -q
24 passed in 0.55s
```

21 baseline tests (unchanged, 0 regression) + **3 new regression tests** in `TestReplicatorDynamics`:
- `test_replicator_degenerate_zero_x0_no_nan` — `x0=np.zeros(2)` → `assert not np.isnan(traj).any()` + rows `t>=1` valid (non-negative, sum to 1).
- `test_replicator_degenerate_zero_x0_falls_back_to_uniform` — `traj[1] ≈ [0.5, 0.5]` (the documented sibling-fallback).
- `test_replicator_negative_x0_clamped_without_nan` — `x0=[-0.2,-0.1]` (out-of-simplex) → clamp zeroes it → still no NaN, rows `t>=1` normalized.

Note: `trajectory[0]` records the raw `x0` as-given (stored at the top of the loop before normalization). For a degenerate `x0=zeros`, row 0 legitimately sums to 0 — the guard prevents *forward* NaN, it does not retroactively rewrite the caller's input. The regression tests assert on rows `t>=1`.

## Conformity

- Atomic: 1 domain (GameTheory util numerical-robustness), 1 bug, root-cause fix.
- **`See #7481`** (same degenerate-input guard bug-class, partial contribution). Not `Closes` — no tracking issue for `replicator_dynamics` specifically, and the bug-class vein (#7481/#7489) is already MERGED.
- Anti-regression: 0 production code/proof replaced by sorry/stub; 4-step documented; sibling-guard evidence cited.
- No C.2 implication: 0 notebook modified (Python source + test only).
- Catalogue byte-identical to `main` (0 catalogue change — not a CATALOG marker).
- Fresh rebase off `origin/main` `fdbdac5d2`, isolated worktree `CoursIA-replicator-guard`.
- Pre-flight collision check: `gh pr list --search "replicator"` = 0 OPEN PR touching `replicator_dynamics` (all hits MERGED: #3716 notebook-output alignment, #5417 Axelrod replug, #4925 ICT morphodynamics — none touch the util guard).
- No API key, no QC Cloud, no GPU, no Lean build, no LLM call (numpy-only CPU, tested offline).
