### PR TITLE
fix(gt,#8052): Burn Money (B,O,O) is Nash-but-not-SPE, drop from SPE column

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-10-ForwardInduction-SPE.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-10-ForwardInduction-SPE.ipynb
@@ -1607,7 +1607,7 @@
       "\n",
       "Burn Money (BoS):\n",
       "  Nash:           (B,O,O), (B,F,F), (N,O,O), (N,F,F), ...\n",
-      "  SPE:            (B,O,O), (N,F,F), (N,O,O)\n",
+      "  SPE:            (N,F,F), (N,O,O)\n",
       "  Trembling-hand: (N,O,O)\n",
       "  Forward ind.:   (N,O,O)\n"
      ]
@@ -1635,7 +1635,11 @@
     "        {\n",
     "            'name': 'Burn Money (BoS)',\n",
     "            'nash': ['(B,O,O)', '(B,F,F)', '(N,O,O)', '(N,F,F)', '...'],\n",
-    "            'spe': ['(B,O,O)', '(N,F,F)', '(N,O,O)'],\n",
+    "            # (B,O,O) est Nash (menace non-credible hors-chemin) mais PAS SPE :\n",
+    "            # bruler coute 1.5 ; a la racine J1 prefere toujours ne pas bruler\n",
+    "            # (gain >= 2 sans burn vs <= 1.5 avec burn pour tout prolongement).\n",
+    "            # Analogue a (Out,Fight) dans l'Entry Game (menace non-credible).\n",
+    "            'spe': ['(N,F,F)', '(N,O,O)'],\n",
     "            'trembling': ['(N,O,O)'],\n",
     "            'forward': ['(N,O,O)']\n",
     "        }\n",
@@ -1677,8 +1681,8 @@
     "**Stag Hunt avec option exterieure** : C'est ici que l'induction avant se distingue. Le SPE et le trembling-hand acceptent les deux equilibres de coordination (Stag,Stag) et (Hare,Hare). Seule l'induction avant, en utilisant le **signal** du renoncement a l'option exterieure, selectionne l'equilibre efficient (Stag,Stag).\n",
     "\n",
     "**Burn Money (BoS)** : L'exemple le plus frappant de discrimination :\n",
-    "- Nash : Multitude d'equilibres (avec ou sans burn, Opera ou Foot)\n",
-    "- SPE : Reduit mais reste ambigu\n",
+    "- Nash : Multitude d'equilibres (avec ou sans burn, Opera ou Foot) ; les equilibres avec burn (ex. (B,O,O)) ne sont soutenables que par des menaces non-credibles hors-chemin\n",
+    "- SPE : (N,O,O) et (N,F,F) ; l'equilibre (B,O,O) est elimine car bruler n'est pas credible a la racine (J1 prefere ne pas bruler pour tout prolongement de sous-jeu) -- exactement comme (Out,Fight) dans l'Entry Game\n",
     "- Trembling-hand et Forward induction : Selectionnent uniquement (N,O,O) - ne pas bruler, jouer Opera\n",
     "\n",
     "**Lecon methodologique** : Plus un raffinement est restrictif, plus il reduit l'ensemble des equilibres. Mais attention : un raffinement très restrictif peut parfois eliminer des equilibres \"raisonnables\". Le choix du raffinement depend du contexte et de ce qu'on veut modeliser."


### PR DESCRIPTION
Grain: MED/doc-honesty — lane myia-po-2025:CoursIA — prev: MED/sota-prongb (#8194)

## Defect (firsthand audit #8052, claims ↔ outputs)

The comparison table (cell 25) listed **`(B,O,O)` as a subgame-perfect equilibrium (SPE)** of the Burn Money (BoS) game. It is not.

### Proof (verified firsthand)
Burning costs 1.5. In any SPE the "do not burn" subgame is played at a NE; the pure NE of BoS give J1 ≥ 2 (`(F,F)`→2, `(O,O)`→3). Burning caps J1 at 3 − 1.5 = 1.5. Since 2 > 1.5, J1 always deviates from "burn" to "not burn" at the root → **no SPE burns on the equilibrium path**. `(B,O,O)` is therefore a non-credible equilibrium, exactly analogous to `(Out,Fight)` in the Entry Game — which the SAME notebook correctly excludes from its SPE column (Entry SPE = `(Enter,Acc)` only). The author removed the non-credible Nash for the Entry Game but missed it for Burn Money.

`(B,O,O)` **is** a Nash equilibrium of the whole game (sustainable by a non-credible off-path threat), so the Nash column is unchanged.

## Changes (surgical, 3 hunks, +8/−4)
- **cell 25 (code)**: drop `(B,O,O)` from the Burn Money `'spe'` list + inline comment stating the Entry-Game analogy; re-execute (pure-python print, deterministic, no RNG) → SPE output line refreshed.
- **cell 26 (markdown)**: refine the Burn Money bullet with the non-credible-threat reasoning.

## Validation
- **C.1**: 0 voluntary errors (`raise NotImplementedError` / `assert False` / `1/0`) across all code cells.
- **C.2**: cell 25 `execution_count=11` + refreshed stream output coherent with source; original output structure (list-form text, key order `name→output_type→text`) preserved.
- **H.3**: catalogue byte-identical (untouched); only 1 file changed; nbformat 4.5 valid.
- **#2876**: notebook is unaccented French by design; additions match the unaccented style, 0 accents removed (48 → 48).
- **Determinism**: equilibria are deterministic (no RNG); no markdown-vs-output numeric drift; determinism gate N/A for this fix.
- **Base**: 0 commits behind origin/main (no rebase needed).
- **Collision (L898)**: #8199 (twin-parity tranche 8, GT 3..17) touches only `scripts/notebook_tools/twin_pairs.yaml` — no `.ipynb` content overlap.

See #8052 (partial — epic au long cours; claims↔outputs audit vein). The rest of the notebook was firsthand-audited clean (Entry Game, Stag Hunt + outside option, trembling-hand, commitment game — all claims consistent with their outputs).
