### PR TITLE
docs(probas,#8081): Infer-7 canonical citations + IRT(Rasch 1PL)/DINA fidelity notes

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb
@@ -38,7 +38,15 @@
     "|-----------|--------|\n",
     "| [Infer-4-Bayesian-Networks](Infer-4-Bayesian-Networks.ipynb) | [Infer-6-Debugging](Infer-6-Debugging.ipynb) |\n",
     "\n",
-    "---"
+    "---\n",
+    "\n",
+    "## Sources et références canoniques\n",
+    "\n",
+    "Ce notebook est distillé des sources fondatrices de la psychométrie et du diagnostic cognitif (audit fidélité, voir #8081) :\n",
+    "\n",
+    "- **Item Response Theory (IRT)** — Rasch, G. (1960). *Probabilistic Models for Some Intelligence and Attainment Tests*. Danish Institute for Educational Research. Lord, F. M. (1980). *Applications of Item Response Theory to Practical Testing Problems*. Erlbaum. Birnbaum, A. (1968). *Some latent trait models and their use in inferring an examinee's ability*, dans Lord & Novick, *Statistical Theories of Mental Test Scores*. Addison-Wesley. La formulation $P=\\sigma(\\text{capacite}-\\text{difficulte})$ implémentée ici est le **modèle 1PL / Rasch** ; les extensions 2PL (paramètre de discrimination) et 3PL (paramètre de guessing) sont dues à Birnbaum.\n",
+    "- **Modèle DINA** — de la Torre, J. (2009). *DINA Model and Parameter Estimation: A Didactic*. Journal of Educational and Behavioral Statistics, 34(1):115–130 (DOI 10.3102/1076998607309474). Cadre canonique du diagnostic cognitif : matrice $Q$, paramètres slip/guess, règle conjonctive (Noisy-AND).\n",
+    "- **Diagnosis cognitif (cadre général)** — Rupp, A. A., Templin, J. & Henson, R. A. (2010). *Diagnostic Measurement: Theory, Methods, and Applications*. Guilford Press. Synthèse des modèles DINA, DINO, NIDA et de l'estimation des Q-matrices.\n"
    ]
   },
   {
@@ -409,7 +417,9 @@
     "\n",
     "avantage[i,j] = capacite[i] - difficulte[j]\n",
     "reponse[i,j] ~ Probit(avantage[i,j])\n",
-    "```"
+    "```\n",
+    "\n",
+    "> **Fidélité à la source (Rasch 1960 ; Lord 1980).** Le modèle implémenté est le **1PL (one-parameter logistic) / modèle de Rasch** : un seul paramètre par item (la difficulté), la capacité étant scalée sur une échelle commune. C'est le modèle IRT le plus parcimonieux ; il impose la propriété forte de *specific objectivity* (les comparaisons entre personnes sont indépendantes de l'ensemble d'items, et réciproquement) que Rasch défendait comme une exigence de mesure, pas seulement une commodité. Le passage du logistique ($\\sigma$) au **probit** utilisé en Infer.NET est une variante de lien équivalente pour l'inférence (cf. Infer-9, Bishop PRML §4.3/§4.5) mais ne change pas la structure fondamentale du modèle.\n"
    ]
   },
   {
@@ -1897,7 +1907,9 @@
     "| paramètre | Description |\n",
     "|-----------|-------------|\n",
     "| **Slip** | P(incorrect \\| a toutes les competences) - erreur d'inattention |\n",
-    "| **Guess** | P(correct \\| manque une competence) - reponse au hasard |"
+    "| **Guess** | P(correct \\| manque une competence) - reponse au hasard |\n",
+    "\n",
+    "> **Fidélité à la source (de la Torre 2009).** Le modèle DINA (*Deterministic Input, Noisy-And*) repose sur trois objets canoniques : (1) la **matrice $Q$** qui encode quelles compétences chaque question requiert, (2) le **profil latent** binaire de l'étudiant (possède/ne possède pas chaque compétence), et (3) la règle conjonctive idéalisée — la réponse est correcte si et seulement si **toutes** les compétences requises sont présentes, puis bruitée par les deux paramètres appris **slip** $s$ (erreur d'inattention malgré la maîtrise) et **guess** $g$ (succès au hasard malgré une lacune). Le DINA se distingue de l'IRT par sa **multidimensionnalité discrète** : au lieu d'une capacité scalaire continue, il infère un profil de compétences — c'est ce passage du trait latent au *diagnostic cognitif* qui justifie toute la section 4.\n"
    ]
   },
   {


### PR DESCRIPTION
## Contexte

Suite de l'audit fidélité #8081 (distillation Probas/Infer.NET vs sources originales). Suite de #8238 (Infer-9) + #8239 (Infer-10) : c.846 a pivoté en code-correctness (Sudoku, série CLEAN firsthand). R6 ré-autorise donc 1 cycle citations → **Infer-7-Skills-IRT**, notebook uncontended (≠ #8205 qui cible Infer-2/11/12 + PyMC-2/11).

## Finding firsthand (G.1)

`grep Rasch|Lord|Birnbaum|DINA|JEBS|de la Torre|IRT` sur Infer-7 = **0 hit**. Le notebook couvre l'**Item Response Theory** (modèle 1PL/Rasch, ability/difficulty) et le **modèle DINA** (diagnostic cognitif, slip/guess, matrice Q) — concepts fondateurs de la psychométrie **sans aucune citation** de leurs sources canoniques.

## Backfill markdown-only (3 cellules)

| Cell | Section | Action |
|------|---------|--------|
| 0 | Intro | Lineage + 4 sources canoniques (Rasch 1960, Lord 1980, Birnbaum 1968, de la Torre 2009, Rupp/Templin/Henson 2010) |
| 8 | Modèle IRT | **Note de fidélité** : identifie `P=σ(capacite−difficulte)` comme le **1PL/Rasch**, explicite la *specific objectivity* de Rasch, situe les extensions 2PL (discrimination) / 3PL (guessing) de Birnbaum |
| 24 | DINA | **Note de fidélité** : les 3 objets canoniques (matrice Q, profil latent binaire, règle Noisy-AND bruitée par slip/guess) + le passage clef IRT→DINA = trait latent scalaire → profil de compétences multidimensionnel discret |

**Substance ajoutée au-delà d'une registry** : cell 8 explicite que le notebook implémente le 1PL/Rasch (le modèle le plus parcimonieux, avec la propriété forte de *specific objectivity*) et relie probit↔logistique à Infer-9/Bishop ; cell 24 rend explicite pourquoi DINA est un saut conceptuel (multidimensionnalité discrète vs trait scalaire), justifiant toute la section 4.

## Références vérifiées firsthand (anti-fabrication, SearXNG multi-sources)

- **Rasch, G. (1960)**, *Probabilistic Models for Some Intelligence and Attainment Tests*, Danish Institute for Educational Research.
- **Lord, F. M. (1980)**, *Applications of IRT to Practical Testing Problems*, Erlbaum.
- **Birnbaum, A. (1968)**, dans Lord & Novick, *Statistical Theories of Mental Test Scores*, Addison-Wesley (2PL/3PL).
- **de la Torre, J. (2009)**, *DINA Model and Parameter Estimation: A Didactic*, **JEBS 34(1):115–130**, DOI 10.3102/1076998607309474.

## Validation

- Markdown-only (exception C.2) : **23 code cells byte-identiques** (exec_count/outputs préservés, pas de re-exec).
- Diff `+15/−3` sur 3 cellules markdown, **zéro churn** (serializer `json.dumps(indent=1, ensure_ascii=False)` + LF, round-trip byte-stable vérifié). LaTeX matche la convention du notebook (`capacite`/`difficulte` sans accents LaTeX, comme la cell 8 originale).
- JSON valide, nbformat 4.5, 74 cellules préservées.
- FR (règle readme-french-first).

See #8081 (contribution partielle : ajoute Infer-7 au périmètre d'audit, ne résout pas l'epic).
