### PR TITLE
fix(lean-utils): degenerate-input guards on lean_notebook_utils public API

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/lean_notebook_utils.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/lean_notebook_utils.py
@@ -37,6 +37,27 @@ from typing import Optional, Tuple
 
 
 # ---------------------------------------------------------------------------
+# Input validation (degenerate-input guards, c.703 pattern)
+# ---------------------------------------------------------------------------
+
+def _require_str(name, value):
+    """Reject None / non-str at the boundary with a clear, actionable error.
+
+    Without this guard, ``str.split`` / ``Path / value`` / ``os.path.join``
+    crash deeper with an opaque ``TypeError`` or ``AttributeError`` that points
+    at an implementation line rather than the caller's bad argument.
+    """
+    if not isinstance(value, str):
+        raise TypeError(
+            f"{name} must be a non-empty string, got "
+            f"{type(value).__name__}: {value!r}"
+        )
+    if not value.strip():
+        raise ValueError(f"{name} must be a non-empty string, got {value!r}")
+    return value
+
+
+# ---------------------------------------------------------------------------
 # Platform detection
 # ---------------------------------------------------------------------------
 
@@ -85,6 +106,7 @@ def find_lean_project(project_name: str) -> Path:
     Raises:
         FileNotFoundError: If the project cannot be found.
     """
+    _require_str("project_name", project_name)
     starts = [Path.cwd().resolve()]
 
     # Papermill passes the notebook path as a parameter
@@ -119,7 +141,12 @@ def win_to_wsl(win_path: Path) -> str:
     Returns:
         WSL-compatible path string.
     """
-    p = win_path.resolve()
+    if not isinstance(win_path, (Path, str)):
+        raise TypeError(
+            f"win_path must be a Path or str, got {type(win_path).__name__}: "
+            f"{win_path!r}"
+        )
+    p = Path(win_path).resolve()
     drive_letter = p.drive
 
     if not drive_letter or len(drive_letter) < 2:
@@ -205,6 +232,7 @@ def run_lake(
     Returns:
         Tuple of (returncode, stdout, stderr).
     """
+    _require_str("args", args)
     if is_native_platform():
         lake = _find_lake()
         try:
@@ -248,6 +276,7 @@ def run_lean_snippet(
     Returns:
         Combined stdout + stderr as a string.
     """
+    _require_str("snippet", snippet)
     snippet = textwrap.dedent(snippet).strip() + "\n"
     tmp_file = f"/tmp/lean_{snippet_id}.lean"
 
@@ -343,6 +372,7 @@ def count_sorry(project_path: str, subdir: str = "") -> int:
         project directory cannot be read. ``0`` if the directory exists but has
         no ``.lean`` source.
     """
+    _require_str("project_path", project_path)
     search_dir = os.path.join(project_path, subdir) if subdir else project_path
     if not os.path.isdir(search_dir):
         return -1
@@ -384,6 +414,7 @@ def read_lean_module(
     Returns:
         File content as a string.
     """
+    _require_str("module_path", module_path)
     project_dir = find_lean_project(project_name)
     path = project_dir / module_path
     if not path.exists():
@@ -405,6 +436,16 @@ def display_lean_module(
         max_lines: If set, only show the first N lines.
         highlight: List of line numbers to mark with '>>>' (1-indexed).
     """
+    if highlight is not None:
+        # Accept any iterable of ints (list/tuple/set); reject non-iterables
+        # (e.g. a bare int) which would crash opaquely inside ``set(highlight)``.
+        try:
+            iter(highlight)
+        except TypeError:
+            raise TypeError(
+                f"highlight must be an iterable of ints (or None), got "
+                f"{type(highlight).__name__}: {highlight!r}"
+            )
     content = read_lean_module(project_name, module_path)
     if content.startswith("[FICHIER INTROUVABLE]"):
         print(content)

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/tests/test_lean_notebook_utils_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/tests/test_lean_notebook_utils_guards.py
@@ -1,0 +1,166 @@
+"""Tests for the degenerate-input guards in ``lean_notebook_utils``.
+
+Run with: pytest SymbolicAI/Lean/tests/test_lean_notebook_utils_guards.py -v
+
+Same bug-class as the c.703/c.704 guards on ``draw_search_tree`` /
+``draw_csp_graph`` (Search) and the WFC entry-point guards (#7551/#7553):
+public entry points must reject degenerate arguments (None, wrong type,
+empty) at the boundary with a clear ``TypeError``/``ValueError``, rather
+than crash deeper in the pipeline with an opaque ``AttributeError``
+(``NoneType has no attribute 'resolve'``) or ``TypeError`` (``Path / None``)
+that points at an implementation line instead of the caller's bad argument.
+
+The module is consumed by 5 Lean notebooks (Lean-7b, Lean-13 Kochen-Specker,
+Lean-16a/16b/16f Conway) which call these functions with values derived from
+notebook parameters; a bad parameter deserves an actionable error, not an
+opaque traceback.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import lean_notebook_utils as u  # noqa: E402
+
+
+# --- _require_str helper ----------------------------------------------------
+
+def test_require_str_rejects_none():
+    with pytest.raises(TypeError, match="must be a non-empty string"):
+        u._require_str("x", None)
+
+
+def test_require_str_rejects_int():
+    with pytest.raises(TypeError, match="got int"):
+        u._require_str("x", 5)
+
+
+def test_require_str_rejects_empty_and_whitespace():
+    with pytest.raises(ValueError, match="non-empty"):
+        u._require_str("x", "")
+    with pytest.raises(ValueError, match="non-empty"):
+        u._require_str("x", "   ")
+
+
+def test_require_str_accepts_valid():
+    assert u._require_str("x", "ok") == "ok"
+
+
+# --- find_lean_project ------------------------------------------------------
+
+def test_find_lean_project_none_raises_typeerror():
+    """``project_name=None`` used to crash on ``current / None`` (opaque TypeError)."""
+    with pytest.raises(TypeError, match="project_name must be a non-empty string"):
+        u.find_lean_project(None)
+
+
+def test_find_lean_project_int_raises_typeerror():
+    with pytest.raises(TypeError, match="got int"):
+        u.find_lean_project(42)
+
+
+def test_find_lean_project_empty_raises_valueerror():
+    with pytest.raises(ValueError, match="non-empty"):
+        u.find_lean_project("")
+
+
+# --- win_to_wsl -------------------------------------------------------------
+
+def test_win_to_wsl_none_raises_typeerror():
+    """``win_path=None`` used to crash on ``None.resolve()`` (opaque AttributeError)."""
+    with pytest.raises(TypeError, match="win_path must be a Path or str"):
+        u.win_to_wsl(None)
+
+
+def test_win_to_wsl_int_raises_typeerror():
+    with pytest.raises(TypeError, match="got int"):
+        u.win_to_wsl(123)
+
+
+def test_win_to_wsl_accepts_path_and_str():
+    # Happy path preserved: both Path and str inputs are accepted (the guard
+    # made win_to_wsl MORE permissive by normalizing str -> Path, not less).
+    assert isinstance(u.win_to_wsl(Path("C:/tmp/x")), str)
+    assert isinstance(u.win_to_wsl("D:/proj"), str)
+
+
+# --- run_lake ---------------------------------------------------------------
+
+def test_run_lake_args_none_raises_typeerror():
+    """``args=None`` used to either crash on ``args.split()`` (native) or silently
+    build ``lake None`` (WSL). Either way the caller got no actionable error."""
+    with pytest.raises(TypeError, match="args must be a non-empty string"):
+        u.run_lake("dummy_project_path", None)
+
+
+def test_run_lake_args_empty_raises_valueerror():
+    with pytest.raises(ValueError, match="non-empty"):
+        u.run_lake("dummy", "")
+
+
+# --- run_lean_snippet -------------------------------------------------------
+
+def test_run_lean_snippet_none_raises_typeerror():
+    """``snippet=None`` used to crash inside ``textwrap.dedent(None)`` (opaque)."""
+    with pytest.raises(TypeError, match="snippet must be a non-empty string"):
+        u.run_lean_snippet("dummy", None)
+
+
+def test_run_lean_snippet_int_raises_typeerror():
+    with pytest.raises(TypeError, match="got int"):
+        u.run_lean_snippet("dummy", 123)
+
+
+# --- count_sorry ------------------------------------------------------------
+
+def test_count_sorry_project_path_none_raises_typeerror():
+    """``project_path=None`` used to crash on ``os.path.join(None, ...)`` (native)
+    or silently build ``cd None && grep`` (WSL)."""
+    with pytest.raises(TypeError, match="project_path must be a non-empty string"):
+        u.count_sorry(None)
+
+
+def test_count_sorry_empty_raises_valueerror():
+    with pytest.raises(ValueError, match="non-empty"):
+        u.count_sorry("")
+
+
+# --- read_lean_module -------------------------------------------------------
+
+def test_read_lean_module_module_path_none_raises_typeerror():
+    """``module_path=None`` used to crash on ``project_dir / None`` (opaque TypeError)."""
+    with pytest.raises(TypeError, match="module_path must be a non-empty string"):
+        u.read_lean_module("dummy_project", None)
+
+
+def test_read_lean_module_empty_raises_valueerror():
+    with pytest.raises(ValueError, match="non-empty"):
+        u.read_lean_module("dummy_project", "")
+
+
+# --- display_lean_module ----------------------------------------------------
+
+def test_display_lean_module_highlight_int_raises_typeerror():
+    """``highlight=5`` (a bare int instead of a list of ints) used to crash
+    opaquely inside ``set(5)`` -> ``TypeError: int object is not iterable``."""
+    with pytest.raises(TypeError, match="highlight must be an iterable"):
+        u.display_lean_module("dummy_project", "dummy.lean", highlight=5)
+
+
+def test_display_lean_module_highlight_none_accepted():
+    """``highlight=None`` (the default) must remain valid -- the guard only
+    rejects NON-iterable values, not the documented None sentinel."""
+    # This calls into find_lean_project('dummy_project') which raises
+    # FileNotFoundError -- that's fine, we only assert the highlight guard
+    # itself did NOT raise a TypeError.
+    with pytest.raises(FileNotFoundError):
+        u.display_lean_module("dummy_project", "dummy.lean", highlight=None)
+
+
+def test_display_lean_module_highlight_list_accepted():
+    # A list/tuple/set of ints is the documented contract -- must pass the guard.
+    with pytest.raises(FileNotFoundError):
+        u.display_lean_module("dummy_project", "dummy.lean", highlight=[1, 3, 5])


### PR DESCRIPTION
## Degenerate-input guards (c.703 pattern) on a fresh module

Same bug-class as the c.703/c.704 guards on `draw_search_tree` / `draw_csp_graph` (Search, #7587) and the WFC entry-point guards (#7551/#7553): public entry points that crash with an **opaque** `AttributeError`/`TypeError` on degenerate input (`None`, wrong type, empty) instead of a clear, actionable error pointing at the caller's bad argument.

**Genre rotation (R6).** Previous 3 cycles were Prong-B optimization demos (CP-SAT #7588, Z3 #7589, PDDL #7592). This cycle pivots to **robustness/guard** (c.700 method — enumerate all entry points of a fresh module). Garniture grain (within the 1/lane/jour cap, first guard today).

## Module

`lean_notebook_utils.py` — cross-platform Lean 4 notebook execution utility (Windows/WSL/Linux/macOS). Consumed by **5 Lean notebooks**: Lean-7b, Lean-13 (Kochen-Specker), Lean-16a/16b/16f (Conway). Pure Python input validation — **no Lean proof or subprocess-behavior change**.

## Guards added (7 public functions)

| Function | Degenerate input | Opaque crash before | Clear error after |
|----------|------------------|---------------------|-------------------|
| `find_lean_project` | `project_name=None` | `TypeError: Path / None` | `TypeError: project_name must be a non-empty string` |
| `win_to_wsl` | `win_path=None` | `AttributeError: None.resolve()` | `TypeError: win_path must be a Path or str` |
| `run_lake` | `args=None` | silent `lake None` cmd / crash on `.split()` | `TypeError: args must be a non-empty string` |
| `run_lean_snippet` | `snippet=None` | `TypeError` in `textwrap.dedent()` | `TypeError: snippet must be a non-empty string` |
| `count_sorry` | `project_path=None` | silent `cd None` / `os.path.join` crash | `TypeError: project_path must be a non-empty string` |
| `read_lean_module` | `module_path=None` | `TypeError: Path / None` | `TypeError: module_path must be a non-empty string` |
| `display_lean_module` | `highlight=5` (bare int) | `TypeError` in `set(int)` | `TypeError: highlight must be an iterable` |

Also: `win_to_wsl` became slightly **more permissive** (accepts `str` in addition to `Path` via `Path(win_path)` normalization).

## G.1 non-vacuous proven

```bash
# patched:
pytest ... => 21 passed
# unpatched (stash module to origin/main, keep tests):
pytest ... => 19 failed, 2 passed   (the 2 = happy-path tests not exercising guards)
# restored: 21 passed
```

The 19 failures on unpatched prove each guard test catches a real opaque crash that the guard now converts to a clear error.

## Validation

- **pytest**: 21/21 passed (first `tests/` dir for this module).
- **Diff**: module `+42/-1` (input validation only), +21 new tests.
- **Happy-path preserved**: import + `is_native_platform` + valid inputs unchanged; the 2 happy-path tests pass both patched and unpatched.
- No Lean proof touched (anti-regression D N/A — this is a Python utility, not a `*.lean` file).
- Catalogue byte-identical to main.

See #2314. See #2315. (Module origin — PR #2323.)

Co-Authored-By: Claude-Code <noreply@anthropic.com>