### PR TITLE
fix(gametheory,#3801): GT-6-EvolutionTrust reversed Axelrod rankings + false winner (markdown cells 16+39)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-6-EvolutionTrust.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-6-EvolutionTrust.ipynb
@@ -964,11 +964,11 @@
     "\n",
     "| Sans bruit | Avec bruit (5%) | Evolution |\n",
     "|------------|-----------------|-----------|\n",
-    "| 1. TitForTwoTats | 1. Pavlov | Pavlov prend la tete |\n",
-    "| 2. TitForTat | 2. TitForTwoTats | Stable (top 2) |\n",
-    "| 3. Grudger | 3. TitForTat | TFT recule (3e) |\n",
-    "| 4. Pavlov | 4. SuspiciousTFT | Hausse |\n",
-    "| 5. AlwaysCooperate | 5. Random | Hausse |\n",
+    "| 1. TitForTwoTats | 1. TitForTwoTats | Stable (leader #1) |\n",
+    "| 2. TitForTat | 2. Pavlov | Forte hausse (#4 -> #2) |\n",
+    "| 3. Grudger | 3. TitForTat | Recule (#2 -> #3) |\n",
+    "| 4. Pavlov | 4. Random(p=0.5) | Hausse (#6 -> #4) |\n",
+    "| 5. AlwaysCooperate | 5. Grudger | Recule (#3 -> #5) |\n",
     "\n",
     "**Mécanismes observes** :\n",
     "\n",
@@ -1967,7 +1967,7 @@
    "source": [
     "### Interprétation : notre jouet vs la référence SOTA\n",
     "\n",
-    "**Convergence qualitative** : le tournoi round-robin de la librairie Axelrod confirme les phénomènes mis en évidence par notre implémentation pédagogique — les stratégies rétitives (Grudger, TitForTat) dominent les stratégies exploitées (Cooperator) et l'exploiteur pur (Defector) est puni dès qu'une stratégie rancunière est présente. Dans cette configuration à 6 stratégies, **Grudger l'emporte** : il punit Defector à perpétuité, ce qui fait chuter le score de Defector et valorise la robustesse de Grudger. TitForTat, gagnant des tournois historiques d'Axelrod (1980), arrive 3e en round-robin pur — sa domination historique s'exprime surtout dans les formats écologiques à élimination (processus de Moran), déjà illustrés par la section replicator-dynamics ci-dessus.\n",
+    "**Lecture du classement** : le tournoi round-robin de la librairie Axelrod (convention : le score = années de prison, donc moins = mieux) place **Defector en tête** (#1), devant Grudger (#2) et TitForTat (#3). Ce verdict surprend par rapport au récit classique « nice guys finish first », mais il est cohérent avec le dilemme du prisonnier en round-robin statique sur ce petit pool : il contient un Cooperator naïf, donc la défection unilatérale l'exploite et procure à Defector très peu d'années de prison. Le récit s'inverse en **dynamique écologique** (processus de Moran) : l'exploiteur épuise ses cibles coopératives au fil des générations et décline — c'est pourquoi les stratégies « nice » dominent les tournois historiques d'Axelrod (1980). TitForTat n'arrive ici que 3e en round-robin statique ; sa domination s'exprime dans les formats évolutifs à élimination, déjà illustrés par la section replicator-dynamics ci-dessus.\n",
     "\n",
     "**Ce qu'apporte la librairie** : (a) 243 stratégies standardisées vs nos 6 pédagogiques, (b) tournois reproductibles bit-à-bit (graine fixée), (c) gestion du bruit, des tournois à élimination et du processus de Moran, (d) interaction avec `axelrod-stratégies` (le zoo communautaire). **Ce qu'apporte notre implémentation** : la compréhension intime de la mécanique — comment se calcule un score de tournoi, comment se propage une population, pourquoi telle stratégie gagne. Les deux sont **complémentaires** : l'implémentation manuelle enseigne *le comment*, la librairie permet *la recherche à l'échelle*.\n"
    ]


### PR DESCRIPTION
Grain: MED/doc-honesty — lane po-2023 — EPIC #3801 (SOTA axe-2 doc-honesty)

## Summary

`GameTheory-6-EvolutionTrust.ipynb` had **two markdown interpretation cells contradicting their own committed code-cell outputs** (firsthand G.1-verified against `origin/main` `f4e355986`). Found via an Explore (sonnet) read-only scan of GT-6/7/8/9/10, then **each HIGH finding was G.1 firsthand-verified before fixing** (defense against the c.787 over-assertion failure mode — Explore can over-assert).

GT-7, GT-8, GT-10 were scanned CLEAN (negative result — logged to prevent re-dispatch). GT-9 had one LOW/low-confidence finding (centipede reasoning muddle that self-corrects, bottom-line correct) — left alone (G.3 marginal).

## Defect 1 — cell[16] noisy-tournament ranking table reversed/scrambled

cell[15] committed output (avec bruit 5%, the ground truth):
```
1 TitForTwoTats 440.83   2 Pavlov 440.21   3 TitForTat 432.24
4 Random(p=0.5) 431.31   5 Grudger 428.87  6 SuspiciousTFT 428.30
7 AlwaysDefect 424.02    8 AlwaysCooperate 383.77
```

cell[16] markdown table claimed the OPPOSITE for the "Avec bruit (5%)" column:

| Rank | Markdown claim | Committed truth (cell 15) |
|------|----------------|---------------------------|
| 1 | "1. Pavlov" | **1. TitForTwoTats** (440.83) |
| 2 | "2. TitForTwoTats" | **2. Pavlov** (440.21) |
| 3 | "3. TitForTat" | 3. TitForTat ✓ |
| 4 | "4. SuspiciousTFT" | **4. Random** (SuspiciousTFT is actually #6) |
| 5 | "5. Random" | **5. Grudger** |

Plus the prose "Pavlov prend la tete" was false — TitForTwoTats led, Pavlov was a close 2nd (−0.62 pts).

The **sans-bruit column** (vs cell[13] output) was already correct — only the avec-bruit column was a stale interpretation from an earlier run where the close top-2 (440.83 vs 440.21) ordered differently. The 4 "Mécanismes observés" bullets below the table were already correct (unchanged).

## Defect 2 — cell[39] false winner claim (Grudger vs Defector reversed)

cell[38] committed output (Axelrod library round-robin, 200 tours × 10 reps):
```
1. Defector   2. Grudger   3. Tit For Tat   4. Win-Stay Lose-Shift
5. Cooperator   6. Random: 0.5
(convention : le score = années de prison, donc MOINS = mieux)
```

cell[39] markdown claimed the EXACT OPPOSITE: **"Grudger l'emporte : il punit Defector à perpétuité, ce qui fait chuter le score de Defector"**. In reality **Defector is #1** (fewest prison years), Grudger is #2.

**Verified the output is a genuine result, not a scoring bug**: cell[38] source uses the real `axelrod` library (`axl.Tournament(players, turns=200, repetitions=10)` + `results.ranked_names`) with the correct stated convention ("le score = années de prison, donc MOINS = mieux"). Under this prison-years convention, Defector exploits the naive `Cooperator` in this 6-strategy pool (unilateral defection → fewest years) — a real, surprising-but-true result. This is *exactly why* the ecological/Moran format (which the notebook's own next section covers) was needed to show cooperation's evolutionary advantage. The rewrite reports Defector #1 honestly and preserves the already-correct Moran / TFT-3rd contrast.

## Fix — markdown-only (C.2 exception)

Both defects are in markdown interpretation cells; the code-cell outputs (cells 13/15/38) are correct and committed, so **no re-execution is needed** (C.2 exception: markdown-only edit → previous outputs valid). No code cell touched, no output hand-edited (Stop & Repair respected).

## Changes

| Cell | Change |
|------|--------|
| cell[16] (markdown) | "Avec bruit (5%)" column + "Evolution" column rewritten to match committed cell[15] output; 4 mechanism bullets unchanged. |
| cell[39] (markdown) | "Convergence qualitative" paragraph rewritten → "Lecture du classement" (Defector #1, honest round-robin-vs-ecological contrast); 2nd paragraph ("Ce qu'apporte la librairie") unchanged. |

46/48 cells **byte-identical to origin/main** (cell_sig verified: source + outputs + exec_count + metadata). Per-cell trailing-newline convention preserved (cell[16] last line no `\n`, cell[39] last line `\n` — both match original).

## Validation

- **C.2 exception (markdown-only):** no code cell touched, no re-exec required; committed outputs (cells 13/15/38) unchanged and authoritative.
- **C.1:** 0 `raise NotImplementedError` / `assert False` / `1/0` (markdown-only PR).
- **nbformat validate OK** (48 cells).
- **Surgical:** 46/48 cells byte-identical; only cell[16] + cell[39] source changed; top-level `metadata` + `nbformat` byte-identical.
- **Honesty (Stop & Repair):** no cell output hand-edited — only markdown source rewritten; all code outputs left exactly as committed.
- **G.1:** both HIGH findings firsthand-verified (read FULL cell outputs, recomputed rankings) before fixing.

See **#3801** (EPIC SOTA axe-2 doc-honesty registry). Partial contribution — `See #3801` (no auto-close).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
