### PR TITLE
feat(audit,#8050): phantom-detection for check_denominators (catalogue -> missing file)

### DIFF
--- a/scripts/audit/check_denominators.py
+++ b/scripts/audit/check_denominators.py
@@ -11,12 +11,20 @@ Issue : #8050. SHA verifie : be5998073 (2026-07-23).
 Usage :
     py scripts/audit/check_denominators.py --root MyIA.AI.Notebooks
     py scripts/audit/check_denominators.py --root MyIA.AI.Notebooks --json-out out.json
-    py scripts/audit/check_denominators.py --root MyIA.AI.Notebooks --strict  # exit 1 si drift
+    py scripts/audit/check_denominators.py --root MyIA.AI.Notebooks --strict  # exit 1 si drift/phantom
 
 Exit codes :
-    0 — OK (drift dans les limites declarees)
-    1 — Drift catalogue > 0 (notebooks curés manquants)
+    0 — OK (drift et phantoms dans les limites declarees)
+    1 — Drift catalogue > 0 (notebooks curés manquants) OU phantom catalogue (entry -> fichier inexistant)
     2 — Erreur d'execution (fichier manquant, etc.)
+
+Detecte deux classes de divergence distinctes :
+  - DRIFT   : notebooks presents sur disque/forensic mais manquants du catalogue (curation incomplete).
+  - PHANTOM : entrees du catalogue qui pointent vers un notebook ABSENT du disque (catalogue drift,
+    ex: renommage/suppression non propage). Le catalog-cron ne self-heal pas toujours les phantoms
+    (ex: suffixe '-executed' resurgit a chaque regen si le generateur le deduit d'un artefact).
+    Un phantom est le signal le plus actionnable : il indique un bug catalogue reel, pas une
+    exclusion saine.
 """
 
 import argparse
@@ -106,6 +114,12 @@ def main():
     catalog_expected = forensic - catalog_excluded
     drift = sorted(catalog_expected - catalog)
 
+    # PHANTOM : entrees catalogue dont le fichier n'existe pas sur disque.
+    # Distinct du drift (notebook manquant du catalogue) : ici c'est le catalogue
+    # qui reference un notebook absent -> bug catalogue (ex: suffixe '-executed'
+    # resurgissant). Le signal le plus actionnable.
+    phantoms = sorted(p for p in catalog if p not in disk)
+
     report = {
         "denominators": {
             "disk": len(disk),
@@ -115,11 +129,13 @@ def main():
         "expected_with_exclusions": len(catalog_expected),
         "drift_count": len(drift),
         "drift_by_series": {},
+        "phantom_count": len(phantoms),
         "exclusion_breakdown": {
             "forensic_excluded_dirs": len(disk - forensic),
             "catalog_excluded_pedagogical": len(catalog_excluded),
         },
         "drift_paths": drift,
+        "phantom_paths": phantoms,
     }
 
     # Drift par série (premier segment du path)
@@ -161,9 +177,17 @@ def main():
             print(f"  ... et {len(drift) - 20} autres")
     else:
         print("OK : drift catalogue = 0")
+    print()
+    print(f"PHANTOM catalogue  : {len(phantoms)} entrees -> fichier inexistant")
+    if phantoms:
+        print(f"--- PHANTOM paths ({len(phantoms)}) ---")
+        for p in phantoms:
+            print(f"  ! {p}  (absent du disque)")
+    else:
+        print("OK : phantom catalogue = 0")
     print("=" * 64)
 
-    if args.strict and drift:
+    if args.strict and (drift or phantoms):
         return 1
     return 0
 

--- a/scripts/audit/tests/test_check_denominators.py
+++ b/scripts/audit/tests/test_check_denominators.py
@@ -1,0 +1,165 @@
+"""Tests for scripts/audit/check_denominators.py (#8050 phantom-detection follow-up).
+
+Covers the two divergence classes:
+  - DRIFT   : notebook on disk/forensic but missing from the catalogue.
+  - PHANTOM : catalogue entry pointing to a file absent from disk (catalogue bug,
+    e.g. a '-executed' suffix residue). Distinct from drift; the most actionable
+    signal because the catalog-cron does not always self-heal it.
+
+Uses a synthetic mini-tree so the tests do not depend on the live repo state.
+"""
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+CHECK_PATH = HERE.parent / "check_denominators.py"
+
+
+def _load_check():
+    spec = importlib.util.spec_from_file_location("check_denominators", CHECK_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _notebook(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "cells": [
+                    {
+                        "cell_type": "code",
+                        "execution_count": 1,
+                        "outputs": [],
+                        "source": [],
+                    }
+                ],
+                "metadata": {},
+                "nbformat": 4,
+                "nbformat_minor": 5,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _catalog(repo_root: Path, entries: list[str]) -> None:
+    (repo_root / "COURSE_CATALOG.generated.json").write_text(
+        json.dumps([{"path": p, "serie": p.split("/")[0]} for p in entries]),
+        encoding="utf-8",
+    )
+
+
+def _run(tmp_path, catalog_entries, extra_on_disk=()):
+    """Build a synthetic tree + catalog, return the check module + computed sets."""
+    mod = _load_check()
+    root = tmp_path / "MyIA.AI.Notebooks"
+    for rel in catalog_entries:
+        _notebook(root / rel)
+    for rel in extra_on_disk:
+        _notebook(root / rel)
+    _catalog(tmp_path, catalog_entries)
+    return mod, root
+
+
+def test_phantom_detected_as_exit1(tmp_path, capsys, monkeypatch):
+    """A catalogue entry whose file is missing on disk -> phantom -> exit 1 in --strict."""
+    mod, root = _run(
+        tmp_path,
+        ["IIT/Real.ipynb", "IIT/Phantom-Does-Not-Exist.ipynb"],
+    )
+    # Phantom-Does-Not-Exist.ipynb is in the catalogue but NOT created on disk
+    (root / "IIT" / "Phantom-Does-Not-Exist.ipynb").unlink()
+
+    monkeypatch.setattr(
+        sys, "argv",
+        ["check_denominators.py", "--root", str(root),
+         "--catalog", str(tmp_path / "COURSE_CATALOG.generated.json"), "--strict"],
+    )
+    rc = mod.main()
+    out = capsys.readouterr().out
+    assert rc == 1, "phantom catalogue entry must fail the check in --strict"
+    assert "Phantom-Does-Not-Exist.ipynb" in out
+    assert "PHANTOM" in out
+
+
+def test_phantom_in_report_json(tmp_path, capsys, monkeypatch):
+    """The JSON report carries phantom_paths separately from drift_paths."""
+    mod, root = _run(
+        tmp_path,
+        ["GenAI/NB-1.ipynb", "Search/Ghost.ipynb"],  # Ghost.ipynb phantom
+    )
+    (root / "Search" / "Ghost.ipynb").unlink()
+    json_out = tmp_path / "report.json"
+    monkeypatch.setattr(
+        sys, "argv",
+        ["check_denominators.py", "--root", str(root),
+         "--catalog", str(tmp_path / "COURSE_CATALOG.generated.json"),
+         "--json-out", str(json_out)],
+    )
+    mod.main()
+    report = json.loads(json_out.read_text(encoding="utf-8"))
+    assert report["phantom_count"] == 1
+    assert "Search/Ghost.ipynb" in report["phantom_paths"]
+    assert "Search/Ghost.ipynb" not in report["drift_paths"]
+
+
+def test_no_phantom_exit0(tmp_path, monkeypatch):
+    """A catalogue whose every entry exists on disk -> no phantom -> exit 0 (no drift either)."""
+    mod, root = _run(tmp_path, ["GenAI/NB-1.ipynb", "Search/NB-2.ipynb"])
+    monkeypatch.setattr(
+        sys, "argv",
+        ["check_denominators.py", "--root", str(root),
+         "--catalog", str(tmp_path / "COURSE_CATALOG.generated.json"), "--strict"],
+    )
+    rc = mod.main()
+    assert rc == 0, "clean tree (no drift, no phantom) must pass --strict"
+
+
+def test_drift_and_phantom_independent(tmp_path, capsys, monkeypatch):
+    """Drift (notebook missing from catalogue) and phantom (catalogue -> missing file)
+    are independent signals: a tree can have both, neither, or one without the other."""
+    mod, root = _run(
+        tmp_path,
+        ["GenAI/Cataloged.ipynb", "IIT/Phantom.ipynb"],  # Phantom.ipynb absent from disk
+        extra_on_disk=["ML/Drifted.ipynb"],  # on disk + forensic, but NOT in catalogue -> drift
+    )
+    (root / "IIT" / "Phantom.ipynb").unlink()  # make it a phantom
+    monkeypatch.setattr(
+        sys, "argv",
+        ["check_denominators.py", "--root", str(root),
+         "--catalog", str(tmp_path / "COURSE_CATALOG.generated.json"), "--strict"],
+    )
+    rc = mod.main()
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "Phantom.ipynb" in out  # phantom surfaced
+    # Drifted.ipynb is excluded from catalogue by CATALOG_EXCLUDE_PEDAGOGICAL? No -> it's drift
+    assert "ML/Drifted.ipynb" in out or "DRIFT" in out
+
+
+def test_executed_suffix_phantom_pattern(tmp_path, capsys, monkeypatch):
+    """Regression for the real-world ICT-15c case: a '-executed' suffix residue
+    where the real file exists without the suffix and the catalogue lists BOTH."""
+    mod, root = _run(
+        tmp_path,
+        [
+            "IIT/ICT-15c-Real.ipynb",            # real file, on disk
+            "IIT/ICT-15c-Real-executed.ipynb",   # phantom: in catalogue, NOT on disk
+        ],
+    )
+    # Only create the real file on disk; the -executed one stays phantom
+    (root / "IIT" / "ICT-15c-Real-executed.ipynb").unlink()
+    monkeypatch.setattr(
+        sys, "argv",
+        ["check_denominators.py", "--root", str(root),
+         "--catalog", str(tmp_path / "COURSE_CATALOG.generated.json"), "--strict"],
+    )
+    rc = mod.main()
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "ICT-15c-Real-executed.ipynb" in out
+    assert "ICT-15c-Real.ipynb" not in out.split("PHANTOM")[1]  # real file not flagged as phantom


### PR DESCRIPTION
## Summary

Follow-up à **#8070** (qui a clos #8050). Le check de #8070 détectait le **DRIFT** (notebooks présents sur disque/forensic mais manquants du catalogue), mais une 2e classe de divergence — plus actionnable — n'était pas couverte : le **PHANTOM** (entry catalogue pointant vers un notebook **absent du disque**).

## Pourquoi le phantom est distinct du drift

| Classe | Sens | Signal |
|---|---|---|
| **DRIFT** | disque → catalogue manquant | curation incomplète (bénigne) |
| **PHANTOM** | catalogue → fichier inexistant | **bug catalogue réel** (rename/delete non propagé) |

Le phantom est le signal **le plus actionnable**. Et le `catalog-cron` ne le self-heal pas toujours : la preuve est vivante sur main — le catalogue référence toujours `IIT/ICT-Series/ICT-15c-MetaProxyObstruction-executed.ipynb` (absent du disque ; le fichier réel est `…MetaProxyObstruction.ipynb` sans `-executed`). Le suffixe `-executed` resurgit à chaque regen (catalogue régénéré 2026-07-22T06:12, phantom **toujours présent** 2026-07-23) → phantom-detection = capability **durable**, pas un fix one-shot.

## Origine

Surfacé durant la collision c.683 : ma PR duplicate #8167 (closed) détectait le phantom via un script **séparé**. Ce PR replie cette capability **dans le check canonique #8070** (pas de 2e script), comme suggéré dans le close-comment de #8167.

## Changements (`scripts/audit/check_denominators.py`)

- Calcule `phantoms = {entries catalogue absentes du disque}`, rapporté **séparément** du drift.
- Ajoute `phantom_count` + `phantom_paths` au rapport JSON.
- Section `PHANTOM` dans la sortie texte (distincte de `DRIFT`).
- `--strict` exit 1 sur drift **OU** phantom (avant : drift seul) ; docstring + exit-codes mis à jour.

## Tests (`scripts/audit/tests/test_check_denominators.py` — NOUVEAU, 5 tests)

- phantom → exit 1 en `--strict` ;
- `phantom_paths` dans le rapport JSON, séparé de `drift_paths` ;
- arbre propre → exit 0 ;
- drift et phantom sont **indépendants** (un arbre peut avoir les deux) ;
- **régression du pattern suffixe `-executed` réel** (catalogue liste le fichier réel + le phantom `-executed` ; seul le phantom est flaggé).

## Validation

- **5/5 tests PASS**. `check_denominators.py --root MyIA.AI.Notebooks` rapporte désormais « PHANTOM catalogue : 1 entrées » (ICT-15c-executed) ; `--strict` EXIT=1.
- **0 régression** : la détection drift (84 notebooks) est inchangée.
- **0 CRLF** (LF byte-level). Catalogue byte-identical à main (automation-owned HARD 1 — le phantom guérit quand le générateur est corrigé en amont, pas par hand-edit sur branche).
- Scope chirurgical : 1 fichier modifié (+28/−4) + 1 nouveau fichier de tests (+166).

See #8050 (déjà clos-par-#8070 ; ce PR renforce l'audit). See #4208.

Co-Authored-By: Claude <noreply@anthropic.com>
