### PR TITLE
fix(infer): Infer-7-Skills-IRT cell 16 sigma-uncertainty claim backwards (intermediaires vs extremes)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb
@@ -1485,7 +1485,7 @@
     "Cela correspond aux taux de réussite observés (80%, 70%, 50%, 30%, 20%).\n",
     "\n",
     "**Avantage du modèle IRT sur le score brut** :\n",
-    "- L'**écart-type** reflète l'incertitude (plus grande pour les scores intermédiaires)\n",
+    "- L'**écart-type** reflète l'incertitude : elle est **plus grande aux scores extrêmes** (0/5 et 5/5 : sigma ≈ 0,67) et **plus faible aux scores intermédiaires** (2/5, 3/5 : sigma ≈ 0,59-0,60). Effet de **plafond/plancher** : un élève qui réussit tout (5/5) ou rate tout (0/5) sature les items, et le modèle ne peut pas situer sa capacité exacte au-delà de ce que les items mesurent ; les scores intermédiaires, eux, engagent les items discriminants proches du niveau de l'élève, ce qui resserre le posterieur.\n",
     "- La capacité tient compte de la **difficulté des questions réussies**\n",
     "- Un étudiant qui réussit Q5 (difficile) a une capacité plus élevée qu'un autre avec le même score mais sur des questions faciles"
    ]


### PR DESCRIPTION
Grain: MED/doc-honesty — lane myia-po-2025:CoursIA — prev: MED/fix-functional-bug (#7886 Planners-5)

## Defect (conceptual doc-honesty, IRT uncertainty claim backwards)

`Infer-7-Skills-IRT.ipynb` cell 16 — the "Avantage du modèle IRT sur le score brut" bullet — claimed posterior uncertainty (the reported sigma) is **"plus grande pour les scores intermédiaires"**. This is backwards.

## G.1 firsthand verification (committed cell-12 output)

The Infer.NET posterior sigmas, by score, form a clear **inverted-U**:

| Score | Sigma (committed cell 12) |
|-------|---------------------------|
| 0/5   | 0,67  (Etudiant 5)        |
| 5/5   | 0,67  (Etudiant 9)        |
| 4/5   | 0,61-0,62                  |
| 1/5   | 0,61-0,62                  |
| 2/5   | 0,59-0,60                  |
| 3/5   | 0,59-0,60                  |

Uncertainty is **LARGEST at the extremes** (0/5 and 5/5: ~0,67) and **SMALLEST at the middle** (2/5, 3/5: ~0,59-0,60). The original claim said the opposite, contradicting both the notebook's own committed output and IRT theory.

**Why the real pattern holds** (floor/ceiling effects): a student who answers everything right (5/5) or everything wrong (0/5) saturates the items — the model can infer they are above/below the items' range but cannot pin *how far*, leaving a wide posterior. Intermediate scores engage the discriminating items near the student's ability level, which tighten the posterior. This is the canonical IRT information curve.

## Fix (markdown-only, C.2 exception)

Corrected the bullet to state the real pattern, grounded in the committed sigma values, and added the conceptual explanation (plafond/plancher effects at the extremes vs discriminating items pinning intermediate scores). The committed cell-12 output is already correct — only the interpretation was wrong, so no re-execution is needed (C.2 markdown-only exception).

## Validation

- **nbformat validate OK** (74 cells)
- **Scope**: cell 16 (source markdown). **73 other cells byte-identical to origin/main**.
- **C.1 clean**: no `NotImplementedError`/`assert False` in changed cell.
- **CRLF=0, LF, UTF-8 no-BOM, trailing newline.**
- Preexisting validator warning unchanged (1 on both origin/main and this branch).
- +1/-1, 1 file, 1 commit.

## SOTA verdict

**SOTA-OK** — the Infer.NET IRT model runs correctly (cell-12 sigmas are the real posterior); this fix only corrects the markdown interpretation to match the real output and IRT theory. No workaround, no fabricated claim.

## Method

Defect found via Explore sonnet scan (read-only, Probas/Infer family — fresh, untouched this cluster). **G.1 firsthand-verified before action**: extracted all sigma values from the committed cell-12 output and confirmed the inverted-U pattern. Notably, the Explore scan flagged 2 "Class A code bugs" in the Infer family (Infer-13 Dirichlet prior, Infer-15 cold-start weights) that firsthand inspection revealed were **already honestly documented** by the notebooks themselves (Infer-13 cell 22 explains the prior artifact; Infer-15 cells 44/45 declare the simulation) — confirming the need to G.1-verify every Explore finding rather than act on the scan label alone.

See #3801.

Generated with Claude Code
