### PR TITLE
feat(prover,#7477): add reasoning_budget_exceeded run verdict (P5a-search)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
@@ -848,6 +848,14 @@ class MultiAgentSorryProver:
                 _credit = ""
             print(f"  Workflow reasoning-budget timeout ({workflow_timeout_s}s "
                   f"reasoning{_credit}) — aborting")
+            # P5a-search (#7477 forensic): latch the session-level reasoning
+            # wall-clock so _derive_result_kind classifies the run
+            # reasoning_budget_exceeded (distinct from no_progress). This is
+            # the multi-agent capture site (the autonomous path latches at its
+            # WALL-CLOCK CAP branch). Distinct from heartbeat_budget_exceeded
+            # (compile-level): here the agent loop burned the whole reasoning
+            # budget without converging on an edit.
+            state.reasoning_budget_exceeded = True
             proof_found = False
         except Exception as e:
             print(f"  Workflow error: {e}")
@@ -1124,6 +1132,14 @@ class MultiAgentSorryProver:
             # restructuring) so forensic ROI ranks these runs honestly instead
             # of counting an unproven sorry-spray as progress.
             "decomposition_regression": decomposition_regression,
+            # P5a-search (#7477 forensic): session-level reasoning wall-clock
+            # latched either in the multi-agent `except _asyncio.TimeoutError`
+            # or the autonomous WALL-CLOCK CAP branch. Surfaced so
+            # _derive_result_kind classifies the run reasoning_budget_exceeded
+            # (distinct from no_progress). getattr-default keeps legacy traces
+            # (field absent) falsy -> no_progress, identical to the heartbeat
+            # field's legacy-safe contract.
+            "reasoning_budget_exceeded": getattr(state, "reasoning_budget_exceeded", False),
             # FX-12 (#6790 pathology 3): count of build-verified *structural*
             # edits (file_replace_lines / file_insert_lines whose build_check
             # passed). Distinct from ``structural_progress`` (a boolean
@@ -1488,6 +1504,13 @@ class AutonomousProver:
                             )
                         except Exception:
                             pass  # Tracing is best-effort, don't fail on log errors
+                        # P5a-search (#7477 forensic): mirror of the multi-agent
+                        # `except _asyncio.TimeoutError` latch — this is the
+                        # autonomous reasoning-wall-clock capture site. The run
+                        # spent its reasoning budget without converging on an
+                        # edit; surface reasoning_budget_exceeded so the run is
+                        # not mislabelled no_progress.
+                        state.reasoning_budget_exceeded = True
                         _wallclock_capped = True
                         break
                 state.iteration = iteration
@@ -2028,6 +2051,12 @@ class AutonomousProver:
             # no_progress) — the target needs a cheaper tactic / higher
             # maxHeartbeats / decomposition, NOT more iterations.
             "heartbeat_budget_exceeded": getattr(state, "heartbeat_budget_exceeded", False),
+            # P5a-search (#7477 forensic): session-level reasoning wall-clock
+            # (latched at the autonomous WALL-CLOCK CAP branch). Surfaced so
+            # _derive_result_kind classifies reasoning_budget_exceeded. Mirror
+            # of the multi-agent result-dict field; getattr-default keeps
+            # legacy traces falsy -> no_progress.
+            "reasoning_budget_exceeded": getattr(state, "reasoning_budget_exceeded", False),
             # FX-12 (#6790 pathology 3): count of build-verified *structural*
             # edits (file_replace_lines / file_insert_lines whose build_check
             # passed). Distinct from ``structural_progress`` (boolean success

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py
@@ -63,6 +63,19 @@ def _derive_result_kind(result, final_sorry: int, original_sorry: int) -> str:
                           restructuring has verified_tactic_count > 0. Tells a
                           coordinator the decomposition was an unproven spray,
                           NOT progress — do NOT harvest / branch it.
+      reasoning_budget_exceeded -> the run burned its SESSION reasoning wall-
+                          clock (max_session_seconds / workflow_timeout_s)
+                          without converging on an edit (latched in the
+                          multi-agent `except _asyncio.TimeoutError` or the
+                          autonomous WALL-CLOCK CAP branch, #7477 P5a-search).
+                          Distinct from heartbeat_budget_exceeded (compile-
+                          level Lean maxHeartbeats wall): this is session-level
+                          — the agent loop spent the whole budget reasoning and
+                          emitted 0 attempts. Forensic: kimi-k3 run `bt56gsv78`
+                          (DEMO 62 ne, 8->8, 0 attempts, 1800s Search-phase).
+                          Tells a coordinator the arm needs a shorter reasoning
+                          budget / different search / smaller decomposition, NOT
+                          more wall-clock or iterations.
       no_progress      -> diagnostic data only
 
     Real progress outranks the outage flag: a run that lowered the sorry count
@@ -117,6 +130,21 @@ def _derive_result_kind(result, final_sorry: int, original_sorry: int) -> str:
     # identical to the classifier's None->False contract.
     if isinstance(result, dict) and result.get("decomposition_regression"):
         return "decomposition_regression"
+    # P5a-search (#7477 forensic, jsboige A-B 2026-07-20): the run burned its
+    # session reasoning wall-clock without converging on an edit (0 attempts).
+    # Ranked AFTER sorry_decreased / structural_only / provider_outage /
+    # correctly_refused / heartbeat_budget_exceeded / decomposition_regression:
+    # those are all more specific pathologies (real progress, provider death,
+    # explicit refusal, compile-level heartbeat wall, unverified spray). This
+    # flag only reclassifies what would otherwise be no_progress — the most
+    # generic budget-wall diagnosis. Distinct from heartbeat_budget_exceeded
+    # (compile-level): here the agents never got a tactic to the compiler, they
+    # spent the whole budget in Search-phase reasoning. Forensic kimi-k3 run
+    # `bt56gsv78` (DEMO 62 ne, 8->8, 0 attempts, 1800s) previously scored
+    # no_progress; reasoning_budget_exceeded lets a coordinator distinguish
+    # "agent spun reasoning without editing" from "agent tried and failed".
+    if isinstance(result, dict) and result.get("reasoning_budget_exceeded"):
+        return "reasoning_budget_exceeded"
     return "no_progress"
 
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/state.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/state.py
@@ -124,6 +124,21 @@ class ProofState:
     # structural_only: a run that lowered the sorry count before blowing the
     # budget is still progress.
     heartbeat_budget_exceeded: bool = False
+    # P5a-search (#7477 forensic, jsboige A-B 2026-07-20): the run burned its
+    # *session* reasoning wall-clock (max_session_seconds / workflow_timeout_s)
+    # without the agents converging on an edit — distinct from heartbeat_budget
+    # _exceeded which is a *compile-level* wall (a Lean tactic blew maxHeartbeats
+    # during a single build). This is the *session-level* wall: the agent loop
+    # (typically Search-phase reasoning) spent the whole budget thinking and
+    # emitted 0 attempts. Forensic evidence: kimi-k3 run `bt56gsv78` on DEMO 62
+    # ne — 8->8, 0 attempts, "reasoning-budget timeout 1800s en phase Search".
+    # Surfaced so run_prover_bg._derive_result_kind classifies the run as
+    # reasoning_budget_exceeded (distinct from no_progress) — telling a
+    # coordinator the arm needs a shorter reasoning budget / different search
+    # strategy / smaller goal decomposition, NOT more wall-clock. Ranked AFTER
+    # sorry_decreased / structural_only / heartbeat_budget_exceeded: a run that
+    # lowered sorry or blew a Lean heartbeat first ranks as that outcome.
+    reasoning_budget_exceeded: bool = False
 
     # F9 (2026-05-17, C37 forensic): Director consultation gate. The
     # Coordinator MUST call request_director_guidance() at least once

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_reasoning_budget.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_reasoning_budget.py
@@ -1,0 +1,180 @@
+"""Unit tests for #7477 P5a-search — `reasoning_budget_exceeded` run verdict.
+
+The search-twin of ``heartbeat_budget_exceeded`` (P5a, #7548). Where the
+heartbeat verdict captures a *compile-level* wall (a Lean tactic blew
+``maxHeartbeats`` during a single build), this captures the *session-level*
+wall: the agent loop burned its whole reasoning wall-clock
+(``max_session_seconds`` / ``workflow_timeout_s``) without converging on an
+edit — typically Search-phase reasoning that never emitted an attempt.
+
+Forensic evidence (jsboige A-B, 2026-07-20): on DEMO 62 ``ne`` arm
+(``HashlifeCorrectness.lean:3193``), ``moonshotai/kimi-k3`` run ``bt56gsv78``
+scored 8->8 with **0 attempts** and a "reasoning-budget timeout 1800s en phase
+Search". Without a typed verdict such a run was indistinguishable from
+``no_progress`` (a tactic that simply failed). The fix:
+
+  1. ``ProofState.reasoning_budget_exceeded`` (state.py) — the latch flag.
+  2. ``provers.py`` sets it in BOTH the multi-agent ``except
+     _asyncio.TimeoutError`` (the "Workflow reasoning-budget timeout" path)
+     and the autonomous ``WALL-CLOCK CAP`` branch — the two session-level
+     reasoning wall-clock capture sites.
+  3. The result dict surfaces it (both the multi-agent and autonomous return
+     paths) so ``run_prover_bg._derive_result_kind`` can classify it.
+
+These tests exercise the classification contract (the part that matters for
+forensic ROI) and the field default. The latch itself is driven by the BG
+integration runs (kimi-k3 ``bt56gsv78`` is the firsthand reproduction); the
+session-supervisor loop that hosts it is not a clean unit so it is not
+mocked here, mirroring how the heartbeat latch is the one exercised by real
+``compile()`` calls.
+
+Run from ``agent_tests/``::
+
+    python -m pytest tests/test_prover_reasoning_budget.py -q
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make `prover/` importable regardless of how pytest was invoked (same
+# bootstrap convention as tests/test_prover_heartbeat_budget.py).
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+sys.path.insert(0, str(ROOT))
+
+from prover import run_prover_bg  # noqa: E402
+from prover.state import ProofState  # noqa: E402
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# _derive_result_kind — the reasoning_budget_exceeded branch
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _derive(result, final_sorry, original_sorry):
+    """Thin wrapper so each test reads as the verdict for one scenario."""
+    return run_prover_bg._derive_result_kind(result, final_sorry, original_sorry)
+
+
+def test_reasoning_budget_exceeded_when_flag_set():
+    """A run whose result carries reasoning_budget_exceeded=True is classified
+    reasoning_budget_exceeded, not no_progress."""
+    result = {"reasoning_budget_exceeded": True}
+    assert _derive(result, final_sorry=5, original_sorry=5) == "reasoning_budget_exceeded"
+
+
+def test_reasoning_flag_needs_truthy():
+    """Flag absent or False falls through to no_progress (no false positive).
+    A run that never burned the budget must NOT be mislabelled."""
+    assert _derive({}, 5, 5) == "no_progress"
+    assert _derive({"reasoning_budget_exceeded": False}, 5, 5) == "no_progress"
+    assert _derive({"reasoning_budget_exceeded": None}, 5, 5) == "no_progress"
+
+
+def test_sorry_decreased_outranks_reasoning():
+    """Real progress outranks the diagnostic: a run that lowered the sorry
+    count before the session timed out is still a harvest."""
+    result = {"reasoning_budget_exceeded": True}
+    assert _derive(result, final_sorry=3, original_sorry=5) == "sorry_decreased"
+
+
+def test_structural_progress_outranks_reasoning():
+    """A decomposition landed (structural_progress=True) before the budget
+    burned: structural_only, not reasoning_budget_exceeded."""
+    result = {"reasoning_budget_exceeded": True, "structural_progress": True}
+    assert _derive(result, 5, 5) == "structural_only"
+
+
+def test_provider_outage_outranks_reasoning():
+    """A provider death mid-run is provider_outage regardless of the reasoning
+    wall: the prover never got to work."""
+    result = {"reasoning_budget_exceeded": True, "provider_outage": True}
+    assert _derive(result, 5, 5) == "provider_outage"
+
+
+def test_correctly_refused_outranks_reasoning():
+    """An explicit Coordinator abandon (intractable) is correctly_refused
+    regardless of the reasoning wall — the agent refused; it did not spin."""
+    result = {"reasoning_budget_exceeded": True, "intractable": True}
+    assert _derive(result, 5, 5) == "correctly_refused"
+
+
+def test_heartbeat_outranks_reasoning():
+    """A compile-level heartbeat wall (Lean tactic blew maxHeartbeats) is more
+    specific than a session-level reasoning wall, so heartbeat_budget_exceeded
+    wins when both flags are set. (The agent got a tactic to the compiler AND
+    the session later timed out — the actionable signal is the compile wall.)"""
+    result = {
+        "reasoning_budget_exceeded": True,
+        "heartbeat_budget_exceeded": True,
+    }
+    assert _derive(result, 5, 5) == "heartbeat_budget_exceeded"
+
+
+def test_decomposition_regression_outranks_reasoning():
+    """An unverified sorry-spray (P3 decomposition_regression) is a more
+    specific pathology than the generic session reasoning wall, so it wins
+    when both flags are set."""
+    result = {
+        "reasoning_budget_exceeded": True,
+        "decomposition_regression": True,
+    }
+    assert _derive(result, 5, 5) == "decomposition_regression"
+
+
+def test_crashed_outranks_reasoning():
+    """An explicit error is crashed regardless of the reasoning wall."""
+    result = {"error": "kaboom", "reasoning_budget_exceeded": True}
+    assert _derive(result, 5, 5) == "crashed"
+
+
+def test_reasoning_plumbs_through_classification_from_result_fields():
+    """End-to-end of the classification: a result dict shaped like the real
+    provers.py return (reasoning_budget_exceeded surfaced via getattr(state,...),
+    no sorry drop, no structural progress, no outage, no intractable, no
+    heartbeat, no decomposition regression) classifies as
+    reasoning_budget_exceeded — the exact path a real reasoning-wall run takes."""
+    result = {
+        "success": False,
+        "sorry_evolution": "5 -> 5",
+        "structural_progress": False,
+        "provider_outage": False,
+        "provider_failures": 0,
+        "intractable": False,
+        "heartbeat_budget_exceeded": False,
+        "decomposition_regression": False,
+        "reasoning_budget_exceeded": True,
+        "iterations": 0,
+        "attempts": 0,
+    }
+    assert _derive(result, final_sorry=5, original_sorry=5) == "reasoning_budget_exceeded"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# ProofState — the latch field
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_proofstate_reasoning_budget_exceeded_defaults_false():
+    """A fresh ProofState must default reasoning_budget_exceeded=False so a run
+    that never hit the session wall is not mislabelled. (Mirrors the heartbeat
+    field default.)"""
+    state = ProofState(theorem_statement="t")
+    assert state.reasoning_budget_exceeded is False
+    # The heartbeat sibling is present too — guards against a rename that would
+    # silently break the ranking test above.
+    assert state.heartbeat_budget_exceeded is False
+
+
+def test_proofstate_reasoning_budget_exceeded_is_settable():
+    """The field is settable by the session-supervisor latch (the multi-agent
+    `except _asyncio.TimeoutError` / autonomous WALL-CLOCK CAP branches set
+    `state.reasoning_budget_exceeded = True`). Sanity that the attribute is
+    writable, not a read-only property."""
+    state = ProofState(theorem_statement="t")
+    state.reasoning_budget_exceeded = True
+    assert state.reasoning_budget_exceeded is True


### PR DESCRIPTION
## Summary

The **search-twin of `heartbeat_budget_exceeded`** (#7548, P5a #7477). Where the heartbeat verdict captures a **compile-level** wall (a Lean tactic blew `maxHeartbeats` during a single build), this captures the **session-level** wall: the agent loop burned its whole reasoning wall-clock (`max_session_seconds` / `workflow_timeout_s`) without converging on an edit — typically Search-phase reasoning that emitted 0 attempts.

### Forensic evidence (jsboige A-B, 2026-07-20)

On DEMO 62 `ne` arm (`HashlifeCorrectness.lean:3193`), `moonshotai/kimi-k3` run `bt56gsv78` scored **8→8 with 0 attempts** and a "reasoning-budget timeout 1800s en phase Search". Without a typed verdict this was indistinguishable from `no_progress`. The A-B also confirmed **P5 is NOT SOTA-sensitive** (no frontier factors the lemma spontaneously), so the fix is the typed diagnostic, not a bigger model.

## Why a prover-harness change (§B justification)

This PR touches `agent_tests/prover/*.py` (Python harness), not `*.lean`. The change is **not a refactor** — it adds a new diagnostic verdict (`reasoning_budget_exceeded`) to the `result_kind` contract, resolving the #7477 P5a-search residual explicitly named in jsboige's A-B comment and my own c.550 bonus clarification. It is bounded, model-independent, and evidence-cited. N/A: `grep -c sorry`, Lake build, Proof integrity (no `.lean` files modified).

## Change (4 files, pure additions — 0 deletions on production code)

| File | Change |
|------|--------|
| `prover/state.py` | Add `ProofState.reasoning_budget_exceeded` latch field (mirror of `heartbeat_budget_exceeded`), +15 |
| `prover/provers.py` | Latch in **both** session-level capture sites — multi-agent `except _asyncio.TimeoutError` ("Workflow reasoning-budget timeout") AND autonomous `WALL-CLOCK CAP` branch. Surface in **both** result dicts (multi-agent + autonomous) via `getattr`-default (legacy-safe), +29 |
| `prover/run_prover_bg.py` | `_derive_result_kind` gains a `reasoning_budget_exceeded` branch + docstring entry, +28 |
| `tests/test_prover_reasoning_budget.py` | **New** — 12 tests: classification, truthy-gate, full ranking (8 outranks tests), end-to-end plumbing, ProofState field default/settable |

### Ranking in `_derive_result_kind`

`reasoning_budget_exceeded` slots **after** `decomposition_regression` and **before** the `no_progress` fallthrough — it is the most generic budget-wall diagnosis:
- `sorry_decreased` / `structural_only` (real progress) outrank it
- `provider_outage` / `correctly_refused` / `heartbeat_budget_exceeded` (compile wall) / `decomposition_regression` (unverified spray) are all more specific pathologies and outrank it
- It only reclassifies what would otherwise be `no_progress`

## Validation

- **Tests**: `python -m pytest tests/ -q` → **404 passed** (12 new reasoning + 392 existing, **0 regressions**, 1.93s)
- **Anti-regression**: 0 deletions on production code (all additions); no existing verdict/ranking changed
- **Legacy-safe**: `getattr(state, "reasoning_budget_exceeded", False)` — old traces without the field classify as before (`no_progress`)
- **Atomicity** (R3): 1 subject (the reasoning_budget_exceeded verdict), 4 files
- **Scope hygiene**: `proof_knowledge.json` (test-generated cache, rewritten during pytest) was reverted — NOT committed

## Context on the c.550 deferral

This resolves the residual I flagged in my own [#7477 c.550 comment](https://github.com/jsboige/CoursIA/issues/7477), which deferred to ai-01 ONLY because "RooSync is down this cycle, I cannot confirm nobody else started it." RooSync is back up; no `reasoning_budget_exceeded` PR existed (checked closed/merged: #7482 P1a, #7500 P2a, #7488 P2b, #7532 P1b, #7533 P4, #7548 P5a-heartbeat, #7593 docs — none cover the session-level reasoning wall); the blocker is cleared.

See #7477 · See #1453