### PR TITLE
fix(search,#7463): guard draw_search_tree against degenerate root=None/max_depth<=0 (rebased)

### DIFF
--- a/MyIA.AI.Notebooks/Search/search_helpers.py
+++ b/MyIA.AI.Notebooks/Search/search_helpers.py
@@ -41,7 +41,25 @@ def draw_search_tree(root: SearchTreeNode, max_depth: int = 5,
                      title: str = "Arbre de recherche",
                      highlight_path: bool = True,
                      figsize: tuple = (14, 8)):
-    """Dessine un arbre de recherche avec matplotlib."""
+    """Dessine un arbre de recherche avec matplotlib.
+
+    Raises:
+        TypeError: si ``root`` n'est pas un ``SearchTreeNode``.
+        ValueError: si ``max_depth`` n'est pas strictement positif.
+            (Avec ``max_depth <= 0``, la position verticale devient
+            nulle et la legende / les aretes degenerent -- on refuse
+            plutot que de rendre un graphe deroutant.)
+    """
+    if not isinstance(root, SearchTreeNode):
+        raise TypeError(
+            f"root must be a SearchTreeNode instance, got "
+            f"{type(root).__name__} (None or other type)"
+        )
+    if not isinstance(max_depth, int) or max_depth <= 0:
+        raise ValueError(
+            f"max_depth must be a strictly positive integer, got {max_depth!r}"
+        )
+
     fig, ax = plt.subplots(1, 1, figsize=figsize)
     ax.set_title(title, fontsize=14, fontweight='bold')
     ax.axis('off')

--- a/MyIA.AI.Notebooks/Search/tests/test_search_helpers.py
+++ b/MyIA.AI.Notebooks/Search/tests/test_search_helpers.py
@@ -220,3 +220,63 @@ class TestDrawCspGraphDegenerateInputGuard:
         """An empty ``constraints`` list is valid (no edges)."""
         fig = sh.draw_csp_graph(["A", "B"], {}, [])
         assert fig is not None
+
+
+# --- draw_search_tree degenerate-input guard (c.703) -----------------------
+
+class TestDrawSearchTreeDegenerateInputGuard:
+    """Garde-fou d'entree pour ``draw_search_tree``.
+
+    Reproduit le pattern robusteur c.702 sur ``wfc_cpsat.run_all`` /
+    ``wfc_cpsat.adjacency_violations`` : refuser explicitement les
+    arguments degeneres plutot que de laisser une ``AttributeError``
+    opaque (``root=None`` -> ``'NoneType' object has no attribute
+    'children'``) ou un rendu matplotlib pathologique (``max_depth<=0``
+    -> y=1.0 partout, aretes confondues avec la legende).
+    """
+
+    def test_root_none_raises_typeerror(self):
+        # L'AttributeError d'origine etait silencieuse et confondait
+        # l'appelant avec un bug dans son arbre -- on la remplace par
+        # un TypeError explicite qui pointe la cause reelle.
+        with pytest.raises(TypeError, match="root must be a SearchTreeNode"):
+            sh.draw_search_tree(None)
+
+    def test_root_non_node_raises_typeerror(self):
+        # Tout objet qui n'est pas un SearchTreeNode est rejete avec
+        # le meme message -- la verification se fait sur le type, pas
+        # sur la verite/falsete (un SearchTreeNode est toujours truthy
+        # en pratique, mais on ne veut pas dependre de __bool__).
+        with pytest.raises(TypeError, match="got str"):
+            sh.draw_search_tree("not_a_node")
+
+    def test_root_dict_raises_typeerror(self):
+        with pytest.raises(TypeError, match="got dict"):
+            sh.draw_search_tree({"state": "A"})
+
+    def test_max_depth_zero_raises_valueerror(self):
+        # max_depth=0 -> toutes les positions y=1.0, aretes illisibles.
+        with pytest.raises(ValueError, match="max_depth must be a strictly positive"):
+            sh.draw_search_tree(sh.SearchTreeNode("root"), max_depth=0)
+
+    def test_max_depth_negative_raises_valueerror(self):
+        with pytest.raises(ValueError, match="max_depth must be a strictly positive"):
+            sh.draw_search_tree(sh.SearchTreeNode("root"), max_depth=-5)
+
+    def test_max_depth_non_int_raises_valueerror(self):
+        # 1.5 est un float valide ; on exige un int strict.
+        with pytest.raises(ValueError, match="max_depth must be a strictly positive"):
+            sh.draw_search_tree(sh.SearchTreeNode("root"), max_depth=1.5)
+
+    def test_max_depth_one_still_renders(self):
+        # Sanity check : l'invariant "max_depth>=1 OK" doit etre preserve.
+        fig = sh.draw_search_tree(sh.SearchTreeNode("root"), max_depth=1)
+        assert fig is not None
+
+    def test_valid_root_unaffected(self):
+        # Pas de regression sur l'appel normal (defaut max_depth=5).
+        root = sh.SearchTreeNode("root")
+        root.add_child("a")
+        root.add_child("b")
+        fig = sh.draw_search_tree(root)
+        assert fig is not None


### PR DESCRIPTION
Rebase propre de #7557 (était DIRTY/CONFLICTING post merges Search de ce cycle). Diff = **uniquement** le guard + ses tests, appliqués sur `origin/main` courant (`348fc1733`).

## Scope (degenerate-input bug-class, see #7463)
- `draw_search_tree(root=None)` levait `AttributeError` opaque (`'NoneType' object has no attribute 'children'`) → désormais `TypeError` actionnable depuis la boundary.
- `draw_search_tree(root, max_depth<=0)` rendait un graphe dégénéré (toutes positions y=1.0, arêtes confondues avec la légende) → désormais `ValueError`.
- `max_depth` non-int (ex `1.5`) → `ValueError` (on exige un int strict).

## Conflit de rebase — résolu en KEEP BOTH
Le fichier de test avait reçu une classe d'un MERGE de ce cycle (`TestDrawCspGraphDegenerateInputGuard`, guards `draw_csp_graph`) ET ma classe (`TestDrawSearchTreeDegenerateInputGuard`). Les deux testent des fonctions distinctes → **les deux conservées**, chacune avec son assert final propre.

## G.1 non-vacuous proof (handsfirst)
- Patché : `pytest tests/test_search_helpers.py` → **35 passed** (27 pré-existants + 8 nouveaux).
- Dé-patché (`git checkout origin/main -- search_helpers.py`) : `pytest ::TestDrawSearchTreeDegenerateInputGuard` → **6 failed, 2 passed**. Les 6 tests de guard FAIL avec `DID NOT RAISE` (les 2 qui passent = happy-path `test_max_depth_one_still_renders` / `test_valid_root_unaffected`, corrects dans les deux cas).
- Restore depuis HEAD → 8 passed. Le guard est bien ce qui fait passer les tests.

## Diff
```
 MyIA.AI.Notebooks/Search/search_helpers.py         | 20 +++++++-
 .../Search/tests/test_search_helpers.py            | 60 ++++++++++++++++++++++
 2 files changed, 79 insertions(+), 1 deletion(-)
```

See #7463 (epic degenerate-input, non entièrement résolu par un seul guard). Supersède #7557 (DIRTY, à fermer au merge de celle-ci).