### PR TITLE
feat(prover,#7477): P3 decomposition_regression result kind (rebase)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/decomposition_regression.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/decomposition_regression.py
@@ -1,0 +1,62 @@
+"""P3 (#7477 forensic): classify decomposition-regression honestly.
+
+The Hashlife/conway family macro-signal (forensic #7477, 11 dedup'd runs,
+~16,800s aggregate): **``verified_tactic_count == 0`` in all 11 runs**, and
+the net sorry delta is *negative* (regressions outweigh wins). The founding
+incident (L2551, grew 4->8) scored ``structural_only`` /
+``structural_progress: true`` -- a net sorry-INCREASE decomposition with
+ZERO build-verified tactics, labelled as *progress*. That mis-label corrupts
+forensic ROI: a run that sprayed unproven sub-sorries looks indistinguishable
+from a run that genuinely restructured a hard goal.
+
+P3 separates the two: a net-sorry-INCREASE decomposition is *structural
+progress* only when at least one tactic was build-verified
+(``verified_tactic_count > 0``); with zero verified tactics it is a
+**decomposition-regression** -- more sorries than it started with and nothing
+proved. Surfacing the typed verdict lets ``analyze_traces`` rank these runs
+honestly instead of counting them as progress.
+
+The per-edit ``sorry guard`` ceiling (``tools.py`` decomposition-budget) lets
+a within-budget increase through on purpose (a legitimate decomposition
+raises the count while the sub-goals compile); this module is the RUN-LEVEL
+terminal check that re-classifies the outcome when none of those sub-goals
+was actually *verified closed*. It does not revert the committed snapshot
+(reversion is a separate, riskier decision) -- it classifies.
+
+Stdlib-only and self-contained so it is unit-testable by file-path load on a
+bare CPU runner that lacks the ``agent_framework`` LLM stack (same pattern as
+``heartbeat_budget.py`` / ``forensic_guards.py``).
+
+See #7477 (prover harness forensic). See #1453 (prover co-evolution epic).
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+__all__ = ["is_decomposition_regression"]
+
+
+def is_decomposition_regression(
+    final_sorry: int,
+    original_sorry_count: int,
+    verified_tactic_count: Optional[int],
+) -> bool:
+    """Return True iff the run is a net-sorry-INCREASE decomposition with zero
+    build-verified tactics (the #7477 P3 regression pattern).
+
+    Conditions (all required):
+      - ``final_sorry > original_sorry_count`` -- the sorry count grew (a
+        pure decomposition: same/lower count is never a regression by this
+        signal; a drop is real progress, a same-count is handled by the
+        FX-8 / statement-mutation guard).
+      - ``verified_tactic_count == 0`` -- no tactic was build-verified. A
+        decomposition that produced at least one compiling, verified sub-goal
+        is genuine structural progress and is NOT flagged.
+      - ``verified_tactic_count is None`` returns ``False`` (legacy caller
+        that does not track verified tactics -- cannot classify, preserve
+        prior behaviour rather than guess).
+    """
+    if verified_tactic_count is None:
+        return False
+    return final_sorry > original_sorry_count and verified_tactic_count == 0

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
@@ -17,6 +17,7 @@ from agent_framework import ToolResultCompactionStrategy
 from .trace import TraceLogger
 from .state import ProofState, SorryContext, ProofPhase, PHASE_TRANSITIONS, TacticAttempt
 from .p4_final_verify import _evaluate_final_verify
+from .decomposition_regression import is_decomposition_regression
 from .lean_utils import (
     extract_sorry_block, get_goal_state, verify_sorry_replacement,
     extract_hypotheses, extract_local_lemmas, build_def_type_warnings,
@@ -770,6 +771,10 @@ class MultiAgentSorryProver:
         # "provider was down" apart from "no tactical progress".
         provider_outage = False
         provider_failures = 0
+        # P3 (#7477 forensic): default so the result dict is always defined
+        # even if the verify block raises before the decomposition-regression
+        # check runs.
+        decomposition_regression = False
         try:
             # Build-credited wall-clock supervisor (user mandate 2026-06-21:
             # "mettre en pause le timer de mesure pendant les builds"). A single
@@ -971,6 +976,27 @@ class MultiAgentSorryProver:
         verified_tactic_count = sum(
             1 for a in state.tactic_history if a.success
         )
+        # P3 (#7477 forensic): decomposition-regression guard. A net-sorry-
+        # INCREASE decomposition with ZERO build-verified tactics is a
+        # regression (runaway sub-sorry spraying), not structural progress.
+        # Founder: L2551 grew 4->8, verified_tactic_count==0, yet scored
+        # structural_progress:true -- mis-leading forensic ROI. Demote it
+        # honestly: a decomposition is structural progress ONLY when at least
+        # one tactic was build-verified. Same-count (final==original) stays
+        # the FX-8 / statement-mutation guard's territory; a drop is never a
+        # regression by this signal. Does NOT revert the committed snapshot
+        # (reversion is a separate, riskier decision) -- it classifies,
+        # surfacing decomposition_regression for forensic ROI. Verified>0
+        # decompositions (legitimate restructuring) are untouched.
+        decomposition_regression = is_decomposition_regression(
+            final_sorry, original_sorry_count, verified_tactic_count)
+        if decomposition_regression:
+            print(
+                f"  DECOMPOSITION_REGRESSION: sorry {original_sorry_count}"
+                f" -> {final_sorry} with 0 verified tactic. Net sorry growth"
+                f" unproven -- not structural progress (#7477 P3)."
+            )
+            structural_progress = False
         stmt_mutation = _stmt_mutation_guard(
             final_sorry, original_sorry_count, final_build_ok,
             proof_found, verified_tactic_count,
@@ -1072,6 +1098,13 @@ class MultiAgentSorryProver:
             # no_progress) — the target needs a cheaper tactic / higher
             # maxHeartbeats / decomposition, NOT more iterations.
             "heartbeat_budget_exceeded": getattr(state, "heartbeat_budget_exceeded", False),
+            # P3 (#7477 forensic): True when the run was a net-sorry-INCREASE
+            # decomposition with zero build-verified tactics (runaway sub-sorry
+            # spraying), demoted from structural_progress. Distinct from a
+            # legitimate decomposition (verified_tactic_count > 0, real
+            # restructuring) so forensic ROI ranks these runs honestly instead
+            # of counting an unproven sorry-spray as progress.
+            "decomposition_regression": decomposition_regression,
             # FX-12 (#6790 pathology 3): count of build-verified *structural*
             # edits (file_replace_lines / file_insert_lines whose build_check
             # passed). Distinct from ``structural_progress`` (a boolean

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py
@@ -57,6 +57,12 @@ def _derive_result_kind(result, final_sorry: int, original_sorry: int) -> str:
                           tactic too expensive for the budget. Needs a cheaper
                           tactic / higher maxHeartbeats / decomposition, NOT more
                           iterations.
+      decomposition_regression -> a net-sorry-INCREASE decomposition with ZERO
+                          build-verified tactics (runaway sub-sorry spraying,
+                          #7477 P3). Distinct from structural_only: a real
+                          restructuring has verified_tactic_count > 0. Tells a
+                          coordinator the decomposition was an unproven spray,
+                          NOT progress — do NOT harvest / branch it.
       no_progress      -> diagnostic data only
 
     Real progress outranks the outage flag: a run that lowered the sorry count
@@ -93,6 +99,24 @@ def _derive_result_kind(result, final_sorry: int, original_sorry: int) -> str:
     # NOT more iterations.
     if isinstance(result, dict) and result.get("heartbeat_budget_exceeded"):
         return "heartbeat_budget_exceeded"
+    # P3 (#7477 forensic): a net-sorry-INCREASE decomposition with ZERO build-
+    # verified tactics — a spray of unproven sub-sorries the multi-agent path
+    # previously mis-labelled as structural_progress (founder L2551 grew 4->8
+    # with verified_tactic_count==0 across 11 dedup'd runs). provers.py classifies
+    # this via is_decomposition_regression(final, original, verified) and, on a
+    # regression, forces structural_progress=False + sets the
+    # decomposition_regression flag; this branch surfaces the precise pathology
+    # for the forensic harvest instead of letting it fall through to no_progress.
+    # Ranked AFTER sorry_decreased / structural_only / provider_outage /
+    # correctly_refused / heartbeat_budget_exceeded: those outrank it (a run that
+    # lowered sorry, landed a verified decomposition, or hit an
+    # outage/refusal/budget wall first ranks as that outcome). Mutually exclusive
+    # with structural_only in practice — the P3 guard only fires when
+    # structural_progress was demoted. Legacy-safe: a result dict without the
+    # field (autonomous path / old traces) returns None -> falsy -> no_progress,
+    # identical to the classifier's None->False contract.
+    if isinstance(result, dict) and result.get("decomposition_regression"):
+        return "decomposition_regression"
     return "no_progress"
 
 
@@ -272,7 +296,7 @@ def _run_prover_locked(demo, name, filepath, line, mode, iterations, provider,
         "sorry_reduction": original_sorry - final_sorry,  # positif = progres (lecture non ambigue)
         # Canonical verdict (see _derive_result_kind): sorry_decreased |
         # structural_only | provider_outage | no_progress | crashed |
-        # already_solved | heartbeat_budget_exceeded.
+        # already_solved | heartbeat_budget_exceeded | decomposition_regression.
         "result_kind": result_kind,
         "elapsed_s": round(elapsed, 1),
         "result": result,

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_decomposition_regression.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_decomposition_regression.py
@@ -1,0 +1,130 @@
+"""Unit tests for the decomposition-regression classifier (P3, #7477 forensic).
+
+Loads ``decomposition_regression.py`` DIRECTLY by file path, bypassing
+``prover/__init__.py`` (which cascades the ``agent_framework`` LLM stack,
+absent on a bare CPU runner). The classifier is stdlib-only and
+self-contained, so these tests run everywhere (no agent_framework / Lean /
+network). Mirrors ``tests/test_heartbeat_budget.py``'s file-path load.
+
+The founding incident (forensic #7477): L2551 grew 4->8 (net +4 sorry) with
+``verified_tactic_count == 0`` in all 11 Hashlife/conway family runs, yet
+scored ``structural_progress: true`` -- a net sorry-INCREASE decomposition
+with ZERO build-verified tactics, mis-labelled as progress. This corrupts
+forensic ROI: an unproven sub-sorry spray looks indistinguishable from a
+genuine restructuring.
+
+P3 separates the two: an increase is structural progress only when at least
+one tactic was build-verified; with zero verified tactics it is a
+decomposition-regression. The macro-signal ``verified_tactic_count == 0`` is
+the forensic's own cited diagnostic.
+
+Run from `agent_tests/`:
+    python -m pytest tests/test_decomposition_regression.py -q
+
+See #7477 (prover harness forensic), See #1453 (prover co-evolution epic).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+
+_spec = importlib.util.spec_from_file_location(
+    "prover_decomposition_regression",
+    ROOT / "prover" / "decomposition_regression.py",
+)
+_dr = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_dr)
+
+classify = _dr.is_decomposition_regression
+
+
+# ── Acceptance: the founder incident classifies as regression ──────────────
+
+class TestRegressionDetected:
+    """A net-sorry-INCREASE with zero verified tactics IS a regression."""
+
+    def test_founder_l2551_four_to_eight(self):
+        """The exact forensic #7477 founding incident: 4 -> 8, verified=0."""
+        assert classify(8, 4, 0) is True
+
+    def test_large_runaway_spray(self):
+        """1 -> 10 with nothing verified is runaway sub-sorry spraying."""
+        assert classify(10, 1, 0) is True
+
+    def test_minimal_increase_one(self):
+        """Even a minimal 4 -> 5 with zero verified is a regression
+        (the signal is the unproven growth, not its magnitude)."""
+        assert classify(5, 4, 0) is True
+
+    def test_huge_original_with_growth(self):
+        """100 -> 101, verified=0 -- still a regression (growth + unproven)."""
+        assert classify(101, 100, 0) is True
+
+
+# ── Negative: legitimate progress must NOT be mis-labelled ────────────────
+
+class TestLegitimateProgressNotFlagged:
+    """A decomposition with at least one verified tactic is real structural
+    progress and must stay unflagged (preserves the FX-8 comment's explicit
+    intent: 'a decomposition (final > original, any verified count) ... stay
+    structural progress')."""
+
+    def test_decomposition_with_two_verified(self):
+        """4 -> 6 with 2 build-verified sub-goals = genuine restructuring."""
+        assert classify(6, 4, 2) is False
+
+    def test_decomposition_with_one_verified(self):
+        """Even a single verified tactic means the decomposition produced a
+        compiling, verified sub-goal -- not a spray."""
+        assert classify(6, 4, 1) is False
+
+    def test_large_increase_with_verified(self):
+        """1 -> 10 but 1 tactic verified: the agent proved something in the
+        decomposition, so it is not a pure regression."""
+        assert classify(10, 1, 1) is False
+
+
+class TestNonIncreaseNotFlagged:
+    """A same-count or drop is NEVER a regression by this signal (the
+    increase is the defining condition). Same-count is the FX-8 /
+    statement-mutation guard's territory; a drop is real progress."""
+
+    def test_same_count_zero_verified(self):
+        """4 -> 4, verified=0 is handled by FX-8 / stmt-mutation, not P3."""
+        assert classify(4, 4, 0) is False
+
+    def test_drop_zero_verified(self):
+        """A sorry DROP is never a regression here (it is progress, even if
+        the FX-6 guard separately demotes a drop with 0 verified)."""
+        assert classify(2, 4, 0) is False
+
+    def test_drop_to_zero(self):
+        assert classify(0, 4, 1) is False
+
+    def test_same_count_with_verified(self):
+        assert classify(4, 4, 2) is False
+
+
+# ── Legacy / contract ──────────────────────────────────────────────────────
+
+class TestLegacyAndContract:
+    def test_none_verified_preserves_prior_behaviour(self):
+        """A legacy caller that does not track verified tactics (None) cannot
+        be classified -- preserve prior behaviour rather than guess."""
+        assert classify(8, 4, None) is False
+
+    def test_exports_classify_function(self):
+        assert "is_decomposition_regression" in _dr.__all__
+        assert callable(classify)
+
+    def test_returns_bool_not_truthy(self):
+        """The verdict is persisted to JSON traces and consumed by
+        ``if result['decomposition_regression']``; it must be a real bool."""
+        assert type(classify(8, 4, 0)) is bool
+        assert type(classify(6, 4, 2)) is bool

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_decomposition_regression.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_decomposition_regression.py
@@ -1,0 +1,150 @@
+"""Unit tests for #7477 P3 — ``decomposition_regression`` run verdict.
+
+A net-sorry-INCREASE decomposition with ZERO build-verified tactics (runaway
+sub-sorry spraying) was previously mis-labelled ``structural_progress`` by the
+multi-agent path (founder L2551 grew 4->8 with ``verified_tactic_count==0``
+across 11 dedup'd runs). The fix has two parts:
+
+  1. ``provers.MultiAgentSorryProver`` classifies the outcome via
+     ``is_decomposition_regression(final, original, verified)`` (pure helper in
+     ``prover/decomposition_regression.py``, exercised by
+     ``tests/test_decomposition_regression.py``) and, on a regression, forces
+     ``structural_progress = False`` + sets the ``decomposition_regression``
+     flag on the result dict.
+  2. ``run_prover_bg._derive_result_kind`` gains a ``decomposition_regression``
+     branch (ranked AFTER sorry_decreased / structural_only / provider_outage /
+     correctly_refused / heartbeat_budget_exceeded: real progress and the other
+     forensic siblings outrank it) so the forensic harvest ranks these runs
+     honestly instead of letting them fall through to ``no_progress``.
+
+This module locks in part 2 — the ``_derive_result_kind`` branch — and the
+HARD invariant (mandate user forensic #7477): the result_kinds **coexist**,
+no resolution clobbers a sibling. The classification logic itself (part 1) is
+covered by ``test_decomposition_regression.py``.
+
+Run from ``agent_tests/``::
+
+    python -m pytest tests/test_prover_decomposition_regression.py -q
+
+Requires the prover stack (``agent-framework-openai``) — same collection
+contract as ``tests/test_prover_heartbeat_budget.py``. See #7477 (forensic),
+#1453 (prover co-evolution epic).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make `prover/` importable regardless of how pytest was invoked (same
+# bootstrap convention as tests/test_prover_heartbeat_budget.py).
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+sys.path.insert(0, str(ROOT))
+
+from prover import run_prover_bg  # noqa: E402
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# _derive_result_kind — the decomposition_regression branch
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _derive(result, final_sorry, original_sorry):
+    """Thin wrapper so each test reads as the verdict for one scenario."""
+    return run_prover_bg._derive_result_kind(result, final_sorry, original_sorry)
+
+
+def test_decomposition_regression_when_flag_set():
+    """A run whose result carries decomposition_regression=True (final > original,
+    verified==0 — set by provers.py via is_decomposition_regression) is classified
+    decomposition_regression, not no_progress."""
+    result = {"decomposition_regression": True}
+    assert _derive(result, final_sorry=8, original_sorry=4) == "decomposition_regression"
+
+
+def test_decomposition_regression_flag_needs_truthy():
+    """Flag absent or False falls through to no_progress (no false positive).
+    A legitimate decomposition or a plain stall must NOT be mislabelled."""
+    assert _derive({}, 8, 4) == "no_progress"
+    assert _derive({"decomposition_regression": False}, 8, 4) == "no_progress"
+    assert _derive({"decomposition_regression": None}, 8, 4) == "no_progress"
+
+
+def test_sorry_decreased_outranks_decomposition_regression():
+    """Real progress outranks the diagnostic: a run that lowered the sorry count
+    is still a harvest even if the regression flag was somehow set."""
+    result = {"decomposition_regression": True}
+    assert _derive(result, final_sorry=3, original_sorry=5) == "sorry_decreased"
+
+
+def test_structural_progress_outranks_decomposition_regression():
+    """A verified decomposition landed (structural_progress=True) — structural_only.
+    In practice the P3 guard forces structural_progress=False on a regression, so
+    these are mutually exclusive; the ranking still holds if both were set."""
+    result = {"decomposition_regression": True, "structural_progress": True}
+    assert _derive(result, 8, 4) == "structural_only"
+
+
+def test_provider_outage_outranks_decomposition_regression():
+    """A provider death mid-run is provider_outage regardless of regression flag:
+    the prover never got to work."""
+    result = {"decomposition_regression": True, "provider_outage": True}
+    assert _derive(result, 8, 4) == "provider_outage"
+
+
+def test_correctly_refused_outranks_decomposition_regression():
+    """An explicit Coordinator abandon (intractable) is correctly_refused
+    regardless of the regression flag — the agent refused; it did not spray."""
+    result = {"decomposition_regression": True, "intractable": True}
+    assert _derive(result, 8, 4) == "correctly_refused"
+
+
+def test_heartbeat_budget_exceeded_outranks_decomposition_regression():
+    """A Lean tactic that blew the maxHeartbeats budget (heartbeat_budget_exceeded)
+    outranks decomposition_regression — the sibling is checked first. This is the
+    HARD invariant: the P3 branch does NOT clobber the P5a sibling (#7477)."""
+    result = {"decomposition_regression": True, "heartbeat_budget_exceeded": True}
+    assert _derive(result, 8, 4) == "heartbeat_budget_exceeded"
+
+
+def test_crashed_outranks_decomposition_regression():
+    """An explicit error is crashed regardless of the regression flag."""
+    result = {"error": "kaboom", "decomposition_regression": True}
+    assert _derive(result, 8, 4) == "crashed"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# HARD invariant — siblings preserved (no clobber), 4 branches coexist
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_correctly_refused_sibling_still_works():
+    """The P2a sibling (correctly_refused) is untouched by the P3 branch:
+    a run with only intractable=True still classifies correctly_refused."""
+    assert _derive({"intractable": True}, 5, 5) == "correctly_refused"
+
+
+def test_heartbeat_budget_sibling_still_works():
+    """The P5a sibling (heartbeat_budget_exceeded) is untouched by the P3 branch:
+    a run with only heartbeat_budget_exceeded=True still classifies as such."""
+    assert _derive({"heartbeat_budget_exceeded": True}, 5, 5) == "heartbeat_budget_exceeded"
+
+
+def test_four_forensic_siblings_coexist():
+    """The 4 forensic result_kinds coexist: each flag, set alone, yields its own
+    verdict (none is shadowed by another). This is the mandate-user HARD
+    invariant for #7477 — no resolution overwrites a sibling."""
+    assert _derive({"intractable": True}, 5, 5) == "correctly_refused"
+    assert _derive({"heartbeat_budget_exceeded": True}, 5, 5) == "heartbeat_budget_exceeded"
+    assert _derive({"decomposition_regression": True}, 8, 4) == "decomposition_regression"
+    # structural_only is the 4th forensic-adjacent kind (verified decomposition).
+    assert _derive({"structural_progress": True}, 5, 5) == "structural_only"
+
+
+def test_plain_no_progress_unchanged():
+    """A flat run (no flag, final==original) is still no_progress — the P3 branch
+    only fires on the explicit decomposition_regression flag, never on shape."""
+    assert _derive({}, 5, 5) == "no_progress"


### PR DESCRIPTION
## Supersedes #7506 — rebase propre sur origin/main (P3 decomposition regression)

Rebase triple post-cycle de merge ai-01 (2026-07-20T07:17Z). PR originale
#7506 (prover P3 decomposition_regression branch kind) auto-fermee par
GitHub quand la branche distante a ete recreee apres delete+push
(force-push signature). Impossible de rouvrir (422 `state cannot be changed`).

Cette PR pointe vers la meme branche `feature/prover-p3-decomposition-regression`
(SHA `b68377c341814858f9d1fdbc0149f4ce577384a3`) avec le meme diff rebase
sur origin/main frais.

### Diff

```
agent_tests/prover/decomposition_regression.py            |  62 ++++
agent_tests/prover/provers.py                             |  33 +++
agent_tests/prover/run_prover_bg.py                       |  26 +++-
agent_tests/prover/test_decomposition_regression.py       | 130 ++++++++++++
agent_tests/prover/test_prover_decomposition_regression.py | 150 ++++++++++++
5 files changed, 400 insertions(+), 1 deletion(-)
```

### Changement (forensic #7477 P3, derniers grains)

- `decomposition_regression.py` : resultat de prover dedie pour run qui
  decompose (final_sorry > original_sorry OU zero sub-sorry dans une
  sous-tache)
- 3-branches `_derive_result_kind` preservees et coexistent dans
  `run_prover_bg.py` :
  - `correctly_refused` (L48)
  - `heartbeat_budget_exceeded` (L53)
  - `decomposition_regression` (L60)
- Wrap `_stamp_provider` de #7532 preserve intact (1 def + 4 call sites)

### Verification

- [x] 26/26 tests PASSED (pytest, base conda `C:/ProgramData/miniconda3/python.exe`
      avec agent-framework 1.3.0)
- [x] 3-branches `_derive_result_kind` verifiees dans `run_prover_bg.py` L48/L53/L60
- [x] `_stamp_provider` preserve (provers.py L42 + 4 call sites L88/L101/L132/L148)
- [x] Base = origin/main HEAD frais (post-cycle merge ai-01)

### Note

PR originale #7506 fermee par GitHub (auto-close, force-push signature
detection). Pas un revert : le contenu est preserve verbatim sur la
branche, juste rebase sur origin/main frais.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
