### PR TITLE
fix(z3,#3801): Z3-Python-01 cell 4 markdown example model contradicted committed output (x=6,y=4 vs x=9,y=1)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction.ipynb
@@ -173,7 +173,7 @@
    "source": [
     "### Interpretation : sat / unsat / unknown\n",
     "\n",
-    "**Sortie obtenue** : le solveur repond `sat` et fournit un modèle concret (par exemple `x = 6, y = 4`).\n",
+    "**Sortie obtenue** : le solveur repond `sat` et fournit un modèle concret (`x = 9, y = 1` ici, parmi d'autres possibles).\n",
     "\n",
     "| Reponse | Signification | Action |\n",
     "|---------|---------------|--------|\n",


### PR DESCRIPTION
Grain: LIGHT/doc-honesty — lane po-2023 — EPIC #3801 (SOTA axe-2 doc-honesty)

## Summary

`Z3-Python-01-Introduction.ipynb` cell 4 (Interpretation: sat/unsat/unknown) said the solver returns **"un modèle concret (par exemple `x = 6, y = 4`)"**, but cell 3 committed output is **`x = 9, y = 1`**. The markdown example contradicted the output a student reads right above it. Firsthand G.1-verified against `origin/main` (3× re-verified across c.805/806/808).

## Defect

- cell 3 code: `s.add(x + y == 10, x > 0, y > 0, x > y)`; `s.check()` → `sat`.
- cell 3 committed output: `x = 9`, `y = 1` (`Verification : x + y = 10`).
- cell 4 markdown: "fournit un modèle concret (par exemple `x = 6, y = 4`)".
- `x = 6, y = 4` **IS** a valid model (6+4=10, 6>4) — but it is **not** the model Z3 returned. A student matching the prose to the output sees a discrepancy on the very first notebook of the Z3 series.

## Fix — align markdown example to committed output (markdown-only)

Changed line to "fournit un modèle concret (`x = 9, y = 1` ici, parmi d'autres possibles)" so the prose matches cell 3's actual output. Preserved the multi-model teaching (point 1 of the same cell already notes `s.model()` returns one of several — "parmi d'autres possibles" reinforces it honestly).

Markdown-only (C.2 exception: cell 4 is markdown; cell 3 code + outputs byte-identical).

## Validation

- **nbformat VALID** (strict, 26 cells).
- **C.1:** 0 `raise NotImplementedError` / `assert False` / `1/0`.
- **Surgical:** 1 file, +1/−1, all in cell 4 markdown line 2; 25/26 cells + top-level `metadata` + `nbformat` byte-identical to `origin/main` (json round-trip byte-identity verified: `json.loads→dump(indent=1)+'\n' == origin/main`).
- **Honest:** matches cell 3's actual committed output (`x = 9, y = 1`).

## G.1 firsthand verification

Re-verified 3× against `origin/main` (c.805, c.806, c.808): cell 4 markdown `x = 6, y = 4` vs cell 3 output `x = 9, y = 1`. No OPEN PR for this defect (collision-guarded: #7719 was Z3-01 Optimize/knapsack, different cell; #5606 was Z3-02 givens, different notebook).

See **#3801** (EPIC SOTA axe-2 doc-honesty). Partial contribution — `See #3801` (no auto-close).

Co-Authored-By: Claude-Code <noreply@anthropic.com>