### PR TITLE
docs(ml): enrich ML-4 with CV-vs-single-split interpretation

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-4-Evaluation.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-4-Evaluation.ipynb
@@ -1125,6 +1125,23 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4740fbd9",
+   "metadata": {},
+   "source": [
+    "### Lecture de la validation croisée : un estimateur plus honnête qu'un seul découpage\n",
+    "\n",
+    "La sortie ci-dessus mérite une interprétation soigneuse, car elle porte le point pédagogique central de l'évaluation en machine learning. Mettons en regard les deux estimations obtenues sur le **même jeu de test** :\n",
+    "\n",
+    "- **Découpage unique** (cellule précédente, `Evaluate` sur un seul partage train/test) : **R² = 0,941**, **MAE = 0,41**, **RMSE = 2,33**.\n",
+    "- **Validation croisée 5-fold ci-dessus** (chaque modèle entraîné sur 4/5 des données d'entraînement, puis évalué sur le jeu de test) : en moyenne **R² ≈ 0,888**, **MAE ≈ 1,36**, **RMSE ≈ 3,22**, avec une dispersion non négligeable d'un fold à l'autre (R² de 0,878 à 0,894 ; MAE de 1,26 à 1,54).\n",
+    "\n",
+    "L'écart est parlant : le découpage unique était **optimiste** d'environ 5 points de R² (0,94 vs 0,89) et sous-estimait l'erreur d'un facteur d'environ 3 sur le MAE (0,41 vs 1,36). Ce n'est pas que le modèle soit mauvais — il généralise correctement — mais le partage unique est tombé sur une partition favorable : un jeu de test « facile » et un sous-ensemble d'entraînement chanceux. La validation croisée, en moyennant sur cinq partitions distinctes de l'entraînement, lisse cet effet de chance : elle révèle la **performance typique** du modèle (R²≈0,89) **et sa variance** d'un fold à l'autre (le fold à MAE 1,54 correspond à la partition d'entraînement la plus défavorable).\n",
+    "\n",
+    "C'est précisément la leçon : **un seul découpage train/test est un estimateur à haute variance** — il peut atterrir loin de la véritable performance de généralisation, tantôt optimiste, tantôt pessimiste, selon le tirage. La validation croisée ne change pas le modèle ; elle fournit un **estimateur plus fiable** de cette performance, en exposant à la fois la tendance centrale et la dispersion. C'est pourquoi on ne conclut jamais sur la qualité d'un modèle à partir d'un unique `Evaluate`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "9d28d200",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
Grain: MED/notebook-enrichment — lane myia-po-2025:CoursIA — prev: MED/notebook-enrichment (SC-6 #7755)

G-VAR-3 OK : genre **enrichment** consécutif (c.617 SC-6 → c.618 ML-4) MAIS MED substance **genuinely distinct** (statistique d'évaluation CV ≠ patterns de sécurité Solidity) + famille **ML.ML fraîche** (7e famille distincte : Planning→Probas→IIT→SW→Sudoku→SC→ML) + langage **C#/.NET** distinct de Solidity. Litmus LIGHT échoue (interp requiert comprendre biais optimiste du single-split + variance inter-fold + estimateur haute-variance, pas scan-générable) = MED.

## Gap (1 démo CV sans interp markdown)

`MyIA.AI.Notebooks/ML/ML.Net/ML-4-Evaluation.ipynb` (.NET C#, 86 cells). G.1 firsthand (Explore sonnet RANK 1 + self-verify cells 26-28/32-37 via `git show origin/main`, outputs en `text/html` dni-treeview .NET — parsés sur les 5 folds) :

- **Cell 27** (code ec=14, `Evaluate` sur un seul partage train/test) output : **R²=0.941, MAE=0.41, RMSE=2.33** — l'estimation **optimiste**.
- **Cell 35** (code ec=18, CV 5-fold, chaque modèle entraîné sur 4/5 puis évalué sur le **même** jeu de test) output mean : **R²≈0.888, MAE≈1.36, RMSE≈3.22** + variance inter-fold (R² 0.878-0.894, MAE 1.26-1.54, fold 4 le plus difficile).
- **Cell 36** = `## Explicabilité du modèle` — **saute directement SANS interpréter** la chute R² 0.94→0.89 / MAE ×3 / RMSE ×1.4. Le punchline pédagogique central (CV = estimateur honnête, single-split = point estimate haute-variance qui peut atterrir optimiste) est **invisible**.

## What (1 cell markdown FR insérée)

**After cell 35** → nouveau cell 36 (CV interp) :
- **Contraste chiffré** : single-split (cellule précédente, R²=0.941, MAE=0.41, RMSE=2.33) vs CV mean (R²≈0.888, MAE≈1.36, RMSE≈3.22).
- **Diagnostic honnête** : écart de ~5 points R² / ×3 MAE = **optimisme du découpage unique** (partition favorable : test « facile » + entraînement chanceux), **PAS** un défaut du modèle (il généralise correctement).
- **Leçon CV** : la validation croisée ne change pas le modèle, elle donne un **estimateur plus fiable** en exposant la **tendance centrale ET la variance** inter-fold (le fold à MAE 1.54 = partition d'entraînement la plus défavorable). Un seul `Evaluate` = estimateur à haute variance → ne jamais conclure dessus.

## Honnêteté (G.9)

Chaque nombre est **groundé dans les outputs committés** (verified firsthand, .NET Interactive stocke les `RegressionMetrics` en `text/html` dni-treeview tables, parsés sur les 5 folds complets). Ne sur-affirme pas : n'invoque pas « overfitting » (le modèle généralise — seul l'estimateur single-split était favorable). **0 claim fabriquée**. Le découpage unique n'est pas « faux », c'est un estimateur haute-variance qui a atterri optimiste — cadrage honnête.

## Scope (chirurgical, markdown-only)

1 fichier, **+17/−0** pur additif (1 cell insérée, 0 supprimée). **Markdown-only** → règle C.2 exception : pas de re-exec (code cells ec 14/17/18 + outputs `text/html` byte-préservés). **86/86 cells préexistantes byte-identiques** à `origin/main`.

## Validation (H.1 / H.3)

- **nbformat 4.5** `validate` OK ; **87 cells** (was 86).
- **C.1** : 0 `NotImplementedException`/`throw new NotImplemented`/`assert False`/`1/0` (code cells inchangés).
- **Byte-identity** : 86/86 pre-existing cells byte-identiques à origin/main.
- **LF** (0 CRLF) ; **catalogue byte-identique** (non dans le diff).
- **Round-trip JSON** : format standard `indent=1 + \n` validé byte-identical avant édition.

## Variation (R6 / G-VAR-3)

c.614 MED/notebook-python (Planners-11 #7728) · c.615a MED/notebook-enrichment (Probas Infer-2 #7737) · c.615b MED/fix (IIT-2 #7748) · c.616 MED/fix (SW-13 #7751) · c.616b LIGHT/fix (Sudoku-17 #7752) · c.617 MED/notebook-enrichment (SmartContracts SC-6 #7755) · **c.618 MED/notebook-enrichment (ML.ML ML-4)**. **7e famille distincte**. Genre enrichment consécutif (c.617→c.618) autorisé : MED chacun, substance genuinely distinct (sécurité Solidity ≠ statistique CV), litmus LIGHT échoue (R6/G-VAR-3 honored).

See #3801 (SOTA/Prong-A honesty axis — le notebook exécute le vrai `Microsoft.ML.Regression.CrossValidate` ; cet enrichissement rend compte pédagogiquement de ces outputs CV réels, pas de workaround).

Generated with Claude Code
