### PR TITLE
docs(scripts-reference,#7422): sync Tests inventory to real scripts/tests/

### DIFF
--- a/docs/reference/scripts-reference.md
+++ b/docs/reference/scripts-reference.md
@@ -147,20 +147,20 @@ python scripts/notebook_tools/notebook_tools.py execute <notebook> --cell-by-cel
 
 ## Tests — `scripts/tests/` + `scripts/notebook_tools/tests/`
 
-46 fichiers de test dans `scripts/tests/`, 1729 tests au total (pytest). Couverture par domaine :
+`scripts/tests/` regroupe **51 fichiers** de test (1303 tests) ; `scripts/notebook_tools/tests/` en regroupe **81** (2049 tests — couvre les modules notebook_tools : CLI, helpers, skeleton, lint, catalogue, qualité C.1/C.2/C.3, leak detection, forensic, execution, enrich, reporting), soit **3354 tests au total** (snapshot `pytest --collect-only` 2026-07-20). Couverture de `scripts/tests/` par domaine :
 
 | Domaine | Fichiers | Modules couverts |
 | ------- | -------- | --------------- |
-| **notebook_tools/** | 14 | CLI principal (notebook_tools.py pure fn), helpers, skeleton, lint, catalogue (generate/expand/verify/coverage), qualite C.1/C.2/C.3, leak detection, forensic, execution (exec_single_cell, wsl_papermill, batch_reexecute, execute_qcpy_docker), enrich, reporting |
-| **genai-stack/** | 8 | config.py, commands/validate.py, commands/audio_apis.py, commands/models.py, commands/notebooks.py, commands/auth.py, core/comfyui_client.py, core/auth_manager.py |
-| **sudoku/core/** | 5 | solvers.py (Norvig CSP), graph.py (edge index), dataset.py (parse_81 + collate_fn), generation.py (grid + puzzles), models.py (SudokuRRN + count_params). evaluate.py = GPU-only, non CPU-testable |
-| **top-level scripts/** | 7 | fix_robust_dotenv.py, extract_pptx_titles.py, extract_slidev_titles.py, validate_pr_notebooks.py, weekly_digest.py, validate_sc_notebooks.py, epita_prcon_autograde.py |
-| **datasets/** | 2 | stitch_crypto.py, build_panier_anti_bias.py |
-| **autres** | 10 | validate_qc_projects.py, series_progress_manager.py, update_navigation.py, scan_student_forks.py, catalog_coverage.py, qc_classify.py, forensic_scan.py, generate_parcours.py, check_c2_compliance.py, verify_catalog_readme.py |
+| **genai-stack/** | 9 | config.py, commands/{validate,audio_apis,models,notebooks,auth,gpu}.py, core/{comfyui_client,auth_manager}.py, models.py |
+| **sudoku/** | 9 | core/{solvers,graph,dataset,generation,models,training,evaluate}.py, sudoku_rrn, sudoku_solvers (evaluate.py = GPU-only, partiellement couvert) |
+| **smartcontracts/** | 2 | validate_sc_notebooks.py |
+| **extract-titles (top-level)** | 4 | extract_pptx_titles.py, extract_slidev_titles.py, extract_titles.py, extract_readme_figures.py |
+| **ml/** | 1 | garch_baseline |
+| **autres (top-level + misc)** | 26 | check_docs_links, convert_print_to_deploy, regen_quarto_render, render_envs (secrets), scan_student_forks, series_progress_manager, update_navigation, validate_qc_projects, execute_sudoku_python, execute_qcpy_docker, translation_sync, translate_csv, detect_{ascii_workaround,blank_figures,svg_decimal_commas}, verify_{prosody,transcript}, audit_exposed_services, auth_manager, configure_max_quantization, container_startup, download_yfinance, manage_crypto_archive, notebook_tools_pure, repair_genai_notebooks, validation_dispatch |
 
 Lancer la suite : `python -m pytest scripts/tests/ -v` (depuis la racine du repo).
 
-Modules genai-stack non testes (intentionnellement) : commands/docker.py (subprocess Docker), commands/gpu.py (nvidia-smi subprocess), commands/quant.py (API externe).
+Modules genai-stack non testes (intentionnellement) : commands/docker.py (subprocess Docker), commands/quant.py (API externe).
 
 ## Voir aussi
 


### PR DESCRIPTION
## Summary

Bounded **UPDATE** grain of #7422 (docs/ hygiene, user-mandated 2026-07-19): the "Tests" section of [`docs/reference/scripts-reference.md`](docs/reference/scripts-reference.md) had drifted — stale counts, a directory conflation, and several path-misclassified scripts. Evidence-cited reconciliation against `origin/main`.

The doc was last touched 2026-07-18; the cluster has been merging ~3-5 PRs/h since (40+ in 2 days), so the test inventory genuinely drifted.

## Drift found (all verified firsthand via `git ls-tree origin/main` + `pytest --collect-only`)

| Claim in doc | Reality on `origin/main` |
|---|---|
| "46 fichiers de test dans `scripts/tests/`" | **51** test files (`git ls-tree -r origin/main -- scripts/tests/ \| grep test_.*\.py \| wc -l`) |
| "1729 tests au total" | **3354** (scripts/tests/ = 1303 + scripts/notebook_tools/tests/ = 2049, `pytest --collect-only` 2026-07-20) |
| "notebook_tools/ \| 14" row inside the scripts/tests/ table | Conflation — that row describes the **other** dir (`scripts/notebook_tools/tests/`, now 81 files), miscounted into the scripts/tests/ total |
| "top-level scripts/ \| 7" lists `validate_pr_notebooks.py`, `weekly_digest.py`, `epita_prcon_autograde.py` | These live in `scripts/notebook_tools/`, **not** top-level |
| "top-level scripts/" lists `validate_sc_notebooks.py` | Lives in `scripts/smartcontracts/` |
| "datasets/ \| 2" claims coverage for `stitch_crypto.py`, `build_panier_anti_bias.py` | **No** `test_stitch_crypto.py` / `test_build_panier_anti_bias.py` exists in scripts/tests/ (the tested datasets modules `download_yfinance` / `manage_crypto_archive` are real, now listed under "autres") |
| "autres \| 10" lists `catalog_coverage.py`, `qc_classify.py`, `forensic_scan.py`, `generate_parcours.py`, `check_c2_compliance.py`, `verify_catalog_readme.py` | These are `scripts/notebook_tools/` modules tested in the **other** dir |
| "Modules genai-stack non testes : ... `commands/gpu.py`" | `test_genai_commands_gpu.py` **exists** → commands/gpu.py IS tested |

## Fix

Rewrite the per-domain table to the verified 51-file grouping: **9** genai-stack + **9** sudoku + **2** smartcontracts + **4** extract-titles + **1** ml + **26** autres = 51. Clarify the two-directory structure in the intro line (scripts/tests/ = 51 files / 1303 tests ; scripts/notebook_tools/tests/ = 81 files / 2049 tests ; 3354 total), date-stamp the snapshot (`pytest --collect-only` 2026-07-20), and remove `commands/gpu.py` from the untested-modules line.

## Fichier-entier audit (§E)

The whole file was reconciled against disk, not just the Tests section:
- **Maintenance table (lines 124-146)**: every listed script verified to exist on `origin/main` (`validate_lean11.py`, `setup_lean4_all.py`, `lean_kernel_check.py`, `smoke_test_epita_is.py`, `dispatch.py`+`matrix.yml`, `genai.py`, `repair_genai_notebooks.py`, `audit_genai_corruption.py`, `fix_robust_dotenv.py`, `scan_student_forks.py`, `series_progress_manager.py`, `validate_qc_projects.py`, `update_navigation.py`, `extract_pptx_titles.py`, `extract_slidev_titles.py`, `execute_with_env.py`, `execute_dotnet_notebook.py`, `execute_sudoku_python.py`) — **all present, table left unchanged**.
- **Subdir row (line 146)**: `scripts/{quantconnect,smartcontracts,sudoku,datasets,tests}/` all exist (4/14/18/9/54 entries).
- **Tests section**: the drift above, now fixed.
- **Voir aussi links**: stable (common-commands.md, kernels-runtime.md, genai-services.md, wsl-kernels.md all exist).

## Scope / honesty

- Single subject (the Tests-section reconciliation of one doc), 1 file, ~+20/−18. Catalog byte-identical to `origin/main`.
- **Honest scope-class**: this is a bounded docs UPDATE (the "référence pérenne désynchronisée" category #7422 explicitly targets), not a DEEP grain. The non-doc CPU/text pool is genuinely drained this tick (corroborated po-2023 c.688/c.690, po-2025 c.552, po-2024 c.707/709/711 across prover/GameTheory/notebook-tools/SmartContracts/Search). #7422 is user-mandated (19/07) and the cleanest available R6-fresh grain for a GLM/CPU/text lane (my c.708-711 were prover/notebook-tools/gametheory — docs is a fresh family).
- Worktree fresh off `origin/main` `f166be8d0`.
- Note: these test counts are a live metric that will drift again as the cluster adds tests; the snapshot date (2026-07-20) makes that explicit rather than falsely precise.

See #7422 (partial contribution to the docs/ hygiene epic — not a close). See #4208 (parent epic).
