### PR TITLE
fix(docs,#7422): correct stable-marriage breadcrumb path in docs/README.md L65

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -62,7 +62,7 @@ Iteration history prover, intractable diagnosis, LLM endpoints.
 | [lean/llm-endpoints.md](lean/llm-endpoints.md) | Providers LLM du prover multi-agent (configuration, sans clés) |
 | [lean/prover_iteration_history.md](lean/prover_iteration_history.md) | Historique itération prover |
 | [lean/sota-2026-analysis.md](lean/sota-2026-analysis.md) | État de l'art preuve automatique Lean 4 (mai 2026) |
-| [lean/stable_marriage_intractable_diagnosis.md](../archive/lean-intractable-diagnosis/stable-marriage.md) | Diagnostic des preuves stable-marriage intractables (archivé c.696) |
+| [archive/lean-intractable-diagnosis/stable-marriage.md](archive/lean-intractable-diagnosis/stable-marriage.md) | Diagnostic des preuves stable-marriage intractables (archivé c.696) |
 
 ## Curriculum (docs/curriculum/)
 


### PR DESCRIPTION
## Scope

**1 file / +1/-1** — single-line breadcrumb fix on  L65.

Unblocks PR #7538 (c.696 archive) which currently fails the `check-links` CI gate with **1 new broken link: `docs/README.md:65 -> ../archive/lean-intractable-diagnosis/stable-marriage.md`**.

## Root cause

The c.696 archive commit (`664648390`) renamed the file from `docs/lean/stable_marriage_intractable_diagnosis.md` to `docs/archive/lean-intractable-diagnosis/stable-marriage.md` and updated the `docs/README.md` L65 entry — but the breadcrumb has **two errors**:

1. **Display text still shows the OLD filename** `lean/stable_marriage_intractable_diagnosis.md` (should be `archive/lean-intractable-diagnosis/stable-marriage.md`)
2. **Link target uses `../archive/...`** but `docs/README.md` lives at `docs/`, so `..` goes up to the repo root and resolves to `<root>/archive/...` (does not exist). Correct path from `docs/` is `archive/...` (one level too many).

## Fix

```diff
-| [lean/stable_marriage_intractable_diagnosis.md](../archive/lean-intractable-diagnosis/stable-marriage.md) | Diagnostic des preuves stable-marriage intractables (archivé c.696) |
+| [archive/lean-intractable-diagnosis/stable-marriage.md](archive/lean-intractable-diagnosis/stable-marriage.md) | Diagnostic des preuves stable-marriage intractables (archivé c.696) |
```

Dropped the spurious `../` and updated the display text to match the new archive path.

## Validation

```bash
$ python scripts/check_docs_links.py --check
OK: No new broken links. (0 pre-existing, 4012 total)
```

Programmatic first-hand verification (G.1):
- `Path('docs/README.md:65').resolve()` → `C:\dev\CoursIA-c698-checker-archive-fix\docs\archive\lean-intractable-diagnosis\stable-marriage.md` (exists) ✅
- Before fix: `Path('docs/README.md:65').resolve()` → `C:\dev\CoursIA-c698-checker-archive-fix\archive\lean-intractable-diagnosis\stable-marriage.md` (does NOT exist) ❌

## Anti-hallu

Confirmed via programmatic scan that **`docs/README.md:65` is the ONLY `../archive/` path that resolves incorrectly**. All other `../archive/` paths in `docs/` resolve correctly because their source files are at deeper paths (`docs/lean/*`, `docs/qc/*`, `docs/reference/*`) where `..` correctly reaches `docs/`.

| Source file | `../archive/` link count | Resolves to |
|---|---|---|
| `docs/README.md` (this PR) | 1 broken → fixed | `docs/archive/...` |
| `docs/lean/*.md` | all valid | `docs/archive/...` |
| `docs/qc/*.md` | all valid | `docs/archive/...` |
| `docs/reference/*.md` | all valid | `docs/archive/...` |

## Cross-lane coordination

- **c.696 PR #7538** is owned by `myia-po-2023 c.581b`. This fix is **NOT** amending their branch (L726-L1 ★: cherry-pick + relocate vs amend).
- **ai-01 coordinates merge order**: this PR can merge first (unblocks c.696 CI), or be cherry-picked into c.696 — coordinator's call.
- **L420-L1 ★★** anti-contamination cross-lane respected: cross-lane cleanup assistance, not a take-over.

## Pattern canon (L689 ★ NEW candidate)

**breadcrumb-rename drift detection**: when an archive PR renames a file + updates a breadcrumb entry, the breadcrumb path must be re-validated by direct `Path.resolve().exists()` check, not just visual inspection. Visual check misses the `../` level error because the visible diff text appears identical to a correct breadcrumb.

**Mitigation rule** (proposed for `.claude/rules/anti-regression.md`): every archive PR (L686 ★ pattern) that touches a breadcrumb **must run** `scripts/check_docs_links.py --check` and report the result in the PR body BEFORE requesting review. This is not yet enforced by CI on archive PRs — could be added as a fast pre-merge check.

## See

- `See #7422` — partial: docs-hygiene epic
- `See #7538` — unblocks upstream c.696 archive PR

## Diff stat

```
docs/README.md | 2 +-
1 file changed, 1 insertion(+), 1 deletion(-)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)