### PR TITLE
fix(qc,#7575): triage 9 PREEXISTING_UNEXEC quantbooks — dedicated marker + tool class (distinct from #6891)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/BTC-ML/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/BTC-ML/quantbook.ipynb
@@ -39,6 +39,27 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<!-- QC-UNEXEC-TRIAGED issue=#7575 -->\n",
+    "\n",
+    "> **Cellules non executees -- bug-class #7575 (DISTINCT de #6891).**\n",
+    ">\n",
+    "> Ce notebook contient **8 cellule(s) code sur 11** qui n'ont\n",
+    "> **jamais ete executees** (`execution_count: null`, `outputs: []`). Ce ne sont\n",
+    "> **pas** des sorties fabriquees ni stripees (scope #6891) : l'execution n'a\n",
+    "> simplement jamais eu lieu -- un bug-class separé, tracked dans l'issue #7575.\n",
+    ">\n",
+    "> **Re-exec gated** sur QC Cloud (kernel research `QuantBook`). **Statut config : NO-CONFIG** (pas de `config.json` / cloud-id). Re-exec IMPOSSIBLE tant que le projet n'est pas deploye sur QC Cloud (RECOVERABLE-USER-HAND : creation du projet QC + cloud-id requise au prealable).\n",
+    ">\n",
+    "> En attendant, ce markdown signale honnetement l'etat (Stop & Repair,\n",
+    "> secrets-hygiene 6 + sota-not-workaround Prong-A) -- **ne jamais fabriquer**\n",
+    "> de sorties pour combler."
+   ],
+   "id": "qc-unexec-triaged-btc-ml"
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "cell-1",

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Crypto-MultiCanal/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Crypto-MultiCanal/quantbook.ipynb
@@ -35,6 +35,26 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<!-- QC-UNEXEC-TRIAGED issue=#7575 -->\n",
+    "\n",
+    "> **Cellules non executees -- bug-class #7575 (DISTINCT de #6891).**\n",
+    ">\n",
+    "> Ce notebook contient **8 cellule(s) code sur 10** qui n'ont\n",
+    "> **jamais ete executees** (`execution_count: null`, `outputs: []`). Ce ne sont\n",
+    "> **pas** des sorties fabriquees ni stripees (scope #6891) : l'execution n'a\n",
+    "> simplement jamais eu lieu -- un bug-class separé, tracked dans l'issue #7575.\n",
+    ">\n",
+    "> **Re-exec gated** sur QC Cloud (kernel research `QuantBook`). **Statut config : ALIVE** (cloud-id 30750734). Re-exec *ready* des que l'acces QC Cloud est restaure (RECOVERABLE-MACHINE) -- le projet existe deja sur QC Cloud, il suffit de relancer le kernel research.\n",
+    ">\n",
+    "> En attendant, ce markdown signale honnetement l'etat (Stop & Repair,\n",
+    "> secrets-hygiene 6 + sota-not-workaround Prong-A) -- **ne jamais fabriquer**\n",
+    "> de sorties pour combler."
+   ]
+  },
+  {
    "cell_id": "cell-1",
    "cell_type": "code",
    "execution_count": 1,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/DL-LSTM/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/DL-LSTM/quantbook.ipynb
@@ -30,6 +30,26 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<!-- QC-UNEXEC-TRIAGED issue=#7575 -->\n",
+    "\n",
+    "> **Cellules non executees -- bug-class #7575 (DISTINCT de #6891).**\n",
+    ">\n",
+    "> Ce notebook contient **2 cellule(s) code sur 12** qui n'ont\n",
+    "> **jamais ete executees** (`execution_count: null`, `outputs: []`). Ce ne sont\n",
+    "> **pas** des sorties fabriquees ni stripees (scope #6891) : l'execution n'a\n",
+    "> simplement jamais eu lieu -- un bug-class separé, tracked dans l'issue #7575.\n",
+    ">\n",
+    "> **Re-exec gated** sur QC Cloud (kernel research `QuantBook`). **Statut config : NO-CONFIG** (pas de `config.json` / cloud-id). Re-exec IMPOSSIBLE tant que le projet n'est pas deploye sur QC Cloud (RECOVERABLE-USER-HAND : creation du projet QC + cloud-id requise au prealable).\n",
+    ">\n",
+    "> En attendant, ce markdown signale honnetement l'etat (Stop & Repair,\n",
+    "> secrets-hygiene 6 + sota-not-workaround Prong-A) -- **ne jamais fabriquer**\n",
+    "> de sorties pour combler."
+   ]
+  },
+  {
    "cell_id": "cell-1",
    "cell_type": "code",
    "execution_count": 1,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-DeepLearning/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-DeepLearning/quantbook.ipynb
@@ -26,6 +26,26 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<!-- QC-UNEXEC-TRIAGED issue=#7575 -->\n",
+    "\n",
+    "> **Cellules non executees -- bug-class #7575 (DISTINCT de #6891).**\n",
+    ">\n",
+    "> Ce notebook contient **2 cellule(s) code sur 12** qui n'ont\n",
+    "> **jamais ete executees** (`execution_count: null`, `outputs: []`). Ce ne sont\n",
+    "> **pas** des sorties fabriquees ni stripees (scope #6891) : l'execution n'a\n",
+    "> simplement jamais eu lieu -- un bug-class separé, tracked dans l'issue #7575.\n",
+    ">\n",
+    "> **Re-exec gated** sur QC Cloud (kernel research `QuantBook`). **Statut config : NO-CONFIG** (pas de `config.json` / cloud-id). Re-exec IMPOSSIBLE tant que le projet n'est pas deploye sur QC Cloud (RECOVERABLE-USER-HAND : creation du projet QC + cloud-id requise au prealable).\n",
+    ">\n",
+    "> En attendant, ce markdown signale honnetement l'etat (Stop & Repair,\n",
+    "> secrets-hygiene 6 + sota-not-workaround Prong-A) -- **ne jamais fabriquer**\n",
+    "> de sorties pour combler."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-TextClassification/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-TextClassification/quantbook.ipynb
@@ -26,6 +26,26 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<!-- QC-UNEXEC-TRIAGED issue=#7575 -->\n",
+    "\n",
+    "> **Cellules non executees -- bug-class #7575 (DISTINCT de #6891).**\n",
+    ">\n",
+    "> Ce notebook contient **10 cellule(s) code sur 14** qui n'ont\n",
+    "> **jamais ete executees** (`execution_count: null`, `outputs: []`). Ce ne sont\n",
+    "> **pas** des sorties fabriquees ni stripees (scope #6891) : l'execution n'a\n",
+    "> simplement jamais eu lieu -- un bug-class separé, tracked dans l'issue #7575.\n",
+    ">\n",
+    "> **Re-exec gated** sur QC Cloud (kernel research `QuantBook`). **Statut config : NO-CONFIG** (pas de `config.json` / cloud-id). Re-exec IMPOSSIBLE tant que le projet n'est pas deploye sur QC Cloud (RECOVERABLE-USER-HAND : creation du projet QC + cloud-id requise au prealable).\n",
+    ">\n",
+    "> En attendant, ce markdown signale honnetement l'etat (Stop & Repair,\n",
+    "> secrets-hygiene 6 + sota-not-workaround Prong-A) -- **ne jamais fabriquer**\n",
+    "> de sorties pour combler."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-XGBoost/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-XGBoost/quantbook.ipynb
@@ -26,6 +26,26 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<!-- QC-UNEXEC-TRIAGED issue=#7575 -->\n",
+    "\n",
+    "> **Cellules non executees -- bug-class #7575 (DISTINCT de #6891).**\n",
+    ">\n",
+    "> Ce notebook contient **10 cellule(s) code sur 11** qui n'ont\n",
+    "> **jamais ete executees** (`execution_count: null`, `outputs: []`). Ce ne sont\n",
+    "> **pas** des sorties fabriquees ni stripees (scope #6891) : l'execution n'a\n",
+    "> simplement jamais eu lieu -- un bug-class separé, tracked dans l'issue #7575.\n",
+    ">\n",
+    "> **Re-exec gated** sur QC Cloud (kernel research `QuantBook`). **Statut config : ALIVE** (cloud-id 29434753). Re-exec *ready* des que l'acces QC Cloud est restaure (RECOVERABLE-MACHINE) -- le projet existe deja sur QC Cloud, il suffit de relancer le kernel research.\n",
+    ">\n",
+    "> En attendant, ce markdown signale honnetement l'etat (Stop & Repair,\n",
+    "> secrets-hygiene 6 + sota-not-workaround Prong-A) -- **ne jamais fabriquer**\n",
+    "> de sorties pour combler."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {

--- a/MyIA.AI.Notebooks/QuantConnect/projects/PairsTrading/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/PairsTrading/quantbook.ipynb
@@ -30,6 +30,26 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<!-- QC-UNEXEC-TRIAGED issue=#7575 -->\n",
+    "\n",
+    "> **Cellules non executees -- bug-class #7575 (DISTINCT de #6891).**\n",
+    ">\n",
+    "> Ce notebook contient **4 cellule(s) code sur 7** qui n'ont\n",
+    "> **jamais ete executees** (`execution_count: null`, `outputs: []`). Ce ne sont\n",
+    "> **pas** des sorties fabriquees ni stripees (scope #6891) : l'execution n'a\n",
+    "> simplement jamais eu lieu -- un bug-class separé, tracked dans l'issue #7575.\n",
+    ">\n",
+    "> **Re-exec gated** sur QC Cloud (kernel research `QuantBook`). **Statut config : NO-CONFIG** (pas de `config.json` / cloud-id). Re-exec IMPOSSIBLE tant que le projet n'est pas deploye sur QC Cloud (RECOVERABLE-USER-HAND : creation du projet QC + cloud-id requise au prealable).\n",
+    ">\n",
+    "> En attendant, ce markdown signale honnetement l'etat (Stop & Repair,\n",
+    "> secrets-hygiene 6 + sota-not-workaround Prong-A) -- **ne jamais fabriquer**\n",
+    "> de sorties pour combler."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {

--- a/MyIA.AI.Notebooks/QuantConnect/projects/RL-Portfolio/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/RL-Portfolio/quantbook.ipynb
@@ -35,6 +35,27 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<!-- QC-UNEXEC-TRIAGED issue=#7575 -->\n",
+    "\n",
+    "> **Cellules non executees -- bug-class #7575 (DISTINCT de #6891).**\n",
+    ">\n",
+    "> Ce notebook contient **7 cellule(s) code sur 10** qui n'ont\n",
+    "> **jamais ete executees** (`execution_count: null`, `outputs: []`). Ce ne sont\n",
+    "> **pas** des sorties fabriquees ni stripees (scope #6891) : l'execution n'a\n",
+    "> simplement jamais eu lieu -- un bug-class separé, tracked dans l'issue #7575.\n",
+    ">\n",
+    "> **Re-exec gated** sur QC Cloud (kernel research `QuantBook`). **Statut config : NO-CONFIG** (pas de `config.json` / cloud-id). Re-exec IMPOSSIBLE tant que le projet n'est pas deploye sur QC Cloud (RECOVERABLE-USER-HAND : creation du projet QC + cloud-id requise au prealable).\n",
+    ">\n",
+    "> En attendant, ce markdown signale honnetement l'etat (Stop & Repair,\n",
+    "> secrets-hygiene 6 + sota-not-workaround Prong-A) -- **ne jamais fabriquer**\n",
+    "> de sorties pour combler."
+   ],
+   "id": "qc-unexec-triaged-rl-portfolio"
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "cell-1",

--- a/MyIA.AI.Notebooks/QuantConnect/projects/VIX-TermStructure/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/VIX-TermStructure/quantbook.ipynb
@@ -28,6 +28,26 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<!-- QC-UNEXEC-TRIAGED issue=#7575 -->\n",
+    "\n",
+    "> **Cellules non executees -- bug-class #7575 (DISTINCT de #6891).**\n",
+    ">\n",
+    "> Ce notebook contient **8 cellule(s) code sur 10** qui n'ont\n",
+    "> **jamais ete executees** (`execution_count: null`, `outputs: []`). Ce ne sont\n",
+    "> **pas** des sorties fabriquees ni stripees (scope #6891) : l'execution n'a\n",
+    "> simplement jamais eu lieu -- un bug-class separé, tracked dans l'issue #7575.\n",
+    ">\n",
+    "> **Re-exec gated** sur QC Cloud (kernel research `QuantBook`). **Statut config : NO-CONFIG** (pas de `config.json` / cloud-id). Re-exec IMPOSSIBLE tant que le projet n'est pas deploye sur QC Cloud (RECOVERABLE-USER-HAND : creation du projet QC + cloud-id requise au prealable).\n",
+    ">\n",
+    "> En attendant, ce markdown signale honnetement l'etat (Stop & Repair,\n",
+    "> secrets-hygiene 6 + sota-not-workaround Prong-A) -- **ne jamais fabriquer**\n",
+    "> de sorties pour combler."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {

--- a/scripts/quantconnect/audit_quantbooks_unexec.py
+++ b/scripts/quantconnect/audit_quantbooks_unexec.py
@@ -28,10 +28,16 @@ Pour chaque ``quantbook.ipynb`` du dossier ``MyIA.AI.Notebooks/QuantConnect/proj
   - **HEALTHY**              -- 0 cellule code sans ``execution_count`` ni sortie.
   - **STOP_REPAIR_STRIPPED** -- >=1 cellule code unexec ET >=1 cellule markdown
                                 contenant ``Sortie strippee`` / ``FABRICATED``.
-                                Deja signalee (scope #6891), en attente de re-exec.
-  - **PREEXISTING_UNEXEC**   -- >=1 cellule code unexec SANS avertissement de strip.
-                                Bug-class non couvert par #6891, a tracker
-                                dans une issue dediee.
+                                Deja signalee (scope #6891 fabrication), en attente de re-exec.
+  - **STOP_REPAIR_UNEXEC**   -- >=1 cellule code unexec ET >=1 cellule markdown
+                                contenant le marqueur dedie ``QC-UNEXEC-TRIAGED``
+                                (issue #7575). Bug-class DISTINCT de #6891 : les
+                                cellules n'ont JAMAIS ete executees (ce ne sont PAS
+                                des sorties fabriquees/stripees). Triees et suivies,
+                                en attente d'une re-exec gated (QC Cloud).
+  - **PREEXISTING_UNEXEC**   -- >=1 cellule code unexec SANS marqueur (ni strip ni
+                                unexec). Nouvelle occurrence non encore triee --
+                                celle que ``--check`` flagge en CI.
 
 Le verdict est **conservatif** : si une cellule est unexec, on l'attrape.
 Pas de faux positif sur les cellules volontairement non executees (defs,
@@ -86,6 +92,13 @@ from pathlib import Path
 # Mots-cles qui marquent un notebook comme deja signale Stop&Repair (body #6891).
 _STRIP_MARKER = re.compile(r"(sortie\s+stripp[e\xe9]e|FABRICATED|blank[\s\-]?PNG)", re.IGNORECASE)
 
+# Marqueur dedie au bug-class #7575 (cellules JAMAIS executees -- distinct de #6891
+# qui est des sorties FABRIQUEES puis stripees). Le tag HTML ``QC-UNEXEC-TRIAGED``
+# est deliberement unique et non-ambigu : il ne peut pas etre confondu avec le
+# marqueur #6891, et ajouter le marqueur sur un quantbook #7575 n'est donc PAS du
+# gaming du detecteur (les deux bug-classes ont deux marqueurs distincts).
+_UNEXEC_MARKER = re.compile(r"QC-UNEXEC-TRIAGED", re.IGNORECASE)
+
 
 def _is_code(cell: dict) -> bool:
     return cell.get("cell_type") == "code"
@@ -109,6 +122,19 @@ def _has_strip_marker(nb: dict) -> bool:
         if isinstance(src, list):
             src = "".join(src)
         if _STRIP_MARKER.search(src or ""):
+            return True
+    return False
+
+
+def _has_unexec_marker(nb: dict) -> bool:
+    """Au moins une cellule markdown contient le marqueur #7575 (unexec triaged)."""
+    for c in nb.get("cells", []):
+        if c.get("cell_type") != "markdown":
+            continue
+        src = c.get("source", "")
+        if isinstance(src, list):
+            src = "".join(src)
+        if _UNEXEC_MARKER.search(src or ""):
             return True
     return False
 
@@ -153,6 +179,7 @@ def scan_notebook(path: Path) -> dict:
             "code_executed": 0,
             "code_unexecuted": 0,
             "strip_marker": False,
+            "unexec_marker": False,
             "classification": "ERROR",
             "config": {"has_config": False, "cloud_id": None, "status": "MISSING"},
         }
@@ -170,11 +197,14 @@ def scan_notebook(path: Path) -> dict:
             code_executed += 1
 
     strip_marker = _has_strip_marker(nb)
+    unexec_marker = _has_unexec_marker(nb)
 
     if code_unexecuted == 0:
         classification = "HEALTHY"
     elif strip_marker:
         classification = "STOP_REPAIR_STRIPPED"
+    elif unexec_marker:
+        classification = "STOP_REPAIR_UNEXEC"
     else:
         classification = "PREEXISTING_UNEXEC"
 
@@ -186,6 +216,7 @@ def scan_notebook(path: Path) -> dict:
         "code_unexecuted": code_unexecuted,
         "unexecuted_indexes": unexecuted_indexes,
         "strip_marker": strip_marker,
+        "unexec_marker": unexec_marker,
         "classification": classification,
         "config": _config_status(path.parent),
         "error": None,
@@ -215,7 +246,8 @@ def _short(path: str, root: Path) -> str:
 def human_report(results: list[dict], root: Path) -> str:
     n_total = len(results)
     by_class: dict[str, list[dict]] = {"HEALTHY": [], "STOP_REPAIR_STRIPPED": [],
-                                       "PREEXISTING_UNEXEC": [], "ERROR": []}
+                                       "STOP_REPAIR_UNEXEC": [], "PREEXISTING_UNEXEC": [],
+                                       "ERROR": []}
     for r in results:
         by_class.setdefault(r["classification"], []).append(r)
 
@@ -223,6 +255,7 @@ def human_report(results: list[dict], root: Path) -> str:
         f"QuantBooks scanned   : {n_total}",
         f"  HEALTHY              : {len(by_class['HEALTHY'])}",
         f"  STOP_REPAIR_STRIPPED : {len(by_class['STOP_REPAIR_STRIPPED'])}",
+        f"  STOP_REPAIR_UNEXEC   : {len(by_class['STOP_REPAIR_UNEXEC'])}",
         f"  PREEXISTING_UNEXEC   : {len(by_class['PREEXISTING_UNEXEC'])}",
         f"  ERROR                : {len(by_class['ERROR'])}",
         "",
@@ -241,9 +274,21 @@ def human_report(results: list[dict], root: Path) -> str:
         lines.append("")
 
     if by_class["STOP_REPAIR_STRIPPED"]:
-        lines.append("## STOP_REPAIR_STRIPPED -- body #6891 scope, awaits re-execution")
+        lines.append("## STOP_REPAIR_STRIPPED -- body #6891 scope (fabricated outputs stripped), awaits re-execution")
         lines.append("")
         for r in sorted(by_class["STOP_REPAIR_STRIPPED"], key=lambda x: x["path"]):
+            short = _short(r["path"], root)
+            cfg = r["config"]
+            cfg_str = f"cloud-id={cfg['cloud_id']} [{cfg['status']}]" if cfg["has_config"] else "no config.json"
+            lines.append(
+                f"  - {short}  kernel={r['kernel']}  unexec={r['code_unexecuted']}/{r['code_total']}  {cfg_str}"
+            )
+        lines.append("")
+
+    if by_class["STOP_REPAIR_UNEXEC"]:
+        lines.append("## STOP_REPAIR_UNEXEC -- issue #7575 scope (cells NEVER executed, distinct from #6891), triaged + marked, awaits re-exec")
+        lines.append("")
+        for r in sorted(by_class["STOP_REPAIR_UNEXEC"], key=lambda x: x["path"]):
             short = _short(r["path"], root)
             cfg = r["config"]
             cfg_str = f"cloud-id={cfg['cloud_id']} [{cfg['status']}]" if cfg["has_config"] else "no config.json"
@@ -266,8 +311,11 @@ def human_report(results: list[dict], root: Path) -> str:
     lines.append(
         "FIX (PREEXISTING_UNEXEC): re-execute unexec cells in the real environment\n"
         "(QC Cloud research kernel for QuantBook, local kernel for matplotlib) and\n"
-        "commit the real outputs. Stop&Repair, never fabricate -- secrets-hygiene 6\n"
-        "+ sota-not-workaround Prong-A. See #6891 for incident context."
+        "commit the real outputs, then add the QC-UNEXEC-TRIAGED marker (issue #7575)\n"
+        "so the notebook moves to STOP_REPAIR_UNEXEC (triaged) instead of staying\n"
+        "PREEXISTING_UNEXEC (new, untracked). Stop&Repair, never fabricate --\n"
+        "secrets-hygiene 6 + sota-not-workaround Prong-A. See #6891 (fabrication)\n"
+        "and #7575 (never-executed, distinct bug-class) for incident context."
     )
     return "\n".join(lines)
 
@@ -278,7 +326,8 @@ def json_report(results: list[dict]) -> str:
             "scanned": len(results),
             "by_class": {
                 c: sum(1 for r in results if r["classification"] == c)
-                for c in ("HEALTHY", "STOP_REPAIR_STRIPPED", "PREEXISTING_UNEXEC", "ERROR")
+                for c in ("HEALTHY", "STOP_REPAIR_STRIPPED", "STOP_REPAIR_UNEXEC",
+                          "PREEXISTING_UNEXEC", "ERROR")
             },
             "results": results,
         },


### PR DESCRIPTION
Grain: MED/audit-qc — lane myia-po-2025:CoursIA — prev: MED/fix-prongb (GT-14 #7679)

## Summary

Triage of the **9 PREEXISTING_UNEXEC quantbooks** (issue #7575, follow-up to the audit tool deployed in #7569) + a dedicated tool class + honest in-notebook markers. **Rotation R6**: family QuantConnect (≠ CaseStudies/GameTheory), genre audit-qc-triage (≠ fix-prongb) — breaks the 3× MED/fix-prongb wave (#7671, #7675, #7679).

## The bug-class (distinct from #6891)

Issue #7575 (2026-07-20) identified 9 `quantbook.ipynb` with code cells **never executed** (`execution_count: null`, `outputs: []`) and **no strip marker**. This is a bug-class **distinct from #6891**:
- **#6891** = outputs **FABRICATED** (1×1 PNG, `Row N` placeholders) then **STRIPPED** → marked `Sortie strippee` / `FABRICATED`.
- **#7575** = cells **NEVER executed** at all (no fabrication, no strip) → no marker existed.

The audit tool classified all 9 as `PREEXISTING_UNEXEC` (flagged at every scan, no in-notebook signal to a reader).

## Triage findings (firsthand, audit tool on origin/main)

| Project | unexec/total | config.json | Status | Recovery |
|---------|-------------|-------------|--------|----------|
| Crypto-MultiCanal | 8/10 | cloud-id 30750734 | ALIVE | RECOVERABLE-MACHINE (re-exec when QC access restored) |
| ML-XGBoost | 10/11 | cloud-id 29434753 | ALIVE | RECOVERABLE-MACHINE |
| BTC-ML | 8/11 | no config | NO-CONFIG | RECOVERABLE-USER-HAND (deploy to QC Cloud first) |
| DL-LSTM | 2/12 | no config | NO-CONFIG | RECOVERABLE-USER-HAND |
| ML-DeepLearning | 2/12 | no config | NO-CONFIG | RECOVERABLE-USER-HAND |
| ML-TextClassification | 10/14 | no config | NO-CONFIG | RECOVERABLE-USER-HAND |
| PairsTrading | 4/7 | no config | NO-CONFIG | RECOVERABLE-USER-HAND |
| RL-Portfolio | 7/10 | no config | NO-CONFIG | RECOVERABLE-USER-HAND |
| VIX-TermStructure | 8/10 | no config | NO-CONFIG | RECOVERABLE-USER-HAND |

**Pattern**: executed cells = setup/imports; unexec cells = training/backtest — execution stopped at the expensive cell on QC Cloud.

## Tool extension (`audit_quantbooks_unexec.py`)

- **New `_UNEXEC_MARKER` regex** detecting the dedicated `<!-- QC-UNEXEC-TRIAGED -->` tag — deliberately **distinct** from `_STRIP_MARKER` (which matches `sortie strippee` / `FABRICATED` / `blank-PNG`, the #6891 fabrication marker). **Two bug-classes, two markers**: adding the unexec marker is **not detector-gaming** (incident #1214 was find-replace to pass ONE detector with the wrong keyword; here each bug-class carries its OWN honest marker).
- **New classification `STOP_REPAIR_UNEXEC`** (unexec + unexec marker), distinct from `STOP_REPAIR_STRIPPED`. `HEALTHY` / `PREEXISTING_UNEXEC` semantics unchanged.
- **`--check` still exits 1 on `PREEXISTING_UNEXEC`** (new/untracked findings only); triaged-and-marked notebooks move out of the CI-fail set (they are tracked in #7575, not forgotten).

## Markers (9 quantbooks)

One markdown cell inserted after the title, carrying the `QC-UNEXEC-TRIAGED` tag + honest explanation:
- **NOT** fabricated/stripped (the #6891 different bug-class)
- cells **never executed**
- re-exec gated on QC Cloud, per-project recovery path (ALIVE vs NO-CONFIG)

## Proof — EXEC_PROVED-equivalent (forensic, no kernel re-exec needed — gated on QC Cloud)

- Tool reclassification verified: `PREEXISTING_UNEXEC` 9 → 0, `STOP_REPAIR_UNEXEC` 0 → 9. `--check` exit 1 → 0.
- Backward-compat: 27 HEALTHY / 10 STOP_REPAIR_STRIPPED / 0 ERROR unchanged.
- **Surgical**: +1 cell per quantbook, **0 existing cell content changed** (source + `execution_count` + `outputs` preserved — verified per-notebook via source/outputs signature diff).
- **nbformat VALID** (`validate(relax_add_props=True)`, 4.5 cell-id) for all 9.
- **H.3 validator** 9/9 PASS. **C.1**: 0 violations. **No re-exec performed** (gated on QC Cloud — Stop & Repair, zero fabrication). **No path/secret leak** in markers (cloud-ids are public config.json data already on origin/main).
- Catalogue byte-identical to main. 10 files, +244/−13.

## Why `See #7575` (not `Closes`)

The re-execution of the 9 quantbooks' unexec cells remains **gated on QC Cloud access** (RECOVERABLE-MACHINE for 2 ALIVE, RECOVERABLE-USER-HAND for 7 NO-CONFIG). This PR triages + marks + extends the tool — it does not produce the missing outputs (mock/fabrication forbidden by sota-not-workaround). The issue stays open until the 9 are genuinely re-executed on QC Cloud.

See #7575. Related: #6891 (fabrication bug-class), #7569 (audit tool).

