### PR TITLE
enrich(probas,#8081): PyMC-8 demonstrate closed-form EP update V(t)/W(t) numerically

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-8-TrueSkill.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-8-TrueSkill.ipynb
@@ -1653,6 +1653,75 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "ep-closedform-demo",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mise a jour closed-form EP sur un match (priors egaux, mu=25, sigma=8.33)\n",
+      "  c = 13.1762   t = 0.0000   V(t) = 0.7979   W(t) = 0.6366\n",
+      "  GAGNANT : mu 25.00 -> 29.21   sigma 8.33 -> 5.02\n",
+      "  PERDANT  : mu 25.00 -> 20.79   sigma 8.33 -> 5.02\n",
+      "Constate : le gagnant monte, le perdant descend, l'incertitude (sigma) se contracte\n",
+      "des deux cotes -- exactement la dynamique qu'on retrouve dans les sorties NUTS des sections 2-3,\n",
+      "mais ici en O(1) analytique (aucun echantillonnage).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Demonstration numerique : la mise a jour closed-form EP (V(t), W(t)) de la section 7 bis.\n",
+    "# On calcule l'equivalent analytique exact de ce que NUTS approxime par echantillonnage plus haut.\n",
+    "from scipy.stats import norm\n",
+    "from math import sqrt\n",
+    "\n",
+    "# Memes parametres qu'a l'initialisation (cellule 7) : mu=25, sigma=25/3, beta=sigma/2\n",
+    "mu_w, mu_l = 25.0, 25.0          # un match entre deux joueurs de skill identique (priors egaux)\n",
+    "sig_w = sig_l = 25.0 / 3.0       # sigma initial\n",
+    "beta = (25.0 / 3.0) / 2.0\n",
+    "\n",
+    "# Fonctions de troncature de la Gaussienne centree reduite (formules de la section 7 bis)\n",
+    "c = sqrt(2 * beta**2 + sig_w**2 + sig_l**2)   # denominateur commun\n",
+    "t = (mu_w - mu_l) / c                          # ecart standardise\n",
+    "V = norm.pdf(t) / norm.cdf(t)                  # V(t)\n",
+    "W = V * (V + t)                                # W(t)\n",
+    "\n",
+    "# Mises a jour closed-form (formes fermees de Herbrich-Minka-Graepel 2007)\n",
+    "mu_w_new = mu_w + sig_w**2 * V / c\n",
+    "mu_l_new = mu_l - sig_l**2 * V / c\n",
+    "sig_w_new = sqrt(sig_w**2 * (1 - W))\n",
+    "sig_l_new = sqrt(sig_l**2 * (1 - W))\n",
+    "\n",
+    "print(\"Mise a jour closed-form EP sur un match (priors egaux, mu=25, sigma=8.33)\")\n",
+    "print(f\"  c = {c:.4f}   t = {t:.4f}   V(t) = {V:.4f}   W(t) = {W:.4f}\")\n",
+    "print(f\"  GAGNANT : mu {mu_w:.2f} -> {mu_w_new:.2f}   sigma {sig_w:.2f} -> {sig_w_new:.2f}\")\n",
+    "print(f\"  PERDANT  : mu {mu_l:.2f} -> {mu_l_new:.2f}   sigma {sig_l:.2f} -> {sig_l_new:.2f}\")\n",
+    "print(\"Constate : le gagnant monte, le perdant descend, l'incertitude (sigma) se contracte\")\n",
+    "print(\"des deux cotes -- exactement la dynamique qu'on retrouve dans les sorties NUTS des sections 2-3,\")\n",
+    "print(\"mais ici en O(1) analytique (aucun echantillonnage).\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ep-closedform-interp",
+   "metadata": {},
+   "source": [
+    "### Interpretation : la mise a jour analytique EP\n",
+    "\n",
+    "La cellule precedente calcule en forme fermee (O(1), aucun echantillonnage) ce que NUTS\n",
+    "approxime par tirages Monte Carlo dans les sections 2-3. Sur un match a priors egaux,\n",
+    "l'ecart standardise est nul ($t = 0$) : le match est maximalement informatif ($V(0) \u0007pprox 0{,}80$),\n",
+    "d'ou un deplacement important du skill ($\\pm 4{,}2$ points) et une forte contraction de\n",
+    "l'incertitude ($\\sigma$ : $8{,}33 \to 5{,}02$, soit $-40\\,\\%$). C'est le meme raisonnement qui produit,\n",
+    "apres plusieurs matchs successifs, la hierarchie Alice $\\mu = 33{,}3$ observee en section 4 --\n",
+    "mais ici chaque mise a jour coute une multiplication plutot qu'une serie de tirages.\n",
+    "C'est ce cout O(1) qui rend TrueSkill deployable a l'echelle de millions de joueurs.\n"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "1e2770fb",
    "metadata": {


### PR DESCRIPTION
## Contexte — #8081 pilote #3 (PyMC-8 vs MBML Ch.3) + Prong-B #3801

L'audit fidélité #8081 (pilote #3, PyMC-8-TrueSkill vs MBML Ch.3 « Meeting Your Match ») conclut **FIDÈLE** : le notebook est *plus riche* que la source (il a déjà la section EP « 7 bis » cell 27 + une conclusion distinguant honnêtement l'implémentation MCMC pédagogique du vrai TrueSkill EP closed-form).

**Une seule lacune Prong-B** : la cellule 27 *explique* la mise à jour closed-form EP (V(t), W(t), formes fermées μ/σ, dynamique τ² — Herbrich-Minka-Graepel 2007) en **markdown uniquement**, sans jamais la **démontrer numériquement**. La prose affirme « l'équivalent analytique exact de ce que NUTS approxime » mais le code ne le montre jamais. #3801 Prong-B : rendre visible la capacité du moteur.

## Livrable — 2 cellules après la section EP (markdown → code → interpretation)

**Cellule code (ec=15)** : calcule la mise à jour closed-form sur un match à priors égaux (μ=25, σ=25/3, β=σ/2 — les valeurs d'init de la cellule 7) :
```
c = 13.18   t = 0.00   V(t) = 0.7979   W(t) = 0.6366
GAGNANT : mu 25.00 -> 29.21   sigma 8.33 -> 5.02
PERDANT  : mu 25.00 -> 20.79   sigma 8.33 -> 5.02
```
Gagnant monte, perdant descend, σ se contracte des deux côtés — exactement la dynamique que les sections NUTS (2-3) produisent par échantillonnage, mais ici en **O(1) analytique**.

**Cellule interpretation markdown** : relie le démo (t=0 maximalement informatif, σ −40 %) à la hiérarchie Alice μ=33.3 de la section 4.

## Preuves vérifiables

- **Math vérifiée firsthand** : formules verbatim depuis cell 27, exécutées standalone avant insertion (c=13.18, V=0.7979, W=0.6366 — Herbrich-Minka-Graepel canonique).
- **Vrai exec kernel** : python3 via nbconvert (scipy 1.17.0 + numpy 2.3.4, **pas besoin de PyMC** pour la closed-form). ec=15, output réel déterministe.
- **Byte-surgical** : raw JSON splice sur ancres d'id unique (cell28 id `1e2770fb`). **0 cellule pré-existante modifiée** (vérifié par comparaison id-keyed vs origin/main). `+69/−0`, 1 fichier, **pur additif**.
- **H.3 PASS** : `validate_pr_notebooks.py` 15 code cells.
- **detect_solution_leaks** : 0 HIGH / 0 MEDIUM / 0 errors.
- **C.1** : 0 violations (pas de `raise NotImplementedError`/`assert False`/`1/0`).
- **nbformat VALID** (35 cells).
- **Catalogue byte-identique** à origin/main.
- **Non-twin** : PyMC-8 absent de `twin_pairs.yaml` (grep=0) → twin-parity gate non-affecté.

## Scope — audit #8081 pilote #3 (Python, R6 pivot depuis Lean)

Cette PR = enrichissement Prong-B ciblé sur UN notebook (PyMC-8), issu de l'audit fidélité #8081 (pilote #3). Ne clôt pas #8081 (audit epic ongoing, d'autres pilotes) ni #3801 (registre Prong-B).

`See #8056`? Non. `See #8081` (fidelity audit, partial — pilote #3). `See #3801` (Prong-B problem-richness).

---
*Livré par po-2026 (worker cron). Audit #8081 pilote #3 + enrichissement Prong-B #3801.*
