### PR TITLE
fix(search,#3801): Search-16 Section 6 Edmonds-Karp — reverse-edge augmentor + max-flow=15

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-16-QuikGraph.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-16-QuikGraph.ipynb
@@ -966,32 +966,54 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "EXCEPTION flot max : InvalidOperationException\r\n"
+      "\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Message : The graph has not been augmented yet.\r\n",
-      "Call ReversedEdgeAugmentorAlgorithm.AddReversedEdges() before running this algorithm.\r\n"
+      "Flot maximum S -> T : 15,00\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  (Verification min-cut : {S} | {A,B,T} = S->A(10) + S->B(5) = 15)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fin cellule flot max.\r\n"
      ]
     }
    ],
    "source": [
-    "try\n",
-    "{\n",
-    "// Reseau :\n",
+    "// Reseau de flot canonique (Cormen et al., chapitre 26) : 4 sommets S, A, B, T.\n",
     "//   S -> A (10)   A -> T (8)\n",
     "//   S -> B (5)    B -> T (10)\n",
     "//   A -> B (3)\n",
-    "// Le flot max de S a T est min(S_outs, T_ins) = min(15, 18) = 15 (sur ce reseau il est en fait 13\n",
-    "// car A->T limite par S_outs=10 + B_outs=5 partage A->T (8) et B->T (10) : voir trace).\n",
     "//\n",
-    "// NB : le mini-reseau 4 sommets est documente dans la litterature comme exemple\n",
-    "// canonique d'Edmonds-Karp (Cormen et al., chapitre 26). La cle pedagogique : le\n",
-    "// BFS augmentant peut avoir besoin de plusieurs passes (deux passes ici suffisent)\n",
-    "// pour atteindre le flot optimal.\n",
+    "// Flot max S -> T = 15 (min-cut : la coupe {S} | {A,B,T} vaut S->A(10) + S->B(5) = 15,\n",
+    "// et par le theoreme max-flow/min-cut c'est aussi le flot maximum). L'arete A->B laisse\n",
+    "// A router son excedent vers B puis T : S->A(10) se partage en A->T(8) + A->B(2), et B\n",
+    "// recevant S->B(5) + A->B(2) = 7 les pousse vers B->T (capacite 10). Total arrive a T = 15.\n",
+    "//\n",
+    "// API QuikGraph 2.5.0 : EdmondsKarpMaximumFlowAlgorithm exige que le graphe soit augmente\n",
+    "// de ses aretes residuelles AVANT l'appel a Compute (sinon InvalidOperationException\n",
+    "// \"The graph has not been augmented yet\"). On instancie donc le ReversedEdgeAugmentorAlgorithm\n",
+    "// separement, on appelle AddReversedEdges(), puis on construit l'algorithme sur le graphe\n",
+    "// augmente. Cleanup final via RemoveReversedEdges() pour ne pas polluer le graphe.\n",
     "\n",
     "var flowGraph = new BidirectionalGraph<string, STaggedEdge<string, double>>();\n",
     "flowGraph.AddVertex(\"S\");\n",
@@ -1016,26 +1038,27 @@
     "EdgeFactory<string, STaggedEdge<string, double>> creeAretesResiduelles =\n",
     "    (s, t) => new STaggedEdge<string, double>(s, t, 0.0);\n",
     "\n",
+    "// Etape obligatoire : augmenter le graphe des aretes residuelles AVANT l'algorithme.\n",
+    "var augmentor = new ReversedEdgeAugmentorAlgorithm<string, STaggedEdge<string, double>>(\n",
+    "    flowGraph, creeAretesResiduelles);\n",
+    "augmentor.AddReversedEdges();\n",
+    "\n",
     "var maxFlowAlgo = new EdmondsKarpMaximumFlowAlgorithm<string, STaggedEdge<string, double>>(\n",
     "    flowGraph,\n",
     "    e => e.Tag,\n",
     "    creeAretesResiduelles,\n",
-    "    new ReversedEdgeAugmentorAlgorithm<string, STaggedEdge<string, double>>(flowGraph, creeAretesResiduelles)\n",
+    "    augmentor\n",
     ");\n",
     "maxFlowAlgo.Compute(\"S\", \"T\");\n",
     "\n",
     "Console.WriteLine();\n",
     "Console.WriteLine($\"Flot maximum S -> T : {maxFlowAlgo.MaxFlow:F2}\");\n",
-    "Console.WriteLine($\"  (Verification theorique : 13 = 10 par S->A + 3 par A->B->T = 10 + 3 = 13)\");\n",
+    "Console.WriteLine(\"  (Verification min-cut : {S} | {A,B,T} = S->A(10) + S->B(5) = 15)\");\n",
     "Console.WriteLine();\n",
     "Console.WriteLine(\"Fin cellule flot max.\");\n",
-    "}\n",
-    "catch (System.Exception ex)\n",
-    "{\n",
-    "    Console.WriteLine($\"EXCEPTION flot max : {ex.GetType().Name}\");\n",
-    "    Console.WriteLine($\"Message : {ex.Message}\");\n",
-    "    if (ex.InnerException != null) Console.WriteLine($\"Inner : {ex.InnerException.Message}\");\n",
-    "}"
+    "\n",
+    "// Cleanup : retirer les aretes residuelles ajoutees pour ne pas polluer le graphe.\n",
+    "augmentor.RemoveReversedEdges();\n"
    ]
   },
   {
@@ -1267,7 +1290,9 @@
    "cell_type": "markdown",
    "id": "555705b6",
    "metadata": {},
-   "source": "### Exercice 2 : Flot maximum sur un mini-reseau electrique\n\n**Ennonce** : Modelisez un reseau electrique simplifie du **CaseStudy SmartGrid CC3** (cf. `MyIA.AI.Notebooks/CaseStudies/`) avec 5 noeuds :\n\n- Producteur `P1` (centrale solaire)\n- Producteur `P2` (eolien)\n- Noeud intermediaire `J1` (jonction)\n- Noeud intermediaire `J2` (jonction)\n- Client `C1` (quartier residentiel)\n\nAretes (avec capacite en MW) : `P1 -> J1 : 10`, `P1 -> J2 : 5`, `P2 -> J1 : 8`, `P2 -> J2 : 5`, `J1 -> C1 : 12`, `J2 -> C1 : 7`.\n\nLancez `EdmondsKarpMaximumFlowAlgorithm<string, STaggedEdge<string, double>>` entre `P1+P2` (super source) et `C1`. **Indice** : QuikGraph ne supporte pas directement une super-source ; ajoutez un sommet `S` relie a `P1` et `P2` avec capacites infinies (ou très grandes), puis appelez `algo.Compute(\"S\", \"C1\")`."
+   "source": [
+    "### Exercice 2 : Flot maximum sur un mini-reseau electrique\n\n**Ennonce** : Modelisez un reseau electrique simplifie du **CaseStudy SmartGrid CC3** (cf. `MyIA.AI.Notebooks/CaseStudies/`) avec 5 noeuds :\n\n- Producteur `P1` (centrale solaire)\n- Producteur `P2` (eolien)\n- Noeud intermediaire `J1` (jonction)\n- Noeud intermediaire `J2` (jonction)\n- Client `C1` (quartier residentiel)\n\nAretes (avec capacite en MW) : `P1 -> J1 : 10`, `P1 -> J2 : 5`, `P2 -> J1 : 8`, `P2 -> J2 : 5`, `J1 -> C1 : 12`, `J2 -> C1 : 7`.\n\nLancez `EdmondsKarpMaximumFlowAlgorithm<string, STaggedEdge<string, double>>` entre `P1+P2` (super source) et `C1`. **Indice** : QuikGraph ne supporte pas directement une super-source ; ajoutez un sommet `S` relie a `P1` et `P2` avec capacites infinies (ou très grandes), puis appelez `algo.Compute(\"S\", \"C1\")`.\n\n> **Attention API** : comme en section 6, `EdmondsKarpMaximumFlowAlgorithm` exige que le graphe soit augmente de ses aretes residuelles **avant** `Compute`. Instanciez un `ReversedEdgeAugmentorAlgorithm`, appelez `AddReversedEdges()`, puis `Compute` (cf. section 6 pour le patron complet)."
+   ]
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
## Summary

**Section 6 (flot maximum) headline demo was silently broken.** Cell `43bbfd4d` threw `InvalidOperationException` (*"The graph has not been augmented yet. Call ReversedEdgeAugmentorAlgorithm.AddReversedEdges() before running this algorithm."*), which a surrounding `try/catch` swallowed — printing the exception text instead of the max-flow. The canonical Cormen 4-vertex network (S→A:10, S→B:5, A→T:8, B→T:10, A→B:3) **never had its max-flow computed**. The section's core claim was unsubstantiated: the engine it names (Edmonds-Karp) was never actually exercised.

### Fix (QuikGraph 2.5.0 idiomatic API)

```csharp
var augmentor = new ReversedEdgeAugmentorAlgorithm<string, STaggedEdge<string, double>>(flowGraph, creeAretesResiduelles);
augmentor.AddReversedEdges();   // ← the missing step the exception itself named
var maxFlowAlgo = new EdmondsKarpMaximumFlowAlgorithm<...>(flowGraph, e => e.Tag, creeAretesResiduelles, augmentor);
maxFlowAlgo.Compute("S", "T");
// ... MaxFlow ...
augmentor.RemoveReversedEdges();   // cleanup so residual edges don't pollute downstream cells
```

- Instantiate the augmentor **separately**, call `AddReversedEdges()` **before** constructing the algorithm (the step the swallowed exception itself named). Pass the pre-augmented augmentor.
- **Remove the `try/catch`** that masked the bug — the computation now runs clean.
- Cleanup via `RemoveReversedEdges()`.

### The computed value also CORRECTS a notebook error

Engine output: **`MaxFlow = 15.00`**. The notebook's prior hand-prediction was **"13"** — a hand-calc error. True value is **15** (max-flow/min-cut theorem):

- Min-cut `{S} | {A,B,T}` = S→A(10) + S→B(5) = **15**.
- Edge A→B lets A route its surplus to B→T: S→A(10) = A→T(8) + A→B(2); B receives S→B(5) + A→B(2) = 7 and pushes it to B→T (cap 10). Total into T = 8 + 7 = 15.

Comment updated with the min-cut justification. Exo 2 hint cell extended with the `AddReversedEdges()` API warning so students don't hit the same trap.

---

**Grain: MED/fix-execution — lane myia-po-2023:CoursIA — prev: DEEP/dotnet (A2 #7661)**

R6/variation-protocol (#7655, G-VAR-3 #7657): this is the deferred Section 6 fix explicitly split from #7659 (Section 7, heterogeneous Dijkstra terrain) — distinct notebook-section, same-family but genuinely independent defect. Tag TIER=MED (real engine execution recovered, not cosmetic), GENRE=fix-execution (differs from the A2 socle's dotnet/new-feature genre of the prior cycle).

## Validation (EXEC_PROVED, H.1)

| Check | Result |
|-------|--------|
| Full notebook end-to-end exec (jupyter nbconvert, `.net-csharp` kernel) | **0 errors** in any cell |
| Cell `43bbfd4d` output | matches committed output exactly — `Flot maximum S -> T : 15,00 / (Verification min-cut : {S} \| {A,B,T} = S->A(10) + S->B(5) = 15)` |
| `execution_count` | 9 (not null) |
| Path-leak scan on changed lines | CLEAN (0 machine path) |
| C.1 voluntary-error check (`raise NotImplementedError` / `assert False` / `1/0`) | NONE — `try/catch` removed (no swallowed exception) |
| Catalogue byte-identity | untouched (no catalog file in diff) |
| Hybrid rebuild (C.3) | only 2 cells changed: `43bbfd4d` (code) + `555705b6` (Exo 2 hint markdown); rest byte-identical to origin/main |
| Line endings | LF-only (0 CR) |
| Diff size | `1 file, +47/-22` — bounded, single subject (HARD 3) |

## Scope

One subject, one section (HARD 3): Section 6 max-flow only. Split from #7659 (Section 7 Dijkstra) per po-2025 finding — bundling forbidden.

See #3801.

🤖 Generated with [Claude Code](https://claude.com/claude-code)