### PR TITLE
enrich(probas,#8081): exercise the debugging loop in Infer-6 §7 (run the broken model)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb
@@ -2434,6 +2434,78 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "infer6-debug-loop-8081-md",
+   "metadata": {},
+   "source": [
+    "### Étape manquante : faire TOURNER le modèle cassé pour le diagnostiquer\n",
+    "\n",
+    "> **Note (#8081)** : la version initiale de cet exemple guidé laissait le modèle cassé **en commentaire** et passait directement à la version corrigée. Or le geste distinctif d'un notebook de *debugging* est précisément de **faire échouer l'inférence puis de la diagnostiquer** — pas seulement de décrire la panne. On exécute ici le modèle cassé (prior trop concentré, `Gamma` de shape < 1, observation à ~500 écarts-types du centre du prior) et on applique les fonctions `DiagnosticGaussian` / `DiagnosticGamma` du §6.1 pour voir le symptôme **apparaître dans la sortie**, avant d'appliquer les corrections de la cellule suivante.\n",
+    "\n",
+    "C'est la boucle *exécuter le modèle suspect → diagnostiquer le posterior → corriger* qui transforme un catalogue d'erreurs en une vraie démarche de débogueur."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "infer6-debug-loop-8081-code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Modele CASSE execute : prior trop concentre + Gamma(shape<1) + obs a 500 ecarts-types ===\n",
+      "\n",
+      "=== Diagnostic : moyenne (modele casse) ===\n",
+      "  Distribution : Gaussian(0,0002382, 0,01)\n",
+      "  Moyenne : 0,0002\n",
+      "  Variance : 0,010000\n",
+      "=== Diagnostic : precision (modele casse) ===\n",
+      "  Distribution : Gamma(0,6003, 0,0007935)[mean=0,0004764]\n",
+      "  Moyenne : 0,0005\n",
+      "  Variance : 0,000000\n",
+      ">>> Symptome : la moyenne posterieure (~0) n'a quasi pas bouge malgre l'observation a 50.\n",
+      "    Le prior N(0, var=0.01) etait si concentre que la donnee n'a pas pu le deplacer :\n",
+      "    le diagnostic de variance seul passe (0.01 est 'raisonnable'), MAIS la moyenne est\n",
+      "    a 500 ecarts-types de l'observation - echec de type 'prior ecrase la donnee', invisible\n",
+      "    au seul controle de variance. C'est ce constat qui motive les corrections de la cellule\n",
+      "    suivante (prior precision 0.01 -> la moyenne suit la donnee, comme on le verra : ~49.5).\n"
+     ]
+    }
+   ],
+   "source": [
+    "// #8081 — Faire TOURNER le modele casse pour voir le symptome (avant de corriger)\n",
+    "// Le modele ci-dessous est celui laisse en commentaire dans la cellule suivante.\n",
+    "// On l'execute vraiment pour observer ce que donne une inference mal specifiee,\n",
+    "// puis on applique les fonctions de diagnostic du §6.1 (definies plus haut, cellule 35).\n",
+    "\n",
+    "Console.WriteLine(\"=== Modele CASSE execute : prior trop concentre + Gamma(shape<1) + obs a 500 ecarts-types ===\");\n",
+    "Console.WriteLine();\n",
+    "\n",
+    "Variable<double> m_casse = Variable.GaussianFromMeanAndPrecision(0, 100);    // prior N(0, var=0.01) — beaucoup trop serre\n",
+    "Variable<double> p_casse = Variable.GammaFromShapeAndScale(0.1, 0.1);        // shape < 1 : densite impropre en 0\n",
+    "Variable<double> obs_casse = Variable.GaussianFromMeanAndPrecision(m_casse, p_casse);\n",
+    "obs_casse.ObservedValue = 50;                                                 // observation a ~500 ecarts-types du prior\n",
+    "\n",
+    "InferenceEngine eng_casse = new InferenceEngine();\n",
+    "eng_casse.Compiler.CompilerChoice = CompilerChoice.Roslyn;\n",
+    "eng_casse.ShowProgress = false;\n",
+    "\n",
+    "var mPost_casse = eng_casse.Infer<Gaussian>(m_casse);\n",
+    "var pPost_casse = eng_casse.Infer<Gamma>(p_casse);\n",
+    "DiagnosticGaussian(mPost_casse, \"moyenne (modele casse)\");\n",
+    "DiagnosticGamma(pPost_casse, \"precision (modele casse)\");\n",
+    "\n",
+    "Console.WriteLine(\">>> Symptome : la moyenne posterieure (~0) n'a quasi pas bouge malgre l'observation a 50.\");\n",
+    "Console.WriteLine(\"    Le prior N(0, var=0.01) etait si concentre que la donnee n'a pas pu le deplacer :\");\n",
+    "Console.WriteLine(\"    le diagnostic de variance seul passe (0.01 est 'raisonnable'), MAIS la moyenne est\");\n",
+    "Console.WriteLine(\"    a 500 ecarts-types de l'observation - echec de type 'prior ecrase la donnee', invisible\");\n",
+    "Console.WriteLine(\"    au seul controle de variance. C'est ce constat qui motive les corrections de la cellule\");\n",
+    "Console.WriteLine(\"    suivante (prior precision 0.01 -> la moyenne suit la donnee, comme on le verra : ~49.5).\");"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 15,
    "id": "7e3ddf44",


### PR DESCRIPTION
## Summary

#8081 fidelity audit on `Infer-6-Debugging` found a bounded gap and backfills it: §7 "Exemple guide : Debugger un modèle" left the **broken model commented out** and jumped straight to the corrected version. For a *debugging* notebook, the distinctive gesture is to make inference **fail and then diagnose it** — the §6.1 diagnostic functions were demonstrated only on a healthy posterior, never catching a real problem.

## #8081 finding (firsthand, po-2026 c.696)

Infer-6-Debugging (50 cells, C# Infer.NET) is **largely FIDÈLE** — most distinctive capabilities ARE exercised with real outputs:
- **§3 EP vs VMP** (cell 16): runs both algorithms, shows posterior means/variances numerically (not just described). *(Side note, Prong-B not #8081: the demo model is conjugate so EP≈VMP — only ~5% variance difference, the "VMP underestimates uncertainty" claim is weakly shown. Separate axis, not backfilled here.)*
- **§5 priors** (cells 29-30): real Beta-prior comparison, numbers match the analytic formula.
- **§6.1 diagnostics** (cell 35): DiagnosticGaussian/Gamma/Beta demonstrated — but **only on a healthy `test` posterior**.

**The gap (§7)**: the worked debug example describes the broken model (prior precision 100, `Gamma(0.1,0.1)`, obs at 50 = ~500 prior σ) **in comments**, then runs only the corrected version. The student never sees inference **fail**, nor the diagnostic functions **catch** a failure. The debugging loop (*run suspect → diagnose → fix*) is narrated, not exercised — the same model-critique-loop class as PyMC-2 (#8341) and the EP-motivation gap in Infer-8 (#8097).

## Backfill (2 cells, +72/−0, after the "à votre tour" prompt)

A markdown intro + a code cell that **actually runs** the broken model and applies the §6.1 diagnostics.

**Honest finding (richer than "alert fires")**: the broken model does **not** throw — it returns a posterior whose **mean (~0) ignored the data (50)** because the over-concentrated prior (precision 100 → var 0.01) dominated. Crucially, the §6.1 **variance-based diagnostic does NOT flag it** (variance 0.01 is "reasonable") — the failure is a "prior crushes the data" mode **invisible to a variance-only check**; you must compare the posterior mean to the data. This is shown live, then the existing corrected cell (precision 0.01 → mean tracks data at ~49.5) resolves it.

| | Broken (this cell) | Corrected (existing cell 40) |
|---|---|---|
| mean posterior | Gaussian(**0.0002**, 0.01) — stuck at prior | Gaussian(**49.48**, 2.826) — tracks data |
| precision posterior | Gamma mean 0.0005 — collapsed | Gamma mean 0.975 |

## Validation

- `nbformat.validate`: **VALID** (52 cells).
- `validate_pr_notebooks.py` (H.3): **PASS** (18 code cells, `.net-csharp`).
- C.1: clean (no `raise NotImplementedError`/`assert False`/`1/0`; the broken model returns a degenerate posterior, it does not raise).
- **Byte-surgical**: `+72/−0`, **1 hunk (pure additive)**, **0 existing cells changed** (id-keyed verify vs `origin/main` `d4bc196c3`), EOF matched. Base fresh (0 ahead/0 behind).

## Honest notes

- **Execution method — standalone Infer.NET console** (not nbconvert). nbconvert is broken in `mcp-jupyter-py310` (tornado SSL import-time failure, c.695). The .NET C# jupyter kernel IS registered, but to avoid the Python/nbconvert path entirely I ran a standalone `dotnet` console project (Microsoft.ML.Probabilistic + Compiler, Roslyn, net10) replicating the §6.1 diagnostic functions, and captured the **real** stdout. This is real execution of the same Infer.NET model → real outputs (C.2/H.1 satisfied; the in-process-executor pattern, not a stub).
- **Version authenticity verified**: the corrected-model twin run in my console produced `Gaussian(49.48, 2.826)` — **byte-identical** to the notebook's committed cell-40 output, confirming the standalone context matches the notebook's Infer.NET version + locale (comma decimal = French locale = the notebook's existing convention for all its outputs). No hand-edited/fabricated numbers (Stop & Repair honored).
- **Scope**: §7 only. §2.2 "problème de convergence" (cell 12) has a milder version of the same pattern (describes the symmetric-mode failure via `Console.WriteLine` rather than running it) — noted in the audit comment, **not** backfilled here (kept this PR atomic to §7; §2.2 is a candidate for a follow-up if the lane wants it).

## Vision QA (deferred)

po-2026 runs on GLM (no vision capability). This backfill adds no figures (text outputs only), so vision QA is N/A.

## Scope

See #8081 — Infer-6 verdict (FIDÈLE on most sections, this bounded §7 gap backfilled) posted as an audit comment. The #8081 Probas audit continues (~12 Infer + ~14 PyMC notebooks remaining). Related: #8341 (PyMC-2 model-critique loop), #8097 (Infer-8 EP motivation) — same finding class.
