### PR TITLE
enrich(planners,#3801): HTN-9 method-selection demonstration (backtracking)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-9-HTN.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-9-HTN.ipynb
@@ -1263,6 +1263,134 @@
   },
   {
    "cell_type": "markdown",
+   "id": "p9-methodsel-lead",
+   "metadata": {
+    "papermill": {
+     "duration": 0.010471,
+     "end_time": "2026-06-09T16:13:58.168631+00:00",
+     "exception": false,
+     "start_time": "2026-06-09T16:13:58.158160+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 5.3 Démonstration : sélection de méthode par backtracking\n",
+    "\n",
+    "Les deux méthodes de décomposition de la tâche `deliver` (`m_deliver_direct` et `m_deliver_via_intermediate`) constituent le cœur de l'expressivité HTN : le planificateur ne se contente pas de « développer » une recette fixe, il **recherche parmi les méthodes applicables** et revient en arrière (*backtracking*) si celle qu'il essaie mène à une impasse.\n",
+    "\n",
+    "L'Exemple 1 ci-dessus livrait `pkg1` du dépôt au magasin avec une liaison **directe** `depot -> store` : la méthode `m_deliver_direct` était applicable et donnait un plan de 3 actions. La méthode `m_deliver_via_intermediate` n'était **jamais sollicitée**.\n",
+    "\n",
+    "Pour rendre visible la **sélection de méthode**, retirons la liaison directe `depot <-> store` : la méthode directe devient inapplicable, et le planificateur doit backtracker vers `m_deliver_via_intermediate` (passage par l'entrepôt).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "p9-methodsel-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-09T16:13:58.248659Z",
+     "iopub.status.busy": "2026-06-09T16:13:58.248482Z",
+     "iopub.status.idle": "2026-06-09T16:13:58.254663Z",
+     "shell.execute_reply": "2026-06-09T16:13:58.254010Z"
+    },
+    "papermill": {
+     "duration": 0.010785,
+     "end_time": "2026-06-09T16:13:58.255210+00:00",
+     "exception": false,
+     "start_time": "2026-06-09T16:13:58.244425+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Demonstration : selection de methode par backtracking\n",
+    "# On retire la connexion directe depot <-> store : m_deliver_direct devient\n",
+    "# inapplicable, forcant le planificateur a backtracker vers m_deliver_via_intermediate.\n",
+    "\n",
+    "initial_facts_nodirect = {\n",
+    "    ('at-pkg', 'pkg1', 'depot'),\n",
+    "    ('at-pkg', 'pkg2', 'warehouse'),\n",
+    "    ('at-veh', 'truck1', 'depot'),\n",
+    "    # Graphe : depot <-> warehouse <-> store  (PAS de liaison depot <-> store directe)\n",
+    "    ('connected', 'depot', 'warehouse'),\n",
+    "    ('connected', 'warehouse', 'depot'),\n",
+    "    ('connected', 'warehouse', 'store'),\n",
+    "    ('connected', 'store', 'warehouse'),\n",
+    "}\n",
+    "\n",
+    "state_nodirect = State(initial_facts_nodirect)\n",
+    "tasks_nodirect = [('deliver', ['pkg1', 'depot', 'store'])]\n",
+    "\n",
+    "planner_bs = HTNPlanner(actions=actions, methods=methods)\n",
+    "plan_bs = planner_bs.solve(state_nodirect, tasks_nodirect)\n",
+    "\n",
+    "# Infere la methode selectionnee a partir de la structure du plan (nombre de drive)\n",
+    "n_drives = sum(1 for a in plan_bs if a.startswith(\"drive\")) if plan_bs else 0\n",
+    "method_used = \"m_deliver_direct\" if n_drives == 1 else \"m_deliver_via_intermediate\"\n",
+    "\n",
+    "print(\"=\" * 60)\n",
+    "print(\"SELECTION DE METHODE - liaison directe depot<->store ABSENTE\")\n",
+    "print(\"=\" * 60)\n",
+    "print(f\"\\nTache : deliver(pkg1, depot, store)\")\n",
+    "print(f\"\\nm_deliver_direct       : inapplicable (precondition 'connected(depot, store)'\")\n",
+    "print(f\"                          non satisfaite) -> ecartee par le solveur.\")\n",
+    "print(f\"m_deliver_via_intermediate : applicable via ?mid=warehouse\")\n",
+    "print(f\"                          (connected(depot,warehouse) + connected(warehouse,store)).\")\n",
+    "print(f\"\\nPLAN TROUVE (backtracking vers la 2e methode) :\")\n",
+    "print(\"-\" * 60)\n",
+    "if plan_bs:\n",
+    "    for i, action in enumerate(plan_bs, 1):\n",
+    "        print(f\"  {i}. {action}\")\n",
+    "    print(\"-\" * 60)\n",
+    "    print(f\"Longueur du plan : {len(plan_bs)} actions (vs 3 avec la liaison directe)\")\n",
+    "    print(f\"Methode selectionnee (inferee) : {method_used} ({n_drives} drive(s))\")\n",
+    "else:\n",
+    "    print(\"  ECHEC : aucun plan trouve\")\n"
+   ],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "============================================================\nSELECTION DE METHODE - liaison directe depot<->store ABSENTE\n============================================================\n\nTache : deliver(pkg1, depot, store)\n\nm_deliver_direct       : inapplicable (precondition 'connected(depot, store)'\n                          non satisfaite) -> ecartee par le solveur.\nm_deliver_via_intermediate : applicable via ?mid=warehouse\n                          (connected(depot,warehouse) + connected(warehouse,store)).\n\nPLAN TROUVE (backtracking vers la 2e methode) :\n------------------------------------------------------------\n  1. load(pkg1, truck1, depot)\n  2. drive(truck1, depot, warehouse)\n  3. drive(truck1, warehouse, store)\n  4. unload(pkg1, truck1, store)\n------------------------------------------------------------\nLongueur du plan : 4 actions (vs 3 avec la liaison directe)\nMethode selectionnee (inferee) : m_deliver_via_intermediate (2 drive(s))\n"
+    }
+   ],
+   "execution_count": 7
+  },
+  {
+   "cell_type": "markdown",
+   "id": "p9-methodsel-interp",
+   "metadata": {
+    "papermill": {
+     "duration": 0.010471,
+     "end_time": "2026-06-09T16:13:58.168631+00:00",
+     "exception": false,
+     "start_time": "2026-06-09T16:13:58.158160+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : le backtracking révèle la puissance de la décomposition HTN\n",
+    "\n",
+    "| Instance | Liaison `depot->store` | Méthode sélectionnée | Plan | Longueur |\n",
+    "|----------|------------------------|----------------------|------|----------|\n",
+    "| Exemple 1 (cellule précédente) | Directe disponible | `m_deliver_direct` | load -> drive(depot->store) -> unload | 3 |\n",
+    "| Démonstration ci-dessus | Absente | `m_deliver_via_intermediate` | load -> drive(depot->wh) -> drive(wh->store) -> unload | 4 |\n",
+    "\n",
+    "**Ce que cette démonstration rend visible** :\n",
+    "\n",
+    "1. **Le planificateur explore l'espace des méthodes**, il n'exécute pas une recette figée. Lorsque `m_deliver_direct` échoue (précondition `connected(depot, store)` non satisfaite), il revient en arrière et sélectionne `m_deliver_via_intermediate`, qui route la livraison via l'entrepôt.\n",
+    "\n",
+    "2. **C'est la différence essentielle avec la planification classique** : un planificateur classique chercherait le chemin `depot -> warehouse -> store` dans l'espace d'états (exploration des actions `drive`). Le planificateur HTN, lui, dispose de la **connaissance procédurale** encodée par le concepteur du domaine (« pour livrer sans liaison directe, passer par un intermédiaire ») et exploite directement cette décomposition.\n",
+    "\n",
+    "3. **La méthode `m_deliver_via_intermediate` n'était jusqu'ici que décorative** : définie dans le domaine (cellule 5.1) mais jamais sélectionnée par les instances précédentes. Cette démonstration l'active et montre que sa présence enrichit le répertoire de plans accessibles au solveur.\n",
+    "\n",
+    "> **Leçon** : la richesse d'un domaine HTN se mesure au nombre de méthodes concurrentes pour une même tâche abstraite -- c'est ce qui donne au planificateur sa capacité à s'adapter à des situations variées. Un domaine à méthode unique dégénère en exécution séquentielle déterministe et perd l'intérêt même du paradigme HTN.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "w1f1kl7d2eh",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA — prev: DEEP/sota-prongb (#8158)

## Sujet

`Planners-9-HTN` définissait **deux** méthodes de décomposition pour la tâche `deliver` :
- `m_deliver_direct` (load → drive direct → unload, 3 actions)
- `m_deliver_via_intermediate` (load → drive via intermédiaire → drive → unload, 4 actions)

Mais **chaque instance démontrée** avait `connected(depot, store)` présent → `m_deliver_direct` était **toujours** applicable et sélectionnée. `m_deliver_via_intermediate` était **définie mais jamais exercée** → la capacité distinctive du HTN (recherche / backtracking parmi des méthodes concurrentes) était **inerte** dans la démo.

## Fix (enrichment additif, +128/-0)

3 cells insérées après la résolution Logistics (Exemple 1) :
1. **Lead-in markdown** : cadre la sélection de méthode comme cœur de l'expressivité HTN.
2. **Code cell** : instance **sans** la liaison directe `depot<->store`. Le solveur backtracks de `m_deliver_direct` (précondition non satisfaite) vers `m_deliver_via_intermediate` (`?mid=warehouse`). Plan = **4 actions** vs 3 avec la liaison directe.
3. **Interprétation markdown** : tableau comparatif + 3 points pédagogiques + leçon.

## Validation (réelle, firsthand)

- **G.1 firsthand** : solveur `_decompose` (cell 18) itère méthodes en ordre + backtrack (`if result is not None: return result`).
- **Discrimination mesurée firsthand** : direct → 3 actions ; no-direct → 4 actions via warehouse. Mesuré AVANT claim (anti-fabrication).
- **Determinism gate 3×** : plan identique.
- **C.2** : nouveau output réel (ec=7) ; autres cells byte-identiques.
- **C.1** = 0 ; **H.3** ec non-null ; **#2876** nouvelles MD accentuées (+78 chars).
- **Catalogue byte-identical** ; **nbformat 4.5** OK (58 cells).

## G-VAR

TIER **MED**, GENRE **notebook-python** (pivot vs 3 sota-prongb précédents). Famille fraîche Planners/HTN. G-VAR-1/2/3 ✓.

See #3801

🤖 Generated with [Claude Code](https://claude.com/claude-code)
