### PR TITLE
fix(sudoku): cell 18 stale output — restore sibling-consistent test harness (C.2)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Python.ipynb
@@ -926,14 +926,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "Exercice a completer\n"
+      "Resultat de la comparaison : None\n"
      ]
     }
    ],
@@ -943,7 +943,11 @@
     "    # TODO: Comparez les deux solveurs sur les memes puzzles\n",
     "    # Retournez un dict avec les temps et nombre d'appels pour chaque solveur\n",
     "    result = None  # TODO etudiant\n",
-    "    return result\n"
+    "    return result\n",
+    "\n",
+    "# Test : la comparaison renvoie None tant que l'exercice n'est pas complete\n",
+    "resultat_comparaison = compare_solvers(easy_puzzles[:3])\n",
+    "print(f\"Resultat de la comparaison : {resultat_comparaison}\")  # None attendu (a completer)"
    ],
    "id": "cell-eaef66b3"
   },


### PR DESCRIPTION
## Summary

Fixes a C.2 / doc-honesty defect in `Sudoku-1-Backtracking-Python.ipynb` cell 18: an **un-reproducible committed output**. Purely additive test harness (4 lines), no solution filled.

## Root cause (G.1 firsthand, determinism gate)

Cell 18 (`# EXERCICE : Comparer les performances Backtracking simple vs MRV`) defined `compare_solvers` (stub returning `result = None`) with **no module-level test call**. So a fresh `nbconvert --execute` produces **no output** — contradicting the committed output `"Exercice a completer"`.

Every sibling exercise stub in the notebook follows a consistent pattern:

| Cell | Stub return | Module-level test print | Reproducible output |
|------|-------------|-------------------------|---------------------|
| 10 `is_valid_solution` | `False` | `print(f"Solution valide : {...}")` | `Solution valide (puzzle de test) : False` |
| 27 `count_solutions` | `0` | `print(f"Nombre de solutions: {nb}")` | `Nombre de solutions: 0` |
| 31 `count_first_col_placements` | `None` (pass) | `print(f"Nombre de placements ... : {nb_col}")` | `Nombre de placements valides ... : None` |
| **18 `compare_solvers`** | `None` | **(none)** | committed `"Exercice a completer"` — **un-reproducible** |

Cell 18 was the lone outlier: missing its test harness, with a stale marker output from an earlier version.

## Fix (Stop & Repair — re-execute, never hand-edit output)

Added the module-level test call matching the sibling pattern. The **stub is untouched** (`result = None  # TODO etudiant`, `return result`) — the exercise is **not solved**. Only an honest placeholder print is added, so a fresh exec now shows the stub's `None`, consistent with cells 10/27/31 surfacing `False`/`0`/`None`.

New reproducible output: `Resultat de la comparaison : None`.

## Validation

- **nbconvert EXEC_PROVED** (determinism gate): re-executed cell 18, `execution_count` 1 -> 8, output `Resultat de la comparaison : None`.
- **H.3**: 0 unexecuted code cells.
- **nbformat validate**: OK.
- **0 CRLF** (LF-normalized).
- **Catalogue byte-identical** to main.
- **Leak detector**: 0 HIGH — cell 18 correctly classified as a stub (`result = None  # TODO`), NOT flagged.
- **Surgical merge (C.3)**: only cell 18 source + output + execution_count changed; all 32 other cells byte-identical to origin/main. Volatile benchmark timings (cells 15/20) and the normalized `<repo>` path (cell 3) left untouched.

## Diff

8 insertions / 4 deletions, 1 file, 1 cell.

See #3801 (doc-honesty). No issue auto-close (incremental C.2 fix on a mature notebook; the broader doc/code-honesty vein is drained fleet-wide).

Co-Authored-By: Claude <noreply@anthropic.com>
