### PR TITLE
fix(gt5,#3801): saddle_game matrix had no saddle point (named 'Jeu avec point-selle')

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-5-ZeroSum-Minimax.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-5-ZeroSum-Minimax.ipynb
@@ -417,32 +417,32 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "\n",
       "Jeu avec point-selle (gains de Row)\n",
       "==================================================\n",
       "              C1        C2        C3\n",
       "------------------------------------\n",
-      "    R1      3.00      2.00      4.00\n",
+      "    R1      1.00      2.00      4.00\n",
       "    R2      1.00      4.00      3.00\n",
       "    R3      2.00      3.00      2.00\n",
       "\n",
       "Analyse maximin/minimax:\n",
       "----------------------------------------\n",
-      "Maximin (Row): action 'R1', valeur = 2.0\n",
-      "Minimax (Col): action 'C1', valeur = 3.0\n",
+      "Maximin (Row): action 'R3', valeur = 2.0\n",
+      "Minimax (Col): action 'C1', valeur = 2.0\n",
       "\n",
-      "=> Pas de point-selle en strategies pures\n",
-      "   Gap: 1.0\n"
+      "=> Point-selle existe ! Valeur du jeu = 2.0\n",
+      "   Equilibre: (R3, C1)\n"
      ]
     }
    ],
    "source": [
     "# Jeu avec point-selle\n",
     "saddle_game = ZeroSumGame(\n",
-    "    A=[[3, 2, 4],\n",
+    "    A=[[1, 2, 4],\n",
     "       [1, 4, 3],\n",
     "       [2, 3, 2]],\n",
     "    row_labels=['R1', 'R2', 'R3'],\n",


### PR DESCRIPTION
Grain: MED/code-correctness — lane myia-po-2025:CoursIA — prev: MED/doc-honesty (#7991 App-4)

## Defect (G.1 firsthand, #3801 code-honesty)

`GameTheory-5-ZeroSum-Minimax.ipynb` cell 7 defines a game **named `"Jeu avec point-selle"`** (game *with* a saddle point) but its matrix has **no saddle point** — the output printed `=> Pas de point-selle en stratégies pures, Gap: 1.0`.

Matrix (committed):
```
A = [[3, 2, 4],
     [1, 4, 3],
     [2, 3, 2]]
```
Hand-verified:
- Row mins: R1=min(3,2,4)=2, R2=min(1,4,3)=1, R3=min(2,3,2)=2 → **maximin = 2**
- Col maxes: C1=max(3,1,2)=3, C2=max(2,4,3)=4, C3=max(4,3,2)=4 → **minimax = 3**
- maximin (2) ≠ minimax (3) → **no saddle point**. No entry is simultaneously min-of-its-row AND max-of-its-column. The output's "Gap 1.0" confirms it.

**Intent is unambiguous** (two independent signals):
1. The variable is `saddle_game` with `name="Jeu avec point-selle"` — clearly intended to *demonstrate* a saddle point, contrasting with the no-saddle games (Matching Pennies, RPS) analyzed in cells 5-6.
2. Cell 5's `analyze_maximin_minimax` has a **`Point-selle existe !` branch** that **never fires** in any committed output — all three analyzed games (MP, RPS, `saddle_game`) hit the no-saddle branch. The saddle-demo branch is effectively dead code because `saddle_game` is buggy.
3. Cell 29 (Exercice 3) asks students to *"Construire un jeu 3x3 ... possédant un point-selle ... Une matrice avec un élément qui est à la fois le minimum de sa ligne et le maximum de sa colonne"* — the concept is taught, but the notebook's own worked example fails to illustrate it.

## Fix (minimal, single-element matrix change + faithful re-exec)

Changed a single matrix entry `a[0][0]: 3 → 1`:
```
A = [[1, 2, 4],   <- was [[3, 2, 4],
     [1, 4, 3],
     [2, 3, 2]]
```
Now:
- Row mins: 1, 1, 2 → **maximin = 2** (R3)
- Col maxes: C1=max(1,1,2)=2, C2=4, C3=4 → **minimax = 2** (C1)
- maximin == minimax == 2 → **saddle point exists** at **(R3, C1) = 2**, unique (only `a[2][0]=2` is both min-of-row-3 and max-of-col-1).

**Why this minimal change** (not a wholesale matrix redesign): lowering `a[0][0]` from 3 to 1 removes the value that was forcing C1's column-max up to 3; C1's max then drops to 2 (= R3's contribution), making maximin == minimax. It is the smallest edit that makes the game live up to its name, it yields a *unique* saddle (cleaner pedagogically than a minimal edit creating multiple tied saddles), and it respects the author's original matrix structure.

The cell now prints:
```
=> Point-selle existe ! Valeur du jeu = 2.0
   Equilibre: (R3, C1)
```

## Re-execution (C.2, real — not hand-edited)

Cell 7 is **pure NumPy** (`np.min`, `np.max`, `np.argmax`, `print`) — it does **not** use `nashpy` or `linprog` (those are in later cells 9/11/17, untouched). I re-ran the cell's exact logic (reproducing the `ZeroSumGame` class from cell 3 + `analyze_maximin_minimax` from cell 5 + the fixed cell 7) in a real kernel and captured the actual stdout — **this is a faithful re-exec (Stop & Repair), not a hand-edited output**. NumPy's `argmax`/`argmin`/`min`/`max` are deterministic and kernel-agnostic, so the result is identical regardless of the declared `gametheory-wsl` kernel (the cell has no nashpy dependency). Only cell 7's source matrix + output changed; all other 32 cells byte-identical to origin/main (diff scope verified programmatically).

## Validation

- G.1 firsthand: hand-derived maximin=2 / minimax=3 (old, no saddle) and maximin=minimax=2 (new, saddle at R3,C1) before AND after; confirmed by real kernel re-exec (output matches hand-computation exactly).
- Repo validator: 0 OK / 1 Warning / 0 Errors — the Warning is **PRE-EXISTING on origin/main** (verified via `git stash` round-trip, present before AND after), not introduced.
- nbformat strict OK; round-trip stable (`json.dumps indent=1` + trailing newline).
- Diff scope: ONLY cell 7 (source + output) changed. C.1 n/a (no stub touched). No downstream cell references `saddle_game` (cells 9-21 use `mp`/`rps`/`asym_game`/`blotto`), so no cascade.

## Variation-protocol

G-VAR-1 ✓ (MED/code-correctness plancher — breaks the doc-honesty streak: #7979→#7987→#7991 were 3 consecutive doc-honesty; this is a fresh `notebook-python` code-correctness grain). G-VAR-3 ✓ (fresh family GT-5 first-touch + distinct defect-class = wrong-example-matrix / dead-branch, vs prior doc-honesty markdown-vs-output claims; requires game-theory domain reasoning — saddle-point enumeration — not scan-generatable).

Part of the #3801 code/output-honesty correction wave. Backlog po-2026 c.648.

See #3801
