### PR TITLE
fix(catalog,#8050): exclude-always segment match (bin was excluding 5 GT-8)

### DIFF
--- a/scripts/notebook_tools/generate_catalog.py
+++ b/scripts/notebook_tools/generate_catalog.py
@@ -721,7 +721,7 @@ def scan_all_notebooks(
             if pedagogical and nb_path.stem.endswith("_executed"):
                 continue
             parts = nb_path.relative_to(series_dir).parts
-            if any(exc in part for part in parts for exc in EXCLUDE_ALWAYS):
+            if any(part in EXCLUDE_ALWAYS for part in parts):
                 continue
             if pedagogical and any(
                 exc in str(nb_path.relative_to(series_dir))


### PR DESCRIPTION
## Summary

`generate_catalog.py`'s `EXCLUDE_ALWAYS` exclusion was applied as a **substring** match (`exc in part`) instead of a **segment** match, so the token `"bin"` (meant to skip .NET build dirs) falsely matched **"Com-bin-atorial"** and excluded all 5 GT-8 CombinatorialGames notebooks from the generated catalog.

This is the root cause of the "5 GT-8 excluded with no matching rule" residual I documented in #8078.

## Root cause

`scripts/notebook_tools/generate_catalog.py` line 724 (pre-fix):

```python
parts = nb_path.relative_to(series_dir).parts
if any(exc in part for part in parts for exc in EXCLUDE_ALWAYS):   # SUBSTRING
    continue
```

`EXCLUDE_ALWAYS = {".ipynb_checkpoints", "obj", "bin", "__pycache__", ".git"}` — these are build/artifact **directory names**. The substring check `'bin' in 'GameTheory-8-CombinatorialGames.ipynb'` → `True` (index 16), so every GT-8 CombinatorialGames variant was silently dropped.

Note line 714 (`series_dir.name in EXCLUDE_ALWAYS`) was **already correct** (segment match on a single dir name) — only the per-path-part check at 724 was wrong.

## Fix

Segment match, mirroring the already-correct line 714:

```python
parts = nb_path.relative_to(series_dir).parts
if any(part in EXCLUDE_ALWAYS for part in parts):   # SEGMENT
    continue
```

The intent of `EXCLUDE_ALWAYS` is to skip path **segments** that are build dirs (`bin/`, `obj/`, `__pycache__/`), not notebook filenames containing those substrings.

`EXCLUDE_PEDAGOGICAL` substring match (lines 726-730) is **intentionally kept** — it must catch both `/research/` dirs AND `*_research.ipynb` filenames, which requires substring. Not changed.

## Verified impact (G.1/G.2 firsthand)

Regenerated catalog to a scratchpad dir (NOT committed — artifact belongs to automation per catalog-pr-hygiene HARD 1) and diffed paths vs origin/main's committed catalog:

- **Causal effect of this fix: +5, 0 removed** — the 5 GT-8 CombinatorialGames variants:
  - `GameTheory-8-CombinatorialGames.ipynb`
  - `GameTheory-8-CombinatorialGames-Csharp.ipynb`
  - `GameTheory-8b-Lean-CombinatorialGames.ipynb`
  - `GameTheory-8c-CombinatorialGames-Csharp.ipynb`
  - `GameTheory-8c-CombinatorialGames-Python.ipynb`
- Fresh regen shows **+7 total (832 → 837)**; the extra **+2** (Search `MGS-7c-RosenbrockGriewank`, `MGS-7d-MichalewiczDixonPrice`) are **newly-tracked since the last main-catalog cron regen** (PRs #8006/#7999), **NOT caused by this fix** — confirmed `OLD-excluded=False matches=[]` for those paths. The automation's next regen picks them up regardless.

## Resolves

- The open residual in #8078 §6 ("5 GT-8 excluded with no matching exclusion rule").

## Scope

- `See #8050` — **partial** delivery (this fixes the exclusion-rule bug, one axis of the catalog denominators reconciliation epic; denominators doc/convergence is broader).
- One-line surgical change, single file, catalog artifact byte-identical to main (not staged).

## Notes for reviewer

- This is a **code-correctness** fix to the catalog generator (genre ≠ the #8078 tooling-metadata doc) — the generated artifact itself stays byte-identical to main on this branch; the cron / catalog-drift CI will regenerate it (and pick up all 7 entries).
- Verify: `python scripts/notebook_tools/generate_catalog.py --check` before/after shows the +5 GT-8.

---
Co-Authored-By: Claude-Code <noreply@anthropic.com>