### PR TITLE
test(i18n,#4957): unit tests for i18n/sync _slug / write_csv / _extract_text

### DIFF
--- a/scripts/i18n/tests/test_sync_render.py
+++ b/scripts/i18n/tests/test_sync_render.py
@@ -19,6 +19,15 @@ Test grid (≥11 gates) :
 11. Render fallback : when EN is empty, render falls back to FR text.
 12. Render warning on orphan keys (CSV keys not in FR).
 
+Unit tests (primitive contracts, independent of the markdown layer) :
+- ``_slug`` : lowercase + whitespace collapse + non-word strip, accented-Latin
+  and CJK preservation, empty fallback, 40-char cap.
+- ``write_csv`` : RFC-4180 format (QUOTE_ALL, LF terminator), header schema,
+  ``keys_ordered`` row order, missing-lang empty cell, parent-dir creation,
+  and round-trip through ``read_csv``.
+- ``_extract_text`` : leaf precedence (text > raw), ``text``/``link``/``image``
+  /``emphasis``/``strong`` re-emission as markdown, mixed string+dict children.
+
 Run with : ``python -m pytest scripts/i18n/tests/test_sync_render.py -v``
 """
 from __future__ import annotations
@@ -38,7 +47,14 @@ for p in (_SCRIPTS_I18N, _REPO_ROOT):
     if str(p) not in sys.path:
         sys.path.insert(0, str(p))
 
-from scripts.i18n.sync import parse_markdown, sync, read_csv  # noqa: E402
+from scripts.i18n.sync import (  # noqa: E402
+    _extract_text,
+    _slug,
+    parse_markdown,
+    read_csv,
+    sync,
+    write_csv,
+)
 from scripts.i18n.render import render  # noqa: E402
 
 
@@ -265,3 +281,174 @@ def test_render_warns_on_orphan_keys(tmp_paths, capsys):
             w.writerow([k] + [row.get(l, "") for l in langs])
     results = render(csv_path, fr, [("en", out)])
     assert "ORPHAN_KEY.para1" in results[0].orphan_keys
+
+
+# --- Unit tests : _slug -------------------------------------------------- #
+# ``_slug`` is the key-derivation primitive of the whole CSV pipeline : two
+# distinct FR cells must map to two distinct keys, or translations silently
+# overwrite each other. ``parse_markdown`` exercises it indirectly via every
+# key, but a focused unit test pins the contract (CJK preserved, accents
+# preserved, empty fallback, length cap) independently of the markdown layer.
+def test_slug_lowercases_collapses_whitespace_strips_punct():
+    """Lowercase, ``\\s+`` -> single underscore, non-word chars stripped."""
+    assert _slug("Hello World!") == "hello_world"
+    assert _slug("Multi  spaces\ttabs") == "multi_spaces_tabs"
+
+
+def test_slug_preserves_accented_latin():
+    """Python3 ``\\w`` is Unicode-aware : accented Latin (première) is kept.
+
+    This matters for FR source content where section slugs namespace every
+    downstream key (e.g. ``première_section.para1``). Stripping accents here
+    would collide ``premiere`` and ``première`` sections.
+    """
+    assert _slug("Première Section") == "première_section"
+
+
+def test_slug_preserves_cjk():
+    """CJK ideographs (``一-鿿`` range kept by the explicit allow-list) survive.
+
+    Required for zh/ja source cells — a stripped CJK slug would collapse every
+    Chinese heading to the ``cell`` fallback and lose all translation keys.
+    """
+    s = _slug("测试中文标题")
+    assert "测" in s and s != "cell", f"CJK must be preserved, got {s!r}"
+
+
+def test_slug_empty_or_blank_falls_back_to_cell():
+    """Empty / whitespace-only slug falls back to ``cell`` (never empty key)."""
+    assert _slug("") == "cell"
+    assert _slug("   ") == "cell"
+
+
+def test_slug_truncates_to_40_chars():
+    """Slug is capped at 40 chars to bound CSV key length."""
+    assert _slug("a" * 50) == "a" * 40
+    assert len(_slug("x" * 200)) == 40
+
+
+# --- Unit tests : write_csv --------------------------------------------- #
+# ``write_csv`` emits the RFC-4180 CSV consumed by the Argumentum .NET
+# ``DatasetUpdater`` engine. ``sync()`` covers it indirectly through a full
+# extract+diff round-trip, but the format contract (QUOTE_ALL, LF terminator,
+# header schema, key ordering, parent-dir creation) is pinned here in isolation
+# so a regression in the writer is caught without re-running the whole pipeline.
+def test_write_csv_round_trips_through_read_csv(tmp_path):
+    """write_csv then read_csv recovers the same data + language list."""
+    csv_path = tmp_path / "sub" / "out.csv"
+    langs = ["fr", "en", "es"]
+    data = {
+        "k1": {"fr": "a", "en": "A", "es": "α"},
+        "k2": {"fr": "b", "en": "B", "es": "β"},
+    }
+    write_csv(csv_path, langs, data, keys_ordered=["k1", "k2"])
+    rlangs, rdata = read_csv(csv_path)
+    assert rlangs == langs
+    assert rdata == data
+
+
+def test_write_csv_header_is_key_plus_langs(tmp_path):
+    """First row is the literal header ``key,<lang1>,<lang2>,...``."""
+    csv_path = tmp_path / "out.csv"
+    write_csv(csv_path, ["fr", "en"], {"k": {"fr": "x", "en": "y"}}, ["k"])
+    first_line = csv_path.read_text(encoding="utf-8").splitlines()[0]
+    assert first_line == '"key","fr","en"'
+
+
+def test_write_csv_quotes_all_cells_and_uses_lf(tmp_path):
+    """QUOTE_ALL -> every cell quoted ; lineterminator = LF (not CRLF).
+
+    CRLF would break the Argumentum .NET reader line-splitting on the
+    committed (autocrlf) repo. LF is the canonical RFC-4180 terminator here.
+    """
+    csv_path = tmp_path / "out.csv"
+    write_csv(csv_path, ["fr"], {"k": {"fr": "v"}}, ["k"])
+    raw = csv_path.read_bytes()
+    assert b"\r\n" not in raw, "write_csv must not emit CRLF"
+    text = raw.decode("utf-8")
+    # Every non-empty line is fully quoted (QUOTE_ALL).
+    for line in text.splitlines():
+        assert line.startswith('"') and line.endswith('"'), (
+            f"QUOTE_ALL expects every cell quoted, got {line!r}"
+        )
+
+
+def test_write_csv_respects_keys_ordered(tmp_path):
+    """``keys_ordered`` controls row order, independent of dict insertion."""
+    csv_path = tmp_path / "out.csv"
+    data = {"zebra": {"fr": "z"}, "alpha": {"fr": "a"}, "mike": {"fr": "m"}}
+    write_csv(csv_path, ["fr"], data, keys_ordered=["alpha", "mike", "zebra"])
+    rows = csv_path.read_text(encoding="utf-8").splitlines()
+    keys_in_file_order = [r.split('","')[0].lstrip('"') for r in rows[1:]]
+    assert keys_in_file_order == ["alpha", "mike", "zebra"]
+
+
+def test_write_csv_missing_lang_yields_empty_cell(tmp_path):
+    """A key lacking one language writes an empty cell (not an error)."""
+    csv_path = tmp_path / "out.csv"
+    data = {"k1": {"fr": "a"}}  # no "en"
+    write_csv(csv_path, ["fr", "en"], data, ["k1"])
+    _, rdata = read_csv(csv_path)
+    assert rdata["k1"]["fr"] == "a"
+    assert rdata["k1"]["en"] == ""
+
+
+def test_write_csv_creates_parent_dir(tmp_path):
+    """``write_csv`` mkdirs the parent so a fresh series path works."""
+    csv_path = tmp_path / "deep" / "nested" / "series.csv"
+    assert not csv_path.parent.exists()
+    write_csv(csv_path, ["fr"], {"k": {"fr": "v"}}, ["k"])
+    assert csv_path.exists()
+
+
+# --- Unit tests : _extract_text ----------------------------------------- #
+# ``_extract_text`` flattens a mistune AST node into visible text while
+# re-emitting link/image/emphasis as markdown so the translator keeps the URL.
+# It is called ~12x per cell by ``parse_markdown`` ; a recursion or syntax bug
+# would silently strip URLs / alt-text from every translated cell.
+def test_extract_text_leaf_prefers_text_then_raw():
+    """Leaf token (no children): ``text`` wins, else ``raw``."""
+    assert _extract_text({"text": "hi", "raw": "hello"}) == "hi"
+    assert _extract_text({"raw": "hello"}) == "hello"
+    assert _extract_text({}) == ""
+
+
+def test_extract_text_text_child():
+    """Child of type ``text`` contributes its ``raw`` value."""
+    tok = {"children": [{"type": "text", "raw": "hello"}]}
+    assert _extract_text(tok) == "hello"
+
+
+def test_extract_text_re_emits_link_as_markdown():
+    """``link`` child is re-emitted ``[text](url)`` to preserve the URL."""
+    tok = {"children": [
+        {"type": "link", "attrs": {"url": "http://x"},
+         "children": [{"type": "text", "raw": "click"}]},
+    ]}
+    assert _extract_text(tok) == "[click](http://x)"
+
+
+def test_extract_text_re_emits_image_as_markdown():
+    """``image`` child is re-emitted ``![alt](url)``."""
+    tok = {"children": [
+        {"type": "image", "attrs": {"url": "img.png", "alt": "pic"}},
+    ]}
+    assert _extract_text(tok) == "![pic](img.png)"
+
+
+def test_extract_text_emphasis_and_strong():
+    """``emphasis`` -> ``*x*`` ; ``strong`` -> ``**x**`` (recursion preserved)."""
+    emph = {"children": [
+        {"type": "emphasis", "children": [{"type": "text", "raw": "x"}]},
+    ]}
+    assert _extract_text(emph) == "*x*"
+    strong = {"children": [
+        {"type": "strong", "children": [{"type": "text", "raw": "x"}]},
+    ]}
+    assert _extract_text(strong) == "**x**"
+
+
+def test_extract_text_mixed_string_and_dict_children():
+    """``children`` may contain raw strings (mistune inline literals)."""
+    tok = {"children": ["literal string", {"type": "text", "raw": " ok"}]}
+    assert _extract_text(tok) == "literal string ok"


### PR DESCRIPTION
## Summary

Extend `scripts/i18n/tests/test_sync_render.py` with **17 focused unit tests** for the three primitives of `scripts/i18n/sync.py` that were only covered **indirectly** via the `sync()` integration round-trip (the 12 pre-existing gates exercise `parse_markdown` / `sync` / `render` end-to-end but never isolate the leaf helpers contracts).

### Coverage gap closed (verified firsthand)

| Primitive | Role | Pre-PR direct coverage | Why it matters |
|-----------|------|------------------------|----------------|
| `_slug` | key derivation | 0 unit test | Collision-prevention primitive for the **whole** CSV pipeline — 2 distinct FR cells must map to 2 distinct keys or translations silently overwrite |
| `write_csv` | RFC-4180 emitter | indirect only (via `sync()`) | Consumed by the **Argumentum .NET DatasetUpdater** engine — a CRLF terminator or missing QUOTE_ALL would break the .NET reader on the autocrlf repo |
| `_extract_text` | mistune AST flattener | 0 unit test | Called ~12x per cell by `parse_markdown` ; a recursion / re-emit bug would silently strip URLs / alt-text from every translated cell |

### Tests added (17)

- **`_slug`** (5): lowercase + whitespace collapse + punct strip ; accented-Latin preserved (`première_section`) ; CJK preserved ; empty/blank fallback to `cell` ; 40-char cap.
- **`write_csv`** (6): round-trip through `read_csv` ; header `key,fr,en` schema ; QUOTE_ALL + **no CRLF** (LF only) ; `keys_ordered` row order ; missing-lang empty cell ; parent-dir `mkdir -p`.
- **`_extract_text`** (6): leaf precedence (`text` > `raw`) ; `text` child ; `link` re-emitted `[text](url)` ; `image` `![alt](url)` ; `emphasis`/`strong` ; mixed string+dict children.

## Validation

```
python -m pytest scripts/i18n/tests/test_sync_render.py -v
29 passed in 0.34s   (12 pre-existing gates + 17 new unit tests)
```

0 regression on the 12 pre-existing gates. G.9 non-vacuous: each function output **empirically verified before** writing assertions (no guessed behavior).

## Scope

- 1 file, `+188 / -1` (test-only addition, +1 import line).
- `scripts/i18n/sync.py` untouched. Catalogue byte-identical to `main`.

## Follow-up (out of scope, noted for a separate PR)

G.9 check surfaced that the **explicit CJK range** in `_slug` (`[^\w\u4e00-\u9fff…]`) is **redundant** with Python3 `\w` unicode default — a test breaking that range still passes because `\w` alone preserves CJK. The `_slug` docstring "preserves CJK via hex if needed" is slightly misleading (no hex encoding involved). A separate refactor PR could simplify the regex; this PR only adds coverage of the current (correct) behavior.

See #4957 (CSV-by-series pipeline), #6949 (T3 translation engine fork). Partial: adds unit-test coverage of the sync module primitives, does not close either epic.

```
Validation: 29/29 PASS (pytest), 0 regression
```