### PR TITLE
feat(prover,#7477): classify decomposition-regression honestly (P3)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/decomposition_regression.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/decomposition_regression.py
@@ -1,0 +1,62 @@
+"""P3 (#7477 forensic): classify decomposition-regression honestly.
+
+The Hashlife/conway family macro-signal (forensic #7477, 11 dedup'd runs,
+~16,800s aggregate): **``verified_tactic_count == 0`` in all 11 runs**, and
+the net sorry delta is *negative* (regressions outweigh wins). The founding
+incident (L2551, grew 4->8) scored ``structural_only`` /
+``structural_progress: true`` -- a net sorry-INCREASE decomposition with
+ZERO build-verified tactics, labelled as *progress*. That mis-label corrupts
+forensic ROI: a run that sprayed unproven sub-sorries looks indistinguishable
+from a run that genuinely restructured a hard goal.
+
+P3 separates the two: a net-sorry-INCREASE decomposition is *structural
+progress* only when at least one tactic was build-verified
+(``verified_tactic_count > 0``); with zero verified tactics it is a
+**decomposition-regression** -- more sorries than it started with and nothing
+proved. Surfacing the typed verdict lets ``analyze_traces`` rank these runs
+honestly instead of counting them as progress.
+
+The per-edit ``sorry guard`` ceiling (``tools.py`` decomposition-budget) lets
+a within-budget increase through on purpose (a legitimate decomposition
+raises the count while the sub-goals compile); this module is the RUN-LEVEL
+terminal check that re-classifies the outcome when none of those sub-goals
+was actually *verified closed*. It does not revert the committed snapshot
+(reversion is a separate, riskier decision) -- it classifies.
+
+Stdlib-only and self-contained so it is unit-testable by file-path load on a
+bare CPU runner that lacks the ``agent_framework`` LLM stack (same pattern as
+``heartbeat_budget.py`` / ``forensic_guards.py``).
+
+See #7477 (prover harness forensic). See #1453 (prover co-evolution epic).
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+__all__ = ["is_decomposition_regression"]
+
+
+def is_decomposition_regression(
+    final_sorry: int,
+    original_sorry_count: int,
+    verified_tactic_count: Optional[int],
+) -> bool:
+    """Return True iff the run is a net-sorry-INCREASE decomposition with zero
+    build-verified tactics (the #7477 P3 regression pattern).
+
+    Conditions (all required):
+      - ``final_sorry > original_sorry_count`` -- the sorry count grew (a
+        pure decomposition: same/lower count is never a regression by this
+        signal; a drop is real progress, a same-count is handled by the
+        FX-8 / statement-mutation guard).
+      - ``verified_tactic_count == 0`` -- no tactic was build-verified. A
+        decomposition that produced at least one compiling, verified sub-goal
+        is genuine structural progress and is NOT flagged.
+      - ``verified_tactic_count is None`` returns ``False`` (legacy caller
+        that does not track verified tactics -- cannot classify, preserve
+        prior behaviour rather than guess).
+    """
+    if verified_tactic_count is None:
+        return False
+    return final_sorry > original_sorry_count and verified_tactic_count == 0

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
@@ -17,6 +17,7 @@ from agent_framework import ToolResultCompactionStrategy
 from .trace import TraceLogger
 from .state import ProofState, SorryContext, ProofPhase, PHASE_TRANSITIONS, TacticAttempt
 from .p4_final_verify import _evaluate_final_verify
+from .decomposition_regression import is_decomposition_regression
 from .lean_utils import (
     extract_sorry_block, get_goal_state, verify_sorry_replacement,
     extract_hypotheses, extract_local_lemmas, build_def_type_warnings,
@@ -770,6 +771,10 @@ class MultiAgentSorryProver:
         # "provider was down" apart from "no tactical progress".
         provider_outage = False
         provider_failures = 0
+        # P3 (#7477 forensic): default so the result dict is always defined
+        # even if the verify block raises before the decomposition-regression
+        # check runs.
+        decomposition_regression = False
         try:
             # Build-credited wall-clock supervisor (user mandate 2026-06-21:
             # "mettre en pause le timer de mesure pendant les builds"). A single
@@ -971,6 +976,27 @@ class MultiAgentSorryProver:
         verified_tactic_count = sum(
             1 for a in state.tactic_history if a.success
         )
+        # P3 (#7477 forensic): decomposition-regression guard. A net-sorry-
+        # INCREASE decomposition with ZERO build-verified tactics is a
+        # regression (runaway sub-sorry spraying), not structural progress.
+        # Founder: L2551 grew 4->8, verified_tactic_count==0, yet scored
+        # structural_progress:true -- mis-leading forensic ROI. Demote it
+        # honestly: a decomposition is structural progress ONLY when at least
+        # one tactic was build-verified. Same-count (final==original) stays
+        # the FX-8 / statement-mutation guard's territory; a drop is never a
+        # regression by this signal. Does NOT revert the committed snapshot
+        # (reversion is a separate, riskier decision) -- it classifies,
+        # surfacing decomposition_regression for forensic ROI. Verified>0
+        # decompositions (legitimate restructuring) are untouched.
+        decomposition_regression = is_decomposition_regression(
+            final_sorry, original_sorry_count, verified_tactic_count)
+        if decomposition_regression:
+            print(
+                f"  DECOMPOSITION_REGRESSION: sorry {original_sorry_count}"
+                f" -> {final_sorry} with 0 verified tactic. Net sorry growth"
+                f" unproven -- not structural progress (#7477 P3)."
+            )
+            structural_progress = False
         stmt_mutation = _stmt_mutation_guard(
             final_sorry, original_sorry_count, final_build_ok,
             proof_found, verified_tactic_count,
@@ -1072,6 +1098,13 @@ class MultiAgentSorryProver:
             # no_progress) — the target needs a cheaper tactic / higher
             # maxHeartbeats / decomposition, NOT more iterations.
             "heartbeat_budget_exceeded": getattr(state, "heartbeat_budget_exceeded", False),
+            # P3 (#7477 forensic): True when the run was a net-sorry-INCREASE
+            # decomposition with zero build-verified tactics (runaway sub-sorry
+            # spraying), demoted from structural_progress. Distinct from a
+            # legitimate decomposition (verified_tactic_count > 0, real
+            # restructuring) so forensic ROI ranks these runs honestly instead
+            # of counting an unproven sorry-spray as progress.
+            "decomposition_regression": decomposition_regression,
             # FX-12 (#6790 pathology 3): count of build-verified *structural*
             # edits (file_replace_lines / file_insert_lines whose build_check
             # passed). Distinct from ``structural_progress`` (a boolean

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py
@@ -57,6 +57,12 @@ def _derive_result_kind(result, final_sorry: int, original_sorry: int) -> str:
                           tactic too expensive for the budget. Needs a cheaper
                           tactic / higher maxHeartbeats / decomposition, NOT more
                           iterations.
+      decomposition_regression -> a net-sorry-INCREASE decomposition with ZERO
+                          build-verified tactics (runaway sub-sorry spraying,
+                          #7477 P3). Distinct from structural_only: a real
+                          restructuring has verified_tactic_count > 0. Tells a
+                          coordinator the decomposition was an unproven spray,
+                          NOT progress — do NOT harvest / branch it.
       no_progress      -> diagnostic data only
 
     Real progress outranks the outage flag: a run that lowered the sorry count
@@ -93,6 +99,24 @@ def _derive_result_kind(result, final_sorry: int, original_sorry: int) -> str:
     # NOT more iterations.
     if isinstance(result, dict) and result.get("heartbeat_budget_exceeded"):
         return "heartbeat_budget_exceeded"
+    # P3 (#7477 forensic): a net-sorry-INCREASE decomposition with ZERO build-
+    # verified tactics — a spray of unproven sub-sorries the multi-agent path
+    # previously mis-labelled as structural_progress (founder L2551 grew 4->8
+    # with verified_tactic_count==0 across 11 dedup'd runs). provers.py classifies
+    # this via is_decomposition_regression(final, original, verified) and, on a
+    # regression, forces structural_progress=False + sets the
+    # decomposition_regression flag; this branch surfaces the precise pathology
+    # for the forensic harvest instead of letting it fall through to no_progress.
+    # Ranked AFTER sorry_decreased / structural_only / provider_outage /
+    # correctly_refused / heartbeat_budget_exceeded: those outrank it (a run that
+    # lowered sorry, landed a verified decomposition, or hit an
+    # outage/refusal/budget wall first ranks as that outcome). Mutually exclusive
+    # with structural_only in practice — the P3 guard only fires when
+    # structural_progress was demoted. Legacy-safe: a result dict without the
+    # field (autonomous path / old traces) returns None -> falsy -> no_progress,
+    # identical to the classifier's None->False contract.
+    if isinstance(result, dict) and result.get("decomposition_regression"):
+        return "decomposition_regression"
     return "no_progress"
 
 
@@ -272,7 +296,7 @@ def _run_prover_locked(demo, name, filepath, line, mode, iterations, provider,
         "sorry_reduction": original_sorry - final_sorry,  # positif = progres (lecture non ambigue)
         # Canonical verdict (see _derive_result_kind): sorry_decreased |
         # structural_only | provider_outage | no_progress | crashed |
-        # already_solved | heartbeat_budget_exceeded.
+        # already_solved | heartbeat_budget_exceeded | decomposition_regression.
         "result_kind": result_kind,
         "elapsed_s": round(elapsed, 1),
         "result": result,

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_decomposition_regression.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_decomposition_regression.py
@@ -1,0 +1,130 @@
+"""Unit tests for the decomposition-regression classifier (P3, #7477 forensic).
+
+Loads ``decomposition_regression.py`` DIRECTLY by file path, bypassing
+``prover/__init__.py`` (which cascades the ``agent_framework`` LLM stack,
+absent on a bare CPU runner). The classifier is stdlib-only and
+self-contained, so these tests run everywhere (no agent_framework / Lean /
+network). Mirrors ``tests/test_heartbeat_budget.py``'s file-path load.
+
+The founding incident (forensic #7477): L2551 grew 4->8 (net +4 sorry) with
+``verified_tactic_count == 0`` in all 11 Hashlife/conway family runs, yet
+scored ``structural_progress: true`` -- a net sorry-INCREASE decomposition
+with ZERO build-verified tactics, mis-labelled as progress. This corrupts
+forensic ROI: an unproven sub-sorry spray looks indistinguishable from a
+genuine restructuring.
+
+P3 separates the two: an increase is structural progress only when at least
+one tactic was build-verified; with zero verified tactics it is a
+decomposition-regression. The macro-signal ``verified_tactic_count == 0`` is
+the forensic's own cited diagnostic.
+
+Run from `agent_tests/`:
+    python -m pytest tests/test_decomposition_regression.py -q
+
+See #7477 (prover harness forensic), See #1453 (prover co-evolution epic).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+
+_spec = importlib.util.spec_from_file_location(
+    "prover_decomposition_regression",
+    ROOT / "prover" / "decomposition_regression.py",
+)
+_dr = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_dr)
+
+classify = _dr.is_decomposition_regression
+
+
+# ── Acceptance: the founder incident classifies as regression ──────────────
+
+class TestRegressionDetected:
+    """A net-sorry-INCREASE with zero verified tactics IS a regression."""
+
+    def test_founder_l2551_four_to_eight(self):
+        """The exact forensic #7477 founding incident: 4 -> 8, verified=0."""
+        assert classify(8, 4, 0) is True
+
+    def test_large_runaway_spray(self):
+        """1 -> 10 with nothing verified is runaway sub-sorry spraying."""
+        assert classify(10, 1, 0) is True
+
+    def test_minimal_increase_one(self):
+        """Even a minimal 4 -> 5 with zero verified is a regression
+        (the signal is the unproven growth, not its magnitude)."""
+        assert classify(5, 4, 0) is True
+
+    def test_huge_original_with_growth(self):
+        """100 -> 101, verified=0 -- still a regression (growth + unproven)."""
+        assert classify(101, 100, 0) is True
+
+
+# ── Negative: legitimate progress must NOT be mis-labelled ────────────────
+
+class TestLegitimateProgressNotFlagged:
+    """A decomposition with at least one verified tactic is real structural
+    progress and must stay unflagged (preserves the FX-8 comment's explicit
+    intent: 'a decomposition (final > original, any verified count) ... stay
+    structural progress')."""
+
+    def test_decomposition_with_two_verified(self):
+        """4 -> 6 with 2 build-verified sub-goals = genuine restructuring."""
+        assert classify(6, 4, 2) is False
+
+    def test_decomposition_with_one_verified(self):
+        """Even a single verified tactic means the decomposition produced a
+        compiling, verified sub-goal -- not a spray."""
+        assert classify(6, 4, 1) is False
+
+    def test_large_increase_with_verified(self):
+        """1 -> 10 but 1 tactic verified: the agent proved something in the
+        decomposition, so it is not a pure regression."""
+        assert classify(10, 1, 1) is False
+
+
+class TestNonIncreaseNotFlagged:
+    """A same-count or drop is NEVER a regression by this signal (the
+    increase is the defining condition). Same-count is the FX-8 /
+    statement-mutation guard's territory; a drop is real progress."""
+
+    def test_same_count_zero_verified(self):
+        """4 -> 4, verified=0 is handled by FX-8 / stmt-mutation, not P3."""
+        assert classify(4, 4, 0) is False
+
+    def test_drop_zero_verified(self):
+        """A sorry DROP is never a regression here (it is progress, even if
+        the FX-6 guard separately demotes a drop with 0 verified)."""
+        assert classify(2, 4, 0) is False
+
+    def test_drop_to_zero(self):
+        assert classify(0, 4, 1) is False
+
+    def test_same_count_with_verified(self):
+        assert classify(4, 4, 2) is False
+
+
+# ── Legacy / contract ──────────────────────────────────────────────────────
+
+class TestLegacyAndContract:
+    def test_none_verified_preserves_prior_behaviour(self):
+        """A legacy caller that does not track verified tactics (None) cannot
+        be classified -- preserve prior behaviour rather than guess."""
+        assert classify(8, 4, None) is False
+
+    def test_exports_classify_function(self):
+        assert "is_decomposition_regression" in _dr.__all__
+        assert callable(classify)
+
+    def test_returns_bool_not_truthy(self):
+        """The verdict is persisted to JSON traces and consumed by
+        ``if result['decomposition_regression']``; it must be a real bool."""
+        assert type(classify(8, 4, 0)) is bool
+        assert type(classify(6, 4, 2)) is bool

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_decomposition_regression.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_decomposition_regression.py
@@ -1,0 +1,150 @@
+"""Unit tests for #7477 P3 — ``decomposition_regression`` run verdict.
+
+A net-sorry-INCREASE decomposition with ZERO build-verified tactics (runaway
+sub-sorry spraying) was previously mis-labelled ``structural_progress`` by the
+multi-agent path (founder L2551 grew 4->8 with ``verified_tactic_count==0``
+across 11 dedup'd runs). The fix has two parts:
+
+  1. ``provers.MultiAgentSorryProver`` classifies the outcome via
+     ``is_decomposition_regression(final, original, verified)`` (pure helper in
+     ``prover/decomposition_regression.py``, exercised by
+     ``tests/test_decomposition_regression.py``) and, on a regression, forces
+     ``structural_progress = False`` + sets the ``decomposition_regression``
+     flag on the result dict.
+  2. ``run_prover_bg._derive_result_kind`` gains a ``decomposition_regression``
+     branch (ranked AFTER sorry_decreased / structural_only / provider_outage /
+     correctly_refused / heartbeat_budget_exceeded: real progress and the other
+     forensic siblings outrank it) so the forensic harvest ranks these runs
+     honestly instead of letting them fall through to ``no_progress``.
+
+This module locks in part 2 — the ``_derive_result_kind`` branch — and the
+HARD invariant (mandate user forensic #7477): the result_kinds **coexist**,
+no resolution clobbers a sibling. The classification logic itself (part 1) is
+covered by ``test_decomposition_regression.py``.
+
+Run from ``agent_tests/``::
+
+    python -m pytest tests/test_prover_decomposition_regression.py -q
+
+Requires the prover stack (``agent-framework-openai``) — same collection
+contract as ``tests/test_prover_heartbeat_budget.py``. See #7477 (forensic),
+#1453 (prover co-evolution epic).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make `prover/` importable regardless of how pytest was invoked (same
+# bootstrap convention as tests/test_prover_heartbeat_budget.py).
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+sys.path.insert(0, str(ROOT))
+
+from prover import run_prover_bg  # noqa: E402
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# _derive_result_kind — the decomposition_regression branch
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _derive(result, final_sorry, original_sorry):
+    """Thin wrapper so each test reads as the verdict for one scenario."""
+    return run_prover_bg._derive_result_kind(result, final_sorry, original_sorry)
+
+
+def test_decomposition_regression_when_flag_set():
+    """A run whose result carries decomposition_regression=True (final > original,
+    verified==0 — set by provers.py via is_decomposition_regression) is classified
+    decomposition_regression, not no_progress."""
+    result = {"decomposition_regression": True}
+    assert _derive(result, final_sorry=8, original_sorry=4) == "decomposition_regression"
+
+
+def test_decomposition_regression_flag_needs_truthy():
+    """Flag absent or False falls through to no_progress (no false positive).
+    A legitimate decomposition or a plain stall must NOT be mislabelled."""
+    assert _derive({}, 8, 4) == "no_progress"
+    assert _derive({"decomposition_regression": False}, 8, 4) == "no_progress"
+    assert _derive({"decomposition_regression": None}, 8, 4) == "no_progress"
+
+
+def test_sorry_decreased_outranks_decomposition_regression():
+    """Real progress outranks the diagnostic: a run that lowered the sorry count
+    is still a harvest even if the regression flag was somehow set."""
+    result = {"decomposition_regression": True}
+    assert _derive(result, final_sorry=3, original_sorry=5) == "sorry_decreased"
+
+
+def test_structural_progress_outranks_decomposition_regression():
+    """A verified decomposition landed (structural_progress=True) — structural_only.
+    In practice the P3 guard forces structural_progress=False on a regression, so
+    these are mutually exclusive; the ranking still holds if both were set."""
+    result = {"decomposition_regression": True, "structural_progress": True}
+    assert _derive(result, 8, 4) == "structural_only"
+
+
+def test_provider_outage_outranks_decomposition_regression():
+    """A provider death mid-run is provider_outage regardless of regression flag:
+    the prover never got to work."""
+    result = {"decomposition_regression": True, "provider_outage": True}
+    assert _derive(result, 8, 4) == "provider_outage"
+
+
+def test_correctly_refused_outranks_decomposition_regression():
+    """An explicit Coordinator abandon (intractable) is correctly_refused
+    regardless of the regression flag — the agent refused; it did not spray."""
+    result = {"decomposition_regression": True, "intractable": True}
+    assert _derive(result, 8, 4) == "correctly_refused"
+
+
+def test_heartbeat_budget_exceeded_outranks_decomposition_regression():
+    """A Lean tactic that blew the maxHeartbeats budget (heartbeat_budget_exceeded)
+    outranks decomposition_regression — the sibling is checked first. This is the
+    HARD invariant: the P3 branch does NOT clobber the P5a sibling (#7477)."""
+    result = {"decomposition_regression": True, "heartbeat_budget_exceeded": True}
+    assert _derive(result, 8, 4) == "heartbeat_budget_exceeded"
+
+
+def test_crashed_outranks_decomposition_regression():
+    """An explicit error is crashed regardless of the regression flag."""
+    result = {"error": "kaboom", "decomposition_regression": True}
+    assert _derive(result, 8, 4) == "crashed"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# HARD invariant — siblings preserved (no clobber), 4 branches coexist
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_correctly_refused_sibling_still_works():
+    """The P2a sibling (correctly_refused) is untouched by the P3 branch:
+    a run with only intractable=True still classifies correctly_refused."""
+    assert _derive({"intractable": True}, 5, 5) == "correctly_refused"
+
+
+def test_heartbeat_budget_sibling_still_works():
+    """The P5a sibling (heartbeat_budget_exceeded) is untouched by the P3 branch:
+    a run with only heartbeat_budget_exceeded=True still classifies as such."""
+    assert _derive({"heartbeat_budget_exceeded": True}, 5, 5) == "heartbeat_budget_exceeded"
+
+
+def test_four_forensic_siblings_coexist():
+    """The 4 forensic result_kinds coexist: each flag, set alone, yields its own
+    verdict (none is shadowed by another). This is the mandate-user HARD
+    invariant for #7477 — no resolution overwrites a sibling."""
+    assert _derive({"intractable": True}, 5, 5) == "correctly_refused"
+    assert _derive({"heartbeat_budget_exceeded": True}, 5, 5) == "heartbeat_budget_exceeded"
+    assert _derive({"decomposition_regression": True}, 8, 4) == "decomposition_regression"
+    # structural_only is the 4th forensic-adjacent kind (verified decomposition).
+    assert _derive({"structural_progress": True}, 5, 5) == "structural_only"
+
+
+def test_plain_no_progress_unchanged():
+    """A flat run (no flag, final==original) is still no_progress — the P3 branch
+    only fires on the explicit decomposition_regression flag, never on shape."""
+    assert _derive({}, 5, 5) == "no_progress"


### PR DESCRIPTION
## What

**P3 (#7477 forensic)** — typed `decomposition_regression` classification for the prover harness. The founding incident (forensic #7477, Hashlife/conway family, 11 dedup'd runs, ~16,800s aggregate): **`verified_tactic_count == 0` in all 11 runs**, and the net sorry delta is *negative* (regressions outweigh wins). L2551 grew **4→8** (net +4) with zero build-verified tactics, yet scored `structural_only` / `structural_progress: true` — a net sorry-INCREASE decomposition mis-labelled as *progress*, corrupting forensic ROI (an unproven sub-sorry spray looks indistinguishable from a genuine restructuring).

P3 separates the two: an increase is *structural progress* only when at least one tactic was build-verified (`verified_tactic_count > 0`); with zero verified tactics it is a **decomposition-regression**. The `verified_tactic_count == 0` macro-signal is the forensic's own cited diagnostic.

**Distinct pathology** from P5a (heartbeat wall, PR #7502) and P2b (launcher DO-NOT-TARGET, #7488 MERGED). See #7477 (forensic). See #1453 (prover co-evolution epic).

## Bug (reproduced firsthand on origin/main `f166be8d0`)

`provers.py` MultiAgentSorryProver.prove_sorry, the structural-progress block:

```python
if (final_sorry >= original_sorry_count and not proof_found):   # L857
    if last_ok_content and last_ok_content != original_content:
        # ... restore last build-passing snapshot
        structural_progress = True                                # L865 — BUG
```

`structural_progress = True` is set on a net-sorry-INCREASE (the `>=` covers `final > original`) whenever a build-passing snapshot exists, **without checking `verified_tactic_count`**. So L2551 (4→8, verified=0) set `structural_progress = True`. The autonomous-path FX-8 guard (`_autonomous_success_gate` L305-306) only blocks the EQUALITY case (`final == original ∧ verified == 0`) — the increase case slips through on the multi-agent path.

## Fix (root cause, classification — does NOT revert the snapshot)

**New stdlib-only module `prover/decomposition_regression.py`** — pure classifier `is_decomposition_regression(final_sorry, original_sorry_count, verified_tactic_count)`: True iff `final_sorry > original_sorry_count AND verified_tactic_count == 0` (None → False, legacy-safe). Stdlib-only so it is unit-testable by file-path load on a bare CPU runner lacking the `agent_framework` LLM stack — same proven pattern as `heartbeat_budget.py` / `forensic_guards.py`.

**`provers.py`** (MultiAgentSorryProver, the DEMO 62 prover) — 3 bounded additions:
1. `from .decomposition_regression import is_decomposition_regression` (L19).
2. Default `decomposition_regression = False` before the try block (so the result dict is always defined even if the verify raises early) — mirrors the `provider_outage = False` default.
3. After `verified_tactic_count` is computed: classify, and when it IS a regression, force `structural_progress = False` + print a diagnostic. This is the correctness fix (a regression is no longer labelled progress).
4. New result-dict field `"decomposition_regression"` (forensic visibility for `analyze_traces`).

**Does NOT revert the committed snapshot** — reversion is a separate, riskier decision (could destroy a legitimate-in-progress decomposition). P3 *classifies* the outcome honestly, matching the forensic's wording ("classify decomposition_regression, not progress").

## Anti-regression protocol (CLAUDE.md section D)

1. **Exact problem**: L2551 grew 4→8 (verified=0), scored `structural_progress:true` — net sorry-INCREASE labelled as progress, corrupting forensic ROI (#7477 forensic, corroborated across 11 runs).
2. **3 tactics**: (a) pure classifier + force structural_progress=False on regression **[chosen — surgical tightening, legitimate cases untouched, testable CPU]**; (b) tighten the FX-8 guard itself to cover the increase case **[rejected — FX-8 is the autonomous path's shared gate; the incident is multi-agent, and broadening FX-8 risks the explicitly-preserved "final > original, any verified" legitimate decomposition]**; (c) revert the regressed snapshot **[rejected — riskier, could destroy legitimate in-progress decomposition; forensic asks to CLASSIFY not REVERT]**.
3. **Coherent diff**: +1 stdlib-only module (60L), provers.py +33 (import + default + check + field, **0 deletion**), +1 test (~150L). **0 deletion on production code.** No `sorry`/stub/`return None`. provers.py `py_compile` OK.
4. **Consumers verified firsthand**: `grep "decomposition_regression"` repo-wide = 0 consumer outside this PR (new field, additive). The verdict mirrors `provider_outage`/`heartbeat_budget_exceeded` typed-sibling pattern. **Behavior is TIGHTENING only** (regression demoted from progress); legitimate decomposition (verified>0), same-count (FX-8/stmt-mutation), and drop (FX-6) are all untouched — traced case-by-case:
   - legit decomposition (final=6, orig=4, verified=2) → `is_decomposition_regression`=False → structural_progress unchanged (preserved) ✓
   - regression (final=8, orig=4, verified=0) → True → structural_progress=False, success=False ✓ (the fix)
   - same-count (final=4, orig=4, verified=0) → False → FX-8/stmt-mutation as before ✓
   - drop (final=2, orig=4, verified=0) → False → FX-6 as before ✓

## Validation (reproducible, CPU-only)

```
$ cd MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests
$ python -m pytest tests/test_decomposition_regression.py -q
14 passed in 0.06s
$ python -m pytest tests/test_decomposition_regression.py tests/test_prover_forensic_guards.py -q
45 passed in 0.09s
```

**14 tests CPU-only self-contained** (file-path load; no agent_framework / Lean / network). Cover:
- `TestRegressionDetected` (4): founder L2551 4→8 verified=0 → True; large runaway spray; minimal 4→5; huge original 100→101.
- `TestLegitimateProgressNotFlagged` (3): decomposition with verified=2 / verified=1 / large increase with verified=1 → False (FX-8 intent preserved).
- `TestNonIncreaseNotFlagged` (4): same-count (FX-8 territory), drop, drop-to-zero, same-count+verified → False.
- `TestLegacyAndContract` (3): None verified → False (legacy-safe); export contract; returns real `bool`.

**Regression**: `test_prover_forensic_guards.py` 31/31 pass (file-path-load sibling, unchanged). provers.py `py_compile` OK.

## Conformity

- Atomic: 1 domain (prover harness classification, P3), 1 pathology, root-cause (honest classification vs mis-label).
- **`See #7477`** + **`See #1453`** (Epic parent). Not `Closes` — P3 is 1 part of the #7477 multi-part forensic (P1a/P1b/P2a/P2b/P5a MERGED/in-flight; P4/P5b/P6 remain separate grains).
- Anti-regression: 0 production code/proof replaced by sorry/stub; 4-step documented; behavior tightening-only, case-by-case traced; stdlib-only classifier evidence-cited.
- Not bundled with P5a/#7502 (separate pathology, separate PR) — this PR is off a clean `f166be8d0` base without #7502's changes.
- No C.2 implication: 0 notebook modified (Python source + test only).
- Catalogue byte-identical to `main` (0 catalogue change).
- Fresh base off `origin/main` `f166be8d0`, isolated worktree `CoursIA-prover-p3`.
- Pre-flight collision check: `decomposition_regression` absent from repo (0 name collision). `gh pr list --search "decomposition regression"` = 0 OPEN PR touching this pathology.
- Local-git-only (ai-01 constraint): no `gh` ops in sub-agents, all `git` local.
- No API key, no QC Cloud, no GPU, no Lean build, no LLM call (stdlib classifier + file-path-load test, CPU offline).
