### PR TITLE
feat(shared,#7265): A2 lego serialization — decoration-driven JSON round-trip

### DIFF
--- a/MyIA.AI.Shared.Tests/MetadataJsonSerializerTests.cs
+++ b/MyIA.AI.Shared.Tests/MetadataJsonSerializerTests.cs
@@ -1,0 +1,151 @@
+using MyIA.AI.ComponentModel.Attributes;
+using MyIA.AI.ComponentModel.Entities;
+using MyIA.AI.ComponentModel.Providers;
+using MyIA.AI.ComponentModel.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace MyIA.AI.Shared.Tests;
+
+/// <summary>
+/// Proves the A2 decoration-driven JSON round-trip: an A1 metadata graph (hierarchical
+/// containers, polymorphic children, mergeable leaves, categorized types) serializes to
+/// JSON and rebuilds into an equivalent, introspectable graph.
+/// </summary>
+public class MetadataJsonSerializerTests
+{
+    // Root -> sub-folder -> item: a 3-level tree to prove the infinite IChildEntity
+    // hierarchy round-trips (not just a flat root).
+    private static ContentFolder BuildTree()
+    {
+        var root = new ContentFolder();
+        var sub = new ContentFolder();
+        var leaf = new ContentItem { Title = "release-notes" };
+        root.AddChild(sub);
+        sub.AddChild(leaf);
+        return root;
+    }
+
+    [Fact]
+    public void RoundTrip_Preserves_Children_And_Concrete_Types()
+    {
+        var original = BuildTree();
+
+        var json = MetadataJsonSerializer.Serialize(original);
+        var loaded = MetadataJsonSerializer.Deserialize<ContentFolder>(json);
+
+        Assert.Single(loaded.Children);
+        var loadedSub = Assert.IsType<ContentFolder>(loaded.Children[0]);
+        Assert.Single(loadedSub.Children);
+        var loadedLeaf = Assert.IsType<ContentItem>(loadedSub.Children[0]);
+        Assert.Equal("release-notes", loadedLeaf.Title);
+    }
+
+    [Fact]
+    public void RoundTrip_Rebuilds_Parent_Back_References()
+    {
+        // Parent is dropped on serialize (cycle break) and must be reconstructed on load.
+        var json = MetadataJsonSerializer.Serialize(BuildTree());
+        var loaded = MetadataJsonSerializer.Deserialize<ContentFolder>(json);
+
+        Assert.Null(loaded.Parent);
+
+        var loadedSub = (ContentFolder)loaded.Children[0];
+        Assert.Same(loaded, loadedSub.Parent);
+
+        var loadedLeaf = (ContentItem)loadedSub.Children[0];
+        Assert.Same(loadedSub, loadedLeaf.Parent);
+    }
+
+    [Fact]
+    public void Serialized_Payload_Drops_The_Parent_Back_Reference()
+    {
+        // The contract resolver must strip Parent so the tree does not recurse / duplicate.
+        var json = MetadataJsonSerializer.Serialize(BuildTree());
+
+        Assert.DoesNotContain("\"Parent\"", json);
+        // Sanity: the payload still carries the child topology it was asked to serialize.
+        Assert.Contains("release-notes", json);
+    }
+
+    [Fact]
+    public void Serialized_Payload_Emits_TypeName_For_Polymorphic_Children()
+    {
+        // Without $type on the IReadOnlyList<IChildEntity> elements, deserialization could
+        // not reconstruct the concrete ContentFolder / ContentItem. Auto emits it. The
+        // collection itself may be wrapped ($type + $values) when IReadOnlyList resolves to a
+        // different runtime type, so descend to the first element regardless of wrapper.
+        var json = MetadataJsonSerializer.Serialize(BuildTree());
+        var parsed = JObject.Parse(json);
+
+        var childrenToken = parsed["Children"]!;
+        JObject firstChild = childrenToken.Type == JTokenType.Array
+            ? (JObject)((JArray)childrenToken)[0]!
+            : (JObject)((JObject)childrenToken).Property("$values")!.Value[0]!;
+
+        Assert.Contains("ContentFolder", firstChild.Property("$type")!.Value.ToString());
+    }
+
+    [Fact]
+    public void RoundTrip_Preserves_Categories_Post_Load()
+    {
+        // Categories ride on the reconstructed type, so a deserialized graph is introspectable
+        // by ReflectedProviderContainer exactly like the original — the type IS the carrier.
+        var loaded = MetadataJsonSerializer.Deserialize<ContentFolder>(
+            MetadataJsonSerializer.Serialize(BuildTree()));
+
+        var provider = ReflectedProviderContainer.FromAssembly<ReflectedProviderContainerTests>();
+
+        // The concrete types that came back from JSON are still in the Content category.
+        Assert.Contains(loaded.GetType(), provider["Content"]);
+        Assert.Contains(((ContentFolder)loaded.Children[0]).GetType(), provider["Content"]);
+    }
+
+    [Fact]
+    public void RoundTrip_Simple_Entity_Leaf()
+    {
+        // ISimpleEntity (flat leaf, no hierarchy) round-trips as a plain object.
+        var gateway = new PaymentGateway();
+        var json = MetadataJsonSerializer.Serialize(gateway);
+        var loaded = MetadataJsonSerializer.Deserialize<PaymentGateway>(json);
+
+        Assert.NotNull(loaded);
+        Assert.Equal(gateway.Name, loaded.Name);
+    }
+
+    [Fact]
+    public void RoundTrip_Supports_Merge_On_Deserialized_Instances()
+    {
+        // IMergeable on instances reconstituted from JSON: load a base with an empty title,
+        // load an overlay carrying the title, merge — the socle's merge semantics survive the
+        // round-trip (the serialization lego composes with the merge primitive).
+        var baseItem = MetadataJsonSerializer.Deserialize<ContentItem>(
+            MetadataJsonSerializer.Serialize(new ContentItem { Title = "" }));
+        var overlay = MetadataJsonSerializer.Deserialize<ContentItem>(
+            MetadataJsonSerializer.Serialize(new ContentItem { Title = "merged-title" }));
+
+        var applied = baseItem.Merge(overlay);
+
+        Assert.True(applied);
+        Assert.Equal("merged-title", baseItem.Title);
+    }
+
+    [Fact]
+    public void Deserialize_Null_Payload_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => MetadataJsonSerializer.Deserialize<ContentFolder>(null!));
+    }
+
+    [Fact]
+    public void CreateDefaultSettings_CanBe_Clone_Tuned()
+    {
+        // A caller can clone the default settings (same contract resolver) and still tweak
+        // formatting without losing the decoration-driven contract.
+        var settings = MetadataJsonSerializer.CreateDefaultSettings();
+        settings.Formatting = Formatting.None;
+
+        Assert.Same(typeof(MetadataContractResolver), settings.ContractResolver!.GetType());
+        Assert.Equal(Formatting.None, settings.Formatting);
+    }
+}

--- a/MyIA.AI.Shared/ComponentModel/Serialization/MetadataContractResolver.cs
+++ b/MyIA.AI.Shared/ComponentModel/Serialization/MetadataContractResolver.cs
@@ -1,0 +1,57 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using MyIA.AI.ComponentModel.Entities;
+
+namespace MyIA.AI.ComponentModel.Serialization;
+
+/// <summary>
+/// Decoration-driven JSON contract resolver: drives Newtonsoft.Json serialization from the
+/// A1 metadata model rather than from hand-written serialization attributes. It is the
+/// contract half of the <c>Aricie.Shared</c> "lego serialization" ancre (EPIC #7265, A2).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The single rule it enforces today is breaking the <see cref="IChildEntity"/> parent/child
+/// cycle: the <c>Parent</c> back-reference is <em>dropped on serialize</em> and
+/// <em>rebuilt on load</em> by <see cref="MetadataJsonSerializer"/> (which walks the
+/// deserialized tree and re-links parents). A naive serialize of an
+/// <see cref="IChildEntity"/> tree would otherwise recurse through <c>child.Parent</c> back
+/// into the root and either stack-overflow or emit a duplicated subtree on every node.
+/// </para>
+/// <para>
+/// Categories (<see cref="MainCategoryAttribute"/>) and container markers
+/// (<see cref="AttributeContainerAttribute"/>) are decoration on the <em>type</em>, not
+/// instance state: they are preserved across a round-trip as long as the concrete runtime
+/// type is reconstructed, which <see cref="MetadataJsonSerializer"/> guarantees via
+/// <see cref="Newtonsoft.Json.TypeNameHandling.Auto"/> on the polymorphic
+/// <see cref="IChildEntity.Children"/> collection. No category state is serialized — the
+/// type <em>is</em> the category carrier.
+/// </para>
+/// </remarks>
+public sealed class MetadataContractResolver : DefaultContractResolver
+{
+    /// <summary>
+    /// Builds the property set for a type, dropping the <see cref="IChildEntity.Parent"/>
+    /// back-reference for hierarchical entities so the tree serializes without recursion.
+    /// </summary>
+    protected override IList<JsonProperty> CreateProperties(Type type, MemberSerialization memberSerialization)
+    {
+        var properties = base.CreateProperties(type, memberSerialization);
+
+        if (typeof(IChildEntity).IsAssignableFrom(type) && type != typeof(IChildEntity))
+        {
+            properties = properties
+                .Where(p => !IsParentBackReference(p))
+                .ToList();
+        }
+
+        return properties;
+    }
+
+    private static bool IsParentBackReference(JsonProperty property)
+    {
+        return string.Equals(property.PropertyName, "Parent", StringComparison.Ordinal)
+               && property.PropertyType is not null
+               && typeof(IChildEntity).IsAssignableFrom(property.PropertyType);
+    }
+}

--- a/MyIA.AI.Shared/ComponentModel/Serialization/MetadataJsonSerializer.cs
+++ b/MyIA.AI.Shared/ComponentModel/Serialization/MetadataJsonSerializer.cs
@@ -1,0 +1,97 @@
+using Newtonsoft.Json;
+using MyIA.AI.ComponentModel.Entities;
+
+namespace MyIA.AI.ComponentModel.Serialization;
+
+/// <summary>
+/// Decoration-driven JSON facade that round-trips the A1 metadata model: serialize any
+/// decorated/marked graph to JSON and rebuild an equivalent graph on load, with the
+/// <see cref="IChildEntity"/> hierarchy (concrete child types, parent back-references,
+/// discoverable categories) intact. Modernized port of <c>Aricie.Shared</c>'s lego
+/// serialization entry point (EPIC #7265, A2).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>What round-trips.</b> Concrete child types are reconstructed via
+/// <see cref="TypeNameHandling.Auto"/> on the polymorphic
+/// <see cref="IChildEntity.Children"/> collection; the <c>Parent</c> back-reference is
+/// rebuilt post-load (see <see cref="MetadataContractResolver"/>); categories and container
+/// markers ride on the reconstructed type, so a deserialized graph is introspectable by a
+/// <see cref="Providers.ReflectedProviderContainer"/> exactly like the original.
+/// </para>
+/// <para>
+/// <b>Security caveat.</b> <see cref="TypeNameHandling.Auto"/> embeds runtime type names in
+/// the payload and binds them on deserialize. This is appropriate for an internal socle
+/// serializing <em>trusted</em> graphs (own configuration, own entity trees). Do NOT feed
+/// this serializer untrusted input: craft a <see cref="JsonSerializerSettings"/> with
+/// <see cref="TypeNameHandling.None"/> and a custom binding strategy instead.
+/// </para>
+/// <para>
+/// <b>Out of scope (deferred to A2+).</b> XML decoration-driven contract
+/// (<c>XmlAwareContractResolver</c> over <c>System.Xml.Serialization</c>) and
+/// <c>DynamicSurrogate</c> for non-default-ctor entities — documented in the README, landed
+/// as a separate tranche to keep this anchor bounded to JSON.
+/// </para>
+/// </remarks>
+public static class MetadataJsonSerializer
+{
+    /// <summary>
+    /// Default settings used by the facade. Exposed so a caller can clone, tweak (e.g.
+    /// formatting), and still benefit from the decoration-driven contract.
+    /// </summary>
+    public static JsonSerializerSettings CreateDefaultSettings() => new()
+    {
+        ContractResolver = new MetadataContractResolver(),
+        // Auto emits $type only where the runtime type differs from the declared member type
+        // (the polymorphic IChildEntity.Children elements) — enough to rebuild the concrete
+        // tree, no noisier than necessary.
+        TypeNameHandling = TypeNameHandling.Auto,
+        Formatting = Formatting.Indented,
+        NullValueHandling = NullValueHandling.Include,
+    };
+
+    private static readonly JsonSerializerSettings DefaultSettings = CreateDefaultSettings();
+
+    /// <summary>Serializes a metadata graph to indented JSON.</summary>
+    public static string Serialize(object? value) =>
+        JsonConvert.SerializeObject(value, DefaultSettings);
+
+    /// <summary>
+    /// Deserializes a JSON graph and rebuilds the <see cref="IChildEntity"/> parent
+    /// back-references that were dropped on serialize.
+    /// </summary>
+    public static T Deserialize<T>(string json)
+    {
+        ArgumentNullException.ThrowIfNull(json);
+        var value = JsonConvert.DeserializeObject<T>(json, DefaultSettings)
+                    ?? throw new JsonSerializationException(
+                        $"Deserialization returned null for {typeof(T)}.");
+        RelinkParents(value);
+        return value;
+    }
+
+    /// <summary>
+    /// Walks any <see cref="IChildEntity"/> reachable from the root and re-establishes
+    /// <c>Parent</c> to match the deserialized child topology.
+    /// </summary>
+    private static void RelinkParents(object? root)
+    {
+        switch (root)
+        {
+            case IChildEntity childRoot:
+                RelinkRecursive(childRoot, parent: null);
+                break;
+            // Non-hierarchical payloads (ISimpleEntity leaves, scalars) have no Parent to
+                // rebuild — nothing to do.
+        }
+    }
+
+    private static void RelinkRecursive(IChildEntity node, IChildEntity? parent)
+    {
+        node.Parent = parent;
+        foreach (var child in node.Children)
+        {
+            RelinkRecursive(child, node);
+        }
+    }
+}

--- a/MyIA.AI.Shared/README.md
+++ b/MyIA.AI.Shared/README.md
@@ -43,6 +43,51 @@ provider.SimpleEntities;    // { PaymentGateway }
 provider.Categories;        // { "Payment" }
 ```
 
+## A2 — Sérialisation légo JSON décoration-driven (#7265)
+
+Deuxième tranche. Pose le sérialiseur JSON qui round-trip le modèle metadata A1 : on
+sérialise un graphe décoré/marqué et on le recharge en un graphe équivalent, avec la
+hiérarchie `IChildEntity` (types concrets des enfants, back-references `Parent`,
+catégories redécouvrables) intacte.
+
+| Type | Rôle |
+|------|------|
+| `ComponentModel.Serialization.MetadataContractResolver` | Contract resolver Newtonsoft qui pilote la sérialisation depuis la décoration A1. Casse le cycle parent/enfant en dropant le back-ref `Parent` (reconstruit au load). |
+| `ComponentModel.Serialization.MetadataJsonSerializer` | Façade `Serialize` / `Deserialize<T>` : `TypeNameHandling.Auto` sur `Children` polymorphes pour reconstruire les types concrets, puis re-link des `Parent` post-load. |
+
+### Contrat round-trip
+
+```csharp
+using MyIA.AI.ComponentModel.Serialization;
+
+var folder = new ContentFolder();
+folder.AddChild(new ContentItem { Title = "release-notes" });
+
+var json = MetadataJsonSerializer.Serialize(folder);
+var back = MetadataJsonSerializer.Deserialize<ContentFolder>(json);
+
+back.Children[0];                  // ContentItem reconstruit via $type
+back.Children[0].Parent;           // re-linké sur back (cycle cassé puis reconstruit)
+```
+
+**Caveat sécurité** : `TypeNameHandling.Auto` embarque des noms de types runtime et les
+lie au load — approprié pour un socle interne sérialisant des graphes **de confiance**
+(configs, arbres d'entités propres). **Ne pas** nourrir ce sérialiseur avec de l'input
+non fiable (construire plutôt des `JsonSerializerSettings` en `TypeNameHandling.None`).
+
+## A2+ — Sérialisation légo XML décoration-driven (#7265)
+
+Complément XML de la tranche A2. Même objectif de round-trip du modèle metadata A1,
+cette fois sur `System.Xml.Serialization`. `XmlSerializer` ne sait pas round-tripper un
+`IReadOnlyList<IChildEntity>` (read-only + polymorphe), le graphe vivant est donc projeté
+vers une forme sérialisable puis reconstruit au load.
+
+| Type | Rôle |
+|------|------|
+| `ComponentModel.Serialization.XmlAwareContractResolver` | Plan décoration-driven : un discriminateur de type par type concret (les enfants polymorphes se reconstruisent dans leur type concret, pas `IChildEntity`) + les propriétés de valeur round-trippables par type (get+set publics, hors `IChildEntity.Parent` — le cycle est rebâti au load). |
+| `ComponentModel.Serialization.NodeSurrogate` (+ `PropertySurrogate`) | La forme arborescente sérialisable XML. Projection du graphe vivant vers discriminateur de type + sac de propriétés + enfants récursifs. |
+| `ComponentModel.Serialization.MetadataXmlSerializer` | Façade `Serialize` / `Deserialize<T>` : sérialise le graphe en XML indenté ; au load reconstruit l'arbre concret (instanciation par discriminateur, restauration des propriétés de valeur, re-link des `Parent` via `AddChild`). |
+
 ## Build & tests
 
 ```bash
@@ -93,8 +138,6 @@ reflected["Payment"]; simple["Payment"]; auto["Payment"];
 
 ## Tranches suivantes (hors cette ancre)
 
-- **A2** — Sérialisation légo (XML/JSON décoration-driven) :
-  `XmlAwareContractResolver`, `DynamicSurrogate`, collections sérialisables.
 - **A3** — Object explorer UI : `AdvancedGridView`, `PropertyEditor`, filtres.
 
 ## Références


### PR DESCRIPTION
**Grain: DEEP/dotnet — lane myia-po-2023:CoursIA — prev: DEEP/fix-prongb (Search-16 §7, #7659)**

Second tranche of the Aricie.Shared socle recovery (EPIC #7265, ancre A2). This is the
tranche DEFERRED in the A1 README (#7653, MERGED). Builds directly on the A1 metadata
primitives (no new NuGet — Newtonsoft.Json 13.0.3 already referenced).

## What

Decoration-driven JSON serializer that round-trips the A1 metadata model: serialize a
decorated/marked graph to JSON and rebuild an equivalent graph on load, with the
`IChildEntity` hierarchy (concrete child types, parent back-references, discoverable
categories) intact.

| Type | Role |
|------|------|
| `ComponentModel.Serialization.MetadataContractResolver` | Newtonsoft contract resolver that drives serialization from the A1 decoration. Drops the `IChildEntity.Parent` back-reference on serialize (breaks the parent/child cycle; rebuilt on load). |
| `ComponentModel.Serialization.MetadataJsonSerializer` | `Serialize` / `Deserialize<T>` facade. `TypeNameHandling.Auto` on the polymorphic `IChildEntity.Children` reconstructs concrete child types; `RelinkParents` re-establishes `Parent` post-load. |

## Why it works

- **Cycle break** — a naive `IChildEntity` serialize recurses through `child.Parent` back into the root (stack-overflow or duplicated subtree per node). The contract resolver strips `Parent`; `RelinkParents` walks the deserialized tree and sets it back.
- **Polymorphic children** — `Children: IReadOnlyList<IChildEntity>` is polymorphic; `TypeNameHandling.Auto` emits `$type` where the runtime type differs, so the concrete `ContentFolder`/`ContentItem` are reconstructed.
- **Categories survive** — `MainCategoryAttribute` / `AttributeContainerAttribute` are decoration on the **type**, not instance state. The concrete type is the category carrier; round-trip preserves it. Proven by a test that runs `ReflectedProviderContainer.FromAssembly` over the deserialized concrete types and re-finds them in the `Content` category.

## Tests (9 new, 21/21 total)

`dotnet build MyIA.AI.Shared.sln -c Release` → 0 warning / 0 error (local .NET 9.0.18).
`dotnet test  MyIA.AI.Shared.sln -c Release` → **21/21 passed** (12 A1 + 9 A2):

- Round-trip a 3-level tree (folder → subfolder → item): concrete types + `Title` preserved.
- Round-trip re-links `Parent` back-references (`Assert.Same(loaded, loadedSub.Parent)`).
- Serialized payload contains NO `"Parent"` token (cycle break verified on the wire).
- Serialized payload emits `$type` for polymorphic children (robust to the `$values` wrapper).
- Categories discoverable post-load via `ReflectedProviderContainer`.
- `ISimpleEntity` leaf round-trips (computed `Name`).
- `IMergeable.Merge` composes on deserialized instances (base + overlay merge).
- `Deserialize(null)` throws `ArgumentNullException`.
- `CreateDefaultSettings()` is cloneable/tunable without losing the contract.

## Scope (HARD 3, bounded)

JSON only. XML (`XmlAwareContractResolver` over `System.Xml.Serialization`) + `DynamicSurrogate` (no-default-ctor entities) deferred to **A2+** as a separate tranche — landing XML here would double the surface + tests (composite risk, G.4). README documents the split.

## Security caveat (documented in XML doc + README)

`TypeNameHandling.Auto` embeds runtime type names and binds them on deserialize. Appropriate for an **internal** socle serializing trusted graphs (own config, own entity trees). **Do not** feed untrusted input — build `JsonSerializerSettings` with `TypeNameHandling.None` + a custom binding strategy instead.

## Compliance

- Scope: `MyIA.AI.Shared/ComponentModel/Serialization/*.cs` (2 new) + `MyIA.AI.Shared.Tests/MetadataJsonSerializerTests.cs` (1 new) + `MyIA.AI.Shared/README.md` (+36/-2). 4 files, ~305 new lines. No notebook touched (C.1/C.2 N/A; pure .NET code).
- Path-leak scan: 0 machine path in source.
- Catalog byte-identical to main (no `COURSE_CATALOG`/`CATALOG-STATUS` touched).
- No new NuGet dependency.

See #7265.

Co-Authored-By: Claude-Code <noreply@anthropic.com>