### PR TITLE
docs(planning_lean,#3979): document i18n FR/EN bilingual coverage (#4980)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/planning_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/planning_lean/README.md
@@ -76,6 +76,8 @@ flowchart TD
 | [`Planning/Relaxation.lean`](Planning/Relaxation.lean) | Exécution réelle `run` et relaxée `runR`, `reaches`/`reachesR`, **monotonie de l'atteignabilité relaxée** `runR_mono`, **lemme central** `run_subset_runR`. |
 | [`Planning/Admissibility.lean`](Planning/Admissibility.lean) | **Théorème phare `relaxed_plan_admissible`** (h⁺ ≤ h\*) : tout plan réel est un plan relaxé. |
 
+- **Couverture i18n (EPIC #4980)** : lake entièrement bilingue FR/EN — 3 modules `.lean` livrés en FR canonique + 3 siblings `*_en.lean` miroirs sur `main` (`Planning/Strips_en.lean`, `Planning/Relaxation_en.lean`, `Planning/Admissibility_en.lean`). Convention EPIC #4980 Option A : docstrings `/-- ... -/` et commentaires `-- ...` diffèrent entre FR et EN, signatures et preuves byte-identiques. Vérifié par `scripts/lean/check_i18n_siblings.py` : 3/3 paires byte-identical, 0 drift, 0 orphan.
+
 ## Théorèmes prouvés (0 sorry)
 
 - `relaxed_plan_admissible : reaches π s g → reachesR π s g` — tout plan réel atteignant


### PR DESCRIPTION
## Summary

`planning_lean` has been a **fully bilingual FR/EN lake** since #5536 (commit `ce79072e5` — *"add Planning.*_en siblings — EN mirrors, planning_lean lake fully bilingual"*), but the README only documented the 3 FR modules. This PR adds the missing i18n coverage section.

## Drift (G.1 firsthand)

- **Disk**: 3 FR modules + 3 EN `*_en.lean` siblings (`Planning/Strips_en.lean`, `Planning/Relaxation_en.lean`, `Planning/Admissibility_en.lean`)
- **README**: last touched by #4328 (Mermaid diagrams) and #4168 (initial) — **before** the EN siblings were added in #5536. The i18n EPIC #4980 coverage was never reflected.
- **`check_i18n_siblings.py`**: 3/3 paires byte-identical, 0 drift, 0 orphan ✓

## Fix

Add a **"Couverture i18n (EPIC #4980)"** bullet under the Modules section, mirroring the pattern already in `sensitivity_lean/README.md`. Documents:
- 3 FR canonical modules + 3 EN sibling mirrors
- Option A byte-identity convention (docstrings/comments FR vs EN, signatures/proofs byte-identical)
- `check_i18n_siblings.py` verification (3/3 byte-identical, 0 drift, 0 orphan)

## Validation (G.1)

```
$ python scripts/lean/check_i18n_siblings.py MyIA.AI.Notebooks/SymbolicAI/Planners/planning_lean
OK      Planning/Admissibility_en.lean
OK      Planning/Relaxation_en.lean
OK      Planning/Strips_en.lean
3/3 pairs byte-identical | 0 consumer-pattern | 0 drift | 0 orphan | 0 unbuilt
```

sorry=0 + no `sorryAx` unchanged (verified firsthand: `grep -rnE '^\s*sorry\b|:=\s*sorry\b' Planning/` = 0, no `axiom`/`sorryAx` declarations). Toolchain `v4.31.0-rc1` unchanged.

## Scope (atomique)

| File | Change |
|---|---|
| `planning_lean/README.md` | +2/-0 (1 i18n coverage bullet) |

1 fichier, 1 sujet (document bilingual coverage), 1 domaine (Lean math). Sous les seuils G.4.

## Conformité

- **R1 catalog-pr-hygiene**: N/A — pas un hub README (0 marqueur `CATALOG-STATUS` dans `planning_lean/README.md`).
- **R3 atomique**: 1 fichier, 1 sujet.
- **R4**: `See #3979` strict (planning_lean = "autres séries Lean math" dans mon scope partition #3979 ; acceptance #3979 large, contribution partielle).
- **readme-french-first**: contenu FR ✓.
- **G-VAR-3**: prev = guard (c.728 mine_lean_sessions) → readme-i18n = genre distinct ✓.

See #3979 (Lean math READMEs — partition po-2026:CoursIA-2).
See #4980 (Lean i18n FR-first canonical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>