### PR TITLE
fix(genai-texte,#8052): NB-4 cells 12+38 claims inverted vs committed outputs

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/4_Function_Calling.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/4_Function_Calling.ipynb
@@ -603,26 +603,21 @@
    "source": [
     "### Interprétation de la réponse\n",
     "\n",
-    "**Finish reason : `tool_calls`**\n",
+    "**Finish reason : `stop`**\n",
     "\n",
-    "Contrairement à un finish_reason `stop` (réponse textuelle normale), `tool_calls` indique que le modèle a décidé d'appeler une fonction.\n",
+    "Avec `tool_choice: \"auto\"`, le modèle **décide lui-même** d'appeler un outil ou non. Pour cette requête (« What's the weather forecast for tomorrow in NYC? »), il a choisi de **répondre directement** (`finish_reason: stop`) plutôt que d'appeler `get_weather` — il a jugé pouvoir formuler une réponse en langage naturel sans recourir à l'outil.\n",
     "\n",
-    "**Structure de tool_call :**\n",
+    "> **Leçon** : `tool_choice: \"auto\"` ne **garantit pas** un appel d'outil. Pour observer un véritable `tool_calls` (et la structure ci-dessous), on force l'appel avec `tool_choice: \"required\"`, ou l'on regarde le §4 (appels parallèles) où le modèle a effectivement déclenché plusieurs outils.\n",
+    "\n",
+    "**Structure d'un tool_call** (lorsque le modèle décide d'appeler un outil — exemple observé en §4) :\n",
     "\n",
     "| Champ | Valeur | Signification |\n",
     "|-------|--------|---------------|\n",
     "| `id` | `call_XXX` | Identifiant unique pour lier la réponse de l'outil |\n",
     "| `function.name` | `get_weather` | Fonction choisie par le modèle |\n",
-    "| `function.arguments` | `{\"location\": \"New York, NY\", \"unit\": \"fahrenheit\"}` | Arguments générés (JSON) |\n",
+    "| `function.arguments` | `{\"location\": \"...\", \"unit\": \"...\"}` | Arguments générés (JSON) |\n",
     "\n",
-    "**Le modèle a fait quoi exactement ?**\n",
-    "\n",
-    "1. Analysé la question : \"Quelle est la météo à New York aujourd'hui?\"\n",
-    "2. Reconnu qu'il a besoin de données en temps réel\n",
-    "3. Choisi la fonction `get_weather` (grâce à la description)\n",
-    "4. Extrait les arguments : `location=\"New York, NY\"`, `unit=\"fahrenheit\"`\n",
-    "\n",
-    "> **Important** : Le modèle ne **exécute PAS** la fonction. Il retourne uniquement les instructions. C'est à l'application de l'exécuter."
+    "> **Important** : le modèle n'**exécute pas** la fonction lui-même. Il retourne uniquement les instructions (nom + arguments) ; c'est l'application qui exécute la fonction et réinjecte le résultat.\n"
    ]
   },
   {
@@ -1957,7 +1952,7 @@
    "source": [
     "### Interprétation de l'orchestration\n",
     "\n",
-    "Le modèle a démontré une capacité clé des **agents autonomes** : décomposer une intention complexe en étapes atomiques.\n",
+    "Le modèle illustre un comportement caractéristique des **agents conversationnels** face à une intention complexe : il privilégie la proposition textuelle et la confirmation avant l'action.\n",
     "\n",
     "**Analyse du comportement :**\n",
     "- **Entrée** : \"Planifie ma journée demain - réveil à 7h, sport à 8h, travail à 9h\"\n",
@@ -1969,7 +1964,7 @@
     "- **Workflows complexes** : Orchestration automatique de tâches interdépendantes\n",
     "- **Interfaces conversationnelles** : Réduire le nombre d'interactions utilisateur\n",
     "\n",
-    "> **Pattern clé** : Le modèle transforme \"planifie ma journée\" en une séquence de 3 actions atomiques sans intervention humaine. C'est le cœur du paradigme **agentique**."
+    "> **Pattern clé** : face à une intention ouverte (« planifie ma journée »), le modèle a produit une **proposition textuelle** et **sollicité la confirmation** de l'utilisateur plutôt que d'exécuter des actions atomiques (la sortie `Étapes exécutées:` est vide) — comportement prudent typique avant une action à effet de bord (création de rappels). L'orchestration pleinement autonome (actions exécutées sans intervention) s'obtient en forçant les appels d'outils (`tool_choice: \"required\"`) ou en précisant l'intention."
    ]
   },
   {


### PR DESCRIPTION
fix(genai-texte,#8052): NB-4 cells 12+38 claims inverted vs committed outputs

Claims<->outputs audit (#8052) on GenAI/Texte. Notebook:
4_Function_Calling. Two confirmed defects (firsthand vs committed outputs):

1. cell[12] "Interpretation de la reponse" claimed finish_reason =
   `tool_calls` and described a tool_call in detail (get_weather chosen,
   args {"location":"New York, NY","unit":"fahrenheit"}, "le modele a
   decide d'appeler une fonction", 4-step reasoning). But the COMMITTED
   cell[11] output shows `Finish reason: stop` -- with tool_choice "auto"
   the model answered directly WITHOUT calling any tool. The entire
   interpretation was fabricated vs the output.

2. cell[38] closing "Pattern cle" claimed the model transformed the
   request into "une sequence de 3 actions atomiques sans intervention
   humaine" (intro echoed "decomposer en etapes atomiques"). But the
   COMMITTED cell[37] output shows "Etapes executees:" EMPTY (0 steps)
   and the model produced a text proposal requesting confirmation
   ("dites-moi si vous voulez que j'ajuste") -- WITH human solicitation,
   no atomic actions executed.

Fix: markdown-only (C.2 exception -- LLM tool-calling is non-deterministic,
re-exec produces a different result; keep committed outputs as source of
truth and align the markdown to them honestly).
- cell[12] rewritten to report the real `stop` result + auto-mode lesson
  (tool_choice "auto" does not guarantee a tool call) + forward-ref to the
  parallel-calls section (cell 20) which DID produce real tool_calls.
  Removed the fabricated args + 4-step list. Kept the tool_call structure
  table as reference (clearly marked "when the model does call a tool").
- cell[38] intro + closing reframed to match the empty-steps +
  confirmation-request output (prudent agent pattern before side-effect
  actions; fully-autonomous orchestration via tool_choice "required").

Validation: +9/-14, only cells 12+38 changed, 0 CRLF, catalog
byte-identical to main, H.3 validator 1/1 PASS (19 code cells),
0 NotImplementedError, cells 11+37 outputs/code untouched (Stop & Repair:
align markdown to outputs, never hand-edit outputs). Markdown-only -> no
re-exec needed (C.2 exception); outputs are SOTA-OK real OpenAI API.

See #8052 (partial).

Co-authored-by: myia-po-2024 <myia-po-2024@coursia.local>
