### PR TITLE
fix(iit-3): disclose macro-phi artifact in cell[12] (markdown honesty)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/IIT-3-CoarseGrainingMacroPhi.ipynb
+++ b/MyIA.AI.Notebooks/IIT/IIT-3-CoarseGrainingMacroPhi.ipynb
@@ -350,13 +350,15 @@
     "tags": []
    },
    "source": [
-    "### Interprétation honnête\n",
+    "### Interprétation honnête - et un piège à éviter\n",
     "\n",
-    "Sur cet exemple canonique 4-nœuds, on constate que **$\\Phi$ macro $\\approx$ $\\Phi$ micro** (différence quasi nulle). Cela **confirme empiriquement** l'avertissement du §0 : le coarse-grain ne crée **pas automatiquement** d'emergence positive.\n",
+    "**La comparaison ci-dessus est un artefact, pas une mesure d'emergence.** La fonction `pyphi.examples.macro_subsystem()` renvoie un `Subsystem` *ordinaire* sur le réseau micro - dans le code source de pyphi, sa définition est simplement `Subsystem(macro_network(), (0, 0, 0, 0))`, sans aucun coarse-grain. Les deux valeurs `$\\Phi$` affichées (cellules précédentes, $\\approx 0.114$) sont donc **toutes deux des `$\\Phi$` micro** du même sous-système : l'écart nul qui en résulte ne mesure rien, c'est une tautologie. On ne peut **pas** en conclure que « ce réseau ne montre pas d'emergence ».\n",
     "\n",
-    "**Pourquoi ?** L'emergence positive (Hoel 2013) apparaît lorsque le coarse-grain **filtre du bruit** : si les nœuds micro sont *probabilistes* (bruit) et que le macro-nœud agrège plusieurs copies corrélées, la moyennisation réduit la variance et augmente l'EI. Sur des réseaux **déterministes** (comme nos toys), il n'y a pas de bruit à filtrer, donc pas de gain d'emergence.\n",
+    "**La bonne API est `pyphi.macro.emergence(network, state)`.** Elle énumère les coarse-grainages (et partitions temporelles) possibles et renvoie un objet portant `.micro_phi` (calculé via le complex majeur du réseau micro) et `.macro_phi` (le maximum trouvé après coarse-grain). Or la docstring du réseau d'exemple indique qu'il a été construit précisément pour avoir une **plus grande integrated information après coarse-graining** - l'artefact ci-dessus masque donc une emergence qui est *censée* être là. (Exécution de `emergence()` non reprise ici : `pyphi 1.2.0` n'est pas compatible avec l'environnement Python 3.13 local - `from collections import Iterable` lève `ImportError` depuis Python 3.10, et le `multiprocessing` Windows boucle à l'import.)\n",
     "\n",
-    "L'IIT prédit que sur des réseaux probabilistes spécifiques (cf. Albantakis, Marshall, Tononi), le $\\Phi$ macro dépasse le $\\Phi$ micro — mais exhiber ce cas proprement dans pyphi 1.2.0 stable exige une construction TPM probabiliste soignée (et des conditions d'indépendance conditionnelle strictes), qui dépasse le cadre d'un notebook d'introduction. Le résultat **qualitatif** à retenir : **l'échelle macro est une vraie dimension de l'analyse IIT**, et le module `pyphi.macro` fournit les outils pour l'explorer (EI, coarse-grain, blackbox), mais l'emergence positive n'est ni triviale ni garantie."
+    "**Pourquoi l'emergence macro peut-elle dépasser le micro ?** (Hoel 2013) L'emergence positive apparaît lorsque le coarse-grain **filtre du bruit** : si les nœuds micro sont *probabilistes* et que le macro-nœud agrège plusieurs éléments corrélés, la moyennisation réduit la variance et augmente l'EI effectif - d'où un `$\\Phi$` macro supérieur. Sur des réseaux strictement **déterministes** (comme le réseau copie de la section 1), il n'y a pas de bruit à filtrer.\n",
+    "\n",
+    "**Leçon qualitative à retenir** : l'échelle macro est une vraie dimension de l'analyse IIT, et le module `pyphi.macro` (EI, coarse-grain, blackbox) fournit les outils pour l'explorer - mais mesurer l'emergence demande la bonne API (`emergence()`), pas une comparaison directe de deux `$\\Phi$` micro du même sous-système.\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Correction honnete d'une **affirmation factuellement fausse** dans `IIT-3-CoarseGrainingMacroPhi.ipynb` cell[12], decouverte par lecture directe de la source pyphi (G.1).

### Le defaut

La cellule[12] concluait :

> "Sur cet exemple canonique 4-nuds, on constate que **Phi macro approx Phi micro** (difference quasi nulle). Cela **confirme empiriquement** [...] le coarse-grain ne cree **pas automatiquement** d'emergence positive."

**C'est un artefact, pas une mesure d'emergence.** Verification firsthand dans la source pyphi (`pyphi/examples.py`) :

```python
def macro_subsystem():
    net = macro_network()
    state = (0, 0, 0, 0)
    return Subsystem(net, state)   # <-- plain Subsystem, PAS de coarse-grain
```

`pyphi.examples.macro_subsystem()` renvoie un `Subsystem` *ordinaire* sur le reseau micro. Les deux valeurs Phi comparees en cell[11] (`phi(Subsystem(net,(0,0,0,0)))` vs `phi(macro_subsystem())`) sont donc **toutes deux du micro-phi du meme sous-systeme**. Le diff = 0 qui en resulte est une tautologie, pas une preuve empirique d'absence d'emergence.

Pire, la docstring de `macro_network()` indique que ce reseau a ete construit pour avoir *"greater integrated information after coarse graining"* — l'artefact masque donc une emergence *censee* etre la.

## Change

Rewrite markdown de cell[12] (uniquement cette cellule markdown) :
- **Reveler l'artefact** honnetement (les deux valeurs sont du micro-phi)
- **Fonder sur la source** pyphi (definition de `macro_subsystem` + docstring `macro_network`)
- **Pointer vers la bonne API** : `pyphi.macro.emergence(network, state)` qui renvoie `.micro_phi` (via major_complex) et `.macro_phi` (max apres coarse-grain)
- **Noter** pourquoi `emergence()` n'est pas execute ici : pyphi 1.2.0 casse sur Python 3.13 (`from collections import Iterable` -> ImportError depuis 3.10 + spawn `multiprocessing` Windows en boucle)
- **Preserver** la pedagogie Hoel (filtrage de bruit) et la lecon qualitative

## Validation

- `validate_pr_notebooks.py` : **PASS** (8 cellules code, kernel pyphi)
- C.1 : **0 violation** (`raise NotImplementedError` / `assert False` / `1/0`)
- Markdown-only (cell[12]) : exception C.2, outputs inchanges, pas de re-exec
- Convention JSON : `json.dumps(indent=1, ensure_ascii=False)+"\n"` == raw, 0 CRLF
- `git diff --stat` : 1 fichier, 6 insertions / 4 deletions (cellule cell[12] uniquement)

## Scope residuel (routage)

Le **fix code complet** (cell[10]/[11] : utiliser `pyphi.macro.emergence()` + re-exec pour obtenir un vrai macro_phi) est **routé comme RECOVERABLE-MACHINE** (pyphi 1.2.0 exige un env Python <= 3.9 sur machine dediee). Cette PR markdown corrige immediatement la faussete factuelle sans attendre le fix code machine-blocked.

Verdict SOTA Prong A : **RECOVERABLE-MACHINE** pour la partie code (routée), la correction markdown presente est honnete sur le plafond atteignable localement.

## Test plan
- [x] Validator PASS
- [x] C.1 = 0
- [x] Markdown-only (C.2 exception)
- [x] Byte-identity (1 cell changed)
