### PR TITLE
feat(sudoku,#3801): demonstrate CP-SAT optimization (Maximize/Minimize) — Prong-B

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb
@@ -61,8 +61,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
    "id": "31f3025f-f1c7-4b39-bbcc-fe29c9da0ea2",
+   "execution_count": 1,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-06-02T21:28:43.686089Z",
@@ -110,8 +110,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
    "id": "ce562fc7",
+   "execution_count": 2,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-06-02T21:28:49.454068Z",
@@ -188,8 +188,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
    "id": "90syyx3imf8",
+   "execution_count": 3,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-06-02T21:28:56.427948Z",
@@ -254,8 +254,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
    "id": "b26eb748",
+   "execution_count": 4,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-06-02T21:28:56.466407Z",
@@ -366,8 +366,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
    "id": "5ca77913",
+   "execution_count": 5,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-06-02T21:28:56.498926Z",
@@ -477,8 +477,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
    "id": "d8a967af",
+   "execution_count": 6,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-06-02T21:28:56.525661Z",
@@ -631,8 +631,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
    "id": "bdea3db5",
+   "execution_count": 7,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-06-02T21:28:56.652636Z",
@@ -756,6 +756,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "cell-d4e7f3f8",
    "metadata": {},
    "source": [
     "## Exercice : Ajouter une contrainte d'anti-symetrie\n",
@@ -767,11 +768,11 @@
     "\n",
     "**Indice**\n",
     "Utilisez `model.Add(cells[0][i] == i+1)` pour chaque colonne i de la ligne 0.\n"
-   ],
-   "id": "cell-d4e7f3f8"
+   ]
   },
   {
    "cell_type": "code",
+   "id": "cell-d8057ef5",
    "execution_count": 1,
    "metadata": {},
    "outputs": [
@@ -790,13 +791,12 @@
     "    # que la premiere ligne doit etre (1,2,3,...,9)\n",
     "    result = {}  # TODO etudiant\n",
     "    return result\n"
-   ],
-   "id": "cell-d8057ef5"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
    "id": "322xetmzp7c",
+   "execution_count": 8,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-06-02T21:28:56.706130Z",
@@ -925,8 +925,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
    "id": "obch45ox3ca",
+   "execution_count": 9,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-06-02T21:28:57.163098Z",
@@ -1058,8 +1058,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
    "id": "d32b39fe",
+   "execution_count": 10,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-06-02T21:28:57.320734Z",
@@ -1131,6 +1131,177 @@
     "                print(f\"    {row}\")\n",
     "    else:\n",
     "        print(f\"  N={n}: Aucune solution trouvee\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "95932fa0cba0",
+   "metadata": {},
+   "source": [
+    "## Exemple : Optimisation avec CP-SAT (au-dela de la satisfaction)\n",
+    "\n",
+    "Jusqu'ici, CP-SAT a resolu des problemes de **satisfaction** : trouver UNE\n",
+    "solution realisable (une grille de Sudoku valide, N-Reines non-conflictuelles).\n",
+    "\n",
+    "La puissance distinctive de CP-SAT est l'**optimisation** : parmi toutes les\n",
+    "solutions realisables, trouver celle qui **maximise** (ou **minimise**) un\n",
+    "objectif -- `model.Maximize(...)` / `model.Minimize(...)`. C'est ce qui fait de\n",
+    "CP-SAT le moteur d'optimisation combinatoire de reference (ordonnancement,\n",
+    "tournees, packing, allocation de ressources).\n",
+    "\n",
+    "**Demonstration** : un « carre latin a bonus » -- chaque cellule (i, j) offre un\n",
+    "*reward* dependant de la valeur placee (tableau `reward[i][j][v]`). Parmi tous\n",
+    "les carres latins 5x5 valides, CP-SAT trouve celui qui **maximise le reward\n",
+    "total**. Le solveur renvoie le statut `OPTIMAL` (preuve qu'aucune meilleure\n",
+    "solution n'existe), pas seulement `FEASIBLE`.\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "4ef6e28e669f",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Statut: OPTIMAL (status=CpSolverStatus.OPTIMAL)\nReward optimal maximise: 178.0\nGrille optimale (carre latin 5x5 max-reward):\n   [3, 2, 1, 5, 4]\n   [2, 1, 5, 4, 3]\n   [1, 4, 2, 3, 5]\n   [5, 3, 4, 1, 2]\n   [4, 5, 3, 2, 1]\n"
+    }
+   ],
+   "source": [
+    "from ortools.sat.python import cp_model\n",
+    "\n",
+    "\n",
+    "def solve_max_reward_latin_square(n: int = 5, reward=None, seed: int = 42):\n",
+    "    \"\"\"Carre latin NxN maximisant le reward total (demontre model.Maximize).\n",
+    "\n",
+    "    CP-SAT ne se contente pas de trouver une solution realisable : il sait\n",
+    "    OPTIMISER un objectif. Chaque cellule (i, j) offre un reward dependant de\n",
+    "    la valeur placee ; parmi toutes les grilles valides, on cherche celle qui\n",
+    "    MAXIMISE le reward total.\n",
+    "    \"\"\"\n",
+    "    import random\n",
+    "    rng = random.Random(seed)\n",
+    "    if reward is None:\n",
+    "        reward = [[[rng.randint(0, 10) for _ in range(n + 1)] for _ in range(n)] for _ in range(n)]\n",
+    "\n",
+    "    model = cp_model.CpModel()\n",
+    "    x = {}\n",
+    "    for i in range(n):\n",
+    "        for j in range(n):\n",
+    "            for v in range(1, n + 1):\n",
+    "                x[i, j, v] = model.NewBoolVar(f\"x_{i}_{j}_{v}\")\n",
+    "            model.AddExactlyOne([x[i, j, v] for v in range(1, n + 1)])\n",
+    "        for v in range(1, n + 1):\n",
+    "            model.AddExactlyOne([x[i, j, v] for j in range(n)])\n",
+    "    for j in range(n):\n",
+    "        for v in range(1, n + 1):\n",
+    "            model.AddExactlyOne([x[i, j, v] for i in range(n)])\n",
+    "\n",
+    "    model.Maximize(\n",
+    "        sum(reward[i][j][v] * x[i, j, v]\n",
+    "            for i in range(n) for j in range(n) for v in range(1, n + 1))\n",
+    "    )\n",
+    "\n",
+    "    solver = cp_model.CpSolver()\n",
+    "    status = solver.Solve(model)\n",
+    "    if status not in (cp_model.OPTIMAL, cp_model.FEASIBLE):\n",
+    "        return None, None, status\n",
+    "    grid = [[0] * n for _ in range(n)]\n",
+    "    for i in range(n):\n",
+    "        for j in range(n):\n",
+    "            for v in range(1, n + 1):\n",
+    "                if solver.Value(x[i, j, v]):\n",
+    "                    grid[i][j] = v\n",
+    "    return grid, solver.ObjectiveValue(), status\n",
+    "\n",
+    "\n",
+    "grid, obj, status = solve_max_reward_latin_square(n=5)\n",
+    "status_name = {cp_model.OPTIMAL: \"OPTIMAL\", cp_model.FEASIBLE: \"FEASIBLE\",\n",
+    "               cp_model.INFEASIBLE: \"INFEASIBLE\", cp_model.UNKNOWN: \"UNKNOWN\"}.get(status, str(status))\n",
+    "print(f\"Statut: {status_name} (status={status})\")\n",
+    "print(f\"Reward optimal maximise: {obj}\")\n",
+    "print(\"Grille optimale (carre latin 5x5 max-reward):\")\n",
+    "for row in grid:\n",
+    "    print(\"  \", row)\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "61ba06857f42",
+   "metadata": {},
+   "source": [
+    "### Exercice : Minimiser un cout avec CP-SAT\n",
+    "\n",
+    "Miroir de l'exemple precedent : meme espace de carres latins realisables, mais\n",
+    "on **minimise** une fonction de cout (somme des valeurs sur la diagonale\n",
+    "principale) au lieu de maximiser un reward. Prouve que CP-SAT optimise dans les\n",
+    "deux sens -- `model.Maximize(...)` <-> `model.Minimize(...)`.\n",
+    "\n",
+    "**Question** : quel est le cout diagonal minimal d'un carre latin 5x5 ? (la\n",
+    "diagonale vaut `grid[i][i]` pour `i` dans `0..n-1`)\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "edd6d738b7e2",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Statut: OPTIMAL (status=CpSolverStatus.OPTIMAL)\nCout diagonal minimal: 5.0\nVerification (somme diagonale calculee): 5\nGrille optimale (carre latin 5x5 min-diagonale):\n   [1, 3, 5, 4, 2]\n   [2, 1, 4, 3, 5]\n   [3, 2, 1, 5, 4]\n   [4, 5, 2, 1, 3]\n   [5, 4, 3, 2, 1]\nDiagonale minimisee: [1, 1, 1, 1, 1]\n"
+    }
+   ],
+   "source": [
+    "from ortools.sat.python import cp_model\n",
+    "\n",
+    "\n",
+    "def solve_min_diagonal_latin_square(n: int = 5):\n",
+    "    \"\"\"Carre latin NxN MINIMISANT la somme des valeurs sur la diagonale.\n",
+    "\n",
+    "    Miroir de solve_max_reward_latin_square : meme espace de solutions\n",
+    "    realisables, mais on minimise une fonction de cout (somme diagonale) au\n",
+    "    lieu de maximiser un reward. Prouve que CP-SAT optimise dans les deux sens.\n",
+    "    \"\"\"\n",
+    "    model = cp_model.CpModel()\n",
+    "    # val[i][j] = valeur de la cellule (domaine 1..n)\n",
+    "    val = [[model.NewIntVar(1, n, f\"v_{i}_{j}\") for j in range(n)] for i in range(n)]\n",
+    "    # contraintes de carre latin : chaque valeur une fois par ligne et par colonne\n",
+    "    for i in range(n):\n",
+    "        model.AddAllDifferent(val[i])\n",
+    "        model.AddAllDifferent([val[i][j] for j in range(n)])\n",
+    "    for j in range(n):\n",
+    "        model.AddAllDifferent([val[i][j] for i in range(n)])\n",
+    "\n",
+    "    # OBJECTIF : minimiser la somme des valeurs sur la diagonale principale\n",
+    "    diagonale = [val[i][i] for i in range(n)]\n",
+    "    model.Minimize(sum(diagonale))\n",
+    "\n",
+    "    solver = cp_model.CpSolver()\n",
+    "    status = solver.Solve(model)\n",
+    "    if status not in (cp_model.OPTIMAL, cp_model.FEASIBLE):\n",
+    "        return None, None, status\n",
+    "    grid = [[solver.Value(val[i][j]) for j in range(n)] for i in range(n)]\n",
+    "    return grid, solver.ObjectiveValue(), status\n",
+    "\n",
+    "\n",
+    "grid, obj, status = solve_min_diagonal_latin_square(n=5)\n",
+    "status_name = {cp_model.OPTIMAL: \"OPTIMAL\", cp_model.FEASIBLE: \"FEASIBLE\",\n",
+    "               cp_model.INFEASIBLE: \"INFEASIBLE\", cp_model.UNKNOWN: \"UNKNOWN\"}.get(status, str(status))\n",
+    "somme_diag = sum(grid[i][i] for i in range(5))\n",
+    "print(f\"Statut: {status_name} (status={status})\")\n",
+    "print(f\"Cout diagonal minimal: {obj}\")\n",
+    "print(f\"Verification (somme diagonale calculee): {somme_diag}\")\n",
+    "print(\"Grille optimale (carre latin 5x5 min-diagonale):\")\n",
+    "for row in grid:\n",
+    "    print(\"  \", row)\n",
+    "print(\"Diagonale minimisee:\", [grid[i][i] for i in range(5)])\n",
+    ""
    ]
   },
   {


### PR DESCRIPTION
## Context — EPIC #3801 Prong-B finding

Firsthand forensic of my native Sudoku turf: the series (19 notebooks across all solvers — OR-Tools, Z3, Choco, Backtracking, Genetic, etc.) demonstrates CP-SAT **only on the SATISFACTION problem**. The solver's signature **OPTIMIZATION** capability (`model.Maximize` / `model.Minimize`) is **never exercised anywhere** in the entire series.

Verified firsthand:
\`\`\`
grep -E '\.(Minimize|Maximize)\(' across all Sudoku notebooks → 0 matches
\`\`\`

This is exactly the Prong-B gap the mandate flags (*msg3: « proposer des problèmes additionnels plus complexes pour faire valoir toutes les capacités des moteurs externes »*). CP-SAT is the industrial optimization engine (scheduling, routing, packing); showing it only on satisfaction undersells it.

## Scope — 4 cells added to Sudoku-10-ORTools-Python

Inserted before the final benchmark interpretation. **Existing 25 cells fully preserved** (source byte-identical, execution_count + outputs intact — verified cell-by-cell vs origin/main).

1. **Intro markdown** — explains CP-SAT optimization vs satisfaction, the OPTIMAL vs FEASIBLE distinction.
2. **Worked example** — \`solve_max_reward_latin_square(5)\`: weighted « carré latin à bonus » that **maximizes** total reward. Demonstrates \`model.Maximize(...)\` + \`OPTIMAL\` status. Self-contained (own \`cp_model\` import, bounded 5×5).
3. **Exercise markdown** — mirror problem (minimize diagonal cost).
4. **Worked solution** — \`solve_min_diagonal_latin_square(5)\`: \`model.Minimize(...)\`, \`OPTIMAL\` diagonal cost 5. Shows optimization in both directions.

## Validation (C.2 / H.1 — real execution, not structural-only)

- **Papermill end-to-end** from \`MyIA.AI.Notebooks/Sudoku\` dir (cwd = Puzzles parent): **SUCCESS, 0 errors**. Both new cells produce \`OPTIMAL\` verdicts — Maximize reward **178**, Minimize diagonal cost **5**.
- **nbformat.validate**: OK (0 errors). Cell \`id\` fields added (nbformat 4.5 consistency, matches existing cells).
- **OR-Tools installed locally** (regle F) — real CP-SAT solver invoked (Prong-A SOTA-OK, no workaround/degraded output).
- Non-vacuous: the OPTIMAL status proves CP-SAT searched the solution space and certified no better solution exists — a capability absent from the satisfaction-only notebooks.

## SOTA verdicts (sota-not-workaround.md)

- **Prong-A (real tool)**: SOTA-OK — real OR-Tools CP-SAT, not a toy reimplementation.
- **Prong-B (non-trivial)**: the optimization problem is bounded but genuine (linear objective over the Latin-square solution space, OPTIMAL certification) — exercises the distinctive capability the satisfaction-only notebooks missed.

## Why this grain

Pool substance was genuinely drained for my constraints this cycle (translation T2 saturated, prover = user-active, ICT gelé, QC Docker-down, Lean grothendieck-worktree active). Default grain per my c.710 commitment to ai-01 (audit Prong-B Sudoku → finding → fix). Native Sudoku turf, non-capped (notebook enhancement ≠ guard/test/doc/accent/path-leak/translation caps).

See #3801 (Prong-B). Not \`Closes\` — the EPIC is ongoing across families.