### PR TITLE
fix(genai-texte): 10_LocalLlama reconcile doc-honesty markdown cells 12/15/27

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb
@@ -1226,8 +1226,8 @@
     "\n",
     "| Endpoint | Modèles | Temps | Observation |\n",
     "|----------|---------|-------|-------------|\n",
-    "| **cloud-gpt5.2** (gpt-5.2 via OpenRouter) | 340 modèles | ~1.3s | Catalogue OpenRouter complet, modèle configure `gpt-5.2` trouve |\n",
-    "| **openweight-llama4** (llama-4-maverick via OpenRouter) | 340 modèles | ~1.3s | Même catalogue, modèle configure `meta-llama/llama-4-maverick` trouve |\n",
+    "| **cloud-gpt5.2** (gpt-5.2 via OpenRouter) | 340 modèles | ~0.3s | Catalogue OpenRouter complet, modèle configure `gpt-5.2` trouve |\n",
+    "| **openweight-llama4** (llama-4-maverick via OpenRouter) | 340 modèles | ~0.3s | Même catalogue, modèle configure `meta-llama/llama-4-maverick` trouve |\n",
     "\n",
     "> Sur un **deploiement local complet** (vLLM/Ollama distincts par modèle), la\n",
     "> ligne `local-mini` (ZwZ-8B, 1 modèle, ~20ms) et `local-medium` (Qwen3.5 MoE\n",
@@ -1237,7 +1237,7 @@
     "**Points pedagogiques** :\n",
     "\n",
     "1. **OpenRouter vs vLLM** : OpenRouter expose tout son catalogue (340 modèles), tandis que vLLM ne sert que le modèle charge. Le code tronque l'affichage a 5 modèles et verifie que le modèle configure est present.\n",
-    "2. **Latence locale** : Les serveurs locaux repondent en ~20ms (reseau local), contre ~400ms pour OpenRouter (latence Internet + catalogue).\n",
+    "2. **Latence catalogue** : L'endpoint `/models` d'OpenRouter repond en ~0.3s (aller-retour Internet + lecture du catalogue de 340 modèles) ; un serveur vLLM local repondrait en ~20ms (reseau local, 1 seul modèle).\n",
     "3. **Nom du modèle** : Le `served-model-name` vLLM (`zwz-8b`, `qwen3.5-35b-a3b`) doit correspondre exactement a `OPENAI_CHAT_MODEL_ID` dans `.env`."
    ]
   },
@@ -1570,12 +1570,12 @@
     "| Endpoint | Statut | Latence | Reponse |\n",
     "|----------|--------|---------|---------|\n",
     "| **cloud-gpt5.2** (gpt-5.2) | 200 OK | ~2.2s | \"Je suis un assistant conversationnel d'OpenAI (un modèle de langage)...\" |\n",
-    "| **openweight-llama4** (llama-4-maverick) | 200 OK | ~2.4s | \"Je suis un modèle de langage base sur l'intelligence artificielle...\" |\n",
+    "| **openweight-llama4** (llama-4-maverick) | 200 OK | ~1.4s | \"Je suis un modèle de langage base sur l'intelligence artificielle...\" |\n",
     "\n",
     "**Points pedagogiques** :\n",
     "\n",
-    "1. **Modèle proprietaire (cloud)** : gpt-5.2 via OpenRouter repond correctement en francais avec une latence de ~2.2s (aller-retour Internet + inference).\n",
-    "2. **Modèle open-weight** : llama-4-maverick (Meta) repond via le même format API OpenAI, confirmant l'**interoperabilite** -- tout serveur compatible OpenAI (vLLM, Ollama, TGI, OpenRouter) consomme le même payload.\n",
+    "1. **Modèle proprietaire (cloud)** : gpt-5.2 via OpenRouter repond correctement en francais avec une latence de ~2.2s (aller-retour Internet + inference). L'appel renvoie 100 tokens (`completion_tokens`).\n",
+    "2. **Modèle open-weight** : llama-4-maverick (Meta) repond via le même format API OpenAI en ~1.4s (75 tokens), confirmant l'**interoperabilite** -- tout serveur compatible OpenAI (vLLM, Ollama, TGI, OpenRouter) consomme le même payload.\n",
     "3. **Format commun** : Les 2 endpoints utilisent le même format OpenAI (`messages`, `model`, `max_completion_tokens`). C'est ce standard qui permet de basculer entre cloud et local sans changer le code applicatif -- coeur de la promesse d'auto-hebergement."
    ]
   },
@@ -3047,20 +3047,19 @@
     "\n",
     "Ce test utilise la **bibliotheque officielle `openai`** plutot que `requests` :\n",
     "\n",
-    "**Résultats observes** :\n",
+    "**Résultats observes** (2 endpoints configures, prompt \"philosophie stoicienne\") :\n",
     "\n",
     "| Endpoint | Latence | Tokens | Vitesse | Reponse |\n",
     "|----------|---------|--------|---------|---------|\n",
-    "| **OpenAI** (Gemma 27B) | 4.53s | 17 | ~3.8 tok/s | Philosophie stoicienne, bonne qualite |\n",
-    "| **local-mini** (ZwZ-8B) | 1.41s | 170 | ~120 tok/s | Reponse riche, bien structuree |\n",
-    "| **local-medium** (Qwen3.5) | 8.17s | 525 | ~64 tok/s | Inclut \"Thinking Process\" (raisonnement visible) |\n",
+    "| **cloud-gpt5.2** (gpt-5.2) | 3.33s | 164 | ~49 tok/s | Philosophie stoicienne, bonne qualite |\n",
+    "| **openweight-llama4** (llama-4-maverick) | 2.16s | 174 | ~80 tok/s | Reponse riche, bien structuree |\n",
     "\n",
     "**Points pedagogiques** :\n",
     "\n",
-    "1. **Tokens reportes** : OpenRouter ne reporte que `prompt_tokens` (17) et `completion_tokens: 0` pour les modèles gratuits. Les modèles locaux donnent des comptages complets.\n",
-    "2. **Thinking overhead** : Qwen3.5 utilise 525 tokens dont ~300 de raisonnement interne. C'est normal pour un modèle MoE avec thinking.\n",
-    "3. **Vitesse locale** : ZwZ-8B (120 tok/s mono-requête) est beaucoup plus rapide que le modèle cloud, malgre la gratuite de ce dernier.\n",
-    "4. **Compatibilite** : La bibliotheque `openai` fonctionne identiquement sur les 3 endpoints -- c'est l'intérêt du standard OpenAI API.\n"
+    "1. **Tokens reportes** : Les 2 endpoints reportent `total_tokens` (164 et 174, incluant prompt + completion) via `response.usage.total_tokens`. Sur certains modèles gratuits d'OpenRouter, l'usage peut être incomplet (`completion_tokens: 0`) -- le code gère ce cas en relevant `total_tokens` quand il est disponible.\n",
+    "2. **Latence cloud vs open-weight** : gpt-5.2 (3.33s) est plus lent que llama-4-maverick (2.16s) sur ce prompt, le routing OpenRouter ajoutant un saut réseau vers le modèle cloud.\n",
+    "3. **Vitesse** : llama-4-maverick (~80 tok/s) est plus rapide que gpt-5.2 (~49 tok/s) sur ce prompt mono-requête.\n",
+    "4. **Compatibilite** : La bibliotheque `openai` fonctionne identiquement sur les 2 endpoints -- c'est l'intérêt du standard OpenAI API."
    ]
   },
   {


### PR DESCRIPTION
## Defect (doc-honesty)

The markdown interpretation cells of `10_LocalLlama.ipynb` cited latencies, token counts and model names **absent from the committed code outputs** (pattern Sudoku-15 / SW-13, lane po-2023). The notebook was evidently written for a full-local vLLM deployment (Gemma/ZwZ/Qwen) then reconfigured to two OpenRouter cloud endpoints, but the interpretation markdown was not reconciled.

Firsthand reconciliation against committed outputs:

| Cell | Markdown claimed | Committed output (real) |
|------|-----------------|------------------------|
| **cell12** (/models analyse) | cloud-gpt5.2 / openweight-llama4 ~**1.3s** each | cell11: `/models` responds in **0.33s** (~0.3s) |
| **cell15** (/chat brut) | openweight-llama4 ~**2.4s** | cell14: HTTP 200 in **1.37s** (cloud-gpt5.2 ~2.2s was correct) |
| **cell27** (openai library) | 3-row table: Gemma 27B **4.53s/17tok**, ZwZ-8B **1.41s/170tok**, Qwen3.5 **8.17s/525tok** | cell26: 2 OpenRouter endpoints — gpt-5.2 **164tok/3.33s**, llama-4-maverick **174tok/2.16s** |

The cell27 numbers (4.53 / 1.41 / 8.17s, 17 / 170 / 525 tok) appear in **no** committed output. The §1 note ("OpenRouter reports only prompt_tokens=17, completion=0") was also stale — the committed run reports `total_tokens` (164 / 174).

## Fix (markdown-only)

Rewrote the 3 interpretation cells to match committed outputs, preserving the pedagogical structure and correct qualitative conclusions (OpenRouter-vs-vLLM catalogue, OpenAI-format interoperability, cloud-vs-openweight latency):
- **cell12**: ~1.3s -> ~0.3s (table + §2 latency point aligned to the real 0.33s catalogue read).
- **cell15**: openweight-llama4 ~2.4s -> ~1.4s (real 1.37s); added the real `completion_tokens` (100 / 75) to the two points.
- **cell27**: table rewritten to the 2 real endpoints (gpt-5.2 164tok/3.33s ~49 tok/s, llama-4-maverick 174tok/2.16s ~80 tok/s); §1-§4 rewritten (the OpenRouter incomplete-usage caveat is kept as a generic note rather than citing the absent "17" run).

## Verification

- **Markdown-only** (C.3 exception): no code cell source changed, so prior outputs remain valid; no re-execution required.
- **Byte-identity**: 57/60 cells unchanged, verified per-cell sha1 (`only cells [12,15,27] changed`).
- **Diff scope**: `1 file changed, 13 insertions(+), 14 deletions(-)` — all changed lines are markdown `source` strings.
- **Line endings**: LF preserved (0 CRLF in diff).
- **JSON**: valid, 60 cells, types markdown confirmed.

```
Grain: MED/doc-honesty
EPIC: #3801 (axe-2, lane po-2023)
```

See #3801
