### PR TITLE
fix(prover): declare missing opentelemetry-sdk in agent_tests requirements

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/requirements.txt
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/requirements.txt
@@ -20,6 +20,11 @@ openai>=2.0.0
 # Configuration via .env (PROVIDER=zai|openrouter|local|deepseek|...)
 python-dotenv>=1.0.0
 
+# Tracing OTEL du prover (prover/otel_setup.py importe opentelemetry.sdk.trace.export)
+# opentelemetry-api arrive transitivement via agent-framework, mais PAS le sdk :
+# sans ce paquet, `from prover import ...` echoue (ModuleNotFoundError: opentelemetry.sdk).
+opentelemetry-sdk>=1.20.0
+
 # Test runner
 pytest>=8.0.0
 pytest-asyncio>=0.23.0


### PR DESCRIPTION
## Summary

Le harnais prover (`agent_tests/prover/`) importe `opentelemetry.sdk.trace.export` via `prover/otel_setup.py` (L31, L152-153), mais `agent_tests/requirements.txt` ne declarait que `opentelemetry-api` (tire **transitivement** par `agent-framework`, pas explicitement). Sur un environnement **frais**, l'import du package echoue :

```
ModuleNotFoundError: No module named 'opentelemetry.sdk'
```

## Fix

Ajout d'une ligne `opentelemetry-sdk>=1.20.0` (floor conservateur ; `trace.export.SimpleSpanProcessor` stable depuis longtemps ; pip resout la version compatible avec l'`opentelemetry-api` deja contraint par agent-framework).

## Preuve d'execution (firsthand, regle F / verify-before-claiming)

Env **frais** = venv python 3.12 systeme + `pip install -r requirements.txt` :

- **AVANT** ce fix : `from prover import ...` -> `ModuleNotFoundError: No module named 'opentelemetry.sdk'`
- **APRES** ajout d'`opentelemetry-sdk` + re-import :
  ```
  prover harness imports OK
  DEMOS: 62 PROVED_DEMOS: 12
  ```

Contexte : rencontre en reparant l'env prover BG (la base miniforge WSL etant corrompue au niveau native-lib, l'harnais a ete rebati sur un venv system-python 3.12 propre — c'est la que le gap de dependance declaree est apparu).

See #1453 (harnais prover forensic).