### PR TITLE
fix(search-csp,#7721): CSP-2 8-Reines degeneracy — diagonal constraint + MAC full-neighbors

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-2-Consistency-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-2-Consistency-Csharp.ipynb
@@ -94,10 +94,10 @@
    "id": "e7c41269",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:50:06.111475Z",
-     "iopub.status.busy": "2026-07-03T23:50:06.111277Z",
-     "iopub.status.idle": "2026-07-03T23:50:06.454699Z",
-     "shell.execute_reply": "2026-07-03T23:50:06.454491Z"
+     "iopub.execute_input": "2026-07-21T17:34:28.585319Z",
+     "iopub.status.busy": "2026-07-21T17:34:28.585052Z",
+     "iopub.status.idle": "2026-07-21T17:34:29.176715Z",
+     "shell.execute_reply": "2026-07-21T17:34:29.176449Z"
     }
    },
    "outputs": [
@@ -171,10 +171,10 @@
    "id": "e6295c97",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:50:06.455845Z",
-     "iopub.status.busy": "2026-07-03T23:50:06.455639Z",
-     "iopub.status.idle": "2026-07-03T23:50:06.502695Z",
-     "shell.execute_reply": "2026-07-03T23:50:06.502520Z"
+     "iopub.execute_input": "2026-07-21T17:34:29.178801Z",
+     "iopub.status.busy": "2026-07-21T17:34:29.178527Z",
+     "iopub.status.idle": "2026-07-21T17:34:29.244835Z",
+     "shell.execute_reply": "2026-07-21T17:34:29.244259Z"
     }
    },
    "outputs": [
@@ -237,10 +237,10 @@
    "id": "640c0c49",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:50:06.503998Z",
-     "iopub.status.busy": "2026-07-03T23:50:06.503723Z",
-     "iopub.status.idle": "2026-07-03T23:50:06.733021Z",
-     "shell.execute_reply": "2026-07-03T23:50:06.732849Z"
+     "iopub.execute_input": "2026-07-21T17:34:29.246617Z",
+     "iopub.status.busy": "2026-07-21T17:34:29.246375Z",
+     "iopub.status.idle": "2026-07-21T17:34:29.598745Z",
+     "shell.execute_reply": "2026-07-21T17:34:29.598497Z"
     }
    },
    "outputs": [
@@ -328,10 +328,10 @@
    "id": "f47c5c6a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:50:06.734521Z",
-     "iopub.status.busy": "2026-07-03T23:50:06.734318Z",
-     "iopub.status.idle": "2026-07-03T23:50:06.844909Z",
-     "shell.execute_reply": "2026-07-03T23:50:06.844611Z"
+     "iopub.execute_input": "2026-07-21T17:34:29.600652Z",
+     "iopub.status.busy": "2026-07-21T17:34:29.600382Z",
+     "iopub.status.idle": "2026-07-21T17:34:29.809658Z",
+     "shell.execute_reply": "2026-07-21T17:34:29.809157Z"
     }
    },
    "outputs": [
@@ -392,8 +392,6 @@
     "for (int col = 0; col < n; col++)\n",
     "    nqDomains[\"Q\" + col] = Enumerable.Range(0, n).Cast<object>().ToList();\n",
     "// Contraintes : rangees differentes + pas de conflit diagonal\n",
-    "BinaryConstraint diffRows = (vi, vj) => !vi.Equals(vj);\n",
-    "BinaryConstraint noDiag = (vi, vj) => true;  // placeholder : geré par selection des voisins\n",
     "var nqConstraints = new Dictionary<(string, string), List<BinaryConstraint>>();\n",
     "var nqNeighbors = new Dictionary<string, List<string>>();\n",
     "for (int i = 0; i < n; i++)\n",
@@ -401,15 +399,24 @@
     "    nqNeighbors[\"Q\" + i] = new List<string>();\n",
     "    for (int j = 0; j < n; j++) if (i != j) nqNeighbors[\"Q\" + i].Add(\"Q\" + j);\n",
     "}\n",
+    "// Contrainte binaire par paire : rangees differentes ET pas de conflit diagonal.\n",
+    "// Le delegate BinaryConstraint(vi,vj) ne recoit que les VALEURS (pas les indices de\n",
+    "// colonne) : on capture donc i,j dans une closure per-pair (sinon |i-j| inaccessible).\n",
     "foreach (var (xi, neighs) in nqNeighbors)\n",
-    "    foreach (var xj in neighs)\n",
-    "        nqConstraints[(xi, xj)] = new List<BinaryConstraint> { diffRows };\n",
-    "// Filtrer les diagonales : pour Q_i=v et Q_j=w, rejeter si |i-j| == |v-w|\n",
-    "BinaryConstraint diffRowsAndDiag = (vi, vj) =>\n",
     "{\n",
-    "    int v = (int)vi, w = (int)vj;\n",
-    "    return v != w;  // diagonale geree par reduce_domain ci-dessous\n",
-    "};\n",
+    "    int i = int.Parse(xi.Substring(1));\n",
+    "    foreach (var xj in neighs)\n",
+    "    {\n",
+    "        int j = int.Parse(xj.Substring(1));\n",
+    "        int ci = i, cj = j;  // capture locale (evite la fermeture sur la boucle)\n",
+    "        BinaryConstraint noConflict = (vi, vj) =>\n",
+    "        {\n",
+    "            int v = (int)vi, w = (int)vj;\n",
+    "            return v != w && Math.Abs(ci - cj) != Math.Abs(v - w);\n",
+    "        };\n",
+    "        nqConstraints[(xi, xj)] = new List<BinaryConstraint> { noConflict };\n",
+    "    }\n",
+    "}\n",
     "var nqueensCSP = new CSP(nqDomains, nqNeighbors, nqConstraints);\n",
     "Console.WriteLine($\"N-Reines ({n}x{n}) : {nqueensCSP}\");"
    ]
@@ -430,10 +437,10 @@
    "id": "5ad5527d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:50:06.846317Z",
-     "iopub.status.busy": "2026-07-03T23:50:06.846128Z",
-     "iopub.status.idle": "2026-07-03T23:50:06.927737Z",
-     "shell.execute_reply": "2026-07-03T23:50:06.927448Z"
+     "iopub.execute_input": "2026-07-21T17:34:29.811300Z",
+     "iopub.status.busy": "2026-07-21T17:34:29.811074Z",
+     "iopub.status.idle": "2026-07-21T17:34:29.911060Z",
+     "shell.execute_reply": "2026-07-21T17:34:29.910591Z"
     }
    },
    "outputs": [
@@ -559,10 +566,10 @@
    "id": "bf302925",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:50:06.929153Z",
-     "iopub.status.busy": "2026-07-03T23:50:06.928952Z",
-     "iopub.status.idle": "2026-07-03T23:50:06.971496Z",
-     "shell.execute_reply": "2026-07-03T23:50:06.971321Z"
+     "iopub.execute_input": "2026-07-21T17:34:29.913349Z",
+     "iopub.status.busy": "2026-07-21T17:34:29.913067Z",
+     "iopub.status.idle": "2026-07-21T17:34:30.006690Z",
+     "shell.execute_reply": "2026-07-21T17:34:30.006433Z"
     }
    },
    "outputs": [
@@ -617,10 +624,10 @@
    "id": "c543fba3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:50:06.972538Z",
-     "iopub.status.busy": "2026-07-03T23:50:06.972359Z",
-     "iopub.status.idle": "2026-07-03T23:50:07.018496Z",
-     "shell.execute_reply": "2026-07-03T23:50:07.018340Z"
+     "iopub.execute_input": "2026-07-21T17:34:30.008477Z",
+     "iopub.status.busy": "2026-07-21T17:34:30.008190Z",
+     "iopub.status.idle": "2026-07-21T17:34:30.093567Z",
+     "shell.execute_reply": "2026-07-21T17:34:30.093196Z"
     }
    },
    "outputs": [
@@ -675,10 +682,10 @@
    "id": "80aabb73",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:50:07.019578Z",
-     "iopub.status.busy": "2026-07-03T23:50:07.019405Z",
-     "iopub.status.idle": "2026-07-03T23:50:07.088014Z",
-     "shell.execute_reply": "2026-07-03T23:50:07.087849Z"
+     "iopub.execute_input": "2026-07-21T17:34:30.095549Z",
+     "iopub.status.busy": "2026-07-21T17:34:30.095239Z",
+     "iopub.status.idle": "2026-07-21T17:34:30.198301Z",
+     "shell.execute_reply": "2026-07-21T17:34:30.198022Z"
     }
    },
    "outputs": [
@@ -863,10 +870,10 @@
    "id": "d390fc54",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:50:07.089242Z",
-     "iopub.status.busy": "2026-07-03T23:50:07.089061Z",
-     "iopub.status.idle": "2026-07-03T23:50:07.146677Z",
-     "shell.execute_reply": "2026-07-03T23:50:07.146431Z"
+     "iopub.execute_input": "2026-07-21T17:34:30.200132Z",
+     "iopub.status.busy": "2026-07-21T17:34:30.199864Z",
+     "iopub.status.idle": "2026-07-21T17:34:30.299075Z",
+     "shell.execute_reply": "2026-07-21T17:34:30.298870Z"
     }
    },
    "outputs": [
@@ -1157,10 +1164,10 @@
    "id": "fce16f11",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:50:07.359740Z",
-     "iopub.status.busy": "2026-07-03T23:50:07.359488Z",
-     "iopub.status.idle": "2026-07-03T23:50:07.423806Z",
-     "shell.execute_reply": "2026-07-03T23:50:07.423634Z"
+     "iopub.execute_input": "2026-07-21T17:34:30.698859Z",
+     "iopub.status.busy": "2026-07-21T17:34:30.698605Z",
+     "iopub.status.idle": "2026-07-21T17:34:30.811210Z",
+     "shell.execute_reply": "2026-07-21T17:34:30.810643Z"
     }
    },
    "outputs": [
@@ -1264,10 +1271,10 @@
    "id": "e8494c37",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:50:07.425138Z",
-     "iopub.status.busy": "2026-07-03T23:50:07.424892Z",
-     "iopub.status.idle": "2026-07-03T23:50:08.105532Z",
-     "shell.execute_reply": "2026-07-03T23:50:08.105309Z"
+     "iopub.execute_input": "2026-07-21T17:34:30.813328Z",
+     "iopub.status.busy": "2026-07-21T17:34:30.813035Z",
+     "iopub.status.idle": "2026-07-21T17:34:31.487493Z",
+     "shell.execute_reply": "2026-07-21T17:34:31.487279Z"
     }
    },
    "outputs": [
@@ -1434,10 +1441,10 @@
    "id": "40e758dc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:50:08.106843Z",
-     "iopub.status.busy": "2026-07-03T23:50:08.106672Z",
-     "iopub.status.idle": "2026-07-03T23:50:08.169553Z",
-     "shell.execute_reply": "2026-07-03T23:50:08.169364Z"
+     "iopub.execute_input": "2026-07-21T17:34:31.489125Z",
+     "iopub.status.busy": "2026-07-21T17:34:31.488897Z",
+     "iopub.status.idle": "2026-07-21T17:34:31.597645Z",
+     "shell.execute_reply": "2026-07-21T17:34:31.596802Z"
     }
    },
    "outputs": [
@@ -1510,10 +1517,10 @@
    "id": "c928c722",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:50:08.170826Z",
-     "iopub.status.busy": "2026-07-03T23:50:08.170626Z",
-     "iopub.status.idle": "2026-07-03T23:50:08.256280Z",
-     "shell.execute_reply": "2026-07-03T23:50:08.256078Z"
+     "iopub.execute_input": "2026-07-21T17:34:31.599990Z",
+     "iopub.status.busy": "2026-07-21T17:34:31.599603Z",
+     "iopub.status.idle": "2026-07-21T17:34:31.789993Z",
+     "shell.execute_reply": "2026-07-21T17:34:31.789465Z"
     }
    },
    "outputs": [
@@ -1528,14 +1535,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Noeuds explores : 8\r\n"
+      "  Noeuds explores : 75\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Temps : 2,3 ms\r\n"
+      "  Temps : 10,5 ms\r\n"
      ]
     },
     {
@@ -1549,13 +1556,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Assignation : Q0->0 Q1->1 Q2->2 Q3->3 Q4->4 Q5->5 Q6->6 Q7->7\r\n"
+      "  Assignation : Q0->0 Q1->4 Q2->7 Q3->5 Q4->2 Q5->6 Q6->1 Q7->3\r\n"
      ]
     }
    ],
    "source": [
     "// Backtracking avec FC sur 8-Reines\n",
-    "// Note : pour les Reines, FC elimine les colonnes en conflit de rangee (les diagonales sont gerees par IsConsistent)\n",
+    "// Note : la contrainte noConflict (cellule de setup) encode rangees ET diagonales ; FC l'utilise\n",
+    "// pour reduire les domaines des voisins, et IsConsistent la verifie aussi sur l'assignation courante.\n",
     "int fcNodes = 0;\n",
     "var startFC = DateTime.Now;\n",
     "var (fcSol, _) = BacktrackingFC(nqueensCSP, new Dictionary<string, object>(),\n",
@@ -1604,10 +1612,10 @@
    "id": "99752c32",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:50:08.257733Z",
-     "iopub.status.busy": "2026-07-03T23:50:08.257508Z",
-     "iopub.status.idle": "2026-07-03T23:50:08.312417Z",
-     "shell.execute_reply": "2026-07-03T23:50:08.312136Z"
+     "iopub.execute_input": "2026-07-21T17:34:31.793194Z",
+     "iopub.status.busy": "2026-07-21T17:34:31.792667Z",
+     "iopub.status.idle": "2026-07-21T17:34:31.932403Z",
+     "shell.execute_reply": "2026-07-21T17:34:31.931970Z"
     }
    },
    "outputs": [
@@ -1645,11 +1653,13 @@
     "        var macDomains = domains.ToDictionary(kv => kv.Key, kv => new List<object>(kv.Value));\n",
     "        // Forcer la valeur assignee dans le domaine\n",
     "        macDomains[varMRV] = new List<object> { vi };\n",
-    "        // Construire un sous-CSP pour les variables non assignees\n",
-    "        var subCSP = new CSP(macDomains,\n",
-    "            csp.Neighbors.Where(kv => !localAssignment.ContainsKey(kv.Key))\n",
-    "                         .ToDictionary(kv => kv.Key, kv => kv.Value),\n",
-    "            csp.Constraints);\n",
+    "        // Sous-CSP = graphe complet (toutes les variables, y compris assignees dont le\n",
+    "        // domaine est reduit a une seule valeur ci-dessus). On NE filtre PAS les voisins :\n",
+    "        // filtrer les cles OU les listes a un moment donne a leve KeyNotFoundException\n",
+    "        // (AC3 re-enfile (xk,xi) pour xk assignee absente de subCSP.Neighbors) ET privait\n",
+    "        // MAC de la propagation depuis la variable fraichement assignee (l'affaiblissant\n",
+    "        // sous FC). Le graphe complet = MAC textbook (Mackworth 1977) : propagation totale.\n",
+    "        var subCSP = new CSP(macDomains, csp.Neighbors, csp.Constraints);\n",
     "        var (subReduced, _) = AC3(subCSP);\n",
     "        // Verifier qu aucun domaine n est vide\n",
     "        bool empty = subReduced.Domains.Values.Any(d => d.Count == 0);\n",
@@ -1670,10 +1680,10 @@
    "id": "912a8364",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:50:08.314168Z",
-     "iopub.status.busy": "2026-07-03T23:50:08.313920Z",
-     "iopub.status.idle": "2026-07-03T23:50:08.405371Z",
-     "shell.execute_reply": "2026-07-03T23:50:08.405122Z"
+     "iopub.execute_input": "2026-07-21T17:34:31.934979Z",
+     "iopub.status.busy": "2026-07-21T17:34:31.934319Z",
+     "iopub.status.idle": "2026-07-21T17:34:32.075481Z",
+     "shell.execute_reply": "2026-07-21T17:34:32.074860Z"
     }
    },
    "outputs": [
@@ -1688,14 +1698,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Noeuds explores : 8\r\n"
+      "  Noeuds explores : 20\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Temps : 8,0 ms\r\n"
+      "  Temps : 6,1 ms\r\n"
      ]
     },
     {
@@ -1737,10 +1747,10 @@
    "id": "b3a4b064",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:50:08.406922Z",
-     "iopub.status.busy": "2026-07-03T23:50:08.406689Z",
-     "iopub.status.idle": "2026-07-03T23:50:08.474208Z",
-     "shell.execute_reply": "2026-07-03T23:50:08.473987Z"
+     "iopub.execute_input": "2026-07-21T17:34:32.078040Z",
+     "iopub.status.busy": "2026-07-21T17:34:32.077700Z",
+     "iopub.status.idle": "2026-07-21T17:34:32.209847Z",
+     "shell.execute_reply": "2026-07-21T17:34:32.209494Z"
     }
    },
    "outputs": [
@@ -1755,21 +1765,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  BT (no propagation)  :    36 noeuds,   0,8 ms\r\n"
+      "  BT (no propagation)  :   876 noeuds,  12,8 ms\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  FC (forward check)   :     8 noeuds,   2,3 ms\r\n"
+      "  FC (forward check)   :    75 noeuds,  10,5 ms\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  MAC (AC-3 complet)   :     8 noeuds,   8,0 ms\r\n"
+      "  MAC (AC-3 complet)   :    20 noeuds,   6,1 ms\r\n"
      ]
     }
    ],
@@ -1825,10 +1835,10 @@
    "id": "90d657a7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:50:08.475492Z",
-     "iopub.status.busy": "2026-07-03T23:50:08.475291Z",
-     "iopub.status.idle": "2026-07-03T23:50:08.537716Z",
-     "shell.execute_reply": "2026-07-03T23:50:08.537560Z"
+     "iopub.execute_input": "2026-07-21T17:34:32.211773Z",
+     "iopub.status.busy": "2026-07-21T17:34:32.211482Z",
+     "iopub.status.idle": "2026-07-21T17:34:32.317761Z",
+     "shell.execute_reply": "2026-07-21T17:34:32.318151Z"
     }
    },
    "outputs": [
@@ -1836,13 +1846,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Graphique prepare : BT=36, FC=8, MAC=8 noeuds\r\n"
+      "Graphique prepare : BT=876, FC=75, MAC=20 noeuds\r\n"
      ]
     },
     {
      "data": {
       "text/html": [
-       "<img class='' style='' src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAArwAAAGQCAYAAABMPLOTAAAABHNCSVQICAgIfAhkiAAAIABJREFUeJzt3W+II/md3/FPzXr9Z+278RCk6falbY45YkKqR0wu7ieBpImUuSYSexBIQluCu4EMxE/UDKhhAgN5MjkGpLBpwQXCHBkWJPTADwJDl5l0VHed3CWQBnvSlkiMzTxwOkl3q2wm+G7n/ti7lQdzVVv62yW1pJKq3y8QK1WVqr5St3Y+/dO3fmW4rusKAAAAiKlrURcAAAAAzBKBFwAAALFG4AUAAECsEXgBAAAQawReAAAAxBqBFwAAALFG4AUAAECsEXgBAAAQawReAAAAxBqBFwAAALFG4AUAAECsEXgBzNzOzo4Mw5Bt21GXAgC4ggi8QIy1220ZhtF1C8sLqb23XC43Vg2O46harUqSnj9/PtZzo1Cv1we+7mBgH/S+9t4qlcrYxx6033q9PnBbx3H6tm2321N5nb0qlcqlfw9GHXtnZ2fsfYT5vQ5Tb/D3/KKf2bTfh97P2LCfNYDLI/ACMdVut7W+vt633DAMOY4z8X4tyxorOCcSCRWLRUnS+++/P/FxF0Emk5npKPWLFy/6lhUKhb4gZNu2ksnkzOrweKF6d3d3avus1+sqFApdy6rV6qWCo6S+n0uYn1PwjzFJOjw8HLrdtN+HnZ2drmNLb3/Wk/yhBOBiBF4gprzwlM1m5bquXNf11x0cHITeT/D55XLZXz5O8Nvb25Prukqn06Gfswg6nY5c11Wr1fKXnZ2dyTRN/z3pdDr+ulqt5i8vlUoTHdN7vuu6ymazkqSjoyN/veM4ymQykqRisdi1vWmaEx3Te529vyfBUN1qtbq2uXXr1kTHajQakqRyudz13lqWNdYItcd7j16+fNm13HvsrR/E+xx42wyrYdrvQzBoN5tNua6rWq0mSVMN1QA+ReAFYm5zc9O/7420rqysTLSvO3fuDF3X+1VvcBS59yvj4Ff3tm2P/Fq592v+3pHAQW0Aw8K4bdsTfQ19fn7u30+lUmM9dxy9IdmyLEnSxsaGvywY0vb29mZWS3BUudVq9YXpyx7b+10K7vfmzZtj78cLnL1B0Xsc/P3v5YXvBw8e+J+N3lH2Wb8Pt2/flvTp79WogA7gElwAsSWp71YsFkM9t1gsupLcbDbbtyz4v45OpzPwOJLcTqfTVUe5XHZd13VbrdbQ50hyW62W67qu22w2B673ahq2n2azOfI1BY/Rq1arDa1rkODrr9VqfeuHvYZhdWSz2a713nvW+xpqtVrX6+nd7iLB1+n9nAbVEfz5D1Mul0e+xqBhP7NB790owZ9178/dW1Yulwf+HvfW0el0ut6PebwPw37Phv1eArgcRniBGPO+Jg26f//+WPvwenYNw/C/hg1+xf/hhx9K6v563Wt98NaN4j0vuM/j42NJ0gcffOC/DjfwNb9lWbJt299O6v5afljrhNdDnM1mJ/r6/7L9z5PY3d3tOuarV68kve33DPaA7u7uTtz/mUwmh55ANmnrwjCmafqjqUH5fH7ifXq/b95Jkd5/t7a2hj7HG8ktFotKJBK6e/euv27QNwTTfh8Gvd5isThxWwqA0Qi8QExVKhX/5CA30Gu6vr7u/4PufcU/ziwOzWaz6x9l70SfarXq78P7Ovnk5OTC/XkhNLjP09NTOY7jf6VfKBT8fXvLzs7OutoLvNA2qrc4nU7LdV3t7+9fWJfUHaI99+7dC/Xc3mMOu/UGnP39/b4e3kHHDPZWewFy2ElXl+EF7FFKpdLI1xiUy+VUrVb9P3Sazaaky/0x4QXbarXa1R87Kjx6v6Neu0gikfDf70GziUzzffBOgpM+/WOuXC5P5eQ9AIMReIEYchzH/wfdCxSJRMIf8R1nejAvWHnPnfVMBePwTh4LymQyMznT3QuVXuAOa9AfFWGnEtve3h56zGBvqhfaxq3NEwz2Xk+qN6IZ5mSyQdN1DfojyrZtv8ZHjx5JevsHgffejnMyZZBpmn5Yffz4sSR1nWDZK/j7O+iPKS84S7N5H7xvPrLZrD/S6/VvT3ryHoDRCLxAzAXPXvdO0vEMGn0cJp/P+6HCmyVA+jQQ9M4YEAxPk0gkEv79YEuDdwt+Jdw70jlsZHnSk9aCo4azOqnIcZy+oN7785I+DcHBk7S87Qa1Ckwq2Pqyvr7eF8ImmTs36Pvf/76k/qnBJuW9L96+RrUzhPmDzwvfs3wfLMvyg/Wi/BEJxNb02oEBLJJRJ9AMO6kraNDJPsETtLyT30adgBbmpLVgLb3bDTuxx6tp2PphJ3AFT/IadKLWqH0Oe+8uOmktrFEn//Xud9h23glP3s9+1AmKF520dtF7EeYkrkF6T8rr/X0Jvg+jTuDq/XkEf6cGnWjpLbvo5zXoJLVpvw+jftaTvq8ARmOEF4ipUqk08KS1Tqcz8Xy4wbaIarWqSqUi0zS75qKdpnw+77dkhFWr1YbOgRs8aS04ghxWq9Wa2VzCwR7S3mP2nuDkBvp7PZ1Ox+9Z9Ua4L3uhj3w+P3TUf9R0X6Ps7+/3jUR7bTOJRMKfAm7cEwuDbQ2jagueSDloirlgG4k3mjvt9yGRSAzcX7lcDt1fDmA8hjvsUwwAWEq5XE6WZanT6UwU7KNk27YymYzK5fLEF+8AgF6M8AJAjHizW0w6ih01r+d81EVOAGBcjPACAAAg1hjhBQAAQKwReAEAABBrBF4AAADEGoEXAAAAsUbgBQAAQKwReAEAABBrBF4AAADEGoEXAAAAsUbgBQAAQKwReAEAABBrBF4AAADEGoEXAAAAsUbgBQAAQKwReAEAABBrBF4AAADEGoEXAAAAsUbgBQAAQKwReAEAABBrBF4AAADE2meiLuCyDMOIugQAAADMgeu6Ez1v6QOvNPmLR7ROT0+1uroadRnA0uGzA0yGz85yu8wgJy0NAAAAiDUCLwAAAGJtaVsa6N0FAABAGEs7wuu6Lr27AAAAuNDSBl4AAAAgDAIvAAAAYo3ACwAAgFgj8AIAACDWCLwAAACINQIvAAAAYo15eAEAABBrSzvCyzy8AAAACGNpAy8AAAAQBoEXAAAAsUbgBQAAQKwReAEAABBrBF4AAADE2tJOSxaVH/3oR/rOd74TdRmx8LOf/Uy//Mu/HHUZsfGtb31Ln/3sZ6MuAwCAhbO0gTeqeXi/973v6dHv/Ct9/ld/PZLjx4srifmUp+H/fe87+u3f/m0CLwAAAyxt4PXm4I0i+H7xK7+mz2/+07kfFxjmT9p21CUAALCw5trDW6/XZRiGDMNQLpfrWpfL5fx1hmHIcZx5lgYAAICYmmvgTaVS/hXSbt26pXq93rW+0+n46xOJxDxLAwAAQEzNNfCapunf39jY6FpnWRYhFwAAAFMX2bRkjUZDqVSqa5nXztA78gsAAABMaq4nrTmOo2QyKelt+0JwRNc7Cc3bJpVKdY0IAwAAAJOYa+BNJBJ+sM3lctrc3FSpVOrbplar6fj4eGDgHTQrw+np6WwKHuD169f+awAWheu6Ojs705s3b6IuBXNwfn4edQnAUuKzc3VFNi3Zs2fPdO/evb7Ae5HesGkYhlZXV6dZ2kg3btyIbA5gYBjDMLSysqLr169HXQrmZJ7/3wPihM/O1TTXHl7b/nSu0IODA21ubvZt4ziOCoWC7t69O8fKAAAAEFdzDbyZTMY/Me3o6Mgf3W232/7yZDKpVqvFjA0AAACYirm2NAzrfTVNk75YAAAAzERk05IBAAAA80DgBQAAQKwReAEAABBrkU1LdllMDQYAAIAwlnaE13VdTnQDAADAhZY28AIAAABhEHgBAAAQawReAAAAxBqBFwAAALFG4AUAAECsEXgBAAAQa8zDCwAAgFhb2hFe5uEFAABAGEsbeAEAAIAwCLwAAACINQIvAAAAYo3ACwAAgFgj8AIAACDWCLwAAACINebhBQAAQKwt7Qgv8/ACAAAgjKUNvAAAAEAYBF4AAADEGoEXAAAAsUbgBQAAQKwReAEAABBrBF4AAADEGvPwAgAAINaWdoSXeXgBAAAQxlwDb71el2EYMgxDuVyua51t2/66SqUyz7IAAAAQY3MNvKlUyh+ZvXXrlur1uiTJcRxlMhl/3eHhodrt9jxLAwAAQEzNNfCapunf39jY8O8fHByoVqv5j7e3t/XixYt5lgYAAICYiqyHt9FoKJVKSZKOjo78+9LbkeCTk5OoSgMAAECMzHWWBsdxlEwmJUmdTkeJRGKehwcAAMAVNNcR3kQi4ffp3rt3j5PTAAAAMHORzcP77Nkz3bt3T6VSSWtrazo+PvZ7fI+Pj7t6fIMGzb97eno601qDXr9+zXRoWDiu6+rs7Exv3ryJuhTMwfn5edQlAEuJz87VNdfAa9u20um0pLcnqm1ubkqStra29PDhQ+XzeUlv+3ufPXs2cB+9YdMwDK2urs6u6B43btzgohdYOIZhaGVlRdevX4+6FMzJPP+/B8QJn52raa4tDZlMxp9r9+joSKVSSdLb2Ru2t7f9dQ8ePKC/FwAAAFMx1xHeUa0A+XzeH+EFAAAApmVpLy0MAAAAhEHgBQAAQKwReAEAABBrBF4AAADEWmTz8F4WU4MBAAAgjKUd4fWu2AYAAACMsrSBFwAAAAiDwAsAAIBYI/ACAAAg1gi8AAAAiDUCLwAAAGKNackAAAAQa0s7wsu0ZAAAAAhjaQMvAAAAEAaBFwAAALFG4AUAAECsEXgBAAAQawReAAAAxBqBFwAAALEWOvDmcjkZhiHHcSS9nQfXu0UhymMDAABgeYQOvJZlqVgsKpFIqFKpdK3b2dmZemEXYR5eAAAAhDF2S4PjONrd3ZX0NnQWi0VVq9WpFwYAAABMQ+jA6wXbZDIpSSqXyzMrCgAAAJiW0IF3b2+v63GpVJJt26pWqyoWi1MvDAAAAJiGz4yzcW/PbDqdpo8WAAAAC22sHt56ve7PjhDFiWoAAADAuEIH3nq9rkKh0LWs3W7LMIy+WRsAAACARRE68DYaDUmfzswgSaZpKpvN6vDwcCbFjcI8vAAAAAhj7Hl4h62bN+bhBQAAQBihA282m1W1WvWvtCa9bWmwLEvZbDbUPmzbHnqFNu9Kbt4teBwAAABgUqED75MnTyRJyWRS1WpV1WpV6+vrkqTt7e1Q+zg7O/NHZmu1Wl/vb6fT8dcnEomwpQEAAABDhQ68pmmq0+n0LW82m8rn86H2EdwulUrp5OTEf2xZFiEXAAAAUzfWtGSJRMIfgfVu6XR6ogOfn59rbW2ta5nXzlCv1yfaJwAAANBrrAtPTIvjOMpkMl0nnXn3HcdRMplUKpWSaZpRlAcAAIAYCT3C642+ttvtSx3Qtm3du3dv6AwLiURCtVpNx8fHlzoOAAAAII0xwpvNZmVZlm7evDnxwer1uk5PT7W/vz/xPgbNvXt6ejrx/sb1+vVrpkPDwnFdV2dnZ3rz5k3UpWAOzs/Poy4BWEp8dq6u0IH3yZMnsixLjx8/1t7e3kQHazQaF4Zdx3FUKBQGniAnqS9sGoah1dXVieqZxI0bN7jgBRaOYRhaWVnR9evXoy4FczLP/+8BccJn52oK3dLgTUFWrVa75ssNe8Uzx3FkWVbf8xzH8S9RbBiGksmkWq0WMzYAAABgKuZ20po3w8O46wAAAIDLCB14CaQAAABYRmPNwwsAAAAsm7ECb7DXNtiDCwAAACyq0IHXtm3/xLWgZDJ56bl5AQAAgFkJHXifP38uSWo2m/5lhZvNpiTp6dOns6luhLCzQwAAAOBqCx14q9Wqstms0um0vyydTiubzaparc6kuFG80A0AAACMwklrAAAAiLXQgbdYLMqyLNXrdX+ZbduyLEvFYnEmxQEAAACXFTrw3r9/X5JUKBT8/tlMJtO1DgAAAFg0oS88YZqmOp2Okslk1/JOp8NlgAEAALCwxrq0MJcABgAAwLLhpDUAAADE2tAR3nHnuJ33yC9z8AIAACCMpR3hZR5eAAAAhDF0hJcwCQAAgDhY2hFeAAAAIIyxAm+9Xvfn4PVujuPMqjYAAADg0kIH3nq9rkKh0Lc8mUyq3W5PtSgAAABgWkIH3kajIUlqNpv+CWO1Wk2S9PDhw9lUBwAAAFxS6MBrWZay2azS6bS/LJ/P++sAAACARRT6SmvFYlGvXr3qW57NZqdaUFjMwwsAAIAwQgfeR48eKZlMyrZtf5TXtm1ZlqVmszmzAofxpk0j+AIAAGCU0IE3mUxKkjKZTN+6QcuYxxcAAACLgHl4AQAAEGuhR3gZsQUAAMAyCj3Cu7OzM9E6AAAAIEqhA2+1Wu27slq73ZZhGKpWqzMpDgAAALissXt4k8mk6vW6dnZ2tL6+PouaQvEubQwAAACMEjrwuq6rcrksSSoUCl2jup1OZ/qVhaiHvmIAAABcZKwR3lKppFar5T9utVpyXVeJRGLqhQEAAADTEDrwOo4jwzC62hjW19fHaiuwbdtvReh9XnBdpVIJvU8AAABglNCB17vwhPT2MsPFYtF/HDb0np2d+a0ItVrND7aO4yiTyfjrDg8P1W63w5YGAAAADBV6Hl5Pq9WSaZqSpPv374914lo+n/fvp1IpHR0dSZIODg5Uq9X8ddvb23rx4oV/HAAAAGBSoUd4i8WiXNftCqGmacp13a7R3rDOz8+1trYmSTo6OlIqlfLXpVIpnZycjL1PAAAAoFfowLu3t6d6ve732QYvNrG3tzfWQb0WhlKpNNbzAAAAgHGFbmmo1+sqFApdy9rtttbX11Uul0OHV9u29cEHH0w8pdigfuHT09OJ9jWJ169fMx0aFo7rujo7O9ObN2+iLgVzcH5+HnUJwFLis3N1hQ68jUZD0tt/WL3RXdM0lc1mdXh4GCrw1ut1nZ6ean9/v2v52tqajo+P/XaJ4+NjbWxsDNxHb9g0DEOrq6thX8al3bhxgwteYOEYhqGVlRVdv3496lIwJ/P8/x4QJ3x2rqbQLQ2WZQ3t1bUsK9Q+Go3GwGC8tbXlB2pvu7t374YtDQAAABgqdODNZrOqVqtyHMdf1m63ZVmWstnshc93HEeWZXXNw2sYhhzHkWma2t7e9pc9ePCAi1kAAABgKkK3NDx58kSWZXXNx+tdXnh7e/vC5ycSiZG9r/l8vmvaMgAAAGAaQgde0zTV6XS6Aq8kNZtNpdPpqRcGAAAATMNYF564aJQWAAAAWDShe3gBAACAZTT2pYUXBVODAQAAIIylHeF1XZf2CgAAAFxoaQMvAAAAEAaBFwAAALFG4AUAAECshQ68uVzOvzKapK6rpQEAAACLKnTgtSxLxWJRiURClUqla93Ozs7UCwMAAACmYeyWBsdxtLu7K+ntTAnFYtG/xDAAAACwaEIHXi/YepcWLpfLMysqDNopAAAAEEbowLu3t9f1uFQqybZtVatVFYvFqRd2EebhBQAAQBhjXWmtN2Cm02lCJwAAABYa05IBAAAg1oaO8I7bH8tILwAAABYRI7wAAACItaGB1zspzLvVajVJUrPZ7FvWarXmUy0AAAAwptAjvI1GQ9lsVul02l+Wz+eVzWb18OHDmRQHAAAAXFboWRosy5po3awwBy8AAADCCD3Cm81mJUn1et1fZtu2LMvy180T8/ACAAAgjNCB98mTJ5KkQqHgX+Usk8lIkra3t2dTHQAAAHBJoVsaTNNUp9PxLy3saTabXX29AAAAwCIZ60priUSCNgIAAAAsFebhBQAAQKwReAEAABBroVsaLpoGjFYHAAAALKKxengXCfPwAgAAIIzQLQ29lxp2Xde/pHAUlxZmHl4AAACEcakeXtM0J7q08M7OjiqVSteyXC7nz+9rGIYcx7lMaQAAAICkSwZex3FkWVboSwvbtj2yFaHT6fgjt4lE4jKlAQAAAJLGCLzB0Vfv5l2EolgshtpHOp2W67ra2NjoW2dZFiEXAAAAUzeVacn29vamsRs/SNfr9ansDwAAAAg9S8OsTxDz9u84jpLJpFKplEzTnOkxAQAAEH9jTUtWr9dVKBQkvW1jmNbIblAikVCtVtPx8fHAwDuoB/j09HTqdQzz+vVrZofAwnFdV2dnZ3rz5k3UpWAOzs/Poy4BWEp8dq6u0IE3GHY97XZb6+vrKpfLKpVKUy9ukN6waRiGVldX53JsSbpx4wZzAGPhGIahlZUVXb9+PepSMCfz/P8eECd8dq6m0D28jUZD0tvA6Z2k5k1Ldnh4OLWCHMdRoVDQ3bt3p7ZPAAAAXF2hA69lWUNnYwg7Ldkw7Xa7a+aHVqvFjA0AAACYitAtDdlsVtVqVY8ePfKXtdttWZalbDY71kHz+XzXY9M06YsFAADATIQOvE+ePJFlWf7cu5JUrVYlSdvb29OvDAAAAJiC0IHXNE11Op2uwCtJzWZT6XR66oUBAAAA0zDWtGSJRILWAwAAACyVsQLvImFqMAAAAIQx1qWFg7MpeDfHcWZV20iu6zLaDAAAgAuFDry2bWt9fb1veTKZVLvdnmpRAAAAwLSEDrzPnz+X9PYkNW90tdlsSpKePn06m+oAAACASwodeKvVqrLZbNeMDOl02p+fFwAAAFhEY/XwAgAAAMsmdOAtFouyLEv1et1fZtv2yEsOAwAAAFELHXjv378vSSoUCv4MDZlMpmsdAAAAsGgufaW1TqejRCIx9cIuwjy8AAAACGNpr7Tm1UHwBQAAwCictAYAAIBYI/ACAAAg1ka2NIzTLrAorQ4AAABAECO8AAAAiLWRgde7hHDvrdPpdG1XLpdnWiQAAAAwqbFmaZCker2uQqHgP261WjJNc6pFAQAAANMyVkvDzs6OH3az2axc140s7HoXvwAAAABGCTXC6zhO1wUnyuWySqXSzIoKg3l4AQAAEMaFgZcWBgAAACyzkS0Ni9TCAAAAAExi5AhvtVr171uWNbJ9gHl4AQAAsIiYhxcAAACxNnKEl1FbAAAALDtGeAEAABBrY194YlEwHRkAAADCWNoRXu8yxwAAAMAokQTenZ0dVSqVrmW2bftXT+tdBwAAAExqroHXC7W9HMdRJpPxR20PDw/VbrfnWRoAAABiaq6BN51Oy3VdbWxsdC0/ODhQrVbzH29vb+vFixfzLA0AAAAxtRA9vEdHR0qlUv7jVCqlk5OTCCsCAABAXCxE4AUAAABmhcALAACAWFuIeXjX1tZ0fHws0zQlScfHx319vp5BJ72dnp7OtL6g169fMx0aFo7rujo7O9ObN2+iLgVzcH5+HnUJwFLis3N1LUTg3dra0sOHD5XP5yVJjUZDz549G7htb9g0DEOrq6szr9Fz48YNLnqBhWMYhlZWVnT9+vWoS8GczPP/e0Cc8Nm5mhYi8Jqmqe3tbT9INptNJRKJiKsCAABAHEQSeL2R3N5lg5YDAAAAl8FJawAAAIg1Ai8AAABijcALAACAWCPwAgAAINYWYpaGSTA1GAAAAMJY2hFe13W5AAQAAAAutLSBFwAAAAiDwAsAAIBYI/ACAAAg1gi8AAAAiDUCLwAAAGKNackAzMW3v/1t/cF/+sOoy4iFN28+0nvvfTHqMmLhV7/2Ve3ulqIuY6TH//J39H9Pz6IuIxb47EzPb/z9tH7zN38z6jJCW9rA601JRvAFlsN3/sN/1Lf/y//U537lr0ddSgy8I+nPoi5i6X38xz9V4vcPFz7w/tvf+3f649Vf1zvvXY+6lBjgszMNf3bS1rV3rhF4AWCQz3/1tr505x9EXQYgSfqL81fSf/tR1GWE8qW/8ff0mb/yV6MuA/hLy3cdBHp4AQAAEGsEXgAAAMQagRcAAACxRuAFAABArBF4AQAAEGtLO0sD05EBAAAgjKUd4XVd15+LFwAAABhmaQMvAAAAEAaBFwAAALFG4AUAAECsEXgBAAAQawReAAAAxBqBFwAAALHGPLwAAACItaUd4WUeXgAAAISxtIEXAAAACGNhAm8ul5NhGP7NcZyoSwIAAEAMLFQPb6fTUSKRiLoMAAAAxMjCjPBalkXYBQAAwNQtTOCV5Lcz1Ov1qEsBAABATCxMS4M344LjOEomk0qlUjJNM+KqAAAAsOwWJvB6EomEarWajo+PBwbeQfPvnp6ezqM0SdLr16+ZDg0Lx3VdnZ2d6c2bN1GXMtSf/umfSno36jKALh9//Iu5/hsyiY8/+WSxvo4FJL356M3Cf3aCFi7wXqQ3bBqGodXV1bkd/8aNG1z0AgvHMAytrKzo+vXrUZcy1Be+8IWoSwD6vPPOZ+b6b8gk3rl2TQyzYNG898X3Fv6zE7RwgddxHBUKBXU6nahLAQAAQAwsxLck7XbbP2EtmUyq1WoxYwMAAACmYiFGeE3TpC8WAAAAM7EQI7wAAADArCzECC8AALg6/vx//w99/PLf69o1TgJfRtf++Kf6/dN3lMvlpr7vb37zm/rmN7859f0SeAEAwFx9/Cc/1dd+SfoXj/551KVggTQaDf3whz+cyb6XNvAyNRgAAMsrcXNlJiOEWF7f/e53Z3ZO19L28Lquy4luAAAAMfLzn/9cH330kT766KOp7ndpAy8AAADi5Sc/+Yl+8IMf6Ac/+MFU90vgBQAAQKwReAEAABBrBF4AAADEGoEXAAAsrE8+cfXxFG/DVCqVgbNG5HI5OY4zy5fYVYNt23M5VlC9Xle9Xp/7cedpaaclAwAA8fcb//o/60edP5na/g4e/B39tZu/NHCdZVmq1+vK5/NTOx4Ww9KO8BqGwVy8AABgaprNpgqFwtxGdDE/Sxt4mYcXAABMW7PZ1OPHj4eu9wbcDMNQpVIZuq7dbkvqb1Pofext39tOUa/Xhx5n0DY7Ozv+/oPbe7V4bQu5XM5/zrBgv7OzM7Aubx/BmgbV0LuPKNo0ei1t4AUAAJi2dDotSQNDWi6XU7PZ9AfdTk5O/N7XXC6nTqfjr3v48OGFxwru79mzZ9rd3ZUkOY6jRqPh76tUKvU917ZtnZ6e+ttsbGzItm2VSiWdnJyo3W6rUqmo2WzKNE1JUqFQ0LNnz+S6rmqrqGzLAAAKCElEQVS12sBgX6lUtLa25u93e3u7K8gWCgW/pmE12LbdtQ/vPY0SgRcAACDg0aNHymQyXcu80dBgeLt//76Ojo7kOI4sy1IymfRHNS3LGtka0bu/RCKhcrns35fUFTR7vXz5Uru7u/7xCoWCXr586de/vr7eV2+tVvP3nc/nVa1W+/Z7eHio3/qt3/If925Xq9UurOH27dva3d1dqBPhCLwAAAABiURCtVpN9Xpdt27dGrnt2tqaJCmbzfojmt7NC5fDjNr3/v6+7t+/P7KlITjaPGwkeJRsNnvp7QbVkEgk/LZTWhoAAAAWVD6fV6FQ0KtXryR9OuoaDG9Pnz7VnTt3Bq7zrK6u+iOvkvy2hUQioWq16vf6Oo7jr/OYpqlOp6PDw8O+/d65c0cffPDBwNofP36sVqvltzZ4Go2Gf79SqWhzc7PvuZubm/rwww/9x/V6feB2F9UgvX0Pm81m1+uPCtOSAQAADNBsNrtaG/b397tmiKrVan7LwLNnz5RMJv11xWJRe3t7yufzMgzDD7Ne24IktVotv/Ugm8366xzH6dpXq9Xqqy2dTuvly5dd9bRaLT19+lRra2syTVOPHj1SMpn0n7+5uelvn81mtb+/37ffUqnkn3AWfB2DDKvh/Py8631bhEkGCLwAAODKG9QOkE6n+8LasPAW/Bq/17DlpmmO/ZygUqnUV3cwnAZrOj4+1urq6sD99s47vLe3NzDkDpqfeFANo15XVJY28DIHLwAA8fcP/+avqPOzP5/a/m689+7U9oXlsbSBN9gMDQAA4ulbm78WdQmIgaUNvAAAAAjnql8umVkaAAAAEGsEXgAAAMQagRcAAACxRuAFAABArC3tSWvMzgAAAIAwljbwMi0ZAADL67/+0R/qG3/777598MknkhbrQgUYzv3kF3r3mqHPfe5zU93vj3/8Y929e3eq+/QsbeAFAADL6fNfXde1uw908pePP/5ZR+7Hv4i0JoT35z8+1t9a/az+yT/+R1Pf91e+8pWp71NaoMBr27Z/3eVyuTzwEn8AAGD5XXvvy/r8177sP/75T/6X3F/8RYQVYRy/eP1/lLz5BX3jG9+IupTQFiLwOo6jTCbjtynkcjltbW3JNM2IKwMAALNmvPs5Gdc4j35ZGO+8q3fffVdf+tKXoi4ltIUIvAcHB6rVav7j7e1tvXjxgsALAMAV8JnrN6MuAWO49t51ffnGF/X1r3896lJCW4g/p46OjpRKpfzHqVRKJycnI54BAAAAhLMQgRcAAACYlYVoaRjHoGnIIpma7L//wfyPCYzw5S9/+eKNFsBPD/5N1CUAXZZiesvf+2dRVwB0+V1b+t3qXtRlhLYQgXdtbU3Hx8d+z+7x8bE2NjYGbuud2IblZxgGP09gAnx2gMnw2bm6FqKlYWtrS41Gw3/caDRmNvEwAAAArpaFGOE1TVPb29v+10rNZlOJRCLiqgAAABAHhsvYPiLCV0vAZPjsAJPhs3N1EXgBAAAQawvRwwsAAADMCoEXAAAAsUbgBQAAQKwReDEXlUpFhmH4t3a7LUmq1+tdy72bbdsRVwwshlwuN/Sz0fv5cRwnwkqB+bNte+jvfrvd7vr3xlOpVLSzszNwf95z+Lcofgi8mJtmsynXddXpdLS+vi5Jyufz/rJsNivXdeW6rtLpdMTVAouj0+n0fTYqlYqOjo785a7r6sMPP4y4UiAag373X7x4MXDbw8NDSeoLybZta319vesz9fLly6nXimgQeDF3zLEMXE673dbJyYn29rov61kqlSKqCIhOuVzW7u5u3/LDw0MVi8WuZe12W5ubm9rY2NDBwUHXukwm0zdlGZ+p+CDwYu5s21a5XI66DGBpvXjxQu+//37UZQALo1wu97X7bG9v92334sUL3blzR3fv3u26wiv/LsXfQlxpDVdDJpPx73c6nQgrAZZLMpn073ufnZs3b0ZVDrBwtra29PTpU7/lp9FoaH9/X0dHR13b7e7u+qO4t27dUrvdlmmakqTV1dX5Fo25YoQXc+P18Lquq3v37vWdSABgsGAPr9cSdH5+HnFVwOLwQmu73ZZt29rc3OzbpncU9/333+/q8z09PZ15nYgOgReR2Nzc5B9sYEJ37tzR8+fPoy4DWChegH3+/Lm2trb61j9//ly7u7v+DAyZTMbv/b19+/bAPmDEB4EXkTg8POQrWWBC6XRar169UqVS6Vre+xi4StLptB9avRFfj+M4qlarXTMwuK6rYrEo27aVSCRULpeVy+W6nsdnKj7o4cXcBHt4m81m3/+QAIS3v7+vnZ0dGYbhL+s9wxy4amq1mlZWVvqWHxwcDDwp7f3339fz58+VTqdVKpW0urra9ZlqtVozrRfzY7j8HxIAAAAxRksDAAAAYo3ACwAAgFgj8AIAACDWCLwAAACINQIvAAAAYo3ACwAAgFgj8AIAACDWCLwAAACINQIvAAAAYo3ACwAAgFgj8AJAxOr1ugzDkGEYchzn0vub5r4AIA4IvAAwhBcch91yuVzUJfaxbdu/f3BwEGElALA4CLwAECPpdNq/f/fu3QgrAYDFQeAFgCFc1/Vv2WxWklQsFv1l+/v7EVc4mFdfIpGIuhQAWAgEXgCYgmAfrmEYqlQqfdtUKpVQLRHBbdrtdt/ySqXSdbzgftrttr882N5g23bXfoOPvWPkcjkZhqGdnZ2BNQft7Oz07Q8AFhWBFwAuqVKpqFAodC3b3d3tCr25XE67u7sX7iuZTHY9Xl9f79tmd3e363iWZalerw/dZ71eVyaT6VrW+3gcuVxO1Wq1b3+EXgCLisALAJfgOI4fZFutllzXVafTkfQ2mDqOI9u2ZVmWJKlWq/ktB9vb2337azabcl1XtVrNXxYc5fV4+/AcHR0NrdELx9ls1n9euVye4NWq67V4+2o2m5KkDz74YKJ9AsCsEXgB4BK+//3v+/fX19dlGEbXKO35+blevnwp6W3gzOfz/rrgfc/t27clSalUaugxg2G1WCxKkl69ejVw2+DUZA8ePPDvb21tDd3/KN5rkT5tsfBGi70gDACLhsALAACAWCPwAsAl3Lx507/vtTQEb6ZpanV1VVJ/r+2ovttpCc7U8Pz5c//+06dP+7a9deuWJHX15x4eHnZt470WSX2vNdhiAQCLhMALAJdgmqbfVuC1NPTO1BBsXSgUCv76RqMxlxq9Fohqteofu/ekM0na2Njw73vb9bYpBF9L74U4OGkNwKIi8ALAJe3t7V14Epjrun4w9ngjqrNWKpW66stms/6JZkH5fL6rxlqtNvB1BeclBoBlYLh8BwUAV45t2/7JZq1WS6ZpRlwRAMwOI7wAAACINQIvAAAAYo3ACwAAgFijhxcAAACxxggvAAAAYo3ACwAAgFgj8AIAACDWCLwAAACINQIvAAAAYo3ACwAAgFj7/9BKi+/fREcCAAAAAElFTkSuQmCC\"></img>"
+       "<img class='' style='' src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAArwAAAGQCAYAAABMPLOTAAAABHNCSVQICAgIfAhkiAAAIABJREFUeJzt3V1oI+me5/lfZNfp6a7qOUsPhI1r8FUu27Ajlzv7xXvVSzYSXi8hcmHudGQ4FLt5sTdhCizIGXJZhvYsuStBtbQzMJAXSU1L6GphSCwwRgFmpxcWM905Popuelmyhx5Du6xoOpszUzXTL5UxF57nKb06Q7asl/D3A+JYT4QiHskZp35+9H+ecOI4jgUAAACk1IN5dwAAAAC4SwReAAAApBqBFwAAAKlG4AUAAECqEXgBAACQagReAAAApBqBFwAAAKlG4AUAAECqEXgBAACQagReAAAApBqBFwAAAKlG4AVwI2EYynEc5fP5eXcFAIBrEXiBJbS3tyfHceyj0Wgkep0JqaMeQRBM1IejoyNJUqvVUhiGE7+HWbrufVcqFbvfuH3M4zbhfvBYvZ9Zo9G49ryDv5sgCIb2mcTgvx/z2NvbG9o3n89f+5nd9pzmEUXRtZ/FpP8+k3w+SX63k/RhWp+VNPpzGHWdVSqVG/1/AXDfEHiBJbO3t6dardbXtru7e+P/sBq5XG6i/1ju7OxIkjzPUyaTudW556lUKt36s/uQUYFrY2MjcYhbXV21P1cqFeVyuan1bRwTqlut1p2fS5Jc15UkXVxc3MnxR/3RMOlr3rx5M3a/aX5WYRhqd3d3qH1jY6Mv9FYqFZVKpb59dnd3Cb3ACAReYIlEUWTDbrvdVhzHqtfrkjT0H74PMa/vdru2rdlsJn59JpNRHMc6PDyc6LzzZt53HMe27fz8XJJsexzH8jxPkuT7vm27yXvtDU3dbldxHMv3fUnS69evJUnFYrHv3HEcq1wu2/ObPyiCILC/53q93rf/TXie13eMarUq6Spw9Ybq3n16/71MolqtDr1H8xmbf8O9en9PcRwrm83e6LzmHINh1Tw320cxvx+zz6hr7C4+K6n/99t7HPPNShRFtj/mszL/rkaFZeC+I/ACS+qzzz6TJG1ubkq6/j/c13Fdd+xrB7+G7g1vvV+5mq+je7/G7d0+6uvi6449avu4r5yjKBrqRxK9+25tbSV+3U15nmdHMc351tfXx/bNhJnnz5/bdhPAyuWyisXinfX15cuX9ufBMO26rvb39299jiAI1Gq15Hle33sxf3z0jmrfxsOHDyUNh1Xz/PHjxyNf1/vH5atXr/r63esuPqtMJtP3mYy6Ro+Pj+3P5o+Bp0+f2rZFLzMCZi4GsFTq9XosaejR6XQ++NpOp2P3b7fbQ231et3u63neyPOY1/X2o9vtxnEcj9z/Jsf2fX9om+d5H/w8es8x7n0n/dxMH33fv3b7qMfga0a9n+v+79fsXy6X+9p7+zzqc0vKHH/UZ9rtdu1xB88/yiSfw6j3Mtj3Uceb9P0NHn/wOKatXC6P/SzMvyvTbvbrfU+z+qxGXbflcnmo3739uclnBqQZI7zAkhk1stf7tXdSuVxOjuNoY2PDHsMc24y+Sd9/RdtutyVJX375ZaLjxwNftZ+eniY+thlZK5fLHywn2N7eHvlzUpPU0t5U78ibMeprfOlqZM68/x//+Me2vXdE2vzOjFwud6P30Gq1rp3wtLa2NvExkzDn8TwvUanCTd+fYcpDzAi5+V9Thz6KKe8pFAqSpCdPnki6+rc56puEu/qsgiDou0ZvWtoB3HcEXmCJmK/vpe9r/Mrlsmq1Wt9X/oOzxT80icXzPFu/KfXXO5pjmDrFJBNzTMCQZOsK3759m/jY5jWlUumDqyO4rmtDsSkZuE5vbag5Ty6Xm6gcQpIODw+HalLNo/ez7A0snU7H1q6Om2hoajR93x/7fnr/EDDGTai6jSQTyJJ+Dr0Gw+R1xzNMSL0JE2xNWDV/UIz7IzEMQ/tv0ZQMmRIiqb+cwLiLz2pvb89eG+VyeeznCeDDCLzAEvnqq68kqa/u0dQITro8mAl+5rWLtJ5utVrtGwE1I5GThtIP6a3dvby8nOi1o5agGrW8lxm1LpfLNmC9ePFC0uhJUKbNjCiO8ujRI/uzCe2m9nUSg5PWisViX8hOMhEy6edg9IbJJCPy5o8n8wfTTWQyGVsDe3Bw0HfcUcwfHdLVaLrjOFpZWbFtJrDf5WfVuxpLp9MZqgU2I8q9f4D2/hvuDegACLzAUmq1Wjb8jfqqd3Ak6boJTqacoNVq2ZHg3q9nR41G3UbSY5uVCzqdjm0bFUpvOmlN6l+VYlqTpMY5OTmxP/cGql69v8vBwOK67tDqDr2jldOceNf7x8bgkmpRFN1qGTfz3nsn8fUeu/fbiN7Je+MmlyVlRpPN53VdOcOHwmvvH5d38VkFQWD72e12R45Em5Fns7/0/QS6UZ8tcO9NsR4YwB3rnZQy+Bg3qavXqMkvcfz9BBj1TOIad54kk9Z6J/CMmhT0oWOP227O06u3H+Mm6lw3aW2wv8aHJq0l1Ttp6kPnHTURKen7GOz3uAl8cXz9pLXBfZJ+XkmZ/o06xnX/vs3vvnef6yZqDv6b6P3set/34GfR+/saPP64SWrT/qySHm/cfkxYA4YxwgssEVOvOqhcLt9qPdzer0s3NjYURVHfOqnTdpNjx2NqdHu/Fr/J17j1en0qy2yNk81m+0apjXa7PXReMwo8bjQzk8kMre1qyhKMScoFrlOtVkf2W+ovqZhEFEW2f6OOMer3a96f2WZG+Se94UlvWcN1o8W9kzIHj987yt47Cjztzypp+Ua1WrX9MTqdDhPbgBGceNR/PQEASyeKIq2srMjzvKW7IUhSQRAol8upXC7f6R8qANKFEV4ASImf/OQnkm5f77rIzGoUNx1lBnA/McILAACAVGOEFwAAAKlG4AUAAECqEXgBAACQagReAAAApBqBFwAAAKlG4AUAAECqEXgBAACQagReAAAApBqBFwAAAKlG4AUAAECqEXgBAACQagReAAAApBqBFwAAAKlG4AUAAECqEXgBAACQagReAAAApBqBFwAAAKlG4AUAAECqEXgBAACQah/NuwN3xXGceXcBAAAAUxTH8Y1el9rAK938Q8F8XVxcaG1tbd7dAJYC1wswGa6Z5XWbwUxKGgAAAJBqBF4AAACkGoEXAAAAqZbKwMuENQAAABgzD7yO49hHryAIbHulUunbls/n7bYoij54DiarAQAAwJhp4M3n82q324rjWPV6XXt7e5KkKIqUy+UUx7HiONbJyYnCMJQkVSoVFQoFxXGsdrutg4ODWXYZAAAAS86JZzQcGkWRPv/8cx0eHn5/csdRHMdqNBqSpGKxKElqNBq6uLjQ/v6+3af3Nd1uV67rXnu+wddhebBkDJAc1wswGa6Z5XWbbDfXGl7P8xRFkU5PT7W5uWnbNzc3dX5+rjAM5ft+32t839fl5eWsuwoAAIAlNbPAa0ZkgyCw/9tqtWZ1egAAANxTM73T2qtXr7SysiLpaqTW87xZnh4AAAD30MxqeAf11vRWKhWtra311fBK0vb2tlZWVoZqeMd1eXDlhz/90z+9o97jLl1eXmp1dXXe3QCWAtcLMBmumeX16aef3riGd6YjvL0ODg70xRdfSJJ2dnb07NkzG3ibzaZevXol13Xl+76CIFA2m1UQBCqXy2OPORiMKUpfXvzugOS4XoDJcM3cPzMNvHt7e6rVapKker2ubDYrScpkMioUCnaEtt1u25rfarVq2z3P61vlAQAAAPiQuZU03DWWJVteLBkDJMf1AkyGa2Z5Le2yZAAAAMBdI/ACAAAg1VIZeAdXawAAAMD9NbdVGu5SHMczD71//ud/rt/5nd+Z6TnT6qc//al++MMfzrsbS+9XfuVX9Bu/8Rvz7gYAAHOXysA7D19//bX+wf/yv+qT//o3592VFIglMUp/G//h67f6/H/4NwReAABE4J2qn//h39Enj/+neXcD0Pt/9S/EGiUAAFxJZQ0vAAAAYBB4AQAAkGoEXgAAAKRaKgMvy5IBAADASGXg5ZbCAAAAMFIZeAEAAACDwAsAAIBUI/ACAAAg1Qi8AAAASLVUBl5WaQAAAICRysDLKg0AAAAwUhl4AQAAAIPACwAAgFQj8AIAACDVCLwAAABINQIvAAAAUi2VgZdlyQAAAGDMPPA6jmMfvYIgsO2VSqVvWz6ft9uiKPrgOViWDAAAAMZMA2+lUlG9Xlccx6rX69rb25MkRVGkXC6nOI4Vx7FOTk4UhqF9TaFQUBzHarfbOjg4mGWXAQAAsORmGnjPz8+1ubkpSdre3tbbt28lScfHx6rX63a/QqGgo6MjSVKpVFKxWJQkZbNZ1Wq1RKO8AAAAgDTjwLu1taWzszNJVyH38ePHkqTT01MbhCVpc3NT5+fnCsNQvu/3HcP3fV1eXs6szwAAAFhuMw28xWJRp6enchxHzWZT+/v7szw9AAAA7qGPZnmyfD6vFy9eqFqtKooi5fN5HR4eTu34gxPhLi4upnbsD4miSO/fM1kOi+Pbb76d6TWA+eAbL2AyXDP308wCr6m7zWQykiTXdfXw4UOFYaj19XWdnZ3ZbWdnZ9ra2tLq6qpqtZqq1ao9zuDzXr2rMziOo7W1tbt6O0PevXunBw9YDg2L4+NPPp7pNYD54fcMTIZr5v6ZWUmD67pqtVp29YUoilSr1bS6uqqdnR01m027b7PZ1Pb2tlzXle/7CoJA0tXSZeVyeVZdBgAAQArMtKSh0+loY2Oj77nrunJdV4VCwZYktNttua4rSapWq7bd87yplkAAAAAg/WYaeDOZzNibQhSLRbv82CBuJAEAAICbSuWthQEAAACDwAsAAIBUS2XgHVyeDAAAAPdXKgMvNb8AAAAwUhl4AQAAAIPACwAAgFQj8AIAACDVCLwAAABItVQGXlZpAAAAgJHKwMsqDQAAADBSGXgBAAAAg8ALAACAVCPwAgAAINUIvAAAAEi1VAZeVmkAAACAkcrAyyoNAAAAMFIZeAEAAACDwAsAAIBUI/ACAAAg1Qi8AAAASDUCLwAAAFItlYGXZckAAABgzCzwhmEox3GGHmEYSpKCILBtlUql77X5fN5ui6Log+diWTIAAAAYMwu8mUxGcRzbR6fTke/7ymQyiqJIuVzObjs5ObFBuFKpqFAoKI5jtdttHRwczKrLAAAASIG5lTS8fPlST58+lSQdHx+rXq/bbYVCQUdHR5KkUqmkYrEoScpms6rVaolGeQEAAABpToHXBNZMJiNJOj091ebmpt2+ubmp8/NzhWEo3/f7Xuv7vi4vL2fXWQAAACy1uQTer776Sk+ePJnHqQEAAHDPfDSPk5ZKpTuZWDa4OsPFxcXUzzFOFEV6/57Jclgc337z7UyvAcwH33gBk+GauZ9mHnjDMFS5XO5rW19f19nZmS1xODs709bWllZXV1Wr1VStVu2+g8979YZox3G0trZ2B+9gtHfv3unBA5ZDw+L4+JOPZ3oNYH74PQOT4Zq5f2Ze0nB0dKRHjx71te3s7KjZbNrnzWZT29vbcl1Xvu8rCAJJV0uXDYZlAAAA4DozH+E9Pz/Xzs5OX1smk1GhULAlCe12W67rSpKq1apt9zxPh4eHs+0wAAAAltrMA++4coRisWiXHxvEjSQAAABwU6m8tTAAAABgEHgBAACQaqkMvIPLkwEAAOD+SmXgpeYXAAAARioDLwAAAGAQeAEAAJBqBF4AAACkGoEXAAAAqZbKwMsqDQAAADASB958Pi/HcRRFkaSrUGkei4ZVGgAAAGAkDrytVku+78t1XVUqlb5te3t7U+8YAAAAMA0TlzREUaRSqSTpaiTV933VarWpdwwAAACYhsSB1wTblZUVSVK5XL6zTgEAAADTkjjwVqvVvuf7+/sKgkC1Wk2+70+9YwAAAMA0fDTJzoOTwbLZLBPEAAAAsNAmquFtNBp2ZYZFnqi2iCtHAAAAYD4SB95Go6Hd3d2+tjAM5TjO0KoN88aoMwAAAIzEgbfZbEr6fmUGScpkMvI8TycnJ3fSOQAAAOC2Jl6Hd9w2AAAAYBElDrye56lWq9k7rUlXJQ2tVkue591J5wAAAIDbSrxKw4sXL9Rqtew6vJLsDScKhcL0ewYAAABMQeLAm8lk1O12+wKvJLXbbWWz2al37DZYpQEAAADGRMuSua6rOI77HpOGXbOyw+DSZkEQ2PbBVR/y+bzd1ltSMQ6rNAAAAMCYKPDeVhiG2tjYsGHZ3L0tiiLlcjnbfnJyojAMJUmVSkWFQkFxHKvdbuvg4GCWXQYAAMCSSxx4zQirCaI3cXR0pE6nM9R+fHyser1unxcKBR0dHUmSSqWSisWipKs7uw1OnAMAAACuM9EqDZK0urp645OVSiWdnZ3Z8BwEgSTp9PRUm5ubdr/NzU2dn58rDMOhpdB839fl5eWN+wAAAID7JXHgffHihSRNpaQgjmN1u13lcjlGawEAAHCnEgfejY0NSVdLkZkR2t5HUqY8wXVdRmsBAABw5xIvSzYNnucpiiK5rtvXvr6+rrOzM2UyGUnS2dmZtra2tLq6qlqtZie3SRp63msweF9cXEz5HYwXRZHev2d1CCyOb7/5dqbXAOaDQQNgMlwz91PiwDuNpb4eP36sr776Svv7+4qiqC+8Pnv2zI7+NptNvXr1yo4CB0GgbDarIAhULpcT9dFxHK2trd26z0m9e/dODx6w/i8Wx8effDzTawDzw+8ZmAzXzP0z0xHe/f195fN5lUolSVK325V0dVOLQqFgR2jb7bYdBa5Wq7bd8zwdHh7OsssAAABYchMFXrOObq9utztUonCdcYG1WCzaEd5B3EgCAAAAN5V40loQBENhV5JWVlZutTYvAAAAcJcSB97Xr19Luio3MHdEa7fbkqSXL1/eTe8AAACAW0oceGu1mjzPUzabtW3ZbFae56lWq91J525qkmXSAAAAkG6JA+8yoeYXAAAARuLA6/u+Wq2WGo2GbQuCQK1Wa+j2vwAAAMCiSBx4nz59Kkna3d21d1fL5XJ92wAAAIBFk3hZskwmo263q5WVlb72SZclAwAAAGZponV4XdelPhYAAABLJZWT1gAAAABj7AjvpEt7LdLIL8uSAQAAwEjlCO8ihW8AAADM19gRXkIjAAAA0iCVI7wAAACAMVHgbTQadg1e84ii6K76BgAAANxa4sDbaDS0u7s71L6ysqIwDKfaKQAAAGBaEgfeZrMpSWq324rjWHEcq16vS5KePXt2N727IVZpAAAAgJE48LZaLXmep2w2a9uKxaLdtkiYcAcAAAAj8Z3WfN/X27dvh9o9z5tqhwAAAIBpShx4nz9/rpWVFQVBYEd5gyBQq9VSu92+sw4CAAAAt5E48K6srEiScrnc0LZRbZQVAAAAYBGwDi8AAABSLfEI7zKN2LJKAwAAAIzEI7x7e3s32tYrCIK+m1ZUKpWR23rbJSmfz090o4tlCucAAAC4W4kDb61WGwqcYRjKcRzVarXEJyyXy3Yd3/39fUlSFEXK5XK2/eTkxN7MolKpqFAoKI5jtdttHRwcJD4XAAAAMHEN78rKihqNhvb29rSxsTHRa7/++mutra0NtR8fH9ubWEhSoVDQ0dGRJKlUKtn1frPZrGq1GrczBgAAQGKJA28cxyqXy5Kk3d3dvlHdbreb+IS7u7u2PME4PT3V5uamfb65uanz83OFYSjf9/te7/u+Li8vE58PAAAA99tEI7z7+/vqdDr2eafTURzHcl030euLxaItWyiXy4lrfwEAAICbSrxKQxRFdi1ew5Q03GSS2P7+vhzHUbVanfi1AAAAQFIT33hCki0zMGUNjuPcamWE9fV1nZ2dKZPJSJLOzs60tbWl1dVV1Wq1vlA8+LzX4HJkFxcXN+7TpKIo0vv3rA6BxfHtN9/O9BrAfFDiBUyGa+Z+Shx4jU6nY4Pp06dPJ564ZlQqFVsTvLOzo2fPntnJac1mU69evZLruvJ9397OOAgC+5pRekO34zgjJ8jdlXfv3unBA9b/xeL4+JOPZ3oNYH74PQOT4Zq5fxLX8Pq+rziObdiVpEwmoziOhyaWjbO3t2cnrJ2fn9tlyTKZjAqFgt32xRdf2LrgarWqXC4nx3H05Zdf2tcAAAAASSQOvNVqVY1Gw4bS3glnSetwq9WqnbQ2+JreCW3ZbLZvm2k/PDxM2l0AAABA0gSBt9FoaHd3t6/N3Hhi8M5oAAAAwKJIHHibzaYk9ZUwZDIZeZ6nk5OTO+kcAAAAcFuJA2+r1Rpbq9tqtabWoWkYXK0BAAAA91fiwOt53tBtfcMwVKvVkud5d9K5m7rNEmkAAABIl8TLkr148UKtVqtvPV6zDm+hUJh+zwAAAIApSBx4M5mMut3u0N3W2u320KoKAAAAwKKY6MYTrutSLgAAAIClkriGFwAAAFhGBF4AAACkWioDL8uSAQAAwEhl4KXOGAAAAEYqAy8AAABgEHgBAACQaokDbz6fl+M49k5rjuPYBwAAALCoEgfeVqsl3/fluq4qlUrftr29val3DAAAAJiGiUsaoihSqVSSdDU5zPd9e4vhRcGoMwAAAIzEgdcEW3Nr4XK5fGedui1WaQAAAICROPBWq9W+5/v7+wqCQLVaTb7vT71jAAAAwDR8NMnOgyOn2WyW0VQAAAAsNJYlAwAAQKqNHeGddOIXI70AAABYRIzwAgAAINXGBt44jvse9XpdktRut4faOp3ObHqbEMuSAQAAwEg8wttsNuV5nrLZrG0rFovyPE/Pnj2b+MSO4ygMQ/s8CAJ757bBG1uYu7z13untOpRXAAAAwJjoTmutVmvstkk0Go2+51EUKZfL2ZHjk5MTG4YrlYoKhYLiOFa73dbBwcFE5wIAAMD9ljjwep4nqT+sBkGgVqtltyURRZFOT0/71u49Pj625RGSVCgUdHR0JEkqlUoqFouSrpZBq9VqiUZ5AQAAAGmCwPvixQtJ0u7uri0vyOVykq4CalIHBwd6/vx5X9vp6ak2Nzft883NTZ2fnysMw6GbWvi+r8vLy8TnAwAAwP2W+MYTmUxG3W7X3lrYaLfbfXW912k0Gtra2pLrupP1EgAAALihie605rrujSeEhWGo09PToVsUT9Pg6gwXFxd3dq5BURTp/Xsmy2FxfPvNtzO9BjAffOMFTIZr5n5y4hktabC3t6darTbU3m639ebNG62trdlaXVMnvL29rZWVlb6Q7ThOotCddL9p+cM//EP9xnZef3v3/5zZOYFx/t2/+hcq/L1P9E+qvz3vruCOXVxcaG1tbd7dAJYG18zyuk22m9mNJ6rVat+6vr7vq9PpKJvNamdnR81m0+7bbDa1vb0t13Xl+76CIJB0NUmuXC7PqssAAABIgcQlDR+6mcNtRlMzmYwKhYI9R7vdtnW+1WrVtnuep8PDwxufBwAAAPfPRDW80zRYy1ssFm1JwyBuJAEAAICbSlzSMHir4TiO7S2FF+3WwgAAAIBxqxreTCZz41sLAwAAALNwq5KGKIomvq3wLHyo3hgAAAD3x1QmrQ3eDW3e4jgm9AIAAEDSlJYlu8ubSQAAAAC3kXiEl5USAAAAsIwmGuFtNBpyHEeO42hvb++u+gQAAABMTeLA22g0tLu729cWhqEcx1GlUpl6xwAAAIBpSBx4za1/zW2Bpe+XJTs5ObmTzt0UE9YAAABgJA68rVZr7GoMi7Y0GfXGAAAAMBIHXs/zVKvVFEWRbQvDUK1WS57n3UnnAAAAgNtKvErDixcv1Gq1tLKyYttqtZokqVAoTL9nAAAAwBQkDryZTEbdbrcv8EpSu91WNpudescAAACAaZjo1sKu61IfCwAAgKUylTutAQAAAItqosBr1t3tffROYlsULEsGAAAAI3HgDYJAGxsbQ+0rKysKw3Cqnbotyi4AAABgJA68r1+/lnQ1SS2OY8VxrHa7LUl6+fLl3fQOAAAAuKXEgbdWq8nzvL4VGbLZrF2fFwAAAFhETFoDAABAqiUOvL7vq9VqqdFo2LYgCK695TAAAAAwb4kD79OnTyVJu7u7doWGXC7Xt21RsEoDAAAAjMSB19xpbVC321Umk0l0jEajYcNyPp/v2xYEgd1WqVT6tuXz+YmWQWOVBgAAABgT1fCaO631PlzXTfz6zc1N+7qHDx/a8ogoipTL5ey2k5MTu9RZpVJRoVCwq0IcHBxM0mUAAADcczOdtNY7Ery1tWV/Pj4+Vr1et88LhYKOjo4kSaVSScViUdLVqhC1Wm0hb3YBAACAxTS3VRqazaY2NzclSaenp/Zn6Wok+Pz8XGEYDk2I831fl5eXM+0rAAAAltdH122cZPJXkrrZKIq0srIi6ar2d5JyCAAAAOAmrg2802ZqgKWriWiPHz/W/v7+1I4/GNAvLi6mduwPiaJI798zWQ6L49tvvp3pNYD54BsvYDJcM/fTtYF33Kht70itJJXL5YlP/OrVK33++efa39/X+vq6zs7ObI3v2dmZtra2tLq6qlqtpmq1al83+Hxcfx3H0dra2sT9uql3797pwQOWQ8Pi+PiTj2d6DWB++D0Dk+GauX8mruFtNBp9YbfT6SQepQ2CwP58fHysx48fS5J2dnbUbDbttmazqe3tbbmuK9/37euCILhRuAYAAMD9NVFJw97enmq1miTJ8zwdHh5OdDJzowrpavKZGanNZDIqFAq2JKHdbtv63mq1attvck4AAADcb4kC76gShpvU3l43sa1YLNrlxyZ5HQAAAHCdDwbeRqOh3d1d+7zT6SS+sxoAAAAwb9fW8O7t7dmw63me4jgm7AIAAGCpXDvCa+p1JanVal27Lu8ilR1Msn4wAAAA0m1ud1q7S4sUvgEAADBfN1qHFwAAAFgWqRzhBQAAAAwCLwAAAFKNwAsAAIBUS2XgZZUGAAAAGKkMvEy2AwAAgJHKwAsAAAAYBF4AAACkGoEXAAAAqUbgBQAAQKoReAEAAJBqqQy8LEsGAAAAI5WBl2XJAAAAYKQy8AIAAAAGgRcAAACpRuAFAABAqhF4AQAAkGqpDLys0gAAAABDXXuIAAAP2UlEQVRjpoE3CAI5jmMf47ZVKpW+bfl83m6LouiD52GVBgAAABgzDbxff/214jhWHMeq1+s22EZRpFwuZ7ednJwoDENJUqVSUaFQUBzHarfbOjg4mGWXAQAAsORmGniLxaL9eXNzU+fn55Kk4+Nj1et1u61QKOjo6EiSVCqV7Ouy2axqtVqiUV4AAABAmmMN7+XlpdbX1yVJp6en2tzctNtMGA7DUL7v973O931dXl7OtK8AAABYXh/N46S9JQwAAADAXZr5CG8QBPr8888JuwAAAJiJmY7wNhoNXVxc6PDwsK99fX1dZ2dnymQykqSzszNtbW1pdXVVtVpN1WrV7jv4vNfgyg8XFxdTfgfjRVGk9+8J8Vgc337z7UyvAcwHJV7AZLhm7qeZBt5mszkUdiVpZ2dHz549s5PTms2mXr16Jdd15fu+giBQNptVEAQql8tjj987auw4jtbW1qb/JsZ49+6dHjxg/V8sjo8/+Xim1wDmh98zMBmumftnZoE3iiK1Wq2hUdhut6tMJqNCoWC3tdttua4rSapWq7bd87yRgRkAAAAYZ2aB13Xda+t2i8Vi37Jlvaj3BQAAwE2l8tbCAAAAgEHgBQAAQKqlMvAO1gkDAADg/kpl4KXmFwAAAEYqAy8AAABgEHgBAACQagReAAAApBqBFwAAAKlG4AUAAECqpTLwsiwZAAAAjFQGXpYlAwAAgJHKwAsAAAAYBF4AAACkGoEXAAAAqUbgBQAAQKqlMvCySgMAAACMVAZeVmkAAACAkcrACwAAABgEXgAAAKQagRcAAACpRuAFAABAqhF4AQAAkGqpDLwsSwYAAABjLoF3b29PlUqlry0IAjmOI8dxhrbl83m7LYqiDx6fZckAAABgzDTwmlA7KIoi5XI5xXGsOI51cnKiMAwlSZVKRYVCQXEcq91u6+DgYJZdBgAAwJKbaeDNZrOK41hbW1t97cfHx6rX6/Z5oVDQ0dGRJKlUKqlYLNrX12q1RKO8AAAAgLQgNbynp6fa3Ny0zzc3N3V+fq4wDOX7ft++vu/r8vJy1l0EAADAkvpo3h0AAAD3y+/+7u/qxYsXczn3X/3VX+lnf/Zn53JufNiPfvQj/ehHP5r6cVMVeAfrgy8uLmZ27iiK9P49k+WwOL795tuZXgOYD77xwjL6gz/4A/3FX/yFnj17Nu+uYIE0m039/u//vn7zN39z6sdeiMC7vr6us7MzZTIZSdLZ2Zm2tra0urqqWq2marVq9x183qt3dQbHcbS2tna3He/x7t07PXjAcmhYHB9/8vFMrwHMD79nLJtf/MVf1Keffqp8Pj/vrmCB/N7v/Z7iOL6T/09biBrenZ0dNZtN+7zZbGp7e1uu68r3fQVBIOlqlYdyuTyvbgIAAOAO/fVf/7W++eYbffPNN1M97kKM8GYyGRUKBVuS0G635bquJKlardp2z/N0eHg4t34CAADg7vzZn/2Z/uiP/kiS9Ku/+qtTO+5cAq9ZZmywbVS7xI0kAAAAcHMLUdIAAAAA3JVUBt5Rd3MDAADA/ZTKwEsJBAAA6fD+fazvpvgYp1KpjFw1Ip/Pz+wOr5VKxU7Un6VGo6FGozHz887SQkxaA3D//NZv/Zb+txf/x7y7kQKxJL7Vuq0HjvT//O6/1C//8i/PuysY8N/99v+t/7/776d2vOMv/lv9V6t/e+S2VqulRqMxdk4RlheBF8Bc/If/+B/1c7+c1w//m78/764A+ub/eq7vvvtu3t3AnLXbbeVyObs0KtIjlSUNAJbEz/xAzs9+zIPH/B8PfmbeVwMWRLvd1sHBwdjtjuPYR6VSGbstDENJw2UKg8/N/oPlFI1GY+x5Ru2zt7dnj9+7v+mLKVvI5/P2NeNKNfb29kb2yxyjt0+j+jB4jHmUaQwi8AIAAPxn2WxWkkaGtHw+r3a7rTiOFcexzs/Pbe1rPp9Xt9u125LcNrn3eK9evVKpVJIkRVGkZrNpj7W/vz/02iAIdHFxYffZ2tpSEATa39/X+fm5wjBUpVJRu922d7Ld3d3Vq1evFMex6vX6yGBfqVS0vr5uj1soFPqC7O7uru3TuD4EQdB3DPOZzhOBFwAAoMfz58+Vy+X62sxoaG94e/r0qU5PTxVFkVqtllZWVuyoZqvVunay2+DxXNe1d5M15RS9QXPQmzdvVCqV7Pl2d3f15s0b2/+NjY2h/tbrdXvsYrGoWq02dNyTkxP9+Mc/ts8H96vX6x/sw2effaZSqbRQE+FSGXhZlgwAANyU67qq1+tqNBp6+PDhtfuur69LurobrBnRNI8P1QFfd+zDw0M9ffr02pKG3tHmcSPB1/E879b7jeqD67p2xSxKGu4Qy5IBAIDbKBaL2t3d1du3byV9P+raG95evnypR48ejdxmrK2t2ZFXSbZswXVd1Wo1W+sbRZHdZmQyGXW7XZ2cnAwd99GjR/ryyy9H9v3g4ECdTseWNhjNZtP+XKlU9Pjx46HXPn78WF999ZV93mg0Ru73oT5IV59hu93ue//zwioNAAAAI5hVG4zDw8O+b5Hr9botGXj16pVWVlbsNt/3Va1WVSwW5TiODbOmbEGSOp2OLT3wPM9ui6Ko71idTmeob9lsVm/evOnrT6fT0cuXL7W+vq5MJqPnz59rZWXFvv7x48d2f8/zdHh4OHTc/f19O+Gs932MMq4Pl5eXfZ/bIgxEEngBAMC9N6ocIJvNDoW1ceGt92v8QePaM5nMxK/ptb+/P9Tv3nDa26ezszOtra2NPO7gusPVanVkyB21PvGoPlz3vuaFwAsAABbW3/+Vv6vuT/9yasf7xY9/MLVjYXkQeAEAwML6nx//l/PuAlIglYGXVRoAAAC+d99vl8wqDQAAAEi1VAZeAAAAwCDwAgAAINUIvAAAAEg1Ai8AAABSLZWrNAAAkDZhGOov/3J669HO0x//8R/r5OTE3rL2/fv3Mzt3HMes5jQlDx5Md9z0T/7kT7S9vT3VYxqpDLz8QwYApM32f+/pL/UDPfho+W+cEL//Tn/zMz+vf/3//RtJ0vu/+RvFmlHofS++376l+Lvv9Ld+xtE//q1/NPVjf/rpp1M/prQkgTefz6vVakmSut2uXNe9dn/+egMApM1372P9/JN/qI/+i9V5d2Xq/vrP/q3iv/mreXcDCX330670//5z/fqv//q8u5LYwgfeSqWiQqGgw8NDBUGgg4ODkfd3BgAAy8n5wd+SM+Wvx3F33v/g56QHjn7hF35h3l1JbOEDb6lUsjeSyGazyuVyev78+QdHeQEAwHJI46h1ujnSRz/QL/3SL827I4kt9J9TYRjK9/2+Nt/3dXl5OaceAQAAYNksdOAFAAAAbmvhSxomMThRbR4T1/78f8/P/JzAKP80kP5pbfHr3f/iX/7OvLsASJJ+7dd+bd5d+LB/9j/OuweAtUwLBDixKZBdQFEUaWVlRb1ddBxHC9xlTAG/YyA5rhdgMlwz99NClzS4rivf9xUEgSQpCAKVy+U59woAAADLZKFHeA0zZO55ng4PD+fcG9w1/voGkuN6ASbDNXM/LUUNL/8wAQAAcFNLMcILAAAA3NRC1/ACAAAAt0XgBQAAQKoReAEAAJBqBF7MTRAEchzHPhqNhqSrW0r3tptHpVKZc4+B+apUKmOvicHrxiznCKSd+W9JFEVD28x1EYZhX3ulUtHe3t7I43EtpROBF3NVLpcVx7HiOFaz2VQYhspkMrbN8zx1u13Fcaz9/f15dxeYu3a7ba8Pc00EQaCNjQ3bHsex3rx5M+eeArP11VdfDbUdHR2N3Pfk5ESShkIy11J6EXixMB4+fDjvLgBLKZfLDS3fyB+IuE/K5bJKpdJQ+8nJiXzf72sLw1CPHz/W1taWjo+P+7ZxLaUXgRcLIYoivX37VplMZt5dAZYKd6AErpTL5b7yg0ajoUKhMLTf0dGRHj16pO3tbTWbTdvOtZRuBF7MValUkuM4WllZ0RdffDHv7gALL5fLDdUWrq2tzblXwPzt7Ozo9evX9nmz2VSxWBzar1QqKZvNynVdPXz4sK++l2spvQi8mKveGt43b97YiWsARuut4c1ms5Kki4uLOfcKmD/zDWEYhgqCQI8fPx7aZ3AU98mTJ311vlxL6UXgxcJ49OgR/2cDTOizzz4bWbsI3EcmwL5+/Vo7OztD21+/fm2/WXQcR7lczl4/XEvpRuDFwnjz5g1fJwETcl1X5XJZ+Xy+r51l/HAfZbNZG1oH54REUaRarda3AkMcx/J9X0EQcC2lHIEXc9X7l7akkfVWAK63v7+vQqHQt3boqNEt4D6o1+t68uTJUPvx8fHISWlPnjyxtb9cS+nlxIPrbwAAAAApwggvAAAAUo3ACwAAgFQj8AIAACDVCLwAAABINQIvAAAAUo3ACwAAgFQj8AIAACDVCLwAAABINQIvAAAAUo3ACwAAgFQj8ALAAgnDUI7jyHEcBUFw6+Pt7e1N7VgAsKwIvACQgAmO1z2iKJp3N/tEUaRarSZJev369Zx7AwDzQ+AFgJRyXVe+70uSnjx5MufeAMD8EHgBIIFqtao4jhXHscrlsm03bXEcy3XdOfZwNNPvbDY7764AwNwQeAFgynrrcB3HUT6fH9onCIJEJRG9pRSNRmOoPZ/PD52v9zimrVKp2LYoivr27+2LOUelUrFto/ochqFtbzQafcfrPRcALAICLwBMURAE2tjY6GtrtVp9obdSqSiXy33wWLlcztbgStLu7m5f0DTHHjzfwcHB2GOGYaiVlZWh89xUpVLR7u5uX1upVCL0AlgoBF4AmKIvv/xSklSv122pg+d5arVaCoJAURSpVCpJknzft/u02+2hY5XLZcVxrE6nY9vOzs6G9ut0Oorj2Nbr9obkQS9fvrQ/d7vdsedOove9mD50u11JV6F30SbxAbi/Ppp3BwAgLaIoUqvVknQ1Gjs48vn111/3PX/+/Ln92dTYXl5e2rZHjx5JkjKZzNhzep5nt29tbfX1ZVRN8du3byVdhWmz/ab1vT/5yU/sz4OjzNLVe1nEumYA9w8jvAAAAEg1Ai8ATEnvaGZvSYN5FItFra6u2n16a21NucNde/jwoSTZUgRJfZPhjLW1NfuzqRt+8+ZN3z6978WUNPQ+rhuZBoBZIvACwBTV63VJVyUNo1ZqyGQyfbW2ZvttJo5Nonc9XnPuwdILSdrc3LQ/b2xsyHGcvpAs9b8Xsw8rNQBYRAReAJiiYrH4wUlg1WrVBuNes6h3zWazQ/3rnRRnZDKZvj76vj/yfVWr1b51iQFgETlxHMfz7gQAYH6iKLJLldXrdRWLxTn3CACmixFeAAAApBqBFwAAAKlG4AUAAECqUcMLAACAVGOEFwAAAKlG4AUAAECqEXgBAACQagReAAAApBqBFwAAAKlG4AUAAECq/Sd1ZwywbjzYtwAAAABJRU5ErkJggg==\"></img>"
       ]
      },
      "metadata": {},
@@ -1853,7 +1863,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.3.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
       "\r\n"
      ]
     }
@@ -1922,10 +1932,10 @@
    "id": "20a4dde7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:50:08.539141Z",
-     "iopub.status.busy": "2026-07-03T23:50:08.538962Z",
-     "iopub.status.idle": "2026-07-03T23:50:08.571366Z",
-     "shell.execute_reply": "2026-07-03T23:50:08.571192Z"
+     "iopub.execute_input": "2026-07-21T17:34:32.319867Z",
+     "iopub.status.busy": "2026-07-21T17:34:32.319646Z",
+     "iopub.status.idle": "2026-07-21T17:34:32.357851Z",
+     "shell.execute_reply": "2026-07-21T17:34:32.357630Z"
     }
    },
    "outputs": [
@@ -1974,10 +1984,10 @@
    "id": "499cdcf2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:50:08.572531Z",
-     "iopub.status.busy": "2026-07-03T23:50:08.572342Z",
-     "iopub.status.idle": "2026-07-03T23:50:08.603823Z",
-     "shell.execute_reply": "2026-07-03T23:50:08.603638Z"
+     "iopub.execute_input": "2026-07-21T17:34:32.359473Z",
+     "iopub.status.busy": "2026-07-21T17:34:32.359265Z",
+     "iopub.status.idle": "2026-07-21T17:34:32.397364Z",
+     "shell.execute_reply": "2026-07-21T17:34:32.397128Z"
     }
    },
    "outputs": [
@@ -2024,10 +2034,10 @@
    "id": "7733d74e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:50:08.605169Z",
-     "iopub.status.busy": "2026-07-03T23:50:08.604838Z",
-     "iopub.status.idle": "2026-07-03T23:50:08.637857Z",
-     "shell.execute_reply": "2026-07-03T23:50:08.637674Z"
+     "iopub.execute_input": "2026-07-21T17:34:32.399166Z",
+     "iopub.status.busy": "2026-07-21T17:34:32.398887Z",
+     "iopub.status.idle": "2026-07-21T17:34:32.441138Z",
+     "shell.execute_reply": "2026-07-21T17:34:32.440842Z"
     }
    },
    "outputs": [
@@ -2121,7 +2131,7 @@
    "mimetype": "text/x-csharp",
    "name": "C#",
    "pygments_lexer": "csharp",
-   "version": "12.0"
+   "version": "13.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary

Fixes the **degenerate 8-Reines comparison** in CSP-2 (BT vs FC vs MAC). The diagonal constraint was an inert placeholder + dead code, so `nqConstraints` held ONLY `diffRows`. The CSP collapsed into a permutation (8! solutions), the identity permutation was immediately valid, and **MAC = FC = 8 nodes** (the AC-3 cascade never triggered) — defeating the pedagogical goal that MAC > FC > BT.

| | Before (degenerate) | After (fixed) |
|---|---|---|
| BT (no propagation) | 36 | **876** |
| FC (forward check) | 8 | **75** |
| MAC (AC-3 complet) | 8 | **20** |

MAC now genuinely dominates (cascade AC-3 prunes dramatically). The propagation lever visibly matters.

## The 4 bugs (per issue) — all resolved

**Bug 1 (CONFIRMED) — diagonal constraint missing** (cell[8] `f47c5c6a`): FIXED. `noDiag = => true` (inert placeholder) + `diffRowsAndDiag` (dead code, never added to `nqConstraints`, and just `v != w` anyway) replaced with a **per-pair closure capturing column indices i,j** (the `BinaryConstraint` delegate receives only values, not indices — hence the closure). Constraint now checks `v != w && |i-j| != |v-w|` (rows AND diagonals). Removed the now-dead `diffRows`.

**Bug 3 (CONFIRMED via re-exec) — `KeyNotFoundException` in AC3/BacktrackingMAC** (cell[35] `99752c32`): FIXED. `subCSP` filtered `Neighbors` dict KEYS to unassigned vars but not the neighbor LISTS, so AC3's re-enqueue (`csp.Neighbors[xi]` for an assigned `xi` that made it into the queue) raised `KeyNotFoundException` when real constraints were active. This was **latent** — invisible on the degenerate CSP (AC3 triggered no useful revision, so the bad queue path was never reached).

Filtering is wrong on both counts: it crashed AND starved MAC of propagation from the just-assigned variable (which would weaken MAC below FC). Fix = **full neighbor graph** (textbook Mackworth MAC): `new CSP(macDomains, csp.Neighbors, csp.Constraints)` — `macDomains` holds all variables (assigned ones forced to single value), so every `csp.Neighbors[xi]` resolves.

**Bug 2 (CONFIRMED) — false interpretation cell[41]** (`6adf1701`): AUTO-RESOLVED. The "MAC explore le moins de noeuds / FC entre les deux" claim was false **only because** the outputs were degenerate (MAC=FC=8). With the fix, MAC=20 < FC=75 < BT=876 — the existing interpretation is now factually correct. No markdown edit needed.

**Bug 4 (SUSPECTED) — FC still identity permutation after Bug 1 fix**: DEBUNKED — a testing artifact. The issue author used `notebook_tools.py execute`, which validates in-memory and does **not** persist inplace (known tool behavior), so the fix appeared inert. Re-exec via `nbconvert --execute --inplace` shows FC now produces a real valid solution `Q0->0 Q1->4 Q2->7 Q3->5 Q4->2 Q5->6 Q6->1 Q7->3` (not the identity permutation).

## Validation (H.1 / C.2)

- Re-executed the whole notebook (`jupyter nbconvert --to notebook --execute --inplace`, kernel `.net-csharp`, dotnet-interactive, timeout 300s): **0 errors**, deterministic.
- cell[32] FC output: real valid solution (not identity permutation).
- cell[36] MAC output: 20 nodes explored (was 8).
- cell[38] comparison: BT=876, FC=75, MAC=20.
- cell[40] chart: BT=876, FC=75, MAC=20.

## Prong-B verdict (#3801)

**SOTA-OK.** The solver now runs on a **discriminating** problem where the propagation lever (AC-3 cascade) visibly changes the node count (876 vs 75 vs 20). No workaround, no trivial baseline equivalence. Real `BinaryConstraint` closures + textbook AC-3/MAC (Mackworth 1977).

## C.3 surgical

Cells 1, 22 restored byte-identical to origin (kernel cache-buster HTML `$CACHE_BUSTER$` + SkiaSharp extension-loading log with a `.nuget` path — run-to-run noise; the Australia 7-variable AC-3 demo in cell[22] is unaffected by the 8-Queens fix). Only **3 source + 4 output cells** legitimately changed. `execution_count` unchanged across all cells (no ec churn — same cell order).

Grain: DEEP/search-csp. Closes #7721. See #3801.
