### PR TITLE
fix(gametheory): guard FictitiousPlay.train(iterations<=0) silent no-op

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/game_theory_utils.py
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_utils.py
@@ -1119,6 +1119,15 @@ class FictitiousPlay:
 
     def train(self, iterations: int):
         """Run fictitious play for n iterations."""
+        # Guard degenerate iteration counts (sister to kuhn_poker_cfr.train /
+        # shapley_value_monte_carlo n_samples): iterations<=0 makes range() an
+        # empty loop, i.e. a SILENT no-op — the caller believes training ran
+        # while the average strategy is unchanged from its Laplace uniform prior.
+        # Reject explicitly instead of returning a silently-untrained learner.
+        if iterations <= 0:
+            raise ValueError(
+                f"iterations must be positive, got {iterations}"
+            )
         for _ in range(iterations):
             self.step()
 

--- a/MyIA.AI.Notebooks/GameTheory/tests/test_fictitious_play.py
+++ b/MyIA.AI.Notebooks/GameTheory/tests/test_fictitious_play.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+"""
+Tests pour ``FictitiousPlay`` (game_theory_utils.py) — algorithme de jeu
+apprentissage (Brown 1949 / Robinson 1951) pour jeux matriciels zero-sum.
+
+Chaque joueur joue la meilleure reponse a la distribution empirique de
+l'adversaire (best-response to empirical play). La classe est le companion
+du notebook GameTheory-17-MultiAgent-RL.ipynb.
+
+Avant le garde d'entree ``iterations <= 0``, ``train(iterations)`` faisait
+``for _ in range(iterations)`` : un compte <= 0 produit une boucle VIDE, donc
+un **no-op silencieux** — l'appelant croit que l'apprentissage a tourne alors
+que la strategie moyenne reste inchangee (uniforme Laplace). FictitiousPlay
+etait l'INCOHERENT de la famille des learners : ``kuhn_poker_cfr.train``
+(#7489) et ``shapley_value_monte_carlo`` n_samples (#7481) rejettent deja
+``<= 0`` via ``ValueError``. Ces tests pinent le garde nouvellement ajoute.
+
+Non-vacuous : sur le module non-patche, ``train(0)`` et ``train(-5)`` ne
+levent RIEN (boucle vide) ; sur le module patche, ils levent ``ValueError``.
+
+Run with: pytest tests/test_fictitious_play.py -v
+"""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+# Ajoute GameTheory/ au path (meme convention que test_kuhn_poker_cfr /
+# test_strategies).
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from game_theory_utils import FictitiousPlay, create_rps_matrix  # noqa: E402
+
+
+# ----------------------------------------------------------------------------
+# Fixtures.
+# ----------------------------------------------------------------------------
+
+@pytest.fixture
+def rps():
+    """Un jeu Pierre-Papier-Ciseaux (zero-sum, equilibrable)."""
+    return FictitiousPlay(create_rps_matrix())
+
+
+# ----------------------------------------------------------------------------
+# Garde d'entree : iterations <= 0 (le fix, non-vacuous).
+# ----------------------------------------------------------------------------
+
+class TestTrainIterationsGuard:
+    """train(iterations) doit rejeter les comptes degeneres au lieu de
+    silencieusement ne rien faire (boucle vide = strategie inchangee)."""
+
+    def test_zero_iterations_raises(self, rps):
+        """iterations=0 -> range(0) = boucle vide -> NO-OP silencieux avant le
+        garde. Non-vacuous : non-patche ne leve rien ; patche leve ValueError."""
+        with pytest.raises(ValueError, match="iterations must be positive"):
+            rps.train(0)
+
+    def test_negative_iterations_raises(self, rps):
+        """iterations<0 -> range(-5) = boucle vide -> NO-OP silencieux (compte
+        absurde). Non-vacuous : non-patche ne leve rien ; patche leve ValueError."""
+        with pytest.raises(ValueError, match="iterations must be positive"):
+            rps.train(-5)
+
+    def test_negative_iterations_message_carries_value(self, rps):
+        """Le message d'erreur embarque la valeur recue (diagnostic, pas juste
+        'must be positive')."""
+        try:
+            rps.train(-42)
+        except ValueError as e:
+            assert "-42" in str(e)
+        else:
+            pytest.fail("ValueError expected for iterations=-42")
+
+
+# ----------------------------------------------------------------------------
+# Happy path : train>0 mute reellement la strategie (anti-regression du garde).
+# ----------------------------------------------------------------------------
+
+class TestTrainHappyPath:
+    """Le garde ne doit PAS casser le chemin nominal : train(positive) tourne
+    reellement et fait evoluer les comptes d'actions."""
+
+    def test_train_positive_runs_and_mutates(self, rps):
+        """Apres train(50), les comptes d'actions ont augmente (l'apprentissage
+        a reellement tourne) — pin que le garde n'a pas court-circuite train."""
+        before_p1 = rps.counts_p1.sum()
+        rps.train(50)
+        after_p1 = rps.counts_p1.sum()
+        assert after_p1 == before_p1 + 50  # 50 increments de step()
+
+    def test_train_one_runs_without_error(self, rps):
+        """iterations=1 (limite valide) tourne exactement un step."""
+        before = rps.counts_p1.sum()
+        rps.train(1)
+        assert rps.counts_p1.sum() == before + 1
+
+    def test_average_strategy_remains_distribution_after_train(self, rps):
+        """Apres entrainement, get_average_strategy est toujours une distribution
+        de probabilite valide (somme a 1) — le garde n'a pas corrompu l'etat."""
+        rps.train(100)
+        for player in (0, 1):
+            strat = rps.get_average_strategy(player)
+            assert strat.shape == (3,)
+            assert np.isclose(strat.sum(), 1.0)
+            assert (strat >= 0).all()
+
+
+# ----------------------------------------------------------------------------
+# Etat initial (Laplace uniforme) — invariant de __init__.
+# ----------------------------------------------------------------------------
+
+class TestInitialState:
+    """__init__ part d'un prior uniforme (smoothing de Laplace, compte=1 par
+    action). Pin que l'etat initial est une distribution valide avant tout train."""
+
+    def test_initial_strategy_is_uniform(self, rps):
+        """Avant tout train(), la strategie moyenne est uniforme (Laplace)."""
+        for player in (0, 1):
+            strat = rps.get_average_strategy(player)
+            assert np.allclose(strat, np.ones(3) / 3)
+
+    def test_initial_counts_all_ones(self, rps):
+        """Les comptes d'actions partent a 1 (smoothing de Laplace)."""
+        assert np.all(rps.counts_p1 == 1)
+        assert np.all(rps.counts_p2 == 1)


### PR DESCRIPTION
## Summary

Self-found **degenerate-input guard** for `FictitiousPlay.train(iterations)` in `game_theory_utils.py:1120`. `iterations <= 0` produced an empty `range()` loop — a **silent no-op**: the caller believed training ran while the average strategy stayed unchanged from its Laplace uniform prior. FictitiousPlay was the **inconsistent** learner: `kuhn_poker_cfr.train` (#7489) and `shapley_value_monte_carlo` n_samples (#7481) already reject `<= 0` via `ValueError`. This makes the learner family consistent. Catalog byte-identical to `origin/main`, 2 files (+137).

## Bug firsthand (G.1, read `origin/main`)

```python
def train(self, iterations: int):
    """Run fictitious play for n iterations."""
    for _ in range(iterations):   # range(0) / range(-5) = EMPTY loop
        self.step()
```

- `iterations=0` → `range(0)` empty → **silent no-op**, uniform Laplace prior unchanged, caller unaware.
- `iterations<0` (e.g. `-5`) → `range(-5)` empty → **silent no-op** (absurd negative count, no error).

Reproduced firsthand: on the unpatched module `train(0)` and `train(-5)` raise nothing; `get_average_strategy` stays uniform.

## Fix — entry guard mirroring the sisters

```python
def train(self, iterations: int):
    """Run fictitious play for n iterations."""
    if iterations <= 0:
        raise ValueError(
            f"iterations must be positive, got {iterations}"
        )
    for _ in range(iterations):
        self.step()
```

Same shape as `kuhn_poker_cfr.train` (#7489, closest sister — same `train(iterations)` contract) and `shapley_value_monte_carlo` n_samples (#7481). Pure additive guard; the happy path (`iterations>0`) is byte-identical.

## Origin — first-hand verified, fresh family for this lane

Firsthand-spotted by po-2023 (c.689) but **deferred** as their 5th GameTheory grain (R6 anti-monotony for *their* lane). For this lane it is a **fresh family** — my recent cycles were prover/prover/notebook-tools. Re-verified firsthand against `origin/main` (G.1: never trust another agent's report unverified) before claiming. Collision-guard: no open PR touches `FictitiousPlay` (po-2023's #7513/#7522 = compute_payoff/stackelberg/cournot, different functions). po-2023's cross-fork PRs are not yet on `origin/main`, so this guard merges independently (FictitiousPlay L1120, no line overlap).

## Tests — `test_fictitious_play.py` (new, 8 tests)

| Class | Tests | Pin |
|-------|-------|-----|
| `TestTrainIterationsGuard` | `test_zero_iterations_raises`, `test_negative_iterations_raises`, `test_negative_iterations_message_carries_value` | **the fix, non-vacuous** |
| `TestTrainHappyPath` | `test_train_positive_runs_and_mutates`, `test_train_one_runs_without_error`, `test_average_strategy_remains_distribution_after_train` | guard did not break the nominal path |
| `TestInitialState` | `test_initial_strategy_is_uniform`, `test_initial_counts_all_ones` | Laplace-prior invariant |

## Validation

```
$ python -m pytest tests/test_fictitious_play.py -q          # patched
8 passed in 1.14s

# Non-vacuous proof (git stash the source fix, run guard tests on unpatched):
$ python -m pytest tests/test_fictitious_play.py -q -k Guard
3 failed   (Failed: DID NOT RAISE <ValueError> / "ValueError expected")
# restore fix -> 3 passed

$ python -m pytest GameTheory/tests/ -q                       # full dir regression
510 passed, 2 failed
```

The 2 failures are `test_lean_definitions.py` (`bash: cd: /home/jesse/lean-projects/notebook_context: No such file or directory`) — a **WSL/Lean path env** issue, **PREEXISTING + ENVIRONMENTAL** (verified identical on clean `origin/main` via stash; unrelated to this Python-only change). No regression from this PR.

## Scope / collision

- Single subject (the `train(iterations<=0)` guard + its non-vacuous tests), 2 files, +137/−0. Catalog byte-identical to `origin/main`.
- Honest scope-class: MED-light (single-function guard, sister-mirror) — not novelty, but a real defect + API consistency, not cosmetic padding. The non-doc CPU/text pool is genuinely thin this tick (independently corroborated by po-2023 c.688 and po-2025 c.552).
- Worktree fresh off `origin/main` `f166be8d0`.

See #7489, #7481 (the sister guards this makes consistent).
