### PR TITLE
fix(search,#710): make MGS-18-CecBanc notebook portable (relative paths)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-18-CecBanc.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-18-CecBanc.ipynb
@@ -35,69 +35,191 @@
   },
   {
    "cell_type": "code",
-   "id": "c01",
-   "metadata": {},
    "execution_count": 1,
+   "id": "c01",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-20T15:49:04.285266Z",
+     "iopub.status.busy": "2026-07-20T15:49:04.274330Z",
+     "iopub.status.idle": "2026-07-20T15:49:09.415841Z",
+     "shell.execute_reply": "2026-07-20T15:49:09.403243Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://2a01:e0a:9d4:f320:6701:5a41:8422:35ad:2048/\",\"http://2a01:e0a:9d4:f320:8a9:994d:a413:1f6e:2048/\",\"http://fe80::902b:f9f6:2003:66a1%20:2048/\",\"http://192.168.0.51:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::ae60:2bbf:92f7:4e06%14:2048/\",\"http://172.25.160.1:2048/\",\"http://fe80::a397:972b:8ef8:dd2%44:2048/\",\"http://172.25.0.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '21668.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "DLLs chargees. Moteur de-biais CEC :\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  ShiftedFitness         : ShiftedFitness\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  RotatedFitness         : RotatedFitness\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  ShiftVectors           : ShiftVectors\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  RotationMatrices       : RotationMatrices\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  CenterBiasBenchmark    : CenterBiasBenchmark\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  MetaHeuristicsService  : MetaHeuristicsService\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  AckleyFitness          : AckleyFitness\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  RosenbrockFitness      : RosenbrockFitness\r\n"
      ]
@@ -105,11 +227,11 @@
    ],
    "source": [
     "// Cablage : DLLs MetaGeneticSharp + GeneticSharp + Extensions (KnownFunctions + decorateurs + banc).\n",
-    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/GeneticSharp.Infrastructure.Framework.dll\"\n",
-    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/GeneticSharp.Domain.dll\"\n",
-    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/MetaGeneticSharp.Infrastructure.dll\"\n",
-    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/MetaGeneticSharp.Domain.dll\"\n",
-    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Extensions/bin/Debug/net9.0/MetaGeneticSharp.Extensions.dll\"\n",
+    "#r \"../MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/GeneticSharp.Infrastructure.Framework.dll\"\n",
+    "#r \"../MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/GeneticSharp.Domain.dll\"\n",
+    "#r \"../MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/MetaGeneticSharp.Infrastructure.dll\"\n",
+    "#r \"../MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/MetaGeneticSharp.Domain.dll\"\n",
+    "#r \"../MetaGeneticSharp/src/MetaGeneticSharp.Extensions/bin/Debug/net9.0/MetaGeneticSharp.Extensions.dll\"\n",
     "\n",
     "using MetaGeneticSharp;\n",
     "using GeneticSharp;\n",
@@ -130,20 +252,27 @@
   },
   {
    "cell_type": "code",
-   "id": "c02",
-   "metadata": {},
    "execution_count": 2,
+   "id": "c02",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-20T15:49:09.418500Z",
+     "iopub.status.busy": "2026-07-20T15:49:09.418500Z",
+     "iopub.status.idle": "2026-07-20T15:49:11.204028Z",
+     "shell.execute_reply": "2026-07-20T15:49:11.204028Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Setup OK. PopSize=50, NFE=5000 (gens=100). Smoke GA/Sphere objectif=0,008 (proche 0 = OK).\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Portfolio : 8 optimiseurs.\r\n"
      ]
@@ -217,105 +346,112 @@
   },
   {
    "cell_type": "code",
-   "id": "c03",
-   "metadata": {},
    "execution_count": 3,
+   "id": "c03",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-20T15:49:11.206388Z",
+     "iopub.status.busy": "2026-07-20T15:49:11.206388Z",
+     "iopub.status.idle": "2026-07-20T15:49:11.495986Z",
+     "shell.execute_reply": "2026-07-20T15:49:11.495986Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Offset (decalage de loptimum) : ["
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  -0,11"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  -1,82"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  -0,17"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "   1,62"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  -1,31"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       " ]\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Matrice de rotation 5x5 orthogonale (Seeded, seed=23) : construite.\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  Verif orthogonalite : ||M*M^T - I||_F = 0,0000 (proche 0 = orthogonal OK).\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "\n",
       "Sanity Ackley au point x=(1,2,3,4,5) (objectif, les 4 doivent differe) :\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  plain    : 9,6973\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  shifted  : 12,1977\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  rotated  : 10,7205\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  combined : 13,0514\r\n"
      ]
@@ -372,84 +508,91 @@
   },
   {
    "cell_type": "code",
-   "id": "c04",
-   "metadata": {},
    "execution_count": 4,
+   "id": "c04",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-20T15:49:11.497988Z",
+     "iopub.status.busy": "2026-07-20T15:49:11.497988Z",
+     "iopub.status.idle": "2026-07-20T15:49:21.133203Z",
+     "shell.execute_reply": "2026-07-20T15:49:21.132193Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "\n",
       "===== Ackley (dim=5, NFE=5000, moy 3 seeds) -- objectif (proche 0 = meilleur) =====\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Optimiseur|     plain|   shifted|   rotated|  combined|  pire-cas\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "--------------------------------------------------------------\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Random   |     8,609|     6,739|     9,127|     6,200|     9,127\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "GA       |     2,000|     1,645|     3,242|     2,705|     3,242\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "WOA      |     0,000|     2,971|     1,198|     2,421|     2,971\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "EO       |     0,000|     0,000|     0,000|     0,000|     0,000\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "FBI      |     0,000|     0,000|     0,000|     0,000|     0,000\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "DE       |     0,000|     0,000|     0,000|     0,000|     0,000\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "BBPSO    |     0,000|     1,740|     0,000|     1,475|     1,740\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "SA       |     0,003|     0,005|     0,006|     0,006|     0,006\r\n"
      ]
@@ -510,84 +653,91 @@
   },
   {
    "cell_type": "code",
-   "id": "c06",
-   "metadata": {},
    "execution_count": 5,
+   "id": "c06",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-20T15:49:21.135204Z",
+     "iopub.status.busy": "2026-07-20T15:49:21.135204Z",
+     "iopub.status.idle": "2026-07-20T15:49:27.846794Z",
+     "shell.execute_reply": "2026-07-20T15:49:27.846794Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "\n",
       "===== Interaction Ackley : le combine est-il additif ? =====\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Optimiseur|  d_shift|    d_rot|    somme|   d_comb| interaction\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "------------------------------------------------------------\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Random   |   -1,870|    0,518|   -1,353|   -2,409|  -1,057 sous-additif\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "GA       |   -0,355|    1,243|    0,888|    0,705|  -0,182 additif\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "WOA      |    2,971|    1,198|    4,169|    2,421|  -1,748 sous-additif\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "EO       |    0,000|    0,000|    0,000|    0,000|  -0,000 additif\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "FBI      |    0,000|    0,000|    0,000|    0,000|  -0,000 additif\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "DE       |   -0,000|   -0,000|   -0,000|   -0,000|   0,000 additif\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "BBPSO    |    1,740|   -0,000|    1,740|    1,475|  -0,265 additif\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "SA       |    0,001|    0,003|    0,004|    0,003|  -0,002 additif\r\n"
      ]
@@ -624,84 +774,91 @@
   },
   {
    "cell_type": "code",
-   "id": "c07",
-   "metadata": {},
    "execution_count": 6,
+   "id": "c07",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-20T15:49:27.850190Z",
+     "iopub.status.busy": "2026-07-20T15:49:27.849178Z",
+     "iopub.status.idle": "2026-07-20T15:49:34.652403Z",
+     "shell.execute_reply": "2026-07-20T15:49:34.651403Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "\n",
       "===== Rosenbrock (dim=5, NFE=5000, moy 3 seeds) -- objectif (proche 0 = meilleur) =====\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Optimiseur|     plain|   shifted|   rotated|  combined|  pire-cas\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "--------------------------------------------------------------\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Random   |    14,393|     9,548|    12,455|    13,227|    14,393\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "GA       |     1,680|     2,813|     3,705|     3,482|     3,705\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "WOA      |     2,818|     5,185|     3,126|     6,910|     6,910\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "EO       |     1,681|     2,781|     1,470|     2,500|     2,781\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "FBI      |     2,324|     1,528|     2,743|     2,369|     2,743\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "DE       |     1,584|     0,920|     1,706|     1,498|     1,706\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "BBPSO    |     2,158|     2,415|     3,327|     2,957|     3,327\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "SA       |     1,719|     1,751|     1,067|     1,407|     1,751\r\n"
      ]
@@ -725,90 +882,97 @@
   },
   {
    "cell_type": "code",
-   "id": "c08",
-   "metadata": {},
    "execution_count": 7,
+   "id": "c08",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-20T15:49:34.654158Z",
+     "iopub.status.busy": "2026-07-20T15:49:34.654158Z",
+     "iopub.status.idle": "2026-07-20T15:49:47.330580Z",
+     "shell.execute_reply": "2026-07-20T15:49:47.329577Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "===== Synthese robustesse CEC : pire-cas (max) sur Ackley+Rosenbrock x 4 variantes =====\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Optimiseur| Ackley pire| Rosenbrock pire|verdict\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "------------------------------------------------------------\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Random   |       9,127|          14,393|a eviter\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "GA       |       3,242|           3,705|moyen\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "WOA      |       2,971|           6,910|a eviter\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "EO       |       0,000|           2,781|moyen\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "FBI      |       0,000|           2,743|moyen\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "DE       |       0,000|           1,706|moyen\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "BBPSO    |       1,740|           3,327|moyen\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "SA       |       0,006|           1,751|moyen\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "\n",
       "=> La these structurelle (DE/SA vectoriels > EO/BBPSO > WOA ancre > GA composante) tient-elle sous le combine ?\r\n"
@@ -853,13 +1017,20 @@
   },
   {
    "cell_type": "code",
-   "id": "e1c",
-   "metadata": {},
    "execution_count": 8,
+   "id": "e1c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-20T15:49:47.332579Z",
+     "iopub.status.busy": "2026-07-20T15:49:47.331579Z",
+     "iopub.status.idle": "2026-07-20T15:49:47.422485Z",
+     "shell.execute_reply": "2026-07-20T15:49:47.422485Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Exercice a completer : banc CEC sur Griewank (cf Ackley ci-dessus).\r\n"
      ]
@@ -882,13 +1053,20 @@
   },
   {
    "cell_type": "code",
-   "id": "e2c",
-   "metadata": {},
    "execution_count": 9,
+   "id": "e2c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-20T15:49:47.424486Z",
+     "iopub.status.busy": "2026-07-20T15:49:47.424486Z",
+     "iopub.status.idle": "2026-07-20T15:49:47.446926Z",
+     "shell.execute_reply": "2026-07-20T15:49:47.445929Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Exercice a completer : trouver interaction super-additive (cf InteractionTable).\r\n"
      ]
@@ -911,13 +1089,20 @@
   },
   {
    "cell_type": "code",
-   "id": "e3c",
-   "metadata": {},
    "execution_count": 10,
+   "id": "e3c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-20T15:49:47.448929Z",
+     "iopub.status.busy": "2026-07-20T15:49:47.447928Z",
+     "iopub.status.idle": "2026-07-20T15:49:47.482777Z",
+     "shell.execute_reply": "2026-07-20T15:49:47.482271Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Exercice a completer : effet de la dimension sur le signal combine.\r\n"
      ]
@@ -940,13 +1125,20 @@
   },
   {
    "cell_type": "code",
-   "id": "e4c",
-   "metadata": {},
    "execution_count": 11,
+   "id": "e4c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-20T15:49:47.484786Z",
+     "iopub.status.busy": "2026-07-20T15:49:47.484786Z",
+     "iopub.status.idle": "2026-07-20T15:49:47.509988Z",
+     "shell.execute_reply": "2026-07-20T15:49:47.508987Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Exercice a completer : banc CEC augmente dun 3e decorateur de bruit.\r\n"
      ]
@@ -984,7 +1176,11 @@
    "name": ".net-csharp"
   },
   "language_info": {
-   "name": "C#"
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-18-CecBanc.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-18-CecBanc.ipynb
@@ -55,7 +55,7 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
-       "async function probeAddresses(probingAddresses) {\r\n",
+       
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -65,10 +65,10 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
-       "    if (Array.isArray(probingAddresses)) {\r\n",
-       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       
+       
        "\r\n",
-       "            let rootUrl = probingAddresses[i];\r\n",
+       
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -83,7 +83,7 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
-       "                    body: probingAddresses[i]\r\n",
+       
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -95,8 +95,8 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
-       "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://2a01:e0a:9d4:f320:6701:5a41:8422:35ad:2048/\",\"http://2a01:e0a:9d4:f320:8a9:994d:a413:1f6e:2048/\",\"http://fe80::902b:f9f6:2003:66a1%20:2048/\",\"http://192.168.0.51:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::ae60:2bbf:92f7:4e06%14:2048/\",\"http://172.25.160.1:2048/\",\"http://fe80::a397:972b:8ef8:dd2%44:2048/\",\"http://172.25.0.1:2048/\"])\r\n",
+       
+       
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
@@ -145,13 +145,13 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
-       "        loadDotnetInteractiveApi();\r\n",
+       
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
-       "    loadDotnetInteractiveApi();\r\n",
+       
        "}\r\n",
        "\r\n",
        "    </script>\r\n",


### PR DESCRIPTION
## Summary

Apply the **#710 portability pattern** to `MGS-18-CecBanc.ipynb` — the next notebook in the Search Part4-Metaheuristics portability sweep (cf #7595 MGS-7-TSP, #7598 MGS-10-CenterBias, #7603 MGS-19). The notebook's wiring cell had 5 hardcoded `#r "c:/dev/MetaGeneticSharp/..."` references that only worked on a specific developer machine.

## Change

`Part4-Metaheuristics/MGS-18-CecBanc.ipynb` — cell 2 (wiring):
- `#r "c:/dev/MetaGeneticSharp/src/.../GeneticSharp.Infrastructure.Framework.dll"` × 5 lines
- → `#r "../MetaGeneticSharp/src/.../GeneticSharp.Infrastructure.Framework.dll"` × 5 lines

**Forward-slash form** (`../MetaGeneticSharp/`) chosen for true cross-platform portability (the actual goal of #710 — not just Windows-relative), matching the canonical form already on `main` for MGS-3-Eukaryote's cell 2. .NET `#r` accepts forward slashes on Windows. Build config stays **Debug** (matches canonical, minimum surface change). MetaGeneticSharp submodule pointer NOT bumped (no submodule content change).

## Execution proof (§D / C.2 / H.1)

Re-executed end-to-end via `.net-csharp` kernel (Jupyter nbconvert), after building `MetaGeneticSharp.sln` in Debug (0 errors):

| Check | Result |
|-------|--------|
| `dotnet build MetaGeneticSharp.sln -c Debug` | **0 errors** (benign CA1416 platform-compat warnings) |
| Code cells executed | **11/11**, `execution_count != null` for all |
| Error outputs | **0** |
| Wiring cell (cell 2) output | `"DLLs chargees. Moteur de-biais CEC :"` + the de-bias engine type names — **proves the relative `../MetaGeneticSharp/` paths load the DLLs** |
| End-to-end (papermill-equivalent) | nbconvert `--execute --inplace` SUCCESS (46365 bytes written) |
| `grep -nE "raise NotImplementedError|assert False|1/0"` | none |
| Anti-regression (no `# Solution` / `# Exemple résolu` cell removed) | none removed |

Outputs regenerated (the diff is dominated by the regenerated .NET Interactive HTML outputs + CEC-benchmark results — expected and required for a re-executed code cell per C.2). The source-code change is exactly 5 `#r` lines.

## Scope (R3 atomicity)

1 file, 1 notebook, 1 subject — portable-path fix for MGS-18. Catalog byte-identical to main.

See #710
