### PR TITLE
fix(ml,#3801): ML-1 R2 label bug — Evaluate labelColumnName Size→Price

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-1-Introduction.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-1-Introduction.ipynb
@@ -609,7 +609,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Coefficient de détermination pour le modèle entraîné : 0,97\r\n"
+      "Coefficient de détermination pour le modèle entraîné : 0,85\r\n"
      ]
     }
    ],
@@ -634,7 +634,7 @@
     "\n",
     "IDataView trainingTestData = mlContext.Data.LoadFromEnumerable(testData);\n",
     "IDataView transformedTestData = model.Transform(trainingTestData);\n",
-    "RegressionMetrics trainedModelMetrics = mlContext.Regression.Evaluate(transformedTestData, labelColumnName: \"Size\");\n",
+    "RegressionMetrics trainedModelMetrics = mlContext.Regression.Evaluate(transformedTestData, labelColumnName: \"Price\");\n",
     "Console.WriteLine($\"Coefficient de détermination pour le modèle entraîné : {trainedModelMetrics.RSquared:0.00}\");"
    ]
   },
@@ -644,17 +644,17 @@
    "source": [
     "### Interpretation : Evaluation du modèle de regression\n",
     "\n",
-    "**résultat obtenu** : Le coefficient de determination R² (Wright, 1921) = 0,97 indique que le modèle explique 97 % de la variance des données de test.\n",
+    "**résultat obtenu** : Le coefficient de determination R² (Wright, 1921) = 0,85 indique que le modèle explique 85 % de la variance des données de test — un ajustement correct, mais non parfait.\n",
     "\n",
     "| Metrique | Valeur | Signification |\n",
     "|----------|--------|---------------|\n",
-    "| R² | 0,97 | Ajustement excellent, proche de la perfection |\n",
+    "| R² | 0,85 | Ajustement correct (85 % de variance expliquée) |\n",
     "| données d'entrainement | 4 exemples | Dataset minimal pour une demonstration |\n",
     "| données de test | 15 exemples | Couvrent la plage 1,1 a 8,0 en taille |\n",
     "\n",
     "**Points cles** :\n",
     "\n",
-    "1. **R² proche de 1** : La relation taille-prix est fortement lineaire dans ce jeu de données synthetiques\n",
+    "1. **R² de 0,85, pas 1** : Le modèle linéaire, entraîné sur 4 points seulement (tailles 1,1 à 3,4), doit extrapoler vers les grandes maisons (jusqu'à 8,0) où le prix au pied carré augmente (effet « premium ») — une relation légèrement non linéaire qu'une droite ne capture pas parfaitement\n",
     "2. **Biais potentiel** : Les données d'entrainement et de test se chevauchent partiellement, ce qui peut surerestimer la qualite du modèle\n",
     "3. **Generalisation** : Un R² eleve sur un petit dataset ne garantit pas la performance sur des données reelles plus complexes"
    ],


### PR DESCRIPTION
## Bug

`ML-1-Introduction.ipynb` cell[19] evaluated the SDCA regression model with `labelColumnName: "Size"`, while the trainer (cell[15]) targets `"Price"`:

```csharp
// cell[15] — trainer
.Append(mlContext.Regression.Trainers.Sdca(labelColumnName: "Price", ...))
// cell[19] — evaluation (BUG: label was Size, not Price)
var modelMetrics = mlContext.Regression.Evaluate(transformedTestData, labelColumnName: "Size");
```

Because `pred_Price = a + b·Size` (the model regresses Price on Size), scoring the prediction against **Size** computes R² between `pred_Price` and `Size` — which is ≈1 by construction, **not** the true test R². The committed `0,97` was this artefact.

## Fix + proof (firsthand, G.2)

Re-executed the notebook end-to-end with the `.net-csharp` kernel after the `Size→Price` correction. The true test R² is **0,85** (was 0,97):

| | before | after |
|---|---|---|
| cell[19] source | `labelColumnName: "Size"` | `labelColumnName: "Price"` |
| cell[19] R² output | 0,97 (artefact) | 0,85 (true) |

This matches the sklearn twin `ML-1-Introduction-Python.ipynb` cell[12], which correctly scores **0,852** on the same 15 test points — so the C# notebook now agrees with its Python sibling instead of reporting a physically-impossible near-perfect fit.

## Interpretation (cell[20]) reconciled

Dropped the "proche de la perfection" reading of the artefact R². Honest 0,85: the linear model, trained on 4 points only (sizes 1,1–3,4), must extrapolate to large houses (up to 8,0) where the price/sqft rises ("premium" effect) — a mild non-linearity a straight line cannot capture perfectly. This is exactly the interpretation the Python twin already carries.

## Diff

Surgical (5 insertions / 5 deletions), single notebook:
- cell[19]: source token `Size`→`Price` + R² output `0,97`→`0,85`
- cell[20]: interp headline `0,97 / 97 %`→`0,85 / 85 %`, table row grade, point-clé 1 rewritten

Byte-identity of all 35 other cells preserved via raw-text surgery (0 churn on untouched cells, CRLF/LF preserved).

## Validation

- JSON valid (40 cells) ✓
- `grep -nE 'raise NotImplementedError|assert False|1/0'` → **0** (C.1) ✓
- `execution_count is None and not outputs` → **0** (H.3) ✓
- 16/16 code cells executed (`execution_count` populated end-to-end) ✓
- Re-exec firsthand: `R² 0,97 → 0,85` ✓

See #3801 (Prong-A SOTA honesty — a notebook whose entire point is to teach train/test evaluation must not mis-demonstrate it). See #4956 (ML.NET→Python parity — the C# R² now matches its Python twin).