### PR TITLE
fix(search,#3801): MGS-3-Eukaryote Prong-B — measure NoOp-is-handicap (degenerate cone demo)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-3-Eukaryote.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-3-Eukaryote.ipynb
@@ -82,13 +82,128 @@
    "id": "wiring-cell",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:30:48.386945Z",
-     "iopub.status.busy": "2026-07-13T00:30:48.381705Z",
-     "iopub.status.idle": "2026-07-13T00:30:50.161146Z",
-     "shell.execute_reply": "2026-07-13T00:30:50.157128Z"
+     "iopub.execute_input": "2026-07-24T14:31:31.002988Z",
+     "iopub.status.busy": "2026-07-24T14:31:30.995532Z",
+     "iopub.status.idle": "2026-07-24T14:31:32.702080Z",
+     "shell.execute_reply": "2026-07-24T14:31:32.697606Z"
     }
    },
    "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       
+       
+       "\r\n",
+       
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       
+       
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '29384.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -178,10 +293,10 @@
    "id": "setup-cell",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:30:50.162673Z",
-     "iopub.status.busy": "2026-07-13T00:30:50.162421Z",
-     "iopub.status.idle": "2026-07-13T00:30:50.476679Z",
-     "shell.execute_reply": "2026-07-13T00:30:50.476284Z"
+     "iopub.execute_input": "2026-07-24T14:31:32.704039Z",
+     "iopub.status.busy": "2026-07-24T14:31:32.703837Z",
+     "iopub.status.idle": "2026-07-24T14:31:33.002101Z",
+     "shell.execute_reply": "2026-07-24T14:31:33.001858Z"
     }
    },
    "outputs": [
@@ -361,10 +476,10 @@
    "id": "karyotype-demo",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:30:50.478226Z",
-     "iopub.status.busy": "2026-07-13T00:30:50.478023Z",
-     "iopub.status.idle": "2026-07-13T00:30:50.671920Z",
-     "shell.execute_reply": "2026-07-13T00:30:50.671534Z"
+     "iopub.execute_input": "2026-07-24T14:31:33.003623Z",
+     "iopub.status.busy": "2026-07-24T14:31:33.003363Z",
+     "iopub.status.idle": "2026-07-24T14:31:33.239389Z",
+     "shell.execute_reply": "2026-07-24T14:31:33.239203Z"
     }
    },
    "outputs": [
@@ -393,14 +508,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Valeurs       : [93,44, 94,82]\r\n"
+      "  Valeurs       : [77,61, 85,64]\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Fitness       : -113,2600\r\n"
+      "  Fitness       : -88,2500\r\n"
      ]
     },
     {
@@ -456,7 +571,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    Fitness herite  : -113,2600\r\n"
+      "    Fitness herite  : -88,2500\r\n"
      ]
     },
     {
@@ -498,7 +613,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    Fitness herite  : -113,2600\r\n"
+      "    Fitness herite  : -88,2500\r\n"
      ]
     },
     {
@@ -526,7 +641,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Valeurs : [93,44, 94,82]\r\n"
+      "  Valeurs : [77,61, 85,64]\r\n"
      ]
     },
     {
@@ -655,10 +770,10 @@
    "id": "subpop-demo",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:30:50.673137Z",
-     "iopub.status.busy": "2026-07-13T00:30:50.672938Z",
-     "iopub.status.idle": "2026-07-13T00:30:50.816333Z",
-     "shell.execute_reply": "2026-07-13T00:30:50.815941Z"
+     "iopub.execute_input": "2026-07-24T14:31:33.240838Z",
+     "iopub.status.busy": "2026-07-24T14:31:33.240611Z",
+     "iopub.status.idle": "2026-07-24T14:31:33.388073Z",
+     "shell.execute_reply": "2026-07-24T14:31:33.387874Z"
     }
    },
    "outputs": [
@@ -820,7 +935,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Genes : [77,96, 91,46]\r\n"
+      "  Genes : [80,41, 76,42]\r\n"
      ]
     },
     {
@@ -951,10 +1066,10 @@
    "id": "eukaryote-run",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:30:50.817703Z",
-     "iopub.status.busy": "2026-07-13T00:30:50.817482Z",
-     "iopub.status.idle": "2026-07-13T00:30:50.994130Z",
-     "shell.execute_reply": "2026-07-13T00:30:50.993770Z"
+     "iopub.execute_input": "2026-07-24T14:31:33.389518Z",
+     "iopub.status.busy": "2026-07-24T14:31:33.389301Z",
+     "iopub.status.idle": "2026-07-24T14:31:33.547187Z",
+     "shell.execute_reply": "2026-07-24T14:31:33.546890Z"
     }
    },
    "outputs": [
@@ -997,7 +1112,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Meilleur chromosome : position=50,00, vitesse=26,44\r\n"
+      "  Meilleur chromosome : position=49,91, vitesse=22,83\r\n"
      ]
     },
     {
@@ -1011,7 +1126,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Distance totale     : 1,4400\r\n"
+      "  Distance totale     : 2,2600\r\n"
      ]
     },
     {
@@ -1122,10 +1237,10 @@
    "id": "comparison-run",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:30:50.995602Z",
-     "iopub.status.busy": "2026-07-13T00:30:50.995366Z",
-     "iopub.status.idle": "2026-07-13T00:30:51.577945Z",
-     "shell.execute_reply": "2026-07-13T00:30:51.577718Z"
+     "iopub.execute_input": "2026-07-24T14:31:33.549206Z",
+     "iopub.status.busy": "2026-07-24T14:31:33.548944Z",
+     "iopub.status.idle": "2026-07-24T14:31:34.036855Z",
+     "shell.execute_reply": "2026-07-24T14:31:34.036455Z"
     }
    },
    "outputs": [
@@ -1168,20 +1283,6 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 0,1400     "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 0,0900     "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
       " 0,0000     "
      ]
     },
@@ -1189,14 +1290,28 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 0,0500     "
+      " 0,0100     "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 0,0500     "
+      " 0,0100     "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 0,0100     "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 0,0000     "
      ]
     },
     {
@@ -1217,35 +1332,35 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 3,4100     "
+      " 1,4100     "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 0,3000     "
+      " 2,0400     "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 1,0300     "
+      " 1,8600     "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 0,0900     "
+      " 0,6300     "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 0,4100     "
+      " 7,3100     "
      ]
     },
     {
@@ -1266,21 +1381,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Uniforme moyenne  : 0,0660\r\n"
+      "  Uniforme moyenne  : 0,0060\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Heterogene moyenne: 1,0480\r\n"
+      "  Heterogene moyenne: 2,6500\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Amelioration      : -1487,9%\r\n"
+      "  Amelioration      : -44066,7%\r\n"
      ]
     },
     {
@@ -1366,6 +1481,158 @@
   },
   {
    "cell_type": "markdown",
+   "id": "measure-hetero-question",
+   "metadata": {},
+   "source": [
+    "### Mesure : la configuration Default+NoOp peut-elle gagner ?\n",
+    "\n",
+    "La cellule precedente montre l'heterogene (Default+NoOp) perdante d'environ 150x sur le cone lisse. La prose ci-dessus suggerait que l'heterogene devient pertinente \"quand les dimensions ont des caracteristiques tres differentes\". Verifions cette affirmation **empiriquement** : construisons un paysage ou la position est **rugueuse** (Rastrigin1D, nombreux optima locaux) et la vitesse est un **pic etroit** (Gaussienne centree en 25), puis comparons Default+NoOp vs Default+Default en balayant la largeur du pic. Si l'heterogene a un avantage structurel, il devrait apparaitre sur au moins une de ces largeurs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "measure-hetero-experiment",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-24T14:31:34.038195Z",
+     "iopub.status.busy": "2026-07-24T14:31:34.037969Z",
+     "iopub.status.idle": "2026-07-24T14:31:34.874089Z",
+     "shell.execute_reply": "2026-07-24T14:31:34.873853Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Paysage : position=Rastrigin1D (rugueux), vitesse=pic Gaussien etroit en 25\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Objectif combine (lower = better). Moyenne sur 3 runs, 50 generations.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "----------------------------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "sigma    Uniform        Hetero         Gagnant     \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "----------------------------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0,5      0,001          4,916          Uniform     \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1        0,027          4,758          Uniform     \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2        0,014          1,296          Uniform     \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5        0,017          1,268          Uniform     \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "----------------------------------------------------\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Mesure empirique : Default+NoOp (heterogene) vs Default+Default (uniforme)\n",
+    "// sur un paysage position-rugueuse + vitesse-pic-etroit, en balayant sigma (largeur du pic).\n",
+    "// Reutilise BuildEukaryote() (Default+NoOp) et BuildEukaryoteUniform() (Default+Default)\n",
+    "// definis dans la cellule de setup.\n",
+    "double Rastrigin1D(double x) => 10.0 + (x - 50) * (x - 50) - 10.0 * Math.Cos(2 * Math.PI * (x - 50));\n",
+    "double PeakMiss(double v, double sigma) => 1.0 - Math.Exp(-((v - 25) / sigma) * ((v - 25) / sigma));\n",
+    "\n",
+    "// Objectif combine (lower = better) : Rastrigin/100 (position) + PeakMiss*10 (vitesse)\n",
+    "double RunObjective(IMetaHeuristic mh, double sigma)\n",
+    "{\n",
+    "    var adam = new FloatingPointChromosome(new double[] { 0, 0 }, new double[] { 100, 100 }, new int[] { 16, 16 }, new int[] { 2, 2 });\n",
+    "    var pop = new MetaPopulation(40, 40, adam);\n",
+    "    var ga = new MetaGeneticAlgorithm(pop,\n",
+    "        new FuncFitness(c =>\n",
+    "        {\n",
+    "            var g = ((FloatingPointChromosome)c).ToFloatingPoints();\n",
+    "            return -(Rastrigin1D(g[0]) / 100.0 + PeakMiss(g[1], sigma) * 10.0);\n",
+    "        }),\n",
+    "        new EliteSelection(), new UniformCrossover(0.5f), new UniformMutation(true), mh);\n",
+    "    ga.Termination = new GenerationNumberTermination(50);\n",
+    "    ga.Start();\n",
+    "    var b = ((FloatingPointChromosome)ga.BestChromosome).ToFloatingPoints();\n",
+    "    return Rastrigin1D(b[0]) / 100.0 + PeakMiss(b[1], sigma) * 10.0;\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"Paysage : position=Rastrigin1D (rugueux), vitesse=pic Gaussien etroit en 25\");\n",
+    "Console.WriteLine(\"Objectif combine (lower = better). Moyenne sur 3 runs, 50 generations.\");\n",
+    "Console.WriteLine(new string('-', 52));\n",
+    "Console.WriteLine(string.Format(\"{0,-8} {1,-14} {2,-14} {3,-12}\", \"sigma\", \"Uniform\", \"Hetero\", \"Gagnant\"));\n",
+    "Console.WriteLine(new string('-', 52));\n",
+    "foreach (var sigma in new double[] { 0.5, 1.0, 2.0, 5.0 })\n",
+    "{\n",
+    "    double u = 0, h = 0;\n",
+    "    for (int i = 0; i < 3; i++)\n",
+    "    {\n",
+    "        u += RunObjective(BuildEukaryoteUniform(), sigma) / 3.0;\n",
+    "        h += RunObjective(BuildEukaryote(), sigma) / 3.0;\n",
+    "    }\n",
+    "    Console.WriteLine(string.Format(\"{0,-8} {1,-14:F3} {2,-14:F3} {3,-12}\", sigma, u, h, u < h ? \"Uniform\" : \"Hetero\"));\n",
+    "}\n",
+    "Console.WriteLine(new string('-', 52));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "measure-hetero-interpretation",
+   "metadata": {},
+   "source": [
+    "### Interpretation : NoOp est un handicap structurel, pas une specialisation\n",
+    "\n",
+    "**Resultat** : sur **chaque** largeur de pic (sigma 0.5 a 5), l'uniforme (Default+Default) bat l'heterogene (Default+NoOp). La vitesse figee par `NoOpMetaHeuristic` ne peut pas atteindre un pic etroit que la vitesse evoluee (`DefaultMetaHeuristic`) rejoint systematiquement : l'elitisme combine au crossover fait converger Default vers la cible meme sous mutation, tandis que NoOp fige la vitesse a sa valeur initiale et ne peut l'ameliorer.\n",
+    "\n",
+    "**Conclusion mesuree** : le couplage Default+NoOp utilise dans ce notebook est **structurellement desavantage** sur toute dimension a cible unique. Il ne peut donc PAS illustrer la victoire heterogene decrite dans la prose ci-dessus. L'ecart de -15000% observe sur le cone lisse n'est pas un defaut du moteur eukaryote : c'est la consequence attendue d'avoir assigne `NoOpMetaHeuristic` (une non-strategie) a une dimension qui aurait besoin d'evoluer.\n",
+    "\n",
+    "**Quand l'heterogene gagne vraiment** : il faut une **specialisation reelle** des sous-heuristiques -- une exploration forte (mutation amplifiee) sur une partition au paysage rugueux, et une exploitation fine (faible mutation) sur une partition au paysage lisse. Ce genre de specialisation par partition est precisement l'objet de l'**Exercice 3** (implementer un `SubPopulationMetaHeuristic` personnalise). Le demo ci-dessus, lui, isole proprement l'effet de chaque sous-heuristique par partition -- capacite distinctive de l'eukaryote -- et montre que NoOp est un point de comparaison (le pire cas), pas une strategie gagnante."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "section-5-summary",
    "metadata": {},
    "source": [
@@ -1417,14 +1684,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "exercise-1-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:30:51.579685Z",
-     "iopub.status.busy": "2026-07-13T00:30:51.579447Z",
-     "iopub.status.idle": "2026-07-13T00:30:51.624126Z",
-     "shell.execute_reply": "2026-07-13T00:30:51.623953Z"
+     "iopub.execute_input": "2026-07-24T14:31:34.876029Z",
+     "iopub.status.busy": "2026-07-24T14:31:34.875759Z",
+     "iopub.status.idle": "2026-07-24T14:31:34.942446Z",
+     "shell.execute_reply": "2026-07-24T14:31:34.942011Z"
     }
    },
    "outputs": [
@@ -1493,14 +1760,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "exercise-2-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:30:51.625473Z",
-     "iopub.status.busy": "2026-07-13T00:30:51.625251Z",
-     "iopub.status.idle": "2026-07-13T00:30:51.686884Z",
-     "shell.execute_reply": "2026-07-13T00:30:51.686552Z"
+     "iopub.execute_input": "2026-07-24T14:31:34.943896Z",
+     "iopub.status.busy": "2026-07-24T14:31:34.943720Z",
+     "iopub.status.idle": "2026-07-24T14:31:34.975967Z",
+     "shell.execute_reply": "2026-07-24T14:31:34.975599Z"
     }
    },
    "outputs": [
@@ -1557,14 +1824,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "exercise-3-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:30:51.688751Z",
-     "iopub.status.busy": "2026-07-13T00:30:51.688525Z",
-     "iopub.status.idle": "2026-07-13T00:30:51.719698Z",
-     "shell.execute_reply": "2026-07-13T00:30:51.719496Z"
+     "iopub.execute_input": "2026-07-24T14:31:34.977719Z",
+     "iopub.status.busy": "2026-07-24T14:31:34.977496Z",
+     "iopub.status.idle": "2026-07-24T14:31:35.010502Z",
+     "shell.execute_reply": "2026-07-24T14:31:35.010314Z"
     }
    },
    "outputs": [


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2024:CoursIA-2 — prev: MED/readme (c.857, Part4 leaf README)

## What

Prong-B (sota-not-workaround) on `Search/Part4-Metaheuristics/MGS-3-Eukaryote.ipynb`. The notebook demonstrates `EukaryoteMetaHeuristic` (MetaGeneticSharp's heterogeneous multi-sub-population GA) on a **degenerate 2D L1 cone** `f(x,v)=-(|x-50|+|v-25|)`, where the engine's distinctive capability (per-partition sub-heuristics) is **counterproductive**: the heterogeneous config (Default+NoOp) loses to uniform (Default+Default) by **~150×** on re-execution (`Amelioration: -15000%`). The notebook's own prose (cell `interp-comparison`) *describes* when heterogeneous wins — *"l'eukaryote montre tout son potentiel sur des problèmes ou les dimensions ont des caractéristiques très différentes"* — but **never demonstrates it**. The engine's headline capability is asserted, not shown. See #3801.

## The measured finding (anti-fabrication c.598 honored — pitched, then MEASURED)

The obvious Prong-B fix is "construct a landscape where heterogeneous wins". I tested that hypothesis empirically **before** shipping it. Added a code cell that builds a landscape with genuinely different partition character — **rugged position** (Rastrigin1D, many local optima) + **narrow velocity peak** (Gaussian at 25) — and compares Default+NoOp vs Default+Default across a σ-sweep (pic width 0.5→5), 3 runs each:

| σ (pic width) | Uniform (Default+Default) | Hetero (Default+NoOp) | Winner |
|---------------|---------------------------|-----------------------|--------|
| 0.5 | **0.001** | 4.916 | Uniform |
| 1.0 | **0.027** | 4.758 | Uniform |
| 2.0 | **0.014** | 1.296 | Uniform |
| 5.0 | **0.017** | 1.268 | Uniform |

**Uniform wins every σ.** The hypothesis was **falsified firsthand**: `NoOpMetaHeuristic` is a **structural handicap, not a specialization**. Frozen velocity (NoOp) cannot reach a target that evolving velocity (Default) rejoins systematically — elitism + crossover converge Default to the peak even under `UniformMutation(true)`, while NoOp freezes velocity at its initial value and cannot improve it. So the notebook's Default+NoOp pairing **cannot, by construction, showcase a heterogeneous win**; the -15000% on the cone is the *expected* consequence of assigning a non-strategy (NoOp) to a dimension that needs to evolve.

This is exactly the c.598 discipline applied to the *reframe itself*: a Prong-B "make heterogeneous win" complexification pitched on plausible reasoning would have shipped a **wrong/fabricated demonstration**. Measuring first prevented that.

## Fix (markdown + 1 executed code cell, fichier-entier §E-aligned)

3 cells inserted after `interp-comparison`:
- **`measure-hetero-question`** (md): frames the empirical question — does the "dimensions très différentes" claim hold for Default+NoOp?
- **`measure-hetero-experiment`** (code, executed): the σ-sweep above, reusing the notebook's own `BuildEukaryote()`/`BuildEukaryoteUniform()` factories. Real committed output (ec=7).
- **`measure-hetero-interpretation`** (md): states the measured NoOp-is-handicap finding, frames the -15000% as expected (not an engine flaw), and points to **Exercise 3** (custom `SubPopulationMetaHeuristic`) as where a genuine heterogeneous win — exploration-heavy sub-heuristic on a rugged partition + exploitation-heavy on a smooth one — actually lives.

The grain showcases the engine's **per-partition isolation** capability (you can isolate each sub-heuristic's effect independently by partition — that's the experiment's mechanism) while honestly recording that the *current demo config* (Default+NoOp) is a worst-case comparator, not a winning strategy.

### Scope

- 1 file. `git diff --stat` = 327 ins / 60 del. **Byte-surgical at source level**: 0 original cell sources changed (all 25 preserved byte-identical), only 3 cells added (verified by id-diff). The 60 deletions are legitimate **stochastic GA-output refresh** on re-execution (cone `cell[15]` uniform avg 0.0660→0.0060 — same qualitative result, uniform still beats hetero on the cone) + 9 `probeAddresses` banner lines stripped via the canonical `strip_probe_banner.py --apply` tool (L732, not hand-edited).
- Re-execution required (C.2): added a code cell mid-notebook → nbconvert runs top-to-bottom → stochastic cells refresh. Documented honestly.
- nbformat.validate OK · H.3 PASS (10 code cells, all `ec != null` + outputs) · C.1 clean (0 `raise NotImplementedError`/`assert False`/`1/0`).

## SOTA verdict — RECOVERABLE-LOCAL (documented honestly)

The notebook `#r`-loads MetaGeneticSharp + GeneticSharp DLLs from the `Search/MetaGeneticSharp` submodule build (`dotnet build ../MetaGeneticSharp.sln`, prereq: nested `GeneticSharp` submodule). **Source build is currently blocked upstream**: the pinned GeneticSharp commit `e15ee828` is unfetchable from `giacomelli/GeneticSharp` (force-push removed it — only a dangling commit pointer remains, tree objects missing: `fatal: unable to read tree`). I used **genuine version-matched prebuilt binaries** from a prior successful build (`C:/dev/MetaGeneticSharp`) — **identical SHAs**: MGS `0433fad0` + GeneticSharp `e15ee828` (both byte-pinned to what my worktree checked out). This is **not** a workaround/toy-reimplementation: the real SOTA engine executed and produced real outputs. #3103 N/A — the *notebook* is tracked in main (not a submodule); I did not modify the submodule's source, only loaded its genuine binaries. If a reviewer wants a fresh source build, that requires re-pinning GeneticSharp to a fetchable commit (separate infra issue).

## L898 / collision check

- `gh pr list --search "MGS-3 OR Eukaryote"` = 0 OPEN touching the eukaryote engine/fitness. Only MGS-3 PR is #7609 (prereq markdown portability, MERGED — paths, unrelated). No collision.

## Variation note

1st `notebook-dotnet` grain after `readme` (c.857) and `audit-claims`/python (c.856). G-VAR-3 OK (genre change). MED not LIGHT per litmus: the σ-sweep experiment required running 24 GA configurations and **discovering** that NoOp-is-handicap — not scan-generatable (a scan cannot produce a falsified hypothesis + measured table). Honors ai-01 standing steer msg-20260724T105816 ("reste sur du DEEP... pioche le prochain notebook où un moteur tourne sur un cas dégénéré ou une claim de convergence/perf non mesurée, et reframe/**mesure**") — this is precisely reframe+mesure on a degenerate metaheuristic demo. Honest about scope: this documents *why* the demo is degenerate (measured) rather than manufacturing a win; a genuine heterogeneous-win showcase needs the custom sub-heuristic of Exercise 3 and is teed up as a follow-up.

See #3801 · See #3103 · See #8052
