### PR TITLE
docs(ml-net,#4956): ML-1 C# parity — prediction interpolation/extrapolation markdown

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-1-Introduction.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-1-Introduction.ipynb
@@ -780,6 +780,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "70618d7d",
+   "source": "### Interprétation : la prédiction, l'interpolation et l'extrapolation\n\nLa prédiction de **276,18 €k** pour 2 500 pieds carrés (Size = 2,5) tombe **entre** les données d'entraînement : le jeu d'apprentissage couvre les tailles 1,1 à 3,4 (soit 1 100 à 3 400 pieds carrés). Il s'agit d'une **interpolation** — la zone où un modèle linéaire est le plus fiable, car il n'a pas à deviner la pente au-delà de ce qu'il a vu.\n\nLa droite apprise passe environ par `Prix ≈ 1,05 × Size + 0,14` (soit ~2,76 à Size = 2,5, ce qui correspond bien à la sortie ci-dessus). À l'inverse, les données de test s'étendent jusqu'à Size = 8,0 (8 000 pieds carrés), largement au-delà de la plage d'entraînement : c'est de l'**extrapolation**. Les grands points de test s'écartent alors de la droite :\n\n| Size | Prix réel (test) | Prix prédit par la droite | Écart |\n|------|------------------|---------------------------|-------|\n| 4,0 | 6,1 | ~4,3 | sous-estimé |\n| 8,0 | 10,3 | ~8,5 | sous-estimé |\n\nLe vrai prix monte **plus vite** qu'une ligne droite — effet « premium » des grandes surfaces. C'est précisément ce phénomène non linéaire qui plafonne le R² à 0,85 plutôt qu'à 1 : la droite, ajustée sur le segment 1,1–3,4, sous-estime systématiquement les grandes maisons.\n\n**Règle pratique** : un modèle de régression linéaire mérite une confiance élevée à l'**intérieur** du domaine d'entraînement (interpolation) et doit être utilisé avec prudence dès qu'on **extrapole** au-delà. C'est pourquoi la prédiction à 2 500 pieds carrés est crédible, tandis qu'une prédiction pour 9 000 pieds carrés le serait beaucoup moins.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "79a119d9",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-dotnet (c.760 #7837)

## Summary

Parité pédagogique Python⇄C# : le twin C# `ML-1-Introduction.ipynb` portait déjà le moteur de prédiction et la sortie de prédiction (cell `bffc3036` : **276,18 €k** pour Size=2,5), ainsi que l'interprétation de l'évaluation (cell `de81f76f` : R²=0,85), mais **manquait l'interprétation de la prédiction** que possède le jumeau Python `ML-1-Introduction-Python.ipynb` (cell `c18` : pourquoi la prédiction à 2 500 pieds carrés est fiable = interpolation dans la plage d'entraînement 1,1–3,4, et pourquoi les grands points de test Size≥4 dévient = extrapolation).

Cette PR ajoute **1 cellule markdown** (md-only) après la cellule de code de prédiction, portant le contenu de la cellule Python `c18` adapté au contexte C# :
- **Interpolation** : la prédiction 276,18 €k (Size=2,5) tombe entre les données d'entraînement (1,1–3,4), zone de fiabilité maximale d'un modèle linéaire.
- **Droite calculée** : `Prix ≈ 1,05 × Size + 0,14` (→ 2,76 à Size=2,5, correspond exactement à la sortie réelle).
- **Extrapolation** : table 3 lignes documentant l'écart sur les grands points de test (Size 4,0 : réel 6,1 vs ~4,3 prédit ; Size 8,0 : réel 10,3 vs ~8,5 prédit) — effet « premium » des grandes surfaces.
- **Boucle avec R²=0,85** : la droite sous-estime systématiquement les grandes maisons, ce qui plafonne le R² en dessous de 1.

## Why (parité justifiée, EPIC #4956)

Contribution à l'EPIC **#4956** « Parité .NET ⇄ Python des séries de notebooks ». Le twin C# se déclare jumeau .NET du Python (même dataset `HouseData`, mêmes 4 points d'entraînement Size∈{1,1, 1,9, 2,8, 3,4}, même trainer SDCA). L'asymétrie ici n'était pas algorithmique (le code de prédiction était déjà porté) mais **pédagogique** : le jumeau Python encadre sa prédiction d'une cellule d'interprétation interpolation/extrapolation, le C# sautait directement de la sortie `276,18 €k` à « Félicitations ». Motif L751-L2 (parité twin .NET⇄Python = angle d'extension reproductible).

## Scope (anti-régression D, catalog-pr-hygiene)

- **1 fichier** : `ML-1-Introduction.ipynb` (+1 cellule markdown, +7/-1).
- **Markdown-only** → exception C.2 (« modifs uniquement markdown → outputs précédents valides ») : **0 re-exécution requise**. Les 16 cellules de code existantes gardent leur `execution_count` et leurs outputs byte-identiques (sortie `276,18 €k` intacte).
- **Catalogue byte-identique** (catalog-pr-hygiene R1 ✓).
- 0 secret, 0 path absolu `c:/dev` résiduel.

## Verification (firsthand, G.1)

- **G.1 source-level** : twin Python `ML-1-Introduction-Python.ipynb` cell `c18` (`### Interprétation : la prédiction et la droite` : interpolation + Size≥4 dévient) = présent ; C# = absent avant cette PR (vérifié : le C# allait directement cell `bffc3036` prédiction → cell `79a119d9` « Félicitations »).
- **Droite de régression calculée firsthand** : OLS sur les 4 points d'entraînement (1,1;1,2),(1,9;2,3),(2,8;3,0),(3,4;3,7) → pente ≈ 1,049, intercept ≈ 0,137 → à Size=2,5 : 2,760 = correspond **exactement** à la sortie réelle `276,18 €k`. À Size=4,0 : ~4,33 (réel 6,1) ; à Size=8,0 : ~8,53 (réel 10,3). Les valeurs du tableau sont des estimations honnêtes de la droite OLS.
- **C.2 préservée** : 16 cellules code, **0 `execution_count: null`**, tous les outputs d'origine intacts (diff inspecté : pure addition de 1 cellule md, 0 cellule code altérée — `git diff | grep -cE '^\+\s*"source"'` = 1).
- **C.1** : 0 `raise NotImplementedError` / `assert False` / `1/0` (inchangé, aucune cellule code touchée).

## G-VAR-3 justification (same-genre MED/notebook-dotnet)

c.760 (#7837 GT-12 Cheap Talk) et c.761 (cette PR ML-1) sont tous deux `MED/notebook-dotnet`. G-VAR-3 autorise 2× le même genre DEEP/MED consécutif **si la substance est genuinement distincte dans le domaine-cœur de la lane**. C'est le cas :
- **Familles distinctes** : GameTheory (théorie des jeux / cheap talk signaling) ≠ ML.Net (régression linéaire / interpolation-extrapolation).
- **Substance distincte** : c.760 portait un cadrage théorique (modèle Crawford-Sobel, 3 régimes biais) ; c.761 porte une analyse quantitative (droite OLS calculée, table d'écart extrapolation, boucle avec R²). Le litmus LIGHT « générable en série par scan de l'instance d'à-côté ? » → NON : chacun demande du raisonnement de domaine neuf (calcul OLS ici, modèle économique là). ML.Net est partition po-2024 (cf MEMORY).
