### PR TITLE
fix(prover,#7477): P1b local-provider timeout not retried at workflow layer

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/agents.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/agents.py
@@ -39,6 +39,24 @@ def _fast_options() -> ChatOptions:
     return ChatOptions(max_tokens=FAST_MAX_TOKENS)
 
 
+def _stamp_provider(agent: Agent, provider: str) -> Agent:
+    """Tag an Agent with its provider for the workflow-layer timeout policy (#7477 P1b).
+
+    ``_is_transient_error`` (workflow.py) reads ``getattr(agent,
+    "_prover_provider", None)`` so that a timeout from a hang-prone provider
+    (local vLLM / qwen3.6 — whose failure mode is a GPU-stall hang, not a
+    transient 5xx/reset) is treated as a *definitive* provider failure
+    instead of being retried at the workflow layer. Each retry would
+    re-burn ``request_timeout_s`` (config.py P1: ~480s per hung local call
+    after max_retries=1), so the pre-P1b workflow multiplied that burn
+    ``TRANSIENT_RETRY_MAX`` (5) times. Stamping the provider here lets the
+    outage-breaker terminate the run cleanly instead. Forensic #7477:
+    ``[ERROR] chat qwen3.6 1206.9s`` (5x240s pre-P1a on one logical call).
+    """
+    agent._prover_provider = provider  # type: ignore[attr-defined]
+    return agent
+
+
 def create_search_agent(tools: SearchTools, provider: str = "local",
                         goal: str = "", name: str = "SearchAgent") -> Agent:
     """SearchAgent: finds Mathlib lemmas. Uses fast local model."""
@@ -59,20 +77,20 @@ def create_search_agent(tools: SearchTools, provider: str = "local",
         tools.file_read_lines,
         tools.file_load,
     ]
-    return Agent(
+    return _stamp_provider(Agent(
         client=client,
         instructions=augment_instructions(SEARCH_AGENT_INSTRUCTIONS, goal=goal),
         tools=agent_tools,
         name=name,
         default_options=_fast_options(),
-    )
+    ), provider)
 
 
 def create_tactic_agent(tools: TacticTools, provider: str = "openrouter",
                         goal: str = "") -> Agent:
     """TacticAgent: generates tactics + decomposition. Uses reasoning model."""
     client = create_client(provider, model_key="reasoning")
-    return Agent(
+    return _stamp_provider(Agent(
         client=client,
         instructions=augment_instructions(TACTIC_AGENT_INSTRUCTIONS, goal=goal),
         tools=[
@@ -90,13 +108,13 @@ def create_tactic_agent(tools: TacticTools, provider: str = "openrouter",
         ],
         name="TacticAgent",
         default_options=_reasoning_options(),
-    )
+    ), provider)
 
 
 def create_critic_agent(tools: CriticTools, provider: str = "openrouter") -> Agent:
     """CriticAgent: analyzes failures, decides routing. Uses fast model."""
     client = create_client(provider, model_key="fast")
-    return Agent(
+    return _stamp_provider(Agent(
         client=client,
         instructions=CRITIC_AGENT_INSTRUCTIONS,
         tools=[
@@ -106,13 +124,13 @@ def create_critic_agent(tools: CriticTools, provider: str = "openrouter") -> Age
         ],
         name="CriticAgent",
         default_options=_fast_options(),
-    )
+    ), provider)
 
 
 def create_coordinator_agent(tools: CoordinatorTools, provider: str = "openrouter") -> Agent:
     """CoordinatorAgent: strategic escalation. Uses reasoning model."""
     client = create_client(provider, model_key="reasoning")
-    return Agent(
+    return _stamp_provider(Agent(
         client=client,
         # #1081: the Coordinator sets the attack plan — ground it in the
         # committed reference docs (mmaaz-git strategies, ported defs).
@@ -137,7 +155,7 @@ def create_coordinator_agent(tools: CoordinatorTools, provider: str = "openroute
         ],
         name="CoordinatorAgent",
         default_options=_reasoning_options(),
-    )
+    ), provider)
 
 
 # 512 was too tight: a frontier reasoning model (Opus 4.7 / GPT-5.5) needs
@@ -162,7 +180,7 @@ def create_director_agent(provider: str = "openrouter",
     Budget: max 2048 tokens, max 3 calls per session.
     """
     client = create_client(provider, model_key="reasoning")
-    return Agent(
+    return _stamp_provider(Agent(
         client=client,
         # #1081: the whole point of the frontier Director is grounded guidance
         # — inject the committed reference docs (mmaaz-git proofs, ported defs,
@@ -173,13 +191,13 @@ def create_director_agent(provider: str = "openrouter",
         tools=[],
         name="DirectorAgent",
         default_options=ChatOptions(max_tokens=DIRECTOR_MAX_TOKENS),
-    )
+    ), provider)
 
 
 def create_diagnosis_agent(tools: DiagnosisTools, provider: str = "local") -> Agent:
     """DiagnosisAgent: qualitative verification. Uses fast local model."""
     client = create_client(provider, model_key="fast")
-    return Agent(
+    return _stamp_provider(Agent(
         client=client,
         instructions=DIAGNOSIS_AGENT_INSTRUCTIONS,
         tools=[
@@ -193,4 +211,4 @@ def create_diagnosis_agent(tools: DiagnosisTools, provider: str = "local") -> Ag
         ],
         name="DiagnosisAgent",
         default_options=_fast_options(),
-    )
+    ), provider)

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py
@@ -104,18 +104,48 @@ def _transient_backoff_s(attempt: int) -> float:
     return min(2.0 ** (attempt - 1), TRANSIENT_RETRY_BACKOFF_CAP_S)
 
 
-def _is_transient_error(exc: BaseException) -> bool:
+# P1b (#7477): providers whose timeout = a GPU-stall hang, not a transient
+# network blip. The local vLLM server does not serve 5xx/reset transients, so
+# a timeout means the endpoint accepted the connection then stalled — retrying
+# re-burns request_timeout_s with zero recovery chance (config.py P1 already
+# dropped the OpenAI-SDK max_retries to 1 for local; this stops the workflow
+# layer from multiplying that burn via TRANSIENT_RETRY_MAX). Forensic span
+# evidence: `[ERROR] chat qwen3.6 1206.9s`, `[ERROR] invoke_agent SearchAgent
+# 2299.7s` (#7477). Remote providers (zai/openrouter/mistral) stay retryable.
+HANG_PRONE_PROVIDERS = frozenset({"local"})
+
+# String-form timeout markers (the OpenAI SDK / httpx raise these as
+# APITimeoutError / ReadTimeout; agent_framework may wrap them). Used by
+# `_is_transient_error` to recognize a timeout when no structured status_code
+# is available. Kept separate from the general `transient_markers` tuple so
+# the hang-prone-provider carve-out (above) targets ONLY timeouts.
+_TIMEOUT_MARKERS = (
+    "read timeout", "connect timeout", "timed out", "timeout",
+)
+
+
+def _is_transient_error(exc: BaseException, provider: Optional[str] = None) -> bool:
     """Return True if `exc` looks like a transient provider/network error.
 
     Matches ONLY conditions worth retrying:
       - HTTP 5xx server errors (500, 502, 503, 504),
       - connection reset / aborted / refused,
-      - read / connect timeouts.
+      - read / connect timeouts (for *remote* providers — see ``provider``).
 
     Explicitly EXCLUDES 404 (bad/missing model_id — a config bug, retrying just
     wastes time) and other 4xx client errors (401/403/422). `agent_framework`
     may wrap the underlying httpx / openai error, so we probe both the
     `status_code` attribute and the stringified message defensively.
+
+    ``provider`` (P1b, #7477): the agent's provider (stamped on the Agent by
+    ``agents._stamp_provider``, read at the retry call site). For a
+    hang-prone provider (``HANG_PRONE_PROVIDERS``) a timeout is a GPU-stall
+    hang, NOT a transient blip — the OpenAI SDK already exhausted its internal
+    retries (max_retries=1 for local, config.py P1) each re-burning the full
+    request_timeout_s, and the workflow layer must NOT multiply that burn
+    (TRANSIENT_RETRY_MAX=5). The timeout is returned as non-transient so the
+    outage-breaker terminates the run cleanly. Remote providers keep the
+    retry behavior (a 504/read-timeout on openrouter can resolve on retry).
     """
     # 1. Structured HTTP status code, if the provider exposed one. Checked on
     #    the exception and a common nested `.response` (httpx-style) attribute.
@@ -135,6 +165,17 @@ def _is_transient_error(exc: BaseException) -> bool:
     if any(code in msg for code in (" 404", "404 ", "not found",
                                     " 401", " 403", " 422",
                                     "unauthorized", "forbidden")):
+        return False
+
+    # P1b (#7477): a hang-prone provider (local vLLM) that times out is in a
+    # GPU-stall hang — retrying re-burns request_timeout_s with no chance of
+    # recovery. Treat it as a definitive provider failure (return False) so
+    # the outage-breaker terminates the run instead of multiplying the burn.
+    # A local server never serves a structured 504 (handled in step 1), so
+    # this only catches the string-form timeout markers.
+    if provider in HANG_PRONE_PROVIDERS and any(
+        marker in msg for marker in _TIMEOUT_MARKERS
+    ):
         return False
 
     transient_markers = (
@@ -480,7 +521,9 @@ class AgentExecutor(Executor):
                             agent=self._agent.name, role="error_retry_failed",
                             content=str(e2)[:200],
                         )
-            elif _is_transient_error(e):
+            elif _is_transient_error(
+                e, getattr(self._agent, "_prover_provider", None)
+            ):
                 # Transient provider/network error (HTTP 5xx, connection
                 # reset/aborted, read/connect timeout). Forensic: several
                 # iterations were lost when an agent crashed mid-run on a
@@ -511,7 +554,10 @@ class AgentExecutor(Executor):
                         _last_exc = e_retry
                         # Only keep retrying while still transient; a fresh
                         # non-transient error must fall through immediately.
-                        if not _is_transient_error(e_retry):
+                        if not _is_transient_error(
+                            e_retry,
+                            getattr(self._agent, "_prover_provider", None),
+                        ):
                             break
                 if response_text is None:
                     # Retries exhausted (or a non-transient error surfaced) —

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_p1b_timeout.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_p1b_timeout.py
@@ -1,0 +1,163 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for the prover P1b hang-prone-provider timeout policy (#7477).
+
+``_is_transient_error`` (prover/workflow.py) classifies which provider/network
+errors are worth retrying at the workflow layer. Forensic #7477 showed that a
+*hanging* local endpoint (vLLM / qwen3.6 GPU stall) burned the whole wall-clock
+budget on a single logical call: the OpenAI SDK retried the timeout
+``max_retries`` times (each re-burning ``request_timeout_s``), then the
+workflow layer re-classified the timeout as transient and retried
+``TRANSIENT_RETRY_MAX`` (5) more times — span evidence ``[ERROR] chat qwen3.6
+1206.9s``, ``invoke_agent SearchAgent 2299.7s``.
+
+P1a (config.py, #7482) capped the SDK retries for ``local`` to 1. P1b (this
+change) stops the *workflow* layer from multiplying the burn: for a
+hang-prone provider (``HANG_PRONE_PROVIDERS = {"local"}``) a timeout is a
+definitive provider failure (non-transient), so it flows to the
+``_provider_failed`` branch and the outage-breaker (``PROVIDER_OUTAGE_BREAKER``)
+terminates the run cleanly instead of retrying.
+
+These tests pin the provider-aware carve-out. Non-vacuous: on the unpatched
+``_is_transient_error`` (no ``provider`` arg), every local-timeout case below
+returns ``True`` (transient → retried 5×) — the exact burn we eliminate.
+
+Run from `agent_tests/`:
+    python -m pytest tests/test_prover_p1b_timeout.py -q
+
+See #7477 (prover forensic) and #1453 (prover robustness epic).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Make `prover/` importable regardless of how pytest was invoked (same
+# bootstrap convention as test_prover_guards.py).
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+sys.path.insert(0, str(ROOT))
+
+from prover.workflow import (  # noqa: E402
+    HANG_PRONE_PROVIDERS,
+    _is_transient_error,
+)
+from prover.agents import _stamp_provider  # noqa: E402
+
+
+class _FakeStatusError(Exception):
+    """An exception exposing a structured ``status_code`` (httpx/openai-style)."""
+
+    def __init__(self, message: str, status_code: int):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+# ---------------------------------------------------------------------------
+# P1b core: hang-prone provider timeout = NOT transient (the fix).
+# ---------------------------------------------------------------------------
+
+def test_hang_prone_providers_contains_local():
+    """The carve-out targets exactly the local vLLM provider."""
+    assert "local" in HANG_PRONE_PROVIDERS
+
+
+def test_local_timeout_is_not_transient():
+    """A local-provider timeout is a GPU-stall hang — must NOT be retried.
+
+    Non-vacuous: on the unpatched function (no provider arg) this returns True
+    (the 1206.9s burn). With P1b it returns False → flows to _provider_failed
+    → outage-breaker.
+    """
+    for msg in ("Read timed out", "read timeout", "connect timeout",
+                "The request timed out.", "Operation timed out after 240s"):
+        assert _is_transient_error(RuntimeError(msg), provider="local") is False, (
+            f"local timeout must not be transient (msg={msg!r})"
+        )
+
+
+def test_local_timeout_not_transient_even_with_default_provider_arg():
+    """provider defaults to None → unknown provider → keep retry behavior.
+
+    Backward-compat guard: an agent WITHOUT the stamp (e.g. a test fixture or
+    a future agent not built via create_*_agent) keeps the legacy
+    timeout=transient behavior. Only an explicit hang-prone provider opts out.
+    """
+    assert _is_transient_error(RuntimeError("read timeout")) is True
+    assert _is_transient_error(RuntimeError("read timeout"), provider=None) is True
+
+
+# ---------------------------------------------------------------------------
+# P1b does NOT weaken the remote-provider retry behavior (regression fence).
+# ---------------------------------------------------------------------------
+
+def test_remote_timeout_still_transient():
+    """Remote providers (zai/openrouter/mistral) keep retrying timeouts — a
+    remote 504 / read-timeout can resolve on retry (cheap fast-fail)."""
+    for provider in ("zai", "openrouter", "mistral"):
+        assert _is_transient_error(
+            RuntimeError("read timeout"), provider=provider
+        ) is True, f"remote {provider} timeout must stay transient"
+
+
+def test_local_5xx_still_transient():
+    """P1b carves out ONLY timeouts for local providers. A genuine 5xx from
+    a local server (rare, but possible on a restart) still retries."""
+    assert _is_transient_error(
+        RuntimeError("500 internal server error"), provider="local"
+    ) is True
+
+
+def test_local_connection_reset_still_transient():
+    """Connection reset is a transient transport blip, not a hang — still
+    retried even for local providers."""
+    assert _is_transient_error(
+        RuntimeError("connection reset by peer"), provider="local"
+    ) is True
+
+
+# ---------------------------------------------------------------------------
+# 4xx guard + structured-status path take priority over the timeout carve-out.
+# ---------------------------------------------------------------------------
+
+def test_4xx_guard_wins_over_local_timeout():
+    """A 404 (config bug) is never transient, even for a local provider and
+    even when the message also contains 'timeout'."""
+    assert _is_transient_error(
+        RuntimeError("404 not found: model timeout"), provider="local"
+    ) is False
+
+
+def test_structured_504_is_transient_regardless_of_provider():
+    """A structured status_code=504 (gateway timeout) is transient via the
+    status-code path (step 1) — provider is irrelevant there. A local server
+    never serves a structured 504, but if agent_framework surfaces one it is
+    still treated as transient (the carve-out only catches string timeouts)."""
+    err = _FakeStatusError("gateway timeout", status_code=504)
+    assert _is_transient_error(err, provider="local") is True
+    assert _is_transient_error(err, provider="openrouter") is True
+
+
+def test_structured_404_not_transient_regardless_of_provider():
+    """A structured 4xx (config bug) is never transient, for any provider."""
+    err = _FakeStatusError("not found", status_code=404)
+    assert _is_transient_error(err, provider="local") is False
+    assert _is_transient_error(err, provider="openrouter") is False
+
+
+# ---------------------------------------------------------------------------
+# _stamp_provider (agents.py) tags the agent so the retry site can read it.
+# ---------------------------------------------------------------------------
+
+def test_stamp_provider_sets_attribute():
+    """_stamp_provider tags an arbitrary object with _prover_provider and
+    returns it (the Agent object allows attribute assignment — no __slots__)."""
+
+    class _FakeAgent:
+        pass
+
+    agent = _FakeAgent()
+    assert not hasattr(agent, "_prover_provider")
+    returned = _stamp_provider(agent, "local")
+    assert returned is agent  # returns the same object
+    assert agent._prover_provider == "local"


### PR DESCRIPTION
## Summary

**P1b** of the #7477 forensic survey — the single highest-ROI remaining transport fix (ai-01 steer `msg-...ssmvvi`, HIGH). Closes the second multiplicative layer of the local-endpoint hang-burn that P1a (#7482) opened. **ai-01 greenlit the direction** (« Bon prochain grain si tu restes forensic »); this implements it.

The hang-burn had two layers: (1) the OpenAI SDK retried a hanging endpoint `max_retries` times, each re-burning `request_timeout_s`; (2) the workflow layer (`_is_transient_error`) re-classified the timeout as TRANSIENT and retried `TRANSIENT_RETRY_MAX` (5) more times. **P1a** (config.py, merged) capped layer 1 for `local` to `max_retries=1`. **P1b** (this PR) stops layer 2 from multiplying the remaining burn.

## Bug firsthand (G.1, read `origin/main`)

`_is_transient_error` (workflow.py) classified `"read timeout"/"timed out"/"connect timeout"` as **transient** for ALL providers. For the local vLLM provider, a timeout is a **GPU-stall hang** (the endpoint accepted the connection then stalled). The SDK already exhausted its (P1a-capped) retries, each re-burning the full 240s. The workflow then retried 5× more: **2 SDK attempts × 240s × 5 ≈ 2400s on ONE logical chat call**. Forensic span evidence: `[ERROR] chat qwen3.6 1206.9s`, `[ERROR] invoke_agent SearchAgent 2299.7s` (#7477).

## Fix — provider-aware carve-out (3 files)

**`workflow.py`**:
- New `HANG_PRONE_PROVIDERS = frozenset({"local"})` + `_TIMEOUT_MARKERS` tuple (kept separate from the general `transient_markers` so the carve-out targets ONLY timeouts).
- `_is_transient_error(exc, provider=None)`: when `provider in HANG_PRONE_PROVIDERS` AND the error is a string-form timeout, return **False** (non-transient) — placed AFTER the 4xx guard, BEFORE the general transient_markers (correct precedence). A local timeout now flows to the existing `else: _provider_failed` branch → feeds `PROVIDER_OUTAGE_BREAKER` → clean `provider_outage` verdict in minutes instead of burning the wall-clock cap.
- Structured-status-code path (step 1) **unchanged**: a real 5xx stays transient for every provider. A local server never serves a structured 504, so the carve-out only catches string-form timeouts.
- Both `_is_transient_error` call sites in `AgentExecutor.handle` pass `getattr(self._agent, "_prover_provider", None)`.

**`agents.py`**:
- `_stamp_provider(agent, provider)` helper + all 6 `create_*_agent` functions stamp `agent._prover_provider`. `agent_framework.Agent` has no `__slots__` and is not a frozen dataclass → attribute assignment is safe.
- This solves the "provider not reachable at the retry decision-point" problem (the `AgentExecutor` wraps a built Agent; previously the provider was dropped at build time).

## Behavior preserved (regression fences)

| Case | Behavior | Changed? |
|---|---|---|
| Local timeout | was: transient → retried 5× (~2400s) / now: non-transient → outage-breaker | **FIXED** |
| Remote timeout (zai/openrouter/mistral) | transient → retried (a remote 504 can resolve) | unchanged |
| Unknown provider / `None` (default) | timeout → transient (backward compat) | unchanged |
| Local 5xx | transient (still retried) | unchanged |
| Local connection-reset | transient (still retried) | unchanged |
| 4xx guard (404/401/403) | wins over timeout regardless of provider | unchanged |
| Structured status_code=504 | transient (status path, provider-agnostic) | unchanged |

## Validation

- **10/10 new tests** in `tests/test_prover_p1b_timeout.py` (provider-aware carve-out + stamp helper + regression fences).
- **Full prover `tests/` suite: 284 passed, 0 regression** (274 baseline + 10 new).
- **G.9 NON-VACUOUS proven airtight**: neutralizing the carve-out (git-temp edit `if False and ...`) makes `test_local_timeout_is_not_transient` FAIL with `assert True is False` (unpatched returns True = the burn); restoring makes it pass. Confirmed locally.
- `proof_knowledge.json` restored after pytest (MEMORY lesson: pytest run regenerates it; never `git add -A`).
- Catalog byte-identical to `origin/main`.

## Scope / honesty

- 3 files, +80/−16 prod + new test (+178). Catalog byte-identical. Worktree fresh off `origin/main` `c7f919362`.
- **Honest scope-class**: MED-DEEP transport-layer fix on prover-critical code — real bug (evidence-cited span burn), not cosmetic. Multi-touch (agents stamp + workflow logic + 2 call sites + tests) — appropriately a full-cycle grain, NOT rushed in a partial window (rule D). Design option (a) proposed to ai-01 in DM `msg-...kokp43` before implementation; implemented without waiting for reply since ai-01's original steer already authorized the direction.
- Note: this is a **bounded** fix — it eliminates the workflow-layer retry multiplication for local timeouts but does NOT change the SDK-layer timeout itself (240s, where reasoning models legitimately take 30-90s). The two together (P1a SDK-cap + P1b workflow-skip) bound a hung local call at ~1× request_timeout_s before the outage-breaker fires.

See #7477 (prover forensic). See #1453 (prover robustness epic). Co-author: ai-01 (steer + forensic context).
