### PR TITLE
fix(smt,#3801): Z3-Python-03 Tactics cell[11] bit-vector signed display — sign-extend 8-bit

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics-Csharp.ipynb
@@ -513,7 +513,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  a = 200 (unsigned) = 200 (signed)\r\n"
+      "  a = 200 (unsigned) = -56 (signed)\r\n"
      ]
     },
     {
@@ -583,7 +583,11 @@
     "if (s.Check() == Status.SATISFIABLE) {\n",
     "    var m = s.Model;\n",
     "    var bvnum = (BitVecNum)m.Evaluate(a5);\n",
-    "    Console.WriteLine(\"  a = \" + bvnum.UInt64 + \" (unsigned) = \" + bvnum.Int64 + \" (signed)\");\n",
+    "    // Sign-extension 8 bits : bvnum.Int64 retourne la valeur NON signee (200) ;\n",
+    "    // l interpretation signee (two's complement) de 11001000 sur 8 bits = -56.\n",
+    "    ulong bvUnsigned = bvnum.UInt64;\n",
+    "    long bvSigned = (bvUnsigned & 0x80) != 0 ? (long)bvUnsigned - 256 : (long)bvUnsigned;\n",
+    "    Console.WriteLine(\"  a = \" + bvUnsigned + \" (unsigned) = \" + bvSigned + \" (signed)\");\n",
     "}\n",
     "Console.WriteLine();\n",
     "Console.WriteLine(\"Operateurs signes vs non signes :\");\n",


### PR DESCRIPTION
## Summary

Cell 11 of `Z3-Python-03-Tactics-Csharp.ipynb` printed `a = 200 (unsigned) = 200 (signed)` — **mathematically impossible** (200 cannot be a signed 8-bit value; range is [-128,127]). The two's complement of `11001000` (200) is **-56**. Cell 10 markdown correctly stated *« La valeur `200` non signée = `-56` signée »*, so the **code output contradicted the markdown interpretation it was meant to illustrate**.

## Root cause

Z3 .NET `BitVecNum` gotcha: `bvnum.Int64` on a `BitVec(200,8)` returns the **unsigned** value (200) and does **not** sign-extend. `pyz3` `as_signed_long(200,8)` returns `-56`, confirming the .NET binding is the outlier.

## Fix

Explicit 8-bit sign-extension in the `WriteLine`:

```csharp
ulong bvUnsigned = bvnum.UInt64;
long bvSigned = (bvUnsigned & 0x80) != 0 ? (long)bvUnsigned - 256 : (long)bvUnsigned;
Console.WriteLine("  a = " + bvUnsigned + " (unsigned) = " + bvSigned + " (signed)");
```

Re-exec'd via **.NET Interactive** (kernel `.net-csharp`, Stop & Repair per rule F — kernel installed locally). Output now:

```
a = 200 (unsigned) = -56 (signed)
```

— consistent with cell 10 interpretation.

## Genre / variation

`Grain: MED/fix-dotnet-code` — lane `po-2023:CoursIA`. Non-i18n genre after i18n-Lean (c.772b) → **G-VAR-3 OK**.

## Verification (H.5 EXEC_PROVED)

- Re-exec'd locally via `nbconvert --execute --inplace` (`.net-csharp` kernel)
- `execution_count: 6`, `0` errors
- `grep NotImplementedError` = 0 (rule C.1)
- Leak scan: **NONE (clean)** (no machine paths / secrets / keys)
- `0` CRLF (origin/main = 1016 LF — matched)
- **Surgical splice** (rule C.3): only cell 11 source + outputs changed; `0` metadata churn on other cells; `7/3` numstat

## References

- `See #3801` — SOTA honesty (latent doc/code contradiction)
- `See #1206` — Z3 .NET twins family

Co-Authored-By: Claude <noreply@anthropic.com>