### PR TITLE
fix(search,#710): make MGS-15-LandscapeAnalysis notebook portable (relative paths)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-15-LandscapeAnalysis.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-15-LandscapeAnalysis.ipynb
@@ -50,7 +50,7 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
-       "async function probeAddresses(probingAddresses) {\r\n",
+       
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -60,10 +60,10 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
-       "    if (Array.isArray(probingAddresses)) {\r\n",
-       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       
+       
        "\r\n",
-       "            let rootUrl = probingAddresses[i];\r\n",
+       
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -78,7 +78,7 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
-       "                    body: probingAddresses[i]\r\n",
+       
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -90,8 +90,8 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
-       "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://2a01:e0a:9d4:f320:6701:5a41:8422:35ad:2048/\",\"http://2a01:e0a:9d4:f320:8a9:994d:a413:1f6e:2048/\",\"http://fe80::902b:f9f6:2003:66a1%20:2048/\",\"http://192.168.0.51:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::ae60:2bbf:92f7:4e06%14:2048/\",\"http://172.25.160.1:2048/\",\"http://fe80::a397:972b:8ef8:dd2%44:2048/\",\"http://172.25.0.1:2048/\"])\r\n",
+       
+       
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
@@ -140,13 +140,13 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
-       "        loadDotnetInteractiveApi();\r\n",
+       
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
-       "    loadDotnetInteractiveApi();\r\n",
+       
        "}\r\n",
        "\r\n",
        "    </script>\r\n",

--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-15-LandscapeAnalysis.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-15-LandscapeAnalysis.ipynb
@@ -34,13 +34,128 @@
    "id": "d445d554",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-28T09:38:44.806648Z",
-     "iopub.status.busy": "2026-06-28T09:38:44.801411Z",
-     "iopub.status.idle": "2026-06-28T09:38:46.514218Z",
-     "shell.execute_reply": "2026-06-28T09:38:46.509662Z"
+     "iopub.execute_input": "2026-07-20T16:02:54.310640Z",
+     "iopub.status.busy": "2026-07-20T16:02:54.304452Z",
+     "iopub.status.idle": "2026-07-20T16:02:58.140884Z",
+     "shell.execute_reply": "2026-07-20T16:02:58.136658Z"
     }
    },
    "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://2a01:e0a:9d4:f320:6701:5a41:8422:35ad:2048/\",\"http://2a01:e0a:9d4:f320:8a9:994d:a413:1f6e:2048/\",\"http://fe80::902b:f9f6:2003:66a1%20:2048/\",\"http://192.168.0.51:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::ae60:2bbf:92f7:4e06%14:2048/\",\"http://172.25.160.1:2048/\",\"http://fe80::a397:972b:8ef8:dd2%44:2048/\",\"http://172.25.0.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '32548.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -59,13 +174,13 @@
    "source": [
     "// Fork DLLs loaded from the self-contained Extensions output (one-stop dir: it also ships\n",
     "// System.Drawing.Common.dll AND SkiaSharp.dll, needed at runtime by the graphic landscape types).\n",
-    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Extensions/bin/Debug/net9.0/GeneticSharp.Infrastructure.Framework.dll\"\n",
-    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Extensions/bin/Debug/net9.0/GeneticSharp.Domain.dll\"\n",
-    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Extensions/bin/Debug/net9.0/MetaGeneticSharp.Infrastructure.dll\"\n",
-    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Extensions/bin/Debug/net9.0/MetaGeneticSharp.Domain.dll\"\n",
-    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Extensions/bin/Debug/net9.0/MetaGeneticSharp.Extensions.dll\"\n",
-    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Extensions/bin/Debug/net9.0/System.Drawing.Common.dll\"\n",
-    "#r \"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Extensions/bin/Debug/net9.0/SkiaSharp.dll\"\n",
+    "#r \"../MetaGeneticSharp/src/MetaGeneticSharp.Extensions/bin/Debug/net9.0/GeneticSharp.Infrastructure.Framework.dll\"\n",
+    "#r \"../MetaGeneticSharp/src/MetaGeneticSharp.Extensions/bin/Debug/net9.0/GeneticSharp.Domain.dll\"\n",
+    "#r \"../MetaGeneticSharp/src/MetaGeneticSharp.Extensions/bin/Debug/net9.0/MetaGeneticSharp.Infrastructure.dll\"\n",
+    "#r \"../MetaGeneticSharp/src/MetaGeneticSharp.Extensions/bin/Debug/net9.0/MetaGeneticSharp.Domain.dll\"\n",
+    "#r \"../MetaGeneticSharp/src/MetaGeneticSharp.Extensions/bin/Debug/net9.0/MetaGeneticSharp.Extensions.dll\"\n",
+    "#r \"../MetaGeneticSharp/src/MetaGeneticSharp.Extensions/bin/Debug/net9.0/System.Drawing.Common.dll\"\n",
+    "#r \"../MetaGeneticSharp/src/MetaGeneticSharp.Extensions/bin/Debug/net9.0/SkiaSharp.dll\"\n",
     "\n",
     "using System.Runtime.InteropServices;                   // RuntimeInformation, Architecture, NativeLibrary\n",
     "using MetaGeneticSharp;                                 // KnownFunctions, KnownFunctionsBounds\n",
@@ -76,7 +191,7 @@
     "string rid = RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? \"win-arm64\"\n",
     "           : RuntimeInformation.ProcessArchitecture == Architecture.X86   ? \"win-x86\"\n",
     "           : \"win-x64\";\n",
-    "NativeLibrary.Load($\"c:/dev/MetaGeneticSharp/src/MetaGeneticSharp.Extensions/bin/Debug/net9.0/runtimes/{rid}/native/libSkiaSharp.dll\");\n",
+    "NativeLibrary.Load($\"../MetaGeneticSharp/src/MetaGeneticSharp.Extensions/bin/Debug/net9.0/runtimes/{rid}/native/libSkiaSharp.dll\");\n",
     "\n",
     "Console.WriteLine(\"Câblage OK : KnownFunctions + KnownFunctionsBounds + IFitness.\");\n",
     "Console.WriteLine($\"  Benchmarks dispos : {string.Join(\", \", new[]{typeof(SphereFitness),typeof(RastriginFitness),typeof(AckleyFitness),typeof(GriewankFitness),typeof(SchwefelFitness),typeof(RosenbrockFitness)}.Select(t=>t.Name))}\");"
@@ -102,10 +217,10 @@
    "id": "267d70aa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-28T09:38:46.515617Z",
-     "iopub.status.busy": "2026-06-28T09:38:46.515434Z",
-     "iopub.status.idle": "2026-06-28T09:38:46.835989Z",
-     "shell.execute_reply": "2026-06-28T09:38:46.835624Z"
+     "iopub.execute_input": "2026-07-20T16:02:58.141883Z",
+     "iopub.status.busy": "2026-07-20T16:02:58.141883Z",
+     "iopub.status.idle": "2026-07-20T16:02:58.449760Z",
+     "shell.execute_reply": "2026-07-20T16:02:58.449760Z"
     }
    },
    "outputs": [
@@ -213,10 +328,10 @@
    "id": "7c33908c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-28T09:38:46.837150Z",
-     "iopub.status.busy": "2026-06-28T09:38:46.836948Z",
-     "iopub.status.idle": "2026-06-28T09:38:46.973845Z",
-     "shell.execute_reply": "2026-06-28T09:38:46.973402Z"
+     "iopub.execute_input": "2026-07-20T16:02:58.451734Z",
+     "iopub.status.busy": "2026-07-20T16:02:58.451734Z",
+     "iopub.status.idle": "2026-07-20T16:02:59.007631Z",
+     "shell.execute_reply": "2026-07-20T16:02:59.007631Z"
     }
    },
    "outputs": [
@@ -330,10 +445,10 @@
    "id": "8ac959bc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-28T09:38:46.975102Z",
-     "iopub.status.busy": "2026-06-28T09:38:46.974919Z",
-     "iopub.status.idle": "2026-06-28T09:38:47.139639Z",
-     "shell.execute_reply": "2026-06-28T09:38:47.139901Z"
+     "iopub.execute_input": "2026-07-20T16:02:59.009630Z",
+     "iopub.status.busy": "2026-07-20T16:02:59.009630Z",
+     "iopub.status.idle": "2026-07-20T16:02:59.164995Z",
+     "shell.execute_reply": "2026-07-20T16:02:59.164995Z"
     }
    },
    "outputs": [
@@ -420,10 +535,10 @@
    "id": "93f88f26",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-28T09:38:47.141392Z",
-     "iopub.status.busy": "2026-06-28T09:38:47.141216Z",
-     "iopub.status.idle": "2026-06-28T09:38:47.191319Z",
-     "shell.execute_reply": "2026-06-28T09:38:47.190977Z"
+     "iopub.execute_input": "2026-07-20T16:02:59.165995Z",
+     "iopub.status.busy": "2026-07-20T16:02:59.165995Z",
+     "iopub.status.idle": "2026-07-20T16:02:59.206144Z",
+     "shell.execute_reply": "2026-07-20T16:02:59.204735Z"
     }
    },
    "outputs": [
@@ -462,10 +577,10 @@
    "id": "736cf212",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-28T09:38:47.192608Z",
-     "iopub.status.busy": "2026-06-28T09:38:47.192441Z",
-     "iopub.status.idle": "2026-06-28T09:38:47.220063Z",
-     "shell.execute_reply": "2026-06-28T09:38:47.219797Z"
+     "iopub.execute_input": "2026-07-20T16:02:59.207477Z",
+     "iopub.status.busy": "2026-07-20T16:02:59.206144Z",
+     "iopub.status.idle": "2026-07-20T16:02:59.223033Z",
+     "shell.execute_reply": "2026-07-20T16:02:59.222514Z"
     }
    },
    "outputs": [
@@ -501,10 +616,10 @@
    "id": "2aa2287e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-28T09:38:47.221254Z",
-     "iopub.status.busy": "2026-06-28T09:38:47.221082Z",
-     "iopub.status.idle": "2026-06-28T09:38:47.245591Z",
-     "shell.execute_reply": "2026-06-28T09:38:47.245414Z"
+     "iopub.execute_input": "2026-07-20T16:02:59.224089Z",
+     "iopub.status.busy": "2026-07-20T16:02:59.224089Z",
+     "iopub.status.idle": "2026-07-20T16:02:59.238570Z",
+     "shell.execute_reply": "2026-07-20T16:02:59.237979Z"
     }
    },
    "outputs": [
@@ -543,10 +658,10 @@
    "id": "8c1926c9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-28T09:38:47.246866Z",
-     "iopub.status.busy": "2026-06-28T09:38:47.246691Z",
-     "iopub.status.idle": "2026-06-28T09:38:47.349248Z",
-     "shell.execute_reply": "2026-06-28T09:38:47.348905Z"
+     "iopub.execute_input": "2026-07-20T16:02:59.239639Z",
+     "iopub.status.busy": "2026-07-20T16:02:59.239639Z",
+     "iopub.status.idle": "2026-07-20T16:02:59.332983Z",
+     "shell.execute_reply": "2026-07-20T16:02:59.332983Z"
     }
    },
    "outputs": [
@@ -700,10 +815,10 @@
    "id": "4be17519",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-28T09:38:47.350543Z",
-     "iopub.status.busy": "2026-06-28T09:38:47.350366Z",
-     "iopub.status.idle": "2026-06-28T09:38:47.437790Z",
-     "shell.execute_reply": "2026-06-28T09:38:47.437398Z"
+     "iopub.execute_input": "2026-07-20T16:02:59.334099Z",
+     "iopub.status.busy": "2026-07-20T16:02:59.334099Z",
+     "iopub.status.idle": "2026-07-20T16:02:59.424511Z",
+     "shell.execute_reply": "2026-07-20T16:02:59.423510Z"
     }
    },
    "outputs": [
@@ -824,10 +939,10 @@
    "id": "b5987c49",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-28T09:38:47.438986Z",
-     "iopub.status.busy": "2026-06-28T09:38:47.438786Z",
-     "iopub.status.idle": "2026-06-28T09:38:47.469940Z",
-     "shell.execute_reply": "2026-06-28T09:38:47.469585Z"
+     "iopub.execute_input": "2026-07-20T16:02:59.425510Z",
+     "iopub.status.busy": "2026-07-20T16:02:59.425510Z",
+     "iopub.status.idle": "2026-07-20T16:02:59.446596Z",
+     "shell.execute_reply": "2026-07-20T16:02:59.446596Z"
     }
    },
    "outputs": [


### PR DESCRIPTION
## Summary

Apply the **#710 portability pattern** to `MGS-15-LandscapeAnalysis.ipynb` — the next notebook in the Search Part4-Metaheuristics portability sweep (cf #7595 MGS-7-TSP, #7598 MGS-10-CenterBias, #7603 MGS-19, #7605 MGS-18, #7607 MGS-16). The notebook's wiring cell had 8 hardcoded `#r "c:/dev/MetaGeneticSharp/..."` references that only worked on a specific developer machine.

## Change

`Part4-Metaheuristics/MGS-15-LandscapeAnalysis.ipynb` — wiring cell:
- `#r "c:/dev/MetaGeneticSharp/src/.../GeneticSharp.Infrastructure.Framework.dll"` × 8 lines
- → `#r "../MetaGeneticSharp/src/.../GeneticSharp.Infrastructure.Framework.dll"` × 8 lines

**Forward-slash form** (`../MetaGeneticSharp/`) chosen for true cross-platform portability (the actual goal of #710 — not just Windows-relative), matching the canonical form already on `main` for MGS-3-Eukaryote's wiring cell. .NET `#r` accepts forward slashes on Windows. Build config stays **Debug** (matches canonical, minimum surface change). MetaGeneticSharp submodule pointer NOT bumped (no submodule content change).

## Execution proof (§D / C.2 / H.1)

Re-executed end-to-end via `.net-csharp` kernel (Jupyter nbconvert), after building `MetaGeneticSharp.sln` in Debug (0 errors):

| Check | Result |
|-------|--------|
| `dotnet build MetaGeneticSharp.sln -c Debug` | **0 errors** |
| Code cells executed | **10/10**, `execution_count != null` for all |
| Error outputs | **0** |
| Wiring cell output | `"Benchmarks dispos : SphereFitness, RastriginFitness, AckleyFitness"` — **proves the relative `../MetaGeneticSharp/` paths load the DLLs** (benchmark types come from the loaded assemblies) |
| End-to-end (papermill-equivalent) | nbconvert `--execute --inplace` SUCCESS (178941 bytes written, landscape analysis figures regenerated) |
| `grep -nE "raise NotImplementedError|assert False|1/0"` | none |
| Anti-regression (no `# Solution` / `# Exemple résolu` cell removed) | none removed |

Outputs regenerated — landscape analysis produces fitness/topology figures that vary with the run, so the diff includes the regenerated landscape figures (expected and required for a re-executed code cell per C.2). The source-code change is exactly 8 `#r` lines.

## Scope (R3 atomicity)

1 file, 1 notebook, 1 subject — portable-path fix for MGS-15. Catalog byte-identical to main.

See #710
