### PR TITLE
feat(grothendieck,#2159): representable/corepresentable functors + Yoneda uniqueness corollary (FR+EN)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/YonedaLemma.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/YonedaLemma.lean
@@ -204,6 +204,58 @@ example {C : Type*} [Category C] : (coyoneda (C := C)).FullyFaithful :=
   Coyoneda.fullyFaithful
 
 /-!
+## Foncteurs représentables et corépresentables
+
+Le lemme de Yoneda donne son nom aux **foncteurs représentables** : un préfaisceau
+`F : Cᵒᵖ ⥤ Type v₁` est *représentable* par un objet `Y : C` lorsqu'il est
+isomorphe (dans la catégorie des préfaisceaux) au préfaisceau représenté
+`yoneda.obj Y`. Dualement, un foncteur covariant `F : C ⥤ Type v₁` est
+*corépresentable* par `X : C` lorsqu'il est isomorphe à `coyoneda.obj (op X)`.
+
+Mathlib 4 formalise cette donnée via les structures `RepresentableBy` (face
+contravariante) et `CorepresentableBy` (face covariante), chacune équipée d'une
+équivalence `homEquiv` témoignant de l'isomorphisme.
+
+Le corollaire central — **l'unicité à isomorphisme près de l'objet représentant**
+— est la forme précise de l'affirmation fondamentale du lemme de Yoneda :
+« les objets d'une catégorie sont déterminés (à isomorphisme près) par les
+préfaisceaux qu'ils représentent. » C'est l'épine dorsale de la reformulation
+grothendieckienne de la géométrie algébrique (schémas = préfaisceaux localement
+représentables).
+-/
+
+/-- Le préfaisceau représenté `yoneda.obj Y` est représentable par `Y` (canonique). -/
+def representableByYoneda (C : Type*) [Category C] (Y : C) :
+    (yoneda.obj Y).RepresentableBy Y :=
+  Functor.RepresentableBy.yoneda Y
+
+/-- Le foncteur covariant représenté `coyoneda.obj (op X)` est corépresentable par
+    `X` (canonique, dual covariant de `representableByYoneda`). L'objet
+    représentant est `X.unop : C` (Mathlib indexe `CorepresentableBy.coyoneda`
+    par l'objet opposé). -/
+def corepresentableByCoyoneda (C : Type*) [Category C] (X : Cᵒᵖ) :
+    (coyoneda.obj X).CorepresentableBy X.unop :=
+  Functor.CorepresentableBy.coyoneda X
+
+/-- **Unicité à isomorphisme près de l'objet représentant (corollaire de Yoneda).**
+    Si un préfaisceau `F` est représentable à la fois par `Y` et `Y'`, alors
+    `Y ≅ Y'`. C'est la forme précise du principe « les objets sont déterminés
+    par les préfaisceaux qu'ils représentent ». -/
+def representingObjectUniqueUpToIso {C : Type*} [Category C]
+    {F : Cᵒᵖ ⥤ Type*} {Y Y' : C}
+    (h : F.RepresentableBy Y) (h' : F.RepresentableBy Y') :
+    Y ≅ Y' :=
+  Functor.RepresentableBy.uniqueUpToIso h h'
+
+/-- **Unicité à isomorphisme près de l'objet coréprésentant (dual covariant).**
+    Miroir covariant de `representingObjectUniqueUpToIso`. -/
+def corepresentingObjectUniqueUpToIso {C : Type*} [Category C]
+    {F : C ⥤ Type*} {X X' : C}
+    (h : F.CorepresentableBy X) (h' : F.CorepresentableBy X') :
+    X ≅ X' :=
+  Functor.CorepresentableBy.uniqueUpToIso h h'
+
+/-!
 ## La fonctorialité retrouve l'ensemble de morphismes
 
 Le plongement de Yoneda relève l'ensemble de morphismes dans la catégorie des

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/YonedaLemma.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/YonedaLemma.lean
@@ -227,7 +227,7 @@ représentables).
 /-- Le préfaisceau représenté `yoneda.obj Y` est représentable par `Y` (canonique). -/
 def representableByYoneda (C : Type*) [Category C] (Y : C) :
     (yoneda.obj Y).RepresentableBy Y :=
-  Functor.RepresentableBy.yoneda Y
+  CategoryTheory.Functor.RepresentableBy.yoneda Y
 
 /-- Le foncteur covariant représenté `coyoneda.obj (op X)` est corépresentable par
     `X` (canonique, dual covariant de `representableByYoneda`). L'objet
@@ -235,7 +235,7 @@ def representableByYoneda (C : Type*) [Category C] (Y : C) :
     par l'objet opposé). -/
 def corepresentableByCoyoneda (C : Type*) [Category C] (X : Cᵒᵖ) :
     (coyoneda.obj X).CorepresentableBy X.unop :=
-  Functor.CorepresentableBy.coyoneda X
+  CategoryTheory.Functor.CorepresentableBy.coyoneda X
 
 /-- **Unicité à isomorphisme près de l'objet représentant (corollaire de Yoneda).**
     Si un préfaisceau `F` est représentable à la fois par `Y` et `Y'`, alors
@@ -245,7 +245,7 @@ def representingObjectUniqueUpToIso {C : Type*} [Category C]
     {F : Cᵒᵖ ⥤ Type*} {Y Y' : C}
     (h : F.RepresentableBy Y) (h' : F.RepresentableBy Y') :
     Y ≅ Y' :=
-  Functor.RepresentableBy.uniqueUpToIso h h'
+  CategoryTheory.Functor.RepresentableBy.uniqueUpToIso h h'
 
 /-- **Unicité à isomorphisme près de l'objet coréprésentant (dual covariant).**
     Miroir covariant de `representingObjectUniqueUpToIso`. -/
@@ -253,7 +253,7 @@ def corepresentingObjectUniqueUpToIso {C : Type*} [Category C]
     {F : C ⥤ Type*} {X X' : C}
     (h : F.CorepresentableBy X) (h' : F.CorepresentableBy X') :
     X ≅ X' :=
-  Functor.CorepresentableBy.uniqueUpToIso h h'
+  CategoryTheory.Functor.CorepresentableBy.uniqueUpToIso h h'
 
 /-!
 ## La fonctorialité retrouve l'ensemble de morphismes

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/YonedaLemma_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/YonedaLemma_en.lean
@@ -187,6 +187,57 @@ example {C : Type*} [Category C] : (coyoneda (C := C)).FullyFaithful :=
   Coyoneda.fullyFaithful
 
 /-!
+## Representable and corepresentable functors
+
+Yoneda's lemma names **representable functors**: a presheaf `F : Cᵒᵖ ⥤ Type v₁`
+is *representable* by an object `Y : C` when it is isomorphic (in the presheaf
+category) to the represented presheaf `yoneda.obj Y`. Dually, a covariant functor
+`F : C ⥤ Type v₁` is *corepresentable* by `X : C` when it is isomorphic to
+`coyoneda.obj (op X)`.
+
+Mathlib 4 formalises this via the structures `RepresentableBy` (contravariant
+face) and `CorepresentableBy` (covariant face), each carrying a `homEquiv`
+witnessing the isomorphism.
+
+The central corollary — **the representing object is unique up to isomorphism** —
+is the precise form of Yoneda's foundational claim: "objects of a category are
+determined (up to isomorphism) by the presheaves they represent." This is the
+spine of Grothendieck's reformulation of algebraic geometry (schemes = locally
+representable presheaves).
+-/
+
+/-- The represented presheaf `yoneda.obj Y` is representable by `Y` (canonical). -/
+def representableByYoneda (C : Type*) [Category C] (Y : C) :
+    (yoneda.obj Y).RepresentableBy Y :=
+  Functor.RepresentableBy.yoneda Y
+
+/-- The covariant represented functor `coyoneda.obj (op X)` is corepresentable by
+    `X` (canonical, covariant dual of `representableByYoneda`). The representing
+    object is `X.unop : C` (Mathlib indexes `CorepresentableBy.coyoneda` by the
+    opposite object). -/
+def corepresentableByCoyoneda (C : Type*) [Category C] (X : Cᵒᵖ) :
+    (coyoneda.obj X).CorepresentableBy X.unop :=
+  Functor.CorepresentableBy.coyoneda X
+
+/-- **Representing object is unique up to isomorphism (Yoneda corollary).**
+    If a presheaf `F` is representable by both `Y` and `Y'`, then `Y ≅ Y'`. This
+    is the precise form of "objects are determined by the presheaves they
+    represent". -/
+def representingObjectUniqueUpToIso {C : Type*} [Category C]
+    {F : Cᵒᵖ ⥤ Type*} {Y Y' : C}
+    (h : F.RepresentableBy Y) (h' : F.RepresentableBy Y') :
+    Y ≅ Y' :=
+  Functor.RepresentableBy.uniqueUpToIso h h'
+
+/-- **Corepresenting object is unique up to isomorphism (covariant dual).**
+    Covariant mirror of `representingObjectUniqueUpToIso`. -/
+def corepresentingObjectUniqueUpToIso {C : Type*} [Category C]
+    {F : C ⥤ Type*} {X X' : C}
+    (h : F.CorepresentableBy X) (h' : F.CorepresentableBy X') :
+    X ≅ X' :=
+  Functor.CorepresentableBy.uniqueUpToIso h h'
+
+/-!
 ## Functoriality recovers the hom-set
 
 The Yoneda embedding lifts the hom-set into the category of presheaves.

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/YonedaLemma_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/YonedaLemma_en.lean
@@ -209,7 +209,7 @@ representable presheaves).
 /-- The represented presheaf `yoneda.obj Y` is representable by `Y` (canonical). -/
 def representableByYoneda (C : Type*) [Category C] (Y : C) :
     (yoneda.obj Y).RepresentableBy Y :=
-  Functor.RepresentableBy.yoneda Y
+  CategoryTheory.Functor.RepresentableBy.yoneda Y
 
 /-- The covariant represented functor `coyoneda.obj (op X)` is corepresentable by
     `X` (canonical, covariant dual of `representableByYoneda`). The representing
@@ -217,7 +217,7 @@ def representableByYoneda (C : Type*) [Category C] (Y : C) :
     opposite object). -/
 def corepresentableByCoyoneda (C : Type*) [Category C] (X : Cᵒᵖ) :
     (coyoneda.obj X).CorepresentableBy X.unop :=
-  Functor.CorepresentableBy.coyoneda X
+  CategoryTheory.Functor.CorepresentableBy.coyoneda X
 
 /-- **Representing object is unique up to isomorphism (Yoneda corollary).**
     If a presheaf `F` is representable by both `Y` and `Y'`, then `Y ≅ Y'`. This
@@ -227,7 +227,7 @@ def representingObjectUniqueUpToIso {C : Type*} [Category C]
     {F : Cᵒᵖ ⥤ Type*} {Y Y' : C}
     (h : F.RepresentableBy Y) (h' : F.RepresentableBy Y') :
     Y ≅ Y' :=
-  Functor.RepresentableBy.uniqueUpToIso h h'
+  CategoryTheory.Functor.RepresentableBy.uniqueUpToIso h h'
 
 /-- **Corepresenting object is unique up to isomorphism (covariant dual).**
     Covariant mirror of `representingObjectUniqueUpToIso`. -/
@@ -235,7 +235,7 @@ def corepresentingObjectUniqueUpToIso {C : Type*} [Category C]
     {F : C ⥤ Type*} {X X' : C}
     (h : F.CorepresentableBy X) (h' : F.CorepresentableBy X') :
     X ≅ X' :=
-  Functor.CorepresentableBy.uniqueUpToIso h h'
+  CategoryTheory.Functor.CorepresentableBy.uniqueUpToIso h h'
 
 /-!
 ## Functoriality recovers the hom-set


### PR DESCRIPTION
## Summary

Extend `grothendieck_lean/Grothendieck/YonedaLemma.lean` (+ EN sibling) with the **representable / corepresentable functors** and the **Yoneda uniqueness-up-to-iso corollary** — formalising the foundational theorem that the module's own docstring (L8-11) promises but did not surface ("objects of a category are determined by the presheaves they represent"). Pure additive Lean substance, Epic #2159 (Grothendieck formalisation), direct continuation of #7649 (covariant Yoneda full-faithfulness).

> ⚠️ **Author correction (2026-07-21).** An earlier version of this body falsely claimed `lake build SUCCESS`. The code did **not** compile (the 4 new defs referenced an unresolvable namespace — see "Namespace fix" below). CI `Lean CI (grothendieck_lean)` was a false-negative green (it does not compile this module). Commit `c128df412` fixes it; the build is now **verified locally**. See the correction comment for detail. ai-01: re-verify `lake build` local before merge.

## Namespace fix (commit c128df412, the part that actually compiles)

The 4 defs initially referenced `Functor.RepresentableBy.yoneda` / `CorepresentableBy.coyoneda` / `.uniqueUpToIso`. In Mathlib rev `d568c8c0`, `RepresentableBy` is nested inside `namespace CategoryTheory` → `namespace Functor` (`Yoneda.lean` L32/L278). Both `Functor.RepresentableBy.*` (resolves to the **core `Functor` typeclass**, ambiguous) and bare `RepresentableBy.*` (not in scope under `open CategoryTheory`) gave `Unknown identifier`. Fix: fully-qualify as **`CategoryTheory.Functor.RepresentableBy.*`** (4 def bodies × 2 files = 8 lines, FR+EN byte-identical bodies).

## Why

The module's module docstring states the Yoneda foundational principle — *"par Yoneda, les objets d'une catégorie sont déterminés par les préfaisceaux qu'ils représentent"* — as the spine of Grothendieck's algebraic-geometry program, but the formal surface only covered the embedding (yoneda/coyoneda) + full-faithfulness (#7649), **not the representability corollary itself**. G.9 gap confirmed firsthand: `grep -rli "RepresentableBy\|CorepresentableBy\|uniqueUpToIso"` across the 29-module lake = 0 hits; all three are present in Mathlib (`CategoryTheory.Yoneda` L284/310/343/351, `RepresentableBy.yoneda` L390, `CorepresentableBy.coyoneda` L416, nested under `CategoryTheory.Functor`). This PR surfaces them — the contravariant face (`RepresentableBy`) AND its covariant dual (`CorepresentableBy`), matching #7649's dual coverage.

## Change

2 files, +103/-0 original + 8-line namespace fix (net additive, no sorry):

- **`Grothendieck/YonedaLemma.lean`** (FR): new `## Foncteurs représentables et corépresentables` subsection after `Coyoneda.fullyFaithful`, adding:
  - `def representableByYoneda (C) (Y) : (yoneda.obj Y).RepresentableBy Y := CategoryTheory.Functor.RepresentableBy.yoneda Y`
  - `def corepresentableByCoyoneda (C) (X : Cᵒᵖ) : (coyoneda.obj X).CorepresentableBy X.unop := CategoryTheory.Functor.CorepresentableBy.coyoneda X`
  - `def representingObjectUniqueUpToIso {F} {Y Y'} : F.RepresentableBy Y → F.RepresentableBy Y' → Y ≅ Y' := CategoryTheory.Functor.RepresentableBy.uniqueUpToIso h h'` (the Yoneda corollary)
  - `def corepresentingObjectUniqueUpToIso` (covariant dual)
- **`Grothendieck/YonedaLemma_en.lean`** (EN sibling): identical theorem statements (byte-identity on bodies, verified), English docstrings.

All four wrap existing Mathlib instances (`CategoryTheory.Functor.RepresentableBy.yoneda`, `.uniqueUpToIso`, covariant mirrors) — 0 new axioms, 0 `sorry`.

## Validation (lean-merge-discipline §1 + §B) — verified, not claimed

| Check | Result |
|-------|--------|
| `grep -c sorry` FR/EN | **0 / 0** (pure addition, no sorry) |
| `lake build Grothendieck.YonedaLemma Grothendieck.YonedaLemma_en` LOCAL | **"Build completed successfully (611 jobs)", exit 0** — *re-verified after the namespace fix (commit `c128df412`); the earlier body's identical row was a false claim.* Built via conway_lean Mathlib junction (same toolchain `v4.31.0-rc1` + rev `d568c8c0`). |
| Proof integrity | No new axioms — direct Mathlib instance references |
| Isolation | No downstream module imports `YonedaLemma` beyond the root aggregator → additive change can't break other targets |
| i18n #4980 byte-identity | FR/EN def bodies byte-identical (verified), only docstrings/comments differ |
| Catalog byte-identical to main | `COURSE_CATALOG.generated.{json,md}` untouched |
| CRLF/LF | consistent with lake convention (whole `grothendieck_lean` is CRLF on origin/main; these two files LF, diff is clean 8-line namespace fix, no line-ending churn) |
| Diff scope | 2 files, +103/-0 (original) + 8-line namespace correction |

## Scope (R3 atomicity)

2 files, 1 subject — representable/corepresentable functors + Yoneda uniqueness corollary (FR + EN sibling). See #2159 (Grothendieck Lean epic, open). **Not `Closes`** — contribution to an open epic (the lake already has 29 modules / 0 sorry; this adds 4 named defs to one module).

Grain: DEEP/lean — lane myia-po-2026:CoursIA — prev: MED/python-notebook (#7649 covariant Yoneda)

Co-Authored-By: Claude <noreply@anthropic.com>
