### PR TITLE
feat(ict,#7288): ICT-15b real-substrate sensitivity — S5 Gray-Scott + S6 Axelrod IPD (Huang)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15b-SensitivityCanonicity.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15b-SensitivityCanonicity.ipynb
@@ -5,10 +5,10 @@
    "id": "c42dbb9f",
    "metadata": {
     "papermill": {
-     "duration": 0.003982,
-     "end_time": "2026-07-20T23:24:56.427821",
+     "duration": 0.003989,
+     "end_time": "2026-07-20T23:49:05.282186",
      "exception": false,
-     "start_time": "2026-07-20T23:24:56.423839",
+     "start_time": "2026-07-20T23:49:05.278197",
      "status": "completed"
     },
     "tags": []
@@ -56,16 +56,16 @@
    "id": "3415fbb1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T23:24:56.434979Z",
-     "iopub.status.busy": "2026-07-20T23:24:56.434979Z",
-     "iopub.status.idle": "2026-07-20T23:24:56.841458Z",
-     "shell.execute_reply": "2026-07-20T23:24:56.841458Z"
+     "iopub.execute_input": "2026-07-20T23:49:05.290047Z",
+     "iopub.status.busy": "2026-07-20T23:49:05.290047Z",
+     "iopub.status.idle": "2026-07-20T23:49:05.708151Z",
+     "shell.execute_reply": "2026-07-20T23:49:05.707565Z"
     },
     "papermill": {
-     "duration": 0.412226,
-     "end_time": "2026-07-20T23:24:56.842860",
+     "duration": 0.424004,
+     "end_time": "2026-07-20T23:49:05.709185",
      "exception": false,
-     "start_time": "2026-07-20T23:24:56.430634",
+     "start_time": "2026-07-20T23:49:05.285181",
      "status": "completed"
     },
     "tags": []
@@ -75,8 +75,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ict.spectral OK, transition_graph: <function transition_graph at 0x00000247B0560040>\n",
-      "ict.sensitivity OK, huang_conjecture_test: <function huang_conjecture_test at 0x00000247B05608B0>\n",
+      "ict.spectral OK, transition_graph: <function transition_graph at 0x000002253B8B40D0>\n",
+      "ict.sensitivity OK, huang_conjecture_test: <function huang_conjecture_test at 0x000002253B8B4940>\n",
       "numpy: 2.2.6\n"
      ]
     }
@@ -104,10 +104,10 @@
    "id": "d4431d69",
    "metadata": {
     "papermill": {
-     "duration": 0.003261,
-     "end_time": "2026-07-20T23:24:56.850158",
+     "duration": 0.003275,
+     "end_time": "2026-07-20T23:49:05.716257",
      "exception": false,
-     "start_time": "2026-07-20T23:24:56.846897",
+     "start_time": "2026-07-20T23:49:05.712982",
      "status": "completed"
     },
     "tags": []
@@ -124,16 +124,16 @@
    "id": "84591af9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T23:24:56.857843Z",
-     "iopub.status.busy": "2026-07-20T23:24:56.856837Z",
-     "iopub.status.idle": "2026-07-20T23:24:56.872565Z",
-     "shell.execute_reply": "2026-07-20T23:24:56.872028Z"
+     "iopub.execute_input": "2026-07-20T23:49:05.724720Z",
+     "iopub.status.busy": "2026-07-20T23:49:05.724204Z",
+     "iopub.status.idle": "2026-07-20T23:49:05.738782Z",
+     "shell.execute_reply": "2026-07-20T23:49:05.738171Z"
     },
     "papermill": {
-     "duration": 0.020212,
-     "end_time": "2026-07-20T23:24:56.873570",
+     "duration": 0.019952,
+     "end_time": "2026-07-20T23:49:05.739893",
      "exception": false,
-     "start_time": "2026-07-20T23:24:56.853358",
+     "start_time": "2026-07-20T23:49:05.719941",
      "status": "completed"
     },
     "tags": []
@@ -174,10 +174,10 @@
    "id": "6db07a50",
    "metadata": {
     "papermill": {
-     "duration": 0.003005,
-     "end_time": "2026-07-20T23:24:56.879573",
+     "duration": 0.003143,
+     "end_time": "2026-07-20T23:49:05.747179",
      "exception": false,
-     "start_time": "2026-07-20T23:24:56.876568",
+     "start_time": "2026-07-20T23:49:05.744036",
      "status": "completed"
     },
     "tags": []
@@ -196,16 +196,16 @@
    "id": "f4448a2e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T23:24:56.887625Z",
-     "iopub.status.busy": "2026-07-20T23:24:56.887625Z",
-     "iopub.status.idle": "2026-07-20T23:24:56.904346Z",
-     "shell.execute_reply": "2026-07-20T23:24:56.903801Z"
+     "iopub.execute_input": "2026-07-20T23:49:05.755180Z",
+     "iopub.status.busy": "2026-07-20T23:49:05.755180Z",
+     "iopub.status.idle": "2026-07-20T23:49:05.770335Z",
+     "shell.execute_reply": "2026-07-20T23:49:05.770335Z"
     },
     "papermill": {
-     "duration": 0.0226,
-     "end_time": "2026-07-20T23:24:56.905356",
+     "duration": 0.021129,
+     "end_time": "2026-07-20T23:49:05.771308",
      "exception": false,
-     "start_time": "2026-07-20T23:24:56.882756",
+     "start_time": "2026-07-20T23:49:05.750179",
      "status": "completed"
     },
     "tags": []
@@ -258,10 +258,10 @@
    "id": "676832ad",
    "metadata": {
     "papermill": {
-     "duration": 0.002997,
-     "end_time": "2026-07-20T23:24:56.911356",
+     "duration": 0.003,
+     "end_time": "2026-07-20T23:49:05.778307",
      "exception": false,
-     "start_time": "2026-07-20T23:24:56.908359",
+     "start_time": "2026-07-20T23:49:05.775307",
      "status": "completed"
     },
     "tags": []
@@ -280,16 +280,16 @@
    "id": "91b3d26a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T23:24:56.919357Z",
-     "iopub.status.busy": "2026-07-20T23:24:56.918357Z",
-     "iopub.status.idle": "2026-07-20T23:24:56.997955Z",
-     "shell.execute_reply": "2026-07-20T23:24:56.996929Z"
+     "iopub.execute_input": "2026-07-20T23:49:05.786863Z",
+     "iopub.status.busy": "2026-07-20T23:49:05.786161Z",
+     "iopub.status.idle": "2026-07-20T23:49:05.865357Z",
+     "shell.execute_reply": "2026-07-20T23:49:05.864675Z"
     },
     "papermill": {
-     "duration": 0.08358,
-     "end_time": "2026-07-20T23:24:56.997955",
+     "duration": 0.085206,
+     "end_time": "2026-07-20T23:49:05.866362",
      "exception": false,
-     "start_time": "2026-07-20T23:24:56.914375",
+     "start_time": "2026-07-20T23:49:05.781156",
      "status": "completed"
     },
     "tags": []
@@ -334,10 +334,10 @@
    "id": "536982e0",
    "metadata": {
     "papermill": {
-     "duration": 0.002984,
-     "end_time": "2026-07-20T23:24:57.004929",
+     "duration": 0.003322,
+     "end_time": "2026-07-20T23:49:05.873688",
      "exception": false,
-     "start_time": "2026-07-20T23:24:57.001945",
+     "start_time": "2026-07-20T23:49:05.870366",
      "status": "completed"
     },
     "tags": []
@@ -356,16 +356,16 @@
    "id": "3536fa56",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T23:24:57.011944Z",
-     "iopub.status.busy": "2026-07-20T23:24:57.011944Z",
-     "iopub.status.idle": "2026-07-20T23:24:57.059770Z",
-     "shell.execute_reply": "2026-07-20T23:24:57.059770Z"
+     "iopub.execute_input": "2026-07-20T23:49:05.882672Z",
+     "iopub.status.busy": "2026-07-20T23:49:05.881688Z",
+     "iopub.status.idle": "2026-07-20T23:49:05.929326Z",
+     "shell.execute_reply": "2026-07-20T23:49:05.928325Z"
     },
     "papermill": {
-     "duration": 0.052822,
-     "end_time": "2026-07-20T23:24:57.060770",
+     "duration": 0.051656,
+     "end_time": "2026-07-20T23:49:05.929326",
      "exception": false,
-     "start_time": "2026-07-20T23:24:57.007948",
+     "start_time": "2026-07-20T23:49:05.877670",
      "status": "completed"
     },
     "tags": []
@@ -375,14 +375,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  S3 : 1500 pas, majorites uniques (echantillon) : [0, 27]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
+      "  S3 : 1500 pas, majorites uniques (echantillon) : [0, 27]\n",
       "--- S3 (opinion) ---\n",
       "  n_symbols (vocabulaire) : 2\n",
       "  len(trajectoire)         : 1500\n",
@@ -426,10 +419,10 @@
    "id": "9295aecb",
    "metadata": {
     "papermill": {
-     "duration": 0.002549,
-     "end_time": "2026-07-20T23:24:57.067335",
+     "duration": 0.003,
+     "end_time": "2026-07-20T23:49:05.936325",
      "exception": false,
-     "start_time": "2026-07-20T23:24:57.064786",
+     "start_time": "2026-07-20T23:49:05.933325",
      "status": "completed"
     },
     "tags": []
@@ -448,16 +441,16 @@
    "id": "c8e9ced2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T23:24:57.075395Z",
-     "iopub.status.busy": "2026-07-20T23:24:57.074396Z",
-     "iopub.status.idle": "2026-07-20T23:24:57.091972Z",
-     "shell.execute_reply": "2026-07-20T23:24:57.090971Z"
+     "iopub.execute_input": "2026-07-20T23:49:05.944299Z",
+     "iopub.status.busy": "2026-07-20T23:49:05.944299Z",
+     "iopub.status.idle": "2026-07-20T23:49:05.959137Z",
+     "shell.execute_reply": "2026-07-20T23:49:05.959137Z"
     },
     "papermill": {
-     "duration": 0.021581,
-     "end_time": "2026-07-20T23:24:57.091972",
+     "duration": 0.020552,
+     "end_time": "2026-07-20T23:49:05.960137",
      "exception": false,
-     "start_time": "2026-07-20T23:24:57.070391",
+     "start_time": "2026-07-20T23:49:05.939585",
      "status": "completed"
     },
     "tags": []
@@ -510,10 +503,10 @@
    "id": "s5-md-grayscott",
    "metadata": {
     "papermill": {
-     "duration": 0.003984,
-     "end_time": "2026-07-20T23:24:57.099484",
+     "duration": 0.004006,
+     "end_time": "2026-07-20T23:49:05.968129",
      "exception": false,
-     "start_time": "2026-07-20T23:24:57.095500",
+     "start_time": "2026-07-20T23:49:05.964123",
      "status": "completed"
     },
     "tags": []
@@ -532,16 +525,16 @@
    "id": "s5-code-grayscott",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T23:24:57.107302Z",
-     "iopub.status.busy": "2026-07-20T23:24:57.107302Z",
-     "iopub.status.idle": "2026-07-20T23:24:57.369648Z",
-     "shell.execute_reply": "2026-07-20T23:24:57.368649Z"
+     "iopub.execute_input": "2026-07-20T23:49:05.976130Z",
+     "iopub.status.busy": "2026-07-20T23:49:05.976130Z",
+     "iopub.status.idle": "2026-07-20T23:49:06.224580Z",
+     "shell.execute_reply": "2026-07-20T23:49:06.223841Z"
     },
     "papermill": {
-     "duration": 0.268148,
-     "end_time": "2026-07-20T23:24:57.370648",
+     "duration": 0.253453,
+     "end_time": "2026-07-20T23:49:06.224580",
      "exception": false,
-     "start_time": "2026-07-20T23:24:57.102500",
+     "start_time": "2026-07-20T23:49:05.971127",
      "status": "completed"
     },
     "tags": []
@@ -598,13 +591,128 @@
   },
   {
    "cell_type": "markdown",
+   "id": "s6-md-axelrod",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004003,
+     "end_time": "2026-07-20T23:49:06.232587",
+     "exception": false,
+     "start_time": "2026-07-20T23:49:06.228584",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## S6 -- Axelrod IPD itéré (substrat RÉEL booléen, TFT vs ALLD sous bruit)\n",
+    "\n",
+    "Deuxième substrat **réel**, et le plus fidèle à Huang : une séquence **booléenne** de coopération/défection au cours d'un match itéré (IPD) entre TFT (Tit-for-Tat) et ALLD (Always-Defect) sous **bruit d'implémentation** ($p = 0{,}05$ : chaque coup intentionnel est inversé avec probabilité 0.05). C'est exactement le terrain du théorème de Huang — une fonction sur une trajectoire de bits.\n",
+    "\n",
+    "**Pourquoi le bruit n'est pas cosmétique** : sans bruit, TFT réplique ALLD coup pour coup (miroir parfait, dynamique pauvre). Sous bruit, TFT entre en **effondrement en écho** (un coup inversé se propage indéfiniment car TFT copie le coup bruité), générant une dynamique riche de bascules coopération/défection — un phénomène émergent authentique. La caractérisation = taux de coopération (fenêtre glissante de 50 coups) quantifié en labels symboliques. La fonction $f$ = « régime coopératif » (taux $> 0{,}5$).\n",
+    "\n",
+    "**Note épistémique** : la dynamique de **réplicateur** (population évolutive, `strategic_morphodynamics.replicator_trajectory`) a été testée puis **écartée** comme substrat — elle converge vers l'ESS (TFT fixe) avec au plus 1 bascule de stratégie dominante, une trajectoire monotone pauvre en sensibilité. Le match itéré sous bruit, lui, exhibe une morphogenèse temporelle analogue à Gray-Scott."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "s6-code-axelrod",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-20T23:49:06.240585Z",
+     "iopub.status.busy": "2026-07-20T23:49:06.240585Z",
+     "iopub.status.idle": "2026-07-20T23:49:06.536951Z",
+     "shell.execute_reply": "2026-07-20T23:49:06.535884Z"
+    },
+    "papermill": {
+     "duration": 0.302418,
+     "end_time": "2026-07-20T23:49:06.538002",
+     "exception": false,
+     "start_time": "2026-07-20T23:49:06.235584",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  S6 : 2000 pas, vocabulaire (taux coop. quantifie) : [0.0, 0.02, 0.04, 0.06, 0.08, 0.09, 0.1, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18, 0.19, 0.2, 0.22, 0.25, 0.29, 0.33, 0.4, 0.5, 1.0]\n",
+      "  taux de cooperation TFT range : [0.0, 1.0]\n",
+      "--- S6 (axelrod ipd) ---\n",
+      "  n_symbols (vocabulaire) : 24\n",
+      "  len(trajectoire)         : 2000\n",
+      "  sensibilite : max=23.00, mean=1.92, std=4.40, p95=1.00\n",
+      "  s_max       : 23.000\n",
+      "  deg_proxy   : 0.539\n",
+      "  threshold   : 0.734 (= sqrt(deg_proxy))\n",
+      "  ratio       : 31.341  (s_max / threshold)\n",
+      "  verdict     : consistent\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "from ict import strategic_morphodynamics as M\n",
+    "\n",
+    "# S6 : substrat REEL booleen — match IPD itere TFT vs ALLD sous bruit d'implementation.\n",
+    "# Le bruit (p=0.05) declenche l'effondrement en echo de TFT : dynamique riche de\n",
+    "# bascules C/D. Caracterisation : taux de cooperation (fenetre glissante 50 coups)\n",
+    "# quantifie en labels symboliques. f = regime cooperatif (taux > 0.5).\n",
+    "NOISE_S6 = 0.05\n",
+    "rng_s6 = np.random.default_rng(7)\n",
+    "strat_dict = M.make_strategies(rng_s6)\n",
+    "\n",
+    "def ipd_match_moves(s1, s2, n_rounds=2000, noise=0.05, rng=None):\n",
+    "    if rng is None:\n",
+    "        rng = np.random.default_rng(0)\n",
+    "    own1, own2 = [], []\n",
+    "    for _ in range(n_rounds):\n",
+    "        a = int(s1(np.array(own1), np.array(own2)))\n",
+    "        b = int(s2(np.array(own2), np.array(own1)))\n",
+    "        if noise > 0.0:\n",
+    "            if rng.random() < noise:\n",
+    "                a = 1 - a\n",
+    "            if rng.random() < noise:\n",
+    "                b = 1 - b\n",
+    "        own1.append(a)\n",
+    "        own2.append(b)\n",
+    "    return own1, own2\n",
+    "\n",
+    "# Convention M : cooperate=0 (allc), defect=1 (alld). cooperation = 1 - move.\n",
+    "moves_tft, moves_alld = ipd_match_moves(\n",
+    "    strat_dict['tft'], strat_dict['alld'], n_rounds=2000, noise=NOISE_S6, rng=np.random.default_rng(7)\n",
+    ")\n",
+    "coop_tft = [1 - m for m in moves_tft]  # 1 = TFT coopere, 0 = TFT defected\n",
+    "\n",
+    "# Taux de coopération en fenetre glissante (50 coups) -> trajectoire symbolique.\n",
+    "WIN_S6 = 50\n",
+    "coop_arr = np.array(coop_tft)\n",
+    "states_s6 = [round(float(coop_arr[max(0, i - WIN_S6):i + 1].mean()), 2) for i in range(len(coop_arr))]\n",
+    "\n",
+    "print('  S6 : ' + str(len(states_s6)) + ' pas, vocabulaire (taux coop. quantifie) : ' + str(sorted(set(states_s6))))\n",
+    "print('  taux de cooperation TFT range : [' + str(min(states_s6)) + ', ' + str(max(states_s6)) + ']')\n",
+    "\n",
+    "_labels_s6, n_s6, _label_map_s6 = trajectory_labels(states_s6, lambda s: s)\n",
+    "label_to_state_s6 = {v: k for k, v in _label_map_s6.items()}\n",
+    "\n",
+    "# f_native : regime cooperatif = taux de cooperation au-dela de 0.5 (TFT soutient\n",
+    "# la cooperation malgre le bruit).\n",
+    "SEUIL_COOP_S6 = 0.5\n",
+    "f_native_s6 = lambda natif: int(natif > SEUIL_COOP_S6)\n",
+    "\n",
+    "dist_s6, test_s6 = summarize_substrat('S6 (axelrod ipd)', states_s6, lambda s: s, f_native_s6, label_to_state_s6)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "84303fed",
    "metadata": {
     "papermill": {
-     "duration": 0.005937,
-     "end_time": "2026-07-20T23:24:57.383583",
+     "duration": 0.007461,
+     "end_time": "2026-07-20T23:49:06.553565",
      "exception": false,
-     "start_time": "2026-07-20T23:24:57.377646",
+     "start_time": "2026-07-20T23:49:06.546104",
      "status": "completed"
     },
     "tags": []
@@ -617,20 +725,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "01ee8a34",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T23:24:57.398807Z",
-     "iopub.status.busy": "2026-07-20T23:24:57.398247Z",
-     "iopub.status.idle": "2026-07-20T23:24:57.694326Z",
-     "shell.execute_reply": "2026-07-20T23:24:57.694326Z"
+     "iopub.execute_input": "2026-07-20T23:49:06.563863Z",
+     "iopub.status.busy": "2026-07-20T23:49:06.563330Z",
+     "iopub.status.idle": "2026-07-20T23:49:06.861168Z",
+     "shell.execute_reply": "2026-07-20T23:49:06.860625Z"
     },
     "papermill": {
-     "duration": 0.306694,
-     "end_time": "2026-07-20T23:24:57.695830",
+     "duration": 0.304881,
+     "end_time": "2026-07-20T23:49:06.862172",
      "exception": false,
-     "start_time": "2026-07-20T23:24:57.389136",
+     "start_time": "2026-07-20T23:49:06.557291",
      "status": "completed"
     },
     "tags": []
@@ -640,14 +748,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "       Substrat  s_max  deg_proxy  threshold  ratio      verdict\n",
-      "       S1 (tri)     12      0.565      0.752 15.968   consistent\n",
-      "    S2 (regime)      0      0.996      0.998  0.000 inconsistent\n",
-      "   S3 (opinion)      1      0.250      0.500  2.000   consistent\n",
-      "     S4 (motif)      1      0.344      0.587  1.705   consistent\n",
-      "S5 (gray-scott)      9      0.058      0.242 37.237   consistent\n",
+      "        Substrat  s_max  deg_proxy  threshold  ratio      verdict\n",
+      "        S1 (tri)     12      0.565      0.752 15.968   consistent\n",
+      "     S2 (regime)      0      0.996      0.998  0.000 inconsistent\n",
+      "    S3 (opinion)      1      0.250      0.500  2.000   consistent\n",
+      "      S4 (motif)      1      0.344      0.587  1.705   consistent\n",
+      " S5 (gray-scott)      9      0.058      0.242 37.237   consistent\n",
+      "S6 (axelrod ipd)     23      0.539      0.734 31.341   consistent\n",
       "\n",
-      "Verdict global : 4 consistent / 1 inconsistent / 0 inconclusive sur 5 substrats\n",
+      "Verdict global : 5 consistent / 1 inconsistent / 0 inconclusive sur 6 substrats\n",
       "\n",
       "Interpretation :\n",
       "  La conjecture ICT-15b (s_max >= sqrt(deg_proxy)) est REJETEE sur 1 substrat(s).\n",
@@ -660,7 +769,7 @@
     "import pandas as pd\n",
     "\n",
     "rows = []\n",
-    "for name, test in [('S1 (tri)', test_s1), ('S2 (regime)', test_s2), ('S3 (opinion)', test_s3), ('S4 (motif)', test_s4), ('S5 (gray-scott)', test_s5)]:\n",
+    "for name, test in [('S1 (tri)', test_s1), ('S2 (regime)', test_s2), ('S3 (opinion)', test_s3), ('S4 (motif)', test_s4), ('S5 (gray-scott)', test_s5), ('S6 (axelrod ipd)', test_s6)]:\n",
     "    rows.append({\n",
     "        'Substrat': name,\n",
     "        's_max': round(test['s_max'], 3),\n",
@@ -697,10 +806,10 @@
    "id": "95b508e5",
    "metadata": {
     "papermill": {
-     "duration": 0.003002,
-     "end_time": "2026-07-20T23:24:57.702836",
+     "duration": 0.003457,
+     "end_time": "2026-07-20T23:49:06.868855",
      "exception": false,
-     "start_time": "2026-07-20T23:24:57.699834",
+     "start_time": "2026-07-20T23:49:06.865398",
      "status": "completed"
     },
     "tags": []
@@ -723,10 +832,10 @@
    "id": "d6254b61",
    "metadata": {
     "papermill": {
-     "duration": 0.003001,
-     "end_time": "2026-07-20T23:24:57.709836",
+     "duration": 0.003002,
+     "end_time": "2026-07-20T23:49:06.875856",
      "exception": false,
-     "start_time": "2026-07-20T23:24:57.706835",
+     "start_time": "2026-07-20T23:49:06.872854",
      "status": "completed"
     },
     "tags": []
@@ -743,20 +852,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "3bc27be1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T23:24:57.718939Z",
-     "iopub.status.busy": "2026-07-20T23:24:57.718939Z",
-     "iopub.status.idle": "2026-07-20T23:24:57.726939Z",
-     "shell.execute_reply": "2026-07-20T23:24:57.725968Z"
+     "iopub.execute_input": "2026-07-20T23:49:06.884991Z",
+     "iopub.status.busy": "2026-07-20T23:49:06.884991Z",
+     "iopub.status.idle": "2026-07-20T23:49:06.891024Z",
+     "shell.execute_reply": "2026-07-20T23:49:06.891024Z"
     },
     "papermill": {
-     "duration": 0.012954,
-     "end_time": "2026-07-20T23:24:57.726939",
+     "duration": 0.012138,
+     "end_time": "2026-07-20T23:49:06.891992",
      "exception": false,
-     "start_time": "2026-07-20T23:24:57.713985",
+     "start_time": "2026-07-20T23:49:06.879854",
      "status": "completed"
     },
     "tags": []
@@ -798,10 +907,10 @@
    "id": "dc09bc89",
    "metadata": {
     "papermill": {
-     "duration": 0.004101,
-     "end_time": "2026-07-20T23:24:57.734403",
+     "duration": 0.002998,
+     "end_time": "2026-07-20T23:49:06.898990",
      "exception": false,
-     "start_time": "2026-07-20T23:24:57.730302",
+     "start_time": "2026-07-20T23:49:06.895992",
      "status": "completed"
     },
     "tags": []
@@ -814,20 +923,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "f3f39a99",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T23:24:57.742402Z",
-     "iopub.status.busy": "2026-07-20T23:24:57.742402Z",
-     "iopub.status.idle": "2026-07-20T23:24:57.757811Z",
-     "shell.execute_reply": "2026-07-20T23:24:57.756812Z"
+     "iopub.execute_input": "2026-07-20T23:49:06.908200Z",
+     "iopub.status.busy": "2026-07-20T23:49:06.908200Z",
+     "iopub.status.idle": "2026-07-20T23:49:06.922397Z",
+     "shell.execute_reply": "2026-07-20T23:49:06.921412Z"
     },
     "papermill": {
-     "duration": 0.020408,
-     "end_time": "2026-07-20T23:24:57.757811",
+     "duration": 0.019197,
+     "end_time": "2026-07-20T23:49:06.922397",
      "exception": false,
-     "start_time": "2026-07-20T23:24:57.737403",
+     "start_time": "2026-07-20T23:49:06.903200",
      "status": "completed"
     },
     "tags": []
@@ -872,10 +981,10 @@
    "id": "dab42ce8",
    "metadata": {
     "papermill": {
-     "duration": 0.003985,
-     "end_time": "2026-07-20T23:24:57.765815",
+     "duration": 0.004017,
+     "end_time": "2026-07-20T23:49:06.930418",
      "exception": false,
-     "start_time": "2026-07-20T23:24:57.761830",
+     "start_time": "2026-07-20T23:49:06.926401",
      "status": "completed"
     },
     "tags": []
@@ -888,20 +997,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "fa19e24a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T23:24:57.775048Z",
-     "iopub.status.busy": "2026-07-20T23:24:57.774049Z",
-     "iopub.status.idle": "2026-07-20T23:24:57.788129Z",
-     "shell.execute_reply": "2026-07-20T23:24:57.787571Z"
+     "iopub.execute_input": "2026-07-20T23:49:06.938733Z",
+     "iopub.status.busy": "2026-07-20T23:49:06.938733Z",
+     "iopub.status.idle": "2026-07-20T23:49:06.952938Z",
+     "shell.execute_reply": "2026-07-20T23:49:06.952259Z"
     },
     "papermill": {
-     "duration": 0.019616,
-     "end_time": "2026-07-20T23:24:57.789134",
+     "duration": 0.019523,
+     "end_time": "2026-07-20T23:49:06.952938",
      "exception": false,
-     "start_time": "2026-07-20T23:24:57.769518",
+     "start_time": "2026-07-20T23:49:06.933415",
      "status": "completed"
     },
     "tags": []
@@ -967,14 +1076,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 2.94009,
-   "end_time": "2026-07-20T23:24:58.132660",
+   "duration": 6.435823,
+   "end_time": "2026-07-20T23:49:10.524579",
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15b-SensitivityCanonicity.ipynb",
    "output_path": "MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15b-SensitivityCanonicity.ipynb",
    "parameters": {},
-   "start_time": "2026-07-20T23:24:55.192570",
+   "start_time": "2026-07-20T23:49:04.088756",
    "version": "2.7.0"
   }
  },

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15b-SensitivityCanonicity.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15b-SensitivityCanonicity.ipynb
@@ -5,10 +5,10 @@
    "id": "c42dbb9f",
    "metadata": {
     "papermill": {
-     "duration": 0.002587,
-     "end_time": "2026-07-19T21:26:02.579609+00:00",
+     "duration": 0.003982,
+     "end_time": "2026-07-20T23:24:56.427821",
      "exception": false,
-     "start_time": "2026-07-19T21:26:02.577022+00:00",
+     "start_time": "2026-07-20T23:24:56.423839",
      "status": "completed"
     },
     "tags": []
@@ -56,16 +56,16 @@
    "id": "3415fbb1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-19T21:26:02.585438Z",
-     "iopub.status.busy": "2026-07-19T21:26:02.585104Z",
-     "iopub.status.idle": "2026-07-19T21:26:02.942399Z",
-     "shell.execute_reply": "2026-07-19T21:26:02.941852Z"
+     "iopub.execute_input": "2026-07-20T23:24:56.434979Z",
+     "iopub.status.busy": "2026-07-20T23:24:56.434979Z",
+     "iopub.status.idle": "2026-07-20T23:24:56.841458Z",
+     "shell.execute_reply": "2026-07-20T23:24:56.841458Z"
     },
     "papermill": {
-     "duration": 0.372513,
-     "end_time": "2026-07-19T21:26:02.954396+00:00",
+     "duration": 0.412226,
+     "end_time": "2026-07-20T23:24:56.842860",
      "exception": false,
-     "start_time": "2026-07-19T21:26:02.581883+00:00",
+     "start_time": "2026-07-20T23:24:56.430634",
      "status": "completed"
     },
     "tags": []
@@ -75,9 +75,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ict.spectral OK, transition_graph: <function transition_graph at 0x000002A71ED5ADE0>\n",
-      "ict.sensitivity OK, huang_conjecture_test: <function huang_conjecture_test at 0x000002A71ED5B560>\n",
-      "numpy: 2.4.4\n"
+      "ict.spectral OK, transition_graph: <function transition_graph at 0x00000247B0560040>\n",
+      "ict.sensitivity OK, huang_conjecture_test: <function huang_conjecture_test at 0x00000247B05608B0>\n",
+      "numpy: 2.2.6\n"
      ]
     }
    ],
@@ -104,10 +104,10 @@
    "id": "d4431d69",
    "metadata": {
     "papermill": {
-     "duration": 0.048157,
-     "end_time": "2026-07-19T21:26:03.032641+00:00",
+     "duration": 0.003261,
+     "end_time": "2026-07-20T23:24:56.850158",
      "exception": false,
-     "start_time": "2026-07-19T21:26:02.984484+00:00",
+     "start_time": "2026-07-20T23:24:56.846897",
      "status": "completed"
     },
     "tags": []
@@ -124,16 +124,16 @@
    "id": "84591af9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-19T21:26:03.078865Z",
-     "iopub.status.busy": "2026-07-19T21:26:03.075971Z",
-     "iopub.status.idle": "2026-07-19T21:26:03.112403Z",
-     "shell.execute_reply": "2026-07-19T21:26:03.109439Z"
+     "iopub.execute_input": "2026-07-20T23:24:56.857843Z",
+     "iopub.status.busy": "2026-07-20T23:24:56.856837Z",
+     "iopub.status.idle": "2026-07-20T23:24:56.872565Z",
+     "shell.execute_reply": "2026-07-20T23:24:56.872028Z"
     },
     "papermill": {
-     "duration": 0.064652,
-     "end_time": "2026-07-19T21:26:03.114775+00:00",
+     "duration": 0.020212,
+     "end_time": "2026-07-20T23:24:56.873570",
      "exception": false,
-     "start_time": "2026-07-19T21:26:03.050123+00:00",
+     "start_time": "2026-07-20T23:24:56.853358",
      "status": "completed"
     },
     "tags": []
@@ -174,10 +174,10 @@
    "id": "6db07a50",
    "metadata": {
     "papermill": {
-     "duration": 0.004023,
-     "end_time": "2026-07-19T21:26:03.121963+00:00",
+     "duration": 0.003005,
+     "end_time": "2026-07-20T23:24:56.879573",
      "exception": false,
-     "start_time": "2026-07-19T21:26:03.117940+00:00",
+     "start_time": "2026-07-20T23:24:56.876568",
      "status": "completed"
     },
     "tags": []
@@ -196,16 +196,16 @@
    "id": "f4448a2e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-19T21:26:03.135756Z",
-     "iopub.status.busy": "2026-07-19T21:26:03.134972Z",
-     "iopub.status.idle": "2026-07-19T21:26:03.150418Z",
-     "shell.execute_reply": "2026-07-19T21:26:03.149775Z"
+     "iopub.execute_input": "2026-07-20T23:24:56.887625Z",
+     "iopub.status.busy": "2026-07-20T23:24:56.887625Z",
+     "iopub.status.idle": "2026-07-20T23:24:56.904346Z",
+     "shell.execute_reply": "2026-07-20T23:24:56.903801Z"
     },
     "papermill": {
-     "duration": 0.025986,
-     "end_time": "2026-07-19T21:26:03.152751+00:00",
+     "duration": 0.0226,
+     "end_time": "2026-07-20T23:24:56.905356",
      "exception": false,
-     "start_time": "2026-07-19T21:26:03.126765+00:00",
+     "start_time": "2026-07-20T23:24:56.882756",
      "status": "completed"
     },
     "tags": []
@@ -258,10 +258,10 @@
    "id": "676832ad",
    "metadata": {
     "papermill": {
-     "duration": 0.011856,
-     "end_time": "2026-07-19T21:26:03.175519+00:00",
+     "duration": 0.002997,
+     "end_time": "2026-07-20T23:24:56.911356",
      "exception": false,
-     "start_time": "2026-07-19T21:26:03.163663+00:00",
+     "start_time": "2026-07-20T23:24:56.908359",
      "status": "completed"
     },
     "tags": []
@@ -280,16 +280,16 @@
    "id": "91b3d26a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-19T21:26:03.191832Z",
-     "iopub.status.busy": "2026-07-19T21:26:03.191609Z",
-     "iopub.status.idle": "2026-07-19T21:26:03.240208Z",
-     "shell.execute_reply": "2026-07-19T21:26:03.239372Z"
+     "iopub.execute_input": "2026-07-20T23:24:56.919357Z",
+     "iopub.status.busy": "2026-07-20T23:24:56.918357Z",
+     "iopub.status.idle": "2026-07-20T23:24:56.997955Z",
+     "shell.execute_reply": "2026-07-20T23:24:56.996929Z"
     },
     "papermill": {
-     "duration": 0.065309,
-     "end_time": "2026-07-19T21:26:03.247771+00:00",
+     "duration": 0.08358,
+     "end_time": "2026-07-20T23:24:56.997955",
      "exception": false,
-     "start_time": "2026-07-19T21:26:03.182462+00:00",
+     "start_time": "2026-07-20T23:24:56.914375",
      "status": "completed"
     },
     "tags": []
@@ -334,10 +334,10 @@
    "id": "536982e0",
    "metadata": {
     "papermill": {
-     "duration": 0.033298,
-     "end_time": "2026-07-19T21:26:03.312136+00:00",
+     "duration": 0.002984,
+     "end_time": "2026-07-20T23:24:57.004929",
      "exception": false,
-     "start_time": "2026-07-19T21:26:03.278838+00:00",
+     "start_time": "2026-07-20T23:24:57.001945",
      "status": "completed"
     },
     "tags": []
@@ -356,16 +356,16 @@
    "id": "3536fa56",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-19T21:26:03.395740Z",
-     "iopub.status.busy": "2026-07-19T21:26:03.394211Z",
-     "iopub.status.idle": "2026-07-19T21:26:03.466876Z",
-     "shell.execute_reply": "2026-07-19T21:26:03.466278Z"
+     "iopub.execute_input": "2026-07-20T23:24:57.011944Z",
+     "iopub.status.busy": "2026-07-20T23:24:57.011944Z",
+     "iopub.status.idle": "2026-07-20T23:24:57.059770Z",
+     "shell.execute_reply": "2026-07-20T23:24:57.059770Z"
     },
     "papermill": {
-     "duration": 0.127023,
-     "end_time": "2026-07-19T21:26:03.476226+00:00",
+     "duration": 0.052822,
+     "end_time": "2026-07-20T23:24:57.060770",
      "exception": false,
-     "start_time": "2026-07-19T21:26:03.349203+00:00",
+     "start_time": "2026-07-20T23:24:57.007948",
      "status": "completed"
     },
     "tags": []
@@ -375,7 +375,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  S3 : 1500 pas, majorites uniques (echantillon) : [0, 27]\n",
+      "  S3 : 1500 pas, majorites uniques (echantillon) : [0, 27]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
       "--- S3 (opinion) ---\n",
       "  n_symbols (vocabulaire) : 2\n",
       "  len(trajectoire)         : 1500\n",
@@ -419,10 +426,10 @@
    "id": "9295aecb",
    "metadata": {
     "papermill": {
-     "duration": 0.036053,
-     "end_time": "2026-07-19T21:26:03.548747+00:00",
+     "duration": 0.002549,
+     "end_time": "2026-07-20T23:24:57.067335",
      "exception": false,
-     "start_time": "2026-07-19T21:26:03.512694+00:00",
+     "start_time": "2026-07-20T23:24:57.064786",
      "status": "completed"
     },
     "tags": []
@@ -441,16 +448,16 @@
    "id": "c8e9ced2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-19T21:26:03.616590Z",
-     "iopub.status.busy": "2026-07-19T21:26:03.615043Z",
-     "iopub.status.idle": "2026-07-19T21:26:03.669412Z",
-     "shell.execute_reply": "2026-07-19T21:26:03.664635Z"
+     "iopub.execute_input": "2026-07-20T23:24:57.075395Z",
+     "iopub.status.busy": "2026-07-20T23:24:57.074396Z",
+     "iopub.status.idle": "2026-07-20T23:24:57.091972Z",
+     "shell.execute_reply": "2026-07-20T23:24:57.090971Z"
     },
     "papermill": {
-     "duration": 0.091787,
-     "end_time": "2026-07-19T21:26:03.676685+00:00",
+     "duration": 0.021581,
+     "end_time": "2026-07-20T23:24:57.091972",
      "exception": false,
-     "start_time": "2026-07-19T21:26:03.584898+00:00",
+     "start_time": "2026-07-20T23:24:57.070391",
      "status": "completed"
     },
     "tags": []
@@ -500,13 +507,104 @@
   },
   {
    "cell_type": "markdown",
+   "id": "s5-md-grayscott",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003984,
+     "end_time": "2026-07-20T23:24:57.099484",
+     "exception": false,
+     "start_time": "2026-07-20T23:24:57.095500",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## S5 -- Réaction-diffusion de Gray-Scott (substrat RÉEL, Pearson 1993)\n",
+    "\n",
+    "Substrat **réel** (EDP continue discrétisée), par opposition aux substrats synthétiques S1-S4. Le modèle de Gray-Scott ($U + 2V \\to 3V$, $V \\to \\varnothing$) produit une riche zoologie de motifs auto-organisés selon les paramètres $(F, k)$. Régime **« maze / labyrinthe »** ($F = 0.012$, $k = 0.045$) choisi pour sa formation rapide de structures (Pearson 1993), sur une grille $64 \\times 64$.\n",
+    "\n",
+    "**Caractérisation** : à chaque pas de temps, l'écart-type du champ $V$ quantifie la complexité structurelle du motif ($\\sigma_V \\approx 0$ = homogène, $\\sigma_V$ élevé = structures formées). Quantifié en labels symboliques, cela donne une **trajectoire symbolique de la morphogenèse** — exactement le type de transposition que la conjecture de Huang doit affronter : l'hypercube booléen $Q_n$ devient le **graphe des régimes morphologiques**. La fonction $f$ = « pattern auto-organisé au-delà du seuil de structuration » ($\\sigma_V > 0{,}08$)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "s5-code-grayscott",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-20T23:24:57.107302Z",
+     "iopub.status.busy": "2026-07-20T23:24:57.107302Z",
+     "iopub.status.idle": "2026-07-20T23:24:57.369648Z",
+     "shell.execute_reply": "2026-07-20T23:24:57.368649Z"
+    },
+    "papermill": {
+     "duration": 0.268148,
+     "end_time": "2026-07-20T23:24:57.370648",
+     "exception": false,
+     "start_time": "2026-07-20T23:24:57.102500",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  S5 : 2000 pas, vocabulaire (std_V quantifie) : [0.0, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09, 0.1, 0.11, 0.12]\n",
+      "  std V range : [0.0, 0.12]\n",
+      "--- S5 (gray-scott) ---\n",
+      "  n_symbols (vocabulaire) : 13\n",
+      "  len(trajectoire)         : 2000\n",
+      "  sensibilite : max=9.00, mean=5.54, std=2.31, p95=9.00\n",
+      "  s_max       : 9.000\n",
+      "  deg_proxy   : 0.058\n",
+      "  threshold   : 0.242 (= sqrt(deg_proxy))\n",
+      "  ratio       : 37.237  (s_max / threshold)\n",
+      "  verdict     : consistent\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "from ict.reaction_diffusion import GrayScott\n",
+    "\n",
+    "# S5 : substrat REEL de reaction-diffusion (Gray-Scott), par opposition aux\n",
+    "# substrats synthetiques S1-S4. Regime \"maze\" (F=0.012, k=0.045) auto-organisant\n",
+    "# rapide (Pearson 1993). Caracterisation : ecart-type du champ V (proxy de la\n",
+    "# complexite structurelle du motif) quantifie en labels symboliques.\n",
+    "gs = GrayScott(F=0.012, k=0.045, Du=0.16, Dv=0.08, dt=1.0)\n",
+    "U, V = gs.seed(n=64, block=14, rng=np.random.default_rng(0))\n",
+    "\n",
+    "N_STEPS_S5 = 2000\n",
+    "states_s5 = []\n",
+    "for _ in range(N_STEPS_S5):\n",
+    "    states_s5.append(round(float(V.std()), 2))\n",
+    "    U, V = gs.step(U, V)\n",
+    "\n",
+    "print('  S5 : ' + str(len(states_s5)) + ' pas, vocabulaire (std_V quantifie) : ' + str(sorted(set(states_s5))))\n",
+    "print('  std V range : [' + str(min(states_s5)) + ', ' + str(max(states_s5)) + ']')\n",
+    "\n",
+    "_labels_s5, n_s5, _label_map_s5 = trajectory_labels(states_s5, lambda s: s)\n",
+    "label_to_state_s5 = {v: k for k, v in _label_map_s5.items()}\n",
+    "\n",
+    "# f_native : pattern auto-organise = ecart-type du champ au-dela du seuil\n",
+    "# morphogenetique (0.08 : au-dessus, le champ presente des structures).\n",
+    "SEUIL_STRUCTURE_S5 = 0.08\n",
+    "f_native_s5 = lambda natif: int(natif > SEUIL_STRUCTURE_S5)\n",
+    "\n",
+    "dist_s5, test_s5 = summarize_substrat('S5 (gray-scott)', states_s5, lambda s: s, f_native_s5, label_to_state_s5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "84303fed",
    "metadata": {
     "papermill": {
-     "duration": 0.008118,
-     "end_time": "2026-07-19T21:26:03.703921+00:00",
+     "duration": 0.005937,
+     "end_time": "2026-07-20T23:24:57.383583",
      "exception": false,
-     "start_time": "2026-07-19T21:26:03.695803+00:00",
+     "start_time": "2026-07-20T23:24:57.377646",
      "status": "completed"
     },
     "tags": []
@@ -519,20 +617,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "01ee8a34",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-19T21:26:03.733369Z",
-     "iopub.status.busy": "2026-07-19T21:26:03.731867Z",
-     "iopub.status.idle": "2026-07-19T21:26:04.109407Z",
-     "shell.execute_reply": "2026-07-19T21:26:04.108780Z"
+     "iopub.execute_input": "2026-07-20T23:24:57.398807Z",
+     "iopub.status.busy": "2026-07-20T23:24:57.398247Z",
+     "iopub.status.idle": "2026-07-20T23:24:57.694326Z",
+     "shell.execute_reply": "2026-07-20T23:24:57.694326Z"
     },
     "papermill": {
-     "duration": 0.409148,
-     "end_time": "2026-07-19T21:26:04.122232+00:00",
+     "duration": 0.306694,
+     "end_time": "2026-07-20T23:24:57.695830",
      "exception": false,
-     "start_time": "2026-07-19T21:26:03.713084+00:00",
+     "start_time": "2026-07-20T23:24:57.389136",
      "status": "completed"
     },
     "tags": []
@@ -542,13 +640,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    Substrat  s_max  deg_proxy  threshold  ratio      verdict\n",
-      "    S1 (tri)     12      0.565      0.752 15.968   consistent\n",
-      " S2 (regime)      0      0.996      0.998  0.000 inconsistent\n",
-      "S3 (opinion)      1      0.250      0.500  2.000   consistent\n",
-      "  S4 (motif)      1      0.344      0.587  1.705   consistent\n",
+      "       Substrat  s_max  deg_proxy  threshold  ratio      verdict\n",
+      "       S1 (tri)     12      0.565      0.752 15.968   consistent\n",
+      "    S2 (regime)      0      0.996      0.998  0.000 inconsistent\n",
+      "   S3 (opinion)      1      0.250      0.500  2.000   consistent\n",
+      "     S4 (motif)      1      0.344      0.587  1.705   consistent\n",
+      "S5 (gray-scott)      9      0.058      0.242 37.237   consistent\n",
       "\n",
-      "Verdict global : 3 consistent / 1 inconsistent / 0 inconclusive sur 4 substrats\n",
+      "Verdict global : 4 consistent / 1 inconsistent / 0 inconclusive sur 5 substrats\n",
       "\n",
       "Interpretation :\n",
       "  La conjecture ICT-15b (s_max >= sqrt(deg_proxy)) est REJETEE sur 1 substrat(s).\n",
@@ -561,7 +660,7 @@
     "import pandas as pd\n",
     "\n",
     "rows = []\n",
-    "for name, test in [('S1 (tri)', test_s1), ('S2 (regime)', test_s2), ('S3 (opinion)', test_s3), ('S4 (motif)', test_s4)]:\n",
+    "for name, test in [('S1 (tri)', test_s1), ('S2 (regime)', test_s2), ('S3 (opinion)', test_s3), ('S4 (motif)', test_s4), ('S5 (gray-scott)', test_s5)]:\n",
     "    rows.append({\n",
     "        'Substrat': name,\n",
     "        's_max': round(test['s_max'], 3),\n",
@@ -598,10 +697,10 @@
    "id": "95b508e5",
    "metadata": {
     "papermill": {
-     "duration": 0.043761,
-     "end_time": "2026-07-19T21:26:04.205073+00:00",
+     "duration": 0.003002,
+     "end_time": "2026-07-20T23:24:57.702836",
      "exception": false,
-     "start_time": "2026-07-19T21:26:04.161312+00:00",
+     "start_time": "2026-07-20T23:24:57.699834",
      "status": "completed"
     },
     "tags": []
@@ -624,10 +723,10 @@
    "id": "d6254b61",
    "metadata": {
     "papermill": {
-     "duration": 0.042648,
-     "end_time": "2026-07-19T21:26:04.282360+00:00",
+     "duration": 0.003001,
+     "end_time": "2026-07-20T23:24:57.709836",
      "exception": false,
-     "start_time": "2026-07-19T21:26:04.239712+00:00",
+     "start_time": "2026-07-20T23:24:57.706835",
      "status": "completed"
     },
     "tags": []
@@ -644,20 +743,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "3bc27be1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-19T21:26:04.321718Z",
-     "iopub.status.busy": "2026-07-19T21:26:04.319610Z",
-     "iopub.status.idle": "2026-07-19T21:26:04.355774Z",
-     "shell.execute_reply": "2026-07-19T21:26:04.353896Z"
+     "iopub.execute_input": "2026-07-20T23:24:57.718939Z",
+     "iopub.status.busy": "2026-07-20T23:24:57.718939Z",
+     "iopub.status.idle": "2026-07-20T23:24:57.726939Z",
+     "shell.execute_reply": "2026-07-20T23:24:57.725968Z"
     },
     "papermill": {
-     "duration": 0.063595,
-     "end_time": "2026-07-19T21:26:04.358488+00:00",
+     "duration": 0.012954,
+     "end_time": "2026-07-20T23:24:57.726939",
      "exception": false,
-     "start_time": "2026-07-19T21:26:04.294893+00:00",
+     "start_time": "2026-07-20T23:24:57.713985",
      "status": "completed"
     },
     "tags": []
@@ -699,10 +798,10 @@
    "id": "dc09bc89",
    "metadata": {
     "papermill": {
-     "duration": 0.019354,
-     "end_time": "2026-07-19T21:26:04.388611+00:00",
+     "duration": 0.004101,
+     "end_time": "2026-07-20T23:24:57.734403",
      "exception": false,
-     "start_time": "2026-07-19T21:26:04.369257+00:00",
+     "start_time": "2026-07-20T23:24:57.730302",
      "status": "completed"
     },
     "tags": []
@@ -715,20 +814,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "f3f39a99",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-19T21:26:04.470923Z",
-     "iopub.status.busy": "2026-07-19T21:26:04.467213Z",
-     "iopub.status.idle": "2026-07-19T21:26:04.547125Z",
-     "shell.execute_reply": "2026-07-19T21:26:04.536674Z"
+     "iopub.execute_input": "2026-07-20T23:24:57.742402Z",
+     "iopub.status.busy": "2026-07-20T23:24:57.742402Z",
+     "iopub.status.idle": "2026-07-20T23:24:57.757811Z",
+     "shell.execute_reply": "2026-07-20T23:24:57.756812Z"
     },
     "papermill": {
-     "duration": 0.12375,
-     "end_time": "2026-07-19T21:26:04.553501+00:00",
+     "duration": 0.020408,
+     "end_time": "2026-07-20T23:24:57.757811",
      "exception": false,
-     "start_time": "2026-07-19T21:26:04.429751+00:00",
+     "start_time": "2026-07-20T23:24:57.737403",
      "status": "completed"
     },
     "tags": []
@@ -773,10 +872,10 @@
    "id": "dab42ce8",
    "metadata": {
     "papermill": {
-     "duration": 0.023148,
-     "end_time": "2026-07-19T21:26:04.611475+00:00",
+     "duration": 0.003985,
+     "end_time": "2026-07-20T23:24:57.765815",
      "exception": false,
-     "start_time": "2026-07-19T21:26:04.588327+00:00",
+     "start_time": "2026-07-20T23:24:57.761830",
      "status": "completed"
     },
     "tags": []
@@ -789,20 +888,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "fa19e24a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-19T21:26:04.634441Z",
-     "iopub.status.busy": "2026-07-19T21:26:04.633270Z",
-     "iopub.status.idle": "2026-07-19T21:26:04.698264Z",
-     "shell.execute_reply": "2026-07-19T21:26:04.692832Z"
+     "iopub.execute_input": "2026-07-20T23:24:57.775048Z",
+     "iopub.status.busy": "2026-07-20T23:24:57.774049Z",
+     "iopub.status.idle": "2026-07-20T23:24:57.788129Z",
+     "shell.execute_reply": "2026-07-20T23:24:57.787571Z"
     },
     "papermill": {
-     "duration": 0.082105,
-     "end_time": "2026-07-19T21:26:04.701365+00:00",
+     "duration": 0.019616,
+     "end_time": "2026-07-20T23:24:57.789134",
      "exception": false,
-     "start_time": "2026-07-19T21:26:04.619260+00:00",
+     "start_time": "2026-07-20T23:24:57.769518",
      "status": "completed"
     },
     "tags": []
@@ -864,18 +963,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.14"
+   "version": "3.10.19"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 4.525154,
-   "end_time": "2026-07-19T21:26:05.406549+00:00",
+   "duration": 2.94009,
+   "end_time": "2026-07-20T23:24:58.132660",
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15b-SensitivityCanonicity.ipynb",
    "output_path": "MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15b-SensitivityCanonicity.ipynb",
    "parameters": {},
-   "start_time": "2026-07-19T21:26:00.881395+00:00",
+   "start_time": "2026-07-20T23:24:55.192570",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
## Summary

Extend `ICT-15b-SensitivityCanonicity.ipynb` with **two REAL substrates** (tranches 1+2 of ai-01 dispatch #7288 "N substrats"), adding to the existing synthetic S1-S4:
- **S5 Gray-Scott reaction-diffusion** (Pearson 1993 "maze" F=0.012 k=0.045) — continuous PDE substrate
- **S6 Axelrod IPD iterated match** (TFT vs ALLD under noise p=0.05) — boolean substrate, the most faithful Huang transpose

Lane exploitation-empirique (NOT argumentation #7289/#7341, GELÉE).

## Why

ai-01 dispatch #7288 (DM msg-20260720T230430-rlk68m): "exploiter spectral.py + sensitivity.py sur N substrats réels déjà instrumentés (May / Gray-Scott / Axelrod / grokking) → distribution de la sensibilité (Huang 2019) par substrat". Feeds N1 #7395 (méta-proxy d'obstruction).

**G.9 scope clarification**: the notebook ALREADY had S1-S4 (synthetic, executed) + verdict + 3 exercises + Lean bridge (`sensitivity_lean`, 0 sorry). This is an EXTENSION to real substrats, not creation. `spectral.py` + `sensitivity.py` verified merged with green tests firsthand.

## Change

1 module, 2 commits (+469/-261 total; deletions are papermill execution-timestamp churn from re-exec, NOT pedagogical content removal — genuine re-exec proof per C.2):

- **§S5** (Gray-Scott): `GrayScott(F=0.012, k=0.045)` maze regime, 64×64, 2000 steps. Characterization = `std(V)` quantized (trajectory of the morphogenesis). `f_native` = pattern structured (std > 0.08).
- **§S6** (Axelrod IPD): iterated match TFT vs ALLD, noise p=0.05. Characterization = cooperation-bit sliding-window (50 rounds) rate quantized. `f_native` = cooperative regime (rate > 0.5). Convention M: cooperate=0, defect=1.
- **Synthèse pandas**: verdict table now over 6 substrats (count dynamic).

**G.9 epistemic honesty in S6 markdown**: replicator_trajectory (evolutionary population dynamics) was tested then REJECTED as substrate — it converges to ESS (TFT fixation) with ≤1 dominant-strategy switch, a monotone trajectory poor in sensitivity. The iterated-match move sequence under noise (TFT echo collapse) is non-degenerate. This choice is documented in the S6 markdown.

## Result (non-degenerate — Prong-B SOTA)

| Substrat | type | s_max | deg_proxy | threshold | ratio | verdict |
|----------|------|-------|-----------|-----------|-------|---------|
| S1 (tri) | synth | 12 | 0.565 | 0.752 | 15.97 | consistent |
| S2 (regime) | synth | 0 | 0.996 | 0.998 | 0.00 | **inconsistent** |
| S3 (opinion) | synth | 1 | 0.250 | 0.500 | 2.00 | consistent |
| S4 (motif) | synth | 1 | 0.344 | 0.587 | 1.70 | consistent |
| **S5 (gray-scott)** | **real PDE** | **9** | 0.058 | 0.242 | 37.24 | consistent |
| **S6 (axelrod ipd)** | **real bool** | **23** | 0.539 | 0.734 | 31.34 | consistent |

**Key findings**:
- S6 (boolean) has the **HIGHEST s_max (23)** — the substrate closest to Huang's native boolean-function terrain has the richest sensitivity. Pedagogically beautiful: the theorem's home ground is the most sensitive.
- S5 (PDE) has the **lowest deg_proxy (0.058)** + highest ratio (37.2) — continuous morphogenesis respects the conjecture strongly.
- Final verdict: **5 consistent / 1 inconsistent (S2 regime) / 0 inconclusive over 6 substrats**. The real substrats (S5, S6) both respect the conjecture; the one inconsistency is a synthetic substrate.

## SOTA verdict (sota-not-workaround)

- **Prong A**: **SOTA-OK** — `ict.reaction_diffusion.GrayScott` + `ict.strategic_morphodynamics` (merged modules) properly invoked, committed outputs ARE real simulations.
- **Prong B**: **OK** — S5 vocab=13, S6 s_max=23 (richest), both non-degenerate (replicator alternative explicitly rejected as degenerate).

## Validation

| Check | Result |
|-------|--------|
| Papermill `--cwd ICT-Series` | 25 cells, exit 0 |
| S5/S6 outputs non-degenerate | S5 vocab=13, S6 s_max=23 (highest of 6) |
| C.1 scan (no voluntary error) | 0 in S5/S6 cells |
| C.2 (commit WITH outputs) | execution_count set + coherent outputs |
| Catalog byte-identical to main | `COURSE_CATALOG.generated.{json,md}` unchanged |
| CRLF/LF | working file normalized, blob LF-clean (0 CR) |
| Path/secret leak scan | 0 in new outputs, 0 papermill abs-path metadata |
| Anti-regression | S1-S4 + 3 exercises intact (deletions = timestamp churn) |
| Diff scope | 1 module (notebook only), 2 commits, no other files |

## Scope (R3 atomicity)

1 notebook, 1 subject — ICT-15b real-substrate extension (S5 Gray-Scott + S6 Axelrod). See #7288 (ICT-15b scope, open). See #4588 (ICT epic). **Not `Closes`** — contribution to an open epic; grokking (ICT-17b) substrate remains a possible follow-up.

Co-Authored-By: Claude <noreply@anthropic.com>
