### PR TITLE
docs(lean): correct stale Mathlib cache guidance — local junction, not cache get

### DIFF
--- a/docs/lean/coordinator-workflow.md
+++ b/docs/lean/coordinator-workflow.md
@@ -25,14 +25,24 @@ cd D:/CoursIA/MyIA.AI.Notebooks/GameTheory/social_choice_lean
 lake build SocialChoice.Voting   # ou autre module touche
 ```
 
-Lake = elan installe sous `C:\Users\MYIA\.elan\bin\`. Lean v4.29.1 OK.
+Lake = elan installe sous `C:\Users\MYIA\.elan\bin\`. Toolchain courante **v4.31.0-rc1** (cf. `lean-toolchain` et `lake-manifest.json` `inputRev`).
 
-Si "no such file or directory" sur des oleans Mathlib (cache corrompu) :
+### Cache Mathlib local (junction partage) — ne PAS `cache get` par defaut
+
+Les oleans Mathlib sont **deja presents localement** via un cache mutualise junctionne. Le defaut est de **reutiliser** ce cache ; `cache get` est un fallback.
+
+- **Emplacement** : `MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/.lake/packages/mathlib/.lake/build/lib/lean/` — le `conway_lean` (lake-pivot) porte le checkout Mathlib a rev **v4.31.0-rc1**.
+- **Mutualisation** : les autres lakes junctionnent leur `.lake/packages` vers celui de `conway_lean` (ex. `game_theory_lean/.lake/packages` est une `Junction` -> `conway_lean/.lake/packages`). Verifier : `(Get-Item <lake>/.lake/packages).LinkType` doit valoir `Junction`.
+- **Lake reutilise les oleans** : un `lake build <module-set>` sur un worktree propre compile en ~1min (ex. `RepeatedGames.GrimTrigger` = 2948 jobs ~49s, Mathlib reused integralement), PAS 30-60min de recompile frais.
+
+**Piege false-absent (incident 2026-07-24, re-propage sur 3 cycles)** : chercher les oleans dans `.mathlib-cache/` (chemin unused) OU dans le repertoire SOURCE `.../mathlib/Mathlib/` renvoie **0 fichier** — Lake stocke les oleans dans `.lake/build/lib/lean/`, PAS alongside la source. Un `find .../Mathlib/ -name '*.olean'` vide **ne prouve PAS** un cache vide : verifier `.lake/build/lib/lean/Mathlib/` (snapshot 2026-07-24 : ~8100 oleans).
+
+**Fallback `cache get` (UNIQUEMENT si junction cassee / oleans manquants dans `.lake/build/lib/lean/`)** :
 ```bash
-lake exe cache get   # ~3min, 8232 oleans pre-builts depuis Azure
+lake exe cache get   # ~3min, oleans pre-builts depuis Azure — fallback, pas defaut
 ```
 
-Toujours `cache get` AVANT un build neuf, pas apres.
+Si le build echoue alors que la junction est intacte et `.lake/build/lib/lean/Mathlib/` peuple, le probleme est le **code** (cf. incident 2026-05-10), pas le cache.
 
 ### CI != Lake build local
 


### PR DESCRIPTION
## Summary

Corrects the stale Mathlib cache guidance in [`docs/lean/coordinator-workflow.md`](docs/lean/coordinator-workflow.md) §1. The doc propagated a **false premiss** — \"`cache get` required before a fresh build (8232 oleans from Azure)\" — while the local junctioned Mathlib cache makes `cache get` a **fallback**, not the default.

**Dispatched by ai-01** (DM 2026-07-24, HIGH) to kill the re-propagated false-premiss that blocked the Lean lane for 3 cycles (c.635 ai-01, c.703/c.704 po-2026).

## Root cause of the false-premiss

Checking the **wrong path** reports \"cache empty\". Lake stores oleans in `.lake/build/lib/lean/`, NOT alongside source — so `find .../mathlib/Mathlib/` or `.mathlib-cache/` returns 0 files while the cache is in fact populated. This is the exact bug.

## Verified firsthand on c:\dev\CoursIA

| Fact | Evidence |
|------|----------|
| Cache populated | `conway_lean/.lake/packages/mathlib/.lake/build/lib/lean/` EXISTS, **8119 oleans** (snapshot 2026-07-24), Mathlib rev **v4.31.0-rc1** (`lake-manifest.json` `inputRev`) |
| Shared via junction | `game_theory_lean/.lake/packages` is a `Junction` → `conway_lean/.lake/packages` (`(Get-Item ...).LinkType == 'Junction'`) |
| Lake reuses it | `lake build RepeatedGames.GrimTrigger` worktree propre = **2948 jobs ~49s** (Mathlib reused), not 30-60min fresh recompile |

## Changes (docs-only, +14/−4, 1 file)

- Document the junctioned shared cache (location, rev, mutualisation, reuse timing)
- Document the **false-absent pattern** (wrong path → \"empty\")
- Demote `cache get` to **FALLBACK** (only if junction broken / oleans missing in `.lake/build/lib/lean/`)
- Correct toolchain version **v4.29.1 → v4.31.0-rc1** (same build-env block, aligned with the cache rev reference)

## Scope / validation

- **Docs-only** — no code, no `.lake` contention, no notebook
- `check_docs_links.py --check` EXIT 0 (no link regression; diff adds zero new markdown links, only backtick code paths)
- Whole-file read for coherence (§E spirit); the cache block is internally consistent post-edit

## See

Dispatched by ai-01. Partial contribution to Lean docs freshness — `See #3973` (epic open). Reusable for the whole fleet (prevents re-propagation of the \"cache empty\" false-premiss).

Co-Authored-By: Claude <noreply@anthropic.com>