### PR TITLE
fix(twin-parity,#8264): per-pair CI mode to prevent fleet-wide gate failure

### DIFF
--- a/.github/workflows/twin-parity.yml
+++ b/.github/workflows/twin-parity.yml
@@ -15,6 +15,16 @@ name: Twin Parity Check
 # ("metadonnee de parite auditable, pas declarative"). Blocking is the only
 # way to make the auditable promise real.
 #
+# Per-pair semantics (#8264): the workflow runs in `--per-pair --base
+# origin/main` mode, comparing the registry + blob SHAs at the PR's HEAD vs
+# at origin/main (the base ref). The gate FAILS only on pairs that the PR
+# itself has moved (base=OK, head=DRIFT/MISSING) or introduced/removed
+# without rebaseline. Drift already present at origin/main is reported as
+# `drift_pre_existing` but does NOT fail the gate -- it belongs to a
+# dedicated rebaseline PR (cf #8264 batch precedent: #8282, #8289, #8322,
+# #8372). This keeps the gate green for legitimate single-side edits while
+# still surfacing fleet-wide stale SHAs through the report.
+#
 # Pattern: the worker who edits a twin must either re-audit (and rebaseline
 # the SHAs in the registry, `python scripts/notebook_tools/check_twin_parity.py --update`)
 # OR split the edit so the twin moves in lockstep on the same PR. The
@@ -27,7 +37,7 @@ name: Twin Parity Check
 #     the tool itself filters down to the pairs in the registry).
 #
 # Reuses the proven structure of catalog-drift.yml (read-only checkout of
-# the PR merge ref, run tool, surface result) but FAILS on DRIFT/MISSING.
+# the PR merge ref, run tool, surface result) but FAILS on DRIFT_INTRODUCED.
 
 on:
   pull_request:
@@ -64,20 +74,22 @@ jobs:
         id: check
         run: |
           set +e
-          OUTPUT=$(python scripts/notebook_tools/check_twin_parity.py --json --check 2>&1)
+          OUTPUT=$(python scripts/notebook_tools/check_twin_parity.py --json --check --per-pair --base origin/main 2>&1)
           EXIT=$?
           echo "$OUTPUT" > twin_parity_report.json
           set -e
           if [ $EXIT -eq 0 ]; then
-            echo "drift=false" >> "$GITHUB_OUTPUT"
-            echo "missing=false" >> "$GITHUB_OUTPUT"
-            echo "Twin parity OK : aucune paire en DRIFT ou MISSING."
+            INTRO=$(python -c "import json; d=json.load(open('twin_parity_report.json')); print(d.get('drift_introduced',0))")
+            PRE=$(python -c "import json; d=json.load(open('twin_parity_report.json')); print(d.get('drift_pre_existing',0))")
+            echo "drift_introduced=$INTRO" >> "$GITHUB_OUTPUT"
+            echo "drift_pre_existing=$PRE" >> "$GITHUB_OUTPUT"
+            echo "Twin parity OK : $PRE paire(s) en DRIFT pre-existant (base=origin/main) ne fail pas le gate (rellevent d'une PR de rebaseline dediee, cf #8264)."
           elif [ $EXIT -eq 1 ]; then
-            DRIFT=$(python -c "import json; d=json.load(open('twin_parity_report.json')); print(d.get('drift',0))")
-            MISSING=$(python -c "import json; d=json.load(open('twin_parity_report.json')); print(d.get('missing',0))")
-            echo "drift=$DRIFT" >> "$GITHUB_OUTPUT"
-            echo "missing=$MISSING" >> "$GITHUB_OUTPUT"
-            echo "::error title=Twin parity DRIFT/MISSING detected::Le registre signale des paires dont un jumeau a evolue sans re-audit, ou des chemins manquants. Voir twin_parity_report.json dans les artifacts. Action : re-auditer la paire firsthand puis \`python scripts/notebook_tools/check_twin_parity.py --update\` pour rebaseline, OU splitter le PR en deux PRs distincts pour que chaque cote evolue separement."
+            INTRO=$(python -c "import json; d=json.load(open('twin_parity_report.json')); print(d.get('drift_introduced',0))")
+            PRE=$(python -c "import json; d=json.load(open('twin_parity_report.json')); print(d.get('drift_pre_existing',0))")
+            echo "drift_introduced=$INTRO" >> "$GITHUB_OUTPUT"
+            echo "drift_pre_existing=$PRE" >> "$GITHUB_OUTPUT"
+            echo "::error title=Twin parity DRIFT INTRODUCED by this PR::La PR a introduit $INTRO paire(s) en DRIFT/MISSING qui etaient OK au base-ref origin/main. Action : re-auditer la paire firsthand puis \`python scripts/notebook_tools/check_twin_parity.py --update\` pour rebaseline le SHA dans le meme PR, OU splitter en deux PRs pour que chaque cote evolue separement avec rebaseline. Drift pre-existant ($PRE paire(s)) releve d'une PR dediee cf #8264. Voir twin_parity_report.json dans les artifacts."
             exit 1
           else
             echo "::error title=Twin parity tool error::Erreur d'execution du check (exit $EXIT). Voir les logs ci-dessus."

--- a/scripts/notebook_tools/check_twin_parity.py
+++ b/scripts/notebook_tools/check_twin_parity.py
@@ -38,7 +38,7 @@ Usage
 -----
     # verifier toutes les paires vs le registre
     python check_twin_parity.py
-    # exit 1 si drift/missing (CI-ready)
+    # exit 1 si drift/missing (CI-ready, mode historique fleet-wide)
     python check_twin_parity.py --check
     # restreindre a une famille
     python check_twin_parity.py --family SMT/Z3-API
@@ -46,17 +46,26 @@ Usage
     python check_twin_parity.py --update
     # sortie machine
     python check_twin_parity.py --json
+    # mode per-pair : ne FAIL que sur le drift INTRODUIT par la PR en cours
+    # (paire OK au base-ref mais DRIFT au HEAD). Necessite --base <ref>.
+    # Compare le registre+blobs au base-ref (avant la PR) vs au HEAD (apres la PR).
+    # Le drift pre-existant (deja present au base-ref) n'est PAS comptabilise ici
+    # -- il releve d'une PR de rebaseline dediee (cf #8264 batch precedent).
+    python check_twin_parity.py --check --per-pair --base origin/main
+    python check_twin_parity.py --check --per-pair --base HEAD~1
 
 Exit codes
 ----------
-    0 -- toutes les paires OK (ou mode non --check)
-    1 -- un ou plusieurs DRIFT / MISSING (--check seulement)
+    0 -- toutes les paires OK (ou mode non --check), ou zero nouveau drift en --per-pair
+    1 -- un ou plusieurs DRIFT / MISSING (mode --check fleet-wide)
+         OU nouveau(s) DRIFT introduit(s) par la PR (mode --check --per-pair)
     2 -- erreur (registre illisible, pas un depot git)
 
 Voir aussi
 ----------
 - twin_pairs.yaml (registre curated, a cote de ce script)
 - Issue #8057 (metadonnee de parite des jumeaux Python/C#)
+- Issue #8264 (batch rebaseline precedent -- pattern DRIFT pre-existant)
 - Issue #4208 (parent : open-courseware fiabilise/publie)
 """
 from __future__ import annotations
@@ -75,10 +84,14 @@ except ImportError:  # pragma: no cover
 DEFAULT_REGISTRY = Path(__file__).resolve().parent / "twin_pairs.yaml"
 
 
-def _git_blob_sha(repo_root: Path, rel_path: str) -> str | None:
-    """Git blob SHA d'un fichier versionne a HEAD (None si absent)."""
+def _git_blob_sha(repo_root: Path, rel_path: str, git_ref: str = "HEAD") -> str | None:
+    """Git blob SHA d'un fichier versionne a `git_ref` (defaut: HEAD, None si absent).
+
+    Accepte un ref arbitraire (HEAD, origin/main, HEAD~1, <sha>, ...) -- permet de
+    lire l'etat du depot a un instant donne sans modifier le working tree.
+    """
     r = subprocess.run(
-        ["git", "ls-tree", "HEAD", "--", rel_path],
+        ["git", "ls-tree", git_ref, "--", rel_path],
         capture_output=True, text=True, cwd=str(repo_root),
     )
     if r.returncode != 0 or not r.stdout.strip():
@@ -88,6 +101,21 @@ def _git_blob_sha(repo_root: Path, rel_path: str) -> str | None:
     if len(parts) >= 3:
         return parts[2]
     return None
+
+
+def _git_show_file(repo_root: Path, git_ref: str, rel_path: str) -> str | None:
+    """Contenu d'un fichier versionne a `git_ref` (None si absent).
+
+    Utilise `git show <ref>:<path>` (mode stream), evite de checkout le working tree.
+    Necessaire pour lire le registre YAML au base-ref sans polluer le workspace CI.
+    """
+    r = subprocess.run(
+        ["git", "show", f"{git_ref}:{rel_path}"],
+        capture_output=True, cwd=str(repo_root),
+    )
+    if r.returncode != 0:
+        return None
+    return r.stdout.decode("utf-8", errors="replace")
 
 
 def _repo_root() -> Path:
@@ -111,10 +139,11 @@ def load_registry(path: Path) -> list:
     return data
 
 
-def check_pair(repo_root: Path, pair: dict) -> dict:
+def check_pair(repo_root: Path, pair: dict, git_ref: str = "HEAD") -> dict:
     """Verifie une paire. Retourne {name, python, csharp, status, details}.
 
     status in {OK, DRIFT, MISSING}. details = liste de chaines explicatives.
+    `git_ref` permet de checker a un instant arbitraire (HEAD, origin/main, <sha>...).
     """
     name = pair.get("name", "?")
     py = pair["python"]
@@ -123,8 +152,8 @@ def check_pair(repo_root: Path, pair: dict) -> dict:
     rec_py = audit.get("python_sha")
     rec_cs = audit.get("csharp_sha")
 
-    cur_py = _git_blob_sha(repo_root, py)
-    cur_cs = _git_blob_sha(repo_root, cs)
+    cur_py = _git_blob_sha(repo_root, py, git_ref)
+    cur_cs = _git_blob_sha(repo_root, cs, git_ref)
 
     details = []
     status = "OK"
@@ -198,10 +227,131 @@ def main(argv=None) -> int:
                    help="Rebaseline : ecrit les SHAs courants comme nouveau last_audit "
                         "(a lancer APRES une audit firsthand d'une paire)")
     p.add_argument("--json", action="store_true", help="Sortie machine JSON")
+    p.add_argument("--per-pair", action="store_true",
+                   help="Mode per-pair : compare HEAD vs --base <ref>. Ne FAIL que "
+                        "le drift INTRODUIT par la PR, jamais le drift pre-existant.")
+    p.add_argument("--base", default=None,
+                   help="Ref git de base pour le mode --per-pair (ex. origin/main, HEAD~1).")
     args = p.parse_args(argv)
+
+    # Cross-validation : --per-pair <-> --base
+    if args.per_pair and not args.base:
+        p.error("--per-pair necessite --base <ref>")
+    if args.base and not args.per_pair:
+        p.error("--base necessite --per-pair")
+    if args.update and (args.per_pair or args.base):
+        p.error("--update est incompatible avec --per-pair/--base")
 
     repo_root = _repo_root()
     reg_path = Path(args.registry)
+
+    # --- Mode --per-pair : comparaison HEAD vs base-ref ---
+    if args.per_pair:
+        # Charge le registre a HEAD (working tree) et au base-ref (git show)
+        pairs_head = load_registry(reg_path)
+        # reg_path peut etre absolu ou relatif -- on prend toujours le path
+        # relatif au repo_root pour `git show <ref>:<relpath>`.
+        # IMPORTANT : on normalise en forward-slashes (git sur Windows
+        # refuse les backslashes dans `<ref>:<path>`).
+        try:
+            reg_rel = reg_path.resolve().relative_to(repo_root).as_posix()
+        except ValueError:
+            # reg_path n'est pas sous repo_root : on tente quand meme avec son nom
+            reg_rel = Path(reg_path.name).as_posix()
+        reg_text_base = _git_show_file(repo_root, args.base, reg_rel)
+        if reg_text_base is None:
+            raise SystemExit(f"Impossible de lire le registre au base-ref '{args.base}' : {reg_rel}")
+        if yaml is None:
+            raise SystemExit("PyYAML requis pour --per-pair.")
+        data_base = yaml.safe_load(reg_text_base)
+        if not isinstance(data_base, list):
+            raise SystemExit("Le registre au base-ref n'est pas une liste.")
+        pairs_base = data_base
+        # Index par nom (au cas ou l'ordre ou les ajouts/suppressions different)
+        base_by_name = {pp.get("name", "?"): pp for pp in pairs_base}
+
+        if args.family:
+            pairs_head = [pp for pp in pairs_head if pp.get("family") == args.family]
+            if not pairs_head:
+                print(f"Aucune paire pour la famille '{args.family}'.", file=sys.stderr)
+
+        results = []
+        for pp in pairs_head:
+            name = pp.get("name", "?")
+            head_state = check_pair(repo_root, pp, git_ref="HEAD")
+            base_pp = base_by_name.get(name)
+            if base_pp is None:
+                # Paire ajoutee par la PR -> si elle n'est PAS OK au HEAD, c'est du drift introduit
+                base_status = "MISSING"
+                base_details = [f"Paire '{name}' absente du registre au base-ref '{args.base}' (ajoutee par la PR)"]
+            else:
+                base_check = check_pair(repo_root, base_pp, git_ref=args.base)
+                base_status = base_check["status"]
+                base_details = base_check["details"]
+
+            head_status = head_state["status"]
+            # Classification per-pair
+            if base_status == "OK" and head_status == "OK":
+                verdict = "OK"
+            elif base_status == "OK" and head_status in ("DRIFT", "MISSING"):
+                verdict = "DRIFT_INTRODUCED"
+            elif base_status in ("DRIFT", "MISSING") and head_status == "OK":
+                verdict = "DRIFT_RESOLVED"
+            else:
+                verdict = "DRIFT_PRE_EXISTING"
+
+            results.append({
+                "name": name,
+                "family": pp.get("family", "?"),
+                "parity_level": pp.get("parity_level", "?"),
+                "base_ref": args.base,
+                "base_status": base_status,
+                "head_status": head_status,
+                "verdict": verdict,
+                "base_details": base_details,
+                "head_details": head_state["details"],
+            })
+
+        n_ok = sum(1 for r in results if r["verdict"] == "OK")
+        n_introduced = sum(1 for r in results if r["verdict"] == "DRIFT_INTRODUCED")
+        n_resolved = sum(1 for r in results if r["verdict"] == "DRIFT_RESOLVED")
+        n_pre_existing = sum(1 for r in results if r["verdict"] == "DRIFT_PRE_EXISTING")
+
+        if args.json:
+            out = {
+                "mode": "per_pair",
+                "registry": str(reg_path),
+                "base_ref": args.base,
+                "total": len(results),
+                "ok": n_ok,
+                "drift_introduced": n_introduced,
+                "drift_resolved": n_resolved,
+                "drift_pre_existing": n_pre_existing,
+                "pairs": results,
+            }
+            print(json.dumps(out, ensure_ascii=False, indent=2))
+        else:
+            tag_map = {
+                "OK": "OK",
+                "DRIFT_INTRODUCED": "DRIFT-INTRO",
+                "DRIFT_RESOLVED": "DRIFT-FIXED",
+                "DRIFT_PRE_EXISTING": "DRIFT-PRE",
+            }
+            for r in results:
+                tag = tag_map[r["verdict"]]
+                print(f"[{tag}] {r['name']} ({r['family']}, {r['parity_level']}) "
+                      f"base={r['base_status']} head={r['head_status']}")
+                if r["verdict"] != "OK":
+                    for d in r["head_details"]:
+                        print(f"       HEAD: {d}")
+            print(f"\nTotal : {len(results)} paire(s) | "
+                  f"OK={n_ok} INTRO={n_introduced} FIXED={n_resolved} PRE={n_pre_existing}")
+
+        if args.check and n_introduced > 0:
+            return 1
+        return 0
+
+    # --- Mode historique (fleet-wide) ---
     pairs = load_registry(reg_path)
 
     if args.family:

--- a/scripts/notebook_tools/check_twin_parity.py
+++ b/scripts/notebook_tools/check_twin_parity.py
@@ -215,6 +215,30 @@ def update_pair(repo_root: Path, pair: dict) -> tuple[dict, str | None]:
     return audit, cur_py
 
 
+def _classify_per_pair(base_status: str, head_status: str) -> str:
+    """Verdict per-pair pour le mode --per-pair (compare HEAD vs base-ref).
+
+    Retourne un de : OK / DRIFT_INTRODUCED / DRIFT_RESOLVED / DRIFT_PRE_EXISTING.
+    Le gate (--check --per-pair) ne FAIL que sur DRIFT_INTRODUCED.
+
+    Cas special : une paire AJOUTEE par la PR (base_status="MISSING", absente au
+    base-ref). Pour une paire nouvelle, il n'y a PAS d'etat pre-existant -- son etat
+    au HEAD est exactement ce que la PR introduit. Donc ajoutee+OK -> OK, ajoutee+
+    DRIFT -> DRIFT_INTRODUCED. (Avant le fix, le 'else' classait MISSING+DRIFT en
+    DRIFT_PRE_EXISTING, qui ne fail pas le gate -- contredisait le comment inline et
+    laissait passer une paire ajoutee driftante. Forensic po-2026 c.709.)
+    """
+    if base_status == "MISSING":
+        return "OK" if head_status == "OK" else "DRIFT_INTRODUCED"
+    if base_status == "OK" and head_status == "OK":
+        return "OK"
+    if base_status == "OK" and head_status in ("DRIFT", "MISSING"):
+        return "DRIFT_INTRODUCED"
+    if base_status == "DRIFT" and head_status == "OK":
+        return "DRIFT_RESOLVED"
+    return "DRIFT_PRE_EXISTING"
+
+
 def main(argv=None) -> int:
     p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
     p.add_argument("--registry", default=str(DEFAULT_REGISTRY),
@@ -290,15 +314,9 @@ def main(argv=None) -> int:
                 base_details = base_check["details"]
 
             head_status = head_state["status"]
-            # Classification per-pair
-            if base_status == "OK" and head_status == "OK":
-                verdict = "OK"
-            elif base_status == "OK" and head_status in ("DRIFT", "MISSING"):
-                verdict = "DRIFT_INTRODUCED"
-            elif base_status in ("DRIFT", "MISSING") and head_status == "OK":
-                verdict = "DRIFT_RESOLVED"
-            else:
-                verdict = "DRIFT_PRE_EXISTING"
+            # Classification per-pair (cf _classify_per_pair -- le cas paire ajoutee
+            # est special : pas d'etat pre-existant, l'etat HEAD = ce que la PR introduit).
+            verdict = _classify_per_pair(base_status, head_status)
 
             results.append({
                 "name": name,

--- a/scripts/notebook_tools/tests/test_check_twin_parity.py
+++ b/scripts/notebook_tools/tests/test_check_twin_parity.py
@@ -1,0 +1,91 @@
+"""Tests for check_twin_parity --per-pair classification (_classify_per_pair).
+
+Pins the edge-case fix for ADDED pairs (forensic po-2026 c.709, executable proof).
+
+Before the fix, a pair ADDED by the PR (absent from the base-ref registry,
+base_status="MISSING") that was NOT OK at HEAD (head_status="DRIFT") was
+mis-classified as DRIFT_PRE_EXISTING -- which does NOT fail the gate (the gate
+fails only on DRIFT_INTRODUCED). So a PR that added a new twin_pairs.yaml entry
+with driftant SHAs passed the per-pair gate. That contradicted the inline comment
+("paire ajoutee -> si pas OK au HEAD, c'est du drift introduit") and the
+"sound edge case" LGTM claim.
+
+The fix: a pair absent from the base-ref has NO pre-existing state -- its HEAD
+state IS what the PR introduces. So MISSING+DRIFT -> DRIFT_INTRODUCED (gate
+fails), and MISSING+OK -> OK (not the misleading DRIFT_RESOLVED).
+
+All 9 combos of base_status x head_status are pinned here so the classification
+table is regression-locked.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from check_twin_parity import _classify_per_pair  # noqa: E402
+
+
+# --- the full 9-combo classification table (base_status x head_status) --------
+# (base, head) -> (verdict, fails_gate)
+# fails_gate = True iff verdict == "DRIFT_INTRODUCED" (the --check --per-pair exit 1).
+EXPECTED = {
+    # Existing pair, clean at base
+    ("OK", "OK"): ("OK", False),
+    ("OK", "DRIFT"): ("DRIFT_INTRODUCED", True),
+    ("OK", "MISSING"): ("DRIFT_INTRODUCED", True),
+    # Existing pair, already driftant at base
+    ("DRIFT", "OK"): ("DRIFT_RESOLVED", False),
+    ("DRIFT", "DRIFT"): ("DRIFT_PRE_EXISTING", False),
+    ("DRIFT", "MISSING"): ("DRIFT_PRE_EXISTING", False),
+    # Pair ADDED by the PR (absent at base) -- the fixed edge cases
+    ("MISSING", "OK"): ("OK", False),              # PR adds a clean pair
+    ("MISSING", "DRIFT"): ("DRIFT_INTRODUCED", True),   # <-- the bug: was PRE_EXISTING
+    ("MISSING", "MISSING"): ("DRIFT_INTRODUCED", True), # <-- the bug: was PRE_EXISTING
+}
+
+
+@pytest.mark.parametrize("base,head", sorted(EXPECTED.keys()))
+def test_classify_all_combos(base, head):
+    verdict, fails_gate = EXPECTED[(base, head)]
+    got = _classify_per_pair(base, head)
+    assert got == verdict, (
+        f"_classify_per_pair({base!r}, {head!r}) = {got!r}, expected {verdict!r}"
+    )
+    # The gate (--check --per-pair) returns 1 iff there is >=1 DRIFT_INTRODUCED.
+    assert (got == "DRIFT_INTRODUCED") == fails_gate
+
+
+# --- the two founding-bug cases, spelled out explicitly ----------------------
+
+
+def test_added_pair_driftant_at_head_fails_gate():
+    """The founding bug: an ADDED pair (base MISSING) that is DRIFT at HEAD must
+    be classified DRIFT_INTRODUCED (gate fails), NOT DRIFT_PRE_EXISTING (gate pass).
+    """
+    assert _classify_per_pair("MISSING", "DRIFT") == "DRIFT_INTRODUCED"
+
+
+def test_added_pair_with_missing_files_at_head_fails_gate():
+    """Same bug, files-missing variant: ADDED pair whose files don't exist at HEAD
+    must be DRIFT_INTRODUCED, not silently passed as PRE_EXISTING."""
+    assert _classify_per_pair("MISSING", "MISSING") == "DRIFT_INTRODUCED"
+
+
+def test_added_clean_pair_is_OK_not_resolved():
+    """An ADDED pair that is OK at HEAD is OK (the PR adds a clean pair), NOT
+    DRIFT_RESOLVED (nothing was resolved -- there was no prior driftant state)."""
+    assert _classify_per_pair("MISSING", "OK") == "OK"
+
+
+def test_pre_existing_drift_does_not_fail_gate():
+    """Sanity: a pair driftant at BOTH base and HEAD is PRE_EXISTING (not the PR's
+    fault) and must NOT fail the gate. This is the whole point of --per-pair mode."""
+    assert _classify_per_pair("DRIFT", "DRIFT") == "DRIFT_PRE_EXISTING"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Grain: MED/twin-parity — lane myia-po-2023:CoursIA-2 — prev: MED/notebook-genai-deprecation-fix (c.867)

# c.869 — `fix(twin-parity,#8264)`: per-pair CI mode to prevent fleet-wide gate failure from single stale sha

## Scope

Implements the **durable fix** called for in issue #8264 body: "enforce that
any PR touching a registered twin rebaselines its sha in the SAME PR".
Rather than adding a workflow that audits every registered pair (expensive
and noisy), we make the **per-pair semantics explicit** at the gate level:

- **before this PR**: CI fails on ANY drift anywhere in the 39-pair fleet,
  even if the drift was already present at `origin/main` (single stale sha
  = whole fleet blocked, since #8185 made twin-parity BLOCKING).
- **after this PR**: CI fails ONLY on drift the PR itself introduced
  (base=OK, head=DRIFT/MISSING). Pre-existing drift is reported but doesn't
  block the PR — it belongs to a dedicated rebaseline PR (cf #8264 batch
  precedent: #8282, #8289, #8322, #8372).

## Changements

**Substance : 2 fichiers, +181/-19 strict, scope = twin-parity gate uniquement.**

### `scripts/notebook_tools/check_twin_parity.py` (+154/-14)

1. **`_git_blob_sha(repo_root, rel_path, git_ref="HEAD")`** : accepte un ref
   arbitraire (HEAD, origin/main, HEAD~1, sha). Lecture reproductible sans
   checkout working tree.

2. **`_git_show_file(repo_root, git_ref, rel_path)`** : nouveau helper pour
   lire le contenu d'un fichier à un ref arbitraire via `git show
   <ref>:<path>`. Utilisé pour charger `twin_pairs.yaml` au base-ref
   (sans polluer le workspace CI). **Path normalisé en forward-slashes**
   (`as_posix()`) — bug détecté en local : git sur Windows refuse les
   backslashes dans `<ref>:<path>` (rc=128 `path 'scripts\notebook_tools
   \twin_pairs.yaml' does not exist`).

3. **`check_pair(repo_root, pair, git_ref="HEAD")`** : propage le ref
   arbitraire. Par défaut `HEAD` (compat ascendante).

4. **`--per-pair` + `--base <ref>`** dans `main()` (cross-validés) :
   - Charge le registre à HEAD (working tree) ET au base-ref (via `git show`).
   - Pour chaque paire, calcule `base_status` (au base-ref) et
     `head_status` (à HEAD), puis classifie :
     - `base=OK + head=OK` → **OK**
     - `base=OK + head=DRIFT/MISSING` → **DRIFT_INTRODUCED** (← le PR l'a fait)
     - `base=DRIFT/MISSING + head=OK` → **DRIFT_RESOLVED** (rebénéfice)
     - `base=DRIFT/MISSING + head=DRIFT/MISSING` → **DRIFT_PRE_EXISTING**
   - Sortie JSON : `{mode: "per_pair", base_ref, ok, drift_introduced,
     drift_resolved, drift_pre_existing, pairs:[...]}`. Sortie texte :
     tags `OK / DRIFT-INTRO / DRIFT-FIXED / DRIFT-PRE`.
   - Exit code : 1 UNIQUEMENT si `drift_introduced > 0` ET `--check`.
     Mode fleet-wide (sans `--per-pair`) : comportement préservé.

5. **Cross-validation argparse** : `--per-pair` exige `--base`, `--base` exige
   `--per-pair`, `--update` est incompatible avec `--per-pair/--base`.

### `.github/workflows/twin-parity.yml` (+27/-5)

- Commande changée : `python scripts/notebook_tools/check_twin_parity.py
  --json --check --per-pair --base origin/main`.
- Le commentaire d'en-tête explique la sémantique per-pair + référence le
  batch precedent (#8282, #8289, #8322, #8372).
- Lecture des nouveaux compteurs JSON (`drift_introduced`,
  `drift_pre_existing`) au lieu de `drift`/`missing` legacy.
- Le message d'erreur titre devient `Twin parity DRIFT INTRODUCED by this PR`
  (plus précis que le générique `DRIFT/MISSING detected`).

## Méthode (byte-surgical, L982 ★★ / L983 ★★)

1. **Lecture firsthand** de `check_twin_parity.py` (10174 bytes, LF-only
   CR=0, version de c.801 #8185) avant toute édition.
2. **3 Edit operations** ciblées (signature `_git_blob_sha` + helper
   `_git_show_file` + propagation `git_ref` + bloc per-pair dans `main()`),
   préservant l'ordre original des fonctions et la compat fleet-wide.
3. **Validation Python** : `ast.parse` → SYNTAX OK.
4. **Validation workflow** : `yaml.safe_load` → YAML OK.
5. **LF-only** préservé (`write_bytes` jamais utilisé ici ; Edits en place
   sur chaînes LF-only) : `raw.count(b'\r\n') == 0` après edits.
6. **Pas de regen catalogue** (catalog-pr-hygiene R1) : `git diff --name-only
   | grep -E "COURSE_CATALOG|README.*CATALOG-STATUS"` → 0 match.

## Validations (post-fix, firsthand)

| Validation | Résultat | Détail |
|---|---|---|
| `ast.parse` syntaxe Python | **PASS** | Aucune erreur |
| `yaml.safe_load` workflow | **PASS** | YAML valide |
| LF-only CR=0 sur le script | **OK** | `raw.count(b'\r\n') == 0` |
| LF-only sur le workflow YAML | **OK** | pas d'édition binaire |
| `git diff --stat` | **+181/-19 strict** | 2 fichiers exactement |
| `git diff --name-only` | **2 fichiers** | `check_twin_parity.py` + `twin-parity.yml` |
| Pas de catalogue touché | **0 ligne** | `grep COURSE_CATALOG` → 0 match |
| **Test clean baseline** | **PASS** | `--check --per-pair --base origin/main` → 39 OK, INTRO=0, FIXED=0, PRE=0, exit 0 |
| **Test drift introduit (PyMC-2)** | **PASS** | commit whitespace-only sur PyMC-2 → `--check --per-pair --base origin/main` → 38 OK, INTRO=1, PRE=0, exit 1 (DRIFT_INTRODUCED correctement classifié) |
| **Test mode fleet-wide préservé** | **PASS** | `--check` (sans `--per-pair`) → toujours exit 1 sur DRIFT/MISSING |
| **Cross-validation argparse** | **PASS** | `--per-pair` sans `--base` → argparse.error ; `--update --per-pair` → argparse.error |
| Collision cross-lane (L898 ★★★) | **0 PR OPEN** | `gh pr list --search "#8264"` → aucun PR ouvert sur cette cible |

## Garde-fous (L898 ★★★ / L977 ★★ / L954 ★★)

- **L898 ★★★ + L977 ★★ collision pre-push** : `gh pr list --search
  "#8264"` → 0 PR OPEN (4 PRs MERGED = batch rebaseline precedent ; 2
  PRs CLOSED = c.840 + c.837 superseded). Mon PR est strictement
  **complementaire** : outillage de gate, pas rebaseline.
- **L954 ★★ pivot cross-famille** : c.867 = MED/notebook-genai-deprecation-fix,
  c.868 = MED/notebook-genai-costfm, c.869 = MED/twin-parity → **3ᵉ pivot
  consécutif post-c.867** honoré (genre `twin-parity` distinct des
  précédents). 23ᵉ pivot consécutif post-c.839 + 2.
- **G-VAR-1/2/3** : plat principal MED (outillage de gate + ré-audit
  + classifications OK/INTRO/FIXED/PRE), 0 LIGHT consomme aujourd'hui sur
  la lane, genre `twin-parity` distinct des précédents.
- **C248-L2 backup MEMORY** : `cp MEMORY.md MEMORY.md.bak.c869` avant
  edit final.

## Hors scope (pour memoire)

- **#8264 n'est pas entierement clos** (intentionnellement) : cette PR est
  le **grain structurel** de l'epic parente #4208 (open-courseware
  fiabilisé). Reste à exploiter : (a) audit README fichier-entier des
  sous-séries avec CATALOG-STATUS stale (cf PR #5345 Probas), (b) ledger
  de rébaselines pour traçabilité, (c) migration du registre vers
  validation JSON-Schema typée (les 14 champs costfm sont un sous-ensemble
  de ce qui pourrait être validé). Voir labels `twin-parity` GH restants.
- **#8056 #8057 #8185 antecedents** : la CI twin-parity est devenue
  **blocking** post-#8185 ; ce PR la rend **intelligente** (fail seulement
  sur l'introduced) sans la dégrader en advisory.

## Liens

- Issue : [#8264](https://github.com/jsboige/CoursIA/issues/8264)
  "twin-registry fleet drift — 14 stale pairs block ALL PRs"
- PRs batch rebaseline (precedents MERGED) :
  [#8372](https://github.com/jsboige/CoursIA/pull/8372) (15 paires, le plus
  récent) · [#8322](https://github.com/jsboige/CoursIA/pull/8322)
  (Probas-18/19, c.844/c.845/c.847 own-omissions) · [#8289](https://github.com/jsboige/CoursIA/pull/8289) (ML-1/2/3/5 + CSP-3) ·
  [#8282](https://github.com/jsboige/CoursIA/pull/8282) (13 Probas paires, 19→6)
- PRs blocked-by-stale-sha (closes) : [#8267](https://github.com/jsboige/CoursIA/pull/8267) (c.840 resync superseded by #8282)
- Issue #8185 : "ci(#8057): blocking twin parity workflow + script bug-fix
  + CSP-2 rebaseline" (le PR qui a rendu twin-parity **blocking** ; c.869
  en opérationnalise la sémantique)
- Issue #8057 : registre de parité auditable (parent conceptuel)
- Pivot post-c.867 : c.868 = MED/notebook-genai-costfm, c.869 =
  MED/twin-parity, 3ᵉ pivot consécutif post-c.867.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
