### PR TITLE
docs(harness,#3801): Prong-B anti-fabrication caveat — measure discrimination firsthand

### DIFF
--- a/.claude/rules/sota-not-workaround.md
+++ b/.claude/rules/sota-not-workaround.md
@@ -34,6 +34,14 @@ Cas canonique : **BFS vs A*** sur un graphe a cout uniforme (A* degenere en BFS,
 
 Action : **complexifier le probleme existant** OU **ajouter un probleme additionnel plus riche**, de sorte que la capacite annoncee soit **visible dans la sortie**. **Modulo un temps de traitement raisonnable** : viser un probleme **discriminant mais borne**, pas un benchmark de plusieurs minutes dans un notebook pedagogique.
 
+### Verification anti-fabrication — mesurer la discrimination AVANT de clamer « heuristique X echoue »
+
+Un enrichissement Prong-B ne se declare pas sur un **pitch plausible** (« les heuristiques gloutonnes rattrapent le nombre chromatique sur les graphes de Mycielski, donc CP-SAT est essentiel ») : on **mesure** d'abord la discrimination firsthand (installer le solveur, regle F, comparer resultat-heuristique vs χ exact sur le graphe candidat). Un pitch non mesure = violation G.9 en attente d'etre livree.
+
+**Anti-exemple verifie firsthand (c.598, ortools 9.15 + networkx 3.4.2)** : sur les graphes de Mycielski standard M_3 (C5), M_4 (Grotzsch), M_5, la coloration gloutonne **et** DSATUR **avec l'ordre networkx par defaut** trouvent **le** χ (3/4/5) — le folklore « greedy rattrape sur Mycielski » **ne reproduit pas** ici (il exige des ordres de sommets adversariaux). S'en servir comme cas Prong-B de coloration = fabriquer un enrichissement faux. Le vrai cas discriminant pour CP-SAT en coloration est le **graphe aleatoire dense Erdos-Renyi G(n, p>=0.3)** (greedy utilise strictement plus de couleurs que χ) — et App-2-GraphColoring le demontre deja (cell benchmark : n=200, greedy=22 / DSATUR=19 / CP-SAT=18).
+
+**Faux signal technique** : un notebook MiniZinc couvre l'optimisation via la syntaxe `solve minimize obj;` (chaine dans le modele), **pas** via `.minimize(` Python — un `grep '.minimize('` renvoie `opt=0` sur des notebooks qui traitent bel et bien l'optimisation. Pour MiniZinc, grepper `solve (min|max)imize` dans les chaines de modele.
+
 ## Comportement des bots reviewers (signaler + enforce)
 
 Les bots **DOIVENT** poster `CHANGES_REQUESTED` quand une PR notebook (interne/contributeur) :


### PR DESCRIPTION
## Summary

Adds a **"Verification anti-fabrication"** sub-section to **Prong B** of [.claude/rules/sota-not-workaround.md](.claude/rules/sota-not-workaround.md), serving the user's **#3801 msg2** mandate to « tenir un registre et **resserrer le harnais** ».

## Why

Prong-B enrichments must not be declared on a **plausible pitch** — they must be **measured firsthand**. This codifies a G.9 (anti-fabrication) verification step that prevents future workers from shipping unmeasured-claim enrichments.

## Firsthand-verified datum (c.598)

ortools 9.15 + networkx 3.4.2 (installed per rule F). The textbook pitch **« greedy/DSATUR overshoot χ on Mycielski graphs, so CP-SAT exact optimization is essential »** **DOES NOT REPRODUCE** on standard M_3 (C5) / M_4 (Grötzsch) / M_5 with networkx default ordering — both heuristics find χ (3/4/5). Reaching for Mycielski as the graph-coloring Prong-B fix would ship a **fabricated** enrichment. The real discriminating case is dense **Erdős-Rényi G(n, p≥0.3)**, already demonstrated by App-2-GraphColoring (benchmark cell: n=200 → greedy=22 / DSATUR=19 / CP-SAT=18).

Also documents a **false-signal**: MiniZinc notebooks use `solve minimize obj;` syntax (string in model), not Python `.minimize(` — a grep for the latter returns `opt=0` on notebooks that DO cover optimization.

## Scope

1 file, +8/-0 (purely additive — anti-regression §D compliant). No §B content removed, no pendulum (new datum, not swinging an existing line). UTF-8 no-BOM, LF (matches existing).

## Context

This is a harness refinement grounded in firsthand measurement across c.598 (9 G.1 firsthand catches confirming SymbolicAI families Search/CSP/Planners/SMT/Z3/SmartContracts are SOTA-OK + discriminating — the Prong-B space there is genuinely drained). The lesson is durable and also saved to per-machine memory as `prong-b-mycielski-greedy-no-overshoot`.

See #3801 (not `Closes` — partial harness contribution to the epic). Related: #7423 (harness global review).

Grain: LIGHT/harness-rule — lane po-2026:CoursIA — prev: —/— (c.598 drainage, 0 PR). Evidence-backed (firsthand ortools measurement), sanctioned by user #3801 msg2 mandate. PROTOCOLE-VARIATION: 1 LIGHT this lane today, no prior LIGHT PR genre, within G-VAR-2/G-VAR-3.
