### PR TITLE
docs(genai-image,#3974): reference tutorials/ subfolder + assets/ in structure tree

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Image/README.md
@@ -29,7 +29,9 @@ Image/
 ├── 02-Advanced/       # Modèles avancés
 ├── 03-Orchestration/  # Multi-modèles
 ├── 04-Applications/   # Production
-└── examples/          # Cas d'usage
+├── assets/            # Médias partagés (couvertures, panneaux)
+├── examples/          # Cas d'usage par domaine
+└── tutorials/         # Guides de référence (markdown)
 ```
 
 ## Progression par niveau
@@ -136,6 +138,17 @@ Applications directes par domaine : histoire-géographie (cartes, reconstitution
 | [history-geography](examples/history-geography.ipynb) | Histoire-Géographie |
 | [literature-visual](examples/literature-visual.ipynb) | Littérature |
 | [science-diagrams](examples/science-diagrams.ipynb) | Diagrammes scientifiques |
+
+### tutorials/ - Guides de référence
+
+Section transversale de guides markdown (pas de notebooks) — quatre références longues pour approfondir un aspect précis du pipeline image, à consulter après avoir pratiqué les notebooks ci-dessus :
+
+| Guide | Sujet |
+|-------|-------|
+| [dalle3-complete-guide](tutorials/dalle3-complete-guide.md) | DALL-E 3 de bout en bout — prompt engineering, exemples, retrait OpenAI et remplacement par gpt-image-1 |
+| [educational-workflows](tutorials/educational-workflows.md) | Concevoir des workflows ComfyUI orientés production pédagogique (vignettes, schémas, planches de cours) |
+| [gpt5-image-analysis-guide](tutorials/gpt5-image-analysis-guide.md) | GPT-5 Image : forces, faiblesses, structure de prompt recommandée, comparaison à gpt-image-1 |
+| [openrouter-ecosystem-guide](tutorials/openrouter-ecosystem-guide.md) | Routage multi-modèles via OpenRouter — DALL-E / GPT-5 / Stability / Recraft / BlackForest Labs selon coût et quota |
 
 ## Technologies
 


### PR DESCRIPTION
## Why

Cycle **c.747** post-c.746 (PR #7514 OPEN MERGEABLE DSWA parent README 27→28) et c.745 (PR #7510 OPEN ML/README racine table socle). Issue umbrella **#3974** « [EPIC #3973] READMEs feuilles — GenAI + familles Python (ML/Probas/IIT/Search-Py/RL) » owner `po-2025:CoursIA` (mandat user 2026-07-19 « casser les vagues monothématiques »). Epic parent **#3973**.

**Steer ai-01 [VARIETE] 2026-07-19** : « sweep QC-README OK jusqu'au drain des 7 parents (~2 cycles), ENSUITE rotation genre obligatoire ». Drain C731 = 7/7 rattrapés MERGED+OPEN. **Pivot R6 post-drain (c.690+) obligatoire hors QC-README** : cibles listées dashboard = Video parent GenAI / Image-Edit sub-folders / IIT-ICT figures / registre doc/README résiduel.

**Analyse c.747 pivot grain disponible** : umbrella #3974 contient explicitement « GenAI + familles Python (ML/Probas/IIT/Search-Py/RL) » → la sous-tranche **GenAI** fait partie de la partition native po-2025 sur umbrella #3974. Cibles du steer (`Video parent GenAI`, GPU/ComfyUI = cross-lane owner po-2023) sont partiellement cross-lane ; `Image-Edit sub-folders` + `IIT-ICT figures` + `GenAI Image parent` = partition native po-2025 (lecture/édition markdown + audit structure tree, sans substance GPU/ComfyUI).

**Cible c.747 = `MyIA.AI.Notebooks/GenAI/Image/README.md` grain MED-substance structure-tree** : le README référençait les 5 niveaux pédagogiques (01-Foundation / 02-Advanced / 03-Orchestration / 04-Applications / examples) mais **omettait deux sous-dossiers réels sur disque** :
- `tutorials/` (4 guides markdown : `dalle3-complete-guide.md` 27K, `educational-workflows.md` 50K, `gpt5-image-analysis-guide.md` 35K, `openrouter-ecosystem-guide.md` 45K — datés 2026-05-29 et 2026-07-04)
- `assets/` (médias partagés référencés via `<img src="assets/readme/...">` dans 6+ endroits du README lui-même : `dalle3-cover.webp`, `forge-sdxl-turbo.webp`, `qwen-edit-panel.png`, `flux1-advanced.webp`, `lumina2-zimage.webp`, `workflow-orchestration.png`)

Discrimination : les dossiers existent sur disque avec contenu substantiel, sont référencés en `<img>` tag dans le README mais **jamais nommés dans la structure** — dérive silencieuse par omission, pas une décision curatorial (le contenu cité dans `assets/readme/` est par construction partie prenante du README).

**Pivot R6 anti-monotonie** : c.745 (ML/README racine, table socle 02-ML-Cours) + c.746 (DSWA parent README, 4 sites de cohérence) + c.747 (GenAI/Image parent README, structure tree) = 3 grains umbrella #3974 consécutifs mais **trois familles distinctes** (ML socle Python CPU / DataScienceWithAgents socle ML Python / GenAI Image GPU pédagogique) et **substance distincte** (table socle numérique / breakdown 27→28 / structure tree sub-folders omission). Pivot global R6 post-drain C731 = OK.

## What

| Élément | Détail |
|---------|--------|
| Fichiers modifiés | 1 (`MyIA.AI.Notebooks/GenAI/Image/README.md`) |
| Lignes diff | +14 / -1 (15 lignes touchées) |
| Secteurs touchés | 2 (structure tree + Progression par niveau fin de section) |
| Notebook ajouté | **0** (guides markdown `tutorials/` DÉJÀ sur disque) |
| Silent gap détecté | **0** (`ls tutorials/` = 4 guides, `ls assets/readme/` couvert) |
| CATALOG-STATUS | **INTACT** (R1 catalog-pr-hygiene, hors scope — pas de marqueur agrégé ici, le catalogue parent vit dans `MyIA.AI.Notebooks/GenAI/Image/` cron-généré) |

**Rattrapage C747 = single-mode** (analogue c.745) :
- 5 entrées structure tree → 7 entrées (ajout `assets/` et `tutorials/`)
- Section « Progression par niveau » → nouveau sous-bloc `### tutorials/ - Guides de référence`
- 0 guide markdown ajouté (4 DÉJÀ sur disque, datés mai-juillet 2026)
- 0 PNG manquant à extraire

## Audit §E fichier-entier (R6 ★★★ pattern consolidé c.740)

**Vérification first-hand disque + tree + parangonnage cross-référence :**

| Claim README | Verdict post-c.747 |
|---|---|
| L27-32 structure tree (5 sous-dossiers pédagogiques, omets `tutorials/` et `assets/`) | ✗ DRIFT — disque contient 7 sous-dossiers (`01-Foundation / 02-Advanced / 03-Orchestration / 04-Applications / assets / examples / tutorials`) |
| L44-45 `<img src="assets/readme/dalle3-cover.webp">` | ✓ cohérent — `assets/readme/` est le sous-dossier cité, mais omis du tree |
| L52-55 table `01-Foundation` (5 notebooks) | ✓ match disk (`ls 01-Foundation/*.ipynb` = 5 hors `_output`) |
| L83-88 table `02-Advanced` (5 notebooks) | ✓ match disk (`ls 02-Advanced/*.ipynb` = 5 hors `_output`) |
| L110-113 table `03-Orchestration` (3 notebooks) | ✓ match disk (`ls 03-Orchestration/*.ipynb` = 3 hors `_output`) |
| L121-126 table `04-Applications` (4 notebooks) | ✓ match disk (`ls 04-Applications/*.ipynb` = 4 hors `_output`) |
| L136-138 table `examples/` (3 notebooks) | ✓ match disk (`ls examples/*.ipynb` = 3 hors `_output`) |
| L160-165 Technologies (gpt-image-1 / ComfyUI+Qwen / ComfyUI+FLUX / ComfyUI+SD 3.5 / Z-Image/Lumina / Bonsai) | ✓ cohérent avec tables ci-dessus |
| **Aucun sous-bloc `tutorials/` dans « Progression par niveau »** | ✗ DRIFT — `ls tutorials/` = 4 guides markdown, présents sur disque mais invisibles |
| Mermaid flowchart L203-227 | ✓ non touché |
| FAQ sections L229-303 | ✓ non touché |

**Note sur `_output.ipynb`** : la consigne catalogue exclut les artefacts `*_output.ipynb` produits par papermill (cf c.745 ML/PR #7331 commentaire reviewer). Pour GenAI Image, aucun notebook exécuté localement ne génère d'artefact `_output` (les notebooks GenAI sont GPU-only et exécutés sur po-2023 / po-2026 / cluster owner), donc le count par sous-dossier = nombre de notebooks pédagogiques directement.

**Voir-aussi cohérence cross-référence** : `<img src="assets/readme/...">` dans le README pointe 6+ fichiers visuels dont l'ajout de `assets/` au tree documente la **localisation canonique** sans toucher aux références existantes (toutes déjà fonctionnelles).

## Changements

### 1. Structure tree L27-33 — ajout `assets/` et `tutorials/`

**Avant** :
```
Image/
├── 01-Foundation/     # Modèles de base
├── 02-Advanced/       # Modèles avancés
├── 03-Orchestration/  # Multi-modèles
├── 04-Applications/   # Production
└── examples/          # Cas d'usage
```

**Après** :
```
Image/
├── 01-Foundation/     # Modèles de base
├── 02-Advanced/       # Modèles avancés
├── 03-Orchestration/  # Multi-modèles
├── 04-Applications/   # Production
├── assets/            # Médias partagés (couvertures, panneaux)
├── examples/          # Cas d'usage par domaine
└── tutorials/         # Guides de référence (markdown)
```

Placés dans l'ordre `niveaux / assets / examples / tutorials` : assets est un **dossier de support transverse** cité partout via `<img>`, examples est un **niveau pédagogique parallèle** (3 notebooks par domaine), tutorials est une **section transversale de guides** (4 markdown). Ordre cohérent avec le statut croissant transverse → pédagogique.

### 2. Sous-bloc `### tutorials/` dans « Progression par niveau » — après `### examples/`

**Avant** : section « Progression par niveau » se terminait à `### examples/` (L130-138).

**Après** : ajout d'un sous-bloc `### tutorials/ - Guides de référence` après `### examples/`, listant les 4 guides markdown en table 2 colonnes (Guide / Sujet), avec une phrase d'introduction positionnant cette section comme **transversale et post-pratique** :

```
### tutorials/ - Guides de référence

Section transversale de guides markdown (pas de notebooks) — quatre références
longues pour approfondir un aspect précis du pipeline image, à consulter après
avoir pratiqué les notebooks ci-dessus :

| Guide | Sujet |
|-------|-------|
| [dalle3-complete-guide](tutorials/dalle3-complete-guide.md) | DALL-E 3 de bout en bout — prompt engineering, exemples, retrait OpenAI et remplacement par gpt-image-1 |
| [educational-workflows](tutorials/educational-workflows.md) | Concevoir des workflows ComfyUI orientés production pédagogique (vignettes, schémas, planches de cours) |
| [gpt5-image-analysis-guide](tutorials/gpt5-image-analysis-guide.md) | GPT-5 Image : forces, faiblesses, structure de prompt recommandée, comparaison à gpt-image-1 |
| [openrouter-ecosystem-guide](tutorials/openrouter-ecosystem-guide.md) | Routage multi-modèles via OpenRouter — DALL-E / GPT-5 / Stability / Recraft / BlackForest Labs selon coût et quota |
```

Les **sujets** sont dérivés du contenu manifeste des 4 fichiers (lecture first-hand `head -50` + `wc -l`) — pas de fabrication marketing, le contenu du guide dicte la description courte. Le lien `[<guide>](tutorials/<guide>.md)` reste cohérent avec les chemins existants sur disque.

## Conformité règles

- **R1 catalog-pr-hygiene** : `git diff origin/main -- "**/CATALOG-STATUS*" "**/COURSE_CATALOG*"` = **vide**. Pas de marqueur CATALOG-STATUS agrégé sur ce sous-fichier (le marqueur parent vit sur `MyIA.AI.Notebooks/GenAI/Image/` catalog-cron.yml géré).
- **R2 fresh base origin/main** : base = `f166be8d0` (2026-07-20 PR #7491 MERGED) ≤1 jour, branche `feature/c747-genai-image-readme-resync` créée par `git worktree add ../CoursIA-c747-genai-image-readme-resync -b feature/c747-genai-image-readme-resync origin/main`.
- **R3 atomicité** : 1 sujet = structure-tree resync GenAI/Image parent (2 sites de cohérence : tree + sous-bloc tutorials). +14/-1 ≪ 3000L. 1 fichier, 1 feature, 1 périmètre. Pas de composite (pas de notion de cross-LLM, cross-modèle, cross-stack).
- **R4 `See #X`** : `See #3974` (umbrella READMEs feuilles, owner po-2025) — contribution partielle, pas `Closes`.
- **L268 #4 LF-only** : `git diff | tr -cd '\r' | wc -c` = **0**.
- **L143 secrets-hygiene** : `grep -iE "sk-|ghp_|AIza|password=|secret=|os.getenv"` sur le diff = **0 hit**.
- **L677-L3 ★★** : `--body-file` PR body HORS worktree (cf scratchpad path).
- **L420-L1 ★★ anti-contamination cross-lane** : c.747 = GenAI/Image structure tree resync (umbrella #3974 owner `po-2025:CoursIA` = partition native). Pas cross-lane. Substance GPU/ComfyUI des notebooks sous-jacents = owner po-2023, mais le **grain c.747 = édition markdown structurelle** sur README parent, sans toucher au contenu des notebooks eux-mêmes.
- **§E audit fichier-entier (R6 ★★★ consolidé c.740)** : `find -maxdepth 2 -type d` = 7, `find -name '*.ipynb' ! -name '*_output*'` = 20 cohérent avec tables progression, cohérence structure tree ↔ tables progression ↔ `<img src=...>` ↔ sections FAQ avant et après le diff, `tutorials/` 4 guides existants vérifiés avec tailles 27K/50K/35K/45K.
- **§E doctrine corrigée** (issue #5780) : pas de section `## Galerie`, figures intégrées in-situ dans la prose narrative (existait déjà avant c.747, préservé par construction).

## Hors scope (volontairement)

- **Pas de regen catalogue** : R1 respectée, le cron `catalog-cron.yml` sur main régénère les marqueurs. Pas de marqueur CATALOG-STATUS à toucher dans cette branche (le parent vit dans le cron agrégé).
- **Pas de modification des notebooks GenAI Image eux-mêmes** : grain = README structurel uniquement. Les notebooks Image (01-Foundation, 02-Advanced, 03-Orchestration, 04-Applications, examples) restent inchangés — leur contenu GPU/ComfyUI est le territoire de po-2023 (vision-capable GenAI).
- **Pas de re-exécution des notebooks GenAI** : aucun notebook source modifié, scope c.747 = documentation seulement. Conformité C.3 strict respectée par construction.
- **Pas d'audit des autres sous-familles umbrella #3974** (GenAI/Audio, GenAI/Video, GenAI/Texte, FineTuning, PostTraining, RAG-et-Memoire-Semantique, Vibe-Coding, CaseStudies, Open-WebUI, IIT, Search-Part1/2/3, RL) : grain c.747 = 1/15+ familles umbrella, 1 cycle par famille reste R6 anti-monotonie. Autres grains umbrella #3974 = c.748+ (po-2025 ou po-2026 cross-famille).
- **Pas de breakdown count chiffré** (style « 5 niveaux + 4 guides ») : les autres séries du même umbrella utilisent parfois un breakdown chiffré en tête ou dans une section « Vue d'ensemble », mais Image parent n'a pas de section Vue d'ensemble actuelle — introduire un count chiffré = enrichissement hors-scope c.747, risqué monotonie. Rester strictement sur structure tree + sous-bloc tutorials.

## Liens opérationnels

- **#3974** (umbrella READMEs feuilles, owner po-2025, EPIC actif) — `See`
- **#3973** (méthode ascendante README EPIC parent) — référence méthode
- **#7514** (PR c.746 DSWA parent README, OPEN MERGEABLE) — grain précédent, complémentaire sans dupliquer (c.746 = 27→28 notebooks breakdown, c.747 = structure tree sub-folders)
- **#7510** (PR c.745 ML/README racine table socle, OPEN MERGEABLE) — grain précédent, complémentaire sans dupliquer
- **#7331** (PR c.740 MERGED socle count + énumération) — pattern analog socle count correction
- **#7485** (PR c.740 Probas/README resync OPEN HELD ai-01) — pattern analog umbrella #3974 owner po-2025

Refs #3974

🤖 Generated with [Claude Code](https://claude.com/claude-code)
