### PR TITLE
refactor(catalog,#8051): gate FORMALLY_VERIFIED on sorry-free proof, not companion presence

### DIFF
--- a/scripts/notebook_tools/generate_catalog.py
+++ b/scripts/notebook_tools/generate_catalog.py
@@ -714,16 +714,27 @@ def classify_scientific_review(
     *,
     scientific_reviewed_by: str | None = None,
     last_validator: str | None = None,
-    has_lean_companion: bool = False,
-    has_multi_seed_benchmark: bool = False,
+    sorry_free: bool = False,
 ) -> str:
     """Axe 3 — revue scientifique (UNREVIEWED/AUTHOR_REVIEWED/PEER_REVIEWED/FORMALLY_VERIFIED).
 
-    Cf docs/PARCOURS.md. Sans signal explicite, on retombe sur UNREVIEWED — une
-    promotion necessite soit un signal catalogue (PR label 'scientific-reviewed-by'),
-    soit la presence d'un fichier .lean companion, soit un benchmark multi-seed.
+    Cf docs/PARCOURS.md. Sans signal explicite, on retombe sur UNREVIEWED.
+
+    **Contrat honnete pour FORMALLY_VERIFIED** (issue #8051). La promotion vers
+    FORMALLY_VERIFIED exige une PREUVE, pas une simple presence :
+      - un compagnon `.lean` EXISTANT n'est PAS une preuve — un lake compagnon
+        peut porter sa propre sorry-debt (9/18 notebooks lean4-wsl ont du sorry
+        cell-level, cf scripts/audit/check_lean_notebook_sorry.py #8351).
+        Detecter le compagnon et emettre FORMALLY_VERIFIED = faux claim.
+      - un benchmark multi-seed est une rigueur EMPIRIQUE, pas une preuve
+        formelle (formelle = mathematique, sans axiome admis).
+    Le seul signal honnete est ``sorry_free`` : un lake Lean dont le build
+    reussit SANS aucun ``sorry`` (artifact Lean-CI a brancher ; absent pour
+    l'instant, donc ``sorry_free`` default False -> FORMALLY_VERIFIED reste
+    inatteignable tant que l'artifact n'est pas cable). Le catalog-gen ne peut
+    PAS deviner la sorry-freedom ; il consomme un artifact produit en amont.
     """
-    if has_lean_companion or has_multi_seed_benchmark:
+    if sorry_free:
         return "FORMALLY_VERIFIED"
     if scientific_reviewed_by and last_validator and scientific_reviewed_by != last_validator:
         return "PEER_REVIEWED"
@@ -816,8 +827,11 @@ def analyze_notebook(nb_path: Path, pedagogical: bool, git_meta: dict | None = N
         notebook,
         scientific_reviewed_by=gm.get("scientific_reviewed_by"),
         last_validator=gm.get("last_validator"),
-        has_lean_companion=any(p.endswith(".lean") for p in parts),
-        has_multi_seed_benchmark=False,  # pas de signal canonique pour l'instant
+        # FORMALLY_VERIFIED exige un lake Lean sorry-free PROUVE (artifact Lean-CI),
+        # pas une simple presence de compagnon (cf #8051, #8351). Le champ
+        # git_meta 'sorry_free' n'est pas encore cable -> default False honnete :
+        # aucun notebook ne peut etre faussement claim FORMALLY_VERIFIED.
+        sorry_free=gm.get("sorry_free", False),
     )
     maturity = aggregate_maturity(
         editorial, reproducibility, scientific_review,

--- a/scripts/notebook_tools/tests/test_generate_catalog.py
+++ b/scripts/notebook_tools/tests/test_generate_catalog.py
@@ -28,6 +28,7 @@ from generate_catalog import (
     analyze_notebook,
     check_errors,
     classify_maturity,
+    classify_scientific_review,
     count_todos,
     detect_kernel,
     detect_requirements,
@@ -605,6 +606,58 @@ class TestClassifyMaturity:
         code_cells = [executed] + todo_cells
         nb = self._full_nb([_md("# Title")] + code_cells)
         assert classify_maturity(nb, code_cells, "Python 3") == "DRAFT"
+
+
+# --- classify_scientific_review (axe 3, #8051) ---
+
+class TestClassifyScientificReview:
+    """Axe 3 — revue scientifique. FORMALLY_VERIFIED exige une PREUVE sorry-free,
+    pas une simple presence de compagnon (cf #8051, #8351)."""
+
+    def test_default_is_unreviewed(self):
+        # Sans aucun signal -> UNREVIEWED (jamais de claim auto).
+        assert classify_scientific_review({}) == "UNREVIEWED"
+
+    def test_author_reviewed_self_validates(self):
+        # reviewed_by == last_validator = auteur se valide lui-meme.
+        assert classify_scientific_review(
+            {}, scientific_reviewed_by="a@b.c", last_validator="a@b.c"
+        ) == "AUTHOR_REVIEWED"
+
+    def test_peer_reviewed_distinct_validator(self):
+        # reviewed_by != last_validator = peer review effective.
+        assert classify_scientific_review(
+            {}, scientific_reviewed_by="a@b.c", last_validator="c@d.e"
+        ) == "PEER_REVIEWED"
+
+    def test_sorry_free_yields_formally_verified(self):
+        # Le SEUL chemin honnete vers FORMALLY_VERIFIED = preuve sorry-free.
+        assert classify_scientific_review({}, sorry_free=True) == "FORMALLY_VERIFIED"
+
+    def test_sorry_free_dominates_peer(self):
+        # sorry_free (preuve formelle) > peer review.
+        assert classify_scientific_review(
+            {}, sorry_free=True,
+            scientific_reviewed_by="a@b.c", last_validator="c@d.e",
+        ) == "FORMALLY_VERIFIED"
+
+    def test_companion_presence_alone_does_not_verify(self):
+        # REGRESSION GUARD (#8051): l'ancien code emettait FORMALLY_VERIFIED des
+        # qu un compagnon .lean existait (signal mort, mais piege si active).
+        # Un lake compagnon peut porter sa sorry-debt -> presence != preuve.
+        # On verifie que rien dans l'API ne permet de claim FORMALLY_VERIFIED
+        # sans sorry_free=True (pas de param has_lean_companion).
+        import inspect
+        sig = inspect.signature(classify_scientific_review)
+        assert "sorry_free" in sig.parameters
+        assert "has_lean_companion" not in sig.parameters, (
+            "has_lean_companion retiré : presence de compagnon != preuve sorry-free (#8051)"
+        )
+        assert "has_multi_seed_benchmark" not in sig.parameters, (
+            "has_multi_seed_benchmark retiré : rigueur empirique != preuve formelle"
+        )
+        # Et sans sorry_free, on retombe sur UNREVIEWED meme si on essaye.
+        assert classify_scientific_review({}) == "UNREVIEWED"
 
 
 # --- _is_exercise_stub ---


### PR DESCRIPTION
## Summary

`classify_scientific_review()` emitted `FORMALLY_VERIFIED` whenever a Lean companion existed (`has_lean_companion`) or a multi-seed benchmark was present. Both signals were broken — and worse, **trap-laden**:

1. **`has_lean_companion` was DEAD** (`generate_catalog.py:819` passed the `.ipynb` path segments, never a `.lean` segment → always `False`). But it was a **false-claim trap**: if naively "fixed" to detect a real companion lake, it would auto-emit `FORMALLY_VERIFIED` for lakes that carry sorry-debt. **9/18 `lean4-wsl` notebooks have cell-level sorry** (cf PR #8351); a companion *existing* ≠ a sorry-free *proof*.
2. **`has_multi_seed_benchmark`** was hardcoded `False` and conflated *empirical rigor* (multi-seed) with *formal verification* (mathematical, no admitted axioms).

**Fix**: replace both with a single honest `sorry_free: bool` signal — the only honest path to `FORMALLY_VERIFIED` is a Lean lake whose build succeeds with **zero `sorry`** (the real formal-proof artifact). The caller reads it from `git_meta` (`sorry_free=gm.get("sorry_free", False)`). That field is **not yet wired** (not in `CURATED_GIT_FIELDS`, no populator) → defaults `False` → `FORMALLY_VERIFIED` stays unreachable until a Lean-CI sorry-tally artifact is plumbed in.

This codifies in code the constraint ai-01 noted on the dashboard (« `has_lean_companion` DEAD; catalog-gen ne peut émettre `FORMALLY_VERIFIED` sans artifact Lean-CI ») and hardens against a naive future "fix" creating 9 false claims.

## No-op on catalog output (proven)

All 836 catalog entries are currently `UNREVIEWED` (0 `FORMALLY_VERIFIED` / `PEER_REVIEWED` / `AUTHOR_REVIEWED` — verified firsthand). After this change:
- `sorry_free` is unpopulated in `git_meta` → stays `False` at gen time → `FORMALLY_VERIFIED` branch never taken.
- The `PEER_REVIEWED` / `AUTHOR_REVIEWED` branches are **byte-unchanged**.

Hence `scientific_review` (and the derived `maturity`) are byte-identical before/after → **`COURSE_CATALOG.generated.json` / `.md` untouched** (catalog-pr-hygiene HARD 1).

## Validation

- `python -m pytest scripts/notebook_tools/tests/test_generate_catalog.py -q` → **170 passed** (165 existing + 5 new + 1 regression guard).
- New `TestClassifyScientificReview` covers all branches (`sorry_free → FORMALLY_VERIFIED`, `sorry_free` dominates peer, author self-validate, peer distinct validator, default UNREVIEWED) + a regression guard asserting the old `has_lean_companion`/`has_multi_seed_benchmark` params are gone from the signature.

## Design note for review

This is the **honest floor** (Option A): `FORMALLY_VERIFIED` is unreachable until a sorry-tally artifact is wired. A follow-up (Option B) would plumb the Lean-CI sorry-count into `git_meta` so genuinely sorry-free lakes reach `FORMALLY_VERIFIED` — kept separate to stay atomic and avoid touching CI / the meta pipeline in this PR.

See #8051.