### PR TITLE
fix(sudoku,#3801): Sudoku-14 cell 37 "À retenir" 2 factual errors (BDD reduction + Z3 timing)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb
@@ -3035,10 +3035,10 @@
     "\n",
     "Les **BDD/MDD** offrent une représentation compacte des fonctions booléennes et des domaines finis :\n",
     "\n",
-    "- Un BDD pour `x AND y` nécessite **5 nœuds** (vs 4 lignes de table de vérité) grâce au partage de sous-graphes.\n",
+    "- Un BDD **non réduit** pour `x AND y` compte **5 nœuds** (cf. cellule 7, où les deux feuilles `False` ne sont pas fusionnées) ; la **réduction** BDD partage ces terminaux identiques et descend à **4 nœuds**. C'est sur des fonctions plus complexes que ce partage de sous-graphes fait décoller l'avantage du BDD face à une table de vérité exponentielle (2ⁿ lignes).\n",
     "- Le MDD d'une seule ligne Sudoku atteint **5 611 771 nœuds** (vs 9! = 362 880 permutations valides) : l'explosion d'états rend les MDD complets impraticables pour Sudoku.\n",
     "- Le solveur MDD est en réalité **hybride** (backtracking + vérification MDD), résolu en **0,46 ms** sur grille Easy.\n",
-    "- **Z3/SMT (Sudoku-12)** reste l'approche de production (~20 ms), tandis que les BDD excellent en **model checking et vérification formelle**.\n"
+    "- **Z3/SMT (Sudoku-12)** reste l'approche de production (~166-470 ms en bitvectors selon la difficulté), tandis que les BDD excellent en **model checking et vérification formelle**.\n"
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/doc-honesty — lane po-2023 — EPIC #3801 (SOTA axe-2 doc-honesty)

## Summary

`Sudoku-14-BDD-Csharp.ipynb` cell[37] (markdown "À retenir" conclusion) carried **2 factual errors**: one self-contradicted the correct cell[8] interpretation, the other contradicted the Sudoku-12 cell[23] benchmark output. Firsthand G.1-verified against `origin/main` (`e496ece1b`): read FULL cell 7 (BDD tree output), cell 8 (correct interpretation), cell 37 (À retenir), and Sudoku-12 cell 23 (Z3 benchmark).

## Defect 1 — "5 nœuds grâce au partage de sous-graphes" (backwards)

cell[7] output shows the `x AND y` BDD as a **5-node UNREDUCED tree** (two distinct `(False)` leaves, not shared):
```
x?
  |-> y?
  |     |-> (True)
  |     |-> (False)      <- False leaf #1 (under y)
  |-> (False)            <- False leaf #2 (under x)
Noeuds : 5
```

cell[8] **correctly** says: *"Le BDD pour x AND y a 5 nœuds. Si nous appliquions la réduction complète (partage de sous-graphes identiques), nous aurions moins de nœuds car les terminaux False sont partagés."*

But cell[37] said the 5 nodes were **"grâce au partage de sous-graphes"** — **backwards**: the 5-node version is the **non-reduced** tree (no sharing); the **reduced/shared** BDD is **4 nodes** (2 decision nodes + shared `True`/`False` terminals). cell[37] directly contradicted cell[8].

## Defect 2 — "Z3 ~20 ms" (wrong by ~8×)

cell[37] claimed *"Z3/SMT (Sudoku-12) reste l'approche de production (~20 ms)"*. But **Sudoku-12 cell[23]** benchmark shows Z3 bitvector times **166,5 ms** (best, Substitution Easy) to **470,9 ms** (Tactic Hard); integers 273–1367 ms. **No Z3 result near 20 ms** — the "~20 ms" understates Z3 by ~8×.

## Fix — honest framing consistent with cell 8 + Sudoku-12 cell 23

Markdown-only (C.2 exception). Rewrote the 2 affected bullets:
- **Bullet 1**: *"Un BDD **non réduit** pour `x AND y` compte **5 nœuds** (cf. cellule 7, où les deux feuilles `False` ne sont pas fusionnées) ; la **réduction** BDD partage ces terminaux identiques et descend à **4 nœuds**. C'est sur des fonctions plus complexes que ce partage de sous-graphes fait décoller l'avantage du BDD face à une table de vérité exponentielle (2ⁿ lignes)."*
- **Bullet 4**: *"Z3/SMT (Sudoku-12) reste l'approche de production (~166-470 ms en bitvectors selon la difficulté)..."*

**Preserved**: MDD `5 611 771 nœuds` (vs 9! = 362 880 — ratio ~15×, verified `5611771/362880 = 15.46`), hybrid solver `0,46 ms`, model-checking framing.

## Validation

- **nbformat VALID** (strict, 40 cells).
- **C.1:** 0 `raise NotImplementedError` / `assert False` / `1/0`.
- **H.3:** cell 37 is markdown (no exec_count requirement); all code cells healthy.
- **Surgical:** 1 file, +2/−2 (the 2 affected bullet lines); 39/40 cells + top-level `metadata` + `nbformat` byte-identical to `origin/main` (`cell_sig` verified).
- **Honest (Stop & Repair):** markdown rewritten to match cell 7/8 outputs + Sudoku-12 cell 23; **no output hand-edited**.

## G.1 firsthand verification

Defects firsthand-verified: cell[7] BDD tree (5 nodes, two unshared `False` leaves), cell[8] correct interpretation ("5... moins si réduction"), cell[37] contradictory claims, Sudoku-12 cell[23] Z3 benchmark (min 166,5 ms). Recomputed `5611771/362880 = 15.46` (cell[21] "~15 fois" ✓, preserved). Reduced-BDD node count: 2 decision (x, y) + 2 shared terminals (True, False) = 4 ✓.

See **#3801** (EPIC SOTA axe-2 doc-honesty registry). Partial contribution — `See #3801` (no auto-close).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
