### PR TITLE
fix(iit,#3801): IIT-2 §2.3 intractabilité = bipartitions, pas nombre de Bell

### DIFF
--- a/MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb
+++ b/MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb
@@ -322,7 +322,9 @@
     "\n",
     "### 2.3. Complexite du partitionnement\n",
     "\n",
-    "Le nombre de partitions possibles croit exponentiellement avec la taille du système (nombre de Bell). C'est pourquoi le calcul exact de $\\Phi$ est **intractable** pour de grands reseaux."
+    "Le calcul exact de $\\Phi$ est **intractable** pour de grands reseaux, à cause d'une **explosion combinatoire**. Pour chaque mécanisme possible (sous-ensemble d'éléments — il y en a $2^n - 1$ pour un système à $n$ noeuds), PyPhi doit énumérer toutes les **bipartitions** du purview pour trouver la coupe minimisante (la MIP). Un ensemble à $n$ éléments admet $2^{n-1}$ bipartitions : c'est exactement ce que compte la cellule suivante (4 pour $n=3$).\n",
+    "\n",
+    "La même cellule affiche aussi les **nombres de Bell**, qui comptent *toutes* les partitions (en 2, 3, 4... parties), pas seulement les bipartitions. C'est pourquoi, pour $n=3$, on observe **4 bipartitions** mais **5 partitions de Bell** : la partition en trois singletons $\\{0\\}|\\{1\\}|\\{2\\}$ est comptée par Bell mais n'est pas une bipartition (une coupe sépare le système en deux parties, pas davantage). Les nombres de Bell croissent plus vite que les bipartitions, mais le MIP de l'IIT 3.0 ne parcourt que des bipartitions — l'intractabilité réelle provient surtout du produit « nombre de mécanismes $\\times$ bipartitions », répété pour chaque mécanisme."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/fix — lane myia-po-2025:CoursIA — prev: MED/notebook-enrichment (c.615a Probas Infer-2 #7737)

G-VAR-3 OK : genre fix (claim factuelle corrigée) ≠ notebook-enrichment. Famille **IIT** fraîche (jamais touchée ce cluster) + langage Python/PyPhi (vs c.615a .NET Infer-2 et c.614 Planners unified_planning).

## Gap (claim factuelle contredite par la sortie du moteur)

`IIT/IIT-2-AdvancedTopics.ipynb` (PyPhi, 39 cells, python3). G.1 firsthand (origin/main @21e4ea88d) :

- **Cell 6** (md) §2.3 affirme : « Le nombre de partitions possibles croit exponentiellement avec la taille du système **(nombre de Bell)**. C'est pourquoi le calcul exact de Φ est **intractable** pour de grands reseaux. »
- **Cell 7** (code ec=4) output expose elle-même l'inconséquence : pour `n=3` noeuds, PyPhi compte **4 bipartitions** MAIS affiche aussi **5 partitions de Bell**. L'output exhibe donc `4 ≠ 5` — la partition en trois singletons `{0}|{1}|{2}` est comptée par Bell mais n'est pas une bipartition.

La claim §2.3 attribuait l'intractabilité au **mauvais décompte** : en IIT 3.0 (Oizumi 2014), le MIP (« Minimum Information Partition », la coupe minimisante) itère sur des **bipartitions** (partition en 2 parties, `2^(n−1)`), **pas** sur toutes les partitions de Bell. La prose discréditait silencieusement la sortie réelle du moteur PyPhi.

## What (cell 6 §2.3 reformulé, §2.2 préservé)

§2.3 reformulé pour réconcilier prose ↔ output :
1. Le MIP énumère `2^(n−1)` bipartitions par ensemble — c'est ce que cell 7 compte (4 pour `n=3`).
2. Les nombres de Bell affichés par cell 7 comptent **toutes** les partitions (2, 3, 4… parties), à titre de comparaison.
3. Pour `n=3` : **4 bipartitions vs 5 Bell** — la partition en 3 singletons est comptée par Bell mais pas par bipartition (une coupe sépare en 2, pas plus).
4. Intractabilité réelle = produit « mécanismes `(2^n−1)` × bipartitions », répété pour chaque mécanisme.

§2.2 (« Interpretation de la MIP ») préservé byte-for-byte. Header §2.3 + blank inchangés.

## Honnêteté (G.9 / Stop & Repair)

Ne sur-affirme pas la complexité exacte de Φ (qui dépend aussi des purviews, cause repertoires, etc. — non traité ici). Affirmations vérifiées :
- « Le MIP ne parcourt que des bipartitions » — vrai (`pyphi.partition.bipartition` retourne les bipartitions ordonnées, incluant la triviale `()|(all)` → `2^(n−1)`).
- « Bell = toutes les partitions » — vrai (`Bell(3)=5` inclut `{123}, {1}{23}, {2}{13}, {3}{12}, {1}{2}{3}`).
- « Partition en 3 singletons = comptée par Bell, pas par bipartition » — vrai (3 parties ≠ 2).

Aucun nombre fabriqué : `2^(n−1)`, `4`, `5`, `Bell(3)=5` viennent de l'output committé cell 7 et de la définition standard.

## Scope (chirurgical, markdown-only)

1 fichier, **+3/−1**. §2.2 inchangé, cells 0-5 et 7-38 byte-identiques à origin/main. **Markdown-only** → règle C.2 exception : pas de re-exec (code cell 7 ec=4 + outputs byte-préservés — la cellule code qui produit les nombres n'est pas touchée).

## Validation (H.1 / H.3)

- **nbformat 4.5** `validate` OK ; **39 cells** (inchangé).
- **C.1** : 0 `raise NotImplementedError`/`assert False`/`1/0` dans les code cells (inchangés).
- **Byte-identity** : cells 0-5, 7-38 byte-identiques à `origin/main` (re-parse JSON, comparaison cell par cell).
- **Cell 7 code** : ec=4 + outputs (4 bipartitions, 5 Bell pour n=3) byte-préservés.
- **LF** (0 CRLF) ; **catalogue byte-identique** (non dans le diff).

## Variation (R6 / G-VAR-3)

c.614 = MED/notebook-python-code (Planners-11, SymbolicAI/Planning, #7728). c.615a = MED/notebook-enrichment (Probas Infer-2, #7737). c.615b = MED/fix (IIT-2, PyPhi). Genre distinct (fix claim factuelle ≠ enrichment ≠ python-code) **et** famille distincte (IIT fraîche) **et** langage distinct (Python/PyPhi). G-VAR-3 trivial.

RANK 1 IIT-1 α=2.0 **ABANDONNÉ** (collision firsthand vérifiée : PR #7670 jsboigeEpita supprime déjà exactement les lignes concernées) → pivot propre vers IIT-2 §2.3 (R7 never-idle = un pick collisionne, en prendre un autre).

See #3801 (SOTA/Prong-B problem-richness — corrige une claim factuelle qui discréditait la sortie réelle du moteur PyPhi).

Generated with Claude Code
