### PR TITLE
fix(qc): word-boundary-safe relabel — stop corrupting multi-digit exercise headers

### DIFF
--- a/scripts/relabel_qc_exercises.py
+++ b/scripts/relabel_qc_exercises.py
@@ -60,23 +60,23 @@ def get_exercice_num(cell_source) -> int | None:
 def _replace_in_source(source, old_n: int, new_n: int):
     ph = f"__RL_{new_n}__"
     prefixes = ["Exercice", "Exemple guide"]
+    # Word-boundary-safe match: the trailing `(?!\d)` requires the number to be
+    # followed by a non-digit, so renaming "Exercice 1" -> "Exercice 9" leaves
+    # "Exercice 12" intact. The naive `str.replace("Exercice 1", ...)` matched
+    # the "1" prefix of "12" and silently corrupted "Exercice 12" -> "Exercice 92".
+    label_re = re.compile(
+        r"(" + "|".join(re.escape(pf) for pf in prefixes) + rf") {old_n}(?!\d)"
+    )
 
-    if isinstance(source, str):
-        text = source
-        for pf in prefixes:
-            text = text.replace(f"{pf} {old_n}", f"{pf} {ph}")
+    def _swap(text: str) -> str:
+        text = label_re.sub(lambda m: f"{m.group(1)} {ph}", text)
         for pf in prefixes:
             text = text.replace(f"{pf} {ph}", f"{pf} {new_n}")
         return text
-    else:
-        result = []
-        for line in source:
-            for pf in prefixes:
-                line = line.replace(f"{pf} {old_n}", f"{pf} {ph}")
-            for pf in prefixes:
-                line = line.replace(f"{pf} {ph}", f"{pf} {new_n}")
-            result.append(line)
-        return result
+
+    if isinstance(source, str):
+        return _swap(source)
+    return [_swap(line) for line in source]
 
 
 def audit_qc():

--- a/scripts/tests/test_relabel_qc_exercises.py
+++ b/scripts/tests/test_relabel_qc_exercises.py
@@ -137,6 +137,50 @@ def test_replace_only_touches_target_number():
     assert out == "Exercice 1 then Exercice 7"
 
 
+# Multi-digit boundary regression (was a silent corruption: the naive
+# str.replace matched the "1" prefix of "12", turning "Exercice 12" into
+# "Exercice 92" when relabeling exercise 1 -> 9).
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_replace_multi_digit_not_corrupted_by_single_digit_old():
+    """Renaming 1->9 must leave 'Exercice 12' intact (was corrupted to
+    'Exercice 92' by the prefix-matching str.replace)."""
+    src = "### Exercice 1\nSee Exercice 12 for context."
+    out = _replace_in_source(src, old_n=1, new_n=9)
+    assert out == "### Exercice 9\nSee Exercice 12 for context."
+
+
+def test_replace_multi_digit_not_corrupted_when_relabeling_higher_digit():
+    """Renaming 3->1 must also leave 'Exercice 30' intact (the naive
+    str.replace('Exercice 3', ...) matched the '3' in '30')."""
+    src = "Exercice 3 then Exercice 30"
+    out = _replace_in_source(src, old_n=3, new_n=1)
+    assert out == "Exercice 1 then Exercice 30"
+
+
+def test_replace_multi_digit_old_n_matched_correctly():
+    """A multi-digit old_n is matched as a whole (relabeling 12 -> 5 touches
+    'Exercice 12' but not 'Exercice 1' nor 'Exercice 120')."""
+    src = "Exercice 1, Exercice 12, Exercice 120"
+    out = _replace_in_source(src, old_n=12, new_n=5)
+    assert out == "Exercice 1, Exercice 5, Exercice 120"
+
+
+def test_replace_multi_digit_list_source_not_corrupted():
+    """The boundary guard applies on the per-line list path too."""
+    src = ["### Exercice 1\n", "Refs Exercice 12.\n"]
+    out = _replace_in_source(src, old_n=1, new_n=9)
+    assert "".join(out) == "### Exercice 9\nRefs Exercice 12.\n"
+
+
+def test_replace_exemple_guide_multi_digit_not_corrupted():
+    """The 'Exemple guide' label gets the same boundary protection."""
+    src = "Exemple guide 1 and Exemple guide 12"
+    out = _replace_in_source(src, old_n=1, new_n=2)
+    assert out == "Exemple guide 2 and Exemple guide 12"
+
+
 # ──────────────────────────────────────────────────────────────────────────
 # RELABEL_MAP sanity (the hand-curated target table)
 # ──────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes a **silent data-corruption bug** in `scripts/relabel_qc_exercises.py:_replace_in_source`. The function used `str.replace(f"{pf} {old_n}", ...)`, which matched the numeric prefix of a multi-digit header:

| Relabel | Cell content | Before (bug) | After |
|---------|--------------|--------------|-------|
| 1 → 9 | `Exercice 1` + `Exercice 12` | `Exercice 9` + **`Exercice 92`** ❌ | `Exercice 9` + `Exercice 12` ✓ |
| 3 → 1 | `Exercice 3` + `Exercice 30` | `Exercice 1` + **`Exercice 10`** ❌ | `Exercice 1` + `Exercice 30` ✓ |
| 12 → 5 | `Exercice 1, 12, 120` | (also mis-matched) | `Exercice 1, 5, 120` ✓ |

The naive `str.replace("Exercice 1", ...)` matched the "1" inside "12". The fix compiles a regex with a `(?!\d)` lookahead so only a whole-number match moves.

## Salvage context (coordinator greenlight)

The latent bug was documented as a **strict xfail** in #7558 (closed-without-merge as duplicate of #7559, which had broader test coverage on the same file). The coordinator salvaged the xfail:

> *"`test_multidigit_boundary_bug` documents a VRAI bug latent multi-digit dans `_replace_in_source` — plus de valeur en le transformant en **PR de fix** (correction + test qui passe) qu'en test dupliqué. **Si le bug reproduit encore sur main post-#7559, file le fix : c'est de la substance, pas de la garniture.**"*

G.1 verified firsthand: the bug **still reproduces on current main** (post-#7559) — reproduced `"### Exercice 1\nSee Exercice 12..."` → `"Exercice 92"`. Hence this fix.

## Fix

Replace the first-pass `str.replace` with a compiled regex requiring the number to be followed by a non-digit:
```python
label_re = re.compile(
    r"(" + "|".join(re.escape(pf) for pf in prefixes) + rf") {old_n}(?!\d)"
)
```
The two-pass placeholder swap (`old → __RL_new__ → new`, which prevents chained rewrites when old_n and new_n overlap) is **preserved** — only the first pass gains the boundary guard. Both the string and list code paths now share a single `_swap` helper (removed the duplicated loop body).

## Validation

- `python -m pytest scripts/tests/test_relabel_qc_exercises.py` → **24 passed** (19 existing + 5 new multi-digit boundary tests).
- **G.1 non-vacuous proof** (`git stash` the prod fix, re-run `-k multi_digit`): all 5 new tests **FAIL** showing the exact corruption (`"Exercice 92"`, `"Exemple guide 22"`); with the fix restored, all 24 pass.
- Caller regression: dry-run / disk-write / RELABEL_MAP-sanity tests still pass (0 regression).

## Diff stat

```
 scripts/relabel_qc_exercises.py            | 28 +++++++++----------
 scripts/tests/test_relabel_qc_exercises.py | 44 ++++++++++++++++++++++++++++++
 2 files changed, 58 insertions(+), 14 deletions(-)
```

Net refactor: +44 tests, prod is −14/+14 (the `_swap` extraction removes the duplicated str/list loop body). Pure additions in tests; the prod change is a same-size refactor + boundary guard.

One subject (fix one latent bug + its regression tests), atomic. CPU-only, no docs/ touched (check-links n/a).

See #7558

Co-Authored-By: Claude-Code <noreply@anthropic.com>