### PR TITLE
enrich(probas,#8081): Infer-8 add Elo preamble (C# twin of PyMC-8 trigger)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb
@@ -390,6 +390,208 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0eb6018c",
+   "metadata": {},
+   "source": [
+    "### Elo : le prédécesseur déterministe que TrueSkill généralise\n",
+    "\n",
+    "Avant TrueSkill, le classement compétitif était dominé par **Elo** (échecs, années 1960), que la cellule suivante implémente from-scratch. Chaque joueur y est représenté par un **unique scalaire** $R$ (son rating) :\n",
+    "\n",
+    "$$E_A = \\frac{1}{1 + 10^{(R_B - R_A)/400}}, \\qquad R_A \\leftarrow R_A + K \\cdot (S_A - E_A)$$\n",
+    "\n",
+    "- $E_A$ : score **attendu** de A (probabilité de victoire implicite),\n",
+    "- $S_A$ : score **observé** (1 = gagne, 0 = perd, 0.5 = nul),\n",
+    "- $K$ : facteur de mise à jour **FIXE** (typiquement 16 à 32).\n",
+    "\n",
+    "Elo est simple, robuste et éprouvé. Mais il est **déterministe et ponctuel** : il ne modélise pas son incertitude. La cellule suivante montre concrètement ce que cela implique, et pourquoi Microsoft a développé TrueSkill pour Xbox Live.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "05363eab",
+   "metadata": {},
+   "execution_count": 1,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "ELO : LE PREDECESSEUR DETERMINISTE\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "============================================================\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Avant : R1 = 1500,0, R2 = 1500,0  (deux nouveaux joueurs)\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  Score attendu de J1 : E = 0,500\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Apres (J1 gagne) : R1 = 1516,0, R2 = 1484,0  (Delta = +16,0 / -16,0)\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "CECITE A L'INCERTITUDE : Elo applique le meme K en permanence\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "------------------------------------------------------------\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  Victoire 1 : R1 =  1516,0  (increment +16,0)\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  Victoire 2 : R1 =  1530,5  (increment +14,5)\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  Victoire 3 : R1 =  1543,7  (increment +13,2)\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  Victoire 4 : R1 =  1555,8  (increment +12,1)\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  Victoire 5 : R1 =  1566,8  (increment +11,0)\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      ">>> Elo ne SAIT PAS qu'il est incertain. Un nouveau joueur et un\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "    veteran de 1000 matchs au meme rating sont traites identiquement.\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "    C'est ce defaut que TrueSkill corrige en modelisant sigma.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Elo : le systeme de classement deterministe que TrueSkill generalise.\n",
+    "// Implementation from-scratch (pure C#, deterministe) pour servir de baseline.\n",
+    "\n",
+    "double ExpectedScore(double ratingA, double ratingB)\n",
+    "    => 1.0 / (1.0 + Math.Pow(10, (ratingB - ratingA) / 400.0));\n",
+    "\n",
+    "(double, double) UpdateElo(double ratingA, double ratingB, double scoreA, double K = 32)\n",
+    "{\n",
+    "    double ea = ExpectedScore(ratingA, ratingB);\n",
+    "    return (ratingA + K * (scoreA - ea), ratingB - K * (scoreA - ea)); // somme nulle\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"ELO : LE PREDECESSEUR DETERMINISTE\");\n",
+    "Console.WriteLine(new string('=', 60));\n",
+    "// Deux nouveaux joueurs, meme rating initial (convention Elo : 1500).\n",
+    "double R1 = 1500.0, R2 = 1500.0;\n",
+    "Console.WriteLine($\"Avant : R1 = {R1:F1}, R2 = {R2:F1}  (deux nouveaux joueurs)\");\n",
+    "Console.WriteLine($\"  Score attendu de J1 : E = {ExpectedScore(R1, R2):F3}\");\n",
+    "// Joueur 1 gagne (resultat = 1).\n",
+    "(R1, R2) = UpdateElo(R1, R2, scoreA: 1.0);\n",
+    "Console.WriteLine($\"Apres (J1 gagne) : R1 = {R1:F1}, R2 = {R2:F1}  (Delta = +16,0 / -16,0)\");\n",
+    "\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"CECITE A L'INCERTITUDE : Elo applique le meme K en permanence\");\n",
+    "Console.WriteLine(new string('-', 60));\n",
+    "// Une serie de 5 victoires consecutives de J1.\n",
+    "R1 = 1500.0; R2 = 1500.0;\n",
+    "double prev = R1;\n",
+    "for (int k = 1; k <= 5; k++)\n",
+    "{\n",
+    "    (R1, R2) = UpdateElo(R1, R2, scoreA: 1.0);\n",
+    "    double delta = R1 - prev;\n",
+    "    Console.WriteLine($\"  Victoire {k} : R1 = {R1,7:F1}  (increment +{delta:F1})\");\n",
+    "    prev = R1;\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\">>> Elo ne SAIT PAS qu'il est incertain. Un nouveau joueur et un\");\n",
+    "Console.WriteLine(\"    veteran de 1000 matchs au meme rating sont traites identiquement.\");\n",
+    "Console.WriteLine(\"    C'est ce defaut que TrueSkill corrige en modelisant sigma.\");\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "79a292b0",
+   "metadata": {},
+   "source": [
+    "### Lecture : Elo est aveugle à sa propre incertitude\n",
+    "\n",
+    "Les incréments **rétrécissent** (16,0 → 14,5 → 13,2 → 12,1 → 11,0) au fil des victoires consécutives. Ce n'est **pas** parce qu'Elo « apprend » qu'il est confiant : c'est un effet **mécanique**. À mesure que $R_1$ monte, le score attendu $E_A$ grimpe vers 1, donc l'écart $(S_A - E_A)$ diminue, et la même mise $K$ produit un delta plus petit. C'est une **conséquence arithmétique de la formule**, pas une modélisation de l'incertitude.\n",
+    "\n",
+    "La limite fondamentale : un **nouveau joueur** (0 match) et un **vétéran** (1000 matchs) au même rating reçoivent **exactement le même $K$**. Elo ne sait pas distinguer « je suis sûr à 25,0 ± 8,3 » de « je suis sûr à 25,0 ± 0,1 ». C'est précisément ce défaut que TrueSkill corrige en représentant chaque compétence par une **distribution** $\\mathcal{N}(\\mu, \\sigma^2)$ : $\\sigma$ diminue avec chaque match observé, et la mise à jour s'adapte à l'incertitude courante plutôt qu'à un $K$ figé.\n",
+    "\n",
+    "Le tableau de comparaison ci-dessus (axes Représentation, Incertitude, Convergence…) prend maintenant tout son sens : TrueSkill n'est pas « un meilleur Elo », c'est une **généralisation bayésienne** qui substitue une distribution au scalaire, rendant l'incertitude explicite et exploitée."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "l30e2s5e4oj",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
## Summary

**PERTE PAR COMPLAISANCE backfill on `Infer-8-TrueSkill`** — the DIRECT C# twin of `PyMC-8-TrueSkill`, the notebook that **triggered** the #8081 fidelity audit. The same gap the user flagged on PyMC-8 applies here unchanged.

### The gap (firsthand, same class as the PyMC-8 trigger)

Infer-8 says TrueSkill *"est une généralisation bayésienne du système Elo"* (cell 6) and shows a 6-row **comparison foil** "TrueSkill vs Elo" (cell 7: Représentation, Incertitude, Convergence, Matchs nuls, Équipes, Multi-joueurs) — but **Elo is never derived, implemented, or executed**. Of 19 code cells, **zero** compute Elo. The student sees *"Elo = score unique (ex: 1800)"* in a table without ever learning HOW Elo works — precisely the deterministic baseline that makes TrueSkill's Bayesian generalization meaningful. This is the exact *"perte par complaisance"* the user raised in #8081.

## Fix (mirrors PyMC-8 trigger commit `29b7b226d`, adapted to C# / Infer-8)

3 cells inserted after the cell-7 comparison table (pure addition):

1. **markdown intro** — expected-score formula `E = 1/(1+10^((Rb-Ra)/400))` + K-update, positioned as the deterministic predecessor TrueSkill generalizes.
2. **code cell** — from-scratch pure-C# Elo (K=32, scale 400): single match (R1 1500→1516) then 5 consecutive wins showing shrinking increments (**16,0 → 14,5 → 13,2 → 12,1 → 11,0**) — numbers **byte-identical to the Python twin** (IEEE-754 double, deterministic pure math).
3. **markdown interp** — honest nuance: shrinking increments are a **MECHANICAL proxy** of confidence (expected score rises → (S−E) shrinks → same K yields smaller delta), **NOT modeled uncertainty** like sigma. Points back to the existing cell-7 comparison table (no redundant re-tabulation).

## Validation (C.2 PROVED)

- **Executed via the `.net-csharp` kernel** (dotnet-interactive 1.0.712001). Code cell committed **WITH real outputs** (ec=1, 17 stream outputs). Re-exec-stable (deterministic pure-math, no MCMC drift — unlike Infer.NET EP cells).
- **FR-locale comma decimals** ("1500,0", "0,500", "+16,0") are **CONSISTENT with Infer-8's existing convention** (cell 12/19/30 TrueSkill posteriors all use comma decimals) — not forced to dots. Verified firsthand: 10+ existing outputs use commas; only code-literals in display_data use dots.
- **No banner leak** — output scanned for `Microsoft.Hosting`/`Lifetime`/IPv6/`http://` tokens: clean (my code uses only `Console.WriteLine`, no `.Display()`, no Infer.NET).
- **Byte-stable**: +202/0 (pure addition, 0 existing cells modified — anti-regression clean). Cell count 60 → 63.
- `nbformat.validate` OK. **H.3 PASS** (20 cells). **C.1: 0** violations. No catalogue / README / marker churn (catalog-pr-hygiene HARD 1 respected).

## Cross-paradigm note (#8081 registry)

This is the 2nd PERTE PAR COMPLAISANCE found in the TrueSkill pair (PyMC-8 trigger + now Infer-8 twin) — but the cross-paradigm finding holds: across 13 audited Probas notebooks, PERTE remains **isolated** (2/13), the rest FIDÈLE. The TrueSkill pair is the clearest case of the pattern (Elo-as-foil) because both twins distilled from the same MBML Ch.2 / Infer.NET TrueSkill source.

See #8081 (audit issue). Mirrors PyMC-8 trigger commit `29b7b226d`.

Co-Authored-By: Claude-Code <noreply@anthropic.com>