### PR TITLE
fix(gametheory): GT-11-BayesianGames cell 21 reversed Cournot comparison (MOINS<->PLUS)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-11-BayesianGames.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-11-BayesianGames.ipynb
@@ -1008,9 +1008,9 @@
       "\n",
       "Observations:\n",
       "  - Avec info incomplete, les quantites sont differentes\n",
-      "  - Le type a cout bas produit MOINS qu'avec info complete\n",
+      "  - Le type a cout bas produit PLUS qu'avec info complete\n",
       "    (car il anticipe un adversaire potentiellement inefficace)\n",
-      "  - Le type a cout haut produit PLUS qu'avec info complete\n",
+      "  - Le type a cout haut produit MOINS qu'avec info complete\n",
       "    (car il anticipe un adversaire potentiellement efficace)\n"
      ]
     }
@@ -1041,9 +1041,9 @@
     "    print(\"\\n\" + \"=\"*60)\n",
     "    print(\"\\nObservations:\")\n",
     "    print(\"  - Avec info incomplete, les quantites sont differentes\")\n",
-    "    print(\"  - Le type a cout bas produit MOINS qu'avec info complete\")\n",
+    "    print(\"  - Le type a cout bas produit PLUS qu'avec info complete\")\n",
     "    print(\"    (car il anticipe un adversaire potentiellement inefficace)\")\n",
-    "    print(\"  - Le type a cout haut produit PLUS qu'avec info complete\")\n",
+    "    print(\"  - Le type a cout haut produit MOINS qu'avec info complete\")\n",
     "    print(\"    (car il anticipe un adversaire potentiellement efficace)\")\n",
     "\n",
     "compare_cournot_complete_incomplete()"


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA — prev: MED/notebook-python (#7901 GT-16)

## Defect (class A doc-honesty in stdout, G.1 firsthand-verified)

`GameTheory-11-BayesianGames.ipynb` cell 21 — the Cournot complete-vs-incomplete-info comparison — printed the observation direction **BACKWARDS**. The cell correctly computes and prints the quantities:
- Info complete: q(c=10)=30.0, q(c=30)=23.3
- Info incomplete: q(c_L)=31.67, q(c_H)=21.67

but then states:
- "Le type a cout bas produit **MOINS** qu'avec info complete" ← FALSE: 31.67 > 30.0
- "Le type a cout haut produit **PLUS** qu'avec info complete" ← FALSE: 21.67 < 23.3

The correct direction is the opposite: low-cost type produces MORE (31.67 > 30.0), high-cost type produces LESS (21.67 < 23.3).

## G.1 firsthand verification

The two **rationales** printed in the same block already match the CORRECT direction:
- cout bas "anticipe un adversaire potentiellement inefficace" → produces more (correct for PLUS),
- cout haut "anticipe un adversaire potentiellement efficace" → produces less (correct for MOINS).

And the cell-22 markdown immediately below states it correctly: "Le type a cout bas produit **PLUS** (31.67 vs 30.0)" / "Le type a cout haut produit **MOINS** (21.67 vs 23.3)". So cell 21 stdout contradicted both its own rationales and cell 22.

## Fix (2-word swap + real re-exec, rule F)

Swapped the two MOINS/PLUS words; kept the rationales (already correct). Re-exec cell 1 (imports) + cell 18 (`solve_cournot_bayesian`) + cell 21 with real Python; **numbers unchanged** (q_L=31.67, q_H=21.67), only the two observation lines corrected. Real stdout transplanted (Stop & Repair, no hand-edit).

## Validation

- **nbformat validate OK** (49 cells)
- **Scope**: cell 21 (2 print lines + output). **48 other cells byte-identical to origin/main** (surgical raw-json round-trip).
- **C.1 clean**, **0 leaks**, **CRLF=0, LF, UTF-8 no-BOM, trailing newline**. 4+/4-, 2 hunks, 1 file.

## SOTA verdict

**SOTA-OK** — the cell runs the real Bayesian-Cournot solver; this fix only corrects the two observation strings to match the real printed numbers. No workaround.

## Method

Defect found via Explore sonnet scan (read-only, GameTheory family). G.1 firsthand-verified: extracted committed cell-21 numbers + observation text and confirmed the reversal against the rationales and cell 22. Distinct substance from #7901 (mechanism-design IC completeness vs Bayesian-Cournot quantity comparison).

See #3801.

Generated with Claude Code
