### PR TITLE
docs(smartcontracts): enrich SC-3 Solidity interpretations (deploy, globals, conversions)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-3-Solidity-Basics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-3-Solidity-Basics.ipynb
@@ -252,6 +252,18 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a1c4e7f2",
+   "metadata": {},
+   "source": [
+    "### Interpretation : deploiement reel sur la chaine locale\n",
+    "\n",
+    "L'adresse `0x5FbDB2315678afecb367f032d93F642f64180aa3` n'est pas une simulation : le contrat `Counter` a ete **reellement compile** (solc) puis **broadcaste** a la chaine locale `anvil` (Foundry). Cette adresse est identique a chaque redemarrage d'anvil frais car elle est **deterministe** : c'est l'adresse canonique du premier contrat deploye depuis le compte `0xf39Fd6...` avec un nonce de 0.\n",
+    "\n",
+    "Une fois deploye, le contrat « vit » a cette adresse : son **bytecode est immuable** (plus modifiable), mais son **etat** (`count`) evolue a chaque transaction. C'est cette dualite — code fige, etat mutable — qui fonde la programmation smart contract : on ne « patch » pas un contrat deploye, on en deploie un nouveau (souvent derriere un proxy).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "bc4013f3",
    "metadata": {
     "papermill": {
@@ -1191,6 +1203,23 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b2d5e8a3",
+   "metadata": {},
+   "source": [
+    "### Interpretation : les variables globales de la EVM\n",
+    "\n",
+    "Les valeurs lues sont celles de la chaine `anvil` au moment de l'appel :\n",
+    "\n",
+    "- **`msg.sender = 0xf39Fd6...b92266`** — l'adresse qui a appele la fonction. C'est le **compte #0** de la phrase mnemonique de test par defaut d'anvil/Hardhat (well-known test account), ici le `deployer`. Critique en securite : tout controle d'acces repose sur cette valeur (`require(msg.sender == owner)`).\n",
+    "- **`block.timestamp = 1780884575`** — horodatage Unix du bloc courant (secondes depuis 1970-01-01). La EVM n'expose pas `now` hors du bloc courant : c'est la **seule** notion de temps disponible on-chain, avec une granularite de l'ordre de la seconde (un bloc ~= 12s sur Ethereum mainnet).\n",
+    "- **`block.number = 12`** — hauteur du bloc courant (le 12e bloc mine sur cette chaine locale).\n",
+    "- **`block.gaslimit = 30 000 000`** — quantite maximale de gaz autorisee par bloc (30M, standard Ethereum mainnet).\n",
+    "\n",
+    "Ces variables sont des **entrees implicites** de toute fonction : elles ne figurent pas dans la signature mais caracterisent le contexte d'execution. Un meme appel par deux comptes differents produit deux `msg.sender` differents — d'ou l'importance de ne jamais les supposer constantes.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "7e820f41",
    "metadata": {
     "papermill": {
@@ -1288,6 +1317,23 @@
     "\n",
     "print(\"Conversions de types Solidity:\")\n",
     "print(CONVERSION_EXAMPLE)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3e6f1b4",
+   "metadata": {},
+   "source": [
+    "### Interpretation : les conversions de types en Solidity\n",
+    "\n",
+    "Les quatre conversions couvrent les cas les plus frequents :\n",
+    "\n",
+    "- **`uint256 -> int256`** (explicite) — toujours sure (tout entier non signe tient dans le signe) ; la reciproque `int256 -> uint256` est dangereuse (un negatif devient un entier positif immense).\n",
+    "- **`address -> address payable`** — necessaire pour appeler `.transfer()` ou `.send()`. Depuis Solidity 0.8, `payable(addr)` est la syntaxe explicite ; la conversion inverse est automatique.\n",
+    "- **`string -> bytes`** — `bytes` est la representation bas-niveau ; la conversion est gratuite car `string` est deja encodee en UTF-8 sous le capot.\n",
+    "- **`address -> uint160`** — une adresse Ethereum n'est qu'un entier de 160 bits ; cette conversion sert a **comparer ou trier** des adresses (mapping dense, arithmetique).\n",
+    "\n",
+    "Toutes ces fonctions sont marquees `pure` : elles ne lisent ni n'ecrivent l'etat du contrat, elles transforment juste leurs arguments. Un appel `pure` est donc **gratuit hors-transaction** (view call local, pas de frais de gaz).\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary

`SC-3-Solidity-Basics` had **3 code cells with real outputs but no following pedagogical interpretation**:

| Cell | Content | Output (real) |
|------|---------|---------------|
| 5 | `Counter` contract deployed on `anvil` | `Deploye: Counter a 0x5FbDB2315678...` |
| 25 | EVM global variables | `msg.sender=0xf39Fd6...`, `block.timestamp=1780884575`, `block.number=12`, `block.gaslimit=30M` |
| 27 | Type conversions | `uint256→int256`, `address→payable`, `string→bytes`, `address→uint160` |

## Change

Add **3 markdown interpretation cells** (FR, primary doc language) inserted **after** each code cell:

1. **Counter deploy** — the address is deterministic (canonical first-contract address on fresh anvil from account #0 nonce 0); explains immutable-code / mutable-state duality.
2. **EVM global vars** — each value decoded (anvil test account #0, Unix timestamp as the *only* on-chain time, block height, 30M gaslimit); stresses `msg.sender` as the access-control basis.
3. **Type conversions** — the 4 patterns + why `pure` makes view calls free off-chain.

## Validation

- **Markdown-only insert** → no re-exec required (C.2 exception for markdown-only edits).
- **Byte-identity preserved** on all 48 existing cells (verified post-edit: 0 source-changed old cells, 0 code cells with `execution_count`/`outputs` diff vs `origin/main`).
- Diff: `1 file changed, 46 insertions(+), 0 deletions(-)` — pure addition.

## Notes

- Collision-checked: no open PR touches SC-3 content (recent SmartContracts PRs = skill/backend/README/data-ingestion).
- Grain: `MED/SmartContracts-doc` (variation-protocol #7655). Fresh family after 2x Search-.NET (c.758/c.759).

Co-Authored-By: Claude <noreply@anthropic.com>