### PR TITLE
fix(pymc,#3801): PyMC-6 ADVI convergence (n=10000 -> n=100000) so the demo shows what it claims

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-6-Debugging.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-6-Debugging.ipynb
@@ -616,7 +616,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "b51fae2c",
    "metadata": {
     "execution": {
@@ -636,13 +636,6 @@
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Initializing NUTS using jitter+adapt_diag...\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
@@ -651,6 +644,13 @@
       "Observations : [2.1 1.9 2.3 2.  1.8 2.2]\n",
       "Moyenne empirique : 2.050\n",
       "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Initializing NUTS using jitter+adapt_diag...\n"
      ]
     },
     {
@@ -671,14 +671,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 2 chains for 1_000 tune and 2_000 draw iterations (2_000 + 4_000 draws total) took 10 seconds.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "There was 1 divergence after tuning. Increase `target_accept` or reparameterize.\n"
+      "Sampling 2 chains for 1_000 tune and 2_000 draw iterations (2_000 + 4_000 draws total) took 23 seconds.\n"
      ]
     },
     {
@@ -692,7 +685,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Finished [100%]: Average Loss = 16.555\n"
+      "Finished [100%]: Average Loss = 9.5596\n"
      ]
     },
     {
@@ -700,8 +693,8 @@
      "output_type": "stream",
      "text": [
       "Resultats sur le parametre 'mean' :\n",
-      "  NUTS : mean = 2.044, std = 0.1321\n",
-      "  ADVI : mean = 1.556, std = 0.9984\n",
+      "  NUTS : mean = 2.049, std = 0.1112\n",
+      "  ADVI : mean = 2.047, std = 0.0985\n",
       "\n",
       "Note : ADVI tend a avoir une variance plus faible (sous-estime l'incertitude)\n",
       "       car il approxime par une distribution gaussienne factorisee.\n"
@@ -736,7 +729,7 @@
     "    sigma = pm.HalfNormal(\"sigma\", sigma=10)\n",
     "    obs = pm.Normal(\"obs\", mu=mean, sigma=sigma, observed=observations)\n",
     "    approx = pm.fit(\n",
-    "        method=\"advi\", n=10000, random_seed=RANDOM_SEED,\n",
+    "        method=\"advi\", n=100000, random_seed=RANDOM_SEED,\n",
     "        progressbar=False\n",
     "    )\n",
     "    trace_advi = approx.sample(2000)\n",
@@ -769,24 +762,24 @@
    "source": [
     "**interprétation des résultats NUTS vs ADVI** :\n",
     "\n",
-    "Les deux algorithmes estiment la moyenne autour de 2.05 (proche de la moyenne empirique), mais avec des caractéristiques différentes :\n",
+    "Les deux algorithmes estiment la moyenne autour de 2.05 (proche de la moyenne empirique 2.050), avec un accord quasi-parfait sur l'estimation ponctuelle : NUTS `mean=2.049` et ADVI `mean=2.047`. Les deux std postérieures (`NUTS=0.111`, `ADVI=0.099`) sont également très proches et sous-estiment légèrement l'écart-type empirique (les 6 observations donnent un écart-type d'échantillon ~0.18), ce qui est attendu avec un prior aussi vague et peu de données.\n",
     "\n",
     "| Metrique | NUTS | ADVI | interprétation |\n",
     "|----------|------|------|----------------|\n",
     "| Moyenne postérieure | ~2.05 | ~2.05 | Accord sur l'estimation ponctuelle |\n",
-    "| Ecart-type postérieur | ~0.13 (observe) | ~1.00 (observe) | Sur cet exemple n=6, ADVI deplace sa moyenne (1.56 vs 2.04) et sa variance marginale est plus large - voir note ci-dessous |\n",
+    "| Ecart-type postérieur | ~0.11 | ~0.10 | ADVI légèrement plus petit (sous-estimation marginale de l'incertitude) |\n",
     "\n",
     "> **Pourquoi ADVI sous-estime l'incertitude ?**\n",
     "> \n",
-    "> ADVI (Automatic Differentiation Variational inférence, Kucukelbir et al. 2017) approxime le posterior par une distribution gaussienne factorisee (\"mean-field\"). Cette hypothese d'indépendance ignore les corrélations entre variables, ce qui conduit **en général (asymptotiquement)** a des posteriors trop \"confiants\" (variance sous-estimee).\n",
+    "> ADVI (Automatic Differentiation Variational Inférence, Kucukelbir et al. 2017) approxime le posterior par une distribution gaussienne factorisée (\"mean-field\"). Cette hypothèse d'indépendance ignore les corrélations entre variables, ce qui conduit **en général (asymptotiquement)** à des posteriors trop \"confiants\" (variance sous-estimée).\n",
     ">\n",
-    "> **Sur ce petit exemple (n=6)** : l'output montre l'inverse - `ADVI: std=0.9984` vs `NUTS: std=0.1321`. La cause est qu'ADVI deplace sa moyenne (1.56 vs 2.04) sur aussi peu de données, ce qui gonfle la variance marginale. Ce cas illustre que la sous-estimation ADVI est une **tendance asymptotique**, pas une garantie sur chaque run. Pour un diagnostic fiable, utiliser un plus grand n ou comparer les intervalles de prediction.\n",
+    "> **Important — convergence d'ADVI** : ADVI fait de la descente de gradient stochastique ; il faut **suffisamment d'itérations** pour converger. Avec trop peu d'itérations (par ex. `n=10000` ici), la moyenne postérieure d'ADVI reste éloignée de la vraie valeur (~1.56 au lieu de ~2.05) et sa variance marginale explose — l'inverse de la tendance asymptotique. C'est pourquoi cette cellule lance `n=100000` itérations : à convergence, ADVI et NUTS sont d'accord sur la moyenne (2.047 vs 2.049), et l'écart-type ADVI (0.099) est seulement légèrement plus petit que celui de NUTS (0.111) — la sous-estimation mean-field est ici marginale. **Leçon de debugging** : un désaccord marqué entre NUTS et ADVI sur un modèle simple est souvent le signe d'une ADVI sous-convergée (augmenter `n`), pas d'un bug du modèle.\n",
     ">\n",
-    "> NUTS (No-U-Turn Sampler) echantillonne directement du posterior, capturant les corrélations et produisant des estimations d'incertitude plus fiables.\n",
+    "> NUTS (No-U-Turn Sampler) échantillonne directement du posterior, capturant les corrélations et produisant des estimations d'incertitude plus fiables (et sans paramètre `n` à régler).\n",
     "\n",
-    "**Quand cela importe** : La sous-estimation de l'incertitude par ADVI peut etre problematique pour :\n",
-    "- La prise de decision sous incertitude\n",
-    "- Les intervalles de prediction\n",
+    "**Quand cela importe** : La sous-estimation de l'incertitude par ADVI peut être problématique pour :\n",
+    "- La prise de décision sous incertitude\n",
+    "- Les intervalles de prédiction\n",
     "- La propagation de l'incertitude dans des modèles hiérarchiques"
    ]
   },


### PR DESCRIPTION
## Defect (Prong-B SOTA honesty)

The notebook's stated pedagogical point (cell 14) is that **NUTS and ADVI give comparable results** on a simple Gaussian-mean model. But the committed run (cell 15) used `pm.fit(n=10000)`, which **under-converges** mean-field ADVI:

```
committed cell 15 output:
  NUTS : mean = 2.044, std = 0.1321
  ADVI : mean = 1.556, std = 0.9984   <- far from empirical mean 2.05
```

So ADVI was NOT comparable to NUTS on the committed run. cell 16 markdown was then **self-contradictory**: it claimed "~2.05 / accord" in one table row while a footnote admitted "ADVI deplace sa moyenne (1.56 vs 2.04)". The hardcoded note in cell 15 ("ADVI variance plus faible") was also **refuted** by the very output (std 0.9984 > 0.1321).

## Root cause (firsthand-verified)

ADVI needs more iterations to converge on this model. Probe (genuine kernel, `RANDOM_SEED=42`):

```
n=10000  -> ADVI mean=1.585, std=1.041   (under-converged, as committed)
n=100000 -> ADVI mean=2.042, std=0.098   (converged, ~= NUTS)
```

## Fix

Increase `n=10000 -> n=100000` so ADVI actually converges and the demo demonstrates what it announces. Re-exec cell 15 via nbconvert (genuine kernel), new committed output:

```
  NUTS : mean = 2.049, std = 0.1112
  ADVI : mean = 2.047, std = 0.0985   <- now ~= NUTS, ~= empirical 2.05
```

With convergence, the markdown claims become **TRUE**: both ~2.05, agreement on the point estimate. cell 16 is rewritten to reflect the converged results and to turn the under-convergence into an explicit **debugging lesson** ("a marked NUTS-vs-ADVI disagreement on a simple model is often under-converged ADVI, not a model bug"). The refuted stale values (1.56, 0.9984) are removed from the running interpretation; 1.56 survives only as a cited counter-example inside the debugging lesson.

This is the **SOTA-honest fix** (make ADVI converge) rather than a doc-only workaround that rationalizes a disagreement. Replaces the committed under-converged output with genuine re-executed output (Stop & Repair: no hand-edited outputs).

## Scope & validation

- 2 cells changed (15 src+outputs, 16 markdown), **41 byte-identical** to main (json `indent=1 ensure_ascii=False +
`).
- Repo validator **PASS** (13 code cells, 0 null-exec); **C.1 clean**; **LF only** (0 CRLF).
- Collision-guarded (`gh pr view --json files` sweep: 0 open PR touches `PyMC-6-Debugging.ipynb`).

See #3801 (Prong-B SOTA honesty). Found by sonnet doc-honesty scan of the PyMC family, firsthand-verified + root-caused + convergence-tested locally.

Co-Authored-By: Claude-Code <noreply@anthropic.com>