### PR TITLE
ci(solution-leak,#8053): wire semantic solution-leak detector as WARN-mode HIGH-delta gate

### DIFF
--- a/.github/workflows/solution-leak-guard.yml
+++ b/.github/workflows/solution-leak-guard.yml
@@ -1,0 +1,90 @@
+name: solution-leak-guard
+
+# Advisory (WARN-phase) guard for the "Exercice cell containing its solution"
+# academic-integrity vector (issue #8053, parent epic #4208). Mirrors the
+# pip-leak-guard HIGH-delta pattern (#6314) but runs in WARN mode: it reports
+# only HIGH-severity solution-leak findings *newly introduced* by the PR (vs
+# its base ref), and NEVER fails.
+#
+# Why WARN, not FAIL (acceptance #8053: "Mode WARN d'abord, puis bascule FAIL
+# une fois le backlog nettoyé"):
+#   - the detector (scripts/notebook_tools/audit_solution_leaks.py) currently
+#     emits ~498 function_body_leak findings across the repo, the large
+#     majority of which are legitimate worked examples (functions with >3 logic
+#     lines that are guided examples, not exercise stubs with their solution
+#     pasted in). Precision on C#/.NET+Lean is known low (~95% FP, fleet memory
+#     solution-leak-detector-csharp-lean-fp; retracted for `// TODO` c.827).
+#   - an absolute FAIL would therefore block the whole cluster. The delta +
+#     WARN form posts an advisory summary a reviewer reads, without freezing.
+#   - the FAIL switch (a future --fail-on-delta flag on solution_leak_delta.py)
+#     is gated on a detector-precision fix and backlog drain, tracked out of
+#     scope here.
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '**.ipynb'
+      - 'scripts/notebook_tools/audit_solution_leaks.py'
+      - 'scripts/notebook_tools/solution_leak_delta.py'
+      - '.github/workflows/solution-leak-guard.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: solution-leak-guard-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  solution-leak-delta:
+    name: "Solution-leak HIGH delta (WARN phase, #8053)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # base ref must be reachable for the BASE scan
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: HEAD scan (PR head)
+        run: |
+          python scripts/notebook_tools/audit_solution_leaks.py --json > /tmp/head.json
+
+      # Swap MyIA.AI.Notebooks/ to the PR base ref, scan, then restore. head.json
+      # is already captured above, so the swap cannot contaminate the delta.
+      - name: BASE scan (PR base ref)
+        if: github.event_name == 'pull_request'
+        run: |
+          git checkout ${{ github.event.pull_request.base.sha }} -- MyIA.AI.Notebooks
+          python scripts/notebook_tools/audit_solution_leaks.py --json > /tmp/base.json
+          git checkout HEAD -- MyIA.AI.Notebooks
+
+      - name: "Report HIGH delta (WARN — never fails)"
+        if: github.event_name == 'pull_request'
+        run: |
+          {
+            echo "## Solution-leak HIGH delta (WARN phase, #8053)"
+            echo ""
+            echo "_Advisory only — this check does NOT fail the PR. Lists HIGH "
+            "solution-leak candidates newly introduced by this PR vs its base ref. "
+            "Detector candidates, not auto-verdicts: verify by CONTENT "
+            "(cf exercise-example-labeling.md) — a guided example is legitimate._"
+            echo ""
+            python scripts/notebook_tools/solution_leak_delta.py /tmp/base.json /tmp/head.json
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # workflow_dispatch (no base ref): single scan, full markdown report to summary.
+      - name: "Full inventory (manual dispatch)"
+        if: github.event_name != 'pull_request'
+        run: |
+          {
+            echo "## Solution-leak audit (manual dispatch)"
+            echo ""
+            python scripts/notebook_tools/audit_solution_leaks.py
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/solution-leak-guard.yml
+++ b/.github/workflows/solution-leak-guard.yml
@@ -71,10 +71,10 @@ jobs:
           {
             echo "## Solution-leak HIGH delta (WARN phase, #8053)"
             echo ""
-            echo "_Advisory only — this check does NOT fail the PR. Lists HIGH "
-            "solution-leak candidates newly introduced by this PR vs its base ref. "
-            "Detector candidates, not auto-verdicts: verify by CONTENT "
-            "(cf exercise-example-labeling.md) — a guided example is legitimate._"
+            echo "_Advisory only — this check does NOT fail the PR. Lists HIGH"
+            echo "solution-leak candidates newly introduced by this PR vs its base ref."
+            echo "Detector candidates, not auto-verdicts: verify by CONTENT"
+            echo "(cf exercise-example-labeling.md) — a guided example is legitimate._"
             echo ""
             python scripts/notebook_tools/solution_leak_delta.py /tmp/base.json /tmp/head.json
           } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/notebook_tools/audit_solution_leaks.py
+++ b/scripts/notebook_tools/audit_solution_leaks.py
@@ -7,6 +7,7 @@ Detects 3 patterns per issue #362:
 3. Pre-resolved cells: # Solution / # Exemple resolu with complete answers
 """
 
+import argparse
 import json
 import sys
 import re
@@ -345,13 +346,15 @@ def audit_notebook(path):
     return all_leaks
 
 
-def main():
+def _run_audit():
+    """Scan all notebooks and return (output_dict, notebook_count).
+
+    Shared by the human-readable report (default) and the ``--json`` machine
+    output consumed by ``solution_leak_delta.py`` (CI WARN-mode gate, #8053).
+    """
     notebooks = list(NOTEBOOKS_DIR.rglob('*.ipynb'))
     notebooks = [n for n in notebooks if '_output' not in n.name and '_executed' not in n.name
                  and '.ipynb_checkpoints' not in str(n)]
-
-    print(f"Auditing {len(notebooks)} notebooks for solution leaks...")
-    print()
 
     results = {}
     total_leaks = {
@@ -367,7 +370,41 @@ def main():
             for leak in leaks:
                 total_leaks[leak['type']] = total_leaks.get(leak['type'], 0) + 1
 
-    # Report
+    output = {
+        'total_notebooks': len(notebooks),
+        'notebooks_with_leaks': len(results),
+        'leak_counts': total_leaks,
+        'findings': {k: v for k, v in results.items()},
+    }
+    return output, len(notebooks)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Audit solution leaks in pedagogical notebooks (issue #362, #8053 CI gate)."
+    )
+    parser.add_argument(
+        '--json', action='store_true',
+        help="Emit the findings dict as a single JSON document on stdout (for "
+             "solution_leak_delta.py CI consumption). Suppresses the markdown "
+             "report and the results-file write.",
+    )
+    args = parser.parse_args(argv)
+
+    output, nb_count = _run_audit()
+
+    if args.json:
+        # Machine output for CI delta comparison. No file write, no human report.
+        json.dump(output, sys.stdout, indent=2, ensure_ascii=False, default=str)
+        sys.stdout.write('\n')
+        return
+
+    # --- human-readable report (default, unchanged behaviour) ---
+    total_leaks = output['leak_counts']
+    results = output['findings']
+
+    print(f"Auditing {nb_count} notebooks for solution leaks...")
+    print()
     print(f"## Audit Results: {len(results)} notebooks with findings")
     print(f"Total: function_body_leak={total_leaks.get('function_body_leak', 0)}, "
           f"commented_solution_leak={total_leaks.get('commented_solution_leak', 0)}, "
@@ -402,14 +439,6 @@ def main():
                     leak_desc += f" L{leak['start_line']}"
                 print(leak_desc)
             print()
-
-    # JSON output for further processing
-    output = {
-        'total_notebooks': len(notebooks),
-        'notebooks_with_leaks': len(results),
-        'leak_counts': total_leaks,
-        'findings': {k: v for k, v in results.items()},
-    }
 
     output_path = REPO_ROOT / 'audit_solution_leaks_results.json'
     with open(output_path, 'w', encoding='utf-8') as f:

--- a/scripts/notebook_tools/solution_leak_delta.py
+++ b/scripts/notebook_tools/solution_leak_delta.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Solution-leak delta guard — compare two ``audit_solution_leaks.py --json``
+scans and report HIGH-severity findings *newly introduced* by a PR.
+
+Why a delta AND a WARN mode (not an absolute FAIL)
+-------------------------------------------------
+``audit_solution_leaks.py`` currently emits ~498 ``function_body_leak`` findings
+across the repo, the large majority of which are legitimate worked examples
+(functions with >3 logic lines that are *guided examples*, not student-exercise
+stubs with their solution pasted in). The detector's precision on C#/.NET+Lean
+is known low (~95% false-positive rate, fleet memory
+``solution-leak-detector-csharp-lean-fp``; retracted for ``// TODO`` c.827).
+
+An **absolute** gate would therefore (a) post a scary "497 leaks!" inventory on
+every PR and (b) block the whole cluster once flipped to FAIL. Both are wrong.
+
+The durable transposition, per issue #8053 acceptance "Mode WARN d'abord
+(inventaire), puis bascule FAIL une fois le backlog nettoyé", is a **delta guard
+in WARN mode**:
+
+* compare HIGH findings on BASE vs HEAD, keyed by (path, type, func_name,
+  cell_index, start_line) so unchanged inherited findings never count;
+* report only the HIGH findings HEAD has that BASE does not (newly introduced
+  / worsened by THIS PR) — a typical PR touches 1-7 notebooks, so the delta is
+  compact and reviewer-actionable;
+* **never fail** (exit 0) in this phase — the output is advisory, posted to the
+  GitHub Actions job summary. The FAIL switch is gated on a detector-precision
+  fix (reduce C#/.NET+Lean FP, restore ``// TODO`` discrimination) tracked
+  separately and explicitly out of scope here.
+
+Usage (driven by ``.github/workflows/solution-leak-guard.yml``)::
+
+    python scripts/notebook_tools/audit_solution_leaks.py --json > head.json
+    git checkout baseref -- MyIA.AI.Notebooks
+    python scripts/notebook_tools/audit_solution_leaks.py --json > base.json
+    git checkout HEAD -- MyIA.AI.Notebooks
+    python scripts/notebook_tools/solution_leak_delta.py base.json head.json
+
+Exit codes: 0 always (WARN phase). A future ``--fail-on-delta`` flag will flip
+to exit 1 once precision is fixed and the backlog is drained.
+
+See #8053 (CI gate), #8052 (audit sampling), exercise-example-labeling.md
+(content-based rule), pip_leak_delta.py (mirror pattern, #6314).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+# Only HIGH-severity findings participate in the delta. MEDIUM/LOW/FLAG (C#
+# candidates) are excluded: FLAG is explicitly manual-review-only and MEDIUM/LOW
+# carry too much noise for an advisory gate. This mirrors pip_leak_delta.py
+# restricting to HIGH_CLASSIFICATIONS.
+DELTA_SEVERITY = "HIGH"
+
+
+def _fingerprint(path, leak):
+    """Stable identity for a finding so an unchanged inherited leak is not
+    double-counted across BASE and HEAD. ``context`` (the raw source lines) is
+    intentionally excluded: a reviewer-touched comment or whitespace tweak would
+    otherwise create a phantom 'new' finding for the same logical leak."""
+    return (
+        path,
+        leak.get("type"),
+        leak.get("func_name"),
+        leak.get("cell_index"),
+        leak.get("start_line"),
+    )
+
+
+def _high_findings(data):
+    """Yield (path, fingerprint, leak) for every HIGH finding in a parsed
+    audit_solution_leaks JSON document. Findings are de-duplicated on
+    fingerprint (the base detector can emit the same function twice — e.g.
+    ``inheritance_value`` cell 47 listed 2x — which would otherwise inflate the
+    delta)."""
+    findings = data.get("findings", {}) if isinstance(data, dict) else {}
+    seen = set()
+    for path, leaks in findings.items():
+        for leak in leaks:
+            if leak.get("severity") != DELTA_SEVERITY:
+                continue
+            fp = _fingerprint(path, leak)
+            if fp in seen:
+                continue
+            seen.add(fp)
+            yield path, fp, leak
+
+
+def _high_set(data):
+    """map(fingerprint -> leak) for HIGH findings (deduplicated)."""
+    return {fp: leak for _path, fp, leak in _high_findings(data)}
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Report HIGH solution-leak findings introduced by HEAD vs BASE (WARN mode, #8053)."
+    )
+    parser.add_argument("base", help="BASE JSON (audit_solution_leaks.py --json)")
+    parser.add_argument("head", help="HEAD JSON (audit_solution_leaks.py --json)")
+    args = parser.parse_args(argv)
+
+    try:
+        with open(args.base, encoding="utf-8") as fh:
+            base = json.load(fh)
+        with open(args.head, encoding="utf-8") as fh:
+            head = json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"error: cannot read JSON inputs: {exc}", file=sys.stderr)
+        return 2
+
+    base_map = _high_set(base)
+    head_map = _high_set(head)
+    base_n = len(base_map)
+    head_n = len(head_map)
+
+    # New = fingerprints present in HEAD but absent in BASE.
+    new_fps = [fp for fp in head_map if fp not in base_map]
+    delta = len(new_fps)
+
+    print(f"solution-leak guard (WARN phase): BASE HIGH={base_n}  HEAD HIGH={head_n}  new={delta}")
+    print(
+        "WARN-only (exit 0): inherited HIGH findings tolerated; only newly-introduced "
+        "HIGH findings are listed below. FAIL switch gated on detector-precision fix "
+        "(C#/.NET+Lean FP, // TODO discrimination) — see #8053."
+    )
+
+    if delta > 0:
+        print()
+        print(f"### {delta} newly-introduced HIGH solution-leak candidate(s)")
+        print()
+        print(
+            "_These are detector candidates, not auto-verdicts. A HIGH "
+            "`function_body_leak` flags a function with >3 logic lines found under "
+            "an Exercice marker — verify by CONTENT (cf exercise-example-labeling.md): "
+            "a guided example (Exemple resolu) is legitimate and must NOT be stubbed._"
+        )
+        print()
+        # Group new findings by notebook path for readability.
+        by_path = {}
+        for fp in new_fps:
+            path = fp[0]
+            by_path.setdefault(path, []).append(head_map[fp])
+        for path in sorted(by_path):
+            print(f"**{path}**")
+            for leak in by_path[path]:
+                desc = f"- [{leak.get('type')}]"
+                if leak.get("func_name"):
+                    desc += f" `{leak['func_name']}`"
+                if leak.get("logic_lines") is not None:
+                    desc += f" ({leak['logic_lines']} logic lines)"
+                if leak.get("cell_index") is not None:
+                    desc += f" cell {leak['cell_index']}"
+                if leak.get("start_line") is not None:
+                    desc += f" L{leak['start_line']}"
+                print(desc)
+            print()
+
+    # WARN phase: never fail. Reviewer reads the job summary; FAIL is a future
+    # flag (--fail-on-delta) gated on precision work.
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
See #8053 (parent epic #4208). Branches the existing semantic detector (`audit_solution_leaks.py`, lignée leak-scanner #1214/#1336/#1344 + `exercise-example-labeling` rule) into a CI workflow, mirroring the pip-leak-guard HIGH-delta pattern (#6314) **but in WARN mode** per acceptance « Mode WARN d'abord, puis bascule FAIL une fois le backlog nettoyé ».

## Three changes — one subject (wire the detector into CI)

| File | Change |
|------|--------|
| `audit_solution_leaks.py` | **Extend**: add `--json` flag (emit findings dict on stdout, no root-file write, no markdown noise) for delta consumption. Default mode unchanged. Refactor `main()` → `_run_audit()`. |
| `solution_leak_delta.py` *(new)* | Diff two `--json` scans, report **HIGH findings newly introduced by HEAD vs BASE** (keyed by `path/type/func/cell/start_line`, deduped). **WARN mode: exit 0 always.** |
| `solution-leak-guard.yml` *(new)* | PR-triggered (on `*.ipynb` + scripts + workflow): HEAD scan → swap base ref → BASE scan → delta, posted to `$GITHUB_STEP_SUMMARY`. |

## Why WARN, not FAIL (honest — G.1 firsthand + acceptance)

The detector currently emits **~498 `function_body_leak` findings** across the repo, the large majority being **legitimate worked examples** (functions with >3 logic lines that are guided examples, NOT exercise stubs with their solution pasted in). Precision on C#/.NET+Lean is known low (~95% FP, fleet memory `solution-leak-detector-csharp-lean-fp`; retracted for `// TODO` c.827). An **absolute FAIL would freeze the whole cluster**. The delta+WARN form posts an advisory summary a reviewer reads without blocking. The FAIL switch (a future `--fail-on-delta` flag) is **gated on a detector-precision fix + backlog drain**, explicitly out of scope here.

The delta is the key de-noiser: a typical PR touches 1-7 notebooks, so only HIGH findings HEAD has that BASE does not are listed — inherited findings (drained one-PR-per-notebook) never count.

## Acceptance coverage (#8053)

- [x] Detector identified + wired into a CI workflow (or extended if insufficient).
- [x] Content-based rule (already in detector — Exercice+solution flagged, Exemple+stub flagged, else OK).
- [x] Anti-false-positive: delta (inherited tolerated) + WARN (no block) + explicit « guided example is legitimate, verify by CONTENT » note in the summary.
- [x] **Mode WARN d'abord** (exit 0 always); FAIL switch is a **future flag** gated on precision fix.

⚠️ **Partial contribution** — the FAIL switch is intentionally NOT in this PR (gated on detector precision). `See #8053` (not `Closes`) — the issue stays open for the precision work + FAIL rollout.

## Validation

- `--json` emits valid JSON (no root-file write) ✓ ; default mode unchanged (file + report) ✓
- Delta script: base==head → `new=0`/exit 0 ✓ ; 2 unique HIGH fingerprints removed from base → `new=2`/exit 0, grouped by path, dedup OK ✓
- YAML lint OK ✓ ; `py_compile` OK ✓ ; catalog byte-identical ✓

Co-Authored-By: Claude-Code <noreply@anthropic.com>