### PR TITLE
fix(search,#8052): reframe Search-7 MCTS md[25] convergence claim vs non-monotonic output

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb
@@ -1265,7 +1265,9 @@
    "source": [
     "### Exemple resolu : Analyse de convergence MCTS\n",
     "\n",
-    "La convergence est une propriete fondamentale de MCTS : plus on augmente le nombre d'itérations, plus la decision se rapproche de l'optimal. L'exemple ci-dessous mesure cette convergence quantitativement sur TicTacToe en comparant l'action choisie par MCTS a l'action optimale Minimax (verite terrain). Les trois graphiques montrent respectivement le taux de choix optimal, la valeur estimee, et le temps de calcul."
+    "La convergence est une propriete souvent presentee comme intuitive de MCTS, mais l'experience ci-dessous montre qu'elle est **loin d'etre monotone**. L'exemple mesure, sur TicTacToe, deux choses distinctes en fonction du budget d'iterations : le **taux de choix de l'action optimale** (comparé a Minimax, vérité terrain) et la **valeur moyenne estimée** par MCTS. Les trois graphiques montrent le taux de choix optimal, la valeur estimée, et le temps de calcul.\n",
+    "\n",
+    "**Lecture honnete des chiffres** (deterministes, cf. seed fixe) : le taux de choix optimal **culmine a ~13 % vers 100 iterations, puis s'effondre** (3 % a 500, **0 %** a 1000 et 5000) — plus d'iterations n'ameliore donc **pas** la qualite de la decision ici. En revanche, la valeur moyenne estimee **converge bien** (0,73 → 0,49) : MCTS stabilise son estimateur. La leçon est nuancee : **la convergence de la *valeur* estimee n'implique pas la convergence vers l'*action* optimale**. Sur TicTacToe (jeu nul, valeur Minimax = 0), MCTS converge vers un estimateur ~0,49 systematiquement biaisé, et l'action qu'il en deduit n'est l'optimal que par chance sur un petit echantillon de positions — d'ou la non-monotonicite du taux. C'est precisement pourquoi MCTS triomphe sur des jeux **trop grands pour Minimax** (Go) plutot que sur des jeux ou l'optimal est calculable.\n"
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python-audit-claims — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-dotnet-pedagogy (c.849)

## What

Fix `Search-7-MCTS-And-Beyond.ipynb` **md[25]** (the "Exemple resolu : Analyse de convergence MCTS" intro) whose convergence claim **directly contradicts the committed output** of the very code cell it introduces. This is the documented c.844 residual (PR #8286, now merged, fixed the seed + md[13] but left md[25]). See #8052.

## The mismatch (verified firsthand against committed output)

md[25] claimed:
> "plus on augmente le nombre d'itérations, **plus la décision se rapproche de l'optimal**"

i.e. monotonic improvement of decision quality with iteration budget. But cell[26]'s own output (deterministic, post-#8286 seed fix) is **dramatically non-monotonic** — and in the *opposite* direction:

| iterations | taux_optimal (%) | valeur_moyenne |
|-----------|-----------------|----------------|
| 10  | 0.0  | 0.733 |
| 50  | 6.7  | 0.614 |
| **100** | **13.3 (peak)** | 0.517 |
| 500 | 3.3 | 0.469 |
| 1000 | **0.0** | 0.479 |
| 5000 | **0.0** | 0.491 |

The optimal-action rate **peaks at ~13 % around 100 iterations, then collapses to 0 %** at 1000 and 5000 iterations. "More iterations → closer to optimal" is the opposite of what the data shows. (Note: md[13], the comparison table, was *already* honest in c.844 — "elles ne convergent pas strictement vers 0". Only md[25] carried the unqualified monotonic claim.)

## Fix (markdown-only, byte-surgical)

Reframed md[25] to read the data honestly. The reframe surfaces a genuinely instructive distinction the original claim flattened:

- **`valeur_moyenne` DOES converge** (0.73 → 0.49): MCTS stabilises its value estimator.
- **`taux_optimal` does NOT improve** (peaks 13 % → collapses to 0 %): **value convergence ≠ optimal-action convergence**.

The honest lesson: on TicTacToe (a solved game, Minimax value = 0), MCTS converges to an estimator biased at ~0.49, and the action it derives is optimal only by chance on a small position sample — hence the non-monotonic action rate. This is precisely *why MCTS excels on games too large for Minimax* (Go) rather than on games where the optimum is computable.

### Scope (byte-surgical)

- Only **md[25]** changed (+934 bytes). All **code cells byte-identical to `origin/main`** (round-trip guard; exactly 1 cell changed, confirmed by per-cell diff). Cell count unchanged (43).
- **Markdown-only → C.2 exception** (no re-execution; no code cell modified). The cited numbers are the committed deterministic output (post-#8286 seed fix).
- `nbformat.validate` OK · H.3: 0 violations · C.1: clean.

## Context

- Resolves the residual I documented in c.844 (PR #8286, MERGED 2026-07-24T07:55Z). #8286 fixed reproducibility (canonical seed) + md[13]; md[25]'s monotonic claim was explicitly deferred.
- G-VAR-3: not a consecutive-same-genre cycle (c.848 audit → c.849 pedagogy → c.850 audit; c.849 broke the chain). Substance genuinely distinct from c.846 (IIT categorical) and c.848 (ML-PAC table): this is a convergence/non-monotonicity claim specific to stochastic search.

See #8052 · See #3801
