### PR TITLE
fix(z3-python-04): date regex AAAA-MM-JJ under-constrained (code-correctness #3801)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb
@@ -539,26 +539,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Numero a 4 chiffres : sat\n",
-      "  numero = 0000\n",
+      "Numéro a 4 chiffres : sat\n",
+      "  numéro = 0000\n",
       "\n",
       "Email simplifie : sat\n",
-      "  email = p@d.h\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  email = b@t.m\n",
       "\n",
-      "Date AAAA-MM-JJ : sat\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  date = 022-2-8242\n"
+      "Date AAAA-MM-JJ : sat\n",
+      "  date = 0000-00-00\n"
      ]
     }
    ],
@@ -590,23 +578,32 @@
     "    m2 = s2.model()\n",
     "    print(f\"  email = {m2[email].as_string()}\")\n",
     "\n",
-    "# Exemple 3 : format de date AAAA-MM-JJ\n",
+    "# Exemple 3 : format de date AAAA-MM-JJ (4-2-2 chiffres EXACTS)\n",
     "s3 = Solver()\n",
     "date = String('date')\n",
+    "\n",
+    "\n",
+    "def chiffres(n):\n",
+    "    \"\"\"n chiffres consécutifs [0-9]{n} : longueur FIXEE (contrairement a Plus = [0-9]+ variable).\"\"\"\n",
+    "    return Concat(*[Range('0', '9') for _ in range(n)])\n",
+    "\n",
+    "\n",
+    "# AAAA-MM-JJ : groupes de longueur fixee (4, 2, 2) et non Plus (variable).\n",
+    "# Avec Plus, le solveur retournait des chaînes non-dates comme 022-2-8242 (3-1-4 chiffres).\n",
     "regex_date = Concat(\n",
-    "    Plus(Range('0', '9')),  # annee\n",
+    "    chiffres(4),  # annee AAAA\n",
     "    Re('-'),\n",
-    "    Plus(Range('0', '9')),  # mois\n",
+    "    chiffres(2),  # mois MM\n",
     "    Re('-'),\n",
-    "    Plus(Range('0', '9')),  # jour\n",
+    "    chiffres(2),  # jour JJ\n",
     ")\n",
     "s3.add(InRe(date, regex_date))\n",
-    "s3.add(Length(date) == 10)  # forcer le format compact\n",
+    "s3.add(Length(date) == 10)  # desormais implicite (4+1+2+1+2 = 10), garde pour lisibilite\n",
     "\n",
     "print(f\"\\nDate AAAA-MM-JJ : {s3.check()}\")\n",
     "if s3.check() == sat:\n",
     "    m3 = s3.model()\n",
-    "    print(f\"  date = {m3[date].as_string()}\")"
+    "    print(f\"  date = {m3[date].as_string()}\")\n"
    ]
   },
   {
@@ -631,7 +628,7 @@
     "|-----|------------------------|------------------|\n",
     "| 4 chiffres | `Plus(Range('0','9'))` | `[0-9]+` |\n",
     "| Email | `Concat(mot, Re('@'), mot, Re('.'), mot)` | `[a-z]+@[a-z]+\\.[a-z]+` |\n",
-    "| Date | `Concat(chiffres, Re('-'), chiffres, Re('-'), chiffres)` | `[0-9]+-[0-9]+-[0-9]+` |\n",
+    "| Date | `Concat(chiffres(4), Re('-'), chiffres(2), Re('-'), chiffres(2))` | `[0-9]{4}-[0-9]{2}-[0-9]{2}` |\n",
     "\n",
     "**Points cles** :\n",
     "1. `InRe(s, r)` est le predicat d'appartenance : la chaîne `s` doit matcher l'expression reguliere `r`.\n",


### PR DESCRIPTION
## Summary

Correction d'un défaut **code-correctness** (EPIC #3801 Prong-B : l'outil tourne mais sous-spécifie la capacité annoncée) dans la cellule[13] de `Z3-Python-04-Strings-Regex.ipynb` (série canonique trackée `SMT/Z3-API/`).

### Le défaut (vérifié firsthand + probe z3)

La cellule[13] « Date AAAA-MM-JJ » utilisait `Plus(Range('0','9'))` (= `[0-9]+`, **longueur variable**) pour l'année/mois/jour. Seul `Length(date) == 10` contraignait le total. Conséquence : Z3 retournait des modèles qui **ne sont pas des dates** :

- output committé : `date = 022-2-8242` (3-1-4 chiffres)
- **non-déterministe** entre runs (un second run donne `0-24-28200`)

Le label « AAAA-MM-JJ » + `Length == 10` (4+1+2+1+2 = 10) prouvent que l'intention était du **4-2-2 fixe**, mais le regex sous-contraignait → le notebook ne démontrait pas le format de date qu'il annonçait.

## Change

**cell[13] code** — helper `chiffres(n)` à longueur fixée `[0-9]{n}` :
```python
def chiffres(n):
    return Concat(*[Range('0', '9') for _ in range(n)])
regex_date = Concat(chiffres(4), Re('-'), chiffres(2), Re('-'), chiffres(2))
```

**cell[13] outputs** — re-exec RÉELLE avec z3 (stdout capturé, pas de hand-edit) :
```
Numéro a 4 chiffres : sat
  numéro = 0000
Email simplifie : sat
  email = b@t.m
Date AAAA-MM-JJ : sat
  date = 0000-00-00
```
La date `0000-00-00` est un vrai format 4-2-2. L'ancien modèle non-date `022-2-8242` est désormais **UNSAT** sous le regex fixé (vérifié par probe).

**cell[14] table** — ligne Date mise à jour : `Concat(chiffres(4), Re('-'), chiffres(2), Re('-'), chiffres(2))` / `[0-9]{4}-[0-9]{2}-[0-9]{2}` (la table référençait déjà un helper `chiffres` inexistant — le fix le rend réel).

## Preuve de la non-trivialité (Prong-B)

Ce n'est pas un cas dégénéré : Z3 démontre ici sa capacité distinctive de **génération** d'une chaîne satisfaisant un motif exact, ce qu'aucun moteur `re` impératif ne sait faire. Le bug était que le motif **annonçait** AAAA-MM-JJ mais **n'imposait pas** la structure 4-2-2 — le fix resserre le motif pour qu'il tienne sa promesse pédagogique.

## Validation

- **nbformat VALID** (python nbformat.validate)
- **C.1** : 0 violation (`raise NotImplementedError` / `assert False`)
- **Re-exec RÉELLE** : `from z3 import *`, exécution du code fixé, capture stdout (Stop & Repair respecté — pas de hand-edit d'output)
- **Diff scope** : seules les cellules 13 (code+outputs) et 14 (table markdown) modifiées — `git diff origin/main` confirme ; Exemple 1 (`numéro`) et Exemple 2 (`email`) source **byte-identiques**
- **Bonus** : la re-exec a réaligné les accents de l'output `numéro` avec sa source accentuée (l'ancien output committé avait « Numero »/« numero » sans accents alors que la source utilise « numéro »)
- Convention JSON : `json.dumps(indent=1, ensure_ascii=False) + "\n"` == raw, 0 CRLF
- `git diff --stat` : 1 fichier, 21 insertions / 24 deletions

## Test plan
- [x] nbformat VALID
- [x] C.1 = 0
- [x] Re-exec réelle (date = 0000-00-00, ancien modèle UNSAT sous regex fixé)
- [x] Diff scope = cellules 13+14 uniquement
- [x] Byte-identity Exemple 1/2

See #3801 (Prong-B, contribution partielle à l'epic).
