### PR TITLE
fix(ci): golden-set H.7 P3 gate no longer reds on comment-post 403

### DIFF
--- a/.github/workflows/notebook-execution-required.yml
+++ b/.github/workflows/notebook-execution-required.yml
@@ -37,6 +37,11 @@ on:
 
 permissions:
   contents: read
+  # PR comments are posted via the *issues* API (github.rest.issues.*),
+  # so the summary steps need issues:write, not just pull-requests:write.
+  # Without it, createComment/updateComment 403 "Resource not accessible
+  # by integration" — which silently killed the golden-set gate (see below).
+  issues: write
   pull-requests: write
 
 jobs:
@@ -239,21 +244,30 @@ jobs:
             }
             core.info(body);
             // Post as PR comment when on a PR; otherwise just log.
-            if (context.eventName === 'pull_request') {
-              const { data: comments } = await github.rest.issues.listComments({
-                owner: context.repo.owner, repo: context.repo.repo,
-                issue_number: context.issue.number,
-              });
-              const existing = comments.find(c => c.user.type === 'Bot' && c.body.includes('Golden-Set Execution'));
-              if (existing) {
-                await github.rest.issues.updateComment({
+            // A comment-post failure must NEVER red the execution gate: the
+            // H.7 P3 verdict reflects notebook execution (step above), not the
+            // health of this cosmetic summary step. validate-static already
+            // wraps its poster the same way; the golden-set poster did not,
+            // so a 403 on createComment silently failed the whole gate.
+            try {
+              if (context.eventName === 'pull_request') {
+                const { data: comments } = await github.rest.issues.listComments({
                   owner: context.repo.owner, repo: context.repo.repo,
-                  comment_id: existing.id, body,
+                  issue_number: context.issue.number,
                 });
-              } else {
-                await github.rest.issues.createComment({
-                  owner: context.repo.owner, repo: context.repo.repo,
-                  issue_number: context.issue.number, body,
-                });
+                const existing = comments.find(c => c.user.type === 'Bot' && c.body.includes('Golden-Set Execution'));
+                if (existing) {
+                  await github.rest.issues.updateComment({
+                    owner: context.repo.owner, repo: context.repo.repo,
+                    comment_id: existing.id, body,
+                  });
+                } else {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner, repo: context.repo.repo,
+                    issue_number: context.issue.number, body,
+                  });
+                }
               }
+            } catch (e) {
+              core.warning('Could not post golden-set summary comment: ' + e.message);
             }


### PR DESCRIPTION
## Problem

Every notebook PR's **Golden-set execution (H.7 P3)** check has been going RED even when the notebooks execute fine. Firsthand log evidence (from #7601's run `88404925191`):

- Step 5 `Execute golden-set (Papermill)` = **SUCCESS**, `✅ 8/8 notebooks passed (certified reproducible)`
- Step 6 `Post golden-set summary` = **FAILURE**: `RequestError [HttpError]: Resource not accessible by integration` (403) on `github.rest.issues.createComment`

## Root cause

1. `permissions:` granted `pull-requests: write`, but PR comments are posted through the **issues** API (`github.rest.issues.createComment`), which needs `issues: write`. So the call 403'd.
2. The golden-set poster had **no try/catch** (unlike `validate-static`'s poster, which swallows the identical error at L180-182) — so the 403 failed the whole job.

Net effect: a cosmetic comment-post failure masqueraded as an execution-gate failure, false-failing **every** notebook PR (markdown-only PRs included, e.g. #7609).

## Fix (minimal, two-part)

- Grant `issues: write` so the summary comment actually posts.
- Wrap the golden-set poster in `try/catch` (`core.warning` on failure) so the H.7 P3 verdict reflects **only** notebook execution, never comment-poster health. Mirrors the existing `validate-static` guard.

## Self-validating

Editing `.github/workflows/notebook-execution-required.yml` self-triggers `golden-set-execute` (path filter L25), so this PR's own golden-set check exercises the fix.

See #4208 / #4209 (axe A H.7 P3).