### PR TITLE
feat(grothendieck,#2159): Equivalences module — category equivalences (i18n #4980)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck.lean
@@ -198,5 +198,6 @@ import Grothendieck.SheafCohomology.MayerVietoris
 import Grothendieck.SheafCohomology.Cech
 import Grothendieck.YonedaLemma
 import Grothendieck.Adjunction
+import Grothendieck.Equivalences
 import Grothendieck.Monads
 import Grothendieck.Construction

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Equivalences.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Equivalences.lean
@@ -1,0 +1,189 @@
+/-
+Grothendieck Partie 27 — Équivalences de catégories
+
+Alexandre Grothendieck (1928-2014).
+
+Extension Phase 2+ (#2159, Epic #1646).
+
+L'équivalence de catégories est la « bonne » notion de sameness en
+catégorie : deux catégories équivalentes sont indistinguables du point de
+vue de la théorie, même si elles ne sont pas identiques ensembles d'objets.
+Grothendieck en fait un usage constant : le théorème de Yoneda dit que
+tout foncteur représentable est équivalent à un foncteur de Hom ; la
+géométrie algébrique identifie les schémas affines à la catégorie opposée
+des anneaux commutatifs (anti-équivalence de catégories) ; les topos sont
+définis comme des catégories équivalentes à la catégorie des faisceaux
+d'ensembles sur un site ; et toute la théorie des catégories dérivées
+repose sur des équivalences de catégories triangulées.
+
+Une **équivalence de catégories** `C ≌ D` est la donnée de deux foncteurs
+`functor : C ⥤ D` et `inverse : D ⥤ C`, ainsi que deux isomorphismes
+naturels `unitIso : 𝟭 C ≅ functor ⋙ inverse` et
+`counitIso : inverse ⋙ functor ≅ 𝟭 D` satisfaisant les identités
+triangulaires. C'est l'analogue catégorique d'un isomorphisme, mais « à
+isomorphisme près sur les objets » — ce qui est la bonne notion : les
+objets n'ont pas de substance intrinsèque en théorie des catégories, seules
+les flèches comptent.
+
+Le critère pratique (le plus utilisé) : un foncteur est une équivalence si
+et seulement s'il est **pleinement fidèle** (bijecte les Hom) et
+**essentiellement surjectif** (tout objet cible est isomorphe à l'image d'un
+objet source). Mathlib encode cela dans la classe `Functor.IsEquivalence`.
+
+Mathlib 4 formalise toute cette infrastructure dans
+`Mathlib.CategoryTheory.Equivalence` :
+  - `CategoryTheory.Equivalence : Type*` — la structure d'équivalence C ≌ D
+  - `CategoryTheory.Equivalence.functor` / `inverse` — les deux foncteurs
+  - `CategoryTheory.Equivalence.unitIso` / `counitIso` — les isos naturels
+  - `CategoryTheory.Equivalence.functor_unitIso_comp` — l'identité triangulaire
+  - `CategoryTheory.Equivalence.refl` / `symm` / `trans` — structure de (2-)groupeoïde
+  - `CategoryTheory.Functor.FullyFaithful` — le foncteur bijecte les Hom
+  - `CategoryTheory.Functor.EssSurj` — essential surjectivity
+  - `CategoryTheory.Functor.IsEquivalence` — la propriété d'être une équivalence
+
+Ce module ré-expose ces faits comme un parcours pédagogique organisé, pour
+des apprenants découvrant les équivalences pour la première fois, en miroir
+des modules `Grothendieck.Adjunction` et `Grothendieck.Limits` (l'adjonction
+donne les équivalences « locales » Hom_D(LX,Y) ≃ Hom_C(X,RY) ; l'équivalence
+est une adjonction où l'unité et la coïnité sont des isomorphismes).
+
+Epic #1646, See #2159. Tous les `sorry` éliminés à la création.
+
+### i18n — convention #4980 ratifiée 2026-07-04
+
+Ce module est jumelé avec sa version anglaise canonique dans le fichier
+sibling `Equivalences_en.lean`. Les énoncés de théorèmes, les noms de lemmes,
+les tactiques Lean et les références Mathlib restent en anglais. Seules les
+**docstrings `/-- ... -/`** et les **commentaires `-- ...`** diffèrent entre
+les deux fichiers. Anti-§D byte-identity garanti.
+-/
+
+import Mathlib.CategoryTheory.Equivalence
+import Mathlib.CategoryTheory.Functor.FullyFaithful
+
+universe v₁ v₂ u₁ u₂
+
+namespace Grothendieck.Equivalences
+
+open CategoryTheory
+
+variable {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D]
+
+/-!
+## 1. La structure d'équivalence
+
+Une équivalence `e : C ≌ D` est la donnée d'un foncteur `e.functor : C ⥤ D`,
+d'un inverse `e.inverse : D ⥤ C`, et de deux isomorphismes naturels
+`e.unitIso : 𝟭 C ≅ e.functor ⋙ e.inverse` et
+`e.counitIso : e.inverse ⋙ e.functor ≅ 𝟭 D`. La notation `C ≌ D` dénote
+`Equivalence C D`.
+-/
+
+-- La structure d'équivalence de catégories C ≌ D.
+#check @CategoryTheory.Equivalence
+
+-- Le foncteur « aller » e.functor : C ⥤ D de l'équivalence.
+#check @CategoryTheory.Equivalence.functor
+
+-- Le foncteur « retour » e.inverse : D ⥤ C de l'équivalence.
+#check @CategoryTheory.Equivalence.inverse
+
+/-!
+## 2. Unité et coïnité, identités triangulaires
+
+Comme pour une adjonction (cf `Grothendieck.Adjunction`), une équivalence
+détermine une unité `unitIso : 𝟭 C ≅ functor ⋙ inverse` et une coïnité
+`counitIso : inverse ⋙ functor ≅ 𝟭 D` — mais ce sont ici des **isomorphismes
+naturels** (pas de simples transformations naturelles). C'est précisément ce
+qui distingue une équivalence d'une adjonction quelconque : l'unité et la
+coïnité sont inversibles.
+-/
+
+-- L'isomorphisme naturel unité 𝟭 C ≅ functor ⋙ inverse.
+#check @CategoryTheory.Equivalence.unitIso
+
+-- L'isomorphisme naturel coïnité inverse ⋙ functor ≅ 𝟭 D.
+#check @CategoryTheory.Equivalence.counitIso
+
+-- La première identité triangulaire (compatibilité unité × coïnité).
+#check @CategoryTheory.Equivalence.functor_unitIso_comp
+
+/-!
+## 3. La (2-)catégorie des catégories : refl, symm, trans
+
+Les équivalences de catégories se composent et s'inversent : elles forment
+une structure de (2-)groupeoïde. `Equivalence.refl` est l'équivalence
+identité, `Equivalence.symm` inverse une équivalence (échange functor ↔
+inverse), et `Equivalence.trans` compose deux équivalences.
+-/
+
+-- L'équivalence identité C ≌ C.
+#check @CategoryTheory.Equivalence.refl
+
+-- L'inverse d'une équivalence : si C ≌ D alors D ≌ C.
+#check @CategoryTheory.Equivalence.symm
+
+-- La composition de deux équivalences : C ≌ D et D ≌ E donne C ≌ E.
+#check @CategoryTheory.Equivalence.trans
+
+/-!
+## 4. Le critère pratique : pleinement fidèle + essentiellement surjectif
+
+Le critère le plus utilisé en pratique : un foncteur `F : C ⥤ D` est une
+équivalence si et seulement s'il est **pleinement fidèle** (pour tous
+`X Y : C`, l'application `Hom_C(X,Y) → Hom_D(FX,FY)` est bijective) et
+**essentiellement surjectif** (tout objet de `D` est isomorphe à l'image
+d'un objet de `C`). Mathlib encode cela dans la classe `Functor.IsEquivalence`.
+-/
+
+-- La structure témoignant qu'un foncteur est pleinement fidèle (bijecte les Hom).
+#check @CategoryTheory.Functor.FullyFaithful
+
+-- La classe témoignant qu'un foncteur est essentiellement surjectif.
+#check @CategoryTheory.Functor.EssSurj
+
+-- La propriété pour un foncteur d'être une équivalence (plein + fidèle + ess. surj.).
+#check @CategoryTheory.Functor.IsEquivalence
+
+/-!
+## 5. Théorèmes ponts
+
+Reformulations dans l'espace de noms du projet, pontant les faits Mathlib.
+-/
+
+/-- Pont : le foncteur « aller » d'une équivalence C ≌ D, exposé comme
+    foncteur nu dans la catégorie des foncteurs. C'est la moitié « directe »
+    de l'équivalence, l'autre étant `equivalence_inverse`. -/
+noncomputable def equivalence_functor (e : C ≌ D) : C ⥤ D :=
+  e.functor
+
+/-- Pont : le foncteur « retour » d'une équivalence C ≌ D. Avec
+    `equivalence_functor`, il forme la paire de foncteurs quasi-inverses. -/
+noncomputable def equivalence_inverse (e : C ≌ D) : D ⥤ C :=
+  e.inverse
+
+/-- Pont : l'isomorphisme naturel unité d'une équivalence — 𝟭 C ≅ functor ⋙
+    inverse. C'est le témoignage que « aller puis revenir » est isomorphe à
+    l'identité (à isomorphisme près, pas égalité). -/
+noncomputable def equivalence_unit (e : C ≌ D) : 𝟭 C ≅ e.functor ⋙ e.inverse :=
+  e.unitIso
+
+/-- Pont : l'isomorphisme naturel coïnité d'une équivalence — inverse ⋙
+    functor ≅ 𝟭 D. C'est le témoignage dual que « revenir puis aller » est
+    isomorphe à l'identité. -/
+noncomputable def equivalence_counit (e : C ≌ D) : e.inverse ⋙ e.functor ≅ 𝟭 D :=
+  e.counitIso
+
+/-- Pont : l'équivalence symétrique (inverse) — si C ≌ D alors D ≌ C.
+    Échange les rôles de functor et inverse ; l'unité de `e.symm` est la
+    coïnité de `e` et réciproquement. -/
+noncomputable def equivalence_symm (e : C ≌ D) : D ≌ C :=
+  e.symm
+
+/-- Pont : la composition de deux équivalences — C ≌ D et D ≌ E donne C ≌ E.
+    La composition préserve les équivalences (fermeture de la structure de
+    2-groupeoïde). -/
+noncomputable def equivalence_trans {E : Type*} [Category E] (e : C ≌ D) (f : D ≌ E) : C ≌ E :=
+  e.trans f
+
+end Grothendieck.Equivalences

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Equivalences_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Equivalences_en.lean
@@ -1,0 +1,186 @@
+/-
+Grothendieck Part 27 — Equivalences of categories [English mirror of Equivalences.lean]
+
+Alexander Grothendieck (1928-2014).
+
+Extension Phase 2+ (#2159, Epic #1646).
+
+Equivalence of categories is the "right" notion of sameness in category
+theory: two equivalent categories are indistinguishable from the viewpoint
+of the theory, even though they need not be equal as sets of objects.
+Grothendieck uses it constantly: the Yoneda lemma says every representable
+functor is equivalent to a Hom functor; algebraic geometry identifies affine
+schemes with the opposite category of commutative rings (an
+anti-equivalence of categories); toposes are defined as categories
+equivalent to the category of sheaves of sets on a site; and all of derived
+category theory rests on equivalences of triangulated categories.
+
+An **equivalence of categories** `C ≌ D` is the data of two functors
+`functor : C ⥤ D` and `inverse : D ⥤ C`, together with two natural
+isomorphisms `unitIso : 𝟭 C ≅ functor ⋙ inverse` and
+`counitIso : inverse ⋙ functor ≅ 𝟭 D` satisfying the triangle identities.
+It is the categorical analogue of an isomorphism, but "up to isomorphism on
+objects" — which is the correct notion: objects have no intrinsic substance
+in category theory, only arrows matter.
+
+The practical criterion (the most used one): a functor is an equivalence if
+and only if it is **fully faithful** (bijects the Homs) and **essentially
+surjective** (every target object is isomorphic to the image of a source
+object). Mathlib encodes this in the `Functor.IsEquivalence` class.
+
+Mathlib 4 formalises all of this infrastructure in
+`Mathlib.CategoryTheory.Equivalence`:
+  - `CategoryTheory.Equivalence : Type*` — the C ≌ D structure
+  - `CategoryTheory.Equivalence.functor` / `inverse` — the two functors
+  - `CategoryTheory.Equivalence.unitIso` / `counitIso` — the natural isos
+  - `CategoryTheory.Equivalence.functor_unitIso_comp` — the triangle identity
+  - `CategoryTheory.Equivalence.refl` / `symm` / `trans` — (2-)groupoid structure
+  - `CategoryTheory.Functor.FullyFaithful` — the functor bijects the Homs
+  - `CategoryTheory.Functor.EssSurj` — essential surjectivity
+  - `CategoryTheory.Functor.IsEquivalence` — the property of being an equivalence
+
+This module re-exposes these facts as an organised pedagogical tour, for
+learners meeting equivalences for the first time, mirroring the
+`Grothendieck.Adjunction` and `Grothendieck.Limits` modules (an adjunction
+gives "local" equivalences Hom_D(LX,Y) ≃ Hom_C(X,RY); an equivalence is an
+adjunction where the unit and counit are isomorphisms).
+
+Epic #1646, See #2159. No `sorry` at creation.
+
+### i18n — convention #4980 ratified 2026-07-04
+
+This module is the English mirror of `Equivalences.lean`. Theorem statements,
+lemma names, Lean tactics and Mathlib references stay in English. Only the
+**docstrings `/-- ... -/`** and **comments `-- ...`** differ between the two
+files. Anti-§D byte-identity guaranteed.
+-/
+
+import Mathlib.CategoryTheory.Equivalence
+import Mathlib.CategoryTheory.Functor.FullyFaithful
+
+universe v₁ v₂ u₁ u₂
+
+namespace Grothendieck.Equivalences_en
+
+open CategoryTheory
+
+variable {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D]
+
+/-!
+## 1. The equivalence structure
+
+An equivalence `e : C ≌ D` is the data of a functor `e.functor : C ⥤ D`, an
+inverse `e.inverse : D ⥤ C`, and two natural isomorphisms
+`e.unitIso : 𝟭 C ≅ e.functor ⋙ e.inverse` and
+`e.counitIso : e.inverse ⋙ e.functor ≅ 𝟭 D`. The notation `C ≌ D` denotes
+`Equivalence C D`.
+-/
+
+-- The structure of an equivalence of categories C ≌ D.
+#check @CategoryTheory.Equivalence
+
+-- The "forward" functor e.functor : C ⥤ D of the equivalence.
+#check @CategoryTheory.Equivalence.functor
+
+-- The "backward" functor e.inverse : D ⥤ C of the equivalence.
+#check @CategoryTheory.Equivalence.inverse
+
+/-!
+## 2. Unit and counit, triangle identities
+
+As for an adjunction (see `Grothendieck.Adjunction`), an equivalence
+determines a unit `unitIso : 𝟭 C ≅ functor ⋙ inverse` and a counit
+`counitIso : inverse ⋙ functor ≅ 𝟭 D` — but these are here **natural
+isomorphisms** (not mere natural transformations). This is precisely what
+distinguishes an equivalence from an arbitrary adjunction: the unit and
+counit are invertible.
+-/
+
+-- The unit natural isomorphism 𝟭 C ≅ functor ⋙ inverse.
+#check @CategoryTheory.Equivalence.unitIso
+
+-- The counit natural isomorphism inverse ⋙ functor ≅ 𝟭 D.
+#check @CategoryTheory.Equivalence.counitIso
+
+-- The first triangle identity (unit × counit compatibility).
+#check @CategoryTheory.Equivalence.functor_unitIso_comp
+
+/-!
+## 3. The (2-)category of categories: refl, symm, trans
+
+Equivalences of categories compose and invert: they form a (2-)groupoid
+structure. `Equivalence.refl` is the identity equivalence, `Equivalence.symm`
+inverts an equivalence (swapping functor ↔ inverse), and `Equivalence.trans`
+composes two equivalences.
+-/
+
+-- The identity equivalence C ≌ C.
+#check @CategoryTheory.Equivalence.refl
+
+-- The inverse of an equivalence: if C ≌ D then D ≌ C.
+#check @CategoryTheory.Equivalence.symm
+
+-- The composition of two equivalences: C ≌ D and D ≌ E gives C ≌ E.
+#check @CategoryTheory.Equivalence.trans
+
+/-!
+## 4. The practical criterion: fully faithful + essentially surjective
+
+The most used criterion in practice: a functor `F : C ⥤ D` is an equivalence
+if and only if it is **fully faithful** (for all `X Y : C`, the map
+`Hom_C(X,Y) → Hom_D(FX,FY)` is bijective) and **essentially surjective**
+(every object of `D` is isomorphic to the image of an object of `C`). Mathlib
+encodes this in the `Functor.IsEquivalence` class.
+-/
+
+-- The structure witnessing that a functor is fully faithful (bijects the Homs).
+#check @CategoryTheory.Functor.FullyFaithful
+
+-- The class witnessing that a functor is essentially surjective.
+#check @CategoryTheory.Functor.EssSurj
+
+-- The property of a functor being an equivalence (full + faithful + ess. surj.).
+#check @CategoryTheory.Functor.IsEquivalence
+
+/-!
+## 5. Bridge theorems
+
+Reformulations in the project namespace, bridging the Mathlib facts.
+-/
+
+/-- Bridge: the "forward" functor of an equivalence C ≌ D, exposed as a bare
+    functor in the functor category. This is the "direct" half of the
+    equivalence, the other being `equivalence_inverse`. -/
+noncomputable def equivalence_functor (e : C ≌ D) : C ⥤ D :=
+  e.functor
+
+/-- Bridge: the "backward" functor of an equivalence C ≌ D. Together with
+    `equivalence_functor`, it forms the pair of quasi-inverse functors. -/
+noncomputable def equivalence_inverse (e : C ≌ D) : D ⥤ C :=
+  e.inverse
+
+/-- Bridge: the unit natural isomorphism of an equivalence — 𝟭 C ≅ functor ⋙
+    inverse. This witnesses that "go then come back" is isomorphic to the
+    identity (up to isomorphism, not equality). -/
+noncomputable def equivalence_unit (e : C ≌ D) : 𝟭 C ≅ e.functor ⋙ e.inverse :=
+  e.unitIso
+
+/-- Bridge: the counit natural isomorphism of an equivalence — inverse ⋙
+    functor ≅ 𝟭 D. This is the dual witness that "come back then go" is
+    isomorphic to the identity. -/
+noncomputable def equivalence_counit (e : C ≌ D) : e.inverse ⋙ e.functor ≅ 𝟭 D :=
+  e.counitIso
+
+/-- Bridge: the symmetric (inverse) equivalence — if C ≌ D then D ≌ C.
+    Swaps the roles of functor and inverse; the unit of `e.symm` is the
+    counit of `e` and conversely. -/
+noncomputable def equivalence_symm (e : C ≌ D) : D ≌ C :=
+  e.symm
+
+/-- Bridge: the composition of two equivalences — C ≌ D and D ≌ E gives
+    C ≌ E. Composition preserves equivalences (closure of the 2-groupoid
+    structure). -/
+noncomputable def equivalence_trans {E : Type*} [Category E] (e : C ≌ D) (f : D ≌ E) : C ≌ E :=
+  e.trans f
+
+end Grothendieck.Equivalences_en


### PR DESCRIPTION
## Summary

New `Grothendieck.Equivalences` module (+ EN sibling `Grothendieck.Equivalences_en`) covering **equivalences of categories** — the "right" notion of sameness in category theory (CoursIA #2159 "au-delà de Yoneda"). Fills a genuine gap: the lake had Adjunction (#7658-era), Yoneda, Monads, Construction, Limits (#7676) but **no module on equivalences**, even though an equivalence is precisely an adjunction whose unit and counit are isomorphisms (the natural closure of the Adjunction + Limits pair).

Pedagogical restatement of the Mathlib `CategoryTheory.Equivalence` API, mirroring the established `Adjunction.lean` / `Limits.lean` style (`#check` tour + namespace bridges).

## Content (5 sections)

1. **The equivalence structure** — `Equivalence` (C ≌ D), `.functor`, `.inverse`
2. **Unit & counit, triangle identities** — `unitIso`, `counitIso` as *natural isomorphisms* (vs adjunction's mere transformations), `functor_unitIso_comp`
3. **(2-)groupoid structure** — `Equivalence.refl` / `.symm` / `.trans`
4. **Practical criterion** — `Functor.FullyFaithful` + `Functor.EssSurj` + `Functor.IsEquivalence` (equivalence iff fully faithful + essentially surjective)
5. **6 namespace bridges** — `equivalence_functor`, `equivalence_inverse`, `equivalence_unit`, `equivalence_counit`, `equivalence_symm`, `equivalence_trans`

The module explicitly cross-references `Adjunction` (an equivalence = an adjunction with invertible unit/counit) and `Limits` — completing the adjunction/limits/equivalence triad that underpins "everything is a Kan extension" philosophy.

## i18n #4980 (ratified 2026-07-04)

- FR/EN sibling pair: `Equivalences.lean` / `Equivalences_en.lean`
- **English bridge names in BOTH files** (`equivalence_functor`, `equivalence_symm`, …) — enables byte-identity drift-detection
- Namespace suffix `_en` (`Grothendieck.Equivalences` ↔ `Grothendieck.Equivalences_en`)
- Theorem statements + Mathlib refs identical
- **Byte-identity verified**: code identical FR/EN, only docstrings + comments differ

## Validation (firsthand, anti-false-SUCCESS per #7658)

| Target | Result |
|--------|--------|
| `lake build Grothendieck.Equivalences` | ✅ SUCCESS (497 jobs), 0 errors |
| `lake build Grothendieck.Equivalences_en` | ✅ SUCCESS (497 jobs), 0 errors |
| `sorry` count (real proofs) | ✅ 0 in both files |
| Catalog drift | ✅ byte-identical to main |
| Line endings | ✅ LF (no CRLF) |

**Mathlib identifiers verified BEFORE authoring** — `CategoryTheory.Equivalence` (struct @ L87: functor/inverse/unitIso/counitIso/functor_unitIso_comp), `≌` notation, `Equivalence.refl` (L361)/`.symm` (L369)/`.trans` (L386), `Functor.FullyFaithful` (FullyFaithful.lean:127), `Functor.EssSurj`, `Functor.IsEquivalence` (L612) — all confirmed in source, avoiding the #7658 unknown-identifier trap.

**Full-lib root aggregator flaked** (Windows c.544 stack-overrun `0xC0000409` + `.olean`/`.olean.private` read errors on UNTOUCHED modules `Construction`/`DenseTopology`/`LeftExact_en`/`Monads_en` cascading on missing Mathlib deps needing source-compile under parallel load). Same documented exception as #7676 (Limits) — CI `Lean CI (grothendieck_lean)` confirmed that PR on a clean Linux runner. My modules are proven standalone-green.

## Changed files (3)

- `Grothendieck/Equivalences.lean` (new, 189L)
- `Grothendieck/Equivalences_en.lean` (new, 186L)
- `Grothendieck.lean` (+1 line: `import Grothendieck.Equivalences`)

Grain: DEEP/lean — lane myia-po-2026:CoursIA — prev: MED/python-notebook (IIT #7672) / DEEP/lean (Limits #7676)

See #2159 (Epic #1646, open). See #4980 (i18n, open).

Co-Authored-By: Claude <noreply@anthropic.com>
