### PR TITLE
docs(smartgrid): enrich CC3 result interpretation — 4 cells grounded in outputs

### DIFF
--- a/MyIA.AI.Notebooks/CaseStudies/SmartGrid-Energy/solution/SmartGrid-Energy.ipynb
+++ b/MyIA.AI.Notebooks/CaseStudies/SmartGrid-Energy/solution/SmartGrid-Energy.ipynb
@@ -259,6 +259,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "smartgrid-interp-dispatch-c835",
+   "metadata": {},
+   "source": [
+    "### Interprétation : le dispatch min-coût et ses limites\n",
+    "\n",
+    "Le statut **OPTIMAL** confirme que CP-SAT a trouvé le dispatch de coût minimal satisfaisant toutes les contraintes (équilibre offre/demande, capacités min/max). Lecture du résultat :\n",
+    "\n",
+    "- Le **charbon** porte l'essentiel de la charge (270–340 MW) et s'ajuste heure par heure pour suivre la demande ; l'**hydroélectricité** reste plate à 150 MW, vraisemblablement son plafond de capacité (`pmax`).\n",
+    "- Le coût optimal de **63 600 €** est le plancher économique : c'est la stratégie « Économique » que l'on retrouvera dans la comparaison finale (Partie 4).\n",
+    "- **Limite de cette stratégie** : minimiser le coût seul pousse vers le charbon (le moins cher par MWh), mais ce sont aussi les émissions de CO2 les plus élevées. C'est précisément ce déséquilibre que les Parties 2 (risque) et 3 (multi-objectif) viennent corriger en intégrant d'autres axes que le coût.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "c7",
    "metadata": {},
    "source": [
@@ -364,6 +378,19 @@
   },
   {
    "cell_type": "markdown",
+   "id": "smartgrid-interp-risk-c835",
+   "metadata": {},
+   "source": [
+    "### Interprétation : un risque de queue négligeable, piloté par l'incertitude\n",
+    "\n",
+    "Les risques de défaillance sont **astronomiquement faibles** (de l'ordre de 10⁻³⁸ à 10⁻²⁸⁴) : avec 800 MW de capacité pilotable pour une demande nette de 420–490 MW, la marge est si large que la probabilité d'un dépassement (queue de distribution gaussienne via `erfc`) est numériquement négligeable.\n",
+    "\n",
+    "- Le risque **ne suit pas le niveau de demande** mais **l'incertitude de la prévision renouvelable** : H4 (demande 480 MW, incertitude ±25 MW) affiche le risque le plus élevé (≈ 8·10⁻³⁸), très au-dessus de H0 (demande 420 MW, ±15 MW, ≈ 7·10⁻¹⁴²) — alors que la demande de H0 est plus faible. C'est l'écart-type `renewable_forecast_std`, pas la demande, qui pilote la probabilité de queue.\n",
+    "- **Enseignement** : tant que la capacité pilotable surpasse largement la demande nette, la fiabilité est quasi gratuite. Le risque ne devient pertinent qu'en cas de marge tendue ou d'incertitude élevée — c'est ce que l'Exercice 2 explore en amplifiant l'incertitude renouvelable.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "c11",
    "metadata": {},
    "source": [
@@ -459,6 +486,22 @@
     "score_min_cost = multi_objective_score(dispatch, net, weights=(1.0, 1.0, 1.0),\n",
     "                                       norms={'cost': 200000, 'co2': 2000000, 'max_risk': 1.0})\n",
     "print(f'Score multi-objectif du dispatch min-cout (ref non normalise): {score_min_cost:.3f}')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "smartgrid-interp-score-c835",
+   "metadata": {},
+   "source": [
+    "### Interprétation : décomposition du score multi-objectif\n",
+    "\n",
+    "Le score **1,137** du dispatch min-coût se décompose, avec les poids `(1, 1, 1)` et les normes `{cost: 200 000, co2: 2 000 000, max_risk: 1,0}` :\n",
+    "\n",
+    "- **coût** : 63 600 / 200 000 ≈ **0,32** (faible → bon marché) ;\n",
+    "- **CO2** : 1 638 000 / 2 000 000 ≈ **0,82** (élevé → polluant) ;\n",
+    "- **risque** : ≈ **0** (la capacité excède largement la demande, cf. Partie 2).\n",
+    "\n",
+    "Le terme **CO2 domine** (0,82) : optimiser le coût seul produit un dispatch bon marché mais sale. C'est la traduction chiffrée du conflit d'objectifs. Le score multi-objectif rend ce compromis **comparable** entre stratégies (Partie 4) : un score plus bas indique un meilleur équilibre global coût/CO2/risque.\n"
    ]
   },
   {
@@ -573,6 +616,23 @@
     "print()\n",
     "best = min(analysis.items(), key=lambda kv: kv[1]['score'])\n",
     "print(f'Strategie optimale (score multi-objectif minimal) : {best[0]}')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "smartgrid-interp-comparative-c835",
+   "metadata": {},
+   "source": [
+    "### Interprétation : le coût de la transition bas-carbone\n",
+    "\n",
+    "Les trois stratégies sont ici scorées avec des poids égaux `(1, 1, 1)` et des normes tirées des extrêmes (coût et CO2 max). Décomposition des scores :\n",
+    "\n",
+    "- **Économique** (1,596) = coût 0,60 + CO2 **1,00** + risque 0 : excellent sur le coût, maximal sur le CO2.\n",
+    "- **Écologique** (1,560) = coût **1,00** + CO2 0,56 + risque 0 : inverse, bon sur le CO2, maximal sur le coût.\n",
+    "\n",
+    "**L'Écologique l'emporte** (1,560 < 1,596) bien qu'elle coûte plus cher (106 800 € contre 63 600 €) : la réduction de CO2 (−44 %, soit 720 000 kg évités) compense la perte économique. **Compromis = Écologique** : les deux stratégies convergent vers un dispatch identique (mêmes coût, CO2 et risque). Avec les poids de recherche `(1, 3)` donnant 3 fois plus de poids au CO2, la somme pondérée sélectionne en fait la solution min-CO2 — le compromis coïncide ici avec l'extrémité écologique du front.\n",
+    "\n",
+    "**Coût marginal d'évitement** : passer du min-coût au min-CO2 coûte +43 200 € (+68 %) pour éviter 720 000 kg de CO2, soit environ **0,06 €/kg de CO2 évité**. C'est le type d'arbitrage chiffré qu'un opérateur de réseau doit expliciter avant de décider.\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary

CC3 `SmartGrid-Energy` (capstone interdisciplinaire : OR-Tools CP-SAT + inférence bayésienne + optimisation multi-objectif + jumeau numérique) : les **4 cellules de solveur « fondation »** (dispatch CP-SAT, risque bayésien, score multi-objectif, synthèse comparative) produisaient des sorties réelles non triviales mais chacune suivie d'un prompt d'Exercice/Conclusion **sans cellule d'interprétation entre les deux**.

## Défaut (G.1 firsthand)

Vérifié sur `origin/main` : pour chacune des 4 cellules, une sortie réelle existe (`execution_count` non null, `outputs` non vides), aucune cellule d'interprétation ne suit, et les résultats sont non triviaux → **gap d'enrichissement genuïne** (pas un FP — leçon po-2026 NB-12/18 appliquée : j'ai vérifié outputs exist + pas d'interp qui suit + résultats non triviaux).

## Livrable : 4 cellules d'interprétation ancrées sur les sorties committées

Tous les chiffres sont **vérifiés arithmétiquement** contre le code source + les outputs :

| Cellule | Sortie committée | Interprétation ajoutée |
|---------|------------------|------------------------|
| CP-SAT dispatch (cell 6) | `OPTIMAL`, Charbon 270–340 MW + Hydro 150 MW, coût 63 600 € | statut OPTIMAL, charbon porte la charge + hydro plafonné (pmax), pourquoi min-coût pousse au charbon (motive Parties 2–3) |
| Risque bayésien (cell 10) | risque 6,9e-142 … 8,2e-38 par heure | astronomiquement faible car 800 MW >> 420–490 MW ; le risque suit `renewable_forecast_std` (incertitude), pas le niveau de demande |
| Score multi-objectif (cell 14) | `1,137` | décomposition : coût 0,32 + CO2 0,82 + risque ~0 ; le terme CO2 domine (dispatch min-coût = bon marché mais sale) |
| Synthèse comparative (cell 18) | Écologique 1,560 < Économique 1,596 ; Compromis = Écologique | l'Écologique gagne malgré +68 % de coût pour −44 % CO2 ; Compromis (poids 1,3) = coin min-CO2 ; coût marginal d'évitement ≈ 0,06 €/kg CO2 |

## Validation

- **Markdown-only** (C.2 exception, pas de re-exec) : 8 cellules code + outputs **byte-identiques** à `origin/main` (vérifié in-script : comparaison source code avant/après). Diff : **60 insertions, 0 suppressions**.
- `nbformat` 4.5 **VALID**, H.3 ok (0 cellule code avec `ec=null`).
- **Catalogue byte-identique** à main.
- Base fraîche (`origin/main` aff8189a0, 0 behind/ahead).
- G.1 anti-FP : chaque cellule ajoutée suit immédiatement la cellule de code dont elle interprète la sortie (convention « interp APRES le code interprété »).

## Scope

`Grain: MED/notebook-python enrichment`. Famille fraîche (CaseStudies, jamais touchée). Pivot genre vs c.833 tooling (#8169) + c.834 doc-honesty (#8178) → G-VAR-3 ok.

Co-Authored-By: Claude-Code <noreply@anthropic.com>