### PR TITLE
fix(detect-solution-leaks,#8053): cross-cell attribution guard — intervening same/higher header breaks exercise

### DIFF
--- a/scripts/notebook_tools/detect_solution_leaks.py
+++ b/scripts/notebook_tools/detect_solution_leaks.py
@@ -125,6 +125,49 @@ def code_cell_first_comment_labels_example(source: str) -> bool:
     return False
 
 
+def _header_level(line: str) -> int:
+    """Return the ATX heading level (count of leading ``#``), or 0 if not a
+    header line."""
+    m = re.match(r'^(#{1,6})\s', line)
+    return len(m.group(1)) if m else 0
+
+
+def intervening_section_breaks_attribution(cells, exercise_idx, code_idx) -> bool:
+    """Return True if a markdown header at the same or higher level than the
+    exercise header appears between ``exercise_idx`` and ``code_idx``.
+
+    A same-or-higher-level header (e.g. ``## Conclusion``, ``## Section 6``,
+    or a ``### 6.1 ...`` sibling of ``### Exercice 2``) starts a new section and
+    breaks the attribution of the code cell to the exercise: the code then
+    belongs to that later section, not the exercise. A DEEPER sub-header (e.g.
+    ``### Indice`` under a ``## Exercice 1``) does NOT break the section (it is
+    a child of the exercise, common in worked exercise scaffolding).
+
+    This suppresses cross-cell false positives where a demo/visualisation code
+    cell sits a few cells after an exercise header but is actually owned by a
+    later ``## Conclusion`` / ``## Section N`` section. Cf exercise-example-labeling.md
+    (content-based rule). Safe default: if the exercise header level cannot be
+    determined, do not suppress.
+    """
+    ex_src = ''.join(cells[exercise_idx].get('source', []))
+    ex_level = 0
+    for line in ex_src.split('\n'):
+        if EXERCISE_HEADER_RE.search(line):
+            ex_level = _header_level(line)
+            break
+    if not ex_level:
+        return False
+    for k in range(exercise_idx + 1, code_idx):
+        cell = cells[k]
+        if cell.get('cell_type') != 'markdown':
+            continue
+        src = ''.join(cell.get('source', []))
+        for header_line in HEADER_LINE_RE.findall(src):
+            if _header_level(header_line) <= ex_level:
+                return True
+    return False
+
+
 def is_stub_code(source: str) -> bool:
     """Check if code cell source is a stub (not a real solution)."""
     lines = source.strip().split('\n')
@@ -222,6 +265,14 @@ def scan_notebook(path: str) -> list[dict]:
             # section — no markdown sub-header to attribute to. Cf exercise-example-labeling.md.
             if (closest_preceding_header_is_example(cells, next_code_idx)
                     or code_cell_first_comment_labels_example(next_code_source)):
+                continue
+            # Cross-cell attribution guard: if a same-or-higher-level markdown
+            # section header (e.g. "## Conclusion", "## Section 6", a "### 6.1"
+            # sibling) appears between the exercise header and this code cell,
+            # the code belongs to that later section, not the exercise. Suppress
+            # the false positive. A deeper sub-header ("### Indice" under
+            # "## Exercice 1") does not break the section.
+            if intervening_section_breaks_attribution(cells, i, next_code_idx):
                 continue
             solution_markers = bool(SOLUTION_MARKER_RE.search(next_code_source))
             if solution_markers or len(next_code_source.strip().split('\n')) > 8:

--- a/scripts/notebook_tools/tests/test_detect_solution_leaks.py
+++ b/scripts/notebook_tools/tests/test_detect_solution_leaks.py
@@ -564,3 +564,53 @@ class TestWorkedExampleFalsePositiveSuppression:
         findings = scan_notebook(str(nb))
         assert not any(f.get("severity") == "HIGH" for f in findings)
 
+    def test_cross_cell_higher_header_breaks_attribution(self, tmp_path):
+        # The Kokoro / Infer-6 residual false positive: an "### Exercice 3"
+        # header, then an intervening SAME-OR-HIGHER-level section header
+        # ("## Conclusion"), then a demo code cell. The code belongs to the
+        # Conclusion section, not the exercise — the intervening header breaks
+        # the attribution. Without the guard this is wrongly flagged HIGH.
+        nb = _write_nb(
+            tmp_path / "nb.ipynb",
+            [
+                _md("---\n\n### Exercice 3 : Synthese\n\nObjectif..."),
+                _md("## Conclusion\n\nRecap."),
+                _code(_SOLUTION_BODY),
+            ],
+        )
+        findings = scan_notebook(str(nb))
+        assert not any(f.get("severity") == "HIGH" for f in findings)
+
+    def test_cross_cell_sibling_header_breaks_attribution(self, tmp_path):
+        # Same-level sibling header also breaks: "### Exercice 2" (level 3)
+        # followed by "### 6.1 Fonctions" (level 3 sibling) then a code cell.
+        # The code belongs to section 6.1, not the exercise.
+        nb = _write_nb(
+            tmp_path / "nb.ipynb",
+            [
+                _md("### Exercice 2 : Impact du prior\n\nObjectif..."),
+                _md("### 6.1 Fonctions de diagnostic\n\nDetails..."),
+                _code(_SOLUTION_BODY),
+            ],
+        )
+        findings = scan_notebook(str(nb))
+        assert not any(f.get("severity") == "HIGH" for f in findings)
+
+    def test_deeper_subheader_does_not_break_attribution(self, tmp_path):
+        # Recall guard: a DEEPER sub-header ("### Indice" under a "## Exercice 1"
+        # level-2 header) is a CHILD of the exercise, not a new section. The code
+        # after it is still the exercise's and MUST stay flagged (no recall
+        # regression from the cross-cell guard).
+        nb = _write_nb(
+            tmp_path / "nb.ipynb",
+            [
+                _md("## Exercice 1 : Objectif\n\nEnonce..."),
+                _md("### Indice\n\nPensez a la reciprocite."),
+                _code(_SOLUTION_BODY),
+            ],
+        )
+        findings = scan_notebook(str(nb))
+        highs = [f for f in findings if f.get("severity") == "HIGH"]
+        assert len(highs) == 1
+        assert highs[0]["cell_index"] == 2
+


### PR DESCRIPTION
## Summary

Closes the **cross-cell attribution** false-positive class of `detect_solution_leaks.py` — one of the two OPEN FP classes that block de-HOLD of #8084 (per ai-01 msg-20260723T020241). Purely additive: 51 lines added in the detector, 0 deleted; 3 new tests.

## Root cause

The flagging loop finds an `Exercice` header at cell `i`, then looks forward (`i+1..i+3`) for the next code cell, **without checking whether an intervening markdown section header breaks the attribution**. A demo/visualisation code cell sitting a few cells after an exercise header but actually owned by a later section (`## Conclusion`, `## Section 6`, a `### 6.1` sibling) was wrongly flagged HIGH.

Concrete cases identified firsthand (c.674/675, re-verified this cycle on origin/main):
- **Kokoro `01-5-Kokoro-TTS-Local.ipynb` cell 38** — `### Exercice 3` (cell 35) → `## Conclusion` (cell 36) → `## Section 6` (cell 37) → Inflect-Nano demo (cell 38). The demo belongs to Section 6, not Exercice 3.
- **Infer-6 `Infer-6-Debugging.ipynb` cell 35** — `### Exercice 2` (cell 32) → `## 6. Checklist` (cell 33) → `### 6.1 Fonctions` (cell 34) → diagnostic utility (cell 35). Belongs to 6.1, not Exercice 2.

## Fix

New helper `intervening_section_breaks_attribution(cells, exercise_idx, code_idx)`:
- Determines the exercise header level (count of leading `#`).
- Scans intervening markdown cells; if a header at **the same or higher level** appears (a sibling or parent section start), the attribution breaks → suppress.
- A **deeper** sub-header (`### Indice` under `## Exercice 1`) does NOT break (it is a child of the exercise — common in worked scaffolding).
- Safe default: if the exercise level can't be determined, do not suppress.

Gated in the flagging loop right after the existing example-suppression checks.

## Recall safety

A real exercise solution never sits after a `## Conclusion` / `## Section N` header — it is directly under the exercise header or under a deeper sub-header. The guard only fires when a section break intervenes. Pinned by `test_deeper_subheader_does_not_break_attribution`: code after `### Indice` under `## Exercice 1` stays flagged.

## Empirical validation (G.1, apples-to-apples)

Ran OLD detector (origin/main) vs NEW detector (this branch) on the same origin/main notebook set:

| | HIGH count |
|---|---|
| OLD (origin/main) | 48 |
| NEW (this branch) | 39 |
| **Delta** | **−9** |

All **9 suppressed findings verified firsthand as false positives** (0 real leaks suppressed):

| Notebook:cell | Why it's a FP |
|---|---|
| Kokoro cell 38 | Inflect-Nano demo under `## Section 6` |
| Infer-6 cell 35 | diagnostic utility under `### 6.1 Fonctions` |
| QC-Py-12 cell 31 | teaching fn `calculate_drawdown_series` under `Partie 2 / 2.1` |
| QC-Py-12 cell 71 | teaching fn `calculate_rolling_statistics` under `6.2` |
| QC-Py-13 cell 17 | `# [REFERENCE QC] Code a copier... non executable` under `3.1` |
| QC-Py-13 cell 43 | conceptuel reference under `Composite` section |
| MGS-2 cell 21 | Section 5 Rastrigin demo |
| Lean-16b cell 2 | `import sys; from pathlib import Path` setup |
| Tweety-4 cell 34 | worked example (`# Exemple guide : Diagnostic meteo`) — different topic from the exercise (legitimate per exercise-example-labeling.md) |

## Tests

3 new tests (`test_cross_cell_higher_header_breaks_attribution`, `test_cross_cell_sibling_header_breaks_attribution`, `test_deeper_subheader_does_not_break_attribution`) + 71 existing = **74 passed**.

## Scope / residual

Closes the cross-cell FP class. Remaining OPEN FP class blocking #8084 de-HOLD: **commented-solution-prompt** (Search-3 cell 64) — separate cycle. Also leaves Infer-6 cell 20 (demo/visualisation under exercise header *without* intervening section break — harder semantic class, not decidable by a header-level heuristic). All three (this PR, commented-solution, cell-20 class) are independent precision improvements; this PR is self-contained.

See #8053 (epic). No issue auto-close (incremental precision on an epic, partial).
