### PR TITLE
feat(gt-7,#2161): restructure section 8 exercises into per-exercise cells + markdown

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-7-ExtensiveForm.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-7-ExtensiveForm.ipynb
@@ -1544,39 +1544,25 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "gt7-ex1-md",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 — SPE du jeu de l'ultimatum par induction arrière\n",
+    "\n",
+    "**Contexte.** Le jeu de l'ultimatum (§ formes extensives séquentielles) oppose un proposeur J1 à un récepteur J2 : J1 offre un partage $x \\in \\{2,4,5,6,8\\}$ d'un total de 10, puis J2 accepte ou refuse (refus $\\to$ gains $(0,0)$). C'est le cas d'école de l'**induction arrière** : la solution repose sur ce que J2 fera rationnellement, et J1 anticipe cette réaction.\n",
+    "\n",
+    "**Objectif.** Implémenter `solve_ultimatum(offers, total)` qui, par backward induction, détermine l'offre SPE de J1. Le raisonnement : J2 rationnel accepte toute offre positive (un gain $x>0$ vaut mieux que $0$ du refus) ; J1 le sait et choisit donc l'offre acceptée qui **maximise** son propre gain $(total - x)$, soit la plus petite offre de la liste.\n",
+    "\n",
+    "Les étapes détaillées et un indice sur le résultat attendu figurent dans la **docstring** du stub ci-dessous (`# Etape N`, `# Indice`)."
+   ]
+  },
+  {
    "cell_type": "code",
+   "id": "gt7-ex1-code",
+   "metadata": {},
    "execution_count": 13,
-   "id": "17510cae",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-07-11T09:35:37.845517Z",
-     "iopub.status.busy": "2026-07-11T09:35:37.845346Z",
-     "iopub.status.idle": "2026-07-11T09:35:37.851826Z",
-     "shell.execute_reply": "2026-07-11T09:35:37.851165Z"
-    },
-    "papermill": {
-     "duration": 0.008856,
-     "end_time": "2026-06-04T17:58:50.574267+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T17:58:50.565411+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "3 exos a completer : solve_ultimatum, build_three_player_entry_game, verify_spe\n",
-      "\n",
-      "Resultats stubs (non implementes) :\n",
-      "  solve_ultimatum([2,4,5,6,8]) -> {'spe_offer': 0, 'j1_payoff': 0, 'j2_payoff': 0, 'j2_accepts': []}\n",
-      "  build_three_player_entry_game() -> 3-Player Entry Game\n",
-      "  verify_spe(entry_game, ...) -> False\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# === Exercices : Jeux extensifs et SPE ===\n",
     "# Stubs pour les 3 exos definis en section 8 (8.1, 8.2, 8.3).\n",
@@ -1627,7 +1613,30 @@
     "        'j2_accepts': [],\n",
     "    }  # TODO etudiant : remplacer par le vrai calcul SPE\n",
     "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt7-ex2-md",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — Construire l'arbre d'un jeu séquentiel à 3 joueurs\n",
     "\n",
+    "**Contexte.** Les exemples précédents (§1–§6) portaient sur des arbres à 2 joueurs. Un jeu d'entrée séquentiel à **3 firmes** (A $\\to$ B $\\to$ C, chacune observant les choix précédents) généralise la structure : il faut composer plusieurs ensembles d'information et relier correctement les nœuds internes aux feuilles.\n",
+    "\n",
+    "**Objectif.** Compléter `build_three_player_entry_game()` pour construire l'arbre complet : 1 racine (A), 2 nœuds intermédiaires (B, un par choix de A), 8 feuilles (C : $2\\times2\\times2$), et 7 ensembles d'information (1 pour A + 2 pour B + 4 pour C). Les gains reflètent le partage du marché selon le nombre d'entrants.\n",
+    "\n",
+    "La structure attendue (nœuds, infosets, gains) est détaillée dans la **docstring** du stub ci-dessous."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "gt7-ex2-code",
+   "metadata": {},
+   "execution_count": 14,
+   "outputs": [],
+   "source": [
     "def build_three_player_entry_game() -> ExtensiveFormGame:\n",
     "    \"\"\"Construit l'arbre de jeu a 3 firmes sequentielles (A -> B -> C).\n",
     "\n",
@@ -1656,7 +1665,43 @@
     "    # TODO etudiant : completer l'arbre ci-dessus\n",
     "    return game\n",
     "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt7-ex3-md",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — Vérifier un équilibre de Nash parfait en sous-jeux (SPE)\n",
     "\n",
+    "**Contexte.** Un équilibre de Nash du jeu global peut reposer sur une **menace non crédible** — une stratégie qui ne serait pas rationnelle si le sous-jeu correspondant était réellement atteint. Le **SPE** (Subgame Perfect Equilibrium) élimine ces menaces en exigeant un équilibre de Nash dans **chaque** sous-jeu. C'est précisément ce que la backward induction garantit (Exercice 1) et que la simple vérification de Nash global rate.\n",
+    "\n",
+    "**Objectif.** Implémenter `verify_spe(game, strategies)` : pour chaque sous-jeu (identifié par sa racine), vérifier qu'aucun joueur ne peut améliorer son gain par déviation unilatérale **dans ce sous-jeu**. Retourner `is_spe` et la liste des violations (sous-jeu + joueur + déviation profitable).\n",
+    "\n",
+    "La cellule suivante contient un **test rapide** des trois stubs (avec signatures non implémentées) pour vérifier que tout s'exécute de bout en bout. Les étapes détaillées figurent dans la **docstring** du stub."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "gt7-ex3-code",
+   "metadata": {},
+   "execution_count": 15,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3 exos a completer : solve_ultimatum, build_three_player_entry_game, verify_spe\n",
+      "\n",
+      "Resultats stubs (non implementes) :\n",
+      "  solve_ultimatum([2,4,5,6,8]) -> {'spe_offer': 0, 'j1_payoff': 0, 'j2_payoff': 0, 'j2_accepts': []}\n",
+      "  build_three_player_entry_game() -> 3-Player Entry Game\n",
+      "  verify_spe(entry_game, ...) -> False\n"
+     ]
+    }
+   ],
+   "source": [
     "def verify_spe(game: ExtensiveFormGame,\n",
     "               strategies: Dict[int, PureStrategy]) -> Dict[str, Any]:\n",
     "    \"\"\"Verifie qu'un profil de strategies pures est un SPE.\n",


### PR DESCRIPTION
feat(gt-7,#2161): restructure section 8 exercises into per-exercise cells + markdown

GameTheory-7-ExtensiveForm (Extensive-Form Games / backward induction / SPE) had
all 3 exercise stubs (solve_ultimatum, build_three_player_entry_game, verify_spe)
lumped into a SINGLE code cell (C26, ec=13) with NO per-exercise markdown
headers -- violating exercise-example-labeling (each exercise must be preceded by
markdown: contexte + objectif + indices) and #2161 placement.

Splits C26 into 3 code cells (ec=13/14/15, no cascade -- C26 was the last code
cell; M27 "## 9. Resume" follows and is markdown), each preceded by a
### Exercice N markdown cell (FR) with contexte (concept + link to sections 1-7),
objectif (what the student produces), and a pointer to the in-stub hints
(Etape/Indice). The trailing test block (which exercises all 3 stubs and
references sections 1-7 cross-cell state: entry_game, entrant_enter,
incumbent_acc) stays in the LAST code cell, preserving execution order.

The stubs themselves are UNCHANGED -- only their containers are restructured
(proven: the concatenated source of the 3 split cells is byte-identical to the
original C26 source). Anti-regression: no stub content, docstring, or TODO hint
was modified.

Validation:
- C.2 PROVEN: full notebook executed end-to-end (nbconvert exit 0, 0 errors).
  Cell C (verify_spe + test block) output is byte-identical to the original C26
  output AND to the fresh full-exec output. Cells A/B (defs) produce no output
  (def-only), as expected.
- Stub content byte-identical to origin (concatenated split == original C26).
- ec sequential 1..15 (13 split into 13/14/15, no other cell bumped).
- H.3 + nbformat: PASS (15 code cells). Leak scanner: 1 pre-existing FP (stub
  docstrings with TODO, unchanged). C.1: 0 real violations (the "raise
  NotImplementedError"/"assert False" mentions are markdown prose in M25
  explaining the C.1 convention -- false positive, pre-existing).
- Byte-stable: +76/-31 (C26 region replaced; every other byte intact).

See #2161 (three-exercises-per-notebook) and exercise-example-labeling convention.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
