### PR TITLE
fix(harness): repair 2 dead memory-topic links flagged by check-links CI

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -83,7 +83,7 @@ gh pr list --state all --search "head:<branch>" --json number,state -q '.[].numb
 **Voir aussi** : [lecon-L576](https://github.com/jsboige/CoursIA/blob/main/.claude/memory/lecon-L576-rest-commits-pulls-fpos.md) (detail fondateur + symtome 5 branches `jsboige/*` decouvertes c.576 / attachees a #7086-#7091). Sub-grain 5/5 de l'epic #7423 « revue globale du harnais » (boucle vertueuse close par cette PR — dernier orphelin L576 ancre dans git-workflow ; reste 5 orphelines pour futurs grains cross-famille : L574 / L751 / L770 / L771 / L772+L789+L790+L791).
 ## PR Body Generation
 
-**Leçon ancrée** — [L677-L4 ★★](cycle-c680-argumentation-stale-paths.md) (c.680, voir aussi c.683/c.684/c.685/c.686/c.687/c.688/c.689/c.690 réutilisations) : le **body de PR se génère HORS worktree**, jamais dans un fichier du worktree (qui finirait stageé par `git add .` ou committe accidentellement).
+**Leçon ancrée** — L677-L4 ★★ (c.680, voir aussi c.683/c.684/c.685/c.686/c.687/c.688/c.689/c.690 réutilisations ; détail en mémoire locale per-machine) : le **body de PR se génère HORS worktree**, jamais dans un fichier du worktree (qui finirait stageé par `git add .` ou committe accidentellement).
 
 | Pattern | Correct | Wrong |
 |---------|---------|-------|

--- a/.claude/rules/lean-merge-discipline.md
+++ b/.claude/rules/lean-merge-discipline.md
@@ -26,7 +26,7 @@ Apres **chaque PR** ou **message dashboard/inbox** de `myia-po-2026:*` mentionna
 
 ## L750 ★★ Leçons ancrées — Pivot Lean specialist + scope discipline
 
-**Leçons ancrées** — [L750 ★★](cycle-c750-grothendieck-pullback-union.md) (c.750, PR #7895 MERGED feat(lean,#2159)) : 5 règles opérationnelles pour pivot/scope Lean specialist. Source : pivot verbatim ai-01 (msg-20260722T050055-i12hh3) qui a greenlit Folk.lean Tactic-1 (refuted firsthand, STRETCH polytope dure Fudenberg-Maskin) → Grothendieck `pullback_union` DEEP, même lake, rebase propre entre grains.
+**Leçons ancrées** — L750 ★★ (c.750, PR #7895 MERGED feat(lean,#2159) ; détail en mémoire locale per-machine) : 5 règles opérationnelles pour pivot/scope Lean specialist. Source : pivot verbatim ai-01 (msg-20260722T050055-i12hh3) qui a greenlit Folk.lean Tactic-1 (refuted firsthand, STRETCH polytope dure Fudenberg-Maskin) → Grothendieck `pullback_union` DEEP, même lake, rebase propre entre grains.
 
 ### Règle 1 — Vérifier scope STRETCH avant tout sorry (anti-claim discharge)
 


### PR DESCRIPTION
## Objet

Répare les **2 liens morts** que le check-links CI signale sur `main`, introduits par les PR de promotion de règles **#8104** (L677-L4) et **#8109/#8110** (L750) mergées le 2026-07-22 : elles pointaient vers des fichiers de **mémoire topic per-machine** (`cycle-c680-argumentation-stale-paths.md`, `cycle-c750-grothendieck-pullback-union.md`) **non trackés dans le dépôt** → `check-links` échoue fleet-wide.

## Correctif (mécanique, 2 lignes)

| Fichier | Avant (lien mort) | Après |
|---------|-------------------|-------|
| `.claude/rules/git-workflow.md` | `[L677-L4 ★★](cycle-c680-…md)` | `L677-L4 ★★ (… ; détail en mémoire locale per-machine)` |
| `.claude/rules/lean-merge-discipline.md` | `[L750 ★★](cycle-c750-…md)` | `L750 ★★ (… ; détail en mémoire locale per-machine)` |

**Contenu opérationnel des règles 100 % préservé** — seul le lien (pointeur cassé vers un fichier non-tracké) est retiré, remplacé par une note en clair. Aucune modification de sémantique de règle. +2/−2, 2 fichiers.

## Note gouvernance

Touche `.claude/rules/` → sous **gel de règles / sign-off user**. Ce n'est PAS un changement de gouvernance (réparation de lien mécanique), mais je respecte le gate : **PR ouverte, tenue pour sign-off user**, pas de self-merge. `check-links` est **advisory** (non-bloquant — les merges CLEAN passent), donc c'est du nettoyage de rouge cosmétique, pas un déblocage urgent.

*See #7423 (revue globale du harnais).*
