### PR TITLE
docs(harness): scaffold variation-protocol Grain tag in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,24 @@
 
 > **Etudiants (PR de TP)** : remplissez seulement **Summary**. Les checklists de review sont pour l'encadrant — laissez-les telles quelles. Une CI rouge ne bloque pas le merge de votre TP.
 
+<!-- AGENTS INTERNES (workers po-*, ai-01) : la PREMIERE LIGNE du body doit porter le tag variation-protocol. ETUDIANTS : ignorez ce bloc. -->
+
+**Grain (agents internes — [variation-protocol](../.claude/rules/variation-protocol.md))** — premiere ligne du body, format :
+
+`Grain: <TIER>/<GENRE> — lane <machine:workspace> — prev: <TIER>/<GENRE>`
+
+<!--
+TIER (test objectif, detail dans .claude/rules/variation-protocol.md) :
+  DEEP  = main gagne un resultat/capacite inexistant, produit par du raisonnement de domaine
+          (sorry Lean retire + lake build OK, backtest/training multi-seed, notebook execute >=3 exos, moteur SOTA branche verdict SOTA-OK).
+  MED   = etend de la substance existante avec re-exec/verif ET change quelque chose
+          (enrichissement + re-exec, audit borne qui change une decision, refactor + tests verts, README fichier-entier corrigeant un drift structurel reel).
+  LIGHT = generable en serie par scan (guard-tranche, path-fix, doc-resync +1/-1, ledger append, fix accent/leak/FP).
+          Litmus : « pourrais-je en generer une douzaine a la chaine en scannant l'instance d'a-cote ? » -> oui = LIGHT, quel que soit le label.
+GENRE : lean . qc . training . genai . notebook-python . notebook-dotnet . docs . guard . refactor . ledger . readme . test
+Gates durs : plancher du cycle = DEEP ou MED (G-VAR-1) ; <=1 LIGHT/lane/jour, agrege (G-VAR-2) ; pas 2x le meme genre LIGHT consecutif (G-VAR-3).
+-->
+
 ## Summary
 
 <!-- 1-3 bullet points describing what this PR does -->


### PR DESCRIPTION
Grain: MED/docs — lane myia-ai-01:CoursIA — prev: n/a (merge-pass 33 PRs)

## Summary

- Adds the variation-protocol `Grain: <TIER>/<GENRE> — lane … — prev: …` line-1 scaffold to the PR template (mandate user 2026-07-21).
- Inlines the TIER litmus (DEEP/MED/LIGHT objective test) + GENRE list + the three G-VAR gates, so the merge-gate the coordinator enforces is self-documenting.
- Student-exemption UX preserved: block is marked "agents internes" and students are told to ignore it.

## Changes

- `.github/pull_request_template.md`: +18 lines, one HTML-comment block + a `**Grain (agents internes)**` line, inserted after the student header and before `## Summary`. No existing section altered.

## Test plan

- Rendered form: the added block is an HTML comment + one bold line → invisible clutter for students, discoverable for internal agents.
- This PR body itself carries the line-1 `Grain:` tag (lead by example).

See #4208 (public-reference hygiene). Refs `.claude/rules/variation-protocol.md`.