### PR TITLE
fix(genai): guard degenerate inputs in live video_helpers (extract_frames n_frames, frames_to_video fps)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/shared/helpers/test_video_helpers.py
+++ b/MyIA.AI.Notebooks/GenAI/shared/helpers/test_video_helpers.py
@@ -418,3 +418,32 @@ def test_add_audio_to_video_trims_audio_when_longer(monkeypatch, tmp_path):
     # Audio was trimmed because audio.duration > video.duration.
     assert audio.subclipped == (0, 10.0)
     assert video.audio_set is audio
+
+
+# ---------------------------------------------------------------------------
+# Degenerate-input guards (live functions only)
+# ---------------------------------------------------------------------------
+
+def test_extract_frames_rejects_non_positive_n_frames():
+    """extract_frames must reject n_frames<=0 upfront (before decord/PIL import).
+
+    Previously n_frames=0 returned [] silently and n_frames<0 crashed inside
+    numpy.linspace with an opaque 'Number of samples must be non-negative'.
+    """
+    for bad in (0, -1, -8):
+        with pytest.raises(ValueError, match="n_frames must be positive"):
+            vh.extract_frames("v.mp4", n_frames=bad)
+
+
+def test_frames_to_video_rejects_non_positive_fps():
+    """frames_to_video must reject fps<=0 upfront (before imageio import).
+
+    Previously fps<=0 was forwarded to imageio.get_writer, which raised an
+    opaque error deep in the writer.
+    """
+    import numpy as np
+    from PIL import Image  # noqa: F401  (ensure PIL present; not the point)
+    frame = Image.fromarray(np.zeros((4, 4, 3), dtype=np.uint8))
+    for bad in (0, 0.0, -1.5):
+        with pytest.raises(ValueError, match="fps must be positive"):
+            vh.frames_to_video([frame], fps=bad, output_path="out.mp4")

--- a/MyIA.AI.Notebooks/GenAI/shared/helpers/video_helpers.py
+++ b/MyIA.AI.Notebooks/GenAI/shared/helpers/video_helpers.py
@@ -90,6 +90,9 @@ def extract_frames(path: str, n_frames: int = 8,
     Returns:
         Liste d'images PIL.Image
     """
+    if n_frames <= 0:
+        raise ValueError(f"n_frames must be positive, got {n_frames}")
+
     from PIL import Image
     import decord
     decord.bridge.set_bridge('native')
@@ -229,6 +232,9 @@ def frames_to_video(frames: List, fps: float, output_path: str,
         output_path: Chemin du fichier de sortie
         codec: Codec video (libx264, libx265, mpeg4)
     """
+    if fps <= 0:
+        raise ValueError(f"fps must be positive, got {fps}")
+
     import imageio
 
     Path(output_path).parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

`extract_frames` and `frames_to_video` in [`GenAI/shared/helpers/video_helpers.py`](MyIA.AI.Notebooks/GenAI/shared/helpers/video_helpers.py) — the two **live** functions of that module (verified used in 5 GenAI/Video notebooks + QuantConnect GPU-training) — silently misbehaved or crashed opaquely on non-positive inputs. This adds upfront `ValueError` guards + lockstep pytest coverage.

## Bugs (reproduced firsthand before fixing — G.1)

| Call | Before | After |
|------|--------|-------|
| `extract_frames(path, n_frames=0)` | returned `[]` **silently** (no error) | `ValueError: n_frames must be positive, got 0` |
| `extract_frames(path, n_frames=-3)` | opaque `numpy` error: `Number of samples, -3, must be non-negative` (from `linspace`) | `ValueError: n_frames must be positive, got -3` |
| `frames_to_video(frames, fps=0)` | opaque error deep in `imageio.get_writer` | `ValueError: fps must be positive, got 0` |

A silent empty return on `n_frames=0` is the worst case — a notebook extracting 0 frames proceeds as if nothing happened instead of failing loudly.

## Scope — live functions only

Repo-wide usage check (`git grep` across all files, not just notebooks):

| Function | Used | Action |
|----------|------|--------|
| `extract_frames` | 5 GenAI/Video notebooks | **guarded** ✅ |
| `frames_to_video` | `QuantConnect/shared/gpu_training.py` (+ its test) | **guarded** ✅ |
| `extract_frames_at_times` | 0 refs | dead — **not touched** |
| `trim_video` | 0 refs | dead — **not touched** |
| `concatenate_videos` | 0 refs | dead — **not touched** |
| `resize_video` | 0 refs | dead — **not touched** |
| `display_video_comparison` | 0 refs | dead — **not touched** |

The 5 dead wrappers are deliberately **not** guarded — guarding dead code is low-value busywork (the `#1876`/`#1885` dead-code trap). If a notebook later adopts one, the guard can be added then.

## Validation (ran the ACTUAL pytest suite, lesson c.558)

```
=== my 2 new guard tests ===
2 passed in 0.29s

=== FULL test_video_helpers.py (existing 14 + new 2) ===
16 passed in 0.33s   # no regression
```

- Line endings: CR=0 on both files (LF clean)
- Diff: `2 files changed, 35 insertions(+)` — pure additive, 0 deletions

## Context

Extends the degenerate-input guard discipline to a **new family** (GenAI) — the same pattern as `compute_payoff_matrix` / `play_match` (GameTheory) but on previously-unscanned terrain. Single subject, single module.

<!-- codex-meta po-2026 machine="myia-po-2026" lane="CoursIA" -->
