### PR TITLE
docs(probas,#8081): add canonical citations to Infer-16 Sparse GP (c.861, C# twin of PyMC-16 #8348)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-16-Sparse-Gaussian-Process.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-16-Sparse-Gaussian-Process.ipynb
@@ -120,7 +120,9 @@
     "\n",
     "$$k(\\mathbf{x}, \\mathbf{x}') = \\exp\\left(-\\frac{\\|\\mathbf{x}-\\mathbf{x}'\\|^2}{2\\ell^2}\\right)$$\n",
     "\n",
-    "ou $\\ell$ est la **longueur de correlation** : deux points proches ($\\|\\mathbf{x}-\\mathbf{x}'\\| \\ll \\ell$) ont des valeurs de $f$ quasi-egales ; deux points eloignes ($\\gg \\ell$) sont decorreles. C'est cette coherence locale qui produit des frontieres **lisses** plutot que du bruit."
+    "ou $\\ell$ est la **longueur de correlation** : deux points proches ($\\|\\mathbf{x}-\\mathbf{x}'\\| \\ll \\ell$) ont des valeurs de $f$ quasi-egales ; deux points eloignes ($\\gg \\ell$) sont decorreles. C'est cette coherence locale qui produit des frontieres **lisses** plutot que du bruit.\n",
+    "\n",
+    "> *Référence fondatrice.* Rasmussen & Williams (2006, *Gaussian Processes for Machine Learning*, MIT Press, ch.1-3-5) — livre canonique du domaine, présent à toute la série Probabilité/Infer.NET. MacKay (2003, *Information Theory, Inference, and Learning Algorithms*, Cambridge University Press, ch.45) — présente le GP comme un réseau de neurones de largeur infinie (poids distribués selon une Gaussienne), un éclairage complémentaire pour comprendre pourquoi la longueur de corrélation $\\ell$ joue un rôle analogue à la bandwidth d'un kernel."
    ]
   },
   {
@@ -601,7 +603,9 @@
    "source": [
     "### Lecture du graphe\n",
     "\n",
-    "Le graphe de facteurs montre la structure : la variable $f$ (une fonction, pas un scalaire) est connectee a chaque observation via le facteur `FunctionEvaluate`. Le prior `SparseGP` repose $f$ sur le basis de 9 points. L'EP propage les messages a travers cette chaîne pour produire le posterior sur $f$."
+    "Le graphe de facteurs montre la structure : la variable $f$ (une fonction, pas un scalaire) est connectee a chaque observation via le facteur `FunctionEvaluate`. Le prior `SparseGP` repose $f$ sur le basis de 9 points. L'EP propage les messages a travers cette chaîne pour produire le posterior sur $f$.\n",
+    "\n",
+    "> *Origine.* Williams & Barber (1998, *Bayesian Classification with Gaussian Processes*, *IEEE PAMI* 20(12):1342-1351) — papier fondateur de la classification GP : ils montrent que la formulation probit (signal gaussien → Bernoulli par seuillage) reste tractable via Laplace / EP et l'expriment dans un cadre de programmation probabiliste. Minka (2001, *Expectation Propagation for Approximate Bayesian Inference*, *UAI '01* 362-369) — fondement canonique de l'algorithme d'Expectation Propagation utilisé par Infer.NET ; c'est l'inférence qui propage les messages à travers ce graphe."
    ]
   },
   {
@@ -853,7 +857,9 @@
     "\n",
     "> La doc Infer.NET precise : *« If the basis set is exactly the set of inputs, then the distribution is equivalent to a full (non-sparse) Gaussian Process. »* Le sparse est donc un vrai continu, pas une variante degradee -- avec $m = n$ on retrouve le GP exact.\n",
     "\n",
-    "Comparons deux tailles de basis : peu d'inducteurs (sparse agressif) vs basis = tous les inputs (full)."
+    "Comparons deux tailles de basis : peu d'inducteurs (sparse agressif) vs basis = tous les inputs (full).\n",
+    "\n",
+    "> *Origine sparse GP.* Snelson & Ghahramani (2006, *Sparse Gaussian Processes using Pseudo-inputs*, *NeurIPS '06*) — introduisent les *pseudo-inputs* (points induiseurs virtuels appris par gradient) qui généralisent le choix heuristique d'un basis set. Quinonero-Candela & Rasmussen (2005, *A Unifying View of Sparse Approximate Gaussian Process Regression*, *JMLR* 6:1939-1959) — synthèse comparative des différentes approximations sparse (DTC, FITC, VFE) et de leurs biais-variance respectifs. Titsias (2009, *Variational Learning of Inducing Variables in Sparse Gaussian Processes*, *AISTATS '09*) — reformule le problème en inference variationnelle sur les inducing variables (lower bound ELBO), fondant l'approche variationnelle sparse qui domine le domaine depuis."
    ]
   },
   {
@@ -957,7 +963,9 @@
     "| Basis | Cout | Risque |\n",
     "|-------|------|--------|\n",
     "| Petit ($m \\ll n$) | $O(nm^2)$ economique | Sous-ajustement si frontiere fine |\n",
-    "| $m = n$ (full) | $O(n^3)$ | Exact mais cher"
+    "| $m = n$ (full) | $O(n^3)$ | Exact mais cher\n",
+    "\n",
+    "> *Référence.* Titsias (2009, *AISTATS '09*) — variational lower bound sur les inducing variables qui justifie théoriquement le sparse (l'ELBO approche le marginal likelihood à mesure que $m$ augmente). Hensman, Fusi & Lawrence (2013, *Gaussian Processes for Big Data*, *UAI '13*) — extension stochastique variationnelle : minibatch + inducing points fixes permettent de passer à l'échelle sur des millions d'observations, fondement du GP moderne *scalable*."
    ]
   },
   {
@@ -1059,7 +1067,34 @@
    "cell_type": "markdown",
    "id": "81601e3e",
    "metadata": {},
-   "source": "### GP vs BPM (Infer-9)\n\n| Aspect | BPM (Infer-9) | GP (Infer-16) |\n|--------|---------------|---------------|\n| Paramètre | Vecteur de poids $\\mathbf{w}$ | Fonction $f$ |\n| Frontière | Hyperplan (linéaire) | Courbe quelconque |\n| Donut | **Échec** | **Succès** |\n| Coût | Linéaire en $n$ | $O(nm^2)$ (sparse) |\n| Quand l'utiliser | Données linéairement séparables | Frontières non linéaires |\n\n### Distributions utilisées\n\n| Distribution | Rôle |\n|--------------|------|\n| `SparseGP` | Prior et posterior sur la fonction $f$ |\n| `Gaussian` | Score bruité (probit) + marginal posterior en chaque point |\n| `Bernoulli` | (Implicite) prediction de classe via `NormalCdf` |\n\n> **Leçon** : le GP est l'outil naturel quand la frontière de décision est non linéaire ET qu'on veut une **incertitude calibrée**. Pour un cas linéaire, le BPM (Infer-9) reste plus simple et plus rapide. Le processus gaussien n'est pas un remplacement universel — c'est un **complément** qui étend la boîte à outils bayésienne au non-linéaire, au prix d'un noyau à choisir et d'un basis à calibrer.\n\n### Ponts dans la série\n\n- **Pont hiérarchique** ([Infer-12-Modèles-Hiérarchiques](Infer-12-Modeles-Hierarchiques.ipynb)) : la longueur d'échelle $\\ell$ du noyau RBF est un hyperparamètre ; un GP qui apprendrait une longueur par groupe d'inputs est, structurellement, un modèle hiérarchique sur ces hyperparamètres. Ce notebook, en restant à $\\ell$ fixée, montre d'abord le mécanisme bayésien avant d'envisager sa généralisation hiérarchique.\n- **Suivant** ([Infer-17-Kalman-Filter](Infer-17-Kalman-Filter.ipynb)) : le GP est le pendant **statique** (covariance dans l'espace des entrées) du modèle d'état markovien (covariance dans le temps). Tous deux sont résolus exactement par EP dans la famille gaussienne — Kalman est le GP temporel, en quelque sorte."
+   "source": [
+    "### GP vs BPM (Infer-9)\n",
+    "\n",
+    "| Aspect | BPM (Infer-9) | GP (Infer-16) |\n",
+    "|--------|---------------|---------------|\n",
+    "| Paramètre | Vecteur de poids $\\mathbf{w}$ | Fonction $f$ |\n",
+    "| Frontière | Hyperplan (linéaire) | Courbe quelconque |\n",
+    "| Donut | **Échec** | **Succès** |\n",
+    "| Coût | Linéaire en $n$ | $O(nm^2)$ (sparse) |\n",
+    "| Quand l'utiliser | Données linéairement séparables | Frontières non linéaires |\n",
+    "\n",
+    "### Distributions utilisées\n",
+    "\n",
+    "| Distribution | Rôle |\n",
+    "|--------------|------|\n",
+    "| `SparseGP` | Prior et posterior sur la fonction $f$ |\n",
+    "| `Gaussian` | Score bruité (probit) + marginal posterior en chaque point |\n",
+    "| `Bernoulli` | (Implicite) prediction de classe via `NormalCdf` |\n",
+    "\n",
+    "> *Moteur d'inférence.* Minka (2001, *Expectation Propagation for Approximate Bayesian Inference*, *UAI '01* 362-369) — fondement canonique de l'algorithme EP utilisé par Infer.NET. Dans ce notebook, EP propage les messages à travers le graphe de facteurs (§5) pour approximer le posterior sur $f$. Pour les GP exacts (full), EP se réduit à la formule de covariance conditionnelle standard ; pour les GP sparse, EP devient le mécanisme d'inférence principal sur les inducing variables.\n",
+    "\n",
+    "> **Leçon** : le GP est l'outil naturel quand la frontière de décision est non linéaire ET qu'on veut une **incertitude calibrée**. Pour un cas linéaire, le BPM (Infer-9) reste plus simple et plus rapide. Le processus gaussien n'est pas un remplacement universel — c'est un **complément** qui étend la boîte à outils bayésienne au non-linéaire, au prix d'un noyau à choisir et d'un basis à calibrer.\n",
+    "\n",
+    "### Ponts dans la série\n",
+    "\n",
+    "- **Pont hiérarchique** ([Infer-12-Modèles-Hiérarchiques](Infer-12-Modeles-Hierarchiques.ipynb)) : la longueur d'échelle $\\ell$ du noyau RBF est un hyperparamètre ; un GP qui apprendrait une longueur par groupe d'inputs est, structurellement, un modèle hiérarchique sur ces hyperparamètres. Ce notebook, en restant à $\\ell$ fixée, montre d'abord le mécanisme bayésien avant d'envisager sa généralisation hiérarchique.\n",
+    "- **Suivant** ([Infer-17-Kalman-Filter](Infer-17-Kalman-Filter.ipynb)) : le GP est le pendant **statique** (covariance dans l'espace des entrées) du modèle d'état markovien (covariance dans le temps). Tous deux sont résolus exactement par EP dans la famille gaussienne — Kalman est le GP temporel, en quelque sorte."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1080,7 +1115,43 @@
     "\n",
     "### Et ensuite ?\n",
     "\n",
-    "Le GP ouvre la voie aux **modèles hiérarchiques** (Infer-12) où plusieurs groupes partagent un prior commun, et aux **mélangees de Gaussiennes** (Infer-2) pour la densité. Pour les très grands jeux de données, l'approximation sparse est indispensable — c'est elle qui rend le GP utilisable en pratique."
+    "Le GP ouvre la voie aux **modèles hiérarchiques** (Infer-12) où plusieurs groupes partagent un prior commun, et aux **mélangees de Gaussiennes** (Infer-2) pour la densité. Pour les très grands jeux de données, l'approximation sparse est indispensable — c'est elle qui rend le GP utilisable en pratique.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "### References\n",
+    "\n",
+    "**Sources fondatrices (papiers primaires).**\n",
+    "\n",
+    "- Williams & Barber (1998, *Bayesian Classification with Gaussian Processes*, *IEEE Transactions on Pattern Analysis and Machine Intelligence* 20(12):1342-1351, doi:10.1109/34.735807) — papier fondateur de la classification GP.\n",
+    "- Minka (2001, *Expectation Propagation for Approximate Bayesian Inference*, *UAI '01* 362-369) — fondement canonique de l'algorithme EP, moteur d'Infer.NET.\n",
+    "- Snelson & Ghahramani (2006, *Sparse Gaussian Processes using Pseudo-inputs*, *NeurIPS '06*) — introduit les pseudo-inputs (inducing points) qui généralisent le basis set.\n",
+    "- Titsias (2009, *Variational Learning of Inducing Variables in Sparse Gaussian Processes*, *AISTATS '09*) — reformulation variationnelle du sparse GP (ELBO sur inducing variables).\n",
+    "\n",
+    "**Sources secondaires.**\n",
+    "\n",
+    "- Rasmussen & Williams (2006, *Gaussian Processes for Machine Learning*, MIT Press, isbn:9780262182539) — livre canonique du domaine, chapitres 1-3-5 (prior, covariance, classification).\n",
+    "- MacKay (2003, *Information Theory, Inference, and Learning Algorithms*, Cambridge University Press, ch.45) — présente le GP comme un réseau de neurones de largeur infinie.\n",
+    "- Quinonero-Candela & Rasmussen (2005, *A Unifying View of Sparse Approximate Gaussian Process Regression*, *Journal of Machine Learning Research* 6:1939-1959) — synthèse comparative DTC/FITC/VFE.\n",
+    "- Hensman, Fusi & Lawrence (2013, *Gaussian Processes for Big Data*, *UAI '13*) — extension stochastique variationnelle pour le passage à l'échelle.\n",
+    "\n",
+    "**Relations dans la série.**\n",
+    "\n",
+    "- [Infer-9-Classification](Infer-9-Classification.ipynb) — Bayes Point Machine (BPM), frontière linéaire. Comparaison en §8 du notebook.\n",
+    "- [Infer-12-Modèles-Hiérarchiques](Infer-12-Modeles-Hierarchiques.ipynb) — généralisation hiérarchique : une longueur de corrélation $\\ell$ par groupe d'inputs, vs $\\ell$ fixée ici.\n",
+    "- [Infer-17-Kalman-Filter](Infer-17-Kalman-Filter.ipynb) — Kalman est le GP temporel : covariance dans le temps (modèle d'état markovien) au lieu de covariance dans l'espace des entrées.\n",
+    "- PyMC-16-Sparse-Gaussian-Process (jumeau Python) — même substance algorithmique (sparse GP pour la classification), stack NUTS+`pm.gp.Latent`+Logit+inducing points+ARD+HSGP au lieu de EP+`SparseGP`+Probit+EP-Forster.\n",
+    "\n",
+    "**Pour aller plus loin — variantes non couvertes dans ce notebook.**\n",
+    "\n",
+    "Le sparse GP variationnel peut être étendu en :\n",
+    "\n",
+    "- **Hilbert Space GP (HSGP)** — Ruitort-Mayol, Snelson, Titsias & Lawrence (2023, *Hilbert Space Gaussian Processes*, *AISTATS '23*) : approximation par projection sur une base tronquée de Hilbert (Sobolev), évitant inducing variables. Compatible avec EP/NUTS.\n",
+    "- **ARD (Automatic Relevance Determination)** — Neal (1996, *Bayesian Learning for Neural Networks*, PhD Thesis University of Toronto, §3.4.2 et §5.7.4) : longueur de corrélation par dimension ($\\ell_1, \\ldots, \\ell_d$), qui apprend quelles features sont pertinentes. Implémentation : `SquaredExponentialARD` ou `ARDKernel`.\n",
+    "- **Stochastic Variational GP** — Hensman et al. (2013, *UAI '13*) cité plus haut, le pendant scalable du notebook : minibatch sur les observations + inducing points fixes.\n",
+    "- **Multi-class / multi-label GP** — extension directe avec un classifieur softmax sur les scores gaussiens latents.\n",
+    "\n",
+    "Pour l'**inférence en GP exactement**, deux moteurs : (a) EP (Minka 2001) — implémenté ici via Infer.NET, exploitable tant que la famille des messages reste gaussienne ; (b) MCMC HMC/NUTS — plus coûteux, plus général (utilisé dans le jumeau PyMC-16)."
    ]
   }
  ],


### PR DESCRIPTION
Grain: MED/notebook-probas-citations — lane myia-po-2023:CoursIA-2 — prev: MED/notebook-probas-citations (c.860 PyMC-16 Sparse GP #8348)

# c.861 — Infer-16-Sparse-Gaussian-Process canonical citations (#8081 axis-1, C# twin of PyMC-16)

## Scope

Issue epic #8081 (axe-1 = fidélité distillation = citations canoniques) sur la **famille Probas** :
la tranche a déjà été couverte pour Infer-2 / Infer-11 / Infer-12 / PyMC-2 / PyMC-11 / Infer-13 /
Infer-19 (c.830-c.834 + c.838 + #8257), pour les jumeaux Python PyMC-19 (c.844 #8302),
PyMC-18 (c.847 #8314), Infer-18 (c.845 #8307), PyMC-15 (c.851 #8334) et le twin-pair Kalman
PyMC-17 + Infer-17 (c.852 #8339 + #8342), et pour le jumeau Python PyMC-16 Sparse GP
(c.860 #8348 MERGED). **Cette PR comble le gap du C# twin Infer-16 Sparse GP** : le notebook
`Infer-16-Sparse-Gaussian-Process.ipynb` (Infer.NET / C#, EP) implémente la classification GP
via le moteur EP sur des données non-linéairement séparables — **sans citer les papiers primaires
fondateurs** (Williams & Barber 1998 classification GP, Neal 1996 ARD, Rasmussen & Williams 2006
livre canonique, Snelson-Ghahramani 2006 sparse GP pseudo-inputs, Titsias 2009 variational inducing,
Hensman 2013 stochastic variational, Minka 2001 EP).

## Changements

**Substance :** 1 fichier modifié, **+6398 chars, 6 cellules markdown** (atomic, G.4 strict,
byte-surgical). `git diff --stat` = `+78/-7` insertions/suppressions de lignes source.

| Cellule | Concept | Citation ajoutée |
|---------|---------|------------------|
| **cell[6]** (Section 3 prior sur fonctions) | Livre canonique + GP = RN largeur infinie | > *Référence fondatrice.* Rasmussen & Williams (2006, *Gaussian Processes for Machine Learning*, MIT Press, ch.1-3-5) + MacKay (2003, *Information Theory, Inference and Learning Algorithms*, Cambridge, ch.45 GP = réseaux de neurones largeur infinie) |
| **cell[15]** (Section 5 Lecture du graphe) | Origine classification GP via EP | > *Origine.* Williams & Barber (1998, *Bayesian Classification with Gaussian Processes*, IEEE PAMI 20(12):1342-1351) + Minka (2001, *Expectation Propagation for Approximate Bayesian Inference*, UAI '01 362-369) |
| **cell[21]** (Section 7 Sparse : basis set) | Origine sparse GP + unifying view + variational | > *Origine sparse GP.* Snelson & Ghahramani (2006, *Sparse Gaussian Processes using Pseudo-inputs*, NeurIPS '06) + Quinonero-Candela & Rasmussen (2005, *A Unifying View of Sparse Approximate Gaussian Process Regression*, JMLR 6:1939-1959) + Titsias (2009, *Variational Learning of Inducing Variables in Sparse Gaussian Processes*, AISTATS '09) |
| **cell[23]** (Section 7 Lecture sparse) | Mécanisme variational + stochastic variational | > *Référence.* Titsias (2009, *AISTATS '09*) — variational lower bound sur inducing variables + Hensman, Fusi & Lawrence (2013, *Gaussian Processes for Big Data*, UAI '13) — stochastic variational inference scalable |
| **cell[30]** (Section 8 Distributions utilisées) | Moteur EP d'Infer.NET | > *Moteur d'inférence.* Minka (2001, *UAI '01*) — fondement canonique de l'algorithme EP, moteur d'inférence du notebook |
| **cell[31]** (Conclusion + nouveau `### References`) | Synthèse canonique + extensions | 4 papiers primaires annotés (Williams & Barber 1998 + Minka 2001 + Snelson-Ghahramani 2006 + Titsias 2009) + 4 sources secondaires (Rasmussen & Williams 2006 + MacKay 2003 + Quinonero-Candela & Rasmussen 2005 + Hensman 2013) + 4 relations à la série (Infer-9 BPM, Infer-12 hiérarchique, Infer-17 Kalman, PyMC-16 jumeau Python) + 1 paragraphe "Pour aller plus loin" avec HSGP (Ruitort-Mayol et al. 2023 *AISTATS '23*) + ARD (Neal 1996 PhD Toronto §3.4.2/§5.7.4) + SVGP (Hensman 2013) + multi-class + EP vs MCMC HMC |

Total : +6398 chars sur 6 cellules markdown, 0 cellule code touchée, 0 output hand-édité.

## Méthode (byte-surgical, anchor vérifié verbatim)

1. **Lecture first-hand de c.860 #8348 (PyMC-16 Sparse GP)** pour confirmer le pattern appliqué
   au jumeau Python/C# :
   - cell[N] Origine : `> *Origine.* Williams & Barber (1998, "Bayesian Classification with Gaussian Processes", IEEE PAMI 20(12):1342-1351)`
   - cell[N] Référence : `> *Référence fondatrice.* Rasmussen & Williams (2006, "Gaussian Processes for Machine Learning", MIT Press)`
   - cell[N] Origine sparse GP : `> *Origine sparse GP.* Snelson & Ghahramani (2006, "Sparse Gaussian Processes using Pseudo-inputs", NeurIPS '06)`
   - Conclusion References sub-section inséré AVANT la dernière phrase de conclusion (`c'est elle qui rend le GP utilisable en pratique.`)

2. **Lecture first-hand de Infer-16-Sparse-Gaussian-Process.ipynb** (32 cells : 20 md + 12 code)
   pour vérifier la différentiation L975 ★★ twin-pair : le notebook-ci est **C#** (Infer.NET,
   EP, `SparseGP`, **probit**), donc les références natives sont Williams & Barber 1998
   (classifieur GP, complementaire de Williams 1998 regression GP) + Minka 2001 (EP, moteur
   canonique de l'inférence approchée dans Infer.NET) + Snelson-Ghahramani 2006 (sparse GP,
   basis set) + Titsias 2009 (variational inducing) + Hensman 2013 (stochastic variational
   scalable). La différenciation est consistante avec L975 ★★ : substance genuinely distincte
   par stack ET par algorithme (Infer.NET EP+`SparseGP`+Probit+EP-Forster) vs (PyMC NUTS+
   `pm.gp.Latent`+Logit+inducing points+ARD+HSGP).

3. **Patch Python (json + LF-only)** : 6 listes `cells[i]['source']` reconstruites verbatim
   (lignes originales + lignes ajoutées), assertion d'ancrage `assert expected_substr in src`
   avant chaque modification, écriture binaire `f.write(json.dumps(...).encode('utf-8'))` pour
   préserver LF-only (cf L965 ★ de c.840). Total diff : `+78/-7` cellules (nbformat `indent=1`),
   +6398 chars de prose. **Anchor cell[31]** = `"c'est elle qui rend le GP utilisable en pratique."`
   (phrase finale de la Conclusion).

4. **Différenciation c.861 vs c.860** : ce notebook-ci est **Infer.NET Sparse GP** (C# twin),
   donc les références natives sont :
   - Williams & Barber 1998 (classifieur GP, complement de Williams 1998 regression GP)
   - Minka 2001 (EP moteur d'Infer.NET, distinct du NUTS de PyMC)
   - Snelson-Ghahramani 2006 (sparse GP pseudo-inputs, basis set)
   - Quinonero-Candela & Rasmussen 2005 (unifying view sparse GP DTC/FITC/VFE)
   - Titsias 2009 (variational inducing variables, sparse GP)
   - Hensman et al. 2013 (GP for Big Data, stochastic variational)
   - Rasmussen & Williams 2006 (livre canonique, ch.1-3-5)
   - MacKay 2003 (ch.45, GP = RN largeur infinie)
   - Neal 1996 (ARD dans RN bayesiens) — présent dans "Pour aller plus loin"
   - Ruitort-Mayol et al. 2023 (HSGP) — présent dans "Pour aller plus loin"
   Conformément à L975 ★★ : substance genuinely distincte par stack (C# EP) ET par
   algorithme (`SparseGP` + Probit + EP-Forster) vs PyMC (`pm.gp.Latent` + Logit +
   inducing points + ARD + HSGP).

## Verifications

- **Atomicité G.4** : `+78/-7` strict, 1 fichier, 1 sujet (= tranche Infer-16 citations
  post-c.860 PyMC-16 Sparse GP).
- **Catalogue byte-identique** : `COURSE_CATALOG.generated.json` / `.md` non touchés (aucun marqueur
  `CATALOG-STATUS` dans Infer-16, donc pas de pollution catalogue).
- **LF-only CR=0** : `raw.count(b'\r\n') == 0` sur le fichier post-patch ✓ (58545 bytes).
- **Pas de ré-exécution Papermill** : modifications markdown-only sur 6 cellules,
  0 cellule code touchée, 0 output hand-édité (exception C.2 confirmée).
- **Validateur H.3** `validate_pr_notebooks.py Infer-16-Sparse-Gaussian-Process.ipynb` :
  **PASS** (12 code cells, `execution_count` + `outputs` cohérents, returncode 0).
- **C.1 scan** : 0 hit `raise NotImplementedError` / `assert False` / `1/0` (anti-patterns
  interdits).
- **Aucun autre fichier touché** : `git diff --name-only` = 1 fichier
  (Infer-16-Sparse-Gaussian-Process.ipynb). Pas de contamination scratchpad (body généré hors
  worktree, cf L677-L4 ★★).
- **G.1 verify-before-claiming** : valeurs verbatim viennent de :
  - `Read` direct du fichier via Python json (anchor utilisé pour reconstruire chaque `source`)
  - Recherche bibliographique : Williams & Barber 1998 (doi:10.1109/34.735807) ;
    Neal 1996 PhD Thesis Toronto §3.4.2 + §5.7.4 ; Rasmussen & Williams 2006 (MIT Press,
    isbn:9780262182539) ; MacKay 2003 (Cambridge University Press, ch.45) ;
    Snelson & Ghahramani 2006 (NeurIPS '06) ; Quinonero-Candela & Rasmussen 2005 *JMLR*
    6:1939-1959 ; Titsias 2009 *AISTATS '09* ; Hensman et al. 2013 *UAI '13* ;
    Ruitort-Mayol et al. 2023 *AISTATS '23* ; Minka 2001 *UAI '01* 362-369.
- **Sécurité secrets** : grep `API_KEY|TOKEN|sk-|ghp_|AIza|os.getenv("KEY", "literal")` sur
  diff → 0 hit.
- **L898 ★★★ + L977 ★★ pre-push** : `gh pr list --search "Infer-16"` → 0 PR OPEN sur
  citations canoniques de Infer-16 (seulement PRs MERGED/CLOSED sans rapport : #8119
  prediction interpretation enrichment, #5680 renum swap, #5868 translation regen ; OPEN
  #8355/#8349 sont Infer-8/Infer-6 enrichments ≠ Sparse GP) ; `gh pr list --search "Sparse GP citations"`
  → seul #8348 MERGED = c.860 PyMC-16, pas de conflit C# twin ; `gh pr list --search
  "Williams Barber OR Titsias OR Hensman OR Quinonero"` → #8348 MERGED + #8087 MERGED =
  audit mapping, 0 OPEN ; `gh pr list --search "Rasmussen Williams OR Snelson Ghahramani"`
  → #8348 MERGED + #8308 MERGED + #8326 MERGED (PyMC-16 logit/probit fix), 0 OPEN.
- **L954 ★ pivot cross-famille** : c.860 (PyMC-16 Sparse GP, dernier grain) → c.861 =
  16ᵉ pivot consécutif post-c.839, R6 variété respectée (sub-genre `Sparse GP C#` twin
  ≠ `Sparse GP Python` ≠ `Kalman C#` ≠ `Recommenders Python` ≠ `Recommenders C#` =
  substance genuinely distincte par stack + algorithme).
- **Genre G-VAR-3 OK** : sub-genre `notebook-citations C# Sparse GP twin` DISTINCT de
  c.860 (PyMC-16 Sparse GP Python twin) DISTINCT de c.852 (PyMC-17 + Infer-17 Kalman
  twin-pair) DISTINCT de c.851 (PyMC-15 Recommenders) DISTINCT de c.850 (Infer-15
  Recommenders) DISTINCT de c.847 (PyMC-18 Change-Point) — substance genuinely distincte
  par sujet (classification GP + sparse GP + ARD/HSGP vs Recommenders vs Kalman vs
  Change-Point).

## Hors scope (pour mémoire)

- **#8348 (PyMC-16 Sparse GP citations, c.860 MERGED 2026-07-24)** : jumeau Python de c.861,
  substance distincte (PyMC NUTS + `pm.gp.Latent` + Logit + inducing points + ARD + HSGP
  vs Infer.NET EP + `SparseGP` + Probit + EP-Forster), voir PR #8348 body pour les ancres
  canoniques exactes.
- **#8339 + #8342 (Kalman twin-pair, c.852 MERGED 2026-07-24)** : Kalman 1960 + RTS 1965
  + Sage-Melsa 1971 + Jazwinski 1970 + Maybeck 1979 + (PyMC: Hoffman-Gelman 2014 +
  Salvatier 2016 + Gelman BDA3) / (Infer: Minka 2001 + Minka 2001b EP-Kalman + Minka 2001c
  PhD Gaussian EP). Substance Kalman distincte du Sparse GP.
- **#8331 + #8334 (Recommenders twin-pair, c.850 + c.851 MERGED)** : Koren-Bell-Volinsky
  2009 + Schein 2002 + Chapelle-Zhang 2009 + (PyMC: Mnih-Salakhutdinov 2007 PMF + Funk 2006).
  Substance Recommenders distincte.
- **#8302 + #8307 (Survival/Change-Point twin-pair, c.844 + c.845)** : Cox 1972 + Kaplan-Meier
  + Weibull + (PyMC: Salvatier 2016 PyMC3 + Hoffman-Gelman 2014) / (Infer: Western-Harrison 1989
  + CGS 1992 minière). Substance distincte.
- **#8326 (PyMC-16 logit/probit fix, po-2025)** : fix code cell 10 + fig title 14, re-exec,
  substance distincte (sub-grain probit→logit fix vs c.861 axis-1 citations).
- **#8308 (PyMC-16 GP classifier is logit, not probit)** : fix substance logit/probit fix,
  substance distincte (correction claim vs c.861 axis-1 citations).
- **#8119 (Infer-16 enrich GP prediction MERGED 2026-07-23)** : enrichment GP prediction
  interpretation (sign + uncertainty), substance distincte (enrichissement markdown pedagogique
  sur outputs GP, hors scope de c.861 qui cible cell[6]/[15]/[21]/[23]/[30]/[31]).
- **#8081 closed-loop** : Infer-2 (c.819 #8163) + Infer-11 (c.830) + Infer-12 (c.831) +
  PyMC-2 (c.834) + PyMC-11 (#8233 closes #8205) + Infer-13 (c.838 #8247) + Infer-19
  (#8257 MERGED) + PyMC-19 (c.844 MERGED) + Infer-18 (c.845 MERGEABLE) + PyMC-18
  (c.847 MERGEABLE) + Infer-15 (c.850 MERGEABLE) + PyMC-15 (c.851 MERGEABLE) +
  PyMC-17 + Infer-17 (c.852 MERGEABLE twin-pair) + PyMC-16 (c.860 MERGED) +
  **Infer-16 (c.861 ce PR)** = 14 cibles du corpus Probas axis-1. Autres cibles non-claimées
  après cette PR : PyMC-1/3/4/5/6/7/8/9/10/12/13/14, Infer-1/3/4/5/6/7/8/9/10.
- **#8272 (Z3-06 prose/code mismatch Python)** : issue ouverte par po-2024 c.842, turf po-2025
  post-cascade.

## Liens

- Issue epic : [#8081](https://github.com/jsboige/CoursIA/issues/8081) (audit fidélité
  distillation MBML/Infer.NET, axe-1 = citations canoniques)
- PRs antérieures liées : [#8348](https://github.com/jsboige/CoursIA/pull/8348) (c.860 PyMC-16
  Sparse GP MERGED), [#8334](https://github.com/jsboige/CoursIA/pull/8334) (c.851 PyMC-15
  Recommenders MERGEABLE), [#8331](https://github.com/jsboige/CoursIA/pull/8331) (c.850 Infer-15
  Recommenders MERGEABLE), [#8339](https://github.com/jsboige/CoursIA/pull/8339) (c.852 PyMC-17
  Kalman MERGEABLE), [#8342](https://github.com/jsboige/CoursIA/pull/8342) (c.852 Infer-17
  Kalman MERGEABLE), [#8314](https://github.com/jsboige/CoursIA/pull/8314) (c.847 PyMC-18
  citations MERGEABLE), [#8307](https://github.com/jsboige/CoursIA/pull/8307) (c.845 Infer-18
  citations MERGEABLE), [#8302](https://github.com/jsboige/CoursIA/pull/8302) (c.844 PyMC-19
  citations MERGED), [#8257](https://github.com/jsboige/CoursIA/pull/8257) (Infer-19 citations
  MERGED 2026-07-24, po-2025), [#8247](https://github.com/jsboige/CoursIA/pull/8247) (c.838
  Infer-13 Crowdsourcing MERGEABLE), [#8234](https://github.com/jsboige/CoursIA/pull/8234)
  (c.834 PyMC-2 GMM MERGEABLE), [#8230](https://github.com/jsboige/CoursIA/pull/8230)
  (Infer-12 Hierarchical MERGEABLE), [#8231](https://github.com/jsboige/CoursIA/pull/8231)
  (Infer-2 GMM MERGEABLE), [#8232](https://github.com/jsboige/CoursIA/pull/8232) (Infer-11 LDA
  MERGEABLE), [#8233](https://github.com/jsboige/CoursIA/pull/8233) (PyMC-11 LDA closes #8205
  MERGEABLE)
- Pivot post-c.860 : c.861 = 16ᵉ pivot cross-famille consécutif post-c.839/c.840/c.841/c.842b/
  c.843/c.844/c.845/c.846/c.847/c.848/c.849/c.850/c.851/c.852/c.860, R6 variété respectée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)