### PR TITLE
fix(notebook-tools): force LF in generate_parcours output (#7693)

### DIFF
--- a/scripts/notebook_tools/generate_parcours.py
+++ b/scripts/notebook_tools/generate_parcours.py
@@ -239,7 +239,7 @@ def main():
         else:
             PARCOURS_DIR.mkdir(parents=True, exist_ok=True)
             out_path = PARCOURS_DIR / f"{pid}.md"
-            out_path.write_text(page, encoding="utf-8")
+            out_path.write_text(page, encoding="utf-8", newline="\n")
             print(f"  {pid}: {out_path} ({len(filtered)} notebooks)")
 
     if not args.dry_run and not args.parcours:


### PR DESCRIPTION
Grain: MED/notebook-tools-fix — lane myia-po-2025:CoursIA-2 — prev: MED/notebook-dotnet-fix (c.728y+1)

## Bug

`scripts/notebook_tools/generate_parcours.py` ligne 242 :

```python
out_path.write_text(page, encoding="utf-8")
```

Sur Windows, `Path.write_text()` sans argument `newline=` émet **CRLF** par défaut (comportement `io.open` Python). Conséquence : à chaque régénération de `docs/curriculum/*.md`, le fichier de sortie passe de LF (baseline git) à CRLF → 1178/1178 lignes churn documenté dans le diff `git diff origin/main --stat` après exécution.

## Fix

Ajout de `newline="\n"` pour forcer LF, platform-independent :

```python
out_path.write_text(page, encoding="utf-8", newline="\n")
```

## Validation

| Test | Résultat |
|------|----------|
| `pytest scripts/notebook_tools/tests/test_generate_parcours.py` | **22/22 passed** (0.12s) |
| EOL verification `out.read_bytes()` sur tempfile | **0 CRLF, 0x0a (LF) présent** |
| `git diff --stat origin/main..HEAD` | 1 fichier, +1/-1 |
| Scope C.3 strict | 1 ligne modifiée, 0 fichier collateral |

## Conformité règles

- **R1 catalog-pr-hygiene** : 0 marqueur `CATALOG-STATUS` touché, 0 fichier catalogue régénéré (le script touche `docs/curriculum/`, pas le catalogue)
- **R3 atomic** : 1 sujet = 1 fichier = 1 ligne
- **R4** : `See #7693` strict (slice partielle EPIC #7422 docs/)
- **G-VAR-3** : `MED/notebook-tools-fix` ≠ c.728y+1 `MED/notebook-dotnet-fix` (genres distincts)
- **L887 family (Windows CRLF pollution)** : pattern c.728v `PythonAgentsForDataScience/` rename reproduit ici sur `Path.write_text()`

## Liens

- #7693 — issue signalant le CRLF pollution
- #7422 — EPIC parent (hygiène docs/)
- L887 (c.728v) — leçon EOL preservation Windows CRLF (`*.ipynb text eol=lf`)
- L891 (c.728y+1) — leçon PR body escaping via `--input body.json`
- L886 (c.728u) — leçon PR REST API contourne GraphQL quota