### PR TITLE
docs(search-csp,#7779): cell[49] recap BT/FC/MAC align on measured outputs (See #7721)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-2-Consistency-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-2-Consistency-Csharp.ipynb
@@ -208,7 +208,7 @@
    "source": [
     "## 1. Pourquoi la propagation de contraintes ?\n",
     "\n",
-    "Dans le notebook [CSP-1-Fundamentals](CSP-1-Fundamentals.ipynb), nous avons vu que la recherche en profondeur (backtracking) peut etre très inefficace : sur 8-Reines, elle explore typiquement ~500 noeuds avant de trouver une solution. La **propagation de contraintes** (contraintes unaires et binaires) reduit l espace de recherche **avant** ou **pendant** la recherche en eliminant les valeurs incompatibles.\n",
+    "Dans le notebook [CSP-1-Fundamentals](CSP-1-Fundamentals.ipynb), nous avons vu que la recherche en profondeur (backtracking) peut etre très inefficace : sur 8-Reines (avec diagonales), le backtracking naif explore **876 noeuds** avant de trouver une solution (cf. `Comparaison BT vs FC vs MAC` plus bas dans ce notebook). La **propagation de contraintes** (contraintes unaires et binaires) reduit l espace de recherche **avant** ou **pendant** la recherche en eliminant les valeurs incompatibles.\n",
     "\n",
     "### Trois niveaux de consistance\n",
     "\n",
@@ -1591,7 +1591,7 @@
    "source": [
     "### Interpretation : Forward Checking sur 8-Reines\n",
     "\n",
-    "**Sortie obtenue** : FC explore significativement moins de noeuds que le backtracking simple (typiquement <100 vs ~500). Pour chaque assignation `Qi = r`, FC elimine la rangee `r` des domaines des autres colonnes. Si une colonne voit son domaine devenir vide (toutes les rangees eliminees par les assignations précédentes), on backtrack immediatement.\n",
+    "**Sortie obtenue** : FC explore significativement moins de noeuds que le backtracking simple (75 noeuds vs 876 pour BT, cf. tableau recapitulatif plus bas). Pour chaque assignation `Qi = r`, FC elimine la rangee `r` des domaines des autres colonnes. Si une colonne voit son domaine devenir vide (toutes les rangees eliminees par les assignations précédentes), on backtrack immediatement.\n",
     "\n",
     "FC est **plus efficace** que le backtracking nu, mais **moins puissant** que MAC : il ne propage que les contraintes directes entre la variable assignee et ses voisins, sans considerer les interactions entre voisins."
    ]
@@ -2096,9 +2096,10 @@
     "\n",
     "| Algorithme | Propagation | Cout par noeud | Noeuds explores (8-Reines) |\n",
     "|------------|-------------|----------------|----------------------------|\n",
-    "| **Backtracking** | Aucune | O(1) | ~500 |\n",
-    "| **Forward Checking** | Domaines des voisins directs | O(d * deg) | ~100 |\n",
-    "| **MAC** | AC-3 complet | O(e * d^3) | ~20 |\n",
+    "| **Backtracking** | Aucune | O(1) | 876 |\n",
+    "| **Forward Checking** | Domaines des voisins directs | O(d * deg) | 75 |\n",
+    "| **MAC** | AC-3 complet | O(e * d^3) | 20 |\n",
+    "**Source des chiffres** : `876 / 75 / 20` sont les **vraies mesures** observees dans ce notebook (cellule `Comparaison BT vs FC vs MAC sur 8-Reines`, sortie kernel `.net-csharp` via `dotnet-interactive 1.0.707101`) apres execution complete des trois solveurs. Voir la cellule d'interpretation \"MAC domine\" plus haut pour le tableau `BT=876 / FC=75 / MAC=20` avec temps d'execution associes (9,7 ms / 6,5 ms / 4,1 ms). Les ratios derives : **MAC explore 44x moins de noeuds que BT** (876/20 = 43,8) et **FC environ 12x moins** (876/75 = 11,7).\n",
     "\n",
     "### Choco-solver vs implementations custom\n",
     "\n",
@@ -2124,7 +2125,9 @@
     "- [CSP-3-Advanced.ipynb](CSP-3-Advanced.ipynb) -- techniques avancees (variable ordering, AC-4)\n",
     "- [CSP-4-Scheduling-Csharp.ipynb](CSP-4-Scheduling-Csharp.ipynb) -- IKVM 8.15.0 + Choco + OR-Tools pour scheduling\n",
     "- [EPIC #4956](https://github.com/jsboige/CoursIA/issues/4956) -- parite .NET ⇄ Python des series de notebooks\n",
-    "- [CSP-2-Consistency.ipynb](CSP-2-Consistency.ipynb) -- version Python de ce notebook"
+    "- [CSP-2-Consistency.ipynb](CSP-2-Consistency.ipynb) -- version Python de ce notebook\n",
+    "- Issue [#7721](https://github.com/jsboige/CoursIA/issues/7721) -- 8-Reines CSP degeneree : la diagonale `|i-j| == |vi-vj|` fixee par [#7729](https://github.com/jsboige/CoursIA/pull/7729) avant la mesure (Bug 1 contournait la contrainte diagonale, sous-estimant artificiellement BT et MAC)\n",
+    "- Issue [#7779](https://github.com/jsboige/CoursIA/issues/7779) -- alignement recap sur les vraies mesures (cette PR)\n"
    ]
   }
  ],


### PR DESCRIPTION
Grain: MED/notebook-csharp — lane myia-po-2025:CoursIA-2 — prev: MED/docs (c.728y+16)

## Résumé

Issue **#7779** : cellule `[49]` (`ca3c3c9c`) du notebook `CSP-2-Consistency-Csharp.ipynb` (récapitulatif) affiche `~500 / ~100 / ~20` (placeholder non sourcé) au lieu des **vraies mesures** observées dans la cellule de comparaison `BT vs FC vs MAC sur 8-Reines`. Alignement sur les chiffres mesurés : **876 / 75 / 20**.

Substance MED/notebook-csharp :
- **3 cellules markdown éditées** (zéro cellule code touchée, C.2 exception légitime — pas de ré-exécution kernel requise) ;
- Chiffres `876 / 75 / 20` vérifiés firsthand dans la cellule de comparaison `BT vs FC vs MAC sur 8-Reines` (sortie kernel `.net-csharp` via `dotnet-interactive 1.0.707101`) aux lignes 1768, 1849, 1899 ;
- Ajout d'un **paragraphe d'attribution** dans la cellule `[49]` citant la source kernel + ratios dérivés ;
- Cross-références ajoutées : §1 intro et §5 FC interpretation alignées sur `876` (plus de `~500` qui contredisait la mesure) ;
- Liens vers #7721 (parent — Bug 1 diagonale fixée par #7729 avant la mesure) et #7779 (cette PR) ajoutés à la section « Voir aussi ».

## Fichiers modifiés

| Fichier | Δ | Description |
|---------|---|-------------|
| `MyIA.AI.Notebooks/Search/Part2-CSP/CSP-2-Consistency-Csharp.ipynb` | +9 / −6 | 3 cellules markdown (50 cellules totales préservées) |

## Vérifications G.1 firsthand (anti-fabrication)

| Claim | Source vérifiée |
|-------|-----------------|
| `BT = 876 noeuds` | `CSP-2-Consistency-Csharp.ipynb` ligne 1768 (sortie cell Comparaison BT vs FC vs MAC) |
| `FC = 75 noeuds` | ligne 1849 |
| `MAC = 20 noeuds` | ligne 1899 |
| Issue #7721 OPEN (parent) | confirmé via `gh issue view 7721` |
| PR #7729 MERGED (Bug 1 fixé) | confirmé via `gh pr view 7729` |

## Contexte — pourquoi ce changement est légitime

Avant cette PR, la cellule de **récapitulatif** (la dernière avant « Voir aussi ») affichait `~500 / ~100 / ~20` alors que la cellule de **comparaison mesurée** (placée en amont) affiche `876 / 75 / 20`. **Incohérence pédagogique factuelle** dans le même notebook : un étudiant lisant le récap pense que BT explore ~500 noeuds, alors que la cellule mesurée prouve 876.

Issue **#7721** (toujours OPEN) documente 4 bugs dans la version **dégénérée** du 8-Reines (diagonale non-respectée par BT, sous-estimant artificiellement l'exploration). PR **#7729** (po-2026, MERGED) a fixé Bug 1 (`|i-j| == |vi-vj|` diagonale absente du placeholder) **avant** la mesure. Les `876` reflètent la version corrigée, mais le récap n'avait pas été mis à jour.

## Scope strict (R3 atomic)

- ✅ 1 sujet = 1 fichier = 1 dossier (`Search/Part2-CSP/`)
- ✅ 0 cellule code touchée (C.2 exception légitime)
- ✅ Catalogue `COURSE_CATALOG.generated.{json,md}` byte-identique à main (R1 catalog-pr-hygiene)
- ✅ Pas de force-push (R2 rebase frais : branche depuis `origin/main` via worktree)
- ✅ `See #7721` (parent OPEN, contribution partielle)

## Variation-protocol

- **Grain**: `MED/notebook-csharp` (substance vérifiable, pas générable-en-série)
- **G-VAR-1** ✅ : DEEP/MED (pas LIGHT)
- **G-VAR-2** ✅ : pas de LIGHT cumulée aujourd'hui (cf MEMORY L904 c.728y+16 = MED/docs)
- **G-VAR-3** ✅ : genre `notebook-csharp` ≠ genre `docs` du cycle précédent

## Anti-régression (CLAUDE.md §D)

Toutes les cellules voisines du bloc "Trois niveaux de consistance" + table + phrase de fin de la cellule `2f59658f` (§1 intro) sont **préservées verbatim** : seul l'item [2] a été modifié (`~500` → `876`). Vérification anti-régression par `git diff` : aucune ligne de pédagogie supprimée.

## Liens

- Issue parente : **#7721** (8-Reines CSP dégénérée — 4 bugs, dont Bug 1 fixé par #7729)
- Issue de cette PR : **#7779**
- PR corrigeant Bug 1 : **#7729** (MERGED, po-2026)
- Notebook : `MyIA.AI.Notebooks/Search/Part2-CSP/CSP-2-Consistency-Csharp.ipynb`
- EPIC parité .NET ⇄ Python : **#4956**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
