### PR TITLE
fix(z3-python-02): Sudoku indices count ~35 -> 30 (doc-honesty, matches output)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-02-Sudoku.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-02-Sudoku.ipynb
@@ -293,7 +293,7 @@
     "| Famille de contraintes | Nombre | Rôle |\n",
     "|------------------------|--------|------|\n",
     "| Domaine (1-9) | 81 | Bornes des variables |\n",
-    "| Indices figes | ~35 | Enonce du puzzle |\n",
+    "| Indices figes | 30 | Enonce du puzzle (puzzle_facile, cf. cellule 3) |\n",
     "| `Distinct` ligne | 9 | Une seule occurrence par ligne |\n",
     "| `Distinct` colonne | 9 | Une seule occurrence par colonne |\n",
     "| `Distinct` bloc | 9 | Une seule occurrence par bloc 3x3 |\n",


### PR DESCRIPTION
## Summary

Correction d'un défaut **doc-honesty** dans la table d'interprétation cell[6] de `Z3-Python-02-Sudoku.ipynb` (série trackée `SMT/Z3-API/`).

### Le défaut (vérifié firsthand)

cell[6] table : « Indices figes | **~35** | Enonce du puzzle » — mais le puzzle démontré (`puzzle_facile`) a **exactement 30 indices**. cell[3] définit la grille ET imprime `Puzzle facile : 30 indices donnes` (l'intermédiaire en a 36). Le `~35` contredit l'output committé affiché 2 cellules plus haut (~17% d'écart, ne correspond à aucun des deux puzzles).

## Change

`~35` → `30`, avec un pointeur vers la cellule 3 pour que le lecteur puisse vérifier le compte contre la vraie grille (reproductible : somme des cases non-nulles de `puzzle_facile`).

| Famille de contraintes | Nombre | Rôle |
|------------------------|--------|------|
| Domaine (1-9) | 81 | Bornes des variables |
| **Indices figes** | **30** | Enonce du puzzle (puzzle_facile, cf. cellule 3) |

## Validation

- **Recomptage firsthand** : `puzzle_facile = 30 indices`, `puzzle_intermediaire = 36` (somme des cases ≠ 0)
- **Markdown-only** (cell[6]) : exception C.2, code et outputs inchangés
- **nbformat VALID** ; **C.1** = 0 violations
- **Diff chirurgical** : 1 fichier, 1 insertion / 1 délétion (uniquement la ligne de table)
- Convention JSON : `json.dumps(indent=1, ensure_ascii=False) + "\n"` == raw, 0 CRLF

## Test plan
- [x] Recomptage firsthand (30 indices, pas ~35)
- [x] Markdown-only (C.2 exception)
- [x] nbformat VALID + C.1 = 0
- [x] Diff chirurgical 1 ligne
