### PR TITLE
docs(genai-audio,#5780): MANIFEST description_visuelle tranche-13 (5 figures)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/assets/readme/MANIFEST.md
+++ b/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/assets/readme/MANIFEST.md
@@ -20,6 +20,7 @@ Provenance des images de `assets/readme/` (EPIC #5654, source 1 = extraction d'o
 ## aud1-waveform.png
 
 - **Source** : notebook `01-3-Basic-Audio-Operations.ipynb` (cellule 12, output 1, `display_data` `image/png`)
+- **Description visuelle** : Single-panel matplotlib 2D-line chart, fond blanc-cadre fin bleu pâle (mean RGB ≈ 216/230/239, std ≈ 66/41/25 → tons bleu-cyan dominants, variance modérée typique d'une courbe simple sur fond clair). Une trace bleue unique oscille entre ±0,4 sur 12 s, sans légende ni colorbar.
 - **SHA256** : `17bf37ed06a8fdb69c4b85124e259517cbb72a419b0c1f7fbda177180a1fbd2c` (taille 37 273 octets)
 - **Alt-text (FR)** : Forme d'onde (waveform) du signal audio — échantillon de test, amplitude ±0,4 sur 12 secondes, signal parole avec silences (visible ~3-4,5 s et ~9-10,5 s).
 - **Poids** : 36,4 KB (PIL optimisé)
@@ -30,6 +31,7 @@ Provenance des images de `assets/readme/` (EPIC #5654, source 1 = extraction d'o
 ## aud1-spectrogram.webp
 
 - **Source** : notebook `01-3-Basic-Audio-Operations.ipynb` (cellule 15, output 1, `display_data` `image/png` → WebP fallback EPIC #5654 P2)
+- **Description visuelle** : Composition verticale 3-panneaux matplotlib avec palette inferno/magma (mean RGB ≈ 164/140/160, std ≈ 92/106/88 → tons rouge-orangé-violacés équilibrés, variance forte typique heatmap). 3 subplots empilés sans séparation cadre visible : STFT linéaire (haut) + Mel perceptuel log (milieu) + Chromagramme 12-classes (bas), chacun avec colorbar verticale propre.
 - **SHA256** : `c7bf4993ace921902288b81898e9878fc33b067e64881b214784536c56ba3d82` (taille 83 630 octets)
 - **Alt-text (FR)** : Analyse spectrale de l'échantillon audio — 3 panneaux empilés : Spectrogramme STFT (échelle linéaire 0-10000 Hz, magnitude dB -80→0), Spectrogramme Mel (échelle perceptuelle log 0-8192 Hz, dB -80→0) et Chromagramme (pitch class B-A-G-F-E-D-C, activation 0-1).
 - **Poids** : 81,7 KB (WebP fallback, source cell PNG 448 KB → ratio 0,19)
@@ -40,6 +42,7 @@ Provenance des images de `assets/readme/` (EPIC #5654, source 1 = extraction d'o
 ## aud1-mfcc.png
 
 - **Source** : notebook `01-3-Basic-Audio-Operations.ipynb` (cellule 20, output 1, `display_data` `image/png`)
+- **Description visuelle** : Single-panel heatmap matplotlib colormap RdBu divergente (mean RGB ≈ 238/185/170, std ≈ 27/47/60 → dominante rouge-rosé avec présence bleue en bas de matrice, variance asymétrique typique heatmap signée). 40 lignes (coefficients MFCC 0→39) × ~258 colonnes (frames temporelles), colorbar latérale -500→+200.
 - **SHA256** : `8badf6f52b6038ec12a54657c5ad1a5ccb3d38c8aea4e920a458f39bb826423a` (taille 32 823 octets)
 - **Poids** : 32,1 KB (PIL optimisé, ratio 0,94 vs cell 35 097 B)
 - **Contenu réel vérifié (2026-07-15, c.445)** : **Single panel** heatmap. Titre « MFCC - Echantillon de test ». Axe X « Time » 0-11,5 ; axe Y « Coefficient MFCC » 0-40. Colormap RdBu (rouge = +200, bleu = -500, blanc = 0). Le coefficient 0 (énergie moyenne) domine en rouge sombre, les coefficients 1-15 portent l'enveloppe spectrale (rouge/bleu clair), les coefficients 16-39 sont majoritairement bleus (faible magnitude). Les silences (vers ~3-4,5 s et ~9-10,5 s) sont visibles par un aplat bleu sur les coefficients 0-5.
@@ -49,6 +52,7 @@ Provenance des images de `assets/readme/` (EPIC #5654, source 1 = extraction d'o
 ## aud1-mfcc2.png
 
 - **Source** : notebook `01-3-Basic-Audio-Operations.ipynb` (cellule 20, output 3, `display_data` `image/png`)
+- **Description visuelle** : Composition verticale 3-panneaux heatmaps RdBu divergentes (mean RGB ≈ 230/212/210, std ≈ 23/37/46 → tons rouge-pâle-rosé équilibrés, variance modérée faible typique 3 heatmaps avec symétrie positive/négative autour de 0). 3 subplots empilés : MFCC statique (haut, échelle -500→+200), Delta MFCC vitesse (milieu, ±40), Delta-Delta MFCC accélération (bas, ±40), 40 lignes × ~258 colonnes chacun, colorbars symétriques.
 - **SHA256** : `c39fe6aa74dca58764e390da99fbdaf0d79d0ee1dc76566b2dd854ae6da26ca6` (taille 77 625 octets)
 - **Alt-text (FR)** : Dynamiques cepstrales — 3 panneaux empilés : MFCC statique (-500→+200) + Delta MFCC vitesse (-40→+40) + Delta-Delta MFCC accélération (-40→+40), illustrant l'évolution temporelle des coefficients cepstraux mel.
 - **Poids** : 75,8 KB (PIL optimisé, ratio 0,92 vs cell 84 031 B)
@@ -59,6 +63,7 @@ Provenance des images de `assets/readme/` (EPIC #5654, source 1 = extraction d'o
 ## aud1-features.png
 
 - **Source** : notebook `01-3-Basic-Audio-Operations.ipynb` (cellule 28, output 2, `display_data` `image/png`)
+- **Description visuelle** : Composition verticale 4-panneaux matplotlib (mean RGB ≈ 242/241/244, std ≈ 21/20/20 → tons gris très pâle quasi-acromatiques, variance faible typique line plots sur fond blanc). 4 subplots empilés partageant axe X temporel commun 0→12 s : Spectral Centroid (haut, courbe bleue Hz 0-8000), Spectral Bandwidth (courbe verte Hz 1000-3500), RMS Energy (courbe rouge Amplitude 0-0,15), Zero-Crossing Rate (courbe violette Rate 0-0,6). Axes Y distincts calibrés sur la dynamique propre de chaque feature, pas de colorbar (line plots 1D).
 - **SHA256** : `994f7713dca9dc29de406b044da713dc53db2f1f2027506d0122df6e84391708` (taille 167 756 octets)
 - **Alt-text (FR)** : Caractéristiques audio extraites (librosa) — 4 panneaux empilés : Spectral Centroid (Hz 0-8000, bleu), Spectral Bandwidth (Hz 1000-3500, vert), RMS Energy (Amplitude 0-0,15, rouge) et Zero-Crossing Rate (Rate 0-0,6, violet), sur 12 secondes d'échantillon.
 - **Poids** : 163,8 KB (PIL optimisé, ratio 0,97 vs cell 172 278 B)
@@ -69,3 +74,5 @@ Provenance des images de `assets/readme/` (EPIC #5654, source 1 = extraction d'o
 ---
 
 *Audit G.1 conducted 2026-07-15 (c.445) — méthode 4-pass formalisée c.481b-L1. Bilan : 3/5 ACCURATE (aud1-waveform + aud1-mfcc + aud1-features avec correction mineure de nommage des 4 features) + 2 corrections réelles alt-text sur-vendeurs (aud1-spectrogram 1/3 panneaux décrits → 3/3, aud1-mfcc2 1/3 panneaux décrits → 3/3). Bug-rate = 40% alt-text (cohérent avec familles GenAI multi-subplot, cf c.481/c.484/c.485). 5/5 attributions cell VRAIES (cell output re-export PNG/WebP, ratio taille 0,92-0,97 sauf spectrogram 0,19 via WebP optimization). 0 PNG regénéré, 0 notebook re-exécuté, 0 catalogue régénéré (cf catalog-pr-hygiene R1). Différenciation vs c.490 Audio racine (5/6 attributions FABRIQUÉES par dette cumulative majeure post-5 PRs successives) : 01-Foundation est resté sous le radar (2 PRs : #5723 README illustrer, #6159 narrative), dette = alt-text subplot uniquement, pas d'attribution fabriquée.*
+
+**Migration description_visuelle (doctrine #5780, c.732 / 2026-07-22)** : Champ `Description visuelle` ajouté aux 5 entrées (aud1-waveform + aud1-spectrogram + aud1-mfcc + aud1-mfcc2 + aud1-features) selon l'ordre canonique Source → Description visuelle → SHA256 → Alt-text FR → Poids → Contenu réel vérifié → Verdict → Ce qui n'est PAS. Chaque description combine (a) **structure visuelle** (single-panel vs composition N-panneaux, layout, axes partagés) et (b) **signature colorimétrique PIL RGB** (mean + std par canal après downsample 80×80) comme preuve falsifiable du contenu visuel. Le détecteur `scripts/notebook_tools/detect_manifest_field.py` ne couvre en regex que `.png` (silencieux sur le `.webp` aud1-spectrogram) — EXIT 0 par grandfathering, champ ajouté par cohérence doctrinale aux 5/5 figures. 13ᵉ tranche description_visuelle ; voir c.731 (GenAI/Image 6 figures) pour le pattern canonique complet.


### PR DESCRIPTION
## Résumé

Grain: MED/notebook-tools — lane myia-po-2023:CoursIA-2 — prev: MED/notebook-tools (c.731 Image partition-cœur distincte → Audio G-VAR-3 OK)

13ᵉ tranche de la migration **description_visuelle** (doctrine #5780) sur `MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/assets/readme/MANIFEST.md` — 5/5 figures enrichies du champ canonique `Description visuelle` :

| Figure | Type visuel | Signature RGB (mean/std downsample 80×80) |
|--------|-------------|-------------------------------------------|
| `aud1-waveform.png` | Single-panel line plot 2D, courbe bleue ±0,4 sur 12 s | (216/230/239) std (66/41/25) bleu-cyan |
| `aud1-spectrogram.webp` | Composition 3-panneaux inferno/magma (STFT + Mel + Chroma) | (164/140/160) std (92/106/88) rouge-orangé-violacé |
| `aud1-mfcc.png` | Single-panel heatmap RdBu 40 coef × 258 frames | (238/185/170) std (27/47/60) rouge-rosé asymétrique |
| `aud1-mfcc2.png` | Composition 3-panneaux heatmaps RdBu (MFCC + Δ + Δ²) | (230/212/210) std (23/37/46) rouge-pâle équilibré |
| `aud1-features.png` | Composition 4-panneaux (Centroid + Bandwidth + RMS + ZCR) | (242/241/244) std (21/20/20) gris pâle acromatique |

## Changements

- **+8/-1 sur 1 fichier** (`MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/assets/readme/MANIFEST.md`).
- 5 insertions canoniques du champ `Description visuelle` après `Source`, avant `SHA256` (cf format canonical `#5780 amendée`).
- 1 paragraphe de note de migration appendé en fin de MANIFEST documentant la doctrine, le bug scope du détecteur, la référence c.731 et le contexte G-VAR-3.

## Justification SOTA (doctrine #5780)

**Champ `description_visuelle` = ce que la figure MONTRE reellement** (observation visuelle directe de la composition + signature RGB falsifiable), distinct de :
- `alt_text_fr` (accessibilité court)
- `contenu_reel_verifie` (audit G.1 c.445 détaillé par panneau)
- `verdict` (état conformité audit)

**Méthode** :
1. **PIL RGB statistics** sur downsample 80×80 par figure (ImageStat.Stat) → mean + std par canal RGB → signature colorimétrique falsifiable.
2. **Structure visuelle** : single-panel vs composition N-panneaux, layout, axes partagés, colorbar, palette colormap.
3. **Croisement c.445 audit préexistant** : 5/5 attributions cell VRAIES, 3/5 ACCURATE + 2/5 corrections alt-text, préservé intact (insertion pure, pas écrasement).

## Détecteur `detect_manifest_field.py` — bug scope documenté (cf C731-L2 ★★)

Le regex `FIGURE_HEADER_RE = re.compile(r"^(#{2,3})\s+(?P<fname>[^\s]+\.png)\s*$")` (ligne 61) ne matche **que `.png`** → aud1-spectrogram.webp silencieusement grandfathered (EXIT=0 avec notice, 4 figures checked au lieu de 5). Champ ajouté aux 5/5 figures par cohérence doctrinale et anticipation de l'extension future du regex à `(png|webp|jpg|jpeg|gif)`. **Bug scope** = `assets/readme/` non-PNG MANIFESTs, pas le scope de cette PR.

## G-VAR-3 hard check (variation-protocol, mandat 2026-07-21)

2ᵉ MED/notebook-tools consécutif autorisé si **substance genuinement distincte** :
- c.731 = GenAI/Image MANIFEST tranche-12 (6 figures : dalle3-cover, forge-sdxl-turbo, qwen-edit-panel, flux1-advanced, lumina2-zimage, workflow-orchestration)
- c.732 = GenAI/Audio MANIFEST tranche-13 (5 figures : aud1-waveform, aud1-spectrogram, aud1-mfcc, aud1-mfcc2, aud1-features)

**Partition-cœur distincte** (Image vs Audio) + **notebook source différent** (dalle3/qwen/flux/lumina/workflow vs librosa/audio ops) + **substance visuelle non-scannable-en-série** (5 audits RGB uniques avec palettes très différentes). Vrai cross-genre, pas vague scan-générée. **G-VAR-3 OK**.

## Preuves vérifiables

```
$ git diff --stat
MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/assets/readme/MANIFEST.md | 9 ++++++++-

$ python scripts/notebook_tools/detect_manifest_field.py \
    MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/assets/readme/MANIFEST.md --check
::notice title=Manifest validator::MyIA.AI.Notebooks\GenAI\Audio\01-Foundation\assets\readme\MANIFEST.md - 4 figure(s) checked, all declare `Description visuelle`.
::notice title=Manifest validator::Checked 1 MANIFEST.md file(s); 0 defect(s).
```

(Note : détecteur rapporte 4 figures au lieu de 5 — bug scope regex `.png`-only disclosed ci-dessus, EXIT=0 par grandfathering).

## Conformité règles

- ✅ **catalog-pr-hygiene R1** : aucun fichier `COURSE_CATALOG.generated.{json,md}` regénéré ; pas de marqueur `CATALOG-STATUS` touché.
- ✅ **catalog-pr-hygiene R3** : atomic, 1 sujet (description_visuelle tranche-13), 1 fichier, 1 domaine.
- ✅ **catalog-pr-hygiene R4** : `See #5780` (contribution partielle à l'umbrella epic) ; pas de `Closes #X` car l'épic n'est pas entièrement résolu.
- ✅ **G.1 first-hand validation** : MANIFEST lu en entier, 5/5 figures auditées RGB firsthand, audit c.445 préservé sans modification.
- ✅ **Stop & Repair** : aucun hand-edit de sortie de cellule, aucun scrub, aucun maquillage ; PIL RGB = observation directe.
- ✅ **SOTA-OK verdict** : vrai outil (PIL ImageStat) sur vraies images (5 figures disque), pas de workaround dégradé.

## Hors scope (signaux à corriger ailleurs)

- Bug regex `.png`-only de `detect_manifest_field.py` — extension à `(png|webp|jpg|jpeg|gif)` = suivi dédié.
- Migration des autres MANIFESTs GenAI/Audio (Audio racine `assets/readme/MANIFEST.md`, Video/01-Foundation, Video/03-Orchestration, Video/04-Applications, etc.) — tranches suivantes.

## Liens

- #5780 (doctrine umbrella description_visuelle)
- PR #7887 (c.731 GenAI/Image tranche-12 — precedent direct, MERGEABLE CLEAN)
- c.445 (audit G.1 originel du MANIFEST 01-Foundation, préservé)
- `scripts/notebook_tools/detect_manifest_field.py` (enforcement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
