### PR TITLE
fix(genai): NB-16/NB-17 Limites honnetes echantillon count 6 -> 12 (match committed output)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/16_Scaling_Test_Time_Compute.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/16_Scaling_Test_Time_Compute.ipynb
@@ -662,7 +662,7 @@
     "\n",
     "Ce notebook est **illustratif**, pas une replication a l'echelle de Snell et al. 2024 :\n",
     "\n",
-    "- **Petit n / petit K** (6 echantillons, K <= 6) : l'estimateur pass@k a une variance elevee ;\n",
+    "- **Petit n / petit K** (12 echantillons, K <= 6) : l'estimateur pass@k a une variance elevee ;\n",
     "  les courbes sont bruitees. Snell utilise des milliers d'echantillons sur des centaines de\n",
     "  problemes de competition (MATH).\n",
     "- **Petit modèle** (llama-3.3-70b via OpenRouter) : sur de l'arithmetique simple, pass@1 peut\n",

--- a/MyIA.AI.Notebooks/GenAI/Texte/17_Native_Reasoning_vs_Scaling.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/17_Native_Reasoning_vs_Scaling.ipynb
@@ -669,7 +669,7 @@
    "source": [
     "## 5. Limites honnetes (G.2)\n",
     "\n",
-    "- **n petit** (6 echantillons) : pass@k bruite ; les points du modèle a raisonnement sont\n",
+    "- **n petit** (12 echantillons) : pass@k bruite ; les points du modèle a raisonnement sont\n",
     "  estimes sur 2 problemes par bucket (bruit fort). Snell utilise des milliers d'evaluations.\n",
     "- **Une seule comparaison modèle** (deepseek-r1 vs llama-3.3-70b) : le verdict depend du couple\n",
     "  de modèles. Snell compare a un modèle 14x plus gros ; ici le rapport de taille/cout differe.\n",


### PR DESCRIPTION
## Summary

Doc-honesty fix in two GenAI/Texte test-time-scaling notebooks: the "Limites honnetes" prose claimed **6 echantillons** but the committed BoN output prints **12 echantillons**. Markdown-only, 2 cells.

## Root cause (G.1 firsthand)

`N_ECHANTILLONS = 6 if BATCH_MODE else 12`. The committed run used `BATCH_MODE=False` (interactive branch → 12 samples). The "Limites honnetes" prose described the `BATCH_MODE=True` (batch) value (6), contradicting the output the reader sees directly above.

Verified firsthand via `git show origin/main:` (the shared working tree is 1292 commits behind origin/main and shows stale content — NOT used):

| Notebook | cell 7 committed output | claim cell | prose (before) |
|---|---|---|---|
| `16_Scaling_Test_Time_Compute` | `BoN : 12 echantillons / probleme, K=[1, 2, 4, 6]` | cell 12 | `(6 echantillons, K <= 6)` |
| `17_Native_Reasoning_vs_Scaling` | `BoN baseline : 12 echantillons / probleme` | cell 13 | `(6 echantillons)` |

## Fix

Align the prose to the committed output: `6 echantillons` → `12 echantillons` in both claim cells.

- The **K <= 6** half of the NB-16 claim is correct (`K_LIST=[1,2,4,6]`, unchanged).
- The **"2 problemes par bucket"** half of the NB-17 claim is correct (unchanged).
- Both 6 and 12 are "petit n", so the qualitative point (high pass@k variance vs Snell's thousands of evaluations) holds either way.

Markdown-only — no re-execution. The committed outputs (real LLM API runs) are left byte-identical (C.2 markdown-edit exception).

## Validation

- nbformat validate OK (both notebooks).
- 0 CRLF (LF-normalized).
- Catalogue byte-identical to main.
- Outputs intact (cell 7 still prints "12 echantillons").

## Diff

2 insertions / 2 deletions, 2 files, 1 cell each.

The remaining UNSUPPORTED candidate from the bounded GenAI/Texte audit (11_Quantization cell 26 — fp16 KV-cache figures 206K / 96-109 tok/s) is **deliberately not fixed here**: the notebook explicitly attributes its benchmarks to the production stack (3x RTX 4090), so those figures may be real production measurements simply not reprinted in a local output cell. It warrants a human look, not an automated edit. NB-15 (Tree of Thoughts) and NB-7 (Code Interpreter) audited CLEAN.

See #3801 (doc-honesty). No issue auto-close (incremental markdown fix on a mature notebook).

Co-Authored-By: Claude <noreply@anthropic.com>
