### PR TITLE
feat(pymc11): interpret Phi distribution viz (cross-topic contamination)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-11-Topic-Models.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-11-Topic-Models.ipynb
@@ -1050,6 +1050,34 @@
   },
   {
    "cell_type": "markdown",
+   "id": "pymc11_phi_viz_interp",
+   "metadata": {},
+   "source": [
+    "**Interprétation — la distribution Phi révèle la contamination inter-sujets.**\n",
+    "\n",
+    "Le seuil rouge/gris de la visualisation (P(mot|sujet) > 0,1) isole les mots qui *définissent* chaque sujet :\n",
+    "les pics rouges sont nets — `atome` (0,41), `experience` (0,24), `theorie` (0,16) pour la Science ;\n",
+    "`ballon` (0,33), `equipe` (0,25) pour le Sport ; `recette` (0,36), `ingredient` (0,26) pour la Cuisine.\n",
+    "Cette concentration sur quelques mots dominants est précisément ce que le **prior de Dirichlet asymétrique**\n",
+    "a forcé (cellule précédente) : en pénalisant les distributions plates, il pousse chaque sujet vers un *pic*.\n",
+    "\n",
+    "Mais la visualisation expose aussi ce que le tableau des 4 mots dominants masque : la **contamination**.\n",
+    "\n",
+    "1. **`four` est rouge dans DEUX sujets** — Cuisine (0,185, l'« oven », sémantiquement correct) **et** Sport (0,114).\n",
+    "   Le modèle n'a pas pu attribuer ce mot à un seul sujet : il est polysémique (ou bruité), et LDA le\n",
+    "   « partage » entre les deux. C'est inhérent au modèle de sac de mots, qui ignore le contexte.\n",
+    "2. **`match` fuit dans les trois sujets** — rouge en Sport (0,169, son sens dominant « match sportif »),\n",
+    "   mais gris en Science (0,046) et Cuisine (0,053). Sa présence faible hors-Sport est l'empreinte du\n",
+    "   lissage du prior : aucun mot n'a une probabilité strictement nulle sous Dirichlet.\n",
+    "\n",
+    "**Leçon** : les sujets LDA ne sont jamais *purs*. La lecture des distributions Phi complètes (et non\n",
+    "seulement des mots dominants) révèle les mots-frontières — ceux qui résistent à la classification unique.\n",
+    "Ces mots partagés sont aussi les premiers candidats à une **fusion de sujets** si l'on augmente le nombre\n",
+    "de documents ou diminue le nombre de sujets K."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "42ca454f",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
Grain: MED/enrichment — lane myia-po-2025:CoursIA — prev: MED/doc-honesty (#8036 rl_5)

## Defect (G.1 firsthand — thin narrative)

`Probas/PyMC/PyMC-11-Topic-Models.ipynb` cell 22 plots the **full Phi distribution** (P(mot|sujet) per topic — a 3-panel bar chart with a `>0.1` red/gray threshold), but **no markdown interpreted it** before cell 23 jumped straight to `### Analyse des proportions Theta`. A student reading top-to-bottom meets a rich visualization with zero guidance on *what the red/gray threshold isolates* or *what the shared gray bars mean*.

The two interpretation cells that DO exist (cell 19 "Interpretation des résultats" + cell 18's top-4-word print) only surface the **dominant** words. The visualization in cell 22 exposes the **cross-topic contamination** those hide — the genuinely new pedagogical content the viz carries.

## Fix (markdown-only enrichment, 1 grounded interpretation cell)

One new markdown cell inserted after cell 22 (`pymc11_phi_viz_interp`), grounded in the committed phi values (cell 18 output = ground truth):

1. **Red (>0.1) = topic-defining words** — the sharp peaks `atome` (0.41), `experience` (0.24), `theorie` (0.16) for Science; `ballon` (0.33), `equipe` (0.25) for Sport; `recette` (0.36), `ingredient` (0.26) for Cuisine. This concentration is what the **asymmetric Dirichlet prior** forced (it penalizes flat distributions).

2. **`four` is RED in TWO topics** — Cuisine (0.185, "oven", semantically correct) **AND** Sport (0.114). LDA cannot assign this word to a single topic: it is polysémique (or noise), and the model *splits* it between both. Inherent to the bag-of-words assumption (context-blind).

3. **`match` leaks into all three** — red in Sport (0.169, dominant sense) but gray in Science (0.046) and Cuisine (0.053). Its weak off-Sport presence is the **Dirichlet smoothing footprint** (no word is ever exactly zero probability under Dirichlet).

4. **Lesson** — LDA topics are never *pure*. Reading the full Phi distribution (not just the top words) reveals the *boundary words* that resist unique classification — the first candidates for topic merging if K decreases or the corpus grows.

## Why MED (not LIGHT)

Each claim is grounded in a specific committed phi value (cell 18 output), and the interpretation requires genuine LDA-domain reasoning (Dirichlet smoothing, bag-of-words contamination, polysémie) — not scan-generatable transition prose (the repo bans generic "Suite du traitement").

## Validation

- **G.1 firsthand**: read cell 18 (committed phi output, ground truth), cell 19 (existing numeric interpretation), cell 22 (viz source), cell 23 (Theta header); confirmed the viz shows contamination the table hides. Every cited phi value re-verified against cell 18 committed output before writing (anti-fabrication, cf c.662 SW-11 self-correction).
- **C.2 markdown exception**: markdown-only edit (no code cell, no output touched) → no re-exec required.
- **Repo validator**: **1 OK / 0 Warnings / 0 Errors**.
- **nbformat strict OK**; round-trip stable (`json.dumps indent=1, ensure_ascii=False` + trailing newline).
- **Diff scope**: +1 markdown cell, 28 insertions / 0 deletions, single file. All 33 original cells byte-identical (reindexed).
- French-first markdown with accents (matches the notebook's existing style; only NEW accented content added, no existing text altered — no #2876 regression).

## Variation-protocol

G-VAR-1 ✓ (MED/enrichment plancher — genuine LDA-domain reasoning grounded in committed phi values). G-VAR-3 ✓: **different genre** (enrichment vs prev doc-honesty #8036) AND **different family** (Probas/PyMC topic-models first-touch vs the Search/SemanticWeb/SmartContracts/RL streak c.661-664). Litmus "générable-en-série par scan ?" → no (each interpretation needs phi-value grounding + LDA-semantics explanation).

See #3801
