### PR TITLE
fix(detect-solution-leaks,#8053): skip nested git worktree dirs to avoid double-count

### DIFF
--- a/scripts/notebook_tools/detect_solution_leaks.py
+++ b/scripts/notebook_tools/detect_solution_leaks.py
@@ -443,9 +443,19 @@ def scan_notebook(path: str) -> list[dict]:
 
 
 def discover_notebooks(root: str) -> list[str]:
-    """Find all .ipynb files under root, excluding _output and .ipynb_checkpoints."""
+    """Find all .ipynb files under root, excluding _output, .ipynb_checkpoints, and nested git worktrees.
+
+    Nested git worktrees have a `.git` *file* (not directory) pointing to <parent>/.git/worktrees/<name>.
+    Descending into them would double-count all notebooks (e.g. orphan worktree `feat/c741-grothendieck-readme`
+    inside MyIA.AI.Notebooks/, which shares the same .git dir as the main repo).
+    """
     notebooks = []
     for dirpath, dirnames, filenames in os.walk(root):
+        # Skip dirs whose `.git` entry is a FILE (git worktree pointer) — descend-bait.
+        # Plain `.git` directory is already excluded by the dirnames filter below.
+        if '.git' in filenames and not os.path.isdir(os.path.join(dirpath, '.git')):
+            dirnames[:] = []
+            continue
         dirnames[:] = [d for d in dirnames if d not in ('.ipynb_checkpoints', '_output', '.git', '__pycache__', 'node_modules')]
         for f in filenames:
             if f.endswith('.ipynb') and not f.endswith('_output.ipynb'):

--- a/scripts/notebook_tools/test_detect_solution_leaks_nested_worktree.py
+++ b/scripts/notebook_tools/test_detect_solution_leaks_nested_worktree.py
@@ -1,0 +1,128 @@
+"""Tests unitaires pour detect_solution_leaks.discover_notebooks.
+
+Couvre le FP class "nested-git-worktree" : un répertoire de travail contient un
+worktree git (`.git` *fichier* pointant vers `.git/worktrees/<name>`) ; sans
+filtre, `os.walk` descend dedans et double-compte tous les notebooks.
+
+Run: python scripts/notebook_tools/test_detect_solution_leaks_nested_worktree.py
+"""
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from detect_solution_leaks import discover_notebooks  # noqa: E02
+
+
+def _make_notebook(path: Path) -> None:
+    """Build a minimal but valid .ipynb at `path`."""
+    nb = {
+        "cells": [
+            {
+                "cell_type": "markdown",
+                "metadata": {},
+                "source": ["# Exercice 1"],
+            },
+            {
+                "cell_type": "code",
+                "execution_count": 1,
+                "metadata": {},
+                "outputs": [],
+                "source": ["x = 1\ny = 2\nprint(x + y)"],
+            },
+        ],
+        "metadata": {
+            "kernelspec": {"display_name": "Python 3", "name": "python3", "language": "python"}
+        },
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(nb, f)
+
+
+def _make_git_worktree_file(path: Path, parent_repo: str = "/tmp/parent") -> None:
+    """Create a `.git` *file* (not directory) simulating a git worktree pointer."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(f"gitdir: {parent_repo}/.git/worktrees/test-orphan\n")
+
+
+class TestNestedWorktreeSkip(unittest.TestCase):
+    """FP class: nested git worktree must be skipped to avoid double-count."""
+
+    def test_orphan_worktree_is_skipped(self):
+        """A `.git` file inside a subdirectory must NOT cause descent."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "tree"
+            # Main tree notebook (kept)
+            _make_notebook(root / "MyIA.AI.Notebooks" / "MainTest.ipynb")
+            # Orphan worktree: `.git` FILE pointing elsewhere
+            orphan_dir = root / "MyIA.AI.Notebooks" / "SymbolicAI" / "Lean" / "orphan"
+            _make_git_worktree_file(orphan_dir / ".git")
+            # Notebook inside the orphan (would be double-counted without the fix)
+            _make_notebook(orphan_dir / "MyIA.AI.Notebooks" / "Search" / "OrphanTest.ipynb")
+
+            found = discover_notebooks(str(root))
+            rel = [os.path.relpath(p, str(root)) for p in found]
+
+            self.assertIn(os.path.join("MyIA.AI.Notebooks", "MainTest.ipynb"), rel)
+            self.assertNotIn(
+                os.path.join(
+                    "MyIA.AI.Notebooks",
+                    "SymbolicAI",
+                    "Lean",
+                    "orphan",
+                    "MyIA.AI.Notebooks",
+                    "Search",
+                    "OrphanTest.ipynb",
+                ),
+                rel,
+                msg=f"Orphan was not skipped — found: {rel}",
+            )
+            self.assertEqual(len(found), 1, msg=f"Expected exactly 1, got {len(found)}: {rel}")
+
+    def test_plain_git_directory_is_still_skipped(self):
+        """`.git` as a *directory* (not a file) is still excluded (regression guard)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            git_dir = root / ".git"
+            git_dir.mkdir(exist_ok=True)
+            (git_dir / "HEAD").write_text("ref: refs/heads/main\n")
+            # Notebook anywhere inside is fine, but the .git/* contents are NOT notebooks
+            _make_notebook(root / "MyIA.AI.Notebooks" / "MainTest.ipynb")
+            found = discover_notebooks(str(root))
+            rel = [os.path.relpath(p, str(root)) for p in found]
+            self.assertEqual(rel, [os.path.join("MyIA.AI.Notebooks", "MainTest.ipynb")])
+
+    def test_no_git_marker_at_all(self):
+        """No `.git` anywhere → behave as before, scan everything (sanity)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "tree"
+            _make_notebook(root / "A.ipynb")
+            _make_notebook(root / "sub" / "B.ipynb")
+            found = discover_notebooks(str(root))
+            self.assertEqual(len(found), 2)
+
+    def test_dotfile_dotgit_file_alongside_real_notebooks(self):
+        """`.git` file with sibling notebooks in same dir: only notebooks are picked up."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "tree"
+            worktree = root / "wt"
+            worktree.mkdir(parents=True)
+            _make_git_worktree_file(worktree / ".git")
+            _make_notebook(worktree / "Search.ipynb")  # must be skipped (descend-bait)
+            _make_notebook(root / "Top.ipynb")  # must be picked up
+            found = discover_notebooks(str(root))
+            rel = sorted(os.path.relpath(p, str(root)) for p in found)
+            self.assertEqual(rel, ["Top.ipynb"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
fix(detect-solution-leaks,#8053): skip nested git worktree dirs to avoid double-count

## Problem

A nested git worktree checked out inside `MyIA.AI.Notebooks/` (concretely `feat/c741-grothendieck-readme` at `MyIA.AI.Notebooks/SymbolicAI/Lean/CoursIA-c741-grothendieck-readme/`) has a `.git` **file** (not directory) pointing to `<parent>/.git/worktrees/<name>`. The existing `.git` exclusion in `discover_notebooks()` only matched directories, so `os.walk` descended into the worktree and double-counted all of its notebooks.

## Evidence

Counts on `python scripts/notebook_tools/detect_solution_leaks.py --scan MyIA.AI.Notebooks` (main repo, with the orphan worktree present):

| | Notebooks scanned | HIGH findings |
|---|---|---|
| **Before fix** | 1909 | 66 (35 were duplicate paths from the orphan) |
| **After fix** | 945 | 31 (matches expected main-tree count) |

The 35 duplicates are paths like `MyIA.AI.Notebooks/SymbolicAI/Lean/CoursIA-c741-grothendieck-readme/MyIA.AI.Notebooks/GameTheory/GameTheory-1-Setup.ipynb` — which `os.walk` was reporting **in addition to** the canonical `MyIA.AI.Notebooks/GameTheory/GameTheory-1-Setup.ipynb`.

## Fix

In `discover_notebooks()`, treat any directory whose `.git` entry is a **file** as descend-bait:

```python
if '.git' in filenames and not os.path.isdir(os.path.join(dirpath, '.git')):
    dirnames[:] = []
    continue
```

This is the canonical fix: a regular `.git` directory is still excluded by the existing `dirnames` filter; a `.git` *file* is a git worktree pointer that shares the parent's `.git` and must not be descended into.

## Regression tests

Added `scripts/notebook_tools/test_detect_solution_leaks_nested_worktree.py` with 4 tests:

- `test_orphan_worktree_is_skipped` — `.git` file in subdir → descendants not scanned
- `test_plain_git_directory_is_still_skipped` — regression guard for the original `.git` directory skip
- `test_no_git_marker_at_all` — sanity baseline (no `.git` anywhere)
- `test_dotfile_dotgit_file_alongside_real_notebooks` — `.git` file with sibling notebooks

All 4 pass:

```
$ python scripts/notebook_tools/test_detect_solution_leaks_nested_worktree.py
test_dotfile_dotgit_file_alongside_real_notebooks ... ok
test_no_git_marker_at_all ... ok
test_orphan_worktree_is_skipped ... ok
test_plain_git_directory_is_still_skipped ... ok

Ran 4 tests in 0.012s
OK
```

## Scope

Grain: LIGHT/guard — sub-grain of #8053 leak-CI reconciliation. Atomic, 1 file modified + 1 file added, 139 insertions / 1 deletion. No other behavior changed.

## Validation

- Detector still functions correctly on the main tree (31 real HIGH findings remain — pre-existing, out of scope).
- `--check` mode still exits 1 on HIGH (preserved).
- No regressions in any other detector path (other FP-class guards intact).

Refs #8053

🤖 Generated with [Claude Code](https://claude.com/claude-code)