### PR TITLE
feat(audit,#8051): lean4-wsl notebook sorry tally (scientific_review axis)

### DIFF
--- a/scripts/audit/check_lean_notebook_sorry.py
+++ b/scripts/audit/check_lean_notebook_sorry.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Diagnostic: per-notebook ``sorry`` tally for ``lean4-wsl`` notebooks.
+
+Context (Epic #8051 — maturity 3-axes). The third maturity axis
+``scientific_review`` (UNREVIEWED / AUTHOR_REVIEWED / PEER_REVIEWED /
+FORMALLY_VERIFIED) is currently non-functional for Lean notebooks: catalog
+generation cannot honestly emit ``FORMALLY_VERIFIED`` because (a) cell-level
+``sorry`` absence does NOT imply transitive sorry-freeness (companion
+``*_lean/`` lakes may carry their own debt), and (b) there is no aggregated
+Lean-CI sorry-count artifact for the catalog to consume. This script gathers
+the notebook-level half of that data so the axis can be designed honestly.
+
+Scope (HONEST, read-only diagnostic):
+  * scans inline Lean code cells of ``lean4-wsl`` kernelspec notebooks only;
+  * strips Lean comments first (``--`` line, ``/- ... -/`` block) then counts
+    word-bounded ``sorry`` — mirroring the canonical
+    ``lean_notebook_utils._strip_lean_comments`` (FX-6 #1453, regression #7414);
+  * does NOT aggregate companion-lake debt and is NOT authoritative. The
+    authoritative sorry count for a lake remains
+    ``lean_notebook_utils.count_sorry(project_path)`` / ``lake build`` warnings.
+    A notebook reported ``SORRY-FREE`` here is a *candidate* only, NOT
+    transitively verified.
+
+Exit code: always 0 (diagnostic, not a gate — Lean sorry-debt is acknowledged
+research, cf ``sorry-debt-easy-lakes-drained``). ``--json`` emits a machine
+record for catalog/coordination consumption.
+
+Usage::
+
+    python scripts/audit/check_lean_notebook_sorry.py            # human table
+    python scripts/audit/check_lean_notebook_sorry.py --json     # machine record
+    python scripts/audit/check_lean_notebook_sorry.py --no-pager  # CI / pipe
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# Canonical Lean comment-stripper (FX-6 #1453, regression #7414). Reused rather
+# than duplicated so the tally stays byte-identical to count_sorry's semantics.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_LEAN_UTILS_DIR = _REPO_ROOT / "MyIA.AI.Notebooks" / "SymbolicAI" / "Lean"
+if str(_LEAN_UTILS_DIR) not in sys.path:
+    sys.path.insert(0, str(_LEAN_UTILS_DIR))
+try:
+    from lean_notebook_utils import _strip_lean_comments as _strip_lean_comments  # type: ignore
+except Exception:  # pragma: no cover - fallback only if canonical module moves
+    _strip_lean_comments = None  # type: ignore
+
+_NOTEBOOKS_ROOT = _REPO_ROOT / "MyIA.AI.Notebooks"
+_LEAN_KERNEL = "lean4-wsl"
+# Word-bounded ``sorry``: not preceded/followed by an identifier char, so
+# ``sorryFoo`` / ``notsorry`` are excluded. Matches count_sorry's intent.
+_SORRY_RE = re.compile(r"(?<![A-Za-z0-9_'])sorry(?![A-Za-z0-9_'])")
+
+
+@dataclass
+class NotebookSorry:
+    """Per-notebook cell-level sorry tally."""
+
+    rel_path: str
+    kernel: str
+    code_cells: int
+    sorry_count: int
+
+    @property
+    def verdict(self) -> str:
+        return "SORRY-FREE-CANDIDATE" if self.sorry_count == 0 else "HAS-SORRY-DEBT"
+
+
+@dataclass
+class AuditReport:
+    """Aggregate report across all lean4-wsl notebooks."""
+
+    notebooks: list[NotebookSorry] = field(default_factory=list)
+    scanned: int = 0
+    skipped_nonlean: int = 0
+
+    @property
+    def total_sorry(self) -> int:
+        return sum(n.sorry_count for n in self.notebooks)
+
+    @property
+    def sorry_free_count(self) -> int:
+        return sum(1 for n in self.notebooks if n.sorry_count == 0)
+
+    def to_dict(self) -> dict:
+        return {
+            "scope": "cell-level lean4-wsl notebooks only (NOT transitive; see module docstring)",
+            "canonical_authoritative": "lean_notebook_utils.count_sorry(lake) / lake build warnings",
+            "scanned_lean_notebooks": len(self.notebooks),
+            "skipped_nonlean_notebooks": self.skipped_nonlean,
+            "total_sorry_cell_level": self.total_sorry,
+            "sorry_free_candidates": self.sorry_free_count,
+            "sorry_debt_notebooks": len(self.notebooks) - self.sorry_free_count,
+            "notebooks": [
+                {
+                    "path": n.rel_path,
+                    "kernel": n.kernel,
+                    "code_cells": n.code_cells,
+                    "sorry_count": n.sorry_count,
+                    "verdict": n.verdict,
+                }
+                for n in sorted(self.notebooks, key=lambda x: (-x.sorry_count, x.rel_path))
+            ],
+        }
+
+
+def _kernel_name(nb: dict) -> str:
+    return (
+        ((nb.get("metadata") or {}).get("kernelspec") or {}).get("name") or ""
+    )
+
+
+def _count_cell_sorry(source_lines: list[str]) -> int:
+    """Count word-bounded ``sorry`` in a notebook cell's joined source."""
+    if not source_lines:
+        return 0
+    joined = "\n".join(source_lines)
+    stripped = _strip_lean_comments(joined) if _strip_lean_comments else joined
+    return len(_SORRY_RE.findall(stripped))
+
+
+def scan_notebook(nb_path: Path, root: Path | None = None) -> NotebookSorry | None:
+    """Return a ``NotebookSorry`` for a lean4-wsl notebook, else None.
+
+    None signals "not a lean4-wsl notebook" (counted separately). Parse errors
+    raise — a corrupt .ipynb in the tree is a real defect worth surfacing.
+    ``root`` scopes ``rel_path``; if the notebook is not under ``root`` the full
+    path is used so standalone calls (e.g. tests) never crash on relative_to.
+    """
+    nb = json.loads(nb_path.read_text(encoding="utf-8"))
+    kernel = _kernel_name(nb)
+    if kernel != _LEAN_KERNEL:
+        return None
+    code_cells = 0
+    sorry_total = 0
+    for cell in nb.get("cells") or []:
+        if (cell.get("cell_type") or "") != "code":
+            continue
+        code_cells += 1
+        sorry_total += _count_cell_sorry(cell.get("source") or [])
+    root = root or _REPO_ROOT
+    try:
+        rel = nb_path.relative_to(root).as_posix()
+    except ValueError:
+        rel = nb_path.as_posix()
+    return NotebookSorry(rel_path=rel, kernel=kernel, code_cells=code_cells, sorry_count=sorry_total)
+
+
+def run_audit(root: Path | None = None) -> AuditReport:
+    """Scan every ``*.ipynb`` under root, tally sorry for lean4-wsl ones."""
+    root = root or _NOTEBOOKS_ROOT
+    report = AuditReport()
+    for nb_path in sorted(root.rglob("*.ipynb")):
+        try:
+            result = scan_notebook(nb_path, root=root)
+        except (json.JSONDecodeError, KeyError) as exc:  # pragma: no cover
+            raise RuntimeError(f"corrupt notebook {nb_path}: {exc}") from exc
+        if result is None:
+            report.skipped_nonlean += 1
+        else:
+            report.notebooks.append(result)
+            report.scanned += 1
+    return report
+
+
+def _human_report(report: AuditReport) -> str:
+    lines = [
+        "Lean4-wsl notebook sorry audit (CELL-LEVEL, not transitive)",
+        "=" * 64,
+        f"scanned lean4-wsl notebooks : {len(report.notebooks)}",
+        f"skipped non-lean notebooks  : {report.skipped_nonlean}",
+        f"total sorry (cell-level)    : {report.total_sorry}",
+        f"SORRY-FREE candidates       : {report.sorry_free_count}",
+        f"HAS-SORRY-DEBT notebooks    : {len(report.notebooks) - report.sorry_free_count}",
+        "",
+        "per-notebook (sorry desc, then path):",
+    ]
+    for n in sorted(report.notebooks, key=lambda x: (-x.sorry_count, x.rel_path)):
+        lines.append(
+            f"  {n.sorry_count:>3} sorry | {n.code_cells:>3} cells | {n.verdict:<22} | {n.rel_path}"
+        )
+    lines.extend([
+        "",
+        "NOTE: cell-level only. Companion *_lean/ lake debt is NOT aggregated.",
+        "Authoritative: lean_notebook_utils.count_sorry(lake) / lake build warnings.",
+        "A SORRY-FREE-CANDIDATE here is NOT transitively verified (Epic #8051).",
+    ])
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--json", action="store_true", help="emit machine record instead of human table")
+    parser.add_argument("--no-pager", action="store_true", help="plain stdout (CI/pipe); default already plain")
+    args = parser.parse_args(argv)
+    report = run_audit()
+    if args.json:
+        print(json.dumps(report.to_dict(), indent=2, ensure_ascii=False))
+    else:
+        print(_human_report(report))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit/tests/test_check_lean_notebook_sorry.py
+++ b/scripts/audit/tests/test_check_lean_notebook_sorry.py
@@ -1,0 +1,191 @@
+"""Tests for scripts/audit/check_lean_notebook_sorry.py (#8051 scientific_review axis).
+
+Covers the cell-level ``sorry`` tally for ``lean4-wsl`` notebooks:
+  - kernel detection (lean4-wsl only; non-lean counted separately),
+  - word-bounded ``sorry`` (sorryFoo / notsorry excluded),
+  - comment stripping (``--`` line + ``/- ... -/`` block sorry NOT counted),
+  - multi-cell aggregation, markdown cells ignored,
+  - verdict classification + JSON record shape.
+
+Uses a synthetic mini-tree (tmp_path) — no dependency on live repo state.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+CHECK_PATH = HERE.parent / "check_lean_notebook_sorry.py"
+
+
+def _load_check():
+    spec = importlib.util.spec_from_file_location("check_lean_notebook_sorry", CHECK_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    # Register before exec so pytest's dataclass/@property introspection
+    # (sys.modules.get(cls.__module__)) resolves — see importlib docs.
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _notebook(path: Path, kernel: str = "lean4-wsl", cells: list[dict] | None = None) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    nb = {
+        "cells": cells or [],
+        "metadata": {"kernelspec": {"name": kernel, "display_name": kernel}},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+    path.write_text(json.dumps(nb), encoding="utf-8")
+
+
+def _code(source: str) -> dict:
+    return {"cell_type": "code", "source": source.splitlines(keepends=True)}
+
+
+def _md(text: str) -> dict:
+    return {"cell_type": "markdown", "source": text.splitlines(keepends=True)}
+
+
+# --------------------------------------------------------------------------- #
+# kernel detection + scan_notebook
+# --------------------------------------------------------------------------- #
+class TestScanNotebook:
+    def setup_method(self):
+        self.mod = _load_check()
+
+    def test_returns_none_for_non_lean_kernel(self, tmp_path):
+        nbp = tmp_path / "PythonNB.ipynb"
+        _notebook(nbp, kernel="python3", cells=[_code("sorry")])
+        assert self.mod.scan_notebook(nbp) is None
+
+    def test_detects_lean4_wsl_kernel(self, tmp_path):
+        nbp = tmp_path / "LeanNB.ipynb"
+        _notebook(nbp, kernel="lean4-wsl", cells=[_code("theorem t : True := by sorry")])
+        result = self.mod.scan_notebook(nbp)
+        assert result is not None
+        assert result.kernel == "lean4-wsl"
+        assert result.sorry_count == 1
+
+    def test_rel_path_is_posix(self, tmp_path, monkeypatch):
+        nbp = tmp_path / "sub" / "NB.ipynb"
+        _notebook(nbp, cells=[_code("sorry")])
+        monkeypatch.setattr(self.mod, "_REPO_ROOT", tmp_path)
+        monkeypatch.setattr(self.mod, "_NOTEBOOKS_ROOT", tmp_path)
+        result = self.mod.scan_notebook(nbp)
+        assert result.rel_path == "sub/NB.ipynb"
+
+
+# --------------------------------------------------------------------------- #
+# sorry counting semantics (word boundary + comment stripping)
+# --------------------------------------------------------------------------- #
+class TestSorryCounting:
+    def setup_method(self):
+        self.mod = _load_check()
+
+    def test_word_boundary_excludes_sorryfoo(self, tmp_path):
+        nbp = tmp_path / "NB.ipynb"
+        _notebook(nbp, cells=[_code("def sorryFoo := 1\nnotsorry")])
+        assert self.mod.scan_notebook(nbp).sorry_count == 0
+
+    def test_line_comment_sorry_not_counted(self, tmp_path):
+        nbp = tmp_path / "NB.ipynb"
+        _notebook(nbp, cells=[_code("-- this is sorry in a comment\ntheorem t := 1")])
+        assert self.mod.scan_notebook(nbp).sorry_count == 0
+
+    def test_block_comment_sorry_not_counted(self, tmp_path):
+        nbp = tmp_path / "NB.ipynb"
+        _notebook(nbp, cells=[_code("/- sorry inside block comment -/\ntheorem t := 1")])
+        assert self.mod.scan_notebook(nbp).sorry_count == 0
+
+    def test_real_sorry_tactic_counted(self, tmp_path):
+        nbp = tmp_path / "NB.ipynb"
+        _notebook(nbp, cells=[_code("theorem t : True := by sorry\ntheorem u : True := by sorry")])
+        assert self.mod.scan_notebook(nbp).sorry_count == 2
+
+    def test_aggregates_across_cells(self, tmp_path):
+        nbp = tmp_path / "NB.ipynb"
+        _notebook(nbp, cells=[_code("sorry"), _code("sorry"), _code("-- sorry")])
+        result = self.mod.scan_notebook(nbp)
+        assert result.sorry_count == 2
+        assert result.code_cells == 3
+
+    def test_markdown_cells_ignored(self, tmp_path):
+        nbp = tmp_path / "NB.ipynb"
+        _notebook(nbp, cells=[_md("We use sorry here in prose"), _code("sorry")])
+        result = self.mod.scan_notebook(nbp)
+        assert result.sorry_count == 1
+        assert result.code_cells == 1
+
+    def test_empty_notebook(self, tmp_path):
+        nbp = tmp_path / "NB.ipynb"
+        _notebook(nbp, cells=[])
+        result = self.mod.scan_notebook(nbp)
+        assert result.sorry_count == 0
+        assert result.code_cells == 0
+        assert result.verdict == "SORRY-FREE-CANDIDATE"
+
+
+# --------------------------------------------------------------------------- #
+# verdict classification + report aggregation
+# --------------------------------------------------------------------------- #
+class TestReport:
+    def setup_method(self):
+        self.mod = _load_check()
+
+    def test_verdict_branches(self, tmp_path):
+        nbp = tmp_path / "NB.ipynb"
+        _notebook(nbp, cells=[_code("sorry")])
+        assert self.mod.scan_notebook(nbp).verdict == "HAS-SORRY-DEBT"
+        nbp2 = tmp_path / "NB2.ipynb"
+        _notebook(nbp2, cells=[_code("theorem t := 1")])
+        assert self.mod.scan_notebook(nbp2).verdict == "SORRY-FREE-CANDIDATE"
+
+    def test_run_audit_classifies_and_skips(self, tmp_path, monkeypatch):
+        _notebook(tmp_path / "lean1.ipynb", cells=[_code("sorry")])
+        _notebook(tmp_path / "lean2.ipynb", cells=[_code("ok")])
+        _notebook(tmp_path / "py.ipynb", kernel="python3", cells=[_code("sorry")])
+        monkeypatch.setattr(self.mod, "_NOTEBOOKS_ROOT", tmp_path)
+        report = self.mod.run_audit()
+        assert len(report.notebooks) == 2
+        assert report.skipped_nonlean == 1
+        assert report.total_sorry == 1
+        assert report.sorry_free_count == 1
+
+    def test_to_dict_shape_and_ordering(self, tmp_path, monkeypatch):
+        _notebook(tmp_path / "debt.ipynb", cells=[_code("sorry\nsorry")])
+        _notebook(tmp_path / "free.ipynb", cells=[_code("ok")])
+        monkeypatch.setattr(self.mod, "_NOTEBOOKS_ROOT", tmp_path)
+        d = self.mod.run_audit().to_dict()
+        assert d["scanned_lean_notebooks"] == 2
+        assert d["total_sorry_cell_level"] == 2
+        assert d["sorry_free_candidates"] == 1
+        assert d["sorry_debt_notebooks"] == 1
+        assert "NOT transitive" in d["scope"]
+        assert d["notebooks"][0]["sorry_count"] >= d["notebooks"][1]["sorry_count"]  # desc order
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+class TestCLI:
+    def setup_method(self):
+        self.mod = _load_check()
+
+    def test_json_flag_emits_valid_record(self, tmp_path, monkeypatch, capsys):
+        _notebook(tmp_path / "lean.ipynb", cells=[_code("sorry")])
+        monkeypatch.setattr(self.mod, "_NOTEBOOKS_ROOT", tmp_path)
+        rc = self.mod.main(["--json"])
+        out = capsys.readouterr().out
+        assert rc == 0
+        parsed = json.loads(out)
+        assert parsed["scanned_lean_notebooks"] == 1
+        assert parsed["notebooks"][0]["sorry_count"] == 1
+
+    def test_exit_code_always_zero(self, tmp_path, monkeypatch):
+        # diagnostic, not a gate: sorry-debt is acknowledged research
+        _notebook(tmp_path / "debt.ipynb", cells=[_code("sorry\nsorry\nsorry")])
+        monkeypatch.setattr(self.mod, "_NOTEBOOKS_ROOT", tmp_path)
+        assert self.mod.main([]) == 0


### PR DESCRIPTION
## Summary

New read-only diagnostic `scripts/audit/check_lean_notebook_sorry.py` that tallies cell-level `sorry` across `lean4-wsl` kernel notebooks. Supports the **third maturity axis** (`scientific_review`) of Epic **#8051** (3-axes maturity model).

### Why this exists — firsthand finding on origin/main

`classify_scientific_review()` returns `UNREVIEWED` for all 836 notebooks. Investigation found two reasons:

1. **Dead signal** (`scripts/notebook_tools/generate_catalog.py:819`): `has_lean_companion=any(p.endswith(".lean") for p in parts)` where `parts = rel.parts` (notebook path segments ending `.ipynb`) → **always False**. Even `GameTheory-15b-Lean-CooperativeGames.ipynb` = UNREVIEWED.
2. **Honesty constraint**: even with the signal fixed, catalog-gen **cannot** honestly emit `FORMALLY_VERIFIED` because cell-level sorry absence ≠ transitive sorry-freeness, and there is no aggregated Lean-CI sorry-count artifact to consume.

This script gathers the **notebook-level** half of that data so the axis can be designed honestly rather than via a dead/over-claiming heuristic.

## Scope (HONEST, read-only)

- Scans inline Lean code cells of `lean4-wsl` kernelspec notebooks only.
- Strips Lean comments (`--` line, `/- ... -/` block) then counts **word-bounded** `sorry`, mirroring the canonical `lean_notebook_utils._strip_lean_comments` (FX-6 #1453, regression #7414) via **import — not duplication**.
- Does **NOT** aggregate companion-lake debt. Authoritative sorry count for a lake remains `lean_notebook_utils.count_sorry(project_path)` / `lake build` warnings.
- A `SORRY-FREE-CANDIDATE` here is **NOT** transitively verified — explicit in output + docstring.

**Complement, not duplicate**: `lean_notebook_utils.count_sorry` is project/lake-level (`.lean` files); this is notebook-cell-level (`.ipynb` lean4-wsl).

## Firsthand data on origin/main

```
scanned lean4-wsl notebooks : 18
total sorry (cell-level)    : 44
SORRY-FREE candidates       : 9
HAS-SORRY-DEBT notebooks    : 9
```

This **confirms** that a blanket `FORMALLY_VERIFIED` marking would create **9 false claims** (anti-complaisance). The honest `scientific_review` axis needs Lean-CI sorry-count integration (Epic-level, ai-01 infra decision), not a catalog-gen heuristic. Flagging to ai-01 as a design decision, similar to the honest finding in #8345.

## Validation

- Exit code **always 0** (diagnostic, not a gate — Lean sorry-debt is acknowledged research, cf `sorry-debt-easy-lakes-drained`).
- `--json` emits a machine record for catalog/coordination consumption.
- **15 unit tests** (synthetic mini-tree): kernel detection, word-boundary counting, comment stripping (line + block), multi-cell aggregation, markdown-cell exclusion, empty notebook, verdict branches, report aggregation/serialization/ordering, CLI `--json` + exit code.
- **3300 tests pass** (15 new + existing `scripts/audit/tests/` + `scripts/notebook_tools/tests/`), no regression.

## Files

- `scripts/audit/check_lean_notebook_sorry.py` (new, +230)
- `scripts/audit/tests/test_check_lean_notebook_sorry.py` (new, +175)

No catalog, no notebook, no README churn (catalog-pr-hygiene HARD 1 respected).

See #8051

Co-Authored-By: Claude-Code <noreply@anthropic.com>