### PR TITLE
feat(planners,#3801): Prong-B search-guidance benchmark C# twin (Planners-5-Heuristics-Csharp §6.1)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-5-Heuristics-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-5-Heuristics-Csharp.ipynb
@@ -917,6 +917,135 @@
   },
   {
    "cell_type": "markdown",
+   "id": "hcs-intro",
+   "metadata": {},
+   "source": [
+    "### 6.1 Les heuristiques guident-elles VRAIMENT la recherche ?\n",
+    "\n",
+    "Le benchmark Blocks World ci-dessus (§6) compare les **valeurs** des heuristiques ($h^{max}$, $h^{add}$, $h^{FF}$) sur un problème donné. Mais toute la valeur d'une heuristique réside dans une chose : **guider la recherche**, c'est-à-dire réduire le nombre de nœuds développés par rapport à une recherche **aveugle** (uniform-cost, qui n'utilise aucune heuristique). Si deux heuristiques donnent la même valeur mais qu'aucune ne fait explorer moins de nœuds que la recherche aveugle, alors elles ne « valent » rien en pratique. Mesurons-le directement.\n",
+    "\n",
+    "Nous ajoutons au problème de la chaîne $c_0 \\to c_1 \\to \\dots \\to c_M$ un ensemble de $D$ **chaînes leurres** (faits et actions non pertinents pour le but). Ces leurres représentent les éléments non pertinents **omniprésents dans les vrais domaines** de planification : un planificateur aveugle perd son temps à les explorer, une recherche guidée par heuristique les ignore."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "hcs-code",
+   "metadata": {},
+   "execution_count": 10,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Benchmark : nombre de NOEUDS DEVELOPPES (deterministe, reproductible)\r\n",
+       "But = chaine de longueur M  ;  D = chaines leurres (faits non pertinents)\r\n",
+       "\r\n",
+       "  M   D |  UCS (aveugle)   A*+h^max   A*+h^add  Greedy+h^FF\r\n",
+       "--------------------------------------------------------------\r\n",
+       "  3   0 |              4          4          4            4\r\n",
+       "  3   4 |             22          4          4            4\r\n",
+       "  3   8 |             56          4          4            4\r\n",
+       "  3  12 |            106          4          4            4\r\n",
+       "  3  16 |            172          4          4            4\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "\n",
+    "// === Port du §6.3 : les heuristiques guident-elles VRAIMENT la recherche ? ===\n",
+    "static List<(STRIPSAction action, HashSet<string> state)> Successeurs(STRIPSProblem problem, HashSet<string> state)\n",
+    "{\n",
+    "    var res = new List<(STRIPSAction, HashSet<string>)>();\n",
+    "    foreach (var a in problem.Actions)\n",
+    "        if (a.Preconditions.All(p => state.Contains(p)))\n",
+    "        {\n",
+    "            var ns = new HashSet<string>(state);\n",
+    "            ns.UnionWith(a.AddEffects);\n",
+    "            if (!ns.SetEquals(state)) res.Add((a, ns));\n",
+    "        }\n",
+    "    return res;\n",
+    "}\n",
+    "static string CleEtat(HashSet<string> s) => string.Join(\",\", s.OrderBy(x => x));\n",
+    "static (int cost, int expansions) Recherche(STRIPSProblem problem, Func<STRIPSProblem, HashSet<string>, int>? hFn, string mode)\n",
+    "{\n",
+    "    var frontier = new PriorityQueue<(HashSet<string> state, int g), (int p1, int p2, int ord)>();\n",
+    "    int counter = 0;\n",
+    "    var depart = new HashSet<string>(problem.InitialState);\n",
+    "    int h0 = hFn != null ? hFn(problem, depart) : 0;\n",
+    "    (int, int) pk(int g, int h) => mode switch { \"ucs\" => (g, 0), \"astar\" => (g + h, g), \"greedy\" => (h, g), _ => (g, 0) };\n",
+    "    var k0 = pk(0, h0);\n",
+    "    frontier.Enqueue((depart, 0), (k0.Item1, k0.Item2, counter++));\n",
+    "    var fermes = new HashSet<string>();\n",
+    "    int expansions = 0;\n",
+    "    while (frontier.Count > 0)\n",
+    "    {\n",
+    "        var (etat, g) = frontier.Dequeue();\n",
+    "        var cle = CleEtat(etat);\n",
+    "        if (fermes.Contains(cle)) continue;\n",
+    "        fermes.Add(cle); expansions++;\n",
+    "        if (problem.Goal.All(gl => etat.Contains(gl))) return (g, expansions);\n",
+    "        foreach (var (action, suivant) in Successeurs(problem, etat))\n",
+    "        {\n",
+    "            if (fermes.Contains(CleEtat(suivant))) continue;\n",
+    "            int ng = g + action.Cost;\n",
+    "            int nh = hFn != null ? hFn(problem, suivant) : 0;\n",
+    "            var nk = pk(ng, nh);\n",
+    "            frontier.Enqueue((suivant, ng), (nk.Item1, nk.Item2, counter++));\n",
+    "        }\n",
+    "    }\n",
+    "    return (-1, expansions);\n",
+    "}\n",
+    "static int HMaxPur(STRIPSProblem p, HashSet<string> s) => HMax(p, s);\n",
+    "static int HAddPur(STRIPSProblem p, HashSet<string> s) => HAdd(p, s).hValue;\n",
+    "static int HFFPur(STRIPSProblem p, HashSet<string> s) => HFF(p, s).hValue;\n",
+    "static STRIPSProblem ProblemeChaineAvecDistracteurs(int M, int D)\n",
+    "{\n",
+    "    var actions = new List<STRIPSAction>();\n",
+    "    for (int j = 0; j < M; j++)\n",
+    "        actions.Add(new STRIPSAction($\"etape_but_{j+1}\", new(){$\"c{j}\"}, new(){$\"c{j+1}\"}, 1));\n",
+    "    for (int j = 0; j < D; j++)\n",
+    "    {\n",
+    "        actions.Add(new STRIPSAction($\"leurre_{j}_1\", new(){\"c0\"}, new(){$\"d{j}\"}, 1));\n",
+    "        actions.Add(new STRIPSAction($\"leurre_{j}_2\", new(){$\"d{j}\"}, new(){$\"dd{j}\"}, 1));\n",
+    "    }\n",
+    "    return new STRIPSProblem(new(){\"c0\"}, new(){$\"c{M}\"}, actions);\n",
+    "}\n",
+    "var sb = new System.Text.StringBuilder();\n",
+    "sb.AppendLine(\"Benchmark : nombre de NOEUDS DEVELOPPES (deterministe, reproductible)\");\n",
+    "sb.AppendLine(\"But = chaine de longueur M  ;  D = chaines leurres (faits non pertinents)\");\n",
+    "sb.AppendLine();\n",
+    "sb.AppendLine(string.Format(\"{0,3} {1,3} | {2,14} {3,10} {4,10} {5,12}\", \"M\", \"D\", \"UCS (aveugle)\", \"A*+h^max\", \"A*+h^add\", \"Greedy+h^FF\"));\n",
+    "sb.AppendLine(new string('-', 62));\n",
+    "foreach (var (M, D) in new[] {(3,0),(3,4),(3,8),(3,12),(3,16)})\n",
+    "{\n",
+    "    var p = ProblemeChaineAvecDistracteurs(M, D);\n",
+    "    int ucs  = Recherche(p, null,     \"ucs\").expansions;\n",
+    "    int amax = Recherche(p, HMaxPur,  \"astar\").expansions;\n",
+    "    int aadd = Recherche(p, HAddPur,  \"astar\").expansions;\n",
+    "    int gff  = Recherche(p, HFFPur,   \"greedy\").expansions;\n",
+    "    sb.AppendLine(string.Format(\"{0,3} {1,3} | {2,14} {3,10} {4,10} {5,12}\", M, D, ucs, amax, aadd, gff));\n",
+    "}\n",
+    "sb.ToString().Display();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "hcs-interp",
+   "metadata": {},
+   "source": [
+    "**Lecture — la différence se mesure en nœuds, pas en valeurs.** Le contraste est tranché : la recherche aveugle (UCS) **explose** quand on ajoute des faits non pertinents (4 → 22 → 56 → 106 → **172** nœuds développés quand $D$ passe de 0 à 16), alors que **toute recherche guidée par heuristique reste plate à 4 nœuds**, indépendamment de $D$. À $D = 16$, c'est **~43× moins de nœuds** — et l'écart ne fait que croître avec le nombre de faits leurres.\n",
+    "\n",
+    "Ce résultat est **strictement identique** à celui du jumeau Python (`Planners-5-Heuristics.ipynb` §6.3) : les deux implémentations (C# et Python) des heuristiques de relaxation produisent les mêmes comptes de nœuds, ce qui confirme que la propriété démontrée est **algorithmique** (indépendante du langage).\n",
+    "\n",
+    "Sur cette structure de chaîne, $h^{max}$, $h^{add}$ et $h^{FF}$ guident identiquement (toutes admissibles ici, toutes identifient le chemin optimal en ignorant les leurres) ; leur *différence* de valeur (l'inadmissibilité de $h^{add}$ en général) est orthogonale au compte de nœuds sur ce problème. Ce qui compte ici est le contraste **heuristique-guidée vs aveugle**.\n",
+    "\n",
+    "> **Lien CS** : A* avec une heuristique admissible ne développe que les nœuds de $f(n) < C^*$, contre tous les nœuds de $g(n) < C^*$ pour uniform-cost. Plus le domaine contient de faits/états non pertinents à $f$ élevé, plus le ratio de nœuds épargnés grandit — exactement ce que la table ci-dessus montre croître avec $D$. C'est la raison pour laquelle Fast Downward résout des problèmes où la recherche aveugle est intractable."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "6c7e2377",
    "metadata": {
     "papermill": {
@@ -959,7 +1088,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "05778994",
    "metadata": {
     "execution": {
@@ -1021,7 +1150,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "093c089c",
    "metadata": {
     "execution": {
@@ -1083,7 +1212,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "f8cc0826",
    "metadata": {
     "execution": {


### PR DESCRIPTION
feat(planners,#3801): Prong-B search-guidance benchmark C# twin (Planners-5-Heuristics-Csharp §6.1)

Ports PR #8336 section 6.3 (Python twin) heuristic-guided-search benchmark to the
C# .NET Interactive twin. The C# notebook previously benchmarked only heuristic
VALUES on Blocks World (section 6) but never demonstrated that heuristics actually
GUIDE the search (reduce expansions vs blind UCS) -- the Prong-B gap.

Adds section 6.1 "Les heuristiques guident-elles VRAIMENT la recherche ?" (3 cells:
markdown intro / C# code ec=10 / markdown interpretation) inserted after the
section 6 Blocks World benchmark, before "## Exercices". The benchmark counts
search-tree node EXPANSIONS (deterministic, reproducible cross-machine) for UCS
(blind) vs A*/greedy guided by h_max/h_add/h_ff on a chain problem with D decoy
chains.

Numbers are byte-identical to the Python twin (twin parity):
  UCS (blind):  D=0->4, 4->22, 8->56, 12->106, 16->172 expansions
  h_max/h_add/h_ff guided: flat 4 expansions (independent of D)
  => ~43x fewer nodes at D=16; confirms the property is algorithmic
     (language-independent).

Validation:
- C.2: output proven real -- full notebook executed end-to-end (nbconvert, exit 0);
  the spliced display_data output is byte-identical to the fresh full-exec output
  (source identical, ec=10 both). The only dropped output is a CS8632 nullable
  compiler WARNING (stderr), consistently with the notebook's 0-stream-outputs
  convention (all 13 code cells: display_data only, no stderr).
- ec renumbered 10->11/11->12/12->13 on the 3 exercise cells to keep the code-cell
  execution_count sequential 1..13 after insertion.
- H.3 + nbformat: PASS (13 code cells). C.1: 0 voluntary errors. No banner leak.
- Byte-stable splice: +132/-3 (3 new cells + 3 ec bumps), every other byte intact.
- Twin parity: clears the Planners-5 twin-drift advisory (Python 6.3 <-> C# 6.1).

See #8336 (Python twin, merged-ready) and #3801 (Prong-B SOTA problem-richness registry).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
