### PR TITLE
fix(iit,#3801): IIT-3 cells 10/11/12 macro-subsystem honesty (re-exec — pyphi 1.2.0 works, #7974 premise stale)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/IIT-3-CoarseGrainingMacroPhi.ipynb
+++ b/MyIA.AI.Notebooks/IIT/IIT-3-CoarseGrainingMacroPhi.ipynb
@@ -264,44 +264,32 @@
    "execution_count": 4,
    "id": "macro-code",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-28T18:54:57.011243Z",
-     "iopub.status.busy": "2026-06-28T18:54:57.011243Z",
-     "iopub.status.idle": "2026-06-28T18:55:01.900450Z",
-     "shell.execute_reply": "2026-06-28T18:55:01.897814Z"
-    },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "macro_network : taille 4 noeuds\n",
-      "EI(macro exemple canonique) = 1.1486\n"
-     ]
-    },
-    {
      "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Phi(macro_subsystem exemple) = 0.1139\n"
-     ]
+     "text": "macro_network : taille 4 noeuds (echelle MICRO)\nEI(reseau canonique) = 1.1486\nPhi MICRO (sous-systeme tous-noeuds, etat (0, 0, 0, 0)) = 0.1139\n"
     }
    ],
    "source": [
-    "# Exemple canonique du module macro (concu par les auteurs de pyphi)\n",
+    "# Exemple canonique du module macro (concu par les auteurs de pyphi).\n",
+    "# NOTE : macro_network() est un reseau MICRO \"qui a une integrated information\n",
+    "# plus grande APRES coarse-graining\" (docstring). macro_subsystem() renvoie le\n",
+    "# sous-systeme MICRO (tous les noeuds) de ce reseau -- ce n'est PAS un sous-systeme\n",
+    "# coarse-grained (type Subsystem, aucun attribut de regroupement).\n",
     "net_macro_ex = pyphi.examples.macro_network()\n",
-    "print(\"macro_network : taille\", net_macro_ex.size, \"noeuds\")\n",
+    "print(\"macro_network : taille\", net_macro_ex.size, \"noeuds (echelle MICRO)\")\n",
     "\n",
-    "# EI a l'echelle macro\n",
+    "# EI a l'echelle du reseau (mesure de Hoel, rapide, independante d'un etat)\n",
     "ei_macro = pyphi.macro.effective_info(net_macro_ex)\n",
-    "print(f\"EI(macro exemple canonique) = {ei_macro:.4f}\")\n",
+    "print(f\"EI(reseau canonique) = {ei_macro:.4f}\")\n",
     "\n",
-    "# Phi du subsystem macro (coarse-grained) dans un etat\n",
-    "macro_sub = pyphi.examples.macro_subsystem()\n",
-    "phi_macro = pyphi.compute.phi(macro_sub)\n",
-    "print(f\"Phi(macro_subsystem exemple) = {phi_macro:.4f}\")"
+    "# Phi du sous-systeme MICRO (tous les noeuds) -- PHI MICRO de reference\n",
+    "micro_sub_canonical = pyphi.examples.macro_subsystem()\n",
+    "phi_micro_canonical = pyphi.compute.phi(micro_sub_canonical)\n",
+    "print(f\"Phi MICRO (sous-systeme tous-noeuds, etat {micro_sub_canonical.state}) = {phi_micro_canonical:.4f}\")"
    ]
   },
   {
@@ -309,38 +297,30 @@
    "execution_count": 5,
    "id": "compare-code",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-28T18:55:01.932543Z",
-     "iopub.status.busy": "2026-06-28T18:55:01.932543Z",
-     "iopub.status.idle": "2026-06-28T18:55:07.137781Z",
-     "shell.execute_reply": "2026-06-28T18:55:07.131787Z"
-    },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "=== Comparaison micro vs macro (exemple canonique 4-noeuds) ===\n",
-      "  EI  (micro = macro, meme reseau) : 1.1486\n",
-      "  Phi (micro, sous-systeme brut)    : 0.1139\n",
-      "  Phi (macro, coarse-grained)      : 0.1139\n",
-      "  Diff Phi (macro - micro)         : +0.0000\n"
-     ]
+     "name": "stdout",
+     "text": "=== Verification de coherence (les deux sont le sous-systeme MICRO) ===\n  Phi MICRO via examples.macro_subsystem() : 0.1139\n  Phi MICRO via Subsystem(macro_network)   : 0.1139\n  Ecart : +0.0000  (attendu : 0, meme calcul micro)\n\nLe PHI MACRO (coarse-grained) > PHI MICRO est ATTENDU sur ce reseau :\n  sa docstring precise 'greater integrated information after coarse\n  graining'. Le mesurer exige pyphi.macro.emergence(), trop lent en cellule\n"
     }
    ],
    "source": [
-    "# Comparaison : meme reseau, vue micro (sous-systeme \"non coarse-graine\")\n",
-    "micro_sub_ex = pyphi.Subsystem(net_macro_ex, (0, 0, 0, 0))\n",
-    "phi_micro_ex = pyphi.compute.phi(micro_sub_ex)\n",
-    "ei_micro_ex = pyphi.macro.effective_info(net_macro_ex)   # EI est definie au niveau reseau\n",
-    "\n",
-    "print(\"=== Comparaison micro vs macro (exemple canonique 4-noeuds) ===\")\n",
-    "print(f\"  EI  (micro = macro, meme reseau) : {ei_micro_ex:.4f}\")\n",
-    "print(f\"  Phi (micro, sous-systeme brut)    : {phi_micro_ex:.4f}\")\n",
-    "print(f\"  Phi (macro, coarse-grained)      : {phi_macro:.4f}\")\n",
-    "print(f\"  Diff Phi (macro - micro)         : {phi_macro - phi_micro_ex:+.4f}\")"
+    "# Verification de coherence : examples.macro_subsystem() et Subsystem(macro_network)\n",
+    "# sont le MEME sous-systeme micro (tous les noeuds) -- leurs Phi coincident par\n",
+    "# construction. Ce n'est PAS une comparaison macro vs micro (cf. note cellule\n",
+    "# precedente : macro_subsystem() n'est pas coarse-grained).\n",
+    "micro_sub_direct = pyphi.Subsystem(net_macro_ex, (0, 0, 0, 0))\n",
+    "phi_micro_direct = pyphi.compute.phi(micro_sub_direct)\n",
+    "print(\"=== Verification de coherence (les deux sont le sous-systeme MICRO) ===\")\n",
+    "print(f\"  Phi MICRO via examples.macro_subsystem() : {phi_micro_canonical:.4f}\")\n",
+    "print(f\"  Phi MICRO via Subsystem(macro_network)   : {phi_micro_direct:.4f}\")\n",
+    "print(f\"  Ecart : {phi_micro_canonical - phi_micro_direct:+.4f}  (attendu : 0, meme calcul micro)\")\n",
+    "print()\n",
+    "print(\"Le PHI MACRO (coarse-grained) > PHI MICRO est ATTENDU sur ce reseau :\")\n",
+    "print(\"  sa docstring precise 'greater integrated information after coarse\")\n",
+    "print(\"  graining'. Le mesurer exige pyphi.macro.emergence(), trop lent en cellule\")"
    ]
   },
   {
@@ -352,11 +332,13 @@
    "source": [
     "### Interprétation honnête\n",
     "\n",
-    "Sur cet exemple canonique 4-nœuds, on constate que **$\\Phi$ macro $\\approx$ $\\Phi$ micro** (différence quasi nulle). Cela **confirme empiriquement** l'avertissement du §0 : le coarse-grain ne crée **pas automatiquement** d'emergence positive.\n",
+    "`pyphi.examples.macro_subsystem()` n'est **pas** un sous-système coarse-grained : c'est le sous-système **micro** (tous les nœuds) du réseau canonique. Les deux valeurs de $\\Phi$ ci-dessus coïncident donc par construction (même calcul micro) -- cet écart nul est un **contrôle de cohérence**, pas une comparaison macro vs micro.\n",
     "\n",
-    "**Pourquoi ?** L'emergence positive (Hoel 2013) apparaît lorsque le coarse-grain **filtre du bruit** : si les nœuds micro sont *probabilistes* (bruit) et que le macro-nœud agrège plusieurs copies corrélées, la moyennisation réduit la variance et augmente l'EI. Sur des réseaux **déterministes** (comme nos toys), il n'y a pas de bruit à filtrer, donc pas de gain d'emergence.\n",
+    "**Où est le $\\Phi$ macro ?** La comparaison coarse-grained exige `pyphi.macro.emergence(réseau, état)`, qui énumère tous les regroupements possibles pour trouver l'échelle spatiale de $\\Phi$ maximal. Sur 4 nœuds cette recherche explose combinatoirement (cf. avertissement du §2 : au-delà de la minute), donc on ne l'invoque pas dans une cellule de notebook.\n",
     "\n",
-    "L'IIT prédit que sur des réseaux probabilistes spécifiques (cf. Albantakis, Marshall, Tononi), le $\\Phi$ macro dépasse le $\\Phi$ micro — mais exhiber ce cas proprement dans pyphi 1.2.0 stable exige une construction TPM probabiliste soignée (et des conditions d'indépendance conditionnelle strictes), qui dépasse le cadre d'un notebook d'introduction. Le résultat **qualitatif** à retenir : **l'échelle macro est une vraie dimension de l'analyse IIT**, et le module `pyphi.macro` fournit les outils pour l'explorer (EI, coarse-grain, blackbox), mais l'emergence positive n'est ni triviale ni garantie."
+    "**Ce que dit le design du réseau.** La docstring de `macro_network()` précise qu'il s'agit d'un réseau micro *qui a une integrated information plus grande après coarse-graining*. Autrement dit, l'émergence positive (Hoel 2013) y est **attendue** -- le coarse-grain augmente le $\\Phi$ en moyennant du bruit ou en réduisant la dégénérescence. Ce notebook montre la **méthode** et l'**API** (`pyphi.macro.effective_info`, `all_partitions`, `emergence`), mais exhiber un $\\Phi$ macro > $\\Phi$ micro concret exige soit un réseau plus petit, soit une exécution hors-cellule (script) tolérante au coût combinatoire.\n",
+    "\n",
+    "Le résultat **qualitatif** à retenir : l'échelle macro est une vraie dimension de l'analyse IIT, et `pyphi.macro` fournit les outils, mais l'émergence positive n'est ni triviale ni gratuite à calculer."
    ]
   },
   {


### PR DESCRIPTION
Grain: DEEP/code-correctness — lane myia-po-2025:CoursIA — prev: DEEP/code-correctness (#7971 GT-10)

## Defect (same root cause as #7974, G.1 firsthand via pyphi 1.2.0 kernel)

`pyphi.examples.macro_subsystem()` is NOT coarse-grained — it is the plain micro `Subsystem` (all 4 nodes) of the canonical `macro_network` (confirmed: `type == Subsystem`, no `groupings`/`partition`/`coarse_grain` attribute). So cell 11 compared `Phi(macro_subsystem)` to `Phi(Subsystem(macro_network,0000))` = **two micro subsystems, identical by construction** (diff +0.0000). That tautology was presented in cell 12 as empirical proof that "coarse-graining does not create emergence" — directly contradicting `macro_network`'s documented design ("a network of micro elements which has greater integrated information after coarse graining").

## This PR vs #7974 (collision — requesting ai-01 arbitration)

#7974 (jsboige) diagnoses the SAME defect and fixes cell 12 markdown. But #7974's body claims the **code fix is RECOVERABLE-MACHINE** — *"pyphi 1.2.0 casse sur Python 3.10+ / exige Python <= 3.9 sur machine dédiée"* — and therefore ships markdown-only.

**That premise is STALE / FALSE.** pyphi 1.2.0 runs fine on the pyphi kernel of this machine: I re-executed cells 10 and 11 firsthand and captured real outputs (EI=1.1486, Phi MICRO=0.1139, ~6s each — confirmed in this PR's committed outputs). Only the full combinatorial `emergence()` search times out (confirmed: 300s/180s timeouts), which is exactly why this PR keeps cells 10/11 as a micro-phi consistency check + pointer to `emergence()` rather than calling it.

So this PR is a **superset** of #7974: cells 10/11 are re-executed with real outputs and relabeled as the MICRO reference / consistency check, plus cell 12 markdown rewritten honestly. ai-01: please arbitrate — merge this + supersede #7974, or merge #7974's markdown and I rebase the code-only delta. Either is fine; I do not merge.

## Changes (real kernel re-execution, pyphi 1.2.0)

- **cell 10** (code, re-exec, ec=4): relabel `macro_network`/`macro_subsystem` as the MICRO reference (not "macro coarse-grained"). EI=1.1486, Phi MICRO=0.1139. Inline note that `macro_subsystem()` is the micro subsystem.
- **cell 11** (code, re-exec, ec=5): reframe as a consistency check (both are micro; diff 0 expected by construction) + pointer to `pyphi.macro.emergence()` as the real macro-vs-micro comparison (not called in-cell: too slow at 4 nodes — matches the §2 warning).
- **cell 12** (markdown, French-accented): honest interpretation — consistency check not emergence comparison; emergence is EXPECTED on this network per docstring; notebook teaches method/API; concrete Phi-macro>Phi-micro needs smaller network or out-of-cell script.

## Validation

- Real pyphi kernel re-execution (outputs captured from actual run, not hand-edited — Stop & Repair respected).
- execution_count 4/5 (stable cell positions).
- Repo validator: 0 OK / 1 Warning / 0 Errors — the Warning is **PRE-EXISTING on origin/main** (verified via `git stash`), not introduced.
- Only cells 10/11/12 changed (diff scope verified programmatically).
- Diff 34/52 = output compaction (list→string) + markdown rewrite; no logic stripped.

Part of the #3801 code/output-honesty correction wave.

See #3801, #7974
