### PR TITLE
docs(gametheory,#3975): add 4 interpretation cells to GT-16-MechanismDesign-Csharp twin (c.841)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-16-MechanismDesign-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-16-MechanismDesign-Csharp.ipynb
@@ -299,6 +299,21 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-gt16-c4-c841",
+   "metadata": {},
+   "source": [
+    "### Lecture des resultats : pourquoi le premier-prix laisse zero surplus\n",
+    "\n",
+    "La sortie oppose les deux encheres sur la meme instance (valeurs 10, 8, 6, 4) :\n",
+    "\n",
+    "- **Premier-prix** : le gagnant (enchérisseur 0, valeur 10) paie sa propre enchere (10). Son utilite vaut donc `10 - 10 = 0`. C'est le **winner's curse** — remporter l'objet au prix exact de sa valeur ne laisse aucun gain. La colonne `sincerity: NON` confirme qu'un joueur a interet a sous-encherir (offrir moins que sa valeur vraie) pour degager un surplus : le premier-prix n'est **pas sincere** (pas strategy-proof).\n",
+    "- **Vickrey (second-prix)** : le meme gagnant paie la **deuxieme meilleure enchere** (8), soit `10 - 8 = 2` d'utilite. declarer sa valeur vraie `r = v` est ici une strategie **dominante** (la cellule suivante le demontre empiriquement) : Vickrey est **strategy-proof**.\n",
+    "\n",
+    "Ce contraste `utilite 0` vs `utilite 2` est le coeur pedagogique du principe de revelation : deux regles d'enchere en apparence proches (toutes deux « le plus offrant gagne ») ont des proprietes strategiques **radicalement differentes** selon ce que le gagnant paie — son propre prix, ou celui du second.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "5926af02-e1d3-4d70-83f9-b1eb5934c269",
    "metadata": {},
    "source": [
@@ -492,6 +507,18 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-gt16-c8-c841",
+   "metadata": {},
+   "source": [
+    "### Lecture du resultat VCG : la regle de Clarke et l'externalite\n",
+    "\n",
+    "Chaque gagnant paie **non pas sa valeur**, mais le cout qu'il impose aux autres (son *externalite*), calculee par la **regle de Clarke** : le paiement d'un gagnant = (somme des valeurs des autres dans l'allocation optimale SANS lui) - (somme des valeurs des autres dans l'allocation optimale AVEC lui).\n",
+    "\n",
+    "Sur la sortie : objet 0 gagne par l'enchérisseur 0 (valeur 10), paiement VCG **8** — soit exactement la valeur qu'aurait recue le second meilleur (8) si l'enchérisseur 0 avait ete absent. De meme pour les objets 1 et 2 (paiements 6 et 3). La somme des paiements (**17**) est **inferieure** a la somme des valeurs attribuees (10+9+7 = 26) : le mecanisme VCG n'est **pas equilibre budgetairement** (il laisse un deficit cote vendeur). C'est le compromis fondamental de VCG : il garantit simultanement **effacite** (allocation optimale) et **sincerite** (strategy-proof), mais au prix d'un budget non equilibre — on ne peut pas avoir les trois (Myerson-Satterthwaite pour les echanges bilateraux).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "3e728c28-2c83-48a5-ac39-0791ef18ef86",
    "metadata": {},
    "source": [
@@ -633,6 +660,18 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-gt16-c10-c841",
+   "metadata": {},
+   "source": [
+    "### Lecture du resultat : stabilite et avantage du coté proposeur\n",
+    "\n",
+    "La sortie affiche `Nombre de paires bloquantes : 0` — c'est la definition meme d'un **matching stable** : aucune paire (homme, femme) ne prefersrait s'etre mutuellement a leur partenaire actuel. L'algorithme de Gale-Shapley (deferred acceptance) termine toujours en au plus $n^2$ iterations sur un tel etat stable.\n",
+    "\n",
+    "Un point subtil, invisible dans le compte rendu mais crucial : comme ce sont les **hommes qui proposent** (cote proposeur), le resultat est **optimal pour les hommes** ET **pessimal pour les femmes** parmi tous les matchings stables. Chaque homme obtient la meilleure partenaire qu'il puisse avoir dans AUCUN matching stable ; chaque femme, la pire. Inverser les roles (femmes proposent) donne le matching dual — egal en stabilite mais inverse en satisfaction. C'est pourquoi Gale-Shapley est utilise en affectation internats-medecins (cote etudiant proposeur) : le coté proposeur est avantagé par construction.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "ebcd5728-5d02-448f-a943-cbc960f8cd90",
    "metadata": {},
    "source": [
@@ -703,6 +742,19 @@
     "}\n",
     "Show(sb5.ToString());\n",
     "\"Verdict : echange efficace (OUI ssi v_b >= c_s). Le prix median partage le surplus.\".Display();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-gt16-c12-c841",
+   "metadata": {},
+   "source": [
+    "### Lecture du resultat : efficacite et partage du surplus\n",
+    "\n",
+    "Deux leçons se lisent dans la sortie :\n",
+    "\n",
+    "1. **Efficacite** : l'echange a lieu (`OUI`) si et seulement si la valeur de l'acheteur $v_b$ est au moins egale au cout du vendeur $c_s$ — cas `v_b=10, c_s=4` (echange) vs `v_b=5, c_s=8` (pas d'echange). C'est exactement le critere d'efficacite de Pareto : transferer l'objet au plus haut valeurant cree du surplus ssi $v_b \\geq c_s$.\n",
+    "2. **Partage du surplus** : le prix median $(v_b + c_s)/2$ partage equitablement le surplus total $(v_b - c_s)$ entre acheteur et vendeur. Pour $v_b=10, c_s=4$ : surplus total 6, prix 7 → acheteur gagne $10-7=3$, vendeur gagne $7-4=3$. Symetrique, donc equitable — mais ce mecanisme median **n'est pas strategy-proof** (chaque coté a interet a manipuler sa declaration pour rapprocher le prix de son coté), contrairement a VCG ci-dessus. La double-auction mediane sacrifie la sincerite pour la simplicite et l'equilibre budgetaire.\n"
    ]
   },
   {


### PR DESCRIPTION
## Contexte

Asymétrie pédagogique jumeaux trouvée **firsthand** (comparaison densité markdown/code des paires Python⇄C#) : `GameTheory-16-MechanismDesign-Csharp.ipynb` (le jumeau C#) compte **11 cellules markdown / 9 code**, contre **34 md / 15 code** pour son jumeau Python `GameTheory-16-MechanismDesign.ipynb`. Le ratio md/code du C# (1,22) tombe à **54 %** de celui du Python (2,27).

Concrètement : le jumeau C# a une cellule markdown d'**introduction** avant chaque code, mais **saute directement à la section suivante après l'exécution** — sans aucune cellule d'**interprétation** du résultat produit. Un apprenant .NET qui n'utilise que le jumeau C# (sans ouvrir le Python) voit le code tourner et afficher un tableau, mais sans l'analyse pédagogique qui explique *pourquoi* ce résultat importe. Le jumeau Python, lui, est activement maintenu (PR récente #7901 a enrichi le test IC cell 41 + table cell 43), ce qui creuse l'écart.

## Changement

Ajout de **4 cellules markdown d'interprétation** dans `GameTheory-16-MechanismDesign-Csharp.ipynb`, chacune positionnée **immédiatement après** la cellule de code dont elle commente la sortie réelle :

1. **Après cellule « premier-prix vs Vickrey »** — pourquoi le premier-prix laisse `utilité 0` (winner's curse : payer son enchère exacte n laisse aucun surplus) alors que Vickrey laisse `utilité 2` (second-prix → `r=v` dominant). Le contraste `0` vs `2` est le cœur du principe de révélation.
2. **Après VCG multi-objets** — la règle de Clarke (paiement = externalité), pourquoi objet 0 paie 8 (= valeur du second absent), et la somme des paiements (17) < somme des valeurs (26) révèle le **déficit structurel de VCG** (non budget-équilibré) — le compromis efficacité+sincérité vs équilibre budgétaire.
3. **Après Gale-Shapley** — `0 paires bloquantes` = définition de la stabilité ; et le point subtil invisible au comptage : comme les **hommes proposent**, le matching est **optimal pour les hommes / pessimal pour les femmes** (d'où l'usage en affectation internat-médecin côté étudiant proposeur).
4. **Après double auction** — efficacité (`trade ssi v_b ≥ c_s` = Pareto) + le prix médian partage le surplus (10,4 → prix 7, surplus 3/3), mais **n'est pas strategy-proof** (chaque côté a intérêt à manipuler) contrairement à VCG.

## Vérification

- **Sorties réelles exécutées** (kernel `.net-csharp`, dotnet-interactive 1.0.712001) AVANT d'écrire l'interprétation — chaque affirmation chiffrée (`utilité 0/2`, Clarke sum 17, 0 blocking pairs, prix médian 7/surplus 3) est **groundée dans la sortie effective**, pas fabriquée (G.1 verify-before-claiming).
- C.1 (0 erreur volontaire — insertion markdown uniquement, 0 cellule code touchée).
- C.2 (les cellules code conservent leurs outputs origin/main ; ajout markdown seul → outputs précédents valides, pas de re-exec requis).
- LF-only (`grep -c '\r' = 0`).
- **Diff byte-surgical +53/-1, 1 fichier** : 4 cellules markdown d'interprétation uniquement. Les 20 cellules existantes sont **byte-identiques** à `origin/main` (-1 = accolade structurelle JSON de décalage d'insertion).

## L898 collision guard

- Aucune PR OPEN/MERGED ne touche `GameTheory-16-MechanismDesign-Csharp.ipynb` (la seule Csharp-connexe #5564 = création du jumeau originelle, merged).
- PR #7901 (MERGED 2026-07-22) touche le jumeau **Python** (cell 41/43), pas le C# — front distinct, pas de collision.

See #3975 (READMEs feuilles GameTheory non-Lean — parité pédagogique .NET) + #2161 (richesse pédagogique).