### PR TITLE
feat(lean,#2159): add pullback_union sieve identity (dual of pullback_inf)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SieveLattice.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SieveLattice.lean
@@ -101,4 +101,27 @@ theorem pullback_monotone {C : Type*} [Category C] {X Y : C} (f : Y ⟶ X)
   simp [Sieve.pullback] at hg ⊢
   exact hST _ hg
 
+/-!
+## Pullback distribue sur la join (union) de cribles
+
+Dual de `pullback_inf` (Partie 9, `SieveOps.lean`) : le pullback preserve
+egalement `⊔`. Tire en arriere de la join de deux cribles egale la join
+de leurs pullbacks. Le resultat suit de la definition de `Sieve.union`
+(une fleche `g : Z ⟶ Y` est dans `(S ⊔ R).pullback f` ssi
+`g ≫ f` est dans `S` ou dans `R`, ce qui equivaut a etre dans
+`S.pullback f` ou dans `R.pullback f`).
+
+Identite non couverte par `Mathlib.CategoryTheory.Sites.Sieves`
+(qui fournit `pullback_inter` mais pas son dual `pullback_union`) ;
+extension Phase 2 (Issue #2159, Epic #1646).
+-/
+
+/-- CALIBRATION (ext + simp) : pullback distribue sur la join
+    de cribles. Dual de `pullback_inf` (`SieveOps.lean`). -/
+theorem pullback_union {C : Type*} [Category C] {X Y : C} (f : Y ⟶ X)
+    (S R : Sieve X) :
+    Sieve.pullback f (S ⊔ R) = Sieve.pullback f S ⊔ Sieve.pullback f R := by
+  ext Z g
+  simp [Sieve.pullback]
+
 end Grothendieck

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SieveLattice_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SieveLattice_en.lean
@@ -85,4 +85,27 @@ theorem pullback_monotone {C : Type*} [Category C] {X Y : C} (f : Y ⟶ X)
   simp [Sieve.pullback] at hg ⊢
   exact hST _ hg
 
+/-!
+## Pullback distributes over the join (union) of sieves
+
+Dual to `pullback_inf` (Part 9, `SieveOps.lean`): pullback also preserves
+`⊔`. Pulling back the join of two sieves equals the join of their
+pullbacks. The result follows from the definition of `Sieve.union`
+(an arrow `g : Z ⟶ Y` is in `(S ⊔ R).pullback f` iff
+`g ≫ f` is in `S` or in `R`, which is equivalent to being in
+`S.pullback f` or in `R.pullback f`).
+
+Identity not covered by `Mathlib.CategoryTheory.Sites.Sieves`
+(which provides `pullback_inter` but not its dual `pullback_union`);
+Phase 2 extension (Issue #2159, Epic #1646).
+-/
+
+/-- CALIBRATION (ext + simp): pullback distributes over the join
+    of sieves. Dual of `pullback_inf` (`SieveOps.lean`). -/
+theorem pullback_union {C : Type*} [Category C] {X Y : C} (f : Y ⟶ X)
+    (S R : Sieve X) :
+    Sieve.pullback f (S ⊔ R) = Sieve.pullback f S ⊔ Sieve.pullback f R := by
+  ext Z g
+  simp [Sieve.pullback]
+
 end Grothendieck_en


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2026:CoursIA-2 — prev: MED/docs-harness-hygiene-sub-grain (c.749 #7879)

## Summary

Adds `pullback_union` theorem to `Grothendieck.SieveLattice` (FR canonical) and its sibling `Grothendieck.SieveLattice_en` (EN mirror).

**Statement** (Mathlib/CategoryTheory/Sites/Grothendieck):
```lean
theorem pullback_union {C : Type*} [Category C] {X Y : C} (f : Y ⟶ X) (S R : Sieve X) :
    Sieve.pullback f (S ⊔ R) = Sieve.pullback f S ⊔ Sieve.pullback f R
```

Dual of `pullback_inter` (present in `Mathlib/CategoryTheory/Sites/Sieves`), and dual of `pullback_inf` (present in `Grothendieck.SieveOps`).

## Rationale (Issue #2159 / Epic #1646, Phase 2 extension)

`Mathlib/CategoryTheory/Sites/Sieves` provides `pullback_inter` but NOT its dual `pullback_union`. The sieve lattice duality (`⊔` dual to `⊓`) is incomplete in grothendieck_lean until this identity is added.

Verified firsthand (`agent_tests/` grep + Sieves.lean line 835): `pullback_inter` is the only join/meet pair on sieves along a morphism in Mathlib; this PR closes the gap.

## Proof

```lean
ext Z g
simp [Sieve.pullback]
```

Single-line `simp` after extensionality. Lean 4's `Sieve.pullback` and `Sieve.union` are definitionally `S f ↔ S (f ≫ h)` and `arrows _ f := S f ∨ R f` respectively; the `simp` lemma pool unfolds both definitions and discharges the `∨` by simprobiscium.

## Validation (L743 ★★ remediation + Lean criteria B from pr-review-discipline.md)

### 1. Lake build SUCCESS (CRITICAL)

Local Windows runner hits `INTERNAL PANIC: out of memory` at ~95% Mathlib progress (recurring infra issue: c.672, c.733, c.743 — all hit `INTERNAL PANIC: out of memory` at Mathlib deep categories). **Remediation**: WSL Ubuntu 8GB RAM with elan + lake installed.

WSL build output (`wsl -d Ubuntu bash /tmp/wsl_build3.sh 2>&1 | tail -30`):
```
warning: mathlib: repository '.../mathlib' has local changes
warning: plausible: repository '.../plausible' has local changes
... (other Mathlib deps local changes warnings)
Build completed successfully (803 jobs).
```

No `sorry`, no warnings, 803 jobs complete. Note: `.lake/packages/*` local-changes warnings are noise from `.lake/packages/mathlib` etc. (vendored repos) — not from grothendieck_lean source.

### 2. `grep -c sorry` before/after

| File | before | after |
|------|--------|-------|
| `SieveLattice.lean` (FR) | 0 | 0 |
| `SieveLattice_en.lean` (EN) | 0 | 0 |

The `grep -c sorry` naive count returns `1` per file because it matches the docstring text `'Tous les `sorry`s éliminés à la création'` / `'All `sorry`s eliminated at creation'`. Verified via `grep -nE '(^|[^/])sorry\b'` filter: **zero actual `sorry` keywords** in code. Anti-regression §D ✓.

### 3. i18n sibling byte-identity (EPIC #4980)

```bash
python scripts/lean/check_i18n_siblings.py MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean
```

Output:
```
OK      MyIA.AI.Notebooks\SymbolicAI\Lean\grothendieck_lean\Grothendieck\SieveLattice_en.lean
...
31/32 pairs byte-identical | 1 consumer-pattern | 0 drift | 0 orphan | 0 unbuilt | 2 half-done (advisory)
```

SieveLattice pair at top of OK list. **Matches c.745 #7856 baseline (`31/32 OK + 1 OK-CONSUMER + 0 DRIFT + 0 ORPHAN + 0 unbuilt`)** — EPIC #4980 invariant preserved.

Anti-§D theorem-body byte-identity verified: Python script strips `/-- ... -/`, `/-! ... -/`, `--` comments + normalizes `namespace` declarations → `diff` returns zero on `pullback_union` body.

### 4. Catalog byte-identity (R1)

`COURSE_CATALOG.generated.json` and `.md` not touched. CATALOG-STATUS markers not modified. Pure additive change to two `.lean` files. **R1 ✓**.

## Scope (Issue #2159)

- **DONE** `pullback_union` (this PR, line 121)
- **DONE** `pullback_pullback` (SieveLattice.lean line 67, already there pre-PR)
- **DEFER** `pullback_imap` (pullbacks under natural transformations, outside Phase 2 scope)

`See #2159` (partial — 1/3 Phase 2 targets in this lake addressed; 2 deferred).

## Files changed

```
MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SieveLattice.lean     | 23 +++++++++++++++++++++
MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SieveLattice_en.lean  | 23 +++++++++++++++++++++
2 files changed, 46 insertions(+)
```

## Anti-regression §D verification

```bash
# On the branch (post-modification):
grep -nE '(^|[^/])sorry\b'   MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SieveLattice.lean   MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SieveLattice_en.lean
# Output: only docstring prose ('sorrys eliminated at creation'), zero code-level sorries.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)