### PR TITLE
fix(probas,#8052): Infer-15 ratio output printed false 0,8 (true 0,75, :F1 banker rounding)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb
@@ -1970,7 +1970,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Ratio donnees/parametres : 15 / 20 = 0,8\r\n"
+      "Ratio donnees/parametres : 15 / 20 = 0,75\r\n"
      ]
     },
     {
@@ -2252,7 +2252,7 @@
     "Console.WriteLine(\"=== Factorisation Corrigee ===\");\n",
     "Console.WriteLine($\"\\nParametres : {nUsers2} users, {nItems2} items, {nTraits2} traits\");\n",
     "Console.WriteLine($\"Observations : {nObs2} notes\");\n",
-    "Console.WriteLine($\"Ratio donnees/parametres : {nObs2} / {(nUsers2 + nItems2) * nTraits2} = {(double)nObs2 / ((nUsers2 + nItems2) * nTraits2):F1}\");\n",
+    "Console.WriteLine($\"Ratio donnees/parametres : {nObs2} / {(nUsers2 + nItems2) * nTraits2} = {(double)nObs2 / ((nUsers2 + nItems2) * nTraits2):F2}\");\n",
     "\n",
     "// Afficher la matrice de notes (partiellement observee)\n",
     "Console.WriteLine(\"\\nMatrice de notes :\");\n",
@@ -2351,7 +2351,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  - Ratio donnees/params : 0,8 (vs 0.4 avant)\r\n"
+      "  - Ratio donnees/params : 0,75 (vs 0.4 avant)\r\n"
      ]
     }
    ],
@@ -2398,7 +2398,7 @@
     "Console.WriteLine(\"\\nModele corrige avec :\");\n",
     "Console.WriteLine($\"  - Prior precision : {priorPrec} (vs 1.0 avant)\");\n",
     "Console.WriteLine($\"  - Biais global : oui\");\n",
-    "Console.WriteLine($\"  - Ratio donnees/params : {(double)nObs2 / ((nUsers2 + nItems2) * nTraits2):F1} (vs 0.4 avant)\");"
+    "Console.WriteLine($\"  - Ratio donnees/params : {(double)nObs2 / ((nUsers2 + nItems2) * nTraits2):F2} (vs 0.4 avant)\");"
    ]
   },
   {


### PR DESCRIPTION
## fix(probas,#8052): Infer-15 ratio output printed false arithmetic "15 / 20 = 0,8" (true 0,75)

Grain: MED/notebook-dotnet — lane myia-po-2025:CoursIA — prev: MED/docs (Infer-19 #8257). Famille Probas/Infer (.NET).

### Le défaut (contradiction interne vérifiée firsthand)

`Infer-15-Recommenders.ipynb` affiche, dans la **sortie commitée** des cellules 23 et 25, un ratio **faux arithmétiquement** :

```
Ratio donnees/parametres : 15 / 20 = 0,8     <-- cell 23 (code output)
  - Ratio donnees/params : 0,8 (vs 0.4 avant) <-- cell 25 (code output)
```

Mais `15 / 20 = 0,75`, pas `0,8`. Le format C# `:F1` (1 décimale) applique un **arrondi bancaire** (`0,75 -> 0,8`), affichant ainsi l'**égalité fausse** « 15 / 20 = 0,8 ».

Pire : la **table markdown de la cellule 26** (interprétation) indique le bon ratio **0,75** pour la nouvelle config :

| Aspect | Ancienne config | Nouvelle config |
|---|---|---|
| Ratio données/params | 0.4 | **0.75** |

Le notebook se contredit donc : le **code output** dit `0,8`, la **prose/table** dit `0,75`. Classe-1 #8052 (claim-vs-output mismatch, internal contradiction). Vérifié firsthand (lecture des 3 cellules + de la sortie commitée).

### Le fix (code + re-exécution réelle, Stop & Repair)

- **Cellules 23 et 25** : format `:F1` -> `:F2` (2 décimales) sur la ligne de ratio uniquement. Le reste du code (matrice, modèle, autres prints) est **intact**.
- **Re-exécution RÉELLE** via `nbconvert --execute` (kernel `.net-csharp`, cold NuGet restore + EP inference) — les outputs des cellules 23+25 sont régénérés depuis l'exécution, **pas hand-édités** (Stop & Repair : corriger la cause + re-exécuter). Sortie confirmée : `15 / 20 = 0,75` et `0,75 (vs 0.4 avant)`.
- **Scope chirurgical (C.3)** : seules les cellules 23+25 (source modifiée) voient leurs outputs rafraîchis. Les autres cellules sont **byte-identiques** à main (aucun drift EP/matrice). Diff total : **+4/−4** (2 lignes source `:F1`→`:F2` + 2 lignes output `0,8`→`0,75`).
- **Déterminisme** : ratio = arithmétique entière pure (`15/20`), déterministe — pas de determinism-gate requis (aucune inference/stochasticité dans ces prints).

### Validation

- **Validateur H.3** `validate_pr_notebooks.py` : **PASS** (26 code cells, `.net-csharp`).
- **C.1/C.3 audit** `audit_c1_c3.py --family Probas` : **0/0** (58 notebooks, 0 violation).
- **Solution-leak detector** : **0 leak** sur Infer-15 (les seuls leaks rapportés SL-7/SL-9 sont non-liés, autre famille).
- **Exercices** : conforme (7 exercices, seuil >=3).
- **Re-exec proof** : `nbconvert --execute` EXIT=0, 249682 bytes, ratio chunk réel `= 0,75\r\n`.
- **Catalogue** byte-identique à main (non touché).

See #8052 (audit claim-vs-output, classe-1 internal contradiction). Note : après scan exhaustif firsthand de toutes les familles (Sudoku, Search, ML, GameTheory, DecInfer, DecPyMC, Probas/PyMC, IIT, .NET), Infer-15 est le **dernier finding réel** de cette veine — convergence fleet-wide confirmée (cycles précédents ~0% yield). PRs précédentes cette fenêtre : ML-2.7 #8251, Infer-19 #8257.
