### PR TITLE
fix(smartcontracts): SC-8-DeFi cell 7 contradictory AMM k bullets (markdown-only)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-8-DeFi-Primitives.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-8-DeFi-Primitives.ipynb
@@ -368,10 +368,10 @@
     "| Impact prix | 1.96% | Glissement de 2000 a 1960.71 USDC/ETH |\n",
     "\n",
     "**Points cles** :\n",
-    "- Le fee de 0.3% est deduit du montant d'entree AVANT le calcul — ce montant alimente les reserves sans augmenter k\n",
+    "- Le fee de 0.3% est deduit du montant d'entree AVANT le calcul (10 ETH -> 9.97 ETH effectifs) ; dans cette simulation le fee (0.03 ETH) est ecarte, NON reinjecte dans les reserves — la constante k reste donc **exactement invariante** (2 000 000 000)\n",
     "- Le price impact de 1.96% pour un swap de 1% des reserves est typique d'un AMM a produit constant\n",
     "- Le prix effectif recu (1974.32 USDC/ETH) est inferieur au prix spot (2000 USDC/ETH) — cette différence est le slippage\n",
-    "- La constante k augmente legerement avec les fees, ce qui beneficie aux fournisseurs de liquidite"
+    "- Note : un vrai Uniswap-V2 **reinjecte** la fee dans le pool (k croit legerement a chaque swap, au benefice des fournisseurs de liquidite) ; cette simulation simplifiee ne modelise pas cette reinjecton, d'ou l'invariance exacte de k ci-dessus"
    ]
   },
   {


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-po-2025:CoursIA — prev: MED/notebook-dotnet (#7907 GT-11)

## Defect (class C doc-honesty, G.1 firsthand-verified, scan finding #3)

`SC-8-DeFi-Primitives.ipynb` cell 7 (markdown) interprets cell 4's Python AMM
`simulate_swap`. Two of its bullets directly **contradict each other AND the code**:

| Bullet | Claim | Reality (cell 4 code) |
|--------|-------|----------------------|
| 1 | "...ce montant **alimente les reserves** sans augmenter k" | The fee is **discarded**, not fed into reserves |
| 4 | "La constante k **augmente legerement** avec les fees..." | k is **exactly invariant** |

Cell 4 code:
```python
amount_in_with_fee = amount_in * (1 - fee/100)   # 10 ETH -> 9.97, fee 0.03 thrown away
new_reserve_a = reserve_a + amount_in_with_fee   # 1000 + 9.97 = 1009.97
new_reserve_b = k / new_reserve_a
# => new_k = 1009.97 * (2e9 / 1009.97) = 2_000_000_000 EXACTLY
```

So bullet 1 is false (the fee is **not** fed into the reserves), bullet 4 is false (k does **not** grow), and the two contradict each other in the same interpretation cell — a student reading cell 7 after cell 4 gets two mutually exclusive stories.

## G.1 firsthand verification

Read cell 4 source + output AND cell 7 source verbatim before editing. Confirmed: `amount_in_with_fee = amount_in * (1 - fee/100)` then `new_reserve_a = reserve_a + amount_in_with_fee` (the 0.03 ETH fee is never added anywhere), so `k` stays exactly `2_000_000_000`. Both bullet strings confirmed verbatim and unique.

## Fix (markdown-only, C.2 exception)

Replaced the two contradictory bullets with a single correct, non-contradictory explanation grounded in the code:
- the fee is deducted from `amount_in` and **discarded** (not reinjected), so `k` stays **exactly invariant**;
- honest pedagogical contrast: a real **Uniswap-V2 reinjects** the fee into the pool (k grows slightly, benefiting LPs); this simplified simulation does not model that — hence the exact invariance observed.

Cell 4 (code + outputs) is **unchanged** — only the cell 7 interpretation markdown is corrected. This is a markdown interpretation cell, so no re-execution is needed (C.2 exception: the cell whose output would change is a markdown cell with no output).

## Validation

- **nbformat validate OK** (23 cells)
- **Scope**: cell 7 source ONLY. `0 output diffs` anywhere; 22 other cells byte-identical to `origin/main` (surgical raw-json round-trip, 2+/2-, 1 file).
- **0 leaks**, **CRLF=0, LF, UTF-8 no-BOM, trailing newline**.

## SOTA verdict

**SOTA-OK** — the markdown now faithfully describes the code that runs. No tool missing, no workaround: cell 4 already runs the correct simplified AMM; this fix only aligns the prose to what the code computes. The contrast with real Uniswap-V2 fee reinjection is stated honestly rather than hidden.

## Method

Defect found via Explore sonnet scan (read-only, SmartContract family — fresh rotation out of GameTheory per R6). G.1 firsthand-verified: read the full cell 4 code (fee discarded → k invariant) and both cell 7 bullet strings before editing. Companion to SC-13 cell 7 (#7907, code-correctness) — same scan, doc-honesty sibling.

See #3801.

Generated with Claude Code
