### PR TITLE
fix(search,#710): make MGS-19-MetropolisReinsertion notebook portable (relative paths)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-19-MetropolisReinsertion.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-19-MetropolisReinsertion.ipynb
@@ -55,7 +55,7 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
-       "async function probeAddresses(probingAddresses) {\r\n",
+       
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -65,10 +65,10 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
-       "    if (Array.isArray(probingAddresses)) {\r\n",
-       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       
+       
        "\r\n",
-       "            let rootUrl = probingAddresses[i];\r\n",
+       
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -83,7 +83,7 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
-       "                    body: probingAddresses[i]\r\n",
+       
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -95,8 +95,8 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
-       "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://2a01:e0a:9d4:f320:6701:5a41:8422:35ad:2048/\",\"http://2a01:e0a:9d4:f320:8a9:994d:a413:1f6e:2048/\",\"http://fe80::902b:f9f6:2003:66a1%20:2048/\",\"http://192.168.0.51:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::ae60:2bbf:92f7:4e06%14:2048/\",\"http://172.25.160.1:2048/\",\"http://fe80::a397:972b:8ef8:dd2%44:2048/\",\"http://172.25.0.1:2048/\"])\r\n",
+       
+       
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
@@ -145,13 +145,13 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
-       "        loadDotnetInteractiveApi();\r\n",
+       
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
-       "    loadDotnetInteractiveApi();\r\n",
+       
        "}\r\n",
        "\r\n",
        "    </script>\r\n",

--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-19-MetropolisReinsertion.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-19-MetropolisReinsertion.ipynb
@@ -35,48 +35,170 @@
   },
   {
    "cell_type": "code",
-   "id": "cell-b0567f0b",
-   "metadata": {},
    "execution_count": 1,
+   "id": "cell-b0567f0b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-20T15:36:51.848632Z",
+     "iopub.status.busy": "2026-07-20T15:36:51.835274Z",
+     "iopub.status.idle": "2026-07-20T15:36:58.562259Z",
+     "shell.execute_reply": "2026-07-20T15:36:58.544939Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://2a01:e0a:9d4:f320:6701:5a41:8422:35ad:2048/\",\"http://2a01:e0a:9d4:f320:8a9:994d:a413:1f6e:2048/\",\"http://fe80::902b:f9f6:2003:66a1%20:2048/\",\"http://192.168.0.51:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::ae60:2bbf:92f7:4e06%14:2048/\",\"http://172.25.160.1:2048/\",\"http://fe80::a397:972b:8ef8:dd2%44:2048/\",\"http://172.25.0.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '38200.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "DLLs chargees. Operateurs de reinsertion du fork :\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  FitnessBasedElitistReinsertion  (defaut GA, global mu+lambda) : FitnessBasedElitistReinsertion\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  FitnessBasedPairwiseReinsertion (pairwise greedy, compound FBI): FitnessBasedPairwiseReinsertion\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  MetropolisReinsertion           (pairwise + annealing, compound SA) : MetropolisReinsertion\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  SimulatedAnnealing               (compound complet)            : SimulatedAnnealing\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  MetaGeneticAlgorithm .Reinsertion settable       : MetaGeneticAlgorithm\r\n"
      ]
@@ -84,11 +206,11 @@
    ],
    "source": [
     "// Cablage : DLLs MetaGeneticSharp + GeneticSharp + Extensions.\n",
-    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/GeneticSharp.Infrastructure.Framework.dll\"\n",
-    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/GeneticSharp.Domain.dll\"\n",
-    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/MetaGeneticSharp.Infrastructure.dll\"\n",
-    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/MetaGeneticSharp.Domain.dll\"\n",
-    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Extensions/bin/Debug/net9.0/MetaGeneticSharp.Extensions.dll\"\n",
+    "#r \"../MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/GeneticSharp.Infrastructure.Framework.dll\"\n",
+    "#r \"../MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/GeneticSharp.Domain.dll\"\n",
+    "#r \"../MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/MetaGeneticSharp.Infrastructure.dll\"\n",
+    "#r \"../MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/MetaGeneticSharp.Domain.dll\"\n",
+    "#r \"../MetaGeneticSharp/src/MetaGeneticSharp.Extensions/bin/Debug/net9.0/MetaGeneticSharp.Extensions.dll\"\n",
     "\n",
     "using MetaGeneticSharp;\n",
     "using GeneticSharp;\n",
@@ -106,20 +228,27 @@
   },
   {
    "cell_type": "code",
-   "id": "cell-efd8ffc4",
-   "metadata": {},
    "execution_count": 2,
+   "id": "cell-efd8ffc4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-20T15:36:58.565270Z",
+     "iopub.status.busy": "2026-07-20T15:36:58.565270Z",
+     "iopub.status.idle": "2026-07-20T15:37:02.515098Z",
+     "shell.execute_reply": "2026-07-20T15:37:02.511886Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Setup OK. PopSize=50, NFE=5000 (gens=100), dim=5, seeds=7, 42, 99.\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Smoke GA+Pairwise/Sphere objectif=0,017 (proche 0 = OK).\r\n"
      ]
@@ -212,63 +341,70 @@
   },
   {
    "cell_type": "code",
-   "id": "cell-5ec92d70",
-   "metadata": {},
    "execution_count": 3,
+   "id": "cell-5ec92d70",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-20T15:37:02.518097Z",
+     "iopub.status.busy": "2026-07-20T15:37:02.517097Z",
+     "iopub.status.idle": "2026-07-20T15:37:02.874101Z",
+     "shell.execute_reply": "2026-07-20T15:37:02.874101Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "\n",
       "===== Sphere (dim=5, NFE=5000, moy 3 seeds) -- objectif (proche 0 = meilleur) =====\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Reinsertion                     |  objectif\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "----------------------------------------------\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Pairwise greedy (controle)      |     0,012\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Metropolis T0=0.2 a=0.90 (froid)|     0,014\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Metropolis T0=1.0 a=0.95 (moyen)|     0,016\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Metropolis T0=5.0 a=0.99 (chaud)|     0,099\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Elitist global (reference)      |     0,011\r\n"
      ]
@@ -309,63 +445,70 @@
   },
   {
    "cell_type": "code",
-   "id": "cell-35497f89",
-   "metadata": {},
    "execution_count": 4,
+   "id": "cell-35497f89",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-20T15:37:02.877101Z",
+     "iopub.status.busy": "2026-07-20T15:37:02.876101Z",
+     "iopub.status.idle": "2026-07-20T15:37:03.173028Z",
+     "shell.execute_reply": "2026-07-20T15:37:03.173028Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "\n",
       "===== Rastrigin (dim=5, NFE=5000, moy 3 seeds) -- objectif (proche 0 = meilleur) =====\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Reinsertion                     |  objectif\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "----------------------------------------------\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Pairwise greedy (controle)      |     1,190\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Metropolis T0=0.2 a=0.90 (froid)|     1,624\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Metropolis T0=1.0 a=0.95 (moyen)|     1,229\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Metropolis T0=5.0 a=0.99 (chaud)|     1,771\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Elitist global (reference)      |     0,385\r\n"
      ]
@@ -397,63 +540,70 @@
   },
   {
    "cell_type": "code",
-   "id": "cell-8eed3bd0",
-   "metadata": {},
    "execution_count": 5,
+   "id": "cell-8eed3bd0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-20T15:37:03.176237Z",
+     "iopub.status.busy": "2026-07-20T15:37:03.175029Z",
+     "iopub.status.idle": "2026-07-20T15:37:03.515321Z",
+     "shell.execute_reply": "2026-07-20T15:37:03.515321Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "\n",
       "===== Ackley (dim=5, NFE=5000, moy 3 seeds) -- objectif (proche 0 = meilleur) =====\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Reinsertion                     |  objectif\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "----------------------------------------------\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Pairwise greedy (controle)      |     2,743\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Metropolis T0=0.2 a=0.90 (froid)|     2,455\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Metropolis T0=1.0 a=0.95 (moyen)|     2,918\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Metropolis T0=5.0 a=0.99 (chaud)|     4,320\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Elitist global (reference)      |     2,000\r\n"
      ]
@@ -483,134 +633,141 @@
   },
   {
    "cell_type": "code",
-   "id": "cell-88454e6e",
-   "metadata": {},
    "execution_count": 6,
+   "id": "cell-88454e6e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-20T15:37:03.518324Z",
+     "iopub.status.busy": "2026-07-20T15:37:03.517322Z",
+     "iopub.status.idle": "2026-07-20T15:37:03.827145Z",
+     "shell.execute_reply": "2026-07-20T15:37:03.824619Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Cooling schedule T_k = T0 * alpha^k (k = generation, sur 100 gens) :\n",
       "\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "   k| T0=0.2 a=0.90| T0=1.0 a=0.95| T0=5.0 a=0.99\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "--------------------------------------------------\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "   0|    2,000E-001|    1,000E+000|    5,000E+000\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  10|    6,974E-002|    5,987E-001|    4,522E+000\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  20|    2,432E-002|    3,585E-001|    4,090E+000\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  30|    8,478E-003|    2,146E-001|    3,699E+000\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  40|    2,956E-003|    1,285E-001|    3,345E+000\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  50|    1,031E-003|    7,694E-002|    3,025E+000\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  60|    3,594E-004|    4,607E-002|    2,736E+000\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  70|    1,253E-004|    2,758E-002|    2,474E+000\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  80|    4,369E-005|    1,652E-002|    2,238E+000\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  90|    1,524E-005|    9,888E-003|    2,024E+000\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       " 100|    5,312E-006|    5,921E-003|    1,830E+000\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "\n",
       "Limite frozen (T0=1e-9) sur Sphere (temoin lisse) : la REGLE devient greedy :\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  Metropolis frozen = 0,0197\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  Pairwise greedy   = 0,0124\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  Ecart |frozen - pairwise| = 0,0073 (proche = regle greedy confirmee ; residu = divergence trajectoire RNG).\r\n"
      ]
@@ -705,14 +862,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 7,
    "id": "6b20fc5c141e",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-20T15:37:03.829787Z",
+     "iopub.status.busy": "2026-07-20T15:37:03.829787Z",
+     "iopub.status.idle": "2026-07-20T15:37:03.900715Z",
+     "shell.execute_reply": "2026-07-20T15:37:03.899676Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Exercice 1 a completer — implementer le tableau 3 schedules x N seeds\r\n"
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer — implementer le tableau 3 schedules x N seeds\r\n"
+     ]
     }
    ],
    "source": [
@@ -759,14 +925,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 8,
    "id": "bc53b0fcdfad",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-20T15:37:03.902374Z",
+     "iopub.status.busy": "2026-07-20T15:37:03.902374Z",
+     "iopub.status.idle": "2026-07-20T15:37:04.016007Z",
+     "shell.execute_reply": "2026-07-20T15:37:04.016007Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Exercice 2 a completer — crossover gaussien + Metropolis sur Ackley\r\n"
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer — crossover gaussien + Metropolis sur Ackley\r\n"
+     ]
     }
    ],
    "source": [
@@ -809,14 +984,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 9,
    "id": "4f48bf6bbd85",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-20T15:37:04.018844Z",
+     "iopub.status.busy": "2026-07-20T15:37:04.018316Z",
+     "iopub.status.idle": "2026-07-20T15:37:04.075650Z",
+     "shell.execute_reply": "2026-07-20T15:37:04.075144Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Exercice 3 a completer — banc archipel heterogene 4 configs x N seeds\r\n"
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer — banc archipel heterogene 4 configs x N seeds\r\n"
+     ]
     }
    ],
    "source": [


### PR DESCRIPTION
## Summary

Apply the **#710 portability pattern** to `MGS-19-MetropolisReinsertion.ipynb` — the next notebook in the Search Part4-Metaheuristics portability sweep (cf #7595 MGS-7-TSP, #7598 MGS-10-CenterBias). The notebook's wiring cell had 5 hardcoded `#r "c:/dev/MetaGeneticSharp/..."` references that only worked on a specific developer machine.

## Change

`Part4-Metaheuristics/MGS-19-MetropolisReinsertion.ipynb` — cell 2 (wiring):
- `#r "c:/dev/MetaGeneticSharp/src/.../GeneticSharp.Infrastructure.Framework.dll"` × 5 lines
- → `#r "../MetaGeneticSharp/src/.../GeneticSharp.Infrastructure.Framework.dll"` × 5 lines

**Forward-slash form** (`../MetaGeneticSharp/`) chosen for true cross-platform portability (the actual goal of #710 — not just Windows-relative), matching the canonical form already on `main` for MGS-3-Eukaryote's cell 2. .NET `#r` accepts forward slashes on Windows. Build config stays **Debug** (matches canonical, minimum surface change). MetaGeneticSharp submodule pointer NOT bumped (no submodule content change).

## Execution proof (§D / C.2 / H.1)

Re-executed end-to-end via `.net-csharp` kernel (Jupyter nbconvert), after building `MetaGeneticSharp.sln` in Debug (0 errors):

| Check | Result |
|-------|--------|
| `dotnet build MetaGeneticSharp.sln -c Debug` | **0 errors** (35 benign CA1416 platform-compat warnings) |
| Code cells executed | **9/9**, `execution_count != null` for all |
| Error outputs | **0** |
| Wiring cell (cell 2) output | `"DLLs chargees. Operateurs de reinsertion du fork :"` + the 5 operator type names — **proves the relative `../MetaGeneticSharp/` paths load the DLLs** |
| End-to-end (papermill-equivalent) | nbconvert `--execute --inplace` SUCCESS (49428 bytes written) |
| `grep -nE "raise NotImplementedError|assert False|1/0"` | none |
| Anti-regression (no `# Solution` / `# Exemple résolu` cell removed) | none removed |

Outputs regenerated (the +263/-79 diff is dominated by the regenerated .NET Interactive HTML outputs + GA-run results — expected and required for a re-executed code cell per C.2). The source-code change is exactly 5 `#r` lines.

## Scope (R3 atomicity)

1 file, 1 notebook, 1 subject — portable-path fix for MGS-19. Catalog byte-identical to main.

See #710
