### PR TITLE
fix(sudoku-15-infer,#8278): fabrication 0-erreur Medium — real re-exec shows 37 (Robuste) / 3 (Itératif) errors

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Csharp.ipynb
@@ -1625,7 +1625,7 @@
   {
    "id": "ea382a18",
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
@@ -1642,809 +1642,423 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "done.\r\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Iterating: \r\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "|"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "|"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "|"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "|"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "."
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "|"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      " 50\r\n"
-     ]
-    },
-    {
-     "output_type": "display_data",
-     "metadata": {},
      "data": {
       "text/plain": [
-       "Sudoku renvoyé:\n",
-       "-------------------------------\n",
-       "| 9  6  2 | 1  8  5 | 4  7  3 | \n",
-       "| 1  7  4 | 9  6  3 | 8  2  5 | \n",
-       "| 5  3  8 | 4  2  7 | 1  6  9 | \n",
-       "-------------------------------\n",
-       "| 8  2  6 | 3  5  9 | 7  4  1 | \n",
-       "| 3  5  7 | 8  1  4 | 2  9  6 | \n",
-       "| 4  9  1 | 6  7  2 | 5  3  8 | \n",
-       "-------------------------------\n",
-       "| 2  4  9 | 5  3  8 | 6  1  7 | \n",
-       "| 7  1  5 | 2  9  6 | 3  8  4 | \n",
-       "| 6  8  3 | 7  4  1 | 9  5  2 | \n",
-       "-------------------------------\n",
-       "Nombre d'erreurs réstantes: 0\n",
-       "Temps de résolution: 336902,8216 ms"
+       "Test des sudokus medium"
       ]
-     }
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "output_type": "display_data",
-     "metadata": {},
      "data": {
       "text/plain": [
        "Résolution par le solver RobustProbabilisticSolver du Sudoku:\n",
        " -------------------------------\n",
-       "|       3 |    2    | 6       | \n",
-       "| 9       | 3     5 |       1 | \n",
-       "|       1 | 8     6 | 4       | \n",
+       "| 8  5    |       2 | 4       | \n",
+       "| 7  2    |         |       9 | \n",
+       "|       4 |         |         | \n",
        "-------------------------------\n",
-       "|       8 | 1     2 | 9       | \n",
-       "| 7       |         |       8 | \n",
-       "|       6 | 7     8 | 2       | \n",
+       "|         | 1     7 |       2 | \n",
+       "| 3     5 |         | 9       | \n",
+       "|    4    |         |         | \n",
        "-------------------------------\n",
-       "|       2 | 6     9 | 5       | \n",
-       "| 8       | 2     3 |       9 | \n",
-       "|       5 |    1    | 3       | \n",
+       "|         |    8    |    7    | \n",
+       "|    1  7 |         |         | \n",
+       "|         |    3  6 |    4    | \n",
        "-------------------------------"
       ]
-     }
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Iterating: \r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "|"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "|"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "|"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "|"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "."
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "|"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       " 50\r\n"
      ]
     },
     {
-     "output_type": "display_data",
-     "metadata": {},
      "data": {
       "text/plain": [
        "Sudoku renvoyé:\n",
        "-------------------------------\n",
-       "| 4  8  3 | 9  2  1 | 6  5  7 | \n",
-       "| 9  6  7 | 3  4  5 | 8  2  1 | \n",
-       "| 2  5  1 | 8  7  6 | 4  9  3 | \n",
+       "| 8  5  1 | 9  9  2 | 4  3  7 | \n",
+       "| 7  2  6 | 3  4  4 | 8  6  9 | \n",
+       "| 9  6  4 | 5  1  8 | 1  2  7 | \n",
        "-------------------------------\n",
-       "| 5  4  8 | 1  3  2 | 9  7  6 | \n",
-       "| 7  2  9 | 5  6  4 | 1  3  8 | \n",
-       "| 1  3  6 | 7  9  8 | 2  4  5 | \n",
+       "| 9  8  9 | 1  6  7 | 3  5  2 | \n",
+       "| 3  7  5 | 8  2  4 | 9  1  4 | \n",
+       "| 1  4  2 | 3  9  3 | 7  1  7 | \n",
        "-------------------------------\n",
-       "| 3  7  2 | 6  8  9 | 5  1  4 | \n",
-       "| 8  1  4 | 2  5  3 | 7  6  9 | \n",
-       "| 6  9  5 | 4  1  7 | 3  8  2 | \n",
+       "| 4  3  3 | 5  8  1 | 2  7  5 | \n",
+       "| 4  1  7 | 2  9  5 | 6  9  3 | \n",
+       "| 5  9  9 | 7  3  6 | 1  4  8 | \n",
        "-------------------------------\n",
-       "Nombre d'erreurs réstantes: 0\n",
-       "Temps de résolution: 136,2585 ms"
+       "Nombre d'erreurs réstantes: 37\n",
+       "Temps de résolution: 73,0605 ms"
       ]
-     }
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -2470,7 +2084,7 @@
    "source": [
     "### Interprétation : Limites du solver robuste sur les grilles moyennes\n",
     "\n",
-    "La cellule de test du solveur robuste sur Medium (cellule `17e91a97`, ec=5) rapporte **0 erreur** sur les 5 grilles testées, conformément à la capacité du modèle Dirichlet+compilation unique à converger pour les difficultés Easy. Sur les grilles Medium, le comportement observé dans les notebooks antérieurs est que Expectation Propagation peut **converger vers un optimum local** qui satisfait partiellement les contraintes all-différent sans garantir la cohérence globale (certains chiffres sont à 0 alors que d'autres cellules portent une distribution multimodale). Les chiffres d'erreurs ci-dessous constituent un **instantané extrait des exécutions antérieures** et dépendent du seed EP ; ils ne sont pas reproduits par la cellule de test ci-dessus (qui reste 0-erreur). Pour une mesure stable, voir la section *Solveur itératif* (cellule `204c7e88`) qui reimpose les cellules les plus confiantes comme priors.\n",
+    "Le test du solveur robuste sur une grille Medium (cellule `ea382a18`) laisse **37 erreurs résiduelles** : Expectation Propagation a convergé vers un optimum local qui satisfait partiellement les contraintes all-différent sans garantir la cohérence globale (certaines cellules portent une distribution multimodale au lieu d'une valeur fixée). Ce comportement est **stochastique** (il dépend du seed EP et de la grille tirée) et **intrinsèque à l'inférence approximative** -- ce n'est pas un bug du solver. À titre de comparaison, le solveur itératif (cellule `204c7e88`), qui réinjecte les cellules les plus confiantes comme nouveaux priors, ramène les erreurs à 3 sur la même grille : la réinjection stabilise la convergence.\n",
     "\n",
     "Le test sur une grille de difficulté moyenne révèle les limites de l'approche probabiliste :\n",
     "\n",
@@ -2485,7 +2099,7 @@
     "2. Les distributions de Dirichlet ne garantissent pas l'unicité de la solution -- elles modélisent une incertitude, pas une contrainte dure\n",
     "3. Les contraintes \"all-différent\" sont bien exprimées dans le modèle (via `ConstrainFalse`) mais leur propagation EP est imparfaite sur les grilles complexes\n",
     "\n",
-    "> **Note méthodologique** : L'échec sur les grilles moyennes est une limitation structurelle de l'inférence EP pure. C'est précisément ce qui motive l'approche itérative (section suivante) qui combine EP + réinjection des cellules les plus confiantes comme nouveaux priors."
+    "> **Note méthodologique** : L'échec sur les grilles moyennes est une limitation structurelle de l'inférence EP pure. C'est précisément ce qui motive l'approche itérative (section suivante) qui combine EP + réinjection des cellules les plus confiantes comme nouveaux priors.\n"
    ]
   },
   {
@@ -3139,7 +2753,7 @@
   {
    "id": "204c7e88",
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
@@ -3156,33 +2770,50 @@
    },
    "outputs": [
     {
-     "output_type": "display_data",
-     "metadata": {},
      "data": {
       "text/plain": [
        "Résolution par le solver IterativeProbabilisticSolver du Sudoku:\n",
        " -------------------------------\n",
-       "| 9     2 |       5 | 4     3 | \n",
-       "| 1       |    6  3 |    2  5 | \n",
-       "| 5     8 | 4     7 |    6    | \n",
+       "|       5 | 3       |         | \n",
+       "| 8       |         |    2    | \n",
+       "|    7    |    1    | 5       | \n",
        "-------------------------------\n",
-       "|    2  6 | 3     9 |       1 | \n",
-       "|    5  7 |    1    | 2  9    | \n",
-       "|    9    | 6  7    | 5  3    | \n",
+       "| 4       |       5 | 3       | \n",
+       "|    1    |    7    |       6 | \n",
+       "|       3 | 2       |    8    | \n",
        "-------------------------------\n",
-       "| 2  4    | 5  3    | 6       | \n",
-       "| 7     5 | 2       | 3     4 | \n",
-       "|    8    |    4  1 | 9  5    | \n",
+       "|    6    | 5       |       9 | \n",
+       "|       4 |         |    3    | \n",
+       "|         |       9 | 7       | \n",
        "-------------------------------"
       ]
-     }
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Compiling model..."
-     ]
+     "data": {
+      "text/plain": [
+       "Sudoku renvoyé:\n",
+       "-------------------------------\n",
+       "| 2  4  5 | 3  8  6 | 1  9  7 | \n",
+       "| 8  3  1 | 9  5  7 | 6  2  4 | \n",
+       "| 6  7  9 | 4  1  2 | 5  3  8 | \n",
+       "-------------------------------\n",
+       "| 4  8  6 | 1  9  5 | 3  7  2 | \n",
+       "| 9  1  2 | 8  7  3 | 4  5  6 | \n",
+       "| 7  5  3 | 2  6  4 | 9  8  1 | \n",
+       "-------------------------------\n",
+       "| 1  6  7 | 5  3  8 | 2  4  9 | \n",
+       "| 5  9  4 | 7  2  1 | 8  3  3 | \n",
+       "| 3  2  8 | 6  4  9 | 7  1  5 | \n",
+       "-------------------------------\n",
+       "Nombre d'erreurs réstantes: 3\n",
+       "Temps de résolution: 1792,0642 ms"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -40656,29 +40287,29 @@
     "\n",
     "Ce notebook a exploré la **programmation probabiliste** appliquée au Sudoku via Infer.NET, en construisant quatre solveurs de complexité croissante.\n",
     "\n",
-    "### Progression des solveurs (résultats vérifiés, issus des sorties `execution_count` commitees)\n",
+    "### Progression des solveurs (résultats vérifiés par ré-exécution, kernel `.net-csharp`)\n",
     "\n",
     "| Solveur | Principe | Easy (cellule test) | Medium (cellule test) | Temps caractéristique |\n",
     "|---------|----------|---------------------|----------------------|----------------------|\n",
-    "| **Naïf** | Recompilation à chaque solve | 0 erreur (`50fc7316` ec=4) | - | ~32-47 s (recompile, voir cellule `a009c961`) |\n",
-    "| **Robuste** | Dirichlet + compilation unique | 0 erreur (`91759baa` ec=6) | 0 erreur (`17e91a97` ec=5) | ~136 ms |\n",
-    "| **Itératif** | Ré-injection des cellules les plus confiantes | 0 erreur (`96b6b947` ec=9) | 0 erreur (`204c7e88` ec=10) | ~1 830 ms (1250 itérations EP) |\n",
-    "| **Précompilé** | Roslyn DLL réutilisable | 0 erreur (`06ddc48b` ec=13) | - | ~20 ms (load DLL) |\n",
+    "| **Naïf** | Recompilation à chaque solve | 0 erreur (`a009c961` ec=5) | - | ~14-26 s (recompile à chaque grille, voir `a009c961`) |\n",
+    "| **Robuste** | Dirichlet + compilation unique | 0 erreur (`91759baa` ec=7) | **37 erreurs** (`ea382a18` ec=9) | ~100 ms par grille (après la compilation initiale) |\n",
+    "| **Itératif** | Ré-injection des cellules les plus confiantes | 0 erreur (`96b6b947` ec=11) | **3 erreurs** (`204c7e88` ec=12) | ~1,8 s |\n",
+    "| **Précompilé** | Roslyn DLL réutilisable | *non validé* (échec compilation Roslyn, voir #8287) | - | - |\n",
     "\n",
-    "> **Note méthodologique** : les chiffres de cette table sont les **outputs reels** des cellules de test correspondantes (execution_count commitees, vérification croisee avec la cellule source). Les difficultés Medium sont résolues **sans erreur** par les solveurs Robuste, Itératif et Precompile ; cela reflète le fait que les tests operent sur des échantillons ou EP converge suffisamment. Les nombres d'erreurs affichés dans certaines sections précédentes (37, 45) provenaient d'exécutions antérieures laissées dans des cellules voisines et ne correspondent pas au comportement actuel des solveurs documentés ici.\n",
+    "> **Note méthodologique** : les solveurs **résolvent les grilles Easy sans erreur**, mais **échouent partiellement sur Medium** : EP converge vers des optima locaux qui violent certaines contraintes all-différent (37 erreurs pour le Robuste, 3 pour l'Itératif sur la grille testée). Ce comportement est **stochastique** (dépendant du seed EP et de la grille tirée) et reflète une limite structurelle de l'inférence approximative pure, corrigée partiellement par la réinjection itérative des priors. Le solveur Précompilé n'a pas pu être validé : sa cellule de test lève une `MissingMethodException` Roslyn (incompatibilité de version `Microsoft.CodeAnalysis.CSharp`), suivie dans l'issue #8287.\n",
     "\n",
     "### Leçons principales\n",
     "\n",
-    "1. **L'inférence probabiliste (EP) tend à converger pour les grilles Easy** : les tests sur 5 échantillons Easy donnent 0 erreur pour les trois solveurs probabalistes. La garantie formelle reste le domaine des solveurs déterministes, mais EP est suffisante en pratique sur la majorité des grilles aléatoires de difficulté modérée.\n",
-    "2. **L'approche itérative est plus stable** sur les grilles plus complexes grâce à la réinjection des priors, au prix d'un coût computationnel plus élevé (~1250 itérations EP).\n",
-    "3. **La précompilation Roslyn** élimine le coût de compilation initial (~30-60 s du solveur naïf) en chargeant directement la DLL compilée -- intéressant pour les déploiements en production.\n",
-    "4. **Les solveurs déterministes (CSP, SAT, MIP)** des notebooks précédents restent supérieurs en termes de garantie : un hybride probabiliste + propagation de contraintes est la voie prometteuse exploree en exercice.\n",
+    "1. **L'inférence probabiliste (EP) résout les grilles Easy mais échoue partiellement sur Medium** : 0 erreur sur les grilles Easy pour les trois solveurs, mais 37 erreurs (Robuste) / 3 erreurs (Itératif) sur Medium. EP converge vers des optima locaux -- la garantie formelle d'une solution correcte reste le domaine des solveurs déterministes (CSP, SAT, MIP).\n",
+    "2. **L'approche itérative est plus stable** sur les grilles plus complexes grâce à la réinjection des priors (37 -> 3 erreurs), au prix d'un coût computationnel plus élevé (~1,8 s, nombreuses itérations EP).\n",
+    "3. **La précompilation Roslyn** vise à éliminer le coût de compilation initial (~30-60 s du solveur naïf) en chargeant directement la DLL compilée, mais la cellule de test échoue actuellement dans cet environnement (voir #8287).\n",
+    "4. **Les solveurs déterministes (CSP, SAT, MIP)** des notebooks précédents restent supérieurs en termes de garantie : un hybride probabiliste + propagation de contraintes est la voie prometteuse explorée en exercice.\n",
     "\n",
     "### Liens avec les autres approches\n",
     "\n",
     "- Les solveurs CSP (Sudoku-10 OR-Tools, Sudoku-11 Choco) garantissent la solution mais sans modélisation probabiliste.\n",
     "- Z3 (Sudoku-12) offre la vérification formelle la plus robuste.\n",
-    "- L'approche hybride probabiliste + contraintes est explorée dans les exercices de ce notebook."
+    "- L'approche hybride probabiliste + contraintes est explorée dans les exercices de ce notebook.\n"
    ]
   },
   {


### PR DESCRIPTION
## fix(sudoku-15-infer,#8278): fabrication « 0 erreur » Medium — real outputs are 37 (Robuste) / 3 (Itératif)

Grain: MED/notebook-dotnet — lane myia-po-2025:CoursIA — prev: MED/notebook-dotnet (Infer-15 #8280). Turf Sudoku po-2025. Distinct substance (honesty re-exec + markdown rewrite vs Infer-15 ratio — different family, different defect class).

### Le défaut (fabrication vérifiée firsthand + re-exec)

`Sudoku-15-Infer-Csharp.ipynb` conclusion (cell 42) + interprétation (cell 20) claiment **« 0 erreur » sur Medium** pour les solveurs Robuste et Itératif, ET **inventent activement un démenti** pour les vrais comptes :

> « Les nombres d'erreurs affichés dans certaines sections précédentes (37, 45) provenaient d'exécutions antérieures laissées dans des cellules voisines et ne correspondent pas au comportement actuel des solveurs documentés ici. »

C'est **faux**. Re-execution réelle (`nbconvert --execute`, kernel `.net-csharp`, EXIT=0) confirme que **37 et 3 SONT les comportements actuels** :

| Solveur | Easy (re-exec) | Medium (re-exec) | Conclusion claimait |
|---------|----------------|------------------|---------------------|
| Robuste | 0 erreur (c14) | **37 erreurs** (c19) | « 0 erreur » ❌ |
| Itératif | 0 erreur (c25) | **3 erreurs** (c27) | « 0 erreur » ❌ |
| Précompilé | *échec compilation Roslyn* (c37) | - | « 0 erreur (ec=13) » ❌ non-validé |

Les outputs commités étaient **stale/misattachés** (c19 montrait un Easy « 0,0 », c27 n'avait aucune validation). La cellule 42 citait des cell-IDs de **définitions de classe** comme « cellule test ».

### Le fix (re-exec réelle + markdown honnête, Stop & Repair)

1. **c19 (Robuste Medium)** : injecté les outputs **réels** re-exec (55 outputs, ec=9) — une seule exécution Medium cohérente, affichant la vraie grille résolue + **37 erreurs résiduelles** + temps. *Plus petit* que les 108 outputs stale commités.
2. **c27 (Itératif Medium)** : injecté les **displays de validation** réels re-exec (ec=12) — grille résolue + **3 erreurs** + ~1,8 s. Les 3016 streams de progression EP (« .........| 50 ») sont du bruit de progress-bar sans information, et le notebook committé **omettait déjà** ces streams pour c27 (commité = 2 outputs) → style cohérent, pas de scrub.
3. **Cell 20** : réécrite — retire « 0 erreur » + « instantané extrait des exécutions antérieures » ; rapporte le vrai résultat 37 erreurs + la comparaison Itératif (3).
4. **Cell 42 (Conclusion)** : réécrite — table honnête (37/3 Medium), retire le démenti fabriqué « 37-45 is stale », corrige Leçon 1 (EP échoue partiellement sur Medium, pas « suffisante en pratique »), marque **Précompilé « non validé »** (Roslyn bug → issue dédiée #8287).
5. **Easy cells (c9/c14/c25) non touchés** : 0 erreur, conforme à la réalité, Easy n'était pas fabricé.

### Issue séparée ouverte : #8287

Le solveur **Précompilé** (cell 37) lève `System.MissingMethodException: Microsoft.CodeAnalysis.CSharp.CSharpCompilationOptions` — incompatibilité de version NuGet Roslyn (cell 32 importe `Microsoft.CodeAnalysis.CSharp` unpinned). **Bug distinct**, tracked dans #8287 (pin Roslyn + valider Précompilé). Hors scope de cette PR (honnêteté fabrication).

### Validation

- **Re-exec proof** : `nbconvert --execute --allow-errors` EXIT=0, 651KB, cells c19/c27 real outputs injectés (37/3 erreurs visibles dans les displays).
- **Validateur H.3** `validate_pr_notebooks.py` : **PASS** (16 code cells, `.net-csharp`).
- **C.1/C.3 audit** `audit_c1_c3.py --family Sudoku` : **0/0** (36 notebooks).
- **Solution-leak detector** : 0 leak sur Sudoku-15.
- **Probe banner** : 0 dans les outputs injectés (nbconvert headless).
- **Catalogue** byte-identique à main.
- **Diff chirurgical** : **+98/−467** (NET NÉGATIF — les outputs stale supprimés > les outputs réels + markdown ajoutés). 0 CRLF, `json.dumps(indent=1)` round-trip stable.

See #8278 (audit #8052 fabrication, classe doc-honesty). See #8287 (Précompilé Roslyn bug, distinct). Note infra : serveur MCP jupyter toujours wedgé → fallback `nbconvert --execute` (mémoire mcp-jupyter-hang).
