### PR TITLE
fix(decinfer,#8056): migrate DecInfer-1 cost frontmatter -> metadata.cost

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-1-Utility-Foundations.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-1-Utility-Foundations.ipynb
@@ -14,22 +14,6 @@
     "tags": []
    },
    "source": [
-    "---\n",
-    "title: DecInfer-1-Utility-Foundations\n",
-    "cost:\n",
-    "  api_usd_est: 0.0\n",
-    "  api_provider: none\n",
-    "  cpu_min: 3\n",
-    "  gpu_required: false\n",
-    "  network: false\n",
-    "  external_account: none\n",
-    "  free_alternative: null\n",
-    "  reduced_pedagogical: null\n",
-    "  reproducibility: HIGH\n",
-    "  last_validated: 2026-07-23T01:30Z\n",
-    "  validator: papermill\n",
-    "---\n",
-    "\n",
     "# DecInfer-1-Utility-Foundations : Axiomes et Fondements\n",
     "**Serie** : Programmation Probabiliste avec Infer.NET (1/10)  \n",
     "**Duree estimee** : 50 minutes  \n",
@@ -2632,6 +2616,19 @@
      }
     ]
    }
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 3,
+   "gpu_required": false,
+   "network": false,
+   "external_account": "none",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "last_validated": "2026-07-23T01:30Z",
+   "validator": "papermill"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary

Move the DecInfer-1 cell0 `---`-YAML cost block into `nb.metadata['cost']` (JSON), the canonical storage location established by #8376 (`check_cost_metadata` reads `metadata.cost` first) and the #8323 Infer-3 reference schema. This also clears the markdown-rendering guard #8352, which was flagging the leading `---` block as a YAML/setext rendering violation.

**Storage-format migration, values VERBATIM** (not re-estimated). The 11 fields present in the legacy frontmatter are moved as-is; the redundant `title:` field is dropped (the descriptive H1 is kept and now leads cell0).

## Scope

- **1 file, +13/−16 lines** — `DecInfer-1-Utility-Foundations.ipynb`
- **0 code cells modified** (byte-stability verified: all 42 non-cell0 cells byte-identical before/after)
- C.2 re-exec N/A — no code cell source touched

DecInfer-1 was the **only** DecInfer notebook still carrying legacy frontmatter on `origin/main`; the other 9 in the series already have neither frontmatter nor `metadata.cost`.

## Validation

| Check | Result |
|-------|--------|
| `check_cost_metadata.py` | `cost_source='metadata'`, findings empty, EXIT 0 |
| `detect_markdown_rendering.py --check` | `OK: no new ERROR-level markdown-rendering violations`, EXIT 0 |
| JSON structure | nbformat 4.5, 43 cells, 16 code cells, 0 H.3-violators |
| byte-stability | cells[1:] unchanged (42 cells) |

## See

#8056 (matrice cout/ressource par notebook, OPEN epic). Partial delivery to the cost-metadata canonicalization effort — `See #8056` (epic remains open).

Co-Authored-By: Claude <noreply@anthropic.com>