### PR TITLE
docs(gametheory,#8081): GT-16 MechanismDesign canonical citations

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-16-MechanismDesign.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-16-MechanismDesign.ipynb
@@ -2534,6 +2534,18 @@
     "\n",
     "---\n",
     "\n",
+    "## Références\n",
+    "\n",
+    "Papiers fondateurs de la théorie des mécanismes, cités dans ce notebook :\n",
+    "\n",
+    "- **Vickrey, W. (1961)**. *Counterspeculation, Auctions, and Competitive Sealed Tenders*. The Journal of Finance, 16(1):8–37. — L'enchère au second prix (§3.2), dite « enchère de Vickrey » ; prix Nobel d'économie 1996.\n",
+    "- **Clarke, E. H. (1971)**. *Multipart Pricing of Public Goods*. Public Choice, 11(1):17–33. — Le « pivot mechanism » (taxe de Clarke), composante C de VCG (§4).\n",
+    "- **Groves, T. (1973)**. *Incentives in Teams*. Econometrica, 41(4):617–631. — Révélation sincère des valuations, composante G de VCG (§4).\n",
+    "- **Gale, D. & Shapley, L. S. (1962)**. *College Admissions and the Stability of Marriage*. The American Mathematical Monthly, 69(1):9–14. — L'algorithme de matching stable (§5) ; prix Nobel d'économie 2012 (Shapley).\n",
+    "- **Gibbard, A. (1973)**. *Manipulation of Voting Schemes: A General Result*. Econometrica, 41(4):587–601. — Le principe de révélation pour les mécanismes directs (§2).\n",
+    "- **Satterthwaite, M. A. (1975)**. *Strategy-Proofness and Arrow's Conditions: Existence and Correspondence Theorems for Voting Procedures and Social Welfare Functions*. Journal of Economic Theory, 10(2):187–217. — Co-auteur du théorème de Gibbard-Satterthwaite (§6).\n",
+    "- **Myerson, R. B. & Satterthwaite, M. A. (1983)**. *Efficient Mechanisms for Bilateral Trading*. Journal of Economic Theory, 29(2):265–281. — Impossibilité (efficacité + IC + IR + équilibre budgétaire) pour l'échange bilatéral (§6) ; prix Nobel 2007 (Myerson).\n",
+    "\n",
     "**Notebook suivant** : [GameTheory-17-MultiAgent-RL](GameTheory-17-MultiAgent-RL.ipynb) - Apprentissage multi-agent et self-play"
    ]
   },


### PR DESCRIPTION
## Summary

Audit fidélité **#8081** (axis: canonical citations) on GameTheory `GameTheory-16-MechanismDesign.ipynb`. The notebook had **no formal References section**. Inline scholarly anchors **existed** but were never resolved into bibliographic entries — classic axis-1 pattern (anchoring implicit, not formalised).

## Defect (firsthand read)

- **`md[6]`**: `### 3.2 Enchère au second prix (Vickrey, 1961)` — Vickrey anchored inline, never resolved.
- **`md[47]`** (conclusion): `- **Gibbard-Satterthwaite** : …` and `- **Myerson-Satterthwaite** : …` — named by hyphenated-author only.
- **`md[22]`**: VCG revenue non-monotonicity `(Conitzer-Sandholm)`.
- Plus the notebook teaches **VCG (Vickrey-Clarke-Groves)** and **Gale-Shapley** by name throughout sections 2–6 — but a reader has no bibliography to look them up.

## Fix

Markdown-only (C.2 exception). **Single cell edit** (`md[47]`, the conclusion). Append a formal `## Références` section resolving the **7 seminal mechanism-design papers** (author, year, title, venue, volume, issue, pages), each anchored to the notebook section where it is used. Navigation line preserved byte-for-byte.

## References verified firsthand (2026-07-24, WebFetch Wikipedia + SearXNG multi-source)

| Paper | Venue | Anchor in notebook |
|-------|-------|--------------------|
| **Vickrey (1961)** *Counterspeculation, Auctions…* | *J. Finance* 16(1):8–37 | Second-price auction (§3.2); Nobel 1996 |
| **Clarke (1971)** *Multipart Pricing of Public Goods* | *Public Choice* 11(1):17–33 | Pivot mechanism / Clarke tax, the "C" of VCG (§4) |
| **Groves (1973)** *Incentives in Teams* | *Econometrica* 41(4):617–631 | Revelation of valuations, the "G" of VCG (§4) |
| **Gale & Shapley (1962)** *College Admissions…* | *AMM* 69(1):9–14 | Stable matching algorithm (§5); Nobel 2012 (Shapley) |
| **Gibbard (1973)** *Manipulation of Voting Schemes…* | *Econometrica* 41(4):587–601 | Revelation principle for direct mechanisms (§2) |
| **Satterthwaite (1975)** *Strategy-Proofness and Arrow's Conditions…* | *JET* 10(2):187–217 | Co-author of the Gibbard-Satterthwaite theorem (§6) |
| **Myerson & Satterthwaite (1983)** *Efficient Mechanisms for Bilateral Trading* | *JET* 29(2):265–281 | Bilateral-trading impossibility (§6); Nobel 2007 (Myerson) |

> **Not fabricated**: the Conitzer-Sandholm / Othman-Sandholm mentions (`md[22]`/`md[26]`/`md[27]`) are specialized results not verified firsthand — the inline attributions are preserved as-is and **deliberately omitted** from the formal section rather than risk a wrong citation.

## Validation

- **+12 insertions, 0 deletions** (pure append — cleaner than a replace)
- **only cell 47 changed** (markdown-only); **15 code cells byte-identical** (untouched)
- **0 CRLF**, LF-only, `json.dumps(indent=1, ensure_ascii=False) == raw` (this file has no trailing newline)
- **catalog byte-identical to main** (no catalog-regen on branch)
- **rebased onto fresh origin/main** (575ec0bfb, 0 commits behind)
- **H.3 validator 1/1 PASS** (15 cells, `gametheory-wsl`), 0 NotImplementedException
- **Markdown-only → no re-exec needed** (C.2 exception)
- **NOT a registered twin** → no twin-parity complication

New family (GameTheory) = R6 family rotation from GenAI/Texte. Genre: canonical citations (#8081 axis-1).

See #8081 (partial, epic ouverte).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
