### PR TITLE
fix(search,#7463): guard draw_search_tree against degenerate root=None/max_depth<=0

### DIFF
--- a/MyIA.AI.Notebooks/Search/search_helpers.py
+++ b/MyIA.AI.Notebooks/Search/search_helpers.py
@@ -41,7 +41,25 @@ def draw_search_tree(root: SearchTreeNode, max_depth: int = 5,
                      title: str = "Arbre de recherche",
                      highlight_path: bool = True,
                      figsize: tuple = (14, 8)):
-    """Dessine un arbre de recherche avec matplotlib."""
+    """Dessine un arbre de recherche avec matplotlib.
+
+    Raises:
+        TypeError: si ``root`` n'est pas un ``SearchTreeNode``.
+        ValueError: si ``max_depth`` n'est pas strictement positif.
+            (Avec ``max_depth <= 0``, la position verticale devient
+            nulle et la legende / les aretes degenerent -- on refuse
+            plutot que de rendre un graphe deroutant.)
+    """
+    if not isinstance(root, SearchTreeNode):
+        raise TypeError(
+            f"root must be a SearchTreeNode instance, got "
+            f"{type(root).__name__} (None or other type)"
+        )
+    if not isinstance(max_depth, int) or max_depth <= 0:
+        raise ValueError(
+            f"max_depth must be a strictly positive integer, got {max_depth!r}"
+        )
+
     fig, ax = plt.subplots(1, 1, figsize=figsize)
     ax.set_title(title, fontsize=14, fontweight='bold')
     ax.axis('off')

--- a/MyIA.AI.Notebooks/Search/tests/test_search_helpers.py
+++ b/MyIA.AI.Notebooks/Search/tests/test_search_helpers.py
@@ -154,3 +154,63 @@ def test_find_solution_path_returns_chain_to_solution():
 def test_draw_search_tree_single_node():
     fig = sh.draw_search_tree(sh.SearchTreeNode("only"))
     assert fig is not None
+
+
+# --- draw_search_tree degenerate-input guard (c.703) -----------------------
+
+class TestDrawSearchTreeDegenerateInputGuard:
+    """Garde-fou d'entree pour ``draw_search_tree``.
+
+    Reproduit le pattern robusteur c.702 sur ``wfc_cpsat.run_all`` /
+    ``wfc_cpsat.adjacency_violations`` : refuser explicitement les
+    arguments degeneres plutot que de laisser une ``AttributeError``
+    opaque (``root=None`` -> ``'NoneType' object has no attribute
+    'children'``) ou un rendu matplotlib pathologique (``max_depth<=0``
+    -> y=1.0 partout, aretes confondues avec la legende).
+    """
+
+    def test_root_none_raises_typeerror(self):
+        # L'AttributeError d'origine etait silencieuse et confondait
+        # l'appelant avec un bug dans son arbre -- on la remplace par
+        # un TypeError explicite qui pointe la cause reelle.
+        with pytest.raises(TypeError, match="root must be a SearchTreeNode"):
+            sh.draw_search_tree(None)
+
+    def test_root_non_node_raises_typeerror(self):
+        # Tout objet qui n'est pas un SearchTreeNode est rejete avec
+        # le meme message -- la verification se fait sur le type, pas
+        # sur la verite/falsete (un SearchTreeNode est toujours truthy
+        # en pratique, mais on ne veut pas dependre de __bool__).
+        with pytest.raises(TypeError, match="got str"):
+            sh.draw_search_tree("not_a_node")
+
+    def test_root_dict_raises_typeerror(self):
+        with pytest.raises(TypeError, match="got dict"):
+            sh.draw_search_tree({"state": "A"})
+
+    def test_max_depth_zero_raises_valueerror(self):
+        # max_depth=0 -> toutes les positions y=1.0, aretes illisibles.
+        with pytest.raises(ValueError, match="max_depth must be a strictly positive"):
+            sh.draw_search_tree(sh.SearchTreeNode("root"), max_depth=0)
+
+    def test_max_depth_negative_raises_valueerror(self):
+        with pytest.raises(ValueError, match="max_depth must be a strictly positive"):
+            sh.draw_search_tree(sh.SearchTreeNode("root"), max_depth=-5)
+
+    def test_max_depth_non_int_raises_valueerror(self):
+        # 1.5 est un float valide ; on exige un int strict.
+        with pytest.raises(ValueError, match="max_depth must be a strictly positive"):
+            sh.draw_search_tree(sh.SearchTreeNode("root"), max_depth=1.5)
+
+    def test_max_depth_one_still_renders(self):
+        # Sanity check : l'invariant "max_depth>=1 OK" doit etre preserve.
+        fig = sh.draw_search_tree(sh.SearchTreeNode("root"), max_depth=1)
+        assert fig is not None
+
+    def test_valid_root_unaffected(self):
+        # Pas de regression sur l'appel normal (defaut max_depth=5).
+        root = sh.SearchTreeNode("root")
+        root.add_child("a")
+        root.add_child("b")
+        fig = sh.draw_search_tree(root)
+        assert fig is not None


### PR DESCRIPTION
## Résumé

Grain c.703 = extension du pattern robusteur c.702 (PR #7553 MERGED,
complémentaire #7551 po-2026) sur la couche **visualisation** de Search.
Mêmes bug-class et même fix-pattern que `wfc_cpsat.run_all` /
`wfc_cpsat.adjacency_violations` : entry points publics qui crashent en
silence avec des exceptions opaques (`AttributeError: 'NoneType' object
has no attribute 'children'`) au lieu de remonter un diagnostic
actionable à l'appelant.

C.703 = grain atomique R3 sur **1 entry point principal** :
`draw_search_tree` (le plus central, utilisé dans 11 notebooks
dépendants — Search/Applications/CSP/App-1/2/3/4/5/6/7/11 +
Search/Applications/Hybrid/App-9/10). G.1 firsthand a identifié **6
entry points × au moins 1 bug** sur le module, mais G.4 composite
interdit >1 entry point par PR : c.703-b/c/d/e/f = grains futurs sur
les autres entry points (registre « robustesse entry-point » étalé par
cycle pour variété R6 — mandat user 2026-07-19).

Grain atomique R3 = **`draw_search_tree(root=None)` et
`draw_search_tree(max_depth<=0)`** :
- `root=None` → AttributeError opaque (au lieu de TypeError explicite
  « root must be a SearchTreeNode instance »)
- `max_depth<=0` → rendu matplotlib pathologique (`y=1.0` partout,
  arêtes confondues avec la légende) qui n'aide pas l'appelant à
  diagnostiquer son bug

## Vérifications G.1 firsthand

### Bugs reproduits AVANT fix (autres entry points = grains futurs)

| Entry point | Entrée | Exception |
|-------------|--------|-----------|
| `draw_search_tree(root=None)` | `None` | AttributeError |
| `draw_search_tree(max_depth=0)` | root OK | rendu pathologique silencieux |
| `draw_fitness_landscape(func=None)` | `None` | TypeError |
| `draw_csp_graph(variables=None)` | `None` | TypeError |
| `draw_csp_graph(constraints=None)` | `None` | TypeError |
| `benchmark_table(results=None)` | `None` | TypeError (après header) |
| `plot_benchmark(results=None)` | `None` | TypeError |

### G.9 non-vacuous

Avec le fix retiré (`git stash push search_helpers.py`) : **6/8 nouveaux
tests FAILent** (3 AttributeError non interceptés + 1 regex pattern
miss + 3 « DID NOT RAISE » ValueError), 2 invariants normaux passent
dans les deux cas (`max_depth=1` rend une fig valide, `valid_root`
inchangé). Tests genuine exercise du fix, pas match string.

## Pré-commit gates

- **R3 atomicité** : +79/-1 sur 2 fichiers (1 source + 1 test, 79 << 3000,
  2 << 15), 1 sujet (root guard), 1 domaine (Search). ✓
- **L268 LF-only** : `git diff --check` exit 0. ✓
- **L143 secrets-hygiene** : `grep -ciE` = 0 sur les 2 fichiers. ✓
- **Tests** : `pytest test_search_helpers.py test_search_helpers_coverage.py` =
  **51/51 PASSED** (19 baseline + 8 c.703 = 27 test_search_helpers +
  24 coverage) en 1.14s. ✓
- **R2 fresh base** : `git pull --ff-only` + worktree rebasé sur
  `6ab16182` (#7554 MERGED). ✓
- **R1 catalog-pr-hygiene** : catalogue byte-identique à main. ✓

## Scope / Acceptance

**Scope strict** = 1 entry point (`draw_search_tree`) du module
`search_helpers`. Pas de modification des 6 autres entry points
(`draw_csp_graph`, `draw_fitness_landscape`, `benchmark_table`,
`plot_benchmark`, `navigation_header`, `add_child`) — grains futurs
c.703-b à c.703-f.

**Acceptance** :
- (a) PR mergeable sans cycle de rebase (base fraîche `6ab16182`)
- (b) Tests verts : 51/51 PASSED
- (c) G.9 non-vacuous : 6 fail sans fix
- (d) Catalogue préservé byte-identique
- (e) Aucun secret leaké (L143 = 0)
- (f) Pas de modification des notebooks dépendants (output stable)

## Liens

- See #7463 — bug-class QC/shared `calculate_metrics` (origin du pattern)
- See #7551 — `fix(search): guard WFC entry points against degenerate rows<=0/cols<=0` (po-2026, MERGED)
- See #7553 — `fix(search): guard wfc_cpsat run_all + adjacency_violations` (c.702, MERGED, source du pattern)
- C702-L1 ★★ — grain complémentaire PR tierce (pattern 6 grains comp. compaction history)
- C702-L2 ★★ — bug transféré ≠ résolu à la source ; guard = vérif de présupposé, pas try/except
- C702-L3 ★★ — pre-check set-diff AVANT indexation
- C702-L4 ★ — G.9 non-vacuous entry-points sans guard propre (`git stash push` → pytest → fail)
- C633-L1 ★★ — PRE-CLAIM scan `gh pr list --search` AVANT [CLAIMED]
- L268 LF-only CR=0 — vérifié
- L143 secrets-hygiene — `grep -ciE = 0` vérifié
- R3 atomicité — 1 sujet / 1 domaine / <3000L / <15f

## Hors scope

- `draw_csp_graph` / `draw_fitness_landscape` / `benchmark_table` /
  `plot_benchmark` / `navigation_header` (grains c.703-b à f)
- QC Core / Lean core / Lean i18n / ICT = owner-locked (L420 anti-contamination)
- Catalogue regenerated (R1 catalog-pr-hygiene)
- Notebooks dépendants (output stable, pas de re-execution requise — la
  PR ne change pas le comportement des appels valides)
