### PR TITLE
fix(csp,#3801): seed OR-Tools + sort set-domain in CSP-3 for reproducible outputs (c.839)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-3-Advanced.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-3-Advanced.ipynb
@@ -369,10 +369,10 @@
    "id": "cumulative-demo",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T22:38:20.938530Z",
-     "iopub.status.busy": "2026-06-08T22:38:20.938184Z",
-     "iopub.status.idle": "2026-06-08T22:38:20.994173Z",
-     "shell.execute_reply": "2026-06-08T22:38:20.992156Z"
+     "iopub.execute_input": "2026-07-24T02:35:00.824523Z",
+     "iopub.status.busy": "2026-07-24T02:35:00.824305Z",
+     "iopub.status.idle": "2026-07-24T02:35:00.839312Z",
+     "shell.execute_reply": "2026-07-24T02:35:00.838560Z"
     },
     "papermill": {
      "duration": 0.068752,
@@ -443,6 +443,8 @@
     "    \n",
     "    # Resolution\n",
     "    solver = cp_model.CpSolver()\n",
+    "    solver.parameters.random_seed = 42\n",
+    "    solver.parameters.num_search_workers = 1\n",
     "    status = solver.solve(model)\n",
     "    \n",
     "    print(\"Ordonnancement de 4 taches sur 2 machines\")\n",
@@ -642,10 +644,10 @@
    "id": "circuit-demo",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T22:38:21.641540Z",
-     "iopub.status.busy": "2026-06-08T22:38:21.641028Z",
-     "iopub.status.idle": "2026-06-08T22:38:21.663083Z",
-     "shell.execute_reply": "2026-06-08T22:38:21.661237Z"
+     "iopub.execute_input": "2026-07-24T02:35:01.041110Z",
+     "iopub.status.busy": "2026-07-24T02:35:01.040919Z",
+     "iopub.status.idle": "2026-07-24T02:35:01.053613Z",
+     "shell.execute_reply": "2026-07-24T02:35:01.052895Z"
     },
     "papermill": {
      "duration": 0.036637,
@@ -665,15 +667,15 @@
       "==================================================\n",
       "Statut : OPTIMAL\n",
       "\n",
-      "Tour optimal : Paris -> Lille -> Bordeaux -> Marseille -> Lyon -> Paris\n",
+      "Tour optimal : Paris -> Bordeaux -> Marseille -> Lyon -> Lille -> Paris\n",
       "Distance totale : 2460 km\n",
       "\n",
       "Successeurs (next[i]) :\n",
-      "       Paris -> Lille\n",
-      "        Lyon -> Paris\n",
+      "       Paris -> Bordeaux\n",
+      "        Lyon -> Lille\n",
       "   Marseille -> Lyon\n",
       "    Bordeaux -> Marseille\n",
-      "       Lille -> Bordeaux\n"
+      "       Lille -> Paris\n"
      ]
     }
    ],
@@ -718,6 +720,8 @@
     "    model.minimize(sum(arcs[k][2] * distances[arcs[k][0]][arcs[k][1]] for k in range(len(arcs))))\n",
     "\n",
     "    solver = cp_model.CpSolver()\n",
+    "    solver.parameters.random_seed = 42\n",
+    "    solver.parameters.num_search_workers = 1\n",
     "    status = solver.solve(model)\n",
     "\n",
     "    print('Contrainte Circuit : TSP a 5 villes (OR-Tools)')\n",
@@ -1585,10 +1589,10 @@
    "id": "lppmj6rfz8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T22:38:57.174084Z",
-     "iopub.status.busy": "2026-06-08T22:38:57.173406Z",
-     "iopub.status.idle": "2026-06-08T22:38:57.196262Z",
-     "shell.execute_reply": "2026-06-08T22:38:57.194150Z"
+     "iopub.execute_input": "2026-07-24T02:35:15.197201Z",
+     "iopub.status.busy": "2026-07-24T02:35:15.196980Z",
+     "iopub.status.idle": "2026-07-24T02:35:15.205437Z",
+     "shell.execute_reply": "2026-07-24T02:35:15.204682Z"
     },
     "papermill": {
      "duration": 0.041838,
@@ -1608,16 +1612,16 @@
       "Probleme : Choisir les participants a une reunion\n",
       "\n",
       "Variable : participants_reunion\n",
-      "Elements possibles : {'Bob', 'Charlie', 'Alice', 'Diana'}\n",
+      "Elements possibles : ['Alice', 'Bob', 'Charlie', 'Diana']\n",
       "Taille : [2, 3]\n",
       "\n",
       "Domaine (10 ensembles possibles) :\n",
-      "  1. {'Bob', 'Charlie'}\n",
-      "  2. {'Bob', 'Alice'}\n",
-      "  3. {'Bob', 'Diana'}\n",
-      "  4. {'Charlie', 'Alice'}\n",
-      "  5. {'Charlie', 'Diana'}\n",
-      "  6. {'Alice', 'Diana'}\n",
+      "  1. ['Alice', 'Bob']\n",
+      "  2. ['Alice', 'Charlie']\n",
+      "  3. ['Alice', 'Diana']\n",
+      "  4. ['Bob', 'Charlie']\n",
+      "  5. ['Bob', 'Diana']\n",
+      "  6. ['Charlie', 'Diana']\n",
       "  ... et 4 autres\n",
       "\n",
       "Contraintes typiques sur les Set Variables :\n",
@@ -1650,7 +1654,7 @@
     "        \"\"\"Genere le domaine (tous les ensembles possibles).\"\"\"\n",
     "        from itertools import combinations\n",
     "        \n",
-    "        elements = list(self.possible_elements)\n",
+    "        elements = sorted(self.possible_elements)  # trie pour domaine deterministe\n",
     "        domain = []\n",
     "        \n",
     "        max_s = self.max_size if self.max_size is not None else len(elements)\n",
@@ -1687,14 +1691,14 @@
     ")\n",
     "\n",
     "print(f\"Variable : {reunion.name}\")\n",
-    "print(f\"Elements possibles : {participants}\")\n",
+    "print(f\"Elements possibles : {sorted(participants)}\")\n",
     "print(f\"Taille : [{reunion.min_size}, {reunion.max_size}]\")\n",
     "\n",
     "# Domaine\n",
     "domain = reunion.get_domain()\n",
     "print(f\"\\nDomaine ({len(domain)} ensembles possibles) :\")\n",
     "for i, s in enumerate(domain[:6]):  # Afficher les 6 premiers\n",
-    "    print(f\"  {i+1}. {set(s)}\")\n",
+    "    print(f\"  {i+1}. {sorted(s)}\")\n",
     "if len(domain) > 6:\n",
     "    print(f\"  ... et {len(domain)-6} autres\")\n",
     "\n",


### PR DESCRIPTION
## Contexte

Reproducibility defect trouvé **firsthand** (diff d'exécution de CSP-3) pendant la phase SOTA/reproductibilité : les outputs commités de `CSP-3-Advanced.ipynb` n'étaient **pas reproductibles** entre runs.

## Changement

`CSP-3-Advanced.ipynb` — scope limité aux cells où le **résultat** (pas le timing) est l'output étudiant :

- **cells 8, 14 (schedule, TSP)** : ajout `solver.parameters.random_seed = 42` + `num_search_workers = 1` après chaque `cp_model.CpSolver()`. Les 7 instances `CpSolver()` du notebook n'avaient **pas** de seed → tie-breaking OR-Tools non-déterministe : le tour TSP cell 14 variait entre tours également optimaux (`Paris→Bordeaux→Marseille→Lyon→Lille` vs `Paris→Lille→Bordeaux→Marseille→Lyon`, tous 2460 km) d'un run à l'autre. Le pattern seed est déjà correct en cell 39 (référence) — cette PR le propage aux cells result.
- **cell 32 (Set variables)** : `{participants}` → `{sorted(participants)}`, `{set(s)}` → `{sorted(s)}`, et `get_domain()` `list(self.possible_elements)` → `sorted(self.possible_elements)`. L'itération de `set`→`list` en Python est non-déterministe → l'énumération du domaine variait entre runs.

**Cells benchmark (17/21/35/37/45) intentionnellement NON seedées** : leur output = timing (inherently non-déterministe, varie avec la charge machine indépendamment du seed) → seeder n'apporte aucun bénéfice de reproductibilité et ajouterait du churn.

## Vérification

```
# determinism : 2 runs nbconvert end-to-end, outputs byte-identiques
$ jupyter nbconvert --execute CSP-3-Advanced.ipynb --output r1.ipynb   # x2
  cell14 TSP tour stable across 2 fresh runs: True
    → Paris -> Bordeaux -> Marseille -> Lyon -> Lille -> Paris (2460 km)
  cell32 set-domain stable across 2 fresh runs: True
    → ['Alice','Bob'], ['Alice','Charlie'], ['Alice','Diana'], ... (alphabétique)

# C.1 : 0 erreurs volontaires
$ grep -nE 'raise NotImplementedError|assert False|1/0' CSP-3-Advanced.ipynb
  (vide)

# C.2 : 20/20 code cells execution_count!=null + outputs
$ python -c "... code cells: 20, sans execution_count: 0 OK"

# LF-only
$ grep -c $'\r' CSP-3-Advanced.ipynb   → 0
```

- **Diff byte-surgical +31/-27, 1 fichier** : lignes source seed/sorted + outputs des 3 cells affectées (8, 14, 32) uniquement. **Pas de churn timestamp nbconvert** sur les 17 autres cells (préservées byte-identiques à `origin/main` via remplacement chirurgical outputs-only).

## Résiduel

- Les 5 cells benchmark (17/21/35/37/45) restent non-seedées par design (aucun bénéfice reproductibilité sur du timing).
- Les autres notebooks Search/Part2-CSP (CSP-1, CSP-2, CSP-4…) n'ont pas été audités pour le même défaut de seed — sous-grain futur si reproductibilité Search-wide visée.

See #3801 (axis-2 SOTA doctrine : utiliser le vrai outil OR-Tools proprement, y compris le mode seeded déterministe pour des outputs commités reproductibles).