### PR TITLE
feat(prover,#7477): add decomposition_regression run verdict (P3)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py
@@ -41,6 +41,12 @@ def _derive_result_kind(result, final_sorry: int, original_sorry: int) -> str:
     re-derived its own verdict — the ai-01 harvest step included.
       sorry_decreased  -> harvest: branch + PR (textual sorry count dropped)
       structural_only  -> keep iterating: decomposition landed, count did not drop
+                          (final <= original)
+      decomposition_regression -> a decomposition net-INCREASED the sorry count
+                          (final > original) without discharging a sub-sorry:
+                          structural_progress is True (the build passes) but the
+                          split did not help — change strategy, do not iterate
+                          another split (#7477 P3).
       crashed          -> postmortem the harness, not the proof
       provider_outage  -> the LLM provider died mid-run (circuit-breaker,
                           #5869): the prover never got to work — retry when
@@ -61,6 +67,21 @@ def _derive_result_kind(result, final_sorry: int, original_sorry: int) -> str:
     if final_sorry < original_sorry:
         return "sorry_decreased"
     if isinstance(result, dict) and result.get("structural_progress"):
+        # P3 (#7477 forensic): a decomposition that net-INCREASED the sorry
+        # count (final > original) did not actually help — it split a goal
+        # into more sub-sorries without discharging any. The autonomous
+        # success gate (_autonomous_success_gate, provers.py:289) sets
+        # structural_progress=True whenever `final >= original` and the build
+        # passes, so a 4->8 split scores structural_only == "keep iterating"
+        # — but iterating more decompositions spirals (4->8->16). Reclassify
+        # as decomposition_regression so a coordinator changes strategy
+        # (target a leaf, not another split) instead of mistaking the net
+        # increase for progress. FX-8 already closed the `final == original`
+        # statement-mutation case; this closes the `final > original` true-
+        # decomposition case. Forensic: L2551 grew 4->8 (within per-edit
+        # budget), committed net +4, scored structural_progress:true.
+        if final_sorry > original_sorry:
+            return "decomposition_regression"
         return "structural_only"
     if isinstance(result, dict) and result.get("provider_outage"):
         return "provider_outage"

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_decomposition_regression.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_decomposition_regression.py
@@ -1,0 +1,114 @@
+"""Unit tests for #7477 P3 — `decomposition_regression` run verdict.
+
+A *strategic decomposition* (one sorry split into N sub-sorries via ``have``) is
+legitimate structural progress **only when it pays off** — i.e. when at least
+one sub-sorry is eventually discharged so the net count does not grow. The
+autonomous success gate (``_autonomous_success_gate``, provers.py) sets
+``structural_progress = True`` whenever ``final >= original`` and the build
+passes, so a 4->8 split (the build still compiles) scored ``structural_only``
+== "keep iterating" — but iterating *another* decomposition spirals (4->8->16).
+Forensic (#7477, DEMO 62 L2551): a run grew 4->8 within the per-edit budget,
+committed net +4, and was reported as ``structural_progress: true``
+(misleading — it was a regression, not progress).
+
+The fix ranks a net-increasing decomposition as ``decomposition_regression``
+(distinct from ``structural_only``) so a coordinator changes strategy (target a
+leaf, not another split) instead of mistaking the increase for progress. FX-8
+already closed the ``final == original`` statement-mutation case; this closes
+the ``final > original`` true-decomposition case.
+
+Run from ``agent_tests/``::
+
+    python -m pytest tests/test_prover_decomposition_regression.py -q
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Make `prover/` importable regardless of how pytest was invoked (same
+# bootstrap convention as tests/test_prover_correctly_refused.py).
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+sys.path.insert(0, str(ROOT))
+
+from prover import run_prover_bg  # noqa: E402
+
+
+def _derive(result, final_sorry, original_sorry):
+    """Thin wrapper so each test reads as the verdict for one scenario."""
+    return run_prover_bg._derive_result_kind(result, final_sorry, original_sorry)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# the decomposition_regression branch
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_net_sorry_increase_with_decomposition_is_regression():
+    """A decomposition that net-increased the sorry count (final > original)
+    with the build passing (structural_progress=True) is decomposition_regression,
+    NOT structural_only. The forensic 4->8 case."""
+    result = {"structural_progress": True}
+    assert _derive(result, final_sorry=8, original_sorry=4) == "decomposition_regression"
+
+
+def test_net_increase_regardless_of_magnitude():
+    """Even a single-net-sorry increase via decomposition is a regression — the
+    magnitude does not matter (a 5->6 split that did not discharge is still a
+    split that did not help)."""
+    result = {"structural_progress": True}
+    assert _derive(result, final_sorry=6, original_sorry=5) == "decomposition_regression"
+    # Larger jump (the forensic's 4->8).
+    assert _derive(result, final_sorry=8, original_sorry=4) == "decomposition_regression"
+
+
+def test_equal_count_decomposition_stays_structural_only():
+    """final == original with structural_progress is structural_only — a
+    decomposition that split then discharged one sub-sorry (net zero) is a
+    legitimate restructure (the FX-8 statement-mutation case is handled
+    upstream via verified_tactic_count; here we only pin that the equality
+    case is NOT misclassified as regression)."""
+    result = {"structural_progress": True}
+    assert _derive(result, final_sorry=4, original_sorry=4) == "structural_only"
+
+
+def test_sorry_decrease_outranks_decomposition_regression():
+    """A run that net-LOWERED the sorry count is sorry_decreased regardless of
+    structural_progress — real progress outranks the regression gate (the
+    decomposition path is checked after the sorry_decreased check)."""
+    result = {"structural_progress": True}
+    assert _derive(result, final_sorry=3, original_sorry=5) == "sorry_decreased"
+
+
+def test_decomposition_regression_only_when_structural_progress():
+    """A net sorry increase WITHOUT structural_progress is NOT
+    decomposition_regression — it falls through to the later checks. Guards
+    against misclassifying a plain sorry regression (no decomposition) as a
+    decomposition regression."""
+    # No structural_progress flag -> the branch is never entered.
+    assert _derive({}, final_sorry=8, original_sorry=4) == "no_progress"
+    assert _derive({"structural_progress": False}, 8, 4) == "no_progress"
+
+
+def test_crashed_outranks_decomposition_regression():
+    """An explicit error is crashed regardless of a net-increasing
+    decomposition (the crashed check ranks first)."""
+    result = {"error": "kaboom", "structural_progress": True}
+    assert _derive(result, final_sorry=8, original_sorry=4) == "crashed"
+
+
+def test_decomposition_regression_plumbs_through_result_dict():
+    """End-to-end of the classification: a result dict shaped like the real
+    provers.py return (structural_progress surfaced, net sorry increase) — the
+    exact path a real 4->8 decomposition run takes."""
+    result = {
+        "success": True,  # _autonomous_success_gate: build passes, final > 0
+        "sorry_evolution": "4 -> 8",
+        "structural_progress": True,
+        "provider_outage": False,
+        "intractable": False,
+        "iterations": 8,
+    }
+    assert _derive(result, final_sorry=8, original_sorry=4) == "decomposition_regression"


### PR DESCRIPTION
## Summary

Implements **#7477 P3** — a typed `decomposition_regression` run verdict. A strategic decomposition (one sorry split into N sub-sorries via `have`) that net-**increased** the sorry count was misleadingly scored `structural_only` ("keep iterating"), when iterating another decomposition spirals (4→8→16). This PR ranks it `decomposition_regression` so a coordinator changes strategy (target a leaf, not another split).

This is a **Python harness classifier fix** (not a Lean proof change). Single bounded subject, 1 source file + 1 test file.

## Root cause

The autonomous success gate (`_autonomous_success_gate`, `provers.py:289`) sets:

```python
structural_progress = (final_sorry >= original_sorry_count
                       and final_build_ok and final_sorry > 0 ...)
```

So a decomposition that grows sorry **4→8** with a passing build sets `structural_progress = True`. `_derive_result_kind` then returns `structural_only` — "keep iterating: decomposition landed". But a net-increasing split did not actually help (no sub-sorry was discharged); iterating another split spirals.

Verified **firsthand** (#7477 forensic span evidence): DEMO 62 L2551 grew 4→8 within the per-edit budget, committed net +4, scored `structural_progress: true` (misleading). FX-8 already closed the `final == original` statement-mutation case (requires `verified_tactic_count > 0` at equality); the `final > original` true-decomposition case was explicitly left "unaffected" (FX-8 comment, `provers.py:282`) — **this PR closes it**.

## Fix

Gate the `structural_only` branch in `run_prover_bg._derive_result_kind` on `final_sorry <= original_sorry`:

```python
if isinstance(result, dict) and result.get("structural_progress"):
    # P3 (#7477 forensic): a decomposition that net-INCREASED the sorry
    # count (final > original) did not actually help ...
    if final_sorry > original_sorry:
        return "decomposition_regression"
    return "structural_only"
```

- `final < original` → `sorry_decreased` (unchanged, checked earlier).
- `final == original` + structural_progress → `structural_only` (legit restructure, net zero — unchanged).
- `final > original` + structural_progress → **`decomposition_regression`** (new).
- `final > original` WITHOUT structural_progress → falls through to `provider_outage`/`correctly_refused`/`no_progress` (a plain sorry regression is NOT a decomposition regression — guarded by the test `test_decomposition_regression_only_when_structural_progress`).

Ranked AFTER `sorry_decreased` and `crashed` (real progress / hard failure outrank the gate).

## Validation (ran the ACTUAL pytest suite)

```
=== new test suite (7 tests) ===
tests/test_prover_decomposition_regression.py .......   [100%]
7 passed in 1.05s

=== regression: existing prover tests ===
tests/test_prover_correctly_refused.py + test_prover_guards.py + test_bg_tree_lock.py
219 passed in 1.63s

=== py_compile ===
OK (run_prover_bg.py)
```

The 7 new tests cover: the 4→8 forensic case; magnitude-invariance (5→6, 4→8); equality stays `structural_only`; `sorry_decreased`/`crashed` outrank; net-increase WITHOUT structural_progress is NOT misclassified (guards false positive); end-to-end result-dict plumb.

## Scope

2 files, +135/-0 (purely additive — a new branch + its tests). No `*.lean` proof touched, no `sorry` added or removed (anti-regression clean). Catalog byte-identical to `main` (HARD 1). Single subject.

`See #7477` (partial: P3 of the forensic — does not close the epic).

<!-- codex-meta po-2026 machine="myia-po-2026" lane="CoursIA" -->
