### PR TITLE
test(prover,#7477): cover _is_transient_error structured-status + network branches

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
@@ -2453,6 +2453,125 @@ def test_transient_backoff_is_exponential_capped():
     assert _transient_backoff_s(20) == TRANSIENT_RETRY_BACKOFF_CAP_S
 
 
+# ──────────────────────────────────────────────────────────────────────────
+# _is_transient_error structured-status + bare-network branches (#7477 audit)
+#
+# The existing tests above cover the wrapped-message markers (the #5869
+# `service failed` gap) and the 4xx-on-wrapped-error guard. The classifier's
+# FIRST branch -- a structured integer `status_code` attribute on the
+# exception or a nested `.response` (the httpx/openai shape) -- had no direct
+# coverage, nor did the bare network-exception fall-through (ConnectionError /
+# ConnectionResetError with no status code). These pin that branch so a future
+# reorder of the checks cannot silently regress retry-vs-skip behavior.
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_structured_5xx_status_is_transient():
+    """An exception exposing an integer status_code in the 5xx range is
+    transient via the first branch (no string inspection needed)."""
+    from prover.workflow import _is_transient_error
+
+    class _HTTP5xx(Exception):
+        status_code = 503
+
+    assert _is_transient_error(_HTTP5xx("anything")) is True
+
+
+@pytest.mark.parametrize("status", [500, 502, 503, 504])
+def test_structured_5xx_status_each_code(status):
+    """Every 5xx code in the transient set classifies as transient."""
+    from prover.workflow import _is_transient_error
+
+    class _Err(Exception):
+        pass
+
+    _Err.status_code = status
+    assert _is_transient_error(_Err("x")) is True
+
+
+@pytest.mark.parametrize("status", [400, 401, 403, 404, 422])
+def test_structured_4xx_status_is_not_transient(status):
+    """Any 4xx status code is NOT transient (config/client bug, retrying is
+    waste) -- this is the structured mirror of the 4xx string guard."""
+    from prover.workflow import _is_transient_error
+
+    class _Err(Exception):
+        pass
+
+    _Err.status_code = status
+    assert _is_transient_error(_Err("x")) is False
+
+
+def test_nested_response_status_code_is_inspected():
+    """httpx-style errors carry the status on a nested `.response` attribute;
+    the classifier probes both the exception and `.response`."""
+    from prover.workflow import _is_transient_error
+
+    class _Resp:
+        status_code = 502
+
+    class _HTTPErr(Exception):
+        response = _Resp()
+
+    assert _is_transient_error(_HTTPErr("bad gateway")) is True
+
+
+def test_bare_connection_error_is_transient():
+    """A ConnectionError with no status code falls through to message
+    inspection; 'connection refused' is a transient marker."""
+    from prover.workflow import _is_transient_error
+
+    assert _is_transient_error(ConnectionError("connection refused")) is True
+
+
+def test_bare_connection_reset_error_is_transient():
+    """ConnectionResetError surfaces as 'connection reset' -- transient."""
+    from prover.workflow import _is_transient_error
+
+    assert _is_transient_error(ConnectionResetError("connection reset by peer")) is True
+
+
+def test_read_timeout_message_is_transient():
+    """A generic read-timeout message (no status) is transient via the
+    'read timeout' / 'timed out' marker."""
+    from prover.workflow import _is_transient_error
+
+    assert _is_transient_error(TimeoutError("read timeout")) is True
+
+
+def test_4xx_substring_guard_beats_timeout_marker():
+    """Priority: if a message contains BOTH a 4xx pattern and a transient
+    marker, the 4xx guard wins (NOT retried). Regression guard for the check
+    order in _is_transient_error (4xx guard runs before transient_markers)."""
+    from prover.workflow import _is_transient_error
+
+    # 'timed out' is a transient marker, but ' 404 ' / 'not found' wins.
+    assert _is_transient_error(
+        RuntimeError("request timed out: 404 not found")) is False
+    assert _is_transient_error(
+        RuntimeError("request timed out 404 ")) is False
+
+
+def test_4xx_parenthesised_is_a_known_gap_not_caught():
+    """Known gap (documented, not a bug): the 4xx guard matches the patterns
+    ' 404', '404 ', 'not found'... but NOT a bare parenthesised '(404)' with no
+    surrounding space. A timeout message that wraps '(404)' therefore classifies
+    as transient (retried). This pins the current behaviour so a future widening
+    of the guard to catch '(404)' is a deliberate, visible change."""
+    from prover.workflow import _is_transient_error
+
+    assert _is_transient_error(
+        RuntimeError("request to /v1/x timed out (404)")) is True
+
+
+def test_plain_value_error_is_not_transient():
+    """A ValueError with no network/status signal is NOT transient (avoids
+    retrying a programming bug)."""
+    from prover.workflow import _is_transient_error
+
+    assert _is_transient_error(ValueError("invalid argument")) is False
+
+
 def test_provider_failure_refunds_iteration_and_counts(no_sleep):
     """A single failed provider hop refunds the iteration it incremented and
     bumps the failure counters — the budget is NOT burned by a transport error."""


### PR DESCRIPTION
## Summary

Adds **16 unit tests** pinning the structured-status and bare-network branches of `_is_transient_error` (the prover's single retry-vs-skip classifier), closing a coverage gap surfaced by the #7477 P6 source-read audit.

`_is_transient_error` (workflow.py) decides whether every provider/network error is retried (transient) or skipped (4xx config bug). Existing tests (test_prover_guards.py ~L2421) cover the wrapped `"service failed"` marker gap (#5869) and the 4xx-on-wrapped-error guard. **The classifier's first branch — a structured integer `status_code` on the exception or a nested `.response` (httpx/openai shape) — had no direct coverage**, nor the bare network-exception fall-through, nor the 4xx-guard priority over a co-occurring transient marker.

## New tests

- **Structured 5xx → transient** (parametrized 500/502/503/504) via integer `status_code` attr
- **Structured 4xx → NOT transient** (parametrized 400/401/403/404/422) — structured mirror of the 4xx string guard
- **Nested `.response.status_code`** inspected (httpx-style errors)
- **Bare `ConnectionError` / `ConnectionResetError`** → transient via message markers (no status code)
- **Bare read-timeout message** → transient
- **4xx-substring guard beats co-occurring transient marker** — priority check (order of the two checks in the classifier)
- **Plain `ValueError`** → NOT transient (no network signal — don't retry a programming bug)
- **Known gap documented**: parenthesised `(404)` is NOT caught by the 4xx guard (matches `" 404"`/`"404 "`/`"not found"` but not `"(404)"`). Pinned as current behaviour so a future widening is a deliberate, visible change.

## Firsthand verification (G.1)

```
$ python -m pytest tests/test_prover_guards.py -q
============================= 191 passed in 1.30s =============================
```
175 existing + 16 new, **0 regressions**.

Self-catch (G.9): my first draft of the priority test asserted `"(404)"` would be caught — it isn't (no surrounding space). I split it into (a) the real priority test with a matching 4xx pattern (`"404 not found"` + `"timed out"` → NOT transient) and (b) an explicit known-gap test pinning the `"(404)"` non-match. No production-code change claimed from a failing test.

## Env (rule F — repair, don't bypass)

Ran in `mcp-jupyter-py310`; installed the two missing prover deps surfaced at collection time — `agent-framework-openai` (1.10.1) and `opentelemetry-sdk` — rather than skipping the suite. These are the documented prover `requirements.txt` deps.

## Note on scope

This PR is test-only (+119, 0 deletions, no production code touched). The #7477 P6 routing verdict itself ("the per-agent provider map is sane and by-design #1289, not a bug") is posted as a **comment on the issue** (comment-5017724956), not in this PR — P6 needs no code fix.

See #7477 (P6 audit side-effect). See #1453.

Co-Authored-By: Claude <noreply@anthropic.com>
