### PR TITLE
fix(sl1-cs,#3801): correct |G| count in CBH-vs-VS comparison markdown (3 -> 8)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning-Csharp.ipynb
@@ -919,7 +919,7 @@
     "## 6. Comparaison CBH vs Version Space\n",
     "\n",
     "Pour comparer les stratégies là où le VS est encore **large** (après 4 exemples,\n",
-    "`|G|=3`), on entraîne sur les 4 premiers et on teste sur les 8 suivants."
+    "`|G|=8`), on entraîne sur les 4 premiers et on teste sur les 8 suivants."
    ]
   },
   {


### PR DESCRIPTION
## Scope

SL-1-LogicalLearning-Csharp cell 12 "Comparaison CBH vs Version Space" markdown contained a fabricated number contradicting the notebook's own committed code output.

**Claim (cell 12, before):**
> Pour comparer les strategies la ou le VS est encore **large** (apres 4 exemples, `|G|=3`), on entraine sur les 4 premiers et on teste sur les 8 suivants.

**Ground truth (committed output, cell 13):**
> Apres 4 exemples d'entrainement : |G|=8, |S|=1

The cell 10 Candidate-Elimination trace independently confirms |G|=8 at the 4th example (Ex=3 row). |G|=3 was wrong.

## Change

Single-number markdown correction: `|G|=3` -> `|G|=8`. Markdown-only edit (C.2 markdown exception — no re-execution needed; prior outputs remain valid). Minimal diff: 1 insertion, 1 deletion.

## Verification (G.1, firsthand against origin/main)

- **Determinism check**: SL-1-C# is pure C# logical learning (CBH + Version Space, from-scratch, no ML lib). Zero LLM/API/openai/gemini/`os.getenv`/requests footprint — the committed output is reproducible ground truth (not a nondeterministic snapshot). Safe to treat the committed output as authoritative. (Contrast SL-9 real-LLM basis, which is NOT safe to "fix" by re-exec.)
- cell 10 trace: Ex=3 row |G|=8 (after 4 examples).
- cell 13 output: "|G|=8, |S|=1".
- cell 12 now consistent with both.
- Notebook still valid (21 cells, nbformat 4.5); no |G|=3 remains anywhere in markdown.

See #3801 (doc-honesty / SOTA registry) — partial contribution to the SymbolicLearning doc-honesty sweep, does not close the epic.

Grain: doc-honesty/markdown-number — lane po-2026:CoursIA — prev: doc-honesty/sl8-grandparentof (#7909)

Co-Authored-By: Claude <noreply@anthropic.com>
