### PR TITLE
fix(probas,#8081): PyMC-6-Debugging §7 — exercise debug loop + make 'correct' model correct

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-6-Debugging.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-6-Debugging.ipynb
@@ -1774,45 +1774,35 @@
   {
    "cell_type": "markdown",
    "id": "098d43bf",
-   "metadata": {
-    "papermill": {
-     "duration": 0.008021,
-     "end_time": "2026-06-15T04:28:03.505412+00:00",
-     "exception": false,
-     "start_time": "2026-06-15T04:28:03.497391+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
-    "## 7. Exemple guide : Debugger un Modèle\n",
+    "## 7. Exemple guide : Debugger un Modele\n",
     "\n",
-    "### Enonce\n",
+    "### Le modele sain (reference)\n",
     "\n",
-    "Le modèle ci-dessous est déjà corrige. Il montre comment spécifier correctement un modèle d'estimation."
+    "Avant de deboguer un modele casse, fixons la cible : a quoi ressemble un modele d'estimation **bien specifie** ? La cellule ci-dessous estime la moyenne et l'ecart-type de 30 mesures. Trois choix sont essentiels pour que l'echantillonnage NUTS se passe proprement :\n",
+    "\n",
+    "- **Prior large sur la moyenne** (`sigma=50`) : il laisse la donnee parler.\n",
+    "- **`HalfNormal` pour l'ecart-type** : un ecart-type est strictement positif ; une `Normal` autoriserait des valeurs negatives.\n",
+    "- **Assez d'observations** (`n=30`) : avec une *seule* observation, $\\sigma$ serait sous-determine et l'echantillonneur divergerait (funnel, voir §2.2).\n",
+    "\n",
+    "Les diagnostics (divergences, $\\hat{R}$, ESS) doivent etre propres -- c'est le signe que le modele est sain.\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
    "id": "c1b60f75",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-15T04:28:03.525680Z",
-     "iopub.status.busy": "2026-06-15T04:28:03.525680Z",
-     "iopub.status.idle": "2026-06-15T04:28:27.748116Z",
-     "shell.execute_reply": "2026-06-15T04:28:27.747449Z"
-    },
-    "papermill": {
-     "duration": 24.234147,
-     "end_time": "2026-06-15T04:28:27.748590+00:00",
-     "exception": false,
-     "start_time": "2026-06-15T04:28:03.514443+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
+   "execution_count": 11,
    "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Exemple : Modele bien specifie (n=30 observations) ===\n",
+      "\n"
+     ]
+    },
     {
      "name": "stderr",
      "output_type": "stream",
@@ -1821,18 +1811,10 @@
      ]
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "=== Exemple : Modele bien specifie ===\n",
-      "\n"
-     ]
-    },
-    {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Multiprocess sampling (4 chains in 4 jobs)\n"
+      "Sequential sampling (4 chains in 1 job)\n"
      ]
     },
     {
@@ -1846,28 +1828,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_000 tune and 2_000 draw iterations (4_000 + 8_000 draws total) took 20 seconds.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "There were 573 divergences after tuning. Increase `target_accept` or reparameterize.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "The rhat statistic is larger than 1.01 for some parameters. This indicates problems during sampling. See https://arxiv.org/abs/1903.08008 for details\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "The effective sample size per chain is smaller than 100 for some parameters.  A higher number is needed for reliable rhat and ess computation. See https://arxiv.org/abs/1903.08008 for details\n"
+      "Sampling 4 chains for 1_000 tune and 2_000 draw iterations (4_000 + 8_000 draws total) took 22 seconds.\n"
      ]
     },
     {
@@ -1876,35 +1837,36 @@
      "text": [
       "Resultats :\n",
       "           mean     sd  hdi_3%  hdi_97%  ess_bulk  r_hat\n",
-      "moyenne  49.393  9.754  27.171   67.109    1556.0   1.01\n",
-      "sigma     8.325  5.878   0.677   18.882     383.0   1.01\n",
+      "moyenne  25.136  1.173  22.895   27.332    4684.0    1.0\n",
+      "sigma     6.443  0.900   4.804    8.065    4711.0    1.0\n",
       "\n",
       "Diagnostics :\n",
-      "  Divergences : 573\n",
-      "  R-hat max : 1.0100\n",
-      "  ESS bulk min : 383\n"
+      "  Divergences : 0\n",
+      "  R-hat max : 1.0000\n",
+      "  ESS bulk min : 4684\n"
      ]
     }
    ],
    "source": [
-    "# Exemple guide : Modele d'estimation bien specifie\n",
-    "\n",
-    "print(\"=== Exemple : Modele bien specifie ===\")\n",
+    "# Exemple guide : Modele d'estimation bien specifie.\n",
+    "# IMPORTANT : on observe n=30 mesures (et non 1 seule) pour que sigma soit IDENTIFIABLE.\n",
+    "# Avec une observation unique, sigma est sous-determine -> NUTS diverge (funnel, voir §2.2).\n",
+    "print(\"=== Exemple : Modele bien specifie (n=30 observations) ===\")\n",
     "print()\n",
     "\n",
+    "# 30 mesures d'une quantite autour de 25 (ecart-type reel ~8).\n",
+    "rng_obs = np.random.default_rng(RANDOM_SEED)\n",
+    "donnees = rng_obs.normal(loc=25.0, scale=8.0, size=30)\n",
+    "\n",
     "with pm.Model() as model_corrige:\n",
-    "    # Prior large sur la moyenne (centree vers les donnees attendues)\n",
-    "    moyenne = pm.Normal(\"moyenne\", mu=25, sigma=50)\n",
-    "    # Prior sur l'ecart-type\n",
-    "    sigma = pm.HalfNormal(\"sigma\", sigma=10)\n",
-    "    # Observation\n",
-    "    obs = pm.Normal(\"obs\", mu=moyenne, sigma=sigma, observed=50)\n",
+    "    moyenne = pm.Normal(\"moyenne\", mu=25, sigma=50)       # prior large\n",
+    "    sigma = pm.HalfNormal(\"sigma\", sigma=10)              # strictement positif\n",
+    "    obs = pm.Normal(\"obs\", mu=moyenne, sigma=sigma, observed=donnees)\n",
     "    trace_corrige = pm.sample(\n",
-    "        draws=2000, chains=4, random_seed=RANDOM_SEED,\n",
+    "        draws=2000, chains=4, cores=1, random_seed=RANDOM_SEED, target_accept=0.95,\n",
     "        progressbar=False, return_inferencedata=True\n",
     "    )\n",
     "\n",
-    "# Diagnostic\n",
     "summary_corrige = az.summary(trace_corrige)\n",
     "print(\"Resultats :\")\n",
     "hdi_cols = [c for c in summary_corrige.columns if 'hdi' in c.lower()]\n",
@@ -1915,47 +1877,35 @@
     "n_div = int(trace_corrige.sample_stats[\"diverging\"].sum().values)\n",
     "print(f\"  Divergences : {n_div}\")\n",
     "print(f\"  R-hat max : {float(summary_corrige['r_hat'].max()):.4f}\")\n",
-    "print(f\"  ESS bulk min : {float(summary_corrige['ess_bulk'].min()):.0f}\")"
+    "print(f\"  ESS bulk min : {float(summary_corrige['ess_bulk'].min()):.0f}\")\n"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "d8874600",
-   "metadata": {
-    "papermill": {
-     "duration": 0.007507,
-     "end_time": "2026-06-15T04:28:27.763609+00:00",
-     "exception": false,
-     "start_time": "2026-06-15T04:28:27.756102+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
-    "A votre tour : identifiez les problèmes dans le modèle suivant."
+    "### A votre tour : un modele bugge\n",
+    "\n",
+    "La cellule suivante comporte **trois erreurs classiques** de specification. On la fait tourner pour en observer les *symptomes*, puis on applique les corrections et on relance pour verifier que le modele sain est retrouve.\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
    "id": "a4e92b89",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-15T04:28:27.781509Z",
-     "iopub.status.busy": "2026-06-15T04:28:27.781509Z",
-     "iopub.status.idle": "2026-06-15T04:28:39.182103Z",
-     "shell.execute_reply": "2026-06-15T04:28:39.182103Z"
-    },
-    "papermill": {
-     "duration": 11.409335,
-     "end_time": "2026-06-15T04:28:39.182103+00:00",
-     "exception": false,
-     "start_time": "2026-06-15T04:28:27.772768+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
+   "execution_count": 12,
    "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Debug : modele bugge, puis corrige ===\n",
+      "Rappel : les donnees (n=30) ont une moyenne empirique de 25.1.\n",
+      "\n",
+      "-- Modele bugge (3 erreurs) --\n"
+     ]
+    },
     {
      "name": "stderr",
      "output_type": "stream",
@@ -1964,18 +1914,58 @@
      ]
     },
     {
-     "name": "stdout",
+     "name": "stderr",
      "output_type": "stream",
      "text": [
-      "=== Exercice : Debugger ce modele ===\n",
-      "\n"
+      "Sequential sampling (2 chains in 1 job)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Multiprocess sampling (2 chains in 2 jobs)\n"
+      "NUTS: [m, s]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Sampling 2 chains for 1_000 tune and 1_000 draw iterations (2_000 + 2_000 draws total) took 5 seconds.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "We recommend running at least 4 chains for robust computation of convergence diagnostics\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Posterior de la moyenne : m ~ 0.001\n",
+      "    --> CONTRADICTION : la donnee vaut ~25.1, mais la posterior reste a ~0.\n",
+      "        Le prior Normal(0, sigma=0.01) est si concentre qu'il ECRASE la donnee.\n",
+      "  Posterior de l'ecart-type : s ~ 11.31 (modélisé par une Normal, non contraint > 0).\n",
+      "  Divergences NUTS : 0  -- attention, 0 divergence ne signifie pas 'modele correct' !\n",
+      "\n",
+      "-- Modele corrige --\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Initializing NUTS using jitter+adapt_diag...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Sequential sampling (2 chains in 1 job)\n"
      ]
     },
     {
@@ -1989,14 +1979,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 2 chains for 1_000 tune and 2_000 draw iterations (2_000 + 4_000 draws total) took 11 seconds.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "There were 314 divergences after tuning. Increase `target_accept` or reparameterize.\n"
+      "Sampling 2 chains for 1_000 tune and 2_000 draw iterations (2_000 + 4_000 draws total) took 12 seconds.\n"
      ]
     },
     {
@@ -2007,88 +1990,80 @@
      ]
     },
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "The effective sample size per chain is smaller than 100 for some parameters.  A higher number is needed for reliable rhat and ess computation. See https://arxiv.org/abs/1903.08008 for details\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Corrections appliquees :\n",
-      "1. Prior sur moyenne : sigma=50 (large) au lieu de sigma=0.01 (etroit)\n",
-      "2. Distribution sigma : HalfNormal (positif) au lieu de Normal\n",
-      "3. Parametrisation claire avec noms explicites\n",
+      "  Posterior de la moyenne : moyenne ~ 25.1  (recovere la donnee)\n",
+      "  Posterior de l'ecart-type : sigma ~ 6.4  (HalfNormal, > 0)\n",
+      "  Divergences : 0\n",
       "\n",
-      "Resultats : moyenne ~ 49.1, sigma ~ 8.0\n"
+      "=> Le reflexe debug : comparer la posterior a la DONNEE, pas seulement aux divergences.\n",
+      "   Ici les deux modeles ont 0 divergence -- c'est l'ecart m~0 vs donnee~25 qui revele le bug.\n"
      ]
     }
    ],
    "source": [
-    "# Exemple guide : Trouvez les problemes dans ce modele\n",
-    "\n",
-    "print(\"=== Exercice : Debugger ce modele ===\")\n",
+    "# Exemple guide : Debuggons un modele BUGGE, puis corrigeons-le.\n",
+    "print(\"=== Debug : modele bugge, puis corrige ===\")\n",
+    "print(f\"Rappel : les donnees (n=30) ont une moyenne empirique de {donnees.mean():.1f}.\")\n",
     "print()\n",
     "\n",
-    "# Probleme 1 : Prior trop etroit pour les observations\n",
-    "# Probleme 2 : Mauvaise distribution pour un ecart-type (peut etre negatif)\n",
-    "# Probleme 3 : Parametrisation confuse\n",
-    "\n",
-    "# Modele original (avec erreurs) : DECOMMENTEZ POUR VOIR LES PROBLEMES\n",
-    "# with pm.Model() as model_buggy:\n",
-    "#     m = pm.Normal(\"m\", mu=0, sigma=0.01)        # Prior trop concentre\n",
-    "#     s = pm.Normal(\"s\", mu=0, sigma=1)            # Peut etre negatif !\n",
-    "#     obs = pm.Normal(\"obs\", mu=m, sigma=s, observed=50)\n",
-    "\n",
-    "# Version corrigee\n",
-    "with pm.Model() as model_corrige_ex:\n",
-    "    # Correction 1 : Prior large (sigma=50 au lieu de 0.01)\n",
-    "    moyenne = pm.Normal(\"moyenne\", mu=25, sigma=50)\n",
-    "    # Correction 2 : HalfNormal pour un ecart-type (strictement positif)\n",
-    "    sigma = pm.HalfNormal(\"sigma\", sigma=10)\n",
-    "    # Correction 3 : Parametrisation claire\n",
-    "    obs = pm.Normal(\"obs\", mu=moyenne, sigma=sigma, observed=50)\n",
-    "    trace_ex = pm.sample(\n",
-    "        draws=2000, chains=2, random_seed=RANDOM_SEED,\n",
+    "print(\"-- Modele bugge (3 erreurs) --\")\n",
+    "with pm.Model() as model_buggy:\n",
+    "    m = pm.Normal(\"m\", mu=0, sigma=0.01)       # Erreur 1 : prior hyper-concentre\n",
+    "    s = pm.Normal(\"s\", mu=0, sigma=1)           # Erreur 2 : non contraint > 0\n",
+    "    obs = pm.Normal(\"obs\", mu=m, sigma=s, observed=donnees)\n",
+    "    trace_buggy = pm.sample(\n",
+    "        draws=1000, chains=2, cores=1, random_seed=RANDOM_SEED,\n",
     "        progressbar=False, return_inferencedata=True\n",
     "    )\n",
-    "\n",
-    "print(\"Corrections appliquees :\")\n",
-    "print(\"1. Prior sur moyenne : sigma=50 (large) au lieu de sigma=0.01 (etroit)\")\n",
-    "print(\"2. Distribution sigma : HalfNormal (positif) au lieu de Normal\")\n",
-    "print(\"3. Parametrisation claire avec noms explicites\")\n",
+    "m_buggy = float(trace_buggy.posterior[\"m\"].mean())\n",
+    "s_buggy = float(trace_buggy.posterior[\"s\"].mean())\n",
+    "n_div_buggy = int(trace_buggy.sample_stats[\"diverging\"].sum().values)\n",
+    "print(f\"  Posterior de la moyenne : m ~ {m_buggy:.3f}\")\n",
+    "print(f\"    --> CONTRADICTION : la donnee vaut ~{donnees.mean():.1f}, mais la posterior reste a ~0.\")\n",
+    "print(f\"        Le prior Normal(0, sigma=0.01) est si concentre qu'il ECRASE la donnee.\")\n",
+    "print(f\"  Posterior de l'ecart-type : s ~ {s_buggy:.2f} (modélisé par une Normal, non contraint > 0).\")\n",
+    "print(f\"  Divergences NUTS : {n_div_buggy}  -- attention, 0 divergence ne signifie pas 'modele correct' !\")\n",
     "print()\n",
-    "print(f\"Resultats : moyenne ~ {trace_ex.posterior['moyenne'].mean().values:.1f}, \"\n",
-    "      f\"sigma ~ {trace_ex.posterior['sigma'].mean().values:.1f}\")"
+    "\n",
+    "print(\"-- Modele corrige --\")\n",
+    "with pm.Model() as model_corrige_ex:\n",
+    "    moyenne = pm.Normal(\"moyenne\", mu=25, sigma=50)\n",
+    "    sigma = pm.HalfNormal(\"sigma\", sigma=10)\n",
+    "    obs = pm.Normal(\"obs\", mu=moyenne, sigma=sigma, observed=donnees)\n",
+    "    trace_ex = pm.sample(\n",
+    "        draws=2000, chains=2, cores=1, random_seed=RANDOM_SEED, target_accept=0.95,\n",
+    "        progressbar=False, return_inferencedata=True\n",
+    "    )\n",
+    "print(f\"  Posterior de la moyenne : moyenne ~ {float(trace_ex.posterior['moyenne'].mean().values):.1f}  (recovere la donnee)\")\n",
+    "print(f\"  Posterior de l'ecart-type : sigma ~ {float(trace_ex.posterior['sigma'].mean().values):.1f}  (HalfNormal, > 0)\")\n",
+    "n_div_ex = int(trace_ex.sample_stats[\"diverging\"].sum().values)\n",
+    "print(f\"  Divergences : {n_div_ex}\")\n",
+    "print()\n",
+    "print(\"=> Le reflexe debug : comparer la posterior a la DONNEE, pas seulement aux divergences.\")\n",
+    "print(\"   Ici les deux modeles ont 0 divergence -- c'est l'ecart m~0 vs donnee~25 qui revele le bug.\")\n"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "818b9439",
-   "metadata": {
-    "papermill": {
-     "duration": 0.006012,
-     "end_time": "2026-06-15T04:28:39.197589+00:00",
-     "exception": false,
-     "start_time": "2026-06-15T04:28:39.191577+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "**Analyse des corrections** :\n",
     "\n",
-    "| problème original | Consequence | Correction appliquée |\n",
-    "|-------------------|-------------|----------------------|\n",
-    "| sigma=0.01 sur le prior | Prior concentre autour de 0 (ecart-type ~0.01) | sigma=50 (ecart-type large) |\n",
-    "| Normal pour l'ecart-type | Peut générer des valeurs negatives (invalides) | HalfNormal (strictement positif) |\n",
-    "| variables anonymes | Difficulte a interpréter les résultats | Nommage explicite |\n",
+    "| probleme original | consequence observee | correction appliquee |\n",
+    "|-------------------|----------------------|----------------------|\n",
+    "| `m = Normal(0, sigma=0.01)` | Prior hyper-concentre : la posterior reste a ~0 et **ignore la donnee** (~25) | `moyenne = Normal(25, sigma=50)` (prior large) |\n",
+    "| `s = Normal(0, sigma=1)` | L'ecart-type n'est pas contraint a rester positif | `sigma = HalfNormal(10)` (strictement positif) |\n",
+    "| variables anonymes (`m`, `s`) | Lecture difficile des resultats | Nommage explicite (`moyenne`, `sigma`) |\n",
     "\n",
-    "Le résultat corrige montre :\n",
-    "- **Moyenne ~50** : proche de l'observation car le prior est large\n",
-    "- **Sigma** : estime avec incertitude a partir d'une seule observation"
+    "Le contraste entre les deux executions est frappant :\n",
+    "\n",
+    "- **Modele bugge** : la posterior de la moyenne reste a ~0 -- le prior a **ecrase la donnee** -- alors que les donnees valent ~25. Pourtant, NUTS ne signale **aucune divergence**.\n",
+    "- **Modele corrige** : la moyenne se recovere autour de ~25 (la donnee l'emporte), $\\sigma$ est estime proprement, et les diagnostics restent propres.\n",
+    "\n",
+    "> **Lecon de debogage** : un prior trop concentre est un piege *silencieux*. Le sampler peut tourner sans divergence apparente, pourtant la posterior ignore la donnee. Le reflexe : **comparer la posterior a la donnee empirique** (et non se fier uniquement aux divergences / $\\hat{R}$ / ESS, qui peuvent rester bonnes).\n"
    ]
   },
   {


### PR DESCRIPTION
## fix(probas,#8081): PyMC-6-Debugging §7 — exercise the debug loop + make the "correct" model actually correct

Grain: MED/notebook-python — lane myia-po-2025:CoursIA — prev: MED/notebook-dotnet (Z3-06-Csharp Prong-B #8353).

Firsthand audit of the PyMC twin of Infer-6 (whose §7 gap was backfilled by po-2026 in #8349). Same gap-class, two defects in `PyMC-6-Debugging.ipynb` §7 "Exemple guide : Debugger un Modèle":

### Defect A — the "correct" example model was itself broken (doc-honesty)

Cell `model_corrige` ("Modele d'estimation **bien specifie** / déjà corrigé") used `observed=50` — a **single scalar observation**. With n=1, `sigma` is unidentified → Neal's funnel → the committed output literally showed **573 divergences + R-hat > 1.01 + ESS < 100**, while the prose (cell 33) claimed it showed "comment spécifier **correctement** un modèle". A *debugging* notebook teaching that 573 divergences = "well-specified" is an integrity bug.

**Firsthand-verified** (coursia-ml-training kernel, PyMC 5.28.5, `random_seed=42`, determinism confirmed): the single-obs model reproduces divergences (49 at 500 draws; 573 at the notebook's 2000/4). A well-specified version with **n=30 observations** samples clean: **0 divergences, R-hat 1.0, ESS 4684**, `moyenne` 25.14 (hdi [22.9, 27.3]), `sigma` 6.44. Fix: cell 34 now uses n=30 simulated data → the "bien spécifié" claim is **true**.

### Defect B — the debug loop was described, not exercised

Cell 36 had the buggy model **commented out** ("`# DECOMMENTEZ POUR VOIR LES PROBLEMES`") and immediately ran the corrected version — so the student **never sees the buggy model fail**. The debug loop (cassé → diagnostic → fix) was prose, not demonstrated.

**Fix**: cell 36 now **runs the buggy model** and shows its real symptom, then the corrected model, side by side:

```
Rappel : les donnees (n=30) ont une moyenne empirique de 25.1.

-- Modele bugge (3 erreurs) --
  Posterior de la moyenne : m ~ 0.001
    --> CONTRADICTION : la donnee vaut ~25.1, mais la posterior reste a ~0.
        Le prior Normal(0, sigma=0.01) est si concentre qu'il ECRASE la donnee.
  Divergences NUTS : 0  -- attention, 0 divergence ne signifie pas 'modele correct' !

-- Modele corrige --
  Posterior de la moyenne : moyenne ~ 25.1  (recovere la donnee)
  Divergences : 0

=> Le reflexe debug : comparer la posterior a la DONNEE, pas seulement aux divergences.
```

The deeper pedagogical finding (mirrors Infer-6 #8349): the bug is **NOT** caught by divergences — both models have 0 — but by **comparing the posterior to the data** (m≈0 vs data≈25). A hyper-concentrated prior is a *silent* trap: the sampler runs cleanly yet the posterior ignores the data. This is the reflex the §7 debugging section exists to teach.

### Validation

- **Firsthand re-executed** via `nbconvert --execute` (kernel `coursia-ml-training`, PyMC 5.28.5, matching the notebook's committed env): 0 errors, real captured outputs (stdout+stderr interleaved correctly).
- **H.3** `validate_pr_notebooks.py origin/main <path>`: **1/1 PASS** (13 code cells).
- **Minimal diff (C.3)**: hybrid reconstruct from `origin/main` baseline + surgical replace of cells 33-37 (intro md + cell34 code + challenge md + cell36 code + analysis md). Verified by-id that **only cells [33,34,35,36,37] changed** — §8/§9 exercises + summary intact. ec preserved (34=11, 36=12; the pre-existing ec anomaly on cells 15/18 is in origin/main, untouched).
- **C.1**: 0 violations (`raise`/`assert False`/`1/0` scan clean).
- **LF** + round-trip stable `json.dumps(indent=1)`.
- Diff: **+133/−158**, 1 file (the net negative = the old 573-divergence output + commented buggy model replaced by the exercised debug loop — legitimate §7 content replacement, not a regression; no exercise/solution stripped).

### Context

PyMC twin of Infer-6 (#8349). Part of the #8081 fidelity audit — PyMC-6 verdict: gap was **localized to §7** (backfilled here); the rest (§2.2 divergences, §3 NUTS-vs-ADVI, §4 ArviZ diagnostics, §5 priors, §6 checklist) is faithful and rich. See #8081, See #8052.
