### PR TITLE
fix(planners,#3801): Planners-7-OR-Tools cell 7 CP-SAT makespan 9 -> 5 (un-gated no-overlap)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-7-OR-Tools.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-7-OR-Tools.ipynb
@@ -248,17 +248,17 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "Statut: OPTIMAL\n",
-      "Makespan optimal: 9\n",
+      "Makespan optimal: 5\n",
       "\n",
       "Assignation des taches:\n",
       "----------------------------------------\n",
-      "  Tache 0: Machine 1, Start=6, End=9\n",
-      "  Tache 1: Machine 0, Start=4, End=6\n",
-      "  Tache 2: Machine 0, Start=0, End=4\n"
+      "  Tache 0: Machine 0, Start=2, End=5\n",
+      "  Tache 1: Machine 0, Start=0, End=2\n",
+      "  Tache 2: Machine 1, Start=0, End=4\n"
      ]
     }
    ],
@@ -294,13 +294,14 @@
     "            model.Add(machine[i] == machine[j]).OnlyEnforceIf(same_machine)\n",
     "            model.Add(machine[i] != machine[j]).OnlyEnforceIf(same_machine.Not())\n",
     "            \n",
-    "            # i avant j OU j avant i (si meme machine)\n",
+    "              # i avant j OU j avant i (uniquement si meme machine)\n",
     "            i_before_j = model.NewBoolVar(f'{i}_before_{j}')\n",
-    "            model.Add(end[i] <= start[j]).OnlyEnforceIf(i_before_j)\n",
-    "            model.Add(end[j] <= start[i]).OnlyEnforceIf(i_before_j.Not())\n",
-    "            \n",
-    "            # Au moins une des conditions doit etre vraie si meme machine\n",
-    "            model.AddBoolOr([same_machine.Not(), i_before_j, i_before_j.Not()])\n",
+    "            # Non-chevauchement GATE sur meme machine : OnlyEnforceIf([same_machine, X])\n",
+    "            # active la contrainte seulement si same_machine ET X sont vrais.\n",
+    "            # Si les taches sont sur des machines differentes (same_machine=False),\n",
+    "            # aucune contrainte d'ordre n'est imposee -> elles s'executent en parallele.\n",
+    "            model.Add(end[i] <= start[j]).OnlyEnforceIf([same_machine, i_before_j])\n",
+    "            model.Add(end[j] <= start[i]).OnlyEnforceIf([same_machine, i_before_j.Not()])\n",
     "    \n",
     "    # Objectif : minimiser le makespan (temps de fin maximum)\n",
     "    makespan = model.NewIntVar(0, horizon, 'makespan')\n",
@@ -342,20 +343,21 @@
    "source": [
     "### Interpretation du résultat\n",
     "\n",
-    "**Sortie obtenue** : Le solveur trouve une assignation optimale des tâches aux machines.\n",
+    "**Sortie obtenue** : Le solveur CP-SAT trouve une assignation **optimale** des 3 tâches sur 2 machines avec un **makespan de 5** unités de temps.\n",
     "\n",
     "| Tâche | Machine | Debut | Fin |\n",
     "|-------|---------|-------|-----|\n",
-    "| 0 | Variable | Variable | Variable |\n",
-    "| 1 | Variable | Variable | Variable |\n",
-    "| 2 | Variable | Variable | Variable |\n",
+    "| 0 | M0 | 2 | 5 |\n",
+    "| 1 | M0 | 0 | 2 |\n",
+    "| 2 | M1 | 0 | 4 |\n",
     "\n",
     "**Points cles** :\n",
-    "1. Le modèle utilise des variables entieres pour les temps\n",
-    "2. Les contraintes de non-chevauchement sont exprimees avec des implications\n",
-    "3. L'objectif est de minimiser le makespan (temps de completion maximum)\n",
+    "1. **Parallélisme réel** : la Tâche 2 (durée 4) s'exécute sur M1 **en parallèle** des Tâches 1 puis 0 qui s'enchaînent sur M0. Le makespan (5) est donc **strictement inférieur** à la somme des durées (3+2+4 = 9) : c'est précisément le bénéfice d'avoir plusieurs machines.\n",
+    "2. **Non-chevauchement sur une même machine** : sur M0, la Tâche 1 [0–2] précède la Tâche 0 [2–5] sans chevauchement. La contrainte d'ordre est **activée uniquement pour les paires de tâches sur la même machine** (booléen `same_machine`), ce qui laisse les tâches de machines différentes se chevaucher librement.\n",
+    "3. **Optimalité** : on ne peut pas faire mieux que 5. D'une part la charge totale (9 unités) répartie sur 2 machines donne une borne inférieure de ⌈9/2⌉ = 5 ; d'autre part la plus longue tâche dure 4 ≤ 5. Les deux bornes coïncident avec le makespan trouvé, qui est donc optimal.\n",
+    "4. **Variables entières et booléennes** : le modèle utilise des `IntVar` pour les temps (début/fin) et la machine assignée, et des `BoolVar` (`same_machine`, `i_before_j`) pour les décisions d'ordonnancement conditionnel exprimées via `OnlyEnforceIf`.\n",
     "\n",
-    "> **Note technique** : CP-SAT utilise des techniques de propagation de contraintes et de recherche SAT pour explorer efficacement l'espace des solutions."
+    "> **Note technique** : CP-SAT combine propagation de contraintes et recherche SAT moderne (CDCL) pour **prouver l'optimalité** du makespan, et non seulement trouver une solution faisable. La résolution par programmation par contraintes se distingue de la planification PDDL (recherche dans l'espace d'états) en raisonnant directement sur les variables et leurs relations.\n"
    ]
   },
   {


### PR DESCRIPTION
Grain: DEEP/code-correctness — lane myia-po-2025:CoursIA — prev: MED/doc-honesty (#7872 SW-13)

## Defect (Prong-B #3801, code-correctness)

`Planners-7-OR-Tools.ipynb` cell 7 — the introductory CP-SAT scheduling example (§2.1, 3 tasks / 2 machines) — produced **makespan 9** (the worst case: full serialization = sum of durations 3+2+4) instead of the genuine optimum **5**. The notebook's printed claim "Makespan optimal: 9" was false on its face (9 is the *worst* feasible, not the optimum).

## Root cause (G.1 firsthand-verified)

The no-overlap ordering constraints were **not gated on `same_machine`**:

```python
i_before_j = model.NewBoolVar(f'{i}_before_{j}')
model.Add(end[i] <= start[j]).OnlyEnforceIf(i_before_j)
model.Add(end[j] <= start[i]).OnlyEnforceIf(i_before_j.Not())
model.AddBoolOr([same_machine.Not(), i_before_j, i_before_j.Not()])  # tautology
```

Since `i_before_j` is a free bool (True or False), exactly ONE ordering constraint was active for **every** task pair regardless of machine -> all tasks serialized -> makespan = sum = 9. The `AddBoolOr([same_machine.Not(), i_before_j, i_before_j.Not()])` was a **tautology** (`i_before_j OR ~i_before_j == True`) and gated nothing.

This is Prong-B (#3801): the CP-SAT engine's distinctive capacity — parallel multi-machine scheduling with optimal makespan **strictly less** than the sum of durations — was completely defeated. It returned the serial solution a trivial greedy would produce.

## Fix (minimal, pedagogical, consistent with the notebook)

Gate the two ordering constraints on `same_machine` via `OnlyEnforceIf([list])` (enforce only if ALL listed bools are true) and drop the tautological `AddBoolOr`:

```python
model.Add(end[i] <= start[j]).OnlyEnforceIf([same_machine, i_before_j])
model.Add(end[j] <= start[i]).OnlyEnforceIf([same_machine, i_before_j.Not()])
```

- `same_machine=False` (different machines): neither ordering enforced -> tasks may overlap (parallel)
- `same_machine=True`: `i_before_j` is free; the solver picks the order minimizing makespan; exactly one constraint active -> no overlap

Consistent with the notebook's own Job-Shop cell 15, which uses the correct `AddNoOverlap` idiom — so the author knew the right pattern; only the introductory example carried the buggy un-gated version.

## Real re-execution (rule F, OR-Tools 9.15)

Re-executed cell 7 with the real OR-Tools CP-SAT solver. New committed output:

```
Statut: OPTIMAL
Makespan optimal: 5

Assignation des taches:
  Tache 0: Machine 0, Start=2, End=5
  Tache 1: Machine 0, Start=0, End=2
  Tache 2: Machine 1, Start=0, End=4
```

Makespan 5 = max(5, 4): Tache 1 [0-2] then Tache 0 [2-5] on M0 (sequential, same machine), Tache 2 [0-4] on M1 (parallel). Lower bound `ceil(9/2) = 5` reached -> optimal proven by CP-SAT. The engine now visibly demonstrates its value (parallelism, optimal makespan < sum).

## Cell 8 markdown (interpretation aligned to committed output)

Rewrote the placeholder table ("Variable" x12) into the **real schedule**, with: (1) parallelism explanation (makespan 5 < sum 9 = the benefit of multiple machines), (2) same-machine no-overlap note, (3) optimality argument (load-balance bound `ceil(9/2)=5` = max single-task bound, both reached), (4) integer/boolean variable types.

## Validation

- **nbformat validate OK** (49 cells)
- **Scope**: cell 7 (source + outputs), cell 8 (source markdown). **47 other cells byte-identical to origin/main**.
- **H.1 EXEC_PROVED**: cell 7 re-executed with real OR-Tools 9.15; exec_count=2, real stdout transplanted (no hand-edit, Stop & Repair respected).
- **C.1 clean**: 0 `NotImplementedError` / `assert False` in changed cells.
- **0 leaks**: no path / IP / username in cell 7 output.
- **CRLF=0, LF, UTF-8 no-BOM, trailing newline.**
- Preexisting validator warning unchanged (1 on both origin/main and this branch — not introduced here).
- +21/-19, 1 file, 1 commit.

## SOTA verdict

**SOTA-OK** — the notebook invokes the real OR-Tools CP-SAT solver, and the fix restores the engine's distinctive parallel-scheduling capacity (makespan 5, not the degenerate serial 9). No workaround, no fabricated numbers.

## Method

Defect found via focused Explore scan (sonnet, read-only, Planning family — un-scanned this cluster). **G.1 firsthand-verified before action**: reproduced the tautology + un-gated ordering; tested the fix standalone -> makespan 5 OPTIMAL with genuine parallelism, before touching the notebook.

See #3801.

Generated with Claude Code
