### PR TITLE
fix(sudoku,#8052): Sudoku-18-Comparison-Csharp cell[43] 200s fabrication + cell[40] ratios off ~10x

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb
@@ -1887,7 +1887,7 @@
     "\n",
     "| Solveur | Variabilite | Explication |\n",
     "|---------|-------------|-------------|\n",
-    "| **Backtracking simple** | très forte | Certains puzzles faciles se resolvent en 1 ms, d'autres en 200+ secondes |\n",
+    "| **Backtracking simple** | très forte | Certains puzzles faciles se resolvent en moins de 1 ms (Easy : 0.66 ms), d'autres font exploser l'arbre de recherche (Medium : Backtracking abandonne vers ~3.8 s sans resoudre, le seul echec du benchmark) |\n",
     "| **BT + MRV** | Forte | L'heuristique reduit l'arbre mais reste sensible a la structure du puzzle |\n",
     "| **Norvig** | très faible | La propagation elimine la plupart de l'alea, temps quasi-constant |\n",
     "| **OR-Tools CP-SAT** | Negligeable | Le solveur industriel est optimise pour des performances predictibles |\n",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb
@@ -1797,8 +1797,8 @@
     "\n",
     "| Comparaison | Facteur | Observation |\n",
     "|-------------|---------|-------------|\n",
-    "| BT simple vs Norvig | ~15000x sur Medium | L'absence d'heuristique coute jusqu'a 4 ordres de grandeur |\n",
-    "| BT + MRV vs BT simple | ~1500x sur Medium | L'heuristique MRV seule apporte un gain massif |\n",
+    "| BT simple vs Norvig | ~1500x sur Medium | Sur le puzzle Medium, Backtracking (3829.84 ms, echec) contre Norvig (2.62 ms) : ~3 ordres de grandeur |\n",
+    "| BT + MRV vs BT simple | ~230x sur Medium | Sur Medium, BT+MRV (16.71 ms) ramene le temps de 3829.84 ms (BT simple, echec) a 16.71 ms |\n",
     "| Norvig vs OR-Tools | ~7x | Performance comparable, Norvig legerement plus rapide sur Python pur |\n",
     "\n",
     "**Point remarquable** : Les puzzles Medium sont les plus discriminants. Ils ont suffisamment de cases vides (64 en moyenne) pour pieger les solveurs naifs, mais restent solvables en un temps raisonnable pour tous les solveurs informes. Les puzzles Hard, paradoxalement, ne sont pas les plus lents car ils ont parfois moins de cases vides mais des contraintes plus serrees qui guident mieux la propagation."


### PR DESCRIPTION
## Summary

Audit claims↔outputs of `Sudoku-18-Comparison-Csharp`. **Two defects fixed, both markdown-only** (C.2 exception — prior outputs valid, no re-exec). This is the C# twin of `Sudoku-18-Comparison-Python` whose defects were fixed in **#8133** (cycle c.805) — the C# twin had never been corrected.

### Defect 1 — cell[43] « 200+ secondes » fabrication

cell[43] (solver variability interpretation) claimed:
> **Backtracking simple** | très forte | Certains puzzles faciles se resolvent en 1 ms, d'autres en **200+ secondes**

**REALITY:** the **MAX timing across ALL outputs** is **3829.84 ms (~3.8 s)** — Backtracking on Medium, which **FAILED (0/1, the only unsolved puzzle)**. No timing anywhere approaches 200 s. Benchmark timeout is **10 s** (cell[33]/cell[37]). **"200+ secondes" is unsupported.**

**Fix:** replaced with the real observed range (Easy 0.66 ms → Medium Backtracking abandons ~3.8 s unsolved).

### Defect 2 — cell[40] comparative ratios off by ~10x

cell[40] order-of-magnitude ratios « sur Medium » did not match the time-ratios from cell[34]:

cell[34] Medium (ms): Backtracking **3829.84** (fail) / BT+MRV **16.71** / Norvig **2.62**

| Comparison | cell[40] claimed | REAL time-ratio | Status |
|------------|------------------|-----------------|--------|
| BT simple vs Norvig | ~15000x | 3829.84/2.62 = **1462x** | fixed → ~1500x |
| BT+MRV vs BT simple | ~1500x | 3829.84/16.71 = **229x** | fixed → ~230x |
| Norvig vs OR-Tools | ~7x | 17.68/2.20 (means) = **8x** | OK, untouched |

Call-counts per difficulty are **not in any output** (cell[34] shows only ms), so the ratios cannot be legitimized as call-ratios either — they were unsourced. Fix re-anchors the two wrong ratios to verifiable time-ratios + cites source timings inline.

## Conventions & Anti-churn

- **C.2 markdown-only exception**: code cells and their `execution_count`/`outputs` byte-untouched (25/25 code cells executed w/ outputs).
- File uses cosmetic blank-lines in source arrays (json.dumps round-trip FAILS) → each fix is **one raw `str.replace`** on a unique anchor. Verified prefix/suffix byte-identical, 0 CRLF, nbformat v4 round-trip OK.

## Evidence

```
cell[34] output (authoritative 4-solver x 4-difficulty table):
  Backtracking: 0.66 / 3829.84(fail) / 226.62 / 72.25
  BT+MRV:       2.13 / 16.71 / 104.28 / 8.15
  Norvig:       2.22 / 2.62 / 1.80 / 2.15
  OR-Tools:     7.82 / 31.69 / 15.93 / 15.29
all-output timing max = 3829.84 ms (grep verified — no value > 4 s exists)
git diff --stat: 1 file, 2 commits (cell[43] +1/-1, cell[40] +2/-2)
```

See #8052 (audit claims↔outputs; partial contribution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)