### PR TITLE
fix(search,#3801): Search-7-MCTS cell 17 fabricated OpenSpiel success narrative

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb
@@ -887,21 +887,20 @@
    "source": [
     "### Interpretation : OpenSpiel et la normalisation des jeux\n",
     "\n",
-    "**Sortie obtenue** : OpenSpiel s'est charge avec succes : le jeu `tic_tac_toe` a ete instancie et son MCTS integre a retourne l'action 4 (centre).\n",
+    "**Sortie obtenue** : sur cette plateforme OpenSpiel **n'est pas installe** (la cellule precedente l'a detecte via le `try/except ImportError`). Le code s'est donc degrade proprement : aucun `MCTSBot` n'a ete instancie et aucune action n'a ete joue. C'est le comportement attendu sur Windows natif -- OpenSpiel requiert Linux ou WSL.\n",
     "\n",
     "| Aspect | Valeur | Signification |\n",
     "|--------|--------|---------------|\n",
-    "| **Statut** | Disponible (execute) | `pyspiel` est installe sur cette plateforme |\n",
-    "| **Jeu charge** | `tic_tac_toe()` | Charge via `pyspiel.load_game(...)` |\n",
-    "| **Action MCTS** | 4 (centre) | Coup retourne par le `MCTSBot` d'OpenSpiel (1000 simulations) |\n",
+    "| **Statut** | Non disponible (repli) | `pyspiel` absent ; le `except ImportError` a pris le relais |\n",
+    "| **Comportement** | Degradation honnete | Le code detecte l'absence et l'indique au lieu d'echouer |\n",
+    "| **Pour executer** | Linux / WSL | `pip install open-spiel`, puis relire la cellule precedente |\n",
     "\n",
     "**Points cles** :\n",
-    "1. **Framework portable** : ici OpenSpiel fonctionne dans l'environnement d'exécution ; selon la plateforme il peut necessiter Linux/WSL (le code conserve un repli `ImportError` pour ce cas)\n",
-    "2. **API standardisee** : OpenSpiel fournit une interface commune pour 40+ jeux (echecs, Go, poker, Hanabi)\n",
-    "3. **Algorithmes inclus** : MCTS, AlphaZero, CFR (Counterfactual Regret Minimization), et autres algorithmes de jeux\n",
-    "4. **Coherence avec MCTS manuel** : le `MCTSBot` d'OpenSpiel joue le centre (action 4), un coup classiquement fort au Morpion\n",
+    "1. **Robustesse** : le bloc `try/except ImportError` est le bon motif quand un outil optionnel et lourd (OpenSpiel) peut manquer -- le notebook reste lisible et le repli est explicite.\n",
+    "2. **API standardisee** : quand OpenSpiel est present, `pyspiel.load_game(\"tic_tac_toe\")` suivi d'un `MCTSBot` illustre l'interface commune a 40+ jeux (echecs, Go, poker, Hanabi).\n",
+    "3. **Algorithmes inclus** : MCTS, AlphaZero, CFR (Counterfactual Regret Minimization), et autres algorithmes de jeux.\n",
     "\n",
-    "> **Note technique** : OpenSpiel permet de tester rapidement MCTS sur différents jeux sans reecrire la logique de jeu. Il inclut aussi des outils d'analyse pour la recherche en théorie des jeux. Le code de cette cellule entoure l'import d'un `try/except ImportError` afin de degrader proprement si la librairie est absente."
+    "> **Note technique** : pour faire tourner reellement MCTS via OpenSpiel sur ce notebook, installez-le dans un environnement Linux/WSL (`pip install open-spiel`), puis re-executez la cellule precedente : le `try` reussira, le jeu `tic_tac_toe` sera charge et le `MCTSBot` jouera un coup. Sur Windows natif, le repli `ImportError` documente honnetement l'absence de la librairie."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/doc-honesty — lane myia-po-2025:CoursIA — prev: MED/code-correctness (#7918 Search-2)

## Defect (class A SOTA-fabrication, G.1 firsthand-verified, scan finding #1)

`Search-7-MCTS-And-Beyond.ipynb` cell 17 — the **OpenSpiel section interpretation** — fabricated a SOTA tool run that never happened.

**cell 16 is honest**: it `try/except`-imports `pyspiel`, and since OpenSpiel is not installed on this platform (it needs Linux/WSL), the `except` branch runs. The committed output reads:
```
OpenSpiel n'est pas installe ou non disponible sur cette plateforme.
Installation: pip install open-spiel (Linux/WSL uniquement)
```

**cell 17 fabricated the opposite**:
> *"OpenSpiel s'est charge avec succes : le jeu `tic_tac_toe` a ete instancie et son MCTS integre a retourne l'action 4 (centre)."*
> *"pyspiel est installe sur cette plateforme"*
> *"Action MCTS: 4 (centre)"*

**No action 4 was ever produced** — the `try` branch never executed. Point 2 even claimed *"ici OpenSpiel fonctionne dans l'environnement d'execution"* (false).

This is a **SOTA-fabrication (Prong-A, #3801)**: the notebook narrates a SOTA framework (DeepMind's OpenSpiel) running when it did not, **inventing a concrete result (action 4)** that never occurred. The honest code already degrades gracefully; only the interpretation lied — misleading any reader (student) into believing the example ran.

## G.1 firsthand verification

Read the **full** cell 16 source AND its committed output (confirmed the `except ImportError` branch ran → "not installed" message), and the full cell 17 markdown (confirmed the fabricated "s'est charge avec succes" + "action 4" + "pyspiel est installe") before editing.

## Fix (markdown-only, C.2 exception)

Rewrote cell 17 to describe what **actually** happened: OpenSpiel absent on Windows, the code degrades honestly via `ImportError`. Pedagogical content is preserved (what OpenSpiel is, the API shape: `pyspiel.load_game` + `MCTSBot`, the 40+ games, MCTS/AlphaZero/CFR), but **no run is claimed that did not happen**. The path to a real run (Linux/WSL + `pip install open-spiel` + re-execute the previous cell) is stated honestly.

cell 16 (code + output) is **unchanged** — it was already honest. Only the cell 17 interpretation markdown is corrected. This is a markdown interpretation cell with no output, so no re-execution is needed (C.2 exception).

## Validation

- **nbformat validate OK** (43 cells)
- **Scope**: cell 17 source ONLY. `0 output diffs` anywhere; 42 other cells byte-identical to `origin/main` (surgical raw-json round-trip, 8+/9-, 1 file).
- **0 leaks**, **CRLF=0, LF, UTF-8 no-BOM, trailing newline**.

## SOTA verdict

**SOTA-OK (honest fallback)** — OpenSpiel genuinely requires Linux/WSL and is unavailable on the Windows-native execution platform; the notebook's code already handles this correctly via `try/except`. The fix removes the fabricated "it ran + action 4" narrative and states the honest status + the real path to a live run. This is the documented `RECOVERABLE-MACHINE` case (WSL) described honestly rather than masqueraded as a successful SOTA run — precisely what Prong-A/Stop & Repair requires. The cell does not commit a degraded output claiming to be OpenSpiel's output.

## Method

Defect found via Explore sonnet scan (read-only, Search Part1-Foundations family — fresh rotation out of Z3-Python per R6), G.1 firsthand-verified (read full cell 16 source+output + cell 17 markdown). The scan's #2 finding (Search-2 UCS % denominator, #7918) was delivered first as the code-correctness floor MED.

See #3801.

Generated with Claude Code
