### PR TITLE
docs(genai-texte,#8081): NB-17 Native Reasoning vs Scaling canonical citations

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/17_Native_Reasoning_vs_Scaling.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/17_Native_Reasoning_vs_Scaling.ipynb
@@ -243,7 +243,7 @@
     "## 1. Suite graduee + verificateur + pass@k (herites de NB-16)\n",
     "\n",
     "Même suite que NB-16 (reponses entieres verifiables) pour que la comparaison soit\n",
-    "**equitable**. Estimateur pass@k non-biasé (HumanEval)."
+    "**equitable**. Estimateur pass@k non-biasé (HumanEval, Chen et al 2021)."
    ]
   },
   {
@@ -532,7 +532,7 @@
     "tags": []
    },
    "source": [
-    "## 4. Comparaison cost-normalisee (la question Snell)\n",
+    "## 4. Comparaison cost-normalisee (la question Snell, Snell et al 2024)\n",
     "\n",
     "On superpose, sur un axe **x = tokens depenses**, :\n",
     "- la **courbe BoN** du modèle standard (pass@k vs tokens cumules, par bucket),\n",
@@ -947,8 +947,14 @@
     "- **Phase 6** — plugin **Semantic Kernel** : integrer les moteurs (BoN/ToT/Reflexion/memory) comme\n",
     "  **plugins SK** (pont series SemanticKernel), exposant le test-time scaling comme outil reutilisable.\n",
     "\n",
-    "**References :** Snell et al. 2024 (test-time compute scaling) ; NB-12 (moteurs), NB-16 (pass@k\n",
-    "scaling), NB-13/14/15 (routeur, memoire, ToT-CSP) de cette serie."
+    "\n",
+    "## References\n",
+    "\n",
+    "- **Snell, Lee, Xu & Kumar (2024)**, *Scaling LLM Test-Time Compute Optimally can be More Effective than Scaling Model Parameters*, arXiv:2408.03314 (ICLR 2025). — La « question Snell » centrale de ce notebook (§4) : à coût (tokens) égal, le raisonnement natif bat-il le scaling hand-rolled (BoN pass@k) ?\n",
+    "- **Chen et al. (2021)**, *Evaluating Large Language Models Trained on Code*, arXiv:2107.03374. — Origine de la métrique **pass@k** et du benchmark **HumanEval** (estimateur non-biaisé utilisé §1).\n",
+    "- **Lightman et al. (2023)**, *Let's Verify Step by Step*, arXiv:2305.20050 (ICLR 2024). — Origine des **process reward models** (PRM) : le « vérificateur » à étapes qui sous-tend le scoring des réponses vérifiables.\n",
+    "\n",
+    "> **Cross-références internes** : NB-12 (moteurs d'inférence), NB-16 (pass@k / scaling hand-rolled), NB-13/14/15 (routeur, mémoire, ToT-CSP) — série Epic #2926.\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary

Audit fidélité **#8081** (axis: canonical citations) on GenAI/Texte `17_Native_Reasoning_vs_Scaling.ipynb`. The notebook **narratively** refers to its core scholarly concepts but never gives **formal** citations (no arXiv ID, no authors, no full title).

## Defect (firsthand read)

- `md[21]` (Conclusion) ended with a narrative mini-reference: *« References : Snell et al. 2024 (test-time compute scaling) ; NB-12 (moteurs), NB-16 (pass@k scaling)… »* — a mention, not a citable reference.
- `md[10]` poses **« la question Snell »** (the paper's central question: at equal token cost, does native reasoning beat hand-rolled scaling?) without anchoring it.
- `md[4]` uses **« pass@k non-biaisé (HumanEval) »** (Chen 2021) without citation.

Classic axis-1 pattern: implicit scholarly anchoring not formalised.

## Fix

Markdown-only (C.2 exception). Three surgical edits by source-list index:

- **`md[4]`**: `pass@k non-biaisé (HumanEval)` → `(HumanEval, Chen et al 2021)`
- **`md[10]`** header: `(la question Snell)` → `(la question Snell, Snell et al 2024)`
- **`md[21]`**: the narrative mini-References line replaced by a formal **References** section (3 papers w/ arXiv IDs) + internal cross-references preserved (NB-12/16/13/14/15).

## References verified firsthand (2026-07-24)

| Paper | arXiv | Anchor in notebook |
|-------|-------|--------------------|
| **Snell, Lee, Xu & Kumar (2024)** *Scaling LLM Test-Time Compute Optimally…* | 2408.03314 (ICLR 2025) | "la question Snell" (md[10]) — at equal token cost, native reasoning vs hand-rolled BoN pass@k |
| **Chen et al. (2021)** *Evaluating LLMs Trained on Code* (Codex) | 2107.03374 | pass@k metric + HumanEval benchmark (md[4]) |
| **Lightman et al. (2023)** *Let's Verify Step by Step* | 2305.20050 (ICLR 2024) | process reward model ("vérificateur") underpinning verifiable-answer scoring |

Snell via SearXNG; Chen + Lightman via WebFetch arxiv.org.

## Validation

- **+10/-4**, only cells 4+10+21 changed (markdown-only)
- **all 10 code cells byte-identical** (untouched)
- **0 CRLF**, LF-only, `json.dumps(indent=1, ensure_ascii=False) + "\n" == raw`
- **catalog byte-identical to main** (no catalog-regen on branch)
- **H.3 validator 1/1 PASS** (10 code cells), 0 NotImplementedError
- **Markdown-only → no re-exec needed** (C.2 exception)

See #8081 (partial, epic ouverte). Epic series GenAI/Texte #2926.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
