### PR TITLE
fix(smt,#3801): Z3-Python-01 Optimize Prong-B — 0/1 knapsack where greedy fails

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction.ipynb
@@ -612,6 +612,109 @@
   },
   {
    "cell_type": "markdown",
+   "id": "nb01-opt-prongb-intro",
+   "metadata": {},
+   "source": [
+    "### Aller plus loin : un cas ou le glouton echoue, et ou `Optimize` devient indispensable\n",
+    "\n",
+    "L'exemple precedent etait un sac a dos **non borne** (variables `>= 0`) avec un objet dominant : A a la meilleure **densite** (valeur/poids), donc la strategie **gloutonne** - remplir le sac en priorisant les objets les plus denses - donne *deja* l'optimum. Dans ce cas degenere, le moteur **branches-boundes** de `Optimize` n'apporte rien : une heuristique triviale suffit.\n",
+    "\n",
+    "Pour **voir** l'apport d'un solveur exact, il faut un probleme ou le glouton echoue. Passons au sac a dos **0/1** : chaque objet est pris une fois au plus (variable binaire `0` ou `1`), avec une instance classique (Cormen, Leiserson, Rivest, Stein) concue pour pieger le glouton. On compare alors les deux approches cote a cote."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "nb01-opt-prongb-code",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Glouton (densite) : ['A', 'B']\n",
+      "  poids = 30/50 kg (capacite inutilisee : 20 kg)\n",
+      "  valeur = 160\n",
+      "\n",
+      "Optimisation Z3 : sat\n",
+      "Optimum Z3      : ['B', 'C']\n",
+      "  poids = 50/50 kg (capacite inutilisee : 0 kg)\n",
+      "  valeur = 220\n",
+      "\n",
+      "Ecart glouton -> optimum : 60 (27 % de valeur perdue)\n",
+      "-> le glouton est SOUS-OPTIMAL : Optimize trouve une meilleure solution.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Sac a dos 0/1 (binaire) : pourquoi Optimize est indispensable.\n",
+    "# Instance classique (Cormen et al.) : 3 objets, capacite 50 kg.\n",
+    "# (nom, valeur, poids)\n",
+    "objets = [(\"A\", 60, 10), (\"B\", 100, 20), (\"C\", 120, 30)]\n",
+    "CAPACITE = 50\n",
+    "\n",
+    "# --- 1. Heuristique gloutonne : trier par densite decroissante, prendre tant que possible ---\n",
+    "ordre = sorted(range(len(objets)), key=lambda i: objets[i][1] / objets[i][2], reverse=True)\n",
+    "poids_g, valeur_g, choix_g = 0, 0, []\n",
+    "for i in ordre:\n",
+    "    if poids_g + objets[i][2] <= CAPACITE:\n",
+    "        poids_g += objets[i][2]\n",
+    "        valeur_g += objets[i][1]\n",
+    "        choix_g.append(objets[i][0])\n",
+    "\n",
+    "print(\"Glouton (densite) :\", choix_g)\n",
+    "print(f\"  poids = {poids_g}/{CAPACITE} kg (capacite inutilisee : {CAPACITE - poids_g} kg)\")\n",
+    "print(f\"  valeur = {valeur_g}\")\n",
+    "print()\n",
+    "# --- 2. Z3 Optimize : resolution EXACTE du sac a dos 0/1 ---\n",
+    "opt = Optimize()\n",
+    "x = [Int(f\"x_{i}\") for i in range(len(objets))]   # x_i = 1 si l'objet i est pris, 0 sinon\n",
+    "for xi in x:\n",
+    "    opt.add(xi >= 0, xi <= 1)                       # variable binaire 0/1\n",
+    "opt.add(Sum([objets[i][2] * x[i] for i in range(len(objets))]) <= CAPACITE)\n",
+    "opt.maximize(Sum([objets[i][1] * x[i] for i in range(len(objets))]))\n",
+    "\n",
+    "print(\"Optimisation Z3 :\", opt.check())\n",
+    "m = opt.model()\n",
+    "choix_z = [objets[i][0] for i in range(len(objets)) if m[x[i]].as_long() == 1]\n",
+    "poids_z = sum(objets[i][2] for i in range(len(objets)) if m[x[i]].as_long() == 1)\n",
+    "valeur_z = sum(objets[i][1] for i in range(len(objets)) if m[x[i]].as_long() == 1)\n",
+    "print(\"Optimum Z3      :\", choix_z)\n",
+    "print(f\"  poids = {poids_z}/{CAPACITE} kg (capacite inutilisee : {CAPACITE - poids_z} kg)\")\n",
+    "print(f\"  valeur = {valeur_z}\")\n",
+    "print()\n",
+    "# --- 3. Confrontation : l'ecart rend visible la valeur d'Optimize ---\n",
+    "ecart = valeur_z - valeur_g\n",
+    "print(f\"Ecart glouton -> optimum : {ecart} ({100 * ecart / valeur_z:.0f} % de valeur perdue)\")\n",
+    "print(\"-> le glouton est SOUS-OPTIMAL : Optimize trouve une meilleure solution.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nb01-opt-prongb-interp",
+   "metadata": {},
+   "source": [
+    "### Interpretation : pourquoi le glouton echoue (et pourquoi `Optimize` gagne)\n",
+    "\n",
+    "**Sortie obtenue** :\n",
+    "\n",
+    "| Methode | Objets choisis | Poids utilise | Valeur |\n",
+    "|---------|----------------|---------------|--------|\n",
+    "| Glouton (densite) | A, B | 30 / 50 kg | 160 |\n",
+    "| Z3 `Optimize` (exact) | B, C | 50 / 50 kg | 220 |\n",
+    "\n",
+    "Le glouton echoue de **deux manieres cumulees** :\n",
+    "\n",
+    "1. **Mauvaise composition.** Il prend d'abord A (densite 6,0) puis B (densite 5,0), atteignant 30 kg. Il ne peut alors plus faire rentrer C (30 kg) : il abandonne. La solution optimale **abandonne A** pour liberer de la place et prend B + C (50 kg, valeur 220). Le glouton est **myope** : il ne peut pas \"voir\" que renoncer a l'objet le plus dense libere assez de capacite pour un objet plus valuable.\n",
+    "2. **Capacite gaspillee.** Le glouton laisse **20 kg inutilises** (30/50), alors que l'optimum remplit le sac **parfaitement** (50/50). Un sac a dos 0/1 n'est pas juste un probleme de \"prendre le maximum d'objets\" : c'est un **equilibre global** que seul un parcours exact du domaine retrouve.\n",
+    "\n",
+    "**Lecon** : le sac a dos 0/1 est **NP-difficile**. Aucune heuristique gloutonne ne garantit l'optimum (le glouton peut etre arbitrairement mauvais sur certaines instances). `Optimize`, par son **exploration branches-boundes** avec preuves de borne, **garantit** l'optimum global - c'est precisement la capacite distinctive que la cellule precedente (instance degeneree) ne permettait pas d'exercer.\n",
+    "\n",
+    "> **Astuce** : variables binaires `x_i dans {0, 1}` modelisees par `Int` + contraintes `xi >= 0, xi <= 1`. Z3 expose aussi un type `Bool` mieux adapte aux pures decisions vrai/faux, mais la formulation entiere 0/1 se prete naturellement au calcul de poids et de valeur via `Sum`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "nb01-ex1-intro",
    "metadata": {
     "papermill": {
@@ -641,7 +744,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "nb01-ex1-code",
    "metadata": {
     "execution": {
@@ -722,7 +825,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "nb01-ex2-code",
    "metadata": {
     "execution": {
@@ -798,7 +901,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "nb01-ex3-code",
    "metadata": {
     "execution": {


### PR DESCRIPTION
## Summary

EPIC **#3801 Prong-B** (sota-not-workaround.md): `Z3-Python-01-Introduction.ipynb` §4 Optimisation demoed `Optimize` on a **degenerate** instance where the SOTA tool's distinctive capability was NOT exercised. The existing worked example was an **unbounded** 3-item knapsack with a single dominant item (A: density 2.0) — so the greedy-by-density heuristic already returns the optimum (5×A = 20), and `Optimize`'s branch-and-bound adds nothing. The interpretation cell *asserted* « NP-difficile / branches-boundes » but the instance never needed it. This is the canonical Prong-B gap (cf BFS-vs-A* on uniform-cost, commit `8905f8845`).

## The fix (Prong-B: complexify so the engine's advantage is VISIBLE)

Add 3 cells after the existing `Optimize` interpretation (preserving the unbounded API intro — anti-regression, additive `+106/-3`):

1. **Transition markdown** — explains why the unbounded dominant-density demo is degenerate for a greedy comparison, motivates the 0/1 binary knapsack.
2. **Code cell** — the **CLRS classic** 0/1 knapsack instance (Cormen et al.), 3 items / capacity 50 kg, running **both** a greedy-by-density heuristic AND Z3 `Optimize` side-by-side, printing the gap. This makes `Optimize`'s advantage **visible in the output**.
3. **Interpretation markdown** — decomposes the double failure (wrong composition + wasted capacity), states the NP-difficulty lesson, links the `Int` 0/1 modelling trick.

### The discriminating output (hand-verified firsthand, z3 5.0.0)

```
Glouton (densite) : ['A', 'B']
  poids = 30/50 kg (capacite inutilisee : 20 kg)
  valeur = 160

Optimisation Z3 : sat
Optimum Z3      : ['B', 'C']
  poids = 50/50 kg (capacite inutilisee : 0 kg)
  valeur = 220

Ecart glouton -> optimum : 60 (27 % de valeur perdue)
-> le glouton est SOUS-OPTIMAL : Optimize trouve une meilleure solution.
```

Greedy fails **twice over**: (1) wrong composition — it commits to A (highest density) which blocks C, whereas the optimum **drops A** to fit B+C; (2) wasted capacity — greedy leaves **20 kg unused** (30/50) while the optimum fills the bag **perfectly** (50/50). 27 % value gap. This is exactly the instance where `Optimize`'s branch-and-bound is **genuinely needed** — the prior unbounded instance did not exercise it.

## Validation (H.1-H.3 / sota-rule Prong-B)

- **End-to-end execution**: `jupyter nbconvert --to notebook --execute --inplace --kernel python3` → exit 0, all 10 code cells ran, **0 errors**. `z3-solver` installed in the `python3` kernel env (rule F: install, never bypass).
- **Real outputs committed (C.2)**: new code cell `execution_count=7` + real stdout (greedy-vs-Z3 gap above). ec sequence `[1..10]` sequential.
- **C.1 clean**: 0 `raise NotImplementedError` / `assert False` / `1/0` in code sources (grep on parsed code cells, not raw JSON — base64 PNG false-positives excluded). 0 `SyntaxError` (ast-parsed every code cell).
- **C.3 surgical scope**: rebuilt from origin/main; **only 3 new cells + 3 structural execution_count bumps** (ex1/ex2/ex3 shifted 7→8, 8→9, 9→10 by the inserted code cell). **0 output changes** on any pre-existing cell (the unbounded demo's output preserved byte-identical — NOT re-executed gratuitously).
- **nbformat 4.5 valid**; LF-only (CR count = 0, hex-verified); indent=1 matches origin.
- **Catalogue byte-identical to main** (HARD rule): `git diff origin/main -- COURSE_CATALOG.generated.{md,json}` = empty.
- **Prong-B verdict**: SOTA-OK — the committed output IS Z3 `Optimize`'s real output on a discriminating instance (greedy provably suboptimal, verified firsthand before writing the cell).
- **Collision-check firsthand**: `gh pr list --state open --search "Z3-Python-01"` and `--search "Z3-API"` → no open PR touches this notebook (#7675 = CaseStudies/Diagnostic-Medical A*, different file/family).
- FR prose (readme-french-first.md). No hardcoded catalog counts.

## Scope (anti-regression)

- 1 file, additive (`+106/-3`): 3 new cells inserted at index 16 (markdown + code + markdown); 3 execution_count label bumps (structural consequence).
- No pre-existing cell source modified. No pre-existing output modified (Stop & Repair respected). No cell deleted.
- Catalogue byte-identical to main.

See #3801 (Prong-B, not `Closes` — partial contribution to the epic). Related: sota-not-workaround.md Prong-B (BFS-vs-A* canonical case).

Grain: MED/fix-prongb — lane po-2026:CoursIA — prev: MED/notebook-enrichment (c.604 #7716 DecPyMC-5). PROTOCOLE-VARIATION: pivot away from notebook-enrichment (c.603 + c.604 = 2-streak enrichment; R6 strict BANS a 3rd consecutive enrichment) → fix-prongb genre distinct (G-VAR-3 OK). Fresh family SymbolicAI/SMT (3rd distinct family in 3 cycles: Search → Probas → SMT; R6 family rotation honored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
