### PR TITLE
fix(planners,#3801): Planners-8 cell 32 critical-path duration typo (j2=5 -> j2=2)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-8-Temporal.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-8-Temporal.ipynb
@@ -1395,7 +1395,7 @@
     "**Points cles :**\n",
     "- Les deux machines travaillent **en parallele** des t=0, maximisant l'utilisation des ressources\n",
     "- Les contraintes de precedence (j1 avant j2, j3 avant j4) sont respectees : chaque tâche ne commence qu'après la fin de sa predecesseure\n",
-    "- Le makespan de 6 est determine par le chemin critique M2 (j3=4 + j4=2), tandis que M1 (j1=3 + j2=5) termine plus tot\n",
+    "- Le makespan de 6 est determine par le chemin critique M2 (j3=4 + j4=2), tandis que M1 (j1=3 + j2=2 = 5) termine plus tot\n",
     "- Si on ajoutait une tâche j5 sur M2 après j4, le makespan augmenterait mais n'affecterait pas M1"
    ]
   },


### PR DESCRIPTION
## Contexte

Deep-read firsthand (solo, rate-limit API actif) de **Planners-8-Temporal** (famille fresh, first-touch — non scannée par les lanes précédentes). La cellule d'interprétation du diagramme de Gantt (cell 32) contenait un nombre erroné dans l'explication du chemin critique.

## Defect (MED/doc-honesty, G.1 firsthand-verified)

Cell 32 « Points cles », 3e bullet :

> Le makespan de 6 est determiné par le chemin critique M2 (j3=4 + j4=2), tandis que M1 (**j1=3 + j2=5**) termine plus tot

**Faux** : la durée de j2 est **2**, pas 5. Le « 5 » est l'end-time de j2 (j2 finit à t=5), confondu avec sa durée.

Preuves croisées (3 sources dans le même notebook) :
- **cell 22** (output unified-planning) : `Taches: j1 (3), j2 (2, apres j1), j3 (4), j4 (2, apres j3)` → j2 = 2.
- **cell 30** (table interprétation) : `| j2 | M1 | 2 | j1 |` → durée j2 = 2.
- **cell 29** (output CP-SAT réel) : `j2 3 5 2` → début 3, fin 5, **durée 2**.

La parenthétique « j1=3 + j2=5 » sommait à **8**, contredisant à la fois le makespan (6) et la phrase qu'elle clôt (« M1 termine plus tot » que le chemin critique M2 = 6). La vraie completion M1 = j1(3) + j2(2) = 5 (j1 0-3, j2 3-5), bien plus tôt que M2 (6).

## Fix

`j2=5` → `j2=2 = 5` (rend la somme explicite et cohérente avec la fin de M1 à 5 < 6). 1 ins / 1 del.

## Validation

- **Markdown-only** (exception C.2 : l'output CP-SAT cell 29 est déterministe et inchangé — Makespan 6, j1 0-3 / j2 3-5 / j3 0-4 / j4 4-6, OR-Tools CP-SAT SOTA-OK genuine).
- Diff cell-level : **seule cell 32 source** modifiée ; 46 autres cellules byte-identiques (json.dumps indent=1 ensure_ascii=False + `\n`, 0 CRLF).
- `validate_pr_notebooks.py` : **PASS** (16 cells).
- C.1 : **0 violation**.

Note R6 : streak markdown doc-honesty (Tweety-5/SW-13/CSP-9) — mais famille **fresh** (Planners-8 first-touch, pas re-mining drained) + defect réel vérifié firsthand. Le scan sonnet productif sur familles fresh est bloqué par rate-limit (reset 19:26Z) ; deep-read solo.
