### PR TITLE
fix(csp,#8052): CSP-2 AC-3 solver claim contradicts committed output (0 revisions, not B forced to 1)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-2-Consistency-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-2-Consistency-Csharp.ipynb
@@ -1339,7 +1339,7 @@
    "source": [
     "### AC-3 peut-il resoudre un CSP seul ?\n",
     "\n",
-    "Sur des problemes ou la consistance d arc suffit a determiner les domaines, AC-3 peut resoudre le CSP sans backtracking. Testons sur un chemin lineaire A-B-C avec 2 couleurs :"
+    "Sur les problemes ou la consistance d arc suffit a determiner les domaines, AC-3 peut en principe resoudre le CSP sans backtracking. Verifions si c est le cas sur un chemin lineaire A-B-C avec 2 couleurs (A != B, B != C) :"
    ]
   },
   {
@@ -1430,9 +1430,9 @@
    "id": "3637dc02",
    "metadata": {},
    "source": [
-    "### Interpretation : AC-3 comme solveur\n",
+    "### Interpretation : AC-3 ne resout pas ce chemin seul\n",
     "\n",
-    "**Sortie obtenue** : sur ce chemin lineaire, AC-3 suffit a resoudre le CSP : `B` se retrouve force a la valeur `1` (par AC-3 qui elague `{0, 1}` puis reaffecte), `A` et `C` gardent leur domaine. AC-3 est un **preprocesseur**, pas un solveur complet : il reduit les domaines mais ne fournit pas d assignation. Pour des problemes plus complexes (8-Reines), il faut **combiner** AC-3 avec une recherche (backtracking) -> c est le rôle du MAC."
+    "**Sortie obtenue** : AC-3 effectue **0 revisions** -- les domaines de `A`, `B` et `C` restent tous `[0, 1]`. Ce n est pas un bug : le chemin A-B-C a 2 couleurs est **deja arc-consistant** (chaque valeur possede un support chez ses voisins : `A=0` est soutenu par `B=1`, etc.), donc AC-3 ne peut rien elaguer. La consistance d arc ne suffit pas a determiner une solution unique ici -- deux colorations valides existent (`A=0, B=1, C=0` et `A=1, B=0, C=1`). AC-3 est bien un **preprocesseur**, pas un solveur complet : il reduit les domaines mais ne fournit pas d assignation. Pour des problemes plus complexes (8-Reines), il faut **combiner** AC-3 avec une recherche (backtracking) -> c est le rôle du MAC."
    ]
   },
   {


### PR DESCRIPTION
## Contexte

Cycle c.849 — **dogfooding de l'extracteur `extract_claims_vs_outputs.py`** (amélioré en #8249 c.848 pour les notebooks .NET). Après avoir *construit* l'outil, ce cycle l'*utilise* pour miner un vrai bug claim-vs-output .NET. Pivot R6 (genre audit-finding/code-correctness ≠ tooling c.848 ≠ citations c.847).

## Finding firsthand (class-1 #8052)

En pilotant l'extracteur sur la flotte .NET, CSP-2-Consistency-Csharp ressort avec une interprétation contredite par sa propre sortie committée.

**Cellule 27 (interprétation « AC-3 comme solveur »)** claimait :
> « sur ce chemin linéaire, AC-3 suffit à résoudre le CSP : `B` se retrouve forcé à la valeur `1` (par AC-3 qui élagage `{0, 1}` puis réaffecte), `A` et `C` gardent leur domaine. »

**Cellule 26 — sortie committée (`exec_count: 13`, 5 outputs)** montre l'exact contraire :
```
Chemin A-B-C (2 couleurs) apres AC-3 :
  A : [0, 1]
  B : [0, 1]      ← B garde SES DEUX valeurs, PAS forcé à 1
  C : [0, 1]
Revisions : 0     ← AC-3 n'a fait AUCUNE révision
```

Le chemin A-B-C à 2 couleurs (A≠B, B≠C) est **déjà arc-consistant** : chaque valeur possède un support chez ses voisins (`A=0` soutenu par `B=1`, etc.), donc AC-3 ne peut rien élaguer. De surcroît, la cellule 27 était **internement contradictoire** : elle affirmait « B forcé à 1 » puis concluait juste après « AC-3 est un préprocesseur, pas un solveur complet : il réduit les domaines mais ne fournit pas d'assignation ».

## Fix (markdown-only, exception C.2 — Stop & Repair)

La sortie committée est **correcte** (AC-3 fait légitimement 0 révisions sur un graphe déjà arc-consistant). C'est l'interprétation qui mentait. On aligne le markdown sur la sortie (jamais l'inverse — pas de hand-edit d'output) :

| Cellule | Changement |
|---------|-----------|
| **25** (intro) | La prémisse « AC-3 peut résoudre le CSP sans backtracking » passe d'**affirmation** à **question testée** (« Vérifions si c'est le cas… A≠B, B≠C ») |
| **27** (interprétation) | Renommée **« AC-3 ne résout pas ce chemin seul »**, réécrite pour décrire la sortie réelle (0 révisions, déjà arc-consistant, deux colorations valides possibles) **tout en préservant la leçon** (AC-3 = préprocesseur, besoin de recherche/backtracking pour 8-Reines, rôle du MAC) |

## Validation

- `validate_pr_notebooks.py` : **PASS** (23 code cells, `.net-csharp`).
- `+3/−3` sur **2 cellules markdown** (25+27), **23 code cells byte-identiques** (`exec_count` + `outputs` préservés, 0 output hand-édité).
- **Zéro churn** : remplacement raw-string ciblé (le serializer original de CSP-2 n'est PAS byte-stable sous `json.dumps(indent=1)`, donc json.dumps aurait churné d'autres cellules — remplacer les 3 chaînes source exactes préserve tout le reste).
- Bug trouvé EN UTILISANT l'outil #8249 que j'ai construit le cycle précédent → démontre sa valeur (l'extracteur a correctement flaggué cette cellule comme unmatched-elevé).

See #8052 (contribution partielle — 2e bug .NET claim-vs-output après Sudoku-5 #8244 ; l'epic reste ouverte).
