### PR TITLE
fix(search): make MGS-3/4/6 prereq markdown portable (relative build path)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-3-Eukaryote.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-3-Eukaryote.ipynb
@@ -169,7 +169,7 @@
     "\n",
     "La cellule suivante charge les DLL MetaGeneticSharp et GeneticSharp depuis le build du sous-module. Assurez-vous que le build est a jour avant d'executer ce notebook.\n",
     "\n",
-    "> **Note** : si le wiring echoue, verifiez que le sous-module GeneticSharp est initialise (`git submodule update --init GeneticSharp`) et que le build est a jour (`dotnet build` depuis `c:/dev/MetaGeneticSharp`)."
+    "> **Note** : si le wiring echoue, verifiez que le sous-module GeneticSharp est initialise (`git submodule update --init GeneticSharp`) et que le build est a jour (`dotnet build` depuis `../MetaGeneticSharp`)."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-4-Islands.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-4-Islands.ipynb
@@ -206,7 +206,7 @@
     "\n",
     "La cellule suivante charge les DLL MetaGeneticSharp et GeneticSharp depuis le build du sous-module. Assurez-vous que le build est a jour avant d'executer ce notebook.\n",
     "\n",
-    "> **Note** : si le wiring echoue, verifiez que le sous-module GeneticSharp est initialise (`git submodule update --init GeneticSharp`) et que le build est a jour (`dotnet build` depuis `c:/dev/MetaGeneticSharp`)."
+    "> **Note** : si le wiring echoue, verifiez que le sous-module GeneticSharp est initialise (`git submodule update --init GeneticSharp`) et que le build est a jour (`dotnet build` depuis `../MetaGeneticSharp`)."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-6-Benchmarks.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-6-Benchmarks.ipynb
@@ -21,7 +21,8 @@
     "\n",
     "Si le design primitives-based est valable, WOA-from-primitives doit être **compétitif** avec Islands (un schéma éprouvé) sur la plupart des surfaces -- sans être une boîte noire. C'est l'argument : la composition ouverte bat ou égale la métaphore opaque.\n",
     "\n",
-    "> **Rappel C.2** : ce notebook s'exécute sur le kernel `.net-csharp` et charge les DLL de MetaGeneticSharp (Domain + Extensions) depuis le build du fork. Prérequis : `dotnet build` dans `c:/dev/MetaGeneticSharp`.\n"
+    "> **Rappel C.2** : ce notebook s'exécute sur le kernel `.net-csharp` et charge les DLL de MetaGeneticSharp (Domain + Extensions) depuis le build du fork. Prérequis : `dotnet build` dans `../MetaGeneticSharp`.\n",
+    ""
    ]
   },
   {


### PR DESCRIPTION
## Summary

Fix the residual hardcoded `c:/dev/MetaGeneticSharp` mention in the markdown prereq notes of **MGS-3-Eukaryote**, **MGS-4-Islands**, and **MGS-6-Benchmarks** → `../MetaGeneticSharp`, consistent with the code.

These 3 notebooks are **already functionally portable**: their `#r` DLL refs already use relative `../MetaGeneticSharp/src/.../net9.0/*.dll` forward-slash paths (verified firsthand — 0 absolute `#r` in code cells). The only residual was a single markdown "Note"/"Rappel C.2" per notebook citing the build path as `c:/dev/MetaGeneticSharp`. Inconsistent prose vs. code → fixed.

Continues the MGS portability sweep: #7595 (MGS-7), #7598 (MGS-10), #7601 (MGS-11), #7602 (MGS-12), #7604 (MGS-13), #7606 (MGS-14).

## Why markdown-only (no re-execution)

- **No code cell is touched** — only markdown prose (1 line per notebook).
- **C.2 exception**: when a modification is markdown-only, the previous outputs remain valid. `execution_count` and `outputs` are byte-preserved (the edit script explicitly skips them).
- No banner/leak concern (markdown cannot carry the .NET probeAddresses banner, which is kernel-injected into code-cell outputs).

## Validation

- Per-notebook: `hardcoded 1 -> 0` (the single markdown mention), code cells clean before and after.
- Diff: `+1/-1` (MGS-3, MGS-4) and `+2/-1` (MGS-6) — pure prose substitution.
- Source/outputs/execution_count: untouched (byte-preserved round-trip `json.dumps(indent=1)`).

## Hygiene

- Submodule pointer NOT bumped, catalogue byte-identical to `main`.
- Atomic by **subject** (markdown prereq-path consistency across 3 trivially-similar notebooks), not one-PR-per-file — avoids 3 near-identical trivial PRs.

See #7595 / #7598 / #7601 / #7602 / #7604 / #7606 (sweep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
