### PR TITLE
docs(probas,infer2): interpret EP label-switching vs claimed divergence

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb
@@ -7306,6 +7306,27 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4e9a4543",
+   "metadata": {},
+   "source": [
+    "### Lecture de la comparaison : EP n'a pas divergé, il a *permuté* les composantes\n",
+    "\n",
+    "L'output ci-dessus appelle une précision importante. La note précédente évoquait le risque qu'EP « diverge sur les variables discrètes ». **Or l'output montre exactement le contraire** : EP a convergé en 50 itérations, sans divergence. Ce qui se passe est plus subtil et plus instructif.\n",
+    "\n",
+    "**EP a permuté les deux composantes.** Regardez les moyennes : VMP dit *Ordinaire* = 15,07 min et *Extraordinaire* = 26,69 min ; EP dit « *Ordinaire* » = 26,23 min et « *Extraordinaire* » = 14,96 min. Les deux clusters trouvés par EP (~15 min et ~26 min) sont **les mêmes** que ceux de VMP — ils sont simplement **étiquetés à l'envers**. En conséquence, les poids du mélange sont aussi inversés : VMP donne P(ordinaire) ≈ 0,67, EP donne P(ordinaire) ≈ 0,35 (soit 1 − 0,67).\n",
+    "\n",
+    "Ce phénomène s'appelle le **label-switching** (permutation des étiquettes). Il est **intrinsèque aux modèles de mélange** (Redner & Walker, 1984) : la vraisemblance d'un mélange gaussien est **symétrique sous permutation des composantes** — permuter les labels des K composantes donne exactement la même distribution. Il n'existe donc pas d'identification canonique des composantes : deux algorithmes (ou deux runs) peuvent converger vers la *même* solution (mêmes clusters) avec des *labellisations* différentes. Ce n'est pas un défaut d'EP en particulier — c'est une propriété fondamentale du modèle.\n",
+    "\n",
+    "**Leçon pratique.** Pour comparer VMP et EP (ou interpréter un mélange), il faut **aligner les labels** avant de comparer les paramètres — sinon un label-swap apparaît comme une « différence » alors que les clusters sous-jacents sont identiques. Ici, après alignement (EP « *Extraordinaire* » ↔ VMP *Ordinaire*, et vice-versa), on voit que :\n",
+    "\n",
+    "- EP est **légèrement moins précis** que VMP (écarts-types plus larges : σ ≈ 2,48 contre 0,87 sur le cluster des trajets longs) — c'est exactement ce que la note précédente disait (« EP moins précis localement »), et c'est vérifié.\n",
+    "- Mais EP **n'a pas divergé** — il a simplement convergé vers la solution symétrique équivalente, avec une labellisation différente.\n",
+    "\n",
+    "> **À retenir** : sur un mélange symétrique, changer d'algorithme (`AlgorithmEnum`) ne change pas seulement la précision locale — il expose la **non-identifiabilité** des composantes. Pour une analyse robuste, on contraint l'ordre des composantes (par exemple μ₁ < μ₂) ou on aligne les labels *a posteriori* avant toute comparaison."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "tnffao04tp",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
Grain: MED/notebook-enrichment — lane myia-po-2025:CoursIA — prev: MED/notebook-python (c.614 Planners-11 #7728)

G-VAR-3 OK : genre notebook-enrichment (markdown interp add) ≠ notebook-python-code (c.614 était code fix + interp). Famille **Probas** fraîche (jamais touchée ce cluster) + langage **.NET** (vraie variation vs mes 3 derniers Python : rl_5 ×2 + Planners-11).

## Gap (interpretation, family Probas/Infer.NET)

`Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb` (.NET Interactive C#, 83 cells) compare EP vs VMP sur un mélange gaussien (temps de trajet cycliste, 2 composantes). G.1 firsthand (origin/main @ac1d3c981) :

- **Cell 62** présente les numbers VMP comme « Résultats obtenus » (Ordinaire = 15,07 min, Extraordinaire = 26,69 min).
- **Cell 63** (markdown) affirme que « VMP est recommandé pour les mélanges » et évoque le risque qu'EP « **diverge sur les variables discrètes** », en disant vouloir le « vérifier ».
- **Cell 64** (code ec=21) exécute la comparaison. L'output committed montre qu'EP n'a **pas divergé** : il a convergé en 50 itérations vers une solution **label-swappée** — EP « Ordinaire » = Gaussian(26,23, 2,478) = le cluster Extraordinaire de VMP, avec poids inversés (Dirichlet 3,887/7,224 vs VMP 7,995/4,005).
- **Cell 65** passe directement aux numbers VMP pour la prédiction **sans réconcilier l'anomalie EP**.

Le notebook démontrait donc le contraire de ce qu'il affirmait : au lieu de la « divergence » redoutée, l'output exhibait un label-switching classique — phénomène **distinct** non interprété.

## What (1 markdown cell, after cell 64)

Nouvelle cellule markdown (FR, readme-french-first) qui réconcilie honnêtement l'output :

1. **Correction factuelle** : EP n'a pas divergé — il a convergé (50 iter) vers une solution permutée.
2. **Diagnostic** : label-switching (Redner & Walker 1984) — la vraisemblance d'un mélange est symétrique sous permutation des composantes, donc il n'y a pas d'identification canonique ; EP et VMP trouvent les **mêmes clusters** (~15 et ~26 min) avec des labellisations différentes.
3. **Leçon pratique** : aligner les labels avant de comparer VMP et EP. Après alignement, on voit qu'EP est **légèrement moins précis** (σ ≈ 2,48 vs 0,87) — ce qui **confirme** la claim « EP moins précis localement » de la cellule 63, tout en corrigeant la claim « peut diverger ».
4. **À retenir** : `AlgorithmEnum` ne change pas que la précision — il expose la non-identifiabilité des composantes ; on contraint l'ordre (μ₁ < μ₂) ou on aligne post-hoc.

## Honnêteté (G.9 / Stop & Repair)

L'interprétation ne **sur-affirme pas** la causalité. Une version antérieure (proposée par l'agent Explore) disait que « VMP factorise l'approximation conjointe et fige les rôles » — ce serait faux (VMP est aussi sujet au label-switching en général ; ici il a convergé vers un labeling spécifique). La version retenue dit explicitement que le label-switching est **intrinsèque aux mélanges** (vrai pour tous les algorithmes), pas un défaut d'EP en particulier, et reconnaît que la claim « EP moins précis » de la cellule 63 **est vérifiée**. Aucun nombre fabriqué : 26,23 / 14,96 / Dirichlet 3,887/7,224 viennent de l'output committé.

## Scope (purely additive, byte-safe)

1 fichier, **+21/−0**. Aucune suppression, aucune cellule modifiée — la markdown cell est **insérée** après cell 64, les 83 cells existantes sont décalées d'un index vers le bas.

**Insertion textuelle byte-safe** : le notebook utilise un format JSON non-standard (multi-line strings, unreproducible par `json.dump` — 16159 diffs vs re-dump standard). Pour préserver byte-identity, la nouvelle cell est **splittée textuellement** dans le raw (parse des offsets via `JSONDecoder.raw_decode`, sérialisation de la seule nouvelle cell avec `json.dumps(indent=1)` + offset 2-espaces, méthode validée sur une cell existante).

Vérification JSON-level :
- **83/83 pre-existing cells byte-identical** à origin/main (re-parse des offsets output, comparaison slice par slice).
- Cell 64 inchangée, cell 65 = NEW interp, cell 66 = ancienne « Prediction » (décalée).

## Validation (H.1 / H.3)

- **Markdown-only** → règle C.2 exception : pas de re-exec (code cells ec 1..22 inchangés, outputs préservés byte-identical).
- **C.1** : 0 `throw NotImplementedException` / `NotImplementedException` dans les code cells.
- **nbformat 4.5** `validate` OK ; **84 cells** (was 83) ; **LF** (0 CRLF) ; UTF-8 no-BOM.
- **Catalogue byte-identique** (non dans le diff).

## Note : leak de chemin préexistant (hors-scope, signalé)

La cell 66 (output de prédiction) contient un leak de chemin machine `D:\dev\CoursIA-probas-infer2\...` (run d'un agent précédent dans un worktree) — **PREEXISTING sur origin/main**, non introduit par ce PR, hors-scope de l'enrichissement markdown. Laissé intact (Stop & Repair scoped : un fix de leak = re-exec du notebook dans un cwd normalisé = PR séparé). Traqué pour trace.

## Variation (R6 / G-VAR-3)

c.614 = MED/notebook-python (Planners-11, SymbolicAI/Planning). c.615 = MED/notebook-enrichment (Infer-2, Probas/Infer.NET). Genre distinct (enrichment ≠ python-code) **et** famille distincte (Probas fraîche) **et** langage distinct (.NET vs Python). G-VAR-3 trivial. Famille Probas jamais touchée par po-2025 ce cluster.

See #3974 (rollout READMEs/docs Probas, tracker assigné po-2025) — contribution pédagogique transverse à la famille Probas.

Generated with Claude Code
