### PR TITLE
docs(gt,#3975): add 2 interpretation cells to GT-12 ReputationGames C# twin

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-12-ReputationGames-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-12-ReputationGames-Csharp.ipynb
@@ -549,6 +549,26 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Interprétation : le seuil de réputation et la dynamique d'imitation\n",
+    "\n",
+    "La sortie met en évidence le **mécanisme central de Kreps-Wilson (1982)** : le monopole *Normal* exploite la petite probabilité $\\epsilon = 0{,}1$ que l'entrant accorde au type *Fou*. Le **seuil de réputation $0{,}5$** partitionne l'espace des croyances — tant que $P(\text{Fou}) \\geq 0{,}5$, l'entrant n'entre pas ; en-deçà, il tente sa chance.\n",
+    "\n",
+    "Partant d'une croyance initiale $P(\text{Fou}) = 0{,}1 < 0{,}5$, le monopole Normal doit **faire monter** sa réputation au-dessus du seuil pour dissuader. Trois stratégies s'offrent à lui :\n",
+    "\n",
+    "| Stratégie | Comportement | Effet sur la réputation |\n",
+    "|-----------|--------------|------------------------|\n",
+    "| **Pooling** | Toujours `Fight` (imite le Fou) | Maximise la dissuasion, mais chaque combat coûte $-1$ |\n",
+    "| **Séparateur** | Toujours `Accommodate` (révèle son type) | Réputation s'effondre, l'entrant entre toujours |\n",
+    "| **Mixte** | `Fight` avec probabilité calibrée | Maintient $P(\text{Fou})$ exactement au seuil $0{,}5$ |\n",
+    "\n",
+    "Le résultat qualitatif ($\\epsilon = 0{,}1 < 0{,}5$ → *environ 2 premiers entrants dissuadés*) illustre le cœur du modèle : **quelques combats précoces suffisent** à hisser la réputation au-dessus du seuil, après quoi la dissuasion devient gratuite. C'est l'investissement initial en réputation qui rend la menace *crédible* — exactement ce que la simulation Monte-Carlo ci-dessous quantifie.\n"
+   ],
+   "id": "gt12-interp-krepswilson"
+  },
+  {
+   "cell_type": "markdown",
    "id": "1d3ba617",
    "metadata": {},
    "source": [
@@ -684,6 +704,24 @@
     "sb.Append(\"  -> Le type Normal investit (-1) sur les combats precoces pour batir la reputacion.\");\n",
     "sb.ToString().Display();\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Interprétation : le coût de l'imitation et le rendement de la dissuasion\n",
+    "\n",
+    "La simulation (10 000 tirages, $\\epsilon = 0{,}1$) quantifie le compromis au cœur du modèle. Comparé à la **référence en information complète** (Monopole = $+10$, Entrants = $+10$ — l'entrant entre toujours et le monopole accommode) :\n",
+    "\n",
+    "| Acteur | Gain moyen | Référence (info complète) | Écart |\n",
+    "|--------|-----------:|--------------------------:|------:|\n",
+    "| Monopole Normal | **$-7{,}00$** | $+10$ | $-17$ (le coût de l'imitation) |\n",
+    "| Monopole Fou | $+11{,}00$ | $+10$ | $+1$ (le type Fou gagne légèrement plus) |\n",
+    "| Entrants (total) | **$-9{,}00$** | $+10$ | $-19$ (la dissuasion réussit) |\n",
+    "\n",
+    "La lecture est nette : le monopole Normal **investit** (il subit $-1$ sur chaque combat précoce pour bâtir sa réputation, d'où l'écart de $-17$), et cet investissement **paye** — les entrants, croyant rencontrer le type Fou, sont dissuadés et perdent $-19$ au lieu de gagner $+10$. La réputation n'est pas gratuite : elle coûte ici $17$ au monopole, mais elle lui évite l'effondrement qu'entraînerait une révélation de son type. C'est la **prime à l'incertitude** que formalise Kreps-Wilson — une menace non crédible en information complète devient rationnellement soutenable dès qu'existe une petite probabilité d'être « fou ».\n"
+   ],
+   "id": "gt12-interp-montecarlo"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
Grain: MED/notebook-dotnet-pedagogy — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-python-audit-claims (c.850)

## What

Add 2 post-output **interpretation cells** to `GameTheory/GameTheory-12-ReputationGames-Csharp.ipynb` — the C# twin computes the Kreps-Wilson equilibrium and a Monte-Carlo simulation of the chain-store paradox, but leaves both rich outputs **without pedagogical interpretation**, whereas the Python twin has a `### Interpretation` cell after each. See #3975.

## The asymmetry (firsthand)

The C# twin has 2 code cells with substantive outputs, each followed only by the **next section's header** (no interpretation of the result just produced):

| code cell | output (committed, ec present) | following md |
|-----------|-------------------------------|--------------|
| `code[7]` (§ Kreps-Wilson) | reputation threshold 0.5, pooling/séparateur/mixte strategies, "≈2 premiers entrants dissuadés" | `md[8]` = next section header |
| `code[9]` (§ Monte-Carlo) | Normal −7.00, Fou +11.00, Entrants −9.00 vs reference (info complète) 10/10 | `md[10]` = next section header |

The Python twin (`GameTheory-12-ReputationGames.ipynb`) has a rich `### Interpretation` cell after each of these (py md[10] Kreps-Wilson, py md[12] simulation). The C# student gets the raw output; the Python student gets the *why*.

## Fix (markdown-only, byte-surgical)

Inserted one `### Interprétation` markdown cell after each code cell, each **grounded in the actual C# output** (read firsthand, not copy-pasted from the Python twin — the C# outputs carry their own specific values):

- **After code[7] (Kreps-Wilson)**: the threshold-0.5 mechanism, the 3 strategies (pooling / séparateur / mixte) in a 3-row table, and why "≈2 premiers entrants dissuadés" follows from ε=0.1 < 0.5.
- **After code[9] (Monte-Carlo)**: a 3-row table (acteur / gain moyen / référence info-complète / écart) decomposing the reputation-building tradeoff — the Normal monopoly *invests* −17 (−7 vs +10 ref) to deter entrants by −19 (−9 vs +10 ref). The "prime à l'incertitude" insight the raw numbers carry but no cell explained.

### Scope (byte-surgical — C839-L1 / C744-L1)

- **+36/−0**: pure additions, **0 deletions** (anti-régression compliant).
- All **10 code cells byte-identical to `origin/main`** (verified). No source code, output, or `execution_count` touched.
- **Format note (C744-L1)**: this notebook serializes as `json.dumps(indent=1)` with **no trailing newline** (non-standard) — verified byte-identical pre-edit, and preserved (no spurious trailing-newline diff). New cells include `"id"` fields matching the notebook's nbformat-4.5 convention (existing cells carry ids).
- Markdown-only → **C.2 exception** (no re-execution: no code cell modified). LaTeX (`$\epsilon$`, `$\text{Fou}$`) rendered correctly.
- `nbformat.validate` OK (no warnings) · H.3: 0 violations · C.1: clean · LF-only (no CRLF).

## Out of scope

- The thin pre-code section headers (`md[8]`, `md[10]`, etc.) are kept (section anchors); new cells augment.
- No code change → no re-execution. A future grain could add the ε-impact and KMRW interpretation cells (code[11]/code[15]) if the asymmetry is judged to extend there.

See #3975
