### PR TITLE
fix(notebook-tools): dotnet_executor shuts down kernel on setup failure (Fix C)

### DIFF
--- a/scripts/notebook_tools/dotnet_executor.py
+++ b/scripts/notebook_tools/dotnet_executor.py
@@ -66,16 +66,26 @@ def execute_notebook(notebook_path, kernel_name=".net-csharp", cell_timeout=120,
     notebook_dir = notebook_path.parent.resolve()
     orig_dir = os.getcwd()
 
-    km = jupyter_client.KernelManager(kernel_name=kernel_name)
-    km.start_kernel(cwd=str(notebook_dir))
-    kc = km.client()
-    kc.start_channels()
-
+    # Kernel lifecycle objects are initialized to None BEFORE the try so the
+    # finally can robustly clean up partial setups. start_kernel / client /
+    # start_channels live INSIDE the try: if setup fails AFTER start_kernel()
+    # succeeds (e.g. start_channels() raises on a broken kernel transport), the
+    # started kernel must still be shut down -- otherwise the .NET kernel
+    # process is leaked as an orphan (notably on Windows). Previously the
+    # finally only wrapped cell execution, so a setup failure skipped cleanup
+    # entirely and leaked the kernel.
+    km = None
+    kc = None
     stats = {"total": len(code_cells), "executed": 0, "errors": 0, "time": 0}
     exec_counter = 0
     start_time = time.time()
 
     try:
+        km = jupyter_client.KernelManager(kernel_name=kernel_name)
+        km.start_kernel(cwd=str(notebook_dir))
+        kc = km.client()
+        kc.start_channels()
+
         # Wait for kernel ready
         time.sleep(3)
 
@@ -178,8 +188,20 @@ def execute_notebook(notebook_path, kernel_name=".net-csharp", cell_timeout=120,
     finally:
         elapsed = round(time.time() - start_time, 1)
         stats["time"] = elapsed
-        kc.stop_channels()
-        km.shutdown_kernel()
+        # Guarded cleanup: kc/km may be None if setup failed before they were
+        # fully created, and stop_channels / shutdown_kernel may themselves
+        # raise on a half-started kernel. Swallow cleanup-side errors so the
+        # ORIGINAL setup/execution error propagates instead of being masked.
+        if kc is not None:
+            try:
+                kc.stop_channels()
+            except Exception:
+                pass
+        if km is not None:
+            try:
+                km.shutdown_kernel()
+            except Exception:
+                pass
         os.chdir(orig_dir)
 
     # Write back

--- a/scripts/notebook_tools/tests/test_dotnet_executor.py
+++ b/scripts/notebook_tools/tests/test_dotnet_executor.py
@@ -392,3 +392,42 @@ def test_drain_after_timeout_consumes_interrupted_idle(tmp_path, _patch_kernelma
     assert cells[1]["execution_count"] == 2
     assert any("TIMEOUT" in o.get("text", "") for o in cells[0]["outputs"])
     assert any("TIMEOUT" in o.get("text", "") for o in cells[1]["outputs"])
+
+
+# --- Fix C: setup-failure kernel leak (lifecycle finally scope) -------------
+
+def test_setup_failure_after_start_shuts_down_kernel(tmp_path, _patch_kernelmanager):
+    """Fix C: if setup fails AFTER ``start_kernel()`` succeeds (e.g.
+    ``start_channels()`` raises on a broken kernel transport), the started
+    kernel must STILL be shut down. Before Fix C the ``finally`` only wrapped
+    cell execution — setup lived outside the try — so a setup failure skipped
+    cleanup entirely and the .NET kernel process was leaked (orphan, notably on
+    Windows). ``shutdown_kernel`` must now be called even when ``start_channels``
+    raises.
+
+    Non-vacuous: on the unpatched module ``shutdown_kernel`` is never reached
+    (call_count 0 — the leak); on the patched module it is called once.
+    """
+    nb = _write_nb(tmp_path / "n.ipynb", [_code_cell("var x = 1;")])
+    km, kc = _patch_kernelmanager([[_msg("status", execution_state="idle")]])
+    kc.start_channels.side_effect = RuntimeError("start_channels: broken transport")
+
+    with pytest.raises(RuntimeError, match="broken transport"):
+        dotnet_executor.execute_notebook(nb)
+
+    km.start_kernel.assert_called_once()      # kernel WAS started
+    km.shutdown_kernel.assert_called_once()   # AND shut down (no leak)
+
+
+def test_setup_failure_surfaces_original_error_not_cleanup_error(tmp_path, _patch_kernelmanager):
+    """Fix C finally guard: the cleanup is wrapped so a cleanup-side error
+    (``shutdown_kernel`` raising on a half-built manager) does NOT mask the
+    ORIGINAL setup error. The surfaced exception is the start_channels cause."""
+    nb = _write_nb(tmp_path / "n.ipynb", [_code_cell("var x = 1;")])
+    km, kc = _patch_kernelmanager([[_msg("status", execution_state="idle")]])
+    kc.start_channels.side_effect = RuntimeError("start_channels: broken transport")
+    km.shutdown_kernel.side_effect = RuntimeError("shutdown: never started")
+
+    with pytest.raises(RuntimeError, match="broken transport"):
+        dotnet_executor.execute_notebook(nb)
+    km.shutdown_kernel.assert_called_once()  # guard attempted cleanup, then swallowed


### PR DESCRIPTION
## Summary

Self-found **Fix C** for `scripts/notebook_tools/dotnet_executor.py` — the canonical .NET Interactive cell-by-cell executor (consumed by `notebook_helpers.py`, the pipeline that gives notebooks real `execution_count` / outputs). Pure lifecycle-robustness fix + 2 non-vacuous tests. Catalog byte-identical to `origin/main`, 2 files (+68/−7).

## Bug firsthand

`execute_notebook` placed the kernel lifecycle cleanup (`kc.stop_channels()` / `km.shutdown_kernel()`) in a `finally` that wrapped **only** cell execution. The setup phase — `km.start_kernel()` / `km.client()` / `kc.start_channels()` — ran **before** the `try`. So a setup failure **after** `start_kernel()` succeeded (e.g. `start_channels()` raising on a broken kernel transport) skipped the `finally` entirely → the started .NET kernel was **never shut down** (orphan process, notably on Windows).

```
km = jupyter_client.KernelManager(...)   # outside try
km.start_kernel(cwd=...)                  # succeeds -> kernel IS running
kc = km.client()
kc.start_channels()                       # raises -> propagates BEFORE the try
...                                       # finally never reached -> LEAK
try: ... finally: kc.stop_channels(); km.shutdown_kernel()
```

## Fix — guarded lifecycle (Fix C)

1. Initialize `km = None`, `kc = None` **before** the try.
2. Move `start_kernel` / `client` / `start_channels` **inside** the try.
3. Guard the finally: `if kc is not None: try: kc.stop_channels() except: pass`; same for `km.shutdown_kernel()`. The cleanup-side error is swallowed so the **original** setup/execution error propagates instead of being masked.

Pure restructure on the happy/timeout paths (`kc`/`km` are always non-None there) — the only behavior change is that a setup failure now cleans up instead of leaking. The CWD logic (`start_kernel(cwd=notebook_dir)` for `#load` directives) is untouched.

## G.1 self-catch (stale-tree inventory)

My initial scan reported `dotnet_executor.py` as **0 tests**. That scan ran against the **shared working tree**, which is ~1112 commits behind `origin/main` (its `main` ref is stuck at `1e69d7cdc` from 2026-07-12). A 394-line `test_dotnet_executor.py` (Fix A parent-filter + Fix B interrupt/drain) was added to `origin/main` after that date. Re-verified against `origin/main`: the test file exists and covers the happy/timeout/message-routing paths — but **none** of its tests exercise a setup failure (all use a happy-path kernel mock). Fix C is therefore novel (the bug is unfixed on `origin/main`), and this PR **extends** the existing suite rather than duplicating it.

## Tests — 2 added (Fix C), reusing the suite's fakes

| Test | Pin |
|------|-----|
| `test_setup_failure_after_start_shuts_down_kernel` | **Non-vacuous**: on the unpatched module `shutdown_kernel` is called **0 times** (the leak); on the patched module **1 time** |
| `test_setup_failure_surfaces_original_error_not_cleanup_error` | the finally guard swallows a cleanup-side error so the original `start_channels` cause surfaces |

## Validation

```
$ python -m pytest scripts/notebook_tools/tests/test_dotnet_executor.py -q   # patched
23 passed in 0.39s   (21 baseline + 2 new Fix-C — 0 regression)

# Non-vacuous proof (git stash the source fix, run only Fix-C tests on unpatched):
$ python -m pytest ... -k setup_failure -q
2 failed   (AssertionError: Expected 'shutdown_kernel' to have been called once. Called 0 times.)
# restore fix -> 2 passed

$ python -m pytest scripts/notebook_tools/tests/ -q                            # full dir
3191 passed in 66.00s   (0 regression across the whole notebook_tools suite)
```

CPU-only (mocks `jupyter_client.KernelManager` / client with `MagicMock` fakes) → **no live kernel, no network, no .NET runtime**. `time.sleep` patched out. Deterministic.

## Scope / collision

- `gh pr list --json files` (open) → only #7501 (po-2023, `check_c2_compliance.py`) touches `scripts/`; `dotnet_executor.py` clear. po-2025 evaluated then **renounced** `execute_dotnet_notebook.py` (a different file) as borderline — no overlap.
- Single subject (Fix C lifecycle leak + its non-vacuous tests), 2 files, +68/−7. Catalog byte-identical to `origin/main`.
- Worktree fresh off `origin/main` `f166be8d0`.
