### PR TITLE
feat(tooling,#8056): check_cost_metadata reads metadata.cost first (canonical) + doc PR A

### DIFF
--- a/docs/notebook-metadata/cost-matrix.md
+++ b/docs/notebook-metadata/cost-matrix.md
@@ -14,36 +14,65 @@ L'open-courseware CoursIA héberge **300+ notebooks** (Python + .NET Interactive
 3. **Le catalogue** (`COURSE_CATALOG.generated.json`) n'expose **aucun champ** runtime/ressource.
 4. **Les audits sémantiques** (#8052) prennent l'output comme vérité — si l'exécution a silencieusement *skip* une cellule GPU, le claim reste faux même avec une note pédagogique d'avertissement.
 
-## Schéma `cost:` — YAML frontmatter portable
+## Schéma `cost:` — `nb.metadata['cost']` (JSON, forme canonique)
 
-Chaque notebook pédagogique DOIT exposer en cellule 0 (markdown) un bloc YAML :
+**Forme canonique (design-gate c.866, #8056).** Chaque notebook pédagogique DOIT
+exposer sa matrice de coût dans **`nb.metadata['cost']`** (objet JSON, invisible
+au rendu markdown). C'est la seule forme propre : une cellule markdown portant un
+bloc `---\n...\n---` est promue par markdown-it en **setext-H2 supersize**
+(défaut de rendu que le guard `#8352` bloque en ERROR). L'exemplar de référence =
+[`Infer-3-Factor-Graphs`](../../MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb)
++ `Infer-4-Bayesian-Networks` (PR #8323).
 
-```yaml
----
-title: <titre du notebook>
-cost:
-  api_usd_est: <float|range>     # Coût API estimé par exécution end-to-end (USD). 0 si gratuit.
-  api_provider: <string>         # openai | anthropic | mistral | hf | replicate | google | local
-  cpu_min: <int>                 # Estimation CPU-only minutes (range ou best-case)
-  gpu_min: <int>                 # Estimation GPU minutes (range ou best-case)
-  gpu_required: <bool>           # true si impossible sans GPU
-  vram_gb: <int|range>           # VRAM minimum (GB), ex: 12, 24, ou range "16-24"
-  vram_tier: <LITE|MID|HIGH>     # Catégorie VRAM (cf table §"Tiers VRAM")
-  network: <bool>                # Accès réseau requis (téléchargement modèle, appel API)
-  external_account: <string|none>  # Compte externe obligatoire (openai, anthropic, hf, qc, ...)
-  free_alternative: <string|none>  # Notebook du dépôt qui couvre le même sujet sans coût
-  reduced_pedagogical: <string|none>  # Version pédagogique réduite (sous-ensemble ou mock)
-  reproducibility: <HIGH|MED|LOW>  # Reproductibilité : HIGH=déterministe, MED=seed-dépendant, LOW=stochastique
-  last_validated: <ISO8601>       # Date dernière exécution validée (papermill/QC Cloud/MCP)
-  validator: <papermill|qc_cloud|manual|lean_build|sk_agent|sk_visual>
----
+```json
+// nb.metadata["cost"] — l'objet JSON sérialisé par le notebook (.ipynb = JSON).
+{
+  "api_usd_est": 0.40,            // Coût API estimé par exécution end-to-end (USD). 0 si gratuit.
+  "api_provider": "openai",       // openai | anthropic | mistral | hf | replicate | google | local | none
+  "cpu_min": 1,                   // Estimation CPU-only minutes (range ou best-case)
+  "gpu_min": 0,                   // Estimation GPU minutes (range ou best-case)
+  "gpu_required": false,          // true si impossible sans GPU
+  "vram_gb": 0,                   // VRAM minimum (GB), ex: 12, 24, ou range "16-24"
+  "vram_tier": "LITE",            // Catégorie VRAM (cf table §"Tiers VRAM")
+  "network": true,                // Accès réseau requis (téléchargement modèle, appel API)
+  "external_account": "openai",   // Compte externe obligatoire (openai, anthropic, hf, qc, ...) | "none"
+  "free_alternative": null,       // Notebook du dépôt qui couvre le même sujet sans coût | null
+  "reduced_pedagogical": null,    // Version pédagogique réduite (sous-ensemble ou mock) | null
+  "reproducibility": "HIGH",      // HIGH=déterministe, MED=seed-dépendant, LOW=stochastique
+  "last_validated": "2026-07-24", // Date dernière exécution validée (ISO8601, papermill/QC Cloud/MCP)
+  "validator": "papermill",       // papermill | qc_cloud | manual | lean_build | sk_agent | sk_visual
+}
 ```
+
+> Le champ `title` (présent dans l'ancienne forme YAML) est **retiré** : redondant
+> avec le titre H1 du notebook. Les valeurs sont identiques à l'ancien schéma YAML
+> (seul le **lieu de stockage** change : JSON metadata au lieu de cellule markdown).
+
+### Migration & backward-compat
+
+La migration de masse des ~100 notebooks existants se fait **par tranches famille**
+(rollout c.795/796/797 pattern), chaque lane migrant sa famille opportuniste. Le
+vérificateur [`check_cost_metadata.py`](../../scripts/audit/check_cost_metadata.py)
+lit **`metadata['cost']` d'abord**, retombe sur le scan de cellule `---...---` en
+**fallback** (backward-compat) — les deux formes coexistent pendant la transition,
+l'ordre de migration est non-bloquant. À terme, toutes les cellules `---`-YAML
+sont retirées (elles déclenchent le guard `#8352`).
+
+**Divulguation coût côté étudiant (OPTIONNELLE).** La matrice `metadata.cost` est
+machine-only (invisible). Si on souhaite la surface à l'étudiant, une **petite
+table markdown rendue** ou un **badge** suffit — jamais reproduire le YAML brut :
+
+```markdown
+> 💰 **Coût** : gratuit (CPU local, ~3 min). Pas de compte externe requis.
+```
+
+Ne pas sur-scoper 100 notebooks avec une table rendue — `metadata.cost` reste la
+source de vérité, le badge est un confort de lecture.
 
 ### Champs obligatoires vs optionnels
 
 | Champ | Obligatoire | Défaut si omis |
 |-------|-------------|----------------|
-| `title` | ✓ | (chaîne libre) |
 | `cost.api_usd_est` | ✓ | `0` |
 | `cost.api_provider` | ✓ | `"none"` |
 | `cost.cpu_min` | ✓ | `0` |
@@ -56,7 +85,7 @@ cost:
 | `cost.free_alternative` | optionnel | `null` (peut être ajouté après-coup) |
 | `cost.reduced_pedagogical` | optionnel | `null` |
 | `cost.reproducibility` | ✓ | `"HIGH"` |
-| `cost.last_validated` | ✓ | (date de création du frontmatter) |
+| `cost.last_validated` | ✓ | (date de création de la metadata) |
 | `cost.validator` | ✓ | `"manual"` |
 
 ### Tiers VRAM (déterminé par `vram_gb`)
@@ -90,6 +119,13 @@ Le champ `cost.free_alternative` permet le routage machine : si `po-2025` n'a pa
 ## Peuplement pilote (cycle c.794)
 
 5 familles × 2 notebooks = 10 entrées de référence (échantillon ≥5%/famille, conforme protocole #8052).
+
+> **Note — syntaxe des exemples.** Les blocs ci-dessous sont en **YAML commenté**
+> pour la lisibilité (le JSON canonique de `metadata['cost']` ne supporte pas les
+> commentaires inline). Les **valeurs des champs** sont strictement identiques entre
+> l'ancienne forme YAML cellule et la nouvelle forme `metadata.cost` JSON — seul le
+> **lieu de stockage** change. En pratique, ces valeurs vont dans
+> `nb.metadata['cost']` (objet JSON sérialisé par le `.ipynb`).
 
 ### GenAI/Image (GPU + API $)
 
@@ -310,14 +346,14 @@ cost:
 
 ## Intégration à la grille audit sémantique #8052
 
-Le script `extract_claims_vs_outputs.py` (livré par [PR #8068 / cycle c.793](https://github.com/jsboige/CoursIA/pull/8068) — branche `feature/c793-audit-semantic-sampling-8052`) confronte claims-du-markdown ↔ outputs réels. **Litmus 5 (cohérence pédagogique)** peut être étendu pour vérifier que la cellule frontmatter `cost:` est cohérente avec le reste du notebook :
+Le script `extract_claims_vs_outputs.py` (livré par [PR #8068 / cycle c.793](https://github.com/jsboige/CoursIA/pull/8068) — branche `feature/c793-audit-semantic-sampling-8052`) confronte claims-du-markdown ↔ outputs réels. **Litmus 5 (cohérence pédagogique)** vérifie que la matrice `metadata['cost']` est cohérente avec le reste du notebook :
 
 | Incohérence | Sévérité |
 |-------------|----------|
-| Frontmatter `cost.gpu_required: false` mais cellule code lance `torch.cuda.device()` | MAJOR |
-| Frontmatter `cost.api_usd_est: 0.0` mais cellule appelle `openai.ChatCompletion.create()` | CRITICAL |
-| Frontmatter `cost.external_account: none` mais cellule demande `HF_TOKEN` | MAJOR |
-| Frontmatter `cost.free_alternative` pointe vers un notebook inexistant | MAJOR |
+| `metadata.cost.gpu_required: false` mais cellule code lance `torch.cuda.device()` | MAJOR |
+| `metadata.cost.api_usd_est: 0.0` mais cellule appelle `openai.ChatCompletion.create()` | CRITICAL |
+| `metadata.cost.external_account: none` mais cellule demande `HF_TOKEN` | MAJOR |
+| `metadata.cost.free_alternative` pointe vers un notebook inexistant | MAJOR |
 | Notebook QC sans `qc_cloud` validator | MAJOR |
 | Notebook GPU sans `sk_visual` validator (cf #5780 sweep) | MINOR |
 
@@ -328,7 +364,7 @@ Ces extensions restent **hors scope c.794** (à dispatcher cycles c.795+) — la
 Pour chaque cycle mensuel :
 
 - 1 fichier `docs/notebook-metadata/cost-matrix.md` mis à jour (peuplement continu par famille)
-- N notebooks avec frontmatter `cost:` ajouté (pilote : 10 en c.794, ~50 en c.795+)
+- N notebooks avec `metadata['cost']` ajouté (pilote : 10 en c.794, ~50 en c.795+)
 - 1 entrée catalogue `cost` exposée dans `COURSE_CATALOG.generated.json` (cf catalog-pr-hygiene R1 : régénération automatique par cron quotidien, pas manuel)
 - 1 validateur `scripts/audit/check_cost_metadata.py` (cf livrable 2) — flag les incohérences litmus 5
 
@@ -344,7 +380,7 @@ Pour chaque cycle mensuel :
 
 | # | Critère | Status c.794 |
 |---|---------|--------------|
-| 1 | Schéma `cost:` portable (YAML frontmatter cellule 0) | ✅ Défini ci-dessus (15 champs) |
+| 1 | Schéma `cost:` canonique (`nb.metadata['cost']` JSON, cellule `---`-YAML retirée du mandat guard #8352) | ✅ Défini ci-dessus (14 champs, `title` retiré) |
 | 2 | Colonne catalogue correspondante (`COURSE_CATALOG.generated.json.cost`) | ✅ Schéma JSON défini (cf §"Colonne catalogue") |
 | 3 | ≥5%/famille pilote (10/300 = 3.3% global, mais 2/famille sur 5 familles pilotes = pilote suffisant) | ✅ 10 notebooks, 5 familles |
 | 4 | Alternative gratuite / version pédagogique réduite / compte externe requis | ✅ Champs `free_alternative` + `reduced_pedagogical` + `external_account` |

--- a/scripts/audit/check_cost_metadata.py
+++ b/scripts/audit/check_cost_metadata.py
@@ -1,12 +1,18 @@
 #!/usr/bin/env python3
 """
-check_cost_metadata.py — Vérificateur cohérence frontmatter `cost:`.
+check_cost_metadata.py — Vérificateur cohérence matrice de coût `cost:`.
 
 Issue #8056 (P1) — matrice coût/ressource par notebook.
 
+Forme CANONIQUE (design-gate c.866) : `nb.metadata['cost']` (JSON, invisible au
+rendu markdown). La cellule markdown `---YAML---` est LÉGACY, RETIREE du mandat
+(markdown-it promeut le bloc `---` en setext-H2 supersize = guard #8352 ERROR).
+Ce vérificateur lit `metadata['cost']` D'ABORD, retombe sur le scan cellule
+`---...---` en backward-compat pendant la migration de masse (ordre non-bloquant).
+
 But : extraire pour un notebook :
-  - Le bloc YAML `cost:` de la première cellule markdown le portant
-    (convention c.800 = cell[1], après le titre markdown cell[0])
+  - La matrice `cost:` — depuis `nb.metadata['cost']` (canonical) ou, à défaut,
+    le bloc YAML `---...---` d'une cellule markdown (legacy fallback)
   - Les usages réels : appels API, .cuda(), HF_TOKEN, QuantBook, etc.
   - Signaler les :
       (1) gpu_required: false mais cellule code lance torch.cuda / tensorflow GPU
@@ -64,7 +70,12 @@ TOKEN_PATTERNS = {
 
 
 def parse_cost_frontmatter(cell_source: str) -> dict:
-    """Parse le bloc YAML `--- ... ---` d'une cellule markdown (c.800 = cell[1])."""
+    """Parse le bloc YAML `--- ... ---` d'une cellule markdown (LÉGACY fallback).
+
+    Forme canonique = `nb.metadata['cost']` (cf check_notebook). Cette fonction ne
+    sert qu'au backward-compat pour les notebooks pas encore migrés (convention
+    c.800 = cell[1], après le titre markdown cell[0]).
+    """
     # Pattern : début de cellule = `---`, lignes YAML, `---` final
     pattern = r'^---\s*\n(.*?)\n---\s*\n'
     match = re.match(pattern, cell_source, re.DOTALL)
@@ -114,24 +125,38 @@ def check_notebook(notebook_path: Path, repo_root: Path) -> dict:
 
     findings = []
     cost_meta = {}
+    cost_source = None  # provenance: 'metadata' (canonical) | 'markdown_cell' (legacy fallback)
     code_cells_source = []
 
-    # Extraction frontmatter : scan de TOUTES les cellules markdown.
-    # Convention c.800 = frontmatter à cell[1] (après le titre markdown cell[0],
-    # avant le code Papermill params). L'ancienne lecture cell[0]-seule ratait
-    # tous les notebooks c.800/c.801/c.821/c.822/c.823/c.824 (L829 NEW).
-    # Le premier bloc YAML `---...---` contenant `cost:` gagne ; backward-compatible
-    # (cell[0] markdown avec frontmatter reste détecté en premier).
-    for cell in nb.cells:
-        if cell.get('cell_type') != 'markdown':
-            continue
-        source = cell.get('source', '')
-        if isinstance(source, list):
-            source = ''.join(source)
-        parsed = parse_cost_frontmatter(source)
-        if 'cost' in parsed:
-            cost_meta = parsed.get('cost', {})
-            break
+    # Extraction de la matrice de coût.
+    # PR A (#8056, design-gate c.866) : la forme CANONIQUE est `nb.metadata['cost']`
+    # (JSON, invisible au rendu markdown). La cellule markdown `---YAML---` est la
+    # forme LÉGACY, RETIREE du mandat : markdown-it promeut le bloc `---` en
+    # setext-H2 supersize (guard #8352 ERROR). On lit metadata d'abord, puis on
+    # retombe sur le scan cellule en backward-compat (les deux formes coexistent
+    # pendant la migration de masse ; l'ordre est non-bloquant).
+    # Cf docs/notebook-metadata/cost-matrix.md, PR exemplar #8323 (Infer-3/4).
+    nb_metadata = nb.metadata or {}
+    md_cost = nb_metadata.get('cost')
+    if isinstance(md_cost, dict) and md_cost:
+        cost_meta = dict(md_cost)
+        cost_source = 'metadata'
+
+    # Fallback LÉGACY : scan de TOUTES les cellules markdown pour un bloc
+    # `---...---` contenant `cost:` (convention c.800 = cell[1]). Backward-compat
+    # pour les notebooks pas encore migrés vers metadata.cost.
+    if not cost_meta:
+        for cell in nb.cells:
+            if cell.get('cell_type') != 'markdown':
+                continue
+            source = cell.get('source', '')
+            if isinstance(source, list):
+                source = ''.join(source)
+            parsed = parse_cost_frontmatter(source)
+            if 'cost' in parsed:
+                cost_meta = parsed.get('cost', {})
+                cost_source = 'markdown_cell'
+                break
 
     # Agrégation cellules code
     for idx, cell in enumerate(nb.cells):
@@ -209,6 +234,7 @@ def check_notebook(notebook_path: Path, repo_root: Path) -> dict:
     return {
         'notebook': str(notebook_path),
         'cost_meta_found': bool(cost_meta),
+        'cost_source': cost_source,
         'cost_meta': cost_meta,
         'uses_gpu': uses_gpu,
         'api_used': sorted(api_used),
@@ -240,6 +266,7 @@ def main():
     lines = [
         f"notebook: {result['notebook']}",
         f"cost_meta_found: {result['cost_meta_found']}",
+        f"cost_source: {result['cost_source']!r}",
         f"uses_gpu: {result['uses_gpu']}",
         f"api_used: {result['api_used']}",
         f"tokens_required: {result['tokens_required']}",


### PR DESCRIPTION
## Summary

**PR A** (surrogate for **po-2025**, intermittent ~1 week, per ai-01 DM dispatch c.877) — canonicalize the `#8056` cost-matrix storage form to `nb.metadata['cost']` (JSON), retiring the `---`-YAML markdown cell from the mandate.

Two coupled changes (one subject: the canonical-form pivot):

### 1. `scripts/audit/check_cost_metadata.py` — metadata-first reader

`check_notebook()` now reads `nb.metadata['cost']` **FIRST** (canonical form), falling back to the markdown cell-scan (`^---...---`) in backward-compat for notebooks not yet migrated. Adds a `cost_source` provenance field (`'metadata'` | `'markdown_cell'` | `None`) to the result dict + YAML output.

Both forms coexist during the mass migration (rollout by family tranches); the read order is non-bloquant.

### 2. `docs/notebook-metadata/cost-matrix.md` — canonical form documented

Rewrites the schema section: canonical = `metadata['cost']` JSON (invisible to markdown render). The `---`-YAML cell is **RETIRED from the mandate** — markdown-it promotes it to setext-H2 supersize, which guard `#8352` blocks as ERROR. Other updates:
- Dropped redundant `title` field (H1 of the notebook suffices).
- Pilot-examples clarifying note: YAML used only for inline-comment readability (JSON is comment-free); field **values** are identical, storage = `metadata['cost']`.
- Student-facing cost disclosure = **OPTIONAL** (md badge / small rendered table, never raw YAML) — do not over-scope 100 notebooks.
- `#8052` litmus + acceptance criterion 1 + sortie-attendue references refreshed.

Exemplar of the canonical form: **#8323** (Infer-3/4 `metadata.cost`).

## Validation (post-rebase onto `502daf882`)

Parser — 5 tests, **all PASS**:

| Test | Notebook | Expected | Result |
|------|----------|----------|--------|
| T1 | Infer-3-Factor-Graphs | metadata.cost canonical | `cost_source: 'metadata'` ✅ |
| T2 | Infer-4-Bayesian-Networks | metadata.cost canonical | `cost_source: 'metadata'` ✅ |
| T3 | GenAI/Audio 01-1-OpenAI-TTS-Intro | legacy `---`-cell backward-compat | `cost_source: 'markdown_cell'` ✅ |
| T4 | Infer-1-Setup | no cost matrix | `cost_meta_found: False, cost_source: None` ✅ |
| T5 | GenAI/Audio 01-1 (litmus) | free_alternative finding | `free_alternative_missing` MAJOR detected ✅ |

- Python syntax OK (`py_compile` clean).

**Bonus catch (out of scope here):** T5 surfaces a real data defect — Audio 01-1's `free_alternative: '01-5-Kokoro-TTS-Local'` points to an absent file. The validator works as intended; the fix belongs in a separate data PR (PR C tranche), not this tooling/doc PR.

## Scope

Surrogate for po-2025 on `#8056` PR A. **Partial contribution** to the open epic — does not close it (mass migration of ~100 notebooks is PR C, distributed by family tranches across lanes).

See #8056. Part of #4208.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
