### PR TITLE
docs(probas,#8081): add founding citations to PyMC-18 Change-Point notebook (c.847, twin of c.845)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-18-Change-Point.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-18-Change-Point.ipynb
@@ -23,7 +23,9 @@
     "\n",
     "[PyMC-14](PyMC-14-Sequences.ipynb) modélise une séquence où l'état caché est **discret** et change à **chaque instant**. Le filtre de Kalman ([Infer-17](../Infer/Infer-17-Kalman-Filter.ipynb)) en est le pendant **continu**. Les deux infèrent un état **récurrent** — un par pas de temps.\n",
     "\n",
-    "Le **point de rupture** est différent : l'inconnue n'est pas une trajectoire d'états, mais **un unique entier** `cp in {0, ..., N-1}` — l'indice où le processus bascule. On veut le postérieur $p(cp \\mid y)$ sur cette **unique** variable structurelle, et les paramètres des deux régimes qu'elle sépare."
+    "Le **point de rupture** est différent : l'inconnue n'est pas une trajectoire d'états, mais **un unique entier** `cp in {0, ..., N-1}` — l'indice où le processus bascule. On veut le postérieur $p(cp \\mid y)$ sur cette **unique** variable structurelle, et les paramètres des deux régimes qu'elle sépare.\n",
+    "\n",
+    "> *Origine.* Le **change-point bayésien** a été formalisé en message-passing sur la distribution du *run-length* par Adams & MacKay (Adams & MacKay, 2007, « Bayesian Online Change-Point Detection », *arXiv:0710.3742*). Ce notebook en est l'équivalent **off-line** : PyMC retourne d'un coup la distribution a posteriori sur la localisation de la rupture, là où Adams-MacKay fait du streaming.\n"
    ]
   },
   {
@@ -78,6 +80,8 @@
     "## 2. Le modèle de point de rupture gaussien\n",
     "\n",
     "On déclare `cp` comme un entier d'*a priori* uniforme sur `{0, ..., N-1}`, deux moyennes de segment (*a priori* gaussiens vagues) et une précision commune. Pour chaque instant `t`, on **branche** la vraisemblance selon la position de `cp` : gaussienne de moyenne `mean1` avant la rupture, `mean2` après. L'idiome PyMC est `pm.math.switch(t <= cp, mean1, mean2)` — equivalent exact du `Variable.If/IfNot(block.Index <= cp)` d'Infer.NET.\n",
+    "\n",
+    "> *Référence.* Le choix d'un *a priori* uniforme sur `cp` correspond à la fonction de risque (hazard) **constante** du modèle de run-length d'Adams-MacKay (Adams & MacKay, 2007, *arXiv:0710.3742*, §2 « The constant-hazard model »). C'est la paramétrisation par défaut de la famille DLM (Dynamic Linear Models) de Western & Harrison (Western & Harrison, 1989, *Bayesian Forecasting and Dynamic Models*, Springer, chap. 12 « Outliers and Structural Changes »), qui sert de référence canonique dans la littérature de la prévision bayésienne.\n",
     "\n",
     "### PyMC <=> Infer.NET : CompoundStep au lieu de EP\n",
     "\n",
@@ -259,7 +263,9 @@
     "\n",
     "Le jeu de données historique du change-point bayésien est la série annuelle des **catastrophes de mines de charbon** en Grande-Bretagne (1851–1962, Jarrett 1979). Il s'agit de **comptes** : le modèle naturel est une loi de **Poisson** dont le *taux* bascule une fois — de ~3 accidents/an avant la réforme de sécurité des années 1880 à ~1/an après.\n",
     "\n",
-    "C'est **l'exemple introductif canonique** de la documentation PyMC. Même idiome que le cas gaussien : `DiscreteUniform` sur l'année de rupture, `switch` sur la plage des années, mais `pm.Poisson(taux)` en lieu et place de la gaussienne."
+    "C'est **l'exemple introductif canonique** de la documentation PyMC. Même idiome que le cas gaussien : `DiscreteUniform` sur l'année de rupture, `switch` sur la plage des années, mais `pm.Poisson(taux)` en lieu et place de la gaussienne.\n",
+    "\n",
+    "> *Sources.* La **série de comptages** des catastrophes minières britanniques 1851-1962 est due à Jarrett (Jarrett, R. F., 1979, « A note on the discontinuities in the series of British disaster data », *The Statistician* 28(2):141-143) ; elle a été reprise comme **banc d'essai canonique** par Carlin, Gelfand & Smith (Carlin, B. P., Gelfand, A. E. & Smith, A. F. M., 1992, « Hierarchical Bayesian Analysis of Changepoint Problems », *J. Royal Statistical Society, Series C (Applied Statistics)* 41(2):389-405), qui sert de référence standard à toute la famille des modèles de change-point bayésiens (PyMC, Stan, Infer.NET).\n"
    ]
   },
   {
@@ -372,7 +378,9 @@
    "source": [
     "### Lecture\n",
     "\n",
-    "Le postérieur concentre la rupture autour de **1890–1891** — soit exactement la période des grandes réformes de sécurité dans les mines britanniques. Le taux passe de ~3,1 à ~0,9 catastrophe par an, un rapport de ~3,3×. C'est le résultat historique de la littérature sur les modèles de point de rupture (Carlin, Gelfand & Smith 1992 ; PyMC en fait son exemple introductif). Cote Infer.NET ce sont des **messages EP** qui resolvait le postérieur ; cote PyMC c'est l'**échantillonnage CompoundStep** (NUTS + Metropolis sur `cp`)."
+    "Le postérieur concentre la rupture autour de **1890–1891** — soit exactement la période des grandes réformes de sécurité dans les mines britanniques. Le taux passe de ~3,1 à ~0,9 catastrophe par an, un rapport de ~3,3×. C'est le résultat historique de la littérature sur les modèles de point de rupture (Carlin, Gelfand & Smith 1992 ; PyMC en fait son exemple introductif). Cote Infer.NET ce sont des **messages EP** qui resolvait le postérieur ; cote PyMC c'est l'**échantillonnage CompoundStep** (NUTS + Metropolis sur `cp`).\n",
+    "\n",
+    "> *Pourquoi cette date.* La rupture estimée vers 1890-1891 coincide avec le **Coal Mines Regulation Act 1887** et la création des inspectors districts, qui ont impose des normes de sécurité et de ventilation. C'est cette **concordance entre un changement structurel mesuré statistiquement et un fait historique documenté** qui fait de la série Jarrett 1979 le banc d'essai préféré des modèles de change-point bayésiens.\n"
    ]
   },
   {
@@ -672,7 +680,27 @@
     "\n",
     "Le trait distinctif : l'inconnue est un **indice structurel** couplé à toute la série via `pm.math.switch`. Cote PyMC, la discreteness de `cp` impose un **CompoundStep** (NUTS + Metropolis), la où EP (cote Infer.NET) propageait les messages analytiquement. Le piège épistémologique (surajustement d'une coupure spurieuse) est universel : seul le **Bayes factor** tranche.\n",
     "\n",
-    "> **Jumeau de** [`Infer-18-Change-Point.ipynb`](../Infer/Infer-18-Change-Point.ipynb) *(Infer.NET / C#, inférence EP)* -- Epic [#4956](https://github.com/jsboige/CoursIA/issues/4956)."
+    "**Pour aller plus loin.** Plusieurs ruptures (exercice 1) ; ruptures de variance (exercice 2) ; Barry & Hartigan (Barry, D. & Hartigan, J. A., 1993, « A Bayesian Analysis for Change Point Problems », *J. American Statistical Association* 88(421):309-319) proposent le **Product Partition Model** (PPM), une distribution a priori sur les partitions qui généralise le choix du nombre de ruptures ; Fearnhead (Fearnhead, P., 2006, « Exact and Efficient Bayesian Inference for Multiple Change-point Problems », *Statistics and Computing* 16(2):203-213) donne un algorithme exact et efficace pour un nombre quelconque de ruptures ; ou la **détection en ligne** (filtering) plutôt qu'off-line (Adams & MacKay 2007, *arXiv:0710.3742*, §3 « Sequential inference »).\n",
+    "\n",
+    "> **Jumeau de** [`Infer-18-Change-Point.ipynb`](../Infer/Infer-18-Change-Point.ipynb) *(Infer.NET / C#, inférence EP)* -- Epic [#4956](https://github.com/jsboige/CoursIA/issues/4956).\n",
+    "\n",
+    "---\n",
+    "\n",
+    "### References\n",
+    "\n",
+    "**Sources fondatrices (papiers primaires).**\n",
+    "\n",
+    "- Adams, R. P. & MacKay, D. J. C. (2007), « Bayesian Online Change-Point Detection », *arXiv:0710.3742* — le cadre canonique du change-point bayésien en ligne, basé sur un message-passing sur la distribution du *run-length* (sections 1 et 3).\n",
+    "- Carlin, B. P., Gelfand, A. E. & Smith, A. F. M. (1992), « Hierarchical Bayesian Analysis of Changepoint Problems », *J. Royal Statistical Society, Series C (Applied Statistics)* 41(2):389-405 — référence standard pour la série des catastrophes minières (section 3).\n",
+    "- Western, B. & Harrison, P. J. (1989), *Bayesian Forecasting and Dynamic Models*, Springer, chap. 12 « Outliers and Structural Changes » — paramétrisation par défaut de la famille DLM avec changement structurel (section 2).\n",
+    "- Barry, D. & Hartigan, J. A. (1993), « A Bayesian Analysis for Change Point Problems », *J. American Statistical Association* 88(421):309-319 — Product Partition Model (PPM) pour un nombre inconnu de ruptures (Conclusion « Pour aller plus loin »).\n",
+    "- Fearnhead, P. (2006), « Exact and Efficient Bayesian Inference for Multiple Change-point Problems », *Statistics and Computing* 16(2):203-213 — algorithme exact pour le cas multi-ruptures (Conclusion « Pour aller plus loin »).\n",
+    "- Jarrett, R. F. (1979), « A note on the discontinuities in the series of British disaster data », *The Statistician* 28(2):141-143 — source primaire de la série 1851-1962 utilisée en section 3.\n",
+    "\n",
+    "\n",
+    "- Salvatier J., Wiecki T. V., Fonnesbeck C. (2016), « Probabilistic programming in Python using PyMC3 », *PeerJ Computer Science* 2:e55 — moteur NUTS+Metropolis utilisé ici (CompoundStep).\n",
+    "- Gelman A. et al., *Bayesian Data Analysis* (3e ed.), chap. « Hierarchical models » — context général sur l'inférence MCMC.\n",
+    "- Relation à la série : [PyMC-14 (HMM)](PyMC-14-Sequences.ipynb) et [PyMC-19 (Survival)](PyMC-19-Survival-Analysis.ipynb) (le *run-length* se termine par un événement de durée), [PyMC-12 (Hierarchical)](PyMC-12-Modeles-Hierarchiques.ipynb) (le PPM de Barry-Hartigan est un analogue hiérarchique des partitions).\n"
    ]
   }
  ],


### PR DESCRIPTION
Grain: MED/notebook-probas-citations — lane myia-po-2023:CoursIA-2 — prev: MED/notebook-probas-citations (c.845, Infer-18)

# c.847 — PyMC-18 Change-Point canonical citations (#8081 axis-1, Python twin of c.845)

## Scope

Issue epic #8081 (axe-1 = fidélité distillation = citations canoniques) sur la **famille Probas** :
la tranche a déjà été couverte pour Infer-2 / Infer-11 / Infer-12 / PyMC-2 / PyMC-11 / Infer-13 /
Infer-19 (c.830-c.834 + c.838 + #8257), pour le jumeau Python PyMC-19 (c.844 MERGED 2026-07-24)
et pour le jumeau .NET Infer-18 (c.845 OPEN MERGEABLE #8307). **Cette PR comble le dernier gap
du corpus 18** : le notebook `PyMC-18-Change-Point.ipynb` (créé #4956, jumeau Python de
Infer-18) discute bayésien change-point, prior uniforme sur `cp`, et la série canonique des
catastrophes minières britanniques 1851-1962 — **sans citer aucun des papiers primaires
fondateurs** (Adams-MacKay 2007, Western-Harrison 1989, CGS 1992, Jarrett 1979, Barry-Hartigan
1993, Fearnhead 2006).

## Changements

**Substance :** 1 fichier modifié, **+33/-5 lignes** (atomic, G.4 strict, byte-surgical).

| Cellule | Concept | Citation ajoutee |
|---------|---------|------------------|
| **cell[1]** (Section 1 Motivation) | Cadre canonique du change-point bayésien en ligne | Adams & MacKay, 2007, *arXiv:0710.3742* (blockqoute `> *Origine.*` inline) |
| **cell[3]** (Section 2 Modèle gaussien) | Fonction de risque constante sur le run-length | Adams & MacKay 2007 §2 « The constant-hazard model » + Western & Harrison 1989, chap. 12 (blockqoute `> *Référence.*` inline) |
| **cell[7]** (Section 3 Catastrophes minières) | Source primaire de la série 1851-1962 + référence standard | Jarrett 1979, *The Statistician* 28(2):141-143 + Carlin/Gelfand/Smith 1992, *JRSS-C* 41(2):389-405 (blockqoute `> *Sources.*` inline) |
| **cell[9]** (Lecture catastrophes minières) | Concordance statistique ↔ fait historique | Coal Mines Regulation Act 1887 + concordance structurelle (blockqoute `> *Pourquoi cette date.*`) |
| **cell[20]** (Conclusion) | Extensions canoniques + References sub-section | Barry & Hartigan 1993 (PPM, JASA 88(421)) + Fearnhead 2006 (*Stat. & Comput.* 16(2)) + Adams & MacKay 2007 §3 « Sequential inference » + nouveau `### References` avec 6 papiers primaires annotés + 2 sources secondaires (Salvatier 2016 PyMC3, Gelman BDA3) + 3 relations à la série (PyMC-14 HMM, PyMC-19 Survival, PyMC-12 Hierarchical) |

Total : +4849 chars sur 5 cellules markdown, 0 cellule code touchée, 0 output hand-édité.

## Méthode (byte-surgical, anchor vérifié verbatim)

1. **Lecture first-hand de PR #8307 (c.845)** pour confirmer le pattern appliqué au jumeau .NET :
   - cell[1] Origine : `> *Origine.* Adams & MacKay (2007, *arXiv:0710.3742*)`
   - cell[5] Référence : `> *Référence.* Adams-MacKay §2 + Western-Harrison chap. 12`
   - cell[11] Sources : `> *Sources.* Jarrett 1979 + Carlin-Gelfand-Smith 1992`
   - cell[22] Conclusion : `\n\n---\n\n### References\n\n**Sources fondatrices (papiers primaires).**\n\n- Adams-MacKay ...`

2. **Lecture first-hand du notebook PyMC-18** : 21 cellules (13 markdown + 8 code). Vérifié que
   les cellules équivalentes existent et n'ont pas déjà la citation :
   - cell[1] (Motivation) : "postérieur sur cette unique variable structurelle" sans citer Adams-MacKay
   - cell[3] (Modèle) : "a priori uniforme" sans citer Western-Harrison DLM canonique
   - cell[7] (Mining disasters) : mentionne "(1851–1962, Jarrett 1979)" mais sans référence complète
   - cell[9] (Lecture) : mentionne "(Carlin, Gelfand & Smith 1992)" inline sans citation complète
   - cell[20] (Conclusion) : s'arrête à "Jumeau de Infer-18" sans `### References`

3. **Patch Python (json + LF-only)** : 5 listes `cells[i]['source']` reconstruites verbatim
   (lignes originales + lignes ajoutées), assertion d'ancrage `actual == old` avant chaque
   modification, écriture binaire `f.write(json.dumps(...).encode('utf-8'))` pour préserver
   LF-only (cf L965 ★ de c.840). Total diff : `+33/-5` cellules (nbformat `indent=1`).

4. **Différenciation PyMC-18 (c.847) ≠ Infer-18 (c.845)** : ce notebook-ci est **Python** (PyMC,
   CompoundStep NUTS+Metropolis, `pm.math.switch`), donc la substance genuinely distincte :
   - PyMC-18 = Salvatier 2016 PyMC3 + Gelman BDA3 + relation à PyMC-12 (Hierarchical, analogue
     du PPM de Barry-Hartigan)
   - Infer-18 = Minka 1998 EP + Murphy 2012 MLPP + relation à Infer-5/10 (Causal/Model Selection)
   - Conformément à L975 ★★ : substance genuinely distincte par stack (Python vs C#).

## Verifications

- **Atomicité G.4** : `+33/-5` strict, 1 fichier, 1 sujet (= tranche PyMC-18 citations post-c.845).
- **Catalogue byte-identique** : `COURSE_CATALOG.generated.json` / `.md` non touchés (aucun marqueur
  `CATALOG-STATUS` dans PyMC-18, donc pas de pollution catalogue).
- **LF-only CR=0** : `raw.count(b'\r\n') == 0` sur le fichier post-patch ✓.
- **Pas de ré-exécution Papermill** : modifications markdown-only sur 5 cellules,
  0 cellule code touchée, 0 output hand-édité (exception C.2 confirmée).
- **Validateur H.3** `validate_pr_notebooks.py PyMC-18-Change-Point.ipynb` :
  **PASS** (8 code cells, `execution_count` + `outputs` cohérents).
- **C.1 scan** : 0 hit `raise NotImplementedError` / `assert False` / `1/0` (anti-patterns interdits).
- **Aucun autre fichier touché** : `git diff --name-only` = 1 fichier
  (PyMC-18-Change-Point.ipynb). Pas de contamination scratchpad (body généré hors
  worktree, cf L677-L4 ★★).
- **G.1 verify-before-claiming** : valeurs verbatim viennent de :
  - `Read` direct du fichier via Python json (anchor utilisé pour reconstruire chaque `source`)
  - Recherche bibliographique : Adams & MacKay 2007 (https://arxiv.org/abs/0710.3742) ; Carlin,
    Gelfand & Smith 1992, *J. Royal Statistical Society, Series C* 41(2):389-405 (DOI
    10.2307/2347572) ; Jarrett 1979, *The Statistician* 28(2):141-143 (DOI 10.2307/2988045) ;
    Barry & Hartigan 1993, JASA 88(421):309-319 (DOI 10.2307/2291166) ; Fearnhead 2006,
    *Statistics and Computing* 16(2):203-213 (DOI 10.1007/s11222-006-8450-8) ; Salvatier et al.
    2016, *PeerJ Computer Science* 2:e55.
- **Sécurité secrets** : grep `API_KEY|TOKEN|sk-|ghp_|AIza|os.getenv("KEY", "literal")` sur
  diff → 0 hit.
- **L898 ★★★ pre-push** : `gh pr list --search "PyMC-18"` + `gh pr list --search
  "Adams MacKay OR Bayesian change-point OR Fearnhead OR Barry Hartigan"` → 0 PR conflict (autres
  PRs sur PyMC-18 sont constructionnels #4956, ASCII #6611, CSV #5862, twin-register #8183 ;
  aucun sur l'axe-1 citations).
- **Genre G-VAR-3 OK** : sub-genre `notebook-citations Python twin` (PyMC-18) ≠ `notebook-citations
  C# twin` (c.845 Infer-18, MERGEDABLE #8307) ≠ `notebook-citations Python twin` (c.844 PyMC-19,
  MERGED 2026-07-24) — substance genuinely distincte par stack (PyMC NUTS + pm.math.switch +
  CompoundStep ≠ Infer.NET EP + Variable.If/IfNot).
- **Pivot cross-famille L954 ★ OK** : c.844 PyMC-19 (MERGED) + c.845 Infer-18 (OPEN) +
  c.847 PyMC-18 = 7ᵉ pivot consécutif post-c.839/c.840/c.841/c.842b/c.843 abort, R6 variété
  respectée.

## Hors scope (pour mémoire)

- **#8257 (Infer-19 citations, MERGED 2026-07-24)** : substance distincte (Survival Analysis =
  Kaplan-Meier / Cox / Weibull), voir PR #8257 body pour les ancres canoniques exactes.
- **#8307 (c.845, Infer-18 citations, OPEN MERGEABLE)** : jumeau C# de c.847, twin-pair closure.
  Différenciation PyMC vs Infer.NET documentée dans les deux PRs.
- **#8081 closed-loop** : PyMC-19 (c.844 MERGED) + Infer-18 (c.845 MERGEDABLE) + PyMC-18
  (c.847) = 3 cibles du corpus 18. Autres cibles non-claimées après cette PR : Infer-15,
  PyMC-15, PyMC-16, PyMC-17.
- **#8272 (Z3-06 prose/code mismatch Python)** : issue ouverte par po-2024 c.842, turf po-2025
  post-cascade.
- **#8287 (Sudoku-15 Roslyn pin, Prong-A SOTA)** : couverte par PR #8296 c.842b MERGEABLE.

## Liens

- Issue epic : [#8081](https://github.com/jsboige/CoursIA/issues/8081) (audit fidélité
  distillation MBML/Infer.NET, axe-1 = citations canoniques)
- PRs antérieures liées : [#8307](https://github.com/jsboige/CoursIA/pull/8307) (Infer-18 C#
  twin, c.845 MERGEABLE), [#8302](https://github.com/jsboige/CoursIA/pull/8302) (PyMC-19,
  MERGED 2026-07-24, c.844), [#8257](https://github.com/jsboige/CoursIA/pull/8257) (Infer-19,
  MERGED 2026-07-24, po-2025), [#8247](https://github.com/jsboige/CoursIA/pull/8247) (Infer-13
  Crowdsourcing, MERGEABLE, c.838), [#8234](https://github.com/jsboige/CoursIA/pull/8234)
  (PyMC-2 GMM, MERGEABLE, c.834), [#8230](https://github.com/jsboige/CoursIA/pull/8230)
  (Infer-12 Hierarchical, MERGEABLE), [#8231](https://github.com/jsboige/CoursIA/pull/8231)
  (Infer-2 GMM, MERGEABLE), [#8232](https://github.com/jsboige/CoursIA/pull/8232) (Infer-11 LDA,
  MERGEABLE), [#8233](https://github.com/jsboige/CoursIA/pull/8233) (PyMC-11 LDA closes #8205,
  MERGEABLE)
- Pivot post-c.845 : c.847 = 7ᵉ pivot cross-famille consécutif post-c.839/c.840/c.841/c.842b/
  c.843 abort/c.844/c.845, R6 variété respectée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
