### PR TITLE
feat(grothendieck,#2159): covariant Yoneda full-faithfulness (coyoneda_full/faithful)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/YonedaLemma.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/YonedaLemma.lean
@@ -176,6 +176,34 @@ def coyonedaPairingIsoEvaluation (C : Type*) [Category C] :
   coyonedaLemma C
 
 /-!
+### Plénitude et fidélité du plongement covariant
+
+Tout comme son dual contravariant, le plongement covariant `coyoneda` est
+pleinement fidèle : c'est le miroir exact du plongement de Yoneda. Cette
+pleine fidélité est centrale pour la théorie des foncteurs coreprésentables
+(la face covariante des représentables), utilisée notamment en théorie des
+faisceaux et en cohomologie.
+-/
+
+/-- Le plongement de Yoneda covariant est plein. Miroir covariant de
+    `yoneda_full` : la pré-composition se relève le long de `coyoneda`. -/
+theorem coyoneda_full (C : Type*) [Category C] :
+    (coyoneda (C := C)).Full :=
+  Coyoneda.coyoneda_full
+
+/-- Le plongement de Yoneda covariant est fidèle. Miroir covariant de
+    `yoneda_faithful`. -/
+theorem coyoneda_faithful (C : Type*) [Category C] :
+    (coyoneda (C := C)).Faithful :=
+  Coyoneda.coyoneda_faithful
+
+/-- La pleine fidélité de `coyoneda` (le plongement covariant
+    `Cᵒᵖ ⥤ C ⥤ Type v₁` est pleinement fidèle) découle de `Full` et `Faithful`
+    ci-dessus et du constructeur canonique `Functor.FullyFaithful.ofFullyFaithful`. -/
+example {C : Type*} [Category C] : (coyoneda (C := C)).FullyFaithful :=
+  Coyoneda.fullyFaithful
+
+/-!
 ## La fonctorialité retrouve l'ensemble de morphismes
 
 Le plongement de Yoneda relève l'ensemble de morphismes dans la catégorie des

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/YonedaLemma_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/YonedaLemma_en.lean
@@ -159,6 +159,34 @@ def coyonedaPairingIsoEvaluation (C : Type*) [Category C] :
   coyonedaLemma C
 
 /-!
+### Full faithfulness of the covariant embedding
+
+Just like its contravariant dual, the covariant embedding `coyoneda` is fully
+faithful: it is the exact mirror of the Yoneda embedding. This full
+faithfulness is central to the theory of corepresentable functors (the
+covariant face of representables), used notably in sheaf theory and
+cohomology.
+-/
+
+/-- The covariant Yoneda embedding is full. Covariant mirror of
+    `yoneda_full`: pre-composition lifts along `coyoneda`. -/
+theorem coyoneda_full (C : Type*) [Category C] :
+    (coyoneda (C := C)).Full :=
+  Coyoneda.coyoneda_full
+
+/-- The covariant Yoneda embedding is faithful. Covariant mirror of
+    `yoneda_faithful`. -/
+theorem coyoneda_faithful (C : Type*) [Category C] :
+    (coyoneda (C := C)).Faithful :=
+  Coyoneda.coyoneda_faithful
+
+/-- Full faithfulness of `coyoneda` (the covariant embedding
+    `Cᵒᵖ ⥤ C ⥤ Type v₁` is fully faithful) follows from `Full` and `Faithful`
+    above and the canonical `Functor.FullyFaithful.ofFullyFaithful` constructor. -/
+example {C : Type*} [Category C] : (coyoneda (C := C)).FullyFaithful :=
+  Coyoneda.fullyFaithful
+
+/-!
 ## Functoriality recovers the hom-set
 
 The Yoneda embedding lifts the hom-set into the category of presheaves.


### PR DESCRIPTION
## Summary

Extend `grothendieck_lean/Grothendieck/YonedaLemma.lean` (+ EN sibling) with the **covariant Yoneda full-faithfulness** — the dual of the existing contravariant `yoneda_full`/`yoneda_faithful`. Pure additive Lean substance, Epic #2159 (Grothendieck formalisation beyond Phase 1), lane po-2026 (Lean lead).

## Why

`YonedaLemma.lean` stated the contravariant Yoneda embedding is fully faithful (`yoneda_full`, `yoneda_faithful`, `Yoneda.fullyFaithful`) but **omitted the covariant dual** (`coyoneda`). The covariant embedding `coyoneda : Cᵒᵖ ⥤ (C ⥤ Type v₁)` is the exact mirror and is equally foundational — it underpins the theory of corepresentable functors (used in sheaf theory and cohomology, the heart of the Grothendieck program this lake teaches). Mathlib 4 already proves it (`Coyoneda.coyoneda_full`, `Coyoneda.coyoneda_faithful`, `Coyoneda.fullyFaithful`); the lake just didn't surface it. G.9 gap confirmed firsthand: `grep coyoneda_full` across the 29-module lake = 0 hits; `grep Coyoneda.coyoneda_full` in Mathlib = present (L215 of `CategoryTheory/Yoneda.lean`).

## Change

2 files, +56/-0 (28 lines each, FR + EN sibling pair):

- **`Grothendieck/YonedaLemma.lean`** (FR): new `### Plénitude et fidélité du plongement covariant` subsection after the existing `coyonedaPairingIsoEvaluation`, adding:
  - `theorem coyoneda_full (C) : (coyoneda (C := C)).Full := Coyoneda.coyoneda_full`
  - `theorem coyoneda_faithful (C) : (coyoneda (C := C)).Faithful := Coyoneda.coyoneda_faithful`
  - `example : (coyoneda (C := C)).FullyFaithful := Coyoneda.fullyFaithful`
- **`Grothendieck/YonedaLemma_en.lean`** (EN sibling): identical theorem statements (byte-identity on proofs, i18n #4980 convention), English docstrings + comments.

Style mirrors the existing `yoneda_full`/`yoneda_faithful` block exactly (named theorems wrapping the Mathlib instances). 0 `sorry` introduced.

## Validation (lean-merge-discipline §1 + §B)

| Check | Result |
|-------|--------|
| `grep -c sorry` before/after (both files) | **0 → 0** (pure addition, no sorry) |
| `lake build Grothendieck.YonedaLemma Grothendieck.YonedaLemma_en` LOCAL | **SUCCESS** (611 jobs, exit 0) — `coyoneda_full`/`coyoneda_faithful`/`Coyoneda.fullyFaithful` type-check against Mathlib |
| Proof integrity | No new axioms — direct Mathlib instance references (`Coyoneda.coyoneda_full` etc.) |
| Isolation | No downstream module imports `YonedaLemma` beyond the root aggregator → additive change can't break other targets |
| i18n #4980 byte-identity | FR/EN theorem statements identical, only docstrings/comments differ |
| Catalog byte-identical to main | `COURSE_CATALOG.generated.{json,md}` untouched |
| CRLF/LF | consistent with lake convention (whole `grothendieck_lean` is CRLF on origin/main; this PR matches, no line-ending churn — diff is clean +28/-0) |
| Diff scope | 2 files, +56/-0 |

## Build note (reproducibility)

`grothendieck_lean` had no local `.lake` build on this machine (first-build Mathlib = 30-60 min, multi-window). The lake was built by junctioning the **complete pre-compiled Mathlib** from `conway_lean` (same `v4.31.0-rc1` toolchain, identical mathlib rev `d568c8c09630de09` — verified firsthand). Full `lake build Grothendieck` baseline: **2748 jobs SUCCESS** (green). ai-01 re-verifies `lake build` local before merge per lean-merge-discipline §1.

## Scope (R3 atomicity)

2 files, 1 subject — covariant Yoneda full-faithfulness (FR + EN sibling). See #2159 (Grothendieck Lean epic, open). See #1646 (broader Grothendieck epic). **Not `Closes`** — contribution to an open epic (the lake already has 29 modules / 124 named decls / 0 sorry; this adds 2 theorems + 1 example to one module).

Co-Authored-By: Claude <noreply@anthropic.com>
