### PR TITLE
feat(argument-analysis,#4960): AIF attack-node distribution (RA/I/CA) measured on real OWL

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb
@@ -5,10 +5,10 @@
    "id": "cell-0",
    "metadata": {
     "papermill": {
-     "duration": 0.004658,
-     "end_time": "2026-07-10T07:59:50.220890+00:00",
+     "duration": 0.008267,
+     "end_time": "2026-07-24T10:27:55.799390",
      "exception": false,
-     "start_time": "2026-07-10T07:59:50.216232+00:00",
+     "start_time": "2026-07-24T10:27:55.791123",
      "status": "completed"
     },
     "tags": []
@@ -48,10 +48,10 @@
    "id": "cell-1",
    "metadata": {
     "papermill": {
-     "duration": 0.003297,
-     "end_time": "2026-07-10T07:59:50.228069+00:00",
+     "duration": 0.002438,
+     "end_time": "2026-07-24T10:27:55.813704",
      "exception": false,
-     "start_time": "2026-07-10T07:59:50.224772+00:00",
+     "start_time": "2026-07-24T10:27:55.811266",
      "status": "completed"
     },
     "tags": []
@@ -77,10 +77,10 @@
    "id": "cell-2",
    "metadata": {
     "papermill": {
-     "duration": 0.003797,
-     "end_time": "2026-07-10T07:59:50.235336+00:00",
+     "duration": 0.002476,
+     "end_time": "2026-07-24T10:27:55.818044",
      "exception": false,
-     "start_time": "2026-07-10T07:59:50.231539+00:00",
+     "start_time": "2026-07-24T10:27:55.815568",
      "status": "completed"
     },
     "tags": []
@@ -95,16 +95,16 @@
    "id": "cell-3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T07:59:50.243126Z",
-     "iopub.status.busy": "2026-07-10T07:59:50.242593Z",
-     "iopub.status.idle": "2026-07-10T07:59:50.555215Z",
-     "shell.execute_reply": "2026-07-10T07:59:50.553559Z"
+     "iopub.execute_input": "2026-07-24T10:27:55.824125Z",
+     "iopub.status.busy": "2026-07-24T10:27:55.823872Z",
+     "iopub.status.idle": "2026-07-24T10:27:56.199607Z",
+     "shell.execute_reply": "2026-07-24T10:27:56.199106Z"
     },
     "papermill": {
-     "duration": 0.317607,
-     "end_time": "2026-07-10T07:59:50.556474+00:00",
+     "duration": 0.37992,
+     "end_time": "2026-07-24T10:27:56.200392",
      "exception": false,
-     "start_time": "2026-07-10T07:59:50.238867+00:00",
+     "start_time": "2026-07-24T10:27:55.820472",
      "status": "completed"
     },
     "tags": []
@@ -114,8 +114,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Chargement de : D:\\CoursIA\\.claude\\worktrees\\argumentum-ontology-refresh\\MyIA.AI.Notebooks\\SymbolicAI\\Argument_Analysis\\ontologies\\argumentum_fallacies.owl\n",
-      "Existe : True (taille = 6,000,847 octets)\n",
+      "Chargement de : D:\\Dev\\CoursIA-aif-distrib-863\\MyIA.AI.Notebooks\\SymbolicAI\\Argument_Analysis\\ontologies\\argumentum_fallacies.owl\n",
+      "Existe : True (taille = 5,904,124 octets)\n",
       "Longueur du texte : 5,892,331 caracteres, 96,770 lignes\n",
       "\n",
       "Cardinalite : ObjectExactCardinality=36, DataExactCardinality=0 (bien formes).\n"
@@ -170,10 +170,10 @@
    "id": "cell-4",
    "metadata": {
     "papermill": {
-     "duration": 0.003007,
-     "end_time": "2026-07-10T07:59:50.562361+00:00",
+     "duration": 0.002018,
+     "end_time": "2026-07-24T10:27:56.204867",
      "exception": false,
-     "start_time": "2026-07-10T07:59:50.559354+00:00",
+     "start_time": "2026-07-24T10:27:56.202849",
      "status": "completed"
     },
     "tags": []
@@ -187,10 +187,10 @@
    "id": "cell-5",
    "metadata": {
     "papermill": {
-     "duration": 0.002818,
-     "end_time": "2026-07-10T07:59:50.568159+00:00",
+     "duration": 0.002196,
+     "end_time": "2026-07-24T10:27:56.209093",
      "exception": false,
-     "start_time": "2026-07-10T07:59:50.565341+00:00",
+     "start_time": "2026-07-24T10:27:56.206897",
      "status": "completed"
     },
     "tags": []
@@ -218,16 +218,16 @@
    "id": "cell-6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T07:59:50.575874Z",
-     "iopub.status.busy": "2026-07-10T07:59:50.575356Z",
-     "iopub.status.idle": "2026-07-10T07:59:50.677303Z",
-     "shell.execute_reply": "2026-07-10T07:59:50.675639Z"
+     "iopub.execute_input": "2026-07-24T10:27:56.215121Z",
+     "iopub.status.busy": "2026-07-24T10:27:56.214909Z",
+     "iopub.status.idle": "2026-07-24T10:27:56.290847Z",
+     "shell.execute_reply": "2026-07-24T10:27:56.289505Z"
     },
     "papermill": {
-     "duration": 0.108007,
-     "end_time": "2026-07-10T07:59:50.679036+00:00",
+     "duration": 0.080816,
+     "end_time": "2026-07-24T10:27:56.292182",
      "exception": false,
-     "start_time": "2026-07-10T07:59:50.571029+00:00",
+     "start_time": "2026-07-24T10:27:56.211366",
      "status": "completed"
     },
     "tags": []
@@ -301,10 +301,10 @@
    "id": "cell-7",
    "metadata": {
     "papermill": {
-     "duration": 0.004153,
-     "end_time": "2026-07-10T07:59:50.688430+00:00",
+     "duration": 0.00325,
+     "end_time": "2026-07-24T10:27:56.299314",
      "exception": false,
-     "start_time": "2026-07-10T07:59:50.684277+00:00",
+     "start_time": "2026-07-24T10:27:56.296064",
      "status": "completed"
     },
     "tags": []
@@ -318,10 +318,10 @@
    "id": "cell-8",
    "metadata": {
     "papermill": {
-     "duration": 0.002911,
-     "end_time": "2026-07-10T07:59:50.695486+00:00",
+     "duration": 0.003217,
+     "end_time": "2026-07-24T10:27:56.305743",
      "exception": false,
-     "start_time": "2026-07-10T07:59:50.692575+00:00",
+     "start_time": "2026-07-24T10:27:56.302526",
      "status": "completed"
     },
     "tags": []
@@ -338,16 +338,16 @@
    "id": "cell-9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T07:59:50.704538Z",
-     "iopub.status.busy": "2026-07-10T07:59:50.703538Z",
-     "iopub.status.idle": "2026-07-10T07:59:50.785241Z",
-     "shell.execute_reply": "2026-07-10T07:59:50.783514Z"
+     "iopub.execute_input": "2026-07-24T10:27:56.313757Z",
+     "iopub.status.busy": "2026-07-24T10:27:56.313313Z",
+     "iopub.status.idle": "2026-07-24T10:27:56.339780Z",
+     "shell.execute_reply": "2026-07-24T10:27:56.338966Z"
     },
     "papermill": {
-     "duration": 0.087471,
-     "end_time": "2026-07-10T07:59:50.786601+00:00",
+     "duration": 0.032022,
+     "end_time": "2026-07-24T10:27:56.341036",
      "exception": false,
-     "start_time": "2026-07-10T07:59:50.699130+00:00",
+     "start_time": "2026-07-24T10:27:56.309014",
      "status": "completed"
     },
     "tags": []
@@ -358,13 +358,7 @@
      "output_type": "stream",
      "text": [
       "skos:prefLabel extraits : 2,816\n",
-      "Langues : {'FR': 1408, 'EN': 1408}\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Langues : {'FR': 1408, 'EN': 1408}\n",
       "Concepts distincts (par localname) : 1,306\n",
       "\n",
       "Classes de forme Walton-scheme (materialisation AIF_skos) : 100\n",
@@ -434,10 +428,10 @@
    "id": "cell-10",
    "metadata": {
     "papermill": {
-     "duration": 0.002883,
-     "end_time": "2026-07-10T07:59:50.792745+00:00",
+     "duration": 0.003097,
+     "end_time": "2026-07-24T10:27:56.347348",
      "exception": false,
-     "start_time": "2026-07-10T07:59:50.789862+00:00",
+     "start_time": "2026-07-24T10:27:56.344251",
      "status": "completed"
     },
     "tags": []
@@ -451,10 +445,10 @@
    "id": "cell-11",
    "metadata": {
     "papermill": {
-     "duration": 0.002799,
-     "end_time": "2026-07-10T07:59:50.798545+00:00",
+     "duration": 0.003244,
+     "end_time": "2026-07-24T10:27:56.353705",
      "exception": false,
-     "start_time": "2026-07-10T07:59:50.795746+00:00",
+     "start_time": "2026-07-24T10:27:56.350461",
      "status": "completed"
     },
     "tags": []
@@ -478,16 +472,16 @@
    "id": "cell-12",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T07:59:50.806857Z",
-     "iopub.status.busy": "2026-07-10T07:59:50.806339Z",
-     "iopub.status.idle": "2026-07-10T07:59:50.832079Z",
-     "shell.execute_reply": "2026-07-10T07:59:50.830972Z"
+     "iopub.execute_input": "2026-07-24T10:27:56.361918Z",
+     "iopub.status.busy": "2026-07-24T10:27:56.361361Z",
+     "iopub.status.idle": "2026-07-24T10:27:56.372980Z",
+     "shell.execute_reply": "2026-07-24T10:27:56.372301Z"
     },
     "papermill": {
-     "duration": 0.033849,
-     "end_time": "2026-07-10T07:59:50.835336+00:00",
+     "duration": 0.017089,
+     "end_time": "2026-07-24T10:27:56.374035",
      "exception": false,
-     "start_time": "2026-07-10T07:59:50.801487+00:00",
+     "start_time": "2026-07-24T10:27:56.356946",
      "status": "completed"
     },
     "tags": []
@@ -562,10 +556,10 @@
    "id": "cell-13",
    "metadata": {
     "papermill": {
-     "duration": 0.004857,
-     "end_time": "2026-07-10T07:59:50.845297+00:00",
+     "duration": 0.003445,
+     "end_time": "2026-07-24T10:27:56.381211",
      "exception": false,
-     "start_time": "2026-07-10T07:59:50.840440+00:00",
+     "start_time": "2026-07-24T10:27:56.377766",
      "status": "completed"
     },
     "tags": []
@@ -579,10 +573,10 @@
    "id": "cell-14",
    "metadata": {
     "papermill": {
-     "duration": 0.003812,
-     "end_time": "2026-07-10T07:59:50.854348+00:00",
+     "duration": 0.003372,
+     "end_time": "2026-07-24T10:27:56.387822",
      "exception": false,
-     "start_time": "2026-07-10T07:59:50.850536+00:00",
+     "start_time": "2026-07-24T10:27:56.384450",
      "status": "completed"
     },
     "tags": []
@@ -604,16 +598,16 @@
    "id": "cell-15",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T07:59:50.863770Z",
-     "iopub.status.busy": "2026-07-10T07:59:50.863264Z",
-     "iopub.status.idle": "2026-07-10T07:59:50.893467Z",
-     "shell.execute_reply": "2026-07-10T07:59:50.891783Z"
+     "iopub.execute_input": "2026-07-24T10:27:56.396151Z",
+     "iopub.status.busy": "2026-07-24T10:27:56.395642Z",
+     "iopub.status.idle": "2026-07-24T10:27:56.411957Z",
+     "shell.execute_reply": "2026-07-24T10:27:56.411355Z"
     },
     "papermill": {
-     "duration": 0.036409,
-     "end_time": "2026-07-10T07:59:50.894522+00:00",
+     "duration": 0.02172,
+     "end_time": "2026-07-24T10:27:56.412997",
      "exception": false,
-     "start_time": "2026-07-10T07:59:50.858113+00:00",
+     "start_time": "2026-07-24T10:27:56.391277",
      "status": "completed"
     },
     "tags": []
@@ -685,10 +679,10 @@
    "id": "cell-16",
    "metadata": {
     "papermill": {
-     "duration": 0.003953,
-     "end_time": "2026-07-10T07:59:50.901950+00:00",
+     "duration": 0.003063,
+     "end_time": "2026-07-24T10:27:56.419486",
      "exception": false,
-     "start_time": "2026-07-10T07:59:50.897997+00:00",
+     "start_time": "2026-07-24T10:27:56.416423",
      "status": "completed"
     },
     "tags": []
@@ -699,19 +693,115 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cell-17",
+   "id": "aif-dist-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.003145,
-     "end_time": "2026-07-10T07:59:50.908638+00:00",
+     "duration": 0.003084,
+     "end_time": "2026-07-24T10:27:56.425642",
      "exception": false,
-     "start_time": "2026-07-10T07:59:50.905493+00:00",
+     "start_time": "2026-07-24T10:27:56.422558",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 7. Exercices\n",
+    "## 7. Distribution des attaques AIF par type de node\n",
+    "\n",
+    "Le §5 a inventorié **93 `aifAttackedNode`** (la couche AIF attack de l'OWL). Mais *quel type d'attaque* chaque sophisme porte-t-il ? En AIF (Argument Interchange Format), un node attaqué peut l'être à trois endroits distincts de la structure argumentative :\n",
+    "\n",
+    "- **RA-node** (*Rule-Application*) : l'attaque vise la **règle d'inférence** elle-même — en ASPIC+, c'est un **undercut** (le raisonnement est défaillant, indépendamment de la vérité des prémisses) ;\n",
+    "- **I-node** (*Information*) : l'attaque vise une **prémisse / information** — c'est un **undermine** (la donnée invoquée est fausse ou douteuse) ;\n",
+    "- **CA-node** (*Conflict-Application*) : l'attaque vise la **conclusion** — c'est un **rebut** (on conteste la conclusion elle-même, sans toucher au raisonnement qui y mène).\n",
+    "\n",
+    "Compter la répartition de ces trois cibles révèle la **structure dominante** de la modélisation Argumentum : les sophismes attaquent-ils plutôt le raisonnement, la preuve, ou la conclusion ?\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "aif-dist-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-24T10:27:56.433237Z",
+     "iopub.status.busy": "2026-07-24T10:27:56.432823Z",
+     "iopub.status.idle": "2026-07-24T10:27:56.440871Z",
+     "shell.execute_reply": "2026-07-24T10:27:56.440072Z"
+    },
+    "papermill": {
+     "duration": 0.013427,
+     "end_time": "2026-07-24T10:27:56.442259",
+     "exception": false,
+     "start_time": "2026-07-24T10:27:56.428832",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "aifAttackedNode total : 93\n",
+      "  RA-node (undercut, attaque l'inference)  :  61  (66%)\n",
+      "  I-node  (undermine, attaque la premisse) :  29  (31%)\n",
+      "  CA-node (rebut, attaque la conclusion)   :   3  (3%)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Distribution des 93 aifAttackedNode par type de node AIF (RA / I / CA) ---\n",
+    "from collections import Counter\n",
+    "\n",
+    "aif_target = Counter()\n",
+    "for pred_iri, _subj, obj_iri in AA_RES:\n",
+    "    pred = pred_iri.rstrip(\"#\").split(\"#\")[-1].split(\"/\")[-1]\n",
+    "    if pred == \"aifAttackedNode\":\n",
+    "        node_type = obj_iri.rstrip(\"#\").split(\"#\")[-1].split(\"/\")[-1]\n",
+    "        aif_target[node_type] += 1\n",
+    "\n",
+    "total = sum(aif_target.values())\n",
+    "print(f\"aifAttackedNode total : {total}\")\n",
+    "print(f\"  RA-node (undercut, attaque l'inference)  : {aif_target['RA-node']:>3d}  ({aif_target['RA-node']/total:.0%})\")\n",
+    "print(f\"  I-node  (undermine, attaque la premisse) : {aif_target['I-node']:>3d}  ({aif_target['I-node']/total:.0%})\")\n",
+    "print(f\"  CA-node (rebut, attaque la conclusion)   : {aif_target['CA-node']:>3d}  ({aif_target['CA-node']/total:.0%})\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aif-dist-interp",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00313,
+     "end_time": "2026-07-24T10:27:56.448811",
+     "exception": false,
+     "start_time": "2026-07-24T10:27:56.445681",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Lecture** : la modélisation AIF d'Argumentum est massivement dominée par l'**undercut** (RA-node = 61/93, ~66 %) — les sophismes attaquent le plus souvent la **règle d'inférence** (le raisonnement est défaillant), bien avant la **prémisse** (I-node = 29, undermine) et surtout la **conclusion** (CA-node = 3 seulement, rebut marginal). Cette structure (undercut ≫ undermine ≫ rebut) traduit l'orientation de la théorie de l'argumentation : un sophisme est d'abord un **défaut de raisonnement**, non pas simplement une conclusion fausse.\n",
+    "\n",
+    "> Lien avec le §6 : la grappe Equivoque (`semanticAmbiguity`) porte `aifAttackedNode → RA-node` — c'est bien un **undercut** (le sophisme d'équivoque attaque l'usage du terme *dans l'inférence*, pas la conclusion), ce que la distribution globale confirme comme le cas majoritaire. Le rebut (CA-node = 3) est rare : dans cette taxonomie, on conteste rarement une conclusion *sans* remettre en cause le raisonnement qui y mène.\n",
+    "\n",
+    "**Précaution méthodologique** : ce compte (93) reflète l'état de l'OWL **réellement commité** dans CoursIA (`ontologies/argumentum_fallacies.owl`). Des snapshots antérieurs du dépôt Argumentum portaient des nombres plus élevés (~145 nodes modélisés) ; l'écart s'explique par l'évolution du générateur OWL (#763) et la révision du submodule pin — toujours fonder l'analyse sur l'OWL réellement présent, jamais sur un nombre rapporté d'une révision externe.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-17",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003369,
+     "end_time": "2026-07-24T10:27:56.455408",
+     "exception": false,
+     "start_time": "2026-07-24T10:27:56.452039",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 8. Exercices\n",
     "\n",
     "Trois exercices formels (règle #2161 : >= 3 exos par notebook pedagogique). Chaque exercice est un *stub* `print(\"Exercice a completer\")` que l'etudiant complete.\n",
     "\n",
@@ -722,20 +812,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "cell-18",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T07:59:50.918514Z",
-     "iopub.status.busy": "2026-07-10T07:59:50.917999Z",
-     "iopub.status.idle": "2026-07-10T07:59:50.923800Z",
-     "shell.execute_reply": "2026-07-10T07:59:50.922709Z"
+     "iopub.execute_input": "2026-07-24T10:27:56.463051Z",
+     "iopub.status.busy": "2026-07-24T10:27:56.462797Z",
+     "iopub.status.idle": "2026-07-24T10:27:56.466856Z",
+     "shell.execute_reply": "2026-07-24T10:27:56.466254Z"
     },
     "papermill": {
-     "duration": 0.012944,
-     "end_time": "2026-07-10T07:59:50.925099+00:00",
+     "duration": 0.008843,
+     "end_time": "2026-07-24T10:27:56.467782",
      "exception": false,
-     "start_time": "2026-07-10T07:59:50.912155+00:00",
+     "start_time": "2026-07-24T10:27:56.458939",
      "status": "completed"
     },
     "tags": []
@@ -762,10 +852,10 @@
    "id": "cell-19",
    "metadata": {
     "papermill": {
-     "duration": 0.003143,
-     "end_time": "2026-07-10T07:59:50.931464+00:00",
+     "duration": 0.003303,
+     "end_time": "2026-07-24T10:27:56.474157",
      "exception": false,
-     "start_time": "2026-07-10T07:59:50.928321+00:00",
+     "start_time": "2026-07-24T10:27:56.470854",
      "status": "completed"
     },
     "tags": []
@@ -780,20 +870,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "cell-20",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T07:59:50.940563Z",
-     "iopub.status.busy": "2026-07-10T07:59:50.940047Z",
-     "iopub.status.idle": "2026-07-10T07:59:50.955105Z",
-     "shell.execute_reply": "2026-07-10T07:59:50.953469Z"
+     "iopub.execute_input": "2026-07-24T10:27:56.481695Z",
+     "iopub.status.busy": "2026-07-24T10:27:56.481431Z",
+     "iopub.status.idle": "2026-07-24T10:27:56.484995Z",
+     "shell.execute_reply": "2026-07-24T10:27:56.484487Z"
     },
     "papermill": {
-     "duration": 0.022097,
-     "end_time": "2026-07-10T07:59:50.957088+00:00",
+     "duration": 0.008718,
+     "end_time": "2026-07-24T10:27:56.485791",
      "exception": false,
-     "start_time": "2026-07-10T07:59:50.934991+00:00",
+     "start_time": "2026-07-24T10:27:56.477073",
      "status": "completed"
     },
     "tags": []
@@ -820,10 +910,10 @@
    "id": "cell-21",
    "metadata": {
     "papermill": {
-     "duration": 0.003907,
-     "end_time": "2026-07-10T07:59:50.965957+00:00",
+     "duration": 0.002879,
+     "end_time": "2026-07-24T10:27:56.492190",
      "exception": false,
-     "start_time": "2026-07-10T07:59:50.962050+00:00",
+     "start_time": "2026-07-24T10:27:56.489311",
      "status": "completed"
     },
     "tags": []
@@ -836,20 +926,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "cell-22",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T07:59:50.975135Z",
-     "iopub.status.busy": "2026-07-10T07:59:50.974590Z",
-     "iopub.status.idle": "2026-07-10T07:59:50.986161Z",
-     "shell.execute_reply": "2026-07-10T07:59:50.984242Z"
+     "iopub.execute_input": "2026-07-24T10:27:56.498799Z",
+     "iopub.status.busy": "2026-07-24T10:27:56.498573Z",
+     "iopub.status.idle": "2026-07-24T10:27:56.502060Z",
+     "shell.execute_reply": "2026-07-24T10:27:56.501529Z"
     },
     "papermill": {
-     "duration": 0.017864,
-     "end_time": "2026-07-10T07:59:50.987508+00:00",
+     "duration": 0.008298,
+     "end_time": "2026-07-24T10:27:56.503358",
      "exception": false,
-     "start_time": "2026-07-10T07:59:50.969644+00:00",
+     "start_time": "2026-07-24T10:27:56.495060",
      "status": "completed"
     },
     "tags": []
@@ -873,19 +963,77 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cell-23",
+   "id": "aif-ex4-md",
    "metadata": {
     "papermill": {
-     "duration": 0.004433,
-     "end_time": "2026-07-10T07:59:50.997754+00:00",
+     "duration": 0.002817,
+     "end_time": "2026-07-24T10:27:56.509407",
      "exception": false,
-     "start_time": "2026-07-10T07:59:50.993321+00:00",
+     "start_time": "2026-07-24T10:27:56.506590",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 8. Ponts avec la serie\n",
+    "### Exercice 4 -- Undercut vs undermine : quels sophismes attaquent la prémisse ?\n",
+    "\n",
+    "À partir de `AA_RES` et de la mesure du §7, lister les sophismes (par `localname` **et** `prefLabel` FR) dont l'attaque AIF cible un **I-node** (undermine) plutôt qu'un RA-node (undercut). Observer leur thème : l'undermine porte-t-il préférentiellement sur des sophismes de **preuve / témoignage** (où c'est l'*information* qui est attaquée) ?\n",
+    "\n",
+    "*Indice* : croiser `AA_RES` avec `taxonomy` (dict `localname → prefLabel`) pour récupérer les libellés. Bonus : afficher aussi le parent `broader` de chaque match (predicat `broader` dans `AA_RES`).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "aif-ex4-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-24T10:27:56.517453Z",
+     "iopub.status.busy": "2026-07-24T10:27:56.516954Z",
+     "iopub.status.idle": "2026-07-24T10:27:56.521629Z",
+     "shell.execute_reply": "2026-07-24T10:27:56.521011Z"
+    },
+    "papermill": {
+     "duration": 0.009924,
+     "end_time": "2026-07-24T10:27:56.522535",
+     "exception": false,
+     "start_time": "2026-07-24T10:27:56.512611",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 4 a completer\n",
+    "# TODO etudiant : a partir de AA_RES, filtrer les aifAttackedNode -> I-node (undermine).\n",
+    "# Croiser avec `taxonomy` (localname -> prefLabel) pour afficher le label FR de chaque match.\n",
+    "# Bonus : afficher aussi le parent `broader` de chaque match (predicat 'broader' dans AA_RES).\n",
+    "print(\"Exercice a completer\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-23",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003933,
+     "end_time": "2026-07-24T10:27:56.530074",
+     "exception": false,
+     "start_time": "2026-07-24T10:27:56.526141",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 9. Ponts avec la serie\n",
     "\n",
     "| Direction | Lien | Relation |\n",
     "|-----------|------|----------|\n",
@@ -923,18 +1071,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.13.3"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 3.346574,
-   "end_time": "2026-07-10T07:59:51.553184+00:00",
+   "duration": 2.869828,
+   "end_time": "2026-07-24T10:27:56.775266",
    "environment_variables": {},
    "exception": null,
    "input_path": "Argument_Analysis_Ontology_AIF.ipynb",
-   "output_path": "_aif_exec.ipynb",
+   "output_path": "Argument_Analysis_Ontology_AIF.ipynb",
    "parameters": {},
-   "start_time": "2026-07-10T07:59:48.206610+00:00",
+   "start_time": "2026-07-24T10:27:53.905438",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
Grain: DEEP/notebook-python — lane myia-po-2023:CoursIA — prev: #8316 (Infer-101 fix).

## What

Adds **§7 "Distribution des attaques AIF par type de node"** to `Argument_Analysis_Ontology_AIF.ipynb`, plus **Exercise 4** and renumbering (Exercises → §8, Ponts → §9).

The existing notebook (Volet A, #5782) inventories `aifAttackedNode = 93` (§5) but never breaks it down by **attack type**. The new code cell measures, on the OWL really committed in CoursIA:

| Attack | AIF node | Count | % |
|--------|----------|------:|--:|
| **undercut** (attacks the inference rule) | RA-node | **61** | 66% |
| **undermine** (attacks a premise) | I-node | **29** | 31% |
| **rebut** (attacks the conclusion) | CA-node | **3** | 3% |

**Reading**: Argumentum's fallacies are overwhelmingly *undercuts* (defects of reasoning), rarely *rebuts*. Ties back to the Equivoque subgraph of §6 (`aifAttackedNode → RA-node` = undercut, the majority case confirmed).

## Why grounded on the real OWL (G.1)

The dispatch (ai-01) cited `145 fully-modeled AIF (82 undercut / 50 undermine / 5 rebut)` from an Argumentum source-map. **Firsthand verification**: those numbers do **not** match the OWL committed in CoursIA (`aifAttackedNode = 93`, repartition 61/29/3). The cited doc `docs/taxonomy/aif-structural-audit-method.md` does not exist at any path; the submodule pin (`7e72f3e5`) ≠ the local Argumentum clone (`fa490d78`). I therefore grounded the section on the **OWL really committed in CoursIA** and documented the gap explicitly (methodological note in the section) so the analysis is always re-grounded on the present OWL, never a reported external number. Reported to ai-01 (DM thread msg-050457) with the measurement proof.

## Validation

- Re-executed end-to-end (papermill `python3`): 29 cells, **0 errors, 0 null-exec**.
- New measure cell output: `93 total → RA 61 (66%) / I 29 (31%) / CA 3 (3%)` (matches the Python `Counter` computed from `AA_RES`).
- Existing cells **source + output byte-stable** (determinism verified on `cell-6` / `cell-12`: source_same=True, output_same=True — the 124 deletions in the diff are JSON cells-array shift, not content loss).
- `validate_pr_notebooks.py` **PASS 10/10**.
- `detect_solution_leaks` **0 HIGH / 0 MEDIUM / 0 errors** (stubs Exercice 1-4 don't flag).
- `strip_probe_banner` **0** (python kernel, no Kestrel banner).
- `COURSE_CATALOG.generated.{json,md}` byte-identical to main.

See #4960 (Argument_Analysis v3, partial — AIF distribution grain; the epic is COMPLETED but this enriches a Volet-A deliverable). Safe-ref (does not auto-close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
