### PR TITLE
fix(rl,#3801): rl_4 cell15 Greedy regret aligned on committed output (~211 -> ~13)

### DIFF
--- a/MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb
@@ -660,7 +660,7 @@
     "| Agent | Regret final | Comportement |\n",
     "|-------|-------------|-------------|\n",
     "| Random | élevé (~300) | Explore tous les bras equitablement, n'apprend rien |\n",
-    "| Greedy | moyen (~211) | Exploite rapidement mais peut se bloquer sur un bras sous-optimal |\n",
+    "| Greedy | faible (~13) | Exploite rapidement mais peut se bloquer sur un bras sous-optimal |\n",
     "\n",
     "**Points cles** :\n",
     "1. L'agent aléatoire a un regret linéaire : il ne converge jamais vers le meilleur bras\n",


### PR DESCRIPTION
## Summary

`rl_4_multi_armed_bandits.ipynb` cell 15 (interpretation table) claimed `| Greedy | moyen (~211) |` — but `~211` appears in **no committed output**. This is a stale doc-honesty claim (EPIC #3801 axe-2). Grounded firsthand against the committed single-run and corrected.

## Defect (G.1 verified firsthand)

| Claim in cell 15 | Grounded against committed output |
|---|---|
| `Random | élevé (~300)` | cell 11: `Regret final : 311.0` — **OK, preserved** |
| `Greedy | moyen (~211)` | cell 13: `Regret final : 13.0` — **FALSE, `~211` is stale** |

**Config (cell 5):** `BernoulliBandit(n_arms=5, probs=[0.3,0.5,0.2,0.8,0.6], seed=42)`, best arm 3 (0.8). `greedy_agent(n_warmup=10)` → 100 free initial pulls give a good estimate.

**cell 13 output (committed):**
```
Agent glouton - recompense cumulee finale : 787.0 / 800.0
Regret final : 13.0
Bras choisis (derniers 100 pas) : Bras 3=100%
```
Greedy converged to the best arm (3) → single-run regret = **13**, not 211.

**Why stale:** the `~211` predates the `n_warmup` warmup (earlier notebook version where Greedy had no free initial pulls and could lock onto a sub-optimal arm). The code evolved; the interpretation table did not.

## Fix

Surgical 1-line markdown edit: `moyen (~211)` → `faible (~13)`.
- Contraste pédagogique now accurate: Random élevé (~300) vs Greedy faible (~13) — Greedy is dramatically better on this run.
- Random `~300` claim (311) preserved unchanged.
- "peut se bloquer sur un bras sous-optimal" description preserved — the *risk* (Points clés 2) is real and documented, even though this seed-42 run did not realize it.

## Validation

- `git diff --stat`: 1 file, +1/-1 (single source-list string in cell 15).
- Markdown-only edit (C.2 exception — no re-exec needed).
- Byte-identical round-trip verified (`json.dumps(indent=1, ensure_ascii=False)`).
- Catalog byte-identical to `main`.
- Collision check: all prior `rl_4` PRs closed (#7203, #6305, #4633, #2717, …) — none touched the cell 15 regret claim.

## Scope

`Grain: MED/doc-honesty`. See #3801 (axe-2 registry). Distinct from c.833 tooling grain (twin-parity register).

Co-Authored-By: Claude-Code <noreply@anthropic.com>