### PR TITLE
fix(genai-audio,#8052): align MusicGen "Valeur observee" ratio with committed generation output

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-3-MusicGen-Generation.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-3-MusicGen-Generation.ipynb
@@ -924,7 +924,7 @@
     "\n",
     "| Aspect | Valeur observee | Interpretation |\n",
     "|--------|----------------|----------------|\n",
-    "| **Ratio temps reel** | 0.5-2x (GPU) | La generation est plus lente que la lecture mais reste acceptable |\n",
+    "| **Ratio temps reel** | 0.21-0.24x (ce run) | La generation est plus lente que la lecture mais reste acceptable |\n",
     "| **Qualite audio** | 32kHz mono | Qualite correcte pour demos et prototypage |\n",
     "| **Coherence texte** | Bonne a très bonne | Le modèle suit les descriptions avec precision |\n",
     "| **Variabilite** | Haute | Chaque generation est unique (non-déterministe) |\n",


### PR DESCRIPTION
## Contexte — finding #8052 (audit d'échantillonnage sémantique, class-1)

`02-3-MusicGen-Generation.ipynb` cellule `md[18]` = cellule d'interprétation **juste après** la cellule de génération `code[16]`. Sous une colonne explicitement labellisée **"Valeur observee"**, elle cite un ratio real-time `0.5-2x (GPU)` — mais l'output commité de `code[16]` montre que les 3 morceaux générés ont tourné à **0.21x / 0.22x / 0.24x** (47.12s / 46.01s / 42.11s pour 10.0s d'audio). **Tous les ratios observés sont < 0.5**, en dehors de la plage citée. Bug doc-honesty class-1 #8052.

| Cellule | Colonne | Claim | Output commité (`code[16]`) |
|---------|---------|-------|------------------------------|
| `md[18]` | **Valeur observee** | `0.5-2x (GPU)` | `Ratio temps reel : 0.21x` / `0.22x` / `0.24x` |

## Fix — aligner le nombre observé (anti-gaming #1214)

`md[18]` "Valeur observee" `Ratio temps reel` : `0.5-2x (GPU)` → **`0.21-0.24x (ce run)`**

L'interprétation (« plus lente que la lecture mais reste acceptable ») reste vraie pour 0.21-0.24x → inchangée.

**Pourquoi pas un relabel "observée"→"typique" ?** La cellule jumeau `md[19]` cite aussi `0.5-2x` mais sous **"Valeur typique"** (plage typique/attendue RTX 3090, pas un claim sur cette exécution → **pas un bug**, laissée intacte). Relabeler `md[18]` en "typique" pour préserver un nombre qui contredit l'output = **gaming du scanner** (pattern #1214 : find-replace de label pour faire passer l'audit sans corriger). `md[18]` est positionnée comme interprétation de `code[16]` → "observée" est le label honnête → le nombre doit matcher l'output. Le fix correct = aligner le nombre.

**Markdown-only (exception C.2)** : le timing MusicGen est **stochastique** (warmup modèle, compile EnCodec, charge GPU) et les outputs commités sont la source de vérité. Stop & Repair : on aligne la prose, jamais l'output. Aucun code ni output touché.

## Preuves vérifiables

- **Diff chirurgical byte-surgical** : `raw str.replace` sur la ligne unique bold `| **Ratio temps reel** |` (distincte de la ligne non-bold de `md[19]`). **1 insertion / 1 suppression, 1 fichier**. Toutes les autres cellules byte-identiques à origin/main.
- **Guards** : `md[19]` "Valeur typique" `0.5-2x (GPU)` **préservée** (assertion) ; truth values `code[16]` (`0.21x`/`0.22x`/`47.12s`/`46.01s`) **intacts** (assertion).
- **H.3 PASS** : `validate_pr_notebooks.py` 1/1 (13 code cells).
- **C.1** : 0 violation. **detect_solution_leaks** : 0/0/0.
- **Branche fraîche** : 0 behind / 0 ahead.
- **G.1** : finding identifié par sous-agent sonnet (read-heavy délégué) + **re-vérifié firsthand** (lecture directe md[18]/md[19]/code[16], distinction observee-vs-typique tranchée par contenu).

## Nature du grain

Doc-honesty class-1 (observed-value-vs-output) — GenAI/Audio (rotation R6). Contribution **partielle** à #8052 (1 bug class-1 ; l'epic reste ouverte). Sujet séparé de #8270 (Whisper STT, autre notebook) — atomique.

See #8052 (audit échantillonnage sémantique). See #3801 (Prong-B doc-honesty axis).

---
*Livré par po-2026 (worker cron). Suite balayage #8052 GenAI/Audio (Demucs CLEAN, Whisper #8270, MusicGen ici).*
