### PR TITLE
Fix(search,#7463): guard draw_csp_graph against degenerate inputs

### DIFF
--- a/MyIA.AI.Notebooks/Search/search_helpers.py
+++ b/MyIA.AI.Notebooks/Search/search_helpers.py
@@ -135,6 +135,8 @@ def draw_csp_graph(variables: list, domains: dict, constraints: list,
     Args:
         variables: liste des noms de variables (noeuds).
         domains: dict variable -> liste de valeurs (affiche sous chaque noeud).
+            Peut etre ``None`` ou un dict vide (les noeuds n'affichent alors
+            pas de domaine).
         constraints: liste de paires (var1, var2) representant les aretes.
         assignment: dict optionnel variable -> valeur (met les noeuds assignes en vert).
         title: titre du graphe.
@@ -144,7 +146,29 @@ def draw_csp_graph(variables: list, domains: dict, constraints: list,
              geographique). Passer un dict explicite pour une carte geographique
              (cf. CSP-1-Fundamentals Australie : positions AIMA-compatible
              pour que NT/WA/SA/Q/NSW/V/T apparaissent a l'endroit).
+
+    Raises:
+        TypeError: si ``variables`` n'est pas iterable (None / str / bytes),
+            si ``constraints`` n'est pas iterable (None), ou si ``pos`` n'est
+            ni ``None`` ni un ``dict``.
     """
+    # ``variables`` doit etre iterable (list/tuple/set), pas None ni str/bytes.
+    if variables is None or isinstance(variables, (str, bytes)):
+        raise TypeError(
+            f"variables must be an iterable of variable names, got "
+            f"{type(variables).__name__}"
+        )
+    if constraints is None:
+        raise TypeError(
+            f"constraints must be an iterable of pairs (var1, var2), got "
+            f"{type(constraints).__name__}"
+        )
+    if pos is not None and not isinstance(pos, dict):
+        raise TypeError(
+            f"pos must be None or a dict {{variable: (x, y)}}, got "
+            f"{type(pos).__name__}"
+        )
+
     try:
         import networkx as nx
     except ImportError:

--- a/MyIA.AI.Notebooks/Search/tests/test_search_helpers.py
+++ b/MyIA.AI.Notebooks/Search/tests/test_search_helpers.py
@@ -154,3 +154,69 @@ def test_find_solution_path_returns_chain_to_solution():
 def test_draw_search_tree_single_node():
     fig = sh.draw_search_tree(sh.SearchTreeNode("only"))
     assert fig is not None
+
+
+# --- draw_csp_graph: degenerate-input guards (c.704) -------------------------
+
+class TestDrawCspGraphDegenerateInputGuard:
+    """``draw_csp_graph`` must reject degenerate inputs up-front instead of
+    crashing deeper in the pipeline with opaque TypeErrors.
+
+    Bug class is the same as ``draw_search_tree`` (c.703) and the WFC entry
+    points (#7551, #7553): public entry points that crash silently with an
+    opaque exception when the caller passes ``None`` for a required parameter,
+    rather than raising a clear, actionable ``TypeError`` from the boundary.
+    """
+
+    def test_variables_none_raises_typeerror(self):
+        """``variables=None`` used to crash on ``nx.Graph.add_nodes_from(None)``."""
+        with pytest.raises(TypeError, match="variables must be an iterable"):
+            sh.draw_csp_graph(None, {}, [])
+
+    def test_variables_string_raises_typeerror(self):
+        """A bare string is iterable per character -- reject to avoid ambiguity
+        (the caller probably meant a single variable, not a list of chars).
+        """
+        with pytest.raises(TypeError, match="variables must be an iterable"):
+            sh.draw_csp_graph("WA", {}, [])
+
+    def test_variables_bytes_raises_typeerror(self):
+        """Same rationale as ``str``."""
+        with pytest.raises(TypeError, match="variables must be an iterable"):
+            sh.draw_csp_graph(b"WA", {}, [])
+
+    def test_constraints_none_raises_typeerror(self):
+        """``constraints=None`` used to crash on ``for c in None``."""
+        with pytest.raises(TypeError, match="constraints must be an iterable"):
+            sh.draw_csp_graph(["A", "B"], {}, None)
+
+    def test_pos_non_dict_raises_typeerror(self):
+        """``pos='invalid'`` used to crash on ``pos[v] = fallback[v]`` (str)."""
+        with pytest.raises(TypeError, match="pos must be None or a dict"):
+            sh.draw_csp_graph(["A"], {}, [], pos="invalid")
+
+    def test_valid_inputs_unaffected(self):
+        """The guards must not perturb the happy path: a small CSP with a
+        geographic ``pos`` (the Australia use-case from CSP-1-Fundamentals)
+        still renders a figure.
+        """
+        pos = {"WA": (0, 1), "NT": (1, 2), "SA": (1, 1)}
+        fig = sh.draw_csp_graph(
+            ["WA", "NT", "SA"],
+            {"WA": ["red"]},
+            [("WA", "NT"), ("NT", "SA")],
+            pos=pos,
+        )
+        assert fig is not None
+
+    def test_variables_empty_list_still_renders(self):
+        """An empty ``variables`` list is a valid degenerate-but-bounded input
+        -- the caller may want an empty graph. Do NOT reject.
+        """
+        fig = sh.draw_csp_graph([], {}, [])
+        assert fig is not None
+
+    def test_constraints_empty_list_still_renders(self):
+        """An empty ``constraints`` list is valid (no edges)."""
+        fig = sh.draw_csp_graph(["A", "B"], {}, [])
+        assert fig is not None


### PR DESCRIPTION
## Résumé

Grain c.704 = extension du pattern robusteur c.703 (PR #7557 OPEN,
`draw_search_tree`) sur l'entry point sœur `draw_csp_graph` du même module
`search_helpers.py`. Mêmes bug-class et fix-pattern : entry points publics
qui crashent en silence avec des `TypeError` opaques sur entrées
dégénérées, au lieu de remonter un diagnostic actionable depuis la limite.

Atomicité R3 = **1 entry point principal** : `draw_csp_graph` (utilisé par
CSP-1-Fundamentals, CSP-2-Consistency, CSP-3-Advanced + 8 autres notebooks
qui importent `search_helpers`). G.1 firsthand c.703 avait identifié 6
entry points × au moins 1 bug, mais G.4 composite interdit >1 entry point
par PR. c.704 = grain MED-substance = c.703-b du backlog c.703-L2
(draw_csp_graph). c.703-c/d/e/f = grains futurs (draw_fitness_landscape /
benchmark_table+plot_benchmark / navigation_header / résiduels).

Pivot R6 c.704 vs c.703 :
- **Registre changeant** : tree visualisation (c.703) → CSP graph
  visualisation (c.704). NetworkX-required vs SearchTreeNode-required =
  domaines techniques distincts.
- **Bug-class entry-point visualisation intra-Search** : série assumée pour
  purge entry-points fragiles, registre changeant. c.705 pivotera hors
  Search pour respecter steer [VARIETE] ai-01 (mandat 2026-07-19).

Grain atomique R3 = **`draw_csp_graph` 3 entry-point bugs** :
- `variables=None` → `TypeError: 'NoneType' object is not iterable`
  (sur `nx.Graph.add_nodes_from(None)` L181)
- `constraints=None` → `TypeError: 'NoneType' object is not iterable`
  (sur `for c in None` L183)
- `pos='invalid'` (string) → `TypeError: 'str' object does not support item assignment`
  (sur `pos[v] = fallback[v]` L195, dans le fallback geographic)

Fix :
- `TypeError` si `variables` est None / str / bytes (str/bytes ambigus :
  itérable par caractère = sémantique piégeuse)
- `TypeError` si `constraints` est None
- `TypeError` si `pos` n'est ni None ni un dict

Listes vides pour `variables`/`constraints` restent valides (cas légitime
"graphe vide"). Sémantique : on rejette les types invalides, pas les
valeurs vides bornées — analogue à c.703-L3 ★★.

## Vérifications G.1 firsthand

### Bugs reproduits AVANT fix (autres entry points = grains futurs)

| Entry point | Entrée | Exception AVANT fix |
|-------------|--------|---------------------|
| `draw_csp_graph(variables=None)` | `None` | TypeError `'NoneType' object is not iterable` |
| `draw_csp_graph(variables="WA")` | str | (silent iterate per char) → graphe d'1 noeud "W" trompeur |
| `draw_csp_graph(constraints=None)` | `None` | TypeError `'NoneType' object is not iterable` |
| `draw_csp_graph(pos="invalid")` | str | TypeError `'str' object does not support item assignment` |

Cas valides vérifiés : `variables=[]` (graphe vide légitime), `constraints=[]`
(pas d'arêtes), `domains=None` (déjà géré L189 via `if domains and v in domains`),
`pos=None` (default spring_layout), `pos=dict` valide (géographie Australie).

### G.9 non-vacuous

Avec le fix retiré (`git stash push search_helpers.py`) : **5/8 nouveaux
tests FAILent** (3 regex pattern miss — exception TypeError capturée mais
message inattendu + 2 « DID NOT RAISE » pour str/bytes itérable), 3
invariants normaux passent dans les deux cas (`valid_inputs_unaffected`
Australia + `variables=[]` + `constraints=[]`). Tests genuine exercise du
fix, pas match string.

## Pré-commit gates

- **R3 atomicité** : +90/-0 sur 2 fichiers (1 source + 1 test, 90 << 3000,
  2 << 15), 1 sujet (csp_graph guard), 1 domaine (Search). ✓
- **L268 LF-only** : `git diff --check` exit 0. ✓
- **L143 secrets-hygiene** : `grep -ciE = 0` sur les 2 fichiers. ✓
- **Tests** : `pytest test_search_helpers.py test_search_helpers_coverage.py`
  = **51/51 PASSED** (43 baseline + 8 c.704) en 1.17s. Suite élargie
  Search complète (test_search_helpers + test_search_helpers_coverage +
  test_wfc_cpsat) = **95/95 PASSED** en 1.80s. ✓
- **R2 fresh base** : `git pull --ff-only` + worktree rebasé sur
  `6ab16182` (#7554 sudoku guard MERGED). ✓
- **R1 catalog-pr-hygiene** : catalogue byte-identique à main. ✓
- **C633-L1 ★★ PRE-CLAIM** : `gh pr list --search "csp_graph OR
  draw_csp_graph"` = 0 nouvelle PR open par autre agent, 0 collision. ✓

## Scope / Acceptance

**Scope strict** = 1 entry point (`draw_csp_graph`) du module
`search_helpers`. Pas de modification des 5 autres entry points fragiles
(`draw_search_tree` couvert par #7557 c.703, `draw_fitness_landscape` /
`benchmark_table` / `plot_benchmark` / `navigation_header` = grains futurs
c.703-c/d/e).

**Acceptance** :
- (a) PR mergeable sans cycle de rebase (base fraîche `6ab16182`)
- (b) Tests verts : 51/51 PASSED (51 search_helpers) / 95/95 PASSED (Search complet)
- (c) G.9 non-vacuous : 5 fail sans fix
- (d) Catalogue préservé byte-identique
- (e) Aucun secret leaké (L143 = 0)
- (f) Pas de modification des notebooks dépendants (output stable)

## Liens

- See #7463 — bug-class QC/shared `calculate_metrics` (origin du pattern)
- See #7557 — `fix(search): guard draw_search_tree against degenerate
  root=None/max_depth<=0` (c.703, source du pattern intra-Search)
- See #7553 — `fix(search): guard WFC run_all + adjacency_violations`
  (c.702, MERGED, source du pattern robusteur entry-point Search)
- See #7551 — `fix(search): guard WFC entry points against degenerate
  rows<=0/cols<=0` (po-2026, MERGED, origine du pattern robusteur)
- C702-L1 ★★ — grain complémentaire PR tierce post-merge (6 comp. compaction history)
- C702-L2 ★★ — bug transféré ≠ résolu à la source ; guard = vérif de présupposé, pas try/except
- C703-L1 ★★ — atomicité R3 sur 1 entry point (vs composite 6 entry points)
- C703-L2 ★★ — grain complémentaire intra-Search (pas inter-PR tierce), registre changeant
- C703-L3 ★★ — guard `max_depth<=0` pour rendu pathologique silencieux
- C703-L4 ★ — G.9 non-vacuous entry-points : `git stash push <src>` → pytest → fail SAUF invariants
- C703-L5 ★ — push identité jsboige via 2 switches successifs
- C703-L6 ★ — PR body via scratchpad + `D:\CoursIA-c704-PR_BODY.md`
  (NTFS case-insensitive)
- C633-L1 ★★ — PRE-CLAIM scan `gh pr list --search` AVANT [CLAIMED]
- L268 LF-only CR=0 — vérifié
- L143 secrets-hygiene — `grep -ciE = 0` vérifié
- R3 atomicité — 1 sujet / 1 domaine / <3000L / <15f

## Hors scope

- `draw_search_tree` (couvert par #7557 c.703)
- `draw_fitness_landscape` (grain futur c.703-c)
- `benchmark_table` + `plot_benchmark` (grain futur c.703-d, déjà en partie
  couvert par #7383 `plot_benchmark` coerce non-numeric)
- `navigation_header` (grain futur c.703-e)
- QC Core / Lean core / Lean i18n / ICT = owner-locked (L420 anti-contamination)
- Catalogue regenerated (R1 catalog-pr-hygiene)
- Notebooks dépendants (output stable, pas de re-execution requise — la PR
  ne change pas le comportement des appels valides)