### PR TITLE
enrich(SemanticWeb): SW-13 read exemple 2 equivalence output (bidirectional divergence = noise)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb
@@ -2248,6 +2248,31 @@
   },
   {
    "cell_type": "markdown",
+   "id": "sw13-ex2-equivalence-reading",
+   "metadata": {},
+   "source": [
+    "### Lecture de l'exemple 2 : une divergence qui n'en est pas vraiment une\n",
+    "\n",
+    "La sortie ci-dessus répond crûment à la question « owlrl et reasonable produisent-ils les mêmes triples ? » : **non**. Mais le **détail** des triples révèle que ce « non » est trompeur.\n",
+    "\n",
+    "**Les chiffres bruts sont alarmants** : owlrl infère 211 triples, reasonable 36, et leur intersection ne contient que **20** triples communs — d'où une différence symétrique de **207**. Vu de loin, les deux raisonner OWL 2 RL semblent diverger massivement.\n",
+    "\n",
+    "**Mais la divergence est bidirectionnelle et, des deux côtés, constituée de bruit de bas niveau** :\n",
+    "\n",
+    "| Côté | Nb | Nature des triples (exemples réels) |\n",
+    "|------|-----|--------------------------------------|\n",
+    "| Uniquement owlrl | 191 | **Réflexivité** (`owl:Thing owl:sameAs owl:Thing`, `xsd:long owl:sameAs xsd:long`) + **typage XSD** (`langString rdf:type rdfs:Datatype`) |\n",
+    "| Uniquement reasonable | 16 | **Typage d'appartenance** (`PizzaBase rdf:type owl:Thing`, `NonVegetarianPizza rdf:type owl:Thing`) |\n",
+    "\n",
+    "Aucune des deux listes ne contient du *raisononnement* au sens utile (classification d'instances, chaînes de propriétés, restrictions) — seulement des **assertions structurelles** que tout graphe OWL satisfait trivialement. owlrl materialise l'intégralité des règles W3C (réflexivité `sameAs`, typage XSD exhaustif) ; reasonable adopte une convention différente (expliciter l'appartenance à `owl:Thing`). Les deux approches sont **cohérentes**, elles diffèrent juste sur *quelles* tautologies expliciter.\n",
+    "\n",
+    "> **Leçon** : comparer des raisonner OWL 2 RL **au nombre de triples inférés** est trompeur. Ce qui compte n'est pas le volume, mais la **couverture des règles substantielles** (hiérarchie de classes, restrictions, consistance). Sur ce critère, owlrl et reasonable **convergent** : leurs 20 triples communs portent l'essentiel du raisonnement utile. La différence de 207 est un artefact de configuration, pas un désaccord sémantique.\n",
+    "\n",
+    "> **Nuance vs la comparaison générique** (§Comparaison) : le tableau cellule 53 expliquait l'écart par les « fermetures transitives exhaustives » — la lecture concrète ici précise qu'il s'agit en fait de **réflexivité et de typage**, et révèle un aspect que cette explication générique taisait : reasonable produit aussi des triples qu'owlrl ne produit pas (les 16 `type owl:Thing`). L'exercice 2 (indice cellule 75) n'adressait lui aussi que les extras d'owlrl."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "exemple-sw13-3",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
## Summary

`SW-13-Python-Reasoners` **Exemple guidé 2** (cell 59, worked solution: « are owlrl and reasonable equivalent? ») outputs a striking **NO**: 211 vs 36 triples, only 20 common, sym diff **207**. Yet no markdown reads this output at its location — the punchline of the worked example is left uninterpreted.

## Why this is a genuine (moderate) orphan — not duplicative

The existing explanations are split and **partial**:
- **cell[53]** (Comparaison): « 5.9×, l'écart porte sur les fermetures transitives exhaustives » — vague, and slightly inaccurate vs the concrete evidence.
- **cell[75]** (exercice 2 hint): « réflexivité subClassOf, typage XSD complet » — addresses **only owlrl's extras**.
- the code's own `Analyse:` print — also **unidirectional** (owlrl only).

**None address the bidirectional divergence**: reasonable infers **16 triples owlrl does NOT** (`rdf:type owl:Thing` on `PizzaBase`, `NonVegetarianPizza`, ...). Reading the ACTUAL triples shows **both** sides are low-level noise:
- owlrl-only (191): `sameAs` reflexivity (`owl:Thing`, `xsd:long`) + XSD typing
- reasonable-only (16): `rdf:type owl:Thing` typing (different convention)

So the scary 207-difference is an artifact of *which tautologies each reasoner chooses to materialize*, **not a semantic disagreement**. On substantive reasoning (the 20 common triples carry the useful inferences), the reasoners converge.

## Change (markdown-only, C.2 exception)

One markdown cell after cell[59]:
1. The numbers (211/36/20/207 = 191 owlrl-only + 16 reasonable-only)
2. A table of the actual triple natures on each side (evidence cited from the real committed output)
3. The lesson: comparing reasoners by triple **count** is misleading; what matters is coverage of **substantive** rules
4. Explicit cross-ref + **refinement** of cell[53] (« transitive » → actually reflexivity/typing) and cell[75] (which only covered owlrl's extras)

## Validation (firsthand)

- Every number/triple verified against the **real cell[59] committed output** (211/36/20/207/191/16, the actual `sameAs`/`type owl:Thing` examples).
- `nbformat.validate` **OK**.
- Markdown-only → C.2 exception (no re-exec; 31 code cells untouched, execution_counts intact).
- Diff: **25 insertions, 0 deletions** — pure addition, 1 file → anti-regression clean.
- Convention preserved: `json.dumps(indent=1, ensure_ascii=False) + "\n"` == raw, 0 CRLF, no mojibake (verified).

## Honnêteté

This is a **moderate** gap (the generic explanation exists at cell[53]/[75]) — not a lost-substance-by-complaisance case like the EP motivation in Infer-8 (#8097). The value added is: (a) reading the concrete evidence at the worked example's location, (b) addressing the **bidirectional** divergence (reasonable's 16 unique triples) that existing explanations gloss over, (c) the meta-lesson on triple-count as a misleading metric. R6-variety: SemanticWeb is a fresh family (prior cycles were Probas/GameTheory).

Co-Authored-By: Claude-Code <noreply@anthropic.com>