### PR TITLE
chore(docs,#7422): automate parcours regen in catalog cron + refresh 5 stale pages

### DIFF
--- a/.github/workflows/catalog-cron.yml
+++ b/.github/workflows/catalog-cron.yml
@@ -66,11 +66,20 @@ jobs:
           # --git-tracked-only keeps CI output deterministic (ignores untracked).
           python scripts/notebook_tools/generate_catalog.py --git-tracked-only
           python scripts/notebook_tools/expand_catalog_markers.py
+          # Learning paths (parcours, #7422): derive the 5 curriculum pages
+          # under docs/curriculum/ from the freshly-regenerated catalog so
+          # they never drift again (See #7422).
+          python scripts/notebook_tools/generate_parcours.py
 
       - name: Commit + push to main if the catalog drifted
         run: |
           set -euo pipefail
           git add COURSE_CATALOG.generated.json COURSE_CATALOG.generated.md
+          # Stage the 5 generated curriculum (parcours) pages if they drifted.
+          mapfile -t changed_parcours < <(git ls-files -m -- 'docs/curriculum/*.md')
+          if [ "${#changed_parcours[@]}" -gt 0 ]; then
+            git add -- "${changed_parcours[@]}"
+          fi
           # Stage only README files actually modified by marker expansion.
           mapfile -t changed_readmes < <(git ls-files -m -- '*README.md')
           if [ "${#changed_readmes[@]}" -gt 0 ]; then

--- a/docs/curriculum/genai.md
+++ b/docs/curriculum/genai.md
@@ -2,111 +2,214 @@
 
 **Generation d'images, audio, video et texte**
 
-Generation d'images (DALL-E, Stable Diffusion, Qwen, ComfyUI), synthese vocale, generation musicale, video, et orchestration de modèles. Inclut les workflows Vibe-Coding et les pipelines de production.
+Generation d'images (DALL-E, Stable Diffusion, Qwen, ComfyUI), synthese vocale, generation musicale, video, et orchestration de modeles. Inclut les workflows Vibe-Coding et les pipelines de production.
 
 ## Statistiques
 
 | Metrique | Valeur |
 |----------|--------|
-| Notebooks | 68 |
-| PRODUCTION | 5 |
-| BETA | 4 |
-| ALPHA | 59 |
+| Notebooks | 136 |
+| PRODUCTION | 97 |
+| BETA | 34 |
+| ALPHA | 5 |
 
-## GenAI/Audio (19 notebooks)
-
-| # | Notebook | Maturite | Executable |
-|---|----------|----------|------------|
-| 1 | OpenAI TTS - Synthese Vocale par API | ALPHA | Non |
-| 2 | OpenAI Whisper STT - Reconnaissance Vocale par API | ALPHA | Non |
-| 3 | Operations de Base sur l'Audio | ALPHA | Non |
-| 4 | Whisper Local - Transcription GPU avec faster-whisper | ALPHA | Non |
-| 5 | Chatterbox TTS - Synthese Vocale Expressive | ALPHA | Non |
-| 6 | XTTS v2 - Clonage Vocal Zero-Shot | ALPHA | Non |
-| 7 | MusicGen - Generation Musicale par IA | ALPHA | Non |
-| 8 | Demucs v4 - Separation de Sources Audio | ALPHA | Non |
-| 9 | Multi-Model TTS Gateway - Synthese Vocale Multi-Modèles | ALPHA | Oui |
-| 10 | Generation MIDI avec midi-model (SkyTNT) | ALPHA | Non |
-| 11 | Generation de Chansons Completes : YuE vs SongGeneratio | ALPHA | Non |
-| 12 | TTS Expressif : Fish S2 Pro et Modèles SOTA | ALPHA | Non |
-| 13 | Comparaison Multi-Modèles Audio | ALPHA | Non |
-| 14 | Orchestration de Pipelines Audio | ALPHA | Non |
-| 15 | Création de Contenu Audio Educatif | ALPHA | Non |
-| 16 | Pipeline de Transcription et Sous-titrage | ALPHA | Non |
-| 17 | Workflow de Composition Musicale | ALPHA | Non |
-| 18 | Synchronisation Audio-Video (Passerelle) | ALPHA | Non |
-| 19 | Live Coding Musical pilote par LLM | ALPHA | Non |
-
-## GenAI/EPF (4 notebooks)
+## GenAI (1 notebooks)
 
 | # | Notebook | Maturite | Executable |
 |---|----------|----------|------------|
-| 1 | Duel Verbal : Barbie vs l'Âne de Shrek | ALPHA | Non |
-| 2 | Générateur de Recettes PDF | ALPHA | Oui |
-| 3 | Jeu de devinette : Père Fouras vs Laurent Jalabert | ALPHA | Non |
-| 4 | Docteur vs ChatGPT: Chatbot médical | ALPHA | Non |
+| 1 | GenAI E2E Quant Validation | BETA | Non |
 
-## GenAI/Image (16 notebooks)
+## GenAI/00-GenAI-Environment (6 notebooks)
 
 | # | Notebook | Maturite | Executable |
 |---|----------|----------|------------|
-| 1 | OpenAI DALL-E 3 - Generation d'Images | ALPHA | Non |
-| 2 | 🤖 GPT-5 Multimodal - Analyse et Génération d'Images | ALPHA | Non |
-| 3 | 🖼️ Opérations de Base sur les Images | ALPHA | Non |
-| 4 | Notebook: Stable Diffusion Forge - SD XL Turbo | BETA | Non |
-| 5 | Notebook: Qwen Image-Edit 2.5 - API ComfyUI | ALPHA | Non |
-| 6 | Qwen Image Edit 2509 - Édition Avancée d'Images | ALPHA | Non |
-| 7 | FLUX.1 - Génération d'Images Avancée | BETA | Non |
-| 8 | Stable Diffusion 3.5 - Génération de Pointe | ALPHA | Non |
-| 9 | Z-Image (Lumina-2) : Generation Avancee avec ComfyUI | ALPHA | Non |
-| 10 | Comparaison Multi-Modèles : SDXL Turbo, Qwen2-VL, Z-Ima | ALPHA | Oui |
-| 11 | Workflow Orchestration - Chaînage Multi-Modèles | BETA | Oui |
-| 12 | 🚀 Performance Optimization pour la Génération d'Images | ALPHA | Non |
-| 13 | 🎓 Educational Content Generation - GenAI | ALPHA | Non |
-| 14 | Creative Workflows - GenAI | ALPHA | Non |
-| 15 | 🏭 Production Integration - GenAI | ALPHA | Non |
-| 16 | Génération d’un patron de point de croix à partir d’une | ALPHA | Non |
+| 1 | 🚀 GenAI Environment Setup - CoursIA | BETA | Non |
+| 2 | 🐳 Docker Services Management - GenAI | BETA | Non |
+| 3 | 🔗 Configuration des API Endpoints | BETA | Non |
+| 4 | ✅ Environment Validation - GenAI | BETA | Non |
+| 5 | 00-5: ComfyUI Local - Test Rapide | PRODUCTION | Non |
+| 6 | Deploiement Docker Local des Services GenAI | PRODUCTION | Non |
 
-## GenAI/SemanticKernel (12 notebooks)
+## GenAI/Audio (30 notebooks)
 
 | # | Notebook | Maturite | Executable |
 |---|----------|----------|------------|
-| 1 | SK-1-Fundamentals : Introduction a Semantic Kernel | ALPHA | Non |
+| 1 | OpenAI TTS - Synthese Vocale par API | PRODUCTION | Non |
+| 2 | OpenAI Whisper STT - Reconnaissance Vocale par API | PRODUCTION | Non |
+| 3 | Opérations de Base sur l'Audio | PRODUCTION | Non |
+| 4 | Whisper Local - Transcription GPU avec faster-whisper | PRODUCTION | Non |
+| 5 | Kokoro TTS Local - Synthese Vocale Legere | PRODUCTION | Non |
+| 6 | Chatterbox TTS - Synthese Vocale Expressive | PRODUCTION | Non |
+| 7 | XTTS v2 - Clonage Vocal Zero-Shot | PRODUCTION | Non |
+| 8 | MusicGen - Generation Musicale par IA | PRODUCTION | Non |
+| 9 | Demucs v4 - Separation de Sources Audio | PRODUCTION | Non |
+| 10 | Multi-Model TTS Gateway - Synthese Vocale Multi-Modèles | PRODUCTION | Non |
+| 11 | Generation MIDI avec midi-model (SkyTNT) | PRODUCTION | Non |
+| 12 | Generation de Chansons Completes : YuE vs SongGeneratio | PRODUCTION | Non |
+| 13 | TTS Expressif : Fish S2 Pro et Modèles SOTA | PRODUCTION | Non |
+| 14 | Ace-Step v1.5 - Generation Musicale avec Paroles | PRODUCTION | Non |
+| 15 | Comparaison Multi-Modèles Audio | PRODUCTION | Non |
+| 16 | Orchestration de Pipelines Audio | PRODUCTION | Non |
+| 17 | OpenAI Realtime Voice API | PRODUCTION | Non |
+| 18 | Creation de Contenu Audio Educatif | PRODUCTION | Non |
+| 19 | P3 - Annotation Prosodique pour TTS Agentique | PRODUCTION | Non |
+| 20 | P4 — Generation TTS pour Audiobook | PRODUCTION | Non |
+| 21 | P5 — Compilation Audio pour Audiobook | PRODUCTION | Oui |
+| 22 | Audiobook Agentique avec FishAudio S2-Pro | PRODUCTION | Non |
+| 23 | Pipeline de Transcription et Sous-titrage | PRODUCTION | Non |
+| 24 | Workflow de Composition Musicale | PRODUCTION | Non |
+| 25 | Synchronisation Audio-Video (Passerelle) | PRODUCTION | Non |
+| 26 | Live Coding Musical pilote par LLM | PRODUCTION | Non |
+| 27 | Pipeline Audiobook Agentique | PRODUCTION | Non |
+| 28 | Benchmark TTS : Comparaison des Modèles Vocaux pour l'A | BETA | Non |
+| 29 | Lecture Analytique pour Audiobook | PRODUCTION | Oui |
+| 30 | Voice Casting : Attribution de voix TTS par personnage | BETA | Non |
+
+## GenAI/CaseStudies (4 notebooks)
+
+| # | Notebook | Maturite | Executable |
+|---|----------|----------|------------|
+| 1 | Duel Verbal : Barbie vs l'Âne de Shrek | BETA | Non |
+| 2 | Jeu de devinette : Père Fouras vs Laurent Jalabert | BETA | Non |
+| 3 | Docteur vs ChatGPT : Chatbot medical multi-agent | BETA | Non |
+| 4 | Générateur de Recettes PDF | BETA | Non |
+
+## GenAI/FineTuning (5 notebooks)
+
+| # | Notebook | Maturite | Executable |
+|---|----------|----------|------------|
+| 1 | FT-01 : Introduction au Fine-Tuning | PRODUCTION | Non |
+| 2 | FT-02 : QLoRA — Fine-Tuning avec Quantization | PRODUCTION | Non |
+| 3 | FT-03 : Supervised Fine-Tuning (SFT) — Instruction Foll | PRODUCTION | Non |
+| 4 | FT-04 : RLHF et Alignement — Préférences Humaines et DP | PRODUCTION | Non |
+| 5 | FT-05 : Fusion et Routage de Modèles -- Combiner les Ex | BETA | Non |
+
+## GenAI/Image (17 notebooks)
+
+| # | Notebook | Maturite | Executable |
+|---|----------|----------|------------|
+| 1 | OpenAI DALL-E 3 - Generation d'Images | BETA | Non |
+| 2 | 🤖 GPT-5 Multimodal - Analyse et Génération d'Images | PRODUCTION | Non |
+| 3 | 🖼️ Opérations de Base sur les Images | PRODUCTION | Non |
+| 4 | Notebook: Stable Diffusion Forge - SD XL Turbo | PRODUCTION | Non |
+| 5 | Notebook: Qwen Image-Edit 2.5 - API ComfyUI | BETA | Non |
+| 6 | Qwen Image Edit 2509 - Édition Avancée d'Images | PRODUCTION | Non |
+| 7 | FLUX.1 - Génération d'Images Avancée | PRODUCTION | Non |
+| 8 | Stable Diffusion 3.5 - Génération de Pointe | BETA | Non |
+| 9 | Z-Image (Lumina-2) : Generation Avancee avec ComfyUI | PRODUCTION | Non |
+| 10 | Bonsai-Image : Generation Text-to-Image avec Quantizati | PRODUCTION | Non |
+| 11 | Comparaison Multi-Modèles : SDXL Lightning-4step, Z-Ima | PRODUCTION | Non |
+| 12 | Workflow Orchestration - Chaînage Multi-Modèles | PRODUCTION | Non |
+| 13 | 🚀 Performance Optimization pour la Génération d'Images | PRODUCTION | Non |
+| 14 | 🎓 Educational Content Generation - GenAI | PRODUCTION | Non |
+| 15 | Creative Workflows - GenAI | PRODUCTION | Non |
+| 16 | 🏭 Production Integration - GenAI | PRODUCTION | Non |
+| 17 | Génération d’un patron de point de croix à partir d’une | BETA | Non |
+
+## GenAI/Open-WebUI (7 notebooks)
+
+| # | Notebook | Maturite | Executable |
+|---|----------|----------|------------|
+| 1 | Parcours QA-OWUI — Notebook chapeau de la mission | BETA | Oui |
+| 2 | Module 01 — Découverte de Playwright & Open WebUI | PRODUCTION | Oui |
+| 3 | Module 02 — Navigation & Authentification | PRODUCTION | Oui |
+| 4 | Module 03 — Chat & Streaming LLM | PRODUCTION | Oui |
+| 5 | Module 04 — RAG, Outils MCP & Fonctionnalités avancées | PRODUCTION | Oui |
+| 6 | Module 05 — Multi-tenant, API Testing & CI/CD | PRODUCTION | Oui |
+| 7 | Module 06 — Tester les nouveautés v0.10 (« l'ère agenti | PRODUCTION | Non |
+
+## GenAI/PostTraining (7 notebooks)
+
+| # | Notebook | Maturite | Executable |
+|---|----------|----------|------------|
+| 1 | PT-01 — Introduction et vue d'ensemble | PRODUCTION | Non |
+| 2 | PT-02 — Supervised Fine-Tuning baseline (SFT) | PRODUCTION | Non |
+| 3 | PT-03 — Direct Préférence Optimization (DPO) | BETA | Non |
+| 4 | PT-04 — Group Relative Policy Optimization (GRPO) | BETA | Non |
+| 5 | PT-05 — Reinforcement Learning with Verifiable Rewards  | BETA | Non |
+| 6 | PT-06 — Evaluation Comparative du Post-Training | PRODUCTION | Non |
+| 7 | PT-07 — Détecter le reward hacking avec rewardspy | PRODUCTION | Oui |
+
+## GenAI/RAG-et-Memoire-Semantique (1 notebooks)
+
+| # | Notebook | Maturite | Executable |
+|---|----------|----------|------------|
+| 1 | Hands-On Grounding — Qdrant en mémoire | PRODUCTION | Oui |
+
+## GenAI/SemanticKernel (17 notebooks)
+
+| # | Notebook | Maturite | Executable |
+|---|----------|----------|------------|
+| 1 | SK-1-Fundamentals : Introduction a Semantic Kernel | PRODUCTION | Non |
 | 2 | SK-2-Functions : Function Calling, Memory et Fonctionna | PRODUCTION | Non |
-| 3 | SK-3-Agents : Agent Framework Semantic Kernel | BETA | Non |
+| 3 | SK-3-Agents : Agent Framework Semantic Kernel | PRODUCTION | Non |
 | 4 | SK-4-Filters : Filtres et Observabilite | PRODUCTION | Non |
 | 5 | SK-5-VectorStores : RAG avec Qdrant | PRODUCTION | Non |
-| 6 | SK-6-ProcessFramework : Workflows et Orchestration | PRODUCTION | Oui |
-| 7 | SK-7-MultiModal : Images, Audio et Vision | ALPHA | Non |
+| 6 | SK-6-ProcessFramework : Workflows et Orchestration | PRODUCTION | Non |
+| 7 | SK-7-MultiModal : Images, Audio et Vision | PRODUCTION | Non |
 | 8 | SK-8-MCP : Model Context Protocol et Integration | PRODUCTION | Non |
-| 9 | SK-10-NotebookMaker : Systeme Multi-Agents pour Generat | ALPHA | Non |
-| 10 | 🚀 Conception Automatique de Notebook par Agents IA | ALPHA | Non |
-| 11 | Notebook final — Démonstration reproductible (template) | ALPHA | Oui |
-| 12 | Notebook de travail | ALPHA | Oui |
+| 9 | SK-9-Building-CLR : Interoperabilite Python/.NET via py | PRODUCTION | Non |
+| 10 | SK-10-NotebookMaker : Système Multi-Agents pour Generat | PRODUCTION | Non |
+| 11 | 🚀 Conception Automatique de Notebook par Agents IA | BETA | Non |
+| 12 | 🚀 Conception Automatique de Notebook par Agents IA | BETA | Non |
+| 13 | Projet Createur de Mail personnalise | BETA | Non |
+| 14 | Notebook de travail | BETA | Oui |
+| 15 | Notebook de conception de Notebook | ALPHA | Non |
+| 16 | Jeu de devinette : Père Fouras vs Laurent Jalabert | ALPHA | Non |
+| 17 | Jeu de devinette : Père Fouras vs Laurent Jalabert | BETA | Non |
 
-## GenAI/Texte (10 notebooks)
-
-| # | Notebook | Maturite | Executable |
-|---|----------|----------|------------|
-| 1 | 10. Hébergement Local de Modèles Génératifs | ALPHA | Non |
-| 2 | 11. Quantization des LLMs | ALPHA | Non |
-| 3 | Prompt Engineering : Advanced Prompting avec OpenAI | ALPHA | Non |
-| 4 | Structured Outputs : Sorties JSON Garanties avec OpenAI | ALPHA | Non |
-| 5 | Function Calling : Connecter les LLMs au Monde Réel | ALPHA | Non |
-| 6 | 5. RAG Modern - Retrieval Augmented Generation | ALPHA | Non |
-| 7 | PDF et Web Search : Sources Documentaires avec OpenAI | ALPHA | Non |
-| 8 | Code Interpreter : Exécution de Code avec OpenAI | ALPHA | Non |
-| 9 | Modèles de Raisonnement : gpt-5-mini | ALPHA | Non |
-| 10 | Patterns de Production : APIs Avancées OpenAI | ALPHA | Non |
-
-## GenAI/Video (7 notebooks)
+## GenAI/Texte (20 notebooks)
 
 | # | Notebook | Maturite | Executable |
 |---|----------|----------|------------|
-| 1 | Operations de Base sur les Videos | ALPHA | Oui |
-| 2 | GPT-5 Video Understanding - Comprehension Video par IA | ALPHA | Non |
-| 3 | Qwen2.5-VL Video Analysis - Comprehension Video Locale | ALPHA | Non |
-| 4 | AnimateDiff - Introduction a la Generation Text-to-Vide | ALPHA | Non |
-| 5 | HunyuanVideo - Generation Video Haute Qualite**Module : | ALPHA | Non |
-| 6 | LTX-Video - Generation Video Rapide et Legere | ALPHA | Non |
-| 7 | Wan 2.1/2.2 - Generation Video Multilingue | ALPHA | Non |
+| 1 | 10. Hébergement Local de Modèles Génératifs | PRODUCTION | Non |
+| 2 | 11. Quantization des LLMs | PRODUCTION | Non |
+| 3 | 12 - Test-Time Scaling : le second axe de mise a l'eche | PRODUCTION | Non |
+| 4 | 13. Orchestration agentique du test-time scaling | BETA | Non |
+| 5 | 14. Memoire persistante pour le test-time scaling | BETA | Non |
+| 6 | 15. Tree-of-Thoughts sur de vrais problemes de recherch | BETA | Non |
+| 7 | 16. Scaling du test-time compute (Snell 2024) | BETA | Non |
+| 8 | 17. Modèles a raisonnement natif vs scaling du test-tim | BETA | Non |
+| 9 | 18. Plugins Semantic Kernel pour le test-time scaling | BETA | Non |
+| 10 | 19. Orchestration et tâches planifiées avec Open WebUI  | PRODUCTION | Non |
+| 11 | 1. Introduction a l'IA generative avec l'API OpenAI | PRODUCTION | Non |
+| 12 | 20. OWUI Native API v0.9.6 — introspection REST et surf | PRODUCTION | Non |
+| 13 | 2. Prompt Engineering : Techniques Avancées | BETA | Non |
+| 14 | 3. Structured Outputs : Sorties JSON Garanties | PRODUCTION | Non |
+| 15 | Function Calling : Connecter les LLMs au Monde Réel | PRODUCTION | Non |
+| 16 | 5. RAG Modern - Retrieval Augmented Generation | PRODUCTION | Non |
+| 17 | PDF et Web Search : Sources Documentaires avec OpenAI | PRODUCTION | Non |
+| 18 | Code Interpreter : Exécution de Code avec OpenAI | PRODUCTION | Non |
+| 19 | Modèles de Raisonnement : gpt-5-mini | PRODUCTION | Non |
+| 20 | Patterns de Production : APIs Avancées OpenAI | PRODUCTION | Non |
+
+## GenAI/Vibe-Coding (6 notebooks)
+
+| # | Notebook | Maturite | Executable |
+|---|----------|----------|------------|
+| 1 | Claude CLI - Les Bases | PRODUCTION | Oui |
+| 2 | Claude CLI - Gestion des Sessions | PRODUCTION | Oui |
+| 3 | Claude CLI - References et Contexte | PRODUCTION | Oui |
+| 4 | Claude CLI - Agents et Subagents | PRODUCTION | Oui |
+| 5 | Claude CLI - Automatisation Avancee | PRODUCTION | Non |
+| 6 | Claude Code via Claudish | PRODUCTION | Non |
+
+## GenAI/Video (15 notebooks)
+
+| # | Notebook | Maturite | Executable |
+|---|----------|----------|------------|
+| 1 | Opérations de Base sur les Videos | PRODUCTION | Non |
+| 2 | GPT-5 Video Understanding - Comprehension Video par IA | PRODUCTION | Non |
+| 3 | Qwen2.5-VL Video Analysis - Comprehension Video Locale | BETA | Non |
+| 4 | Video Enhancement - Real-ESRGAN et Interpolation de Fra | BETA | Non |
+| 5 | AnimateDiff - Introduction a la Generation Text-to-Vide | PRODUCTION | Non |
+| 6 | HunyuanVideo - Generation Video Haute Qualite**Module : | PRODUCTION | Non |
+| 7 | LTX-Video - Generation Video Rapide et Legere | PRODUCTION | Non |
+| 8 | Wan 2.1/2.2 - Generation Video Multilingue | PRODUCTION | Non |
+| 9 | LTX-2 - Generation Audiovisuelle Conjointe (Video + Aud | PRODUCTION | Non |
+| 10 | Comparaison Multi-Modèles de Generation Video | ALPHA | Non |
+| 11 | Orchestration de Pipelines Video | ALPHA | Non |
+| 12 | ComfyUI - Workflows Video via API | PRODUCTION | Non |
+| 13 | Workflows Video Creatifs | PRODUCTION | Non |
+| 14 | Sora API - Generation Video Cloud | ALPHA | Non |
+| 15 | Pipeline Video de Production | PRODUCTION | Non |

--- a/docs/curriculum/ia-classique.md
+++ b/docs/curriculum/ia-classique.md
@@ -1,47 +1,191 @@
 # IA Classique
 
-**Recherche, CSP et résolution de problemes**
+**Recherche, CSP et resolution de problemes**
 
-Algorithmes de recherche classique, satisfaction de contraintes (CSP), résolution de Sudoku, planification classique. De A* aux heuristiques avancees, en passant par les solveurs SAT/SMT.
+Algorithmes de recherche classique, satisfaction de contraintes (CSP), resolution de Sudoku, planification classique. De A* aux heuristiques avancees, en passant par les solveurs SAT/SMT.
 
 ## Statistiques
 
 | Metrique | Valeur |
 |----------|--------|
-| Notebooks | 13 |
-| PRODUCTION | 2 |
-| BETA | 11 |
+| Notebooks | 147 |
+| PRODUCTION | 114 |
+| BETA | 33 |
 | ALPHA | 0 |
 
-## Search/Applications (2 notebooks)
+## Search/Applications (40 notebooks)
 
 | # | Notebook | Maturite | Executable |
 |---|----------|----------|------------|
-| 1 | App-8-MiniZinc : Modelisation declarative par contraint | BETA | Oui |
-| 2 | App-9 : Detection de bords par algorithmes genetiques | BETA | Oui |
+| 1 | App-1 : Le Problème des N-Reines | PRODUCTION | Oui |
+| 2 | App-11 - Picross (Nonogrammes) | PRODUCTION | Oui |
+| 3 | App-11b : Picross (Nonogrammes) — Jumeau C# | PRODUCTION | Oui |
+| 4 | App-15 : Planification de Calendrier Sportif (CSP) | PRODUCTION | Oui |
+| 5 | App-15b : Planification de Calendrier Sportif -- Jumeau | PRODUCTION | Oui |
+| 6 | App-16-Crossword-CSP (C#) | BETA | Oui |
+| 7 | App-16 : Générateur de Mots Croises (CSP) | PRODUCTION | Oui |
+| 8 | App-19 (C#) — Génération procédurale par Wave Function  | BETA | Oui |
+| 9 | App-19 — Génération procédurale de niveaux via WFC + CP | PRODUCTION | Oui |
+| 10 | App-1b : Le problème des N-Reines — Jumeau C# | PRODUCTION | Oui |
+| 11 | App-2 : Coloration de Graphes | PRODUCTION | Oui |
+| 12 | App-20 — Benchmark comparatif des solveurs Sudoku Pytho | PRODUCTION | Oui |
+| 13 | App-20b : Benchmark compare des solveurs Sudoku (jumeau | PRODUCTION | Oui |
+| 14 | App-2b : Coloration de graphes — Jumeau C# | PRODUCTION | Oui |
+| 15 | App-3 : Nurse Scheduling (Planification des horaires in | PRODUCTION | Oui |
+| 16 | App-3b : Nurse Scheduling — Twin C# (planification de g | PRODUCTION | Oui |
+| 17 | App-4 : Job-Shop Scheduling | PRODUCTION | Oui |
+| 18 | App-4b : Job-Shop Scheduling — Twin C# (ordonnancement  | PRODUCTION | Oui |
+| 19 | App-5 : Emploi du temps universitaire — Twin C# (Univer | PRODUCTION | Oui |
+| 20 | App-5 : Emploi du temps universitaire (University Timet | PRODUCTION | Oui |
+| 21 | App-6 - Demineur (C#) : CSP, probabilites et NP-complet | BETA | Oui |
+| 22 | App-6 - Demineur : CSP, Probabilites et NP-completude | PRODUCTION | Oui |
+| 23 | App-7 : Wordle Solver -- CSP et théorie de l'informatio | PRODUCTION | Oui |
+| 24 | App-7b : Solveur Wordle -- CSP et théorie de l'informat | PRODUCTION | Oui |
+| 25 | App-8 : Modelisation declarative par contraintes (twin  | BETA | Oui |
+| 26 | App-8-MiniZinc : Modelisation declarative par contraint | PRODUCTION | Oui |
+| 27 | App-10 : Optimisation de portefeuille par algorithme gé | PRODUCTION | Oui |
+| 28 | App-10b : Optimisation de portefeuille par algorithme g | BETA | Oui |
+| 29 | App-13 : Le Problème du Voyageur de Commerce (TSP) | PRODUCTION | Oui |
+| 30 | App-13b : TSP (Voyageur de Commerce) — Jumeau C# | PRODUCTION | Oui |
+| 31 | App-17 : Vehicle Routing Problem (VRP) | PRODUCTION | Oui |
+| 32 | App-17b : Vehicle Routing Problem (VRP) — Twin C# (méta | PRODUCTION | Oui |
+| 33 | App-18: Optimisation d'Hyperparametres - Approches Hybr | PRODUCTION | Oui |
+| 34 | App-18b : Optimisation d'Hyperparametres - Jumeau C# | PRODUCTION | Oui |
+| 35 | App-9 : Detection de bords par algorithmes génétiques | PRODUCTION | Oui |
+| 36 | TP : Conception d'Algorithmes Génétiques avec GeneticSh | PRODUCTION | Oui |
+| 37 | App-12 (C#) : Puissance 4 -- Comparaison d'algorithmes  | PRODUCTION | Oui |
+| 38 | App-12 : Puissance 4 -- Comparaison d'algorithmes IA (B | PRODUCTION | Oui |
+| 39 | App-14-ConnectFour-Adversarial-CSharp — Jumeau C# : rec | BETA | Oui |
+| 40 | App-14 - Connect Four : Benchmark Adversarial Search | PRODUCTION | Oui |
 
-## Search/Part1-Foundations (1 notebooks)
+## Search/Part1-Foundations (29 notebooks)
 
 | # | Notebook | Maturite | Executable |
 |---|----------|----------|------------|
-| 1 | Search-4-LocalSearch : Recherche Locale et Metaheuristi | BETA | Oui |
+| 1 | Search-1 : Espaces d'etats et formalisation de probleme | BETA | Oui |
+| 2 | Search-1 : Espaces d'etats et formulation de problemes | PRODUCTION | Oui |
+| 3 | Search-10 (C#) : Automates Finis Classiques — jumeau .N | PRODUCTION | Oui |
+| 4 | Search-10 : Automates Symboliques avec Z3 | PRODUCTION | Oui |
+| 5 | Search-11 (C#) : Métaheuristiques — Optimisation par es | PRODUCTION | Oui |
+| 6 | Search-11-métaheuristiques : Optimisation avec MEALPy | PRODUCTION | Oui |
+| 7 | Search-11b (Part 2) : Particle Swarm Optimization (C# / | PRODUCTION | Oui |
+| 8 | Search-11b-Métaheuristiques-Deep-Part3 : Artificial Bee | BETA | Oui |
+| 9 | Search-11b-Métaheuristiques-Deep-Part4 : Benchmark Comp | BETA | Oui |
+| 10 | Search-11b : Métaheuristiques d'optimisation (C# / .NET | PRODUCTION | Oui |
+| 11 | Search-15 : Théorie des Graphes avec NetworkX (C#) | BETA | Oui |
+| 12 | Search-15-NetworkX : Algorithmes de Graphe avec Network | PRODUCTION | Oui |
+| 13 | Search-16-QuikGraph : bibliotheque de graphes pour .NET | PRODUCTION | Oui |
+| 14 | Search-2-Uninformed (C#) : Algorithmes de Recherche Non | PRODUCTION | Oui |
+| 15 | Search-2-Uninformed : Algorithmes de Recherche Non Info | PRODUCTION | Oui |
+| 16 | Search-3-Informed (C#) : Recherche Informée | PRODUCTION | Oui |
+| 17 | Search-3-Informed : Algorithmes de Recherche Informée | PRODUCTION | Oui |
+| 18 | Search-4-LocalSearch (C#) : Recherche Locale et Métaheu | BETA | Oui |
+| 19 | Search-4-LocalSearch : Recherche Locale et métaheuristi | PRODUCTION | Oui |
+| 20 | Search-5-GeneticAlgorithms-Csharp : Algorithmes Génétiq | PRODUCTION | Oui |
+| 21 | Search-5 : Algorithmes génétiques | PRODUCTION | Oui |
+| 22 | Search-6 — Recherche adversariale (jeux à somme nulle)  | BETA | Oui |
+| 23 | Search-6-AdversarialSearch : Recherche Adversariale | PRODUCTION | Oui |
+| 24 | Search-7-MCTS-And-Beyond (C#) : Monte Carlo Tree Search | PRODUCTION | Oui |
+| 25 | Search-7-MCTS-And-Beyond : Monte Carlo Tree Search et E | PRODUCTION | Non |
+| 26 | Search-8-DancingLinks-Csharp : L'algorithme X et Dancin | BETA | Oui |
+| 27 | Search-8-DancingLinks : L'algorithme X et Dancing Links | PRODUCTION | Oui |
+| 28 | Search-9 : Programmation Linéaire et Simplexe (C# / .NE | PRODUCTION | Oui |
+| 29 | Search-9-LinearProgramming : Programmation Lineaire et  | PRODUCTION | Oui |
 
-## Search/Part2-CSP (2 notebooks)
+## Search/Part2-CSP (18 notebooks)
 
 | # | Notebook | Maturite | Executable |
 |---|----------|----------|------------|
-| 1 | CSP-1 : Fondamentaux des CSP | PRODUCTION | Oui |
-| 2 | CSP-2 : Propagation de Contraintes et Consistance | BETA | Oui |
+| 1 | CSP-1 : Fondamentaux des CSP - Version .NET (Choco-solv | PRODUCTION | Oui |
+| 2 | CSP-1 : Fondamentaux des CSP | PRODUCTION | Oui |
+| 3 | CSP-2 : Propagation de Contraintes et Consistance - Ver | PRODUCTION | Oui |
+| 4 | CSP-2 : Propagation de Contraintes et Consistance | PRODUCTION | Oui |
+| 5 | CSP-3 : CSP Avancé — Contraintes globales et stratégies | PRODUCTION | Oui |
+| 6 | CSP-3 : CSP Avance - Contraintes globales, OR-Tools et  | PRODUCTION | Oui |
+| 7 | CSP-4-Scheduling-Csharp : Problèmes d'Ordonnancement av | PRODUCTION | Oui |
+| 8 | CSP-4-Scheduling : Problèmes d'Ordonnancement | PRODUCTION | Oui |
+| 9 | CSP-5-Optimization-Csharp : Optimisation Combinatoire a | PRODUCTION | Oui |
+| 10 | CSP-5-Optimization : Problèmes d'Optimisation Combinato | PRODUCTION | Oui |
+| 11 | CSP-6-Hybridation : Approches Hybrides Modernes (.NET / | PRODUCTION | Non |
+| 12 | CSP-6-Hybridation : Approches Hybrides Modernes | PRODUCTION | Non |
+| 13 | CSP-7 : Contraintes Souples avec Choco-solver | PRODUCTION | Oui |
+| 14 | CSP-7 : Contraintes Souples - Soft CSP | PRODUCTION | Non |
+| 15 | CSP-8 : Temporels - Raisonnement sur le Temps | PRODUCTION | Oui |
+| 16 | CSP-8 : Temporels - Raisonnement sur le Temps | PRODUCTION | Non |
+| 17 | CSP-9-Distributed : CSP Distribués (DisCSP)**Navigation | PRODUCTION | Oui |
+| 18 | CSP-9-Distributed : CSP Distribués (DisCSP) | PRODUCTION | Oui |
 
-## Sudoku (8 notebooks)
+## Search/Part3-Advanced (6 notebooks)
 
 | # | Notebook | Maturite | Executable |
 |---|----------|----------|------------|
-| 1 | Notebook 11: Résolution de Sudoku avec Choco Constraint | PRODUCTION | Oui |
-| 2 | Sudoku-12-Z3-Python : Z3 SMT Solver (Python) | BETA | Oui |
-| 3 | Sudoku-13 : Automates avec BDD/MDD - Approche Pure | BETA | Oui |
-| 4 | Sudoku-15-Infer-Python : Résolution Probabiliste avec N | BETA | Oui |
-| 5 | Sudoku-Python-Genetic : Algorithme Genetique (Python) | BETA | Oui |
-| 6 | Sudoku-5 : Particle Swarm Optimization (Python) | BETA | Oui |
-| 7 | Sudoku-6 : Résolution par CSP Academique (Python) | BETA | Oui |
-| 8 | Sudoku-9-GraphColoring-Python : Coloration de Graphe (P | BETA | Oui |
+| 1 | Search-12 (C#) — Bases de données de motifs (Pattern Da | BETA | Oui |
+| 2 | Search-12 — Bases de données de motifs (Pattern Databas | BETA | Oui |
+| 3 | Search-13 (C#) — Recherche à écart limité (Limited Disc | PRODUCTION | Oui |
+| 4 | Search-13 — Recherche à écart limité (Limited Discrepan | BETA | Oui |
+| 5 | Search-14 (C#) — Weighted A\* : recherche à sous-optima | PRODUCTION | Oui |
+| 6 | Search-14 — Weighted A\* : recherche à sous-optimalité  | BETA | Oui |
+
+## Search/Part4-Metaheuristics (19 notebooks)
+
+| # | Notebook | Maturite | Executable |
+|---|----------|----------|------------|
+| 1 | MGS-1 : Introduction a MetaGeneticSharp et au moteur au | PRODUCTION | Oui |
+| 2 | MGS-10 : Le test du biais central — un optimiseur « san | BETA | Oui |
+| 3 | MGS-11 : Synergie d'iles complementaires -- exploration | PRODUCTION | Oui |
+| 4 | MGS-12 : Le test de l'alignement d'axes -- un optimiseu | BETA | Oui |
+| 5 | MGS-13 — Visualiser les paysages dé-biaisés : pourquoi  | BETA | Oui |
+| 6 | MGS-14 — Trouver une synergie (et dire quand il n'y en  | BETA | Oui |
+| 7 | MGS-15 : Analyse de paysage -- la corrélation fitness-d | BETA | Oui |
+| 8 | MGS-16-AlgorithmSelection : Sélectionner le bon optimis | BETA | Oui |
+| 9 | MGS-17 — Contrôle de paramètres (Parameter Control) | PRODUCTION | Oui |
+| 10 | MGS-18 — Banc CEC consolide : la combinaison des deux b | BETA | Oui |
+| 11 | MGS-19 — Recuit simulé décomposé : l'opérateur de Metro | PRODUCTION | Oui |
+| 12 | MGS-2 : Composition de métaheuristiques -- Match et pri | BETA | Oui |
+| 13 | MGS-3 : L'Eukaryote -- sous-populations et chromosomes  | PRODUCTION | Oui |
+| 14 | MGS-4 : Le Modèle Insulaire -- populations structurees  | PRODUCTION | Oui |
+| 15 | MGS-5 : Construire les métaheuristiques composées — des | BETA | Oui |
+| 16 | MGS-6 : Benchmarks comparatifs -- l'argument primitives | BETA | Oui |
+| 17 | MGS-7 : TSP combinatoire -- la grammaire de composition | BETA | Oui |
+| 18 | MGS-8 : Fitness Landscape Explorer -- voir la surface p | PRODUCTION | Oui |
+| 19 | MGS-9 - Trouver l'Everest : relief reel et bassins d'at | PRODUCTION | Oui |
+
+## Sudoku (35 notebooks)
+
+| # | Notebook | Maturite | Executable |
+|---|----------|----------|------------|
+| 1 | Sudoku-0 : Environnement et Classes de Base (C#) | PRODUCTION | Oui |
+| 2 | Sudoku-1 : Résolution par Backtracking | PRODUCTION | Oui |
+| 3 | Sudoku-1 : Resolution par Backtracking (Python) | PRODUCTION | Oui |
+| 4 | Sudoku-10 : Résolution avec OR-Tools (C#) | PRODUCTION | Oui |
+| 5 | Sudoku-10-ORTools-Python : OR-Tools CP-SAT (Python) | BETA | Oui |
+| 6 | Notebook 11: Résolution de Sudoku avec Choco Constraint | PRODUCTION | Oui |
+| 7 | Sudoku-12 : Résolution avec Z3 SMT Solver (C#) | BETA | Oui |
+| 8 | Sudoku-12-Z3-Python : Z3 SMT Solver (Python) | PRODUCTION | Oui |
+| 9 | Sudoku-13 : Le Sudoku comme Regex Symbolique - l'échell | PRODUCTION | Oui |
+| 10 | Sudoku-13 : Le Sudoku comme Regex Symbolique — twin Pyt | PRODUCTION | Oui |
+| 11 | Sudoku-14 : Automates avec BDD/MDD - Approche Pure | PRODUCTION | Oui |
+| 12 | Sudoku-14 : Automates avec BDD/MDD - Approche Pure (Pyt | PRODUCTION | Oui |
+| 13 | Résolution de Sudoku avec Infer.NET | PRODUCTION | Oui |
+| 14 | Sudoku-15-Infer-Python : Resolution Probabiliste avec N | PRODUCTION | Oui |
+| 15 | Sudoku-16 : Résolution par Réseaux de Neurones | PRODUCTION | Non |
+| 16 | Notebook 17: Resolution de Sudoku avec Large Language M | BETA | Non |
+| 17 | Comparaison des Solveurs de Sudoku | BETA | Oui |
+| 18 | Comparaison des Solveurs de Sudoku | PRODUCTION | Oui |
+| 19 | Sudoku-7b — Soundness de la propagation de contraintes  | BETA | Oui |
+| 20 | Résolution de Sudoku avec Algorithm X et Dancing Links | PRODUCTION | Oui |
+| 21 | Sudoku-Python-DancingLinks : Dancing Links / Algorithm  | PRODUCTION | Oui |
+| 22 | Sudoku-3 : Résolution par Algorithme Génétique (C#) | PRODUCTION | Oui |
+| 23 | Sudoku-Python-Genetic : Algorithme Génétique (Python) | PRODUCTION | Oui |
+| 24 | Résolution de Sudoku par Recuit Simulé | PRODUCTION | Oui |
+| 25 | Sudoku-4 : Recuit Simule (Python) | PRODUCTION | Oui |
+| 26 | Sudoku-5 : Particle Swarm Optimization (PSO) | PRODUCTION | Oui |
+| 27 | Sudoku-5 : Particle Swarm Optimization (Python) | PRODUCTION | Oui |
+| 28 | Sudoku-6 : Résolution par CSP Académique (AIMA) | PRODUCTION | Oui |
+| 29 | Sudoku-6 : Résolution par CSP Académique (Python) | PRODUCTION | Oui |
+| 30 | Sudoku-7 : Résolution par Propagation de Contraintes (N | PRODUCTION | Oui |
+| 31 | Sudoku-7 : Résolution par Propagation de Contraintes (N | PRODUCTION | Oui |
+| 32 | Résolution de Sudoku par Stratégies Humaines | PRODUCTION | Oui |
+| 33 | Sudoku-8 : Resolution par Stratégies Humaines (Python) | PRODUCTION | Oui |
+| 34 | Notebook 9: Résolution de Sudoku par Coloration de Grap | PRODUCTION | Oui |
+| 35 | Sudoku-9 : Coloration de Graphe (Python) | PRODUCTION | Oui |

--- a/docs/curriculum/ia-symbolique.md
+++ b/docs/curriculum/ia-symbolique.md
@@ -8,124 +8,272 @@ Preuves formelles en Lean 4, logique probabiliste avec Tweety, web semantique, p
 
 | Metrique | Valeur |
 |----------|--------|
-| Notebooks | 82 |
-| PRODUCTION | 1 |
-| BETA | 29 |
-| ALPHA | 52 |
+| Notebooks | 220 |
+| PRODUCTION | 177 |
+| BETA | 42 |
+| ALPHA | 1 |
 
-## SymbolicAI (2 notebooks)
-
-| # | Notebook | Maturite | Executable |
-|---|----------|----------|------------|
-| 1 | LINQ to Z3 - Résolution de Contraintes Déclarative | ALPHA | Oui |
-| 2 | OR-Tools : Résolution du Problème du Régime de Stigler | ALPHA | Oui |
-
-## SymbolicAI/Argument_Analysis (4 notebooks)
+## SymbolicAI (1 notebooks)
 
 | # | Notebook | Maturite | Executable |
 |---|----------|----------|------------|
-| 1 | 🧠 Notebook d'Analyse Rhétorique Collaborative par Agent | ALPHA | Non |
-| 2 | 🚀 Analyse Rhétorique Collaborative par Agents IA - Exéc | BETA | Oui |
-| 3 | Interface de Configuration et Préparation du Texte | BETA | Oui |
-| 4 | 🚀 Analyse Rhétorique Collaborative par Agents IA - Exéc | ALPHA | Oui |
+| 1 | Configuration de l'environnement C# | BETA | Oui |
 
-## SymbolicAI/Lean (11 notebooks)
+## SymbolicAI/Argument_Analysis (22 notebooks)
 
 | # | Notebook | Maturite | Executable |
 |---|----------|----------|------------|
-| 1 | Lean 4 - Installation et Configuration | BETA | Non |
-| 2 | Lean 10 : LeanDojo - ML/LLM Theorem Proving | ALPHA | Non |
-| 3 | Lean 2 - Types Dependants et Calcul des Constructions | BETA | Oui |
-| 4 | Lean 3 - Propositions et Preuves | BETA | Oui |
-| 5 | Lean 4 - Quantificateurs et Logique du Premier Ordre | ALPHA | Oui |
-| 6 | Lean 5 - Mode Tactique | BETA | Oui |
-| 7 | Lean 6 - Mathlib4 : La Bibliotheque Mathematique | BETA | Oui |
-| 8 | Lean 7 - Integration des LLMs pour l'Assistance aux Pre | ALPHA | Non |
-| 9 | Lean 7b - Exemples Progressifs et Benchmarks | ALPHA | Non |
-| 10 | Lean 8 - Agents Autonomes pour Demonstration de Theorem | ALPHA | Non |
-| 11 | Description du notebook | ALPHA | Non |
+| 1 | Argument_Analysis_Agentic-0-init : configuration de l'e | PRODUCTION | Oui |
+| 2 | Introduction : Analyse Rhetorique Collaborative par Age | PRODUCTION | Non |
+| 3 | Argument_Analysis_Agentic-1-informal : Detection de sop | PRODUCTION | Oui |
+| 4 | Introduction : Agent InformalAnalysisAgent (Definitions | PRODUCTION | Non |
+| 5 | Argument_Analysis_Agentic-2-formal : Verification Logiq | PRODUCTION | Oui |
+| 6 | 6. Agent : PropositionalLogicAgent (Definitions) | PRODUCTION | Oui |
+| 7 | Argument_Analysis_Agentic-3-orchestration : deux paradi | PRODUCTION | Oui |
+| 8 | Introduction : Orchestration de la Conversation Multi-A | ALPHA | Non |
+| 9 | Argument_Analysis_Agentic-4-capstone : capstone d'integ | PRODUCTION | Oui |
+| 10 | Argument_Analysis_Agentic-5-jtms : Truth Maintenance Sy | PRODUCTION | Oui |
+| 11 | ArgumentProfile : la fiche d'identite multidimensionnel | PRODUCTION | Oui |
+| 12 | Argumentation abstraite de Dung — sémantiques grounded, | PRODUCTION | Oui |
+| 13 | 🚀 Analyse Rhétorique Collaborative par Agents IA - Exéc | PRODUCTION | Non |
+| 14 | Matrice de richesse formelle — évaluer honnêtement ce q | BETA | Oui |
+| 15 | Routage multi-backend : decider ou echouer bruyamment | BETA | Oui |
+| 16 | Ontologie AIF.owl -- l'architecture Argumentum des soph | BETA | Oui |
+| 17 | Argument_Analysis_Ontology_CrossLinks.ipynb — PR-B #496 | PRODUCTION | Oui |
+| 18 | Ontologie des vertus argumentatives -- le pole miroir d | PRODUCTION | Oui |
+| 19 | Argumentation graduée — sémantiques de classement (h-Ca | BETA | Oui |
+| 20 | Restitution en 3 actes — scaffold déterministe, narrati | BETA | Non |
+| 21 | Interface de Configuration et Préparation du Texte | PRODUCTION | Oui |
+| 22 | I2 - Génération de contre-arguments par raisonnement fo | PRODUCTION | Oui |
 
-## SymbolicAI/Planners (13 notebooks)
-
-| # | Notebook | Maturite | Executable |
-|---|----------|----------|------------|
-| 1 | Planners-0-Setup | BETA | Oui |
-| 2 | Planners-1-Introduction a la Planification Automatique | ALPHA | Oui |
-| 3 | Planners-2-PDDL-Basics | BETA | Oui |
-| 4 | Planners-3-State-Space - Recherche dans l'Espace d'Etat | ALPHA | Oui |
-| 5 | Planners-4-Fast-Downward - Planificateur Classique | ALPHA | Oui |
-| 6 | Planners-5-Heuristiques en Planification | ALPHA | Oui |
-| 7 | Planners-6-Domains - Domaines Classiques de Planificati | ALPHA | Oui |
-| 8 | Planners-7-OR-Tools - Programmation par Contraintes | ALPHA | Oui |
-| 9 | Planners-8-Temporal - Planification Temporelle | ALPHA | Oui |
-| 10 | Planners-9-HTN - Planification Hierarchique | ALPHA | Oui |
-| 11 | Planners-10: LLMs pour la Planification | ALPHA | Non |
-| 12 | Planners-11: Unified Planning | ALPHA | Oui |
-| 13 | Planners-12: Learning to Plan avec LOOP | ALPHA | Non |
-
-## SymbolicAI/SemanticWeb (16 notebooks)
+## SymbolicAI/Lean (28 notebooks)
 
 | # | Notebook | Maturite | Executable |
 |---|----------|----------|------------|
-| 1 | SW-1-Setup | BETA | Oui |
-| 2 | SW-11-RDFStar | ALPHA | Oui |
-| 3 | SW-12-KnowledgeGraphs | ALPHA | Oui |
-| 4 | SW-13-GraphRAG | ALPHA | Non |
-| 5 | SW-2-RDFBasics | BETA | Oui |
-| 6 | SW-2b-Python-RDFBasics | BETA | Oui |
-| 7 | SW-3-GraphOperations | ALPHA | Oui |
-| 8 | SW-4-SPARQL | ALPHA | Oui |
-| 9 | SW-4b-Python-SPARQL | ALPHA | Oui |
-| 10 | SW-5-LinkedData | ALPHA | Non |
-| 11 | SW-5b-Python-LinkedData | BETA | Non |
-| 12 | SW-6-RDFS | BETA | Oui |
-| 13 | SW-7-OWL | BETA | Oui |
-| 14 | SW-7b-Python-OWL | BETA | Oui |
-| 15 | SW-9-SHACL | ALPHA | Oui |
-| 16 | SW-10-JSONLD | ALPHA | Oui |
+| 1 | Lean 4 - Installation et Configuration | PRODUCTION | Non |
+| 2 | Lean 10 : LeanDojo - ML/LLM Theorem Proving | PRODUCTION | Non |
+| 3 | Lean 11a - TorchLean : Implémentation Python des Réseau | PRODUCTION | Non |
+| 4 | Lean 11 - TorchLean : Réseaux de Neurones Formellement  | PRODUCTION | Non |
+| 5 | Lean-12 : Le Theoreme de Sensibilite (Huang 2019) | PRODUCTION | Non |
+| 6 | Lean-12b — Théorème de Sensibilité de Huang (companion  | BETA | Non |
+| 7 | Lean-13 : Le Theoreme de Kochen-Specker (Cabello 18 vec | PRODUCTION | Non |
+| 8 | Lean-14 — Dérivées symboliques de Brzozowski : la finit | BETA | Non |
+| 9 | Lean-15 : Hommage a Alexandre Grothendieck -- Le langag | PRODUCTION | Non |
+| 10 | Lean-15b : Grothendieck en Lean -- Atelier pratique | PRODUCTION | Non |
+| 11 | Lean-16a - Conway, l'homme et l'oeuvre | PRODUCTION | Non |
+| 12 | Lean-16b : Hommage a John Conway — Game of Life as Comp | PRODUCTION | Non |
+| 13 | Lean-16c - Conway Game of Life : les 3 piliers, en imag | PRODUCTION | Non |
+| 14 | Lean-16d : Game of Life sur kernel Lean natif | BETA | Non |
+| 15 | Lean-16e : FRACTRAN, la machine universelle de Conway,  | BETA | Non |
+| 16 | Lean-16f : Le Theoreme du Libre Arbitre (Conway-Kochen) | PRODUCTION | Non |
+| 17 | Lean 17a — Conway, les Nœuds et la Preuve de Piccirillo | BETA | Non |
+| 18 | Lean 17b — Invariants de Nœuds : Calcul et Vérification | PRODUCTION | Non |
+| 19 | Lean-18 : A* et l'optimalité sous heuristique admissibl | PRODUCTION | Non |
+| 20 | Lean 2 - Types Dependants et Calcul des Constructions | PRODUCTION | Non |
+| 21 | Lean 3 - Propositions et Preuves | PRODUCTION | Non |
+| 22 | Lean 4 - Quantificateurs et Logique du Premier Ordre | PRODUCTION | Non |
+| 23 | Lean 5 - Mode Tactique | PRODUCTION | Non |
+| 24 | Lean 6 - Mathlib4 : La Bibliotheque Mathematique | PRODUCTION | Non |
+| 25 | Lean 7 - Integration des LLMs pour l'Assistance aux Pre | PRODUCTION | Non |
+| 26 | Lean 7b - Exemples Progressifs et Benchmarks | PRODUCTION | Non |
+| 27 | Lean 8 - Agents Autonomes pour Demonstration de Theorem | PRODUCTION | Non |
+| 28 | Lean 9 : Multi-Agents avec Semantic Kernel | PRODUCTION | Non |
 
-## SymbolicAI/SmartContracts (26 notebooks)
-
-| # | Notebook | Maturite | Executable |
-|---|----------|----------|------------|
-| 1 | SC-0-Cypherpunk-Origins - Les origines Cypherpunk de la | ALPHA | Oui |
-| 2 | SC-1-Setup-Foundry - Environnement Smart Contracts | BETA | Oui |
-| 3 | SC-2-Setup-Web3py - Python et la Blockchain | ALPHA | Oui |
-| 4 | SC-3-Solidity-Basics - Fondements de Solidity | BETA | Oui |
-| 5 | SC-4-Functions-State - Fonctions et Etat | BETA | Oui |
-| 6 | SC-5-Inheritance - Heritage et Interfaces | BETA | Oui |
-| 7 | SC-6-Errors-Events - Erreurs et Evenements | ALPHA | Oui |
-| 8 | SC-10-Account-Abstraction - ERC-4337 | BETA | Oui |
-| 9 | SC-11-LLM-Assisted - Developpement Smart Contracts Assi | ALPHA | Non |
-| 10 | SC-7-Token-Standards - Standards de Tokens | ALPHA | Oui |
-| 11 | SC-8-DeFi-Primitives - Primitives DeFi | ALPHA | Oui |
-| 12 | SC-12-Foundry-Testing - Tests avec Foundry | BETA | Non |
-| 13 | SC-13-Fuzz-Invariants - Fuzz Testing | BETA | Oui |
-| 14 | SC-14-Formal-Verification - Verification Formelle | BETA | Non |
-| 15 | SC-15-Zero-Knowledge-Proofs - Preuves a Divulgation Nul | ALPHA | Oui |
-| 16 | SC-16-Homomorphic-Encryption - Chiffrement Homomorphiqu | ALPHA | Oui |
-| 17 | SC-17-E2E-Verifiable-Voting - Vote Electronique Verifia | ALPHA | Oui |
-| 18 | SC-18-Vyper - Smart Contracts en Python-like | ALPHA | Oui |
-| 19 | SC-19-Ripple-XRP - Protocole Ripple et XRP Ledger | ALPHA | Oui |
-| 20 | SC-20-Bitcoin-Scripting - Bitcoin, UTXO et Scripts | BETA | Non |
-| 21 | SC-21-Move-Sui - Move sur Sui | BETA | Oui |
-| 22 | SC-22-Solana-Anchor - Solana avec Anchor | BETA | Oui |
-| 23 | SC-23-Cross-Chain - Interoperabilite Cross-Chain | BETA | Oui |
-| 24 | SC-24 : Deploiement sur Testnets | ALPHA | Oui |
-| 25 | SC-25 : Deploiement Mainnet (L2) | ALPHA | Oui |
-| 26 | SC-26 : Projet Final - DApp Complete | ALPHA | Oui |
-
-## SymbolicAI/Tweety (10 notebooks)
+## SymbolicAI/Planners (23 notebooks)
 
 | # | Notebook | Maturite | Executable |
 |---|----------|----------|------------|
-| 1 | Configuration et Installation TweetyProject | BETA | Oui |
-| 2 | Logiques de Base - Propositionnelle et Premier Ordre | ALPHA | Oui |
-| 3 | Logiques Avancées - DL, Modale, QBF, Conditional | ALPHA | Oui |
-| 4 | Révision de Croyances et Incohérence | ALPHA | Oui |
-| 5 | Argumentation Abstraite (Dung) | PRODUCTION | Oui |
-| 6 | Argumentation Structuree | ALPHA | Oui |
-| 7 | Frameworks d'Argumentation Étendus | ALPHA | Oui |
-| 8 | Sémantiques de Classement et Argumentation Probabiliste | ALPHA | Oui |
-| 9 | Dialogues Multi-Agents Argumentatifs | ALPHA | Oui |
-| 10 | Préférences et Théorie du Vote | ALPHA | Oui |
+| 1 | Planners-0-Setup | PRODUCTION | Oui |
+| 2 | Planners-1-Introduction-Csharp : la planification autom | PRODUCTION | Oui |
+| 3 | Planners-1-Introduction a la Planification Automatique | PRODUCTION | Oui |
+| 4 | Planners-2-PDDL-Basics-Csharp | PRODUCTION | Oui |
+| 5 | Planners-2-PDDL-Basics | PRODUCTION | Oui |
+| 6 | Planners-3 : Recherche dans l'Espace d'Etats — twin C#  | PRODUCTION | Oui |
+| 7 | Planners-3-State-Space - Recherche dans l'Espace d'Etat | PRODUCTION | Oui |
+| 8 | Planners-4-Fast-Downward (C#) | PRODUCTION | Oui |
+| 9 | Planners-4-Fast-Downward - Planificateur Classique | PRODUCTION | Oui |
+| 10 | Planners-5-Heuristics-Csharp | PRODUCTION | Oui |
+| 11 | Planners-5-Heuristiques en Planification | PRODUCTION | Oui |
+| 12 | Planners-5b — Admissibilité de la relaxation sans-delet | BETA | Non |
+| 13 | Planners-6-Domains-Csharp — Jumeau C# : planificateur S | PRODUCTION | Oui |
+| 14 | Planners-6-Domains - Domaines Classiques de Planificati | PRODUCTION | Oui |
+| 15 | Planners-7-OR-Tools-Csharp — Jumeau C# : solveur CP fro | PRODUCTION | Oui |
+| 16 | Planners-7-OR-Tools - Programmation par Contraintes | PRODUCTION | Oui |
+| 17 | Planners-8-Temporal — Planification Temporelle (twin C# | PRODUCTION | Oui |
+| 18 | Planners-8-Temporal - Planification Temporelle | PRODUCTION | Oui |
+| 19 | Planners-9-HTN (C#) | BETA | Oui |
+| 20 | Planners-9-HTN - Planification Hiérarchique | PRODUCTION | Oui |
+| 21 | Planners-10: LLMs pour la Planification | PRODUCTION | Non |
+| 22 | Planners-11: Unified Planning | PRODUCTION | Oui |
+| 23 | Planners-12: Learning to Plan avec LOOP | PRODUCTION | Non |
+
+## SymbolicAI/SMT (42 notebooks)
+
+| # | Notebook | Maturite | Executable |
+|---|----------|----------|------------|
+| 1 | Z3 (C# / .NET) — Introduction au solveur SMT | PRODUCTION | Oui |
+| 2 | Z3-Python 01 — Introduction a la resolution de contrain | PRODUCTION | Oui |
+| 3 | Z3 (C# / .NET) — Sudoku par contraintes | PRODUCTION | Oui |
+| 4 | Z3-Python 02 — Sudoku comme problème de satisfaction de | PRODUCTION | Oui |
+| 5 | Z3 (C# / .NET) — Tactiques, théories BitVec et Array | BETA | Oui |
+| 6 | Z3-Python 03 — Tactiques et théories | PRODUCTION | Oui |
+| 7 | Z3 (C# / .NET) — Théorie des chaînes et expressions reg | BETA | Oui |
+| 8 | Z3-Python 04 — Chaînes de caractères et expressions reg | PRODUCTION | Oui |
+| 9 | Z3 (C# / .NET) — Quantificateurs et preuves par refutat | BETA | Oui |
+| 10 | Z3-Python 05 — Quantificateurs et preuves formelles | PRODUCTION | Oui |
+| 11 | Z3-Python 06 -- Optimisation avancee (twin C#) | PRODUCTION | Oui |
+| 12 | Z3-Python 06 — Optimisation avancee | PRODUCTION | Oui |
+| 13 | Z3-Python 07 — Du style declaratif LINQ au solveur Z3 e | PRODUCTION | Oui |
+| 14 | Z3-Python-08 : Ordonnancement de tâches (Job-Shop Sched | PRODUCTION | Oui |
+| 15 | Z3-Python-09 : L'enigme d'Einstein (Zebra puzzle) | BETA | Oui |
+| 16 | 10. Cryptarithmes (SEND + MORE = MONEY) | BETA | Oui |
+| 17 | 11. Coloration de graphe : le graphe de Petersen | BETA | Oui |
+| 18 | 12. Arithmetique reelle : raisonner sur les irrationnel | BETA | Oui |
+| 19 | 13. UNSAT cores : expliquer l'insatisfiabilite (le ' po | BETA | Oui |
+| 20 | 14. Bit-vectors : verifier le debordement arithmetique | BETA | Oui |
+| 21 | 15. Tableaux imbriqués et grilles 2D : carrés latins, S | PRODUCTION | Oui |
+| 22 | 16. Meal-Planner déclaratif : du modèle Z3 au plan hebd | BETA | Oui |
+| 23 | Z3-Python 17 — Théorie des tableaux : Select, Store et  | PRODUCTION | Oui |
+| 24 | Z3-Python 18 — Sudoku 4x4 : comparaison des modes `Arra | PRODUCTION | Oui |
+| 25 | LINQ to Z3 - Résolution de Contraintes Déclarative | BETA | Oui |
+| 26 | Sudoku : Théorème Explicite vs Modèle Implicite par Arr | PRODUCTION | Oui |
+| 27 | Sudoku 4x4 : comparaison des modes `Array` et `Constant | BETA | Oui |
+| 28 | Théorie des Tableaux Z3 — Select, Store et Switching | PRODUCTION | Oui |
+| 29 | Tableaux Imbriqués et Grilles 2D : API Déclarative `The | PRODUCTION | Oui |
+| 30 | Notebook 06 — Meal-Planner declaratif : du modèle Z3 au | BETA | Oui |
+| 31 | 07 — Données réelles & externe : Ciqual × RecipeML (cou | PRODUCTION | Oui |
+| 32 | 08 — Capstone hiérarchique : du squelette `int[][]` rée | BETA | Oui |
+| 33 | 09 — Convergence à l'échelle : l'encodage décide de la  | PRODUCTION | Oui |
+| 34 | 10 — Générer un témoin depuis `A & ~B` (fork Automata v | PRODUCTION | Oui |
+| 35 | Notebook 11 — Ordonnancement d'atelier (Job Shop Schedu | PRODUCTION | Oui |
+| 36 | Notebook 12 - Coloration de graphe : le graphe de Peter | PRODUCTION | Oui |
+| 37 | Notebook 13 — Cryptarithmes : l'arithmétique positionne | PRODUCTION | Oui |
+| 38 | Notebook 14 — De SAT à OPT : optimisation et contrainte | PRODUCTION | Oui |
+| 39 | 15 — Théorie des bit-vectors Z3 : vérifier le débordeme | BETA | Oui |
+| 40 | 16 — Arithmétique réelle Z3 : raisonner sur les irratio | BETA | Oui |
+| 41 | 17 — UNSAT cores Z3 : expliquer l'insatisfiabilité (le  | BETA | Oui |
+| 42 | Notebook 18 - L'enigme d'Einstein : la logique des attr | PRODUCTION | Oui |
+
+## SymbolicAI/SemanticWeb (25 notebooks)
+
+| # | Notebook | Maturite | Executable |
+|---|----------|----------|------------|
+| 1 | Introduction au web sémantique avec RDF.Net | PRODUCTION | Non |
+| 2 | SW-1-Setup | PRODUCTION | Oui |
+| 3 | SW-10-CSharp-RDFStar — Jumeau C# : annoter des triplets | PRODUCTION | Oui |
+| 4 | SW-10-Python-RDFStar | PRODUCTION | Oui |
+| 5 | SW-11-CSharp-KnowledgeGraphs | BETA | Oui |
+| 6 | SW-11-Python-KnowledgeGraphs | PRODUCTION | Oui |
+| 7 | SW-12-Python-GraphRAG | PRODUCTION | Non |
+| 8 | SW-13-Reasoners | PRODUCTION | Oui |
+| 9 | SW-13 (C#) : Raisonneurs RDF/OWL — Inferer des connaiss | BETA | Oui |
+| 10 | SW-2-RDFBasics | PRODUCTION | Oui |
+| 11 | SW-2b-Python-RDFBasics | PRODUCTION | Oui |
+| 12 | SW-3-GraphOperations | PRODUCTION | Oui |
+| 13 | SW-3b-Python-GraphOperations | PRODUCTION | Oui |
+| 14 | SW-4-SPARQL | PRODUCTION | Oui |
+| 15 | SW-4b-Python-SPARQL | PRODUCTION | Oui |
+| 16 | SW-5-LinkedData | PRODUCTION | Non |
+| 17 | SW-5b-Python-LinkedData | PRODUCTION | Non |
+| 18 | SW-6-RDFS | PRODUCTION | Oui |
+| 19 | SW-6b-Python-RDFS | PRODUCTION | Oui |
+| 20 | SW-7-OWL | PRODUCTION | Oui |
+| 21 | SW-7b-Python-OWL | PRODUCTION | Non |
+| 22 | SW-8-CSharp-SHACL | PRODUCTION | Oui |
+| 23 | SW-8-Python-SHACL | PRODUCTION | Oui |
+| 24 | SW-9-CSharp-JSONLD — JSON-LD avec dotNetRDF (twin C#) | PRODUCTION | Oui |
+| 25 | SW-9-Python-JSONLD | PRODUCTION | Oui |
+
+## SymbolicAI/SmartContracts (27 notebooks)
+
+| # | Notebook | Maturite | Executable |
+|---|----------|----------|------------|
+| 1 | SC-0-Cypherpunk-Origins - Les origines Cypherpunk de la | PRODUCTION | Oui |
+| 2 | SC-1-Setup-Foundry - Environnement Smart Contracts | PRODUCTION | Oui |
+| 3 | SC-2-Setup-Web3py - Python et la Blockchain | PRODUCTION | Oui |
+| 4 | SC-3-Solidity-Basics - Fondements de Solidity | PRODUCTION | Oui |
+| 5 | SC-4-Functions-State - Fonctions et Etat | PRODUCTION | Oui |
+| 6 | SC-5-Inheritance - Heritage et Interfaces | PRODUCTION | Oui |
+| 7 | SC-6-Errors-Events - Erreurs et Événements | PRODUCTION | Oui |
+| 8 | SC-10-Account-Abstraction - ERC-4337 | PRODUCTION | Oui |
+| 9 | SC-11-LLM-Assisted - Développement Smart Contracts Assi | PRODUCTION | Non |
+| 10 | SC-7-Token-Standards - Standards de Tokens | PRODUCTION | Oui |
+| 11 | SC-8-DeFi-Primitives - Primitives DeFi | PRODUCTION | Oui |
+| 12 | SC-9-DAO-Governance - Gouvernance DAO | PRODUCTION | Oui |
+| 13 | SC-12-Foundry-Testing - Tests avec Foundry | PRODUCTION | Non |
+| 14 | SC-13-Fuzz-Invariants - Fuzz Testing | PRODUCTION | Oui |
+| 15 | SC-14-Formal-Verification - Verification Formelle | PRODUCTION | Non |
+| 16 | SC-15-Zero-Knowledge-Proofs - Preuves a Divulgation Nul | PRODUCTION | Oui |
+| 17 | SC-16-Homomorphic-Encryption - Chiffrement Homomorphiqu | PRODUCTION | Oui |
+| 18 | SC-17-E2E-Verifiable-Voting - Vote Electronique Verifia | PRODUCTION | Oui |
+| 19 | SC-18-Vyper - Smart Contracts en Python-like | PRODUCTION | Oui |
+| 20 | SC-19-Ripple-XRP - Protocole Ripple et XRP Ledger | PRODUCTION | Oui |
+| 21 | SC-20-Bitcoin-Scripting - Bitcoin, UTXO et Scripts | PRODUCTION | Non |
+| 22 | SC-21-Move-Sui - Move sur Sui | PRODUCTION | Oui |
+| 23 | SC-22-Solana-Anchor - Solana avec Anchor | PRODUCTION | Oui |
+| 24 | SC-23-Cross-Chain - Interoperabilite Cross-Chain | PRODUCTION | Oui |
+| 25 | SC-24 : Deploiement sur Testnets | PRODUCTION | Oui |
+| 26 | SC-25 : Deploiement Mainnet (L2) | PRODUCTION | Oui |
+| 27 | SC-26 : Projet Final - DApp Complete | PRODUCTION | Oui |
+
+## SymbolicAI/SymbolicLearning (20 notebooks)
+
+| # | Notebook | Maturite | Executable |
+|---|----------|----------|------------|
+| 1 | SL-1 - Apprentissage Logique : CBH Search et Version Sp | PRODUCTION | Oui |
+| 2 | SL-1 - Apprentissage Logique : CBH Search et Version Sp | PRODUCTION | Oui |
+| 3 | SL-10 --- Apprentissage Actif d'Automates (L* d'Angluin | PRODUCTION | Oui |
+| 4 | SL-10 --- Apprentissage Actif d'Automates (L* d'Angluin | PRODUCTION | Oui |
+| 5 | SL-11 --- Capstone : un pipeline neuro-symbolique de bo | PRODUCTION | Non |
+| 6 | SL-12 : Differentiable Logic Gate Networks | PRODUCTION | Non |
+| 7 | SL-2 - Apprentissage et Connaissance : EBL & RBL (C#) | BETA | Oui |
+| 8 | SL-2 --- Apprentissage et Connaissance (EBL & RBL) | PRODUCTION | Oui |
+| 9 | SL-3 — Apprentissage basé sur la pertinence (twin C# fr | BETA | Oui |
+| 10 | SL-3 --- Apprentissage Base sur la Pertinence (RBL Appr | PRODUCTION | Oui |
+| 11 | SL-4 — Programmation Logique Inductive (ILP) — Twin C#  | PRODUCTION | Oui |
+| 12 | SL-4 --- Programmation Logique Inductive (ILP) | PRODUCTION | Non |
+| 13 | SL-5 - Resolution Inverse & ILP (C#) | BETA | Oui |
+| 14 | SL-5 --- Resolution Inverse et Progol (ILP bottom-up) | PRODUCTION | Oui |
+| 15 | SL-6 (C#) : Moteurs ILP modernes — apprendre des progra | BETA | Oui |
+| 16 | SL-6 --- Moteurs ILP modernes : Aleph, Metagol, Popper  | PRODUCTION | Non |
+| 17 | SL-7 : Integration Neuro-Symbolique | PRODUCTION | Non |
+| 18 | SL-8 (C#) : ILP Moderne et Knowledge Graphs | PRODUCTION | Oui |
+| 19 | SL-8 - ILP Moderne et Knowledge Graphs | PRODUCTION | Oui |
+| 20 | SL-9 - LLMs et Apprentissage Symbolique : Generation et | PRODUCTION | Non |
+
+## SymbolicAI/Tweety (32 notebooks)
+
+| # | Notebook | Maturite | Executable |
+|---|----------|----------|------------|
+| 1 | Configuration et Installation TweetyProject | PRODUCTION | Oui |
+| 2 | Tweety-10 — Markov Logic Networks (MLN) en .NET (C# / I | PRODUCTION | Oui |
+| 3 | Tweety-10 — Markov Logic Networks (MLN) | PRODUCTION | Oui |
+| 4 | Tweety-11 — Inférence causale & do-calculus (twin C# fr | BETA | Oui |
+| 5 | Tweety-11 — Raisonnement Causal : du do-calculus aux co | PRODUCTION | Oui |
+| 6 | Tweety C# / IKVM - Logiques de Base (Port .NET du noteb | PRODUCTION | Oui |
+| 7 | Logiques de Base - Propositionnelle et Premier Ordre | PRODUCTION | Oui |
+| 8 | Tweety C# / IKVM - Sémantique propositionnelle : mondes | PRODUCTION | Oui |
+| 9 | Tweety-2c — Logique du premier ordre en C#/.NET (port n | PRODUCTION | Oui |
+| 10 | Tweety-3 — Description Logics en C#/.NET (port natif IK | PRODUCTION | Oui |
+| 11 | Logiques Avancees - DL, Modale, QBF, Conditional | PRODUCTION | Oui |
+| 12 | Tweety-3 — Conditional Logics en C#/.NET (port natif IK | PRODUCTION | Oui |
+| 13 | Tweety-3 — Argumentation abstraite de Dung en C#/.NET ( | PRODUCTION | Oui |
+| 14 | Tweety-3 Modal Logic en C#/.NET (port natif IKVM) | PRODUCTION | Oui |
+| 15 | Tweety-3 - Quantified Boolean Formulas en C#/.NET (port | PRODUCTION | Oui |
+| 16 | Tweety-4 — Argumentation structurée ASPIC+ en C#/.NET ( | PRODUCTION | Oui |
+| 17 | Tweety C# / IKVM - Revision de Croyances (Port .NET du  | BETA | Oui |
+| 18 | Révision de Croyances et Incohérence | PRODUCTION | Oui |
+| 19 | Tweety-5 : Argumentation Abstraite de Dung (C# / .NET)  | PRODUCTION | Oui |
+| 20 | Argumentation Abstraite (Dung) | PRODUCTION | Oui |
+| 21 | Tweety-5b — Théorie de l'argumentation de Dung (compani | BETA | Non |
+| 22 | Tweety-6 — Argumentation structuree (twin C# / .NET Int | BETA | Oui |
+| 23 | Argumentation Structuree | PRODUCTION | Oui |
+| 24 | Tweety-7a : Frameworks d'Argumentation Etendus (C#) | PRODUCTION | Oui |
+| 25 | Frameworks d'Argumentation Étendus | PRODUCTION | Oui |
+| 26 | Tweety-7b - Ranking Probabilistic Conditional Logic en  | PRODUCTION | Oui |
+| 27 | Sémantiques de Classement et Argumentation Probabiliste | PRODUCTION | Oui |
+| 28 | Dialogues Multi-Agents Argumentatifs (twin C#) | PRODUCTION | Oui |
+| 29 | Dialogues Multi-Agents Argumentatifs | PRODUCTION | Oui |
+| 30 | Préférences et Théorie du Vote en C# / .NET (port natif | BETA | Oui |
+| 31 | Préférences et Théorie du Vote | PRODUCTION | Oui |
+| 32 | Tweety .NET - Probe Phase 1 axe 2 : initialisation du r | BETA | Oui |

--- a/docs/curriculum/recherche.md
+++ b/docs/curriculum/recherche.md
@@ -8,78 +8,209 @@ Inference probabiliste (Infer.NET, Pyro, PyMC), theorie de l'information integre
 
 | Metrique | Valeur |
 |----------|--------|
-| Notebooks | 51 |
-| PRODUCTION | 4 |
-| BETA | 3 |
-| ALPHA | 44 |
+| Notebooks | 157 |
+| PRODUCTION | 116 |
+| BETA | 40 |
+| ALPHA | 1 |
 
-## GameTheory (23 notebooks)
+## GameTheory (43 notebooks)
 
 | # | Notebook | Maturite | Executable |
 |---|----------|----------|------------|
-| 1 | GameTheory-1-Setup | ALPHA | Non |
-| 2 | GameTheory-10-ForwardInduction-SPE | ALPHA | Oui |
-| 3 | GameTheory-12-ReputationGames | ALPHA | Oui |
-| 4 | GameTheory-13 : Jeux a Information Imparfaite et CFR | ALPHA | Oui |
-| 5 | GameTheory-14 : Jeux Differentiels et Equilibres de Sta | ALPHA | Oui |
-| 6 | GameTheory-15-CooperativeGames | ALPHA | Non |
-| 7 | GameTheory 15b - Jeux Cooperatifs en Lean : Formalisati | ALPHA | Oui |
-| 8 | GameTheory 15c - Jeux Cooperatifs Lean (Python) | BETA | Oui |
-| 9 | GameTheory-16 : Theorie des Mecanismes et Principe de R | ALPHA | Oui |
-| 10 | GameTheory 16b - Choix Social : Arrow, Sen et l'Electeu | ALPHA | Oui |
-| 11 | GameTheory 16c - Choix Social (Python) | ALPHA | Oui |
-| 12 | GameTheory 16d - Choix Social et Solveurs SAT | ALPHA | Oui |
-| 13 | GameTheory 16e - Tour de SocialChoiceLean (DominikPeter | BETA | Oui |
-| 14 | GameTheory 16f - Choix Social et Solveurs SMT (z3) | ALPHA | Oui |
-| 15 | GameTheory-17 : Apprentissage par Renforcement Multi-Ag | ALPHA | Oui |
-| 16 | GameTheory 2b - Formalisation Lean : Definitions de Bas | BETA | Oui |
-| 17 | GameTheory-3-Topology2x2 | ALPHA | Oui |
-| 18 | GameTheory-4-NashEquilibrium | ALPHA | Oui |
-| 19 | GameTheory 4b - Theoreme d'Existence de Nash (Lean) | ALPHA | Oui |
-| 20 | GameTheory-5-ZeroSum-Minimax | ALPHA | Oui |
-| 21 | GameTheory-6-EvolutionTrust | ALPHA | Oui |
-| 22 | GameTheory-7-ExtensiveForm | ALPHA | Oui |
-| 23 | GameTheory-9-BackwardInduction | ALPHA | Oui |
+| 1 | GameTheory-1-Setup | PRODUCTION | Non |
+| 2 | GameTheory-10 — Équilibres Parfaits de Sous-Jeux et Ind | PRODUCTION | Oui |
+| 3 | GameTheory-10-ForwardInduction-SPE | PRODUCTION | Oui |
+| 4 | GameTheory-11-BayesianGames-Csharp | PRODUCTION | Oui |
+| 5 | GameTheory-11-BayesianGames | PRODUCTION | Oui |
+| 6 | GameTheory-11b — Jeux Bayésiens en Lean 4 (companion) | BETA | Non |
+| 7 | GameTheory-12 — Jeux de Réputation (twin C# du notebook | BETA | Oui |
+| 8 | GameTheory-12-ReputationGames | PRODUCTION | Oui |
+| 9 | GameTheory-13 : Jeux a Information Imparfaite et CFR (C | BETA | Oui |
+| 10 | GameTheory-13 : Jeux a Information Imparfaite et CFR | PRODUCTION | Non |
+| 11 | GameTheory-14 : Jeux Differentiels et Equilibres de Sta | PRODUCTION | Oui |
+| 12 | GameTheory-14 : Jeux Differentiels et Equilibres de Sta | PRODUCTION | Oui |
+| 13 | GameTheory-15 — Jeux Coopératifs (Twin C#) | PRODUCTION | Oui |
+| 14 | GameTheory-15-CooperativeGames | PRODUCTION | Oui |
+| 15 | GameTheory 15b - Jeux Cooperatifs en Lean : Formalisati | PRODUCTION | Non |
+| 16 | GameTheory 15c - Jeux Cooperatifs (C# / .NET) | PRODUCTION | Oui |
+| 17 | GameTheory 15c - Jeux Cooperatifs Lean (Python) | PRODUCTION | Oui |
+| 18 | GameTheory-16-MechanismDesign (C#) | BETA | Oui |
+| 19 | GameTheory-16 : Théorie des Mécanismes et Principe de R | PRODUCTION | Oui |
+| 20 | GameTheory-17 (C#) : Multi-Agent Reinforcement Learning | BETA | Oui |
+| 21 | GameTheory-17 : Apprentissage par Renforcement Multi-Ag | PRODUCTION | Oui |
+| 22 | GameTheory-2 (Part 2) : Support Enumeration — Équilibre | PRODUCTION | Oui |
+| 23 | GameTheory-2 : Jeux sous forme normale (C# / .NET) — Tr | PRODUCTION | Oui |
+| 24 | GameTheory-2-NormalForm | PRODUCTION | Oui |
+| 25 | GameTheory 2b - Formalisation Lean : Definitions de Bas | PRODUCTION | Non |
+| 26 | GameTheory-3 : Topologie des Jeux 2×2 — Twin C# (classi | PRODUCTION | Oui |
+| 27 | GameTheory-3-Topology2x2 | PRODUCTION | Oui |
+| 28 | GameTheory-4-NashEquilibrium (C#) | BETA | Oui |
+| 29 | GameTheory-4-NashEquilibrium | PRODUCTION | Oui |
+| 30 | GameTheory 4b - Theoreme d'Existence de Nash (Lean) | PRODUCTION | Non |
+| 31 | GameTheory 4c - Théorème d'Existence de Nash (C#) | BETA | Oui |
+| 32 | GameTheory 4c - Theoreme d'Existence de Nash (Python) | PRODUCTION | Non |
+| 33 | GameTheory-5-ZeroSum-Minimax (Twin C#) | BETA | Oui |
+| 34 | GameTheory-5-ZeroSum-Minimax | PRODUCTION | Oui |
+| 35 | GameTheory-5b — Théorème minimax de von Neumann (compan | BETA | Non |
+| 36 | GameTheory-6 : Évolution et Confiance — Twin C# (tourno | PRODUCTION | Oui |
+| 37 | GameTheory-6-EvolutionTrust | PRODUCTION | Oui |
+| 38 | GameTheory-6c (C#) : Jeux Repetes et Theoreme Folk | PRODUCTION | Oui |
+| 39 | GameTheory-6c : Jeux Répétés et Théorème Folk (Folk The | PRODUCTION | Oui |
+| 40 | GameTheory-7-ExtensiveForm (Twin C#) | BETA | Oui |
+| 41 | GameTheory-7-ExtensiveForm | PRODUCTION | Oui |
+| 42 | GameTheory-9-BackwardInduction (C#) | BETA | Oui |
+| 43 | GameTheory-9-BackwardInduction | PRODUCTION | Oui |
+
+## GameTheory/SocialChoice (7 notebooks)
+
+| # | Notebook | Maturite | Executable |
+|---|----------|----------|------------|
+| 1 | SocialChoice 01 : Théorème d'impossibilité d'Arrow (twi | BETA | Oui |
+| 2 | SocialChoice 01 - Theoreme d'Arrow : Preuve Formelle et | PRODUCTION | Oui |
+| 3 | SocialChoice 02 - Choix Social Formel en Lean 4 | BETA | Non |
+| 4 | SocialChoice 03 : Méthodes de Vote et Paradoxes (twin C | PRODUCTION | Oui |
+| 5 | SocialChoice 03 - Méthodes de Vote et Paradoxes | PRODUCTION | Oui |
+| 6 | SocialChoice 04 : Agregation Computationnelle - SAT et  | BETA | Oui |
+| 7 | SocialChoice 04 - Agregation Computationnelle : SAT et  | PRODUCTION | Oui |
+
+## IIT (3 notebooks)
+
+| # | Notebook | Maturite | Executable |
+|---|----------|----------|------------|
+| 1 | IIT - Introduction à PyPhi et Integrated Information Th | PRODUCTION | Oui |
+| 2 | IIT - Sujets Avances : Partitionnement, Repertoires Cau | PRODUCTION | Oui |
+| 3 | IIT-3. Coarse-graining, blackboxing et l'échelle du $\P | BETA | Oui |
+
+## IIT/ICT-Series (29 notebooks)
+
+| # | Notebook | Maturite | Executable |
+|---|----------|----------|------------|
+| 1 | ICT-1 — Trajectoires de $\Phi$ | BETA | Oui |
+| 2 | ICT-10 — Grammaire des catastrophes : *l'obstacle qui e | PRODUCTION | Oui |
+| 3 | ICT-11 — Profils d'agence causale : à quelle échelle l' | BETA | Oui |
+| 4 | ICT-12 — Champs de valence et animats : rôles mesures,  | BETA | Oui |
+| 5 | ICT-13 — Morphodynamique stratégique : une stratégie es | BETA | Oui |
+| 6 | ICT-14 — Énergie libre et surprise du représentant inte | BETA | Oui |
+| 7 | ICT-15 — Integrated Complexity : convergence Φ / F / K  | BETA | Oui |
+| 8 | ICT-16 — MDL / code en deux parties et bosse complexite | BETA | Oui |
+| 9 | ICT-17 -- Mecanique computationnelle (epsilon-machine d | BETA | Oui |
+| 10 | Grokking et compression-progress : la jambe K à l'épreu | PRODUCTION | Oui |
+| 11 | ICT-18 -- Fleche du temps et reversibilisation (strate  | BETA | Oui |
+| 12 | ICT-19 — La batterie de l'ENJEU : auto-maintien vs pur  | PRODUCTION | Oui |
+| 13 | ICT-19 — Raffinement et résolution des stubs (tranche 3 | PRODUCTION | Non |
+| 14 | ICT-2 — Le tri comme morphogenèse minimale (self-sortin | ALPHA | Oui |
+| 15 | ICT-20 — FeatureCatastrophes : *calibration de méthode* | PRODUCTION | Non |
+| 16 | ICT-21 — SAETrajectoires : le substrat S4 entre au banc | BETA | Non |
+| 17 | ICT-22 — LLMSubstrat : le transformer comme quatrième s | BETA | Non |
+| 18 | ICT-23 — PersonaCatastrophe : la fronce de Thom appliqu | BETA | Oui |
+| 19 | ICT-24 — WorkspaceIgnition : l'axe Global Workspace et  | BETA | Non |
+| 20 | ICT-25 — InoculationRL : GRPO à récompense *hackable*,  | BETA | Non |
+| 21 | ICT-3 — Robustesse & délai de gratification : étude qua | PRODUCTION | Oui |
+| 22 | ICT-4 — Tableaux chimériques & agrégation émergente («  | BETA | Oui |
+| 23 | ICT-5 : Émergence causale — quelle échelle décrit le mi | BETA | Oui |
+| 24 | ICT-6 — Du tri a la chaîne de Markov : emergence causal | BETA | Oui |
+| 25 | ICT-7 — Signatures *scale-free* & criticalite | BETA | Oui |
+| 26 | ICT-8 — Paysages d'attracteurs & signaux precurseurs :  | PRODUCTION | Oui |
+| 27 | ICT-9 — Agence & regeneration : *reparer sa forme, ou s | PRODUCTION | Oui |
+| 28 | Tete-a-tete SAE <-> J-space -- les deux lentilles du wo | PRODUCTION | Non |
+| 29 | ICT-Synthèse — un seul appareil de mesure, cinq substra | BETA | Non |
 
 ## Probas (2 notebooks)
 
 | # | Notebook | Maturite | Executable |
 |---|----------|----------|------------|
-| 1 | Infer-101 : Introduction a Infer.NET | ALPHA | Oui |
-| 2 | Le Framework Rational Speech Act (RSA) | ALPHA | Oui |
+| 1 | Infer-101 : Introduction a Infer.NET | PRODUCTION | Oui |
+| 2 | Le Framework Rational Speech Act (RSA) | PRODUCTION | Oui |
 
-## Probas/Infer (20 notebooks)
-
-| # | Notebook | Maturite | Executable |
-|---|----------|----------|------------|
-| 1 | Infer-1-Setup : Introduction et Installation | ALPHA | Oui |
-| 2 | Infer-13-Crowdsourcing : Agregation de Labels et Fiabil | ALPHA | Oui |
-| 3 | Infer-14-Sequences : Hidden Markov Models et Series Tem | ALPHA | Oui |
-| 4 | Infer-15-Recommenders : Systemes de Recommandation | ALPHA | Oui |
-| 5 | Infer-6-Debugging : Troubleshooting et Bonnes Pratique | ALPHA | Oui |
-| 6 | Infer-14-Decision-Utility-Foundations : Axiomes et Fond | PRODUCTION | Oui |
-| 7 | Infer-15-Decision-Utility-Money : Utilite de l'Argent e | ALPHA | Oui |
-| 8 | Infer-16-Decision-Multi-Attribute : Utilite Multi-Attri | PRODUCTION | Oui |
-| 9 | Infer-17-Decision-Networks : Reseaux de Decision | ALPHA | Oui |
-| 10 | Infer-18-Decision-Value-Information : Valeur de l'Infor | PRODUCTION | Oui |
-| 11 | Infer-19-Decision-Expert-Systems : Decisions Robustes e | PRODUCTION | Oui |
-| 12 | Infer-2-Gaussian-Mixtures : Distributions Gaussiennes e | ALPHA | Oui |
-| 13 | Infer-20-Decision-Sequential : MDPs, Bandits et POMDPs | ALPHA | Oui |
-| 14 | Infer-3-Factor-Graphs : Graphes de Facteurs et Inferenc | ALPHA | Oui |
-| 15 | Infer-4-Bayesian-Networks : Reseaux Bayesiens Classique | ALPHA | Oui |
-| 16 | Infer-7-Skills-IRT : Evaluation de Competences et Psych | ALPHA | Oui |
-| 17 | Infer-8-TrueSkill : Systeme de Classement et Apprentiss | ALPHA | Oui |
-| 18 | Infer-9-Classification : Classification Bayesienne | ALPHA | Oui |
-| 19 | Infer-10-Model-Selection : Selection et Comparaison de M | ALPHA | Oui |
-| 20 | Infer-11-Topic-Models : Latent Dirichlet Allocation (LDA | ALPHA | Oui |
-
-## RL (6 notebooks)
+## Probas/DecisionTheory (18 notebooks)
 
 | # | Notebook | Maturite | Executable |
 |---|----------|----------|------------|
-| 1 | RL-4 : MDP, Programmation Dynamique et Q-Learning Tabul | ALPHA | Oui |
-| 2 | RL-5 : Deep Q-Network (DQN) et Policy Gradient | ALPHA | Oui |
-| 3 | RL-6 : Introduction a l'Apprentissage Multi-Agent | ALPHA | Oui |
-| 4 | Tutoriel Stable Baselines3 - Premiers pas | ALPHA | Oui |
-| 5 | Notebook 2 – Wrappers Gym, Sauvegarde/Chargement, Multi | ALPHA | Oui |
-| 6 | Notebook 3 – Hindsight Experience Replay (HER) et Sauve | ALPHA | Oui |
+| 1 | Du graphe causal au do-calculus — le pont entre les qua | PRODUCTION | Oui |
+| 2 | DecInfer-1-Utility-Foundations : Axiomes et Fondements | PRODUCTION | Oui |
+| 3 | DecInfer-10-Thompson-Sampling : Bandits bayesiens par I | PRODUCTION | Oui |
+| 4 | DecInfer-2-Théorème de représentation de von Neumann–Mo | BETA | Oui |
+| 5 | DecInfer-3-Utility-Money : Utilite de l'Argent et Avers | PRODUCTION | Oui |
+| 6 | DecInfer-4-Multi-Attribute : Utilite Multi-Attributs | PRODUCTION | Oui |
+| 7 | DecInfer-5-Decision-Networks : Reseaux de Decision | PRODUCTION | Oui |
+| 8 | DecInfer-6-Value-Information : Valeur de l'Information | PRODUCTION | Oui |
+| 9 | DecInfer-7-Expert-Systems : Decisions Robustes et Systè | PRODUCTION | Oui |
+| 10 | DecInfer-8-Sequential : MDPs, Bandits et POMDPs | PRODUCTION | Oui |
+| 11 | DecInfer-9-Preuves formelles — Indice de Gittins | PRODUCTION | Oui |
+| 12 | DecPyMC-1-Utility-Foundations : Axiomes et Fondements | PRODUCTION | Oui |
+| 13 | DecPyMC-2-Utility-Money : Utilite de l'Argent et Aversi | PRODUCTION | Oui |
+| 14 | DecPyMC-3-Multi-Attribute : Utilite Multi-Attributs | PRODUCTION | Oui |
+| 15 | DecPyMC-4-Decision-Networks : Reseaux de Decision | PRODUCTION | Oui |
+| 16 | DecPyMC-5-Valeur de l'Information | PRODUCTION | Oui |
+| 17 | DecPyMC-6-Systèmes Experts et Decisions Robustes | PRODUCTION | Oui |
+| 18 | DecPyMC-7-MDPs, Bandits et POMDPs | PRODUCTION | Oui |
+
+## Probas/Infer (19 notebooks)
+
+| # | Notebook | Maturite | Executable |
+|---|----------|----------|------------|
+| 1 | Infer-1-Setup : Introduction et Installation | PRODUCTION | Oui |
+| 2 | Infer-10-Model-Sélection : Sélection et Comparaison de  | PRODUCTION | Oui |
+| 3 | Infer-11-Topic-Models : Latent Dirichlet Allocation (LD | PRODUCTION | Oui |
+| 4 | 12. Modèles Hiérarchiques Bayésiens — Pooling Partiel e | BETA | Oui |
+| 5 | Infer-13-Crowdsourcing : Agregation de Labels et Fiabil | PRODUCTION | Oui |
+| 6 | Infer-14-Sequences : Hidden Markov Models et Series Tem | PRODUCTION | Oui |
+| 7 | Infer-15-Recommenders : systèmes de Recommandation | PRODUCTION | Oui |
+| 8 | Infer-16-Sparse-Gaussian-Process : Processus Gaussiens  | PRODUCTION | Oui |
+| 9 | Infer-17 — Filtre de Kalman : systèmes dynamiques linéa | PRODUCTION | Oui |
+| 10 | Infer-18 — Détection de Rupture (Change-Point) : infére | PRODUCTION | Oui |
+| 11 | Infer-19 — Analyse de survie / fiabilite bayesienne : i | BETA | Oui |
+| 12 | Infer-2-Gaussian-Mixtures : Distributions Gaussiennes e | PRODUCTION | Oui |
+| 13 | Infer-3-Factor-Graphs : Graphes de Facteurs et Inferenc | PRODUCTION | Oui |
+| 14 | Infer-4-Bayesian-Networks : Reseaux Bayesiens Classique | PRODUCTION | Oui |
+| 15 | Infer-5-Causal-Inference : Inférence Causale et do-calc | PRODUCTION | Oui |
+| 16 | Infer-6-Debugging : Troubleshooting et Bonnes Pratiques | PRODUCTION | Oui |
+| 17 | Infer-7-Skills-IRT : Evaluation de Competences et Psych | PRODUCTION | Oui |
+| 18 | Infer-8-TrueSkill : Système de Classement et Apprentiss | PRODUCTION | Oui |
+| 19 | Infer-9-Classification : Classification Bayesienne | PRODUCTION | Oui |
+
+## Probas/PyMC (19 notebooks)
+
+| # | Notebook | Maturite | Executable |
+|---|----------|----------|------------|
+| 1 | PyMC-1 : Configuration et Premier Modèle | PRODUCTION | Oui |
+| 2 | PyMC-10 : Sélection de Modèles et Comparaison Bayesienn | PRODUCTION | Oui |
+| 3 | PyMC-11 : Modèles de Sujets (Topic Models) et LDA | PRODUCTION | Oui |
+| 4 | 12. Modèles Hiérarchiques Bayesiens -- Pooling Partiel  | BETA | Oui |
+| 5 | PyMC-13 : Crowdsourcing - Agregation de Labels et Fiabi | PRODUCTION | Oui |
+| 6 | PyMC-14 — Modèles de Sequences et Chaînes de Markov Cac | PRODUCTION | Oui |
+| 7 | PyMC-15-Recommenders : Systèmes de Recommandation Proba | PRODUCTION | Oui |
+| 8 | PyMC-16 : Processus Gaussiens et frontières non linéair | PRODUCTION | Oui |
+| 9 | 17. Filtre de Kalman : systèmes dynamiques lineaires ga | PRODUCTION | Oui |
+| 10 | 18. Detection de Rupture (Change-Point) : inferer le mo | PRODUCTION | Oui |
+| 11 | 19. Analyse de survie / fiabilite bayesienne : inferer  | PRODUCTION | Oui |
+| 12 | PyMC-2 : Distributions Gaussiennes et Melanges | PRODUCTION | Oui |
+| 13 | PyMC-3 : Graphes de Facteurs et Inference Discrete | PRODUCTION | Oui |
+| 14 | PyMC-4 : Reseaux Bayesiens | PRODUCTION | Oui |
+| 15 | PyMC-5-Causal-Inference : Inference Causale et do-calcu | PRODUCTION | Oui |
+| 16 | PyMC-6-Debugging : Troubleshooting et Bonnes Pratiques | PRODUCTION | Oui |
+| 17 | PyMC-7 : Modèles de Competences (IRT et DINA) | PRODUCTION | Oui |
+| 18 | PyMC-8 : TrueSkill - Classement et Apprentissage en Lig | PRODUCTION | Oui |
+| 19 | PyMC-9 : Classification Bayesienne et Tests A/B | PRODUCTION | Oui |
+
+## RL (17 notebooks)
+
+| # | Notebook | Maturite | Executable |
+|---|----------|----------|------------|
+| 1 | RL-10 : Reward Shaping et Curriculum Learning | PRODUCTION | Oui |
+| 2 | RL-11 : POMDP - Partial Observability et Belief Trackin | PRODUCTION | Oui |
+| 3 | RL-12 : Distributional RL — C51 (Categorical DQN) depui | PRODUCTION | Non |
+| 4 | RL 13 - Exploration par curiosité : Random Network Dist | PRODUCTION | Oui |
+| 5 | Tutoriel Stable Baselines3 - Premiers pas | BETA | Oui |
+| 6 | Notebook 2 – Wrappers Gym, Sauvegarde/Chargement, Multi | BETA | Non |
+| 7 | Notebook 3 – Hindsight Expérience Replay (HER) et Sauve | PRODUCTION | Oui |
+| 8 | RL-4 : Bandits Manchots et le Compromis Exploration-Exp | PRODUCTION | Oui |
+| 9 | RL-5 : MDP, Programmation Dynamique et Q-Learning Tabul | PRODUCTION | Oui |
+| 10 | RL-6 : Deep Q-Network (DQN) et Policy Gradient | PRODUCTION | Oui |
+| 11 | RL-6b - Actor-Critic : unir valeur et politique | PRODUCTION | Oui |
+| 12 | PPO (Proximal Policy Optimization) depuis zero | PRODUCTION | Oui |
+| 13 | SAC (Soft Actor-Critic) depuis zero | PRODUCTION | Oui |
+| 14 | GRPO (Group Relative Policy Optimization) depuis zero | PRODUCTION | Non |
+| 15 | RL-7 : Introduction a l'Apprentissage Multi-Agent | PRODUCTION | Oui |
+| 16 | RL-8 : Model-Based RL — Dyna-Q et planification | PRODUCTION | Oui |
+| 17 | RL-9 : RL offline — Behavior Cloning et erreur d'extrap | PRODUCTION | Oui |

--- a/docs/curriculum/trading.md
+++ b/docs/curriculum/trading.md
@@ -8,88 +8,264 @@ Strategies de trading algorithmique avec QuantConnect, pipeline ML (Transformer,
 
 | Metrique | Valeur |
 |----------|--------|
-| Notebooks | 56 |
-| PRODUCTION | 16 |
-| BETA | 2 |
-| ALPHA | 38 |
+| Notebooks | 207 |
+| PRODUCTION | 154 |
+| BETA | 17 |
+| ALPHA | 36 |
 
-## ML/DataScienceWithAgents (13 notebooks)
-
-| # | Notebook | Maturite | Executable |
-|---|----------|----------|------------|
-| 1 | Lab 8: Introduction au Framework ADK et Multi-Provider | ALPHA | Non |
-| 2 | Lab 9: Premier Agent ADK pour Data Science | ALPHA | Oui |
-| 3 | Lab 11: Planner-Coder-Verifier Loop (DS-STAR Core) | ALPHA | Oui |
-| 4 | Lab 12: DS-STAR Workshop - Analyse Multi-Fichiers | ALPHA | Oui |
-| 5 | Lab 13: Web Search pour Modèles SOTA (MLE-STAR Componen | ALPHA | Oui |
-| 6 | Lab 14: Ablation et Raffinement Ciblé (MLE-STAR Compone | ALPHA | Oui |
-| 7 | Lab 15: Kaggle Challenge avec MLE-STAR | ALPHA | Oui |
-| 8 | Lab 16: Data Science Agent avec GCP BigQuery | ALPHA | Oui |
-| 9 | Lab 17: Projet Final - Pipeline DS-STAR Complet | ALPHA | Oui |
-| 10 | Lab 4 - Le Nettoyage de Données avec Pandas | ALPHA | Oui |
-| 11 | Lab 4 - Le Nettoyage de Données avec Pandas | ALPHA | Oui |
-| 12 | Lab 5 - De la Visualisation au Machine Learning | ALPHA | Oui |
-| 13 | Lab 5 - De la Visualisation au Machine Learning | ALPHA | Oui |
-
-## ML/ML.Net (6 notebooks)
+## ML/DataScienceWithAgents (28 notebooks)
 
 | # | Notebook | Maturite | Executable |
 |---|----------|----------|------------|
-| 1 | ML-1 : Introduction au Machine Learning avec ML.NET | ALPHA | Oui |
-| 2 | ML-2 : Préparation des données et ingénierie des featur | ALPHA | Oui |
-| 3 | ML-3 : Entraînement et AutoML | ALPHA | Oui |
-| 4 | ML-4 : Evaluation des modèles | ALPHA | Oui |
-| 5 | ML-6 : ONNX Model Integration avec ML.NET | BETA | Oui |
-| 6 | TP : Prevision des ventes d'assurance | ALPHA | Oui |
+| 1 | 1.2 - Manipulation de Données avec NumPy | PRODUCTION | Oui |
+| 2 | 1.3 - Analyse de Données avec Pandas | PRODUCTION | Oui |
+| 3 | 2.1 — Le workflow d'apprentissage automatique | PRODUCTION | Oui |
+| 4 | 2.2 — La descente de gradient : comment un modèle appre | PRODUCTION | Oui |
+| 5 | 2.3 — Régression linéaire et régression logistique | PRODUCTION | Oui |
+| 6 | 2.4 — Arbres de décision, forêts aléatoires et boosting | PRODUCTION | Oui |
+| 7 | 2.5 — Biais, variance, validation croisée et courbe ROC | PRODUCTION | Oui |
+| 8 | 2.6 — Clustering (KMeans) et réduction de dimension (PC | PRODUCTION | Oui |
+| 9 | 2.7 — Modèles non paramétriques : SVM et k plus proches | PRODUCTION | Oui |
+| 10 | 2.8 — Théorie de l'apprentissage : PAC et dimension de  | PRODUCTION | Oui |
+| 11 | 2.9 — Grokking : la généralisation qui arrive en retard | PRODUCTION | Oui |
+| 12 | Lab 8: Introduction au Framework ADK et Multi-Provider | PRODUCTION | Non |
+| 13 | Lab 9: Premier Agent ADK pour Data Science | PRODUCTION | Oui |
+| 14 | Lab 10: Data File Analyzer (DS-STAR Component) | PRODUCTION | Oui |
+| 15 | Lab 11: Planner-Coder-Verifier Loop (DS-STAR Core) | BETA | Oui |
+| 16 | Lab 12: DS-STAR Workshop - Analyse Multi-Fichiers | PRODUCTION | Oui |
+| 17 | Lab 13: Web Search pour Modèles SOTA (MLE-STAR Componen | PRODUCTION | Oui |
+| 18 | Lab 14: Ablation et Raffinement Ciblé (MLE-STAR Compone | BETA | Oui |
+| 19 | Lab 15: Kaggle Challenge avec MLE-STAR | PRODUCTION | Oui |
+| 20 | Lab 16: Data Science Agent avec GCP BigQuery | BETA | Oui |
+| 21 | Lab 17: Projet Final - Pipeline DS-STAR Complet | BETA | Oui |
+| 22 | Lab 1 - Les Bases de la Data Science en Python | PRODUCTION | Oui |
+| 23 | Lab 2 - Analyser un Appel d'Offre avec l'IA | PRODUCTION | Non |
+| 24 | Lab 3 - Pré-qualifier des Candidats avec l'IA | PRODUCTION | Non |
+| 25 | Lab 4 - Le Nettoyage de Données avec Pandas | PRODUCTION | Oui |
+| 26 | Lab 5 - De la Visualisation au Machine Learning | PRODUCTION | Oui |
+| 27 | Lab 6 - Anatomie de votre premier Agent d'IA | BETA | Non |
+| 28 | Lab 7 - Votre premier Agent Analyste de Données | PRODUCTION | Non |
+
+## ML/ML.Net (19 notebooks)
+
+| # | Notebook | Maturite | Executable |
+|---|----------|----------|------------|
+| 1 | ML-1 (Python) : Introduction au Machine Learning avec s | PRODUCTION | Oui |
+| 2 | ML-1 : Introduction au Machine Learning avec ML.NET | PRODUCTION | Oui |
+| 3 | ML-2 : Préparation des données et ingénierie des featur | PRODUCTION | Oui |
+| 4 | ML-2 : Préparation des données et ingénierie des featur | PRODUCTION | Oui |
+| 5 | ML-3 : Entraînement et AutoML | PRODUCTION | Oui |
+| 6 | ML-3 (Python) : Entraînement et AutoML | PRODUCTION | Oui |
+| 7 | ML-4 : Évaluation des modèles (Python / sklearn) | PRODUCTION | Oui |
+| 8 | ML-4 : Evaluation des modèles | ALPHA | Oui |
+| 9 | ML-5 (Python) : Prévision de séries temporelles (STL +  | PRODUCTION | Oui |
+| 10 | ML-5 : Time Series Forecasting avec ML.NET | PRODUCTION | Oui |
+| 11 | ML-6 (Python) : Intégration de modèles ONNX (skl2onnx + | PRODUCTION | Oui |
+| 12 | ML-6 : ONNX Model Integration avec ML.NET | PRODUCTION | Oui |
+| 13 | ML-7 (Python) : Systèmes de recommandation par factoris | PRODUCTION | Oui |
+| 14 | ML-7 : Systèmes de Recommandation avec ML.NET | PRODUCTION | Oui |
+| 15 | ML-8 (Python) : Clustering non-supervisé avec K-Means | PRODUCTION | Oui |
+| 16 | ML-8 : Clustering non-supervise avec K-Means | PRODUCTION | Oui |
+| 17 | ML-9 (Python) : Détection d'anomalies par PCA (erreur d | PRODUCTION | Oui |
+| 18 | ML-9 : Detection d'anomalies avec Randomized PCA | PRODUCTION | Oui |
+| 19 | TP : Prevision des ventes d'assurance | PRODUCTION | Oui |
 
 ## Probas (2 notebooks)
 
 | # | Notebook | Maturite | Executable |
 |---|----------|----------|------------|
-| 1 | Infer-101 : Introduction a Infer.NET | ALPHA | Oui |
-| 2 | Le Framework Rational Speech Act (RSA) | ALPHA | Oui |
+| 1 | Infer-101 : Introduction a Infer.NET | PRODUCTION | Oui |
+| 2 | Le Framework Rational Speech Act (RSA) | PRODUCTION | Oui |
 
-## Probas/Infer (20 notebooks)
-
-| # | Notebook | Maturite | Executable |
-|---|----------|----------|------------|
-| 1 | Infer-1-Setup : Introduction et Installation | ALPHA | Oui |
-| 2 | Infer-13-Crowdsourcing : Agregation de Labels et Fiabil | ALPHA | Oui |
-| 3 | Infer-14-Sequences : Hidden Markov Models et Series Tem | ALPHA | Oui |
-| 4 | Infer-15-Recommenders : Systemes de Recommandation | ALPHA | Oui |
-| 5 | Infer-6-Debugging : Troubleshooting et Bonnes Pratique | ALPHA | Oui |
-| 6 | Infer-14-Decision-Utility-Foundations : Axiomes et Fond | PRODUCTION | Oui |
-| 7 | Infer-15-Decision-Utility-Money : Utilite de l'Argent e | ALPHA | Oui |
-| 8 | Infer-16-Decision-Multi-Attribute : Utilite Multi-Attri | PRODUCTION | Oui |
-| 9 | Infer-17-Decision-Networks : Reseaux de Decision | ALPHA | Oui |
-| 10 | Infer-18-Decision-Value-Information : Valeur de l'Infor | PRODUCTION | Oui |
-| 11 | Infer-19-Decision-Expert-Systems : Decisions Robustes e | PRODUCTION | Oui |
-| 12 | Infer-2-Gaussian-Mixtures : Distributions Gaussiennes e | ALPHA | Oui |
-| 13 | Infer-20-Decision-Sequential : MDPs, Bandits et POMDPs | ALPHA | Oui |
-| 14 | Infer-3-Factor-Graphs : Graphes de Facteurs et Inferenc | ALPHA | Oui |
-| 15 | Infer-4-Bayesian-Networks : Reseaux Bayesiens Classique | ALPHA | Oui |
-| 16 | Infer-7-Skills-IRT : Evaluation de Competences et Psych | ALPHA | Oui |
-| 17 | Infer-8-TrueSkill : Systeme de Classement et Apprentiss | ALPHA | Oui |
-| 18 | Infer-9-Classification : Classification Bayesienne | ALPHA | Oui |
-| 19 | Infer-10-Model-Selection : Selection et Comparaison de M | ALPHA | Oui |
-| 20 | Infer-11-Topic-Models : Latent Dirichlet Allocation (LDA | ALPHA | Oui |
-
-## QuantConnect/Python (15 notebooks)
+## Probas/DecisionTheory (18 notebooks)
 
 | # | Notebook | Maturite | Executable |
 |---|----------|----------|------------|
-| 1 | QC-Py-18 - Feature Engineering pour Machine Learning Tr | ALPHA | Oui |
-| 2 | QC-Py-30 - LSTM Training Multi-Asset (GPU) | PRODUCTION | Non |
-| 3 | QC-Py-31 - Transformer Encoder Multi-Asset (GPU) | PRODUCTION | Non |
-| 4 | QC-Py-32 - Reinforcement Learning DQN pour le Trading | PRODUCTION | Non |
-| 5 | QC-Py-41 : Paper Trading IBKR - SP500 Momentum | ALPHA | Oui |
-| 6 | QC-Py-Cloud-01 : Analyse de Sentiment FinBERT sur QC Cl | BETA | Oui |
-| 7 | QC-Py-Cloud-02 : Classification de Texte et Sentiment N | PRODUCTION | Oui |
-| 8 | QC-Py-Cloud-02 — Sector Rotation & Multi-Asset Momentum | PRODUCTION | Oui |
-| 9 | QC-Py-Cloud-03 — Dual Momentum : Asset Selection Matter | PRODUCTION | Oui |
-| 10 | QC-Py-Cloud-03 : Parite de Risque (Risk Parity) | PRODUCTION | Oui |
-| 11 | QC-Py-Cloud-04 — Mean Reversion on Sector ETFs | PRODUCTION | Oui |
-| 12 | QC-Py-Cloud-04 : Reinforcement Learning - DQN Trading | PRODUCTION | Oui |
-| 13 | QC-Py-Cloud-05 : Prevision par Reseau de Neurones (MLP) | PRODUCTION | Oui |
-| 14 | QC-Py-Cloud-05 — Regime Switching : Momentum in Bull, D | PRODUCTION | Oui |
-| 15 | QC-Py-Cloud-06 -- Volatility Targeting : Risk Managemen | PRODUCTION | Oui |
+| 1 | Du graphe causal au do-calculus — le pont entre les qua | PRODUCTION | Oui |
+| 2 | DecInfer-1-Utility-Foundations : Axiomes et Fondements | PRODUCTION | Oui |
+| 3 | DecInfer-10-Thompson-Sampling : Bandits bayesiens par I | PRODUCTION | Oui |
+| 4 | DecInfer-2-Théorème de représentation de von Neumann–Mo | BETA | Oui |
+| 5 | DecInfer-3-Utility-Money : Utilite de l'Argent et Avers | PRODUCTION | Oui |
+| 6 | DecInfer-4-Multi-Attribute : Utilite Multi-Attributs | PRODUCTION | Oui |
+| 7 | DecInfer-5-Decision-Networks : Reseaux de Decision | PRODUCTION | Oui |
+| 8 | DecInfer-6-Value-Information : Valeur de l'Information | PRODUCTION | Oui |
+| 9 | DecInfer-7-Expert-Systems : Decisions Robustes et Systè | PRODUCTION | Oui |
+| 10 | DecInfer-8-Sequential : MDPs, Bandits et POMDPs | PRODUCTION | Oui |
+| 11 | DecInfer-9-Preuves formelles — Indice de Gittins | PRODUCTION | Oui |
+| 12 | DecPyMC-1-Utility-Foundations : Axiomes et Fondements | PRODUCTION | Oui |
+| 13 | DecPyMC-2-Utility-Money : Utilite de l'Argent et Aversi | PRODUCTION | Oui |
+| 14 | DecPyMC-3-Multi-Attribute : Utilite Multi-Attributs | PRODUCTION | Oui |
+| 15 | DecPyMC-4-Decision-Networks : Reseaux de Decision | PRODUCTION | Oui |
+| 16 | DecPyMC-5-Valeur de l'Information | PRODUCTION | Oui |
+| 17 | DecPyMC-6-Systèmes Experts et Decisions Robustes | PRODUCTION | Oui |
+| 18 | DecPyMC-7-MDPs, Bandits et POMDPs | PRODUCTION | Oui |
+
+## Probas/Infer (19 notebooks)
+
+| # | Notebook | Maturite | Executable |
+|---|----------|----------|------------|
+| 1 | Infer-1-Setup : Introduction et Installation | PRODUCTION | Oui |
+| 2 | Infer-10-Model-Sélection : Sélection et Comparaison de  | PRODUCTION | Oui |
+| 3 | Infer-11-Topic-Models : Latent Dirichlet Allocation (LD | PRODUCTION | Oui |
+| 4 | 12. Modèles Hiérarchiques Bayésiens — Pooling Partiel e | BETA | Oui |
+| 5 | Infer-13-Crowdsourcing : Agregation de Labels et Fiabil | PRODUCTION | Oui |
+| 6 | Infer-14-Sequences : Hidden Markov Models et Series Tem | PRODUCTION | Oui |
+| 7 | Infer-15-Recommenders : systèmes de Recommandation | PRODUCTION | Oui |
+| 8 | Infer-16-Sparse-Gaussian-Process : Processus Gaussiens  | PRODUCTION | Oui |
+| 9 | Infer-17 — Filtre de Kalman : systèmes dynamiques linéa | PRODUCTION | Oui |
+| 10 | Infer-18 — Détection de Rupture (Change-Point) : infére | PRODUCTION | Oui |
+| 11 | Infer-19 — Analyse de survie / fiabilite bayesienne : i | BETA | Oui |
+| 12 | Infer-2-Gaussian-Mixtures : Distributions Gaussiennes e | PRODUCTION | Oui |
+| 13 | Infer-3-Factor-Graphs : Graphes de Facteurs et Inferenc | PRODUCTION | Oui |
+| 14 | Infer-4-Bayesian-Networks : Reseaux Bayesiens Classique | PRODUCTION | Oui |
+| 15 | Infer-5-Causal-Inference : Inférence Causale et do-calc | PRODUCTION | Oui |
+| 16 | Infer-6-Debugging : Troubleshooting et Bonnes Pratiques | PRODUCTION | Oui |
+| 17 | Infer-7-Skills-IRT : Evaluation de Competences et Psych | PRODUCTION | Oui |
+| 18 | Infer-8-TrueSkill : Système de Classement et Apprentiss | PRODUCTION | Oui |
+| 19 | Infer-9-Classification : Classification Bayesienne | PRODUCTION | Oui |
+
+## Probas/PyMC (19 notebooks)
+
+| # | Notebook | Maturite | Executable |
+|---|----------|----------|------------|
+| 1 | PyMC-1 : Configuration et Premier Modèle | PRODUCTION | Oui |
+| 2 | PyMC-10 : Sélection de Modèles et Comparaison Bayesienn | PRODUCTION | Oui |
+| 3 | PyMC-11 : Modèles de Sujets (Topic Models) et LDA | PRODUCTION | Oui |
+| 4 | 12. Modèles Hiérarchiques Bayesiens -- Pooling Partiel  | BETA | Oui |
+| 5 | PyMC-13 : Crowdsourcing - Agregation de Labels et Fiabi | PRODUCTION | Oui |
+| 6 | PyMC-14 — Modèles de Sequences et Chaînes de Markov Cac | PRODUCTION | Oui |
+| 7 | PyMC-15-Recommenders : Systèmes de Recommandation Proba | PRODUCTION | Oui |
+| 8 | PyMC-16 : Processus Gaussiens et frontières non linéair | PRODUCTION | Oui |
+| 9 | 17. Filtre de Kalman : systèmes dynamiques lineaires ga | PRODUCTION | Oui |
+| 10 | 18. Detection de Rupture (Change-Point) : inferer le mo | PRODUCTION | Oui |
+| 11 | 19. Analyse de survie / fiabilite bayesienne : inferer  | PRODUCTION | Oui |
+| 12 | PyMC-2 : Distributions Gaussiennes et Melanges | PRODUCTION | Oui |
+| 13 | PyMC-3 : Graphes de Facteurs et Inference Discrete | PRODUCTION | Oui |
+| 14 | PyMC-4 : Reseaux Bayesiens | PRODUCTION | Oui |
+| 15 | PyMC-5-Causal-Inference : Inference Causale et do-calcu | PRODUCTION | Oui |
+| 16 | PyMC-6-Debugging : Troubleshooting et Bonnes Pratiques | PRODUCTION | Oui |
+| 17 | PyMC-7 : Modèles de Competences (IRT et DINA) | PRODUCTION | Oui |
+| 18 | PyMC-8 : TrueSkill - Classement et Apprentissage en Lig | PRODUCTION | Oui |
+| 19 | PyMC-9 : Classification Bayesienne et Tests A/B | PRODUCTION | Oui |
+
+## QuantConnect/ML-Training-Pipeline (1 notebooks)
+
+| # | Notebook | Maturite | Executable |
+|---|----------|----------|------------|
+| 1 | M3b - HAR Asymetrique : Decomposition Semivariance et E | PRODUCTION | Non |
+
+## QuantConnect/Python (52 notebooks)
+
+| # | Notebook | Maturite | Executable |
+|---|----------|----------|------------|
+| 1 | QC-Py-01 : Configuration et Premier Backtest QuantConne | ALPHA | Non |
+| 2 | QC-Py-02 : QuantConnect Platform Fundamentals - QCAlgor | ALPHA | Non |
+| 3 | QC-Py-03 - Data Management in QuantConnect | ALPHA | Non |
+| 4 | QC-Py-04 - Research Workflow with QuantBook | PRODUCTION | Non |
+| 5 | QC-Py-05 - Universe Sélection dans QuantConnect | ALPHA | Non |
+| 6 | QC-Py-06 : Options Trading dans QuantConnect | ALPHA | Non |
+| 7 | QC-Py-07 : Futures et Forex Trading dans QuantConnect | PRODUCTION | Non |
+| 8 | QC-Py-09 : Types d'Ordres et Order Management dans Quan | ALPHA | Non |
+| 9 | QC-Py-10 - Risk Management et Portfolio Management | ALPHA | Non |
+| 10 | QC-Py-11 - Indicateurs Techniques dans QuantConnect | ALPHA | Non |
+| 11 | QC-Py-12 - Backtesting et Analyse de Performance | ALPHA | Non |
+| 12 | QC-Py-13 - Alpha Models et Algorithm Framework | ALPHA | Non |
+| 13 | QC-Py-14 - Portfolio Construction et Exécution Models | ALPHA | Non |
+| 14 | QC-Py-15 - Parameter Optimization et Walk-Forward Analy | PRODUCTION | Non |
+| 15 | QC-Py-16 - Alternative Data dans QuantConnect | ALPHA | Non |
+| 16 | QC-Py-17 - Sentiment Analysis pour le Trading | PRODUCTION | Non |
+| 17 | QC-Py-18 - Feature Engineering pour Machine Learning Tr | PRODUCTION | Non |
+| 18 | QC-Py-19 - Machine Learning Classification pour Directi | PRODUCTION | Non |
+| 19 | QC-Py-20 - Machine Learning Regression pour Price Predi | ALPHA | Non |
+| 20 | QC-Py-21 - Portfolio Optimization avec Machine Learning | ALPHA | Non |
+| 21 | QC-Py-22 - Modern Time Series Deep Learning (SOTA 2024- | PRODUCTION | Non |
+| 22 | QC-Py-23 - State Space Models (Mamba) pour Trading | PRODUCTION | Non |
+| 23 | QC-Py-23b - PatchTST et iTransformer pour Prevision Fin | BETA | Non |
+| 24 | QC-Py-24 - Modèles Génératifs pour Anomaly Detection et | PRODUCTION | Non |
+| 25 | QC-Py-25 - Reinforcement Learning pour le Trading | PRODUCTION | Non |
+| 26 | QC-Py-26 - LLM Trading Signals | BETA | Non |
+| 27 | QC-Py-27 - Production Deployment | ALPHA | Non |
+| 28 | QC-Py-28 - Market Regime Detection | BETA | Non |
+| 29 | QC-Py-30 - LSTM Training Multi-Asset (GPU) | PRODUCTION | Non |
+| 30 | QC-Py-31 - Transformer Encoder Multi-Asset (GPU) | PRODUCTION | Non |
+| 31 | QC-Py-32 - Reinforcement Learning DQN pour le Trading | PRODUCTION | Non |
+| 32 | QC-Py-33 - Reinforcement Learning PPO pour le Trading | PRODUCTION | Non |
+| 33 | QC-Py-34 - SAC et A2C : Comparaison d'Agents RL pour le | PRODUCTION | Non |
+| 34 | QC-Py-35 - Reinforcement Learning pour la Construction  | PRODUCTION | Non |
+| 35 | QC-Py-40 : Paper Trading Binance - Mean Reversion Crypt | PRODUCTION | Non |
+| 36 | QC-Py-41 : Paper Trading IBKR - SP500 Momentum | PRODUCTION | Non |
+| 37 | QC-Py-Cloud-01 : Analyse de Sentiment FinBERT sur QC Cl | PRODUCTION | Non |
+| 38 | QC-Py-Cloud-01 — Risk Parity Composite Multi-Asset | ALPHA | Non |
+| 39 | QC-Py-Cloud-02 : Classification de Texte et Sentiment N | PRODUCTION | Non |
+| 40 | QC-Py-Cloud-02 — Sector Rotation & Multi-Asset Momentum | ALPHA | Non |
+| 41 | QC-Py-Cloud-03 — Dual Momentum : Asset Sélection Matter | ALPHA | Non |
+| 42 | QC-Py-Cloud-03 : Parite de Risque (Risk Parity) | PRODUCTION | Non |
+| 43 | QC-Py-Cloud-04 — Mean Reversion on Sector ETFs | ALPHA | Non |
+| 44 | QC-Py-Cloud-04 : Reinforcement Learning - DQN Trading | PRODUCTION | Non |
+| 45 | QC-Py-Cloud-05 : Prevision par Reseau de Neurones (MLP) | PRODUCTION | Non |
+| 46 | QC-Py-Cloud-05 — Regime Switching : Momentum in Bull, D | ALPHA | Non |
+| 47 | QC-Py-Cloud-06 — PCA Statistical Arbitrage Mean Reversi | ALPHA | Non |
+| 48 | QC-Py-Cloud-06 -- Volatility Targeting : Risk Managemen | ALPHA | Non |
+| 49 | QC-Py-Cloud-07 — Temporal CNN Direction Prediction | ALPHA | Non |
+| 50 | Value Factor Z-Score — Sélection multi-facteurs fondame | ALPHA | Non |
+| 51 | Option Wheel — Le paradoxe du win-rate eleve | ALPHA | Non |
+| 52 | Workflow : Téléchargement et gestion des datasets | PRODUCTION | Non |
+
+## QuantConnect/kelly_lean (1 notebooks)
+
+| # | Notebook | Maturite | Executable |
+|---|----------|----------|------------|
+| 1 | Le critere de Kelly — compagnon Python du lake `kelly_l | ALPHA | Non |
+
+## QuantConnect/projects (48 notebooks)
+
+| # | Notebook | Maturite | Executable |
+|---|----------|----------|------------|
+| 1 | Research QuantBook: Adaptive Asset Allocation | PRODUCTION | Non |
+| 2 | Research QuantBook: All-Weather Portfolio | PRODUCTION | Non |
+| 3 | Alpha Correlation Analysis | BETA | Non |
+| 4 | Research QuantBook: BTC ML Enhanced | ALPHA | Non |
+| 5 | Initializing environment | BETA | Non |
+| 6 | Research QuantBook: Multi-Channel ZigZag Crypto | ALPHA | Non |
+| 7 | Research QuantBook: Deep Learning LSTM pour SPY | ALPHA | Non |
+| 8 | Research QuantBook: DualMomentum (Antonacci) | PRODUCTION | Non |
+| 9 | Research QuantBook: Dual Momentum No TLT | PRODUCTION | Non |
+| 10 | Research QuantBook: EMA-Cross Alpha Model | PRODUCTION | Non |
+| 11 | Research QuantBook: EMA Cross Equity | PRODUCTION | Non |
+| 12 | Research QuantBook: EMA Crossover SPY Index | PRODUCTION | Non |
+| 13 | Research QuantBook: Multi-Stock EMA Crossover | PRODUCTION | Non |
+| 14 | Research QuantBook: ETF Pairs Trading | PRODUCTION | Non |
+| 15 | Research QuantBook: Fama-French Factor ETF Rotation | PRODUCTION | Non |
+| 16 | Research QuantBook: ForexCarry (G10 FX Momentum) | PRODUCTION | Non |
+| 17 | Research QuantBook: Framework Composite EMA-Trend | PRODUCTION | Non |
+| 18 | Research QuantBook: Framework Composite FamaFrench + Al | PRODUCTION | Non |
+| 19 | Research QuantBook: Framework Composite Momentum + Regi | PRODUCTION | Non |
+| 20 | Framework Composite TrendWeather - Research | PRODUCTION | Non |
+| 21 | Research QuantBook: FuturesTrend (Donchian Breakout) | PRODUCTION | Non |
+| 22 | Research QuantBook: ML Classification (RandomForest) | PRODUCTION | Non |
+| 23 | ML Deep Learning - LSTM/GRU pour Trading | ALPHA | Non |
+| 24 | Research QuantBook: ML-Enhanced Pairs Trading | PRODUCTION | Non |
+| 25 | Research QuantBook: ML Ensemble | PRODUCTION | Non |
+| 26 | Research QuantBook: ML Feature Engineering | PRODUCTION | Non |
+| 27 | ML Random Forest - Classification pour Trading | BETA | Non |
+| 28 | Research QuantBook: ML Regression | PRODUCTION | Non |
+| 29 | ML SVM - Support Vector Machine pour Trading | BETA | Non |
+| 30 | ML Text Classification for Trading | ALPHA | Non |
+| 31 | ML XGBoost - Gradient Boosting pour Trading | ALPHA | Non |
+| 32 | Research QuantBook: Mean Reversion (Sector ETFs) | PRODUCTION | Non |
+| 33 | Research QuantBook: MomentumStrategy (Sector ETF Rotati | PRODUCTION | Non |
+| 34 | Research QuantBook: Equity Multi-Layer EMA + ML Filters | PRODUCTION | Non |
+| 35 | Research QuantBook: Option Wheel Strategy | PRODUCTION | Non |
+| 36 | Research QuantBook: Options Wheel Tech Stocks | PRODUCTION | Non |
+| 37 | Research QuantBook: Covered Call Strategy | PRODUCTION | Non |
+| 38 | Research QuantBook: PairsTrading (Statistical Arbitrage | ALPHA | Non |
+| 39 | Portfolio Hybride IBKR (50%) + Binance (50%) — Phase 1  | BETA | Non |
+| 40 | Research QuantBook: RL Portfolio Allocation | ALPHA | Non |
+| 41 | Research QuantBook: RegimeSwitching Alpha Model | PRODUCTION | Non |
+| 42 | Research QuantBook: RiskParity (Inverse-Volatility Weig | PRODUCTION | Non |
+| 43 | Research QuantBook: Sector-Momentum (Dual Momentum) | PRODUCTION | Non |
+| 44 | Research QuantBook: Trend Following Competition | PRODUCTION | Non |
+| 45 | Research QuantBook: TrendStocks Alpha Model | PRODUCTION | Non |
+| 46 | Research QuantBook: TurnOfMonth (Calendar Anomaly) | PRODUCTION | Non |
+| 47 | Research QuantBook: VIX-TermStructure (Short Volatility | ALPHA | Non |
+| 48 | Top-4 Sharpe > 0.5 Stratégies: OOS Deep-Dive (Issue #75 | PRODUCTION | Non |


### PR DESCRIPTION
## Summary

Delivers a second **UPDATE + maintenance-cadence** grain of #7422 (same class as #7491 / HEALTH_DASHBOARD): wire the 5 generated student learning-path pages (`docs/curriculum/*.md`) into the daily catalog cron so they stop drifting, and refresh the committed snapshots to current.

The 5 parcours pages (`ia-classique`, `ia-symbolique`, `genai`, `trading`, `recherche`) are GENERATED by `scripts/notebook_tools/generate_parcours.py` from `COURSE_CATALOG.generated.json` (#3973 curriculum renumbering). They had **no automation** keeping them fresh, so they drifted badly as the catalog grew — e.g. `ia-classique.md` was last regenerated against a much smaller catalog (47 lines, "13 notebooks") while the generator now produces 191 lines off the current 824-notebook catalog.

## Files

- **`.github/workflows/catalog-cron.yml`** — run `generate_parcours.py` right after the catalog regen (reads the just-regenerated catalog → 5 pages stay in lockstep) and stage `docs/curriculum/*.md` in the cron's commit step. +9 lines.
- **`docs/curriculum/{ia-classique,ia-symbolique,genai,trading,recherche}.md`** — refresh committed snapshots to current (generated by the documented script, not hand-edited).

## Firsthand verification (G.1)

Off current main (`b7fe5bbdc`, post-#7475):
```
$ python scripts/notebook_tools/generate_parcours.py --check
  -> 6 uncovered CaseStudies notebooks (informational, not an error)
$ python scripts/notebook_tools/generate_parcours.py
  -> Generated 5 parcours pages
$ git diff --stat
  1181 insertions / 470 deletions across 5 docs + 9 lines on the cron
```
Generator is stdlib-only (argparse/json/sys/pathlib) — runs clean in the cron's Python 3.11 on `ubuntu-latest`.

## Scope notes (honest)

- **Not `COURSE_CATALOG.generated.*`** (the catalog-pr-hygiene HARD 1 target). These are stable downstream artifacts with no git-derived-churn poison, and this branch is off **current main** (no stale-base regen) — the specific failure mode HARD 1 guards against doesn't apply.
- **Generator accent gap** (separate issue, NOT introduced here): `generate_parcours.py`'s prose templates strip French accents (`"avancees"`, `"Metrique"`). The regen faithfully reproduces what was already committed — no regression. Fixing the generator's accent handling is out of scope (a prose-quality PR, not a freshness PR).
- **CRLF**: `docs/curriculum/*.md` are CRLF on main; the regen matches (no whole-file churn from newline flip). The cron workflow stays LF.
- Under G.4 thresholds: 1181 lines (< 3000), 6 files (< 15), 1 feature, 1 domain (docs).

## What this does NOT do

The broader `docs/` triage (#7422 step 1) remains open. From the partial triage posted earlier (comment on #7422): `docs/lean/` is entirely KEEP (referenced infra), `docs/archive/` is already disciplined, root `index.md`/`README.md` verified current. The two concrete drift grains I could safely execute were the generated snapshots — HEALTH_DASHBOARD (#7491) and now the parcours pages (this PR).

See #7422. Part of #4208 Wave 1.

Co-Authored-By: Claude <noreply@anthropic.com>
