### PR TITLE
fix(notebook-tools,#5780): detect indented 'pass' stubs via re.MULTILINE (follow-up #7885 orphaned by merge race)

### DIFF
--- a/scripts/notebook_tools/detect_solution_leaks.py
+++ b/scripts/notebook_tools/detect_solution_leaks.py
@@ -57,7 +57,10 @@ def is_stub_code(source: str) -> bool:
         return True
 
     for pattern in STUB_PATTERNS:
-        if re.search(pattern, source, re.IGNORECASE):
+        # re.MULTILINE so anchored patterns like `^\s*pass\s*$` match an
+        # INDENTED `pass` inside a function body (the real-world stub case),
+        # not just a top-level `pass` at the start of the cell source.
+        if re.search(pattern, source, re.IGNORECASE | re.MULTILINE):
             return True
 
     code_lines = [l for l in non_empty if not l.startswith('import ') and not l.startswith('from ')]

--- a/scripts/notebook_tools/tests/test_detect_solution_leaks.py
+++ b/scripts/notebook_tools/tests/test_detect_solution_leaks.py
@@ -54,6 +54,23 @@ class TestIsStubCode:
     def test_pass_is_stub(self):
         assert is_stub_code("pass") is True
 
+    def test_indented_pass_is_stub(self):
+        # Regression: the `^\s*pass\s*$` stub pattern requires re.MULTILINE to
+        # match an INDENTED `pass` inside a function body (the real-world stub
+        # case). Without MULTILINE it only matched a top-level `pass` at the
+        # start of the cell, so function-stub exercises (def f(): ... pass)
+        # were systematically false-positive as HIGH leaks across the Python
+        # notebooks (e.g. CSP-2 path_consistency).
+        code = (
+            'def path_consistency(csp, domains):\n'
+            '    """Apply path consistency."""\n'
+            '    # A COMPLETER\n'
+            '    # Pour chaque paire (Xi, Xj) ...\n'
+            '    pass\n'
+            'print("Exercice 2 : implementer path_consistency")\n'
+        )
+        assert is_stub_code(code) is True
+
     def test_print_exercice_a_completer(self):
         assert is_stub_code('print("Exercice a completer")') is True
 


### PR DESCRIPTION
Grain: MED/notebook-tools — lane myia-po-2024:CoursIA-2 — prev: DEEP/notebook-tools (#7885, just merged)

## Summary — follow-up to #7885, orphaned by a merge race

PR #7885 shipped **two** related root-cause fixes to `is_stub_code` in `scripts/notebook_tools/detect_solution_leaks.py`. The coordinator squash-merged #7885 as `63bd5b9f1` carrying **commit 1 only** (C# `// TODO` parity, 308→126) — commit 2 (this fix) was pushed to the branch a few minutes later and landed orphaned on the closed branch, **not on `main`**. This PR re-delivers the orphaned commit 2 so `main` reaches the documented 308→116 state. Verified firsthand:

```
$ git show origin/main:scripts/notebook_tools/detect_solution_leaks.py | grep MULTILINE   # commit1-only main
(empty — MULTILINE absent)

$ git branch -r --contains ba8320fd7                      # orphaned commit 2
  origin/feature/c770-leak-detector-csharp-todo           # branch only, NOT origin/main
```

This is genuinely the **second** of two distinct root-cause bugs (not a re-scan variant): #7885 fixed a **missing language marker** (`// TODO`); this fixes **missing `re.MULTILINE`** on an anchored pattern — different code line, different regex semantics, different regression test.

## The bug

`STUB_PATTERNS` includes `r'^\s*pass\s*$'`. `is_stub_code` searched it **without `re.MULTILINE`**, so `^` anchored to the **start of the whole cell string only**. It matched a **top-level** `pass` (the unit test `test_pass_is_stub("pass")`) but **NOT** a `pass` **indented inside a function body** — the real-world stub case (`def f(): ... pass`). Every function-stub exercise was systematically false-positive as a HIGH leak.

Root cause proven firsthand:
```python
>>> import re; s = 'def f():\n    pass\n'
>>> bool(re.search(r'^\s*pass\s*$', s))              # no MULTILINE — the bug
False
>>> bool(re.search(r'^\s*pass\s*$', s, re.MULTILINE))  # with MULTILINE — the fix
True
```

## The fix

```python
    for pattern in STUB_PATTERNS:
        # re.MULTILINE so anchored patterns like `^\s*pass\s*$` match an
        # INDENTED `pass` inside a function body (the real-world stub case),
        # not just a top-level `pass` at the start of the cell source.
        if re.search(pattern, source, re.IGNORECASE | re.MULTILINE):
            return True
```

Only the **anchored** `^\s*pass\s*$` pattern is affected. Unanchored markers (`# TODO`, `// TODO`, `return None`, `print(...a completer)`, `Console.WriteLine(...)`) match anywhere regardless of flags, so they are unchanged.

## Empirical proof (G.1 firsthand)

| Scope | main (commit 1 only) | this branch (+ commit 2) |
|-------|----------------------|--------------------------|
| `--scan CSP-2-Consistency` | `path_consistency` c58 flagged HIGH | **0 HIGH** |
| `--scan-all` (repo-wide) | 126 HIGH | **113 HIGH** (−13; count drifts as main advances) |

(The repo-wide absolute count drifts as `main` advances — new commits land — so the **per-notebook** delta is the reliable signal; CSP-2 path_consistency HIGH→0 is the canonical proof.)

## Why this is safe (no real leak hidden)

Firsthand PAR-CONTENU: the stubs caught by this fix (e.g. CSP-2 `path_consistency`) are genuine C.1 stubs — `def path_consistency(csp, domains): """...""" # A COMPLETER ... pass`. A completed solution does not carry a bare `pass` by doctrine, so recognizing indented `pass` as a stub marker **cannot mask a real leak**. The fix only changes the flags on the existing anchored pattern — nothing else tightens.

## Verification

- `pytest scripts/notebook_tools/tests/test_detect_solution_leaks.py` → **49 passed** (47 + 2 regressions: `test_csharp_multiline_todo_stub` from #7885 + `test_indented_pass_is_stub` from this PR).
- `detect_solution_leaks.py --scan CSP-2-Consistency` → 0 HIGH (was: path_consistency HIGH).
- Cherry-picked clean onto fresh `origin/main` (16baa2529); no conflicts.

## Scope (anti-régression D, catalog-pr-hygiene R1, C.3)

- **2 files, +21/-1**: `detect_solution_leaks.py` (+MULTILINE comment/flags) and its test (+1 regression). No notebook touched (C.2/C.3 n/a).
- Catalog byte-identique (R1 ✓). No secret, no absolute `c:/dev` path.
- Distinct root cause from #7885 (marker parity vs regex anchoring) — same detector family, genuinely distinct substance, not a scan-generated variant.

See #5780. refs #7885.