### PR TITLE
fix(app3b,#8052): Conclusion glouton claim matches committed output (hard=0, not hard-violation)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-3b-NurseScheduling-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-3b-NurseScheduling-CSharp.ipynb
@@ -1068,7 +1068,7 @@
     "\n",
     "Ce twin C# a d\u00e9roul\u00e9 **trois solveurs from-scratch** sur le Nurse Rostering Problem :\n",
     "\n",
-    "- Le **glouton** est rapide mais myope : il peut violer des contraintes dures faute de retour arri\u00e8re.\n",
+    "- Le **glouton** est rapide mais myope : il atteint la faisabilit\u00e9 (co\u00fbt dur = 0), mais faute de retour arri\u00e8re il n'optimise pas les pr\u00e9f\u00e9rences \u2014 4 viol\u00e9es, le plus mauvais des trois solveurs.\n",
     "- Le **backtracking** garantit la **faisabilit\u00e9** (un planning valide) mais ignore l'optimisation.\n",
     "- Le **min-conflicts** atteint la faisabilit\u00e9 **et** minimise les pr\u00e9f\u00e9rences, en se laissant guider par le co\u00fbt.\n",
     "\n",


### PR DESCRIPTION
## Summary

claims↔outputs audit on `App-3b-NurseScheduling-CSharp.ipynb` (cell 22, Conclusion). The glouton bullet contradicted the committed benchmark output.

## Defect

The Conclusion's first bullet characterized the glouton as:

> « Le **glouton** est rapide mais myope : il **peut violer des contraintes dures** faute de retour arrière. »

But the committed benchmark output shows the glouton achieves **hard = 0** (zero hard violations) — it is feasible. The three solvers are distinguished only on **soft preferences** (Glouton=4, Backtracking=2, Min-Conflicts=0), which is exactly how the benchmark itself is framed (cell 12: « le min-conflicts doit battre le glouton sur l'objectif souple tout en atteignant la faisabilité »).

So the Conclusion contradicted **both** the committed output **and** the benchmark's own framing — the glouton's *demonstrated* weakness is soft-preference suboptimality (4, the worst), not hard-constraint violation.

## Cross-checked firsthand against committed outputs

| Cell | Output | Value |
|---|---|---|
| cell[7] glouton | `Violations dures : C2=0, C3=0, C4=0 \| Cout total = 4` | hard=0, soft=4 |
| cell[9] backtracking | `Violations dures : C2=0, C3=0, C4=0 \| Cout total = 2` | hard=0, soft=2 |
| cell[11] min-conflicts | `Violations dures : C2=0, C3=0, C4=0 \| Preferences = 0 \| Cout total = 0` | hard=0, soft=0 |
| cell[13] benchmark table | Glouton hard=0/soft=4, Backtracking hard=0/soft=2, Min-Conflicts hard=0/soft=0 | ✓ consistent |

Also confirmed faithful (no change needed): cell[2] data = 5 nurses × 7 days × 3 shifts = **105** boolean-equivalent / **21** integer vars → matches cell[14] twin-comparison table (« 105 booléens », « 21 entiers »).

## Fix

Markdown-only (C.2 exception — no re-exec, code cells untouched). Rewrite the glouton bullet to match the output:

> « Le **glouton** est rapide mais myope : il atteint la faisabilité (coût dur = 0), mais faute de retour arrière il n'optimise pas les préférences — 4 violées, le plus mauvais des trois solveurs. »

Backtracking and min-conflicts bullets left **byte-identical** (already faithful). The three-bullet narrative now coherently reflects the benchmark's soft-preference gradient (4 → 2 → 0).

## Validation

- JSON round-trip (`indent=1`, `ensure_ascii=True`) — verified **byte-stable serializer** beforehand, so zero collateral churn.
- Diff: exactly **1 line** (+1/−1); 24 cells / 10 code cells **all executed** (outputs intact).
- 0 CRLF (byte-level); trailing newline preserved.
- Cited numbers (`hard=0`, `4` preferences) pulled directly from committed outputs — no fabrication.

See #8052 (partial — epic au long cours, no `Closes`).

Co-Authored-By: Claude <noreply@anthropic.com>
