### PR TITLE
docs(gametheory,#4959): reconcile CATALOG-STATUS marker 50→55 (post-tranche-8)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/README.md
@@ -4,9 +4,10 @@
 
 <!-- CATALOG-STATUS
 series: GameTheory
-pedagogical_count: 50
-breakdown: root=43, SocialChoice=7
+pedagogical_count: 55
+breakdown: root=48, SocialChoice=7
 maturity: PRODUCTION=36, BETA=14
+maturity_note: maturity counts not reconciled post-tranche-8 (5 notebooks missing from catalog: GT-8, GT-8b, GT-8c-Python, GT-8c-Csharp, GT-8-Csharp); cron catalog-cron.yml will regenerate on next daily run.
 -->
 
 La théorie des jeux est le langage mathématique de la stratégie. Elle modélise les situations où des agents rationnels prennent des décisions dont le résultat dépend des choix des autres : enchères, négociations commerciales, élections, poker, guerre commerciale, allocation de ressources. Cette dualité entre coopération et compétition est omniprésente en économie, en sciences politiques et en informatique (mécanismes de vote, smart contracts, réseaux). Le prix Nobel d'économie a été décerné à des théoriciens des jeux à sept reprises entre 1994 et 2020 — c'est un domaine vivant et influent.


### PR DESCRIPTION
Grain: MED/docs — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-dotnet (c.751)

## Summary

PR pédagogique cycle c.752 — `docs(gametheory,#4959)` — réconcilie le marqueur `CATALOG-STATUS` du README GameTheory avec la vérité git-tracked. Découverte first-hand : `git ls-files MyIA.AI.Notebooks/GameTheory/*.ipynb` = **55 fichiers** (48 root + 7 SocialChoice), mais le README claim `pedagogical_count: 50` + `breakdown: root=43, SocialChoice=7`.

Diff strictement additif au marker (3+/2-) :
- `pedagogical_count: 50` → `55`
- `breakdown: root=43, SocialChoice=7` → `root=48, SocialChoice=7`
- `maturity: PRODUCTION=36, BETA=14` (inchangé — voir note)
- **+1 ligne `maturity_note:`** documentant l'incertitude sur la maturité (5 notebooks de la tranche 8 manquent au catalogue généré ; le cron `catalog-cron.yml` quotidien régénèrera)

## Découverte first-hand (G.1)

```
$ git ls-files MyIA.AI.Notebooks/GameTheory/ | grep -c '\.ipynb$'
55
$ git ls-files MyIA.AI.Notebooks/GameTheory/ | grep -c '/GameTheory-' | grep -v SocialChoice
48 (root)
$ git ls-files MyIA.AI.Notebooks/GameTheory/SocialChoice/ | grep -c '\.ipynb$'
7 (SocialChoice)
```

**5 notebooks git-trackés mais absents du catalogue généré** :
- `GameTheory-8-CombinatorialGames.ipynb`
- `GameTheory-8-CombinatorialGames-Csharp.ipynb`
- `GameTheory-8b-Lean-CombinatorialGames.ipynb`
- `GameTheory-8c-CombinatorialGames-Python.ipynb`
- `GameTheory-8c-CombinatorialGames-Csharp.ipynb`

→ Le catalogue (authoritative) a 50 entrées, le README en déclarait 50, mais **55 fichiers existent**. Le README suit le catalogue (50) ; la réalité git-tracked (55) était invisible tant qu'on n'avait pas fait `ls-files` direct.

## Pourquoi la maturité reste à `PRODUCTION=36, BETA=14`

**G.9 culture du doute** : je ne peux PAS recalculer honnêtement le ratio PRODUCTION/BETA des 5 notebooks de la tranche 8 sans (a) exécuter chaque notebook pour vérifier qu'il tourne end-to-end (process multi-heure) ou (b) toucher au catalogue (interdit par R1 catalog-pr-hygiene, qui réserve cette opération au cron `catalog-cron.yml`).

**Décision : ne pas inventer un chiffre**. J'ajoute une `maturity_note:` qui (1) nomme le sous-grain (« 5 notebooks missing from catalog »), (2) pointe vers le cron canonique pour la régénération, et (3) signale explicitement que la maturité sera ré-écrite par le cron quotidien post-merge.

Cette approche respecte simultanément :
- **R1 catalog-pr-hygiene** : je NE régénère PAS le catalogue (le cron le fera)
- **G.1 verify-before-claiming** : je claim `pedagogical_count: 55` parce que `git ls-files` le prouve
- **G.9 culture du doute** : je NE claim PAS une maturité précise que je n'ai pas pu vérifier

## Validation (H.1 + Règle G.1)

- `git ls-files` direct = 48 root + 7 SocialChoice = **55**
- `git show origin/main:COURSE_CATALOG.generated.json` filtré série=GameTheory = **50 entrées** (5 manquantes, identifiées par path)
- Aucune cellule de code touchée (1 fichier README, marker uniquement)
- Pas de modification de la prose du README (les claims chiffrés "50" et "43" n'apparaissent **que** dans le bloc CATALOG-STATUS lignes 7-8 ; le reste du fichier utilise "7" pour SocialChoice et "55" pour des minutes — contexte non concerné)
- `catalog-guard.yml` : ne devrait pas se déclencher (pas de modification de `COURSE_CATALOG.generated.json`)

## Anti-régression D — substance distincte

Cette PR ne duplique PAS :
- **c.746 PR #7800** (Sudoku, `docs(sudoku,#4959)` reconcile « 19 → 36 ») : notebook diff, sujet diff, marqueur diff.
- **c.747 PR #7803** (Planners, `docs(symbolicai-planners,#4959)` reconcile « 14 → 23 ») : série diff, sujet diff.
- **c.744 PR #7793** (QC leaf CATALOG-STATUS markers) : pattern inverse (markers dans les LEAFS, pas le HUB).
- **c.745 PR #7797** (quantbooks status LIVE) : refonte d'un fichier status, pas marker HUB.
- **c.749 PR #7806** (search-part4 CSV resync post-#7577) : fichier CSV, pas marker HUB.

Substance c.752 = **réconciliation marker HUB GameTheory post-tranche-8**, indépendamment des 5 PRs ci-dessus.

## Pourquoi maintenant (timing)

La **tranche 8** (GT-8 CombinatorialGames + GT-8b Lean + GT-8c Python + twins C#) a été livrée récemment (cf c.601 « Statut de maturité — 8 NOUVEAU, 8c COMPLET » post-PR #7388 et #7457). Le marqueur n'a pas été remis à jour depuis. C'est exactement le pattern établi par c.746 (Sudoku 19→36) et c.747 (Planners 14→23).

## Variation Protocol (mandat user 2026-07-21)

**`Grain: MED/docs`** — vérifié par litmus (L746-L1 ★, L747-L1 ★) :
- « un claim chiffré obsolète dans un marqueur CATALOG-STATUS » = substance (raisonnement : identifier la source autoritative, réconcilier, ne pas inventer)
- ≠ LIGHT (qui serait « pourrais-je générer une douzaine d'autres à la chaîne en scannant le suivant » → non, chaque réconciliation est un cas unique avec sa propre source-of-truth)

Genre = **docs** (réconciliation marqueur CATALOG-STATUS), rotation vs c.751 (notebook-dotnet) → OK G-VAR-3 (pas 2× même genre consécutif).

## Compliance

- C.1 ✓ (aucun notebook touché)
- C.2 ✓ (aucune cellule code touchée)
- C.3 ✓ (aucune re-execution Papermill, scope strict)
- D ✓ (substance distincte des 5 PRs citées)
- G.1 ✓ (firsthand `git ls-files` + `git show origin/main:COURSE_CATALOG.generated.json`)
- G.9 ✓ (maturity non claimée faute de vérification, `maturity_note:` honnête)
- H.1 ✓ (validation : git ls-files + diff stat + grep claims obsolètes)
- H.3 ✓ (pas de notebook touché, scope = 1 fichier README marker)
- R1 catalog-pr-hygiene ✓ (catalogue non régénéré, marker réconcilié ponctuellement)
- R7 never-idle ✓ (grain de substance du pool, anti-monoculture docs c.742-747 → c.752 = même genre mais substance distincte et genuinement nécessaire ; next-cycle rotation vers autre genre prévue)
- Variation Protocol ✓ (G-VAR-1 plancher MED, G-VAR-3 alternance genres respectée)

## References

- **#4959 EPIC catalogue-cohérence** — registre documentaire
- **c.746 PR #7800** (Sudoku 19→36, pattern réconciliation CATALOG-STATUS)
- **c.747 PR #7803** (Planners 14→23, pattern réconciliation CATALOG-STATUS)
- **c.744 PR #7793** (QC leaf CATALOG-STATUS, pattern inverse)
- **c.745 PR #7797** (quantbooks status LIVE refond, status file vs marker)
- **catalog-pr-hygiene.md** — règles R1-R4 catalogue et branches
- **catalog-cron.yml** — cron quotidien de régénération catalogue sur main