### PR TITLE
feat(sw11,#3801): interpret two worked SPARQL examples (FILTER symmetry, GROUP_CONCAT)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-CSharp-KnowledgeGraphs.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-CSharp-KnowledgeGraphs.ipynb
@@ -873,6 +873,22 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "sw11interp1",
+   "metadata": {},
+   "source": [
+    "**Interprétation — Exemple 1.** Cette requête mesure une *affinité cinématographique* entre réalisateurs : combien de genres deux réalisateurs partagent-ils, tous films confondus ?\n",
+    "\n",
+    "Trois astuces SPARQL méritent d'être soulignées :\n",
+    "\n",
+    "1. **Le motif de jointure** `?f1 ex:hasGenre ?g . ?f2 ex:hasGenre ?g` relie deux films `f1` et `f2` dès qu'ils partagent au moins un genre `?g`. Les réalisateurs `?d1`, `?d2` sont récupérés via `directedBy`. C'est le bloc de base d'une mesure de similarité « contenu partagé ».\n",
+    "2. **`FILTER(STR(?d1) < STR(?d2))`** est crucial : sans lui, chaque paire apparaîtrait **deux fois** ((Cameron, Nolan) *et* (Nolan, Cameron)) et chaque réalisateur serait apparié **avec lui-même**. La comparaison lexicographique stricte ne conserve que l'ordonnancement canonique de la paire — l'équivalent SPARQL d'une demi-matrice triangulaire.\n",
+    "3. **`COUNT(DISTINCT ?g) AS ?shared`** + `GROUP BY ?d1 ?d2` agrège : on compte les genres *distincts* partagés par chaque paire, puis `ORDER BY DESC(?shared)` trie les paires les plus proches stylistiquement en premier.\n",
+    "\n",
+    "**Lecture du résultat** (genres vérifiés sur le graphe source, cellule 7) : Cameron (*Avatar* : SciFi, Action) et Nolan (*Inception*, *Interstellar* : SciFi, …) partagent **SciFi + Action** — le cinéma de spectacle à grand budget. Bong (*Parasite*, *Memories of Murder*) et Tarantino (*Pulp Fiction*, *Django*) partagent **Crime + Drama** — le polar dramatique. Les deux paires à 1 genre commun (Bong & Nolan, Nolan & Tarantino) ne croisent que sur **Drama**, qui est aussi le genre le plus représenté du graphe (6 films sur 8). Sur un graphe de milliers de films, cette même requête alimente un *recommender system* de type filtrage collaboratif basé sur les attributs."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 12,
    "id": "aa1b5416",
@@ -919,6 +935,20 @@
     "Console.WriteLine(\"Filmographie de Bong (genres agreges) :\");\n",
     "foreach (SparqlResult r in res4)\n",
     "    Console.WriteLine($\"  {Short(r[\"film\"])} : {((ILiteralNode)r[\"genres\"]).Value.Replace(\"http://example.org/cinema#\",\"\")}\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sw11interp2",
+   "metadata": {},
+   "source": [
+    "**Interprétation — Exemple 2.** Cette requête produit, pour chaque film de Bong Joon-ho, la liste agrégée de ses genres sur une seule ligne.\n",
+    "\n",
+    "- **`GROUP_CONCAT(DISTINCT ?g; SEPARATOR=\", \") AS ?genres`** est l'opérateur-clé : il *aplatit* les plusieurs lignes `(film, genre)` d'un même film en une unique chaîne `\"Crime, Drama\"`. `DISTINCT` dédoublonne les genres répétés ; le `SEPARATOR` contrôle le séparateur affiché.\n",
+    "- **`GROUP BY ?film`** garantit une ligne de sortie **par film** (sans lui, `GROUP_CONCAT` fusionnerait tous les genres de toute la filmographie en une seule chaîne).\n",
+    "- **Piège C# rappelé en commentaire** : la requête est insérée dans une chaîne *verbatim* `@\"...\"`. En C#, un `\"` littéral s'y écrit `\"\"` (doubled). Donc `SEPARATOR=\"\", \"\"` dans le source C# devient `SEPARATOR=\", \"` côté SPARQL. C'est cette mécanique d'échappement qu'il faut avoir en tête quand on relit la requête.\n",
+    "\n",
+    "**Lecture du résultat** : *Memories of Murder* (Crime, Drama) puis *Parasite* (Drama, Thriller). Le genre **Drama** est le fil conducteur — le invariant de la filmographie de Bong — autour duquel il greffe tour àtour du polar et du thriller. Cette évolution génree par génree est précisément ce que l'agrégation `GROUP_CONCAT` rend lisible en un coup d'œil."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/enrichment — lane myia-po-2025:CoursIA — prev: MED/code-correctness (CSP-3 #8024)

## Defect (G.1 firsthand — thin narrative)

`SemanticWeb/SW-11-CSharp-KnowledgeGraphs.ipynb` ships two worked SPARQL examples (cells 30, 31) that produce **real, non-trivial results** — but with **no interpretation markdown** between or after them. Cell 29 is a 2-line section header (`## Exemples guidés`); cell 30 (Exemple 1) runs immediately, then cell 31 (Exemple 2), then cell 32 jumps straight to `## Exercices à compléter`. A student reading top-to-bottom meets two rich query outputs with zero guidance on *what SPARQL feature each one demonstrates* or *how to read the result*.

The two examples are pedagogically dense and deserve their own reading cells:
- **Exemple 1** (cell 30): director pairs sharing genres → output `Cameron & Nolan : 2 genre(s) commun(s)`, `Bong & Tarantino : 2`, etc.
- **Exemple 2** (cell 31): Bong filmography with aggregated genres → output `MemoriesOfMurder : Crime, Drama`, `Parasite : Drama, Thriller`.

G.1-CONFIRMED firsthand: read all of cells 29-34 (source + outputs). No interpretation cell exists; cell 27 (an earlier worked example) and cell 28 DO carry interpretation, so the gap at 30/31 is an inconsistency in the notebook's own pedagogical pattern.

## Fix (markdown-only enrichment, 2 interpretation cells)

Two new markdown cells inserted (id `sw11interp1`, `sw11interp2`), each **substantive and output-specific** (not generic transition prose):

1. **After Exemple 1** — three SPARQL mechanics tied to the actual query/result:
   - the join pattern `?f1 hasGenre ?g . ?f2 hasGenre ?g` as a shared-content similarity block;
   - `FILTER(STR(?d1) < STR(?d2))` as the symmetry-elimination trick (avoids duplicate (A,B)/(B,A) pairs and self-pairs — the SPARQL equivalent of a triangular half-matrix);
   - `COUNT(DISTINCT ?g) AS ?shared` + `GROUP BY ... ORDER BY DESC(?shared)`.
   - **Grounded result reading** (genres verified against the source KG, cell 7): Cameron & Nolan share **SciFi + Action**; Bong & Tarantino share **Crime + Drama**; the 1-genre pairs share only **Drama** (the most-represented genre, 6/8 films). Frames it as a collaborative-filtering-style affinity measure.

2. **After Exemple 2** — `GROUP_CONCAT(DISTINCT ?g; SEPARATOR=", ")` as the row-flattening operator, `GROUP BY ?film` (why one row per film), the C# verbatim-string `""` escaping gotcha (verbatim `SEPARATOR="", ""` → SPARQL `SEPARATOR=", "`), and a grounded reading of Bong's genre evolution (Drama as the through-line).

## Why MED (not LIGHT)

Each interpretation cell requires genuine domain reasoning — explaining specific SPARQL operators AND grounding the reading in the actual KG data (verified genre assignments). Not scan-generatable generic transition text (which the repo explicitly bans: "pas 'Suite du traitement' generique").

## Validation

- **G.1 firsthand**: read cells 7 (KG data), 27/28 (existing interpretation pattern), 29-34 (the gap + outputs); re-derived every genre-sharing claim by intersecting director genre-sets from cell 7 BEFORE writing the interpretation (Cameron∩Nolan={SciFi,Action}, Bong∩Tarantino={Crime,Drama}, Drama count=6/8). No fabrication: an earlier draft inferred "science-fiction" without verification — corrected to cite the verified intersection.
- Repo validator: **1 OK / 0 Warnings / 0 Errors** (markdown-only, no warning introduced).
- nbformat strict OK; round-trip stable (`json.dumps indent=1, ensure_ascii=False` + trailing newline).
- Diff scope: ONLY +2 markdown cells (30 insertions, 0 deletions, single file). All 40 original cells byte-identical (reindexed, source+outputs untouched). No code cell modified → C.2 markdown exception (no re-exec needed; existing code-cell execution_counts/outputs preserved).
- French-first markdown with accents (matches the notebook's existing markdown style in cells 27/32; no #2876 accent regression — only NEW accented content added, no existing text altered).

## Variation-protocol

G-VAR-1 ✓ (MED/enrichment plancher — genuine pedagogical substance). G-VAR-3 ✓ : **different genre** (enrichment vs prev MED/code-correctness CSP-3 #8024) AND **different family** (SemanticWeb first-touch this window vs the Search/GameTheory streak c.657-661). Litmus "générable-en-série par scan ?" → no (each interpretation cell needs SPARQL-feature explanation + KG-grounded result reading, not generic prose).

See #3801
