### PR TITLE
feat(notebook-tools,#8057): twin parity register tranche 3 — ML.NET/Python (8 pairs)

### DIFF
--- a/scripts/notebook_tools/twin_pairs.yaml
+++ b/scripts/notebook_tools/twin_pairs.yaml
@@ -15,8 +15,8 @@
 #   native-both = traduction fidele cellule-par-cellule (rare)
 #
 # PILOTE (po-2024, 2026-07-23) : famille SMT/Z3-API (6 paires, NB-01..06).
-# Les autres familles (Search/CSP, ML.NET/Python, etc.) sont a peupler dans des
-# PRs suivantes — ce registre est concu pour grandir. Voir #8057.
+# Familles suivantes peuplees dans des PRs ulterieurs : Search/Part1-Part2 (c.802/#8079, 7 paires)
+# + ML.NET/Python (c.803, 8 paires ; ML-6 ONNX exclu = format d'echange, SKIP per #4956 CLOSED). Voir #8057.
 
 - name: "Z3-Python-01 Introduction"
   family: SMT/Z3-API
@@ -223,3 +223,127 @@
     - "Idiomes framework : Python = `import heapq` (priority queue avec (f, tie_breaker, noeud)). C# = `PriorityQueue<AStarNode, double>` (f-cost = g + h)."
     - "Asymetrie pedagogique interessante : le notebook Python inclut une discussion sur l'admissibilite vs consistance des heuristiques (h <= h* + coherence), le C# se concentre sur les benchmarks (noeuds explores pour h=Manhattan vs h=Euclidean sur le meme probleme)."
     - "Pas d'extension solveur tiers - implementation from-scratch sur les deux cotes."
+
+# === Tranche ML.NET/Python (c.803, po-2024 2026-07-23) — acceptance #8057 checkbox 3 ===
+# 8 paires ML.NET(C#) <-> sklearn/statsmodels(Python). SHAs verifies firsthand `git ls-tree HEAD`.
+# ML-6 ONNX exclu : format d'echange (pas un algo ML), SKIP per campaign #4956 (CLOSED).
+
+- name: "ML-1 Introduction"
+  family: ML.NET/Python
+  python: MyIA.AI.Notebooks/ML/ML.Net/ML-1-Introduction-Python.ipynb
+  csharp: MyIA.AI.Notebooks/ML/ML.Net/ML-1-Introduction.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-23"
+    by: po-2024
+    python_sha: ca51aaf39444df06a6a134e84979fe0d4a8a06ce
+    csharp_sha: 4b5d5820394845d9f3f79edbc6716b4bce16abb6
+  known_differences:
+    - "Socle pedagogique commun : regression lineaire (R2, MAE) + regression logistique (accuracy, ROC-AUC). Dataset : prediction de prix / classification binaire."
+    - "Idiomes framework : C# = `Microsoft.ML` (API imperative MLContext -> PredictionEngine, schema via classes [ColumnName]). Python = `sklearn.linear_model` (LinearRegression, LogisticRegression) fonctionnel (estimator.fit/predict), metrics `r2_score, mean_absolute_error, accuracy_score, roc_auc_score`."
+    - "Meme concept demontre des deux cotes (pipeline regression de base) ; asymetrie d'idiome MLContext-vs-estimator, pas d'ecart algorithmique."
+
+- name: "ML-2 Data&Features"
+  family: ML.NET/Python
+  python: MyIA.AI.Notebooks/ML/ML.Net/ML-2-Data&Features-Python.ipynb
+  csharp: MyIA.AI.Notebooks/ML/ML.Net/ML-2-Data&Features.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-23"
+    by: po-2024
+    python_sha: 3c8120e47cb36b6fc4d6f28b05c778c7568bbe28
+    csharp_sha: 8927072ee91e058dd55eae7178913edc54acd06c
+  known_differences:
+    - "Socle pedagogique commun : featurization (encodage categoriel one-hot, normalisation, imputation) sur donnees tabulaires."
+    - "Idiomes framework : C# = `mlContext.Transforms.Categorical.OneHotEncoding` (OutputKind.Binary) sur IDataView (LoadFromEnumerable). Python = `sklearn.preprocessing` (OneHotEncoder, StandardScaler, SimpleImputer) composes via `ColumnTransformer` + `Pipeline`."
+    - "Difference conceptuelle : ML.NET exprime les transforms comme un pipeline chained (.Append), sklearn comme un ColumnTransformer declaratif (colonnes numeriques vs categorielles routees separement)."
+
+- name: "ML-3 Entrainement&AutoML"
+  family: ML.NET/Python
+  python: MyIA.AI.Notebooks/ML/ML.Net/ML-3-Entrainement-Python.ipynb
+  csharp: MyIA.AI.Notebooks/ML/ML.Net/ML-3-Entrainement&AutoML.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-23"
+    by: po-2024
+    python_sha: 37ab572c0337e78bccb3ffcb84b19004a5e59f3a
+    csharp_sha: a2bf6b309eccd8cf5429481c7fc13251f28e6726
+  known_differences:
+    - "Socle pedagogique commun : comparaison de trainers de regression (lineaire vs boosting) + evaluation RMSE train/test."
+    - "Zoos de modeles distincts : C# = `Regression.Trainers.Sdca` (Stochastic Dual Coord Ascent) + `LightGbm` (binding ML.NET LightGBM natif). Python = `LinearRegression` + `GradientBoostingRegressor, RandomForestRegressor, DecisionTreeRegressor, SVR` (ensemble sklearn)."
+    - "Asymetrie de couverture : Python expose nativement `GridSearchCV` + `cross_val_score` (recherche d'hyperparametres + CV K-fold) ; le C# compare manuellement SDCA vs LightGbm sans AutoML sur ce notebook (AutoML apparait en ML-4)."
+
+- name: "ML-4 Evaluation"
+  family: ML.NET/Python
+  python: MyIA.AI.Notebooks/ML/ML.Net/ML-4-Evaluation-Python.ipynb
+  csharp: MyIA.AI.Notebooks/ML/ML.Net/ML-4-Evaluation.ipynb
+  parity_level: surface
+  last_audit:
+    date: "2026-07-23"
+    by: po-2024
+    python_sha: 9e37f461f597d0b3d486672402540afd2718bffd
+    csharp_sha: cfee38be39500a5e92cfb680b8bdfde25eb24161
+  known_differences:
+    - "ASYSMETRIE MAJEURE DE PROFONDEUR : C# = 40 cellules de code (tour exhaustif d'evaluation : FastTree, OneHotEncoding, ReplaceMissingValues, Concatenate Features + `mlContext.Auto().Regression` AutoML complet) ; Python = 10 cellules (pendant tronque : LinearRegression + RandomForestRegressor + cross_validate/GridSearchCV)."
+    - "Le pendant Python couvre le CONCEPT (evaluer + GridSearchCV + metrics r2/MAE/MSE) mais n'egale pas l'exhaustivite du C# (AutoML ML.NET absent cote Python, feature engineering detaille reduit)."
+    - "parity_level = surface : meme theme (evaluation de modeles + recherche d'hyperparametres) mais le Python est une SELECTION, pas une parite cellule-par-cellule. A noter pour toute re-audit : combler l'ecart exigerait d'etendre le Python (multi-cycle, cf memo #4956)."
+
+- name: "ML-5 TimeSeries"
+  family: ML.NET/Python
+  python: MyIA.AI.Notebooks/ML/ML.Net/ML-5-TimeSeries-Python.ipynb
+  csharp: MyIA.AI.Notebooks/ML/ML.Net/ML-5-TimeSeries.ipynb
+  parity_level: surface
+  last_audit:
+    date: "2026-07-23"
+    by: po-2024
+    python_sha: 9d5f13fc2f7b50016a09ab696eeeb604068c3215
+    csharp_sha: 118f3b0a0b682cc8d6e7c368d9f1d49f6a56d460
+  known_differences:
+    - "FAMILLES ALGORITHMIQUES DIFFERENTES (pas un simple idiome swap) : C# = `Microsoft.ML.Transforms.TimeSeries` -> `ForecastBySsa` (Singular Spectrum Analysis, decomposition spectrale ML.NET-native). Python = `statsmodels` -> `STL` (seasonal-trend LOESS decomposition) + `SARIMAX` (seasonal ARIMA classique)."
+    - "Aucune lib Python n'expose SSA de facon pedagogique equivalente ; le pendant Python choisit donc l'approche statistique classique (STL+SARIMAX) pour couvrir le meme besoin (forecast saisonnier) avec un OUTIL different."
+    - "parity_level = surface : meme probleme (prevision de series temporelles avec saisonnalite) mais algorithmes distincts (SSA spectral vs STL/SARIMAX statistique). Les resultats numeriques ne sont pas directement comparables ; c'est une parite de OBJECTIF pedagogique, pas de methode."
+
+- name: "ML-7 Recommendation"
+  family: ML.NET/Python
+  python: MyIA.AI.Notebooks/ML/ML.Net/ML-7-Recommendation-Python.ipynb
+  csharp: MyIA.AI.Notebooks/ML/ML.Net/ML-7-Recommendation.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-23"
+    by: po-2024
+    python_sha: b823380d75f0d87b9666fe6c5458cfe7566e2a28
+    csharp_sha: a36aa7a2e12bd343ca79c738a954aad255ecd070
+  known_differences:
+    - "Socle pedagogique commun : filtrage collaboratif par factorisation de matrices (recommandation user-item, K facteurs latents)."
+    - "Idiomes framework : C# = `mlContext.Recommendation().Trainers.MatrixFactorization` (trainer dedie + MapValueToKey pour UserId/MovieId). Python = `sklearn.decomposition.NMF` (Non-negative Matrix Factorization generique, init='nndsvda', solver='mu') avec erreur de reconstruction explicite."
+    - "Difference conceptuelle : ML.NET expose un trainer SPECIALISE recommandation (MatrixFactorization avec метriques de ranking) ; sklearn NMF est un decomposeur generique applique a la matrice user-item. Meme mathematique de fond (factorisation), abstraction differente."
+
+- name: "ML-8 Clustering"
+  family: ML.NET/Python
+  python: MyIA.AI.Notebooks/ML/ML.Net/ML-8-Clustering-Python.ipynb
+  csharp: MyIA.AI.Notebooks/ML/ML.Net/ML-8-Clustering.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-23"
+    by: po-2024
+    python_sha: 1ca21efdd41f9b57fde4ee7b24b98f0b24ba8f1e
+    csharp_sha: fdc7675363c636a501ae52efb6247dab610a96ed
+  known_differences:
+    - "Socle pedagogique commun : K-Means (K=3) avec normalisation MinMax preprocess ; evaluation par metriques de cohesion de clusters."
+    - "Parite conceptuelle proche du natif : C# = `mlContext.Clustering.Trainers.KMeans(\"Features\", numberOfClusters: 3)` + `NormalizeMinMax`, prediction via `PredictedClusterId` (uint). Python = `sklearn.cluster.KMeans(n_clusters=3, n_init=10)` + `MinMaxScaler` via Pipeline."
+    - "Asymetrie de metriques : Python expose `davies_bouldin_score` + `silhouette_score` (comparaison de qualite de clustering) ; le C# se concentre sur l'affectation PredictedClusterId. n_init=10 explicite cote Python (ML.NET gere les restarts en interne)."
+
+- name: "ML-9 Anomaly-Detection"
+  family: ML.NET/Python
+  python: MyIA.AI.Notebooks/ML/ML.Net/ML-9-Anomaly-Detection-Python.ipynb
+  csharp: MyIA.AI.Notebooks/ML/ML.Net/ML-9-Anomaly-Detection.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-23"
+    by: po-2024
+    python_sha: c4aaf62d0cf0271f014827793f96aa70c7dd15d5
+    csharp_sha: f23f6817497f2fc9bf7170214941b1d418f127c0
+  known_differences:
+    - "Socle pedagogique commun : detection d'anomalies par PCA (Analyse en Composantes Principales) sur donnees capteurs."
+    - "Idiomes framework : C# = `mlContext.AnomalyDetection.Trainers.RandomizedPca` (trainer dedie qui encapsule le scoring d'anomalie). Python = `sklearn.decomposition.PCA` brut (l'utilisateur construit le score d'erreur de reconstruction manuellement) + `roc_auc_score`."
+    - "Difference d'abstraction : ML.NET fournit un trainer ANOMALIE complet (scoring + seuillage integres) ; sklearn fournit le decomposeur PCA et laisse le pipeline de scoring a l'utilisateur. Meme fondement mathematique (PCA randomized), niveau d'abstraction different."


### PR DESCRIPTION
Grain: MED/tooling-extension — lane myia-po-2024:CoursIA (GLM-5.1) — prev: Infer-3 audit verdict (#8081)

## Summary

Extension du registre de parité des jumeaux Python/C# (`scripts/notebook_tools/twin_pairs.yaml`, #8057 parent #4208) — **tranche 3** sur la famille **ML.NET/Python** : 8 paires `ML-N.ipynb` (C# ML.NET) ⇄ `ML-N-Python.ipynb` (Python sklearn/statsmodels), ML-1..5,7..9. **Satisfait l'acceptance #8057 checkbox 3** (« Pilote sur une paire Search/CSP + une paire ML.NET/Python ») — complète c.801 (SMT/Z3-API, 6 paires) + c.802/#8079 (Search/Part1+Part2, 7 paires).

**ML-6 ONNX exclu** : format d'échange (pas un algorithme ML), twin Python sans sens algorithmique — SKIP documenté per campaign #4956 (CLOSED, décision superseded c.N+58).

## Litmus Variation (R6/G-VAR-3)

Substance distincte vs c.801/c.802 : ni Z3-API ni idiomes framework de Search. Ici c'est la **parité ML.NET ⇄ sklearn/statsmodels** — un zoo d'algorithmes où l'écart n'est pas un simple idiome swap mais parfois une **famille algorithmique différente** (ML-5 : `ForecastBySsa` ML.NET-native vs `STL`+`SARIMAX` statsmodels classique). 8 paires couvrent 5 concepts ML canoniques (intro/régression, featurization, entraînement+AutoML, évaluation, séries temporelles, recommandation, clustering, anomaly detection).

## Preuves vérifiables (G.1)

**8 paires SHA-vérifiées firsthand** via `git ls-tree HEAD` (2026-07-23, worktree base `0276639ce`). `known_differences` citent les **VRAIES** API calls lues dans les notebooks (pas du boilerplate générique) :

| ML | C# (ML.NET) | Python (sklearn/statsmodels) | parity_level |
|----|-------------|------------------------------|--------------|
| ML-1 Intro | `MLContext`, `PredictionEngine` | `sklearn.linear_model` (LinearRegression, LogisticRegression) | semantic |
| ML-2 Data&Features | `Transforms.Categorical.OneHotEncoding` (IDataView) | `ColumnTransformer` + `Pipeline` (OneHotEncoder, StandardScaler, SimpleImputer) | semantic |
| ML-3 Entraînement | `Regression.Trainers.Sdca` + `LightGbm` | `GradientBoostingRegressor`, `RandomForestRegressor`, `SVR` + `GridSearchCV` | semantic |
| ML-4 Evaluation | `mlContext.Auto().Regression` + FastTree (40 cells) | `LinearRegression`+`RandomForestRegressor`+`cross_validate` (10 cells) | **surface** |
| ML-5 TimeSeries | `ForecastBySsa` (Singular Spectrum Analysis) | `statsmodels` `STL` + `SARIMAX` | **surface** |
| ML-7 Recommendation | `Recommendation().Trainers.MatrixFactorization` | `sklearn.decomposition.NMF` | semantic |
| ML-8 Clustering | `Clustering.Trainers.KMeans(numberOfClusters:3)` + `NormalizeMinMax` | `sklearn.cluster.KMeans(n_clusters=3, n_init=10)` + `MinMaxScaler` + silhouette | semantic |
| ML-9 Anomaly | `AnomalyDetection.Trainers.RandomizedPca` | `sklearn.decomposition.PCA` brut + `roc_auc_score` | semantic |

**ML-4 et ML-5 flaggées `surface`** (honnête, pas gonflé en `semantic`) :
- ML-4 : asymétrie de profondeur majeure (40 vs 10 cellules C#→Python) — le pendant Python est une sélection, l'AutoML ML.NET est absent côté Python.
- ML-5 : familles algorithmiques différentes (SSA spectral vs STL/SARIMAX statistique) — parité d'OBJECTIF pédagogique, pas de méthode.

## Validation

- `python scripts/notebook_tools/check_twin_parity.py` → **21 pairs OK, DRIFT=0, MISSING=0** (acceptance #2 = drift checker, passe ; les SHAs audités sont frais = HEAD).
- `yaml.safe_load` parse OK (21 entrées, 8 ML.NET/Python).
- 0 CRLF, header PILOTE comment mis à jour pour refléter la famille ML.NET/Python peuplée.

## Scope

Single file (`twin_pairs.yaml`), +126/-2. Append-only (aucune entrée existante modifiée). Pas de notebook touché, pas de catalogue.

See #8057 (contribution partielle — checkbox pilote ML.NET/Python satisfaite ; le registre est conçu pour grandir vers les familles restantes : SemanticWeb/Tweety/GameTheory .NET⇄Python). Parent epic #4208 open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)