### PR TITLE
fix(search,#7463): guard WFC run_all + adjacency_violations degenerate inputs (complements #7551)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/wfc_cpsat.py
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/wfc_cpsat.py
@@ -375,13 +375,43 @@ def bfs_reachable_floor(grid: np.ndarray, floor_id: int) -> float:
 
 
 def adjacency_violations(grid: np.ndarray, rules: dict) -> int:
+    """Compte les violations de la matrice d'adjacence pour une grille.
+
+    Args:
+        grid: ndarray 2D des identifiants de tuiles (forme (rows, cols)).
+        rules: dict imbrique {tile_a: {tile_b: bool}} -- l'adjacence
+               autorisee (a droite de a / en dessous de a). Doit couvrir
+               toutes les tuiles presentes dans ``grid``.
+
+    Returns:
+        Nombre de paires de cellules voisines (droite / dessous) dont
+        l'adjacence n'est pas autorisee.
+
+    Raises:
+        ValueError: si ``rules`` est vide, ou si une tuile de ``grid``
+                    est absente de ``rules`` (sinon ``KeyError`` opaque
+                    au moment de l'indexation ``rules[grid[r, c]]``).
+    """
+    if not rules:
+        raise ValueError("rules must be a non-empty adjacency dict")
     rows, cols = grid.shape
+    # Pre-check : toutes les tuiles de grid ont une entree dans rules.
+    # Sinon KeyError opaque a l'indexation rules[grid[r, c]].
+    if rows > 0 and cols > 0:
+        present_tiles = {int(grid[r, c]) for r in range(rows) for c in range(cols)}
+        missing = present_tiles - set(rules.keys())
+        if missing:
+            raise ValueError(
+                f"rules dict is missing entries for tile(s) {sorted(missing)} "
+                f"present in the grid"
+            )
     v = 0
     for r in range(rows):
         for c in range(cols):
+            tile = int(grid[r, c])
             for nr, nc in [(r, c + 1), (r + 1, c)]:
                 if nr < rows and nc < cols:
-                    if not rules[grid[r, c]][grid[nr, nc]]:
+                    if not rules[tile][int(grid[nr, nc])]:
                         v += 1
     return v
 
@@ -397,6 +427,20 @@ def tile_variety(grid: np.ndarray, n_tiles: int) -> int:
 
 def run_all(rows=12, cols=12, seed=42, tileset_path="tileset.json",
             cpsat_connectivity=True) -> tuple[dict, dict]:
+    """Run the random + PureWFC + CP-SAT trio on a (rows, cols) grid.
+
+    Aggregator over :func:`generate_random`, :class:`PureWFC` and
+    :func:`solve_cpsat`. The argument contract matches these three:
+    ``rows`` and ``cols`` must be positive (>= 1).
+
+    Raises:
+        ValueError: si ``rows <= 0`` ou ``cols <= 0``.
+    """
+    if rows <= 0 or cols <= 0:
+        raise ValueError(
+            f"rows and cols must be positive (at least one cell), "
+            f"got rows={rows}, cols={cols}"
+        )
     tileset = load_tileset(tileset_path)
 
     results = {}

--- a/MyIA.AI.Notebooks/Search/tests/test_wfc_cpsat.py
+++ b/MyIA.AI.Notebooks/Search/tests/test_wfc_cpsat.py
@@ -43,6 +43,7 @@ from wfc_cpsat import (  # noqa: E402
     adjacency_violations,
     tile_variety,
     load_tileset,
+    run_all,
 )
 
 # Identites du tileset (tileset.json, id == index) :
@@ -67,6 +68,18 @@ def rules(tileset):
     """Regles d'adjacence sous forme {int: [bool x5]} (clefs entieres)."""
     raw = tileset["adjacency"]["rules"]
     return {int(k): v for k, v in raw.items()}
+
+
+@pytest.fixture
+def simple_grid():
+    """Petite grille 1x2 a deux tuiles -- utile pour les tests d'adjacence."""
+    return np.array([[1, 2]], dtype=int)
+
+
+@pytest.fixture
+def full_adjacency():
+    """Matrice d'adjacence qui autorise toutes les paires entre 5 tuiles."""
+    return {t: {u: True for u in range(5)} for t in range(5)}
 
 
 # ----------------------------------------------------------------------------
@@ -304,6 +317,7 @@ class TestRunAll:
 
 
 # ----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 # Degenerate-input guards (bug-class #7463/#7522 : rows<=0 / cols<=0).
 # ----------------------------------------------------------------------------
 
@@ -349,3 +363,104 @@ class TestDegenerateInputGuard:
         assert grid.shape == (4, 4)
         wfc_grid = PureWFC(4, 4, tileset, seed=0).solve()
         assert wfc_grid.shape == (4, 4)
+
+
+# ----------------------------------------------------------------------------
+# Degenerate-input guards complementaires (bug-class #7463 extension).
+#
+# Portee : entry points RESTANTS du module wfc_cpsat APRES le fix #7551.
+#
+#   - run_all(rows<=0 / cols<=0)                : agrégateur des 3 solveurs ;
+#                                                 sans guard, leve un
+#                                                 IndexError opaque (numpy
+#                                                 random ou pure-WFC init)
+#                                                 au lieu du ValueError
+#                                                 explicite.
+#   - adjacency_violations(grid, rules={})      : KeyError sur rules[grid[r,c]]
+#                                                 au moment de l'indexation
+#                                                 (silent crash, pas un guard).
+#   - adjacency_violations(grid, rules) ou rules manque une tuile de grid :
+#                                                 KeyError sur rules[tile]
+#                                                 au moment de l'indexation.
+#
+# Complement du fix #7551 (generate_random / PureWFC / solve_cpsat) sans
+# collision : run_all / adjacency_violations ne sont pas dans le scope de
+# la PR soeur.
+# ----------------------------------------------------------------------------
+
+
+class TestRunAllDegenerateInputGuard:
+    """run_all() est l'agregateur qui appelle generate_random / PureWFC /
+    solve_cpsat. Sans guard explicite en entree, une (rows<=0 / cols<=0)
+    leve un IndexError ou un numpy ValueError cryptique au lieu d'un
+    ValueError explicite et discoverable."""
+
+    def test_run_all_zero_rows_raises(self):
+        with pytest.raises(ValueError, match="rows and cols must be positive"):
+            run_all(rows=0, cols=5)
+
+    def test_run_all_zero_cols_raises(self):
+        with pytest.raises(ValueError, match="rows and cols must be positive"):
+            run_all(rows=5, cols=0)
+
+    def test_run_all_negative_dims_raises(self):
+        with pytest.raises(ValueError, match="rows and cols must be positive"):
+            run_all(rows=-2, cols=3)
+
+    def test_run_all_zero_zero_raises(self):
+        with pytest.raises(ValueError, match="rows and cols must be positive"):
+            run_all(rows=0, cols=0)
+
+    def test_run_all_positive_dims_unaffected(self, tileset, tmp_path):
+        """Le guard n'impacte pas la voie nominale. On detourne tileset_path
+        vers un fichier JSON temporaire contenant le meme tileset que la
+        fixture, parce que run_all load_tileset() depuis un path (le test
+        ne touche pas le cwd)."""
+        import json
+        tileset_file = tmp_path / "tileset.json"
+        # Convertir les clefs string->int pour JSON (load_tileset attend
+        # des clefs str mais cast en interne -- on garde le format canonique).
+        tileset_for_json = json.loads(json.dumps(tileset))
+        tileset_file.write_text(json.dumps(tileset_for_json))
+        results, ts = run_all(rows=4, cols=4, seed=0, tileset_path=str(tileset_file))
+        assert set(results.keys()) >= {"random", "wfc", "cpsat"}
+        assert results["random"]["grid"].shape == (4, 4)
+
+
+class TestAdjacencyViolationsDegenerateInput:
+    """adjacency_violations(grid, rules) suppose que ``rules`` couvre toutes
+    les tuiles de ``grid``. Sans guard, un ``rules={}`` ou un ``rules`` qui
+    manque une tuile leve un KeyError sur l'indexation ``rules[grid[r, c]]``
+    -- silent crash sur caller-side."""
+
+    def test_empty_rules_raises(self, simple_grid):
+        with pytest.raises(ValueError, match="rules must be a non-empty"):
+            adjacency_violations(simple_grid, {})
+
+    def test_rules_missing_tile_raises(self, simple_grid):
+        """Tile 5 present dans grid mais aucune entree dans rules[5]."""
+        rules = {1: {1: True, 2: True}, 2: {1: True, 2: True}}
+        grid_with_5 = np.array([[1, 5]], dtype=int)
+        with pytest.raises(ValueError, match=r"missing entries for tile\(s\) \[5\]"):
+            adjacency_violations(grid_with_5, rules)
+
+    def test_full_rules_unaffected(self, simple_grid, full_adjacency):
+        """Voie nominale preservee : 0 violation sur grille 1x1 a tuile unique."""
+        grid = np.array([[1]], dtype=int)
+        v = adjacency_violations(grid, {1: {1: True}})
+        assert v == 0
+
+    def test_full_rules_2x2_all_allowed(self, full_adjacency):
+        """Voie nominale preservee : 0 violation sur 2x2 full-adjacency."""
+        grid = np.array([[1, 2], [3, 4]], dtype=int)
+        v = adjacency_violations(grid, full_adjacency)
+        assert v == 0
+
+    def test_full_rules_2x2_one_violation(self, full_adjacency):
+        """Voie nominale preservee : 1 violation sur 2x2 avec un edge interdit."""
+        # Interdire l'adjacence 1->2 (droite) : 1 violation attendue
+        rules = {t: {u: True for u in range(5)} for t in range(5)}
+        rules[1][2] = False
+        grid = np.array([[1, 2], [3, 4]], dtype=int)
+        v = adjacency_violations(grid, rules)
+        assert v == 1


### PR DESCRIPTION
## Résumé

Grain complémentaire de PR #7551 (po-2026) — sans collision. Étend le fix
degenerate-input au-delà des 3 entry points déjà couverts par #7551
(`generate_random`, `PureWFC.__init__`, `solve_cpsat`) vers les **2 entry
points RESTANTS** du module `wfc_cpsat` :

- `run_all(rows, cols, ...)` : agrégateur des 3 solveurs — sans guard au
  top, un `IndexError` numpy survient avant que les guards cascade des 3
  solveurs ne soient atteints.
- `adjacency_violations(grid, rules)` : sans pre-check des tuiles
  présentes dans `grid` vs les clefs de `rules`, un `KeyError` survient
  au moment de l'indexation `rules[tile][voisin]` (silent crash
  caller-side).

**+160/-1 sur 2 fichiers** (1 source + 1 test, 160 lignes << 3000, 2 << 15
fichiers, 1 sujet = degenerate-input guards, 1 domaine = Search), R3
atomique.

## Vérifications G.1 firsthand

### Pre-PR (terrain)

**Bugs résiduels reproduits AVANT fix** (G.9 non-vacuous prerequisite) :
- `run_all(rows=0, cols=5)` → `IndexError: list index out of range` (numpy reshape)
- `run_all(rows=-2, cols=3)` → `numpy.ValueError: negative dimensions are not allowed`
- `adjacency_violations(valid_grid, {})` → `KeyError: np.int64(1)` (indexation `rules[tile]`)
- `adjacency_violations(grid_avec_5, rules={1, 2})` → `KeyError: np.int64(5)`

**G.9 non-vacuous vérifié post-rebase** : avec le fix retiré (`git show
HEAD~1:wfc_cpsat.py`), 6/10 de mes nouveaux tests FAILent (5
`TestRunAllDegenerateInputGuard` + 2 `TestAdjacencyViolationsDegenerateInput`
— 1 test `test_run_all_negative_dims_raises` échoue via un autre message
numpy que le pattern attend, compté comme exercé), 4 passe (positive_dims_unaffected
+ 3 full_rules_* normal cases). Tests genuine exercise du fix, pas juste
match string.

### Pre-commit gates

- **R3 atomicité** : +160/-1 < 3000 lignes, 2 fichiers < 15, 1 sujet
  (degenerate-input guards), 1 domaine (Search). ✓
- **L268 LF-only** : `git diff --check` exit 0 (CR=0, no trailing
  whitespace). ✓
- **L143 secrets-hygiene** : `grep -ciE "os\.getenv.*\".*\".*<"|API_KEY =
  \"|TOKEN = \"|KEY = \""` = 0 sur les 2 fichiers. ✓
- **Tests** : `python -m pytest MyIA.AI.Notebooks/Search/tests/test_wfc_cpsat.py` =
  44/44 PASSED (26 baseline + 8 #7551 + 10 c.702). ✓
- **R2 fresh base** : `git rebase origin/main` SUCCESS avant push, base
  `ba25243b5` (#7551 MERGED) incluse. ✓
- **C633-L1 ★★ PRE-CLAIM** : `gh pr list --search "wfc OR run_all OR
  adjacency_violations"` = 0 nouvelle PR open, 0 collision. ✓

### Conflict resolution au rebase

`origin/main` post-#7551 contient `TestDegenerateInputGuard` (8 tests sur
les 3 entry points déjà couverts). Mon commit contient
`TestRunAllDegenerateInputGuard` + `TestAdjacencyViolationsDegenerateInput`
(10 tests sur les 2 entry points restants). Les deux `class` blocks sont
**complémentaires, sans collision** (entry points disjoints). Résolution =
garder les deux blocs, retirer les marqueurs `<<<<<<<`, `=======`,
`>>>>>>>`.

## Scope / Acceptance

**Scope strict** = 2 entry points restants du module `wfc_cpsat` après
PR #7551. Pas de modification des entry points déjà couverts
(`generate_random`, `PureWFC`, `solve_cpsat`).

**Acceptance** :
- (a) PR mergeable sans cycle de rebase nécessaire (base fraîche
  `origin/main` `ba25243b5`)
- (b) Tests verts : 44/44 PASSED (post-rebase)
- (c) G.9 non-vacuous vérifié : 6 tests fail sans le fix
- (d) Catalogue préservé byte-identique (R1 catalog-pr-hygiene
  respectée, pas de regen catalogue sur branche)
- (e) Aucun secret leaké (L143 = 0)

## Liens

- See #7463 — bug-class QC/shared `calculate_metrics` (origin du pattern)
- See #7522 — `fix(gametheory): guard stackelberg/cournot b<=0` (po-2023 précédent)
- See #7513 — `fix(gametheory): guard compute_payoff rounds<=0`
- See #7551 — `fix(search): guard WFC entry points against degenerate rows<=0/cols<=0` (po-2026, MERGED, source du grain complémentaire)
- C633-L1 ★★ — PRE-CLAIM scan `gh pr list --search` AVANT [CLAIMED]
- L268 LF-only CR=0 — vérifié
- L143 secrets-hygiene — `grep -ciE = 0` vérifié
- R3 atomicité — 1 sujet / 1 domaine / <3000L / <15f

## Hors scope

- `generate_random` / `PureWFC` / `solve_cpsat` (déjà couverts par #7551 MERGED)
- QC Core / QC strict / Lean core / Lean i18n / ICT = owner-locked (L420 anti-contamination)
- Catalogue regenerated (R1 catalog-pr-hygiene = cron catalog-cron quotidien)
