### PR TITLE
chore(trading-converter): pin System.Text.RegularExpressions 4.3.1 (audit-clean, companion to #7818)

### DIFF
--- a/MyIA.Trading.Converter/MyIA.Trading.Converter.csproj
+++ b/MyIA.Trading.Converter/MyIA.Trading.Converter.csproj
@@ -49,6 +49,7 @@
     <PackageReference Include="SevenZipExtractor" Version="1.0.17" />
     <PackageReference Include="SharpCompress" Version="0.48.0" />
     <PackageReference Include="SimdJsonSharp.Managed" Version="1.5.0" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="Squid-Box.SevenZipSharp" Version="1.6.1.23" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
     <PackageReference Include="System.Linq.Dynamic.Core" Version="1.6.0" />


### PR DESCRIPTION
## Summary

Pins the **transitive** `System.Text.RegularExpressions` to its patched version `4.3.1`, clearing the `dotnet list package --vulnerable` audit flag (GHSA-cmhx-cq75-c4mj). Companion to #7818 — together they make `MyIA.Trading.Converter` **audit-clean**.

## ⚠️ Honest framing — this is NOT a runtime-exposure fix

**Verified firsthand (G.1): the vulnerability is NOT a runtime exposure.** `System.Text.RegularExpressions 4.3.0` enters the NuGet *restore* graph transitively (via `System.Text.Encoding.Extensions 4.0.11` ← a legacy dep), but it is **completely shadowed at runtime** by the framework-bundled copy in `Microsoft.NETCore.App` (net9.0 ships it at 9.0.x). The runtime resolution artifact `bin/Release/net9.0/MyIA.Trading.Converter.deps.json` (single target `.NETCoreApp,Version=v9.0`) contains **zero** references to `System.Text.RegularExpressions` — the standalone package is never loaded.

So the 4.3.0 transitive is a **NuGet-audit false positive at runtime**: the advisory affects the standalone package, which the app never executes. **Do not merge this PR under the impression it closes a live HIGH exposure** — it does not.

## Why pin it anyway (defensive hygiene)

1. **CI audit hygiene.** A CI step running `dotnet list package --vulnerable --include-transitive` fails on the 4.3.0 flag. Pinning 4.3.1 clears it ("aucun package vulnérable" verified firsthand), keeping the audit gate green.
2. **Patched-at-the-source.** The transitive is pinned to its security-patched version regardless of shadowing — if a future change removes the framework reference, the patched version is already in place.
3. **Natural pair with #7818.** #7818 remediated the SharpCompress MEDIUM vuln (a *real* exposure — SharpCompress is directly called); this pin clears the *remaining* audit flag so the project is fully audit-clean.

## Validation (H.1 firsthand, stacked on #7818)

```
$ dotnet build MyIA.Trading.Converter.csproj -c Release
  3 Avertissement(s)   0 Erreur(s)     (same as post-#7818 baseline)

$ dotnet list package --vulnerable --include-transitive
  Le projet spécifié 'MyIA.Trading.Converter' n'a aucun package vulnérable
```

- Build green (0 errors, 3 warnings — unchanged from #7818). Audit clean (4.3.1 clears GHSA-cmhx-cq75-c4mj).
- 4.3.1 exists and restores cleanly (no NU1102 — unlike the 4.7.x runtime version which is not a NuGet package).
- Runtime-shadowing proven: `deps.json` has zero `System.Text.RegularExpressions` references (framework reference at 9.0.x wins).
- CRLF: 0 CR (LF-only). Catalogue byte-identical to main.

## Scope

- `+1` line in `MyIA.Trading.Converter.csproj` (the direct pin). No logic change, no other file.
- Stacked on #7818 (`chore/bump-sharpcompress-7807`), which is stacked on #7813. GitHub auto-retargets to `main` once the lower PRs merge.

See #7818 (the real exposure fix) — this PR is the audit-clean companion. See GHSA-cmhx-cq75-c4mj.

Grain: LIGHT/chore-security-pin — lane po-2026:CoursIA — prev: MED/chore-security-bump (c.623 #7818). [Strictly defensive pin for a runtime-shadowed (non-exposed) vuln, transparently framed. .NET/Trading-Converter family (3rd this session: #7813 build-break, #7818 SharpCompress bump, this audit-pin) — R6 bans 4× family, 3× OK.]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
