### PR TITLE
test(c2-compliance): cover catalog branch + guard missing-path KeyError

### DIFF
--- a/scripts/notebook_tools/check_c2_compliance.py
+++ b/scripts/notebook_tools/check_c2_compliance.py
@@ -141,10 +141,18 @@ def get_target_notebooks(args) -> list[Path]:
     if args.exclude_broken:
         entries = [e for e in entries if e.get("status") != "BROKEN"]
 
+    # ``e.get("path")`` guards a malformed/partial catalog entry that omits
+    # the ``path`` key (schema drift, manual edit): the sibling filters above
+    # already use ``.get()`` defensively, but the raw ``e["path"]`` access
+    # below would raise KeyError and abort the whole scan. Skip such entries
+    # instead of crashing — same missing-key unification as catalog_coverage
+    # (#7473). ``path`` is the primary key of the generated catalog, so this
+    # is unreachable via ``generate_catalog.py`` today, but defensive parity
+    # with the filters is the right contract for a partial/manual catalog.
     return [
         NOTEBOOKS_DIR / e["path"]
         for e in entries
-        if (NOTEBOOKS_DIR / e["path"]).exists()
+        if e.get("path") and (NOTEBOOKS_DIR / e["path"]).exists()
     ]
 
 

--- a/scripts/notebook_tools/tests/test_check_c2_compliance.py
+++ b/scripts/notebook_tools/tests/test_check_c2_compliance.py
@@ -419,6 +419,156 @@ class TestGetTargetNotebooks:
 
 
 # ---------------------------------------------------------------------------
+# get_target_notebooks — catalog branch (serie/maturity/exclude_broken filters
+# + existence check). This is the PRODUCTION path (no --no-catalog) and was
+# previously 0% covered: every test above set no_catalog=True.
+# ---------------------------------------------------------------------------
+
+class TestGetTargetNotebooksCatalog:
+    """Tests for the catalog-driven branch of get_target_notebooks.
+
+    Exercises the serie/maturity/exclude_broken filters, the on-disk
+    existence check, and the missing-``path`` guard. All tests mock
+    CATALOG_PATH to a synthetic catalog under tmp_path.
+    """
+
+    def _make_args(self, **kwargs):
+        import argparse
+        defaults = {
+            "path": None, "serie": None, "maturity": None,
+            "exclude_broken": False, "no_catalog": False,
+            "fix": False, "json": False,
+        }
+        defaults.update(kwargs)
+        return argparse.Namespace(**defaults)
+
+    def _write_catalog(self, catalog_path: Path, entries: list[dict]) -> None:
+        catalog_path.parent.mkdir(parents=True, exist_ok=True)
+        catalog_path.write_text(json.dumps(entries), encoding="utf-8")
+
+    def test_catalog_no_filters_returns_existing(self, tmp_path):
+        """All catalog entries that exist on disk are returned (no filters)."""
+        cat = tmp_path / "cat.json"
+        (tmp_path / "notebooks" / "GenAI").mkdir(parents=True)
+        (tmp_path / "notebooks" / "GenAI" / "a.ipynb").write_text("{}", encoding="utf-8")
+        self._write_catalog(cat, [{"path": "GenAI/a.ipynb"}])
+        with patch("check_c2_compliance.NOTEBOOKS_DIR", tmp_path / "notebooks"), \
+             patch("check_c2_compliance.CATALOG_PATH", cat):
+            result = get_target_notebooks(self._make_args())
+        assert len(result) == 1
+        assert result[0].name == "a.ipynb"
+
+    def test_catalog_missing_on_disk_filtered_out(self, tmp_path):
+        """Catalog entry whose file does not exist on disk is skipped."""
+        cat = tmp_path / "cat.json"
+        (tmp_path / "notebooks").mkdir(parents=True)
+        (tmp_path / "notebooks" / "a.ipynb").write_text("{}", encoding="utf-8")
+        # b.ipynb is in the catalog but absent on disk.
+        self._write_catalog(cat, [
+            {"path": "a.ipynb"},
+            {"path": "b.ipynb"},
+        ])
+        with patch("check_c2_compliance.NOTEBOOKS_DIR", tmp_path / "notebooks"), \
+             patch("check_c2_compliance.CATALOG_PATH", cat):
+            result = get_target_notebooks(self._make_args())
+        names = [p.name for p in result]
+        assert names == ["a.ipynb"]
+
+    def test_serie_filter(self, tmp_path):
+        """--serie keeps only entries matching that serie."""
+        cat = tmp_path / "cat.json"
+        (tmp_path / "notebooks").mkdir(parents=True)
+        (tmp_path / "notebooks" / "a.ipynb").write_text("{}", encoding="utf-8")
+        (tmp_path / "notebooks" / "b.ipynb").write_text("{}", encoding="utf-8")
+        self._write_catalog(cat, [
+            {"path": "a.ipynb", "serie": "GenAI"},
+            {"path": "b.ipynb", "serie": "Search"},
+        ])
+        with patch("check_c2_compliance.NOTEBOOKS_DIR", tmp_path / "notebooks"), \
+             patch("check_c2_compliance.CATALOG_PATH", cat):
+            result = get_target_notebooks(self._make_args(serie="GenAI"))
+        assert [p.name for p in result] == ["a.ipynb"]
+
+    def test_maturity_filter(self, tmp_path):
+        """--maturity keeps only entries matching that maturity."""
+        cat = tmp_path / "cat.json"
+        (tmp_path / "notebooks").mkdir(parents=True)
+        (tmp_path / "notebooks" / "a.ipynb").write_text("{}", encoding="utf-8")
+        (tmp_path / "notebooks" / "b.ipynb").write_text("{}", encoding="utf-8")
+        self._write_catalog(cat, [
+            {"path": "a.ipynb", "maturity": "PRODUCTION"},
+            {"path": "b.ipynb", "maturity": "DRAFT"},
+        ])
+        with patch("check_c2_compliance.NOTEBOOKS_DIR", tmp_path / "notebooks"), \
+             patch("check_c2_compliance.CATALOG_PATH", cat):
+            result = get_target_notebooks(self._make_args(maturity="PRODUCTION"))
+        assert [p.name for p in result] == ["a.ipynb"]
+
+    def test_exclude_broken_filter(self, tmp_path):
+        """--exclude-broken drops entries with status=BROKEN."""
+        cat = tmp_path / "cat.json"
+        (tmp_path / "notebooks").mkdir(parents=True)
+        (tmp_path / "notebooks" / "a.ipynb").write_text("{}", encoding="utf-8")
+        (tmp_path / "notebooks" / "b.ipynb").write_text("{}", encoding="utf-8")
+        self._write_catalog(cat, [
+            {"path": "a.ipynb", "status": "READY"},
+            {"path": "b.ipynb", "status": "BROKEN"},
+        ])
+        with patch("check_c2_compliance.NOTEBOOKS_DIR", tmp_path / "notebooks"), \
+             patch("check_c2_compliance.CATALOG_PATH", cat):
+            result = get_target_notebooks(self._make_args(exclude_broken=True))
+        assert [p.name for p in result] == ["a.ipynb"]
+
+    def test_combined_filters(self, tmp_path):
+        """serie + maturity + exclude_broken compose (AND semantics)."""
+        cat = tmp_path / "cat.json"
+        (tmp_path / "notebooks").mkdir(parents=True)
+        for n in ("a.ipynb", "b.ipynb", "c.ipynb", "d.ipynb"):
+            (tmp_path / "notebooks" / n).write_text("{}", encoding="utf-8")
+        self._write_catalog(cat, [
+            {"path": "a.ipynb", "serie": "GenAI", "maturity": "PRODUCTION", "status": "READY"},
+            {"path": "b.ipynb", "serie": "GenAI", "maturity": "PRODUCTION", "status": "BROKEN"},
+            {"path": "c.ipynb", "serie": "GenAI", "maturity": "DRAFT", "status": "READY"},
+            {"path": "d.ipynb", "serie": "Search", "maturity": "PRODUCTION", "status": "READY"},
+        ])
+        with patch("check_c2_compliance.NOTEBOOKS_DIR", tmp_path / "notebooks"), \
+             patch("check_c2_compliance.CATALOG_PATH", cat):
+            result = get_target_notebooks(self._make_args(
+                serie="GenAI", maturity="PRODUCTION", exclude_broken=True))
+        assert [p.name for p in result] == ["a.ipynb"]
+
+    def test_missing_path_key_does_not_crash(self, tmp_path):
+        """A malformed catalog entry without ``path`` is skipped, not crashed.
+
+        Regression guard mirroring catalog_coverage (#7473): the sibling
+        filters use ``.get()` defensively, but the raw ``e["path"]`` access
+        would raise KeyError and abort the whole scan on a partial/manual
+        catalog. The entry is skipped instead.
+        """
+        cat = tmp_path / "cat.json"
+        (tmp_path / "notebooks").mkdir(parents=True)
+        (tmp_path / "notebooks" / "a.ipynb").write_text("{}", encoding="utf-8")
+        self._write_catalog(cat, [
+            {"path": "a.ipynb"},
+            {"title": "malformed, no path key"},  # KeyError surface pre-fix
+        ])
+        with patch("check_c2_compliance.NOTEBOOKS_DIR", tmp_path / "notebooks"), \
+             patch("check_c2_compliance.CATALOG_PATH", cat):
+            # Pre-fix: KeyError: 'path'. Post-fix: malformed entry skipped.
+            result = get_target_notebooks(self._make_args())
+        assert [p.name for p in result] == ["a.ipynb"]
+
+    def test_empty_catalog(self, tmp_path):
+        """An empty catalog yields no targets."""
+        cat = tmp_path / "cat.json"
+        self._write_catalog(cat, [])
+        with patch("check_c2_compliance.NOTEBOOKS_DIR", tmp_path / "notebooks"), \
+             patch("check_c2_compliance.CATALOG_PATH", cat):
+            result = get_target_notebooks(self._make_args())
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

`get_target_notebooks` had two branches: a filesystem fallback (`--no-catalog`) and a **catalog-driven branch (the PRODUCTION path)**. The catalog branch was **0% covered** — every existing test set `no_catalog=True`. This left the serie/maturity/exclude_broken filters, the on-disk existence check, and the final `e["path"]` resolution untested.

Genre: **test-coverage** (R6 rotation off GameTheory / off bug-hunt). Same surface family as my #7473 (catalog_coverage missing-serie guard, MERGED).

## Coverage added — `TestGetTargetNotebooksCatalog` (8 tests)

- no-filter resolution of existing entries
- missing-on-disk entries filtered out by the existence check
- `--serie` / `--maturity` / `--exclude-broken` filters individually
- combined filters (AND semantics)
- empty catalog

## Guard — defensive consistency with the sibling filters

The serie/maturity/status filters (L137-142) use `.get()` defensively, but the final resolution used a raw `e["path"]` access — a malformed/partial catalog entry omitting the `path` key would raise `KeyError` and abort the whole scan. Guard with `e.get("path")` (short-circuit before the access), mirroring the catalog_coverage missing-key unification (#7473).

`path` is the primary key of the generated catalog, so this is **unreachable via `generate_catalog.py` today** (820/820 entries have path, verified). But defensive parity with the filters is the right contract for a partial/manual catalog — stated honestly, not inflated.

## Validation

- **G.9 non-vacuous**: `test_missing_path_key_does_not_crash` fails with `KeyError: 'path'` on the unpatched module (verified by stripping the guard) and passes on the patched module.
- **42/42 pass** (34 baseline + 8 new), 0.49s. 0 regression.

## Anti-regression (section D)

+159/−1 (test-coverage + 1 defensive guard, pure addition on the comprehension). 0 sorry/stub, 0 business logic removed. No notebook touched (pure `.py`). Catalogue byte-identical to main.

Note: pushed via fork route (`jsboigeEpita/CoursIA`) due to credential drift — worker cannot `gh auth switch` (#1502).

Co-Authored-By: Claude-Code <noreply@anthropic.com>