### PR TITLE
fix(search,#8364): ground MGS-3 prose numbers in committed cone-lisse output

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-3-Eukaryote.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-3-Eukaryote.ipynb
@@ -1486,7 +1486,7 @@
    "source": [
     "### Mesure : la configuration Default+NoOp peut-elle gagner ?\n",
     "\n",
-    "La cellule precedente montre l'heterogene (Default+NoOp) perdante d'environ 150x sur le cone lisse. La prose ci-dessus suggerait que l'heterogene devient pertinente \"quand les dimensions ont des caracteristiques tres differentes\". Verifions cette affirmation **empiriquement** : construisons un paysage ou la position est **rugueuse** (Rastrigin1D, nombreux optima locaux) et la vitesse est un **pic etroit** (Gaussienne centree en 25), puis comparons Default+NoOp vs Default+Default en balayant la largeur du pic. Si l'heterogene a un avantage structurel, il devrait apparaitre sur au moins une de ces largeurs."
+    "La cellule precedente montre l'heterogene (Default+NoOp) perdante de plus de 440x sur le cone lisse (Amelioration -44066,7% a la cellule precedente). La prose ci-dessus suggerait que l'heterogene devient pertinente \"quand les dimensions ont des caracteristiques tres differentes\". Verifions cette affirmation **empiriquement** : construisons un paysage ou la position est **rugueuse** (Rastrigin1D, nombreux optima locaux) et la vitesse est un **pic etroit** (Gaussienne centree en 25), puis comparons Default+NoOp vs Default+Default en balayant la largeur du pic. Si l'heterogene a un avantage structurel, il devrait apparaitre sur au moins une de ces largeurs."
    ]
   },
   {
@@ -1626,7 +1626,7 @@
     "\n",
     "**Resultat** : sur **chaque** largeur de pic (sigma 0.5 a 5), l'uniforme (Default+Default) bat l'heterogene (Default+NoOp). La vitesse figee par `NoOpMetaHeuristic` ne peut pas atteindre un pic etroit que la vitesse evoluee (`DefaultMetaHeuristic`) rejoint systematiquement : l'elitisme combine au crossover fait converger Default vers la cible meme sous mutation, tandis que NoOp fige la vitesse a sa valeur initiale et ne peut l'ameliorer.\n",
     "\n",
-    "**Conclusion mesuree** : le couplage Default+NoOp utilise dans ce notebook est **structurellement desavantage** sur toute dimension a cible unique. Il ne peut donc PAS illustrer la victoire heterogene decrite dans la prose ci-dessus. L'ecart de -15000% observe sur le cone lisse n'est pas un defaut du moteur eukaryote : c'est la consequence attendue d'avoir assigne `NoOpMetaHeuristic` (une non-strategie) a une dimension qui aurait besoin d'evoluer.\n",
+    "**Conclusion mesuree** : le couplage Default+NoOp utilise dans ce notebook est **structurellement desavantage** sur toute dimension a cible unique. Il ne peut donc PAS illustrer la victoire heterogene decrite dans la prose ci-dessus. L'ecart de -44066,7% observe sur le cone lisse n'est pas un defaut du moteur eukaryote : c'est la consequence attendue d'avoir assigne `NoOpMetaHeuristic` (une non-strategie) a une dimension qui aurait besoin d'evoluer.\n",
     "\n",
     "**Quand l'heterogene gagne vraiment** : il faut une **specialisation reelle** des sous-heuristiques -- une exploration forte (mutation amplifiee) sur une partition au paysage rugueux, et une exploitation fine (faible mutation) sur une partition au paysage lisse. Ce genre de specialisation par partition est precisement l'objet de l'**Exercice 3** (implementer un `SubPopulationMetaHeuristic` personnalise). Le demo ci-dessus, lui, isole proprement l'effet de chaque sous-heuristique par partition -- capacite distinctive de l'eukaryote -- et montre que NoOp est un point de comparaison (le pire cas), pas une strategie gagnante."
    ]


### PR DESCRIPTION
Closes #8368. See #8364, #8367 (rule C.4), #8052 (EPIC).

## What & why

MGS-3 interpretation markdown cited magnitudes (**150x**, **-15000%**) that do not appear in the committed `cell[15]` output, which prints `Amelioration : -44066,7%` (ratio `2,6500 / 0,0060` = ~441,7x worse). Rule C.4 (#8367) forbids citing values absent from observed outputs without re-measuring or reformulating.

This is the first **dogfood** of rule C.4 — the author of #8367 applies it to a defect surfaced in #8368.

## Change (markdown-only — C.2 exception, outputs already real)

| Cell | id | Before | After |
|------|----|--------|-------|
| cell[17] | `measure-hetero-question` | "perdante d'environ **150x** sur le cone lisse" | "perdante de plus de **440x** sur le cone lisse (Amelioration **-44066,7%** a la cellule precedente)" |
| cell[19] | `measure-hetero-interpretation` | "ecart de **-15000%** observe sur le cone lisse" | "ecart de **-44066,7%** observe sur le cone lisse" |

Both values now **literally present** in `cell[15]` committed output (`Amelioration : -44066,7%`).

## C.4 verdict: `CAUSE_FIXED`

The committed output (`cell[15]`, `ec=6`, 25 outputs) was **always correct** — it literally contains `-44066,7%`. Only the prose **mis-remembered** the magnitude. Cause root: stale recall in prose, not a drifted execution. Fix = align prose to the (correct, stable) output. No degeneration consecrated; no re-exec needed (C.2 markdown-only exception).

## Validation

- Markdown-only: `+2/-2`, **0** code/output/`execution_count` changes (`git diff` grep).
- Ground-truth `cell[15]` untouched (ec=6, 25 outputs, contains `-44066,7%`).
- Byte-stable: surgical substring replace (each target unique in file), `write_bytes` preserves LF (**0** CRLF after edit).
- JSON valid post-edit.
- Base fresh: rebased on `origin/main` (`8743cafb1`); PR carries **1** atomic commit.

## Scope

Single notebook, single concern (rule C.4 grounding). No catalogue churn (byte-identical to main). Not promoting any rule — `C.4` stays in [notebook-conventions.md](../../.claude/rules/notebook-conventions.md), awaiting coordinator validation in #8367.

Co-Authored-By: Claude-Code <noreply@anthropic.com>