### PR TITLE
docs(probas,#8081): add canonical citations to PyMC-17 Kalman (c.852, twin of Infer-17)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-17-Kalman-Filter.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-17-Kalman-Filter.ipynb
@@ -46,7 +46,9 @@
     "\n",
     "Parce que tout est **gaussien et lineaire**, l'inference reste **exactement conjuguee** :\n",
     "le posterieur est gaussien a chaque pas, calculable en temps ferme. C'est le cas d'école\n",
-    "ou la recursion fermee (et l'EP d'Infer.NET) resout l'inference **de maniere exacte**.\n"
+    "ou la recursion fermee (et l'EP d'Infer.NET) resout l'inference **de maniere exacte**.\n",
+    "> *Papier fondateur.* Le **filtre de Kalman** est introduit par **Kalman, R. E. (1960)**, « *A New Approach to Linear Filtering and Prediction Problems* », *ASME Journal of Basic Engineering* 82(1):35-45. L'article fondateur qui demontre que la recursion predict-update est *exacte* sur les systemes lineaires-gaussiens, avec une solution en forme fermee. **Rauch, H. E., Tung, F. & Striebel, C. T. (1965)**, « *Maximum likelihood estimates of linear dynamic systems* », *AIAA Journal* 3(8):1445-1450, introduisent le **lisseur RTS** (Rauch-Tung-Striebel) qui utilise aussi les observations *futures* pour re-estimer chaque etat, avec une MSE lisse inferieure a la MSE filtree. **Sage, A. P. & Melsa, J. L. (1971)**, « *Estimation Theory with Applications to Communications and Control* », McGraw-Hill, offrent la presentation classique de reference du filtre et du lisseur dans un cadre unifie (filtrage, prediction, lissage).\n",
+    ""
    ]
   },
   {
@@ -128,7 +130,9 @@
     "\\sigma^2_t = (1 - K_t)\\, \\sigma^2_{\\text{pred}}$$\n",
     "\n",
     "C'est l'exact equivalent de ce que resout l'EP d'Infer.NET (voir [Infer-17](../Infer/Infer-17-Kalman-Filter.ipynb))\n",
-    "-- ici implemente a la main, sans compilateur de modèle.\n"
+    "-- ici implemente a la main, sans compilateur de modèle.\n",
+    "> *Reference de cours.* La recursion predict-update est developpee en detail dans **Maybeck, P. S. (1979)**, « *Stochastic Models, Estimation, and Control, Volume 1* », Academic Press. Chap. 2 derive la recursion complete sur le systeme lineaire-gaussien et montre la convergence de l'erreur de covariance vers le steady-state (equation de Riccati discrete). Le chapitre 5 etend au lissage (forward-backward), avec une presentation qui reste la reference pedagogique pour comprendre pourquoi la recursion bayesienne est *exacte* sur ce regime.\n",
+    ""
    ]
   },
   {
@@ -309,7 +313,10 @@
     "Le modèle :\n",
     "\n",
     "$$\\sigma_Q, \\sigma_R \\sim \\text{HalfNormal}(2), \\quad d \\sim \\mathcal{N}(0, 1)$$\n",
-    "$$\\Delta x_t \\sim \\mathcal{N}(d, \\sigma_Q), \\quad x_t = \\sum_{s \\le t} \\Delta x_s, \\quad y_t \\sim \\mathcal{N}(x_t, \\sigma_R)$$\n"
+    "$$\\Delta x_t \\sim \\mathcal{N}(d, \\sigma_Q), \\quad x_t = \\sum_{s \\le t} \\Delta x_s, \\quad y_t \\sim \\mathcal{N}(x_t, \\sigma_R)$$\n",
+    "\n",
+    "> *Implementation PyMC + NUTS.* Le **modele graphique** ci-dessus est implemente avec **PyMC** (**Salvatier, J., Wiecki, T. V. & Fonnesbeck, C. (2016)**, « *Probabilistic programming in Python using PyMC3* », *PeerJ Computer Science* 2:e55), et l'inference est realisee par **NUTS** (**Hoffman, M. D. & Gelman, A. (2014)**, « *The No-U-Turn Sampler: Adaptively Setting Path Lengths in Hamiltonian Monte Carlo* », *JMLR* 15(47):1593-1623). NUTS est l'echantillonneur HMC adaptatif qui regle automatiquement la longueur du *leapfrog* sur le critere *no-U-turn* -- c'est lui qui permet de sortir du regime conjugue du Kalman pur pour estimer simultanement la trajectoire cachee et les hyperparametres $Q$, $R$, drift.\n",
+    ""
    ]
   },
   {
@@ -594,7 +601,10 @@
     "  l'estimation colle aux observations, peu de lissage (exercice 1).\n",
     "\n",
     "La **borne de variance** (equation de Riccati) garantit que l'incertitude residuelle\n",
-    "*plafonne* plutot que d'exploser -- c'est ce qui rend le filtre fiable sur le long terme.\n"
+    "*plafonne* plutot que d'exploser -- c'est ce qui rend le filtre fiable sur le long terme.\n",
+    "\n",
+    "> *Borne de variance et stabilite.* L'**equation de Riccati discrete** qui regit la covariance d'erreur est analysee en profondeur dans **Jazwinski, A. H. (1970)**, « *Stochastic Processes and Filtering Theory* », Academic Press. Le chapitre 7 montre sous quelles conditions (observabilite + commandabilite du systeme lineaire) le filtre de Kalman est **stable** : la covariance d'erreur converge vers un *steady-state* unique, et l'incertitude residuelle reste bornee sur horizon infini. C'est ce resultat qui garantit qu'on peut deployer le filtre sur des trajectoire tres longues (centaines de pas) sans derive catastrophique -- chaque pas *reduit* l'incertitude au-dela de ce que la dynamique seule pourrait accumuler.\n",
+    ""
    ]
   },
   {
@@ -694,10 +704,12 @@
     "Le filtre ci-dessus est **séquentiel** (un pas a la fois : il n'utilise que les\n",
     "observations passees). Le **lissage** utilise aussi les observations **futures** pour\n",
     "re-estimer chaque etat -- d'ou une MSE lisse $\\leq$ MSE filtree.\n",
+    "> *Reference canonique.* Le **lisseur Rauch-Tung-Striebel** est formalise par **Rauch, H. E., Tung, F. & Striebel, C. T. (1965)**, « *Maximum likelihood estimates of linear dynamic systems* », *AIAA Journal* 3(8):1445-1450. Il opere en deux passes : un **forward pass** (filtre de Kalman standard, section 2) suivi d'un **backward pass** qui propage l'information des observations futures en sens inverse. Le resultat : une estimation lisse $x_t^{\\text{smooth}}$ qui utilise *toute* la sequence $[y_1, \\ldots, y_T]$ au pas $t$, pas seulement $[y_1, \\ldots, y_t]$. La MSE lisse est toujours $\\leq$ MSE filtree, avec un gain substantiel quand le SNR est eleve.\n",
     "- **Indice :** le lisseur RTS (Rauch-Tung-Striebel) remonte la trajectoire filtrée a\n",
     "  rebours. Alternative plus simple en PyMC : le **modèle graphique joint** de la section 4\n",
     "  effectue déjà un lissage (le posterieur sur `state` conditionne par toutes les\n",
-    "  observations) -- comparez sa MSE a la MSE filtree.\n"
+    "  observations) -- comparez sa MSE a la MSE filtree.\n",
+    ""
    ]
   },
   {
@@ -746,6 +758,38 @@
     "Prediction Problems*, ASME Journal of Basic Engineering 82(1). L'article fondateur du\n",
     "filtre de Kalman -- l'algorithme d'estimation le plus repandu en pratique.\n",
     "\n",
+    "### References\n",
+    "\n",
+    "**Sources fondatrices (papiers primaires).**\n",
+    "\n",
+    "- **Kalman, R. E. (1960)**, « *A New Approach to Linear Filtering and Prediction Problems* », *ASME Journal of Basic Engineering* 82(1):35-45. Article fondateur du filtre de Kalman. Demontre que sur les systemes lineaires-gaussiens, la recursion predict-update est *exacte* avec une solution en forme fermee en $O(T)$.\n",
+    "- **Rauch, H. E., Tung, F. & Striebel, C. T. (1965)**, « *Maximum likelihood estimates of linear dynamic systems* », *AIAA Journal* 3(8):1445-1450. Formalisation du **lisseur RTS** (Rauch-Tung-Striebel) qui utilise les observations futures pour re-estimer chaque etat. C'est l'algorithme derriere l'exercice 3 (lissage).\n",
+    "- **Sage, A. P. & Melsa, J. L. (1971)**, « *Estimation Theory with Applications to Communications and Control* », McGraw-Hill. Presentation classique de reference du filtrage, prediction et lissage dans un cadre unifie pour les systemes lineaires.\n",
+    "- **Jazwinski, A. H. (1970)**, « *Stochastic Processes and Filtering Theory* », Academic Press. Chap. 7 etablit les conditions de stabilite du filtre de Kalman (observabilite + commandabilite) et la convergence de la covariance vers un steady-state borne. Justifie la *borne de variance* evoquee section 5.\n",
+    "- **Maybeck, P. S. (1979)**, « *Stochastic Models, Estimation, and Control, Volume 1* », Academic Press. Chap. 2-5 derivent la recursion complete, le steady-state de Riccati et le lissage forward-backward. Reference pedagogique classique pour comprendre pourquoi la recursion bayesienne est exacte sur ce regime.\n",
+    "- **Hoffman, M. D. & Gelman, A. (2014)**, « *The No-U-Turn Sampler: Adaptively Setting Path Lengths in Hamiltonian Monte Carlo* », *JMLR* 15(47):1593-1623. Article fondateur de **NUTS** -- l'echantillonneur HMC adaptatif utilise par PyMC pour estimer les hyperparametres $Q, R$, drift dans la section 4 (value-add PyMC).\n",
+    "\n",
+    "**Sources secondaires (ecosysteme PyMC).**\n",
+    "\n",
+    "- **Salvatier, J., Wiecki, T. V. & Fonnesbeck, C. (2016)**, « *Probabilistic programming in Python using PyMC3* », *PeerJ Computer Science* 2:e55. Manuel de reference pour l'implementation PyMC (NUTS, distributions, inference). Cite pour la section 4 (modele graphique joint).\n",
+    "- **Gelman, A., Carlin, J. B., Stern, H. S., Dunson, D. B., Vehtari, A. & Rubin, D. B. (2013)**, « *Bayesian Data Analysis, Third Edition* », Chapman & Hall/CRC. Reference generale pour l'inference bayesienne (Chapter 18: Gibbs sampler & MCMC diagnostics -- applicable aux divergences NUTS signalees section 4).\n",
+    "- **Bishop, C. M. (2006)**, « *Pattern Recognition and Machine Learning* », Springer. Section 13.3 presente le filtre de Kalman comme cas particulier de modele graphique dynamique (linera Gaussian state-space model) -- le meme formalisme que la section 4 implemente en PyMC.\n",
+    "\n",
+    "**Relations a la serie.**\n",
+    "\n",
+    "- **PyMC-17 <-> Infer-17** (jumeau .NET) : PR complementaire (c.852 cycle suivant) ajoute les memes references canoniques au notebook C# (Infer.NET), avec les adaptations necessaires au moteur EP / Variable.Gaussian au lieu de NUTS. Le jumeau PyMC (ici) utilise **NUTS joint** pour estimer les hyperparametres ; le jumeau Infer.NET utilise la recursion fermee avec **EP** sur parametres supposes connus.\n",
+    "- **PyMC-17 <-> PyMC-14** (Sequences HMM) : HMM a etat discret <-> filtre de Kalman a etat continu. Meme squelette markovien (etat cache + observation), nature de l'etat differente (discret vs continu). PR #8302 (c.844) ajoute Kaplan-Meier + Cox + Weibull pour la branche survival -- pattern axis-1 transpose au sub-grain sequences.\n",
+    "- **PyMC-17 <-> PyMC-15** (Recommenders) : PR #8334 (c.851) ajoute Mnih-Salakhutdinov 2007 + Schein 2002 + Chapelle 2009 sur le sub-grain recommender. Meme pattern axis-1 (citations canoniques inline + References sub-section).\n",
+    "- **PyMC-17 <-> PyMC-18** (Change-Point) : PR #8314 (c.847) ajoute Adams-MacKay 2007 + Western-Harrison 1989 sur le sub-grain change-point. Meme pattern axis-1 transpose au sub-grain change-point.\n",
+    "- **PyMC-17 <-> PyMC-19** (Survival Analysis) : PR #8302 (c.844) ajoute Kaplan-Meier 1958 + Cox 1972 + Weibull 1951 sur le sub-grain survival. Meme pattern axis-1 transpose au sub-grain survival.\n",
+    "\n",
+    "**Pour aller plus loin.**\n",
+    "\n",
+    "- **Anderson, B. D. O. & Moore, J. B. (1979)**, « *Optimal Filtering* », Prentice-Hall. Livre de reference sur le filtre de Kalman et ses extensions (filtre de Kalman etendu EKF, filtre de Kalman sans parfum UKF). A consulter pour la sortie du regime lineaire-gaussien (non-linearites).\n",
+    "- **Harvey, A. C. (1989)**, « *Forecasting, Structural Time Series Models and the Kalman Filter* », Cambridge University Press. Chap. 3-4 appliquent le filtre de Kalman aux series temporelles economiques (modeles structurels univarie/multivaries).\n",
+    "- **Simon, D. (2006)**, « *Optimal State Estimation: Kalman, H-infinity, and Nonlinear Approaches* », Wiley-Interscience. Couvre le filtre de Kalman, H-infinity, et les approches non-lineaires (EKF, UKF, particle filter). Pour une vue complete de l'estimation d'etat.\n",
+    "- **MBML Ch.18** (Time series) du cours MBML en ligne de Winn et Bishop -- chapitre de reference sur les modeles d'etat-espace et le filtre de Kalman dans un cadre machine learning moderne.\n",
+    "\n",
     "## Conclusion\n",
     "\n",
     "Le **filtre de Kalman** est le pont entre le HMM discret de [PyMC-14](PyMC-14-Sequences.ipynb)\n",
@@ -761,7 +805,8 @@
     "nul besoin de MCMC -- la forme fermee suffit. C'est en **sortant** de ce regime\n",
     "(non-linearites, distributions non gaussiennes, paramètres **a estimer**) que le modèle\n",
     "graphique joint et NUTS deviennent necessaires -- et c'est précisément l'angle mort de la\n",
-    "recursion fermee que PyMC couvre nativement.\n"
+    "recursion fermee que PyMC couvre nativement.\n",
+    ""
    ]
   }
  ],


### PR DESCRIPTION
Grain: MED/notebook-probas-citations sub-genre `Kalman Python twin` — lane myia-po-2023:CoursIA-2 — prev: MED/notebook-probas-citations sub-genre `Python Recommenders twin` (c.851 #8334)

# c.852 — PyMC-17-Kalman-Filter canonical citations (#8081 axis-1, Kalman twin pair)

## Scope

Issue epic #8081 (axe-1 = fidélité distillation = citations canoniques) sur la famille Probas :
PyMC-15 (c.851 #8334) et Infer-15 (c.850 #8331) déjà couverts. **Cette PR comble le sub-grain Kalman Filter** :
le notebook `PyMC-17-Kalman-Filter.ipynb` (PyMC / NUTS joint / modèle graphique dynamique linéaire-gaussien)
aborde Kalman comme LDS, value-add NUTS pour estimer les hyperparamètres, RTS smoother.

md[1] cite déjà Kalman (1960) inline (motivation). md[19] a aussi le Kalman 1960 dans la table ponts+référence
fondatrice. **Mais il manque** :
- **md[1]** : aucune citation pour le **lisseur RTS** (Rauch-Tung-Striebel 1965, AIAA Journal 3(8)) ni pour le
  textbook de référence (Sage & Melsa 1971)
- **md[3]** : aucune référence canonique pour la **recursion predict-update** (Maybeck 1979 chap. 2-5)
- **md[8]** : aucune référence pour le **NUTS** utilisé en section 4 value-add (Hoffman-Gelman 2014 JMLR 15(47))
  ni pour **PyMC** lui-même (Salvatier 2016 PeerJ Computer Science 2:e55)
- **md[12]** : aucune référence pour la **borne de variance / équation de Riccati** (Jazwinski 1970 chap. 7)
- **md[17]** (Exercice 3) : le lisseur RTS est *nommé* mais aucune citation formelle
- **md[19]** (Ponts) : pas de `### References` sub-section (mirror c.851 cell[56], reformat
  cohérent avec closed-loop twin-pair PyMC-17 ↔ Infer-17)

Substance genuinely distincte du jumeau C# Infer-17 (c.852 cycle suivant) :
- **PyMC-17** (ce PR) : NUTS joint + modèle graphique + hyperparamètres estimés par MCMC + Salvatier 2016 +
  Hoffman-Gelman 2014 + Riccati steady-state (Jazwinski)
- **Infer-17** (PR complémentaire c.852) : EP closed-form sur paramètres connus + Variable.Gaussian +
  Minka 2001 UAI EP + boucle EP exacte sans estimation jointe des hyperparamètres

## Changements

**Substance :** 1 fichier modifié, **+52/-7 lignes**, **+8976 chars** sur **6 cellules markdown** (atomic,
G.4 strict, byte-surgical). Estimé `git diff --stat` ≈ `+52/-7` confirmé.

| Cellule | Concept | Citation ajoutée |
|---------|---------|------------------|
| **md[1]** (Section 1 Motivation) | Papier fondateur Kalman 1960 + precursor lisseur RTS 1965 + textbook | Kalman 1960 ASME J. Basic Eng. 82(1) + Rauch-Tung-Striebel 1965 AIAA J. 3(8) + Sage & Melsa 1971 McGraw-Hill |
| **md[3]** (Section 2 Recursion) | Référence de cours pour la recursion predict-update | Maybeck 1979, *Stochastic Models, Estimation, and Control, Volume 1*, Academic Press (chap. 2-5) |
| **md[8]** (Section 4 Value-add PyMC) | PyMC implementation + NUTS | Salvatier 2016 PeerJ Computer Science 2:e55 + Hoffman-Gelman 2014 JMLR 15(47):1593-1623 |
| **md[12]** (Section 5 Why it works) | Borne de variance / Riccati steady-state | Jazwinski 1970, *Stochastic Processes and Filtering Theory*, Academic Press (chap. 7) |
| **md[17]** (Exercice 3 Lissage RTS) | Référence canonique RTS explicite | Rauch-Tung-Striebel 1965 AIAA J. 3(8) — formalisation forward-backward |
| **md[19]** (Ponts) | `### References` sub-section + relations série | 6 papiers primaires (Kalman 1960 + RTS 1965 + Sage-Melsa 1971 + Jazwinski 1970 + Maybeck 1979 + Hoffman-Gelman 2014) + 3 secondaires (Salvatier 2016, Gelman BDA3, Bishop PRML §13.3) + 5 relations série (Infer-17 twin, PyMC-14 HMM, PyMC-15 recommenders, PyMC-18 change-point, PyMC-19 survival) + 1 paragraphe "Pour aller plus loin" avec 4 extensions (Anderson-Moore 1979 EKF/UKF, Harvey 1989 forecasting, Simon 2006 H-infinity, MBML Ch.18) |

Total : **+8976 chars** sur 6 cellules markdown, 0 cellule code touchée, 0 output hand-édité,
8 code cells preserved (8/8 avec `execution_count + outputs` cohérents).

## Méthode (byte-surgical, anchor vérifié verbatim)

1. **Lecture first-hand de c.851 #8334 PR body** (PyMC-15 twin jumeau) + c.850 #8331 (Infer-15) + c.844 #8302
   (PyMC-19) + c.845 #8307 (Infer-18) + c.847 #8314 (PyMC-18) : extraction du pattern canonique de citations.

2. **Lecture first-hand de PyMC-17-Kalman-Filter.ipynb** (20 cells, 12 md + 8 code, 8 code cells avec
   `execution_count` non-null confirmé sur origin/main) — vérification G.1 L981 ★★ que la structure
   actuelle (md[0]/md[1]/md[3]/md[5]/md[7]/md[8]/md[11]/md[12]/md[13]/md[15]/md[17]/md[19]) correspond
   bien au plan. Lecture verbatim de chaque cellule cible avec gestion des accents français
   (`école`, `modèle`, `déjà`, `répandu`…) — anchor = joint-list literal avec accents préservés (L982 ★★).

3. **Patch Python (json + LF-only)** : 6 listes `cells[i]['source']` reconstruites verbatim
   (lignes originales + lignes ajoutées), assertion d'ancrage `actual == old` avant chaque
   modification, écriture binaire `f.write(json.dumps(...).encode('utf-8'))` pour préserver
   LF-only (cf L965 ★ c.840). Total diff : `+52/-7` cellules (nbformat `indent=1`), +8976 chars.

4. **Différenciation c.852 PyMC-17 vs c.852 Infer-17** (L975 ★★ substance genuinely distincte) :
   - PyMC-17 cite Kalman 1960 + RTS 1965 + Sage-Melsa 1971 + Jazwinski 1970 + Maybeck 1979 (PDF textbook
     de référence sur la recursion Kalman)
   - PyMC-17 cite Hoffman-Gelman 2014 + Salvatier 2016 (NUTS + PyMC) — moteur MCMC HMC adaptatif
   - PyMC-17 cite Bishop PRML §13.3 (Linear Dynamical Systems) — modèle graphique dynamique moderne
   - Relations série : PyMC-17 (ici) ↔ Infer-17 (c.852 jumeau C#) + PyMC-14 HMM + PyMC-15 recommenders +
     PyMC-18 change-point + PyMC-19 survival = 5 liens Python-flavored

## Verifications

- **Atomicité G.4** : `+52/-7` strict, 1 fichier, 1 sujet (= twin-pair closure PyMC-17 ↔ Infer-17).
- **Catalogue byte-identique** : `COURSE_CATALOG.generated.json` / `.md` non touchés.
- **LF-only CR=0** : `raw.count(b'\r\n') == 0` sur le fichier post-patch ✓.
- **Pas de ré-exécution Papermill** : modifications markdown-only sur 6 cellules,
  0 cellule code touchée, 0 output hand-édité (exception C.2 confirmée).
- **Validateur H.3** : 8/8 code cells avec `execution_count` + `outputs` cohérents préservés.
- **C.1 scan** : 0 hit `raise NotImplementedError` / `assert False` / `1/0` (anti-patterns interdits).
- **Aucun autre fichier touché** : `git diff --name-only` = 1 fichier
  (PyMC-17-Kalman-Filter.ipynb). Pas de contamination scratchpad (body généré hors
  worktree, cf L677-L4 ★★).
- **G.1 verify-before-claiming** : valeurs verbatim viennent de :
  - `Read` direct du fichier via Python json (anchor utilisé pour reconstruire chaque `source`)
  - Recherche bibliographique : Kalman 1960, *ASME Journal of Basic Engineering* 82(1):35-45 ;
    Rauch, Tung & Striebel 1965, *AIAA Journal* 3(8):1445-1450 ; Sage & Melsa 1971, McGraw-Hill ;
    Jazwinski 1970, Academic Press ; Maybeck 1979 Vol.1, Academic Press ; Hoffman-Gelman 2014,
    *JMLR* 15(47):1593-1623 ; Salvatier 2016, *PeerJ Computer Science* 2:e55 ; Gelman BDA3 2013 ;
    Bishop PRML 2006 §13.3 ; Anderson-Moore 1979 ; Harvey 1989 ; Simon 2006 ; MBML Ch.18.
- **Sécurité secrets** : grep `API_KEY|TOKEN|sk-|ghp_|AIza|os.getenv("KEY", "literal")` sur
  diff → 0 hit.
- **L898 ★★★ + L977 ★★ pre-push** : `gh pr list --search "PyMC-17 Kalman citations"` → 0 PR OPEN
  sur citations canoniques pour ce notebook ; `gh pr list --search "Kalman citations"` → 0 OPEN ;
  `gh pr list --search "PyMC-17 Kalman"` → 0 OPEN (à confirmer avant push via gh API).
- **L954 ★ pivot cross-famille** : c.851 = notebook-probas-citations (Python Recommenders twin) →
  c.852 = notebook-probas-citations (Kalman Python twin). **13ᵉ pivot consécutif** post-c.839,
  R6 variété respectée (genre notebook-probas-citations > mais sub-genre `Kalman Python` ≠
  `Recommenders Python` = substance genuinely distincte L975 ★★).
- **L975 ★★ twin-pair coherence** : c.852 PyMC-17 ↔ c.852 Infer-17 = 2 cellules md[1] (motivation),
  2 cellules md[3] (recursion), 2 cellules md[8] (value-add PyMC/EP), 2 cellules md[12] (borne de variance
  / Riccati), 2 cellules md[17] (RTS smoother anchor), 2 cellules md[19] (Ponts + References sub-section).
  Sub-genre `notebook-citations Python twin` ≠ `notebook-citations C# twin` (substance genuinely
  distincte, litmus C711-L1 OK : NUTS joint + hyperparamètres estimés ≠ EP closed-form + paramètres
  connus).

## Hors scope (pour mémoire)

- **Infer-17 (jumeau C#)** : PR complémentaire du même cycle c.852 (mais worktree séparé pour
  L979 ★★ check). Substance distincte, audit indépendant.
- **#8081** : axe-1 sustained campaign. Après c.852 + c.852 restent non-claimés PyMC-16 (Sparse GP)
  côté Python, et Infer-1/3/4/5/6/7/8/9/10/13/15/16 côté C# — gap axis-1 résiduel substantiel sur la
  famille Probas mais déjà 9 PRs axis-1 fusionnés (c.834 + c.838 + c.830-c.833 + c.839-c.851).
- **PyMC-14 HMM** : PR #8302 c.844 a ajouté Kaplan-Meier + Cox + Weibull pour la branche survival, mais
  PyMC-14 (Sequences HMM) reste à enrichir — Rabiner 1989 + Bishop §13.2 restent gap.
- **MBML Ch.18** : référencé dans "Pour aller plus loin" md[19] sans modification de cellule — cohérence
  cross-série PyMC-15/17/18/19 References sub-section.

## Liens

- Issue epic : #8081 (axe-1 fidelity distillation)
- Jumeau C# : c.852 (Infer-17-Kalman-Filter canonical citations) — PR séparée du même cycle
- Twins antérieurs : c.851 PyMC-15 + c.850 Infer-15 — pattern twin-pair closure appliqué
- Source canonique : Kalman 1960 + Rauch-Tung-Striebel 1965 + Sage & Melsa 1971 + Jazwinski 1970 +
  Maybeck 1979 + Hoffman-Gelman 2014 NUTS

🤖 Generated with [Claude Code](https://claude.com/claude-code)