### PR TITLE
fix(gametheory): guard Tournament(repetitions<=0) ZeroDivisionError + silent zero

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/tests/test_trust_simulation.py
+++ b/MyIA.AI.Notebooks/GameTheory/tests/test_trust_simulation.py
@@ -485,6 +485,28 @@ class TestTournament:
         # Sanity : le score casse (16) ne doit plus revenir.
         assert self_play_via_tournament > 20
 
+    def test_zero_repetitions_raises(self):
+        """repetitions=0 -> before the guard, ``total1 / self.repetitions``
+        raised ZeroDivisionError at run(); now rejected at construction.
+
+        Same degenerate-input bug-class as #7513 compute_payoff_matrix
+        (rounds<=0) and #7524 FictitiousPlay.train (iterations<=0): the count
+        drives ``range()`` AND a division, so 0 crashes and <0 silently zeroes.
+        """
+        with pytest.raises(ValueError, match="repetitions must be positive"):
+            Tournament(strategies=DETERMINISTIC, repetitions=0)
+
+    def test_negative_repetitions_raises(self):
+        """repetitions<0 -> ``range(neg)`` empty + ``0.0 / negative`` = 0.0:
+        silently returned an all-zero scoreboard before the guard."""
+        with pytest.raises(ValueError, match="repetitions must be positive"):
+            Tournament(strategies=DETERMINISTIC, repetitions=-2)
+
+    def test_positive_repetitions_unaffected(self):
+        """The guard does not impact the normal path (deterministic run)."""
+        t = Tournament(strategies=DETERMINISTIC, rounds_per_match=20, repetitions=1).run()
+        assert len(t.rankings) == len(DETERMINISTIC)
+
 
 # ============================================================================
 # run_axelrod_tournament (convenience wrapper).

--- a/MyIA.AI.Notebooks/GameTheory/trust_simulation/tournament.py
+++ b/MyIA.AI.Notebooks/GameTheory/trust_simulation/tournament.py
@@ -69,6 +69,15 @@ class Tournament:
             noise: Probability of action being flipped (for noisy environments)
         """
         self.strategy_classes = strategies or ALL_STRATEGIES
+        # Guard: repetitions drives ``range(self.repetitions)`` and the
+        # per-match average ``total / self.repetitions`` in run(). A
+        # non-positive count either crashes (ZeroDivisionError) or silently
+        # zeroes every score (empty range -> 0.0 / negative). A tournament
+        # with no repetitions is ill-posed, not a zero-average tournament.
+        if repetitions <= 0:
+            raise ValueError(
+                f"repetitions must be positive, got {repetitions}"
+            )
         self.rounds_per_match = rounds_per_match
         self.repetitions = repetitions
         self.noise = noise


### PR DESCRIPTION
## Summary

`trust_simulation.Tournament.run()` divides the per-match totals by ``self.repetitions`` (``avg1 = total1 / self.repetitions``) and drives the repeat loop with ``range(self.repetitions)``. A non-positive count has two silent-failure modes:

- ``repetitions=0`` → **ZeroDivisionError: float division by zero** (crash)
- ``repetitions=-3`` → ``range(-3)`` empty, ``0.0 / -3 = -0.0`` → **all-zero scoreboard** (absurd "tournament where nobody scored anything")

Same degenerate-input bug-class as the sibling guards on main: #7513 `compute_payoff_matrix(rounds<=0)`, #7524 `FictitiousPlay.train(iterations<=0)`, #7489 `kuhn_poker_cfr.train(iterations<=0)`.

## Bug reproduced firsthand (G.9)

```
repetitions=0  -> ZeroDivisionError (crash)
repetitions=-3 -> no crash, scores=[0.0, 0.0] (silent nonsense)
```

## Fix

Entry guard in `__init__` (validates at construction, before `run()` can divide), sister-mirror pattern:
```python
if repetitions <= 0:
    raise ValueError(f"repetitions must be positive, got {repetitions}")
```
Pure additive; the happy path (repetitions>=1) is byte-identical.

## Validation (H.1 / G.9)

- **G.9 non-vacuous**: reverting only the production guard makes the two raises-tests FAIL (`DID NOT RAISE ValueError` — construction no longer rejects); restoring → pass.
- 60/60 trust_simulation tests pass (57 baseline + 3 new guard tests: zero raises, negative raises, positive unaffected).
- Full `GameTheory/tests/` = **524 passed, 0 failed**.

## Collision check (G.1, post c.693 lesson)

`git ls-tree -r origin/main | grep trust` → existing `test_trust_simulation.py` tests `Tournament.run()` with `repetitions=1` (L391) or default — **none pass repetitions<=0**, so the guard breaks no existing test. `gh pr list --state all --search "trust tournament repetitions"` = 0 collision.

## Scope

+9 production / +22 test, 2 files. No callers pass `repetitions<=0`. Catalog byte-identical. `See #7422` (partial — guard hygiene).

Co-Authored-By: Claude-Code <noreply@anthropic.com>