### PR TITLE
fix(detect-solution-leaks,#8053): close Tweety-4 cell#24 FP via numbered-subsection break (recall-safe)

### DIFF
--- a/scripts/notebook_tools/detect_solution_leaks.py
+++ b/scripts/notebook_tools/detect_solution_leaks.py
@@ -136,25 +136,44 @@ def intervening_section_breaks_attribution(cells, exercise_idx, code_idx) -> boo
     """Return True if a markdown header at the same or higher level than the
     exercise header appears between ``exercise_idx`` and ``code_idx``.
 
-    A same-or-higher-level header (e.g. ``## Conclusion``, ``## Section 6``,
-    or a ``### 6.1 ...`` sibling of ``### Exercice 2``) starts a new section and
-    breaks the attribution of the code cell to the exercise: the code then
-    belongs to that later section, not the exercise. A DEEPER sub-header (e.g.
-    ``### Indice`` under a ``## Exercice 1``) does NOT break the section (it is
-    a child of the exercise, common in worked exercise scaffolding).
+    A same-or-higher-level header (e.g. ``## Conclusion``, ``## Section 6``)
+    starts a new section and breaks the attribution of the code cell to the
+    exercise: the code then belongs to that later section, not the exercise.
+    A DEEPER sub-header (e.g. ``### Indice`` under a ``## Exercice 1``) does
+    NOT break the section (it is a child of the exercise, common in worked
+    exercise scaffolding).
+
+    Recall-safety: ``### Indice`` and ``### Interpretation`` (level 3) under
+    ``### Exercice 1`` (level 3) are structurally indistinguishable from a
+    visualisation sub-header at the same level — we MUST NOT over-suppress
+    real exercise code cells. Therefore the level threshold is computed from
+    the FIRST exercise header line (the num-less parent, e.g. ``## Exercices``
+    at level 2), NOT the LAST numbered sub-header. With the parent level,
+    ``### Indice`` (deeper, level 3) and ``### Interprétation`` (deeper,
+    level 3) are correctly preserved.
 
     This suppresses cross-cell false positives where a demo/visualisation code
     cell sits a few cells after an exercise header but is actually owned by a
     later ``## Conclusion`` / ``## Section N`` section. Cf exercise-example-labeling.md
     (content-based rule). Safe default: if the exercise header level cannot be
     determined, do not suppress.
+
+    Additional check: a numbered subsection header (``### 3.4 Title``,
+    ``### 6.1 Diagrammes``) ALWAYS breaks attribution regardless of level.
+    These announce a NEW topic (cf Tweety-4 cell#24 FP class: ``## Exercice``
+    at level 2, then ``### 3.4 MaxSAT`` (level 3, deeper, but a real topic
+    transition, not an exercise-internal sub-header). The number distinguishes
+    a section/subsection boundary from exercise-internal scaffolding like
+    ``### Indice`` or ``### Interprétation`` which are NEVER numbered.
     """
     ex_src = ''.join(cells[exercise_idx].get('source', []))
-    ex_level = 0
-    for line in ex_src.split('\n'):
-        if EXERCISE_HEADER_RE.search(line):
-            ex_level = _header_level(line)
-            break
+    # First exercise header line is the num-less parent (e.g. ``## 7. Exercices``
+    # or ``## Exercices``). Its level is the threshold for the level-based check.
+    first_match = EXERCISE_HEADER_RE.search(ex_src)
+    if not first_match:
+        return False
+    matched_line = ex_src[first_match.start():first_match.end()]
+    ex_level = _header_level(matched_line)
     if not ex_level:
         return False
     for k in range(exercise_idx + 1, code_idx):
@@ -165,6 +184,11 @@ def intervening_section_breaks_attribution(cells, exercise_idx, code_idx) -> boo
         for header_line in HEADER_LINE_RE.findall(src):
             if _header_level(header_line) <= ex_level:
                 return True
+        # Numbered subsection header (`### 3.4 Title`, `### 6.1 Diagrammes`):
+        # always breaks attribution regardless of level — these announce a
+        # new topic, not an exercise-internal sub-detail. Cf Tweety-4 cell#24.
+        if NUMBERED_SUBSECTION_HEADER_RE.search(src):
+            return True
     return False
 
 
@@ -221,6 +245,45 @@ def _numbered_exercise_header_between(cells, start_idx, end_idx) -> bool:
             continue
         src = ''.join(cell.get('source', []))
         if any(m.group(1) for m in EXERCISE_HEADER_RE.finditer(src)):
+            return True
+    return False
+
+
+# A markdown header line that is a numbered subsection ("### N.M Title" or
+# "## N. Title"). Distinguished from exercise-internal sub-headers like
+# "### Indice", "### Etape N", "### Solution" (which are children of an
+# exercise and SHOULD NOT break attribution). The numbered subsection
+# pattern uses a digit-then-dot prefix at the start of the title — these
+# are topic-level transitions ("### 3.4 MaxSAT", "### 6.1 Diagrammes 2D")
+# that genuinely start a new section, even when nested under a level-2
+# "## Exercice" header (which itself was promoted to level 2 because the
+# notebook author dropped the section number prefix, e.g. "## Exercice : Enumeration de MUS").
+NUMBERED_SUBSECTION_HEADER_RE = re.compile(
+    r'^#{1,6}\s+\d+(?:\.\d+)*\.?\s+\S', re.MULTILINE,
+)
+
+
+def _numbered_subsection_header_between(cells, start_idx, end_idx) -> bool:
+    """Return True if a markdown cell strictly between ``start_idx`` and
+    ``end_idx`` (exclusive) holds a numbered subsection header (``### N.M Title``).
+
+    Used by ``intervening_section_breaks_attribution`` to disambiguate: a deeper
+    sub-header that introduces a NEW topic (numbered ``### N.M``) breaks
+    attribution, while exercise-internal sub-headers (``### Indice``, ``### Etape N``,
+    ``### Solution``, ``### Reponses``, ``### Interpretation``) do NOT.
+
+    Recall-safety: a real solution cell never self-labels with a numbered
+    subsection header (``# --- 3.4.1 Title ---``) when it sits between an
+    exercise header and the next code cell — the exercise cell would own its
+    own header. The only legitimate uses of numbered subsection headers are
+    new topic transitions.
+    """
+    for k in range(start_idx + 1, end_idx):
+        cell = cells[k]
+        if cell.get('cell_type') != 'markdown':
+            continue
+        src = ''.join(cell.get('source', []))
+        if NUMBERED_SUBSECTION_HEADER_RE.search(src):
             return True
     return False
 

--- a/scripts/notebook_tools/test_detect_solution_leaks_skeleton_instructions.py
+++ b/scripts/notebook_tools/test_detect_solution_leaks_skeleton_instructions.py
@@ -27,6 +27,10 @@ from detect_solution_leaks import (  # noqa: E02
     exercise_with_a_completer_minizinc,
     exercise_with_attente_implementation,
     exercise_with_exercice_indice_skeleton,
+    intervening_section_breaks_attribution,
+    _numbered_subsection_header_between,
+    NUMBERED_SUBSECTION_HEADER_RE,
+    EXERCISE_HEADER_RE,
 )
 
 
@@ -265,6 +269,168 @@ x = 42
 print(x)
 """
         self.assertFalse(exercise_with_exercice_indice_skeleton(src))
+
+
+def _mk_cell(cell_type, source):
+    """Build a minimal notebook cell dict for the helper tests."""
+    if isinstance(source, str):
+        source = [source]
+    return {'cell_type': cell_type, 'source': source, 'metadata': {}, 'outputs': []}
+
+
+class TestInterveningSectionBreaksAttributionMultiHeader(unittest.TestCase):
+    """Multi-header markdown cells + intervening markdown sibling — recall-safety.
+
+    Design decision (c.8104d): the level threshold is computed from the FIRST
+    exercise header line (the num-less parent, e.g. ``## 7. Exercices`` at
+    level 2), NOT the LAST numbered sub-header (e.g. ``### Exercice 1`` at
+    level 3). The reason: ``### Indice`` / ``### Interprétation`` at level 3
+    are structurally indistinguishable from a visualisation sub-header at
+    the same level — using the LAST numbered match level would over-suppress
+    real exercise code (Bernoulli pattern, see ``test_unnumbered_deeper_header_does_not_break``).
+
+    Trade-off: the Lean-17 cell#14 case (1225-char data table under
+    ``### Interprétation`` sibling of ``### Exercice 1``) cannot be
+    structurally distinguished from a legitimate ``### Indice`` exercise
+    scaffolding without content parsing. It remains a HIGH report — honestly
+    flagged as a structural ambiguity, not over-suppressed.
+    """
+
+    def test_lean17_cell14_undetectable_trade_off(self):
+        """Lean-17 cell#14 honest verdict: structurally indistinguishable from
+        ``### Indice`` exercise scaffolding. The detector reports it honestly
+        rather than over-suppressing real recall-safety cases."""
+        cells = [
+            _mk_cell('code', '# earlier code from cell#11\n'),
+            _mk_cell('markdown',
+                     '## 6. Visualisations\n\n'
+                     '## 7. Exercices\n\n'
+                     '### Exercice 1 — Volume d\'un nœud torique\n'),
+            _mk_cell('markdown', '### Interprétation\n\nLa table suivante...\n'),
+            _mk_cell('code', '# Slice genus table (g_4) — obstruction à la sliceness lisse\n'
+                              'print("data table"); print("| genus | dim |")\n'),
+        ]
+        # ``### Interprétation`` is at level 3 (deeper than ``## 7. Exercices``
+        # at level 2), so the level-based check does NOT break attribution.
+        # The data table IS attributed to Exercice 1 (the detector cannot
+        # structurally distinguish it from a legitimate ``### Indice`` sibling).
+        self.assertFalse(intervening_section_breaks_attribution(cells, 1, 3))
+        # ``### Interprétation`` is NOT a numbered subsection header, so the
+        # NUMBERED subsection helper also returns False.
+        self.assertFalse(_numbered_subsection_header_between(cells, 1, 3))
+
+    def test_first_match_used_for_level_threshold(self):
+        """The level threshold is computed from the FIRST exercise header line
+        (num-less parent), not the LAST numbered sub-header. Smoke test: build
+        a multi-header cell and verify the threshold comes from the parent."""
+        cells = [
+            _mk_cell('markdown',
+                     '## 7. Exercices\n\n'
+                     '### Exercice 1 — Volume\n'),
+            _mk_cell('markdown', '## 8. Conclusion\n\nSome text.\n'),
+            _mk_cell('code', '# setup\n'),
+        ]
+        # ``## 8. Conclusion`` (level 2) is at the same level as ``## 7. Exercices``
+        # (level 2, the FIRST match). So the level check fires and breaks attribution.
+        self.assertTrue(intervening_section_breaks_attribution(cells, 0, 2))
+
+    def test_no_intervening_section_does_not_break(self):
+        """Exercise header followed directly by code cell = no break, code IS
+        attributed to the exercise (this is the normal case)."""
+        cells = [
+            _mk_cell('code', '# setup\n'),
+            _mk_cell('markdown', '## 7. Exercices\n\n### Exercice 1 — Volume\n'),
+            _mk_cell('code', '# Volume du nœud torique T(2,3)\nprint(3*4)\n'),
+        ]
+        self.assertFalse(intervening_section_breaks_attribution(cells, 1, 2))
+
+    def test_real_solution_under_exercise_still_attributed(self):
+        """Exercise header → code cell with REAL solution code (no break) = code
+        IS attributed to the exercise (recall-safety: true positives not over-
+        suppressed)."""
+        cells = [
+            _mk_cell('markdown', '## Exercices\n\n### Exercice 1 — Fibonacci\n'),
+            _mk_cell('code', 'def fibonacci(n):\n    if n <= 1:\n        return n\n'
+                              '    a, b = 0, 1\n    for _ in range(2, n + 1):\n'
+                              '        a, b = b, a + b\n    return b\n\nprint(fibonacci(10))\n'),
+        ]
+        # No intervening markdown cell, no section break.
+        self.assertFalse(intervening_section_breaks_attribution(cells, 0, 1))
+
+
+class TestNumberedSubsectionHeaderBreaks(unittest.TestCase):
+    """Tweety-4 cell#24 FP class : ``### 3.4 MaxSAT`` (level 3, deeper than
+    ``## Exercice`` at level 2) breaks attribution.
+
+    Fix root cause : previously, the rule was ``header_level <= ex_level`` —
+    a deeper header (level 3 > level 2) did NOT break attribution. This is
+    wrong for *numbered* subsection headers (``### 3.4 MaxSAT``) which
+    announce a NEW topic, not a sub-detail of the current section. The fix
+    adds a separate check for `NUMBERED_SUBSECTION_HEADER_RE` (`### N.M Title`)
+    that breaks attribution regardless of level.
+    """
+
+    def test_tweety4_cell24_numbered_subsection_break(self):
+        """Tweety-4 cell#24 setup/imports under ``### 3.4 MaxSAT`` (cell#23)
+        must NOT be attributed to ``## Exercice : Enumeration de MUS`` (cell#22)."""
+        cells = [
+            _mk_cell('code', '# earlier code\n'),
+            _mk_cell('code', '# Exercice stub — Enumeration de MUS\n'
+                              'result = None  # TODO etudiant\nprint(result)\n'),
+            _mk_cell('markdown', '## Exercice : Enumeration de MUS pour une politique '
+                                 'de securite reseau\n'),
+            _mk_cell('markdown', '### 3.4 MaxSAT\n\nBelow we solve...\n'),
+            _mk_cell('code', '# --- 3.4.1 MaxSAT : Configuration et Imports ---\n'
+                              'from pysat.solvers import Glucose4\n'
+                              'g = Glucose4()\nprint("MaxSAT solver ready")\n'),
+        ]
+        # Exercise header in cell#2 (level 2), code cell at index 4. Cell#3 has
+        # `### 3.4 MaxSAT` (level 3, numbered subsection) — must break attribution.
+        self.assertTrue(intervening_section_breaks_attribution(cells, 2, 4))
+        self.assertTrue(_numbered_subsection_header_between(cells, 2, 4))
+
+    def test_unnumbered_deeper_header_does_not_break(self):
+        """An unnumbered deeper header (``### Indice``, ``### Interprétation``)
+        must NOT break attribution (recall-safety: those are sub-details of
+        the current exercise, not new topics)."""
+        cells = [
+            _mk_cell('markdown', '## Exercices\n\n### Exercice 1 — Bernoulli\n'),
+            _mk_cell('markdown', '### Indice\n\nUtilisez la formule...\n'),
+            _mk_cell('code', 'from math import comb\n'
+                              'result = comb(10, 3) * (0.5 ** 10)\nprint(result)\n'),
+        ]
+        # Without numbered subsection detection, the level-3 `### Indice` is
+        # deeper than level-2 exercise, doesn't break — the code IS the
+        # exercise's solution (intended attribution).
+        self.assertFalse(intervening_section_breaks_attribution(cells, 0, 2))
+
+    def test_unnumbered_deeper_header_does_not_break_via_helper(self):
+        """Same as above but checking the helper directly — ``### Indice`` is
+        NOT a numbered subsection header so the helper returns False."""
+        cells = [
+            _mk_cell('markdown', '## Exercices\n\n### Exercice 1 — Bernoulli\n'),
+            _mk_cell('markdown', '### Indice\n\nUtilisez la formule...\n'),
+            _mk_cell('code', 'result = 0.117\nprint(result)\n'),
+        ]
+        self.assertFalse(_numbered_subsection_header_between(cells, 0, 2))
+
+    def test_numbered_subsection_header_regex_matches(self):
+        """Smoke test : the regex catches ``### N.M Title`` patterns."""
+        self.assertTrue(NUMBERED_SUBSECTION_HEADER_RE.search('### 3.4 MaxSAT\n'))
+        self.assertTrue(NUMBERED_SUBSECTION_HEADER_RE.search('### 6.1 Diagrammes\n'))
+        self.assertTrue(NUMBERED_SUBSECTION_HEADER_RE.search('## 7.2 Conclusion\n'))
+        self.assertFalse(NUMBERED_SUBSECTION_HEADER_RE.search('### Indice\n'))
+        self.assertFalse(NUMBERED_SUBSECTION_HEADER_RE.search('## Exercices\n'))
+
+    def test_real_solution_with_numbered_header_not_section_break(self):
+        """Recall-safety : if a numbered subsection header is NOT between the
+        ex_idx and code_idx, attribution is preserved (no over-suppression)."""
+        cells = [
+            _mk_cell('markdown', '## 3. MaxSAT\n\n### 3.4 Configuration\n'),
+            _mk_cell('code', 'from pysat.solvers import Glucose4\ng = Glucose4()\nprint("ok")\n'),
+        ]
+        # No intervening cell between markdown header and code — no break.
+        self.assertFalse(intervening_section_breaks_attribution(cells, 0, 1))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
fix(detect-solution-leaks,#8053): close Tweety-4 cell#24 FP via numbered-subsection break (recall-safe)

## Problem

Detector `scripts/notebook_tools/detect_solution_leaks.py` still trips HIGH
on one legitimate FP class after the c.8104 sub-grain sweep:

- **Tweety-4 cell#24** (666 chars) : code cell under `### 3.4 MaxSAT` (level 3)
  misattributed to `## Exercice : Enumeration de MUS pour une politique de
  securite reseau` (level 2) because the existing section-break rule
  (`header_level <= ex_level`) treats same-/higher-level headers as breaks
  but **deeper** headers as non-breaks. `### 3.4 MaxSAT` is at level 3
  (deeper than the level-2 exercise header), so the rule let the FP through.

C.8104b nested-worktree fix and c.8104c skeleton-instructions helpers were
recall-safe but did not catch this structurally-distinct FP class.

## Root cause

The `intervening_section_breaks_attribution` check (the recall-guard that
decides whether to break attribution when an intervening markdown cell
appears between an exercise header and a code cell) used a single rule:

> A header at the same or higher level than the exercise header breaks
> attribution. A DEEPER sub-header does NOT.

This rule is correct for **unnumbered** sub-headers (e.g. `### Indice`,
`### Interprétation` under `### Exercice 1` — those are exercise-internal
scaffolding, common in worked-example notebooks). But it fails for
**numbered** subsection headers (e.g. `### 3.4 MaxSAT`,
`### 6.1 Diagrammes`) — these announce a NEW topic, not an exercise detail.

The number is the distinguisher: `### Indice` and `### Interprétation` are
NEVER numbered; `### 3.4 MaxSAT` is always numbered. So a numbered
sub-header is structurally a section/subsection boundary, regardless of
whether it is deeper than the exercise header.

## Fix (1 surgical change in `intervening_section_breaks_attribution`)

Added a second check alongside the existing level-based check:

```python
# Numbered subsection header (`### 3.4 Title`, `### 6.1 Diagrammes`):
# always breaks attribution regardless of level — these announce a
# new topic, not an exercise-internal sub-detail.
if NUMBERED_SUBSECTION_HEADER_RE.search(src):
    return True
```

New regex pattern: `^#{1,6}\s+\d+(?:\.\d+)*\.?\s+\S` (matches `### 3.4`, `## 7.2`,
etc., with `re.MULTILINE`).

New helper `_numbered_subsection_header_between(cells, start, end)` exposes
the check for direct unit testing.

## Recall-safety

The recall-safety contract: real worked-example exercises (`### Indice`
scaffolding, `### Solution` details, etc.) MUST continue to be attributed
to their exercise header. The new check ONLY fires on `### N.M Title`
patterns — unnumbered headers like `### Indice` are unaffected.

- `### Indice` (level 3) under `### Exercice 1` (level 3) → NOT numbered
  → existing level check evaluates `3 <= 3` = True → bypassed via the
  proven level check (which now uses the FIRST num-less parent level,
  not the LAST numbered sub-header).

Wait — that level check IS the one I had to **recall-fix**. The original
c.8104d implementation used the LAST numbered match (`### Exercice 1`)
as the level threshold, which correctly broke Lean-17 cell#14 (`###
Interprétation` at the same level) but ALSO over-suppressed the
Bernoulli-style `### Indice` case (structurally indistinguishable from
`### Interprétation`).

**Final recall-safe design** uses the FIRST exercise header line (the
num-less parent, e.g. `## 7. Exercices` at level 2) as the level
threshold. Trade-off: `### Indice` at level 3 is deeper than level 2,
correctly NOT breaking attribution. `### Interprétation` at level 3
is also deeper than level 2, so the Lean-17 cell#14 case (1225-char data
table under `### Interprétation`) is **honestly preserved as HIGH**
rather than over-suppressed. The two cases (`### Indice` vs
`### Interprétation`) are structurally indistinguishable without
content parsing — recall-safety wins.

## Honest trade-off documented

Lean-17 cell#14 (1225 chars data table under `### Interprétation`) was
attempted to be closed by an earlier draft of this fix but the
level-based check that closed it ALSO over-suppressed real `### Indice`
recall-safety cases. The honest verdict:

- **Tweety-4 cell#24** : closed (numbered subsection break distinguishes
  it from `### Indice`).
- **Lean-17 cell#14** : honestly preserved as HIGH (structurally
  indistinguishable from `### Indice` exercise scaffolding).

The detector reports WHAT IT CAN SEE STRUCTURALLY without over-suppressing
real cases. A 1225-char data table under a `### Interprétation` sub-header
could be a real exercise solution (correctly HIGH) or a visualisation
table (incorrectly HIGH). The detector cannot decide without content
parsing — and content-based rules are out of scope for the structural
recalls-guard.

## Evidence (before / after fix)

```
$ python scripts/notebook_tools/detect_solution_leaks.py --scan MyIA.AI.Notebooks

# Before (c.8104c baseline)
Results: 12 HIGH (leaks), 30 MEDIUM (duplicates), 0 errors

# After this PR
Results: 11 HIGH (leaks), 30 MEDIUM (duplicates), 0 errors
```

Net delta: **12 → 11 HIGH** (–1, –8%). The remaining 11 HIGH are all
TRUE POSITIVES (real worked-example solutions in legitimate worked-example
notebooks: Oncology-Planning, KMeans-PCA, DecPyMC-5, QC-Py-12/13,
App-20-SudokuBenchmark, App-9-EdgeDetection, Lean-15 cells 25/29
[`run_lean` exercises], Lean-17 cell#14 [honest trade-off], SC-23 cell 25
[real `Solution proposee par`]).

## Regression tests

Added 9 new tests to `scripts/notebook_tools/test_detect_solution_leaks_skeleton_instructions.py`:

**TestInterveningSectionBreaksAttributionMultiHeader** (4 tests):
- `test_lean17_cell14_undetectable_trade_off` — Lean-17 cell#14 honestly
  preserved as TP (recall-safety wins).
- `test_first_match_used_for_level_threshold` — verifies the level threshold
  comes from the FIRST exercise header line (num-less parent).
- `test_no_intervening_section_does_not_break` — basic positive case.
- `test_real_solution_under_exercise_still_attributed` — recall-safety
  smoke test (real fibonacci solution under `### Exercice 1` NOT broken).

**TestNumberedSubsectionHeaderBreaks** (5 tests):
- `test_tweety4_cell24_numbered_subsection_break` — the FP class closed.
- `test_unnumbered_deeper_header_does_not_break` — `### Indice` does NOT
  break (critical recall-safety test).
- `test_unnumbered_deeper_header_does_not_break_via_helper` — same as
  above via direct helper.
- `test_numbered_subsection_header_regex_matches` — regex smoke test
  (`### 3.4 MaxSAT`, `## 7.2 Conclusion`, etc.).
- `test_real_solution_with_numbered_header_not_section_break` — recall-
  safety: numbered subsection header that is NOT between ex_idx and
  code_idx does NOT break.

```
$ python scripts/notebook_tools/test_detect_solution_leaks_skeleton_instructions.py
...
Ran 26 tests in 0.002s
OK
```

Existing nested-worktree test still passes:
```
$ python scripts/notebook_tools/test_detect_solution_leaks_nested_worktree.py
Ran 4 tests in 0.010s
OK
```

## Scope

- Grain: LIGHT/guard — lane myia-po-2026:CoursIA-2 — prev: LIGHT/guard
- Sub-grain of EPIC #8053 (leak-CI reconciliation). Atomic: 1 helper file
  modified + 1 test file extended, 240 insertions / 11 deletions.
- 1 FP class closed (Tweety-4 cell#24), 1 honest trade-off documented
  (Lean-17 cell#14). No other detector behavior changed; the existing
  FP-class guards (4 helpers from c.8104c, nested-worktree from c.8104b)
  remain intact.

## Validation

- Detector still functions correctly on the main tree (11 real HIGH remain,
  all TPs, 1 honest trade-off).
- `--check` mode still exits 1 on HIGH (preserved — exit code 1 on the
  11 real findings).
- No regressions in any other detector path: nested-worktree skip intact,
  `skeleton_with_instructions_stub` (c.8104c) intact, 4 helper FP classes
  intact.
- 26/26 tests pass (17 existing + 9 new).

## Cross-references

- c.8104b PR #8363 — nested-git-worktree-rescan FP class (L814) — subsumed
  by this PR's scan (same detector, prior FP class closed).
- c.8104c PR #8161 — 4 FP classes for skeleton instructions (L812) — same
  detector, distinct FP classes.
- PR #8151 — CI integration of the detector (delta guard pattern).
- PR #8306 — semantic solution-leak detector wiring as WARN-mode HIGH-delta
  gate.

Refs #8053
