### PR TITLE
fix(genai-texte,#8052): NB-3 cell[31] score 86->88 to match committed output

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/3_Structured_Outputs.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/3_Structured_Outputs.ipynb
@@ -1529,7 +1529,7 @@
     "L'évaluation structurée démontre la puissance de la validation Pydantic combinée aux Structured Outputs :\n",
     "\n",
     "**Résultats obtenus** :\n",
-    "- **Score** : 86/100 (validé automatiquement dans la plage 0-100 grâce à `conint`)\n",
+    "- **Score** : 88/100 (validé automatiquement dans la plage 0-100 grâce à `conint`)\n",
     "- **Analyse qualitative** : Le modèle a identifié que le texte est factuel mais manque de détails\n",
     "- **Points forts** : Concision, clarté de l'affirmation\n",
     "- **Axes d'amélioration** : Enrichissement avec exemples et justifications\n",


### PR DESCRIPTION
fix(genai-texte,#8052): NB-3 cell[31] score 86->88 to match committed output

Claims<->outputs audit (#8052) on GenAI/Texte (fresh family). Notebook:
3_Structured_Outputs.

Defect: cell[31] "Resultats obtenus" claimed "- **Score** : 86/100" but
the COMMITTED cell[30] output shows "Score: 88/100". Single numeric
mismatch (class-1: wrong number restating an output). Verified all other
interpretation cells (8,13,21,23,28,34) MATCH their committed outputs --
only cell[31] diverges.

Fix: markdown-only (C.2 exception -- LLM scores are non-deterministic,
re-exec produces a different number; keep committed outputs as source of
truth and align the markdown to them). Single-number swap 86->88 via raw
str.replace on a unique anchor (byte-faithful: prefix/suffix preserved,
round-trip json valid).

Validation: +1/-1, only cell[31] changed, 0 CRLF, catalog byte-identical
to main, H.3 validator 1/1 PASS (12 code cells), 0 NotImplementedError,
cell[30] output (88/100 committed) untouched. Markdown-only -> no re-exec
needed (C.2 exception); outputs are SOTA-OK real OpenAI API.

See #8052 (partial).

Co-authored-by: myia-po-2024 <myia-po-2024@coursia.local>
