### PR TITLE
docs(sudoku-6): interpret CBJ benchmark — reconcile backjumping promise with CBJ~FC parity on easy

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb
@@ -1998,6 +1998,32 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ecc2340b",
+   "metadata": {},
+   "source": [
+    "### Lecture du benchmark : ce que les chiffres révèlent du « piège CBJ »\n",
+    "\n",
+    "Le tableau ci-dessus confirme chiffrée la mise en garde énoncée plus haut, et révèle une nuance que la prose qualitative ne disait pas :\n",
+    "\n",
+    "| Stratégie | Assignations | Backtracks | Temps (ms) |\n",
+    "|-----------|-------------|------------|------------|\n",
+    "| Backtracking MRV+LCV (nu) | **366** | 10 | 158 |\n",
+    "| Conflict-Based Backjumping | **82** | **1** | 82 |\n",
+    "| Forward Checking | 91 | 10 | 82 |\n",
+    "\n",
+    "**Deux observations honnêtes, l'une attendue, l'autre plus subtile.**\n",
+    "\n",
+    "1. **Le backjumping tient sa promesse théorique — sur les backtracks.** CBJ divise les assignations par ~4,5 (366 → 82) et les retours arrière par 10 (10 → 1) face au backtracking MRV+LCV nu. En évitant de remonter chronologiquement vers des variables sans lien avec le conflit, CBJ court-circuite effectivement les branches mortes : c'est exactement ce que prédisait la théorie de Prosser (1993).\n",
+    "\n",
+    "2. **Mais sur ces puzzles faciles, CBJ ≈ Forward Checking.** Regardez la dernière ligne : FC fait 91 assignations et 10 backtracks en 82 ms, quand CBJ fait 82 assignations et **1 seul** backtrack… en **82 ms aussi**. Le backjumping divise pourtant les backtracks par 10 (10 → 1) sans se traduire en gain de temps. Pourquoi ? Parce que la gestion des *conflict sets* (détection, fusion au backjump) a un **coût de bookkeeping** qui compense exactement le gain de retours arrière évités — et parce que sur ces puzzles faciles, la **propagation de contraintes de FC supprime déjà l'essentiel** des branches mortes avant même qu'un conflit ne se matérialise.\n",
+    "\n",
+    "**C'est tout le sens du « piège » annoncé.** Sur des puzzles faciles, ce n'est pas le backjumping qui fait le travail, c'est la propagation : FC (propagation à 1 niveau) suffit, et CBY n'apporte qu'un gain marginal (82 vs 91 assignations) par-dessus. La supériorité théorique de CBJ — remonter au coupable d'un conflit plutôt qu'au prédécesseur immédiat — ne paie vraiment que sur des puzzles **difficiles** comportant de **longues chaînes de conflit** que le backtracking chronologique explorerait vainement. C'est précisément pourquoi le framing prévenait qu'« il faut le combiner avec des heuristiques de sélection **et** de propagation de contraintes » : CBJ seul, sans FC/AC-3, plafonne là où la propagation serait déterminante.\n",
+    "\n",
+    "> **À retenir.** Un benchmark sur des instances faciles peut faire croire qu'un algorithme « théoriquement supérieur » tient sa promesse (CBJ a bien 1 backtrack contre 10) tout en masquant qu'il n'apporte rien de mesurable par-dessus une propagation simple (CBJ ≈ FC en temps). La leçon « ne jugez pas un algorithme seulement sur des instances faciles » se lit ici dans les chiffres : pour départager CBJ et FC, il faudrait des puzzles où la profondeur des conflits fait décoller CBJ — ou, à l'inverse, où l'overhead de bookkeeping le fait perdre."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "69fac6e4",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
Grain: MED/notebook-enrichment — lane myia-po-2025:CoursIA — prev: MED/fix (c.621b GT-8 #7780)

G-VAR-3 OK : genre **enrichment** ≠ fix (c.621a Search fix-prongb · c.621b GT-8 fix). Casse la série fix×2. Tier **MED** : interprétation non-triviale d'un benchmark réel (relier des nombres concrets à un framing qualitatif + insight CBJ≈FC non-énoncé), pas un enrichissement scan-générable. Famille **Sudoku fraîche** (11e distincte ce cluster : Planning→Probas→IIT→SW→Sudoku-17/18(fixes)→SC→ML→Oncology→Search→GameTheory→**Sudoku-6**). Litmus LIGHT échoue (comprendre backjumping bookkeeping overhead + rôle propagation FC + quand CBJ paie = raisonnement de domaine).

## Gap (benchmark chiffré jamais relié au framing qualitatif)

`MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb` (python3, 42 cells). G.1 firsthand (git show origin/main) :

- **Cell 34** (markdown) framing qualitatif : « Sur les puzzles faciles, CBJ avec MRV fonctionne bien... Mais sur les puzzles **difficiles**, le backjumping seul ne compense pas l'absence de propagation de contraintes (FC, AC-3) » + « **Lecon** : ne jugez pas un algorithme seulement sur des instances faciles ».
- **Cell 37** (ec=18) benchmark chiffré : `CBJ 82 assigns/1 backtrack/82ms`, `FC 91/10/82ms`, `MRV+LCV 366/10/158ms`.
- **Cell 38** saute à « ## Exercice : Coloriage de graphe » **sans markdown reliant les chiffres au framing**.

Le lecteur reçoit un avertissement qualitatif ET un résultat quantitatif qui ne sont jamais connectés. Pire, les chiffres révèlent une **nuance non-énoncée** : CBJ≈FC sur easy (le backjumping ne paie pas son overhead).

## What (1 cellule markdown FR insérée, grounded dans l'output cell 37)

**After cell 37** → nouvelle cellule 38 (avant le coloriage exercise) :
- **Relit les chiffres réels** : CBJ divise les assigns par 4,5× (366→82) et les backtracks par 10× (10→1) vs MRV+LCV nu → le backjumping tient sa promesse théorique sur les backtracks (Prosser 1993).
- **Insight non-trivial que le framing qualitatif ne disait pas** : **CBJ ≈ FC sur easy** (82 vs 91 assigns, **82 ms = 82 ms** malgré 1 vs 10 backtracks). Le backjumping divise les backtracks par 10 SANS gain de temps → l'overhead de bookkeeping des conflict sets compense exactement le gain, ET FC propage déjà l'essentiel sur easy.
- **Réconcilie avec le framing** : la supériorité théorique de CBJ ne paie vraiment que sur les puzzles **difficiles** à chaînes de conflit profondes ; sur easy, propagation (FC) ≥ backjumping (CBJ) → illustre chiffré pourquoi il faut combiner CBJ avec propagation, pas le juger sur easy seul.

## Honnêteté (G.9)

**G.9 auto-correction Explore** : Explore a rapporté une « contradiction framing-vs-résultat » — c'est **faux**. Le framing cell 34 **anticipe** le résultat (dit explicitement « CBJ fonctionne bien sur easy, échoue sur difficult »). Le vrai gap = les nombres concrets du benchmark ne sont jamais **relus** en regard du framing. L'interp ajoute l'insight non-trivial (CBJ≈FC parity, overhead annule le gain de temps) que le framing qualitatif ne pouvait pas énoncer. **0 claim fabriquée** — chaque nombre (82/91/366 assigns, 1/10 backtracks, 82/82/158 ms) vient de l'output committé cell 37.

## Scope (chirurgical, markdown-only)

1 fichier, additif pur (1 cellule markdown insérée, 0 supprimée). **Markdown-only** → règle C.2 exception : pas de re-exec (code cell 37 ec=18 + outputs `text/plain` byte-préservés). **42/42 pre-existing cells byte-identiques** à `origin/main`.

## Validation (H.1 / H.3)

- **nbformat 4.5** `validate` OK ; **43 cells** (was 42).
- **C.1** : 0 `raise NotImplementedError`/`assert False`/`1/0` (code cells inchangés).
- **H.3** : 0 code cell non-exécutée.
- **Byte-identity** : 42/42 pre-existing cells byte-identiques à origin/main.
- **LF** (0 CRLF) ; **catalogue byte-identique** (non dans le diff).

## Variation (R6 / G-VAR-3)

c.621a Search/fix-prongb · c.621b GT-8/fix · **c.622 Sudoku/enrichment**. Genre enrichment casse fix×2. 11e famille fraîche (Sudoku-6 jamais touché ce cluster — Sudoku-17/18 étaient fixes). Tier MED (interp non-triviale d'un benchmark réel, pas un nouveau résultat).

See #3801 (SOTA/Prong-A honesty axis indirectly — le notebook exécute le vrai benchmark CBJ ; cet enrichissement rend compte pédagogiquement de ces nombres réels, pas de workaround).

Generated with Claude Code
