### PR TITLE
fix(gametheory): guard run_tournament against empty strategies / repetitions<=0

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/game_theory_utils.py
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_utils.py
@@ -475,6 +475,14 @@ def run_tournament(strategies: List[Strategy],
     Returns:
         Dictionary {strategy_name: average_score_per_match}
     """
+    if not strategies:
+        raise ValueError(
+            "strategies must be a non-empty list (a tournament needs at least one strategy)"
+        )
+    if repetitions <= 0:
+        raise ValueError(
+            f"repetitions must be positive, got {repetitions}"
+        )
     n = len(strategies)
     scores = defaultdict(float)
     match_count = defaultdict(int)

--- a/MyIA.AI.Notebooks/GameTheory/tests/test_strategies.py
+++ b/MyIA.AI.Notebooks/GameTheory/tests/test_strategies.py
@@ -210,6 +210,36 @@ class TestTournament:
         assert results["TitForTat"] >= results["AlwaysCooperate"] - 1
 
 
+class TestTournamentGuard:
+    """run_tournament must reject degenerate inputs explicitly.
+
+    Without the guards, degenerate inputs return a silently-empty result
+    dict (no error), masking a caller-side bug:
+      - run_tournament([])          -> n=0, range(0) skipped, returns {} silently
+      - run_tournament([...], repetitions=0)  -> range(0) skipped, returns {} silently
+      - run_tournament([...], repetitions=-2) -> range(-2) skipped, returns {} silently
+
+    Same degenerate-input bug-class as compute_payoff_matrix rounds<=0
+    (#7517), make_batch_edge_index batch_size<=0 (#7554)."""
+
+    def test_empty_strategies_raises(self):
+        with pytest.raises(ValueError, match="strategies must be a non-empty list"):
+            run_tournament([])
+
+    def test_zero_repetitions_raises(self):
+        with pytest.raises(ValueError, match="repetitions must be positive"):
+            run_tournament([TitForTat(), AlwaysDefect()], repetitions=0)
+
+    def test_negative_repetitions_raises(self):
+        with pytest.raises(ValueError, match="repetitions must be positive"):
+            run_tournament([TitForTat(), AlwaysDefect()], repetitions=-3)
+
+    def test_default_repetitions_unaffected(self):
+        """The guard does not impact the normal path (default repetitions=1)."""
+        results = run_tournament([TitForTat(), AlwaysCooperate()], rounds=50)
+        assert len(results) == 2
+
+
 class TestReplicatorDynamics:
     """Tests for replicator dynamics."""
 


### PR DESCRIPTION
## Summary

`run_tournament(strategies, rounds, noise, repetitions)` sets `n = len(strategies)` then loops `range(repetitions) × range(n) × range(n)`, returning `{strategy_name: average_score_per_match}`. Degenerate inputs returned a **silently-empty result dict** (no error), masking a caller-side bug:

| Call (unpatched) | Behavior |
|---|---|
| `run_tournament([])` | `n=0`, all `range(0)` skipped, returns `{}` silently |
| `run_tournament([...], repetitions=0)` | `range(0)` skipped, returns `{}` silently |
| `run_tournament([...], repetitions=-2)` | `range(-2)` skipped, returns `{}` silently |

An empty tournament or a tournament run zero/negative times is meaningless and masks a caller-side bug (e.g. a strategy-list filter that dropped everything). This PR adds explicit `ValueError` guards at entry.

Same degenerate-input bug-class as #7517 (compute_payoff_matrix `rounds<=0`), #7554 (make_batch_edge_index `batch_size<=0`), #7551 (WFC `rows<=0`).

## Context — why this was missed before
This entry point was missed when the GameTheory degenerate-input vein was declared CLOSED (c.689). `run_tournament`'s caller-controlled `repetitions` and empty-list path were not enumerated in that sweep — the same class of oversight as #7551 missing `run_all`/`adjacency_violations` (complemented by #7553). Re-found by re-applying the count-check: enumerate all 18 public fns in `game_theory_utils.py` and verify each entry point for caller-controlled iteration.

## Changes
- `game_theory_utils.py` (+8): two guards at entry of `run_tournament` (`not strategies`, `repetitions <= 0`).
- `tests/test_strategies.py` (+30): new `TestTournamentGuard` class (4 tests: empty raises, zero reps raises, negative reps raises, default-reps unaffected invariant).

## Validation (G.9 non-vacuous)
- **Reproduce unpatched**: confirmed `run_tournament([]) == {}`, `run_tournament([TFT], repetitions=0) == {}`, `repetitions=-2 == {}` — all silent, no error.
- **Non-vacuous**: reverting the prod guard (stash) makes the 3 raise-tests FAIL (`DID NOT RAISE` — the silent `{}` is the unpatched behavior). The default-repetitions invariant test stays PASS.
- **Non-regression**: 30/30 `test_strategies.py` pass (26 nominal + 4 guard); full `GameTheory/tests/` = **540 passed, 0 regression** (excluding `test_lean_definitions.py` which requires Lean/WSL, a pre-existing environmental skip).

Run: `cd MyIA.AI.Notebooks/GameTheory && python -m pytest tests/test_strategies.py -v`

See #7517 (sibling bug-class).