### PR TITLE
docs(lean-i18n,#4980): Conway/Nim FR-first canonical - flip 19 EN docstrings + section block

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Nim.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Nim.lean
@@ -37,113 +37,114 @@ import Mathlib.Data.Nat.Bitwise
 import Mathlib.Data.List.Basic
 
 namespace Conway
-/-- The nim-sum of a position: XOR-fold of the heap sizes. -/
+/-- Le nim-sum d'une position : XOR-fold des tailles de tas. -/
 def nimSum (heaps : List Nat) : Nat :=
   heaps.foldl (· ^^^ ·) 0
 
-/-- A nim position is a first-player win iff its nim-sum is non-zero. -/
+/-- Une position de Nim est gagnante pour le premier joueur ssi son nim-sum est non nul. -/
 def isWinningNim (heaps : List Nat) : Bool :=
   nimSum heaps != 0
 
--- A few sanity evaluations (3^^4 = 7, 7^^5 = 2 ≠ 0, so [3,4,5] is winning).
+-- Quelques évaluations de cohérence (3^^4 = 7, 7^^5 = 2 ≠ 0, donc [3,4,5] est gagnante).
 #eval nimSum [3, 4, 5]      -- 2
 #eval isWinningNim [3, 4, 5] -- true
-#eval isWinningNim [1, 1]    -- false (balanced)
+#eval isWinningNim [1, 1]    -- false (équilibré)
 
-/-- Proved anchor: the empty position has nim-sum 0. -/
+/-- Ancre prouvée : la position vide a un nim-sum nul. -/
 theorem nimSum_nil : nimSum [] = 0 := rfl
 
-/-- CALIBRATION (decide): the position [3,4,5] is a first-player win. -/
+/-- CALIBRATION (decide) : la position [3,4,5] est gagnante pour le premier joueur. -/
 theorem isWinningNim_345 : isWinningNim [3, 4, 5] = true := by
   native_decide
 
-/-- CALIBRATION (unfold + zero_xor): a single heap has nim-sum equal to its size. -/
+/-- CALIBRATION (unfold + zero_xor) : un tas unique a un nim-sum égal à sa taille. -/
 theorem nimSum_single (n : Nat) : nimSum [n] = n := by
   simp [nimSum, Nat.zero_xor]
 
-/-- CALIBRATION (xor cancellation): two equal heaps cancel — the losing P-position. -/
+/-- CALIBRATION (annulation xor) : deux tas égaux s'annulent — la P-position perdante. -/
 theorem nimSum_self (n : Nat) : nimSum [n, n] = 0 := by
   simp [nimSum, Nat.xor_self]
 
-/-! ## Bouton's Strategy (1901) — The Core of Combinatorial Game Theory
+/-! ## Stratégie de Bouton (1901) — Le cœur de la théorie des jeux combinatoires
 
-The fundamental theorem of Nim (Bouton, 1901): a position is a first-player
-win (N-position) if and only if the nim-sum is nonzero. The strategy is
-constructive: when `nimSum ≠ 0`, the first player can always make a move that
-sets the nim-sum to zero (a P-position for the opponent).
+Le théorème fondamental de Nim (Bouton, 1901) : une position est gagnante
+pour le premier joueur (N-position) si et seulement si le nim-sum est non nul.
+La stratégie est constructive : lorsque `nimSum ≠ 0`, le premier joueur peut
+toujours jouer un coup qui annule le nim-sum (une P-position pour l'adversaire).
 
-Conway's *On Numbers and Games* (1976) generalizes this to all impartial games
-via the Sprague-Grundy theorem: every impartial game is equivalent to a Nim heap.
-This module proves the constructive direction of Bouton's theorem using `native_decide`
-on small instances, plus the general XOR property that makes it work. -/
+*On Numbers and Games* de Conway (1976) généralise cela à tous les jeux
+impartiaux via le théorème de Sprague-Grundy : tout jeu impartial est équivalent
+à un tas de Nim. Ce module prouve la direction constructive du théorème de Bouton
+à l'aide de `native_decide` sur de petites instances, plus la propriété générale
+du XOR qui la sous-tend. -/
 
-/-- CALIBRATION (decide): the 3-heap position [1, 2, 3] is winning.
-    1 ^^^ 2 = 3, and 3 ^^^ 3 = 0, so actually nimSum = 0 — this is a LOSS.
-    Correction: [1, 4, 5] is winning: 1 ^^^ 4 = 5, 5 ^^^ 5 = 0. Wait —
-    Let me use [3, 5, 6]: 3 ^^^ 5 = 6, 6 ^^^ 6 = 0... also balanced.
-    [3, 5, 7]: 3 ^^^ 5 = 6, 6 ^^^ 7 = 1 ≠ 0 — winning. -/
+/-- CALIBRATION (decide) : la position à 3 tas [1, 2, 3] est gagnante.
+    1 ^^^ 2 = 3, et 3 ^^^ 3 = 0, donc en réalité nimSum = 0 — c'est une PERTE.
+    Correction : [1, 4, 5] est gagnante : 1 ^^^ 4 = 5, 5 ^^^ 5 = 0. Attendez —
+    Utilisons [3, 5, 6] : 3 ^^^ 5 = 6, 6 ^^^ 6 = 0... aussi équilibrée.
+    [3, 5, 7] : 3 ^^^ 5 = 6, 6 ^^^ 7 = 1 ≠ 0 — gagnante. -/
 theorem isWinningNim_357 : isWinningNim [3, 5, 7] = true := by
   native_decide
 
-/-- After removing k stones from heap i, the new nim-sum is the old nim-sum
-    XOR'd with the change in that heap. This is the algebraic key to the
-    winning strategy: to zero the nim-sum, pick a heap where heap_i XOR s < heap_i
-    (where s = nimSum), and reduce it to heap_i XOR s.
+/-- Après avoir retiré k pierres du tas i, le nouveau nim-sum est l'ancien nim-sum
+    XOR avec le changement dans ce tas. C'est la clé algébrique de la stratégie
+    gagnante : pour annuler le nim-sum, choisir un tas où heap_i XOR s < heap_i
+    (où s = nimSum), et le réduire à heap_i XOR s.
 
-    Here we verify the strategy on the concrete position [3, 5, 7]:
-    nimSum = 1. Heap 3: 3 ^^^ 1 = 2 < 3, reduce 3 to 2.
-    New position [2, 5, 7]: 2 ^^^ 5 ^^^ 7 = 0. P-position! -/
+    Ici nous vérifions la stratégie sur la position concrète [3, 5, 7] :
+    nimSum = 1. Tas 3 : 3 ^^^ 1 = 2 < 3, réduire 3 à 2.
+    Nouvelle position [2, 5, 7] : 2 ^^^ 5 ^^^ 7 = 0. P-position ! -/
 theorem nimStrategy_357 :
     nimSum [2, 5, 7] = 0 ∧ 2 < 3 := by
   native_decide
 
-/-- XOR with zero is the identity. -/
+/-- Le XOR avec zéro est l'identité. -/
 theorem xor_zero (n : Nat) : n ^^^ 0 = n := by
   exact Nat.xor_zero n
 
-/-- XOR is commutative. -/
+/-- Le XOR est commutatif. -/
 theorem xor_comm (a b : Nat) : a ^^^ b = b ^^^ a := by
   exact Nat.xor_comm a b
 
-/-- XOR is associative. -/
+/-- Le XOR est associatif. -/
 theorem xor_assoc (a b c : Nat) : a ^^^ (b ^^^ c) = (a ^^^ b) ^^^ c := by
   exact Nat.xor_assoc a b c |>.symm
 
-/-- The nim-sum of three elements in association-invariant order. -/
+/-- Le nim-sum de trois éléments dans l'ordre invariant par association. -/
 theorem nimSum3_assoc (a b c : Nat) : a ^^^ b ^^^ c = a ^^^ (b ^^^ c) := by
   rw [← Nat.xor_assoc]
 
-/-- The Bouton strategy verified: in position [3, 5, 7] with nimSum = 1,
-    the winning move is to reduce heap 0 from 3 to 2 (= 3 XOR 1).
-    The resulting position [2, 5, 7] has nimSum 0 (P-position). -/
+/-- Stratégie de Bouton vérifiée : en position [3, 5, 7] avec nimSum = 1,
+    le coup gagnant est de réduire le tas 0 de 3 à 2 (= 3 XOR 1).
+    La position résultante [2, 5, 7] a un nimSum de 0 (P-position). -/
 theorem winning_move_357 :
     nimSum [3, 5, 7] = 1 ∧
     nimSum [2, 5, 7] = 0 := by
   native_decide
 
-/-- Another concrete strategy: position [1, 2, 3] has nimSum 0 (P-position),
-    meaning the SECOND player wins. Any move the first player makes leads
-    to an N-position (non-zero nimSum). -/
+/-- Une autre stratégie concrète : la position [1, 2, 3] a un nimSum 0 (P-position),
+    ce qui signifie que le SECOND joueur gagne. Tout coup du premier joueur mène
+    à une N-position (nimSum non nul). -/
 theorem losing_position_123 : nimSum [1, 2, 3] = 0 := by
   native_decide
 
-/-- After the first player's move from [1, 2, 3], every resulting position
-    has non-zero nimSum (N-position). -/
+/-- Après le coup du premier joueur depuis [1, 2, 3], toute position résultante
+    a un nimSum non nul (N-position). -/
 theorem all_moves_from_123_winning :
     nimSum [0, 2, 3] ≠ 0 ∧ nimSum [1, 1, 3] ≠ 0 ∧ nimSum [1, 0, 3] ≠ 0 ∧
     nimSum [1, 2, 2] ≠ 0 ∧ nimSum [1, 2, 0] ≠ 0 := by
   native_decide
 
-/-- If `a ^^^ s < a` where `s = nimSum heaps`, then reducing heap `a` to
-    `a ^^^ s` zeros the nim-sum. This is the **key property** of the winning
-    strategy: it relies on the fact that for the most significant bit of `s`,
-    at least one heap has that bit set, making `a ^^^ s < a` true.
+/-- Si `a ^^^ s < a` où `s = nimSum heaps`, alors réduire le tas `a` à
+    `a ^^^ s` annule le nim-sum. C'est la **propriété clé** de la stratégie
+    gagnante : elle repose sur le fait que pour le bit le plus significatif de `s`,
+    au moins un tas a ce bit positionné, rendant `a ^^^ s < a` vrai.
 
-    We verify this on concrete instances: -/
+    Nous vérifions cela sur des instances concrètes : -/
 theorem xor_reduce_3_1 : 3 ^^^ 1 = 2 ∧ 2 < 3 := by native_decide
 
-/-- For [3, 5, 7]: the full strategy verification.
-    nimSum = 1. Reducing heap 0 (size 3) to 3 ^^^ 1 = 2 zeros the sum. -/
+/-- Pour [3, 5, 7] : la vérification complète de la stratégie.
+    nimSum = 1. Réduire le tas 0 (taille 3) à 3 ^^^ 1 = 2 annule la somme. -/
 theorem winning_move_verified_357 :
     let s := nimSum [3, 5, 7]
     s = 1 ∧


### PR DESCRIPTION
Grain: MED/i18n-Lean

docs(lean-i18n,#4980): Conway/Nim FR-first canonical - flip 19 EN docstrings + section block

## Gap (G.1 firsthand vs origin/main)

`Conway/Nim.lean` was a **genuine half-done i18n candidate**: the module doc was already FR (declares #4980 FR-first canonical + sibling `Nim_en.lean`, accented French), but ~18 inline `/--` docstrings, the `/-! ## Bouton'''s Strategy (1901)` section block, and a standalone `--` comment were still EN.

## Fix (docstring/comment-only)

Flipped all EN docstrings + the Bouton'''s Strategy section block + the standalone sanity-evaluations comment + the `(balanced)` trailing annotation to **accented French**, matching the module-doc style and the Fractran/LookAndSay/HashlifeMemo sibling-pair pilots.

**Byte-identical preserved**: signatures, defs, theorems (`nimSum`, `isWinningNim`, `xor_zero`/`comm`/`assoc`, `nimStrategy_357`, `nimSum3_assoc`, `winning_move_357`...), tactics (`native_decide`/`simp`/`exact`), `#eval!` lines, `namespace Conway` stay byte-identical.

## Validation (4 proofs)

- **Byte-identity (anti-regression section B)**: stripped all `/- ... -/` block comments (nesting-aware) + `--` line comments from both new and `origin/main`, sha1 the code residual: `fa2e6c45cedbb6261768afc9ba6239ad377b9f91` == `origin/main`. PROOF OK.
- **sorry count**: 0 -> 0 (grep both).
- **Dogfood checker**: `scripts/lean/check_i18n_siblings.py` - `Nim_en.lean` OK; `conway_lean` 26/26 pairs byte-identical, 0 drift, 0 orphan; repo-wide `--all` shows no HALF_DONE flag for the Nim pair.
- **Diff**: +49/-48, 1 file, docstring/comment-only.

## Scope

`Conway/Nim.lean` uniquement (canonical FR). `Nim_en.lean` sibling untouched (keeps EN). Docstring-only change = pas de lake build requis (0 tactic/proof/def modifie).

See #4980 (Lean i18n FR-first rollout). Sibling-pair of Fractran/LookAndSay/HashlifeMemo (cycle c.518 declared in the module doc).

Co-Authored-By: Claude-Code <noreply@anthropic.com>