### PR TITLE
docs(probas,#8081): Infer-10 canonical citations + evidence/Bayes-factor/ARD fidelity notes

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb
@@ -37,7 +37,15 @@
     "|-----------|--------|\n",
     "| [Infer-11-Topic-Models](Infer-11-Topic-Models.ipynb) | [Infer-14-Sequences](Infer-14-Sequences.ipynb) |\n",
     "\n",
-    "---"
+    "---\n",
+    "\n",
+    "## Sources et références canoniques\n",
+    "\n",
+    "Ce notebook est distillé des sources fondatrices suivantes (audit fidélité, voir #8081) :\n",
+    "\n",
+    "- **Evidence / marginal likelihood (Occam factor)** — Bishop, C. M. (2006). *Pattern Recognition and Machine Learning*. Springer, §3.4 (Bayesian model comparison) et §3.5 (The evidence approximation). MacKay, D. J. C. (1992). *Bayesian Interpolation*, Neural Computation 4(3):415–447 — cadre fondateur de l'evidence framework.\n",
+    "- **Facteur de Bayes et échelle d'interprétation** — Kass, R. E. & Raftery, A. E. (1995). *Bayes Factors*. Journal of the American Statistical Association, 90(430):773–795 (DOI 10.1080/01621459.1995.10476572). L'échelle de comparaison (substantielle / forte / décisive) est l'échelle de Jeffreys (1961), *Theory of Probability*, telle que rapportée et normalisée par Kass & Raftery.\n",
+    "- **Automatic Relevance Determination (ARD)** — Tipping, M. E. (2001). *Sparse Bayesian Learning and the Relevance Vector Machine*. Journal of Machine Learning Research, 1:211–244. Également Bishop PRML §3.5 (ARD) et §7.2 (Relevance Vector Machines).\n"
    ]
   },
   {
@@ -391,7 +399,9 @@
     "\n",
     "- Un modèle simple fait des predictions moins precises mais moins dispersees\n",
     "- Un modèle complexe fait des predictions plus precises mais plus dispersees\n",
-    "- L'evidence favorise le bon equilibre"
+    "- L'evidence favorise le bon equilibre\n",
+    "\n",
+    "> **Fidélité à la source (Bishop 2006, §3.4 ; MacKay 1992).** L'evidence réalise un arbitrage automatique entre ajustement et complexité via le **facteur d'Occam** : un modèle complexe répartit sa masse de probabilité sur un espace d'hypothèses plus large, donc *dilue* $P(D|M)$ dès que les données tombent hors d'une région étroite. Le modèle qui maximise l'evidence n'est ni le plus simple ni le mieux ajusté, mais celui dont la « portée » (volume de prédictions plausibles) épouse le mieux les données — c'est la formalisation bayésienne du rasoir d'Ockham que Bishop §3.4 développe en détail et que l'intégrale ci-dessus encode implicitement.\n"
    ]
   },
   {
@@ -2750,7 +2760,9 @@
     "| 1-2 | 3-10 | Substantielle |\n",
     "| 2-3 | 10-30 | Forte |\n",
     "| 3-5 | 30-150 | Très forte |\n",
-    "| >5 | >150 | Decisive |"
+    "| >5 | >150 | Decisive |\n",
+    "\n",
+    "> **Référence.** Kass & Raftery (1995), *Bayes Factors*, JASA 90(430):773–795. Le tableau ci-dessus est l'échelle de Jeffreys (1961, *Theory of Probability*) telle que consolidée par Kass & Raftery. À noter : les seuils originels de Jeffreys (1–3 / 3–10 / 10–30 / 30–150 / >150 en $\\log$) diffèrent légèrement des seuils alternatifs (3 / 20 / 150) utilisés ailleurs dans la littérature — le notebook suit la convention de Jeffreys, ce qui est un choix légitime à documenter explicitement.\n"
    ]
   },
   {
@@ -3850,7 +3862,9 @@
     "$$\\alpha_f \\sim \\text{Gamma}(a, b)$$\n",
     "$$w_f \\sim \\mathcal{N}(0, \\alpha_f^{-1})$$\n",
     "\n",
-    "Si $\\alpha_f$ devient grand, le poids $w_f$ est contraint pres de 0 -> feature non pertinente."
+    "Si $\\alpha_f$ devient grand, le poids $w_f$ est contraint pres de 0 -> feature non pertinente.\n",
+    "\n",
+    "> **Fidélité à la source (Tipping 2001 ; Bishop PRML §3.5).** Le mécanisme d'ARD est le cœur du *Sparse Bayesian Learning* de Tipping : le prior hiérarchique $\\alpha_f \\sim \\text{Gamma}$ agit comme une « précision » apprise par inférence. Pour une feature non pertinente, les données ne contraignent pas $w_f$, le posterior de $\\alpha_f$ croît vers de grandes valeurs, et le prior $w_f \\sim \\mathcal{N}(0, \\alpha_f^{-1})$ rétrécit le poids vers zéro — la feature est ainsi **automatiquement désactivée** par le modèle lui-même, sans seuillage manuel. C'est exactement le principe exploité par le Relevance Vector Machine (RVM), qui n'en retient qu'un petit sous-ensemble de « relevance vectors ».\n"
    ]
   },
   {


### PR DESCRIPTION
## Contexte

Suite de l'audit fidélité #8081 (distillation Probas/Infer.NET vs sources originales). Suite directe de #8238 (Infer-9, c.844) : même bug-class — notebooks Infer distillés de sources fondatrices **sans aucune citation académique** — appliqué à **Infer-10-Model-Selection**, notebook uncontended (≠ #8205 qui cible Infer-2/11/12 + PyMC-2/11, saturé).

## Finding firsthand (G.1)

`grep Bishop|MacKay|Kass|Raftery|Tipping|JMLR|JASA|PRML` sur Infer-10 = **0 hit**. Le notebook couvre trois concepts fondateurs majeurs — evidence/marginal likelihood, facteurs de Bayes (avec l'échelle de Jeffreys), et Automatic Relevance Determination — **sans aucune citation** de leurs sources canoniques.

## Backfill markdown-only (4 cellules)

| Cell | Section | Action |
|------|---------|--------|
| 0 | Intro | Lineage + 4 sources canoniques (Bishop PRML §3.4/§3.5, MacKay 1992, Kass-Raftery 1995, Tipping 2001) |
| 8 | Evidence | **Note de fidélité Occam factor** : l'evidence pénalise la complexité (concept central Bishop §3.4 non explicite dans le notebook) |
| 18 | Facteur de Bayes | Citation Kass & Raftery (1995) + Jeffreys (1961) ; **documente** que les seuils (1-3/3-10/…) sont la convention Jeffreys (≠ seuils alternatifs 3/20/150) |
| 25 | ARD | **Note de fidélité mécanisme ARD** : le prior Gamma sur α désactive les features non pertinentes (cœur du Sparse Bayesian Learning de Tipping / RVM) |

**Substance ajoutée au-delà d'une registry** : cell 8 explicite le facteur d'Occam (la formalisation bayésienne du rasoir d'Ockham que l'intégrale encode implicitement) ; cell 25 rend le mécanisme d'auto-élagage des features explicite plutôt qu'implicite. Comme #8238 sur Infer-9, ce n'est pas du simple nettoyage de références.

## Références vérifiées firsthand (anti-fabrication, SearXNG multi-sources)

- **Tipping, M. E. (2001)**, *Sparse Bayesian Learning and the RVM*, **JMLR 1:211–244** (vol 1, même convention que BPM Herbrich c.844).
- **Kass, R. E. & Raftery, A. E. (1995)**, *Bayes Factors*, **JASA 90(430):773–795**, DOI 10.1080/01621459.1995.10476572.
- Bishop, C. M. (2006), *PRML*, §3.4 (Bayesian model comparison) + §3.5 (evidence approximation, ARD).
- MacKay, D. J. C. (1992), *Bayesian Interpolation*, Neural Computation 4(3):415–447.

## Validation

- Markdown-only (exception C.2) : **18 code cells byte-identiques** (exec_count/outputs préservés, pas de re-exec).
- Diff `+18/−4` sur 4 cellules markdown, **zéro churn** (serializer `json.dumps(indent=1, ensure_ascii=False)` + LF, round-trip byte-stable vérifié).
- JSON valide, nbformat 4.5, 58 cellules préservées.
- FR (règle readme-french-first).

See #8081 (contribution partielle : ajoute Infer-10 au périmètre d'audit, ne résout pas l'epic).
