### PR TITLE
docs(sw): SW-8 — interprétation rapport SHACL à sévérités multiples (Violation/Warning/Info)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb
@@ -2587,6 +2587,34 @@
   },
   {
    "cell_type": "markdown",
+   "id": "9b53391a",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : que dit ce rapport de validation à sévérités multiples ?\n",
+    "\n",
+    "Le rapport renvoyé par `pyshacl` mélange **trois niveaux de sévérité** sur le produit invalide `ex:prod2`. Cette hiérarchie est centrale pour comprendre comment SHACL sépare le *blocage* de la *simple remarque*.\n",
+    "\n",
+    "**1. Pourquoi `conforms = False` alors qu'il y a 5 résultats ?**\n",
+    "Le booléen `conforms` est piloté **uniquement par les `sh:Violation`**. Ici on en compte trois : le nom trop court (`\"X\"`), le prix hors bornes (`200000`) et l'absence simultanée de marque **et** de fabricant. Les `sh:Warning` (catégorie manquante) et `sh:Info` (description trop courte) sont bien présents dans le rapport mais **ne font pas basculer** `conforms` : ils informent l'utilisateur sans invalider la donnée. C'est ce qui distingue une *erreur fatale* d'une *alerte* ou d'une *suggestion*.\n",
+    "\n",
+    "**2. Le rôle de `sh:or` (contrainte logique OU).**\n",
+    "La troisième Violation provient d'un `sh:or` : la forme exige qu'un produit ait **soit** une `schema:brand` **soit** un `schema:manufacturer`. Comme `prod2` n'a ni l'un ni l'autre, aucune branche du OU n'est satisfaite → Violation. Si `prod2` avait eu seulement une marque, la contrainte serait passée. `sh:or` (comme `sh:and`, `sh:not`, `sh:xone`) permet d'exprimer des combinaisons logiques que des contraintes atomiques ne sauraient capturer.\n",
+    "\n",
+    "**3. Le design intentionnel des trois sévérités.**\n",
+    "\n",
+    "| Sévérité | Sémantique | Effet sur `conforms` | Cas typique |\n",
+    "|----------|------------|---------------------|-------------|\n",
+    "| `sh:Violation` (défaut) | Contrainte dure violée | `False` | Champ obligatoire absent, type incorrect |\n",
+    "| `sh:Warning` | Anomalie suspecte | inchangé | Donnée facultative mais recommandée absente |\n",
+    "| `sh:Info` | Remarque informative | inchangé | Convention de style non respectée |\n",
+    "\n",
+    "> **À retenir** : un `conforms = True` ne signifie **pas** « zéro résultat dans le rapport » — il signifie « zéro `sh:Violation` ». Pour un audit complet, il faut donc lire le rapport entier (Violations + Warnings + Infos), pas seulement le booléen. Inversement, un pipeline automatisé qui rejette les données peut se contenter de `conforms` : les Warning/Info sont destinés à un humain, pas à un gate automatique."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "exemple-042a82e3",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
Grain: MED/notebook-enrichment — lane myia-po-2025:CoursIA — prev: MED/notebook-enrichment (IIT-1 #7705 c.610)

## Gap (G.1-verified firsthand, worktree off origin/main @4d3e513ff)

`SW-8-Python-SHACL.ipynb` cell 47 (code, ec=18, "Exemple guide 6 : ProductShape - Sévérités et sh:or") generates a **mixed-severity** validation report on `ex:prod2`:
- **3 × sh:Violation** : nom trop court (`"X"`), prix hors bornes (`200000`), ni marque ni fabricant (via `sh:or`)
- **1 × sh:Warning** : catégorie manquante
- **1 × sh:Info** : description trop courte (`"court"`)
- → `Conforme : False` (5 results, 3 distinct severities)

The student reads the raw report with **no interpretation**: cell 46 = "Exemple guide 6" title, cell 48 = jumps straight to "Exemple guide 7 : BibliographicRecordShape". Three pedagogically central points were missing:
1. Why is `conforms = False` driven by the 3 Violations **alone** (not by all 5 results)?
2. Warning/Info are reported but **do not flip** the boolean.
3. The `sh:or` mechanism (logical OR: brand OR manufacturer required).

## Fix (MED — pedagogical markdown interpretation)

One new markdown cell inserted after cell 47 (becomes index 48; Exemple guide 7 shifts to 49). In French:
- **conforms is driven ONLY by sh:Violation** — the 3 Violations here make conforms=False; the Warning and Info are present but non-blocking.
- **sh:or role** : brand OR manufacturer; prod2 has neither → Violation. Contrasts with sh:and/sh:not/sh:xone.
- **A severity table** (semantics / effect on conforms / typical use) for Violation/Warning/Info.
- **Takeaway** : conforms=True means "zero Violations", not "zero results"; a full audit reads the whole report, an automated gate can rely on conforms.

## Scope

One new markdown cell. 1 file, +28/0. No code cell touched.

## Validation (H.1 / H.3)

- **Markdown-only edit** → rule C.2 exception: pre-existing outputs remain valid, no re-execution (pyshacl not in local kernel; the interpretation cell carries no code/output). The severities cited in the new cell (3 Violation / 1 Warning / 1 Info) were verified firsthand against cell 47's actual output via a regex guard before commit.
- All **23 code cells retain execution_count** and their outputs.
- C.1: `grep -nE "raise NotImplementedError|assert False|1/0"` → **0 violations**.
- nbformat 4.5 `validate` OK.
- Catalogue byte-identical (no catalog file in diff).
- Surgical rebuild C.3: diff vs origin/main = ONLY the new markdown cell (id `9b53391a`) between the ProductShape code cell and Exemple guide 7. No RNG/timing/output drift elsewhere.

## HORS scope (exercise-example-labeling rule)

The code cell carries the comment `# Exercice 3 : ProductShape...` while the preceding markdown title says `### Exemple guide 6`. By content (complete working solution + validation + report output) this is an EXEMPLE, so the `# Exercice 3` comment is arguably a mislabel. **This PR does NOT relabel** — it enriches only. Relabeling is a separate concern. Flagged here for visibility, not actioned.

## Variation (R6 / G-VAR-3)

c.610 = MED/notebook-enrichment IIT-1 (Φ cause-effect invariance). c.611 = MED/notebook-enrichment SW-8 (SHACL mixed-severity). Same MED/enrichment genre consecutive — **permitted under G-VAR-3** because the domain reasoning is genuinely distinct (IIT integrated-information theory ≠ SHACL validation severity semantics), and these are MED grains (not LIGHT, so the consecutive-genre ban does not apply). Fresh SemanticWeb family.

## Collision-check (G.1 firsthand)

- `gh pr list --state open` (REST) → 0 open PR on SW-8 / SHACL / SW-13 / reasoner.
- `git ls-remote --heads origin` → no `sw-8`/`shacl` branch. (A stale branch `audit/sw13-reasoners-fidelity-3164` exists for SW-13 with no open PR — SW-13 avoided this cycle out of caution; SW-8 is clean.)

See #3801 (SOTA enrichment axis).

Generated with Claude Code