### PR TITLE
feat(prover,#7477): degenerate-input guards for mine_lean_sessions entry points

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/mine_lean_sessions.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/mine_lean_sessions.py
@@ -21,6 +21,37 @@ from typing import Dict, List, Optional, Tuple
 logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
 log = logging.getLogger(__name__)
 
+
+def _require_path(name: str, value) -> Path:
+    """Reject None/non-Path values at the public boundary.
+
+    Mirrors the #7596/-#7637/-#7638 boundary-guard pattern across the prover.
+    Returns the value cast to Path if it is already a Path, raises ValueError
+    otherwise. Use for entry points that immediately call Path methods
+    (.exists / .read_text / .write_text / .glob), which fail opaquely on None.
+    """
+    if value is None:
+        raise ValueError(f"{name} is None (expected a pathlib.Path)")
+    if not isinstance(value, Path):
+        raise ValueError(f"{name} must be a pathlib.Path, got {type(value).__name__}")
+    return value
+
+
+def _require_list(name: str, value):
+    """Reject None/non-list values that the caller will iterate over.
+
+    The mining pipeline (run_mining / dedup_cookbook / dedup_failures /
+    _extract_successful_patterns) treats list-typed arguments as iterable
+    inputs. Passing None yields an opaque TypeError at the first ``for ... in``
+    site — pin the failure to the call boundary with a named ValueError.
+    """
+    if value is None:
+        raise ValueError(f"{name} is None (expected an iterable)")
+    if not isinstance(value, list):
+        raise ValueError(f"{name} must be a list, got {type(value).__name__}")
+    return value
+
+
 PROVER_DIR = Path(__file__).parent
 HISTORY_DIR = PROVER_DIR / ".prover_history"
 TRACES_DIR = PROVER_DIR / "baselines" / "traces"
@@ -45,6 +76,7 @@ BUILD_SUCCESS_KW = ("BUILD SUCCESS", "Build completed successfully", "[100%] Bui
 
 
 def load_json(path: Path, default=None):
+    path = _require_path("path", path)
     if not path.exists():
         return default
     try:
@@ -54,12 +86,14 @@ def load_json(path: Path, default=None):
 
 
 def save_json(path: Path, data):
+    path = _require_path("path", path)
     path.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
 
 
 # ── Source 1: .prover_history/*.json ─────────────────────────────
 
 def mine_attempt_history(history_dir: Path) -> Tuple[List[Dict], List[Dict]]:
+    history_dir = _require_path("history_dir", history_dir)
     successes, failures = [], []
     for f in sorted(history_dir.glob("*.json")):
         records = load_json(f, [])
@@ -87,6 +121,7 @@ def mine_attempt_history(history_dir: Path) -> Tuple[List[Dict], List[Dict]]:
 # ── Source 2: baselines/traces/*.json ────────────────────────────
 
 def mine_trace_conversations(traces_dir: Path) -> Tuple[List[Dict], List[Dict], List[Dict]]:
+    traces_dir = _require_path("traces_dir", traces_dir)
     cookbook, failed, api = [], [], []
     for f in sorted(traces_dir.glob("*.json")):
         trace = load_json(f, [])
@@ -345,6 +380,8 @@ def _tactic_signature(tactic: str) -> str:
 
 
 def dedup_cookbook(existing: List[Dict], new_entries: List[Dict]) -> List[Dict]:
+    existing = _require_list("existing", existing)
+    new_entries = _require_list("new_entries", new_entries)
     sigs = {e.get("name", "").lower() + "|" + _tactic_signature(e.get("tactic", "")) for e in existing}
     merged = list(existing)
     for ne in new_entries:
@@ -356,6 +393,8 @@ def dedup_cookbook(existing: List[Dict], new_entries: List[Dict]) -> List[Dict]:
 
 
 def dedup_failures(existing: List[Dict], new_entries: List[Dict]) -> List[Dict]:
+    existing = _require_list("existing", existing)
+    new_entries = _require_list("new_entries", new_entries)
     whats = {e.get("what_failed", "").lower()[:100] for e in existing}
     merged = list(existing)
     for ne in new_entries:
@@ -367,6 +406,8 @@ def dedup_failures(existing: List[Dict], new_entries: List[Dict]) -> List[Dict]:
 
 
 def _extract_successful_patterns(successes: List[Dict], failures: List[Dict]) -> List[Dict]:
+    successes = _require_list("successes", successes)
+    failures = _require_list("failures", failures)
     by_src = defaultdict(list)
     for s in successes: by_src[s["source_file"]].append(s)
     fail_by = defaultdict(list)
@@ -426,6 +467,15 @@ def run_mining(
     jsonl_dir: Optional[Path] = None,
     dry_run: bool = False,
 ) -> Dict:
+    history_dir = _require_path("history_dir", history_dir)
+    traces_dir = _require_path("traces_dir", traces_dir)
+    kb_path = _require_path("kb_path", kb_path)
+    # jsonl_dir is Optional[Path]; the inner check (``if jsonl_dir``) already
+    # handles None, but a non-Path/non-None sentinel would still surprise the
+    # ``.glob`` below — guard explicitly for clarity.
+    if jsonl_dir is not None and not isinstance(jsonl_dir, Path):
+        raise ValueError(f"jsonl_dir must be a pathlib.Path or None, got {type(jsonl_dir).__name__}")
+
     kb = load_json(kb_path, {"version": 3, "entries": {},
                               "tactic_cookbook": {"patterns": []},
                               "failed_approaches": [], "mathlib_api": {}})

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_mine_lean_sessions.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_mine_lean_sessions.py
@@ -1,0 +1,224 @@
+"""Unit tests for ``mine_lean_sessions.py`` degenerate-input guards + happy-path.
+
+Loads the module DIRECTLY by file path (mirrors ``test_lean_utils.py``,
+``test_knowledge.py``, ``test_attempt_history.py``), bypassing
+``prover/__init__.py`` which cascades the ``agent_framework`` LLM stack
+absent on a bare CPU runner. The module is stdlib-only (``json``,
+``logging``, ``re``, ``collections``, ``datetime``, ``pathlib``, ``typing``)
+and loads cleanly.
+
+These tests pin two things:
+
+1. **Guards (#7596-pattern, G.9):** every public entry point that
+   immediately calls a ``Path`` method (``.exists`` / ``.read_text`` /
+   ``.write_text`` / ``.glob``) or iterates over a list-shaped argument
+   rejects ``None`` / non-Path / non-list with a clear ``ValueError``
+   naming the offending argument — converting the OPAQUE ``AttributeError``
+   ("NoneType has no attribute 'exists'") / ``TypeError`` ("NoneType is
+   not iterable") that an agent-generated ``None`` previously produced
+   into a diagnosable message.
+
+2. **Happy-path preservation:** the guards are pure defense-in-depth and
+   must not change behavior for valid inputs (load_json on missing file,
+   mine_attempt_history on empty dir, dedup on non-overlapping entries).
+
+Run from ``agent_tests/``::
+
+    python -m pytest tests/test_mine_lean_sessions.py -q
+
+See #1453 (prover co-evolution epic), See #7477 (prover harness forensic).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+
+_spec = importlib.util.spec_from_file_location(
+    "prover_mine_lean_sessions_under_test",
+    ROOT / "prover" / "mine_lean_sessions.py",
+)
+mls = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mls)
+
+
+# A reusable temp directory under pytest's tmp_path for happy-path tests.
+@pytest.fixture
+def empty_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "empty_mining"
+    d.mkdir()
+    return d
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Guards — Path parameters must reject None / non-Path with clear messages
+# ──────────────────────────────────────────────────────────────────────────
+
+class TestPathGuards:
+    """Every Path-typed public entry point rejects None/non-Path inputs."""
+
+    @pytest.mark.parametrize(
+        "fn,argname",
+        [
+            (lambda p: mls.load_json(p), "path"),
+            (lambda p: mls.save_json(p, {}), "path"),
+            (lambda p: mls.mine_attempt_history(p), "history_dir"),
+            (lambda p: mls.mine_trace_conversations(p), "traces_dir"),
+        ],
+    )
+    def test_none_raises_value_error(self, fn, argname):
+        with pytest.raises(ValueError, match=argname):
+            fn(None)
+
+    @pytest.mark.parametrize(
+        "fn",
+        [
+            lambda p: mls.load_json(p),
+            lambda p: mls.save_json(p, {}),
+            lambda p: mls.mine_attempt_history(p),
+            lambda p: mls.mine_trace_conversations(p),
+        ],
+    )
+    def test_non_path_raises_value_error(self, fn):
+        with pytest.raises(ValueError, match="pathlib.Path"):
+            fn(123)  # type: ignore[arg-type]
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Guards — List parameters must reject None / non-list with clear messages
+# ──────────────────────────────────────────────────────────────────────────
+
+class TestListGuards:
+    """Every list-typed public entry point rejects None/non-list inputs."""
+
+    def test_dedup_cookbook_none_existing(self):
+        with pytest.raises(ValueError, match="existing"):
+            mls.dedup_cookbook(None, [])  # type: ignore[arg-type]
+
+    def test_dedup_cookbook_none_new_entries(self):
+        with pytest.raises(ValueError, match="new_entries"):
+            mls.dedup_cookbook([], None)  # type: ignore[arg-type]
+
+    def test_dedup_failures_none_existing(self):
+        with pytest.raises(ValueError, match="existing"):
+            mls.dedup_failures(None, [])  # type: ignore[arg-type]
+
+    def test_dedup_failures_none_new_entries(self):
+        with pytest.raises(ValueError, match="new_entries"):
+            mls.dedup_failures([], None)  # type: ignore[arg-type]
+
+    def test_extract_successful_patterns_none_successes(self):
+        with pytest.raises(ValueError, match="successes"):
+            mls._extract_successful_patterns(None, [])  # type: ignore[arg-type]
+
+    def test_extract_successful_patterns_none_failures(self):
+        with pytest.raises(ValueError, match="failures"):
+            mls._extract_successful_patterns([], None)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize(
+        "bad_input",
+        [("a", "b"), {"x": 1}, "string", 42],
+    )
+    def test_dedup_cookbook_non_list_existing(self, bad_input):
+        with pytest.raises(ValueError, match="existing must be a list"):
+            mls.dedup_cookbook(bad_input, [])  # type: ignore[arg-type]
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Guards — run_mining orchestrator
+# ──────────────────────────────────────────────────────────────────────────
+
+class TestRunMiningGuards:
+    """``run_mining`` is the orchestrator and must guard all Path inputs + jsonl_dir."""
+
+    def test_run_mining_none_history_dir(self, empty_dir):
+        with pytest.raises(ValueError, match="history_dir"):
+            mls.run_mining(None, empty_dir, empty_dir / "kb.json")
+
+    def test_run_mining_none_traces_dir(self, empty_dir):
+        with pytest.raises(ValueError, match="traces_dir"):
+            mls.run_mining(empty_dir, None, empty_dir / "kb.json")
+
+    def test_run_mining_none_kb_path(self, empty_dir):
+        with pytest.raises(ValueError, match="kb_path"):
+            mls.run_mining(empty_dir, empty_dir, None)
+
+    def test_run_mining_jsonl_dir_must_be_path_or_none(self, empty_dir):
+        # jsonl_dir is Optional[Path]; explicit non-Path non-None is rejected
+        with pytest.raises(ValueError, match="jsonl_dir"):
+            mls.run_mining(
+                empty_dir, empty_dir, empty_dir / "kb.json", jsonl_dir="not_a_path"
+            )
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Happy-path preservation — guards must not change valid-input behavior
+# ──────────────────────────────────────────────────────────────────────────
+
+class TestHappyPath:
+    """Guards are pure defense-in-depth — valid inputs keep their behavior."""
+
+    def test_load_json_missing_returns_default(self, empty_dir):
+        assert mls.load_json(empty_dir / "does_not_exist.json", default={"k": 1}) == {"k": 1}
+
+    def test_load_json_missing_no_default(self):
+        assert mls.load_json(Path(r"C:\does\not\exist\xyz_abc.json")) is None
+
+    def test_mine_attempt_history_empty_dir(self, empty_dir):
+        succ, fail = mls.mine_attempt_history(empty_dir)
+        assert succ == []
+        assert fail == []
+
+    def test_mine_trace_conversations_empty_dir(self, empty_dir):
+        cookbook, failed, api = mls.mine_trace_conversations(empty_dir)
+        assert cookbook == []
+        assert failed == []
+        assert api == []
+
+    def test_dedup_cookbook_non_overlapping(self):
+        existing = [{"name": "a", "tactic": "omega"}]
+        new = [{"name": "b", "tactic": "linarith"}]
+        merged = mls.dedup_cookbook(existing, new)
+        assert len(merged) == 2
+
+    def test_dedup_cookbook_overlapping_keeps_existing(self):
+        existing = [{"name": "a", "tactic": "omega"}]
+        new = [{"name": "a", "tactic": "omega"}, {"name": "b", "tactic": "linarith"}]
+        merged = mls.dedup_cookbook(existing, new)
+        # The duplicate (same name + tactic signature) is dropped
+        assert len(merged) == 2
+        names = {e["name"] for e in merged}
+        assert names == {"a", "b"}
+
+    def test_dedup_failures_non_overlapping(self):
+        existing = [{"what_failed": "tactic a"}]
+        new = [{"what_failed": "tactic b"}]
+        merged = mls.dedup_failures(existing, new)
+        assert len(merged) == 2
+
+    def test_save_json_roundtrip(self, tmp_path):
+        # save_json must still work on a valid Path (the guard is non-blocking
+        # for valid input)
+        out = tmp_path / "out.json"
+        mls.save_json(out, {"a": [1, 2, 3]})
+        assert mls.load_json(out) == {"a": [1, 2, 3]}
+
+    def test_run_mining_dry_run_on_empty(self, tmp_path):
+        # End-to-end on an empty workspace — should not crash
+        kb = tmp_path / "kb.json"
+        stats = mls.run_mining(
+            history_dir=tmp_path,
+            traces_dir=tmp_path,
+            kb_path=kb,
+            jsonl_dir=None,
+            dry_run=True,
+        )
+        assert stats["history_files"] == 0
+        assert stats["trace_files"] == 0
+        assert stats["jsonl_files"] == 0
+        assert not kb.exists()  # dry_run must not write


### PR DESCRIPTION
## Summary

Convert opaque `AttributeError` / `TypeError` on `None` input into clear `ValueError` naming the offending argument, for the 7 public entry points of `agent_tests/prover/mine_lean_sessions.py`.

Pattern mirrors the success of:
- #7616 (lean_utils)
- #7637 (knowledge)
- #7638 (attempt_history)

## Scope (atomique)

| File | Change |
|---|---|
| `prover/mine_lean_sessions.py` | +50 lines: `_require_path` / `_require_list` helpers + 7 guards |
| `tests/test_mine_lean_sessions.py` | +224 lines: 31 new tests (guards + happy-path) |

**Total: +274/-0, 2 files, 1 domain.** Well under the G.4 composite thresholds (>3000 lines, >15 files, >4 features).

## Guards added

Path args (raise `ValueError` on `None` / non-Path):
- `load_json(path)`
- `save_json(path, data)`
- `mine_attempt_history(history_dir)`
- `mine_trace_conversations(traces_dir)`
- `run_mining(history_dir, traces_dir, kb_path, jsonl_dir=None)` — explicit `jsonl_dir` type check (Optional[Path])

List args:
- `dedup_cookbook(existing, new_entries)`
- `dedup_failures(existing, new_entries)`
- `_extract_successful_patterns(successes, failures)` (helper, exposed for tests)

## Firsthand verification (G.1)

Before the patch, probe `probe_mine.py` confirmed 11/13 crashes:
- `load_json(None)` → `AttributeError: 'NoneType' object has no attribute 'exists'`
- `save_json(None, {})` → `AttributeError: 'NoneType' object has no attribute 'write_text'`
- `mine_attempt_history(None)` → `AttributeError: 'NoneType' object has no attribute 'glob'`
- `dedup_cookbook(None, [])` → `TypeError: 'NoneType' is not iterable'`

After the patch, `probe_mine_v2.py` confirmed 14/14 guards work:
`OK load_json(None): ValueError(path is None (expected a pathlib.Path))`
`OK dedup_cookbook(None, []): ValueError(existing is None (expected an iterable))`
`OK run_mining(jsonl='bad'): ValueError(jsonl_dir must be a pathlib.Path or None, got str)`

Happy-path preserved end-to-end.

## Tests

- **31 new** tests in `test_mine_lean_sessions.py` (file-path load via importlib, mirroring `test_lean_utils.py` / `test_attempt_history.py`)
- **Full suite 435/435** (baseline 404 + 31 new, 0 regression)
- **G.9 non-vacuous proof**: stash-then-test confirmed **22/31 tests FAIL** against the unpatched module with the exact opaque errors we're converting

```
$ python -m pytest tests/test_mine_lean_sessions.py -q
...............................                                         [100%]
============================= 31 passed in 0.07s ==============================
```

```
$ python -m pytest tests/ -q
============================= 435 passed in 2.58s ==============================
```

## See

- See #7477 — epic stays open (4th module of the garniture tranche)
- See #1453 — prover co-evolution epic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>