### PR TITLE
fix(infer-101): correct variance/precision decomposition in predictive cell 22 (doc-honesty)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer-101.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer-101.ipynb
@@ -1530,15 +1530,15 @@
    "source": [
     "### Interpretation : Distribution predictive\n",
     "\n",
-    "La prediction du trajet de demain a une **variance plus large** que le posterieur de la moyenne :\n",
+    "La prediction du trajet de demain a une **variance plus large** que le posterieur de la moyenne. Infer.NET affiche `Gaussian(moyenne, variance)` : le second parametre est la variance (verifiable via `GetVariance()` dans la cellule precedente, `sqrt(4.613) ~ 2.15`), et non la precision. La variance predictive se decompose donc en deux termes qui s'ajoutent pour atteindre le total observe :\n",
     "\n",
     "| Source | Variance |\n",
     "|--------|---------|\n",
-    "| Incertitude sur la moyenne | 1/1.32 ≈ 0.76 min^2 |\n",
-    "| Bruit du trajet (Gamma) | ~1/bruit posterieur ≈ 1.8 min^2 |\n",
-    "| Variance totale predictive | ≈ 4.61 min^2 → ecart type 2.15 min |\n",
+    "| Incertitude sur la moyenne (`Gaussian(15.33, 1.32)`) | 1.32 min^2 |\n",
+    "| Bruit du trajet (`E[1/bruit]`, bruit etant la precision `Gamma(2.24, 0.24)`) | ~ 3.29 min^2 |\n",
+    "| Variance totale predictive | 1.32 + 3.29 ~ 4.61 min^2 -> ecart type 2.15 min |\n",
     "\n",
-    "L'incertitude totale combine l'incertitude sur les paramètres ET le bruit inherent du trajet. Même si on connaissait exactement la moyenne reelle, les trajets varieraient toujours autour d'elle."
+    "L'incertitude totale combine l'incertitude sur les paramètres ET le bruit inherent du trajet. Même si on connaissait exactement la moyenne reelle, les trajets varieraient toujours autour d'elle.\n"
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/doc-honesty — lane myia-po-2025:CoursIA — prev: DEEP/new-cell (#7951 GT-15)

## Sujet

`Infer-101.ipynb` cell 22 — la table d'interprétation de la **variance prédictive** décomposait le total avec **deux termes erronés** qui ne sommaient pas au total annoncé.

## Defect (G.1 firsthand-verified)

| Terme dans la table | Valeur écrite | Problème |
|---|---|---|
| Incertitude sur la moyenne | `1/1.32 ≈ 0.76 min²` | Traite le 2ᵉ param de `Gaussian` comme une **précision** (calcule 1/1.32) |
| Bruit du trajet (Gamma) | `~1/bruit posterieur ≈ 1.8 min²` | Utilise `1/E[τ] = 1/0.5482` au lieu de `E[1/τ]` |
| **Total annoncé** | `≈ 4.61 min²` | **0.76 + 1.82 = 2.58 ≠ 4.61** → incohérent |

## Preuve de la cause racine (Infer.NET affiche `(mean, variance)`)

La cell 21 code appelle explicitement `Math.Sqrt(distribDemain.GetVariance())` et affiche « écart type 2.148 » depuis `Gaussian(15.33, 4.613)` → `sqrt(4.613) = 2.148`, donc le 2ᵉ paramètre **est la variance** (pas la précision). Confirmé par cell 36 : `Gaussian(15.85, 17.1)` → `sqrt(17.1) = 4.135` = l'écart type affiché.

Conséquence : `Gaussian(15.33, 1.32)` a une **variance de 1.32** (le terme correct est 1.32, pas `1/1.32 = 0.76`).

## Décomposition corrigée (exacte)

- **Var(moyenne)** = `1.32` (2ᵉ param du Gaussian = variance).
- **Bruit** : `Gamma(2.242, 0.2445)` = (shape, scale) car `2.242 × 0.2445 = 0.5482` = mean. Le bruit étant une **précision**, la variance de bruit = `E[1/bruit]` (moyenne de l'Inverse-Gamma) = `1/(scale·(shape−1))` = `1/(0.2445 × 1.242)` = **3.29** (et non `1/E[bruit] = 1.82`).
- **Total** = `1.32 + 3.29 = 4.61` ✓ **matche exactement** la variance prédictive (4.613).

La nouvelle table est arithmétiquement cohérente avec le total observé, et la prose précise la convention `Gaussian(moyenne, variance)` pour éviter que l'étudiant ne reproduise l'inversion.

## Scope

- **Cell 22 source uniquement** (+5/−5 lignes). Markdown-only → C.2 exception (aucune cellule code touchée, outputs inchangés valides).
- Repo `notebook_tools` validator : **PASS** (0 Errors, 0 Warnings).
- Le strict `nbformat.validate` échoue sur **cell 68 pré-existante** (markdown avec artefact papermill `execution_count`/`outputs`, présent sur `origin/main`, hors scope, non touché).
- Pas de catalogue. Pas de leak. Déterminisme N/A (markdown).

See #3801. Ne `Closes` aucune issue (enrichissement doc-honesty).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
