### PR TITLE
fix(notebook-tools,#8053): Infer-6 demo-under-exercise FP - reorder cells demo/header/stub

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb
@@ -971,93 +971,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "30ed2236",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-06T14:50:44.698304Z",
-     "iopub.status.busy": "2026-06-06T14:50:44.698118Z",
-     "iopub.status.idle": "2026-06-06T14:50:44.736718Z",
-     "shell.execute_reply": "2026-06-06T14:50:44.736589Z"
-    },
-    "papermill": {
-     "duration": 0.045018,
-     "end_time": "2026-06-06T14:50:44.736786+00:00",
-     "exception": false,
-     "start_time": "2026-06-06T14:50:44.691768+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exercice a completer : diagnostiquer et corriger le melange gaussien\r\n"
-     ]
-    }
-   ],
-   "source": [
-    "// Exercice : Diagnostic d'un modele de melange gaussien\n",
-    "\n",
-    "// Modele avec problemes (a corriger)\n",
-    "double[] dataMelange = { -4.2, -3.8, -5.1, -4.5, -3.9, 5.3, 4.8, 5.1, 4.6, 5.5 };\n",
-    "int nData = dataMelange.Length;\n",
-    "int nComposantes = 2;\n",
-    "\n",
-    "// TODO 1 : Definir des priors asymetriques pour les moyennes des 2 composantes\n",
-    "// Indice : composante 0 centree vers -5, composante 1 centree vers +5\n",
-    "// Variable<double> mean0 = ...\n",
-    "// Variable<double> mean1 = ...\n",
-    "\n",
-    "// TODO 2 : Definir un prior raisonnable pour la precision commune\n",
-    "// Indice : GammaFromShapeAndScale avec shape >= 1\n",
-    "\n",
-    "// TODO 3 : Creer le tableau d'observations avec VariableArray\n",
-    "// Indice : chaque observation est tiree d'une des deux composantes\n",
-    "\n",
-    "// TODO 4 : Choisir l'algorithme d'inference adapte (EP ou VMP)\n",
-    "// Indice : pour un melange gaussien, EP est generalement recommande\n",
-    "\n",
-    "// TODO 5 : Executer l'inference et verifier les posterieurs avec DiagnosticGaussian()\n",
-    "\n",
-    "Console.WriteLine(\"Exercice a completer : diagnostiquer et corriger le melange gaussien\");"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c3138f24",
-   "metadata": {
-    "papermill": {
-     "duration": 0.006957,
-     "end_time": "2026-06-06T14:50:44.751168+00:00",
-     "exception": false,
-     "start_time": "2026-06-06T14:50:44.744211+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "## Exercice 1 : Diagnostic d'un modèle de melange gaussien\n",
-    "\n",
-    "**Objectif** : Identifiez et corrigez les problemes dans un modèle de melange gaussien a 2 composantes.\n",
-    "\n",
-    "**Contexte** : Un modèle de melange gaussien tente de separer des données issues de deux distributions distinctes, mais l'inference produit des résultats inattendus (moyennes identiques ou divergence).\n",
-    "\n",
-    "**étapes** :\n",
-    "1. Analysez le modèle fourni et identifiez au moins 2 problemes parmi : prior symetrique, algorithme mal adapte, observation hors-support\n",
-    "2. Corrigez chaque problème en vous basant sur les bonnes pratiques vues dans ce notebook\n",
-    "3. Comparez les résultats obtenus avec EP et VMP sur votre modèle corrige\n",
-    "\n",
-    "**Indices** :\n",
-    "- # Indice 1 : Les composantes d'un melange doivent avoir des priors distincts pour eviter le label switching\n",
-    "- # Indice 2 : Testez avec `engine.ShowProgress = true` pour observer la convergence\n",
-    "- # Indice 3 : Utilisez `DiagnosticGaussian()` pour verifier la sante des posterieurs"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 8,
    "id": "ae3b9309",
    "metadata": {
@@ -1311,6 +1224,93 @@
     "\n",
     "display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));\n",
     "FactorGraphHelper.CleanupGeneratedFiles();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3138f24",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006957,
+     "end_time": "2026-06-06T14:50:44.751168+00:00",
+     "exception": false,
+     "start_time": "2026-06-06T14:50:44.744211+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 1 : Diagnostic d'un modèle de melange gaussien\n",
+    "\n",
+    "**Objectif** : Identifiez et corrigez les problemes dans un modèle de melange gaussien a 2 composantes.\n",
+    "\n",
+    "**Contexte** : Un modèle de melange gaussien tente de separer des données issues de deux distributions distinctes, mais l'inference produit des résultats inattendus (moyennes identiques ou divergence).\n",
+    "\n",
+    "**étapes** :\n",
+    "1. Analysez le modèle fourni et identifiez au moins 2 problemes parmi : prior symetrique, algorithme mal adapte, observation hors-support\n",
+    "2. Corrigez chaque problème en vous basant sur les bonnes pratiques vues dans ce notebook\n",
+    "3. Comparez les résultats obtenus avec EP et VMP sur votre modèle corrige\n",
+    "\n",
+    "**Indices** :\n",
+    "- # Indice 1 : Les composantes d'un melange doivent avoir des priors distincts pour eviter le label switching\n",
+    "- # Indice 2 : Testez avec `engine.ShowProgress = true` pour observer la convergence\n",
+    "- # Indice 3 : Utilisez `DiagnosticGaussian()` pour verifier la sante des posterieurs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "30ed2236",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-06T14:50:44.698304Z",
+     "iopub.status.busy": "2026-06-06T14:50:44.698118Z",
+     "iopub.status.idle": "2026-06-06T14:50:44.736718Z",
+     "shell.execute_reply": "2026-06-06T14:50:44.736589Z"
+    },
+    "papermill": {
+     "duration": 0.045018,
+     "end_time": "2026-06-06T14:50:44.736786+00:00",
+     "exception": false,
+     "start_time": "2026-06-06T14:50:44.691768+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : diagnostiquer et corriger le melange gaussien\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice : Diagnostic d'un modele de melange gaussien\n",
+    "\n",
+    "// Modele avec problemes (a corriger)\n",
+    "double[] dataMelange = { -4.2, -3.8, -5.1, -4.5, -3.9, 5.3, 4.8, 5.1, 4.6, 5.5 };\n",
+    "int nData = dataMelange.Length;\n",
+    "int nComposantes = 2;\n",
+    "\n",
+    "// TODO 1 : Definir des priors asymetriques pour les moyennes des 2 composantes\n",
+    "// Indice : composante 0 centree vers -5, composante 1 centree vers +5\n",
+    "// Variable<double> mean0 = ...\n",
+    "// Variable<double> mean1 = ...\n",
+    "\n",
+    "// TODO 2 : Definir un prior raisonnable pour la precision commune\n",
+    "// Indice : GammaFromShapeAndScale avec shape >= 1\n",
+    "\n",
+    "// TODO 3 : Creer le tableau d'observations avec VariableArray\n",
+    "// Indice : chaque observation est tiree d'une des deux composantes\n",
+    "\n",
+    "// TODO 4 : Choisir l'algorithme d'inference adapte (EP ou VMP)\n",
+    "// Indice : pour un melange gaussien, EP est generalement recommande\n",
+    "\n",
+    "// TODO 5 : Executer l'inference et verifier les posterieurs avec DiagnosticGaussian()\n",
+    "\n",
+    "Console.WriteLine(\"Exercice a completer : diagnostiquer et corriger le melange gaussien\");"
    ]
   },
   {


### PR DESCRIPTION
fix(notebook-tools,#8053): Infer-6 demo-under-exercise FP — reorder cells demo→header→stub

**Closes** one FP class within #8053 (sub-grain c.8104).
**See** #8053, #8081.

## Summary

`detect_solution_leaks.py` flagged `MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb` cell 20 as a HIGH solution leak (1341 chars of factor-graph demo code) under the "## Exercice 1" markdown header (cell 19).

**Root cause (structural, not content)**: the *real* exercise stub (TODO 1-5) was placed BEFORE the "## Exercice 1" markdown header, and the factor-graph visualization demo (which illustrates the same EP/VMP model as §3 just above) sat BETWEEN the header and the next section — creating the "demo under exercise header" FP class.

**Fix**: reorder the 3 cells to a coherent pedagogical flow:

| New idx | Cell ID | Content | Was at |
|---------|---------|---------|--------|
| 18 | `ae3b9309` | `// Visualisation du factor graph du modele EP vs VMP` (demo) | idx 20 |
| 19 | `c3138f24` | `## Exercice 1 : Diagnostic d'un modèle de melange gaussien` (header) | idx 19 |
| 20 | `30ed2236` | `// Exercice : Diagnostic d'un modele de melange gaussien` (stub with TODO 1-5) | idx 18 |

All cell IDs, `execution_count`, outputs, and metadata preserved exactly. LF-only line endings. No content touched beyond cell ordering.

## Verification

| Check | Before | After |
|-------|--------|-------|
| `detect_solution_leaks.py --scan` | 1 HIGH (cell 20) | **0 HIGH, 0 MEDIUM** |
| `check_c2_compliance.py` | PASS | PASS (17/17 executed code cells) |
| Line endings (CR count) | 0 | 0 |
| Total cells | 50 | 50 (preserved) |
| Executed code cells | 17 | 17 (preserved) |
| Catalog (`COURSE_CATALOG.generated.json`) | byte-identique | byte-identique |

## Conformité

- **L268 LF-only** : `git diff | tr -cd '\r' | wc -c` = 0
- **L143 secrets-hygiene** : no `sk-` / `ghp_` / `AIza` in diff (0 hits)
- **C.1 strict** : no `raise NotImplementedError`, no `assert False`, no `1/0` introduced
- **C.2** : notebooks committed WITH outputs; `execution_count != null` on 17/17 code cells
- **C.3 strict** : 0 notebook ré-exécuté, 0 cell source modified (only cell ordering in JSON)
- **R3 atomic** : 1 file modified (`Infer-6-Debugging.ipynb`)
- **R4 partial** : `Closes #8053` (one FP class within the epic fully resolved), `See #8053, #8081`
- **R1 catalog-pr-hygiene** : catalog untouched (byte-identique to main)
- **content-based labeling** : per `.claude/rules/exercise-example-labeling.md`, the demo was correctly labeled (factor graph visualization), the header was correctly labeled (Exercice 1) — only the cell ORDERING was wrong. Fix preserves all labels, only reorders.

## Sub-grain mapping

c.8104 (this PR) = continuation of c.8103 (MED/audit-cross-source-distillation c.8103 PyMC-7 audit) into the leak-detection cleanup lane within EPIC #8053.

L-NNN candidate (to be promoted next cycle) : "structural demo-under-exercise FP = reorder cells, not relabel or stub-replace" — distinguishes from the typical "demo under Exercice" anti-pattern where the fix is relabeling or stub-replacement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)