### PR TITLE
docs(rl): rl_12 interpret learned return distribution (C51 pedagogical gap)

### DIFF
--- a/MyIA.AI.Notebooks/RL/rl_12_distributional_rl.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_12_distributional_rl.ipynb
@@ -760,6 +760,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ffe2297b",
+   "source": "### Lecture : que nous apprend la distribution apprise ?\n\nLa politique greedy choisit **l'action 1 (droite)** : c'est simplement l'action dont l'espérance $\\mathbb{E}[Z]$ est la plus élevée — la ligne rouge pointillée sur chaque sous-figure. Un DQN scalaire aurait pris la **même** décision ; jusqu'ici, rien de neuf.\n\nLa différence est dans les **barres**. Pour chaque action, C51 expose la *forme complète* du retour : sa concentration, sa dispersion, son asymétrie, ses éventuels modes. L'espérance (la ligne rouge) résume cette distribution en un seul nombre et **jette tout le reste**. Or deux distributions de même moyenne peuvent avoir des risques radicalement différents : l'une concentrée autour de sa moyenne (retour prévisible), l'autre bimodale ou étalée (jackpot ou effondrement). Un DQN les verrait comme **identiques** ; C51 les distingue.\n\nC'est précisément cette information que l'**Exercice 3** exploite : au lieu de maximiser l'espérance, on peut maximiser la **CVaR** (la moyenne conditionnelle des pires scénarios) et obtenir une politique *averse au risque* — strictement impossible avec un scalaire $Q$. La section suivante explique pourquoi, empiriquement, ce signal d'apprentissage plus riche stabilise aussi l'entraînement.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "366c955a",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
Grain: MED/enrichment-notebook — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-dotnet (c.763 #7846)

## Summary

Enrichissement pédagogique : le notebook `rl_12_distributional_rl.ipynb` (C51 / Categorical DQN from-scratch) produisait son **centre pédagogique** — la **distribution de retour apprise $Z(s,a)$** par action, l'intérêt même du RL distributionnel — dans la cellule code `c1e7aa39` (sortie réelle : politique greedy = action 1 / droite + deux distributions en barres avec $\mathbb{E}[Z]$ marqué en rouge), puis enchaînait directement sur la §6 (comparaison C51 vs DQN) **SANS aucune cellule markdown interprétant ce que le plot révèle**.

Cette PR ajoute **1 cellule markdown** (md-only) après la cellule code de distribution, portant le pattern pédagogique « ### Lecture » utilisé dans toute la série RL. Le contenu est **groundé dans la sortie réelle** de la cellule (politique greedy = action 1 droite ; ligne rouge pointillée = $\mathbb{E}[Z] = Q$) :

1. **La décision greedy** (argmax $\mathbb{E}[Z]$) est exactement ce qu'un DQN scalaire ferait — aucune différence au niveau de la décision.
2. **La valeur est dans les barres** : C51 expose la *forme complète* (concentration, dispersion, asymétrie, modes) ; l'espérance (ligne rouge) résume à un nombre et **jette l'info de risque**.
3. Deux distributions de **même moyenne** mais de formes différentes (concentrée vs bimodale) sont **identiques** pour un DQN mais **distinctes** pour C51.
4. C'est exactement ce qu'exploite l'**Exercice 3** (politique CVaR averse au risque) — **impossible** avec un scalaire $Q$.
5. Pont vers la §6 (pourquoi ce signal plus riche stabilise aussi l'apprentissage).

## Why (enrichissement justifié, EPIC #1454)

Le RL distributionnel est partition-cœur po-2024 (EPIC #1454 « po-2024 pionnier RL/PPO »). L'asymétrie n'était pas algorithmique (le code C51 est complet et exécuté) mais **pédagogique** : le notebook démontre le THÈME central de C51 (la distribution, pas l'espérance) puis le laisse non commenté avant de passer à la comparaison théorique. Le pattern « Lecture » est établi dans la série (rl_8 c8 « Lecture de la courbe », rl_9 c7/c19, rl_13 c8/c13). Motif L751-L2 (angle d'extension reproductible sur partition saturée).

## Scope (anti-régression D, catalog-pr-hygiene)

- **1 fichier** : `rl_12_distributional_rl.ipynb` (+1 cellule markdown, **+6/-0 pure additif**).
- **Markdown-only** → exception C.2 (« modifs uniquement markdown → outputs précédents valides ») : **0 re-exécution requise**. Les 12 cellules code existantes gardent leur `execution_count` et outputs byte-identiques (cellule distribution `c1e7aa39` : ec=9, 2 outputs intacts = PNG plot + stream « Action choisie … : 1 (action 1 (droite)) »).
- **Catalogue byte-identique** (catalog-pr-hygiene R1 ✓).
- 0 secret, 0 path absolu `c:/dev` résiduel.

## Verification (firsthand, G.1)

- **G.1 source-level** : la cellule `c1e7aa39` (code, ec=9) produit le plot distribution + `print` greedy action ; la cellule suivante `366c955a` est `## 6. C51 vs DQN` (table comparaison + Rainbow) — **vérifié firsthand** : `366c955a` n'est PAS vide (un scan de structure premier-ligne laissait croire à une section vide ; lecture complète confirme le contenu riche). La lacune est précise : pas d'interprétation du plot entre les deux.
- **Sortie réelle extraite firsthand** (`jq '.cells[].outputs'`) : `STREAM: 'Action choisie par la politique greedy (argmax E[Z]) : 1 (action 1 (droite))\n'` + `display_data [image/png, text/plain]`. Aucun nombre fabriqué dans la cellule ajoutée — tout est groundé dans cette sortie + les annotations du plot (`label=f"E[Z] = Q = {q[i].item():.1f}"`).
- **C.2 préservée** : 12 cellules code, **0 `execution_count: null`**, tous outputs d'origine intacts. Diff inspecté : pure addition d'1 cellule md, 0 cellule code altérée.
- **C.1** : 0 `raise NotImplementedError` / `assert False` / `1/0` (inchangé, aucune cellule code touchée).
- **Diff chirurgical** : +6/-0 (NotebookEdit avait normalisé `papermill.duration 0.0 → 0` sur 2 cellules sans rapport + strippé le newline EOF → **restaurés byte-identity** par remplacement ciblé, diff final = pure insertion de la cellule markdown).

## G-VAR-3 justification (changement de genre)

c.763 (#7846 ML-1 parity) était `MED/notebook-dotnet`. c.764 (cette PR rl_12) est `MED/enrichment-notebook` = **genre distinct**, G-VAR-3 satisfait sans exception. Aucun collision cross-lane : la session // po-2024 travaille sur `notebook-tools` (tranche-7 Search MANIFEST), ≠ RL enrichment.

## Residual (hors-scope, tracked)

La nouvelle cellule markdown ajoute 1 `cell_id` (`ffe2297b`) non présent dans le CSV de traduction de la famille RL (EPIC #4957 T2). Comme pour toute cellule nouvelle, c'est un « new cell » que `extract_cells_to_csv.py --update` prendra en charge lors d'une resync translation séparée (pattern établi). Pas dans le scope de cette PR atomique.
