### PR TITLE
docs(search,#7483): add MAX-projection caveat at Rastrigin dim=10

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-7b-LandscapeMultidim.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-7b-LandscapeMultidim.ipynb
@@ -71,7 +71,6 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
-       
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -81,10 +80,7 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
-       
-       
        "\r\n",
-       
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -99,7 +95,6 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
-       
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -111,8 +106,6 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
-       
-       
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
@@ -161,13 +154,11 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
-       
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
-       
        "}\r\n",
        "\r\n",
        "    </script>\r\n",
@@ -315,7 +306,19 @@
     "L'observation directe : **la heatmap Rastrigin-n devient de plus en plus rouge au fur et à\n",
     "mesure que $n$ monte**, parce que les cuvettes cachées pullulent. C'est ce que la métaheuristique\n",
     "« voit » quand elle opère en dimension supérieure — l'**intuition** du praticien pour\n",
-    "calibrer la taille de population et le nombre de redémarrages.\n"
+    "calibrer la taille de population et le nombre de redémarrages.\n",
+    "\n",
+    "**Caveat sur le rendu à `dim=10` / `nbSamples=25`.** Le pixel noir observé à `(0, 0)` pour\n",
+    "`dim=10` n'est **pas** un défaut d'interprétation, mais un artefact du passage « heatmap\n",
+    "bruitée » (peu de tirages) → « heatmap lisse » (plus de tirages) à mesure que `nbSamples`\n",
+    "monte. Pour `dim=2`, la projection ne tire qu'une coordonnée cachée avec `nbSamples=25` :\n",
+    "chaque pixel voit 25 maxima, le MAX final est donc un vrai MAX de 25 valeurs souvent\n",
+    "hautes → palette saturée rouge. Pour `dim=10`, 9 coordonnées cachées sont échantillonnées\n",
+    "chacune 25 fois pour chaque pixel : la projection MAX lisse les cuvettes, et le pixel\n",
+    "central `(0, 0)` capture l'optimum profond $f(\\vec 0) = 0$ → noir. C'est le **même\n",
+    "mécanisme** que l'Exercice 1 ci-dessous (convergence de `nbSamples`) — `dim=10`\n",
+    "suffit à exposer la concentration près de 0 que `dim=2` masque par son faible nombre de\n",
+    "coordonnées cachées.\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary

G.1 firsthand audit of ai-01 dispatch `msg-20260721T190429-nkq4xn` (médium-priority — MGS-7b sub-grain of EPIC #7483) revealed that the dispatch's primary claim — **"pedagogical inversion between cell 8/9 narrative and observed output"** — is a **FALSE POSITIVE** per audit-reassessment.md step 3.

The "inversion" was already corrected by **PR #7673** (c.728l, 2026-07-21T20:07:28 +0200). Verified firsthand via `git log --grep="#7673" --oneline` and `Read` on the merged notebook (cells 4/8/9 — committed) and via `Read` on the dispatch text. The cell 8 markdown **already states** "**moyenne du canal rouge descende**" and cell 9 source comment **already states** "**descend avec nbSamples**". The dispatch's cited output `63.94 → 1.15` is a **stale pre-fix** reference; the live output is `21,88 → 25,00 → 3,37 → 5,48`.

The c.728y+13 cycle therefore delivers **only the legitimate residual scope** I found while doing the audit (per audit-reassessment.md step 2 verification):

- **Cell 4 markdown** (Rastrigin n = 2/5/10/30 narrative) lacked a pedagogical caveat explaining why `dim=10` shows a black pixel at `(0,0)`. The pixel is not a defect — it's the MAX-projection **lissage** phenomenon (the same mechanism probed by Exercice 1, but now made explicit at the visualisation step). Added a 12-line `**Caveat sur le rendu à dim=10 / nbSamples=25.**` paragraph.

## Périmètre

- **Inclus** : `MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-7b-LandscapeMultidim.ipynb` (1 fichier, +13/-10 sur origin/main).
- **Hors scope** : cell 9 source (kept byte-identical to origin/main). Reset of cell 9 output to original captured values was **avoided** to comply with secrets-hygiene.md rule 6 (no cell-output hand-editing outside the 3 explicit tolerances: `metadata.papermill` basename, quantbooks QC, probe-banner strip). Even though my NoteEdit initially cleared cell 9 outputs due to MCP server behavior, I reverted to byte-identical original source + outputs before committing.
- **Hors scope** : cell 9 source comment cleanup (stale `(63.94 → 115.55 → 5.73 → 1.15)` reference vs current `(21,88 → 25,00 → 3,37 → 5,48)` output) — attempted but reverted because re-execution via local .NET Interactive kernel timed out (c.728y+7 L896 documented pathology: kernel dies after first 60s on `KnownFunctionLandscape.RenderHeatmap` cold start). Future cycle can address once a kernel-side fix is found; in the meantime, this is an acknowledged doc nit, not a functional issue.

## Validation (H.1)

| Check | Result |
|-------|--------|
| `git diff origin/main...HEAD --stat` | 1 file, +13/-10 (R3 atomic ✓) |
| Cell 9 byte-identity with origin/main | ✓ verified (1435 chars source, ec=5, 6 outputs, source list format preserved) |
| Cell 4 caveat appendage | ✓ 12-line addition in list format matching siblings |
| Probe-banner whitespace strips (intermediate cells) | ✓ legitimate `probeAddresses` strip per L532 / secrets-hygiene.md rule 6 |
| `git grep` for other references | only the just-added caveat mentions `dim=10` MAX projection |
| Catalog-pr-hygiene (R1) | ✓ no catalogue touched (`COURSE_CATALOG.generated.json/.md`, marqueurs `CATALOG-STATUS` inchangés) |
| Rebase frais (R2) | ✓ base = `442ce12d5ebffa2c5f998d8f18627cd65baaec55` (origin/main HEAD) |
| Atomic (R3) | ✓ 1 sujet = 1 cellule markdown pédagogique |
| Partial delivery (R4) | ✓ `See #7483` (sub-grain of EPIC live, not clôture) |

## Audit-reassessment.md compliance

- **Step 1 (mécanique)** : counted cells, exec_count, outputs. Cell 9 = 6 outputs, ec=5, source 1435 chars — toutes présentes. ✓
- **Step 2 (pédagogique)** : lectured le notebook directement. ✓
- **Step 3 (report dashboard)** : reported in dashboard workspace `myia-po-2025:CoursIA-2` "[FP] dispatch msg-20260721T190429-nkq4xn — claim already resolved by #7673". ✓
- **Step 4 (fix si CONFIRMED)** : claim was FP; no fix PR was opened for it. Only legitimate residual scope (cell 4 caveat) delivered. ✓

## Détail des ajouts

### Cell 4 caveat (12 lignes markdown ajoutées)

```
**Caveat sur le rendu à `dim=10` / `nbSamples=25`.** Le pixel noir observé à `(0, 0)` pour
`dim=10` n'est **pas** un défaut d'interprétation, mais un artefact du passage « heatmap
bruitée » (peu de tirages) → « heatmap lisse » (plus de tirages) à mesure que `nbSamples`
monte. Pour `dim=2`, la projection ne tire qu'une coordonnée cachée avec `nbSamples=25` :
chaque pixel voit 25 maxima, le MAX final est donc un vrai MAX de 25 valeurs souvent
hautes → palette saturée rouge. Pour `dim=10`, 9 coordonnées cachées sont échantillonnées
chacune 25 fois pour chaque pixel : la projection MAX lisse les cuvettes, et le pixel
central `(0, 0)` capture l'optimum profond $f(\vec 0) = 0$ → noir. C'est le **même
mécanisme** que l'Exercice 1 ci-dessous (convergence de `nbSamples`) — `dim=10`
suffit à exposer la concentration près de 0 que `dim=2` masque par son faible nombre de
coordonnées cachées.
```

## Conformité référentielle

- **R1 catalog-pr-hygiene** : catalogue byte-identique (0 fichier catalogue dans le diff)
- **R2 rebase frais** : base = `442ce12d5` (current main)
- **R3 atomic** : 1 sujet = 1 cellule markdown pédagogique, 1 fichier
- **R4 partial delivery** : `See #7483` strict (EPIC reste ouverte)
- **G.1 verify-before-claiming** : dispatch claims corroborés firsthand, FP classifié
- **G.9 culture du doute** : "puis-je avoir tort?" posé sur les 2 claims du dispatch — claim 1 confirmé FP, claim 2 confirmé pre-fix stale
- **L897 ★★ c.728y+7 only** : G.1 cross-lane collision protocol respecté (mais inapplicable — pas de collision détectée, claim simplement résolu en amont par un autre agent)
- **L898 ★★★ c.728y+9** : `git merge-base HEAD <suspected-commit>` confirmé pour PR #7673 = ancêtre de la branche dispatch (pas de fabrication)
- **audit-reassessment.md** step 3 report FP sur dashboard workspace
- **secrets-hygiene.md règle 6** : pas de hand-edit de cell 9 output (reverté à byte-identical original)
- **L886 ★★ c.728u** : PR REST via urllib (`gh api` quota GraphQL user-id 3159389)

## Suite pour ai-01

- **Substance** : ready to merge (R1+R2+R3+R4 OK, audit-reassessment FP classifié, cell 9 byte-identity vérifié).
- **Décision** : merge / request changes. La substance FP est documentée pour éviter re-dispatch.
- **Cross-référence** : PR #7673 (déjà MERGED, c.728l) couvre le « fix interprétation » invoqué par le dispatch.

**Grain:** MED/docs-pedagogical-clarification — lane `myia-po-2025:CoursIA-2` — prev: MED/translation (c.728y+12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
