### PR TITLE
fix(smt): Z3-Python-04 date regex fixed-length groups (Prong-B)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb
@@ -536,29 +536,17 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "Numero a 4 chiffres : sat\n",
-      "  numero = 0000\n",
+      "Numéro a 4 chiffres : sat\n",
+      "  numéro = 0000\n",
       "\n",
       "Email simplifie : sat\n",
-      "  email = p@d.h\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  email = b@t.m\n",
       "\n",
-      "Date AAAA-MM-JJ : sat\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  date = 022-2-8242\n"
+      "Date AAAA-MM-JJ : sat\n",
+      "  date = 0000-00-00\n"
      ]
     }
    ],
@@ -590,18 +578,19 @@
     "    m2 = s2.model()\n",
     "    print(f\"  email = {m2[email].as_string()}\")\n",
     "\n",
-    "# Exemple 3 : format de date AAAA-MM-JJ\n",
+    "# Exemple 3 : format de date AAAA-MM-JJ (4-2-2 chiffres)\n",
+    "# Piege : Plus(Range('0','9')) = [0-9]+ accepte une longueur VARIABLE par groupe.\n",
+    "# Contraindre seulement Length(date)==10 ne garantit PAS le decoupage 4-2-2\n",
+    "# (le solveur peut produire 022-2-8242). On definit donc un groupe de longueur FIXE.\n",
+    "def chiffres(n):\n",
+    "    \"\"\"n chiffres consecutifs (longueur fixe), equivalent a [0-9]{n}.\"\"\"\n",
+    "    return Concat(*[Range('0', '9') for _ in range(n)])\n",
+    "\n",
     "s3 = Solver()\n",
     "date = String('date')\n",
-    "regex_date = Concat(\n",
-    "    Plus(Range('0', '9')),  # annee\n",
-    "    Re('-'),\n",
-    "    Plus(Range('0', '9')),  # mois\n",
-    "    Re('-'),\n",
-    "    Plus(Range('0', '9')),  # jour\n",
-    ")\n",
+    "regex_date = Concat(chiffres(4), Re('-'), chiffres(2), Re('-'), chiffres(2))\n",
     "s3.add(InRe(date, regex_date))\n",
-    "s3.add(Length(date) == 10)  # forcer le format compact\n",
+    "# La longueur totale 10 est desormais garantee par construction (4+1+2+1+2).\n",
     "\n",
     "print(f\"\\nDate AAAA-MM-JJ : {s3.check()}\")\n",
     "if s3.check() == sat:\n",
@@ -631,12 +620,13 @@
     "|-----|------------------------|------------------|\n",
     "| 4 chiffres | `Plus(Range('0','9'))` | `[0-9]+` |\n",
     "| Email | `Concat(mot, Re('@'), mot, Re('.'), mot)` | `[a-z]+@[a-z]+\\.[a-z]+` |\n",
-    "| Date | `Concat(chiffres, Re('-'), chiffres, Re('-'), chiffres)` | `[0-9]+-[0-9]+-[0-9]+` |\n",
+    "| Date | `Concat(chiffres(4), Re('-'), chiffres(2), Re('-'), chiffres(2))` | `[0-9]{4}-[0-9]{2}-[0-9]{2}` |\n",
     "\n",
     "**Points cles** :\n",
     "1. `InRe(s, r)` est le predicat d'appartenance : la chaîne `s` doit matcher l'expression reguliere `r`.\n",
     "2. Le solveur peut **inventer** une chaîne satisfaisant le motif, ce qu'aucun moteur `re` imperatif ne sait faire.\n",
     "3. Les expressions regulieres Z3 supportent les mêmes constructeurs que la théorie classique (Kleene), mais en notation fonctionnelle.\n",
+    "4. **Longueur fixe vs variable** : `Plus(Range('0','9'))` (`[0-9]+`) autorise une longueur variable par groupe ; contraindre la longueur totale (`Length == 10`) ne garantit pas le decoupage `AAAA-MM-JJ`. Pour forcer un format precis, on construit des groupes de longueur fixe (`chiffres(n)` = `[0-9]{n}`).\n",
     "\n",
     "> **Note technique** : Z3 supporte également `Option(r)` (zero ou une occurrence, equivalent `r?`) et la construction `Range(c1, c2)` pour les intervalles de caractères."
    ]


### PR DESCRIPTION
Grain: MED/code-correctness — lane myia-po-2025:CoursIA — prev: MED/enrichment (#8037 PyMC-11)

## Defect (G.1 firsthand — code-correctness / Prong-B)

`MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb` cell 13 Exemple 3 ("date AAAA-MM-JJ") used `Plus(Range('0','9'))` — a variable-length `[0-9]+` — for year/month/day, then constrained only `Length(date) == 10`. That does NOT force the 4-2-2 split: the committed output was `date = 022-2-8242` (year=3 digits, month=1, day=4) — a malformed non-canonical date a student would mistake for a valid AAAA-MM-JJ.

This is exactly the Prong-B degeneracy class (EPIC #3801): a format-validation demo whose regex engine's distinctive capacity (anchored fixed-length groups) is not actually exercised — the buggy model passes `Length==10` while violating the AAAA-MM-JJ structure it claims to demonstrate.

## Fix

`chiffres(n)` helper builds a fixed-length digit group `Concat(*[Range('0','9') for _ in range(n)])` ≡ `[0-9]{n}`. The date regex becomes `Concat(chiffres(4), Re('-'), chiffres(2), Re('-'), chiffres(2))` — 4-2-2 forced by construction. The redundant `Length(date) == 10` constraint is removed (now inherent: 4+1+2+1+2). Cell 14 table row corrected `[0-9]+-[0-9]+-[0-9]+` → `[0-9]{4}-[0-9]{2}-[0-9]{2}` + key point 4 on fixed vs variable length.

## Validation

- **G.1 firsthand (z3 4.16.0)**: BUG (Plus+Length==10) produced 12/12 distinct malformed dates across runs; FIX (chiffres(n)) produces **deterministic `0000-00-00`** (1 distinct). Ex1 `numero=0000` unchanged.
- **Determinism gate investigated**: `smt.random_seed` does NOT control z3 string-model choice (6 distinct models within seed=42). Ex2 email is therefore inherently non-deterministic — committed `p@d.h` was one arbitrary model; re-exec renders a valid-but-different email each run. Pedagogically acceptable (any `x@y.z` demonstrates the regex). Documented, not scrubbed.
- **Stop & Repair**: cell 13 output is the REAL z3 execution (subprocess), not hand-edited.
- **Repo validator**: 1 OK / 0 Warnings / 0 Errors.
- **nbformat strict OK**; round-trip stable (indent=1, ensure_ascii=False, trailing newline).
- **Scope**: ONLY cell 13 (source + output) + cell 14 (source). 18 ins / 28 del single file (concise chiffres helper replaces verbose Plus(Range)×3 + redundant Length constraint removed — correct code replacing buggy code, not anti-regression territory).
- **C.1 OK** (no voluntary errors); H.3 OK (execution_count=6 non-null, outputs non-empty).

## Variation-protocol

G-VAR-1 ✓ (MED/code-correctness floor — real z3 re-exec + domain reasoning on fixed-vs-variable length + determinism-gate investigation, not scan-generatable). G-VAR-3 ✓: different genre than prev enrichment (#8037); code-correctness on z3 string-theory is genuinely distinct from c.663 SC-13 Solidity fuzz (separated by 2 cycles + different domain).

See #3801
