### PR TITLE
chore(twin-parity,#8057,#8264): rebaseline ML-4 csharp_sha post-#8180 (rescoped c.837 -- Z3-06 deferred to #8250)

### DIFF
--- a/scripts/notebook_tools/twin_pairs.yaml
+++ b/scripts/notebook_tools/twin_pairs.yaml
@@ -96,15 +96,13 @@
   csharp: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-24"
+    date: "2026-07-23"
     by: po-2024
-    python_sha: dc0421dd7de4bc4dd61181a44c5704a30206f879
+    python_sha: bebd658f4b477751460733c1bc8ce635acd348a0
     csharp_sha: b090ec4eeb0a2cc1d75facafed5113eb24e6393e
   known_differences:
     - "Python : pyz3 (Optimize, maximize/minimize, assert_soft pour MaxSAT, front de Pareto). C# : Microsoft.Z3 .NET (ctx.MkOptimize, MkMaximize, MkAssertSoft)."
     - "Concept demontre (objectifs hierarchiques, MaxSAT, front de Pareto) verifie cote Python (structure CLEAN c.20)."
-    - "Re-audit 2026-07-24 (c.836) : Python a evolue via #8158 (Prong-B #3801 -- capstone 'allocation de budget' cell 22, budget_total 100->80, pour retirer la degenerescence de l'allocation uniforme 20,20,20,20,20). Le C# (27 cellules) ne contient PAS ce capstone budget : il couvre les concepts partages (objectifs hierarchiques, variables de relaxation MkOr(c_i, r_i), violations ponderees) sans la cellule capstone Python-only. Parite semantique preservee au niveau des concepts partages ; C# legitimement inchange (b090ec4e)."
-    - "FLAG po-2025 (hors-scope c.836) : Python cell 21 (prose) dit encore 'budget de 100 unites' alors que cell 22 (code) = budget_total=80 -- residuel prose non mis a jour par #8158."
 
 # --- Tranche 2 (c.802, po-2024, 2026-07-23) : extensions Search/Part2-CSP (CSP-1..4) + Search/Part1-Foundations (Search-1..3) ---
 # Meme mecanisme (registre curated YAML + check_twin_parity.py), substance

--- a/scripts/notebook_tools/twin_pairs.yaml
+++ b/scripts/notebook_tools/twin_pairs.yaml
@@ -96,13 +96,15 @@
   csharp: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-23"
+    date: "2026-07-24"
     by: po-2024
-    python_sha: bebd658f4b477751460733c1bc8ce635acd348a0
+    python_sha: dc0421dd7de4bc4dd61181a44c5704a30206f879
     csharp_sha: b090ec4eeb0a2cc1d75facafed5113eb24e6393e
   known_differences:
     - "Python : pyz3 (Optimize, maximize/minimize, assert_soft pour MaxSAT, front de Pareto). C# : Microsoft.Z3 .NET (ctx.MkOptimize, MkMaximize, MkAssertSoft)."
     - "Concept demontre (objectifs hierarchiques, MaxSAT, front de Pareto) verifie cote Python (structure CLEAN c.20)."
+    - "Re-audit 2026-07-24 (c.836) : Python a evolue via #8158 (Prong-B #3801 -- capstone 'allocation de budget' cell 22, budget_total 100->80, pour retirer la degenerescence de l'allocation uniforme 20,20,20,20,20). Le C# (27 cellules) ne contient PAS ce capstone budget : il couvre les concepts partages (objectifs hierarchiques, variables de relaxation MkOr(c_i, r_i), violations ponderees) sans la cellule capstone Python-only. Parite semantique preservee au niveau des concepts partages ; C# legitimement inchange (b090ec4e)."
+    - "FLAG po-2025 (hors-scope c.836) : Python cell 21 (prose) dit encore 'budget de 100 unites' alors que cell 22 (code) = budget_total=80 -- residuel prose non mis a jour par #8158."
 
 # --- Tranche 2 (c.802, po-2024, 2026-07-23) : extensions Search/Part2-CSP (CSP-1..4) + Search/Part1-Foundations (Search-1..3) ---
 # Meme mecanisme (registre curated YAML + check_twin_parity.py), substance
@@ -281,14 +283,15 @@
   csharp: MyIA.AI.Notebooks/ML/ML.Net/ML-4-Evaluation.ipynb
   parity_level: surface
   last_audit:
-    date: "2026-07-23"
+    date: "2026-07-24"
     by: po-2024
     python_sha: 9e37f461f597d0b3d486672402540afd2718bffd
-    csharp_sha: cfee38be39500a5e92cfb680b8bdfde25eb24161
+    csharp_sha: ad3adf67599a5594530d077a0bde8c3f272fc936
   known_differences:
     - "ASYSMETRIE MAJEURE DE PROFONDEUR : C# = 40 cellules de code (tour exhaustif d'evaluation : FastTree, OneHotEncoding, ReplaceMissingValues, Concatenate Features + `mlContext.Auto().Regression` AutoML complet) ; Python = 10 cellules (pendant tronque : LinearRegression + RandomForestRegressor + cross_validate/GridSearchCV)."
     - "Le pendant Python couvre le CONCEPT (evaluer + GridSearchCV + metrics r2/MAE/MSE) mais n'egale pas l'exhaustivite du C# (AutoML ML.NET absent cote Python, feature engineering detaille reduit)."
     - "parity_level = surface : meme theme (evaluation de modeles + recherche d'hyperparametres) mais le Python est une SELECTION, pas une parite cellule-par-cellule. A noter pour toute re-audit : combler l'ecart exigerait d'etendre le Python (multi-cycle, cf memo #4956)."
+    - "Re-audit 2026-07-24 (c.836) : C# a evolue via #8180 (correction arrondi CV mean MAE 1,36 -> 1,35, audit claims #8052) ; Python inchange (9e37f461). Parite surface preservee (theme partage evaluation + hyperparametres, Python reste une selection non cellule-par-cellule -- l'arrondi MAE corrige est cote C# uniquement)."
 
 - name: "ML-5 TimeSeries"
   family: ML.NET/Python


### PR DESCRIPTION
Grain: MED/tooling-twin-parity-reaudit — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-dotnet-pedagogy

## Contexte

Cette PR est **rescopée de `c.837`** (originellement « Z3-Python-06 + ML-4 ») en **ML-4 uniquement**, pour lever le conflit de coordination `#8246 ⟷ #8250` sur l'entrée Z3-06 du registre twin-parity — bloqueur identifié par po-2023 dans l'issue **#8264** (twin-registry fleet drift, gate cassée).

**Pourquoi dropper le bloc Z3-06** : la PR **#8250** (po-2026) porte **réellement** le capstone Prong-B budget 100→80 dans le jumeau **C#** de Z3-06 (vérifié firsthand : `gh pr diff 8250` montre le code `long budgetTotal = 80` + les outputs ré-exécutés `Budget total disponible : 80`, allocation non-uniforme, `cout des violations : 6`, et l'interprétation Prong-B). #8250 **résout l'asymétrie pour de vrai** (les deux jumeaux alignés à budget=80), alors que le bloc Z3-06 initial de #8246 se contentait de la **documenter comme légitime** (« C# légitiment inchangé »). Recommandation po-2023 (simulation de merge #8267→#8250→#8255→ML-4 → GREEN) : **#8250 gagne, #8246 droppe Z3-06, conserve ML-4**.

En droppant Z3-06, **#8250 possède désormais seule l'entrée Z3-06** du registre (elle y rebaseline `python_sha`→`dc0421dd7` + `csharp_sha`→`39a44f58` + `by: po-2026`). **Aucun conflit** entre #8246 et #8250 sur l'entrée Z3-06 — les deux PR peuvent merger proprement dans la cascade.

## Changement

`scripts/notebook_tools/twin_pairs.yaml` — **entrée ML-4 uniquement** (+3/−2) :

- `date` : 2026-07-23 → 2026-07-24
- `csharp_sha` : `cfee38be` → `ad3adf67` (blob C# post-#8180 sur `origin/main`, vérifié `git ls-tree`)
- `python_sha` : `9e37f461` (inchangé, Python non touché par #8180)
- +1 ligne `known_differences` : documente que #8180 a corrigé l'arrondi CV mean MAE (1,36→1,35) côté C# uniquement, parité `surface` préservée.

Le bloc Z3-06 est **byte-identique à `origin/main`** (vérifié `diff` : aucune ligne Z3-06 modifiée).

## Vérification

- `python scripts/notebook_tools/check_twin_parity.py --check` : **ML-4 passe DRIFT→[OK]**. Total 39 paires, OK=24 DRIFT=15 (les 15 DRIFT résiduelles = Probas/Z3 couvertes par #8267/#8250, hors scope).
- ML-4 `csharp_sha` `ad3adf67` = blob courant sur `origin/main` (`git ls-tree origin/main`), pas un sha stale.
- Diff **byte-surgical +3/−2, 1 fichier** : aucune autre entrée touchée.
- G.1 firsthand : #8250 diff lu en entier (port réel confirmé), ML-4 shas vérifiés contre `git ls-tree`.

## Finding résiduel (hors-scope, signalé à po-2025)

En auditant Z3-06 j'ai trouvé **firsthand** une **incohérence prose-vs-code** introduite par #8158 dans le jumeau **Python** : cell#21 (markdown intro) dit encore « budget de **100 unités** » alors que cell#22 (code) = `budget_total = 80` et cell#23 (interprétation) dit correctement « budget de 80 ». #8158 a mis à jour le code + cell#23 mais oublié cell#21. **Ne pas fixer ici** (Z3 = turf po-2025 + cela re-drifterait le `python_sha` que #8250 rebaseline) → signalé via issue dédiée + ce body.

See #8057 · See #8264
