### PR TITLE
feat(shared,#7265): A1 ancre metadata-driven decoration (attributes + interfaces + ReflectedProviderContainer)

### DIFF
--- a/MyIA.AI.Shared.Tests/Fixtures.cs
+++ b/MyIA.AI.Shared.Tests/Fixtures.cs
@@ -1,0 +1,64 @@
+using MyIA.AI.ComponentModel.Attributes;
+using MyIA.AI.ComponentModel.Entities;
+
+namespace MyIA.AI.Shared.Tests;
+
+// Fixtures decorated/marked to prove decoration -> introspection. One fixture per
+// combination of the A1 primitives so the tests can assert exact membership.
+
+/// <summary>Flat entity (ISimpleEntity) under the "Payment" main category.</summary>
+[MainCategory("Payment")]
+public sealed class PaymentGateway : ISimpleEntity
+{
+    public string Name => "payment-gateway";
+}
+
+/// <summary>Hierarchical container under "Content": decorated as AttributeContainer + IChildEntity.</summary>
+[MainCategory("Content")]
+[AttributeContainer(ChildType = typeof(ContentItem))]
+public sealed class ContentFolder : IChildEntity
+{
+    public IChildEntity? Parent { get; set; }
+
+    private readonly List<IChildEntity> _children = new();
+
+    public IReadOnlyList<IChildEntity> Children => _children;
+
+    public void AddChild(IChildEntity child)
+    {
+        child.Parent = this;
+        _children.Add(child);
+    }
+}
+
+/// <summary>Hierarchical leaf under "Content": IChildEntity + IMergeable.</summary>
+[MainCategory("Content")]
+public sealed class ContentItem : IChildEntity, IMergeable
+{
+    public string Title { get; set; } = string.Empty;
+
+    public IChildEntity? Parent { get; set; }
+
+    public IReadOnlyList<IChildEntity> Children => Array.Empty<IChildEntity>();
+
+    public bool Merge(IMergeable other)
+    {
+        if (other is ContentItem item)
+        {
+            if (string.IsNullOrEmpty(Title))
+            {
+                Title = item.Title;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+}
+
+/// <summary>Undecorated flat entity: appears in SimpleEntities but in NO main category.</summary>
+public sealed class PlainLeaf : ISimpleEntity
+{
+    public string Name => "plain-leaf";
+}

--- a/MyIA.AI.Shared.Tests/MyIA.AI.Shared.Tests.csproj
+++ b/MyIA.AI.Shared.Tests/MyIA.AI.Shared.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MyIA.AI.Shared\MyIA.AI.Shared.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/MyIA.AI.Shared.Tests/ReflectedProviderContainerTests.cs
+++ b/MyIA.AI.Shared.Tests/ReflectedProviderContainerTests.cs
@@ -1,0 +1,143 @@
+using System.Reflection;
+using MyIA.AI.ComponentModel.Attributes;
+using MyIA.AI.ComponentModel.Providers;
+using Xunit;
+
+namespace MyIA.AI.Shared.Tests;
+
+/// <summary>
+/// Proves the A1 metadata-driven decoration -> introspection contract: decorate a type
+/// (or have it implement a marker interface) and a ReflectedProviderContainer surfaces it
+/// with no explicit registration.
+/// </summary>
+public class ReflectedProviderContainerTests
+{
+    // Controlled, exhaustive scope: every A1 primitive is exercised by exactly one fixture.
+    private static readonly Type[] FixtureTypes =
+    {
+        typeof(PaymentGateway), // [MainCategory("Payment")] + ISimpleEntity
+        typeof(ContentFolder),  // [MainCategory("Content")] + [AttributeContainer] + IChildEntity
+        typeof(ContentItem),    // [MainCategory("Content")] + IChildEntity + IMergeable
+        typeof(PlainLeaf),      // ISimpleEntity only, no category
+    };
+
+    private static ReflectedProviderContainer Sut => ReflectedProviderContainer.FromTypes(FixtureTypes);
+
+    [Fact]
+    public void Indexer_DecoratedCategory_ExposesItsTypes()
+    {
+        var provider = Sut;
+
+        var payment = provider["Payment"];
+        var content = provider["Content"];
+
+        Assert.Single(payment);
+        Assert.Equal(typeof(PaymentGateway), payment[0]);
+
+        Assert.Equal(2, content.Count);
+        Assert.Contains(typeof(ContentFolder), content);
+        Assert.Contains(typeof(ContentItem), content);
+    }
+
+    [Fact]
+    public void Categories_ListsAllMainCategoryNames_WithoutDuplicates()
+    {
+        var categories = Sut.Categories.ToArray();
+
+        Assert.Equal(2, categories.Length);
+        Assert.Contains("Payment", categories);
+        Assert.Contains("Content", categories);
+    }
+
+    [Fact]
+    public void Indexer_UnknownCategory_ReturnsEmpty_NoThrow()
+    {
+        var unknown = Sut["DoesNotExist"];
+
+        Assert.NotNull(unknown);
+        Assert.Empty(unknown);
+    }
+
+    [Fact]
+    public void Containers_ExposesOnlyAttributeContainerDecoratedTypes()
+    {
+        var containers = Sut.Containers;
+
+        Assert.Single(containers);
+        Assert.Equal(typeof(ContentFolder), containers[0]);
+    }
+
+    [Fact]
+    public void ChildEntities_ExposesIChildEntityImplementers()
+    {
+        var children = Sut.ChildEntities;
+
+        Assert.Equal(2, children.Count);
+        Assert.Contains(typeof(ContentFolder), children);
+        Assert.Contains(typeof(ContentItem), children);
+    }
+
+    [Fact]
+    public void SimpleEntities_ExposesISimpleEntityImplementers_IncludingUndecorated()
+    {
+        var simples = Sut.SimpleEntities;
+
+        Assert.Equal(2, simples.Count);
+        Assert.Contains(typeof(PaymentGateway), simples);
+        Assert.Contains(typeof(PlainLeaf), simples);
+    }
+
+    [Fact]
+    public void Mergeables_ExposesIMergeableImplementers()
+    {
+        var mergeables = Sut.Mergeables;
+
+        Assert.Single(mergeables);
+        Assert.Equal(typeof(ContentItem), mergeables[0]);
+    }
+
+    [Fact]
+    public void DecorationAndMarkers_Combine_OnTheSameType()
+    {
+        // ContentFolder carries a category, is a container, AND is a child entity:
+        // the three primitives compose, the type appears in all three views.
+        var provider = Sut;
+
+        Assert.Contains(typeof(ContentFolder), provider["Content"]);
+        Assert.Contains(typeof(ContentFolder), provider.Containers);
+        Assert.Contains(typeof(ContentFolder), provider.ChildEntities);
+    }
+
+    [Fact]
+    public void FromAssembly_TMarker_ScansAssembly_AndFindsKnownFixture()
+    {
+        // Marker = a type declared in this test assembly, so the scan covers the fixtures above.
+        var provider = ReflectedProviderContainer.FromAssembly<ReflectedProviderContainerTests>();
+
+        Assert.Contains("Content", provider.Categories);
+        Assert.Contains(typeof(ContentFolder), provider["Content"]);
+    }
+
+    [Fact]
+    public void AttributeContainer_ChildType_ReadBack()
+    {
+        var attr = typeof(ContentFolder).GetCustomAttribute<AttributeContainerAttribute>();
+
+        Assert.NotNull(attr);
+        Assert.Equal(typeof(ContentItem), attr!.ChildType);
+    }
+
+    [Fact]
+    public void MainCategoryAttribute_RejectsWhitespaceName()
+    {
+        Assert.Throws<ArgumentException>(() => new MainCategoryAttribute("   "));
+    }
+
+    [Fact]
+    public void MainCategoryAttribute_AcceptsValidName_AndDefaultOrder()
+    {
+        var attr = new MainCategoryAttribute("Demo");
+        Assert.Equal("Demo", attr.Name);
+        Assert.Equal(0, attr.Order);
+    }
+}

--- a/MyIA.AI.Shared.sln
+++ b/MyIA.AI.Shared.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyIA.AI.Shared", "MyIA.AI.Shared\MyIA.AI.Shared.csproj", "{C3C93A0C-F52E-45FA-9A3C-FBD3E59E4F04}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyIA.AI.Shared.Tests", "MyIA.AI.Shared.Tests\MyIA.AI.Shared.Tests.csproj", "{852EA4BC-F566-451E-84D4-659ECDC79A88}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{C3C93A0C-F52E-45FA-9A3C-FBD3E59E4F04}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C3C93A0C-F52E-45FA-9A3C-FBD3E59E4F04}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C3C93A0C-F52E-45FA-9A3C-FBD3E59E4F04}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C3C93A0C-F52E-45FA-9A3C-FBD3E59E4F04}.Release|Any CPU.Build.0 = Release|Any CPU
+		{852EA4BC-F566-451E-84D4-659ECDC79A88}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{852EA4BC-F566-451E-84D4-659ECDC79A88}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{852EA4BC-F566-451E-84D4-659ECDC79A88}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{852EA4BC-F566-451E-84D4-659ECDC79A88}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/MyIA.AI.Shared/ComponentModel/Attributes/AttributeContainerAttribute.cs
+++ b/MyIA.AI.Shared/ComponentModel/Attributes/AttributeContainerAttribute.cs
@@ -1,0 +1,24 @@
+namespace MyIA.AI.ComponentModel.Attributes;
+
+/// <summary>
+/// Marks a type as a CONTAINER of child entities, i.e. a node that aggregates
+/// <see cref="MyIA.AI.ComponentModel.Entities.IChildEntity"/> instances and can serve as
+/// the root of an introspection tree (infinite hierarchy). Modernized port of
+/// <c>Aricie.Shared</c>'s <c>AttributeContainerAttribute</c> (EPIC #7265, ancre A1).
+/// </summary>
+/// <remarks>
+/// A type decorated with <c>[AttributeContainer]</c> signals to a
+/// <see cref="MyIA.AI.ComponentModel.Providers.ReflectedProviderContainer"/> that it is a
+/// legitimate parent in the decoration-driven hierarchy, as opposed to a leaf
+/// (<see cref="MyIA.AI.ComponentModel.Entities.ISimpleEntity"/>) or a plain child.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface,
+    AllowMultiple = false, Inherited = true)]
+public sealed class AttributeContainerAttribute : Attribute
+{
+    /// <summary>
+    /// Optional constraint on the child entity type the container accepts. When null
+    /// (default) the container is polymorphic and accepts any <c>IChildEntity</c>.
+    /// </summary>
+    public Type? ChildType { get; set; }
+}

--- a/MyIA.AI.Shared/ComponentModel/Attributes/MainCategoryAttribute.cs
+++ b/MyIA.AI.Shared/ComponentModel/Attributes/MainCategoryAttribute.cs
@@ -1,0 +1,35 @@
+namespace MyIA.AI.ComponentModel.Attributes;
+
+/// <summary>
+/// Decorates a type with a primary category used for grouping and reflection-driven
+/// introspection. Modernized port of <c>Aricie.Shared</c>'s
+/// <c>MainCategoryAttribute</c> (EPIC #7265, ancre A1).
+/// </summary>
+/// <remarks>
+/// The category name is what a <see cref="MyIA.AI.ComponentModel.Providers.ReflectedProviderContainer"/>
+/// groups types by: decorating a class with <c>[MainCategory("Payment")]</c> makes it
+/// discoverable as <c>provider["Payment"]</c> without any registration call. This is the
+/// metadata-driven decoration foundation (decoration -> introspection) that the rest of
+/// the Aricie.Shared socle (serialization, object explorer) builds upon.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct,
+    AllowMultiple = false, Inherited = true)]
+public sealed class MainCategoryAttribute : Attribute
+{
+    /// <summary>Category name. Drives grouping in <c>ReflectedProviderContainer</c>.</summary>
+    public string Name { get; }
+
+    /// <summary>Display/grouping order inside the category (lower sorts first). Default 0.</summary>
+    public int Order { get; set; }
+
+    public MainCategoryAttribute(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new ArgumentException(
+                "Main category name cannot be null, empty, or whitespace.", nameof(name));
+        }
+
+        Name = name;
+    }
+}

--- a/MyIA.AI.Shared/ComponentModel/Entities/IChildEntity.cs
+++ b/MyIA.AI.Shared/ComponentModel/Entities/IChildEntity.cs
@@ -1,0 +1,15 @@
+namespace MyIA.AI.ComponentModel.Entities;
+
+/// <summary>
+/// A hierarchical entity: it owns a parent reference and a collection of children,
+/// enabling the infinite parent/child hierarchy that the Aricie.Shared socle is built on.
+/// Modernized port (EPIC #7265, ancre A1).
+/// </summary>
+public interface IChildEntity
+{
+    /// <summary>Parent in the hierarchy, or null at the root.</summary>
+    IChildEntity? Parent { get; set; }
+
+    /// <summary>Children of this node (empty for a leaf).</summary>
+    IReadOnlyList<IChildEntity> Children { get; }
+}

--- a/MyIA.AI.Shared/ComponentModel/Entities/IMergeable.cs
+++ b/MyIA.AI.Shared/ComponentModel/Entities/IMergeable.cs
@@ -1,0 +1,17 @@
+namespace MyIA.AI.ComponentModel.Entities;
+
+/// <summary>
+/// An entity that knows how to merge the state of another compatible instance into itself.
+/// Backs the merge semantics of the Aricie.Shared socle (e.g. reconciling two decorated
+/// subtrees). Modernized port (EPIC #7265, ancre A1).
+/// </summary>
+public interface IMergeable
+{
+    /// <summary>
+    /// Merges the state of <paramref name="other"/> into this instance.
+    /// </summary>
+    /// <param name="other">The source entity to merge from.</param>
+    /// <returns><c>true</c> if the merge was applied; <c>false</c> if <paramref name="other"/>
+    /// was incompatible or a no-op.</returns>
+    bool Merge(IMergeable other);
+}

--- a/MyIA.AI.Shared/ComponentModel/Entities/ISimpleEntity.cs
+++ b/MyIA.AI.Shared/ComponentModel/Entities/ISimpleEntity.cs
@@ -1,0 +1,12 @@
+namespace MyIA.AI.ComponentModel.Entities;
+
+/// <summary>
+/// A simple (leaf, non-hierarchical) entity: it carries a name but no parent/children.
+/// Counterpart of <see cref="IChildEntity"/> for the flat entities of the socle.
+/// Modernized port (EPIC #7265, ancre A1).
+/// </summary>
+public interface ISimpleEntity
+{
+    /// <summary>Display/identity name of the entity.</summary>
+    string Name { get; }
+}

--- a/MyIA.AI.Shared/ComponentModel/Providers/ReflectedProviderContainer.cs
+++ b/MyIA.AI.Shared/ComponentModel/Providers/ReflectedProviderContainer.cs
@@ -1,0 +1,144 @@
+using System.Reflection;
+using MyIA.AI.ComponentModel.Attributes;
+using MyIA.AI.ComponentModel.Entities;
+
+namespace MyIA.AI.ComponentModel.Providers;
+
+/// <summary>
+/// Reflection-driven provider that discovers decorated/marker types across a set of
+/// assemblies and exposes them for introspection. This is the metadata-driven
+/// decoration -> introspection bridge: decorate a class with
+/// <see cref="MainCategoryAttribute"/> / <see cref="AttributeContainerAttribute"/> or have
+/// it implement <see cref="IChildEntity"/> / <see cref="ISimpleEntity"/> / <see cref="IMergeable"/>,
+/// and the container surfaces it with no explicit registration.
+/// </summary>
+/// <remarks>
+/// Minimal first anchor of <c>Aricie.Shared</c>'s provider family (EPIC #7265, ancre A1).
+/// <c>AutoProviderContainer</c> (assembly-scan conventions) and <c>SimpleProviderContainer</c>
+/// (flat lookup) are deferred to follow-up tranches.
+/// </remarks>
+public sealed class ReflectedProviderContainer
+{
+    private readonly IReadOnlyDictionary<string, List<Type>> _byCategory;
+    private readonly List<Type> _containers;
+    private readonly List<Type> _childEntities;
+    private readonly List<Type> _simpleEntities;
+    private readonly List<Type> _mergeables;
+
+    private ReflectedProviderContainer(
+        IReadOnlyDictionary<string, List<Type>> byCategory,
+        List<Type> containers,
+        List<Type> childEntities,
+        List<Type> simpleEntities,
+        List<Type> mergeables)
+    {
+        _byCategory = byCategory;
+        _containers = containers;
+        _childEntities = childEntities;
+        _simpleEntities = simpleEntities;
+        _mergeables = mergeables;
+    }
+
+    /// <summary>Builds a container by scanning the assembly that declares <typeparamref name="TMarker"/>.</summary>
+    public static ReflectedProviderContainer FromAssembly<TMarker>() =>
+        FromAssembly(typeof(TMarker).Assembly);
+
+    /// <summary>Builds a container by scanning a single assembly.</summary>
+    public static ReflectedProviderContainer FromAssembly(Assembly assembly) =>
+        FromAssemblies(assembly);
+
+    /// <summary>Builds a container by scanning several assemblies (union of their types).</summary>
+    public static ReflectedProviderContainer FromAssemblies(params Assembly[] assemblies)
+    {
+        ArgumentNullException.ThrowIfNull(assemblies);
+
+        var types = new List<Type>();
+        foreach (var assembly in assemblies)
+        {
+            ArgumentNullException.ThrowIfNull(assembly);
+            Type[] declared;
+            try
+            {
+                declared = assembly.GetTypes();
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+                // Keep the types that did load; a single unloadable type must not poison the container.
+                declared = ex.Types.Where(t => t is not null).ToArray()!;
+            }
+
+            types.AddRange(declared.Where(t => t is { IsClass: true } || (t.IsInterface && !t.IsSpecialName)));
+        }
+
+        return FromTypes(types);
+    }
+
+    /// <summary>Builds a container from an explicit type set (test seam + controlled scope).</summary>
+    public static ReflectedProviderContainer FromTypes(IEnumerable<Type> types)
+    {
+        ArgumentNullException.ThrowIfNull(types);
+
+        var byCategory = new Dictionary<string, List<Type>>(StringComparer.Ordinal);
+        var containers = new List<Type>();
+        var childEntities = new List<Type>();
+        var simpleEntities = new List<Type>();
+        var mergeables = new List<Type>();
+
+        foreach (var type in types)
+        {
+            ArgumentNullException.ThrowIfNull(type);
+
+            if (type.GetCustomAttribute<MainCategoryAttribute>() is { } category)
+            {
+                if (!byCategory.TryGetValue(category.Name, out var bucket))
+                {
+                    bucket = new List<Type>();
+                    byCategory[category.Name] = bucket;
+                }
+
+                bucket.Add(type);
+            }
+
+            if (type.GetCustomAttribute<AttributeContainerAttribute>() is not null)
+            {
+                containers.Add(type);
+            }
+
+            if (typeof(IChildEntity).IsAssignableFrom(type) && type != typeof(IChildEntity))
+            {
+                childEntities.Add(type);
+            }
+
+            if (typeof(ISimpleEntity).IsAssignableFrom(type) && type != typeof(ISimpleEntity))
+            {
+                simpleEntities.Add(type);
+            }
+
+            if (typeof(IMergeable).IsAssignableFrom(type) && type != typeof(IMergeable))
+            {
+                mergeables.Add(type);
+            }
+        }
+
+        return new ReflectedProviderContainer(byCategory, containers, childEntities, simpleEntities, mergeables);
+    }
+
+    /// <summary>Categories discovered, in first-seen order.</summary>
+    public IEnumerable<string> Categories => _byCategory.Keys;
+
+    /// <summary>Types registered under <paramref name="category"/>, or empty if unknown.</summary>
+    public IReadOnlyList<Type> this[string category] =>
+        _byCategory.TryGetValue(category, out var bucket) ? bucket : Array.Empty<Type>();
+
+    /// <summary>Types decorated with <see cref="AttributeContainerAttribute"/>.</summary>
+    public IReadOnlyList<Type> Containers => _containers;
+
+    /// <summary>Types implementing <see cref="IChildEntity"/> (hierarchical nodes).</summary>
+    public IReadOnlyList<Type> ChildEntities => _childEntities;
+
+    /// <summary>Types implementing <see cref="ISimpleEntity"/> (flat leaves).</summary>
+    public IReadOnlyList<Type> SimpleEntities => _simpleEntities;
+
+    /// <summary>Types implementing <see cref="IMergeable"/>.</summary>
+    public IReadOnlyList<Type> Mergeables => _mergeables;
+}

--- a/MyIA.AI.Shared/README.md
+++ b/MyIA.AI.Shared/README.md
@@ -1,0 +1,68 @@
+# MyIA.AI.Shared
+
+Socle .NET transverse partagé de CoursIA. Cible désignée (EPIC **#7265**) pour
+récupérer, dans un équivalent C# moderne (net9.0) d'`Aricie.Shared`, les composants
+techniques transverses du patrimoine endormi d'Aricie (~10 ans de travail) :
+UI / sérialisation / rule-engine metadata-driven. Les modules de **domaine**
+(Trading : Converter E1, Backtester E2) atterrissent dans un projet dédié à côté,
+dépendant de Shared seulement quand on y mutualise des structures réutilisables.
+
+> Cadrage user 2026-07-19 (issue #7265) : *« transverse dans Shared, domaine en
+> projet dédié »*.
+
+## A1 — Décoration metadata-driven (ancre, #7265)
+
+Première tranche de la fondation. Pose les primitives qui font tenir tout le reste :
+**décorer un type → l'introspecter par réflexion, sans inscription explicite**.
+
+### Primitives livrées
+
+| Type | Rôle |
+|------|------|
+| `ComponentModel.Attributes.MainCategoryAttribute` | Décore un type avec une catégorie principale (groupement/introspection). |
+| `ComponentModel.Attributes.AttributeContainerAttribute` | Marque un type comme conteneur d'entités enfants (racine de hiérarchie). |
+| `ComponentModel.Entities.IChildEntity` | Entité hiérarchique (parent + enfants) — hiérarchie infinie. |
+| `ComponentModel.Entities.ISimpleEntity` | Entité simple (feuille plate, non hiérarchique). |
+| `ComponentModel.Entities.IMergeable` | Entité qui sait fusionner une instance compatible en elle-même. |
+| `ComponentModel.Providers.ReflectedProviderContainer` | Provider reflection-driven : discover les types décorés/marqués et les expose (par catégorie, conteneurs, interfaces marqueuses). |
+
+### Contrat décoration → introspection
+
+```csharp
+using MyIA.AI.ComponentModel.Attributes;
+using MyIA.AI.ComponentModel.Entities;
+using MyIA.AI.ComponentModel.Providers;
+
+[MainCategory("Payment")]
+public sealed class PaymentGateway : ISimpleEntity { public string Name => "gw"; }
+
+// Aucune inscription : la décoration suffit.
+var provider = ReflectedProviderContainer.FromAssembly<PaymentGateway>();
+provider["Payment"];        // { PaymentGateway }
+provider.SimpleEntities;    // { PaymentGateway }
+provider.Categories;        // { "Payment" }
+```
+
+## Build & tests
+
+```bash
+dotnet build MyIA.AI.Shared.sln -c Release
+dotnet test  MyIA.AI.Shared.sln -c Release
+```
+
+Solution `MyIA.AI.Shared.sln` (socle-only : lib + tests) pour un build/test isolé,
+sans tirer `MyIA.AI.Notebooks`. La solution racine `MyIA.CoursIA.sln` référence déjà
+le projet lib.
+
+## Tranches suivantes (hors cette ancre)
+
+- **A1+** : providers `AutoProviderContainer` (conventions de scan) et
+  `SimpleProviderContainer` (lookup plat).
+- **A2** — Sérialisation légo (XML/JSON décoration-driven) :
+  `XmlAwareContractResolver`, `DynamicSurrogate`, collections sérialisables.
+- **A3** — Object explorer UI : `AdvancedGridView`, `PropertyEditor`, filtres.
+
+## Références
+
+- EPIC **#7265** — index de la pompe patrimoine Aricie.
+- `See #7265`.


### PR DESCRIPTION
## Summary

**First bounded tranche (anchor) of the metadata-driven decoration foundation in `MyIA.AI.Shared/`** — the net9.0 modernized equivalent of `Aricie.Shared` (EPIC #7265, ancre A1). Per ai-01 dispatch (DM `msg-20260721T023730`): *first anchor, NOT all of A1*. Mission DEEP, diversity HORS my Z3/MGS/Search rut (new domain: metadata-driven architecture).

No source-copy from Aricie: reimplemented from the #7265 spec. User 2026-07-19 (issue comment): *"transverse dans Shared, domaine en projet dédié"* — A1 (metadata-driven socle) is genuinely transverse, lands in `MyIA.AI.Shared/`.

## Primitives added (`MyIA.AI.Shared/ComponentModel/`)

| Type | Role |
|------|------|
| `Attributes/MainCategoryAttribute` | Decorates a type with a primary category (grouping + reflection-driven introspection). `Order` property; ctor guards whitespace names. |
| `Attributes/AttributeContainerAttribute` | Marks a type as a container of child entities (root of an introspection hierarchy). `ChildType` constraint optional. |
| `Entities/IChildEntity` | Hierarchical entity (parent + children) — infinite hierarchy. |
| `Entities/ISimpleEntity` | Flat leaf entity (name only). |
| `Entities/IMergeable` | Entity that merges a compatible instance into itself. |
| `Providers/ReflectedProviderContainer` | Reflection-driven bridge **decoration → introspection**: discovers decorated/marker types across assemblies and exposes them by category / container / marker interface, with **no explicit registration**. Factories: `FromAssembly<TMarker>` / `FromAssembly` / `FromAssemblies` / `FromTypes` (test seam). |

## Contract: decoration → introspection

```csharp
[MainCategory("Payment")]
public sealed class PaymentGateway : ISimpleEntity { public string Name => "gw"; }

var provider = ReflectedProviderContainer.FromAssembly<PaymentGateway>();
provider["Payment"];     // { PaymentGateway }
provider.SimpleEntities; // { PaymentGateway }
provider.Categories;     // { "Payment" }
```

## Findings

| Metric | Value |
|---|---|
| Primitives (attributes + interfaces + provider) | 6 |
| `dotnet build MyIA.AI.Shared.sln -c Release` | **0 warning, 0 error** (.NET 9.0.18) |
| `dotnet test MyIA.AI.Shared.sln -c Release` | **12/12 passed** |
| Files | 11 (`+567/-0`) |
| Catalogue touched | **No** (byte-identical to main) |
| Notebooks / `.lean` touched | **No** |

## Tests (`MyIA.AI.Shared.Tests`, xUnit, 12)

- Indexer category lookup + unknown-category empty (no throw).
- `Categories` lists all `MainCategory` names without duplicates.
- `Containers` / `ChildEntities` / `SimpleEntities` / `Mergeables` expose the right fixtures.
- `DecorationAndMarkers_Combine` — the 3 primitives compose on the same type.
- `FromAssembly<TMarker>` assembly-scan path.
- `AttributeContainer.ChildType` read-back + `MainCategory` whitespace-rejection + valid-name/Order.

## Scope hygiene

- **Bounded anchor**: `AutoProviderContainer` + `SimpleProviderContainer` (A1+), serialization (A2), object explorer (A3) explicitly deferred — documented in `MyIA.AI.Shared/README.md` "Tranches suivantes".
- `MyIA.CoursIA.sln` (repo root, already references `MyIA.AI.Shared`) **left intact**.
- Added `MyIA.AI.Shared.sln` (socle-only: lib + tests) for isolated build/test without pulling `MyIA.AI.Notebooks`.
- 1 subject, 1 domain (transverse .NET socle), well under composite thresholds.

## Verdict SOTA

Genuine from-scratch metadata-driven socle (no degraded workaround, no toy stub), `dotnet build` green, `dotnet test` green.

See #7265
