### PR TITLE
fix(sudoku-14): mdd_product dropped g constraint when f reached valid terminal (code-correctness)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Python.ipynb
@@ -1068,9 +1068,11 @@
     "    if f.is_terminal and g.is_terminal:\n",
     "        return MDD_VALID if (f.is_valid and g.is_valid) else MDD_INVALID\n",
     "    if f.is_terminal:\n",
-    "        return f if f.is_valid else MDD_INVALID\n",
+    "        # f terminal : INVALID court-circuite (AND) ; VALID => il reste a verifier g.\n",
+    "        return MDD_INVALID if not f.is_valid else g\n",
     "    if g.is_terminal:\n",
-    "        return g if g.is_valid else MDD_INVALID\n",
+    "        # symetrique : g INVALID court-circuite ; g VALID => il reste a verifier f.\n",
+    "        return MDD_INVALID if not g.is_valid else f\n",
     "\n",
     "    assert f.children is not None and g.children is not None\n",
     "    # Si les deux MDD testent la même cellule, on fusionne les branches.\n",
@@ -1089,7 +1091,8 @@
     "    return MDDNode.create(f.cell_name, children)\n",
     "\n",
     "\n",
-    "print(\"mdd_product défini (produit explicite, fusion sur cellule commune).\")\n"
+    "print(\"mdd_product défini (produit explicite, fusion sur cellule commune).\")\n",
+    ""
    ]
   },
   {
@@ -1134,12 +1137,12 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "MDD ligne 0 (size=2) : 7 nœuds\n",
       "MDD ligne 1 (size=2) : 7 nœuds\n",
-      "MDD produit 2x2      : 7 nœuds\n",
+      "MDD produit 2x2      : 19 nœuds\n",
       "\n",
       "Grille valide    {1,2},{2,1} : True  (attendu True)\n",
       "Grille invalide  {1,1},{2,1} : False  (attendu False)\n"


### PR DESCRIPTION
Grain: MED/code-correctness — lane myia-po-2025:CoursIA — prev: MED/doc-honesty (#8065 PyMC-7)

## Bug (code-correctness, G.1-verified firsthand)

Sudoku-14-BDD-Python.ipynb cell 22 `mdd_product` (explicit conjunction of two MDD constraints) had two buggy terminal branches:

```python
if f.is_terminal:
    return f if f.is_valid else MDD_INVALID   # BUG: valid -> returns f, ignores g
if g.is_terminal:
    return g if g.is_valid else MDD_INVALID   # BUG: valid -> returns g, ignores f
```

When one operand reaches its **VALID** terminal before the other, the product returned VALID immediately **without checking the remaining operand**. In a conjunction (AND), a VALID operand must let the **other** operand be fully evaluated — only INVALID short-circuits.

## Reproduced firsthand

Exhaustive 2×2 grid check (all 16 grids of digits {1,2}): **4 grids misclassified**, all of them "row0 valid (distinct) + row1 invalid (doublon)". The MDD product accepted them (`True`) when it should reject (`False`) — row1's distinctness constraint was silently dropped. The committed cell 24 output showed `MDD produit 2x2 : 7 nœuds` (= row0 alone), confirming the product had degenerated to a single constraint instead of conjoining both.

## Fix (AND semantics)

```python
if f.is_terminal:
    # f terminal : INVALID court-circuite (AND) ; VALID => il reste a verifier g.
    return MDD_INVALID if not f.is_valid else g
if g.is_terminal:
    # symetrique : g INVALID court-circuite ; g VALID => il reste a verifier f.
    return MDD_INVALID if not g.is_valid else f
```

## Re-execution (Stop & Repair — real machinery output)

Re-executed cell 24 (the only caller; `solve_sudoku_mdd` in cell 26 uses backtracking + propagation, NOT `mdd_product`, so unaffected) with the real BDD/MDD machinery:
- **product node count 7 → 19** (row0 AND row1 now conjoined correctly)
- documented tests unchanged (valid `{1,2},{2,1}`=True, invalid `{1,1},{2,1}`=False)
- exhaustive 2×2 now 16/16 correct (the previously-misclassified `{1,2},{1,1}` etc. correctly rejected)

Deterministic (BDD/MDD construction, no `np.random`).

## Validation

- Validator: **1 OK / 0 Warnings / 0 Errors** (clean before AND after — no pre-existing Warning masked)
- nbformat strict OK; JSON round-trip stable
- C.1 (no voluntary error): 0 violations in code-source cells
- Scope: **cell 22 source + cell 24 output only**, 8 ins / 5 del, single file
- Blast radius: cell 22 (`mdd_product` def) + cell 24 (only caller)

See #3801

🤖 Generated with [Claude Code](https://claude.com/claude-code)