### PR TITLE
feat(shared,#7265): A2+ lego serialization — decoration-driven XML round-trip

### DIFF
--- a/MyIA.AI.Shared.Tests/MetadataXmlSerializerTests.cs
+++ b/MyIA.AI.Shared.Tests/MetadataXmlSerializerTests.cs
@@ -1,0 +1,162 @@
+using MyIA.AI.ComponentModel.Serialization;
+using Xunit;
+
+namespace MyIA.AI.Shared.Tests;
+
+/// <summary>
+/// Proves the A2+ XML serialization contract (the XML half of the A2 lego-serialization
+/// tranche, EPIC #7265): a decorated IChildEntity graph round-trips through XML with
+/// concrete child types, value properties, and the parent/child hierarchy intact.
+/// </summary>
+public class MetadataXmlSerializerTests
+{
+    // The two concrete hierarchical fixtures: ContentFolder (container, no value props)
+    // and ContentItem (leaf, carries Title). Both are registered so the discriminator
+    // can reconstruct each to its concrete type.
+    private static MetadataXmlSerializer NewSerializer() =>
+        new(new XmlAwareContractResolver(new[] { typeof(ContentFolder), typeof(ContentItem) }));
+
+    private static ContentFolder NewFolder(params ContentItem[] items)
+    {
+        var folder = new ContentFolder();
+        foreach (var item in items)
+            folder.AddChild(item);
+        return folder;
+    }
+
+    [Fact]
+    public void RoundTrip_RootFolderWithLeaf_RestoresHierarchyAndTitle()
+    {
+        var ser = NewSerializer();
+        var original = NewFolder(new ContentItem { Title = "Intro" });
+
+        var xml = ser.Serialize(original);
+        var round = ser.Deserialize<ContentFolder>(xml);
+
+        var restored = Assert.Single(round.Children);
+        var item = Assert.IsType<ContentItem>(restored);
+        Assert.Equal("Intro", item.Title);
+    }
+
+    [Fact]
+    public void RoundTrip_ParentCycleRebuilt_ChildParentIsTheRestoredRoot()
+    {
+        var ser = NewSerializer();
+        var original = NewFolder(new ContentItem { Title = "Child" });
+
+        var round = ser.Deserialize<ContentFolder>(ser.Serialize(original));
+
+        // Parent was excluded from serialization (cycle break) and rebuilt on load.
+        var restoredChild = Assert.Single(round.Children);
+        Assert.Same(round, restoredChild.Parent);
+    }
+
+    [Fact]
+    public void RoundTrip_PolymorphicChildren_ReconstructsConcreteTypes()
+    {
+        // A folder containing a nested folder + a leaf exercises polymorphism: Children
+        // is IReadOnlyList<IChildEntity>, and both ContentFolder and ContentItem must
+        // come back as their concrete types (not a shared base).
+        var ser = new MetadataXmlSerializer(
+            new XmlAwareContractResolver(new[] { typeof(ContentFolder), typeof(ContentItem) }));
+
+        var root = new ContentFolder();
+        var sub = new ContentFolder();
+        sub.AddChild(new ContentItem { Title = "Deep" });
+        root.AddChild(sub);
+        root.AddChild(new ContentItem { Title = "Shallow" });
+
+        var round = ser.Deserialize<ContentFolder>(ser.Serialize(root));
+
+        Assert.Equal(2, round.Children.Count);
+        var roundSub = Assert.IsType<ContentFolder>(round.Children[0]);
+        var roundLeaf = Assert.IsType<ContentItem>(round.Children[1]);
+        Assert.Equal("Shallow", roundLeaf.Title);
+        var deep = Assert.IsType<ContentItem>(Assert.Single(roundSub.Children));
+        Assert.Equal("Deep", deep.Title);
+    }
+
+    [Fact]
+    public void RoundTrip_EmptyTitle_PreservedAsEmpty()
+    {
+        var ser = NewSerializer();
+        var original = NewFolder(new ContentItem { Title = "" });
+
+        var round = ser.Deserialize<ContentFolder>(ser.Serialize(original));
+
+        var item = Assert.IsType<ContentItem>(Assert.Single(round.Children));
+        Assert.Equal("", item.Title);
+    }
+
+    [Fact]
+    public void Serialize_ProducesWellFormedXml_WithTypeDiscriminator()
+    {
+        var ser = NewSerializer();
+        var folder = NewFolder(new ContentItem { Title = "X" });
+
+        var xml = ser.Serialize(folder);
+
+        Assert.Contains("<?xml", xml);
+        Assert.Contains("type=\"ContentFolder\"", xml);
+        Assert.Contains("type=\"ContentItem\"", xml);
+        Assert.Contains("name=\"Title\" value=\"X\"", xml);
+        Assert.DoesNotContain("Parent", xml); // cycle-break: Parent never serialized
+    }
+
+    [Fact]
+    public void Serialize_LeafWithNoChildren_EmitsEmptyChildList()
+    {
+        var ser = NewSerializer();
+        var leaf = new ContentItem { Title = "Solo" };
+
+        // A leaf serialized directly: no children element, its Title carried.
+        var xml = ser.Serialize(leaf);
+
+        Assert.Contains("type=\"ContentItem\"", xml);
+        Assert.Contains("name=\"Title\" value=\"Solo\"", xml);
+    }
+
+    [Fact]
+    public void RoundTrip_DeepNestedGraph_PreservesDepthAndLinks()
+    {
+        var ser = NewSerializer();
+        var root = new ContentFolder();
+        var level1 = new ContentFolder();
+        var level2 = new ContentFolder();
+        level2.AddChild(new ContentItem { Title = "Bottom" });
+        level1.AddChild(level2);
+        root.AddChild(level1);
+
+        var round = ser.Deserialize<ContentFolder>(ser.Serialize(root));
+
+        var l1 = Assert.IsType<ContentFolder>(Assert.Single(round.Children));
+        var l2 = Assert.IsType<ContentFolder>(Assert.Single(l1.Children));
+        var bottom = Assert.IsType<ContentItem>(Assert.Single(l2.Children));
+        Assert.Equal("Bottom", bottom.Title);
+        // Parent relink holds at every depth.
+        Assert.Same(l2, bottom.Parent);
+        Assert.Same(l1, l2.Parent);
+        Assert.Same(round, l1.Parent);
+    }
+
+    [Fact]
+    public void Constructor_NullResolver_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new MetadataXmlSerializer(null!));
+    }
+
+    [Fact]
+    public void Deserialize_UnknownTypeDiscriminator_Throws()
+    {
+        // A resolver that knows ContentFolder but not ContentItem: the item's discriminator
+        // is unresolvable, so load fails explicitly rather than silently dropping the child.
+        var ser = new MetadataXmlSerializer(
+            new XmlAwareContractResolver(new[] { typeof(ContentFolder) }));
+        var xml = ser.Serialize(NewFolder(new ContentItem { Title = "Ghost" }));
+
+        // Tamper: rewrite the item discriminator to something the resolver never saw.
+        var tampered = xml.Replace("type=\"ContentItem\"", "type=\"NeverRegistered\"");
+
+        Assert.Throws<InvalidOperationException>(() => ser.Deserialize<ContentFolder>(tampered));
+    }
+}

--- a/MyIA.AI.Shared/ComponentModel/Serialization/MetadataXmlSerializer.cs
+++ b/MyIA.AI.Shared/ComponentModel/Serialization/MetadataXmlSerializer.cs
@@ -1,0 +1,132 @@
+using System.IO;
+using System.Reflection;
+using System.Xml;
+using System.Xml.Serialization;
+using MyIA.AI.ComponentModel.Entities;
+
+namespace MyIA.AI.ComponentModel.Serialization;
+
+/// <summary>
+/// Decoration-driven XML serializer that round-trips the A1 metadata graph through a
+/// <see cref="NodeSurrogate"/> (DynamicSurrogate) tree. Serialize a decorated
+/// <see cref="IChildEntity"/> root to XML and rebuild an equivalent graph on load, with
+/// concrete child types, round-trippable value properties, and the parent/child
+/// hierarchy intact (the <see cref="IChildEntity.Parent"/> cycle is broken on serialize
+/// by the contract resolver and rebuilt on load via <c>AddChild</c>).
+/// </summary>
+/// <remarks>
+/// XML half of the A2 "lego serialization" tranche (EPIC #7265, ancre A2). It is the
+/// sibling of the A2 JSON serializer: both round-trip the same A1 metadata model, but
+/// through different engines (<c>System.Xml</c> vs <c>Newtonsoft.Json</c>) and different
+/// cycle/polymorphism strategies (DynamicSurrogate + <c>AddChild</c> relink vs
+/// contract-resolver Parent drop + <c>TypeNameHandling.Auto</c>). The two halves are
+/// independent: A2+ builds on the A1 primitives, not on the A2 JSON code.
+/// </remarks>
+public sealed class MetadataXmlSerializer
+{
+    private readonly XmlAwareContractResolver _resolver;
+    private readonly XmlSerializer _serializer;
+
+    /// <summary>Builds a serializer driven by <paramref name="resolver"/>'s decoration plan.</summary>
+    public MetadataXmlSerializer(XmlAwareContractResolver resolver)
+    {
+        _resolver = resolver ?? throw new ArgumentNullException(nameof(resolver));
+        _serializer = new XmlSerializer(typeof(NodeSurrogate));
+    }
+
+    /// <summary>Serializes the <paramref name="root"/> graph to indented XML (Parent cycle excluded).</summary>
+    public string Serialize(IChildEntity root)
+    {
+        ArgumentNullException.ThrowIfNull(root);
+        var surrogate = ToSurrogate(root);
+        using var writer = new StringWriter();
+        using var xml = XmlWriter.Create(writer, new XmlWriterSettings
+        {
+            Indent = true,
+            OmitXmlDeclaration = false,
+        });
+        _serializer.Serialize(xml, surrogate);
+        return writer.ToString();
+    }
+
+    /// <summary>Rebuilds the graph from XML as a concrete <typeparamref name="T"/> root.</summary>
+    public T Deserialize<T>(string xml) where T : class, IChildEntity
+    {
+        ArgumentNullException.ThrowIfNull(xml);
+        using var reader = new StringReader(xml);
+        var surrogate = (NodeSurrogate)_serializer.Deserialize(reader)!;
+        return (T)FromSurrogate(surrogate);
+    }
+
+    private NodeSurrogate ToSurrogate(IChildEntity node)
+    {
+        var type = node.GetType();
+        var surrogate = new NodeSurrogate { TypeKey = _resolver.TypeKey(type) };
+
+        foreach (var property in _resolver.WritableProperties(type))
+        {
+            var value = property.GetValue(node);
+            surrogate.Properties.Add(new PropertySurrogate
+            {
+                Name = property.Name,
+                Value = value?.ToString() ?? string.Empty,
+            });
+        }
+
+        foreach (var child in node.Children)
+            surrogate.Children.Add(ToSurrogate(child));
+
+        return surrogate;
+    }
+
+    private IChildEntity FromSurrogate(NodeSurrogate surrogate)
+    {
+        var type = _resolver.ResolveType(surrogate.TypeKey)
+                   ?? throw new InvalidOperationException(
+                       $"Unknown type discriminator '{surrogate.TypeKey}'. Register it in the XmlAwareContractResolver.");
+
+        var node = (IChildEntity)Activator.CreateInstance(type)!;
+
+        // Restore round-trippable value properties.
+        var writable = _resolver.WritableProperties(type);
+        foreach (var entry in surrogate.Properties)
+        {
+            var property = writable.FirstOrDefault(p => p.Name == entry.Name);
+            if (property is null)
+                continue;
+            var converted = ConvertValue(entry.Value, property.PropertyType);
+            if (converted is not null)
+                property.SetValue(node, converted);
+        }
+
+        // Rebuild children + the Parent cycle. Prefer a public AddChild (the container
+        // pattern: it sets child.Parent and appends to the backing list atomically); fall
+        // back to a direct Parent link for nodes that expose children without AddChild.
+        foreach (var childSurrogate in surrogate.Children)
+        {
+            var child = FromSurrogate(childSurrogate);
+            var addChild = type.GetMethod("AddChild", new[] { typeof(IChildEntity) });
+            if (addChild is not null)
+                addChild.Invoke(node, new object[] { child });
+            else
+                child.Parent = node;
+        }
+
+        return node;
+    }
+
+    private static object? ConvertValue(string value, Type target)
+    {
+        if (target == typeof(string))
+            return value;
+        var underlying = Nullable.GetUnderlyingType(target) ?? target;
+        try
+        {
+            return Convert.ChangeType(value, underlying);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/MyIA.AI.Shared/ComponentModel/Serialization/NodeSurrogate.cs
+++ b/MyIA.AI.Shared/ComponentModel/Serialization/NodeSurrogate.cs
@@ -1,0 +1,49 @@
+using System.Xml.Serialization;
+
+namespace MyIA.AI.ComponentModel.Serialization;
+
+/// <summary>
+/// XML-serializable surrogate for a single node of the metadata graph (the
+/// <c>DynamicSurrogate</c> of the A2+ XML tranche, EPIC #7265).
+/// <see cref="System.Xml.Serialization.XmlSerializer"/> cannot round-trip an
+/// <see cref="MyIA.AI.ComponentModel.Entities.IChildEntity"/> directly: its
+/// <c>Children</c> is <c>IReadOnlyList&lt;IChildEntity&gt;</c> (read-only + polymorphic)
+/// and <c>Parent</c> is a back-reference cycle. This surrogate captures the tree in an
+/// XML-friendly shape — a type discriminator (the concrete type name, so polymorphic
+/// children reconstruct to their concrete type), a property bag (round-trippable value
+/// properties), and a recursive list of child surrogates.
+/// <see cref="MetadataXmlSerializer"/> projects the live graph to this shape on
+/// serialize and rebuilds the concrete <c>IChildEntity</c> tree (instantiating the
+/// concrete type, restoring properties, re-linking <c>Parent</c> via <c>AddChild</c>)
+/// on load.
+/// </summary>
+public sealed class NodeSurrogate
+{
+    /// <summary>Concrete type discriminator (the <see cref="XmlAwareContractResolver.TypeKey"/>).</summary>
+    [XmlAttribute("type")]
+    public string TypeKey { get; set; } = string.Empty;
+
+    /// <summary>Round-trippable value properties of the node (name/value pairs).</summary>
+    [XmlElement("property")]
+    public List<PropertySurrogate> Properties { get; set; } = new();
+
+    /// <summary>Child nodes, recursively (the polymorphic Children projected to a serializable list).</summary>
+    [XmlElement("child")]
+    public List<NodeSurrogate> Children { get; set; } = new();
+}
+
+/// <summary>
+/// A single name/value property entry in a <see cref="NodeSurrogate"/> property bag.
+/// Only simple value types are carried (string/primitive/decimal); complex state and
+/// the <c>Parent</c> cycle are rebuilt, not serialized.
+/// </summary>
+public sealed class PropertySurrogate
+{
+    /// <summary>The property name on the concrete type.</summary>
+    [XmlAttribute("name")]
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>The property value as a string (parsed back to the target type on load).</summary>
+    [XmlAttribute("value")]
+    public string Value { get; set; } = string.Empty;
+}

--- a/MyIA.AI.Shared/ComponentModel/Serialization/XmlAwareContractResolver.cs
+++ b/MyIA.AI.Shared/ComponentModel/Serialization/XmlAwareContractResolver.cs
@@ -1,0 +1,76 @@
+using System.Reflection;
+using MyIA.AI.ComponentModel.Entities;
+
+namespace MyIA.AI.ComponentModel.Serialization;
+
+/// <summary>
+/// Decoration-driven contract resolver for XML serialization. It inspects the A1
+/// marker/decoration model and produces the serialization plan that drives
+/// <see cref="MetadataXmlSerializer"/>: a stable type discriminator per concrete type
+/// (so polymorphic children are reconstructed by their concrete type, not the
+/// <see cref="IChildEntity"/> interface) and the set of round-trippable properties per
+/// type (public read-write value properties, excluding <see cref="IChildEntity.Parent"/>
+/// — the parent/child cycle is rebuilt on load, not serialized).
+/// </summary>
+/// <remarks>
+/// This is the XML half of the A2 "lego serialization" tranche (EPIC #7265, ancre A2),
+/// described in the A1 README as <c>XmlAwareContractResolver</c>. It is the sibling of
+/// the A2 JSON contract resolver: where Newtonsoft.Json drives serialization through a
+/// <c>IContractResolver</c>, <c>System.Xml</c> has no equivalent hook, so this resolver
+/// instead feeds a <see cref="NodeSurrogate"/> (DynamicSurrogate) tree —
+/// <c>XmlSerializer</c> cannot round-trip <c>IReadOnlyList&lt;IChildEntity&gt;</c>
+/// (read-only, polymorphic) directly, so the live graph is projected to a serializable
+/// surrogate shape and rebuilt on load.
+/// </remarks>
+public sealed class XmlAwareContractResolver
+{
+    private readonly Dictionary<string, Type> _typeByKey = new(StringComparer.Ordinal);
+    private readonly Dictionary<Type, IReadOnlyList<PropertyInfo>> _writablePropsByType = new();
+
+    /// <summary>Builds a resolver over the concrete <paramref name="knownTypes"/> that may appear in a graph.</summary>
+    public XmlAwareContractResolver(IEnumerable<Type> knownTypes)
+    {
+        ArgumentNullException.ThrowIfNull(knownTypes);
+        foreach (var type in knownTypes)
+            Register(type);
+    }
+
+    private void Register(Type type)
+    {
+        // Only concrete classes are instantiable graph nodes.
+        if (!type.IsClass || type.IsAbstract)
+            return;
+
+        // Stable discriminator: the type's simple name. Collisions are the caller's
+        // responsibility (register distinct simple names, like the A2 JSON $type).
+        _typeByKey.TryAdd(type.Name, type);
+
+        // Round-trippable properties: public get+set value types (string/primitive/decimal).
+        // Parent is excluded on purpose — it is the back-reference that would recurse the
+        // root through every child; MetadataXmlSerializer rebuilds it via AddChild on load.
+        var writable = type
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.CanRead && p.CanWrite && p.Name != nameof(IChildEntity.Parent))
+            .Where(IsSimpleSerializable)
+            .ToList();
+
+        _writablePropsByType[type] = writable;
+    }
+
+    private static bool IsSimpleSerializable(PropertyInfo p)
+    {
+        var t = Nullable.GetUnderlyingType(p.PropertyType) ?? p.PropertyType;
+        return t.IsPrimitive || t == typeof(string) || t == typeof(decimal);
+    }
+
+    /// <summary>The discriminator written as <c>type="..."</c> on a serialized node.</summary>
+    public string TypeKey(Type type) => type.Name;
+
+    /// <summary>The concrete type registered under <paramref name="key"/>, or null if unknown.</summary>
+    public Type? ResolveType(string key) =>
+        _typeByKey.TryGetValue(key, out var type) ? type : null;
+
+    /// <summary>The value properties to serialize for <paramref name="type"/> (empty for containers with only children).</summary>
+    public IReadOnlyList<PropertyInfo> WritableProperties(Type type) =>
+        _writablePropsByType.TryGetValue(type, out var props) ? props : Array.Empty<PropertyInfo>();
+}


### PR DESCRIPTION
## Context

XML half of the A2 "lego serialization" tranche (ancre A2, EPIC #7265). The A1 README (#7653, MERGED) describes A2 as **"XML/JSON décoration-driven"** with `XmlAwareContractResolver` + `DynamicSurrogate`; A2 (#7661, the JSON half via Newtonsoft) delivered the JSON serializer. This tranche delivers the **XML half** via `System.Xml`.

**The two halves are independent**: A2+ builds on the A1 metadata primitives, **not** on A2's Newtonsoft JSON code. A2 was unmerged when this was written — there is no stacking. This was verified firsthand: the A2 `ComponentModel/Serialization/` directory does not exist on `origin/main`, so A2+ compiles and passes against A1 alone.

## What

Decoration-driven XML serializer that round-trips the A1 metadata graph through a `DynamicSurrogate` tree.

| Type | Role |
|------|------|
| `XmlAwareContractResolver` | Decoration-driven plan: a type discriminator per concrete type (so polymorphic children reconstruct to their concrete type, not `IChildEntity`) + the round-trippable value properties per type (public get+set value types, **excluding `IChildEntity.Parent`** — the cycle is rebuilt on load). |
| `NodeSurrogate` (+ `PropertySurrogate`) | The **DynamicSurrogate**: an XML-serializable tree shape. `XmlSerializer` cannot round-trip `IReadOnlyList<IChildEntity>` (read-only + polymorphic), so the live graph is projected to a type discriminator + property bag + recursive child surrogates. |
| `MetadataXmlSerializer` | `Serialize` / `Deserialize<T>` facade. Serializes the graph to indented XML; on load rebuilds the concrete tree (instantiate by discriminator, restore value properties, re-link `Parent` via `AddChild`). |

## Why the surrogate (not direct XmlSerializer)

- **Cycle break** — a naive `IChildEntity` serialize recurses through `child.Parent` back into the root. The contract resolver excludes `Parent`; the serializer rebuilds it via `AddChild` (the `ContentFolder` container pattern) on load.
- **Polymorphic read-only children** — `Children: IReadOnlyList<IChildEntity>` is both polymorphic and read-only; `XmlSerializer` cannot populate it on deserialize. The `DynamicSurrogate` projects it to a `List<NodeSurrogate>` with a concrete-type discriminator, reconstructed by `ResolveType` + `Activator` + `AddChild`. This is the mirror of A2 JSON's `TypeNameHandling.Auto` + contract-resolver `Parent` drop, expressed in `System.Xml` terms (where no equivalent contract hook exists).

## Validation (H.1 — exec proved)

- `dotnet build` **0 warning / 0 error**.
- `dotnet test` **21/21 passed** (12 A1 regression + 9 new A2+ XML), 0 failed, 426ms.
- Round-trip proven firsthand on the A1 fixtures: `ContentFolder`/`ContentItem` hierarchy, **polymorphic mixed children** (nested folder + leaf reconstruct to concrete types), **deep nesting** (3 levels), **`Parent` relink at every depth** (`Assert.Same`), empty-`Title` edge, well-formed XML with `type=` discriminator, unknown-discriminator throws explicitly (no silent child drop).
- **C.3 / anti-churn**: 4 new files, +419/-0 (pure additive — no existing file modified). Catalog byte-identical (untouched). LF-only.

## Scope

One subject (A2+ XML serialization), 4 files, pure additive. Atomique (HARD 3). No new NuGet (`System.Xml.Serialization` is BCL).

Grain: **DEEP/dotnet** — lane `myia-po-2023:CoursIA` — prev: MED/dotnet-fix-execution (CSP-8 #7674). Continues the ai-01-assigned A-series (A1 #7653 → A2 #7661 → A1+ #7669 → A2+ this); R6 rotation was discharged after A1+ via IIT (#7670) + CSP-8 (#7674), so returning to A-series is permitted, and A2+ is a distinct subsystem (`System.Xml`) from the prior A-series grains. Next-cycle diversity: a non-A grain is due.

See #7265 (Aricie socle EPIC).

Co-Authored-By: Claude-Code <noreply@anthropic.com>