### PR TITLE
docs(ml): ML-3 — interprétation résultats entraîneurs + hyper-paramètres

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-3-Entrainement&AutoML.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-3-Entrainement&AutoML.ipynb
@@ -307,6 +307,22 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a3d30001",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : adapter la famille de modèle à la structure des données\n",
+    "\n",
+    "Sur ce jeu de données **linéaire**, l'entraîneur linéaire `SDCA` atteint une RMSE d'environ **2,9**, alors que `LightGbm` (arbres de boosting) plafonne autour de **120** — un écart d'environ **40×**. Ce ratio spectaculaire illustre concrètement le théorème *« no free lunch »* : aucun algorithme n'est universellement supérieur, et la performance dépend avant tout de l'adéquation entre la famille de modèle et la structure du signal.\n",
+    "\n",
+    "`LightGbm` est conçu pour capturer des relations non linéaires par morceaux ; appliqué à une dépendance purement linéaire, il n'exploite pas la régularité globale du signal et paie ici le prix fort. À l'inverse, `SDCA` (régression linéaire régularisée) correspond exactement à la forme générative des données.\n",
+    "\n",
+    "**Leçon pratique** : face à un nouveau jeu de données, il faut donc **essayer plusieurs familles d'entraîneurs** et comparer leurs performances plutôt que d'en privilégier une a priori. C'est précisément cette recherche comparative qu'`AutoML` va automatiser dans la section suivante.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "04a214e2",
    "metadata": {
     "papermill": {
@@ -387,6 +403,22 @@
     "var largeLgbmMetric = context.Regression.Evaluate(largeLgbmEval, \"y\");\n",
     "\n",
     "Console.WriteLine($\"small lgbm rmse sur testset: {smallLgbmMetric.RootMeanSquaredError}, large lgbm rmse sur testset: {largeLgbmMetric.RootMeanSquaredError}\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a3d30002",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : sensibilité aux hyper-paramètres\n",
+    "\n",
+    "Sur les données non linéaires ($y = 100 x^2 + \\text{bruit}$), `LightGbm` avec peu de feuilles (`numberOfLeaves = 10`, RMSE ≈ **173 938**) reste nettement moins performant qu'avec une capacité plus large (`numberOfLeaves = 1000`, RMSE ≈ **132 927**) — la RMSE du modèle le plus petit est environ **31 % plus élevée**.\n",
+    "\n",
+    "Cette fois, **le même algorithme** produit des résultats très différents selon la valeur d'un seul hyper-paramètre : avec trop peu de feuilles, le modèle est en **sous-apprentissage** (capacité insuffisante pour épouser la courbure $x^2$) et laisse un résidu important. Passer de 10 à 1000 feuilles lui donne la flexibilité nécessaire pour capturer la non-linéarité.\n",
+    "\n",
+    "**Leçon pratique** : choisir le bon algorithme (Exemple 1) ne suffit pas — il faut aussi **régler ses hyper-paramètres**. Cette double recherche (sélection d'algorithme + optimisation des hyper-paramètres) est fastidieuse à la main ; c'est exactement la tâche qu'`AutoML` (section suivante) rationalise en l'automatisant.\n"
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-enrichment — lane myia-po-2023:CoursIA — prev: SCAN-PRECISION/anti-fabrication (c.755)

## Gap (G.1-verified firsthand, worktree off origin/main @4d3e513ff)

`ML-3-Entrainement&AutoML.ipynb` avait **2 cellules code produisant un résultat concept-key sans aucune cellule markdown d'interprétation** :

**Cell [5]** (ec=3) — entraîneurs sur données linéaires :
```
sdca rmse sur trainset: 2,88..., lgbm rmse sur trainset: 117,95...
sdca rmse sur testset: 2,92..., lgbm rmse sur testset: 119,86...
```
SDCA (~2,9) vs LightGbm (~120) → **écart ~40×**. La cellule suivante [6] est le header `## Exemple 2` + méthodologie : **zéro interprétation** du ratio. C'est la motivation centrale du notebook (et de l'AutoML introduit 2 cellules plus loin).

**Cell [7]** (ec=4) — sensibilité hyper-paramètres sur données non-linéaires :
```
small lgbm rmse sur testset: 173938,..., large lgbm rmse sur testset: 132927,...
```
LightGbm `numberOfLeaves=10` vs `1000` → **RMSE du petit ~31 % plus élevée**. La cellule [6] *précédente* annonce « l'importance de l'optimisation des hyper-paramètres » — mais les chiffres réels de [7] n'étaient **jamais interprétés**. La cellule suivante [8] est `## AutoML`.

## Fix

2 cellules markdown FR d'interprétation insérées (après cell 5, après cell 7), thème unifié « interpréter les résultats empiriques qui motivent AutoML » :

- **« adapter la famille de modèle à la structure des données »** — théorème *no free lunch* : `LightGbm` (arbres) appliqué à un signal purement linéaire n'exploite pas la régularité globale ; `SDCA` (linéaire régularisé) correspond à la forme générative. Leçon : essayer plusieurs familles → motive la recherche comparative d'AutoML.
- **« sensibilité aux hyper-paramètres »** — le même algorithme donne des résultats très différents selon un seul hyper-paramètre ; trop peu de feuilles = sous-apprentissage. Leçon : il faut aussi régler les hyper-paramètres → motive l'HPO automatisée d'AutoML.

## Validation

- **diff purement additif** : `+32/-0`, 1 fichier (`ML-3-Entrainement&AutoML.ipynb`). Aucune cellule code touchée ; code cells `execution_count` **1..9 inchangés** (séquentiels).
- **markdown-only → exception C.2** : outputs pré-existants valides, pas de ré-exec. Insérer des cellules markdown ne change pas le `execution_count` des cellules code (la preuve d'exécution `.NET Interactive` locale — `execution_count != null` — reste intacte sur les 9 cellules code).
- **nbformat 4.5 validate** OK. **Catalogue byte-identical** à main (catalog-pr-hygiene HARD 1 respecté).
- **byte-identity** : round-trip `json.dumps(indent=1, ensure_ascii=False)` vérifié identique au fichier original sur le contenu inchangé (seules les 2 nouvelles cellules sont ajoutées).
- **convention LaTeX confirmée** : ML-4 utilise `$R^2$`/`$-\infty$`, le jumeau **ML-3-Python** utilise la même formule `$y = 100 x^2 + \text{bruit}$` — notation alignée (rendu MathJax standard).
- **collision-check firsthand** : `gh pr list --state open --search ML-3` = aucune PR ne touche `ML-3-Entrainement&AutoML.ipynb` (#7690 est un rename `docs/ml #7688` DataScienceWithAgents ≠ ML-3 notebook).
- **scan delegué (sonnet, read-only)** : 3 gaps HIGH-confidence identifiés dans ML.Net (ML-3×2, ML-7×1), tous G.1-verified firsthand avant claim.

Pas de `Closes` (enrichissement pédagogique auto-contenu). Pas de `See #` spécifique (cf. PR #7705 po-2025 du même registre, sans issue parent).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
