### PR TITLE
fix(app15b,#8052): variable-count growth is cubic, not quadratic (n(n-1)^2 = degree 3)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb
@@ -2833,7 +2833,7 @@
     "| Metrique | Observation | Signification |\n",
     "|----------|-------------|---------------|\n",
     "| **Temps (n=4..10)** | 0.01 a ~0.05 s | Concordance d'ordre de grandeur avec le twin Python |\n",
-    "| **Variables** | `n*(n-1)*(n-1)` | Croissance quadratique (ex: n=10 -> 810 vars) |\n",
+    "| **Variables** | `n*(n-1)*(n-1)` | Croissance cubique (ex: n=10 -> 810 vars) |\n",
     "| **Seuil pratique** | ~20-30 équipes | Au-dela, augmenter le timeout ou accepter du faisable |\n",
     "\n",
     "> **Note technique** : le theoreme dit ce problème NP-difficile, mais CP-SAT resout instantanement les petites instances grace a la propagation par clauses paresseuses (LCG). Les temps observes (0.01-0.05 s pour n=4..10) reproduisent l'ordre de grandeur du twin Python ; les valeurs exactes varient d'une machine a l'autre."


### PR DESCRIPTION
## Summary

claims↔outputs audit on `App-15b-SportsScheduling-CSharp.ipynb` (cell 35, « Scalabilité du Solveur CP-SAT »). The Variables row mislabeled the growth of the variable count as **quadratic** — it is **cubic**.

## Defect

The scalability table labeled the growth of `n*(n-1)*(n-1)` as « Croissance **quadratique** ». But:

$$n(n-1)^2 = n^3 - 2n^2 + n$$

is a **degree-3 (cubic)** polynomial, not degree-2. The label contradicted both the formula printed in the same cell and the benchmark data one cell above.

## Verified firsthand against committed benchmark (cell[14] output)

| n | vars observed | = n(n−1)² |
|---|---|---|
| 4 | 36 | 4·3·3 ✓ |
| 6 | 150 | 6·5·5 ✓ |
| 8 | 392 | 8·7·7 ✓ |
| 10 | 810 | 10·9·9 ✓ |

Growth n=4 → n=10: **810/36 = 22.5×** for a 2.5× team increase. Cubic predicts 2.5³ = 15.6×, quadratic only 2.5² = 6.2× — the data is unambiguously super-quadratic. There is no interpretation under which n(n−1)² is quadratic.

## Fix

Markdown-only (C.2 exception — no re-exec, code cells untouched): « Croissance **quadratique** » → « Croissance **cubique** » in cell 35. The (correct) example « n=10 -> 810 vars » is unchanged.

Byte-level replace on a unique plain-ASCII site — the notebook uses ScottPlot SVG + custom cell ids, so a json round-trip risks collateral churn on untouched cells (cf. MGS-7/18 pattern); byte-level replace guarantees the diff is exactly the one word.

## Validation

- Diff: exactly **1 line** (+1/−1); 40 cells / 15 code cells **all executed** (outputs intact).
- 0 CRLF (byte-level); trailing newline preserved; JSON parses.
- Math re-derived in-script: n(n−1)² = n³−2n²+n (degree 3), data 36/150/392/810 matches.

## Residual (NOT fixed — machine-dependent, hedged, defensible)

The *Temps* row claims « 0.01 a ~0.05 s » while the committed output shows 0.004–0.015 s (upper bound ~3× high). The cell explicitly frames times as order-of-magnitude + machine-dependent (« varie d'une machine a l'autre ») and as a twin-Python comparison, so the loose time range is a softer mismatch than the unambiguous growth-rate error — left out of this surgical fix.

See #8052 (partial — epic au long cours, no `Closes`).

Co-Authored-By: Claude <noreply@anthropic.com>
