### PR TITLE
feat(probas,#8056): metadata.cost peuplement — Infer foundational tranche (7 nb) + twin rebaseline

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb
@@ -2277,6 +2277,23 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "last_validated": "2026-07-24",
+   "validator": "papermill",
+   "notes": "Configuration env .NET Interactive + Microsoft.ML.Probabilistic (NuGet). Notebook d'installation / Setup — entry point reduit de la serie. Re-exec mesure : 9s."
+  },
   "kernelspec": {
    "display_name": ".NET (C#)",
    "language": "C#",

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb
@@ -8946,6 +8946,23 @@
    ]
   }],
  "metadata": {
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": "Probas/Infer/Infer-1-Setup.ipynb",
+   "reproducibility": "HIGH",
+   "last_validated": "2026-07-24",
+   "validator": "papermill",
+   "notes": "Melanges gaussiens (GMM) + inference EM avec Infer.NET. Re-exec mesure : 19s."
+  },
   "kernelspec": {
    "display_name": ".NET (C#)",
    "language": "C#",

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-5-Causal-Inference.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-5-Causal-Inference.ipynb
@@ -1838,6 +1838,23 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": "Probas/Infer/Infer-1-Setup.ipynb",
+   "reproducibility": "HIGH",
+   "last_validated": "2026-07-24",
+   "validator": "papermill",
+   "notes": "Inference causale, do-calculus (intervention counterfactuelle), ajustement backdoor sur confondeur. cpu_min estime (aucune duree papermill enregistree) ; re-exec observe ~1min (15 cellules code, do-calculus VMP)."
+  },
   "kernelspec": {
    "display_name": ".NET (C#)",
    "language": "C#",

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb
@@ -2985,6 +2985,23 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": "Probas/Infer/Infer-1-Setup.ipynb",
+   "reproducibility": "HIGH",
+   "last_validated": "2026-07-24",
+   "validator": "papermill",
+   "notes": "Debugging de modeles probabilistes — diagnostics d'inference, inspection des messages VMP. Re-exec mesure : 16s."
+  },
   "kernelspec": {
    "display_name": ".NET (C#)",
    "language": "C#",

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb
@@ -7118,6 +7118,23 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": "Probas/Infer/Infer-1-Setup.ipynb",
+   "reproducibility": "HIGH",
+   "last_validated": "2026-07-24",
+   "validator": "papermill",
+   "notes": "Item Response Theory (IRT) — modeles de competence, estimation des parametres difficulte/competence. Re-exec mesure : 15s."
+  },
   "kernelspec": {
    "display_name": ".NET (C#)",
    "language": "C#",

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb
@@ -5840,6 +5840,23 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": "Probas/Infer/Infer-1-Setup.ipynb",
+   "reproducibility": "HIGH",
+   "last_validated": "2026-07-24",
+   "validator": "papermill",
+   "notes": "TrueSkill — classement bayesien des joueurs (rating, incertitude). Re-exec mesure : 19s."
+  },
   "kernelspec": {
    "display_name": ".NET (C#)",
    "language": "C#",

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb
@@ -6004,6 +6004,23 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": "Probas/Infer/Infer-1-Setup.ipynb",
+   "reproducibility": "HIGH",
+   "last_validated": "2026-07-24",
+   "validator": "papermill",
+   "notes": "Classification bayesienne (BPM / logistic Infer.NET). Re-exec mesure : 14s."
+  },
   "kernelspec": {
    "display_name": ".NET (C#)",
    "language": "C#",

--- a/scripts/notebook_tools/twin_pairs.yaml
+++ b/scripts/notebook_tools/twin_pairs.yaml
@@ -365,7 +365,7 @@
     date: '2026-07-24'
     by: po-2023
     python_sha: da13439ee00e75ef65a0729087c450a34847b415
-    csharp_sha: dc33fc60f854fd06855701e387985cc5a73ed693
+    csharp_sha: c463b0da453cb9d53d722ec13a27f89035df8ca9
   known_differences:
   - 'Socle pedagogique commun : melanges de distributions gaussiennes (GMM) modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational
@@ -413,7 +413,7 @@
     date: '2026-07-24'
     by: po-2023
     python_sha: c577dc03216f318a392f373ba61aa85287037f98
-    csharp_sha: e495c6935e61214af55a64d5598412720e7f80fe
+    csharp_sha: b514156edf4e4e8533a9105c42c17bc24e09d023
   known_differences:
   - 'Socle pedagogique commun : inference causale (do-calculus, ajustement) modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational
@@ -429,7 +429,7 @@
     date: '2026-07-24'
     by: po-2023
     python_sha: 466d8b8b098d63782651c8357dbfc798a448d029
-    csharp_sha: 05db832236c4344172f9db52526e8441d5748cd1
+    csharp_sha: f89c42e298da074aa14990cc1279557bc7e312b7
   known_differences:
   - 'Socle pedagogique commun : debugging de modeles probabilistes (diagnostics d''inference) modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational
@@ -445,7 +445,7 @@
     date: '2026-07-24'
     by: po-2023
     python_sha: 243abda6c6d8da742e47ae61a60d780b770e77ad
-    csharp_sha: 3734352b4af21f92da63865c32b78d6fd3b5dd31
+    csharp_sha: 4ee17fda8afb065f28f37dde6fe1b96104257495
   known_differences:
   - 'Socle pedagogique commun : Item Response Theory (modeles de competences / IRT) modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational
@@ -461,7 +461,7 @@
     date: '2026-07-24'
     by: po-2023
     python_sha: ece691bf53797d4b37c404f62932f5a656daa6aa
-    csharp_sha: f0c94045444eff8102b6ca6a4da47f363e15f133
+    csharp_sha: a3ae179fce9fbfa45df6eabba7984a3a8fc69fea
   known_differences:
   - 'Socle pedagogique commun : TrueSkill (classement et apprentissage en ligne) modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational
@@ -477,7 +477,7 @@
     date: '2026-07-24'
     by: po-2023
     python_sha: be07a64cf703c3bef33d6898601ce6b021d3abf3
-    csharp_sha: 9cfc62e7089756ed550cbae76645a95589a0fe93
+    csharp_sha: 0aeed2f0efdf0afda422702b3a99c5d5985de589
   known_differences:
   - 'Socle pedagogique commun : classification bayesienne modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational


### PR DESCRIPTION
## Summary

**PR C tranche 1** of `#8056` — cost-metadata peuplement on the **foundational Probas/Infer.NET** notebooks. Direct continuation of the merged `#8376` (parser reads `metadata.cost` canonical) + `#8323` (Infer-3/4 exemplar). Surrogate lane work for po-2025 (intermittent).

Adds `nb.metadata['cost']` to 7 Infer notebooks that lacked a cost matrix: **Infer-1-Setup, Infer-2-Gaussian-Mixtures, Infer-5-Causal-Inference, Infer-6-Debugging, Infer-7-Skills-IRT, Infer-8-TrueSkill, Infer-9-Classification**.

### Cost profile (honest, firsthand-verified)

All 7 are **CPU-only / deterministic (Infer.NET VMP) / no API / no GPU / no network / no external account** — verified firsthand in the `#8081` fidelity audit (13/13 Infer FIDÈLE). `cpu_min=2` = **cold-NuGet-restore-aware** (matches the `#8323` exemplar, where Infer-3 measured 16s warm but set `cpu_min: 2`). The measured warm `papermill.duration` is documented **verbatim** in each `notes` field:

| Notebook | warm measured | cpu_min |
|----------|--------------|---------|
| Infer-1-Setup | 9s | 2 |
| Infer-2-Gaussian-Mixtures | 19s | 2 |
| Infer-5-Causal-Inference | *(no duration recorded → explicit estimate in notes)* | 2 |
| Infer-6-Debugging | 16s | 2 |
| Infer-7-Skills-IRT | 15s | 2 |
| Infer-8-TrueSkill | 19s | 2 |
| Infer-9-Classification | 14s | 2 |

Infer-1-Setup is the setup/reduced entry point → `reduced_pedagogical: null` (no self-reference); the others point `reduced_pedagogical` to it.

## Validation

- **Byte-identity (surgical):** the cost block is inserted as the first notebook-level metadata key (after ` "metadata": {`). Pure additions, **0 deletions** on cells/existing-metadata — no `json.dumps` round-trip (which churned Infer-2's compact `}]` cells-closing on first attempt). `git diff --stat`: `7 files, +119 insertions, 0 deletions`.
- **Line endings:** LF-only (no CRLF) — written with `newline=''` to match `origin/main`.
- **JSON parses** on all 7 (Python `json.load` OK).
- **Parser reads each as canonical:** `check_cost_metadata.py` → `cost_source: 'metadata'` × 7.
- **metadata['cost'] is notebook-level JSON → 0 code cells modified → no re-exec required** (rule C.2 does not apply; matches `#8323` "0 cellule code modifiée").
- **Twin-parity CI green:** the 6 registered Probas twins (Probas-2/5/6/7/8/9, Infer.NET↔PyMC) are rebaselined in commit 2 — `check_twin_parity.py --check`: **OK=39 DRIFT=0**. Semantic parity holds (metadata field, not teaching content; #8081 FIDÈLE). Follows the going-forward precedent (#8250/#8262/#8372): modifying a registered twin rebaselines its sha in the same PR.

## Scope

7-notebook foundational tranche (stays atomic: ≤15 files per `pr-review-discipline` §A). A second tranche (Infer-10..19) can follow. **Partial contribution** to the open epic.

See #8056. Part of #4208.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
