### PR TITLE
docs(search,#5780): fix app2-graphcoloring alt-text mismatch (vision-QA)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/README.md
+++ b/MyIA.AI.Notebooks/Search/Applications/README.md
@@ -75,7 +75,7 @@ Les classiques fondateurs d'abord : les N-Queens (App-1) — le banc d'essai can
 
 La coloration de graphes (App-2) part, elle, du graphe d'adjacence des départements français métropolitains — encore sans couleur assignée ici, le tracé sert de support à l'illustration de la contrainte de différence par frontière :
 
-[![Graphe d'adjacence des départements français métropolitains (101 sommets), colorié après résolution CP-SAT](assets/readme/app2-graphcoloring-map.png)](CSP/App-2-GraphColoring.ipynb)
+[![Graphe d'adjacence des départements français métropolitains — vue non colorée servant de support à l'illustration de la contrainte de différence par frontière](assets/readme/app2-graphcoloring-map.png)](CSP/App-2-GraphColoring.ipynb)
 
 Viennent ensuite les problèmes d'ordonnancement réalistes. Le planning infirmier (App-3) montre 15 infirmières réparties sur 28 jours, avec les créneaux Matin/Après-midi/Nuit, les jours de repos et les week-ends marqués en rouge :
 


### PR DESCRIPTION
## Summary

Vision-QA sweep of `MyIA.AI.Notebooks/Search/Applications/README.md` figures (EPIC #5780, steer ai-01 c.722 exploiting MiniMax vision capability). Found 1 documentation-coherence defect out of 6 figures audited.

**Defect:** the badge alt-text for `app2-graphcoloring-map.png` (L78) claimed:

> "(101 sommets), colorié après résolution CP-SAT"

This contradicts **both**:
1. **The figure itself** — its matplotlib title reads *"Graphe des départements français (sans coloration)"*, and the render shows an uncolored adjacency graph (~subset of départements, uniform light blue).
2. **The surrounding prose (L76)** — which explicitly frames it as the *uncolored* input graph:

> "La coloration de graphes (App-2) part, elle, du graphe d'adjacence des départements français métropolitains — **encore sans couleur assignée ici**, le tracé sert de support à l'illustration de la contrainte de différence par frontière."

## SOTA verdict — SOTA-OK (not a workaround)

This is **not** a degenerate-placeholder / workaround-degraded figure (EPIC #3801 Prong A). The image is a **legitimate networkx render of the input adjacency graph**, deliberately shown uncolored as a pedagogical support (the constraint *before* it is solved by CP-SAT in the notebook). The notebook produces this figure correctly. **No regeneration needed** — the fix is purely aligning the alt-text description with the actual image + prose framing.

## Fix

Corrected the alt-text (markdown-only, surgical) to describe what the figure actually shows and to mirror the prose framing:

```
- [![Graphe d'adjacence des départements français métropolitains (101 sommets), colorié après résolution CP-SAT](...)]
+ [![Graphe d'adjacence des départements français métropolitains — vue non colorée servant de support à l'illustration de la contrainte de différence par frontière](...)]
```

## Validation

- **G.1 firsthand**: read `Applications/README.md` L70-104 (prose + badge) + the image content directly. Sub-agent MiniMax vision reading confirmed image title "sans coloration". Text contradiction L76 vs L78 is certain regardless of vision.
- **Scope C.3 / markdown-only**: +1/−1 line, no notebook touched, no re-execution needed (L529/L683 canon for markdown surgical fixes).
- **Catalogue byte-identique** to `origin/main` (catalog-pr-hygiene R1): no `COURSE_CATALOG.generated.*` churn.
- **`See #5780`** (partial contribution to epic — sweep continues across ML/Sudoku/Probas/CaseStudies families).

## Other figures audited (5/6 SOTA-OK)

All other Applications figures verified SOTA-OK (real solver outputs, coherent alt-text): `app1-nqueens-board`, `app3-nurseschedule-planning`, `app15-sports-calendar`, `app11-picross-grid`, `app19-wfc-tiles`. No changes needed.

See #5780

🤖 Generated with [Claude Code](https://claude.com/claude-code)