### PR TITLE
[c.802] feat(notebook-tools,#8057): twin parity register extension tranche 2 (Search/Part1-Foundations + Part2-CSP)

### DIFF
--- a/scripts/notebook_tools/check_twin_parity.py
+++ b/scripts/notebook_tools/check_twin_parity.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Detecte la derive des jumeaux Python/C# depuis le registre de parite (#8057).
+
+Pourquoi cet outil existe
+-------------------------
+La campagne de **jumeaux Python/C#** est devenue structurante (Search/CSP,
+ML.NET + pendants Python, SemanticWeb, Planners, Z3/SMT : des dizaines de
+paires). Une **parite de surface** peut masquer une derive silencieuse : un
+notebook evolue (fix, enrichissement, re-exec) tandis que son jumeau reste a
+l'etat anterieur, et les deux implimentations derivent separement sans que
+personne ne re-audite la parite. Aujourd'hui la parite est **declarative**
+(des notes eparses dans des READMEs) ; ce outil la rend **auditable**.
+
+Le registre `twin_pairs.yaml` (a cote de ce script) decrit chaque paire :
+le chemin des deux notebooks, le `parity_level` (surface | semantic |
+native-both), le `last_audit` (date, auteur, et le **git blob SHA** de chaque
+notebook au moment de l'audit) et les `known_differences` documentees.
+
+Comment ca marche
+-----------------
+Pour chaque paire du registre, on :
+  1. lit le **git blob SHA courant** de chaque notebook via `git ls-tree HEAD`
+     (le contenu versionne, pas le working tree — reproductible) ;
+  2. compare le SHA courant au `last_audit.{python,csharp}_sha` enregistre ;
+  3. **DRIFT** si l'un des deux a change depuis le dernier audit -> la paire
+     doit etre re-auditee (un cote a evolue, la parite n'est plus garantie) ;
+  4. **MISSING** si le chemin n'existe pas dans git (typo, deplacement, jumeau
+     non cree) ;
+  5. **OK** sinon (les deux cotes sont au SHA audite, parite tenue).
+
+Le bouclage d'audit : apres avoir re-audite une paire firsthand, on rebaseline
+avec `--update` qui reecrit les SHAs courants comme nouvelle reference.
+
+Cet outil lit seulement par defaut (git ls-tree). Le mode `--update` ecrit le
+registre (curated YAML, pas un notebook -> pas de souci de re-exec C.2).
+
+Usage
+-----
+    # verifier toutes les paires vs le registre
+    python check_twin_parity.py
+    # exit 1 si drift/missing (CI-ready)
+    python check_twin_parity.py --check
+    # restreindre a une famille
+    python check_twin_parity.py --family SMT/Z3-API
+    # rebaseline apres audit firsthand (ecrit les SHAs courants)
+    python check_twin_parity.py --update
+    # sortie machine
+    python check_twin_parity.py --json
+
+Exit codes
+----------
+    0 -- toutes les paires OK (ou mode non --check)
+    1 -- un ou plusieurs DRIFT / MISSING (--check seulement)
+    2 -- erreur (registre illisible, pas un depot git)
+
+Voir aussi
+----------
+- twin_pairs.yaml (registre curated, a cote de ce script)
+- Issue #8057 (metadonnee de parite des jumeaux Python/C#)
+- Issue #4208 (parent : open-courseware fiabilise/publie)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    yaml = None
+
+DEFAULT_REGISTRY = Path(__file__).resolve().parent / "twin_pairs.yaml"
+
+
+def _git_blob_sha(repo_root: Path, rel_path: str) -> str | None:
+    """Git blob SHA d'un fichier versionne a HEAD (None si absent)."""
+    r = subprocess.run(
+        ["git", "ls-tree", "HEAD", "--", rel_path],
+        capture_output=True, text=True, cwd=str(repo_root),
+    )
+    if r.returncode != 0 or not r.stdout.strip():
+        return None
+    # format : "<mode> <type> <blob_sha>\t<path>"
+    parts = r.stdout.split()
+    if len(parts) >= 3:
+        return parts[2]
+    return None
+
+
+def _repo_root() -> Path:
+    r = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True, text=True,
+    )
+    if r.returncode != 0:
+        raise SystemExit("Erreur : pas un depot git (impossible de trouver la racine).")
+    return Path(r.stdout.strip())
+
+
+def load_registry(path: Path) -> list:
+    if path is None or not path.exists():
+        raise SystemExit(f"Erreur : registre introuvable : {path}")
+    if yaml is None:
+        raise SystemExit("Erreur : PyYAML requis (pip install pyyaml).")
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, list):
+        raise SystemExit("Erreur : le registre doit etre une liste de paires.")
+    return data
+
+
+def check_pair(repo_root: Path, pair: dict) -> dict:
+    """Verifie une paire. Retourne {name, python, csharp, status, details}.
+
+    status in {OK, DRIFT, MISSING}. details = liste de chaines explicatives.
+    """
+    name = pair.get("name", "?")
+    py = pair["python"]
+    cs = pair["csharp"]
+    audit = pair.get("last_audit", {}) or {}
+    rec_py = audit.get("python_sha")
+    rec_cs = audit.get("csharp_sha")
+
+    cur_py = _git_blob_sha(repo_root, py)
+    cur_cs = _git_blob_sha(repo_root, cs)
+
+    details = []
+    status = "OK"
+
+    if cur_py is None:
+        details.append(f"Python MANQUANT dans git : {py}")
+        status = "MISSING"
+    if cur_cs is None:
+        details.append(f"C# MANQUANT dans git : {cs}")
+        status = "MISSING"
+
+    if status == "OK":
+        py_drift = (rec_py is not None and cur_py != rec_py)
+        cs_drift = (rec_cs is not None and cur_cs != rec_cs)
+        no_baseline = (rec_py is None or rec_cs is None)
+        if py_drift:
+            details.append(f"Python a drift : {rec_py[:8]} -> {cur_py[:8]}")
+        if cs_drift:
+            details.append(f"C# a drift : {rec_cs[:8]} -> {cur_cs[:8]}")
+        if no_baseline:
+            details.append("Pas de last_audit_sha enregistre (--update requis)")
+        if py_drift or cs_drift or no_baseline:
+            status = "DRIFT"
+
+    return {
+        "name": name,
+        "family": pair.get("family", "?"),
+        "python": py,
+        "csharp": cs,
+        "parity_level": pair.get("parity_level", "?"),
+        "status": status,
+        "current_python_sha": cur_py,
+        "current_csharp_sha": cur_cs,
+        "recorded_python_sha": rec_py,
+        "recorded_csharp_sha": rec_cs,
+        "last_audit_date": audit.get("date"),
+        "last_audit_by": audit.get("by"),
+        "details": details,
+    }
+
+
+def update_pair(repo_root: Path, pair: dict) -> tuple[dict, str | None]:
+    """Rebaseline une paire : enregistre les SHAs courants comme nouvelle ref.
+
+    Retourne (last_audit_dict mis a jour, sha_utilise_pour_python ou None si missing).
+    """
+    py = pair["python"]
+    cs = pair["csharp"]
+    cur_py = _git_blob_sha(repo_root, py)
+    cur_cs = _git_blob_sha(repo_root, cs)
+    today = pair.get("last_audit", {}).get("date")  # conserve si deja la
+    by = pair.get("last_audit", {}).get("by", "manual")
+    audit = {
+        "date": today,
+        "by": by,
+        "python_sha": cur_py,
+        "csharp_sha": cur_cs,
+    }
+    return audit, cur_py
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    p.add_argument("--registry", default=str(DEFAULT_REGISTRY),
+                   help=f"Chemin du registre YAML (defaut: {DEFAULT_REGISTRY.name})")
+    p.add_argument("--family", default=None,
+                   help="Restreindre a une famille (ex. SMT/Z3-API)")
+    p.add_argument("--check", action="store_true",
+                   help="Exit 1 si DRIFT/MISSING detecte (CI-ready)")
+    p.add_argument("--update", action="store_true",
+                   help="Rebaseline : ecrit les SHAs courants comme nouveau last_audit "
+                        "(a lancer APRES une audit firsthand d'une paire)")
+    p.add_argument("--json", action="store_true", help="Sortie machine JSON")
+    args = p.parse_args(argv)
+
+    repo_root = _repo_root()
+    reg_path = Path(args.registry)
+    pairs = load_registry(reg_path)
+
+    if args.family:
+        pairs = [pp for pp in pairs if pp.get("family") == args.family]
+        if not pairs:
+            print(f"Aucune paire pour la famille '{args.family}'.", file=sys.stderr)
+
+    if args.update:
+        # rebaseline toutes les paires (ou filtrees par --family)
+        updated = 0
+        for pp in pairs:
+            audit, cur_py = update_pair(repo_root, pp)
+            if cur_py is not None:
+                pp["last_audit"] = audit
+                updated += 1
+        # re-ecrit le registre entier (conserve l'ordre + les autres paires)
+        if yaml is None:
+            raise SystemExit("Erreur : PyYAML requis pour --update.")
+        reg_path.write_text(
+            yaml.safe_dump(pairs, sort_keys=False, allow_unicode=True, width=100),
+            encoding="utf-8",
+        )
+        msg = f"Registre rebaseline : {updated} paire(s) mise(s) a jour -> {reg_path}"
+        print(msg)
+        return 0
+
+    results = [check_pair(repo_root, pp) for pp in pairs]
+    n_ok = sum(1 for r in results if r["status"] == "OK")
+    n_drift = sum(1 for r in results if r["status"] == "DRIFT")
+    n_missing = sum(1 for r in results if r["status"] == "MISSING")
+
+    if args.json:
+        out = {
+            "registry": str(reg_path),
+            "total": len(results),
+            "ok": n_ok,
+            "drift": n_drift,
+            "missing": n_missing,
+            "pairs": results,
+        }
+        print(json.dumps(out, ensure_ascii=False, indent=2))
+    else:
+        for r in results:
+            tag = {"OK": "OK", "DRIFT": "DRIFT", "MISSING": "MISSING"}[r["status"]]
+            print(f"[{tag}] {r['name']} ({r['family']}, {r['parity_level']})")
+            if r["status"] != "OK":
+                for d in r["details"]:
+                    print(f"       - {d}")
+        print(f"\nTotal : {len(results)} paire(s) | OK={n_ok} DRIFT={n_drift} MISSING={n_missing}")
+
+    if args.check and (n_drift > 0 or n_missing > 0):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/notebook_tools/twin_pairs.yaml
+++ b/scripts/notebook_tools/twin_pairs.yaml
@@ -1,0 +1,104 @@
+# Registre de parite des jumeaux Python/C# (#8057, parent #4208).
+#
+# Chaque entree decrit une paire de notebooks jumeaux : le chemin des deux
+# cotes, le niveau de parite, le dernier audit (date + auteur + git blob SHA de
+# chaque notebook au moment de l'audit) et les differences connues documentees.
+#
+# Le check `check_twin_parity.py` compare le SHA courant (git ls-tree HEAD) au
+# SHA audite : DRIFT = un cote a evolue sans re-audit -> parite a reverifier.
+# Apres une audit firsthand, rebaseline avec :
+#   python scripts/notebook_tools/check_twin_parity.py --update [--family ...]
+#
+# parity_level :
+#   surface     = meme plan/sections, implimentations independantes
+#   semantic    = meme contenu mathematique/conceptuel, API idiomatique differente
+#   native-both = traduction fidele cellule-par-cellule (rare)
+#
+# PILOTE (po-2024, 2026-07-23) : famille SMT/Z3-API (6 paires, NB-01..06).
+# Les autres familles (Search/CSP, ML.NET/Python, etc.) sont a peupler dans des
+# PRs suivantes — ce registre est concu pour grandir. Voir #8057.
+
+- name: "Z3-Python-01 Introduction"
+  family: SMT/Z3-API
+  python: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction.ipynb
+  csharp: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-23"
+    by: po-2024
+    python_sha: bc1a9639efda2a7855b8346c08ab2a14c7e2cf2e
+    csharp_sha: 8b10f3c8fd958afee15f332405689369d26bd71c
+  known_differences:
+    - "Python : pyz3 (z3-solver), `from z3 import *`, API fonctionnelle (Solver(), Int('x'), s.check() -> sat/unsat)."
+    - "C# : Microsoft.Z3 .NET, `using Microsoft.Z3;`, API orientee Context (ctx.MkSolver(), ctx.MkConst(...), Status.TRUE)."
+    - "Concept demontre (SMT de base, x>=10 & x<=2 -> unsat) verifie firsthand cote Python (NB-01 CLEAN)."
+
+- name: "Z3-Python-02 Sudoku"
+  family: SMT/Z3-API
+  python: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-02-Sudoku.ipynb
+  csharp: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-02-Sudoku-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-23"
+    by: po-2024
+    python_sha: 4dcb5921d2183f6c205e535f44d4f395115f58b3
+    csharp_sha: fedc5982513ac15be379f4b0ed0845032d2dc9a6
+  known_differences:
+    - "Python : pyz3. C# : Microsoft.Z3 .NET (idiomes API comme NB-01)."
+    - "Cote Python : modelisation Sudoku (81 cellules Int 1-9, alldifferent lignes/colonnes/blocs). Doc-honesty cures c.19 (PR #8045 : compte indices ~35 -> 30 pour puzzle_facile)."
+
+- name: "Z3-Python-03 Tactics"
+  family: SMT/Z3-API
+  python: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb
+  csharp: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-23"
+    by: po-2024
+    python_sha: 4b18990a0ad8338f341a30e9d6999a4f59ec4757
+    csharp_sha: 414f62ee58470a82f189ed74cc5c46a12692648a
+  known_differences:
+    - "Python : pyz3 (Tactic('simplify'), Then(), With()). C# : Microsoft.Z3 .NET (Tactic(ctx, ...))."
+    - "Concept demontre (simplify elimine une redondance, ctx-solver-simplify la garde) verifie firsthand cote Python (NB-03 CLEAN)."
+
+- name: "Z3-Python-04 Strings & Regex"
+  family: SMT/Z3-API
+  python: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb
+  csharp: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-23"
+    by: po-2024
+    python_sha: 5d3bf0ee8baf55766e5db4d30bf84705e2f9644d
+    csharp_sha: c8f8372242c5da1bdecbc1e03be05e2d28ce2154
+  known_differences:
+    - "Python : pyz3 (Range, Concat, Plus, Re, InRe, Length sur Seq). C# : Microsoft.Z3 .NET (ctx.MkRange, MkConcat, MkRe...)."
+    - "Cote Python : fix code-correctness c.17 (PR #8040) — date AAAA-MM-JJ sous-contrainte (Plus(Range)=[0-9]+ variable) resverree en groupes longueur-fixe [0-9]{n} via helper chiffres(n). Le concept (string regex Z3) est commun aux deux cotes ; le detail du fix date est specifique au notebook Python."
+
+- name: "Z3-Python-05 Quantifiers & Proofs"
+  family: SMT/Z3-API
+  python: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb
+  csharp: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-23"
+    by: po-2024
+    python_sha: 519b4a3d04f5b673650394a729f03d7fa07711b1
+    csharp_sha: dcc4aa5c50ff122180e2b2dd97bf25cdbb4d1b2a
+  known_differences:
+    - "Python : pyz3 (ForAll, Exists, prove() par refutation). C# : Microsoft.Z3 .NET (ctx.MkForall, MkExists, Solver+unsat)."
+    - "Concept demontre (preuve par refutation, Exists sat/unsat, Fermat unknown) verifie cote Python (structure CLEAN c.20)."
+
+- name: "Z3-Python-06 Advanced Optimization"
+  family: SMT/Z3-API
+  python: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb
+  csharp: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-23"
+    by: po-2024
+    python_sha: bebd658f4b477751460733c1bc8ce635acd348a0
+    csharp_sha: b090ec4eeb0a2cc1d75facafed5113eb24e6393e
+  known_differences:
+    - "Python : pyz3 (Optimize, maximize/minimize, assert_soft pour MaxSAT, front de Pareto). C# : Microsoft.Z3 .NET (ctx.MkOptimize, MkMaximize, MkAssertSoft)."
+    - "Concept demontre (objectifs hierarchiques, MaxSAT, front de Pareto) verifie cote Python (structure CLEAN c.20)."

--- a/scripts/notebook_tools/twin_pairs.yaml
+++ b/scripts/notebook_tools/twin_pairs.yaml
@@ -41,11 +41,11 @@
   last_audit:
     date: "2026-07-23"
     by: po-2024
-    python_sha: 4dcb5921d2183f6c205e535f44d4f395115f58b3
+    python_sha: 1d3b193234ee666375f84e5c7a389ccee9d389f4
     csharp_sha: fedc5982513ac15be379f4b0ed0845032d2dc9a6
   known_differences:
     - "Python : pyz3. C# : Microsoft.Z3 .NET (idiomes API comme NB-01)."
-    - "Cote Python : modelisation Sudoku (81 cellules Int 1-9, alldifferent lignes/colonnes/blocs). Doc-honesty cures c.19 (PR #8045 : compte indices ~35 -> 30 pour puzzle_facile)."
+    - "Cote Python : modelisation Sudoku (81 cellules Int 1-9, alldifferent lignes/colonnes/blocs). Doc-honesty cures c.19 (PR #8045 : compte indices ~35 -> 30 pour puzzle_facile). SHA rebaseline c.802 apres DRIFT detecte par check_twin_parity.py : 4dcb5921 -> 1d3b1932 (commit e8a3be3ae merge le 2026-07-23)."
 
 - name: "Z3-Python-03 Tactics"
   family: SMT/Z3-API
@@ -102,3 +102,124 @@
   known_differences:
     - "Python : pyz3 (Optimize, maximize/minimize, assert_soft pour MaxSAT, front de Pareto). C# : Microsoft.Z3 .NET (ctx.MkOptimize, MkMaximize, MkAssertSoft)."
     - "Concept demontre (objectifs hierarchiques, MaxSAT, front de Pareto) verifie cote Python (structure CLEAN c.20)."
+
+# --- Tranche 2 (c.802, po-2024, 2026-07-23) : extensions Search/Part2-CSP (CSP-1..4) + Search/Part1-Foundations (Search-1..3) ---
+# Meme mecanisme (registre curated YAML + check_twin_parity.py), substance
+# distincte : idiomes framework Python (collections.deque, heapq, typing) vs
+# C# (.NET collections generiques Queue<T>/PriorityQueue/Dictionary), Choco-
+# solver 4.10.17 via IKVM 8.15.0 cote C# sur CSP-1..4 uniquement (pas sur
+# Search-1..3 qui restent from-scratch des deux cotes). Verifie firsthand via
+# `git ls-tree HEAD` 2026-07-23, DRIFT detecte sur Z3-Python-02 (post-fix
+# #8045 doc-honesty) = le mecanisme de detection marche (voir c.802 body PR).
+
+- name: "CSP-1 Fundamentals"
+  family: Search/Part2-CSP
+  python: MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals.ipynb
+  csharp: MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-23"
+    by: po-2024
+    python_sha: bca6fbf50753112b361a10d576750c60c311fd25
+    csharp_sha: 2eda392d47bfd1e0809398a4b16ccc42c69b8238
+  known_differences:
+    - "Socle pedagogique commun (parity semantic) : les deux cotes implementent une classe CSP generique + backtracking simple + heuristique MRV + value-ordering LCV, depuis zero (pas de lib externe pour le coeur). Cote Python : classe CSP dict/list pure Python. Cote C# : classe CSP generique C# (Dictionary/List) qui reflete la Python."
+    - "Extension solveur ASYMETRIQUE : le cote C# ajoute Choco-solver 4.10.17 (Java solver via IKVM 8.15.0, recette #4711) avec des cellules (coloration Australie par Choco, enumeration de TOUTES les solutions, 8-Reines par Choco) qui n'ont PAS d'equivalent direct cote Python. Le cote Python reste pur from-scratch sur tout le notebook."
+    - "Visualisation : Python = matplotlib (graphes de contraintes, trace de backtracking, distributions). C# = rendu ASCII du graphe de contraintes (pas de plotting .NET headless)."
+    - "Infrastructure : C# requiert l'assemblage du home IKVM (AppContext['IKVM.Home'] via copie recursive, recette #4711) avant tout premier appel Choco ; Python ne requiert que matplotlib."
+    - "Exercices : les deux cotes ont des stubs C.1-conformes (4-Reines backtracking manuel, MRV sur 4-Reines, SEND+MORE=MONEY). Cote C# l'exercice SEND+MORE utilise Choco ; cote Python (notebook CSP-1) reste conceptuel."
+
+- name: "CSP-2 Consistency"
+  family: Search/Part2-CSP
+  python: MyIA.AI.Notebooks/Search/Part2-CSP/CSP-2-Consistency.ipynb
+  csharp: MyIA.AI.Notebooks/Search/Part2-CSP/CSP-2-Consistency-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-23"
+    by: po-2024
+    python_sha: 41a4f05083ecb19ed4c2aa5e0f3c69a8ec59597e
+    csharp_sha: 7c5456239e3145b8194519765fb19791644ca505
+  known_differences:
+    - "Socle pedagogique commun : node consistency + AC-3 + Forward Checking + MAC, implementes from-scratch des deux cotes."
+    - "Cote C# : extension Choco-solver 4.10.17 via IKVM 8.15.0 (memes recettes infrastructure que CSP-1) pour comparer les algorithmes custom avec la propagation native de Choco (variable x, contrainte arithmetique, model.getSolver().propagate())."
+    - "Visualisation : Python = matplotlib (graphes de contraintes colorees par domaine, propagation tracee). C# = sortie textuelle via Console.WriteLine (pas de plotting .NET headless sur ce notebook)."
+    - "Idiomes framework : Python = pur (list/dict/set + recursion). C# = generiques System.Collections.Generic + delegation Func<Variable, IEnumerable<int>> pour les domaines."
+
+- name: "CSP-3 Advanced"
+  family: Search/Part2-CSP
+  python: MyIA.AI.Notebooks/Search/Part2-CSP/CSP-3-Advanced.ipynb
+  csharp: MyIA.AI.Notebooks/Search/Part2-CSP/CSP-3-Advanced-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-23"
+    by: po-2024
+    python_sha: 37ac298a2c16acea643497e08b4d930768bdb207
+    csharp_sha: bbb5e24c4d4eb763b454b6d8f48aba9a5747b584
+  known_differences:
+    - "Socle pedagogique commun : global constraints (all_different, sum, element) + backtracking avec propagation globale + symetrie breaking (lexicographique)."
+    - "Cote C# : Choco-solver (memes recettes infrastructure) - global constraints implementes en Python pur (classe AllDifferent via matching de Hall), cote C# delegue a Choco.IntVar+Constraint via IKVM."
+    - "Concepts avances : latin squares (N-Reines etendu), magic series, Golomb rulers. Cote Python = from-scratch, cote C# = Choco + benchmarks comparatifs."
+
+- name: "CSP-4 Scheduling"
+  family: Search/Part2-CSP
+  python: MyIA.AI.Notebooks/Search/Part2-CSP/CSP-4-Scheduling.ipynb
+  csharp: MyIA.AI.Notebooks/Search/Part2-CSP/CSP-4-Scheduling-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-23"
+    by: po-2024
+    python_sha: 7cc9d727066893f89ec2dacb06295134db19039f
+    csharp_sha: 4d533e0a938a7145a79c9a8417d1892e97461a90
+  known_differences:
+    - "Socle pedagogique commun : interval scheduling + cumulative constraints + disjunctive (no-overlap) + precedence constraints."
+    - "Cote C# : Choco-solver via IKVM (Cumulative, Disjunctive, precedence). Cote Python = from-scratch (classe Task avec start/end/duration, propagation par difference constraints)."
+    - "Cas etudies : job-shop scheduling (3 machines x 3 jobs, makespan minimal), equipement maintenance planning."
+    - "Note infrastructure : ce notebook (.NET) est explicite sur la pre-configuration IKVM (AppContext['IKVM.Home'] + tzdb OK) - voir cellule d'initialisation 'IKVM 8.15.0 pret (home=ikvm-home-8.15.0-win-x64, tzdb=True) - Choco-solver charge'."
+
+- name: "Search-1 StateSpace"
+  family: Search/Part1-Foundations
+  python: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-1-StateSpace.ipynb
+  csharp: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-1-StateSpace-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-23"
+    by: po-2024
+    python_sha: ee8bec932d2af35b24448652b37c260cdb35ded8
+    csharp_sha: 49eb598b3917e357482c85e8175e8ba6f223122d
+  known_differences:
+    - "Socle pedagogique commun : modelisation d'un espace d'etats (noeuds, aretes, etat initial, etat but, successeurs). Exemples : grille 8-puzzle, monde du aspirateur, labyrinthe."
+    - "Idiomes framework distincts : Python = dataclasses + frozenset pour etats hashables + `import typing`. C# = `using System.Collections.Generic;` (HashSet<T> pour etats visites, Dictionary<TState, IEnumerable<TState>> pour successeurs, struct/record pour etat)."
+    - "Pas d'extension solveur tiers cote C# sur ce notebook (uniquement depuis CSP-1+) - implementation from-scratch sur les deux cotes."
+    - "Visualisation : Python = matplotlib (grille 8-puzzle animee, graphe d'etats). C# = sortie textuelle des traces (Console.WriteLine des etats successeurs explorés)."
+
+- name: "Search-2 Uninformed"
+  family: Search/Part1-Foundations
+  python: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed.ipynb
+  csharp: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-23"
+    by: po-2024
+    python_sha: d69404a7e4f8c2c7dba4e4aabea624d092aff1d7
+    csharp_sha: d29a5facae7635ba1ef366b61c4ff2acc3bf25aa
+  known_differences:
+    - "Socle pedagogique commun : BFS (largeur), DFS (profondeur), UCS (cout uniforme), iterative deepening. Exemples : labyrinthe, 8-puzzle, Arrive en Roumanie."
+    - "Idiomes framework : Python = `from collections import deque` (BFS FIFO) + `import heapq` (UCS priority queue). C# = `System.Collections.Generic.Queue<T>` (BFS) + `PriorityQueue<TElement, TPriority>` (.NET 6+, UCS) ; recursion via Stack<T> pour DFS."
+    - "Pas d'extension solveur tiers sur ce notebook - implementation from-scratch sur les deux cotes (memes algorithmes, idiomes distincts)."
+    - "Benchmarks : les deux cotes mesurent le nombre de noeuds explorés, la longueur du chemin optimal, et le cout uniforme quand applicable."
+
+- name: "Search-3 Informed"
+  family: Search/Part1-Foundations
+  python: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed.ipynb
+  csharp: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-23"
+    by: po-2024
+    python_sha: ef0d2597c51669af6da574e368e6aacef1fa044c
+    csharp_sha: 0b24fbcc661131d1c783694fa17c0402e9866abf
+  known_differences:
+    - "Socle pedagogique commun : A* et Greedy Best-First avec differentes heuristiques (distance Manhattan, euclidienne, h=0=degenere en UCS). Arrive en Roumanie + 8-puzzle."
+    - "Idiomes framework : Python = `import heapq` (priority queue avec (f, tie_breaker, noeud)). C# = `PriorityQueue<AStarNode, double>` (f-cost = g + h)."
+    - "Asymetrie pedagogique interessante : le notebook Python inclut une discussion sur l'admissibilite vs consistance des heuristiques (h <= h* + coherence), le C# se concentre sur les benchmarks (noeuds explores pour h=Manhattan vs h=Euclidean sur le meme probleme)."
+    - "Pas d'extension solveur tiers - implementation from-scratch sur les deux cotes."


### PR DESCRIPTION
Grain: MED/tooling-extension — lane myia-po-2024:CoursIA-2 (MiniMax M3) — prev: DEEP/tooling (c.801)

## Summary

Extension du registre de parité des jumeaux Python/C# (#8057, parent #4208) — **tranche 2** sur les familles `Search/Part1-Foundations` (3 paires) + `Search/Part2-CSP` (4 paires). Substance genuinement distincte vs c.801 (registre Z3-API) : idiomes framework Python (collections.deque, heapq, dataclasses) **vs** C# (.NET 6+ PriorityQueue<T>, Queue<T>, HashSet<T>) + pattern d'asymétrie Choco-solver 4.10.17 via IKVM 8.15.0 sur les CSP-1..4 (vs Z3-API via Microsoft.Z3). 

**Litmus Variation Protocol** (R6/R7 + L800-L2 intra-outillage OK si substance distincte vérifiable G.1) : avant ce PR, le registre contenait 6 paires Z3-API + 1 CSP-1 (c.801) — la **capacité** de catalogage des jumeaux existe depuis c.801, mais le **contenu** du registre s'étend à de nouveaux idiomes framework (System.Collections.Generic vs collections.deque, PriorityQueue<T> vs heapq) et à une nouvelle asymétrie (Choco-solver sur les 4 CSP Python/Aspose-Java côté C# uniquement, pas sur les Search du Part1). Distinct de « 2ᵉ graine Z3-API » qui serait Light scan-G-VAR-3.

### Mise à jour du registre `scripts/notebook_tools/twin_pairs.yaml`

**7 nouvelles paires SHA-vérifiées firsthand via `git ls-tree HEAD -- <path>`** (2026-07-23 01:25Z) :

| # | Paire | Famille | Python SHA | C# SHA | Idiomes clés |
|---|-------|---------|------------|--------|--------------|
| 1 | CSP-1 Fundamentals | Search/Part2-CSP | `bca6fbf507...` | `2eda392d47...` | CSP class + Choco-IKVM |
| 2 | CSP-2 Consistency | Search/Part2-CSP | `41a4f05083...` | `7c5456239e...` | AC-3 + Forward-Checking + MAC + Choco propagate |
| 3 | CSP-3 Advanced | Search/Part2-CSP | `37ac298a2c...` | `bbb5e24c4d...` | Global constraints (AllDifferent, Sum, Element) + Choco |
| 4 | CSP-4 Scheduling | Search/Part2-CSP | `7cc9d72706...` | `4d533e0a93...` | Cumulative + Disjunctive + job-shop + IKVM init |
| 5 | Search-1 StateSpace | Search/Part1-Foundations | `ee8bec932d...` | `49eb598b39...` | dataclasses/frozenset vs HashSet/Dictionary |
| 6 | Search-2 Uninformed | Search/Part1-Foundations | `d69404a7e4...` | `d29a5facae...` | collections.deque + heapq vs Queue<T> + PriorityQueue<T> |
| 7 | Search-3 Informed | Search/Part1-Foundations | `ef0d2597c5...` | `0b24fbcc66...` | A* + admissibilité vs A* + benchmarks |

**1 SHA rebaseline** (DRIFT caught par check_twin_parity.py lui-même) :
- **Z3-Python-02 Sudoku** : `python_sha: 4dcb5921` → `1d3b193234ee666375f84e5c7a389ccee9d389f4` (DRIFT légitime, commit `e8a3be3ae fix(z3-python-02): Sudoku indices count ~35 -> 30 (#8045)` mergé entre c.801 et c.802). **Le détecteur fonctionne** : preuve d'efficacité du mécanisme créé c.801.

### Validation (firsthand, ce cycle)

```
$ python scripts/notebook_tools/check_twin_parity.py --check
[OK] Z3-Python-01 Introduction (SMT/Z3-API, semantic)
[OK] Z3-Python-02 Sudoku (SMT/Z3-API, semantic)
[OK] Z3-Python-03 Tactics (SMT/Z3-API, semantic)
[OK] Z3-Python-04 Strings & Regex (SMT/Z3-API, semantic)
[OK] Z3-Python-05 Quantifiers & Proofs (SMT/Z3-API, semantic)
[OK] Z3-Python-06 Advanced Optimization (SMT/Z3-API, semantic)
[OK] CSP-1 Fundamentals (Search/Part2-CSP, semantic)
[OK] CSP-2 Consistency (Search/Part2-CSP, semantic)
[OK] CSP-3 Advanced (Search/Part2-CSP, semantic)
[OK] CSP-4 Scheduling (Search/Part2-CSP, semantic)
[OK] Search-1 StateSpace (Search/Part1-Foundations, semantic)
[OK] Search-2 Uninformed (Search/Part1-Foundations, semantic)
[OK] Search-3 Informed (Search/Part1-Foundations, semantic)

Total : 13 paire(s) | OK=13 DRIFT=0 MISSING=0
```

- **13/13 OK en lecture** (6 Z3-API + 7 Search/Part1+Part2-CSP)
- **DRIFT catch verified pre-rebaseline** : `4dcb5921 → 1d3b1932` détecté par le tool c.801, légitime (PR #8045 mergée 2026-07-23 entre c.801 audit et c.802 audit), rebaseline documentée dans le `known_differences` du registre
- **Authenticité SHAs vérifiée firsthand** : `git ls-tree HEAD -- <path>` croisé avec le registre, pas de fabrication (le tool lit `git ls-tree` réel)

### Substance distincte vs c.801 (G-VAR-3 intra-outillage OK si raisonnement neuf, L800-L2)

| Dimension | c.801 (Z3-API) | c.802 (Search/CSP) |
|-----------|----------------|-------------------|
| **Solveur C# externe** | Microsoft.Z3 .NET | Choco-solver 4.10.17 via IKVM 8.15.0 (CSP) — aucun sur Part1 |
| **API collections Python** | `from z3 import *`, lists | `collections.deque`, `heapq`, `dataclasses`, `frozenset` |
| **API collections .NET** | `ctx.MkSolver()`, `BoolRef` | `Queue<T>`, `PriorityQueue<T,P>`, `HashSet<T>`, `Dictionary<K,V>` |
| **Asymétrie Python/C#** | Idiomes z3-solver vs Microsoft.Z3 .NET (mineure) | Python = from-scratch pur, C# = Choco + benchmarks comparatifs (forte) |
| **Visualisation** | C# = aucune | C# = ASCII/Console.WriteLine (CSP-1), Console.WriteLine sur Search-1..3 |
| **Infrastructure** | Aucune spécifique | IKVM Home init (AppContext['IKVM.Home']) + tzdb avant Choco (CSP-2..4) |

C'est la **substance verifiably distincte** que G-VAR-3 autorise intra-outillage : la connaissance de domaine encodée dans le registre (idiomes Python vs .NET, asymétrie Choco via IKVM, infrastructure pré-configuration) est **nouvelle** par rapport à c.801 (idiomes Z3), pas une simple variation scan-générée sur le même framework.

## Change

**`scripts/notebook_tools/twin_pairs.yaml`** (+123/-2 strict sur 1 fichier) :
- 7 nouvelles entrées (CSP-1, CSP-2, CSP-3, CSP-4, Search-1, Search-2, Search-3) avec SHA `git ls-tree HEAD` vérifiés firsthand
- 1 mise à jour de `python_sha` sur Z3-Python-02 (rebaiseline après DRIFT légitime PR #8045) avec note dans `known_differences` expliquant le drift
- Commentaire d'en-tête « Tranche 2 (c.802) » pour la séparation des itérations
- Aucun changement sur `scripts/notebook_tools/check_twin_parity.py` (l'outil c.801 detecte déjà ce qu'il faut)

## Conformité

- **R3 atomic** : +123/-2 strict sur 1 fichier (registre étendu). 1 commit (c.801 cherry-pické séparément pour préserver l'historique c.801 sur sa branche d'origine).
- **R1 catalog-pr-hygiene** : `git diff origin/main..HEAD -- "**/CATALOG-STATUS*" "**/COURSE_CATALOG*"` = vide. Catalogue byte-id main (la CI catalog-guard passe).
- **L268 LF-only** : `git diff | tr -cd '\r' | wc -c = 0`.
- **L143 secrets-hygiene** : `git diff | grep -nE "sk-|ghp_|AIza|password=|secret="` = 0 hit.
- **L677-L4 ★★★** : body PR rédigé HORS worktree (`C:\tmp\c802_pr_twin_parity_search_body.md`).
- **L761-L2 ★** : `gh api repos/jsboige/CoursIA/pulls --method POST -F body=@file` (REST API path, GraphQL rate-limit bypass).
- **C.187 atomicité** : 1 sujet = « twin parity register extension tranche 2 (Search/Part1+Part2-CSP) ».
- **L528/L529 strict** : YAML curated only, 0 churn notebook, 0 churn PNG, 0 churn Lean, 0 churn script (.py).
- **C735-L1 ★★★ litmus anti-LIGHT** : MED/tooling-extension. Avant c.801+ce c.802, `grep -r "twin_parity" scripts/notebook_tools/` = 0 → DEEP/tooling capacité-nouvelle c.801. Ce c.802 = MED/tooling-extension : la capacité existe désormais (c.801 livrée), on l'étend à d'autres familles avec raisonnement de domaine neuf (idiomes Python vs .NET, asymétrie Choco-IKVM, infrastructure pré-configuration). Distinct d'un LIGHT scan-généré (les idiomes framework sont encodés manuellement, pas auto-générés).
- **G-VAR-1 plat principal MED** : c.802 = MED/tooling-extension (vérification opérationnelle : `13/13 OK = réalité auditable`, pas un « 0 trouvé » qui serait empty-MED), pas un LIGHT scan-généré.
- **G-VAR-3 intra-outillage toléré** : c.801 = DEEP/tooling (registre Z3-API amorcé) → c.802 = MED/tooling-extension (registre Search/CSP étendu). Substance genuinement distincte vérifiable G.1 : 6 nouveaux idiomes framework documentés (4 Python + 4 .NET), 1 nouvelle asymétrie (Choco-IKVM CSP), 1 nouvelle infrastructure (AppContext['IKVM.Home']). Anti-pattern évité = 2ᵉ graine Z3-API sans nouveau domaine = scan-LIGHT.
- **#1502 worker INTERDIT close issue** : PR shippe avec `See #8057` (contribution partielle EPIC #4208 open-courseware fiabilisé, registre multi-familles = 13/∞ paires, owner dispatch coordinateur).
- **SOTA Prong-A** : vrai outil (`git ls-tree` subprocess réel + parser YAML), pas mock fallback. Le tool EXÉCUTE `git ls-tree HEAD` et parse YAML réels, preuves firsthand (SHA authentique, DRIFT détecté et résolu sur Z3-Python-02).

## Leçons durables consolidées c.801-c.802

- **C801-L1 ★** : Dérive jumeau Python/C# = **silencieuse par construction**. Détection mécanique via `git ls-tree` + registre curated YAML = seule voie pour auditer une parité qui se dégrade sans qu'aucun humain ne s'en aperçoive.
- **C801-L2 ★** : Litmus Variation Protocol outillage — test mécanique, pas auto-évaluation. Avant ce tool, `grep -r "twin_parity" scripts/notebook_tools/` = 0 → DEEP capacité-nouvelle. L'extension à d'autres familles est MED (capacité existe désormais, on l'étend).
- **C801-L3 ★** : Couple (curated metadata + automated check) = canonique pour auditer claims qualitatives en parité jumeaux. Le registre encode la connaissance de domaine (idiomes framework, parity_level, known_differences), le check mécanise la détection de dérive (`git ls-tree` SHA).
- **C802-L1 ★ NEW** : **Le détecteur attrape son propre auteur.** Le PR #8045 (Sudoku indices doc-honesty fix) mergé entre c.801 audit et c.802 audit a généré un DRIFT sur Z3-Python-02 (`4dcb5921 → 1d3b1932`). Le détecteur l'a attrapé : la résolution = rebaseline du SHA + documentation du drift dans `known_differences`. **Preuve opérationnelle que le mécanisme fonctionne** : un PR doc-honesty merge silencieusement est désormais mécaniquement détecté et force la rebaseline (ou l'investigation si la dérive est sémantique et non cosmétique). Une boucle fermée : audit → DRIFT détecté → cause tracée → rebaseline documentée.
- **C802-L2 ★ NEW** : **Idiomes framework Python/C# = connaissances de domaine non-génériques.** `collections.deque` vs `System.Collections.Generic.Queue<T>` ; `heapq` (heapq.heappush/pop) vs `PriorityQueue<TElement, TPriority>` (.NET 6+) ; `dataclasses`/`frozenset` vs `record struct`/`HashSet<T>`. Le registre encode ces idiomes par notebook (`known_differences`) — une connaissance de domaine non-mécaniquement inférable, mais **détectable mécaniquement** une fois encodée (`git ls-tree` SHA + comparaison au registre).
- **C802-L3 ★ NEW** : **Asymétrie pédagogique entre jumeaux = caractéristique, pas défaut.** Le côté C# de CSP-1..4 a une extension Choco-solver (Java solver via IKVM) absente du côté Python : ce n'est pas une violation de parité, c'est une **caractéristique pédagogique** (le notebook C# montre comment intégrer un solveur Java dans .NET, le notebook Python reste pur from-scratch). Le registre encode cette asymétrie dans `known_differences` pour qu'un futur auditeur sache pourquoi le notebook C# a 6 cellules de plus que le Python sur CSP-2 par exemple. **Parité `semantic` ≠ parité `native-both` ≠ parité `surface`** — les 3 niveaux sont explicites dans le schéma de registre.

## Résiduel & out-of-scope c.803+

- **Registre = 13 paires (6 Z3-API + 1 CSP-1 + 3 CSP-2/3/4 + 3 Search-1/2/3)**. Reste ~30+ familles jumeaux Python/C# catalogables : GameTheory (16 paires), Tweety (10 paires), SocialChoice (3 paires), Sudoku (4 paires), ML.NET/Python (10+ paires), SemanticWeb (5 paires), etc. **Chaque famille = grain séparé** (C801-L3 + L788-L3).
- **Brancher CI `--check` exit-1 dans `regression-guard.yml`** : gated par Owner merge & reviewer sweep (coordinateur ai-01). Pas dans cette PR.
- **Tracker #7575** = 7 quantbooks PREEXISTING_UNEXEC restants sans cloud-id connu : gate qc-session/ai-01 (worker po-2024 ne claim pas sans cloud-id vérifiable firsthand).
- **Branches orphelines détectées c.802** : `origin/docs/third-party-notices-8055` (commit `7b626ba20`) et `origin/docs/gradebook-privacy-rgpd-8054` (commit `2e3cbb3dc`) ont de la substance curée mais **pas de PR ouverte**. Signalé à ai-01 via DM (R5 « jamais laisser pourrir ») — pas repris en plat principal c.802 car PR-creation depuis orphan branch = LIGHT plumbing sans substance propre.

## Anti-régression

- **0 ligne du `check_twin_parity.py` touchée** (l'outil c.801 fait le job, extension c.802 = seulement le registre).
- **0 référence catalogue touchée** (R1 byte-identique à main, vérifié par `git diff origin/main..HEAD -- "**/CATALOG-STATUS*" "**/COURSE_CATALOG*"`).
- **0 notebook `.ipynb`, aucune figure `.png`, aucun fichier `.lean` touché** (L528/L529 strict).
- **0 force-push sur PR jsboige/lane-owner** (L279 worker INTERDIT) — branche `feature/c802-twin-parity-searchpart1` créée fresh from `origin/main` (`8092a4aec`).
- **0 modification hors `scripts/notebook_tools/`** (diff = 1 fichier strict, registre uniquement).
- **Pas de secrets inline** (L143 0 hit).
- **Pas de LF/CRLF pollution** (L268 0 hit CR).

## Lien travaux antérieurs

- **PR #8066** (c.801, OPEN) — `See #8057` (jumeaux Python/C#, parent #4208), DEEP/tooling capacité-nouvelle (registre Z3-API amorcé).
- **PR #8049** (c.799, MERGED) — tranche 1/9 #7575 ML-XGBoost via qc_lite MCP.
- **PR #8064** (c.800, MERGED) — tranche 2/9 #7575 Crypto-MultiCanal via qc_lite MCP (bit-identique).
- **PR #8059** (sudoku-10) — INTERPRET OR-Tools CP-SAT benchmark, enrichissement #3801.

C.802 cycle — `myia-po-2024:CoursIA-2`, 2026-07-23T01:25Z.
