### PR TITLE
fix(sudoku,#3801): Sudoku-15 cell[24] reconcile stale timing claims to committed outputs

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Csharp.ipynb
@@ -3076,17 +3076,17 @@
     "\n",
     "| Aspect | Valeur observée | Analyse |\n",
     "|--------|----------------|---------|\n",
-    "| Première résolution | 193,8 secondes | Compilation initiale + 25 itérations |\n",
-    "| Seconde résolution | 0,64 secondes | Modèle déjà compilé, 25 itérations seulement |\n",
+    "| Première résolution | ≈ 350 s (349,9 s mesurés) | Compilation initiale du modèle |\n",
+    "| Seconde résolution | ≈ 0,92 s (922 ms mesurés) | Modèle déjà compilé |\n",
     "| Erreurs | 0 | Les solutions sont correctes |\n",
-    "| Itérations EP | 25 × 50 = 1250 | Chaque fixation de cellule requiert 50 itérations EP |\n",
+    "| Itérations EP | 50 EP par fixation, ≈ 2150 au total (2 grilles) | Chaque fixation de cellule requiert 50 itérations EP |\n",
     "\n",
     "**Points clés** :\n",
     "1. Le paramètre `NbIterationCells = 2` signifie qu'on fixe 2 cellules par itération\n",
-    "2. La première résolution inclut le temps de compilation du modèle (~3 minutes)\n",
+    "2. La première résolution inclut le temps de compilation du modèle (≈ 5,8 minutes)\n",
     "3. Les résolutions subsequentes sont beaucoup plus rapides\n",
     "\n",
-    "> **Note technique** : Le nombre important d'itérations EP (1250 au total pour une grille facile) s'explique par la réexécution de l'algorithme après chaque fixation de cellule. Cette approche est coûteuse mais permet de propager les contraintes progressivement."
+    "> **Note technique** : Le nombre important d'itérations EP (plusieurs centaines au total pour une grille facile) s'explique par la réexécution de l'algorithme après chaque fixation de cellule. Cette approche est coûteuse mais permet de propager les contraintes progressivement.\n"
    ]
   },
   {


### PR DESCRIPTION
## Defect

Cell 24 (Interpretation: performance du solver iteratif sur grilles faciles) cited timing values that appear **nowhere in any committed output** (G.1 firsthand: `193` count=0, `0,64` count=0 across all cells):

| Claim (stale) | Committed output (cell 32) |
|---|---|
| Premiere resolution = **193,8 s** | `Temps de resolution: 349879,5824 ms` (~350 s, compilation) |
| Seconde resolution = **0,64 s** | `Temps de resolution: 922,295 ms` (~0,92 s, compiled) |
| compilation ~3 minutes | ~5,8 minutes (349,9 s) |
| 25 x 50 = 1250 iterations | cell 32 stream: 43 iteration blocks x 50 EP ~ 2150 (2 grids) |

## Fix

Reconciled the stale numbers to the **committed cell-32 outputs** (C.2: outputs are the deliverable). **Qualitative conclusion preserved** (it is correct): iterative solver solves easy grids with 0 errors, slow first run (compilation), fast second run (compiled), costly EP re-execution per cell fixation. `Erreurs = 0` kept (cell 32 both solves: 0 erreurs restantes).

**Markdown-only edit** (rule C.3 exception - no code/output touched, existing outputs remain valid).

## Genre / variation

`Grain: MED/doc-honesty` - lane `po-2023:CoursIA`. Different genre from `fix-dotnet-code` (PR #7814) so G-VAR-3 OK.

## Verification

- Surgical splice: **only** cell 24 source changed (src=1 out=0 ec=0 meta=0)
- 5/5 numstat, 1 file
- 0 CRLF (origin/main LF preserved, 41078=41078)
- Leak scan: NONE (clean); NotImplementedError: 0
- Firsthand G.1 on `origin/main` (not shared tree)

## References

- `See #3801` - SOTA honesty (stale interpretation numbers)

Co-Authored-By: Claude <noreply@anthropic.com>