### PR TITLE
docs(gametheory,#8081): GT-7 ExtensiveForm canonical citations

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-7-ExtensiveForm.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-7-ExtensiveForm.ipynb
@@ -1770,7 +1770,20 @@
     "\n",
     "La conversion entre forme extensive et forme normale a mis en evidence un phenomene important : la representation extensive est plus parcimonieuse, car la forme normale peut exploser exponentiellement en fonction du nombre de noeuds de decision. Le jeu d'entree sur le marche a également souleve la question des menaces non credibles, que la forme extensive detecte mais ne resout pas formellement.\n",
     "\n",
-    "Le notebook suivant plonge dans la théorie des jeux combinatoires avec le celebre theoreme de Sprague-Grundy : [GameTheory-8-CombinatorialGames](GameTheory-8-CombinatorialGames.ipynb)."
+    "Le notebook suivant plonge dans la théorie des jeux combinatoires avec le celebre theoreme de Sprague-Grundy : [GameTheory-8-CombinatorialGames](GameTheory-8-CombinatorialGames.ipynb).",
+    "\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## Références\n",
+    "\n",
+    "Papiers fondateurs de la théorie des jeux sous forme extensive :\n",
+    "\n",
+    "- **Kuhn, H. W. (1953)**. *Extensive Games and the Problem of Information*. In Kuhn & Tucker (eds.), *Contributions to the Theory of Games, Volume II*, Annals of Mathematics Studies 28, Princeton University Press, pp. 193–216. — La formalisation moderne des jeux sous forme extensive (ensembles d'information, stratégies comportementales, théorème d'équivalence §3.3).\n",
+    "- **Nash, J. F. (1950)**. *Equilibrium Points in N-Person Games*. Proceedings of the National Academy of Sciences, 36(1):48–49. — L'existence d'équilibre (le concept résolu ici sur l'arbre de jeu).\n",
+    "- **Nash, J. F. (1951)**. *Non-Cooperative Games*. Annals of Mathematics, 54(2):286–295. — La démonstration d'existence via point fixe (prix Nobel d'économie 1994).\n",
+    "\n",
+    "> **Note** : la backward induction (solution des jeux à information parfaite) remonte à **Zermelo (1913)** sur le jeu d'échecs, et la sélection d'équilibres parfaits en sous-jeux à **Selten (1965)** — non reproduites ici faute de vérification bibliographique firsthand ce cycle.\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary

Audit fidélité **#8081** (axis: canonical citations) on `GameTheory-7-ExtensiveForm.ipynb`. The notebook had **no formal References section**. It teaches extensive-form games (Kuhn theorem §3.3), information sets, behavioral strategies, backward induction, non-credible threats, and Nash equilibrium on the game tree (Kuhn Poker) — all by concept/name, never resolved into bibliographic entries. Classic axis-1.

## Fix

Markdown-only (C.2 exception). **Single cell edit** (`md[29]`, the conclusion). Append a formal `## Références` section resolving **3 seminal papers verified firsthand**. Navigation line preserved byte-for-byte.

## References verified firsthand (2026-07-24)

| Paper | Venue | Anchor in notebook |
|-------|-------|--------------------|
| **Kuhn (1953)** *Extensive Games and the Problem of Information* | *Contrib. Theory of Games II*, Annals Math Studies 28, Princeton, pp. 193–216 | Formalisation of extensive form + information sets (§3.3) |
| **Nash (1950)** *Equilibrium Points in N-Person Games* | *PNAS* 36(1):48–49 | Equilibrium existence on the game tree |
| **Nash (1951)** *Non-Cooperative Games* | *Annals of Mathematics* 54(2):286–295 | Fixed-point existence proof (Nobel 1994) |

> **Not verified firsthand → deliberately omitted** (honest over fabricated): Zermelo 1913 (backward induction / chess) and Selten 1965 (subgame-perfect equilibrium). Zermelo's proceedings could not be confirmed firsthand this cycle (SearXNG rate-limited); Selten is not named in the notebook. Both are acknowledged in a `> Note` blockquote pointing to them, without a formal (unverified) citation.

## Validation

- **+14/-1**, only cell 29 changed (markdown-only); **13 code cells byte-identical** (untouched)
- **0 CRLF**, LF-only; format `json.dumps(indent=1, ensure_ascii=False) + "\n" == raw` (auto-detected)
- **catalog byte-identical to main**; **rebased onto fresh origin/main** (2b77a57e9)
- **H.3 validator 1/1 PASS** (13 cells, python3), 0 NotImplementedException
- **Markdown-only → no re-exec needed** (C.2 exception)
- **NOT a registered twin** (GameTheory absent from twin register) → no twin-parity complication

Genre: canonical citations (#8081 axis-1).

See #8081 (partial, epic ouverte).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
