### PR TITLE
fix(rl5): align Policy Iteration count markdown with committed output (doc-honesty)

### DIFF
--- a/MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb
@@ -721,7 +721,7 @@
     "tags": []
    },
    "source": [
-    "Policy Itération converge en très peu d'itérations (souvent 2-3) sur FrozenLake déterministe. Les deux méthodes aboutissent a la même politique optimale, comme garanti par la théorie."
+    "Policy Itération converge en peu d'itérations (ici 7 sur ce FrozenLake déterministe à 16 états — comme l'Itération de Valeur, qui converge elle aussi en 7 pas). Les deux méthodes aboutissent à la même politique optimale, comme garanti par la théorie."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/doc-honesty — lane myia-po-2025:CoursIA — prev: MED/code-correctness (#8032 SC-13)

## Defect (G.1 firsthand — markdown-vs-output doc-honesty)

`RL/rl_5_mdp_dp_qlearning.ipynb` cell 18 markdown claims:

> "Policy Itération converge en très peu d'itérations **(souvent 2-3)** sur FrozenLake déterministe."

But the notebook's OWN committed outputs show both Value Iteration and Policy Iteration converging at **iteration 7** on this deterministic FrozenLake (`is_slippery=False`, cell 5):

- cell 11 (Value Iteration): `Convergence a l'iteration 7 (delta=0.00e+00)`
- cell 17 (Policy Iteration): `Politique stable atteinte a l'iteration 7`

A student reading "2-3" in the prose then "iteration 7" in the output sees a direct contradiction — exactly the markdown-vs-committed-output mismatch class (cf po-2023 banked defects Sudoku-11 "27 cases (30%)" vs 45 givens, Z3-Python-02 "~35" vs 30).

G.1-CONFIRMED firsthand: read cell 18 markdown + cells 11/17 committed outputs + cell 5 env setup. `is_slippery=False` ⇒ deterministic MDP ⇒ exact DP ⇒ the "7" is reproducible ground truth (not a stale run).

## Fix (markdown-only, C.2 exception)

Cell 18 rewritten to cite the real count and the honest VI comparison:

> "Policy Itération converge en peu d'itérations (ici **7** sur ce FrozenLake déterministe à 16 états — comme l'Itération de Valeur, qui converge elle aussi en 7 pas). Les deux méthodes aboutissent à la même politique optimale, comme garanti par la théorie."

- Corrects the wrong number (2-3 → 7, matching committed output).
- Softens "très peu" → "peu" (7 is few, not "très peu"/2-3 on a 16-state MDP).
- Adds the grounded VI comparison (also 7) — both reach the same optimal policy.
- Preserves the "même politique optimale" conclusion.

## Validation

- **G.1 firsthand**: cell 18 markdown + cells 11/17 outputs + cell 5 `is_slippery=False` read; determinism confirms "7" is reproducible.
- **C.2 markdown exception**: markdown-only edit (no code cell, no output touched) → no re-exec required; the committed deterministic-DP outputs ARE the ground truth being cited.
- **Repo validator**: 0 OK / 1 Warning / 0 Errors — the Warning is **PRE-EXISTING on origin/main** (verified via `git stash` baseline: identical 1 Warning before AND after my edit).
- **nbformat strict OK**; round-trip stable (`json.dumps indent=1, ensure_ascii=False` + trailing newline).
- **Diff scope**: ONLY cell 18 markdown source. 1 insertion / 1 deletion, single file. No code cell, no output, no execution_count touched.

## Variation-protocol

G-VAR-1 ✓ (MED/doc-honesty plancher — genuine verification: markdown claim cross-checked against committed output + determinism reasoning + domain-aware (PI/VI semantics) honest rephrasing, not a scan-generatable count-fix). G-VAR-3 ✓: **genre distinct** (doc-honesty vs prev code-correctness #8032) AND **family distinct** (RL first-touch vs the Search/SemanticWeb/SmartContracts streak c.661-663). Litmus "générable-en-série par scan ?" → no (requires reading markdown + output + understanding DP determinism to phrase the correction honestly).

See #3801
