### PR TITLE
feat(lean,i18n): add mathlib_examples_en.lean EN sibling (See #4980)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/examples/mathlib_examples_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/examples/mathlib_examples_en.lean
@@ -1,0 +1,104 @@
+/-
+  Lean Examples - Mathlib Usage (EN sibling)
+
+  This file contains Mathlib4 usage examples
+  corresponding to the Lean-6 notebook.
+
+  NOTE: These examples require Mathlib to be installed.
+  Without Mathlib, this file will not compile.
+
+  English sibling of mathlib_examples.lean (i18n #4980): docstrings and
+  comments translated to English; theorems, definitions, tactics, and
+  variables are byte-identical to the French original.
+-/
+
+-- Uncomment the imports if Mathlib is installed:
+-- import Mathlib.Tactic
+-- import Mathlib.Data.Nat.Prime
+-- import Mathlib.Algebra.Ring.Basic
+
+-- ============================================================
+-- Examples without Mathlib (work with base Lean)
+-- ============================================================
+
+-- omega : linear arithmetic
+theorem omega_example_1 (n m : Nat) (h : n < m) : n + 1 <= m := by
+  omega
+
+theorem omega_example_2 (a b c : Int) (h1 : a + b = c) (h2 : a - b = 0) : 2 * a = c := by
+  omega
+
+-- decide : decidable propositions
+theorem decide_example_1 : 7 * 8 = 56 := by rfl
+theorem decide_example_2 : 100 > 50 := by decide
+
+-- ============================================================
+-- Examples with Mathlib (uncomment if Mathlib is available)
+-- ============================================================
+
+/-
+-- ring : polynomial algebra
+example (a b : Int) : (a + b)^2 = a^2 + 2*a*b + b^2 := by ring
+example (a b : Int) : a^2 - b^2 = (a + b) * (a - b) := by ring
+example (x y z : Int) : (x + y + z)^2 = x^2 + y^2 + z^2 + 2*x*y + 2*x*z + 2*y*z := by ring
+
+-- linarith : linear inequalities
+example (x : Int) (h : x > 5) : x >= 5 := by linarith
+example (x y : Int) (h1 : x <= y) (h2 : y <= x + 3) : y - x <= 3 := by linarith
+
+-- norm_num : numerical computations
+example : (2 : Nat) + 2 = 4 := by norm_num
+example : (123 : Nat) * 456 = 56088 := by norm_num
+example : Nat.Prime 17 := by norm_num
+
+-- field_simp : simplification in fields
+example (a b : Rat) (hb : b ≠ 0) : a / b * b = a := by field_simp
+-/
+
+-- ============================================================
+-- Algebraic structures (Mathlib concepts without import)
+-- ============================================================
+
+-- Simplified definition of a monoid
+class MyMonoid (M : Type) where
+  one : M
+  mul : M -> M -> M
+  one_mul : forall a : M, mul one a = a
+  mul_one : forall a : M, mul a one = a
+  mul_assoc : forall a b c : M, mul (mul a b) c = mul a (mul b c)
+
+-- Nat is an additive monoid
+instance : MyMonoid Nat where
+  one := 0
+  mul := Nat.add
+  one_mul := Nat.zero_add
+  mul_one := Nat.add_zero
+  mul_assoc := Nat.add_assoc
+
+-- ============================================================
+-- Number theory (basic concepts)
+-- ============================================================
+
+-- Definition of a prime number (simplified)
+def myPrime (n : Nat) : Prop :=
+  n > 1 /\ forall d : Nat, d > 0 -> d < n -> n % d = 0 -> d = 1
+
+-- 2 is prime
+theorem two_is_prime : myPrime 2 := by
+  constructor
+  . decide
+  . intro d hd1 hd2 hdiv
+    omega
+
+-- ============================================================
+-- Theorem search
+-- ============================================================
+
+-- Useful commands for exploring Mathlib:
+-- #check Nat.add_comm
+-- #check Nat.mul_comm
+-- #print Nat.add_assoc
+
+-- Search with exact? and apply?:
+-- example (n : Nat) : n + 0 = n := by exact?
+-- example (n m : Nat) : n <= n + m := by apply?


### PR DESCRIPTION
## Summary

Adds the second English sibling for a standalone Lean example — `SymbolicAI/Lean/examples/mathlib_examples_en.lean`, EN sibling of `mathlib_examples.lean` (EPIC **#4980**, i18n FR/EN). Continues the rollout started by PR #7564 (`quantifiers_en.lean`).

`mathlib_examples.lean` had **no** `_en` sibling; it is a Mathlib tactic showcase (`omega` / `decide` / `norm_num` / `ring` / `linarith`) corresponding to the Lean-6 notebook, referenced in `examples/README.md` + `examples/README.en.md`.

This is a **pure i18n addition** (one new file, no source change to the FR original).

## i18n #4980 byte-identity

FR and EN differ **only** in docstrings `/-- ... -/` and comments `-- ...`. The **theorems, definitions, tactics, notation, and variables are byte-identical** — verified by stripping all comments and diffing the pure code (25 lines IDENTICAL).

## Verification (lean-merge-discipline, firsthand, G.1)

```
$ lean mathlib_examples_en.lean   # standalone, Mathlib imports commented out
(run 1) exit=0  0 errors
(run 2) exit=0  0 errors         # consistent (not a flake)

$ <comment-stripped diff FR vs EN>
25 pure-code lines IDENTICAL

$ grep -c sorry mathlib_examples_en.lean
0
$ tr -cd '\r' < mathlib_examples_en.lean | wc -c
0                               # LF, no CRLF
```

The example is **standalone** (no `lakefile.lean` enclosing it, no active `import` lines — Mathlib imports are explicitly commented out per the FR original) and **Mathlib-free** when compiled standalone, so it verifies via `lean` directly in seconds — no per-lake Mathlib build wall.

## Why this example

`examples/mathlib_examples.lean` was chosen after firsthand compile check of all 5 standalone examples (G.1):

- `quantifiers.lean` — clean compile, consistent → sibling delivered in #7564 (MERGED).
- `mathlib_examples.lean` — clean compile, consistent → sibling delivered here (PR open).
- `basic_logic.lean` — redeclares Prelude names (`and_comm`/`and_assoc`/`or_comm`); standalone compile fails identically in FR and EN (byte-identity holds, but a reviewer sees errors) → weak target.
- `tactics_demo.lean` / `llm_assisted_proof.lean` — `simp [Nat.add_succ, ...]` hits `maxRecDepth`; standalone compile fails consistently in FR and EN → weak target.

So `mathlib_examples_en.lean` is the **cleanest remaining verifiable sibling** among the standalone examples.

## Note on the Lean CI matrix

The dedicated CI workflow (`.github/workflows/lean-mathlib-examples.yml`) watches `MyIA.AI.Notebooks/SymbolicAI/Lean/mathlib_examples/**.lean` — not `examples/mathlib_examples.lean` (the path of the FR + new EN file). The CI is therefore not triggered by this PR, consistent with the FR file's history (no CI run for the standalone example). A separate PR updating the path-glob to cover `examples/mathlib_examples{,_en}.lean` is out of scope here (would also build Mathlib if anyone un-comments the imports — heavy CI cost).

## Scope

1 file, +104/-0 (purely additive — **zero source changes** to the FR original). Catalog byte-identical to `origin/main` (HARD 1). CRLF = 0. Single subject.

`See #4980` (partial — second example sibling; Epic #4980 remains open: standalone examples are FR-first course material by default, `_en` siblings are optional for EN-audience support).

<!-- codex-meta po-2026 machine="myia-po-2026" lane="CoursIA" -->
