### PR TITLE
fix(smartcontracts,#3801): SC-19 cell 27 payment-channel cost arithmetic (0.000024/pmt was total, real per-payment 0.0000024)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-19-Ripple-XRP.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-19-Ripple-XRP.ipynb
@@ -1259,7 +1259,7 @@
     "| Reglement final | Soumission du dernier claim | Oui | 1 transaction |\n",
     "\n",
     "**Points cles** :\n",
-    "- Le rapport cout/transfert est de 2 transactions pour 10 paiements, soit un cout effectif de ~0.000024 XRP par paiement (vs 0.000012 XRP si chaque paiement etait on-chain)\n",
+    "- Le rapport cout/transfert est de 2 transactions pour 10 paiements, soit un cout effectif de ~0.0000024 XRP par paiement : 2 transactions x 12 drops = 24 drops = 0.000024 XRP au total, reparti sur 10 paiements (vs 0.000012 XRP par paiement, soit 10 x 12 drops = 0.00012 XRP au total, si chaque paiement etait on-chain)\n",
     "- L'avantage principal n'est pas le cout mais la **latence** : les claims off-chain sont instantanes\n",
     "- L'integrite est garantie : `5.0 + 95.0 = 100.0 XRP` (conservation parfaite)"
    ]


### PR DESCRIPTION
## Scope

SC-19-Ripple-XRP cell **27** (Payment Channel interpretation) — arithmetic error in the per-payment cost claim.

## Defect (firsthand-verified, G.1)

Cell 27 bullet:
> "Le rapport cout/transfert est de 2 transactions pour 10 paiements, soit un cout effectif de **~0.000024 XRP par paiement** (vs 0.000012 XRP si chaque paiement etait on-chain)"

The notebook defines the fee everywhere as **12 drops/tx** (cells 14/15: "Frais 12 drops (0.000012 XRP)", "Fee 12 drops (~0.000012 XRP)"; cell 10/12: 1 XRP = 1,000,000 drops). Arithmetic:
- 2 tx × 12 drops = **24 drops = 0.000024 XRP** → that is the **TOTAL** for 10 payments, not per-payment.
- per-payment = 24/10 = 2.4 drops = **0.0000024 XRP** — the markdown overstated 10× by labeling the total as per-payment.
- on-chain baseline (0.000012 XRP/payment = 12 drops) was correct.

## Change

Markdown-only correction (cell 27, single bullet):
> "un cout effectif de **~0.0000024 XRP par paiement** : 2 transactions x 12 drops = 24 drops = 0.000024 XRP au total, reparti sur 10 paiements (vs 0.000012 XRP par paiement, soit 10 x 12 drops = 0.00012 XRP au total, si chaque paiement etait on-chain)"

Makes total vs per-payment unambiguous, and spells out both totals so the 10× channel savings is visible.

## Safety

Pure arithmetic from a stated constant (12 drops/tx, defined in the notebook) — deterministic, no RNG, no LLM. Safe.

## Verification (firsthand vs origin/main)

- nbformat VALID, 45 cells.
- 1 file, +1/−1, single bullet changed (cell 27 source only).
- Outputs untouched; catalogue byte-identical; C.1 = 0.

See #3801. Does not close the epic.

Grain: MED/doc-honesty — lane po-2026:CoursIA — prev: MED/doc-honesty SC-16 (#7964)

Co-Authored-By: Claude <noreply@anthropic.com>
