### PR TITLE
fix(pymc-15,#8081): fill unfilled {moyenne}/{ecart_type} template placeholders in md[8] stats table

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-15-Recommenders.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-15-Recommenders.ipynb
@@ -281,8 +281,8 @@
     "| Statistique | Valeur |\n",
     "|-------------|--------|\n",
     "| Observations | 8 sur 20 possibles (40%) |\n",
-    "| Moyenne | {moyenne} |\n",
-    "| Ecart-type | {ecart_type} |"
+    "| Moyenne | 3.38 |\n",
+    "| Ecart-type | 1.32 |"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Fix a doc-honesty defect found via the #8081 distillation-fidelity audit (po-2024 firsthand sweep of unaudited PyMC notebooks): `PyMC-15-Recommenders.ipynb` md[8] (the data-interpretation stats table) had **two unfilled Python template placeholders committed as literal text**:

```markdown
| Moyenne | {moyenne} |          ← literal {moyenne}, never f-string-substituted
| Ecart-type | {ecart_type} |   ← literal {ecart_type}
```

The intended f-string wiring was never completed, so readers see raw `{moyenne}` / `{ecart_type}` instead of values.

### Fix (markdown-only, C.2 exception)

Filled with the real values computed from the **fixed hardcoded observation array** in code[7] (`rating_obs = [5,3,4,1,4,5,2,3]`):

| Stat | Value |
|------|-------|
| Moyenne | **3.38** (`numpy.mean`) |
| Écart-type | **1.32** (`numpy.std`, population, ddof=0) |

No re-exec needed — the data is hardcoded (not sampled), so the values are deterministic and reproducible. The existing observation-count claim (`8 sur 20 possibles (40%)`) is correct and unchanged.

## Why not re-exec

C.2 exception for markdown-only edits: the values derive from a fixed hardcoded array (code[7]), not from a stochastic run. `python3 -c "import numpy as np; r=np.array([5,3,4,1,4,5,2,3]); print(r.mean(), r.std())"` → `3.38 1.32`. The cell outputs are otherwise untouched.

## Twin-parity

`PyMC-15-Recommenders` is a registered twin of `Infer-15-Recommenders`. Infer-15 has a **different stats table** (Users/Items/Observations/Traits — no Moyenne/Écart-type rows), so filling these rows introduces **no parity divergence**. Infer-15 was not edited.

## Validation

- `git diff --stat`: `+2/-2`, only md[8] lines 5-6 changed
- H.3 / C.1: 0 violations (58 cells, 0 null-exec, 0 voluntary-error patterns)
- 0 CRLF introduced (format auto-probed: `indent=1, ensure_ascii=False, trailing_nl=True`)
- Catalogue byte-identical to main (no `COURSE_CATALOG.generated.*` touched)
- All other 57 cells byte-identical (round-trip self-check passed)

See #8081 (distillation-fidelity audit — PyMC-15 was unaudited; this fills a real gap, not a cosmetic one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
