### PR TITLE
fix(gradebook): fuzzy_match_group honors configurable threshold (3-arg crash + dead config)

### DIFF
--- a/GradeBookApp/gradebook.py
+++ b/GradeBookApp/gradebook.py
@@ -326,10 +326,14 @@ def _leading_group_code(normalized):
     return match.group(1) if match else None
 
 
-def fuzzy_match_group(eval_group_name, student_project_string):
+def fuzzy_match_group(eval_group_name, student_project_string, threshold=90):
     """
     Correspondance entre nom de groupe évalué et nom de projet inscrit.
-    Privilégie la correspondance exacte ou quasi-exacte (>= 90% similarité).
+    Privilégie la correspondance exacte ou quasi-exacte (>= threshold % similarité).
+
+    Le seuil ``threshold`` (défaut 90, comportement historique) rend effectif le
+    paramètre ``group_match_threshold`` configurable par épreuve (commit 3a612f85c).
+    Les appelants 2-args conservent le défaut 90 (comportement inchangé).
     """
     if not isinstance(eval_group_name, str) or not isinstance(student_project_string, str):
         return False
@@ -357,10 +361,10 @@ def fuzzy_match_group(eval_group_name, student_project_string):
     if eval_norm == student_norm:
         return True
 
-    # Cas 2: Correspondance par similarité très élevée (>= 90%)
+    # Cas 2: Correspondance par similarité très élevée (>= threshold %)
     # Gère les petites variations de ponctuation, accents, etc.
     similarity = fuzz.ratio(eval_norm, student_norm)
-    if similarity >= 90:
+    if similarity >= threshold:
         return True
 
     # Cas 3: Pour les anciens formats (groupe X, project X)

--- a/GradeBookApp/test_fuzzy_match_group.py
+++ b/GradeBookApp/test_fuzzy_match_group.py
@@ -1,0 +1,63 @@
+"""Tests for GradeBookApp/gradebook.py::fuzzy_match_group.
+
+Guards its heavy deps (pandas/rapidfuzz/...) via ``pytest.importorskip`` so the
+suite skips cleanly in CI (no GradeBookApp Python env) but runs on any machine
+that has the grading-engine deps installed.
+
+Covers the regression fixed alongside this test: commit 3a612f85c wired a
+configurable ``group_match_threshold`` and a 3-arg call site (gradebook.py
+l.1137) but never updated ``fuzzy_match_group``'s signature -- so the 3-arg
+call raised ``TypeError`` and the threshold was dead config. The fix restores
+the author's documented intent via a backward-compatible ``threshold=90``
+default.
+"""
+import os
+import sys
+
+import pytest
+
+# Make ``gradebook`` (sibling file) importable regardless of invocation cwd,
+# since the repo root pytest.ini uses ``--import-mode importlib`` and does not
+# put GradeBookApp/ on sys.path.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+pd = pytest.importorskip("pandas")
+pytest.importorskip("rapidfuzz")
+
+from gradebook import fuzzy_match_group  # noqa: E402  (after importorskip guards)
+
+
+def test_three_arg_call_no_longer_crashes():
+    """Regression: l.1137 passes 3 args; the old 2-param signature raised TypeError."""
+    # Exact pair -> Cas 1 -> True, at any threshold. Point: 3-arg call must be callable.
+    assert fuzzy_match_group("projet alpha", "projet alpha", 90) is True
+    assert fuzzy_match_group("projet alpha", "projet alpha", 100) is True
+
+
+def test_threshold_governs_cas2_borderline():
+    """Cas 2 admission follows the configurable threshold, not a hardcoded 90.
+    Derives the assertion from the actual fuzz ratio (no brittle magic number)."""
+    from rapidfuzz import fuzz
+
+    a = "projet machine learning"
+    b = "projet machine learnig"  # 1-char typo -> ratio < 100, reaches Cas 2
+    ratio = fuzz.ratio(a, b)
+    assert ratio < 100, "fixture must not be exact (would short-circuit at Cas 1)"
+    assert 50 < ratio < 100, f"fixture ratio {ratio} outside the expected band"
+    # Admitted at/under the measured ratio, rejected strictly above it.
+    assert fuzzy_match_group(a, b, threshold=int(ratio)) is True
+    assert fuzzy_match_group(a, b, threshold=100) is False
+
+
+def test_two_arg_backward_compat_default_90():
+    """Existing 2-arg callers (l.742, l.853) keep the historical default-90 behavior."""
+    a = "projet machine learning"
+    b = "projet machine learnig"
+    assert fuzzy_match_group(a, b) == fuzzy_match_group(a, b, 90)
+
+
+def test_cas0_distinct_group_codes_never_match():
+    """Cas 0 dominates: distinct leading codes must not match, even at a low threshold."""
+    assert fuzzy_match_group("a1 - projet", "a2 - projet", threshold=10) is False
+    # Same code matches regardless of a strict threshold.
+    assert fuzzy_match_group("a1 - projet", "a1 - projet", threshold=100) is True


### PR DESCRIPTION
## Summary

Latent `TypeError` crash + dead config in `GradeBookApp/gradebook.py::fuzzy_match_group`, both introduced by commit `3a612f85c` ("configurable group_match_threshold per epreuve").

## Root cause

That commit wired a per-epreuve threshold (`gradebook.py` l.1136) and a **3-arg** call site (l.1137):

```python
threshold = epreuve_config.get('group_match_threshold', 90)
members = [s for s in student_records if fuzzy_match_group(name, s.sujets[0], threshold)]
```

but it **never updated** `fuzzy_match_group`'s signature (l.329), which stayed at **2 params**. Two consequences:

1. **Latent crash** — the 3-arg call at l.1137 raises `TypeError: fuzzy_match_group() takes 2 positional arguments but 3 were given` on any non-empty grouped evaluation set. (The other two call sites, l.742 and l.853, call it correctly with 2 args, so they masked the regression.)
2. **Dead config** — the function hardcodes `>= 90` in Cas 2, ignoring the per-epreuve `group_match_threshold` the feature was meant to honor.

## Fix

Add a backward-compatible `threshold=90` default param and use it in Cas 2:

```python
def fuzzy_match_group(eval_group_name, student_project_string, threshold=90):
    ...
    if similarity >= threshold:   # was: >= 90
        return True
```

- Existing 2-arg callers (l.742, l.853) → **byte-identical** default-90 behavior.
- The 3-arg caller (l.1137) → now works **and** honors the configured threshold — restoring the author's documented intent.

## Validation

- `ast.parse` OK; diff is surgical (signature + docstring + one Cas-2 line).
- **New `GradeBookApp/test_fuzzy_match_group.py` — 4/4 PASS** (`pytest`, both from `GradeBookApp/` and repo root):
  - `test_three_arg_call_no_longer_crashes` — the l.1137 3-arg form is now callable (the regression).
  - `test_threshold_governs_cas2_borderline` — admission follows `threshold`, not a hardcoded 90 (derives the assertion from the measured `fuzz.ratio`, no brittle magic number).
  - `test_two_arg_backward_compat_default_90` — 2-arg == explicit 3-arg-at-90.
  - `test_cas0_distinct_group_codes_never_match` — Cas 0 (distinct leading codes) still dominates regardless of threshold.
- `importorskip`-guarded (pandas/rapidfuzz): skips cleanly in CI (no GradeBookApp Python deps), runs where the grading-engine deps are installed.
- Byte-level LF (0 CRLF) on both files.

## Scope

Engine code only — **no PII**. `PRIVACY.md` §4 confirms no network calls in the grading engine; configs/data stay private on GDrive. Related-but-distinct context: `PRIVACY.md` §6 documents the threshold *policy*; this PR makes the threshold *config mechanically functional* — it does not address §6's separate "enforcement under threshold" item (structured logging / hard gate), which remains a tracked improvement.

See #8054 (RGPD notice context); this is an engine bugfix, not a closure of that docs issue.

Co-Authored-By: Claude <noreply@anthropic.com>
