### PR TITLE
fix(prover,#7477): guard verify_with_lean degenerate inputs (#7596 series)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/verifier.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/verifier.py
@@ -89,10 +89,33 @@ def reset_verifier(project_dir: Optional[str] = None) -> None:
         _verifiers.pop(project_dir, None)
 
 
+def _require_str(name: str, value, *, allow_empty: bool = False) -> str:
+    """Boundary guard: reject None / non-str degenerate inputs (#7596-pattern, G.9).
+
+    Converts OPAQUE TypeErrors (``None[:60]`` -> "NoneType is not subscriptable",
+    reached at the ``trace.log`` slicing of a None ``theorem``) and the SILENT
+    construction of bogus Lean code (``f"{None} := by {None}"`` ->
+    ``"None := by None"``) into a clear ValueError naming the offending argument.
+    Without this guard, a misconfigured demo (``theorem: null`` / ``proof: null``,
+    or an LLM/extraction step returning None) forwards None into ``verify_with_lean``,
+    which then wastes a full Lake build on ``"None := by None"`` before an opaque
+    crash. By default empty strings are rejected too (an empty theorem/tactic is
+    never a valid Lean program); pass ``allow_empty=True`` for parameters where
+    ``''`` is a legitimate input (an empty Lean file has 0 sorries).
+    """
+    if not isinstance(value, str):
+        raise ValueError(f"{name}: expected str, got {type(value).__name__}")
+    if not allow_empty and not value:
+        raise ValueError(f"{name}: expected non-empty str, got empty string")
+    return value
+
+
 def verify_with_lean(theorem: str, tactic: str, imports: Optional[str],
                      project_dir: Optional[str], trace: TraceLogger,
                      agent_name: str = "LeanVerifier") -> dict:
     """Verify a Lean proof using LeanVerifier."""
+    theorem = _require_str("theorem", theorem)
+    tactic = _require_str("tactic", tactic)
     if imports:
         code = f"{imports}\n{theorem} := by {tactic}"
     else:

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_verifier_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_verifier_guards.py
@@ -1,0 +1,109 @@
+"""Boundary-guard tests for ``verify_with_lean`` (#7596-pattern ``_require_str``).
+
+``verify_with_lean`` is the last unguarded prover entry point in the #7596
+``_require_str`` series (knowledge / attempt_history / mine_lean_sessions /
+instructions / lean_utils all carry the guard). Without it, a misconfigured demo
+(``theorem: null`` / ``proof: null``, or an LLM/extraction step returning None)
+forwards None into the function, which (a) silently builds bogus Lean code
+``"None := by None"`` (wastes a full Lake build), then (b) crashes opaquely at
+``trace.log`` slicing (``None[:60]`` -> ``TypeError: NoneType is not
+subscriptable``). The guard converts both into a clear ``ValueError`` naming the
+offending argument, and — critically — fires BEFORE ``get_verifier`` so no Lake
+build is ever wasted on a degenerate input.
+
+These tests cover ONLY the boundary contract; they do NOT invoke a real Lake
+build (the guard short-circuits first, which is itself asserted below).
+
+Run from ``agent_tests/``:
+    python -m pytest tests/test_prover_verifier_guards.py -q
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make `prover/` importable regardless of how pytest was invoked.
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+sys.path.insert(0, str(ROOT))
+
+from prover.verifier import verify_with_lean  # noqa: E402
+from prover.trace import TraceLogger  # noqa: E402
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# #7596 degenerate-input boundary contract on verify_with_lean
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class TestVerifyWithLeanRejectsDegenerateInputs:
+    """theorem/tactic must be non-empty str; None/non-str/empty -> ValueError.
+
+    imports/project_dir stay Optional (None is legitimate for both), so the
+    guard applies ONLY to theorem and tactic — the two fields a misconfigured
+    demo or a failed LLM extraction can null out. See #7596, #7477.
+    """
+
+    def test_none_theorem_raises_value_error(self):
+        with pytest.raises(ValueError, match="theorem: expected str, got NoneType"):
+            verify_with_lean(theorem=None, tactic="rfl", imports=None,
+                             project_dir="/tmp/dummy", trace=TraceLogger())
+
+    def test_none_tactic_raises_value_error(self):
+        with pytest.raises(ValueError, match="tactic: expected str, got NoneType"):
+            verify_with_lean(theorem="theorem t : True := by", tactic=None,
+                             imports=None, project_dir="/tmp/dummy",
+                             trace=TraceLogger())
+
+    def test_non_str_theorem_raises_value_error(self):
+        # An int theorem (e.g. a JSON field accidentally typed as a number)
+        # must be rejected, not stringified into bogus Lean code.
+        with pytest.raises(ValueError, match="theorem: expected str, got int"):
+            verify_with_lean(theorem=42, tactic="rfl", imports=None,
+                             project_dir="/tmp/dummy", trace=TraceLogger())
+
+    def test_empty_theorem_raises_value_error(self):
+        with pytest.raises(ValueError, match="theorem: expected non-empty str"):
+            verify_with_lean(theorem="", tactic="rfl", imports=None,
+                             project_dir="/tmp/dummy", trace=TraceLogger())
+
+    def test_empty_tactic_raises_value_error(self):
+        with pytest.raises(ValueError, match="tactic: expected non-empty str"):
+            verify_with_lean(theorem="theorem t : True := by", tactic="",
+                             imports=None, project_dir="/tmp/dummy",
+                             trace=TraceLogger())
+
+    def test_theorem_guarded_before_tactic(self):
+        # Both degenerate: the first guard (theorem) fires, naming theorem.
+        with pytest.raises(ValueError, match="theorem: expected str, got NoneType"):
+            verify_with_lean(theorem=None, tactic=None, imports=None,
+                             project_dir="/tmp/dummy", trace=TraceLogger())
+
+
+class TestVerifyWithLeanGuardFiresBeforeBuild:
+    """The guard must short-circuit BEFORE ``get_verifier`` -> no Lake build.
+
+    The whole point of the guard is to fail fast on a degenerate input instead
+    of wasting a full Lake build on bogus code (``"None := by None"``). We assert
+    this by trapping ``get_verifier``: if the guard works, it raises ValueError
+    and ``get_verifier`` is never reached; if the guard regressed, the trap would
+    fire (the test would see the trap's AssertionError, not the expected ValueError).
+    """
+
+    def test_guard_short_circuits_before_get_verifier(self, monkeypatch):
+        import prover.verifier as vmod
+
+        def _build_must_not_run(*args, **kwargs):
+            raise AssertionError(
+                "get_verifier must not be reached — the boundary guard should "
+                "have raised ValueError before any Lake build was scheduled."
+            )
+
+        monkeypatch.setattr(vmod, "get_verifier", _build_must_not_run)
+        # If the guard works, this raises ValueError (not the trap above).
+        with pytest.raises(ValueError, match="theorem: expected str, got NoneType"):
+            verify_with_lean(theorem=None, tactic="rfl", imports=None,
+                             project_dir="/tmp/dummy", trace=TraceLogger())


### PR DESCRIPTION
## Summary

Extends the established **#7596 `_require_str` boundary-guard series** to the last unguarded prover entry point: `prover/verifier.py::verify_with_lean`. The series (knowledge / attempt_history / mine_lean_sessions / instructions / lean_utils — 30 call sites) converts opaque degenerate-input failures into clear `ValueError`s naming the offending argument. `verify_with_lean` was the lone holdout.

**Honest framing — defensive hygiene, not a live-bug fix.** No current DEMO triggers the None path: the 5 standard demos (1-5) carry real `theorem`/`proof` strings (`rfl`, `omega`, ...), and the other 57 are `sorry_type` and bypass `verify_with_lean` entirely. The value is **fail-fast boundary hygiene**: if a demo is ever misconfigured with `theorem: null`/`proof: null` (or an LLM/extraction step returns None), `verify_with_lean` currently (a) **silently builds bogus Lean code** `"None := by None"` — wasting a full Lake build — then (b) **crashes opaquely** at the `trace.log` slicing (`None[:60]` → `TypeError: 'NoneType' object is not subscriptable`). The guard converts both into a clear `ValueError` naming `theorem`/`tactic`, and fires **before** `get_verifier` so no Lake build is ever wasted on a degenerate input.

See #7477 (prover-harness forensic context — this PR is a defensive companion, not one of the P1-P6 pathologies which are all delivered), See #7596 (the `_require_str` series).

## The fix

`verifier.py`:
- Added `_require_str(name, value, *, allow_empty=False)` — verbatim copy of the canonical helper from `knowledge.py:18-35` (per-module local definition is the series convention; not a shared import).
- Guarded `theorem` and `tactic` at the top of `verify_with_lean`, before `code = f"{theorem} := by {tactic}"` and before `get_verifier(project_dir)`.
- `imports` and `project_dir` stay `Optional` (None is legitimate for both) — the guard applies ONLY to `theorem`/`tactic`.

## Validation (H.1 firsthand)

```
$ python -m pytest tests/test_prover_verifier_guards.py tests/test_prover_guards.py -q
  198 passed   (7 new + 191 existing guards — 0 contract break)

$ python -m pytest tests/test_prover_forensic_guards.py tests/test_attempt_history.py \
    tests/test_mine_lean_sessions.py -q
  101 passed   (#7596 series siblings + forensic guards — 0 cross-module break)

  Total: 299 passed, 0 failed.
```

New tests (`tests/test_prover_verifier_guards.py`, 7 cases):
- `none_theorem` / `none_tactic` → `ValueError match="...: expected str, got NoneType"`
- `non_str_theorem` (int) → `ValueError match="...: expected str, got int"`
- `empty_theorem` / `empty_tactic` → `ValueError match="...: expected non-empty str"`
- `theorem_guarded_before_tactic` (both None → first guard fires)
- **`guard_short_circuits_before_get_verifier`** — monkeypatches `get_verifier` to raise if reached; confirms the guard raises `ValueError` *before* any Lake build is scheduled (the core value claim).

## Scope (anti-regression)

- `+23/-0` on `prover/verifier.py` (pure additive: 1 helper + 2 guard lines).
- `+109` new test file `tests/test_prover_verifier_guards.py` (7 cases).
- **Launcher-side / guard-only** — does NOT touch `_derive_result_kind`, the result-kind contract, `_resolve_target_line`, or any proof logic. No `.lean` touched, no `sorry` touched.
- Catalogue byte-identical to main.

See #7477, #7596. See #1453.

Grain: MED/fix-prover-harness — lane po-2026:CoursIA — prev: MED/fix-prover-harness (c.615 PR #7778 P2b target-line guard). [2nd prover-harness PR this session; R6 OK (ban=4x family); distinct sub-systems — launcher target-line (c.615) vs verifier degenerate-input (this PR).]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
