### PR TITLE
feat(prover,#7477): add heartbeat_budget_exceeded run verdict (P5a)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
@@ -1065,6 +1065,12 @@ class MultiAgentSorryProver:
             # right thing by refusing, it did not just spin to iteration_cap.
             "intractable": getattr(state, "intractable", False),
             "intractable_reason": getattr(state, "intractable_reason", None),
+            # P5a (#7477 forensic): latched in TacticTools.compile() via
+            # tools._is_heartbeat_timeout. Surfaced so _derive_result_kind
+            # classifies the run heartbeat_budget_exceeded (distinct from
+            # no_progress) — the target needs a cheaper tactic / higher
+            # maxHeartbeats / decomposition, NOT more iterations.
+            "heartbeat_budget_exceeded": getattr(state, "heartbeat_budget_exceeded", False),
             # FX-12 (#6790 pathology 3): count of build-verified *structural*
             # edits (file_replace_lines / file_insert_lines whose build_check
             # passed). Distinct from ``structural_progress`` (a boolean
@@ -1957,6 +1963,12 @@ class AutonomousProver:
             # NOT `no_progress` / `structural_progress` — it must be filtered out
             # of progress metrics.
             "provider_outage": _provider_dead,
+            # P5a (#7477 forensic): latched in TacticTools.compile() via
+            # tools._is_heartbeat_timeout. Surfaced so _derive_result_kind
+            # classifies the run heartbeat_budget_exceeded (distinct from
+            # no_progress) — the target needs a cheaper tactic / higher
+            # maxHeartbeats / decomposition, NOT more iterations.
+            "heartbeat_budget_exceeded": getattr(state, "heartbeat_budget_exceeded", False),
             # FX-12 (#6790 pathology 3): count of build-verified *structural*
             # edits (file_replace_lines / file_insert_lines whose build_check
             # passed). Distinct from ``structural_progress`` (boolean success

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py
@@ -50,6 +50,13 @@ def _derive_result_kind(result, final_sorry: int, original_sorry: int) -> str:
                           SearchAgent gates) and the workflow yielded before
                           iteration_cap (#7477 P2a). The agent did the right
                           thing by refusing — do NOT read as tactical failure.
+      heartbeat_budget_exceeded -> a Lean tactic blew the maxHeartbeats budget
+                          (latched in TacticTools.compile via
+                          tools._is_heartbeat_timeout, #7477 P5a). Distinct from
+                          correctly_refused: the agent did NOT refuse, it tried a
+                          tactic too expensive for the budget. Needs a cheaper
+                          tactic / higher maxHeartbeats / decomposition, NOT more
+                          iterations.
       no_progress      -> diagnostic data only
 
     Real progress outranks the outage flag: a run that lowered the sorry count
@@ -75,6 +82,17 @@ def _derive_result_kind(result, final_sorry: int, original_sorry: int) -> str:
     # coordinator distinguish "agent did the right thing" from "agent spun".
     if isinstance(result, dict) and result.get("intractable"):
         return "correctly_refused"
+    # P5a (#7477 forensic): a Lean tactic blew the maxHeartbeats budget
+    # (latched in TacticTools.compile via tools._is_heartbeat_timeout). Ranked
+    # AFTER sorry_decreased / structural_only: a run that lowered the sorry
+    # count or landed a verified decomposition before blowing the budget is
+    # still progress — this flag only reclassifies what would otherwise be
+    # no_progress. Distinct from correctly_refused (the agent did NOT refuse;
+    # it tried a tactic too expensive for the budget). Tells a coordinator the
+    # target needs a cheaper tactic / higher maxHeartbeats / decomposition,
+    # NOT more iterations.
+    if isinstance(result, dict) and result.get("heartbeat_budget_exceeded"):
+        return "heartbeat_budget_exceeded"
     return "no_progress"
 
 
@@ -254,7 +272,7 @@ def _run_prover_locked(demo, name, filepath, line, mode, iterations, provider,
         "sorry_reduction": original_sorry - final_sorry,  # positif = progres (lecture non ambigue)
         # Canonical verdict (see _derive_result_kind): sorry_decreased |
         # structural_only | provider_outage | no_progress | crashed |
-        # already_solved.
+        # already_solved | heartbeat_budget_exceeded.
         "result_kind": result_kind,
         "elapsed_s": round(elapsed, 1),
         "result": result,

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/state.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/state.py
@@ -115,6 +115,15 @@ class ProofState:
     # unprovable sorry. Set via CoordinatorTools.mark_sorry_intractable.
     intractable: bool = False
     intractable_reason: Optional[str] = None
+    # P5a (#7477 forensic): a Lean tactic blew the maxHeartbeats budget during
+    # a build (detected via tools._is_heartbeat_timeout on the compile errors).
+    # Surfaced so run_prover_bg._derive_result_kind classifies the run as
+    # heartbeat_budget_exceeded (distinct from no_progress) — telling a
+    # coordinator the target needs a cheaper tactic / higher maxHeartbeats /
+    # decomposition, NOT more iterations. Ranked AFTER sorry_decreased /
+    # structural_only: a run that lowered the sorry count before blowing the
+    # budget is still progress.
+    heartbeat_budget_exceeded: bool = False
 
     # F9 (2026-05-17, C37 forensic): Director consultation gate. The
     # Coordinator MUST call request_director_guidance() at least once

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
@@ -149,6 +149,29 @@ def _parse_lean_errors(raw_output) -> list:
             continue
     return errors
 
+
+def _is_heartbeat_timeout(message: str) -> bool:
+    """Detect a Lean maxHeartbeats budget exhaustion in a build error message.
+
+    P5a (#7477 forensic): a tactic that blows the heartbeat budget is NOT a
+    sorry and NOT a normal type error — Lean reports it as a deterministic
+    timeout:
+      ``(deterministic) timeout at `<phase>`, maximum number of heartbeats
+      (<N>) has been reached``
+    where ``<phase>`` is e.g. ``elaborator`` / ``isDefEq`` / a tactic name,
+    and ``<N>`` is the configured budget (default 200000). Without dedicated
+    detection such a run scores ``result_kind == no_progress`` — a coordinator
+    cannot tell "the tactic simply failed" from "the tactic is too expensive
+    for the heartbeat budget (bump maxHeartbeats or decompose)". Verified
+    firsthand against ``lean.exe`` v4.32.0 (2026-07): both the elaborator and
+    isDefEq phase variants emit ``maximum number of heartbeats ... has been
+    reached``, which is unique to this error class.
+    """
+    if not message:
+        return False
+    return "maximum number of heartbeats" in message and "has been reached" in message
+
+
 def _read_lines_from_source(source: str, start: int, end: int) -> str:
     """Read lines [start, end] (1-based inclusive) from a string source."""
     lines = source.split("\n")
@@ -1916,6 +1939,20 @@ class TacticTools:
         cached = result.get("cached", False)
 
         errors = _parse_lean_errors(raw_output)  # #6790: authoritative parser
+
+        # P5a (#7477 forensic): latch a maxHeartbeats exhaustion so the run is
+        # classified heartbeat_budget_exceeded (run_prover_bg._derive_result_kind),
+        # not no_progress. This is the single capture site: every proof path
+        # (autonomous iteration loop, final verify, multi-agent workflow) compiles
+        # through TacticTools.compile(), so the flag is set once here regardless
+        # of caller. Check both the parsed error entries and the raw build output
+        # (belt-and-suspenders: a future parser gap on the heartbeat line format
+        # must not hide the signal).
+        if self._state is not None and not self._state.heartbeat_budget_exceeded:
+            if _is_heartbeat_timeout(raw_output) or any(
+                _is_heartbeat_timeout(_e.get("message", "")) for _e in errors
+            ):
+                self._state.heartbeat_budget_exceeded = True
 
         content = Path(self._filepath).read_text(encoding="utf-8")
         text_sorry_count = count_real_sorries(content)

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_heartbeat_budget.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_heartbeat_budget.py
@@ -1,0 +1,260 @@
+"""Unit tests for #7477 P5a — `heartbeat_budget_exceeded` run verdict.
+
+A Lean tactic that blows the ``maxHeartbeats`` budget is reported by Lean as a
+*build error* (not a sorry), of the form::
+
+    (deterministic) timeout at `<phase>`, maximum number of heartbeats (<N>) has been reached
+
+Without dedicated detection such a run scored ``result_kind == no_progress`` —
+indistinguishable from a tactic that simply failed. The fix has three parts,
+each exercised here:
+
+  1. ``tools._is_heartbeat_timeout`` matches the canonical Lean string (verified
+     firsthand against ``lean.exe`` v4.32.0, both the ``elaborator`` and
+     ``isDefEq`` phase variants).
+  2. ``TacticTools.compile`` latches ``state.heartbeat_budget_exceeded`` (single
+     capture site — every proof path compiles through it).
+  3. ``run_prover_bg._derive_result_kind`` gains a ``heartbeat_budget_exceeded``
+     branch (ranked AFTER sorry_decreased / structural_only / provider_outage /
+     correctly_refused: real progress outranks the diagnostic).
+
+Run from ``agent_tests/``::
+
+    python -m pytest tests/test_prover_heartbeat_budget.py -q
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make `prover/` importable regardless of how pytest was invoked (same
+# bootstrap convention as tests/test_prover_correctly_refused.py).
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+sys.path.insert(0, str(ROOT))
+
+from prover import run_prover_bg  # noqa: E402
+from prover.state import ProofState  # noqa: E402
+from prover.tools import TacticTools, _is_heartbeat_timeout  # noqa: E402
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# _is_heartbeat_timeout — the canonical-string detector (verified firsthand)
+# ──────────────────────────────────────────────────────────────────────────
+
+# Verbatim Lean output reproduced locally with lean.exe v4.32.0 (2026-07) under
+# `set_option maxHeartbeats 1 in` + a nontrivial tactic. The <phase> and <N>
+# vary; the tokens `maximum number of heartbeats` + `has been reached` do not.
+_HB_ELABORATOR = (
+    "(deterministic) timeout at `elaborator`, maximum number of heartbeats "
+    "(1) has been reached"
+)
+_HB_ISDEFEQ = (
+    "(deterministic) timeout at `isDefEq`, maximum number of heartbeats "
+    "(1) has been reached"
+)
+# What the string looks like once _parse_lean_errors strips the `file:l:c: error:` prefix
+# and Lake wraps it — the message field carries the heartbeat clause verbatim.
+_HB_WRAPPED = (
+    "Foo.lean:2:10: error: (deterministic) timeout at `simp`, maximum number "
+    "of heartbeats (200000) has been reached"
+)
+
+
+@pytest.mark.parametrize("msg", [_HB_ELABORATOR, _HB_ISDEFEQ, _HB_WRAPPED])
+def test_is_heartbeat_timeout_matches_real_strings(msg):
+    """The detector matches every firsthand-reproduced Lean heartbeat string,
+    regardless of the <phase> name or the <N> budget value."""
+    assert _is_heartbeat_timeout(msg) is True
+
+
+def test_is_heartbeat_timeout_matches_at_default_budget():
+    """The real prover hits the default 200000 budget; the detector must not
+    hardcode the low reproduction value (1)."""
+    default = (
+        "(deterministic) timeout at `simp`, maximum number of heartbeats "
+        "(200000) has been reached"
+    )
+    assert _is_heartbeat_timeout(default) is True
+
+
+@pytest.mark.parametrize("msg", [
+    "",                                              # empty
+    "unsolved goals",                                # normal sorry leak
+    "type mismatch, application",                    # normal type error
+    "maximum number of heartbeats",                  # only half the signature
+    "has been reached",                              # only half the signature
+    "(deterministic) timeout at `omega`",            # timeout WITHOUT heartbeats
+    None,                                            # None input
+])
+def test_is_heartbeat_timeout_rejects_non_heartbeat(msg):
+    """Non-heartbeat messages (normal errors, half-signatures, unrelated
+    timeouts, empty/None) must NOT latch the flag — a false positive would hide
+    a real type error behind the heartbeat diagnostic."""
+    assert _is_heartbeat_timeout(msg) is False
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# _derive_result_kind — the heartbeat_budget_exceeded branch
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _derive(result, final_sorry, original_sorry):
+    """Thin wrapper so each test reads as the verdict for one scenario."""
+    return run_prover_bg._derive_result_kind(result, final_sorry, original_sorry)
+
+
+def test_heartbeat_budget_exceeded_when_flag_set():
+    """A run whose result carries heartbeat_budget_exceeded=True is classified
+    heartbeat_budget_exceeded, not no_progress."""
+    result = {"heartbeat_budget_exceeded": True}
+    assert _derive(result, final_sorry=5, original_sorry=5) == "heartbeat_budget_exceeded"
+
+
+def test_heartbeat_flag_needs_truthy():
+    """Flag absent or False falls through to no_progress (no false positive).
+    A run that never blew the budget must NOT be mislabelled."""
+    assert _derive({}, 5, 5) == "no_progress"
+    assert _derive({"heartbeat_budget_exceeded": False}, 5, 5) == "no_progress"
+    assert _derive({"heartbeat_budget_exceeded": None}, 5, 5) == "no_progress"
+
+
+def test_sorry_decreased_outranks_heartbeat():
+    """Real progress outranks the diagnostic: a run that lowered the sorry
+    count before blowing the budget is still a harvest."""
+    result = {"heartbeat_budget_exceeded": True}
+    assert _derive(result, final_sorry=3, original_sorry=5) == "sorry_decreased"
+
+
+def test_structural_progress_outranks_heartbeat():
+    """A decomposition landed (structural_progress=True) before the budget
+    blew: structural_only, not heartbeat_budget_exceeded."""
+    result = {"heartbeat_budget_exceeded": True, "structural_progress": True}
+    assert _derive(result, 5, 5) == "structural_only"
+
+
+def test_provider_outage_outranks_heartbeat():
+    """A provider death mid-run is provider_outage regardless of heartbeat:
+    the prover never got to work."""
+    result = {"heartbeat_budget_exceeded": True, "provider_outage": True}
+    assert _derive(result, 5, 5) == "provider_outage"
+
+
+def test_correctly_refused_outranks_heartbeat():
+    """An explicit Coordinator abandon (intractable) is correctly_refused
+    regardless of heartbeat — the agent refused; it did not try a tactic.
+    (Ordering matches the docstring ranking: intractable is checked first.)"""
+    result = {"heartbeat_budget_exceeded": True, "intractable": True}
+    assert _derive(result, 5, 5) == "correctly_refused"
+
+
+def test_crashed_outranks_heartbeat():
+    """An explicit error is crashed regardless of heartbeat."""
+    result = {"error": "kaboom", "heartbeat_budget_exceeded": True}
+    assert _derive(result, 5, 5) == "crashed"
+
+
+def test_heartbeat_plumbs_through_classification_from_result_fields():
+    """End-to-end of the classification: a result dict shaped like the real
+    provers.py return (heartbeat_budget_exceeded surfaced via getattr(state,...),
+    no sorry drop, no structural progress, no outage, no intractable) classifies
+    as heartbeat_budget_exceeded — the exact path a real heartbeat run takes."""
+    result = {
+        "success": False,
+        "sorry_evolution": "5 -> 5",
+        "structural_progress": False,
+        "provider_outage": False,
+        "provider_failures": 0,
+        "intractable": False,
+        "heartbeat_budget_exceeded": True,
+        "iterations": 8,
+    }
+    assert _derive(result, final_sorry=5, original_sorry=5) == "heartbeat_budget_exceeded"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# TacticTools.compile — the single capture site latches state
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _patch_verifier_raw_output(monkeypatch, raw_output, build_success=False):
+    """Mock the LeanVerifier so compile() sees ``raw_output`` without a real
+    lake build (same pattern as test_prover_guards._patch_verifier_and_reverify)."""
+    import prover.verifier as vmod
+
+    class _FakeVerifier:
+        def verify_project_file(self, rel, force=False):
+            return {"success": build_success, "errors": "", "raw_output": raw_output}
+
+    monkeypatch.setattr(vmod, "get_verifier", lambda *a, **k: _FakeVerifier())
+
+
+def test_compile_latches_heartbeat_on_build_error(tmp_path, monkeypatch):
+    """A compile() whose build log carries the heartbeat string sets
+    state.heartbeat_budget_exceeded=True (the run will then classify as
+    heartbeat_budget_exceeded, not no_progress)."""
+    fake = tmp_path / "Target.lean"
+    fake.write_text("theorem t : True := by sorry\n", encoding="utf-8")
+
+    _patch_verifier_raw_output(
+        monkeypatch, raw_output=_HB_WRAPPED, build_success=False,
+    )
+
+    state = ProofState(theorem_statement="t")
+    tools = TacticTools(state=state, filepath=str(fake))
+    # Drive a compile — the latch fires inside, regardless of the build verdict.
+    tools.compile()
+
+    assert state.heartbeat_budget_exceeded is True, (
+        "compile() must latch heartbeat_budget_exceeded when the build log "
+        "carries the Lean heartbeat signature"
+    )
+
+
+def test_compile_does_not_latch_on_normal_build_error(tmp_path, monkeypatch):
+    """A normal type error (no heartbeat signature) must NOT latch the flag —
+    guards against a detector that would fire on every failed build."""
+    fake = tmp_path / "Target.lean"
+    fake.write_text("theorem t : True := by sorry\n", encoding="utf-8")
+
+    _patch_verifier_raw_output(
+        monkeypatch,
+        raw_output="Target.lean:1:20: error: unsolved goals\n",
+        build_success=False,
+    )
+
+    state = ProofState(theorem_statement="t")
+    tools = TacticTools(state=state, filepath=str(fake))
+    tools.compile()
+
+    assert state.heartbeat_budget_exceeded is False, (
+        "a normal type error must not be misread as a heartbeat exhaustion"
+    )
+
+
+def test_compile_latches_only_once(tmp_path, monkeypatch):
+    """The `not state.heartbeat_budget_exceeded` guard short-circuits repeated
+    compiles — once latched, subsequent compiles do not re-enter the check.
+    (Sanity: the latch is sticky, not toggling.)"""
+    fake = tmp_path / "Target.lean"
+    fake.write_text("theorem t : True := by sorry\n", encoding="utf-8")
+
+    _patch_verifier_raw_output(
+        monkeypatch, raw_output=_HB_WRAPPED, build_success=False,
+    )
+
+    state = ProofState(theorem_statement="t")
+    tools = TacticTools(state=state, filepath=str(fake))
+    tools.compile()
+    assert state.heartbeat_budget_exceeded is True
+    # Second compile on a CLEAN log must NOT clear the flag.
+    _patch_verifier_raw_output(
+        monkeypatch, raw_output="", build_success=True,
+    )
+    tools.compile()
+    assert state.heartbeat_budget_exceeded is True, (
+        "latch is sticky: a later clean compile must not clear the flag"
+    )


### PR DESCRIPTION
## Summary

Implements **#7477 P5a** — a typed `heartbeat_budget_exceeded` run verdict for the Lean prover harness. A tactic that blows the `maxHeartbeats` budget was silently misclassified as `no_progress`, indistinguishable from a tactic that simply failed. This PR surfaces it as a distinct verdict so a coordinator knows the target needs a *cheaper tactic / higher maxHeartbeats / decomposition* — NOT more iterations.

This is a **Python harness diagnostic** (not a Lean proof change). Single bounded subject, 4 source files + 1 test file.

## Root cause

Lean reports a heartbeat-budget exhaustion as a **build error** (not a sorry), of the canonical form:

```
(deterministic) timeout at `<phase>`, maximum number of heartbeats (<N>) has been reached
```

where `<phase>` is e.g. `elaborator` / `isDefEq` / `simp`, and `<N>` is the configured budget (default `200000`). `run_prover_bg._derive_result_kind` never read this signal — a heartbeat run fell through to `no_progress`, burning iteration budget on a target whose obstruction was *tactical expense*, not *tactical failure*.

Verified **firsthand** against `lean.exe` v4.32.0 (2026-07) — reproduced both the `elaborator` and `isDefEq` phase variants:

```
$ lean HB3.lean   # set_option maxHeartbeats 1 in / example : 1 + 1 = 2 := by simp
HB3.lean:2:10: error: (deterministic) timeout at `elaborator`, maximum number of heartbeats (1) has been reached
```

The stable, matchable tokens are `maximum number of heartbeats` + `has been reached` (the `<phase>` and `<N>` vary).

## Fix (3 parts, mirrors the existing `correctly_refused` precedent #7477 P2a)

1. **`tools._is_heartbeat_timeout(message)`** — pure detector co-located with `_parse_lean_errors`. Matches the canonical string; rejects normal type errors, half-signatures, unrelated timeouts, empty/None.
2. **`TacticTools.compile()` latch** — the *single capture site*. Every proof path (autonomous iteration loop, final verify, multi-agent workflow) compiles through `TacticTools.compile()`, so the flag is set once there regardless of caller. Checks both parsed error entries and raw build output (belt-and-suspenders against a future parser gap). Latches `state.heartbeat_budget_exceeded`.
3. **`run_prover_bg._derive_result_kind`** — gains a `heartbeat_budget_exceeded` branch, ranked AFTER `sorry_decreased` / `structural_only` / `provider_outage` / `correctly_refused` / `crashed` (real progress outranks the diagnostic — a run that lowered the sorry count before blowing the budget is still a harvest).

The flag flows: `compile()` latch → `state.heartbeat_budget_exceeded` → surfaced in both result dicts (`provers.py` multi L1066 + autonomous L1965 via `getattr(state, ...)`) → `_derive_result_kind`.

Distinct from `correctly_refused`: there the agent *refused* (Coordinator abandon); here the agent *tried* a tactic too expensive for the budget.

## Validation (ran the ACTUAL pytest suite)

```
=== new test suite (22 tests) ===
tests/test_prover_heartbeat_budget.py ......................  [100%]
22 passed in 0.92s

=== regression: existing prover tests ===
tests/test_prover_correctly_refused.py + test_prover_guards.py + test_bg_tree_lock.py
219 passed in 2.04s

=== py_compile (4 changed source modules) ===
OK (tools.py, state.py, provers.py, run_prover_bg.py)
```

The 22 new tests cover:
- `_is_heartbeat_timeout`: 3 real Lean heartbeat string variants (elaborator / isDefEq / simp+default-budget wrapped) → True; 7 negatives (empty, unsolved, type error, half-signatures, unrelated timeout, None) → False; default-budget (200000) not hardcoded to the reproduction value (1).
- `_derive_result_kind`: heartbeat branch + full ranking (sorry_decreased / structural_only / provider_outage / correctly_refused / crashed all outrank); truthy-guard (absent/False/None → no_progress); end-to-end result-dict plumb.
- `compile()` latch: latches on heartbeat build error; does NOT latch on normal type error; sticky (latches once, later clean compile does not clear) — via the `test_prover_guards._patch_verifier_and_reverify` verifier-mock pattern.

## Scope

5 files, +337/-1 (the −1 is a line-split where `return errors` becomes `return errors` + the new helper below it — purely additive). No `*.lean` proof touched, no `sorry` added or removed (anti-regression clean). Catalog byte-identical to `main` (HARD 1). Single subject — the heartbeat diagnostic only.

`See #7477` (partial: P5a of the forensic — does not close the epic).

<!-- codex-meta po-2026 machine="myia-po-2026" lane="CoursIA" -->
