### PR TITLE
feat(gametheory): GT-15 additif — WAIT-ACT margin analysis explainer

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games/__init__.py
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games/__init__.py
@@ -114,6 +114,8 @@ __all__ = [
     "off_switch_game",
     "off_switch_analysis",
     "off_switch_metauncertain",
+    "off_switch_margin_analysis",
+    "off_switch_margin_report",
     "AssistanceGame",
     "paperclip_vs_coordination_comparison",
     "PaperclipGameResult",

--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games/assistance_games.py
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games/assistance_games.py
@@ -466,6 +466,147 @@ def off_switch_metauncertain(
     )
 
 
+# Additive Pedagogical Analysis — WAIT-ACT Margin vs Confidence
+# ============================================================================
+#
+# This block is an ADDITIVE pedagogical complement to the Off-Switch Game above.
+# It does NOT replace override_threshold (which is a deliberate safety choice,
+# see git blame: commit 467e9a1f7 by jsboige, 2026-02-01, rationale comment:
+# "Robots with <90% confidence now defer (SAFE zone); better reflects AIMA
+# insight: uncertainty makes robots safer"). It makes the math explicit:
+#
+#   WAIT-ACT margin = E[U|WAIT] - E[U|ACT]
+#                    = p           - (2p - 1)
+#                    = 1 - p
+#
+# The margin SHRINKS linearly with confidence and vanishes at p=1. The
+# override_threshold = 0.9 therefore lives in a regime where the margin is
+# exactly 1 - 0.9 = 0.1 (10% of utility). That is the SAFETY CHOICE: by
+# staying strictly below the "almost certain" regime (margin -> 0), the
+# robot remains in the "provably deferring" zone.
+#
+# Reading guide:
+#   - margin(0.5) = 0.5  : large safety buffer, WAIT obviously dominates
+#   - margin(0.9) = 0.1  : threshold zone, 10% margin — override_threshold
+#   - margin(0.99) = 0.01: razor-thin, near certainty
+#   - margin(1.0) = 0    : limit case, off-switch is moot (robot IS certain)
+
+
+def off_switch_margin_analysis(
+    override_threshold: float = 0.9,
+    n_points: int = 1001,
+) -> Dict[str, np.ndarray]:
+    """Analyze how the WAIT-ACT margin shrinks as robot confidence grows.
+
+    This is a pedagogical complement to :func:`off_switch_game`. The core
+    game (above) is left untouched; this function sweeps the closed interval
+    [0, 1] and returns the three primitive quantities plus their difference
+    (the margin) and the binary defer/override decision.
+
+    Args:
+        override_threshold: Confidence above which the robot may resist.
+            Defaults to 0.9 (matches :func:`off_switch_game` default).
+        n_points: Number of sweep points on the confidence axis.
+
+    Returns:
+        Dictionary with keys:
+          - ``confidence`` (n_points,): confidence values p in [0, 1]
+          - ``wait`` (n_points,):       E[U | WAIT] = p
+          - ``act`` (n_points,):        E[U | ACT]  = 2p - 1
+          - ``margin`` (n_points,):     E[U|WAIT] - E[U|ACT] = 1 - p
+          - ``defers`` (n_points, bool): robot defers iff p < override_threshold
+          - ``threshold_margin`` (float): margin at p = override_threshold
+          - ``override_threshold`` (float): echoed for downstream consumers
+    """
+    p = np.linspace(0.0, 1.0, n_points)
+    wait = p                 # E[U|WAIT]
+    act = 2.0 * p - 1.0      # E[U|ACT]
+    margin = wait - act      # = 1 - p, by construction
+    defers = p < override_threshold
+
+    return {
+        "confidence": p,
+        "wait": wait,
+        "act": act,
+        "margin": margin,
+        "defers": defers,
+        "threshold_margin": float(1.0 - override_threshold),
+        "override_threshold": float(override_threshold),
+    }
+
+
+def off_switch_margin_report(
+    override_threshold: float = 0.9,
+    samples: Tuple[float, ...] = (0.5, 0.8, 0.9, 0.95, 0.99, 1.0),
+) -> str:
+    """Print a human-readable WAIT-ACT margin report at sampled confidences.
+
+    Args:
+        override_threshold: Forwarded to :func:`off_switch_margin_analysis`.
+        samples: Tuple of confidence values to display.
+
+    Returns:
+        Multi-line string with a per-sample table (p, WAIT, ACT, margin,
+        defers?).
+    """
+    analysis = off_switch_margin_analysis(override_threshold=override_threshold)
+    p_arr = analysis["confidence"]
+
+    lines = [
+        "=" * 64,
+        "OFF-SWITCH GAME — WAIT-ACT MARGIN vs CONFIDENCE",
+        "=" * 64,
+        "",
+        f"Override threshold (deliberate safety choice): "
+        f"{override_threshold:.3f}",
+        f"Threshold margin = 1 - threshold = "
+        f"{analysis['threshold_margin']:.3f}",
+        "",
+        "Margin = E[U|WAIT] - E[U|ACT] = p - (2p - 1) = 1 - p",
+        "",
+        f"{'p':>6}  {'WAIT':>8}  {'ACT':>8}  {'margin':>8}  {'defers':>8}",
+        "-" * 64,
+    ]
+
+    for s in samples:
+        # Locate the closest sweep point to the requested sample.
+        idx = int(np.argmin(np.abs(p_arr - s)))
+        wait_v = float(analysis["wait"][idx])
+        act_v = float(analysis["act"][idx])
+        margin_v = float(analysis["margin"][idx])
+        defers_v = bool(analysis["defers"][idx])
+        marker = "<= threshold" if defers_v else ">  threshold"
+        lines.append(
+            f"{s:>6.3f}  {wait_v:>8.3f}  {act_v:>8.3f}  "
+            f"{margin_v:>8.3f}  {marker}"
+        )
+
+    lines.extend([
+        "",
+        "INTERPRETATION:",
+        "-" * 64,
+        f"  At p = {override_threshold:.2f}, the WAIT-ACT margin is",
+        f"  exactly {analysis['threshold_margin']:.2f}. Choosing this",
+        "  threshold keeps the robot in a regime where waiting is",
+        "  RATIONALLY better than acting by a measurable, non-tiny",
+        "  amount. Above the threshold the margin keeps shrinking;",
+        "  below it the margin is large enough that a rational robot",
+        "  has no reason to override the human.",
+        "",
+        "  This is why the threshold is NOT 0.5 (too conservative —",
+        "  robots would defer on tasks they obviously understand) and",
+        "  NOT 1.0 (trivially permissive — margin is exactly 0, the",
+        "  off-switch loses all bite). 0.9 is the deliberately safe",
+        "  middle: a 10% margin that is small enough to be honest",
+        "  about robot competence, large enough to keep humans in",
+        "  the loop.",
+        "",
+        "=" * 64,
+    ])
+
+    return "\n".join(lines)
+
+
 # ============================================================================
 # Assistance Game as Cooperative Game
 # ============================================================================

--- a/MyIA.AI.Notebooks/GameTheory/tests/test_assistance_games.py
+++ b/MyIA.AI.Notebooks/GameTheory/tests/test_assistance_games.py
@@ -44,6 +44,8 @@ from cooperative_games.assistance_games import (  # noqa: E402
     off_switch_analysis,
     off_switch_game,
     off_switch_metauncertain,
+    off_switch_margin_analysis,
+    off_switch_margin_report,
     paperclip_game_equilibrium,
     paperclip_payoff_analysis,
     paperclip_print_analysis,
@@ -389,3 +391,91 @@ class TestAssistanceGame:
         res = ag.analyze_assistance_value()
         # humans_alone=0 -> pct branche sur 0
         assert res["assistance_gain_pct"] == 0.0
+
+
+# ── Off-Switch margin analysis (additive pedagogical complement) ────────────
+
+
+class TestOffSwitchMarginAnalysis:
+    """Complement pedagogique : marge WAIT-ACT = 1 - p qui tend vers 0
+    quand p -> 1. Le seuil override_threshold = 0.9 vit dans la zone ou
+    marge = 10% (choix de securite delibere, cf commit 467e9a1f7).
+    """
+
+    def test_margin_identity_one_minus_p(self):
+        # Identity: margin = 1 - p partout sur la grille de sweep.
+        a = off_switch_margin_analysis(override_threshold=0.9, n_points=501)
+        np.testing.assert_allclose(a["margin"], 1.0 - a["confidence"], atol=1e-12)
+
+    def test_wait_equals_confidence(self):
+        # E[U|WAIT] = p.
+        a = off_switch_margin_analysis(override_threshold=0.9)
+        np.testing.assert_allclose(a["wait"], a["confidence"], atol=1e-12)
+
+    def test_act_equals_two_p_minus_one(self):
+        # E[U|ACT] = 2p - 1.
+        a = off_switch_margin_analysis(override_threshold=0.9)
+        np.testing.assert_allclose(a["act"], 2.0 * a["confidence"] - 1.0, atol=1e-12)
+
+    def test_arrays_aligned_length(self):
+        a = off_switch_margin_analysis(override_threshold=0.9)
+        n = len(a["confidence"])
+        assert n == len(a["wait"]) == len(a["act"]) == len(a["margin"]) == len(a["defers"])
+        assert n == 1001  # defaut
+
+    def test_threshold_margin_exact(self):
+        # A p = override_threshold = 0.9, marge = 0.1.
+        a = off_switch_margin_analysis(override_threshold=0.9)
+        assert a["threshold_margin"] == pytest.approx(0.1)
+
+    def test_threshold_margin_with_custom(self):
+        # Seuil 0.5 -> marge au seuil = 0.5.
+        a = off_switch_margin_analysis(override_threshold=0.5)
+        assert a["threshold_margin"] == pytest.approx(0.5)
+
+    def test_margin_vanishes_at_p_one(self):
+        # Limite : a p=1, marge = 0 exactement.
+        a = off_switch_margin_analysis(override_threshold=0.9)
+        assert a["margin"][-1] == pytest.approx(0.0, abs=1e-12)
+
+    def test_margin_is_one_at_p_zero(self):
+        # Limite basse : a p=0, marge = 1 (robot tres incertain, WAIT >> ACT).
+        a = off_switch_margin_analysis(override_threshold=0.9)
+        assert a["margin"][0] == pytest.approx(1.0)
+
+    def test_defers_strict_inequality_at_threshold(self):
+        # p < override_threshold (strict) -> defers True. p = 0.9, threshold = 0.9 -> defers False.
+        a = off_switch_margin_analysis(override_threshold=0.9)
+        # p=0.9 est dans la grille (linspace inclut 1.0 et 0.0).
+        idx = int(np.argmin(np.abs(a["confidence"] - 0.9)))
+        assert a["defers"][idx] == False  # noqa: E712 (numpy bool)
+        # p=0.89 -> defers True.
+        idx89 = int(np.argmin(np.abs(a["confidence"] - 0.89)))
+        assert a["defers"][idx89] == True  # noqa: E712
+
+    def test_echoed_threshold_in_return(self):
+        a = off_switch_margin_analysis(override_threshold=0.7)
+        assert a["override_threshold"] == pytest.approx(0.7)
+
+
+class TestOffSwitchMarginReport:
+    """off_switch_margin_report produit un rapport lisible."""
+
+    def test_report_contains_key_phrases(self):
+        out = off_switch_margin_report()
+        assert "OFF-SWITCH GAME" in out
+        assert "WAIT-ACT MARGIN" in out
+        assert "Override threshold" in out
+
+    def test_report_table_has_header_and_rows(self):
+        out = off_switch_margin_report()
+        # Header + au moins 1 ligne par echantillon (defaut 6).
+        assert "p" in out and "WAIT" in out and "ACT" in out and "margin" in out
+        # Verifie qu'au moins un sample est affiche.
+        assert "0.500" in out  # sample par defaut
+
+    def test_report_threshold_explanation(self):
+        # L'interpretation explique pourquoi le seuil est a 0.9 et pas 0.5 ou 1.0.
+        out = off_switch_margin_report(override_threshold=0.9)
+        assert "0.90" in out or "0.9" in out
+        assert "deliberately" in out or "deliberate" in out or "safety" in out.lower()


### PR DESCRIPTION
## GT-15 additif — explainer WAIT-ACT margin (Off-Switch Game)

**Grain: MED/additive-pedagogical** — lane `myia-po-2025:CoursIA-2` — prev: MED/docs-hygiene (`ref-quality`, c.728y+48, PR #7940).

### Verdict steer ai-01 — additive pédagogique respecte user-authored feature

Suite au DM HIGH `msg-20260722T105726-x2vaeb` (point #2), grain DEEP/MED GT-15 additif **complète** la leçon `override_threshold=0.9` **sans la retirer** (anti-régression : #7914 FP sur audit-reassessment confirmé, override_threshold n'est PAS un bug — provenance commit `467e9a1f7` user-authored 2026-02-01, rationale verbatim : *"Robots with <90% confidence now defer (SAFE zone); better reflects AIMA insight: uncertainty makes robots safer"*).

**Cible** : `MyIA.AI.Notebooks/GameTheory/cooperative_games/assistance_games.py` (Python — la lane est bien `Python/GameTheory/Argument_Analysis`, pas Lean).

### Math rendue explicite (le insight)

Le code de `off_switch_game` calcule en silence :
```
E[U | WAIT] = p
E[U | ACT]  = 2p - 1
```

La **marge** = E[U|WAIT] - E[U|ACT] = `p - (2p - 1)` = **`1 - p`**.

Au seuil `override_threshold = 0.9`, **marge = 0.1** (10% de marge d'utilité sous la zone d'override). C'est exactement le **choix de sécurité délibéré** :
- **Pas 0.5** : trop conservateur (robots déféreraient sur des tâches qu'ils comprennent évidemment)
- **Pas 1.0** : trivialement permissif (marge = 0, off-switch sans mordant)
- **0.9** : 10% de marge — assez honnête sur la compétence du robot, assez large pour garder l'humain dans la boucle

### Additions (3 fichiers, +234/-0 nominal)

| Fichier | Δ | Contenu |
|---------|---|---------|
| `MyIA.AI.Notebooks/GameTheory/cooperative_games/assistance_games.py` | +142/-0 | `off_switch_margin_analysis()` (numpy sweep + dict structuré) + `off_switch_margin_report()` (table échantillonnée + interprétation) |
| `MyIA.AI.Notebooks/GameTheory/cooperative_games/__init__.py` | +2/-0 | Exports des 2 nouvelles fonctions |
| `MyIA.AI.Notebooks/GameTheory/tests/test_assistance_games.py` | +90/-0 | 13 nouveaux tests (identité marge = 1-p, threshold_margin, defers strict inequality, report structure) |

### Validation (H.1 firsthand)

```
$ python -m pytest MyIA.AI.Notebooks/GameTheory/tests/test_assistance_games.py -v
============================= 54 passed in 0.80s =============================
```

- **41 tests existants** : **41/41 PASSED** (intact, aucune régression, notamment `test_custom_override_threshold` L206-209 qui valide que `override_threshold` est un paramètre intentionnel)
- **13 nouveaux tests** : **13/13 PASSED** — couvrent les invariants mathématiques (margin = 1 - p, wait = p, act = 2p-1), le comportement au seuil (strict inequality `p < override_threshold`), et la lisibilité du rapport

### Conformité

- **c.187 HARD atomic** : 1 commit `b4ceea1b2` / 3 fichiers / +234/-0 nominal ✓
- **L279 NEW** : PR créée par worker, **PAS mergée** localement — sweep §H.4 awaiting ai-01 ✓
- **L281 NEW** : rebase frais `origin/main @ b8a2cbb47` (worktree `D:/dev/CoursIA-2-gt15-additif`) ✓
- **L282 NEW** : `[CLAIMED] GT-15 additif — myia-po-2025:CoursIA-2` posté dashboard AVANT `git push` ✓ (mirror-lanes protection)
- **L283 NEW** : aucun claim vérifié via dashboard status condensé — `git log --oneline -1` firsthand ✓
- **c.281-L1 NEW** : MD047 trailing newline sur les 3 fichiers vérifié (`endsLF=True hasCRLF=False`) ✓
- **CJK post-edit filter** : 0 codepoint parasite (Edit tool avec contrôle `replace_all=false`, ASCII pur)
- **R1 catalog-pr-hygiene** : 0 fichier catalogue touché ✓
- **R3 atomic** : 1 sujet (WAIT-ACT margin analysis), 1 domaine (GameTheory), pas de composite ✓
- **R6/R7** : 11 cycles consécutifs docs-hygiene → GT-15 additif cross-famille (GameTheory/Argument_Analysis Python) **✓ G-VAR-3** pivot majeure anti-monoculture ✓ **G-VAR-1** MED/additive-pedagogical = substance (raisonnement de domaine : démontrer l'identité math `1-p`, pas du scan-génère)
- **G.1 firsthand** : `commit 467e9a1f7` vérifié via `git show` (auteur jsboige, date 2026-02-01, message verbatim) ; override_threshold est bien user-authored et non fabrication ✓
- **G.4 composite** : +234 lignes, 3 fichiers — bien sous les seuils 3000/15/4/1 ✓
- **G.7 anti-stagnation** : pool global cross-lane honored (R5), GT-15 additif = grain DEEP/MED nommé par coordinateur (DM HIGH), pas auto-pioché dans un silo ✓

### Out-of-scope (cycles à venir)

- **#7880 DecInfer-4** : pousser complément prose-only (mini-note par cellule header) — à dispatcher post-GT-15 additif livré, c.187 HARD atomic 1 PR/1 sujet
- **c.728y+48b/c** : `ML-Training-Pipeline/README.en.md:16` + `Python/README.md:24+:28` — stale cross-refs vers archive `qc-strategies-status.md`, sub-grain `ref-quality` à dispatcher (1 PR par fichier si SINGLE sub-grain atomic, sinon batch MED par sous-dir)
- **#7896/#7905** : HOLD user-gated, ICT strate 5 — **pas d'action sans user decision** (mandat user 2026-07-21, voir dashboard status)

### Liens

- Branch : `feature/gt15-additif-1p-margin`
- Base : `origin/main @ b8a2cbb47` (rebase frais, L281 NEW)
- Commit : `b4ceea1b2`
- Diff : `+234/-0` (1 commit, 3 fichiers, MED/additive-pedagogical)
- Worktree : `D:/dev/CoursIA-2-gt15-additif`
- DM réponse ai-01 : `msg-20260722T111118-oq960d` (4 items ack)
- Dashboard : `[CLAIMED] GT-15 additif — myia-po-2025:CoursIA-2`
- Steering original : `msg-20260722T105726-x2vaeb` (HIGH ai-01)
- Audit-reassessment #7914 : CLOSED = FP confirmé (override_threshold user-authored, pas de bug)
- Test file : `MyIA.AI.Notebooks/GameTheory/tests/test_assistance_games.py` (54/54 PASSED)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
