### PR TITLE
docs(ict,#4588): coherence pass — collapse delivered ICT-19 spec, tighten Extensions, de-date transition note

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-0-Framing.md
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-0-Framing.md
@@ -337,20 +337,14 @@ IIT/
 Le cadrage stratégique de 2026-07 (Epic #4588, section « Jambes 2026-07 ») étend la série sur
 quatre fronts, chacun ancré dans un résultat déjà livré :
 
-1. **La « fin » de la réversibilisation, mesurée** (#7287, slot ICT-18b). ICT-18 a outillé le
-   *moyen* (la production d'entropie $\sigma$ comme instrument) et ICT-19 l'*enjeu* (la batterie
-   $I_\text{stake}$). Il manquait la troisième jambe de la triade moyen / fin / enjeu (#5352) : la
-   réversibilisation comme **ressource** — un budget $B(t)$ qui s'épuise et se régénère.
-   **Livré** (module `ict/reversibility_budget.py` + notebook
-   [ICT-18b](ICT-18b-ReversibilityBudget.ipynb)) : deux définitions honnêtement comparées
-   ($B_\text{state}$ Monte-Carlo sur la dynamique = primaire robuste, $B_\text{work}$ distance à
-   $P_\text{rev}$ = témoin secondaire). Prédictions pré-enregistrées puis testées — verdicts bruts :
-   **P1 PASS** (budget ↓ au pli, $\tau_\text{Kendall}=-0.917$, co-varie avec les EWS ; un signal
-   précurseur *est* un épuisement de budget), **P2 DISSOCIATION** (sur S4, dissiper plus ne
-   régénère pas plus — la lecture ressource s'affaiblit sur le substrat continu, résultat honnête),
-   **P3 PASS** (monoculture d'Axelrod = état absorbant, $B_\text{post} \ll B_\text{pre}$ : dette
-   d'irréversibilité culturelle mesurée). La triade moyen / fin / enjeu a désormais sa jambe
-   mesurée.
+1. **La « fin » de la réversibilisation, mesurée** (#7287, slot ICT-18b) — **livré**. La troisième
+   jambe de la triade moyen / fin / enjeu (#5352) : la réversibilisation comme **ressource** (un
+   budget $B(t)$ qui s'épuise et se régénère), au-delà du *moyen* (production d'entropie $\sigma$,
+   ICT-18) et de l'*enjeu* (batterie $I_\text{stake}$, ICT-19). Module
+   `ict/reversibility_budget.py` + notebook [ICT-18b](ICT-18b-ReversibilityBudget.ipynb) — deux
+   définitions comparées ($B_\text{state}$ Monte-Carlo primaire, $B_\text{work}$ témoin) et verdicts
+   pré-enregistrés **P1 PASS / P2 DISSOCIATION / P3 PASS** (détail : feuille de route + notebook).
+   La triade a désormais sa jambe mesurée.
 
 2. **La canonicité des scalaires du zoo** (#7288, slot ICT-15b). La synthèse cross-substrat a
    falsifié le « scalaire universel » ($\Phi/F$ covarient, $K$ diverge) ; la question méta devient :
@@ -484,67 +478,20 @@ laquelle *les revendications cognitives sont des revendications de protocole* (c
 **« Pourquoi parler de compétences ? »** ci-dessus) : une compétence n'est créditée à un modèle
 qu'au vu de ce qu'une expérience explicite en mesure.
 
-## ICT-19 — squelette de spec (cadrage B, voir #5483)
+## ICT-19 / ICT-19b — batterie de l'ENJEU (livré)
 
-> **Statut 2026-07** : livré (#5489), puis raffiné par
-> [`ICT-19b-EnjeuBattery-Raffinement.ipynb`](ICT-19b-EnjeuBattery-Raffinement.ipynb) (#5728, mesure
-> S4 en espace de champ ; renommé **ICT-19b**, #7260). La spec ci-dessous est conservée telle quelle
-> pour trace.
-
-ICT-19 construit la **seconde batterie** (celle de l'**ENJEU**) qu'ICT-18 nomme *hors de sa portée*
-dans son reframe #5352 (triade **moyen / fin / enjeu**), puis la **fusionne** à la batterie MOYEN
-d'ICT-18 sur le banc de substrats S1-S5 de l'ICT-Synthèse.
-
-### Périmètre (cadrage B, auto-maintien seul)
-
-- **Batterie MOYEN** (empruntée ICT-18) — production d'entropie / réversibilisation thermodynamique
-  (`ict/time_arrow.py`) : la *seule* grandeur `I_thermo` mesure.
-- **Batterie ENJEU** (à construire) — mesure opérationnelle d'**auto-maintien** : retour au bassin
-  attracteur `B` après une perturbation contrefactuelle `do(x ← x + δ)` (Pearl, fil rouge
-  causalité ICT-5). `I_stake` = distance normalisée parcourue vers `B` (gain de réparation).
-- **Livrable = PAIRE** `{I_thermo, I_stake}`, **pas indice agrégé**.
-
-### Substrats (réutilisés de l'ICT-Synthèse, zéro nouveau substrat)
-
-- **S1** (ICT-2 tri) — auto-organisé, point de consigne faible.
-- **S2** (ICT-8 bistable) — deux bassins, pas de défense d'un point de consigne.
-- **S3** (ICT-13 Axelrod) — réplicateur stratégique, équilibre de population.
-- **S4** (ICT-9 Gray-Scott) — *l'agent* : dissipe *et* défend un point de consigne via la
-  compétition Tu/Snell-Scott.
-- **S5** — *pur dissipateur*, contrôle négatif **obligatoire** : système qui dissipe sans enjeu
-  (réaction-diffusion hors-régime, ou chaîne markovienne stationnaire sans maintenance).
-
-### Gates falsifiables
-
-- **Gate ENJEU-1** : `I_stake(S4) > I_stake(S5) + marge`, avec `I_thermo(S4) ≈ I_thermo(S5)`
-  (l'ICT-18 Gate 7 montre déjà que le MOYEN seul allume S4 et S5 à égalité). La PAIRE doit donc
-  *séparer* l'agent du pur dissipateur là où le MOYEN seul ne le peut pas.
-- **Gate ENJEU-2** (graduation) : `I_stake(S4) > {S3, S1} > S2 > S5`.
-
-### Distinction sémantique (critique)
-
-- **Réversibilité thermodynamique** (detailed balance, `σ=0`) = le **MOYEN** que `I_thermo` mesure.
-- **Réversibilité comportementale** (récupérabilité cinématique de l'espace d'états,
-  ICT-2/3/9, Levin *competency for free*) = la **FIN** que la lutte thermodynamique poursuit —
-  *pas* un second axe à mesurer. Le retour au bassin `B` après `do(·)` est précisément **la
-  manifestation opérationnelle de cette récupérabilité**, là où la production d'entropie en est
-  le coût.
-
-### Contraintes
-
-- **GPU-free** (chaînes de Markov + ODE + reaction-diffusion 2D petit champ, kernel CPU).
-- **Contrôle négatif obligatoire** (S5) : sans lui, la batterie ne prouve rien ; c'est
-  l'ingrédient nommément manqué d'ICT-18, désormais comblé.
-- **Résultat nul honnête** : si ENJEU-1 échoue, le verdict est *négatif* — pas maquillé en succès.
-- Notebook exécuté CPU, outputs C.2 réels, 0 `raise NotImplementedError` (C.1), ≥3 exercices
-  (return-to-basin / repair-gain / extension substrat), prose FR.
-
-### Liens cadrage ICT-19
-
-- Issue de cadrage : **#5483** — décision user 2026-07-06 (cadrage B verrouillé).
-- Issue d'implémentation : **#5489** — acceptance criteria + livrables.
-- Reframe parent : **#5352** — triade moyen / fin / enjeu (ICT-18 v2).
-- Epic : **#4588** — registre des livrables ICT.
+La batterie de l'**ENJEU** — auto-maintien / retour au bassin attracteur `B` après une
+perturbation contrefactuelle `do(·)` (Pearl, fil rouge causalité ICT-5), fusionnée à la batterie
+MOYEN d'ICT-18 sur le banc de substrats S1-S5 de l'ICT-Synthèse (S5 = *pur dissipateur* = contrôle
+négatif **obligatoire**) — est **livrée** : [ICT-19](ICT-19-EnjeuBattery.ipynb) (#5489, cadrage B
+verrouillé user 2026-07-06) puis raffinée par
+[ICT-19b](ICT-19b-EnjeuBattery-Raffinement.ipynb) (#5728, mesure S4 en espace de champ ; renommée
+**ICT-19b**, #7260). Le livrable est la **paire** `{I_thermo, I_stake}` (jamais un indice agrégé),
+séparée par les gates falsifiables ENJEU-1 / ENJEU-2, sur la **distinction sémantique** :
+réversibilité *thermodynamique* (detailed balance, `σ=0` — le MOYEN que `I_thermo` mesure) ↔
+récupérabilité *comportementale* (Levin *competency for free* — la FIN que la lutte thermodynamique
+poursuit). Spec de cadrage complète : **#5483** ; reframe parent triade moyen / fin / enjeu :
+**#5352** ; registre des livrables : **#4588**.
 
 ## Voir aussi
 

--- a/docs/suivis/iit-ict-transition.md
+++ b/docs/suivis/iit-ict-transition.md
@@ -1,7 +1,6 @@
 # IIT → ICT — note de transition
 
-> Suivi de cycle **c.478** (po-2025 : `myia-po-2025:CoursIA-2`).
-> Pivot narratif et architectural de la série [`MyIA.AI.Notebooks/IIT/ICT-Series/`](../../MyIA.AI.Notebooks/IIT/ICT-Series/) (Epic [#4588](https://github.com/jsboige/CoursIA/issues/4588), plan de partition [#5081](https://github.com/jsboige/CoursIA/issues/5081)).
+> Note de transition durable de la série [`MyIA.AI.Notebooks/IIT/ICT-Series/`](../../MyIA.AI.Notebooks/IIT/ICT-Series/) (Epic [#4588](https://github.com/jsboige/CoursIA/issues/4588), plan de partition [#5081](https://github.com/jsboige/CoursIA/issues/5081)) — pivot narratif et architectural IIT → ICT. Posée initialement au cycle c.478 (po-2025 : `myia-po-2025:CoursIA-2`), tenue à jour au fil des livraisons.
 
 Cette note **n'est pas** un substitut des documents fondateurs de la série — qui sont
 déjà posés, conservés verbatim, et font foi :
@@ -67,7 +66,7 @@ La réconciliation tient en **une phrase** (citée du cadrage, [ICT-0-Framing §
 
 ## 3. Partition du travail — couche `ict/` à côté de PyPhi
 
-L'inventaire à jour de la couche `ict/` est dans [ICT-0-Framing § « Architecture »](../../MyIA.AI.Notebooks/IIT/ICT-Series/ICT-0-Framing.md#architecture-une-couche-ict-à-côté-de-pyphi). Au cycle c.478, la livraison inclut :
+L'inventaire à jour de la couche `ict/` est dans [ICT-0-Framing § « Architecture »](../../MyIA.AI.Notebooks/IIT/ICT-Series/ICT-0-Framing.md#architecture-une-couche-ict-à-côté-de-pyphi). Les modules livrés incluent :
 
 | Module | Rôle | Première livraison |
 |---|---|---|
@@ -99,7 +98,7 @@ thermodynamiques).
 | **Strate 2** — morphogenèse dynamique | ICT-8 à ICT-10 | Paysage d'attracteurs (May bistable), régénération (Gray-Scott), grammaire des catastrophes (Thom) | Le système **génère** son propre paysage de buts (et ne le reçoit plus) |
 | **Strate 3** — agents | ICT-11 à ICT-13 | Profils d'agence causale, animats valence, Axelrod IPD | Trois « jouets » actantiels sur trois substrats différents |
 | **Strate 4** — représentationnel | ICT-14 | Free energy / Friston | La jambe énergie-libre du représentationnel (substrat computationnel de l'anticipation) |
-| **Strate 5** — convergence & capstone | ICT-15 à ICT-24 | Banc cross-substrat (tri, Gray-Scott, Axelrod, LLM) : convergence $\Phi / F / K$, MDL, $\epsilon$-machine, flèche du temps, batterie ENJEU, feature catastrophes, SAE, persona, Global Workspace | L'appareil unique sur plusieurs substrats, qui pousse ses mesures à leur frontière |
+| **Strate 5** — convergence & capstone | ICT-15 à ICT-25 | Banc cross-substrat (tri, Gray-Scott, Axelrod, LLM) : convergence $\Phi / F / K$, MDL, $\epsilon$-machine, flèche du temps, batterie ENJEU, feature catastrophes, SAE, persona, Global Workspace | L'appareil unique sur plusieurs substrats, qui pousse ses mesures à leur frontière |
 
 Le détail notebook par notebook est maintenu dans [ICT-0-Framing § « Feuille de route des notebooks »](../../MyIA.AI.Notebooks/IIT/ICT-Series/ICT-0-Framing.md#feuille-de-route-des-notebooks) — la table de cette section est un index réduit.
 
@@ -114,12 +113,12 @@ Le détail notebook par notebook est maintenu dans [ICT-0-Framing § « Feuille 
 | Bifurcation pli + EWS | May 1977, Scheffer 2009, Dakos 2012 | `ict/bistable.py` + `ict/early_warning.py` | ICT-8 |
 | Agence régénérative | Gray-Scott (Pearson 1993), Levin *competency for free* | `ict/reaction_diffusion.py`, `ict/agency.py` | ICT-9, ICT-11 |
 | Grammaire des catastrophes | Thom 1972 (sémiophysique), *sans complaisance* | `ict/catastrophe.py` | ICT-10 |
-| Free energy principle | Friston 2010 | (prévu ICT-14 [#5089](https://github.com/jsboige/CoursIA/issues/5089)) | ICT-14 |
+| Free energy principle | Friston 2010 | ICT-14 livré ([#5089](https://github.com/jsboige/CoursIA/issues/5089)) | ICT-14 |
 | $\Phi_\text{dyn}$ | Discussion ChatGPT, ICT-0-Annexe | (instrument thermodynamique `ict/time_arrow.py`, mesure le **MOYEN** de la triade) | ICT-18, ICT-19 |
-| MDL / deux-parts code | Grünwald 2007 | (prévu ICT-16 [#5099](https://github.com/jsboige/CoursIA/issues/5099)) | ICT-16 |
-| $\epsilon$-machine | Crutchfield 1994 | (prévu ICT-17 [#5100](https://github.com/jsboige/CoursIA/issues/5100)) | ICT-17 |
+| MDL / deux-parts code | Grünwald 2007 | ICT-16 livré ([#5099](https://github.com/jsboige/CoursIA/issues/5099)) | ICT-16 |
+| $\epsilon$-machine | Crutchfield 1994 | ICT-17 livré ([#5100](https://github.com/jsboige/CoursIA/issues/5100)) | ICT-17 |
 | SAE features | Anthropic 2024 | `ict/sae.py` (à venir) | ICT-21 [#5101](https://github.com/jsboige/CoursIA/issues/5101), ICT-22 [#5102](https://github.com/jsboige/CoursIA/issues/5102) |
-| Global Workspace | Dehaene, Baars | `ict/workspace.py` (livré #5641) | ICT-24 (notebook à construire, [#5635](https://github.com/jsboige/CoursIA/issues/5635)) |
+| Global Workspace | Dehaene, Baars | `ict/workspace.py` (livré #5641) | ICT-24 livré ([#5635](https://github.com/jsboige/CoursIA/issues/5635)) |
 
 ## 6. Triade *moyen / fin / enjeu* — l'enseignement propre à ICT-18
 
@@ -142,22 +141,19 @@ ICT-18 (Flèche du temps & réversibilisation, [#5279](https://github.com/jsboig
 - **ICT-14** (free energy / Friston) pour l'**ENJEU** (le *stake* de l'auto-maintien) ;
 - **ICT-15 / 17** (complexité intégrée, $\epsilon$-machine) pour la **structure** sous-jacente.
 
-ICT-19 a démarré (cadrage B verrouillé par user 2026-07-06, [#5483](https://github.com/jsboige/CoursIA/issues/5483), implémentation [#5489](https://github.com/jsboige/CoursIA/issues/5489), raffinement [#5728](https://github.com/jsboige/CoursIA/issues/5728)) pour **fusionner** la batterie MOYEN d'ICT-18 (`I_thermo`) avec la batterie ENJEU (`I_stake` = gain de réparation après `do(·)`) sur le banc cross-substrat S1-S5, avec contrôle négatif obligatoire (S5 = pur dissipateur).
+ICT-19 / ICT-19b (cadrage B verrouillé par user 2026-07-06, [#5483](https://github.com/jsboige/CoursIA/issues/5483), implémentation [#5489](https://github.com/jsboige/CoursIA/issues/5489), raffinement [#5728](https://github.com/jsboige/CoursIA/issues/5728)) **fusionne** la batterie MOYEN d'ICT-18 (`I_thermo`) avec la batterie ENJEU (`I_stake` = gain de réparation après `do(·)`) sur le banc cross-substrat S1-S5, avec contrôle négatif obligatoire (S5 = pur dissipateur).
 
-## 7. Lacunes restantes au cycle c.478
+## 7. Lacunes restantes
 
-Lacunaire = connu, planifié, à faire dans un cycle ultérieur :
+Connu, planifié, à faire dans un cycle ultérieur :
 
 | Lacune | Cycle attendu | Raison |
 |---|---|---|
 | **ICT-21 / ICT-22** (LLM comme substrat S4) | GPU-required (Qwen local, RTX 3090) | Non exécutable sur cette machine CPU/.NET |
-| **ICT-24** (Global Workspace, notebook) | Module `ict/workspace.py` livré #5641, **notebook à construire** | Planifié [#5635](https://github.com/jsboige/CoursIA/issues/5635), standalone CPU-free |
-| **ICT-25** (InoculationRL, capstone pont PostTraining) | GPU-required | Planifié [#5105](https://github.com/jsboige/CoursIA/issues/5105) |
-| **ICT-14** (Free energy / Friston) | Implémentation ouverte | [#5089](https://github.com/jsboige/CoursIA/issues/5089), CPU-feasible |
-| **Doublons de nommage** ICT-18 / ICT-19 (versions `_Raffinement`) | Documentation de la transition | À clarifier dans un commit ultérieur (ne pas renommer en c.478 — risque de churn doc ↔ notebook) |
+| **ICT-25** (InoculationRL, capstone pont PostTraining ; phase GPU) | GPU-required | Planifié [#5105](https://github.com/jsboige/CoursIA/issues/5105) — réalignement 3 bras N/I/P avant phase GPU |
 | **Catalogue** (`COURSE_CATALOG.generated.json`) | Régén par `catalog-cron.yml` sur `main` | **NE PAS** régénérer sur branche (cf `catalog-pr-hygiene` R1) — laisser le cron faire |
 
-## 8. Cycle c.478 — ce que cette note livre
+## 8. Ce que cette note livre (PR de transition fondatrice, c.478)
 
 - **Un suivi de transition** (ce fichier) : fil conducteur IIT → ICT, double lecture du sigle, partition `ict/` ↔ PyPhi, strates, ancres théoriques, triade *moyen/fin/enjeu*, lacunes restantes.
 - **Aucun notebook modifié** (ICT-18 et ICT-19 restent *tels quels*, dans la lignée « sans complaisance »).


### PR DESCRIPTION
## Scope

Passe de **cohérence** sur les docs de cadrage de la série ICT (Epic #4588), pour repartir sur une base propre. **Dé-croûtage ciblé, aucune réécriture** — tout le contenu pédagogique et le cadrage technique publique-sûr sont préservés. Deux fichiers docs, catalogue byte-identique, zéro notebook touché.

## Changements

### `ICT-0-Framing.md`
- **Collapse** de la section `## ICT-19 — squelette de spec` (~60 lignes) en un pointeur : ICT-19 / ICT-19b sont **livrés** (#5489 / #5728), la spec de cadrage complète reste dans l'issue #5483 et les notebooks. *(Consolider != Archiver : contenu durable préservé à sa source avant de trimmer.)*
- **Resserrage** de « Extensions 2026-07 » front 1 (ICT-18b livré) — les verdicts P1 PASS / P2 DISSOCIATION / P3 PASS vivent déjà dans la feuille de route + le notebook ; on garde le cadrage, on retire la duplication.

### `docs/suivis/iit-ict-transition.md`
- **Dé-datée** : requalifiée en note de transition durable, provenance c.478 / po-2025 conservée en en-tête et signature.
- **De-stale** : ICT-14/16/17/24 marqués « prévu / à construire » -> **livrés** ; ICT-19 « a démarré » -> **livré** ; lignes « Lacunes restantes » désormais délivrées retirées ; renommage ICT-18b/19b (#7260) acté ; strate 5 « ICT-15 à ICT-24 » -> « à ICT-25 ».

### Inchangés
- `README.md` de la série + catalogue : déjà à jour, laissés **byte-identiques** (marqueur `CATALOG-STATUS` non touché, cf `catalog-pr-hygiene`).

## Note

Distinct du chantier de fond piloté par la digestion d'insights ChatGPT (réécriture profonde #4588 body / cadrage), qui reste **différé**. Cette PR est la passe légère préalable, à relire d'un coup d'œil.

See #4588

🤖 Generated with [Claude Code](https://claude.com/claude-code)