### PR TITLE
fix(search-csp,#7721): 8-Reines diagonal regression guard (Bug 1 Step 2)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-2-Consistency-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-2-Consistency-Csharp.ipynb
@@ -47,13 +47,128 @@
    "id": "f5e3a0d6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:50:04.861242Z",
-     "iopub.status.busy": "2026-07-03T23:50:04.849982Z",
-     "iopub.status.idle": "2026-07-03T23:50:06.110122Z",
-     "shell.execute_reply": "2026-07-03T23:50:06.107627Z"
+     "iopub.execute_input": "2026-07-21T23:12:50.566206Z",
+     "iopub.status.busy": "2026-07-21T23:12:50.555509Z",
+     "iopub.status.idle": "2026-07-21T23:12:52.868301Z",
+     "shell.execute_reply": "2026-07-21T23:12:52.864778Z"
     }
    },
    "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       
+       
+       "\r\n",
+       
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       
+       
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '1205968.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -94,10 +209,10 @@
    "id": "e7c41269",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:50:06.111475Z",
-     "iopub.status.busy": "2026-07-03T23:50:06.111277Z",
-     "iopub.status.idle": "2026-07-03T23:50:06.454699Z",
-     "shell.execute_reply": "2026-07-03T23:50:06.454491Z"
+     "iopub.execute_input": "2026-07-21T23:12:52.870219Z",
+     "iopub.status.busy": "2026-07-21T23:12:52.870026Z",
+     "iopub.status.idle": "2026-07-21T23:12:53.362815Z",
+     "shell.execute_reply": "2026-07-21T23:12:53.362528Z"
     }
    },
    "outputs": [
@@ -171,10 +286,10 @@
    "id": "e6295c97",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:50:06.455845Z",
-     "iopub.status.busy": "2026-07-03T23:50:06.455639Z",
-     "iopub.status.idle": "2026-07-03T23:50:06.502695Z",
-     "shell.execute_reply": "2026-07-03T23:50:06.502520Z"
+     "iopub.execute_input": "2026-07-21T23:12:53.364380Z",
+     "iopub.status.busy": "2026-07-21T23:12:53.364113Z",
+     "iopub.status.idle": "2026-07-21T23:12:53.433171Z",
+     "shell.execute_reply": "2026-07-21T23:12:53.432920Z"
     }
    },
    "outputs": [
@@ -237,10 +352,10 @@
    "id": "640c0c49",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:50:06.503998Z",
-     "iopub.status.busy": "2026-07-03T23:50:06.503723Z",
-     "iopub.status.idle": "2026-07-03T23:50:06.733021Z",
-     "shell.execute_reply": "2026-07-03T23:50:06.732849Z"
+     "iopub.execute_input": "2026-07-21T23:12:53.435137Z",
+     "iopub.status.busy": "2026-07-21T23:12:53.434902Z",
+     "iopub.status.idle": "2026-07-21T23:12:53.831558Z",
+     "shell.execute_reply": "2026-07-21T23:12:53.831308Z"
     }
    },
    "outputs": [
@@ -328,10 +443,10 @@
    "id": "f47c5c6a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:50:06.734521Z",
-     "iopub.status.busy": "2026-07-03T23:50:06.734318Z",
-     "iopub.status.idle": "2026-07-03T23:50:06.844909Z",
-     "shell.execute_reply": "2026-07-03T23:50:06.844611Z"
+     "iopub.execute_input": "2026-07-21T23:12:53.833339Z",
+     "iopub.status.busy": "2026-07-21T23:12:53.833049Z",
+     "iopub.status.idle": "2026-07-21T23:12:54.077398Z",
+     "shell.execute_reply": "2026-07-21T23:12:54.076837Z"
     }
    },
    "outputs": [
@@ -424,6 +539,74 @@
   },
   {
    "cell_type": "markdown",
+   "id": "9adb6bad",
+   "metadata": {},
+   "source": [
+    "### Garde anti-régression : contrainte diagonale (Bug 1, See #7721)\n",
+    "\n",
+    "Le bug #7721 (placeholder inerte `=> true` à la place de la contrainte diagonale) avait dégénéré les 8-Reines en une simple permutation de lignes (8! = 40320 solutions), rendant fausse toute la comparaison BT vs FC vs MAC et induisant les étudiants en erreur. La cellule suivante vérifie **explicitement** que la contrainte diagonale est active : `IsConsistent` doit rejeter deux reines alignées sur une même diagonale (`Q0=0, Q1=1` → refusé) et accepter une paire sûre (`Q0=0, Q1=4` → accepté). Cette garde empêche le placeholder de réapparaître lors d'une modification future des contraintes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "a4dc9dbb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-21T23:12:54.079139Z",
+     "iopub.status.busy": "2026-07-21T23:12:54.078894Z",
+     "iopub.status.idle": "2026-07-21T23:12:54.164282Z",
+     "shell.execute_reply": "2026-07-21T23:12:54.164030Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Garde diagonale (#7721) :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  IsConsistent({Q0:0, Q1:1}) = False  (attendu : False, attaque en diagonale)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  IsConsistent({Q0:0, Q1:4}) = True  (attendu : True, pas d'attaque)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  -> OK : contrainte diagonale active (Bug 1 maitrise)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Garde anti-regression Bug 1 (#7721) : la contrainte diagonale doit etre active.\n",
+    "// Q0=0, Q1=1 -> colonnes 0 et 1, lignes 0 et 1 : |0-1| == |0-1| -> attaque en diagonale -> IsConsistent == False.\n",
+    "var diagAttack = new Dictionary<string, object> { [\"Q0\"] = 0, [\"Q1\"] = 1 };\n",
+    "// Q0=0, Q1=4 -> colonnes 0 et 1, lignes 0 et 4 : |0-1| != |0-4| -> pas d'attaque -> IsConsistent == True.\n",
+    "var safePair   = new Dictionary<string, object> { [\"Q0\"] = 0, [\"Q1\"] = 4 };\n",
+    "\n",
+    "bool attackRejected = !nqueensCSP.IsConsistent(diagAttack);\n",
+    "bool safeAccepted   =  nqueensCSP.IsConsistent(safePair);\n",
+    "\n",
+    "Console.WriteLine(\"Garde diagonale (#7721) :\");\n",
+    "Console.WriteLine($\"  IsConsistent({{Q0:0, Q1:1}}) = {nqueensCSP.IsConsistent(diagAttack)}  (attendu : False, attaque en diagonale)\");\n",
+    "Console.WriteLine($\"  IsConsistent({{Q0:0, Q1:4}}) = {nqueensCSP.IsConsistent(safePair)}  (attendu : True, pas d'attaque)\");\n",
+    "Console.WriteLine($\"  -> {(attackRejected && safeAccepted ? \"OK : contrainte diagonale active (Bug 1 maitrise)\" : \"ECHEC : contrainte diagonale inactive (regression Bug 1 !)\")}\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "c5ec7cb3",
    "metadata": {},
    "source": [
@@ -434,14 +617,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "5ad5527d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:50:06.846317Z",
-     "iopub.status.busy": "2026-07-03T23:50:06.846128Z",
-     "iopub.status.idle": "2026-07-03T23:50:06.927737Z",
-     "shell.execute_reply": "2026-07-03T23:50:06.927448Z"
+     "iopub.execute_input": "2026-07-21T23:12:54.165909Z",
+     "iopub.status.busy": "2026-07-21T23:12:54.165674Z",
+     "iopub.status.idle": "2026-07-21T23:12:54.279533Z",
+     "shell.execute_reply": "2026-07-21T23:12:54.279201Z"
     }
    },
    "outputs": [
@@ -563,14 +746,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "bf302925",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:50:06.929153Z",
-     "iopub.status.busy": "2026-07-03T23:50:06.928952Z",
-     "iopub.status.idle": "2026-07-03T23:50:06.971496Z",
-     "shell.execute_reply": "2026-07-03T23:50:06.971321Z"
+     "iopub.execute_input": "2026-07-21T23:12:54.281560Z",
+     "iopub.status.busy": "2026-07-21T23:12:54.281265Z",
+     "iopub.status.idle": "2026-07-21T23:12:54.398294Z",
+     "shell.execute_reply": "2026-07-21T23:12:54.398110Z"
     }
    },
    "outputs": [
@@ -621,14 +804,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "c543fba3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:50:06.972538Z",
-     "iopub.status.busy": "2026-07-03T23:50:06.972359Z",
-     "iopub.status.idle": "2026-07-03T23:50:07.018496Z",
-     "shell.execute_reply": "2026-07-03T23:50:07.018340Z"
+     "iopub.execute_input": "2026-07-21T23:12:54.399452Z",
+     "iopub.status.busy": "2026-07-21T23:12:54.399256Z",
+     "iopub.status.idle": "2026-07-21T23:12:54.442636Z",
+     "shell.execute_reply": "2026-07-21T23:12:54.442455Z"
     }
    },
    "outputs": [
@@ -679,14 +862,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "80aabb73",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:50:07.019578Z",
-     "iopub.status.busy": "2026-07-03T23:50:07.019405Z",
-     "iopub.status.idle": "2026-07-03T23:50:07.088014Z",
-     "shell.execute_reply": "2026-07-03T23:50:07.087849Z"
+     "iopub.execute_input": "2026-07-21T23:12:54.443881Z",
+     "iopub.status.busy": "2026-07-21T23:12:54.443694Z",
+     "iopub.status.idle": "2026-07-21T23:12:54.547518Z",
+     "shell.execute_reply": "2026-07-21T23:12:54.547277Z"
     }
    },
    "outputs": [
@@ -867,14 +1050,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "d390fc54",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:50:07.089242Z",
-     "iopub.status.busy": "2026-07-03T23:50:07.089061Z",
-     "iopub.status.idle": "2026-07-03T23:50:07.146677Z",
-     "shell.execute_reply": "2026-07-03T23:50:07.146431Z"
+     "iopub.execute_input": "2026-07-21T23:12:54.549393Z",
+     "iopub.status.busy": "2026-07-21T23:12:54.549146Z",
+     "iopub.status.idle": "2026-07-21T23:12:54.711641Z",
+     "shell.execute_reply": "2026-07-21T23:12:54.711388Z"
     }
    },
    "outputs": [
@@ -1062,14 +1245,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "822a850c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:50:07.147852Z",
-     "iopub.status.busy": "2026-07-03T23:50:07.147680Z",
-     "iopub.status.idle": "2026-07-03T23:50:07.357901Z",
-     "shell.execute_reply": "2026-07-03T23:50:07.358261Z"
+     "iopub.execute_input": "2026-07-21T23:12:54.713736Z",
+     "iopub.status.busy": "2026-07-21T23:12:54.713439Z",
+     "iopub.status.idle": "2026-07-21T23:12:55.069387Z",
+     "shell.execute_reply": "2026-07-21T23:12:55.069514Z"
     }
    },
    "outputs": [
@@ -1085,7 +1268,7 @@
     {
      "data": {
       "text/plain": [
-       ""
+       "Loading extensions from `C:\\Users\\jsboi\\.nuget\\packages\\skiasharp\\2.88.9\\interactive-extensions\\dotnet\\SkiaSharp.DotNet.Interactive.dll`"
       ]
      },
      "metadata": {},
@@ -1112,7 +1295,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.3.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
       "\r\n"
      ]
     }
@@ -1161,14 +1344,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "fce16f11",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:50:07.359740Z",
-     "iopub.status.busy": "2026-07-03T23:50:07.359488Z",
-     "iopub.status.idle": "2026-07-03T23:50:07.423806Z",
-     "shell.execute_reply": "2026-07-03T23:50:07.423634Z"
+     "iopub.execute_input": "2026-07-21T23:12:55.071078Z",
+     "iopub.status.busy": "2026-07-21T23:12:55.070822Z",
+     "iopub.status.idle": "2026-07-21T23:12:55.169721Z",
+     "shell.execute_reply": "2026-07-21T23:12:55.169205Z"
     }
    },
    "outputs": [
@@ -1268,14 +1451,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "e8494c37",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:50:07.425138Z",
-     "iopub.status.busy": "2026-07-03T23:50:07.424892Z",
-     "iopub.status.idle": "2026-07-03T23:50:08.105532Z",
-     "shell.execute_reply": "2026-07-03T23:50:08.105309Z"
+     "iopub.execute_input": "2026-07-21T23:12:55.171770Z",
+     "iopub.status.busy": "2026-07-21T23:12:55.171506Z",
+     "iopub.status.idle": "2026-07-21T23:12:55.670247Z",
+     "shell.execute_reply": "2026-07-21T23:12:55.669758Z"
     }
    },
    "outputs": [
@@ -1438,14 +1621,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "40e758dc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:50:08.106843Z",
-     "iopub.status.busy": "2026-07-03T23:50:08.106672Z",
-     "iopub.status.idle": "2026-07-03T23:50:08.169553Z",
-     "shell.execute_reply": "2026-07-03T23:50:08.169364Z"
+     "iopub.execute_input": "2026-07-21T23:12:55.671885Z",
+     "iopub.status.busy": "2026-07-21T23:12:55.671634Z",
+     "iopub.status.idle": "2026-07-21T23:12:55.762259Z",
+     "shell.execute_reply": "2026-07-21T23:12:55.761712Z"
     }
    },
    "outputs": [
@@ -1514,14 +1697,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "c928c722",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:50:08.170826Z",
-     "iopub.status.busy": "2026-07-03T23:50:08.170626Z",
-     "iopub.status.idle": "2026-07-03T23:50:08.256280Z",
-     "shell.execute_reply": "2026-07-03T23:50:08.256078Z"
+     "iopub.execute_input": "2026-07-21T23:12:55.763970Z",
+     "iopub.status.busy": "2026-07-21T23:12:55.763678Z",
+     "iopub.status.idle": "2026-07-21T23:12:55.890504Z",
+     "shell.execute_reply": "2026-07-21T23:12:55.890213Z"
     }
    },
    "outputs": [
@@ -1543,7 +1726,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Temps : 6,5 ms\r\n"
+      "  Temps : 4,2 ms\r\n"
      ]
     },
     {
@@ -1608,14 +1791,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "99752c32",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:50:08.257733Z",
-     "iopub.status.busy": "2026-07-03T23:50:08.257508Z",
-     "iopub.status.idle": "2026-07-03T23:50:08.312417Z",
-     "shell.execute_reply": "2026-07-03T23:50:08.312136Z"
+     "iopub.execute_input": "2026-07-21T23:12:55.892376Z",
+     "iopub.status.busy": "2026-07-21T23:12:55.892096Z",
+     "iopub.status.idle": "2026-07-21T23:12:55.981433Z",
+     "shell.execute_reply": "2026-07-21T23:12:55.980976Z"
     }
    },
    "outputs": [
@@ -1676,14 +1859,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "id": "912a8364",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:50:08.314168Z",
-     "iopub.status.busy": "2026-07-03T23:50:08.313920Z",
-     "iopub.status.idle": "2026-07-03T23:50:08.405371Z",
-     "shell.execute_reply": "2026-07-03T23:50:08.405122Z"
+     "iopub.execute_input": "2026-07-21T23:12:55.982836Z",
+     "iopub.status.busy": "2026-07-21T23:12:55.982599Z",
+     "iopub.status.idle": "2026-07-21T23:12:56.067011Z",
+     "shell.execute_reply": "2026-07-21T23:12:56.066764Z"
     }
    },
    "outputs": [
@@ -1705,7 +1888,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Temps : 4,1 ms\r\n"
+      "  Temps : 4,8 ms\r\n"
      ]
     },
     {
@@ -1743,14 +1926,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "id": "b3a4b064",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:50:08.406922Z",
-     "iopub.status.busy": "2026-07-03T23:50:08.406689Z",
-     "iopub.status.idle": "2026-07-03T23:50:08.474208Z",
-     "shell.execute_reply": "2026-07-03T23:50:08.473987Z"
+     "iopub.execute_input": "2026-07-21T23:12:56.069060Z",
+     "iopub.status.busy": "2026-07-21T23:12:56.068773Z",
+     "iopub.status.idle": "2026-07-21T23:12:56.153669Z",
+     "shell.execute_reply": "2026-07-21T23:12:56.153119Z"
     }
    },
    "outputs": [
@@ -1765,21 +1948,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  BT (no propagation)  :   876 noeuds,   9,7 ms\r\n"
+      "  BT (no propagation)  :   876 noeuds,   7,6 ms\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  FC (forward check)   :    75 noeuds,   6,5 ms\r\n"
+      "  FC (forward check)   :    75 noeuds,   4,2 ms\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  MAC (AC-3 complet)   :    20 noeuds,   4,1 ms\r\n"
+      "  MAC (AC-3 complet)   :    20 noeuds,   4,8 ms\r\n"
      ]
     }
    ],
@@ -1831,14 +2014,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "id": "90d657a7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:50:08.475492Z",
-     "iopub.status.busy": "2026-07-03T23:50:08.475291Z",
-     "iopub.status.idle": "2026-07-03T23:50:08.537716Z",
-     "shell.execute_reply": "2026-07-03T23:50:08.537560Z"
+     "iopub.execute_input": "2026-07-21T23:12:56.155518Z",
+     "iopub.status.busy": "2026-07-21T23:12:56.155297Z",
+     "iopub.status.idle": "2026-07-21T23:12:56.243311Z",
+     "shell.execute_reply": "2026-07-21T23:12:56.243128Z"
     }
    },
    "outputs": [
@@ -1936,14 +2119,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "id": "20a4dde7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:50:08.539141Z",
-     "iopub.status.busy": "2026-07-03T23:50:08.538962Z",
-     "iopub.status.idle": "2026-07-03T23:50:08.571366Z",
-     "shell.execute_reply": "2026-07-03T23:50:08.571192Z"
+     "iopub.execute_input": "2026-07-21T23:12:56.245153Z",
+     "iopub.status.busy": "2026-07-21T23:12:56.244924Z",
+     "iopub.status.idle": "2026-07-21T23:12:56.286083Z",
+     "shell.execute_reply": "2026-07-21T23:12:56.285547Z"
     }
    },
    "outputs": [
@@ -1988,14 +2171,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "id": "499cdcf2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:50:08.572531Z",
-     "iopub.status.busy": "2026-07-03T23:50:08.572342Z",
-     "iopub.status.idle": "2026-07-03T23:50:08.603823Z",
-     "shell.execute_reply": "2026-07-03T23:50:08.603638Z"
+     "iopub.execute_input": "2026-07-21T23:12:56.287715Z",
+     "iopub.status.busy": "2026-07-21T23:12:56.287388Z",
+     "iopub.status.idle": "2026-07-21T23:12:56.320599Z",
+     "shell.execute_reply": "2026-07-21T23:12:56.320313Z"
     }
    },
    "outputs": [
@@ -2038,14 +2221,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "id": "7733d74e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T23:50:08.605169Z",
-     "iopub.status.busy": "2026-07-03T23:50:08.604838Z",
-     "iopub.status.idle": "2026-07-03T23:50:08.637857Z",
-     "shell.execute_reply": "2026-07-03T23:50:08.637674Z"
+     "iopub.execute_input": "2026-07-21T23:12:56.322136Z",
+     "iopub.status.busy": "2026-07-21T23:12:56.321903Z",
+     "iopub.status.idle": "2026-07-21T23:12:56.355567Z",
+     "shell.execute_reply": "2026-07-21T23:12:56.355092Z"
     }
    },
    "outputs": [
@@ -2139,7 +2322,7 @@
    "mimetype": "text/x-csharp",
    "name": "C#",
    "pygments_lexer": "csharp",
-   "version": "12.0"
+   "version": "13.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-dotnet (#7810, same-cycle CSP-1 §6.2 — distinct substance: bug-guard vs parity, G-VAR-3 ok)

## Summary

Ajoute une **garde anti-régression explicite** dans `CSP-2-Consistency-Csharp.ipynb` vérifiant que la contrainte diagonale des 8-Reines est active sur `nqueensCSP` : `IsConsistent({Q0:0, Q1:1})` doit valoir `False` (attaque en diagonale) et `IsConsistent({Q0:0, Q1:4})` doit valoir `True` (paire sûre).

Cela **complète définitivement l'acceptance de #7721** : l'issue (4 bugs, solution proposée en 5 étapes) était résolue à 95 % par #7729 (Bugs 1/3/5) et #7779 (recap cell[49] / interp cell[41]), mais l'**étape 2 (« Valider Bug 4 : confirmer IsConsistent({Q0:0,Q1:1}) == false ») n'avait jamais été postée ni intégrée** (0 commentaire sur l'issue). Cette PR la réalise sous forme d'une garde permanente in-notebook.

## Pourquoi cette garde (défense en profondeur)

Le Bug 1 de #7721 était **sevère** : un placeholder inerte `=> true` à la place de la contrainte diagonale avait dégénéré les 8-Reines en une simple permutation (8! = 40320 solutions), rendant **fausse toute la comparaison BT vs FC vs MAC** de la section 5/6/7 et induisant les étudiants en erreur (le notebook affichait « MAC domine » alors que MAC = FC = 8 nœuds, cascade AC-3 inutile). Une garde explicite empêche ce placeholder de réapparaître lors d'une modification future des contraintes.

## Verification (firsthand, G.1 — re-exec indépendante)

- **Re-exec complète** : `jupyter nbconvert --to notebook --execute --inplace --ExecutePreprocessor.kernel_name=.net-csharp` → **23/23 cellules OK**, EXEC_PROVED.
- **Garde cell (`a4dc9dbb`, exec=6)** :
  ```
  Garde diagonale (#7721) :
    IsConsistent({Q0:0, Q1:1}) = False  (attendu : False, attaque en diagonale)
    IsConsistent({Q0:0, Q1:4}) = True  (attendu : True, pas d'attaque)
    -> OK : contrainte diagonale active (Bug 1 maitrise)
  ```
- **Bug 4 confirmé fantôme firsthand** : cell FC (`c928c722`) produit une solution **valide non-identité** `Q0->0 Q1->4 Q2->7 Q3->5 Q4->2 Q5->6 Q6->1 Q7->3` (75 nœuds) — le Bug 4 suspecté par l'OP n'était qu'un fantôme du CSP dégénéré (Bug 1), résolu par le fix diagonal de #7729.
- **Aucune régression** : ordering préservé **BT=876 > FC=75 > MAC=20** (cellules `b3a4b064` + `912a8364`), compte de nœuds identique (seuls les temps muraux varient — non-déterminisme normal).
- **C.1** : 0 `raise NotImplementedError` / `assert False` / `1/0` dans le notebook.
- **C.2** : 0 cellule code avec `execution_count: null` (hors exercise-stubs).
- **probeAddresses banner** : 9 lignes strippées (re-introduites par la re-exec .NET) via `strip_probe_banner.py --apply`.

## Scope (anti-régression D, catalog-pr-hygiene)

- **1 fichier** : `CSP-2-Consistency-Csharp.ipynb` (+2 cellules : markdown explicatif `9adb6bad` + code garde `a4dc9dbb`).
- **Source byte-identique** sur les 50 cellules pré-existantes (vérifié par comparaison `source` field-by-field : 0 changement de code source existant). Le diff git (296/+113) = 2 nouvelles cellules + churn de metadata de re-exec (timestamps `iopub.execute_input` mis à jour sur chaque cellule) + regen des wrappers HTML ScottPlot (**PNG byte-identiques** : base64 len 18812/16448 inchangés sur `822a850c`/`90d657a7`).
- **Catalogue byte-identique** (catalog-pr-hygiene R1 ✓).
- 0 secret, 0 path absolu `c:/dev` résiduel.

## Residual (hors-scope, tracked)

La nouvelle cellule markdown+code ajoute 2 `cell_id` (`9adb6bad`, `a4dc9dbb`) non présents dans `translations/search-part2/search-part2.csv`. Comme pour toute cellule nouvelle, c'est un « new cell » que `extract_cells_to_csv.py --update` prendra en charge lors d'une resync translation séparée (pattern établi, ex. PR #7772). Pas dans le scope de cette PR atomique.

## Pattern établi

Garde anti-régression in-notebook après fix multi-bug = consolidation durable (cf #7729 fix + cette garde). `Closes #7721` car l'issue est désormais **entièrement résolue** (4/4 bugs + 5/5 étapes d'acceptance, étape 2 désormais permanente).