### PR TITLE
fix(tweety,#3801): Tweety-2 cell 51 SAT witness non-model (Info→après-midi violated info_am)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-2-Basic-Logics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-2-Basic-Logics.ipynb
@@ -2884,10 +2884,10 @@
    "id": "l8jm9v7af8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-20T11:13:05.348154Z",
-     "iopub.status.busy": "2026-06-20T11:13:05.347857Z",
-     "iopub.status.idle": "2026-06-20T11:13:05.461606Z",
-     "shell.execute_reply": "2026-06-20T11:13:05.459469Z"
+     "iopub.execute_input": "2026-07-22T14:43:44.231041Z",
+     "iopub.status.busy": "2026-07-22T14:43:44.230691Z",
+     "iopub.status.idle": "2026-07-22T14:43:44.528865Z",
+     "shell.execute_reply": "2026-07-22T14:43:44.527520Z"
     },
     "papermill": {
      "duration": 0.015068,
@@ -2903,9 +2903,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Maths      → après-midi\n",
-      "Info       → après-midi\n",
-      "Physique   → matin\n",
+      "Maths      → matin\n",
+      "Info       → matin\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Physique   → après-midi\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "\n",
       "Physique le matin aussi → OK\n"
      ]
@@ -2918,11 +2930,10 @@
     "if jvm_ready:\n",
     "    from org.tweetyproject.logics.pl.syntax import Proposition, PlBeliefSet, Negation, Conjunction, Disjunction\n",
     "    from org.tweetyproject.logics.pl.sat import Sat4jSolver, SatSolver\n",
-    "    from java.util import ArrayList\n",
     "    from org.tweetyproject.logics.pl.reasoner import SatReasoner\n",
     "\n",
     "    parser = PlParser()\n",
-    "    p = parser.parseFormula  \n",
+    "    p = parser.parseFormula\n",
     "\n",
     "    kb = PlBeliefSet()\n",
     "\n",
@@ -2933,25 +2944,42 @@
     "    kb.add(p(\"!(maths_am && phys_am)\"))\n",
     "    kb.add(p(\"!(maths_pm && phys_pm)\"))\n",
     "\n",
-    "    kb.add(p(\"info_am\"))\n",
+    "    kb.add(p(\"info_am\"))  # Contrainte 3 : Info doit etre le matin\n",
     "\n",
     "    SatSolver.setDefaultSolver(Sat4jSolver())\n",
     "    solver = SatSolver.getDefaultSolver()\n",
     "\n",
-    "    witness = solver.getWitness(ArrayList(kb))\n",
-    "    if witness is None:\n",
+    "    if not solver.isSatisfiable(kb):\n",
     "        print(\"Pas de solution.\")\n",
     "    else:\n",
-    "        vrais = {str(f) for f in witness}\n",
-    "        for nom, am in ((\"Maths\", \"maths_am\"), (\"Info\", \"info_am\"), (\"Physique\", \"phys_am\")):\n",
-    "            if am in vrais:\n",
+    "        # Extraction d'une affectation valide : pour chaque cours on tente le\n",
+    "        # creneau \"matin\" et on verifie via le solveur SAT qu'il reste\n",
+    "        # consistant avec les choix deja retenus ; sinon c'est l'apres-midi.\n",
+    "        # (L'extraction directe d'un temoin par Sat4j n'etait pas fiable ici :\n",
+    "        #  elle renvoyait une affectation ne satisfaisant pas la contrainte\n",
+    "        #  unitaire info_am, d'ou la reconstruction pas-a-pas ci-dessous.)\n",
+    "        choix = PlBeliefSet()\n",
+    "        for f in kb:\n",
+    "            choix.add(f)\n",
+    "        for nom, am, pm in ((\"Maths\", \"maths_am\", \"maths_pm\"),\n",
+    "                            (\"Info\", \"info_am\", \"info_pm\"),\n",
+    "                            (\"Physique\", \"phys_am\", \"phys_pm\")):\n",
+    "            essai = PlBeliefSet()\n",
+    "            for g in choix:\n",
+    "                essai.add(g)\n",
+    "            essai.add(p(am))\n",
+    "            if solver.isSatisfiable(essai):\n",
+    "                choix.add(p(am))\n",
     "                print(f\"{nom:10} → matin\")\n",
     "            else:\n",
+    "                choix.add(p(pm))\n",
     "                print(f\"{nom:10} → après-midi\")\n",
+    "\n",
+    "    # Contrainte supplementaire : \"Physique le matin\" est-elle compatible ?\n",
     "    kb.add(p(\"phys_am\"))\n",
-    "    if solver.isSatisfiable(ArrayList(kb)):\n",
+    "    if solver.isSatisfiable(kb):\n",
     "        print(\"\\nPhysique le matin aussi → OK\")\n",
-    "    else:   \n",
+    "    else:\n",
     "        print(\"\\nPhysique le matin aussi → contradiction\")\n",
     "else:\n",
     "    print(\"Exemple saute : JVM Tweety non disponible\")\n"


### PR DESCRIPTION
Grain: MED/code-correctness — lane po-2023 — EPIC #3801 (SOTA axe-2 doc-honesty)
Dispatched by po-2026 (P0 DM, firsthand-diagnosed). Re-diagnosed on re-exec.

## Summary

`Tweety-2-Basic-Logics.ipynb` cell 51 (Exemple guide: Planification en logique propositionnelle) modeled **"Info doit etre le matin"** via `kb.add(p("info_am"))`, but the committed witness output showed **"Info → après-midi"** — directly violating the unit clause just added. Firsthand G.1-verified + re-executed against `origin/main` (TweetyProject v1.30, 77 JARs, zulu17 JDK).

## Defect — witness violates the kb it was drawn from

- cell 50 markdown: constraint 3 = "Info doit etre le matin"; Indices: "Info_am".
- cell 51 code: `kb.add(p("info_am"))`, then `solver.getWitness(ArrayList(kb))`.
- committed output: `Info → après-midi` (info_am NOT in witness).

## Root cause (re-diagnosed — po-2026 hypothesis refined, NOT forced)

po-2026 hypothesized `ArrayList(kb)` drops the unit clause (fix: `→ kb`). Firsthand re-exec shows the cause is **different and deeper**:

1. **`ArrayList(kb)` does NOT drop the clause** — both `kb.size()` and `ArrayList(kb).size()` = 9; formulas include `"info_am"`.
2. **`SatReasoner().query(kb, info_am)` = True** — the kb correctly entails info_am (constraint well-modeled; satisfiability correct).
3. **`Sat4jSolver.getWitness` returns an INVALID `PossibleWorld`** `[phys_pm, maths_pm, phys_am]` — satisfies NEITHER `info_am` NOR the `!(phys_am && phys_pm)` mutex. Broken under **all** overloads: `Collection`, `BeliefSet` (via reflection), and `Formula` (ambiguous). `getWitness` is unreliable for this mixed-clause kb.
4. **`getWitness(kb)` direct THROWS** — jpype "Ambiguous overloads" (`PlBeliefSet` is both `Collection<PlFormula>` and `BeliefSet`). The `ArrayList(kb)` wrapper was an (incomplete) workaround for that ambiguity, but it routed to the broken `DimacsSatSolver.getWitness(Collection)` path that mangles the bare unit proposition.

## Fix — reconstruct the schedule via `isSatisfiable` (proven reliable)

Replaced the broken `getWitness`-based extraction with a **greedy `isSatisfiable` pass**: for each course try "matin", keep it if SAT-consistent with prior committed choices, else "après-midi". Deterministic (Sat4j boolean, no RNG/LLM). Removed the `ArrayList` import (no longer needed).

**Output** (genuine kernel exec, `nbconvert --allow-errors`, cwd = shared-tree `SymbolicAI/Tweety/` so the JVM bootstrap finds `libs/` + `jdk-17-portable`):
```
Maths      → matin
Info       → matin        (was après-midi — FIX)
Physique   → après-midi

Physique le matin aussi → OK
```

**Valid model**: each course exactly one slot; Maths & Physique in different slots (am vs pm — satisfies `!(maths_am && phys_am)`); Info matin (constraint 3). "Physique le matin aussi → OK" is correct — Info and Physique have no mutual-exclusion constraint, so Physique can also be morning (Maths goes pm).

## Validation

- **nbformat VALID** (strict, 55 cells).
- **C.1:** 0 `raise NotImplementedError` / `assert False` / `1/0`.
- **Surgical:** 1 file, +45/−17, **all in cell 51**; 54/55 cells + top-level `metadata` + `nbformat` byte-identical to `origin/main` (json round-trip byte-identity verified: `json.loads→dump(indent=1)+'\n' == origin/main`).
- **Honest (Stop & Repair):** outputs from real `python3` kernel exec (no hand-editing); root cause re-diagnosed firsthand rather than forcing po-2026's predicted fix (which throws — reported back via DM).

## G.1 firsthand verification

Re-executed cell 51 against `origin/main` content with the canonical Tweety env (shared-tree `libs/` 77 JARs + `jdk-17-portable/zulu17.50.19`). Probed all `getWitness` overloads (Collection / BeliefSet via reflection / Formula) — all return the same invalid `[phys_pm, maths_pm, phys_am]` non-model. Confirmed `SatReasoner().query(kb, info_am)=True` (kb entails info_am) and the two valid models `{info_am,maths_am,phys_pm}` / `{info_am,maths_pm,phys_am}`. The greedy `isSatisfiable` reconstruction deterministically yields the first valid model (Maths matin, Info matin, Physique après-midi).

See **#3801** (EPIC SOTA axe-2 doc-honesty / code-correctness registry). Partial contribution — `See #3801` (no auto-close).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
