### PR TITLE
docs(index,#7422): align root index.md with README.md (GenAI ranking + SymbolicAI sub-disciplines)

### DIFF
--- a/index.md
+++ b/index.md
@@ -28,11 +28,11 @@ Chaque série est introduite par son thème central, ses prérequis et un pointe
 
 ### Intelligence artificielle générative
 
-- **[GenAI](MyIA.AI.Notebooks/GenAI/README.md)** — IA générative multimodale : Image, Audio, Vidéo, Texte, Semantic Kernel, Vibe Coding. La plus grande série du dépôt. *Intermédiaire à avancé selon les sous-séries ; nécessite des clés API (OpenAI, Anthropic) pour les volets LLM.*
+- **[GenAI](MyIA.AI.Notebooks/GenAI/README.md)** — IA générative multimodale : Image, Audio, Vidéo, Texte, Semantic Kernel, Vibe Coding. L'une des plus vastes séries du dépôt (SymbolicAI est la plus vaste ; voir `COURSE_CATALOG.generated.md` pour les comptes exacts). *Intermédiaire à avancé selon les sous-séries ; nécessite des clés API (OpenAI, Anthropic) pour les volets LLM.*
 
 ### Raisonnement formel et symbolique
 
-- **[SymbolicAI](MyIA.AI.Notebooks/SymbolicAI/README.md)** — Lean 4 (preuves formelles), Tweety (argumentation), Semantic Web (RDF, OWL), Smart Contracts, Planners, Symbolic Learning. *Avancé.*
+- **[SymbolicAI](MyIA.AI.Notebooks/SymbolicAI/README.md)** — Lean 4 (preuves formelles), Tweety (argumentation), Semantic Web (RDF, OWL), Smart Contracts, Planners, SMT (Z3), Argument Analysis, Symbolic Learning. La plus vaste série du dépôt. *Avancé.*
 - **[Probas](MyIA.AI.Notebooks/Probas/README.md)** — Programmation probabiliste (Infer.NET, NumPyro). *Intermédiaire à avancé.*
 - **[GameTheory](MyIA.AI.Notebooks/GameTheory/README.md)** — Théorie des jeux, équilibres de Nash, mechanism design, social choice (Arrow, Sen, Voting) avec ports Lean. *Intermédiaire à avancé.*
 


### PR DESCRIPTION
## Summary

The root `index.md` portal **contradicted `README.md`** on two points that a prior staleness pass fixed in README.md + the index.md counts but missed on the index.md thematic descriptions. Triple-grounded fix: `index.md` ↔ `README.md` ↔ `COURSE_CATALOG.generated.md` now agree.

## Changes (2 lines)

1. **GenAI ranking (L31)** — index.md claimed GenAI is *« La plus grande série du dépôt »*. False by the catalog's own count (which index.md cites as authoritative): **SymbolicAI (219) > GenAI (141)**. README.md L36 correctly says GenAI is *« l'une des plus vastes séries »*. Aligned index.md to the same qualitative framing + pointer to `COURSE_CATALOG.generated.md` for exact counts (no hardcoded number that re-drifts).

2. **SymbolicAI sub-disciplines (L35)** — index.md omitted **`SMT (Z3)`** and **`Argument Analysis`**, both of which exist as sub-directories under `SymbolicAI/` and are listed in README.md L35. Added them + the *« la plus vaste série du dépôt »* ranking to match README.md.

## G.1 cross-check (firsthand)

| Claim | index.md (before) | README.md (current) | Catalog | Fixed? |
|-------|-------------------|---------------------|---------|--------|
| Largest series | GenAI | SymbolicAI (220) | SymbolicAI (219) > GenAI (141) | ✅ L31 |
| SymbolicAI sub-disciplines | 6 (no SMT/ArgAnalysis) | 8 (incl. SMT, Argument Analysis) | dirs exist | ✅ L35 |

All 15 index.md README links + catalog link re-verified resolving (**0 broken**, #7422 acceptance met).

## Scope honesty

Focused 2-line cross-portal consistency fix (+2/-2). The broader index.md staleness (hardcoded *« 637 notebooks »* x2, Sudoku *« 33 »*) was **already fixed** by a prior merged pass that introduced the *« total à jour / voir CATALOG-STATUS »* pattern — these two thematic-description residuals were missed in that pass. No cosmetic padding; nothing else genuine to bundle (README.md root is correct, docs/ tree well-curated). If a reviewer prefers this bundled into a larger docs PR, it can stay on hold — but the fix is correct and ready.

See #7422 (point 3: root portal freshness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)