### PR TITLE
fix(pymc): PyMC-13 Crowdsourcing cell7 lecture -> match committed data (Item 0 + W4 defect)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-13-Crowdsourcing.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-13-Crowdsourcing.ipynb
@@ -310,10 +310,10 @@
     "\n",
     "| Pattern | Items | Observation |\n",
     "|---------|-------|-------------|\n",
-    "| Consensus (4/4) | Item 0, Item 1 | Tous d'accord, haute confiance |\n",
-    "| Majorite (3/1) | Item 2, 3, 4 | Un worker diverge, le modèle doit ponderer |\n",
+    "| Consensus (4/4) | Item 1 | Les 4 workers d'accord, haute confiance |\n",
+    "| Majorite (3/1) | Item 0, 2, 3, 4 | Un worker diverge, le modèle doit ponderer |\n",
     "\n",
-    "Le Worker 4 (W4) est le seul a se tromper sur les Items 0 et 2 — c'est un bon candidat pour tester la detection de workers biaisés."
+    "Sur chaque item en desaccord (3/1), exactement un worker se trompe : le Worker 4 sur l'Item 0 (W4=0 alors que vrai=1), le Worker 3 sur l'Item 2 (W3=0 alors que vrai=1), et le Worker 2 sur les Items 3 et 4. W2 cumule deux erreurs sur cinq --- c'est le worker le plus souvent en desaccord, un bon candidat pour tester la detection de workers biaisés."
    ]
   },
   {


### PR DESCRIPTION
## What

Prong-B doc-honesty fix (EPIC #3801). PyMC-13-Crowdsourcing cell[7] (data lecture markdown) contradicted cell[6] committed output table on two points.

## Defect (firsthand-verified against committed output)

cell[6] committed output:


### Defect 1 - table row: Item 0 misclassified as 4/4 consensus
- Output labels Item 0 as a 3/1 "desaccord" (1 vote 0, 3 votes 1).
- cell[7] md table listed Item 0 under "Consensus (4/4)".
- Only Item 1 is a true 4/0 consensus.

### Defect 2 - sentence: W4 falsely accused on Item 2
- Output Item 2: "1 1 0 1 | 1" -> W3=0 is the only wrong vote; W4=1 matches the true label.
- cell[7] md said "Le Worker 4 (W4) est le seul a se tromper sur les Items 0 et 2".
- W4 errs only on Item 0. On Item 2 the divergent worker is W3.

Per-item divergence (hand-computed from the committed data table):
- Item 0 (vrai=1): W4=0 diverges
- Item 2 (vrai=1): W3=0 diverges
- Item 3 (vrai=0): W2=1 diverges
- Item 4 (vrai=1): W2=0 diverges

Worker error counts: W1=0, W2=2, W3=1, W4=1. The most error-prone worker is W2 (2 errors on Items 3 and 4), not W4.

## Fix

Rewrite cell[7] table + sentence to cite the exact per-item divergent worker, grounded in the committed data table. W2 named as the 2-error worker (best bias-detection candidate), preserving the pedagogical point honestly.

Markdown-only edit (C.2 exception: prior outputs stay valid, no re-exec needed).

## Validation

- changed cells: [7] only (1 cell, 3 ins / 3 del)
- 42 cells byte-identical (json round-trip identity confirmed: indent=1, ensure_ascii=False, +newline)
- C.1 scan: 0 voluntary errors
- CRLF 0, LF 2267
- cell[6] output cross-checked item-by-item (each divergence hand-computed)

See #3801

Generated with Claude Code