### PR TITLE
fix(probas,#8081): Infer-101 probability-threshold defect (13 mislabeled as 18mn)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer-101.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer-101.ipynb
@@ -151,7 +151,7 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
-       "async function probeAddresses(probingAddresses) {\r\n",
+       
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -161,10 +161,10 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
-       "    if (Array.isArray(probingAddresses)) {\r\n",
-       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       
+       
        "\r\n",
-       "            let rootUrl = probingAddresses[i];\r\n",
+       
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -179,7 +179,7 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
-       "                    body: probingAddresses[i]\r\n",
+       
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -191,8 +191,8 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
-       "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://2a01:cb14:11a:e100:1173:a4f3:3c59:d15d:2048/\",\"http://2a01:cb14:11a:e100:8ca1:dccb:4973:12ce:2048/\",\"http://fe80::1a3e:4483:b69e:11bc%12:2048/\",\"http://192.168.0.46:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::4050:b6c1:81f8:3162%24:2048/\",\"http://172.31.16.1:2048/\",\"http://fe80::71be:4d39:59da:67f4%49:2048/\",\"http://172.26.208.1:2048/\"])\r\n",
+       
+       
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
@@ -241,13 +241,13 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
-       "        loadDotnetInteractiveApi();\r\n",
+       
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
-       "    loadDotnetInteractiveApi();\r\n",
+       
        "}\r\n",
        "\r\n",
        "    </script>\r\n",

--- a/MyIA.AI.Notebooks/Probas/Infer-101.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer-101.ipynb
@@ -124,10 +124,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:34:01.418893Z",
-     "iopub.status.busy": "2026-06-04T06:34:01.406126Z",
-     "iopub.status.idle": "2026-06-04T06:34:04.013321Z",
-     "shell.execute_reply": "2026-06-04T06:34:04.010235Z"
+     "iopub.execute_input": "2026-07-24T09:50:57.982146Z",
+     "iopub.status.busy": "2026-07-24T09:50:57.976255Z",
+     "iopub.status.idle": "2026-07-24T09:51:10.803917Z",
+     "shell.execute_reply": "2026-07-24T09:51:10.799683Z"
     },
     "papermill": {
      "duration": 2.713736,
@@ -145,11 +145,133 @@
     {
      "data": {
       "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://2a01:cb14:11a:e100:1173:a4f3:3c59:d15d:2048/\",\"http://2a01:cb14:11a:e100:8ca1:dccb:4973:12ce:2048/\",\"http://fe80::1a3e:4483:b69e:11bc%12:2048/\",\"http://192.168.0.46:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::4050:b6c1:81f8:3162%24:2048/\",\"http://172.31.16.1:2048/\",\"http://fe80::71be:4d39:59da:67f4%49:2048/\",\"http://172.26.208.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '1812.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
        "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>Microsoft.ML.Probabilistic, 0.4.2504.701</span></li><li><span>Microsoft.ML.Probabilistic.Compiler, 0.4.2504.701</span></li></ul></div></div>"
       ]
      },
      "metadata": {},
      "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Packages NuGet Microsoft.ML.Probabilistic charges\r\n"
+     ]
     }
    ],
    "source": [
@@ -202,10 +324,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:34:04.446222Z",
-     "iopub.status.busy": "2026-06-04T06:34:04.445868Z",
-     "iopub.status.idle": "2026-06-04T06:34:05.225330Z",
-     "shell.execute_reply": "2026-06-04T06:34:05.225129Z"
+     "iopub.execute_input": "2026-07-24T09:51:10.805251Z",
+     "iopub.status.busy": "2026-07-24T09:51:10.805070Z",
+     "iopub.status.idle": "2026-07-24T09:51:10.852319Z",
+     "shell.execute_reply": "2026-07-24T09:51:10.852140Z"
     },
     "papermill": {
      "duration": 0.841596,
@@ -270,10 +392,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:34:05.591350Z",
-     "iopub.status.busy": "2026-06-04T06:34:05.591022Z",
-     "iopub.status.idle": "2026-06-04T06:34:08.107581Z",
-     "shell.execute_reply": "2026-06-04T06:34:08.107378Z"
+     "iopub.execute_input": "2026-07-24T09:51:10.853772Z",
+     "iopub.status.busy": "2026-07-24T09:51:10.853581Z",
+     "iopub.status.idle": "2026-07-24T09:51:12.736115Z",
+     "shell.execute_reply": "2026-07-24T09:51:12.735935Z"
     },
     "papermill": {
      "duration": 2.605534,
@@ -373,10 +495,10 @@
    "id": "b2f446be",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:34:08.724078Z",
-     "iopub.status.busy": "2026-06-04T06:34:08.723729Z",
-     "iopub.status.idle": "2026-06-04T06:34:08.761418Z",
-     "shell.execute_reply": "2026-06-04T06:34:08.761207Z"
+     "iopub.execute_input": "2026-07-24T09:51:12.737397Z",
+     "iopub.status.busy": "2026-07-24T09:51:12.737222Z",
+     "iopub.status.idle": "2026-07-24T09:51:12.766213Z",
+     "shell.execute_reply": "2026-07-24T09:51:12.766038Z"
     },
     "papermill": {
      "duration": 0.110266,
@@ -445,10 +567,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:34:09.086159Z",
-     "iopub.status.busy": "2026-06-04T06:34:09.085718Z",
-     "iopub.status.idle": "2026-06-04T06:34:09.139637Z",
-     "shell.execute_reply": "2026-06-04T06:34:09.139092Z"
+     "iopub.execute_input": "2026-07-24T09:51:12.767316Z",
+     "iopub.status.busy": "2026-07-24T09:51:12.767133Z",
+     "iopub.status.idle": "2026-07-24T09:51:12.821114Z",
+     "shell.execute_reply": "2026-07-24T09:51:12.820734Z"
     },
     "papermill": {
      "duration": 0.120568,
@@ -504,10 +626,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:34:09.625527Z",
-     "iopub.status.busy": "2026-06-04T06:34:09.625039Z",
-     "iopub.status.idle": "2026-06-04T06:34:09.670749Z",
-     "shell.execute_reply": "2026-06-04T06:34:09.670533Z"
+     "iopub.execute_input": "2026-07-24T09:51:12.823036Z",
+     "iopub.status.busy": "2026-07-24T09:51:12.822770Z",
+     "iopub.status.idle": "2026-07-24T09:51:12.871605Z",
+     "shell.execute_reply": "2026-07-24T09:51:12.871424Z"
     },
     "papermill": {
      "duration": 0.227827,
@@ -566,10 +688,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:34:10.142979Z",
-     "iopub.status.busy": "2026-06-04T06:34:10.142666Z",
-     "iopub.status.idle": "2026-06-04T06:34:10.178501Z",
-     "shell.execute_reply": "2026-06-04T06:34:10.178224Z"
+     "iopub.execute_input": "2026-07-24T09:51:12.873032Z",
+     "iopub.status.busy": "2026-07-24T09:51:12.872843Z",
+     "iopub.status.idle": "2026-07-24T09:51:12.905509Z",
+     "shell.execute_reply": "2026-07-24T09:51:12.905319Z"
     },
     "papermill": {
      "duration": 0.147775,
@@ -626,10 +748,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:34:10.620219Z",
-     "iopub.status.busy": "2026-06-04T06:34:10.619886Z",
-     "iopub.status.idle": "2026-06-04T06:34:12.225967Z",
-     "shell.execute_reply": "2026-06-04T06:34:12.215716Z"
+     "iopub.execute_input": "2026-07-24T09:51:12.906941Z",
+     "iopub.status.busy": "2026-07-24T09:51:12.906758Z",
+     "iopub.status.idle": "2026-07-24T09:51:13.494831Z",
+     "shell.execute_reply": "2026-07-24T09:51:13.493264Z"
     },
     "papermill": {
      "duration": 1.678054,
@@ -1102,10 +1224,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:34:12.972096Z",
-     "iopub.status.busy": "2026-06-04T06:34:12.970378Z",
-     "iopub.status.idle": "2026-06-04T06:34:13.847999Z",
-     "shell.execute_reply": "2026-06-04T06:34:13.833800Z"
+     "iopub.execute_input": "2026-07-24T09:51:13.496383Z",
+     "iopub.status.busy": "2026-07-24T09:51:13.496178Z",
+     "iopub.status.idle": "2026-07-24T09:51:13.900558Z",
+     "shell.execute_reply": "2026-07-24T09:51:13.894326Z"
     },
     "papermill": {
      "duration": 1.036832,
@@ -1569,10 +1691,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:34:14.853033Z",
-     "iopub.status.busy": "2026-06-04T06:34:14.852612Z",
-     "iopub.status.idle": "2026-06-04T06:34:15.248295Z",
-     "shell.execute_reply": "2026-06-04T06:34:15.234993Z"
+     "iopub.execute_input": "2026-07-24T09:51:13.902688Z",
+     "iopub.status.busy": "2026-07-24T09:51:13.902493Z",
+     "iopub.status.idle": "2026-07-24T09:51:14.342642Z",
+     "shell.execute_reply": "2026-07-24T09:51:14.335896Z"
     },
     "papermill": {
      "duration": 0.511932,
@@ -2036,10 +2158,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:34:16.164355Z",
-     "iopub.status.busy": "2026-06-04T06:34:16.164070Z",
-     "iopub.status.idle": "2026-06-04T06:34:16.227196Z",
-     "shell.execute_reply": "2026-06-04T06:34:16.227003Z"
+     "iopub.execute_input": "2026-07-24T09:51:14.344308Z",
+     "iopub.status.busy": "2026-07-24T09:51:14.344070Z",
+     "iopub.status.idle": "2026-07-24T09:51:14.410053Z",
+     "shell.execute_reply": "2026-07-24T09:51:14.409825Z"
     },
     "papermill": {
      "duration": 0.201305,
@@ -2137,10 +2259,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:34:16.884465Z",
-     "iopub.status.busy": "2026-06-04T06:34:16.884153Z",
-     "iopub.status.idle": "2026-06-04T06:34:17.003505Z",
-     "shell.execute_reply": "2026-06-04T06:34:17.003162Z"
+     "iopub.execute_input": "2026-07-24T09:51:14.411510Z",
+     "iopub.status.busy": "2026-07-24T09:51:14.411266Z",
+     "iopub.status.idle": "2026-07-24T09:51:14.482066Z",
+     "shell.execute_reply": "2026-07-24T09:51:14.481843Z"
     },
     "papermill": {
      "duration": 0.254502,
@@ -2222,10 +2344,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:34:17.614484Z",
-     "iopub.status.busy": "2026-06-04T06:34:17.614089Z",
-     "iopub.status.idle": "2026-06-04T06:34:17.651909Z",
-     "shell.execute_reply": "2026-06-04T06:34:17.651701Z"
+     "iopub.execute_input": "2026-07-24T09:51:14.483479Z",
+     "iopub.status.busy": "2026-07-24T09:51:14.483226Z",
+     "iopub.status.idle": "2026-07-24T09:51:14.519733Z",
+     "shell.execute_reply": "2026-07-24T09:51:14.519470Z"
     },
     "papermill": {
      "duration": 0.181117,
@@ -2304,10 +2426,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:34:18.231642Z",
-     "iopub.status.busy": "2026-06-04T06:34:18.231289Z",
-     "iopub.status.idle": "2026-06-04T06:34:18.850577Z",
-     "shell.execute_reply": "2026-06-04T06:34:18.850349Z"
+     "iopub.execute_input": "2026-07-24T09:51:14.521261Z",
+     "iopub.status.busy": "2026-07-24T09:51:14.520901Z",
+     "iopub.status.idle": "2026-07-24T09:51:14.992295Z",
+     "shell.execute_reply": "2026-07-24T09:51:14.992031Z"
     },
     "papermill": {
      "duration": 0.758024,
@@ -2782,10 +2904,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:34:19.941927Z",
-     "iopub.status.busy": "2026-06-04T06:34:19.941545Z",
-     "iopub.status.idle": "2026-06-04T06:34:20.344469Z",
-     "shell.execute_reply": "2026-06-04T06:34:20.344253Z"
+     "iopub.execute_input": "2026-07-24T09:51:14.993828Z",
+     "iopub.status.busy": "2026-07-24T09:51:14.993612Z",
+     "iopub.status.idle": "2026-07-24T09:51:15.492864Z",
+     "shell.execute_reply": "2026-07-24T09:51:15.492697Z"
     },
     "papermill": {
      "duration": 0.577257,
@@ -2839,7 +2961,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Probabilité que le trajet prenne moins de 18mn: 0,25\r\n"
+      "Probabilité que le trajet prenne moins de 18mn: 0,70\r\n"
      ]
     }
    ],
@@ -2850,7 +2972,7 @@
     "Gaussian distribDemain = maPrediction.EstimerTempsDemain();\n",
     "\n",
     "Console.WriteLine($\"Prédiction demain: {distribDemain}, écart type: {Math.Sqrt(distribDemain.GetVariance())}\");\n",
-    "double probMoinsDe18Mn = maPrediction.EstimerTempsDemainInferieurA(13).GetProbTrue();\n",
+    "double probMoinsDe18Mn = maPrediction.EstimerTempsDemainInferieurA(18).GetProbTrue();\n",
     "Console.WriteLine($\"Probabilité que le trajet prenne moins de 18mn: {probMoinsDe18Mn:F2}\");"
    ]
   },
@@ -2873,7 +2995,7 @@
     "Le modèle OO produit **les mêmes résultats que le modèle plat** (même algorithme, meilleure architecture) :\n",
     "\n",
     "- **Prediction demain** : Gaussian(15.85, 17.1) → moyenne 15.85 min, ecart type 4.14 min\n",
-    "- **P(trajet < 18 min)** : 0.25 (25% de chances)\n",
+    "- **P(trajet < 18 min)** : 0.70 (70% de chances)\n",
     "\n",
     "La refactorisation OO n'affecte pas les résultats numériques, mais permet de :\n",
     "1. Reutiliser les classes pour plusieurs cyclistes independants\n",
@@ -2932,10 +3054,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:34:21.739327Z",
-     "iopub.status.busy": "2026-06-04T06:34:21.738830Z",
-     "iopub.status.idle": "2026-06-04T06:34:21.802049Z",
-     "shell.execute_reply": "2026-06-04T06:34:21.795637Z"
+     "iopub.execute_input": "2026-07-24T09:51:15.494161Z",
+     "iopub.status.busy": "2026-07-24T09:51:15.493974Z",
+     "iopub.status.idle": "2026-07-24T09:51:15.543973Z",
+     "shell.execute_reply": "2026-07-24T09:51:15.541386Z"
     },
     "papermill": {
      "duration": 0.235074,
@@ -3393,10 +3515,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:34:23.000388Z",
-     "iopub.status.busy": "2026-06-04T06:34:22.998139Z",
-     "iopub.status.idle": "2026-06-04T06:34:23.199289Z",
-     "shell.execute_reply": "2026-06-04T06:34:23.199049Z"
+     "iopub.execute_input": "2026-07-24T09:51:15.545545Z",
+     "iopub.status.busy": "2026-07-24T09:51:15.545286Z",
+     "iopub.status.idle": "2026-07-24T09:51:15.883239Z",
+     "shell.execute_reply": "2026-07-24T09:51:15.883015Z"
     },
     "papermill": {
      "duration": 0.39305,
@@ -3443,7 +3565,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Probabilité que le trajet prenne moins de 18mn: 0,23\r\n"
+      "Probabilité que le trajet prenne moins de 18mn: 0,47\r\n"
      ]
     }
    ],
@@ -3452,7 +3574,7 @@
     "Gaussian distribDemain = maPrediction.EstimerTempsDemain();\n",
     "Console.WriteLine($\"Prédiction demain: {distribDemain}\");\n",
     "Console.WriteLine($\"Ecart type: {Math.Sqrt(distribDemain.GetVariance())}\");\n",
-    "double probMoinsDe18Mn = maPrediction.EstimerTempsDemainInferieurA(13).GetProbTrue();\n",
+    "double probMoinsDe18Mn = maPrediction.EstimerTempsDemainInferieurA(18).GetProbTrue();\n",
     "Console.WriteLine($\"Probabilité que le trajet prenne moins de 18mn: {probMoinsDe18Mn:F2}\");"
    ]
   },
@@ -3478,7 +3600,7 @@
     "|----------|-----------------|-----------------|-----------|\n",
     "| Moyenne predictive | 15.85 min | 18.49 min | +2.64 min |\n",
     "| Ecart type | 4.14 min | 7.36 min | Plus incertain |\n",
-    "| P(trajet < 18 min) | 0.25 | 0.23 | Quasi identique |\n",
+    "| P(trajet < 18 min) | 0.70 | 0.47 | Baisse (-0.23) |\n",
     "\n",
     "L'augmentation de l'ecart type reflete que la deuxieme semaine avait une forte variabilite (de 11 a 30 min). L'apprentissage en ligne a correctement integre ces nouvelles informations sans oublier la semaine précédente."
    ]
@@ -3517,10 +3639,10 @@
    "id": "880b91b6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:34:24.511926Z",
-     "iopub.status.busy": "2026-06-04T06:34:24.511581Z",
-     "iopub.status.idle": "2026-06-04T06:34:24.543277Z",
-     "shell.execute_reply": "2026-06-04T06:34:24.543065Z"
+     "iopub.execute_input": "2026-07-24T09:51:15.885214Z",
+     "iopub.status.busy": "2026-07-24T09:51:15.884934Z",
+     "iopub.status.idle": "2026-07-24T09:51:15.920813Z",
+     "shell.execute_reply": "2026-07-24T09:51:15.920566Z"
     },
     "papermill": {
      "duration": 0.246085,
@@ -3582,10 +3704,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:34:25.381524Z",
-     "iopub.status.busy": "2026-06-04T06:34:25.381216Z",
-     "iopub.status.idle": "2026-06-04T06:34:25.447461Z",
-     "shell.execute_reply": "2026-06-04T06:34:25.447240Z"
+     "iopub.execute_input": "2026-07-24T09:51:15.922353Z",
+     "iopub.status.busy": "2026-07-24T09:51:15.922012Z",
+     "iopub.status.idle": "2026-07-24T09:51:15.998878Z",
+     "shell.execute_reply": "2026-07-24T09:51:15.998609Z"
     },
     "papermill": {
      "duration": 0.260387,
@@ -3605,11 +3727,11 @@
      "output_type": "stream",
      "text": [
       "\r\n",
+      "(5,26): warning CS0649: Le champ 'DonneesCyclisteMixte.DistribMixe' n'est jamais assigné et aura toujours sa valeur par défaut null\r\n",
+      "\r\n",
       "(4,24): warning CS0649: Le champ 'DonneesCyclisteMixte.DistribBruitTraffic' n'est jamais assigné et aura toujours sa valeur par défaut null\r\n",
       "\r\n",
       "(3,27): warning CS0649: Le champ 'DonneesCyclisteMixte.DistribMoyenne' n'est jamais assigné et aura toujours sa valeur par défaut null\r\n",
-      "\r\n",
-      "(5,26): warning CS0649: Le champ 'DonneesCyclisteMixte.DistribMixe' n'est jamais assigné et aura toujours sa valeur par défaut null\r\n",
       "\r\n"
      ]
     }
@@ -3689,10 +3811,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:34:26.367947Z",
-     "iopub.status.busy": "2026-06-04T06:34:26.367348Z",
-     "iopub.status.idle": "2026-06-04T06:34:26.412382Z",
-     "shell.execute_reply": "2026-06-04T06:34:26.412163Z"
+     "iopub.execute_input": "2026-07-24T09:51:16.000302Z",
+     "iopub.status.busy": "2026-07-24T09:51:15.999999Z",
+     "iopub.status.idle": "2026-07-24T09:51:16.039627Z",
+     "shell.execute_reply": "2026-07-24T09:51:16.039247Z"
     },
     "papermill": {
      "duration": 0.330089,
@@ -3779,10 +3901,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:34:27.371492Z",
-     "iopub.status.busy": "2026-06-04T06:34:27.370456Z",
-     "iopub.status.idle": "2026-06-04T06:34:27.447570Z",
-     "shell.execute_reply": "2026-06-04T06:34:27.447110Z"
+     "iopub.execute_input": "2026-07-24T09:51:16.041059Z",
+     "iopub.status.busy": "2026-07-24T09:51:16.040867Z",
+     "iopub.status.idle": "2026-07-24T09:51:16.076890Z",
+     "shell.execute_reply": "2026-07-24T09:51:16.076573Z"
     },
     "papermill": {
      "duration": 0.386423,
@@ -3859,10 +3981,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:34:28.513038Z",
-     "iopub.status.busy": "2026-06-04T06:34:28.512271Z",
-     "iopub.status.idle": "2026-06-04T06:34:29.049826Z",
-     "shell.execute_reply": "2026-06-04T06:34:29.029722Z"
+     "iopub.execute_input": "2026-07-24T09:51:16.078056Z",
+     "iopub.status.busy": "2026-07-24T09:51:16.077864Z",
+     "iopub.status.idle": "2026-07-24T09:51:16.826733Z",
+     "shell.execute_reply": "2026-07-24T09:51:16.818953Z"
     },
     "papermill": {
      "duration": 0.876354,
@@ -4370,10 +4492,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:34:30.529731Z",
-     "iopub.status.busy": "2026-06-04T06:34:30.528879Z",
-     "iopub.status.idle": "2026-06-04T06:34:30.940838Z",
-     "shell.execute_reply": "2026-06-04T06:34:30.921256Z"
+     "iopub.execute_input": "2026-07-24T09:51:16.828691Z",
+     "iopub.status.busy": "2026-07-24T09:51:16.828461Z",
+     "iopub.status.idle": "2026-07-24T09:51:17.546448Z",
+     "shell.execute_reply": "2026-07-24T09:51:17.534714Z"
     },
     "papermill": {
      "duration": 0.695772,
@@ -4848,10 +4970,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:34:32.580430Z",
-     "iopub.status.busy": "2026-06-04T06:34:32.580124Z",
-     "iopub.status.idle": "2026-06-04T06:34:32.620337Z",
-     "shell.execute_reply": "2026-06-04T06:34:32.620004Z"
+     "iopub.execute_input": "2026-07-24T09:51:17.548139Z",
+     "iopub.status.busy": "2026-07-24T09:51:17.547896Z",
+     "iopub.status.idle": "2026-07-24T09:51:17.598248Z",
+     "shell.execute_reply": "2026-07-24T09:51:17.598013Z"
     },
     "papermill": {
      "duration": 0.325363,
@@ -4927,10 +5049,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:34:34.115431Z",
-     "iopub.status.busy": "2026-06-04T06:34:34.112050Z",
-     "iopub.status.idle": "2026-06-04T06:34:34.164406Z",
-     "shell.execute_reply": "2026-06-04T06:34:34.164194Z"
+     "iopub.execute_input": "2026-07-24T09:51:17.599660Z",
+     "iopub.status.busy": "2026-07-24T09:51:17.599437Z",
+     "iopub.status.idle": "2026-07-24T09:51:17.640270Z",
+     "shell.execute_reply": "2026-07-24T09:51:17.640068Z"
     },
     "papermill": {
      "duration": 0.427062,
@@ -5006,10 +5128,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:34:35.265861Z",
-     "iopub.status.busy": "2026-06-04T06:34:35.265480Z",
-     "iopub.status.idle": "2026-06-04T06:34:35.298373Z",
-     "shell.execute_reply": "2026-06-04T06:34:35.298158Z"
+     "iopub.execute_input": "2026-07-24T09:51:17.641803Z",
+     "iopub.status.busy": "2026-07-24T09:51:17.641563Z",
+     "iopub.status.idle": "2026-07-24T09:51:17.682214Z",
+     "shell.execute_reply": "2026-07-24T09:51:17.681746Z"
     },
     "papermill": {
      "duration": 0.306873,
@@ -5085,10 +5207,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:34:36.640574Z",
-     "iopub.status.busy": "2026-06-04T06:34:36.639994Z",
-     "iopub.status.idle": "2026-06-04T06:34:37.588062Z",
-     "shell.execute_reply": "2026-06-04T06:34:37.572149Z"
+     "iopub.execute_input": "2026-07-24T09:51:17.683995Z",
+     "iopub.status.busy": "2026-07-24T09:51:17.683701Z",
+     "iopub.status.idle": "2026-07-24T09:51:19.213475Z",
+     "shell.execute_reply": "2026-07-24T09:51:19.210007Z"
     },
     "papermill": {
      "duration": 1.239184,
@@ -5972,10 +6094,10 @@
    "id": "2fb49e4b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-04T06:34:39.505412Z",
-     "iopub.status.busy": "2026-06-04T06:34:39.504960Z",
-     "iopub.status.idle": "2026-06-04T06:34:39.538880Z",
-     "shell.execute_reply": "2026-06-04T06:34:39.538668Z"
+     "iopub.execute_input": "2026-07-24T09:51:19.215297Z",
+     "iopub.status.busy": "2026-07-24T09:51:19.215054Z",
+     "iopub.status.idle": "2026-07-24T09:51:19.252138Z",
+     "shell.execute_reply": "2026-07-24T09:51:19.251757Z"
     },
     "papermill": {
      "duration": 0.372638,
@@ -6076,7 +6198,7 @@
    "mimetype": "text/x-csharp",
    "name": "C#",
    "pygments_lexer": "csharp",
-   "version": "12.0"
+   "version": "13.0"
   },
   "papermill": {
    "default_parameters": {},


### PR DESCRIPTION
## Defect (audit #8081 — claim-vs-output fidelity)

`Infer-101.ipynb` cells **36** and **43** call `EstimerTempsDemainInferieurA(13)` while the prose, the variable name (`probMoinsDe18Mn`), the `Console.WriteLine` label, and the surrounding markdown all announce **"moins de 18 minutes"**. The committed outputs (`0.25` / `0.23`) were therefore `P(X<13)`, not `P(X<18)` — the code computed a different quantity than what it claimed.

## Fix

Pass `18` as the threshold so the code computes the probability the prose announces. Re-executed end-to-end with the `.net-csharp` kernel:

| cell | predictive | before | after | cross-check |
|------|-----------|--------|-------|-------------|
| 36 (week 1) | Gaussian(15.85, var 17.1) | 0.25 | **0.70** | NormalDist P(X<18 \| μ=15.85, σ=4.14) = 0.698 |
| 43 (week 2) | Gaussian(18.49, var 54.19) | 0.23 | **0.47** | NormalDist P(X<18 \| μ=18.49, σ=7.36) = 0.473 |

Markdown aligned (values were the same stale `P(X<13)`):
- **md[37]**: `P(trajet < 18 min) 0.25` → `0.70 (70% de chances)`
- **md[44]**: table `0.25 / 0.23` → `0.70 / 0.47`; verdict `Quasi identique` → `Baisse (-0.23)` — after week 2 the mean rose above 18 min and uncertainty grew, so `P(<18)` drops. Coherent.

The pre-existing predictive stats (μ 15.85 / 18.49, σ 4.14 / 7.36) were already correct and unchanged — only the P-values (which used the wrong threshold) and the now-invalid comparison verdict moved.

## Incidental honest re-exec byproducts (kept, not hand-edited — Stop & Repair)

- **cell[2]**: restored the missing `Packages NuGet Microsoft.ML.Probabilistic chargés` output (was `execution_count=1` with empty `outputs` — a latent C.2 gap).
- **cell[48]**: Roslyn `CS0649` field-warning emission order is non-deterministic (same set of 3 warnings, reordered). Benign.

## Validation

- `python scripts/notebook_tools/validate_pr_notebooks.py origin/main …Infer-101.ipynb` → **PASS 28/28 cells** (.net-csharp).
- 0 errors, 0 null-exec, 0 `raise NotImplementedError`/`assert False`/`1/0` (C.1).
- `COURSE_CATALOG.generated.{json,md}` byte-identical to main.
- Infer.NET EP is deterministic on the hardcoded data; cells 36/43 are the only ones whose threshold moved, so the rest of the notebook is unaffected.

See #8081 (partial — Infer-101 audit-fidélité grain; the epic remains open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
