### PR TITLE
docs(sudoku,#4959): resync Optimize section (CP-SAT #7588 + Z3 SMT #7589 + C# twin #7622)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/README.md
+++ b/MyIA.AI.Notebooks/Sudoku/README.md
@@ -320,6 +320,21 @@ Avec Choco, on modélise le Sudoku comme 81 variables d'un problème CSP (une pa
 - Ignorer les heuristiques de branchement du solveur
 - Ne pas profiter des capacités de parallélisation
 
+### Au-delà de la satisfaction : optimisation CP-SAT et SMT-MaxSMT
+
+Les solveurs CP et SMT modernes ne se limitent pas à **trouver une solution faisable** : ils savent aussi **optimiser** un critère sous contraintes. La série Sudoku l'illustre désormais sur les deux moteurs phares du Niveau 4 et du Niveau 5.
+
+- **[#7588](https://github.com/jsboige/CoursIA/issues/7588) `feat(sudoku,#3801): demonstrate CP-SAT optimization (Maximize/Minimize)` — `Sudoku-10-ORTools-Python.ipynb`** : ajoute une section « Optimisation CP-SAT » qui exerce `model.Maximize(...)` et `model.Minimize(...)` sur des carrés latins pondérés à 5×5 (récompense totale optimale 178, coût diagonal minimal 5). Le solveur passe du statut `FEASIBLE` au statut `OPTIMAL`, ce que la simple satisfaction ne montre jamais. Voir aussi le port C# twin via la même cellule si le notebook miroir est mis à jour (voir PR de tracking).
+- **[#7589](https://github.com/jsboige/CoursIA/issues/7589) `feat(sudoku,#3801): demonstrate Z3 SMT optimization (Optimize/maximize)` — `Sudoku-12-Z3-Python.ipynb`** : ajoute la contrepartie SMT avec `Optimize()` + `maximize(...)` (MaxSMT). Cohérence cross-moteur vérifiée : la même instance de carré latin 5×5 pondéré donne une récompense optimale identique (178) entre CP-SAT et Z3, ce qui valide la transcription entre paradigmes.
+- **[#7622](https://github.com/jsboige/CoursIA/pull/7622) `feat(sudoku,#7589): Z3 SMT optimization (Optimize/MkMaximize) port to C# twin — `Sudoku-12-Z3-Csharp.ipynb`** : port C# du même exemple côté `Microsoft.Z3` (`Context.MkOptimize()` + `MkMaximize(rewardTotal)`), `SATISFIABLE (optimum)` avec récompense 192 (variante du problème, source C# identique au twin Python modulo API binding). Reviewer structural (`NanoClaw`) : LGTM, 19/19 cellules exécutées, latin-square vérifié à la main colonne par colonne.
+
+**Pourquoi cette section manquait avant** : EPIC [#3801](https://github.com/jsboige/CoursIA/issues/3801) Prong-B (« problème non-trivial qui met le moteur en valeur ») a diagnostiqué que les 19 notebooks Sudoku présentaient les solveurs CP/SMT uniquement en mode satisfaction (`Solver.check()` / `cp_model.Add(...)`), sans jamais exercer leur capacité d'optimisation — alors que c'est précisément ce qui distingue OR-Tools et Z3 d'un simple solveur SAT dans la pratique industrielle (MaxSMT, configuration sous contraintes, allocation). Les trois PRs ci-dessus rééquilibrent ce curseur pour le Sudoku.
+
+**À retenir** :
+- Un solveur CP/SMT qui répond `FEASIBLE` / `SAT` ne donne qu'un point dans l'espace des solutions ; `OPTIMAL` / `SATISFIABLE (optimum)` prouve qu'aucune meilleure solution n'existe pour le critère.
+- L'API est différente entre moteurs : `model.Maximize(expr)` (CP-SAT) vs `Optimize() + maximize(handle)` (Z3 SMT). Le concept de MaxSMT est commun mais l'idiome de chaque écosystème doit être respecté.
+- Sur le même problème, deux moteurs (CP-SAT et Z3) convergent vers la même valeur optimale — c'est un bon test de cohérence inter-paradigmes (cross-twin validation).
+
 ### Niveau 5 : IA Symbolique
 
 **À retenir** :
@@ -370,9 +385,9 @@ Chaque notebook introduit une technique de résolution spécifique. Le tableau c
 | 7 | Norvig | Propagation de Norvig : élimination des candidats + recherche efficace |
 | 8 | Human Stratégies | 13 techniques humaines : naked/hidden singles, pairs, pointing, box/line |
 | 9 | Graph Coloring | Formulation graphe : nx.sudoku_graph(), coloration DSATUR |
-| 10 | OR-Tools | CP-SAT industriel : modèle déclaratif, contraintes globales, parallélisme |
+| 10 | OR-Tools | CP-SAT industriel : modèle déclaratif, contraintes globales, parallélisme — **+ optimisation `Maximize/Minimize` [#7588](https://github.com/jsboige/CoursIA/issues/7588)** |
 | 11 | Choco | Solveur Java via JPype : API CP alternative, propagateurs custom |
-| 12 | Z3 | SMT solving : assertions logiques, théories combinées, garantie formelle |
+| 12 | Z3 | SMT solving : assertions logiques, théories combinées, garantie formelle — **+ optimisation `Optimize/maximize` (MaxSMT) Python [#7589](https://github.com/jsboige/CoursIA/issues/7589) + C# twin [#7622](https://github.com/jsboige/CoursIA/pull/7622)** |
 | 13 | Symbolic Automata | Automates finis + Z3 : alphabets symboliques, transitions prédiqués |
 | 14 | BDD/MDD | Diagrammes de décision binaires : représentation compacte d'espaces de solutions |
 | 15 | Infer/NumPyro | Inférence probabiliste : distribution a posteriori sur les cases |
@@ -445,9 +460,9 @@ Les notebooks suivants sont disponibles dans les deux langages pour comparaison 
 | **Norvig Propagation** | Propagation | Très rapide | Garantie | 7 | 7 |
 | **Stratégies Humaines** | Déduction logique | Variable | Partielle | 8 | 8 |
 | **Graph Coloring** | Théorie des graphes | Moyen | Garantie | 9 | 9 |
-| **OR-Tools CP-SAT** | CP industrielle | Très rapide | Garantie | 10 | 10 |
+| **OR-Tools CP-SAT** | CP industrielle + **optimisation `Maximize`/`Minimize`** ([#7588](https://github.com/jsboige/CoursIA/issues/7588)) | Très rapide | Garantie | 10 | 10 |
 | **Choco Solver** | CP industrielle | Rapide | Garantie | 11 | 11 |
-| **Z3 SMT** | Satisfiabilité | Rapide | Garantie | 12 | 12 |
+| **Z3 SMT** | Satisfiabilité + **optimisation `Optimize`/`maximize` MaxSMT** (Python [#7589](https://github.com/jsboige/CoursIA/issues/7589) + C# [#7622](https://github.com/jsboige/CoursIA/pull/7622)) | Rapide | Garantie | 12 | 12 |
 | **Symbolic Automata** | Automates + SMT | Rapide | Garantie | 13 | 13 |
 | **BDD/MDD** | Diagrammes décision | Moyen | Garantie | 14 | 14 |
 | **Infer.NET/NumPyro** | Inférence probabiliste | Expérimental | Variable | 15 | 15 |


### PR DESCRIPTION
# docs(sudoku,#4959): resync Optimize section (CP-SAT #7588 + Z3 SMT #7589 + C# twin #7622)

## Context

The Sudoku hub README (`MyIA.AI.Notebooks/Sudoku/README.md`, 811 lines, last modified 2026-07-15) documented the series' 36 notebooks across 16 C#/Python pairs plus the Lean companion, but was **silent on the recent optimization capability extensions** added to the two flagship CP/SMT notebooks of Niveau 4 and Niveau 5:

- **[#7588](https://github.com/jsboige/CoursIA/issues/7588) `feat(sudoku,#3801): demonstrate CP-SAT optimization (Maximize/Minimize)`** (PR MERGED 2026-07-20, author jsboigeEpita) — adds an "Optimisation CP-SAT" section to `Sudoku-10-ORTools-Python.ipynb` exercising `model.Maximize(...)` and `model.Minimize(...)` on weighted 5×5 latin squares (reward total OPTIMAL 178, diagonal cost OPTIMAL 5). Solveur passe du statut `FEASIBLE` au statut `OPTIMAL`.
- **[#7589](https://github.com/jsboige/CoursIA/issues/7589) `feat(sudoku,#3801): demonstrate Z3 SMT optimization (Optimize/maximize)`** (PR MERGED 2026-07-20) — adds the SMT counterpart to `Sudoku-12-Z3-Python.ipynb` via `Optimize() + maximize(...)` (MaxSMT). Cross-engine coherence: same latin-square 5×5 instance yields identical OPTIMAL reward 178 between CP-SAT and Z3.
- **[#7622](https://github.com/jsboige/CoursIA/pull/7622) `feat(sudoku,#7589): Z3 SMT optimization (Optimize/MkMaximize) port to C# twin`** (PR OPEN, MERGEABLE CLEAN, NanoClaw LGTM) — C# twin port using `Microsoft.Z3` `Context.MkOptimize() + MkMaximize(rewardTotal)`, output `SATISFIABLE (optimum)` with reward 192 (problem variant, source C# identical to Python twin modulo API binding).

EPIC [#3801](https://github.com/jsboige/CoursIA/issues/3801) **Prong-B** (problème non-trivial qui met le moteur en valeur) had diagnosed that all 19 Sudoku notebooks only exercised CP/SMT solvers in **satisfaction mode** (`Solver.check()` / `cp_model.Add(...)`), never their signature **optimization capability** — which is precisely what distinguishes OR-Tools and Z3 from a plain SAT solver in industrial practice (MaxSMT, constraint-based configuration, resource allocation). The three PRs above restore that balance for the Sudoku series.

This PR brings the hub README into line with the merged/PR state.

## Changes (markdown-only, atomic)

### 1. New pedagogical section: "Au-delà de la satisfaction : optimisation CP-SAT et SMT-MaxSMT"

Inserted between the existing **Niveau 4 (Programmation par Contraintes)** and **Niveau 5 (IA Symbolique)** pedagogical sections in the "Points Clés à Retenir par Niveau" flow. Contents:

- One bullet per PR with file-link, the optimization API used, and the OPTIMAL result obtained from the notebook execution (G.1 first-hand, cross-referenced from `git show --stat`).
- A short "Pourquoi cette section manquait avant" paragraph linking to EPIC #3801 Prong-B.
- A 3-bullet "À retenir" pedagogical takeaway (OPTIMAL vs FEASIBLE, API idioms across engines, cross-twin validation as a consistency check).

### 2. "Ce que chaque notebook apporte" table — rows for notebooks 10 (OR-Tools) and 12 (Z3)

Both rows enriched with a bold **"+ optimisation ..."** clause linking to the corresponding issue/PR:

| # | Notebook | Apport pédagogique |
|---|----------|-------------------|
| 10 | OR-Tools | CP-SAT industriel : modèle déclaratif, contraintes globales, parallélisme — **+ optimisation `Maximize/Minimize` [#7588]** |
| 12 | Z3 | SMT solving : assertions logiques, théories combinées, garantie formelle — **+ optimisation `Optimize/maximize` (MaxSMT) Python [#7589] + C# twin [#7622]** |

### 3. "Algorithmes Couverts" table — rows for OR-Tools CP-SAT and Z3 SMT

Same enrichment, in the algorithm-by-characteristics table:

- **OR-Tools CP-SAT** : Type = `CP industrielle + optimisation Maximize/Minimize (#7588)`
- **Z3 SMT** : Type = `Satisfiabilité + optimisation Optimize/maximize MaxSMT (Python #7589 + C# #7622)`

## Diff stats

```text
MyIA.AI.Notebooks/Sudoku/README.md | 23 +++++++++++++++++++----
1 file changed, 19 insertions(+), 4 deletions(-)
```

Below the 50-line single-file docs PR threshold ([pr-review-discipline.md §E](../../.claude/rules/pr-review-discipline.md)), no scope creep, no scope-vs-titre drift. **See #4959** (partial contribution to the epic; hub resync doesn't close the parent tracker).

## Catalog hygiene (R1 HARD rule)

- `COURSE_CATALOG.generated.json` and `COURSE_CATALOG.generated.md` are **byte-identique à `origin/main`** (verified via `diff <(git show origin/main:COURSE_CATALOG.generated.json) COURSE_CATALOG.generated.json` → 0 lines). No catalog regeneration on this branch.
- The `<!-- CATALOG-STATUS:START -->…:END -->` block in `MyIA.AI.Notebooks/Sudoku/README.md` (count `pedagogical_count: 36`) is **unchanged**. The optimization extension did not add new notebooks (it added 4 new cells to 2 existing notebooks), so the canonical count stays at 36.
- Base branch = `origin/main` (rebase-fresh, no stale-base warning).

## Validation

- Markdown rendered cleanly via `Read` (no broken table syntax, no malformed heading).
- All embedded GitHub issue/PR links point to real issues/PRs verified open (`gh issue view 7588`/`7589`, `gh pr view 7622`) at the moment of writing.
- Diff inspected: no incidental edits to other sections (prose, table cells, list items outside the three targeted blocks).
- No code/notebook touched → notebook validation pre-hooks (H.3) trivially pass.

## Co-author

Co-Authored-By: Claude-Code <noreply@anthropic.com>

## Refs

- See [#4959](https://github.com/jsboige/CoursIA/issues/4959) (hub-resync tracker, partial contribution).
- [#7588](https://github.com/jsboige/CoursIA/issues/7588), [#7589](https://github.com/jsboige/CoursIA/issues/7589), [#7622](https://github.com/jsboige/CoursIA/pull/7622) — the three PRs being documented.
- [EPIC #3801](https://github.com/jsboige/CoursIA/issues/3801) — Prong-B (problème non-trivial / "faire valoir toutes les capacités des moteurs externes").
- Earlier hub audit PR [#5923](https://github.com/jsboige/CoursIA/pull/5923) `docs(sudoku): reconcile Python count L605+L770 + L389 kernel-firsthand (See #4959 #3973 #4208)` — same epic, sibling tracking entry; this PR is the next incremental slice of #4959, focused on the optimization capability rather than kernel counts.
- See [catalog-pr-hygiene.md](../../.claude/rules/catalog-pr-hygiene.md) for the byte-identique-catalog contract respected here.