### PR TITLE
fix(gametheory): GT-13 CFR cell[16] — K is NOT « parfaitement apprise » (contradicts own table + output)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-13-ImperfectInfo-CFR.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-13-ImperfectInfo-CFR.ipynb
@@ -1006,7 +1006,7 @@
    "source": [
     "### Interpretation des stratégies apprises\n",
     "\n",
-    "Les stratégies moyennes convergent bien vers l'equilibre de Nash théorique :\n",
+    "Les stratégies moyennes convergent vers l'equilibre de Nash théorique, avec des écarts notables pour J (bluff) et K (value bet) à 10 000 itérations :\n",
     "\n",
     "| Info Set | Appris (bet/pass) | Théorique | Analyse |\n",
     "|----------|-------------------|-----------|---------|\n",
@@ -1018,11 +1018,11 @@
     "| Kb | 1.00 / 0.00 | 1.00 / 0.00 | Toujours call avec K |\n",
     "\n",
     "**Points cles** :\n",
-    "- Q et K en position initiale : stratégies pures parfaitement apprises\n",
+    "- Q : stratégie pure parfaitement apprise (pass systématique) ; en revanche K n'a pas convergé : value bet incomplet (0.67 vs 1.00 théorique)\n",
     "- J : le bluff a 1/3 n'est pas encore atteint (0.22 vs 0.33)\n",
     "- Les reponses aux bets (Jb, Qb, Kb) sont très proches de l'equilibre\n",
     "\n",
-    "> **Note** : Avec plus d'itérations, J convergerait vers le ratio de bluff optimal de 1/3, qui rend l'adversaire indifferent entre call et fold avec Q."
+    "> **Note** : Avec plus d'itérations, J convergerait vers le ratio de bluff optimal de 1/3 (rendant l'adversaire indifférent entre call et fold avec Q) et K vers la stratégie pure de value bet (1.00). CFR converge géométriquement, mais les stratégies pures (K) et les mélanges exacts (J) sont plus lentes à atteindre que la stratégie « facile » de Q (pass systématique)."
    ]
   },
   {


### PR DESCRIPTION
## Bug (G.1-verified firsthand)

`GameTheory-13-ImperfectInfo-CFR.ipynb` cell[16] (id `2a57a252`, markdown "Interpretation des stratégies apprises") made a **factual claim contradicted by its own table AND the code output**:

- **Bullet 1** said: *"Q et K en position initiale : stratégies pures parfaitement apprises"*
- **cell[15] output** (id `0b5d0b40`) shows: `K (0.668/0.332)` vs theoretical `(1.000/0.000)` — K is the **furthest from convergence**, not "parfaitement apprise".
- The cell's **own table** row already labelled K *"Value bet incomplet"* — so the bullet contradicted the table two inches above it.
- The **opening** *"Les stratégies moyennes convergent bien"* was also overstated (J=0.22 vs 0.33, K=0.67 vs 1.00 are ~33% deviations).

The notebook was asserting its own central demonstration succeeds while its own data shows it is partial.

## Fix (markdown honesty correction)

Markdown-only edit to cell[16] — **no code change, no re-exec** (C.2 exception for markdown-only edits):

1. **Opening** softened: acknowledges partial convergence for J (bluff) and K (value bet) at 10 000 iterations.
2. **Bullet 1** separated: Q perfectly learned (pure pass); K NOT converged (value bet incomplete, 0.67 vs 1.00).
3. **Note** enriched: explains CFR's geometric convergence + **why** pure strategies (K) and exact mixtures (J) converge slower than Q's "easy" pure pass — a real CFR property (regret for the dominated pass-action on K decays slowly), genuine pedagogical value.

The cell is now internally consistent: prose matches the table (K "Value bet incomplet"), the output (K=0.67 vs 1.00), bullet 2 (J bluff), and the Note.

## Validation

- **byte-identity verified**: 43/43 cells, only `cell[16]` source changed, **0 code cells with `execution_count`/`outputs` diff** vs `origin/main`.
- **C.1**: 0 intentional errors.
- Diff: `1 file changed, +N/-M` on markdown prose only.

## Rationale: honesty fix vs re-exec

Considered re-running CFR with more iterations until K converges to pure (1.0, 0.0). Rejected because (a) the 10 000-iter result is a **real and interesting** teaching moment about CFR's gradual convergence — running it to full convergence would erase that point; (b) CFR's average strategy approaches pure but rarely hits exact (1.0, 0.0); (c) markdown-honesty is the textbook content-fix (no rule-F env risk, preserves all outputs). The notebook still exercises CFR (the real engine) on Kuhn Poker (non-trivial imperfect-info game) — Prong-A/B SOTA satisfied.

## Notes

- Collision-checked: no open PR touches GT-13 Python content (#7371 = terminal frame fix merged, #5580 = C# twin, #7517/#7523 = guard fixes — none on cell[16]).
- Genre: `MED/GameTheory-Python content-fix` (factual-error correction) — ≠ enrichment c.760 (#7732 SC-3). Variation-protocol #7655 honored (fresh family after SmartContracts, content-fix ≠ enrichment).
- Sub-agent (sonnet Explore, read-only) surfaced the candidate; I **G.1-verified firsthand** (read cell[15] output + full cell[16] + cross-checked the table-vs-bullet contradiction myself) before editing — corrected the sub-agent's off-by-one cell indices but confirmed the contradiction.

Co-Authored-By: Claude <noreply@anthropic.com>