### PR TITLE
fix(prover,#1453): degenerate-input guards on lean_utils public entry points

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/lean_utils.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/lean_utils.py
@@ -26,6 +26,25 @@ _HONEST_SORRY_RE = re.compile(
 _SORRY_TOKEN_RE = re.compile(r"\bsorry\b")
 
 
+def _require_str(name: str, value, *, allow_empty: bool = False) -> str:
+    """Boundary guard: reject None / non-str degenerate inputs (#7596-pattern, G.9).
+
+    Converts OPAQUE TypeErrors (``Path(None)`` -> "expected str", ``len(None)`` ->
+    "NoneType has no len") and AttributeErrors (``None.split()``) into clear
+    ValueErrors naming the offending argument, so a prover workflow that
+    forwards an agent-generated None filepath/content fails fast with a
+    diagnosable message instead of an opaque stack trace. By default empty
+    strings are rejected too (invalid for file paths / identifiers); pass
+    ``allow_empty=True`` for content parameters where ``''`` is a legitimate
+    input (an empty Lean file has 0 sorries).
+    """
+    if not isinstance(value, str):
+        raise ValueError(f"{name}: expected str, got {type(value).__name__}")
+    if not allow_empty and not value:
+        raise ValueError(f"{name}: expected non-empty str, got empty string")
+    return value
+
+
 def _has_lakefile(p: Path) -> bool:
     """True if directory ``p`` holds a Lake manifest (lakefile.lean/.toml)."""
     return (p / "lakefile.lean").exists() or (p / "lakefile.toml").exists()
@@ -47,6 +66,7 @@ def resolve_lake_module(filepath) -> Tuple[str, str]:
     it falls back to the legacy depth-2 derivation so callers keep working on
     non-Lake or oddly-laid-out trees.
     """
+    filepath = _require_str("filepath", filepath)
     p = Path(filepath).resolve()
     stem = p.stem
     cur = p.parent
@@ -71,6 +91,9 @@ def probe_relative_path(filepath, project_dir, tmp_name: str) -> str:
     given root lacks a lakefile, which ``resolve_lake_module`` now prevents, so
     the path must be correct at derivation. Falls back to the legacy form when the
     probe sits outside the resolved root (non-Lake / oddly-laid-out trees)."""
+    filepath = _require_str("filepath", filepath)
+    project_dir = _require_str("project_dir", project_dir)
+    tmp_name = _require_str("tmp_name", tmp_name)
     tmp_path = Path(filepath).parent / tmp_name
     try:
         return tmp_path.resolve().relative_to(Path(project_dir).resolve()).as_posix()
@@ -86,6 +109,7 @@ def strip_lean_comments(content: str) -> str:
     token ``sorry`` inside a string literal, and over-stripping there cannot
     create a false token.
     """
+    content = _require_str("content", content, allow_empty=True)
     out = []
     i, n, depth = 0, len(content), 0
     while i < n:
@@ -124,6 +148,7 @@ def count_real_sorries(content: str) -> int:
     so their deltas stay consistent — the legacy substring counter was retired
     repo-wide in one pass to avoid mixed-counter drift.
     """
+    content = _require_str("content", content, allow_empty=True)
     return len(_SORRY_TOKEN_RE.findall(strip_lean_comments(content)))
 
 
@@ -157,6 +182,7 @@ def sorry_is_in_statement(content: str, sorry_line: int) -> bool:
 
     ``--`` line comments ARE stripped per-line before the structural scan.
     """
+    content = _require_str("content", content, allow_empty=True)
     lines = content.split("\n")
     if not (1 <= sorry_line <= len(lines)):
         return False
@@ -242,6 +268,7 @@ def is_true_placeholder_goal(filepath: str, sorry_line: int) -> Tuple[bool, str]
     where probe errors cascade, or any compile/parse ambiguity — never blocks
     a legitimate run).
     """
+    filepath = _require_str("filepath", filepath)
     try:
         content = Path(filepath).read_text(encoding="utf-8")
     except OSError:
@@ -311,6 +338,7 @@ def is_honest_sorry(filepath: str, sorry_line: int,
 
     Returns (is_honest, reason). The reason is the matched comment block.
     """
+    filepath = _require_str("filepath", filepath)
     try:
         content = Path(filepath).read_text(encoding="utf-8")
     except OSError as e:
@@ -355,6 +383,7 @@ def extract_sorry_block(filepath: str, sorry_line: int, context_lines: int = 15)
       - indentation: indentation level of the sorry
       - goal_hint: extracted from comments before sorry
     """
+    filepath = _require_str("filepath", filepath)
     content = Path(filepath).read_text(encoding="utf-8")
     lines = content.split("\n")
 
@@ -428,6 +457,7 @@ def get_goal_state(filepath: str, sorry_line: int) -> Optional[str]:
     Only considers errors at the EXACT sorry line to avoid cascade errors.
     For deeply nested sorries (indent >= 8), skips probing and uses heuristics.
     """
+    filepath = _require_str("filepath", filepath)
     from .verifier import get_verifier
 
     content = Path(filepath).read_text(encoding="utf-8")
@@ -611,6 +641,7 @@ def extract_hypotheses(filepath: str, sorry_line: int) -> list:
     Parses have-statements, intro'd variables, case-pattern variables,
     split_ifs hypotheses, let-bindings, and theorem parameters.
     """
+    filepath = _require_str("filepath", filepath)
     content = Path(filepath).read_text(encoding="utf-8")
     lines = content.split("\n")
 
@@ -701,6 +732,7 @@ def extract_local_lemmas(filepath: str, sorry_lines: set = None) -> list:
 
     Returns list of names that the agent can reference as already-proven helpers.
     """
+    filepath = _require_str("filepath", filepath)
     content = Path(filepath).read_text(encoding="utf-8")
     lines = content.split("\n")
     sorry_lines = sorry_lines or set()
@@ -794,6 +826,7 @@ def classify_definitions(filepath: str, goal_identifiers: list = None) -> list:
       - signature: first line of the definition (truncated)
       - reason: why unfold may fail (if applicable)
     """
+    filepath = _require_str("filepath", filepath)
     content = Path(filepath).read_text(encoding="utf-8")
     lines = content.split("\n")
     results = []
@@ -936,6 +969,8 @@ def verify_sorry_replacement(filepath: str, sorry_line: int, replacement: str,
         ``real_build_ok`` (bool|None: real-module rebuild verdict, None if not
         attempted).
     """
+    filepath = _require_str("filepath", filepath)
+    replacement = _require_str("replacement", replacement, allow_empty=True)
     from .verifier import get_verifier
 
     content = Path(filepath).read_text(encoding="utf-8")

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_lean_utils.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_lean_utils.py
@@ -1,0 +1,233 @@
+"""Unit tests for prover ``lean_utils.py`` degenerate-input guards + happy-path.
+
+Loads ``lean_utils.py`` DIRECTLY by file path, bypassing
+``prover/__init__.py`` (which cascades the ``agent_framework`` LLM stack,
+absent on a bare CPU runner). The module's top level is stdlib-only
+(``re`` / ``pathlib`` / ``typing``); the ``from .verifier import`` statements
+are deferred inside the verifier-probing functions, so the module loads
+cleanly anywhere. Mirrors ``tests/test_decomposition_regression.py``'s
+file-path load.
+
+These tests pin two things:
+  1. **Guards (#7596-pattern, G.9):** every public ``filepath`` / ``content``
+     entry point rejects ``None`` / non-str with a clear ``ValueError`` naming
+     the offending argument — converting the OPAQUE ``TypeError`` ("NoneType
+     has no len", "expected str") / ``AttributeError`` ("None.split") that an
+     agent-generated None filepath/content previously produced into a
+     diagnosable message. ``filepath`` params also reject empty (silent
+     garbage: ``resolve_lake_module('')`` returned ``('C:\\', 'dev.CoursIA')``);
+     ``content`` params allow ``''`` (an empty Lean file has 0 sorries).
+  2. **Happy-path preservation:** the guard is pure defense-in-depth and must
+     not change behavior for valid inputs (FX-6 word-bounded sorry counting,
+     Lake-root resolution, comment stripping, sorry-block extraction).
+
+Run from ``agent_tests/``:
+    python -m pytest tests/test_lean_utils.py -q
+
+See #1453 (prover co-evolution epic), See #7477 (prover harness forensic).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+
+_spec = importlib.util.spec_from_file_location(
+    "prover_lean_utils_under_test",
+    ROOT / "prover" / "lean_utils.py",
+)
+lu = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(lu)
+
+
+# A minimal .lean file used by the filepath-function happy-path tests.
+_SAMPLE_LEAN = """\
+theorem foo (n : Nat) : n = n := by
+  sorry
+"""
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Happy-path preservation — guards must not change valid-input behavior
+# ──────────────────────────────────────────────────────────────────────────
+
+class TestCountRealSorriesHappyPath:
+    """FX-6 (#1453): word-bounded, comment-stripped sorry counting."""
+
+    def test_single_sorry(self):
+        assert lu.count_real_sorries("theorem foo := by sorry") == 1
+
+    def test_empty_content_is_zero(self):
+        # Empty string is a LEGITIMATE content input (empty file = 0 sorries).
+        assert lu.count_real_sorries("") == 0
+
+    def test_prose_sorry_in_comment_not_counted(self):
+        # "sorry" mentioned in a line comment must NOT inflate the count.
+        src = "-- sorry about the mess below\ntheorem foo := by sorry"
+        assert lu.count_real_sorries(src) == 1
+
+    def test_prose_sorry_in_block_comment_not_counted(self):
+        src = "/- this sorry is prose -/\ntheorem foo := by sorry"
+        assert lu.count_real_sorries(src) == 1
+
+    def test_multiple_real_sorries(self):
+        src = "theorem a := by sorry\ntheorem b := by sorry"
+        assert lu.count_real_sorries(src) == 2
+
+
+class TestStripLeanCommentsHappyPath:
+    def test_keeps_newline_after_line_comment(self):
+        assert lu.strip_lean_comments("-- a comment\nfoo") == "\nfoo"
+
+    def test_empty_content(self):
+        assert lu.strip_lean_comments("") == ""
+
+    def test_nested_block_comments(self):
+        # Lean allows nested /- -/ block comments.
+        assert lu.strip_lean_comments("/- outer /- inner -/ still outer -/x") == "x"
+
+
+class TestResolveLakeModuleHappyPath:
+    def test_finds_lake_root_and_dotted_module(self, tmp_path):
+        (tmp_path / "lakefile.lean").write_text("")
+        pkg = tmp_path / "Conway" / "Life"
+        pkg.mkdir(parents=True)
+        f = pkg / "HashlifeCorrectness.lean"
+        f.write_text("")
+        root, module = lu.resolve_lake_module(str(f))
+        assert root == str(tmp_path)
+        assert module == "Conway.Life.HashlifeCorrectness"
+
+    def test_fallback_legacy_depth2_when_no_lakefile(self, tmp_path):
+        # No lakefile anywhere up the tree -> legacy depth-2 derivation.
+        pkg = tmp_path / "Foo"
+        pkg.mkdir(parents=True)
+        f = pkg / "Nim.lean"
+        f.write_text("")
+        root, module = lu.resolve_lake_module(str(f))
+        assert module == "Foo.Nim"
+
+
+class TestClassifyDefinitionsHappyPath:
+    def test_classifies_inductive_and_def(self, tmp_path):
+        f = tmp_path / "M.lean"
+        f.write_text(
+            "inductive Nat where\n"
+            "  | zero\n"
+            "def inc (n : Nat) := Nat.zero\n"
+        )
+        defs = lu.classify_definitions(str(f))
+        kinds = {d["name"]: d["kind"] for d in defs}
+        assert kinds.get("Nat") == "inductive"
+        assert kinds.get("inc") == "def"
+
+
+class TestExtractSorryBlockHappyPath:
+    def test_returns_sorry_context(self, tmp_path):
+        f = tmp_path / "P.lean"
+        f.write_text(_SAMPLE_LEAN)
+        block = lu.extract_sorry_block(str(f), 2)
+        assert "error" not in block
+        assert block["sorry_line"] == 2
+        assert "sorry" in block["sorry_text"]
+
+    def test_out_of_range_line_returns_error_dict(self, tmp_path):
+        f = tmp_path / "P.lean"
+        f.write_text(_SAMPLE_LEAN)
+        block = lu.extract_sorry_block(str(f), 99)
+        assert "error" in block  # graceful, not an exception
+
+
+class TestSorryIsInStatementHappyPath:
+    def test_sorry_in_body_returns_false(self):
+        src = "theorem foo : True := by\n  sorry"
+        assert lu.sorry_is_in_statement(src, 2) is False
+
+    def test_empty_content_returns_false(self):
+        assert lu.sorry_is_in_statement("", 1) is False
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Guards — degenerate inputs raise clear ValueError (#7596-pattern)
+# ──────────────────────────────────────────────────────────────────────────
+
+class TestContentGuardsRejectNone:
+    """content params reject None / non-str but ALLOW empty string."""
+
+    @pytest.mark.parametrize("fn", [
+        lu.count_real_sorries,
+        lu.strip_lean_comments,
+        lu.sorry_is_in_statement,
+    ])
+    def test_none_rejected(self, fn):
+        with pytest.raises(ValueError, match="expected str"):
+            if fn is lu.sorry_is_in_statement:
+                fn(None, 1)
+            else:
+                fn(None)
+
+    def test_non_str_rejected(self):
+        with pytest.raises(ValueError, match="expected str"):
+            lu.count_real_sorries(123)
+
+
+class TestFilepathGuardsRejectNoneAndEmpty:
+    """filepath params reject None / non-str / empty (empty = silent garbage)."""
+
+    FILEPATH_FNS = [
+        ("resolve_lake_module", lambda: lu.resolve_lake_module(None)),
+        ("extract_sorry_block", lambda: lu.extract_sorry_block(None, 1)),
+        ("classify_definitions", lambda: lu.classify_definitions(None)),
+        ("extract_hypotheses", lambda: lu.extract_hypotheses(None, 1)),
+        ("extract_local_lemmas", lambda: lu.extract_local_lemmas(None)),
+        ("get_goal_state", lambda: lu.get_goal_state(None, 1)),
+        ("is_true_placeholder_goal", lambda: lu.is_true_placeholder_goal(None, 1)),
+        ("is_honest_sorry", lambda: lu.is_honest_sorry(None, 1)),
+        ("verify_sorry_replacement", lambda: lu.verify_sorry_replacement(None, 1, "trivial")),
+    ]
+
+    @pytest.mark.parametrize("name,call", FILEPATH_FNS)
+    def test_none_rejected(self, name, call):
+        with pytest.raises(ValueError, match="filepath: expected str"):
+            call()
+
+    @pytest.mark.parametrize("name,call", [
+        ("resolve_lake_module", lambda: lu.resolve_lake_module("")),
+        ("extract_sorry_block", lambda: lu.extract_sorry_block("", 1)),
+        ("classify_definitions", lambda: lu.classify_definitions("")),
+        ("extract_hypotheses", lambda: lu.extract_hypotheses("", 1)),
+        ("extract_local_lemmas", lambda: lu.extract_local_lemmas("")),
+        ("get_goal_state", lambda: lu.get_goal_state("", 1)),
+    ], ids=lambda x: x if isinstance(x, str) else "")
+    def test_empty_rejected(self, name, call):
+        # Empty filepath was previously silent garbage (resolve_lake_module('')
+        # returned ('C:\\', 'dev.CoursIA')) — now a clear ValueError.
+        with pytest.raises(ValueError, match="non-empty str"):
+            call()
+
+
+class TestProbeRelativePathGuards:
+    def test_none_filepath_rejected(self):
+        with pytest.raises(ValueError, match="filepath: expected str"):
+            lu.probe_relative_path(None, ".", "_X.lean")
+
+    def test_none_project_dir_rejected(self):
+        with pytest.raises(ValueError, match="project_dir: expected str"):
+            lu.probe_relative_path("x.lean", None, "_X.lean")
+
+    def test_none_tmp_name_rejected(self):
+        with pytest.raises(ValueError, match="tmp_name: expected str"):
+            lu.probe_relative_path("x.lean", ".", None)
+
+
+class TestVerifySorryReplacementReplacementGuard:
+    def test_none_replacement_rejected(self):
+        # filepath is guarded first; use a valid-looking path to reach the
+        # replacement guard.
+        with pytest.raises(ValueError, match="replacement: expected str"):
+            lu.verify_sorry_replacement("x.lean", 1, None)


### PR DESCRIPTION
## Summary

Add **degenerate-input boundary guards** to the 13 public entry points of `agent_tests/prover/lean_utils.py` (the prover's Lean-file utility module) that crashed **opaquely** on `None` / non-str inputs — converting cryptic `TypeError`/`AttributeError` stack traces into clear `ValueError`s naming the offending argument. Garniture robustesse, lane prover (#1453), R6 family-rotation compliant (Python prover ≠ Search).

## Why

`lean_utils.py` (1223 lines, 18 public functions) had **no test file** and **no input validation**. A prover workflow that forwards an agent-generated `None` filepath/content (LLM call failed, file deleted in a race, empty edit) hit opaque crashes:
- `count_real_sorries(None)` → `TypeError: object of type 'NoneType' has no len()`
- `sorry_is_in_statement(None, 5)` → `AttributeError: 'NoneType' object has no attribute 'split'`
- `resolve_lake_module(None)` → `TypeError: expected str, bytes or os.PathLike object, not NoneType`
- `resolve_lake_module('')` → **silent garbage** `('C:\\', 'dev.CoursIA')` (parsed the cwd)

13 opaque crashes reproduced across 8 functions firsthand. Same #7596-pattern (po-2023 `lean_notebook_utils` guards) applied to the prover's own utility module — my home lane.

## Change

`lean_utils.py` (+35, pure-additive):
- New `_require_str(name, value, *, allow_empty=False)` boundary helper.
- Applied to 13 public functions: `resolve_lake_module`, `probe_relative_path`, `strip_lean_comments`, `count_real_sorries`, `sorry_is_in_statement`, `is_true_placeholder_goal`, `is_honest_sorry`, `extract_sorry_block`, `get_goal_state`, `extract_hypotheses`, `extract_local_lemmas`, `classify_definitions`, `verify_sorry_replacement`.
- **`content` params use `allow_empty=True`** (empty Lean file = 0 sorries is legitimate, preserved); **`filepath` params reject empty** (silent garbage otherwise).

`tests/test_lean_utils.py` (+233, new file, 38 tests):
- Happy-path preservation: FX-6 word-bounded sorry counting (prose "sorry" in comments not counted), Lake-root resolution (real lakefile + legacy fallback), `classify_definitions` (inductive vs def), `extract_sorry_block` context + out-of-range graceful dict, `sorry_is_in_statement` body vs statement.
- Guard tests: each of the 13 functions raises `ValueError` on `None` (+ empty for filepath params), with parametrized coverage.

## Anti-regression proof

- **No `except TypeError`** anywhere in the prover codebase → changing TypeError→ValueError breaks no specific except clause. The broad `except Exception` catches in `provers.py` catch both.
- **All 6 prover call sites** (verified firsthand: `provers.py:163/237`, `workflow.py:1152`, `tools.py:2119`, + `count_real_sorries` 23 sites) pass valid demo filepath strings — guards are pure defense-in-depth, never trigger in the normal workflow.
- `is_true_placeholder_goal`/`is_honest_sorry` keep their `try/except OSError → safe default`; None filepath now raises ValueError *before* the try (fail-fast on programmer error vs silent default — more correct).

## G.9 non-vacuous proof (the #7596 method)

| State | test_lean_utils.py |
|-------|--------------------|
| **Patched** (guards applied) | **38 passed** |
| **De-patched** (origin/main lean_utils + new tests kept) | **23 failed** (guards catch old opaque crashes) + **15 passed** (happy-path) |

The 23 failures on de-patch are the old `TypeError`/`AttributeError` — proving the guards catch real crashes, not theoretical ones.

## Validation

| Check | Result |
|-------|--------|
| Full prover suite (`pytest tests/`) | **392 passed**, 0 regression |
| New `test_lean_utils.py` | **38 passed** |
| `py_compile lean_utils.py` | OK |
| Diff scope | 1 module (+35) + 1 new test (+233), no other files |
| Catalog byte-identical to main | `COURSE_CATALOG.generated.{json,md}` unchanged |
| CRLF/LF | staged blobs LF-clean (0 CR bytes, matching origin/main convention) |
| `proof_knowledge.json` | runtime-rewrite discarded (not my work) |

## Scope (R3 atomicity)

1 module + 1 new test file, 1 subject — prover `lean_utils.py` degenerate-input guards. See #1453 (prover co-evolution epic), See #7477 (forensic — all 6 pathologies P1-P6 now delivered).
