### PR TITLE
fix(iit,#3801): IIT-2 cell 6 MIP illustration aligned with committed partition

### DIFF
--- a/MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb
+++ b/MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb
@@ -316,7 +316,7 @@
     "\n",
     "La MIP nous dit **ou le système est le plus faiblement integre**. Dans notre reseau XOR :\n",
     "\n",
-    "- Si la coupe separe les noeuds {A, B} de {C}, cela signifie que le lien A,B -> C est le plus faible\n",
+    "- Ici, la coupe MIP separe le noeud {B} de {A, C} (cf. sortie de la cellule precedente : `Cut [B] -> [A, C]`) : cela signifie que l'integration de B avec le reste du systeme est le maillon le plus faible\n",
     "- Plus $\\Phi$ est eleve, plus le système est irreductiblement integre\n",
     "- Un $\\Phi = 0$ signifie que le système est completement decomposable (pas d'integration)\n",
     "\n",


### PR DESCRIPTION
## Contexte

Deep-read firsthand (solo, rate-limit API actif) de **IIT-2-AdvancedTopics** (famille FRESH, first-touch — non scannée). La cellule d'interprétation de la MIP (cell 6) illustrait la coupe avec la mauvaise bipartition.

## Defect (MED/doc-honesty, G.1 firsthand-verified)

Cell 6 « Interpretation de la MIP », 1er bullet :

> Si la coupe separe les noeuds **{A, B} de {C}**, cela signifie que le lien A,B -> C est le plus faible

**Incohérent avec l'output committé** : la cell 5 (PyPhi `sia`) donne Big Phi = 1.874999 et **`Coupe (MIP): Cut [B] ━━/ /━━➤ [A, C]`** (from_nodes=(1,)=B, to_nodes=(0,2)={A,C}), c'est-à-dire la bipartition **{B} | {A,C}**, pas {A,B} | {C}.

Preuve croisée — cell 7 énumère les 4 bipartitions possibles du sous-système XOR (3 noeuds A=0,B=1,C=2) :

| # | Bipartition |
|---|-------------|
| 1 | {} \| {A,B,C} |
| 2 | {A} \| {B,C} |
| 3 | **{B} \| {A,C}** ← la MIP réelle (from B vers {A,C}) |
| 4 | {A,B} \| {C} ← ce qu'illustrait l'interp |

Le bullet décrivait la partition #4 alors que la MIP committée est la #3. Placé juste après l'output réel et introduit par « Dans notre reseau XOR », il se lisait comme décrivant la coupe de CE système — induisant en erreur sur quelle partition est la MIP.

## Fix

Bullet réécrit pour utiliser la **vraie MIP committée** {B} | {A,C}, en citant la sortie cell 5 (`Cut [B] -> [A, C]`), et en énonçant correctement que l'intégration de B avec le reste du système est le maillon le plus faible. Bullets 2-3 et section 2.3 préservés. 1 ins / 1 del.

## Validation

- **Markdown-only** (exception C.2 : calcul PyPhi déterministe pour `xor_network` à l'état (0,0,0) → output Big Phi/MIP inchangé).
- Diff cell-level : **seule cell 6 source** modifiée ; 39 autres cellules byte-identiques (json.dumps indent=1 ensure_ascii=False + `\n`, 0 CRLF).
- `validate_pr_notebooks.py` : **PASS** (19 cells, kernel pyphi).
- C.1 : **0 violation**.

R6 : streak markdown, mais **famille FRESH** (IIT-2 first-touch, pas re-mining) + defect réel vérifié firsthand (inconsistance interp↔output). Le scan sonnet productif multi-famille reste bloqué par rate-limit (reset 19:26Z).
