### PR TITLE
enrich(genai-texte): NB-13 synthesis cell for the 3 routing demos

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/13_Agentic_Orchestration.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/13_Agentic_Orchestration.ipynb
@@ -823,6 +823,28 @@
   },
   {
    "cell_type": "markdown",
+   "id": "nb13-demo-synthesis-c831",
+   "metadata": {},
+   "source": [
+    "### Interprétation : le choix du moteur émerge du raisonnement\n",
+    "\n",
+    "Les trois démos confirment la promesse de la section 4 : **le routeur sélectionne seul le moteur adapté à la nature de la tâche**, là où NB-12 codait ce choix en dur. Lecture des sorties committées ci-dessus :\n",
+    "\n",
+    "| Démo | Tâche | Outil appelé (tour 1) | Moteur |\n",
+    "|------|-------|----------------------|--------|\n",
+    "| 1 | 24-game (combinatoire) | `resoudre_tot_24` | **ToT** |\n",
+    "| 2 | palindrome (code) | `resoudre_reflexion` | **réflexion** |\n",
+    "| 3 | fizzbuzz (code) | `resoudre_reflexion` | **réflexion** |\n",
+    "\n",
+    "- La tâche **combinatoire** (24-game) est orientée **ToT** : il faut explorer un arbre de combinaisons, ce qu'aucune génération directe ne fait de façon fiable.\n",
+    "- Les tâches de **génération de code** sont orientées **réflexion** : des passes successives fiabilisent le code produit.\n",
+    "- Les trois démos suivent le même **schéma à 2 tours** : tour 1 = appel d'outil (le modèle choisit le moteur), tour 2 = synthèse de la réponse finale.\n",
+    "\n",
+    "C'est précisément l'apport de l'orchestration agentique : **un routeur unique remplace les appels codés en dur** et adapte la stratégie au problème soumis.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "9d258c9b",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
## Gap (firsthand verified)

`GenAI/Texte/13_Agentic_Orchestration.ipynb` section 4 — cell 11 header promises:

> ## 4. Demonstration — l'agent choisit le bon moteur
> On soumet trois tâches de natures différentes et on observe **le choix de l'agent**.

The 3 demos then run (cells 12/13/14), but **no markdown cell interpreted the results** — the notebook jumped straight to section 5 (production). The section's pedagogical promise ("observe the agent's choice") was left unfulfilled: a student sees 3 raw JSON-ish outputs with no synthesis of what the routing demonstrates.

## Fix

Added **one grounded synthesis markdown cell** after the 3 demos (new index 15), interpreting the routing behavior. Grounded in the **committed demo outputs** (verified firsthand, regex-extracted the `outil` field):

| Demo | Task | Tool called (tour 1) | Engine |
|------|------|----------------------|--------|
| 1 | 24-game (combinatorial) | `resoudre_tot_24` | **ToT** |
| 2 | palindrome (code) | `resoudre_reflexion` | **réflexion** |
| 3 | fizzbuzz (code) | `resoudre_reflexion` | **réflexion** |

The cell synthesizes: the router matched engine to task type (combinatorial → ToT, code → réflexion), all 3 demos follow a 2-tour pattern (tour 1 = tool call / engine selection, tour 2 = final-answer synthesis), and the choice emerged from the model's reasoning rather than being hard-coded as in NB-12 — fulfilling the section-4 promise.

## Validation

- **Markdown-only** (C.2 exception: prior code outputs byte-identical, no re-exec). Diff verified = only the new markdown cell (+22 structural lines, 0 code/output changes).
- **Byte-identical round-trip** (`json.dumps(indent=1, ensure_ascii=False)` + LF): +22/-0, delta +1402 bytes.
- Grounded against committed cell 12/13/14 outputs (tool-routing fields), not fabricated.
- H.3 PASS (0 unexecuted code cells); `nbformat` valid (26 cells); C.1 clean (no `raise NotImplementedError`).

## Scope

1 file, +22/-0, 1 notebook. Grain: **MED/enrichment** (lane `myia-po-2023:CoursIA`). Fresh family (GenAI/Texte), distinct genre from c.830 doc-honesty (G-VAR-3 compliant).

Note: cell 13's source comment predicts "l'agent choisit best_of_n" but the committed output shows the agent chose `resoudre_reflexion` — a latent minor code-comment discrepancy, out of scope for this enrichment-only PR (could be a separate doc-honesty nit).

See #3801.