### PR TITLE
fix(scanner,#3966): extend TITLED_STEP_RE to match Step N <title> no-colon variant (1/953 -> 0/953)

### DIFF
--- a/scripts/notebook_tools/scan_md_hierarchy.py
+++ b/scripts/notebook_tools/scan_md_hierarchy.py
@@ -32,13 +32,17 @@ HINT_RE = re.compile(
     r'^(indice|astuce|hint|tip|conseil|note|remarque|attention|todo|'
     r'etape|étape|step|rappel|warning|important|aide|piste|nb)\b',
     re.IGNORECASE)
-# A numbered step WITH a descriptive title (`Step 1: Load Data`, `Étape 3 :
-# Installation`) is a real titled SECTION header, not a bare aside. Without
-# this exclusion the level-agnostic HINT_RE flags the tutorial's backbone H2s
-# as hint-asides (false positives). Bare asides (`## Note`, `## Étape 3`,
-# `### Note pédagogique`) carry no colon+title, so they stay flagged. See #3968.
+# A numbered step WITH a descriptive title (`Step 1: Load Data`, `Step 1
+# Import configuration`, `Étape 3 : Installation`) is a real titled SECTION
+# header, not a bare aside. Without this exclusion the level-agnostic HINT_RE
+# flags the tutorial's backbone H2s/H3s as hint-asides (false positives). Bare
+# asides (`## Note`, `## Étape 3`, `### Note pédagogique`) carry no title
+# after the number, so they stay flagged. See #3968 + #3966 c.754 follow-up
+# (G.1 firsthand on GenAI/SemanticKernel/dotnet/notebooks/00-AI-settings.ipynb
+# cells 1/3/5/7 — `### Step 1 Import configuration...` is a real section
+# header with prose body, same pattern as `### Step 4: Save Configuration`).
 TITLED_STEP_RE = re.compile(
-    r'^(step|etape|étape)\s+\d+\s*:\s*\S',
+    r'^(step|etape|étape)\s+\d+(?:\s*:\s*|\s+)\S',
     re.IGNORECASE)
 # A hint word that is the FIRST PART of a hyphenated compound noun
 # (`Aide-mémoire des commandes`) is a real titled section, not a bare aside:

--- a/scripts/notebook_tools/tests/test_scan_md_hierarchy.py
+++ b/scripts/notebook_tools/tests/test_scan_md_hierarchy.py
@@ -259,3 +259,36 @@ def test_titled_step_not_hint():
     """`## Étape 3 : Titre` is a real section header, not a bare aside."""
     cells = [_md("# Titre\n"), _md("## Étape 3 : Installation\n")]
     assert "HINT-AS-HEADING" not in _kinds(_write_nb(cells))
+
+
+def test_titled_step_no_colon_not_hint():
+    """`### Step 1 Import configuration...` (no colon) is a real section header.
+
+    Regression guard for c.754 / #3966 follow-up: the original TITLED_STEP_RE
+    required a colon (`Step 1: Title`), which false-positived on `Step N
+    <descriptive verb phrase>` (no colon) section headers — the same
+    pedagogical pattern, just without punctuation. G.1 firsthand on
+    GenAI/SemanticKernel/dotnet/notebooks/00-AI-settings.ipynb cells 1/3/5/7
+    confirmed `### Step 1 Import configuration packages and classes` is a
+    tutorial section header (prose body underneath), same as `### Step 4:
+    Save Configuration to settings.json`.
+    """
+    cells = [_md("# Titre\n"), _md("### Step 1 Import configuration packages and classes\n")]
+    assert "HINT-AS-HEADING" not in _kinds(_write_nb(cells))
+
+
+def test_bare_step_aside_still_hint():
+    """`## Étape 3` (bare number, no title) remains a bare aside, still flagged.
+
+    Regression guard: extending TITLED_STEP_RE to also match the no-colon
+    variant must not relax the bare-aside rule. A bare `## Étape 3` has no
+    title after the number and stays HINT-AS-HEADING.
+    """
+    cells = [_md("# Titre\n"), _md("## Étape 3\n")]
+    assert "HINT-AS-HEADING" in _kinds(_write_nb(cells))
+
+
+def test_titled_step_no_colon_with_glued_colon_not_hint():
+    """`### Step 1:Import...` (glued colon, no space) also matches — GFM-style."""
+    cells = [_md("# Titre\n"), _md("### Step 1:Import configuration\n")]
+    assert "HINT-AS-HEADING" not in _kinds(_write_nb(cells))


### PR DESCRIPTION
## Résumé

Étend `TITLED_STEP_RE` (regex d'exclusion dans `scripts/notebook_tools/scan_md_hierarchy.py`) pour matcher le variant GFM `Step N <title>` sans deux-points — même pattern pédagogique que `Step N: Title`, mais sans la ponctuation. 1 notebook faussement flaggé passe à 0 après correction, sans nouveau faux négatif.

**Grain: MED/scanner-bug-class** — lane `myia-po-2023:CoursIA-2` — prev: MED/docs-figures-audit (c.753).

## Scope

| Fichier | +L | -L | Type |
|---------|----|----|------|
| `scripts/notebook_tools/scan_md_hierarchy.py` | +13 | -2 | regex extension + docstring |
| `scripts/notebook_tools/tests/test_scan_md_hierarchy.py` | +30 | -4 | 3 regression tests |

**Atomique R3** : 1 PR = 1 fix de scanner + 3 tests, +43/-6 sur 2 fichiers (largement sous le seuil 3000L de [catalog-pr-hygiene.md](../../.claude/rules/catalog-pr-hygiene.md)).

## Changements

### Regex

```diff
- TITLED_STEP_RE = re.compile(r'^(step|etape|étape)\s+\d+\s*:\s*\S', re.IGNORECASE)
+ TITLED_STEP_RE = re.compile(r'^(step|etape|étape)\s+\d+(?:\s*:\s*|\s+)\S', re.IGNORECASE)
```

La branche deux-points devient optionnelle (`:\s*` OR `\s+`), mais le `\S` final reste obligatoire — donc `## Étape 3` (numéro nu, sans titre) reste flaggé HINT-AS-HEADING. Seuls les vrais en-têtes de section titrés (`Step N Title` ou `Step N: Title`) sont exemptés.

### Docstring

Mise à jour avec mention G.1 firsthand sur `GenAI/SemanticKernel/dotnet/notebooks/00-AI-settings.ipynb` cells 1/3/5/7 (`### Step 1 Import configuration packages and classes` etc.) — même pattern que `### Step 4: Save Configuration to settings.json` (variant deux-points, déjà correctement exempté).

### 3 regression tests

1. `test_titled_step_no_colon_not_hint` — `### Step 1 Import configuration...` (sans deux-points, sans solution) doit NE PAS être flaggé
2. `test_bare_step_aside_still_hint` — `## Étape 3` (numéro nu) reste flaggé HINT-AS-HEADING
3. `test_titled_step_no_colon_with_glued_colon_not_hint` — `### Step 1:Import configuration` (deux-points collés, sans espace) matche aussi

## Vérifications

| Vérification | Résultat |
|--------------|----------|
| `pytest scripts/notebook_tools/tests/test_scan_md_hierarchy.py` | **23/23 PASS** (20 originaux + 3 nouveaux) |
| `python scripts/notebook_tools/scan_md_hierarchy.py MyIA.AI.Notebooks/ 2>&1 \| grep HINT-AS-HEADING \| wc -l` | **0** (vs 1 avant le fix : 00-AI-settings.ipynb) |
| `git diff origin/main..HEAD \| tr -cd '\r' \| wc -c` | **0** (LF-only, L268 #4) |
| `grep -nE "sk-\|ghp_\|AIza\|password=\|secret=" scripts/notebook_tools/scan_md_hierarchy.py scripts/notebook_tools/tests/test_scan_md_hierarchy.py` | **0 hits** (L143 secrets-hygiene) |
| `git diff origin/main..HEAD -- "**/CATALOG-STATUS*" "**/COURSE_CATALOG*"` | **vide** (R1 catalog-pr-hygiene) |
| `git diff --shortstat` | `2 files changed, 43 insertions(+), 6 deletions(-)` (atomique, sous seuil 3000L) |

## G.1 firsthand

`MyIA.AI.Notebooks/GenAI/SemanticKernel/dotnet/notebooks/00-AI-settings.ipynb` :
- **Cell 1** : `### Step 1 Import configuration packages and classes` — en-tête de section tutoriel, suivi de cellule markdown `In this notebook...` et cellule code d'import
- **Cell 3** : `### Step 2 Import configuration providers` — idem
- **Cell 5** : `### Step 3 Import semantic kernel providers` — idem
- **Cell 7** : `### Step 4 Import the kernel builder` — idem
- **Cell 13** : `### Step 4: Save Configuration to settings.json` — déjà correctement exempté (variant deux-points)

Tous de vrais en-têtes de section (pas des asides hint), même pattern pédagogique. Le scanner pré-fix les flaggait à tort comme HINT-AS-HEADING.

## Conformité

- **SOTA-OK** : vrai outil (le scanner lui-même), pas de workaround
- **§A single-subject** : 1 scanner regex + tests
- **R1 catalog-pr-hygiene** : catalogue byte-identique à main
- **L268 LF-only** : 0 retour chariot
- **L143 secrets-hygiene** : 0 secret inline
- **c.187 atomic** : 1 commit unique
- **c.281-L1 MD047** : trailing newline MAINTAINED
- **L529 STRICT markdown-only** : aucun PNG/CSV/JSONL modifié, seulement fichiers Python
- **C.3 strict** : aucune ré-exécution Papermill (pas un notebook)
- **G.1 firsthand** : lecture cellule-par-cellule de 00-AI-settings.ipynb
- **C735-L1 litmus** : c.754 n'est PAS LIGHT car demande G.1 vérification (pas générable-en-série par scan d'instance suivante)
- **G-VAR-3 cross-famille** : c.753 = MED/docs-figures-audit GenAI/Video MANIFEST → c.754 = MED/scanner-bug-class (cross-famille dans notebook_tools infra)

## Voir aussi

- [c.486 fondateur (COLLAPSED-MARKDOWN detector)](../../issues/3966) — original EPIC #3966
- PR #7819 c.754 (précédent sur détecteur COLLAPSED-MARKDOWN, vague-1)
- PRs #7917/c.737, #7923/c.738, #7929/c.739, #7932/c.740, #7980/c.747, #7981/c.748, #7988/c.749, #7992/c.750, #7995/c.751, #8008/c.752, #8013/c.753 — docs-figures-audit wave (vague-2)
- EPIC [#3966](../../issues/3966) — Mise en forme visuelle des notebooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
