### PR TITLE
fix(sc,#8053): de-leak SC-6 Exercice 2/3 — stub Voting/Auction (leak case #1)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-6-Errors-Events.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-6-Errors-Events.ipynb
@@ -1122,7 +1122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 12,
    "id": "cell-13",
    "metadata": {
     "execution": {
@@ -1142,75 +1142,10 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "--- Exercice 2 : Voting avec custom errors ---\n"
-     ]
-    },
-    {
      "name": "stdout",
-     "output_type": "stream",
      "text": [
-      "Deploye: Voting a 0x959922bE3CAee4b8Cd9a407cc3ac1C251C2007B1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  0x70997970... a vote pour proposalId=0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  0x3C44CdDd... a vote pour proposalId=1\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  0x90F79bf6... a vote pour proposalId=0\n",
-      "  Proposal 0 'Alice' : 2 vote(s)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Proposal 1 'Bob' : 1 vote(s)\n",
-      "  Proposal 2 'Charlie' : 0 vote(s)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  vote() depuis voter1 → revert AlreadyVoted (attendu)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  vote(99) → revert InvalidProposal (attendu)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  closeVoting() → VotingFinalized timestamp=1780879746\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  vote() apres fermeture → revert VotingClosed (attendu)\n"
+      "Exercice a completer : Voting avec custom errors (AlreadyVoted, VotingClosed, InvalidProposal)\n"
      ]
     }
    ],
@@ -1220,88 +1155,33 @@
     "// SPDX-License-Identifier: MIT\n",
     "pragma solidity ^0.8.28;\n",
     "\n",
-    "// Custom errors\n",
-    "error AlreadyVoted(address voter);\n",
-    "error VotingClosed();\n",
-    "error InvalidProposal(uint256 proposalId);\n",
+    "// TODO etudiant : definir les 3 custom errors (AlreadyVoted, VotingClosed, InvalidProposal)\n",
     "\n",
     "contract Voting {\n",
-    "    struct Proposal {\n",
-    "        string name;\n",
-    "        uint256 voteCount;\n",
-    "    }\n",
-    "\n",
-    "    Proposal[] public proposals;\n",
-    "    mapping(address => bool) public hasVoted;\n",
-    "    bool public votingOpen = true;\n",
-    "\n",
-    "    event Voted(address indexed voter, uint256 indexed proposalId);\n",
-    "    event VotingFinalized(uint256 timestamp);\n",
+    "    // TODO etudiant : definir struct Proposal { string name; uint256 voteCount; }\n",
+    "    // TODO etudiant : definir Proposal[] proposals, mapping(address=>bool) hasVoted, bool votingOpen\n",
+    "    // TODO etudiant : definir les events Voted(address indexed voter, uint256 indexed proposalId) et VotingFinalized(uint256 timestamp)\n",
     "\n",
     "    constructor(string[] memory _proposalNames) {\n",
-    "        for (uint i = 0; i < _proposalNames.length; i++) {\n",
-    "            proposals.push(Proposal(_proposalNames[i], 0));\n",
-    "        }\n",
+    "        // TODO etudiant : peupler proposals a partir de _proposalNames\n",
+    "        pass\n",
     "    }\n",
     "\n",
     "    function vote(uint256 proposalId) public {\n",
-    "        if (!votingOpen) revert VotingClosed();\n",
-    "        if (hasVoted[msg.sender]) revert AlreadyVoted(msg.sender);\n",
-    "        if (proposalId >= proposals.length) revert InvalidProposal(proposalId);\n",
-    "        hasVoted[msg.sender] = true;\n",
-    "        proposals[proposalId].voteCount++;\n",
-    "        emit Voted(msg.sender, proposalId);\n",
+    "        // TODO etudiant : reverts AlreadyVoted / VotingClosed / InvalidProposal\n",
+    "        // TODO etudiant : incrementer voteCount et emettre Voted\n",
+    "        pass\n",
     "    }\n",
     "\n",
     "    function closeVoting() public {\n",
-    "        votingOpen = false;\n",
-    "        emit VotingFinalized(block.timestamp);\n",
+    "        // TODO etudiant : passer votingOpen a false et emettre VotingFinalized\n",
+    "        pass\n",
     "    }\n",
     "}\n",
     "'''\n",
     "\n",
-    "print(\"--- Exercice 2 : Voting avec custom errors ---\")\n",
-    "voting, _ = compile_and_deploy(w3, EXERCICE_VOTING, deployer, [\"Alice\", \"Bob\", \"Charlie\"])\n",
-    "\n",
-    "voter1 = w3.eth.accounts[1]\n",
-    "voter2 = w3.eth.accounts[2]\n",
-    "voter3 = w3.eth.accounts[3]\n",
-    "\n",
-    "# Votes valides\n",
-    "for voter, proposal_id in [(voter1, 0), (voter2, 1), (voter3, 0)]:\n",
-    "    tx = voting.functions.vote(proposal_id).transact({'from': voter})\n",
-    "    receipt = w3.eth.get_transaction_receipt(tx)\n",
-    "    logs = voting.events.Voted().process_receipt(receipt)\n",
-    "    print(f\"  {voter[:10]}... a vote pour proposalId={logs[0]['args']['proposalId']}\")\n",
-    "\n",
-    "# Verifier les compteurs\n",
-    "for i in range(3):\n",
-    "    p = voting.functions.proposals(i).call()\n",
-    "    print(f\"  Proposal {i} '{p[0]}' : {p[1]} vote(s)\")\n",
-    "\n",
-    "# AlreadyVoted\n",
-    "try:\n",
-    "    voting.functions.vote(0).transact({'from': voter1})\n",
-    "except Exception:\n",
-    "    print(\"  vote() depuis voter1 → revert AlreadyVoted (attendu)\")\n",
-    "\n",
-    "# InvalidProposal\n",
-    "try:\n",
-    "    voting.functions.vote(99).transact({'from': w3.eth.accounts[4]})\n",
-    "except Exception:\n",
-    "    print(\"  vote(99) → revert InvalidProposal (attendu)\")\n",
-    "\n",
-    "# Fermer le vote et emettre VotingFinalized\n",
-    "tx = voting.functions.closeVoting().transact({'from': deployer})\n",
-    "receipt = w3.eth.get_transaction_receipt(tx)\n",
-    "logs = voting.events.VotingFinalized().process_receipt(receipt)\n",
-    "print(f\"  closeVoting() → VotingFinalized timestamp={logs[0]['args']['timestamp']}\")\n",
-    "\n",
-    "# VotingClosed apres fermeture\n",
-    "try:\n",
-    "    voting.functions.vote(1).transact({'from': w3.eth.accounts[5]})\n",
-    "except Exception:\n",
-    "    print(\"  vote() apres fermeture → revert VotingClosed (attendu)\")"
+    "print(\"Exercice a completer : Voting avec custom errors (AlreadyVoted, VotingClosed, InvalidProposal)\")\n",
+    ""
    ]
   },
   {
@@ -1325,7 +1205,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 13,
    "id": "cell-15",
    "metadata": {
     "execution": {
@@ -1345,61 +1225,10 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "--- Exercice 3 : Auction avec events ---\n"
-     ]
-    },
-    {
      "name": "stdout",
-     "output_type": "stream",
      "text": [
-      "Deploye: Auction a 0x68B1D87F95878fE05B998F19b66F4baba5De1aed\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  bidder1 offre 1 ETH → HighestBidIncreased: 1 ETH\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  bidder2 offre 2 ETH → HighestBidIncreased: 2 ETH\n",
-      "  pendingReturns[bidder1] = 1 ETH\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  bid(0.5 ETH) → revert BidTooLow (attendu)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  bidder1 withdraw() → BidRefunded: 1 ETH\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  auctionEnd() → AuctionFinalized: winner=0x3C44CdDd..., amount=2 ETH\n",
-      "  beneficiaire a recu +2 ETH\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  auctionEnd() une seconde fois → revert 'Auction already finalized' (attendu)\n"
+      "Exercice a completer : Auction avec events (HighestBidIncreased, AuctionFinalized, BidRefunded)\n"
      ]
     }
    ],
@@ -1409,109 +1238,37 @@
     "// SPDX-License-Identifier: MIT\n",
     "pragma solidity ^0.8.28;\n",
     "\n",
-    "error AuctionEnded();\n",
-    "error BidTooLow(uint256 currentBid, uint256 minBid);\n",
+    "// TODO etudiant : definir les custom errors (AuctionEnded, BidTooLow)\n",
     "\n",
     "contract Auction {\n",
-    "    address public beneficiary;\n",
-    "    uint256 public auctionEndTime;\n",
-    "    address public highestBidder;\n",
-    "    uint256 public highestBid;\n",
-    "    bool public ended;\n",
-    "\n",
-    "    mapping(address => uint256) public pendingReturns;\n",
-    "\n",
-    "    event HighestBidIncreased(address indexed bidder, uint256 amount);\n",
-    "    event AuctionFinalized(address winner, uint256 amount);\n",
-    "    event BidRefunded(address indexed bidder, uint256 amount);\n",
+    "    // TODO etudiant : definir beneficiary, auctionEndTime, highestBidder, highestBid, bool ended\n",
+    "    // TODO etudiant : definir mapping(address=>uint256) pendingReturns\n",
+    "    // TODO etudiant : definir les events HighestBidIncreased, AuctionFinalized, BidRefunded\n",
     "\n",
     "    constructor(uint256 biddingTime, address _beneficiary) {\n",
-    "        beneficiary = _beneficiary;\n",
-    "        auctionEndTime = block.timestamp + biddingTime;\n",
+    "        // TODO etudiant : initialiser beneficiary et auctionEndTime\n",
+    "        pass\n",
     "    }\n",
     "\n",
     "    function bid() public payable {\n",
-    "        if (block.timestamp >= auctionEndTime || ended) revert AuctionEnded();\n",
-    "        if (msg.value <= highestBid) revert BidTooLow(highestBid, msg.value);\n",
-    "        if (highestBid > 0) {\n",
-    "            pendingReturns[highestBidder] += highestBid;\n",
-    "        }\n",
-    "        highestBidder = msg.sender;\n",
-    "        highestBid = msg.value;\n",
-    "        emit HighestBidIncreased(msg.sender, msg.value);\n",
+    "        // TODO etudiant : reverts AuctionEnded / BidTooLow, gerer pendingReturns, emettre HighestBidIncreased\n",
+    "        pass\n",
     "    }\n",
     "\n",
     "    function withdraw() public returns (bool) {\n",
-    "        uint256 amount = pendingReturns[msg.sender];\n",
-    "        if (amount > 0) {\n",
-    "            pendingReturns[msg.sender] = 0;\n",
-    "            payable(msg.sender).transfer(amount);\n",
-    "            emit BidRefunded(msg.sender, amount);\n",
-    "        }\n",
-    "        return true;\n",
+    "        // TODO etudiant : rembourser via pendingReturns, emettre BidRefunded\n",
+    "        pass\n",
     "    }\n",
     "\n",
     "    function auctionEnd() public {\n",
-    "        require(block.timestamp >= auctionEndTime, \"Auction not yet ended\");\n",
-    "        require(!ended, \"Auction already finalized\");\n",
-    "        ended = true;\n",
-    "        emit AuctionFinalized(highestBidder, highestBid);\n",
-    "        payable(beneficiary).transfer(highestBid);\n",
+    "        // TODO etudiant : finaliser l'enchere, emettre AuctionFinalized\n",
+    "        pass\n",
     "    }\n",
     "}\n",
     "'''\n",
     "\n",
-    "print(\"--- Exercice 3 : Auction avec events ---\")\n",
-    "beneficiary_addr = w3.eth.accounts[3]\n",
-    "bidder1 = w3.eth.accounts[1]\n",
-    "bidder2 = w3.eth.accounts[2]\n",
-    "\n",
-    "auction, _ = compile_and_deploy(w3, EXERCICE_AUCTION, deployer, 60, beneficiary_addr)\n",
-    "\n",
-    "# bidder1 offre 1 ETH\n",
-    "tx = auction.functions.bid().transact({'from': bidder1, 'value': w3.to_wei(1, 'ether')})\n",
-    "receipt = w3.eth.get_transaction_receipt(tx)\n",
-    "logs = auction.events.HighestBidIncreased().process_receipt(receipt)\n",
-    "print(f\"  bidder1 offre 1 ETH → HighestBidIncreased: {w3.from_wei(logs[0]['args']['amount'], 'ether')} ETH\")\n",
-    "\n",
-    "# bidder2 surencherit a 2 ETH → bidder1 entre dans pendingReturns\n",
-    "tx = auction.functions.bid().transact({'from': bidder2, 'value': w3.to_wei(2, 'ether')})\n",
-    "receipt = w3.eth.get_transaction_receipt(tx)\n",
-    "logs = auction.events.HighestBidIncreased().process_receipt(receipt)\n",
-    "print(f\"  bidder2 offre 2 ETH → HighestBidIncreased: {w3.from_wei(logs[0]['args']['amount'], 'ether')} ETH\")\n",
-    "print(f\"  pendingReturns[bidder1] = {w3.from_wei(auction.functions.pendingReturns(bidder1).call(), 'ether')} ETH\")\n",
-    "\n",
-    "# BidTooLow\n",
-    "try:\n",
-    "    auction.functions.bid().transact({'from': w3.eth.accounts[4], 'value': w3.to_wei(0.5, 'ether')})\n",
-    "except Exception:\n",
-    "    print(\"  bid(0.5 ETH) → revert BidTooLow (attendu)\")\n",
-    "\n",
-    "# bidder1 recupere son ETH via withdraw()\n",
-    "tx = auction.functions.withdraw().transact({'from': bidder1})\n",
-    "receipt = w3.eth.get_transaction_receipt(tx)\n",
-    "logs = auction.events.BidRefunded().process_receipt(receipt)\n",
-    "print(f\"  bidder1 withdraw() → BidRefunded: {w3.from_wei(logs[0]['args']['amount'], 'ether')} ETH\")\n",
-    "\n",
-    "# Avancer le temps de 61 secondes sur anvil pour expirer l'enchere\n",
-    "w3.provider.make_request(\"evm_increaseTime\", [61])\n",
-    "w3.provider.make_request(\"evm_mine\", [])\n",
-    "\n",
-    "# auctionEnd() : transfère les fonds au beneficiaire\n",
-    "beneficiary_before = w3.eth.get_balance(beneficiary_addr)\n",
-    "tx = auction.functions.auctionEnd().transact({'from': deployer})\n",
-    "receipt = w3.eth.get_transaction_receipt(tx)\n",
-    "logs = auction.events.AuctionFinalized().process_receipt(receipt)\n",
-    "beneficiary_after = w3.eth.get_balance(beneficiary_addr)\n",
-    "gain = w3.from_wei(beneficiary_after - beneficiary_before, 'ether')\n",
-    "print(f\"  auctionEnd() → AuctionFinalized: winner={logs[0]['args']['winner'][:10]}..., amount={w3.from_wei(logs[0]['args']['amount'], 'ether')} ETH\")\n",
-    "print(f\"  beneficiaire a recu +{gain} ETH\")\n",
-    "\n",
-    "# Double appel → revert Auction already finalized\n",
-    "try:\n",
-    "    auction.functions.auctionEnd().transact({'from': deployer})\n",
-    "except Exception:\n",
-    "    print(\"  auctionEnd() une seconde fois → revert 'Auction already finalized' (attendu)\")"
+    "print(\"Exercice a completer : Auction avec events (HighestBidIncreased, AuctionFinalized, BidRefunded)\")\n",
+    ""
    ]
   },
   {


### PR DESCRIPTION
## Summary

De-leaks **SC-6-Errors-Events** cells 20 (Exercice 2) and 22 (Exercice 3): both embedded the **complete Solidity solution** as a Python string variable AND compiled+deployed it to anvil with full error-path tests in the committed output. This is **leak case #1** (exercise-example-labeling): a full functional solution under an `### Exercice` header.

## Root cause (G.1 firsthand, origin/main `a49ba8cff`)

SC-6 stores Solidity contracts as Python string variables (`VAR = '''...'''`) consumed by a `compile_and_deploy(w3, VAR, ...)` helper. The notebook has a clean, consistent pedagogical pattern:

| Cell | Variable | Content | Behavior |
|---|---|---|---|
| 4/6/8/10 | `ERROR_HANDLING`/`CUSTOM_ERRORS`/`EVENTS_EXAMPLE`/`INDEXED_EXAMPLE` | full contract | **Exemple** — deployed + demonstrated |
| **15** | `EXERCICE_WHITELIST` | skeleton `// TODO etudiant` + `pass` | **Exercice stub** — print "a completer", NO deploy |
| **17** | `EXERCICE_ACCESS_CONTROL` | skeleton `// TODO etudiant` + `pass` | **Exercice stub** — print, NO deploy |
| **20** | `EXERCICE_VOTING` | **complete `contract Voting`** (86 lines) | **LEAK** — deployed + tested all 3 errors |
| **22** | `EXERCICE_AUCTION` | **complete `contract Auction`** (107 lines) | **LEAK** — deployed + tested |
| **25** | `EXERCICE_PAYMENT_PROCESSOR` | skeleton `// TODO etudiant` + `pass` | **Exercice stub** — print, NO deploy |

Cells 20/22 were the anomalies: filled-in complete solutions under `### Exercice` headers, that also deployed to anvil (committed output: `Deploye: Voting a 0x959...`, `vote() → revert AlreadyVoted (attendu)`, etc.). The sibling exercise stubs (15/17/25) confirm the intended state: `// TODO etudiant` skeleton + `pass`/`return 0` + `print("Exercice a completer")`, no deployment.

## Fix

Stub cells 20/22 to match the sibling style (cell 25 `PAYMENT_PROCESSOR` is the template):
- `contract Voting` / `contract Auction` → skeleton with `// TODO etudiant` markers (custom errors, state vars, events, function bodies to fill) + `pass`.
- Remove the `compile_and_deploy` + error-path test code.
- Add `print("Exercice a completer : ...")`.

The cells become **anvil-independent** (pure Python string + print), so they execute standalone for a real output — consistent with the sibling stubs.

## Recall-safety / no downstream break

- Verified **no downstream cell references the deployed `voting`/`auction` objects** (cells 20/22 are self-contained). Stubbing breaks nothing downstream.
- The deployment demonstrations remain in the **Exemple** cells (4 ErrorHandling, 6 CustomErrors, 8 EventsExample, 10 IndexedExample) — only the two mislabeled-as-Exercice leaked solutions are stubbed.

## Validation (G.1 firsthand)

- `detect_solution_leaks.py` on SC-6: **2 HIGH → 0 HIGH** (0 MEDIUM, 0 errors).
- **Surgical scope**: ONLY cells 20/22 changed (source-changed = `[20, 22]`); the 26 other cells byte-identical (json round-trip `indent=1`). 31 ins / 274 del.
- nbformat OK (28 cells), **0 CRLF** (LF-normalized), **0 C.1 violations** (stubs use `pass` + `print`, no `NotImplementedError`/`assert False`/`1/0`).
- **H.3 pre-commit**: 0 violations (cells 20/22 carry `execution_count` 12/13 + real executed stdout outputs, captured by standalone-running the stub source).
- Catalogue byte-identical to main.

## Scope

SmartContracts family (fresh vs my recent detector/genai/audit-Probas cycles — R6 OK). Markdown+code surgical edit on 1 notebook, 2 cells.

See #8053 (leak-detection epic — partial contribution, does not close it). Contributes to the #8084 CI-wiring de-HOLD sequence (real HIGH backlog 36 → 34).

Co-Authored-By: Claude <noreply@anthropic.com>
