### PR TITLE
fix(z3,#3801): Z3-Python-03 cell 6 doc-honesty -- simplify DOES detect syntactic redundancy

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb
@@ -282,12 +282,14 @@
    "source": [
     "### Interpretation : simplification contextuelle\n",
     "\n",
-    "**Sortie obtenue** : la tactique `simplify` normalise les contraintes (par exemple `x > 10` devient `Not(x <= 10)`) mais ne detecte pas les redundances. La tactique `ctx-solver-simplify` raisonne sur le contexte mais peut conserver certaines contraintes selon la version de Z3.\n",
+    "**Sortie obtenue** : sur ce goal, `simplify` produit **2 contraintes** alors que `ctx-solver-simplify` en conserve **3**. C'est donc `simplify` qui elimine ici une redondance : les contraintes `x > 5` et `x + 2 > 7` se normalisent toutes deux en `Not(x <= 5)`, et `simplify` les fusionne en une seule (deduplication **syntaxique**). Inversement, `ctx-solver-simplify` -- bien que concue pour exploiter le contexte -- ne retire ni `x > 5` ni `x + 2 > 7` (pourtant impliquees par `x > 10`) et conserve les trois contraintes.\n",
     "\n",
     "**Points cles** :\n",
-    "1. `simplify` traite chaque contrainte isolement et normalise les expressions.\n",
-    "2. `ctx-solver-simplify` tient compte du **contexte global** pour eliminer les redundances detectees.\n",
-    "3. Sur de gros problemes, le pretraitement peut reduire significativement le nombre de contraintes utiles."
+    "1. `simplify` normalise chaque contrainte puis fusionne les formes **syntaxiquement identiques** (ici `x > 5` et `x + 2 > 7`) : deduplication locale, peu couteuse.\n",
+    "2. `ctx-solver-simplify` cible la subsomption **contextuelle** (retirer une contrainte impliquee par les autres), mais son comportement n'est pas garanti : selon la version de Z3 et la forme du goal, elle peut laisser passer des contraintes contextuellement redondantes, comme on le voit ici.\n",
+    "3. Les deux tactiques sont **complementaires** plutot que hierarchisees : `simplify` attrape les doublons syntaxiques que `ctx-solver-simplify` laisse passer, et reciproquement pour les implications contextuelles. Sur de gros problemes, on les combine souvent dans un pipeline (`Then`).\n",
+    "\n",
+    "> **Note technique** : le resultat de `ctx-solver-simplify` depend de la version de Z3 (tactique historique au comportement partiel). Pour une subsomption contextuelle fiable, on prefere generalement combiner `simplify` avec d'autres tactiques plutot que de s'y fier seule."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/doc-honesty — lane myia-po-2025:CoursIA — prev: MED/doc-honesty (#7979 Tweety-4)

## Defect (G.1 firsthand, backlog po-2026 c.648)

`Z3-Python-03-Tactics.ipynb` cell 6 (interpretation of `ctx-solver-simplify`) claimed:

> "`simplify` normalise les contraintes ... mais **ne detecte pas les redundances**."

This **directly contradicts the cell 5 output** it claims to interpret. On the goal `x > 10, x > 5, x + 2 > 7`:
- `simplify` produces **2 constraints** (`Not(x<=10)`, `Not(x<=5)`) — it normalized `x>5` and `x+2>7` (which both reduce to `Not(x<=5)`) and **merged** them: it DID detect a redundancy (syntactic deduplication).
- `ctx-solver-simplify` produces **3 constraints** (`Not(x<=10)`, `x>5`, `x+2>7`) — it **kept** both `x>5` and `x+2>7`, even though both are implied by `x>10`.

So the markdown inverts the output's actual lesson: on this goal, `simplify` removed a redundancy while `ctx-solver-simplify` did not. The claim "simplify ne detecte pas les redundances" is factually wrong against the committed output.

## Fix (markdown-only, C.2 exception)

Rewrote cell 6 to be grounded in the cell 5 output:
- states the real counts (simplify → 2, ctx-solver → 3);
- explains that `simplify` does **syntactic** normalization + deduplication (caught `x>5 ≡ x+2>7`);
- explains that `ctx-solver-simplify` targets **contextual** subsumption but its behavior is not guaranteed (version-dependent, legacy tactic) — it left contextually-redundant constraints here;
- corrects the pedagogical framing: the two tactics are **complementary** (syntactic vs contextual), not hierarchized as the old text implied.

This adds the genuine Z3-tactics insight — simplify catches *syntactic* duplicates that ctx-solver-simplify misses, and vice-versa for *contextual* implications — which the original markdown obscured by asserting the opposite of what the output shows.

## Validation

- Markdown-only (C.2 exception — no re-exec needed; cell 5 output is deterministic and unchanged).
- G.1 firsthand: re-derived both tactics' output by hand against the committed cell 5 goal + output.
- Repo validator: 0 OK / 1 Warning / 0 Errors — the Warning is **PRE-EXISTING on origin/main** (verified via `git stash` round-trip, present before AND after), not introduced.
- nbformat strict OK; round-trip stable (`json.dumps indent=1`).
- Only cell 6 changed (+6/−4, diff scope verified programmatically); C.1 clean (0 `NotImplementedError`/`assert False`/`1/0`).

## Variation-protocol note (transparency for ai-01 merge-gate)

This is my 2nd consecutive MED/doc-honesty grain. It is genuinely distinct from #7979 (fresh family Z3 vs Tweety; defect class = tactic-semantics misrepresentation vs MaxSAT cost-arithmetic; requires Z3 domain reasoning, not a count resync). I scanned **3 fresh Z3/Sudoku notebooks firsthand this cycle** (Z3-Python-11 Graph-Coloring, Z3-Python-12 Real-Arithmetic, Sudoku-12-Z3-Python) — all CORRECT, confirming the fleet-wide convergence signal. The DEEP substance pool for po-2025 is genuinely gated this cycle: Lean (#7477 prover = #1453 coordinator-tandem deferred by po-2026; #6724 GOL = Mathlib rc1 cache empty/blocked), .NET (#7225 decision-gated/submodule), QC (#6891 Docker down), and API rate-limit blocks sonnet sub-agents (Explore) until 19:26Z. Requesting ai-01 DEEP redirect/provisioning (variation-protocol §4) for the next cycle.

Part of the #3801 code/output-honesty correction wave. Backlog po-2026 c.648.

See #3801
