### PR TITLE
docs(search-csp,#7721): CSP-2 corrige interpretation cell[41] MAC-vs-FC (claim fausse)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-2-Consistency-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-2-Consistency-Csharp.ipynb
@@ -1880,9 +1880,11 @@
    "id": "6adf1701",
    "metadata": {},
    "source": [
-    "### Interpretation : MAC domine\n",
+    "### Interpretation : BT vs FC vs MAC sur 8-Reines\n",
     "\n",
-    "**Sortie obtenue** : MAC explore **le moins de noeuds** des trois techniques, grace a la propagation en cascade. FC est entre les deux : mieux que BT mais sans la propagation transitive de MAC.\n",
+    "**Sortie obtenue** : BT explore **36 noeuds** contre **8** pour FC et MAC. La propagation (FC comme MAC) divise donc deja par ~4 le nombre de noeuds par rapport au backtracking naive : anticiper les conflits de rangée évite d'explorer des branches sans issue.\n",
+    "\n",
+    "**Pourquoi FC et MAC explorent-ils le meme nombre de noeuds ici ?** Sur ce CSP simplifié (contraintes de rangée différentes seulement, sans les conflits diagonaux), les 8-Reines dégénèrent en une permutation : la première valeur de chaque colonne est immédiatement valide, donc ni FC ni MAC n'ont besoin de backtracker. La cascade AC-3 de MAC ne trouve rien de plus à élaguer que FC, et paie juste son surcout de propagation (8,0 ms vs 2,3 ms). Le différentiel **MAC vs FC** se manifeste sur des problèmes fortement contraints où la propagation transitive d'AC-3 cascade à travers plusieurs variables. L'issue #7721 trace l'activation des vraies contraintes diagonales (8-Reines complètes), qui rendra cette distinction visible.\n",
     "\n",
     "**Règle pratique** : sur des problemes fortement contraints (peu de solutions, domaines denses), MAC surpasse généralement FC. Sur des problemes faiblement contraints, le surcout d AC-3 après chaque assignation peut rendre MAC plus lent que FC en temps mural, même s il explore moins de noeuds. Le choix depend du ratio **cout de propagation / cout d un noeud explore**."
    ]


### PR DESCRIPTION
## Summary

`Search/Part2-CSP/CSP-2-Consistency-Csharp.ipynb` cell[41] (markdown) avait une interprétation **factuellement fausse** : elle claimait « MAC explore le moins de noeuds des trois techniques, grace a la propagation en cascade » — mais l'output cell[38] (ec=18) montre `BT=36 / FC=8 / MAC=8` : MAC = FC (égalité, pas domination). La cascade AC-3 ne se déclenche pas. L'étudiant lisait une claim contredite par la sortie visible.

## Fix (markdown-only)

Reformule honnêtement autour du VRAI output :
- le pruning forward (FC) divise déjà par ~4 les nœuds vs BT naïve (36 → 8) ;
- sur ce CSP simplifié (rangées seulement, sans diagonales), les 8-Reines dégénèrent en permutation → ni FC ni MAC ne backtrackent → MAC paie juste son surcoût de propagation (8,0 ms vs 2,3 ms) sans gain de pruning ;
- le différentiel MAC vs FC se manifeste sur des problèmes fortement contraints (cascade AC-3 transitive) ;
- pointe vers #7721 qui trace l'activation des vraies contraintes diagonales (le fix complet qui rendra la distinction MAC vs FC visible) ;
- règle pratique conceptuelle conservée.

## Scope du cycle c.758

Investigation profonde du defect CSP-2 (scan sonnet → firsthand G.1-verify → re-exec kernel .net-csharp) → **issue #7721** avec diagnostic des **4 bugs** : (1) contrainte diagonale manquante `noDiag` placeholder + `diffRowsAndDiag` dead code, (2) claim cell[41] fausse (corrigée ici), (3) bug AC3/MAC latent `KeyNotFoundException` préexistant exposé par vraies contraintes, (4) FC produit encore identity malgré fix diagonal (à valider). Le fix complet est **multi-cycle** (valider closure + fix AC3 cell[35] + comprendre FC-identity) — tracé par #7721.

Cette PR corrige le bug #2 (la claim fausse, erreur factuelle pédagogique) immédiatement, sans attendre le fix code complet. **Ce n'est pas un maquillage du défaut en « intentionnel »** : la cell dit explicitement que le CSP est « simplifié » et renvoie au fix #7721.

## Validation

- markdown-only → exception C.2 (22 code cells ec 1..22 inchangés, byte-identity confirmée vs origin/main)
- diff chirurgical +4/-2, 1 fichier, 1 cell (id 6adf1701)
- catalogue byte-identique à main
- collision-check : 0 PR ouverte sur CSP-2-Consistency

See #7721. See #3801 (EPIC SOTA Prong-B). See #4956 (.NET twins).

EPIC #3801 — registre SOTA-axe2 (Search-.NET).

/grain LIGHT/notebook-interpretation