### PR TITLE
fix(prover,#7477): checkpoint aliasing in restore_checkpoint breaks snapshot immutability

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/state.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/state.py
@@ -211,7 +211,20 @@ class ProofState:
         return label
 
     def restore_checkpoint(self, label: str) -> bool:
-        """Restore state from a named checkpoint (B.8). Returns True if found."""
+        """Restore state from a named checkpoint (B.8). Returns True if found.
+
+        The mutable fields (``current_proof``, ``discovered_lemmas``, ``plan``,
+        ``sorry_goals``) are **re-copied** here, mirroring the defensive copies
+        ``save_checkpoint`` already makes on the way in. Without these copies
+        ``self.<field>`` would alias the list/dict object stored under
+        ``self._checkpoints[label]``: a subsequent ``add_tactic_attempt`` /
+        ``add_lemma`` / ``sorry_goals[k] = v`` would then mutate the STORED
+        checkpoint in place, so a second ``restore_checkpoint(label)`` would
+        return the corrupted (post-mutation) state instead of the snapshot --
+        silently breaking the preserve/revert gate (``_build_check_or_revert``,
+        cf #7477). Verified firsthand: pre-fix, restore -> add_tactic_attempt
+        -> re-restore returned the appended tactic (c.732).
+        """
         cp = self._checkpoints.get(label)
         if not cp:
             return False
@@ -219,16 +232,16 @@ class ProofState:
         self.phase = ProofPhase(cp["phase"])
         self.iteration = cp["iteration"]
         self.current_goal = cp["current_goal"]
-        self.current_proof = cp["current_proof"]
+        self.current_proof = list(cp["current_proof"])  # c.732: copy, don't alias
         self.consecutive_failures = cp["consecutive_failures"]
         self.error_count = cp["error_count"]
         self.best_sorry_count = cp["best_sorry_count"]
         self.consecutive_delta0_compiles = cp.get("consecutive_delta0_compiles", 0)
         self.consecutive_compile_fail = cp.get("consecutive_compile_fail", 0)  # P4 (c.317b)
-        self.discovered_lemmas = cp["discovered_lemmas"]
-        self.plan = cp["plan"]
+        self.discovered_lemmas = list(cp["discovered_lemmas"])  # c.732: copy, don't alias
+        self.plan = list(cp["plan"])  # c.732: copy, don't alias
         self.plan_phase = cp["plan_phase"]
-        self.sorry_goals = cp["sorry_goals"]
+        self.sorry_goals = dict(cp["sorry_goals"])  # c.732: copy, don't alias
         return True
 
     def list_checkpoints(self) -> List[str]:

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_state_checkpoint_aliasing.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_state_checkpoint_aliasing.py
@@ -1,0 +1,176 @@
+"""Regression suite for ``prover.state.ProofState`` checkpoint immutability (c.732, #7477).
+
+Background. ``save_checkpoint`` makes defensive copies of the mutable fields
+(``list(self.current_proof)``, ``list(self.discovered_lemmas)``,
+``list(self.plan)``, ``dict(self.sorry_goals)``) so each stored checkpoint is
+an independent snapshot. ``restore_checkpoint`` historically assigned the
+STORED list/dict reference directly (``self.current_proof = cp["current_proof"]``)
+instead of re-copying -- so after a restore, ``self.current_proof`` WAS the
+checkpoint's list object. Any subsequent mutation via the normal API
+(``add_tactic_attempt`` appends to ``current_proof``; ``add_lemma`` appends to
+``discovered_lemmas``; ``provers.py:1384 state.sorry_goals[k] = v``) then
+corrupted the STORED checkpoint in place, and a second ``restore_checkpoint``
+of the same label returned the post-mutation state instead of the snapshot.
+
+This silently breaks the preserve/revert gate (``tools._build_check_or_revert``
+relies on a checkpoint being an immutable fallback to revert to when a
+candidate edit does not compile clean) -- exactly the class of subtle harness
+integrity pathology the #7477 forensic catalogues.
+
+These tests pin the contract: **a checkpoint is an immutable snapshot; restore
+does not alias it; restore-then-mutate-then-restore round-trips to the
+original snapshot.** G.9 non-vacuous: against the pre-fix ``restore_checkpoint``
+the ``test_*_not_aliased`` cases FAIL (the stored list gains the appended
+entry), so the suite genuinely guards the fix.
+
+Stdlib-only -- imports ``ProofState`` via ``sys.path`` insert exactly like
+``test_prover_guards.py`` (#7477), so it runs without the LLM stack.
+
+Run: ``python -m pytest tests/test_state_checkpoint_aliasing.py -q``
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make `prover/` importable regardless of how pytest was invoked.
+ROOT = Path(__file__).resolve().parents[1]  # agent_tests/
+sys.path.insert(0, str(ROOT))
+
+from prover.state import ProofState  # noqa: E402
+
+
+def _fresh_state() -> ProofState:
+    return ProofState(theorem_name="t", current_goal="g")
+
+
+# ---------------------------------------------------------------------------
+# current_proof aliasing
+# ---------------------------------------------------------------------------
+
+
+def test_current_proof_not_aliased_after_restore():
+    """After restore, appending a tactic must NOT mutate the stored checkpoint."""
+    ps = _fresh_state()
+    ps.current_proof.append("tactic_A")
+    label = ps.save_checkpoint("cp")
+    ps.restore_checkpoint(label)
+    ps.add_tactic_attempt("tactic_B", success=True)  # appends to current_proof
+    stored = ps._checkpoints[label]["current_proof"]
+    assert stored == ["tactic_A"], (
+        f"checkpoint current_proof was aliased/mutated: {stored}"
+    )
+
+
+def test_current_proof_roundtrip_after_mutation():
+    """restore -> mutate -> restore must return the ORIGINAL snapshot."""
+    ps = _fresh_state()
+    ps.current_proof.append("tactic_A")
+    label = ps.save_checkpoint("cp")
+    ps.restore_checkpoint(label)
+    ps.add_tactic_attempt("tactic_B", success=True)
+    ps.current_proof.append("tactic_C")
+    assert ps.restore_checkpoint(label) is True
+    assert ps.current_proof == ["tactic_A"], (
+        f"second restore did not return the snapshot: {ps.current_proof}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# discovered_lemmas aliasing
+# ---------------------------------------------------------------------------
+
+
+def test_discovered_lemmas_not_aliased_after_restore():
+    """After restore, add_lemma must NOT mutate the stored checkpoint."""
+    ps = _fresh_state()
+    ps.add_lemma("lem1", statement="stmt1")
+    label = ps.save_checkpoint("cp")
+    ps.restore_checkpoint(label)
+    ps.add_lemma("lem2", statement="stmt2")  # appends to discovered_lemmas
+    stored = ps._checkpoints[label]["discovered_lemmas"]
+    assert len(stored) == 1, f"checkpoint discovered_lemmas was aliased: {stored}"
+    assert "lem1" in stored[0]
+    assert not any("lem2" in s for s in stored)
+
+
+# ---------------------------------------------------------------------------
+# sorry_goals aliasing (mutated live by provers.py:1384)
+# ---------------------------------------------------------------------------
+
+
+def test_sorry_goals_not_aliased_after_restore():
+    """After restore, an external sorry_goals[k]=v must NOT mutate the stored
+    checkpoint (provers.py:1384 does exactly this assignment)."""
+    ps = _fresh_state()
+    ps.sorry_goals[5] = "goal_at_5"
+    label = ps.save_checkpoint("cp")
+    ps.restore_checkpoint(label)
+    ps.sorry_goals[9] = "goal_at_9"  # mirrors provers.py:1384
+    stored = ps._checkpoints[label]["sorry_goals"]
+    assert stored == {5: "goal_at_5"}, (
+        f"checkpoint sorry_goals was aliased: {stored}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# plan aliasing
+# ---------------------------------------------------------------------------
+
+
+def test_plan_not_aliased_after_restore():
+    """After restore, appending to plan must NOT mutate the stored checkpoint."""
+    ps = _fresh_state()
+    ps.plan.append("step1")
+    label = ps.save_checkpoint("cp")
+    ps.restore_checkpoint(label)
+    ps.plan.append("step2")
+    stored = ps._checkpoints[label]["plan"]
+    assert stored == ["step1"], f"checkpoint plan was aliased: {stored}"
+
+
+# ---------------------------------------------------------------------------
+# Full round-trip independence across multiple checkpoints
+# ---------------------------------------------------------------------------
+
+
+def test_two_checkpoints_independent():
+    """Two distinct checkpoints must stay independent even when the live state
+    is mutated between restores -- no cross-contamination via shared aliases."""
+    ps = _fresh_state()
+    ps.current_proof.append("a")
+    cp1 = ps.save_checkpoint("cp1")
+    ps.current_proof.append("b")
+    cp2 = ps.save_checkpoint("cp2")
+    # Mutate live state heavily
+    ps.add_tactic_attempt("c", success=True)
+    ps.add_lemma("L", statement="S")
+    ps.sorry_goals[1] = "g1"
+    # Both stored checkpoints must be untouched
+    assert ps._checkpoints[cp1]["current_proof"] == ["a"]
+    assert ps._checkpoints[cp2]["current_proof"] == ["a", "b"]
+    assert ps._checkpoints[cp1]["discovered_lemmas"] == []
+    assert ps._checkpoints[cp2]["discovered_lemmas"] == []
+    assert ps._checkpoints[cp1]["sorry_goals"] == {}
+    assert ps._checkpoints[cp2]["sorry_goals"] == {}
+    # Restoring either must give its own snapshot, not the mutated live state
+    ps.restore_checkpoint(cp1)
+    assert ps.current_proof == ["a"]
+    ps.restore_checkpoint(cp2)
+    assert ps.current_proof == ["a", "b"]
+
+
+# ---------------------------------------------------------------------------
+# Restore of a missing checkpoint
+# ---------------------------------------------------------------------------
+
+
+def test_restore_missing_checkpoint_returns_false():
+    """Restoring an unknown label returns False and leaves state untouched."""
+    ps = _fresh_state()
+    ps.current_proof.append("x")
+    assert ps.restore_checkpoint("does_not_exist") is False
+    assert ps.current_proof == ["x"]


### PR DESCRIPTION
Grain: MED/fix — lane myia-po-2026:CoursIA-2 — prev: MED/test (c.731)

## Bug

`save_checkpoint` makes defensive copies of the mutable fields (`current_proof`, `discovered_lemmas`, `plan`, `sorry_goals`) so each stored checkpoint is an independent snapshot. `restore_checkpoint` historically assigned the STORED list/dict reference directly (`self.current_proof = cp["current_proof"]`), so after a restore `self.<field>` WAS the checkpoint's list object. Any subsequent mutation via the normal API then corrupted the STORED checkpoint in place, and a second `restore_checkpoint` of the same label returned the post-mutation state instead of the snapshot.

This silently breaks the **preserve/revert gate** (`_build_check_or_revert` relies on a checkpoint being an immutable fallback to revert to when a candidate edit does not compile clean) — exactly the class of subtle harness-integrity pathology the #7477 forensic catalogues.

**Mutation vectors (live in the harness):**
- `add_tactic_attempt(..., success=True)` appends to `current_proof`
- `add_lemma(...)` appends to `discovered_lemmas`
- `provers.py:1384 state.sorry_goals[sorry_line] = goal_state` mutates `sorry_goals`
- `plan` appends in CoordinatorAgent plan-building

## G.1 firsthand reproduction (pre-fix, c.732)

```python
ps.current_proof.append('tactic_A')
label = ps.save_checkpoint('cp')
ps.restore_checkpoint(label)
ps.add_tactic_attempt('tactic_B', success=True)   # appends tactic_B
ps._checkpoints[label]['current_proof']
# -> ['tactic_A', 'tactic_B']   <-- STORED checkpoint mutated (BUG)
ps.restore_checkpoint(label)
ps.current_proof
# -> ['tactic_A', 'tactic_B']   <-- 2nd restore = corrupted, not snapshot
```

Same aliasing reproduced on `discovered_lemmas`, `sorry_goals`, `plan`.

## Fix

`restore_checkpoint` re-copies the 4 mutables (`list()`/`dict()`), mirroring exactly the defensive copies `save_checkpoint` makes on the way in. New docstring documents the contract.

## G.9 non-vacuous proof

De-patching the 4 copies back to aliasing makes **5 of 7** new tests FAIL (the aliasing discriminators: `test_current_proof_not_aliased_after_restore`, `test_current_proof_roundtrip_after_mutation`, `test_discovered_lemmas_not_aliased_after_restore`, `test_sorry_goals_not_aliased_after_restore`, `test_plan_not_aliased_after_restore`); 2 pass (`test_two_checkpoints_independent` save-time path + `test_restore_missing_checkpoint_returns_false`, which don't exercise restore-then-mutate). Re-patched → **7/7 pass**.

## Validation

- `python -m pytest tests/test_state_checkpoint_aliasing.py -q` → **7/7 passed**
- `python -m pytest tests/ -q` → **534/534 passed** (origin/main baseline 527 + 7 new). c.731 `test_read_lines_from_source` not yet in origin/main (tracked in PR #7698), hence the 534 vs c.731's 545.
- Diff: 2 files, +194/-5 (state.py fix +18/-5, regression suite +176/-0). Atomic, one subject.

See #7477