### PR TITLE
fix(probas-decpymc,#8052): align Site B probability claim with committed Monte Carlo output

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-4-Decision-Networks.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-4-Decision-Networks.ipynb
@@ -2070,7 +2070,7 @@
     "| B (rural) | 1.0 (300M = min) | 0.50 | 1.00 | ~0.78 |\n",
     "| C (periurbain) | 0.5 | 0.60 | 0.56 | ~0.55 |\n",
     "\n",
-    "La simulation Monte Carlo revelle que Site B a environ 95%+ de chances d'etre le meilleur choix, confirmant la robustesse de la decision face a l'incertitude des attributs.\n",
+    "La simulation Monte Carlo revelle que Site B a environ 76% de chances d'etre le meilleur choix, confirmant la robustesse de la decision face a l'incertitude des attributs.\n",
     "\n",
     "#### Extensions possibles\n",
     "\n",


### PR DESCRIPTION
## Contexte — finding #8052 (audit d'échantillonnage sémantique, class-1)

`DecPyMC-4-Decision-Networks.ipynb` md[39] (interprétation multi-attribut) cite une probabilité stale contredisant l'output Monte Carlo commité de la cellule code[38] qu'elle décrit.

| Cellule | Claim markdown | Output commité (`code[38]`) |
|---------|----------------|------------------------------|
| `md[39]` | « Site B a environ **95%+** de chances d'etre le meilleur choix » | `Site B (rural) : P(meilleur) = 76.0%` + `Site dominant : Site B (P = 76.0%)` |

**76% ≠ 95%+** — la probabilité citée contredit la sortie commitée. Motif canonique de l'audit #8052.

## Fix — aligner le nombre à l'output (Stop & Repair)

`md[39]` : `environ 95%+ de chances` → **`environ 76% de chances`**

L'interprétation (« robustesse de la décision ») reste **vraie** à 76% : Site B domine toujours (Site A suivant à 12.5%, soit ~3:1) → seul le nombre était faux. On aligne le nombre, on garde l'interprétation valide.

**Toutes les autres valeurs résultats vérifiées matching leurs outputs commités** : exemple Bayes md[12] (`51.4%`/`80.3`/`91.0`/`99.4`) = code[9] exact ; utilité md[15] `95.90` = code[14] exact ; formule `4.90 = 95.90 − 91.0` arithmétiquement correcte. **Seul le `95%+` était stale.**

**Markdown-only (exception C.2)** : PyMC Monte Carlo est **stochastique** et `pymc` n'est pas installé localement pour re-exec ; les outputs commités sont la source de vérité. Stop & Repair : on aligne la prose sur l'output, on ne hand-édite jamais le champ `outputs`. Aucune cellule de code ni output touché.

## Preuves vérifiables

- **Diff chirurgical byte-surgical** : `raw str.replace` sur la ligne unique, pas de `json.dump` round-trip. **1 insertion / 1 suppression, 1 fichier**, 42 autres cellules byte-identiques à origin/main.
- **Truth values préservés** : assertions que les outputs Monte Carlo commités (`P(meilleur) = 76.0%`, `Site dominant : Site B (P = 76.0%)`, `EU = 0.742`, `P(meilleur) = 12.5%`, `P = 11.5%`) restent byte-identiques.
- **H.3 PASS** : `validate_pr_notebooks.py` 1/1 (14 code cells).
- **C.1** : 0 violation.
- **detect_solution_leaks** : 0 HIGH / 0 MEDIUM / 0 errors.
- **Branche fraîche** : 0 behind / 0 ahead de origin/main (rebase frais, base 500dfdf91).
- **G.1** : finding identifié par scan drift de la famille PyMC (DecPyMC, ma lane decision-theory), puis **re-vérifié firsthand** (lecture directe md[39] + code[38], distinction stale-claim vs formula-params/arithmetic-derivations tranchée par contenu).

## Nature du grain

Doc-honesty class-1 (stale-probability-vs-output) — famille **Probas/PyMC** (rotation R6, ≠ GenAI/Texte-Audio-Video et ≠ ML/Sudoku des cycles précédents ; axe claims↔outputs distinct des citations PyMC-12 #8259 de po-2024 et du twin-parity #8267 de po-2023). Contribution **partielle** à #8052 (1 bug class-1 sur 1 notebook DecPyMC ; l'epic reste ouverte, d'autres notebooks PyMC ont une surface drift à vérifier au prochain cycle).

See #8052 (audit échantillonnage sémantique). See #3801 (Prong-B doc-honesty axis).

---
*Livré par po-2026 (worker cron). Nouvelle famille #8052 (Probas/PyMC DecPyMC) après drainage GenAI/ML/Sudoku/Search.*
