### PR TITLE
docs(curriculum,#7422): datation Last reviewed frontmatter (rebase)

### DIFF
--- a/docs/curriculum/genai.md
+++ b/docs/curriculum/genai.md
@@ -4,6 +4,8 @@
 
 Génération d'images (DALL-E, Stable Diffusion, Qwen, ComfyUI), synthèse vocale, génération musicale, vidéo, et orchestration de modèles. Inclut les workflows Vibe-Coding et les pipelines de production.
 
+**Last reviewed**: 2026-07-20
+
 ## Statistiques
 
 | Métrique | Valeur |

--- a/docs/curriculum/ia-classique.md
+++ b/docs/curriculum/ia-classique.md
@@ -4,6 +4,8 @@
 
 Algorithmes de recherche classique, satisfaction de contraintes (CSP), résolution de Sudoku, planification classique. De A* aux heuristiques avancées, en passant par les solveurs SAT/SMT.
 
+**Last reviewed**: 2026-07-20
+
 ## Statistiques
 
 | Métrique | Valeur |

--- a/docs/curriculum/ia-symbolique.md
+++ b/docs/curriculum/ia-symbolique.md
@@ -4,6 +4,8 @@
 
 Preuves formelles en Lean 4, logique probabiliste avec Tweety, web sémantique, planification classique et avancée, contrats intelligents. Du raisonnement déductif à la vérification formelle.
 
+**Last reviewed**: 2026-07-20
+
 ## Statistiques
 
 | Métrique | Valeur |

--- a/docs/curriculum/recherche.md
+++ b/docs/curriculum/recherche.md
@@ -4,6 +4,8 @@
 
 Inférence probabiliste (Infer.NET, Pyro, PyMC), théorie de l'information intégrée (IIT), reinforcement learning avancé, théorie des jeux (OpenSpiel). Pour étudiants en master/recherche.
 
+**Last reviewed**: 2026-07-20
+
 ## Statistiques
 
 | Métrique | Valeur |

--- a/docs/curriculum/trading.md
+++ b/docs/curriculum/trading.md
@@ -4,6 +4,8 @@
 
 Stratégies de trading algorithmique avec QuantConnect, pipeline ML (Transformer, DQN, LSTM), indicateurs techniques avancés, et modèles probabilistes. Du backtesting basique au reinforcement learning.
 
+**Last reviewed**: 2026-07-20
+
 ## Statistiques
 
 | Métrique | Valeur |


### PR DESCRIPTION
## Supersedes #7546 — rebase propre sur origin/main

Rebase triple post-cycle de merge ai-01 (2026-07-20T07:17Z). PR originale
#7546 (datation frontmatter cartes curriculum) auto-fermee par GitHub quand
la branche distante a ete recreee apres delete+push (force-push signature).
Impossible de rouvrir (422 `state cannot be changed`).

Cette PR pointe vers la meme branche `feature/c700-curriculum-datation-frontmatter`
(SHA `34db54ef7779046be6c371917843a3e64701c5a6`) avec le meme diff rebase
sur origin/main frais.

### Diff

```
docs/curriculum/genai.md            | 2 ++
docs/curriculum/ia-classique.md    | 2 ++
docs/curriculum/ia-symbolique.md   | 2 ++
docs/curriculum/recherche.md       | 2 ++
docs/curriculum/trading.md         | 2 ++
5 files changed, 10 insertions(+)
```

### Changement

Ajoute `**Last reviewed**: 2026-07-20` + ligne vide apres le sous-titre de
chaque carte curriculum, avant la section `## Statistiques`.

### Verification

- [x] 5 cartes curriculum : insert position verifiee (`## Statistiques` au meme offset relatif)
- [x] `git diff origin/main..HEAD --stat` = 5 files changed, +10/0
- [x] Base = origin/main HEAD frais (post-cycle merge ai-01)
- [x] Aucune autre modification dans le diff

### Note

PR originale #7546 fermee par GitHub (auto-close, force-push signature
detection). Pas un revert : le contenu est preserve verbatim sur la
branche, juste rebase sur origin/main frais.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
