### PR TITLE
fix(translation,#6949): make provider-keys test env-hermetic

### DIFF
--- a/scripts/tests/test_translate_csv.py
+++ b/scripts/tests/test_translate_csv.py
@@ -277,6 +277,13 @@ def test_provider_keys_empty_without_env(monkeypatch):
 def test_provider_keys_read_openai_env(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test-only-in-env")
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    # DEFAULT_BASE_URL / DEFAULT_MODEL are module-level globals bound from env at
+    # import time (translate_csv.py L67-68). On a host with OPENAI_BASE_URL set
+    # (e.g. a local OpenAI-compatible proxy) the canonical assertion below would
+    # read the proxy URL instead. Sandbox the globals so the test is env-hermetic
+    # regardless of the host environment.
+    monkeypatch.setattr(tc, "DEFAULT_BASE_URL", "https://api.openai.com/v1")
+    monkeypatch.setattr(tc, "DEFAULT_MODEL", "gpt-5.5")
     provs = tc._provider_keys()
     assert len(provs) == 1
     _model, key, base = provs[0]


### PR DESCRIPTION
## Summary

`test_provider_keys_read_openai_env` failed on any host with a custom `OPENAI_BASE_URL` (e.g. a local OpenAI-compatible proxy at `http://192.168.0.47:5002/v1`):

```
AssertionError: assert 'http://192.168.0.47:5002/v1' == 'https://api.openai.com/v1'
```

**Root cause.** `DEFAULT_BASE_URL` (`scripts/translation/translate_csv.py` L68) is a **module-level global bound from `OPENAI_BASE_URL` at import time**. The test only `setenv`/`delenv`'d the API keys, never the base URL global, so on a proxified host the canonical assertion read the proxy URL.

**Fix.** Sandbox the module globals `DEFAULT_BASE_URL` / `DEFAULT_MODEL` via `monkeypatch.setattr` so the test is env-hermetic regardless of the host environment. Runtime behavior of `translate_csv.py` is unchanged (the globals still read env at import in production); only the test is sandboxed.

## Validation

```
$ python -m pytest scripts/tests/test_translate_csv.py scripts/tests/test_translation_sync.py
============================= 56 passed in 0.70s =============================
```

Was **55 passed, 1 failed** before; now **56 passed** including the round-trip acceptance test (`test_roundtrip_extract_then_check_in_sync`).

## Scope

1 file, +7/-0. No production code touched.

See #6949.

Co-Authored-By: Claude <noreply@anthropic.com>