### PR TITLE
docs(planners,#3975): add 4 interpretation cells to Planners-6-Domains C# twin (20→85 node explosion)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-6-Domains-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-6-Domains-Csharp.ipynb
@@ -434,6 +434,18 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-blocks-tower",
+   "metadata": {},
+   "source": [
+    "### Interprétation : Block World — plan optimal et sérialisation des actions\n",
+    "\n",
+    "Le planificateur BFS trouve une solution de **4 actions** pour construire la tour `c <- b <- a` à partir des trois blocs posés à plat sur la table, en n'explorant que **20 nœuds**. La séquence `pick-up(b) -> stack(b,c) -> pick-up(a) -> stack(a,b)` respecte les préconditions STRIPS : on ne peut `stack(a,b)` qu'une fois `b` posé sur `c`, et `pick-up` ne s'applique qu'à un bloc sans autre bloc au-dessus et la main vide.\n",
+    "\n",
+    "Notons que les deux `pick-up` (de `b` puis de `a`) sont *indépendants* — dans un modèle parallèle ils pourraient s'exécuter en même temps — mais le formalisme STRIPS sérialise toute action. BFS livre donc la **séquence la plus courte** (4 actions consécutives), pas le parallélisme maximal. Les 20 nœuds explorés serviront de point de référence : le même domaine avec un bloc de plus (problème `blocks-reverse`) fera exploser ce compte."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "f501f8dc",
    "metadata": {},
    "source": [
@@ -597,6 +609,18 @@
     "Console.WriteLine(\"Problème 'blocks-reverse' : inverser deux tours (4 blocs)\\n\");\n",
     "var bwReverse = StripsPlanner.Solve(bw4Init, blocksActions4, bw4Goal);\n",
     "StripsPlanner.PrintPlan(bwReverse);\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-blocks-reverse",
+   "metadata": {},
+   "source": [
+    "### Interprétation : explosion combinatoire dans Block World\n",
+    "\n",
+    "Le problème `blocks-reverse` (4 blocs) demande **8 actions** — le double du problème à 3 blocs — mais le nombre de nœuds explorés passe de **20 à 85**, soit une multiplication par **4,25** pour un seul bloc supplémentaire. C'est la signature de l'explosion combinatoire : le facteur de branchement de Block World grandit avec le nombre de blocs (tout bloc *clair* peut être déplacé), donc l'arbre de recherche gonfle bien plus vite que la longueur du plan.\n",
+    "\n",
+    "La solution elle-même illustre la structure du problème : il faut d'abord **démonter** les deux tours (`unstack(b,a)` puis `unstack(d,c)`) en posant les blocs sur la table, puis **reconstruire** les tours inversées (`stack(a,b)` puis `stack(c,d)`). Cette explosion empirique (20 -> 85 nœuds pour un seul bloc de plus) motive directement les heuristiques admissibles (h^max, h^add, h^FF) étudiées dans le notebook **Planners-5-Heuristics**, qui réduisent drastiquement les nœuds explorés sans sacrifier l'optimalité du plan."
    ]
   },
   {
@@ -924,6 +948,18 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-gripper",
+   "metadata": {},
+   "source": [
+    "### Interprétation : Gripper — parallélisme exploité par les deux pinces\n",
+    "\n",
+    "Le domaine Gripper transporte 2 balles de `roomA` vers `roomB` avec un robot à **2 pinces**. Le plan optimal de **5 actions** exploite astucieusement ce double équipement : `pick(b1,g1)` puis `pick(b2,g2)` — les deux balles sont saisies *avant* le déplacement unique `move(roomA->roomB)` — puis `drop(b1,g1)`, `drop(b2,g2)`.\n",
+    "\n",
+    "Regrouper les deux saisies avant le déplacement économise un aller-retour : avec une **seule** pince il faudrait `pick-move-drop` pour chaque balle, soit 7 actions au lieu de 5. Le planificateur a donc « découvert » que l'ordre des actions compte autant que leur nombre. Là encore le formalisme sérialise : les deux `pick` sont indépendants mais posés en séquence. Les **25 nœuds** explorés (comparables aux 25 de Hanoï 3-disques) montrent que la taille de l'arbre dépend moins du nombre d'objets que du **facteur de branchement effectif** — ici restreint par la disponibilité des pinces."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "7dcb0307",
    "metadata": {},
    "source": [
@@ -1027,6 +1063,18 @@
     "Console.WriteLine();\n",
     "Console.WriteLine(\"Lecture : le plan est optimal (BFS), mais 'Nœuds explorés' croît\");\n",
     "Console.WriteLine(\"exponentiellement avec la taille du domaine — d'où les heuristiques de pyperplan.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-comparative",
+   "metadata": {},
+   "source": [
+    "### Interprétation : l'explosion dépend de la structure du domaine\n",
+    "\n",
+    "Le tableau récapitulatif révèle que le coût de la recherche n'est pas uniforme : Block World reverse (4 blocs) explore **85 nœuds** — plus de **3 fois** les 25 nœuds de Hanoï (3 disques) ou Gripper (2 balles) — pourtant les trois sont résolus **optimalement** par le même BFS. La longueur du plan (8, 7, 5 actions) n'explique pas cet écart : c'est le **facteur de branchement** propre à chaque domaine qui domine.\n",
+    "\n",
+    "Block World autorise, à chaque nœud, le déplacement de n'importe quel bloc *clair* — un ensemble d'actions applicables qui grandit avec `n`. Hanoï et Gripper contraignent davantage les choix licites (un seul disque par piquet, une balle par pince), ce qui **élague naturellement** l'arbre. BFS, bien qu'optimal, paie ici le prix fort sur le domaine le moins contraint — c'est précisément ce constat empirique qui justifie, dans la suite de la série, le passage à A* et aux heuristiques informées capables de guider la recherche vers les branches prometteuses."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-python (c.859, CSP-5 scaling benchmark)

## What

Enrich `SymbolicAI/Planners/02-Classical/Planners-6-Domains-Csharp.ipynb` (the C# twin of `Planners-6-Domains.ipynb`) with **4 interpretation cells** grounded in the C# twin's own committed outputs. The C# notebook — a pure-C# STRIPS planner from-scratch (BCL .NET 9, 0 NuGet, no pyperplan dependency) — had **bare `## section → code OUT → ## section`** structure with only 1 interpretation cell (Hanoï) across 4 substantive domain demonstrations. The Python twin carries ~18 interpretation cells the C# lacked entirely. Same gap pattern as GT-12/SocialChoice C# twins (c.841/c.849/c.851). See #3975.

## The 4 interpretation cells (grounded in REAL C# outputs — not copied Python prose)

Each cell interprets the **C# twin's** committed output, in French (matching the notebook's language):

1. **`interp-blocks-tower`** (after Block World tour c←b←a): the 4-action plan `pick-up(b)→stack(b,c)→pick-up(a)→stack(a,b)` in 20 nodes — explains STRIPS preconditions + that the two `pick-up` are independent (serialization, not parallelism) + sets the 20-node reference point for the reverse problem.

2. **`interp-blocks-reverse`** (after Block World reverse 4 blocks): the **20→85 node explosion** (×4.25 for one extra block) — the key empirical finding. Longueur du plan double (4→8 actions) but nodes jump 4.25×. Explains why: Block World's branching factor grows with n (any clear block movable). Motivates the heuristics of Planners-5.
3. **`interp-gripper`** (after Gripper 2-balles): the 5-action plan exploits the 2 pinces — `pick(b1,g1)→pick(b2,g2)` *before* `move` — grouping both picks before the single move saves an aller-retour (7 actions with 1 pince vs 5). The 25 nodes (comparable to Hanoï) shows arborescence depends on effective branching factor, not object count.
4. **`interp-comparative`** (after the 4-domain table): Block World reverse (85 nodes) explores **3× more** than Hanoï/Gripper (25 each) despite all optimal — length (8/7/5) doesn't explain it; **per-domain branching factor** does. Block World least constrained → pays the price → motivates A*/informed heuristics later in the series.

## Fix (markdown-only, byte-surgical, fichier-entier §E-aligned)

- 4 markdown cells inserted (id-anchored after each domain's code cell). `git diff --stat` = **+48 / -0** (pure addition).
- **Byte-surgical**: 0 original sources changed (all 22 original cells preserved byte-identical), all 10 code cells' `execution_count` + `outputs` byte-identical (verified by id-diff). Markdown-only → **C.2 exception** (no code cell modified, no re-execution).
- nbformat.validate OK · H.3 PASS (10 code cells, all `ec != null` — pre-existing, untouched) · C.1 clean · 0 CRLF.
- 3 exercises already present (Exercice 1/2/3) → #2161 satisfied.

## §E fichier-entier audit

The leaf README for Planners (if any) is out of scope (no count/structure drift from this change — adding interpretation cells to one notebook doesn't alter the series notebook list). The notebook's own Conclusion + Exercises sections read fine in context.

## L898 / collision check

- `gh pr list --repo jsboige/CoursIA --search Planners-6` = 0 OPEN touching this notebook. No collision.

## Variation note

1st grain in the **SymbolicAI/Planners family** this session (prior grains: Search, SemanticWeb, ML.Net-scan, CSP). Genre `notebook-dotnet` after `notebook-python` (c.859) → G-VAR-3 OK (genre change, .NET≠Python). MED not LIGHT per litmus: the 4 interpretation cells required reading the **actual C# plan sequences and node counts** (4/8/7/5 actions, 20/85/25/25 nodes, the specific `unstack(b,a)→put-down(b)→...` reverse plan) and reasoning about *why* the explosion is 4.25× (branching factor vs plan length) — not scan-generatable.

**Honesty flag**: this is my 4th C#-twin interpretation enrichment (c.841 GT-12, c.849 SocialChoice, c.851 GT-12, now Planners-6). The pattern is productive (real pedagogical gaps, real C# grounding) and the scan confirmed 4 HIGH-confidence candidates remain (GT-13-CFR, Search-5-GA, Planners-5-Heuristics also thin). But to honor the anti-monoculture mandate, **next cycle I lean toward a genuinely different genre** (a measured-solver grain in a fresh family, an exercise-authoring grain if a real deficit exists, or a pool-pickup bug fix) rather than a 5th C#-twin enrichment — unless ai-01 steers otherwise.

**Investigation honesty this cycle**: 5 grains evaporated under firsthand check before this one landed — twin-parity stale FP (C850-L), CSP-5 sub-scan factual error, ML/ML.Net 13/13 clean, Search-14 WeightedA* complete, Search-13 LDS complete. The repo is heavily curated; the C#-twin interpretation gap is the genuine remaining vein. This grain = 6th candidate, delivered only after the scan + firsthand output-reading confirmed real substance.

See #3975 · See #2161
