### PR TITLE
docs(archive,#7422): c.728y+43 fix 5 stale cross-refs in ml-trading-state.md

### DIFF
--- a/docs/archive/ml-trading-state.md
+++ b/docs/archive/ml-trading-state.md
@@ -1,4 +1,4 @@
-> **ARCHIVED 2026-07-22** — Document de référence sur les leçons consolidées ML/trading post-ladder #1409 (2026-05-14, Mission ML-Training-Pipeline). Verdict méthodologique **canonique** maintenu pour audit PR ML futures (cf `.claude/rules/pr-review-discipline.md` §C "7 disciplines") : pattern empirique M5-M17 (direction imprévisible, vol prévisible, parcimonie HAR, transaction costs tuent edges) + politique datasets anti-FAANG/Mag7 + ladder #1409 (L4 DT = seul BEATS 24/26). Cité par 10+ fichiers actifs (`docs/qc/quantconnect.md` L22/L25/L283/L285, `ML-Training-Pipeline/README.md` L67, `ML-Training-Pipeline/CURRICULUM.md` L17 FINAL VERDICT, `ML-Training-Pipeline/docs/M12_HF_PROPOSAL.md` L13/L200, `.claude/agents/training-specialist.md` L88, `.claude/skills/train-model/SKILL.md` L69, `STABLE_SNAPSHOT.md` L108). **Note** : 2 cross-refs internes obsolètes pointent vers `docs/quantconnect.md` et `docs/kernels-runtime.md` (root, déplacés) — sub-grain `c.728y+43 ref-quality` à dispatcher. Source triage : issuecomment à venir (#7422).
+> **ARCHIVED 2026-07-22** — Document de référence sur les leçons consolidées ML/trading post-ladder #1409 (2026-05-14, Mission ML-Training-Pipeline). Verdict méthodologique **canonique** maintenu pour audit PR ML futures (cf `../../.claude/rules/pr-review-discipline.md` §C "7 disciplines") : pattern empirique M5-M17 (direction imprévisible, vol prévisible, parcimonie HAR, transaction costs tuent edges) + politique datasets anti-FAANG/Mag7 + ladder #1409 (L4 DT = seul BEATS 24/26). Cité par 10+ fichiers actifs (`docs/qc/quantconnect.md` L22/L25/L283/L285, `ML-Training-Pipeline/README.md` L67, `ML-Training-Pipeline/CURRICULUM.md` L17 FINAL VERDICT, `ML-Training-Pipeline/docs/M12_HF_PROPOSAL.md` L13/L200, `.claude/agents/training-specialist.md` L88, `.claude/skills/train-model/SKILL.md` L69, `STABLE_SNAPSHOT.md` L108). **Note** : 5 cross-refs internes obsolètes corrigés en `c.728y+43 ref-quality` — 3 chemins absolus post-reorg S3 (`docs/quantconnect.md` → `docs/qc/quantconnect.md`, `docs/kernels-runtime.md` → `docs/reference/kernels-runtime.md`) + 2 chemins `.claude/rules/` depuis archive (manquaient `../`). Source triage : #7422.
 
 # ML Trading — Etat consolide
 
@@ -73,7 +73,7 @@ Tout training ou evaluation ML applique au trading qui ne respecte pas ces 7 dis
 6. **Anti-survivorship bias** : pas de panier "stocks survivants" (CRSP/Norgate ideal, sinon documenter le biais). **Pas de FAANG** (cf section datasets).
 7. **Anti-data-snooping** : log des hypotheses tentees, deflated Sharpe pour comptes exhaustifs. Pas de "j'ai trouve une strategie parmi 10000" sans correction Bonferroni / deflated Sharpe.
 
-**Audit PR : ces 7 points doivent etre visibles dans le body ou refusable CHANGES_REQUESTED** (cf [.claude/rules/pr-review-discipline.md](../.claude/rules/pr-review-discipline.md) section C).
+**Audit PR : ces 7 points doivent etre visibles dans le body ou refusable CHANGES_REQUESTED** (cf [../../.claude/rules/pr-review-discipline.md](../../.claude/rules/pr-review-discipline.md) section C).
 
 **Consequences observees en cas de non-respect** :
 - DirAcc plateauent a freq(up_days) sans qu'on s'en rende compte (LSTM/Transformer 0.5795 = freq SPY) — metrique trompeuse, succes apparent qui n'apprend rien
@@ -121,11 +121,11 @@ Datasets s'arretent ~aout 2024. Pour periode recente : completer via Binance API
 
 *Hands-On AI Trading* (Pik, Chan, Broad, Sun, Singh, Wiley 2025) — https://www.hands-on-ai-trading.com/
 
-Le livre documente precisement les ecueils ci-dessus et les bonnes pratiques (vol forecasting, regime gating, Kelly capped, multi-asset). A relire en cas de doute methodo. Repo exemples : https://github.com/QuantConnect/HandsOnAITradingBook (cf section "Livre de reference" de [quantconnect.md](quantconnect.md)).
+Le livre documente precisement les ecueils ci-dessus et les bonnes pratiques (vol forecasting, regime gating, Kelly capped, multi-asset). A relire en cas de doute methodo. Repo exemples : https://github.com/QuantConnect/HandsOnAITradingBook (cf section "Livre de reference" de [../qc/quantconnect.md](../qc/quantconnect.md)).
 
 ## Pointeurs cross-doc
 
-- Infrastructure QC + MCP + backtest : [docs/quantconnect.md](quantconnect.md)
-- Env Conda ML training + GPU wrapper : [docs/kernels-runtime.md](kernels-runtime.md)
+- Infrastructure QC + MCP + backtest : [../qc/quantconnect.md](../qc/quantconnect.md)
+- Env Conda ML training + GPU wrapper : [../reference/kernels-runtime.md](../reference/kernels-runtime.md)
 - Historique training par iteration : `MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/REGISTRY.md` + `docs/M<N>_*.md`
-- Regles audit PR ML : [.claude/rules/pr-review-discipline.md](../.claude/rules/pr-review-discipline.md) section C
+- Regles audit PR ML : [../../.claude/rules/pr-review-discipline.md](../../.claude/rules/pr-review-discipline.md) section C


### PR DESCRIPTION
## Scope

Fix 5 **stale cross-refs** dans  — sub-grain **`c.728y+43 ref-quality`** explicitement flaggé dans le header du fichier (ligne 1, ligne d'archive post-#7922 c.728y+42).

**1 file / +6/-6** = purement markdown, **0 .lean touché**.

## Cross-refs corrigés

| Ligne | Avant | Après | Catégorie |
|------:|------|-------|-----------|
| 76 | `[../../.claude/rules/pr-review-discipline.md](../.claude/rules/pr-review-discipline.md)` (manque `../`) | `[../../.claude/rules/pr-review-discipline.md](../../.claude/rules/pr-review-discipline.md)` | chemin .claude depuis archive |
| 124 | `[quantconnect.md](quantconnect.md)` | `[../qc/quantconnect.md](../qc/quantconnect.md)` | chemin absolu post-reorg S3 #2456 |
| 128 | `[docs/quantconnect.md](quantconnect.md)` | `[../qc/quantconnect.md](../qc/quantconnect.md)` | chemin absolu post-reorg S3 |
| 129 | `[docs/kernels-runtime.md](kernels-runtime.md)` | `[../reference/kernels-runtime.md](../reference/kernels-runtime.md)` | chemin absolu post-reorg S3 |
| 131 | `[../../.claude/rules/pr-review-discipline.md](../.claude/rules/pr-review-discipline.md)` (manque `../`) | `[../../.claude/rules/pr-review-discipline.md](../../.claude/rules/pr-review-discipline.md)` | chemin .claude depuis archive |

**Header L1** mis à jour :
- "2 cross-refs obsolètes" → "5 cross-refs corrigés en c.728y+43"
- "`docs/quantconnect.md` et `docs/kernels-runtime.md` (root, déplacés)" → 3 chemins absolus + 2 chemins .claude manquants `../`
- Lien inline plain-text `.claude/rules/pr-review-discipline.md` → `../../.claude/rules/...` pour cohérence (toujours plain-text, juste chemin correct)

## Catégories de drift (2)

1. **Chemins absolus post-reorg S3 (#2456)** : `docs/quantconnect.md` → `docs/qc/quantconnect.md` (3 occurrences, dont L124 mention "Livre de reference" + L128 "Infrastructure QC"), `docs/kernels-runtime.md` → `docs/reference/kernels-runtime.md` (L129 "Env Conda ML training").
2. **Chemins `.claude/rules/` depuis archive** : depuis `docs/archive/`, le bon préfixe est `../../.claude/rules/` (2 niveaux `../`), pas `../.claude/` (1 seul). L76 (mention audit PR inline) + L131 (référence section C dans liste pointeurs).

## Acceptance gates

- [x] **R1 (catalog-pr-hygiene)** : catalogue byte-identique à `origin/main` — `git diff --stat origin/main -- 'COURSE_CATALOG.generated.md' 'COURSE_CATALOG.generated.json'` = empty
- [x] **L529 STRICT markdown-only** : `git diff --name-only origin/main` = 1 `.md` file only, **0 `.lean` touché**
- [x] **L741 audit-fichier-entier** : autres compteurs/rows inchangés (file = 131 lignes, inchangé ; ARCHIVED header conservé)
- [x] **Tous targets résolvent** : depuis `docs/archive/`, `test -f ../qc/quantconnect.md` ✓ · `../reference/kernels-runtime.md` ✓ · `../../.claude/rules/pr-review-discipline.md` ✓
- [x] **Worktree hygiene** : modifs committées dans `CoursIA-c754-ml-trading-refs` (NOT in main), per `git-workflow.md`
- [x] **Rebase frais** : branch from `origin/main @ b8a2cbb47` (HEAD of main as of 2026-07-22, post-c.728y+42 #7922 MERGED)
- [x] **G.1 firsthand sibling verify** : 3 fichiers cibles vérifiés on disk AVANT commit (`ls`)

## Cross-references

- **Closes** nothing (drift correction sub-grain d'EPIC #7422)
- **See** #7422 partial (docs-hygiene prerequisite de fraîcheur avant traduction #1650 Phase 0.5)
- **Tracks** sub-grain `c.728y+43 ref-quality` explicitement mentionné dans le header L1 du fichier archive (post-c.728y+42 #7922 MERGED 2026-07-22)
- **Source triage** : issuecomment à venir sur #7422 (cette PR)

## Grain & R6/R7 (variation protocol)

Grain: **MED/docs-hygiene** — lane jsboige:CoursIA-2 — prev: c.754 MED/docs-LEAN

G-VAR-3 cross-genre pivot validé : docs-hygiene (cross-ref fix) est **distinct** de docs-LEAN (Modules-table row edit). Les 2 grains ciblent 2 sous-problèmes différents du même epic #7422 (fraîcheur docs), mais le **genre** est différent :
- c.754 docs-LEAN = structurel (row counts FR/EN mirror)
- c.728y+43 docs-hygiene = référentiel (cross-refs absolus post-reorg S3)

Pas 2× même genre LIGHT consécutif. Substance genuinely distincte (paths absolus reorg vs counts row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)