### PR TITLE
docs(#7422): archive orphan root docs/qc-comparative-backtests.md (superseded)

### DIFF
--- a/docs/archive/INDEX.md
+++ b/docs/archive/INDEX.md
@@ -26,6 +26,7 @@ Ces documents sont conserves pour reference mais ne sont plus actifs. Ne pas mod
 | handson-book-mapping.md | Cartographie du livre Hands-On AI Trading (Jared Broad) |
 | integration-roadmap.md | Roadmap integration |
 | qc-broken-strategies-audit.md | Audit strategies QuantConnect broken |
+| qc-comparative-backtests.md | Backtests comparatifs cohorte 1630-*-aligned (archivé 2026-07-20, superseded by docs/qc/qc-comparative-backtests.md, #7422) |
 | qc-league-ece.md | League ECE QuantConnect |
 | qc-stabilization-phase2.md | Stabilisation QC phase 2 |
 | slides-refonte-procedure.md | Procedure refonte slides |

--- a/docs/archive/qc-comparative-backtests.md
+++ b/docs/archive/qc-comparative-backtests.md
@@ -1,3 +1,19 @@
+<!--
+  ARCHIVÉ LE 2026-07-20 (issue #7422 — hygiène docs/ + racine).
+  RAISON : ce fichier était un orphelin à la racine de docs/ (0 lien entrant
+  vérifié : toutes les références au catalogue comparatif pointent vers le
+  canonique docs/qc/qc-comparative-backtests.md). Il entrait en collision de nom
+  avec ce canonique (792 lignes, 36 baselines vérifiées) tout en n'en étant qu'un
+  sous-ensemble (3 stratégies de la cohorte 1630-*-aligned, cycles c.332/c.336).
+  DONNÉES SUPERSEDÉES : les 3 stratégies (DualMomentum 0.350, RiskParity 0.361,
+  TrendFollowing) et les 3 backtests « en file » (AdaptiveConformalRisk,
+  PCAStatArbitrage, c2-regime) sont toutes couvertes dans le canonique
+  (Key-findings #38, #40, #39 + lignes table 237/239).
+  SUPERSEDED-BY : docs/qc/qc-comparative-backtests.md
+  PRÉSERVATION : fichier conservé tel quel (git mv, historique préservé),
+  conformément à « Consolider != Archiver » (CLAUDE.md global) et #7422
+  (« Jamais de delete aveugle »). Aucune donnée supprimée.
+-->
 # Backtests comparatifs QuantConnect — cohorte `1630-*-aligned`
 
 > Epic [#1621](../MyIA.AI.Notebooks/QuantConnect/) (Consolidation QC/Trading) · cohorte de stratégies `1630-*` alignées pour l'évaluation comparative.


### PR DESCRIPTION
## Summary

Advances **#7422** (docs/ hygiene + root freshness — user mandate 2026-07-19). The root-level `docs/qc-comparative-backtests.md` (48 lines, cohorte `1630-*-aligned`, cycle c.332/c.336) was a **misplaced orphan colliding by name** with the canonical `docs/qc/qc-comparative-backtests.md` (792 lines, 36 verified baselines).

## Firsthand verification (G.1, 3-way inbound-link grep on origin/main)

- **0 references link the root path** `docs/qc-comparative-backtests.md`.
- All 10+ references (QuantConnect READMEs, `QUICK_TOUR.md`, `qc_strategies_catalog.md`) point to the **subdir canonical** `docs/qc/qc-comparative-backtests.md` (via `../../docs/qc/qc-comparative-backtests.md`).
- The root file's data is a **subset already covered in the canonical**:
  - DualMomentum 0.350 → canonical table L239
  - RiskParity 0.361 → canonical table L237
  - TrendFollowing → covered (finding #18)
  - The 3 "queued" backtests (AdaptiveConformalRisk, PCAStatArbitrage, c2-regime) → all resolved in canonical Key-findings #38, #40, #39.

## Cure

- `git mv docs/qc-comparative-backtests.md → docs/archive/qc-comparative-backtests.md` (follows the established flat pattern, sibling to the `docs/archive/qc-strategies-status.md` precedent).
- **Preservation header** added (date, reason, superseded-by) per "Consolider != Archiver" and #7422 ("Jamais de delete aveugle"). **No content deleted** — git tracks the move as a rename (history preserved).
- `INDEX.md` row added.

## Validation

- **0 broken links**: post-move grep confirms nothing linked the old root path (orphan verified).
- **Catalogue byte-identical to main**: only `docs/archive/INDEX.md` + the moved file changed; 0 `CATALOG-STATUS` markers touched.
- **Diff stat**: `docs/{ => archive}/qc-comparative-backtests.md` (rename, +16 header lines) + `docs/archive/INDEX.md` (+1 row). 2 files, +17 insertions, 0 deletions of content.

## Scope

One subject (archive one orphan doc), atomic. Does NOT touch the canonical 792-line `docs/qc/qc-comparative-backtests.md` (po-2024's active QC work) → no collision. FR prose per `readme-french-first`.

See #7422 (partial — advances the docs/ root-freshness + orphan-cleanup grain; the broader bulk triage of docs/reference remains open).

Co-Authored-By: Claude-Code <noreply@anthropic.com>