### PR TITLE
fix(search,#3801): Search-11 multimodal profit stretch PSO/SA past the analytical optimum

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics-Csharp.ipynb
@@ -1058,6 +1058,90 @@
      "text": [
       "Concordance avec l'optimum analytique (x=17,143, y=15,714, profit=1057,143) : les metaheuristiques le retrouvent.\r\n"
      ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Profit saisonnier (multimodal) - PSO vs SA sur 5 seeds :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Seed   PSO profit   SA profit    PSO (x,y)            SA (x,y)            \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "------------------------------------------------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0      1173,97      1173,12      (17,01, 16,99)       (16,98, 17,08)      \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "42     1173,97      1173,63      (17,01, 16,99)       (17,06, 17,02)      \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "123    1173,97      1170,41      (17,01, 16,99)       (19,60, 14,48)      \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "456    1170,81      1171,92      (19,61, 14,41)       (17,15, 16,92)      \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "789    1173,97      1173,97      (17,01, 16,99)       (17,02, 16,99)      \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PSO : meilleur profit = 1173,97, moyenne = 1173,34\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SA  : meilleur profit = 1173,97, moyenne = 1172,61\r\n"
+     ]
     }
    ],
    "source": [
@@ -1086,7 +1170,83 @@
     "var (solS, fitS, msS) = saProfit.Solve();\n",
     "Console.WriteLine($\"SA  : x={solS[0]:F4}, y={solS[1]:F4}, profit={-fitS:F4} ({msS:F1} ms)\");\n",
     "Console.WriteLine();\n",
-    "Console.WriteLine($\"Concordance avec l'optimum analytique (x={xOpt:F3}, y={yOpt:F3}, profit={profitOpt:F3}) : les metaheuristiques le retrouvent.\");\n"
+    "Console.WriteLine($\"Concordance avec l'optimum analytique (x={xOpt:F3}, y={yOpt:F3}, profit={profitOpt:F3}) : les metaheuristiques le retrouvent.\");\n",
+    "\n",
+    "// --- Profit SAISONNIER : quand le metaheuristique devient necessaire ---\n",
+    "// Le profit concave ci-dessus est unimodal : un seul optimum, accessible analytiquement,\n",
+    "// que PSO et SA retrouvent trivialement (une descente de gradient ferait l'affaire).\n",
+    "// Un marche reel est cyclique (saisonnalite). Ajoutons une composante sinusoidale :\n",
+    "//   P(x,y) = 50x + 80y - x^2 - 2y^2 - xy + 120*sin(1.2x)*sin(1.2y)\n",
+    "// Le terme sinusoidal grave un quadrillage de ~15 maxima locaux aux bassins profonds dans\n",
+    "// [0,20]^2. L'optimum n'est plus accessible analytiquement (gradient = 0 = systeme non\n",
+    "// lineaire sans solution fermee), et une descente de gradient resterait coincee dans le\n",
+    "// premier bassin rencontre.\n",
+    "// C'est precisement la que PSO (exploration globale par essaim) et SA (echappement des\n",
+    "// minima locaux par acceptation probabiliste de mouvements defavorables) deviennent\n",
+    "// indispensables - leur capacite distinctive est enfin mise a contribution.\n",
+    "static double ProfitSaisonnierNeg(double[] sol)\n",
+    "{\n",
+    "    double x = sol[0], y = sol[1];\n",
+    "    double baseConcave = 50*x + 80*y - x*x - 2*y*y - x*y;\n",
+    "    double saison = 120.0 * Math.Sin(1.2*x) * Math.Sin(1.2*y);\n",
+    "    return -(baseConcave + saison);\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"Profit saisonnier (multimodal) - PSO vs SA sur 5 seeds :\");\n",
+    "int[] seedsMM = { 0, 42, 123, 456, 789 };\n",
+    "Console.WriteLine($\"{\"Seed\",-6} {\"PSO profit\",-12} {\"SA profit\",-12} {\"PSO (x,y)\",-20} {\"SA (x,y)\",-20}\");\n",
+    "Console.WriteLine(new string('-', 72));\n",
+    "double psoBestMM = double.MinValue, saBestMM = double.MinValue, psoSumMM = 0, saSumMM = 0;\n",
+    "foreach (int sd in seedsMM)\n",
+    "{\n",
+    "    var (solP, fitP, _) = new PSO(2, 0.0, 20.0, ProfitSaisonnierNeg, 30, 100, seed: sd).Solve();\n",
+    "    var (solS, fitS, _) = new SA (2, 0.0, 20.0, ProfitSaisonnierNeg, 3000, tempInit: 50, alpha: 0.999, stepSize: 3.0, seed: sd).Solve();\n",
+    "    double profP = -fitP, profS = -fitS;\n",
+    "    psoSumMM += profP; saSumMM += profS;\n",
+    "    if (profP > psoBestMM) psoBestMM = profP;\n",
+    "    if (profS > saBestMM) saBestMM = profS;\n",
+    "    string posP = $\"({solP[0]:F2}, {solP[1]:F2})\";\n",
+    "    string posS = $\"({solS[0]:F2}, {solS[1]:F2})\";\n",
+    "    Console.WriteLine($\"{sd,-6} {profP,-12:F2} {profS,-12:F2} {posP,-20} {posS,-20}\");\n",
+    "}\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine($\"PSO : meilleur profit = {psoBestMM:F2}, moyenne = {psoSumMM/seedsMM.Length:F2}\");\n",
+    "Console.WriteLine($\"SA  : meilleur profit = {saBestMM:F2}, moyenne = {saSumMM/seedsMM.Length:F2}\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c01e6a2c",
+   "metadata": {},
+   "source": [
+    "### Lecture du contraste : quand le métaheuristique devient nécessaire\n",
+    "\n",
+    "La cellule ci-dessus oppose **deux paysages sur le même thème** (maximiser un profit d'entreprise) pour montrer précisément *quand* PSO et SA apportent quelque chose qu'une méthode classique ne pourrait pas.\n",
+    "\n",
+    "**Profit concave (première partie).** `P(x,y) = 50x + 80y − x² − 2y² − xy` est *unimodal* : un seul optimum, accessible analytiquement en annulant le gradient (`x ≈ 17,14`, `y ≈ 15,71`, `P ≈ 1057`). PSO et SA le retrouvent en une fraction de milliseconde. Sur un tel paysage, **une descente de gradient ferait l'affaire** — le métaheuristique n'apporte rien, et c'est une bonne chose de le vérifier d'abord (baseline de validation).\n",
+    "\n",
+    "**Profit saisonnier (deuxième partie).** On ajoute une cyclicité de marché :\n",
+    "\n",
+    "```\n",
+    "P(x,y) = 50x + 80y − x² − 2y² − xy  +  120·sin(1,2x)·sin(1,2y)\n",
+    "         ╰──────────────────────╯     ╰──────────────────────╯\n",
+    "           profit de base (concave)     saisonnalité du marché\n",
+    "```\n",
+    "\n",
+    "Le terme sinusoïdal grave **une grille d'une quinzaine de maxima locaux** aux bassins profonds dans `[0,20]²`. L'optimum n'est plus accessible analytiquement (`∇P = 0` est un système non-linéaire sans solution fermée), et une descente de gradient resterait **coincée dans le premier bassin rencontré**. C'est ici que le métaheuristique devient indispensable.\n",
+    "\n",
+    "**Ce que montre la comparaison multi-seed (5 tirages).** L'optimum global est à `(x,y) ≈ (17,01 ; 16,99)`, `P ≈ 1173,97`. Mais un second bassin attracteur existe autour de `(19,6 ; 14,4)` (`P ≈ 1170,8`), et les deux algorithmes s'y laissent parfois piéger :\n",
+    "\n",
+    "| | PSO (essaim, 30 particules) | SA (marche aléatoire recuite) |\n",
+    "|---|---|---|\n",
+    "| Meilleur profit sur 5 seeds | 1173,97 (optimum global) | 1173,97 (optimum global) |\n",
+    "| Moyenne sur 5 seeds | 1173,34 | 1172,61 |\n",
+    "| Atteint l'optimum global | 4 seeds / 5 | 1 seed / 5 |\n",
+    "\n",
+    "PSO est **plus robuste** sur ce paysage accidenté : son essaim de 30 particules explore plusieurs bassins en parallèle, ce qui lui permet de revenir du bassin sous-optimal vers le global dans la plupart des cas. SA, qui marche pas à pas depuis un seul point de départ, se laisse plus souvent enfermer dans un bassin local — sa capacité d'échappement (accepter un mouvement défavorable selon une probabilité qui décroît avec la température) ne suffit pas toujours quand le refroidissement est trop rapide.\n",
+    "\n",
+    "> **À retenir.** Aucun des deux algorithmes n'est infaillible : même PSO rate l'optimum global sur un seed (`456` → `1170,81`). C'est exactement **pourquoi on exécute plusieurs seeds** et qu'on rapporte meilleure + moyenne (et non un seul tirage, qui pourrait être chanceux ou malchanceux) — la même discipline que pour l'étude de la taille de population plus haut dans ce notebook. Sur un paysage *unimodal*, cette précaution est superflue (l'optimum analytique tranche) ; sur un paysage *multimodal*, elle devient **la condition même d'une conclusion fiable**. C'est tout l'intérêt d'un métaheuristique : non pas remplacer l'analyse quand elle suffit, mais **prendre le relais là où elle échoue**."
    ]
   },
   {


### PR DESCRIPTION
Grain: DEEP/fix-prongb-code — lane myia-po-2025:CoursIA — prev: MED/notebook-enrichment (c.620 Oncology)

G-VAR-3 OK : genre **fix-prongb-code** ≠ enrichment (casse la série enrichment : c.617 SC / c.618 ML / c.620 Oncology). Tier **DEEP** : produit un résultat falsifiable nouveau (comparaison quantitative PSO-vs-SA sur paysage multimodal calibré), demande du raisonnement de domaine (calibrage empirique itératif amplitude 60→120 pour une distinction nette). Famille **Search fraîche** (9e distincte ce cluster : Planning→Probas→IIT→SW→Sudoku→SC→ML→Oncology→Search). Litmus LIGHT échoue (concevoir/calibrer un paysage multimodal + interpréter multi-seed honnêtement = raisonnement, pas scan).

## Gap (Prong-B degeneracy : métaheuristique sur fonction unimodale)

`MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics-Csharp.ipynb` (.net-csharp, 28 cells). G.1 firsthand (git show origin/main) :

- **Cell 19** (markdown) dérive analytiquement l'optimum du profit `P(x,y) = 50x + 80y − x² − 2y² − xy` (∂P/∂x = 0, ∂P/∂y = 0) → `x ≈ 17,143, y ≈ 15,714, P ≈ 1057`.
- **Cell 20** (ec=11) **calcule cet optimum analytique en C# et l'imprime AVANT** de lancer PSO et SA (`Console.WriteLine($"Optimum analytique : x={xOpt:F4}, y={yOpt:F4}, profit={profitOpt:F4}")`), puis PSO/SA le retrouvent trivialement (`profit=1057,1429`, ~0,2 ms).

C'est le pattern Prong-B canonique (#3801) : un métaheuristique démontré sur une fonction **unimodale concave** où sa capacité distinctive (échapper aux minima locaux / explorer un paysage multimodal) est **invisible** — une descente de gradient ferait l'affaire, et le moteur « démontré » n'est jamais réellement mis à contribution. Le notebook fournit lui-même la réponse analytique dans la même cellule.

## What (contraste unimodal-trivial vs multimodal-nécessaire)

**Cell 20 MODIFIÉE in-place** (bloc concave **KEPT** comme baseline de validation — anti-regression) + **APPEND** d'un bloc « profit saisonnier » multimodal :
```
P(x,y) = 50x + 80y − x² − 2y² − xy  +  120·sin(1,2x)·sin(1,2y)
         ╰──────────────────────╯     ╰──────────────────────╯
           profit de base (concave)     saisonnalité du marché
```
Le terme sinusoïdal grave **~15 maxima locaux aux bassins profonds** dans `[0,20]²`. L'optimum n'est plus accessible analytiquement (`∇P = 0` = système non-linéaire sans solution fermée), et une descente de gradient resterait **coincée dans le premier bassin**.

**Comparaison multi-seed PSO vs SA** (5 tirages, seeds 0/42/123/456/789) — résultats re-exec .NET firsthand :

| | PSO (essaim ×30) | SA (walk recuit) |
|---|---|---|
| Meilleur profit (5 seeds) | **1173,97** (optimum global) | **1173,97** (optimum global) |
| Moyenne (5 seeds) | **1173,34** | **1172,61** |
| Atteint l'optimum global (~17,01 ; 16,99) | **4 seeds / 5** | **1 seed / 5** |

Bassin secondaire ~ (19,6 ; 14,4), P ≈ 1170,8 — les deux algorithmes s'y laissent piéger. **PSO est nettement plus robuste** (essaim explore plusieurs bassins en parallèle), SA plus souvent coincé (single walk). **MAIS aucun n'est infaillible** (PSO rate seed 456 → 1170,81) — c'est exactement pourquoi on exécute plusieurs seeds et qu'on rapporte meilleure + moyenne (pas un seul tirage chanceux), discipline déjà appliquée au tuning de population (cell 18).

**Nouvelle cell markdown interp** (index 21) : contraste unimodal-trivial (gradient suffit, analytique tranche) vs multimodal-nécessaire (analytique impossible, métaheuristique + multi-seed deviennent la condition d'une conclusion fiable).

## Honnêteté (G.9) — calibrage empirique itéré, 0 claim fabriquée

- **1er essai** (amplitude 60, ω=0,8) : écart PSO-vs-SA **sub-0,1 %** (les deux trouvent le global sur tous les seeds) — contraste trop faible pour exercer les moteurs. **Rejeté** (mes résultats firsthand montraient 1109,09 vs 1109,09/1108,99).
- **2e essai** (amplitude 120, ω=1,2) : écart **net** (PSO 4/5 vs SA 1/5 au global) — contraste qui met la capacité distinctive en évidence. **Retenu**.
- Chaque nombre du body et de la cell interp (1173,97 / 1173,34 / 1172,61 / 4/5 / 1/5 / positions 17,01-16,99 / 19,6-14,4) vient **directement des outputs .NET re-executés** (transplantés, jamais hand-édités). L'interp reconnaît explicitement que PSO n'est pas infaillible (1/5 rate) — **pas de sur-affirmation**.

## Scope (chirurgical, 1 fichier)

cell 20 modifiée in-place (bloc concave byte-préservé, bloc multimodal appendu, re-executée sur `.net-csharp`, **ec=11 KEPT** → pas de re-numérotation, pas de collision avec cell 22 ec=12) + 1 cell markdown interp insérée à l'index 21 (md = pas d'ec → pas de re-numérotation). **27/27 pre-existing cells byte-identiques** à `origin/main`.

## Validation (H.1 / H.3)

- **nbformat 4.5** `validate` OK ; **29 cells** (was 28).
- **C.1** : 0 `throw new NotImplemented`/`NotImplementedException`/`1/0` (cell code modifiée n'en introduit aucun).
- **H.3** : cell 20 ec=11 + 18 outputs réels ; 0 code cell non-exécutée.
- **Byte-identity** : 27/27 cells non-(20, 21) byte-identiques à origin/main.
- **Re-exec** : `jupyter nbconvert --execute --inplace --ExecutePreprocessor.timeout=600 --ExecutePreprocessor.kernel_name=.net-csharp` sur harness minimal `[imports, PSO class, SA class, cell20-modified]` → outputs transplantés (technique C.3, pas de --inplace full qui aurait churné cell 18 `Temps (ms)`).
- **strip_probe_banner --apply** : 0 probeAddresses banner (notebook propre).
- **no-leak** : 0 chemin machine / IP / probeAddresses dans les outputs (regex check).
- **LF** (0 CRLF au niveau fichier ; les `\r\n` dans les strings stdout sont les données console .NET, cohérentes avec cell 18 et le reste du notebook) ; UTF-8 no-BOM.
- **Catalogue byte-identique** (non dans le diff → catalog-guard CI OK).

## Variation (R6 / G-VAR-3)

c.617 MED/enrichment (SC) · c.618 MED/enrichment (ML) · c.619 DEEP/fix-prongb (Infer-4) · c.620 MED/enrichment (Oncology) · **c.621 DEEP/fix-prongb-code (Search-11)**. Genre fix-prongb-code casse la série enrichment×3. Famille **Search fraîche** (9e distincte). Tier **DEEP** (calibrage empirique itératif amplitude 60→120 + interprétation multi-seed honnête = raisonnement de domaine, pas scan).

See #3801 (SOTA/Prong-B — le notebook exerce désormais PSO+SA sur un problème assez riche pour que leur capacité distinctive soit visible dans la sortie, au lieu d'un cas unimodal où ils dégénèrent en baseline triviale ; auparavant l'optimum était calculé analytiquement dans la même cellule, rendant le métaheuristique superflu).

Generated with Claude Code
