### PR TITLE
docs(genai-video,#8056): cost: frontmatter on 02-5-LTX2-Audiovisual (c.831 sub-grain-residu)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-5-LTX2-Audiovisual.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-5-LTX2-Audiovisual.ipynb
@@ -30,6 +30,14 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\ntitle: \"LTX-2 - generation audiovisuelle conjointe video + audio (Lightricks 22B)\"\ncost:\n  api_usd_est: 0.00            # Local 100% (ltx-core + ltx-pipelines)\n  api_provider: none           # GPU local obligatoire\n  cpu_min: 4\n  gpu_min: 1\n  gpu_required: true           # GPU lourd obligatoire (22B quantize)\n  vram_gb: 20                  # 24 GB fp8-cast/GGUF Q4\n  vram_tier: GPU_HIGH\n  network: true                # HF checkpoints + ltx-pipelines\n  external_account: huggingface # HF_TOKEN via os.environ si gated\n  free_alternative: self       # Local uniquement\n  reduced_pedagogical: quantized # fp8-cast / GGUF Q4 obligatoire\n  reproducibility: LOW         # diffusion sampling stochastic, lip-sync variable\n  last_validated: 2026-07-24T01:30Z\n  validator: papermill\nnotes: |\n  LTX-2 (Lightricks) generation audiovisuelle conjointe video + audio.\n  Modele 22B ; quantization obligatoire (fp8-cast natif ou GGUF Q4).\n  Packages non-standards (ltx-core + ltx-pipelines).\n  Lip-sync audio-video variable (reproductibilite LOW).\n---\n"
+   ],
+   "id": "ltx2-frontmatter-00"
+  },
+  {
+   "cell_type": "markdown",
    "id": "ltx2-00",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
## docs(genai-video,#8056): cost: frontmatter on 02-5-LTX2-Audiovisual (c.831 sub-grain-residu)

**Grain : DEEP/docs-cost-matrix — lane myia-po-2025:CoursIA-2 — prev : DEEP/docs-cost-matrix (c.830 Video 02-Advanced)**

### Substance

Insertion d'une cellule markdown avec bloc YAML `cost:` (15-field canonique c.800) entre la cellule code Papermill `# Parameters` (c0) et la cellule markdown titre `# LTX-2 ...` (c1) du notebook `02-5-LTX2-Audiovisual.ipynb`. Pattern C sub-grain-residu (analogue c.821 Image sub-grain-residu).

### Pourquoi Pattern C et pas Pattern A

- **Pattern A** (c.829/c.830) : cell[0]=markdown + cell[1]=code → insert new markdown cell at cell[1].
- **Pattern C sub-grain-residu** (c.821 + cette PR) : cell[0]=code + cell[1]=markdown → insert new markdown cell at cell[1] (entre c0 et c1, **PAS** au-dessus de c0).

Pourquoi ne pas prépender au-dessus de c0 ? Parce que c0 contient `# Parameters\nBATCH_MODE = "true"` qui est une cellule Papermill injectée en tête — prépendre au-dessus **supprimerait** la cellule de paramètres batch et empêcherait Papermill d'injecter ses paramètres. Le sub-grain-residu préserve donc c0 intacte et insère **après**.

### Champs `cost:` adaptés pour LTX-2 (vs c.830 canonical)

| Champ | LTX-2 (c.831) | HunyuanVideo (c.830) | Différence |
|-------|---------------|----------------------|------------|
| `gpu_required` | **true** | false | 22B GPU lourd obligatoire (vs HunyuanVideo API ComfyUI optionnelle) |
| `vram_gb` | **20** | 18 | fp8-cast/GGUF Q4 obligatoire, ne tient pas en FP16 sur 24 GB |
| `reduced_pedagogical` | **quantized** | self | Quantification obligatoire, pas d'option self-clean |
| `reproducibility` | **LOW** | MED | Lip-sync audio-video stochastic (vs text-to-video pur) |
| `vram_tier` | GPU_HIGH | GPU_HIGH | Idem |
| `api_usd_est` | 0.00 | 0.00 | Local 100% (ltx-core + ltx-pipelines) |
| `api_provider` | none | none | Pas d'API canonique pay-per-call |

### Conformité stricte

- **yaml.safe_load** : 14/14 keys `cost:` + sibling `notes:` parsés strict
- **regex match** : `---\n` opening + `---\n` closing présents
- **nbformat.validate** : OK (id field `ltx2-frontmatter-00` ajouté à la cellule)
- **LF-only CR=0** (L268)
- **c.281-L1 MD047** : trailing newline mandatory
- **L924 round-trip safe** : smoke test `c831_smoke_roundtrip.py` confirme c0 source byte-identique après `json.dumps(indent=1, ensure_ascii=False)` round-trip
- **c.187 atomic strict** : 1 commit, 1 file, +8/-0 (insertion 1 cellule)
- **R1 catalog byte-identique** : aucun fichier `COURSE_CATALOG.generated.*` touché
- **C.3 0 Papermill re-exec** : insertion markdown uniquement, code/outputs préservés
- **L143 secrets** : 0 literal inline (`.env` only via `os.environ`)
- **L800** : `open('wb')` + UTF-8 no-BOM + trailing LF manuel

### Couverture post-merge

| Phase | Image | Audio | Video | Texte | QC | ML |
|-------|-------|-------|-------|-------|----|----|
| post-c.831 | 20/20 (100%) | 30/30 (100%) | **10/17 (59%)** | 20/20 (100%) | 67/67 (100%) | 28/52 (54%) |

### Reste EPIC #8056 Video

- ✅ Video 01-Foundation (5/5) — PR #8235 (c.829)
- ✅ Video 02-Advanced canonical (4/5) — PR #8237 (c.830)
- ✅ Video 02-Advanced residu (1/1) — cette PR (c.831)
- ❌ Video 03-Orchestration (3) : 03-1-Multi-Model + 03-2-Video-Workflow + 03-3-ComfyUI-Workflows
- ❌ Video 04-Applications (4) : 04-1-Educational + 04-2-Creative + 04-3-Sora + 04-4-Production

### Refs

- See #8056 (EPIC #8056 partial: Video sub-grain-residu 1/8 = 12.5% Video residu)
- Refs PR #8237 (c.830 Video 02-Advanced canonical Pattern A 4/5)
- Refs PR #8235 (c.829 Video 01-Foundation Pattern A 5/5)

### Worktree

`D:/dev/CoursIA-2-c831-video-residu/` branche `feature/c831-video-residu-ltx2` SHA `c111e307a`. Cleanup post-merge.