### PR TITLE
docs(search-csp): add §5.2 LCV concept subsection to CSP-1 C# twin (parity with Python)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals-Csharp.ipynb
@@ -979,6 +979,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "3757c66b",
+   "source": "### 5.2 Value Ordering : LCV (Least Constraining Value)\n\n**Principe** : pour la variable choisie (par MRV), essayer d'abord la valeur qui **élimine le moins de possibilités** pour les variables voisines non assignées.\n\n**Intuition (\"succeed-first\")** : à l'inverse du « fail-first » pour les variables, pour les valeurs on préfère maximiser les chances que le reste du problème reste soluble — on garde le maximum de flexibilité pour la suite de la recherche.\n\n$$\\text{LCV}(v) = \\sum_{\\text{voisin } Y \\text{ non assigné}} |\\{w \\in D_Y : \\text{contrainte}(X, v, Y, w) \\text{ violée}\\}|$$\n\nOn trie les valeurs de $D_X$ par $\\text{LCV}(v)$ **croissant** (la moins contraignante d'abord). L'implémentation C# correspondante est la méthode `OrderLCV` dans la cellule suivante.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 11,
    "id": "51b6440b",


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2024:CoursIA-2 — prev: MED/docs

## Summary

Pédagogie / parité .NET ⇄ Python : le notebook jumeau C# `CSP-1-Fundamentals-Csharp.ipynb` manquait de la sous-section **§5.2 LCV (Least Constraining Value)** que possède son jumeau Python `CSP-1-Fundamentals.ipynb` (cell[33]). Le notebook C# passait directement de l'interprétation MRV (§5.1, « fail-first ») au code LCV (`OrderLCV`) avec seulement un commentaire inline, sans expliquer le **principe symétrique** (« succeed-first ») ni la formule.

Ajout d'une cellule markdown §5.2 (cell `3757c66b`) insérée entre l'interprétation MRV (`c5p1tr4n`, qui pointait déjà vers « LCV … présentée dans la cellule suivante ») et le code LCV (`51b6440b`). Contenu porté fidèlement du jumeau Python (même structure : Principe / Intuition succeed-first / formule / tri croissant), adapté au contexte C# (cross-reference `OrderLCV`).

## Why (parité justifiée)

Le notebook se déclare lui-même « binôme .NET » du Python (« Nous y implementons les mêmes algorithmes », `docs/reference/notebook-parity-table.md`). MRV bénéficiait d'une sous-section complète §5.1 (principe + intuition + formule) ; LCV, sa complémentaire exacte, n'avait que le code. Asymétrie pédagogique corrigée — les deux heuristiques reçoivent maintenant un traitement symétrique, comme dans le jumeau Python.

## Scope

- **1 fichier** : `CSP-1-Fundamentals-Csharp.ipynb` (+1 cellule markdown, +7/-1 dont −1 = newline EOF cosmétique).
- **Markdown-only** → exception C.2 (« modifs uniquement markdown → outputs précédents valides ») : **0 re-exécution requise**. Aucune cellule code touchée.
- 0 secret, 0 exercice stub modifié (anti-regression D : ajout pur, aucune suppression de contenu).

## Verification (firsthand, G.1)

- Position confirmée : `cell[20] id=3757c66b` entre `c5p1tr4n` (cell[19], MRV-interp) et `51b6440b` (cell[21], LCV-code).
- **C.2 préservée** : 19 cellules code, **0 `execution_count: null`, 0 sans outputs** (tous les outputs d'origine intacts).
- Diff inspecté (`git diff`) : pure addition de la cellule + newline EOF. Aucun code/output altéré.
- Parité vérifiée : jumeau Python `CSP-1-Fundamentals.ipynb` cell[33] = « ### 5.2 Value Ordering : LCV » (présent) ; C# = absent avant cette PR.

## Residual (hors-scope, tracked)

La nouvelle cellule markdown ajoute 1 cell_id (`3757c66b`) non présent dans `translations/search-part2/search-part2.csv`. Comme pour toute cellule nouvelle, c'est un « new cell » que le script `extract_cells_to_csv.py --update` prendra en charge lors d'une resync translation séparée (pattern établi, ex. PR #7772 « 1 new cell »). Pas dans le scope de cette PR (catalog-pr-hygiene : un sujet par PR).
