### PR TITLE
docs(search): CSP-1-Fundamentals reconcile stale interpretation numbers with code-cell outputs

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals-Csharp.ipynb
@@ -1176,16 +1176,16 @@
     "\n",
     "| Variante | Assignations | Commentaire |\n",
     "|----------|-------------|-------------|\n",
-    "| Backtracking simple | ~11 | Ordre naif des variables et valeurs |\n",
-    "| + MRV | ~15 | Fail-first : surcout ici non amorti |\n",
-    "| + MRV + LCV | ~15 | idem, LCV ne change rien |\n",
+    "| Backtracking simple | 102 | Ordre naif des variables et valeurs |\n",
+    "| + MRV | 102 | Meme arbre explore, aucun elagage |\n",
+    "| + MRV + LCV | 102 | idem, LCV ne change rien au compte |\n",
     "\n",
     "**Points cles** :\n",
-    "1. Sur ce petit problème (7 variables, 3 couleurs, espace déjà très contraint), l ordre naif tombe déjà sur une solution ; MRV ajoute ici un surcout de sélection non amorti\n",
-    "2. L effet des heuristiques est **instance-dependant** : nul ou negatif sur une instance facile, il devient dramatique sur des instances plus dures (cf. les 8-Reines ci-dessous : 876 -> 572 avec MRV)\n",
+    "1. Sur ce petit problème (7 variables, 3 couleurs, espace déjà très contraint), l ordre naif tombe déjà sur une solution ; les heuristiques n elaguent aucun noeud - l arbre de recherche est identique (102 noeuds pour les trois variantes)\n",
+    "2. L effet des heuristiques est **instance-dependant** : nul sur une instance facile, il devient dramatique sur des instances plus dures (cf. les 8-Reines ci-dessous : 876 -> 572 avec MRV)\n",
     "3. Conclusion honnete : aucune heuristique n est monotonement benefique, il faut mesurer et non presupposer une amelioration\n",
     "\n",
-    "> **Règle pratique** : mesurer empiriquement. MRV rapporte gros sur les instances dures (N-Reines), mais son surcout n est pas amorti sur les instances faciles comme la coloration de l'Australie."
+    "> **Règle pratique** : mesurer empiriquement. MRV rapporte gros sur les instances dures (N-Reines), mais sur une instance facile comme la coloration de l'Australie, l arbre de recherche est si petit que les heuristiques n ont rien a elaguer."
    ]
   },
   {
@@ -1329,7 +1329,7 @@
    "id": "d2d3ac0d",
    "metadata": {},
    "source": [
-    "**Interpretation** : Choco-solver resout la coloration de l'Australie en moins de 10 ms avec 6 lignes de modelisation declaratives.\n",
+    "**Interpretation** : Choco-solver resout la coloration de l'Australie en 63,82 ms au premier appel, puis seulement 2,94 ms une fois la JVM chaude (cf. enumeration cellule suivante). Le premier appel paie le demarrage de la JVM Java (IKVM) sous-jacente ; en regime etabli, le coeur metier (propagation + backtracking) est bien inferieur a 10 ms.\n",
     "\n",
     "| Aspect | Implementation manuelle C# | Choco-solver 4.10.17 |\n",
     "|--------|---------------------------|----------------------|\n",


### PR DESCRIPTION
Grain: MED/CSP-doc-honesty

docs(search): CSP-1-Fundamentals reconcile stale interpretation numbers with code-cell outputs

Deux cellules markdown d'interprétation de `CSP-1-Fundamentals-Csharp.ipynb`
cotaient des nombres **contrédits par la sortie de leur propre cellule de code**
(pattern stale-interpretation-numbers). Les outputs committés sont corrects,
seule la prose était périmée/fabriquée.

## Gaps (G.1 firsthand vs origin/main)

**Cell 26** (interprétation Choco, après cell 25 ec=14) :
- Affirmait « resout ... en **moins de 10 ms** » mais cell 25 output imprime
  `Temps : 63,82 ms`. Le <10 ms est une fiction de cold-start IKVM : le premier
  appel Choco paie le warm-up JVM. Cell 27 (ec=15) le confirme :
  `Temps enumeration : 2,94 ms` en régime établi.

**Cell 23** (interprétation heuristiques, après cell 22 ec=13) :
- Table `~11 / ~15 / ~15` assignations + « MRV surcout non amorti », mais cell 22
  output imprime `102 / 102 / 102` (les 3 variantes explorent l'arbre identique)
  en 0,85 / 0,24 / 0,93 ms. Les nombres ~11/~15 n'ont jamais été produits par la
  cellule.

## Fix (markdown-only)

- **Cell 26** → cadrage cold-start honnête : 63,82 ms au premier appel (démarrage
  JVM IKVM), 2,94 ms une fois chaude, cœur moteur <10 ms en régime établi.
- **Cell 23** → table réconciliée `102/102/102` + point 1 et blockquote réécrits :
  les heuristiques n'élaguent **aucun nœud** sur cette instance facile (arbre
  identique de 102 nœuds), pas un « surcout non amorti ».

**Conclusion CORRECTE préservée** (anti-régression stale-interpretation-numbers) :
les heuristiques ne servent à rien sur instance facile, deviennent décisives sur
instances dures (8-Reines 876→572 avec MRV). Seuls les nombres périmés et le
claim non sourcé « surcout » sont corrigés.

## Validation

- **C.2 exception markdown-only** : pas de re-exec. Code cells, outputs,
  execution_count byte-identiques (vérifié cell-by-cell : seules les cells 23 et
  26 source ont changé).
- nbformat 4 valide, 41 cells, 0 leaks, 0 erreurs volontaires (C.1), pas de
  churn catalogue.
- Diff chirurgical : +7/-7, 1 fichier, 2 cellules markdown.

Scope : CSP-1-Fundamentals-Csharp.ipynb uniquement (cell 23 + cell 26).
Notebook frais (0 activité cluster ; tous PR antérieurs = accents/navlinks/MD047).

See #3801 (SOTA honesty / problem-richness). See #2876 (accents — hors scope ici).
