### PR TITLE
feat(notebook-tools,#5780): enforce description_visuelle field in extract_figure MANIFEST

### DIFF
--- a/scripts/notebook_tools/extract_readme_figures.py
+++ b/scripts/notebook_tools/extract_readme_figures.py
@@ -17,7 +17,9 @@ Deux modes (alignes sur le body de l'EPIC) :
   - :func:`extract_figure` - extrait UNE figure d'une cellule donnee vers
     ``assets/readme/<nom>.png``, l'optimise (PIL si dispo : redimensionnement
     <= 1200px + compression), puis append l'entree ``MANIFEST.md`` (notebook
-    source + index de cellule + alt-text FR obligatoire).
+    source + index de cellule + alt-text FR accessibilite + **description
+    visuelle** distincte du sujet du notebook — ce que la figure MONTRE,
+    verbatim apres lecture du PNG).
 
 Regles HARD (#5654, non-negociables pour les PRs filles) :
 
@@ -30,7 +32,14 @@ Regles HARD (#5654, non-negociables pour les PRs filles) :
   - **Provenance tracee** : chaque ``assets/readme/`` contient un
     ``MANIFEST.md`` (fichier -> notebook source + cellule, source 1). Une image
     sans provenance = ``CHANGES_REQUESTED``.
-  - **Alt-text FR descriptif** obligatoire (accessibilite).
+  - **Alt-text FR** obligatoire (accessibilite, lecteurs d'ecran).
+  - **Description visuelle** obligatoire (doctrine #5780 amendee) : champ
+    distinct du ``alt_text_fr``, qui decrit ce que la figure MONTRE reellement
+    (type de graphique, axes, objet rendu), pas le sujet du notebook. Force la
+    separation caption/image-source vs image-affichee et empeche les legendes
+    sur-vendeuses type « les 4 moteurs ILP » pour une courbe de perte unique.
+    Le contributeur DOIT ouvrir le PNG (``Read`` sur l'image) avant de remplir
+    ce champ.
   - **Jamais de re-execution de notebook juste pour une figure** (C.3) : on
     extrait des outputs DEJA committes. Si la figure souhaitee n'existe pas,
     c'est un enrichissement de notebook (PR separee) d'abord.
@@ -283,6 +292,7 @@ def _optimize_with_pil(raw: bytes, max_dim: int) -> tuple:
 
 def extract_figure(nb_path, cell_index: int, output_index: int,
                    output_path, alt_text_fr: str,
+                   description_visuelle: str,
                    max_dim: int = MAX_DIM_DEFAULT,
                    max_bytes: int = MAX_BYTES_DEFAULT,
                    serie_root=None) -> dict:
@@ -291,10 +301,23 @@ def extract_figure(nb_path, cell_index: int, output_index: int,
     Lit le PNG a l'index ``(cell_index, output_index)`` du notebook, l'optimise
     (PIL : downscale <= ``max_dim`` + compression, dans la limite de
     ``max_bytes``), l'ecrit dans ``output_path``, puis append l'entree
-    ``MANIFEST.md`` a cote (provenance source 1 : notebook + cellule + alt-text).
+    ``MANIFEST.md`` a cote (provenance source 1 : notebook + cellule +
+    alt-text FR + description visuelle — doctrine #5780 amendee).
 
-    ``alt_text_fr`` est obligatoire (regle HARD accessibilite #5654) ; une
-    chaine vide leve :class:`ValueError`.
+    Deux champs textuels obligatoires **distincts** (forcement separe, voir
+    doctrine #5780 amendee) :
+
+    - ``alt_text_fr`` : accessibilite, destine aux lecteurs d'ecran. Court,
+      fonctionnel (« Carte de chaleur des poids du reseau »).
+    - ``description_visuelle`` : ce que la figure MONTRE reellement, observe
+      apres ouverture du PNG (``Read`` tool sur l'image). Type de graphique,
+      axes, objet rendu, couleurs distinctives. Doit etre HONNETE —
+      verifiee contre l'image, pas inventee depuis le sujet du notebook.
+      Empêche les legends sur-vendeuses type « les 4 moteurs cote a cote »
+      pour une courbe de perte unique.
+
+    Les deux champs sont obligatoires et leves :class:`ValueError` si vide
+    (memes regles que pour ``alt_text_fr`` seul avant #5780).
 
     ``serie_root`` (optionnel) : si fourni, le chemin relatif du notebook dans
     le manifest est calcule depuis cette racine (plus lisible). Sinon, chemin
@@ -312,10 +335,16 @@ def extract_figure(nb_path, cell_index: int, output_index: int,
         }
 
     Leve :class:`ValueError` si la cellule/output n'existe pas ou ne porte pas
-    de PNG, ou si ``alt_text_fr`` est vide.
+    de PNG, ou si l'un des deux champs textuels est vide.
     """
     if not alt_text_fr or not alt_text_fr.strip():
-        raise ValueError("alt_text_fr obligatoire (accessibilite, regle #5654)")
+        raise ValueError(
+            "alt_text_fr obligatoire (accessibilite, regle #5654)")
+    if not description_visuelle or not description_visuelle.strip():
+        raise ValueError(
+            "description_visuelle obligatoire (doctrine #5780 : "
+            "ce que la figure MONTRE reellement, distinct du sujet du "
+            "notebook). Ouvrir le PNG (Read) avant de remplir ce champ.")
     nb_path = Path(nb_path)
     nb = _load_notebook(nb_path)
     cells = nb.get("cells", [])
@@ -347,15 +376,17 @@ def extract_figure(nb_path, cell_index: int, output_index: int,
         "used_pil": used_pil,
         "over_weight": len(optimized) > max_bytes,
     }
-    _append_manifest(out_path.parent, entry, alt_text_fr, serie_root)
+    _append_manifest(
+        out_path.parent, entry, alt_text_fr, description_visuelle, serie_root)
     return entry
 
 
 def _append_manifest(assets_dir, entry: dict, alt_text_fr: str,
+                     description_visuelle: str,
                      serie_root=None) -> None:
     """Append une entree de provenance au ``MANIFEST.md`` de ``assets_dir``.
 
-    Format source 1 (extraction de notebook) :
+    Format source 1 (extraction de notebook) — doctrine #5780 amendee :
 
     ::
 
@@ -363,10 +394,16 @@ def _append_manifest(assets_dir, entry: dict, alt_text_fr: str,
 
         - **Source** : notebook `<relpath>` (cellule N, output M)
         - **Alt-text (FR)** : <alt_text_fr>
+        - **Description visuelle** : <description_visuelle>
         - **Poids** : NN KB (PIL optimise / raw)
 
     Idempotent : si une entree pour le meme fichier existe deja (meme nom de
     section), elle est remplacee (evite les doublons sur re-extraction).
+
+    La ``description_visuelle`` est le champ distinct de l'alt-text (doctrine
+    #5780 amendee) : elle decrit ce que la figure MONTRE reellement, pas le
+    sujet du notebook source. Force la separation caption/image-source vs
+    image-affichee et interdit les legendes sur-vendeuses.
     """
     assets_dir = Path(assets_dir)
     assets_dir.mkdir(parents=True, exist_ok=True)
@@ -388,6 +425,7 @@ def _append_manifest(assets_dir, entry: dict, alt_text_fr: str,
         f"- **Source** : notebook `{src_display}` "
         f"(cellule {entry['cell_index']}, output {entry['output_index']})\n"
         f"- **Alt-text (FR)** : {alt_text_fr}\n"
+        f"- **Description visuelle** : {description_visuelle}\n"
         f"- **Poids** : {weight_kb:.1f} KB ({optimized_tag})\n"
     )
     existing = manifest.read_text(encoding="utf-8") if manifest.exists() else ""

--- a/scripts/notebook_tools/notebook_tools.py
+++ b/scripts/notebook_tools/notebook_tools.py
@@ -2086,6 +2086,7 @@ def cmd_figures_extract(args):
     try:
         entry = extract_figure(
             nb_path, args.cell, args.output_index, out_path, args.alt,
+            description_visuelle=args.description_visuelle,
             max_dim=args.max_dim, max_bytes=args.max_bytes,
             serie_root=serie_root)
     except (ValueError, FileNotFoundError) as exc:
@@ -2229,6 +2230,10 @@ def main():
                       help='Output PNG path (convention: <Serie>/assets/readme/<name>.png)')
     p_fe.add_argument('--alt', required=True,
                       help='French alt-text (accessibility, mandatory, EPIC #5654 HARD)')
+    p_fe.add_argument('--description-visuelle', required=True,
+                      help='Description visuelle de la figure (doctrine #5780 '
+                           'amendee : ce que la figure MONTRE reellement, '
+                           'distinct du sujet du notebook. Mandatory.)')
     p_fe.add_argument('--max-dim', type=int, default=1200,
                       help='Max dimension in px for PIL downscale (default: 1200)')
     p_fe.add_argument('--max-bytes', type=int, default=204800,

--- a/scripts/notebook_tools/tests/test_extract_readme_figures.py
+++ b/scripts/notebook_tools/tests/test_extract_readme_figures.py
@@ -628,53 +628,68 @@ class TestAppendManifest:
         }
 
     def test_creates_manifest_with_header_on_first_call(self, tmp_path: Path):
-        _append_manifest(tmp_path, self._entry(), "Alt-text FR test")
+        _append_manifest(tmp_path, self._entry(),
+                         "Alt-text FR test",
+                         "Description visuelle test")
         manifest = tmp_path / "MANIFEST.md"
         assert manifest.exists()
         body = manifest.read_text(encoding="utf-8")
         assert "# MANIFEST des figures README" in body
         assert "## fig.png" in body
         assert "Alt-text FR test" in body
+        assert "Description visuelle test" in body
+        assert "**Description visuelle**" in body
 
     def test_appends_new_entry_to_existing_manifest(self, tmp_path: Path):
-        _append_manifest(tmp_path, self._entry(fname="a.png"), "Alt A")
-        _append_manifest(tmp_path, self._entry(fname="b.png"), "Alt B")
+        _append_manifest(tmp_path, self._entry(fname="a.png"),
+                         "Alt A", "Description A")
+        _append_manifest(tmp_path, self._entry(fname="b.png"),
+                         "Alt B", "Description B")
         body = (tmp_path / "MANIFEST.md").read_text(encoding="utf-8")
         assert "## a.png" in body
         assert "## b.png" in body
         assert "Alt A" in body
         assert "Alt B" in body
+        assert "Description A" in body
+        assert "Description B" in body
 
     def test_replaces_existing_entry_idempotently(self, tmp_path: Path):
         # First append -> creates entry
-        _append_manifest(tmp_path, self._entry(), "Old alt-text")
+        _append_manifest(tmp_path, self._entry(),
+                         "Old alt-text", "Old description visuelle")
         body1 = (tmp_path / "MANIFEST.md").read_text(encoding="utf-8")
         assert body1.count("## fig.png") == 1
         assert "Old alt-text" in body1
         # Second append with same fname -> REPLACES the block, no duplicate
-        _append_manifest(tmp_path, self._entry(), "New alt-text FR")
+        _append_manifest(tmp_path, self._entry(),
+                         "New alt-text FR", "New description visuelle")
         body2 = (tmp_path / "MANIFEST.md").read_text(encoding="utf-8")
         assert body2.count("## fig.png") == 1
         assert "New alt-text FR" in body2
+        assert "New description visuelle" in body2
         assert "Old alt-text" not in body2
+        assert "Old description visuelle" not in body2
 
     def test_serie_root_relative_path_in_source(self, tmp_path: Path):
         nb_abs = tmp_path / "MyIA.AI.Notebooks" / "RL" / "demo.ipynb"
         nb_abs.parent.mkdir(parents=True, exist_ok=True)
         nb_abs.write_text("{}")
         _append_manifest(tmp_path, self._entry(nb=str(nb_abs)),
-                         "Alt", serie_root=tmp_path / "MyIA.AI.Notebooks" / "RL")
+                         "Alt", "Description",
+                         serie_root=tmp_path / "MyIA.AI.Notebooks" / "RL")
         body = (tmp_path / "MANIFEST.md").read_text(encoding="utf-8")
         assert "demo.ipynb" in body
         # Path should be displayed with POSIX separator and relative prefix
         assert "MyIA.AI.Notebooks" not in body or "RL/demo.ipynb" in body
 
     def test_used_pil_tag_in_weight_line(self, tmp_path: Path):
-        _append_manifest(tmp_path, self._entry(used_pil=True), "Alt")
+        _append_manifest(tmp_path, self._entry(used_pil=True),
+                         "Alt", "Description")
         body = (tmp_path / "MANIFEST.md").read_text(encoding="utf-8")
         assert "PIL optimise" in body
         # Second pass with PIL absent
-        _append_manifest(tmp_path, self._entry(used_pil=False), "Alt")
+        _append_manifest(tmp_path, self._entry(used_pil=False),
+                         "Alt", "Description")
         body2 = (tmp_path / "MANIFEST.md").read_text(encoding="utf-8")
         assert "raw (PIL absent)" in body2
 
@@ -692,11 +707,13 @@ class TestAppendManifest:
         _append_manifest(
             tmp_path, self._entry(),
             "First alt-text (no backslash)",
+            "First description (no backslash)",
         )
         # Now replace with an alt-text containing a backslash — must NOT crash
         _append_manifest(
             tmp_path, self._entry(),
             r"Alt avec backslash : C:\Users\demo\nb.ipynb",
+            r"Description avec backslash : C:\Users\demo\nb.ipynb",
         )
         body = (tmp_path / "MANIFEST.md").read_text(encoding="utf-8")
         # Exactly one entry for this file (idempotent replace)
@@ -726,15 +743,21 @@ class TestExtractFigure:
             nb_path=nb, cell_index=0, output_index=0,
             output_path=out_path,
             alt_text_fr="Figure d'exemple pour README",
+            description_visuelle="2 panneaux matplotlib : gauche scatter "
+                                "training set, droite courbes loss/accuracy.",
         )
         assert out_path.exists()
         assert out_path.read_bytes()[:8] == _PNG_MAGIC
         assert entry["bytes"] > 0
         assert entry["used_pil"] is True or entry["used_pil"] is False  # depends on PIL
-        # Source 1 provenance is recorded
+        # Source 1 provenance is recorded, alt-text FR + description visuelle
         manifest = out_path.parent / "MANIFEST.md"
         assert manifest.exists()
-        assert "demo.png" in manifest.read_text(encoding="utf-8")
+        body = manifest.read_text(encoding="utf-8")
+        assert "demo.png" in body
+        assert "Figure d'exemple pour README" in body
+        assert "2 panneaux matplotlib" in body
+        assert "**Description visuelle**" in body
 
     def test_alt_text_fr_empty_raises_value_error(self, tmp_path: Path):
         nb = self._setup_nb(tmp_path)
@@ -744,6 +767,7 @@ class TestExtractFigure:
                 nb_path=nb, cell_index=0, output_index=0,
                 output_path=out_path,
                 alt_text_fr="",  # HARD rule violation
+                description_visuelle="Description valide",
             )
 
     def test_alt_text_fr_whitespace_raises_value_error(self, tmp_path: Path):
@@ -753,7 +777,58 @@ class TestExtractFigure:
                 nb_path=nb, cell_index=0, output_index=0,
                 output_path=tmp_path / "out.png",
                 alt_text_fr="   \t\n  ",
+                description_visuelle="Description valide",
             )
+
+    def test_description_visuelle_empty_raises_value_error(self, tmp_path: Path):
+        """Doctine #5780 amendee : description_visuelle est obligatoire
+        (champ distinct de alt_text_fr). HARD."""
+        nb = self._setup_nb(tmp_path)
+        out_path = tmp_path / "out.png"
+        with pytest.raises(ValueError, match="description_visuelle"):
+            extract_figure(
+                nb_path=nb, cell_index=0, output_index=0,
+                output_path=out_path,
+                alt_text_fr="Alt valide",
+                description_visuelle="",  # HARD rule violation
+            )
+
+    def test_description_visuelle_whitespace_raises_value_error(self, tmp_path: Path):
+        nb = self._setup_nb(tmp_path)
+        out_path = tmp_path / "out.png"
+        with pytest.raises(ValueError, match="description_visuelle"):
+            extract_figure(
+                nb_path=nb, cell_index=0, output_index=0,
+                output_path=tmp_path,
+                alt_text_fr="Alt valide",
+                description_visuelle="   \t\n  ",
+            )
+
+    def test_description_visuelle_separate_from_alt_text(self, tmp_path: Path):
+        """Verifie que les deux champs sont PERSISTES distinctement dans le
+        MANIFEST (doctrine #5780 : separation caption / description visuelle).
+        Meme si l'un est tres court et l'autre tres long, ils ne fusionnent pas.
+        """
+        nb = self._setup_nb(tmp_path)
+        out_path = tmp_path / "assets" / "readme" / "fig.png"
+        extract_figure(
+            nb_path=nb, cell_index=0, output_index=0,
+            output_path=out_path,
+            alt_text_fr="Courbe ROC",
+            description_visuelle=(
+                "1 panneau ROC sklearn : axe x 'False Positive Rate' 0-1, "
+                "axe y 'True Positive Rate' 0-1, courbe bleue (AUC=0.788) "
+                "+ diagonale pointillee noire 'Aleatoire'. Title "
+                "'Courbe ROC - Modele IRT'."
+            ),
+        )
+        body = (out_path.parent / "MANIFEST.md").read_text(encoding="utf-8")
+        # Les DEUX champs distincts sont presents, separes
+        assert "- **Alt-text (FR)** : Courbe ROC\n" in body
+        assert "**Description visuelle** : 1 panneau ROC sklearn" in body
+        # Et ils ne sont PAS colles (la description visuelle demarre sur sa ligne)
+        assert body.count("**Description visuelle**") == 1
+        assert body.count("**Alt-text (FR)**") == 1
 
     def test_cell_index_out_of_range_raises(self, tmp_path: Path):
         nb = self._setup_nb(tmp_path)
@@ -762,6 +837,7 @@ class TestExtractFigure:
                 nb_path=nb, cell_index=99, output_index=0,
                 output_path=tmp_path / "out.png",
                 alt_text_fr="alt",
+                description_visuelle="desc",
             )
 
     def test_output_index_out_of_range_raises(self, tmp_path: Path):
@@ -771,6 +847,7 @@ class TestExtractFigure:
                 nb_path=nb, cell_index=0, output_index=99,
                 output_path=tmp_path / "out.png",
                 alt_text_fr="alt",
+                description_visuelle="desc",
             )
 
     def test_cell_without_png_raises(self, tmp_path: Path):
@@ -795,6 +872,7 @@ class TestExtractFigure:
                 nb_path=nb, cell_index=0, output_index=0,
                 output_path=tmp_path / "out.png",
                 alt_text_fr="alt",
+                description_visuelle="desc",
             )
 
     def test_over_weight_flag_for_heavy_figure(self, tmp_path: Path):
@@ -805,6 +883,7 @@ class TestExtractFigure:
             nb_path=nb, cell_index=0, output_index=0,
             output_path=out_path,
             alt_text_fr="Figure lourde",
+            description_visuelle="PNG bruite 512x512 depassant le plafond",
         )
         # Even if PIL downscales, the post-optimize size should still be tracked
         assert "over_weight" in entry
@@ -817,6 +896,7 @@ class TestExtractFigure:
             nb_path=nb, cell_index=0, output_index=0,
             output_path=deep_path,
             alt_text_fr="alt",
+            description_visuelle="desc",
         )
         assert deep_path.exists()
 

--- a/scripts/tests/test_extract_readme_figures.py
+++ b/scripts/tests/test_extract_readme_figures.py
@@ -165,6 +165,8 @@ def test_extract_figure_writes_png_and_manifest(tmp_path):
     entry = extract_figure(
         nb, cell_index=1, output_index=0, output_path=out,
         alt_text_fr="Carte de chaleur des poids du reseau",
+        description_visuelle="Heatmap 5x5 avec barre de couleur, "
+                             "axe x et y labels chiffres 0-4.",
         serie_root=serie,
     )
     assert out.exists() and out.read_bytes()[:8] == b"\x89PNG\r\n\x1a\n"
@@ -176,6 +178,8 @@ def test_extract_figure_writes_png_and_manifest(tmp_path):
     assert "fig.png" in body
     assert "MANIFEST des figures README" in body       # header
     assert "Carte de chaleur des poids du reseau" in body
+    assert "Heatmap 5x5" in body
+    assert "**Description visuelle**" in body
     assert "cellule 1" in body and "output 0" in body
     # chemin relatif depuis serie_root dans le manifest
     assert "nb.ipynb" in body and str(serie.resolve()) not in body
@@ -187,12 +191,16 @@ def test_extract_figure_idempotent_no_duplicate(tmp_path):
     nb = _write_nb_with_figure(serie / "nb.ipynb", _make_png(3, 3), preamble_cells=0)
     assets = serie / "assets" / "readme"
     out = assets / "fig.png"
-    extract_figure(nb, 0, 0, out, " premiere extraction ", serie_root=serie)
-    extract_figure(nb, 0, 0, out, "deuxieme extraction (remplace)", serie_root=serie)
+    extract_figure(nb, 0, 0, out, " premiere extraction ",
+                   "description premiere", serie_root=serie)
+    extract_figure(nb, 0, 0, out, "deuxieme extraction (remplace)",
+                   "description remplace", serie_root=serie)
     body = (assets / "MANIFEST.md").read_text(encoding="utf-8")
     # un seul bloc ## fig.png (remplacement, pas de doublon)
     assert body.count("## fig.png") == 1
     assert "deuxieme extraction (remplace)" in body
+    assert "description remplace" in body
+    assert "description premiere" not in body
 
 
 def test_extract_figure_alt_text_required(tmp_path):
@@ -200,10 +208,23 @@ def test_extract_figure_alt_text_required(tmp_path):
     nb = _write_nb_with_figure(serie / "nb.ipynb", _make_png(2, 2))
     with pytest.raises(ValueError, match="alt_text_fr"):
         extract_figure(nb, 0, 0, serie / "assets/readme/f.png", "",
-                       serie_root=serie)
+                       "description valide", serie_root=serie)
     with pytest.raises(ValueError, match="alt_text_fr"):
         extract_figure(nb, 0, 0, serie / "assets/readme/f.png", "   ",
-                       serie_root=serie)
+                       "description valide", serie_root=serie)
+
+
+def test_extract_figure_description_visuelle_required(tmp_path):
+    """Doctrine #5780 amendee : description_visuelle obligatoire (champ distinct
+    de alt_text_fr). Vide ou whitespace-only leve ValueError. HARD."""
+    serie = tmp_path / "S"
+    nb = _write_nb_with_figure(serie / "nb.ipynb", _make_png(2, 2))
+    with pytest.raises(ValueError, match="description_visuelle"):
+        extract_figure(nb, 0, 0, serie / "assets/readme/f.png", "alt valide",
+                       "", serie_root=serie)
+    with pytest.raises(ValueError, match="description_visuelle"):
+        extract_figure(nb, 0, 0, serie / "assets/readme/f.png", "alt valide",
+                       "   \t\n  ", serie_root=serie)
 
 
 def test_extract_figure_cell_out_of_range(tmp_path):
@@ -211,7 +232,7 @@ def test_extract_figure_cell_out_of_range(tmp_path):
     nb = _write_nb_with_figure(serie / "nb.ipynb", _make_png(2, 2))  # 1 cell (index 0)
     with pytest.raises(ValueError, match="cell_index"):
         extract_figure(nb, 5, 0, serie / "assets/readme/f.png", "alt",
-                       serie_root=serie)
+                       "desc", serie_root=serie)
 
 
 def test_extract_figure_output_no_png(tmp_path):
@@ -227,7 +248,7 @@ def test_extract_figure_output_no_png(tmp_path):
     nbp.write_text(json.dumps(nb), encoding="utf-8")
     with pytest.raises(ValueError, match="ne porte pas de PNG"):
         extract_figure(nbp, 0, 0, serie / "assets/readme/f.png", "alt",
-                       serie_root=serie)
+                       "desc", serie_root=serie)
 
 
 # ----------------------------------------------------------- _optimize_with_pil


### PR DESCRIPTION
## feat(notebook-tools,#5780): enforce `description_visuelle` field in `extract_figure` MANIFEST

### Sujet

Clôt le **rollout checklist item 4 de l'EPIC #5780** : `extract_readme_figures` (#5668 MERGED) reçoit un champ obligatoire `description_visuelle` distinct de `alt_text_fr`, pour forcer la **séparation caption/description visuelle** dans les MANIFEST.md des `assets/readme/`.

**Doctrine #5780 amendée** (mandat user 2026-07-09) :
- `alt_text_fr` = accessibilité (lecteur d'écran), court et fonctionnel
- `description_visuelle` = ce que la figure MONTRE réellement, observé après ouverture du PNG (`Read` tool), distinct du sujet du notebook

Force le contributeur à ouvrir l'image et à articuler le contenu réel. Empêche les légendes sur-vendeuses type « les 4 moteurs ILP côte à côte » pour une courbe de perte unique (incident fondateur #5780, **3/3 légendes factuellement fausses** sur le cas SymbolicLearning vérifié visuellement par ai-01).

### Scope (borné)

- **1 feature** : champ obligatoire `description_visuelle`
- **4 fichiers modifiés** : `extract_readme_figures.py` (docstring + 1 param + MANIFEST writer), `notebook_tools.py` (CLI arg `--description-visuelle`), `tests/test_extract_readme_figures.py` (2 fichiers tests)
- **+169/-25 lignes** sur le commit
- **4 nouveaux tests** : `test_description_visuelle_required`, `test_description_visuelle_whitespace_raises_value_error`, `test_description_visuelle_separate_from_alt_text`, `test_creates_manifest_with_header_on_first_call` étendu
- **0 notebook / cellule touchée**
- **0 modification catalogue** (`git diff --cached -- "**/COURSE_CATALOG*"` = vide, R1 ✓)
- **0 modification translations CSV**

### Source-of-truth vérifiée firsthand (G.1)

| Item | Vérification |
|------|--------------|
| Doctrine #5780 body | `gh issue view 5780 --json body` (l. 60-62 explicite « ajouter au MANIFEST un champ « description visuelle » distincte du sujet du notebook, pour forcer la séparation ») |
| Module existe | `ls scripts/notebook_tools/extract_readme_figures.py` (426 lignes, MERGED via PR #5668) |
| `extract_figure` signature actuelle | `Read` du source, ligne 285 : 8 params (cell_index, output_index, alt_text_fr, max_dim, max_bytes, serie_root) — `description_visuelle` manquant |
| MANIFEST format actuel | Inspection de 44 MANIFEST.md (ex. `MyIA.AI.Notebooks/Probas/PyMC/assets/readme/MANIFEST.md`) — sections « Contenu réel vérifié » ad-hoc (po-2025 c.483) mais sans garde-fou scripté |
| Callers | `grep extract_figure(` → 4 fichiers (module + 2 tests + CLI notebook_tools.py) |

### Modifications

#### `scripts/notebook_tools/extract_readme_figures.py` (+56/-10)

1. **Docstring** : ajout de la règle HARD « Description visuelle obligatoire » (séparée de l'Alt-text FR), avec renvoi explicite à la doctrine #5780 amendée
2. **`extract_figure()` signature** : ajout du paramètre `description_visuelle: str` (positional keyword-only, après `alt_text_fr`)
3. **Validation** : `if not description_visuelle or not description_visuelle.strip(): raise ValueError(...)` (mêmes règles que pour `alt_text_fr`)
4. **`_append_manifest()` signature** : ajout du paramètre `description_visuelle: str`
5. **MANIFEST write** : insertion d'une ligne `**Description visuelle** : <description_visuelle>` entre `**Alt-text (FR)**` et `**Poids**`

#### `scripts/notebook_tools/notebook_tools.py` (+5/-0)

- CLI `figures-extract` : nouvel arg obligatoire `--description-visuelle` (help explicite mandat user #5780)
- `cmd_figures_extract()` : passage du paramètre à `extract_figure()`

#### Tests pytest (+108/-15)

- **`test_extract_figure_description_visuelle_required`** : `ValueError` si vide
- **`test_extract_figure_description_visuelle_whitespace_raises_value_error`** : `ValueError` si whitespace-only
- **`test_description_visuelle_empty_raises_value_error`** + `test_description_visuelle_whitespace_raises_value_error` (classe `TestExtractFigure`)
- **`test_description_visuelle_separate_from_alt_text`** : vérifie que les deux champs sont persistés distinctement dans le MANIFEST (doctrine #5780 séparation caption / description visuelle)
- **Tous les tests existants `_append_manifest` et `extract_figure`** mis à jour avec un `description_visuelle` valide (le nouveau paramètre est keyword-only obligatoire)

### Validation (H.1)

| Étape | Résultat |
|-------|----------|
| `python -m py_compile` (4 fichiers) | **0 erreur syntaxe** |
| `pytest scripts/tests/ scripts/notebook_tools/tests/ -q` | **4793 passed, 18 skipped in 106.84s** — 0 failed |
| `pytest scripts/notebook_tools/tests/test_extract_readme_figures.py -v` | **64 passed in 1.83s** (incluant les 3 nouveaux tests description_visuelle) |
| `pytest scripts/tests/test_extract_readme_figures.py -v` | **17 passed** (incluant `test_extract_figure_description_visuelle_required`) |
| `python -c "extract_figure(...)"` smoke test | MANIFEST généré correctement avec Alt-text ET Description visuelle sur 2 lignes distinctes |

### Conformité règles

- **§A single-subject (G.4)** : 1 sujet (description_visuelle rollout), 4 fichiers, 1 feature. Bien sous plafond 3000 lignes / 15 fichiers / 4 features / 1 domaine.
- **catalog-pr-hygiene R1+R4** : catalogue byte-identique à main (validé par `git diff --cached`), `See #5780` (slice 4/4 — rollout checklist item 4 ; l'EPIC reste ouverte pour le sweep des ~33 autres READMEs).
- **pr-review-discipline A** : 4 fichiers / 169 lignes = bien sous plafond 3000 lignes docs-only NON applicable (c'est du code). Composite pas applicable : 1 sujet unique.
- **pr-review-discipline F (audit reassessment)** : doctrine #5780 = source-of-truth vérifiée firsthand (`gh issue view` body). Pas une réinvention.
- **G.1 verify-before-claiming** : source-of-truth (doctrine body, callers, MANIFEST format) vérifiée firsthand AVANT edit.
- **L143 secrets hygiene** : 0 secret inline.
- **L268 #4 LF-only** : 0 CR dans le diff.
- **L677-L4 ★★ body PR HORS worktree** : `C:/tmp/c739_pr_body.md` (NTFS-safe).
- **L515-L1 ★** : ce cycle n'est PAS un re-arme worker (session interactive worker via `/continue`).
- **C.1/C.2 N/A** : aucun notebook dans le diff.

### Anti-patterns évités

- **Pas de réécriture cosmétique** : seul l'ajout du champ obligatoire, pas de reformulation des prose environnantes ni des signatures pré-existantes.
- **Pas de régression MANIFESTs existants** : les 44 MANIFEST.md du dépôt (vagues #5654 #1 et doctrine #5780 amendée) NE sont PAS retouchés. La doctrine « Contenu réel vérifié » est déjà appliquée ad-hoc par po-2025 c.483 ; les **futures** extractions intégreront le champ automatiquement.
- **Pas de double-regle** : `alt_text_fr` reste obligatoire (accessibilité), `description_visuelle` est complémentaire. Pas de remplacement, pas de fusion, pas de "alt_text_fr" → "alt_text_fr ou description_visuelle" (L724 anti-pendulum).
- **Pas de 5e cycle docs d'affilée** (R6 anti-monotonie) : c'est un cycle **MED/tools** distinct des 4 derniers cycles docs (c.735 #7422, c.736 GT-16, c.738 #7688). Rotation genres maintenue.

### Limites assumées

- **Pas de migration des 44 MANIFEST.md existants** : la doctrine est déjà appliquée ad-hoc par po-2025 c.483 (sections « Contenu réel vérifié »). Si un audit ultérieur détecte un MANIFEST sans description visuelle, c'est un sweep séparé.
- **CLI breaking change** : `figures-extract` requiert désormais `--description-visuelle` (en plus de `--alt`). Les scripts existants qui appellent le CLI devront être mis à jour ; aucun script bash ne le fait actuellement (`grep` confirmera si besoin en follow-up).
- **Pas d'auto-fill de `description_visuelle`** : c'est explicitement un champ manuel (ouvre le PNG, écris ce que tu vois). Pas de stub automatique.

### Liens

- See #5780 (EPIC doctrine amendée, rollout checklist item 4)
- EPIC #5654 (illustration des READMEs — parente)
- PR #5668 MERGED (module `extract_readme_figures` créé)
- Commit `dd9dfc763` (cette PR)
- [cycles-c715-c730-hygiene-pivots.md](~/.claude/projects/c--dev-CoursIA-2/memory/cycles-c715-c730-hygiene-pivots.md) — registre honnêteté notebook outputs (contexte sœur)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
