### PR TITLE
fix(tweety,#3801): Tweety-9 cell 18 hardcoded manipulation note refuted by its own Borda scores

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-9-Preferences.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-9-Preferences.ipynb
@@ -1228,22 +1228,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "--- Resultats de l'exercice de synthese ---\n",
-      "Vainqueur Borda: Berlin (scores: {'Berlin': 9, 'Rome': 8, 'Paris': 7, 'Madrid': 6})\n",
-      "Vainqueur Pluralite: Berlin (2 votes)\n",
-      "Vainqueur Condorcet: Berlin\n",
-      "\n",
-      "Consensus (Borda == Pluralite == Condorcet): True\n",
-      "\n",
-      "--- Manipulation Strategique (Votant 3) ---\n",
-      "Votant 3 change son vote de ['Rome', 'Madrid', 'Paris', 'Berlin'] a ['Paris', 'Rome', 'Madrid', 'Berlin']\n",
-      "Nouveau vainqueur Borda: Paris (score augmente)\n",
-      "Nouveau vainqueur Pluralite: Paris (tie avec Berlin)\n",
-      "Note: Dans ce profil, la manipulation renforce le gagnant initial Borda.\n"
-     ]
+     "name": "stdout",
+     "text": "--- Resultats de l'exercice de synthese ---\nVainqueur Borda: Berlin (scores: {'Berlin': 9, 'Rome': 8, 'Paris': 7, 'Madrid': 6})\nVainqueur Pluralite: Berlin (2 votes)\nVainqueur Condorcet: Berlin\n\nConsensus (Borda == Pluralite == Condorcet): True\n\n--- Manipulation Strategique (Votant 3) ---\nVotant 3 change son vote de ['Rome', 'Madrid', 'Paris', 'Berlin'] a ['Paris', 'Rome', 'Madrid', 'Berlin']\nNouveau vainqueur Borda: Paris (scores: {'Paris': 9, 'Berlin': 9, 'Rome': 7, 'Madrid': 5})\nNouveau vainqueur Pluralite: Paris (egalite a 2 votes avec ['Berlin', 'Paris'])\nNote: la manipulation DEPLACE le gagnant Borda initial (Berlin). Elle cree une egalite a 9 points entre ['Berlin', 'Paris'], que la regle max() tranche en faveur de Paris (ordre d'insertion dans le dict) -- le depouillage d'une egalite etant arbitraire, il est lui aussi manipulable.\n"
     }
    ],
    "source": [
@@ -1303,9 +1290,32 @@
     "print(f\"Votant 3 change son vote de {profils[2]} a ['Paris', 'Rome', 'Madrid', 'Berlin']\")\n",
     "profils_manip[2] = ['Paris', 'Rome', 'Madrid', 'Berlin']\n",
     "b2, p2, c2 = calculate_all_rules(profils_manip, candidats)\n",
-    "print(f\"Nouveau vainqueur Borda: {max(b2, key=b2.get)} (score augmente)\")\n",
-    "print(f\"Nouveau vainqueur Pluralite: {max(p2, key=p2.get)} (tie avec Berlin)\")\n",
-    "print(\"Note: Dans ce profil, la manipulation renforce le gagnant initial Borda.\")"
+    "\n",
+    "# Analyse derivee des donnees (pas de conclusion en dur) : on detecte les egalites\n",
+    "# et on compare le nouveau gagnant Borda au gagnant initial pour conclure honnetement.\n",
+    "b2_win = max(b2, key=b2.get)\n",
+    "p2_win = max(p2, key=p2.get)\n",
+    "max_b2 = b2[b2_win]\n",
+    "b2_ties = [c for c in candidats if b2[c] == max_b2]\n",
+    "max_p2 = p2[p2_win]\n",
+    "p2_ties = [c for c in candidats if p2[c] == max_p2]\n",
+    "\n",
+    "print(f\"Nouveau vainqueur Borda: {b2_win} (scores: {dict(sorted(b2.items(), key=lambda x: -x[1]))})\")\n",
+    "if len(p2_ties) > 1:\n",
+    "    print(f\"Nouveau vainqueur Pluralite: {p2_win} (egalite a {max_p2} votes avec {sorted(p2_ties)})\")\n",
+    "else:\n",
+    "    print(f\"Nouveau vainqueur Pluralite: {p2_win} ({max_p2} votes)\")\n",
+    "\n",
+    "# Conclusion honnete : le gagnant Borda initial est-il preserve ou deplace ?\n",
+    "if b2_win == b_win:\n",
+    "    print(f\"Note: la manipulation preserve le gagnant Borda initial ({b_win}).\")\n",
+    "elif len(b2_ties) > 1:\n",
+    "    print(f\"Note: la manipulation DEPLACE le gagnant Borda initial ({b_win}). \"\n",
+    "          f\"Elle cree une egalite a {max_b2} points entre {sorted(b2_ties)}, que la \"\n",
+    "          f\"regle max() tranche en faveur de {b2_win} (ordre d'insertion dans le dict) \"\n",
+    "          f\"-- le depouillage d'une egalite etant arbitraire, il est lui aussi manipulable.\")\n",
+    "else:\n",
+    "    print(f\"Note: la manipulation deplace le gagnant Borda initial ({b_win}) au profit de {b2_win}.\")"
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/fix — lane myia-po-2025:CoursIA — prev: MED/doc-honesty (Tweety-4 #7847)

## Bug (confirmed firsthand, G.1)

`Tweety-9-Preferences.ipynb` cell 18 (Borda/Plurality/Condorcet voting example) ended with a **hardcoded FALSE conclusion**:

```python
print("Note: Dans ce profil, la manipulation renforce le gagnant initial Borda.")
```

This is refuted by the cell's own printed scores. The initial Borda winner is **Berlin (9 pts)**. After Votant 3's strategic manipulation (changes vote to `['Paris','Rome','Madrid','Berlin']`):

| Candidate | Initial Borda | Post-manip Borda |
|---|---|---|
| Paris | 7 | **9** (V3 now ranks Paris 1st) |
| Berlin | **9** (winner) | **9** (unchanged) |
| Rome | 8 | 7 |
| Madrid | 6 | 5 |

- Paris rises 7→9, Berlin **unchanged** at 9 → **Paris = Berlin = 9 (tie)**
- `max(b2, key=b2.get)` breaks the tie toward **Paris** (dict insertion order: Paris is first)
- So the new winner is **Paris**, **displacing** Berlin as unique winner

Berlin's score did **not** augment, and Berlin **lost** its winner status. The manipulation **displaced** the initial winner (via an arbitrary tiebreak), it did **not** reinforce it. A student would be taught the opposite of what happened.

## Fix

Rewrote the manipulation print section to be **data-driven** -- it computes whether the initial winner is preserved/displaced, detects ties, and prints an honest conclusion. The real re-executed output now reads:

```
Nouveau vainqueur Borda: Paris (scores: {'Paris': 9, 'Berlin': 9, 'Rome': 7, 'Madrid': 5})
Nouveau vainqueur Pluralite: Paris (egalite a 2 votes avec ['Berlin', 'Paris'])
Note: la manipulation DEPLACE le gagnant Borda initial (Berlin). Elle cree une egalite a 9 points entre ['Berlin', 'Paris'], que la regle max() tranche en faveur de Paris (ordre d'insertion dans le dict) -- le depouillage d'une egalite etant arbitraire, il est lui aussi manipulable.
```

This also surfaces a **richer pedagogical lesson**: the tiebreak (Python `max()` over a dict) is arbitrary, hence itself manipulable -- a genuine Gibbard-Satterthwaite flavor that the original hardcoded note buried.

## H.1 -- proof of real execution

Cell 18 **re-executed standalone** (pure Python, self-contained: defines its own `candidats`/`profils`/`calculate_all_rules`; no JPype/Tweety dependency). The real stdout is transplanted as the committed output (`ec=6` kept). The output is deterministic (no RNG). Re-running reproduces it exactly.

## H.3 / byte-identity

- **changed cells: exactly [18]** (source + outputs, as expected for a re-executed code cell); all 24 other cells **byte-identical** to origin/main
- cell 18: `id`/`metadata`/`ec` preserved; only `source` + `outputs` changed (intended)
- No-BOM, LF (0 CRLF), trailing newline
- C.1 = 0 (`raise NotImplementedError`/`assert False` scan clean)
- 0 leaks (full-notebook scan clean)
- Diff: +28/−18 (surgical, single notebook, single code cell)

## SOTA verdict

**SOTA-OK** -- the voting-rule implementation (`calculate_all_rules`: Borda count, plurality, Condorcet) is real, pure-Python pedagogical code. This PR corrects a hardcoded false conclusion to match the code's own computation; no workaround, no fabricated numbers. The #3801 Prong-B angle (manipulation revealing a limit of voting rules) is genuinely exercised.

## D. anti-regression

Not applicable (no Lean/Coq proof, no production function, no stub). The fix adds an honest data-driven conclusion and removes a hardcoded lie. Exercise cells (19-20) untouched.

## Method

Defect found via Explore scan (sonnet, read-only), **firsthand-verified** before action (G.1: confirmed initial Berlin=9, computed pre/post Borda scores by hand -- Paris 7→9, Berlin 9→9 tie, max()→Paris). Stop & Repair: fixed the source + re-executed (did NOT hand-edit the committed output).

See #3801.
