### PR TITLE
docs(symbolicai-planners,#4959): reconcile Planners README H1 "14 notebooks" claim with CATALOG-STATUS pedagogical_count = 23

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/README.md
@@ -13,7 +13,7 @@ Cette série de notebooks introduit la **Planification Automatique**, une branch
 
 La planification répond à une question différente de celle de l'apprentissage : non pas « que prédire ? » mais « **que faire ?** ». À partir d'un modèle du monde — un état initial, des actions avec leurs préconditions et effets, un but — un planificateur cherche automatiquement une suite d'actions qui mène au but. C'est une technologie éprouvée : elle pilote des robots (manipulation, navigation), optimise la logistique et l'ordonnancement, et a dirigé des engins spatiaux autonomes (Remote Agent sur Deep Space 1, planification d'activités des rovers martiens). Le langage **PDDL** a standardisé la manière de décrire ces problèmes, donnant naissance à tout un écosystème de solveurs comparables. La planification connaît aujourd'hui un regain d'intérêt avec les LLMs, comme moyen de doter les modèles de langage d'une capacité d'action vérifiable et orientée vers un but.
 
-**14 notebooks** | **5 parties** | **~10h**
+**14 numéros logiques** (23 fichiers `.ipynb` : 14 Python + 9 CSharp twins + 1 Lean companion, cf. marqueur `<!-- CATALOG-STATUS -->` ci-dessus) | **5 parties** | **~10h**
 
 **À qui s'adresse cette série** : étudiants en IA, ingénieurs en robotique et logistique, développeurs souhaitant intégrer la planification symbolique dans leurs applications. Aucun prérequis en planification : les concepts sont introduits progressivement depuis les fondements STRIPS jusqu'aux approches neuro-symboliques modernes.
 


### PR DESCRIPTION
Grain: MED/docs — lane myia-po-2024:CoursIA-2 — prev: MED/docs (c.746)

docs(symbolicai-planners,#4959): reconcile Planners README H1 "14 notebooks" claim with CATALOG-STATUS pedagogical_count = 23

## Résumé

Audit inter-familles catalog-pr-hygiene post-c.746 (cf L902 ★ filesystem-first) : la H1 `**14 notebooks** | **5 parties** | **~10h**` (l. 16) du `MyIA.AI.Notebooks/SymbolicAI/Planners/README.md` utilise un **périmètre logique** (Planners-0 à Planners-12 + Planners-5b Lean = 14 numéros logiques), alors que le marqueur `<!-- CATALOG-STATUS -->` byte-identique au début du fichier dit `pedagogical_count: 23` (= fichiers `.ipynb` hors archive Fast-Downward-Legacy). Sans annotation, un lecteur peut penser que la série ne contient que 14 fichiers .ipynb alors qu'elle en contient **23** (14 Python + 9 CSharp twins + 1 Lean companion − 1 archive hors compteur = 23).

Le « 14 » est correct pour son périmètre (numéros logiques), mais comme c.746 (Sudoku « 19 notebooks » → 36), c'est un claim **non explicitement délimité** dans la phrase introductive. Réconciliation chirurgicale : ajouter une mention de périmètre au H1 + renvoyer au CATALOG-STATUS pour le compte physique. **Aucune modification de cellule notebook, aucune régénération du marqueur (R1 strict).**

## Périmètre

- **Inclus** : `MyIA.AI.Notebooks/SymbolicAI/Planners/README.md` (1 fichier, +1/-1, 1 ligne touchée — la H1)
- **Hors scope** : CATALOG-STATUS byte-identique (R1 strict) ; aucune modification de cellule notebook ; aucune régénération catalogue ; pas de modification du tableau ligne 24 (déjà explicite sur le périmètre « 1 setup + 3 foundation + 4 classical dont 1 companion Lean + 3 advanced + 3 neuro-symbolic = 14 numéros logiques »).

## G.1 vérifications firsthand (2026-07-22)

```bash
$ git ls-files MyIA.AI.Notebooks/SymbolicAI/Planners/ | grep -E "\.ipynb$" | wc -l
24
$ git ls-files MyIA.AI.Notebooks/SymbolicAI/Planners/ | grep -E "\.ipynb$" | grep -v archive | wc -l
23
$ git ls-files MyIA.AI.Notebooks/SymbolicAI/Planners/ | grep -E "\.ipynb$" | grep -v archive | grep -v -i csharp | grep -v -i lean | wc -l
14
$ git ls-files MyIA.AI.Notebooks/SymbolicAI/Planners/ | grep -E "\.ipynb$" | grep -v archive | grep -i csharp | wc -l
9
$ git ls-files MyIA.AI.Notebooks/SymbolicAI/Planners/ | grep -E "\.ipynb$" | grep -v archive | grep -i "lean" | wc -l
1
```

Total = 14 Python + 9 CSharp twins + 1 Lean companion = **24 fichiers** ; archive `Fast-Downward-Legacy.ipynb` explicitement « hors compteur pédagogique » (l. 210) → **23 pédagogiques** ✓ aligné avec `<!-- CATALOG-STATUS -->` (`pedagogical_count: 23`, `breakdown: Planners=23`).

Le « 14 » de la H1 = périmètre **numéros logiques** (Planners-0 setup + Planners-1 à Planners-12 + Planners-5b Lean = 14 numéros, certains avec jumeaux CSharp = +1 fichier par jumeau). Pattern analogue à c.746 L.22 « 2 notebooks Python uniquement » : périmètre correct mais non explicité dans la phrase introductive.

## Anti-régression D — pivots antérieurs évités

| Candidat rejeté | Raison | Pivot |
|---|---|---|
| `Search/README.md` (part4 figures footer alignement) | grain LIGHT, viole G-VAR-1 ; c.747 = substance MED/docs | pivot |
| `SymbolicAI/SMT/README.md` CATALOG-STATUS markers | PR #7789 OPEN MERGEABLE cible exactement ces 3 fichiers | pivot |
| `SymbolicAI/SymbolicLearning/README.md` 22→20 reconcile | PR #7783 OPEN MERGEABLE cible hub SymbolicAI (mais SymbolicLearning via hub) | pivot |
| `SymbolicAI/Argument_Analysis/README.md` 21→22 reconcile | PR #7783 OPEN MERGEABLE | pivot |
| `SymbolicAI/Tweety/README.md` maturity 32 (1 DRAFT manquant) | sub-LIGHT (accents), pas MED/docs | hors scope |
| `GameTheory/README.md` counts | pas de drift chiffré détecté (50 CATALOG = 50 pédagogie) | pas de grain |
| `Probas/README.md` (28+28+2=58) | CATALOG-STATUS cohérent avec disk | pas de drift |
| `ML/README.md` / `ML/ML.Net/README.md` | CATALOG-STATUS cohérent avec disk | pas de drift |
| `RL/README.md` (17) | CATALOG-STATUS cohérent avec disk | pas de drift |
| `SemanticWeb/README.md` (25) | CATALOG-STATUS cohérent avec disk | pas de drift |
| `CaseStudies/README.md` (6) | CATALOG-STATUS cohérent avec disk | pas de drift |
| `Search/Part4-Metaheuristics/README.md` MANIFEST footer | grain LIGHT, viole G-VAR-1 ; alignement pattern canonique non-trivial | pivot |
| **SymbolicAI/Planners/README.md H1 « 14 notebooks »** | **claim non explicitement délimité vs CATALOG-STATUS 23** | **GRAIN c.747** ✓ |

## Diff

```
-**14 notebooks** | **5 parties** | **~10h**
+**14 numéros logiques** (23 fichiers `.ipynb` : 14 Python + 9 CSharp twins + 1 Lean companion, cf. marqueur `<!-- CATALOG-STATUS -->` ci-dessus) | **5 parties** | **~10h**
```

Diff chirurgical : `+1/-1`, 1 fichier, 1 ligne touchée. Le claim « 14 » reste sémantiquement intact (les 14 numéros logiques du tableau l. 24 sont corrects), seul le périmètre est désormais explicité inline + renvoyé au CATALOG-STATUS pour le compte physique exhaustif.

## Validation (H.1)

| Check | Result |
|---|---|
| `git diff origin/main --stat` | 1 file, +1/-1 (atomique, R3) |
| R1 CATALOG-STATUS byte-identique | OK (`git diff origin/main -- README.md \| grep "CATALOG-STATUS" \| wc -l` = 0) |
| R3 anti-régression : notebooks intacts | OK (0 fichier notebook modifié) |
| G.1 firsthand disk vs README | OK (23 fichiers `.ipynb` pédagogiques confirmés) |
| G.9 culture du doute | OK (vérifié chiffre « 14 » = périmètre logique vs CATALOG-STATUS = périmètre physique) |
| readme-french-first | OK (FR préservé) |
| secrets-hygiene.md | OK (0 secret, doc-only) |
| pr-review-discipline §E (README rollout) | OK (audit fichier ENTIER : CATALOG-STATUS + tableau décomposition l. 24 + paragraphe archive l. 210) |
| pr-review-discipline §E cohérence cross-leaf | OK — PR #7783 (c.728y+14 OPEN) cible hub SymbolicAI, #7789 (c.728y+15 OPEN) cible SMT markers ; Planners README non-touché par ces PRs |

## Conformité

- **R1 catalog-pr-hygiene** : CATALOG-STATUS byte-identique (catalogue non régénéré sur branche)
- **R2 rebase frais** : base `aec14a6c5` (origin/main à jour au moment du commit — confirmé `git rev-list --left-right --count feature/c747...origin/main` = 0 0)
- **R3 atomic** : 1 sujet = réconciliation claim périmètre « 14 notebooks » vs CATALOG-STATUS pédagogique_count ; 1 fichier ; +1/-1 ligne
- **R4 partial delivery** : `See #4959` strict (EPIC reste ouverte ; autres audits sub-séries planifiés en audits séparés)
- **G.1 verify-before-claiming** : filesystem-first, `git ls-files` direct
- **G.9 culture du doute** : « 14 » = périmètre logique vs CATALOG-STATUS = périmètre physique, les deux vrais et complémentaires
- **pr-review-discipline §E (README rollout)** : audit fichier ENTIER exécuté (CATALOG-STATUS + tableau décomposition + paragraphe archive)

## Transmission coordinateur (futurs grains)

D'autres audits catalog-pr-hygiene potentiels sur la famille SymbolicAI, **hors scope c.747** :

| Site | Périmètre | Statut |
|---|---|---|
| `SymbolicAI/SMT/README.md` CATALOG-STATUS markers | PR #7789 OPEN c.728y+15 | **claim par po-2025** |
| `SymbolicAI/SymbolicLearning/README.md` counts | PR #7783 OPEN c.728y+14 (hub) | **claim par po-2025** |
| `SymbolicAI/Argument_Analysis/README.md` counts | PR #7783 OPEN c.728y+14 (hub) | **claim par po-2025** |
| `SymbolicAI/Tweety/README.md` maturity (1 DRAFT manquant) | sub-LIGHT, accents #2876 | sub-grain future |
| `SymbolicAI/Planners/README.md` tableau l. 24 (déjà explicite) | — | cohérent |
| `SymbolicAI/Planners/README.md` archive Fast-Downward-Legacy (l. 210) | déjà disclosé | cohérent |

L'audit a été borné au claim chiffré non-trivial de la H1 Planners README ; l'extension à l'audit fichier-entier complet de la famille SymbolicAI relèverait d'un audit séparé plus large (variante §E plafonnée, owner po-2025).

## Leçons

- **L747-L1 ★** : un claim chiffré H1 « non explicitement délimité » n'est pas un drift (cf c.746 L.22 « 2 Python uniquement » = correct) — c'est un **périmètre implicite à expliciter**. Pattern transférable : toute phrase introductive de README contenant un nombre devrait inclure la mention « numéros logiques » vs « fichiers .ipynb » vs « kernel-X vs kernel-Y » si l'ambiguïté est possible.
- **L747-L2 ★** : audit catalog-pr-hygiene inter-familles (13+ familles auditées en c.747) = 1 grain MED/docs légitime trouvé. Le ratio coût/bénéfice de l'audit reste élevé même quand le pool est saturé (la H1 Planners était un drift silencieux non-claimé).
- **L747-L3 ★** : la sub-série Planners = bon cas pour entraînement pedagogique « périmètre logique vs périmètre physique » : Setup-0 (1) + Planners-1 à Planners-12 (12 × 2 langages Python+CSharp pour la plupart, certains mono-langage) + Planners-5b Lean (1) + archive = 24 fichiers, 14 numéros logiques. Pattern transferable aux autres séries avec jumeaux CSharp (CSP-1 à CSP-8, GT-2 à GT-17, etc.).

See #4959
