### PR TITLE
fix(sudoku,#3801): Sudoku-18 stale-benchmark-numbers honesty sweep (7 md cells)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb
@@ -464,12 +464,12 @@
    "source": [
     "### Interpretation : Solveur Backtracking simple\n",
     "\n",
-    "**résultat** : Le backtracking simple resout le puzzle de test en 201 appels recursifs et 1.22 ms.\n",
+    "**résultat** : Le backtracking simple resout le puzzle de test en 201 appels recursifs et 0.82 ms.\n",
     "\n",
     "| Metrique | Valeur | Contexte |\n",
     "|----------|--------|----------|\n",
     "| Appels recursifs | 201 | Nombre d'entrees dans `_backtrack` |\n",
-    "| Temps | 1.22 ms | Rapide pour ce puzzle facile |\n",
+    "| Temps | 0.82 ms | Rapide pour ce puzzle facile |\n",
     "| résultat | Succes | Solution trouvee |\n",
     "\n",
     "**Analyse** :\n",
@@ -480,7 +480,7 @@
     "\n",
     "3. **rôle de baseline** : Ce solveur sert de reference pour mesurer l'impact des ameliorations. Toute optimisation (MRV, propagation, etc.) sera comparee a cette baseline.\n",
     "\n",
-    "> **Comparaison a venir** : Le solveur MRV suivant fera seulement 50 appels sur ce même puzzle -- déjà 4x moins. La différence sera beaucoup plus marquee sur les puzzles Medium et Hard."
+    "> **Comparaison a venir** : Le solveur MRV suivant fera seulement 50 appels sur ce même puzzle -- déjà 4x moins. La différence sera beaucoup plus marquee sur les puzzles Medium et Hard.\n"
    ]
   },
   {
@@ -734,7 +734,7 @@
     "| Metrique | Backtracking simple | BT + MRV | Amelioration |\n",
     "|----------|--------------------|---------|-------------|\n",
     "| Appels recursifs | 201 | 50 | **4x moins** |\n",
-    "| Temps | 1.22 ms | 2.62 ms | Plus lent |\n",
+    "| Temps | 0.82 ms | 2.62 ms | Plus lent |\n",
     "\n",
     "**Paradoxe apparent** : MRV fait moins d'appels mais prend plus de temps. Cela s'explique par le cout de l'heuristique :\n",
     "\n",
@@ -746,7 +746,7 @@
     "2. Sur les puzzles difficiles, MRV reduit l'arbre de recherche de plusieurs ordres de grandeur\n",
     "3. Le surcout par appel est constant, mais le nombre d'appels evites croit exponentiellement avec la difficulte\n",
     "\n",
-    "> **Principe MRV** : Toujours choisir la variable la plus contrainte (\"fail-first\"). En traitant d'abord les cases avec peu de candidats, on detecte les impasses plus tot et on evite d'explorer des sous-arbres inutiles."
+    "> **Principe MRV** : Toujours choisir la variable la plus contrainte (\"fail-first\"). En traitant d'abord les cases avec peu de candidats, on detecte les impasses plus tot et on evite d'explorer des sous-arbres inutiles.\n"
    ]
   },
   {
@@ -908,12 +908,12 @@
    "source": [
     "### Interpretation : Solveur Norvig (propagation de contraintes)\n",
     "\n",
-    "**résultat** : Norvig resout le puzzle en **1 appel récursif** et 2.34 ms.\n",
+    "**résultat** : Norvig resout le puzzle en **1 appel récursif** et 3.81 ms.\n",
     "\n",
     "| Metrique | Valeur | Observation |\n",
     "|----------|--------|-------------|\n",
     "| Appels recursifs | 1 | Aucune recherche necessaire |\n",
-    "| Temps | 2.34 ms | Le plus rapide sur ce puzzle |\n",
+    "| Temps | 3.81 ms | Le plus lent sur ce puzzle facile (l'initialisation des structures domine) |\n",
     "\n",
     "**Pourquoi un seul appel ?**\n",
     "\n",
@@ -926,7 +926,7 @@
     "\n",
     "**Comparaison avec le backtracking** : Le solveur simple a necessite 201 appels recursifs pour le même puzzle. Norvig atteint la même solution en un seul appel grace a la propagation qui elimine les branches inutiles avant même de les explorer.\n",
     "\n",
-    "> **Point cle** : La force de Norvig n'est pas la vitesse pure, mais la capacite a resoudre sans recherche. Sur des puzzles plus difficiles, le backtracking MRV prend le relais avec un espace de recherche déjà drastiquement reduit."
+    "> **Point cle** : La force de Norvig n'est pas la vitesse pure sur un cas trivial -- sur ce puzzle facile, l'initialisation des structures de propagation (Squares/Units/Peers) coute plus cher que la recherche elle-même, d'où un temps supérieur au backtracking brut (0.82 ms). Cet investissement est rentabilisé dès que le puzzle résiste : sur le benchmark complet (cellule suivante), Norvig devient le plus rapide sur Medium/Hard/Expert (1.80 a 2.62 ms) la où le backtracking simple explose. La vraie force de Norvig est la capacite a resoudre sans recherche, pas la vitesse pure.\n"
    ]
   },
   {
@@ -1023,22 +1023,22 @@
    "source": [
     "### Interpretation : Solveur OR-Tools CP-SAT\n",
     "\n",
-    "**résultat** : OR-Tools resout le puzzle en 63.21 ms avec succes.\n",
+    "**résultat** : OR-Tools resout le puzzle en 253.78 ms avec succes.\n",
     "\n",
     "| Metrique | Valeur | Observation |\n",
     "|----------|--------|-------------|\n",
-    "| Temps | 63.21 ms | Plus lent que Norvig (2.34 ms) sur ce puzzle |\n",
+    "| Temps | 253.78 ms | Plus lent que Norvig (3.81 ms) sur ce puzzle |\n",
     "| Appels | 1 | Le solveur gere tout en interne |\n",
     "\n",
     "**Analyse** :\n",
     "\n",
-    "1. **Overhead de modelisation** : Le temps inclut la construction du modèle (81 variables, 27 contraintes AllDifferent) et l'initialisation du solveur. Pour un seul puzzle, cet overhead est significatif.\n",
+    "1. **Overhead de modelisation** : Le temps inclut la construction du modèle (81 variables, 27 contraintes AllDifferent) et l'initialisation du solveur. Pour un seul puzzle, cet overhead est significatif et explique l'écart important avec les solveurs maison.\n",
     "\n",
     "2. **Avantage sur les grands problemes** : Contrairement aux solveurs Python purs, OR-Tools est compile en C++ et optimise pour des problemes avec des milliers de variables. Le temps de resolution reste quasi-constant quelle que soit la difficulte du puzzle.\n",
     "\n",
     "3. **Declaratif vs imperatif** : Le code ne contient **aucune logique de recherche** -- on declare les contraintes et le solveur trouve la solution. C'est l'approche la plus concise (~15 lignes utiles).\n",
     "\n",
-    "> **Quand utiliser OR-Tools** : Quand la robustesse et la previsibilite sont plus importantes que la vitesse brute, ou quand le problème est trop complexe pour un solveur maison."
+    "> **Quand utiliser OR-Tools** : Quand la robustesse et la previsibilite sont plus importantes que la vitesse brute, ou quand le problème est trop complexe pour un solveur maison.\n"
    ]
   },
   {
@@ -1505,7 +1505,7 @@
     "\n",
     "Affichons les résultats sous forme de tableau synthetique, puis sous forme graphique.\n",
     "\n",
-    "> **Note** : Le benchmark utilise 1 puzzle par niveau de difficulte avec un timeout de 30s par puzzle pour garantir une exécution rapide tout en montrant les différences de performance entre solveurs."
+    "> **Note** : Le benchmark utilise 1 puzzle par niveau de difficulte avec un timeout de 10s par puzzle pour garantir une exécution rapide tout en montrant les différences de performance entre solveurs.\n"
    ]
   },
   {
@@ -1695,17 +1695,26 @@
    "source": [
     "### Interpretation : résultats du benchmark\n",
     "\n",
+    "Le benchmark couvre **4 niveaux de difficulté** (Easy / Medium / Hard / Expert), un puzzle par niveau, timeout 10 s.\n",
+    "\n",
     "**résultats cles du tableau** :\n",
     "\n",
-    "1. **Backtracking simple** echoue sur le puzzle Medium (timeout : 58770 ms) mais resout Easy (1.87 ms) et Hard (1862 ms) -- 2/3 resolus. Sans heuristique, l'arbre de recherche explose quand le nombre de cases vides depasse ~60.\n",
+    "1. **Backtracking simple** echoue sur le puzzle **Medium** (3829.84 ms, le seul échec du benchmark) mais resout Easy (0.66 ms), Hard (226.62 ms) et Expert (72.25 ms) -- **3/4 resolus**. Sans heuristique, l'arbre de recherche explose sur les puzzles a forte contrainte comme le Medium.\n",
     "\n",
-    "2. **BT + MRV** resout les 3 puzzles (3/3), y compris le Medium en 37.58 ms la ou le backtracking simple explose. L'heuristique MRV aide enormement, mais reste plus lent que la propagation (313 ms sur le puzzle Hard).\n",
+    "2. **BT + MRV** resout les **4 puzzles (4/4)**, y compris le Medium en 16.71 ms la ou le backtracking simple explose. L'heuristique MRV aide enormement ; le puzzle Hard reste le plus lent de sa série (104.28 ms).\n",
     "\n",
-    "3. **Norvig** est le champion absolu : 3/3 resolus, avec un temps moyen global de 3.25 ms/puzzle. La propagation de contraintes elimine la quasi-totalite de l'exploration.\n",
+    "3. **Norvig** est le champion absolu : **4/4 resolus**, temps moyen global de **2.20 ms/puzzle**. La propagation de contraintes elimine la quasi-totalite de l'exploration (1.80 ms sur Hard, 2.15 ms sur Expert).\n",
     "\n",
-    "4. **OR-Tools CP-SAT** est également 3/3 fiable a ~22 ms/puzzle (21.65). Legerement plus lent que Norvig sur ce problème en raison de l'overhead de construction du modèle, mais plus robuste a la mise a l'echelle.\n",
+    "4. **OR-Tools CP-SAT** est également **4/4 fiable** a **17.68 ms/puzzle** en moyenne. Legerement plus lent que Norvig sur ces petits puzzles en raison de l'overhead de construction du modèle, mais plus robuste a la mise a l'echelle.\n",
     "\n",
-    "**Surprise** : Les puzzles Hard ne sont pas les plus lents pour le backtracking simple. Cela s'explique par le fait que la difficulte humaine (nombre de techniques logiques necessaires) ne correspond pas toujours a la difficulte algorithmique (taille de l'arbre de recherche)."
+    "--- Temps moyen global (toutes difficultes confondues) ---\n",
+    "\n",
+    "  Backtracking      :  1032.34 ms/puzzle, 3/4 resolus\n",
+    "  BT + MRV          :    32.82 ms/puzzle, 4/4 resolus\n",
+    "  Norvig            :     2.20 ms/puzzle, 4/4 resolus\n",
+    "  OR-Tools CP-SAT   :    17.68 ms/puzzle, 4/4 resolus\n",
+    "\n",
+    "**Surprise** : le puzzle **Medium** (et non le Hard) est le plus lent pour le backtracking simple (3829.84 ms, seul échec). Cela s'explique par le fait que la difficulte humaine (nombre de techniques logiques necessaires) ne correspond pas toujours a la difficulte algorithmique (taille de l'arbre de recherche) : un puzzle jugé \"moyen\" pour un humain peut exiger une exploration arborescente massive pour un solveur naif.\n"
    ]
   },
   {
@@ -2336,24 +2345,24 @@
    "source": [
     "### Analyse : le solveur Norvig + FC est-il competitif ?\n",
     "\n",
-    "**Reponse courte** : oui, il est competitif avec Norvig standard, mais il n'apporte pas de gain significatif sur ce benchmark.\n",
+    "**Reponse courte** : sur ce puzzle, Norvig + FC ne coupe aucune branche que Norvig pur n'aurait déjà coupée -- le forward check explicite est redondant avec la propagation de Norvig.\n",
     "\n",
     "**résultats obtenus** :\n",
     "\n",
     "| Solveur | Temps (puzzle de test) | Appels recursifs | Coupes FC |\n",
     "|---------|------------------------|------------------|-----------|\n",
-    "| Norvig | 2.34 ms | 1 | - |\n",
-    "| Norvig + FC | 2.39 ms | 1 | 0 |\n",
+    "| Norvig | 3.81 ms | 1 | - |\n",
+    "| Norvig + FC | 1.60 ms | 1 | 0 |\n",
     "\n",
     "**Explications** :\n",
     "\n",
-    "1. **Performances quasi identiques a Norvig**. Sur le puzzle de test, Norvig + FC resout en 2.39 ms (vs 2.34 ms pour Norvig pur), avec 0 coupe FC. Normal : la propagation `_eliminate` déjà presente dans Norvig detecte les domaines vides a la source. Le forward check explicite ne coupe en pratique aucune branche additionnelle (`fc_cuts` = 0).\n",
+    "1. **Forward check sans effet ici**. Le forward check explicite a produit **0 coupe FC** (`fc_cuts` = 0) : aucune branche additionnelle n'a été élagée par rapport a Norvig pur. Les deux solveurs explorent donc exactement le même arbre (1 appel récursif chacun). L'écart de temps mesuré (1.60 ms vs 3.81 ms) reflète la **variance d'exécution sur des temps sub-5 ms** (échauffement JIT, GC, charge machine) plutot qu'un gain algorithmique du forward check -- confirmé par l'absence totale de coupes FC.\n",
     "\n",
-    "2. **Legere surcharge par appel**. Le forward check parcourt les 81 cases a chaque descente récursive, ce qui ajoute un cout lineaire par appel. Sur un puzzle ou peu de branches sont coupees, ce cout n'est pas amorti et on peut même etre un peu plus lent que Norvig standard.\n",
+    "2. **Legere surcharge par appel**. Le forward check parcourt les 81 cases a chaque descente récursive, ce qui ajoute un cout lineaire par appel. Sur un puzzle ou peu de branches sont coupees, ce cout n'est pas amorti.\n",
     "\n",
     "3. **Ou le forward checking brille reellement**. Si on retirait la propagation puissante de Norvig (elimination + naked singles) et qu'on gardait uniquement un backtracking MRV + forward checking, l'impact du FC serait beaucoup plus visible : il servirait de principal mécanisme d'elagage. Ici, la propagation fait déjà l'essentiel du travail.\n",
     "\n",
-    "**Conclusion** : Le forward checking est une **technique fondamentale** en CSP, mais son utilite depend du solveur dans lequel on l'integre. Sur un solveur déjà fortement propage comme Norvig, il est redondant ; sur un backtracking naif, il apporte un gain enorme. C'est un bon exemple du principe **\"la somme des ameliorations n'est pas toujours additive\"** : certaines techniques se recouvrent.\n"
+    "**Conclusion** : Le forward checking est une **technique fondamentale** en CSP, mais son utilite depend du solveur dans lequel on l'integre. Sur un solveur déjà fortement propage comme Norvig, il est redondant (0 coupe FC mesurée) ; sur un backtracking naif, il apporte un gain enorme. C'est un bon exemple du principe **\"la somme des ameliorations n'est pas toujours additive\"** : certaines techniques se recouvrent.\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary

The interpretation markdown in `Sudoku-18-Comparison-Csharp.ipynb` cited benchmark numbers from an **older 3-difficulty run**, contradicting the committed **4-difficulty** (Easy/Medium/Hard/Expert) code outputs of cells 9/14/17/20/34/46. Markdown-only sweep (C.2 exception — no re-exec, no code/output touched).

Two cells had **inverted conclusions** (not just stale numbers); the rest were stale-number swaps.

## The 7 cells

| Cell | ID | Fix |
|------|----|-----|
| 10 | `412a107e` | BT simple 1.22 ms → **0.82 ms** (matches cell[9]) |
| 15 | `0085d323` | BT+MRV comparison table 1.22 ms → 0.82 ms |
| 18 | `811aaf8a` | Norvig 2.34 ms → **3.81 ms** + **DROP "Le plus rapide"** (inverted) |
| 21 | `f929b306` | OR-Tools 63.21 ms → **253.78 ms**; Norvig ref 2.34 → 3.81 |
| 33 | `17767b6e` | timeout "30s" → "10s" (matches cell[32]) |
| 37 | `04ab291e` | benchmark interp **FULL rewrite** with cell[34] real 4-difficulty numbers |
| 56 | `c43989c3` | Norvig+FC 2.34/2.39 → **3.81/1.60 ms** (conclusion kept — see below) |

## The 2 inverted conclusions

**cell[18] Norvig — was wrong, fixed.** Old text: "Norvig resout le puzzle en 2.34 ms ... Le plus rapide sur ce puzzle." Reality (cell[17]): Norvig = 3.81 ms, the **slowest** of the three on Easy (BT 0.82, BT+MRV 2.62, Norvig 3.81). The propagation-structure init (Squares/Units/Peers) dominates on a trivial puzzle. Fixed to "Le plus lent sur ce puzzle facile (l'initialisation des structures domine)" + sharpened the "Point cle" that this init overhead is amortized on Hard (cell[34]: Norvig 1.80 ms on Hard beats all).

**cell[56] Norvig+FC — conclusion was CORRECT, kept; numbers updated.** The sub-agent proposed flipping "quasi identiques" to "~2.4× plus rapide" (Norvig+FC 1.60 vs Norvig 3.81). I rejected that as the **opposite dishonesty**: with **0 FC cuts** (`fc_cuts = 0`), both solveurs explore the **identical search tree** (1 recursive call each) — the 1.60 vs 3.81 ms gap on sub-5ms timings is **execution variance** (JIT/GC/machine load), not an algorithmic speedup. Over-claiming a noise gap as "2.4× faster" would be as misleading as the stale "quasi identiques". The honest framing: same algorithmic work (0 cuts), measured time gap attributed to sub-5ms variance. The "forward check is redundant atop Norvig's propagation" conclusion stands.

## cell[37] — the big one

The benchmark interpretation described a **3-difficulty** run (Easy/Hard/Expert, "2/3 resolus", Norvig 3.25 ms/puzzle, BT+MRV "313 ms sur Hard"). The committed cell[34] output is **4-difficulty**:

| Solveur | Easy | Medium | Hard | Expert | avg | resolus |
|---------|------|--------|------|--------|-----|---------|
| Backtracking | 0.66 | **3829.84 (FAIL)** | 226.62 | 72.25 | 1032.34 | **3/4** |
| BT + MRV | 2.13 | 16.71 | 104.28 | 8.15 | 32.82 | 4/4 |
| Norvig | 2.22 | 2.62 | 1.80 | 2.15 | **2.20** | 4/4 |
| OR-Tools | 7.82 | 31.69 | 15.93 | 15.29 | 17.68 | 4/4 |

**Surprise para updated**: Medium (not Hard) is the slowest for naive backtracking (3829.84 ms, sole failure) — human difficulty ≠ algorithmic difficulty.

## Validation (C.2 exception / C.3 surgical)

- **Markdown-only**: forensic diff vs `origin/main` → exactly **7 markdown cells** changed (10/15/18/21/33/37/56, all IDs verified), **0 code cells**, **0 outputs churn**, **0 execution_count churn**. Notebook remains 68 cells.
- No re-execution needed (no source code or outputs touched). Code outputs of cells 9/14/17/20/34/46 are the ground truth the markdown now reflects.

## Prong-B / honesty verdict

This is a **honesty** fix (interpretation contradicting real outputs), not strictly a Prong-A/B SOTA-tool change. The Sudoku benchmark already uses real solvers on a discriminating problem (cell[34] shows BT genuinely fails Medium while Norvig/MRV succeed) — no degenerate-baseline issue. Scope = report-the-truth.

Grain: MED/sudoku-doc. Self-discovered (no tracker issue — Explore scan of Sudoku family found the systemic gap). See #3801 (notebook-quality epic, honesty axis).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
