### PR TITLE
fix(detect-solution-leaks,#8053): commented-template stub guard (commented-out solution + prompt print)

### DIFF
--- a/scripts/notebook_tools/detect_solution_leaks.py
+++ b/scripts/notebook_tools/detect_solution_leaks.py
@@ -190,6 +190,79 @@ def is_stub_code(source: str) -> bool:
     return False
 
 
+# A code line that DEFINES a new construct (function/class/proof). When such a
+# line is EXECUTABLE (not commented out), the cell contains a real definition and
+# cannot be a pure commented-template stub. Used by commented_template_stub as a
+# fast early-exit (the real recall guard is the "non-trivial executable line"
+# fallback below it).
+EXECUTABLE_DEFINITION_RE = re.compile(
+    r'^\s*(?:def |class |struct |namespace |interface |enum |theorem |lemma |defn |'
+    r'inductive |instance |record |void |int |bool |string |float |double |var )',
+)
+
+# A prompt / TODO marker indicating the cell is a skeleton left for the student.
+# A real complete solution never carries one of these.
+PROMPT_MARKER_RE = re.compile(
+    r'(?:TODO|a compl[ée]ter|compl[ée]ter|impl[ée]mentez|impl[ée]menter|'
+    r'[àa] compl|votre code|student fills|etudiant|r[ée]pondez|r[ée]aliser)',
+    re.IGNORECASE,
+)
+
+
+def commented_template_stub(source: str) -> bool:
+    """Return True if the cell is a "commented-template" exercise stub.
+
+    Some exercise cells embed the FULL solution as COMMENTED-OUT code (``# ...``,
+    ``// ...``, ``-- ...``) plus a small amount of executable scaffolding (data
+    assignments, a prompt print), so the student uncomments and fills the TODOs.
+    Such a cell is a legitimate exercise skeleton, NOT a solution leak — but it
+    trips ``len(source) > 8`` and has no matching STUB_PATTERN, so it is a HIGH
+    false positive. Suppresses that FP.
+
+    Recall-safe: a real (complete) solution always has EITHER an executable
+    definition (``def``/``class``/``theorem``/...) OR at least one non-trivial
+    executable line (a loop, a solver call, ...). Both make this return False.
+    Only cells whose executable code is ENTIRELY trivial (assignments, prints,
+    imports, collection literals) AND that carry a prompt/TODO marker are
+    suppressed. A complete solution never carries a prompt marker.
+
+    Cf exercise-example-labeling.md (content-based rule).
+    """
+    exec_lines = []
+    for raw in source.split('\n'):
+        s = raw.strip()
+        if not s:
+            continue
+        # comment lines for the languages in this repo
+        if (s.startswith('#') or s.startswith('//') or s.startswith('--')
+                or s.startswith('(*') or s.startswith('/*') or s.endswith('*)') or s.endswith('*/')):
+            continue
+        exec_lines.append(s)
+
+    # Fast early-exit: an executable definition => real code, not a template.
+    if any(EXECUTABLE_DEFINITION_RE.search(l) for l in exec_lines):
+        return False
+
+    # Every executable line must be trivial (assignment / print / import /
+    # collection literal / closing bracket). ANY non-trivial line (loop, call,
+    # statement) => real code => not a template.
+    for s in exec_lines:
+        if s.startswith(('print(', 'Print(', 'Console.', 'Display(', 'printf', 'puts(', 'puts ')):
+            continue
+        if s.startswith(('import ', 'from ', 'using ', 'open ', 'require ', '#!')):
+            continue
+        if re.match(r'^[A-Za-z_][\w\[\]."\']*\s*(?:=|:=)', s):  # assignment target = / :=
+            continue
+        if s.startswith(('[', '(', '{', '{|')) or s.endswith((']', ')', '}', ',', '|}')):
+            continue  # collection literal / continuation
+        if s in (']', ')', '}', '|}'):
+            continue
+        return False  # non-trivial executable line -> not a pure template
+
+    # Must carry a prompt/TODO marker (a complete solution never does).
+    return bool(PROMPT_MARKER_RE.search(source))
+
+
 def scan_notebook(path: str) -> list[dict]:
     """Scan a single notebook for solution leaks."""
     findings = []
@@ -273,6 +346,14 @@ def scan_notebook(path: str) -> list[dict]:
             # the false positive. A deeper sub-header ("### Indice" under
             # "## Exercice 1") does not break the section.
             if intervening_section_breaks_attribution(cells, i, next_code_idx):
+                continue
+            # Commented-template stub: the whole solution is commented out and
+            # only data assignments + a prompt print execute (the student
+            # uncomments and fills the TODOs). A legitimate exercise skeleton,
+            # not a leak. Suppresses the commented-solution-prompt FP class.
+            # Recall-safe: a real solution has an executable def/class or a
+            # non-trivial executable line, which makes the helper return False.
+            if commented_template_stub(next_code_source):
                 continue
             solution_markers = bool(SOLUTION_MARKER_RE.search(next_code_source))
             if solution_markers or len(next_code_source.strip().split('\n')) > 8:

--- a/scripts/notebook_tools/tests/test_detect_solution_leaks.py
+++ b/scripts/notebook_tools/tests/test_detect_solution_leaks.py
@@ -19,6 +19,7 @@ from detect_solution_leaks import (
     STUB_PATTERNS,
     closest_preceding_header_is_example,
     code_cell_first_comment_labels_example,
+    commented_template_stub,
     discover_notebooks,
     is_stub_code,
     scan_notebook,
@@ -613,4 +614,121 @@ class TestWorkedExampleFalsePositiveSuppression:
         highs = [f for f in findings if f.get("severity") == "HIGH"]
         assert len(highs) == 1
         assert highs[0]["cell_index"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Commented-template stub (commented-solution-prompt precision fix)
+# ---------------------------------------------------------------------------
+
+class TestCommentedTemplateStub:
+    # A code cell whose whole solution is COMMENTED OUT and whose only
+    # executable code is data assignments + a prompt print is a legitimate
+    # exercise skeleton (the student uncomments and fills the TODOs), not a
+    # leak. The helper returns True (suppress) for these.
+
+    def test_commented_python_class_plus_data_is_stub(self):
+        # The measured Search-3 cell 64 false positive: WeightedGridProblem
+        # class + weighted_manhattan + A* call all commented out, only the
+        # weighted_grid test data and a prompt print execute.
+        code = (
+            "# --- Exercice 5 : Pathfinding sur grille ponderee ---\n"
+            "# class WeightedGridProblem(GridProblem):\n"
+            "#     def actions(self, state):\n"
+            "#         return [...]\n"
+            "#     def step_cost(self, state, action, next_state):\n"
+            "#         pass  # student fills here\n"
+            "# def weighted_manhattan(state, goal, min_cost):\n"
+            "#     pass  # student fills here\n"
+            "weighted_grid = [\n"
+            "    [2, 2, 2, 2, 2, 2, 2, 2],\n"
+            "    [2, 3, 3, 3, 0, 2, 2, 2],\n"
+            "]\n"
+            'print("Exercice 5 : implementez les TODO ci-dessus.")\n'
+        )
+        assert commented_template_stub(code) is True
+
+    def test_commented_loop_plus_empty_list_is_stub(self):
+        # The measured ML-FinBERT cell 13 false positive: mes_titres empty list
+        # with commented TODO items, the for-loop commented out, a prompt print.
+        code = (
+            "# Exercice 1 - Votre propre jeu de titres\n"
+            "# Etape 1: completez la liste mes_titres ci-dessous.\n"
+            "mes_titres = [\n"
+            "    # 'TODO etudiant: titre 1',\n"
+            "    # 'TODO etudiant: titre 2',\n"
+            "]\n"
+            "# for h in mes_titres:\n"
+            "#     print(h, finbert_sentiment(h))\n"
+            "print('Exercice 1 a completer')\n"
+        )
+        assert commented_template_stub(code) is True
+
+    def test_assignment_none_stubs_with_prompt_is_stub(self):
+        # The measured Lab4 cell 22 false positive: three `= None` assignment
+        # stubs (no trailing inline comment, so the assignment-stub STUB_PATTERN
+        # does not match) plus prints. 'votre code' carries the prompt marker.
+        code = (
+            "# Votre code pour l'Exercice 1\n"
+            "df['mois'] = None\n"
+            "ca_par_mois = None\n"
+            "mois_max_ca = None\n"
+            "print(ca_par_mois)\n"
+        )
+        assert commented_template_stub(code) is True
+
+    def test_real_executable_def_is_not_stub(self):
+        # Recall guard: a real solution with an EXECUTABLE def is never a
+        # commented-template stub.
+        code = (
+            "# Exercice : implementez f\n"
+            "def f(x):\n"
+            "    return x * 2\n"
+            "print(f(5))\n"
+        )
+        assert commented_template_stub(code) is False
+
+    def test_real_executable_loop_is_not_stub(self):
+        # Recall guard: a real solution with a non-trivial executable line (a
+        # loop) is never a commented-template stub, even with no def.
+        code = (
+            "# Exercice : sommez la liste\n"
+            "total = 0\n"
+            "for x in data:\n"  # non-trivial executable line
+            "    total += x\n"
+            "print(total)\n"
+        )
+        assert commented_template_stub(code) is False
+
+    def test_no_prompt_marker_is_not_stub(self):
+        # Recall guard: trivial executable code WITHOUT a prompt/TODO marker is
+        # not suppressed (a complete trivial solution never carries a prompt).
+        code = (
+            "weighted_grid = [[2, 2], [3, 3]]\n"
+            "start_w = (0, 0)\n"
+            'print("resultat")\n'
+        )
+        assert commented_template_stub(code) is False
+
+
+class TestCommentedTemplateSuppression:
+    def test_commented_template_under_exercice_not_flagged(self, tmp_path):
+        # Integration: the commented-template cell under an Exercice header is
+        # not flagged HIGH (the FP class is suppressed end-to-end).
+        body = (
+            "# Exercice 5 : implementez\n"
+            "# class Foo:\n"
+            "#     def bar(self):\n"
+            "#         pass  # student fills\n"
+            "data = [1, 2, 3]\n"
+            'print("Exercice 5 : implementez les TODO ci-dessus.")\n'
+        )
+        nb = _write_nb(
+            tmp_path / "nb.ipynb",
+            [
+                _md("### Exercice 5 : a completer\n\nImplementez la classe."),
+                _code(body),
+            ],
+        )
+        findings = scan_notebook(str(nb))
+        assert not any(f.get("severity") == "HIGH" for f in findings)
 


### PR DESCRIPTION
## Summary

Closes the **commented-solution-prompt** false-positive class of `detect_solution_leaks.py` — the **last mechanical FP class** blocking de-HOLD of #8084 (per ai-01 msg-20260723T020241 sequence). Purely additive: 81 lines added in the detector, 0 deleted; 7 new tests.

## Root cause

An exercise cell that embeds the **full solution as commented-out code** (`# class Foo:`, `// def bar():`, `# for h in ...`) plus a small amount of executable scaffolding (data assignments + a prompt print) trips `len(source) > 8` and matches no `STUB_PATTERN`, so it is flagged HIGH. Such a cell is a legitimate exercise skeleton (the student uncomments and fills the TODOs), **not** a leak.

Concrete instances identified firsthand (G.1, verified on origin/main HEAD 0276639ce):

| Notebook:cell | Why it's a FP |
|---|---|
| **Search-3-Informed cell 64** | `WeightedGridProblem` class + `weighted_manhattan` + the A* call ALL commented out; only the `weighted_grid` test data + `print("Exercice 5 : implementez les TODO ci-dessus.")` execute. ec=24. |
| **ML-FinBERT-Sentiment/research cell 13** | `mes_titres = []` (with commented `# 'TODO etudiant'` items), the `for h in mes_titres:` loop commented out, `print('Exercice 1 a completer')`. The `"1 "` in the print breaks the existing `print\(["']Exercice a completer` STUB_PATTERN. |
| **Lab4-DataWrangling cell 22** | Three `= None` assignment stubs (`df['mois'] = None`, `ca_par_mois = None`, `mois_max_ca = None`) — no inline trailing comment, so the `=\s*None\s*#.*TODO` assignment-stub STUB_PATTERN does not match — + prints. Output shows `None`/`None` placeholder. |

## Fix

New helper `commented_template_stub(source)` — returns True when:
1. the executable code (comment lines `#`/`//`/`--`/`(*`/`/*` stripped) has **no executable definition** (`def`/`class`/`struct`/`theorem`/`lemma`/`void`/...); AND
2. **every** executable line is trivial (assignment / print / import / collection-literal / closing bracket) — any non-trivial line (loop, solver call, statement) → return False; AND
3. the cell carries a **prompt/TODO marker** (`TODO`, `a completer`, `implementez`, `votre code`, `student fills`, `etudiant`, ...).

Gated in the flagging loop right after the worked-example suppression checks.

## Recall safety

A real (complete) solution always has EITHER an executable definition OR at least one non-trivial executable line (loop, solver call). Both make the helper return False. The prompt-marker requirement is never present in a complete solution. So **0 real leaks are suppressed**. The 3 recall-guard tests pin this:
- executable `def f(x): return x*2` → not suppressed,
- executable `for x in data: total += x` → not suppressed,
- trivial code with NO prompt marker → not suppressed.

## Empirical validation (G.1, apples-to-apples)

Ran OLD detector (origin/main) vs NEW detector (this branch) on the **same** origin/main notebook set:

| | HIGH count |
|---|---|
| OLD (origin/main) | 48 |
| NEW (this branch) | 45 |
| **Delta** | **−3** |

All **3 suppressed findings verified firsthand as false positives** (table above). The 45 kept all have an executable `def`/`class`/non-trivial executable code (sanity-checked: e.g. App-13 `def cheapest_insertion`, Kokoro cell 38, Infer-6 cell 35). Zero recall regression.

## Tests

7 new tests (`TestCommentedTemplateStub` × 6 + `TestCommentedTemplateSuppression` × 1: 3 measured-instance regressions + 3 recall guards + 1 end-to-end suppression) + 71 existing = **78 passed**.

## Scope / residual

Closes the **last mechanical** FP class. The only remaining OPEN class blocking #8084 de-HOLD is the **non-mechanical** `cell20 demo-under-exercise` class (Infer-6 cell 20: a visualisation cell under an exercise header *without* an intervening section break — no header-level heuristic can decide "is this the exercise's answer or scaffolding?"; it needs a semantic judgment). This PR is self-contained and independent of #8126 (cross-cell) — both are additive gates in the same flagging loop; they rebase onto each other cleanly in either merge order.

## Environmental finding (side-note, NOT in this PR scope)

While measuring, I found the **shared working tree at `c:/dev/CoursIA` is checked out at a local `main` (25369a46a) that is 1292 commits behind `origin/main` (0276639ce)**, and its `detect_solution_leaks.py` is the pre-#8092/#8106 version (missing `// TODO`, all Lean/sorry/.Display patterns, closest-header helpers). A `--scan-all` there reported 306 HIGH (garbage) vs the true 48 on origin/main. Sessions working *in the shared tree* rather than an origin/main worktree are on ancient code. Flagging for ai-01 — not touching the shared tree (other sessions' WIP present). All measurements in this PR use the origin/main worktree.

See #8053 (epic). No issue auto-close (incremental precision on an epic, partial).

Co-Authored-By: Claude <noreply@anthropic.com>
