### PR TITLE
fix(infer,#3801): Infer-11 cell 29 stale counting output (Doc 7 Politique=1.00 -> Sport=0.60)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb
@@ -3135,7 +3135,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Doc 7 : Sport=0,00, Politique=1,00, Musique=0,00\r\n"
+      "Doc 7 : Sport=0,60, Politique=0,40, Musique=0,00\r\n"
      ]
     },
     {


### PR DESCRIPTION
Grain: DEEP/code-correctness — lane po-2023 — EPIC #3801 (SOTA axe-2 doc-honesty)

## Summary

`Infer-11-Topic-Models.ipynb` cell[29] (simplified per-document topic inference by word counting) committed a **STALE output** that destroyed the notebook's CENTRAL teaching point and self-contradicted both the code logic and the adjacent markdown. Firsthand G.1-verified against `origin/main` (`b8a2cbb47`): read FULL cell 12 (documents array) + cell 29 (counting loop) + committed output + cells 28/30 (markdown), recomputed the counts by hand. Found via Explore (sonnet, read-only) Infer .NET scan; G.1 firsthand-verified before fixing.

## Defect — stale output contradicts code + markdown

Vocabulary (cell 12): `[sport(0), equipe(1), match(2), politique(3), election(4), vote(5), musique(6), concert(7), artiste(8)]`. Sport=indices 0-2, Politique=3-5, Musique=6-8.

**Doc 7 = `{2, 2, 5, 2, 4}`** = [match, match, vote, match, election]. The document is **political** (vote + election) but contains the polysemic **"match"** (index 2, counted as Sport) **3 times**.

Counting logic (cell 29):
```
countSport     = Count(w <= 2)           = {2,2,2} = 3  (match x3)
countPolitique = Count(w >= 3 && w <= 5) = {5,4}   = 2  (vote, election)
total = 3 + 2 + 0 + 0.001 = 5.001
Sport = 3/5.001 = 0.60,  Politique = 2/5.001 = 0.40
```

The **code correctly produces** `Doc 7 : Sport=0,60, Politique=0,40` — i.e. counting **FAILS** (classifies the political Doc 7 as 60% Sport because "match" is polysemic). This failure is the **whole point** of the section: it motivates why LDA joint inference is needed (the LDA cell recovers Doc 7 as Politique ≈ 65% via co-occurrence).

But the **committed output said** `Doc 7 : Sport=0,00, Politique=1,00` — counting **succeeds** (100% Politique). This is **STALE** (from a prior version where Doc 7 was pure-politique like Doc 2). The stale output:

1. **Self-contradicts the code** (which produces Sport=0.60, not 0.00).
2. **Self-contradicts cell 28 markdown**: *"le comptage classe 'match' en Sport ... alors que le document est politique"* — EXPECTS Sport>0 for Doc 7.
3. **Self-contradicts cell 30 markdown**: *"Doc 7 | Sport = 60% (erreur) | Comptage trompé par « match » polysémique"* + *"là où le comptage échoue (Sport 60 %)"* — both EXPECT Sport=60%.
4. **Destroys the contrast**: if counting succeeds on Doc 7, the LDA motivation (the notebook's central claim) vanishes.

## Fix — re-exec cell 29 via the real `.net-csharp` kernel, transplant corrected output

cell 29 is **pure C# LINQ** (no Infer.NET dependency: no `InferenceEngine`, no `using Microsoft`). Re-executed via the real **dotnet-interactive 1.0.707101** kernel (rule F satisfied — `.NET Interactive` installable everywhere) in a minimal harness `[culture fr-FR | cell 12 documents | cell 29 counting]` to match the committed comma-decimal format. The re-exec produced **exactly 10 stream entries** (one per `Console.WriteLine`), identical structure — **ONLY entry[8] (Doc 7) differs**. Transplanted the 10 re-exec outputs; kept cell 29 source + `execution_count=10` + metadata byte-identical.

| Doc | Before (STALE) | After (corrected re-exec) | Notes |
|-----|----------------|---------------------------|-------|
| Doc 2 | Politique=1,00 | Politique=1,00 | pure politique, **unchanged** |
| Doc 7 | Sport=0,00, Politique=1,00 | **Sport=0,60, Politique=0,40** | counting FAILS (match polysemic) — **the fix** |
| Docs 1,3-6 | (unchanged) | (unchanged) | byte-identical |

## Validation

- **nbformat VALID** (strict, 55 cells).
- **C.1:** 0 `raise NotImplementedError` / `assert False` / `1/0` in cell 29 source.
- **H.3:** cell 29 `execution_count=10` (non-null, preserved), 10 outputs (non-empty), real `.net-csharp` kernel re-exec.
- **Surgical:** 1 file, **1 insertion(+), 1 deletion(-)** — ONLY the Doc 7 output line changed; 54/55 cells + top-level `metadata` + `nbformat` byte-identical to `origin/main` (`cell_sig` verified: source + outputs + exec_count + metadata per cell).
- **Honesty (Stop & Repair):** output transplanted from a **real .net-csharp kernel re-execution**, never hand-edited.

## G.1 firsthand verification

Defect firsthand-verified: read FULL cell 12 (documents array + vocabulary) + cell 29 (counting loop source) + cell 29 committed output + cells 28/30 (markdown), recomputed the counts by hand (countSport=3, countPolitique=2, total=5.001 → Sport=0.60, Politique=0.40), confirmed the code↔committed-output↔markdown three-way contradiction. Explore (sonnet) was the finder; its transcription was 100% correct here but G.1 firsthand-verified regardless before fixing.

See **#3801** (EPIC SOTA axe-2 doc-honesty registry). Partial contribution — `See #3801` (no auto-close).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
