### PR TITLE
fix(search): CSP-8-Temporal Exercice 2b/3b uncompletable (stray-return short-circuit)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-8-Temporal-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-8-Temporal-Csharp.ipynb
@@ -1311,56 +1311,6 @@
      "text": [
       "Exercice 2b a completer\r\n"
      ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(18,5): warning CS0162: Code inaccessible détecté\r\n",
-      "\r\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<details open=\"open\" class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[  ]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Count</td><td><div class=\"dni-plaintext\"><pre>0</pre></div></td></tr><tr><td>Comparer</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>System.Collections.Generic.EnumEqualityComparer`1[Submission#3+AllenRelation]</code></span></summary><div><table><thead><tr></tr></thead><tbody></tbody></table></div></details></td></tr><tr><td><i>(values)</i></td><td><i>(empty)</i></td></tr></tbody></table></div></details><style>\r\n",
-       ".dni-code-hint {\r\n",
-       "    font-style: italic;\r\n",
-       "    overflow: hidden;\r\n",
-       "    white-space: nowrap;\r\n",
-       "}\r\n",
-       ".dni-treeview {\r\n",
-       "    white-space: nowrap;\r\n",
-       "}\r\n",
-       ".dni-treeview td {\r\n",
-       "    vertical-align: top;\r\n",
-       "    text-align: start;\r\n",
-       "}\r\n",
-       "details.dni-treeview {\r\n",
-       "    padding-left: 1em;\r\n",
-       "}\r\n",
-       "table td {\r\n",
-       "    text-align: start;\r\n",
-       "}\r\n",
-       "table tr { \r\n",
-       "    vertical-align: top; \r\n",
-       "    margin: 0em 0px;\r\n",
-       "}\r\n",
-       "table tr td pre \r\n",
-       "{ \r\n",
-       "    vertical-align: top !important; \r\n",
-       "    margin: 0em 0px !important;\r\n",
-       "} \r\n",
-       "table th {\r\n",
-       "    text-align: start;\r\n",
-       "}\r\n",
-       "</style>"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -1379,18 +1329,22 @@
     "try\n",
     "{\n",
     "    if (stpAvecB == null || stpSansB == null)\n",
-    "        Console.WriteLine(\"Exercice 2b a completer\"); return new HashSet<AllenRelation>();;\n",
+    "    {\n",
+    "        Console.WriteLine(\"Exercice 2b a completer\");\n",
+    "    }\n",
+    "    else\n",
+    "    {\n",
+    "        var (okA, solA) = stpAvecB.Solve();\n",
+    "        var (okS, solS) = stpSansB.Solve();\n",
     "\n",
-    "    var (okA, solA) = stpAvecB.Solve();\n",
-    "    var (okS, solS) = stpSansB.Solve();\n",
-    "\n",
-    "    if (okA) Console.WriteLine($\"Avec B : duree = {solA[\"end\"] - solA[\"start\"]:F2}h\");\n",
-    "    if (okS) Console.WriteLine($\"Sans B : duree = {solS[\"end\"] - solS[\"start\"]:F2}h\");\n",
+    "        if (okA) Console.WriteLine($\"Avec B : duree = {solA[\"end\"] - solA[\"start\"]:F2}h\");\n",
+    "        if (okS) Console.WriteLine($\"Sans B : duree = {solS[\"end\"] - solS[\"start\"]:F2}h\");\n",
+    "    }\n",
     "}\n",
     "catch (Exception ex)\n",
     "{\n",
     "    Console.WriteLine($\"Exercice non complete : {ex.Message}\");\n",
-    "}\n"
+    "}"
    ]
   },
   {
@@ -1562,56 +1516,6 @@
      "text": [
       "Exercice 3b a completer\r\n"
      ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(12,5): warning CS0162: Code inaccessible détecté\r\n",
-      "\r\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<details open=\"open\" class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[  ]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Count</td><td><div class=\"dni-plaintext\"><pre>0</pre></div></td></tr><tr><td>Comparer</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>System.Collections.Generic.EnumEqualityComparer`1[Submission#3+AllenRelation]</code></span></summary><div><table><thead><tr></tr></thead><tbody></tbody></table></div></details></td></tr><tr><td><i>(values)</i></td><td><i>(empty)</i></td></tr></tbody></table></div></details><style>\r\n",
-       ".dni-code-hint {\r\n",
-       "    font-style: italic;\r\n",
-       "    overflow: hidden;\r\n",
-       "    white-space: nowrap;\r\n",
-       "}\r\n",
-       ".dni-treeview {\r\n",
-       "    white-space: nowrap;\r\n",
-       "}\r\n",
-       ".dni-treeview td {\r\n",
-       "    vertical-align: top;\r\n",
-       "    text-align: start;\r\n",
-       "}\r\n",
-       "details.dni-treeview {\r\n",
-       "    padding-left: 1em;\r\n",
-       "}\r\n",
-       "table td {\r\n",
-       "    text-align: start;\r\n",
-       "}\r\n",
-       "table tr { \r\n",
-       "    vertical-align: top; \r\n",
-       "    margin: 0em 0px;\r\n",
-       "}\r\n",
-       "table tr td pre \r\n",
-       "{ \r\n",
-       "    vertical-align: top !important; \r\n",
-       "    margin: 0em 0px !important;\r\n",
-       "} \r\n",
-       "table th {\r\n",
-       "    text-align: start;\r\n",
-       "}\r\n",
-       "</style>"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -1625,20 +1529,26 @@
     "// Puis resoudre et afficher le planning.\n",
     "try\n",
     "{\n",
-    "    if (stpCours == null) Console.WriteLine(\"Exercice 3b a completer\"); return new HashSet<AllenRelation>();;\n",
-    "    var (ok, sol) = stpCours.Solve();\n",
-    "    if (ok)\n",
+    "    if (stpCours == null)\n",
     "    {\n",
-    "        Console.WriteLine(\"=== Planification cours ===\");\n",
-    "        foreach (var kv in sol.OrderBy(x => x.Value))\n",
-    "            Console.WriteLine($\"  {kv.Key,-10} : {kv.Value,5:F2}h\");\n",
+    "        Console.WriteLine(\"Exercice 3b a completer\");\n",
     "    }\n",
-    "    else Console.WriteLine(\"Pas de solution admissible.\");\n",
+    "    else\n",
+    "    {\n",
+    "        var (ok, sol) = stpCours.Solve();\n",
+    "        if (ok)\n",
+    "        {\n",
+    "            Console.WriteLine(\"=== Planification cours ===\");\n",
+    "            foreach (var kv in sol.OrderBy(x => x.Value))\n",
+    "                Console.WriteLine($\"  {kv.Key,-10} : {kv.Value,5:F2}h\");\n",
+    "        }\n",
+    "        else Console.WriteLine(\"Pas de solution admissible.\");\n",
+    "    }\n",
     "}\n",
     "catch (Exception ex)\n",
     "{\n",
     "    Console.WriteLine($\"Exercice non complete : {ex.Message}\");\n",
-    "}\n"
+    "}"
    ]
   },
   {


### PR DESCRIPTION
## Context

Firsthand scan of my partition (.NET Search/CSP) for execution defects in the `#7667` vein (real bugs, not A-series socle). **CSP-8-Temporal-Csharp.ipynb** Exercice 2b (cell 30) and 3b (cell 34) were **uncompletable**: a stray top-level `return new HashSet<AllenRelation>();;` short-circuited each cell.

## Defect

Both exercise cells (recycled from Allen Exercice 1b stubs in #474) carried:
```csharp
if (stpAvecB == null || stpSansB == null)
    Console.WriteLine("Exercice 2b a completer"); return new HashSet<AllenRelation>();;
```
The `if` has **no braces**, so the `return` is **unconditional** — it aborts the cell before the student's `Solve()` code. Three consequences:
1. **Exercises uncompletable** — the Solve block (where the student works) is unreachable.
2. **CS0162 warning** `(18,5): warning CS0162: Code inaccessible détecté` in stderr.
3. **Bogus output** — the top-level `return` of an empty `HashSet<AllenRelation>` was rendered by .NET Interactive as a ~50-line `dni-treeview` HTML dump (`Count=0`, `Comparer=EnumEqualityComparer...`) leaking into the student's exercise output.

The `return new HashSet<AllenRelation>()` is also a wrong-type copy-paste (this is a temporal-problem exercise, not Allen relations).

## Fix

Restructure to a proper `if/else`. The null-stub state prints `Exercice Nb a completer` cleanly (C.1-compliant, no error, no NotImplementedError) and the exercise becomes completable: the student instantiates the STP variables above, and the `else` branch runs `Solve()`.

```csharp
if (stpAvecB == null || stpSansB == null)
{
    Console.WriteLine("Exercice 2b a completer");
}
else
{
    var (okA, solA) = stpAvecB.Solve();
    ...
}
```

## Validation (H.1 — exec proved)

- **Full .NET (C#) kernel re-execution** via `jupyter nbconvert --execute --kernel=.net-csharp` (timeout 420s): **16/16 code cells executed, 0 errors**.
- Cells 30/34 outputs reduced **3 → 1**: CS0162 warning + bogus HTML dump removed; remaining output is the clean `Exercice Nb a completer` stdout.
- `execution_count` preserved (12, 14).
- **C.3**: only cells 30/34 differ from `origin/main`; all other cells byte-identical (verified cell-by-cell). `origin/main` is `indent=1`-serialized; identity re-dump = 0 diff.
- Notebooks committed **WITH outputs** (C.2). No `NotImplementedException`/`assert False`/`1/0` introduced (C.1).

## Scope

1 file, 25+/115- (the 115 deletions are the removed warning + bogus HTML dump + unreachable code). One notebook, one defect-type (stray-return in 2 sibling exercise cells) — atomique (HARD 3).

Grain: **TIER MED / GENRE dotnet-fix-execution** — lane `myia-po-2023:CoursIA` — prev: MED/python (IIT-1 actual causation c.745). Bug-fix genre (not A-series socle, not monothematic wave).

See #4956 (Search .NET twins marathon).