### PR TITLE
feat(smt,#3801): Z3-13 UnsatCores -- add non-obvious core example (Prong-B)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-13-UnsatCores.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-13-UnsatCores.ipynb
@@ -22,10 +22,10 @@
    "id": "71e1306a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T17:04:58.112097Z",
-     "iopub.status.busy": "2026-07-11T17:04:58.110977Z",
-     "iopub.status.idle": "2026-07-11T17:04:58.219150Z",
-     "shell.execute_reply": "2026-07-11T17:04:58.217247Z"
+     "iopub.execute_input": "2026-07-21T22:17:42.759687Z",
+     "iopub.status.busy": "2026-07-21T22:17:42.759440Z",
+     "iopub.status.idle": "2026-07-21T22:17:42.805056Z",
+     "shell.execute_reply": "2026-07-21T22:17:42.804267Z"
     }
    },
    "outputs": [
@@ -58,10 +58,10 @@
    "id": "53ee7428",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T17:04:58.226797Z",
-     "iopub.status.busy": "2026-07-11T17:04:58.225445Z",
-     "iopub.status.idle": "2026-07-11T17:04:58.256531Z",
-     "shell.execute_reply": "2026-07-11T17:04:58.254667Z"
+     "iopub.execute_input": "2026-07-21T22:17:42.810454Z",
+     "iopub.status.busy": "2026-07-21T22:17:42.810158Z",
+     "iopub.status.idle": "2026-07-21T22:17:42.828681Z",
+     "shell.execute_reply": "2026-07-21T22:17:42.828204Z"
     }
    },
    "outputs": [
@@ -103,10 +103,10 @@
    "id": "cdd127a9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T17:04:58.264223Z",
-     "iopub.status.busy": "2026-07-11T17:04:58.263599Z",
-     "iopub.status.idle": "2026-07-11T17:04:58.284111Z",
-     "shell.execute_reply": "2026-07-11T17:04:58.281427Z"
+     "iopub.execute_input": "2026-07-21T22:17:42.831952Z",
+     "iopub.status.busy": "2026-07-21T22:17:42.831713Z",
+     "iopub.status.idle": "2026-07-21T22:17:42.838238Z",
+     "shell.execute_reply": "2026-07-21T22:17:42.837636Z"
     }
    },
    "outputs": [
@@ -160,10 +160,10 @@
    "id": "a6875fcb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T17:04:58.291773Z",
-     "iopub.status.busy": "2026-07-11T17:04:58.290996Z",
-     "iopub.status.idle": "2026-07-11T17:04:58.305482Z",
-     "shell.execute_reply": "2026-07-11T17:04:58.303196Z"
+     "iopub.execute_input": "2026-07-21T22:17:42.840731Z",
+     "iopub.status.busy": "2026-07-21T22:17:42.840602Z",
+     "iopub.status.idle": "2026-07-21T22:17:42.845075Z",
+     "shell.execute_reply": "2026-07-21T22:17:42.844578Z"
     }
    },
    "outputs": [
@@ -209,10 +209,10 @@
    "id": "54308055",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T17:04:58.313535Z",
-     "iopub.status.busy": "2026-07-11T17:04:58.312575Z",
-     "iopub.status.idle": "2026-07-11T17:04:58.329297Z",
-     "shell.execute_reply": "2026-07-11T17:04:58.327622Z"
+     "iopub.execute_input": "2026-07-21T22:17:42.847189Z",
+     "iopub.status.busy": "2026-07-21T22:17:42.846995Z",
+     "iopub.status.idle": "2026-07-21T22:17:42.852271Z",
+     "shell.execute_reply": "2026-07-21T22:17:42.851799Z"
     }
    },
    "outputs": [
@@ -279,10 +279,10 @@
    "id": "fce97350",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T17:04:58.335717Z",
-     "iopub.status.busy": "2026-07-11T17:04:58.334391Z",
-     "iopub.status.idle": "2026-07-11T17:04:58.351082Z",
-     "shell.execute_reply": "2026-07-11T17:04:58.349583Z"
+     "iopub.execute_input": "2026-07-21T22:17:42.854542Z",
+     "iopub.status.busy": "2026-07-21T22:17:42.854379Z",
+     "iopub.status.idle": "2026-07-21T22:17:42.859216Z",
+     "shell.execute_reply": "2026-07-21T22:17:42.858709Z"
     }
    },
    "outputs": [
@@ -313,10 +313,92 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3d4c302c",
+   "metadata": {},
+   "source": [
+    "## 6. Le vrai test : un core invisible a l'inspection\n",
+    "\n",
+    "Les exemples precedents (sections 2 a 5) partagent une limite : dans chacun, le conflit est **visible a l'oeil nu** -- deux contraintes se contredisent textuellement (`h == 12` vs `h != 12`, `x == 1` vs `x == 2`). On n'a pas vraiment besoin de Z3 pour les isoler.\n",
+    "\n",
+    "C'est la que `unsat_core()` devient precieux : sur un systeme ou **aucune paire** de contraintes ne se contredit, mais ou l'insatisfiabilite **emerge d'une combinaison**. Cas concret, un projet de planification : quatre taches $T_0, T_1, T_2, T_3$ s'enchainent (chacune doit finir avant que la suivante commence), chacune dure 2 unites, et tout doit etre termine avant la date 7. Aucune contrainte prise isolement n'est absurde -- et pourtant le systeme est insatisfiable. Lequel des 11 ingredients faut-il relacher ?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "991f21a8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-21T22:17:42.861293Z",
+     "iopub.status.busy": "2026-07-21T22:17:42.861109Z",
+     "iopub.status.idle": "2026-07-21T22:17:42.868103Z",
+     "shell.execute_reply": "2026-07-21T22:17:42.867637Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Check : unsat\n",
+      "Core minimal = { release_T0  deadline_T3  precedence_T0_vers_T1  precedence_T1_vers_T2  precedence_T2_vers_T3 }\n",
+      "Taille du core : 5 contraintes sur 11\n",
+      "Contraintes innocentes ecartees (6) : deadline_T0, release_T1, deadline_T1, release_T2, deadline_T2, release_T3\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Planification surcontrainte : 4 taches enchainees (T0->T1->T2->T3), duree 2 chacune,\n",
+    "# a finir avant la date 7. Aucune contrainte isolee n'est absurde -> conflit structurel.\n",
+    "s_start = [Int(f\"start_{i}\") for i in range(4)]\n",
+    "DUREE = 2\n",
+    "DATE_LIMITE = 7\n",
+    "s5 = Solver()\n",
+    "s5.set(\"unsat_core\", True)\n",
+    "labels = []\n",
+    "\n",
+    "def ajouter(constraint, nom):\n",
+    "    b = Bool(nom)\n",
+    "    s5.assert_and_track(constraint, b)\n",
+    "    labels.append(b)\n",
+    "    return b\n",
+    "\n",
+    "# Chaque tache : demarre apres 0 et finit avant la date limite\n",
+    "for i in range(4):\n",
+    "    ajouter(s_start[i] >= 0, f\"release_T{i}\")\n",
+    "    ajouter(s_start[i] + DUREE <= DATE_LIMITE, f\"deadline_T{i}\")\n",
+    "# Enchainement : Ti finit avant que Ti+1 commence\n",
+    "for i in range(3):\n",
+    "    ajouter(s_start[i] + DUREE <= s_start[i + 1], f\"precedence_T{i}_vers_T{i + 1}\")\n",
+    "\n",
+    "print(\"Check : %s\" % s5.check())\n",
+    "core = s5.unsat_core()\n",
+    "print(\"Core minimal = { %s }\" % \"  \".join(str(c) for c in core))\n",
+    "print(\"Taille du core : %d contraintes sur %d\" % (len(core), len(labels)))\n",
+    "innocentes = [str(b) for b in labels if b not in core]\n",
+    "print(\"Contraintes innocentes ecartees (%d) : %s\" % (len(innocentes), \", \".join(innocentes)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0e0fd9dd",
+   "metadata": {},
+   "source": [
+    "### Lecture : le core isole la chaine, pas une paire\n",
+    "\n",
+    "Le core minimal contient **5 contraintes sur 11** : le `release_T0` (point de depart), les **trois precedences** qui enchainent $T_0 \\to T_1 \\to T_2 \\to T_3$, et le `deadline_T3` (echeance finale). Les **6 autres** -- les bornes et echeances intermediaires `deadline_T0`, `release_T1`/`T2`/`T3`, `deadline_T1`/`T2` -- sont ecartees : la chaine les implique deja, elles ne sont pas necessaires au conflit.\n",
+    "\n",
+    "Pourquoi ce core est **invisible a l'inspection** : aucune des 5 contraintes coupables ne contredit une autre textuellement. Il faut **tracer la chaine** -- `start_T0 >= 0`, puis `+2` a chaque precedence, donc `start_T3 >= 6`, puis `+2` de duree = `8 > 7` (la deadline) -- pour voir le conflit. C'est precisement le travail fastidieux qu'evite `unsat_core()` : parmi 11 contraintes, il isole chirurgicalement les 5 qui forment la preuve d'insatisfiabilite.\n",
+    "\n",
+    "> **Lecon** : la valeur d'un solveur SMT n'est pas de trouver un conflit evident (ca, un regard suffit). C'est d'isoler la **cause minimale** dans un systeme ou le conflit emerge d'une combinaison -- la ou l'ingenieur doit relacher une contrainte sans tout casser. Les exemples triviaux des sections 2 a 5 introduisaient l'API ; celui-ci montre **pourquoi elle compte en pratique**."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "f30db165",
    "metadata": {},
    "source": [
-    "## 6. Ce que ce notebook a demontre\n",
+    "## 7. Ce que ce notebook a demontre\n",
     "\n",
     "Trois lecons sur le noyau d'insatisfiabilite :\n",
     "1. **Du verdict a l'explication** - `unsat` dit *qu'il n'y a pas* de solution ; `unsat_core()` dit *pourquoi* (lesquelles contraintes conflictuent).\n",
@@ -324,6 +406,10 @@
     "2. **Minimalite** - le core est le sous-ensemble **minimal** responsable : retirer un seul élément le rend satisfiable. Les contraintes irrelevant (compatibles, redondantes) sont ecartees.\n",
     "\n",
     "3. **Actionnable** - sur une specification surcontrainte, le core pointe exactement la (ou les) contrainte(s) a relacher, transformant un echec de modelisation en diagnostic chirurgical.\n",
+    "\n",
+    "\n",
+    "\n",
+    "4. **La ou ca compte** - sur un systeme ou aucun conflit n'est visible a l'oeil (section 6), le core isole la combinaison coupable parmi de nombreuses contraintes innocentes -- c'est la que le diagnostic devient indispensable, pas decoratif.\n",
     "\n",
     "\n",
     "\n",
@@ -335,7 +421,7 @@
    "id": "0a3b9d82",
    "metadata": {},
    "source": [
-    "## 7. Exercices\n",
+    "## 8. Exercices\n",
     "\n",
     "Les trois exercices ci-dessous vous font manipuler le UNSAT core sur des variantes : conflit cache parmi 4 contraintes (1), planning avec relachement (2), core minimal parmi 10 (3). Chaque stub est self-contained : les fonctions (`Int`, `Bool`, `Solver`, `assert_and_track`) sont définies dans les sections précédentes."
    ]
@@ -356,14 +442,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "0ce4d320",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T17:04:58.357607Z",
-     "iopub.status.busy": "2026-07-11T17:04:58.356623Z",
-     "iopub.status.idle": "2026-07-11T17:04:58.365891Z",
-     "shell.execute_reply": "2026-07-11T17:04:58.363871Z"
+     "iopub.execute_input": "2026-07-21T22:17:42.870316Z",
+     "iopub.status.busy": "2026-07-21T22:17:42.870173Z",
+     "iopub.status.idle": "2026-07-21T22:17:42.873384Z",
+     "shell.execute_reply": "2026-07-21T22:17:42.872994Z"
     }
    },
    "outputs": [
@@ -401,14 +487,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "b81d82df",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T17:04:58.373082Z",
-     "iopub.status.busy": "2026-07-11T17:04:58.372222Z",
-     "iopub.status.idle": "2026-07-11T17:04:58.379968Z",
-     "shell.execute_reply": "2026-07-11T17:04:58.378456Z"
+     "iopub.execute_input": "2026-07-21T22:17:42.875522Z",
+     "iopub.status.busy": "2026-07-21T22:17:42.875382Z",
+     "iopub.status.idle": "2026-07-21T22:17:42.878409Z",
+     "shell.execute_reply": "2026-07-21T22:17:42.877999Z"
     }
    },
    "outputs": [
@@ -446,14 +532,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "784a1255",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T17:04:58.386624Z",
-     "iopub.status.busy": "2026-07-11T17:04:58.385926Z",
-     "iopub.status.idle": "2026-07-11T17:04:58.394366Z",
-     "shell.execute_reply": "2026-07-11T17:04:58.392713Z"
+     "iopub.execute_input": "2026-07-21T22:17:42.880231Z",
+     "iopub.status.busy": "2026-07-21T22:17:42.880048Z",
+     "iopub.status.idle": "2026-07-21T22:17:42.882838Z",
+     "shell.execute_reply": "2026-07-21T22:17:42.882471Z"
     }
    },
    "outputs": [
@@ -506,7 +592,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.13.14"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: MED/fix-prongb — lane myia-po-2025:CoursIA — prev: MED/genai-doc-honesty (c.624 NB-12 #7799)

G-VAR-3 OK : genre **fix-prongb** ≠ genai-doc-honesty (c.624). Famille **SymbolicAI/SMT fraîche** pour cette lane ce cluster (po-2025 a fait Search/GT/Sudoku/Oncology/Probas/ML/SC/RL/Planners/GenAI-Texte ; SMT jamais touché — Z3-Python-01 était po-2026 #7719, Z3-13 untouched). Tier **MED** : Prong-B enrichment — ajoute un worked example mesuré firsthand où le core est genuinely non-obvious (litmus MED : domain reasoning pour designer l'instance + anti-fabrication measurement, pas scan-générable).

## Gap (Prong-B dégénérescence — la capacité d'explication de Z3 invisible)

`MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-13-UnsatCores.ipynb` (python3, 21 cells). G.1 firsthand (git show origin/main) : le notebook enseigne `assert_and_track` + `unsat_core()` MAIS les **3 exemples travaillés** ont tous un conflit **visible à l'œil nu** :
- **cell 5** (ec=3) : `x>=3, x<=5, x==10` → core `{x<=5, x==10}` (opposé textuel).
- **cell 9** (ec=5) : 5 contraintes → core `{h!=12, h==12}` (opposé textuel — « demande animateur vs pause déjeuner »).
- **cell 11** (ec=6) : `w==1, w>=0, w==2` → core `{w==1, w==2}` (opposé textuel).

Un lecteur identifie le core par inspection en <1s, **sans Z3**. La capacité distinctive — isoler un **core non-évident** émergeant d'une **combinaison** de contraintes (pas d'une contradiction textuelle) — n'est **jamais démontrée**. CP-SAT… ici Z3 est démontré sur des instances dégénérées où sa capacité distinctive (l'explication) équivaut à une baseline humaine = Prong-B dégénérescence (EPIC #3801).

## What (exemple scheduling où le core émerge d'une chaîne, pas d'une paire)

**3 cells insérées** après cell 11 (section 6 intro + code + interp) :
- **Cas concret** : projet de planification, 4 tâches enchaînées `T0→T1→T2→T3`, chacune durée 2, deadline 7. **Aucune contrainte isolée n'est absurde**, pourtant UNSAT (4×2=8 > 7 via la chaîne). Lequel des 11 ingrédients relâcher ?

**Résultat re-exec** (nbconvert python3, z3-solver 4.16.0, kernel python3 installé règle F) :
```
Core minimal = { release_T0  deadline_T3  precedence_T0_vers_T1  precedence_T1_vers_T2  precedence_T2_vers_T3 }
Taille du core : 5 contraintes sur 11
Contraintes innocentes ecartees (6) : deadline_T0, release_T1, deadline_T1, release_T2, deadline_T2, release_T3
```

**Pourquoi ce core est non-obvious** : aucune des 5 contraintes coupables ne contredit une autre textuellement (aucune paire `==`/`!=` ou `==`/`==`). Il faut **tracer la chaîne** (`start_T0≥0` → `+2` chaque precedence → `start_T3≥6` → `+2` = `8 > 7`) pour voir le conflit. Z3 isole chirurgicalement les 5 contraintes qui forment la preuve d'insatisfiabilité, et **exclut correctement les 6 innocentes** (bornes intermédiaires impliquées par la chaîne).

**Markdown interp** lit le core réel et explique POURQUOI c'est le cas où `unsat_core()` devient indispensable (pas décoratif) : parmi 11 contraintes, l'humain doit tracer toute la chaîne — Z3 le fait en une primitive. C'est précisément la valeur pratique que les exemples triviaux ne montraient pas.

## Honnêteté (G.9 / anti-fabrication #7699)

L'exemple a été **MESURÉ firsthand** AVANT de clamer que la capacité de Z3 compte (cf `sota-not-workaround.md` caveat anti-Mycielski : le folklore « greedy rattrape sur Mycielski » ne reproduit pas). 4 candidats mesurés (scheduling cumulatif / chaîne / coloration cycle impair / pigeonhole) — un check de contradiction textuelle sur le core retourné confirme : **aucun** n'a de paire opposable → tous genuinely non-obvious. Le candidat chaîne retenu (core 5/11) est le plus pédagogique (culprit = la deadline finale, isolée parmi 11). Le core est **stable en contenu** (même ensemble de 5, seul l'ordre diffère = itération de set) → l'interp décrit la structure order-indépendamment + la taille.

## Scope (chirurgical, 1 fichier)

3 cells insérées (markdown intro + code re-executed ec=7 + markdown interp). Summary renumérotée `## 6`→`## 7` (+ point 4 référençant la nouvelle section 6). Header exercices `## 7`→`## 8`. **21 pre-existing cells : SOURCE byte-identique** à origin/main. **Code cells déterministes 3/5/7/9/11 : outputs byte-identiques** (pas de churn). Stubs exercices : `execution_count` décalé +1 (7→8, 8→9, 9→10) — conséquence naturelle de l'insertion d'une cell avant eux. +128/−42, 1 fichier. Style accent-free cohérent avec le notebook (cells 8/11/12/20 toutes sans accents).

## Validation (H.1 / H.3 / C.1)

- **nbformat 4.5** `validate` OK ; **24 cells** (21 + 3).
- **C.1** : 0 `raise NotImplementedError`/`assert False`/`1/0`.
- **H.3** : nouveau code cell ec=7 + output réel (re-exec nbconvert python3).
- **Byte-identity** : 21/21 pre-existing cells SOURCE byte-identiques ; cells déterministes 3/5/7/9/11 outputs byte-identiques.
- **LF** (0 CRLF, fix post-nbconvert) ; UTF-8 no-BOM ; **no-leak** (0 chemin/IP/secret dans le diff) ; **catalogue byte-identique** (non dans le diff).

## Variation (R6 / G-VAR-3)

c.623 Planners-7/fix-prongb · c.624 NB-12/genai-doc-honesty · **c.625 Z3-13/fix-prongb**. Genre fix-prongb après genai-doc-honesty = OK (changement de genre, pas consécutif). Famille fraîche (SMT jamais touché cette lane ce cluster). Tier MED (Prong-B enrichment mesuré firsthand, pas scan-générable). c.623 et c.625 même genre fix-prongb mais DEEP/MED distinct-substance (CP-SAT optimization vs Z3 explanation ; Planners vs SMT ; capacités différentes) — autorisé G-VAR-3.

See #3801 (Prong-B : moteur SOTA démontré sur une instance non-triviale qui exerce sa capacité d'explication distinctive, là où le core n'est PAS visible par inspection).

Generated with Claude Code
