### PR TITLE
enrich(sudoku-6,#3801): FC-vs-MAC hard-puzzle benchmark — make MAC's propagation advantage visible

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb
@@ -1536,16 +1536,16 @@
    "id": "ad2f5862",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T11:16:04.120854Z",
-     "iopub.status.busy": "2026-06-05T11:16:04.118814Z",
-     "iopub.status.idle": "2026-06-05T11:16:40.055493Z",
-     "shell.execute_reply": "2026-06-05T11:16:40.055493Z"
+     "iopub.execute_input": "2026-07-24T01:05:35.114951Z",
+     "iopub.status.busy": "2026-07-24T01:05:35.114841Z",
+     "iopub.status.idle": "2026-07-24T01:06:07.555088Z",
+     "shell.execute_reply": "2026-07-24T01:06:07.544889Z"
     },
     "papermill": {
-     "duration": 35.974481,
-     "end_time": "2026-06-05T11:16:40.057219",
+     "duration": 32.440247,
+     "end_time": "2026-07-24T01:06:07.555088",
      "exception": false,
-     "start_time": "2026-06-05T11:16:04.082738",
+     "start_time": "2026-07-24T01:05:35.114841",
      "status": "completed"
     },
     "tags": []
@@ -1566,17 +1566,43 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BACKTRACKING SIMPLE          2889322       499461        35636 2/2\n",
-      "BACKTRACKING MRV LCV             255            0           74 2/2\n",
-      "FORWARD CHECKING                  81            0           51 2/2\n"
+      "BACKTRACKING SIMPLE          2889322       499461        20111 2/2\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "MAC                               81            0          137 2/2\n",
-      "================================================================================\n"
+      "BACKTRACKING MRV LCV             255            0          237 2/2\n",
+      "FORWARD CHECKING                  81            0          187 2/2\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MAC                               81            0          259 2/2\n",
+      "================================================================================\n",
+      "\n",
+      "=== FC vs MAC sur 4 puzzles difficiles (top95) ===\n",
+      "======================================================================\n",
+      "Strategie                 Assigns   Backtracks    Temps(ms)   Succes\n",
+      "----------------------------------------------------------------------\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "FORWARD CHECKING             2143         2062         6302 4/4\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MAC                          1060          979         5296 4/4\n",
+      "======================================================================\n"
      ]
     }
    ],
@@ -1650,7 +1676,37 @@
     "    name = strategy.name.replace('_', ' ')\n",
     "    print(f\"{name:<25} {total_assigns//num_benchmark_puzzles:>10} {total_backtracks//num_benchmark_puzzles:>12} {total_time*1000:>12.0f} {successes}/{num_benchmark_puzzles}\")\n",
     "\n",
-    "print(\"=\" * 80)"
+    "print(\"=\" * 80)",
+    "\n",
+    "# --- FC vs MAC sur puzzles difficiles (top95) ---\n",
+    "# Sur les puzzles faciles ci-dessus, FC et MAC convergent (0 backtrack chacun) :\n",
+    "# la grille très contrainte est déjà presque résolue par propagation unitaire, la\n",
+    "# propagation 1-niveau de FC suffit à détecter tous les culs-de-sac, et le fixpoint\n",
+    "# AC-3 de MAC n'y ajoute rien. Leur écart théorique (profondeur de propagation)\n",
+    "# n'apparaît que sur des instances faiblement contraintes : on le mesure sur top95.\n",
+    "hard_puzzles = load_puzzles(str(PUZZLES_DIR / 'Sudoku_top95.txt'), max_puzzles=4)\n",
+    "num_hard = len(hard_puzzles)\n",
+    "print()\n",
+    "print(f\"=== FC vs MAC sur {num_hard} puzzles difficiles (top95) ===\")\n",
+    "print(\"=\" * 70)\n",
+    "print(f\"{'Strategie':<22} {'Assigns':>10} {'Backtracks':>12} {'Temps(ms)':>12} {'Succes':>8}\")\n",
+    "print(\"-\" * 70)\n",
+    "for strategy in [CSPStrategy.FORWARD_CHECKING, CSPStrategy.MAC]:\n",
+    "    total_assigns = 0\n",
+    "    total_backtracks = 0\n",
+    "    total_time = 0\n",
+    "    successes = 0\n",
+    "    for i in range(min(num_hard, len(hard_puzzles))):\n",
+    "        grid = SudokuGrid.from_string(hard_puzzles[i])\n",
+    "        result, assigns, backtracks, elapsed = solve_with_strategy(grid, strategy)\n",
+    "        total_assigns += assigns\n",
+    "        total_backtracks += backtracks\n",
+    "        total_time += elapsed\n",
+    "        if result and result.is_valid():\n",
+    "            successes += 1\n",
+    "    name = strategy.name.replace('_', ' ')\n",
+    "    print(f\"{name:<22} {total_assigns//num_hard:>10} {total_backtracks//num_hard:>12} {total_time*1000:>12.0f} {successes}/{num_hard}\")\n",
+    "print(\"=\" * 70)"
    ]
   },
   {
@@ -1679,7 +1735,11 @@
     "**Observations clés** :\n",
     "1. **MRV** est l'heuristique la plus impactante (reduction souvent > 10x)\n",
     "2. **FC** ajoute un gain significatif en détectant les échecs plus tot\n",
-    "3. **MAC** est optimal mais plus couteux par noeud (AC-3 à chaque pas)"
+    "3. **MAC** est optimal mais plus couteux par noeud (AC-3 à chaque pas)",
+    "\n",
+    "\n",
+    "> **Pourquoi FC et MAC donnent-ils des résultats identiques sur les puzzles faciles ?**\n",
+    "> Une grille facile (fortement contrainte) est déjà presque résolue par propagation unitaire : la propagation **1-niveau** de FC détecte à elle seule tous les culs-de-sac, et le fixpoint AC-3 de MAC n'y ajoute rien — les deux convergent vers 81 assignations et 0 backtrack. Leur écart théorique (profondeur de propagation) n'apparaît que sur des instances **faiblement contraintes**, où des domaines intermédiaires se vident en profondeur : c'est ce que mesure le benchmark **top95** ci-dessus, où FC accumule environ **deux fois plus de backtracks** que MAC. Le surcoût de MAC (AC-3 à chaque pas) ne se rentabilise donc que sur les instances où la propagation 1-niveau ne suffit pas.\n"
    ]
   },
   {


### PR DESCRIPTION
## Prong-B enrichment — Sudoku-6 FC vs MAC : rendre visible l'écart invisibilisé par des puzzles faciles (See #3801, See #8052)

**Grain**: MED/prong-b — lane myia-po-2025:CoursIA — prev: MED/docs (cost-frontmatter #8220-#8228). Pivot de genre (prong-b ≠ docs).

### Le défaut (auto-incriminant, confirmé firsthand)

`Sudoku-6-AIMA-CSP-Python.ipynb` enseigne Forward Checking (FC) et MAC comme deux stratégies *distinctes* et claim MAC > FC (table d'interprétation cell 33 : « FC Très réduit / 1-niveau » vs « MAC Minimal / Propagation complète »). Mais le seul benchmark peuplé (cell 32) tourne sur **2 puzzles faciles** où FC et MAC donnent des nombres **identiques** :

```
FORWARD CHECKING   81 assigns, 0 backtracks
MAC                81 assigns, 0 backtracks   <-- identique, la claim MAC > FC n'est pas supportée
```

L'énoncé d'exercice lui-même (cell 39) admet que le Sudoku est un substrat dégénéré pour cette comparaison (« Contrairement au Sudoku (grille structurée), le coloriage de graphe offre des topologies variées qui mettent en évidence les différences entre FC et MAC ») — mais la démo graph-coloring (cell 40) est un **stub étudiant vide**. Résultat : un étudiant qui ne fait pas l'exercice n'observe **jamais** FC différer de MAC dans le notebook.

### Dégénérescence, précisément

FC et MAC utilisent tous deux MRV (`select_mrv`) + LCV (`order_lcv`) — ils diffèrent **uniquement** par la profondeur de propagation : FC = propagation 1-niveau (`ForwardChecking.propagate`), MAC = fixpoint AC-3 (`AC3.run`). Sur un puzzle facile (fortement contraint), la propagation 1-niveau de FC suffit déjà à détecter tous les culs-de-sac : le fixpoint de MAC n'ajoute rien, les deux convergent (81/0). L'écart asymptotique n'apparaît que sur des instances faiblement contraintes où des domaines intermédiaires se vident en profondeur.

### La mesure (discrimination mesurée firsthand, pas pitchée — règle Prong-B / sota §B)

Sonde FC vs MAC sur `Sudoku_top95.txt` — l'écart apparaît sur **chaque** puzzle dur (FC ≈ 2× MAC backtracks). Determinism-gate : nombres stables sur 3 runs (MRV+LCV déterministe).

Le benchmark ajouté à cell 32 (moyenne sur 4 puzzles top95, < 3 s chacun) :
```
=== FC vs MAC sur 4 puzzles difficiles (top95) ===
Strategie              Assigns   Backtracks    Temps(ms)   Succes
FORWARD CHECKING         2143        2062         6302    4/4
MAC                      1060         979         5296    4/4
```

### Le fix (légitime, ne touche PAS l'exercice étudiant)

- **Cell 32 (exemple)** : on garde le benchmark facile (spectre Simple→MRV→FC + convergence FC≈MAC honnête sur instances contraintes) et on **ajoute une seconde table « FC vs MAC sur top95 »** qui exhibe l'écart. `BACKTRACKING_SIMPLE` est exclu de cette 2e table (explosion sur dur — d'où le timeout existant) : on compare les deux stratégies à propagation.
- **Cell 33 (interprétation)** : note nuancée — sur puzzles faciles FC≈MAC (propagation 1-niveau suffit), l'écart théorique apparaît sur top95 (FC ≈ 2× MAC backtracks). La table existante « FC Très réduit / MAC Minimal » devient **supportée par les données** au lieu de contredite.
- **Cell 40 (exercice)** : **NON touchée**. Les stubs `generate_random_graph`/`build_graph_coloring_csp` restent des exercices étudiants (exercise-example-labeling : résoudre un stub = banni).

### Validation

- **Re-exécution réelle** cell 32 (kernel `python3`, nbconvert) : `execution_count=16`, 0 erreur, 6 stream outputs.
- **Validateur H.3 du repo** `validate_pr_notebooks.py` : PASS (19 code cells).
- **C.1/C.3 audit** `audit_c1_c3.py` : 42/42 notebooks Sudoku pass.
- **Solution-leak detector** : 0 HIGH, 0 MEDIUM.
- **Determinism-gate** 3× : FC a=8574/b=8250, MAC a=4242/b=3918 stables (top95[:4]).
- **Diff chirurgical** : seules cell 32 (source + outputs) et cell 33 (markdown) modifiées. Cells 35/37/40 (CBJ + exercice) byte-identiques. 1 fichier, +74/−14.
- **Transparence sur le drift** : le benchmark facile garde ses `assigns`/`backtracks` **byte-identiques** (déterministes : 2889322/499461, 255/0, 81/0, 81/0) ; seules les valeurs `Temps(ms)` du benchmark facile ont dérivé (non-déterminisme wall-clock, attendu quand on ré-exécute une cellule qui émet du timing). Aucune sortie hand-éditée (Stop & Repair respecté).

See #3801 (SOTA Prong-B registry), See #8052 (audit échantillonnage — ce défaut est un cas « claim non supporté par les outputs »).
