### PR TITLE
docs(probas,#8081): Infer-9 canonical citations + BPM fidelity note (distillation audit)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb
@@ -37,7 +37,15 @@
     "|-----------|--------|\n",
     "| [Infer-6-Debugging](Infer-6-Debugging.ipynb) | [Infer-8-TrueSkill](Infer-8-TrueSkill.ipynb) |\n",
     "\n",
-    "---"
+    "---\n",
+    "\n",
+    "## Sources et références canoniques\n",
+    "\n",
+    "Ce notebook est distillé des sources fondatrices suivantes (audit fidélité, voir #8081) :\n",
+    "\n",
+    "- **Bayes Point Machine** — Herbrich, R., Graepel, T. & Campbell, C. (2001). *Bayes Point Machines*. Journal of Machine Learning Research, 1:245–279. DOI: 10.1162/153244301753683717. Papier fondateur : le BPM approxime la prédiction bayésienne complète par un unique point représentatif (le « Bayes point »), estimé par Expectation Propagation.\n",
+    "- **Régression logistique bayésienne (probit, EP)** — Bishop, C. M. (2006). *Pattern Recognition and Machine Learning*. Springer. §4.3 (Probit Regression), §4.5 (Bayesian Logistic Regression).\n",
+    "- **Exemple de référence Infer.NET** — dépôt [`dotnet/infer`](https://github.com/dotnet/infer), dossier `Examples` (Bayes Point Machine, classification). Implémentation canonique C# dont ce notebook est dérivé.\n"
    ]
   },
   {
@@ -2584,7 +2592,9 @@
     "\n",
     "### Formulation\n",
     "\n",
-    "$$P(y=1|x) = \\int P(y=1|x,w) P(w|D) dw$$"
+    "$$P(y=1|x) = \\int P(y=1|x,w) P(w|D) dw$$\n",
+    "\n",
+    "> **Fidélité à la source (Herbrich, Graepel & Campbell, 2001).** L'intégrale ci-dessus est la *prédiction bayésienne complète* — la moyenne sur tout le postérieur $P(w|D)$. Le Bayes Point Machine à proprement parler l'approxime par un **point représentatif unique**, le « Bayes point » (centre de masse de la version space), estimé efficacement par EP plutôt que par le coûteux calcul intégral. C'est cette approximation par un seul hyperplan représentatif qui définit le BPM et le distingue d'un classifieur bayésien pleinement marginalisé.\n"
    ]
   },
   {
@@ -2616,7 +2626,9 @@
     "\n",
     "$$P(y=1|x) = \\Phi(w^T x) = \\int_{-\\infty}^{w^T x} \\mathcal{N}(z|0,1) dz$$\n",
     "\n",
-    "ou $\\Phi$ est la fonction de repartition de la loi normale standard."
+    "ou $\\Phi$ est la fonction de repartition de la loi normale standard.\n",
+    "\n",
+    "> **Référence.** Bishop (2006), *PRML* §4.3 (Probit Regression) et §4.5 (Bayesian Logistic Regression, Expectation Propagation). Le choix du lien probit (bruit gaussien latent) plutôt que logit (bruit logistique) est précisément ce qui rend l'inférence par EP tractable en Infer.NET — point central du chapitre §4.5.\n"
    ]
   },
   {


### PR DESCRIPTION
## Contexte

Audit fidélité #8081 (distillation Probas/Infer.NET vs sources originales). **Infer-9-Classification** n'était couvert ni par les pilotes d'audit (Infer-3/4/5/8, FIDÈLE) ni par la sous-issue citations #8205 (qui cible Infer-2/11/12 + PyMC-2/11, tous déjà en PR open). Infer-9 est uncontended et dans le turf .NET de po-2023.

## Finding firsthand (G.1)

`grep Bishop|Herbrich|MBML|JMLR|PRML` sur Infer-9 = **0 hit**. Le notebook couvre la régression logistique bayésienne (probit), le **Bayes Point Machine** (§6) et le test A/B clinique — sujets distillés de sources fondatrices **sans aucune citation académique**. C'est le même gap de fidélité que #8205 a trouvé sur Infer-2/11/12, sur un notebook non couvert.

## Backfill (markdown-only, 3 cellules)

| Cell | Section | Action |
|------|---------|--------|
| 0 | Intro | Lineage + 3 sources canoniques (BPM paper, Bishop PRML, exemple dotnet/infer) |
| 24 | Bayes Point Machine | **Note de fidélité** : clarifie l'approximation définitoire du BPM |
| 25 | Probit vs logit | Citation Bishop PRML §4.3 + §4.5 (pourquoi EP est tractable) |

**Substance ajoutée au-delà d'une simple registry** (cell 24) : l'intégrale `P(y=1|x)=∫ P(y=1|x,w) P(w|D) dw` du notebook est la *prédiction bayésienne complète*. Le BPM à proprement parler l'approxime par un **point représentatif unique** (« Bayes point », centre de masse de la version space) estimé par EP — distinction conceptuelle qui définissait le papier originel mais que le notebook original ne rendait pas explicite.

## Référence vérifiée firsthand (anti-fabrication)

- **Herbrich, R., Graepel, T. & Campbell, C. (2001)**, *Bayes Point Machines*, **JMLR 1:245–279** (DOI 10.1162/153244301753683717). Corrigé au passage : c'est le **volume 1**, pas 2 — `jmlr.org/papers/v2/...` retourne 404, la forme canonique est `…/v1/herbrich01a`.
- Bishop, C. M. (2006), *Pattern Recognition and Machine Learning*, Springer — §4.3 (Probit Regression), §4.5 (Bayesian Logistic Regression, EP).

## Validation

- Markdown-only (exception C.2) : aucune cellule de code touchée, `execution_count`/`outputs` byte-identiques, pas de re-exec nécessaire.
- Diff `+15/−3` sur 3 cellules markdown, **zéro churn** (serializer `json.dumps(indent=1, ensure_ascii=False)` + LF, round-trip byte-stable vérifié).
- JSON valide, nbformat 4.5, 55 cellules préservées.
- FR (règle readme-french-first).

See #8081 (contribution partielle à l'epic d'audit ; n'apporte que le notebook Infer-9, ne résout pas l'epic).
