### PR TITLE
docs(search,#8081): Search-15-NetworkX canonical citations

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-15-NetworkX.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-15-NetworkX.ipynb
@@ -1751,7 +1751,22 @@
     "\n",
     "**Référence** : [Documentation officielle NetworkX](https://networkx.org/documentation/stable/)\n",
     "\n",
-    "**Livrable équivalent C#/.NET** : voir [issue #5082](https://github.com/jsboige/CoursIA/issues/5082) pour la parité Python ⇄ .NET avec **QuikGraph** (successeur maintenu de QuickGraph, NuGet) sous .NET Interactive."
+    "**Livrable équivalent C#/.NET** : voir [issue #5082](https://github.com/jsboige/CoursIA/issues/5082) pour la parité Python ⇄ .NET avec **QuikGraph** (successeur maintenu de QuickGraph, NuGet) sous .NET Interactive.",
+    "\n",
+    "\n",
+    "## Références\n",
+    "\n",
+    "Papiers fondateurs des algorithmes de graphe embarqués par NetworkX dans ce notebook :\n",
+    "\n",
+    "- **Dijkstra, E. W. (1959)**. *A Note on Two Problems in Connexion with Graphs*. Numerische Mathematik, 1:269–271. — L'algorithme de plus court chemin à poids non négatifs (`nx.shortest_path`, `dijkstra_path`).\n",
+    "- **Bellman, R. (1958)**. *On a Routing Problem*. Quarterly of Applied Mathematics, 16(1):87–90. — Bellman-Ford : plus court chemin avec poids négatifs (`nx.bellman_ford_path`), via la programmation dynamique.\n",
+    "- **Ford, L. R. & Fulkerson, D. R. (1962)**. *Flows in Networks*. Princeton University Press, pp. 130–134. — La théorie du flot maximum dont dérive Edmonds-Karp (`nx.maximum_flow`).\n",
+    "- **Edmonds, J. & Karp, R. M. (1972)**. *Theoretical Improvements in Algorithmic Efficiency for Network Flow Problems*. Journal of the ACM, 19(2):248–264. — La variante BFS polynomiale de Ford-Fulkerson (`nx.maximum_flow` avec méthode `edmonds-karp`).\n",
+    "- **Kamada, T. & Kawai, S. (1989)**. *An Algorithm for Drawing General Undirected Graphs*. Information Processing Letters, 31(1):7–15. — Le layout `kamada_kawai_layout` basé sur les distances de plus court chemin.\n",
+    "- **Hagberg, A., Schult, D. & Swart, P. (2008)**. *Exploring Network Structure, Dynamics, and Function using NetworkX*. Proceedings of the 7th Python in Science Conference (SciPy 2008), pp. 11–15. — La bibliothèque NetworkX elle-même (développée depuis 2004, utilisée tout au long de ce notebook).\n",
+    "\n",
+    "> **Documentation** : [NetworkX officielle](https://networkx.org/documentation/stable/).\n",
+    "> **Algorithmes A\\* et Floyd-Warshall** : approfondis dans [Search-2-Uninformed](Search-2-Uninformed.ipynb) (BFS, Dijkstra, Bellman-Ford) et [Search-3-Informed](Search-3-Informed.ipynb) (A\\*, heuristiques admissibles) — implémentations pédagogiques faites main.\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Audit fidélité **#8081** (axis: canonical citations) on Search/Part1-Foundations `Search-15-NetworkX.ipynb`. The notebook had **no formal References section**. The conclusion named the classic graph algorithms by name only (Dijkstra, Bellman-Ford, Floyd-Warshall, Edmonds-Karp, `kamada_kawai`, PageRank) and linked the NetworkX doc (singular "Reference") — but never resolved them into bibliographic entries. Classic axis-1: anchoring implicit, not formalised.

## Fix

Markdown-only (C.2 exception). **Single cell edit** (`md[40]`, the conclusion). Append a formal `## Références` section resolving **6 seminal papers verified firsthand** (author, year, title, venue, volume:pages) + the NetworkX library paper + a cross-reference to the dedicated algorithm notebooks in the series. Existing content (NetworkX doc link, QuikGraph .NET parity line) preserved byte-for-byte.

## References verified firsthand (2026-07-24, WebFetch Wikipedia + SciPy/NuGet)

| Paper | Venue | Anchor in notebook |
|-------|-------|--------------------|
| **Dijkstra (1959)** *A Note on Two Problems in Connexion with Graphs* | *Numerische Mathematik* 1:269–271 | `dijkstra_path` shortest path |
| **Bellman (1958)** *On a Routing Problem* | *Q. Appl. Math.* 16(1):87–90 | Bellman-Ford, negative weights |
| **Ford & Fulkerson (1962)** *Flows in Networks* | Princeton UP, pp. 130–134 | Max-flow theory (→ Edmonds-Karp) |
| **Edmonds & Karp (1972)** *Theoretical Improvements…* | *JACM* 19(2):248–264 | `maximum_flow` (edmonds-karp) |
| **Kamada & Kawai (1989)** *An Algorithm for Drawing General Undirected Graphs* | *Inf. Process. Lett.* 31(1):7–15 | `kamada_kawai_layout` |
| **Hagberg, Schult & Swart (2008)** *Exploring Network Structure…NetworkX* | *SciPy 2008*, pp. 11–15 | NetworkX library itself |

> **Not fabricated**: Floyd 1962, Warshall 1962, Hart-Nilsson-Raphael 1968 (A\*), PageRank — **not verified firsthand this cycle** → deliberately omitted from the formal section (A\* is cross-referenced to `Search-3-Informed`). Honest over fabricated.

## Validation

- **+16/-1**, only cell 40 changed (markdown-only); **all code cells byte-identical** (untouched)
- **0 CRLF**, LF-only, `json.dumps(indent=1, ensure_ascii=False) + "\n" == raw`
- **catalog byte-identical to main** (no catalog-regen on branch)
- **H.3 validator 1/1 PASS** (21 cells), 0 NotImplementedException
- **Markdown-only → no re-exec needed** (C.2 exception)
- **NOT a registered twin** (Search-1..3 only) → no twin-parity complication

New family (Search/Part1-Foundations) = R6 family rotation. Genre: canonical citations (#8081 axis-1).

See #8081 (partial, epic ouverte).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
