### PR TITLE
feat(translation): WRONG_SCRIPT verdict in check_translation_sync (#6949)

### DIFF
--- a/scripts/tests/test_check_translation_sync.py
+++ b/scripts/tests/test_check_translation_sync.py
@@ -1,0 +1,164 @@
+"""Regression suite for ``scripts/translation/check_translation_sync.py`` (c.734, #6949).
+
+Background. ``check_translation_sync.py`` (notre T2 de l EPIC #6949) detectait
+4 classes de drift (IN_SYNC / SRC_DRIFT / TRAD_DRIFT / MISSING_LANG / ORPHAN_ROW)
+mais manquait la 3e des 5 classes Argumentum : **WRONG_SCRIPT** -- un contenu
+``text_<lang>`` depose pour une langue non-Latine (ar/fa/zh/ru) sans AUCUN
+caractere du script Unicode attendu (typiquement un copier-coller de FR ou d EN
+dans la mauvaise colonne). C.734 ajoute le verdict ``WRONG_SCRIPT`` via la
+detection deterministe ``_has_expected_script`` (plages Unicode UCD).
+
+Cette suite couvre :
+
+  * ``_has_expected_script`` (unite) : chaque langue non-Latine OK/WRONG,
+    ASCII-seul = WRONG, langues Latines (en/es/pt) jamais WRONG, texte vide = OK.
+  * ``check_csv`` (integration) : un CSV synthetique avec ``text_zh="bonjour"``
+    produit un verdict ``WRONG_SCRIPT`` ; avec ``text_zh="你好"`` -> aucun.
+
+G.9 non-vacuous : contre le ``check_translation_sync.py`` d origin/main (sans le
+verdict WRONG_SCRIPT ni la fonction ``_has_expected_script``), les tests
+d import et de detection FAIL (ImportError sur ``_has_expected_script`` /
+aucune anomalie WRONG_SCRIPT remontee), donc la suite garde le fix.
+
+Run: ``python -m pytest scripts/tests/test_check_translation_sync.py -q``
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts" / "translation"))
+
+import check_translation_sync as C  # noqa: E402
+
+
+def test_arabic_text_has_arabic_script():
+    assert C._has_expected_script("ar", "مرحبا بكم") is True
+
+
+def test_chinese_text_has_cjk_script():
+    assert C._has_expected_script("zh", "你好世界") is True
+
+
+def test_russian_text_has_cyrillic_script():
+    assert C._has_expected_script("ru", "Привет мир") is True
+
+
+def test_persian_text_has_arabic_script():
+    assert C._has_expected_script("fa", "سلام دنیا") is True
+
+
+def test_non_latin_text_with_ascii_payload_still_ok():
+    assert C._has_expected_script("zh", "你好 world 123") is True
+    assert C._has_expected_script("ar", "code: print(x) مرحبا") is True
+
+
+def test_zh_latin_only_is_wrong_script():
+    assert C._has_expected_script("zh", "bonjour") is False
+
+
+def test_ar_latin_only_is_wrong_script():
+    assert C._has_expected_script("ar", "bonjour") is False
+
+
+def test_ru_latin_only_is_wrong_script():
+    assert C._has_expected_script("ru", "bonjour") is False
+
+
+def test_fa_latin_only_is_wrong_script():
+    assert C._has_expected_script("fa", "bonjour") is False
+
+
+def test_ascii_only_payload_is_wrong_script():
+    assert C._has_expected_script("zh", "123 hello **bold**") is False
+
+
+def test_markdown_wrapped_latin_is_wrong_script():
+    assert C._has_expected_script("zh", "# Titre\n\n- item\n- item") is False
+
+
+def test_latin_langs_never_wrong_script():
+    for lang in ("en", "es", "pt"):
+        assert C._has_expected_script(lang, "anything in French here") is True
+
+
+def test_empty_text_is_not_wrong_script():
+    for lang in ("ar", "zh", "ru", "fa", "en"):
+        assert C._has_expected_script(lang, "") is True
+
+
+def test_unknown_lang_is_not_wrong_script():
+    assert C._has_expected_script("xx", "anything") is True
+
+
+def _write_source_notebook(repo_root, nb_name, cell_id, source):
+    nb_rel = f"tmp_{nb_name}.ipynb"
+    (repo_root / nb_rel).write_text(
+        json.dumps(
+            {"cells": [{"id": cell_id, "cell_type": "markdown", "source": [source]}],
+             "metadata": {}, "nbformat": 4, "nbformat_minor": 5},
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    return nb_rel
+
+
+def _write_csv(csv_path, nb_rel, cell_id, texts):
+    row = {
+        "notebook": nb_rel, "cell_id": cell_id, "cell_type": "markdown",
+        "src_lang": "fr", "src_hash": "", "text_fr": "Bonjour",
+    }
+    for lang in C.ALL_LANGS:
+        row.setdefault(f"text_{lang}", "")
+        row.setdefault(f"hash_{lang}", "")
+    for lang, txt in texts.items():
+        row[f"text_{lang}"] = txt
+    with csv_path.open("w", encoding="utf-8", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=list(row.keys()))
+        w.writeheader()
+        w.writerow(row)
+
+
+def test_check_csv_flags_wrong_script_zh(tmp_path):
+    nb_rel = _write_source_notebook(tmp_path, "nb1", "abc", "Bonjour")
+    csv_path = tmp_path / "sync.csv"
+    _write_csv(csv_path, nb_rel, "abc", {"zh": "bonjour"})
+    anomalies = C.check_csv(csv_path, tmp_path)
+    wrong = [a for a in anomalies if a["verdict"] == "WRONG_SCRIPT"]
+    assert len(wrong) == 1, f"expected 1 WRONG_SCRIPT, got {anomalies}"
+    assert wrong[0]["lang"] == "zh"
+
+
+def test_check_csv_no_wrong_script_for_correct_zh(tmp_path):
+    nb_rel = _write_source_notebook(tmp_path, "nb2", "abc", "Bonjour")
+    csv_path = tmp_path / "sync.csv"
+    _write_csv(csv_path, nb_rel, "abc", {"zh": "你好"})
+    anomalies = C.check_csv(csv_path, tmp_path)
+    assert not any(a["verdict"] == "WRONG_SCRIPT" for a in anomalies)
+
+
+def test_check_csv_wrong_script_all_non_latin(tmp_path):
+    nb_rel = _write_source_notebook(tmp_path, "nb3", "abc", "Bonjour")
+    csv_path = tmp_path / "sync.csv"
+    _write_csv(csv_path, nb_rel, "abc", {"ar": "bonjour", "fa": "bonjour",
+                                          "zh": "bonjour", "ru": "bonjour",
+                                          "en": "bonjour", "es": "bonjour", "pt": "bonjour"})
+    anomalies = C.check_csv(csv_path, tmp_path)
+    wrong = [a for a in anomalies if a["verdict"] == "WRONG_SCRIPT"]
+    wrong_langs = sorted(a["lang"] for a in wrong)
+    assert wrong_langs == ["ar", "fa", "ru", "zh"], (
+        f"expected ar/fa/ru/zh flagged, got {wrong_langs} (full={anomalies})"
+    )
+
+
+def test_check_csv_empty_text_no_wrong_script(tmp_path):
+    nb_rel = _write_source_notebook(tmp_path, "nb4", "abc", "Bonjour")
+    csv_path = tmp_path / "sync.csv"
+    _write_csv(csv_path, nb_rel, "abc", {"zh": ""})
+    anomalies = C.check_csv(csv_path, tmp_path)
+    assert not any(a["verdict"] == "WRONG_SCRIPT" for a in anomalies)

--- a/scripts/translation/check_translation_sync.py
+++ b/scripts/translation/check_translation_sync.py
@@ -46,6 +46,24 @@ PIVOT_LANG = "fr"
 TARGET_LANGS = ["en", "es", "ar", "fa", "zh", "ru", "pt"]
 ALL_LANGS = [PIVOT_LANG] + TARGET_LANGS
 
+# Plages Unicode du script attendu pour les langues cibles non-Latines.
+# Une cellule text_<lang> deposee dont le contenu ne porte AUCUN caractere de
+# son script attendu (en ignorant ASCII = ponctuation/chiffres/espaces/markup
+# markdown) est un WRONG_SCRIPT : typiquement un copier-coller de FR ou d'EN
+# dans la colonne text_ar / text_zh / text_ru / text_fa. Detection deterministe,
+# zero faux-positif (une vraie traduction arabe/chinoise/russe CONTIENT au moins
+# un caractere de son script). Les langues Latines (en/es/pt) ne sont PAS couvertes
+# ici : la contamination FR de ces langues est la classe heuristique FR_CONTAM
+# (taxonomie Argumentum 5-classes), hors scope de ce check deterministe (#6949).
+# Source des plages : Unicode UCD (Arabic 0600-06FF, Cyrillic 0400-04FF,
+# CJK Unified Ideographs 4E00-9FFF, etc.).
+LANG_SCRIPT_RANGES: dict[str, list[tuple[int, int]]] = {
+    "ar": [(0x0600, 0x06FF), (0x0750, 0x077F), (0x08A0, 0x08FF)],  # Arabic block
+    "fa": [(0x0600, 0x06FF), (0x0750, 0x077F), (0xFB50, 0xFDFF), (0xFE70, 0xFEFF)],  # Arabic + Presentation forms (Persian)
+    "zh": [(0x4E00, 0x9FFF), (0x3400, 0x4DBF), (0xF900, 0xFAFF), (0x3000, 0x303F)],  # CJK Unified + Ext A + CJK symbols/punct
+    "ru": [(0x0400, 0x04FF), (0x0500, 0x052F), (0x2DE0, 0x2DFF), (0xA640, 0xA69F)],  # Cyrillic + ext + supplement
+}
+
 
 def normalize(text: str) -> str:
     """Meme normalisation que extract_cells_to_csv.py (anti faux-drift cosmétique)."""
@@ -55,6 +73,31 @@ def normalize(text: str) -> str:
 
 def cell_hash(text: str) -> str:
     return hashlib.sha256(normalize(text).encode("utf-8")).hexdigest()[:16]
+
+
+def _has_expected_script(lang: str, text: str) -> bool:
+    """True si text contient au moins un caractere du script attendu pour lang.
+
+    Langues Latines (en/es/pt, absentes de LANG_SCRIPT_RANGES) : retourne True
+    (pas de verdict WRONG_SCRIPT -- la contamination FR de ces langues est la
+    classe heuristique FR_CONTAM, hors scope). Texte vide : True (rien a checker,
+    etat attendu pre-T3). Sinon on scanne les caracteres non-ASCII : s'il en
+    existe au moins un dans une plage attendue de lang, c'est OK ; si AUCUN
+    caractere non-ASCII n'appartient au script attendu, retourne False -> WRONG_SCRIPT.
+
+    Une traduction legitime arabe/chinoise/russe contient du code ou des nombres
+    (ASCII) MAIS doit aussi contenir au moins un caractere du script cible.
+    """
+    ranges = LANG_SCRIPT_RANGES.get(lang)
+    if not ranges or not text:
+        return True
+    for ch in text:
+        cp = ord(ch)
+        if cp < 0x0080:  # ASCII : ponctuation, chiffres, espaces, markup markdown (*_#-`).
+            continue
+        if any(lo <= cp <= hi for lo, hi in ranges):
+            return True
+    return False
 
 
 def load_notebook_cells(nb_path: Path) -> dict[str, str] | None:
@@ -117,10 +160,19 @@ def check_csv(csv_path: Path, repo_root: Path) -> list[dict]:
                      "detail": f"source modifié (csv={csv_src_hash} <> actuel={current_src}) -> retraduction requise"}
                 )
 
-            # TRAD_DRIFT / MISSING_LANG par langue cible.
+            # TRAD_DRIFT / MISSING_LANG / WRONG_SCRIPT par langue cible.
             # Le pivot (fr) EST le notebook source (xxx.ipynb, pas xxx_fr.ipynb) :
             # sa cohérence est déjà vérifiée par SRC_DRIFT ci-dessus -> on le skippe.
             for lang in TARGET_LANGS:
+                # WRONG_SCRIPT : le contenu depose text_<lang> est-il dans le bon
+                # script ? (detection Unicode deterministe ; Latin langs exclus.)
+                trad_text = row.get(f"text_{lang}", "")
+                if trad_text and not _has_expected_script(lang, trad_text):
+                    anomalies.append(
+                        {"csv": str(csv_path), "notebook": nb_rel, "cell_id": cell_id, "lang": lang,
+                         "verdict": "WRONG_SCRIPT",
+                         "detail": f"text_{lang} depose sans aucun caractere du script attendu (copier-coller FR/EN dans la mauvaise colonne ?)"}
+                    )
                 csv_hash = row.get(f"hash_{lang}", "")
                 if not csv_hash:
                     continue  # rien déposé = attendu pre-T3, pas un drift.


### PR DESCRIPTION
Grain: **DEEP/feature** — lane `myia-po-2026:CoursIA-2` — prev: MED/fix (c.732 #7701)

## Contexte (#6949)

L issue #6949 demande d harmoniser notre T2 `scripts/translation/check_translation_sync.py` avec les **5 classes de drift** de la taxonomie Argumentum. Notre outil n en detectait que 4 : `IN_SYNC` / `SRC_DRIFT` / `TRAD_DRIFT` / `MISSING_LANG` / `ORPHAN_ROW`. Cette PR ajoute la 3e classe : **`WRONG_SCRIPT`**.

## Quoi

Un contenu `text_<lang>` depose pour une langue **non-Latine** (`ar`/`fa`/`zh`/`ru`) **sans AUCUN caractere du script Unicode attendu** -> typiquement un copier-coller de FR ou d EN dans la mauvaise colonne (faute recurrente du flux T3 `translate_csv.py` quand l operateur se trompe de cellule cible).

Detection **deterministe** via `_has_expected_script(lang, text)` : plages Unicode UCD declarees dans `LANG_SCRIPT_RANGES` (Arabic `0600-06FF`, Cyrillic `0400-04FF`, CJK Unified `4E00-9FFF`, + extensions). **Zero faux-positif** : une vraie traduction arabe/chinoise/russe CONTIENT forcement au moins un caractere de son script ; ASCII seul (chiffres/ponctuation/markup markdown `*_#\`-`) ne compte pas.

## Périmètre (volontaire)

- **Inclus** : `ar`/`fa`/`zh`/`ru` (scripts non-Latins, test deterministe sans ambiguite).
- **Exclu** : `en`/`es`/`pt` (langues Latines). Leur contamination par du FR est la classe **heuristique** `FR_CONTAM` (taxonomie Argumentum 5-classes), hors scope de ce check deterministe Unicode. Le helper retourne `True` pour ces langues (`LANG_SCRIPT_RANGES` ne les liste pas) -> pas de verdict `WRONG_SCRIPT`. Documente inline.
- **Prospective** : le verdict se declenche des qu un `text_<lang>` est depose (meme pre-hash), donc il attrape les erreurs au moment ou T3 `translate_csv.py` remplit la colonne, avant meme que le notebook `_en.ipynb` soit genere.

## Tests (`scripts/tests/test_check_translation_sync.py`, 18 tests)

- **14 unites** sur `_has_expected_script` : chaque langue non-Latine (OK avec script cible / WRONG avec Latin pur), ASCII-seul = WRONG, markdown-wrapped Latin = WRONG, langues Latines jamais WRONG, texte vide = OK, langue inconnue = OK.
- **4 integration** sur `check_csv` : CSV synthetique + notebook source minimal ; `text_zh="bonjour"` -> 1 `WRONG_SCRIPT(zh)` ; `text_zh="你好"` -> aucun ; `bonjour` depose en `ar/fa/zh/ru` -> 4 flags (`en/es/pt` -> 0) ; `text_zh=""` -> aucun (etat pre-T3).

### G.9 non-vacuous (preuve de-patch)
```
git checkout origin/main -- scripts/translation/check_translation_sync.py   # de-patch
python -m pytest scripts/tests/test_check_translation_sync.py -q
# -> 16 failed, 2 passed
```
Les 16 FAIL : 14 unites en `AttributeError: module has no attribute '_has_expected_script'` (la fonction n existe pas pre-fix) + 2 integration `test_check_csv_*_wrong_script*` qui n obtiennent plus aucune anomalie WRONG_SCRIPT. Les 2 PASS (`test_check_csv_no_wrong_script_for_correct_zh`, `test_check_csv_empty_text_no_wrong_script`) sont les gardes no-false-positive (assertent l ABSENCE de WRONG_SCRIPT, trivialement vrai quand la feature est absente). Re-patch -> 18/18 PASS.

Suite globale : `41/41 passed` avec le sibling `test_translate_csv.py` (po-2023 #6949 core) -- pas de regression.

## Validation

- `python -m pytest scripts/tests/test_check_translation_sync.py -q` -> **18 passed**
- `python -m pytest scripts/tests/test_translate_csv.py scripts/tests/test_check_translation_sync.py -q` -> **41 passed**
- Compile OK, EOL LF pur (0 CRLF, 0 BOM) sur les 2 fichiers.
- Diff atomique : `+217/-1`, 2 fichiers (1 source +52/-1, 1 test +165).

See #6949 (issue reste ouverte : classes Argumentum restantes apres ce commit = `FR_CONTAM` + `COGNATE`, heuristiques hors scope du check deterministe Unicode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)