### PR TITLE
fix(z3-06-csharp,#3801,#8057): port Prong-B budget capstone 100->80 to C# twin

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb
@@ -1178,7 +1178,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Budget total disponible : 100\r\n"
+      "Budget total disponible : 80\r\n"
      ]
     },
     {
@@ -1206,7 +1206,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    Beta |     3 |    8 |    2 |     20 |      60\r\n"
+      "    Beta |     3 |    8 |    2 |      8 |      24\r\n"
      ]
     },
     {
@@ -1220,7 +1220,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "   Delta |     2 |   12 |    3 |     20 |      40\r\n"
+      "   Delta |     2 |   12 |    3 |     12 |      24\r\n"
      ]
     },
     {
@@ -1241,7 +1241,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "   TOTAL |       |      |      |    100 |     420\r\n"
+      "   TOTAL |       |      |      |     80 |     368\r\n"
      ]
     },
     {
@@ -1249,7 +1249,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Cout des violations souples : 0\r\n"
+      "Cout des violations souples : 6\r\n"
      ]
     },
     {
@@ -1271,7 +1271,7 @@
     "    (\"Delta\", 2, 12, 3),   // basse priorite\n",
     "    (\"Epsil\", 4,  6, 2),   // moyenne priorite\n",
     "};\n",
-    "long budgetTotal = 100;\n",
+    "long budgetTotal = 80;\n",
     "int nProjets = projets.Length;\n",
     "// Variables : allocation[i] = montant investi dans le projet i\n",
     "var alloc = new IntExpr[nProjets];\n",
@@ -1333,24 +1333,39 @@
    "id": "b138a368",
    "metadata": {},
    "source": [
-    "### Interpretation : allocation multi-objectif complete\n",
+    "### Interprétation : allocation multi-objectif complète\n",
     "\n",
-    "**Sortie obtenue** : Z3 produit une allocation qui respecte tous les minimums de financement (contraintes dures), minimise les violations de bonus prioritaire (contraintes souples), puis maximise la valeur totale. Avec 5 projets et un budget de 100, la solution minimisant les violations donne 20 unites a chaque projet (cout de violations nul).\n",
+    "**Sortie obtenue** : avec un budget de 80 (inférieur à la demande idéale de 5 x 20 = 100), Z3 ne peut pas satisfaire toutes les contraintes souples simultanément. Il produit une allocation **non uniforme** qui révèle les deux mécanismes distincts du capstone :\n",
     "\n",
-    "| Type de contrainte | Mécanisme Microsoft.Z3 | Effet sur la solution |\n",
-    "|--------------------|------------------------|----------------------|\n",
-    "| Budget total | `ctx.MkAdd(alloc) <= 100` | Contrainte dure absolue |\n",
-    "| Minimum par projet | `alloc[i] >= fin_min` | Chaque projet viable |\n",
-    "| Bonus priorite | `ctx.MkOr(alloc[i] >= 20, r)` + poids | Projets prioritaires favorises |\n",
-    "| Valeur totale | `opt.MkMaximize(valeur_totale)` | Optimisee en second lieu |\n",
+    "| Projet | Val/u | Min | Prio | Alloué | Valeur | Bonus prio ? |\n",
+    "|--------|-------|-----|------|--------|--------|--------------|\n",
+    "| Alpha | 5 | 10 | 1 | 20 | 100 | Oui |\n",
+    "| Beta | 3 | 8 | 2 | **8** | 24 | **Non** (ramené au min) |\n",
+    "| Gamma | 7 | 5 | 1 | 20 | 140 | Oui |\n",
+    "| Delta | 2 | 12 | 3 | **12** | 24 | **Non** (ramené au min) |\n",
+    "| Epsil | 4 | 6 | 2 | 20 | 80 | Oui |\n",
+    "| **TOTAL** | | | | **80** | **368** | cout = 6 |\n",
     "\n",
-    "**Points cles** :\n",
-    "1. Les contraintes dures garantissent la **faisabilite** (budget, minimums).\n",
-    "2. Les contraintes souples hierarchisent les **préférences** (favoriser les projets prioritaires).\n",
-    "3. L'objectif principal maximise la **valeur** une fois les préférences honorees.\n",
-    "4. L'ordre `MkMinimize` puis `MkMaximize` impose la lexicographie : les violations sont eliminees en priorite, puis la valeur est maximisee.\n",
+    "**Pourquoi cette instance est discriminante ?**\n",
     "\n",
-    "> **Note technique** : Ce cas pratique combine les trois techniques du notebook : relaxation booleenne (section 2/5), lexicographie (section 3) et contraintes dures (NB01). C'est le pattern typique des problemes d'allocation de ressources reels."
+    "1. **La hiérarchie des priorités est ACTIVE** : Z3 ne peut honorer qu'un sous-ensemble des bonus prioritaires. Il sacrifie en priorité le projet de **basse priorité Delta (poids 1)**, le ramenant à son minimum 12, puis **Beta (poids 5)** à son minimum 8. Les projets haute priorité (Alpha, Gamma prio 1 + Epsil prio 2 tenu) restent à 20. Le cout total des violations = 5 (Beta) + 1 (Delta) = **6** -- exactement l'ordre imposé par la pondération. Si le budget avait permis 100, toutes les contraintes souples seraient satisfaites (cout = 0) et la hiérarchie n'aurait eu **aucun effet visible**.\n",
+    "\n",
+    "2. **La maximisation de valeur est ACTIVE** : une fois le cout des violations minimisé, Z3 répartit le budget résiduel vers les projets les plus rentables. Gamma (valeur 7) est porté à son plafond pertinent, et le budget économisé sur Delta (valeur 2, le moins rentable) est conservé pour les projets à plus forte valeur. Avec budget=100, l'allocation était forcée à (20,20,20,20,20) et la valeur 420 était identique à celle d'une répartition uniforme triviale -- l'objectif de valeur n'aurait rien pu discriminer.\n",
+    "\n",
+    "| Type de contrainte | Mécanisme Z3 (.NET) | Effet sur la solution (budget=80) |\n",
+    "|--------------------|---------------------|-----------------------------------|\n",
+    "| Budget total | `ctx.MkLe(ctx.MkAdd(alloc), ctx.MkInt(80))` | Contrainte dure absolue |\n",
+    "| Minimum par projet | `ctx.MkGe(alloc[i], ctx.MkInt(finMin))` | Chaque projet viable (Beta=8, Delta=12 à leur minimum) |\n",
+    "| Bonus priorité | `ctx.MkOr(ctx.MkGe(alloc[i], 20), r)` + poids | Hiérarchie ACTIVE : Delta (poids 1) puis Beta (poids 5) sacrifiés |\n",
+    "| Valeur totale | `optB.MkMaximize(valeurTotale)` | Optimisée APRÈS cout minimisé : budget vers projets rentables |\n",
+    "\n",
+    "**Points clés** :\n",
+    "1. Les contraintes dures garantissent la **faisabilité** (budget, minimums).\n",
+    "2. Les contraintes souples hiérarchisent les **préférences** -- mais ne sont visibles **que si le budget est contraint** (ici 80 < 100). Sur un budget généreux, toutes les préférences sont honorées (cout = 0) et la hiérarchie devient invisible.\n",
+    "3. L'objectif principal maximise la **valeur** une fois les préférences honorées au mieux -- ici aussi, ne discrimine que parce que l'instance force un arbitrage.\n",
+    "4. L'ordre `optB.MkMinimize(coutViolations)` puis `optB.MkMaximize(valeurTotale)` impose la lexicographie : éliminer les violations d'abord (Delta puis Beta), puis maximiser la valeur sur l'espace restant.\n",
+    "\n",
+    "> **Leçon Prong-B** : un problème d'allocation ne met en valeur l'optimisation multi-objectif que si la demande dépasse la ressource. Avec budget=100 = somme exacte des seuils souples, le solveur n'avait aucun arbitrage à faire -- il suffisait de donner 20 à chacun. La réduction à budget=80 force l'arbitrage et rend les deux objectifs (hiérarchie + valeur) observables. C'est le cas dégénéré qui rend l'exemple pédagogiquement instructif."
    ]
   },
   {

--- a/scripts/notebook_tools/twin_pairs.yaml
+++ b/scripts/notebook_tools/twin_pairs.yaml
@@ -96,13 +96,14 @@
   csharp: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-23"
-    by: po-2024
-    python_sha: bebd658f4b477751460733c1bc8ce635acd348a0
-    csharp_sha: b090ec4eeb0a2cc1d75facafed5113eb24e6393e
+    date: "2026-07-24"
+    by: po-2026
+    python_sha: dc0421dd7de4bc4dd61181a44c5704a30206f879
+    csharp_sha: 39a44f588e5a0da9fd8983b7fca62b0f1196c16a
   known_differences:
     - "Python : pyz3 (Optimize, maximize/minimize, assert_soft pour MaxSAT, front de Pareto). C# : Microsoft.Z3 .NET (ctx.MkOptimize, MkMaximize, MkAssertSoft)."
     - "Concept demontre (objectifs hierarchiques, MaxSAT, front de Pareto) verifie cote Python (structure CLEAN c.20)."
+    - "2026-07-24 (po-2026) : Prong-B (#3801) porte au twin C# -- capstone budget 100->80 (cas non-degenere). Avant : C# restait a budget=100 (cas degenere, valeur=420, cout=0) tandis que Python etait passe a 80 (#8158). Apres port : les deux jumeaux alignes a budget=80 (valeur=368, cout=6), l'arbitrage multi-objectif (hierarchie + valeur) visible des deux cotes. DRIFT resorbe."
 
 # --- Tranche 2 (c.802, po-2024, 2026-07-23) : extensions Search/Part2-CSP (CSP-1..4) + Search/Part1-Foundations (Search-1..3) ---
 # Meme mecanisme (registre curated YAML + check_twin_parity.py), substance


### PR DESCRIPTION
## Contexte — drift détecté par `check_twin_parity.py`

Le twin C# de Z3-Python-06 (Advanced Optimization) avait dérivé de son jumeau Python :

- **Python** a reçu le Prong-B (#3801) dans #8158 : le capstone d'allocation de budget est passé de `budget=100` à `budget=80`. Raison : à budget=100 (= somme exacte des seuils souples 5×20), le solveur n'a **aucun arbitrage** — il donne 20 à chaque projet (valeur=420, cout=0), cas **dégénéré** où l'optimisation multi-objectif lexicographique est pédagogiquement invisible.
- **C#** est resté à `budgetTotal = 100` (cas dégénéré) tandis que Python était passé à 80.

`check_twin_parity.py` flagait cela comme **[DRIFT] Z3-Python-06 (semantic)** : la parité sémantique entre jumeaux était rompue.

## Fix — port du Prong-B vers le twin C#

- `budgetTotal` 100 → 80 (cell 22)
- **Re-exécuté sur kernel `.net-csharp`** (`exec_dotnet_persist.py`, 10 cellules, 0 erreurs) : le C# produit maintenant le même résultat non-dégénéré que Python — `valeur=368`, `cout=6` (sacrifie Delta poids 1 puis Beta poids 5).
- Cell 23 (interprétation) réécrite pour documenter le comportement non-dégénéré (les deux objectifs hiérarchie + valeur ACTIFS), miroir de la cell 23 Python, avec l'API Microsoft.Z3 (`MkLe`, `MkOr`, `MkMaximize`).

Les deux jumeaux sont maintenant alignés à budget=80 → **parité restaurée, DRIFT résorbé** (`check_twin_parity.py --family SMT/Z3-API` : OK=6 DRIFT=0).

## Preuves vérifiables

- Re-exec : `exec_dotnet_persist.py`, 10 cells, 0 errors. Cell 22 output : `Budget total disponible : 80` / `TOTAL 80 | 368` / `Cout des violations souples : 6`.
- Banner probe-addresses filtré (est allé dans cell 1, restaurée byte-identique depuis origin/main). Aucun leak chemin machine dans cell 22.
- Diff chirurgical : cell 22 (source 1 ligne + output table) + cell 23 (markdown) + registre (entrée Z3-06 : SHAs + note audit). **35 ins / 20 del sur le notebook, 9 lignes sur le registre.**
- `check_twin_parity.py` : Z3-Python-06 passe de [DRIFT] à [OK].
- H.3 : `execution_count=9`, 13 outputs, zéro `raise NotImplementedError`/`assert False`/`1/0`.

## Registre de parité (#8057)

Mise à jour de l'entrée `Z3-Python-06` dans `scripts/notebook_tools/twin_pairs.yaml` : `python_sha` et `csharp_sha` rebaselined sur les blobs courants, note d'audit documentant le port du Prong-B.

See #8057 (twin parity register). See #3801 (Prong-B problem-richness). See #8158 (Python-side Prong-B port).

---
*Livré par po-2026 (worker cron). Auto-alimentation pool-global après finding négatif sur #8052 (Sudoku/CaseStudies audités clean).*
