### PR TITLE
test(gametheory): cover analyze_coalition_dynamics orchestration (Shapley efficiency invariant)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/tests/test_french_politics.py
+++ b/MyIA.AI.Notebooks/GameTheory/tests/test_french_politics.py
@@ -34,6 +34,7 @@ from cooperative_games.french_politics import (  # noqa: E402
     TOTAL_SEATS,
     FrenchLeftCoalition2024,
     analyze_barrage_effect,
+    analyze_coalition_dynamics,
     create_voting_game_assembly,
     get_2024_legislative_data,
     negotiation_value,
@@ -322,6 +323,70 @@ class TestAnalyzeBarrageEffect:
         # Les desistements officiels par bloc doivent apparaitre.
         assert str(SECOND_ROUND_RESULTS['NFP']['withdrawals']) in out
         assert str(SECOND_ROUND_RESULTS['RN']['withdrawals']) in out
+
+
+class TestAnalyzeCoalitionDynamics:
+    """Couverture de ``analyze_coalition_dynamics`` (orchestrateur haut-niveau
+    qui assemble Shapley + Core + convexite + tables pour les 3 fonctions de
+    valeur). Non couvert avant ce test (0 ref dans le fichier). Les assertions
+    portent sur le contrat structurel + l'invariant d'efficiency de Shapley
+    (sum des valeurs == valeur de la grande coalition) — un invariant de game
+    theory fondamental, pas un pin de valeur : si l'orchestration passait le
+    mauvais game a ``shapley_value_exact`` ou melait les value_type,
+    l'efficiency casserait. Valeurs confirmees par execution firsthand (G.9).
+    """
+
+    EXPECTED_KEYS = {
+        "game", "shapley_values", "shapley_dict", "grand_coalition_value",
+        "core_exists", "core_point", "is_convex", "analysis_text",
+        "marginal_table",
+    }
+
+    @pytest.mark.parametrize("value_type", ["seats", "voting_power", "negotiation"])
+    def test_returns_all_documented_keys(self, value_type):
+        results = analyze_coalition_dynamics(value_type=value_type)
+        assert set(results.keys()) == self.EXPECTED_KEYS
+
+    @pytest.mark.parametrize("value_type", ["seats", "voting_power", "negotiation"])
+    def test_shapley_efficiency_holds(self, value_type):
+        """Invariant d'efficiency : sum(shapley_values) == grand_coalition_value.
+        Propriete definissoire de la valeur de Shapley (efficiency = 1)."""
+        results = analyze_coalition_dynamics(value_type=value_type)
+        total = float(np.sum(results["shapley_values"]))
+        gv = float(results["grand_coalition_value"])
+        assert abs(total - gv) < 1e-6, (
+            f"Shapley efficiency broken for value_type={value_type}: "
+            f"sum={total}, grand_coalition_value={gv}"
+        )
+
+    @pytest.mark.parametrize("value_type", ["seats", "voting_power", "negotiation"])
+    def test_shapley_dict_keys_are_the_four_parties(self, value_type):
+        results = analyze_coalition_dynamics(value_type=value_type)
+        assert set(results["shapley_dict"].keys()) == set(FrenchLeftCoalition2024.PARTIES)
+
+    @pytest.mark.parametrize("value_type", ["seats", "voting_power", "negotiation"])
+    def test_shapley_dict_values_match_shapley_values(self, value_type):
+        """shapley_dict[PARTIES[i]] doit egaler shapley_values[i] (coherence
+        entre les deux representations du meme calcul)."""
+        results = analyze_coalition_dynamics(value_type=value_type)
+        parties = FrenchLeftCoalition2024.PARTIES
+        shapley = results["shapley_values"]
+        for i, party in enumerate(parties):
+            assert abs(results["shapley_dict"][party] - shapley[i]) < 1e-9
+
+    @pytest.mark.parametrize("value_type", ["seats", "voting_power", "negotiation"])
+    def test_core_and_convexity_are_bool(self, value_type):
+        results = analyze_coalition_dynamics(value_type=value_type)
+        assert isinstance(results["core_exists"], bool)
+        assert isinstance(results["is_convex"], bool)
+
+    @pytest.mark.parametrize("value_type", ["seats", "voting_power", "negotiation"])
+    def test_narrative_tables_are_nonempty_strings(self, value_type):
+        """analysis_text et marginal_table sont des rapports formates (str) ;
+        vides = l'orchestration a saute la generation."""
+        results = analyze_coalition_dynamics(value_type=value_type)
+        assert isinstance(results["analysis_text"], str) and len(results["analysis_text"]) > 0
+        assert isinstance(results["marginal_table"], str) and len(results["marginal_table"]) > 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`analyze_coalition_dynamics` ([`french_politics.py:605`](MyIA.AI.Notebooks/GameTheory/cooperative_games/french_politics.py#L605)) — the high-level orchestrator that assembles Shapley values + Core existence/point + convexity check + narrative tables across the 3 value functions (`seats` / `voting_power` / `negotiation`) — had **0 test references** (verified by `git grep`). This adds the first coverage.

## What is tested

`TestAnalyzeCoalitionDynamics` — 6 methods, each parametrized over the 3 `value_type`s = **18 new test cases**:

| Test | Asserts |
|------|---------|
| `test_returns_all_documented_keys` | the returned `dict` has exactly the 9 documented keys (`game`, `shapley_values`, `shapley_dict`, `grand_coalition_value`, `core_exists`, `core_point`, `is_convex`, `analysis_text`, `marginal_table`) — catches silent schema changes |
| `test_shapley_efficiency_holds` | `abs(sum(shapley_values) - grand_coalition_value) < 1e-6` — **the defining efficiency property of the Shapley value (efficiency = 1)**. A genuine invariant, not a value pin |
| `test_shapley_dict_keys_are_the_four_parties` | `shapley_dict` keys == `FrenchLeftCoalition2024.PARTIES` |
| `test_shapley_dict_values_match_shapley_values` | `shapley_dict[PARTIES[i]] == shapley_values[i]` within 1e-9 — coherence between the two representations of the same computation |
| `test_core_and_convexity_are_bool` | `core_exists` / `is_convex` are `bool` (not truthy junk) |
| `test_narrative_tables_are_nonempty_strings` | `analysis_text` + `marginal_table` are non-empty `str` — empty = orchestration skipped generation |

## Why invariant-based, not value-pinning

Per the [[pin-invariant-not-hardcoded-output]] lesson (c.535): pinning exact Shapley numbers would crystalize the calibrated `PARTIES_2024` constants / synergy factors. Instead the efficiency test asserts the **invariant** `sum(phi) == v(grand coalition)` — if the orchestration passed the wrong `game` to `shapley_value_exact` or mixed `value_type`s, the efficiency axiom breaks regardless of the constant values.

## Validation

```
=== my new tests ===
18 passed in 0.72s

=== FULL test_french_politics.py (existing 5 classes + new) ===
60 passed in 0.70s   # 42 existing + 18 new, no regression
```

- Line endings: CR=0 (LF clean — `*.py` CRLF hygiene)
- Diff: `1 file changed, 65 insertions(+)` — pure additive, 0 deletions

## Scope

Single file, single subject (test-coverage for one untested public function). See #7422 (test-coverage is a partial contribution to the docs/test hygiene epic, not a full resolution — no `Closes`).

<!-- codex-meta po-2026 machine="myia-po-2026" lane="CoursIA" -->
