### PR TITLE
fix(z3,#3801): Z3-Python-06 budget capstone Prong-B -- budget 100->80

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb
@@ -1125,32 +1125,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Allocation de budget : sat\n"
-     ]
-    },
-    {
      "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Budget total disponible : 100\n",
-      "\n",
-      "  Projet | Val/u |  Min | Prio | Alloue |  Valeur\n",
-      "--------------------------------------------------\n",
-      "   Alpha |     5 |   10 |    1 |     20 |     100\n",
-      "    Beta |     3 |    8 |    2 |     20 |      60\n",
-      "   Gamma |     7 |    5 |    1 |     20 |     140\n",
-      "   Delta |     2 |   12 |    3 |     20 |      40\n",
-      "   Epsil |     4 |    6 |    2 |     20 |      80\n",
-      "--------------------------------------------------\n",
-      "   TOTAL |       |      |      |    100 |     420\n",
-      "\n",
-      "Cout des violations souples : 0\n",
-      "Budget non utilise : 0\n"
-     ]
+     "text": "Allocation de budget : sat\n\nBudget total disponible : 80\n\n  Projet | Val/u |  Min | Prio | Alloue |  Valeur\n--------------------------------------------------\n   Alpha |     5 |   10 |    1 |     20 |     100\n    Beta |     3 |    8 |    2 |      8 |      24\n   Gamma |     7 |    5 |    1 |     20 |     140\n   Delta |     2 |   12 |    3 |     12 |      24\n   Epsil |     4 |    6 |    2 |     20 |      80\n--------------------------------------------------\n   TOTAL |       |      |      |     80 |     368\n\nCout des violations souples : 6\nBudget non utilise : 0\n"
     }
    ],
    "source": [
@@ -1167,7 +1144,7 @@
     "    (\"Delta\", 2, 12, 3),   # basse priorite\n",
     "    (\"Epsil\", 4,  6, 2),   # moyenne priorite\n",
     "]\n",
-    "budget_total = 100\n",
+    "budget_total = 80\n",
     "n_projets = len(projets)\n",
     "\n",
     "# Variables : allocation[i] = montant investi dans le projet i\n",
@@ -1248,22 +1225,37 @@
    "source": [
     "### Interpretation : allocation multi-objectif complete\n",
     "\n",
-    "**Sortie obtenue** : Z3 produit une allocation qui respecte tous les minimums de financement (contraintes dures), minimise les violations de bonus prioritaire (contraintes souples), puis maximise la valeur totale.\n",
+    "**Sortie obtenue** : avec un budget de 80 (inférieur à la demande idéale de 5 x 20 = 100), Z3 ne peut pas satisfaire toutes les contraintes souples simultanément. Il produit une allocation **non uniforme** qui révèle les deux mécanismes distincts du capstone :\n",
     "\n",
-    "| Type de contrainte | Mécanisme Z3 | Effet sur la solution |\n",
-    "|--------------------|-------------|----------------------|\n",
-    "| Budget total | `somme_alloc <= 100` | Contrainte dure absolue |\n",
-    "| Minimum par projet | `alloc[i] >= fin_min` | Chaque projet viable |\n",
-    "| Bonus priorite | `Or(alloc[i] >= 20, r)` + poids | Projets prioritaires favorises |\n",
-    "| Valeur totale | `maximize(valeur_totale)` | Optimisee en second lieu |\n",
+    "| Projet | Val/u | Min | Prio | Alloué | Valeur | Bonus prio ? |\n",
+    "|--------|-------|-----|------|--------|--------|--------------|\n",
+    "| Alpha | 5 | 10 | 1 | 20 | 100 | Oui |\n",
+    "| Beta | 3 | 8 | 2 | **8** | 24 | **Non** (ramené au min) |\n",
+    "| Gamma | 7 | 5 | 1 | 20 | 140 | Oui |\n",
+    "| Delta | 2 | 12 | 3 | **12** | 24 | **Non** (ramené au min) |\n",
+    "| Epsil | 4 | 6 | 2 | 20 | 80 | Oui |\n",
+    "| **TOTAL** | | | | **80** | **368** | cout = 6 |\n",
     "\n",
-    "**Points cles** :\n",
-    "1. Les contraintes dures garantissent la **faisabilite** (budget, minimums).\n",
-    "2. Les contraintes souples hierarchisent les **préférences** (favoriser les projets prioritaires).\n",
-    "3. L'objectif principal maximise la **valeur** une fois les préférences honorées.\n",
-    "4. L'ordre `minimize` puis `maximize` impose la lexicographie : les violations sont eliminees en priorite, puis la valeur est maximisee.\n",
+    "**Pourquoi cette instance est discriminante ?**\n",
     "\n",
-    "> **Note technique** : Ce cas pratique combine les trois techniques du notebook : relaxation booleenne (section 2/5), lexicographie (section 3) et contraintes dures (NB01). C'est le pattern typique des problemes d'allocation de ressources reels."
+    "1. **La hiérarchie des priorités est ACTIVE** : Z3 ne peut honorer qu'un sous-ensemble des bonus prioritaires. Il sacrifie en priorité le projet de **basse priorité Delta (poids 1)**, le ramenant à son minimum 12, puis **Beta (poids 5)** à son minimum 8. Les projets haute priorité (Alpha, Gamma prio 1 + Epsil prio 2 tenu) restent à 20. Le cout total des violations = 5 (Beta) + 1 (Delta) = **6** -- exactement l'ordre imposé par la pondération. Si le budget avait permis 100, toutes les contraintes souples seraient satisfaites (cout = 0) et la hiérarchie n'aurait eu **aucun effet visible**.\n",
+    "\n",
+    "2. **La maximisation de valeur est ACTIVE** : une fois le cout des violations minimisé, Z3 répartit le budget résiduel vers les projets les plus rentables. Gamma (valeur 7) est porté à son plafond pertinent, et le budget économisé sur Delta (valeur 2, le moins rentable) est conservé pour les projets à plus forte valeur. Avec budget=100, l'allocation était forcée à (20,20,20,20,20) et la valeur 420 était identique à celle d'une répartition uniforme triviale -- l'objectif de valeur n'aurait rien pu discriminer.\n",
+    "\n",
+    "| Type de contrainte | Mécanisme Z3 | Effet sur la solution (budget=80) |\n",
+    "|--------------------|-------------|-----------------------------------|\n",
+    "| Budget total | `somme_alloc <= 80` | Contrainte dure absolue |\n",
+    "| Minimum par projet | `alloc[i] >= fin_min` | Chaque projet viable (Beta=8, Delta=12 à leur minimum) |\n",
+    "| Bonus priorité | `Or(alloc[i] >= 20, r)` + poids | Hiérarchie ACTIVE : Delta (poids 1) puis Beta (poids 5) sacrifiés |\n",
+    "| Valeur totale | `maximize(valeur_totale)` | Optimisée APRÈS cout minimisé : budget vers projets rentables |\n",
+    "\n",
+    "**Points clés** :\n",
+    "1. Les contraintes dures garantissent la **faisabilité** (budget, minimums).\n",
+    "2. Les contraintes souples hiérarchisent les **préférences** -- mais ne sont visibles **que si le budget est contraint** (ici 80 < 100). Sur un budget généreux, toutes les préférences sont honorées (cout = 0) et la hiérarchie devient invisible.\n",
+    "3. L'objectif principal maximise la **valeur** une fois les préférences honorées au mieux -- ici aussi, ne discrimine que parce que l'instance force un arbitrage.\n",
+    "4. L'ordre `minimize(cout)` puis `maximize(valeur)` impose la lexicographie : éliminer les violations d'abord (Delta puis Beta), puis maximiser la valeur sur l'espace restant.\n",
+    "\n",
+    "> **Leçon Prong-B** : un problème d'allocation ne met en valeur l'optimisation multi-objectif que si la demande dépasse la ressource. Avec budget=100 = somme exacte des seuils souples, le solveur n'avait aucun arbitrage à faire -- il suffisait de donner 20 à chacun. La réduction à budget=80 force l'arbitrage et rend les deux objectifs (hiérarchie + valeur) observables. C'est le cas dégénéré qui rend l'exemple pédagogiquement instructif."
    ]
   },
   {


### PR DESCRIPTION
Grain: DEEP/sota-prongb -- lane myia-po-2025:CoursIA -- prev: MED/doc-honesty (#8154)

## Sujet

Z3-Python-06-Advanced-Optimization capstone (cell 22, allocation de budget) etait **degenere** (Prong-B #3801). `budget_total=100` avec seuil souple 5x20=100 forcait `cout_violations=0` et l'allocation uniforme UNIQUE (20,20,20,20,20). Une baseline triviale « donner 20 a chacun » reproduisait l'output committe exactement.
- **Hierarchie souple inerte** : aucune preference arbitree (prio-1 vs prio-3 traites identiquement).
- **Maximisation de valeur inerte** : cout=0 force le point uniforme unique, 0 degre de liberte.

La cell 23 interp clamait « hierarchise les preferences » + « maximise la valeur » mais **aucune** des deux capacites n'etait exercee.

## Fix (verifie firsthand G.1 + determinism gate 3x)

`budget_total` 100 -> 80 (toujours >= somme hard-min 41, faisable).
- **budget=80 -> alloc (Alpha=20, Beta=8, Gamma=20, Delta=12, Epsil=20), cout=6, valeur=368**.
- **Hierarchie souple ACTIVE** : Delta (prio 3, poids 1) -> min 12, puis Beta (prio 2, poids 5) -> min 8 ; cout=5+1=6 (poids le plus faible sacrifie en premier).
- **Maximisation de valeur ACTIVE** : budget libere reste sur value-7 Gamma / value-5 Alpha / value-4 Epsil (tenus a 20), PAS value-2 Delta (tenu a min 12).

## Anti-fabrication Prong-B

Mesure de la degenerecence firsthand AVANT de clamer le fix :
- budget=100 reproduit l'allocation uniforme (confirmé, G.1).
- budget=80 produit allocation non-uniforme cout=6 (confirmé, G.1).
- Determinism gate 3x : alloc/cout/valeur stables (distinct={((20,8,20,12,20),6,368)}).
- Z3 `Optimize` avec `minimize`+`maximize` = lexicographique ici (verifié : pareto-vs-lexico donnent le meme resultat a budget=80).

## Cellules modifiees (churgical)

| Cell | Type | Changement |
|------|------|------------|
| 22 | code | `budget_total = 100` -> `80` + re-exec output reel (alloc non-uniforme cout=6) |
| 23 | markdown | interp reecrite -- demontre les 2 capacites desormais visibles (table + analyse arbitrage Delta/Beta + lecon Prong-B) |

## Validation

- **C.1** : 0 violations (scan).
- **C.2** : cell 22 re-exec (output reel budget=80), execution_count preserve (=9).
- **H.3** : notebook execute (output reel capture via re-exec cellule modifiee).
- **Determinisme** : 3x gate PASS, Z3 Optimize sur Int borne deterministe.
- **Prong-A (SOTA-OK)** : vrai solveur Z3 Optimize (z3 5.0.0 installe, rule F) invoque, vraie allocation sat, pas de workaround ASCII/stub.
- **Prong-B** : instance discriminante (cout=6, alloc non-uniforme), pas degenere. Mesure firsthand avant claim.
- **#2876** : 0 accent retire (cell 23 accents 6->71, prose enrichie en francais accentue ; cell 22 code 0->0).
- **Anti-regression** : aucun code/example strippé (1 param + output regen + interp rewrite).
- **Catalogue** : byte-identique a main.

See #3801 (contribution partielle EPIC SOTA, ne resout pas l'epic entiere).