### PR TITLE
fix(ml,#3801): ML-3 AutoML markdown cites stale trial count + refuted linear/nonlinear conclusion

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-3-Entrainement&AutoML.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-3-Entrainement&AutoML.ipynb
@@ -706,7 +706,26 @@
   {
    "cell_type": "markdown",
    "id": "4de4c975",
-   "source": "## Visualisation : leaderboard des essais AutoML\n\nL'expérience ci-dessus a produit **15 essais terminés** en 30 secondes, avec un RMSE allant de **90 262** (essai #13, meilleur) à **30 523 762** (essai #1, pire) — un écart de **300×** entre le pire et le meilleur essai. Mais lire 30 lignes de `Console.WriteLine` ne permet pas de voir d'un coup d'œil *quel entraîneur a gagné* ni *combien d'entraîneurs différents* AutoML a testés.\n\nLa cellule suivante extrait les essais terminés depuis le `NotebookMonitor`, lit le nom de l'entraîneur de chaque essai (via `pipeline.ToString(trial.TrialSettings.Parameter)` qui rend une chaîne du type `Concatenate=>SdcaRegression` ou `Concatenate=>FastTreeRegression`), puis trace un **leaderboard** qui rend la discrimination visuelle :\n\n1. **Graphique en barres** : RMSE du meilleur essai par entraîneur (le gagnant se détache).\n2. **Tableau de synthèse** : nom de l'entraîneur, nombre d'essais, meilleur RMSE, durée cumulée.\n\n### Pourquoi ce n'est pas un workaround dégradé (#3801 Prong-A)\n\nLe notebook invoque le **vrai AutoML de ML.NET** (`Microsoft.ML.AutoML` 0.23.0, `AutoMLExperiment`) avec le **vrai outil de visualisation** (`Plotly.NET.Interactive` 3.0.2 + `Plotly.NET.CSharp` 0.0.1). Le leaderboard est produit par lecture directe du résultat d'`experiment.RunAsync()` — pas une simulation ASCII ni une fabrication. La sortie est *EXEC_PROVED* : la cellule est exécutée localement via `.NET Interactive` et commitée avec `execution_count != null`.\n\n### Pourquoi le problème discrimine les entraîneurs (#3801 Prong-B)\n\nLes données sont **non linéaires** (`y = 100*x² + bruit`). Sur ce type de signal, un entraîneur **linéaire** comme `SdcaRegression` ne peut capturer qu'une droite — il sera battu à plate couture par un entraîneur **non-linéaire basé sur les arbres** comme `FastTreeRegression` ou `LightGbmRegression`. Le leaderboard fait apparaître cette discrimination : les RMSE linéaires se regroupent en haut du graphique, les RMSE non-linéaires en bas. C'est cette **discrimination visible** qui fait la valeur pédagogique de l'AutoML — sans graphique, l'étudiant devrait comparer 15 nombres à la main.",
+   "source": [
+    "## Visualisation : leaderboard des essais AutoML\n",
+    "\n",
+    "L'expérience ci-dessus a produit **10 essais terminés** en 30 secondes, avec un RMSE allant de **90 262** (essai #6, `LightGbmRegression`, meilleur) à **30 523 762** (essai #1, `FastTreeRegression`, pire) — un écart de **plus de 300×** entre le pire et le meilleur essai. Mais lire ces 10 résultats de `Console.WriteLine` ne permet pas de voir d'un coup d'œil *quel entraîneur a gagné* ni *combien d'entraîneurs différents* AutoML a testés.\n",
+    "\n",
+    "La cellule suivante extrait les essais terminés depuis le `NotebookMonitor`, lit le nom de l'entraîneur de chaque essai (via `pipeline.ToString(trial.TrialSettings.Parameter)` qui rend une chaîne du type `Concatenate=>SdcaRegression` ou `Concatenate=>FastTreeRegression`), puis trace un **leaderboard** qui rend la discrimination visuelle :\n",
+    "\n",
+    "1. **Graphique en barres** : RMSE du meilleur essai par entraîneur (le gagnant se détache).\n",
+    "2. **Tableau de synthèse** : nom de l'entraîneur, nombre d'essais, meilleur RMSE, durée cumulée.\n",
+    "\n",
+    "### Pourquoi ce n'est pas un workaround dégradé (#3801 Prong-A)\n",
+    "\n",
+    "Le notebook invoque le **vrai AutoML de ML.NET** (`Microsoft.ML.AutoML` 0.23.0, `AutoMLExperiment`) avec le **vrai outil de visualisation** (`Plotly.NET.Interactive` 3.0.2 + `Plotly.NET.CSharp` 0.0.1). Le leaderboard est produit par lecture directe du résultat d'`experiment.RunAsync()` — pas une simulation ASCII ni une fabrication. La sortie est *EXEC_PROVED* : la cellule est exécutée localement via `.NET Interactive` et commitée avec `execution_count != null`.\n",
+    "\n",
+    "### Pourquoi le problème discrimine les entraîneurs (#3801 Prong-B)\n",
+    "\n",
+    "Les données sont **non linéaires** (`y = 100*x² + bruit`). Sur ce type de signal, `LightGbmRegression` (non-linéaire, gradient boosting) s'impose nettement avec un RMSE de ~90 262, soit **plus de 300× meilleur** que le pire entraîneur. C'est cette **discrimination massive** — invisible sans le leaderboard — qui fait la valeur pédagogique de l'AutoML : sans graphique, l'étudiant devrait comparer 10 nombres à la main.\n",
+    "\n",
+    "**Lecture honnête du classement.** Le leaderboard **nuance** l'idée reçue « non-linéaire bat toujours linéaire » : si `LightGbmRegression` gagne largement, `FastTreeRegression` (lui aussi non-linéaire, à base d'arbres) finit **dernier** (30,5 millions) — pire que les entraîneurs linéaires `SdcaRegression` (11,3 M) et `LbfgsPoissonRegression` (6,3 M). La séparation n'est donc pas simplement « linéaire en haut / non-linéaire en bas ». Une explication partielle : `LightGbmRegression` a bénéficié de **3 essais** d'hyper-paramètres contre **1 seul** pour `FastTreeRegression` — l'AutoML a eu moins d'occasions de bien le régler. La leçon n'en est que plus riche : la *famille* d'algorithme ne garantit pas le succès, c'est l'association **bon algorithme + bons hyper-paramètres** que l'AutoML cherche conjointement."
+   ],
    "metadata": {}
   },
   {


### PR DESCRIPTION
Grain: MED/doc-honesty — lane myia-po-2025:CoursIA — prev: MED/fix (IIT-2 #7833)

## Bug (confirmed firsthand, G.1)

`ML-3-Entrainement&AutoML.ipynb` cell 12 (markdown) cites facts that the committed cell 11/13 outputs **refute** (doc-honesty defect, the canonical stale-numbers + contradicted-conclusion pattern).

### Defect 1 — stale-numbers (HIGH)

| | markdown (cell 12) | committed output (cells 11+13) |
|---|---|---|
| trials completed | **15 essais terminés** | **10** (`Essais complétés: 10`) |
| best trial | **essai #13, meilleur** | **essai #6** (`LightGbmRegression`, RMSE 90262.7424) |

Trial #13 never ran -- only #0-#9 completed (plus #10 started, not completed). A student cross-checking would search for "essai #13" that does not exist.

### Defect 2 — doc-dishonest conclusion (MEDIUM)

Markdown claimed the non-linear tree trainers (`FastTreeRegression`, `LightGbmRegression`) would crush the linear `SdcaRegression`, and that "les RMSE linéaires se regroupent en haut, les non-linéaires en bas". The committed leaderboard refutes this:

```
LightGbmRegression      3     90262   #6   <- winner (non-linear)
FastForestRegression    4   5932134   #7
LbfgsPoissonRegression  1   6303500   #8   <- linear
SdcaRegression          1  11323122   #4   <- linear
FastTreeRegression      1  30523762   #1   <- DEAD LAST (non-linear!)
```

`FastTreeRegression` (non-linear) is **dead last** -- *worse* than the linear `SdcaRegression`. The clean "linear up / nonlinear down" story is false. (Partial reason: LightGbm got 3 hyperparameter trials vs only 1 for FastTree, so the comparison is not fully fair -- but that nuance was absent from the original text.)

## Fix

Rewrote cell 12 markdown to match the committed outputs:
- Stale numbers: "15 essais" -> "10 essais"; "essai #13" -> "essai #6 (LightGbmRegression)".
- Conclusion reframed honestly: the discrimination IS real (LightGbm wins >300x), but it is NOT a simple linear-vs-nonlinear split (FastTree non-linear is last, worse than the linear trainers). The richer lesson preserved: family != success; AutoML searches algorithm + hyperparameters jointly.

## H.1 -- proof

Markdown-only edit (C.2 exception: no code/output change -> committed cell 11/13 outputs unchanged & valid, no re-exec needed). The committed AutoML outputs (cell 11 `execution_count=5`, cell 13 `ec=6`) are the source of truth and are untouched.

## H.3 / byte-identity

- **changed cells: exactly [12]** (markdown only); all 23 other cells **byte-identical** to origin/main
- cell 12: `id`/`metadata`/`cell_type` preserved; only `source` changed; markdown has no `outputs`/`execution_count` (correct nbformat 4.5)
- No-BOM, LF (0 CRLF), trailing newline
- C.1 = 0 (`raise NotImplementedError`/`assert False` scan clean)
- 0 leaks introduced (the preexisting `C:\Users\jsboi\.nuget\...` extension-loading banner in cell 1 is **out of scope** -- it is not in my changes and is not re-introduced; noted as a separate follow-up)
- Diff: +21/-2 (surgical, single notebook, single markdown cell)

## SOTA verdict

**SOTA-OK** -- the real tool (ML.NET AutoML 0.23.0, `AutoMLExperiment` + Plotly.NET visualization) IS invoked. This PR only corrects the markdown interpretation to match the tool's real output; no workaround, no fabricated numbers. The #3801 Prong-B discrimination (AutoML on quadratic data) is genuinely exercised -- LightGbm wins by 300x.

## D. anti-regression

Not applicable (no Lean/Coq proof, no production function). No `sorry`/stub. The fix adds an *honest* reading and removes a *false* claim -- no real content stripped.

See #3801. Defect found via Explore scan (sonnet, read-only), **firsthand-verified** before action (G.1: confirmed cell 11 "10 essais"/"#6", confirmed cell 13 leaderboard, confirmed FastTree dead-last).
