### PR TITLE
docs(gametheory,#4959): resync GT-16 hub description with VCG revenue non-monotonicity (#7610)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/README.md
@@ -116,7 +116,7 @@ Si vous préférez les cas d'usage aux fondements théoriques :
 1. **5** (ZeroSum) : programmation linéaire, dualité, trading
 2. **6** (EvolutionTrust) : émergence de la coopération, biologie
 3. **13** (CFR) : poker AI, regret minimization
-4. **16** (MechanismDesign) : enchères VCG, allocation de ressources
+4. **16** (MechanismDesign) : enchères VCG, allocation de ressources, et le piège de la non-monotonie du revenu (Conitzer-Sandholm)
 5. **SC-03** (Voting) : Condorcet, Borda, modèles électoraux
 
 #### Parcours informatique théorique (~5h)
@@ -208,7 +208,7 @@ flowchart TD
 | 15b | [GameTheory-15b-Lean-CooperativeGames](GameTheory-15b-Lean-CooperativeGames.ipynb) | Lean 4 | Axiomes Shapley formels, Core | 55 min |
 | 15c | [GameTheory-15c-CooperativeGames-Python](GameTheory-15c-CooperativeGames-Python.ipynb) | Python | Exemples avancés (Glove Game, politique) | 40 min |
 | 15c (C#) | [GameTheory-15c-CooperativeGames-Csharp](GameTheory-15c-CooperativeGames-Csharp.ipynb) | .NET (C#) | Twin C# du 15c : Shapley (permutations), Banzhaf (swing), Core vide (majorité 3-joueurs), Mini-ONU, convexité from-scratch (See #4956) | 40 min |
-| 16 | [GameTheory-16-MechanismDesign](GameTheory-16-MechanismDesign.ipynb) | Python | Principe de révélation, VCG, matching | 65 min |
+| 16 | [GameTheory-16-MechanismDesign](GameTheory-16-MechanismDesign.ipynb) | Python | Principe de révélation, VCG (non-monotonie du revenu, Conitzer-Sandholm), matching | 65 min |
 | 16 (C#) | [GameTheory-16-MechanismDesign-Csharp](GameTheory-16-MechanismDesign-Csharp.ipynb) | .NET (C#) | Twin C# du 16 : **enchères Vickrey 1er/2nd prix + VCG (règle de Clarke) + Gale-Shapley (stable matching) + double auction** from-scratch, BCL .NET 9 (See #4956) | 50 min |
 | SC-01 | [SocialChoice/01-Arrow-Impossibility-Theorem](SocialChoice/01-Arrow-Impossibility-Theorem.ipynb) | Python | Arrow : preuve formelle vs simulation | 45 min |
 | SC-01 (C#) | [SocialChoice/01-Arrow-Impossibility-Theorem-Csharp](SocialChoice/01-Arrow-Impossibility-Theorem-Csharp.ipynb) | .NET (C#) | Twin C# du SC-01 : **théorème d'Arrow from-scratch** (BCL .NET 9, 0 NuGet), preuve déterministe par énumération des profils de préférences (See #4956) | 45 min |
@@ -260,7 +260,7 @@ Chaque notebook introduit un concept ou un modèle spécifique. Le tableau ci-de
 | 13 | ImperfectInfo-CFR | CFR vanilla, MCCFR, Deep CFR, poker AI |
 | 14 | DifferentialGames | Jeux continus, Stackelberg, boucle ouverte/fermée |
 | 15 | CooperativeGames | Valeur de Shapley, Core, Bondareva-Shapley |
-| 16 | MechanismDesign | Principe de révélation, VCG, matching, enchères |
+| 16 | MechanismDesign | Principe de révélation, VCG (incl. non-monotonie du revenu), matching, enchères |
 | 17 | MultiAgent-RL | NFSP, PSRO, AlphaZero intro, lien vers RL |
 
 ### Side tracks Lean 4 (formalisation)


### PR DESCRIPTION
## Summary

PR **#7610** (merged 2026-07-20T18:49Z) added **section 4.5 « Piège de VCG : non-monotonie du revenu (Conitzer-Sandholm) »** to `GameTheory-16-MechanismDesign.ipynb` — the key pedagogical point that VCG can **FAIL**: welfare rises (10→16) while seller revenue **falls** (8→4) when a 3rd bidder enters a 2-item combinatorial auction. This motivates Ausubel-Milgrom ascending combinatorial auctions. It completed **#1469 Track 1** alongside the Lean twin **#7600** (`vcg_revenue_non_monotone`).

The hub `GameTheory/README.md` described GT-16 content in **3 places**, all pre-#7610 — none mentioned the VCG failure mode. This PR resyncs all 3 so the hub reflects what the notebook actually teaches.

## Change (1 file, 3 coherent prose edits)

| Line | Section | Before → After |
|------|---------|----------------|
| L119 | Parcours apprentissage | `enchères VCG, allocation de ressources` → + `et le piège de la non-monotonie du revenu (Conitzer-Sandholm)` |
| L211 | Table principale | `Principe de révélation, VCG, matching` → `VCG (non-monotonie du revenu, Conitzer-Sandholm), matching` |
| L263 | Table concepts | `VCG, matching, enchères` → `VCG (incl. non-monotonie du revenu), matching, enchères` |

Verified firsthand against the notebook: `## 4.5 Piege de VCG : non-monotonie du revenu (Conitzer-Sandholm)` heading confirmed present (cell 22), with the 2-bidder→3-bidder revenue 8→4 demonstration + `assert revenue3 < revenue2`.

## Validation

- **Scope**: markdown-only (C.3 — no notebook re-execution, prose/table description cells only)
- **Catalogue**: byte-identical to main (CATALOG-STATUS markers untouched, `git diff --name-only | grep catalog` = empty)
- **Atomicity** (R3): 1 file, 1 subject (GT-16 hub description resync for #7610)
- **§E audit**: the 3 edits are the exhaustive set of GT-16 *content* references in the hub (L119 parcours, L211 main table, L263 concepts table); L591 stats row left untouched (approximate counts, #7610 added interpretive cells not new exercises)
- **Anti-regression**: pure description enrichment, no content removed

See #4959 (hub resync epic) · See #1469 (closed — VCG work complete via #7610 Python + #7600 Lean) · See #7610 (the merged PR whose content this reflects)