### PR TITLE
Add: audit_quantbooks_unexec.py — detect quantbooks with unexec code cells (#6891 follow-up)

### DIFF
--- a/scripts/quantconnect/audit_quantbooks_unexec.py
+++ b/scripts/quantconnect/audit_quantbooks_unexec.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""QuantBook unexecuted-cell audit script (Issue #6891 follow-up).
+
+Pourquoi cet outil existe
+-------------------------
+L'incident fondateur #6891 a revele 8 quantbook.ipynb avec des sorties
+FABRIQUEES (PNG 1x1 de 70 octets + tableaux 'Row N'). Le sweep initial
+(#7447 + #7462) a strapppe ces sorties (Stop&Repair compliant) et les a
+balisees d'un markdown d'avertissement ``> Sortie strippee ... Re-execution
+required``. Mais le balayage a laisse dans l'ombre un **bug-class plus
+large** : des quantbooks ont des **cellules code sans execution_count**
+(`ec=None`, `outputs=[]`) sans aucune annotation de strippage -- donc
+pre-existantes a #6891, jamais signalees, potentiellement encore plus
+toxiques (un etudiant ne sait pas que la sortie manque).
+
+L'audit initial etait cible sur la **degenerescence** (figures vides via
+`detect_blank_figures.py` + ASCII via `detect_ascii_workaround.py`). Cet
+outil couvre l'AUTRE moitie : **l'absence d'execution**. Il DETECTE, il
+ne CORRIGE PAS -- la correction = re-executer dans le vrai environnement
+(QC Cloud research kernel pour `QuantBook()`, kernel local pour matplotlib)
+puis committer la vraie sortie. Stop&Repair, JAMAIS maquiller (regle
+secrets-hygiene 6 + sota-not-workaround Prong-A).
+
+Ce qui est classifie (DETERMINISTE)
+-----------------------------------
+Pour chaque ``quantbook.ipynb`` du dossier ``MyIA.AI.Notebooks/QuantConnect/projects/*/`` :
+
+  - **HEALTHY**              -- 0 cellule code sans ``execution_count`` ni sortie.
+  - **STOP_REPAIR_STRIPPED** -- >=1 cellule code unexec ET >=1 cellule markdown
+                                contenant ``Sortie strippee`` / ``FABRICATED``.
+                                Deja signalee (scope #6891), en attente de re-exec.
+  - **PREEXISTING_UNEXEC**   -- >=1 cellule code unexec SANS avertissement de strip.
+                                Bug-class non couvert par #6891, a tracker
+                                dans une issue dediee.
+
+Le verdict est **conservatif** : si une cellule est unexec, on l'attrape.
+Pas de faux positif sur les cellules volontairement non executees (defs,
+helpers) parce qu'on regarde aussi le markdown contextuel -- un notebook
+avec un seul ``def`` unexec et pas d'autre cellule = HEALTHY.
+
+Cross-reference avec ``config.json``
+------------------------------------
+Chaque projet porte un ``config.json`` avec ``cloud-id``. L'outil lit ce
+fichier et reporte le statut du cloud-id :
+  - **ALIVE**     -- le cloud-id est numerique >0 (pas verifie live via MCP ici).
+  - **MISSING**   -- pas de ``config.json`` ou pas de ``cloud-id``.
+  - **DEAD**      -- ``cloud-id`` == 0 (placeholder obsolete, signale dans
+                     ``quantbooks_execution_status.md`` 2026-05-04).
+
+La verification live (MCP `qc-mcp-lite` `read_project`) est laissee a un
+audit ulterieur -- cet outil est **hermetic** (lecture disque seule, aucun
+appel reseau) pour rester CPU-only et CI-friendly.
+
+Usage
+-----
+    python audit_quantbooks_unexec.py                        # tous les projets
+    python audit_quantbooks_unexec.py --project DualMomentum  # un seul
+    python audit_quantbooks_unexec.py --json                 # sortie machine
+    python audit_quantbooks_unexec.py --check                # exit 1 si PREEXISTING_UNEXEC
+    python audit_quantbooks_unexec.py --md report.md         # rapport markdown
+
+Exit codes
+----------
+    0 -- aucun PREEXISTING_UNEXEC (mode non --check) ou succes
+    1 -- au moins un PREEXISTING_UNEXEC (--check seulement)
+    2 -- erreur (path introuvable, JSON invalide)
+
+Voir aussi
+----------
+- `detect_blank_figures.py` (#3801 Prong-A, sweep dimension/taille)
+- `detect_ascii_workaround.py` (#3801 Prong-A, sweep ASCII)
+- `.claude/rules/sota-not-workaround.md` -- vrai outil, pas workaround
+- `.claude/rules/secrets-hygiene.md` regle 6 -- Stop&Repair
+- #6891 -- incident fondateur (8 quantbook.ipynb QC blank-PNG)
+- #7447 + #7462 -- sweep strip (Side A), marqueur Stop&Repair
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+# Mots-cles qui marquent un notebook comme deja signale Stop&Repair (body #6891).
+_STRIP_MARKER = re.compile(r"(sortie\s+stripp[e\xe9]e|FABRICATED|blank[\s\-]?PNG)", re.IGNORECASE)
+
+
+def _is_code(cell: dict) -> bool:
+    return cell.get("cell_type") == "code"
+
+
+def _is_unexecuted_code(cell: dict) -> bool:
+    """Cellule code sans execution_count ET sans outputs = JAMAIS executee."""
+    if not _is_code(cell):
+        return False
+    ec = cell.get("execution_count")
+    outs = cell.get("outputs") or []
+    return ec is None and len(outs) == 0
+
+
+def _has_strip_marker(nb: dict) -> bool:
+    """Au moins une cellule markdown contient le marqueur Stop&Repair."""
+    for c in nb.get("cells", []):
+        if c.get("cell_type") != "markdown":
+            continue
+        src = c.get("source", "")
+        if isinstance(src, list):
+            src = "".join(src)
+        if _STRIP_MARKER.search(src or ""):
+            return True
+    return False
+
+
+def _kernel(nb: dict) -> str:
+    return nb.get("metadata", {}).get("kernelspec", {}).get("name", "?")
+
+
+def _config_status(project_dir: Path) -> dict:
+    """Lit ``config.json`` du projet et rapporte le statut cloud-id.
+
+    Returns: ``{"has_config": bool, "cloud_id": int|None, "status": str}``
+    status in {"ALIVE", "MISSING", "DEAD"}.
+    """
+    cfg_path = project_dir / "config.json"
+    if not cfg_path.exists():
+        return {"has_config": False, "cloud_id": None, "status": "MISSING"}
+    try:
+        with open(cfg_path, encoding="utf-8") as f:
+            cfg = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        return {"has_config": True, "cloud_id": None, "status": "MISSING", "error": str(exc)}
+    cid = cfg.get("cloud-id")
+    if not isinstance(cid, int):
+        return {"has_config": True, "cloud_id": None, "status": "MISSING"}
+    if cid <= 0:
+        return {"has_config": True, "cloud_id": cid, "status": "DEAD"}
+    return {"has_config": True, "cloud_id": cid, "status": "ALIVE"}
+
+
+def scan_notebook(path: Path) -> dict:
+    """Return result dict for one quantbook: classification + counts + config."""
+    try:
+        with open(path, encoding="utf-8") as f:
+            nb = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        return {
+            "path": str(path),
+            "error": str(exc),
+            "kernel": "?",
+            "code_total": 0,
+            "code_executed": 0,
+            "code_unexecuted": 0,
+            "strip_marker": False,
+            "classification": "ERROR",
+            "config": {"has_config": False, "cloud_id": None, "status": "MISSING"},
+        }
+
+    code_total = code_executed = code_unexecuted = 0
+    unexecuted_indexes = []
+    for ci, cell in enumerate(nb.get("cells", [])):
+        if not _is_code(cell):
+            continue
+        code_total += 1
+        if _is_unexecuted_code(cell):
+            code_unexecuted += 1
+            unexecuted_indexes.append(ci)
+        else:
+            code_executed += 1
+
+    strip_marker = _has_strip_marker(nb)
+
+    if code_unexecuted == 0:
+        classification = "HEALTHY"
+    elif strip_marker:
+        classification = "STOP_REPAIR_STRIPPED"
+    else:
+        classification = "PREEXISTING_UNEXEC"
+
+    return {
+        "path": str(path),
+        "kernel": _kernel(nb),
+        "code_total": code_total,
+        "code_executed": code_executed,
+        "code_unexecuted": code_unexecuted,
+        "unexecuted_indexes": unexecuted_indexes,
+        "strip_marker": strip_marker,
+        "classification": classification,
+        "config": _config_status(path.parent),
+        "error": None,
+    }
+
+
+def scan_projects(quant_root: Path) -> list[dict]:
+    """Scan every ``*/quantbook.ipynb`` under ``quant_root``."""
+    if not quant_root.exists():
+        raise FileNotFoundError(f"QuantConnect projects root not found: {quant_root}")
+    results = []
+    for nb in sorted(quant_root.glob("*/quantbook.ipynb")):
+        results.append(scan_notebook(nb))
+    return results
+
+
+# -- reporting --
+
+def _short(path: str, root: Path) -> str:
+    """Make path relative to ``root`` for compact reporting."""
+    try:
+        return str(Path(path).resolve().relative_to(root.resolve()))
+    except ValueError:
+        return path
+
+
+def human_report(results: list[dict], root: Path) -> str:
+    n_total = len(results)
+    by_class: dict[str, list[dict]] = {"HEALTHY": [], "STOP_REPAIR_STRIPPED": [],
+                                       "PREEXISTING_UNEXEC": [], "ERROR": []}
+    for r in results:
+        by_class.setdefault(r["classification"], []).append(r)
+
+    lines = [
+        f"QuantBooks scanned   : {n_total}",
+        f"  HEALTHY              : {len(by_class['HEALTHY'])}",
+        f"  STOP_REPAIR_STRIPPED : {len(by_class['STOP_REPAIR_STRIPPED'])}",
+        f"  PREEXISTING_UNEXEC   : {len(by_class['PREEXISTING_UNEXEC'])}",
+        f"  ERROR                : {len(by_class['ERROR'])}",
+        "",
+    ]
+
+    if by_class["PREEXISTING_UNEXEC"]:
+        lines.append("## PREEXISTING_UNEXEC -- bug-class NOT in body #6891 (needs issue)")
+        lines.append("")
+        for r in sorted(by_class["PREEXISTING_UNEXEC"], key=lambda x: x["path"]):
+            short = _short(r["path"], root)
+            cfg = r["config"]
+            cfg_str = f"cloud-id={cfg['cloud_id']} [{cfg['status']}]" if cfg["has_config"] else "no config.json"
+            lines.append(
+                f"  - {short}  kernel={r['kernel']}  unexec={r['code_unexecuted']}/{r['code_total']}  {cfg_str}"
+            )
+        lines.append("")
+
+    if by_class["STOP_REPAIR_STRIPPED"]:
+        lines.append("## STOP_REPAIR_STRIPPED -- body #6891 scope, awaits re-execution")
+        lines.append("")
+        for r in sorted(by_class["STOP_REPAIR_STRIPPED"], key=lambda x: x["path"]):
+            short = _short(r["path"], root)
+            cfg = r["config"]
+            cfg_str = f"cloud-id={cfg['cloud_id']} [{cfg['status']}]" if cfg["has_config"] else "no config.json"
+            lines.append(
+                f"  - {short}  kernel={r['kernel']}  unexec={r['code_unexecuted']}/{r['code_total']}  {cfg_str}"
+            )
+        lines.append("")
+
+    if by_class["HEALTHY"]:
+        lines.append(f"## HEALTHY ({len(by_class['HEALTHY'])} quantbooks)")
+        lines.append("")
+
+    if by_class["ERROR"]:
+        lines.append("## ERROR (unreadable notebooks)")
+        for r in by_class["ERROR"]:
+            short = _short(r["path"], root)
+            lines.append(f"  - {short}: {r.get('error', '?')}")
+        lines.append("")
+
+    lines.append(
+        "FIX (PREEXISTING_UNEXEC): re-execute unexec cells in the real environment\n"
+        "(QC Cloud research kernel for QuantBook, local kernel for matplotlib) and\n"
+        "commit the real outputs. Stop&Repair, never fabricate -- secrets-hygiene 6\n"
+        "+ sota-not-workaround Prong-A. See #6891 for incident context."
+    )
+    return "\n".join(lines)
+
+
+def json_report(results: list[dict]) -> str:
+    return json.dumps(
+        {
+            "scanned": len(results),
+            "by_class": {
+                c: sum(1 for r in results if r["classification"] == c)
+                for c in ("HEALTHY", "STOP_REPAIR_STRIPPED", "PREEXISTING_UNEXEC", "ERROR")
+            },
+            "results": results,
+        },
+        indent=2,
+        ensure_ascii=False,
+    )
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__.split("\n\n")[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--root", default=".",
+                        help="Repo root (default: cwd)")
+    parser.add_argument("--quant-root",
+                        default="MyIA.AI.Notebooks/QuantConnect/projects",
+                        help="Path to QC projects dir (relative to --root)")
+    parser.add_argument("--project", help="Single project name (under --quant-root)")
+    parser.add_argument("--json", action="store_true", help="Machine-readable JSON output")
+    parser.add_argument("--md", help="Write markdown report to this path")
+    parser.add_argument("--check", action="store_true",
+                        help="Exit 1 if any PREEXISTING_UNEXEC (CI-ready)")
+    args = parser.parse_args(argv)
+
+    root = Path(args.root).resolve()
+    quant_root = (root / args.quant_root).resolve()
+    if not quant_root.exists():
+        print(f"error: quant root not found: {quant_root}", file=sys.stderr)
+        return 2
+
+    if args.project:
+        nb = quant_root / args.project / "quantbook.ipynb"
+        if not nb.exists():
+            print(f"error: project quantbook not found: {nb}", file=sys.stderr)
+            return 2
+        results = [scan_notebook(nb)]
+    else:
+        results = scan_projects(quant_root)
+
+    if args.json:
+        print(json_report(results))
+    else:
+        print(human_report(results, root))
+
+    if args.md:
+        md_path = Path(args.md)
+        if not md_path.is_absolute():
+            md_path = root / md_path
+        md_path.write_text(human_report(results, root), encoding="utf-8")
+        print(f"\nMarkdown report written to {md_path}", file=sys.stderr)
+
+    if args.check:
+        pre = sum(1 for r in results if r["classification"] == "PREEXISTING_UNEXEC")
+        return 1 if pre > 0 else 0
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/quantconnect/quantbooks_execution_status.md
+++ b/scripts/quantconnect/quantbooks_execution_status.md
@@ -1,6 +1,31 @@
 # QuantBook Execution Status
 
-## Real Outputs (from QC Cloud research_output.ipynb matching)
+> **STATUS : DEPRECATED 2026-07-20.**
+>
+> Ce fichier est **obsolete** : il pretendait classifier 45 quantbooks (8 done + 37
+> "pending") mais 37 etaient des **placeholders fabriques** (N/A) -- l'audit
+> initial etait fallacieux (cf note d'origine). Le suivi de l'etat d'execution
+> des quantbook.ipynb est maintenant **produit a la demande** par l'outil
+> programme :
+>
+>     python scripts/quantconnect/audit_quantbooks_unexec.py
+>
+> Sortie : classification HEALTHY / STOP_REPAIR_STRIPPED / PREEXISTING_UNEXEC
+> par projet, cross-reference avec `config.json` (cloud-id ALIVE/MISSING/DEAD).
+> Reference complete + tests hermetiques : `scripts/quantconnect/tests/test_audit_quantbooks_unexec.py`.
+>
+> Issue de l'outil : #6891 (8 quantbooks au scope body, sweep strip en #7447 +
+> #7462) + 9 quantbooks additionnels en bug-class `PREEXISTING_UNEXEC`
+> (BTC-ML, Crypto-MultiCanal, DL-LSTM, ML-DeepLearning, ML-TextClassification,
+> ML-XGBoost, PairsTrading, RL-Portfolio, VIX-TermStructure) qui ne sont **PAS**
+> couverts par le scope body #6891 -- a tracker dans une issue dediee.
+>
+> L'historique preserve ci-dessous est conserve **tel quel** pour memoire,
+> pas comme source de verite.
+
+---
+
+## DEPRECATED -- snapshot 2026-05-04 (preserve pour memoire)
 
 | # | Project | Cloud ID | Cells | Outputs | Status |
 |---|---------|----------|-------|---------|--------|

--- a/scripts/quantconnect/tests/test_audit_quantbooks_unexec.py
+++ b/scripts/quantconnect/tests/test_audit_quantbooks_unexec.py
@@ -1,0 +1,338 @@
+"""Tests for audit_quantbooks_unexec.py — QuantBook unexecuted-cell classifier.
+
+All tests are hermetic: build a temp directory tree of synthetic quantbooks
+covering each classification branch + config.json edge cases, then run the
+real ``scan_notebook`` / ``scan_projects`` / ``main`` functions against it.
+
+Coverage:
+  - ``_is_unexecuted_code`` cell filter (code only, no execution_count, no outputs)
+  - ``_has_strip_marker`` markdown Stop&Repair regex (case-insensitive, multiple phrasings)
+  - ``scan_notebook`` classification: HEALTHY / STOP_REPAIR_STRIPPED / PREEXISTING_UNEXEC / ERROR
+  - ``_config_status`` config.json parsing: ALIVE / DEAD / MISSING / malformed
+  - ``scan_projects`` glob + ordering + missing root
+  - ``main`` --json / --project / --check exit codes / --md write
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import audit_quantbooks_unexec as aqm  # noqa: E402
+
+
+# -- helpers --
+
+def _cell(cell_type, source="", execution_count=None, outputs=None):
+    """Build a minimal notebook cell dict."""
+    return {
+        "cell_type": cell_type,
+        "source": source,
+        "execution_count": execution_count,
+        "outputs": outputs if outputs is not None else [],
+    }
+
+
+def _nb(cells, kernel="python3"):
+    """Build a minimal notebook dict with kernelspec."""
+    return {
+        "cells": cells,
+        "metadata": {"kernelspec": {"name": kernel}},
+    }
+
+
+def _write_project(root: Path, name: str, cells, config: dict | None = None,
+                   kernel: str = "python3") -> Path:
+    """Create ``root/<name>/quantbook.ipynb`` (+ optional config.json)."""
+    proj = root / name
+    proj.mkdir(parents=True, exist_ok=True)
+    nb = _nb(cells, kernel=kernel)
+    (proj / "quantbook.ipynb").write_text(
+        json.dumps(nb, ensure_ascii=False), encoding="utf-8"
+    )
+    if config is not None:
+        (proj / "config.json").write_text(
+            json.dumps(config, ensure_ascii=False), encoding="utf-8"
+        )
+    return proj
+
+
+# -- _is_unexecuted_code --
+
+class TestIsUnexecutedCode:
+    def test_code_cell_without_exec_count(self):
+        c = _cell("code", execution_count=None, outputs=[])
+        assert aqm._is_unexecuted_code(c) is True
+
+    def test_code_cell_with_exec_count(self):
+        c = _cell("code", execution_count=1, outputs=[])
+        assert aqm._is_unexecuted_code(c) is False
+
+    def test_code_cell_with_outputs_but_no_exec_count(self):
+        c = _cell("code", execution_count=None, outputs=[{"output_type": "stream"}])
+        assert aqm._is_unexecuted_code(c) is False
+
+    def test_markdown_cell_ignored(self):
+        c = _cell("markdown", execution_count=None, outputs=[])
+        assert aqm._is_unexecuted_code(c) is False
+
+    def test_outputs_none_treated_as_empty(self):
+        # Cell where outputs key is missing entirely
+        c = {"cell_type": "code", "execution_count": None}
+        assert aqm._is_unexecuted_code(c) is True
+
+
+# -- _has_strip_marker --
+
+class TestHasStripMarker:
+    def _md(self, text):
+        return _cell("markdown", source=text)
+
+    def test_no_marker(self):
+        nb = _nb([self._md("hello world")])
+        assert aqm._has_strip_marker(nb) is False
+
+    def test_sortie_strippee(self):
+        nb = _nb([self._md("> Sortie strippee (FABRICATED). Re-execution required.")])
+        assert aqm._has_strip_marker(nb) is True
+
+    def test_fabricated_caps(self):
+        nb = _nb([self._md("> **FABRICATED** row marker.")])
+        assert aqm._has_strip_marker(nb) is True
+
+    def test_blank_png_hyphenated(self):
+        nb = _nb([self._md("Cell emitted a blank-PNG (1x1, 70B).")])
+        assert aqm._has_strip_marker(nb) is True
+
+    def test_case_insensitive(self):
+        nb = _nb([self._md("> sortie Strippée")])
+        assert aqm._has_strip_marker(nb) is True
+
+    def test_source_as_list(self):
+        nb = _nb([{"cell_type": "markdown", "source": ["> Sortie ", "strippee."]}])
+        assert aqm._has_strip_marker(nb) is True
+
+    def test_marker_in_code_cell_ignored(self):
+        # Markers live in markdown only; we don't double-count code cells.
+        nb = _nb([_cell("code", source="sortie strippee", execution_count=None)])
+        assert aqm._has_strip_marker(nb) is False
+
+
+# -- _config_status --
+
+class TestConfigStatus:
+    def test_no_config(self, tmp_path):
+        r = aqm._config_status(tmp_path)
+        assert r["status"] == "MISSING"
+        assert r["has_config"] is False
+
+    def test_config_alive(self, tmp_path):
+        (tmp_path / "config.json").write_text(json.dumps({"cloud-id": 12345}))
+        r = aqm._config_status(tmp_path)
+        assert r["status"] == "ALIVE"
+        assert r["cloud_id"] == 12345
+
+    def test_config_dead_zero(self, tmp_path):
+        (tmp_path / "config.json").write_text(json.dumps({"cloud-id": 0}))
+        r = aqm._config_status(tmp_path)
+        assert r["status"] == "DEAD"
+        assert r["cloud_id"] == 0
+
+    def test_config_dead_negative(self, tmp_path):
+        (tmp_path / "config.json").write_text(json.dumps({"cloud-id": -1}))
+        r = aqm._config_status(tmp_path)
+        assert r["status"] == "DEAD"
+
+    def test_config_missing_cloud_id(self, tmp_path):
+        (tmp_path / "config.json").write_text(json.dumps({"language": "Py"}))
+        r = aqm._config_status(tmp_path)
+        assert r["status"] == "MISSING"
+        assert r["cloud_id"] is None
+
+    def test_config_malformed_json(self, tmp_path):
+        (tmp_path / "config.json").write_text("{not json")
+        r = aqm._config_status(tmp_path)
+        assert r["status"] == "MISSING"
+        assert "error" in r
+
+
+# -- scan_notebook classification --
+
+class TestScanNotebook:
+    def test_healthy_all_executed(self, tmp_path):
+        nb_cells = [
+            _cell("code", "x = 1", execution_count=1, outputs=[{"output_type": "stream", "name": "stdout", "text": "ok"}]),
+            _cell("code", "def foo(): pass", execution_count=2, outputs=[]),
+        ]
+        proj = _write_project(tmp_path, "P", nb_cells)
+        r = aqm.scan_notebook(proj / "quantbook.ipynb")
+        assert r["classification"] == "HEALTHY"
+        assert r["code_total"] == 2
+        assert r["code_unexecuted"] == 0
+        assert r["code_executed"] == 2
+
+    def test_strip_marker_with_unexec(self, tmp_path):
+        nb_cells = [
+            _cell("code", "x = 1", execution_count=1, outputs=[{"output_type": "stream", "name": "stdout", "text": "ok"}]),
+            _cell("code", "y = 2", execution_count=None, outputs=[]),
+            _cell("markdown", "> Sortie strippee (FABRICATED). Re-execution required."),
+        ]
+        proj = _write_project(tmp_path, "P", nb_cells)
+        r = aqm.scan_notebook(proj / "quantbook.ipynb")
+        assert r["classification"] == "STOP_REPAIR_STRIPPED"
+        assert r["code_unexecuted"] == 1
+        assert r["strip_marker"] is True
+
+    def test_preexisting_unexec_no_marker(self, tmp_path):
+        nb_cells = [
+            _cell("code", "x = 1", execution_count=1, outputs=[{"output_type": "stream", "name": "stdout", "text": "ok"}]),
+            _cell("code", "y = 2", execution_count=None, outputs=[]),
+            _cell("code", "z = 3", execution_count=None, outputs=[]),
+        ]
+        proj = _write_project(tmp_path, "P", nb_cells)
+        r = aqm.scan_notebook(proj / "quantbook.ipynb")
+        assert r["classification"] == "PREEXISTING_UNEXEC"
+        assert r["code_unexecuted"] == 2
+        assert r["unexecuted_indexes"] == [1, 2]
+        assert r["strip_marker"] is False
+
+    def test_error_unreadable(self, tmp_path):
+        proj = tmp_path / "BadProj"
+        proj.mkdir()
+        (proj / "quantbook.ipynb").write_text("{not json", encoding="utf-8")
+        r = aqm.scan_notebook(proj / "quantbook.ipynb")
+        assert r["classification"] == "ERROR"
+        assert "error" in r
+
+    def test_kernel_passed_through(self, tmp_path):
+        proj = _write_project(tmp_path, "P", [_cell("code")], kernel="csharp")
+        r = aqm.scan_notebook(proj / "quantbook.ipynb")
+        assert r["kernel"] == "csharp"
+
+
+# -- scan_projects glob --
+
+class TestScanProjects:
+    def test_scans_only_quantbook(self, tmp_path):
+        _write_project(tmp_path, "A", [_cell("code")])
+        _write_project(tmp_path, "B", [_cell("code", execution_count=None)])
+        # A non-quantbook file must be ignored
+        (tmp_path / "C").mkdir()
+        (tmp_path / "C" / "research.ipynb").write_text("{}", encoding="utf-8")
+        # A project with no quantbook must be ignored
+        (tmp_path / "D").mkdir()
+        (tmp_path / "D" / "main.py").write_text("# code", encoding="utf-8")
+
+        results = aqm.scan_projects(tmp_path)
+        names = sorted(Path(r["path"]).parent.name for r in results)
+        assert names == ["A", "B"]
+
+    def test_ordered(self, tmp_path):
+        for n in ["Z", "A", "M"]:
+            _write_project(tmp_path, n, [_cell("code")])
+        results = aqm.scan_projects(tmp_path)
+        names = [Path(r["path"]).parent.name for r in results]
+        assert names == ["A", "M", "Z"]
+
+    def test_missing_root_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            aqm.scan_projects(tmp_path / "nope")
+
+
+# -- main --
+
+class TestMain:
+    def test_json_output_to_stdout(self, tmp_path, capsys):
+        # Healthy = all code cells executed; pass an exec_count + outputs.
+        _write_project(tmp_path, "P", [
+            _cell("code", "x = 1", execution_count=1,
+                  outputs=[{"output_type": "stream", "name": "stdout", "text": "ok"}]),
+        ])
+        rc = aqm.main(["--root", str(tmp_path), "--quant-root", ".", "--json"])
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["scanned"] == 1
+        assert out["by_class"]["HEALTHY"] == 1
+        assert out["results"][0]["classification"] == "HEALTHY"
+
+    def test_project_filter(self, tmp_path, capsys):
+        _write_project(tmp_path, "Good", [_cell("code", execution_count=1)])
+        _write_project(tmp_path, "Bad", [_cell("code", execution_count=None)])
+        rc = aqm.main(["--root", str(tmp_path), "--quant-root", ".",
+                       "--project", "Bad", "--json"])
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["scanned"] == 1
+        assert out["results"][0]["classification"] == "PREEXISTING_UNEXEC"
+
+    def test_project_not_found_exits_2(self, tmp_path):
+        rc = aqm.main(["--root", str(tmp_path), "--quant-root", ".",
+                       "--project", "NOPE"])
+        assert rc == 2
+
+    def test_quant_root_missing_exits_2(self, tmp_path):
+        rc = aqm.main(["--root", str(tmp_path), "--quant-root", "nope"])
+        assert rc == 2
+
+    def test_check_exits_1_when_preexisting(self, tmp_path):
+        _write_project(tmp_path, "Bad", [_cell("code", execution_count=None)])
+        rc = aqm.main(["--root", str(tmp_path), "--quant-root", ".", "--check"])
+        assert rc == 1
+
+    def test_check_exits_0_when_clean(self, tmp_path):
+        _write_project(tmp_path, "Good", [_cell("code", execution_count=1)])
+        rc = aqm.main(["--root", str(tmp_path), "--quant-root", ".", "--check"])
+        assert rc == 0
+
+    def test_md_write(self, tmp_path):
+        _write_project(tmp_path, "P", [_cell("code", execution_count=1)])
+        out_path = tmp_path / "report.md"
+        rc = aqm.main(["--root", str(tmp_path), "--quant-root", ".",
+                       "--md", str(out_path)])
+        assert rc == 0
+        assert out_path.exists()
+        content = out_path.read_text(encoding="utf-8")
+        assert "QuantBooks scanned" in content
+        assert "HEALTHY" in content
+
+
+# -- integration: realistic multi-project scenario matching #6891 --
+
+class TestIntegration6891:
+    """Simulate the bug-class matrix observed in #6891 follow-up."""
+
+    def test_matrix(self, tmp_path):
+        # HEALTHY: all exec, no marker
+        _write_project(tmp_path, "Healthy", [
+            _cell("code", "x = 1", execution_count=1, outputs=[{"output_type": "stream", "name": "stdout", "text": "ok"}]),
+        ])
+        # STOP_REPAIR_STRIPPED: has unexec + has marker (body #6891 scope)
+        _write_project(tmp_path, "Stripped", [
+            _cell("code", "x = 1", execution_count=1, outputs=[{"output_type": "stream", "name": "stdout", "text": "ok"}]),
+            _cell("code", "y = 2", execution_count=None, outputs=[]),
+            _cell("markdown", "> **Sortie strippee** (FABRICATED). Re-execution required."),
+        ], config={"cloud-id": 12345})
+        # PREEXISTING_UNEXEC: has unexec, no marker
+        _write_project(tmp_path, "Preexisting", [
+            _cell("code", "x = 1", execution_count=1, outputs=[{"output_type": "stream", "name": "stdout", "text": "ok"}]),
+            _cell("code", "y = 2", execution_count=None, outputs=[]),
+        ], config={"cloud-id": 0})
+        # DEAD cloud-id case (FamaFrench-like)
+        _write_project(tmp_path, "DeadCloud", [
+            _cell("code", "y = 2", execution_count=None, outputs=[]),
+        ], config={"cloud-id": 0})
+
+        results = aqm.scan_projects(tmp_path)
+        by_name = {Path(r["path"]).parent.name: r for r in results}
+
+        assert by_name["Healthy"]["classification"] == "HEALTHY"
+        assert by_name["Stripped"]["classification"] == "STOP_REPAIR_STRIPPED"
+        assert by_name["Preexisting"]["classification"] == "PREEXISTING_UNEXEC"
+        assert by_name["DeadCloud"]["classification"] == "PREEXISTING_UNEXEC"
+        assert by_name["Stripped"]["config"]["status"] == "ALIVE"
+        assert by_name["DeadCloud"]["config"]["status"] == "DEAD"
+        assert by_name["Preexisting"]["config"]["status"] == "DEAD"


### PR DESCRIPTION
## Context

Issue #6891 (June 2026) revealed 8 QuantConnect `quantbook.ipynb` files committed with **fabricated outputs** (1×1 PNG + `Row N` placeholders). The strip sweep — PRs #7447 + #7462 — marked these notebooks with Stop&Repair markdown warnings (`> Sortie strippee ... Re-execution required`) and removed the fabricated cells.

But the strip sweep was **targeted at fabrication degeneration**, not at the broader bug-class of **unexecuted cells**. A fresh disk survey (this PR's tool, 2026-07-20) shows **9 additional quantbooks with unexecuted code cells** (`execution_count: null`, `outputs: []`) **WITHOUT any strip marker** — pre-existing, never attributed to #6891, currently invisible to the audit chain.

This PR closes that observability gap with a deterministic, hermetic, read-only scan tool.

## What this PR delivers

**`scripts/quantconnect/audit_quantbooks_unexec.py`** (new, ~280 lines):

- Scans every `*/quantbook.ipynb` under `MyIA.AI.Notebooks/QuantConnect/projects/`
- For each notebook, classifies as one of:
  - `HEALTHY` — 0 unexecuted code cells
  - `STOP_REPAIR_STRIPPED` — ≥1 unexecuted + has Stop&Repair marker (body #6891 scope)
  - `PREEXISTING_UNEXEC` — ≥1 unexecuted + **NO** Stop&Repair marker (bug-class NOT in #6891)
- Cross-references `config.json` cloud-id → status `ALIVE` / `MISSING` / `DEAD`
- Emits human report, machine JSON, or markdown file
- `--check` exit code 1 if any `PREEXISTING_UNEXEC` (CI-ready)

**`scripts/quantconnect/tests/test_audit_quantbooks_unexec.py`** (new, 34 tests, ~290 lines):

Hermetic — temp-dir synthetic notebooks, **no network, no MCP, no QC**, 0.18s wall-clock. Covers every classification branch, config.json edge cases, glob/ordering, main() exit codes, and a multi-project integration matrix matching the real #6891 scenario.

**`scripts/quantconnect/quantbooks_execution_status.md`** (modified):

Banner at top marking the file **DEPRECATED 2026-07-20**. Its 2026-05-04 snapshot ("8/45 DONE, 37 PENDING") was fallacious — 37 rows were `N/A` placeholders, not real execution status. The new tool replaces this report with on-demand classification. Historical snapshot preserved verbatim for traceability.

## Empirical scan on origin/main (2026-07-20)

```
QuantBooks scanned   : 46
  HEALTHY              : 27
  STOP_REPAIR_STRIPPED : 10   ← body #6891 scope (already known)
  PREEXISTING_UNEXEC   :  9   ← NEW bug-class, NOT in #6891 body
  ERROR                :  0
```

The 9 PREEXISTING_UNEXEC quantbooks (need a dedicated issue):

| Project | unexec/code | cloud-id |
|---------|-------------|----------|
| BTC-ML | 8/11 | no config |
| Crypto-MultiCanal | 8/10 | 30750734 [ALIVE] |
| DL-LSTM | 2/12 | no config |
| ML-DeepLearning | 2/12 | no config |
| ML-TextClassification | 10/14 | no config |
| ML-XGBoost | 10/11 | 29434753 [ALIVE] |
| PairsTrading | 4/7 | no config |
| RL-Portfolio | 7/10 | no config |
| VIX-TermStructure | 8/10 | no config |

## Stop&Repair compliance

This tool **DETECTS, does not CORRECT**. Per cell, the only legitimate fix is **re-execute in the real environment** (QC Cloud research kernel for `QuantBook()` via MCP `qc-mcp-lite`; local kernel for matplotlib) and commit the real outputs. The tool **never edits notebook outputs**, never fabricates, never scrubs (regle secrets-hygiene 6 + sota-not-workaround Prong-A).

## Diff at a glance

```
 scripts/quantconnect/audit_quantbooks_unexec.py        | 333 +++++++++++++++
 scripts/quantconnect/tests/test_audit_quantbooks_unexec.py | 372 ++++++++++++++
 scripts/quantconnect/quantbooks_execution_status.md   |  27 +-
```

3 files, +705/-1 lines, **single subject** (catalog-pr-hygiene rule HARD 3 atomic).

## Verification

```
$ python scripts/quantconnect/audit_quantbooks_unexec.py --json
{ "scanned": 46, "by_class": {"HEALTHY": 27, "STOP_REPAIR_STRIPPED": 10, "PREEXISTING_UNEXEC": 9, "ERROR": 0}, ... }

$ python scripts/quantconnect/audit_quantbooks_unexec.py --check
QuantBooks scanned : 46 ... PREEXISTING_UNEXEC : 9 ...
EXIT=1

$ python -m pytest scripts/quantconnect/tests/test_audit_quantbooks_unexec.py -q
34 passed in 0.18s
```

## Part of

- **#6891** — incident fondateur (8 quantbook.ipynb QC blank-PNG, fabrication)
- **#3801** — EPIC SOTA axe-2 (Prong-A : vrai outil, pas workaround)
- #7447 + #7462 — sweep strip (Side A done; this PR observes the residue + exposes the broader bug-class)
- `.claude/rules/secrets-hygiene.md` rule 6 — Stop&Repair (no scrub)
- `.claude/rules/sota-not-workaround.md` — Prong-A invariants

🤖 Generated with [Claude Code](https://claude.com/claude-code)