### PR TITLE
feat(translation,#6949): FR_CONTAM verdict in check_translation_sync (Argumentum 5-classes, 4e)

### DIFF
--- a/scripts/tests/test_translation_sync.py
+++ b/scripts/tests/test_translation_sync.py
@@ -422,3 +422,156 @@ def test_roundtrip_extract_then_check_in_sync(tmp_path):
     csv = _write_csv(tmp_path / "drift.csv", rows)
     # T2 doit trouver 0 anomalie sur ce CSV fraichement extrait de T1.
     assert t2.check_csv(csv, repo) == []
+
+
+# --------------------------------------------------------------------------- #
+#  FR_CONTAM (Argumentum 5-classes, 4e - #6949)                                #
+#                                                                             #
+# Une traduction dont le texte normalise est IDENTIQUE au source fr (non       #
+# traduite - le francais a fuite tel quel dans la colonne en/es/pt/...).       #
+# Miroir multilingual-drift-audit.py : val == fr_val, garde len >= 4.          #
+# --------------------------------------------------------------------------- #
+
+
+# --- _is_fr_contam : predicat pur (miroir fork Argumentum @7e72f3e) --------- #
+
+
+def test_fr_contam_identical_long_text():
+    """Texte traduit == source (>= 4 cars) -> FR_CONTAM (non traduit)."""
+    assert t2._is_fr_contam("Bonjour le monde", "Bonjour le monde") is True
+
+
+def test_fr_contam_different_text_no_contam():
+    """Texte traduit != source -> pas de contamination (vraie traduction)."""
+    assert t2._is_fr_contam("Bonjour le monde", "Hello world") is False
+
+
+def test_fr_contam_identical_short_text_suppressed():
+    """Texte identique mais < 4 cars normalises -> supprime (garde len du fork)."""
+    assert t2._is_fr_contam("Hi", "Hi") is False
+    assert t2._is_fr_contam("OK", "OK") is False
+
+
+def test_fr_contam_boundary_len_exactly_four():
+    """Frontiere : exactement 4 cars normalises -> FR_CONTAM (inclusive)."""
+    assert t2._is_fr_contam("abcd", "abcd") is True
+
+
+def test_fr_contam_boundary_len_three_excluded():
+    """Frontiere : 3 cars normalises -> supprime (strictement < 4)."""
+    assert t2._is_fr_contam("abc", "abc") is False
+
+
+def test_fr_contam_normalized_equal_trailing_whitespace():
+    """Le fork normalise avant legalite : trailing whitespace/blank lines ignores."""
+    assert t2._is_fr_contam("Bonjour le monde  \n\n", "Bonjour le monde") is True
+
+
+def test_fr_contam_empty_strings():
+    """Deux textes vides -> pas de contam (len 0 < 4)."""
+    assert t2._is_fr_contam("", "") is False
+
+
+def test_fr_contam_french_accents_unicode():
+    """Texte accentue identique -> FR_CONTAM (l Unicode francais passe)."""
+    assert t2._is_fr_contam("Cafe reunion a Paris", "Cafe reunion a Paris") is True
+
+
+def test_fr_contam_whitespace_only_not_contam():
+    """Whitespace seul normalise vers vide (len 0) -> pas de contam."""
+    assert t2._is_fr_contam("   \n  ", "   \n  ") is False
+
+
+# --- check_csv : detection FR_CONTAM en integration ------------------------- #
+
+
+def test_check_csv_fr_contam_untranslated_en(tmp_path):
+    """Cellule EN identique au source FR (hash_en == src_hash, en-sync) -> FR_CONTAM."""
+    repo = tmp_path
+    src_text = "Introduction a la theorie des jeux"
+    _write_notebook(repo / "S" / "Foo.ipynb", [_make_cell("c1", "markdown", src_text)])
+    _write_notebook(repo / "S" / "Foo_en.ipynb", [_make_cell("c1", "markdown", src_text)])
+    csv = _write_csv(tmp_path / "drift.csv", [
+        _row("S/Foo.ipynb", "c1", t2.cell_hash(src_text),
+             **{"hash_en": t2.cell_hash(src_text)})
+    ])
+    anomalies = t2.check_csv(csv, repo)
+    verdicts = [a["verdict"] for a in anomalies]
+    assert "FR_CONTAM" in verdicts
+    fc = next(a for a in anomalies if a["verdict"] == "FR_CONTAM")
+    assert fc["lang"] == "en"
+    assert fc["cell_id"] == "c1"
+
+
+def test_check_csv_fr_contam_translated_no_anomaly(tmp_path):
+    """Cellule EN correctement traduite (!= source) -> aucun FR_CONTAM."""
+    repo = tmp_path
+    _write_notebook(repo / "S" / "Foo.ipynb", [_make_cell("c1", "markdown", "Bonjour le monde")])
+    _write_notebook(repo / "S" / "Foo_en.ipynb", [_make_cell("c1", "markdown", "Hello world")])
+    csv = _write_csv(tmp_path / "drift.csv", [
+        _row("S/Foo.ipynb", "c1", t2.cell_hash("Bonjour le monde"),
+             **{"hash_en": t2.cell_hash("Hello world")})
+    ])
+    anomalies = t2.check_csv(csv, repo)
+    assert all(a["verdict"] != "FR_CONTAM" for a in anomalies)
+
+
+def test_check_csv_fr_contam_short_cell_suppressed(tmp_path):
+    """Cellule EN identique au FR mais < 4 cars -> pas de FR_CONTAM (garde len)."""
+    repo = tmp_path
+    _write_notebook(repo / "S" / "Foo.ipynb", [_make_cell("c1", "markdown", "Py")])
+    _write_notebook(repo / "S" / "Foo_en.ipynb", [_make_cell("c1", "markdown", "Py")])
+    csv = _write_csv(tmp_path / "drift.csv", [
+        _row("S/Foo.ipynb", "c1", t2.cell_hash("Py"),
+             **{"hash_en": t2.cell_hash("Py")})
+    ])
+    anomalies = t2.check_csv(csv, repo)
+    assert all(a["verdict"] != "FR_CONTAM" for a in anomalies)
+
+
+def test_check_csv_fr_contam_coexists_with_trad_drift(tmp_path):
+    """EN actuellement == source (FR_CONTAM) MAIS csv_hash_en etait different
+    (TRAD_DRIFT) -> les deux verdicts sont complementaires, pas exclusifs."""
+    repo = tmp_path
+    src_text = "Analyse de la decision rationnelle"
+    _write_notebook(repo / "S" / "Foo.ipynb", [_make_cell("c1", "markdown", src_text)])
+    _write_notebook(repo / "S" / "Foo_en.ipynb", [_make_cell("c1", "markdown", src_text)])
+    csv = _write_csv(tmp_path / "drift.csv", [
+        _row("S/Foo.ipynb", "c1", t2.cell_hash(src_text),
+             **{"hash_en": t2.cell_hash("a previous real translation")})
+    ])
+    anomalies = t2.check_csv(csv, repo)
+    verdicts = [a["verdict"] for a in anomalies]
+    assert "TRAD_DRIFT" in verdicts
+    assert "FR_CONTAM" in verdicts
+
+
+def test_check_csv_fr_contam_multiple_langs(tmp_path):
+    """EN et ES tous deux non traduits (== source) -> 2 anomalies FR_CONTAM."""
+    repo = tmp_path
+    src_text = "Conclusion du chapitre sur les votions"
+    _write_notebook(repo / "S" / "Foo.ipynb", [_make_cell("c1", "markdown", src_text)])
+    _write_notebook(repo / "S" / "Foo_en.ipynb", [_make_cell("c1", "markdown", src_text)])
+    _write_notebook(repo / "S" / "Foo_es.ipynb", [_make_cell("c1", "markdown", src_text)])
+    csv = _write_csv(tmp_path / "drift.csv", [
+        _row("S/Foo.ipynb", "c1", t2.cell_hash(src_text),
+             **{"hash_en": t2.cell_hash(src_text), "hash_es": t2.cell_hash(src_text)})
+    ])
+    anomalies = t2.check_csv(csv, repo)
+    fc_langs = sorted(a["lang"] for a in anomalies if a["verdict"] == "FR_CONTAM")
+    assert fc_langs == ["en", "es"]
+
+
+def test_check_csv_fr_contam_lazy_text_load_no_false_positive(tmp_path):
+    """Une traduction dont le hash != source (vraie traduction) ne declenche PAS
+    le chargement des textes - et ne produit aucun FR_CONTAM. Verifie le pre-check
+    par hash filtre correctement avant tout chargement de texte."""
+    repo = tmp_path
+    _write_notebook(repo / "S" / "Foo.ipynb", [_make_cell("c1", "markdown", "Texte source francais")])
+    _write_notebook(repo / "S" / "Foo_en.ipynb", [_make_cell("c1", "markdown", "French source text")])
+    csv = _write_csv(tmp_path / "drift.csv", [
+        _row("S/Foo.ipynb", "c1", t2.cell_hash("Texte source francais"),
+             **{"hash_en": t2.cell_hash("French source text")})
+    ])
+    anomalies = t2.check_csv(csv, repo)
+    assert all(a["verdict"] != "FR_CONTAM" for a in anomalies)

--- a/scripts/translation/README.md
+++ b/scripts/translation/README.md
@@ -49,6 +49,7 @@ Détecte le drift entre les notebooks courants et le CSV. **Non-bloquant** (mode
 | `TRAD_DRIFT` | une traduction a été éditée à la main sans repercussion sur le CSV |
 | `MISSING_LANG` | le notebook `xxx_<lang>.ipynb` n'existe plus alors qu'un hash était déposé |
 | `ORPHAN_ROW` | la ligne CSV référence un `cell_id` absent du notebook source (cellule supprimée) |
+| `FR_CONTAM` | la traduction `xxx_<lang>.ipynb` est **identique au source fr** (non traduite, français leaké) — Argumentum 5-classes (4e), garde `len>=4` (#6949) |
 
 ```bash
 # Vérifier un CSV (exit 1 si drift)
@@ -59,6 +60,8 @@ python scripts/translation/check_translation_sync.py translations/ --check
 ```
 
 En phase POC (T1, seule la colonne pivot est remplie), le script ne remonte que du `SRC_DRIFT` éventuel ; l'absence de traductions déposées n'est pas un drift (c'est l'état attendu pré-T3). Le pivot (`fr`) étant le notebook source lui-même, sa cohérence est couverte par `SRC_DRIFT` — pas de faux `MISSING_LANG` sur le pivot.
+
+**Harmonisation taxonomie Argumentum (#6949)** : ce script couvre désormais 4 des 5 classes de drift du fork `multilingual-drift-audit.py` — `MISSING`/`ORPHAN` (MISSING_LANG/ORPHAN_ROW), `WRONG_SCRIPT` (script Unicode attendu absent, c.734 #7714), `FR_CONTAM` (c.738). La 5e classe `COGNATE` (noms propres / faux-amis légitimement répétés, `kind == "name"`, **informationnelle** — hors `total_drift` dans le fork) est **N/A** par construction : notre modèle est cell-based (pas de distinction name/prose).
 
 ## CI
 

--- a/scripts/translation/check_translation_sync.py
+++ b/scripts/translation/check_translation_sync.py
@@ -18,6 +18,15 @@ Verdicts par ligne CSV (cf. #4957 §2) :
                  etait depose dans le CSV
     ORPHAN_ROW   la ligne CSV reference un cell_id absent du notebook source
                  (cellule supprimee)
+    FR_CONTAM    la traduction xxx_<lang>.ipynb est IDENTIQUE au source fr
+                 (non traduite, francais leaké dans la colonne en/es/pt/...).
+                 Miroir Argumentum multilingual-drift-audit.py : val == fr_val,
+                 garde len >= 4 (#6949 harmonisation 5-classes, 4e classe).
+
+    Note taxonomie Argumentum (#6949) : la 5e classe COGNATE (noms propres /
+    faux-amis legitiment repetes, kind == "name", informationnelle — hors
+    total_drift dans le fork) n'a pas d'equivalent ici : notre modele est
+    cell-based (pas de distinction name/prose), donc N/A par construction.
 
 En phase POC (T1, seule la colonne pivot est remplie), le script ne remonte
 que du SRC_DRIFT eventuel ; l'absence de traductions deposees n'est pas un drift
@@ -100,6 +109,22 @@ def _has_expected_script(lang: str, text: str) -> bool:
     return False
 
 
+def _is_fr_contam(src_text: str, lang_text: str) -> bool:
+    """FR_CONTAM (taxonomie Argumentum 5-classes, 4e) : une traduction dont le
+    texte normalisé EST IDENTIQUE au source français (non traduite — le français
+    a fuité tel quel dans la colonne ``en``/``es``/``pt``/...).
+
+    Miroir fidèle de ``multilingual-drift-audit.py`` (fork Argumentum @7e72f3e) :
+    ``val == fr_val`` post-normalisation, garde ``len(val) >= 4`` pour supprimer
+    les correspondances triviales (token unique, chiffre, ponctuation, markup).
+    Déterministe, zéro liste de mots — l'égalité exacte post-normalisation
+    suffit. Les faux-amis cognates (noms propres legitiment repetes) relevent
+    de la 5e classe COGNATE (informationnelle, hors de notre modele cell-based).
+    """
+    norm_lang = normalize(lang_text)
+    return norm_lang == normalize(src_text) and len(norm_lang) >= 4
+
+
 def load_notebook_cells(nb_path: Path) -> dict[str, str] | None:
     """Retourne {cell_id: hash} pour un notebook, ou None si illisible."""
     try:
@@ -115,6 +140,28 @@ def load_notebook_cells(nb_path: Path) -> dict[str, str] | None:
     return cells
 
 
+def load_notebook_cell_texts(nb_path: Path) -> dict[str, str] | None:
+    """Retourne {cell_id: texte_source} pour un notebook, ou None si illisible.
+
+    Miroir de ``load_notebook_cells`` mais conserve le texte brut (non haché) —
+    sert au verdict ``FR_CONTAM`` qui compare le texte traduit au texte source
+    (garde ``len >= 4``). Chargeur lazy : appelé uniquement quand un candidat
+    FR_CONTAM est détecté via égalité de hash (sha256 collision-free), pour
+    éviter de charger les textes de tout notebook sauf candidat.
+    """
+    try:
+        nb = json.loads(nb_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    texts: dict[str, str] = {}
+    for cell in nb.get("cells", []):
+        cid = cell.get("id")
+        if not cid or cell.get("cell_type") not in ("markdown", "code"):
+            continue
+        texts[cid] = "".join(cell.get("source", []))
+    return texts
+
+
 def translated_notebook_path(source_path: str, lang: str, repo_root: Path) -> Path:
     """`dir/foo.ipynb` + lang `en` -> `dir/foo_en.ipynb` (#1650 convention notebooks)."""
     p = repo_root / source_path
@@ -127,6 +174,8 @@ def check_csv(csv_path: Path, repo_root: Path) -> list[dict]:
     with csv_path.open(encoding="utf-8") as f:
         reader = csv.DictReader(f)
         source_cache: dict[str, dict[str, str] | None] = {}
+        source_text_cache: dict[str, dict[str, str] | None] = {}
+        trad_text_cache: dict[str, dict[str, str] | None] = {}
         for row in reader:
             nb_rel = row.get("notebook", "")
             cell_id = row.get("cell_id", "")
@@ -198,6 +247,25 @@ def check_csv(csv_path: Path, repo_root: Path) -> list[dict]:
                          "verdict": "TRAD_DRIFT",
                          "detail": f"traduction {lang} éditée (csv={csv_hash} <> actuel={trad_cells[cell_id]})"}
                     )
+
+                # FR_CONTAM (Argumentum 5-classes, 4e, #6949) : la traduction
+                # est-elle IDENTIQUE au source fr (non traduite) ? Pre-check par
+                # égalité de hash (sha256 collision-free -> hash égal = texte
+                # identique) pour ne charger les textes que sur candidat, puis
+                # _is_fr_contam confirme via la garde len >= 4 (miroir fork).
+                if trad_cells[cell_id] == current_src:
+                    if nb_rel not in source_text_cache:
+                        source_text_cache[nb_rel] = load_notebook_cell_texts(repo_root / nb_rel)
+                    if trad_path not in trad_text_cache:
+                        trad_text_cache[trad_path] = load_notebook_cell_texts(trad_path)
+                    src_txts = source_text_cache[nb_rel] or {}
+                    trad_txts = trad_text_cache[trad_path] or {}
+                    if _is_fr_contam(src_txts.get(cell_id, ""), trad_txts.get(cell_id, "")):
+                        anomalies.append(
+                            {"csv": str(csv_path), "notebook": nb_rel, "cell_id": cell_id, "lang": lang,
+                             "verdict": "FR_CONTAM",
+                             "detail": f"traduction {lang} identique au source fr (non traduite)"}
+                        )
     return anomalies
 
 


### PR DESCRIPTION
Grain: MED/enhancement-translation-python — lane myia-po-2026:CoursIA-2 — prev: DEEP/fix-notebook-dotnet (c.737 #7729)

Ports the **FR_CONTAM** drift class from the Argumentum fork `multilingual-drift-audit.py` (@7e72f3e) into our T2 sync checker, mirroring how c.734 (#7714) ported WRONG_SCRIPT (3rd class). Issue #6949 line 57 asks to harmonize our T2 with the fork's 5 drift classes; this completes the **4th**.

## FR_CONTAM — what it detects

A translation cell whose normalized text is **IDENTICAL to the French source** (untranslated — French leaked verbatim into the en/es/pt/... column). Mirrors the fork's exact rule `if kind=="prose" and val and fr_present and val==fr_val and len(val)>=4:`, adapted to our cell-based model.

**Deterministic, zero word-lists.** c.734 deferred this class as a "heuristic", but reading the fork source firsthand (WebFetch on the pinned SHA) reveals the actual rule is **exact-equality + `len>=4` guard** — no heuristic word-list involved:

- `_is_fr_contam(src_text, lang_text)` — pure predicate: normalize-equality + `len >= 4` (suppresses trivial 1-3 char matches: lone tokens, digits, punctuation, markdown markup).
- Loop: pre-check by hash equality (`trad_cells[cell_id] == current_src` — sha256 collision-free ⟹ equal hash = identical text) to **avoid loading cell texts unless a candidate exists**, then `_is_fr_contam` confirms with the len guard via lazily-loaded texts (`load_notebook_cell_texts`, cached per notebook). FR_CONTAM is **complementary** to TRAD_DRIFT, not exclusive (a cell can be both untranslated AND edited-since-sync — both verdicts fire).

## COGNATE (5th class) — documented N/A

The fork's COGNATE (`kind=="name"` exact-equality, proper nouns legitimately repeated — "Aristotle"/"Aristote") is **informational-only** in the fork (excluded from `total_drift`) and has no equivalent in our cell-based model (no name/prose distinction) → documented N/A in the docstring + README, **not** implemented. The 5-class harmonization is now complete:

| Argumentum class | Our T2 | Status |
|---|---|---|
| MISSING | MISSING_LANG | ✓ (pre-existing) |
| ORPHAN | ORPHAN_ROW | ✓ (pre-existing) |
| WRONG_SCRIPT | WRONG_SCRIPT | ✓ c.734 #7714 |
| **FR_CONTAM** | **FR_CONTAM** | **✓ this PR** |
| COGNATE | — | N/A documented (informational-only, no name kind) |

## G.9 non-vacuous (firsthand)

15 new tests (9 unit on `_is_fr_contam`, 6 integration on `check_csv`). De-patch (restore origin/main script) → **12 FAIL** (9 unit `AttributeError: _is_fr_contam` + 3 integration asserting FR_CONTAM present); 3 PASS are the no-false-positive guards (assert ABSENCE, trivially true when the feature is absent — exact mirror of c.734's 2 guards). Re-patch → 15/15.

- Full suite: **48/48** (origin/main 33 + 15 new).
- Sibling `test_translate_csv`: 23/23 (no regression).

## Real-world smoke

`check_translation_sync.py translations/ --check` on all **33 real CSVs**: exit 0, **FR_CONTAM=0** anomalies. Honest — POC state has few deposited translations (pre-T3, pivot-only), and the deposited ones are properly translated; 0 false positives confirms the `len>=4` + hash-equality guards work in production. The verdict is armed for when T3 deposits real translations.

## Scope

3 files, +224/-0. Catalog byte-identical to main. EOL LF.

**Coordination note vs #7714 (c.734 WRONG_SCRIPT)**: both PRs touch `check_translation_sync.py` + `test_translation_sync.py` + `README.md` (same files, different verdict classes). Independent detection (FR_CONTAM doesn't depend on `_has_expected_script`). Merge-order: whichever merges first, the other rebates cleanly (different code regions — #7714 adds the `_has_expected_script`/`LANG_SCRIPT_RANGES`/`WRONG_SCRIPT` block; this adds `_is_fr_contam`/`load_notebook_cell_texts`/`FR_CONTAM`). No semantic conflict.

See #6949 (partial — completes the 5-class verdict harmonization sub-task; the T3 engine fork itself remains open). See #4957 / #1650 (translation infrastructure).