### PR TITLE
docs(probas,#8081): PyMC-12 canonical citations (mirror Infer-12 twin #4956)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-12-Modeles-Hierarchiques.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-12-Modeles-Hierarchiques.ipynb
@@ -622,6 +622,28 @@
    "source": [
     "## Conclusion\n\nLes **modèles hiérarchiques** resolvent le dilemme pooling/no-pooling par un **prior de population partage**. PyMC les exprime naturellement : un vecteur de paramètres `theta[c]` tire d'une loi commune `(mu, sigma_theta)`, avec l'indexation `theta[group_index]` qui rattache chaque observation a sa classe.\n\nLa **retraction** (*shrinkage*) n'est pas un artefact -- c'est la consequence optimale du theoreme de Bayes sur des groupes inegalement informes. Elle auto-equilibre la confiance entre données locales et regroupement global, et l'ecart-type de population `sigma_theta` est **estime depuis les données** pour calibrer la force du regroupement (`tau` grand = classes semblables = retraction forte).\n\n### Ce que PyMC apporte au-dela de l'EP\n\nLe source Infer.NET infere par **Expectation Propagation** (analytique pour la famille gaussienne). PyMC utilise **NUTS**, qui expose deux diagnostics inaccessibles a EP :\n1. Les **divergences** -- revelatrices du *funnel de Neal* -- et leur remede, la **parametrisation non centree** (demontree ci-dessus).\n2. Les diagnostics de convergence `r_hat` / `ess` d'ArviZ, qui verifient que l'echantillonnage a explore tout le posterieur.\n\nSur ce modèle gaussien a 8 classes, EP et NUTS convergent vers le même posterieur ; sur des hiérarchies plus profondes ou non-gaussiennes, NUTS reste fiable la ou EP doit approximer.\n\n> **Jumeau de** [`Infer-12-Modèles-Hiérarchiques.ipynb`](../Infer/Infer-12-Modeles-Hierarchiques.ipynb) *(Infer.NET / C#, inférence EP)* -- Epic [#4956](https://github.com/jsboige/CoursIA/issues/4956)."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "references-pymc12-8081",
+   "metadata": {},
+   "source": [
+    "## Références\n",
+    "\n",
+    "Ce notebook est le **jumeau Python** (PyMC v5 / NUTS) de `Infer-12-Modèles-Hiérarchiques` (Infer.NET / EP, parité #4956). La théorie du pooling partiel et de la rétraction est **identique** ; les références canoniques sont reprises ci-dessous, augmentées des sources spécifiques à l'inférence par échantillonnage (NUTS, funnel, paramétrisation non-centrée).\n",
+    "\n",
+    "| Référence | Lien au notebook |\n",
+    "|-----------|-------------------|\n",
+    "| Gelman, Carlin, Stern, Dunson, Vehtari & Rubin, *Bayesian Data Analysis* (3rd ed., 2014), chap. 5 | Modèles hiérarchiques : structure, prior de population, shrinkage, exemple « 8 écoles » §5.5 |\n",
+    "| Rubin (1981), *J. Educ. Stat.* 6:377-401 | Estimation multi-niveaux — exemple fondateur des « 8 écoles » (rétraction des estimations par groupe clairsemé) |\n",
+    "| Efron & Morris (1975), *J. Am. Stat. Assoc.* 70:311-319, « Stein's Paradox in Statistics » | James-Stein shrinkage : pooling empirique bayésien |\n",
+    "| James & Stein (1961), *Proc. Berkeley Symp. Math. Stat. Prob.* | Estimateur James-Stein : origine théorique de la rétraction |\n",
+    "| Gelman (2006), *Technometrics* 48:241-255, « Prior distributions for variance parameters in hierarchical models » | Choix des priors sur σ, τ (half-Cauchy / half-Normal) |\n",
+    "| Hoffman & Gelman (2014), *JMLR* 15(47):1593-1623, « The No-U-Turn Sampler » | **NUTS** — l'échantillonneur Hamiltonien adaptatif utilisé par PyMC (§5, « NUTS au lieu de EP ») |\n",
+    "| Betancourt & Girolami (2013), arXiv:1312.0906, « Hamiltonian Monte Carlo for Hierarchical Models » | Pathologie du **funnel de Neal** et **paramétrisation non-centrée** qui la corrige (§10) |\n",
+    "\n",
+    "> **Note pédagogique** : l'exemple « 8 écoles » de Rubin (1981), repris dans BDA3 §5.5, est le test canonique du pooling partiel. La spécification probabiliste est ici **identique** au jumeau Infer.NET ; la différence est le moteur — EP analytique côté .NET, échantillonnage NUTS côté PyMC. Le **non-centrage** (§10) n'est nécessaire *que* pour l'échantillonnage : NUTS souffre du funnel sur les modèles centrés, là où l'EP d'Infer.NET est naturellement robuste.\n"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary

Audit fidélité **#8081** (axis: canonical citations). `PyMC-12-Modeles-Hierarchiques` is the explicit **Python twin** of `Infer-12-Modèles-Hiérarchiques` (md[0]: « jumeau Python de Infer-12... Parité #4956 »). It covers the **SAME** concepts (partial pooling, shrinkage, Neal's funnel, non-centered parameterization, posterior predictive) but **LACKED a References cell**, whereas Infer-12 has a rich one (md[18], added by po-2023 in #8230).

## Fix

Append a References cell at the end, **MIRRORING** Infer-12's 5 canonical entries (verified canon-verbatim) + **2 PyMC-specific refs** for the sampling-engine concepts this twin adds:

| # | Reference | Link to notebook |
|---|-----------|------------------|
| 1 | Gelman et al, *BDA3* (3rd ed., 2014), chap. 5 | Hierarchical models: population prior, shrinkage, 8-schools §5.5 |
| 2 | Rubin (1981), *J. Educ. Stat.* 6:377-401 | Multi-level estimation — founding « 8 schools » example |
| 3 | Efron & Morris (1975), *JASA* 70:311-319 | James-Stein shrinkage / Stein's paradox |
| 4 | James & Stein (1961), *Proc. Berkeley Symp.* | James-Stein estimator: theoretical origin of shrinkage |
| 5 | Gelman (2006), *Technometrics* 48:241-255 | Variance priors (σ, τ — half-Cauchy / half-Normal) |
| 6 | Hoffman & Gelman (2014), *JMLR* 15(47):1593-1623 | **NUTS** — PyMC's Hamiltonian sampler (md[5] « NUTS au lieu de EP ») |
| 7 | Betancourt & Girolami (2013), arXiv:1312.0906 | **Neal's funnel** pathology + **non-centered parameterization** (md[10]) |

Refs verified firsthand: Betancourt & Girolami via SearXNG (arXiv:1312.0906 confirmed); Hoffman & Gelman NUTS = textbook-canonical; Infer-12 entries mirrored verbatim from po-2023's canon-verified #8230.

A pedagogical note connects the **EP (Infer.NET) vs NUTS (PyMC)** engine difference and explains why the non-centered parameterization is only needed for sampling (NUTS suffers the funnel on centered models; EP is naturally robust).

## Validation

- **+22/-0**, only **1 new markdown cell appended** (md[23], `id=references-pymc12-8081`)
- **23 original cells byte-identical** (deep-compare, no churn)
- **0 CRLF**, LF-only, `json.dumps(indent=1, ensure_ascii=False) + "\n" == raw`
- **catalog byte-identical to main** (no catalog-regen on branch)
- **H.3 validator 1/1 PASS** (9 code cells), `0 NotImplementedError`
- **Markdown-only → no re-exec needed** (C.2 exception)
- **Genre**: canonical citations (#8081) ≠ claims↔outputs

See #8081 (partial, epic ouverte). Twin-parity alignment #4956 / #8057.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
