### PR TITLE
feat(pymc-13,#3801): Prong-B discriminating Dawid-Skene demo (biased workers)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-13-Crowdsourcing.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-13-Crowdsourcing.ipynb
@@ -1210,6 +1210,151 @@
   },
   {
    "cell_type": "markdown",
+   "id": "dsb-intro",
+   "metadata": {},
+   "source": [
+    "### Quand Dawid-Skene surpasse-t-il VRAIMENT le vote majoritaire ?\n",
+    "\n",
+    "Sur le jeu de données ci-dessus (§5), le vote majoritaire et Dawid-Skene atteignent **tous les deux 100 %** de précision : les quatre workers sont fiables, le problème est trop facile pour que le modèle de Dawid-Skene montre sa valeur. La table de comparaison ci-dessous affirme « Dawid-Skene souvent meilleur », mais rien dans les sorties commitées ne le **démontre** — les deux méthodes y sont ex aequo.\n",
+    "\n",
+    "Pour rendre la capacité distinctive de Dawid-Skene **visible dans les nombres**, il faut un problème où le vote majoritaire a quelque chose à **perdre** : un jeu de données contaminé par des *workers biaisés*. C'est précisément la situation omniprésente dans le vrai crowdsourcing (annotateurs inattentifs, bots, spammeurs). Construisons ce cas : 3 workers fiables + 2 « spammers » qui votent toujours 1."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "dsb-code",
+   "metadata": {},
+   "execution_count": 12,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "=== Cas discriminant : 3 workers fiables + 2 spammers (toujours 1) ===\n",
+      "            W1 W2 W3 W4 W5 | Vrai\n",
+      "  Item 0 :  1  1  1  1  1  |  1\n",
+      "  Item 1 :  0  0  0  1  1  |  0\n",
+      "  Item 2 :  1  1  1  1  1  |  1\n",
+      "  Item 3 :  0  1  0  1  1  |  0\n",
+      "  Item 4 :  1  1  1  1  1  |  1\n",
+      "  Item 5 :  0  0  0  1  1  |  0\n",
+      "  Item 6 :  1  1  1  1  1  |  1\n",
+      "  Item 7 :  0  0  1  1  1  |  0\n",
+      "\n",
+      "--- Vote majoritaire (baseline) ---\n",
+      "Predictions : [1, 0, 1, 1, 1, 0, 1, 1]\n",
+      "Precision   : 75.0% (6 / 8)\n",
+      "Items en erreur : [3, 7]\n",
+      "\n",
+      "--- Dawid-Skene (EM) ---\n",
+      "Convergence a l'iteration 7\n",
+      "Predictions : [1, 0, 1, 0, 1, 0, 1, 0]\n",
+      "Precision   : 100.0% (8 / 8)\n",
+      "\n",
+      ">>> Dawid-Skene recupere 2 item(s) que le vote majoritaire ratait (100.0% vs 75.0%).\n",
+      "\n",
+      "--- Matrices de confusion estimees (le biais des spammers est reconnu) ---\n",
+      "\n",
+      "W1 :\n",
+      "           Pred 0   Pred 1\n",
+      "  Vrai 0 :  1.00     0.00\n",
+      "  Vrai 1 :  0.00     1.00\n",
+      "\n",
+      "W2 :\n",
+      "           Pred 0   Pred 1\n",
+      "  Vrai 0 :  0.75     0.25\n",
+      "  Vrai 1 :  0.00     1.00\n",
+      "\n",
+      "W3 :\n",
+      "           Pred 0   Pred 1\n",
+      "  Vrai 0 :  0.75     0.25\n",
+      "  Vrai 1 :  0.00     1.00\n",
+      "\n",
+      "W4 (SPAMMER) :\n",
+      "           Pred 0   Pred 1\n",
+      "  Vrai 0 :  0.00     1.00\n",
+      "  Vrai 1 :  0.00     1.00\n",
+      "\n",
+      "W5 (SPAMMER) :\n",
+      "           Pred 0   Pred 1\n",
+      "  Vrai 0 :  0.00     1.00\n",
+      "  Vrai 1 :  0.00     1.00\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Cas discriminant : workers biaisés (le vote majoritaire echoue) ---\n",
+    "# Sur le jeu de donnees precedent (section 5), Dawid-Skene ET le vote majoritaire\n",
+    "# atteignent 100 % : les workers sont fiables, le probleme est trop facile pour\n",
+    "# que le modele de Dawid-Skene montre sa valeur. Construisons un cas ou des\n",
+    "# workers biaisés (des \"spammers\" qui votent toujours 1) font echouer le vote\n",
+    "# majoritaire, et regardons si Dawid-Skene recupere les vrais labels.\n",
+    "\n",
+    "# 3 workers fiables (avec quelques erreurs honnetes) + 2 spammers (toujours 1)\n",
+    "vrais_labels_biais = np.array([1, 0, 1, 0, 1, 0, 1, 0])\n",
+    "n_items_biais = len(vrais_labels_biais)\n",
+    "W1 = vrais_labels_biais.copy()              # worker fiable parfait\n",
+    "W2 = vrais_labels_biais.copy(); W2[3] = 1   # erreur honnete (vrai=0 -> 1)\n",
+    "W3 = vrais_labels_biais.copy(); W3[7] = 1   # erreur honnete (vrai=0 -> 1)\n",
+    "W4 = np.ones(n_items_biais, dtype=int)      # spammer : vote toujours 1\n",
+    "W5 = np.ones(n_items_biais, dtype=int)      # spammer : vote toujours 1\n",
+    "labels_biais = np.stack([W1, W2, W3, W4, W5], axis=1)\n",
+    "\n",
+    "print(\"=== Cas discriminant : 3 workers fiables + 2 spammers (toujours 1) ===\")\n",
+    "print(\"            W1 W2 W3 W4 W5 | Vrai\")\n",
+    "for i in range(n_items_biais):\n",
+    "    print(\"  Item {} :  {}  |  {}\".format(\n",
+    "        i, \"  \".join(str(int(labels_biais[i, w])) for w in range(5)),\n",
+    "        vrais_labels_biais[i]))\n",
+    "\n",
+    "# Vote majoritaire (baseline)\n",
+    "preds_mv_biais = np.array([1 if np.sum(labels_biais[i] == 1) > np.sum(labels_biais[i] == 0) else 0\n",
+    "                           for i in range(n_items_biais)])\n",
+    "acc_mv_biais = np.mean(preds_mv_biais == vrais_labels_biais)\n",
+    "print(\"\\n--- Vote majoritaire (baseline) ---\")\n",
+    "print(\"Predictions : {}\".format(preds_mv_biais.tolist()))\n",
+    "print(\"Precision   : {:.1%} ({} / {})\".format(acc_mv_biais,\n",
+    "      int(np.sum(preds_mv_biais == vrais_labels_biais)), n_items_biais))\n",
+    "print(\"Items en erreur : {}\".format(np.where(preds_mv_biais != vrais_labels_biais)[0].tolist()))\n",
+    "\n",
+    "# Dawid-Skene : modelise le biais de chaque worker via sa matrice de confusion\n",
+    "print(\"\\n--- Dawid-Skene (EM) ---\")\n",
+    "class_probs_biais, confusion_biais = dawid_skene_em(labels_biais, n_classes=2)\n",
+    "preds_ds_biais = np.argmax(class_probs_biais, axis=1)\n",
+    "acc_ds_biais = np.mean(preds_ds_biais == vrais_labels_biais)\n",
+    "print(\"Predictions : {}\".format(preds_ds_biais.tolist()))\n",
+    "print(\"Precision   : {:.1%} ({} / {})\".format(acc_ds_biais,\n",
+    "      int(np.sum(preds_ds_biais == vrais_labels_biais)), n_items_biais))\n",
+    "\n",
+    "gain = int(np.sum(preds_ds_biais == vrais_labels_biais)) - int(np.sum(preds_mv_biais == vrais_labels_biais))\n",
+    "print(\"\\n>>> Dawid-Skene recupere {} item(s) que le vote majoritaire ratait \"\n",
+    "      \"({:.1%} vs {:.1%}).\".format(gain, acc_ds_biais, acc_mv_biais))\n",
+    "\n",
+    "print(\"\\n--- Matrices de confusion estimees (le biais des spammers est reconnu) ---\")\n",
+    "for w in range(labels_biais.shape[1]):\n",
+    "    nom = \"W{} (SPAMMER)\".format(w + 1) if w >= 3 else \"W{}\".format(w + 1)\n",
+    "    print(\"\\n{} :\".format(nom))\n",
+    "    print(\"           Pred 0   Pred 1\")\n",
+    "    print(\"  Vrai 0 :  {:.2f}     {:.2f}\".format(confusion_biais[w, 0, 0], confusion_biais[w, 0, 1]))\n",
+    "    print(\"  Vrai 1 :  {:.2f}     {:.2f}\".format(confusion_biais[w, 1, 0], confusion_biais[w, 1, 1]))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dsb-interp",
+   "metadata": {},
+   "source": [
+    "**Lecture — Dawid-Skene récupère ce que le vote majoritaire rate.** Le contraste est net : sur les 8 items, le vote majoritaire tombe à **75 %** (il se trompe sur les items 3 et 7, où les 2 spammers + une erreur honnête d'un worker fiable font basculer la majorité vers 1 alors que le vrai label est 0), tandis que Dawid-Skene **retrouve les 8 vrais labels (100 %)** — soit **+2 items récupérés**.\n",
+    "\n",
+    "Le mécanisme est lisible dans les **matrices de confusion estimées** : le modèle a reconnu que W4 et W5 votent *toujours* 1, indépendamment de la vérité ($P(\\text{pred}=1 \\mid \\text{vrai}=0) = 1{,}0$ **et** $P(\\text{pred}=1 \\mid \\text{vrai}=1) = 1{,}0$ — un vote qui ne transporte **aucune information** sur le vrai label). Dawid-Skene *déprécie* donc ces workers (leurs votes ne pèsent plus dans l'estimation) et s'appuie sur les workers fiables W1–W3 pour reconstruire la vérité. Le vote majoritaire, lui, traite tous les votes à parts égales — il est aveugle au biais.\n",
+    "\n",
+    "C'est la raison d'être du modèle de Dawid-Skene (Dawid & Skene, 1979) : ce n'est pas sur les données propres qu'il surpasse la baseline, mais **sur les données bruitées et biaisées** — exactement ce que l'on rencontre en production (étiquetage humain à grande échelle, annotation médicale multi-experts, modération de contenu).\n",
+    "\n",
+    "> **Lien pratique** : la capacité démontrée ici (identifier et déprécier les workers non informatifs) est aussi ce qui permet à l'**apprentissage actif** (§7) de cibler les items où annoter davantage apporterait le plus d'information — et au modèle **Community** (§6) de regrouper les workers par profil de fiabilité plutôt que de les traiter individuellement."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "fda5a509",
    "metadata": {
     "papermill": {
@@ -1256,7 +1401,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "pymc-demo-mcmc-code",
    "metadata": {
     "execution": {
@@ -1492,7 +1637,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "dd0ab71d",
    "metadata": {
     "execution": {
@@ -1790,7 +1935,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "d2ef04f9",
    "metadata": {
     "execution": {
@@ -1924,7 +2069,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "802c1784",
    "metadata": {
     "execution": {
@@ -2129,7 +2274,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "a3e3935e",
    "metadata": {
     "execution": {


### PR DESCRIPTION
feat(pymc-13,#3801): Prong-B discriminating Dawid-Skene demo (biased workers)

The committed crowdsourcing dataset (C6) is degenerate: both majority vote
(C9) and Dawid-Skene EM (C25) reach 100% accuracy on it. So Dawid-Skene's
DISTINCTIVE capability -- recovering true labels BETTER than majority vote by
modeling per-worker confusion/bias -- is INVISIBLE: the M26 comparison table
asserts "Dawid-Skene | Souvent meilleur" but nothing in the committed outputs
DEMONSTRATES it (the two methods are ex aequo there).

This is the sota-not-workaround Prong-B section-B anti-pattern (a model
demonstrated on a case where the SOTA is equivalent to a baseline).

Adds 3 cells (markdown intro / code ec=12 / markdown interpretation) inserted
AFTER the Dawid-Skene EM cell (C25, ec=11) and BEFORE the comparison table (M26).
A new discriminating dataset -- 3 reliable workers + 2 "spammers" who always
vote 1 -- makes majority vote FAIL while Dawid-Skene RECOVERS the true labels:

  Vote majoritaire : 75.0% (6/8) -- items 3, 7 wrong (spammers + 1 honest
                                         error outvote the correct label)
  Dawid-Skene (EM) : 100.0% (8/8) -- +2 items recovered

The recovered confusion matrices make the mechanism legible: the model
recognizes the spammers (P(pred=1|vrai=0)=1.0 AND P(pred=1|vrai=1)=1.0 -- a
vote carrying NO information) and down-weights them, relying on the reliable
workers. Majority vote, treating all votes equally, is blind to the bias.

Reuses the notebook's real dawid_skene_em() def (C25). Deterministic (pure
numpy, no MCMC/randomness) => reproducible cross-machine.

Validation:
- C.2 PROVEN in force: the full notebook executed end-to-end via nbconvert
  (exit 0, 0 errors). The spliced cell's stdout output is BYTE-IDENTICAL to
  the fresh full-exec output (source identical, ec=12 both).
- ec renumbered 12->13 .. 16->17 on the 5 code cells after C25 to keep the
  code-cell execution_count sequential 1..17.
- Byte-stable splice: +150/-5 (3 new cells + 5 ec bumps), every other byte
  intact (verified vs origin/main).
- H.3 + nbformat: PASS (17 code cells). C.1: 0 voluntary errors. Leak scanner:
  0 findings. LaTeX intact (\text{}, \mid preserved via raw strings).

See #3801 (Prong-B SOTA problem-richness registry).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
