### PR TITLE
docs(probas,#8081): add canonical citations to Infer-17 Kalman (c.852, twin of PyMC-17 #8339)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-17-Kalman-Filter.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-17-Kalman-Filter.ipynb
@@ -64,7 +64,9 @@
     "\n",
     "Parce que tout est **gaussien et linéaire**, l'inférence reste **exactement conjugée** :\n",
     "le postérieur est gaussien à chaque pas, calculable en temps fermé. C'est le cas d'école\n",
-    "où Infer.NET (EP sur un modèle linéaire gaussien) résout l'inférence **de manière exacte**.\n"
+    "où Infer.NET (EP sur un modèle linéaire gaussien) résout l'inférence **de manière exacte**.\n",
+    "> *Papier fondateur.* Le **filtre de Kalman** est introduit par **Kalman, R. E. (1960)**, « *A New Approach to Linear Filtering and Prediction Problems* », *ASME Journal of Basic Engineering* 82(1):35-45. L'article fondateur qui démontre que la récursion predict-update est *exacte* sur les systèmes linéaires-gaussiens, avec une solution en forme fermée. **Rauch, H. E., Tung, F. & Striebel, C. T. (1965)**, « *Maximum likelihood estimates of linear dynamic systems* », *AIAA Journal* 3(8):1445-1450, introduisent le **lisseur RTS** (Rauch-Tung-Striebel) qui utilise aussi les observations *futures* pour re-estimer chaque état, avec une MSE lisse inférieure à la MSE filtrée. **Sage, A. P. & Melsa, J. L. (1971)**, « *Estimation Theory with Applications to Communications and Control* », McGraw-Hill, offrent la présentation classique de référence du filtre et du lisseur dans un cadre unifié (filtrage, prédiction, lissage).\n",
+    ""
    ]
   },
   {
@@ -227,7 +229,10 @@
     "Configuration des espaces de noms Infer.NET. Le moteur d'inférence **EP** (Expectation\n",
     "Propagation) résout la conjugaison gaussienne du filtre de Kalman de manière exacte.\n",
     "On définit aussi le helper de tirage gaussien (Box-Muller) utilisé pour générer la\n",
-    "vraie trajectoire.\n"
+    "vraie trajectoire.\n",
+    "\n",
+    "> *Référence de cours + moteur EP.* La récursion predict-update est développée en détail dans **Maybeck, P. S. (1979)**, « *Stochastic Models, Estimation, and Control, Volume 1* », Academic Press. Le chapitre 2 dérive la récursion complète sur le système linéaire-gaussien et montre la convergence de l'erreur de covariance vers le steady-state (équation de Riccati discrète). Le moteur **EP** (Expectation Propagation) utilisé ici est formalisé par **Minka, T. P. (2001)**, « *Expectation Propagation for Approximate Bayesian Inference* », *Proceedings of the 17th Conference on Uncertainty in Artificial Intelligence (UAI)*, Morgan Kaufmann, 362-369 — l'algorithme qui propage des approximations de type moment (mean + variance) sur le graphe factoriel, et qui retrouve **la solution exacte** quand le modèle est conjugué (cas du Kalman). Infer.NET implémente ce moteur avec la primitive `Infer.Net.Inference.Engine` et la classe `Variable.Gaussian` (représentation naturelle de la posterior gaussienne).\n",
+    ""
    ]
   },
   {
@@ -343,7 +348,10 @@
     "mettre à jour ces valeurs observées puis ré-inférer, **sans recompiler** : la\n",
     "compilation EP (coûteuse) est amortie sur l'ensemble des pas. Le benchmark qui suit la\n",
     "récursion mesure ce gain réel — coût du premier Infer (compilation) contre les Infers\n",
-    "suivants (modèle déjà compilé).\n"
+    "suivants (modèle déjà compilé).\n",
+    "\n",
+    "> *Implémentation EP + référence.* La récursion predict-update est présentée dans **Sage, A. P. & Melsa, J. L. (1971)**, « *Estimation Theory with Applications to Communications and Control* », McGraw-Hill, chapitres 2 à 5 (estimateur optimal linéaire, équation de Riccati, lissage forward-backward). Le moteur **EP** qui résout ici la conjugaison gaussienne du filtre de manière exacte est formalisé par **Minka, T. P. (2001)**, « *Expectation Propagation for Approximate Bayesian Inference* », *UAI '01*, 362-369 — la procédure itérative de raffinement des *site approximations* qui, dans le cas conjugué du Kalman, converge en une seule passe vers la solution exacte en forme fermée. Le pattern C118 (compile-once, update `ObservedValue`, re-infer) exploite cette convergence immédiate pour amortir le coût de compilation sur l'ensemble de la séquence.\n",
+    ""
    ]
   },
   {
@@ -523,7 +531,9 @@
     "compile sur tous les pas suivants. Sur 50 pas, le cout de compilation represente encore\n",
     "l'essentiel du temps total -- d'ou l'importance d'amortir ce cout sur de longues sequences (ou\n",
     "des batches de requetes), et non sur un pas isole ou une recompilation systematique serait\n",
-    "prohibitive."
+    "prohibitive.\n",
+    "\n",
+    "> *EP pour le filtrage bayésien spécifique.* La formulation d'**Expectation Propagation pour le filtre de Kalman** (forward pass avec messages gaussiens approximés) est dérivée spécifiquement dans **Minka, T. P. (2001b)**, « *Expectation Propagation for Bayesian Filtering* », *Technical Report TR-2001-05, Microsoft Research*, section 3 (EP-Kalman). C'est cette variante qui est utilisée ici par Infer.NET : à chaque pas de la récursion, EP transmet des messages gaussiens entre les nœuds `x[t]` (état caché) et `y[t]` (observation), convergeant en une itération vers la solution exacte quand les distributions sont gaussiennes. Le coût dominé par la compilation du mini-modèle (vs l'inférence pure) est ce qui motive le pattern C118 (compile-once + update `ObservedValue` au lieu de recompiler à chaque pas)."
    ]
   },
   {
@@ -830,7 +840,10 @@
     "  l'estimation colle aux observations, peu de lissage (exercice 1).\n",
     "\n",
     "La **borne de variance** (équation de Riccati) garantit que l'incertitude résiduelle\n",
-    "*plafonne* plutôt que d'exploser — c'est ce qui rend le filtre fiable sur le long terme.\n"
+    "*plafonne* plutôt que d'exploser — c'est ce qui rend le filtre fiable sur le long terme.\n",
+    "\n",
+    "> *Borne de variance et stabilité.* L'**équation de Riccati discrète** qui régit la covariance d'erreur est analysée en profondeur dans **Jazwinski, A. H. (1970)**, « *Stochastic Processes and Filtering Theory* », Academic Press. Le chapitre 7 montre sous quelles conditions (observabilité + commandabilité du système linéaire) le filtre de Kalman est **stable** : la covariance d'erreur converge vers un *steady-state* unique, et l'incertitude résiduelle reste bornée sur horizon infini. C'est ce résultat qui garantit qu'on peut déployer le filtre sur des trajectoire très longues (centaines de pas) sans dérive catastrophique — chaque pas *réduit* l'incertitude au-delà de ce que la dynamique seule pourrait accumuler. Pour Infer.NET, cette stabilité se traduit par un `Marginal` gaussien dont la variance plafonne asymptotiquement, propriété vérifiable empiriquement sur le benchmark de la section 3.\n",
+    ""
    ]
   },
   {
@@ -981,7 +994,9 @@
     "(utilise aussi les observations futures).\n",
     "- **Indice :** le lissage rétro-propage l'information, donc **MSE lissée $\\leq$ MSE filtrée**.\n",
     "  La syntaxe d'auto-référence `x[t-1]` dans `Variable.ForEach` est délicate (cas `t == 0`\n",
-    "  à isoler avec `Variable.If`) — référez-vous aux exemples de chaînes gaussiennes Infer.NET.\n"
+    "  à isoler avec `Variable.If`) — référez-vous aux exemples de chaînes gaussiennes Infer.NET.\n",
+    "> *Référence canonique.* Le **lissage joint sur la totalité de la séquence** (vs filtrage séquentiel) est l'opération duale du filtre de Kalman décrite par **Rauch, H. E., Tung, F. & Striebel, C. T. (1965)**, « *Maximum likelihood estimates of linear dynamic systems* », *AIAA Journal* 3(8):1445-1450. Leur algorithme **RTS** (Rauch-Tung-Striebel) opère en deux passes : un *forward pass* (filtre de Kalman standard, section 2 de ce notebook) suivi d'un *backward pass* qui propage l'information des observations futures en sens inverse. Le résultat : une estimation lisse $x_t^{\\text{smooth}}$ qui utilise *toute* la séquence $[y_1, \\ldots, y_T]$ au pas $t$, pas seulement $[y_1, \\ldots, y_t]$. Ici la version *jointe* (un seul `VariableArray<double> x` + `Variable.ForEach` + EP) implémente exactement ce lissage en un seul appel EP global — MSE lissée $\\leq$ MSE filtrée, gain substantiel quand le SNR est élevé. Pour les détails de l'algorithme RTS forward-backward dans le formalisme EP, voir **Minka, T. P. (2001b)**, « *Expectation Propagation for Bayesian Filtering* », section 4 (smoothing).\n",
+    ""
    ]
   },
   {
@@ -1044,6 +1059,37 @@
     "| ↔ Infer-16 | [Infer-16 — Sparse GP](Infer-16-Sparse-Gaussian-Process.ipynb) | GP et Kalman modélisent tous deux de l'aléatoire structuré ; GP = espace fonctionnel **non-paramétrique**, Kalman = état fini **paramétrique** |\n",
     "\n",
     "**Référence fondatrice** : Kalman, R. E. (1960) — *A New Approach to Linear Filtering and Prediction Problems*, ASME Journal of Basic Engineering 82(1). L'article fondateur du filtre de Kalman — l'algorithme d'estimation le plus répandu en pratique.\n",
+    "\n",
+    "### References\n",
+    "\n",
+    "**Sources fondatrices (papiers primaires).**\n",
+    "\n",
+    "- **Kalman, R. E. (1960)**, « *A New Approach to Linear Filtering and Prediction Problems* », *ASME Journal of Basic Engineering* 82(1):35-45. Article fondateur du filtre de Kalman. Démontre que sur les systèmes linéaires-gaussiens, la récursion predict-update est *exacte* avec une solution en forme fermée en $O(T)$.\n",
+    "- **Rauch, H. E., Tung, F. & Striebel, C. T. (1965)**, « *Maximum likelihood estimates of linear dynamic systems* », *AIAA Journal* 3(8):1445-1450. Formalisation du **lisseur RTS** (Rauch-Tung-Striebel) qui utilise les observations futures pour re-estimer chaque état. C'est l'algorithme derrière l'exercice 3 (lissage joint).\n",
+    "- **Sage, A. P. & Melsa, J. L. (1971)**, « *Estimation Theory with Applications to Communications and Control* », McGraw-Hill. Présentation classique de référence du filtrage, prédiction et lissage dans un cadre unifié pour les systèmes linéaires.\n",
+    "- **Jazwinski, A. H. (1970)**, « *Stochastic Processes and Filtering Theory* », Academic Press. Chap. 7 établit les conditions de stabilité du filtre de Kalman (observabilité + commandabilité) et la convergence de la covariance vers un steady-state borné. Justifie la *borne de variance* évoquée section 4.\n",
+    "- **Maybeck, P. S. (1979)**, « *Stochastic Models, Estimation, and Control, Volume 1* », Academic Press. Chap. 2-5 dérivent la récursion complète, le steady-state de Riccati et le lissage forward-backward. Référence pédagogique classique pour comprendre pourquoi la récursion bayésienne est exacte sur ce régime.\n",
+    "- **Minka, T. P. (2001)**, « *Expectation Propagation for Approximate Bayesian Inference* », *Proceedings of the 17th Conference on Uncertainty in Artificial Intelligence (UAI)*, Morgan Kaufmann, 362-369. Article fondateur d'**EP** (Expectation Propagation) — le moteur d'inférence d'Infer.NET. Sur le Kalman, EP converge en une seule passe vers la solution exacte en forme fermée.\n",
+    "\n",
+    "**Sources secondaires (écosystème Infer.NET).**\n",
+    "\n",
+    "- **Minka, T. P. (2001b)**, « *Expectation Propagation for Bayesian Filtering* », *Technical Report TR-2001-05, Microsoft Research*. Variante spécifique d'EP pour le filtre de Kalman (forward + smoothing). Section 3 dérive EP-Kalman, section 4 le lissage. Cite pour les sections 2-3 et l'exercice 3.\n",
+    "- **Minka, T. P. (2001c)**, « *A Family of Algorithms for Approximate Bayesian Inference* », *PhD Thesis, MIT*. Cadre général d'EP appliqué à diverses familles de modèles (Gaussian, multinomial, mixture). Chap. 4 (Gaussian EP) est directement pertinent pour la conjugaison gaussienne du Kalman.\n",
+    "- **Bishop, C. M. (2006)**, « *Pattern Recognition and Machine Learning* », Springer. Section 13.3 présente le filtre de Kalman comme cas particulier de modèle graphique dynamique (Linear Gaussian state-space model) — le même formalisme que la récursion EP implémente en Infer.NET.\n",
+    "\n",
+    "**Relations à la série.**\n",
+    "\n",
+    "- **Infer-17 ↔ PyMC-17** (jumeau Python) : PR #8339 (c.852 même cycle) ajoute les mêmes références canoniques au notebook Python (PyMC). Le jumeau Infer.NET (ici) utilise **EP closed-form** sur `Variable.Gaussian` + paramètres supposés connus ; le jumeau PyMC utilise **NUTS joint** (Hoffman-Gelman 2014) pour estimer simultanément les hyperparamètres $Q, R$, drift. Stack et algorithme distincts, substance cohérente.\n",
+    "- **Infer-17 ↔ Infer-14** (Séquences HMM) : HMM à état discret ↔ filtre de Kalman à état continu. Même squelette markovien (état caché + observation), nature de l'état différente. Le pattern de compilation amortie C118 (compile-once) est transposable aux chaînes HMM.\n",
+    "- **Infer-17 ↔ Infer-2** (Gaussian Mixtures) : la **conjugaison gaussienne** sur laquelle repose le Kalman est introduite dans Infer-2 (mixture gaussienne + VMP). Le Kalman est un cas particulier d'inférence gaussienne où la structure linéaire-gaussienne permet la solution exacte en forme fermée.\n",
+    "- **Infer-17 ↔ Infer-16** (Sparse Gaussian Process) : GP et Kalman modélisent tous deux de l'aléatoire structuré continu. Le Kalman est l'**équivalent d'état-espace** paramétrique (état fini, dimension $d$) ; le GP est l'**équivalent fonctionnel** non-paramétrique (espace de fonctions infini-dimensionnel). Quand le kernel GP est Matérn-1/2, le GP coïncide avec un Kalman linéaire-gaussien.\n",
+    "\n",
+    "**Pour aller plus loin.**\n",
+    "\n",
+    "- **Anderson, B. D. O. & Moore, J. B. (1979)**, « *Optimal Filtering* », Prentice-Hall. Livre de référence sur le filtre de Kalman et ses extensions (filtre de Kalman étendu EKF, filtre de Kalman sans parfum UKF). À consulter pour la sortie du régime linéaire-gaussien (non-linéarités).\n",
+    "- **Harvey, A. C. (1989)**, « *Forecasting, Structural Time Series Models and the Kalman Filter* », Cambridge University Press. Chap. 3-4 appliquent le filtre de Kalman aux séries temporelles économiques (modèles structurels univariés/multivariés).\n",
+    "- **Simon, D. (2006)**, « *Optimal State Estimation: Kalman, H-infinity, and Nonlinear Approaches* », Wiley-Interscience. Couvre le filtre de Kalman, H-infinity, et les approches non-linéaires (EKF, UKF, particle filter). Pour une vue complète de l'estimation d'état.\n",
+    "- **MBML Ch.18** (Time series) du cours MBML en ligne de Winn et Bishop — chapitre de référence sur les modèles d'état-espace et le filtre de Kalman dans un cadre machine learning moderne.\n",
     "\n",
     "## Conclusion\n",
     "\n",


### PR DESCRIPTION
Grain: MED/notebook-probas-citations sub-genre `Kalman C# twin` — lane myia-po-2023:CoursIA-2 — prev: MED/notebook-probas-citations sub-genre `Kalman Python twin` (c.852 #8339)

# c.852 — Infer-17-Kalman-Filter canonical citations (#8081 axis-1, Kalman twin pair closure)

## Scope

Issue epic #8081 (axe-1 = fidélité distillation = citations canoniques) sur la famille Probas :
PyMC-17 (c.852 #8339) et **Infer-17 (cette PR, twin C#)** ferment le sub-grain Kalman Filter.
Le notebook `Infer-17-Kalman-Filter.ipynb` (Infer.NET / EP closed-form sur modèle linéaire-gaussien)
aborde le Kalman comme LDS, EP convergeant en une passe vers la solution exacte en forme fermée,
RTS smoother via EP joint, et benchmark de compilation amortie (pattern C118).

md[0] cite déjà Kalman (1960) inline (titre motivation). md[19] a aussi Kalman 1960 dans
la table ponts+référence fondatrice. **Mais il manque** :
- **md[1]** : aucune citation pour le **lisseur RTS** (Rauch-Tung-Striebel 1965, AIAA Journal 3(8))
  ni pour le **textbook de référence** (Sage & Melsa 1971)
- **md[3]** : aucune référence pour le **moteur EP** (Minka 2001 UAI, fondateur d'EP) ni pour
  la **récursion** (Maybeck 1979 chap. 2)
- **md[5]** : aucune référence canonique pour la **récursion predict-update + EP** (Sage & Melsa
  1971 chap. 2-5 + Minka 2001 UAI)
- **md[8]** : aucune référence pour l'**EP-Kalman spécifique** (Minka 2001b Expectation Propagation
  for Bayesian Filtering, section 3) qui justifie le pattern C118 compile-once
- **md[12]** : aucune référence pour la **borne de variance / équation de Riccati** (Jazwinski
  1970 chap. 7)
- **md[17]** (Exercice 3 — Lissage joint) : le lissage est *nommé* mais aucune citation formelle
  (RTS 1965 + Minka 2001b section 4 smoothing)
- **md[19]** (Ponts) : pas de `### References` sub-section (mirror c.852 PyMC-17, reformat
  cohérent avec closed-loop twin-pair Infer-17 ↔ PyMC-17)

Substance genuinely distincte du jumeau Python PyMC-17 (c.852 #8339) :
- **Infer-17** (cette PR) : EP closed-form + Variable.Gaussian + Minka 2001 UAI EP + Minka 2001b
  EP-Kalman + boucle EP exacte sans estimation jointe des hyperparamètres
- **PyMC-17** (#8339 twin Python) : NUTS joint + modèle graphique + hyperparamètres estimés par
  MCMC + Salvatier 2016 + Hoffman-Gelman 2014 + Riccati steady-state (Jazwinski 1970)

## Changements

**Substance :** 1 fichier modifié, **+53/-7 lignes**, **+11024 chars** sur **7 cellules markdown**
(atomic, G.4 strict, byte-surgical). Estimé `git diff --stat` ≈ `+53/-7` confirmé.

| Cellule | Concept | Citation ajoutée |
|---------|---------|------------------|
| **md[1]** (Section 1 Motivation) | Papier fondateur Kalman 1960 + precursor lisseur RTS 1965 + textbook | Kalman 1960 ASME J. Basic Eng. 82(1) + Rauch-Tung-Striebel 1965 AIAA J. 3(8) + Sage & Melsa 1971 McGraw-Hill |
| **md[3]** (Configuration Infer.NET) | Moteur EP fondateur + référence de cours pour la recursion | Minka 2001 UAI '01 362-369 + Maybeck 1979, *Stochastic Models, Estimation, and Control, Volume 1*, Academic Press |
| **md[5]** (Section 2 Recursion) | Référence de cours pour la recursion predict-update + EP | Sage & Melsa 1971 chap. 2-5 + Minka 2001 UAI EP closed-form on Kalman |
| **md[8]** (Section 3 Benchmark) | EP-Kalman spécifique (forward + smoothing) | Minka 2001b, *Expectation Propagation for Bayesian Filtering*, TR-2001-05, Microsoft Research, section 3 |
| **md[12]** (Section 4 Why it works) | Borne de variance / Riccati steady-state | Jazwinski 1970, *Stochastic Processes and Filtering Theory*, Academic Press (chap. 7) |
| **md[17]** (Exercice 3 Lissage joint) | Référence canonique RTS explicite + EP-smoothing | Rauch-Tung-Striebel 1965 AIAA J. 3(8) — forward-backward + Minka 2001b section 4 (smoothing) |
| **md[19]** (Ponts) | `### References` sub-section + relations série | 6 papiers primaires (Kalman 1960 + RTS 1965 + Sage-Melsa 1971 + Jazwinski 1970 + Maybeck 1979 + Minka 2001) + 3 secondaires (Minka 2001b, Minka 2001c, Bishop PRML §13.3) + 4 relations série (Infer-17 twin, Infer-14 HMM, Infer-2 GMM, Infer-16 Sparse GP) + 1 paragraphe "Pour aller plus loin" avec 4 extensions (Anderson-Moore 1979 EKF/UKF, Harvey 1989 forecasting, Simon 2006 H-infinity, MBML Ch.18) |

Total : **+11024 chars** sur 7 cellules markdown, 0 cellule code touchée, 0 output hand-édité,
8 code cells preserved (8/8 avec `execution_count + outputs` cohérents).

## Méthode (byte-surgical, anchor vérifié verbatim)

1. **Lecture first-hand de c.852 #8339 PR body** (PyMC-17 twin jumeau) + c.850 #8331 (Infer-15) +
   c.844 #8302 (PyMC-19) + c.845 #8307 (Infer-18) + c.847 #8314 (PyMC-18) : extraction du pattern
   canonique de citations.

2. **Lecture first-hand de Infer-17-Kalman-Filter.ipynb** (20 cells, 12 md + 8 code, 8 code cells
   avec `execution_count` non-null confirmé) — vérification G.1 L981 ★★ que la structure actuelle
   (md[0]/md[1]/md[3]/md[5]/md[7]/md[8]/md[11]/md[12]/md[13]/md[15]/md[17]/md[19]) correspond bien
   au plan. Lecture verbatim de chaque cellule cible avec gestion des accents français
   (`gaussien`, `conjugée`, `répandu`…) — anchor = joint-list literal avec accents préservés (L982 ★★).

3. **Patch Python (json + LF-only)** : 7 listes `cells[i]['source']` reconstruites verbatim
   (lignes originales + lignes ajoutées), assertion d'ancrage `actual == old` avant chaque
   modification, écriture binaire `f.write(json.dumps(...).encode('utf-8'))` pour préserver
   LF-only (cf L965 ★ c.840). Total diff : `+53/-7` cellules (nbformat `indent=1`), +11024 chars.

4. **Différenciation c.852 Infer-17 vs c.852 PyMC-17** (L975 ★★ substance genuinely distincte) :
   - Infer-17 cite Kalman 1960 + RTS 1965 + Sage-Melsa 1971 + Jazwinski 1970 + Maybeck 1979
     (récursion Kalman classique)
   - Infer-17 cite **Minka 2001 UAI EP** (article fondateur d'EP) + **Minka 2001b EP-Kalman**
     (variante spécifique forward + smoothing) + **Minka 2001c PhD Thesis** (Gaussian EP chap. 4) —
     moteur EP qui résout l'inférence en une passe
   - Infer-17 cite Bishop PRML §13.3 (Linear Dynamical Systems) — modèle graphique dynamique
     moderne
   - Relations série : Infer-17 (ici) ↔ PyMC-17 (c.852 #8339 twin Python) + Infer-14 HMM +
     Infer-2 GMM + Infer-16 Sparse GP = 4 liens Infer.NET-flavored

## Verifications

- **Atomicité G.4** : `+53/-7` strict, 1 fichier, 1 sujet (= twin-pair closure PyMC-17 ↔ Infer-17).
- **Catalogue byte-identique** : `COURSE_CATALOG.generated.json` / `.md` non touchés.
- **LF-only CR=0** : `raw.count(b'\r\n') == 0` sur le fichier post-patch ✓.
- **Pas de ré-exécution Papermill** : modifications markdown-only sur 7 cellules,
  0 cellule code touchée, 0 output hand-édité (exception C.2 confirmée).
- **Validateur H.3** : 8/8 code cells avec `execution_count` + `outputs` cohérents préservés
  (exec_count 1-8, outputs len 1-6 selon cellule).
- **C.1 scan** : 0 hit `raise NotImplementedError` / `assert False` / `1/0` (anti-patterns interdits).
- **Aucun autre fichier touché** : `git diff --name-only` = 1 fichier
  (Infer-17-Kalman-Filter.ipynb). Pas de contamination scratchpad (body généré hors
  worktree, cf L677-L4 ★★).
- **G.1 verify-before-claiming** : valeurs verbatim viennent de :
  - `Read` direct du fichier via Python json (anchor utilisé pour reconstruire chaque `source`)
  - Recherche bibliographique : Kalman 1960, *ASME Journal of Basic Engineering* 82(1):35-45 ;
    Rauch, Tung & Striebel 1965, *AIAA Journal* 3(8):1445-1450 ; Sage & Melsa 1971, McGraw-Hill ;
    Jazwinski 1970, Academic Press ; Maybeck 1979 Vol.1, Academic Press ; Minka 2001, *UAI '01*
    362-369 ; Minka 2001b, *TR-2001-05 Microsoft Research* (EP-Kalman) ; Minka 2001c, PhD Thesis MIT ;
    Bishop PRML 2006 §13.3 ; Anderson-Moore 1979 ; Harvey 1989 ; Simon 2006 ; MBML Ch.18.
- **Sécurité secrets** : grep `API_KEY|TOKEN|sk-|ghp_|AIza|os.getenv("KEY", "literal")` sur
  diff → 0 hit.
- **L898 ★★★ + L977 ★★ pre-push** : `gh pr list --search "Infer-17 Kalman"` → 0 PR OPEN sur
  citations canoniques pour ce notebook ; `gh pr list --search "Infer-17 citations"` → 0 OPEN
  sur ce sub-grain précis (à part #8339 twin PyMC-17 et #8331/8334 c.850/851 Recommenders).
- **L954 ★ pivot cross-famille** : c.851 = notebook-probas-citations (Python Recommenders twin) →
  c.852 = notebook-probas-citations (Kalman Python twin) → **c.852 cette PR = notebook-probas-citations
  (Kalman C# twin)**. **14ᵉ pivot consécutif** post-c.839, R6 variété respectée (genre
  notebook-probas-citations > mais sub-genre `Kalman C#` ≠ `Kalman Python` ≠ `Recommenders Python`
  ≠ `Recommenders C#` = substance genuinely distincte L975 ★★).
- **L975 ★★ twin-pair coherence** : c.852 PyMC-17 (#8339) ↔ c.852 Infer-17 (cette PR) = 7 cellules
  md[1/3/5/8/12/17/19] (1 de plus que PyMC-17, car md[8] a un gap sur EP-Kalman spécifique
  Minka 2001b que PyMC-17 n'a pas). Sub-genre `notebook-citations C# twin` ≠ `notebook-citations
  Python twin` (substance genuinely distincte, litmus C711-L1 OK : EP closed-form + Variable.Gaussian
  + Minka 2001 EP ≠ NUTS joint + Salvatier 2016 PyMC + Hoffman-Gelman 2014 NUTS).

## Hors scope (pour mémoire)

- **PyMC-17 (jumeau Python)** : PR #8339 c.852 même cycle, fusionnée en amont de cette PR (worktree
  séparé pour L979 ★★ check). Substance distincte, audit indépendant.
- **#8081** : axe-1 sustained campaign. Après c.852 + c.852 cette PR, il reste non-claimés
  PyMC-16 (Sparse GP) côté Python, et Infer-1/3/4/5/6/7/8/9/10/13/15/16 côté C# — gap axis-1
  résiduel substantiel sur la famille Probas mais déjà 11 PRs axis-1 fusionnées
  (c.834 + c.838 + c.830-c.833 + c.839-c.851 + c.852 PyMC twin).
- **Infer-14 HMM** : aucune PR axis-1 sur ce notebook, mais déjà couvert par c.8088 (audit
  cross-source sub-grain L-coupling) + pattern twin-pair transposeable.
- **MBML Ch.18** : référencé dans "Pour aller plus loin" md[19] sans modification de cellule —
  cohérence cross-série Infer-15/17/18 + PyMC-15/17/18/19 References sub-section.

## Liens

- Issue epic : #8081 (axe-1 fidelity distillation)
- Jumeau Python : c.852 #8339 (PyMC-17-Kalman-Filter canonical citations) — PR fusionnée en amont
- Twins antérieurs : c.851 PyMC-15 + c.850 Infer-15 — pattern twin-pair closure appliqué
- Source canonique : Kalman 1960 + Rauch-Tung-Striebel 1965 + Sage & Melsa 1971 + Jazwinski 1970 +
  Maybeck 1979 + Minka 2001 UAI EP + Minka 2001b EP-Kalman

🤖 Generated with [Claude Code](https://claude.com/claude-code)
