### PR TITLE
docs(notebook-metadata,#8055): register DataScienceWithAgents Track1-LangChain + reorganize to dedicated section

### DIFF
--- a/docs/notebook-metadata/DATASET_REGISTRY.md
+++ b/docs/notebook-metadata/DATASET_REGISTRY.md
@@ -7,7 +7,7 @@
 
 ## Pourquoi ce registre
 
-L'open-courseware CoursIA héberge **~25 datasets pédagogiques** (CSV, ZIP, binaires) répartis sur 6 familles thématiques : ML/ML.Net, ML/DataScienceWithAgents, Probas/Infer, Probas/PyMC, QuantConnect/datasets, SymbolicAI/Argument_Analysis, SemanticWeb, RL, CaseStudies. Sans registre structuré :
+L'open-courseware CoursIA héberge **~25 datasets pédagogiques** (CSV, ZIP, binaires) répartis sur 9 familles thématiques : ML/ML.Net, ML/DataScienceWithAgents, Probas/Infer, Probas/PyMC, QuantConnect/datasets, SymbolicAI/Argument_Analysis, SemanticWeb, RL, CaseStudies. Sans registre structuré :
 
 1. **L'étudiant fork le repo et reproduit en aveugle** → les données ont peut-être été modifiées depuis la dernière publication, le notebook calcule sur des chiffres divergents, le claim devient faux.
 2. **Le coordinateur ne peut pas vérifier** la cohérence disque ↔ checksum avant publication open-courseware — impossible de garantir la reproductibilité d'un exercice.
@@ -60,15 +60,22 @@ Chaque ligne du registre respecte le schéma :
 
 ## Registre (pilote c.795)
 
-**20 entrées**, couvrant 8 familles thématiques. Toutes vérifiées firsthand via `sha256sum` au SHA `8092a4aec` (origin/main) le 2026-07-23.
+**22 entrées**, couvrant 9 familles thématiques. Toutes vérifiées firsthand via `sha256sum` au SHA `8092a4aec` (origin/main) le 2026-07-23, complétées au cycle c.797 (Track1-LangChain × 2 datasets ajoutés).
 
-### ML / ML.NET (5)
+### ML / ML.NET (4)
 
 | Chemin | Taille (B) | SHA256 (16 hex) | Licence | Catégorie | Usage | Card |
 |--------|----------:|-----------------|---------|-----------|-------|------|
 | `MyIA.AI.Notebooks/ML/ML.Net/daily-sales.csv` | 19 662 | `072b30f55ac726f7…` | SYNTHETIQUE-COURS | pedagogique-synthetique | ML-1/ML-2 ventes quotidiennes | — |
 | `MyIA.AI.Notebooks/ML/ML.Net/product-ratings.csv` | 4 881 | `306855179f4cd3e…` | SYNTHETIQUE-COURS | pedagogique-synthetique | ML.NET régression | — |
 | `MyIA.AI.Notebooks/ML/ML.Net/sample-classification.csv` | 11 431 | `9cb425ee99b4197…` | SYNTHETIQUE-COURS | pedagogique-synthetique | ML.NET classification | — |
+
+### ML / DataScienceWithAgents (3)
+
+| Chemin | Taille (B) | SHA256 (16 hex) | Licence | Catégorie | Usage | Card |
+|--------|----------:|-----------------|---------|-----------|-------|------|
+| `MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track1-LangChain/Day1-Foundations/Labs/sales_data.csv` | 163 | `fdfddb0640d83ef1…` | SYNTHETIQUE-COURS | pedagogique-synthetique | Track1 LangChain Day 1 foundations | — |
+| `MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track1-LangChain/Day3-Data-Agents/Labs/Lab4-DataWrangling/transactions.csv` | 280 | `ac49b1635d071a89…` | SYNTHETIQUE-COURS | pedagogique-synthetique | Track1 LangChain Lab4 DataWrangling | — |
 | `MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day4-Foundations/sales_data.csv` | 4 466 | `727a7ff0eface02…` | SYNTHETIQUE-COURS | pedagogique-synthetique | Google ADK Day 4 foundations | — |
 
 ### Probas / Infer.NET (5)


### PR DESCRIPTION
Grain: MED/docs-dataset-registry — lane myia-po-2025:CoursIA-2 — prev: MED/docs-hygiene-reference-repair (c.807)

## Substance

Sub-grain DataScienceWithAgents **post-pilote c.795** (PR #8083 MERGED). Le pilote avait inscrit **1 entrée** Track2-GoogleADK dans la section `### ML / ML.NET (5)` (logique mais topologiquement mal classé), laissant les **2 fichiers Track1-LangChain** (`sales_data.csv` + `transactions.csv`) non-référencés dans le registre, alors qu'ils sont chargés par `Lab4-DataWrangling.ipynb` (3 exercices, outputs réels).

Ce PR **complète c.797** ciblé par ai-01 (mandat msg-20260723T021139-unqtsi greenlight HIGH).

### Fix appliqué (1 fichier, +10/-3 atomic)

| Élément | Avant | Après |
|---------|-------|-------|
| Section `### ML / ML.NET` | (5) entrées | (4) entrées — Track2 retirée |
| Section `### ML / DataScienceWithAgents` | inexistante | **(3) entrées** nouvelle section |
| Compteur total intro | 20 entrées / 8 familles | **22 entrées / 9 familles** |
| Bug typo pré-existant | `6 familles thématiques` ligne 10 | `9 familles thématiques` (cohérent avec la liste Effective) |

### Choix DEEP vs MED scope (transparence ai-01)

ai-01 a dit `Vise DEEP/notebook-python`. Audit Lab4-DataWrangling.ipynb firsthand : **12 cellules code, toutes avec `execution_count: <int>` ET `outputs: [...]` cohérents** (statut C.2 OK, déjà SOTA-OK cf axe-2 ledger #017 c.421).

→ **Enrichissement artificiel = G.9 violation** (faux enrichissement sur notebook déjà conforme), donc je pivote sur **MED/docs-dataset-registry** = sub-grain acceptance accepté par ai-01 comme fallback. Pas de modification du notebook, pas de fausse ré-exécution. Substance = registre réel + cohérent.

### Entrées ajoutées (3 lignes nouvelles)

```
| MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track1-LangChain/Day1-Foundations/Labs/sales_data.csv | 163 | fdfddb0640d83ef1… | SYNTHETIQUE-COURS | pedagogique-synthetique | Track1 LangChain Day 1 foundations | — |
| MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track1-LangChain/Day3-Data-Agents/Labs/Lab4-DataWrangling/transactions.csv | 280 | ac49b1635d071a89… | SYNTHETIQUE-COURS | pedagogique-synthetique | Track1 LangChain Lab4 DataWrangling | — |
| MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day4-Foundations/sales_data.csv | 4 466 | 727a7ff0eface02… | SYNTHETIQUE-COURS | pedagogique-synthetique | Google ADK Day 4 foundations | — | (déplacée de ML/ML.NET)
```

### Validation locale

- **`scripts/audit/check_dataset_registry.py` Exit 0** avant ET après modif
- Avant : `total_entries: 20, ok_truncated_count: 20, drift: 0, missing: 0`
- Après : `total_entries: 22, ok_truncated_count: 22, drift: 0, missing: 0`
- Tous les 22 SHA256 vérifiés firsthand via `sha256sum` (cf listing validator)

### Conformité règles dures

- **c.187 atomic** : UNIQUE commit `6c1fa06ac` `+10/-3` (1 fichier)
- **R1 catalog-pr-hygiene** : `git diff origin/main..HEAD -- 'COURSE_CATALOG.generated.*'` = vide (catalog byte-identique)
- **R3 atomicité** : 1 sujet (registry inscription), 1 fichier < 15 (G.4 split)
- **L268 LF-only** : CR=0 sur le fichier (`python3 -c "print(data.count(b'\\r'))"` = 0)
- **c.281-L1 MD047** : trailing newline vérifié (`endswith(b'\\n')` = True)
- **L143 secrets-hygiene** : 0 hit grep `sk-|ghp_|AIza|password|token.*=` sur le diff (datasets sont pédagogiques synthétiques, pas de credentials)
- **L279 worker JAMAIS `gh pr merge`** : PR reste OPEN, DM ai-01 §H.4 sweep-ready post-commit
- **L283 anti-hallucination** : tous les SHA256 vérifiés firsthand via `sha256sum` sur disque + cross-check validator
- **L282 mirror-lanes collision** : `[CLAIMED]` dashboard posé AVANT de commencer le c.797 (post-c.807 worktree cleanup)
- **G-VAR-3 sub-genre rotation** : c.807 = MED/docs-hygiene-reference-repair ≠ c.797 = MED/docs-dataset-registry (sub-genres distincts, genre commun docs-hygiene accepté, séparés par pivot c.808)
- **G-VAR-1 plancher substance** : c.797 n'est PAS une LIGHT (registry inscription + audit first-hand + déplacement cohérent = substance MED > LIGHT)

### 3-prong C715-L2 verified firsthand AVANT claim

```
gh pr list --search "DataScienceWithAgents" --state all → 0 collisionnant sur dataset registry (PR #7878/#7766 = MANIFEST desc, substance distincte)
gh pr list --search "DATASET_REGISTRY|datasets.*registry" --state all → 1 antérieur PR #8083 MERGED pilote, sub-grain accepté
gh ls-tree origin/main docs/notebook-metadata/DATASET_REGISTRY.md → présent (sub-grain dans scope)
```

### Cross-refs protocole

- **Cadre théorique** : [#8055](https://github.com/jsboige/CoursIA/issues/8055) (tranche 2 — registre datasets)
- **Parent epic** : [#4208](https://github.com/jsboige/CoursIA/issues/4208) (open-courseware fiabilisé)
- **Sibling pilote** : [PR #8083](https://github.com/jsboige/CoursIA/pull/8083) c.795 DATASET_REGISTRY **MERGED 2026-07-23T00:13:43Z** SHA `14ac15ca`
- **Sibling audit-pattern** : [#8052](https://github.com/jsboige/CoursIA/issues/8052) (c.793 PR #8068 MERGED)
- **Sibling coût-matrice** : [#8056](https://github.com/jsboige/CoursIA/issues/8056) (c.794 PR #8073 MERGED)
- **Sibling docs-hygiene c.806** : PR #8107 OPEN (consolidation post-c.264 worker discipline)
- **Sibling c.807 docs-hygiene-reference-repair** : PR #8111 MERGED 2026-07-23T02:11:02Z SHA `0276639c`
- **Notebook audité** : `MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track1-LangChain/Day3-Data-Agents/Labs/Lab4-DataWrangling/Lab4-DataWrangling.ipynb` (12 cellules code, exécution C.2 OK)

### Suite logique (c.798+)

| Cycle | Cible |
|-------|-------|
| **c.797 (this PR)** | sub-grain `ML/DataScienceWithAgents` (3 entrées) |
| c.798 | sub-grain `QuantConnect` completeness (génération colonne `dataset` catalogue) |
| c.799 | sub-grain `ML/ML.Net` completeness (taxi-fare.csv si réintroduit) |
| c.800+ | Roulement famille par famille jusqu'à ~80% de couverture |

### Diff canonique

```
 docs/notebook-metadata/DATASET_REGISTRY.md | 13 ++++++++++---
 1 file changed, 10 insertions(+), 3 deletions(-)
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
