### PR TITLE
fix(tooling,#8056): validator scans all markdown cells for cost frontmatter (c.825, L829)

### DIFF
--- a/scripts/audit/check_cost_metadata.py
+++ b/scripts/audit/check_cost_metadata.py
@@ -5,7 +5,8 @@ check_cost_metadata.py — Vérificateur cohérence frontmatter `cost:`.
 Issue #8056 (P1) — matrice coût/ressource par notebook.
 
 But : extraire pour un notebook :
-  - Le bloc YAML `cost:` de la cellule 0 (markdown frontmatter)
+  - Le bloc YAML `cost:` de la première cellule markdown le portant
+    (convention c.800 = cell[1], après le titre markdown cell[0])
   - Les usages réels : appels API, .cuda(), HF_TOKEN, QuantBook, etc.
   - Signaler les :
       (1) gpu_required: false mais cellule code lance torch.cuda / tensorflow GPU
@@ -63,7 +64,7 @@ TOKEN_PATTERNS = {
 
 
 def parse_cost_frontmatter(cell_source: str) -> dict:
-    """Parse le bloc YAML `--- ... ---` en cellule 0 markdown."""
+    """Parse le bloc YAML `--- ... ---` d'une cellule markdown (c.800 = cell[1])."""
     # Pattern : début de cellule = `---`, lignes YAML, `---` final
     pattern = r'^---\s*\n(.*?)\n---\s*\n'
     match = re.match(pattern, cell_source, re.DOTALL)
@@ -115,12 +116,22 @@ def check_notebook(notebook_path: Path, repo_root: Path) -> dict:
     cost_meta = {}
     code_cells_source = []
 
-    # Extraction frontmatter cellule 0 markdown
-    if nb.cells and nb.cells[0].get('cell_type') == 'markdown':
-        source = nb.cells[0].get('source', '')
+    # Extraction frontmatter : scan de TOUTES les cellules markdown.
+    # Convention c.800 = frontmatter à cell[1] (après le titre markdown cell[0],
+    # avant le code Papermill params). L'ancienne lecture cell[0]-seule ratait
+    # tous les notebooks c.800/c.801/c.821/c.822/c.823/c.824 (L829 NEW).
+    # Le premier bloc YAML `---...---` contenant `cost:` gagne ; backward-compatible
+    # (cell[0] markdown avec frontmatter reste détecté en premier).
+    for cell in nb.cells:
+        if cell.get('cell_type') != 'markdown':
+            continue
+        source = cell.get('source', '')
         if isinstance(source, list):
             source = ''.join(source)
-        cost_meta = parse_cost_frontmatter(source).get('cost', {})
+        parsed = parse_cost_frontmatter(source)
+        if 'cost' in parsed:
+            cost_meta = parsed.get('cost', {})
+            break
 
     # Agrégation cellules code
     for idx, cell in enumerate(nb.cells):


### PR DESCRIPTION
## Summary

Fix `scripts/audit/check_cost_metadata.py` to scan **all markdown cells** for the YAML `cost:` frontmatter block, instead of only `nb.cells[0]`.

**Root cause (L829 NEW, documented c.821→c.824)** : the validator at L118-123 read ONLY `nb.cells[0]` to detect the `---...---` frontmatter. The c.800 canonical convention inserts frontmatter at **cell[1]** (after the markdown title `cell[0]`, before the Papermill params code cell). Result: `cost_meta_found: False` on **all 31+ cluster-wide cost-matrix PRs** following the c.800 convention (c.800/c.801/c.821 Image + c.822/c.823/c.824 Audio). The validator was technically broken vs the applied convention.

**Grain** : MED/tooling-ci — distinct genre from c.821-c.824 docs-cost-matrix (G-VAR-3 rotation: `tooling` vs `docs`).

## The fix

```python
# AVANT (L118-123) : cell[0]-seule
if nb.cells and nb.cells[0].get('cell_type') == 'markdown':
    source = nb.cells[0].get('source', '')
    ...
    cost_meta = parse_cost_frontmatter(source).get('cost', {})

# APRÈS : scan toutes les cellules markdown, premier bloc `cost:` gagne
for cell in nb.cells:
    if cell.get('cell_type') != 'markdown':
        continue
    source = cell.get('source', '')
    if isinstance(source, list):
        source = ''.join(source)
    parsed = parse_cost_frontmatter(source)
    if 'cost' in parsed:
        cost_meta = parsed.get('cost', {})
        break
```

**Backward-compatible** : cell[0] markdown with frontmatter is still checked first (DecInfer-1 c.794 pilote pattern preserved). The loop scans in order; the first parseable block containing `cost:` wins.

## Validation firsthand (G.1 verify-before-claiming)

```
=== Detection on origin/main cost-frontmatter notebooks ===
  OK   01-1-OpenAI-DALL-E-3.ipynb       (c.800, frontmatter at cell[1])
  OK   01-2-GPT-5-Image-Generation.ipynb (c.800, cell[1])
  OK   01-4-Forge-SD-XL-Turbo.ipynb     (c.800, cell[1])
  OK   01-5-Qwen-Image-Edit.ipynb       (c.800, cell[1])
  OK   02-1-Qwen-Image-Edit-2509.ipynb  (c.800, cell[1])
  OK   02-2-FLUX-1-Advanced-Generation.ipynb (c.800, cell[1])
  OK   02-3-Stable-Diffusion-3-5.ipynb  (c.800, cell[1])
  OK   02-4-Z-Image-Lumina2.ipynb       (c.800, cell[1])
  OK   DecInfer-1-Utility-Foundations.ipynb (c.794, cell[0])
  Detected: 9/9   (was 1/9 before fix — only DecInfer-1 at cell[0])

=== False-positive check (notebooks WITHOUT cost frontmatter) ===
  OK (no cost): 01-1-Video-Operations-Basics.ipynb
  OK (no cost): 01-2-GPT-5-Video-Understanding.ipynb
  OK (no cost): 01-3-Qwen-VL-Video-Analysis.ipynb
  OK (no cost): 10_LocalLlama.ipynb
  → 0 false positives
```

**Net effect** : 8 more notebooks detected on `origin/main` (all c.800 Image at cell[1]) + unblocks detection on all unmerged c.801/c.821/c.822/c.823/c.824 PRs once they merge.

## Diff metric

```
git diff --stat HEAD
 scripts/audit/check_cost_metadata.py | 23 +++++++++++++++++------
 1 file changed, 17 insertions(+), 6 deletions(-)
```

Strict c.187 atomic (+17/-6), G.4 atomique (1 commit, 1 sub-genre tooling-ci).

## Conformité run

- **L268 LF-only** : `tr -cd '\r' | wc -c = 0` in diff.
- **L143 secrets-hygiene** : 0 hit.
- **c.187 atomic** : +17/-6 strict, 1 file.
- **G.4 atomique** : 1 commit, 1 sub-genre (tooling-ci, distinct from c.824 docs-cost-matrix — G-VAR-3 rotation `tooling` vs `docs`).
- **G.1 verify-before-claiming** : 9/9 detection + 0 FP validated firsthand (proof above).
- **No CI workflow change** : validator invoked on-demand, no `.github/` refs (`grep -rl check_cost_metadata .github/` = 0). Pure library fix.
- **Python syntax OK** : `ast.parse` clean.
- **Backward-compatible** : cell[0] frontmatter pattern (DecInfer-1 c.794) preserved.

## Relation EPIC #8056

| Cycle | Tranche | Sub-genre | Statut |
|-------|---------|-----------|--------|
| c.794 | DecInfer pilote | cost-matrix pilote | MERGED #8073 |
| c.800 | Image × 8 | c.800 sub-grain | MERGED #8140 |
| c.801 | Image × 6 | c.801 sub-grain | OPEN MERGEABLE #8147 |
| c.821 | Image × 6 (residu) | c.821 sub-grain-residu | OPEN MERGEABLE #8204 |
| c.822 | Audio × 14 (F+A) | c.822 sub-grain-fa | OPEN MERGEABLE #8208 |
| c.823 | Audio × 3 (Orchestration) | c.823 sub-grain-orchestration | OPEN MERGEABLE #8211 |
| c.824 | Audio × 13 (Applications) | c.824 sub-grain-applications | OPEN MERGEABLE #8217 |
| **c.825** | **validator fix** | **tooling-ci (L829 NEW sub-issue)** | **THIS** |

This PR resolves the L829 NEW sub-issue documented in c.821/c.822/c.823/c.824 PR bodies. Once merged, the validator will correctly report `cost_meta_found: True` for all c.800-convention notebooks.

## Suite logique (c.826+)

- **c.826+** (DEEP/docs-cost-matrix-tranche-video-texte-ml) : Video (17), Texte (20), ML (52) sub-familles — distinct sub-genre per family defendable (G-VAR-3 same-genre-DEEP allowed if substance genuinely distincte).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
