### PR TITLE
fix(sudoku): Sudoku-17 cell 26 opening — simulation mock results don't confirm literature

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb
@@ -1513,7 +1513,7 @@
    "source": [
     "### Interpretation des Résultats du Benchmark\n",
     "\n",
-    "Les résultats du benchmark confirment les tendances attendues dans la litterature sur les LLM pour la resolution de Sudoku.\n",
+    "En **mode simulation** (sans appel API réel), ce benchmark illustre d'abord les limites du mode *mock* : les approches zero-shot et few-shot échouent car elles retournent des grilles prédefinies qui ne correspondent pas aux puzzles, tandis que code-interpreter réussit via du code Python pré-généré. Ces résultats **ne confirment pas** les tendances de la littérature (recensées plus bas) ; pour les observer, il faut basculer `simulation_mode = False` avec une vraie clé API.\n",
     "\n",
     "| Approche | Taux de succes | Performance | Observations |\n",
     "|----------|----------------|-------------|--------------|\n",


### PR DESCRIPTION
Grain: LIGHT/fix — lane myia-po-2025:CoursIA — prev: MED/fix (c.616 SW-13 #7751)

## Gap (opening sentence contradit la sortie ET le corps de la cell)

`Sudoku/Sudoku-17-LLM-Python.ipynb` (41 cells, python3). G.1 firsthand (Explore RANK 3 + self-verify cell 25 output + cell 26 full source + cell 10 `simulation_mode` flag via `git show origin/main`) :

- **Cell 26** (md) ouverture affirme : « Les résultats du benchmark **confirment les tendances attendues dans la littérature** sur les LLM pour la résolution de Sudoku. »
- **Cell 25** output = **0%** (zero-shot) / **0%** (few-shot) / **100%** (code-interpreter) — parce que le LLM tourne en **mode simulation mock** (cell 10 `self.simulation_mode = True` : `zero_shot_solve`/`few_shot_solve` retournent des grilles prédefinies qui ne correspondent pas aux puzzles).
- Les résultats mock ne « confirment » **aucune** tendance de littérature. Un étudiant lisant la 1ʳᵉ ligne repart en pensant « les LLM confirment la littérature » alors qu'**aucun appel API réel** n'a été fait.

**Le corps de la cell 26 est DÉJÀ honnête** — Points clés #1 (« Mode simulation : Les réponses zero-shot et few-shot sont des grilles prédéfinies »), la colonne Observations du tableau (« Le mode simulation retourne une grille prédéfinie »), la Note technique (cite les nombres réels de littérature zero-shot ~30-50%, few-shot ~50-70%, code-interpreter ~95-99%), et la Note simulation (cite `simulation_mode = False`). **Seule l'ouverture** contredit son propre corps + l'output.

## What (1 phrase d'ouverture réécrite, reste intact)

Réécriture de l'ouverture pour dire explicitement : mode simulation mock, les résultats **ne confirment pas** la littérature ; pour observer les tendances recensées ci-dessous, basculer `simulation_mode = False` avec une vraie clé API.

L'ouverture devient ainsi **cohérente avec le corps** de la cell (qui disait déjà ça). Tableau, Points clés, et les deux Notes préservés byte-for-byte.

## Honnêteté (G.9)

Le corps de la cell était **déjà honnête** — ce fix retire une phrase d'ouverture trompeuse qui contredisait son propre corps. Ne sur-affirme pas : garde les nombres de littérature de la Note technique tels quels (« ce qu'on attendrait avec une vraie API »), exactement comme le corps les cadrait déjà.

## Scope (chirurgical, markdown-only)

1 fichier, 1 cell, **+1/−1**. **Markdown-only** → règle C.2 exception : pas de re-exec (code cell 25 ec=9 + outputs byte-préservés). Cells 0-25, 27-40 **byte-identiques** à `origin/main` ; cell 26 modifiée **uniquement dans source**.

## Validation (H.1 / H.3)

- **nbformat 4.5** `validate` OK ; **41 cells** (inchangé).
- **C.1** : 0 `raise NotImplementedError`/`assert False`/`1/0` (code cells inchangés).
- **Byte-identity** : 40 cells non-touchées byte-identiques à origin/main ; cell 26 modifiée seulement dans `source` (metadata/id/type identiques).
- **LF** (0 CRLF) ; **catalogue byte-identique** (non dans le diff).

## Tier honnête + variation

**LIGHT/fix** : correction d'1 phrase d'ouverture dans une cell par ailleurs honnête. Litmus « générable en série par scan ? » est **partiel** (reconnaître « ouverture vs corps » est un motif, mais vérifier requiert de comprendre `simulation_mode`) → tag conservateur **LIGHT**. **1er LIGHT ce jour** (c.615b/c.616 = MED), G-VAR-2 budget 1 LIGHT/lane/jour disponible, G-VAR-3 (pas 2× LIGHT consécutif : c.616 était MED) satisfait.

**PR-plancher du cycle = #7751 (MED SW-13)**. Sudoku-17 = bonus 2e grain à **valeur pédagogique réelle** (empêche le mislearning « LLM confirment la littérature » sans vrai appel API). R7 « ≥1 PR/wakeup » = plafond dépassé (2 PRs MED+LIGHT).

c.614 MED/notebook-python (Planners-11 #7728) · c.615a MED/notebook-enrichment (Probas Infer-2 #7737) · c.615b MED/fix (IIT-2 #7748) · c.616 MED/fix (SW-13 #7751) · **c.616b LIGHT/fix (Sudoku-17)**. 5e famille distincte (Planning→Probas→IIT→SW→**Sudoku**).

See #3801 (SOTA/Prong-A — le reasoner du notebook est un `LLMClient` simulé, pas un vrai appel LLM ; ce fix rend l'ouverture honnête là-dessus, en complément du cadrage existant du corps).

Generated with Claude Code
