### PR TITLE
fix(search,#7674): CSP-8-Temporal Exercice 2b/3b stubs reachable

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-8-Temporal-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-8-Temporal-Csharp.ipynb
@@ -1298,10 +1298,10 @@
    "id": "6a32f7dd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T00:36:19.270002Z",
-     "iopub.status.busy": "2026-07-04T00:36:19.269718Z",
-     "iopub.status.idle": "2026-07-04T00:36:19.356017Z",
-     "shell.execute_reply": "2026-07-04T00:36:19.356254Z"
+     "iopub.execute_input": "2026-07-21T13:38:58.441051Z",
+     "iopub.status.busy": "2026-07-21T13:38:58.440877Z",
+     "iopub.status.idle": "2026-07-21T13:38:58.481693Z",
+     "shell.execute_reply": "2026-07-21T13:38:58.481436Z"
     }
    },
    "outputs": [
@@ -1311,56 +1311,6 @@
      "text": [
       "Exercice 2b a completer\r\n"
      ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(18,5): warning CS0162: Code inaccessible détecté\r\n",
-      "\r\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<details open=\"open\" class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[  ]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Count</td><td><div class=\"dni-plaintext\"><pre>0</pre></div></td></tr><tr><td>Comparer</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>System.Collections.Generic.EnumEqualityComparer`1[Submission#3+AllenRelation]</code></span></summary><div><table><thead><tr></tr></thead><tbody></tbody></table></div></details></td></tr><tr><td><i>(values)</i></td><td><i>(empty)</i></td></tr></tbody></table></div></details><style>\r\n",
-       ".dni-code-hint {\r\n",
-       "    font-style: italic;\r\n",
-       "    overflow: hidden;\r\n",
-       "    white-space: nowrap;\r\n",
-       "}\r\n",
-       ".dni-treeview {\r\n",
-       "    white-space: nowrap;\r\n",
-       "}\r\n",
-       ".dni-treeview td {\r\n",
-       "    vertical-align: top;\r\n",
-       "    text-align: start;\r\n",
-       "}\r\n",
-       "details.dni-treeview {\r\n",
-       "    padding-left: 1em;\r\n",
-       "}\r\n",
-       "table td {\r\n",
-       "    text-align: start;\r\n",
-       "}\r\n",
-       "table tr { \r\n",
-       "    vertical-align: top; \r\n",
-       "    margin: 0em 0px;\r\n",
-       "}\r\n",
-       "table tr td pre \r\n",
-       "{ \r\n",
-       "    vertical-align: top !important; \r\n",
-       "    margin: 0em 0px !important;\r\n",
-       "} \r\n",
-       "table th {\r\n",
-       "    text-align: start;\r\n",
-       "}\r\n",
-       "</style>"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -1379,18 +1329,22 @@
     "try\n",
     "{\n",
     "    if (stpAvecB == null || stpSansB == null)\n",
-    "        Console.WriteLine(\"Exercice 2b a completer\"); return new HashSet<AllenRelation>();;\n",
+    "    {\n",
+    "        Console.WriteLine(\"Exercice 2b a completer\");\n",
+    "    }\n",
+    "    else\n",
+    "    {\n",
+    "        var (okA, solA) = stpAvecB.Solve();\n",
+    "        var (okS, solS) = stpSansB.Solve();\n",
     "\n",
-    "    var (okA, solA) = stpAvecB.Solve();\n",
-    "    var (okS, solS) = stpSansB.Solve();\n",
-    "\n",
-    "    if (okA) Console.WriteLine($\"Avec B : duree = {solA[\"end\"] - solA[\"start\"]:F2}h\");\n",
-    "    if (okS) Console.WriteLine($\"Sans B : duree = {solS[\"end\"] - solS[\"start\"]:F2}h\");\n",
+    "        if (okA) Console.WriteLine($\"Avec B : duree = {solA[\"end\"] - solA[\"start\"]:F2}h\");\n",
+    "        if (okS) Console.WriteLine($\"Sans B : duree = {solS[\"end\"] - solS[\"start\"]:F2}h\");\n",
+    "    }\n",
     "}\n",
     "catch (Exception ex)\n",
     "{\n",
     "    Console.WriteLine($\"Exercice non complete : {ex.Message}\");\n",
-    "}\n"
+    "}"
    ]
   },
   {
@@ -1549,10 +1503,10 @@
    "id": "a743973a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T00:36:19.409211Z",
-     "iopub.status.busy": "2026-07-04T00:36:19.409009Z",
-     "iopub.status.idle": "2026-07-04T00:36:19.452915Z",
-     "shell.execute_reply": "2026-07-04T00:36:19.453014Z"
+     "iopub.execute_input": "2026-07-21T13:38:58.541736Z",
+     "iopub.status.busy": "2026-07-21T13:38:58.541565Z",
+     "iopub.status.idle": "2026-07-21T13:38:58.600736Z",
+     "shell.execute_reply": "2026-07-21T13:38:58.600503Z"
     }
    },
    "outputs": [
@@ -1562,56 +1516,6 @@
      "text": [
       "Exercice 3b a completer\r\n"
      ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(12,5): warning CS0162: Code inaccessible détecté\r\n",
-      "\r\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<details open=\"open\" class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[  ]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Count</td><td><div class=\"dni-plaintext\"><pre>0</pre></div></td></tr><tr><td>Comparer</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>System.Collections.Generic.EnumEqualityComparer`1[Submission#3+AllenRelation]</code></span></summary><div><table><thead><tr></tr></thead><tbody></tbody></table></div></details></td></tr><tr><td><i>(values)</i></td><td><i>(empty)</i></td></tr></tbody></table></div></details><style>\r\n",
-       ".dni-code-hint {\r\n",
-       "    font-style: italic;\r\n",
-       "    overflow: hidden;\r\n",
-       "    white-space: nowrap;\r\n",
-       "}\r\n",
-       ".dni-treeview {\r\n",
-       "    white-space: nowrap;\r\n",
-       "}\r\n",
-       ".dni-treeview td {\r\n",
-       "    vertical-align: top;\r\n",
-       "    text-align: start;\r\n",
-       "}\r\n",
-       "details.dni-treeview {\r\n",
-       "    padding-left: 1em;\r\n",
-       "}\r\n",
-       "table td {\r\n",
-       "    text-align: start;\r\n",
-       "}\r\n",
-       "table tr { \r\n",
-       "    vertical-align: top; \r\n",
-       "    margin: 0em 0px;\r\n",
-       "}\r\n",
-       "table tr td pre \r\n",
-       "{ \r\n",
-       "    vertical-align: top !important; \r\n",
-       "    margin: 0em 0px !important;\r\n",
-       "} \r\n",
-       "table th {\r\n",
-       "    text-align: start;\r\n",
-       "}\r\n",
-       "</style>"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -1625,15 +1529,21 @@
     "// Puis resoudre et afficher le planning.\n",
     "try\n",
     "{\n",
-    "    if (stpCours == null) Console.WriteLine(\"Exercice 3b a completer\"); return new HashSet<AllenRelation>();;\n",
-    "    var (ok, sol) = stpCours.Solve();\n",
-    "    if (ok)\n",
+    "    if (stpCours == null)\n",
     "    {\n",
-    "        Console.WriteLine(\"=== Planification cours ===\");\n",
-    "        foreach (var kv in sol.OrderBy(x => x.Value))\n",
-    "            Console.WriteLine($\"  {kv.Key,-10} : {kv.Value,5:F2}h\");\n",
+    "        Console.WriteLine(\"Exercice 3b a completer\");\n",
     "    }\n",
-    "    else Console.WriteLine(\"Pas de solution admissible.\");\n",
+    "    else\n",
+    "    {\n",
+    "        var (ok, sol) = stpCours.Solve();\n",
+    "        if (ok)\n",
+    "        {\n",
+    "            Console.WriteLine(\"=== Planification cours ===\");\n",
+    "            foreach (var kv in sol.OrderBy(x => x.Value))\n",
+    "                Console.WriteLine($\"  {kv.Key,-10} : {kv.Value,5:F2}h\");\n",
+    "        }\n",
+    "        else Console.WriteLine(\"Pas de solution admissible.\");\n",
+    "    }\n",
     "}\n",
     "catch (Exception ex)\n",
     "{\n",


### PR DESCRIPTION
Grain: MED/notebook-dotnet-fix — lane myia-po-2025:CoursIA-2 — prev: MED/docs/renumeration-analysis-audio (c.728y)

## Bug

`MyIA.AI.Notebooks/Search/Part2-CSP/CSP-8-Temporal-Csharp.ipynb` cellules 30 (Exercice 2b) et 34 (Exercice 3b) contenaient un stray-return short-circuit après le `Console.WriteLine(...)` de la branche stub :

```csharp
if (stpCours == null) Console.WriteLine("Exercice 3b a completer"); return new HashSet<AllenRelation>();;
```

Conséquences (vérifiées sur origin/main via Read direct) :
1. Tout le code après `if (stpCours == null)` était **inaccessible** (warning CS0162 "Code inaccessible" sur stderr)
2. Le `return new HashSet<AllenRelation>();;` était exécuté quand même (la cellule est en void context, mais le runtime .NET Interactive dumpe le HashSet vide en `execute_result` HTML `dni-treeview` parasite — 100+ lignes de HTML bogus à chaque exécution)
3. Si un étudiant complète l'exercice en instanciant `stpCours = ...`, le `return` parasite reste déclenché *quand même* (return non-conditionnel) → code mort, exercice effectivement cassé côté étudiant

## Fix

Restructuré en `if/else` block propre :

```csharp
if (stpCours == null) { Console.WriteLine(...); }
else { var (ok, sol) = stpCours.Solve(); ... }
```

## Validation H.1 EXEC_PROVED

`jupyter nbconvert --to notebook --execute --inplace --ExecutePreprocessor.timeout=180 --ExecutePreprocessor.kernel_name=.net-csharp`

| Cellule | execution_count | output | stderr | HTML dump |
|---------|-----------------|--------|--------|-----------|
| 30 (Ex 2b) | 12 | `Exercice 2b a completer` | clean | absent |
| 34 (Ex 3b) | 14 | `Exercice 3b a completer` | clean | absent |

## Scope C.3 strict

- **2 cellules modifiées** (30 + 34) sur 41 cellules du notebook
- 0 changement sur les 39 autres cellules (origines restaurées après `nbconvert` qui re-formate les metadata kernelspec des cellules voisines — restoration pattern documenté dans la leçon du cycle)
- Top-level metadata `kernelspec` / `language_info` **restaurées à l'identique de origin/main** (le runtime .NET 13 a tenté de bump `language_info.version` 12.0 → 13.0 ; reverté pour préserver le diff scope)

## Diff

```
.../CSP-8-Temporal-Csharp.ipynb | 154 +++++----------------
1 file changed, 32 insertions(+), 122 deletions(-)
```

## Anti-régression

- **Pas de `sorry` / `pass` / `return None` introduit en code de production** : `SimpleTemporalProblem stpCours = null;` reste une **déclaration stub d'exercice étudiant** (conforme C.1 — la cellule documente `# TODO etudiant`, ne contient pas de `raise NotImplementedError`)
- Cellule 26 (autre occurrence du pattern `return default(AllenRelation); return new HashSet<AllenRelation>();`) est **un stub de méthode privée** (`ConvexHullAllenRelations`, signature) et non un défaut : intention pédagogique claire, pas un bug

## Conformité règles

- **R1 catalog-pr-hygiene** : aucun marqueur `CATALOG-STATUS` touché, aucun fichier catalogue régénéré
- **R3 atomic** : 1 sujet = 1 fichier = 2 cellules
- **R4** : `See #7674` strict (contribution partielle au backlog pedagogical-fix, ne clôt pas l'issue)
- **C.1** : 0 `raise NotImplementedError` / `assert False` / `1/0` introduit
- **C.2** : outputs ré-exécutés via nbconvert (ec=12/14, stdout propre)
- **C.3** : scope strict (seulement 2 cellules, 39 autres restaurées à origin)
- **G-VAR-3** : genre pivot `MED/docs/*` (c.728y) → `MED/notebook-dotnet-fix` (cross-genre)

## Liens

- #7674 — issue signalant le bug pédagogique (stub cassé)
- leçon c.728k (L877 ★★) — surgical `NotebookEdit` cross-pool sur 4 leçons .ipynb
- leçon c.728u (L886 ★★) — PR REST API pour contourner quota GraphQL user-id 3159389
