### PR TITLE
fix(ml,#3801): ML-3 cell 8 evaluated on TrainSet but labeled as testset

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-3-Entrainement&AutoML.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-3-Entrainement&AutoML.ipynb
@@ -344,7 +344,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "1fe57bff",
    "metadata": {
     "dotnet_interactive": {
@@ -372,7 +372,9 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "small lgbm rmse sur testset: 173938,52924678137, large lgbm rmse sur testset: 132927,2510939994\r\n"
+     "text": [
+      "small lgbm rmse sur testset: 181156,29191693914, large lgbm rmse sur testset: 140086,26188344564\n"
+     ]
     }
    ],
    "source": [
@@ -396,10 +398,10 @@
     "var largeLgbmModel = largeLgbmPipeline.Fit(trainTestSplit.TrainSet);\n",
     "\n",
     "// évaluation sur le jeu de test\n",
-    "var smallTestEval = smallLgbmModel.Transform(trainTestSplit.TrainSet);\n",
+    "var smallTestEval = smallLgbmModel.Transform(trainTestSplit.TestSet);\n",
     "var smallLgbmMetric = context.Regression.Evaluate(smallTestEval, \"y\");\n",
     "\n",
-    "var largeLgbmEval = largeLgbmModel.Transform(trainTestSplit.TrainSet);\n",
+    "var largeLgbmEval = largeLgbmModel.Transform(trainTestSplit.TestSet);\n",
     "var largeLgbmMetric = context.Regression.Evaluate(largeLgbmEval, \"y\");\n",
     "\n",
     "Console.WriteLine($\"small lgbm rmse sur testset: {smallLgbmMetric.RootMeanSquaredError}, large lgbm rmse sur testset: {largeLgbmMetric.RootMeanSquaredError}\");\n"
@@ -414,7 +416,7 @@
    "source": [
     "### Interprétation : sensibilité aux hyper-paramètres\n",
     "\n",
-    "Sur les données non linéaires ($y = 100 x^2 + \\text{bruit}$), `LightGbm` avec peu de feuilles (`numberOfLeaves = 10`, RMSE ≈ **173 938**) reste nettement moins performant qu'avec une capacité plus large (`numberOfLeaves = 1000`, RMSE ≈ **132 927**) — la RMSE du modèle le plus petit est environ **31 % plus élevée**.\n",
+    "Sur les données non linéaires ($y = 100 x^2 + \\text{bruit}$), `LightGbm` avec peu de feuilles (`numberOfLeaves = 10`, RMSE ≈ **181 156**) reste nettement moins performant qu'avec une capacité plus large (`numberOfLeaves = 1000`, RMSE ≈ **140 086**) — la RMSE du modèle le plus petit est environ **29 % plus élevée**.\n",
     "\n",
     "Cette fois, **le même algorithme** produit des résultats très différents selon la valeur d'un seul hyper-paramètre : avec trop peu de feuilles, le modèle est en **sous-apprentissage** (capacité insuffisante pour épouser la courbure $x^2$) et laisse un résidu important. Passer de 10 à 1000 feuilles lui donne la flexibilité nécessaire pour capturer la non-linéarité.\n",
     "\n",


### PR DESCRIPTION
## Summary

Fixes a **real evaluation-set correctness bug** in `ML-3-Entrainement&AutoML.ipynb` (Exemple 2 — hyper-parameter sensitivity): cell 8 evaluated both LightGbm pipelines on the **training set** while labeling it as the **test set**.

**Firsthand-confirmed against the committed source (G.1):**

```csharp
// évaluation sur le jeu de test
var smallTestEval = smallLgbmModel.Transform(trainTestSplit.TrainSet);  // BUG: TrainSet
...
var largeLgbmEval = largeLgbmModel.Transform(trainTestSplit.TrainSet);  // BUG: TrainSet
Console.WriteLine($"small lgbm rmse sur testset: {...}, large lgbm rmse sur testset: {...}");
```

The comment ("jeu de test"), the variable names (`smallTestEval` / `largeLgbmEval`), and the printed output ("rmse sur testset") all claimed **test-set** error — but `.Transform()` received `TrainSet`. The committed RMSE numbers (173 938 / 132 927) were therefore **training error reported as test error** (data-leakage / wrong-eval-set). Cell 9 markdown then built its "31 % plus élevée" conclusion on those mis-labeled train numbers.

## The fix

1. **Cell 8** — `Transform(trainTestSplit.TrainSet)` → `Transform(trainTestSplit.TestSet)` for both pipelines (the `.Fit()` calls correctly stay on `TrainSet`). The comment, variable names, and output label are now all **true**.
2. **Re-executed** the cell via the real **.NET Interactive kernel** (`Microsoft.ML 5.0.0` LightGbm, SOTA-OK, rule F) and captured the genuine test-set RMSE:
   - small (10 leaves): **181 156**
   - large (1000 leaves): **140 086**
3. **Refreshed cell 9 markdown** to the real numbers (181 156 / 140 086, **~29 % plus élevée** instead of 31 %).

The directional conclusion (more leaves → lower test RMSE → more capacity helps on this non-linear signal) **still holds** and is now honestly test-set-grounded rather than inflated by training error.

## Validation (H.1 firsthand)

- **Real re-execution** via `.NET Interactive` kernel (Microsoft.ML LightGbm invoked — rule F satisfied, not a workaround).
- **C.1 = 0 violations** (no `raise NotImplementedError` / `assert False` / `1/0`).
- **C.2**: cell 8 source changed → re-executed (`execution_count 4→5`, fresh real output); cell 9 markdown-only (numbers refreshed to match cell 8 output).
- **Surgical diff vs `origin/main`**: source changed ONLY cells `[8, 9]`, outputs ONLY `[8]`, `execution_count` ONLY cell 8 — metadata + nbformat byte-identical, **0 collateral churn**. `+7/-5`.
- **Coherence confirmed**: cell 8 output (181156 / 140086) matches cell 9 markdown citations (181 156 / 140 086).
- **LF-only** (0 CR).

## Scope

Single notebook, single subject (one evaluation-set bug + its dependent markdown). No other file touched. Catalogue byte-identical to main.

## Provenance

Defect first reported by **po-2025** (c.731 follow-up list, "autres lanes OK"). **G.1 firsthand-confirmed** here against the committed source + output. This is a genuine correctness bug (wrong evaluation set = data leakage), not just prose — a higher-value class than a pure doc-vs-output mismatch.

See #3801 (correctness/Prong-B registry). Not `Closes` — #3801 is an open epic.

Grain: MED/fix-functional-bug — lane po-2026:CoursIA — prev: MED/doc-honesty (c.629 #7854). [Genre rotation doc-honesty→fix-functional-bug (OK); family rotation Tweety→ML.NET (fresh family, R6 OK). Real .NET Interactive re-exec, surgical byte-clean diff, genuine correctness fix.]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
