### PR TITLE
docs(ml,#4959): ML-3 AutoML leaderboard resync (Prong-A #7642 + Prong-B #7839)

### DIFF
--- a/MyIA.AI.Notebooks/ML/README.md
+++ b/MyIA.AI.Notebooks/ML/README.md
@@ -57,7 +57,7 @@ Six figures illustrent les trois fils de la série : les fondations Python (Pand
 
 ### Track A : ML.NET (.NET/C#, 10 notebooks C# — 9 du parcours ML-1 à ML-9 + 1 TP capstone — et leurs 9 jumeaux Python scikit-learn, ~7h)
 
-Le parcours ML.NET couvre le pipeline complet en C# : les notebooks 1-2 introduisent ML.NET et la préparation de données (IDataView, encodage). Le notebook 3 couvre l'entraînement (SDCA, LightGBM, AutoML). Le notebook 4 est crucial : évaluation rigoureuse par cross-validation et Permutation Feature Importance. Les notebooks 5-7 abordent les séries temporelles, l'export ONNX pour la production, et les systèmes de recommandation. Les notebooks 8-9 ouvrent sur l'apprentissage non-supervisé : clustering K-Means (segmentation RFM, méthode du coude) puis détection d'anomalies par Randomized PCA (maintenance prédictive, choix du seuil de décision). Le TP final (prévision de ventes) combine ML.NET et Infer.NET pour une régression bayésienne. Ce track présuppose .NET 9.0 + dotnet-interactive.
+Le parcours ML.NET couvre le pipeline complet en C# : les notebooks 1-2 introduisent ML.NET et la préparation de données (IDataView, encodage). Le notebook 3 couvre l'entraînement (SDCA, LightGBM, AutoML) — son **leaderboard AutoML** (cell 12-13) rend visible la discrimination entre entraîneurs : sur données quadratiques, `LightGbmRegression` gagne avec un RMSE de 90 262 contre 30,5 millions pour `FastTreeRegression`, soit un écart de **plus de 300×** qu'aucun tableau `Console.WriteLine` ne fait ressortir. Le notebook 4 est crucial : évaluation rigoureuse par cross-validation et Permutation Feature Importance. Les notebooks 5-7 abordent les séries temporelles, l'export ONNX pour la production, et les systèmes de recommandation. Les notebooks 8-9 ouvrent sur l'apprentissage non-supervisé : clustering K-Means (segmentation RFM, méthode du coude) puis détection d'anomalies par Randomized PCA (maintenance prédictive, choix du seuil de décision). Le TP final (prévision de ventes) combine ML.NET et Infer.NET pour une régression bayésienne. Ce track présuppose .NET 9.0 + dotnet-interactive.
 
 ### Track B : Data Science with Agents (Python, 28 notebooks, ~21h)
 
@@ -175,7 +175,7 @@ Pipeline ML.NET complet en C#, de l'introduction à l'évaluation avancée : du 
 | 1-Py | [ML-1-Introduction-Python](ML.Net/ML-1-Introduction-Python.ipynb) | **Jumeau Python** : pipeline ML.NET ⇄ scikit-learn (régression + classification) | Parité .NET⇄Python |
 | 2 | [ML-2-Data&Features](ML.Net/ML-2-Data&Features.ipynb) | IDataView, TextLoader, encodage | Préparation données |
 | 2-Py | [ML-2-Data&Features-Python](ML.Net/ML-2-Data&Features-Python.ipynb) | **Jumeau Python** : `IDataView`/Transforms ⇄ `ColumnTransformer`+`Pipeline` (scikit-learn) | Parité .NET⇄Python |
-| 3 | [ML-3-Entrainement&AutoML](ML.Net/ML-3-Entrainement&AutoML.ipynb) | SDCA, LightGBM, AutoML | Entraînement |
+| 3 | [ML-3-Entrainement&AutoML](ML.Net/ML-3-Entrainement&AutoML.ipynb) | SDCA, LightGBM, AutoML + **leaderboard visuel** (Plotly) | Entraînement |
 | 3-Py | [ML-3-Entrainement-Python](ML.Net/ML-3-Entrainement-Python.ipynb) | **Jumeau Python** : SDCA/LightGBM/AutoML ⇄ `LinearRegression`/`GradientBoosting`/`GridSearchCV` | Parité .NET⇄Python |
 | 4 | [ML-4-Evaluation](ML.Net/ML-4-Evaluation.ipynb) | Cross-validation, métriques, PFI | Évaluation |
 | 4-Py | [ML-4-Evaluation-Python](ML.Net/ML-4-Evaluation-Python.ipynb) | **Jumeau Python** : cross-validation + métriques + PFI ⇄ `cross_val_score` + `permutation_importance` (scikit-learn) | Parité .NET⇄Python |
@@ -190,6 +190,20 @@ Pipeline ML.NET complet en C#, de l'introduction à l'évaluation avancée : du 
 | 9 | [ML-9-Anomaly-Detection](ML.Net/ML-9-Anomaly-Detection.ipynb) | Randomized PCA, AUC, seuil de décision | Détection d'anomalies |
 | 9-Py | [ML-9-Anomaly-Detection-Python](ML.Net/ML-9-Anomaly-Detection-Python.ipynb) | **Jumeau Python** : `RandomizedPca` ⇄ `PCA`+résidu (scikit-learn) | Parité .NET⇄Python |
 | TP | [TP-prevision-ventes](ML.Net/TP-prevision-ventes.ipynb) | Régression bayésienne (Infer.NET) | Application pratique |
+
+#### AutoML : quand le leaderboard bat le `Console.WriteLine` ([#7642](https://github.com/jsboige/CoursIA/pull/7642), [#7707](https://github.com/jsboige/CoursIA/pull/7707), [#7839](https://github.com/jsboige/CoursIA/pull/7839))
+
+Le notebook **ML-3** AutoML produit, sur données non linéaires (`y = 100·x² + bruit`), **10 essais terminés** en 30 secondes, couvrant **5 entraîneurs distincts**. Sans visualisation, l'étudiant doit comparer 10 nombres à la main pour repérer le gagnant — exercice rébarbatif qui masque l'apport pédagogique de l'AutoML. La cellule 13 ([`NotebookMonitor.CompletedTrials`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.ml.automl.runtime.notebookmonitor) + `Plotly.NET.Interactive`) trace un **leaderboard** qui rend la discrimination visible :
+
+| Entraîneur | Essais | Meilleur RMSE |
+|---|---|---|
+| `LightGbmRegression` | 3 | **90 262** ← gagnant |
+| `FastForestRegression` | 4 | 5 932 134 |
+| `LbfgsPoissonRegressionRegression` | 1 | 6 303 500 |
+| `SdcaRegression` | 1 | 11 323 122 |
+| `FastTreeRegression` | 1 | 30 523 762 ← perdant |
+
+L'écart entre le pire et le meilleur essai est de **338×** — un fait pédagogique majeur, **invisible sans graphique**. La lecture honnête du classement nuance aussi le stéréotype « non-linéaire bat linéaire » : `FastTreeRegression` (lui aussi non-linéaire, à base d'arbres) finit **dernier** (30 M), pire que `SdcaRegression` linéaire (11 M). L'AutoML a donné **3 essais** à `LightGbmRegression` mais **un seul** à `FastTreeRegression` — moins d'occasions de bien le régler. La leçon : la *famille* d'algorithme ne garantit pas le succès, c'est l'association **bon algorithme + bons hyper-paramètres** que l'AutoML cherche conjointement. Cette nuance illustre l'**anti-fabrication** [#3801 Prong-B](https://github.com/jsboige/CoursIA/issues/3801) : la cellule trace un graphique à partir des vrais résultats `experiment.RunAsync()`, pas une simulation ASCII ni un workaround dégradé.
 
 ### Trois figures du track ML.NET (scikit-learn, statsmodels)
 


### PR DESCRIPTION
# docs(ml,#4959): ML-3 AutoML leaderboard resync (Prong-A #7642 + Prong-B #7839)

**Grain: MED/doc-honesty — lane myia-po-2023:CoursIA-2 — prev: DEEP/notebook-python (c.727 SC-16 TenSEAL)**

Closes nothing (partial contribution to Epic #4959, use See #4959)

## Context

The ML hub README mentions ML-3 AutoML generically (L60, L178) but does NOT reflect the **AutoML leaderboard Plotly chart** and the **338× trainer discrimination** added by PR [#7642](https://github.com/jsboige/CoursIA/pull/7642) (Prong-A SOTA-OK + Prong-B non-trivial) and the markdown doc-honesty fixes by PR [#7839](https://github.com/jsboige/CoursIA/pull/7839) (stale trial counts + refuted linear/nonlinear conclusion). EPIC #4959 (hub resync) + EPIC #3801 (SOTA).

This follows the precedent established by sibling PRs (markdown-only atomic, ≤50 lines, ≤1 file):

- [PR #7626](https://github.com/jsboige/CoursIA/pull/7626) `docs(sudoku,#4959): resync Optimize section (CP-SAT #7588 + Z3 SMT #7589 + C# twin #7622)` MERGED 2026-07-21 (c.719)
- [PR #7628](https://github.com/jsboige/CoursIA/pull/7628) `docs(probas,#4959): resync EP-vs-VMP comparison section` MERGED 2026-07-21 (c.720)
- [PR #7630](https://github.com/jsboige/CoursIA/pull/7630) `docs(planners,#4959): resync PDDL optimization section` MERGED 2026-07-21 (c.721)
- [PR #7632](https://github.com/jsboige/CoursIA/pull/7632) `docs(gametheory,#4959): resync Moran section` MERGED 2026-07-21 (c.722)
- [PR #7633](https://github.com/jsboige/CoursIA/pull/7633) `docs(search-csharp,#4959): resync deceptive trap section` MERGED 2026-07-21 (c.723)
- [PR #7643](https://github.com/jsboige/CoursIA/pull/7643) `docs(gametheory-17,#4959): resync exploitability Plotly chart` MERGED 2026-07-21 (c.724)

## G.1 first-hand (pas Hearsay)

Direct reading of `git show 7971f83a9` (PR #7642 merge commit) and `git show 40999a2c8` (PR #7839 merge commit) confirms the leaderboard chart and stale-numbers markdown fixes landed on `origin/main` but the ML hub README never reflected them.

### Verbatim numbers from cell 13 outputs (cross-check 9/9 PASS)

Read from `MyIA.AI.Notebooks/ML/ML.Net/ML-3-Entrainement&AutoML.ipynb` cell 13 stream outputs (Python+nbformat, NOT NotebookEdit per C711-L8-10):

```
Entraîneurs distincts testés : 5
Nombre total d'essais terminés : 10

Entraîneur                     Essais   Meilleur RMSE Durée cumulée (ms)  Trial ID
----------------------------------------------------------------------------------
LightGbmRegression                  3      90262,7424               2097         6
FastForestRegression                4    5932134,4276               1082         7
LbfgsPoissonRegressionRegression      1    6303500,8108                 76         8
SdcaRegression                      1   11323122,6660                731         4
FastTreeRegression                  1   30523762,8465                193         1
```

| Item | README resync | Cell 13 output | Verdict |
|---|---|---|---|
| LightGbmRegression RMSE | 90 262 | 90262,7424 | ✓ |
| FastForestRegression RMSE | 5 932 134 | 5932134,4276 | ✓ |
| LbfgsPoissonRegressionRegression RMSE | 6 303 500 | 6303500,8108 | ✓ |
| SdcaRegression RMSE | 11 323 122 | 11323122,6660 | ✓ |
| FastTreeRegression RMSE | 30 523 762 | 30523762,8465 | ✓ |
| Entraîneurs distincts | 5 | 5 | ✓ |
| Essais terminés | 10 | 10 | ✓ |
| LightGbm essais | 3 | 3 | ✓ |
| FastForest essais | 4 | 4 | ✓ |

## Changes (single file, markdown-only atomic, +16/-2)

### `MyIA.AI.Notebooks/ML/README.md` — 3 insertions

**1. L60 Track A narrative enrichment** (ML-3 leaderboard + 300× ratio mention):
```diff
-Le notebook 3 couvre l'entraînement (SDCA, LightGBM, AutoML).
+Le notebook 3 couvre l'entraînement (SDCA, LightGBM, AutoML) — son **leaderboard AutoML** (cell 12-13) rend visible la discrimination entre entraîneurs : sur données quadratiques, `LightGbmRegression` gagne avec un RMSE de 90 262 contre 30,5 millions pour `FastTreeRegression`, soit un écart de **plus de 300×** qu'aucun tableau `Console.WriteLine` ne fait ressortir.
```

**2. L178 table row 3 enrichment** (leaderboard visuel added to ML-3 cell content):
```diff
-| 3 | [ML-3-Entrainement&AutoML] | SDCA, LightGBM, AutoML | Entraînement |
+| 3 | [ML-3-Entrainement&AutoML] | SDCA, LightGBM, AutoML + **leaderboard visuel** (Plotly) | Entraînement |
```

**3. New pedagogical paragraph after L192** (full leaderboard table + honest reading):
- 5-row leaderboard table (verbatim from cell 13 stream outputs)
- 338× ratio (90 262 vs 30 523 762)
- **Anti-fabrication / Prong-B note** : nuance du stéréotype « non-linéaire bat linéaire » — `FastTreeRegression` (lui aussi non-linéaire, à base d'arbres) finit **dernier** (30 M), pire que `SdcaRegression` linéaire (11 M). L'AutoML a donné **3 essais** à `LightGbmRegression` mais **un seul** à `FastTreeRegression` — moins d'occasions de bien le régler. La leçon : la *famille* d'algorithme ne garantit pas le succès, c'est l'association **bon algorithme + bons hyper-paramètres** que l'AutoML cherche conjointement.

### ML-3-Py twin scope (asymmetric, intentional)

Cross-check: `ML-3-Entrainement-Python.ipynb` has 0 occurrences of `leaderboard`, `Plotly`, `CompletedTrials`, or `NotebookMonitor` — the Python twin implements **algorithm-level parity** (SDCA/LightGBM/AutoML ⇄ `LinearRegression`/`GradientBoosting`/`GridSearchCV`), not chart-level parity. The resync correctly mentions the leaderboard for **ML-3 only** (not the twin).

### CATALOG-STATUS marker untouched

Lines 1-11 of `MyIA.AI.Notebooks/ML/README.md` (the `<!-- CATALOG-STATUS ... -->` block + the « À propos des décomptes » paragraph) are byte-identique to `origin/main` (sed diff = 0). Marker reads:
```
pedagogical_count: 47
breakdown: DataScienceWithAgents=28, ML.Net=19
maturity: PRODUCTION=41, BETA=5, ALPHA=1
```
No new notebook added by this PR (only new prose documenting the existing leaderboard chart in ML-3 cell 13), so the marker count is unchanged.

## Diff stats

```text
MyIA.AI.Notebooks/ML/README.md | 18 ++++++++++++++++--
1 file changed, 16 insertions(+), 2 deletions(-)
```

Single file, well below the 50-line single-file docs PR threshold ([pr-review-discipline.md](../../.claude/rules/pr-review-discipline.md) §E). Below the composite >3000L/>15f/>4 features/>1 domaine threshold (§A).

## Catalog hygiene (R1 HARD rule, [catalog-pr-hygiene.md](../../.claude/rules/catalog-pr-hygiene.md))

- `COURSE_CATALOG.generated.json`: **byte-identique** to `origin/main` (sha1 `7c1de1fc00809475ccd12c4f0050487799d1f627`, 617427 bytes).
- `COURSE_CATALOG.generated.md`: byte-identique (sha1 `942e0bc4f62d87d96724d208d8f3047412c4a4f3`).
- `MyIA.AI.Notebooks/ML/README.md` CATALOG-STATUS block (lines 1-11): byte-identique.
- No catalog regeneration on this branch. R1 fully respected.

## Validation

| Check | Result |
|-------|--------|
| G.1 verbatim cross-check (9 numbers) | 9/9 PASS |
| Catalog R1 byte-identique | ✓ (.json + .md + marker) |
| CATALOG-STATUS marker unchanged | ✓ (sed diff lines 1-11 = 0) |
| Trailing newline preserved | ✓ |
| Markdown-only (no code/IPynb touched) | ✓ |
| Atomic single-subject | ✓ |
| Diff size | +16/-2 (well under 50-line docs PR threshold) |

## Anti-patterns avoided (7)

1. **No fabrication** : every number in the README matches cell 13 stream output verbatim (G.1 cross-check 9/9).
2. **No NotebookEdit tool** : read-only Python+nbformat inspection of cell 13 outputs (C711-L8-10 ★★★).
3. **No `git add -A` / `git add -u`** : single-file specific `git add <path>` (worktree isolation, C720-L3).
4. **No force push** : branch created from `origin/main` via worktree; simple push.
5. **No catalog regeneration** : byte-identique confirmed via git show + sha1.
6. **No claim of "hub-resync sweep"** : 1 file = 1 PR atomique < 50L (R3).
7. **No claim of "ML-3 cell modification"** : the README is a passive documentation update only; the underlying notebook cells are unchanged.

## Pivot R6 cross-family (post-c.727 SmartContracts fix-notebook)

c.727 = SmartContracts (SC-16 TenSEAL CKKS) + fix-notebook cells register.
c.728 = ML (.NET) + doc-honesty resync register.
G-VAR-3 OK : cross-family + cross-registre, substance distincte.
G-VAR-1 OK : DEEP/MED plancher (this PR is MED/doc-honesty).
G-VAR-2 OK : not a LIGHT (markdown-only atomic ≠ guard/ledger).

## Refs

- See [#4959](https://github.com/jsboige/CoursIA/issues/4959) (hub-resync tracker, partial contribution).
- See [#3801](https://github.com/jsboige/CoursIA/issues/3801) (SOTA/non-trivial problem tracker, partial contribution — ML-3 leaderboard chart is the canonical Prong-A+Prong-B substance for ML.Net).
- See [#5780](https://github.com/jsboige/CoursIA/issues/5780) (sustained tranche, partial contribution).
- See [#7642](https://github.com/jsboige/CoursIA/pull/7642) PR MERGED 2026-07-21 (leaderboard Plotly chart substance, source of leaderboard data).
- See [#7839](https://github.com/jsboige/CoursIA/pull/7839) PR MERGED 2026-07-22 (stale trial counts + refuted linear/nonlinear conclusion, source of "anti-fabrication Prong-B" framing).
- See [#7707](https://github.com/jsboige/CoursIA/pull/7707) PR MERGED 2026-07-21 (hyper-parameter interpretation enrichment, source of "family ≠ guarantee, hyperparameters matter" lesson).
- Sibling precedent PRs: #7626 (Sudoku, c.719), #7628 (Probas, c.720), #7630 (Planners, c.721), #7632 (GameTheory, c.722), #7633 (Search, c.723), #7643 (GT-17, c.724).
- See [pr-review-discipline.md](../../.claude/rules/pr-review-discipline.md) §E (docs-only PR thresholds).
- See [catalog-pr-hygiene.md](../../.claude/rules/catalog-pr-hygiene.md) for the byte-identique-catalog contract.
- See [sota-not-workaround.md](../../.claude/rules/sota-not-workaround.md) §A (SOTA + RECOVERABLE-*) and §B (non-trivial problem).
- See [anti-regression.md](../../.claude/rules/anti-regression.md) (cell # Solution / # Exemple résolu NOT stripped — this PR does not touch the notebook).
- Topic file: `~/.claude/projects/d--Dev-CoursIA-2/memory/topic-c728-ml-hub-automl-resync.md` (to be written post-merge).
