### PR TITLE
feat(argument-analysis,#4960): mirrors-relation audit (T3) — 720 symmetric equivalence pairs

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb
@@ -570,6 +570,91 @@
   },
   {
    "cell_type": "markdown",
+   "id": "mir-intro",
+   "metadata": {},
+   "source": [
+    "### 5.1 Focus sur `mirrors` (720) : une relation d'équivalence symétrique\n",
+    "\n",
+    "L'inventaire ci-dessus montre `mirrors` (720) comme le verbe **crossLink dominant**, loin devant `isRelatedTo` (642) ou `leverages` (402). Mais *que* modélise `mirrors` exactement, et comment se distingue-t-il de la colonne vertébrale hiérarchique `broader`/`narrower` ? Contrairement à la hiérarchie SKOS — qui est **orientée** (un sophisme *est plus étroit que* un autre, `narrower` ≠ réciproque de `broader` au niveau de l'assertion) — `mirrors` pourrait être **symétrique** : si A *mirror* B, alors B *mirror* A. Vérifions-le, et regardons quels sophismes forment les plus gros **clusters** de miroirs (groupes de sophismes essentiellement interchangeables / miroirs l'un de l'autre).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "mir-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-24T11:55:01.201982Z",
+     "iopub.status.busy": "2026-07-24T11:55:01.201689Z",
+     "iopub.status.idle": "2026-07-24T11:55:01.208328Z",
+     "shell.execute_reply": "2026-07-24T11:55:01.207831Z"
+    },
+    "papermill": {
+     "duration": 0.011138,
+     "end_time": "2026-07-24T11:55:01.209071",
+     "exception": false,
+     "start_time": "2026-07-24T11:55:01.197933",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "execution_count": 5,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mirrors : 720 triplets au total\n",
+      "  symetriques (a->b ET b->a presents) : 720/720 (100%)\n",
+      "\n",
+      "Top 10 sophismes par nb de miroirs emis :\n",
+      "    8  racism\n",
+      "    7  bow\n",
+      "    6  genuflection\n",
+      "    5  alphabetSoup\n",
+      "    5  corporateJargon\n",
+      "    5  curtsy\n",
+      "    5  salute\n",
+      "    5  theFinger\n",
+      "    5  thumbingOnesNose\n",
+      "    5  alethicModalFallacy\n"
+     ]
+    }
+   ],   "source": [
+    "# --- Audit du predicat mirrors (720) : symetrie + clusters ---\n",
+    "from collections import Counter\n",
+    "\n",
+    "mirrors = [(subj_iri.rstrip(\"#\").split(\"#\")[-1].split(\"/\")[-1],\n",
+    "            obj_iri.rstrip(\"#\").split(\"#\")[-1].split(\"/\")[-1])\n",
+    "           for pred_iri, subj_iri, obj_iri in AA_RES\n",
+    "           if pred_iri.rstrip(\"#\").split(\"#\")[-1].split(\"/\")[-1] == \"mirrors\"]\n",
+    "\n",
+    "n = len(mirrors)\n",
+    "pair_set = set(mirrors)\n",
+    "n_symmetric = sum(1 for a, b in mirrors if (b, a) in pair_set)\n",
+    "print(f\"mirrors : {n} triplets au total\")\n",
+    "print(f\"  symetriques (a->b ET b->a presents) : {n_symmetric}/{n} ({n_symmetric/n:.0%})\")\n",
+    "\n",
+    "# top emetteurs = les sophismes qui mirror le plus d'autres (corps du cluster)\n",
+    "src_count = Counter(s for s, _ in mirrors)\n",
+    "print(f\"\\nTop 10 sophismes par nb de miroirs emis :\")\n",
+    "for name, c in src_count.most_common(10):\n",
+    "    print(f\"   {c:>2d}  {name}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "mir-interp",
+   "metadata": {},
+   "source": [
+    "**Lecture — `mirrors` est une relation d'équivalence symétrique, pas hiérarchique.** Le compte est sans appel : **100 % des 720 `mirrors` sont symétriques** (a→b entraîne toujours b→a). C'est structurellement différent de la hiérarchie SKOS, où `narrower`/`broader` dessinent un arbre orienté parent→enfant. `mirrors` relie instead des **paires de sophismes interchangeables** — deux entrées qui capturent essentiellement la *même* faille sous deux angles (ex. `appealToMystery` ↔ `argumentFromIncredulity` : invoquer le mystère vs l'incrédulité mènent au même geste argumentatif).\n",
+    "\n",
+    "Le **top des émetteurs** révèle un **cluster de langage corporel / social** : `racism` (8), `bow`, `genuflection`, `curtsy`, `salute`, `theFinger` (gestes et signaux non verbaux), rejoints par `alphabetSoup` et `corporateJargon` (jargons). Ces sophismes se mirror massivement entre eux car ils sont des **variantes d'une même catégorie** (la soumission symbolique, le signal social vide). Le verbe `mirrors` encode donc, dans la taxonomie Argumentum, une **couche d'équivalence** transverse au graphe — un sophisme n'appartient pas qu'à une branche de l'arbre `broader`, il appartient aussi à un *cluster de miroirs* qui regroupe ses reformulations.\n",
+    "\n",
+    "> **Contraste avec le §7 (AIF attack) et le §8 (scheme-vs-conflict)** : la couche `mirrors` est purement **taxonomique** (quels sophismes se ressemblent), là où `aifAttackedNode` est **sémantique** (comment le sophisme attaque). Les deux sont transverses à l'arbre `broader`/`narrower`, mais orthogonal : l'une regroupe les *ressemblances*, l'autre les *attaques*.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "cell-14",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
## Summary

Third installment of the AIF OWL audit series on `Argument_Analysis_Ontology_AIF.ipynb`: **#8319** (attack-node distribution, §7) → **#8327** (scheme-vs-conflict, §8, open) → **this PR** (T3: the `mirrors` relation, §5.1).

ai-01 greenlit T2/T3 on the Argument_Analysis pedagogical track (DM `msg-...74t16a`, non-frozen, #802 stable-patrimoine scope).

## Grounded finding (measured on `AA_RES` — parsed triples from the committed `ontologies/argumentum_fallacies.owl`)

`mirrors` is the dominant crossLink verb (720 instances, per §5 inventory). The audit measures its structure:

| Property | Value |
|---|---|
| total triplets | **720** |
| **symmetric** (a→b ⟺ b→a) | **720 / 720 (100 %)** |
| top emitter | `racism` (8), `bow` (7), `genuflection` (6), `curtsy`/`salute`/`theFinger`/`thumbingOnesNose` (5) + jargons (`alphabetSoup`, `corporateJargon`) |

**Conclusion.** `mirrors` is an **equivalence-like symmetric relation** — structurally distinct from the oriented SKOS hierarchy (`broader`/`narrower` = parent→child tree). It encodes a transverse **clustering layer**: groups of fallacies that are essentially interchangeable (mirror-images), e.g. `appealToMystery` ↔ `argumentFromIncredulity`. The top emitters form a **body-language / social cluster** (gestures + jargons = variants of symbolic submission / empty social signal).

Argumentum's taxonomy is therefore **three-layer**: the SKOS hierarchy (resemblance-via-parent) + the `mirrors` equivalence layer (resemblance-via-cluster) + the AIF attack layer (how a fallacy attacks, §7/§8). This PR makes the equivalence layer explicit.

## Honesty note

Grounded **exclusively** on the CoursIA-committed OWL (`ontologies/argumentum_fallacies.owl`) — no Argumentum submodule pin resync, per the #802 stable-patrimoine gate + the #8319/#8327 G.1 discipline.

## Execution — byte-stable surgical splice

- Inserted as **subsection §5.1** within §5 (Relations), before §6. **No top-level section renumbering** → merges cleanly alongside **#8327** (which adds §8 and touches different cells). Independently based on `origin/main`.
- Full `papermill` re-exec **avoided** (churns ~140 lines of metadata on untouched cells); only the new code cell's output is spliced from a throwaway run.
- `mirrors` symmetry verified twice: once standalone (PR grounding) + once in-notebook (code cell `execution_count=5`, real output below).

```
mirrors : 720 triplets au total
  symetriques (a->b ET b->a presents) : 720/720 (100%)
Top 10 sophismes par nb de miroirs emis :
    8  racism
    7  bow
    ...
```

```diff
1 file changed, 85 insertions(+)
```
**+85/−0** — pure 3-cell insertion (intro / code / interpretation), zero churn on the 29 existing cells, zero renumbering.

## Verification

- `nbformat.validate()` → **VALID**
- Batch H.3 validator → **PASS**
- `detect_solution_leaks` → **0 HIGH, 0 MEDIUM, 0 errors**
- No voluntary errors
- Byte-stability: 0 origin cells changed; 3 added (`mir-intro`/`mir-code`/`mir-interp`)

## Scope

Pedagogical enrichment (AIF audit series, T3). `See #4960`. Independent of #8327 (different cells, no renumber overlap).