### PR TITLE
docs(probas-infer,#3801): enrich Infer-16 GP prediction interpretation (sign + uncertainty)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-16-Sparse-Gaussian-Process.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-16-Sparse-Gaussian-Process.ipynb
@@ -764,6 +764,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### Lecture des prédictions : le signe de $f$ encode la classe\n\n**Exactitude 16/16 sur un dataset non linéairement séparable.** C'est précisément le\ncas où le GP justifie son emploi : un BPM (Infer-9) aurait échoué (cf. §4), incapable\nde tracer un hyperplan entre le disque et l'anneau. Le GP, lui, apprend une fonction\n$f(\\mathbf{x})$ dont le **signe** sépare les deux régions :\n\n| Région | Points | $E[f]$ | Prédiction | Classe réelle |\n|--------|--------|--------|------------|---------------|\n| Disque intérieur ($r \\approx 0{,}3$–$0{,}6$) | x0–x7 | $-0{,}46$ à $-0{,}82$ | `False` | `False` ✓ |\n| Anneau extérieur ($r \\approx 1{,}2$–$1{,}5$) | x8–x15 | $+0{,}38$ à $+0{,}72$ | `True` | `True` ✓ |\n\nLa frontière de décision $f = 0$ se situe donc entre les deux rayons : le GP a\nreconstitué la structure annulaire qu'aucun hyperplan ne pouvait séparer.\n\n**Chaque prédiction est une Gaussienne, pas un scalaire.** C'est la marque du GP par\nrapport au BPM : le posterior $f(\\mathbf{x}_j) = \\mathcal{N}(\\mu_j, \\sigma_j^2)$\nquantifie l'**incertitude**, pas seulement la classe. Deux observations :\n\n1. **Le disque est plus confiant que l'anneau** ($\\sigma^2 \\approx 0{,}15$–$0{,}25$\n   contre $0{,}18$–$0{,}40$). Les points intérieurs sont plus proches des points\n   induiseurs et mieux contraints par leurs voisins.\n2. **Le point le moins confiant est x14** ($E[f] = +0{,}38$, $\\sigma^2 = 0{,}31$) :\n   sa moyenne est la plus proche de zéro, donc au plus près de la frontière. La\n   variance signale un point à risque — précieux pour l'apprentissage actif ou une\n   décision prudente.\n\nCette double sortie (classe **et** incertitude) est la raison d'être du GP : elle rend\nla frontière exploitable, pas seulement correcte.\n"
+  },
+  {
    "cell_type": "code",
    "id": "01b7cfd8",
    "metadata": {},


### PR DESCRIPTION
## What

`Infer-16-Sparse-Gaussian-Process.ipynb` cell 17 — the training-predictions cell (16/16 accuracy on the non-linearly-separable **donut** dataset) — had **no following interpretation**: the next cell jumped straight to test points. Added **one grounded markdown cell** interpreting the committed output.

## Why (substance, EPIC #3801)

This is a **Prong-B-positive** demonstration: the Sparse GP classifies the donut (no linear separator — a BPM/Infer-9 provably fails, cf §4) at **16/16**. The new cell makes the engine's distinctive value **visible** in the output:

- **Sign of f encodes the class** — $E[f] \in [-0.46, -0.82]$ inside the disk (False), $[+0.38, +0.72]$ on the ring (True) → decision boundary $f=0$ between radii. The GP reconstructed the annular structure no hyperplane could separate.
- **Each prediction is a Gaussian $\mathcal{N}(\mu, \sigma^2)$, not a scalar** — the GP hallmark vs BPM. Disk variance ~0.15–0.25 (confident), ring ~0.18–0.40; **x14** is the least-confident correct point ($E[f]=+0.38$, closest to boundary) — actionable for active learning / risk-aware decisions.

## Validation

- **Markdown-only** (C.2 exception: prior outputs valid, no re-exec). All 31 original cells byte-identical.
- **Surgical edit** verified by byte-identical round-trip (`json.dumps(indent=1, ensure_ascii=False)` + LF): diff = `+5 / -0` lines, single new markdown object inserted at line 766.
- Values cited are **grounded in the committed cell-17 output** (deterministic seed `Random(7)`), not fabricated.
- `nbformat` 4.5 valid; 32 cells.

## Scope

1 file, +5/-0, 1 notebook. `Grain: MED/enrichment` (lane `myia-po-2023:CoursIA`). Genre **distinct** from my last doc-honesty PR (#8010) → G-VAR-3 compliant.

See #3801.

---
*Note: pushed via `myia-po-2023/CoursIA` fork — origin write access for `myia-po-2023` appears downgraded to READ this cycle (was WRITE when #8010 merged). Flagging to @myia-ai-01.*