### PR TITLE
chore(gitignore): ignore root venv lib/ (venv cree par erreur a la racine)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -313,6 +313,8 @@ venv/
 **/.venv/
 pyvenv.cfg
 lib64
+# Venv cree par erreur a la racine du repo (python -m venv /mnt/d/CoursIA depuis WSL) — anti-noise site-packages
+/lib/
 
 # Cake - Uncomment if you are using it
 # tools/**


### PR DESCRIPTION
## Problème
Un venv Python a été créé **par erreur à la racine du repo** : `pyvenv.cfg` porte `command = /usr/bin/python3 -m venv /mnt/d/CoursIA` (donc `python -m venv` lancé depuis WSL avec la racine du repo comme cible). Ça a déposé `lib/python3.12/site-packages/`, `lib64`, `pyvenv.cfg` à la racine.

`pyvenv.cfg` (ligne 314) et `lib64` (ligne 315) étaient déjà ignorés, mais **`/lib/` manquait** → les milliers de fichiers de `lib/python3.12/site-packages/` apparaissaient en `?? lib/` untracked, polluant `git status` et l'indexeur de l'IDE (notifications).

## Fix
Ajout du pattern root-anchored `/lib/` dans la section venv du `.gitignore`.

## Sûreté
- **Root-anchored** (`/lib/`, pas `**/lib/`) : sans effet sur `foundry-lib/lib/**` ni aucun `lib/` imbriqué.
- **Rien n'est traqué** sous la racine `lib/` : `git ls-files -- lib/` = `0` → aucun fichier suivi masqué.
- Non-destructif : les fichiers restent sur le disque, ils cessent juste d'apparaître en untracked.

## Follow-up (hors scope, signalé)
Le venv ne devrait pas vivre à la racine du repo. Le déplacer vers `.venv/` (ou le supprimer/recréer proprement) est une action séparée à trancher par l'owner de l'env (un kernel peut en dépendre) — non fait ici pour rester non-destructif.