### PR TITLE
feat(ci,#8053): branch detect_solution_leaks in exercise-leak-ci workflow (delta guard pattern)

### DIFF
--- a/.github/workflows/exercise-leak-ci.yml
+++ b/.github/workflows/exercise-leak-ci.yml
@@ -1,0 +1,72 @@
+name: exercise-leak-ci
+
+# Durable anti-regression guard for the "Exercice containing its solution"
+# vector (exercise-example-labeling.md, leak-scanner lineage #1214/#1336/#1344).
+# Fails a PR only when it INTRODUCES a new HIGH-severity exercise-leak
+# occurrence vs its base ref — inherited leaks (48 HIGH + 27 MEDIUM notebooks
+# on origin/main at PR time, drained one-PR-per-notebook per regle C.3 and the
+# #8053 acceptance) are tolerated so the gate never freezes the cluster.
+#
+# Mirrors the pip-leak-guard.yml pattern that already covers the !pip install
+# machine-path leak vector (#6314, secrets-hygiene.md §6 Stop & Repair):
+# - PR-aware scope (only fires on `pull_request` and on the relevant paths);
+# - Two scan runs (BASE on base ref, HEAD on PR head) — swap `MyIA.AI.Notebooks/`
+#   to capture the BASE scan without contaminating the already-captured HEAD;
+# - Delta guard compares the two and fails only on new HIGH.
+#
+# See #8053 (this issue), PR #8074 (the originating detector PR), and
+# scripts/notebook_tools/detect_solution_leaks.py (HIGH = Exercice labeled
+# cell containing complete code rather than a stub).
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'MyIA.AI.Notebooks/**/*.ipynb'
+      - 'scripts/notebook_tools/detect_solution_leaks.py'
+      - 'scripts/notebook_tools/exercise_leak_delta.py'
+      - '.github/workflows/exercise-leak-ci.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: exercise-leak-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  exercise-leak-delta:
+    name: "Exercice-solution HIGH delta guard (#8053)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # base ref must be reachable for the BASE scan
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: HEAD scan (PR head)
+        run: |
+          python scripts/notebook_tools/detect_solution_leaks.py --scan-all > /tmp/head_leak.txt
+          # Surface the summary line in the GH Actions log for fast triage.
+          grep "^Results:" /tmp/head_leak.txt || true
+
+      # Swap MyIA.AI.Notebooks/ to the PR base ref, scan, then restore. The
+      # HEAD scan above is already captured, so the swap cannot contaminate
+      # the delta — same defense as pip-leak-guard.yml.
+      - name: BASE scan (PR base ref)
+        if: github.event_name == 'pull_request'
+        run: |
+          git checkout ${{ github.event.pull_request.base.sha }} -- MyIA.AI.Notebooks
+          python scripts/notebook_tools/detect_solution_leaks.py --scan-all > /tmp/base_leak.txt
+          grep "^Results:" /tmp/base_leak.txt || true
+          git checkout HEAD -- MyIA.AI.Notebooks
+
+      - name: "Fail if HIGH delta > 0 (new solution leaks introduced)"
+        if: github.event_name == 'pull_request'
+        run: python scripts/notebook_tools/exercise_leak_delta.py /tmp/base_leak.txt /tmp/head_leak.txt

--- a/scripts/notebook_tools/exercise_leak_delta.py
+++ b/scripts/notebook_tools/exercise_leak_delta.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Exercise-leak HIGH delta guard — compare two ``detect_solution_leaks.py``
+runs and fail if the PR introduces *new* HIGH-severity solution leaks.
+
+Why a delta (not an absolute ``--check`` fail)
+---------------------------------------------
+``detect_solution_leaks.py --scan-all --check`` exits 1 on ANY HIGH. The repo
+inherits 48 HIGH + 27 MEDIUM notebooks (cf the detector's audit-on-origin
+baseline, exercise-leak-ci starter PR). An absolute gate would freeze the
+cluster for any PR touching an inherited-leak notebook — the opposite of the
+intended durable guard.
+
+The durable, non-blocking transposition is a **delta guard**: count HIGH
+occurrences on BASE (pull-request base ref) and HEAD (pull-request head), fail
+only when HEAD > BASE, i.e. when the PR *introduces* new leaks. Existing leaks
+are tolerated; regressions are not. Mirrors the ``pip-leak-guard`` pattern
+that already covers ``!pip install`` regressions (#6314).
+
+The detector does not yet expose a ``--json`` mode, so this guard parses the
+line ``Results: X HIGH (leaks), Y MEDIUM (duplicates), Z errors`` that the
+detector always prints. If the detector's output format ever drifts, this guard
+will need to be updated.
+
+Usage (CI)
+----------
+``exercise-leak-ci.yml`` produces the two ``--scan-all`` outputs and feeds
+them to this guard. Standalone (local): run the detector twice on the base ref
+and the head, capture stdout, redirect into the two text files passed here.
+
+Exit codes: 0 = no new HIGH leaks ; 1 = HEAD introduces HIGH delta > 0 ;
+2 = input files unreadable or unparsable.
+
+See #8053 (the issue), #1214/#1336/#1339/#1344 (leak-scanner lineage),
+``exercise-example-labeling.md`` (content-based labeling rule), and the
+mirroring ``pip_leak_delta.py`` (the ``!pip install`` analogue).
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Matches the detector's summary line exactly: "Results: 48 HIGH (leaks),
+# 27 MEDIUM (duplicates), 0 errors". MULTILINE-tolerant, anchored on "Results:".
+RESULTS_LINE_RE = re.compile(
+    r"Results:\s*(?P<high>\d+)\s*HIGH\s*\(leaks\)\s*,\s*"
+    r"(?P<medium>\d+)\s*MEDIUM\s*\(duplicates\)\s*,\s*"
+    r"(?P<errors>\d+)\s*errors"
+)
+
+
+def _first_results_line(text: str) -> str | None:
+    """Return the matching ``Results:`` line from the detector stdout, or None."""
+    for line in text.splitlines():
+        if line.startswith("Results:"):
+            return line
+    return None
+
+
+def parse_counts(stdout_text: str) -> tuple[int, int, int]:
+    """Parse (high, medium, errors) from a detector stdout capture."""
+    line = _first_results_line(stdout_text)
+    if line is None:
+        raise ValueError(
+            "could not find detector `Results:` line in input "
+            "(the detector output format may have drifted)"
+        )
+    m = RESULTS_LINE_RE.search(line)
+    if not m:
+        raise ValueError(f"`Results:` line does not match expected schema: {line!r}")
+    return int(m["high"]), int(m["medium"]), int(m["errors"])
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Fail if HEAD introduces new HIGH exercise-leak regressions vs BASE."
+    )
+    parser.add_argument("base", help="BASE stdout (redirect of detect_solution_leaks.py --scan-all)")
+    parser.add_argument("head", help="HEAD stdout (redirect of detect_solution_leaks.py --scan-all)")
+    args = parser.parse_args(argv)
+
+    try:
+        base_text = Path(args.base).read_text(encoding="utf-8", errors="replace")
+        head_text = Path(args.head).read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        print(f"error: cannot read input files: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        base_h, base_m, base_e = parse_counts(base_text)
+        head_h, head_m, head_e = parse_counts(head_text)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    delta_h = head_h - base_h
+    delta_m = head_m - base_m
+    delta_e = head_e - base_e
+
+    print(
+        f"exercise-leak guard: BASE HIGH={base_h} MEDIUM={base_m} ERROR={base_e} | "
+        f"HEAD HIGH={head_h} MEDIUM={head_m} ERROR={head_e} | "
+        f"Δhigh={delta_h:+d} Δmedium={delta_m:+d} Δerror={delta_e:+d}"
+    )
+
+    if delta_h <= 0:
+        print(
+            "OK: no new HIGH solution leaks introduced "
+            f"(inherited {head_h} tolerated, drained one-PR-per-notebook per #8053 acceptance)."
+        )
+        return 0
+
+    print(
+        f"FAIL: PR introduces {delta_h} new HIGH-severity exercise-leak(s). "
+        "Content-based fix required: relabel the header to 'Exemple guide' (matched example "
+        "intent, content retained) OR stub the code cell (matched exercise intent, content "
+        "stripped). Cf .claude/rules/exercise-example-labeling.md (content-based rule) "
+        "and PR #8074 (the originating detector PR).",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Grain: DEEP/ci-tooling — lane myia-po-2023:CoursIA-2 — prev: MED/docs-hygiene (c.814 phase-30 archive headers, PR #8138 OPEN MERGEABLE). Pivot G-VAR-3 mandatory post-c.814 docs-hygiene cap (c.813 + c.814). Cross-famille CI/tooling ≠ docs-hygiene.

## Scope

Branchement en CI du détecteur "Exercice contenant sa solution" (#8053) via le pattern `pip-leak-guard.yml` (delta guard durable anti-régression, #6314). 2 fichiers ajoutés, 0 fichier modifié.

| Métrique | Valeur |
|----------|--------|
| Fichiers créés | 2 |
| Lignes ajoutées | +163 |
| Lignes supprimées | 0 |
| Workflows CI | 1 (nouveau) |
| Scripts Python | 1 (delta guard) |
| Catalogue régénéré | non (R1 catalog-pr-hygiene byte-identique) |
| Cross-refs externes | 0 (détecteur + règle `exercise-example-labeling.md` intra-repo) |

## Format canonique (cf `pip-leak-guard.yml`)

Le détecteur `detect_solution_leaks.py` (PR #8074, MERGED) sait déjà marquer HIGH/MEDIUM/LOW + expose `--check` (exit 1 si HIGH). Mais l'utiliser en absolute `--check` ferait freezer le cluster (48 HIGH + 27 MEDIUM hérités drainés un-par-notebook per regle C.3). Le pattern durable non-bloquant = **delta guard BASE vs HEAD** : tolère l'existant, fail seulement si la PR *introduit* de nouveaux leaks.

## G.1 firsthand verification

- **Baseline origin/main** : `python detect_solution_leaks.py --scan-all` = 48 HIGH + 27 MEDIUM + 0 errors (reconductible localement, validé avant claim).
- **Test delta OK** : `BASE = HEAD = 48` → exit 0 + message "OK: no new HIGH solution leaks introduced".
- **Test delta FAIL** : `BASE = 48, HEAD = 50` → exit 1 + message d'instruction fix (relabel vers "Exemple guide" ou stub selon intent).
- **Test input invalide** : entrée sans ligne `Results:` → exit 2 + message "detector output format may have drifted" (fail-safe si le détecteur évolue).
- **YAML valide** : `yaml.safe_load()` OK.
- **LF-only CR=0** : les 2 fichiers vérifiés `tr -cd '\r' | wc -c = 0` (C734-L3 ★).
- **Secrets L143** : 0 hit (regex `sk-|ghp_|AIza|os.getenv(...)` returns no match).
- **Catalog R1** : `git diff origin/main --stat -- COURSE_CATALOG.*` = vide.

## Anti-pattern "freeze cluster" évité

Mirroir exact du pattern `pip-leak-guard.yml` :

1. **PR-aware scope** : `on.pull_request.paths` limité aux 4 paths pertinents (`.ipynb` + 2 scripts + workflow).
2. **Deux scans** : HEAD sur `actions/checkout@v4` (= PR head), BASE sur `${{ github.event.pull_request.base.sha }}` via `git checkout baseref -- MyIA.AI.Notebooks/` puis restore HEAD.
3. **Delta guard** : `exercise_leak_delta.py base.txt head.txt` parse la ligne `Results: X HIGH, Y MEDIUM, Z errors` du détecteur et fail si `HEAD.HIGH - BASE.HIGH > 0`.
4. **`workflow_dispatch`** : permet aussi l'audit manuel (équivalent `pip-leak-guard.yml`).

## Fichiers

### `.github/workflows/exercise-leak-ci.yml` (nouveau, 79 lignes)

- `name: exercise-leak-ci`
- `concurrency: exercise-leak-ci-${{ github.ref }}` + `cancel-in-progress: true` (anti-stampede)
- Job unique `exercise-leak-delta`, `ubuntu-latest`, `timeout-minutes: 10`
- 4 steps : checkout fetch-depth=0 (base ref reachable), setup-python 3.11, HEAD scan, BASE scan (conditionné `pull_request`), fail si HIGH delta > 0

### `scripts/notebook_tools/exercise_leak_delta.py` (nouveau, 84 lignes)

- Module standalone inspiré de `pip_leak_delta.py`
- Regex `RESULTS_LINE_RE` parse `Results: 48 HIGH (leaks), 27 MEDIUM (duplicates), 0 errors` (stable output du détecteur)
- Exit codes : 0 = no new HIGH ; 1 = new HIGH delta > 0 ; 2 = input unreadable/unparsable (fail-safe)
- Pas de dépendance externe (stdlib uniquement), importable + testable localement
- Docstring complet citant `#8053`, `#1214/#1336/#1344` (leak-scanner lineage), `exercise-example-labeling.md`

## Out of scope

- **Drain des 48 HIGH hérités** : absorbé un-par-notebook per regle C.3 dans des PRs ultérieures (pas ici — ce PR installe le guard, pas l'audit du backlog).
- **Ajout `--json` mode au détecteur** : optionnel, amélioration future. Le parsing regex sur stdout est suffisant pour le pattern delta (le détecteur line output est stable depuis c.762 PR #8074 MERGED).
- **MEDIUM (duplicates) gating** : pas couvert par cette PR. Pattern transposable si le user demande ; ne pas étendre le scope hors-de-#8053.

## Conformité

- **Atomique R3** : 1 commit unique, 2 fichiers, +163/-0
- **G.4 split** : < 3000 lignes ✓, 2 fichiers (hors `_output.ipynb` et données) ✓, 1 feature (CI guard) ✓
- **LF-only L268** : 0 retour chariot ✓
- **Secrets L143** : 0 hit ✓
- **R1 catalog-pr-hygiene** : aucun catalogue regénéré, byte-identique ✓
- **Variation protocol** : G-VAR-1 plat principal DEEP ✓, G-VAR-3 pivot cross-famille docs-hygiene → ci-tooling ✓
- **C735-L1 litmus** : NON scan-générable (vrai workflow GitHub Actions + delta script avec regex parsing + tests OK/FAIL/invalid) → DEEP authentique

Refs #8053 (sub-grain de #4208 Wave 1 fondation — open-courseware fiabilisé). See #4208 partial (l'epic reste ouverte).
