### PR TITLE
fix(notebook-tools): force LF in generate_parcours output (Windows CRLF pollution, See #7422)

### DIFF
--- a/scripts/notebook_tools/generate_parcours.py
+++ b/scripts/notebook_tools/generate_parcours.py
@@ -239,7 +239,11 @@ def main():
         else:
             PARCOURS_DIR.mkdir(parents=True, exist_ok=True)
             out_path = PARCOURS_DIR / f"{pid}.md"
-            out_path.write_text(page, encoding="utf-8")
+            # newline="\n" forces LF: on Windows, Path.write_text's default
+            # text mode translates "\n" -> "\r\n", polluting the committed LF
+            # files (docs/curriculum/*.md are LF per .gitattributes) with a
+            # 100%+ line churn on every regen. Force LF so regen is byte-clean.
+            out_path.write_text(page, encoding="utf-8", newline="\n")
             print(f"  {pid}: {out_path} ({len(filtered)} notebooks)")
 
     if not args.dry_run and not args.parcours:


### PR DESCRIPTION
**Grain: LIGHT / tooling-fix** (EPIC #7422 curriculum docs hygiene).

## Bug

`scripts/notebook_tools/generate_parcours.py` wrote parcours pages via:
```python
out_path.write_text(page, encoding="utf-8")
```
On **Windows**, `Path.write_text`'s default text mode translates `"\n"` → `os.linesep` (`"\r\n"`), so running the generator locally on Windows pollutes the committed **LF** files (`docs/curriculum/*.md` are LF per `.gitattributes`) with a **100%+ line churn on every regen**.

The catalog-cron regen (#7503) runs on **Linux CI** where `os.linesep="\n"`, so it was unaffected — the bug only manifests on a **Windows local run** (e.g. a worker refreshing curriculum docs firsthand, as I did triaging #7422 this cycle).

## Fix

```python
out_path.write_text(page, encoding="utf-8", newline="\n")
```
`newline="\n"` forces LF output, platform-independent.

## Proof (firsthand, this worktree from origin/main @ 4d3e513ff)

| | Result |
|--|--------|
| **Before fix** — run `generate_parcours.py` | 1178/1178 line churn across all 5 parcours `.md` (pure CRLF pollution, zero content change) |
| **After fix** — run `generate_parcours.py` | **byte-IDENTICAL** output to all 5 committed curriculum docs (**0 diff**) |
| `test_generate_parcours.py` | **22/22 PASS** |

The 0-diff regen proves two things at once:
1. **The fix works** — generator now emits LF matching committed files.
2. **The committed curriculum docs are current** — `ia-symbolique.md` claims 220 notebooks = real SymbolicAI inventory (1 root + 22 Argument_Analysis + 28 Lean + 23 Planners + 42 SMT + 25 SemanticWeb + 27 SmartContracts + 20 SymbolicLearning + 32 Tweety). No content drift to fix; the generator just needed to be safe to re-run on Windows.

## Scope

- **1 file changed, +5/-1** (`scripts/notebook_tools/generate_parcours.py`). Atomic.
- No notebook / catalogue / curriculum-doc content change.
- Catalogue byte-identical to main.

See #7422 (curriculum docs hygiene epic).

Co-Authored-By: Claude <noreply@anthropic.com>