### PR TITLE
fix(gametheory): guard trust_simulation play_match rounds<=0 (ZeroDivisionError)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/tests/test_trust_simulation.py
+++ b/MyIA.AI.Notebooks/GameTheory/tests/test_trust_simulation.py
@@ -364,6 +364,22 @@ class TestPlayMatch:
         # Apres le match, l'historique ne contient que les 5 tours du match.
         assert len(s1.my_history) == 5
 
+    def test_play_match_zero_rounds_raises(self):
+        """rounds <= 0 doit echouer explicitement (ValueError), pas crasher
+        en ZeroDivisionError. Avant le guard, `total1 / rounds` (et total2)
+        divisait par 0 apres une boucle `for _ in range(0)` vide. Meme
+        bug-class degenerate-input que #7481 (shapley n_samples<=0),
+        #7489 (kuhn_poker iterations<=0), #7495 (replicator normalization),
+        #7517 (compute_payoff_matrix rounds<=0)."""
+        with pytest.raises(ValueError, match="rounds must be positive"):
+            play_match(AlwaysCooperate(), AlwaysDefect(), rounds=0)
+
+    def test_play_match_negative_rounds_raises(self):
+        """rounds < 0 doit aussi echouer explicitement (consistance du guard
+        ; sinon avg = 0/-1 = 0.0 silencieux pour un match sans tours)."""
+        with pytest.raises(ValueError, match="rounds must be positive"):
+            play_match(AlwaysCooperate(), AlwaysDefect(), rounds=-1)
+
 
 # ============================================================================
 # Tournament : round-robin, self-play, payoff matrix, determinisme.

--- a/MyIA.AI.Notebooks/GameTheory/trust_simulation/strategies.py
+++ b/MyIA.AI.Notebooks/GameTheory/trust_simulation/strategies.py
@@ -314,6 +314,9 @@ def play_match(
     Returns:
         Dictionary with match results including total scores
     """
+    if rounds <= 0:
+        raise ValueError(f"rounds must be positive, got {rounds}")
+
     strategy1.reset()
     strategy2.reset()
 


### PR DESCRIPTION
## What

Bug-fix in `GameTheory/trust_simulation/strategies.py:play_match` — the per-match averages `total1 / rounds` and `total2 / rounds` were unguarded, so `rounds=0` raised `ZeroDivisionError` after an empty `for _ in range(0)` loop. **Same degenerate-input guard bug-class as #7481 (shapley `n_samples<=0`), #7489 (kuhn_poker `iterations<=0`), #7495 (replicator normalization), and #7517 (`compute_payoff_matrix rounds<=0`) — all MERGED.** This PR closes the remaining `rounds`-division locus in the bug-class sweep.

## Bug (reproduced firsthand, G.1)

`play_match(strategy1, strategy2, rounds=200, payoffs=None)` runs an iterated Prisoner's Dilemma and returns a results dict including `avg1 = total1 / rounds` and `avg2 = total2 / rounds`. At `rounds=0`, the `for _ in range(rounds)` loop runs zero times (`total1 = total2 = 0`), then the dict construction divides `0 / 0`:

```python
>>> from trust_simulation.strategies import play_match, AlwaysCooperate, AlwaysDefect
>>> play_match(AlwaysCooperate(), AlwaysDefect(), rounds=0)
ZeroDivisionError: division by zero
```

`rounds < 0` does not crash (the loop is empty, `0 / -1 = 0.0`) but silently returns a nonsense average for a match that played no rounds. Identical shape to `compute_payoff_matrix(rounds<=0)` (#7517, same bug-class, different module `game_theory_utils.py`). `play_match` is a **public** function (imported directly by tests and by the `Tournament` orchestrator), so the guard belongs at the function boundary.

## Fix (matches the established guard style)

Input validation at the top of `play_match`, identical to `shapley.py:139-140` (`n_samples`), `kuhn_poker_cfr.py:147-149` (`iterations`), and #7517 (`compute_payoff_matrix`):

```python
if rounds <= 0:
    raise ValueError(f"rounds must be positive, got {rounds}")
```

This closes the `rounds`-division variant of the degenerate-input bug-class across the GameTheory package: `compute_payoff_matrix` (#7517) and `play_match` (this PR) were the two unguarded `/ rounds` sites; the `Tournament` orchestrator passes `rounds_per_match` which is validated upstream and feeds `play_match`, so no other call path is unguarded.

## Tests (matches the established pytest style)

Two tests added to `TestPlayMatch` (where the existing `test_scores_sum_and_avg` / `test_reset_at_start` live), mirroring `test_kuhn_poker_cfr.py:340-342` and #7517:

```python
def test_play_match_zero_rounds_raises(self):
    with pytest.raises(ValueError, match="rounds must be positive"):
        play_match(AlwaysCooperate(), AlwaysDefect(), rounds=0)

def test_play_match_negative_rounds_raises(self):
    with pytest.raises(ValueError, match="rounds must be positive"):
        play_match(AlwaysCooperate(), AlwaysDefect(), rounds=-1)
```

## Validation

- Bug reproduced firsthand pre-fix: `ZeroDivisionError('division by zero')` at `rounds=0`.
- Post-fix: `ValueError("rounds must be positive, got 0")` / `"...got -1"`.
- `python -m pytest tests/test_trust_simulation.py -q` → **57 passed** (55 existing + 2 new, no regression).
- Line endings preserved (LF, CR count = 0 on both files).
- `git diff --stat`: 2 files, 19 ins / 0 del (pure additions).

## Scope note — bug-class sweep status

With this PR, the degenerate-input guard bug-class in GameTheory Python is **closed for the `rounds`-division variant** (`compute_payoff_matrix` #7517 + `play_match` here). The broader sweep (`n_samples` #7481, `iterations` #7489, replicator-normalization #7495) is also complete. Remaining division sites in the package are either already-guarded (`french_politics.py:520/539` ternary `if total_shapley > 0`, `coalition_games/core.py:137` grand-coalition invariant, CFR `if normalizing_sum > 0`) or closed-form economic formulas (Stackelberg/Cournot #7351/#7385, active territory).

## See

- #7481 (shapley `n_samples<=0`), #7489 (kuhn_poker `iterations<=0`), #7495 (replicator normalization), #7517 (`compute_payoff_matrix rounds<=0`) — the degenerate-input guard bug-class this completes.
