### PR TITLE
fix(tweety,#3801): Tweety-4 cell 30 MaxSAT Note wrong cost (15 -> 40, structural insight)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-4-Belief-Revision.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-4-Belief-Revision.ipynb
@@ -1877,7 +1877,7 @@
     "- `a || !b` : `False || False` = **False** → violée, coût 25\n",
     "- `!c` : `True` → **satisfaite**, coût 0\n",
     "\n",
-    "> **Note** : RC2 a trouvé l'optimum global. Si on avait forcé `c=True` (violant `!c`), le coût serait 15, mais on aurait besoin de moins de variables auxiliaires. RC2 prouve mathématiquement que 25 est le minimum atteignable."
+    "> **Note** : RC2 a trouvé l'optimum global. La clause molle `a || !b` est **structurellement toujours violée** : les contraintes dures `!a` (donc `a=False`) et `b` (donc `b=True`) la rendent fausse dans tous les cas, si bien que son coût de 25 est **inévitable**. Le seul vrai degré de liberté est la clause `!c` : forcer `c=True` la violerait (coût 15) *en plus* du 25 inévitable, soit un total de **40** — supérieur à l'optimum. En respectant `!c` (`c=False`, comme RC2 l'a fait), le coût reste 25, qui est bien le minimum atteignable."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/doc-honesty — lane myia-po-2025:CoursIA — prev: DEEP/code-correctness (#7975 IIT-3)

## Defect (G.1 firsthand, backlog po-2026 c.648)

`Tweety-4-Belief-Revision.ipynb` (Python twin) cell 30 — the MaxSAT interpretation Note was **arithmetically wrong and self-contradictory**:

> "Si on avait forcé `c=True` (violant `!c`), le coût serait 15 ... RC2 prouve mathématiquement que **25 est le minimum** atteignable."

If `c=True` truly cost 15, then 15 < 25 and 25 would NOT be the minimum — the Note contradicts itself. The cell 29 RC2 output confirms the optimum: `a=False, b=True, c=False, d=True, f=True, g=False`, **cost 25**.

## Correct arithmetic (firsthand)

The soft clause `a || !b` is **structurally always violated**: the hard constraints `!a` forces `a=False` and `b` forces `b=True`, so `a || !b = False || False = False` in every assignment. Its cost of 25 is **inevitable**, not a choice. Forcing `c=True` would violate `!c` (cost 15) **on top of** the unavoidable 25, for a total of **40** — strictly worse than the optimum. RC2 correctly keeps `c=False` to stay at 25.

## Fix (markdown-only)

Rewrote the final Note paragraph to:
- state that `a || !b` is forced-violated by the hard constraints (25 unavoidable);
- correct the `c=True` cost to **40** (not 15);
- explain that respecting `!c` keeps the cost at the 25 minimum.

This adds the genuine MaxSAT pedagogical insight — **some soft clauses are unsatisfiable given the hard constraints, so their cost is structural, not a choice** (a core MaxSAT concept the original Note obscured).

## Validation

- Markdown-only (C.2 exception — no re-exec needed; the MaxSAT RC2 output in cell 29 is deterministic and unchanged).
- G.1 firsthand: re-derived the cost of `c=True` by hand against the committed hard/soft clauses and the cell 29 output.
- The analysis table above and the "**Coût total : 25**" line were already correct and are preserved byte-identical. Only the final Note changed (**+1/−1**).
- Repo validator: 0 OK / 1 Warning / 0 Errors — the Warning is **PRE-EXISTING on origin/main** (verified via `git stash`), not introduced. nbformat strict OK.
- Only cell 30 changed (diff scope verified programmatically).

Part of the #3801 code/output-honesty correction wave. Backlog po-2026 c.648 (R6 doc-honesty, confirmed firsthand here).

See #3801
