### PR TITLE
feat(lean,i18n): quantifiers_en.lean EN sibling (standalone example, See #4980)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/examples/quantifiers_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/examples/quantifiers_en.lean
@@ -1,0 +1,102 @@
+/-
+  Lean Examples - Quantifiers (EN sibling)
+
+  This file contains first-order logic examples
+  corresponding to the Lean-4 notebook.
+
+  English sibling of quantifiers.lean (i18n #4980): docstrings and
+  comments translated to English; theorems, definitions, tactics, and
+  variables are byte-identical to the French original.
+-/
+
+-- ============================================================
+-- Universal quantifier (forall)
+-- ============================================================
+
+-- Adding zero on the right
+theorem add_zero_right (n : Nat) : n + 0 = n := rfl
+
+-- Commutativity of addition
+theorem add_comm_nat (a b : Nat) : a + b = b + a :=
+  Nat.add_comm a b
+
+-- Associativity of addition
+theorem add_assoc_nat (a b c : Nat) : (a + b) + c = a + (b + c) :=
+  Nat.add_assoc a b c
+
+-- ============================================================
+-- Existential quantifier (exists)
+-- ============================================================
+
+-- There exists an even number
+theorem exists_even : exists n : Nat, 2 * n = n + n :=
+  Exists.intro 1 rfl
+
+-- There exists a number > 5
+theorem exists_gt_5 : exists n : Nat, n > 5 :=
+  Exists.intro 6 (Nat.lt_succ_self 5)
+
+-- There exists a number whose square is 4
+theorem exists_square_4 : exists n : Nat, n * n = 4 :=
+  Exists.intro 2 rfl
+
+-- ============================================================
+-- forall/exists interaction
+-- ============================================================
+
+variable (A : Type) (P Q : A -> Prop)
+
+-- forall distributes over And
+theorem forall_and_distrib :
+  (forall x : A, P x /\ Q x) <-> (forall x : A, P x) /\ (forall x : A, Q x) :=
+  Iff.intro
+    (fun h => And.intro (fun x => (h x).left) (fun x => (h x).right))
+    (fun h x => And.intro (h.left x) (h.right x))
+
+-- exists distributes over Or
+theorem exists_or_distrib :
+  (exists x : A, P x \/ Q x) <-> (exists x : A, P x) \/ (exists x : A, Q x) :=
+  Iff.intro
+    (fun h => match h with
+      | Exists.intro x (Or.inl hp) => Or.inl (Exists.intro x hp)
+      | Exists.intro x (Or.inr hq) => Or.inr (Exists.intro x hq))
+    (fun h => match h with
+      | Or.inl (Exists.intro x hp) => Exists.intro x (Or.inl hp)
+      | Or.inr (Exists.intro x hq) => Exists.intro x (Or.inr hq))
+
+-- Negation of exists = forall not
+theorem not_exists_iff :
+  (Not (exists x : A, P x)) <-> (forall x : A, Not (P x)) :=
+  Iff.intro
+    (fun h x hp => h (Exists.intro x hp))
+    (fun h he => match he with | Exists.intro x hp => h x hp)
+
+-- ============================================================
+-- Divisibility
+-- ============================================================
+
+-- Definition of divisibility
+def divides (a b : Nat) : Prop := exists k : Nat, b = a * k
+
+notation:50 a " | " b => divides a b
+
+-- Every number divides 0
+theorem divides_zero (a : Nat) : a | 0 :=
+  Exists.intro 0 (Nat.mul_zero a).symm
+
+-- 1 divides every number
+theorem one_divides (a : Nat) : 1 | a :=
+  Exists.intro a (Nat.one_mul a).symm
+
+-- Reflexivity of divisibility
+theorem divides_refl (a : Nat) : a | a :=
+  Exists.intro 1 (Nat.mul_one a).symm
+
+-- Transitivity of divisibility
+theorem divides_trans (a b c : Nat) (hab : a | b) (hbc : b | c) : a | c :=
+  match hab, hbc with
+  | Exists.intro k1 hk1, Exists.intro k2 hk2 =>
+    Exists.intro (k1 * k2) (calc
+      c = b * k2 := hk2
+      _ = (a * k1) * k2 := congrArg (. * k2) hk1
+      _ = a * (k1 * k2) := Nat.mul_assoc a k1 k2)


### PR DESCRIPTION
## Summary

Adds the first English sibling for a standalone Lean example — `SymbolicAI/Lean/examples/quantifiers_en.lean`, EN sibling of `quantifiers.lean` (EPIC **#4980**, i18n FR/EN). This example had **no** `_en` sibling; it is a first-order logic demo (forall / exists / divisibility) corresponding to the Lean-4 notebook, referenced in `examples/README.md` + `examples/README.en.md` + `COURSE_CATALOG.generated.json`.

This is a **pure i18n addition** (one new file, no source change to the FR original).

## i18n #4980 byte-identity

FR and EN differ **only** in docstrings `/-- ... -/` and comments `-- ...`. The **theorems, definitions, tactics, notation, and variables are byte-identical** — verified by stripping all comments and diffing the pure code (result: `IDENTICAL`).

## Verification (lean-merge-discipline, firsthand, G.1)

```
$ lean quantifiers_en.lean    # standalone, no Mathlib import, no enclosing lakefile
(run 1) exit=0  0 errors
(run 2) exit=0  0 errors      # consistent (not a flake)

$ <comment-stripped diff FR vs EN>
IDENTICAL pure code

$ grep -c sorry quantifiers_en.lean
0
$ tr -cd '\r' < quantifiers_en.lean | wc -c
0                            # LF, no CRLF
```

The example is **standalone** (no `lakefile.lean` enclosing it, no `import` lines) and **Mathlib-free** (uses only the Lean Prelude + `Nat`/`Prop`/`Exists`/`Iff`/`And`/`Or`), so it verifies via `lean` directly in seconds — no per-lake Mathlib build wall.

## Why this example

`examples/quantifiers.lean` was chosen over the other standalone examples after a firsthand compile check (G.1 — don't trust memory):
- `quantifiers.lean` — **clean compile, consistent** (exit 0). Chosen.
- `mathlib_examples.lean` — clean compile, but has a dedicated CI workflow (`lean-mathlib-examples.yml`) → would need workflow update to build the `_en` variant (out of scope for a minimal sibling PR).
- `basic_logic.lean` — redeclares Prelude names (`and_comm`/`and_assoc`/`or_comm`); standalone compile fails identically in FR and EN (byte-identity holds, but a reviewer sees errors) → weak target.
- `tactics_demo.lean` / `llm_assisted_proof.lean` — `simp [Nat.add_succ, ...]` hits `maxRecDepth`; standalone compile fails consistently in FR and EN → weak target.

So `quantifiers_en.lean` is the cleanest verifiable sibling among the standalone examples.

## Scope

1 file, +107/-0 (purely additive — **zero source changes** to the FR original). Catalog byte-identical to `origin/main` (HARD 1). CRLF = 0. Single subject.

`See #4980` (partial — one example sibling; Epic #4980 remains open: standalone examples are FR-first course material by default, `_en` siblings are optional for EN-audience support).

<!-- codex-meta po-2026 machine="myia-po-2026" lane="CoursIA" -->
