### PR TITLE
fix(search,#3801): Search-2-Uninformed UCS Paris->Rennes wrong % denominator + fabricated print

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed.ipynb
@@ -1566,11 +1566,11 @@
       "  Noeuds explorés  : 10\n",
       "  Noeuds generes   : 31\n",
       "  Frontiere max    : 6\n",
-      "  Temps            : 0.49 ms\n",
+      "  Temps            : 0.08 ms\n",
       "\n",
       "NOTE : sur Bordeaux -> Strasbourg, BFS et UCS trouvent le MEME chemin.\n",
       "C'est un cas ou couts et nombre d'étapes coincident : l'avantage de UCS sur les couts n'est pas visible.\n",
-      "Voir le trajet Paris -> Rennes ci-dessous, ou UCS divise le cout par deux.\n"
+      "Voir le trajet Paris -> Rennes ci-dessous, ou UCS trouve un chemin ~1,7x moins cher.\n"
      ]
     }
    ],
@@ -1583,7 +1583,7 @@
     "result_ucs.display()\n",
     "print(\"\\nNOTE : sur Bordeaux -> Strasbourg, BFS et UCS trouvent le MEME chemin.\")\n",
     "print(\"C'est un cas ou couts et nombre d'étapes coincident : l'avantage de UCS sur les couts n'est pas visible.\")\n",
-    "print(\"Voir le trajet Paris -> Rennes ci-dessous, ou UCS divise le cout par deux.\")\n"
+    "print(\"Voir le trajet Paris -> Rennes ci-dessous, ou UCS trouve un chemin ~1,7x moins cher.\")\n"
    ]
   },
   {
@@ -1636,11 +1636,11 @@
       "  Explore: Lyon            (cout=   465) | Frontiere: 4 noeuds\n",
       "  Explore: Strasbourg      (cout=   490) | Frontiere: 5 noeuds\n",
       "Algorithme                    Chemin  Cout (km)  Longueur  Noeuds explorés Temps (ms)\n",
-      "       BFS  Paris -> Lille -> Rennes        825         2                3       0.09\n",
-      "       UCS Paris -> Nantes -> Rennes        495         2                5       0.12\n",
+      "       BFS  Paris -> Lille -> Rennes        825         2                3       0.03\n",
+      "       UCS Paris -> Nantes -> Rennes        495         2                5       0.03\n",
       "\n",
       "======================================================================\n",
-      "UCS a trouve un chemin 330 km plus court (66.7% de moins).\n",
+      "UCS a trouve un chemin 330 km plus court (40.0% de moins).\n",
       "BFS a developpe Lille en premier (premier voisin alphabetique) et s'est\n",
       "arrete la : 225 + 600 = 825 km. UCS, en suivant le cout cumule g(n), a\n",
       "developpe Nantes en premier et trouve 385 + 110 = 495 km. Meme nombre\n",
@@ -1685,7 +1685,7 @@
     "print(\"\\n\" + \"=\" * 70)\n",
     "if result_bfs_pr.cost > result_ucs_pr.cost:\n",
     "    diff = result_bfs_pr.cost - result_ucs_pr.cost\n",
-    "    pct = (diff / result_ucs_pr.cost) * 100\n",
+    "    pct = (diff / result_bfs_pr.cost) * 100\n",
     "    print(f\"UCS a trouve un chemin {diff:.0f} km plus court ({pct:.1f}% de moins).\")\n",
     "    print(\"BFS a developpe Lille en premier (premier voisin alphabetique) et s'est\")\n",
     "    print(\"arrete la : 225 + 600 = 825 km. UCS, en suivant le cout cumule g(n), a\")\n",


### PR DESCRIPTION
Grain: MED/code-correctness — lane myia-po-2025:CoursIA — prev: MED/code-correctness (#7912 Z3-06)

## Defect (class A code-correctness, G.1 firsthand-verified, scan finding)

`Search-2-Uninformed.ipynb` cell 35 — the notebook's **UCS-vs-BFS cost-advantage example** (Paris → Rennes) — computed the cost reduction with the **wrong denominator** and printed a mathematically false percentage, plus cell 33 carried a matching fabricated hardcoded print.

```
BFS : Paris -> Lille -> Rennes     = 825 km
UCS : Paris -> Nantes -> Rennes    = 495 km     (diff = 330 km)
```

**Bug**: `pct = (diff / result_ucs_pr.cost) * 100` = `330/495` = **66.7%**.

The print reads *"UCS a trouve un chemin {pct}% de moins"* (X% **less**). "X% less" is reduction relative to the **original** (BFS) cost = `(825−495)/825` = **40%**. The code used the wrong denominator (the new UCS cost), so the committed output read **"66.7% de moins"** — wrong (495 is 40% less than 825, not 66.7%). 

**The notebook's own cell 34 markdown already states the correct answer**: *"40% moins cher"* and *"couts divises par ~1,7"* — confirming the intended semantics is 40% (and that cells 33/35 are stale).

**cell 33** had a matching fabricated hardcoded print: *"ou UCS divise le cout par deux"* — 825→495 is **not** halved (half of 825 = 412.5); it is ~1.67×. Again contradicted by cell 34's *"~1,7"*.

## G.1 firsthand verification

Recomputed both framings firsthand before editing: `330/825 = 40.0%` (reduction vs original = correct "% de moins") vs `330/495 = 66.7%` (the code's wrong denominator). Confirmed cell 34 markdown already states *"40% moins cher"* + *"~1,7"*, establishing the notebook's own intent. Read full cell 33/34/35 source + output.

## Fix

- **cell 35**: `pct = (diff / result_bfs_pr.cost) * 100` → **40.0%** (matches cell 34).
- **cell 33**: forward-ref print honest — *"ou UCS trouve un chemin ~1,7x moins cher"* (matches cell 34).

**Re-executed code cells 0..35** with matplotlib Agg (rule F) → real stdout transplanted to cells 33 + 35. Paths unchanged (825/495 — deterministic graph); only the wrong percentage and the fabricated forward-ref are corrected.

## Validation

- **nbformat validate OK** (75 cells)
- **Scope**: cell 33 (source + output) + cell 35 (source + output). **73 other cells byte-identical to `origin/main`** (surgical raw-json round-trip, 7+/7-, 1 file).
- **0 leaks**, **CRLF=0, LF, UTF-8 no-BOM, NO trailing newline** (file convention — round-trip-verified before editing).
- **Rule F**: deterministic graph search re-executed with real Python; no stochasticity (BFS/UCS on a fixed graph).

## SOTA verdict

**SOTA-OK** — the cell now computes and prints the correct cost-reduction percentage (40%) with the correct denominator, consistent with the notebook's own cell 34 markdown. No tool missing, no workaround: the search code itself (BFS/UCS) was already correct; only the percentage arithmetic and a forward-reference print were wrong. Real re-execution.

## Method

Defect found via Explore sonnet scan (read-only, Search Part1-Foundations family — fresh rotation out of Z3-Python per R6), G.1 firsthand-verified (recomputed the two denominators, confirmed cell 34 already correct). The scan's 14 other Search findings (Search-7 OpenSpiel fabrication HIGH, Search-11 metaheuristic benchmark mismatches, Search-5 GA TSP stale numbers, Search-15 A* node-count dead code, Search-16 QuikGraph, Search-6 adversarial depth) are separate grains for future cycles.

See #3801.

Generated with Claude Code
