### PR TITLE
fix(gametheory): guard compute_payoff_matrix rounds<=0 (ZeroDivisionError)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/game_theory_utils.py
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_utils.py
@@ -508,6 +508,9 @@ def compute_payoff_matrix(strategies: List[Strategy], rounds: int = 200) -> np.n
     n = len(strategies)
     M = np.zeros((n, n))
 
+    if rounds <= 0:
+        raise ValueError(f"rounds must be positive, got {rounds}")
+
     for i in range(n):
         for j in range(n):
             s1 = type(strategies[i])()

--- a/MyIA.AI.Notebooks/GameTheory/tests/test_strategies.py
+++ b/MyIA.AI.Notebooks/GameTheory/tests/test_strategies.py
@@ -220,6 +220,22 @@ class TestReplicatorDynamics:
 
         assert M.shape == (2, 2)
 
+    def test_compute_payoff_matrix_zero_rounds_raises(self):
+        """rounds <= 0 doit echouer explicitement (ValueError), pas crasher
+        en ZeroDivisionError. Avant le guard, `M[i, j] = score1 / rounds`
+        divisait par 0. Meme bug-class degenerate-input que #7481 (shapley
+        n_samples<=0), #7489 (kuhn_poker iterations<=0), #7495 (replicator
+        normalization)."""
+        strategies = [AlwaysCooperate(), AlwaysDefect()]
+        with pytest.raises(ValueError, match="rounds must be positive"):
+            compute_payoff_matrix(strategies, rounds=0)
+
+    def test_compute_payoff_matrix_negative_rounds_raises(self):
+        """rounds < 0 doit aussi echouer explicitement (consistance du guard)."""
+        strategies = [AlwaysCooperate(), AlwaysDefect()]
+        with pytest.raises(ValueError, match="rounds must be positive"):
+            compute_payoff_matrix(strategies, rounds=-1)
+
     def test_replicator_trajectory_shape(self):
         """Replicator dynamics should return correct shape."""
         M = np.array([[3, 0], [5, 1]])


### PR DESCRIPTION
## What

Bug-fix in `GameTheory/game_theory_utils.py:compute_payoff_matrix` — the per-cell normalization `M[i, j] = score1 / rounds` was unguarded, so `rounds=0` (or any non-positive value a caller might pass) raised `ZeroDivisionError`. **Same degenerate-input guard bug-class as #7481 (shapley `n_samples<=0`, MERGED), #7489 (kuhn_poker `iterations<=0`, MERGED), and #7495 (replicator normalization, MERGED).** This PR closes the remaining locus in that bug-class.

## Bug (reproduced firsthand, G.1)

`compute_payoff_matrix(strategies, rounds)` builds the pairwise payoff matrix `M[i,j] = average payoff per round`. At L516 a bare `score1 / rounds`:

```python
>>> from game_theory_utils import compute_payoff_matrix, AlwaysCooperate, AlwaysDefect
>>> compute_payoff_matrix([AlwaysCooperate(), AlwaysDefect()], rounds=0)
ZeroDivisionError: division by zero
```

`rounds` is an integer-count parameter with default `200` but no lower-bound validation — a caller passing `rounds=0` (e.g. an adaptive/metric loop that derives `rounds` from a budget that can hit 0) crashes instead of failing explicitly. Identical shape to `shapley_value_monte_carlo(n_samples<=0)` (#7481) and `kuhn_poker.train(iterations<=0)` (#7489).

## Fix (matches the established guard style)

Input validation at the top of `compute_payoff_matrix`, identical to `shapley.py:139-140` (`n_samples`) and `kuhn_poker_cfr.py:147-149` (`iterations`):

```python
if rounds <= 0:
    raise ValueError(f"rounds must be positive, got {rounds}")
```

Sister functions in the same family confirmed **not** part of this bug-class (no division by the count param):
- `play_match(..., rounds)` — `rounds` is a loop count only (`for _ in range(rounds)`); `rounds<=0` yields 0 scores, no crash.
- `run_tournament(..., rounds)` — divides by `match_count[name]` (≥1 for every name in `scores`, since both are incremented together), not by `rounds`.

So the locus is exactly `compute_payoff_matrix` — atomic, one locus per PR (the sweep's convention: #7481, #7489, #7495, now this).

## Tests (matches the kuhn_poker test style)

Two tests added to `TestReplicatorDynamics` (where the existing `test_payoff_matrix_shape` lives), matching `test_kuhn_poker_cfr.py:340-342`:

```python
def test_compute_payoff_matrix_zero_rounds_raises(self):
    strategies = [AlwaysCooperate(), AlwaysDefect()]
    with pytest.raises(ValueError, match="rounds must be positive"):
        compute_payoff_matrix(strategies, rounds=0)

def test_compute_payoff_matrix_negative_rounds_raises(self):
    strategies = [AlwaysCooperate(), AlwaysDefect()]
    with pytest.raises(ValueError, match="rounds must be positive"):
        compute_payoff_matrix(strategies, rounds=-1)
```

## Validation

- Bug reproduced firsthand pre-fix: `ZeroDivisionError('division by zero')` at `rounds=0`.
- Post-fix: `ValueError("rounds must be positive, got 0")` / `"...got -1"`.
- `python -m pytest tests/test_strategies.py -q` → **26 passed** (24 existing + 2 new, no regression).
- Line endings preserved (LF, CR count = 0 on both files).
- `git diff --stat`: 2 files, 19 ins / 0 del (pure additions).

## See

- #7481 (shapley `n_samples<=0`), #7489 (kuhn_poker `iterations<=0`), #7495 (replicator normalization) — the degenerate-input guard bug-class this completes.
