### PR TITLE
docs(gametheory,#4956): GT-12 C# Cheap Talk markdown parity (definition + interpretation)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-12-ReputationGames-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-12-ReputationGames-Csharp.ipynb
@@ -259,6 +259,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "84a6cca7",
+   "source": "## Cheap Talk : communication non coûteuse\n\n### Définition\n\nLe **cheap talk** est une communication :\n- **Gratuite** : ne coûte rien à émettre.\n- **Non-vérifiable** : ne peut pas être prouvée vraie ou fausse.\n- **Non-engageante** : n'affecte pas directement les gains.\n\n### Quand le cheap talk est-il informatif ?\n\n**Crawford & Sobel (1982)** : le cheap talk peut transmettre de l'information **partielle** si les intérêts de l'expert et du décideur ne sont pas trop divergents. Le modèle minimal :\n- L'expert connaît $\\theta \\in [0,1]$, envoie un message $m$.\n- Le décideur choisit une action $a$.\n- Gains : expert $-(a - \\theta - b)^2$ (biais $b > 0$), décideur $-(a - \\theta)^2$.\n\nPlus le biais $b$ est grand, moins de partitions de l'espace des types sont soutenables à l'équilibre — jusqu'à l'équilibre de « babbling » (parole sans contenu). La cellule suivante déroule l'analyse qualitative, puis le sweep du biais sur les frontières de partition $a_i = i/n + 2b \\cdot i(n-i)$.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
    "id": "5f8a42cd",
@@ -398,6 +404,12 @@
     "           + \"quand b depasse le seuil de validite b <= 1/(2*n*(n-1)) (limitation connue de l'approximation).\");\n",
     "sweep.ToString().Display();\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9023a28b",
+   "source": "### Interprétation : quand la parole vaut quelque chose\n\nLe sweep ci-dessus met en évidence trois régimes de communication :\n\n| Régime | Condition | Exemple |\n|--------|-----------|---------|\n| **Information complète** | Intérêts parfaitement alignés | Médecin–patient (même objectif) |\n| **Information partielle** | Biais modéré ($b < 1/4$) | Expert aux préférences proches |\n| **Babbling** | Biais trop grand ($b \\geq 1/4$) | Vendeur intéressé vs acheteur |\n\nLe paramètre de biais $b$ capture la divergence d'intérêts entre l'expert et le décideur. Plus il est grand :\n- moins de partitions de l'espace des types sont soutenables à l'équilibre ;\n- moins d'information est transmise de façon crédible ;\n- à la limite, seul l'équilibre « babbling » subsiste (parole sans contenu).\n\n> **Application pratique** : ce modèle explique pourquoi les analyses d'experts partiellement intéressés (analystes financiers, lobbys) transmettent de l'information, mais de manière biaisée et incomplète. L'auditeur rationnel doit « décoter » les recommandations en fonction du biais perçu.",
+   "metadata": {}
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-python (c.758 #7831)

## Summary

Parité pédagogique Python⇄C# : le twin C# `GameTheory-12-ReputationGames-Csharp.ipynb` portait déjà (cell `5f8a42cd`) les **deux** fonctions du jumeau Python — l'analyse qualitative `analyze_cheap_talk()` **et** le sweep quantitatif `crawford_sobel_simulation()` (frontières de partition `a_i = i/n + 2b·i(n-i)`, `n_max = ⌊1/(4b)+0.5⌋`, variance intra-partition, % d'info transmise) — mais **sans le cadrage markdown** que le jumeau Python possède (cell `c4` définition + cell `c6` interprétation). Le code C# produisait donc le bon résultat sans expliquer *ce qu'est* le cheap talk ni le régime de lecture.

Cette PR ajoute **2 cellules markdown** (md-only) qui encadrent la cellule de code existante :
1. **Avant** (`84a6cca7`) : `## Cheap Talk : communication non coûteuse` — définition (gratuite / non-vérifiable / non-engageante) + modèle Crawford & Sobel (1982) (expert θ∈[0,1], message m, action a, gains quadratiques avec biais b).
2. **Après** (`9023a28b`) : `### Interprétation : quand la parole vaut quelque chose` — table des 3 régimes (information complète / partielle `b<1/4` / babbling `b≥1/4`) + lecture du paramètre de biais + application pratique (analystes financiers, lobbys).

## Why (parité justifiée, EPIC #4956)

Contribution à l'EPIC **#4956** « Parité .NET ⇄ Python des séries de notebooks ». Le twin C# se déclare jumeau .NET du Python (« implémente from-scratch les mêmes algorithmes », cell `3579383c`). L'asymétrie ici n'était pas algorithmique (le code était déjà porté) mais **pédagogique** : le jumeau Python encadre sa démo Cheap Talk de deux cellules markdown (définition + interprétation), le C# n'en avait aucune. Motif L751-L2 (parité twin .NET⇄Python = angle d'extension reproductible, établi c.748-c.751 sur CSP, ici appliqué à **GameTheory** = famille distincte de CSP/RL).

## Scope (anti-régression D, catalog-pr-hygiene)

- **1 fichier** : `GameTheory-12-ReputationGames-Csharp.ipynb` (+2 cellules markdown, +13/-1 dont -1 = newline EOF cosmétique).
- **Markdown-only** → exception C.2 (« modifs uniquement markdown → outputs précédents valides ») : **0 re-exécution requise**. La cellule de code C# existante (`5f8a42cd`) garde `execution_count: 2` et ses 2 outputs intacts (sweep b∈{0.05,0.1,0.2,0.3} inchangé).
- **Catalogue byte-identique** (catalog-pr-hygiene R1 ✓).
- 0 secret, 0 path absolu `c:/dev` résiduel.

## Verification (firsthand, G.1)

- **G.1 source-level** : twin Python `GameTheory-12-ReputationGames.ipynb` cell `c4` (## Cheap Talk + définition + Crawford-Sobel 1982) et cell `c6` (table 3-régimes + b<1/4 + application pratique) = présents ; C# = absents avant cette PR (vérifié par extraction des headings `##` : le C# allait directement `## Information incomplète` → code → `## Kreps-Wilson`).
- **Code C# déjà porté** : cell `5f8a42cd` contient déjà `analyze_cheap_talk` (StringBuilder intro) + sweep Crawford-Sobel complet (outputs : b=0.05 n_max=5 info 72.0%, b=0.10 n_max=3 info 56.9%, b=0.20/0.30 babbling 0.0%). Les 2 cellules markdown ajoutées **encadrent** cette démo existante sans la modifier.
- **C.2 préservée** : 10 cellules code, **0 `execution_count: null`**, tous les outputs d'origine intacts (diff inspecté : pure addition des 2 cellules md + newline EOF).
- **Diff source isolé** : +13/-1, exactement 2 nouvelles cellules markdown (`84a6cca7`, `9023a28b`), 0 cellule code altérée.
- **C.1** : 0 `raise NotImplementedError` / `assert False` / `1/0` (inchangé, aucune cellule code touchée).

## Residual (hors-scope, tracked)

La nouvelle cellule markdown ajoute 2 `cell_id` (`84a6cca7`, `9023a28b`) non présents dans le CSV de traduction de la famille GameTheory (EPIC #4957 T2). Comme pour toute cellule nouvelle, c'est un « new cell » que `extract_cells_to_csv.py --update` prendra en charge lors d'une resync translation séparée (pattern établi, ex. PR #7772). Pas dans le scope de cette PR atomique.

## Inventaire parallèle

Un sous-agent sonnet a scanné les 17 paires twins GT (heading-level) — 14/17 alignées, 5 paires à gaps. Cette PR adresse le candidat #1 (GT-12 Cheap Talk, gap MEDIUM le plus net). Autres gaps candidats (MED/notebook-dotnet futurs, substance distincte) : GT-3 Pareto (c43), GT-6 bruit/Axelrod (c34), GT-13 Leduc Poker (c31), GT-16 Gibbard-Satterthwaite (c39) + VCG non-monotonie (c22), GT-15 Assistance Games (LARGE 11 cells).
