### PR TITLE
feat(infer-13,#8081): §B-degenerate case where majority vote fails (C# twin of #8344)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb
@@ -2329,6 +2329,297 @@
   },
   {
    "cell_type": "markdown",
+   "id": "i13-caslimite-md",
+   "metadata": {},
+   "source": [
+    "### Cas limite : quand le vote majoritaire échoue\n",
+    "\n",
+    "La cellule précédente utilise le **vote majoritaire comme baseline** et atteint 100 % sur le dataset de la section 1. C'est précisément le **cas dégénéré** où la baseline triviale égale le modèle : tous les workers y étant fiables, le vote majoritaire suffit, et **l'apport du modèle Biased Worker (section 4) est invisible** — l'étudiant ne voit pas pourquoi s'embêter d'un modèle probabiliste.\n",
+    "\n",
+    "Pour rendre cet apport **visible**, construisons un dataset **délibérément adversarial** : 2 workers fiables (qui répondent la vérité) + 3 « spammeurs » (qui répondent toujours 0). Sur les items dont le vrai label est 1, les 3 spammeurs survolent les 2 fiables → le vote majoritaire se trompe systématiquement. Un vote **pondéré par la fiabilité** de chaque annotateur — exactement le mécanisme qu'estime le modèle Biased/Dawid-Skene via la matrice de confusion (section 4, exercice 10) — neutralise les spammeurs et récupère les labels. C'est ici que la modélisation probabiliste justifie son coût face à la baseline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "i13-caslimite-code",
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "=== Vote majoritaire (poids egaux) ===\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  Item 0 : votes 0=3 1=2 -> MV=0  vrai=1 ERREUR\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  Item 1 : votes 0=3 1=2 -> MV=0  vrai=1 ERREUR\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  Item 2 : votes 0=3 1=2 -> MV=0  vrai=1 ERREUR\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  Item 3 : votes 0=5 1=0 -> MV=0  vrai=0 OK\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  Item 4 : votes 0=5 1=0 -> MV=0  vrai=0 OK\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  Item 5 : votes 0=5 1=0 -> MV=0  vrai=0 OK\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  Precision vote majoritaire : 3/6 = 50%\n",
+      "\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  Worker 1 : moy=0,50 var=0,25 -> poids=0,25\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  Worker 2 : moy=0,50 var=0,25 -> poids=0,25\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  Worker 3 : moy=0,00 var=0,00 -> poids=0,00\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  Worker 4 : moy=0,00 var=0,00 -> poids=0,00\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  Worker 5 : moy=0,00 var=0,00 -> poids=0,00\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "=== Vote pondere par la fiabilite ===\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  Item 0 : poids 0=0,00 1=0,50 -> pondere=1  vrai=1 OK\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  Item 1 : poids 0=0,00 1=0,50 -> pondere=1  vrai=1 OK\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  Item 2 : poids 0=0,00 1=0,50 -> pondere=1  vrai=1 OK\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  Item 3 : poids 0=0,50 1=0,00 -> pondere=0  vrai=0 OK\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  Item 4 : poids 0=0,50 1=0,00 -> pondere=0  vrai=0 OK\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  Item 5 : poids 0=0,50 1=0,00 -> pondere=0  vrai=0 OK\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  Precision vote pondere : 6/6 = 100%\n",
+      "\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "=== Conclusion ===\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Vote majoritaire : 50%   |   Vote pondere (fiabilite) : 100%\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Items recuperes par la ponderation : 3/6\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Le modele probabiliste (Biased/Dawid-Skene) rend visible cet ecart :\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "il estime la fiabilite de chaque worker et neutralise les spammeurs,\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "la ou le vote majoritaire les traite comme des voix pleines.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// --- Cas limite : quand le vote majoritaire echoue (apport du modele probabiliste) ---\n",
+    "// Le dataset de la section 1 etait \"propice\" : le vote majoritaire y atteignait 100% (C26),\n",
+    "// si bien que l'avantage du modele Biased Worker (section 4) etait INVISIBLE. On construit\n",
+    "// ici un cas OU le vote majoritaire CASSE : 2 workers fiables + 3 \"spammeurs\" (repondent\n",
+    "// toujours 0). Sur les items de vrai=1, les 3 spammeurs survolent les 2 fiables -> MV se\n",
+    "// trompe. Un vote PONDERE par la fiabilite (apport du modele qui estime la matrice de\n",
+    "// confusion de chaque worker, section 4 / exercice 10) les neutralise et recupere les labels.\n",
+    "\n",
+    "int[,] demoLabels = {\n",
+    "    // W1 W2 W3 W4 W5   (W1,W2 fiables ; W3,W4,W5 spammeurs toujours-0)\n",
+    "    {  1, 1, 0, 0, 0 },  // Item 0 : vrai=1\n",
+    "    {  1, 1, 0, 0, 0 },  // Item 1 : vrai=1\n",
+    "    {  1, 1, 0, 0, 0 },  // Item 2 : vrai=1\n",
+    "    {  0, 0, 0, 0, 0 },  // Item 3 : vrai=0\n",
+    "    {  0, 0, 0, 0, 0 },  // Item 4 : vrai=0\n",
+    "    {  0, 0, 0, 0, 0 },  // Item 5 : vrai=0\n",
+    "};\n",
+    "int[] demoTrue = { 1, 1, 1, 0, 0, 0 };\n",
+    "int demoItems = 6, demoWorkers = 5;\n",
+    "\n",
+    "// --- (1) Vote majoritaire (baseline, poids egaux) ---\n",
+    "int mvCorrect = 0;\n",
+    "Console.WriteLine(\"=== Vote majoritaire (poids egaux) ===\");\n",
+    "for (int i = 0; i < demoItems; i++) {\n",
+    "    int c0 = 0, c1 = 0;\n",
+    "    for (int w = 0; w < demoWorkers; w++) { if (demoLabels[i, w] == 0) c0++; else c1++; }\n",
+    "    int mv = c0 > c1 ? 0 : 1;\n",
+    "    bool ok = mv == demoTrue[i]; if (ok) mvCorrect++;\n",
+    "    Console.WriteLine($\"  Item {i} : votes 0={c0} 1={c1} -> MV={mv}  vrai={demoTrue[i]} {(ok ? \"OK\" : \"ERREUR\")}\");\n",
+    "}\n",
+    "double mvAcc = 100.0 * mvCorrect / demoItems;\n",
+    "Console.WriteLine($\"  Precision vote majoritaire : {mvCorrect}/{demoItems} = {mvAcc:F0}%\\n\");\n",
+    "\n",
+    "// --- (2) Fiabilite par worker = informativite de ses reponses (variance empirique) ---\n",
+    "// Un worker qui repond toujours la meme chose (spammeur) n'apporte aucune information :\n",
+    "// sa variance empirique est nulle. Un worker dont les reponses varient selon l'item est\n",
+    "// informatif. C'est le signal que le modele Dawid-Skene (exercice 10) exploite en estimant\n",
+    "// la matrice de confusion de chaque annotateur.\n",
+    "double[] weight = new double[demoWorkers];\n",
+    "for (int w = 0; w < demoWorkers; w++) {\n",
+    "    double mean = 0;\n",
+    "    for (int i = 0; i < demoItems; i++) mean += demoLabels[i, w];\n",
+    "    mean /= demoItems;\n",
+    "    double vEmp = 0;\n",
+    "    for (int i = 0; i < demoItems; i++) vEmp += (demoLabels[i, w] - mean) * (demoLabels[i, w] - mean);\n",
+    "    vEmp /= demoItems;\n",
+    "    weight[w] = vEmp;\n",
+    "    Console.WriteLine($\"  Worker {w + 1} : moy={mean:F2} var={vEmp:F2} -> poids={weight[w]:F2}\");\n",
+    "}\n",
+    "Console.WriteLine();\n",
+    "\n",
+    "// --- (3) Vote pondere par la fiabilite ---\n",
+    "int wvCorrect = 0;\n",
+    "Console.WriteLine(\"=== Vote pondere par la fiabilite ===\");\n",
+    "for (int i = 0; i < demoItems; i++) {\n",
+    "    double s0 = 0, s1 = 0;\n",
+    "    for (int w = 0; w < demoWorkers; w++) { if (demoLabels[i, w] == 0) s0 += weight[w]; else s1 += weight[w]; }\n",
+    "    int wv = s1 > s0 ? 1 : 0;\n",
+    "    bool ok = wv == demoTrue[i]; if (ok) wvCorrect++;\n",
+    "    Console.WriteLine($\"  Item {i} : poids 0={s0:F2} 1={s1:F2} -> pondere={wv}  vrai={demoTrue[i]} {(ok ? \"OK\" : \"ERREUR\")}\");\n",
+    "}\n",
+    "double wvAcc = 100.0 * wvCorrect / demoItems;\n",
+    "Console.WriteLine($\"  Precision vote pondere : {wvCorrect}/{demoItems} = {wvAcc:F0}%\\n\");\n",
+    "\n",
+    "int recovered = wvCorrect - mvCorrect;\n",
+    "Console.WriteLine(\"=== Conclusion ===\");\n",
+    "Console.WriteLine($\"Vote majoritaire : {mvAcc:F0}%   |   Vote pondere (fiabilite) : {wvAcc:F0}%\");\n",
+    "Console.WriteLine($\"Items recuperes par la ponderation : {recovered}/{demoItems}\");\n",
+    "Console.WriteLine(\"Le modele probabiliste (Biased/Dawid-Skene) rend visible cet ecart :\");\n",
+    "Console.WriteLine(\"il estime la fiabilite de chaque worker et neutralise les spammeurs,\");\n",
+    "Console.WriteLine(\"la ou le vote majoritaire les traite comme des voix pleines.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "9d838173",
    "metadata": {
     "papermill": {
@@ -2362,7 +2653,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "22f720ce",
    "metadata": {
     "execution": {
@@ -2468,7 +2759,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "a1b1439c",
    "metadata": {
     "dotnet_interactive": {
@@ -2682,7 +2973,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "85318986",
    "metadata": {
     "dotnet_interactive": {
@@ -2901,7 +3192,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "7bdf1ade",
    "metadata": {
     "dotnet_interactive": {
@@ -3260,7 +3551,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "66737d8b",
    "metadata": {
     "execution": {
@@ -3349,7 +3640,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "spam-detector-exercise",
    "metadata": {
     "execution": {


### PR DESCRIPTION
feat(infer-13,#8081): add §B-degenerate case where majority vote fails (C# twin of PyMC-13 #8344)

Infer-13-Crowdsourcing §5 used majority vote as the "baseline" and reached 5/5 = 100%
on the section-1 dataset (C26). This is precisely the §B-DEGENERATE case where the
trivial baseline EQUALS the model: all workers there are reliable, so majority vote
suffices, and the Biased Worker capability (§4, C21 recovers W4's confusion matrix
true=1 -> responds 0 @ 0.79) is INVISIBLE. The student never sees WHY a probabilistic
model is worth its cost over plain vote counting. Same defect class as the PyMC-13 C#
twin backfilled in #8344 (c.869).

Backfill (after M27 "### Analyse du vote majoritaire", before M28 "## 5bis"):
  - markdown cell: frames the degenerate case (clean dataset -> MV = model -> capability
    invisible) and sets up the adversarial scenario.
  - self-contained code cell: builds an ADVERSARIAL dataset (2 reliable truth-tellers
    + 3 always-0 spammers, 6 items). Majority vote FAILS (50%: the 3 true=1 items are
    outvoted by spammers). A reliability-WEIGHTED vote -- the mechanism the Dawid-Skene /
    Biased model provides via per-worker confusion matrices (§4, exercise 10) --
    neutralizes the spammers and RECOVERS the labels (100%, 3 items recovered).
    Output: MV 50% | weighted 100%, 3 items recuperes.

The demo is self-contained (no Infer.NET dependency, deterministic, no seed) and does
NOT solve the Dawid-Skene exercise (C46 stub) -- it shows the principle concretely.
Real Infer.NET Biased Worker model (§4) is intact and demonstrated; this adds the
discriminating case that makes its advantage visible.

Validation (gold-standard C.2, proven at 3 levels):
- C.2: demo cell executed in the REAL .net-csharp kernel (jupyter nbconvert --execute).
  Committed output == kernel output byte-for-byte (28 CRLF stream chunks -- matches the
  committed sibling-cell convention: C11 38 chunks, C26 8 chunks, all CRLF Windows
  dotnet-interactive). FR decimal comma (0,50) consistent with Infer-13 house style
  (C21 "0,92"). No Kestrel/Microsoft.Hosting banner leaked into cell output.
- CS0128/CS0136 RULED OUT: simulated shared-submission exec (C11 + C26 + demo cell in
  one C# scope, replicating dotnet-interactive's shared submission) compiles and produces
  the exact demo output -- no variable collision.
- Byte-stable: +297/-6. The -6 are EXACTLY the 6 execution_count bumps (ec cascade:
  new cell ec=9, bumps C29..C48 9->10 ... 14->15, descending order). Zero source line,
  zero output of any pre-existing cell changed (verified: bumped + other cells source &
  outputs byte-identical to origin).
- H.3 validate_pr_notebooks.py vs origin/main: PASS (1/1, 15 code cells, .net-csharp).
- nbformat VALID (52 cells, was 50). C.1: 0 violations. Leak scanner: Infer-13 not
  flagged (demo is a standalone demo, not an exercise solution).

See #8081 (audit fidelite Probas/Infer.NET + PyMC) and #3801 (SOTA axe-2 problem-richness).
C# twin parity follow-up to #8344 (PyMC-13).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
