### PR TITLE
feat(shared,#7265): A1+ provider hierarchy — Simple + Auto discovery, shared IProviderContainer

### DIFF
--- a/MyIA.AI.Shared.Tests/AutoProviderContainerTests.cs
+++ b/MyIA.AI.Shared.Tests/AutoProviderContainerTests.cs
@@ -1,0 +1,98 @@
+using MyIA.AI.ComponentModel.Entities;
+using MyIA.AI.ComponentModel.Providers;
+using Xunit;
+
+namespace MyIA.AI.Shared.Tests;
+
+/// <summary>
+/// Proves the A1+ convention-driven contract: types are discovered across an assembly and
+/// categorized by a caller-supplied rule (namespace/name shape) with NO decoration, while
+/// marker-interface buckets are still derived from the discovered types.
+/// </summary>
+public class AutoProviderContainerTests
+{
+    // Undecorated fixtures: no [MainCategory], so they prove the convention alone files them.
+    // Each implements a marker so the derived buckets are non-empty.
+    public sealed class LegacyGateway : ISimpleEntity { public string Name => "legacy-gw"; }
+    public sealed class LegacyRenderer : ISimpleEntity { public string Name => "legacy-rdr"; }
+    public sealed class LegacyNode : IChildEntity
+    {
+        public IChildEntity? Parent { get; set; }
+        public IReadOnlyList<IChildEntity> Children => Array.Empty<IChildEntity>();
+    }
+
+    // Convention: file by the trailing segment of the type name past "Legacy" (Gateway/Renderer/Node).
+    private static string? CategoryByNameTail(Type t) =>
+        t.Name.StartsWith("Legacy", StringComparison.Ordinal) && t.Name.Length > "Legacy".Length
+            ? t.Name["Legacy".Length..]
+            : null;
+
+    [Fact]
+    public void Convention_CategorizesUndecoratedTypes_WithoutMainCategoryAttribute()
+    {
+        var provider = AutoProviderContainer.FromAssembly<AutoProviderContainerTests>(CategoryByNameTail);
+
+        Assert.Contains(typeof(LegacyGateway), provider["Gateway"]);
+        Assert.Contains(typeof(LegacyRenderer), provider["Renderer"]);
+        Assert.Contains(typeof(LegacyNode), provider["Node"]);
+    }
+
+    [Fact]
+    public void Convention_ExcludesTypesTheRuleReturnsNullFor()
+    {
+        // PaymentGateway/ContentFolder/etc. don't start with "Legacy" -> convention yields null -> excluded.
+        var provider = AutoProviderContainer.FromAssembly<AutoProviderContainerTests>(CategoryByNameTail);
+
+        Assert.DoesNotContain(typeof(PaymentGateway), provider["Gateway"]);
+        Assert.Empty(provider["Payment"]);
+    }
+
+    [Fact]
+    public void Categories_ListsConventionGroups_InFirstSeenOrder()
+    {
+        var provider = AutoProviderContainer.FromAssembly<AutoProviderContainerTests>(CategoryByNameTail);
+
+        Assert.Contains("Gateway", provider.Categories);
+        Assert.Contains("Renderer", provider.Categories);
+        Assert.Contains("Node", provider.Categories);
+    }
+
+    [Fact]
+    public void MarkerBuckets_DerivedFromDiscoveredTypes()
+    {
+        var provider = AutoProviderContainer.FromAssembly<AutoProviderContainerTests>(CategoryByNameTail);
+
+        // The three Legacy fixtures all implement markers; the convention-discovered set flows
+        // into the same derived buckets as decoration-discovered types.
+        Assert.Contains(typeof(LegacyGateway), provider.SimpleEntities);
+        Assert.Contains(typeof(LegacyRenderer), provider.SimpleEntities);
+        Assert.Contains(typeof(LegacyNode), provider.ChildEntities);
+    }
+
+    [Fact]
+    public void Indexer_UnknownCategory_ReturnsEmpty_NoThrow()
+    {
+        var provider = AutoProviderContainer.FromAssembly<AutoProviderContainerTests>(CategoryByNameTail);
+
+        Assert.Empty(provider["DoesNotExist"]);
+    }
+
+    [Fact]
+    public void NamespaceConvention_AlsoWorks()
+    {
+        // A namespace-root convention is the other canonical shape: group by top namespace segment.
+        var provider = AutoProviderContainer.FromAssembly<AutoProviderContainerTests>(
+            t => t.Namespace?.Split('.').LastOrDefault());
+
+        // The test namespace's last segment is "Tests".
+        Assert.Contains("Tests", provider.Categories);
+        Assert.Contains(typeof(LegacyGateway), provider["Tests"]);
+    }
+
+    [Fact]
+    public void FromAssembly_NullConvention_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            AutoProviderContainer.FromAssembly<AutoProviderContainerTests>(null!));
+    }
+}

--- a/MyIA.AI.Shared.Tests/ProviderPolymorphismTests.cs
+++ b/MyIA.AI.Shared.Tests/ProviderPolymorphismTests.cs
@@ -1,0 +1,49 @@
+using MyIA.AI.ComponentModel.Providers;
+using Xunit;
+
+namespace MyIA.AI.Shared.Tests;
+
+/// <summary>
+/// Proves the three discovery strategies (decoration, explicit registration, convention)
+/// are interchangeable through the shared <see cref="IProviderContainer"/> read contract:
+/// a consumer can ask for types without coupling to how they were discovered.
+/// </summary>
+public class ProviderPolymorphismTests
+{
+    private static readonly Type[] FixtureTypes =
+    {
+        typeof(PaymentGateway),
+        typeof(ContentFolder),
+        typeof(ContentItem),
+    };
+
+    [Fact]
+    public void AllThreeStrategies_ImplementIProviderContainer()
+    {
+        IProviderContainer reflected = ReflectedProviderContainer.FromTypes(FixtureTypes);
+        IProviderContainer simple = new SimpleProviderContainer()
+            .Register<PaymentGateway>("Payment")
+            .Register<ContentFolder>("Content")
+            .Register<ContentItem>("Content");
+        IProviderContainer auto = AutoProviderContainer.FromTypes(
+            FixtureTypes,
+            t => t == typeof(PaymentGateway) ? "Payment" : "Content");
+
+        // Same fixture set, same read surface — the three are uniform regardless of strategy.
+        Assert.Single(reflected["Payment"]);
+        Assert.Single(simple["Payment"]);
+        Assert.Single(auto["Payment"]);
+
+        Assert.Contains(typeof(ContentFolder), reflected["Content"]);
+        Assert.Contains(typeof(ContentFolder), simple["Content"]);
+        Assert.Contains(typeof(ContentFolder), auto["Content"]);
+
+        // Marker buckets agree: each strategy files ContentItem as a mergeable child entity.
+        foreach (var container in new[] { reflected, simple, auto })
+        {
+            Assert.Contains(typeof(ContentItem), container.Mergeables);
+            Assert.Contains(typeof(ContentItem), container.ChildEntities);
+            Assert.Contains(typeof(ContentFolder), container.Containers);
+        }
+    }
+}

--- a/MyIA.AI.Shared.Tests/SimpleProviderContainerTests.cs
+++ b/MyIA.AI.Shared.Tests/SimpleProviderContainerTests.cs
@@ -1,0 +1,123 @@
+using MyIA.AI.ComponentModel.Providers;
+using Xunit;
+
+namespace MyIA.AI.Shared.Tests;
+
+/// <summary>
+/// Proves the A1+ flat-registration contract: types added by hand under a category key are
+/// exposed exactly like a decoration-discovered set, with marker-interface buckets derived
+/// from the registered types and no reflection on the source.
+/// </summary>
+public class SimpleProviderContainerTests
+{
+    [Fact]
+    public void Register_ExposesTypeUnderItsCategory()
+    {
+        var provider = new SimpleProviderContainer()
+            .Register<PaymentGateway>("Payment");
+
+        var payment = provider["Payment"];
+
+        Assert.Single(payment);
+        Assert.Equal(typeof(PaymentGateway), payment[0]);
+    }
+
+    [Fact]
+    public void Register_SameTypeUnderSeveralCategories_AppearsInEach()
+    {
+        // A flat container may file one type under several keys (decoration cannot: [MainCategory] is single).
+        var provider = new SimpleProviderContainer()
+            .Register<PaymentGateway>("Payment")
+            .Register<PaymentGateway>("Checkout");
+
+        Assert.Contains(typeof(PaymentGateway), provider["Payment"]);
+        Assert.Contains(typeof(PaymentGateway), provider["Checkout"]);
+    }
+
+    [Fact]
+    public void Register_DuplicateTypeUnderSameCategory_DoesNotDouble()
+    {
+        var provider = new SimpleProviderContainer()
+            .Register<PaymentGateway>("Payment")
+            .Register<PaymentGateway>("Payment");
+
+        Assert.Single(provider["Payment"]);
+    }
+
+    [Fact]
+    public void Categories_ListsRegisteredKeys_InRegistrationOrder()
+    {
+        var provider = new SimpleProviderContainer()
+            .Register<PaymentGateway>("Payment")
+            .Register<ContentFolder>("Content");
+
+        var categories = provider.Categories.ToArray();
+
+        Assert.Equal(new[] { "Payment", "Content" }, categories);
+    }
+
+    [Fact]
+    public void Indexer_UnknownCategory_ReturnsEmpty_NoThrow()
+    {
+        var provider = new SimpleProviderContainer().Register<PaymentGateway>("Payment");
+
+        Assert.Empty(provider["DoesNotExist"]);
+    }
+
+    [Fact]
+    public void MarkerBuckets_DerivedFromRegisteredTypes_EvenWithoutDecoration()
+    {
+        // PlainLeaf is undecorated but implements ISimpleEntity — registering it surfaces it
+        // in SimpleEntities exactly like ReflectedProviderContainer would.
+        var provider = new SimpleProviderContainer()
+            .Register<PlainLeaf>("Misc");
+
+        Assert.Contains(typeof(PlainLeaf), provider.SimpleEntities);
+        Assert.Contains(typeof(PlainLeaf), provider["Misc"]);
+    }
+
+    [Fact]
+    public void ContainersAndChildEntities_DerivedFromRegisteredHierarchyTypes()
+    {
+        var provider = new SimpleProviderContainer()
+            .Register<ContentFolder>("Content")
+            .Register<ContentItem>("Content");
+
+        // ContentFolder carries [AttributeContainer] + IChildEntity; ContentItem is IChildEntity + IMergeable.
+        Assert.Contains(typeof(ContentFolder), provider.Containers);
+        Assert.Contains(typeof(ContentFolder), provider.ChildEntities);
+        Assert.Contains(typeof(ContentItem), provider.ChildEntities);
+        Assert.Contains(typeof(ContentItem), provider.Mergeables);
+    }
+
+    [Fact]
+    public void EmptyContainer_ExposesNothing_WithoutThrowing()
+    {
+        var provider = new SimpleProviderContainer();
+
+        Assert.Empty(provider.Categories);
+        Assert.Empty(provider["Anything"]);
+        Assert.Empty(provider.SimpleEntities);
+    }
+
+    [Fact]
+    public void Register_RejectsWhitespaceCategory()
+    {
+        var provider = new SimpleProviderContainer();
+
+        Assert.Throws<ArgumentException>(() => provider.Register<PaymentGateway>("   "));
+    }
+
+    [Fact]
+    public void Register_AfterRead_InvalidatesCache_SoLaterTypeAppears()
+    {
+        // The lazy read-model is rebuilt on each mutation, so reads are always fresh.
+        var provider = new SimpleProviderContainer().Register<PaymentGateway>("Payment");
+        _ = provider.Categories; // force a build
+
+        provider.Register<ContentFolder>("Content");
+
+        Assert.Contains("Content", provider.Categories.ToArray());
+        Assert.Contains(typeof(ContentFolder), provider["Content"]);
+    }
+}

--- a/MyIA.AI.Shared/ComponentModel/Providers/AutoProviderContainer.cs
+++ b/MyIA.AI.Shared/ComponentModel/Providers/AutoProviderContainer.cs
@@ -1,0 +1,78 @@
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace MyIA.AI.ComponentModel.Providers;
+
+/// <summary>
+/// Convention-driven provider: discovers types across assemblies by a caller-supplied
+/// convention function rather than by decoration. This is the third strategy of the
+/// <c>Aricie.Shared</c> provider hierarchy (EPIC #7265, ancre A1+): where
+/// <see cref="ReflectedProviderContainer"/> needs <c>[MainCategory]</c> and
+/// <see cref="SimpleProviderContainer"/> needs explicit registration, this container
+/// categorizes from the type's own shape — namespace segment, name suffix, or any rule
+/// expressible as <c>Func&lt;Type, string?&gt;</c>. A convention returning <c>null</c>
+/// excludes the type. Marker-interface buckets are derived from the discovered types,
+/// keeping the read surface uniform across the three strategies.
+/// </summary>
+/// <remarks>
+/// Typical conventions: the last segment of the namespace
+/// (<c>t.Namespace?.Split('.').LastOrDefault()</c>), a name suffix (<c>t.Name.EndsWith("Gateway") ? "Payment" : null</c>),
+/// or an attribute other than <c>MainCategory</c>. The convention is opaque to the
+/// container: it only cares that a non-null string assigns the type to a category.
+/// </remarks>
+public sealed class AutoProviderContainer : IProviderContainer
+{
+    private readonly ProviderModel _model;
+
+    private AutoProviderContainer(ProviderModel model) => _model = model;
+
+    /// <summary>
+    /// Scans the assembly that declares <typeparamref name="TMarker"/>, categorizing each
+    /// public type via <paramref name="categoryByConvention"/>.
+    /// </summary>
+    public static AutoProviderContainer FromAssembly<TMarker>(Func<Type, string?> categoryByConvention)
+        => FromAssemblies(categoryByConvention, typeof(TMarker).Assembly);
+
+    /// <summary>
+    /// Scans <paramref name="assemblies"/>, categorizing each public type via
+    /// <paramref name="categoryByConvention"/> (null return = excluded).
+    /// </summary>
+    public static AutoProviderContainer FromAssemblies(
+        Func<Type, string?> categoryByConvention,
+        params Assembly[] assemblies)
+        => FromTypes(ProviderModel.GatherTypes(assemblies), categoryByConvention);
+
+    /// <summary>Builds a container from an explicit type set (test seam + controlled scope).</summary>
+    public static AutoProviderContainer FromTypes(
+        IEnumerable<Type> types,
+        Func<Type, string?> categoryByConvention)
+    {
+        ArgumentNullException.ThrowIfNull(categoryByConvention);
+
+        var model = ProviderModel.Build(
+            types,
+            type => categoryByConvention(type) is { } category && !string.IsNullOrWhiteSpace(category)
+                ? new[] { category }
+                : Array.Empty<string>());
+
+        return new AutoProviderContainer(model);
+    }
+
+    /// <summary>Categories assigned by the convention, in first-seen order.</summary>
+    public IEnumerable<string> Categories => _model.Categories;
+
+    /// <summary>Types the convention placed under <paramref name="category"/>, or empty if unknown.</summary>
+    public IReadOnlyList<Type> this[string category] => _model[category];
+
+    /// <summary>Discovered types marked with <c>AttributeContainerAttribute</c>.</summary>
+    public IReadOnlyList<Type> Containers => _model.Containers;
+
+    /// <summary>Discovered types implementing <c>IChildEntity</c>.</summary>
+    public IReadOnlyList<Type> ChildEntities => _model.ChildEntities;
+
+    /// <summary>Discovered types implementing <c>ISimpleEntity</c>.</summary>
+    public IReadOnlyList<Type> SimpleEntities => _model.SimpleEntities;
+
+    /// <summary>Discovered types implementing <c>IMergeable</c>.</summary>
+    public IReadOnlyList<Type> Mergeables => _model.Mergeables;
+}

--- a/MyIA.AI.Shared/ComponentModel/Providers/IProviderContainer.cs
+++ b/MyIA.AI.Shared/ComponentModel/Providers/IProviderContainer.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+
+namespace MyIA.AI.ComponentModel.Providers;
+
+/// <summary>
+/// Read surface shared by the <c>Aricie.Shared</c> provider hierarchy (EPIC #7265,
+/// ancre A1+). A container exposes the types it knows grouped by category and by the A1
+/// marker interfaces, regardless of <em>how</em> they were discovered: decoration for
+/// <see cref="ReflectedProviderContainer"/>, explicit registration for
+/// <see cref="SimpleProviderContainer"/>, naming/namespace convention for
+/// <see cref="AutoProviderContainer"/>. The three strategies are interchangeable through
+/// this contract so a consumer can ask for types without coupling to the discovery mode.
+/// </summary>
+public interface IProviderContainer
+{
+    /// <summary>Category names known to this container, in first-seen order.</summary>
+    IEnumerable<string> Categories { get; }
+
+    /// <summary>Types registered under <paramref name="category"/>, or empty if unknown.</summary>
+    IReadOnlyList<Type> this[string category] { get; }
+
+    /// <summary>Types marked with <c>AttributeContainerAttribute</c>.</summary>
+    IReadOnlyList<Type> Containers { get; }
+
+    /// <summary>Types implementing <c>IChildEntity</c> (hierarchical nodes).</summary>
+    IReadOnlyList<Type> ChildEntities { get; }
+
+    /// <summary>Types implementing <c>ISimpleEntity</c> (flat leaves).</summary>
+    IReadOnlyList<Type> SimpleEntities { get; }
+
+    /// <summary>Types implementing <c>IMergeable</c>.</summary>
+    IReadOnlyList<Type> Mergeables { get; }
+}

--- a/MyIA.AI.Shared/ComponentModel/Providers/ProviderModel.cs
+++ b/MyIA.AI.Shared/ComponentModel/Providers/ProviderModel.cs
@@ -1,0 +1,143 @@
+using System.Collections.Generic;
+using System.Reflection;
+using MyIA.AI.ComponentModel.Attributes;
+using MyIA.AI.ComponentModel.Entities;
+
+namespace MyIA.AI.ComponentModel.Providers;
+
+/// <summary>
+/// Shared read-model + classification for the provider hierarchy. Centralizes how a set
+/// of types is partitioned into categories / containers / marker-interface buckets so the
+/// three discovery strategies (decoration, explicit registration, naming convention) reuse
+/// one classifier instead of duplicating the reflection loop. Modernized port of
+/// <c>Aricie.Shared</c>'s shared provider indexing (EPIC #7265, ancre A1+).
+/// </summary>
+internal sealed class ProviderModel
+{
+    private readonly IReadOnlyDictionary<string, List<Type>> _byCategory;
+    private readonly List<Type> _containers;
+    private readonly List<Type> _childEntities;
+    private readonly List<Type> _simpleEntities;
+    private readonly List<Type> _mergeables;
+
+    private ProviderModel(
+        IReadOnlyDictionary<string, List<Type>> byCategory,
+        List<Type> containers,
+        List<Type> childEntities,
+        List<Type> simpleEntities,
+        List<Type> mergeables)
+    {
+        _byCategory = byCategory;
+        _containers = containers;
+        _childEntities = childEntities;
+        _simpleEntities = simpleEntities;
+        _mergeables = mergeables;
+    }
+
+    /// <summary>
+    /// Loads the public, non-system types declared in <paramref name="assemblies"/>,
+    /// tolerating unloadable types (a single broken type must not poison the container).
+    /// Shared by <see cref="ReflectedProviderContainer"/> and
+    /// <see cref="AutoProviderContainer"/> so assembly scanning is identical across both.
+    /// </summary>
+    public static List<Type> GatherTypes(params Assembly[] assemblies)
+    {
+        ArgumentNullException.ThrowIfNull(assemblies);
+
+        var types = new List<Type>();
+        foreach (var assembly in assemblies)
+        {
+            ArgumentNullException.ThrowIfNull(assembly);
+            Type[] declared;
+            try
+            {
+                declared = assembly.GetTypes();
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+                // Keep the types that did load; a single unloadable type must not poison the container.
+                declared = ex.Types.Where(t => t is not null).ToArray()!;
+            }
+
+            types.AddRange(declared.Where(t => t is { IsClass: true } || (t.IsInterface && !t.IsSpecialName)));
+        }
+
+        return types;
+    }
+
+    /// <summary>
+    /// Builds the read-model from a set of types, assigning each type to zero or more
+    /// categories via <paramref name="categoryFor"/>. Containers and marker-interface
+    /// buckets are always derived from the type itself (decoration + implemented
+    /// interfaces), independent of the discovery strategy — so a convention- or
+    /// registration-discovered <c>ISimpleEntity</c> lands in <see cref="SimpleEntities"/>
+    /// exactly like a decoration-discovered one.
+    /// </summary>
+    public static ProviderModel Build(IEnumerable<Type> types, Func<Type, IEnumerable<string>> categoryFor)
+    {
+        ArgumentNullException.ThrowIfNull(types);
+        ArgumentNullException.ThrowIfNull(categoryFor);
+
+        var byCategory = new Dictionary<string, List<Type>>(StringComparer.Ordinal);
+        var containers = new List<Type>();
+        var childEntities = new List<Type>();
+        var simpleEntities = new List<Type>();
+        var mergeables = new List<Type>();
+        var seenCategoryKeys = new HashSet<(Type Type, string Category)>();
+
+        foreach (var type in types)
+        {
+            ArgumentNullException.ThrowIfNull(type);
+
+            foreach (var category in categoryFor(type))
+            {
+                // A discovery strategy may yield the same (type, category) pair more than
+                // once (e.g. a type registered twice under the same key); keep one entry.
+                if (!seenCategoryKeys.Add((type, category)))
+                {
+                    continue;
+                }
+
+                if (!byCategory.TryGetValue(category, out var bucket))
+                {
+                    bucket = new List<Type>();
+                    byCategory[category] = bucket;
+                }
+
+                bucket.Add(type);
+            }
+
+            if (type.GetCustomAttribute<AttributeContainerAttribute>() is not null)
+            {
+                containers.Add(type);
+            }
+
+            if (typeof(IChildEntity).IsAssignableFrom(type) && type != typeof(IChildEntity))
+            {
+                childEntities.Add(type);
+            }
+
+            if (typeof(ISimpleEntity).IsAssignableFrom(type) && type != typeof(ISimpleEntity))
+            {
+                simpleEntities.Add(type);
+            }
+
+            if (typeof(IMergeable).IsAssignableFrom(type) && type != typeof(IMergeable))
+            {
+                mergeables.Add(type);
+            }
+        }
+
+        return new ProviderModel(byCategory, containers, childEntities, simpleEntities, mergeables);
+    }
+
+    public IEnumerable<string> Categories => _byCategory.Keys;
+
+    public IReadOnlyList<Type> this[string category] =>
+        _byCategory.TryGetValue(category, out var bucket) ? bucket : Array.Empty<Type>();
+
+    public IReadOnlyList<Type> Containers => _containers;
+    public IReadOnlyList<Type> ChildEntities => _childEntities;
+    public IReadOnlyList<Type> SimpleEntities => _simpleEntities;
+    public IReadOnlyList<Type> Mergeables => _mergeables;
+}

--- a/MyIA.AI.Shared/ComponentModel/Providers/ReflectedProviderContainer.cs
+++ b/MyIA.AI.Shared/ComponentModel/Providers/ReflectedProviderContainer.cs
@@ -1,6 +1,5 @@
 using System.Reflection;
 using MyIA.AI.ComponentModel.Attributes;
-using MyIA.AI.ComponentModel.Entities;
 
 namespace MyIA.AI.ComponentModel.Providers;
 
@@ -9,35 +8,21 @@ namespace MyIA.AI.ComponentModel.Providers;
 /// assemblies and exposes them for introspection. This is the metadata-driven
 /// decoration -> introspection bridge: decorate a class with
 /// <see cref="MainCategoryAttribute"/> / <see cref="AttributeContainerAttribute"/> or have
-/// it implement <see cref="IChildEntity"/> / <see cref="ISimpleEntity"/> / <see cref="IMergeable"/>,
-/// and the container surfaces it with no explicit registration.
+/// it implement <c>IChildEntity</c> / <c>ISimpleEntity</c> / <c>IMergeable</c>, and the
+/// container surfaces it with no explicit registration.
 /// </summary>
 /// <remarks>
-/// Minimal first anchor of <c>Aricie.Shared</c>'s provider family (EPIC #7265, ancre A1).
-/// <c>AutoProviderContainer</c> (assembly-scan conventions) and <c>SimpleProviderContainer</c>
-/// (flat lookup) are deferred to follow-up tranches.
+/// Decoration-driven discovery (this class) is one of three strategies in the
+/// <c>Aricie.Shared</c> provider hierarchy (EPIC #7265): <see cref="SimpleProviderContainer"/>
+/// (explicit flat registration) and <see cref="AutoProviderContainer"/> (naming/namespace
+/// convention scan) are the other two; all share the <see cref="IProviderContainer"/> read
+/// contract and the <see cref="ProviderModel"/> classifier.
 /// </remarks>
-public sealed class ReflectedProviderContainer
+public sealed class ReflectedProviderContainer : IProviderContainer
 {
-    private readonly IReadOnlyDictionary<string, List<Type>> _byCategory;
-    private readonly List<Type> _containers;
-    private readonly List<Type> _childEntities;
-    private readonly List<Type> _simpleEntities;
-    private readonly List<Type> _mergeables;
+    private readonly ProviderModel _model;
 
-    private ReflectedProviderContainer(
-        IReadOnlyDictionary<string, List<Type>> byCategory,
-        List<Type> containers,
-        List<Type> childEntities,
-        List<Type> simpleEntities,
-        List<Type> mergeables)
-    {
-        _byCategory = byCategory;
-        _containers = containers;
-        _childEntities = childEntities;
-        _simpleEntities = simpleEntities;
-        _mergeables = mergeables;
-    }
+    private ReflectedProviderContainer(ProviderModel model) => _model = model;
 
     /// <summary>Builds a container by scanning the assembly that declares <typeparamref name="TMarker"/>.</summary>
     public static ReflectedProviderContainer FromAssembly<TMarker>() =>
@@ -48,97 +33,40 @@ public sealed class ReflectedProviderContainer
         FromAssemblies(assembly);
 
     /// <summary>Builds a container by scanning several assemblies (union of their types).</summary>
-    public static ReflectedProviderContainer FromAssemblies(params Assembly[] assemblies)
-    {
-        ArgumentNullException.ThrowIfNull(assemblies);
-
-        var types = new List<Type>();
-        foreach (var assembly in assemblies)
-        {
-            ArgumentNullException.ThrowIfNull(assembly);
-            Type[] declared;
-            try
-            {
-                declared = assembly.GetTypes();
-            }
-            catch (ReflectionTypeLoadException ex)
-            {
-                // Keep the types that did load; a single unloadable type must not poison the container.
-                declared = ex.Types.Where(t => t is not null).ToArray()!;
-            }
-
-            types.AddRange(declared.Where(t => t is { IsClass: true } || (t.IsInterface && !t.IsSpecialName)));
-        }
-
-        return FromTypes(types);
-    }
+    public static ReflectedProviderContainer FromAssemblies(params Assembly[] assemblies) =>
+        FromTypes(ProviderModel.GatherTypes(assemblies));
 
     /// <summary>Builds a container from an explicit type set (test seam + controlled scope).</summary>
     public static ReflectedProviderContainer FromTypes(IEnumerable<Type> types)
     {
         ArgumentNullException.ThrowIfNull(types);
 
-        var byCategory = new Dictionary<string, List<Type>>(StringComparer.Ordinal);
-        var containers = new List<Type>();
-        var childEntities = new List<Type>();
-        var simpleEntities = new List<Type>();
-        var mergeables = new List<Type>();
+        // Category comes from the [MainCategory] decoration (0 or 1 per type); the marker
+        // buckets are filled by the shared classifier from the implemented interfaces.
+        var model = ProviderModel.Build(
+            types,
+            type => type.GetCustomAttribute<MainCategoryAttribute>() is { } category
+                ? new[] { category.Name }
+                : Array.Empty<string>());
 
-        foreach (var type in types)
-        {
-            ArgumentNullException.ThrowIfNull(type);
-
-            if (type.GetCustomAttribute<MainCategoryAttribute>() is { } category)
-            {
-                if (!byCategory.TryGetValue(category.Name, out var bucket))
-                {
-                    bucket = new List<Type>();
-                    byCategory[category.Name] = bucket;
-                }
-
-                bucket.Add(type);
-            }
-
-            if (type.GetCustomAttribute<AttributeContainerAttribute>() is not null)
-            {
-                containers.Add(type);
-            }
-
-            if (typeof(IChildEntity).IsAssignableFrom(type) && type != typeof(IChildEntity))
-            {
-                childEntities.Add(type);
-            }
-
-            if (typeof(ISimpleEntity).IsAssignableFrom(type) && type != typeof(ISimpleEntity))
-            {
-                simpleEntities.Add(type);
-            }
-
-            if (typeof(IMergeable).IsAssignableFrom(type) && type != typeof(IMergeable))
-            {
-                mergeables.Add(type);
-            }
-        }
-
-        return new ReflectedProviderContainer(byCategory, containers, childEntities, simpleEntities, mergeables);
+        return new ReflectedProviderContainer(model);
     }
 
     /// <summary>Categories discovered, in first-seen order.</summary>
-    public IEnumerable<string> Categories => _byCategory.Keys;
+    public IEnumerable<string> Categories => _model.Categories;
 
     /// <summary>Types registered under <paramref name="category"/>, or empty if unknown.</summary>
-    public IReadOnlyList<Type> this[string category] =>
-        _byCategory.TryGetValue(category, out var bucket) ? bucket : Array.Empty<Type>();
+    public IReadOnlyList<Type> this[string category] => _model[category];
 
     /// <summary>Types decorated with <see cref="AttributeContainerAttribute"/>.</summary>
-    public IReadOnlyList<Type> Containers => _containers;
+    public IReadOnlyList<Type> Containers => _model.Containers;
 
-    /// <summary>Types implementing <see cref="IChildEntity"/> (hierarchical nodes).</summary>
-    public IReadOnlyList<Type> ChildEntities => _childEntities;
+    /// <summary>Types implementing <c>IChildEntity</c> (hierarchical nodes).</summary>
+    public IReadOnlyList<Type> ChildEntities => _model.ChildEntities;
 
-    /// <summary>Types implementing <see cref="ISimpleEntity"/> (flat leaves).</summary>
-    public IReadOnlyList<Type> SimpleEntities => _simpleEntities;
+    /// <summary>Types implementing <c>ISimpleEntity</c> (flat leaves).</summary>
+    public IReadOnlyList<Type> SimpleEntities => _model.SimpleEntities;
 
-    /// <summary>Types implementing <see cref="IMergeable"/>.</summary>
-    public IReadOnlyList<Type> Mergeables => _mergeables;
+    /// <summary>Types implementing <c>IMergeable</c>.</summary>
+    public IReadOnlyList<Type> Mergeables => _model.Mergeables;
 }

--- a/MyIA.AI.Shared/ComponentModel/Providers/SimpleProviderContainer.cs
+++ b/MyIA.AI.Shared/ComponentModel/Providers/SimpleProviderContainer.cs
@@ -1,0 +1,92 @@
+using System.Collections.Generic;
+
+namespace MyIA.AI.ComponentModel.Providers;
+
+/// <summary>
+/// Flat, explicitly-registered provider: types are added by hand under a category key,
+/// with no reflection and no decoration required. This is the no-magic base of the
+/// <c>Aricie.Shared</c> provider hierarchy (EPIC #7265, ancre A1+): where
+/// <see cref="ReflectedProviderContainer"/> discovers by decoration and
+/// <see cref="AutoProviderContainer"/> by naming convention, this container discovers
+/// nothing — the caller states exactly what it holds. Marker-interface buckets
+/// (<see cref="IProviderContainer.SimpleEntities"/>, <see cref="IProviderContainer.ChildEntities"/>,
+/// <see cref="IProviderContainer.Mergeables"/>) are still derived from the registered types,
+/// so the read surface is uniform across the three strategies.
+/// </summary>
+/// <remarks>
+/// Registration is fluent and appendable; the read-model is rebuilt lazily and invalidated
+/// on each <see cref="Register"/>. The same type may be registered under several categories
+/// (it then appears in each) but only once per (type, category) pair.
+/// </remarks>
+public sealed class SimpleProviderContainer : IProviderContainer
+{
+    private readonly Dictionary<string, List<Type>> _byCategory = new(StringComparer.Ordinal);
+    private readonly HashSet<Type> _types = new();
+    private ProviderModel? _model;
+
+    /// <summary>Registers <typeparamref name="T"/> under <paramref name="category"/>.</summary>
+    public SimpleProviderContainer Register<T>(string category) where T : class
+        => Register(typeof(T), category);
+
+    /// <summary>Registers <paramref name="type"/> under <paramref name="category"/>.</summary>
+    public SimpleProviderContainer Register(Type type, string category)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+        if (string.IsNullOrWhiteSpace(category))
+        {
+            throw new ArgumentException(
+                "Category cannot be null, empty, or whitespace.", nameof(category));
+        }
+
+        if (!_byCategory.TryGetValue(category, out var bucket))
+        {
+            bucket = new List<Type>();
+            _byCategory[category] = bucket;
+        }
+
+        if (!bucket.Contains(type))
+        {
+            bucket.Add(type);
+        }
+
+        _types.Add(type);
+        _model = null; // invalidate the cached read-model
+        return this;
+    }
+
+    private ProviderModel Model
+    {
+        get
+        {
+            if (_model is null)
+            {
+                // A type's categories = the keys under which it was registered (0..N).
+                _model = ProviderModel.Build(
+                    _types,
+                    type => _byCategory
+                        .Where(kv => kv.Value.Contains(type))
+                        .Select(kv => kv.Key));
+            }
+
+            return _model;
+        }
+    }
+
+    /// <summary>Categories registered, in first-seen order.</summary>
+    public IEnumerable<string> Categories => Model.Categories;
+
+    /// <summary>Types registered under <paramref name="category"/>, or empty if unknown.</summary>
+    public IReadOnlyList<Type> this[string category] => Model[category];
+
+    /// <summary>Types marked with <c>AttributeContainerAttribute</c> among the registered set.</summary>
+    public IReadOnlyList<Type> Containers => Model.Containers;
+
+    /// <summary>Registered types implementing <c>IChildEntity</c>.</summary>
+    public IReadOnlyList<Type> ChildEntities => Model.ChildEntities;
+
+    /// <summary>Registered types implementing <c>ISimpleEntity</c>.</summary>
+    public IReadOnlyList<Type> SimpleEntities => Model.SimpleEntities;
+
+    /// <summary>Registered types implementing <c>IMergeable</c>.</summary>
+    public IReadOnlyList<Type> Mergeables => Model.Mergeables;
+}

--- a/MyIA.AI.Shared/README.md
+++ b/MyIA.AI.Shared/README.md
@@ -54,10 +54,45 @@ Solution `MyIA.AI.Shared.sln` (socle-only : lib + tests) pour un build/test isol
 sans tirer `MyIA.AI.Notebooks`. La solution racine `MyIA.CoursIA.sln` référence déjà
 le projet lib.
 
+## A1+ — Hiérarchie de providers : 3 stratégies de découverte (#7265)
+
+Complément de l'ancre A1. Pose les deux autres stratégies de découverte de la famille de
+providers `Aricie.Shared`, afin que `ReflectedProviderContainer` (décoration) ne soit plus
+seul : `SimpleProviderContainer` (enregistrement explicite plat) et `AutoProviderContainer`
+(convention de nommage/namespace). Les trois partagent le contrat de lecture
+`IProviderContainer` et le classifieur `ProviderModel` — un consommateur demande des types
+sans se coupler au mode de découverte.
+
+| Type | Rôle |
+|------|------|
+| `ComponentModel.Providers.IProviderContainer` | Contrat de lecture commun (catégories, `Containers`, `ChildEntities`, `SimpleEntities`, `Mergeables`). |
+| `ComponentModel.Providers.ProviderModel` | Classifieur partagé (internal) : répartit un set de types en catégories + buckets marqueurs, tolérant aux types non chargeables. |
+| `ComponentModel.Providers.SimpleProviderContainer` | Découverte par **enregistrement explicite** : `Register<T>("cat")` (aucune réflexion, aucune décoration). Un type peut être filé sous plusieurs catégories. |
+| `ComponentModel.Providers.AutoProviderContainer` | Découverte par **convention** : `Func<Type, string?>` (suffixe de nom, segment de namespace…). `null` exclut le type. |
+
+### Contrat 3 stratégies, 1 surface de lecture
+
+```csharp
+using MyIA.AI.ComponentModel.Providers;
+
+// Décoration (A1) — un attribut suffit.
+IProviderContainer reflected = ReflectedProviderContainer.FromAssembly<PaymentGateway>();
+
+// Enregistrement explicite (A1+) — aucun attribut requis.
+IProviderContainer simple = new SimpleProviderContainer()
+    .Register<PaymentGateway>("Payment")
+    .Register<ContentFolder>("Content");
+
+// Convention (A1+) — règle de nommage, zéro attribut.
+IProviderContainer auto = AutoProviderContainer.FromAssembly<PaymentGateway>(
+    t => t.Name.EndsWith("Gateway") ? "Payment" : null);
+
+// Même surface de lecture quel que soit le mode.
+reflected["Payment"]; simple["Payment"]; auto["Payment"];
+```
+
 ## Tranches suivantes (hors cette ancre)
 
-- **A1+** : providers `AutoProviderContainer` (conventions de scan) et
-  `SimpleProviderContainer` (lookup plat).
 - **A2** — Sérialisation légo (XML/JSON décoration-driven) :
   `XmlAwareContractResolver`, `DynamicSurrogate`, collections sérialisables.
 - **A3** — Object explorer UI : `AdvancedGridView`, `PropertyEditor`, filtres.


### PR DESCRIPTION
## Summary

Completes the `Aricie.Shared` provider family that A1 ([ReflectedProviderContainer](https://github.com/jsboige/CoursIA/blob/main/MyIA.AI.Shared/ComponentModel/Providers/ReflectedProviderContainer.cs), #7653) started. Three discovery strategies now share **one read contract** and **one classifier**:

| Strategy | Class | Discovery |
|----------|-------|-----------|
| Decoration (A1, #7653) | `ReflectedProviderContainer` | `[MainCategory]` / `[AttributeContainer]` / marker interfaces |
| **Explicit registration (A1+)** | `SimpleProviderContainer` | `Register<T>("cat")` — no reflection, no decoration |
| **Convention (A1+)** | `AutoProviderContainer` | `Func<Type, string?>` (name suffix / namespace) — no `[MainCategory]` |

### New types

- **`IProviderContainer`** — common read surface (`Categories`, `this[category]`, `Containers`, `ChildEntities`, `SimpleEntities`, `Mergeables`). A consumer asks for types without coupling to how they were discovered.
- **`SimpleProviderContainer`** — flat explicit registration. One type may be filed under several categories; read-model built lazily and invalidated on each `Register`.
- **`AutoProviderContainer`** — convention scan (`FromAssembly<TMarker>(Func<Type,string?>)`). `null` return excludes the type.
- **`ProviderModel`** (internal) — shared classifier + assembly-type gatherer. Used by all three so `IChildEntity`/`ISimpleEntity`/`IMergeable`/`AttributeContainer` classification is byte-identical across strategies.

### Contract — 3 strategies, 1 read surface

```csharp
IProviderContainer reflected = ReflectedProviderContainer.FromAssembly<PaymentGateway>();     // decoration
IProviderContainer simple    = new SimpleProviderContainer().Register<PaymentGateway>("Pay"); // explicit
IProviderContainer auto      = AutoProviderContainer.FromAssembly<PaymentGateway>(            // convention
    t => t.Name.EndsWith("Gateway") ? "Payment" : null);
reflected["Payment"]; simple["Pay"]; auto["Payment"];   // uniform
```

## Anti-regression note (ReflectedProviderContainer refactor)

This PR touches merged A1 code: `ReflectedProviderContainer` shows **−101/+29** on the file. This is a logic **move, not a deletion**: the 101-line inline classification loop + private fields/ctor were relocated into the shared `ProviderModel`; the class now delegates to `ProviderModel.Build` with a `categoryFor` lambda and implements `IProviderContainer`. Per [anti-regression.md](.claude/rules/anti-regression.md) protocol:
1. **No behavior change**: the 12 unchanged A1 tests ([ReflectedProviderContainerTests](MyIA.AI.Shared.Tests/ReflectedProviderContainerTests.cs)) pass green post-refactor — they pin the exact membership/order semantics.
2. **3 adaptation attempts**: the classification was (a) kept inline-duplicated, (b) extracted as a shared helper (chosen), (c) considered as a base class (rejected — composition over inheritance).
3. **Diff coherent**: PR net is strongly additive (+4 new types, +3 test files); the single-file −101 is the relocated logic now living in `ProviderModel.cs`.

## Validation (EXEC_PROVED, H.1 — code, not notebook)

| Check | Result |
|-------|--------|
| `dotnet build MyIA.AI.Shared.sln -c Release` | **0 warning, 0 error** |
| `dotnet test MyIA.AI.Shared.sln -c Release` | **30/30 passed** (12 A1 regression + 10 Simple + 7 Auto + 1 polymorphism) |
| Reflected refactor regression | 12 A1 tests green — behavior identical |
| Line endings | LF-only (matches repo convention; `od -c` confirmed `\n`) |
| Path-leak scan | CLEAN |
| Catalogue byte-identity | untouched (no catalog file in diff) |
| New NuGet deps | none |
| Diff scope | 1 subject (A1+ provider hierarchy), 9 files |

## Scope

Bounded to A1+ (provider discovery). A2 (serialization lego, #7661 pending) and A3 (object explorer UI, not yet steered) remain separate tranches.

**Grain: DEEP/dotnet — lane myia-po-2023:CoursIA — prev: MED/fix-execution (Search-16 #7667)**

Note for ai-01 (diversity): this is a 4th consecutive .NET-family cycle. The non-.NET substance pool was firsthand-exhausted this cycle — Python = po-2025 saturated (c.599), Lean = po-2026 turf, ICT = argumentation-gated (directive 20/07), QC = Docker-gated, GenAI-figures = vision-gated (GLM has no vision, model-delegation mandate), GenAI-#4433 = user-GO-gated (user asleep). Per ratified variation-protocol (#7655/#7657), G-VAR-1 DEEP/MED plancher ✓ and G-VAR-2/G-VAR-3 are LIGHT-only (N/A here). A routed non-.NET grain or an A3 steer next cycle would restore family diversity.

See #7265.

🤖 Generated with [Claude Code](https://claude.com/claude-code)