### PR TITLE
fix(detect-solution-leaks,#8053): expand STUB_PATTERNS for Lean/.NET/Python stub idioms (84→75 HIGH)

### DIFF
--- a/scripts/notebook_tools/detect_solution_leaks.py
+++ b/scripts/notebook_tools/detect_solution_leaks.py
@@ -33,6 +33,18 @@ STUB_PATTERNS = [
     r'//\s*TODO',
     r'Console\.WriteLine\(["\']Exercice a completer',
     r'Console\.WriteLine\(["\']Exercices a completer',
+    # Lean stub idioms (Lean line comments start with `--`).
+    r'--\s*TODO',
+    # Lean `sorry` tactic admits the goal — an exercise cell using it is a stub
+    # (the proof is unverified, intentionally left for the student).
+    r'\bsorry\b',
+    # .NET Interactive / F# `.Display("...a completer")` idiom (the existing
+    # patterns only cover Console.WriteLine / print).
+    r'\.Display\s*\([^)]*(?:a compl[ée]ter|compl[ée]ter)',
+    # Python assignment-stub: `result = None  # TODO etudiant` /
+    # `matrice = None  # Remplacez None`. `return None` only matches a return
+    # statement, not an assignment that defers the work to the student.
+    r'=\s*None\s*#.*(?:TODO|Remplacez|a compl[ée]ter|compl[ée]ter)',
 ]
 
 EXERCISE_HEADER_RE = re.compile(

--- a/scripts/notebook_tools/tests/test_detect_solution_leaks.py
+++ b/scripts/notebook_tools/tests/test_detect_solution_leaks.py
@@ -129,6 +129,48 @@ class TestIsStubCode:
         )
         assert is_stub_code(code) is True
 
+    def test_lean_dashdash_todo_is_stub(self):
+        # Lean line comments start with `--`, not `#` or `//`. Exercise stubs
+        # like `-- TODO etudiant` were systematically false-positive as HIGH
+        # leaks across the Lean notebooks (e.g. SocialChoice-02 cell 32).
+        code = (
+            "-- EXERCICE 4 : Verifier que le Pareto est respecte\n"
+            "-- TODO etudiant : calculer si la SWF respecte Pareto\n"
+            "#eval dictatorship_alice profils"
+        )
+        assert is_stub_code(code) is True
+
+    def test_lean_sorry_is_stub(self):
+        # `sorry` admits the goal — an exercise proof using it is a stub.
+        assert is_stub_code("theorem ex : 1 + 1 = 2 := by sorry") is True
+
+    def test_dotnet_display_a_completer_is_stub(self):
+        # .NET Interactive `.Display("...a completer")` idiom; the existing
+        # patterns only covered Console.WriteLine / print.
+        assert is_stub_code('display("Exercice 2 : stub a completer.")') is True
+        assert is_stub_code('foo.Display("stub a compléter")') is True
+
+    def test_python_assign_none_todo_is_stub(self):
+        # `matrice = None  # Remplacez None` defers the work to the student.
+        # `return None` only matches a return statement, not this assignment.
+        code = (
+            "matrice = None  # Remplacez None\n"
+            "transposee = None  # Remplacez None\n"
+            "produit = None  # TODO etudiant\n"
+            'print("resultats")'
+        )
+        assert is_stub_code(code) is True
+
+    def test_python_assign_none_without_stub_intent_not_stub(self):
+        # A bare `x = None` without a stub-intent comment is NOT a stub
+        # (avoids false-negative on real code that resets a variable).
+        assert is_stub_code("x = None\ny = compute(x)\nz = process(y)") is False
+
+    def test_real_lean_without_stub_not_stub(self):
+        # Regression guard: a real Lean proof with no sorry/TODO is not a stub.
+        code = "theorem add_comm (n m : Nat) : n + m = m + n := by\n  omega"
+        assert is_stub_code(code) is False
+
 
 # ---------------------------------------------------------------------------
 # EXERCISE_HEADER_RE


### PR DESCRIPTION
fix(detect-solution-leaks,#8053): expand STUB_PATTERNS for Lean/.NET/Python stub idioms

Companion recall fix to #8092 (attribution precision). #8092 reduces
false positives by better header attribution; this PR reduces them by
recognizing MORE legitimate stub idioms that the detector was missing,
so that correctly-stubbed exercise cells are not flagged as HIGH leaks.

Root cause (G.1 firsthand, cross-checked with po-2023's Lean/.NET finding):
STUB_PATTERNS covered `# TODO` / `// TODO` / `print("...a completer")` /
`Console.WriteLine(...)` / `pass` / `return None`, but missed four common
stub shapes, causing HIGH false positives on correctly-stubbed cells:

1. Lean `-- TODO etudiant` — Lean line comments start with `--`, not `#`/`//`.
   Verified firsthand on `02-Lean-SocialChoice-Formal.ipynb` cell 32 (a proper
   exercise stub, flagged HIGH).
2. Lean `sorry` tactic — admits the goal; an exercise proof using it is a stub.
3. .NET Interactive `.Display("...a completer")` — the existing patterns only
   covered `Console.WriteLine` / `print`, not the `.Display`/`display` idiom.
4. Python assignment-stub `result = None  # TODO etudiant` / `matrice = None  # Remplacez None`
   — `return None` only matches a return statement, not an assignment that
   defers the work to the student. Verified on `1.2-Manipulation_de_Donnees_avec_NumPy.ipynb` cell 12.

Each new pattern is gated to avoid false-negatives on real code: `.Display`
requires a "completer" string, the Python assignment-stub requires a
stub-intent comment after `= None`, and a real Lean proof without `sorry`/`-- TODO`
is not flagged (regression-guard test added).

Firsthand quantified on origin/main: repo HIGH count 84 -> 75 (9 more
legitimate stubs no longer misflagged). Combined with #8092 (111 -> 84),
the detector's HIGH count drops 111 -> 75 (-36 false positives, ~32%).

Residual FP classes remain (tracked, out of scope here): commented-out
solution + "implementez les TODO" prompt (Search-3 cell 64), and cross-cell
demo attribution across section boundaries (Kokoro cell 38, Infer-6 cells
20/35) — these are attribution-logic gaps, not stub-pattern gaps.

55 detector tests (49 existing + 6 new) and the full scripts/notebook_tools
suite (3270 passed) — 0 regression.

See #8053. Independent of #8092 (STUB_PATTERNS recall vs attribution logic).
Catalogue byte-identical to main. CRLF=0 (LF-normalised), no secrets inline.

Co-Authored-By: Claude <noreply@anthropic.com>
