### PR TITLE
fix(prover,#7477): launcher target-line guard — reconcile stale line vs description intent (P2b)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py
@@ -10,6 +10,7 @@ Supports both demo-based (from prover/__init__.py DEMOS) and direct file/line ta
 import argparse
 import asyncio
 import json
+import re
 import sys
 import time
 from pathlib import Path
@@ -148,6 +149,73 @@ def _derive_result_kind(result, final_sorry: int, original_sorry: int) -> str:
     return "no_progress"
 
 
+# P2b (#7477 forensic): the launcher must aim at the line the DEMO description
+# *intends*, not a stale `line` INT field. Descriptions embed two
+# human-authored markers that `line` can drift away from after edits shift
+# line numbers:
+#   - "CURRENT TARGET = ... L<N>"  -> the intended target line
+#   - "DO NOT TARGET <token>"      -> regions/lines to avoid
+# Founding forensic (DEMO 62): a baseline run burned its whole remaining
+# budget on a DO-NOT-TARGET line (NW L2970) while the description said
+# CURRENT TARGET = ne (L2973). #6871 re-pointed the `line` field nw->ne by
+# hand — but nothing prevents the stale-`line` class of bug from recurring.
+# This reconciles the two before the run starts: warn always, and redirect
+# `line` to the description's CURRENT TARGET on an unambiguous disagreement
+# (the description is the human-authored intent, kept current — cf #6871).
+# Conservative by design: warn-only on ambiguity, never hard-fail (the
+# operator can still override via --file/--line); a no-op on every DEMO whose
+# description carries no marker.
+_DO_NOT_TARGET_RE = re.compile(r"DO\s*NOT\s*TARGET\s+([A-Za-z0-9_-]+)", re.IGNORECASE)
+_CURRENT_TARGET_RE = re.compile(
+    r"CURRENT\s+TARGET\s*=\s*.*?(?:L|line\s+?)(\d{2,6})", re.IGNORECASE
+)
+
+
+def _resolve_target_line(demo, line):
+    """P2b (#7477): reconcile ``demo['line']`` with the description's intent.
+
+    Returns ``(resolved_line, warnings)`` where ``warnings`` is a list of
+    human-readable strings (empty when the target is clean). ``resolved_line``
+    is the line the launcher should aim at: the description's CURRENT TARGET
+    when it parses to a single line that disagrees with the ``line`` field,
+    otherwise the original ``line`` unchanged. Never raises.
+    """
+    warnings = []
+    description = (demo or {}).get("description") or ""
+    if not description:
+        return line, warnings
+
+    # DO NOT TARGET tokens — informational only. These are region names (NW,
+    # ne) or line labels, NOT line numbers; the token<->line association lives
+    # in free-text prose and is too fragile to map mechanically, so we surface
+    # the tokens for the operator without acting on them.
+    do_not_target = _DO_NOT_TARGET_RE.findall(description)
+    if do_not_target:
+        warnings.append(
+            "description marks DO NOT TARGET: " + ", ".join(do_not_target)
+        )
+
+    # CURRENT TARGET line — the authoritative intended target.
+    current_matches = _CURRENT_TARGET_RE.findall(description)
+    if len(current_matches) == 1:
+        current_line = int(current_matches[0])
+        if line is not None and current_line != line:
+            warnings.append(
+                f"description CURRENT TARGET line {current_line} differs from "
+                f"demo line field {line} — redirecting to {current_line} "
+                f"(description is the human-authored intent; cf #6871)"
+            )
+            return current_line, warnings
+    elif len(current_matches) > 1:
+        # Ambiguous parse (multiple CURRENT TARGET lines) — do not guess.
+        warnings.append(
+            f"description has {len(current_matches)} CURRENT TARGET line "
+            f"matches {current_matches} — ambiguous, not redirecting"
+        )
+
+    return line, warnings
+
+
 def run_prover(demo_num: int = None, filepath: str = None, line: int = None,
                mode: str = "multi", iterations: int = 8,
                provider: str = "zai", local_provider: str = "local",
@@ -169,6 +237,14 @@ def run_prover(demo_num: int = None, filepath: str = None, line: int = None,
         filepath = demo["file"]
         line = demo.get("line")
         name = demo["name"]
+        # P2b (#7477): reconcile the target line with the description intent
+        # before acquiring the tree lock. A stale `line` field (post-edit line
+        # drift) silently aims the whole run at a DO-NOT-TARGET region and the
+        # burn is invisible until iteration_cap. Warn always, redirect on an
+        # unambiguous CURRENT TARGET disagreement.
+        line, _target_warnings = _resolve_target_line(demo, line)
+        for _w in _target_warnings:
+            print(f"[TARGET-GUARD] {_w}")
     elif filepath:
         demo = {"file": filepath, "name": f"custom_{Path(filepath).stem}_L{line}",
                 "line": line, "goal": goal}

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_p2b_target_guard.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_p2b_target_guard.py
@@ -1,0 +1,175 @@
+"""Unit tests for #7477 P2b — launcher target-line guard.
+
+The launcher reads ``demo['line']`` (an INT) and aims the whole run at it.
+DEMO descriptions also embed two human-authored markers that ``line`` can
+drift away from after edits shift line numbers:
+
+  - ``"CURRENT TARGET = ... L<N>"``  -> the intended target line
+  - ``"DO NOT TARGET <token>"``      -> regions/lines to avoid
+
+Founding forensic (DEMO 62): a baseline run burned its whole remaining budget
+on a DO-NOT-TARGET line (NW L2970) while the description said CURRENT TARGET =
+ne (L2973). #6871 re-pointed the ``line`` field nw->ne by hand, but nothing
+prevented the stale-``line`` class of bug from recurring.
+
+``run_prover_bg._resolve_target_line`` is the guard: it parses the markers and
+returns ``(resolved_line, warnings)``. Conservative contract exercised here:
+
+  * no marker        -> line unchanged, no warning (no-op on clean DEMOs)
+  * AGREE            -> line unchanged, no warning
+  * single DISAGREE  -> redirect to CURRENT TARGET line + warning
+  * ambiguous parse  -> line unchanged + warning (do not guess)
+  * DO NOT TARGET    -> informational warning (region name, not acted on)
+
+Run from ``agent_tests/``::
+
+    python -m pytest tests/test_prover_p2b_target_guard.py -q
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Make `prover/` importable regardless of how pytest was invoked (same
+# bootstrap convention as tests/test_prover_correctly_refused.py).
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+sys.path.insert(0, str(ROOT))
+
+from prover import run_prover_bg  # noqa: E402
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# _resolve_target_line — the P2b reconciliation contract
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _resolve(demo, line):
+    """Thin wrapper so each test reads as the verdict for one scenario."""
+    return run_prover_bg._resolve_target_line(demo, line)
+
+
+# --- no marker: total no-op (the guard must not perturb clean DEMOs) ------
+
+
+def test_no_description_is_noop():
+    """A DEMO without a description field leaves the line untouched."""
+    resolved, warnings = _resolve({"name": "X"}, line=500)
+    assert resolved == 500
+    assert warnings == []
+
+
+def test_empty_description_is_noop():
+    """An empty description leaves the line untouched."""
+    resolved, warnings = _resolve({"description": ""}, line=500)
+    assert resolved == 500
+    assert warnings == []
+
+
+def test_description_without_markers_is_noop():
+    """A description with neither CURRENT TARGET nor DO NOT TARGET is a no-op."""
+    resolved, warnings = _resolve(
+        {"description": "Prove foo. The sorry is at L446. Use div_le_iff."},
+        line=446,
+    )
+    assert resolved == 446
+    assert warnings == []
+
+
+# --- AGREE: line field already matches the description intent ------------
+
+
+def test_current_target_agrees_no_redirect():
+    """When the line field already equals the CURRENT TARGET line, no redirect
+    and no warning. (This is DEMO 62 today: line=2973, CURRENT TARGET=ne L2973.)"""
+    demo = {
+        "line": 2973,
+        "description": "NW STATUS - DO NOT TARGET NW. CURRENT TARGET = ne quadrant (L2973): prove.",
+    }
+    resolved, warnings = _resolve(demo, line=2973)
+    assert resolved == 2973
+    # DO NOT TARGET NW is still surfaced (informational), but no disagreement.
+    assert any("DO NOT TARGET" in w for w in warnings)
+    assert not any("redirecting" in w for w in warnings)
+
+
+# --- single DISAGREE: redirect to the description's CURRENT TARGET -------
+
+
+def test_current_target_disagreement_redirects():
+    """A stale line field that disagrees with a single CURRENT TARGET line is
+    redirected, with a warning citing both numbers. This is the founding
+    forensic class: description moved on, the INT field did not."""
+    demo = {
+        "line": 2970,  # stale (was nw, before #6871 re-pointed)
+        "description": "CURRENT TARGET = ne quadrant (L2973): from hypothesis.",
+    }
+    resolved, warnings = _resolve(demo, line=2970)
+    assert resolved == 2973
+    assert len(warnings) == 1
+    assert "2973" in warnings[0] and "2970" in warnings[0]
+    assert "redirecting" in warnings[0]
+
+
+def test_current_target_does_not_infer_missing_line():
+    """A DEMO whose `line` field is None is left None even when the
+    description states a CURRENT TARGET. The guard's contract is to reconcile
+    a *disagreement* (a stale INT field), not to infer a missing one — a
+    multi-sorry agent-driven DEMO may legitimately omit `line`, and silently
+    pinning it from the description could mask a config error or mis-target
+    the run. None cannot disagree, so there is nothing to reconcile."""
+    demo = {"description": "CURRENT TARGET = se quadrant (L2977): prove."}
+    resolved, warnings = _resolve(demo, line=None)
+    assert resolved is None  # not inferred
+    assert warnings == []    # no disagreement to warn about
+
+
+# --- ambiguous parse: do not guess ---------------------------------------
+
+
+def test_multiple_current_target_lines_does_not_redirect():
+    """When the description carries more than one CURRENT TARGET line number,
+    the guard refuses to guess — line unchanged, ambiguity surfaced."""
+    demo = {
+        "line": 2973,
+        "description": (
+            "CURRENT TARGET = ne quadrant (L2973): prove. "
+            "Earlier we had CURRENT TARGET = nw (L2970) but that is factored."
+        ),
+    }
+    resolved, warnings = _resolve(demo, line=2973)
+    assert resolved == 2973  # unchanged
+    assert any("ambiguous" in w for w in warnings)
+
+
+# --- DO NOT TARGET: informational only -----------------------------------
+
+
+def test_do_not_target_token_stripped_clean():
+    """The DO NOT TARGET token is captured without trailing punctuation
+    (region name only), so the warning reads cleanly."""
+    demo = {
+        "line": 2973,
+        "description": "NW STATUS - DO NOT TARGET NW: factored. No CURRENT TARGET marker.",
+    }
+    resolved, warnings = _resolve(demo, line=2973)
+    assert resolved == 2973
+    dnt = [w for w in warnings if "DO NOT TARGET" in w]
+    assert len(dnt) == 1
+    assert "NW" in dnt[0]
+    assert "NW:" not in dnt[0]  # trailing colon stripped, not captured
+
+
+def test_do_not_target_line_label_informative():
+    """A 'DO NOT TARGET L2970' style marker is surfaced as information; the
+    guard does not map it to the line field (the association is too fragile),
+    so a line that happens to equal it is NOT auto-redirected on that basis
+    alone."""
+    demo = {
+        "line": 2970,
+        "description": "DO NOT TARGET L2970 (factored into a private lemma).",
+    }
+    resolved, warnings = _resolve(demo, line=2970)
+    assert resolved == 2970  # no CURRENT TARGET -> no redirect basis
+    assert any("DO NOT TARGET" in w for w in warnings)


### PR DESCRIPTION
## Summary

P2b (#7477 forensic) — the **last bounded + independent** piece of the prover-harness forensic. The launcher reads `demo['line']` (an INT) and aims the whole run at it. DEMO descriptions also embed two human-authored markers that `line` drifts away from after edits shift line numbers:

- `"CURRENT TARGET = ... L<N>"` → the intended target line
- `"DO NOT TARGET <token>"` → regions/lines to avoid

**Founding forensic (DEMO 62):** a baseline run burned its whole remaining budget on a DO-NOT-TARGET line (NW L2970) while the description said `CURRENT TARGET = ne (L2973)`. [#6871](https://github.com/jsboige/CoursIA/pull/6871) re-pointed the `line` field nw→ne **by hand** — but nothing prevents the stale-`line` class of bug from recurring.

P2a ([#7500](https://github.com/jsboige/CoursIA/pull/7500)) was the *reactive* half (score `correctly_refused` when the agent refuses + early-exit). **P2b is the *preventive* half**: reconcile the target line with the description intent *before* the run starts, so a stale `line` field never silently aims the run at a DO-NOT-TARGET region.

## The fix

`run_prover_bg._resolve_target_line(demo, line)` — parses the description markers, returns `(resolved_line, warnings)`:
- **No marker** → no-op (line unchanged, no warning).
- **AGREE** (line field == CURRENT TARGET) → line unchanged; DO NOT TARGET tokens surfaced as information.
- **Single DISAGREE** → redirect `line` to the description's CURRENT TARGET + warning citing both numbers.
- **Ambiguous parse** (multiple CURRENT TARGET lines) → line unchanged + ambiguity warning (do not guess).
- **DO NOT TARGET tokens** → informational warning only (region names, not line numbers; the token↔line association lives in free-text prose and is too fragile to map mechanically).

Called in `run_prover()` right after `demo['line']` is read, before the tree lock. Conservative by design: **warn-only on ambiguity, never hard-fail** (operator can still override via `--file/--line`); a no-op on every DEMO whose description carries no marker.

**Scope-verified firsthand:** only DEMO 62 carries these markers today, and it **AGREEs** (`line=2973 == CURRENT TARGET 2973`). The guard is a pure defensive no-op on the current fleet — zero false-redirect risk.

## Validation (H.1 firsthand)

```
$ python -m pytest tests/test_prover_p2b_target_guard.py -q
  9 passed   (no-marker no-op, AGREE, single-DISAGREE redirect,
              ambiguous-no-guess, DO NOT TARGET informational, None-no-infer)

$ python -m pytest tests/test_prover_{correctly_refused,decomposition_regression,
  heartbeat_budget,reasoning_budget,p1b_timeout}.py -q
  67 passed   (P1b/P2a/P3/P5a/P5a-search regression — no result-kind contract broken)

$ smoke (real DEMO 62):        line=2973 resolved=2973, AGREE, no false redirect
$ smoke (stale-line sim 2970): resolved=2973, redirect fires, warning cites 2970+2973+#6871
```

P2b is **launcher-side** — it does **not** touch `_derive_result_kind` / the result-kind contract that baselines + tests depend on (my c.550 flag was about P5a/P1b contract-touching fixes; P2b is independent, as the issue body states: "P2b ... bounded and independent").

## Scope (anti-regression)

- `+76/-0` on `run_prover_bg.py` (pure additive: 1 helper + 2 regexes + 1 guard call + `import re`).
- `+1` new test file `tests/test_prover_p2b_target_guard.py` (9 cases).
- No `.lean` touched, no `sorry` touched, no result-kind contract touched, no notebook touched.
- Catalogue byte-identical to main.

See #7477 (the last bounded+independent piece; P1a [#7482], P1b [#7532], P2a [#7500], P3 [#7571], P4 [#7533], P5a [#7548]+[#7629], P6 [#7572] all delivered). See #1453.

Grain: MED/fix-prover-harness — lane po-2026:CoursIA — prev: LIGHT/translation-resync (c.614 rl_10 #7772).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
