### PR TITLE
fix(csp,#8052,#8057): CSP-2-Csharp AC-3 path demo — pre-assign A=0 (proper fix, supersedes #8253)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-2-Consistency-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-2-Consistency-Csharp.ipynb
@@ -1366,28 +1366,28 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  A : [0, 1]\r\n"
+      "  A : [0]\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  B : [0, 1]\r\n"
+      "  B : [1]\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  C : [0, 1]\r\n"
+      "  C : [0]\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Revisions : 0\r\n"
+      "Revisions : 2\r\n"
      ]
     }
    ],
@@ -1399,6 +1399,9 @@
     "    [\"B\"] = new List<object> { 0, 1 },\n",
     "    [\"C\"] = new List<object> { 0, 1 }\n",
     "};\n",
+    "// Fixer A = 0 avant AC-3 (mirror Python twin CSP-2-Consistency.ipynb cell 23 : doms_small['A'] = ['R']).\n",
+    "// Sans cette assignation, le chemin A-B-C a 2 couleurs est deja arc-consistant -> AC-3 reduirait a 0 revision.\n",
+    "pathDomains[\"A\"] = new List<object> { 0 };\n",
     "BinaryConstraint diffBin = (vi, vj) => !vi.Equals(vj);\n",
     "var pathNeighbors = new Dictionary<string, List<string>>\n",
     "{\n",
@@ -1432,7 +1435,7 @@
    "source": [
     "### Interpretation : AC-3 comme solveur\n",
     "\n",
-    "**Sortie obtenue** : sur ce chemin lineaire, AC-3 suffit a resoudre le CSP : `B` se retrouve force a la valeur `1` (par AC-3 qui elague `{0, 1}` puis reaffecte), `A` et `C` gardent leur domaine. AC-3 est un **preprocesseur**, pas un solveur complet : il reduit les domaines mais ne fournit pas d assignation. Pour des problemes plus complexes (8-Reines), il faut **combiner** AC-3 avec une recherche (backtracking) -> c est le rôle du MAC."
+    "**Sortie obtenue** : sur ce chemin lineaire A-B-C (2 couleurs), apres avoir fixe `A = 0`, AC-3 resout completement le CSP : `B` est force a `1` (elagage de `0`) puis `C` est force a `0` (elagage de `1`). Les trois domaines deviennent des singletons -- AC-3 a trouve la solution sans backtracking.\n\n| Etape | Action | Domaines |\n|-------|--------|----------|\n| Initial | A = 0 | A:{0}, B:{0,1}, C:{0,1} |\n| REVISE(B,A) | 0 retire de B | A:{0}, B:{1}, C:{0,1} |\n| REVISE(C,B) | 1 retire de C | A:{0}, B:{1}, C:{0} |\n\n**Quand AC-3 suffit-il ?** AC-3 seul peut resoudre un CSP quand :\n1. Le graphe de contraintes est un **arbre** (pas de cycles)\n2. Les domaines sont suffisamment petits par rapport aux contraintes\n\n> **Theoreme** : pour un CSP dont le graphe de contraintes est un arbre, la consistance d'arc garantit la resolution en $O(ed^2)$. Pour les graphes avec cycles (ex: 8-Reines), il faut **combiner** AC-3 avec une recherche (backtracking) -> c est le role du MAC."
    ]
   },
   {

--- a/scripts/notebook_tools/twin_pairs.yaml
+++ b/scripts/notebook_tools/twin_pairs.yaml
@@ -136,10 +136,10 @@
   csharp: MyIA.AI.Notebooks/Search/Part2-CSP/CSP-2-Consistency-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-23"
-    by: po-2024
+    date: "2026-07-24"
+    by: po-2023
     python_sha: fe90bbf647b1e06931df4dad0b2c192d7b932d73
-    csharp_sha: 7c5456239e3145b8194519765fb19791644ca505
+    csharp_sha: 1d8c847d17346eb815ace3bbcbaefd19025ce9a9
   known_differences:
     - "Socle pedagogique commun : node consistency + AC-3 + Forward Checking + MAC, implementes from-scratch des deux cotes."
     - "Cote C# : extension Choco-solver 4.10.17 via IKVM 8.15.0 (memes recettes infrastructure que CSP-1) pour comparer les algorithmes custom avec la propagation native de Choco (variable x, contrainte arithmetique, model.getSolver().propagate())."


### PR DESCRIPTION
## What

`CSP-2-Consistency-Csharp.ipynb` cell 26 claimed **"AC-3 force `B` à la valeur `1`"** but the committed output showed `Revisions : 0` with `A,B,C` all `[0,1]` — the path A-B-C at 2 colors is already arc-consistent, so AC-3 prunes nothing. The claim-vs-output contradiction is a class-1 bug under EPIC #8052, surfaced by dogfooding `extract_claims_vs_outputs.py` (#8249).

## Root cause

The Python twin (`CSP-2-Consistency.ipynb` cell 23) **pre-assigns** `doms_small[A] = [R]` *before* running AC-3, so propagation cascades A={R}→B={V}→C={R} and all domains become singletons. The C# twin left `pathDomains["A"] = {0,1}` — without that pre-assignment AC-3 cannot propagate, and the cells teaching intent ("AC-3 solves a tree-CSP alone") is unreachable.

## Fix (proper, not markdown-only)

Mirror the Python twin: pre-assign `pathDomains["A"] = new List<object> { 0 };` before `AC3(pathCSP)`. Re-executed via the `.net-csharp` kernel (`nbconvert --execute --inplace`, 23 cells OK / 0 errors). New committed output:

```
Chemin A-B-C (2 couleurs) apres AC-3 :
  A : [0]
  B : [1]
  C : [0]
Revisions : 2
```

All three domains are singletons — **the original claim is now TRUE**. Cell 27 interpretation rewritten to match the real output and mirror the Python twin cell 24 (step table REVISE(B,A)/REVISE(C,B) + the $O(ed^2)$ tree-consistency theorem).

## Why this supersedes #8253

#8253 was a markdown-only honest rewrite ("AC-3 fait 0 révisions, déjà arc-consistant"). Honest, but it **broke twin parity** (#8057 FAIL) and surrendered the cells teaching point. This proper fix makes the claim true **and** restores twin parity (rebaselined `last_audit.csharp_sha` in `twin_pairs.yaml`; local `check_twin_parity.py --check` → CSP-2 **OK**).

## Validation
- `notebook_tools validate` → 0 errors.
- `.net-csharp` re-exec → 23/23 OK, 0 errors, 0 NotImplementedError.
- `check_twin_parity.py --check --family Search/Part2-CSP` → 4/4 OK.
- No probeAddresses banner (surgical edit, original had none).
- Diff: +11/−8 (2 files), surgical — no nbconvert churn.

See #8052 · See #8057

Supersedes #8253 (to be closed).

Co-Authored-By: Claude-Code <noreply@anthropic.com>