### PR TITLE
docs(curriculum,#7422): reconcile GenAI Video + Sudoku enumerations and counts (c.748)

### DIFF
--- a/docs/curriculum/genai.md
+++ b/docs/curriculum/genai.md
@@ -8,7 +8,7 @@ Génération d'images (DALL-E, Stable Diffusion, Qwen, ComfyUI), synthèse vocal
 
 | Métrique | Valeur |
 |----------|--------|
-| Notebooks | 136 |
+| Notebooks | 138 |
 | PRODUCTION | 97 |
 | BETA | 34 |
 | ALPHA | 5 |
@@ -194,7 +194,7 @@ Génération d'images (DALL-E, Stable Diffusion, Qwen, ComfyUI), synthèse vocal
 | 5 | Claude CLI - Automatisation Avancee | PRODUCTION | Non |
 | 6 | Claude Code via Claudish | PRODUCTION | Non |
 
-## GenAI/Video (15 notebooks)
+## GenAI/Video (17 notebooks)
 
 | # | Notebook | Maturité | Exécutable |
 |---|----------|----------|------------|
@@ -213,3 +213,5 @@ Génération d'images (DALL-E, Stable Diffusion, Qwen, ComfyUI), synthèse vocal
 | 13 | Workflows Video Creatifs | PRODUCTION | Non |
 | 14 | Sora API - Generation Video Cloud | ALPHA | Non |
 | 15 | Pipeline Video de Production | PRODUCTION | Non |
+| 16 | SVD - Stable Video Diffusion (Image-to-Video) | DRAFT | Non |
+| 17 | Generation de Videos Educatives | DRAFT | Non |

--- a/docs/curriculum/ia-classique.md
+++ b/docs/curriculum/ia-classique.md
@@ -8,10 +8,10 @@ Algorithmes de recherche classique, satisfaction de contraintes (CSP), résoluti
 
 | Métrique | Valeur |
 |----------|--------|
-| Notebooks | 148 |
+| Notebooks | 149 |
 | PRODUCTION | 114 |
 | BETA | 34 |
-| ALPHA | 0 |
+| ALPHA | 1 |
 
 ## Search/Applications (40 notebooks)
 
@@ -151,7 +151,7 @@ Algorithmes de recherche classique, satisfaction de contraintes (CSP), résoluti
 | 19 | MGS-8 : Fitness Landscape Explorer -- voir la surface p | PRODUCTION | Oui |
 | 20 | MGS-9 - Trouver l'Everest : relief reel et bassins d'at | PRODUCTION | Oui |
 
-## Sudoku (35 notebooks)
+## Sudoku (36 notebooks)
 
 | # | Notebook | Maturité | Exécutable |
 |---|----------|----------|------------|
@@ -190,3 +190,4 @@ Algorithmes de recherche classique, satisfaction de contraintes (CSP), résoluti
 | 33 | Sudoku-8 : Resolution par Stratégies Humaines (Python) | PRODUCTION | Oui |
 | 34 | Notebook 9: Résolution de Sudoku par Coloration de Grap | PRODUCTION | Oui |
 | 35 | Sudoku-9 : Coloration de Graphe (Python) | PRODUCTION | Oui |
+| 36 | Sudoku-11-Choco-Csharp : Solveur Choco via IKVM | ALPHA | Oui |


### PR DESCRIPTION
Grain: MED/docs-harness-hygiene -- lane myia-po-2026:CoursIA-2 -- prev: MED/docs-lean-readme-grothendieck-done-right (c.745)

## Scope

Atomic sub-grain of the **#7422 docs/ hygiene triage** Epic: reconcile 2 curriculum counter drifts vs CI-generated catalog (`COURSE_CATALOG.generated.md`).

G.1 firsthand verification (cross-check disk vs curriculum vs catalog):
- `docs/curriculum/genai.md` `## Statistiques` claimed `Notebooks | 136`, catalog = 141. Pedagogically curated gap: **2 truly missing Video notebooks** (3 remaining gaps = intentional exclusions: SemanticKernel templates + workbooks + games).
- `docs/curriculum/ia-classique.md` `## Statistiques` claimed `Notebooks | 148`, catalog = 149. Pedagogically curated gap: **1 truly missing Sudoku notebook**.

## Diff summary

2 files / +8 / -5. Well under all thresholds (3000 lines / 15 files / 4 features / 1 domain).

### docs/curriculum/genai.md (3 surgical patches)

| Patch | Before | After | Why |
|-------|--------|-------|-----|
| Statistiques row | Notebooks | 136 | Notebooks | 138 | Catalog=141, gap=2 (curatable) |
| Video section header | GenAI/Video (15 notebooks) | GenAI/Video (17 notebooks) | Matches row count |
| Video last 2 rows | (row 15 = end) | + row 16 (SVD) + row 17 (Educational) | Catalog-truth alignment |

### docs/curriculum/ia-classique.md (4 surgical patches)

| Patch | Before | After | Why |
|-------|--------|-------|-----|
| Statistiques row | Notebooks | 148 | Notebooks | 149 | Catalog Sudoku=36 vs curriculum=35 |
| Statistiques ALPHA row | ALPHA | 0 | ALPHA | 1 | Sudoku-11-Choco is ALPHA |
| Sudoku section header | Sudoku (35 notebooks) | Sudoku (36 notebooks) | Matches row count |
| Sudoku last row | (row 35 = end) | + row 36 (Choco C# IKVM) | Catalog-truth alignment |

## Verification

Re-parsed both files post-edit:
- genai.md sub-section enumeration: 1 + 6 + 30 + 4 + 5 + 17 + 7 + 7 + 1 + 17 + 20 + 6 + 17 = **138** ✓ (matches declared Statistiques Notebooks row)
- ia-classique.md sub-section enumeration: 40 + 29 + 18 + 6 + 20 + 36 = **149** ✓ (matches declared Statistiques Notebooks row)
- Internal section declared-count matches data-row count in every sub-section (no hidden drift)

## Compliance

| Rule | Status | Note |
|------|--------|------|
| R1 catalog-pr-hygiene | OK | `COURSE_CATALOG.generated.{json,md}` and `CATALOG-STATUS` markers NOT touched (curriculum files contain 0 markers; catalog = CI-owned) |
| R4 partial-contribution | OK | `See #7422` (epic remains open); this PR resolves the curriculum-catalog drift slice, not the full docs/ hygiene triage |
| R6/R7 never-idle | OK | Real grain from `gh issue list --state open` (#7422 cross-famille) transformed to PR |
| Anti-regression D | OK | 0 Lean/Coq/Python code touched; only markdown |
| B/H.4 sub-section audit | OK | Used entry-level sub-section enumeration to detect gap (L736 pattern); not just counters |
| Variation protocol G-VAR-1/2/3 | OK | MED not LIGHT; new genre docs-harness-hygiene vs previous MED docs-lean-readme-grothendieck-done-right |

## Lecon transferable (L748 candidat)

**Curriculum-vs-catalog counter drift = scope-of-curation, not always a bug.** Cross-checking `Statistiques`.Notebooks against `COURSE_CATALOG.generated.md` finds a gap; the gap decomposes into (a) genuinely missing entries (curatable in PR) + (b) intentional pedagogical exclusions (templates, workbooks, games — by design). PR scope = only (a). Determined via entry-level diffing (not just counters) per L736 hub-count lesson.

## Refs

- See #7422 (epic partial contribution)
- See #3979 (docs/ + curriculum broadly)
- See #3973 (Genesis IA Series docs)
- Lessons cited: L736 (hub 3 count-systems), L683 (multi-line surgical fix canon), L897 (cross-lane collision check), L741 (counter stale dispersés grep exhaustif)

🤖 Generated with [Claude Code](https://claude.com/claude-code)