### PR TITLE
docs(sudoku): Sudoku-11-Choco reconcile "1-50 ms" claim with 728 ms cold-start output

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Csharp.ipynb
@@ -1368,7 +1368,7 @@
     "1. **IKVM** permet d'utiliser Choco (Java) depuis C#\n",
     "2. **Contrainte `allDifferent`** : 27 contraintes pour Sudoku (9 lignes + 9 colonnes + 9 blocs)\n",
     "3. **Stratégie FirstFail** : Choisir la variable avec le plus petit domaine (MRV)\n",
-    "4. **Performance** : Typiquement 1-50 ms selon la difficulte\n",
+    "4. **Performance** : ~728 ms au premier appel (demarrage JVM IKVM inclus), puis quelques dizaines de ms en regime etabli selon la difficulte (cf. sortie cellule ci-dessus : Solution trouvee en 728 ms)\n",
     "\n",
     "### Comparaison avec autrès solveurs\n",
     "\n",


### PR DESCRIPTION
Grain: MED/Sudoku-doc-honesty

docs(sudoku): Sudoku-11-Choco reconcile "1-50 ms" claim with 728 ms cold-start output

La cellule de résumé « Points cles » de `Sudoku-11-Choco-Csharp.ipynb` affirmait
« **Performance : Typiquement 1-50 ms** selon la difficulte », mais la sortie de
la propre cellule 21 (execution_count 10) du notebook commet
`Solution trouvee en 728 ms` — **14× la borne supérieure** revendiquée.

## Gap (G.1 firsthand vs origin/main)

Le « 1-50 ms » est une **fiction de cold-start IKVM** : le premier appel Choco
via IKVM paie le warm-up de la JVM Java, donc le timing committé est 728 ms, pas
« 1-50 ms ». Même cause racine que le fix CSP-1 c.769 (#7790) : Choco-solver via
IKVM, premier appel = démarrage JVM. En régime établi, le cœur moteur est bien
de l'ordre de quelques dizaines de ms.

## Fix (markdown-only)

Cellule 28 (Points cles, élément 4) → cadrage cold-start honnête **ancré par la
sortie committée** : ~728 ms au premier appel (démarrage JVM IKVM inclus), puis
quelques dizaines de ms en régime établi selon la difficulté, citant
explicitement « Solution trouvée en 728 ms ».

## Validation

- **C.2 exception markdown-only** : pas de re-exec. **Cell-by-cell verify** :
  seule la cellule 28 source a changé ; tous les code cells, outputs,
  execution_count byte-identiques à origin/main.
- nbformat 4 valide (29 cells), 0 erreur volontaire (C.1), pas de churn
  catalogue.
- Diff chirurgical : +1/−1, 1 fichier, 1 cellule markdown.
- 0 PR open touchant Sudoku-11-Choco (collision clean).

Scope : Sudoku-11-Choco-Csharp.ipynb uniquement (cellule 28). Notebook intact
côté cluster (0 activité ; turf po-2023 Sudoku-.NET).

Même pattern cold-start IKVM que CSP-1 (#7790).

See #3801 (SOTA honesty).
