### PR TITLE
fix(gametheory): guard compute_payoff_matrix rounds<=0 (crash/NaN-silent)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/game_theory_utils.py
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_utils.py
@@ -505,6 +505,19 @@ def compute_payoff_matrix(strategies: List[Strategy], rounds: int = 200) -> np.n
 
     M[i,j] = average payoff per round for strategy i against strategy j
     """
+    # Guard against rounds <= 0: the per-cell average ``score1 / rounds``
+    # divides by zero for ``rounds == 0`` (ZeroDivisionError, reproduced
+    # firsthand) and silently yields a matrix of ``-0.0`` for ``rounds < 0``
+    # (``range(neg)`` runs no rounds -> score1 == 0 -> ``0 / -5``). Same
+    # degenerate-input guard bug-class as ``replicator_dynamics`` (#7495, this
+    # module), ``kuhn_poker_cfr.train`` (#7489, ``iterations <= 0``) and
+    # ``shapley_value_monte_carlo`` (#7481, ``n_samples <= 0``): an integer
+    # loop-count the caller controls, admitted without validation, that crashes
+    # or NaNs on the non-positive value instead of raising a clear ValueError.
+    if rounds <= 0:
+        raise ValueError(
+            f"rounds must be positive, got {rounds}"
+        )
     n = len(strategies)
     M = np.zeros((n, n))
 

--- a/MyIA.AI.Notebooks/GameTheory/tests/test_strategies.py
+++ b/MyIA.AI.Notebooks/GameTheory/tests/test_strategies.py
@@ -276,5 +276,42 @@ class TestReplicatorDynamics:
             assert abs(np.sum(trajectory[t]) - 1.0) < 1e-9
 
 
+class TestComputePayoffMatrixGuard:
+    """compute_payoff_matrix must reject rounds <= 0 explicitly.
+
+    Before the guard, the per-cell average ``M[i,j] = score1 / rounds`` divided
+    by zero for ``rounds == 0`` (ZeroDivisionError) and silently returned a
+    matrix of ``-0.0`` for ``rounds < 0`` (``range(neg)`` runs no rounds, so
+    ``score1 == 0`` and ``0 / -5 == -0.0``). Same degenerate-input guard
+    bug-class as ``replicator_dynamics`` (#7495), ``kuhn_poker_cfr.train``
+    (#7489, ``iterations <= 0``) and ``shapley_value_monte_carlo`` (#7481,
+    ``n_samples <= 0``). The guard unifies the contract: the sibling functions
+    in the same module already defend the degenerate zero-total division
+    (``replicator_dynamics`` normalization, ``CFRSolver.get_strategy``), but
+    ``compute_payoff_matrix`` divided by ``rounds`` without validating it.
+    """
+
+    def test_compute_payoff_zero_rounds_raises(self):
+        """rounds=0 -> ZeroDivisionError before fix; ValueError proper after."""
+        strategies = [TitForTat(), AlwaysDefect()]
+        with pytest.raises(ValueError, match="rounds must be positive"):
+            compute_payoff_matrix(strategies, rounds=0)
+
+    def test_compute_payoff_negative_rounds_raises(self):
+        """rounds<0 -> ``range(neg)`` empty + ``0 / -5`` = -0.0 silent before fix."""
+        strategies = [TitForTat(), AlwaysDefect()]
+        with pytest.raises(ValueError, match="rounds must be positive"):
+            compute_payoff_matrix(strategies, rounds=-5)
+
+    def test_compute_payoff_positive_rounds_unaffected(self):
+        """The guard does not impact the normal path (shape + determinism)."""
+        strategies = [TitForTat(), AlwaysDefect()]
+        M = compute_payoff_matrix(strategies, rounds=50)
+        assert M.shape == (2, 2)
+        # TitForTat vs TitForTat over 50 rounds: mutual cooperation -> R per
+        # round. Sanity-bounds the average (no crash, no NaN).
+        assert not np.isnan(M).any()
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## What

Bug-fix in `MyIA.AI.Notebooks/GameTheory/game_theory_utils.py:compute_payoff_matrix` — the per-cell average `M[i,j] = score1 / rounds` (L516) was unguarded, so `rounds=0` divided by zero (`ZeroDivisionError`) and `rounds<0` silently returned a matrix of `-0.0` (`range(neg)` runs no rounds → `score1=0` → `0/-5`). **Same degenerate-input guard bug-class as `replicator_dynamics` (#7495, this module), `kuhn_poker_cfr.train` (#7489, `iterations<=0`) and `shapley_value_monte_carlo` (#7481, `n_samples<=0`)** — all MERGED. Found by reading the whole module after #7495 (the sibling-guard consistency gap: every other caller-controlled integer loop-count in the codebase was already guarded; `compute_payoff_matrix` was the lone unguarded instance in this module).

## Bug (reproduced firsthand)

```python
>>> from game_theory_utils import compute_payoff_matrix, AlwaysCooperate, AlwaysDefect
>>> strats = [AlwaysCooperate(), AlwaysDefect()]
>>> compute_payoff_matrix(strats, rounds=0)
ZeroDivisionError: division by zero
>>> compute_payoff_matrix(strats, rounds=-5)
array([[-0., -0.],
       [-0., -0.]])   # silent: range(-5) runs no rounds -> score1=0 -> 0/-5
```

## Fix (root cause, sibling-guarded)

```python
if rounds <= 0:
    raise ValueError(f"rounds must be positive, got {rounds}")
```

Mirrors the two existing guards for the exact same caller-controlled loop-count bug-class:
1. `kuhn_poker_cfr.train` (#7489): `if iterations <= 0: raise ValueError("iterations must be positive")`
2. `shapley_value_monte_carlo` (#7481): `if n_samples <= 0: raise ValueError("n_samples must be positive")`

Closes a guard-consistency gap: `compute_payoff_matrix` divided by `rounds` without validating it, while its module sibling `replicator_dynamics` (and `CFRSolver.get_strategy`) already defend their degenerate divisions.

## Anti-regression protocol (CLAUDE.md section D)

1. **Exact failure**: `ZeroDivisionError: division by zero` (rounds=0) + silent `-0.0` matrix (rounds<0). Reproduced firsthand above.
2. **3 tactics**: (a) entry guard `raise ValueError` **[chosen — matches kuhn train #7489 + shapley #7481]**; (b) fallback to `np.zeros((n,n))` on rounds<=0 **[rejected — hides caller bugs, inconsistent with the raise-contract of the sibling guards]**; (c) clamp `rounds=max(1,rounds)` **[rejected — silently mutates caller intent]**.
3. **Coherent diff**: `game_theory_utils.py` +13/−0 (guard + comment, 0 deletion on existing logic), `tests/test_strategies.py` +37/−0 (3 new regression tests). **0 deletion on production code.**
4. **Consumers verified**: `grep -rn "compute_payoff_matrix"` → only `game_theory_utils.py` (def), `tests/test_strategies.py:219` (`rounds=50`, positive), `GameTheory-6-EvolutionTrust.ipynb` (always `rounds=200`). No caller depends on the old crash/-0.0 behavior.

## Validation (reproducible, CPU-only)

```
$ cd MyIA.AI.Notebooks/GameTheory
$ python -m pytest tests/test_strategies.py -q
27 passed in 0.58s   # 24 baseline (incl. #7495 TestReplicatorDynamics) + 3 new
```

3 new regression tests in `TestComputePayoffMatrixGuard`:
- `test_compute_payoff_zero_rounds_raises` — rounds=0 → `ValueError("rounds must be positive")` (was ZeroDivisionError before fix).
- `test_compute_payoff_negative_rounds_raises` — rounds=-5 → `ValueError` (was silent -0.0 matrix before fix).
- `test_compute_payoff_positive_rounds_unaffected` — rounds=50 → shape (2,2), no NaN (normal path intact).

Tests are G.9 non-vacuous: on unpatched code, test 1 FAILs (ZeroDivisionError is not ValueError) and test 2 FAILs (DID NOT RAISE).

## Conformity

- Atomic: 1 domain (GameTheory util numerical-robustness), 1 bug, root-cause fix.
- **`See #7481`** (same degenerate-input guard bug-class, partial contribution). Not `Closes` — no tracking issue for `compute_payoff_matrix` specifically, and the bug-class vein (#7481/#7489/#7495) is already MERGED.
- Anti-regression: 0 production code/proof replaced by sorry/stub; 4-step documented; sibling-guard evidence cited.
- No C.2 implication: 0 notebook modified (Python source + test only).
- Catalogue byte-identical to `main` (0 catalogue change — not a CATALOG marker).
- Fresh rebase off `origin/main` `f166be8d0`, isolated worktree `CoursIA-payoff-guard`.
- Pre-flight collision check: `gh pr list --search "compute_payoff game_theory"` = 0 OPEN; `gh pr list --search "game_theory_utils"` = 0 OPEN. #7495 (replicator) scope-verified firsthand (touched only L551 normalization, not compute_payoff_matrix).
- No API key, no QC Cloud, no GPU, no Lean build, no LLM call (numpy-only CPU, tested offline).
- Cross-fork PR (credential drift: worker cannot `gh auth switch -u jsboige`, #1502).

Co-Authored-By: Claude-Code <noreply@anthropic.com>