### PR TITLE
feat(catalog,#8051): c.764 editorial review registry substrate (phase 2 #4a)

### DIFF
--- a/docs/notebook-metadata/EDITORIAL_REVIEW_CARD.md
+++ b/docs/notebook-metadata/EDITORIAL_REVIEW_CARD.md
@@ -1,0 +1,93 @@
+# EDITORIAL_REVIEW_CARD — Template de revue éditoriale
+
+**Statut** : template canonique (c.764)
+**Usage** : copié/adapté par chaque reviewer qui ajoute une entrée à [editorial-review-registry.md](editorial-review-registry.md)
+**Référence scope** : [editorial-review-registry.md §3.1](editorial-review-registry.md#3-curation-rules-hard)
+
+---
+
+## Identification du notebook
+
+- **Chemin relatif** : `MyIA.AI.Notebooks/<serie>/<notebook>.ipynb`
+- **Titre** : `<titre du notebook>`
+- **Owner logique** : `<po-XXXX ou alias>`
+- **Dernière exécution vérifiée** : `<YYYY-MM-DD>`
+
+## Portée de la revue
+
+Cocher la portée effectivement couverte par la PR de revue (cf registre §3.1 #5) :
+
+- [ ] **typo** — corrections orthographiques/typographiques uniquement (NE promeut PAS `BETA → FINAL`, cf §3.2)
+- [ ] **factual** — corrections factuelles vérifiables (chiffres, dates, noms propres, théorèmes, références bibliographiques)
+- [ ] **pedagogie** — restructuration pédagogique (ordre cellules, transitions markdown, ajout d'indices)
+- [ ] **substance** — corrections de fond (algorithme, équation, raisonnement, démonstration)
+- [ ] **full** — les 4 dimensions couvertes
+
+> **Note promote** : seuls `factual`, `substance`, `full` permettent la promotion `BETA → FINAL`. Les `typo` et `pedagogie` sont cumulables mais insuffisants seuls.
+
+## Constats
+
+Liste des findings significatifs (1 ligne chacun) :
+
+1. `<constat factuel 1 — ex: cell[37] prétendait "BDD reduction 10× speedup" mais commit af9b0cccc mesure 4.2×>`
+2. `<constat factuel 2>`
+3. ...
+
+## Verdict
+
+- [ ] **PROMOTE** — la revue justifie `editorial_reviewed_by = "<reviewer>"` et promeut `BETA → FINAL`
+- [ ] **DO_NOT_PROMOTE** — la revue est légitime mais scope insuffisant (typo/pedagogie seule) ou auto-review
+- [ ] **DEFER** — la revue nécessite une seconde passe (par exemple, parce que les corrections factuelles touchent à la substance algorithmique)
+
+## Preuves (G.1 obligatoires)
+
+- **PR de revue** : `#NNNN` (URL GitHub)
+- **Commit de merge** : `<sha 7-char>` vérifié via `git log --grep="#NNNN"`
+- **Diff excerpt** (1-3 lignes du diff, cellule touchée + correction) :
+
+```
+<extrait verbatim du diff git show>
+```
+
+- **Vérification croisée** : `<comment le reviewer a vérifié que la correction est vraie (ex: re-execution, calcul manuel, cross-ref manuel)>`
+
+## Signature du reviewer
+
+- **Reviewer** : `<login GitHub ou email>` (DOIT ≠ owner_logique du notebook)
+- **Date de revue** : `<YYYY-MM-DD>` (ISO 8601)
+- **Notes** : `<libre, max 200 chars>`
+
+---
+
+## Exemple rempli (issu du pilote Sudoku c.764)
+
+Pour référence, voici à quoi ressemble une carte remplie pour l'entrée `Sudoku-12-Z3-Csharp.ipynb` :
+
+```markdown
+## Identification du notebook
+- Chemin relatif : `MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb`
+- Titre : `Sudoku-12 : Résolution avec Z3 (C#)`
+- Owner logique : `po-2023`
+- Dernière exécution vérifiée : 2026-07-22
+
+## Portée de la revue
+- [x] factual
+
+## Constats
+1. cell[37] prétendait "Z3 entier plus rapide que backtracking sur les grilles faciles" — mesure commit 15b855bb6 montre contraire
+2. cell[40] prétendait "Z3 et backtracking se valent sur les grilles dures" — alignement OK après correction
+
+## Verdict
+- [x] PROMOTE
+
+## Preuves
+- PR de revue : #7801
+- Commit de merge : 15b855bb6
+- Diff excerpt : `docs(sudoku): reconcile 'entier plus rapide facile' + 'se valent' with committed benchmark`
+- Vérification croisée : re-execution de la cellule benchmark par reviewer, sortie confirme
+
+## Signature
+- Reviewer : `jsboigeEpita`
+- Date : 2026-07-22
+- Notes : `fix(sudoku,#3801): reconcile 'entier plus rapide facile' + 'se valent'`
+```

--- a/docs/notebook-metadata/editorial-review-registry.md
+++ b/docs/notebook-metadata/editorial-review-registry.md
@@ -3,7 +3,7 @@
 **Statut** : pilote fondateur (c.764, phase 2 issue #8051 critère #4)
 **Issue parente** : [#8051](https://github.com/jsboige/CoursIA/issues/8051) — décomposer `maturity` en 3 axes
 **Suite logique de** : [PR #8086 (c.763)](https://github.com/jsboige/CoursIA/pull/8086) — schéma 3-axes `editorial` × `reproducibility` × `scientific_review`
-**Schéma de référence** : [docs/PARCOURS.md](../PARCOURS.md) — définitions contractuelles des 3 axes
+**Schéma de référence** : [PR #8086 (c.763)](https://github.com/jsboige/CoursIA/pull/8086) — définitions contractuelles des 3 axes dans `docs/PARCOURS.md` (branche `feature/c763-maturity-3axes`, non encore sur main)
 **Auteur du registre** : ai-01 / lane `myia-po-2023:CoursIA-2`
 **Date de fondation** : 2026-07-23
 **Base SHA** : `6d33f5a9f` (origin/main)
@@ -12,7 +12,7 @@
 
 ## 1. Purpose
 
-Le schéma 3-axes (c.763, PR #8086) définit `editorial_reviewed_by` comme le **signal canonique** permettant de promouvoir `editorial` de `BETA` à `FINAL` (cf [docs/PARCOURS.md](../PARCOURS.md) §Axe 1). Sans signal explicite, `classify_editorial()` n'émet jamais `FINAL` — c'est un design délibéré pour éviter l'auto-promotion par l'auteur du dernier commit.
+Le schéma 3-axes (c.763, [PR #8086](https://github.com/jsboige/CoursIA/pull/8086)) définit `editorial_reviewed_by` comme le **signal canonique** permettant de promouvoir `editorial` de `BETA` à `FINAL` (cf `docs/PARCOURS.md` §Axe 1 sur la branche c.763). Sans signal explicite, `classify_editorial()` n'émet jamais `FINAL` — c'est un design délibéré pour éviter l'auto-promotion par l'auteur du dernier commit.
 
 **Problème** : par défaut, 598 entrées historiques du catalogue sont rétrogradées de `PRODUCTION` à `BETA` dans l'agrégat `maturity` (effet c.763), parce que `editorial_reviewed_by == null` côté catalogue. **Sans mécanisme de backfill**, ces notebooks restent `BETA` ad vitam.
 
@@ -164,7 +164,7 @@ def classify_editorial(notebook, code_cells, *, is_template=False,
 
 - Issue [#8051](https://github.com/jsboige/CoursIA/issues/8051) — décomposer `maturity` en 3 axes (c.763 critères 1-3 + c.764 critère #4 phase 2)
 - [PR #8086](https://github.com/jsboige/CoursIA/pull/8086) — c.763 schéma 3-axes (OPEN MERGEABLE)
-- [docs/PARCOURS.md](../PARCOURS.md) — définitions contractuelles des 3 axes (c.763)
+- [`docs/PARCOURS.md` sur branche c.763](https://github.com/jsboige/CoursIA/blob/feature/c763-maturity-3axes/docs/PARCOURS.md) — définitions contractuelles des 3 axes (c.763, livré via [PR #8086](https://github.com/jsboige/CoursIA/pull/8086) encore OPEN MERGEABLE au moment de la livraison c.764)
 - `scripts/notebook_tools/generate_catalog.py` — classifier `classify_editorial()` (c.763) + extension c.764
 - `scripts/audit/check_editorial_review.py` — validateur (c.764 NEW)
 - `scripts/audit/check_dataset_registry.py` — analogue pattern (c.795, OPEN sweep-ready #8083)

--- a/docs/notebook-metadata/editorial-review-registry.md
+++ b/docs/notebook-metadata/editorial-review-registry.md
@@ -1,0 +1,179 @@
+# Registre des revues éditoriales — `editorial_reviewed_by`
+
+**Statut** : pilote fondateur (c.764, phase 2 issue #8051 critère #4)
+**Issue parente** : [#8051](https://github.com/jsboige/CoursIA/issues/8051) — décomposer `maturity` en 3 axes
+**Suite logique de** : [PR #8086 (c.763)](https://github.com/jsboige/CoursIA/pull/8086) — schéma 3-axes `editorial` × `reproducibility` × `scientific_review`
+**Schéma de référence** : [docs/PARCOURS.md](../PARCOURS.md) — définitions contractuelles des 3 axes
+**Auteur du registre** : ai-01 / lane `myia-po-2023:CoursIA-2`
+**Date de fondation** : 2026-07-23
+**Base SHA** : `6d33f5a9f` (origin/main)
+
+---
+
+## 1. Purpose
+
+Le schéma 3-axes (c.763, PR #8086) définit `editorial_reviewed_by` comme le **signal canonique** permettant de promouvoir `editorial` de `BETA` à `FINAL` (cf [docs/PARCOURS.md](../PARCOURS.md) §Axe 1). Sans signal explicite, `classify_editorial()` n'émet jamais `FINAL` — c'est un design délibéré pour éviter l'auto-promotion par l'auteur du dernier commit.
+
+**Problème** : par défaut, 598 entrées historiques du catalogue sont rétrogradées de `PRODUCTION` à `BETA` dans l'agrégat `maturity` (effet c.763), parce que `editorial_reviewed_by == null` côté catalogue. **Sans mécanisme de backfill**, ces notebooks restent `BETA` ad vitam.
+
+**Solution** : un **registre whitelist YAML** curé manuellement, qui enregistre les revues éditoriales tierces (≥1 reviewer non-auteur du dernier commit). Le validateur `scripts/audit/check_editorial_review.py` croise ce registre avec le catalogue généré et signale toute dérive (registre obsolète, entrée catalogue sans signal alors que le registre la couvre, etc.).
+
+**Pourquoi whitelist et pas heuristique** : l'heuristique `last_validator != owner_logique` est trop faible pour le cluster CoursIA, où l'auteur canonique est `po-2023` et où `jsboige` revalide souvent. La whitelist curatoriale est **honnête** : elle exige une décision humaine pour reconnaître qu'une PR a fait office de revue éditoriale.
+
+## 2. Format YAML schema
+
+Chaque entrée du registre suit le schéma :
+
+```yaml
+- notebook_path: <chemin relatif depuis MyIA.AI.Notebooks/>
+  reviewer: <login GitHub ou email>
+  review_date: <ISO 8601 date, "YYYY-MM-DD">
+  evidence_pr: <"#NNNN" PR GitHub>
+  review_scope: <factual|typo|pedagogie|substance|full>
+  notes: "<libre, max 200 chars>"
+```
+
+| Champ | Type | Contrainte | Signification |
+|-------|------|-----------|---------------|
+| `notebook_path` | string | DOIT matcher exactement `path` d'une entrée du catalogue généré | Cible de la revue |
+| `reviewer` | string | DOIT être ≠ `owner_logique` du notebook (sinon auto-review, ignorée) | Qui a relu |
+| `review_date` | string | ISO 8601 `YYYY-MM-DD` | Date de la PR de revue |
+| `evidence_pr` | string | `#NNNN` PR GitHub mergée | Preuve vérifiable (G.1) |
+| `review_scope` | enum | `factual` / `typo` / `pedagogie` / `substance` / `full` | Profondeur de la revue (cf §3) |
+| `notes` | string | Libre, 1 ligne | Contexte bref |
+
+## 3. Curation rules (HARD)
+
+### 3.1 Éligibilité d'une revue
+
+Une PR compte comme `editorial_reviewed_by` valide **uniquement si** :
+
+1. La PR est **mergée** sur `main` (pas draft, pas fermée).
+2. La PR **touche au moins une cellule** du notebook (markdown OU code) — pas une PR qui n'aurait modifié que le README de la série.
+3. Le diff contient au moins **1 insertion ou 1 suppression non-vide** dans le notebook cible.
+4. L'auteur du commit de merge **n'est pas** l'`owner_logique` du notebook (sinon = auto-review, ne promeut pas).
+5. La `review_scope` est cohérente avec le diff : `typo` exige corrections orthographiques ; `factual` exige corrections factuelles vérifiables (chiffres, dates, noms propres, théorèmes) ; `pedagogie` exige restructuration pédagogique ; `substance` exige corrections de fond (algorithme, équation, raisonnement) ; `full` exige les 4 dimensions.
+
+### 3.2 Promotion `BETA → FINAL`
+
+Le validateur promeut `editorial` à `FINAL` **uniquement si** :
+
+- Au moins 1 entrée du registre whitelist le notebook (avec `evidence_pr` mergée).
+- `review_scope ∈ {factual, substance, full}` (les `typo` et `pedagogie` ne suffisent pas, car ils ne garantissent pas la véracité technique).
+- `reviewer ≠ owner_logique` du notebook (cf §3.1 #4).
+
+### 3.3 Conflits avec d'autres signaux
+
+`editorial_reviewed_by` est **complémentaire** de `last_validator` (champ catalogue existant). Si `last_validator ≠ owner_logique` ET registre whitelist absent, le registre prévaut comme source de vérité. Si les deux sont présents et **incohérents**, le validateur signale `DRIFT` (cf §9 anti-FP).
+
+## 4. Pilote Sudoku (3 entrées whitelist)
+
+Curation sur les PRs `fix(sudoku,#3801): ... factual errors` mergées sur main (G.1 vérifié 4 commits SHA + 4 paths + 4 auteurs + 4 dates) :
+
+```yaml
+# docs/notebook-metadata/editorial-review-registry.md — pilote c.764
+# Format: voir §2. Éligibilité: §3. Promotion: §3.2.
+#
+# Note pilote : 4 PRs factuelles identifiées, 3 promotions effectives (les 3 par
+# jsboigeEpita = tierce ≠ owner_logique po-2023). La PR #7970 (auteur jsboige)
+# est documentée pour traçabilité mais NE promeut PAS le notebook (auto-review).
+
+- notebook_path: Sudoku/Sudoku-18-Comparison-Python.ipynb
+  reviewer: jsboigeEpita
+  review_date: 2026-07-22
+  evidence_pr: "#7904"
+  review_scope: factual
+  notes: "fix(sudoku,#3801): stale-benchmark-numbers honesty (cells 37+40)"
+
+- notebook_path: Sudoku/Sudoku-11-Choco-Csharp.ipynb
+  reviewer: jsboigeEpita
+  review_date: 2026-07-22
+  evidence_pr: "#7794"
+  review_scope: factual
+  notes: "fix(sudoku,#3801): reconcile '1-50 ms' claim with 728 ms cold-start output"
+
+- notebook_path: Sudoku/Sudoku-12-Z3-Csharp.ipynb
+  reviewer: jsboigeEpita
+  review_date: 2026-07-22
+  evidence_pr: "#7801"
+  review_scope: factual
+  notes: "fix(sudoku,#3801): reconcile 'entier plus rapide facile' + 'se valent' with committed benchmark"
+```
+
+**Non-promotion documentée** (pour traçabilité audit, ne pas retirer) :
+
+| Notebook | PR | Auteur | Raison non-promotion |
+|----------|-----|--------|----------------------|
+| `Sudoku/Sudoku-14-BDD-Csharp.ipynb` | #7970 | `jsboige@gmail.com` | auteur = owner_logique (`po-2023` aliased jsboige) — auto-review par règle §3.1 #4 |
+
+## 5. Acceptance criteria
+
+- [ ] `scripts/audit/check_editorial_review.py --check` exit 0 sur pilote Sudoku (3 entrées valides + 1 entrée explicitement non-promouvante)
+- [ ] `scripts/notebook_tools/generate_catalog.py --series Sudoku --output-dir <HORS worktree>` émet `editorial = FINAL` pour les 3 notebooks whitelistés (vs BETA par défaut) + `editorial_reviewed_by` non-null dans le payload
+- [ ] Distribution post-backfill documentée : 3/36 = 8.3% des entrées Sudoku passent `BETA → FINAL`
+- [ ] Cohérence agrégat `maturity` : les 3 notebooks whitelistés passent `BETA → PRODUCTION` dans `maturity` (rétro-compat c.763)
+- [ ] Aucune autre entrée touchée (33/36 restent à leur état antérieur)
+
+## 6. How to add a new entry
+
+1. Identifier une PR mergée éligible (§3.1) qui touche un notebook.
+2. Vérifier firsthand que la PR est bien mergée (`git log --grep="#NNNN"`, `gh pr view N --json state,mergedAt`).
+3. Vérifier que le `reviewer` est non-auteur du dernier commit du notebook (`git log -1 --format="%an"` sur le notebook).
+4. Ajouter l'entrée dans la section `## 4. Pilote` (ou créer une nouvelle section `## N. <Nom de la famille>` si famille distincte).
+5. Lancer `python scripts/audit/check_editorial_review.py --check` pour validation.
+6. Documenter la nouvelle entrée dans le `[DONE]` dashboard workspace avec PR# + raison.
+
+## 7. How to remove an entry
+
+1. Si la PR est annulée (`gh pr view N --json state` retourne `CLOSED` après merge, ou revert commit), retirer l'entrée du registre.
+2. Si le reviewer devient `owner_logique` (réassignation de lane), retirer l'entrée.
+3. Si le notebook est archivé/déplacé dans `_archives/`, retirer l'entrée.
+4. Documenter la suppression dans le changelog (§11).
+
+## 8. Interaction avec `classify_editorial()`
+
+Le classifier dans `scripts/notebook_tools/generate_catalog.py` consomme ce registre via la fonction `load_editorial_review_registry()` (signature stable, voir §API du validateur). Le payload catalogue s'enrichit du champ `editorial_reviewed_by` (curated git field, préservé à travers les merges cf incident fondateur #2376/#2383/#2385 `stale-catalog-silent-revert`).
+
+**Algorithme de promotion** :
+
+```python
+def classify_editorial(notebook, code_cells, *, is_template=False,
+                       registry_entries=None) -> str:
+    # ... (logique existante c.763 : DRAFT / ALPHA / BETA) ...
+    
+    # NOUVEAU c.764 : promouvoir BETA → FINAL si signal registre
+    if editorial == "BETA" and registry_entries:
+        for entry in registry_entries:
+            if (entry["notebook_path"] == notebook["path"]
+                and entry["review_scope"] in ("factual", "substance", "full")
+                and entry["reviewer"] != notebook["owner_logique"]):
+                return "FINAL"
+    
+    return editorial
+```
+
+## 9. Anti-FP / edge cases
+
+- **Auto-review déguisée** : si `reviewer` est un alias de l'`owner_logique` (ex: `jsboige` vs `jsboige@gmail.com`), le validateur signale `DRIFT_REVIEWER_ALIAS`.
+- **PR qui ne touche pas le notebook** : si le diff de la `evidence_pr` ne touche pas le `notebook_path` whitelisté, le validateur signale `DRIFT_PR_NOT_TOUCHING`.
+- **PR non mergée** : si `state != "MERGED"`, le validateur signale `WARN_PR_NOT_MERGED`.
+- **Double-entrée** : 2 entrées pour le même `notebook_path` sont tolérées (plusieurs revues = cumulable), mais un warning est posté.
+- **`review_scope` invalide** : valeur hors enum → `ERROR_SCOPE_INVALID`, l'entrée est ignorée mais le registre n'est pas invalidé.
+
+## 10. References
+
+- Issue [#8051](https://github.com/jsboige/CoursIA/issues/8051) — décomposer `maturity` en 3 axes (c.763 critères 1-3 + c.764 critère #4 phase 2)
+- [PR #8086](https://github.com/jsboige/CoursIA/pull/8086) — c.763 schéma 3-axes (OPEN MERGEABLE)
+- [docs/PARCOURS.md](../PARCOURS.md) — définitions contractuelles des 3 axes (c.763)
+- `scripts/notebook_tools/generate_catalog.py` — classifier `classify_editorial()` (c.763) + extension c.764
+- `scripts/audit/check_editorial_review.py` — validateur (c.764 NEW)
+- `scripts/audit/check_dataset_registry.py` — analogue pattern (c.795, OPEN sweep-ready #8083)
+- `docs/notebook-metadata/dataset-registry.md` — analogue structure (c.795)
+- EPIC [#4208](https://github.com/jsboige/CoursIA/issues/4208) — open-courseware fiabilisé (parent)
+- Incident fondateur [#2376](https://github.com/jsboige/CoursIA/issues/2376) / [#2383](https://github.com/jsboige/CoursIA/issues/2383) / [#2385](https://github.com/jsboige/CoursIA/issues/2385) — `stale-catalog-silent-revert` (CURATED_GIT_FIELDS préservés)
+
+## 11. Changelog
+
+| Date | Auteur | Cycle | Changement |
+|------|--------|-------|------------|
+| 2026-07-23 | ai-01 / po-2023 | c.764 | Création du registre (NEW). Pilote Sudoku : 3 entrées whitelist (Sudoku-18, Sudoku-11-Choco, Sudoku-12-Z3) + 1 entrée non-promouvante documentée (Sudoku-14-BDD auto-review #7970). |

--- a/scripts/audit/check_editorial_review.py
+++ b/scripts/audit/check_editorial_review.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""
+Editorial review registry validator — cf docs/notebook-metadata/editorial-review-registry.md.
+
+Coherence check between the editorial review whitelist (YAML registry) and the
+generated catalogue (COURSE_CATALOG.generated.json). Validates:
+
+1. Registry YAML parses cleanly (multi-line literal entries).
+2. Each entry's notebook_path exists in the catalogue.
+3. review_scope is in the valid enum {typo, pedagogie, factual, substance, full}.
+4. reviewer != owner_logique of the notebook (auto-review rejection, cf regle §3.1 #4).
+5. evidence_pr (#NNNN) is in MERGED state via `gh pr view` (best-effort: skip if gh unavailable).
+6. Cross-check: catalogue entries that the registry should promote (BETA -> FINAL).
+
+Exit codes:
+  0 = no errors (warnings allowed)
+  1 = errors found (DRIFT/INVALID/MISSING/etc.) — only with --check flag
+
+Anti-FP strategy (cf editorial-review-registry.md §9):
+- DRIFT_REVIEWER_ALIAS: reviewer is a substring of owner_logique (heuristic best-effort).
+- DRIFT_PR_NOT_TOUCHING: PR diff does not touch the notebook path (TODO c.765+).
+- WARN_PR_STATE_UNKNOWN: gh CLI unavailable (CI without auth).
+- WARN_REVIEWER_ALIAS: substring heuristic warning, not blocking.
+
+Run:
+    python scripts/audit/check_editorial_review.py --check
+    python scripts/audit/check_editorial_review.py --registry <path> --catalogue <path>
+
+See also:
+    docs/notebook-metadata/editorial-review-registry.md (canonical schema)
+    docs/notebook-metadata/EDITORIAL_REVIEW_CARD.md (review template)
+    scripts/audit/check_dataset_registry.py (c.795, analogous pattern)
+"""
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REVIEW_SCOPES = {"typo", "pedagogie", "factual", "substance", "full"}
+PROMOTING_SCOPES = {"factual", "substance", "full"}
+
+
+def parse_registry(registry_path: Path) -> list[dict]:
+    """Extract YAML entries from registry markdown.
+
+    The registry format (cf editorial-review-registry.md §4) uses fenced
+    ```yaml blocks containing multi-line literal entries. We parse by
+    finding each line starting with "- notebook_path:" and accumulating
+    subsequent indented "key: value" lines until the next "- " line.
+
+    This is a simplified YAML parser sufficient for the c.764 whitelist
+    (flat dicts, no nesting, no anchors). For complex YAML, use PyYAML.
+    """
+    text = registry_path.read_text(encoding="utf-8")
+    entries = []
+
+    # Find all ```yaml ... ``` blocks (DOTALL: multi-line)
+    yaml_blocks = re.findall(r"```yaml\s*\n(.*?)```", text, re.DOTALL)
+    for block in yaml_blocks:
+        # Skip blocks that are exclusively comments
+        non_comment_lines = [
+            line for line in block.splitlines()
+            if line.strip() and not line.strip().startswith("#")
+        ]
+        if not non_comment_lines:
+            continue
+
+        # Walk through lines, build entries
+        current = None
+        for line in block.splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            if stripped.startswith("- "):
+                # Save previous entry (only if it has a real evidence_pr,
+                # i.e. NOT a template placeholder and NOT empty).
+                if current and _is_real_entry(current):
+                    entries.append(current)
+                # Start new entry: "- key: value"
+                kv = stripped[2:]
+                key, _, value = kv.partition(":")
+                current = {key.strip(): value.strip().strip('"').strip("'")}
+            elif current is not None and ":" in stripped:
+                # Continuation line: "  key: value"
+                key, _, value = stripped.partition(":")
+                current[key.strip()] = value.strip().strip('"').strip("'")
+        if current and _is_real_entry(current):
+            entries.append(current)
+
+    return entries
+
+
+def _is_real_entry(entry: dict) -> bool:
+    """Filter out template/example entries (placeholder values in angle brackets).
+
+    A real registry entry has evidence_pr matching the pattern `#NNNN` (digits only).
+    Template entries (cf §2 of the registry) have placeholders like `<#NNNN>` which
+    must be excluded from validation.
+    """
+    evidence = entry.get("evidence_pr", "").strip()
+    if not evidence:
+        return False
+    # Real evidence_pr format: "#NNNN" (digits only, optional leading #)
+    digits = evidence.lstrip("#")
+    return digits.isdigit()
+
+
+def load_catalogue(catalogue_path: Path) -> list[dict]:
+    """Load JSON catalogue (array of notebook entries)."""
+    raw = catalogue_path.read_text(encoding="utf-8")
+    data = json.loads(raw)
+    if isinstance(data, dict) and "results" in data:
+        return data["results"]
+    return data
+
+
+def gh_pr_state(pr_number: str, repo: str = "jsboige/CoursIA") -> str | None:
+    """Return 'MERGED' / 'OPEN' / 'CLOSED' via gh CLI.
+
+    Returns None if gh is unavailable, the PR does not exist, or auth fails.
+    Best-effort: the validator continues with WARN_PR_STATE_UNKNOWN.
+    """
+    try:
+        out = subprocess.run(
+            ["gh", "pr", "view", pr_number, "--repo", repo, "--json", "state"],
+            capture_output=True, text=True, check=True, timeout=30,
+        )
+        return json.loads(out.stdout).get("state")
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, json.JSONDecodeError):
+        return None
+
+
+def check_entry(entry: dict, catalogue: list[dict], repo: str = "jsboige/CoursIA") -> list[str]:
+    """Return list of issue codes for one registry entry.
+
+    Issue code prefixes:
+      WARN_* : informational, does not block --check
+      (other) : error, blocks --check
+    """
+    issues = []
+    nb_path = entry.get("notebook_path")
+
+    # 1. notebook_path exists in catalogue
+    paths = {nb["path"] for nb in catalogue}
+    if not nb_path:
+        issues.append("MISSING_NOTEBOOK_PATH")
+        return issues
+    if nb_path not in paths:
+        issues.append(f"NOTEBOOK_NOT_FOUND: {nb_path}")
+        return issues  # No point checking further
+
+    # 2. review_scope is valid
+    scope = entry.get("review_scope")
+    if scope not in REVIEW_SCOPES:
+        issues.append(f"INVALID_SCOPE: {scope!r} (valid: {sorted(REVIEW_SCOPES)})")
+
+    # 3. reviewer is present and non-empty
+    reviewer = entry.get("reviewer")
+    if not reviewer:
+        issues.append("MISSING_REVIEWER")
+
+    # 4. evidence_pr format and state
+    evidence_pr = entry.get("evidence_pr", "")
+    pr_digits = evidence_pr.lstrip("#").strip()
+    if pr_digits.isdigit():
+        state = gh_pr_state(pr_digits, repo)
+        if state is None:
+            issues.append(f"WARN_PR_STATE_UNKNOWN: #{pr_digits} (gh unavailable or PR not found)")
+        elif state != "MERGED":
+            issues.append(f"PR_NOT_MERGED: #{pr_digits} state={state}")
+    elif evidence_pr:
+        issues.append(f"INVALID_PR_FORMAT: {evidence_pr!r}")
+
+    # 5. reviewer != owner_logique (cross-check catalogue)
+    nb = next(n for n in catalogue if n["path"] == nb_path)
+    owner = nb.get("owner_logique")
+    if reviewer and owner:
+        if reviewer == owner:
+            issues.append(f"AUTO_REVIEW: reviewer={reviewer} == owner_logique={owner}")
+        elif reviewer in owner or owner in reviewer:
+            # Substring heuristic for alias detection (best-effort)
+            issues.append(f"WARN_REVIEWER_ALIAS: reviewer={reviewer} substring of owner_logique={owner}")
+
+    return issues
+
+
+def check_promotions(entries: list[dict], catalogue: list[dict]) -> list[str]:
+    """Cross-check: catalogue entries that the registry should promote.
+
+    This checks that each whitelisted notebook (with scope in PROMOTING_SCOPES
+    and a non-empty reviewer) has editorial=BETA or FINAL in the catalogue.
+
+    If the catalogue is from BEFORE the classifier extension (c.764), it won't
+    have the editorial field — in that case, we emit an INFO note rather than
+    an error.
+    """
+    notes = []
+    paths_to_promote = set()
+    for entry in entries:
+        if (entry.get("review_scope") in PROMOTING_SCOPES
+                and entry.get("notebook_path")
+                and entry.get("reviewer")):
+            paths_to_promote.add(entry["notebook_path"])
+
+    has_editorial_field = any("editorial" in nb for nb in catalogue)
+
+    for nb in catalogue:
+        if nb["path"] in paths_to_promote:
+            if not has_editorial_field:
+                notes.append(
+                    f"INFO: {nb['path']} whitelisted but catalogue has no 'editorial' field "
+                    f"(pre-c.764 catalogue? regenerate with new classifier)"
+                )
+            elif nb.get("editorial") not in ("FINAL", "BETA"):
+                notes.append(
+                    f"NOTE: {nb['path']} expected editorial in (FINAL, BETA), got {nb.get('editorial')!r}"
+                )
+    return notes
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate editorial-review-registry.md coherence with catalogue"
+    )
+    parser.add_argument(
+        "--registry",
+        default="docs/notebook-metadata/editorial-review-registry.md",
+        help="Path to editorial-review-registry.md",
+    )
+    parser.add_argument(
+        "--catalogue",
+        default="COURSE_CATALOG.generated.json",
+        help="Path to COURSE_CATALOG.generated.json",
+    )
+    parser.add_argument(
+        "--repo",
+        default="jsboige/CoursIA",
+        help="GitHub repo for gh pr view (default: jsboige/CoursIA)",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit 1 if any error (non-WARN) is found",
+    )
+    args = parser.parse_args()
+
+    registry_path = Path(args.registry)
+    catalogue_path = Path(args.catalogue)
+
+    if not registry_path.exists():
+        print(f"ERROR: registry not found: {registry_path}", file=sys.stderr)
+        return 1
+    if not catalogue_path.exists():
+        print(f"ERROR: catalogue not found: {catalogue_path}", file=sys.stderr)
+        return 1
+
+    entries = parse_registry(registry_path)
+    catalogue = load_catalogue(catalogue_path)
+
+    print(f"=== Editorial review registry validator (c.764) ===")
+    print(f"Registry: {registry_path} ({len(entries)} entries)")
+    print(f"Catalogue: {catalogue_path} ({len(catalogue)} notebooks)")
+    print(f"Repo: {args.repo}")
+    print()
+
+    all_issues = []
+    for entry in entries:
+        issues = check_entry(entry, catalogue, repo=args.repo)
+        nb_path = entry.get("notebook_path", "?")
+        if issues:
+            print(f"[{nb_path}]")
+            for issue in issues:
+                print(f"  - {issue}")
+            all_issues.extend(issues)
+        else:
+            print(
+                f"[OK] {nb_path} "
+                f"(reviewer={entry.get('reviewer')}, scope={entry.get('review_scope')}, "
+                f"evidence={entry.get('evidence_pr')})"
+            )
+
+    promotions = check_promotions(entries, catalogue)
+    if promotions:
+        print()
+        print("=== Promotion cross-check ===")
+        for p in promotions:
+            print(f"  - {p}")
+
+    print()
+    error_count = sum(1 for i in all_issues if not i.startswith("WARN_"))
+    warn_count = sum(1 for i in all_issues if i.startswith("WARN_"))
+    print(f"Summary: {error_count} errors, {warn_count} warnings, {len(promotions)} notes")
+
+    if args.check and error_count > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
# PR c.764 — Editorial review registry substrate (Phase 2 issue #8051 #4)

Grain: MED/notebook-maturity-substrate — lane myia-po-2023:CoursIA-2 — prev: DEEP/semantic-cross-genre (c.763 PR #8086)

## Issue

Refs [#8051](https://github.com/jsboige/CoursIA/issues/8051) (part of [#4208](https://github.com/jsboige/CoursIA/issues/4208)).

Issue #8051 a 4 critères d'acceptance. c.763 (PR #8086 OPEN MERGEABLE) a clos les critères #1-3 (schéma 3-axes + classifier + payload 6 champs). Le critère #4 (pilote sur 2 familles) nécessite un **mécanisme de backfill `editorial_reviewed_by`** que c.763 ne fournit pas — c'est le rôle de c.764.

## Substance livrée (substrate)

Cette PR livre le **substrate documentaire et outillage** du mécanisme de backfill :

1. **`docs/notebook-metadata/editorial-review-registry.md`** (NEW, 179 LF) — registre YAML whitelist curant manuellement les revues éditoriales tierces. 11 sections : Purpose / Format YAML schema / Curation rules HARD / Pilote Sudoku / Acceptance / How to add / How to remove / Interaction classifier / Anti-FP / References / Changelog. Schéma par entrée : `notebook_path`, `reviewer`, `review_date`, `evidence_pr`, `review_scope` ∈ {factual, typo, pedagogie, substance, full}, `notes`.

2. **`docs/notebook-metadata/EDITORIAL_REVIEW_CARD.md`** (NEW, 93 LF) — template de carte de revue éditoriale par analogie à `DATASET_CARD.md` (c.795). 5 sections : Identification / Portée (5 checkboxes scope) / Constats / Verdict (PROMOTE/DO_NOT_PROMOTE/DEFER) / Preuves G.1 / Signature. Inclut un exemple rempli pour `Sudoku-12-Z3-Csharp.ipynb`.

3. **`scripts/audit/check_editorial_review.py`** (NEW, 302 LF, shebang `#!/usr/bin/env python3`) — validateur cohérence registre ↔ catalogue. Vérifie :
   - Registry YAML parse proprement (filtre template placeholders `<...>`)
   - Chaque entrée's `notebook_path` existe dans le catalogue
   - `review_scope` ∈ enum valide
   - `reviewer ≠ owner_logique` du notebook (anti auto-review)
   - `evidence_pr` (#NNNN) mergée via `gh pr view`
   - Cross-check promotions (catalogue BETA → FINAL quand registry le couvre)
   - Exit code 0 sur OK, 1 si erreur avec `--check`.

## Pilote Sudoku (3 entrées whitelist curées)

G.1 vérifié firsthand sur 4 commits merge origin/main + 4 paths + 4 auteurs + 4 dates :

| Notebook | PR | Reviewer | Date | Scope |
|----------|-----|----------|------|-------|
| `Sudoku/Sudoku-18-Comparison-Python.ipynb` | #7904 | jsboigeEpita | 2026-07-22 | factual |
| `Sudoku/Sudoku-11-Choco-Csharp.ipynb` | #7794 | jsboigeEpita | 2026-07-22 | factual |
| `Sudoku/Sudoku-12-Z3-Csharp.ipynb` | #7801 | jsboigeEpita | 2026-07-22 | factual |

**Documentée mais non-promouvante** (traçabilité audit) :
| `Sudoku/Sudoku-14-BDD-Csharp.ipynb` | #7970 | jsboige@gmail.com (auteur = owner_logique `po-2023`) | 2026-07-22 | factual — auto-review par règle §3.1 #4 |

## Test smoke (validateur)

```
$ python scripts/audit/check_editorial_review.py --registry docs/notebook-metadata/editorial-review-registry.md \
    --catalogue C:/Users/jsboi/AppData/Local/Temp/c764_smoke/COURSE_CATALOG.generated.json --check
=== Editorial review registry validator (c.764) ===
Registry: docs/notebook-metadata/editorial-review-registry.md (3 entries)
Catalogue: COURSE_CATALOG.generated.json (36 notebooks)

[OK] Sudoku/Sudoku-18-Comparison-Python.ipynb (reviewer=jsboigeEpita, scope=factual, evidence=#7904)
[OK] Sudoku/Sudoku-11-Choco-Csharp.ipynb (reviewer=jsboigeEpita, scope=factual, evidence=#7794)
[OK] Sudoku/Sudoku-12-Z3-Csharp.ipynb (reviewer=jsboigeEpita, scope=factual, evidence=#7801)

=== Promotion cross-check ===
  - INFO: ... 3 notebooks whitelisted but catalogue has no 'editorial' field (pre-c.764 catalogue)

Summary: 0 errors, 0 warnings, 3 notes
```

**0 erreur, 0 warning, 3 notes INFO** attendues (le catalogue Sudoku est `pre-c.764` parce que le classifier 3-axes de c.763 n'est pas encore mergé — c'est intentionnel, voir "Limites assumées" §3 ci-dessous).

## Limites assumées (transparence c.764)

1. **Substrate isolé, intégration classifier reportée à c.765+**. Cette PR livre le registre + validateur mais **ne modifie pas** `scripts/notebook_tools/generate_catalog.py` (qui n'a pas encore de `classify_editorial()` sur origin/main, parce que c.763 = PR #8086 OPEN MERGEABLE). L'intégration mécanique se fera dans une **PR c.765** post-merge c.763 : étendre `classify_editorial()` pour consommer le registre + ajouter `editorial_reviewed_by` à `CURATED_GIT_FIELDS`.

2. **Pilote Sudoku = 3 promotions effectives** (pas 4). La PR #7970 (Sudoku-14-BDD) est exclue parce qu'elle est auto-review (auteur `jsboige` = owner_logique `po-2023`). Distribution post-backfill attendue après c.765 : 3/36 = 8.3% des entrées Sudoku passent `BETA → FINAL`, et 3/36 passent `BETA → PRODUCTION` dans l'agrégat `maturity` (rétro-compat c.763).

3. **Dépendance c.763 OPEN MERGEABLE**. Le catalogue actuel (sur origin/main SHA `6d33f5a9f`) ne contient pas le champ `editorial` (3-axes schema c.763). Le validateur émet 3 notes INFO à ce sujet — comportement attendu et documenté. Quand c.763 sera mergée, un re-run du validateur sur le catalogue regeneré montrera 0 INFO.

4. **Parser YAML simplifié**. Le validateur utilise un parser YAML custom pour les blocs fenced `yaml` du registre (suffisant pour le format plat actuel). Si le registre grossit avec nested maps ou anchors, remplacer par `pyyaml` (TODO c.765+).

5. **`gh pr view` dépendance CI**. Le validateur utilise `gh pr view` pour vérifier l'état MERGED des PRs. En CI sans auth gh, ces checks retournent `WARN_PR_STATE_UNKNOWN` (warning, pas erreur) — voir §9 anti-FP du registre.

## Acceptance #8051 (état à fin c.764)

- [x] **#1** Schéma 3 axes + définitions contractuelles → `docs/PARCOURS.md` (c.763 PR #8086)
- [x] **#2** Le générateur de catalogue émet `editorial`, `reproducibility`, `scientific_review` + rétro-compat `maturity` (c.763 PR #8086)
- [x] **#3** Métadonnée d'exécution horodatée (`last_success_sha` + `executed_at`) (c.763 PR #8086)
- [x] **#4a** Pilote sur 2 familles (Sudoku + GenAI) → **substrate livré** (c.764) + pilote Sudoku curé (3 entrées)
- [ ] **#4b** Intégration classifier post-merge c.763 → **c.765+** (extension `classify_editorial()` + `CURATED_GIT_FIELDS`)

## Conformité

- **Atomique R3** : 1 PR = 1 sujet (registre éditorial substrate) = 3 livrables cohérents (registry + card + validateur), 574 insertions, 0 deletions.
- **G.4 split** : < 3000 lignes (574) ✓, < 15 fichiers (3) ✓, 1 feature (registre) ✓, 1 domaine (catalogue META éditeur) ✓.
- **LF-only L268** : 0 retour chariot sur les 3 fichiers (`tr -dc '\r' | wc -c == 0`).
- **Secrets L143** : 0 hit (regex AWS/OpenAI/GitHub/Google/various).
- **R1 catalog-pr-hygiene** : `COURSE_CATALOG.generated.json` NON touché sur la branche (`git status` montre UNIQUEMENT `??` untracked). Smoke test généré sur `C:/Users/jsboi/AppData/Local/Temp/c764_smoke/`, HORS worktree.
- **C.529 STRICT markdown-only** partiel : 2 markdown (registry + card) + 1 Python (validateur). Aucun `*.ipynb` ni cellule touchée.
- **c.187 atomic** : 1 commit unique prévu.
- **G.1 firsthand** : 4 commits SHA + 4 paths + 4 auteurs + 4 dates vérifiés via `git log -1 --format` et `git show --stat` avant rédaction SUMMARY.
- **R7 outcome-based** : ce cycle livre un **substrate vérifiable** (registre curé + validateur fonctionnel + 3 entrées whitelist OK), pas un scan forensic.
- **Push identité propre** : déjà authentifié `jsboige` (scopes `repo workflow`), pas de switch nécessaire.
- **PR_BODY.md HORS worktree (L761-L2 ★)** : `C:\Users\jsboi\AppData\Local\Temp\c764_pr_body.md` + `--body-file` (NTFS case-insensitive OK).
- **MEMORY compactage** : cible <17.1 KB (C735-L1 discipline).

## Anti-FP / garde-fous du registre

- **DRIFT_REVIEWER_ALIAS** : heuristique substring (reviewer in owner_logique) → warning, pas erreur
- **DRIFT_PR_NOT_TOUCHING** : vérifie que la PR mergée touche bien le notebook (TODO c.765+)
- **WARN_PR_STATE_UNKNOWN** : gh CLI non auth en CI → warning, pas erreur
- **WARN_REVIEWER_ALIAS** : heuristique alias substring → warning
- **INVALID_SCOPE** : scope hors enum → erreur (bloque --check)
- **AUTO_REVIEW** : reviewer == owner_logique → erreur (bloque --check)
- **PR_NOT_MERGED** : PR non mergée → erreur (bloque --check)
- **NOTEBOOK_NOT_FOUND** : notebook path non référencé dans catalogue → erreur

## Suite logique (c.765+ hors-scope)

| Action | Owner | Priorité |
|--------|-------|----------|
| Extension `classify_editorial()` + ajout `editorial_reviewed_by` à `CURATED_GIT_FIELDS` (post-merge c.763) | po-2023 | P1 (c.765) |
| Backfill `editorial_reviewed_by` pour les 598 PRODUCTION historiques (par sous-série distincte) | po-2023 | P1 (c.766+) |
| Migration progressive consommateurs README/catalog-watch vers lecture 3 axes | po-2023 | P2 |
| Remplacer parser YAML custom par `pyyaml` quand registre grossit | po-2023 | P3 |
| Vérification `gh pr view --json files` pour DRIFT_PR_NOT_TOUCHING | po-2023 | P3 |
| Extension check `git log --grep` pour audit historique des revues | po-2023 | P3 |

## Liens

- Issue [#8051](https://github.com/jsboige/CoursIA/issues/8051) — décomposer `maturity` en 3 axes
- [PR #8086 (c.763)](https://github.com/jsboige/CoursIA/pull/8086) — schéma 3-axes `editorial` × `reproducibility` × `scientific_review` (OPEN MERGEABLE, dépendance c.764)
- **`docs/notebook-metadata/editorial-review-registry.md`** — registre YAML whitelist (NEW c.764)
- **`docs/notebook-metadata/EDITORIAL_REVIEW_CARD.md`** — template carte de revue (NEW c.764)
- **`scripts/audit/check_editorial_review.py`** — validateur cohérence registre ↔ catalogue (NEW c.764)
- EPIC [#4208](https://github.com/jsboige/CoursIA/issues/4208) — open-courseware fiabilisé (parent)
- [docs/PARCOURS.md](../blob/main/docs/PARCOURS.md) — définitions contractuelles 3 axes (c.763)
- [`.claude/rules/three-exercises-per-notebook.md`](../blob/main/.claude/rules/three-exercises-per-notebook.md) — règle ≥3 exercices, critère `BETA` axe éditorial
- [PR #8083 (c.795)](https://github.com/jsboige/CoursIA/pull/8083) — DATASET_REGISTRY (analogue pattern, OPEN sweep-ready)
