### PR TITLE
fix(semantic-web): SW-11 Instances|0 interpretation -> match committed output (6 individuals)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb
@@ -2541,8 +2541,8 @@
     "|---------|--------|----------|\n",
     "| Classes | 6 | Person, Student, GraduateStudent, Professor, Course, Department |\n",
     "| Object Properties | 4 | enrolledIn, teaches, memberOf, advisedBy |\n",
-    "| Datatype Properties | 2 | name, credits |\n",
-    "| Instances | 0 | (aucune instance declaree dans ce fichier OWL d'exemple) |\n",
+    "| Datatype Properties | 2 | fullName, credits |\n",
+    "| Instances | 6 | prof_dupont, course_ia, course_web_sem, dept_info, etud_martin, etud_bernard |\n",
     "\n",
     "> **Point cle** : La contrainte `disjointWith` entre Professor et Student signifie qu'une personne ne peut pas etre les deux a la fois. Le raisonneur peut detecter des violations de cette contrainte."
    ],


### PR DESCRIPTION
## What

Prong-B doc-honesty fix (EPIC #3801). SW-11-Python-KnowledgeGraphs cell[54] interpretation table contradicted cell[53] committed output in two rows.

## Defect (firsthand-verified)

cell[53] output lists the actual OWL content:
- 6 individuals: prof_dupont (Professor), course_ia (Course), course_web_sem (Course), dept_info (Department), etud_martin (GraduateStudent), etud_bernard (Student)
- datatype properties: fullName : Person -> str, credits : Course -> int

cell[54] md wrongly claimed:
- Instances: 0 (aucune instance declaree dans ce fichier OWL d'exemple)  -> now 6 individuals
- Datatype Properties: name, credits  -> now fullName, credits

The file DOES declare instances; the prose falsely said none.

## Fix

Markdown-only edit to cell[54] (2 table rows). Source + outputs untouched (C.2 markdown-only exception).

## Validation

- changed cells: [54] only (1 cell, 2 ins / 2 del)
- 42 cells byte-identical (json round-trip, CRLF 0)
- C.1 scan: 0 voluntary errors
- cell[53] committed output cross-checked: fullName count=1, name count=0 (md 'name' was fabrication)

See #3801

Generated with Claude Code