### PR TITLE
ci(#8057): blocking twin parity workflow + script bug-fix + CSP-2 rebaseline

### DIFF
--- a/.github/workflows/twin-parity.yml
+++ b/.github/workflows/twin-parity.yml
@@ -1,0 +1,93 @@
+name: Twin Parity Check
+
+# Purpose: FAIL any PR that introduces DRIFT or MISSING in the twin parity
+# register (#8057, parent #4208). The register lists every Python/C# twin
+# pair and the git blob SHA of each notebook at the time of the last audit;
+# this workflow re-runs the check against the PR's merge ref and fails if a
+# notebook has moved without a re-audit (parite silently broke) or if a path
+# is now missing (typo, deletion, twin never created).
+#
+# Why BLOCKING (unlike catalog-drift.yml): the twin parity check is the
+# safety net for the structural parity of bilingual notebooks (Search/CSP,
+# ML.NET, Z3/SMT, SemanticWeb, Probas/InferNET, GameTheory/.NET). A silent
+# drift means the two implementations diverge without anyone re-auditing;
+# this directly contradicts #4956 ("parity Python/C# marathon") and #8057
+# ("metadonnee de parite auditable, pas declarative"). Blocking is the only
+# way to make the auditable promise real.
+#
+# Pattern: the worker who edits a twin must either re-audit (and rebaseline
+# the SHAs in the registry, `python scripts/notebook_tools/check_twin_parity.py --update`)
+# OR split the edit so the twin moves in lockstep on the same PR. The
+# workflow tells them which side has drifted.
+#
+# Paths watched:
+#   - scripts/notebook_tools/twin_pairs.yaml (registry)
+#   - scripts/notebook_tools/check_twin_parity.py (the tool itself)
+#   - All jumeau notebooks: MyIA.AI.Notebooks/**/*.ipynb (broad pattern;
+#     the tool itself filters down to the pairs in the registry).
+#
+# Reuses the proven structure of catalog-drift.yml (read-only checkout of
+# the PR merge ref, run tool, surface result) but FAILS on DRIFT/MISSING.
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'scripts/notebook_tools/twin_pairs.yaml'
+      - 'scripts/notebook_tools/check_twin_parity.py'
+      - 'MyIA.AI.Notebooks/**/*.ipynb'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  twin-parity:
+    name: "Twin parity audit (#8057)"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install PyYAML
+        run: pip install pyyaml
+
+      - name: Run twin parity check
+        id: check
+        run: |
+          set +e
+          OUTPUT=$(python scripts/notebook_tools/check_twin_parity.py --json --check 2>&1)
+          EXIT=$?
+          echo "$OUTPUT" > twin_parity_report.json
+          set -e
+          if [ $EXIT -eq 0 ]; then
+            echo "drift=false" >> "$GITHUB_OUTPUT"
+            echo "missing=false" >> "$GITHUB_OUTPUT"
+            echo "Twin parity OK : aucune paire en DRIFT ou MISSING."
+          elif [ $EXIT -eq 1 ]; then
+            DRIFT=$(python -c "import json; d=json.load(open('twin_parity_report.json')); print(d.get('drift',0))")
+            MISSING=$(python -c "import json; d=json.load(open('twin_parity_report.json')); print(d.get('missing',0))")
+            echo "drift=$DRIFT" >> "$GITHUB_OUTPUT"
+            echo "missing=$MISSING" >> "$GITHUB_OUTPUT"
+            echo "::error title=Twin parity DRIFT/MISSING detected::Le registre signale des paires dont un jumeau a evolue sans re-audit, ou des chemins manquants. Voir twin_parity_report.json dans les artifacts. Action : re-auditer la paire firsthand puis \`python scripts/notebook_tools/check_twin_parity.py --update\` pour rebaseline, OU splitter le PR en deux PRs distincts pour que chaque cote evolue separement."
+            exit 1
+          else
+            echo "::error title=Twin parity tool error::Erreur d'execution du check (exit $EXIT). Voir les logs ci-dessus."
+            exit $EXIT
+          fi
+
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: twin-parity-report
+          path: twin_parity_report.json
+          if-no-files-found: ignore

--- a/scripts/notebook_tools/README.md
+++ b/scripts/notebook_tools/README.md
@@ -333,6 +333,70 @@ aval. Reference canon : `svg-6927-canon` (memoire ai-01).
 
 ---
 
+## Twin parity register (#8057)
+
+Le registre `twin_pairs.yaml` (a cote de `check_twin_parity.py`) decrit chaque
+paire de notebooks jumeaux Python/C# (Search/CSP, ML.NET/Python, Z3/SMT,
+SemanticWeb, Probas/InferNET-PyMC, GameTheory/.NET-Parity). Pour chaque paire
+il enregistre :
+
+- les chemins Python et C# des deux jumeaux,
+- le `parity_level` (`surface` | `semantic` | `native-both`),
+- le `last_audit` (date + auteur + git blob SHA de chaque notebook au moment
+  du dernier audit),
+- les `known_differences` documentees (idiomes framework, bibliotheques
+  differentes, fix specifiques a un seul cote, etc.).
+
+### `check_twin_parity.py` (#8057, c.801/c.802)
+
+Detecte la **derive silencieuse des jumeaux** : pour chaque paire, compare
+le git blob SHA courant (via `git ls-tree HEAD`) au SHA audite. Verdict par
+paire :
+
+- **OK** : les deux cotes sont au SHA audite, parite tenue.
+- **DRIFT** : un cote a evolue (SHA different) sans re-audit -> la parite
+  n'est plus garantie, **re-audit obligatoire**.
+- **MISSING** : un chemin est absent de git (typo, deplacement, jumeau
+  jamais cree).
+
+```bash
+# verifier toutes les paires vs le registre
+python scripts/notebook_tools/check_twin_parity.py
+# exit 1 si DRIFT/MISSING (CI-ready via --check)
+python scripts/notebook_tools/check_twin_parity.py --check
+# restreindre a une famille
+python scripts/notebook_tools/check_twin_parity.py --family SMT/Z3-API
+# rebaseline apres audit firsthand (ecrit les SHAs courants)
+python scripts/notebook_tools/check_twin_parity.py --update
+# sortie machine (json)
+python scripts/notebook_tools/check_twin_parity.py --json
+```
+
+### CI integration (`.github/workflows/twin-parity.yml`, c.818)
+
+Le workflow `.github/workflows/twin-parity.yml` **fail** toute PR qui
+introduit DRIFT/MISSING dans le registre. Pour deriver legitimement (par
+exemple un fix doc-honesty sur un seul cote), le worker doit :
+
+1. **Re-auditer la paire firsthand** (lecture cellule-par-cellule des deux
+   jumeaux, verdict ecrit dans `known_differences` du registre).
+2. **Rebaseline les SHAs** : `python scripts/notebook_tools/check_twin_parity.py --update [--family ...]`.
+3. Committer le registre rebaseline **dans la meme PR** que l'edit du cote
+   modifie (le PR porte a la fois le diff du notebook et le diff du
+   registre).
+
+**Anti-pattern** : editer un cote sans toucher au registre = la CI fail
+avec un message explicite pointant vers la paire et le cote qui a drift.
+Le check est **bloquant** (contrairement a `catalog-drift.yml` qui est
+read-only) parce que la derive silencieuse casse la promesse de parite
+bilingue (#4956).
+
+**Owner** : po-2024 (registre + check) + po-2025 (re-audit + rebaseline sur
+les paires Search/CSP, SMT/Z3, SemanticWeb, Probas/InferNET). Voir
+`docs/reference/twin-parity.md` pour la procedure complete.
+
+---
+
 ## Scanners structurels (l'axe **PEDAGOGIE**)
 
 ### `scan_cell_ordering.py`

--- a/scripts/notebook_tools/check_twin_parity.py
+++ b/scripts/notebook_tools/check_twin_parity.py
@@ -210,18 +210,28 @@ def main(argv=None) -> int:
             print(f"Aucune paire pour la famille '{args.family}'.", file=sys.stderr)
 
     if args.update:
-        # rebaseline toutes les paires (ou filtrees par --family)
+        # IMPORTANT : --update DOIT TOUJOURS reecrire TOUTES les paires du
+        # registre (meme avec --family), sinon on DETRUIT les paires des
+        # autres familles en re-ecrivant le YAML filtre. On ne met a jour
+        # que les paires qui matchent le filtre (ou toutes si pas de filtre).
+        all_pairs = load_registry(reg_path)
+        target = (
+            [pp for pp in all_pairs if pp.get("family") == args.family]
+            if args.family else all_pairs
+        )
+        if args.family and not target:
+            print(f"Aucune paire pour la famille '{args.family}'.", file=sys.stderr)
         updated = 0
-        for pp in pairs:
+        for pp in target:
             audit, cur_py = update_pair(repo_root, pp)
             if cur_py is not None:
                 pp["last_audit"] = audit
                 updated += 1
-        # re-ecrit le registre entier (conserve l'ordre + les autres paires)
+        # re-ecrit le registre ENTIER (conserve l'ordre + les autres paires)
         if yaml is None:
             raise SystemExit("Erreur : PyYAML requis pour --update.")
         reg_path.write_text(
-            yaml.safe_dump(pairs, sort_keys=False, allow_unicode=True, width=100),
+            yaml.safe_dump(all_pairs, sort_keys=False, allow_unicode=True, width=100),
             encoding="utf-8",
         )
         msg = f"Registre rebaseline : {updated} paire(s) mise(s) a jour -> {reg_path}"

--- a/scripts/notebook_tools/twin_pairs.yaml
+++ b/scripts/notebook_tools/twin_pairs.yaml
@@ -137,13 +137,14 @@
   last_audit:
     date: "2026-07-23"
     by: po-2024
-    python_sha: 41a4f05083ecb19ed4c2aa5e0f3c69a8ec59597e
+    python_sha: fe90bbf647b1e06931df4dad0b2c192d7b932d73
     csharp_sha: 7c5456239e3145b8194519765fb19791644ca505
   known_differences:
     - "Socle pedagogique commun : node consistency + AC-3 + Forward Checking + MAC, implementes from-scratch des deux cotes."
     - "Cote C# : extension Choco-solver 4.10.17 via IKVM 8.15.0 (memes recettes infrastructure que CSP-1) pour comparer les algorithmes custom avec la propagation native de Choco (variable x, contrainte arithmetique, model.getSolver().propagate())."
     - "Visualisation : Python = matplotlib (graphes de contraintes colorees par domaine, propagation tracee). C# = sortie textuelle via Console.WriteLine (pas de plotting .NET headless sur ce notebook)."
     - "Idiomes framework : Python = pur (list/dict/set + recursion). C# = generiques System.Collections.Generic + delegation Func<Variable, IEnumerable<int>> pour les domaines."
+    - "DRIFT cote Python corrige c.818 (rebaseline fe90bbf6, was 41a4f050) : doc-honesty po-2025 #8139 a substitue des PLACEHOLDER qualitatifs ('petit/moyen/grand', 'reference/moins/le moins', 'modeste/significatif/important') par des nombres reels deterministes (BT 876 assigns / FC 67 / MAC 20 pour N=8) + tableau croisant taille N / variant / ratio BT/MAC. Substance algorithmique inchangee (memes implementations AC-3/FC/MAC). Cote C# inchange (SHA 7c545623 identique)."
 
 - name: "CSP-3 Advanced"
   family: Search/Part2-CSP


### PR DESCRIPTION
## Grain: DEEP/tooling-ci — lane myia-po-2024:CoursIA-2 — prev: MED/audit-claims

## Résumé

Boucle la **promesse de parité auditable** des jumeaux Python/C# (#8057, parent #4208, #4956) :

1. **CI blocking** : nouveau workflow `.github/workflows/twin-parity.yml` qui **fail** toute PR introduisant DRIFT/MISSING dans le registre.
2. **Bug-fix script** : `check_twin_parity.py --update --family X` réécrivait TOUTES les paires du registre en ne gardant que la famille filtrée (perte des autres paires au reformatage PyYAML). Fix : `--update` charge TOUTES les paires depuis le registre, ne met à jour que celles qui matchent le filtre, réécrit le registre ENTIER. **CRITIQUE** : sans ce fix, la CI workflow pourrait être bypassée par `--update --family X --force` qui écraserait silencieusement le registre.
3. **Rebaseline CSP-2** : `twin_pairs.yaml` ligne 140, python_sha `41a4f05083ecb19ed4c2aa5e0f3c69a8ec59597e` → `fe90bbf647b1e06931df4dad0b2c192d7b932d73` (DRIFT légitime post-#8139). Audit semantique ci-dessous.
4. **Documentation** : sous-section "Twin parity register (#8057)" dans `scripts/notebook_tools/README.md` (entre "Validateurs CI" et "Scanners structurels"), référence au workflow + au fix + à la procédure.

## Audit semantique DRIFT CSP-2 (G.1 firsthand)

Commit `16f270d8b Grain: MED/doc-honesty — lane myia-po-2025:CoursIA — prev: DEEP/sota-prongb (#8139)` par po-2025 :

- **Titre** : `fix(csp,#8081): CSP-2 BT/FC/MAC interpretation — real numbers + honest cost/pruning tradeoff`
- **Substance touched** : cellules markdown cell 46 + cell 53 (interpretation tables)
- **Type de diff** : substitue PLACEHOLDER qualitatifs (`petit/moyen/grand`, `reference/moins/le moins`, `modeste/significatif/important`) par **nombres réels deterministes** (BT 876 assigns / FC 67 / MAC 20 pour N=8, +tableau croisant N / variant / ratio BT/MAC)
- **Algorithmes** : AC-3/FC/MAC implementations INCHANGEES (mêmes implementations from-scratch des deux côtés)
- **Cote C#** : SHA `7c545623...` IDENTIQUE avant/après (non touché)
- **Verdict** : DRIFT purement interprétatif (markdown), substance algorithmique intacte, **rebaseline légitime**.

## Conformité rules

- **R1 catalog-pr-hygiene** : catalogue non touché.
- **R7 never-idle outcome-test** : substance livrée (4 features distinctes, toutes DEEP/MED).
- **G-VAR-3** : pivot cross-genre c.817 (MED/audit-claims) → c.818 (DEEP/tooling-ci), genre distinct.
- **G-VAR-1** : plat principal DEEP.
- **C.1 notebook-conventions** : pas de notebook modifié (uniquement YAML + workflow + script + README).
- **C.2 notebook-conventions** : N/A.
- **Stop & Repair** : pas de hand-edit (substance = code + YAML + workflow + doc).
- **L268 LF-only** : workflow YAML propre, diff clean.
- **L143 secrets-hygiene** : aucun secret (regex scannée OK).
- **L677-L4** ★★★ body PR HORS worktree (`C:\tmp\c818_pr_body.md`).
- **C812-L2** ★ force-with-lease non utilisé (4 commits atomiques, pas de rebase destructif).
- **C816-L1** ★ dénominateurs par exclusion assumée : 21 paires au registre = 21/21 OK après rebaseline, le registre est canonique pour #8057.

## Tests

```bash
# Avant PR :
python scripts/notebook_tools/check_twin_parity.py --check --json
# {"total": 21, "ok": 21, "drift": 0, "missing": 0}

# Workflow local :
python scripts/notebook_tools/check_twin_parity.py --update --json
# {"updated": 21, "msg": "Registre rebaseline : 21 paire(s) mise(s) a jour"}

python scripts/notebook_tools/check_twin_parity.py --family Search/Part2-CSP --update --json
# {"updated": 4, "msg": "Registre rebaseline : 4 paire(s) mise(s) a jour"}
# VERIFY : 21/21 OK apres ce filtre (autres familles preservees)

python scripts/notebook_tools/check_twin_parity.py
# Total : 21 paire(s) | OK=21 DRIFT=0 MISSING=0
```

CI workflow `.github/workflows/twin-parity.yml` reproduit ce check sur PR et **fail** sur tout DRIFT/MISSING.

## Anti-pattern évité

**Bug-fix script (commit 2) CRITIQUE** : le code original faisait `pairs = [pp for pp in pairs if pp.get("family") == args.family]` PUIS `yaml.safe_dump(pairs, ...)` → toute utilisation de `--family X --update` écrasait le registre en ne gardant que X. Le fix charge DEPUIS le disque (`all_pairs = load_registry(reg_path)`), filtre pour la mise à jour uniquement, et réécrit le registre ENTIER (`yaml.safe_dump(all_pairs, ...)`).

Sans ce fix, un worker qui voudrait "rebaseline juste ma famille" aurait écrasé silencieusement les SHAs des autres familles au reformatage PyYAML. Découvert pendant c.818 quand j'ai fait `git diff --stat` après le premier `--family Search/Part2-CSP --update` et vu `-314/+48` (perte de 14 paires SMT/Z3 + ML.NET).

## Liens

- Issue #8057 : Métadonnée de parité des jumeaux Python/C#
- Issue #4208 : parent open-courseware fiabilisé/publié
- Issue #4956 : parité Python/C# marathon
- PR #8139 : doc-honesty CSP-2 (commit `16f270d8b` par po-2025)
- PR #8045 : doc-honesty cures CSP-2 c.19 (référence dans registre)
- PR #8079 : c.802 twin parity Search/CSP (tranche pilote)

🤖 Generated with [Claude Code](https://claude.com/claude-code)