### PR TITLE
docs(ml): ML-7 — interprétation cold start (NaN) sur Top-N recommandations

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-7-Recommendation.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-7-Recommendation.ipynb
@@ -908,6 +908,24 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a7d70001",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : le problème du cold start, observé en direct\n",
+    "\n",
+    "Toutes les notes prédites ci-dessus valent **`NaN`** pour les Films 4 et 5. Ce n'est pas un bug : c'est la manifestation directe du **problème du cold start** (démarrage à froid), la limitation fondamentale du filtrage collaboratif.\n",
+    "\n",
+    "**Pourquoi `NaN` ?** Le modèle de Matrix Factorization a été entraîné sur `movieData`, qui ne contient des notes que pour les Films 1, 2 et 3 (cf. la cellule de configuration du système). Or la fonction de recommandation demande une prédiction pour les Films 4 et 5 — des films **nouveaux**, absents du jeu d'entraînement. La Matrix Factorization apprend un vecteur latent pour chaque film à partir des notes qu'il a reçues : pour un film jamais noté, aucun facteur n'est appris, et le produit scalaire utilisateur·film devient indéfini (`NaN`).\n",
+    "\n",
+    "Par construction, le filtrage collaboratif **ne sait rien faire** pour un item (ou un utilisateur) sans aucune interaction historique. C'est précisément cette limite que la section « Le Cold Start Problem (Schein et al., 2002) », plus bas dans ce notebook, formalise et propose de mitiger (approches content-based, hybrides, biais appris).\n",
+    "\n",
+    "**Leçon à retenir** pour l'évaluation qui suit : un système purement collaboratif est **aveugle aux nouveautés** — une contrainte structurelle à intégrer dans le choix des métriques et le design du système.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "execution_count": null,
    "id": "04d74454",
    "metadata": {


### PR DESCRIPTION
Grain: MED/notebook-enrichment — lane myia-po-2023:CoursIA — prev: ML-3 enrichment (#7707 c.756a)

## Gap (G.1-verified firsthand, worktree off origin/main @4d3e513ff)

`ML-7-Recommendation.ipynb` cell[15] (code, ec=8) — la fonction `RecommendTopMovies` produit :

```
=== Top-3 Recommandations par utilisateur ===
Utilisateur 1: Film 4 : note prédite NaN | Film 5 : note prédite NaN
Utilisateur 2: Film 4 : note prédite NaN | Film 5 : note prédite NaN
Utilisateur 3: Film 4 : note prédite NaN | Film 5 : note prédite NaN
```

**Toutes les prédictions sont `NaN`.** La cellule suivante [16] (`## Évaluation du système de recommandation`) est un tableau générique de métriques (RMSE/MAE/Precision@K/...) — **zéro interprétation du NaN**. Le notebook consacre pourtant une section entière au cold start plus bas (cell[20] « Le Cold Start Problem (Schein et al., 2002) » + cell[31] Exercice 5 « Stratégie de cold start »), **sans jamais la connecter** à l'échec que le lecteur vient d'observer.

## Mécanisme (G.1-verified firsthand)

- `movieData` (cell[3]) ne contient des notes que pour les **Films 1, 2, 3** (5 utilisateurs × 3 films).
- Le modèle Matrix Factorization (cell[9]) est entraîné sur `movieData` → il n'apprend un facteur latent que pour les Films 1-3.
- Cell[15] demande des prédictions pour `allMovieIds = {1,2,3,4,5}` → les **Films 4 et 5 sont des items NOUVEAUX jamais vus** à l'entraînement → pas de facteur latent → produit scalaire user·item indéfini → `NaN`.

C'est la manifestation directe du **cold start problem** (le cas « nouvel item »), la limitation fondamentale du filtrage collaboratif.

## Fix

1 cellule markdown FR d'interprétation insérée après cell[15] : « le problème du cold start, observé en direct » — explique pourquoi `NaN` (aucun facteur latent pour les items non entraînés), relie à la section cold-start ultérieure, et pose la leçon « un système purement collaboratif est aveugle aux nouveautés » pour l'évaluation qui suit.

## Validation

- **diff purement additif +18/-0**, 1 fichier. Code cells `execution_count` inchangés (aucune cellule code touchée).
- **markdown-only → exception C.2** : outputs pré-existants valides, pas de ré-exec. L'insertion d'une cellule markdown ne change pas le `execution_count` des cellules code.
- **byte-identity** : `json.dumps(indent=1, ensure_ascii=False) + "\n"` (convention ML-7) identique au contenu inchangé.
- **ma cellule est propre** (clés `cell_type`/`id`/`metadata`/`source` uniquement). Le `nbformat.validate` strict qui échoue sur cell[0] est **PRÉEXISTANT sur origin/main** (10 markdown cells portent des champs `execution_count`/`outputs` superflus — artefact papermill) — non introduit par ce PR.
- **collision-check firsthand** : aucune PR ouverte ne touche `ML-7-Recommendation.ipynb`.

Pas de `Closes` (enrichissement pédagogique auto-contenu, même registre que #7707).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
