### PR TITLE
docs(search,#4959): resync Search hub — add MGS-7b LandscapeMultidim to MGS table + prose

### DIFF
--- a/MyIA.AI.Notebooks/Search/README.md
+++ b/MyIA.AI.Notebooks/Search/README.md
@@ -125,7 +125,7 @@ Chaque notebook introduit un concept ou algorithme spécifique. Le tableau ci-de
 
 Side track C# .NET 9 (cf. [Search-5](Part1-Foundations/Search-5-GeneticAlgorithms.ipynb), [Search-11](Part1-Foundations/Search-11-Metaheuristics.ipynb)) : reconstruire et **composer** les métaheuristiques au-dessus de GeneticSharp plutôt que d'en importer une boîte noire.
 
-La série se lit en quatre temps : **MGS-1 à 7** bâtissent le moteur et la grammaire de composition (jusqu'aux composés publiés et au TSP) ; **MGS-8 à 14** visualisent les paysages de fitness et mesurent la robustesse aux biais des bancs CEC (décalage, rotation, synergie d'îles) ; **MGS-15 à 18** referment la série sur l'**analyse quantitative de paysage** et la **méta-stratégie** — choisir l'optimiseur selon le paysage (No-Free-Lunch), adapter ses paramètres en cours de route, et confronter le portefeuille au protocole CEC complet ; **MGS-19** prolonge la thèse « composants > métaphores » jusqu'au **démontage** — extraire l'opérateur de Metropolis du recuit simulé et l'éprouver seul sur un GA, pour vérifier que le bénéfice du recuit tient au couplage perturbation+acceptation, pas à l'acceptation seule.
+La série se lit en quatre temps : **MGS-1 à 7** bâtissent le moteur et la grammaire de composition (jusqu'aux composés publiés et au TSP), et **MGS-7b** franchit le passage à la dimension supérieure en projetant un paysage $n$-D sur la heatmap 2-D (pont vers la visualisation) ; **MGS-8 à 14** visualisent les paysages de fitness et mesurent la robustesse aux biais des bancs CEC (décalage, rotation, synergie d'îles) ; **MGS-15 à 18** referment la série sur l'**analyse quantitative de paysage** et la **méta-stratégie** — choisir l'optimiseur selon le paysage (No-Free-Lunch), adapter ses paramètres en cours de route, et confronter le portefeuille au protocole CEC complet ; **MGS-19** prolonge la thèse « composants > métaphores » jusqu'au **démontage** — extraire l'opérateur de Metropolis du recuit simulé et l'éprouver seul sur un GA, pour vérifier que le bénéfice du recuit tient au couplage perturbation+acceptation, pas à l'acceptation seule.
 
 | # | Notebook | Apport pédagogique |
 |---|----------|-------------------|
@@ -136,6 +136,7 @@ La série se lit en quatre temps : **MGS-1 à 7** bâtissent le moteur et la gra
 | 5 | MGS-5 CompoundMetaheuristics | Reconstruire les composés publiés (WOA/EO/FBI) depuis leurs primitives |
 | 6 | MGS-6 Benchmarks | Comparaison honnête des composés vs GA vs Uniform vs Islands |
 | 7 | MGS-7 TSP | Grammaire agnostique à la représentation (permutation, `OrderedCrossover`) |
+| 7b | [MGS-7b LandscapeMultidim](Part4-Metaheuristics/MGS-7b-LandscapeMultidim.ipynb) | Projection N-D des paysages : la surcharge `RenderHeatmap(..., int dimension, ...)` projette en MAX un paysage $n$-D sur la heatmap 2-D (Sphère 2-D vs 5-D, Rastrigin $n \in \{2,5,10,30\}$, Schwefel $n \in \{5,30\}$) — pont entre MGS-6 (heatmap 2-D) et MGS-8 (LandscapeExplorer) |
 | 8 | MGS-8 LandscapeExplorer | Visualiser la surface de fitness (heatmaps, trajectoire de convergence) |
 | 9 | MGS-9 EverestRelief | Relief terrestre réel comme paysage de fitness (DEM, flipbook) |
 | 10 | MGS-10 CenterBias | Biais central vs robustesse au déplacement (banc Kudela 2022) |


### PR DESCRIPTION
## Summary

Hub resync for `MyIA.AI.Notebooks/Search/README.md` (EPIC #4959 — READMEs intermédiaires & centraux). Found a drift: the MGS table (L130-149) **skipped MGS-7b** between MGS-7 TSP and MGS-8 LandscapeExplorer, even though **MGS-7b-LandscapeMultidim.ipynb was merged via #7583** (N-D landscape projection bridge, with 8 Rastrigin/Schwefel/Sphere d2-d30 PNG assets present on disk).

po-2023 delivered the MGS portability sweep + #7583/#7617 but did not resync the hub README, so the MGS series list was missing a member.

## Drift (verified firsthand G.1)

**Before** — table jumped from MGS-7 to MGS-8:
```
| 7 | MGS-7 TSP | Grammaire agnostique à la représentation (permutation, `OrderedCrossover`) |
| 8 | MGS-8 LandscapeExplorer | Visualiser la surface de fitness (heatmaps, trajectoire de convergence) |
```

And the prose arc (L128) read: "**MGS-1 à 7** bâtissent le moteur et la grammaire de composition (jusqu'aux composés publiés et au TSP) ; **MGS-8 à 14** visualisent les paysages de fitness..." — with no bridge note.

## Fix (markdown-only, scope C.3)

1. **Added table row 7b** with an accurate description read firsthand from `Part4-Metaheuristics/MGS-7b-LandscapeMultidim.ipynb` (cells 0-7 read): the N-D MAX-projection overload `RenderHeatmap(..., int dimension, ...)`, Sphere 2-D vs 5-D, Rastrigin $n \in \{2,5,10,30\}$, Schwefel $n \in \{5,30\}$ — described as the **pont between MGS-6 (heatmap 2-D) and MGS-8 (LandscapeExplorer)** (which is exactly how the notebook's cell 0 introduces itself: "pont vers la visualisation").

2. **Added a bridge clause to the prose arc** (L128): "**MGS-7b** franchit le passage à la dimension supérieure en projetant un paysage $n$-D sur la heatmap 2-D (pont vers la visualisation)".

## Validation

- **G.1 firsthand**: read the notebook's first 8 cells (cell 0 markdown intro + cells 3/5/7 code blocks using the N-D overload) to write an accurate description, not an invented one.
- **Markdown-only** (scope C.3): +2/−1 lines in one file, no notebook touched, no re-execution needed (L529/L683 canon for surgical markdown fixes).
- **Catalogue byte-identique** to `origin/main` (catalog-pr-hygiene R1): no `COURSE_CATALOG.generated.*` churn — verified `git diff --name-only` returns only `Search/README.md`.
- **`See #4959`** (partial contribution to the hub READMEs resync epic — other families' hub READMEs may have similar drift, to be picked in follow-up cycles).
- **Scope audit** (pr-review-discipline §E): this is a single-line table addition + single-clause prose update to an existing MGS list — not a structural rewrite, the surrounding list/tree/breakdowns (Part1-Part4 section, counts, other rows) were read and are coherent (the "19 notebooks MGS-1 à MGS-19" count at L80 counts MGS-7b as part of the .NET side-track which is accurate).

See #4959

🤖 Generated with [Claude Code](https://claude.com/claude-code)