### PR TITLE
fix(iit-2-pyphi,#8052): correct categorical 'pure XOR -> Phi=0' vs committed Phi=1.875 (markdown-only)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb
+++ b/MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb
@@ -1038,7 +1038,7 @@
     "\n",
     "Nous construisons un reseau a 4 noeuds en anneau ou chaque noeud depend de ses voisins via des portes **non-lineaires** (AND, OR). C'est l'occasion d'illustrer un point theorique central de l'IIT.\n",
     "\n",
-    "**Pourquoi la non-linearite est-elle essentielle ?** Un reseau purement XOR (addition modulo 2) est une application **lineaire** sur le corps $GF(2)$ : il se decompose parfaitement en sous-reseaux independants, et l'IIT lui attribue $\\Phi = 0$ a tous les etats. L'integration irreductible ($\\Phi > 0$) exige des portes non-lineaires qui melangent reellement l'information de leurs entrees. Autrement dit : **sans non-linearite, pas d'unite irreductible, donc pas de conscience**. C'est pourquoi nous utilisons ici un melange de portes AND et OR plutot qu'un anneau XOR pur."
+    "**Pourquoi munir le 4-noeuds de portes AND/OR ?** Écartons d'abord une idee recue : « un reseau purement XOR implique $\\Phi = 0$ » n'est **pas** une regle generale. L'anneau XOR a 3 noeuds du §1 est bien une application **lineaire** sur $GF(2)$ (le XOR = addition modulo 2), mais il est recurrent et entierement connecte, donc **non decomposable** : PyPhi lui attribue $\\Phi = 1{,}875$ (cf. cellule 5 et le notebook IIT-1). La linearite sur $GF(2)$ n'implique donc pas mecaniquement $\\Phi = 0$.\n"
    ]
   },
   {
@@ -1292,7 +1292,7 @@
     "1. **Plus de noeuds ne signifie pas plus de Phi** : la valeur de $\\Phi$ depend de la structure causale (non-linearite, integration), pas de la taille brute\n",
     "2. **Les reseaux feed-forward ont Phi = 0** : pas de boucle causale = pas d'integration (voir l'Exercice 3)\n",
     "3. **Les reseaux recurrents peuvent avoir Phi > 0** : notre anneau non-lineaire exhibe une integration irreductible — CES non-vide, $\\Phi > 0$, et une vraie coupe MIP (pas un `NullCut`)\n",
-    "4. **La linearite detruit l'integration** : si l'on remplaçait les portes AND/OR par des XOR purs, le reseau deviendrait lineaire sur $GF(2)$, parfaitement decomposable, et son $\\Phi$ s'effondrait a 0 — c'est le piege evite au §6.1\n",
+    "4. **Decomposabilite topologique et effondrement de $\\Phi$** : a l'inverse du 3-noeuds ($\\Phi = 1{,}875$), l'anneau 4-noeuds de cette section a une connectivite **bipartite** ({A, D} d'un cote, {B, C} de l'autre). Muni de portes XOR pures, cette topologie se revele **parfaitement decomposable** et son Big Phi s'effondre a **0** (verifie empiriquement : Big Phi = 0.000000 sur les etats testes). Les portes AND/OR evitent ce piege en preservant l'irreductibilite. La lecon : ce n'est pas la linearite *en soi* qui detruit l'integration (le XOR 3-noeuds l'atteint a 1.875), c'est la **decomposabilite topologique** qu'elle autorise sur certaines structures — d'ou l'interet des portes non-lineaires AND/OR sur ce 4-noeuds.",
     "5. **La symetrie** de la connectivite influence la distribution des concepts"
    ]
   },


### PR DESCRIPTION
Grain: MED/notebook-python-audit-claims — lane myia-po-2024:CoursIA-2 — prev: MED/docs-hub-resync (c.845)

## Contexte

3ᵉ famille pilote de l'audit claims↔outputs #8052 (après Sudoku c.818 PR #8176 et Search/Part4 c.845 PR #8290), sur le steer user explicite de #8052 : « Prochain proposé : **IIT-PyPhi** (phi values) ». Audit de fidélité markdown ↔ sorties committées sur les 3 notebooks IIT.

## Finding (firsthand, G.1)

`IIT-2-AdvancedTopics.ipynb` cell#24 §6.1 portait une claim **catégorique fausse** :

> « Un réseau purement XOR […] l'IIT lui attribue $\Phi = 0$ à tous les états. […] **sans non-linéarité, pas d'unité irréductible, donc pas de conscience**. »

Cette claim **contredit les sorties committées du notebook lui-même** : la cell#5 calcule `Big Phi: 1.874999` pour `pyphi.examples.xor_network()` (l'anneau XOR canonique à 3 nœuds, utilisé dans tout IIT-1 et §1 de IIT-2). L'exemple `xor_network()` des auteurs de pyphi est précisément l'exemple-manuel d'un réseau XOR atteignant $\Phi > 0$ — la claim « XOR pur ⇒ Φ=0 » est doublement fausse (contredit le calcul ET la raison d'être de l'exemple).

**Re-vérification firsthand (pyphi 1.2.0, shim collections.abc pour py3.13, mono-cœur)** :

| Réseau | Big Phi (mesuré) |
|---|---|
| Anneau XOR 3 nœuds `pyphi.examples.xor_network()`, états (0,0,0)/(1,1,0)/(0,1,1) | **1.875000** (confirme cell#5) |
| Anneau XOR **4 nœuds** (cm bipartite de cell#25, portes XOR pures), états (1,1,0,0)/(0,0,0,0)/(1,1,1,1) | **0.000000** |

→ **Nuance cruciale (G.9)** : la claim est fausse **comme énoncé catégorique** (3-nœuds = 1.875), MAIS la claim associée cell#25-comment + cell#28-pt.4 (« le 4-nœuds en XOR pur → Φ=0 ») est **vraie** pour la topologie 4-nœuds spécifique (cm bipartite `{A,D}|{B,C}` → se décompose → Φ=0). La différence entre les deux anneaux est **topologique** (décomposabilité), pas « linéarité vs non-linéarité » : le XOR 3-nœuds est linéaire sur GF(2) mais récurrent/connecté donc non-décomposable (Φ=1.875).

## Changement (markdown-only, byte-surgical)

2 cellules markdown corrigées (+2/−2) :

1. **cell#24** : la claim catégorique « sans non-linéarité, pas d'unité irréductible » est remplacée par la nuance vérifiée — l'anneau XOR 3-nœuds est linéaire sur GF(2) mais **non décomposable** (Φ=1.875, cf. cell#5), donc la linéarité n'implique pas mécaniquement Φ=0.
2. **cell#28 pt.4** : reformulée en « décomposabilité topologique » — attribue l'effondrement Φ=0 du 4-nœuds XOR à sa **connectivité bipartite** (vérifié firsthand : Big Phi=0.000000), et pose la vraie leçon (décomposabilité topologique, pas linéarité en soi), cohérente avec cell#24.

**Non touché (délibéré)** :
- **cell#25 code comment** (« un anneau purement XOR […] Big Phi = 0 ») : lu **dans son contexte 4-nœuds**, cette claim est **correcte** (vérifié). Laissé inchangé pour éviter une edit de cellule code (qui exigerait une re-exec C.2 complète) ; la clarification catégorique est désormais portée par cell#24 juste au-dessus. Note : cell#25 et le commentaire préservent leur cohérence avec la cell#28 pt.4 reformulée.
- **IIT-1-IntroToPyPhi.ipynb** : audité **CLEAN**. Toutes les claims markdown (cell#15 Φ=1.87500 sur 3 états ; cell#18 table sym 4 états / asym « de 0,81 à 2,74 » / 8 valeurs ; cell#27 purview effect {A,B}→(C,) ; cell#29 « 10 liens α=1.0 » + titre transition (1,1,1)→(0,0,0) = code cell#30 exact ; cell#33 « α 0.13 à 0.92 » ; cell#25 « petit phi 0.5 ») **concordent** avec les sorties committées (cell#10 1.874999, cell#14 1.87500×3, cell#17 8 distinctes [0.8073..2.7431], cell#22 3 concepts, cell#24 φ=0.5, cell#30 10 liens, cell#32 9 liens α 0.1285..0.922).
- **IIT-3-CoarseGrainingMacroPhi.ipynb** : audité **CLEAN**. Φ micro=0 correctement cité (cell#4 output 0.0000, cell#5/18 MD) pour le réseau copy dégénéré ; EI=1.0 cité correctement ; cell#12 « Interprétation honnête » corrige même explicitement une méprise (bonne pédagogie).

## Vérification (firsthand, G.1)

- **Re-exec pyphi firsthand** : pyphi 1.2.0 + shim `collections.abc` (py3.13) + `NUMBER_OF_CORES=1` (anti-spawn Windows). 3-nœuds XOR → 1.875000 (×3 états), 4-nœuds XOR → 0.000000 (×3 états). Confirme cell#5 ET la claim 4-nœuds de cell#25/28.
- **Diff byte-surgical** +2/−2, 1 fichier, 2 éléments markdown source. 0 cellule code modifiée → C.2 exception markdown-only (outputs précédents valides, inchangés).
- **H.3** `validate_pr_notebooks.py` PASS (19 code cells, kernel pyphi). **nbformat.validate** OK (40 cells). **C.1** 0 `raise NotImplementedError`/`assert False`/`1/0`. 0 cellule `ec=null ∧ ¬outputs`.
- **L898 cleared** : 0 PR ouverte ne touche `IIT-2-AdvancedTopics.ipynb` (les 2 hits "IIT" en search = cross-refs body Probas #8280 / Sudoku #8291, hors IIT).
- **Base fraîche** : 1 commit behind origin/main (catalog cron `[skip ci]` uniquement, pas de conflit).

## Hors-scope (signalé)

- **cell#25 code comment** : porte la même claim « XOR → Φ=0 » mais **correcte en contexte 4-nœuds** (vérifié). Non édité (évite re-exec C.2) ; grain séparé si on veut harmoniser le commentaire avec la nuance catégorique (nécessiterait re-exec papermill kernel pyphi).
- **pyphi 1.2.0 / py3.13** : la lib ne s'importe pas nativement sur Python 3.13 (`from collections import Iterable`, retiré en 3.10). Shim `collections.abc` appliqué pour la vérification. Si re-exec notebook complète voulue à l'avenir, un env python <3.10 dédié (ou upstream patch pyphi) serait préférable (règle F).

See #8052
