### PR TITLE
fix(iit,#3801): IIT-1 §6.1 actual causation — discriminating demo (XOR α-saturation was degenerate)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb
+++ b/MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb
@@ -1279,13 +1279,9 @@
    "source": [
     "### Interpretation : liens causaux de la transition (1,1,1) vers (0,0,0)\n",
     "\n",
-    "L'analyse revele **10 liens causaux irreductibles** pour cette transition, tous avec une force alpha = 1.0 (sauf le lien global a 2.0). On distingue :\n",
+    "L'analyse revele **10 liens causaux irreductibles**, tous avec une force **alpha = 1.0**. Cette saturation uniforme n'est PAS le signe d'une \"structure riche\" : elle reflete au contraire une **limite du reseau XOR pour la causalite evenementielle**. Le reseau XOR est **deterministe** (chaque noeud = XOR exact de ses deux voisins), donc toute transition valide est parfaitement determinee — chaque mecanisme cause son purview avec la force maximale alpha = 1.0, sans aucune nuance.\n",
     "\n",
-    "- **Causes** (fleches vers la gauche) : chaque noeud individuel (A, B, C) est une cause irreductible pour les deux autres noeuds. Les paires {A,B}, {A,C}, {B,C} causent l'ensemble {A,B,C}.\n",
-    "- **Effets** (fleches vers la droite) : de maniere symetrique, chaque paire produit un effet sur le noeud restant.\n",
-    "- Le lien **{A,B,C} vers {A,B,C}** avec alpha = 2.0 represente l'effet global integre du système sur lui-même.\n",
-    "\n",
-    "Cette symetrie est typique du reseau XOR : chaque noeud depend des deux autres de maniere equivalente, ce qui produit une structure causale riche et fortement integree."
+    "En d'autres termes : sur un reseau deterministe, la causalite evenementielle **ne discrimine pas** — elle attribue la meme force maximale a tous les liens. Pour voir `pyphi.actual` exercer sa capacite distinctive (distinguer les causes fortes des causes faibles), il faut un reseau **probabiliste**, dont les transitions ne sont pas parfaitement determinees. C'est l'objet de la cellule suivante.\n"
    ]
   },
   {
@@ -1362,6 +1358,102 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 6.1bis Causalite evenementielle sur un reseau probabiliste (discrimination)\n",
+    "\n",
+    "Pour voir la causalite evenementielle **discriminer** entre liens forts et faibles, nous construisons un reseau **noisy-AND** : meme connectivite que le XOR (anneau complet a 3 noeuds A, B, C), mais chaque porte AND est bruitee — la transition n'est plus deterministe. La probabilite qu'un noeud s'allume vaut `p` si ses deux entrees sont allumees, sinon une petite probabilite de bruit. Avec `p = 0.9`, certains mecanismes causent leur purview de maniere forte (alpha eleve) et d'autres de maniere faible (alpha faible) : la machinerie `pyphi.actual` peut alors **distinguer les vraies causes des causes marginales**, ce qu'elle ne pouvait pas faire sur le reseau XOR sature.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Transition (1, 1, 0) -> (0, 1, 1) sur le reseau noisy-AND (p=0.9)\n",
+      "Nombre de liens causaux : 9\n",
+      "CausalLink\n",
+      "  α = 0.3653  [C] ◀━━ [A]\n",
+      "CausalLink\n",
+      "  α = 0.8556  [A] ◀━━ [B]\n",
+      "CausalLink\n",
+      "  α = 0.922  [A, B] ◀━━ [C]\n",
+      "CausalLink\n",
+      "  α = 0.3832  [A, B, C] ◀━━ [A, C]\n",
+      "CausalLink\n",
+      "  α = 0.1285  [A, B] ◀━━ [B, C]\n",
+      "CausalLink\n",
+      "  α = 0.8556  [A] ━━▶ [B, C]\n",
+      "CausalLink\n",
+      "  α = 0.8556  [B] ━━▶ [C]\n",
+      "CausalLink\n",
+      "  α = 0.3653  [C] ━━▶ [A]\n",
+      "CausalLink\n",
+      "  α = 0.922  [A, B] ━━▶ [C]\n",
+      "\n",
+      "Force alpha : min=0.128, max=0.922, valeurs distinctes=[0.128, 0.365, 0.383, 0.856, 0.922]\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "import pyphi.actual\n",
+    "\n",
+    "pyphi.config.VALIDATE_SUBSYSTEM_STATES = False\n",
+    "\n",
+    "# Reseau noisy-AND : porte AND bruitee (p=0.9 si les 2 entrees sont ON, sinon bruit).\n",
+    "# Meme connectivite que le XOR (anneau complet), mais TPM NON deterministe.\n",
+    "def noisy_and_tpm(p=0.9):\n",
+    "    tpm = np.zeros((2, 2, 2, 3))\n",
+    "    for a in (0, 1):\n",
+    "        for b in (0, 1):\n",
+    "            for c in (0, 1):\n",
+    "                for ni, inp in enumerate([(b, c), (a, c), (a, b)]):\n",
+    "                    tpm[a, b, c, ni] = p if (inp[0] == 1 and inp[1] == 1) else (1 - p) * 0.5\n",
+    "    return tpm\n",
+    "\n",
+    "p = 0.9\n",
+    "tpm_noisy = noisy_and_tpm(p)\n",
+    "cm_noisy = np.array([[0, 1, 1], [1, 0, 1], [1, 1, 0]])\n",
+    "reseau_noisy = pyphi.Network(tpm_noisy, cm=cm_noisy, node_labels=(\"A\", \"B\", \"C\"))\n",
+    "\n",
+    "# Une transition ou les contributions causales different d'un noeud a l'autre.\n",
+    "avant = (1, 1, 0)\n",
+    "apres = (0, 1, 1)\n",
+    "transition_noisy = pyphi.actual.Transition(\n",
+    "    reseau_noisy, avant, apres, cause_indices=(0, 1, 2), effect_indices=(0, 1, 2)\n",
+    ")\n",
+    "compte_noisy = pyphi.actual.account(transition_noisy)\n",
+    "\n",
+    "print(f\"Transition {avant} -> {apres} sur le reseau noisy-AND (p={p})\")\n",
+    "print(f\"Nombre de liens causaux : {len(compte_noisy)}\")\n",
+    "alphas = [round(float(lien.alpha), 3) for lien in compte_noisy]\n",
+    "for lien in compte_noisy:\n",
+    "    print(lien)\n",
+    "print()\n",
+    "print(f\"Force alpha : min={min(alphas)}, max={max(alphas)}, valeurs distinctes={sorted(set(alphas))}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Interpretation : la causalite evenementielle discrimine\n",
+    "\n",
+    "Contrairement au reseau XOR (ou alpha = 1.0 pour tous les liens), le reseau probabiliste produit des **forces alpha variees** — ici de l'ordre de 0.13 a 0.92. La causalite evenementielle exerce enfin sa capacite distinctive :\n",
+    "\n",
+    "- **Liens forts** (alpha eleve, ~0.92) : mecanismes qui determinent leur purview de maniere fiable dans cette transition — les \"vraies\" causes evenementielles.\n",
+    "- **Liens faibles** (alpha bas, ~0.13) : mecanismes dont la contribution causale est marginale, noyee dans le bruit du reseau.\n",
+    "\n",
+    "Cette discrimination est la raison d'etre de `pyphi.actual` : quantifier **qui a cause quoi** avec une nuance graduee, ce qu'un reseau deterministe (XOR) masque en saturant toutes les forces a la valeur maximale. C'est l'analogue, en causalite evenementielle, du constat deja fait en section 4 sur les etats inaccessibles : la richesse du calcul emergent depend de la structure probabiliste du reseau, pas seulement de sa connectivite.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "ad58565a",
    "metadata": {
     "papermill": {
@@ -1417,7 +1509,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "53ad8dc0",
    "metadata": {
     "execution": {


### PR DESCRIPTION
## Summary

IIT-1 §6.1 (Actual Causation) demonstrated `pyphi.actual` on the canonical XOR network, transition (1,1,1)→(0,0,0). **G.1 firsthand verification proved this is a Prong-B degenerate case**: the XOR network is deterministic, so **all 10 causal links saturate at α = 1.0**. Actual causation analysis *cannot discriminate* on a deterministic network — it assigns the same maximal strength to every link. The notebook's interpretation framed this saturation as a *"rich, highly integrated causal structure"*, which is the opposite of the truth: it is a degenerate case where the machinery's distinctive capacity (distinguishing strong from weak causes) is masked. Same linear-degeneracy family as the IIT-2 S6 finding.

### Root cause (verified empirically, pyphi 1.2.0)

| Network | α across causal links | Discriminates? |
|---------|----------------------|----------------|
| XOR (deterministic TPM) | **1.0 for ALL links** on every valid transition | ❌ No (saturated) |
| Noisy-AND probabilistic (same 3-node ring) | **[0.128, 0.365, 0.383, 0.856, 0.922]** (5 distinct) | ✅ Yes |

### Fix (RECOVERABLE-LOCAL → SOTA-OK; pyphi installed + runs locally, rule F honored)

1. **Corrected cell 25 interpretation** — honestly frames α=1.0-for-all as a degenerate saturation (deterministic TPM), not "rich structure". Notes the machinery cannot discriminate here and routes to the new demo.
2. **Inserted §6.1bis** (markdown + code + markdown):
   - Builds a **noisy-AND probabilistic network** (p=0.9, same connectivity as XOR).
   - Computes `pyphi.actual` on transition (1,1,0)→(0,1,1) → prints 9 causal links with **varying α (0.128 to 0.922)**.
   - Interpretation contrasts strong causes (high α) vs marginal ones (low α) — the discriminative power actual causation is built for, invisible on the saturated XOR net.

```
Transition (1, 1, 0) -> (0, 1, 1) sur le reseau noisy-AND (p=0.9)
Nombre de liens causaux : 9
CausalLink  α = 0.922  [A, B] ◀━━ [C]      <- strong cause
...
CausalLink  α = 0.1285 [A, B] ◀━━ [B, C]   <- marginal cause
Force alpha : min=0.128, max=0.922, valeurs distinctes=[0.128, 0.365, 0.383, 0.856, 0.922]
```

## Validation (EXEC_PROVED, H.1)

| Check | Result |
|-------|--------|
| Full notebook end-to-end exec (jupyter nbconvert, python3 kernel, pyphi 1.2.0) | **0 errors**, only numpy-2.4 deprecation warnings |
| Cell 28 output | REAL pyphi output — 9 links, α range 0.128-0.922, 5 distinct values, exec_count=13 |
| C.1 voluntary-error check (`raise NotImplementedError` / `assert False` / `1/0`) | **0 violations** |
| Path-leak scan on changed content | CLEAN |
| Catalogue byte-identity | untouched (no catalog file in diff) |
| Hybrid rebuild (C.3) | cells 0-26 byte-identical to origin/main except cell 25 (intended source change); last-exercise cell exec_count bumped 13→14 for sequence coherence |
| Diff scope | 1 file, +99/-7, §6.1 only (HARD 3 bounded) |

## Scope

One subject, one section (HARD 3): IIT-1 §6.1 actual causation discrimination. Does NOT touch §1-5 (Φ/CES, already SOTA-OK: Φ=1.875) or §6.2 (macro-subsystems). Distinct from po-2026's active IIT-2 S6 claim (different notebook, different section — no collision).

**Grain: MED/python-notebook — lane myia-po-2023:CoursIA — prev: DEEP/dotnet (A1+ #7669)**

R6 rotation honored: 4 consecutive .NET cycles → Python/IIT (base PyPhi compute family, NOT the ICT argumentation strata which is gated per directive 20/07). Per ratified variation-protocol (#7655/#7657): G-VAR-1 DEEP/MED plancher ✓; G-VAR-2/G-VAR-3 are LIGHT-only (N/A here). Note for ai-01: this corrects my own c.744 claim that "non-.NET is exhausted" — po-2026's IIT-2 S6 work proved the IIT base family has genuine Prong-B defects, and I found a distinct one in IIT-1 §6.1.

See #3801.

🤖 Generated with [Claude Code](https://claude.com/claude-code)