### PR TITLE
fix(gametheory): validate NormalFormGame A/B shape match in constructor

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/game_theory_utils.py
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_utils.py
@@ -69,6 +69,15 @@ class NormalFormGame:
     def __post_init__(self):
         self.A = np.array(self.A, dtype=float)
         self.B = np.array(self.B, dtype=float)
+        if self.A.ndim != 2:
+            raise ValueError(
+                f"A must be a 2-D payoff matrix, got array with shape {self.A.shape}"
+            )
+        if self.A.shape != self.B.shape:
+            raise ValueError(
+                f"A and B must have the same shape, got A.shape={self.A.shape} "
+                f"and B.shape={self.B.shape}"
+            )
         self.m, self.n = self.A.shape
 
         if self.row_labels is None:

--- a/MyIA.AI.Notebooks/GameTheory/tests/test_nash_computation.py
+++ b/MyIA.AI.Notebooks/GameTheory/tests/test_nash_computation.py
@@ -189,5 +189,52 @@ class TestClassicGames:
             assert len(game.col_labels) == game.n
 
 
+class TestNormalFormGameConstruction:
+    """NormalFormGame constructor must reject ill-formed inputs.
+
+    Before the guard, __post_init__ took the shape from A only and never
+    checked B. A mismatched A/B pair was silently accepted, and downstream
+    solvers (find_pure_nash, etc.) returned WRONG results computed on the
+    mismatched B (out-of-range rows/cols silently ignored). Constructing a
+    game with mismatched payoff matrices is always a caller bug — the
+    constructor is the right place to catch it."""
+
+    def test_shape_mismatch_rejected(self):
+        with pytest.raises(ValueError, match="A and B must have the same shape"):
+            NormalFormGame(A=[[1, 2], [3, 4]], B=[[1, 2, 3], [4, 5, 6]])
+
+    def test_row_count_mismatch_rejected(self):
+        with pytest.raises(ValueError, match="A and B must have the same shape"):
+            NormalFormGame(A=[[1, 2], [3, 4]], B=[[1, 2], [3, 4], [5, 6]])
+
+    def test_square_mismatch_rejected(self):
+        """A=2x2, B=3x3 (both square but different sizes) must be rejected."""
+        with pytest.raises(ValueError, match="A and B must have the same shape"):
+            NormalFormGame(
+                A=[[1, 2], [3, 4]],
+                B=[[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+            )
+
+    def test_non_2d_A_rejected(self):
+        with pytest.raises(ValueError, match="A must be a 2-D payoff matrix"):
+            NormalFormGame(A=[1, 2, 3], B=[1, 2, 3])
+
+    def test_matching_shapes_accepted(self):
+        """The guard does not impact valid construction (2x2 invariant)."""
+        game = NormalFormGame(A=[[3, 0], [5, 1]], B=[[3, 5], [0, 1]])
+        assert game.m == 2
+        assert game.n == 2
+        assert game.A.shape == game.B.shape == (2, 2)
+
+    def test_non_square_matching_accepted(self):
+        """Non-square games with matching A/B are valid (m != n)."""
+        game = NormalFormGame(
+            A=[[1, 2, 3], [4, 5, 6]],
+            B=[[6, 5, 4], [3, 2, 1]],
+        )
+        assert game.m == 2
+        assert game.n == 3
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

`NormalFormGame.__post_init__` took `m, n = A.shape` from A only and **never checked B**. A mismatched A/B pair was silently accepted, and downstream solvers (`find_pure_nash`, `find_mixed_nash_2x2`, `solve_minimax_lp`, etc.) returned **WRONG results** computed on the mismatched B — out-of-range rows/cols silently ignored (when B is larger, the extra rows/cols are never examined; when smaller, numpy raises a confusing index error deep in the solver).

**Reproduced before fix:**
```python
NormalFormGame(A=[[1,2],[3,4]], B=[[1,2,3],[4,5,6],[7,8,9]])
  # accepted (m=n=2 from A only); find_pure_nash returns [(1,1)]
  # WRONG — computed on a 2x2 slice of a 3x3 B
NormalFormGame(A=[1,2,3], B=[1,2,3])
  # opaque "not enough values to unpack (expected 2, got 1)"
```

A mismatched-shape game is always a caller bug; the constructor is the right place to catch it (**fail-fast vs silent wrong equilibria**). This PR adds two guards in `__post_init__`: A must be 2-D, and `A.shape == B.shape`.

This is a **correctness fix (constructor invariant)**, distinct from the degenerate-input entry-point guards (#7517 `rounds`, #7554 `batch_size`, #7566 `repetitions`). Found by re-auditing the `game_theory_utils.py` public surface (the count-check that also surfaced #7566).

## Changes
- `game_theory_utils.py` (+9): two shape-validation guards in `NormalFormGame.__post_init__`.
- `tests/test_nash_computation.py` (+47): new `TestNormalFormGameConstruction` class (6 tests: shape mismatch rejected, row-count mismatch rejected, square mismatch rejected, non-2d A rejected, matching shapes accepted, non-square matching accepted).

## Validation (G.9 non-vacuous)
- **Reproduce unpatched**: confirmed the silent-acceptance + wrong-equilibrium + opaque-unpack behaviors firsthand before patching.
- **Non-vacuous**: reverting the prod guard (stash) makes the 4 raise-tests FAIL — 3 mismatch cases silently accept (DID NOT RAISE), non-2d case gets the opaque unpack ValueError instead of the clear guard message. The 2 matching-shapes invariant tests stay PASS.
- **Non-regression**: 18/18 `test_nash_computation.py` pass (12 nominal + 6 new ctor tests); full `GameTheory/tests/` = **542 passed, 0 regression** (excluding `test_lean_definitions.py` which requires Lean/WSL, a pre-existing environmental skip).

Run: `cd MyIA.AI.Notebooks/GameTheory && python -m pytest tests/test_nash_computation.py -v`