### PR TITLE
docs(tooling): generate_parcours emits do-not-hand-edit header on parcours pages

### DIFF
--- a/scripts/notebook_tools/generate_parcours.py
+++ b/scripts/notebook_tools/generate_parcours.py
@@ -126,6 +126,18 @@ def generate_parcours_page(
     """Generate markdown page for a single parcours."""
     config = PARCOURS[parcours_id]
     lines = [
+        "<!--",
+        "  FICHIER GENERE — ne pas editer a la main.",
+        "  Cette page de parcours est derivee du catalogue de notebooks par",
+        "  scripts/notebook_tools/generate_parcours.py, puis regeneree chaque jour",
+        "  sur `main` par .github/workflows/catalog-cron.yml. Toute edition manuelle",
+        "  sera silencieusement ecrasee au prochain passage du cron. Pour corriger",
+        "  une derive (comptes, enumerations), corriger la SOURCE (le catalogue /",
+        "  les metadonnees de notebook) ou le generateur — jamais cette page.",
+        "  Cf .claude/rules/catalog-pr-hygiene.md (les artefacts generes",
+        "  appartiennent a l'automatisation).",
+        "-->",
+        "",
         f"# {config['title']}",
         "",
         f"**{config['subtitle']}**",


### PR DESCRIPTION
Grain: MED/tooling — lane myia-ai-01:CoursIA — prev: MED/docs-harness (#7842 PR-template Grain scaffold)

## Summary

- `docs/curriculum/*.md` are **fully generated** by `generate_parcours.py` and regenerated daily on `main` by `catalog-cron.yml`, but the pages had **no marker** saying so.
- PR #7874 hand-edited two of them to reconcile drifted counts — the exact poison pattern `catalog-pr-hygiene.md` forbids for the catalog (manual edit to a generated, cron-owned artifact → silently reverted next cron run).
- This prepends an HTML-comment header (invisible in rendered markdown) at the top of each generated page, directing future fixes to the **source** (catalog / generator), never the page.

## Scope (atomic, generator-only)

- `scripts/notebook_tools/generate_parcours.py` — one prepended header block in `generate_parcours_page()`.
- **No `.md` regenerated on this branch** — the branch stays byte-identical to `main` for `docs/curriculum/` (catalog-pr-hygiene HARD-1). The header lands on the next daily cron run.

## Verification

- `python scripts/notebook_tools/generate_parcours.py --parcours genai --dry-run` → header renders at page top, page body unchanged.
- `git status docs/curriculum/` clean (dry-run writes nothing; branch does not touch generated pages).

See #7422 (docs/ hygiene). Prevents recurrence of the #7874 poison class.