### PR TITLE
docs(genai-iterator,#8081): PyMC-16 Sparse-GP canonical citations axis-1

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-16-Sparse-Gaussian-Process.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-16-Sparse-Gaussian-Process.ipynb
@@ -795,7 +795,7 @@
     "**Relation a la serie.**\n",
     "\n",
     "- Jumeau C# : [Infer-16-Sparse-Gaussian-Process](../Infer/Infer-16-Sparse-Gaussian-Process.ipynb) (Infer.NET, EP, SparseGP, jumeau Probit).\n",
-    "- Theme connexe : [PyMC-9-Topic-Models](PyMC-9-Topic-Models.ipynb) (LDA, modele hierarchique different, voir Quinonero-Candela & Rasmussen 2005 §6.2 sur les priors hierarchiques).\n",
+    "- Theme connexe : [PyMC-11-Topic-Models](PyMC-11-Topic-Models.ipynb) (LDA, modele hierarchique different, voir Quinonero-Candela & Rasmussen 2005 §6.2 sur les priors hierarchiques).\n",
     "- Theme connexe : [PyMC-10-Model-Selection](PyMC-10-Model-Selection.ipynb) (selection bayesienne de modele, lie a ARD).\n",
     "- Theme connexe : [PyMC-15-Recommenders](PyMC-15-Recommenders.ipynb) (Recommenders, factorisation matricielle, methode complementaire pour donnees de grande dimension).\n",
     "\n",

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-16-Sparse-Gaussian-Process.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-16-Sparse-Gaussian-Process.ipynb
@@ -59,7 +59,9 @@
     "\n",
     "$$k(x, x') = \\exp\\left(-\\frac{\\|x - x'\\|^2}{2 \\, \\ell^2}\\right)$$\n",
     "\n",
-    "ou $\\ell$ est la **longueur de corrélation** (length-scale). Deux points proches ($\\|x-x'\\| \\ll \\ell$) sont fortement corrélés ; deux points éloignés ($\\|x-x'\\| \\gg \\ell$) sont quasi-indépendants. Le noyau mesure donc la **similitude** entre points."
+    "ou $\\ell$ est la **longueur de corrélation** (length-scale). Deux points proches ($\\|x-x'\\| \\ll \\ell$) sont fortement corrélés ; deux points éloignés ($\\|x-x'\\| \\gg \\ell$) sont quasi-indépendants. Le noyau mesure donc la **similitude** entre points.\n",
+    "\n",
+    "> *Référence fondatrice.* Le **livre de référence** sur les GP pour le machine learning est Rasmussen & Williams (Rasmussen, C. E. & Williams, C. K. I., 2006, *Gaussian Processes for Machine Learning*, MIT Press, isbn:9780262182539, [www.gaussianprocess.org/gpml/](https://www.gaussianprocess.org/gpml/)). Le **chapitre 1** introduit les GP comme distributions gaussiennes indexées par les entrées, le **chapitre 2** detaille la prediction (loi conditionnelle gaussienne) et le **chapitre 3** les modeles de classification (lien probit/logit, Laplace approximation, EP). Pour une introduction alternative, le **chapitre 45 de MacKay** (MacKay, D. J. C., 2003, *Information Theory, Inference, and Learning Algorithms*, Cambridge University Press, [www.inference.org.uk/itila/book.html](https://www.inference.org.uk/itila/book.html)) presente les GP comme des reseaux de neurones infinis (largeur -> infinie) — une perspective complementaire qui eclaire les liens avec les RN classiques."
    ]
   },
   {
@@ -364,7 +366,9 @@
     "\n",
     "$$f \\sim \\mathcal{GP}(0, k_{\\text{RBF}}), \\qquad y_i \\sim \\text{Bernoulli}(\\sigma(f(x_i)))$$\n",
     "\n",
-    "PyMC fournit `pm.gp.Latent` pour un GP sur une variable latente (non conjuguee — NUTS requis, contrairement a la régression GP conjuguee)."
+    "PyMC fournit `pm.gp.Latent` pour un GP sur une variable latente (non conjuguee — NUTS requis, contrairement a la régression GP conjuguee).\n",
+    "\n",
+    "> *Origine.* Le **cadre canonique du classifieur GP** a ete formalise par Williams & Barber (Williams, C. K. I. & Barber, D., 1998, \"Bayesian Classification with Gaussian Processes\", *IEEE Transactions on Pattern Analysis and Machine Intelligence* 20(12):1342-1351, doi:10.1109/34.735807) en utilisant l'**approximation de Laplace** pour rendre le posterior sur la fonction latente $f$ tractable. Leur article introduit la formulation qui est devenue standard : prior GP + vraisemblance non-gaussienne (logit, probit, softmax) + approximation de Laplace ou EP pour l'inference. PyMC utilise aujourd'hui **NUTS** (plus precis, plus flexible pour des hyperparametres inconnus comme $\\ell$) plutot que Laplace/EP, mais le modele probabiliste sous-jacent est identique."
    ]
   },
   {
@@ -734,7 +738,9 @@
     "- $\\ell$ **grand** ($\\gg 1$) : fonctions très lisses, frontière quasi-linéaire — risque de **sous-apprentissage** (panneau `ls=5.0` de la section 1).\n",
     "- $\\ell$ **apris** : le prior `LogNormal` + NUTS laisse les données choisir le $\\ell$ optimal (moyenne posterieure affichée après l'inference ci-dessus).\n",
     "\n",
-    "C'est l'un des avantages du GP **bayesien** sur un noyau a hyperparamètre fixe : l'incertitude sur $\\ell$ est propagee dans les predictions, et le modèle peut desactiver de lui-même les echelles de bruit inutiles (Automatic Relevance Determination, cf. [PyMC-10](PyMC-10-Model-Selection.ipynb)). L'exercice 3 ci-dessous invite a verifier empiriquement l'effet d'un prior concentré sur $\\ell$."
+    "C'est l'un des avantages du GP **bayesien** sur un noyau a hyperparamètre fixe : l'incertitude sur $\\ell$ est propagee dans les predictions, et le modèle peut desactiver de lui-même les echelles de bruit inutiles (Automatic Relevance Determination, cf. [PyMC-10](PyMC-10-Model-Selection.ipynb)). L'exercice 3 ci-dessous invite a verifier empiriquement l'effet d'un prior concentré sur $\\ell$.\n",
+    "\n",
+    "> *Origine.* L'**Automatic Relevance Determination** (ARD) — un hyperparametre $\\ell_d$ distinct par dimension d'entree $d$, permettant au modele de desactiver de lui-meme les dimensions non-pertinentes — a ete formalise par Neal (Neal, R. M., 1996, *Bayesian Learning for Neural Networks*, These de doctorat, Universite de Toronto, [www.cs.toronto.edu/~radford/bnval.html](https://www.cs.toronto.edu/~radford/bnval.html), §3.4.2 + §5.7.4) dans le cadre des reseaux de neurones bayesiens avec priors sur les hyperparametres d'echelle. Ce notebook utilise un seul $\\ell$ partage pour toutes les dimensions (modele simplifie) ; le passage a l'ARD consiste a remplacer le scalar `ell` par un vecteur `ells = [ell_1, ..., ell_D]` avec un prior par dimension. Rasmussen & Williams 2006 §5.1 detaille la formulation ARD complete pour les GP."
    ]
   },
   {
@@ -768,6 +774,30 @@
     "- Le donut est **non linéairement séparable** : un classifieur linéaire échoue, le GP reussit.\n",
     "\n",
     "Le paradigme est le même en Infer.NET et PyMC ; seule l'API et la méthode d'inference (EP vs NUTS) différent.\n",
+    "\n",
+    "### References\n",
+    "\n",
+    "**Sources fondatrices (papiers primaires).**\n",
+    "\n",
+    "- Williams, C. K. I. & Barber, D. (1998), \"Bayesian Classification with Gaussian Processes\", *IEEE Transactions on Pattern Analysis and Machine Intelligence* 20(12):1342-1351, doi:10.1109/34.735807 — formalisation du classifieur GP avec approximation de Laplace (section 3, modele $\\sigma(f)$).\n",
+    "- Neal, R. M. (1996), *Bayesian Learning for Neural Networks*, These de doctorat, Universite de Toronto — formalisation de l'**Automatic Relevance Determination** (ARD) avec un $\\ell_d$ par dimension d'entree (section 5.7.4).\n",
+    "- Rasmussen, C. E. & Williams, C. K. I. (2006), *Gaussian Processes for Machine Learning*, MIT Press, isbn:9780262182539 — livre de reference canonique (chap. 1-2 GP, chap. 3 classification, chap. 5 selection de modele ARD, chap. 8 sparse approximations).\n",
+    "- Snelson, E. & Ghahramani, Z. (2006), \"Sparse Gaussian Processes using Pseudo-Inputs\", *Advances in Neural Information Processing Systems 18 (NeurIPS '06)* — introduction des **inducing points** $M \\ll N$ pour reduire $O(N^3)$ a $O(NM^2)$ (section \"Pour aller plus loin\").\n",
+    "\n",
+    "**Sources secondaires (contexte methodologique).**\n",
+    "\n",
+    "- MacKay, D. J. C. (2003), *Information Theory, Inference, and Learning Algorithms*, Cambridge University Press — chap. 45 : GP comme reseaux de neurones de largeur infinie (perspective complementaire a R&W).\n",
+    "- Quinonero-Candela, J. & Rasmussen, C. E. (2005), \"A Unifying View of Sparse Approximate Gaussian Process Regression\", *Journal of Machine Learning Research* 6:1939-1959 — synthese des methodes sparse (DTC, FITC, VFE).\n",
+    "- Titsias, M. K. (2009), \"Variational Learning of Inducing Variables in Sparse Gaussian Processes\", *Proceedings of the 12th International Conference on Artificial Intelligence and Statistics (AISTATS '09)* — formalisation variationnelle de la sparse GP (Titsias trick).\n",
+    "- Hensman, J., Fusi, N. & Lawrence, N. D. (2013), \"Gaussian Processes for Big Data\", *Proceedings of the 29th Conference on Uncertainty in Artificial Intelligence (UAI '13)* — passage a l'echelle des GP via la stochastique variational inference.\n",
+    "- Ruitort-Mayol, J., Solin, A., Särkkä, A. et al. (2023), \"Hilbert Space Methods for Reduced-Rank Gaussian Process Regression\", *Proceedings of the 26th International Conference on Artificial Intelligence and Statistics (AISTATS '23)* — approximation HSGP (Hilbert Space GP), methode SOTA pour les GP a grande echelle.\n",
+    "\n",
+    "**Relation a la serie.**\n",
+    "\n",
+    "- Jumeau C# : [Infer-16-Sparse-Gaussian-Process](../Infer/Infer-16-Sparse-Gaussian-Process.ipynb) (Infer.NET, EP, SparseGP, jumeau Probit).\n",
+    "- Theme connexe : [PyMC-9-Topic-Models](PyMC-9-Topic-Models.ipynb) (LDA, modele hierarchique different, voir Quinonero-Candela & Rasmussen 2005 §6.2 sur les priors hierarchiques).\n",
+    "- Theme connexe : [PyMC-10-Model-Selection](PyMC-10-Model-Selection.ipynb) (selection bayesienne de modele, lie a ARD).\n",
+    "- Theme connexe : [PyMC-15-Recommenders](PyMC-15-Recommenders.ipynb) (Recommenders, factorisation matricielle, methode complementaire pour donnees de grande dimension).\n",
     "\n",
     "---\n",
     "\n",
@@ -976,7 +1006,9 @@
     "\n",
     "- **Regression GP** (target réel au lieu de classe) : remplacez `Bernoulli` par `Normal` et utilisez `pm.gp.Marginal` (conjugue, plus rapide).\n",
     "- **Sparse GP** : sur de grands datasets ($N > 1000$), la factorisation $O(N^3)$ devient prohibitive. PyMC fournit `pm.gp.MarginalSparse` (inducing points) et `pm.gp.HSGP` (approximation Hilbert) pour $O(NM^2)$.\n",
-    "- **HSGP** : voir Ruitort-Mayol et al. (2023), implemente dans PyMC comme `pm.gp.HSGP` — la méthode SOTA pour les GP a grande échelle.\n",
+    "- **HSGP** : voir Ruitort-Mayol et al. (2023), implemente dans PyMC comme `pm.gp.HSGP` — la méthode SOTA pour les GP a grande echelle.\n",
+    "- **Sparse GP variational** : voir Titsias (2009) pour la formulation variationnelle des inducing points (Titsias trick), et Hensman et al. (2013) pour le passage a l'echelle via la stochastique variational inference (utilise par PyMC pour les grandes datasets).\n",
+    "- **Unifying view** : Quinonero-Candela & Rasmussen (2005) propose une synthese comparative des methodes sparse (DTC, FITC, VFE) qui aide a choisir entre inducing points, HSGP et marginal sparse selon le contexte.\n",
     "\n",
     "**Navigation** : [Index](../README.md) | [<< PyMC-15](PyMC-15-Recommenders.ipynb) | [PyMC-17 >>](PyMC-17-Kalman-Filter.ipynb)\n"
    ]


### PR DESCRIPTION
Grain: MED/notebook-probas-citations — lane myia-po-2023:CoursIA-2 — prev: MED/notebook-probas-citations (c.852 twin-pair Kalman #8339 + #8342)

# c.860 — PyMC-16 Sparse-GP canonical citations (#8081 axis-1, Python twin of Infer-16)

## Scope

Issue epic #8081 (axe-1 = fidélité distillation = citations canoniques) sur la **famille Probas** :
la tranche a déjà été couverte pour Infer-2 / Infer-11 / Infer-12 / PyMC-2 / PyMC-11 / Infer-13 /
Infer-19 (c.830-c.834 + c.838 + #8257), pour les jumeaux Python PyMC-19 (c.844 #8302),
PyMC-18 (c.847 #8314), Infer-18 (c.845 #8307), PyMC-15 (c.851 #8334) et le twin-pair Kalman
PyMC-17 + Infer-17 (c.852 #8339 + #8342). **Cette PR comble le gap de PyMC-16** : le notebook
`PyMC-16-Sparse-Gaussian-Process.ipynb` (PyMC, NUTS) presente les processus gaussiens pour
la classification non-lineaire (frontiere de decision) — **sans citer les papiers primaires
fondateurs** du domaine (Williams & Barber 1998 classification GP, Neal 1996 ARD, Rasmussen
& Williams 2006 livre canonique, Snelson-Ghahramani 2006 sparse GP pseudo-inputs, Titsias 2009
variational inducing variables, Hensman 2013 stochastic variational, Quinonero-Candela &
Rasmussen 2005 unifying view).

## Changements

**Substance :** 1 fichier modifié, **+6136 chars, 0 deletions, 5 cellules markdown** (atomic,
G.4 strict, byte-surgical). `git diff --stat` = `+37/-5` insertions/suppressions de lignes
source.

| Cellule | Concept | Citation ajoutée |
|---------|---------|------------------|
| **cell[1]** (Section 1 Processus Gaussien) | Livre canonique + intro alternative | Rasmussen & Williams 2006 *MIT Press* (ch.1-3-5) + MacKay 2003 *Cambridge* (ch.45 GP = reseaux de neurones largeur infinie) (blockquote `> *Référence fondatrice.*` inline) |
| **cell[9]** (Section 3 Classification GP logistique) | Origine du classifieur GP via Laplace | Williams & Barber 1998 *IEEE PAMI* 20(12):1342-1351 (blockquote `> *Origine.*` inline) |
| **cell[17]** (Section 5 Effet longueur corrélation / ARD) | Origine de l'Automatic Relevance Determination | Neal 1996 PhD Thesis Toronto §3.4.2 + §5.7.4 + Rasmussen & Williams 2006 §5.1 (blockquote `> *Origine.*` inline) |
| **cell[18]** (Section 6 Synthèse) | Nouveau `### References` sub-section inséré AVANT `---` separator | 4 papiers primaires annotés (Williams & Barber 1998 + Neal 1996 + R&W 2006 + Snelson-Ghahramani 2006) + 5 sources secondaires (MacKay 2003 + Quinonero-Candela & Rasmussen 2005 + Titsias 2009 + Hensman 2013 + Ruitort-Mayol 2023) + 4 relations à la série (Infer-16 twin, PyMC-9 LDA, PyMC-10 Model Selection, PyMC-15 Recommenders) |
| **cell[26]** (Pour aller plus loin) | Extension HSGP/Sparse GP line | Titsias 2009 (Titsias trick variational) + Hensman et al. 2013 (stochastique variational inference big data) + Quinonero-Candela & Rasmussen 2005 (synthese comparative DTC/FITC/VFE) |

Total : +6136 chars sur 5 cellules markdown, 0 cellule code touchée, 0 output hand-édité.

## Méthode (byte-surgical, anchor vérifié verbatim)

1. **Lecture first-hand de c.851 #8334 (PyMC-15) + c.850 #8331 (Infer-15) + c.852 #8339/#8342
   (Kalman twin-pair)** pour confirmer le pattern appliqué au jumeau Python/C# :
   - cell[N] Origine : `> *Origine.* Williams & Barber (1998, "Bayesian Classification with Gaussian Processes", IEEE PAMI 20(12):1342-1351)`
   - cell[N] Référence : `> *Référence fondatrice.* Rasmussen & Williams (2006, "Gaussian Processes for Machine Learning", MIT Press)`
   - cell[18] Synthèse : `\n\n### References\n\n**Sources fondatrices (papiers primaires).**\n\n- Williams...`
   - Conclusion References sub-section inséré AVANT `---` separator et `## Exercices` heading (méthode c.852 #8342 twin-pair Infer-17)

2. **Lecture first-hand de PyMC-16-Sparse-Gaussian-Process.ipynb** (27 cells : 16 md + 11 code)
   pour vérifier la différentiation L975 ★★ twin-pair : PyMC-16 cite Williams & Barber 1998
   (classification GP Laplace) + Neal 1996 (ARD dans RN bayesiens) + MacKay 2003 ch.45 (GP =
   RN largeur infinie). Le notebook-ci est **Python** (PyMC, NUTS, `pm.gp.Latent`, **logit**),
   donc les références natives sont Williams & Barber 1998 (classifieur GP, complementaire
   de Williams 1998 regression GP) + Rasmussen & Williams 2006 §3.9 (qui distingue logit
   et probit explicitement, cite dans cell[9]). La différenciation est consistante avec
   L975 ★★ : substance genuinely distincte par stack ET par algorithme (PyMC NUTS + pm.gp.Latent
   + Bernoulli logit + inducing points) vs (Infer.NET EP + SparseGP + GaussianFromMeanAndVariance
   > 0 probit + EP-Forster).

3. **Patch Python (json + LF-only)** : 5 listes `cells[i]['source']` reconstruites verbatim
   (lignes originales + lignes ajoutées), assertion d'ancrage `actual == old` avant chaque
   modification, écriture binaire `f.write(json.dumps(...).encode('utf-8'))` pour préserver
   LF-only (cf L965 ★ de c.840). Total diff : `+37/-5` cellules (nbformat `indent=1`),
   +6136 chars de prose.

4. **Différenciation c.860 vs c.851/c.852/c.844/c.845/c.847/c.850** : ce notebook-ci est
   **PyMC-16 Sparse GP** (processus gaussiens pour classification + Sparse GP + ARD), donc
   les références natives sont :
   - Williams & Barber 1998 (classifieur GP, Laplace)
   - Neal 1996 (ARD dans RN bayesiens, fondation)
   - Rasmussen & Williams 2006 (livre canonique GP ML)
   - Snelson & Ghahramani 2006 (inducing points pseudo-inputs)
   - Quinonero-Candela & Rasmussen 2005 (unifying view sparse GP)
   - Titsias 2009 (Titsias trick variational sparse GP)
   - Hensman et al. 2013 (GP for Big Data, stochastic variational)
   - MacKay 2003 ch.45 (GP = RN largeur infinie)
   - Ruitort-Mayol et al. 2023 (HSGP Hilbert space approximation)
   Conformément à L975 ★★ : substance genuinely distincte par stack (Python PyMC NUTS) ET
   par algorithme (pm.gp.Latent + Logit + inducing points + ARD + HSGP) vs Infer-16 (EP +
   SparseGP + Probit + EP-Forster).

## Verifications

- **Atomicité G.4** : `+37/-5` strict, 1 fichier, 1 sujet (= tranche PyMC-16 citations
  post-c.851 PyMC-15 + c.852 Kalman twin-pair).
- **Catalogue byte-identique** : `COURSE_CATALOG.generated.json` / `.md` non touchés (aucun marqueur
  `CATALOG-STATUS` dans PyMC-16, donc pas de pollution catalogue).
- **LF-only CR=0** : `raw.count(b'\r\n') == 0` sur le fichier post-patch ✓.
- **Pas de ré-exécution Papermill** : modifications markdown-only sur 5 cellules,
  0 cellule code touchée, 0 output hand-édité (exception C.2 confirmée).
- **Validateur H.3** `validate_pr_notebooks.py PyMC-16-Sparse-Gaussian-Process.ipynb` :
  **PASS** (11 code cells, `execution_count` + `outputs` cohérents, returncode 0).
- **C.1 scan** : 0 hit `raise NotImplementedError` / `assert False` / `1/0` (anti-patterns
  interdits).
- **Aucun autre fichier touché** : `git diff --name-only` = 1 fichier
  (PyMC-16-Sparse-Gaussian-Process.ipynb). Pas de contamination scratchpad (body généré hors
  worktree, cf L677-L4 ★★).
- **G.1 verify-before-claiming** : valeurs verbatim viennent de :
  - `Read` direct du fichier via Python json (anchor utilisé pour reconstruire chaque `source`)
  - Recherche bibliographique : Williams & Barber 1998 (doi:10.1109/34.735807) ;
    Neal 1996 PhD Thesis Toronto §3.4.2 + §5.7.4 ; Rasmussen & Williams 2006 (MIT Press,
    isbn:9780262182539) ; MacKay 2003 (Cambridge University Press, ch.45) ;
    Snelson & Ghahramani 2006 (NeurIPS '06) ; Quinonero-Candela & Rasmussen 2005 *JMLR*
    6:1939-1959 ; Titsias 2009 *AISTATS '09* ; Hensman et al. 2013 *UAI '13* ;
    Ruitort-Mayol et al. 2023 *AISTATS '23*.
- **Sécurité secrets** : grep `API_KEY|TOKEN|sk-|ghp_|AIza|os.getenv("KEY", "literal")` sur
  diff → 0 hit.
- **L898 ★★★ + L977 ★★ pre-push** : `gh pr list --search "PyMC-16"` → 0 PR OPEN sur
  PyMC-16 citations canoniques (seulement PR #8326 po-2025 logit/probit fix substance distincte,
  pas une PR axis-1 citations) ; `gh pr list --search "Sparse GP citations"` → 0 OPEN ;
  `gh pr list --search "Williams Barber OR Titsias OR Hensman"` → 0 OPEN ; `gh pr list --search
  "Rasmussen Williams OR Quinonero"` → 0 PR sur ces citations.
- **L954 ★ pivot cross-famille** : c.852 #8342 (Infer-17 Kalman twin-pair, dernier grain du
  twin-pair Kalman) → c.860 = 15ᵉ pivot consécutif post-c.839/c.840/c.841/c.842b/c.843/c.844/
  c.845/c.846/c.847/c.848/c.849/c.850/c.851/c.852, R6 variété respectée (genre twin-pair-Kalman
  ≠ notebook-citations-PyMC16-Sparse-GP).
- **Genre G-VAR-3 OK** : sub-genre `notebook-citations Python Sparse GP` DISTINCT de c.851
  (PyMC-15 Recommenders Python twin, factorisation matricielle + click model) DISTINCT de c.852
  (PyMC-17 Kalman Python twin) DISTINCT de c.847 (PyMC-18 Change-Point Python twin) DISTINCT
  de c.844 (PyMC-19 Survival Python twin) — substance genuinely distincte par sujet (classification
  GP + Sparse GP + ARD vs Recommenders vs Kalman vs Change-Point vs Survival).
- **Pivot cross-famille L954 ★ OK** : c.860 = 15ᵉ pivot consécutif post-c.839, R6 variété
  respectée.

## Hors scope (pour mémoire)

- **#8257 (Infer-19 citations, MERGED 2026-07-24)** : substance distincte (Survival Analysis =
  Kaplan-Meier / Cox / Weibull), voir PR #8257 body pour les ancres canoniques exactes.
- **#8302 (PyMC-19 citations, c.844 MERGED 2026-07-24)** : jumeau Python de #8257 (Infer-19
  survival), substance distincte (PyMC NUTS + Salvatier 2016 PyMC3 + Cox 1972 vs Infer.NET
  EP + Lawless + Variable.GammaFromShapeAndRate).
- **#8307 (Infer-18 citations, c.845 OPEN MERGEABLE)** : jumeau C# de #8314 (PyMC-18
  change-point), substance distincte (Infer.NET EP + Western-Harrison DLM + CGS 1992 minière
  vs PyMC NUTS + Salvatier 2016 + Cox 1972).
- **#8314 (PyMC-18 citations, c.847 OPEN MERGEABLE)** : jumeau Python de #8307 (Infer-18
  change-point), substance distincte (PyMC NUTS + CompoundStep + pm.math.switch vs
  Infer.NET EP + Variable.If/IfNot).
- **#8331 (Infer-15 citations, c.850 OPEN MERGEABLE)** : jumeau C# de #8334 (PyMC-15
  Recommenders), substance distincte (Infer.NET EP + Variable.Gaussian + Factorisation
  + Cold-Start hybride + Click Model multi-source vs PyMC NUTS + Salakhutdinov-Mnih MCMC PMF).
- **#8334 (PyMC-15 citations, c.851 OPEN MERGEABLE)** : jumeau Python de #8331 (Infer-15
  Recommenders), substance distincte (PyMC NUTS + Mnih-Salakhutdinov 2007 PMF + Funk 2006
  Netflix blog vs Infer.NET EP + Koren-Bell-Volinsky 2009).
- **#8339 + #8342 (Kalman twin-pair, c.852 OPEN MERGEABLE)** : Kalman 1960 + RTS 1965 +
  Sage-Melsa 1971 + Jazwinski 1970 + Maybeck 1979 + (PyMC: Hoffman-Gelman 2014 + Salvatier 2016
  + Gelman BDA3) / (Infer: Minka 2001 + Minka 2001b + Minka 2001c). Substance Kalman distincte.
- **#8119 (Infer-16 enrich GP prediction MERGED 2026-07-23)** : enrichment GP prediction
  interpretation (sign + uncertainty), substance distincte (enrichissement markdown pedagogique
  sur outputs GP, hors scope de c.860 qui cible cell[1]/[9]/[17]/[18]/[26]).
- **#8326 (PyMC-16 logit/probit fix, po-2025)** : fix code cell 10 + fig title 14, re-exec,
  substance distincte (sub-grain probit→logit fix vs c.860 axis-1 citations).
- **#8081 closed-loop** : Infer-2 (c.819 #8163) + Infer-11 (c.830) + Infer-12 (c.831) +
  PyMC-2 (c.834) + PyMC-11 (#8233 closes #8205) + Infer-13 (c.838 #8247) + Infer-19
  (#8257 MERGED) + PyMC-19 (c.844 MERGED) + Infer-18 (c.845 MERGEABLE) + PyMC-18
  (c.847 MERGEABLE) + Infer-15 (c.850 MERGEABLE) + PyMC-15 (c.851 MERGEABLE) +
  PyMC-17 + Infer-17 (c.852 MERGEABLE twin-pair) + **PyMC-16 (c.860 ce PR)** = 13 cibles
  du corpus Probas axis-1. Autres cibles non-claimées après cette PR : PyMC-1/3/4/5/6/7/8/9/10/12/13/14,
  Infer-1/3/4/5/6/7/8/9/10.
- **#8272 (Z3-06 prose/code mismatch Python)** : issue ouverte par po-2024 c.842, turf po-2025
  post-cascade.

## Liens

- Issue epic : [#8081](https://github.com/jsboige/CoursIA/issues/8081) (audit fidélité
  distillation MBML/Infer.NET, axe-1 = citations canoniques)
- PRs antérieures liées : [#8334](https://github.com/jsboige/CoursIA/pull/8334) (c.851 PyMC-15
  citations MERGEABLE), [#8331](https://github.com/jsboige/CoursIA/pull/8331) (c.850 Infer-15
  citations MERGEABLE), [#8339](https://github.com/jsboige/CoursIA/pull/8339) (c.852 PyMC-17
  Kalman MERGEABLE), [#8342](https://github.com/jsboige/CoursIA/pull/8342) (c.852 Infer-17
  Kalman MERGEABLE), [#8314](https://github.com/jsboige/CoursIA/pull/8314) (c.847 PyMC-18
  citations MERGEABLE), [#8307](https://github.com/jsboige/CoursIA/pull/8307) (c.845 Infer-18
  citations MERGEABLE), [#8302](https://github.com/jsboige/CoursIA/pull/8302) (c.844 PyMC-19
  citations MERGED), [#8257](https://github.com/jsboige/CoursIA/pull/8257) (Infer-19 citations
  MERGED 2026-07-24, po-2025), [#8247](https://github.com/jsboige/CoursIA/pull/8247) (c.838
  Infer-13 Crowdsourcing MERGEABLE), [#8234](https://github.com/jsboige/CoursIA/pull/8234)
  (c.834 PyMC-2 GMM MERGEABLE), [#8230](https://github.com/jsboige/CoursIA/pull/8230) (Infer-12
  Hierarchical MERGEABLE), [#8231](https://github.com/jsboige/CoursIA/pull/8231) (Infer-2 GMM
  MERGEABLE), [#8232](https://github.com/jsboige/CoursIA/pull/8232) (Infer-11 LDA MERGEABLE),
  [#8233](https://github.com/jsboige/CoursIA/pull/8233) (PyMC-11 LDA closes #8205 MERGEABLE)
- Pivot post-c.852 : c.860 = 15ᵉ pivot cross-famille consécutif post-c.839/c.840/c.841/c.842b/
  c.843/c.844/c.845/c.846/c.847/c.848/c.849/c.850/c.851/c.852, R6 variété respectée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)