### PR TITLE
docs(hygiene,#7422): add docs/notebook-metadata/ slice to triage table (c.839)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -110,6 +110,18 @@ Guides pédagogiques et parcours d'apprentissage.
 | [curriculum/genai.md](curriculum/genai.md) | Parcours GenAI multimodale (Image, Audio, Vidéo, Texte) |
 | [curriculum/stage5_mamba_ssm.md](curriculum/stage5_mamba_ssm.md) | Note d'exploration Mamba/SSM pour le forecasting financier |
 
+## Métadonnées notebooks (docs/notebook-metadata/)
+
+Schémas canoniques de métadonnées par notebook : registre datasets (licence + checksum), matrice coût/ressource, et registre de revues éditoriales tierces. Consommés par `scripts/audit/check_*.py` et liés depuis `THIRD_PARTY_NOTICES.md`. Triage #7422 (c.839, po-2023 — slice `notebook-metadata/` non couverte par c.549/c.557/c.600/c.705/c.715/c.728n/c.728r/c.728s/c.734/c.728y+36/c.728y+37).
+
+| Fichier | Verdict | Raison |
+|---------|---------|--------|
+| [notebook-metadata/DATASET_REGISTRY.md](notebook-metadata/DATASET_REGISTRY.md) | **KEEP** | Registre canonique datasets (~25 fichiers, 9 familles) avec licence + checksum SHA256 — alimenté par `scripts/audit/check_dataset_registry.py --audit` ; lié depuis [THIRD_PARTY_NOTICES.md §0](../THIRD_PARTY_NOTICES.md) (séparation licences code vs datasets). Issue #8055 tranche 2 (V0 pilote c.795). 210 lignes |
+| [notebook-metadata/DATASET_CARD.md](notebook-metadata/DATASET_CARD.md) | **KEEP** | Template grade B-méthodologique pour dataset sensible (caractère synthétique + périmètre RGPD + procédure re-validation sur fork). Complète `DATASET_REGISTRY.md` avec une couche descriptive par dataset. Issue #8055 tranche 2. 154 lignes |
+| [notebook-metadata/cost-matrix.md](notebook-metadata/cost-matrix.md) | **KEEP** | Schéma `cost:` frontmatter portable (api_usd_est / cpu_min / gpu_min / vram_gb / qc_cloud_required) — pilote V0 c.794, issue #8056. Consommé par `scripts/audit/check_cost_metadata.py` ; intégration audit sémantique #8052. 375 lignes — référence opérationnelle majeure |
+| [notebook-metadata/EDITORIAL_REVIEW_CARD.md](notebook-metadata/EDITORIAL_REVIEW_CARD.md) | **KEEP** | Template canonique c.764 — copié/adapté par chaque reviewer pour ajouter une entrée à `editorial-review-registry.md`. 5 portées : typo / factual / pedagogie / substance / full (seules `factual`/`substance`/`full` permettent promotion `BETA → FINAL`, cf `docs/PARCOURS.md` §Axe 1). 93 lignes |
+| [notebook-metadata/editorial-review-registry.md](notebook-metadata/editorial-review-registry.md) | **KEEP** | Pilote fondateur c.764 (phase 2 issue #8051 critère #4) — registre whitelist YAML curé manuellement des revues éditoriales tierces. Sans signal `editorial_reviewed_by` non-null dans ce registre, `classify_editorial()` n'émet jamais `FINAL` (598 entrées historiques rétrogradées par défaut, design anti-auto-promotion). Consommé par `scripts/audit/check_editorial_review.py`. 179 lignes |
+
 ## Lecture transversale
 
 | Fichier | Description |


### PR DESCRIPTION
Grain: MED/docs-hygiene — lane myia-po-2023:CoursIA-2 — prev: MED/notebook-probas-citations

# c.839 — `docs/notebook-metadata/` slice dans la table de triage #7422

## Scope

Issue de fond : la table de triage `docs/README.md` (c.805 po-2024) inventorie **13 sections + racine** mais omet **5 fichiers** sous `docs/notebook-metadata/` qui sont des schémas canoniques de métadonnées notebooks consommés par `scripts/audit/check_*.py` et liés depuis `THIRD_PARTY_NOTICES.md`. Les 11+ cycles antérieurs (c.549/c.557/c.600/c.705/c.715/c.728n/c.728r/c.728s/c.734/c.728y+36/c.728y+37) ont couvert : racine, lean/, reference/, ict/, grothendieckian-lens.md, _archives/, genai/, archive/ racine, archive/curriculum-renumbering-phase1/, qc/, curriculum/ — **pas `notebook-metadata/`**.

Cette PR comble le gap en ajoutant une section `## Métadonnées notebooks (docs/notebook-metadata/)` dans `docs/README.md`, avec verdicts KEEP et preuves d'usage (inbound refs audit scripts + THIRD_PARTY_NOTICES).

## Changements

**Substance :** 1 fichier modifié, **+12/-0 lignes** (atomic, G.4 strict).

| Fichier | Verdict | Inbound refs (preuves) |
|---------|---------|------------------------|
| `docs/notebook-metadata/DATASET_REGISTRY.md` | **KEEP** | `scripts/audit/check_dataset_registry.py` ; `THIRD_PARTY_NOTICES.md` §0 (lien retour). Issue #8055 tranche 2 (V0 pilote c.795). 210 lignes |
| `docs/notebook-metadata/DATASET_CARD.md` | **KEEP** | Complète `DATASET_REGISTRY.md` (couche descriptive par dataset sensible — synthétique/RGPD/re-validation). Issue #8055 tranche 2. 154 lignes |
| `docs/notebook-metadata/cost-matrix.md` | **KEEP** | `scripts/audit/check_cost_metadata.py` ; intégration audit sémantique #8052. Issue #8056 (V0 pilote c.794). 375 lignes |
| `docs/notebook-metadata/EDITORIAL_REVIEW_CARD.md` | **KEEP** | Template canonique c.764 — copié/adapté par chaque reviewer pour ajouter une entrée à `editorial-review-registry.md`. 93 lignes |
| `docs/notebook-metadata/editorial-review-registry.md` | **KEEP** | Pilote fondateur c.764 (phase 2 issue #8051 critère #4) — registre whitelist YAML curé manuellement des revues éditoriales tierces. `scripts/audit/check_editorial_review.py`. 179 lignes |

## Verifications

- **Atomicité G.4** : `+12/-0` strict, 1 fichier, 1 sujet.
- **Liens internes valides** : 5 fichiers `docs/notebook-metadata/*.md` confirmés présents sur disque (`test -f`) ; `THIRD_PARTY_NOTICES.md` racine confirmé.
- **Catalogue untouched** : `COURSE_CATALOG.generated.json` / `.md` non touchés (catalog-pr-hygiene règle HARD 1).
- **Marqueurs `CATALOG-STATUS` inchangés** : aucun marqueur `<!-- CATALOG-STATUS:START -->...:END -->` dans `docs/README.md` (seul `index.qmd` racine les porte).
- **Hors scope strict** : pas de regen catalogue, pas de modification `index.md`/`index.qmd` racine (c.674 #7426 a déjà aligné), pas d'archivage (les 5 fichiers sont KEEP, pas ARCHIVE).
- **L954 pivot cross-famille** : 5ᵉ PR consécutive `notebook-probas-citations` atteinte à c.838 → pivot obligatoire vers genre MED/docs-hygiene pour ce cycle.

## Hors scope (pour mémoire)

- **`docs/PARCOURS.md`** : déjà KEEP racine (c.805 + revue c.674). Le référencer dans `docs/README.md` racine créerait une redondance ; PARCOURS est lié depuis `CLAUDE.md` racine + `.claude/rules/`, qui est la bonne chaîne d'autorité.
- **`docs/ledgers/`** : la table inventorie déjà [ledgers/3801-sota-axe2.md](ledgers/3801-sota-axe2.md) (c.728n a posé l'entrée). Aucun gap résiduel à combler côté ledgers dans cette PR.
- **Archivage** : les 5 fichiers sont **KEEP** (consommés par audit scripts) — pas d'archivage à programmer.

## Liens

- Issue epic : [#7422](https://github.com/jsboige/CoursIA/issues/7422) (table de triage `docs/`)
- Triages antérieurs cités : c.549 (po-2026 lean), c.557 (po-2026 small dirs), c.600 (po-2026 genai), c.705 (po-2023 qc+genai), c.715 (po-2026 lean), c.728n (po-2025 reference), c.728r (po-2025 ict+grothendieckian), c.728s (po-2025 _archives abort), c.734 (po-2025 curriculum), c.728y+36 (po-2025 archive racine), c.728y+37 (po-2025 archive curriculum-renumbering)
- Triage fondateur : `docs/README.md` (c.805 po-2024)
- Pivot post-c.838 : L954 plafond atteint (5ᵉ PR `notebook-probas-citations`) → pivot MED/docs-hygiene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
