### PR TITLE
fix(genai): guard degenerate inputs in live audio_helpers (save_audio sr, estimate_audio_duration wpm)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/shared/helpers/audio_helpers.py
+++ b/MyIA.AI.Notebooks/GenAI/shared/helpers/audio_helpers.py
@@ -43,6 +43,9 @@ def save_audio(data: np.ndarray, sr: int, path: str, format: Optional[str] = Non
         path: Chemin de sortie
         format: Format (wav, mp3, flac, ogg). Auto-detecte depuis l'extension si None.
     """
+    if sr <= 0:
+        raise ValueError(f"sr must be positive, got {sr}")
+
     import soundfile as sf
     output_path = Path(path)
     output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -468,5 +471,8 @@ def estimate_audio_duration(text: str, words_per_minute: int = 150) -> float:
     Returns:
         Duree estimee en secondes
     """
+    if words_per_minute <= 0:
+        raise ValueError(f"words_per_minute must be positive, got {words_per_minute}")
+
     word_count = len(text.split())
     return (word_count / words_per_minute) * 60

--- a/MyIA.AI.Notebooks/GenAI/shared/helpers/tests/test_audio_helpers.py
+++ b/MyIA.AI.Notebooks/GenAI/shared/helpers/tests/test_audio_helpers.py
@@ -666,3 +666,34 @@ def test_estimate_audio_duration_pure_no_deps():
 def test_estimate_audio_duration_handles_whitespace_only():
     """estimate_audio_duration("   ") -> split vide -> 0 mots -> 0 secondes (pas d'erreur)."""
     assert audio_helpers.estimate_audio_duration("   \n\t  ") == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Degenerate-input guards (LIVE functions only)
+# ---------------------------------------------------------------------------
+
+def test_save_audio_rejects_non_positive_sr(fake_soundfile, tmp_path):
+    """save_audio must reject sr<=0 upfront.
+
+    Previously sr=0 was forwarded to soundfile.write (file written!) and then
+    crashed in the log line `len(data)/sr` with ZeroDivisionError -- a
+    partial-state bug (file on disk + exception raised). save_audio is used in
+    20 notebooks.
+    """
+    import numpy as np
+    data = np.zeros(16000, dtype=np.float32)
+    for bad in (0, -8000):
+        with pytest.raises(ValueError, match="sr must be positive"):
+            audio_helpers.save_audio(data, bad, str(tmp_path / "out.wav"))
+    # The guard fires BEFORE soundfile.write -> no file written.
+    fake_soundfile.write.assert_not_called()
+
+
+def test_estimate_audio_duration_rejects_non_positive_wpm():
+    """estimate_audio_duration must reject words_per_minute<=0 upfront.
+
+    Previously wpm=0 raised an opaque ZeroDivisionError from the division.
+    """
+    for bad in (0, -60):
+        with pytest.raises(ValueError, match="words_per_minute must be positive"):
+            audio_helpers.estimate_audio_duration("un deux trois", words_per_minute=bad)


### PR DESCRIPTION
## Summary

`save_audio` and `estimate_audio_duration` in [`GenAI/shared/helpers/audio_helpers.py`](MyIA.AI.Notebooks/GenAI/shared/helpers/audio_helpers.py) — two **live** functions (used in 20 + 3 GenAI notebooks) — crashed on non-positive inputs. This adds upfront `ValueError` guards + lockstep pytest coverage.

## Bugs (reproduced firsthand before fixing — G.1)

| Call | Before | After |
|------|--------|-------|
| `save_audio(data, sr=0, path)` | `soundfile.write` **succeeded (file on disk!)** then crashed in the log line `len(data)/sr` with `ZeroDivisionError` — **partial-state bug** | `ValueError: sr must be positive, got 0` (before write) |
| `estimate_audio_duration(text, words_per_minute=0)` | opaque `ZeroDivisionError` from the division | `ValueError: words_per_minute must be positive, got 0` |

The `save_audio` case is the worst: a `sr=0` call **writes the file** to disk and *then* raises — the caller sees an exception but a file exists, leading to confusion. `save_audio` is used in **20 notebooks**.

## Scope — live functions only

Repo-wide usage check (`git grep` across notebooks):

| Function | Used | Action |
|----------|------|--------|
| `save_audio` | 20 notebooks | **guarded** ✅ |
| `estimate_audio_duration` | 3 notebooks | **guarded** ✅ |
| `load_audio` (sr<=0) | 3 notebooks | librosa raises a clear error — not guarded |
| `play_audio` (sr<=0) | 21 notebooks | IPython-internal behavior — not guarded |
| `convert_audio`, `transcribe_api`, `synthesize_tts_api` | 0 refs | dead — not touched |

Only functions with a real degenerate-input bug where the error was opaque or partial-state are guarded (the `#1876`/`#1885` dead-code trap is avoided).

## Validation (ran the ACTUAL pytest suite, lesson c.558)

```
=== my 2 new guard tests ===
2 passed in 0.93s

=== FULL test_audio_helpers.py (existing + new) ===
32 passed, 2 new passed (34 relevant) ; 1 pre-existing failure
```

- The **1 pre-existing failure** (`test_plot_waveform_calls_librosa_display_waveshow` → `ModuleNotFoundError: No module named 'librosa'`) is **environmental and unrelated** — it fails identically on pristine `origin/main` (verified via `git stash` of my edits). `librosa` is not installed in the local `mcp-jupyter-py310` env; CI uses a fuller env. My diff does not touch `plot_waveform`/`librosa` (verified by `git diff | grep`).
- Line endings: CR=0 on both files (LF clean)
- Diff: `2 files changed, 37 insertions(+)` — pure additive, 0 deletions

## Context

Completes the degenerate-input guard sweep over **GenAI/shared/helpers** started in #7537 (`video_helpers`). Same guard discipline as the GameTheory sweep (#7517/#7523/#7522/#7524), extended to a previously-unscanned family. Single subject, single module.

<!-- codex-meta po-2026 machine="myia-po-2026" lane="CoursIA" -->
