### PR TITLE
fix(smt,#3801): remove fabricated Star/global-motif claims in Z3-Python-04 cell 20

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb
@@ -890,12 +890,12 @@
     "\n",
     "| Stratégie | Mécanisme | Avantage | Limite |\n",
     "|-----------|-----------|----------|-------|\n",
-    "| Regex (`InRe`) | Motif global `[a-z]*[A-Z][a-z]*` | Exprime l'ordre et la repetition | Plus verbeux |\n",
+    "| Regex par position (`InRe`) | `Length==8` puis `InRe(SubString(pwd,i,1), Range(...))` sur chaque position | Autorise une *classe* de caracteres par position | Plus verbeux, longueur figee |\n",
     "| Positionnel (`SubString`) | Force des positions spécifiques | Simple et direct | fige la structure |\n",
     "\n",
     "**Points cles** :\n",
     "1. La **generation** d'un mot de passe valide est un test immediat de la politique : si le solveur repond `sat`, les règles sont coherentres entre elles.\n",
-    "2. La première approche utilise `Star` pour autoriser un nombre arbitraire de minuscules autour des caractères obligatoires.\n",
+    "2. Les deux approches fixent `Length(pwd) == 8` (une longueur libre rend le probleme NP-hard) ; elles different par la contrainte sur chaque position : `InRe`+`Range` autorise un *intervalle* de caracteres (`[A-Z]`, `[0-9]`, `[a-z]`), tandis que l'egalite `== StringVal` impose un caractere *precis*.\n",
     "3. En pratique, pour des politiques complexes (caractères speciaux, historique), la modelisation declarative est plus maintenable qu'une cascade de `if`."
    ]
   },


### PR DESCRIPTION
## Scope

Z3-Python-04-Strings-Regex.ipynb cell 20 (interpretation markdown) contained two claims **fabricated relative to the code** it describes:

**Claim (cell 20, before):**
- Table Regex row: "Motif global `[a-z]*[A-Z][a-z]*`"
- Point 2: "La premiere approche utilise `Star` pour autoriser un nombre arbitraire de minuscules"

**Ground truth (committed code, cell 19):**
- `generer_mot_de_passe_valide` + `generer_mot_de_passe_v2` use `Length(pwd)==8` + positional `SubString(pwd, i, 1)` + `Range('A','Z')`/`Range('0','9')`/`Range('a','z')`.
- **NO `Star` anywhere, NO global motif `[a-z]*[A-Z][a-z]*`** (grep firsthand on cell 19).
- Output `Hppp0ppp` / `XABC7DFE` is correct and unchanged.

## Change

Markdown-only correction (C.2 exception -- code unchanged, output valid):
- Table Regex row: removed the fabricated global motif; described the actual mechanism (`Length==8` then `InRe`+`Range` on each `SubString` position).
- Point 2: removed the `Star` claim; honestly contrasted the two approaches (class per position via `InRe`+`Range` vs precise character via `== StringVal`, both fixing `Length==8`).
- Points 1 and 3 (correct) preserved verbatim.

Minimal diff: 1 file, +2/-2.

## Verification (G.1, firsthand against origin/main)

- **Determinism check**: Z3-Python-04 is pure Z3 string theory (deterministic solver, `sat`-based). Zero LLM/API/mealpy/np.random/openai/gemini footprint -- the committed output is reproducible ground truth, safe to treat as authoritative. (Contrast SL-9/Search-11 which are NOT safe to "fix" without a determinism gate.)
- cell 19 grep: `Star`=False, `[a-z]*[A-Z][a-z]*`=False, `Length`/`SubString`/`Range`=True.
- Notebook valid (32 cells: 20 md, 12 code), `nbformat.validate` PASS.
- Output `Hppp0ppp`/`XABC7DFE` unchanged; both still `sat`/valid.
- Single file, +2/-2; no churn to other cells.

See #3801 (doc-honesty / SOTA registry) -- partial contribution to the SMT/Z3 doc-honesty sweep, does not close the epic.

Grain: doc-honesty/markdown-vs-code -- lane po-2026:CoursIA -- prev: translation/gt7-csv-resync (#7916)

Co-Authored-By: Claude <noreply@anthropic.com>
