### PR TITLE
fix(app7b): add missing CRANE to WORD_LIST (C# twin parity with #8046)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb
@@ -30,10 +30,10 @@
    "id": "9162f31d2db6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-15T00:28:29.990805Z",
-     "iopub.status.busy": "2026-07-15T00:28:29.977762Z",
-     "iopub.status.idle": "2026-07-15T00:28:33.139329Z",
-     "shell.execute_reply": "2026-07-15T00:28:33.129702Z"
+     "iopub.execute_input": "2026-07-22T22:36:33.773907Z",
+     "iopub.status.busy": "2026-07-22T22:36:33.765388Z",
+     "iopub.status.idle": "2026-07-22T22:36:36.085676Z",
+     "shell.execute_reply": "2026-07-22T22:36:36.080676Z"
     }
    },
    "outputs": [
@@ -46,6 +46,7 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -55,7 +56,10 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
        "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -70,6 +74,7 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -81,11 +86,13 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://2a01:e0a:9d4:f320:6701:5a41:8422:35ad:2048/\",\"http://2a01:e0a:9d4:f320:7caf:c5ad:fe00:85e5:2048/\",\"http://fe80::902b:f9f6:2003:66a1%20:2048/\",\"http://192.168.0.51:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::ae60:2bbf:92f7:4e06%19:2048/\",\"http://172.21.192.1:2048/\",\"http://fe80::d7f2:2a3e:6d36:1ec0%30:2048/\",\"http://172.25.0.1:2048/\"])\r\n",
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '17264.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '5324.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -129,11 +136,13 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
        "}\r\n",
        "\r\n",
        "    </script>\r\n",
@@ -191,10 +200,10 @@
    "id": "df329766caf2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-15T00:28:33.141979Z",
-     "iopub.status.busy": "2026-07-15T00:28:33.141619Z",
-     "iopub.status.idle": "2026-07-15T00:28:33.873742Z",
-     "shell.execute_reply": "2026-07-15T00:28:33.873410Z"
+     "iopub.execute_input": "2026-07-22T22:36:36.087938Z",
+     "iopub.status.busy": "2026-07-22T22:36:36.087938Z",
+     "iopub.status.idle": "2026-07-22T22:36:36.414095Z",
+     "shell.execute_reply": "2026-07-22T22:36:36.414095Z"
     }
    },
    "outputs": [
@@ -202,7 +211,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Liste de mots : 296 mots de 5 lettres\r\n"
+      "Liste de mots : 297 mots de 5 lettres\r\n"
      ]
     },
     {
@@ -222,7 +231,7 @@
    ],
    "source": [
     "// Liste de mots francais de 5 lettres (sans accents, majuscules).\n",
-    "// STRICTEMENT identique a la WORD_LIST du notebook Python (296 mots) -> parite d'entropie.\n",
+    "// STRICTEMENT identique a la WORD_LIST du notebook Python (297 mots) -> parite d'entropie.\n",
     "static readonly string[] WORD_LIST_SRC = {\n",
     "    \"ABORD\",\"ACIER\",\"ADORE\",\"AGENT\",\"AIDER\",\"AIMER\",\"AINSI\",\"ALBUM\",\"ALGUE\",\"ALLEE\",\"ALLER\",\n",
     "    \"AMOUR\",\"ANCRE\",\"ANGLE\",\"ANNEE\",\"APPEL\",\"ARBRE\",\"ARENE\",\"ARGOT\",\"ASTRE\",\"ATLAS\",\"AVENT\",\n",
@@ -230,7 +239,7 @@
     "    \"BIBLE\",\"BIDON\",\"BILAN\",\"BLANC\",\"BLASE\",\"BOIRE\",\"BONUS\",\"BOTTE\",\"BOURG\",\"BRAVE\",\"BRISE\",\n",
     "    \"BRUME\",\"BULLE\",\"CABLE\",\"CADRE\",\"CALME\",\"CANNE\",\"CARTE\",\"CAUSE\",\"CEDER\",\"CHAMP\",\"CHANT\",\n",
     "    \"CHASE\",\"CHOIX\",\"CHUTE\",\"CIBLE\",\"CLAIR\",\"CLONE\",\"COEUR\",\"COMTE\",\"CONTE\",\"CORDE\",\"COUDE\",\n",
-    "    \"COUPE\",\"CRIER\",\"CRIME\",\"CRISE\",\"CREUX\",\"CROIX\",\"CRUEL\",\"CYCLE\",\"DANSE\",\"DEBUT\",\"DELTA\",\n",
+    "    \"COUPE\",\"CRIER\",\"CRIME\",\"CRISE\",\"CRANE\",\"CREUX\",\"CROIX\",\"CRUEL\",\"CYCLE\",\"DANSE\",\"DEBUT\",\"DELTA\",\n",
     "    \"DENSE\",\"DEPOT\",\"DOIGT\",\"DOUER\",\"DRAME\",\"DROIT\",\"DUPER\",\"ECLAT\",\"ECRAN\",\"ELEVE\",\"EMAIL\",\n",
     "    \"ENVIE\",\"EPAVE\",\"EPICE\",\"ESSAI\",\"ETAGE\",\"EXACT\",\"EXILE\",\"EXTRA\",\"FABLE\",\"FARCE\",\"FAUTE\",\n",
     "    \"FERME\",\"FIBRE\",\"FIGER\",\"FILER\",\"FINAL\",\"FLEUR\",\"FOLIE\",\"FORCE\",\"FORME\",\"FORUM\",\"FOSSE\",\n",
@@ -279,10 +288,10 @@
    "id": "ba59ee2e268c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-15T00:28:33.876211Z",
-     "iopub.status.busy": "2026-07-15T00:28:33.875710Z",
-     "iopub.status.idle": "2026-07-15T00:28:34.325660Z",
-     "shell.execute_reply": "2026-07-15T00:28:34.325378Z"
+     "iopub.execute_input": "2026-07-22T22:36:36.416093Z",
+     "iopub.status.busy": "2026-07-22T22:36:36.416093Z",
+     "iopub.status.idle": "2026-07-22T22:36:36.741886Z",
+     "shell.execute_reply": "2026-07-22T22:36:36.741886Z"
     }
    },
    "outputs": [
@@ -420,10 +429,10 @@
    "id": "4e8548c49d48",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-15T00:28:34.327828Z",
-     "iopub.status.busy": "2026-07-15T00:28:34.327480Z",
-     "iopub.status.idle": "2026-07-15T00:28:34.554567Z",
-     "shell.execute_reply": "2026-07-15T00:28:34.527035Z"
+     "iopub.execute_input": "2026-07-22T22:36:36.744801Z",
+     "iopub.status.busy": "2026-07-22T22:36:36.744801Z",
+     "iopub.status.idle": "2026-07-22T22:36:36.952529Z",
+     "shell.execute_reply": "2026-07-22T22:36:36.918574Z"
     }
    },
    "outputs": [
@@ -1031,10 +1040,10 @@
    "id": "e3c679b9f8d1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-15T00:28:34.557597Z",
-     "iopub.status.busy": "2026-07-15T00:28:34.557006Z",
-     "iopub.status.idle": "2026-07-15T00:28:34.693171Z",
-     "shell.execute_reply": "2026-07-15T00:28:34.692931Z"
+     "iopub.execute_input": "2026-07-22T22:36:36.955733Z",
+     "iopub.status.busy": "2026-07-22T22:36:36.955183Z",
+     "iopub.status.idle": "2026-07-22T22:36:37.065911Z",
+     "shell.execute_reply": "2026-07-22T22:36:37.065911Z"
     }
    },
    "outputs": [
@@ -1098,10 +1107,10 @@
    "id": "4aadc919e76b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-15T00:28:34.694972Z",
-     "iopub.status.busy": "2026-07-15T00:28:34.694718Z",
-     "iopub.status.idle": "2026-07-15T00:28:34.807317Z",
-     "shell.execute_reply": "2026-07-15T00:28:34.807078Z"
+     "iopub.execute_input": "2026-07-22T22:36:37.068072Z",
+     "iopub.status.busy": "2026-07-22T22:36:37.067549Z",
+     "iopub.status.idle": "2026-07-22T22:36:37.200875Z",
+     "shell.execute_reply": "2026-07-22T22:36:37.200344Z"
     }
    },
    "outputs": [
@@ -1123,28 +1132,78 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  CRANE absent de la liste, skip\r\n"
+      "  Tentative 1: OLIVE -> ____G  (297 candidats)\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Tentative 1: REPAS -> YY___  (296 candidats)\r\n"
+      "    -> 56 candidats restants\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    -> 38 candidats restants\r\n"
+      "  Tentative 2: FAUTE -> _Y__G  (56 candidats)\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Tentative 2: LUCRE -> YY_YY  (38 candidats)\r\n"
+      "    -> 10 candidats restants\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Tentative 3: ARBRE -> YG__G  (10 candidats)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    -> 3 candidats restants\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Tentative 4: CRANE -> GGGGG  (3 candidats)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  => Gagne en 4 tentative(s)\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Tentative 1: PEAGE -> _Y___  (297 candidats)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    -> 20 candidats restants\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Tentative 2: LINER -> Y__YG  (20 candidats)\r\n"
      ]
     },
     {
@@ -1173,7 +1232,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Tentative 1: BANDE -> __GGG  (296 candidats)\r\n"
+      "  Tentative 1: CREUX -> __Y__  (297 candidats)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    -> 66 candidats restants\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Tentative 2: TONNE -> _GG_G  (66 candidats)\r\n"
      ]
     },
     {
@@ -1187,21 +1260,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Tentative 2: SONDE -> _GGGG  (2 candidats)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    -> 1 candidats restants\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Tentative 3: MONDE -> GGGGG  (1 candidats)\r\n"
+      "  Tentative 3: MONDE -> GGGGG  (2 candidats)\r\n"
      ]
     },
     {
@@ -1216,21 +1275,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Tentative 1: VASTE -> __GGG  (296 candidats)\r\n"
+      "  Tentative 1: REPAS -> _YY_Y  (297 candidats)\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    -> 4 candidats restants\r\n"
+      "    -> 2 candidats restants\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Tentative 2: PISTE -> GGGGG  (4 candidats)\r\n"
+      "  Tentative 2: PISTE -> GGGGG  (2 candidats)\r\n"
      ]
     },
     {
@@ -1245,56 +1304,42 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Tentative 1: FERME -> ____G  (296 candidats)\r\n"
+      "  Tentative 1: HUILE -> _Y__G  (297 candidats)\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    -> 73 candidats restants\r\n"
+      "    -> 15 candidats restants\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Tentative 2: PLACE -> __Y_G  (73 candidats)\r\n"
+      "  Tentative 2: BAGUE -> _GGGG  (15 candidats)\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    -> 10 candidats restants\r\n"
+      "    -> 1 candidats restants\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Tentative 3: TASSE -> _G__G  (10 candidats)\r\n"
+      "  Tentative 3: VAGUE -> GGGGG  (1 candidats)\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    -> 5 candidats restants\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Tentative 4: VAGUE -> GGGGG  (5 candidats)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  => Gagne en 4 tentative(s)\n",
+      "  => Gagne en 3 tentative(s)\n",
       "\r\n"
      ]
     },
@@ -1302,7 +1347,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Moyenne (parties gagnees) : 3.0 tentatives  (4/5 gagnees)\r\n"
+      "Moyenne (parties gagnees) : 3.0 tentatives  (5/5 gagnees)\r\n"
      ]
     }
    ],
@@ -1364,10 +1409,10 @@
    "id": "e81f5905ae45",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-15T00:28:34.808941Z",
-     "iopub.status.busy": "2026-07-15T00:28:34.808687Z",
-     "iopub.status.idle": "2026-07-15T00:28:35.020572Z",
-     "shell.execute_reply": "2026-07-15T00:28:35.020146Z"
+     "iopub.execute_input": "2026-07-22T22:36:37.203020Z",
+     "iopub.status.busy": "2026-07-22T22:36:37.202490Z",
+     "iopub.status.idle": "2026-07-22T22:36:37.365132Z",
+     "shell.execute_reply": "2026-07-22T22:36:37.364132Z"
     }
    },
    "outputs": [
@@ -1493,10 +1538,10 @@
    "id": "133ff3e98563",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-15T00:28:35.023119Z",
-     "iopub.status.busy": "2026-07-15T00:28:35.022657Z",
-     "iopub.status.idle": "2026-07-15T00:28:35.146923Z",
-     "shell.execute_reply": "2026-07-15T00:28:35.146244Z"
+     "iopub.execute_input": "2026-07-22T22:36:37.368132Z",
+     "iopub.status.busy": "2026-07-22T22:36:37.367132Z",
+     "iopub.status.idle": "2026-07-22T22:36:37.448762Z",
+     "shell.execute_reply": "2026-07-22T22:36:37.448762Z"
     }
    },
    "outputs": [
@@ -1518,14 +1563,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Tentative 1: PEINE -> ___GG  (296 candidats)\r\n"
+      "  Tentative 1: PEINE -> ___GG  (297 candidats)\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Tentative 2: CANNE -> GY_GG  (3 candidats)\r\n"
+      "  Tentative 2: CANNE -> GY_GG  (4 candidats)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Tentative 3: CRANE -> GGGGG  (1 candidats)\r\n"
      ]
     },
     {
@@ -1533,7 +1585,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "=> Perdu en 2 tentative(s)\r\n"
+      "=> Gagne en 3 tentative(s)\r\n"
      ]
     }
    ],
@@ -1579,10 +1631,10 @@
    "id": "57ef50aeb8c7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-15T00:28:35.149978Z",
-     "iopub.status.busy": "2026-07-15T00:28:35.149559Z",
-     "iopub.status.idle": "2026-07-15T00:28:35.260239Z",
-     "shell.execute_reply": "2026-07-15T00:28:35.260020Z"
+     "iopub.execute_input": "2026-07-22T22:36:37.450770Z",
+     "iopub.status.busy": "2026-07-22T22:36:37.450770Z",
+     "iopub.status.idle": "2026-07-22T22:36:37.568077Z",
+     "shell.execute_reply": "2026-07-22T22:36:37.567077Z"
     }
    },
    "outputs": [
@@ -1635,10 +1687,10 @@
    "id": "a3d35d8387d8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-15T00:28:35.261714Z",
-     "iopub.status.busy": "2026-07-15T00:28:35.261460Z",
-     "iopub.status.idle": "2026-07-15T00:28:35.336884Z",
-     "shell.execute_reply": "2026-07-15T00:28:35.336658Z"
+     "iopub.execute_input": "2026-07-22T22:36:37.570078Z",
+     "iopub.status.busy": "2026-07-22T22:36:37.570078Z",
+     "iopub.status.idle": "2026-07-22T22:36:37.618271Z",
+     "shell.execute_reply": "2026-07-22T22:36:37.617750Z"
     }
    },
    "outputs": [
@@ -1660,6 +1712,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  CRANE : H = 5.445 bits\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  ADORE : H = 4.954 bits\r\n"
      ]
     },
@@ -1667,42 +1726,42 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  AIMER : H = 5.031 bits\r\n"
+      "  AIMER : H = 5.027 bits\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  TABLE : H = 5.084 bits\r\n"
+      "  TABLE : H = 5.082 bits\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  EXTRA : H = 4.130 bits\r\n"
+      "  EXTRA : H = 4.128 bits\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  FLEUR : H = 4.374 bits\r\n"
+      "  FLEUR : H = 4.368 bits\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  PISTE : H = 4.827 bits\r\n"
+      "  PISTE : H = 4.818 bits\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  REGLE : H = 4.765 bits\r\n"
+      "  REGLE : H = 4.759 bits\r\n"
      ]
     },
     {
@@ -1710,7 +1769,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Entropie maximale theorique : log2(296) = 8.209 bits\r\n"
+      "Entropie maximale theorique : log2(297) = 8.214 bits\r\n"
      ]
     },
     {
@@ -1750,10 +1809,10 @@
    "id": "78cb164e3164",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-15T00:28:35.338664Z",
-     "iopub.status.busy": "2026-07-15T00:28:35.338412Z",
-     "iopub.status.idle": "2026-07-15T00:28:35.472933Z",
-     "shell.execute_reply": "2026-07-15T00:28:35.472681Z"
+     "iopub.execute_input": "2026-07-22T22:36:37.620927Z",
+     "iopub.status.busy": "2026-07-22T22:36:37.620393Z",
+     "iopub.status.idle": "2026-07-22T22:36:38.066527Z",
+     "shell.execute_reply": "2026-07-22T22:36:38.065987Z"
     }
    },
    "outputs": [
@@ -1789,76 +1848,76 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1     LAINE     5.5043            \r\n"
+      "1     LAINE     5.5115            \r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2     PAIRE     5.4657            \r\n"
+      "2     PAIRE     5.4658            \r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "3     CLAIR     5.4509            \r\n"
+      "3     CLAIR     5.4650            \r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "4     CARTE     5.4497            \r\n"
+      "4     CARTE     5.4638            \r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "5     TRACE     5.3901            \r\n"
+      "5     CRANE     5.4451            \r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "6     TRAIN     5.3695            \r\n"
+      "6     TRACE     5.4044            \r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "7     LANCE     5.3587            \r\n"
+      "7     TRAIN     5.3747            \r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "8     PARIE     5.3555            \r\n"
+      "8     LANCE     5.3664            \r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "9     LITRE     5.2990            \r\n"
+      "9     PARIE     5.3537            \r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "10    ANCRE     5.2836            \r\n"
+      "10    ANCRE     5.2983            \r\n"
      ]
     },
     {
      "data": {
       "text/html": [
-       "<svg viewBox=\"0 0 720 460\" xmlns=\"http://www.w3.org/2000/svg\" style=\"font-family: -apple-system, 'Segoe UI', sans-serif; font-size: 13px;\"><rect x=\"0\" y=\"0\" width=\"720\" height=\"460\" fill=\"white\" stroke=\"#ddd\"/><text x=\"102.0\" y=\"71.5\" fill=\"#333\" text-anchor=\"end\">ANCRE</text><rect x=\"110.0\" y=\"55.6\" width=\"547.1\" height=\"23.8\" fill=\"#2a6dba\"/><text x=\"663.1\" y=\"71.5\" fill=\"#333\">5.284</text><text x=\"102.0\" y=\"106.5\" fill=\"#333\" text-anchor=\"end\">LITRE</text><rect x=\"110.0\" y=\"90.6\" width=\"548.7\" height=\"23.8\" fill=\"#2a6dba\"/><text x=\"664.7\" y=\"106.5\" fill=\"#333\">5.299</text><text x=\"102.0\" y=\"141.5\" fill=\"#333\" text-anchor=\"end\">PARIE</text><rect x=\"110.0\" y=\"125.6\" width=\"554.6\" height=\"23.8\" fill=\"#2a6dba\"/><text x=\"670.6\" y=\"141.5\" fill=\"#333\">5.356</text><text x=\"102.0\" y=\"176.5\" fill=\"#333\" text-anchor=\"end\">LANCE</text><rect x=\"110.0\" y=\"160.6\" width=\"554.9\" height=\"23.8\" fill=\"#2a6dba\"/><text x=\"670.9\" y=\"176.5\" fill=\"#333\">5.359</text><text x=\"102.0\" y=\"211.5\" fill=\"#333\" text-anchor=\"end\">TRAIN</text><rect x=\"110.0\" y=\"195.6\" width=\"556.0\" height=\"23.8\" fill=\"#2a6dba\"/><text x=\"672.0\" y=\"211.5\" fill=\"#333\">5.370</text><text x=\"102.0\" y=\"246.5\" fill=\"#333\" text-anchor=\"end\">TRACE</text><rect x=\"110.0\" y=\"230.6\" width=\"558.2\" height=\"23.8\" fill=\"#2a6dba\"/><text x=\"674.2\" y=\"246.5\" fill=\"#333\">5.390</text><text x=\"102.0\" y=\"281.5\" fill=\"#333\" text-anchor=\"end\">CARTE</text><rect x=\"110.0\" y=\"265.6\" width=\"564.3\" height=\"23.8\" fill=\"#2a6dba\"/><text x=\"680.3\" y=\"281.5\" fill=\"#333\">5.450</text><text x=\"102.0\" y=\"316.5\" fill=\"#333\" text-anchor=\"end\">CLAIR</text><rect x=\"110.0\" y=\"300.6\" width=\"564.5\" height=\"23.8\" fill=\"#2a6dba\"/><text x=\"680.5\" y=\"316.5\" fill=\"#333\">5.451</text><text x=\"102.0\" y=\"351.5\" fill=\"#333\" text-anchor=\"end\">PAIRE</text><rect x=\"110.0\" y=\"335.6\" width=\"566.0\" height=\"23.8\" fill=\"#2a6dba\"/><text x=\"682.0\" y=\"351.5\" fill=\"#333\">5.466</text><text x=\"102.0\" y=\"386.5\" fill=\"#333\" text-anchor=\"end\">LAINE</text><rect x=\"110.0\" y=\"370.6\" width=\"570.0\" height=\"23.8\" fill=\"#2a6dba\"/><text x=\"686.0\" y=\"386.5\" fill=\"#333\">5.504</text><line x1=\"110.0\" y1=\"50\" x2=\"110.0\" y2=\"400\" stroke=\"#e8e8e8\" stroke-width=\"1\"/><text x=\"110.0\" y=\"416\" fill=\"#666\" text-anchor=\"middle\">0.00</text><line x1=\"224.0\" y1=\"50\" x2=\"224.0\" y2=\"400\" stroke=\"#e8e8e8\" stroke-width=\"1\"/><text x=\"224.0\" y=\"416\" fill=\"#666\" text-anchor=\"middle\">1.10</text><line x1=\"338.0\" y1=\"50\" x2=\"338.0\" y2=\"400\" stroke=\"#e8e8e8\" stroke-width=\"1\"/><text x=\"338.0\" y=\"416\" fill=\"#666\" text-anchor=\"middle\">2.20</text><line x1=\"452.0\" y1=\"50\" x2=\"452.0\" y2=\"400\" stroke=\"#e8e8e8\" stroke-width=\"1\"/><text x=\"452.0\" y=\"416\" fill=\"#666\" text-anchor=\"middle\">3.30</text><line x1=\"566.0\" y1=\"50\" x2=\"566.0\" y2=\"400\" stroke=\"#e8e8e8\" stroke-width=\"1\"/><text x=\"566.0\" y=\"416\" fill=\"#666\" text-anchor=\"middle\">4.40</text><line x1=\"680.0\" y1=\"50\" x2=\"680.0\" y2=\"400\" stroke=\"#e8e8e8\" stroke-width=\"1\"/><text x=\"680.0\" y=\"416\" fill=\"#666\" text-anchor=\"middle\">5.50</text><line x1=\"110\" y1=\"400\" x2=\"680\" y2=\"400\" stroke=\"#333\" stroke-width=\"1.5\"/><text x=\"395\" y=\"446\" fill=\"#333\" text-anchor=\"middle\">Entropie (bits)</text><text x=\"360\" y=\"28\" fill=\"#222\" font-size=\"15\" font-weight=\"bold\" text-anchor=\"middle\">Top 10 premiers mots par entropie (H en bits)</text></svg>"
+       "<svg viewBox=\"0 0 720 460\" xmlns=\"http://www.w3.org/2000/svg\" style=\"font-family: -apple-system, 'Segoe UI', sans-serif; font-size: 13px;\"><rect x=\"0\" y=\"0\" width=\"720\" height=\"460\" fill=\"white\" stroke=\"#ddd\"/><text x=\"102.0\" y=\"71.5\" fill=\"#333\" text-anchor=\"end\">ANCRE</text><rect x=\"110.0\" y=\"55.6\" width=\"548.0\" height=\"23.8\" fill=\"#2a6dba\"/><text x=\"664.0\" y=\"71.5\" fill=\"#333\">5.298</text><text x=\"102.0\" y=\"106.5\" fill=\"#333\" text-anchor=\"end\">PARIE</text><rect x=\"110.0\" y=\"90.6\" width=\"553.7\" height=\"23.8\" fill=\"#2a6dba\"/><text x=\"669.7\" y=\"106.5\" fill=\"#333\">5.354</text><text x=\"102.0\" y=\"141.5\" fill=\"#333\" text-anchor=\"end\">LANCE</text><rect x=\"110.0\" y=\"125.6\" width=\"555.0\" height=\"23.8\" fill=\"#2a6dba\"/><text x=\"671.0\" y=\"141.5\" fill=\"#333\">5.366</text><text x=\"102.0\" y=\"176.5\" fill=\"#333\" text-anchor=\"end\">TRAIN</text><rect x=\"110.0\" y=\"160.6\" width=\"555.9\" height=\"23.8\" fill=\"#2a6dba\"/><text x=\"671.9\" y=\"176.5\" fill=\"#333\">5.375</text><text x=\"102.0\" y=\"211.5\" fill=\"#333\" text-anchor=\"end\">TRACE</text><rect x=\"110.0\" y=\"195.6\" width=\"558.9\" height=\"23.8\" fill=\"#2a6dba\"/><text x=\"674.9\" y=\"211.5\" fill=\"#333\">5.404</text><text x=\"102.0\" y=\"246.5\" fill=\"#333\" text-anchor=\"end\">CRANE</text><rect x=\"110.0\" y=\"230.6\" width=\"563.1\" height=\"23.8\" fill=\"#2a6dba\"/><text x=\"679.1\" y=\"246.5\" fill=\"#333\">5.445</text><text x=\"102.0\" y=\"281.5\" fill=\"#333\" text-anchor=\"end\">CARTE</text><rect x=\"110.0\" y=\"265.6\" width=\"565.1\" height=\"23.8\" fill=\"#2a6dba\"/><text x=\"681.1\" y=\"281.5\" fill=\"#333\">5.464</text><text x=\"102.0\" y=\"316.5\" fill=\"#333\" text-anchor=\"end\">CLAIR</text><rect x=\"110.0\" y=\"300.6\" width=\"565.2\" height=\"23.8\" fill=\"#2a6dba\"/><text x=\"681.2\" y=\"316.5\" fill=\"#333\">5.465</text><text x=\"102.0\" y=\"351.5\" fill=\"#333\" text-anchor=\"end\">PAIRE</text><rect x=\"110.0\" y=\"335.6\" width=\"565.3\" height=\"23.8\" fill=\"#2a6dba\"/><text x=\"681.3\" y=\"351.5\" fill=\"#333\">5.466</text><text x=\"102.0\" y=\"386.5\" fill=\"#333\" text-anchor=\"end\">LAINE</text><rect x=\"110.0\" y=\"370.6\" width=\"570.0\" height=\"23.8\" fill=\"#2a6dba\"/><text x=\"686.0\" y=\"386.5\" fill=\"#333\">5.511</text><line x1=\"110.0\" y1=\"50\" x2=\"110.0\" y2=\"400\" stroke=\"#e8e8e8\" stroke-width=\"1\"/><text x=\"110.0\" y=\"416\" fill=\"#666\" text-anchor=\"middle\">0.00</text><line x1=\"224.0\" y1=\"50\" x2=\"224.0\" y2=\"400\" stroke=\"#e8e8e8\" stroke-width=\"1\"/><text x=\"224.0\" y=\"416\" fill=\"#666\" text-anchor=\"middle\">1.10</text><line x1=\"338.0\" y1=\"50\" x2=\"338.0\" y2=\"400\" stroke=\"#e8e8e8\" stroke-width=\"1\"/><text x=\"338.0\" y=\"416\" fill=\"#666\" text-anchor=\"middle\">2.20</text><line x1=\"452.0\" y1=\"50\" x2=\"452.0\" y2=\"400\" stroke=\"#e8e8e8\" stroke-width=\"1\"/><text x=\"452.0\" y=\"416\" fill=\"#666\" text-anchor=\"middle\">3.31</text><line x1=\"566.0\" y1=\"50\" x2=\"566.0\" y2=\"400\" stroke=\"#e8e8e8\" stroke-width=\"1\"/><text x=\"566.0\" y=\"416\" fill=\"#666\" text-anchor=\"middle\">4.41</text><line x1=\"680.0\" y1=\"50\" x2=\"680.0\" y2=\"400\" stroke=\"#e8e8e8\" stroke-width=\"1\"/><text x=\"680.0\" y=\"416\" fill=\"#666\" text-anchor=\"middle\">5.51</text><line x1=\"110\" y1=\"400\" x2=\"680\" y2=\"400\" stroke=\"#333\" stroke-width=\"1.5\"/><text x=\"395\" y=\"446\" fill=\"#333\" text-anchor=\"middle\">Entropie (bits)</text><text x=\"360\" y=\"28\" fill=\"#222\" font-size=\"15\" font-weight=\"bold\" text-anchor=\"middle\">Top 10 premiers mots par entropie (H en bits)</text></svg>"
       ]
      },
      "metadata": {},
@@ -1869,14 +1928,14 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Meilleur premier mot : LAINE (H = 5.5043 bits)\r\n"
+      "Meilleur premier mot : LAINE (H = 5.5115 bits)\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Reduction attendue : 296 -> ~7 candidats en moyenne\r\n"
+      "Reduction attendue : 297 -> ~7 candidats en moyenne\r\n"
      ]
     }
    ],
@@ -1977,10 +2036,10 @@
    "id": "5c0182ad3d81",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-15T00:28:35.474911Z",
-     "iopub.status.busy": "2026-07-15T00:28:35.474621Z",
-     "iopub.status.idle": "2026-07-15T00:28:35.539905Z",
-     "shell.execute_reply": "2026-07-15T00:28:35.539596Z"
+     "iopub.execute_input": "2026-07-22T22:36:38.069229Z",
+     "iopub.status.busy": "2026-07-22T22:36:38.068688Z",
+     "iopub.status.idle": "2026-07-22T22:36:38.127733Z",
+     "shell.execute_reply": "2026-07-22T22:36:38.126720Z"
     }
    },
    "outputs": [
@@ -2035,10 +2094,10 @@
    "id": "0da82110d1cb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-15T00:28:35.542095Z",
-     "iopub.status.busy": "2026-07-15T00:28:35.541766Z",
-     "iopub.status.idle": "2026-07-15T00:28:35.668593Z",
-     "shell.execute_reply": "2026-07-15T00:28:35.668197Z"
+     "iopub.execute_input": "2026-07-22T22:36:38.129720Z",
+     "iopub.status.busy": "2026-07-22T22:36:38.129720Z",
+     "iopub.status.idle": "2026-07-22T22:36:38.215727Z",
+     "shell.execute_reply": "2026-07-22T22:36:38.214726Z"
     }
    },
    "outputs": [
@@ -2060,7 +2119,36 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Tentative 1: LAINE -> Y___Y  (H=5.50, 296 candidats)\r\n"
+      "  Tentative 1: LAINE -> _Y_GG  (H=5.51, 297 candidats)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Tentative 2: ARENE -> YG_GG  (H=1.00, 2 candidats)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Tentative 3: CRANE -> GGGGG  (H=0.00, 1 candidats)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  => Gagne en 3 tentative(s)\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Tentative 1: LAINE -> Y___Y  (H=5.51, 297 candidats)\r\n"
      ]
     },
     {
@@ -2089,7 +2177,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Tentative 1: LAINE -> ___YG  (H=5.50, 296 candidats)\r\n"
+      "  Tentative 1: LAINE -> ___YG  (H=5.51, 297 candidats)\r\n"
      ]
     },
     {
@@ -2118,7 +2206,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Tentative 1: LAINE -> __Y_G  (H=5.50, 296 candidats)\r\n"
+      "  Tentative 1: LAINE -> __Y_G  (H=5.51, 297 candidats)\r\n"
      ]
     },
     {
@@ -2154,7 +2242,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Tentative 1: LAINE -> _G__G  (H=5.50, 296 candidats)\r\n"
+      "  Tentative 1: LAINE -> _G__G  (H=5.51, 297 candidats)\r\n"
      ]
     },
     {
@@ -2183,7 +2271,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Moyenne (parties gagnees) : 3.2 tentatives  (4/5 gagnees)\r\n"
+      "Moyenne (parties gagnees) : 3.2 tentatives  (5/5 gagnees)\r\n"
      ]
     }
    ],
@@ -2231,10 +2319,10 @@
    "id": "54c44907783e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-15T00:28:35.671046Z",
-     "iopub.status.busy": "2026-07-15T00:28:35.670720Z",
-     "iopub.status.idle": "2026-07-15T00:28:35.903468Z",
-     "shell.execute_reply": "2026-07-15T00:28:35.903200Z"
+     "iopub.execute_input": "2026-07-22T22:36:38.218032Z",
+     "iopub.status.busy": "2026-07-22T22:36:38.217496Z",
+     "iopub.status.idle": "2026-07-22T22:36:38.432672Z",
+     "shell.execute_reply": "2026-07-22T22:36:38.432150Z"
     }
    },
    "outputs": [
@@ -2359,10 +2447,10 @@
    "id": "27f36cd39688",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-15T00:28:35.905440Z",
-     "iopub.status.busy": "2026-07-15T00:28:35.905156Z",
-     "iopub.status.idle": "2026-07-15T00:28:36.041103Z",
-     "shell.execute_reply": "2026-07-15T00:28:36.040492Z"
+     "iopub.execute_input": "2026-07-22T22:36:38.434289Z",
+     "iopub.status.busy": "2026-07-22T22:36:38.434289Z",
+     "iopub.status.idle": "2026-07-22T22:36:38.547537Z",
+     "shell.execute_reply": "2026-07-22T22:36:38.546834Z"
     }
    },
    "outputs": [
@@ -2370,7 +2458,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Meilleur mot : LAINE -> 76 patterns distincts, H = 5.504 bits\r\n"
+      "Meilleur mot : LAINE -> 76 patterns distincts, H = 5.512 bits\r\n"
      ]
     },
     {
@@ -2384,14 +2472,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Mauvais mot   : APPEL -> 37 patterns distincts, H = 4.058 bits\r\n"
+      "Mauvais mot   : APPEL -> 37 patterns distincts, H = 4.053 bits\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Top-5 patterns les plus frequents : 67, 43, 30, 16, 16\r\n"
+      "  Top-5 patterns les plus frequents : 67, 44, 30, 16, 16\r\n"
      ]
     },
     {
@@ -2454,17 +2542,17 @@
    "id": "6d6111204218",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-15T00:28:36.044181Z",
-     "iopub.status.busy": "2026-07-15T00:28:36.043802Z",
-     "iopub.status.idle": "2026-07-15T00:28:36.331389Z",
-     "shell.execute_reply": "2026-07-15T00:28:36.330961Z"
+     "iopub.execute_input": "2026-07-22T22:36:38.550233Z",
+     "iopub.status.busy": "2026-07-22T22:36:38.549666Z",
+     "iopub.status.idle": "2026-07-22T22:36:38.646872Z",
+     "shell.execute_reply": "2026-07-22T22:36:38.646872Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<svg viewBox=\"0 0 820 470\" xmlns=\"http://www.w3.org/2000/svg\" style=\"font-family: -apple-system, 'Segoe UI', sans-serif; font-size: 12px;\"><rect x=\"0\" y=\"0\" width=\"820\" height=\"470\" fill=\"white\" stroke=\"#ddd\"/><line x1=\"70\" y1=\"335.0\" x2=\"780\" y2=\"335.0\" stroke=\"#e8e8e8\" stroke-width=\"1\"/><text x=\"62.0\" y=\"339.0\" fill=\"#666\" text-anchor=\"end\">0</text><line x1=\"70\" y1=\"278.0\" x2=\"780\" y2=\"278.0\" stroke=\"#e8e8e8\" stroke-width=\"1\"/><text x=\"62.0\" y=\"282.0\" fill=\"#666\" text-anchor=\"end\">6</text><line x1=\"70\" y1=\"221.0\" x2=\"780\" y2=\"221.0\" stroke=\"#e8e8e8\" stroke-width=\"1\"/><text x=\"62.0\" y=\"225.0\" fill=\"#666\" text-anchor=\"end\">13</text><line x1=\"70\" y1=\"164.0\" x2=\"780\" y2=\"164.0\" stroke=\"#e8e8e8\" stroke-width=\"1\"/><text x=\"62.0\" y=\"168.0\" fill=\"#666\" text-anchor=\"end\">19</text><line x1=\"70\" y1=\"107.0\" x2=\"780\" y2=\"107.0\" stroke=\"#e8e8e8\" stroke-width=\"1\"/><text x=\"62.0\" y=\"111.0\" fill=\"#666\" text-anchor=\"end\">26</text><line x1=\"70\" y1=\"50.0\" x2=\"780\" y2=\"50.0\" stroke=\"#e8e8e8\" stroke-width=\"1\"/><text x=\"62.0\" y=\"54.0\" fill=\"#666\" text-anchor=\"end\">33</text><rect x=\"76.6\" y=\"50.0\" width=\"34.1\" height=\"285.0\" fill=\"#3b82f6\"/><text x=\"93.7\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 93.7 343.0)\">0,0,0,0,2</text><rect x=\"124.0\" y=\"153.6\" width=\"34.1\" height=\"181.4\" fill=\"#3b82f6\"/><text x=\"141.0\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 141.0 343.0)\">0,2,0,0,2</text><rect x=\"171.3\" y=\"179.5\" width=\"34.1\" height=\"155.5\" fill=\"#3b82f6\"/><text x=\"188.3\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 188.3 343.0)\">0,0,0,0,1</text><rect x=\"218.6\" y=\"196.8\" width=\"34.1\" height=\"138.2\" fill=\"#3b82f6\"/><text x=\"235.7\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 235.7 343.0)\">0,1,0,0,2</text><rect x=\"266.0\" y=\"240.0\" width=\"34.1\" height=\"95.0\" fill=\"#3b82f6\"/><text x=\"283.0\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 283.0 343.0)\">1,0,0,0,2</text><rect x=\"313.3\" y=\"240.0\" width=\"34.1\" height=\"95.0\" fill=\"#3b82f6\"/><text x=\"330.3\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 330.3 343.0)\">0,0,1,0,2</text><rect x=\"360.6\" y=\"248.6\" width=\"34.1\" height=\"86.4\" fill=\"#3b82f6\"/><text x=\"377.7\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 377.7 343.0)\">0,0,2,0,2</text><rect x=\"408.0\" y=\"257.3\" width=\"34.1\" height=\"77.7\" fill=\"#3b82f6\"/><text x=\"425.0\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 425.0 343.0)\">0,0,0,1,2</text><rect x=\"455.3\" y=\"265.9\" width=\"34.1\" height=\"69.1\" fill=\"#3b82f6\"/><text x=\"472.3\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 472.3 343.0)\">1,2,0,0,2</text><rect x=\"502.6\" y=\"283.2\" width=\"34.1\" height=\"51.8\" fill=\"#3b82f6\"/><text x=\"519.7\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 519.7 343.0)\">1,1,0,0,2</text><rect x=\"550.0\" y=\"283.2\" width=\"34.1\" height=\"51.8\" fill=\"#3b82f6\"/><text x=\"567.0\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 567.0 343.0)\">0,0,1,0,0</text><rect x=\"597.3\" y=\"283.2\" width=\"34.1\" height=\"51.8\" fill=\"#3b82f6\"/><text x=\"614.3\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 614.3 343.0)\">1,0,2,0,2</text><rect x=\"644.6\" y=\"291.8\" width=\"34.1\" height=\"43.2\" fill=\"#3b82f6\"/><text x=\"661.7\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 661.7 343.0)\">1,1,0,0,0</text><rect x=\"692.0\" y=\"291.8\" width=\"34.1\" height=\"43.2\" fill=\"#3b82f6\"/><text x=\"709.0\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 709.0 343.0)\">1,1,0,0,1</text><rect x=\"739.3\" y=\"291.8\" width=\"34.1\" height=\"43.2\" fill=\"#3b82f6\"/><text x=\"756.3\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 756.3 343.0)\">1,0,0,0,1</text><line x1=\"70\" y1=\"335\" x2=\"780\" y2=\"335\" stroke=\"#333\" stroke-width=\"1.5\"/><line x1=\"70\" y1=\"50\" x2=\"70\" y2=\"335\" stroke=\"#333\" stroke-width=\"1.5\"/><text x=\"18\" y=\"192.5\" fill=\"#333\" text-anchor=\"middle\" transform=\"rotate(-90 18 192.5)\">Nombre de mots</text><text x=\"410\" y=\"28\" fill=\"#222\" font-size=\"15\" font-weight=\"bold\" text-anchor=\"middle\">LAINE (76 patterns, H = 5.504 bits)</text></svg>"
+       "<svg viewBox=\"0 0 820 470\" xmlns=\"http://www.w3.org/2000/svg\" style=\"font-family: -apple-system, 'Segoe UI', sans-serif; font-size: 12px;\"><rect x=\"0\" y=\"0\" width=\"820\" height=\"470\" fill=\"white\" stroke=\"#ddd\"/><line x1=\"70\" y1=\"335.0\" x2=\"780\" y2=\"335.0\" stroke=\"#e8e8e8\" stroke-width=\"1\"/><text x=\"62.0\" y=\"339.0\" fill=\"#666\" text-anchor=\"end\">0</text><line x1=\"70\" y1=\"278.0\" x2=\"780\" y2=\"278.0\" stroke=\"#e8e8e8\" stroke-width=\"1\"/><text x=\"62.0\" y=\"282.0\" fill=\"#666\" text-anchor=\"end\">6</text><line x1=\"70\" y1=\"221.0\" x2=\"780\" y2=\"221.0\" stroke=\"#e8e8e8\" stroke-width=\"1\"/><text x=\"62.0\" y=\"225.0\" fill=\"#666\" text-anchor=\"end\">13</text><line x1=\"70\" y1=\"164.0\" x2=\"780\" y2=\"164.0\" stroke=\"#e8e8e8\" stroke-width=\"1\"/><text x=\"62.0\" y=\"168.0\" fill=\"#666\" text-anchor=\"end\">19</text><line x1=\"70\" y1=\"107.0\" x2=\"780\" y2=\"107.0\" stroke=\"#e8e8e8\" stroke-width=\"1\"/><text x=\"62.0\" y=\"111.0\" fill=\"#666\" text-anchor=\"end\">26</text><line x1=\"70\" y1=\"50.0\" x2=\"780\" y2=\"50.0\" stroke=\"#e8e8e8\" stroke-width=\"1\"/><text x=\"62.0\" y=\"54.0\" fill=\"#666\" text-anchor=\"end\">33</text><rect x=\"76.6\" y=\"50.0\" width=\"34.1\" height=\"285.0\" fill=\"#3b82f6\"/><text x=\"93.7\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 93.7 343.0)\">0,0,0,0,2</text><rect x=\"124.0\" y=\"153.6\" width=\"34.1\" height=\"181.4\" fill=\"#3b82f6\"/><text x=\"141.0\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 141.0 343.0)\">0,2,0,0,2</text><rect x=\"171.3\" y=\"179.5\" width=\"34.1\" height=\"155.5\" fill=\"#3b82f6\"/><text x=\"188.3\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 188.3 343.0)\">0,0,0,0,1</text><rect x=\"218.6\" y=\"196.8\" width=\"34.1\" height=\"138.2\" fill=\"#3b82f6\"/><text x=\"235.7\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 235.7 343.0)\">0,1,0,0,2</text><rect x=\"266.0\" y=\"240.0\" width=\"34.1\" height=\"95.0\" fill=\"#3b82f6\"/><text x=\"283.0\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 283.0 343.0)\">1,0,0,0,2</text><rect x=\"313.3\" y=\"240.0\" width=\"34.1\" height=\"95.0\" fill=\"#3b82f6\"/><text x=\"330.3\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 330.3 343.0)\">0,0,1,0,2</text><rect x=\"360.6\" y=\"248.6\" width=\"34.1\" height=\"86.4\" fill=\"#3b82f6\"/><text x=\"377.7\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 377.7 343.0)\">0,0,2,0,2</text><rect x=\"408.0\" y=\"257.3\" width=\"34.1\" height=\"77.7\" fill=\"#3b82f6\"/><text x=\"425.0\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 425.0 343.0)\">0,0,0,1,2</text><rect x=\"455.3\" y=\"265.9\" width=\"34.1\" height=\"69.1\" fill=\"#3b82f6\"/><text x=\"472.3\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 472.3 343.0)\">1,2,0,0,2</text><rect x=\"502.6\" y=\"283.2\" width=\"34.1\" height=\"51.8\" fill=\"#3b82f6\"/><text x=\"519.7\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 519.7 343.0)\">1,1,0,0,2</text><rect x=\"550.0\" y=\"283.2\" width=\"34.1\" height=\"51.8\" fill=\"#3b82f6\"/><text x=\"567.0\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 567.0 343.0)\">0,0,1,0,0</text><rect x=\"597.3\" y=\"283.2\" width=\"34.1\" height=\"51.8\" fill=\"#3b82f6\"/><text x=\"614.3\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 614.3 343.0)\">1,0,2,0,2</text><rect x=\"644.6\" y=\"291.8\" width=\"34.1\" height=\"43.2\" fill=\"#3b82f6\"/><text x=\"661.7\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 661.7 343.0)\">1,1,0,0,0</text><rect x=\"692.0\" y=\"291.8\" width=\"34.1\" height=\"43.2\" fill=\"#3b82f6\"/><text x=\"709.0\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 709.0 343.0)\">1,1,0,0,1</text><rect x=\"739.3\" y=\"291.8\" width=\"34.1\" height=\"43.2\" fill=\"#3b82f6\"/><text x=\"756.3\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 756.3 343.0)\">1,0,0,0,1</text><line x1=\"70\" y1=\"335\" x2=\"780\" y2=\"335\" stroke=\"#333\" stroke-width=\"1.5\"/><line x1=\"70\" y1=\"50\" x2=\"70\" y2=\"335\" stroke=\"#333\" stroke-width=\"1.5\"/><text x=\"18\" y=\"192.5\" fill=\"#333\" text-anchor=\"middle\" transform=\"rotate(-90 18 192.5)\">Nombre de mots</text><text x=\"410\" y=\"28\" fill=\"#222\" font-size=\"15\" font-weight=\"bold\" text-anchor=\"middle\">LAINE (76 patterns, H = 5.512 bits)</text></svg>"
       ]
      },
      "metadata": {},
@@ -2473,7 +2561,7 @@
     {
      "data": {
       "text/html": [
-       "<svg viewBox=\"0 0 820 470\" xmlns=\"http://www.w3.org/2000/svg\" style=\"font-family: -apple-system, 'Segoe UI', sans-serif; font-size: 12px;\"><rect x=\"0\" y=\"0\" width=\"820\" height=\"470\" fill=\"white\" stroke=\"#ddd\"/><line x1=\"70\" y1=\"335.0\" x2=\"780\" y2=\"335.0\" stroke=\"#e8e8e8\" stroke-width=\"1\"/><text x=\"62.0\" y=\"339.0\" fill=\"#666\" text-anchor=\"end\">0</text><line x1=\"70\" y1=\"278.0\" x2=\"780\" y2=\"278.0\" stroke=\"#e8e8e8\" stroke-width=\"1\"/><text x=\"62.0\" y=\"282.0\" fill=\"#666\" text-anchor=\"end\">13</text><line x1=\"70\" y1=\"221.0\" x2=\"780\" y2=\"221.0\" stroke=\"#e8e8e8\" stroke-width=\"1\"/><text x=\"62.0\" y=\"225.0\" fill=\"#666\" text-anchor=\"end\">26</text><line x1=\"70\" y1=\"164.0\" x2=\"780\" y2=\"164.0\" stroke=\"#e8e8e8\" stroke-width=\"1\"/><text x=\"62.0\" y=\"168.0\" fill=\"#666\" text-anchor=\"end\">40</text><line x1=\"70\" y1=\"107.0\" x2=\"780\" y2=\"107.0\" stroke=\"#e8e8e8\" stroke-width=\"1\"/><text x=\"62.0\" y=\"111.0\" fill=\"#666\" text-anchor=\"end\">53</text><line x1=\"70\" y1=\"50.0\" x2=\"780\" y2=\"50.0\" stroke=\"#e8e8e8\" stroke-width=\"1\"/><text x=\"62.0\" y=\"54.0\" fill=\"#666\" text-anchor=\"end\">67</text><rect x=\"76.6\" y=\"50.0\" width=\"34.1\" height=\"285.0\" fill=\"#3b82f6\"/><text x=\"93.7\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 93.7 343.0)\">0,0,0,1,0</text><rect x=\"124.0\" y=\"152.1\" width=\"34.1\" height=\"182.9\" fill=\"#3b82f6\"/><text x=\"141.0\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 141.0 343.0)\">1,0,0,1,0</text><rect x=\"171.3\" y=\"207.4\" width=\"34.1\" height=\"127.6\" fill=\"#3b82f6\"/><text x=\"188.3\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 188.3 343.0)\">0,0,0,1,1</text><rect x=\"218.6\" y=\"266.9\" width=\"34.1\" height=\"68.1\" fill=\"#3b82f6\"/><text x=\"235.7\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 235.7 343.0)\">1,0,0,0,0</text><rect x=\"266.0\" y=\"266.9\" width=\"34.1\" height=\"68.1\" fill=\"#3b82f6\"/><text x=\"283.0\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 283.0 343.0)\">0,1,0,1,0</text><rect x=\"313.3\" y=\"271.2\" width=\"34.1\" height=\"63.8\" fill=\"#3b82f6\"/><text x=\"330.3\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 330.3 343.0)\">1,0,0,1,1</text><rect x=\"360.6\" y=\"271.2\" width=\"34.1\" height=\"63.8\" fill=\"#3b82f6\"/><text x=\"377.7\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 377.7 343.0)\">0,0,0,2,0</text><rect x=\"408.0\" y=\"275.4\" width=\"34.1\" height=\"59.6\" fill=\"#3b82f6\"/><text x=\"425.0\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 425.0 343.0)\">0,0,0,0,0</text><rect x=\"455.3\" y=\"305.2\" width=\"34.1\" height=\"29.8\" fill=\"#3b82f6\"/><text x=\"472.3\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 472.3 343.0)\">2,0,0,1,0</text><rect x=\"502.6\" y=\"305.2\" width=\"34.1\" height=\"29.8\" fill=\"#3b82f6\"/><text x=\"519.7\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 519.7 343.0)\">0,0,0,2,1</text><rect x=\"550.0\" y=\"305.2\" width=\"34.1\" height=\"29.8\" fill=\"#3b82f6\"/><text x=\"567.0\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 567.0 343.0)\">1,1,0,1,0</text><rect x=\"597.3\" y=\"309.5\" width=\"34.1\" height=\"25.5\" fill=\"#3b82f6\"/><text x=\"614.3\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 614.3 343.0)\">2,0,0,0,0</text><rect x=\"644.6\" y=\"309.5\" width=\"34.1\" height=\"25.5\" fill=\"#3b82f6\"/><text x=\"661.7\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 661.7 343.0)\">1,0,0,0,1</text><rect x=\"692.0\" y=\"318.0\" width=\"34.1\" height=\"17.0\" fill=\"#3b82f6\"/><text x=\"709.0\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 709.0 343.0)\">2,0,0,2,0</text><rect x=\"739.3\" y=\"318.0\" width=\"34.1\" height=\"17.0\" fill=\"#3b82f6\"/><text x=\"756.3\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 756.3 343.0)\">1,1,0,0,0</text><line x1=\"70\" y1=\"335\" x2=\"780\" y2=\"335\" stroke=\"#333\" stroke-width=\"1.5\"/><line x1=\"70\" y1=\"50\" x2=\"70\" y2=\"335\" stroke=\"#333\" stroke-width=\"1.5\"/><text x=\"18\" y=\"192.5\" fill=\"#333\" text-anchor=\"middle\" transform=\"rotate(-90 18 192.5)\">Nombre de mots</text><text x=\"410\" y=\"28\" fill=\"#222\" font-size=\"15\" font-weight=\"bold\" text-anchor=\"middle\">APPEL (37 patterns, H = 4.058 bits)</text></svg>"
+       "<svg viewBox=\"0 0 820 470\" xmlns=\"http://www.w3.org/2000/svg\" style=\"font-family: -apple-system, 'Segoe UI', sans-serif; font-size: 12px;\"><rect x=\"0\" y=\"0\" width=\"820\" height=\"470\" fill=\"white\" stroke=\"#ddd\"/><line x1=\"70\" y1=\"335.0\" x2=\"780\" y2=\"335.0\" stroke=\"#e8e8e8\" stroke-width=\"1\"/><text x=\"62.0\" y=\"339.0\" fill=\"#666\" text-anchor=\"end\">0</text><line x1=\"70\" y1=\"278.0\" x2=\"780\" y2=\"278.0\" stroke=\"#e8e8e8\" stroke-width=\"1\"/><text x=\"62.0\" y=\"282.0\" fill=\"#666\" text-anchor=\"end\">13</text><line x1=\"70\" y1=\"221.0\" x2=\"780\" y2=\"221.0\" stroke=\"#e8e8e8\" stroke-width=\"1\"/><text x=\"62.0\" y=\"225.0\" fill=\"#666\" text-anchor=\"end\">26</text><line x1=\"70\" y1=\"164.0\" x2=\"780\" y2=\"164.0\" stroke=\"#e8e8e8\" stroke-width=\"1\"/><text x=\"62.0\" y=\"168.0\" fill=\"#666\" text-anchor=\"end\">40</text><line x1=\"70\" y1=\"107.0\" x2=\"780\" y2=\"107.0\" stroke=\"#e8e8e8\" stroke-width=\"1\"/><text x=\"62.0\" y=\"111.0\" fill=\"#666\" text-anchor=\"end\">53</text><line x1=\"70\" y1=\"50.0\" x2=\"780\" y2=\"50.0\" stroke=\"#e8e8e8\" stroke-width=\"1\"/><text x=\"62.0\" y=\"54.0\" fill=\"#666\" text-anchor=\"end\">67</text><rect x=\"76.6\" y=\"50.0\" width=\"34.1\" height=\"285.0\" fill=\"#3b82f6\"/><text x=\"93.7\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 93.7 343.0)\">0,0,0,1,0</text><rect x=\"124.0\" y=\"147.8\" width=\"34.1\" height=\"187.2\" fill=\"#3b82f6\"/><text x=\"141.0\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 141.0 343.0)\">1,0,0,1,0</text><rect x=\"171.3\" y=\"207.4\" width=\"34.1\" height=\"127.6\" fill=\"#3b82f6\"/><text x=\"188.3\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 188.3 343.0)\">0,0,0,1,1</text><rect x=\"218.6\" y=\"266.9\" width=\"34.1\" height=\"68.1\" fill=\"#3b82f6\"/><text x=\"235.7\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 235.7 343.0)\">1,0,0,0,0</text><rect x=\"266.0\" y=\"266.9\" width=\"34.1\" height=\"68.1\" fill=\"#3b82f6\"/><text x=\"283.0\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 283.0 343.0)\">0,1,0,1,0</text><rect x=\"313.3\" y=\"271.2\" width=\"34.1\" height=\"63.8\" fill=\"#3b82f6\"/><text x=\"330.3\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 330.3 343.0)\">1,0,0,1,1</text><rect x=\"360.6\" y=\"271.2\" width=\"34.1\" height=\"63.8\" fill=\"#3b82f6\"/><text x=\"377.7\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 377.7 343.0)\">0,0,0,2,0</text><rect x=\"408.0\" y=\"275.4\" width=\"34.1\" height=\"59.6\" fill=\"#3b82f6\"/><text x=\"425.0\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 425.0 343.0)\">0,0,0,0,0</text><rect x=\"455.3\" y=\"305.2\" width=\"34.1\" height=\"29.8\" fill=\"#3b82f6\"/><text x=\"472.3\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 472.3 343.0)\">2,0,0,1,0</text><rect x=\"502.6\" y=\"305.2\" width=\"34.1\" height=\"29.8\" fill=\"#3b82f6\"/><text x=\"519.7\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 519.7 343.0)\">0,0,0,2,1</text><rect x=\"550.0\" y=\"305.2\" width=\"34.1\" height=\"29.8\" fill=\"#3b82f6\"/><text x=\"567.0\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 567.0 343.0)\">1,1,0,1,0</text><rect x=\"597.3\" y=\"309.5\" width=\"34.1\" height=\"25.5\" fill=\"#3b82f6\"/><text x=\"614.3\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 614.3 343.0)\">2,0,0,0,0</text><rect x=\"644.6\" y=\"309.5\" width=\"34.1\" height=\"25.5\" fill=\"#3b82f6\"/><text x=\"661.7\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 661.7 343.0)\">1,0,0,0,1</text><rect x=\"692.0\" y=\"318.0\" width=\"34.1\" height=\"17.0\" fill=\"#3b82f6\"/><text x=\"709.0\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 709.0 343.0)\">2,0,0,2,0</text><rect x=\"739.3\" y=\"318.0\" width=\"34.1\" height=\"17.0\" fill=\"#3b82f6\"/><text x=\"756.3\" y=\"343.0\" fill=\"#333\" text-anchor=\"end\" transform=\"rotate(-45 756.3 343.0)\">1,1,0,0,0</text><line x1=\"70\" y1=\"335\" x2=\"780\" y2=\"335\" stroke=\"#333\" stroke-width=\"1.5\"/><line x1=\"70\" y1=\"50\" x2=\"70\" y2=\"335\" stroke=\"#333\" stroke-width=\"1.5\"/><text x=\"18\" y=\"192.5\" fill=\"#333\" text-anchor=\"middle\" transform=\"rotate(-90 18 192.5)\">Nombre de mots</text><text x=\"410\" y=\"28\" fill=\"#222\" font-size=\"15\" font-weight=\"bold\" text-anchor=\"middle\">APPEL (37 patterns, H = 4.053 bits)</text></svg>"
       ]
      },
      "metadata": {},
@@ -2551,10 +2639,10 @@
    "id": "a6277a07ad7b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-15T00:28:36.333645Z",
-     "iopub.status.busy": "2026-07-15T00:28:36.333359Z",
-     "iopub.status.idle": "2026-07-15T00:28:36.382057Z",
-     "shell.execute_reply": "2026-07-15T00:28:36.381714Z"
+     "iopub.execute_input": "2026-07-22T22:36:38.649421Z",
+     "iopub.status.busy": "2026-07-22T22:36:38.649421Z",
+     "iopub.status.idle": "2026-07-22T22:36:38.669815Z",
+     "shell.execute_reply": "2026-07-22T22:36:38.669217Z"
     }
    },
    "outputs": [
@@ -2601,10 +2689,10 @@
    "id": "96a958a02098",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-15T00:28:36.384454Z",
-     "iopub.status.busy": "2026-07-15T00:28:36.384104Z",
-     "iopub.status.idle": "2026-07-15T00:28:36.446396Z",
-     "shell.execute_reply": "2026-07-15T00:28:36.446136Z"
+     "iopub.execute_input": "2026-07-22T22:36:38.672563Z",
+     "iopub.status.busy": "2026-07-22T22:36:38.672037Z",
+     "iopub.status.idle": "2026-07-22T22:36:38.690285Z",
+     "shell.execute_reply": "2026-07-22T22:36:38.690285Z"
     }
    },
    "outputs": [
@@ -2646,10 +2734,10 @@
    "id": "5abe84161700",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-15T00:28:36.448354Z",
-     "iopub.status.busy": "2026-07-15T00:28:36.448100Z",
-     "iopub.status.idle": "2026-07-15T00:28:36.488706Z",
-     "shell.execute_reply": "2026-07-15T00:28:36.488453Z"
+     "iopub.execute_input": "2026-07-22T22:36:38.690285Z",
+     "iopub.status.busy": "2026-07-22T22:36:38.690285Z",
+     "iopub.status.idle": "2026-07-22T22:36:38.716735Z",
+     "shell.execute_reply": "2026-07-22T22:36:38.716735Z"
     }
    },
    "outputs": [

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb
@@ -46,7 +46,7 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
-       "async function probeAddresses(probingAddresses) {\r\n",
+       
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -56,10 +56,10 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
-       "    if (Array.isArray(probingAddresses)) {\r\n",
-       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       
+       
        "\r\n",
-       "            let rootUrl = probingAddresses[i];\r\n",
+       
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -74,7 +74,7 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
-       "                    body: probingAddresses[i]\r\n",
+       
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -86,8 +86,8 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
-       "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://2a01:e0a:9d4:f320:6701:5a41:8422:35ad:2048/\",\"http://2a01:e0a:9d4:f320:7caf:c5ad:fe00:85e5:2048/\",\"http://fe80::902b:f9f6:2003:66a1%20:2048/\",\"http://192.168.0.51:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::ae60:2bbf:92f7:4e06%19:2048/\",\"http://172.21.192.1:2048/\",\"http://fe80::d7f2:2a3e:6d36:1ec0%30:2048/\",\"http://172.25.0.1:2048/\"])\r\n",
+       
+       
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
@@ -136,13 +136,13 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
-       "        loadDotnetInteractiveApi();\r\n",
+       
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
-       "    loadDotnetInteractiveApi();\r\n",
+       
        "}\r\n",
        "\r\n",
        "    </script>\r\n",


### PR DESCRIPTION
## Summary

The C# twin of `App-7-Wordle` (`App-7b-Wordle-CSharp.ipynb`) had the **same defect** as the Python twin fixed in PR #8046: `CRANE` was absent from `WORD_LIST`. The cell-3 comment explicitly binds the two notebooks by parity (`STRICTEMENT identique a la WORD_LIST du notebook Python -> parite d'entropie`), so the twins must stay word-for-word aligned. PR #8046 added `CRANE` to the Python list (296 → 297); this PR does the same on the C# side to restore parity.

## Defect (G.1 firsthand-verified against `origin/main`)

- `cell id=df329766caf2` (WORD_LIST): 296 words, **CRANE absent** (28 C-words, no CRANE — parity-identical to the Python twin pre-fix).
- `cell id=4aadc919e76b` (simple-filter test, `testWords = { "CRANE", ... }`): committed output `CRANE absent de la liste, skip` — the solver detected the missing entry and skipped it, so it never demonstrated solving CRANE (only the other 4 words).
- `cell id=133ff3e98563` (CSP test, `Solve("CRANE", new Random(42))`): committed output `=> Perdu en 2 tentative(s)` — the CSP solver does not skip, so candidate filtering collapsed to 0 (PEINE → CANNE, 3 candidates, then lose) because the true answer was filtered out.

## Fix

Add `"CRANE"` to the `WORD_LIST_SRC` literal in `cell id=df329766caf2` (before `CREUX`, mirroring the Python twin's placement) and update the parity comment `(296 mots)` → `(297 mots)`. The runtime filtering keeps the list canonical. Re-executed the whole notebook end-to-end on the `.NET (C#)` kernel (dotnet-interactive 1.0.712001, .NET SDK 10).

## Validation

- Re-execution: `nbconvert --execute --inplace`, kernel `.net-csharp`, SDK 10. Exit 0.
- Post-fix outputs (G.1 firsthand):
  - CSP demo (cell 15): `Perdu en 2` → **`Gagne en 3`** (Tentative 3: `CRANE -> GGGGG`).
  - Simple-filter demo (cell 11): no longer skips CRANE → solves it (**`Gagne en 4`**, Tentative 4: `CRANE -> GGGGG`).
  - Candidate count 296 → 297 everywhere (entropy/benchmark cells regenerated consistently).
- Scope: only the WORD_LIST cell (`df329766caf2`) source changed (verified cell-by-cell against `origin/main`); 41 cells unchanged in count; +225/−137 = regenerated dependent outputs (C.2). LF-normalized (no CRLF), catalogue byte-identical to main, H.3 (0 cells with null exec_count + no outputs) and C.1 (no intentional errors) pass.

## SOTA verdict

SOTA-OK: the CSP solver (domain-reduction / propagation) and the simple-filter solver are invoked directly on the real dictionary; no degraded workaround. The fix restores a real, parity-bound demo.

Twin completion of #8046. See #8046 (Python twin). See #3801 (registry — this is a data-correctness fix, not a Prong-B case).
