### PR TITLE
docs(gametheory,#4959): resync exploitability SVG inline section (Prong-A #6855)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/README.md
@@ -240,7 +240,7 @@ flowchart TD
 | SC-04 | [SocialChoice/04-Computational-Aggregation-SAT-Z3](SocialChoice/04-Computational-Aggregation-SAT-Z3.ipynb) | Python | Arrow encodé en SAT + Z3, UNSAT, relaxation | 60 min |
 | SC-04 (C#) | [SocialChoice/04-Computational-Aggregation-SAT-Z3-Csharp](SocialChoice/04-Computational-Aggregation-SAT-Z3-Csharp.ipynb) | .NET (C#) | Twin C# du SC-04 : **solveur SAT DPLL from-scratch** (BCL .NET 9, 0 NuGet), Arrow encodé en CNF → preuve UNSAT (See #4956) | 60 min |
 | 17 | [GameTheory-17-MultiAgent-RL](GameTheory-17-MultiAgent-RL.ipynb) | Python | NFSP, PSRO, AlphaZero intro | 55 min |
-| 17 (C#) | [GameTheory-17-MultiAgent-RL-Csharp](GameTheory-17-MultiAgent-RL-Csharp.ipynb) | .NET (C#) | Twin C# du 17 : **Self-Play naif (cycle R-P-S)**, **Fictitious Play** (BR vs frequence empirique, convergence Robinson 1951), **exploitabilite**, **NFSP table-based** (Q-values + memoire, caveat convergence G.1), **PSRO** (population + meta-Nash) from-scratch, BCL .NET 9 (See #4956) | 50 min |
+| 17 (C#) | [GameTheory-17-MultiAgent-RL-Csharp](GameTheory-17-MultiAgent-RL-Csharp.ipynb) | .NET (C#) | Twin C# du 17 : **Self-Play naif (cycle R-P-S)**, **Fictitious Play** (BR vs frequence empirique, convergence Robinson 1951), **exploitabilite**, **NFSP table-based** (Q-values + memoire, caveat convergence G.1), **PSRO** (population + meta-Nash) from-scratch, BCL .NET 9, **courbes d'exploitabilite SVG inline** (Self-Play naif oscille, FP -> 0 Robinson 1951, NFSP chute puis plafonne) via `SvgChartHelper.Overlay` zero-CDN [#6855] (See #4956) | 50 min |
 
 **Durée totale** : ~26h45 (avec side tracks b/c et sous-série SocialChoice complète)
 


### PR DESCRIPTION
# docs(gametheory,#4959): resync exploitability SVG inline section (Prong-A #6855)

## Context

The GameTheory hub README (`MyIA.AI.Notebooks/GameTheory/README.md`) documented `GameTheory-17-MultiAgent-RL-Csharp` row as "Twin C# du 17 : **Self-Play naif (cycle R-P-S)**, **Fictitious Play** (BR vs frequence empirique, convergence Robinson 1951), **exploitabilite**, **NFSP table-based** (Q-values + memoire, caveat convergence G.1), **PSRO** (population + meta-Nash) from-scratch, BCL .NET 9 (See #4956)" — but **never acknowledged the Prong-A SVG inline exploitability curves** that [#6855](https://github.com/jsboige/CoursIA/pull/6855) `feat(gametheory,#3801): GameTheory-17 exploitability ASCII -> Plotly (Prong-A)` (PR MERGED 2026-07-16, author jsboigeEpita) just executed first-hand on the notebook (+40/-114 on 1 file: `GameTheory-17-MultiAgent-RL-Csharp.ipynb`).

- **[#6855](https://github.com/jsboige/CoursIA/pull/6855)** introduced cell[18] (code, `exec_count=8`, output = SVG inline 8721 chars via `SvgChartHelper.Overlay(...)`) which produces a 3-series exploitability line chart : Self-Play naïf (`#C44E52`), Fictitious Play (`#4C72B0`), NFSP tabulaire (`#55A868`) sur l'axe X "iteration" (0..290 pas de 10). **Résultat first-hand discriminant** : Self-Play naïf oscille (cycle R-P-S), Fictitious Play décroît vers 0 (convergence Robinson 1951), NFSP chute puis plafonne (tabular non-stationnaire). Verdict Prong-A : **SOTA-OK zero-CDN** (renders natively on GitHub/nbviewer/offline sans internet, contrairement à Plotly qui exigeait un CDN externe). Helpers canoniques : `SvgChartHelper.cs` (#6942 MERGED) + Overlay multi-series (#6958 MERGED). Notebook EXEC_PROVED (24 cells, cell 18 exec_count=8 EXEC_PROVED, .NET Interactive 1.0.707101).

EPIC [#3801](https://github.com/jsboige/CoursIA/issues/3801) **Prong-A** (« vrai outil SOTA, jamais workaround dégradé ») demandait que le notebook de visualisation produise une vraie sortie graphique, pas une décharge Console.WriteLine textuelle. #6855 restore ça pour GameTheory-17-Csharp : la cellule commit avant #6855 dumpait un dump texte de 3 méthodes — la complexité visuelle des courbes d'exploitabilité (Self-Play naïf oscille ≠ FP décroît ≠ NFSP chute/plafonne) n'était pas visible sans un vrai chart.

This PR brings the hub README in line with the merged state, mirroring the c.719 Sudoku Optimize documentation PR (#7626), the c.720 Probas EP-vs-VMP documentation PR (#7628), the c.721 Planners PDDL optimization documentation PR (#7630), the c.722 GameTheory Moran process documentation PR (#7632), and the c.723 Search deceptive trap documentation PR (#7633). **7ᵉ hub #4959 livré** in this session window.

## Changes (markdown-only, atomic)

### 1. `GameTheory/README.md` row 17 (.NET C# twin) enriched

Original L243 :
> Twin C# du 17 : **Self-Play naif (cycle R-P-S)**, **Fictitious Play** (BR vs frequence empirique, convergence Robinson 1951), **exploitabilite**, **NFSP table-based** (Q-values + memoire, caveat convergence G.1), **PSRO** (population + meta-Nash) from-scratch, BCL .NET 9 (See #4956)

Enriched to : « + **courbes d'exploitabilite SVG inline** (Self-Play naif oscille, FP -> 0 Robinson 1951, NFSP chute puis plafonne) via `SvgChartHelper.Overlay` zero-CDN [#6855] ».

## Diff stats

```text
MyIA.AI.Notebooks/GameTheory/README.md | 2 +-
1 file changed, 1 insertion(+), 1 deletion(-)
```

Single edit = single-line row replacement (in-place enrichment of the existing table row, not new rows added). Below the 50-line single-file docs PR threshold ([pr-review-discipline.md §E](../../.claude/rules/pr-review-discipline.md)) and the composite >15f/>4 features threshold (§A). **See #4959** (partial contribution to the epic; hub resync doesn't close the parent tracker). **See #3801** (Prong-A parent tracker).

## Catalog hygiene (R1 HARD rule)

- `COURSE_CATALOG.generated.json` and `COURSE_CATALOG.generated.md` are **byte-identique à `origin/main`** (verified via `diff <(git show origin/main:COURSE_CATALOG.generated.json) COURSE_CATALOG.generated.json` → 0 lines ; idem `.md`). No catalog regeneration on this branch.
- No `<!-- CATALOG-STATUS:START -->…:END -->` block in `GameTheory/README.md` (this hub doesn't carry one — the `pedagogical_count` is preserved by the catalog drift CI workflow separately).
- Base branch = `origin/main` (rebase-fresh at HEAD `9035e37e6`, no stale-base warning).

## Validation

- Markdown rendered cleanly: row in-place enrichment, no new rows added, table structure preserved.
- All embedded GitHub issue/PR links point to real issues/PRs verified MERGED at the moment of writing (`gh pr view 6855 --json state`).
- Result numbers cross-checked against cell-18 actual SVG output (`GameTheory-17-MultiAgent-RL-Csharp.ipynb`):
  ```
  === cell[18] SVG output (first 300 chars) ===
  <svg xmlns='http://www.w3.org/2000/svg' width='820' height='480' viewBox='0 0 820 480' font-family='sans-serif' font-size='12'>
  <rect width='820' height='480' fill='white'/>
  <text x='410' y='20' text-anchor='middle' font-size='14' font-weight='bold' fill='#333333'>Exploitabilite (RPS) - convergence vs cycles</text>
  ...
  SVG length = 8721 chars (3 series : Self-Play naif, Fictitious Play, NFSP tabulaire)
  ```
- Discriminant visible : Self-Play naïf oscille, Fictitious Play décroît vers 0 (Robinson 1951), NFSP chute puis plafonne — exactly the 3 dynamics from cell[13] source comment.
- Diff inspected: no incidental edits to other rows (13/14/15/15b/15c/16 .NET twins all preserve their structure except the 1 targeted row enrichment).
- No code/notebook touched → notebook validation pre-hooks (H.3) trivially pass.

## Co-author

Co-Authored-By: Claude-Code <noreply@anthropic.com>

## Refs

- See [#4959](https://github.com/jsboige/CoursIA/issues/4959) (hub-resync tracker, partial contribution).
- [#6855](https://github.com/jsboige/CoursIA/pull/6855) `feat(gametheory,#3801): GameTheory-17 exploitability ASCII -> Plotly (Prong-A)` — the PR being documented.
- [EPIC #3801](https://github.com/jsboige/CoursIA/issues/3801) — Prong-A (« vrai outil SOTA, jamais workaround dégradé »).
- Sibling c.719 hub PR [#7626](https://github.com/jsboige/CoursIA/pull/7626) `docs(sudoku,#4959): resync Optimize section (CP-SAT #7588 + Z3 SMT #7589 + C# twin #7622)`.
- Sibling c.720 hub PR [#7628](https://github.com/jsboige/CoursIA/pull/7628) `docs(probas,#4959): resync EP-vs-VMP comparison section (Prong-B #7590)`.
- Sibling c.721 hub PR [#7630](https://github.com/jsboige/CoursIA/pull/7630) `docs(planners,#4959): resync PDDL optimization section (Prong-B #7592)`.
- Sibling c.722 hub PR [#7632](https://github.com/jsboige/CoursIA/pull/7632) `docs(gametheory,#4959): resync Moran process section (Prong-B #7594)`.
- Sibling c.723 hub PR [#7633](https://github.com/jsboige/CoursIA/pull/7633) `docs(search,#4959): resync deceptive trap section (Prong-B #6849)`.
- [#6942](https://github.com/jsboige/CoursIA/pull/6942) `SvgChartHelper.cs` canonical helper MERGED.
- [#6958](https://github.com/jsboige/CoursIA/pull/6958) `Overlay` multi-series helper MERGED.
- Robinson, *An Iterative Method of Solving a Game* (1951) — theoretical anchor for Fictitious Play convergence.
- See [catalog-pr-hygiene.md](../../.claude/rules/catalog-pr-hygiene.md) for the byte-identique-catalog contract respected here.
