### PR TITLE
fix(prover): to_dict() aliasing — copy mutables on the way out (#7477)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/state.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/state.py
@@ -377,15 +377,30 @@ class ProofState:
         return self.get_state_snapshot(summarize=True)
 
     def to_dict(self) -> Dict[str, Any]:
+        """Serialize the proof state to a plain dict (c.735, #7477 pattern class).
+
+        The mutable fields ``current_proof`` and ``discovered_lemmas`` are
+        **copied** here (``list(...)``), mirroring the defensive copies
+        ``save_checkpoint`` makes on the way in and ``restore_checkpoint`` makes
+        on the way out (c.732). Without these copies the returned dict would
+        alias the live ``self.current_proof`` / ``self.discovered_lemmas`` list
+        objects: a caller appending to ``d["current_proof"]`` would mutate the
+        live ``ProofState`` in place. Verified firsthand: pre-fix,
+        ``d = state.to_dict(); d["current_proof"].append(x)`` injected ``x``
+        into ``state.current_proof``. ``get_state_snapshot(summarize=False)``
+        delegates here, so fixing ``to_dict`` closes both exposures; the
+        ``summarize=True`` branch already builds a fresh dict (scalars + a
+        list-comprehension ``previous_tactics``) and is unaffected.
+        """
         return {
             "session_id": self.session_id,
             "theorem_name": self.theorem_name,
             "theorem_statement": self.theorem_statement,
             "current_goal": self.current_goal,
-            "current_proof": self.current_proof,
+            "current_proof": list(self.current_proof),  # c.735: copy, don't alias
             "phase": self.phase.value,
             "strategy": self.strategy.value,
-            "discovered_lemmas": self.discovered_lemmas,
+            "discovered_lemmas": list(self.discovered_lemmas),  # c.735: copy, don't alias
             "iteration": self.iteration,
             "max_iterations": self.max_iterations,
             "error_count": self.error_count,

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_to_dict_aliasing.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_to_dict_aliasing.py
@@ -1,0 +1,147 @@
+"""Regression suite for ``prover.state.ProofState.to_dict`` aliasing (c.735, #7477).
+
+Background. ``to_dict`` historically returned the live mutable fields
+``current_proof`` and ``discovered_lemmas`` BY REFERENCE (``"current_proof":
+self.current_proof``) instead of copying them. So the dict returned by
+``to_dict()`` ALIASED the live ``ProofState`` list objects: a caller doing
+``d = state.to_dict(); d["current_proof"].append(x)`` would mutate the live
+``state.current_proof`` in place -- silently corrupting the session state.
+
+This is the SAME aliasing pattern class as the ``restore_checkpoint`` bug fixed
+in c.732 (#7701): a method exposing ``self.<mutable>`` must copy it on the way
+out, not hand back the live reference. ``get_state_snapshot(summarize=False)``
+delegates to ``to_dict()``, so the exposure travelled through both entry points
+(the ``summarize=True`` branch already builds a fresh dict and is unaffected).
+
+These tests pin the contract: **``to_dict()`` returns an independent snapshot;
+mutating its lists does NOT corrupt the live ``ProofState``; two calls are
+independent.** G.9 non-vacuous: against the pre-fix ``to_dict`` (returning the
+bare references) the ``test_*_not_aliased`` cases FAIL (the live state gains
+the appended entry), so the suite genuinely guards the fix.
+
+Stdlib-only -- imports ``ProofState`` via ``sys.path`` insert exactly like
+``test_prover_guards.py`` (#7477), so it runs without the LLM stack.
+
+Run: ``python -m pytest tests/test_to_dict_aliasing.py -q``
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make `prover/` importable regardless of how pytest was invoked.
+ROOT = Path(__file__).resolve().parents[1]  # agent_tests/
+sys.path.insert(0, str(ROOT))
+
+from prover.state import ProofState  # noqa: E402
+
+
+def _fresh_state() -> ProofState:
+    return ProofState(theorem_name="t", current_goal="g")
+
+
+# ---------------------------------------------------------------------------
+# to_dict : current_proof aliasing
+# ---------------------------------------------------------------------------
+
+
+def test_to_dict_current_proof_not_aliased():
+    """Appending to the list returned by to_dict must NOT mutate the live state."""
+    ps = _fresh_state()
+    ps.add_tactic_attempt("tactic_A", success=True)  # appends current_proof
+    d = ps.to_dict()
+    d["current_proof"].append("INJECTED")
+    assert ps.current_proof == ["tactic_A"], (
+        f"live current_proof was aliased/mutated via to_dict: {ps.current_proof}"
+    )
+
+
+def test_to_dict_current_proof_independent_across_calls():
+    """Two to_dict calls return independent lists; mutating one touches neither
+    the other nor the live state."""
+    ps = _fresh_state()
+    ps.add_tactic_attempt("tactic_A", success=True)
+    d1 = ps.to_dict()
+    d2 = ps.to_dict()
+    d1["current_proof"].append("X")
+    assert ps.current_proof == ["tactic_A"]
+    assert d2["current_proof"] == ["tactic_A"], (
+        f"second to_dict was aliased to the first: {d2['current_proof']}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# to_dict : discovered_lemmas aliasing
+# ---------------------------------------------------------------------------
+
+
+def test_to_dict_discovered_lemmas_not_aliased():
+    """Appending to the discovered_lemmas list returned by to_dict must NOT
+    mutate the live state."""
+    ps = _fresh_state()
+    ps.add_lemma("lem1", statement="stmt1")
+    d = ps.to_dict()
+    d["discovered_lemmas"].append("INJECTED_LEM")
+    assert "INJECTED_LEM" not in ps.discovered_lemmas, (
+        f"live discovered_lemmas was aliased/mutated via to_dict: {ps.discovered_lemmas}"
+    )
+    assert len(ps.discovered_lemmas) == 1
+
+
+# ---------------------------------------------------------------------------
+# to_dict : round-trip (to_dict -> mutate returned -> to_dict = original snapshot)
+# ---------------------------------------------------------------------------
+
+
+def test_to_dict_roundtrip_after_mutation():
+    """to_dict -> mutate the returned dict -> to_dict again must still reflect
+    the live state (not the mutation applied to the first returned dict)."""
+    ps = _fresh_state()
+    ps.add_tactic_attempt("tactic_A", success=True)
+    d = ps.to_dict()
+    d["current_proof"].append("GHOST")
+    d2 = ps.to_dict()
+    assert d2["current_proof"] == ["tactic_A"], (
+        f"second to_dict leaked the mutation: {d2['current_proof']}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# get_state_snapshot(summarize=False) delegates to to_dict -> also safe
+# ---------------------------------------------------------------------------
+
+
+def test_get_state_snapshot_summarize_false_not_aliased():
+    """get_state_snapshot(summarize=False) returns to_dict(); the mutable lists
+    must not alias the live state either."""
+    ps = _fresh_state()
+    ps.add_tactic_attempt("tactic_A", success=True)
+    ps.add_lemma("lem1", statement="stmt1")
+    snap = ps.get_state_snapshot(summarize=False)
+    snap["current_proof"].append("INJECTED")
+    snap["discovered_lemmas"].append("INJECTED_LEM")
+    assert ps.current_proof == ["tactic_A"]
+    assert "INJECTED_LEM" not in ps.discovered_lemmas
+
+
+# ---------------------------------------------------------------------------
+# summarize=True is a fresh dict (sanity -- already safe, unaffected by fix)
+# ---------------------------------------------------------------------------
+
+
+def test_get_state_snapshot_summarize_true_is_fresh():
+    """The summarize=True branch builds a fresh dict of scalars + a short
+    previous_tactics list-comprehension; mutating it must never reach the live
+    state (this held pre-fix too -- pins it against future regressions)."""
+    ps = _fresh_state()
+    ps.add_tactic_attempt("tactic_A", success=True)
+    snap = ps.get_state_snapshot(summarize=True)
+    # summarize=True exposes no live mutable list directly, but mutate every
+    # list value defensively to prove none aliases the live state.
+    for v in snap.values():
+        if isinstance(v, list):
+            v.append("INJECTED")
+    assert ps.current_proof == ["tactic_A"]


### PR DESCRIPTION
Grain: **MED/fix** — lane `myia-po-2026:CoursIA-2` — prev: DEEP/feature (c.734 #7714)

## Bug (G.1 firsthand, reproduced AVANT le fix)

`ProofState.to_dict()` (state.py:379) retournait `current_proof` et `discovered_lemmas` **PAR RÉFÉRENCE** — les objets `list` *live* de la session, pas des copies. Le dict renvoyé **aliasait** donc les mutables :

```python
d = state.to_dict()
d["current_proof"].append("INJECTED")
# -> state.current_proof == ['tactic_A', 'INJECTED']   LIVE STATE CORROMPU
```

Reproduction empirique (worktree c.735, origin/main) :
```
state before to_dict: ['tactic_A']
state AFTER mutating to_dict() output: ['tactic_A', 'INJECTED']
ALIASING BUG: True
```

Même classe de pattern que le bug `restore_checkpoint` fixé en c.732 (#7701) : **une méthode exposant `self.<mutable>` doit le COPIER à la sortie, pas rendre la référence live** (#7477 pattern class). `get_state_snapshot(summarize=False)` délègue à `to_dict()` → l'exposition passait par les deux entrées (la branche `summarize=True` construit déjà un dict frais de scalars + une list-compréhension `previous_tactics`, non affectée).

## Fix

`list(self.current_proof)` / `list(self.discovered_lemmas)` — miroir exact des copies défensives de `save_checkpoint` (entrée) et `restore_checkpoint` (sortie, c.732). Nouvelle docstring documente le contrat d'immutabilité + la preuve firsthand + le lien c.732.

## Tests (`tests/test_to_dict_aliasing.py`, 6 tests)

| Test | Discriminateur |
|---|---|
| `test_to_dict_current_proof_not_aliased` | append sur le retour → state inchangé |
| `test_to_dict_current_proof_independent_across_calls` | 2 appels indépendants + state indépendant |
| `test_to_dict_discovered_lemmas_not_aliased` | append sur le retour → state inchangé |
| `test_to_dict_roundtrip_after_mutation` | to_dict→mute retour→to_dict = snapshot live (pas la mutation) |
| `test_get_state_snapshot_summarize_false_not_aliased` | delegation to_dict → safe |
| `test_get_state_snapshot_summarize_true_is_fresh` | sanity guard (déjà safe pré-fix) |

Stdlib-only (pas de stack LLM), import via `sys.path.insert(0, str(ROOT))` miroir `test_prover_guards.py` (#7477).

## G.9 non-vacuous (preuve de-patch)
```
git checkout origin/main -- state.py    # de-patch (to_dict retourne les refs nues)
python -m pytest tests/test_to_dict_aliasing.py -q
# -> 5 failed, 1 passed
```
Les 5 FAIL : exactement les 5 discriminateurs aliasing (`AssertionError: ['tactic_A', 'INJECTED'] == ['tactic_A']`). Le 1 PASS (`summarize=True` sanity guard) était déjà safe pré-fix — il pinne le contrat contre une future régression. Re-patch → **6/6 PASS**.

## Validation

- `python -m pytest tests/test_to_dict_aliasing.py -q` → **6 passed**
- `python -m pytest tests/ -q` → **533 passed** (527 baseline origin/main + 6 nouveaux, 0 régression)
- Diff atomique : `+164/-2`, 2 fichiers (state.py +17/-2, test +147)
- EOL LF pur, 0 BOM, 0 CRLF

## Note merge

PR #7701 (c.732) touche aussi `state.py` mais la région `restore_checkpoint` (L213-245), **disjointe** de `to_dict` (L379+) → rebase propre, pas de conflit attendu (rebase fresh avant merge, R1 catalog-pr-hygiene).

See #7477 (Epic prover forensic — résiduel P5b/P6 ; ce fix ferme une 2ᵉ occurrence du pattern-class aliasing documenté en c.732).

🤖 Generated with [Claude Code](https://claude.com/claude-code)