### PR TITLE
docs(planners,#4959): resync PDDL optimization section (Prong-B #7592)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/README.md
@@ -71,7 +71,31 @@ La planification classique épuise ses limites dès que les problèmes deviennen
 
 ### Phase 4 : Neuro-Symbolique (Notebooks 10-12, ~3h)
 
-La dernière partie explore la frontière entre IA symbolique et apprentissage profond. Le notebook 10 (LLM-Planning) montre comment les Large Language Models peuvent générer des plans à partir de descriptions en langage naturel, le prompting pour la planification, et le plan repair. Le notebook 11 (Unified-Planning) détaille l'interface unifiée `unified-planning` : connexion à plusieurs solveurs en quelques lignes, comparaison croisée des performances, et portabilité du modèle PDDL entre moteurs. Le notebook 12 (LOOP) introduit le paradigme **Learning to Plan** : architecture LOOP (state encoder, policy network, value network), encodage PDDL en tenseurs (one-hot, GNN), entraînement par imitation et renforcement, résultats sur benchmarks IPC (85.8% coverage), et comparaison avec KRCL. Ce notebook conclut la série avec les tendances futures : foundation models, meta-learning, inverse reinforcement learning.
+La dernière partie explore la frontière entre IA symbolique et apprentissage profond. Le notebook 10 (LLM-Planning) montre comment les Large Language Models peuvent générer des plans à partir de descriptions en langage naturel, le prompting pour la planification, et le plan repair. Le notebook 11 (Unified-Planning) détaille l'interface unifiée `unified-planning` : connexion à plusieurs solveurs en quelques lignes, comparaison croisée des performances, portabilité du modèle PDDL entre moteurs, **et le saut qualitatif satisfaction → optimisation** via `MinimizeActionCosts` (un moteur *optimal* comme `fast-downward-opt` certifie le plan de coût minimal là où un moteur *satisficing* comme `fast-downward` s'arrête au premier plan trouvé — voir [la section dédiée ci-dessous](#au-delà-de-la-satisfaction--optimisation-pddl-cout-minimal-planners-11)). Le notebook 12 (LOOP) introduit le paradigme **Learning to Plan** : architecture LOOP (state encoder, policy network, value network), encodage PDDL en tenseurs (one-hot, GNN), entraînement par imitation et renforcement, résultats sur benchmarks IPC (85.8% coverage), et comparaison avec KRCL. Ce notebook conclut la série avec les tendances futures : foundation models, meta-learning, inverse reinforcement learning.
+
+### Au-delà de la satisfaction : optimisation PDDL (coût minimal, Planners-11)
+
+Jusqu'ici, les planificateurs de la série résolvent des problèmes de **satisfaction** : trouver *un* plan réalisable, comme `Solver().check() == sat` en SMT. L'ajout de `problem.add_quality_metric(MinimizeActionCosts(...))` (cell 41 du notebook 11) bascule le solveur en mode **optimisation** : parmi tous les plans qui atteignent le but, trouver celui qui **minimise le coût total** — la capacité distinctive de la planification logistique (tournées de livraison), du routing (réseaux pondérés), et de l'ordonnancement (makespan). Le notebook 11 exécute maintenant les **deux modes sur le même domaine** (livraison A → D, arêtes à coûts hétérogènes) :
+
+| Solveur | Plan retourné | Coût total | Justification |
+|---------|--------------|-----------|--------------|
+| `fast-downward` (satisficing) | `A → D` (1 action) | **10** | Premier plan trouvé, sans garantie de coût |
+| `fast-downward-opt` (optimal) | `A → B → C → D` (3 actions) | **3** | Certifié minimal par exploration A\* + heuristique admissible |
+
+**Résultat discriminant** (extrait de la cellule 42 du notebook) :
+```
+Probleme : livraison A -> D, couts heterogenes par trajet.
+Direct A->D       : 1 action, cout 10
+Detour A->B->C->D : 3 actions, cout 1+1+1 = 3
+=> plan le plus court != plan le moins cher.
+```
+
+**Pourquoi cette section manquait avant** : la série présentait jusqu'ici l'unification multi-solveurs *au niveau satisfaction*. La capacité **optimisation** restait implicite dans les notebooks CP-SAT (notebook 7, `model.Maximize`) et Z3 (notebook 12 de Sudoku, `Optimize().maximize`) — mais sans exécution head-to-head d'un planificateur optimal PDDL vs un satisficing sur le **même modèle**. EPIC [#3801](https://github.com/jsboige/CoursIA/issues/3801) **Prong-B** (« problème non-trivial qui met le moteur en valeur ») avait diagnostiqué que la signature « plan optimal » de la planification restait théorique dans la série. [#7592](https://github.com/jsboige/CoursIA/pull/7592) la démontre first-hand sur un cas où le plan optimal est **plus long** (3 actions) que le satisficing (1 action), ce qui rend la qualité métrique non-triviale (un coût uniforme effondrerait le test).
+
+**À retenir** :
+- Sans *quality metric*, un planificateur se réduit à un **chercheur de plan** (BFS/GBFS sur le graphe d'états). L'optimalité n'est pas du tout recherchée.
+- Avec `MinimizeActionCosts`, le moteur devient un **optimiseur combinatoire** (A\* sur graphe pondéré, heuristique admissible, garantie d'optimalité). C'est la signature IPC optimal track.
+- L'arc cross-famille **CP-SAT ([#7588](https://github.com/jsboige/CoursIA/pull/7588)) → Z3 SMT ([#7589](https://github.com/jsboige/CoursIA/pull/7589)) → PDDL ([#7592](https://github.com/jsboige/CoursIA/pull/7592))** montre la même bascule satisfaction → optimisation dans trois familles distinctes de solveurs. Le présent notebook ferme la trilogie côté planification.
 
 ### Parcours alternatifs
 
@@ -119,7 +143,8 @@ Pour les approches combinées apprentissage profond + symbolique :
 | Planification hiérarchique | **Planners-9-HTN** (SHOP2, decomposition) |
 | Frontière LLM + IA | **Planners-10-LLM-Planning** |
 | Approche neuro-symbolique avancée | **Planners-12-LOOP** (85.8% IPC coverage) |
-| Comparer tous les solveurs | **Planners-11-Unified-Planning** |
+| Comparer tous les solveurs (satisfaction) | **Planners-11-Unified-Planning** |
+| Comparer satisfaction **vs** optimisation (`MinimizeActionCosts`) | **Planners-11-Unified-Planning** ([#7592](https://github.com/jsboige/CoursIA/pull/7592)) |
 
 ## Objectifs d'apprentissage
 
@@ -203,7 +228,7 @@ Chaque notebook introduit un concept ou modèle spécifique. Le tableau ci-desso
 | 8 | Temporal | PDDL 2.1, durées d'actions, parallélisme, contraintes temporelles, ordonnancement |
 | 9 | HTN | Planification hiérarchique : tâches primitives/abstraites, méthodes, HDDL, SHOP2 |
 | 10 | LLM-Planning | Planification avec LLMs, prompting, plan repair, limites et avantages |
-| 11 | Unified-Planning | Interface multi-solveurs, comparaison croisée, portabilité du modèle |
+| 11 | Unified-Planning | Interface multi-solveurs, comparaison croisée, portabilité du modèle — + optimisation `MinimizeActionCosts` (optimal bat satisficing de 7 unités) [#7592] |
 | 12 | LOOP | Learning to Plan : state encoder, policy network, value network, 85.8% IPC coverage |
 
 ---
@@ -343,6 +368,8 @@ curl -s http://localhost:8200/health
 | **HTN** | Hierarchical Task Network - décomposition de tâches |
 | **LM-cut** | Heuristique admissible basée sur les landmarks |
 | **CP-SAT** | Constraint Programming-Satisfiability (OR-Tools) |
+| **MinimizeActionCosts** | Quality metric PDDL : minimise le coût total d'un plan (bascule satisfaction → optimisation, voir [section dédiée](#au-delà-de-la-satisfaction--optimisation-pddl-cout-minimal-planners-11)) |
+| **fast-downward-opt** | Variante optimale de Fast Downward (certifie le plan de coût minimal) — [#7592](https://github.com/jsboige/CoursIA/pull/7592) |
 | **Learning to Plan** | Apprentissage d'heuristiques par réseaux de neurones |
 | **LOOP** | Framework neuro-symbolique, 85.8% coverage IPC |
 


### PR DESCRIPTION
# docs(planners,#4959): resync PDDL optimization section (Prong-B #7592)

## Context

The Planners hub README (`MyIA.AI.Notebooks/SymbolicAI/Planners/README.md`, 774 lines, last modified 2026-07-15) documented the series' 23 notebooks across 4 phases (Fondations / Classique / Avancée / Neuro-Symbolique) plus the cross-solver arc (Fast Downward / OR-Tools CP-SAT / PDDL / HTN / unified-planning). But it **never demonstrated the PDDL optimization capability that #7592 just executed first-hand on Planners-11-Unified-Planning**.

- **[#7592](https://github.com/jsboige/CoursIA/pull/7592) `feat(planners,#3801): demonstrate PDDL optimization (MinimizeActionCosts)`** (PR MERGED 2026-07-20T16:36:31Z, commit `bd2586e02`, author jsboigeEpita) — adds +165 lines to `Planners-11-Unified-Planning.ipynb` introducing cells 41-43 ("### Exemple guide 2 : Optimisation -- minimiser le cout total d'un plan" / `MinimizeActionCosts` cell 42 / "### Interpretation : Optimisation vs satisfaction en planification"). Reruns the **same** delivery problem (A → D on a graph with heterogeneous edge costs) twice — once with `fast-downward` (satisficing), once with `fast-downward-opt` (optimal A* + LM-cut). Discriminant result: optimal finds A→B→C→D (3 actions, cost 3) and **certifies it minimal**; satisficing stops at A→D (1 action, cost 10) — optimal beats satisficing by **7 units with more actions** (the qualitative leap: shortest plan ≠ cheapest plan). Notebook EXEC_PROVED (65 cells, 0 null_exec, 0 errors, Papermill 65/65, `up_fast_downward 0.5.2` installed locally per rule F).

EPIC [#3801](https://github.com/jsboige/CoursIA/issues/3801) **Prong-B** (« problème non-trivial qui met le moteur en valeur ») had diagnosed that the optimization capability of planners (`MinimizeActionCosts`) was only implicitly visible through CP-SAT (`model.Maximize`) and Z3 (`Optimize().maximize()`) — but never executed head-to-head on the **same PDDL model** to qualify the optimality gap. #7592 restores that for Planners-11.

This PR brings the hub README into line with the merged state, mirroring the c.719 Sudoku Optimize documentation PR (#7626) and the c.720 Probas EP-vs-VMP documentation PR (#7628).

## Changes (markdown-only, atomic)

### 1. New pedagogical section: "Au-delà de la satisfaction : optimisation PDDL (coût minimal, Planners-11)"

Inserted between **Phase 4 (Neuro-Symbolique, Notebooks 10-12)** and **Parcours alternatifs**, exactly at the boundary where the cross-solver arc meets the practical recommendation matrix. Contents:
- One paragraph framing the qualitative leap satisfaction → optimisation, with citation of cell 41 of the notebook (`MinimizeActionCosts` quality metric).
- A 4-column result table with **first-hand** numbers from cell-42 output: solver (`fast-downward` / `fast-downward-opt`), plan returned (A→D / A→B→C→D), cost total (10 / 3), justification (satisficing first-plan / optimal A* + admissible heuristic).
- The verbatim cell-42 stdout (`Probleme : livraison A -> D, couts heterogenes par trajet. / Direct A->D : 1 action, cout 10 / Detour A->B->C->D : 3 actions, cout 1+1+1 = 3 / => plan le plus court != plan le moins cher.`).
- A "Pourquoi cette section manquait avant" paragraph linking to EPIC #3801 Prong-B and the cross-family satisfaction→optimization arc (CP-SAT #7588 → Z3 #7589 → PDDL #7592).
- A 3-bullet "À retenir" pedagogical takeaway (without quality metric = plan searcher, with = combinatorial optimizer, cross-family closure of the trilogy).

### 2. Phase 4 narrative description enriched

Original (L74):
> "...Le notebook 11 (Unified-Planning) détaille l'interface unifiée `unified-planning` : connexion à plusieurs solveurs en quelques lignes, comparaison croisée des performances, et portabilité du modèle PDDL entre moteurs..."

Enriched to flag the satisfaction → optimisation qualitative leap via `MinimizeActionCosts`, with an in-page anchor link to the new section.

### 3. Table "Quel parcours choisir" — Planners-11 row split

Original row:
```
| Comparer tous les solveurs | **Planners-11-Unified-Planning** |
```
Enriched to two rows, the second explicitly referencing `MinimizeActionCosts` and [#7592](https://github.com/jsboige/CoursIA/pull/7592).

### 4. Table "Apport pédagogique" row 11 enriched

Original (L206):
```
| 11 | Unified-Planning | Interface multi-solveurs, comparaison croisée, portabilité du modèle |
```
Enriched to:
```
| 11 | Unified-Planning | Interface multi-solveurs, comparaison croisée, portabilité du modèle — + optimisation `MinimizeActionCosts` (optimal bat satisficing de 7 unités) [#7592] |
```

### 5. Table "Concepts clés" — two new entries

Added:
- `MinimizeActionCosts` with definition and in-page anchor link to the new section.
- `fast-downward-opt` with definition and [#7592](https://github.com/jsboige/CoursIA/pull/7592) reference.

## Diff stats

```text
MyIA.AI.Notebooks/SymbolicAI/Planners/README.md | 33 ++++++++++++++++++++++---
1 file changed, 30 insertions(+), 3 deletions(-)
```

Below the 50-line single-file docs PR threshold ([pr-review-discipline.md §E](../../.claude/rules/pr-review-discipline.md)), no scope creep, no scope-vs-titre drift. **See #4959** (partial contribution to the epic; hub resync doesn't close the parent tracker).

## Catalog hygiene (R1 HARD rule)

- `COURSE_CATALOG.generated.json` and `COURSE_CATALOG.generated.md` are **byte-identique à `origin/main`** (verified via `diff <(git show origin/main:COURSE_CATALOG.generated.json) COURSE_CATALOG.generated.json` → 0 lines). No catalog regeneration on this branch.
- The `<!-- CATALOG-STATUS:START -->…:END -->` block in `MyIA.AI.Notebooks/SymbolicAI/Planners/README.md` (count `pedagogical_count: 23`) is **unchanged**. The optimization extension did not add new notebooks (it added 3 cells to the existing `Planners-11-Unified-Planning.ipynb`), so the canonical count stays at 23 (PRODUCTION=21, BETA=2).
- The marker count `Planners=23` cross-referenced in the README prose remains accurate.
- Base branch = `origin/main` (rebase-fresh at HEAD `5deda22e6`, no stale-base warning).

## Validation

- Markdown rendered cleanly: new section heading uses `###` (same depth as Phase subsections and the c.720 Probas "Au-delà du consensus par défaut" section), the result table is 4 columns × 2 data rows, the anchor `#au-delà-de-la-satisfaction--optimisation-pddl-cout-minimal-planners-11` matches the GitHub slug convention for the heading text.
- All embedded GitHub issue/PR links point to real issues/PRs verified MERGED at the moment of writing (`gh pr view 7592`).
- Result numbers cross-checked against cell-42 actual stdout output (`Planners-11-Unified-Planning.ipynb`).
- Diff inspected: no incidental edits to other sections (Phase 1 / Phase 2 / Phase 3 / Parcours / Quel stack / Vue d'ensemble des parties / Concepts clés / Domaines PDDL all preserve their structure except the 5 targeted enrichments).
- No code/notebook touched → notebook validation pre-hooks (H.3) trivially pass.

## Co-author

Co-Authored-By: Claude-Code <noreply@anthropic.com>

## Refs

- See [#4959](https://github.com/jsboige/CoursIA/issues/4959) (hub-resync tracker, partial contribution).
- [#7592](https://github.com/jsboige/CoursIA/pull/7592) `feat(planners,#3801): demonstrate PDDL optimization (MinimizeActionCosts)` (commit `bd2586e02`, MERGED 2026-07-20) — the PR being documented.
- [EPIC #3801](https://github.com/jsboige/CoursIA/issues/3801) — Prong-B (« problème non-trivial qui met le moteur en valeur »).
- Earlier Planners hub README PRs on #4959: search needed (none found in the immediate cycle window; this is the first Planners hub resync).
- Sibling c.719 hub PR [#7626](https://github.com/jsboige/CoursIA/pull/7626) `docs(sudoku,#4959): resync Optimize section (CP-SAT #7588 + Z3 SMT #7589 + C# twin #7622)` (OPEN MERGEABLE CLEAN).
- Sibling c.720 hub PR [#7628](https://github.com/jsboige/CoursIA/pull/7628) `docs(probas,#4959): resync EP-vs-VMP comparison section (Prong-B #7590)` (OPEN MERGEABLE UNSTABLE-transient).
- See [catalog-pr-hygiene.md](../../.claude/rules/catalog-pr-hygiene.md) for the byte-identique-catalog contract respected here.
- Solver-signature arc referenced in the new section: `CP-SAT #7588 → Z3 #7589 → PDDL #7592` (the same arc Sudoku Optimize resync covers via #7626).