### PR TITLE
fix(guard,#8352): _is_frontmatter_block precision — no longer flags prose section dividers (FP root-cause)

### DIFF
--- a/scripts/notebook_tools/detect_markdown_rendering.py
+++ b/scripts/notebook_tools/detect_markdown_rendering.py
@@ -108,13 +108,31 @@ def _cell_hash(rule: str, text: str) -> str:
 
 
 def _is_frontmatter_block(lines) -> bool:
-    """True if the cell is a `---\\n ... \\n---` block (leading + a later closing fence)."""
+    """True if the cell is a `---\\n ... \\n---` YAML frontmatter block.
+
+    Requires (a) the leading non-blank line is ``---``, (b) a later non-blank line
+    is also ``---``, and (c) the line *immediately* after the opening fence is
+    non-blank. Condition (c) distinguishes real YAML frontmatter (content starts
+    right after ``---``) from a thematic-break section divider (``---\\n\\n### H``),
+    which is legitimate markdown and must NOT be flagged. Without (c), any prose
+    section sandwiched between two ``---`` hr lines with two colon-bearing phrases
+    (e.g. FR prose ``affiche :``) was misclassified as ``frontmatter_rawyaml``.
+    """
     nz = _nonblank(lines)
     if not nz:
         return False
     if nz[0].strip() != "---":
         return False
-    return any(ln.strip() == "---" for ln in nz[1:])
+    if not any(ln.strip() == "---" for ln in nz[1:]):
+        return False
+    # Locate the opening fence in the raw lines; the very next raw line must carry
+    # content (YAML frontmatter never has a blank line right after the opening ---).
+    for i, ln in enumerate(lines):
+        if ln.strip() == "---":
+            if i + 1 >= len(lines) or lines[i + 1].strip() == "":
+                return False
+            break
+    return True
 
 
 def _frontmatter_supersizes(lines) -> bool:

--- a/scripts/notebook_tools/tests/test_detect_markdown_rendering.py
+++ b/scripts/notebook_tools/tests/test_detect_markdown_rendering.py
@@ -1,0 +1,152 @@
+"""Tests for detect_markdown_rendering — frontmatter/setext rendering guard.
+
+This scanner (#8352, HARD-enforced CI gate) catches markdown cells that render
+badly: YAML frontmatter dumped into a rendered cell (markdown-it promotes the
+``---`` fence to one oversized setext-H2 block) and accidental setext oversize.
+
+These tests pin the precision fix for the prose-section-divider false positive
+(c.882, routed by po-2025 c.870): a markdown cell that sandwiches prose between
+two ``---`` thematic-break lines (``---\\n\\n### Heading\\n...\\n---``) must NOT
+be flagged as frontmatter. The discriminator is the line immediately after the
+opening ``---``: real YAML frontmatter starts its content on the very next line
+(no blank), whereas a section divider follows the ``---`` hr with a blank line
++ heading.
+
+Covers:
+- ``_is_frontmatter_block``: real frontmatter (no blank after ``---``) vs
+  section divider (blank after ``---``) vs non-fence cells.
+- ``scan_cell``: end-to-end — real frontmatter flagged, prose section divider
+  NOT flagged (the founding FP), plain prose/heading cells clean.
+
+All fixtures are synthetic markdown strings — no notebook files, no network.
+Runs in well under a second.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from detect_markdown_rendering import (  # noqa: E402
+    _is_frontmatter_block,
+    scan_cell,
+)
+
+
+def _md(source_lines):
+    """Build a markdown cell dict from a list of source lines."""
+    return {"cell_type": "markdown", "source": source_lines, "metadata": {}}
+
+
+# --- _is_frontmatter_block --------------------------------------------------
+
+
+class TestIsFrontmatterBlock:
+    def test_real_frontmatter_no_blank_after_fence(self):
+        # Canonical YAML frontmatter: content starts immediately after `---`.
+        lines = [
+            "---\n",
+            "title: Real Notebook\n",
+            "cost:\n",
+            "  api_usd_est: 0.0\n",
+            "  cpu_min: 3\n",
+            "---\n",
+        ]
+        assert _is_frontmatter_block(lines) is True
+
+    def test_section_divider_blank_after_fence_is_not_frontmatter(self):
+        # The founding FP (po-2025 c.870, QC-Py-22 cell#60): a thematic-break
+        # section divider `---\n\n### Interprétation\n...prose...\n---`.
+        lines = [
+            "---\n",
+            "\n",
+            "### Interprétation\n",
+            "Le modèle affiche une précision de 0.82 sur le jeu de test.\n",
+            "Voici le détail des résultats ci-dessous.\n",
+            "---\n",
+        ]
+        assert _is_frontmatter_block(lines) is False
+
+    def test_section_divider_with_colon_prose_not_frontmatter(self):
+        # Two colon-bearing phrases between two hr lines must not look like YAML.
+        lines = [
+            "---\n",
+            "\n",
+            "## Résultats\n",
+            "précision : 0.82\n",
+            "rappel : 0.79\n",
+            "---\n",
+        ]
+        assert _is_frontmatter_block(lines) is False
+
+    def test_no_leading_fence(self):
+        assert _is_frontmatter_block(["# Title\n", "some prose\n"]) is False
+
+    def test_single_fence_no_closer(self):
+        # Only one `---` (opening, no closer) -> not a frontmatter block.
+        lines = ["---\n", "title: X\n", "cost:\n", "  cpu_min: 3\n"]
+        assert _is_frontmatter_block(lines) is False
+
+    def test_empty_cell(self):
+        assert _is_frontmatter_block([]) is False
+        assert _is_frontmatter_block(["\n", "\n"]) is False
+
+    def test_leading_blank_lines_before_fence(self):
+        # Leading blanks then a fence: real frontmatter still detected if the
+        # line right after the fence carries content.
+        lines = ["\n", "\n", "---\n", "title: X\n", "cost:\n", "  cpu_min: 3\n", "---\n"]
+        assert _is_frontmatter_block(lines) is True
+
+    def test_leading_blank_then_section_divider(self):
+        # Leading blanks then `---\n\n###` section divider -> not frontmatter.
+        lines = ["\n", "---\n", "\n", "### Heading\n", "prose\n", "---\n"]
+        assert _is_frontmatter_block(lines) is False
+
+
+# --- scan_cell (end-to-end) -------------------------------------------------
+
+
+class TestScanCell:
+    def _rules(self, cell):
+        return [f["rule"] for f in scan_cell(cell)]
+
+    def test_real_frontmatter_flagged(self):
+        cell = _md([
+            "---\n", "title: Real\n", "cost:\n", "  api_usd_est: 0.0\n",
+            "  cpu_min: 3\n", "  gpu_min: 0\n", "---\n",
+        ])
+        rules = self._rules(cell)
+        assert any(r.startswith("frontmatter") for r in rules), rules
+
+    def test_section_divider_not_flagged_as_frontmatter(self):
+        # The exact founding-FP signature (QC-Py-22 cell#60): a thematic-break
+        # section divider must NOT be classified as frontmatter. (A closing
+        # `---` directly under text may legitimately trip the separate
+        # `setext_oversized` rule — that is a different detection, not the FP
+        # being fixed here, so we assert no *frontmatter* rule fires.)
+        cell = _md([
+            "---\n", "\n", "### Interprétation\n",
+            "Le modèle affiche : précision 0.82, rappel 0.79.\n",
+            "Détail des métriques ci-dessous.\n", "---\n",
+        ])
+        rules = self._rules(cell)
+        assert not any(r.startswith("frontmatter") for r in rules), rules
+
+    def test_plain_heading_prose_clean(self):
+        cell = _md(["# Title\n", "\n", "Some paragraph with a colon: value.\n"])
+        assert not any(r.startswith("frontmatter") for r in self._rules(cell))
+
+    def test_non_markdown_cell_clean(self):
+        assert scan_cell({"cell_type": "code", "source": ["print(1)\n"]}) == []
+
+    def test_empty_markdown_clean(self):
+        assert scan_cell(_md([])) == []
+        assert scan_cell(_md(["\n"])) == []
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Grain: MED/guard-8352-frontmatter-fp-prose-section-dividers — lane myia-po-2023:CoursIA — routed by po-2025 c.870 (tooling owner) — genre pivot R6 (tooling root-cause)

# `fix(guard,#8352)`: precision fix — `_is_frontmatter_block` no longer flags prose section dividers (`---\n\n### Heading`)

## Problem (root-caused firsthand, routed by po-2025 c.870)

`detect_markdown_rendering.py` `_is_frontmatter_block` flagged **false positives**: a markdown cell that sandwiches prose between two `---` thematic-break lines — e.g. a section divider `---\n\n### Interprétation\n...affiche :\n...\n---` — was misclassified as `frontmatter_rawyaml`, because (a) `_is_frontmatter_block` returns True for *any* cell starting with `---` that has a later `---`, and (b) the `yamlish >= 2` threshold is met by two colon-bearing French phrases (`affiche :`, `précision :`).

Reproduced firsthand on `QC-Py-22-Deep-Learning-LSTM.ipynb` cell#60, `QC-Py-18-ML-Features-Engineering.ipynb` cell#53 (and 7 more — see census below).

## Fix

Added condition (c) to `_is_frontmatter_block`: **the line immediately after the opening `---` fence must be non-blank.** This is the YAML-frontmatter convention (content starts right after the fence) vs the thematic-break section-divider convention (`---` hr followed by a blank line + heading). Minimal, semantic, strictly more conservative.

```python
# Locate the opening fence; the very next raw line must carry content
# (YAML frontmatter never has a blank line right after the opening ---).
for i, ln in enumerate(lines):
    if ln.strip() == "---":
        if i + 1 >= len(lines) or lines[i + 1].strip() == "":
            return False
        break
```

The `_YAML_KV_RE` regex is left untouched (its looseness is harmless once the block is correctly identified as non-frontmatter).

## Evidence — PROVEN SAFE (zero false negatives)

Repo-wide scan of **every** cell currently triggering the frontmatter path, classified by whether it has a real `title:`/`cost:` key and whether the opening fence is followed by a blank line:

| Class | Count | `blank_after_open` |
|-------|-------|--------------------|
| Real frontmatter (has `title:`/`cost:`) | 212 (→215 incl. supersize path) | **0 True** |
| Prose-section FP (no title/cost key) | 9 | **9 True** |

**Perfect separation.** The `blank_after_open` signal catches all 9 FPs and touches zero real frontmatter → **zero FN risk**.

Before/after finding census (full tree, `--report`):

| Rule | BEFORE (origin/main guard) | AFTER (fixed) | Δ |
|------|---------------------------|---------------|---|
| `frontmatter_rawyaml` | 21 | 12 | **−9** (all FPs cleared) |
| `frontmatter_supersize` | 203 | 203 | 0 (untouched) |
| `setext_oversized` | 19 | 19 | 0 (untouched) |

Exactly the 9 prose-section FPs removed; real detection unchanged.

## Safety guarantee

The fix only **adds a `return False`** (stricter). It can only **reduce** detections, never add. Therefore:
- `detect_markdown_rendering.py --check --baseline markdown_rendering_baseline.json` = **OK, exit 0** (verified = the exact CI command). No PR can newly fail because of this change.
- The 9 FP hashes are in the baseline (482 total); they become stale (never fire) — harmless, since `--check` only fails on *new* findings. Baseline not regenerated here (keeps the diff focused on the one-function logic fix; the stale entries burn down naturally on the next `--update-baseline`).

## Test

Added `scripts/notebook_tools/tests/test_detect_markdown_rendering.py` (13 tests, follows the repo `test_detect_*` convention — every sibling detector has one). Pins:
- `_is_frontmatter_block`: real frontmatter (no blank after fence) True; section divider (blank after fence) False; leading-blank edge cases; no-fence/single-fence negatives.
- `scan_cell`: real frontmatter flagged; the founding-FP signature (QC-Py-22 cell#60) NOT flagged as frontmatter; plain heading/prose clean.

`pytest scripts/notebook_tools/tests/test_detect_markdown_rendering.py` = **13 passed in 0.06s**.

## Scope

One function (`_is_frontmatter_block`, +20/−2) + one new test file. No baseline change, no `_YAML_KV_RE` change, no other rule touched.

See #8352 · See #8056 (the cost-migration rollout this guard gates) · Routed by po-2025 c.870

🤖 Generated with [Claude Code](https://claude.com/claude-code)
