### PR TITLE
fix(sc,#3801): SC-15 cell 5 markdown over-claimed safe prime (cell 7 uses random prime, q=p-1)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-15-Zero-Knowledge-Proofs.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-15-Zero-Knowledge-Proofs.ipynb
@@ -250,19 +250,21 @@
     "tags": []
    },
    "source": [
-    "### Interpretation : Paramètres du groupe\n",
+    "### Interpretation : Paramètres du groupe (version simplifiée)\n",
     "\n",
-    "Les paramètres generes reposent sur la notion de **premier sur** (safe prime) :\n",
+    "La démo interactive ci-dessus (cellule 7) utilise un groupe multiplicatif **simplifié**, à visée pédagogique :\n",
     "\n",
-    "| Paramètre | Rôle | Propriete |\n",
+    "| Paramètre | Rôle | Ce que la cellule 7 génère réellement |\n",
     "|-----------|------|-----------|\n",
-    "| **p** (129 bits) | Module du groupe | `p = 2q + 1` avec q premier (safe prime) |\n",
-    "| **q** (128 bits) | Ordre du sous-groupe | Premier, diviseur de `p - 1` |\n",
-    "| **g** (129 bits) | Générateur | `g = h^2 mod p`, engendre le sous-groupe d'ordre q |\n",
+    "| **p** (256 bits) | Module du groupe | Nombre premier aléatoire via `getPrime(256)` — **pas un safe prime** |\n",
+    "| **q = p − 1** (256 bits) | Ordre du groupe multiplicatif Z_p* | **Non premier** (p − 1 est pair) ; c'est l'ordre du groupe complet |\n",
+    "| **g** (256 bits) | Générateur | Élément aléatoire de Z_p* via `getRandomRange(2, p − 1)` |\n",
     "\n",
-    "**Pourquoi un safe prime ?** Le sous-groupe d'ordre q n'a pas de sous-groupe propre, ce qui elimine les attaques par sous-groupe petit (Pohlig-Hellman). La cle publique `y = g^x mod p` ne revele pas x car le problème du logarithme discret est calculement infaisable dans ce groupe.\n",
+    "Le protocole reste **mathématiquement valide** dans ce groupe complet : le petit théorème de Fermat garantit g^(p−1) ≡ 1 (mod p), donc la vérification g^s ≡ R · y^c (mod p) tient avec s = r + c·x mod (p−1). L'identification fonctionne, la preuve aussi.\n",
     "\n",
-    "**Note** : 128 bits est pedagogique. En production, on utilise 256 bits (RFC 7919) pour une securite de 128 bits equivalente AES.\n"
+    "**Pourquoi cette version n'est pas suffisante en production ?** Travailler dans Z_p* complet (d'ordre p−1 composite) expose aux **attaques par sous-groupe petit (Pohlig-Hellman)** : un attaquant décompose le logarithme discret modulo chaque facteur premier de p−1. La parade standard est le **safe prime** p = 2q + 1 (avec q premier), en se restreignant au sous-groupe d'ordre q via un générateur g = h² mod p. C'est précisément ce qu'implémente la **section 3** ci-dessous (classe `SchnorrZKP`, cellule 12) : génération d'un vrai safe prime et d'un générateur d'ordre q premier.\n",
+    "\n",
+    "**Note** : 256 bits est pédagogique ici. En production, on utilise des groupes d'ordre premier ≥ 256 bits (courbes 25519, RFC 7919) pour une sécurité équivalente à AES-128.\n"
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/doc-honesty — lane po-2023 — EPIC #3801.

## Summary

`SC-15-Zero-Knowledge-Proofs.ipynb` cell 5 markdown ("Interpretation : Paramètres du groupe") **over-claimed** that the demo used a **safe prime** setup, but cell 7 code generates none of it. Firsthand G.1-verified against `origin/main`: read FULL cell 5 (markdown) + cell 7 (code + committed output) + cell 12 (SchnorrZKP).

## Defect — markdown describes a safe prime the code does not generate

| Markdown claim (cell 5) | What cell 7 actually does |
|---|---|
| `p = 2q + 1` with q prime (**safe prime**) | `p = getPrime(256)` — random prime, **NOT** a safe prime |
| **p (129 bits)** / **q (128 bits)** | `bits=256` → p is **256 bits** (committed output: `0xb4fb1e...`) |
| q prime, divisor of p−1, order of subgroup | `q = p - 1` — **composite** (p−1 is even), order of the **full** Z_p* |
| `g = h² mod p`, generates order-q subgroup | `g = getRandomRange(2, p−1)` — random element of Z_p* |

The markdown credited the demo with **Pohlig-Hellman resistance** (subgroup-order-q property) that the code does **not** deliver.

## Fix — honest description of cell 7's simplified setup (markdown-only)

Rewrote cell 5 to accurately describe what cell 7 generates (random prime, q=p−1 non-prime, random g), and clarified the protocol **remains mathematically valid** in the full group (Fermat: g^(p−1)≡1 mod p, so g^s ≡ R·y^c holds with s=r+c·x mod (p−1)). **Preserved** the Pohlig-Hellman / safe-prime teaching, **reframed** as "why this simplified version is not production-secure", with a **forward-reference to section 3 (SchnorrZKP, cell 12)** which correctly implements the proper safe prime (p=2q+1, generator g=h² mod p of order q).

This matches the notebook's pedagogical arc: §2 simplified interactive intro → §3 formalized Schnorr (safe prime). Markdown-only (C.2 exception: cell 5 is markdown; cell 7 code/outputs unchanged).

## Validation

- **nbformat VALID** (strict, 41 cells).
- **Surgical:** 1 file, +10/−8, all in cell 5; 40/41 cells + top-level `metadata` + `nbformat` byte-identical to `origin/main` (json round-trip byte-identity verified).
- **Honest:** matches cell 7's actual params + cell 12's correct safe-prime implementation.

## G.1 firsthand verification

Read FULL cells 5 (over-claiming markdown), 7 (`generate_dlog_params`: getPrime(256), q=p−1, random g; committed output 256-bit p), and 12 (`SchnorrZKP.__init__`: `q=getPrime`, `p=2q+1`, `g=h² mod p` — the correct safe prime). Confirmed cell 7's protocol is valid (Fermat) but lacks the safe-prime property; cell 12 implements it correctly. Markdown now describes cell 7 honestly and points to cell 12.

See **#3801** (EPIC SOTA axe-2 doc-honesty). Partial contribution — `See #3801`.

Co-Authored-By: Claude-Code <noreply@anthropic.com>