### PR TITLE
fix(rl-6,#8052): md claims DQN/REINFORCE reach CartPole threshold 195 — output shows 128.9/75.7

### DIFF
--- a/MyIA.AI.Notebooks/RL/rl_6_dqn_policy_gradient.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_6_dqn_policy_gradient.ipynb
@@ -1038,7 +1038,11 @@
     "tags": []
    },
    "source": [
-    "Les deux agents atteignent généralement le seuil de resolution (195) sur CartPole. Le DQN a tendance a produire des politiques plus stables grace a son replay buffer."
+    "**Aucun des deux agents n'atteint le seuil de résolution (195) sur CartPole lors de cette évaluation.**\n",
+    "\n",
+    "Le DQN obtient une récompense moyenne de 128,9 (±4,8) et REINFORCE 75,7 (±5,7) — soit respectivement environ 66 et 119 points sous le seuil de 195 affiché par le notebook. Les hyperparamètres pédagogiques de cette démonstration (peu d'épisodes d'entraînement, petits réseaux de neurones) ne suffisent pas à résoudre l'environnement : atteindre le seuil de 195 exigerait un entraînement nettement plus long.\n",
+    "\n",
+    "Le DQN surpasse néanmoins REINFORCE (128,9 vs 75,7) **avec une variance plus faible** (±4,8 vs ±5,7) : son *replay buffer* réutilise des transitions passées pour lisser l'estimation du gradient, ce qui produit des politiques plus stables. La conclusion qualitative (DQN plus stable que REINFORCE grâce au replay buffer) est donc juste ; seule l'affirmation d'un seuil atteint ne l'était pas."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python-audit-claims — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-dotnet (c.860, Planners-6-Csharp #8361)

## What

`RL/rl_6_dqn_policy_gradient.ipynb` md[22] (id `w2n3e023`) — the interpretation cell following the CartPole evaluation — **claimed both DQN and REINFORCE reach the solve threshold (195), but the committed evaluation output shows neither does.** Classic doc-honesty defect: markdown claims success, output shows failure. See #8052.

## The defect (firsthand, G.1)

| | md[22] claim | code[21] committed output |
|---|---|---|
| Threshold | "Les deux agents atteignent généralement le seuil de résolution (195)" | `Seuil CartPole-v1 (solve) : 195` |
| DQN | (implied: reaches 195) | `DQN : 128.9 +/- 4.8` → max ~134, **66 short** |
| REINFORCE | (implied: reaches 195) | `REINFORCE : 75.7 +/- 5.7` → max ~81, **119 short** |

**Neither agent reaches 195.** DQN is at ~66% of the threshold, REINFORCE at ~39%. This is not "généralement" defensible — code[21] is the ONLY output mentioning the threshold (verified: no other cell shows an agent reaching 195), so the "atteignent" claim has no basis anywhere in the notebook. Pedagogically misleading: a student reading md[22] would believe both methods solved CartPole.

## The fix (markdown-only reframe, grounded in committed output)

Reworded md[22] to state honestly that **neither agent reaches the threshold**, with the real numbers, while preserving the part of the claim that IS true (DQN > REINFORCE, lower variance, replay buffer):

> "**Aucun des deux agents n'atteint le seuil de résolution (195)** … Le DQN obtient 128,9 (±4,8) et REINFORCE 75,7 (±5,7) — soit environ 66 et 119 points sous le seuil … atteindre 195 exigerait un entraînement nettement plus long. Le DQN surpasse néanmoins REINFORCE (128,9 vs 75,7) **avec une variance plus faible** (±4,8 vs ±5,7) : son *replay buffer* … La conclusion qualitative (DQN plus stable que REINFORCE) est donc juste ; seule l'affirmation d'un seuil atteint ne l'était pas."

## Why this is NOT a "prosaic drift" fix (#8364 distinction)

po-2025's #8364 proposal flags re-aligning numbers that **drifted** under re-execution (stochastic/seed) without understanding why. This is different: it is a **qualitative success claim the output never supported** — not "the output changed and the markdown went stale". The two other candidates the scan surfaced WERE drift traps (explicitly deferred):
- **DecInfer-8 md[33]** ε-greedy row (673,7 vs 666,0): root cause = `EpsilonGreedy._rng = new Random()` is **unseeded** (the bandit's `seed=42` doesn't propagate to the strategy). Re-aligning the markdown would just drift on the next re-exec. Proper fix = seed the strategy RNG (separate, scope-creep PR).
- **rl_4 md[35]** "UCB finit 2e": ranking-wording ambiguity (the cell body itself says "UCB en mauvaise position"), lower severity.

rl_6 md[22] was the cleanest: a threshold success/failure claim, output definitively shows failure, root cause = aspirational prose not a drift artifact.

## Validation (markdown-only, byte-surgical)

- 1 cell changed (md[22] `source` only, id `w2n3e023` preserved). `git diff --stat` = **+5 / -1**.
- **Byte-surgical verified by id-diff**: 0 other cells' `source`/`execution_count`/`outputs` changed (script compared every cell against `origin/main`); 12 code cells ec+outputs byte-identical; total cells unchanged (28).
- Markdown-only → **C.2 exception** (no code cell modified, no re-execution required; the committed output 128.9/75.7 is the truth the prose now reflects).
- nbformat.validate OK · H.3 PASS (12 code cells, all `ec != null` + outputs) · C.1 clean (0 `raise NotImplementedError`/`assert False`/`1/0`) · 0 CRLF.

## Investigation honesty this cycle

- **Explore sub-agent (sonnet) scanned 133 notebooks across 5 fresh families** (SmartContract 27, RL 18, DecisionTheory 18, ML.NET+DataScience 47, SemanticWeb-ex-SW13 23) for concrete md↔output contradictions. **SmartContract / ML.NET / SemanticWeb = 0 mismatches** (confirms the "mined" assessment was accurate for those). **RL = 2, DecisionTheory = 1**.
- **MEMORY record corrected (G.1/G.9)**: my MEMORY declared "13/13 familles CPU/.NET CLEAN (Search/GameTheory/Infer/SemanticWeb/ML/RL)". RL was in that list — **this firsthand finding proves RL was NOT clean** (prior scan was incomplete). Recording the correction.

## L898 / collision check

- `gh pr list --search "rl_6 dqn policy gradient"` = 0 OPEN touching this notebook. No collision.

## Residual (flagged, NOT fixed in this PR — scope)

**CartPole-v1 threshold mislabel**: the notebook uses `gym.make("CartPole-v1")` (verified code[5]/[9]/[16]/[21]) but applies threshold **195 everywhere** (code[21] print, code[11]/[18] `axhline(y=195)`, md). The standard CartPole-**v1** solve threshold is **475** (195 is CartPole-**v0**). So the notebook is lenient by ~2.4× — the agents don't even reach the lenient 195, let alone the real 475. This pervades code + plots (re-exec required) = separate PR. Flagging for a follow-up issue.

## Variation note

1st grain in the **RL family** this session (fresh family — Search/CSP/GameTheory/Sudoku/Infer/Planners/SW all previously worked). Genre `notebook-python-audit-claims` after `notebook-dotnet` (c.860 #8361) → G-VAR-3 OK (genre change). Honors ai-01 standing steer (msg-20260724T105816: "pioche le prochain notebook où … une claim de convergence/perf non mesurée, et reframe/mesure") — rl_6's "threshold reached" perf claim was unmeasured/false, verified firsthand, reframed. MED not LIGHT per litmus: required reading the actual evaluation output and judging the threshold claim false (128.9/75.7 vs 195) — not scan-generatable (the Explore scan + firsthand reverify of 3 candidates, including ruling out 2 drift-traps, was factual judgment, not a regex).

See #8052 · See #3801
