### PR TITLE
test(qc-mcp-lite): isolate tests from live rate limiter (autouse fixture fixes full-suite hang)

### DIFF
--- a/scripts/qc-mcp-lite/tests/test_server.py
+++ b/scripts/qc-mcp-lite/tests/test_server.py
@@ -38,6 +38,22 @@ from server import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _reset_rate_limit_state():
+    """Reset the module-global rate-limit deque before each test.
+
+    ``_rate_limit()`` appends to the module-global ``_call_timestamps`` deque
+    without clearing it. Tests that exercise the real ``_api_post`` (they mock
+    ``requests.post`` but still call ``_rate_limit``) therefore accumulate
+    timestamps across the suite. Once 10 calls fall inside the 60s window, the
+    real ``time.sleep(~60s)`` fires -- hanging the full suite (~60s per excess
+    call, observed: 13 tests = 61.67s; the whole suite hung >2min before this).
+    Clearing the deque per test isolates each test from the live rate limiter.
+    """
+    _call_timestamps.clear()
+    yield
+
+
 # --- _get_credentials ---
 
 


### PR DESCRIPTION
## Summary

The `qc-mcp-lite` test suite (`scripts/qc-mcp-lite/tests/test_server.py`) **hung** when run in full, because the module-global rate-limit deque (`_call_timestamps`) accumulated across tests and eventually triggered the real `time.sleep(~60s)`. This adds an `autouse` fixture that resets the deque before each test — a genuine test-isolation fix (not a guard, not a feature).

## Root cause

`_rate_limit()` (server.py:49) appends to the module-global `_call_timestamps` deque without ever clearing it between requests. In production that's correct (it's a sliding 60s window). But the ~30 tests that exercise the real `_api_post` mock `requests.post` (network level) **while still invoking `_rate_limit`**, so they accumulate timestamps:

- After the 10th call in the 60s window, the 11th calls `time.sleep(~60s)` — real wall-clock sleep.
- Reproduced firsthand: `TestApiPost + TestCreateCompile + TestReadCompile + TestCreateBacktest` (13 tests) = **61.67s** (the 11th–13th each slept ~20s as the window slid).
- The full 53-test suite (~30 such calls) hung past the 2min pytest timeout.

This is invisible when running a single test class in isolation (the bug is *accumulation*), which is why it went undetected.

## Fix

An `autouse` fixture clears `_call_timestamps` before each test:

```python
@pytest.fixture(autouse=True)
def _reset_rate_limit_state():
    _call_timestamps.clear()
    yield
```

The dedicated `TestRateLimit` tests (`test_allows_up_to_max_calls`, `test_throttles_on_excess`, `test_window_expiry`) still meaningfully exercise the real sleep behavior — they self-clear and pre-fill the deque, so the autouse reset is inert for them.

## Validation (ran the ACTUAL full pytest suite, lesson c.558)

```
=== full suite WITH fix ===
53 passed in 2.02s          # was: hang >2min (timeout)
=== TestRateLimit (dedicated, real-sleep tests) still pass ===
5 passed, 48 deselected
```

- Line endings: CR=0 (LF clean)
- Diff: `1 file changed, 16 insertions(+)` — pure additive, 0 deletions

## Scope

Single file, single subject (test isolation fixture). No change to `server.py` production code. This is a different genre from the degenerate-input guard work (#7537/#7539) — it fixes **test infrastructure**, not input validation.

<!-- codex-meta po-2026 machine="myia-po-2026" lane="CoursIA" -->
