### PR TITLE
fix(sudoku,#3801): Sudoku-18 Python twin stale-benchmark-numbers honesty (cells 37+40)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb
@@ -1777,15 +1777,15 @@
     "\n",
     "**Résultats cles du tableau** :\n",
     "\n",
-    "1. **Backtracking simple** echoue sur le puzzle Medium (timeout : 58770 ms) mais resout Easy (1.87 ms) et Hard (1862 ms) -- 2/3 résolus. Sans heuristique, l'arbre de recherche explose quand le nombre de cases vides depasse ~60.\n",
+    "1. **Backtracking simple** echoue sur le puzzle Medium (timeout apres 69543.50 ms, taux 0/1) mais resout Easy (1.27 ms), Hard (2218.89 ms) et Expert (899.20 ms) -- 3/4 résolus. Sans heuristique, l'arbre de recherche explose quand le nombre de cases vides depasse ~60.\n",
     "\n",
-    "2. **BT + MRV** resout les 3 puzzles (3/3), y compris le Medium en 37.58 ms la ou le backtracking simple explose. L'heuristique MRV aide enormêment, mais reste plus lent que la propagation (313 ms sur le puzzle Hard).\n",
+    "2. **BT + MRV** resout les 4 puzzles (4/4), y compris le Medium en 63.85 ms la ou le backtracking simple explose. L'heuristique MRV aide enormêment, mais reste plus lent que la propagation (444.52 ms sur le puzzle Hard).\n",
     "\n",
-    "3. **Norvig** est le champion absolu : 3/3 résolus, avec un temps moyen global de 3.25 ms/puzzle. La propagation de contraintes elimine la quasi-totalite de l'exploration.\n",
+    "3. **Norvig** est le champion absolu : 4/4 résolus, avec un temps moyen global de 8.14 ms/puzzle. La propagation de contraintes elimine la quasi-totalite de l'exploration.\n",
     "\n",
-    "4. **OR-Tools CP-SAT** est également 3/3 fiable a ~22 ms/puzzle (21.65). Legerement plus lent que Norvig sur ce problème en raison de l'overhead de construction du modèle, mais plus robuste a la mise a l'échelle.\n",
+    "4. **OR-Tools CP-SAT** est également 4/4 fiable a ~32 ms/puzzle (32.39). Legerement plus lent que Norvig sur ce problème en raison de l'overhead de construction du modèle, mais plus robuste a la mise a l'échelle.\n",
     "\n",
-    "**Surprise** : Les puzzles Hard ne sont pas les plus lents pour le backtracking simple. Cela s'explique par le fait que la difficulté humaine (nombre de techniques logiques nécessaires) ne correspond pas toujours a la difficulté algorithmique (taille de l'arbre de recherche)."
+    "**Surprise** : Les puzzles Hard ne sont pas les plus lents pour le backtracking simple -- c'est le Medium qui explose (timeout), parce qu'il cumule davantage de cases vides que le Hard. Cela rappelle que la difficulté humaine (nombre de techniques logiques nécessaires) ne correspond pas toujours a la difficulté algorithmique (taille de l'arbre de recherche)."
    ]
   },
   {
@@ -1898,9 +1898,9 @@
     "\n",
     "| Comparaison | Facteur | Observation |\n",
     "|-------------|---------|-------------|\n",
-    "| BT simple vs Norvig | ~15000x sur Medium | L'absence d'heuristique coute jusqu'a 4 ordres de grandeur |\n",
-    "| BT + MRV vs BT simple | ~1500x sur Medium | L'heuristique MRV seule apporte un gain massif |\n",
-    "| Norvig vs OR-Tools | ~7x | Performance comparable, Norvig légèrement plus rapide sur Python pur |\n",
+    "| BT simple vs Norvig | ~7500x sur Medium | L'absence d'heuristique coute jusqu'a 4 ordres de grandeur |\n",
+    "| BT + MRV vs BT simple | ~1100x sur Medium | L'heuristique MRV seule apporte un gain massif |\n",
+    "| Norvig vs OR-Tools | ~4x | Norvig environ 4x plus rapide en moyenne ; OR-Tools compense par sa robustesse a la mise a l'echelle |\n",
     "\n",
     "**Point remarquable** : Les puzzles Medium sont les plus discriminants. Ils ont suffisamment de cases vides (64 en moyenne) pour pieger les solveurs naifs, mais restent solvables en un temps raisonnable pour tous les solveurs informes. Les puzzles Hard, paradoxalement, ne sont pas les plus lents car ils ont parfois moins de cases vides mais des contraintes plus serrees qui guident mieux la propagation."
    ]


### PR DESCRIPTION
## Grain: MED/doc-honesty (po-2023)

## Summary

`Sudoku-18-Comparison-Python.ipynb` **cell[37]** (benchmark interpretation) and **cell[40]** (performance ratios) cited numbers from an **older 3-difficulty run** (Easy/Medium/Hard), contradicting the committed **4-difficulty** (Easy/Medium/Hard/Expert) code output of **cell[34]**.

The **C# twin was already fixed by #7758** (2026-07-21, merged); the **Python twin was missed**. This PR is the Python-side companion — verified firsthand against committed `cell[34]` output on the freshest `origin/main` (16baa2529, post-#7758).

## Defect (firsthand, vs committed cell[34] output)

cell[34] ground truth (4 difficulties, exec_count 13, committed):
```
Backtracking    : Easy 1.27  Medium 69543.50 (0/1 timeout)  Hard 2218.89  Expert 899.20  -> 3/4, 18165.71 ms/puzzle
BT + MRV        : 6.28 / 63.85 / 444.52 / 44.82            -> 4/4, 139.87 ms/puzzle
Norvig          : 3.41 / 9.30 / 7.49 / 12.35               -> 4/4, 8.14 ms/puzzle
OR-Tools CP-SAT : 25.91 / 43.66 / 30.03 / 29.95            -> 4/4, 32.39 ms/puzzle
```

| # | Stale claim (cell 37/40) | Committed truth (cell 34) |
|---|--------------------------|---------------------------|
| 1 | BT "2/3 resolus", Medium 58770ms, Easy 1.87, Hard 1862 | BT **3/4**, Medium **69543.50 (0/1 timeout)**, Easy 1.27, Hard 2218.89, +Expert 899.20 |
| 2 | BT+MRV "3/3", Medium 37.58, Hard 313 | BT+MRV **4/4**, Medium 63.85, Hard 444.52 |
| 3 | Norvig "3/3, 3.25 ms/puzzle" | Norvig **4/4, 8.14 ms/puzzle** |
| 4 | OR-Tools "3/3, ~22 ms (21.65)" | OR-Tools **4/4, ~32 ms (32.39)** |
| 5 | cell[40] BT-vs-Norvig "~15000x Medium" | **~7500x** (69543.50/9.30 = 7478x) |
| 6 | cell[40] BT+MRV-vs-BT "~1500x Medium" | **~1100x** (69543.50/63.85 = 1089x) |
| 7 | cell[40] Norvig-vs-OR-Tools "~7x" | **~4x** (32.39/8.14 = 3.98x) |

The benchmark was extended from 3 puzzles to 4 (Expert tier added, cf #5079) and re-run, but the interpretation markdown was never updated. The "2/3 → 3/4" and "3/3 → 4/4" rate drift is the unambiguous smoking gun.

## Fix — markdown-only number swap (C.2 exception)

Markdown-only: cell[34] committed output is **already correct** (valid exec_count 13, ran successfully), so no re-exec is needed (C.2 exception: markdown-only edit → previous outputs valid). Prose structure, pedagogical framing, and existing accent state preserved — NOT an accent pass (#2876 is a separate concern).

The "Surprise" point is reframed honestly: the new data shows **Medium** (not Hard) is the BT bottleneck (timeout) — because the Medium puzzles in this set carry more empty cells than the Hard ones, which cell[40]'s closing paragraph already explains qualitatively.

## Changes

| Cell | Change |
|------|--------|
| cell[37] (markdown) | 4 stale number sets swapped to match committed cell[34]; "Surprise" reframed (Medium = BT bottleneck). |
| cell[40] (markdown) | 3 stale ratios recomputed (~7500x / ~1100x / ~4x). |

66/68 cells **byte-identical to origin/main** (hash-verified source + outputs + exec_count + metadata).

## Validation

- **C.2 exception (markdown-only):** no code cell touched, no re-exec required; committed cell[34] output unchanged and authoritative.
- **C.1:** `validate_pr_notebooks` PASS (25 code cells), 0 `raise NotImplementedError`/`assert False`/`1/0`.
- **Surgical C.3:** 0 non-target drift; top-level `metadata` + `nbformat` byte-identical to origin/main.
- **Honesty (Stop & Repair):** no cell output hand-edited — only markdown source swapped; cell[34] output left exactly as committed.

See **#3801** (EPIC SOTA axe-2 doc-honesty registry). Partial contribution — `See #3801` (no auto-close). Companion to **#7758** (C# twin).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
