### PR TITLE
fix(search,#3801): Search-10 cell 28 wrong state count for even-int finite automaton (91 -> 46)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb
@@ -1179,8 +1179,8 @@
     "**Exemple** : Reconnaître les entiers pairs entre 10 et 100\n",
     "\n",
     "**Automate fini (impraticable)** :\n",
-    "- 91 etats (un pour chaque valeur 10, 12, 14, ..., 100)\n",
-    "- 91 transitions (une par valeur paire)\n",
+    "- 46 etats (un pour chaque valeur paire 10, 12, 14, ..., 100 ; il y en a (100-10)/2 + 1 = 46)\n",
+    "- 46 transitions (une par valeur paire acceptee)\n",
     "\n",
     "**Automate symbolique** :\n",
     "- 1 etat (ou 2 etats si on veut separer accept/reject)\n",
@@ -1192,7 +1192,7 @@
     "| Transitions | $\\delta(q, a)$ | $\\delta(q, \\phi(x))$ |\n",
     "| Complexite | Explosion d'etats | Taille raisonnable |\n",
     "| Decision | SAT en temps lineaire | SAT via SMT solver |\n",
-    "| Expressivite | Langages reguliers | Langages avec predicats |"
+    "| Expressivite | Langages reguliers | Langages avec predicats |\n"
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/doc-honesty — lane myia-po-2025:CoursIA — prev: MED/doc-honesty (#7957 Infer-101)

## Sujet

`Search-10-SymbolicAutomata.ipynb` cellule 28 (§3.4 Comparaison Automate Fini vs Symbolique) — **mauvais compte d'états** pour l'automate fini reconnaissant les entiers **pairs** entre 10 et 100.

## Defect (G.1 firsthand-verified)

La cellule 28 encadre l'exemple comme « Reconnaître les entiers **pairs** entre 10 et 100 », énumère explicitement « 10, 12, 14, ..., 100 », et donne le prédicat symbolique `x ≥ 10 ∧ x ≤ 100 ∧ x mod 2 = 0`. Mais elle annonce **« 91 états »** et **« 91 transitions »** pour l'automate fini équivalent.

`91` est le compte de **tous** les entiers ∈ [10,100] (100−10+1 = 91), **pas** le compte des entiers pairs.

## Compte correct

Entiers pairs ∈ [10,100] : 10, 12, …, 100 = **(100−10)/2 + 1 = 46** valeurs. La cellule corrigée affiche **46 états / 46 transitions** avec la dérivation arithmétique (l'étudiant peut la re-dériver).

## Pourquoi les cellules 43 et 44 ne sont PAS touchées

Les cellules 43 (Note technique) et 44 (point 1) mentionnent aussi « 91 », mais elles décrivent l'automate défini **deux cellules plus tôt** (cellule 42) qui reconnaît **tous** les entiers ∈ [10,100] — son prédicat est `And(x >= 10, x <= 100)` **sans** clause `mod 2`. Pour cet automate « tous entiers », 91 est le compte correct (91 valeurs de 10 à 100). Les laisser à 91 préserve leur exactitude dans leur contexte. Vérifié firsthand : cellule 42 prédicat = `And(x>=10, x<=100)`.

## Scope

- **Cellule 28 source uniquement** (+3/−3 lignes). Markdown-only → C.2 exception (aucune cellule code touchée, outputs inchangés).
- `nbformat` strict validate : **OK**.
- Repo `notebook_tools` validator : **0 Errors** (1 Warning pré-existant sur `origin/main`, non introduit par cette PR).
- Pas de catalogue. Pas de leak. Déterminisme N/A (markdown).

See #3801.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
