### PR TITLE
enrich(Probas/Infer): Infer-8 motivate WHY Expectation Propagation (vs exact inference)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb
@@ -1034,6 +1034,26 @@
   },
   {
    "cell_type": "markdown",
+   "id": "infer8-ep-motivation",
+   "metadata": {},
+   "source": [
+    "### Pourquoi EP ? Le coût de l'inférence exacte\n",
+    "\n",
+    "La note précédente dit que TrueSkill utilise EP plutôt que VMP — mais une question plus fondamentale reste en suspens : **pourquoi approximer l'inférence du tout ?** Pourquoi ne pas calculer le posterior *exact* des skills ?\n",
+    "\n",
+    "**Le problème vient du facteur `IsGreaterThan`.** Les priors et les facteurs de performance (`GaussianFromMeanAndVariance`) sont Gaussiens, donc conjugués : leur produit reste Gaussien. Mais la contrainte $\\text{perf}_1 > \\text{perf}_2$ **tronque** la Gaussienne (elle annule tout le demi-plan où le joueur 2 gagnerait). Le message qui en résulte n'est plus Gaussien : c'est une **Gaussienne cumulée** (une sigmoïde), et le posterior exact du skill est le produit d'une Gaussienne par cette sigmoïde — une courbe **asymétrique, non-Gaussienne**.\n",
+    "\n",
+    "- **Un posterior exact a trop de paramètres.** Une Gaussienne se résume à 2 nombres ($\\mu$, $\\sigma$). Le posterior exact (Gaussienne $\\times$ Gaussienne cumulée) nécessite **4 paramètres**. Or chaque match ajoute un tel facteur : après $k$ matchs, la représentation exacte du posterior accumule $2(k{+}1)$ paramètres. C'est **insoutenable** pour un système qui classe des millions de joueurs sur des milliers de matchs.\n",
+    "\n",
+    "**C'est là qu'intervient Expectation Propagation (EP).** Plutôt que de traîner un posterior exact de plus en plus complexe, EP **reprojette** le posterior sur une Gaussienne après chaque facteur (en *matchant les moments* — moyenne et variance). Le nombre de paramètres reste borné (toujours 2 par skill), au prix d'une approximation locale.\n",
+    "\n",
+    "> **Lecture du résultat cellule 12** : le posterior affiché `N(29.21, 7.19)` (skill du gagnant) **n'est pas** le posterior exact — c'est la *projection Gaussienne* calculée par EP. Le vrai posterior est légèrement asymétrique ; EP en capture la moyenne et la variance, ce qui suffit pour le matchmaking. C'est ce compromis précision/coût qui rend TrueSkill déployable à l'échelle d'Xbox Live.\n",
+    "\n",
+    "> **Lien avec MBML Ch.3** : cette motivation (explosion paramétrique de l'inférence exacte → nécessité d'EP) est développée en détail dans *Model-Based Machine Learning* (Winn & Bishop), chapitre « Meeting Your Match », dont cette série est distillée."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "ca5ef684",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
## Summary — audit #8081 finding (first pilot)

`Infer-8-TrueSkill` **uses** Expectation Propagation (EP) as its core inference algorithm (cells 11, 15) but never **motivates** it. cell[15] only compares EP-vs-VMP (intra-approximation). The deeper question — *why approximate inference at all?* — goes unanswered. This is the first concrete finding of audit **#8081** (distillation fidelity vs MBML Ch.3): a SOTA engine used without showing its necessity reads as gratuitous (#3801 Prong-B).

## What MBML Ch.3 makes explicit (and Infer-8 lost)

The chapter this series is distilled from — *Model-Based Machine Learning* (Winn & Bishop), « Meeting Your Match » — motivates EP explicitly:

1. The **IsGreaterThan** factor is **not conjugate** to Gaussians: it truncates the Gaussian (kills the half-plane where player 2 wins) → a **cumulative-Gaussian (sigmoid)** message. The exact posterior is an **asymmetric non-Gaussian** (Gaussian × cumulative-Gaussian).
2. An exact posterior needs **4 params** (vs 2 for a Gaussian); each match adds such a factor, so after $k$ matches the exact representation needs $2(k+1)$ params → **unsustainable** for a system ranking millions of players.
3. **EP** re-projects onto a Gaussian after each factor (moment matching), keeping a bounded 2-param-per-skill representation. **That is why EP exists.**

## Change (markdown-only, C.2 exception)

One markdown cell after cell[15], reading the committed posterior `N(29.21, 7.19)` (cell 13) as the **EP Gaussian projection** of a truly-asymmetric posterior — a precision/cost tradeoff that makes TrueSkill deployable at Xbox Live scale.

## Audit verdict for Infer-8 vs MBML Ch.3 (documented in #8081)

- **Largely FIDÈLE** on extensions: draws/draw-margin (§4), teams-as-sums (§6), multi-player ordering (§7), online learning (§5), tournoi simulé (§9) — these cover MBML Ch.3's neighbouring pages.
- **PERTE PAR COMPLAISANCE (this PR corrects it)**: EP motivation (why approximate vs exact) — the engine used without its necessity.
- **PERTE DOCUMENTÉE (legitimate pedagogical choice, not complaisance)**: the iterative *derivation* itself (convolution integral, generative-sampling viewpoint, conjugacy panel). A code-centred notebook presents the finished model rather than the MBML model-building dialogue — a deliberate genre choice, flagged for documentation not wholesale backfill.

## Validation (firsthand)

- `nbformat.validate` **OK**.
- Markdown-only → C.2 exception (no re-exec; prior code outputs unchanged).
- Diff: **20 insertions, 0 deletions** — pure addition, 1 file. 19 code cells untouched (execution_counts intact) → anti-regression clean.
- Convention preserved: `json.dumps(indent=1, ensure_ascii=False) + "\n"` == raw, 0 CRLF.
- UTF-8 French accents verified clean (round-trip tested — no mojibake). LaTeX verified (`\text{perf}_1 > \text{perf}_2`, no `\texttext` typo).
- Every claim grounded in MBML Ch.3 (fetched firsthand) + Infer-8's own committed values.

## Honnêteté

This is a *limited, targeted* finding — Infer-8 is a rich, largely faithful notebook, **not** a case of massive substance loss by complaisance. The audit shows the loss is real (EP motivation) but bounded. Nuance is the point of #8081.

See #8081. Co-Authored-By: Claude-Code <noreply@anthropic.com>