### PR TITLE
ci(solution-leak,#8053): branch detect_solution_leaks in CI (HIGH delta guard, mirror #6314)

### DIFF
--- a/.github/workflows/solution-leak-guard.yml
+++ b/.github/workflows/solution-leak-guard.yml
@@ -1,0 +1,87 @@
+name: solution-leak-guard
+
+# Durable anti-regression guard for the "Exercice containing its solution" leak
+# vector (angle-mut #8053, content-based rule in exercise-example-labeling.md).
+# Fails a PR only when it INTRODUCES a new HIGH-severity solution leak vs its
+# base ref — inherited leaks (111 as of 2026-07, angle-mut #8053, drained
+# one-PR-per-notebook) are tolerated so the gate never freezes the cluster.
+# Mirror of the pip-leak-guard pattern (#6314).
+#
+# A HIGH finding = a cell titled "Exercice N" whose code is a complete working
+# solution instead of a stub (pass / print("Exercice a completer") / return None
+# / # TODO). MEDIUM (duplicate exercise numbering) and LOW are inventoried in
+# the step summary but never gate, per #8053 "WARN first, FAIL after cleanup".
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '**.ipynb'
+      - 'scripts/notebook_tools/detect_solution_leaks.py'
+      - 'scripts/notebook_tools/solution_leak_delta.py'
+      - '.github/workflows/solution-leak-guard.yml'
+  schedule:
+    # Weekly inventory of the inherited backlog (decay tracking). Friday ~09:17 UTC.
+    - cron: '17 9 * * 5'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: solution-leak-guard-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  solution-leak-delta:
+    name: "Solution-leak HIGH delta guard (#8053)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # base ref must be reachable for the BASE scan
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: HEAD scan (PR head)
+        run: |
+          python scripts/notebook_tools/detect_solution_leaks.py --scan-all --json > /tmp/head.json
+          python scripts/notebook_tools/detect_solution_leaks.py --scan-all > /tmp/head.txt
+
+      # Swap MyIA.AI.Notebooks/ to the PR base ref, scan, then restore. head.json
+      # is already captured above, so the swap cannot contaminate the delta.
+      - name: BASE scan (PR base ref)
+        if: github.event_name == 'pull_request'
+        run: |
+          git checkout ${{ github.event.pull_request.base.sha }} -- MyIA.AI.Notebooks
+          python scripts/notebook_tools/detect_solution_leaks.py --scan-all --json > /tmp/base.json
+          git checkout HEAD -- MyIA.AI.Notebooks
+
+      # Inventory posted to the run/PR check summary (WARN: never gates).
+      # Visible decay tracking of the inherited #8053 backlog (HIGH/MEDIUM counts).
+      - name: "Inventory (step summary, WARN — never gates)"
+        run: |
+          {
+            echo '## Solution-leak inventory (#8053)'
+            echo ''
+            echo 'HIGH (Exercice with its solution) = **priority cleanup** — drained one-PR-per-notebook.'
+            echo 'MEDIUM (duplicate exercise numbering) = cosmetic.'
+            echo ''
+            echo '```'
+            grep -E '^Results:|^Scanned:' /tmp/head.txt || true
+            echo ''
+            echo 'HIGH leaks (first 40):'
+            grep '\[HIGH\]' /tmp/head.txt | head -40 || true
+            echo ''
+            echo 'MEDIUM leaks (first 20):'
+            grep '\[MEDIUM\]' /tmp/head.txt | head -20 || true
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: "Fail if HIGH delta > 0 (new solution leaks introduced)"
+        if: github.event_name == 'pull_request'
+        run: python scripts/notebook_tools/solution_leak_delta.py /tmp/base.json /tmp/head.json

--- a/scripts/notebook_tools/detect_solution_leaks.py
+++ b/scripts/notebook_tools/detect_solution_leaks.py
@@ -307,6 +307,11 @@ def main():
     parser.add_argument("--scan-all", action="store_true", help="Scan all notebooks in repo")
     parser.add_argument("--check", action="store_true", help="Exit 1 if any HIGH findings")
     parser.add_argument("--verbose", action="store_true", help="Show all findings including LOW")
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit findings as a JSON array (for CI delta guard, cf solution_leak_delta.py)",
+    )
     args = parser.parse_args()
 
     repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -330,12 +335,22 @@ def main():
         parser.print_help()
         return 1
 
-    print(f"Scanning {len(notebooks)} notebooks...")
+    if not args.json:
+        print(f"Scanning {len(notebooks)} notebooks...")
 
     all_findings = []
     for nb_path in notebooks:
         findings = scan_notebook(nb_path)
         all_findings.extend(findings)
+
+    # Machine-readable output for CI delta guards (cf solution_leak_delta.py,
+    # mirror of pip_leak_delta.py). Emitted before any human-readable prose so
+    # downstream parsers can consume stdout verbatim.
+    if args.json:
+        import json as _json
+
+        print(_json.dumps(all_findings, ensure_ascii=False))
+        return 0
 
     high = [f for f in all_findings if f.get('severity') == 'HIGH']
     medium = [f for f in all_findings if f.get('severity') == 'MEDIUM']

--- a/scripts/notebook_tools/solution_leak_delta.py
+++ b/scripts/notebook_tools/solution_leak_delta.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Solution-leak HIGH delta guard — compare two ``detect_solution_leaks.py``
+JSON scans and fail if the PR introduces *new* HIGH-severity solution leaks
+(an Exercice cell containing its complete solution instead of a stub).
+
+Why a delta (not an absolute ``--check`` fail)
+---------------------------------------------
+``detect_solution_leaks.py --scan-all --check`` fails on ANY HIGH occurrence.
+The repo still carries 111 inherited HIGH leaks (angle-mut #8053, to be drained
+one-PR-per-notebook). An absolute gate would therefore block every PR that
+touches an inherited-leak notebook for an unrelated reason and freeze the whole
+cluster — the opposite of a useful rollout.
+
+The durable, non-blocking transposition is a **delta guard** (mirror of
+``pip_leak_delta.py`` / #6314): count HIGH occurrences on BASE (pull-request
+base) and HEAD (pull-request head), fail only when HEAD > BASE, i.e. when the PR
+*introduces* new leaks. Existing leaks are tolerated (inventoried in the CI step
+summary); regressions are not. When the inherited backlog is drained, the gate
+becomes a strict absolute fail naturally — realising #8053's "WARN first, FAIL
+after cleanup" without a mode switch.
+
+Usage
+-----
+Typically driven by ``.github/workflows/solution-leak-guard.yml`` which produces
+the two JSON files via two ``--scan-all --json`` runs (swapping
+``MyIA.AI.Notebooks/`` between base and head with ``git checkout``)::
+
+    python scripts/notebook_tools/detect_solution_leaks.py --scan-all --json > head.json
+    git checkout baseref -- MyIA.AI.Notebooks
+    python scripts/notebook_tools/detect_solution_leaks.py --scan-all --json > base.json
+    git checkout HEAD -- MyIA.AI.Notebooks
+    python scripts/notebook_tools/solution_leak_delta.py base.json head.json
+
+Standalone (local, no git): the two JSON files may be produced by any means.
+
+Exit codes: 0 = no new HIGH leaks ; 1 = HEAD introduces HIGH delta > 0 ; 2 = IO
+or JSON error.
+
+See #8053 (CI branch of the detector), #6314 (pip-leak mirror pattern),
+exercise-example-labeling.md (content-based Exemple/Exercice rule).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def high_keys(data):
+    """Yield stable identifiers ``(path, cell_index)`` for every HIGH finding.
+
+    A finding is matched on (path, cell_index) so that editing the prose of an
+    already-leaking cell does NOT register as a regression — only a genuinely
+    new leak (new cell or new notebook) does. ``path`` is normalised to
+    forward slashes for cross-platform stability (Windows runs emit ``\\``).
+    """
+    for f in data:
+        if f.get("severity") != "HIGH":
+            continue
+        path = str(f.get("path", "?")).replace("\\", "/")
+        yield (path, f.get("cell_index"))
+
+
+def count_high(data):
+    return sum(1 for _ in high_keys(data))
+
+
+def high_by_path(data):
+    """map(path -> sorted list of cell_index) for HIGH findings."""
+    by: dict[str, list] = {}
+    for path, idx in high_keys(data):
+        by.setdefault(path, []).append(idx)
+    for cells in by.values():
+        cells.sort()
+    return by
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Fail if HEAD introduces new HIGH solution leaks vs BASE."
+    )
+    parser.add_argument("base", help="BASE JSON (detect_solution_leaks.py --json)")
+    parser.add_argument("head", help="HEAD JSON (detect_solution_leaks.py --json)")
+    args = parser.parse_args(argv)
+
+    try:
+        with open(args.base, encoding="utf-8") as fh:
+            base = json.load(fh)
+        with open(args.head, encoding="utf-8") as fh:
+            head = json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"error: cannot read JSON inputs: {exc}", file=sys.stderr)
+        return 2
+
+    base_n = count_high(base)
+    head_n = count_high(head)
+    delta = head_n - base_n
+
+    print(f"solution-leak guard: BASE HIGH={base_n}  HEAD HIGH={head_n}  delta={delta:+d}")
+
+    if delta <= 0:
+        print(
+            "OK: no new HIGH solution leaks introduced "
+            f"(inherited {head_n} tolerated, angle-mut #8053, drained one-PR-per-notebook)."
+        )
+        return 0
+
+    # Report which notebooks gained HIGH occurrences (new or worsened).
+    base_by = high_by_path(base)
+    head_by = high_by_path(head)
+    print(
+        f"FAIL: PR introduces {delta} new HIGH-severity solution leak(s) "
+        "(an Exercice cell containing its complete solution). Stub it per "
+        "exercise-example-labeling.md (pass / print('Exercice a completer') / "
+        "return None / # TODO — never raise NotImplementedError, cf regle C.1).",
+        file=sys.stderr,
+    )
+    print("Newly-leaking / worsened notebooks:", file=sys.stderr)
+    for path, cells in sorted(head_by.items()):
+        prev = len(base_by.get(path, []))
+        if len(cells) > prev:
+            print(f"  +{len(cells) - prev}  {path}  (cells {cells})", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/notebook_tools/tests/test_solution_leak_delta.py
+++ b/scripts/notebook_tools/tests/test_solution_leak_delta.py
@@ -1,0 +1,84 @@
+"""Tests for scripts/notebook_tools/solution_leak_delta.py — HIGH delta guard.
+
+Mirrors the contract of pip_leak_delta.py: exit 0 when HEAD introduces no new
+HIGH solution leaks vs BASE, exit 1 on a positive HIGH delta, exit 2 on IO/JSON
+error. Findings are matched on (normalised path, cell_index) so editing the prose
+of an already-leaking cell is not a false regression.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import solution_leak_delta as delta
+
+
+def _finding(path, severity, cell_index):
+    return {"path": path, "severity": severity, "cell_index": cell_index, "message": "x"}
+
+
+def _write(path: Path, findings):
+    path.write_text(json.dumps(findings), encoding="utf-8")
+    return path
+
+
+def test_count_high_ignores_medium_and_low():
+    data = [
+        _finding("a.ipynb", "HIGH", 3),
+        _finding("a.ipynb", "MEDIUM", 4),
+        _finding("b.ipynb", "LOW", 1),
+        _finding("c.ipynb", "HIGH", 0),
+    ]
+    assert delta.count_high(data) == 2
+
+
+def test_high_keys_normalises_backslashes():
+    data = [_finding("dir\\nb.ipynb", "HIGH", 7)]
+    keys = list(delta.high_keys(data))
+    assert keys == [("dir/nb.ipynb", 7)]
+
+
+def test_no_delta_exits_zero(tmp_path, capsys):
+    findings = [_finding("a.ipynb", "HIGH", 1), _finding("a.ipynb", "HIGH", 2)]
+    base = _write(tmp_path / "base.json", findings)
+    head = _write(tmp_path / "head.json", findings)
+    rc = delta.main([str(base), str(head)])
+    assert rc == 0
+    assert "delta=+0" in capsys.readouterr().out
+
+
+def test_positive_delta_exits_one(tmp_path, capsys):
+    base = _write(tmp_path / "base.json", [_finding("a.ipynb", "HIGH", 1)])
+    head = _write(
+        tmp_path / "head.json",
+        [_finding("a.ipynb", "HIGH", 1), _finding("b.ipynb", "HIGH", 5)],
+    )
+    rc = delta.main([str(base), str(head)])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "delta=+1" in err or "+1" in err
+    assert "b.ipynb" in err  # the worsened notebook is reported
+
+
+def test_decreasing_delta_exits_zero(tmp_path):
+    # HEAD has fewer HIGH than BASE (cleanup) — not a regression.
+    base = _write(
+        tmp_path / "base.json", [_finding("a.ipynb", "HIGH", 1), _finding("b.ipynb", "HIGH", 2)]
+    )
+    head = _write(tmp_path / "head.json", [_finding("a.ipynb", "HIGH", 1)])
+    assert delta.main([str(base), str(head)]) == 0
+
+
+def test_missing_file_exits_two(tmp_path):
+    rc = delta.main([str(tmp_path / "nope.json"), str(tmp_path / "nope2.json")])
+    assert rc == 2
+
+
+def test_invalid_json_exits_two(tmp_path):
+    bad = tmp_path / "bad.json"
+    bad.write_text("not json", encoding="utf-8")
+    ok = _write(tmp_path / "ok.json", [])
+    assert delta.main([str(bad), str(ok)]) == 2


### PR DESCRIPTION
## Summary

The solution-leak detector ([`detect_solution_leaks.py`](scripts/notebook_tools/detect_solution_leaks.py), lignée #1214/#1336/#1344 + règle `exercise-example-labeling`) **existed but was NOT wired into any CI workflow** — exactly the gap flagged in #8053 (ré-audit externe ChatGPT 2026-07-22). The angle-mut « Exercice containing its solution » persisted undetected.

Firsthand scan on `origin/main`: **111 HIGH + 27 MEDIUM** solution leaks across the repo. (G.1 note: an initial `tail -25` scan masked the 111 HIGH by showing only the trailing MEDIUM lines — the full count drove the WARN-first design.)

## What this PR does

Wires the detector via a **durable HIGH-delta guard**, mirroring the proven [`pip-leak-guard`](.github/workflows/pip-leak-guard.yml) pattern (#6314):

| File | Change |
|------|--------|
| `detect_solution_leaks.py` | `+16/−1` — adds `--json` (machine-readable, additive). Pretty-print default unchanged. |
| `solution_leak_delta.py` (NEW) | Fail **only** when a PR introduces NEW HIGH leaks vs its base ref. The 111 inherited HIGH are tolerated (inventoried, not gated). |
| `.github/workflows/solution-leak-guard.yml` (NEW) | PR trigger + weekly cron. HEAD/BASE scans via `git checkout` swap, rich HIGH/MEDIUM inventory in `$GITHUB_STEP_SUMMARY`, delta gate on PR events. |
| `tests/test_solution_leak_delta.py` (NEW) | 7 tests. |

## Why a delta (not an absolute `--check` fail)

`detect_solution_leaks.py --scan-all --check` fails on ANY HIGH occurrence. With 111 inherited HIGH, an absolute gate would block every PR that touches an inherited-leak notebook for an unrelated reason and **freeze the whole cluster**. The delta guard tolerates the inherited backlog while blocking regressions — realising #8053's « WARN d'abord (inventaire), puis bascule FAIL une fois le backlog nettoyé » **without a mode switch**: when the backlog is drained (one-PR-per-notebook), the delta gate becomes a strict absolute fail naturally.

## Acceptance (#8053)

- [x] **Detector identified + wired in CI** — `detect_solution_leaks.py` (lignée #1214/#1336/#1344) + new `solution-leak-guard.yml`.
- [x] **Content-based rule** (cf `exercise-example-labeling.md`) — Exemple resolu cohabits legitimately; only Exercice + complete solution = HIGH.
- [x] **Anti-faux-positif** — a « Exemple guidé » résolu is never flagged (LOW severity, never gates); the detector distinguishes Exemple vs Exercice by the header regex.
- [x] **WARN first, FAIL after cleanup** — delta guard: inherited 111 tolerated (inventoried weekly), new HIGH fail immediately.

## Validation

- **49 existing `detect_solution_leaks` tests + 7 new `solution_leak_delta` tests = 56 passed.**
- **Full `scripts/notebook_tools` suite: 3231 passed, 3 skipped, 0 regression.**
- `--json` produces valid JSON (138 findings / 111 HIGH); delta script verified: exit 0 (no regression), exit 1 (regression caught, +N reported), exit 2 (IO/JSON error).
- YAML syntax valid (parsed).
- Catalogue byte-identical to `origin/main` (HARD 1). CRLF=0, no secrets inline. LF-normalised (origin/*.py are LF on main).

## Residual (tracked, not in scope)

- The **111 inherited HIGH** leaks are inventoried (weekly cron tracks decay) but not fixed here — drained one-PR-per-notebook per cluster convention, not a single mega-PR.
- MEDIUM (27 duplicate-numbering) never gates — cosmetic cleanup.

See #8053 (contribution partielle epic #4208 — l'epic reste ouverte). Lane po-2023 déclarée dans l'issue, mais non-claim + pool global (règle 5, cross-lane) — `[CLAIMED]` posé sur le dashboard workspace avant de coder.
