### PR TITLE
fix(sudoku): guard make_batch_edge_index against degenerate batch_size<=0

### DIFF
--- a/scripts/sudoku/core/graph.py
+++ b/scripts/sudoku/core/graph.py
@@ -34,6 +34,10 @@ def build_sudoku_edge_index():
 
 def make_batch_edge_index(base_edges, batch_size):
     """Replicate edge index for a batch, offsetting node indices."""
+    if batch_size <= 0:
+        raise ValueError(
+            f"batch_size must be positive (at least one graph in the batch), got {batch_size}"
+        )
     n_nodes = 81
     edges_list = []
     for b in range(batch_size):

--- a/scripts/tests/test_sudoku_core_graph.py
+++ b/scripts/tests/test_sudoku_core_graph.py
@@ -513,3 +513,35 @@ class TestCrossInvariants:
         _, y, _ = sudoku_collate_fn(batch)
         assert y.min().item() >= 0
         assert y.max().item() <= 8
+
+
+# ─── Degenerate-input guard (bug-class #7551/#7544) ──────────────────
+
+
+class TestMakeBatchEdgeIndexGuard:
+    """make_batch_edge_index must reject batch_size<=0 explicitly.
+
+    Without the guard, batch_size<=0 produces an empty edges_list, and
+    torch.cat([]) crashes with an opaque ``ValueError: torch.cat(): expected
+    a non-empty list of Tensors`` far from the call site. A batch with zero
+    graphs is meaningless and masks a caller-side bug. Same degenerate-input
+    bug-class as WFC rows<=0 (#7551), Tournament repetitions<=0 (#7544),
+    stackelberg b<=0 (#7522)."""
+
+    def test_batch_size_zero_raises(self):
+        base = build_sudoku_edge_index()
+        with pytest.raises(ValueError, match="batch_size must be positive"):
+            make_batch_edge_index(base, 0)
+
+    def test_batch_size_negative_raises(self):
+        base = build_sudoku_edge_index()
+        with pytest.raises(ValueError, match="batch_size must be positive"):
+            make_batch_edge_index(base, -3)
+
+    def test_positive_batch_size_unaffected(self):
+        """The guard does not impact the normal path (batch-size-1 invariant)."""
+        base = build_sudoku_edge_index()
+        batched = make_batch_edge_index(base, 1)
+        assert torch.equal(batched, base)
+        batched_2 = make_batch_edge_index(base, 2)
+        assert batched_2.shape[1] == base.shape[1] * 2


### PR DESCRIPTION
## Summary

`make_batch_edge_index(base_edges, batch_size)` replicated the Sudoku constraint graph for a batch via ``for b in range(batch_size)``. With `batch_size<=0` the loop body never runs, `edges_list` stays empty, and `torch.cat(edges_list)` crashes with an opaque error far from the call site:

```
ValueError: torch.cat(): expected a non-empty list of Tensors
```

A batch with zero graphs is meaningless and masks a caller-side bug. This PR adds an explicit `ValueError` guard at entry.

Same degenerate-input bug-class as #7551 (WFC `rows<=0`), #7544 (Tournament `repetitions<=0`), #7522 (stackelberg/cournot `b<=0`), #7513 (compute_payoff `rounds<=0`).

## Changes
- `scripts/sudoku/core/graph.py` (+4): `if batch_size <= 0: raise ValueError(...)` at entry of `make_batch_edge_index`.
- `scripts/tests/test_sudoku_core_graph.py` (+32): new `TestMakeBatchEdgeIndexGuard` class (3 tests: zero raises, negative raises, positive unaffected invariant).

## Validation (G.9 non-vacuous)
- **Reproduce unpatched**: confirmed `make_batch_edge_index(base, 0)` and `(base, -2)` both raise the opaque `torch.cat(): expected a non-empty list of Tensors` firsthand before patching.
- **Non-vacuous**: reverting the prod guard (stash) makes the 2 raise-tests FAIL — the opaque torch.cat message does not match `batch_size must be positive`. The tests genuinely distinguish the guard from the downstream crash.
- **Non-regression**: 62/62 tests pass (59 existing nominal + 3 new guard tests), `1.74s`.
- **Normal path preserved**: `test_positive_batch_size_unaffected` confirms batch_size=1 and =2 still behave correctly.

Run: `python -m pytest scripts/tests/test_sudoku_core_graph.py -v`

See #7551 (sibling bug-class).