### PR TITLE
fix(gametheory): guard centipede_payoffs(n_rounds<=0) silent no-op

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/examples/centipede_game.py
+++ b/MyIA.AI.Notebooks/GameTheory/examples/centipede_game.py
@@ -28,7 +28,17 @@ def centipede_payoffs(n_rounds: int,
 
     Returns:
         List of (defector_payoff, other_payoff) at each node
+
+    Raises:
+        ValueError: if ``n_rounds <= 0`` (a centipede game needs at least one
+            decision node; ``n_rounds * 2`` drives ``range()`` and a non-positive
+            count silently collapses the game to the single terminal node,
+            masking the caller error).
     """
+    if n_rounds <= 0:
+        raise ValueError(
+            f"n_rounds must be positive (at least one decision node), got {n_rounds}"
+        )
     payoffs = []
     pot = 1.0
 

--- a/MyIA.AI.Notebooks/GameTheory/tests/test_centipede_game.py
+++ b/MyIA.AI.Notebooks/GameTheory/tests/test_centipede_game.py
@@ -95,6 +95,31 @@ class TestCentipedePayoffs:
         assert p[5] == pytest.approx((48.0, 16.0))
         assert p[-1] == pytest.approx((32.0, 32.0))
 
+    def test_zero_rounds_raises(self):
+        """n_rounds=0 -> before the guard, ``range(0)`` ran no iterations and
+        the function silently returned a single ``[(0.5, 0.5)]`` terminal node
+        — a game with NO decision nodes, masking the caller error. Now raises.
+
+        Same degenerate-input bug-class as the sibling ``train(iterations<=0)``
+        guards (#7489 kuhn_poker_cfr, #7524 FictitiousPlay) and the
+        ``rounds<=0`` guards (#7513 compute_payoff_matrix): a non-positive
+        count drives ``range()`` and collapses the loop to a silent no-op.
+        """
+        with pytest.raises(ValueError, match="n_rounds must be positive"):
+            centipede_payoffs(0)
+
+    def test_negative_rounds_raises(self):
+        """n_rounds<0 -> ``range(n_rounds*2)`` empty (absurd negative count),
+        silently returned ``[(0.5, 0.5)]`` before the guard."""
+        with pytest.raises(ValueError, match="n_rounds must be positive"):
+            centipede_payoffs(-3)
+
+    def test_positive_rounds_unaffected(self):
+        """The guard does not impact the normal path (node-count invariant)."""
+        for n in (1, 2, 5):
+            p = centipede_payoffs(n)
+            assert len(p) == 2 * n + 1
+
 
 # ----------------------------------------------------------------------------
 # backward_induction -- the centipede paradox: SPE is Take at node 0.


### PR DESCRIPTION
## Summary

`centipede_game.centipede_payoffs(n_rounds)` drives its node-count loop with ``range(n_rounds * 2)``. For ``n_rounds <= 0`` the range is empty and the function **silently returns a single ``[(0.5, 0.5)]`` terminal node** — a game with NO decision nodes, masking the caller error. This is the same degenerate-input bug-class as the sibling learner guards already on main:

- #7489 `kuhn_poker_cfr.train(iterations<=0)`
- #7524 `FictitiousPlay.train(iterations<=0)`
- #7513 `compute_payoff_matrix(rounds<=0)`

A centipede game — whose entire point is the decision sequence — has no meaningful 0-round form, so the guard rejects ``n_rounds <= 0`` with a clear `ValueError`, consistent with the family.

## Bug reproduced firsthand (G.9)

```
centipede_payoffs(0)  -> [(0.5, 0.5)]   # silent, looks valid
centipede_payoffs(-1) -> [(0.5, 0.5)]   # silent nonsense
centipede_payoffs(2)  -> [(1.5,0.5),(3.0,1.0),(6.0,2.0),(12.0,4.0),(8.0,8.0)]
```

## Fix

Entry guard after the docstring (sister-mirror pattern):
```python
if n_rounds <= 0:
    raise ValueError(
        f"n_rounds must be positive (at least one decision node), got {n_rounds}"
    )
```
Pure additive; the happy path (n_rounds>=1) is byte-identical.

## Validation (H.1 / G.9)

- **G.9 non-vacuous**: reverting only the production guard makes the two raises-tests FAIL (`DID NOT RAISE ValueError`); restoring → they pass.
- 20/20 centipede tests pass (17 baseline + 3 new guard tests: zero raises, negative raises, positive unaffected).
- Full `GameTheory/tests/` = **523 passed, 1 failed**. The 1 failure is `test_lean_definitions.py::test_basic_lean_compiles` ("Timeout after 30 seconds") = PREEXISTING + ENVIRONMENTAL (Lean/WSL kernel path missing), documented identically by po-2024 in #7524. This PR is Python-only and does not touch Lean → 0 related regression.

## Scope

+10 production / +25 test, 2 files. No callers pass `n_rounds<=0` (the existing tests and the notebook use n_rounds=1..5). Catalog byte-identical. `See #7422` (partial — test/guard hygiene).

## Collision check

`git ls-tree -r origin/main | grep centipede` + `gh pr list --state all --search centipede`: existing `test_centipede_game.py` (#7397) tests backward-induction and payoff formulas with n_rounds in {1,2,3,4,5} — **none pass n_rounds<=0**, so the guard breaks no existing test. No open/merged PR adds this guard.

Co-Authored-By: Claude-Code <noreply@anthropic.com>