### PR TITLE
docs(genai-video,#8274): markdown honest-fix — GPT-5 analysis 400s on temperature=0.2 (not 404 deprecated)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Video/01-Foundation/01-2-GPT-5-Video-Understanding.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/01-Foundation/01-2-GPT-5-Video-Understanding.ipynb
@@ -1155,7 +1155,12 @@
     "tags": []
    },
    "source": [
-    "Les descriptions de scene et le raisonnement temporel sont obtenus. La cellule suivante exploite la même approche pour du Video Q&A : trois questions factuelles sont posees successivement a GPT-5."
+    "**Les appels d'analyse ci-dessus échouent en HTTP 400.** Diagnostic firsthand (sorties commitées + réponse de `models.list()`) :\n",
+    "\n",
+    "- la cellule de configuration appelle `client.models.list()`, qui expose **`gpt-5`**, **`gpt-5-2025-08-07`** et **`gpt-5-chat-latest`** — le modèle sélectionné `gpt-5-mini` **n'apparaît pas** dans cette liste ;\n",
+    "- le message d'erreur 400 renvoyé par l'API est explicite : *« Unsupported value: 'temperature' does not support 0.2 with this model. Only the default (1) value is supported. »* — les modèles GPT-5 (de raisonnement) **n'acceptent que la température par défaut (1)**, pas `temperature=0.2`.\n",
+    "\n",
+    "La cause racine n'est donc **pas** un modèle « déprécié » (404) mais la combinaison (i) d'un nom de modèle invalide (`gpt-5-mini`) et (ii) d'un paramètre `temperature` non supporté. **Correction complète** : `model_name → \"gpt-5\"` (ou `gpt-5-chat-latest`) **et** `temperature → 1` (ou suppression du paramètre), puis re-exécution. Re-exécution en attente sur la lane GenAI (clé OpenAI requise). Verdict SOTA : **RECOVERABLE-MACHINE**. La cellule suivante (Video Q&A) échoue pour la même raison ; elle produira ses réponses dès ces deux paramètres corrigés."
    ]
   },
   {
@@ -1529,7 +1534,7 @@
     "tags": []
    },
    "source": [
-    "Le Q&A demonstre la capacite de GPT-5 a repondre a des questions precises sur le contenu de la video. La cellule suivante propose un mode interactif pour poser une question personnalisee."
+    "Le Q&A ci-dessus échoue pour la même raison (HTTP 400 : `temperature=0.2` non supportée par les modèles GPT-5 ; cf. diagnostic de la section précédente). Une fois `temperature` ramenée à 1 et le modèle corrigé (`gpt-5` / `gpt-5-chat-latest`), ce bloc produira les réponses factuelles attendues. La cellule suivante (mode interactif) reste disponible."
    ]
   },
   {
@@ -1858,7 +1863,7 @@
     "\n",
     "- Les concepts fondamentaux ont ete presentes et illustres\n",
     "- Les Exemple guides proposent une mise en pratique progressive\n",
-    "- Les résultats obtenus permettent de valider la comprehension\n",
+    "- Les appels d'analyse GPT-5 retournent actuellement une erreur 400 (`temperature=0.2` non supportée par les modèles GPT-5 + `gpt-5-mini` absent de `models.list()`) ; correction (température=1, modèle `gpt-5`) et re-exécution tracées dans #8274 (RECOVERABLE-MACHINE, lane GenAI)\n",
     "\n",
     "**Pour aller plus loin** : approfondir les aspects avances du sujet et explorer les liens avec d'autres domaines."
    ]


### PR DESCRIPTION
## docs(genai-video,#8274): markdown honest-fix — GPT-5 analysis 400s on temperature=0.2 (not 404 deprecated)

Grain: MED/genai — lane myia-po-2025:CoursIA — prev: MED/notebook-python (PyMC-16 probit/logit #8308).

### Le défaut (trouvé firsthand, #8274)

`01-2-GPT-5-Video-Understanding.ipynb` — le markdown annonçait que l'analyse vidéo et le Q&A réussissent, **alors que les sorties commitées montrent `HTTP/1.1 400 Bad Request`** sur CHAQUE appel d'analyse (cellules 15, 17). Doc-honesty defect : markdown qui ment vs outputs réels.

### Diagnostic firsthand (CORRIGE le framing de #8274)

#8274 titre dit « gpt-5-mini model deprecated (404) ». La cause racine réelle est **différente et plus riche**, établie en lisant les sorties commitées + `models.list()` :

1. **Le vrai code d'erreur est 400, pas 404.** Le message de l'API (cellule 15) est explicite : *« Unsupported value: 'temperature' does not support 0.2 with this model. Only the default (1) value is supported. »* → les **modèles GPT-5 (de raisonnement) n'acceptent que `temperature=1`**, pas `0.2` (config cellule 2).
2. **`gpt-5-mini` n'est pas dans les modèles disponibles.** La cellule 7 appelle `client.models.list()`, qui expose `gpt-5`, `gpt-5-2025-08-07`, `gpt-5-chat-latest` — le `gpt-5-mini` sélectionné est absent de la liste (cause secondaire).

Ce n'est donc **pas** un modèle « déprécié » (404) : c'est un paramètre `temperature` non supporté + un nom de modèle invalide.

### Le fix (markdown-only, C.2 exception)

3 cellules markdown corrigées (aucune cellule code / output / exec_count touchée) :

| Cell | Avant (mensonge) | Après (honnête) |
|------|------------------|-----------------|
| **md 16** | « Les descriptions de scene et le raisonnement temporel sont obtenus » | **Diagnostic** : les appels 400, `temperature=0.2` non supportée par GPT-5 (défaut =1) + `gpt-5-mini` absent de `models.list()` ; cause racine ≠ 404 dépréciation ; correction complète = `model→gpt-5` ET `temperature→1` |
| **md 22** | « Le Q&A démontre la capacité de GPT-5 à répondre » | Q&A échoue aussi (même 400) ; produira ses réponses dès temperature=1 + modèle corrigé |
| **md 28** (conclusion) | « Les résultats obtenus permettent de valider la compréhension » | « Les appels d'analyse GPT-5 retournent actuellement 400 ; correction + re-exécution tracées dans #8274 » |

### Validation

- **H.3** `validate_pr_notebooks.py origin/main <path>` : **1/1 PASS** (14 code cells).
- **Markdown-only** : vérifié cell-by-cell vs `origin/main` — **seules les cellules 16, 22, 28 (markdown) changent** ; 0 output / 0 `execution_count` / 0 cellule code touchée (C.2 exception, diagnostic dérivé firsthand des sorties commitées + `models.list()`).
- **Round-trip stable** `json.dumps(indent=1)` : pas de churn CRLF.
- **Catalogue byte-identique** à main.
- **C.1** : 0 violation.

### Pourquoi pas le code + re-exec (verdict SOTA : RECOVERABLE-MACHINE)

La correction complète est triviale (`model_name = "gpt-5"`, `temperature = 1`) + re-exécution, MAIS elle exige une **clé OpenAI valide** pour relancer les appels GPT-5 réels sur les frames vidéo. **po-2025 n'a pas de `.env`/clé OpenAI** (`OPENAI_API_KEY` absente → `openai_available=False`). La re-exécution appartient donc à la **lane GenAI** (po-2023, qui a la stack OpenAI + le budget API). Une PR markdown-only qui dirait « ça marche » serait malhonnête ; un patch code-only sans re-exec violerait C.2. Ce PR arrête le mensonge **maintenant** (markdown aligné sur les sorties 400 réelles) et documente le diagnostic précis + la route de résolution — `See #8274` (contribution partielle, le fix complet attend la lane GenAI).

See #8274. Contribution partielle (l'issue reste ouverte jusqu'à la re-exécution par la lane GenAI).
