### PR TITLE
chore(trading-converter): bump SharpCompress 0.34.2 -> 0.48.0 (security GHSA-6c8g-7p36-r338) — Closes #7807

### DIFF
--- a/MyIA.Trading.Converter/CompressionHelper.cs
+++ b/MyIA.Trading.Converter/CompressionHelper.cs
@@ -178,7 +178,7 @@ namespace MyIA.Trading.Converter
         private static Stream DecompressSingleFileSharpCompress(this Stream entryStream, out string fileName)
         {
             fileName = string.Empty;
-            using var reader = ReaderFactory.Open(entryStream);
+            using var reader = ReaderFactory.OpenReader(entryStream, new ReaderOptions());
             while (reader.MoveToNextEntry())
             {
                 if (!reader.Entry.IsDirectory)
@@ -286,7 +286,7 @@ namespace MyIA.Trading.Converter
         {
             var objArchiveType = GetArchiveTypeFromSevenZipFormat(format);
             var objCompressionType = GetCompressionTypeFromSevenZipFormat(format);
-            using var writer = WriterFactory.Open(archiveFileStream, objArchiveType, new WriterOptions(objCompressionType));
+            using var writer = WriterFactory.OpenWriter(archiveFileStream, objArchiveType, new WriterOptions(objCompressionType));
             writer.Write(fileName, entryStream);
         }
 

--- a/MyIA.Trading.Converter/MyIA.Trading.Converter.csproj
+++ b/MyIA.Trading.Converter/MyIA.Trading.Converter.csproj
@@ -47,7 +47,7 @@
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="SevenZipExtractor" Version="1.0.17" />
-    <PackageReference Include="SharpCompress" Version="0.34.2" />
+    <PackageReference Include="SharpCompress" Version="0.48.0" />
     <PackageReference Include="SimdJsonSharp.Managed" Version="1.5.0" />
     <PackageReference Include="Squid-Box.SevenZipSharp" Version="1.6.1.23" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />


### PR DESCRIPTION
## Summary

Bumps **SharpCompress 0.34.2 → 0.48.0** in `MyIA.Trading.Converter`, fixing the known **MEDIUM-severity decompression-bomb/crash vulnerability GHSA-6c8g-7p36-r338** (the 0.34.2 baseline emitted `NU1902` on every build). Closes #7807.

**This is NOT a drop-in bump.** SharpCompress 0.48.0 ships a **breaking API change**: the `ReaderFactory.Open` / `WriterFactory.Open` static factory methods were removed (they became `OpenReader` / `OpenWriter`, and `OpenReader` now requires an explicit `ReaderOptions`). Verified firsthand — bumping the version alone produces two `CS0117` ("does not contain a definition for 'Open'") errors at the two SharpCompress call sites. This PR migrates both call sites, so the bump is genuinely verified (not an unverified version-string change).

## Why this is stacked on #7813

The project **did not compile on `origin/main`** (an unrelated `System.Linq.Dynamic.Core` interface-rename build break). #7813 fixes that break. This PR is based on #7813's branch so the bump can be **build-verified on a compiling tree** (the whole point — H.1 forbids shipping an unverified bump). GitHub will auto-retarget this PR to `main` once #7813 merges; no manual rebase needed.

## The migration (CompressionHelper.cs)

The two SharpCompress call sites, migrated to the 0.48.0 API:

```csharp
// Decompress (line 181): Open(stream) -> OpenReader(stream, ReaderOptions)
using var reader = ReaderFactory.OpenReader(entryStream, new ReaderOptions());

// Compress (line 289): Open(stream, type, opts) -> OpenWriter(stream, type, opts)
using var writer = WriterFactory.OpenWriter(archiveFileStream, objArchiveType, new WriterOptions(objCompressionType));
```

The entry API (`reader.MoveToNextEntry()`, `reader.Entry.IsDirectory`/`.Key`/`.Size`, `reader.WriteEntryTo(...)`, `writer.Write(...)`) is unchanged in 0.48.0 — the build reported ONLY the two `Open`-rename errors, confirming no further migration is needed.

## Validation (H.1 firsthand, isolated worktree stacked on #7813)

```
$ dotnet build MyIA.Trading.Converter.csproj -c Release   (after migration + 0.48.0)
  3 Avertissement(s)   0 Erreur(s)     Temps écoulé 00:00:01.98
```

- **0 errors** (baseline pre-#7813 had 1 unrelated error; this PR adds 0).
- **NU1902 (SharpCompress vuln) warning is GONE** — GHSA-6c8g-7p36-r338 remediated.
- 0.48.0 API surface verified firsthand via reflection: `ReaderFactory.OpenReader(Stream, ReaderOptions)`, `WriterFactory.OpenWriter(Stream, ArchiveType, IWriterOptions)`, `ReaderOptions()` ctor, `WriterOptions(CompressionType)` ctor, `IReader`/`IWriter`/`IReaderEntry` members — all present. `net9.0` TFM available.
- CRLF: 0 CR (LF-only) on both files.

## Scope (anti-regression)

- `+3/-3` across 2 files: `csproj` (version 0.34.2→0.48.0) + `CompressionHelper.cs` (2 API-call renames). No logic change.
- No other file touched. Stacked on #7813 (build-break fix) — the two PRs are independent subjects.

Closes #7807 (the dependency bump is delivered + verified).

Grain: MED/chore-security-bump — lane po-2026:CoursIA — prev: MED/fix-functional-bug (c.622 #7813). [Genre change fix-functional-bug→chore-security-bump (G-VAR-3 OK); family .NET/Trading-Converter consecutive (#7813→this) but R6 bans 4×family, 2× OK; distinct sub-systems — LINQ interface rename (#7813) vs SharpCompress dep version+API (this).]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
