### PR TITLE
fix(tweety-5): md52 non-determinism doc-honesty — align to committed output + disclose variance

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-5-Abstract-Argumentation.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-5-Abstract-Argumentation.ipynb
@@ -2526,18 +2526,18 @@
    "source": [
     "#### Lecture des résultats\n",
     "\n",
-    "Sur des exécutions répétées, les valeurs convergent vers :\n",
-    "- ~88/100 frameworks possèdent au moins une extension stable,\n",
-    "- taille moyenne de la grounded ≈ 0.68,\n",
-    "- nombre moyen d'extensions preferred ≈ 1.65.\n",
+    "La génération étant **non déterministe** (aucune graine fixée, `DefaultDungTheoryGenerator` tire un graphe frais à chaque appel), ces valeurs varient légèrement d'une exécution à l'autre. L'exécution commitée ci-dessus donne :\n",
+    "- **92/100** frameworks possèdent au moins une extension stable,\n",
+    "- taille moyenne de la grounded **≈ 0.76**,\n",
+    "- nombre moyen d'extensions preferred **≈ 1.65**.\n",
     "\n",
-    "**Extensions stables (~88 %) :** contrairement à ce qu'on pourrait attendre, la grande majorité des frameworks admettent une extension stable. À `p = 0.3` sur 10 arguments, les cycles impairs *isolés* (sans attaquant extérieur) sont relativement rares — la densité du graphe crée suffisamment d'attaques croisées pour casser la plupart des cycles avant qu'ils n'invalident tout le graphe.\n",
+    "**Extensions stables (~92 %) :** contrairement à ce qu'on pourrait attendre, la grande majorité des frameworks admettent une extension stable. À `p = 0.3` sur 10 arguments, les cycles impairs *isolés* (sans attaquant extérieur) sont relativement rares — la densité du graphe crée suffisamment d'attaques croisées pour casser la plupart des cycles avant qu'ils n'invalident tout le graphe.\n",
     "\n",
-    "**Grounded ≈ 0.68 :** l'extension grounded est très petite, souvent vide ou réduite à un seul argument. Dans un graphe dense, peu d'arguments sont complètement inattaqués ou défendus sans ambiguïté ; la grounded reste prudente et ne tranche que sur les cas les plus clairs.\n",
+    "**Grounded ≈ 0.76 :** l'extension grounded est très petite, souvent vide ou réduite à un seul argument. Dans un graphe dense, peu d'arguments sont complètement inattaqués ou défendus sans ambiguïté ; la grounded reste prudente et ne tranche que sur les cas les plus clairs.\n",
     "\n",
     "**Preferred ≈ 1.65 :** en moyenne entre 1 et 2 extensions preferred. Le graphe présente généralement quelques zones d'ambiguïté — deux camps locaux que ni l'un ni l'autre ne peut éliminer — mais pas assez pour exploser en de nombreuses extensions.\n",
     "\n",
-    "Ces trois valeurs illustrent l'écart entre les sémantiques : la grounded (≈ 0.68) est bien en dessous de la preferred (≈ 1.65 extensions, chacune souvent plus grande), confirmant que la prudence laisse beaucoup d'arguments non tranchés là où une sémantique prend position et peux plus facilement choisir des groupes."
+    "Ces trois valeurs illustrent l'écart entre les sémantiques : la grounded (≈ 0.76) est bien en dessous de la preferred (≈ 1.65 extensions, chacune souvent plus grande), confirmant que la prudence laisse beaucoup d'arguments non tranchés là où une sémantique prend position et peux plus facilement choisir des groupes."
    ]
   },
   {


### PR DESCRIPTION
## fix(tweety-5): md52 non-determinism doc-honesty — align interpretation to committed output + disclose variance

Grain: MED/notebook-python — lane myia-po-2025:CoursIA — prev: MED/iit (cost-FM #8317).

### The defect (found firsthand)

`Tweety-5-Abstract-Argumentation.ipynb` cell **51** runs a random-framework statistics experiment (100 Dung frameworks, n=10, p=0.3) and the committed output is:

```
1. Cadres avec au moins une extension stable : 92/100
2. Taille moyenne de l'extension grounded     : 0.76
3. Nombre moyen d'extensions preferred        : 1.65
```

The interpretation markdown **md52** then cited **stale, unverified "convergence" values** that do **not** match the committed output: "~88/100", "≈ 0.68" (only preferred 1.65 matched). A reader sees the output (92/0.76) immediately followed by text claiming convergence to ~88/~0.68 — internally inconsistent.

**Root cause (verified firsthand):** cell 51 uses `DefaultDungTheoryGenerationParameters()` + `DefaultDungTheoryGenerator` with **no seed** set anywhere in the notebook (grep `seed|random|setSeed` across all code cells = 0 hits). The generator is **non-deterministic** — each run produces different numbers. md52's "Sur des exécutions répétées, les valeurs convergent vers ~88/0.68" was an **unestablished convergence claim** (no multi-run log exists); the single committed realization happens to be 92/0.76.

### The fix (markdown-only, C.2 exception — determinism-gate compliant)

Per the determinism-gate lesson: for a non-deterministic output, do **not** cite a specific convergence you haven't measured, and do **not** naively flip numbers (a future re-exec would drift again). Instead: align the interpretation to the **committed** output values + **honestly disclose** the non-determinism.

| md52 | Before | After |
|------|--------|-------|
| framing | "Sur des exécutions répétées, les valeurs convergent vers : ~88/100, ≈0.68, ≈1.65" | "La génération étant **non déterministe** (aucune graine fixée, `DefaultDungTheoryGenerator` tire un graphe frais à chaque appel), ces valeurs varient légèrement d'une exécution à l'autre. L'exécution commitée ci-dessus donne : **92/100**, **≈0.76**, **≈1.65**" |
| stable header | "Extensions stables (~88 %)" | "Extensions stables (~92 %)" |
| grounded header/body/closing | ≈ 0.68 | ≈ 0.76 |

Pedagogical interpretation preserved verbatim; only the numbers are corrected to match the committed output, and the false convergence claim is replaced by an honest variance disclosure.

### Why not re-exec / why not seed

- **No re-exec needed** (C.2 markdown-only exception): outputs/`execution_count`/code cells are **untouched** — this PR only aligns the markdown interpretation to the *already-committed* output. The committed 92/0.76/1.65 stay as-is.
- **Not seeding the generator** deliberately: the notebook's pedagogical point (md18: "Etudier statistiquement les sémantiques") is the *distribution* of outcomes, not a fixed instance — seeding would obscure that. The honest fix is disclosing the variance, not hiding it behind a seed.

### Validation

- **H.3** `validate_pr_notebooks.py origin/main <path>`: **1/1 PASS** (19 code cells).
- **Markdown-only**: verified cell-by-cell vs `origin/main` — **only cell 52 (markdown) changes**; 0 outputs / 0 `execution_count` / 0 code cell touched (C.2 exception).
- **Round-trip stable** `json.dumps(indent=1)`: no CRLF churn.
- **Catalogue byte-identical** to main.
- **C.1**: 0 violation.
- Diff: +7/−7, 1 file.

Firsthand finding (not from an audit dispatch). Deterministic AF1/CF2 sections (cells 8/13/35/44/57) verified FAITHFUL — their md interpretations match committed outputs exactly; only the non-deterministic stats cell 51 had the stale-convergence defect.
