### PR TITLE
fix(gametheory,#3801): GT-11 Bayesian auction right-panel revenue n=10 (0.90 -> 0.82)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-11-BayesianGames.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-11-BayesianGames.ipynb
@@ -1554,7 +1554,7 @@
     "- Avec n=10, on offre 90% de sa valeur (competition intense)\n",
     "\n",
     "**Visualisation de droite** : Le revenu du vendeur croit avec n :\n",
-    "- De 0.33 avec 2 joueurs jusqu'a 0.90 avec 10 joueurs\n",
+    "- De 0.33 avec 2 joueurs jusqu'a 0.82 avec 10 joueurs\n",
     "- Convergence vers 1.0 quand n → ∞ (concurrence parfaite)\n",
     "- La concurrence profite au vendeur, pas aux acheteurs\n",
     "\n",


### PR DESCRIPTION
## Defect (firsthand verified, G.1)

`GameTheory-11-BayesianGames.ipynb` cell 32 — right panel of "Interpretation : Strategies d'enchere" — claimed seller revenue grows:

> Le revenu du vendeur croit avec n : De 0.33 avec 2 joueurs jusqu'a **0.90 avec 10 joueurs**

The **0.90 is wrong**. It is the **bid fraction** b(v) = (n-1)/n = 9/10 = 0.90 (the left panel's strategy metric, where it is correct: "avec n=10, on offre 90% de sa valeur"). The **revenue** follows E[R] = (n-1)/(n+1):
- n=2 -> 1/3 = 0.333 (the "0.33" endpoint is **correct**)
- n=10 -> 9/11 = **0.818** (not 0.90)

The committed cell 28 `compare_auctions` output confirms n=10 revenue = **0.8175** (1er prix) / **0.8186** (2e prix) / **0.8182** (theorie) — all ~0.818, nowhere near 0.90. The Note technique in the same cell states E[R] = (n-1)/(n+1).

The author conflated the bid fraction (left panel) with the revenue (right panel). A student reading "0.90 revenue at n=10" and checking the table would find 0.818 — a contradiction.

## Fix

Markdown-only, single character group: `0.90` -> `0.82` in the right-panel revenue line (matches the 2-decimal style of "0.33"; grounded in the (n-1)/(n+1) value 0.818). The n=2 endpoint (0.33) was already correct. The left-panel bid claim "90% de sa valeur" is **preserved** (it is the correct bid-fraction metric).

## Validation

- **Markdown-only** (C.2 exception: prior outputs valid, no re-exec). All other cells byte-identical.
- **Byte-identical round-trip** (`json.dumps(indent=1, ensure_ascii=False)` + LF): diff = `+1 / -1`, delta 0 bytes.
- Guards: no "0.90 avec 10 joueurs" remains; left-panel "90% de sa valeur" preserved; 0 unexecuted code cells (H.3 PASS); `nbformat` 4.5 valid.

## Scope

1 file, +1/-1, 1 notebook. Grain: MED/doc-honesty (lane `myia-po-2023:CoursIA`). G-VAR-3: previous cycle was enrichment, this cycle doc-honesty = distinct genre.

See #3801.