### PR TITLE
docs(lean,#4980): Bayesian Reputation FR canonical HALF-DONE → OK-CONSUMER, 2 docstring blocks (19ᵉ tranche)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Reputation.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Reputation.lean
@@ -106,14 +106,15 @@ theorem gNoRep_restriction :
         gRep.u2 ⟨0, by decide⟩ ⟨0, by decide⟩ a1 a2 := by
   decide
 
-/-! ### Credibility refinement
+/-! ### Raffinement de crédibilité
 
-Normal-form BNE admits non-credible period-2 threats (e.g. in the
-benchmark, "rational fights period 2 / entrant stays out" is a Nash
-profile paying the incumbent 7 — but the threat would never be carried
-out). Sequential rationality in the *last* period is a finite,
-decidable condition on plans: each type's period-2 response must be a
-stage best reply. -/
+Le BNE en forme normale admet des menaces non crédibles de période 2
+(par exemple dans le benchmark, « le rationnel se bat en période 2 /
+l'entrant reste dehors » est un profil de Nash qui paie l'incumbent 7
+— mais la menace ne serait jamais exécutée). La rationalité
+séquentielle en *dernière* période est une condition finie et
+décidable sur les plans : la réponse de période 2 de chaque type doit
+être une meilleure réponse de stade. -/
 
 /-- Crédibilité dans le jeu de réputation : le type rationnel accommode -/
 @[reducible] def credRep (s1 : Strategy1 gRep) : Prop :=
@@ -151,11 +152,11 @@ theorem repS2_eta (s2 : Strategy2 gRep) :
   | zero => rfl
   | succ j => exact j.elim0
 
-/-! ### Equilibrium analysis of the reputation game
+/-! ### Analyse d'équilibre du jeu de réputation
 
-Target profile: rational plays plan 2 = (Fight, Accommodate), tough
-plays plan 3 = (Fight, Fight), entrant plays plan 1 = (Out after
-Fight, In after Accommodate). -/
+Profil cible : le rationnel joue le plan 2 = (Fight, Accommodate), le
+dur joue le plan 3 = (Fight, Fight), l'entrant joue le plan 1 = (Out
+après Fight, In après Accommodate). -/
 
 /-- Le profil de fusion est un BNE du jeu de réputation. -/
 theorem gRep_bne :


### PR DESCRIPTION
Grain: MED/lean — lane myia-po-2023:CoursIA-2 — prev: MED/notebook-tools c.734 Video MANIFEST tranche-14

## Résumé

19ᵉ tranche de la migration **Lean i18n sibling pair** (doctrine **#4980**, ratifiée 2026-07-04) sur `MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Reputation.lean` : 2 blocs `/-! -/` section docstrings FR-localisés EN→FR.

| Bloc | Direction | Avant | Après |
|------|-----------|-------|-------|
| `### Raffinement de crédibilité` body (8 lignes, l.109-116) | FR-localize-from-EN | EN text in FR canonical | FR text dans FR canonical, EN byte-identity préservée |
| `### Analyse d'équilibre du jeu de réputation` body (5 lignes, l.154-158) | FR-localize-from-EN | EN text in FR canonical | FR text dans FR canonical, EN byte-identity préservée |

Math/Lean notation préservée verbatim (`BNE`, `gRep`, `(Fight, Accommodate)`, `Out/In`, `planR2`, etc.). Narrative prose en français, cohérente avec les autres sections déjà localisées du fichier (`### Plan decoders`, `### Stage payoffs`, `### The two games`, `### Canonical strategy constructors (reputation game)`, `### Equilibrium analysis of the benchmark`, `### Punchline`).

## Pivot G-VAR-3 cross-sub-famille (anti-monoculture MED/lean)

c.733 (PR #7903, OPEN MERGEABLE) = `Conway/FreeWillTheorem.lean` MIN axiom (sub-famille **Conway**).
c.735 = `Bayesian/Reputation.lean` (sub-famille **Bayesian** distincte). G-VAR-3 hard check OK : substance genuinement distincte (Kreps-Wilson/Milgrom-Roberts entry-deterrence vs Conway/FreeWill), raisonnement de domaine neuf.

3ᵉ MED/notebook-tools intra-GenAI post-c.731/c.732/c.734 INTERDIT ; pivot MED/lean est le seul registre substance-distinct disponible pour G-VAR-3.

## Vérifications G.1 firsthand (POUR preuves, pas labels)

| Check | Sortie | Verdict |
|-------|--------|---------|
| `git diff --stat` | `1 file changed, 12 insertions(+), 11 deletions(-)` | ✅ surgical, scope borné |
| Line endings | LF préservé (HEAD + current, `od -c`) | ✅ pas de CRLF contamination (cf C734-L3 ★) |
| EN mirror byte-identity | `diff <(git show HEAD:Reputation_en.lean) <(current)` → EXIT=0 | ✅ anti-§D, EN mirror intacte |
| `check_i18n_siblings.py Bayesian/Reputation.lean` | `0 half-done (advisory)` sur ce fichier | ✅ HALF-DONE → OK-CONSUMER pour Reputation |
| `check_i18n_siblings.py --all` | global counter `20 → 19 half-done` (decrement = 2 blocs) | ✅ comptage cohérent, contribution 19ᵉ tranche |
| `lake build Bayesian.Reputation` (local WSL) | EXIT=0, 5 jobs, ~1.4s | ✅ Lake build SUCCESS (cf lean-merge-discipline.md HARD) |
| Autres sections FR canonical | `### Plan decoders`, `### Stage payoffs`, `### The two games`, `### Canonical strategy constructors`, `### Equilibrium analysis of the benchmark`, `### Punchline` — déjà FR-localisés | ✅ cohérent |

## Anti-false-positive : pourquoi Bayesian/Reputation et pas Conway/Angel

`inspect_all_halves.py` a aussi flaggé `Conway/Angel_en.lean` avec 2 blocs identiques (≥100 chars) entre FR/EN. Vérification manuelle :

- Bloc 3 (141 chars) = `def angelMoves` docstring → **theorem docstring en anglais**, DOIT rester EN sur les deux côtés (Mathlib 4 compat + tactic DSL).
- Bloc 7 (234 chars) = `CALIBRATION` docstring → **theorem docstring en anglais**, idem.

→ **FALSE POSITIVE** : le checker flagge des theorem docstrings qui DOIVENT être EN sur les deux côtés par convention sibling pair (cf [code-style.md §Lean i18n](../../.claude/rules/code-style.md)). Skip Conway/Angel, pivot vers Bayesian/Reputation où les 2 blocs sont des **section headers** (`### ...`) avec narrative prose — vraie substance FR-localisable.

## Conformité règles

| Règle | Conformité |
|-------|------------|
| **R1 catalog-pr-hygiene** : JAMAIS regen catalogue sur branche | ✅ aucune modification `COURSE_CATALOG.*` ni blocs `CATALOG-STATUS` |
| **R2 catalog-pr-hygiene** : rebase frais <14j | ✅ base `f4e355986` (avancée de 2 PRs depuis c.734 base `5deda22e6`), well under 14j |
| **R3 catalog-pr-hygiene** : atomique 1 sujet | ✅ 1 fichier, 1 sujet = FR-localisation Lean i18n, 12/-11 lignes |
| **R4 catalog-pr-hygiene** : `See #X` vs `Closes #X` | ✅ `See #4980` (contribution partielle à l'Epic, l'Epic reste ouverte : 19/22 fichiers restants après c.735) |
| **lean-merge-discipline.md** : lake build SUCCESS local AVANT merge | ✅ `lake build Bayesian.Reputation` EXIT=0, 5 jobs, ~1.4s |
| **code-style.md §Lean i18n** : section docstrings FR, theorem docstrings EN | ✅ seules les 2 section headers modifiées, theorem signatures/proofs intactes |
| **anti-regression.md** : pas de `sorry` ajouté | ✅ `grep -c sorry` inchangé, code de production byte-identity hors docstrings |
| **harness-hygiene.md** : info 3 tiers | ✅ rapport sur dashboard, pas de fichier `_REPORT.md`/`_STATUS.md` dans le repo |

## Disclosures (transparence reviewer)

1. **c.733 (`Conway/FreeWillTheorem.lean`, PR #7903 OPEN MERGEABLE)** : indépendant, en attente de review ai-01. Aucune collision de substance (MIN axiom ≠ BNE credibility).
2. **c.731 Image root + c.732 Audio root MANIFEST harmonization** (`Contenu réel vérifié` → `Description visuelle`) : non résolu, future tranche. Le détecteur `detect_manifest_field.py` (c.756 par po-2024, MERGED) reste strict sur la regex `Description visuelle`.
3. **Global HALF-DONE counter** : 19/22 fichiers restants après c.735 (était 20/22 avant). Substance distincte du cross-sub-famille Bayesian vs Conway.

## Out of scope (NE touche PAS)

- `Reputation_en.lean` : EN mirror, byte-identity préservée.
- Autres fichiers Bayesian (`Information.lean`/`_en.lean`, `BNE.lean`) : future tranche.
- Autres sub-familles Lean (Conway, DecisionTheory, SocialChoice, ...) : autre worker.
- Catalogue : JAMAIS regen sur branche, backstop `.github/workflows/catalog-cron.yml`.

## Localisation

- Worktree : `D:\Dev\CoursIA-2-c735-bayesian-reputation-halffix`
- Branch : `feature/c735-bayesian-reputation-halffix`
- Commit : `4c18e6f42`
- Diff : https://github.com/jsboige/CoursIA/pull/<TBD>/files

## Référence

- Epic parent : **#4980** (Lean i18n sibling pair doctrine, ratified 2026-07-04)
- Cible : 22 fichiers FR canonical `.lean` → 0 half-done advisory
- Statut post-c.735 : 19 fichiers restants (était 20 avant c.735)
- Tranches précédentes citées : c.733 (Conway/FreeWillTheorem), c.730 (Lemmas_en), c.729 (Lattice)
- Outil : [`scripts/lean/check_i18n_siblings.py`](../../scripts/lean/check_i18n_siblings.py)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
