### PR TITLE
chore(twin-parity,#8264): rebaseline 13 Probas/Infer.NET-PyMC pairs (sha-only drift, 19→6)

### DIFF
--- a/scripts/notebook_tools/twin_pairs.yaml
+++ b/scripts/notebook_tools/twin_pairs.yaml
@@ -361,10 +361,10 @@
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb
   parity_level: semantic
   last_audit:
-    date: '2026-07-23'
-    by: po-2024
-    python_sha: 1293d479bb2784ab786dc537a7dd923664eaeae8
-    csharp_sha: 0a4bd59dc18d36f504499aa038913403488bc79f
+    date: '2026-07-24'
+    by: po-2023
+    python_sha: 95ffd1e7291d7ace4f06a0bf6dcc6a1b04106d38
+    csharp_sha: f55b9531a3181995760e9ebeb553972cfc1e12cf
   known_differences:
   - 'Socle pedagogique commun : melanges de distributions gaussiennes (GMM) modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational
@@ -377,10 +377,10 @@
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb
   parity_level: semantic
   last_audit:
-    date: '2026-07-23'
-    by: po-2024
+    date: '2026-07-24'
+    by: po-2023
     python_sha: 9f0c7a44ffd98bfc97b6ef091ae28fe7d6802541
-    csharp_sha: e012c8765a612c311e673c0662198064003fea4f
+    csharp_sha: 71e8a8ab7a8c6d38515626b94d062aa9c4c1d875
   known_differences:
   - 'Socle pedagogique commun : graphes de facteurs et variables aleatoires modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational
@@ -393,10 +393,10 @@
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb
   parity_level: semantic
   last_audit:
-    date: '2026-07-23'
-    by: po-2024
+    date: '2026-07-24'
+    by: po-2023
     python_sha: aa853aa35f024e6af153991847a0bebf91caaadf
-    csharp_sha: 735330e82b7c6a50a6a664ea6a0102e3eadbbbaf
+    csharp_sha: 92f9db61a2fa34db87bbd2b9922ea9347dfabfe7
   known_differences:
   - 'Socle pedagogique commun : reseaux bayesiens (DAG de dependances conditionnelles) modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational
@@ -409,10 +409,10 @@
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-5-Causal-Inference.ipynb
   parity_level: semantic
   last_audit:
-    date: '2026-07-23'
-    by: po-2024
+    date: '2026-07-24'
+    by: po-2023
     python_sha: c577dc03216f318a392f373ba61aa85287037f98
-    csharp_sha: 5a56e6d6f4341aab8e5ceeff0dbae6dc603c3abe
+    csharp_sha: e495c6935e61214af55a64d5598412720e7f80fe
   known_differences:
   - 'Socle pedagogique commun : inference causale (do-calculus, ajustement) modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational
@@ -441,10 +441,10 @@
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb
   parity_level: semantic
   last_audit:
-    date: '2026-07-23'
-    by: po-2024
+    date: '2026-07-24'
+    by: po-2023
     python_sha: 243abda6c6d8da742e47ae61a60d780b770e77ad
-    csharp_sha: 0a6a22b40add98c9f2ef2611cf06e53c4ae20f9e
+    csharp_sha: 3734352b4af21f92da63865c32b78d6fd3b5dd31
   known_differences:
   - 'Socle pedagogique commun : Item Response Theory (modeles de competences / IRT) modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational
@@ -457,10 +457,10 @@
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb
   parity_level: semantic
   last_audit:
-    date: '2026-07-23'
-    by: po-2024
+    date: '2026-07-24'
+    by: po-2023
     python_sha: 02beb4247f8c3087e6743bb2b7915ad7215b60e3
-    csharp_sha: 6291ab988840ca8eeb033349efde736f1c40d6a3
+    csharp_sha: b3122444408af43475485135a714c982226d711b
   known_differences:
   - 'Socle pedagogique commun : TrueSkill (classement et apprentissage en ligne) modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational
@@ -473,10 +473,10 @@
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb
   parity_level: semantic
   last_audit:
-    date: '2026-07-23'
-    by: po-2024
+    date: '2026-07-24'
+    by: po-2023
     python_sha: be07a64cf703c3bef33d6898601ce6b021d3abf3
-    csharp_sha: 53fc7e6d5417f47ee6c15bb781ddce9bf15896b3
+    csharp_sha: 9cfc62e7089756ed550cbae76645a95589a0fe93
   known_differences:
   - 'Socle pedagogique commun : classification bayesienne modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational
@@ -489,10 +489,10 @@
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb
   parity_level: semantic
   last_audit:
-    date: '2026-07-23'
-    by: po-2024
+    date: '2026-07-24'
+    by: po-2023
     python_sha: a9659a12d6e0672d694b500ecb53161bd31daeef
-    csharp_sha: 5a93b73a4cbea0eb613a5bada88f975e12edd0ce
+    csharp_sha: 8f551c9b7560f813842919283fdea3c8c3131bcd
   known_differences:
   - 'Socle pedagogique commun : selection de modele (WAIC/LOO, evidence) modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational
@@ -505,10 +505,10 @@
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb
   parity_level: semantic
   last_audit:
-    date: '2026-07-23'
-    by: po-2024
-    python_sha: 9e349a18869a888741befc47108464157236f925
-    csharp_sha: 04632a7f849c543b567e336919edea2442484fc9
+    date: '2026-07-24'
+    by: po-2023
+    python_sha: b2eabcd0b9ddc11477c59b0474068367e8f84962
+    csharp_sha: a599efb43e5aa2194148bbdc14fd05ab0dc119b4
   known_differences:
   - 'Socle pedagogique commun : modeles de topics (LDA / allocation de Dirichlet) modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational
@@ -521,10 +521,10 @@
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-12-Modeles-Hierarchiques.ipynb
   parity_level: semantic
   last_audit:
-    date: '2026-07-23'
-    by: po-2024
-    python_sha: a0d13371fa668e8b1eb6249ef47f5205bf32b07a
-    csharp_sha: 88921c3ff2541ae457f8acdd45ca5bd9b1a0c23c
+    date: '2026-07-24'
+    by: po-2023
+    python_sha: a11ea49af8f7aaa1b140dfa68bddbff690a6ef0b
+    csharp_sha: 156ac25e0570949b2f2db13a4593b9ca829ea5c4
   known_differences:
   - 'Socle pedagogique commun : modeles hierarchiques (effets aleatoires emboites) modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational
@@ -556,10 +556,10 @@
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb
   parity_level: semantic
   last_audit:
-    date: '2026-07-23'
-    by: po-2024
+    date: '2026-07-24'
+    by: po-2023
     python_sha: 765544fe8ac71c15305c2cb91f9b16909e86e1df
-    csharp_sha: 6c911f78b7705518eda21705f1961cc8aa7f117a
+    csharp_sha: 0615f621145fb72de2e690c6bb7ef79838b06b53
   known_differences:
   - 'Socle pedagogique commun : modeles de sequences (chaines de Markov cachees / HMM) modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational
@@ -572,10 +572,10 @@
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb
   parity_level: semantic
   last_audit:
-    date: '2026-07-23'
-    by: po-2024
+    date: '2026-07-24'
+    by: po-2023
     python_sha: 3a4321e6b0e610dfd533982b543997bd9a436c83
-    csharp_sha: c46cdae20cada18251a1a6ba0ddac7337dcd5ce9
+    csharp_sha: 30cbe41bd3c333fb5d360a866b69b98380362112
   known_differences:
   - 'Socle pedagogique commun : systemes de recommandation (filtrage collaboratif) modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational
@@ -636,10 +636,10 @@
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-19-Survival-Analysis.ipynb
   parity_level: semantic
   last_audit:
-    date: '2026-07-23'
-    by: po-2024
+    date: '2026-07-24'
+    by: po-2023
     python_sha: 071a2a1f1848fbd25de2c8e313b004b0d4706f8c
-    csharp_sha: 26e27a8ac4950ebbc373789762d46177a3946afc
+    csharp_sha: 62974bb4be0cf95716c3a109fa70bcfacb9d647f
   known_differences:
   - 'Socle pedagogique commun : analyse de survie (modelisation de durees / censure) modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational


### PR DESCRIPTION
## Summary

13 **Probas/Infer.NET-PyMC** twin pairs had stale `last_audit.{csharp,python}_sha` (recorded sha ≠ current blob sha) — the root cause of the **fleet-wide twin-parity FAIL (#8264)**. The drift came from **citation/reference-cell enrichment PRs** that modified the C# notebooks WITHOUT rebaselining the twin registry at merge time:

| PR | Pair(s) touched | Change |
|----|-----------------|--------|
| #8214 | Infer-2, Infer-11 | 4 reference cells |
| #8231 | Infer-2 | canonical citations |
| #8232 | Infer-11 | canonical citations (LDA) |
| #8243 | Infer-7 | IRT/DINA fidelity citations |
| #8174 | Infer-7, Infer-15 | Serie N/X header reconcile |

## Why this is safe (G.8 spot-audit)

Drift is **SHA-ONLY**. The citation cells are **scholarly apparatus** (bibliographic references), not core probabilistic modeling. Semantic parity (`parity_level: semantic`) is preserved — both twins teach the same GMM / IRT / LDA / factor-graph concepts; `known_differences` already documents the engine split (Infer.NET vs PyMC).

For each of the 13 pairs, `git log` of the drifted notebook confirms the **last-touching commit was a docs/citation PR**, not a semantic modeling edit. Rebaseline = acknowledging the already-merged-and-reviewed state, **not** approving unaudited work (anti-pattern G.8).

## Pairs rebaselined (13)

Probas-**2, 3, 4, 5, 7, 8, 9, 10, 11, 12, 14, 15, 19** — `csharp_sha` on all 13; `python_sha` also on Probas-2, 11, 12 (those PyMC notebooks also got citation cells).

## Method — byte-safe, comment-preserving

**Raw-text 4-line block replacement** anchored on the unique `python_sha`+`csharp_sha` values. **NOT** `yaml.safe_dump` / `check_twin_parity.py --update` (which destroy comments, cf fleet memory). Verified: diff touches **only** `date`/`by`/`sha` lines (+42/−42), 0 structure/comment churn, yaml still valid.

## Validation

`check_twin_parity.py --check`: **OK=33 DRIFT=6** (was OK=20 DRIFT=19) — all 18 Probas pairs now OK (2→19 fixed; Probas-6/13/16/17/18 already OK).

## Residual (out of scope, flagged for ai-01 batch)

6 drifts remain — **fleet gate still fails until these resolve**:
- **ML-1, ML-2, ML-3, ML-5** — drift from #8269 (cost frontmatter) + ML-3 exercise #7937. Involves frontmatter/exercise content → needs deeper spot-audit (not rubber-stamped here).
- **CSP-3** — drift from #8022 (makespan) / #7835 (N-Reines answer-key). Content fixes → needs spot-audit.
- **ML-4** — covered by open **#8246** (jsboige).

## Supersedes #8267

My prior attempt **#8267** is closed as superseded — it became CONFLICTING after #8255 (Probas-6) and #8247 (Probas-13) merged with final shas, and its other shas were stale relative to current `origin/main`. This PR is a clean fresh rebaseline off current `origin/main` with current correct shas.

See #8264 (partial — Probas tranche resolved; ML/CSP residual remains for ai-01).