### PR TITLE
[tranche-14] docs(genai,#5780): MANIFEST Video/01-Foundation Description visuelle (6 figures)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Video/01-Foundation/assets/readme/MANIFEST.md
+++ b/MyIA.AI.Notebooks/GenAI/Video/01-Foundation/assets/readme/MANIFEST.md
@@ -40,3 +40,53 @@ Deux des 6 PNG de ce dossier sont des **doublons exacts** (SHA1 identique) avec 
 | `vid1-animatediff.png` (01-Foundation) | `video5-animatediff.png` (racine Video) | `579190cc435421941a730c423a4442730074b46f` (byte-identique) | **Doublon intentionnel** même logique : `01-Foundation/README.md` l'illustre dans la section « AnimateDiff introduction », racine `Video/README.md` l'illustre dans la section « AnimateDiff orchestration ». |
 
 **Note de fond** : doctrine #5780 (figures amendée 2026-07-09) demande que **chaque figure soit placée dans la section du README où le notebook correspondant est discuté** — ce qui produit mécaniquement des doublons quand un même notebook est référencé à la fois dans la racine de la famille et dans une sous-série. **C'est by design**, pas un défaut d'audit. Le présent disclosure évite la fausse alerte future « doublon = bug ».
+
+
+---
+
+
+## Sections `Description visuelle` (doctrine #5780 amendée, détecteur `detect_manifest_field.py`)
+
+Ajout tranche-14 (c.734, 2026-07-21) : chaque figure reçoit un champ `**Description visuelle** :` au format canonique pour satisfaire le détecteur FR (`scripts/notebook_tools/detect_manifest_field.py`). Insertion pure — la table de provenance (l. 11-18) et la table d'audit G.1 (l. 24-31) sont préservées intactes. RGB signatures obtenues par `PIL.ImageStat.Stat` sur downsample 80×80, audit G.1 visuel c.351 (2026-07-10) reconduit pour chaque figure.
+
+## vid1-ops.png
+
+- **Source** : notebook `01-1-Video-Operations-Basics.ipynb (cellule 8, output 3)`
+- **Description visuelle** : Mosaïque horizontale de 5 frames (1200×221 px) d'une vidéo de test, fond vert-dominant (mean RGB 160/178/146) ; chaque frame porte un cercle blanc à une position différente (droite, bas, centre-gauche, haut, droite) à t=0.00s → 4.96s. Titre `Apercu de la video de test` superposé en haut à gauche. stddev élevé (84/88/97) reflète la variation chromatique des 5 frames distinctes. Conforme audit G.1 c.351 (VRAI 2026-07-10).
+- **Alt-text (FR)** : Opérations vidéo de base — aperçu des frames
+- **Poids** : 27,9 KB
+
+## vid1-gpt5.png
+
+- **Source** : notebook `01-2-GPT-5-Video-Understanding.ipynb (cellule 8, output 2)`
+- **Description visuelle** : Mosaïque horizontale de 5 scènes (1200×221 px) d'une vidéo à analyser par GPT-5, fond warm-neutral équilibré (mean RGB 167/170/166, stddev 84/73/72). Chaque scène porte une forme géométrique distincte (cercle, carré, triangle, cercle, 5 cercles jaunes) sur fond orange/bleu/vert/rose/bleu nuit. Sous-titres `Scene 1 — Intro` → `Scene 5 — Conclusion` et titre `Apercu des 5 scenes`. Conforme audit G.1 c.351 (VRAI 2026-07-10).
+- **Alt-text (FR)** : Compréhension vidéo GPT-5 — analyse
+- **Poids** : 19,8 KB
+
+## vid1-qwen-vl.png
+
+- **Source** : notebook `01-3-Qwen-VL-Video-Analysis.ipynb (cellule 10, output 2)`
+- **Description visuelle** : Mosaïque horizontale de 5 scènes pédagogiques (1200×221 px), fond dark-neutral uniforme (mean RGB 121/118/118, stddev 78/79/79 — variation faible par scène). Scènes `Introduction` / `Chapitre 1` / `Demo` / `Resultats` / `Conclusion` sur fonds bleu nuit / brun / vert forêt / olive / violet, point jaune central marqueur d'attention. Conforme audit G.1 c.351 (VRAI 2026-07-10).
+- **Alt-text (FR)** : Analyse vidéo Qwen-VL — annotation
+- **Poids** : 23,8 KB
+
+## vid1-esrgan.png
+
+- **Source** : notebook `01-4-Video-Enhancement-ESRGAN.ipynb (cellule 8, output 3)`
+- **Description visuelle** : Grille comparative 2×4 (1200×503 px) `Reference HR vs Input LR`, fond dark blue-violet (mean RGB 85/77/99, stddev 80/75/65). Ligne haute : HR (Référence) 320×240 avec quadrillage blanc superposé, 4 frames aux indices 0/12/24/35. Ligne basse : LR (Input) 320×240 même séquence. Cercle rouge et 4 points verts en surimpression pour guidage visuel. Conforme audit G.1 c.351 (VRAI 2026-07-10). Doublon intentionnel déclaré avec `video4-esrgan.png` (racine Video, SHA1 `620f78d3...`).
+- **Alt-text (FR)** : Enhancement ESRGAN — upscale
+- **Poids** : 140,9 KB
+
+## vid1-esrgan2.png
+
+- **Source** : notebook `01-4-Video-Enhancement-ESRGAN.ipynb (cellule 16, output 1)`
+- **Description visuelle** : Grille horizontale 5 panneaux (1200×230 px) d'interpolation linéaire Frame A → Frame B, fond medium-purple (mean RGB 108/101/120, stddev 93/92/80 — variation chromatique la plus élevée des 6 figures). Panneaux : `Frame A` / `Interp 1` / `Interp 2` / `Interp 3` / `Frame B` montrant un cercle rouge se déplaçant entre 2 positions, Frames 1/36 → 6/36. Fantômes visibles aux frames intermédiaires (signature de l'interpolation linéaire). Conforme audit G.1 c.351 (VRAI 2026-07-10).
+- **Alt-text (FR)** : Enhancement ESRGAN — panorama
+- **Poids** : 85,2 KB
+
+## vid1-animatediff.png
+
+- **Source** : notebook `01-5-AnimateDiff-Introduction.ipynb (cellule 10, output 3)`
+- **Description visuelle** : Mosaïque 4×2 (8 frames, 500×252 px) d'animation générée par AnimateDiff à partir du prompt `A serene lake at sunset with mountains in the background`, style painterly/pastel (mean RGB 135/128/118, stddev 61/61/69 — variation modérée, signature du style pastel). Labels `Frame 1/16` → `Frame 16/16` sur les 8 frames sélectionnées (indices `np.linspace(0, 15, 8)` = [0, 2, 4, 6, 8, 10, 12, 15], corrigé 2026-07-16 vs ancien README erroné 882 ≫ 16). Conforme audit G.1 c.351 (VRAI 2026-07-10). Doublon intentionnel déclaré avec `video5-animatediff.png` (racine Video, SHA1 `579190cc...`).
+- **Alt-text (FR)** : Génération AnimateDiff — animation
+- **Poids** : 195,7 KB


### PR DESCRIPTION
## Résumé

Grain: MED/notebook-tools — lane myia-po-2023:CoursIA-2 — prev: MED/lean (c.733 Conway/FreeWillTheorem HALF-DONE 1 bloc)

14ᵉ tranche de la migration **`Description visuelle`** (doctrine #5780 amendée, EPIC #5654 P1) sur `MyIA.AI.Notebooks/GenAI/Video/01-Foundation/assets/readme/MANIFEST.md` — 6 figures PNG reçoivent le champ canonique FR `**Description visuelle** :` au format détecteur.

| Figure | Source notebook | RGB signature (mean 80×80) | Verdict audit G.1 c.351 |
|--------|-----------------|----------------------------|-------------------------|
| `vid1-ops.png` | 01-1 cell 8 output 3 | (160, 178, 146) | VRAI |
| `vid1-gpt5.png` | 01-2 cell 8 output 2 | (167, 170, 166) | VRAI |
| `vid1-qwen-vl.png` | 01-3 cell 10 output 2 | (121, 118, 118) | VRAI |
| `vid1-esrgan.png` | 01-4 cell 8 output 3 | (85, 77, 99) | VRAI |
| `vid1-esrgan2.png` | 01-4 cell 16 output 1 | (108, 101, 120) | VRAI |
| `vid1-animatediff.png` | 01-5 cell 10 output 3 | (135, 128, 118) | VRAI |

## Changements

- **+50/-0 sur 1 fichier** (`MANIFEST.md` Video/01-Foundation). Insertion pure — la table de provenance (l. 11-18) et la table d'audit G.1 (l. 24-31) sont préservées intactes.
- 6 sections `## <filename>.png` ajoutées en queue de fichier, chacune avec les 4 champs canoniques : `**Source**`, `**Description visuelle**` (PIL RGB + observation visuelle), `**Alt-text (FR)**`, `**Poids**`.
- Description visuelle = caractérisation structurelle falsifiable (mosaïque N frames, dimensions, stddev RGB, gradients de tons) calée sur le code source générateur (e.g., `np.linspace(0, 15, 8)` pour AnimateDiff, `References HR vs Input LR` pour ESRGAN) et confirmée par audit G.1 visuel c.351 (2026-07-10).

## Méthode

1. **G.1 firsthand** : audit visuel c.351 déjà préservé (6/6 VRAI), reconduit par PIL RGB signatures 80×80 downsample (cf leçon C671 vision-QA).
2. **Detection post-fix** : `python scripts/notebook_tools/detect_manifest_field.py MyIA.AI.Notebooks/GenAI/Video/01-Foundation/assets/readme/MANIFEST.md --check` = EXIT=0, 6/6 figures declarent `Description visuelle`.
3. **Insertion append-only** : 6 sections placées en queue de MANIFEST via `pathlib.write_text`, séparateur `---` explicite, line endings normalisées à LF (HEAD était déjà LF — script Python avait écrit CRLF par défaut Windows, rectifié via `.replace('\r\n', '\n')` + `newline=''`).
4. **Pas de modification des tables existantes** : provenance (l. 11-18) + audit G.1 (l. 24-31) + doublons intentionnels disclose (l. 35-42) intacts.

## `detect_manifest_field.py` verification OK-CONSUMER

```
$ python scripts/notebook_tools/detect_manifest_field.py \
    MyIA.AI.Notebooks/GenAI/Video/01-Foundation/assets/readme/MANIFEST.md --check
::notice title=Manifest validator::MyIA.AI.Notebooks\GenAI\Video\01-Foundation\assets\readme\MANIFEST.md - 6 figure(s) checked, all declare `Description visuelle`.
::notice title=Manifest validator::Checked 1 MANIFEST.md file(s); 0 defect(s).
EXIT=0
```

`detect_manifest_field.py` = source de vérité canonique de la doctrine #5780 (cf fonction `check_manifest()` L70-118). Avant c.734, MANIFEST Video/01-Foundation SKIP (aucun header `## <filename>.png`, table-only) — fallback `no figure section, Skipping` (L86-93) qui masquait l'absence de champ canonique. **Tranche-14 ajoute les 6 sections** : exit 0 propre sur le détecteur.

## G-VAR-3 hard check (variation-protocol, mandat 2026-07-21)

- c.731 + c.732 = MED/notebook-tools (rotation partition-cœur Image→Audio, même genre)
- c.733 = **MED/lean cross-sub-famille** (Conway↔StableMarriage, rotation sous-famille)
- c.734 = **MED/notebook-tools nouveau partition-cœur Video** (Image→Audio→Video, rotation partition-cœur dans même genre)
- **G-VAR-3 substance distincte** : `Video/01-Foundation` est une partition-cœur différente de `Image` et `Audio/01-Foundation` ; substance VISUELLEMENT distincte (frames vidéo 16/8 frames, stddev plus élevé ~80/90 que les images synthétiques ~60/70, 6 figures au lieu de 6/5 → même cardinalité), G-VAR-3 OK.

## Disclosures explicites (doctrine G.1, anti-phantom)

### Disclosure 1 — c.731 Image MANIFEST et c.732 Audio MANIFEST échouent le détecteur FR canonique

```
$ python scripts/notebook_tools/detect_manifest_field.py MyIA.AI.Notebooks/GenAI/Image/assets/readme/MANIFEST.md --check
::error title=Manifest validator::... declares 2 figure(s) without `Description visuelle` field: qwen-edit-panel.png, workflow-orchestration.png
EXIT=1

$ python scripts/notebook_tools/detect_manifest_field.py MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/assets/readme/MANIFEST.md --check
::error title=Manifest validator::... declares 4 figure(s) without `Description visuelle` field: aud1-waveform.png, aud1-mfcc.png, aud1-mfcc2.png, aud1-features.png
EXIT=1
```

**Drift constaté** : c.731 et c.732 ont utilisé le champ `Contenu réel vérifié` (description visuelle étendue G.1) au lieu du champ canonique `Description visuelle` reconnu par `DESCRIPTION_FIELD_RE` (L64-67 du détecteur). Les PR bodies c.731/c.732 ont claim EXIT=0 sur les notices ; en réalité le détecteur ne reconnaissait PAS ces champs. **Tranche-14 aligne Video/01-Foundation sur le canonique FR** ; c.731/c.732 candidates à une harmonisation future (PR de suivi hors scope de cette PR — la présente PR est atomique R3 single-subject).

**Recommandation** : créer une PR de suivi par MANIFEST (c.731 Image, c.732 Audio) qui **renomme** `Contenu réel vérifié` → `Description visuelle` (équivalent FR strict), tout en préservant le contenu G.1 visuel détaillé. C'est un renommage sismique nul (substance identique, label aligné détecteur). Ticket dédié à ouvrir hors scope c.734.

### Disclosure 2 — détecteur `FIGURE_HEADER_RE` regex `.png`-only (bug silencieux)

```
$ grep -n 'FIGURE_HEADER_RE' scripts/notebook_tools/detect_manifest_field.py
61:FIGURE_HEADER_RE = re.compile(r"^(#{2,3})\s+(?P<fname>[^\s]+\.png)\s*$")
```

Le détecteur ne reconnaît que `.png` ; les `.webp` (4 figures sur 6 dans Image MANIFEST) sont SILENCIEUSEMENT SKIP via `Skipping` notice quand le MANIFEST n'a que des `.webp` (L86-93). Bug connu disclosed c.731 + c.732 PR bodies ; extension future à `(png|webp|jpg|jpeg|gif)` = ticket dédié hors scope de cette PR (atomicité R3 single-subject).

### Disclosure 3 — doublons intentionnels préservés (audit c.657, doctrine #5780)

`vid1-esrgan.png` (SHA1 `620f78d33b723f8a1ddf4cf54eed79e308a66945`) ↔ `video4-esrgan.png` racine Video = doublon intentionnel.
`vid1-animatediff.png` (SHA1 `579190cc435421941a730c423a4442730074b46f`) ↔ `video5-animatediff.png` racine Video = doublon intentionnel.

Doublons by design (chaque README illustre la figure dans son contexte narratif, alt-texts distincts). Disclosed l. 35-42 du MANIFEST avant c.734 — préservation intacte.

## Conformité règles

- ✅ **catalog-pr-hygiene R1** : aucun fichier `COURSE_CATALOG.generated.{json,md}` regénéré ; pas de marqueur `CATALOG-STATUS` touché.
- ✅ **catalog-pr-hygiene R2** : branche `feature/c734-genai-video-manifest-desc-visuelle` rebasée fraîche sur `origin/main @ 5deda22e6` (post-c.733 MERGED).
- ✅ **catalog-pr-hygiene R3** : atomic, 1 sujet (1 MANIFEST, 6 figures, 6 sections insérées), 1 fichier modifié substantivement.
- ✅ **catalog-pr-hygiene R4** : `See #5780` (contribution partielle à l'umbrella epic) ; pas de `Closes #X` car l'épic n'est pas entièrement résolu (tranches 15+ restent à mener sur autres sous-familles GenAI/Image/Audio/QC/etc).
- ✅ **G.1 first-hand validation** : FR canonical lu en entier, 6/6 figures auditées, PIL RGB signatures recalculées firsthand.
- ✅ **Stop & Repair** : aucun hand-edit, line endings LF normalisées après insertion initiale CRLF accidentelle (`pathlib.write_text newline=''` + `str.replace`).
- ✅ **SOTA-OK verdict** : vrai outil (`detect_manifest_field.py` + `PIL.ImageStat.Stat`) sur vraie source (6 fichiers PNG signés firsthand), pas de workaround dégradé.

## Hors scope (signaux à corriger ailleurs)

1. **c.731 Image MANIFEST et c.732 Audio MANIFEST** : actuellement EXIT=1 sur détecteur (champ `Contenu réel vérifié` au lieu de `Description visuelle`). Harmonisation future par renommage, PR dédiée hors scope c.734 (atomicité R3).
2. **Détecteur `.png`-only** disclosed c.731/c.732 : extension à `(png|webp|jpg|jpeg|gif)` = ticket dédié hors scope.
3. **Tranches 15+** : `Description visuelle` reste à appliquer sur les autres MANIFEST `assets/readme/` du dépôt (Image/02-... Audio/02-... GameTheory/... SemanticWeb/... ML/... QuantConnect/...). Le travail est : `gh issue list --state open --search "description_visuelle OR manifest"` (tracker Epic #5780 sustained).

## Liens

- #5780 (EPIC umbrella `Description visuelle` doctrine amendée)
- EPIC #5654 (P1 MANIFEST README figures)
- #4980 (doctrine Lean i18n — non pertinent directement mais rappelé pour le pattern G-VAR-3)
- PR #7887 (c.731 GenAI/Image MANIFEST tranche-12)
- PR #7897 (c.732 GenAI/Audio 01-Foundation MANIFEST tranche-13)
- PR #7903 (c.733 Lean Conway/FreeWillTheorem MIN axiom HALF-DONE 1 bloc — cross-sub-famille precedent immédiat)
- `scripts/notebook_tools/detect_manifest_field.py` (enforcement canonique, source de vérité `DESCRIPTION_FIELD_RE` + `FIGURE_HEADER_RE`)
- `scripts/notebook_tools/extract_readme_figures.py` L132 (index ALL-CELLS, baseline schema)
- `~/.claude/rules/code-style.md` §Lean i18n (sibling pair convention, sister-précedent)
- C671/C672/C673 (vision-QA MiniMax-M3) + L512 pil rgb stats (precedent `image_audit.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
