### PR TITLE
docs(gt,#3975): add 3 interpretation cells to SocialChoice/03 C# twin

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/SocialChoice/03-Voting-Methods-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/SocialChoice/03-Voting-Methods-Csharp.ipynb
@@ -308,6 +308,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Interprétation : la majorité pairwise est intransitive\n",
+    "\n",
+    "Chaque duel pris isolément est parfaitement démocratique — **A bat B**, **B bat C**, mais **C bat A**, chacun par 2 voix contre 1. La transitivité nous ferait pourtant attendre « A bat C » (puisque A bat B et B bat C) : c'est l'inverse qui se produit. La relation de majorité, agrégée depuis des préférences individuelles elles-mêmes transitives, devient ici **cyclique**.\n",
+    "\n",
+    "C'est le **paradoxe fondateur de Condorcet (1785)** : il n'existe sur ce profil **aucun gagnant de Condorcet** — personne ne bat tout le monde. La « volonté générale » ne se laisse pas réduire à un ordre cohérent ; elle forme une boucle. Ce vide est précisément ce qui motive, plus loin, les théorèmes d'impossibilité de Sen et d'Arrow.\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "id": "569633a9",
@@ -650,6 +661,23 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Interprétation : la règle de vote choisit le gagnant\n",
+    "\n",
+    "Sur **un même profil** (V1–V2 : A>B>C ; V3 : B>C>A ; V4–V5 : C>B>A), trois règles également légitimes désignent des vainqueurs distincts :\n",
+    "\n",
+    "| Règle | Classement | Scores | Gagnant |\n",
+    "|-------|------------|-------|--------|\n",
+    "| **Pluralité** | A > C > B | A=2, C=2, B=1 | A et C ex aequo (seuls les premiers choix comptent) |\n",
+    "| **Borda** | B > C > A | A=4, B=6, C=5 | **B** (positions intermédiaires solides) |\n",
+    "| **Copeland** | B > C > A | A=−2, B=+2, C=0 | **B** (gagne ses duels pairwise) |\n",
+    "\n",
+    "B, jamais dernier de personne, est récompensé par les règles qui regardent **tout** le classement (Borda, Copeland) et ignoré par celle qui ne voit que le sommet (pluralité). Il n'existe donc pas de vainqueur « neutre » lu dans le profil : le résultat d'une élection est un **artefact de la règle choisie**, pas une propriété intrinsèque des préférences. Ce constat est la porte d'entrée des théorèmes d'impossibilité qui suivent.\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 7,
    "id": "24108203",
@@ -833,6 +861,24 @@
     "## 5. Theoreme de Sen (1970) : Liberte vs Pareto\n",
     "\n",
     "L'exemple de Lady Chatterley : le **principe de liberte minimale** (chacun decide sur sa sphere privee) combine a la **transitivite** et au **principe de Pareto** mene a une contradiction. Sen prouve ainsi que liberte et Pareto sont incompatibles. Déterministe (argument logique)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Interprétation : liberté, Pareto et cohérence sont incompatibles\n",
+    "\n",
+    "Sen (1970) montre que trois principes individuellement séduisants sont **logiquement contradictoires**. Sur l'exemple de Lady Chatterley (`np` = personne ne lit, `pr` = Prude lit, `lr` = Lewd lit) :\n",
+    "\n",
+    "| Principe | Application | Résultat social |\n",
+    "|----------|------------|----------------|\n",
+    "| **Liberté de Prude** | décide entre `pr` et `np` → préfère `np` | `np > pr` |\n",
+    "| **Liberté de Lewd** | décide entre `lr` et `np` → préfère `lr` | `lr > np` |\n",
+    "| **Transitivité** | `lr > np` et `np > pr` | **`lr > pr`** |\n",
+    "| **Pareto (unanimité)** | Prude **et** Lewd préfèrent tous deux `pr > lr` | **`pr > lr`** |\n",
+    "\n",
+    "Les deux premiers principes combinés à la transitivité forcent `lr > pr` ; le Pareto force `pr > lr` — **contradiction directe**, exactement celle qu'affiche la sortie. On ne peut pas simultanément respecter la souveraineté individuelle, l'efficacité unanime **et** la cohérence de l'ordre social. C'est l'analogue du théorème d'Arrow pour les biens publics et les droits individuels.\n"
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-dotnet-pedagogy — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-python-audit-claims (c.848)

## What

Add 3 post-output **interpretation cells** to `GameTheory/SocialChoice/03-Voting-Methods-Csharp.ipynb` — the C# twin computes the key voting-theory results (Condorcet cycle, divergent winners, Sen's paradox) but leaves them **without pedagogical interpretation**, whereas the Python twin (`03-Voting-Methods.ipynb`) has a dedicated `### Interpretation` cell after each. See #3975.

## The asymmetry (firsthand)

The C# twin has 3 code cells whose outputs carry real, non-obvious results, each followed only by a **thin section header** (2–3 lines):

| code cell | output (committed) | following md (thin) |
|-----------|--------------------|---------------------|
| `code[4]` (§1 cycle) | A>B, B>C, C>A each 2-1 → no Condorcet winner | `md[5]` "Cycle de Condorcet" — 2 sentences |
| `code[10]` (§4 divergent) | Pluralité A>C>B (A,C ex aequo) ; Borda & Copeland B>C>A | `md[11]` "Divergence des règles" — 2 sentences |
| `code[12]` (§5 Sen) | Freedom+Transitivity → `lr>pr` ; Pareto → `pr>lr` → contradiction | `md[13]` "Théorème de Sen" — 3 sentences |

The Python twin, by contrast, has a rich `### Interpretation` cell (table + mechanism) after each of these. The C# student gets the raw output and a one-liner; the Python student gets the breakdown of *why* the result matters. Sections 6 (Arrow) and 8 (Downs) already have interpretation cells in the C# twin — only §1-cycle, §4-divergent, §5-Sen were bare.

## Fix (markdown-only, byte-surgical)

Inserted one `### Interprétation` markdown cell after each thin header (`md[5]`, `md[11]`, `md[13]`), giving the pattern `code → thin header → rich interpretation` (matching the Python twin). Each cell is **grounded in the actual C# output of its code cell** (read firsthand), not copy-pasted from the Python twin — the C# outputs carry their own specific values:

- **Condorcet cycle**: each duel 2-1, transitivité would give A>C but the reverse holds → no Condorcet winner; foreshadows Sen/Arrow.
- **Divergent results**: a 4-row table (rule / ranking / scores / winner) on the committed profile — B rewarded by Borda/Copeland (full-ranking rules), ignored by pluralité (top-only); the winner is an artefact of the rule.
- **Sen**: a 4-row table (principle / application / social result) tracing freedom+transitivité → `lr>pr` vs Pareto → `pr>lr`, the exact contradiction the output prints.

### Scope (byte-surgical — C839-L1 / C744-L1)

- **+46/−0**: pure additions, **0 deletions** (anti-régression compliant).
- All **14 code cells byte-identical to `origin/main`** (verified: source sequences match exactly). **No source code, output, or `execution_count` touched.**
- Markdown-only → **C.2 exception** (no re-execution required: no code cell modified).
- `nbformat.validate` OK · H.3: 0 violations · C.1: clean (no `raise NotImplementedError`/`assert False`/`1/0`).
- Round-trip guard: `json.dumps(indent=1)` byte-identical pre-edit.

## Out of scope

- The thin headers `md[5]`/`md[11]`/`md[13]` themselves are kept as-is (they serve as section anchors); the new cells augment rather than replace them.
- No code change → no re-execution (outputs unchanged). If a future grain sharpens the C# code (e.g. richer Copeland tie-break print), that grain re-executes.

See #3975
