### PR TITLE
feat(mechdesign,#1469): VCG combinatorial revenue non-monotonicity (Conitzer-Sandholm)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/SocialChoice/MechanismDesign.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/SocialChoice/MechanismDesign.lean
@@ -5,7 +5,7 @@
   Decidability results for auction-based mechanism design on finite domains.
 
   - Vickrey (second-price) auction truthfulness: proved by omega + case split
-  - First-price auction non-truthfulness: concrete counter-example via native_decide
+  - First-price auction non-truthfulness: concrete counter-example via decide
   - 3-bidder Vickrey truthfulness: proved by omega + case split
 
   Reference: Vickrey (1961), "Counterspeculation, Auctions, and Competitive Sealed Tenders"
@@ -50,7 +50,7 @@ theorem vickrey_truthful_bidder1 (v0 v1 b1 : ℕ) :
 /-- **Théorème 3** : l'enchère au premier prix N'est PAS vérace.
     Contre-exemple : v = (10, 5). L'utilité vérace = 0. Un bradage à 6 donne utilité = 4. -/
 theorem first_price_not_truthful :
-    (0 : ℤ) < (4 : ℤ) := by native_decide
+    (0 : ℤ) < (4 : ℤ) := by decide
 
 end VickreyTwoBidder
 
@@ -77,5 +77,137 @@ theorem vickrey3_truthful_bidder0 (v0 v1 v2 b0 : ℕ) :
   split_ifs <;> simp_all; omega
 
 end VickreyThreeBidder
+
+/-! ## VCG en enchère combinatoire : non-monotonie du revenu (Conitzer-Sandholm)
+
+    La principale défaillance de VCG en présence de complémentarités : le revenu
+    du vendeur peut STRICTEMENT DIMINUER quand on ajoute un enchérisseur. Ce résultat
+    motive les mécanismes ascendants (Ausubel-Milgrom) et montre que VCG n'est pas
+    approprié aux enchères combinatoires avec fortes complémentarités.
+
+    Référence : Conitzer & Sandholm (2006), "Failures of the VCG Mechanism in
+    Combinatorial Auctions and Multi-agent Systems".
+    Référence : #1469 Track 2 — contre-exemple fini d'échec VCG.
+-/
+
+namespace VCGCombinatorial
+
+/-- Helper : maximum d'une liste de naturels. -/
+def maxOver (vals : List ℕ) : ℕ := vals.foldl Nat.max 0
+
+/- Modélisation : 2 objets A et B. `oA` (resp. `oB`) = indice de l'enchérisseur
+   qui reçoit A (resp. B). Un indice absent de l'allocation ne reçoit rien. -/
+
+/-- Enchérisseur 1 (indice 0) : complémentarités. Valeur 10 pour le bundle {A,B}, 0 sinon. -/
+def v1_of (oA oB : ℕ) : ℕ := if oA = 0 ∧ oB = 0 then 10 else 0
+
+/-- Enchérisseur 2 (indice 1) : veut seulement A. Valeur 8 ssi oA = 1. -/
+def v2_of (oA oB : ℕ) : ℕ := if oA = 1 then 8 else 0
+
+/-- Enchérisseur 3 (indice 2) : veut seulement B. Valeur 8 ssi oB = 2. -/
+def v3_of (oA oB : ℕ) : ℕ := if oB = 2 then 8 else 0
+
+/-- Bien-être social à 2 enchérisseurs {1, 2}. -/
+def sw2 (oA oB : ℕ) : ℕ := v1_of oA oB + v2_of oA oB
+
+/-- Bien-être social à 3 enchérisseurs {1, 2, 3}. -/
+def sw3 (oA oB : ℕ) : ℕ := v1_of oA oB + v2_of oA oB + v3_of oA oB
+
+/-- Maximum du bien-être à 2 enchérisseurs sur les 4 allocations (oA, oB ∈ {0,1}). -/
+def maxSW2 : ℕ := maxOver [sw2 0 0, sw2 0 1, sw2 1 0, sw2 1 1]
+
+/-- Maximum du bien-être à 3 enchérisseurs sur les 9 allocations. -/
+def maxSW3 : ℕ :=
+  maxOver [sw3 0 0, sw3 0 1, sw3 0 2, sw3 1 0, sw3 1 1, sw3 1 2, sw3 2 0, sw3 2 1, sw3 2 2]
+
+/-- **Lemme** : bien-être social maximal à 2 enchérisseurs = 10 (le bidder 1 prend les deux). -/
+theorem maxSW2_eq : maxSW2 = 10 := by decide
+
+/-- **Lemme** : bien-être social maximal à 3 enchérisseurs = 16 (bidders 2 et 3 se partagent). -/
+theorem maxSW3_eq : maxSW3 = 16 := by decide
+
+/-- L'allocation optimale à 2 enchérisseurs est (0, 0) : le bidder 1 prend {A, B}. -/
+theorem opt2 : sw2 0 0 = maxSW2 := by decide
+
+/-- L'allocation optimale à 3 enchérisseurs est (1, 2) : le bidder 2 prend A, le bidder 3 prend B. -/
+theorem opt3 : sw3 1 2 = maxSW3 := by decide
+
+/-! ### Paiements VCG (pivot de Clarke)
+
+    Le paiement de l'enchérisseur `i` est son externalité :
+    `payment_i = maxSW(sans i) − bien-être_des_autres_dans_l'allocation_optimale`. -/
+
+/-- Bien-être max à 2 enchérisseurs quand le bidder 1 est absent (seul le 2 reste). -/
+def maxSW2_without1 : ℕ := maxOver [v2_of 0 0, v2_of 0 1, v2_of 1 0, v2_of 1 1]
+
+/-- Bien-être max à 2 enchérisseurs quand le bidder 2 est absent (seul le 1 reste). -/
+def maxSW2_without2 : ℕ := maxOver [v1_of 0 0, v1_of 0 1, v1_of 1 0, v1_of 1 1]
+
+theorem maxSW2_without1_eq : maxSW2_without1 = 8 := by decide
+theorem maxSW2_without2_eq : maxSW2_without2 = 10 := by decide
+
+/-- Bien-être conjoint des bidders 2 et 3. -/
+def welfare23 (oA oB : ℕ) : ℕ := v2_of oA oB + v3_of oA oB
+/-- Bien-être conjoint des bidders 1 et 3. -/
+def welfare13 (oA oB : ℕ) : ℕ := v1_of oA oB + v3_of oA oB
+
+/-- Bien-être max à 3 enchérisseurs quand le bidder 1 est absent (bidders 2, 3 restent). -/
+def maxSW3_without1 : ℕ :=
+  maxOver [welfare23 0 0, welfare23 0 1, welfare23 0 2,
+           welfare23 1 0, welfare23 1 1, welfare23 1 2,
+           welfare23 2 0, welfare23 2 1, welfare23 2 2]
+
+/-- Bien-être max à 3 enchérisseurs quand le bidder 2 est absent (bidders 1, 3 restent). -/
+def maxSW3_without2 : ℕ :=
+  maxOver [welfare13 0 0, welfare13 0 1, welfare13 0 2,
+           welfare13 1 0, welfare13 1 1, welfare13 1 2,
+           welfare13 2 0, welfare13 2 1, welfare13 2 2]
+
+/-- Bien-être max à 3 enchérisseurs quand le bidder 3 est absent (bidders 1, 2 restent = sw2). -/
+def maxSW3_without3 : ℕ := maxSW2
+
+theorem maxSW3_without1_eq : maxSW3_without1 = 16 := by decide
+theorem maxSW3_without2_eq : maxSW3_without2 = 10 := by decide
+theorem maxSW3_without3_eq : maxSW3_without3 = 10 := maxSW2_eq
+
+/-! ### Revenu à 2 enchérisseurs -/
+
+/-- Paiement VCG du bidder 1 à 2 enchérisseurs (allocation opt (0,0), les autres = bidder 2 → 0). -/
+def payment2_1 : ℕ := maxSW2_without1 - v2_of 0 0
+/-- Paiement VCG du bidder 2 à 2 enchérisseurs (les autres = bidder 1 → v1(0,0) = 10). -/
+def payment2_2 : ℕ := maxSW2_without2 - v1_of 0 0
+
+theorem payment2_1_eq : payment2_1 = 8 := by decide
+theorem payment2_2_eq : payment2_2 = 0 := by decide
+
+/-- Revenu du vendeur à 2 enchérisseurs. -/
+def revenue2 : ℕ := payment2_1 + payment2_2
+theorem revenue2_eq : revenue2 = 8 := by decide
+
+/-! ### Revenu à 3 enchérisseurs (allocation opt (1,2)) -/
+
+/-- others-in-opt pour bidder 1 = v2(1,2) + v3(1,2) = 8 + 8 = 16. -/
+def payment3_1 : ℕ := maxSW3_without1 - (v2_of 1 2 + v3_of 1 2)
+/-- others-in-opt pour bidder 2 = v1(1,2) + v3(1,2) = 0 + 8 = 8. -/
+def payment3_2 : ℕ := maxSW3_without2 - (v1_of 1 2 + v3_of 1 2)
+/-- others-in-opt pour bidder 3 = v1(1,2) + v2(1,2) = 0 + 8 = 8. -/
+def payment3_3 : ℕ := maxSW3_without3 - (v1_of 1 2 + v2_of 1 2)
+
+theorem payment3_1_eq : payment3_1 = 0 := by decide
+theorem payment3_2_eq : payment3_2 = 2 := by decide
+theorem payment3_3_eq : payment3_3 = 2 := by decide
+
+/-- Revenu du vendeur à 3 enchérisseurs. -/
+def revenue3 : ℕ := payment3_1 + payment3_2 + payment3_3
+theorem revenue3_eq : revenue3 = 4 := by decide
+
+/-- **Théorème 5 (Conitzer-Sandholm, 2006)** : VCG n'est PAS monotone en revenu.
+    Ajouter l'enchérisseur 3 (qui valorise B à 8) fait chuter le revenu du vendeur
+    de 8 à 4, bien que le bien-être social augmente (10 → 16). Le bidder 1, qui
+    payait 8 en tant que gagnant complémentaire, est déplacé et les deux bidders
+    singletons ne paient chacun qu'une externalité de 2. -/
+theorem vcg_revenue_non_monotone : revenue3 < revenue2 := by decide
+
+end VCGCombinatorial
 
 end SocialChoice

--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/SocialChoice/MechanismDesign_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/SocialChoice/MechanismDesign_en.lean
@@ -5,7 +5,7 @@
   Decidability results for auction-based mechanism design on finite domains.
 
   - Vickrey (second-price) auction truthfulness: proved by omega + case split
-  - First-price auction non-truthfulness: concrete counter-example via native_decide
+  - First-price auction non-truthfulness: concrete counter-example via decide
   - 3-bidder Vickrey truthfulness: proved by omega + case split
 
   Reference: Vickrey (1961), "Counterspeculation, Auctions, and Competitive Sealed Tenders"
@@ -64,7 +64,7 @@ theorem vickrey_truthful_bidder1 (v0 v1 b1 : ℕ) :
 /-- **Theorem 3**: First-price auction is NOT truthful.
     Counter-example: v = (10, 5). Truthful utility = 0. Shading to 6 gives utility = 4. -/
 theorem first_price_not_truthful :
-    (0 : ℤ) < (4 : ℤ) := by native_decide
+    (0 : ℤ) < (4 : ℤ) := by decide
 
 end VickreyTwoBidder
 
@@ -91,5 +91,137 @@ theorem vickrey3_truthful_bidder0 (v0 v1 v2 b0 : ℕ) :
   split_ifs <;> simp_all; omega
 
 end VickreyThreeBidder
+
+/-! ## VCG in combinatorial auctions: revenue non-monotonicity (Conitzer-Sandholm)
+
+    The main failure of VCG in the presence of complementarities: the seller's
+    revenue can STRICTLY DECREASE when a bidder is added. This result motivates
+    ascending mechanisms (Ausubel-Milgrom) and shows that VCG is not suitable for
+    combinatorial auctions with strong complementarities.
+
+    Reference: Conitzer & Sandholm (2006), "Failures of the VCG Mechanism in
+    Combinatorial Auctions and Multi-agent Systems".
+    Reference: #1469 Track 2 — finite counter-example of VCG failure.
+-/
+
+namespace VCGCombinatorial
+
+/-- Helper: maximum of a list of naturals. -/
+def maxOver (vals : List ℕ) : ℕ := vals.foldl Nat.max 0
+
+/- Model: 2 items A and B. `oA` (resp. `oB`) = index of the bidder receiving
+   A (resp. B). An index absent from the allocation receives nothing. -/
+
+/-- Bidder 1 (index 0): complementarities. Value 10 for the bundle {A,B}, 0 otherwise. -/
+def v1_of (oA oB : ℕ) : ℕ := if oA = 0 ∧ oB = 0 then 10 else 0
+
+/-- Bidder 2 (index 1): wants only A. Value 8 iff oA = 1. -/
+def v2_of (oA oB : ℕ) : ℕ := if oA = 1 then 8 else 0
+
+/-- Bidder 3 (index 2): wants only B. Value 8 iff oB = 2. -/
+def v3_of (oA oB : ℕ) : ℕ := if oB = 2 then 8 else 0
+
+/-- Social welfare with 2 bidders {1, 2}. -/
+def sw2 (oA oB : ℕ) : ℕ := v1_of oA oB + v2_of oA oB
+
+/-- Social welfare with 3 bidders {1, 2, 3}. -/
+def sw3 (oA oB : ℕ) : ℕ := v1_of oA oB + v2_of oA oB + v3_of oA oB
+
+/-- Maximum welfare with 2 bidders over the 4 allocations (oA, oB ∈ {0,1}). -/
+def maxSW2 : ℕ := maxOver [sw2 0 0, sw2 0 1, sw2 1 0, sw2 1 1]
+
+/-- Maximum welfare with 3 bidders over the 9 allocations. -/
+def maxSW3 : ℕ :=
+  maxOver [sw3 0 0, sw3 0 1, sw3 0 2, sw3 1 0, sw3 1 1, sw3 1 2, sw3 2 0, sw3 2 1, sw3 2 2]
+
+/-- **Lemma**: maximal social welfare with 2 bidders = 10 (bidder 1 takes both). -/
+theorem maxSW2_eq : maxSW2 = 10 := by decide
+
+/-- **Lemma**: maximal social welfare with 3 bidders = 16 (bidders 2 and 3 split). -/
+theorem maxSW3_eq : maxSW3 = 16 := by decide
+
+/-- The optimal 2-bidder allocation is (0, 0): bidder 1 takes {A, B}. -/
+theorem opt2 : sw2 0 0 = maxSW2 := by decide
+
+/-- The optimal 3-bidder allocation is (1, 2): bidder 2 takes A, bidder 3 takes B. -/
+theorem opt3 : sw3 1 2 = maxSW3 := by decide
+
+/-! ### VCG payments (Clarke pivot)
+
+    Bidder `i`'s payment is its externality:
+    `payment_i = maxSW(without i) − welfare_of_others_in_the_optimal_allocation`. -/
+
+/-- Max welfare with 2 bidders when bidder 1 is absent (only 2 remains). -/
+def maxSW2_without1 : ℕ := maxOver [v2_of 0 0, v2_of 0 1, v2_of 1 0, v2_of 1 1]
+
+/-- Max welfare with 2 bidders when bidder 2 is absent (only 1 remains). -/
+def maxSW2_without2 : ℕ := maxOver [v1_of 0 0, v1_of 0 1, v1_of 1 0, v1_of 1 1]
+
+theorem maxSW2_without1_eq : maxSW2_without1 = 8 := by decide
+theorem maxSW2_without2_eq : maxSW2_without2 = 10 := by decide
+
+/-- Joint welfare of bidders 2 and 3. -/
+def welfare23 (oA oB : ℕ) : ℕ := v2_of oA oB + v3_of oA oB
+/-- Joint welfare of bidders 1 and 3. -/
+def welfare13 (oA oB : ℕ) : ℕ := v1_of oA oB + v3_of oA oB
+
+/-- Max welfare with 3 bidders when bidder 1 is absent (bidders 2, 3 remain). -/
+def maxSW3_without1 : ℕ :=
+  maxOver [welfare23 0 0, welfare23 0 1, welfare23 0 2,
+           welfare23 1 0, welfare23 1 1, welfare23 1 2,
+           welfare23 2 0, welfare23 2 1, welfare23 2 2]
+
+/-- Max welfare with 3 bidders when bidder 2 is absent (bidders 1, 3 remain). -/
+def maxSW3_without2 : ℕ :=
+  maxOver [welfare13 0 0, welfare13 0 1, welfare13 0 2,
+           welfare13 1 0, welfare13 1 1, welfare13 1 2,
+           welfare13 2 0, welfare13 2 1, welfare13 2 2]
+
+/-- Max welfare with 3 bidders when bidder 3 is absent (bidders 1, 2 remain = sw2). -/
+def maxSW3_without3 : ℕ := maxSW2
+
+theorem maxSW3_without1_eq : maxSW3_without1 = 16 := by decide
+theorem maxSW3_without2_eq : maxSW3_without2 = 10 := by decide
+theorem maxSW3_without3_eq : maxSW3_without3 = 10 := maxSW2_eq
+
+/-! ### Revenue with 2 bidders -/
+
+/-- VCG payment of bidder 1 with 2 bidders (opt alloc (0,0), others = bidder 2 → 0). -/
+def payment2_1 : ℕ := maxSW2_without1 - v2_of 0 0
+/-- VCG payment of bidder 2 with 2 bidders (others = bidder 1 → v1(0,0) = 10). -/
+def payment2_2 : ℕ := maxSW2_without2 - v1_of 0 0
+
+theorem payment2_1_eq : payment2_1 = 8 := by decide
+theorem payment2_2_eq : payment2_2 = 0 := by decide
+
+/-- Seller revenue with 2 bidders. -/
+def revenue2 : ℕ := payment2_1 + payment2_2
+theorem revenue2_eq : revenue2 = 8 := by decide
+
+/-! ### Revenue with 3 bidders (opt alloc (1,2)) -/
+
+/-- others-in-opt for bidder 1 = v2(1,2) + v3(1,2) = 8 + 8 = 16. -/
+def payment3_1 : ℕ := maxSW3_without1 - (v2_of 1 2 + v3_of 1 2)
+/-- others-in-opt for bidder 2 = v1(1,2) + v3(1,2) = 0 + 8 = 8. -/
+def payment3_2 : ℕ := maxSW3_without2 - (v1_of 1 2 + v3_of 1 2)
+/-- others-in-opt for bidder 3 = v1(1,2) + v2(1,2) = 0 + 8 = 8. -/
+def payment3_3 : ℕ := maxSW3_without3 - (v1_of 1 2 + v2_of 1 2)
+
+theorem payment3_1_eq : payment3_1 = 0 := by decide
+theorem payment3_2_eq : payment3_2 = 2 := by decide
+theorem payment3_3_eq : payment3_3 = 2 := by decide
+
+/-- Seller revenue with 3 bidders. -/
+def revenue3 : ℕ := payment3_1 + payment3_2 + payment3_3
+theorem revenue3_eq : revenue3 = 4 := by decide
+
+/-- **Theorem 5 (Conitzer-Sandholm, 2006)**: VCG is NOT revenue-monotone.
+    Adding bidder 3 (who values B at 8) drops the seller's revenue from 8 to 4,
+    although social welfare rises (10 → 16). Bidder 1, who paid 8 as the
+    complementarity winner, is displaced and the two singleton bidders each pay
+    only an externality of 2. -/
+theorem vcg_revenue_non_monotone : revenue3 < revenue2 := by decide
+
+end VCGCombinatorial
 
 end SocialChoice_en


### PR DESCRIPTION
## Summary

Add `VCGCombinatorial` namespace formalizing the **Conitzer-Sandholm (2006) VCG revenue non-monotonicity** counter-example — the canonical "failure" of VCG in combinatorial auctions with complementarities. Delivered as a complete **FR + EN i18n sibling pair** (#4980).

Fills the #1469 Track 2 residual gap: VCG was absent from the `.lean` side (the file previously covered only single-item Vickrey truthfulness). G.1 check before coding confirmed Vickrey 2/3-bidder + first-price counter-example were already present — the genuinely-absent piece was the combinatorial VCG failure.

**Headline result** (`theorem vcg_revenue_non_monotone : revenue3 < revenue2`): adding a bidder can STRICTLY DECREASE seller revenue (8 → 4) while social welfare RISES (10 → 16).

### The mechanism (2 items A, B)
- Bidder 1 (complementarity): `v({A,B}) = 10`, singletons 0
- Bidder 2 (wants only A): `v({A}) = 8`
- Bidder 3 (wants only B): `v({B}) = 8` (added in the 3-bidder setting)

### Why revenue crashes
- **2 bidders {1,2}**: optimal alloc = bidder 1 takes both (SW 10 > bidder 2's 8). Bidder 1 pays Clarke externality = 8, bidder 2 pays 0. **Revenue = 8**.
- **3 bidders {1,2,3}**: optimal alloc flips to bidder 2→A, bidder 3→B (SW 16 > 10). Bidder 1 is displaced → pays 0. Bidders 2,3 each pay externality 2. **Revenue = 4**.
- **4 < 8** despite welfare rising 10 → 16. The complementarity bidder, who paid near-full value as the sole winner, is displaced and the two singletons pay only small externalities.

This is why VCG is inappropriate for combinatorial auctions with strong complementarities and motivates ascending mechanisms (Ausubel-Milgrom).

## Files changed (2 — FR canonical + EN sibling)
- `MechanismDesign.lean` (+134/-2): new `VCGCombinatorial` section (16 theorems + helper). `-2`: `first_price_not_truthful` tactic `native_decide → decide` (avoids Windows v4.31.0-rc1 native-compilation stack-overrun flake on `Std.Tactic.BVDecide`; semantically equivalent for `0 < 4`).
- `MechanismDesign_en.lean` (+134/-2): English i18n mirror. **Byte-identical code to FR** (verified: code lines match modulo `SocialChoice` vs `SocialChoice_en` namespace + docstring language). Same `native_decide → decide` sync to preserve the i18n invariant.

## Lean merge discipline (§B)

| Check | Result |
|-------|--------|
| `grep -c sorry` (both files) | **0** (before: 0, after: 0) |
| `lake build SocialChoice.MechanismDesign` (FR) | **SUCCESS** (12s) |
| `lake build SocialChoice.MechanismDesign_en` (EN) | **SUCCESS** (29s) |
| `lake build` (full game_theory_lean lib) | **SUCCESS** (8541 jobs, 37s) |
| Proof integrity | Kernel `decide` on finite ℕ domain — no axioms, no `sorry`, no `native_decide` |
| i18n byte-identity (#4980) | **IDENTICAL** (code, namespace-normalized) |

All 17 new lemmas/theorems proven by kernel decidability (`decide`), evaluating explicit `Nat.max` folds over the 4 (2-bidder) and 9 (3-bidder) allocations. Clarke payment = `maxSW(without i) − welfare_of_others_in_optimal_alloc`.

## Note on the Conitzer-Sandholm attribution
The instance uses the canonical complementarity-displacement structure from Conitzer & Sandholm (2006), "Failures of the VCG Mechanism in Combinatorial Auctions and Multi-agent Systems". The exact numerical instance (v1=10, v2=v3=8) is chosen so the optimum is unique in both settings (no VCG tie-breaking ambiguity) and every value is a small ℕ (kernel `decide` terminates instantly).

See #1469, #4980
