### PR TITLE
fix(probas-decpymc,#8052): DecPyMC-5 align EVSI table + note with committed outputs

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-5-Value-Information.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-5-Value-Information.ipynb
@@ -2864,10 +2864,10 @@
     "\n",
     "| Sensibilite | EVSI | Efficacite EVSI/EVPI |\n",
     "|-------------|------|---------------------|\n",
-    "| 50% (aléatoire) | Faible | ~10-20% |\n",
+    "| 50% (aléatoire) | 0.0k EUR | 0% |\n",
     "| 80% (test actuel) | 23k EUR | 26% |\n",
-    "| 90% | Croissance rapide | ~40-50% |\n",
-    "| 99% | Proche de EVPI | >90% |\n",
+    "| 90% | Croissance rapide | ~40% |\n",
+    "| 99% | 40.1k EUR | 45% |\n",
     "\n",
     "**Point cle** : La croissance est **concave** -- les gains marginaux diminuent a mesure que\n",
     "la precision augmente. Passer de 50% a 70% apporte un gain substantiel, tandis que passer\n",
@@ -2875,7 +2875,7 @@
     "des rendements decroissants.\n",
     "\n",
     "> **Note technique** : L'efficacité EVSI/EVPI depend aussi de la specificite du test et de\n",
-    "> la structure de la matrice d'utilite. Un test a 80% de sensibilite peut capturer 90% de\n",
+    "> la structure de la matrice d'utilite. Un test a 80% de sensibilite peut capturer environ 26% de\n",
     "> l'EVPI si les enjeux financiers sont bien alignes avec les résultats du test."
    ]
   },


### PR DESCRIPTION
## Summary

Markdown-only doc-honesty fix (`#8052` Stop & Repair) for `DecPyMC-5-Value-Information.ipynb` cell 66 (id `71a7f150`): the EVSI interpretation table and its pedagogical note contradicted the committed cell outputs. The outputs are the source of truth; the markdown prose is aligned to them. **No code cell, no output, no `execution_count` touched.**

## Ground truth (cell 65 `c752eb51` committed output)

```
EVPI de reference : 90k EUR
A sensibilite 50% : EVSI = 0.0k (0% de EVPI)
A sensibilite 99% : EVSI = 40.1k (45% de EVPI)
```

## Changes (4 lines, all in cell 66 markdown)

| Row | Before | After | Why |
|-----|--------|-------|-----|
| 50% (aléatoire) | `~10-20%` | `0.0k EUR / 0%` | output: 0.0k (0%) |
| 90% | `~40-50%` | `~40%` | efficiency monotonic in sensitivity; 99% caps at 45% → 90% cannot reach 50% |
| 99% | `>90%` | `40.1k EUR / 45%` | output: 40.1k (45%) |
| note | `80% capture 90% de l'EVPI` | `80% capture environ 26%` | aligns to the table's own 80%→26% row (internal contradiction removed) |

## Verification

- **G.1 firsthand**: read cells 23/24/65/66 directly (code source + outputs) before editing.
- **H.3 validator**: `validate_pr_notebooks.py` PASS (29 code cells, `execution_count != null`, outputs coherent).
- **Diff scope**: `git diff --stat` = 4 insertions / 4 deletions, all markdown source lines.
- **JSON**: valid (`json.load` succeeds).
- **Not a registered twin** (`grep DecPyMC-5 twin_pairs.yaml` = 0) → no rebaseline.
- **No collision**: `gh pr list --state all --search DecPyMC-5` — #8279 touches DecPyMC-4 (different notebook), #8283 = Z3, #8291 = Sudoku-15.

## Out of scope (deferred — code-correctness, not markdown-only)

Cell 24 (`6e2e1b00`) EVPI formula prose states `(N-1)/N*(valeur-cout) → valeur-cout`. The cell's **own table** (N=5→80) disproves this: it matches `valeur*(N-1)/N = 80`, not `(valeur-cout)*4/5 = 72`. However the cell 23 print statement *also* claims `converge vers valeur_tresor-cout_fouille = 90` (wrong — actual limit is `valeur = 100` per the 80/95/98 trend, since `cout` cancels in `EU_info - EU_sans`). Fixing the markdown formula alone would then contradict that committed print output → this is a **code-correctness bug** (wrong print statement) requiring a code edit + re-execution, left for a separate PR.

See #8052. No `Closes` (epic sub-grain, partial delivery).