### PR TITLE
fix(docs): correct broken archive link in docs/README.md (../archive/ -> archive/)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -62,7 +62,7 @@ Iteration history prover, intractable diagnosis, LLM endpoints.
 | [lean/llm-endpoints.md](lean/llm-endpoints.md) | Providers LLM du prover multi-agent (configuration, sans clés) |
 | [lean/prover_iteration_history.md](lean/prover_iteration_history.md) | Historique itération prover |
 | [lean/sota-2026-analysis.md](lean/sota-2026-analysis.md) | État de l'art preuve automatique Lean 4 (mai 2026) |
-| [lean/stable_marriage_intractable_diagnosis.md](../archive/lean-intractable-diagnosis/stable-marriage.md) | Diagnostic des preuves stable-marriage intractables (archivé c.696) |
+| [lean/stable_marriage_intractable_diagnosis.md](archive/lean-intractable-diagnosis/stable-marriage.md) | Diagnostic des preuves stable-marriage intractables (archivé c.696) |
 
 ## Curriculum (docs/curriculum/)
 


### PR DESCRIPTION
## What

One-line fix to a **broken relative link** in `docs/README.md:65` that was polluting the `check-links` CI baseline on `main`.

| | path |
|---|---|
| Before | `(../archive/lean-intractable-diagnosis/stable-marriage.md)` ❌ |
| After | `(archive/lean-intractable-diagnosis/stable-marriage.md)` ✅ |

## Root cause

`docs/README.md` lives **in** `docs/`, so a `../archive/...` link resolves to `<repo-root>/archive/...` (missing) instead of `docs/archive/...`. The `../` prefix was a mistake from #7538's archiving pass. The sibling links on lines 61-64 all use the correct `docs/`-relative convention (e.g. `lean/coordinator-workflow.md`, no `../`) — line 65 was the lone outlier.

The target `docs/archive/lean-intractable-diagnosis/stable-marriage.md` **exists** (verified via `git ls-tree origin/main` + on disk). Only the link prefix was wrong.

## Verification (G.1, firsthand)

```
$ python scripts/check_docs_links.py --check   # on origin/main, BEFORE fix
REGRESSION: 1 new broken link(s):
  docs/README.md:65 -> ../archive/lean-intractable-diagnosis/stable-marriage.md

$ python scripts/check_docs_links.py --check   # AFTER fix
OK: No new broken links. (0 pre-existing, 4014 total)
```

Confirmed **pre-existing main regression** (reproduced on `origin/main`'s `docs/README.md`) — not introduced by any PR's content. The 5 other `../archive/` links in docs/ subdirs (`docs/lean/`, `docs/qc/`, `docs/reference/`) resolve correctly from their subdirectories and are left untouched.

## Impact

This broken link was the sole failing check on PR #7573 (`check-links` REGRESSION). It is a baseline pollutant — any future docs/ PR inherits it. Fixing it on main clears the baseline for everyone and unblocks #7573 (after #7573 rebases onto this).

## Scope

- 1 file, 1 line. Atomique (one-subject-per-PR).
- Markdown-only, no execution, no catalogue touch (byte-identical catalogue).
- See #7538 (archiving that introduced the wrong prefix). Main regression fix (no issue closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)