### PR TITLE
feat(search-5-csharp,#2161): add per-exercise markdown contexte (match house style)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms-Csharp.ipynb
@@ -616,6 +616,28 @@
    "id": "cell-dbb056a3"
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercices\n",
+    "\n",
+    "Les trois exercices ci-dessous appliquent les concepts démontrés plus haut (sélection §3, optimisation continue §4, mutation adaptative §5.2) sur le squelette `GeneticAlgorithm<T>`. Chaque exercice est **à compléter** : la cellule fournit le point d'entrée et l'objectif chiffré à atteindre, à vous d'implémenter la variation demandée et de mesurer le résultat."
+   ],
+   "id": "s5cs-ex-intro"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 — Tournoi vs roulette (étudiant à compléter)\n",
+    "\n",
+    "**Contexte.** La sélection par roulette (§3) proportionnalise la probabilité de reproduction au fitness. La **sélection par tournoi** (taille $k$) tire $k$ individus au hasard et retient le meilleur : elle offre un contrôle direct de la **pression de sélection** via $k$, et évite les échelles de fitness problématiques (valeurs négatives, plateaux).\n",
+    "\n",
+    "**Objectif.** Remplacez la sélection Roulette par Tournament ($k=3$) sur OneMax, puis mesurez `convGen` (la génération de convergence vers l'optimum). Comparez à la roulette : un tournoi $k=3$ doit converger **plus vite** (pression plus forte). La cellule ci-dessous indique le seuil attendu (`convGen >= 19` avec la roulette)."
+   ],
+   "id": "s5cs-ex1-md"
+  },
+  {
    "cell_type": "code",
    "execution_count": 7,
    "id": "ex74440",
@@ -653,6 +675,18 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — Effet de la taille de population (étudiant à compléter)\n",
+    "\n",
+    "**Contexte.** La taille de population échange **exploration** contre **coût computationnel** : une population large explore davantage l'espace de recherche (meilleure diversité génétique) mais chaque génération coûte plus cher en évaluations ; une population petite converge plus vite mais risque la **dérive génétique** (perte prématurée de bons allèles). Sur Rastrigin (§4, paysage multimodal), ce compromis est critique.\n",
+    "\n",
+    "**Objectif.** Bouclez sur `PopulationSize` dans $\\{20, 50, 100, 200\\}$ sur Rastrigin (mêmes autres paramètres), collectez le meilleur $f(x)$ final de chaque run. Observez la courbe : jusqu'où la taille de population améliore-t-elle la qualité de la solution ? À partir de quand le gain marginal devient négligeable devant le coût ?"
+   ],
+   "id": "s5cs-ex2-md"
+  },
+  {
    "cell_type": "code",
    "execution_count": 8,
    "id": "ex70442",
@@ -688,6 +722,18 @@
     "// Bouclez sur PopulationSize in {20, 50, 100, 200} sur Rastrigin, collectez best f(x).\n",
     "\"Exercice 2 à compléter : sweep PopulationSize sur Rastrigin, afficher best f(x) final.\".Display();\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — Mutation adaptative (étudiant à compléter)\n",
+    "\n",
+    "**Contexte.** Le taux de mutation adaptatif (§5.2) fait décroître la mutation avec les générations : fort au début (~0.1, exploration large), faible à la fin (~0.001, raffinement local). La cellule §5.2 a défini `AdaptiveRate(gen, maxGen)` mais le `GeneticAlgorithm<T>` utilise encore un taux **fixe**.\n",
+    "\n",
+    "**Objectif.** Surchargez `GeneticAlgorithm<T>.Run` pour que `MutateGauss` (opérateur réel, §4) appelle `AdaptiveRate(g, generations)` à chaque génération, puis comparez la trajectoire de convergence (meilleur fitness par génération) à celle du taux fixe $0{,}01$. Hypothèse à vérifier : le taux adaptatif doit atteindre un meilleur optimum final sur Rastrigin, en explorant largement au début puis en stabilisant la population."
+   ],
+   "id": "s5cs-ex3-md"
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
feat(search-5-csharp,#2161): add per-exercise markdown contexte (match house style)

Search-5-GeneticAlgorithms-Csharp was the outlier among Search-C# notebooks: its
3 exercises (C17/C18/C19) were bare code cells with only "// Exercice N" comments,
with NO "## Exercices" section nor per-exercise markdown headers. Sibling notebooks
(Search-4-LocalSearch-C#, Search-7-MCTS-C#) all use "### Exercice N" markdown BEFORE
each stub -- the convention (exercise-example-labeling + #2161: each exercise must be
preceded by markdown giving contexte + objectif).

Adds 4 markdown cells (0 code changes -- markdown-only, C.2 markdown-exception):
  - "## Exercices" intro (between the Synthese section and Ex1 code)
  - "### Exercice 1 -- Tournoi vs roulette" (contexte: selection pressure via k;
    objectif: replace Roulette with Tournament k=3 on OneMax, measure convGen)
  - "### Exercice 2 -- Effet de la taille de population" (contexte: exploration vs
    cost tradeoff on multimodal Rastrigin; objectif: sweep {20,50,100,200}, observe
    best f(x))
  - "### Exercice 3 -- Mutation adaptative" (contexte: the AdaptiveRate schedule
    from 5.2; objectif: overload Run to use AdaptiveRate, compare to fixed 0.01)

The 3 exercise stubs are UNCHANGED (anti-regression): proven byte-identical to
origin (source + outputs unchanged). Only pedagogical framing is added.

Validation:
- C.2: markdown-only change -> pre-existing code outputs valid (C.2 exception).
  Verified by full-notebook re-exec (nbconvert exit 0, 0 errors, all 10 code cells
  executed): the 3 stub sources are byte-identical to origin AND their outputs match
  the fresh full-exec outputs.
- Byte-stable: +46/-0 (4 markdown cells only; zero code cell, execution_count, or
  source line changed -- verified via git diff grep).
- H.3 + nbformat: PASS (10 code cells). C.1: 0 violations. Leak scanner: 0 findings.
- ec sequence unchanged vs origin [1,2,3,4,4,5,6,7,8,9] (markdown insertions don't
  shift code-cell ec; a pre-existing duplicate ec=4 between cells c543trap-code and
  cell-eaed0471 is out of scope for this PR -- noted as residual).

See #2161 (three-exercises-per-notebook) and exercise-example-labeling convention.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
