### PR TITLE
i18n(lean,#4980): MechanismDesign.lean module doc EN->FR flip (half-done migration)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/SocialChoice/MechanismDesign.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/SocialChoice/MechanismDesign.lean
@@ -1,15 +1,15 @@
 /-
-  Mechanism Design — Auction Formalization
-  =========================================
+  Théorie des mécanismes — Formalisation d'enchères
+  =================================================
 
-  Decidability results for auction-based mechanism design on finite domains.
+  Résultats de décidabilité pour la théorie des mécanismes d'enchères sur domaines finis.
 
-  - Vickrey (second-price) auction truthfulness: proved by omega + case split
-  - First-price auction non-truthfulness: concrete counter-example via decide
-  - 3-bidder Vickrey truthfulness: proved by omega + case split
+  - Véracité de l'enchère de Vickrey (second prix) : prouvée par omega + disjonction de cas
+  - Non-véracité de l'enchère au premier prix : contre-exemple concret via decide
+  - Véracité de l'enchère de Vickrey à 3 enchérisseurs : prouvée par omega + disjonction de cas
 
-  Reference: Vickrey (1961), "Counterspeculation, Auctions, and Competitive Sealed Tenders"
-  Reference: #1469 — Mechanism Design kickstart
+  Référence : Vickrey (1961), « Counterspeculation, Auctions, and Competitive Sealed Tenders »
+  Référence : #1469 — Amorçage de la théorie des mécanismes
 -/
 
 import Mathlib.Data.Fintype.Basic


### PR DESCRIPTION
## Summary

EPIC **#4980** (Lean i18n sibling-pair): `game_theory_lean/SocialChoice/MechanismDesign.lean` had the canonical "i18n half-done" pattern — the **module doc (lines 1-13) was entirely in ENGLISH** while the **body (lines 16+) was entirely in FRENCH**. The canonical file is supposed to be FR-first (the `_en` sibling is the English mirror); the module doc was left EN by mistake. This PR flips the module doc EN→FR, completing the migration. Body FR is preserved byte-identical (anti-§D).

### The gap (G.1-verified firsthand against origin/main @ ac1d3c981)

`MechanismDesign.lean` module doc (lines 1-13) — EN:
```
/-
  Mechanism Design — Auction Formalization
  =========================================

  Decidability results for auction-based mechanism design on finite domains.

  - Vickrey (second-price) auction truthfulness: proved by omega + case split
  - First-price auction non-truthfulness: concrete counter-example via decide
  - 3-bidder Vickrey truthfulness: proved by omega + case split

  Reference: Vickrey (1961), "Counterspeculation, Auctions, and Competitive Sealed Tenders"
  Reference: #1469 — Mechanism Design kickstart
-/
```

But the body (lines 16+) is fully FR — e.g. `/-- **Théorème 1** : l'enchère de Vickrey (deuxième prix) est vérace pour l'enchérisseur 0. ...`, comments `-- l'enchérisseur 0 gagne`. The `_en.lean` sibling has the identical EN module doc (as expected — the EN mirror preserves English). So the canonical FR file had an EN module doc by oversight.

## The fix

Flip the module doc (lines 1-13) EN→FR, preserving structure (title, underline, bullets, references, issue number). Vocabulary aligned with the file's own FR body convention: « vérace / véracité », « enchère de Vickrey », « contre-exemple », « premier / second prix », « disjonction de cas » (case split).

```
/-
  Théorie des mécanismes — Formalisation d'enchères
  =================================================

  Résultats de décidabilité pour la théorie des mécanismes d'enchères sur domaines finis.

  - Véracité de l'enchère de Vickrey (second prix) : prouvée par omega + disjonction de cas
  - Non-véracité de l'enchère au premier prix : contre-exemple concret via decide
  - Véracité de l'enchère de Vickrey à 3 enchérisseurs : prouvée par omega + disjonction de cas

  Référence : Vickrey (1961), « Counterspeculation, Auctions, and Competitive Sealed Tenders »
  Référence : #1469 — Amorçage de la théorie des mécanismes
-/
```

## Validation (lean-merge-discipline §1)

- **`lake build SocialChoice.MechanismDesign` → Build completed successfully (2946 jobs), exit 0.** (mathlib junctioned precompiled, MechanismDesign recompiled from source). Two pre-existing linter warnings (`oB` L105, `oA` L108 variable-not-referenced) are in the **body**, which I left byte-identical — NOT introduced by this PR.
- **Anti-§D byte-identity CONFIRMED**: stripped the module-doc block, the residual body (lines 14+) is **byte-identical origin↔mine**. Only the module doc (lines 1-13) differs. No theorem/def/namespace name, tactic, or proof touched.
- **sorry parity**: 0 = 0 (no sorry in either version; no proof content touched).
- **Module-doc well-formed**: opens with `/-`, closes with `-/` at line 13 (delimiters intact → parser-safe → compile cannot break, as confirmed by the build).
- **LF-only** (CR count = 0). **Catalogue byte-identical to main** (`git diff origin/main -- COURSE_CATALOG.generated.{md,json}` = empty).
- **Collision-check firsthand**: REST open-PRs + `git ls-remote` → no open PR or branch touches `MechanismDesign.lean` (GraphQL rate-limited; REST + ls-remote used as fallback per dashboard lesson). game_theory_lean is not any lane's active turf this cycle.
- **i18n fleet context**: the Lean i18n fleet is otherwise DRAINED (c.505: 168 sibling pairs, 0 drift). MechanismDesign.lean's half-done module doc is one of the few remaining gaps; this PR closes it.

## G.1 note (sub-agent unreliability)

An Explore (sonnet) sub-agent ranked a different file (grothendieck_lean/ConstantSheaf.lean) as RANK-1 "EN-canonical" — **FALSE firsthand**: ConstantSheaf.lean is already FR (« Grothendieck Partie 18 — Le faisceau constant », 65 FR-telltales). The sub-agent hallucinated file content. The RANK-2 candidate (this MechanismDesign.lean module doc) was CORRECT firsthand. Lesson: Explore sub-agent reports on Lean linguistic state are not reliable — always verify firsthand before [CLAIM].

## Scope (anti-regression)

- 1 file, `+8/-8`: module doc (lines 1-13) flipped EN→FR. Body (lines 14+) byte-identical.
- No executable code modified. No proof modified. No declaration renamed.
- Catalogue byte-identical to main.

See #4980 (partial contribution to the i18n epic, not `Closes` — the epic stays open). Related: #1469 (Mechanism Design kickstart reference in the module doc).

Grain: MED/lean-i18n — lane po-2026:CoursIA — prev: MED/fix-prongb (c.605 #7719 Z3-Python-01). PROTOCOLE-VARIATION: pivot to fresh family Lean (Search c.603 → Probas c.604 → SMT c.605 → Lean c.606 = 4 distinct families; R6 family rotation honored). Genre lean-i18n distinct from enrichment/fix-prongb (G-VAR-3 OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
