### PR TITLE
fix(search): guard WFC entry points against degenerate rows<=0/cols<=0

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/wfc_cpsat.py
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/wfc_cpsat.py
@@ -37,6 +37,10 @@ def load_tileset(path: str = "tileset.json") -> dict:
 # ---------------------------------------------------------------------------
 
 def generate_random(rows: int, cols: int, tileset: dict, seed: int = 0) -> np.ndarray:
+    if rows <= 0 or cols <= 0:
+        raise ValueError(
+            f"rows and cols must be positive (at least one cell), got rows={rows}, cols={cols}"
+        )
     rng = random.Random(seed)
     n_tiles = len(tileset["tiles"])
     weights = tileset.get("weights", [1] * n_tiles)
@@ -51,6 +55,10 @@ def generate_random(rows: int, cols: int, tileset: dict, seed: int = 0) -> np.nd
 
 class PureWFC:
     def __init__(self, rows: int, cols: int, tileset: dict, seed: int = 0):
+        if rows <= 0 or cols <= 0:
+            raise ValueError(
+                f"rows and cols must be positive (at least one cell), got rows={rows}, cols={cols}"
+            )
         self.rows = rows
         self.cols = cols
         n = len(tileset["tiles"])
@@ -184,6 +192,10 @@ def solve_cpsat(
     Objective:
         Maximize tile variety score to avoid degenerate uniform solutions.
     """
+    if rows <= 0 or cols <= 0:
+        raise ValueError(
+            f"rows and cols must be positive (at least one cell), got rows={rows}, cols={cols}"
+        )
     tiles = tileset["tiles"]
     n_tiles = len(tiles)
     rules_raw = tileset["adjacency"]["rules"]

--- a/MyIA.AI.Notebooks/Search/tests/test_wfc_cpsat.py
+++ b/MyIA.AI.Notebooks/Search/tests/test_wfc_cpsat.py
@@ -301,3 +301,51 @@ class TestRunAll:
         # Random et WFC doivent produire une grille (5x5 realisable).
         assert results["random"]["grid"] is not None
         assert results["random"]["grid"].shape == (5, 5)
+
+
+# ----------------------------------------------------------------------------
+# Degenerate-input guards (bug-class #7463/#7522 : rows<=0 / cols<=0).
+# ----------------------------------------------------------------------------
+
+class TestDegenerateInputGuard:
+    """Les trois entrees publiques (generate_random, PureWFC, solve_cpsat) doivent
+    rejeter explicitement rows<=0 ou cols<=0. Sans guard, generate_random(0, 5)
+    retourne une grille vide silencieuse (shape (0,5)) et PureWFC(0,0).solve()
+    retourne [] -- un niveau WFC a zero cellule n'a aucun sens pedagogique et
+    masque un bug caller-side. Bug-class identique a stackelberg/cournot b<=0 (#7522)
+    et compute_payoff rounds<=0 (#7513)."""
+
+    def test_generate_random_zero_rows_raises(self, tileset):
+        with pytest.raises(ValueError, match="rows and cols must be positive"):
+            generate_random(0, 5, tileset)
+
+    def test_generate_random_zero_cols_raises(self, tileset):
+        with pytest.raises(ValueError, match="rows and cols must be positive"):
+            generate_random(5, 0, tileset)
+
+    def test_generate_random_negative_raises(self, tileset):
+        with pytest.raises(ValueError, match="rows and cols must be positive"):
+            generate_random(-2, 3, tileset)
+
+    def test_purewfc_zero_dims_raises(self, tileset):
+        with pytest.raises(ValueError, match="rows and cols must be positive"):
+            PureWFC(0, 0, tileset)
+
+    def test_purewfc_negative_raises(self, tileset):
+        with pytest.raises(ValueError, match="rows and cols must be positive"):
+            PureWFC(-1, 4, tileset)
+
+    def test_solve_cpsat_zero_dims_raises(self, tileset):
+        with pytest.raises(ValueError, match="rows and cols must be positive"):
+            solve_cpsat(rows=0, cols=4, tileset=tileset)
+
+    def test_solve_cpsat_negative_raises(self, tileset):
+        with pytest.raises(ValueError, match="rows and cols must be positive"):
+            solve_cpsat(rows=3, cols=-1, tileset=tileset)
+
+    def test_positive_dims_unaffected(self, tileset):
+        """Le guard n'impacte pas la voie nominale (invariant shape preserve)."""
+        grid = generate_random(4, 4, tileset, seed=0)
+        assert grid.shape == (4, 4)
+        wfc_grid = PureWFC(4, 4, tileset, seed=0).solve()
+        assert wfc_grid.shape == (4, 4)


### PR DESCRIPTION
## Summary

The three public entry points in `wfc_cpsat.py` (`generate_random`, `PureWFC.__init__`, `solve_cpsat`) accepted `rows<=0` / `cols<=0` without validation, producing silently wrong or crashing results:

| Call (unpatched) | Behavior |
|---|---|
| `generate_random(0, 5)`  | empty grid shape `(0,5)`, no error |
| `generate_random(-2, 3)` | empty array `[]`, no error |
| `PureWFC(0, 0).solve()`  | `[]`, no error |
| `solve_cpsat(rows=0, 4)` | opaque `IndexError: list index out of range` on `cells[0][0]` |

A WFC level with zero cells is meaningless and masks a caller-side bug. This PR adds an explicit `ValueError` guard at each entry point.

Same degenerate-input bug-class as #7522 (stackelberg/cournot `b<=0`), #7513 (compute_payoff `rounds<=0`), #7481 (shapley `n_samples<=0`).

## Changes
- `wfc_cpsat.py` (+12): `if rows <= 0 or cols <= 0: raise ValueError(...)` in `generate_random`, `PureWFC.__init__`, `solve_cpsat` (after docstring).
- `tests/test_wfc_cpsat.py` (+48): new `TestDegenerateInputGuard` class (8 tests) covering zero/negative `rows`/`cols` for all three entry points + a positive-dims-unaffected invariant test.

## Validation (G.9 non-vacuous)
- **Reproduce unpatched**: confirmed the silent-empty / IndexError behaviors above firsthand before patching.
- **Non-vacuous**: reverting the prod guard (stash) makes the 7 raise-tests FAIL (`DID NOT RAISE` for generate_random/PureWFC, `IndexError` for solve_cpsat) — the tests genuinely exercise the fix, not just the match string.
- **Non-regression**: 34/34 tests pass (26 existing nominal + 8 new guard tests), `0.64s`.
- **Normal path preserved**: `test_positive_dims_unaffected` confirms `generate_random(4,4)` and `PureWFC(4,4).solve()` still return correct shapes.

Run: `cd MyIA.AI.Notebooks/Search && python -m pytest tests/test_wfc_cpsat.py -v`

See #7522 (sibling bug-class).