### PR TITLE
docs(probas,#8205): canonical citations PyMC-2 Gaussian Mixtures (c.834)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-2-Gaussian-Mixtures.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-2-Gaussian-Mixtures.ipynb
@@ -685,7 +685,19 @@
     "\n",
     "### Origine du modèle\n",
     "\n",
-    "Les melanges de gaussiennes sont etudies depuis Pearson (1894) ; le traitement moderne de reference est **McLachlan & Peel (2000)**, *Finite Mixture Models* (Wiley), et **Titterington, Smith & Makov (1985)**, *Statistical Analysis of Finite Mixture Distributions* (Wiley). L'algorithme classique d'estimation par maximum de vraisemblance est **EM** (Dempster, Laird & Rubin, 1977) ; ici, a la place d'EM, nous inferons le modèle en Bayesien via MCMC (`pm.sample`), ce qui fournit des intervalles de credibilite sur les poids et les paramètres de chaque composante.\n"
+    "Les melanges de gaussiennes sont etudies depuis Pearson (1894) ; le traitement moderne de reference est **McLachlan & Peel (2000)**, *Finite Mixture Models* (Wiley), et **Titterington, Smith & Makov (1985)**, *Statistical Analysis of Finite Mixture Distributions* (Wiley). L'algorithme classique d'estimation par maximum de vraisemblance est **EM** (Dempster, Laird & Rubin, 1977) ; ici, a la place d'EM, nous inferons le modèle en Bayesien via MCMC (`pm.sample`), ce qui fournit des intervalles de credibilite sur les poids et les paramètres de chaque composante.\n",
+    "\n",
+    "\n",
+    "### References canoniques complementaires\n",
+    "\n",
+    "Au-dela des references classiques ci-dessus (Pearson 1894, EM Dempster-Laird-Rubin 1977, McLachlan & Peel 2000, Titterington-Smith-Makov 1985), le traitement canonique moderne des melanges gaussiens se trouve dans les ouvrages de reference :\n",
+    "\n",
+    "1. **Bishop (2006).** *Pattern Recognition and Machine Learning*, Springer. **§9.2** \"Mixtures of Gaussians\", **§9.2.2** \"EM for mixtures\" (derivee EM + lower-bound maximization + closed-form M-step pour gaussiennes), **§10.7** \"Expectation Propagation\" (variante pour melanges non-conjugues, voir cellule suivante).\n",
+    "2. **Murphy (2012).** *Machine Learning: A Probabilistic Perspective*, MIT Press. **§11.4** \"Mixture models and the EM algorithm\" (traitement unifie EM + variational EM + accelerated EM via sufficient statistics).\n",
+    "3. **Tipping & Bishop (1999).** *Mixtures of probabilistic principal component analyzers*, Neural Computation 11(2), 443-482. Variante bayesienne variationnelle melangeant PCA probabiliste -- pertinent si on etend le GMM a des observations de haute dimension.\n",
+    "4. **Ghahramani & Beal (2000).** *Variational inference for Bayesian mixtures of factor analysers*, NIPS 1999. Inference variationnelle pour melanges bayesiens -- alternative au MCMC `pm.sample` utilise dans ce notebook.\n",
+    "\n",
+    "Ces references completent le socle Pearson/EM/McLachlan-Stephens cite dans le notebook et permettent au lecteur d'approfondir selon l'angle (theorie de l'information, inference variationnelle, ou extension haute-dimension)."
    ]
   },
   {


### PR DESCRIPTION
# docs(probas,#8205): canonical citations PyMC-2 Gaussian Mixtures (c.834)

**Grain:** MED/notebook-probas-citations — lane `myia-po-2023:CoursIA-2` — prev: MED/notebook-probas-citations (c.833 PyMC-11).

G-VAR-3 intra-genre OK : 5ᵉ livraison même-genre mais **substance genuinely distincte** (PyMC collapsed NUTS jumeau c.819 Infer-2, litmus C711-L1 vérifié : PyMC `pm.sample` + NUTS + Multinomial marginalisé ≠ Infer.NET expanded VMP + Variable.Switch + EP/VMP) + **closed-loop batch consolidée #8205** (sub-grain 15 du roadmap #8081, livré à part pour respecter G.4 split obligatoire + L951 batch sub-issue pattern).

## Scope

Applique les **findings actionnables** de l'audit c.819 (PR #8198 CLOSED violation-fix) au notebook `MyIA.AI.Notebooks/Probas/PyMC/PyMC-2-Gaussian-Mixtures.ipynb`. **Sub-grain 15** du roadmap audit-distillation #8081 (jumeau PyMC du c.819 Infer-2). Ce PR complète le batch consolidé #8205 (Refs #8081 partial — ferme le sub-grain 15 ; `See #8205` car le batch reste ouvert tant que toutes les PRs ne sont pas mergées).

**Substance (G.1 first-hand)** : le notebook implémente GMM avec PyMC `pm.sample` (NUTS + BinaryGibbsMetropolis), comparaison Infer.NET vs PyMC sur 23 cellules (13 md + 10 code ALL_EXEC). Le notebook **cite DÉJÀ** 12 références inline (McLachlan-Peel 2000 cell 13/22, Titterington-Smith-Makov 1985 cell 13/22, Dempster-Laird-Rubin 1977 cell 13/22, Redner-Walker 1984 cell 15/22, Stephens 2000 cell 15/22) — **DIV POS assumée** par rapport au jumeau Infer-2 qui cite 0 source (c.819 L942). Mais **manquent les références canoniques modernes** : Bishop PRML §9.2, Murphy ML §11.4, Tipping-Bishop 1999, Ghahramani-Beal 2000.

**Vérification G.1 du mapping fondateur #8087** : comme pour c.819 Infer-2, aucun chapitre MBML ne couvre EM/GMM (vérification G.1 first-hand via WebFetch sur [mbmlbook.com/toc.html](https://www.mbmlbook.com/toc.html) : 7 chap + Ch.8 interlude, Ch.8 = k-means hard clustering non-probabiliste). **Les sources canoniques sont donc Bishop PRML §9.2/§9.2.2/§10.7 + Murphy ML §11.4**, pas MBML — cohérence avec la correction factuelle #8087.

## Modification

**Cellule 13 (markdown « 5. Melange de Gaussiennes (GMM) → Origine du modèle »)** : ajout d'une sous-section « References canoniques complementaires » après le paragraphe existant listant Pearson/EM/McLachlan/Titterington, avec les **4 sources canoniques complémentaires** :

1. **Bishop (2006).** *Pattern Recognition and Machine Learning*, Springer. **§9.2** « Mixtures of Gaussians », **§9.2.2** « EM for mixtures » (derivee EM + lower-bound maximization + closed-form M-step pour gaussiennes), **§10.7** « Expectation Propagation » (variante pour melanges non-conjugues).
2. **Murphy (2012).** *Machine Learning: A Probabilistic Perspective*, MIT Press. **§11.4** « Mixture models and the EM algorithm » (traitement unifie EM + variational EM + accelerated EM via sufficient statistics).
3. **Tipping & Bishop (1999).** *Mixtures of probabilistic principal component analyzers*, Neural Computation 11(2), 443-482. Variante bayesienne variationnelle PCA — pertinent si on etend le GMM a des observations de haute dimension.
4. **Ghahramani & Beal (2000).** *Variational inference for Bayesian mixtures of factor analysers*, NIPS 1999. Inference variationnelle pour melanges bayesiens — alternative au MCMC `pm.sample` utilisé dans ce notebook.

La cellule 15 (interprétation sampling avec Stephens 2000 + Redner-Walker 1984) et la cellule 22 (conclusion avec Dempster-Laird-Rubin 1977 + McLachlan-Peel 2000 + Redner-Walker 1984 + Stephens 2000 + Titterington-Smith-Makov 1985 = **5 références déjà canoniques**) sont **inchangées** — socle canonique déjà présent, **DIV POS assumée** vs le jumeau Infer-2 (c.819).

**Aucune modification** des cellules code (10/10 préservées), de la cellule 15 (Stephens déjà inline), ni de la cellule 22 (5 références canoniques déjà listées).

## Conformité

- **R3 atomique strict** : 1 notebook, 1 cellule markdown touchée, +13/-1 lignes (JSON lines).
- **JSON valide** : `nbformat.validate(nb) == None` (23 cellules intactes).
- **LF-only** : `CR count = 0` vérifié après écriture Python.
- **Outputs préservés** : 10/10 cellules code conservent leurs `execution_count: <int>` et `outputs: [...]` inchangés (audit lecture seule, **0 ré-exécution Papermill**).
- **C.2 notebook-conventions** : aucune cellule code touchée (cf règle C.3 — scope strict des ré-exécutions Papermill).
- **Anti-régression** : pas de cellule `# Solution` / `# Exemple résolu` supprimée.
- **readme-french-first** : prose de documentation en français.
- **G.1 first-hand citations** : chaque référence vérifiée contre la source canonique (Bishop PRML table des matières Chap. 9 + Chap. 10 ; Murphy ML §11.4 table ; Tipping-Bishop 1999 Neural Computation vol.11(2) ; Ghahramani-Beal NIPS 1999 proceedings).

## Sub-issues cumulatives — batch #8205 COMPLET post-merge c.834

La sub-issue batch #8205 couvre **5 notebooks** (c.816 Infer-11 LDA + c.817 PyMC-11 LDA + c.818 Infer-12 Hierarchical + c.819 Infer-2 GMM + **c.834 PyMC-2 GMM jumeau**). Avec ce PR **PyMC-2 GMM**, le batch est **complet** : 5/5 notebooks livrés, **5/5 PRs du pipeline citations canoniques** (Infer-11/Infer-12/Infer-2 livrés en c.832/c.830/c.831, PyMC-11/PyMC-2 livrés en c.833/c.834).

Récapitulatif des livraisons du batch #8205 :

| PR | Notebook | Substance | Citations ajoutées |
|----|----------|-----------|-------------------|
| #8230 | Infer-12 | Modèles hiérarchiques | Gelman BDA3, Gelman-Hill, Rubin, Efron-Morris, James-Stein (5) |
| #8231 | Infer-2 | GMM (Infer.NET VMP/EP) | Bishop, Murphy, McLachlan-Peel, Dempster, Tipping-Bishop, Ghahramani-Beal + Stephens (7) |
| #8232 | Infer-11 | LDA Dirichlet-discret | Blei/Ng/Jordan, MBML sub-page, Pritchard, Wang-Grimson (4) |
| #8233 | PyMC-11 | LDA Dirichlet-discret (jumeau NUTS) | MBML sub-page, Pritchard, Wang-Grimson (3, Blei déjà présent) |
| **#8234** | **PyMC-2** | **GMM (PyMC collapsed NUTS, jumeau c.819)** | **Bishop PRML, Murphy ML, Tipping-Bishop, Ghahramani-Beal (4 ; socle McLachlan/Dempster/Stephens/Titterington/Redner-Walker déjà présent)** |

## Validation H.1 (exécution réelle)

- **Audit lecture seule** : 10/10 cellules code avec `execution_count != null` et `outputs: [...]` cohérents (C.2 OK).
- **0 ré-exécution Papermill** : scope strict (notebook-conventions.md règle C.3) — modification sur cellule markdown uniquement.
- **Modifications cell 13 préservées intactes** : `nbformat.read` + `nbformat.validate` + diff `+13/-1` confirme le caractère additif pur.

Refs #8081 (partial — 15ᵉ sub-grain de 38). **See #8205** (sub-issue batch consolidée 5 sub-grains, ouverte tant que toutes les PRs ne sont pas mergées).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: myia-po-2023 <noreply@anthropic.com>