### PR TITLE
fix(sudoku): guard solve_sudoku/is_valid_puzzle against wrong-length puzzle

### DIFF
--- a/scripts/sudoku/core/solvers.py
+++ b/scripts/sudoku/core/solvers.py
@@ -92,6 +92,10 @@ def solve_sudoku(puzzle_81):
     Returns:
         (81,) int array with solution, or None if unsolvable.
     """
+    if len(puzzle_81) != 81:
+        raise ValueError(
+            f"puzzle_81 must have exactly 81 cells (9x9 grid), got {len(puzzle_81)}"
+        )
     grid = {i: _DIGITS for i in range(81)}
     for i in range(81):
         if puzzle_81[i] != 0:
@@ -107,6 +111,10 @@ def solve_sudoku(puzzle_81):
 
 def is_valid_puzzle(puzzle_81):
     """Quick check: no duplicate non-zero values in any row/col/box."""
+    if len(puzzle_81) != 81:
+        raise ValueError(
+            f"puzzle_81 must have exactly 81 cells (9x9 grid), got {len(puzzle_81)}"
+        )
     for i in range(81):
         if puzzle_81[i] == 0:
             continue

--- a/scripts/tests/test_sudoku_core_solvers.py
+++ b/scripts/tests/test_sudoku_core_solvers.py
@@ -247,3 +247,50 @@ class TestCrossInvariants:
         grid[80] = 5
         grid[8] = 5  # Same row (row 8)
         assert is_valid_puzzle(grid) is False
+
+
+class TestLengthGuard:
+    """Degenerate-input guard: a wrong-length puzzle must raise ValueError,
+    not an opaque IndexError (too short) and not be silently accepted (too long).
+
+    Before the guard, solve_sudoku([]) raised `IndexError: list index out of range`
+    with no hint about the 81-cell contract, and solve_sudoku([0]*82) returned a
+    valid-looking solution while silently ignoring the extra cell — hiding caller
+    bugs. Both fns now validate the documented (81,) contract up front.
+    """
+
+    @pytest.mark.parametrize("bad_len", [0, 1, 80, 82, 100])
+    def test_solve_sudoku_rejects_wrong_length_list(self, bad_len):
+        with pytest.raises(ValueError, match="81"):
+            solve_sudoku([0] * bad_len)
+
+    @pytest.mark.parametrize("bad_len", [0, 80, 82])
+    def test_is_valid_puzzle_rejects_wrong_length_list(self, bad_len):
+        with pytest.raises(ValueError, match="81"):
+            is_valid_puzzle([0] * bad_len)
+
+    def test_solve_sudoku_rejects_short_numpy_array(self):
+        with pytest.raises(ValueError, match="81"):
+            solve_sudoku(np.zeros(80, dtype=np.int64))
+
+    def test_is_valid_puzzle_rejects_short_numpy_array(self):
+        with pytest.raises(ValueError, match="81"):
+            is_valid_puzzle(np.zeros(80, dtype=np.int64))
+
+    def test_solve_sudoku_error_message_reports_actual_length(self):
+        """The ValueError must surface the offending length so the caller can
+        locate the upstream bug (regression test for the silent-82 case)."""
+        try:
+            solve_sudoku([0] * 82)
+        except ValueError as exc:
+            assert "82" in str(exc)
+        else:
+            pytest.fail("solve_sudoku accepted a malformed 82-cell puzzle without raising")
+
+    def test_valid_length_still_accepted(self):
+        """Regression: the guard must not reject a well-formed 81-cell puzzle."""
+        grid = _easy_puzzle()
+        # No exception expected; solver returns a solution or None (both OK here).
+        solve_sudoku(grid)
+        assert is_valid_puzzle(grid) in (True, False)
+


### PR DESCRIPTION
## Summary

Both public entry points in `scripts/sudoku/core/solvers.py` assumed the caller-supplied `puzzle_81` has exactly 81 cells but **never validated it**:

| Bad input | Before (no guard) | After |
|-----------|-------------------|-------|
| too short (`[]`, `[0]*80`, `np.zeros(80)`) | opaque `IndexError: list index out of range` / `index 80 is out of bounds for axis 0 with size 80` — no hint about the 81-cell contract | clear `ValueError: puzzle_81 must have exactly 81 cells (9x9 grid), got N` |
| too long (`[0]*82`) | **silently accepted** (`range(81)` ignores the extra cell), hiding upstream caller bugs | clear `ValueError` reporting the offending length |

This is part of the degenerate-input bug-class sweep (sisters: #7554 graph batch_size, #7563 generation n, #7566 run_tournament strategies, #7568 NormalFormGame ctor shapes).

## Scope (one subject per PR)

Focused on the **documented `(81,)` length contract**. Invalid digit values (>9, negative) already return `None` cleanly (not a crash) and are out of scope.

## Validation

- `python -m pytest scripts/tests/test_sudoku_core_solvers.py` → **37 passed** (25 existing + 12 new).
- Regression (callers of solvers): `test_sudoku_core_dataset.py` + `test_sudoku_core_generation.py` + `test_sudoku_core_evaluate.py` → **49 passed, 17 skipped** (skips = GPU/training).
- **G.1 non-vacuous proof** (`git stash` the prod guard, re-run): `11/12` new tests FAIL on unpatched code with the exact opaque errors above (`IndexError: index 80 is out of bounds`, `IndexError: list index out of range`, and the silent-82 acceptance); all 12 pass with the guard restored. The 12th test (`test_valid_length_still_accepted`) is a guard-doesn't-break-valid-input regression and correctly passes both ways.

## Diff stat

```
 scripts/sudoku/core/solvers.py            |  8 ++++++
 scripts/tests/test_sudoku_core_solvers.py | 47 +++++++++++++++++++++++++++++++
 2 files changed, 55 insertions(+)
```

Pure additions (no deletions on production code).

Co-Authored-By: Claude-Code <noreply@anthropic.com>