### PR TITLE
fix(search,#3801): Search-12-PDB prose stale — 5 tuiles->4 + optimal 32-44->26-52 (markdown-only)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part3-Advanced/Search-12-PatternDatabases.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part3-Advanced/Search-12-PatternDatabases.ipynb
@@ -255,8 +255,8 @@
    "source": [
     "## 5. PDB simple : construction par BFS rétrograde\n",
     "\n",
-    "On construit d'abord une PDB sur **un** motif de 5 tuiles. BFS = coût unitaire =\n",
-    "distances optimales depuis le but abstrait. Cette PDB unique couvre 5 tuiles ;\n",
+    "On construit d'abord une PDB sur **un** motif de 4 tuiles. BFS = coût unitaire =\n",
+    "distances optimales depuis le but abstrait. Cette PDB unique couvre 4 tuiles ;\n",
     "elle servira de briques, puis la **PDB additive** (section 7) en combinera\n",
     "plusieurs pour couvrir les 15 tuiles."
    ],
@@ -319,7 +319,7 @@
    "source": [
     "## 6. La SOTA : PDB *additives* (Korf & Felner 2002)\n",
     "\n",
-    "Une PDB unique sur 5 tuiles n'informe qu'un tiers du puzzle. L'idée de génie de\n",
+    "Une PDB unique sur 4 tuiles n'informe qu'environ un quart du puzzle. L'idée de génie de\n",
     "Korf & Felner (2002) : **partitionner** les 15 tuiles en groupes *disjoints* et\n",
     "construire une PDB par groupe, en ne comptant — dans chaque BFS — **que les\n",
     "mouvements des tuiles du groupe**. Les coûts deviennent alors **additifs** :\n",
@@ -512,7 +512,7 @@
    "source": [
     "## 9. Expérience : Manhattan vs PDB additive (la valeur du moteur, visible)\n",
     "\n",
-    "Trois instances **réalistement difficiles** (brouillage 50-90 pas, optimal ~32-44\n",
+    "Trois instances **réalistement difficiles** (brouillage 50-90 pas, optimal ~26-52\n",
     "coups). On résout à l'optimum avec (a) Manhattan seule, puis (b) la PDB additive.\n",
     "On mesure les **nœuds explorés** : c'est la métrique qui révèle la puissance de\n",
     "l'heuristique. Sur les instances les plus dures, Manhattan frappe la limite\n",


### PR DESCRIPTION
Grain: MED/doc-honesty — lane myia-po-2025:CoursIA — prev: MED/doc-honesty (#7925 Part2-CSP)

## Defect (class A doc-honesty, G.1 firsthand-verified, Explore scan findings)

Three markdown interpretation cells in **Search-12-PatternDatabases** were written for a 5-tile PDB / "32-44 coups" scenario the code no longer matches. A prior refactor trimmed `PATTERN` 5→4 and changed benchmark seeds; the surrounding §5-§9 prose was not updated. Markdown-only (C.2 exception: no code cell touched, no re-exec — outputs already correct ground truth). Deterministic notebook (fixed seeds 11/23/41/1/7; IDA* + BFS are exact algorithms).

### Cell 9 (markdown §5) — "5 tuiles" but PDB builds 4
- Markdown: *"On construit d'abord une PDB sur **un** motif de 5 tuiles ... Cette PDB unique couvre 5 tuiles"*
- Cell 10 code (ground truth): `PATTERN = (1, 2, 3, 4)   # motif de 4 tuiles (concept)`
- Cell 10 output: `PDB simple (4 tuiles) : 524,160 états en 9.3s`
- Fix: `5 tuiles` → `4 tuiles` (both mentions).

### Cell 11 (markdown §6) — "5 tuiles ... un tiers" doubly wrong
- Markdown: *"Une PDB unique sur 5 tuiles n'informe qu'un tiers du puzzle."*
- Same 5→4 issue. Plus `"un tiers"` (5/15 = 33%) is wrong for 4 tiles: 4/15 ≈ 27% ≈ `"un quart"`.
- Fix: `"4 tuiles ... environ un quart"`. (The partition "4-4-4-3" covering 15 tiles described later in the cell is already consistent with a 4-tile single PDB.)

### Cell 17 (markdown §9 intro) — "optimal ~32-44 coups" but range is 26-52
- Markdown: *"Trois instances **réalistement difficiles** (brouillage 50-90 pas, optimal ~32-44 coups)."*
- Cell 18 output (ground truth):
  ```
  I1 (brouillage 50)   optimal=26
  I2 (brouillage 70)   optimal=40
  I3 (brouillage 90)   optimal=52
  ```
  Two of three instances (I1=26, I3=52) fall OUTSIDE the claimed 32-44 band; actual range 26-52. The cell 19 interpretation table already lists the true 26/40/52 values — the §9 intro prose contradicts the notebook's own results table.
- Fix: `optimal ~32-44 coups` → `optimal ~26-52 coups`.

## G.1 firsthand verification

Read the full cell 10 source (confirmed `PATTERN = (1, 2, 3, 4)`) + cell 10 output (`4 tuiles`), cell 18 benchmark output (optimal 26/40/52), and cells 9/11/17 markdowns, all on `origin/main`, before editing. Confirmed all 3 mismatches.

## Validation

- **nbformat validate OK** (30 cells)
- **H.3 notebook_tools validate**: 0 Errors (1 pre-existing Warning, confirmed identical on `origin/main` — not introduced here)
- **Scope**: cells 9, 11, 17 source only (27 other cells byte-identical). **0 output diffs**.
- **C.1**: 0 banned patterns.
- **Catalogue byte-identical to main** (R1) — diff empty.
- **Deterministic** (fixed seeds; exact IDA*/BFS).
- **0 leaks**, **CRLF=0, LF, UTF-8 no-BOM, trailing-nl**.
- Surgical raw-json round-trip (indent=1, ensure_ascii=False), 4+/4-, 1 file.

## SOTA verdict

**SOTA-OK** — the additive PDB engine (Korf & Felner 2002) genuinely runs: cell 18 shows real IDA* node counts (653 / 655,908 / 20,000,000 for Manhattan vs 78 / 63,018 / 972,772 for additive, speedups ×8.4/×10.4/×20.6). The fixes correct stale *markdown interpretation* (post-refactor prose drift), not the engine. No tool missing, no workaround, no re-exec needed.

## Residual (LOW/borderline — NOT addressed, needs re-exec)

Cell 21 (matplotlib title, CODE cell) + cell 29 (conclusion) both say *"un à deux ordres de grandeur"* but observed speedups ×8.4/×10.4/×20.6 = 0.92/1.02/1.31 orders (ceiling ~1.3, not 2). Cell 21 is a `set_title` string baked into the PNG → fixing it requires a re-exec + figure regen, out of scope for a markdown-only PR. Left as a follow-up grain.

## Method

Defects found via Explore sonnet scan (read-only, **Search Part3-Advanced family — fresh rotation out of Part2-CSP per R6**), G.1 firsthand-verified. Search-13-LimitedDiscrepancySearch and Search-14-WeightedAstar verified CLEAN (negative results logged to prevent re-scan).

See #3801.

Generated with Claude Code
