### PR TITLE
feat(audit,#8052): extract_claims_vs_outputs anti-bruit notebooks .NET (header nums + viz Python kernel .NET)

### DIFF
--- a/scripts/audit/extract_claims_vs_outputs.py
+++ b/scripts/audit/extract_claims_vs_outputs.py
@@ -74,12 +74,37 @@ SOTA_TOOLS = [
 ]
 
 
+# Fix A — anti-bruit (cf #8052 pilote C# c.848) : un nombre sur une ligne de header
+# markdown ("# Search-11", "## Étape 3", "### Section 10") est un numéro de
+# section/titre, pas un claim pédagogique. Sur les notebooks .NET (titres riches en
+# numéros de série/section), ce bruit explosait à 100+ "numeric_claim_not_in_outputs"
+# MAJOR qui masquaient les vrais findings. On ne coupe QUE les entiers nus (1-3 digits,
+# sans unité) sur headers — un claim à unité ("95%", "40×") sur un titre est préservé.
+HEADER_BARE_INT_RE = re.compile(r'^\d{1,3}$')
+
+
+def _on_header_line(cell_source: str, start: int) -> bool:
+    """True si le match débutant à `start` est sur une ligne markdown commençant par '#'."""
+    line_start = cell_source.rfind('\n', 0, start) + 1
+    return cell_source[line_start:].lstrip().startswith('#')
+
+
 def extract_markdown_claims(cell_source: str) -> dict:
     """Extrait les claims numériques/qualitatifs d'une cellule markdown."""
     claims = []
     for match in CLAIM_NUMERIC_RE.finditer(cell_source):
+        value = match.group(0).strip()
+        # Fix A : ignore les entiers nus (1-3 digits) sur les lignes de header markdown
+        # — numéros de section/titre ("# Search-11", "## Étape 3"), pas des claims.
+        # SAUF si l'entier est immédiatement suivi d'une unité dans le source ("%","×",
+        # "x","°") : "### Précision : 95%" est un vrai claim (le % échappe au \b du regex
+        # et n'est pas dans la valeur extraite, on le détecte donc via le char qui suit).
+        if HEADER_BARE_INT_RE.match(value) and _on_header_line(cell_source, match.start()):
+            trailing = cell_source[match.end():match.end() + 2]
+            if not re.match(r'^\s*[%×x°]', trailing):
+                continue
         claims.append({
-            'value': match.group(0).strip(),
+            'value': value,
             'span': match.span(),
         })
     has_verdict_header = bool(VERDICT_HEADER_RE.search(cell_source))
@@ -190,6 +215,29 @@ def audit_notebook(notebook_path: Path) -> dict:
     sota_tools_imports = set()
     sota_tools_mentioned = set()
 
+    # Fix B — anti-bruit (cf #8052 pilote C# c.848) : sur un notebook .NET Interactive,
+    # les outils de visualisation Python (matplotlib, seaborn, pyviz) ne sont PAS
+    # pertinents — un .ipynb C#/.NET utilise Plotly/XPlot. Le markdown cite souvent
+    # l'équivalent Python à titre pédagogique comparatif ("en Python on aurait utilisé
+    # matplotlib"), ce que le litmus 4 signalait à tort comme "SOTA mentionné non
+    # importé". On les exclut donc du litmus 4 sur kernel .NET.
+    DOTNET_PYTHON_VIZ = {'matplotlib', 'seaborn', 'pyviz'}
+    ks_name = (nb.get('metadata', {}) or {}).get('kernelspec', {}) or {}
+    ks_name = (ks_name.get('name', '') or '').lower()
+    is_dotnet = any(k in ks_name for k in ('.net', 'csharp', 'fsharp', 'polyglot'))
+    if not is_dotnet:
+        # Heuristique de secours : cellules code .NET Interactive (#r nuget / using
+        # Microsoft. / magic #!csharp). Évite un .ipynb mal étiqueté kernelspec.
+        for c in nb.cells:
+            if c.get('cell_type') != 'code':
+                continue
+            src = c.get('source', '')
+            if isinstance(src, list):
+                src = ''.join(src)
+            if re.search(r'#r\s+"[^"]*nuget|using\s+Microsoft\.|#!\s*(?:csharp|fsharp|pwsh)', src, re.IGNORECASE):
+                is_dotnet = True
+                break
+
     for idx, cell in enumerate(nb.cells):
         cell_type = cell.get('cell_type', '')
         source = cell.get('source', '')
@@ -260,6 +308,9 @@ def audit_notebook(notebook_path: Path) -> dict:
     # On déduplique au niveau canonique AVANT la soustraction (sinon 4 tokens internes
     # mappent au même nom affiché 'Infer.NET' et faussent le comptage).
     mentioned_canon = {canonical_name(t) for t in sota_tools_mentioned}
+    if is_dotnet:
+        # Fix B : viz Python non pertinente en .NET (cf commentaire en tête de fonction)
+        mentioned_canon -= DOTNET_PYTHON_VIZ
     imported_canon = {canonical_name(t) for t in sota_tools_imports}
     mentioned_not_imported_canon = mentioned_canon - imported_canon
     for tool_canon in mentioned_not_imported_canon:

--- a/scripts/audit/tests/test_extract_claims_vs_outputs.py
+++ b/scripts/audit/tests/test_extract_claims_vs_outputs.py
@@ -1,0 +1,155 @@
+"""Tests for scripts/audit/extract_claims_vs_outputs.py (#8052 sampling audit).
+
+Covers the two anti-noise fixes added in c.848 (pilote C#) :
+
+  - Fix A : un entier nu (1-3 digits, sans unité) sur une ligne de header markdown
+            ("# Search-11", "## Étape 3") n'est PAS un claim pédagogique — c'est un
+            numéro de section/titre. Sur les notebooks .NET (titres riches en numéros
+            de série), ce bruit explosait à 100+ ``numeric_claim_not_in_outputs`` MAJOR
+            qui masquaient les vrais findings.
+  - Fix B : sur un notebook .NET Interactive, les outils de visualisation Python
+            (matplotlib, seaborn, pyviz) ne sont pas pertinents — un .ipynb C#/.NET
+            utilise Plotly/XPlot. Le markdown cite l'équivalent Python à titre
+            comparatif ("en Python on aurait utilisé matplotlib"), ce que le litmus 4
+            signalait à tort comme "SOTA mentionné non importé".
+
+Le litmus anti-LIGHT du script reste : il EXTRACT, ne décide pas. Ces tests vérifient
+seulement que l'extraction ne produit plus ces deux classes de faux positifs, SANS
+régresser le comportement sur Python (Fix B doit rester inactif hors .NET).
+"""
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SCRIPT_PATH = HERE.parent / "extract_claims_vs_outputs.py"
+
+
+def _load_extract():
+    spec = importlib.util.spec_from_file_location("extract_claims_vs_outputs", SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _write_nb(path: Path, cells: list, kernel_name: str = ".net-csharp") -> Path:
+    """Écrit un mini-notebook nbformat 4.5 valide sur disque."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "cells": cells,
+                "metadata": {
+                    "kernelspec": {"name": kernel_name, "display_name": kernel_name},
+                },
+                "nbformat": 4,
+                "nbformat_minor": 5,
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _md(source: str) -> dict:
+    return {
+        "cell_type": "markdown",
+        "id": "md-" + str(abs(hash(source)) % 10**8),
+        "metadata": {},
+        "source": source,
+    }
+
+
+def _code(source: str, outputs: list | None = None) -> dict:
+    return {
+        "cell_type": "code",
+        "id": "code-" + str(abs(hash(source)) % 10**8),
+        "metadata": {},
+        "execution_count": 1,
+        "outputs": outputs or [],
+        "source": source,
+    }
+
+
+# === Fix A : header bare integer n'est pas un claim ===
+
+
+def test_fix_A_header_section_number_is_not_a_claim():
+    mod = _load_extract()
+    src = "# Search-11 : Métaheuristiques\n\n## Étape 3\n\nSur ce jeu, RMSE = **2,9** et écart **40×**."
+    claims = mod.extract_markdown_claims(src)["numeric_claims"]
+    values = [c["value"] for c in claims]
+    # Numéros de section/étape sur headers = coupés (bruit titre, pas claims)
+    assert "11" not in values, f"'11' (header section number) should be filtered, got {values}"
+    assert "3" not in values, f"'3' (header step number) should be filtered, got {values}"
+    # Claims du corps préservés
+    assert "2,9" in values, f"'2,9' (body claim) should be kept, got {values}"
+    assert "40" in values, f"'40' (body claim 40x) should be kept, got {values}"
+
+
+def test_fix_A_claim_with_unit_on_header_is_kept():
+    """Un claim qui porte une unité (% , ×) même sur un header doit être conservé.
+    Note : le % échappe au ``\\b`` final du regex (non-word→non-word avec le markdown
+    ``**``), donc la valeur extraite est ``95`` et non ``95%`` — Fix A détecte l'unité
+    via le caractère qui suit immédiatement le match dans le source."""
+    mod = _load_extract()
+    src = "### Résultat : précision **95%** sur le jeu de test"
+    values = [c["value"] for c in mod.extract_markdown_claims(src)["numeric_claims"]]
+    assert "95" in values, f"'95' (claim 95% on header) should be kept, got {values}"
+
+
+# === Fix B : viz Python exclue du litmus 4 sur kernel .NET ===
+
+
+def test_fix_B_dotnet_excludes_matplotlib_from_not_imported(tmp_path):
+    mod = _load_extract()
+    nb = _write_nb(
+        tmp_path / "dotnet.ipynb",
+        cells=[
+            _md("# Mini .NET\nEn Python on aurait utilisé **matplotlib** ; ici Plotly."),
+            _code('#r "nuget:Microsoft.ML,4.0.0"\nusing Microsoft.ML;'),
+        ],
+        kernel_name=".net-csharp",
+    )
+    res = mod.audit_notebook(nb)
+    assert "matplotlib" in res["sota_tools_mentioned"], "matplotlib should still be detected as mentioned"
+    assert "matplotlib" not in res["sota_tools_mentioned_not_imported"], (
+        f"Fix B: matplotlib must NOT be flagged not-imported on .NET kernel, got {res['sota_tools_mentioned_not_imported']}"
+    )
+
+
+def test_fix_B_dotnet_kernelless_detected_via_nuget_directive(tmp_path):
+    """Heuristique de secours : .NET détecté via #r nuget même si kernelspec est générique."""
+    mod = _load_extract()
+    nb = _write_nb(
+        tmp_path / "generic-kernel.ipynb",
+        cells=[
+            _md("# Mini\nComparaison avec **seaborn** (Python)."),
+            _code('#r "nuget:Microsoft.ML,4.0.0"\nusing Microsoft.ML;'),
+        ],
+        kernel_name="python3",  # kernelspec mal étiqueté
+    )
+    res = mod.audit_notebook(nb)
+    assert "seaborn" not in res["sota_tools_mentioned_not_imported"], (
+        "Fix B fallback: seaborn must be excluded when .NET detected via #r nuget directive"
+    )
+
+
+def test_fix_B_python_kernel_still_flags_unimported_viz(tmp_path):
+    """Contrôle : sur un vrai notebook Python, le litmus 4 DOIT continuer à signaler
+    matplotlib mentionné mais non importé (Fix B ne s'applique pas hors .NET)."""
+    mod = _load_extract()
+    nb = _write_nb(
+        tmp_path / "python.ipynb",
+        cells=[
+            _md("# Mini Python\nOn visualise avec **matplotlib**."),
+            _code("import numpy as np\nprint(np.array([1,2,3])"),
+        ],
+        kernel_name="python3",
+    )
+    res = mod.audit_notebook(nb)
+    assert "matplotlib" in res["sota_tools_mentioned_not_imported"], (
+        "Regression guard: on Python, matplotlib-mentioned-not-imported must still fire"
+    )


### PR DESCRIPTION
## Contexte

Pivot R6 c.848 (après 2 cycles code-correctness .NET CLEAN — Sudoku c.846 + ML.Net c.848 — et la veine citations Infer #8238/#8239/#8243) vers un grain **tooling** de l'EPIC **#4208** : améliorer l'extracteur sémantique `extract_claims_vs_outputs.py` (#8052, créé par #8068 pilote DecInfer Python).

## Finding firsthand (c.848)

En pilotant l'outil sur des notebooks **.NET Interactive C#**, j'ai découvert empiriquement un taux de faux positifs massif qui le rendait inutilisable cross-famille (son but déclaré #8052) :

- **Search-11-Metaheuristics-Csharp** : `103 numeric_claims_unmatched` MAJOR dont la majorité = numéros de section/titre extraits du markdown cell 0 (`"# Search-11"`, `"## Étape 3"`, `"### Section 10"`) → bruit de navigation, pas des claims pédagogiques.
- **Litmus 4 (SOTA invoqué)** : `matplotlib` signalé « mentionné non importé » alors que le notebook est C#/.NET — cité à titre comparatif pédagogique, le notebook utilise **Plotly/XPlot**.

## Fix (2 filtres ciblés, esprit « EXTRACT, ne décide pas » préservé)

| Fix | Changement | Raison |
|-----|-----------|--------|
| **A** | Entiers nus (1-3 digits, sans unité qui suit dans le source) sur **ligne de header markdown** ne sont plus extraits comme claims | Numéros de section/titre = bruit. Un claim à unité (`95%`, `40×`) sur header reste conservé (l'unité est détectée via le caractère qui suit, car le `%` échappe au `\b` final du regex). |
| **B** | Sur kernel **.NET Interactive** (`.net-*`/`polyglot` kernelspec, OU cellules `#r nuget` / `using Microsoft.` / magic `#!csharp`), les outils de viz Python (`matplotlib`, `seaborn`, `pyviz`) sont **exclus du litmus 4** | Non pertinents en .NET (notebook utilise Plotly/XPlot). Évite le FP du markdown comparatif. |

## Validation empirique (3 notebooks, re-run avant/après)

| Notebook | Avant | Après | Verdict |
|----------|-------|-------|---------|
| Search-11-Metaheuristics-**Csharp** | 103 unmatched, matplotlib not_imported | **92 unmatched** (−11 header noise), matplotlib **retiré** | Fix A+B effectifs |
| ML-3-Entrainement&AutoML (C#) | — | **84/103 matched** (confirme série CLEAN firsthand c.848), 0 nouveau finding artificiel | pas de régression |
| Sudoku-5-PSO-**Python** | — | matplotlib **correctement détecté IMPORTÉ** (litmus 4 inactif sur Python) | pas de régression cross-langage |

## Tests

`scripts/audit/tests/test_extract_claims_vs_outputs.py` — **5 cas pytest** (nouveaux, convention #7543) :
- `test_fix_A_header_section_number_is_not_a_claim` — `"# Search-11"` / `"## Étape 3"` coupés, claims corps (`2,9`, `40`) préservés.
- `test_fix_A_claim_with_unit_on_header_is_kept` — `95%` sur header conservé (anti faux-négatif).
- `test_fix_B_dotnet_excludes_matplotlib_from_not_imported` — matplotlib exclu du litmus 4 sur kernel `.net-csharp`.
- `test_fix_B_dotnet_kernelless_detected_via_nuget_directive` — heuristique fallback (`#r nuget` quand kernelspec générique).
- `test_fix_B_python_kernel_still_flags_unimported_viz` — **contrôle de régression** : sur Python, matplotlib-non-importé continue de remonter.

Sibling `test_check_denominators.py` inchangé (5/5) — pas de regression sur le reste de `scripts/audit/`.

## Portée

`+207/-1` sur 2 fichiers (1 script + 1 test). Aucun toucher au catalogue généré ni au générateur (`generate_catalog.py`) — aucun risque catalog-guard. Améliore l'acceptance **#8052 box 2** (grille de vérification claims↔outputs) et débloque l'audit C# fleet-wide (Search / Infer.NET / ML.Net — fammes différées du protocole `docs/audit/sampling-protocol.md`).

See #8052 (contribution partielle — l'epic reste ouverte).
