### PR TITLE
feat(translation,#6949): WRONG_SCRIPT verdict in check_translation_sync (#7714)

### DIFF
--- a/scripts/tests/test_check_translation_sync.py
+++ b/scripts/tests/test_check_translation_sync.py
@@ -1,0 +1,164 @@
+"""Regression suite for ``scripts/translation/check_translation_sync.py`` (c.734, #6949).
+
+Background. ``check_translation_sync.py`` (notre T2 de l EPIC #6949) detectait
+4 classes de drift (IN_SYNC / SRC_DRIFT / TRAD_DRIFT / MISSING_LANG / ORPHAN_ROW)
+mais manquait la 3e des 5 classes Argumentum : **WRONG_SCRIPT** -- un contenu
+``text_<lang>`` depose pour une langue non-Latine (ar/fa/zh/ru) sans AUCUN
+caractere du script Unicode attendu (typiquement un copier-coller de FR ou d EN
+dans la mauvaise colonne). C.734 ajoute le verdict ``WRONG_SCRIPT`` via la
+detection deterministe ``_has_expected_script`` (plages Unicode UCD).
+
+Cette suite couvre :
+
+  * ``_has_expected_script`` (unite) : chaque langue non-Latine OK/WRONG,
+    ASCII-seul = WRONG, langues Latines (en/es/pt) jamais WRONG, texte vide = OK.
+  * ``check_csv`` (integration) : un CSV synthetique avec ``text_zh="bonjour"``
+    produit un verdict ``WRONG_SCRIPT`` ; avec ``text_zh="你好"`` -> aucun.
+
+G.9 non-vacuous : contre le ``check_translation_sync.py`` d origin/main (sans le
+verdict WRONG_SCRIPT ni la fonction ``_has_expected_script``), les tests
+d import et de detection FAIL (ImportError sur ``_has_expected_script`` /
+aucune anomalie WRONG_SCRIPT remontee), donc la suite garde le fix.
+
+Run: ``python -m pytest scripts/tests/test_check_translation_sync.py -q``
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts" / "translation"))
+
+import check_translation_sync as C  # noqa: E402
+
+
+def test_arabic_text_has_arabic_script():
+    assert C._has_expected_script("ar", "مرحبا بكم") is True
+
+
+def test_chinese_text_has_cjk_script():
+    assert C._has_expected_script("zh", "你好世界") is True
+
+
+def test_russian_text_has_cyrillic_script():
+    assert C._has_expected_script("ru", "Привет мир") is True
+
+
+def test_persian_text_has_arabic_script():
+    assert C._has_expected_script("fa", "سلام دنیا") is True
+
+
+def test_non_latin_text_with_ascii_payload_still_ok():
+    assert C._has_expected_script("zh", "你好 world 123") is True
+    assert C._has_expected_script("ar", "code: print(x) مرحبا") is True
+
+
+def test_zh_latin_only_is_wrong_script():
+    assert C._has_expected_script("zh", "bonjour") is False
+
+
+def test_ar_latin_only_is_wrong_script():
+    assert C._has_expected_script("ar", "bonjour") is False
+
+
+def test_ru_latin_only_is_wrong_script():
+    assert C._has_expected_script("ru", "bonjour") is False
+
+
+def test_fa_latin_only_is_wrong_script():
+    assert C._has_expected_script("fa", "bonjour") is False
+
+
+def test_ascii_only_payload_is_wrong_script():
+    assert C._has_expected_script("zh", "123 hello **bold**") is False
+
+
+def test_markdown_wrapped_latin_is_wrong_script():
+    assert C._has_expected_script("zh", "# Titre\n\n- item\n- item") is False
+
+
+def test_latin_langs_never_wrong_script():
+    for lang in ("en", "es", "pt"):
+        assert C._has_expected_script(lang, "anything in French here") is True
+
+
+def test_empty_text_is_not_wrong_script():
+    for lang in ("ar", "zh", "ru", "fa", "en"):
+        assert C._has_expected_script(lang, "") is True
+
+
+def test_unknown_lang_is_not_wrong_script():
+    assert C._has_expected_script("xx", "anything") is True
+
+
+def _write_source_notebook(repo_root, nb_name, cell_id, source):
+    nb_rel = f"tmp_{nb_name}.ipynb"
+    (repo_root / nb_rel).write_text(
+        json.dumps(
+            {"cells": [{"id": cell_id, "cell_type": "markdown", "source": [source]}],
+             "metadata": {}, "nbformat": 4, "nbformat_minor": 5},
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    return nb_rel
+
+
+def _write_csv(csv_path, nb_rel, cell_id, texts):
+    row = {
+        "notebook": nb_rel, "cell_id": cell_id, "cell_type": "markdown",
+        "src_lang": "fr", "src_hash": "", "text_fr": "Bonjour",
+    }
+    for lang in C.ALL_LANGS:
+        row.setdefault(f"text_{lang}", "")
+        row.setdefault(f"hash_{lang}", "")
+    for lang, txt in texts.items():
+        row[f"text_{lang}"] = txt
+    with csv_path.open("w", encoding="utf-8", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=list(row.keys()))
+        w.writeheader()
+        w.writerow(row)
+
+
+def test_check_csv_flags_wrong_script_zh(tmp_path):
+    nb_rel = _write_source_notebook(tmp_path, "nb1", "abc", "Bonjour")
+    csv_path = tmp_path / "sync.csv"
+    _write_csv(csv_path, nb_rel, "abc", {"zh": "bonjour"})
+    anomalies = C.check_csv(csv_path, tmp_path)
+    wrong = [a for a in anomalies if a["verdict"] == "WRONG_SCRIPT"]
+    assert len(wrong) == 1, f"expected 1 WRONG_SCRIPT, got {anomalies}"
+    assert wrong[0]["lang"] == "zh"
+
+
+def test_check_csv_no_wrong_script_for_correct_zh(tmp_path):
+    nb_rel = _write_source_notebook(tmp_path, "nb2", "abc", "Bonjour")
+    csv_path = tmp_path / "sync.csv"
+    _write_csv(csv_path, nb_rel, "abc", {"zh": "你好"})
+    anomalies = C.check_csv(csv_path, tmp_path)
+    assert not any(a["verdict"] == "WRONG_SCRIPT" for a in anomalies)
+
+
+def test_check_csv_wrong_script_all_non_latin(tmp_path):
+    nb_rel = _write_source_notebook(tmp_path, "nb3", "abc", "Bonjour")
+    csv_path = tmp_path / "sync.csv"
+    _write_csv(csv_path, nb_rel, "abc", {"ar": "bonjour", "fa": "bonjour",
+                                          "zh": "bonjour", "ru": "bonjour",
+                                          "en": "bonjour", "es": "bonjour", "pt": "bonjour"})
+    anomalies = C.check_csv(csv_path, tmp_path)
+    wrong = [a for a in anomalies if a["verdict"] == "WRONG_SCRIPT"]
+    wrong_langs = sorted(a["lang"] for a in wrong)
+    assert wrong_langs == ["ar", "fa", "ru", "zh"], (
+        f"expected ar/fa/ru/zh flagged, got {wrong_langs} (full={anomalies})"
+    )
+
+
+def test_check_csv_empty_text_no_wrong_script(tmp_path):
+    nb_rel = _write_source_notebook(tmp_path, "nb4", "abc", "Bonjour")
+    csv_path = tmp_path / "sync.csv"
+    _write_csv(csv_path, nb_rel, "abc", {"zh": ""})
+    anomalies = C.check_csv(csv_path, tmp_path)
+    assert not any(a["verdict"] == "WRONG_SCRIPT" for a in anomalies)

--- a/scripts/translation/check_translation_sync.py
+++ b/scripts/translation/check_translation_sync.py
@@ -46,6 +46,24 @@ PIVOT_LANG = "fr"
 TARGET_LANGS = ["en", "es", "ar", "fa", "zh", "ru", "pt"]
 ALL_LANGS = [PIVOT_LANG] + TARGET_LANGS
 
+# Plages Unicode du script attendu pour les langues cibles non-Latines.
+# Une cellule text_<lang> deposee dont le contenu ne porte AUCUN caractere de
+# son script attendu (en ignorant ASCII = ponctuation/chiffres/espaces/markup
+# markdown) est un WRONG_SCRIPT : typiquement un copier-coller de FR ou d'EN
+# dans la colonne text_ar / text_zh / text_ru / text_fa. Detection deterministe,
+# zero faux-positif (une vraie traduction arabe/chinoise/russe CONTIENT au moins
+# un caractere de son script). Les langues Latines (en/es/pt) ne sont PAS couvertes
+# ici : la contamination FR de ces langues est la classe heuristique FR_CONTAM
+# (taxonomie Argumentum 5-classes), hors scope de ce check deterministe (#6949).
+# Source des plages : Unicode UCD (Arabic 0600-06FF, Cyrillic 0400-04FF,
+# CJK Unified Ideographs 4E00-9FFF, etc.).
+LANG_SCRIPT_RANGES: dict[str, list[tuple[int, int]]] = {
+    "ar": [(0x0600, 0x06FF), (0x0750, 0x077F), (0x08A0, 0x08FF)],  # Arabic block
+    "fa": [(0x0600, 0x06FF), (0x0750, 0x077F), (0xFB50, 0xFDFF), (0xFE70, 0xFEFF)],  # Arabic + Presentation forms (Persian)
+    "zh": [(0x4E00, 0x9FFF), (0x3400, 0x4DBF), (0xF900, 0xFAFF), (0x3000, 0x303F)],  # CJK Unified + Ext A + CJK symbols/punct
+    "ru": [(0x0400, 0x04FF), (0x0500, 0x052F), (0x2DE0, 0x2DFF), (0xA640, 0xA69F)],  # Cyrillic + ext + supplement
+}
+
 
 def normalize(text: str) -> str:
     """Meme normalisation que extract_cells_to_csv.py (anti faux-drift cosmétique)."""
@@ -55,6 +73,31 @@ def normalize(text: str) -> str:
 
 def cell_hash(text: str) -> str:
     return hashlib.sha256(normalize(text).encode("utf-8")).hexdigest()[:16]
+
+
+def _has_expected_script(lang: str, text: str) -> bool:
+    """True si text contient au moins un caractere du script attendu pour lang.
+
+    Langues Latines (en/es/pt, absentes de LANG_SCRIPT_RANGES) : retourne True
+    (pas de verdict WRONG_SCRIPT -- la contamination FR de ces langues est la
+    classe heuristique FR_CONTAM, hors scope). Texte vide : True (rien a checker,
+    etat attendu pre-T3). Sinon on scanne les caracteres non-ASCII : s'il en
+    existe au moins un dans une plage attendue de lang, c'est OK ; si AUCUN
+    caractere non-ASCII n'appartient au script attendu, retourne False -> WRONG_SCRIPT.
+
+    Une traduction legitime arabe/chinoise/russe contient du code ou des nombres
+    (ASCII) MAIS doit aussi contenir au moins un caractere du script cible.
+    """
+    ranges = LANG_SCRIPT_RANGES.get(lang)
+    if not ranges or not text:
+        return True
+    for ch in text:
+        cp = ord(ch)
+        if cp < 0x0080:  # ASCII : ponctuation, chiffres, espaces, markup markdown (*_#-`).
+            continue
+        if any(lo <= cp <= hi for lo, hi in ranges):
+            return True
+    return False
 
 
 def load_notebook_cells(nb_path: Path) -> dict[str, str] | None:
@@ -117,10 +160,19 @@ def check_csv(csv_path: Path, repo_root: Path) -> list[dict]:
                      "detail": f"source modifié (csv={csv_src_hash} <> actuel={current_src}) -> retraduction requise"}
                 )
 
-            # TRAD_DRIFT / MISSING_LANG par langue cible.
+            # TRAD_DRIFT / MISSING_LANG / WRONG_SCRIPT par langue cible.
             # Le pivot (fr) EST le notebook source (xxx.ipynb, pas xxx_fr.ipynb) :
             # sa cohérence est déjà vérifiée par SRC_DRIFT ci-dessus -> on le skippe.
             for lang in TARGET_LANGS:
+                # WRONG_SCRIPT : le contenu depose text_<lang> est-il dans le bon
+                # script ? (detection Unicode deterministe ; Latin langs exclus.)
+                trad_text = row.get(f"text_{lang}", "")
+                if trad_text and not _has_expected_script(lang, trad_text):
+                    anomalies.append(
+                        {"csv": str(csv_path), "notebook": nb_rel, "cell_id": cell_id, "lang": lang,
+                         "verdict": "WRONG_SCRIPT",
+                         "detail": f"text_{lang} depose sans aucun caractere du script attendu (copier-coller FR/EN dans la mauvaise colonne ?)"}
+                    )
                 csv_hash = row.get(f"hash_{lang}", "")
                 if not csv_hash:
                     continue  # rien déposé = attendu pre-T3, pas un drift.


### PR DESCRIPTION
## Summary

Re-opens abandoned substance (`po-2023 c.581b`, commit `9f3ab3602`) for issue #7714 (#6949 T2 — harmonisation 5 classes de drift Argumentum).

Cette PR livre la **3ᵉ classe Argumentum** (sur 5) : `WRONG_SCRIPT`. Détection déterministe Unicode qu'un contenu `text_<lang>` déposé pour une langue non-Latine (`ar`/`fa`/`zh`/`ru`) ne porte aucun caractère du script attendu (copier-coller FR/EN dans la mauvaise colonne).

## Provenance

| Champ | Valeur |
|-------|--------|
| Substance originale | `po-2023 c.581b` — commit `9f3ab3602` sur branche `feature/c734-wrong-script-verdict-6949` |
| État pré-réouverture | Branche orpheline, jamais de PR ouverte |
| Re-opening | `po-2025 c.728y+10` — rebase onto `1509e3706` (main actuel) |
| Nouveau SHA | `03ef85236` (1 commit) |
| Branche | `feature/c728y+10-wrong-script-verdict-6949` (nouvelle — pas de force-push) |
| Auteur préservé | `po-2023 c.581b <jsboige+bot@anthropic.com>` |
| Committer | `po-2025 c.728y+10 <jsboige+bot@anthropic.com>` |

## Qu'est-ce que `WRONG_SCRIPT`

Plages Unicode UCD déclarées dans `LANG_SCRIPT_RANGES` (Arabic `0600-06FF`, Cyrillic `0400-04FF`, CJK `4E00-9FFF`, + extensions). Pour les langues cibles non-Latines, un `text_<lang>` qui ne contient **aucun** caractère de son script attendu (en ignorant ASCII = ponctuation/chiffres/markup markdown) est `WRONG_SCRIPT`.

**Zéro faux-positif** : une vraie traduction arabe/chinoise/russe contient forcément au moins un caractère de son script cible.

**Exclu** : `en`/`es`/`pt` (langues Latines). Leur contamination FR est la classe heuristique `FR_CONTAM` (4ᵉ classe Argumentum, #7731). Le helper `_has_expected_script` retourne `True` pour les langues absentes de `LANG_SCRIPT_RANGES` → pas de verdict `WRONG_SCRIPT` pour ces langues.

## Périmètre

- **Inclus** : `ar`/`fa`/`zh`/`ru` (scripts non-Latins, test déterministe).
- **Hors scope** : `FR_CONTAM` (heuristique, #7731) + `COGNATE` (heuristique, futur). Voir #6949.

## Validation (H.1 — code, pas notebook)

| Check | Result |
|-------|--------|
| `python -m pytest scripts/tests/test_check_translation_sync.py -q` | **18 passed** |
| `python -m pytest scripts/tests/test_translate_csv.py scripts/tests/test_check_translation_sync.py -q` | **41 passed** (23 + 18, no regression) |
| EOL | LF-only (0 CRLF, 0 BOM) |
| `git diff origin/main...HEAD --stat` | 2 fichiers, +217/-1 |
| R3 atomic | 1 sujet = 1 verdict Argumentum |
| R1 catalog-pr-hygiene | catalogue non touché (0 fichier catalogue dans le diff) |
| Anti-regression §D | pure addition + 1 ligne de glue dans `check_csv`, pas de suppression |

## Tests (18 = 14 unités + 4 intégration)

### Unités (`_has_expected_script`, 14 tests)

Chaque langue non-Latine : OK avec script cible / WRONG avec Latin pur, ASCII-seul = WRONG, markdown-wrapped Latin = WRONG, langues Latines jamais WRONG, texte vide = OK, langue inconnue = OK.

### Intégration (`check_csv`, 4 tests)

CSV synthétique + notebook source minimal. `text_zh="bonjour"` → 1 `WRONG_SCRIPT(zh)` ; `text_zh="你好"` → 0 ; `bonjour` déposé en `ar/fa/zh/ru` → 4 flags ; `text_zh=""` → 0 (état pré-T3).

### G.9 non-vacuous (preuve de-patch)

De-patch (`git checkout origin/main -- scripts/translation/check_translation_sync.py`) → `python -m pytest scripts/tests/test_check_translation_sync.py -q` → **16/18 FAIL** (14 unités en `AttributeError: module has no attribute '_has_expected_script'` + 2 intégration qui n'obtiennent plus aucune anomalie). Les 2 PASS sont les gardes *no-false-positive* (assertent l'ABSENCE de WRONG_SCRIPT, trivialement vrai quand la feature est absente). Re-patch → **18/18 PASS**.

## Conformité référentielle

- **R1 catalog-pr-hygiene** : catalogue byte-identique (0 fichier catalogue dans le diff)
- **R2 rebase frais** : base = `1509e3706` (main actuel, < 24h)
- **R3 atomic** : 1 sujet = 1 verdict Argumentum, 2 fichiers
- **R4 partial delivery** : `See #6949` strict (issue reste ouverte pour `FR_CONTAM` + `COGNATE`)
- **G.1 verify-before-claiming** : de-patch prouvant 16/18 → 18/18 = non-vacuous
- **G.9 culture du doute** : test confirme que la feature est indispensable (sans elle, 0 détection)

## Note sur la branche-carrier (L895 ★★★)

Branche atomique OBLIGATOIRE respectée : `git diff origin/main...HEAD --stat` = exactement 2 fichiers attendus (1 source +52/-1, 1 test +165). Aucun diff OOS. Diff OOS checké avant push.

## Suite pour ai-01

- **Substance** : ready to merge (R1+R2+R3+R4 OK, 41/41 tests, G.9 non-vacuous).
- **Décision** : merge / request changes / cherry-pick. L'issue #7714 reste ouverte pour la 4ᵉ classe (`FR_CONTAM`, #7731) + 5ᵉ (`COGNATE`).
- **Cross-référence** : #7731 (FR_CONTAM verdict) est le prochain slice de la même epic ; cohérence cross-PR au merge.

Grain: **DEEP/feature** — lane `myia-po-2025:CoursIA-2` — prev: MED/fix (c.728y+9 L898 ★★★ self-correction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)