### PR TITLE
i18n(lean,#4980): conway_lean LookAndSay.lean inline-docstrings EN->FR flip

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/LookAndSay.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/LookAndSay.lean
@@ -34,7 +34,7 @@ import Mathlib.Data.List.Basic
 
 namespace Conway
 
-/-- Split a number into its decimal digits (most significant first).
+/-- Décompose un entier en ses chiffres décimaux (chiffre le plus significatif en premier).
   1211 → [1, 2, 1, 1]  -/
 def natToDigits (n : Nat) : List Nat :=
   if n = 0 then []
@@ -42,15 +42,15 @@ def natToDigits (n : Nat) : List Nat :=
   termination_by n
   decreasing_by omega
 
-/-- Convert a list of digits (most significant first) to a Nat.
+/-- Convertit une liste de chiffres (le plus significatif en premier) en un Nat.
   [1, 2, 1, 1] → 1211 -/
 def digitsToNat : List Nat → Nat
   | [] => 0
   | d :: ds => d * 10 ^ ds.length + digitsToNat ds
 
-/-- Run-length encode a list: group consecutive equal elements.
+/-- Encodage run-length d'une liste : regroupe les éléments consécutifs égaux.
   [1, 1, 2, 2, 2, 1] → [(2, 1), (3, 2), (1, 1)]
-  Uses fuel to satisfy the termination checker. -/
+  Utilise un carburant (fuel) pour satisfaire le vérificateur de terminaison. -/
 def runLengthAux : Nat → List Nat → List (Nat × Nat)
   | 0, _ => []
   | _ + 1, [] => []
@@ -58,28 +58,28 @@ def runLengthAux : Nat → List Nat → List (Nat × Nat)
     match as.span (· = a) with
     | (eqs, rest) => (eqs.length + 1, a) :: runLengthAux fuel rest
 
-/-- Run-length encode a list (wrapper with sufficient fuel). -/
+/-- Encodage run-length d'une liste (enveloppe avec carburant suffisant). -/
 def runLength (l : List Nat) : List (Nat × Nat) :=
   runLengthAux (l.length + 1) l
 
-/-- Flatten (count, digit) pairs into a digit list: [(2,1), (3,2)] → [2,1,3,2] -/
+/-- Aplatit les paires (compte, chiffre) en une liste de chiffres : [(2,1), (3,2)] → [2,1,3,2] -/
 def flattenPairs : List (Nat × Nat) → List Nat
   | [] => []
   | (count, digit) :: rest =>
     natToDigits count ++ [digit] ++ flattenPairs rest
 
-/-- One step of the look-and-say transformation.
-  Read digits left-to-right, output run-length encoding as a number. -/
+/-- Une étape de la transformation look-and-say.
+  Lit les chiffres de gauche à droite, produit l'encodage run-length sous forme d'entier. -/
 def lookAndSayStep (n : Nat) : Nat :=
   if n = 0 then 0
   else digitsToNat (flattenPairs (runLength (natToDigits n)))
 
-/-- Generate the n-th look-and-say number (0-indexed, seed = 1) -/
+/-- Génère le n-ième nombre de la suite look-and-say (indexé depuis 0, germe = 1) -/
 def lookAndSay : Nat → Nat
   | 0 => 1
   | n + 1 => lookAndSayStep (lookAndSay n)
 
--- Verify the first 6 terms of the look-and-say sequence
+-- Vérifie les 6 premiers termes de la suite look-and-say
 #eval! lookAndSay 0  -- 1
 #eval! lookAndSay 1  -- 11
 #eval! lookAndSay 2  -- 21


### PR DESCRIPTION
Grain: MED/i18n-Lean

i18n(lean,#4980): conway_lean LookAndSay.lean inline-docstrings EN->FR flip

LookAndSay.lean était half-done : son module doc était déjà basculé FR lors
d'une passe antérieure (et déclare déjà la convention canonique FR-first
#4980 + le sibling `LookAndSay_en.lean`), mais les 7 docstrings inline `/--`
+ 1 commentaire `--` autonome restaient EN. C'est exactement le pattern
HALF_DONE surfaced par le checker fusionné (PRs #7763/#7774) : le corps
identique du bloc-commentaire partagé entre le canonique FR et le sibling EN.

## Changement

Flip des 7 docstrings inline (natToDigits, digitsToNat, runLengthAux, runLength,
flattenPairs, lookAndSayStep, lookAndSay) EN->FR avec français accentué conforme
à la convention du lac pilote FR-first conway_lean (et au module doc déjà en FR).
Aussi le commentaire `--` autonome avant le bloc `#eval!`. Domaine : chiffres
décimaux, encodage run-length, carburant (fuel) pour le vérificateur de
terminaison, suite look-and-say.

## Preuve byte-identity (anti-regression §B)

Changement docstring/commentaire uniquement — signatures, defs, tactiques,
`#eval!`, noms de théorèmes restent byte-identical. En strippant tous les blocs
`/- ... -/` et commentaires `--` de LookAndSay.lean origin/main et de cette
version, le résidu de code est byte-identical (sha1
`d7a092a0db177556748c8bd51203e3d5755d1375` = match). Les docstrings étant des
commentaires, la compilation est provably unaffected. sorry count inchangé
(0 = 0).

## Dogfood (checker fusionné #7763/#7774)

Re-run de `check_i18n_siblings.py` sur conway_lean après ce flip :
`LookAndSay_en.lean` reporté `OK` (était `HALF-DONE`), et le compteur half-done
du lake chute de 1. Preuve end-to-end que l'advisory fusionné traque l'état réel
de migration et un-flag correctement quand le canonique est basculé.

## Scope

Canonique `LookAndSay.lean` uniquement. Le sibling `LookAndSay_en.lean` n'est
pas touché (son rôle est de porter les docstrings EN). Cela préserve l'Option A
sibling-pair (FR canonique <-> EN sibling). Jumeau du flip Fractran c.767 (#7777).

## Transparence variation (R6 / règle 4)

C'est le 4e lake Lean de la lane ce cycle (après Fractran #7777) + genre
back-to-back (i18n-Lean). Procédé sous le mandat HARD R6 no-idle après avoir
exhaustivement confirmé que les veines non-Lean/non-.NET sont drainées (READMEs,
Prong-B ML.Net, exercise-deficit, docs-links, GenAI-C.2=FP). La preuve
byte-identity + le dogfood du checker rendent ce grain trivialement vérifiable.

Diff : 1 fichier, +10/-10.

See #4980
