### PR TITLE
fix(infer): Infer-2 EP-vs-VMP comparison bullet -> align labels correctly (variance, not sigma; long-cluster)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb
@@ -7319,7 +7319,7 @@
     "\n",
     "**Leçon pratique.** Pour comparer VMP et EP (ou interpréter un mélange), il faut **aligner les labels** avant de comparer les paramètres — sinon un label-swap apparaît comme une « différence » alors que les clusters sous-jacents sont identiques. Ici, après alignement (EP « *Extraordinaire* » ↔ VMP *Ordinaire*, et vice-versa), on voit que :\n",
     "\n",
-    "- EP est **légèrement moins précis** que VMP (écarts-types plus larges : σ ≈ 2,48 contre 0,87 sur le cluster des trajets longs) — c'est exactement ce que la note précédente disait (« EP moins précis localement »), et c'est vérifié.\n",
+    "- EP est **légèrement moins précis** que VMP (variance plus large sur le cluster des trajets longs ~26 min : EP Gaussian(26,23, 2,478) vs VMP Gaussian(26,69, 1,146), après alignement des labels) — c'est exactement ce que la note précédente disait (« EP moins précis localement »), et c'est vérifié. À noter : la deuxième valeur d'une `Gaussian` Infer.NET est la variance, pas l'écart-type (√1,146 ≈ 1,07 min).\n",
     "- Mais EP **n'a pas divergé** — il a simplement convergé vers la solution symétrique équivalente, avec une labellisation différente.\n",
     "\n",
     "> **À retenir** : sur un mélange symétrique, changer d'algorithme (`AlgorithmEnum`) ne change pas seulement la précision locale — il expose la **non-identifiabilité** des composantes. Pour une analyse robuste, on contraint l'ordre des composantes (par exemple μ₁ < μ₂) ou on aligne les labels *a posteriori* avant toute comparaison."


### PR DESCRIPTION
## What

Prong-B doc-honesty fix (EPIC #3801). Infer-2-Gaussian-Mixtures cell[65] (the EP label-switching interpretation added by #7737) teaches the rule "aligner les labels avant de comparer les parametres" - but its comparison bullet violated that very rule and misattributed a value to the wrong cluster.

This PR improves #7737 (does not revert it): the label-switching pedagogical point stands, only the comparison numbers are corrected so the bullet actually demonstrates what the cell teaches.

## Defect (firsthand-verified against committed output)

cell[64] committed output:


cell[65] bullet said: "ecarts-types plus larges : sigma ~ 2,48 contre 0,87 sur le cluster des trajets longs". Two errors:

**Error 1 - cluster misattribution.** 0.8674 is the VMP **short** cluster (Ordinaire 15,07), NOT the long (~26 min) cluster. The long-cluster VMP value is 1.146. The bullet compared EP's long-cluster value (2.478) against VMP's *short*-cluster value (0.8674) - which is exactly the un-aligned comparison the cell itself warns against. After correctly aligning labels (EP "Ordinaire" 26,23 = VMP "Extraordinaire" 26,69 = the long cluster), the apples-to-apples comparison is EP 2.478 vs VMP **1.146**.

**Error 2 - "sigma".** The second parameter of an Infer.NET Gaussian(mean, variance) is the variance, not the standard deviation. Empirically confirmed elsewhere in the notebook: cell[40] Gaussian(16.04, 17.11) -> "Ecart-type 4.14" with sqrt(17.11)=4.136; cell[67] Gaussian(18.48, 33.39) -> "Ecart-type 5.78" with sqrt(33.39)=5.778. So 2.478 and 1.146 are variances.

## Fix

Rewrite the bullet to cite EP Gaussian(26,23, 2.478) vs VMP Gaussian(26,69, 1.146) - both the long (~26 min) cluster, correctly aligned per the cell's own rule. EP's variance is larger (less precise locally), so the bullet's narrative ("EP moins precis localement") is now genuinely supported by the cited numbers. Added a one-line note that the 2nd Gaussian value is the variance (sqrt(1.146) ~ 1.07 min).

## Note for ai-01 (out-of-scope, signaled not fixed)

cell[63] says "EP est plus precis localement" while cell[65] says "EP moins precis localement" - a directional tension between the two cells (predates this PR; both cells were touched by #7590/#7737). Reconciling cell[63]'s claim is out of scope here; this PR only makes cell[65] internally consistent and numerically honest. Flagging for awareness.

## Validation

- 1 cell changed [65], 1 line (+1/-1), raw-string surgery preserving the notebook's non-standard JSON serialization (per #7737, json.dump re-dump produces 16159 spurious diffs)
- 83 cells byte-identical (per-cell sha)
- C.1 scan: 0 voluntary errors (0 throw NotImplementedException)
- CRLF 0, LF 9317
- variance-vs-sigma convention empirically confirmed on cells 40 and 67

See #3801

Generated with Claude Code