### PR TITLE
feat(prover,#7477): typed heartbeat_budget_exceeded verdict (P5a)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/heartbeat_budget.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/heartbeat_budget.py
@@ -1,0 +1,56 @@
+"""P5a (#7477 forensic): classify Lean heartbeat-budget exhaustion.
+
+The structural wall on DEMO 62 (Hashlife P5) is a whnf blowup that hits
+Lean's ``maxHeartbeats`` ceiling (default 200000): a tactic that is
+*correct* becomes unaffordable, and the ``lake build`` output surfaces it
+as
+
+    (deterministic) timeout, maximum heartbeats (200000)
+
+Without a typed verdict, the prover harness sinks these runs into
+``no_progress`` or a generic timeout, hiding a proof-engineering wall
+(confirmed model-independent by ai-01's A-B, c.681: glm-5.2, gpt-5.6-sol
+and kimi-k3 all hit it) under a label that reads as "the agent gave up".
+
+This module is stdlib-only and self-contained so it can be unit-tested by
+file-path load on a bare CPU runner that lacks the ``agent_framework`` LLM
+stack (same pattern as ``forensic_guards.py``). The verdict is surfaced on
+the prover's result dict as ``heartbeat_budget_exceeded`` (See #7477,
+See #1453), distinct from ``no_progress`` (the agent did attempt) and from
+a generic provider / wall-clock timeout.
+
+P5b (factor-lemma / ``set_option maxHeartbeats`` hint) is a SEPARATE grain
+and intentionally not handled here.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+__all__ = ["output_indicates_heartbeat_budget_exceeded"]
+
+# Lean surfaces maxHeartbeats exhaustion via one of two signatures in the
+# `lake build` output. Both mean the proposition/tactic is *correct but
+# unaffordable* under the heartbeat budget, not that the agent is wrong.
+#   - "(deterministic) timeout, maximum heartbeats (N)"  (Lean 4 core)
+#   - bare "maximum heartbeats" (truncated / wrapped variants)
+# Case-insensitive: capitalization varies across Lean versions / wrappers.
+_HEARTBEAT_SIGNATURES = (
+    re.compile(r"maximum heartbeats", re.IGNORECASE),
+    re.compile(r"\(deterministic\)\s+timeout", re.IGNORECASE),
+)
+
+
+def output_indicates_heartbeat_budget_exceeded(text: Optional[str]) -> bool:
+    """Return True iff ``text`` carries a Lean maxHeartbeats-exhaustion signature.
+
+    ``text`` is any build-output fragment the harness captured: the raw
+    ``lake build`` output (``final_verify["raw_output"]``), the per-attempt
+    error string (``TacticAttempt.error``, where a submitted tactic blew the
+    budget), or an error-message excerpt. ``None`` / empty -> ``False``
+    (no evidence, do not classify as a heartbeat wall).
+    """
+    if not text:
+        return False
+    return any(sig.search(text) for sig in _HEARTBEAT_SIGNATURES)

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
@@ -16,6 +16,7 @@ from agent_framework import ToolResultCompactionStrategy
 
 from .trace import TraceLogger
 from .state import ProofState, SorryContext, ProofPhase, PHASE_TRANSITIONS, TacticAttempt
+from .heartbeat_budget import output_indicates_heartbeat_budget_exceeded
 from .lean_utils import (
     extract_sorry_block, get_goal_state, verify_sorry_replacement,
     extract_hypotheses, extract_local_lemmas, build_def_type_warnings,
@@ -1024,6 +1025,27 @@ class MultiAgentSorryProver:
         _best_reported = (_raw_best if _raw_best is not None and _raw_best < 900
                           else min(original_sorry_count, final_sorry))
 
+        # P5a (#7477 forensic): heartbeat-budget exhaustion verdict. The DEMO 62
+        # Hashlife P5 wall is a whnf blowup that hits Lean's `maxHeartbeats`
+        # ceiling (default 200000): a tactic that is *correct* becomes
+        # unaffordable, surfacing as `(deterministic) timeout, maximum
+        # heartbeats (200000)` in the build output. Without a typed verdict the
+        # harness sinks these runs into `no_progress` / generic timeout, hiding
+        # a proof-engineering wall under a label that reads as 'agent gave up'.
+        # Confirmed model-independent (ai-01 A-B c.681: glm-5.2 / gpt-5.6-sol /
+        # kimi-k3 all hit it). Scan every build output seen during the run --
+        # per-attempt errors (where a submitted tactic blew the budget) and the
+        # final verify raw output -- for the signature. Distinct from
+        # `no_progress` (the agent did try) and from a generic provider /
+        # wall-clock timeout. P5b (factor-lemma / set_option maxHeartbeats hint)
+        # is a SEPARATE grain, intentionally not handled here.
+        heartbeat_budget_exceeded = any(
+            output_indicates_heartbeat_budget_exceeded(getattr(a, "error", None))
+            for a in state.tactic_history
+        ) or output_indicates_heartbeat_budget_exceeded(
+            final_verify.get("raw_output") or final_verify.get("raw_output_preview")
+        )
+
         return {
             "success": success,
             "proof": state.final_proof,
@@ -1058,6 +1080,15 @@ class MultiAgentSorryProver:
             # (forensic; each hop already covered its in-hop retries).
             "provider_outage": provider_outage,
             "provider_failures": provider_failures,
+            # P5a (#7477 forensic): True when a build output seen during the run
+            # hit Lean's `maxHeartbeats` ceiling (`(deterministic) timeout,
+            # maximum heartbeats (N)`). The target is likely *correct but
+            # unaffordable* -- a proof-engineering wall, not 'agent gave up'.
+            # Distinct from `no_progress` / generic timeout so forensic ROI does
+            # not mis-rank a heartbeat wall as agent laziness. Model-independent
+            # (ai-01 A-B c.681). P5b (factor-lemma / set_option maxHeartbeats
+            # hint) is a SEPARATE grain.
+            "heartbeat_budget_exceeded": heartbeat_budget_exceeded,
             # FX-12 (#6790 pathology 3): count of build-verified *structural*
             # edits (file_replace_lines / file_insert_lines whose build_check
             # passed). Distinct from ``structural_progress`` (a boolean

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_heartbeat_budget.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_heartbeat_budget.py
@@ -1,0 +1,132 @@
+"""Unit tests for the heartbeat-budget classifier (P5a, #7477 forensic).
+
+Loads ``heartbeat_budget.py`` DIRECTLY by file path, bypassing
+``prover/__init__.py`` (which cascades the ``agent_framework`` LLM stack,
+absent on a bare CPU runner). The classifier is stdlib-only and
+self-contained, so these tests run everywhere (no agent_framework / Lean /
+network). Mirrors ``tests/test_prover_forensic_guards.py``'s file-path
+load of ``forensic_guards.py``.
+
+Acceptance (a) of the P5a steer (ai-01 msg-...ek0f1x): a build output
+containing ``maximum heartbeats (200000)`` classifies
+``heartbeat_budget_exceeded`` (True), NOT ``no_progress``. The classifier
+itself is the source of truth provers.py surfaces on the result dict; the
+DEMO 62 Hashlife P5 wall (model-independent per ai-01 A-B c.681) must be
+distinguishable from a genuinely lazy/lost agent.
+
+Run from `agent_tests/`:
+    python -m pytest tests/test_heartbeat_budget.py -q
+
+See #7477 (prover harness forensic), See #1453 (prover co-evolution epic).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+
+_spec = importlib.util.spec_from_file_location(
+    "prover_heartbeat_budget", ROOT / "prover" / "heartbeat_budget.py"
+)
+_hb = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_hb)
+
+classify = _hb.output_indicates_heartbeat_budget_exceeded
+
+
+# ── Acceptance (a): the DEMO 62 founder signature classifies True ──────────
+
+class TestHeartbeatSignatureDetected:
+    """Lean maxHeartbeats exhaustion MUST classify as heartbeat wall."""
+
+    def test_founder_dem62_max_heartbeats_200000(self):
+        """The exact DEMO 62 probe signature (ai-01 A-B c.681): each probe
+        at L3199 timed out with this message."""
+        out = ("info: ./Conway/Life/Hashlife/P5.lean:3199:0: "
+               "(deterministic) timeout, maximum heartbeats (200000)")
+        assert classify(out) is True
+
+    def test_bare_maximum_heartbeats_with_count(self):
+        assert classify("maximum heartbeats (200000)") is True
+
+    def test_deterministic_timeout_alone(self):
+        """The '(deterministic) timeout' half (without the explicit count).
+
+        Lean wraps the same exhaustion this way in some output paths; both
+        halves of the signature are equally diagnostic."""
+        assert classify("(deterministic) timeout") is True
+
+    def test_case_insensitive(self):
+        """Capitalization varies across Lean versions / wrappers."""
+        assert classify("MAXIMUM HEARTBEATS (200000)") is True
+        assert classify("(Deterministic) Timeout") is True
+
+    def test_embedded_in_multiline_build_output(self):
+        """Signature embedded among other build lines is still detected
+        (the per-attempt error carries the full lake output, not just the
+        signature line)."""
+        out = (
+            "info: building...\n"
+            "info: compiling Conway.Life.Hashlife.P5\n"
+            "info: ./P5.lean:42:3: (deterministic) timeout, maximum heartbeats (200000)\n"
+            "info: some unrelated warning\n"
+        )
+        assert classify(out) is True
+
+    def test_non_default_heartbeat_budget(self):
+        """A raised ceiling (set_option maxHeartbeats 400000) that is STILL
+        exhausted surfaces with the higher count -- still the same wall."""
+        assert classify("maximum heartbeats (400000)") is True
+
+
+# ── Negative: non-heartbeat failures must NOT be mis-labelled ──────────────
+
+class TestNonHeartbeatNotClassified:
+    """A failure without the heartbeat signature must stay False, so the
+    verdict does not mask a genuinely lazy/lost agent or a provider issue
+    (each is its own failure class with its own ROI)."""
+
+    def test_no_progress_prose(self):
+        """A run that made no progress but never hit the heartbeat ceiling
+        must NOT be flagged -- that would mis-rank a lazy agent as a
+        heartbeat wall."""
+        assert classify("agent produced no tactic, sorry count unchanged") is False
+
+    def test_compile_error(self):
+        assert classify("./Foo.lean:10:3: error: unknown identifier 'bar'") is False
+
+    def test_provider_timeout_is_not_heartbeat(self):
+        """A wall-clock / provider timeout (HTTP 504, no Lean heartbeat
+        signature) is the provider_outage / generic-timeout class, NOT the
+        heartbeat wall. The two verdicts must stay distinct (P5a rationale)."""
+        assert classify("Request timed out after 300s (HTTP 504)") is False
+
+    def test_empty_and_none(self):
+        assert classify("") is False
+        assert classify(None) is False
+
+    def test_heartbeat_word_in_unrelated_prose(self):
+        """The bare word 'heartbeat' (without the Lean signature shape) must
+        not trigger -- guards against false positives in error prose."""
+        assert classify("the agent's heartbeat monitor reported healthy") is False
+        assert classify("heartbeat: 72bpm") is False
+
+
+# ── Public API contract ────────────────────────────────────────────────────
+
+class TestPublicApi:
+    def test_exports_classify_function(self):
+        assert "output_indicates_heartbeat_budget_exceeded" in _hb.__all__
+        assert callable(classify)
+
+    def test_returns_bool_not_truthy(self):
+        """The verdict must be a real ``bool`` (consumers do
+        ``if result['heartbeat_budget_exceeded']`` and persist it to JSON
+        traces), not a truthy regex match object."""
+        assert type(classify("maximum heartbeats (200000)")) is bool
+        assert type(classify("no signature here")) is bool


### PR DESCRIPTION
## What

**P5a (#7477 forensic)** — typed `heartbeat_budget_exceeded` verdict for the prover harness. Dispatched by ai-01 (DM msg-...ek0f1x, HIGH). The DEMO 62 (Hashlife P5) structural wall is a whnf blowup that hits Lean's `maxHeartbeats` ceiling (default 200000): a tactic that is *correct* becomes unaffordable, surfacing as `(deterministic) timeout, maximum heartbeats (200000)` in the build output. Without a typed verdict the harness sinks these runs into `no_progress` / generic timeout, hiding a **proof-engineering wall** under a label that reads as "agent gave up". Confirmed **model-independent** (ai-01 A-B c.681: glm-5.2 / gpt-5.6-sol / kimi-k3 all hit it) → P5a classifies it honestly so forensic ROI does not mis-rank the wall as agent laziness.

**Scope strictly P5a** (ai-01: "P5b = grain SÉPARÉ, ne le bundle pas"): classifier + verdict on the result dict. **Not** bundled: P5b (factor-lemma / `set_option maxHeartbeats` hint), AutonomousProver path (follow-up).

See #7477 (prover harness forensic). See #1453 (prover co-evolution epic).

## Fix

**New stdlib-only module `prover/heartbeat_budget.py`** — pure classifier `output_indicates_heartbeat_budget_exceeded(text)`: regex-detects the two Lean signatures (`maximum heartbeats`, `(deterministic) timeout`, case-insensitive) in any build-output fragment. Stdlib-only so it is unit-testable by **file-path load on a bare CPU runner** that lacks the `agent_framework` LLM stack — same proven pattern as `forensic_guards.py` (cf `tests/test_prover_forensic_guards.py`, whose header documents exactly why `prover/__init__.py` cannot be imported on a CPU runner: it cascades `prover.provers → agent_framework`).

**`prover/provers.py`** (MultiAgentSorryProver, the DEMO 62 prover) — 3 bounded additions:
1. `from .heartbeat_budget import output_indicates_heartbeat_budget_exceeded` (L19).
2. Compute `heartbeat_budget_exceeded` before the result dict: scan **every** build output seen during the run — per-attempt errors (`TacticAttempt.error`, where a submitted tactic blew the budget) **and** the final-verify raw output (`final_verify["raw_output"]`) — for the signature.
3. New result-dict field `"heartbeat_budget_exceeded": heartbeat_budget_exceeded` (next to `provider_outage` / `provider_failures`, the existing typed-verdict siblings).

The verdict is **distinct from `no_progress`** (the agent did try) and **from a generic provider / wall-clock timeout** (already typed as `provider_outage`) — surfacing it lets forensic ROI (analyze_traces) rank a heartbeat wall separately instead of drowning it in `no_progress`.

## Anti-regression protocol (CLAUDE.md section D)

1. **Exact problem**: DEMO 62 Hashlife P5 runs that hit the heartbeat ceiling were classified `no_progress` / generic timeout, hiding a model-independent proof-engineering wall (ai-01 A-B c.681 confirmed all 3 frontier/workhorse models hit it).
2. **3 tactics**: (a) pure classifier in stdlib-only module + verdict on result dict **[chosen — testable CPU, mirrors forensic_guards.py]**; (b) inline classifier in provers.py zone L344 **[rejected — provers.py cannot be file-path-loaded on CPU (agent_framework cascade), so the test would need a fragile multi-symbol stub; the stdlib-only module is the established robust pattern]**; (c) verdict at the attempt level not the run level **[rejected — run-level verdict is what forensic ROI consumes; per-attempt is a follow-up if needed]**.
3. **Coherent diff**: +1 stdlib-only module (68L), provers.py +31 (import + compute + field + comments, **0 deletion**), +1 test (~150L). **0 deletion on production code.** No `sorry`/stub/`return None` on existing logic. provers.py `py_compile` OK.
4. **Consumers verified firsthand**: `grep "heartbeat_budget_exceeded"` repo-wide = 0 consumer outside this PR (new field, additive). The verdict mirrors `provider_outage`'s pattern (typed sibling), so `analyze_traces` / forensic consumers pick it up by convention once surfaced. No existing field is renamed/removed.

## Validation (reproducible, CPU-only)

```
$ cd MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests
$ python -m pytest tests/test_heartbeat_budget.py -q
13 passed in 0.07s
$ python -m pytest tests/test_heartbeat_budget.py tests/test_prover_forensic_guards.py -q
44 passed in 0.08s
```

**13 tests CPU-only self-contained** (file-path load of the stdlib-only module; no agent_framework / Lean / network). Cover:
- **Acceptance (a)** `TestHeartbeatSignatureDetected` (6): DEMO 62 founder signature `(deterministic) timeout, maximum heartbeats (200000)` → True; bare `maximum heartbeats (N)`; `(deterministic) timeout` alone; case-insensitive; embedded in multiline build output; non-default budget (`400000`).
- `TestNonHeartbeatNotClassified` (5): no_progress prose → False; compile error → False; provider 504 timeout → False (distinct class); empty/None → False; bare "heartbeat" word in prose → False (FP guard).
- `TestPublicApi` (2): export contract + returns real `bool` (not truthy regex match).

**Regression**: `test_prover_forensic_guards.py` 31/31 pass (file-path-load sibling, unchanged). `test_prover_guards.py` collection fails on po-2025 — **preexisting** (L15 `from agent_framework import` is on origin/main; po-2025 lacks the LLM stack; not this PR's regression). provers.py `py_compile` OK.

## Conformity

- Atomic: 1 domain (prover harness classification, P5a), 1 verdict, root-cause (typed verdict vs sink-into-no_progress).
- **`See #7477`** + **`See #1453`** (Epic parent). Not `Closes` — P5a is 1 part of the #7477 multi-part forensic (P1a/P1b/P2a/P2b MERGED; P5b = separate grain).
- Anti-regression: 0 production code/proof replaced by sorry/stub; 4-step documented; stdlib-only classifier evidence-cited.
- P5b NOT bundled (ai-01 scope boundary respected).
- No C.2 implication: 0 notebook modified (Python source + test only).
- Catalogue byte-identical to `main` (0 catalogue change).
- Fresh base off `origin/main` `bdbf55739`, isolated worktree `CoursIA-prover-p5a`.
- Pre-flight collision check: `heartbeat_budget` absent from repo (0 name collision). `gh pr list --search "heartbeat"` = 0 OPEN PR touching the verdict.
- Local-git-only (ai-01 constraint): no `gh` ops in sub-agents, all `git` local.
- No API key, no QC Cloud, no GPU, no Lean build, no LLM call (stdlib classifier + file-path-load test, CPU offline).
