### PR TITLE
feat(prover,#7477): degenerate-input guards for instructions.py entry points

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/instructions.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/instructions.py
@@ -233,6 +233,26 @@ REGLES:
 - NE JAMAIS repondre par un seul mot comme LEAVERN, ABORT, SKIP, GIVE_UP ou tout autre
   signal de controle. Ta reponse DOIT contenir des tactiques Lean concretes."""
 
+def _require_str(name: str, value, *, allow_empty: bool = False) -> str:
+    """Boundary guard: reject None / non-str degenerate inputs (#7596-pattern, G.9).
+
+    Converts the OPAQUE TypeErrors that ``load_reference_docs(project=None)``
+    (``os.path.join``: "argument must be str, not NoneType") and
+    ``augment_instructions(base=None)`` (``"\n\n---\n\n".join([..., None])``:
+    "expected str instance, NoneType found") previously raised into clear
+    ValueErrors naming the offending argument, so a workflow that forwards an
+    agent-generated None project/base fails fast with a diagnosable message.
+    Empty strings are rejected by default (invalid for a project identifier);
+    pass ``allow_empty=True`` for ``base`` where ``''`` is a legitimate input.
+    Mirrors ``lean_utils._require_str`` (entry #001 of the #7596 sequence).
+    """
+    if not isinstance(value, str):
+        raise ValueError(f"{name}: expected str, got {type(value).__name__}")
+    if not allow_empty and not value:
+        raise ValueError(f"{name}: expected non-empty str, got empty string")
+    return value
+
+
 def load_reference_docs(project: str = "stable_marriage", max_chars: int = 6000) -> str:
     """Load a compact summary of the committed reference docs for `project`.
 
@@ -246,6 +266,8 @@ def load_reference_docs(project: str = "stable_marriage", max_chars: int = 6000)
     keep the total under `max_chars`. Returns "" if the directory is absent.
     """
     import os
+
+    project = _require_str("project", project)
 
     ref_dir = os.path.join(
         os.path.dirname(__file__), "session_state", "reference_docs", project
@@ -404,6 +426,7 @@ def augment_instructions(
     `project` (issue #1081 Part 2). If `target_file` is given, inject proved lemmas
     from the target file so the Director can reference them.
     """
+    base = _require_str("base", base, allow_empty=True)
     from .knowledge import ProofKnowledgeBase
     kb = ProofKnowledgeBase()
     context = kb.generate_prover_context(goal=goal, max_chars=max_chars)

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_instructions.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_instructions.py
@@ -1,0 +1,114 @@
+"""Unit tests for prover ``instructions.py`` degenerate-input guards + happy-path.
+
+Loads ``instructions.py`` DIRECTLY by file path, bypassing ``prover/__init__.py``
+(which cascades the ``agent_framework`` LLM stack, absent on a bare CPU runner).
+The module's top level is stdlib-only (agent-instruction string constants + three
+functions); the only imports reachable at module load are ``import os`` (deferred
+inside ``load_reference_docs`` / ``load_proved_lemmas``) and the deferred
+``from .knowledge import ProofKnowledgeBase`` inside ``augment_instructions`` —
+so the module loads cleanly anywhere. Mirrors ``tests/test_lean_utils.py``'s
+file-path load.
+
+These tests pin two guards (#7596-pattern, G.9):
+  1. ``load_reference_docs(project)`` rejects ``None`` / non-str / empty with a
+     clear ``ValueError`` naming ``project`` — converting the OPAQUE
+     ``TypeError`` ("join() argument must be str ... not NoneType") that
+     ``os.path.join(__file__, ..., None)`` previously raised. The sole caller
+     (``augment_instructions``) forwards ``project`` unchecked when
+     ``include_references=True``, so the guard protects a real path.
+  2. ``augment_instructions(base, ...)`` rejects ``None`` / non-str ``base``
+     with a clear ``ValueError`` naming ``base`` — converting the OPAQUE
+     ``TypeError`` ("sequence item N: expected str instance, NoneType found")
+     that ``"\n\n---\n\n".join([..., None])`` previously raised. The guard runs
+     BEFORE the deferred ``from .knowledge import`` so it is reachable from a
+     direct file-path load. ``base=""`` is allowed (legitimate degenerate input).
+
+``load_proved_lemmas`` is intentionally NOT guarded here: its sole caller
+(``augment_instructions``) pre-guards with ``if target_file else ""``, so it is
+never reached with ``None`` / empty, and it is lenient by design (returns ``""``
+for absent / invalid files rather than raising) — guarding it would convert a
+graceful ``""`` return into a hard error with no opaque crash to fix.
+
+Run from ``agent_tests/``:
+    python -m pytest tests/test_instructions.py -q
+
+See #1453 (prover co-evolution epic), See #7477 (prover harness forensic),
+See #7596 (degenerate-input guard sequence).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent  # agent_tests/
+
+_spec = importlib.util.spec_from_file_location(
+    "prover_instructions_under_test",
+    ROOT / "prover" / "instructions.py",
+)
+instr = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(instr)
+
+
+# --- load_reference_docs: project guard (#7596-pattern, G.9) ---
+
+@pytest.mark.parametrize(
+    "bad",
+    [None, 123, 4.5, [], {}, object()],
+    ids=["none", "int", "float", "list", "dict", "object"],
+)
+def test_load_reference_docs_rejects_non_str_project(bad):
+    """None / non-str ``project`` -> ValueError naming ``project`` (was TypeError)."""
+    with pytest.raises(ValueError, match="project"):
+        instr.load_reference_docs(project=bad)
+
+
+def test_load_reference_docs_rejects_empty_project():
+    """Empty ``project`` is invalid (silent garbage) -> ValueError naming ``project``."""
+    with pytest.raises(ValueError, match="project"):
+        instr.load_reference_docs(project="")
+
+
+def test_load_reference_docs_valid_project_returns_str():
+    """A valid ``project`` str does not raise; returns '' when the dir is absent."""
+    out = instr.load_reference_docs(project="stable_marriage")
+    assert isinstance(out, str)
+
+
+# --- augment_instructions: base guard (#7596-pattern, G.9) ---
+
+@pytest.mark.parametrize(
+    "bad",
+    [None, 123, [], object()],
+    ids=["none", "int", "list", "object"],
+)
+def test_augment_instructions_rejects_non_str_base(bad):
+    """None / non-str ``base`` -> ValueError naming ``base`` (was TypeError on join).
+
+    The guard runs before the deferred ``from .knowledge import``, so it is
+    reachable from this direct file-path load (no prover package context needed).
+    """
+    with pytest.raises(ValueError, match="base"):
+        instr.augment_instructions(base=bad)
+
+
+def test_augment_instructions_empty_base_passes_guard():
+    """``base=""`` is allowed (``allow_empty=True``); it must not raise at the guard.
+
+    The full body cannot be exercised without the prover package context (the
+    deferred ``from .knowledge import`` raises ``ImportError`` under isolated
+    load), so we only assert the guard itself does not reject ``""`` — any
+    downstream ``ImportError`` is expected and is not a guard failure.
+    """
+    try:
+        instr.augment_instructions(base="")
+    except ValueError as exc:
+        pytest.fail(f"empty base should pass the guard, got ValueError: {exc}")
+    except Exception:
+        # ImportError from the deferred `from .knowledge import` is expected
+        # under direct file-path load and is NOT a guard failure.
+        pass


### PR DESCRIPTION
## Summary

Tranche 5 of the **#7596 degenerate-input guard sequence** (lean_utils entry #001 already merged on `origin/main`). Module `agent_tests/prover/instructions.py` — 2 public entry points guarded via a local `_require_str` helper (verbatim-mirrors `lean_utils._require_str`), converting opaque `TypeError` crashes on `None`/non-str inputs into clear `ValueError`s naming the offending argument.

Distinct module vs the 4 prior tranches (lean_utils #7596 / knowledge #7637 / attempt_history #7638 / mine_lean_sessions #7639+#7641) → R6 variety OK.

## What / Why

| Entry point | Pre-fix opaque crash | Post-fix |
|---|---|---|
| `load_reference_docs(project=None/123/...)` | `TypeError: join() argument must be str ... not NoneType` (from `os.path.join(__file__, ..., project)`) | `ValueError: project: expected str, got NoneType` |
| `augment_instructions(base=None/123/...)` | `TypeError: sequence item N: expected str instance, NoneType found` (from `"\n\n---\n\n".join([..., base])`) | `ValueError: base: expected str, got NoneType` |

**Real path protected:** the sole caller of `load_reference_docs` is `augment_instructions` (`instructions.py:411`), which forwards `project` *unchecked* when `include_references=True` — so an agent-generated `None` project previously crashed the DirectorAgent's instruction-augmentation step with an opaque stack trace. `augment_instructions(base=...)` is called by `agents.py` (5 sites) and `provers.py` (1 site), always with a constant instruction string today; the guard is defense-in-depth so a future caller forwarding agent-generated `None` fails fast and diagnosably.

## `load_proved_lemmas` intentionally NOT guarded

Its sole caller (`augment_instructions:412`) pre-guards with `if target_file else ""`, so it is **never reached** with `None`/empty. It is also lenient by design (returns `""` for absent/invalid files). Guarding it would convert a graceful `""` return into a hard error with no opaque crash to fix — a behavior change with no benefit. Documented here so a future tranche does not re-flag it. Verified firsthand: `load_proved_lemmas(None/123/""/"/nonexistent.lean")` all return `""`, no crash (probe below).

## G.9 non-vacuous proof (probe before/after, bare CPU runner)

```
--- load_reference_docs ---
  project=None:  TypeError -> post-fix: ValueError: project: expected str, got NoneType
  project=123:   TypeError -> post-fix: ValueError: project: expected str, got int
  project='':   (returned '') -> post-fix: ValueError: project: expected non-empty str, got empty string
--- augment_instructions (guard precedes deferred KB import) ---
  base=None:    TypeError (in-package) -> post-fix: ValueError: base: expected str, got NoneType
  base=123:     TypeError (in-package) -> post-fix: ValueError: base: expected str, got int
--- load_proved_lemmas (unchanged, lenient) ---
  target_file=None/123/'/nonexistent.lean': returned '' (pre and post identical)
```

## Tests

`tests/test_instructions.py` (new, 13 tests): importlib **direct-file-path load** of `prover/instructions.py`, bypassing `prover/__init__.py` (which cascades the `agent_framework` LLM stack, absent on a bare CPU runner) — mirrors `tests/test_lean_utils.py`. Stdlib-only.

```
$ python -m pytest tests/test_instructions.py tests/test_lean_utils.py -q
... 51 passed in 0.44s   (13 new + 38 existing test_lean_utils, 0 regression)
```

**Full `pytest tests/`:** 9 collection errors = `ModuleNotFoundError: No module named 'agent_framework'` (LLM stack absent on this bare CPU runner — pre-existing env constraint documented in `test_lean_utils.py`, identical on `origin/main` without this change; the diff does not touch `provers.py` / `__init__.py` / the agent_framework import chain). The collectable (stdlib-only) tests all pass.

## Scope hygiene

- 2 files, +137/-0, atomique. No notebook / README / catalog / `.lean` touched.
- `See #7477` (prover harness forensic — partial, epic stays open), `See #1453` (prover co-evolution epic), `See #7596` (guard sequence).
- Catalog byte-identical to `origin/main` (no generated marker touched).

## See

- #7477 — prover harness forensic (SOTA baseline 2026-07-19): this PR hardens `instructions.py`, continuing the degenerate-input boundary-guard recommendation.
- #1453 — prover harness co-evolution epic (ai-01 ⇄ po-2026).
- #7596 — degenerate-input guard sequence (lean_utils entry #001 merged).

— po-2023 (cycle c.737)
