### PR TITLE
docs(docs,#7422): subagents-reference.md — drop stale `code-explorer` reference, anchor catch-all on `general-purpose`

### DIFF
--- a/docs/reference/subagents-reference.md
+++ b/docs/reference/subagents-reference.md
@@ -40,7 +40,7 @@ Distinction : `series-improver` = grain **série** (batch + resume) ; `notebook-
 ### Cross-cutting maintenance (toutes machines, alignement env)
 - `readme-hierarchy-auditor` (audit/maj hiérarchie README bottom-up), `readme-updater` (maj README d'une série après ajout/modif notebooks).
 - `slide-analyzer` / `slide-improver` (decks PPTX/Marp, vision sk-agent) pour les tracks slides EPITA/ECE.
-- `code-explorer` (read-only), `general-purpose` (catch-all) pour exploration/analyse async non couverte par un specialist.
+- `general-purpose` (catch-all, exploration/analyse async non couverte par un specialist).
 
 ## Usage async (pattern)
 


### PR DESCRIPTION
## docs(docs,#7422): subagents-reference.md — fix `code-explorer` stale reference (agent never defined in `.claude/agents/`)

**Grain: MED/docs-hygiene** — lane myia-po-2024:CoursIA-2 — pivot cross-famille post-c.794 cluster-agents+kernels-runtime (G-VAR-3 intra-dossier strict ✓, fichier distinct dans même dossier racine `docs/reference/`).

### Scope (R3 atomic, +1/-1 strict sur 1 fichier / 1 feature)

**Faute factuelle** : 1 référence à l'agent `code-explorer` dans `docs/reference/subagents-reference.md` L43 pointe vers un agent qui **n'a jamais été défini** dans `.claude/agents/` :

- `Glob .claude/agents/code-explorer*` → **No files found** ✓
- `Glob .claude/agents/Explore*` → **No files found** ✓
- `ls .claude/agents/` = 21 fichiers `.md` réels (genai-iterator, infer-notebook-enricher, notebook-{cell-iterator,cleaner,designer,enricher,executor,iterative-builder,modernizer,validator}, prover-forensic, qc-{research-notebook,robustness-researcher,strategy-analyzer,strategy-improver}, readme-{hierarchy-auditor,updater}, series-improver, slide-{analyzer,improver}, training-specialist). Aucun ne s'appelle `code-explorer`.

**Source réelle existante** : `general-purpose` (catch-all, sibling du slot). C'est l'agent listé immédiatement après dans la même phrase, et c'est lui qui fait effectivement le travail d'exploration/analyse async. Per global CLAUDE.md (règle model-delegation), `Explore` est un type d'agent built-in côté Claude Code (tool-level), distinct des agents du dépôt — il n'a pas de fichier `.md` propre dans `.claude/agents/`. Le doc confond les deux.

**Substitution :** suppression de la référence `code-explorer`, conservation de `general-purpose` comme catch-all unique (deux éléments fusionnés en un seul pour préserver la substance pédagogique « pour exploration/analyse async non couverte par un specialist »).

### Découverte C715-L2 3-prong AVANT claim

- **Prong 1** : `git log --all --oneline --grep "code-explorer"` → **0 commit historique**. La référence n'a jamais été corrigée.
- **Prong 2** : `git log --follow -- docs/reference/subagents-reference.md` → 8 commits ; le dernier pertinent = `5abe6bd5f` (PR #7646, c.755, reconcile count drift) qui a corrigé L60 ("17 skills") mais pas L43 (référence `code-explorer`). PR antérieure #7465 ("reconcile subagents-reference roster 15 -> 17 skills") a aussi raté ce slot.
- **Prong 3** : `gh pr list --search "code-explorer" --state all` → 0 PR historique (collision-free). `gh pr list --search "subagents-reference" --state all` → 2 PRs antérieures (#7465, #7646) toutes MERGÉES, aucune n'a touché ce slot.

### Vérifications G.1 firsthand

- `Glob .claude/agents/code-explorer*` → **No files found** ✓ (agent absent)
- `Glob .claude/agents/Explore*` → **No files found** ✓ (pas de variante capitalisée)
- `ls .claude/agents/ | wc -l` = **21** ✓ (cohérent avec L3 doc "21 sous-agents")
- `grep -rn "code-explorer" docs/` → **1 hit unique** = `docs/reference/subagents-reference.md:43`, corrigé. **0 autre référence** à nettoyer (le hit `scratchpad/pr-5653/docs/reference/subagents-reference.md` = copie éphémère hors-repo).
- `grep -rn "code-explorer" .claude/` → 0 hit (les rules ne citent pas ce nom).
- Lecture cross-référencée avec global CLAUDE.md section « MCP Tools » : `Explore` listé comme built-in tool agent type (system-level claude-code subagent), **distinct** des agents dépôt. Confirme que la confusion source du drift.

### Conformité

- **R3 atomicité** : 1 fichier (`docs/reference/subagents-reference.md`), +1/-1 strict (bien sous seuil 3000L §A), 1 feature « remove stale `code-explorer` reference + keep `general-purpose` as canonical catch-all », 1 domaine « docs/reference/ docs-hygiene »
- **R1 catalog-pr-hygiene** : `git diff origin/main..HEAD -- "**/CATALOG-STATUS*" "**/COURSE_CATALOG*"` = vide (catalogue byte-identique)
- **L268 LF-only** : `git diff | tr -cd '\r' | wc -c` = 0 (0 hit CR)
- **L143 secrets-hygiene** : `grep -nE "sk-|ghp_|AIza|password=|secret="` sur le diff = 0 hit
- **L677-L4 ★★★** : body PR rédigé HORS worktree (`C:\tmp\c795_pr_subagents_code_explorer_body.md`), pas `git add -A`
- **L761-L2 ★** : PR REST API path avec `-F body=@file` (GraphQL rate-limit, pas de POST direct)
- **C187** : atomicité 1 sujet = « docs/reference/ subagents-reference stale `code-explorer` reference fix »
- **L528/L529** : md-only strict, 0 churn notebook, 0 churn PNG
- **C735-L1 litmus anti-LIGHT** : G.1 firsthand vérifié (4 disk-vs-doc checks + lecture cross-référencée global CLAUDE.md), cross-référencé avec PR #7646 c.755 + PR #7465 antérieurs, MED substance ≠ scan-LIGHT
- **L791-L1 ★** (c.791 lesson) : sub-genre `MANIFEST-desc-visuelle` NOT applicable (cible = `docs/reference/`, pas un MANIFEST notebook)
- **L793-L1 ★ NEW** (c.793) : doc cite fichier-script = `ls <path>/<file>` AVANT edit, vérifié `Glob .claude/agents/code-explorer*` AVANT edit
- **L793-L2 ★ NEW** (c.793) : `general-purpose` confirmé catch-all canonique sibling, pas d'arbitrage caduque à nettoyer (L43 était mono-claim, pas un arbitrage en cours)
- **L793-L3 ★ NEW** (c.793) : G-VAR-3 intra-dossier `docs/reference/` OK (c.793 scripts-reference+accent-cure → c.794 cluster-agents+kernels-runtime → c.795 subagents-reference = fichiers distincts même dossier racine)
- **L794-L1 ★ NEW** (c.794) : suppression pure vs substitution — ici c'est **substitution par source réelle** (`general-purpose` qui couvre effectivement le rôle) = MED substance ✓ (préserve la fonction pédagogique « exploration/analyse async non couverte par un specialist »)
- **L794-L2 ★ NEW** (c.794) : référence-fantôme (analogue scripts-fantômes) = 3 vérifs systématiques : `Glob` absent ✓ + `git log --grep` = 0 ✓ + agent réel (`general-purpose`) existe ✓
- **L794-L3 ★ NEW** (c.794) : c.793→c.794→c.795 intra-dossier `docs/reference/` G-VAR-3 OK (3 fichiers distincts)
- **L758-L1** : phantom-cycle-detection via `gh pr list --search "code-explorer" --state all` = 0 collision AVANT claim ✓

### Anti-régression

Aucune ligne des autres fichiers `docs/reference/` touchée. Les 21 agents réels dans `.claude/agents/` restent byte-identity. Les autres références `general-purpose` / `readme-hierarchy-auditor` / `readme-updater` / `slide-analyzer` / `slide-improver` intactes. Le total roster doc (L3 « 21 sous-agents ») reste aligné au disque (`ls .claude/agents/ | wc -l` = 21). Le bloc « Cross-cutting maintenance » préserve la fonction pédagogique « exploration/analyse async non couverte par un specialist », juste ancrée sur le bon agent canonique (`general-purpose`).

### Residuel

Aucun. PR mergera post-review ai-01. Si un reviewer demande l'ajout du built-in tool agent `Explore` (system-level Claude Code) en plus de `general-purpose` pour la couverture « exploration read-only », je peux amender dans une PR distincte — c'est un autre sub-grain (clarification outillage Claude Code, hors-scope vague #7422 pure docs-hygiene). La version actuelle est minimaliste et reversible : la fonction pédagogique est préservée en attendant que quelqu'un clarifie le mapping entre agents dépôt et agents built-in Claude Code.

### Leçons durables consolidation c.790-c.795

- **L795-L1 ★ NEW** : doc cite agent = `Glob .claude/agents/<name>*` + `grep -rn "<name>" docs/ .claude/` AVANT edit (analogue L793-L1 fichier-script). Les agents dépôt sont définis par fichiers `.md` à nom-kebab ; un nom cité en doc mais absent du roster = drift à corriger.
- **L795-L2 ★ NEW** : confusion `code-explorer` (drift) vs `Explore` (built-in tool) vs `general-purpose` (catch-all canonique) = 3 noms pour 2 rôles distincts. Le doc avait fusionné par erreur un built-in tool agent avec un agent dépôt inexistant. La canonicalisation = pointer le rôle sur l'agent dépôt réel (`general-purpose`) qui couvre effectivement la fonction.
- **L795-L3 ★ NEW** : G-VAR-3 intra-dossier 3-prong OK (c.793 → c.794 → c.795 = 3 fichiers distincts `docs/reference/`). Cap appliqué strictement à chaque cycle ; la vague « 3 docs-hygiene sub-grains consécutifs dans le même dossier » reste bornée par la limite « 1 sub-grain par dossier par cycle » qu'on s'est fixée (cf c.794 pivot cross-famille prévu).

### Lien vers les travaux antérieurs #7422

Cette PR s'inscrit dans la campagne en cours :
- PR #8027 (c.794, myia-po-2024) — `docs(docs,#7422)` cluster-agents.md + kernels-runtime.md — fix `train_with_checkpoints.py` stale references
- PR #8023 (c.793, myia-po-2024) — `docs(docs,#7422)` scripts-reference + accent-cure-defense fix stale co-listage `check_caps_regression.py`
- PR #8017 (c.792, myia-po-2024) — `docs(docs,#7422)` docs/README.md — Lean archive link + ICT dissociations-matrix missing entry
- PR #7646 (c.755, myia-po-2024) — `docs(reference,#7422)` reconcile count drift in subagents-reference + scripts-reference (a corrigé L60 mais pas L43)
- PR #7465 — `docs(skills)` reconcile subagents-reference roster 15 -> 17 skills (a raté L43)
- PR #7585 (c.755) — `docs(reference,#7422)` apply 3 UPDATEs from docs/reference/ triage (3 corrections atomiques par PR, même pattern sub-grain)

**Pattern RELEASE vague #7422** = cascade sub-grains atomiques détectés par auditors. Auditor c.792 a livré ~10 fichiers METTRE À JOUR dans `docs/reference/`, c.793 + c.794 + c.795 en ont chacun corrigé 1-2 fichiers parmi eux. Reste 5+ candidats c.796+ : `common-commands.md` L76 `run_epf_mis_2026.py` absent, `catalog_markers.md` L28-29 stale counts (448 → 830), `regles-validation-detail.md` L116/121 stale count (988 → 830), `notebook-parity-table.md` L92 wrong SemanticKernel path + L152/L166 missing docs/suivis/...

C.795 cycle — `myia-po-2024:CoursIA-2`, 2026-07-22T21:55Z.