### PR TITLE
fix(sl,#3801): SL-3 determination interpretation -> match committed output

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-3-RelevanceLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-3-RelevanceLearning.ipynb
@@ -788,13 +788,13 @@
     "\n",
     "| Aspect | Valeur | Signification |\n",
     "|--------|--------|---------------|\n",
-    "| détermination minimale | `{logp}` | La lipophilite seule suffit a prédire l'activite |\n",
+    "| détermination minimale | `{mw, logp}` | Il faut combiner la masse (`mw`) ET la lipophilite (`logp`) |\n",
     "| Sous-ensembles testes | $O(n^d)$ | Bien moins que $2^n - 1 = 15$ |\n",
-    "| Reduction d'espace | $O(2^4) \\to O(2^1)$ | Facteur 8x |\n",
+    "| Reduction d'espace | $O(2^4) \\to O(2^2)$ | Facteur 4x |\n",
     "\n",
-    "> **Point cle** : Si on sait que `logp` détermine l'activite, on peut ignorer `mw`, `hbd`, `hba` dans notre modèle. L'espace des hypotheses passe de $2^4 = 16$ a $2^1 = 2$ --- un seul attribut a considerer.\n",
+    "> **Point cle** : ni `logp` ni `mw` ne suffit seul. L'examen des donnees le confirme : `logp=high` donne `active` quand `mw` est `medium`/`high`, mais `inactive` quand `mw=low` (ligne `low | high | ... | inactive`). L'activite resulte donc d'une **interaction** entre masse et lipophilite --- une molecule doit etre a la fois suffisamment grosse ET lipophile. La determination minimale est `{mw, logp}` : on peut ignorer `hbd` et `hba`, mais **pas** `mw`. L'espace des hypotheses passe de $2^4 = 16$ a $2^2 = 4$.\n",
     "\n",
-    "> **Connexion moderne** : En chimoinformatique, c'est l'idee de la **règle de Lipinski** (\"Rule of Five\") : certaines proprietes moleculaires sont plus pertinentes que d'autres pour prédire l'absorption orale. Le RBL formalise cette intuition."
+    "> **Connexion moderne** : En chimoinformatique, c'est l'idee de la **règle de Lipinski** (\"Rule of Five\") : certaines proprietes moleculaires sont plus pertinentes que d'autres pour predire l'absorption orale. Le RBL formalise cette intuition --- ici, `logp` (un critere de Lipinski) est necessaire mais non suffisant."
    ]
   },
   {


### PR DESCRIPTION
## Defect (firsthand, doc-honesty / #3801)

The cell-12 markdown interpretation in `SL-3-RelevanceLearning.ipynb` contradicted the committed cell-11 output on **four points**.

### Evidence

**cell-11 output (committed, correct):**
```
Determination minimale : {mw, logp}
Sous-ensembles testes : 5 / 15
Reduction espace : O(2^4) -> O(2^2), facteur 4
```

**cell-12 markdown (committed, wrong):**

| Markdown claim | Correct value (per output) |
|---|---|
| determination minimale = `{logp}` | `{mw, logp}` |
| reduction $O(2^4) 	o O(2^1)$ facteur 8x | $O(2^4) 	o O(2^2)$ facteur 4 |
| "on peut ignorer `mw`" | mw IS in the determination — cannot be ignored |
| "la lipophilite seule suffit" | false — interaction needed |

### Why {logp} alone fails (the dataset proves it)

Two rows share `logp=high` with **opposite** targets:
- `low | high | low | low | inactive` (mw=low)
- `medium | high | low | low | active` (mw=medium)

→ `logp` alone is NOT a determination by definition. Activity requires the interaction **mw ∈ {medium,high} AND logp=high**, so both attributes are needed. The determination is `{mw, logp}`.

## Fix

Rewrite cell-12's table + Point clé from the committed output:
- determination = `{mw, logp}`
- reduction $O(2^4) 	o O(2^2)$, facteur 4
- Point clé: "ni `logp` ni `mw` ne suffit seul... on peut ignorer `hbd` et `hba`, mais **pas** `mw`" — explains the interaction, grounded in the dataset counterexample.
- Lipinski "Rule of Five" connection preserved (reframed: logp is necessary but not sufficient).

## Validation

- **Markdown-only edit** → C.2 exception (cell[11] code + outputs unchanged and valid; no re-exec needed).
- **Byte-identity**: `json.dumps(indent=1, ensure_ascii=False)+"
"` round-trip == original; **41/42 cells byte-identical** (per-cell source+output sha verified, only cell[12] changed).
- **Scope**: numstat 4/4, 1 file, ONLY cell[12] markdown.
- **C.1** = 0 voluntary errors. **CRLF** = 0 (LF preserved). No secrets.

## Method

Defect found by Explore subagent scan (HIGH confidence, read from committed numbers), **firsthand-verified** before action per the Explore-over-assertion lesson: confirmed cell-11 output prints `{mw, logp}` / `facteur 4`, confirmed the two dataset rows form a counterexample to logp-only determination, confirmed the definition taught in the notebook is violated by the markdown's claim.

See #3801 (doc/SOTA honesty).

---
*Worker po-2024 — cron-driven, does not merge.*