### PR TITLE
feat(gt12): interpret epsilon-sweep reputation comparative static

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-12-ReputationGames.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-12-ReputationGames.ipynb
@@ -1027,6 +1027,30 @@
   },
   {
    "cell_type": "markdown",
+   "id": "gt12_epsilon_sweep_interp",
+   "metadata": {},
+   "source": [
+    "**Interpretation -- la statique comparative revele le seuil de rentabilite de la reputation.**\n",
+    "\n",
+    "Le trace de `analyze_epsilon_impact` fait varier epsilon (probabilite du type Fou) et mesure le gain du monopole Normal. Les valeurs committees (cellule precedente) dessinent une courbe monotone croissante :\n",
+    "\n",
+    "| epsilon (proba type Fou) | Gain Normal | Regime |\n",
+    "|--------------------------|-------------|--------|\n",
+    "| 0.01 | -8.00 | cout pur (aucune dissuasion) |\n",
+    "| 0.05 - 0.10 | -7.00 | cout pur |\n",
+    "| 0.20 | -1.00 | transition |\n",
+    "| 0.30 | +8.00 | dissuasion partielle |\n",
+    "| 0.50 | +20.00 | dissuasion totale |\n",
+    "\n",
+    "1. **Regime de cout pur (epsilon <= 0.1)** : la croyance part de epsilon et la mise a jour bayesienne (le type Normal combat lui aussi avec une probabilite elevee `p_fight_normal = 0.8`) la deplace trop lentement pour franchir le seuil de dissuasion `0.5` sur 10 marches. Le monopole Normal paie donc le cout de combat (-1 par marche) pour **imiter** le type Fou, mais ne recolte jamais le dividende : il finit a -7/-8, *pire* que l'information complete (+10, ou il accommode systematiquement).\n",
+    "2. **Seuil de rentabilite (epsilon ~ 0.2-0.3)** : des qu'epsilon est assez grand, quelques combats suffisent a pousser la croyance au-dessus de 0.5. Les entrants ulterieurs restent **dehors** (le monopole gagne +2 au lieu de +1 par marche accommode). Le gain du Normal devient positif (+8 a epsilon = 0.3).\n",
+    "3. **Dissuasion totale (epsilon = 0.5)** : le Normal atteint +20 -- la ligne de reference « Ideal Monopole (dissuasion totale) = 2 x n_markets ». La reputation franchit le seuil quasi immediatement, tous les entrants sont dissuades, le Normal mime parfaitement le Fou (qui vaut aussi +20).\n",
+    "\n",
+    "**Lecon KMRW** : l'incertitude n'est ni « bonne » ni « mauvaise » pour le monopole -- il existe un **epsilon-seuil** en dessous duquel la construction de reputation est un cout net, au-dessus duquel elle rapporte le dividende de dissuasion. C'est exactement la meme intuition que la section suivante (Dilemme du Prisonnier, « +160 % d'amelioration ») ou une infime probabilite d'un type TFT soutient la cooperation : dans les deux cas, c'est l'**investissement reputationnel** qui transforme un equilibre de defection/d'entree en equilibre cooperatif/dissuasif."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "2b1cea13",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
Grain: MED/enrichment — lane myia-po-2025:CoursIA — prev: MED/code-correctness (#8042 Z3-04)

## Defect (G.1 firsthand — thin narrative over a rich comparative static)

`MyIA.AI.Notebooks/GameTheory/GameTheory-12-ReputationGames.ipynb` cell 13 plots the Normal monopolist's payoff across epsilon (prob of Crazy type) over `[0.01, 0.05, 0.1, 0.2, 0.3, 0.5]`, but **no markdown interpreted it** before cell 14 jumped to the Prisoner's Dilemma section. Cell 12's table only reports the low-epsilon regime (Normal = -7, "cout de l'imitation du type Fou") — so a student reading top-to-bottom sees the reputation investment framed as pure cost, then meets the cell 13 plot's cross-over (Normal payoff rising from -8 to +20) with no guidance on what the cross-over *means*.

The cell 13 committed output is the **correct KMRW comparative static** (verified firsthand — not a degenerate sim):

| epsilon | Normal | Fou | regime |
|---------|--------|-----|--------|
| 0.01 | -8.00 | 10.00 | cost-pure (no deterrence) |
| 0.05/0.1 | -7.00 | 11.00 | cost-pure |
| 0.2 | -1.00 | 13.00 | transition |
| 0.3 | +8.00 | 16.00 | partial deterrence |
| 0.5 | +20.00 | 20.00 | full deterrence |

## Fix (markdown-only enrichment, 1 grounded interpretation cell)

One new markdown cell inserted after cell 13 (`gt12_epsilon_sweep_interp`), grounded in the 6 committed epsilon values:

1. **Cost-pure regime (eps<=0.1)**: the Bayesian belief update (`p_fight_normal=0.8`) moves too slowly to cross the deterrence threshold `0.5` over 10 markets — the Normal pays the -1/market fighting cost to imitate Crazy but never deters, finishing -7/-8 (worse than complete-info +10 where it accommodates).
2. **Profitability threshold (eps~0.2-0.3)**: once epsilon is large enough, a few fights push belief above 0.5, later entrants stay OUT (+2 vs +1), Normal turns positive (+8).
3. **Full deterrence (eps=0.5)**: Normal reaches +20 = the "Ideal Monopole" reference line (2*n_markets) — reputation crosses threshold immediately, Normal mimics Crazy perfectly.
4. **KMRW bridge**: connects the chain-store cross-over to the next section's PD result ("+160% improvement") — same reputation-investment mechanism transforming a defection/entry equilibrium into a cooperative/deterrent one.

## Why MED (not LIGHT)

Each claim is grounded in a specific committed epsilon value (cell 13 output), and the interpretation requires genuine game-theory reasoning (Bayesian belief threshold, reputation-investment cost vs deterrence dividend, KMRW mechanism bridging two sections) — not scan-generatable transition prose.

## Validation

- **G.1 firsthand**: read cell 11 (`simulate_reputation_game` strategy + Bayes update), cell 13 (committed epsilon-sweep output, ground truth), cell 12 (existing low-eps interpretation), cell 14 (PD header); confirmed the plot shows the KMRW cross-over the table hides. Every cited value re-verified against committed output.
- **C.2 markdown exception**: markdown-only edit (no code cell, no output touched) → no re-exec. (The MC simulation is non-deterministic with no seed — re-exec would drift the committed -8/-7/.../+20 values; the determinism lesson confirms NOT re-running.)
- **Repo validator**: 0 OK / 1 Warning / 0 Errors — Warning is **PRE-EXISTING on origin/main** (git stash baseline: identical 1 Warning before AND after my edit).
- **nbformat strict OK**; round-trip stable (`json.dumps indent=1, ensure_ascii=False` + trailing newline).
- **Diff scope**: +1 markdown cell, 24 insertions / 0 deletions, single file. All 28 original cells byte-identical (reindexed).
- **#2876 sensitivity**: new markdown is ASCII-style to match surrounding cell 12 ("Asymetrie/Metrique/Interpretation") — not curing or de-curing accents, just matching existing style.

## Variation-protocol

G-VAR-1 ✓ (MED/enrichment floor — genuine game-theory reasoning grounded in committed epsilon values). G-VAR-3 ✓: different genre than prev code-correctness (#8042 Z3-04); GameTheory-reputation first-touch vs the Search/SW/SC/RL/Probas/SMT streak. Litmus "générable-en-série par scan ?" → no (each interpretation needs epsilon-value grounding + KMRW-semantics explanation + cross-section bridge).

See #3801
