### PR TITLE
docs(smartcontracts): enrich SC-6 with missing interpretations (try/catch, pull-over-push)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-6-Errors-Events.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-6-Errors-Events.ipynb
@@ -866,6 +866,22 @@
   },
   {
    "cell_type": "markdown",
+   "id": "dbf031fc",
+   "metadata": {},
+   "source": [
+    "### Lecture du try/catch : isoler l'échec d'un appel externe\n",
+    "\n",
+    "La sortie ci-dessus illustre le rôle précis du `try/catch` en Solidity, qu'il faut bien distinguer des autres mécanismes de gestion d'erreur :\n",
+    "\n",
+    "- **`require(cond, msg)` / `revert()`** valident une **condition interne** au contrat (précondition sur les entrées, l'état, les permissions). En cas d'échec, la transaction entière est annulée (rollback d'état + gas consommé jusqu'au revert).\n",
+    "- **`assert(cond)`** protège un **invariant critique** (ce qui ne devrait *jamais* arriver si le code est correct) ; un échec déclenche une `Panic` et consomme tout le gas restant.\n",
+    "- **`try/catch`**, lui, est le **seul** à pouvoir **récupérer un échec d'appel externe** sans annuler la transaction appelante. Ici, `safeOperation()` appelle `riskyOperation()` sur un autre contrat ; quand celui-ci `revert` (`shouldFail = True`), le `catch` récupère la main et émet `OperationFailed` plutôt que de faire échouer toute la transaction. Avec `shouldFail = False`, le flux `try` se poursuit et émet `OperationSuccess`.\n",
+    "\n",
+    "Deux pièges à retenir : (1) le `try/catch` **n'attrape que les échecs du contrat externe appelé** (revert, panic ou échec de transfert), jamais une erreur du contrat appelant lui-même ; (2) il ne se substitue pas à `require` — on l'utilise quand on veut **réagir** à un échec prévisible d'un tiers (oracle indisponible, token non-standard, appel facultatif) plutôt que de tout annuler."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "882b56f7",
    "metadata": {
     "papermill": {
@@ -1496,6 +1512,22 @@
     "    auction.functions.auctionEnd().transact({'from': deployer})\n",
     "except Exception:\n",
     "    print(\"  auctionEnd() une seconde fois → revert 'Auction already finalized' (attendu)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e6bed66c",
+   "metadata": {},
+   "source": [
+    "### Lecture du contrat Auction : paiement « pull » et finalisation idempotente\n",
+    "\n",
+    "La sortie ci-dessus met en œuvre deux patterns de sécurité fondamentaux en Solidity, qui ne sautent pas aux yeux depuis le seul journal d'événements.\n",
+    "\n",
+    "**1. Paiement « pull » plutôt que « push » (anti-DoS et anti-réentrance).** Quand `bidder2` surenchérit à 2 ETH, le contrat **ne renvoie pas** automatiquement le 1 ETH de `bidder1`. Il le crédite dans `pendingReturns[bidder1] += 1 ETH` et attend que `bidder1` appelle lui-même `withdraw()` pour récupérer ses fonds. Pourquoi ne pas simplement `payable(bidder1).transfer(...)` dans `bid()` ? Parce qu'un enchérisseur peut être un **contrat malveillant** dont la fonction `receive()` consomme tout le gas ou déclenche une réentrance : en « pushant » les fonds à l'intérieur de `bid()`, on offrirait à ce contrat une prise d'attaque au cœur de la logique d'enchère, et un seul enchérisseur toxique pourrait **bloquer toutes les surenchères** (déni de service). Le pattern « pull » isole le risque : chacun retire ses fonds à sa propre initiative. Notez en outre que `withdraw()` met `pendingReturns[msg.sender] = 0` **avant** le `transfer` — c'est le pattern *checks-effects-interactions* qui empêche la réentrance sur cette même fonction.\n",
+    "\n",
+    "**2. Finalisation idempotente (garde-fou de machine à états).** La fonction `auctionEnd()` effectue la transition **OPEN → CLOSED** exactement une fois : le second appel déclenche `revert \"Auction already finalized\"`. Le booléen `ended` fait office de verrou d'état. L'enjeu est double — éviter un **double-paiement** au bénéficiaire, et garantir que la levée des fonds ne puisse pas être rejouée. C'est l'application directe du principe « une transition d'état critique est une opération *one-shot* » : tout effet financier irréversible (ici, le transfert des 2 ETH au bénéficiaire) doit être protégé par un garde-fou explicite, jamais supposé implicite.\n",
+    "\n",
+    "> **À retenir** : sur une enchère, ces deux patterns se complètent — le « pull » protège les **remboursements** (plusieurs enchérisseuses et enchérisseurs, confiance nulle), la finalisation protège le **paiement final** (bénéficiaire unique, exactement une fois). Ensemble, ils font du contrat une petite machine à états déterministe, robuste face à des participants potentiellement hostiles."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-enrichment — lane myia-po-2025:CoursIA — prev: LIGHT/fix (c.616b Sudoku-17 #7752)

G-VAR-3 OK : genre **enrichment** ≠ fix×3 consécutif (c.615b/c.616/c.616b étaient fix) — **casse la série fix**. Famille **SmartContracts** fraîche (6e famille distincte : Planning→Probas→IIT→SW→Sudoku→SC) + langage **Solidity/Foundry** (nouveau pour cette lane). Litmus LIGHT échoue (interp requiert de comprendre pull-over-push/reentrancy + state-machine + try/catch-vs-require) = MED.

## Gap (2 démos code sans interp markdown)

`SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-6-Errors-Events.ipynb` (Solidity/Foundry, 26 cells). G.1 firsthand (Explore sonnet + self-verify cells 11-13 + 20-23 via `git show origin/main`) : **2 démos code produisent des outputs de sécurité non-triviaux sans interp markdown** (suivies directement d'un exercice) :

- **Cell 12** (code ec=6, Try/Catch) output : `shouldFail=True → OperationFailed caught` vs `shouldFail=False → OperationSuccess`. Cell 13 = Exercice whitelist, **saute SANS contraster** les 3 mécanismes d'erreur Solidity (try/catch vs require/revert vs assert — faciles à confondre).
- **Cell 21** (code ec=10, Auction résolu) output : pull-payment (`pendingReturns[bidder1]=1 ETH` puis `bidder1 withdraw()→BidRefunded`) + state-machine guard (`auctionEnd()` 2e fois → revert 'Auction already finalized'). Cell 22 = Exercice 4, **saute SANS interpréter** ces 2 patterns sécurité.

## What (2 cells markdown FR insérées)

1. **After cell 12** → nouveau cell 13 (try/catch interp) : contraste les 3 mécanismes — `require/revert` (précondition interne, abort tx), `assert` (invariant critique, Panic, brûle gas), `try/catch` (le SEUL à récupérer un échec d'**appel externe**, ne peut pas catcher les erreurs du contrat appelant). 2 pièges pédagogiques explicités.

2. **After cell 21** → nouveau cell 23 (Auction interp) :
   - **Pull-over-push** : pourquoi le contrat crédite `pendingReturns` au lieu d'auto-`transfer` dans `bid()` (défense contre un enchérisseur = contrat malveillant dont `receive()` pourrait gas-grief/réentrer et bloquer toutes les surenchères = DoS).
   - **Checks-effects-interactions** : `withdraw()` met `pendingReturns=0` **avant** le transfer (garde-fou réentrance).
   - **Finalisation idempotente** : le booléen `ended` fait de OPEN→CLOSE une transition *one-shot* (anti double-paiement au bénéficiaire).

## Honnêteté (G.9)

Les interps référencent les patterns visibles dans les outputs committés + le canon de sécurité Solidity standard (pull-over-push / CEI / state-machine idempotent). Ne sur-affirme pas les spécificités d'attaque au-delà de ce que l'output démontre. **0 claim fabriquée**. Cell 21 est un exercice **résolu** (contrat Auction complet, ec=10) = EXEMPLE par contenu (règle exercise-example-labeling : ne pas stubber) — intact, seulement enrichi d'une cell interp suivante.

## Scope (chirurgical, markdown-only)

1 fichier, **+32/−0** pur additif (2 cells insérées, 0 supprimée). **Markdown-only** → règle C.2 exception : pas de re-exec (code cells ec 6/10 + outputs byte-préservés). **26/26 cells préexistantes byte-identiques** à `origin/main`.

## Validation (H.1 / H.3)

- **nbformat 4.5** `validate` OK ; **28 cells** (was 26).
- **C.1** : 0 `raise NotImplementedError`/`assert False`/`1/0` (code cells inchangés).
- **Byte-identity** : 26/26 pre-existing cells byte-identiques à origin/main.
- **LF** (0 CRLF) ; **catalogue byte-identique** (non dans le diff).
- **Round-trip JSON** : format standard `indent=1 + \n` validé byte-identical avant édition.

## Variation (R6 / G-VAR-3)

c.614 MED/notebook-python (Planners-11 #7728) · c.615a MED/notebook-enrichment (Probas Infer-2 #7737) · c.615b MED/fix (IIT-2 #7748) · c.616 MED/fix (SW-13 #7751) · c.616b LIGHT/fix (Sudoku-17 #7752) · **c.617 MED/notebook-enrichment (SmartContracts SC-6)**. 6e famille distincte. Genre enrichment casse la série fix×3 (R6/G-VAR-3 honored).

**RANK 2 Tweety-8** a été **évité** : piège source-vs-`_output.ipynb` (l'output visible n'est que dans le fichier exécuté `_output.ipynb`, pas dans le source canonique committé) — un enrichissement markdown-only référençant un output absent du notebook committé serait incohérent + nécessiterait re-exec Tweety (kernel IKVM, MEMORY `ikvm-inkernel-choco-recipe-4667`). SC-6 = fichier source unique, plus sûr.

See #3801 (SOTA/Prong-A — les démos tournent du vrai Solidity via web3/anvil avec vrais event logs ; cet enrichissement rend compte pédagogiquement de ces outputs réels, pas de workaround).

Generated with Claude Code
