### PR TITLE
fix(gametheory): GT-13 CFRSolver.get_exploitability -> real exploitability via OpenSpiel

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-13-ImperfectInfo-CFR.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-13-ImperfectInfo-CFR.ipynb
@@ -624,15 +624,34 @@
     "    \n",
     "    def get_exploitability(self) -> float:\n",
     "        \"\"\"\n",
-    "        Calcule l'exploitabilite de la strategie courante.\n",
-    "        \n",
-    "        Plus la valeur est basse, plus on est proche de Nash.\n",
+    "        Calcule l'exploitabilite (valeur de meilleure reponse) de la strategie moyenne.\n",
+    "\n",
+    "        L'exploitabilite mesure de combien un meilleur-respondant optimal peut\n",
+    "        battre la strategie moyenne ; 0 = equilibre de Nash (Lisy & Lanctot, 2016).\n",
+    "        On delegue a OpenSpiel, qui calcule la vraie exploitabilite par meilleure\n",
+    "        reponse sur l'arbre extensif du jeu (cf. cellule de reference OpenSpiel).\n",
+    "\n",
+    "        On ne renvoie pas une heuristique typee \"somme des regrets positifs\" :\n",
+    "        cette quantite n'est PAS l'exploitabilite (les regrets peuvent rester\n",
+    "        eleves alors meme que la strategie moyenne a converge vers Nash).\n",
     "        \"\"\"\n",
-    "        # Simplification: on retourne la variance des regrets\n",
-    "        total_positive_regret = 0.0\n",
-    "        for info_set in self.regret_sum:\n",
-    "            total_positive_regret += np.maximum(self.regret_sum[info_set], 0).sum()\n",
-    "        return total_positive_regret / max(1, self.iterations)\n",
+    "        if not OPENSPIEL_AVAILABLE:\n",
+    "            print(\"OpenSpiel indisponible : exploitabilite reelle non calculee \"\n",
+    "                  \"(voir la cellule de reference OpenSpiel). Renvoie NaN.\")\n",
+    "            return float('nan')\n",
+    "        from open_spiel.python import policy as _PolicyMod\n",
+    "        from open_spiel.python.algorithms import exploitability as _expl\n",
+    "        game_os = pyspiel.load_game(\"kuhn_poker\")\n",
+    "        tab = _PolicyMod.TabularPolicy(game_os)\n",
+    "        for os_key in tab.to_dict():\n",
+    "            # Cle OS = \"<carte_digit><histoire>\" ; notre cle = \"<lettre><histoire>\"\n",
+    "            lettre = {'0': 'J', '1': 'Q', '2': 'K'}.get(os_key[0], os_key[0])\n",
+    "            notre_cle = lettre + os_key[1:]\n",
+    "            strat = self.get_average_strategy(notre_cle)\n",
+    "            arr = tab.policy_for_key(os_key)  # vue numpy mutable\n",
+    "            arr[0] = strat[0]  # action 0 = Pass\n",
+    "            arr[1] = strat[1]  # action 1 = Bet\n",
+    "        return float(_expl.exploitability(game_os, tab))\n",
     "\n",
     "\n",
     "print(\"CFRSolver defini avec succes\")"
@@ -715,7 +734,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "  6%|▌         | 581/10000 [00:00<00:01, 5804.65it/s]"
+      "  2%|▏         | 227/10000 [00:00<00:04, 2265.07it/s]"
      ]
     },
     {
@@ -723,7 +742,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 12%|█▏        | 1162/10000 [00:00<00:01, 5757.95it/s]"
+      "  5%|▍         | 491/10000 [00:00<00:03, 2483.46it/s]"
      ]
     },
     {
@@ -731,7 +750,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 17%|█▋        | 1738/10000 [00:00<00:01, 5685.32it/s]"
+      "  7%|▋         | 740/10000 [00:00<00:03, 2423.62it/s]"
      ]
     },
     {
@@ -739,7 +758,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 23%|██▎       | 2307/10000 [00:00<00:01, 5673.31it/s]"
+      " 10%|█         | 1036/10000 [00:00<00:03, 2629.02it/s]"
      ]
     },
     {
@@ -747,7 +766,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 29%|██▉       | 2895/10000 [00:00<00:01, 5745.94it/s]"
+      " 13%|█▎        | 1300/10000 [00:00<00:03, 2561.59it/s]"
      ]
     },
     {
@@ -755,7 +774,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 35%|███▍      | 3470/10000 [00:00<00:01, 5694.03it/s]"
+      " 16%|█▌        | 1557/10000 [00:00<00:03, 2340.69it/s]"
      ]
     },
     {
@@ -763,7 +782,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 41%|████      | 4060/10000 [00:00<00:01, 5757.80it/s]"
+      " 18%|█▊        | 1803/10000 [00:00<00:03, 2375.61it/s]"
      ]
     },
     {
@@ -771,7 +790,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 46%|████▋     | 4649/10000 [00:00<00:00, 5793.03it/s]"
+      " 21%|██        | 2061/10000 [00:00<00:03, 2435.36it/s]"
      ]
     },
     {
@@ -779,7 +798,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 53%|█████▎    | 5255/10000 [00:00<00:00, 5873.60it/s]"
+      " 23%|██▎       | 2307/10000 [00:00<00:03, 2402.44it/s]"
      ]
     },
     {
@@ -787,7 +806,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 58%|█████▊    | 5843/10000 [00:01<00:00, 5832.31it/s]"
+      " 26%|██▌       | 2574/10000 [00:01<00:02, 2481.56it/s]"
      ]
     },
     {
@@ -795,7 +814,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 64%|██████▍   | 6427/10000 [00:01<00:00, 5793.38it/s]"
+      " 29%|██▉       | 2884/10000 [00:01<00:02, 2665.32it/s]"
      ]
     },
     {
@@ -803,7 +822,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 70%|███████   | 7007/10000 [00:01<00:00, 5753.60it/s]"
+      " 32%|███▏      | 3152/10000 [00:01<00:02, 2583.71it/s]"
      ]
     },
     {
@@ -811,7 +830,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 76%|███████▌  | 7586/10000 [00:01<00:00, 5762.87it/s]"
+      " 35%|███▍      | 3468/10000 [00:01<00:02, 2749.77it/s]"
      ]
     },
     {
@@ -819,7 +838,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 82%|████████▏ | 8164/10000 [00:01<00:00, 5766.66it/s]"
+      " 37%|███▋      | 3747/10000 [00:01<00:02, 2759.82it/s]"
      ]
     },
     {
@@ -827,7 +846,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 88%|████████▊ | 8755/10000 [00:01<00:00, 5808.69it/s]"
+      " 40%|████      | 4025/10000 [00:01<00:02, 2696.54it/s]"
      ]
     },
     {
@@ -835,7 +854,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 94%|█████████▎| 9357/10000 [00:01<00:00, 5869.55it/s]"
+      " 43%|████▎     | 4296/10000 [00:01<00:02, 2603.02it/s]"
      ]
     },
     {
@@ -843,7 +862,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|█████████▉| 9955/10000 [00:01<00:00, 5902.18it/s]"
+      " 46%|████▌     | 4558/10000 [00:01<00:02, 2599.87it/s]"
      ]
     },
     {
@@ -851,7 +870,166 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 10000/10000 [00:01<00:00, 5796.95it/s]"
+      " 48%|████▊     | 4819/10000 [00:01<00:02, 2564.30it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 51%|█████     | 5103/10000 [00:01<00:01, 2641.91it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 54%|█████▎    | 5368/10000 [00:02<00:01, 2642.29it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 56%|█████▋    | 5633/10000 [00:02<00:01, 2553.85it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 59%|█████▉    | 5890/10000 [00:02<00:01, 2495.98it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 62%|██████▏   | 6165/10000 [00:02<00:01, 2566.88it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 64%|██████▍   | 6423/10000 [00:02<00:01, 2560.89it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 67%|██████▋   | 6690/10000 [00:02<00:01, 2592.41it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 70%|██████▉   | 6950/10000 [00:02<00:01, 2581.29it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 72%|███████▏  | 7232/10000 [00:02<00:01, 2651.53it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 75%|███████▌  | 7533/10000 [00:02<00:00, 2756.19it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 78%|███████▊  | 7815/10000 [00:03<00:00, 2772.62it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 81%|████████  | 8111/10000 [00:03<00:00, 2826.59it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 84%|████████▍ | 8401/10000 [00:03<00:00, 2846.33it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 87%|████████▋ | 8686/10000 [00:03<00:00, 2742.53it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 90%|████████▉ | 8962/10000 [00:03<00:00, 2652.25it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 92%|█████████▏| 9247/10000 [00:03<00:00, 2707.31it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 96%|█████████▌| 9550/10000 [00:03<00:00, 2800.49it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 98%|█████████▊| 9832/10000 [00:03<00:00, 2783.17it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 10000/10000 [00:03<00:00, 2632.73it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
      ]
     },
     {
@@ -861,14 +1039,8 @@
       "\n",
       "Iterations: 10000\n",
       "Utilite finale J1: -0.0334\n",
-      "Exploitabilite: 0.044653\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
+      "Optional module pokerkit_wrapper was not importable: No module named 'pokerkit'\n",
+      "Exploitabilite: 0.001486\n"
      ]
     }
    ],
@@ -907,7 +1079,7 @@
     "|----------|--------|---------------|\n",
     "| Itérations | 10000 | Nombre de traversees completes de l'arbre |\n",
     "| Utilite finale J1 | -0.033 | Proche de la valeur théorique -1/18 = -0.056 |\n",
-    "| Exploitabilite | 0.045 | Regret moyen par itération |\n",
+    "| Exploitabilite | 0.0015 | Ecart a l equilibre de Nash (meilleure reponse) |\n",
     "\n",
     "**Interpretation** :\n",
     "- L'utilite negative pour J1 est normale : Kuhn Poker est legerement defavorable au premier joueur\n",
@@ -1195,8 +1367,8 @@
      "text": [
       "\n",
       "Resultats apres 5000 iterations:\n",
-      "  CFR:  utilite finale = 0.2450, exploitabilite = 0.058861\n",
-      "  CFR+: utilite finale = -0.0677, exploitabilite = 0.082403\n"
+      "  CFR:  utilite finale = 0.2450, exploitabilite = 0.002332\n",
+      "  CFR+: utilite finale = -0.0677, exploitabilite = 0.002881\n"
      ]
     }
    ],
@@ -1268,7 +1440,28 @@
   {
    "cell_type": "markdown",
    "id": "43c601f5",
-   "source": "### Interpretation : CFR+ sur les petits jeux\n\nLa comparaison entre CFR vanilla et CFR+ sur Kuhn Poker revele un résultat contre-intuitif :\n\n| Algorithme | Exploitabilite | Observations |\n|------------|----------------|--------------|\n| CFR vanilla | 0.059 | Convergence standard |\n| CFR+ | 0.082 | Pas d'amelioration significative |\n\n**Analyse du phenomene** :\n- Sur les petits jeux (12 information sets), CFR+ n'offre pas d'avantage notable\n- Le \"floor a zero\" des regrets est benefique sur les grands jeux avec millions d'infosets\n- Kuhn Poker est trop simple pour beneficier de l'optimisation CFR+\n\n**Pourquoi CFR+ excelle sur les grands jeux** :\n- Le \"floor a zero\" evite l'accumulation de regrets negatifs qui ralentissent la convergence\n- Sur Texas Hold'em (10^14 etats), CFR+ converge 2-10x plus vite\n- Ce résultat ne se generalise pas aux jeux miniatures comme Kuhn\n\n> **Note technique** : L'exploitabilite calculee ici est une approximation (somme des regrets positifs divisee par le nombre d'itérations). Une mesure plus precise necessiterait le calcul de la meilleure reponse pour chaque joueur, ce qui est plus couteux.",
+   "source": [
+    "### Interpretation : CFR+ sur les petits jeux\n",
+    "\n",
+    "La comparaison entre CFR vanilla et CFR+ sur Kuhn Poker revele un résultat contre-intuitif :\n",
+    "\n",
+    "| Algorithme | Exploitabilite | Observations |\n",
+    "|------------|----------------|--------------|\n",
+    "| CFR vanilla | 0.0023 | Convergence standard |\n",
+    "| CFR+ | 0.0029 | Pas d'amelioration significative |\n",
+    "\n",
+    "**Analyse du phenomene** :\n",
+    "- Sur les petits jeux (12 information sets), CFR+ n'offre pas d'avantage notable\n",
+    "- Le \"floor a zero\" des regrets est benefique sur les grands jeux avec millions d'infosets\n",
+    "- Kuhn Poker est trop simple pour beneficier de l'optimisation CFR+\n",
+    "\n",
+    "**Pourquoi CFR+ excelle sur les grands jeux** :\n",
+    "- Le \"floor a zero\" evite l'accumulation de regrets negatifs qui ralentissent la convergence\n",
+    "- Sur Texas Hold'em (10^14 etats), CFR+ converge 2-10x plus vite\n",
+    "- Ce résultat ne se generalise pas aux jeux miniatures comme Kuhn\n",
+    "\n",
+    "> **Note technique** : L'exploitabilite est calculee par meilleure reponse sur l'arbre extensif (delegation a OpenSpiel, voir la cellule de reference plus loin). Ce n'est PAS la somme des regrets positifs, qui n'est qu'un proxy : les regrets peuvent rester eleves alors meme que la strategie moyenne a converge vers Nash. Avec cette vraie mesure, CFR et CFR+ sont tous deux proches de l'equilibre (exploitabilite ~2e-3) des 5000 iterations."
+   ],
    "metadata": {}
   },
   {
@@ -1291,12 +1484,12 @@
     "\n",
     "| Algorithme | Utilite finale | Exploitabilite |\n",
     "|------------|----------------|----------------|\n",
-    "| CFR vanilla | Variable | ~0.059 |\n",
-    "| CFR+ | Proche de Nash | ~0.082 |\n",
+    "| CFR vanilla | Variable | ~0.0023 |\n",
+    "| CFR+ | Proche de Nash | ~0.0029 |\n",
     "\n",
     "**Observations** :\n",
     "- L'utilite finale fluctue car on observe une seule itération\n",
-    "- L'exploitabilite (regret positif cumule) est similaire pour les deux méthodes après 5000 itérations\n",
+    "- L'exploitabilite (meilleure reponse) est similaire pour les deux méthodes après 5000 itérations\n",
     "- CFR+ n'est pas necessairement meilleur sur ce petit jeu\n",
     "\n",
     "**Pourquoi CFR+ excelle sur les grands jeux** :\n",


### PR DESCRIPTION
## Defect

`CFRSolver.get_exploitability` (cell 11) returned a **regret-derived proxy** (sum of positive regrets / iterations) labeled "exploitabilite". That quantity is **not** the exploitability: cumulative positive regrets can stay large even when the average strategy has converged to Nash. The notebook proved its own bug — its OpenSpiel reference cell (27) reports `0.000112` for the same algorithm, while cell 13 printed `0.044653` (**~400x off**) and the CFR-vs-CFR+ comparison (cell 19) used a metric that inverted the known convergence ordering.

## Fix

Delegate `get_exploitability` to **OpenSpiel's best-response exploitability** (Lisy & Lanctot 2016) via a `TabularPolicy` populated from the CFR average strategy (mapping our `J/Q/K` info-set keys to OpenSpiel's digit keys). Fallback returns `NaN` + guidance when OpenSpiel is unavailable (keeps C.1 end-to-end execution — no voluntary error).

## Re-execution (genuine kernel, `nbconvert`)

Cells 13 and 19 re-executed; the directly-dependent markdown (cells 14, 20, 21) that hard-coded the old bogus values (`0.045 / 0.059 / 0.082`) and mislabeled the metric as "regret moyen" / "regret positif cumule" updated to match.

| Cell | Before | After |
|------|--------|-------|
| 13 (Exploitabilite) | 0.044653 | **0.001486** |
| 19 CFR | 0.058861 | **0.002332** |
| 19 CFR+ | 0.082403 | **0.002881** |

`0.001486` is the right magnitude vs the OpenSpiel reference `0.000112` (our vanilla CFR at 10k iters is a little coarser than OpenSpiel's own CFR — expected). The CFR+ "no improvement on small games" narrative (cells 20-21) still holds and is now backed by a **real** metric.

## Scope & validation

- **One logical defect** (bogus exploitability) + its immediate dependents. Changed cells = `[11 src, 13 out, 14 md, 19 out, 20 md, 21 md]`; all other cells **byte-identical** to main (json round-trip `indent=1 ensure_ascii=False +
`).
- Repo validator **PASS** (16 code cells, 0 null-exec); **C.1 clean** (no `NotImplementedError`/`assert False`/`1/0`); **LF only** (0 CRLF).
- Outputs are genuine re-exec results — **no hand-editing** (secrets-hygiene rule 6 / Stop & Repair). The `pokerkit_wrapper` notice in cell 13 is a benign OpenSpiel optional-dependency warning emitted on first call (honest re-exec artifact).

See #3801 (Prong-B problem-richness / SOTA honesty): this replaces a degraded proxy with the real best-response exploitability the notebook claims to demonstrate.

Co-Authored-By: Claude-Code <noreply@anthropic.com>