### PR TITLE
docs(sudoku): Sudoku-12-Z3 reconcile "entier plus rapide facile" + "se valent" with committed benchmark

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb
@@ -1504,7 +1504,7 @@
     "\n",
     "La cellule précédente lance le banc d'essai comparatif (`TestSolvers` + `DisplayResults`) sur trois niveaux de difficulté, avec un budget borné (3 grilles par difficulté, 3 s max par grille) afin que la comparaison tienne dans un temps raisonnable. Le tableau texte capture les temps de résolution réels ; les graphiques Plotly, eux, restent interactifs et ne sont pas sérialisés dans le notebook.\n",
     "\n",
-    "Sur l'exécution committee, les quatre encodages résolvent l'intégralité des grilles (statut `Success`, 3/3 à chaque niveau). On observe néanmoins un contraste net : l'encodage **entier** est le plus rapide sur les grilles faciles mais se dégrade sur les grilles difficiles (`top95`), tandis que les encodages **par vecteurs de bits** restent plus stables et prennent l'avantage sur les grilles les plus dures. Les mesures exactes varient d'une exécution à l'autre (contexte partagé, charge machine), mais cette tendance qualitative est robuste.\n",
+    "Sur l'exécution committee, les quatre encodages résolvent l'intégralité des grilles (statut `Success`, 3/3 à chaque niveau). Le contraste porte sur la **stabilité** : les trois encodages **par vecteurs de bits** dominent sur toutes les difficultés — l'encodage par substitution est le plus rapide en Easy et Medium (166,5 ms / 273,8 ms) et les trois restent sous les ~471 ms même sur `top95` (294,5 à 470,9 ms). L'encodage **entier**, lui, n'est jamais le plus rapide : 3ᵉ sur les grilles faciles (273,2 ms, derrière les vecteurs de bits à 166,5 et 182,5 ms), il **s'effondre** sur les grilles difficiles (**1367 ms**, soit environ 3 à 5× les vecteurs de bits). Les mesures exactes varient d'une exécution à l'autre (contexte partagé, charge machine), mais cette dégradation de l'entier sur `top95` est robuste.\n",
     "\n",
     "| Solveur | Approche | Avantages | Inconvénients |\n",
     "|---------|----------|-----------|---------------|\n",
@@ -1521,7 +1521,7 @@
     "\n",
     "3. **Tactiques** : les tactiques comme \"simplify\" pré-traitent les contraintes, mais l'overhead ne se justifie pas toujours pour des Sudoku simples.\n",
     "\n",
-    "4. **Performance** : sur des grilles faciles les quatre encodages se valent ; l'écart se creuse sur les grilles difficiles, où les vecteurs de bits gardent l'avantage. Le budget borné du banc d'essai (statut `Timeout` / `Disqualified` possible sur `top95`) fait partie de la mesure : un dépassement est un résultat, pas une erreur.\n",
+    "4. **Performance** : contrairement à ce que suggère l'intuition, les vecteurs de bits prennent l'avantage **dès les grilles faciles** (substitution 166,5 ms face à l'entier 273,2 ms — un écart déjà de l'ordre de 65 %) ; l'écart **se creuse massivement** sur les grilles difficiles, où l'entier atteint 1367 ms contre 294,5 à 470,9 ms pour les vecteurs de bits. L'intérêt de l'encodage entier est conceptuel (modélisation directe, facile à comprendre), pas la vitesse. Le budget borné du banc d'essai (statut `Timeout` / `Disqualified` possible sur `top95`) fait partie de la mesure : un dépassement est un résultat, pas une erreur.\n",
     "\n",
     "> **Note technique** : les solveurs Z3 utilisent un contexte statique partage pour optimiser la performance. Dans une application de production, il faudrait gerer le cycle de vie du contexte plus proprement."
    ]


### PR DESCRIPTION
Grain: MED/sudoku-doc-honesty

docs(sudoku): Sudoku-12-Z3 reconcile "entier plus rapide sur les grilles faciles" + "les quatre encodages se valent" with committed benchmark

## Gap (G.1 firsthand vs origin/main)

Sudoku-12-Z3-Csharp cell 24 interpretation had **2 claims contradicted by the notebook'''s own committed benchmark** (cell 23 output):

1. **Paragraph 2**: "l'''encodage **entier** est le plus rapide sur les grilles faciles" — FALSE. Easy times: Substitution-BV **166,5 ms** < Simple-BV **182,5 ms** < **Int 273,2 ms** < Tactic-BV 331,4 ms. The integer encoding is 3rd of 4 on Easy, never the fastest.

2. **Point cle 4**: "sur des grilles faciles les quatre encodages se valent" — FALSE. Easy spread is ~2x (166 to 331 ms).

The fabricated trade-off narrative (Int fast-on-easy / degrades-on-hard vs BV stable) does not match the data: **the integer encoding is never the fastest on any difficulty** and collapses catastrophically on Hard.

## Fix (markdown-only, grounded in committed output)

Reworded to the honest framing grounded verbatim by the committed benchmark:
- The three bit-vector encodings **dominate on every difficulty** (Substitution fastest on Easy 166,5 / Medium 273,8 ms; all three stay under ~471 ms on top95 at 294,5-470,9 ms).
- The integer encoding is **never the fastest** (3rd on Easy at 273,2 ms, behind the bit-vectors at 166,5 and 182,5 ms) and **collapses on Hard (1367 ms, ~3-5x the bit-vectors)**.
- Its virtue is **conceptual** (direct modeling, easy to understand), not speed.

**Correct conclusions preserved**: 4/4 encodings resolve all grids (Success 3/3), bit-vector stability on top95, and the bounded-budget/timeout framing (a timeout is a result, not an error).

## Validation

- **C.2 exception markdown-only**: no re-execution. Cell-by-cell verified: only cell 24 source changed (2 source-list elements); all code cells, outputs, execution counts byte-identical to origin/main.
- nbformat 4.5 valid (42 cells), 0 voluntary errors (C.1), 0 leak, no catalog churn.
- Diff surgical: +2/-2, 1 file, 1 markdown cell.
- 0 PR open touching Sudoku-12-Z3-Csharp (collision clean).

Scope: Sudoku-12-Z3-Csharp.ipynb uniquement (cell 24).

See #3801 (SOTA honesty).

Co-Authored-By: Claude-Code <noreply@anthropic.com>