### PR TITLE
fix(ci,#8345): install PyYAML in catalog-drift + catalog-cron (generate_catalog crashes without it)

### DIFF
--- a/.github/workflows/catalog-cron.yml
+++ b/.github/workflows/catalog-cron.yml
@@ -59,6 +59,12 @@ jobs:
         with:
           python-version: '3.11'
 
+      # PyYAML is required by generate_catalog.py's editorial-review registry
+      # loader (_load_editorial_registry, added in #8345). Without it the
+      # generator crashes: ModuleNotFoundError: No module named 'yaml'.
+      - name: Install PyYAML
+        run: pip install pyyaml
+
       - name: Regenerate catalog (.json + .md) + README markers
         run: |
           set -euo pipefail

--- a/.github/workflows/catalog-drift.yml
+++ b/.github/workflows/catalog-drift.yml
@@ -58,6 +58,12 @@ jobs:
         with:
           python-version: '3.11'
 
+      # PyYAML is required by generate_catalog.py's editorial-review registry
+      # loader (_load_editorial_registry, added in #8345). Without it the
+      # generator crashes: ModuleNotFoundError: No module named 'yaml'.
+      - name: Install PyYAML
+        run: pip install pyyaml
+
       # Canonical regeneration (local to the runner only — nothing is written
       # back to the branch). git-tracked notebooks only, for CI determinism.
       - name: Regenerate catalog + README markers


### PR DESCRIPTION
Closes nothing (#8345 is already merged). See #8345, #8051.

## P0 — fleet-wide CI break since #8345 merged (~2h ago)

`generate_catalog.py` crashes in CI:
```
File ".../generate_catalog.py", line 994, in _load_editorial_registry
    import yaml  # PyYAML — part of repo tooling (cf check_twin_parity.py, #8057)
ModuleNotFoundError: No module named 'yaml'
```
called from `main() -> _apply_editorial_review_promotion() -> _load_editorial_registry()`.

**Root cause** — #8345 (commit e62d819845) added an unconditional `import yaml` to `_load_editorial_registry()`, but the two workflows that run `generate_catalog.py` never install PyYAML:
| workflow | runs generate_catalog? | installs pyyaml? |
|----------|------------------------|------------------|
| `catalog-drift.yml` (per-PR, read-only) | yes | **NO → crashes on every PR** |
| `catalog-cron.yml` (daily main regen) | yes | **NO → will crash next run, stale catalog on main** |
| `twin-parity.yml` (sibling) | runs `check_twin_parity.py` (also `import yaml`) | yes (L60) ✓ |

## Impact
- **All PRs** fail the `Notebook catalog drift (read-only)` check since #8345.
- The **daily catalog-cron** on `main` will crash on its next scheduled run → `COURSE_CATALOG.generated.json/md` goes stale.

## Fix
Add the same `pip install pyyaml` step `twin-parity.yml` uses, after `setup-python`, in both workflows. `+6/-0` each, no code change, matches existing precedent.

## Proof the crash is resolved (local)
```
_load_editorial_registry() -> SUCCESS, returned 3-entry registry
```
(was `ModuleNotFoundError: No module named 'yaml'` before). Both workflow YAMLs re-validated (`yaml.safe_load` OK, install step present).

## NOT caused by #8365 (my earlier catalog refactor)
`git blame` confirms both the `import yaml` (L994) **and** the `_apply_editorial_review_promotion` call (L1291) were added by `e62d819845` (#8345). #8365 only touched `classify_scientific_review` (L714) + its caller (L827) — zero overlap with `main()`, the editorial call, or imports.

## Scope
2 workflow files, `+12/-0`, atomic single concern. No catalogue churn. H.4 forensic verdict: was `STRUCTURAL_ONLY` (crash) → `EXEC_PROVED` once PyYAML is present.

Co-Authored-By: Claude-Code <noreply@anthropic.com>