### PR TITLE
feat(catalog,#8051): wire editorial-review registry to generator promotion

### DIFF
--- a/scripts/notebook_tools/generate_catalog.py
+++ b/scripts/notebook_tools/generate_catalog.py
@@ -942,6 +942,133 @@ def _merge_curated_fields(
     return entries
 
 
+# --- Editorial-review registry promotion (issue #8051, c.763/c.764) -----------
+#
+# classify_editorial() never emits FINAL by design: a structural heuristic cannot
+# assert editorial maturity. A merged third-party review recorded in the curated
+# whitelist `docs/notebook-metadata/editorial-review-registry.md` is the human
+# signal that promotes FINAL. The validator `scripts/audit/check_editorial_review.py`
+# checks the registry's coherence; THIS function is the downstream "catalogue
+# patch" the classify_editorial() docstring refers to — it consumes the registry
+# and applies the promotion so whitelisted notebooks reach editorial=FINAL in the
+# generated catalogue (and propagate to the retro-compat `maturity` aggregate).
+
+EDITORIAL_REGISTRY_PATH = REPO_ROOT / "docs" / "notebook-metadata" / "editorial-review-registry.md"
+
+# review_scope values that warrant an editorial promotion to FINAL. Per registry
+# §3.2, typo/pedagogie alone do not guarantee technical truthfulness.
+PROMOTING_REVIEW_SCOPES = ("factual", "substance", "full")
+
+
+def _load_editorial_registry(registry_path=None):
+    """Parse the editorial-review whitelist YAML embedded in the registry markdown.
+
+    Returns a dict keyed by notebook_path -> {reviewer, review_date, evidence_pr,
+    review_scope, notes}. Returns {} if the file is missing or unparseable: the
+    registry is optional, and its absence leaves every entry at the structural
+    editorial classification emitted by classify_editorial().
+
+    The registry markdown embeds one or more fenced YAML blocks (schema example
+    in §2 + the curated pilot entries in §4). Only entries whose notebook_path
+    looks like a real relative path (ends with ``.ipynb`` and contains no ``<``)
+    are kept, so the §2 placeholder schema block is filtered out.
+    """
+    path = registry_path or EDITORIAL_REGISTRY_PATH
+    if not Path(path).exists():
+        return {}
+    import re
+    import yaml  # PyYAML — part of repo tooling (cf check_twin_parity.py, #8057)
+    text = Path(path).read_text(encoding="utf-8")
+    fence = "`" * 3
+    blocks = re.findall(fence + r"yaml\n(.*?)" + fence, text, re.DOTALL)
+    registry = {}
+    for block in blocks:
+        # Drop full-line comments (the pilot block carries a curation header).
+        lines = [ln for ln in block.split("\n") if not ln.lstrip().startswith("#")]
+        cleaned = "\n".join(lines).strip()
+        if not cleaned:
+            continue
+        try:
+            parsed = yaml.safe_load(cleaned)
+        except yaml.YAMLError:
+            continue
+        if not isinstance(parsed, list):
+            continue
+        for entry in parsed:
+            if not isinstance(entry, dict):
+                continue
+            nb_path = entry.get("notebook_path")
+            if (not isinstance(nb_path, str)
+                    or not nb_path.endswith(".ipynb")
+                    or "<" in nb_path):
+                continue
+            review_date = entry.get("review_date")
+            # PyYAML parses bare ISO dates (2026-07-22) as datetime.date, which
+            # json.dumps cannot serialize — coerce to its ISO string form.
+            if hasattr(review_date, "isoformat"):
+                review_date = review_date.isoformat()
+            registry[nb_path] = {
+                "reviewer": entry.get("reviewer"),
+                "review_date": review_date,
+                "evidence_pr": entry.get("evidence_pr"),
+                "review_scope": entry.get("review_scope"),
+                "notes": entry.get("notes"),
+            }
+    return registry
+
+
+def _apply_editorial_review_promotion(entries, registry=None):
+    """Promote whitelisted notebooks' editorial axis BETA -> FINAL (issue #8051).
+
+    Eligibility mirrors `editorial-review-registry.md` §3.1/§3.2:
+      - notebook_path is present in the registry;
+      - reviewer != owner_logique (no self-review promotion, §3.1 #4);
+      - review_scope in (factual, substance, full) (§3.2);
+      - the entry is not a TEMPLATE (templates keep their own axis).
+
+    On promotion: set ``editorial = FINAL``, populate ``editorial_reviewed_by``
+    (+ review_date / evidence_pr for traceability), and recompute the retro-compat
+    ``maturity`` aggregate so FINAL propagates (BETA -> PRODUCTION when repro and
+    review axes are sufficient).
+    """
+    if registry is None:
+        registry = _load_editorial_registry()
+    if not registry:
+        return entries
+
+    promoted = 0
+    for entry in entries:
+        if entry.get("maturity") == "TEMPLATE":
+            continue
+        review = registry.get(entry.get("path", ""))
+        if not review:
+            continue
+        reviewer = review.get("reviewer")
+        scope = review.get("review_scope")
+        if not reviewer or reviewer == entry.get("owner_logique"):
+            continue  # §3.1 #4 auto-review guard
+        if scope not in PROMOTING_REVIEW_SCOPES:
+            continue  # §3.2 scope guard
+        entry["editorial"] = "FINAL"
+        entry["editorial_reviewed_by"] = reviewer
+        if review.get("review_date"):
+            entry["editorial_review_date"] = review["review_date"]
+        if review.get("evidence_pr"):
+            entry["editorial_review_evidence_pr"] = review["evidence_pr"]
+        # Recompute retro-compat maturity so FINAL propagates downstream.
+        entry["maturity"] = aggregate_maturity(
+            entry["editorial"],
+            entry.get("reproducibility", "UNTESTED"),
+            entry.get("scientific_review", "UNREVIEWED"),
+            is_template=False,
+        )
+        promoted += 1
+
+    if promoted:
+        print(f"Applied editorial-review promotion (BETA->FINAL) for {promoted} entries")
+    return entries
+
+
 def _git_tracked_files() -> set[str] | None:
     """Return set of git-tracked relative paths, or None if not in a git repo."""
     try:
@@ -1143,6 +1270,11 @@ def main():
     # touched on the current branch (prevents stale-branch blanching)
     main_catalog = _load_main_catalog()
     entries = _merge_curated_fields(entries, main_catalog)
+
+    # Apply the editorial-review whitelist promotion (issue #8051): whitelisted
+    # notebooks reviewed by a third party get editorial BETA -> FINAL — the
+    # downstream "catalogue patch" classify_editorial() deliberately never emits.
+    entries = _apply_editorial_review_promotion(entries)
 
     # Deterministic ordering by path. Filesystem iteration order (iterdir/rglob)
     # differs between the Linux CI runner that owns main's catalog and the Windows

--- a/scripts/notebook_tools/tests/test_generate_catalog.py
+++ b/scripts/notebook_tools/tests/test_generate_catalog.py
@@ -18,9 +18,13 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from generate_catalog import (
     CURATED_GIT_FIELDS,
     NOTEBOOKS_DIR,
+    PROMOTING_REVIEW_SCOPES,
+    _apply_editorial_review_promotion,
     _effective_code_cells,
     _is_exercise_stub,
+    _load_editorial_registry,
     _merge_curated_fields,
+    aggregate_maturity,
     analyze_notebook,
     check_errors,
     classify_maturity,
@@ -1365,6 +1369,178 @@ class TestMergeCuratedFields:
             f"got {len(CURATED_GIT_FIELDS)} (extra fields: "
             f"{set(CURATED_GIT_FIELDS) - set(expected_fields)})"
         )
+
+
+class TestEditorialReviewPromotion:
+    """Tests for the editorial-review whitelist promotion (issue #8051).
+
+    classify_editorial() never emits FINAL by design; the registry is the human
+    signal that promotes BETA -> FINAL. _apply_editorial_review_promotion applies
+    that signal and recomputes the retro-compat `maturity` aggregate.
+    """
+
+    def _entry(self, path, owner="po-2023", editorial="BETA",
+               reproducibility="EXECUTED", scientific_review="UNREVIEWED",
+               maturity="BETA", **kw):
+        return {
+            "path": path,
+            "title": kw.get("title", "Test"),
+            "serie": kw.get("serie", "Test"),
+            "kernel": kw.get("kernel", "Python 3"),
+            "status": kw.get("status", "READY"),
+            "owner_logique": owner,
+            "editorial": editorial,
+            "reproducibility": reproducibility,
+            "scientific_review": scientific_review,
+            "maturity": maturity,
+        }
+
+    def test_promotes_whitelisted_beta_to_final(self):
+        """A third-party factual review promotes editorial BETA -> FINAL."""
+        entries = [self._entry("Sudoku/Sudoku-18-Comparison-Python.ipynb")]
+        registry = {
+            "Sudoku/Sudoku-18-Comparison-Python.ipynb": {
+                "reviewer": "jsboigeEpita",  # != owner po-2023
+                "review_date": "2026-07-22",
+                "evidence_pr": "#7904",
+                "review_scope": "factual",
+                "notes": "honesty fix",
+            },
+        }
+        result = _apply_editorial_review_promotion(entries, registry=registry)
+        assert result[0]["editorial"] == "FINAL"
+        assert result[0]["editorial_reviewed_by"] == "jsboigeEpita"
+        assert result[0]["editorial_review_evidence_pr"] == "#7904"
+        assert result[0]["editorial_review_date"] == "2026-07-22"
+        # maturity recomputed from FINAL (BETA -> PRODUCTION needs peer review,
+        # so with scientific_review=UNREVIEWED it stays BETA — aggregate logic)
+        assert result[0]["maturity"] == aggregate_maturity(
+            "FINAL", "EXECUTED", "UNREVIEWED")
+
+    def test_maturity_propagates_to_production_when_peer_reviewed(self):
+        """FINAL + EXECUTED + PEER_REVIEWED -> maturity PRODUCTION."""
+        entries = [self._entry(
+            "S/nb.ipynb", scientific_review="PEER_REVIEWED")]
+        registry = {"S/nb.ipynb": {
+            "reviewer": "reviewer-x", "review_scope": "full"}}
+        result = _apply_editorial_review_promotion(entries, registry=registry)
+        assert result[0]["editorial"] == "FINAL"
+        assert result[0]["maturity"] == "PRODUCTION"
+
+    def test_skips_self_review(self):
+        """reviewer == owner_logique must NOT promote (auto-review, §3.1 #4)."""
+        entries = [self._entry("S/nb.ipynb", owner="po-2023")]
+        registry = {"S/nb.ipynb": {
+            "reviewer": "po-2023", "review_scope": "factual"}}
+        result = _apply_editorial_review_promotion(entries, registry=registry)
+        assert result[0]["editorial"] == "BETA"  # unchanged
+        assert "editorial_reviewed_by" not in result[0]
+
+    def test_skips_non_promoting_scope(self):
+        """typo/pedagogie scopes do not warrant FINAL (§3.2)."""
+        for scope in ("typo", "pedagogie"):
+            entries = [self._entry("S/nb.ipynb")]
+            registry = {"S/nb.ipynb": {
+                "reviewer": "other", "review_scope": scope}}
+            result = _apply_editorial_review_promotion(entries, registry=registry)
+            assert result[0]["editorial"] == "BETA", f"scope {scope} promoted"
+
+    def test_all_promoting_scopes_promote(self):
+        """factual/substance/full all promote (PARAMETRIZED contract)."""
+        for scope in PROMOTING_REVIEW_SCOPES:
+            entries = [self._entry("S/nb.ipynb")]
+            registry = {"S/nb.ipynb": {
+                "reviewer": "other", "review_scope": scope}}
+            result = _apply_editorial_review_promotion(entries, registry=registry)
+            assert result[0]["editorial"] == "FINAL", f"scope {scope} did not promote"
+
+    def test_skips_non_whitelisted(self):
+        """Entries not in the registry are left untouched."""
+        entries = [self._entry("S/other.ipynb")]
+        registry = {"S/different.ipynb": {
+            "reviewer": "other", "review_scope": "factual"}}
+        result = _apply_editorial_review_promotion(entries, registry=registry)
+        assert result[0]["editorial"] == "BETA"
+        assert "editorial_reviewed_by" not in result[0]
+
+    def test_skips_template(self):
+        """TEMPLATE entries keep their axis (no FINAL promotion)."""
+        entries = [self._entry("S/tpl.ipynb", maturity="TEMPLATE", status="TEMPLATE")]
+        registry = {"S/tpl.ipynb": {
+            "reviewer": "other", "review_scope": "factual"}}
+        result = _apply_editorial_review_promotion(entries, registry=registry)
+        assert result[0]["maturity"] == "TEMPLATE"
+        assert "editorial_reviewed_by" not in result[0]
+
+    def test_empty_registry_noop(self):
+        """Empty registry = no entry touched, no crash."""
+        entries = [self._entry("S/nb.ipynb")]
+        result = _apply_editorial_review_promotion(entries, registry={})
+        assert result[0]["editorial"] == "BETA"
+
+    def test_load_registry_filters_schema_placeholder(self):
+        """_load_editorial_registry parses YAML blocks but drops §2 placeholders."""
+        fence = "`" * 3
+        content = (
+            "# Registre\n\n## §2 schema example\n"
+            + fence + "yaml\n"
+            "- notebook_path: <chemin relatif depuis MyIA.AI.Notebooks/>\n"
+            "  reviewer: <login>\n"
+            "  review_scope: factual\n"
+            + fence + "\n\n## §4 pilot\n"
+            + fence + "yaml\n"
+            "# curation header comment\n"
+            "- notebook_path: Sudoku/Sudoku-18-Comparison-Python.ipynb\n"
+            "  reviewer: jsboigeEpita\n"
+            "  review_date: 2026-07-22\n"
+            "  evidence_pr: \"#7904\"\n"
+            "  review_scope: factual\n"
+            "  notes: \"honesty fix\"\n"
+            + fence + "\n"
+        )
+        with tempfile.NamedTemporaryFile(
+                mode="w", suffix=".md", delete=False, encoding="utf-8") as f:
+            f.write(content)
+            tmp = Path(f.name)
+        try:
+            reg = _load_editorial_registry(tmp)
+            assert len(reg) == 1, f"expected 1 real entry, got {reg}"
+            assert "Sudoku/Sudoku-18-Comparison-Python.ipynb" in reg
+            assert reg["Sudoku/Sudoku-18-Comparison-Python.ipynb"]["reviewer"] == "jsboigeEpita"
+        finally:
+            tmp.unlink()
+
+    def test_load_registry_missing_file_returns_empty(self):
+        """Missing registry file = empty dict (registry is optional)."""
+        reg = _load_editorial_registry(Path("/nonexistent/registry.md"))
+        assert reg == {}
+
+    def test_load_registry_coerces_bare_iso_date_to_str(self):
+        """Bare YAML dates (2026-07-22) parse to datetime.date; must coerce
+        to str so the promoted field is JSON-serializable in the catalog."""
+        import datetime
+        fence = "`" * 3
+        content = (
+            fence + "yaml\n"
+            "- notebook_path: S/nb.ipynb\n"
+            "  reviewer: other\n"
+            "  review_date: 2026-07-22\n"  # bare date -> datetime.date via PyYAML
+            "  review_scope: factual\n"
+            + fence + "\n"
+        )
+        with tempfile.NamedTemporaryFile(
+                mode="w", suffix=".md", delete=False, encoding="utf-8") as f:
+            f.write(content)
+            tmp = Path(f.name)
+        try:
+            reg = _load_editorial_registry(tmp)
+            rd = reg["S/nb.ipynb"]["review_date"]
+            assert not isinstance(rd, datetime.date), "date not coerced"
+            assert rd == "2026-07-22"
+            # and it must be JSON-serializable (the catalog output requirement)
+            json.dumps({"d": rd})
+        finally:
+            tmp.unlink()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Closes the missing link in the #8051 maturity 3-axes pipeline. `classify_editorial()` never emits `FINAL` by design (a structural heuristic cannot assert editorial maturity — cf `docs/PARCOURS.md`). The editorial-review registry (#8098, c.764) is the curated whitelist of third-party reviews, and `check_editorial_review.py` validates its coherence — **but `generate_catalog.py` never consumed the registry**, so whitelisted notebooks stayed `editorial: BETA` in the generated catalog despite the validator passing. The registry's acceptance criterion "BETA → FINAL for whitelisted notebooks" was unmet end-to-end.

This PR adds the downstream "catalogue patch" the `classify_editorial()` docstring refers to.

## Changes (additive, +308/-0, 2 files)

- **`_load_editorial_registry()`** — parses the YAML whitelist embedded in the registry markdown. Filters the §2 schema-example placeholders (`notebook_path` with `<` or non-`.ipynb`). Coerces bare ISO dates (`2026-07-22` → `datetime.date` via PyYAML) to `str` so promoted fields are JSON-serializable.
- **`_apply_editorial_review_promotion(entries)`** — promotes eligible entries `editorial: BETA → FINAL`, populates `editorial_reviewed_by` (+ `editorial_review_date` / `editorial_review_evidence_pr`), and recomputes the retro-compat `maturity` aggregate. Wired into `main()` after `_merge_curated_fields`, before sort/write.

**Eligibility** mirrors `editorial-review-registry.md` §3.1/§3.2:
- `reviewer != owner_logique` (no self-review promotion, §3.1 #4)
- `review_scope ∈ {factual, substance, full}` (§3.2 — typo/pedagogie alone don't guarantee truthfulness)
- entry is not a `TEMPLATE`

## E2E proof (origin/main catalog + real registry)

```
Applied editorial-review promotion (BETA->FINAL) for 3 entries
editorial Sudoku:  BETA:36  ->  {BETA:33, FINAL:3}
```

| notebook | editorial | reviewed_by | evidence | control |
|----------|-----------|-------------|----------|---------|
| Sudoku-18 Comparison-Python | FINAL | jsboigeEpita | #7904 | promoted |
| Sudoku-11 Choco-Csharp | FINAL | jsboigeEpita | #7794 | promoted |
| Sudoku-12 Z3-Csharp | FINAL | jsboigeEpita | #7801 | promoted |
| Sudoku-14 BDD-Csharp | BETA | — | — | correctly stays BETA (reviewer == owner_logique, §3.1 #4) |

Validator coherence (`check_editorial_review.py`): **0 errors, 0 warnings**. Catalog is byte-identical on this branch (NOT regenerated — CI/cron applies the legitimate 3-entry change post-merge, per catalog-pr-hygiene HARD rule 1).

## Design note (honest, not a bug)

`maturity` stays `BETA`, not `PRODUCTION`, even after the editorial promotion. `aggregate_maturity()` requires `scientific_review ∈ {PEER_REVIEWED, FORMALLY_VERIFIED}` for `PRODUCTION`; the Sudoku notebooks are `UNREVIEWED`. **This is the 3-axes separation working as designed** — an editorial review (factual correctness by a third party) is not a scientific peer review, so `FINAL` editorial alone does not over-claim `PRODUCTION` maturity. (The registry acceptance §5 criterion #4 "BETA → PRODUCTION" assumes editorial review implies peer review; the 3-axes model deliberately separates them. Flagging for ai-01: reaching PRODUCTION for these notebooks needs a separate scientific-review signal.)

## Tests

164 pass (+12 new): promotion eligibility, auto-review guard (§3.1 #4), scope guard (§3.2), template skip, non-whitelisted skip, empty-registry noop, registry YAML parsing, **date-coercion regression** (the bare-ISO-date serialization bug the e2e regen caught).

```
============================= 164 passed in 0.46s =============================
```

See #8051 (epic #4208 stays open — this contributes the generator-side wiring; the catalog promotion applies via CI/cron).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
