### PR TITLE
docs(forensic,#8050): reconcile notebook denominators + phantom-detection check

### DIFF
--- a/docs/reference/notebook-denominators.md
+++ b/docs/reference/notebook-denominators.md
@@ -1,0 +1,104 @@
+# Réconciliation des dénominateurs de notebooks
+
+> **Issue** : [#8050](https://github.com/jsboige/CoursIA/issues/8050) — réconcilier les dénominateurs forensic (934) / catalogue (830) / disque afin que les ratios « X % exécutés » soient interprétables.
+>
+> **Parent** : See [#4208](https://github.com/jsboige/CoursIA/issues/4208) (open-courseware fiabilisé). Cette note résout entièrement #8050.
+
+## TL;DR — pourquoi 934 ≠ 830 ≠ 945
+
+Quatre outils cohabitent et **mesurent des choses différentes**. Tant que le dénominateur varie, un ratio « 93 % exécutés » est ininterprétable. Les compteurs se réconcilient ainsi (SHA `644bb656d`, 2026-07-23) :
+
+| Dénominateur | Compte | Outil | Ce qu'il mesure |
+|---|---|---|---|
+| **Disque (git-tracked)** | **945** | `git ls-files '*.ipynb'` | Tous les notebooks suivis par git (périmètre repo entier) |
+| **Forensic (live)** | **943** | [`forensic_scan.py`](../../scripts/notebook_tools/forensic_scan.py) | Tous les notebooks sous `MyIA.AI.Notebooks/` sauf `_archives/_old/TrashBin/_output.ipynb/_pending_execution` |
+| **Forensic (snapshot gelé)** | **934** | [`STABLE_SNAPSHOT.md`](../../STABLE_SNAPSHOT.md) (2026-07-17, SHA `d8ea11a`) | Le forensic **au moment du gel** — référence figée, pas le live |
+| **Catalogue (curé)** | **830** | [`COURSE_CATALOG.generated.json`](../../COURSE_CATALOG.generated.json) | Les notebooks **pédagogiques primaires** (les jumeaux C#/.NET/Lean, les research QuantConnect, les examples et les outils ne sont pas listés séparément) |
+
+**Corriger une prémisse fausse de l'audit originel** ([#8050](https://github.com/jsboige/CoursIA/issues/8050) body) : le forensic n'inclut **ni** `_output.ipynb` **ni** les `archives` — il les **exclut** ([`forensic_scan.py:117-125`](../../scripts/notebook_tools/forensic_scan.py), `EXCLUDE_DIRS` + `is_excluded`). Les seules choses que le forensic compte en plus du catalogue curé sont les notebooks `REFERENCE` (quantbooks `qc_reference`, 25) et les `NO_CODE`, classés comme catégories propres. Et le « 934 » du body est le nombre du **snapshot gelé**, pas le live (943 au SHA courant).
+
+## Détail des écarts (vérifié firsthand, SHA `644bb656d`)
+
+### 1. Disque (945) → Forensic (943) : −2
+
+Le forensic exclut 2 notebooks situés dans `_archives/` :
+
+- `SymbolicAI/SymbolicLearning/_archives/2026-07-04-Neurosymbolic-EML-precurseur-SL12/EML-NAND-Compose.ipynb`
+- `SymbolicAI/SymbolicLearning/_archives/2026-07-04-Neurosymbolic-EML-precurseur-SL12/EML-NAND-Explore.ipynb`
+
+> Note outillage : `git ls-files` échappe les chemins non-ASCII en octal (ex. `Cr/303/251ateur` pour `Créateur`). Ces 2 chemins échappés (`GenAI/SemanticKernel/Créateur…`, `Search/archive/…non-informée…`) apparaissent à tort comme « sur disque mais pas en forensic » — ce sont des **artefacts de quoting git**, les fichiers réels sont bien comptés dans les 943.
+
+### 2. Forensic (943) → Catalogue (830) : écart net −114 / +1
+
+| Ensemble | Compte |
+|---|---|
+| `forensic ∩ catalogue` | 829 |
+| Forensic-only (en forensic, pas au catalogue) | **114** |
+| Catalogue-only (au catalogue, pas en forensic) | **1** (fantôme, voir §4) |
+
+**Les 114 forensic-only** se répartissent par série :
+
+| Série | Forensic-only | Raison (non-catalogué car…) |
+|---|---|---|
+| QuantConnect | **99** | Notebooks **research / projets / examples** non pédagogiques : `projects/` 61, `research/` 17, `ML-Training-Pipeline/` 12, `partner-course-quant-trading/examples/` 7, `Python/` 2 |
+| GameTheory | 5 | Jumeaux **C# / Lean** non listés séparément (le catalogue indexe l'entrée primaire) |
+| Search | 4 | Jumeaux C# / variants |
+| SymbolicAI | 2 | Variants / twins |
+| GenAI | 3 | Notebooks `examples/` non primaires (voir §3) |
+| GradeBook.ipynb (racine) | 1 | **Outil de notation**, pas un notebook pédagogique |
+
+**Lecture** : le catalogue currise les **entrées pédagogiques primaires**. Les jumeaux C#/.NET/Lean d'un même concept, les notebooks de recherche QuantConnect, les dossiers `examples/` et les notebooks-outils (GradeBook) ne sont pas des entrées catalogue distinctes — d'où l'écart structurel et sain entre 943 (tout fichier) et 830 (pédagogique primaire).
+
+### 3. GenAI : forensic 144 vs catalogue 141 (écart 3, ligne par ligne)
+
+Les 3 notebooks GenAI comptés par le forensic mais absents du catalogue :
+
+| Notebook | Pourquoi absent du catalogue |
+|---|---|
+| `GenAI/Image/examples/history-geography.ipynb` | Dossier `examples/` — cas d'usage illustratif, pas une entrée de série primaire |
+| `GenAI/Image/examples/literature-visual.ipynb` | idem |
+| `GenAI/Image/examples/science-diagrams.ipynb` | idem |
+
+Aucun notebook du catalogue n'est absent du forensic côté GenAI (0 dans l'autre sens). L'écart 144 vs 141 est donc **entièrement expliqué** par les 3 notebooks `GenAI/Image/examples/`.
+
+### 4. Le fantôme du catalogue (1 entrée catalogue non scannée)
+
+Le catalogue référence `IIT/ICT-Series/ICT-15c-MetaProxyObstruction-executed.ipynb`, **mais ce fichier n'existe pas**. Le fichier réel est `IIT/ICT-Series/ICT-15c-MetaProxyObstruction.ipynb` (sans le suffixe `-executed`). Il s'agit d'une **entrée fantôme du catalogue** (résidu d'un renommage/suppression non propagé).
+
+> Action : le catalogue est propriété de l'automatisation (`catalog-cron.yml` / `catalog-drift.yml`, cf [`.claude/rules/catalog-pr-hygiene.md`](../../.claude/rules/catalog-pr-hygiene.md)) — cette entrée fantôme sera nettoyée par le cron à la prochaine régénération. Ne pas éditer le catalogue sur une branche feature.
+
+## Règles d'exclusion canoniques (par outil)
+
+| Outil | Exclut | Inclut comme catégorie propre |
+|---|---|---|
+| `forensic_scan.py` | `_archive_obsoletes`, `_archives`, `_old`, `TrashBin`/`trashbin`, `.ipynb_checkpoints`, `node_modules`, `*_output.ipynb`, `*_pending_execution/` | `REFERENCE` (`qc_reference`), `NO_CODE`, `PARSE_ERROR` |
+| `generate_catalog.py` | Jumeaux secondaires, research/projets QC, `examples/`, notebooks-outils (GradeBook), archives | — (curration pédagogique) |
+| `git ls-files` | Untracked + gitignored uniquement | tout le suivi |
+
+## Check CI léger : [`check_denominators.py`](../../scripts/notebook_tools/check_denominators.py)
+
+Un script dédié rend cette réconciliation **vérifiable en continu** (acceptance « idéalement » de [#8050](https://github.com/jsboige/CoursIA/issues/8050)) :
+
+- importe `is_excluded` de `forensic_scan` (donc **même périmètre** que le forensic, zéro dérive de logique) ;
+- recalcule l'ensemble forensic (comptage rapide, sans catégorisation lourde) et l'ensemble catalogue ;
+- **détecte les entrées fantômes du catalogue** (catalogue → fichier inexistant) — c'est le signal CI actionnable (le seul écart qui indique un vrai bug, pas une exclusion saine) ;
+- catégorise le forensic-only (research QC / jumeaux / examples / outils) pour qu'un écart inattendu soit visible ;
+- exit 1 si une entrée catalogue pointe vers un notebook absent du disque.
+
+```
+python scripts/notebook_tools/check_denominators.py [--root MyIA.AI.Notebooks]
+```
+
+Le check est **intentionnellement non bloquant sur l'écart structurel** (forensic 943 vs catalogue 830 est sain : les deux mesurent des choses différentes). Il **bloque uniquement** sur les entrées fantômes du catalogue (drift = bug réel).
+
+## Méthode (G.1, reproductible)
+
+```
+# 1. Forensic live (parse JSON seul, ~30 s, zéro exécution de notebook)
+python scripts/notebook_tools/forensic_scan.py --root MyIA.AI.Notebooks --json-out /tmp/forensic.json
+
+# 2. Réconcilier (cf scripts/notebook_tools/check_denominators.py)
+python scripts/notebook_tools/check_denominators.py
+```
+
+Chaque chiffre de cette note est issu d'une exécution firsthand au SHA `644bb656d` (2026-07-23), pas d'une lecture de snapshot. Le snapshot `STABLE_SNAPSHOT.md` (934) est une **référence gelée** à `d8ea11a` (2026-07-17) — entre les deux, +9 notebooks ont été ajoutés, ce qui explique 934 → 943.

--- a/scripts/notebook_tools/check_denominators.py
+++ b/scripts/notebook_tools/check_denominators.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Reconciliation check for notebook denominators (forensic vs catalogue).
+
+Issue #8050 — the forensic scan (~943 notebooks) and the curated catalogue (~830)
+measure DIFFERENT things, so raw counts must never be compared. This check:
+
+  1. Builds the forensic set with the SAME exclusion logic as forensic_scan
+     (imports is_excluded -> zero logic drift).
+  2. Reads the catalogue entry set (COURSE_CATALOG.generated.json).
+  3. Detects PHANTOM catalogue entries (catalogue references a notebook that the
+     forensic set does not contain AND that does not exist on disk). A phantom is
+     the ONLY kind of gap that signals a real bug (catalogue drift); the structural
+     gap (forensic > catalogue, due to research/twins/examples) is healthy and
+     non-blocking.
+  4. Categorizes the forensic-only gap so an unexpected new source of divergence
+     is visible in the report.
+  5. Exits 1 iff phantoms are found. Exits 0 otherwise (structural gap is reported
+     but tolerated).
+
+Run: python scripts/notebook_tools/check_denominators.py [--root MyIA.AI.Notebooks]
+"""
+import argparse
+import importlib.util
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO_DEFAULT = HERE.parents[1]  # HERE = .../scripts/notebook_tools ; parents[1] = repo root
+
+
+def _load_forensic_module():
+    """Import forensic_scan.is_excluded without requiring a package."""
+    spec = importlib.util.spec_from_file_location(
+        "forensic_scan", HERE / "forensic_scan.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def build_forensic_set(root: Path, is_excluded) -> set[str]:
+    """Notebook paths (relative to root, forward-slash) under root, forensic-excluded."""
+    out = set()
+    for p in root.rglob("*.ipynb"):
+        if is_excluded(p):
+            continue
+        out.add(p.relative_to(root).as_posix())
+    return out
+
+
+def read_catalogue(repo_root: Path) -> set[str]:
+    cat_path = repo_root / "COURSE_CATALOG.generated.json"
+    if not cat_path.exists():
+        raise FileNotFoundError(f"catalogue not found: {cat_path}")
+    data = json.loads(cat_path.read_text(encoding="utf-8"))
+    return {e["path"] for e in data}
+
+
+def categorize_forensic_only(paths: list[str]) -> dict[str, int]:
+    """Bucket forensic-only notebooks by why they are not catalogued."""
+    buckets: Counter = Counter()
+    for p in paths:
+        top = p.split("/")[0]
+        pl = p.lower()
+        if p.endswith("GradeBook.ipynb") or top == "GradeBook.ipynb":
+            buckets["tool (GradeBook)"] += 1
+        elif "/examples/" in pl or pl.startswith("examples/"):
+            buckets["examples"] += 1
+        elif "/_archives/" in pl or "/archive/" in pl or "/_old/" in pl:
+            buckets["archive"] += 1
+        elif top == "QuantConnect" and (
+            "/research/" in pl or "/projects/" in pl or "/ml-training-pipeline/" in pl
+        ):
+            buckets["qc research/project"] += 1
+        elif "-csharp" in pl or "-lean" in pl or "-python" in pl:
+            buckets["twin (C#/Lean/Python variant)"] += 1
+        else:
+            buckets[f"other ({top})"] += 1
+    return dict(buckets)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--root", default="MyIA.AI.Notebooks")
+    parser.add_argument("--repo-root", default=str(REPO_DEFAULT))
+    args = parser.parse_args()
+
+    root = Path(args.root).resolve()
+    repo_root = Path(args.repo_root).resolve()
+    if not root.exists():
+        print(f"ERROR: root {root} does not exist", file=sys.stderr)
+        return 2
+
+    forensic_mod = _load_forensic_module()
+    forensic = build_forensic_set(root, forensic_mod.is_excluded)
+    catalogue = read_catalogue(repo_root)
+
+    forensic_only = sorted(forensic - catalogue)
+    catalogue_only = sorted(catalogue - forensic)
+
+    # A catalogue-only entry is a PHANTOM iff the file does not exist on disk.
+    # (catalogue paths are relative to MyIA.AI.Notebooks.)
+    phantoms = [p for p in catalogue_only if not (root / p).exists()]
+    catalogue_only_known = [p for p in catalogue_only if (root / p).exists()]
+
+    print("=== Denominator reconciliation ===")
+    print(f"forensic (under {root.name}, forensic-excluded): {len(forensic)}")
+    print(f"catalogue entries:                                {len(catalogue)}")
+    print(f"  intersection:                                   {len(forensic & catalogue)}")
+    print(f"  forensic-only (structural, healthy):            {len(forensic_only)}")
+    print(f"  catalogue-only:                                 {len(catalogue_only)}")
+    print(f"    of which phantom (file missing on disk):      {len(phantoms)}")
+    print(f"    of which known to forensic-scan set:          {len(catalogue_only_known)}")
+
+    if forensic_only:
+        print("\n=== forensic-only by category (informational, non-blocking) ===")
+        for bucket, n in sorted(
+            categorize_forensic_only(forensic_only).items(), key=lambda kv: -kv[1]
+        ):
+            print(f"  {n:4d}  {bucket}")
+
+    if phantoms:
+        print("\n=== PHANTOM catalogue entries (BLOCKING — catalogue drift) ===")
+        for p in phantoms:
+            print(f"  {p}")
+        print(
+            "\nFAIL: catalogue references notebooks absent from disk. "
+            "The catalogue is regenerated by catalog-cron/catalog-drift CI; "
+            "this should self-heal on the next regen. See "
+            "docs/reference/notebook-denominators.md and "
+            ".claude/rules/catalog-pr-hygiene.md.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("\nOK: no phantom catalogue entries. Structural forensic/catalogue gap is healthy.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/notebook_tools/tests/test_check_denominators.py
+++ b/scripts/notebook_tools/tests/test_check_denominators.py
@@ -1,0 +1,126 @@
+"""Tests for check_denominators.py (#8050).
+
+Verifies phantom detection (the blocking signal), structural-gap tolerance,
+and the forensic-only categorization — using a synthetic mini-tree so the tests
+do not depend on the full repo state.
+"""
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+MODULE_PATH = HERE.parent / "check_denominators.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("check_denominators", MODULE_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _make_notebook(path: Path, *, executed: bool = True) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    ec = 1 if executed else None
+    nb = {
+        "cells": [
+            {"cell_type": "code", "execution_count": ec, "outputs": [], "source": []}
+        ],
+        "metadata": {},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+    path.write_text(json.dumps(nb), encoding="utf-8")
+
+
+def _make_catalogue(repo_root: Path, entries: list[str]) -> None:
+    data = [{"path": p, "serie": p.split("/")[0]} for p in entries]
+    (repo_root / "COURSE_CATALOG.generated.json").write_text(
+        json.dumps(data), encoding="utf-8"
+    )
+
+
+def test_clean_catalogue_no_phantom(tmp_path):
+    """A catalogue whose every entry exists on disk -> exit 0."""
+    mod = _load_module()
+    root = tmp_path / "MyIA.AI.Notebooks"
+    _make_notebook(root / "GenAI" / "NB-1.ipynb")
+    _make_notebook(root / "Search" / "S-1.ipynb")
+    # NB-2 in a _archive dir -> forensic-excluded, not a phantom
+    _make_notebook(root / "Search" / "_archives" / "old.ipynb")
+    _make_catalogue(tmp_path, ["GenAI/NB-1.ipynb", "Search/S-1.ipynb"])
+
+    forensic = mod.build_forensic_set(root, _load_forensic_is_excluded())
+    catalogue = mod.read_catalogue(tmp_path)
+    assert "Search/_archives/old.ipynb" not in forensic  # forensic excludes _archives
+    catalogue_only = sorted(catalogue - forensic)
+    phantoms = [p for p in catalogue_only if not (root / p).exists()]
+    assert phantoms == []
+
+
+def test_phantom_detected(tmp_path, capsys):
+    """A catalogue entry whose file is missing on disk -> phantom -> exit 1."""
+    mod = _load_module()
+    root = tmp_path / "MyIA.AI.Notebooks"
+    _make_notebook(root / "GenAI" / "NB-1.ipynb")
+    # catalogue references a notebook that does NOT exist on disk
+    _make_catalogue(
+        tmp_path, ["GenAI/NB-1.ipynb", "IIT/Phantom-Does-Not-Exist.ipynb"]
+    )
+
+    rc = mod.main.__wrapped__ if hasattr(mod.main, "__wrapped__") else None
+    # call main via argv override
+    sys.argv = ["check_denominators.py", "--root", str(root), "--repo-root", str(tmp_path)]
+    rc = mod.main()
+    captured = capsys.readouterr()
+    assert rc == 1, "phantom catalogue entry must fail the check"
+    assert "ICT" not in captured.err  # synthetic tree, but ensure FAIL surfaced
+    assert "Phantom-Does-Not-Exist.ipynb" in captured.out
+
+
+def test_structural_gap_is_non_blocking(tmp_path, capsys):
+    """forensic > catalogue (research/twins/examples) is healthy -> exit 0."""
+    mod = _load_module()
+    root = tmp_path / "MyIA.AI.Notebooks"
+    _make_notebook(root / "QuantConnect" / "research" / "r1.ipynb")  # forensic-only
+    _make_notebook(root / "QuantConnect" / "NB-1-Csharp.ipynb")  # twin, forensic-only
+    _make_notebook(root / "GenAI" / "NB-1.ipynb")  # catalogued
+    _make_catalogue(tmp_path, ["GenAI/NB-1.ipynb"])  # only the primary
+
+    sys.argv = ["check_denominators.py", "--root", str(root), "--repo-root", str(tmp_path)]
+    rc = mod.main()
+    captured = capsys.readouterr()
+    assert rc == 0, "structural forensic/catalogue gap must NOT block"
+    assert "forensic-only" in captured.out
+
+
+def test_categorize_buckets():
+    """forensic-only notebooks are bucketed by their non-catalogue reason."""
+    mod = _load_module()
+    paths = [
+        "QuantConnect/research/r1.ipynb",
+        "QuantConnect/projects/p1.ipynb",
+        "GenAI/Image/examples/eg.ipynb",
+        "GameTheory/GT-1-Csharp.ipynb",
+        "GradeBook.ipynb",
+        "Search/_archives/old.ipynb",
+        "GameTheory/GT-weird.ipynb",
+    ]
+    buckets = mod.categorize_forensic_only(paths)
+    assert buckets.get("qc research/project") == 2
+    assert buckets.get("examples") == 1
+    assert buckets.get("twin (C#/Lean/Python variant)") == 1
+    assert buckets.get("tool (GradeBook)") == 1
+    assert buckets.get("archive") == 1
+    assert buckets.get("other (GameTheory)") == 1
+
+
+def _load_forensic_is_excluded():
+    """Load forensic_scan.is_excluded for parity tests."""
+    spec = importlib.util.spec_from_file_location(
+        "forensic_scan", HERE.parent / "forensic_scan.py"
+    )
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m.is_excluded


### PR DESCRIPTION
## Summary

**Closes #8050** — réconcilie les 4 dénominateurs de notebooks (forensic/catalogue/disque/snapshot) pour que les ratios « X % exécutés » soient interprétables. Chaque chiffre vérifié firsthand (parse JSON seul, zéro exécution) au SHA `644bb656d` (2026-07-23).

## Les 4 dénominateurs (corrigent 2 prémisses fausses du body #8050)

| Dénominateur | Compte | Outil |
|---|---|---|
| Disque (git-tracked) | 945 | `git ls-files '*.ipynb'` |
| **Forensic (live)** | **943** | `forensic_scan.py` |
| Forensic (snapshot gelé) | 934 | `STABLE_SNAPSHOT.md` (`d8ea11a`, 2026-07-17) |
| Catalogue (curé) | 830 | `COURSE_CATALOG.generated.json` |

**Corrections G.1 du body #8050** : (a) forensic **exclut** `_output.ipynb` + archives (`EXCLUDE_DIRS` / `is_excluded` `forensic_scan.py:117-125`), il ne les inclut pas — le body était imprécis ; (b) le « 934 » du body est le nombre **snapshot** (gelé), pas le live — le live est **943** au main courant (+9 notebooks depuis `d8ea11a`).

## Écart forensic(943) → catalogue(830)

**114 forensic-only** (structurel sain — le catalogue currise les entrées pédagogiques primaires) :
- QuantConnect research / projets / examples : 99
- Jumeaux C#/.NET/Lean (non listés séparément) : 11
- GenAI examples : 3
- `GradeBook.ipynb` (outil de notation) : 1

**1 catalogue-only = PHANTOM** : `IIT/ICT-Series/ICT-15c-MetaProxyObstruction-executed.ipynb` **n'existe pas** (le fichier réel est `…MetaProxyObstruction.ipynb` sans `-executed`). Drift catalogue → self-heal par `catalog-cron` (je ne touche pas au catalogue : automation-owned, HARD 1 [catalog-pr-hygiene]).

## GenAI 144 vs 141 (écart 3, ligne par ligne)

Les 3 notebooks `GenAI/Image/examples/{history-geography, literature-visual, science-diagrams}.ipynb` — examples non primaires, absents du catalogue curé. **0 dans l'autre sens.** Écart entièrement expliqué.

## Livrables

- **`docs/reference/notebook-denominators.md`** (FR-first) — doc de réconciliation : table des 4 dénominateurs, règles d'exclusion par outil, GenAI ligne par ligne, finding fantôme, méthode reproductible.
- **`scripts/notebook_tools/check_denominators.py`** — check CI léger. Importe `forensic_scan.is_excluded` (même périmètre, zéro dérive de logique). Détecte les **fantômes catalogue** (le seul signal actionnable — l'écart structurel est non-bloquant car les 2 outils mesurent des choses différentes). Catégorise le forensic-only. Exit 1 ssi fantôme.
- **`scripts/notebook_tools/tests/test_check_denominators.py`** — 4 tests (détection fantôme, tolérance écart structurel, catégorisation, propre).

## Validation

- `pytest test_check_denominators.py` : **4/4 PASS**. `pytest test_forensic_scan.py` : **27 PASS** (0 régression — `forensic_scan.py` non modifié, seul `is_excluded` importé).
- `check_denominators.py` exécuté sur main : forensic=943, catalogue=830, **fantôme ICT-15c détecté, exit 1** (comportement correct).
- **0 CRLF** (LF-normalisé byte-level), catalogue byte-identical à main, aucun notebook touché (H.3 n/a).
- Liens doc relatifs vérifiés (cibles existants).

## Choix de design — gate CI

Le check CLI est livré (l'« alerte » demandée par l'issue). Le **wiring en gate GH Actions bloquante est déféré** jusqu'à ce que le fantôme ICT-15c soit self-healed par `catalog-cron` (sinon main serait rouge dès le merge). Une fois le fantôme guéri (<24 h via cron), le gate peut être câblé sans risque.

## Scope

Tooling/docs (famille catalogue/forensic, ai-01-blessed pool #8050). 3 fichiers nouveaux, +373/−0, atomique. G.1 : worktree `ict15b` vérifié **PHANTOM** (PR #7635 déjà merged sur main) → pas de pickup.

Closes #8050 (entièrement résolu). See #4208 (epic parent reste ouvert).

Co-Authored-By: Claude <noreply@anthropic.com>
