### PR TITLE
fix(search,#3801): CSP-3 N-Reines answer-key correct symmetry decomposition (was 40x8=320!=92)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-3-Advanced-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-3-Advanced-Csharp.ipynb
@@ -1076,10 +1076,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-03T04:44:58.373931Z",
-     "iopub.status.busy": "2026-07-03T04:44:58.373408Z",
-     "iopub.status.idle": "2026-07-03T04:44:58.524097Z",
-     "shell.execute_reply": "2026-07-03T04:44:58.523464Z"
+     "iopub.execute_input": "2026-07-22T01:29:48.844295Z",
+     "iopub.status.busy": "2026-07-22T01:29:48.844099Z",
+     "iopub.status.idle": "2026-07-22T01:29:48.882286Z",
+     "shell.execute_reply": "2026-07-22T01:29:48.881601Z"
     }
    },
    "outputs": [
@@ -1094,7 +1094,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Nombre de solutions N=8 sans cassage = 92 (40 symmétries uniques × 8 symmétries du carré)\r\n"
+      "Nombre de solutions N=8 sans cassage = 92 (12 solutions fondamentales, expandues par les 8 symmétries du carré : 11×8 + 1×4)\r\n"
      ]
     },
     {
@@ -1112,7 +1112,7 @@
     "\n",
     "// Placeholder pour tester la compilation\n",
     "Console.WriteLine($\"Exercice 2 - N-Reines n={n8} : en attente de votre implementation\");\n",
-    "Console.WriteLine(\"Nombre de solutions N=8 sans cassage = 92 (40 symmétries uniques × 8 symmétries du carré)\");\n",
+    "Console.WriteLine(\"Nombre de solutions N=8 sans cassage = 92 (12 solutions fondamentales, expandues par les 8 symmétries du carré : 11×8 + 1×4)\");\n",
     "Console.WriteLine(\"Avec cassage symmétries : 12 solutions uniques\");"
    ]
   },


### PR DESCRIPTION
## Defect

`CSP-3-Advanced-Csharp.ipynb` cell 22 (Exercice 2 stub — N-Reines symmetry-breaking answer-key hint) printed:

> Nombre de solutions N=8 sans cassage = 92 (40 symmétries uniques × 8 symétries du carré)

**40 × 8 = 320, not 92.** The parenthetical decomposition was arithmetically wrong. The two headline counts (92 total, 12 fundamental) were correct, but the explanatory parenthetical misleads a student who implements the exercise and checks the printed answer-key ("my solver finds 92, but the hint says 40×8=320, am I wrong?").

## Fix

Corrected to the true decomposition: 8-queens has **12 fundamental solutions**, expanded by the 8 symmetries of the square (D4). Of the 12 fundamentals, 11 yield 8 distinct images each and 1 is invariant under 180° rotation (yields only 4) → **11×8 + 1×4 = 88 + 4 = 92**.

> Nombre de solutions N=8 sans cassage = 92 (12 solutions fondamentales, expandues par les 8 symétries du carré : 11×8 + 1×4)

## Genre / variation

Grain: LIGHT/doc-honesty — lane po-2023:CoursIA. C# (.NET Interactive), Search/Part2-CSP family **fresh** for po-2023 this cluster (scanned CSP-3→9 C# twins + Search Part1-Foundations C# + ML.Net this cycle, all CLEAN except this one parenthetical). Genre doc-honesty ≠ math-bug (#7822 c.776) / fix-dotnet-code (#7814 c.774) → G-VAR-3 OK.

## Verification (H.1 EXEC_PROVED)

- Re-executed cell 22 via `.net-csharp` kernel (Google.OrTools), **0 errors**, output regenerated with the corrected parenthetical (`11×8 + 1×4`).
- **Surgical splice (C.3)**: only cell 22 (src+outputs) changed; all 25 other cells **byte-identical** to origin/main (verified per-cell sha1, 0 metadata churn — nbconvert --execute --inplace regenerates all execution metadata, so unchanged cells were restored wholesale from origin/main).
- numstat 6/6, 1 file.
- 0 CRLF (origin/main LF preserved), 0 leaks (no machine paths in cell 22 output), 0 NotImplementedError.
- Firsthand G.1 on `origin/main` (worktree `CoursIA-csp-part2`, HEAD == origin/main b28eaac9b).

## References

- See #3801 — SOTA honesty / committed-output factual correctness (8-queens symmetry decomposition).
- po-2023 lane doc-honesty precedent: Sudoku-11 (#7794), Sudoku-12 (#7801), CSP-1 (#7790), SW-13 (#7751), Sudoku-15 (#7816).

Co-Authored-By: Claude <noreply@anthropic.com>