### PR TITLE
fix(probas,#3801): PyMC-4 d-separation collider claim contradicted by own cell 19 output

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-4-Bayesian-Networks.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-4-Bayesian-Networks.ipynb
@@ -962,8 +962,10 @@
     "   - En observant C : S et R deviennent independants (D-separes)\n",
     "\n",
     "2. **Collision** (Collider) : Sprinkler --> WetGrass <-- Rain\n",
-    "   - Sans observation : S et R sont independants\n",
+    "   - Sans observation : S et R sont independants (regle du collider PUR, valide quand il n'existe **aucun autre chemin** entre eux)\n",
     "   - En observant W : S et R deviennent dependants (explaining away)\n",
+    "\n",
+    "   **Nuance -- reseau Wet Grass complet** : S et R partagent AUSSI la cause commune Cloudy (fourche S <-- C --> R), qui reste un chemin ouvert. La regle d'independence du collider ne s'applique donc pas telle quelle : S et R restent marginalement DEPENDANTS via C. C'est ce que mesure la cellule suivante (correlation -0.263 sans observation). L'effet PROPRE du collider n'apparait qu'en comparant cette correlation marginale a la correlation sachant W=1 (-0.740) : l'ecart supplementaire est l'explaining away.\n",
     "\n",
     "La D-separation est formalisee par **Pearl, Geiger & Verma (1989)** et **Verma & Pearl (1988)**, *Causal Networks: Semantics and Expressiveness*.\n"
    ]


### PR DESCRIPTION
Grain: MED/doc-honesty — lane myia-po-2025:CoursIA — prev: DEEP/code-correctness (#7936 CSP-7 Prong-B)

## Defect — PyMC-4 d-separation collider claim contradicted by its own output (class A doc-honesty)

Cell 18 (markdown §7 "D-Separation", item 2 Collider) states, under "Structures du réseau Wet Grass":

> **Collision** (Collider) : Sprinkler --> WetGrass <-- Rain
> - Sans observation : S et R sont **indépendants**

This is the **pure-collider** rule — correct for an isolated collider X→Z←Y with no other path between the parents. **But in the full Wet Grass network, S and R ALSO share the common cause Cloudy** (the fork S ← C → R), which is an open path when C is unobserved. So S and R are **marginally dependent**, and the pure-collider independence rule does **not** apply to this network as stated.

**Cell 19's own committed output proves the dependence:**
```
=== D-Separation : Fourche (S <-- C --> R) ===
Correlation S-R sans observation : -0.2630
-> S et R sont dependants (partagent la cause C)
```
A student reading cell 18 ("S et R indépendants sans observation") then cell 19 ("Corr S-R = -0.263 → dépendants") sees a **direct contradiction**.

### G.1 firsthand verification
Read full cell 18 markdown + cell 19 source + committed output (`-0.2630` / `-0.7400`) on `origin/main` before editing. Confirmed the mismatch. Deterministic: d-separation is a graph-theoretic property, and the `-0.263` is confirmed by the analytic marginal correlation `Cov(S,R)/√(VarS·VarR)` (recomputed by the scan agent).

## Fix (markdown-only, cell 18)

Keep the pure-collider rule (pedagogically correct in isolation) but add a nuance: in the Wet Grass complet, the fork via C keeps S,R marginally dependent (`-0.263`, cell 19); the collider's *propre* effect only appears by comparing the marginal correlation (`-0.263`) to the correlation sachant W=1 (`-0.740`) — the extra gap is the explaining away. Reconciles cell 18 markdown with cell 19 output.

## Validation

- **nbformat.validate OK** (26 cells).
- **H.3 notebook_tools validate**: 0 Errors (1 pre-existing Warning, identical on `origin/main` — not introduced).
- **Scope**: cell 18 source only (25 other cells byte-identical). **0 output diffs**.
- **C.1**: 0 banned patterns.
- **Deterministic** (d-separation graph-theoretic; fixed-seed + analytic-confirmed correlation).
- **Markdown-only** (C.2 exception: no re-exec — outputs already correct ground truth).
- **0 leaks**, **CRLF=0, LF, UTF-8 no-BOM, trailing-nl**.
- **Catalogue byte-identical to main**.
- No catalog touched.

## SOTA verdict

**SOTA-OK** — the PyMC Bayesian-network engine genuinely runs (cell 19 shows real Wet-Grass sampling with honest d-separation measurements). The fix corrects stale *markdown prose* (a pure-collider rule stated without the network-context caveat), not the engine. No tool missing, no workaround, no re-exec needed.

## Method

Defect found via Explore sonnet scan of the Probas-Python (PyMC) family — fresh rotation out of Search. G.1 firsthand-verified. The PyMC family is otherwise clean: PyMC-1/2/5/7/9-19 verified CLEAN (PyMC-5 Causal-Inference notably high-quality, fully deterministic exact engine); PyMC-3 (cell 8 "Explaining Away" misnomer), PyMC-6 (ADVI variance, non-deterministic), PyMC-8 (cosmetic constants), PyMC-15 (degenerate PMF demo, non-deterministic) are LOW/borderline non-actionable — logged to prevent re-scan.

See #3801.

Generated with Claude Code
