### PR TITLE
fix(tweety,#3801): SAT benchmark — data-driven conclusion + align markdown to real output

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-2-Basic-Logics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-2-Basic-Logics.ipynb
@@ -1281,7 +1281,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "id": "bf242c03",
    "metadata": {
     "execution": {
@@ -1301,8 +1301,8 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "--- 2.1.3a Solveurs SAT Modernes (pySAT / CaDiCaL) ---\n",
       "pySAT installe - acces aux solveurs modernes!\n",
@@ -1311,56 +1311,31 @@
       "[Warmup termine]\n",
       "\n",
       "--- Test 1: Pigeonhole 9->8 (UNSAT crafted) ---\n",
-      "  72 vars, 297 clauses\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    cadical195  : UNSAT   253.32ms\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    glucose42   : UNSAT  2610.59ms"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "    minisat22   : UNSAT   504.09ms\n",
+      "  72 vars, 297 clauses\n",
+      "    cadical195  : UNSAT   545.38ms\n",
+      "    glucose42   : UNSAT  3490.91ms\n",
+      "    minisat22   : UNSAT   817.55ms\n",
       "\n",
       "--- Test 2: Latin Square 13x13 (SAT combinatoire) ---\n",
       "  2197 vars, 39715 clauses\n",
-      "    cadical195  : SAT       3.31ms\n",
-      "    glucose42   : SAT       3.03ms\n",
-      "    minisat22   : SAT       1.44ms\n",
+      "    cadical195  : SAT       3.25ms\n",
+      "    glucose42   : SAT       2.21ms\n",
+      "    minisat22   : SAT       3.54ms\n",
       "\n",
       "--- Test 3: 35-Queens (SAT geometrique) ---\n",
-      "  1225 vars, 69055 clauses\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    cadical195  : SAT      37.33ms\n",
-      "    glucose42   : SAT       4.44ms\n",
-      "    minisat22   : SAT       1.84ms\n",
+      "  1225 vars, 69055 clauses\n",
+      "    cadical195  : SAT      98.92ms\n",
+      "    glucose42   : SAT       5.91ms\n",
+      "    minisat22   : SAT       3.16ms\n",
       "\n",
       "==================================================\n",
-      "Victoires: CaDiCaL=1, Glucose=0, MiniSat=2\n",
+      "Victoires: CaDiCaL=1, Glucose=1, MiniSat=1\n",
       "\n",
-      "Conclusion:\n",
-      "- CaDiCaL: Fort sur UNSAT difficiles (Pigeonhole)\n",
-      "- Glucose: Optimal sur Latin Square 13x13\n",
-      "- MiniSat: Rapide sur problemes geometriques (Queens)\n",
-      "=> Chaque solveur a des forces specifiques!\n"
+      "Conclusion (narrateur data-driven, issu des victoires calculees):\n",
+      "- Pigeonhole (UNSAT): CaDiCaL le plus rapide (545.38ms)\n",
+      "- Latin Square 13x13: Glucose le plus rapide (2.21ms)\n",
+      "- 35-Queens: MiniSat le plus rapide (3.16ms)\n",
+      "=> Victoires: CaDiCaL=1, Glucose=1, MiniSat=1\n"
      ]
     }
    ],
@@ -1488,11 +1463,15 @@
     "            wins[best] += 1\n",
     "    print(f\"Victoires: CaDiCaL={wins['cadical195']}, Glucose={wins['glucose42']}, MiniSat={wins['minisat22']}\")\n",
     "    \n",
-    "    print(\"\\nConclusion:\")\n",
-    "    print(\"- CaDiCaL: Fort sur UNSAT difficiles (Pigeonhole)\")\n",
-    "    print(\"- Glucose: Optimal sur Latin Square 13x13\")\n",
-    "    print(\"- MiniSat: Rapide sur problemes geometriques (Queens)\")\n",
-    "    print(\"=> Chaque solveur a des forces specifiques!\")\n",
+    "    print(\"\\nConclusion (narrateur data-driven, issu des victoires calculees):\")\n",
+    "    _label = {'cadical195': 'CaDiCaL', 'glucose42': 'Glucose', 'minisat22': 'MiniSat'}\n",
+    "    _test_label = {'T1': 'Pigeonhole (UNSAT)', 'T2': 'Latin Square 13x13', 'T3': '35-Queens'}\n",
+    "    for _tk in ['T1', 'T2', 'T3']:\n",
+    "        _res = all_results.get(_tk)\n",
+    "        if _res:\n",
+    "            _best = min(_res, key=lambda s: _res[s][1])\n",
+    "            print(f\"- {_test_label[_tk]}: {_label[_best]} le plus rapide ({_res[_best][1]:.2f}ms)\")\n",
+    "    print(f\"=> Victoires: CaDiCaL={wins['cadical195']}, Glucose={wins['glucose42']}, MiniSat={wins['minisat22']}\")\n",
     "else:\n",
     "    print(\"Pour utiliser les solveurs modernes: pip install python-sat\")"
    ]
@@ -1513,38 +1492,48 @@
    "source": [
     "## Interpretation des benchmarks pySAT\n",
     "\n",
-    "**Résultats obtenus** :\n",
+    "**Résultats obtenus** (sortie de la cellule précédente) :\n",
     "\n",
     "| Test | Vainqueur | Temps | Remarque |\n",
     "|------|-----------|-------|----------|\n",
-    "| **Pigeonhole 9→8** (UNSAT) | CaDiCaL | 234ms | Problème crafted difficile |\n",
-    "| **Latin Square 13x13** (SAT) | Glucose | 1ms | Optimisation apprentissage lemmes |\n",
-    "| **35-Queens** (SAT) | MiniSat | 1.59ms | Geometrie bien exploitee |\n",
+    "| **Pigeonhole 9→8** (UNSAT) | CaDiCaL | 545.38ms | UNSAT crafted difficile |\n",
+    "| **Latin Square 13x13** (SAT) | Glucose | 2.21ms | Apprentissage de lemmes |\n",
+    "| **35-Queens** (SAT) | MiniSat | 3.16ms | Géométrie bien exploitée |\n",
+    "\n",
+    "Détail des temps mesurés (chaque solveur sur les trois instances) :\n",
+    "\n",
+    "| Instance | CaDiCaL | Glucose | MiniSat | Vainqueur |\n",
+    "|----------|---------|---------|---------|-----------|\n",
+    "| Pigeonhole 9→8 (UNSAT, 72 var / 297 cl) | 545.38ms | 3490.91ms | 817.55ms | **CaDiCaL** |\n",
+    "| Latin Square 13x13 (SAT, 2197 var / 39715 cl) | 3.25ms | 2.21ms | 3.54ms | **Glucose** |\n",
+    "| 35-Queens (SAT, 1225 var / 69055 cl) | 98.92ms | 5.91ms | 3.16ms | **MiniSat** |\n",
+    "\n",
+    "**Victoires : CaDiCaL = 1, Glucose = 1, MiniSat = 1** (comptage automatique dans le code).\n",
     "\n",
     "**Analyse** :\n",
     "\n",
     "1. **Pigeonhole (UNSAT crafted)** :\n",
-    "   - CaDiCaL domine sur les UNSAT difficiles (7x plus rapide que Glucose)\n",
-    "   - Glucose peine sur ce type de problème (1635ms)\n",
-    "   - MiniSat performance intermediaire\n",
+    "   - CaDiCaL domine nettement (~545ms contre ~3491ms pour Glucose, soit ~6.4× plus rapide)\n",
+    "   - Glucose peine sur cet UNSAT difficile (plus de 3s)\n",
+    "   - MiniSat se place en intermédiaire (~818ms)\n",
     "\n",
     "2. **Latin Square (SAT combinatoire)** :\n",
-    "   - Tous les solveurs très rapides (~1ms)\n",
-    "   - Glucose legerement en tete grace a son apprentissage de lemmes agressif\n",
-    "   - Structure reguliere favorable\n",
+    "   - Les trois solveurs sont très proches (~2–3.5ms) : instance petite, marge étroite\n",
+    "   - Glucose légèrement en tête grâce à son apprentissage de lemmes agressif\n",
+    "   - Structure régulière favorable aux heuristiques modernes\n",
     "\n",
-    "3. **N-Queens (SAT geometrique)** :\n",
-    "   - MiniSat excelle (1.59ms vs 27ms pour CaDiCaL)\n",
-    "   - Les contraintes geometriques jouent en faveur de l'heuristique MiniSat\n",
-    "   - Glucose aussi très performant (2.70ms)\n",
+    "3. **N-Queens (SAT géométrique)** :\n",
+    "   - MiniSat excelle (3.16ms) ; CaDiCaL nettement en retrait (~99ms)\n",
+    "   - Les contraintes géométriques jouent en faveur de l'heuristique MiniSat\n",
+    "   - Glucose également performant (5.91ms)\n",
     "\n",
     "**Conclusion** :\n",
     "- **Aucun solveur universel** : chaque problème a son champion\n",
     "- **CaDiCaL** : Robuste sur UNSAT difficiles et formules industrielles\n",
-    "- **Glucose** : Excellent sur problemes combinatoires avec structure\n",
-    "- **MiniSat** : Rapide sur geometrie et contraintes spatiales\n",
+    "- **Glucose** : Excellent sur problèmes combinatoires avec structure\n",
+    "- **MiniSat** : Rapide sur géométrie et contraintes spatiales\n",
     "\n",
-    "> **Conseil pratique** : En production, **tester plusieurs solveurs** et choisir selon le domaine."
+    "> **Honnêteté sur la mesure.** Les temps ci-dessus sont un *instantané* d'une exécution sur une machine donnée. À l'échelle de la milliseconde (Latin Square ~2–3.5ms), le classement d'un test peut basculer d'une exécution à l'autre — par exemple une exécution précédente donnait MiniSat vainqueur sur Latin Square (Glucose à 0 victoire). C'est précisément pour cela que la cellule de code **calcule le vainqueur de chaque test** (`min(..., key=...)`) et **déduit sa conclusion du comptage de victoires** plutôt que d'afficher des spécialités figées : la narration suit toujours les résultats réels, sans dérive.\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Fixes a **Prong-B #3801 doc-honesty defect** in `Tweety-2-Basic-Logics.ipynb`: the SAT-solver benchmark's interpretation contradicted its own committed empirical output, at **two layers** (code + markdown).

**Firsthand-verified against the committed output (G.1):** the benchmark (cell 22) computed its own victory tally as `Victoires: CaDiCaL=1, Glucose=0, MiniSat=2` — MiniSat had won Latin Square (1.44ms) and Queens (1.84ms), Glucose won **0** tests. Yet:
- **Cell 22 code** hardcoded a Conclusion that printed `- Glucose: Optimal sur Latin Square 13x13` regardless of the actual results — directly contradicting the `Glucose=0` tally the same cell had just computed.
- **Cell 23 markdown** carried the same false claim ("Latin Square → Glucose, 1ms") plus a table of stale timings (`CaDiCaL 234ms`, `7x`, `Glucose 1635ms`, `Queens 1.59ms vs 27ms`) that matched none of the committed numbers.

So the committed empirical results **refuted** the pedagogical narrative — a reader running the notebook would see Glucose lose and then be told Glucose won.

## The fix (two layers)

1. **Cell 22 — data-driven Conclusion.** Replaced the hardcoded solver-specialty `print` lines with a narrator **derived from the already-computed `wins` dict** (names the real winner of each test + the victory tally). The printed conclusion now **always matches** the computed results — no hardcoded claims, no future drift:
   ```python
   for _tk in ['T1', 'T2', 'T3']:
       _res = all_results.get(_tk)
       if _res:
           _best = min(_res, key=lambda s: _res[s][1])
           print(f"- {_test_label[_tk]}: {_label[_best]} le plus rapide ({_res[_best][1]:.2f}ms)")
   print(f"=> Victoires: CaDiCaL={wins['cadical195']}, Glucose={wins['glucose42']}, MiniSat={wins['minisat22']}")
   ```
2. **Re-executed the benchmark** (pySAT / CaDiCaL / Glucose / MiniSat — real run, SOTA-OK, rule F) and **aligned cell 23 markdown** to the fresh output: corrected every timing, added a per-instance detail table, and kept the (now-genuine) "each solver has a specialty" conclusion.

Fresh committed output: `Victoires: CaDiCaL=1, Glucose=1, MiniSat=1` (CaDiCaL/Pigeonhole, Glucose/Latin Square, MiniSat/Queens) — the data-driven Conclusion reports exactly that.

### Honest note on ms-scale non-determinism

The markdown adds an honest framing: at millisecond scale (Latin Square ~2–3.5ms) the per-test winner **can flip between runs/machines** — the *previous* committed run had MiniSat winning Latin Square (Glucose=0), this run has Glucose winning. This is **precisely why** the code now derives its conclusion from the computed `wins` rather than hardcoding solver specialties: the narrative follows the real results.

## Validation (H.1 firsthand)

- **Real re-execution** via pySAT (`mcp-jupyter-py310`, cadical195/glucose42/minisat22 all invoked) — rule F satisfied (real tool, not a workaround).
- **C.1 = 0 violations** (no `raise NotImplementedError` / `assert False` / `1/0` in the notebook).
- **C.2**: cell 22 re-executed (`execution_count 8→10`, fresh real outputs); cell 23 markdown-only (exception, no exec needed); cell 25 (depends on `pysat_available`, source unchanged) keeps its valid output.
- **Surgical edit confirmed vs `origin/main`**: source changed ONLY cells `[22, 23]`, outputs ONLY `[22]`, `execution_count` ONLY cell 22 — metadata + nbformat byte-identical, **0 collateral churn**. `+55/-66` (output-block consolidation reduces line count).
- **LF-only** (0 CR).

## Scope

Single notebook, single subject (one doc-honesty defect across its 2 adjacent cells). No other file touched. Catalogue byte-identical to main.

## Provenance

Defect surfaced by **po-2025 c.731** Explore scan (listed as follow-up "autres lanes OK"). **G.1 firsthand-confirmed here** — and richer than reported: po-2025 flagged the markdown; firsthand reading revealed the **code Conclusion was also hardcoded-wrong** (a deeper layer). Per my lessons ([[explore-agent-hallucinates-lean-i18n-state]]), an Explore report is RAPPORTE until confirmed against the real file — confirmed here against the actual committed output.

See #3801 (SOTA/problem-richness registry). Not `Closes` — #3801 is an open epic.

Grain: MED/doc-honesty — lane po-2026:CoursIA — prev: LIGHT/chore-security-pin (c.624 #7829). [Genre rotation chore-security-pin→doc-honesty (G-VAR-3 OK: not 2× LIGHT); family rotation .NET/Trading-Converter→Tweety/SymbolicAI (fresh family, R6 OK). Defect verified firsthand, real SOTA re-exec, surgical byte-clean diff.]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
