### PR TITLE
feat(search): add multi-seed PSO variance cell to Search-11 metaheuristics (c.840)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics-Csharp.ipynb
@@ -472,6 +472,162 @@
   },
   {
    "cell_type": "markdown",
+   "id": "multiseed-intro-c840",
+   "metadata": {},
+   "source": [
+    "### Variabilite stochastique — pourquoi un seul run ne suffit pas\n",
+    "\n",
+    "La cellule precedente trace la decroissance de `gbest` pour **un seul run** (seed 42) : la courbe est monotone, ce qui suggere une convergence \"propre\". C'est trompeur. PSO est **stochastique** : l'initialisation de l'essaim et les tirages aleatoires (`r1`, `r2`) changent a chaque execution. Sur Rastrigin (paysage **multimodal**, crible d'optima locaux), deux executions peuvent converger vers des bassins **differents** — l'une proche de l'optimum global (f->0), l'autre piegee dans un optimum local (f=5 a 30).\n",
+    "\n",
+    "La conclusion robuste n'est donc jamais \"PSO a trouve f=2.3\", mais \"PSO trouve f=2.3 **en moyenne sur N seeds**, avec un ecart-type de X\". C'est pourquoi toute etude serieuse de metaheuristique reporte **mean +/- std sur plusieurs seeds** — un standard en optimisation stochastique (et la convention multi-seed exige des notebooks ML/trading, cf. regle de revue section C).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "multiseed-pso-c840",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-24T03:22:54.344033Z",
+     "iopub.status.busy": "2026-07-24T03:22:54.343777Z",
+     "iopub.status.idle": "2026-07-24T03:22:54.484799Z",
+     "shell.execute_reply": "2026-07-24T03:22:54.484198Z"
+    }
+   },
+   "source": [
+    "// Multi-seed : 8 runs PSO independants sur Rastrigin (meme config que cellule 6).\n",
+    "// On releve la fitness finale de chaque seed pour reveler la variabilite cachee par un run unique.\n",
+    "int[] seedsMS = { 1, 2, 3, 4, 5, 6, 7, 8 };\n",
+    "var finals = new List<double>();\n",
+    "Console.WriteLine($\"PSO sur Rastrigin (dim=10, 200 epochs, 30 particules) - 8 seeds independants\");\n",
+    "Console.WriteLine($\"{\"Seed\",-6} {\"gbest final\",-14} {\"lecture\"}\");\n",
+    "Console.WriteLine(new string('-', 44));\n",
+    "foreach (int s in seedsMS)\n",
+    "{\n",
+    "    var p = new PSO(dim: 10, lb: -5.12, ub: 5.12, f: Rastrigin, popSize: 30, epochs: 200, seed: s);\n",
+    "    var (_, fit, _) = p.Solve();\n",
+    "    finals.Add(fit);\n",
+    "    string lecture = fit < 1.0 ? \"proche optimum global\" : (fit < 10.0 ? \"bassin secondaire\" : \"piege local\");\n",
+    "    Console.WriteLine($\"{s,-6} {fit,-14:F4} {lecture}\");\n",
+    "}\n",
+    "Console.WriteLine(new string('-', 44));\n",
+    "double mean = finals.Average();\n",
+    "double std = Math.Sqrt(finals.Average(v => (v - mean) * (v - mean)));\n",
+    "Console.WriteLine($\"Moyenne = {mean:F3}   Ecart-type = {std:F3}   [min {finals.Min():F3}, max {finals.Max():F3}]\");\n",
+    "Console.WriteLine($\"\\nL'ecart-type ({std:F2}) confirme la dispersion : un seul run (seed 42 ci-dessus)\");\n",
+    "Console.WriteLine(\"ne representative pas la distribution reelle des issues. D'ou l'obligation du multi-seed.\");\n"
+   ],
+   "execution_count": 5,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PSO sur Rastrigin (dim=10, 200 epochs, 30 particules) - 8 seeds independants\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Seed   gbest final    lecture\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--------------------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1      6,1629         bassin secondaire\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2      6,5554         bassin secondaire\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3      4,3139         bassin secondaire\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4      5,1778         bassin secondaire\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5      3,1368         bassin secondaire\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "6      7,9811         bassin secondaire\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "7      2,9884         bassin secondaire\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "8      5,2554         bassin secondaire\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--------------------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Moyenne = 5,196   Ecart-type = 1,598   [min 2,988, max 7,981]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "L'ecart-type (1,60) confirme la dispersion : un seul run (seed 42 ci-dessus)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ne representative pas la distribution reelle des issues. D'ou l'obligation du multi-seed.\r\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "a947499d",
    "metadata": {},
    "source": [


### PR DESCRIPTION
## Contexte

Gap pédagogique trouvé **firsthand** (lecture du notebook) : `Search-11-Metaheuristics-Csharp.ipynb` cell#8 "Convergence PSO" trace la décroissance de `gbest` pour **un seul run** (seed 42), avec un commentaire qui reconnaît le problème sans le traiter :

> `// Convergence : UN seul run PSO, on enregistre le gbest aux epochs [10,20,50,100,200].`

La courbe monotone d'un run unique **trompe** l'étudiant : elle suggère une convergence "propre" alors que PSO est **stochastique** et que Rastrigin est **multimodale** (criblé d'optima locaux). Sans multi-seed, l'étudiant ne voit pas que la convergence d'un run cache une **dispersion** des issues.

## Changement

Ajout de **2 cellules** après la cellule de convergence single-run (cell#8), avant la section SA :

1. **Markdown intro** — pose la question : pourquoi un seul run ne suffit pas (stochasticité de PSO + multimodalité de Rastrigin → bassins différents selon le seed ; une conclusion robuste est mean±std sur N seeds, standard en optimisation stochastique).
2. **Code multi-seed** — 8 runs PSO indépendants (seeds 1..8, même config que cell#6 : dim=10, Rastrigin, 200 epochs, 30 particules), relève la fitness finale de chaque seed + calcule moyenne/écart-type/min/max.

## Résultat pédagogique (output exécuté, dotnet-interactive)

```
PSO sur Rastrigin (dim=10, 200 epochs, 30 particules) - 8 seeds independants
Seed   gbest final    lecture
--------------------------------------------
1      6,1629         bassin secondaire
2      6,5554         bassin secondaire
3      4,3139         bassin secondaire
4      5,1778         bassin secondaire
5      3,1368         bassin secondaire
6      7,9811         bassin secondaire
7      2,9884         bassin secondaire
8      5,2554         bassin secondaire
--------------------------------------------
Moyenne = 5,196   Ecart-type = 1,598   [min 2,988, max 7,981]
```

**Punchline pédagogique forte** : sur 8 seeds, **aucun** ne trouve l'optimum global (f≈0) — tous restent piégés dans des bassins locaux (f=3 à 8). L'écart-type (1,60) confirme la dispersion. Ceci démontre concrètement pourquoi le single-run de la cellule précédente est trompeur et pourquoi toute étude de métaheuristique reporte mean±std multi-seed.

## Vérification

```
# exécution réelle end-to-end (kernel .net-csharp, dotnet-interactive 1.0.712001)
$ jupyter nbconvert --execute Search-11-Metaheuristics-Csharp.ipynb   # exit 0, 0 erreur

# C.1 : 0 erreur volontaire (NotImplementedException/throw new Exception/Debug.Fail)
# C.2 : toutes les cellules code execution_count != null + outputs cohérents
# LF-only : grep -c '\r' = 0
```

- **Diff byte-surgical +157/-1, 1 fichier** : les 2 nouvelles cellules (markdown + code + outputs) uniquement. Les 29 cellules existantes sont **byte-identiques** à `origin/main` (pas de churn timestamp nbconvert — copie chirurgicale de l'output de la seule cellule ajoutée, cf pattern C839-L).
- Utilise la classe `PSO` existante (cell#5) qui expose déjà un paramètre `seed` — pas de duplication de code, l'enrichissement s'appuie sur l'implémentation from-scratch du notebook.

## Résiduel

- La même analyse multi-seed pourrait enrichir SA (cell#11) et GA (cell#14) — sous-grain futur si la section mérite une généralisation "variance comparative PSO/SA/GA".
- Les notebooks jumeaux (Search-11 Python, et les variantes 11b-Deep) non touchés.

See #2161 (richesse pédagogique : approfondit l'analyse de convergence au-delà du single-run).