### PR TITLE
docs(lean,#4980): localize isStable_of_check docstring in Lattice.lean (HALF-DONE fix)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/Lattice.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/Lattice.lean
@@ -167,11 +167,11 @@ l'honnête théorème `exists_isManOptimal`.
 -/
 
 /--
-Stability from a fully computable check: it suffices to verify, for every
-man `m`, woman `w` and candidate husband `m'` with `μ.spouse m' = w`, that
-`(m, w)` is not a blocking pair.  This formulation avoids the noncomputable
-`Matching.inverse`, so on concrete instances the hypothesis can be
-discharged by `decide`.
+Stabilité par vérification entièrement calculable : il suffit de vérifier,
+pour chaque homme `m`, femme `w` et mari candidat `m'` avec `μ.spouse m' = w`,
+que `(m, w)` n'est pas une paire bloquante. Cette formulation évite le
+`Matching.inverse` non calculable, de sorte que sur des instances concrètes
+l'hypothèse peut être déchargée par `decide`.
 -/
 lemma isStable_of_check (μ : Matching n)
     (h : ∀ m w m' : Fin n, μ.spouse m' = w →


### PR DESCRIPTION
# docs(lean,#4980): localize isStable_of_check docstring in Lattice.lean (HALF-DONE fix)

**Grain: MED/lean — lane myia-po-2023:CoursIA-2 — prev: MED/docs (c.728 ML-3 AutoML resync)**

Closes nothing (partial contribution to Epic #4980, use See #4980)

## Context

The FR canonical `MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/Lattice.lean` had a residual **EN-only docstring** on `lemma isStable_of_check` (lines 169-175). The lemma name, tactic names, and Mathlib references are intentionally English-compatible (EPIC #4980 ratifies 2026-07-04: lemma names + Mathlib refs + tactic DSL stay English; only docstrings + comments localize). However the `/-- ... -/` docstring body itself should mirror the FR voice used throughout the rest of the file.

This was flagged as a **HALF-DONE advisory** by `scripts/lean/check_i18n_siblings.py`: identical block-comment body(ies) >=100 chars shared between FR canonical and EN mirror, meaning the FR file was likely never re-localized after sibling-pair creation.

EPIC #4980 (Lean i18n) — this is the **smallest** of the 22 HALF-DONE advisories currently flagged by the checker (cf `StableMarriage/Lemmas_en.lean` 8 blocks, `Conway/Life/Hashlife_en.lean` 24 blocks, `CooperativeGames/Shapley_en.lean` 53 blocks, etc.).

## G.1 first-hand (pas Hearsay)

Direct Python regex inspection of the FR + EN sibling pair:

```python
import re, pathlib
def blocks(p): return [m.group(1) for m in re.finditer(r'/--[!-](.*?)-/', pathlib.Path(p).read_text(), re.DOTALL)]
fr, en = blocks("Lattice.lean"), blocks("Lattice_en.lean")
identical = [b for b in fr if any(b == e for e in en) and len(b) >= 100]
# Before fix: 1 identical >=100-char block (the `isStable_of_check` lemma docstring)
# After fix:  0 identical >=100-char blocks (HALF-DONE cleared for this pair)
```

Confirmed: only 1 block was identical >=100 chars — the `isStable_of_check` lemma docstring. Module header, namespace preamble, and 17 other lemma docstrings are all already FR-canonical in `Lattice.lean`.

## Changes (single file, +5/-5, ≤50-line docs PR threshold)

### `MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/Lattice.lean` — 1 block translation

**Lines 169-175** — `lemma isStable_of_check` docstring:

```diff
 /--
-Stability from a fully computable check: it suffices to verify, for every
-man `m`, woman `w` and candidate husband `m'` with `μ.spouse m' = w`, that
-`(m, w)` is not a blocking pair.  This formulation avoids the noncomputable
-`Matching.inverse`, so on concrete instances the hypothesis can be
-discharged by `decide`.
+Stabilité par vérification entièrement calculable : il suffit de vérifier,
+pour chaque homme `m`, femme `w` et mari candidat `m'` avec `μ.spouse m' = w`,
+que `(m, w)` n'est pas une paire bloquante. Cette formulation évite le
+`Matching.inverse` non calculable, de sorte que sur des instances concrètes
+l'hypothèse peut être déchargée par `decide`.
 -/
 lemma isStable_of_check (μ : Matching n)
```

EN mirror `Lattice_en.lean` UNCHANGED — already correct EN content (lines 183-189).

### Post-fix verification

| Check | Result |
|-------|--------|
| Python regex identical >=100-char blocks (FR vs EN) | 0 (was 1) |
| `check_i18n_siblings.py Lattice.lean Lattice_en.lean` | OK-CONSUMER \| 0/1 byte-identical \| 1 consumer-pattern \| 0 drift \| 0 orphan \| 0 unbuilt \| 0 half-done (advisory) |
| File headers FR vs EN | Distinct (FR: "Mariage stable - Structure de treillis" / EN: "Stable Marriage - Lattice Structure") |
| Other 17 lemma docstrings in Lattice.lean | Already FR-canonical (unchanged) |
| Diff stat | 1 file, 5 insertions(+), 5 deletions(-) |

## Sibling pattern (EPIC #4980 / code-style.md)

- **FR canonical** `namespace StableMarriage` (line 54) — body + lemma-names + tactic-names + Mathlib references stay EN (compat Mathlib 4, tactic DSL); only docstrings/comments localize
- **EN mirror** `namespace StableMarriage_en` (line 54 of `Lattice_en.lean`) — imports `StableMarriage.Lemmas` from FR canonical (OK-CONSUMER pattern, anti-collision of names)
- **Only docstrings `/-- ... -/` and comments `-- ...` differ** between the two files
- **Preservation**: byte-identity on the rest (signatures, proofs, tactics) — verifiable by diff

## Lake build

- Did not run `lake build game_theory_lean` locally — fresh worktree would re-fetch Mathlib/Batteries from scratch (C712-L1 ★★ confirms this is expected for fresh worktrees, not related to my edit). The docstring change is **purely textual**, does not touch tactics/signatures/proofs.
- Per [`lean-merge-discipline.md`](../.claude/rules/lean-merge-discipline.md) §1 (HARD), ai-01 performs `lake build <module>` SUCCESS verification pre-merge. My local repo at the worktree base should be sufficient for that.

## Cross-cluster collision check (L897 ★★)

```
$ gh pr list --state open --search "Lattice_en.lean OR Lattice.lean OR StableMarriage/Lattice"
```
→ all results CLOSED or MERGED, 0 OPEN PRs by other lanes. No conflict.

## Pivot R6 cross-genre (post-c.728 doc-honesty monotonie)

c.728 = `MED/docs` (ML.NET hub resync). 
c.729 = `MED/lean` (Lean i18n HALF-DONE fix). 
**G-VAR-3 OK**: cross-genre + cross-family pivot — substantive distinct work, not a scan-generated variant.

## Diff stats

```text
MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/Lattice.lean | 10 +++++-----
1 file changed, 5 insertions(+), 5 deletions(-)
```

Single file, well below the 50-line single-file docs PR threshold ([pr-review-discipline.md](../.claude/rules/pr-review-discipline.md) §E). Below the composite >3000L/>15f/>4 features/>1 domaine threshold (§A).

## Catalog hygiene (R1 HARD rule, [catalog-pr-hygiene.md](../.claude/rules/catalog-pr-hygiene.md))

This PR does NOT touch `MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/README.md` or any catalog artifact. Catalog remains byte-identique to `origin/main`. R1 fully respected.

## Anti-patterns avoided (5)

1. **No fabrication** : the FR translation was modeled on the existing FR voice in `Lattice.lean` (e.g. `join_inverse_anti` uses "Anti-complémentarité du join :" header + "Preuve :" proof-style + causal "ce qui donne"). No invented claims.
2. **No NotebookEdit tool** : this is a `.lean` file edit, not notebook work.
3. **No `git add -A` / `git add -u`** : single-file specific `git add <path>` (worktree isolation, C720-L3 / L530).
4. **No force push** : branch created from `origin/main` via worktree; simple push.
5. **No "fix Mathlib"** : the docstring change is purely textual, does not affect tactics/proofs/signatures — does not fall under the anti-regression RED FLAG del-vs-ins for code de production.

## Refs

- See [#4980](https://github.com/jsboige/CoursIA/issues/4980) (Lean i18n tracker, partial contribution — 1/22 HALF-DONE fix; 21 remaining advisories).
- See [#3801](https://github.com/jsboige/CoursIA/issues/3801) (SOTA/non-trivial problem tracker, partial contribution).
- See [#5780](https://github.com/jsboige/CoursIA/issues/5780) (sustained tranche, partial contribution).
- See [`scripts/lean/check_i18n_siblings.py`](../../scripts/lean/check_i18n_siblings.py) for the canonical i18n checker.
- See [`.claude/rules/lean-merge-discipline.md`](../.claude/rules/lean-merge-discipline.md) §1 for pre-merge `lake build` obligation.
- See [`docs/lean/i18n-sibling-patterns.md`](../../docs/lean/i18n-sibling-patterns.md) for sibling pair taxonomy.
- See [`docs/lean/i18n-inventory-cycle-38.md`](../../docs/lean/i18n-inventory-cycle-38.md) for the fleet-wide i18n inventory.
- See [`docs/reference/harness-hygiene.md`](../../docs/reference/harness-hygiene.md) for FR-canonical convention.
- Topic file: `~/.claude/projects/d--Dev-CoursIA-2/memory/topic-c729-lean-i18n-half-done-lattice.md` (to be written post-merge).