### PR TITLE
docs(index,#7422): fix broken CATALOG-STATUS root-README ref + rotting hardcoded count

### DIFF
--- a/index.md
+++ b/index.md
@@ -2,13 +2,13 @@
 
 Ce document sert de **portail d'entrée éditorial** vers le contenu pédagogique du dépôt CoursIA. Il ne maintient **plus** de liste de liens vers les notebooks individuels (cause racine historique de rot : chemins à la main non resynchronisés après les restructurations de séries).
 
-> **Catalogue à jour** — Pour l'inventaire exhaustif et toujours synchronisé (comptes exacts par série, statuts, maturité, owner), consultez **[`COURSE_CATALOG.generated.md`](COURSE_CATALOG.generated.md)** et le marqueur `CATALOG-STATUS` du `README.md` racine (total = **824** au 2026-07-19). Le catalogue est régénéré automatiquement chaque jour par le workflow `catalog-cron.yml` ; il fait foi sur les chiffres et les statuts.
+> **Catalogue à jour** — Pour l'inventaire exhaustif et toujours synchronisé (total à jour, comptes exacts par série, statuts, maturité, owner), consultez **[`COURSE_CATALOG.generated.md`](COURSE_CATALOG.generated.md)** (en-tête « Total notebooks », régénéré automatiquement chaque jour par le workflow `catalog-cron.yml`). Le catalogue fait foi sur les chiffres et les statuts.
 
 ## 🎯 Trois niveaux de lecture
 
 - **Entrée** (le présent fichier, [`index.md`](index.md)) — portail éditorial : thématiques + parcours. Maintenance manuelle, modifications rares.
 - **Vue d'ensemble** ([`README.md`](README.md)) — cartographie rapide du dépôt + parcours d'apprentissage par niveau. Maintenance manuelle, vue pédagogique consolidée.
-- **Catalogue à jour** ([`COURSE_CATALOG.generated.md`](COURSE_CATALOG.generated.md)) — inventaire exhaustif : voir marqueur `CATALOG-STATUS` du `README.md` racine pour le total à jour (824 au 2026-07-19), décompte par série, statuts, maturités, owners. Maintenance **automatique** (workflow `catalog-cron.yml` quotidien).
+- **Catalogue à jour** ([`COURSE_CATALOG.generated.md`](COURSE_CATALOG.generated.md)) — inventaire exhaustif : total à jour (en-tête « Total notebooks »), décompte par série, statuts, maturités, owners. Maintenance **automatique** (workflow `catalog-cron.yml` quotidien).
 
 Les trois niveaux sont complémentaires : l'`index.md` répond à *« quelles thématiques ? »*, le `README.md` à *« par où commencer ? »*, le catalogue à *« quel notebook précis dans quelle série ? »*.
 
@@ -52,4 +52,3 @@ Pour un inventaire technique exhaustif (notebook par notebook, statuts d'exécut
 ## 📖 Documentation projet
 
 Le répertoire **[docs/](docs/README.md)** centralise les règles de travail, l'infrastructure du dépôt, les procédés récurrents (workflow PR, dispatch d'agents, validation notebook) et les guides d'apprentissage. Cette documentation est destinée aux contributeurs internes du cluster et aux coordinateurs IA.
-


### PR DESCRIPTION
## Summary

`See #7422` (Hygiène docs/ + index.md racine). Partial contribution: **root `index.md` refresh** — fixes a broken reference + a rotting hardcoded count. The docs/ tree triage table (full #7422 scope) will follow on the workspace dashboard, not in the repo (harness-hygiene rule: reports = dashboard).

## The bug (G.1-verified firsthand against origin/main @ 4d3e513ff)

`index.md` cited **« le marqueur `CATALOG-STATUS` du `README.md` racine »** (lines 5 and 11) as the authoritative source for the notebook total — **but that marker does not exist in the root `README.md`**:

```
$ grep -c CATALOG-STATUS README.md
0
```

The `CATALOG-STATUS` marker lives only in **35 series READMEs + `docs/README.md`**, never in the root README. The reference was therefore **dangling**. Worse, the hardcoded count it cited was already rotting:

- index.md line 5/11: `total = 824 au 2026-07-19`
- catalog header (regenerated daily): `Total notebooks: 830` (2026-07-21)

## The fix

Point both lines to the **authoritative anti-rot source**: the catalog file header « Total notebooks » (`COURSE_CATALOG.generated.md`, regenerated daily by `catalog-cron.yml`):

- **Line 5**: removed « marqueur `CATALOG-STATUS` du `README.md` racine (total = **824** au 2026-07-19) » → points to catalog header « Total notebooks ».
- **Line 11**: same dangling reference + hardcoded count removed → points to catalog header.

This aligns `index.md` with its own stated anti-rot principle (line 3: hand-maintained lists/counts = « cause racine historique de rot ») and with the root `README.md` itself, which **already** uses the no-hardcoded-count + catalog-pointer pattern.

## Scope (anti-regression)

- **2 prose lines edited** (5, 11). Pure docs, no code.
- **Line 22 left untouched**: `Sudoku (36 notebooks, voir CATALOG-STATUS)` — the Sudoku README **legitimately has the marker** (`grep -c CATALOG-STATUS Sudoku/README.md = 2`), so that reference is valid.
- **All 12 series README links verified resolving** (Search, Sudoku, ML, RL, GenAI, SymbolicAI, Probas, GameTheory, IIT, QuantConnect, CaseStudies, cross-series) + docs/README link.
- **Catalogue byte-identical** to main (HARD rule, catalog-pr-hygiene.md) — `git diff origin/main -- COURSE_CATALOG.generated.{md,json}` = empty.
- FR prose (readme-french-first.md).
- No CRLF (hex-verified 0x0D = 0). MD012 trailing-blank pre-existing lint also normalized.

## What this does NOT do (scoped out for atomicity)

The full #7422 scope includes: (a) docs/ tree triage ARCHIVE/UPDATE/KEEP classification, (b) `index.md` cadence note, (c) README root refresh. This PR addresses only the **dangling-reference + rotting-count defect** in `index.md` — a single, verifiable, atomic fix. The docs/ triage table (acceptance item of #7422) will be posted to the workspace dashboard as the triage evidence (not committed to the repo per harness-hygiene.md).

## Validation

```
$ git diff origin/main...HEAD --stat
 index.md | 5 ++---
 1 file changed, 2 insertions(+), 3 deletions(-)

$ grep -c CATALOG-STATUS README.md   # confirms marker absent (reference was dangling)
0
$ grep -c CATALOG-STATUS MyIA.AI.Notebooks/Sudoku/README.md   # Sudoku ref still valid
2
```

See #7422. Related: Epic #4208 (public open-courseware freshness prerequisite), #3973 (README hierarchy).

Grain: MED/docs-triage — lane po-2026:CoursIA — prev: DEEP/lean-i18n-module (c.602 #7708 Monoidal). PROTOCOLE-VARIATION: pivot AWAY from lean for R6 variety (c.601 Kan + c.602 Monoidal = 2-streak lean DEEP; dashboard warns Lean/.NET/Prong-B monoculture). G-VAR-1 MED plancher (DEEP→MED is valid), G-VAR-3 genre distinct (docs-triage ≠ lean-i18n).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
