### PR TITLE
fix(ml,#8052): reframe 2.8-PAC interp table to match deterministic output

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.8-Theorie-PAC.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.8-Theorie-PAC.ipynb
@@ -663,14 +663,16 @@
    "source": [
     "### Interprétation : la richesse se paie en exemples\n",
     "\n",
-    "**Constat** : à mesure que le degré augmente, l'accuracy d'entraînement grimpe (la classe plus riche épouse mieux les données), mais **l'écart `train - test` s'élargit** pour ce petit `m = 40`. C'est l'incarnation empirique de la dimension VC :\n",
+    "**Constat** : à mesure que le degré augmente, l'accuracy d'entraînement grimpe sans ambiguïté (0,775 → 0,825 → 0,925) — une classe plus riche épouse toujours mieux les données vues. Mais l'écart `train - test` ne se contente pas de « s'élargir » : il **change de signe**. Négatif aux bas degrés (le test *dépasse* le train — un artefact du petit `m = 40`), il devient positif et croît aux hauts degrés (le train mémorise, le test lâche). C'est la signature empirique de la dimension VC :\n",
     "\n",
-    "| Degré | Capacité (dim VC) | Comportement observé |\n",
-    "|-------|-------------------|----------------------|\n",
-    "| 1 | faible | train et test proches, sous-apprentissage |\n",
-    "| 5 - 7 | élevée | train proche de 1, écart train-test marqué (surapprentissage) |\n",
+    "| Degré | train | test | écart (train - test) | Lecture |\n",
+    "|-------|-------|------|----------------------|---------|\n",
+    "| 1 | 0,775 | 0,831 | **-0,056** | écart le plus large en valeur absolue, et test > train : artefact du petit `m = 40` (l'échantillon test est par chance plus facile), pas un sous-apprentissage « propre » |\n",
+    "| 3 | 0,825 | 0,872 | -0,047 | même inversion (test > train), qui s'amenuise |\n",
+    "| 5 | 0,925 | 0,914 | +0,011 | l'écart change de signe et reste minime : **optimum de généralisation** (test maximal) |\n",
+    "| 7 | 0,925 | 0,897 | **+0,028** | le surapprentissage apparaît enfin : train > test, test recule (0,914 → 0,897) |\n",
     "\n",
-    "La leçon : pour une **même** taille d'échantillon, une classe **plus riche** généralise **moins bien** parce que sa dimension VC plus élevée exige davantage d'exemples pour que la borne de généralisation se resserre. C'est exactement pourquoi 2.5 recommandait la validation croisée pour *choisir* la bonne complexité plutôt que de maximiser la richesse.\n"
+    "La leçon : pour une **même** taille d'échantillon, une classe **plus riche** *finit par* généraliser **moins bien** (le test recule du degré 5 au degré 7) parce que sa dimension VC plus élevée exige davantage d'exemples pour que la borne de généralisation se resserre. C'est exactement pourquoi 2.5 recommandait la validation croisée pour *choisir* la bonne complexité plutôt que de maximiser la richesse.\n"
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python-audit-claims — lane myia-po-2024:CoursIA-2 — prev: DEEP/notebook-dotnet (c.847 yielded)

## What

Fix `2.8-Theorie-PAC.ipynb` cell md[15] (the §4 "Interprétation : la richesse se paie en exemples") whose interpretation table **mischaracterizes its own deterministic output** (code[14]). The committed numbers are correct and reproducible — the *prose* around them was wrong. See #8052.

## The mismatch (re-executed firsthand, C846-L2)

code[14] output (committed, `make_moons(n=400, noise=0.25, random_state=42)` + `train_test_split(train_size=40, random_state=42)` — deterministic). I re-executed firsthand: **identical** to committed.

```
degre 1 : train = 0.775 | test = 0.831 | ecart = -0.056
degre 3 : train = 0.825 | test = 0.872 | ecart = -0.047
degre 5 : train = 0.925 | test = 0.914 | ecart = 0.011
degre 7 : train = 0.925 | test = 0.897 | ecart = 0.028
```

md[15] claimed:

| Claim | Reality (from output) |
|-------|----------------------|
| Degré 1 : "train et test **proches**, sous-apprentissage" | Degree 1 has the **largest** \|écart\| (0.056), and it is **negative** — test (0.831) > train (0.775). Not "proches", not a clean underfit. |
| "l'écart `train - test` **s'élargit**" | The *signed* gap does grow, but it **flips sign** at degree 5: −0.056 → −0.047 → +0.011 → +0.028. The *absolute* gap is **largest at degree 1**, not monotonic widening. |
| "5-7 ... écart train-test **marqué**" | Degree 5's gap is **0.011 (the smallest)**. Only degree 7 shows a (modest) positive gap. |
| train "grimpe" | Climbs then **plateaus at 0.925** for both degree 5 and 7. |

## Fix (markdown-only, byte-surgical)

Reframed md[15] to read the data honestly:
- **Constat** rewritten: train climbs monotonically to a 0.925 plateau; the signed `train - test` gap does not simply "s'élargir" — it **changes sign** (negative at low degree = test beats train, a small-`m=40` artifact; positive only at high degree).
- The 2-row hand-wavy table (`1` / `5-7`) replaced by a **4-row table grounded in the 4 actual degrees**, each row citing the real train/test/écart + a one-line honest lecture.
- Key correction: degree 1 is **not** a "proche/sous-apprentissage" regime — it has the largest gap, inverted (test > train). Degree 5 = generalization optimum (test peaks 0.914). Degree 7 = where genuine overfit finally appears (test retreats 0.914 → 0.897).
- Leçon tightened: "une classe plus riche *finit par* généraliser moins bien" (test recule degré 5→7) — the original absolute "généralise moins bien" was true only past degree 5.

### Scope (byte-surgical — C839-L1)

Only **md[15]** changed (+703 bytes). All 29 other cells **byte-identical to origin/main** (round-trip guard: `json.dumps(indent=1)` verified byte-identical pre-edit; exactly 1 cell changed post-edit, confirmed by per-cell diff).

**code[14] untouched** — it still carries its real committed output (ec=7, outputs=2). Its plot title string `"... ecart grandissant"` remains: consistent with the reframe (the *signed* gap does grow −0.056→+0.028), and changing a code string would force a re-exec (C.2) outside this grain's scope. **Markdown-only → C.2 exception** (no re-exec needed; outputs unchanged).

## Validation (firsthand)

- `nbformat.validate`: OK
- H.3 pre-commit: 0 violations (10 code cells, all `execution_count`/`outputs` present)
- C.1: clean (no `raise NotImplementedError` / `assert False` / `1/0`)
- code[14] output re-executed firsthand (seed=42) → **byte-identical to committed** (deterministic).

## Out of scope

- code[14] plot title `"ecart grandissant"`: defensible (signed gap grows), left as-is. A future grain could sharpen it to "écart signé croissant" if desired.

See #8052
