### PR TITLE
fix(mgs18): correct false super-additive (+1,41) interaction claim #8052

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-18-CecBanc.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-18-CecBanc.ipynb
@@ -877,7 +877,7 @@
     "\n",
     "La table de pire-cas (max sur Ackley + Rosenbrock × 4 variantes) **confirme la these structurelle** : **DE** (pire-cas Rosenbrock 1,71) est l'optimiseur le plus robuste du portefeuille ; **WOA** est **a eviter** (6,91 sur Rosenbrock combine). Les optimiseurs a arithmetique vectorielle (DE, SA) resistent ; l'ancrage central (WOA) et le composante-par-composant (GA) ne tiennent pas sous le protocole complet.\n",
     "\n",
-    "**Le fait subtil que le banc consolide est seul a reveler.** La generalisation a Rosenbrock montre un regime absent sur Ackley : pour WOA, `combined` (6,91) y est **pire que chacun des deux biais isoles** (`shifted` 5,19, `rotated` 3,13) — une interaction **super-additive** (+1,41). Sur Ackley a l'inverse, le même WOA etait sous-additif (déjà effondre sur le decalage, la rotation n'ajoutait rien). Le combine n'est donec ni universellement pire ni inoffensif : **sa severite depend du paysage**. C'est précisément ce que le banc isole (un seul biais a la fois) ne pouvait pas montrer.\n"
+    "**Le fait subtil que le banc consolide est seul a reveler.** La generalisation a Rosenbrock montre un regime absent sur Ackley : pour WOA, `combined` (6,91) y est **pire que chacun des deux biais isoles** (`shifted` 5,19, `rotated` 3,13) — alors que sur Ackley `combined` restait inferieur au biais dominant `shifted` (2,97). Sur Ackley a l'inverse, le même WOA etait sous-additif (déjà effondre sur le decalage, la rotation n'ajoutait rien). Le combine n'est donec ni universellement pire ni inoffensif : **sa severite depend du paysage**. C'est précisément ce que le banc isole (un seul biais a la fois) ne pouvait pas montrer.\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Audit claims↔outputs (#8052) firsthand sur **MGS-18-CecBanc** (famille Search/Part4-Metaheuristics, fraîche per R6 vs c.812 ML.NET ; seul MGS déjà audité par moi = MGS-16 #8137). Notebook **largement FIDÈLE** — tous claims numériques vérifiés contre les bancs committés (cell[7] Ackley, cell[10] interaction, cell[12] Rosenbrock).

**1 défaut logique corrigé** dans cell[13] (cell de synthèse « la thèse structurelle éprouvée ») :
- Le narratif claimait que pour WOA sur Rosenbrock, `combined` (6,91) étant pire que chaque biais isolé impliquait « une interaction **super-additive** (+1,41) ».
- **Mathématiquement faux** : interaction-vs-somme = `combined − (shifted + rotated)` = 6,91 − (5,19+3,13) = 6,91 − 8,32 = **−1,41** → **sous-additive** (négative), exactement comme sur Ackley (−1,75). La table cell[10] confirme la définition (colonne interaction = `d_comb − somme`).
- L'auteur a confondu « combined > chaque biais isolé » (VRAI sur Rosenbrock) avec « super-additif vs somme » (FAUX).

Le **contraste Rosenbrock↔Ackley est réel et préservé** : sur Rosenbrock `combined` dépasse même le pire biais isolé (6,91 > 5,19), alors que sur Ackley `combined` restait **inférieur** au biais dominant `shifted` (2,42 < 2,97). Fix : remplacer l'étiquette fausse par ce contraste factuel.

## Claims vérifiés FIDÈLES (G.1, contre bancs committés)

| Cell | Claim | Output réel (cell[7]/[10]/[12]) | Verdict |
|------|-------|------|---------|
| cell[8] | WOA plain 0,000 / shifted 2,97 / combined 2,42 | 0,000 / 2,971 / 2,421 | ✓ |
| cell[8] | GA rotated 3,24 | 3,242 | ✓ |
| cell[8] | EO/FBI/DE résolvent 4 variantes (~0) | tous 0,000 | ✓ |
| cell[8] | SA stable (~0) | 0,003–0,006 | ✓ |
| cell[9] | WOA Ackley interaction −1,75 sous-additif | −1,748 | ✓ |
| cell[13] | DE pire-cas Rosenbrock 1,71 (plus robuste) | 1,706 (min de toutes) | ✓ |
| cell[13] | WOA à éviter (6,91 Rosenbrock combined) | 6,910 | ✓ |
| cell[13] | WOA shifted 5,19 / rotated 3,13 | 5,185 / 3,126 | ✓ |
| cell[13] | combined pire que chaque biais isolé | 6,91 > 5,19 et > 3,13 | ✓ (vrai, préservé) |

## Fix (markdown-only, exception C.2 — pas de re-exec)

1 edit chirurgical cell[13] (+1/−1). Technique = **raw str.replace** (ce notebook .NET utilise des cell-ids custom `m0` et un formatage qui ne round-trippe PAS sous `json.dumps` ; toute re-sérialisation churning toutes les cells). Vérifié : OLD présent 1× exact, NEW présent 0→1×, size delta exact = single contiguous site, JSON re-parse OK, 0 code cell touchée, 0 output touchée.

Les décorateurs CEC étant seeded (RNG + ShiftVectors/RotationMatrices), une re-exec produirait les mêmes nombres — mais la convention #8052 aligne le markdown vers les outputs committés (source de vérité), pas de re-exec.

## Validation

- 11 code cells (11 exécutées, `execution_count != null`) + tous `outputs` byte-identiques (assert par cellule).
- 0 CRLF, 0 churn hors cell[13], accents préservés (déjà, é, è).
- C.1 = 0 violation.
- Catalogue byte-identique.

## R6

c.812b (tooling Probas twins) → c.813 (audit MGS-18) = pivot de genre (tooling→audit) + famille fraîche (Probas→Search/Part4). c.811/c.812a étaient audit (Sudoku/ML) ; c.812b tooling a cassé la séquence → c.813 audit permis.

See #8052 (partial — 1 défaut fixé, MGS-18 audité largement FIDÈLE documenté). Pas de `Closes`.
