### PR TITLE
fix(detect-solution-leaks,#8053): close Lean-15 cells 25/29 FP via run_lean snippet helper (recall-safe)

### DIFF
--- a/scripts/notebook_tools/detect_solution_leaks.py
+++ b/scripts/notebook_tools/detect_solution_leaks.py
@@ -613,6 +613,89 @@ def exercise_with_exercice_indice_skeleton(source: str) -> bool:
     return not has_substantive_call
 
 
+def exercise_with_run_lean_snippet(source: str) -> bool:
+    """Return True if the cell is a Lean exercise that wraps a ``snippet_exN``
+    string literal passed to ``run_lean(...)`` for isolated execution, with
+    pedagogical commentary (``# Lecture : ...``) — the student inspects the
+    snippet output and answers the conceptual question.
+
+    Structural pattern observed in ``Lean-15-Grothendieck-Tribute`` cells 25
+    and 29 (c.8104g sub-grain of EPIC #8053):
+
+    1. A ``# Exercice N : <topic>`` (or similar) header comment at the top
+       of the cell body — the same language the detector uses to attribute
+       the code cell to its exercise markdown header.
+    2. A multi-line ``snippet_exN = \"\"\" ... Lean code ... \"\"\"`` literal
+       containing ``import`` / ``#check`` / ``#eval`` style verification
+       statements — the snippet itself is mostly *check statements* that
+       demonstrate type-class instances are reachable, not a worked theorem
+       proof.
+    3. A ``resultat_exN = run_lean(snippet_exN, timeout_s=...)`` invocation
+       that compiles and runs the snippet in an isolated Lean process.
+    4. A ``print(resultat_exN)`` trailer that displays the snippet's output.
+    5. Optional pedagogical commentary (``# Lecture : ...``) guiding the
+       student on what to observe.
+
+    These cells are LEGITIMATE EXERCISES under the user's doctrine (cf
+    ``.claude/rules/exercise-example-labeling.md`` §"Classification PAR
+    CONTENU"): the snippet is a verification harness, not a worked theorem
+    proof. The student runs the snippet, observes the Lean output, and
+    formulates an answer to the conceptual question stated in the markdown
+    header above. The detector previously reported this as HIGH because the
+    snippet looks like "real Lean code under an exercise header" — the fix
+    is to recognize the ``run_lean`` wrapper pattern as a Lean-specific
+    exercise skeleton.
+
+    Recall-safe contract: a cell that contains a *real* Lean solution
+    (a complete ``theorem ... := by sorry`` / `:= by <tactics>` proof or a
+    substantive ``example : ... := by ...`` proof — NOT just `#check`
+    imports / type-class reachability checks) must NOT match this helper.
+    Such a cell would lack the ``snippet_exN = \"\"\"...\"\"\"`` wrapper or
+    contain substantive proof tactics, making the regex below return False.
+    """
+    # Marker 1: a `run_lean(` call exists in the cell.
+    if not re.search(r'\brun_lean\s*\(', source):
+        return False
+    # Marker 2: a multi-line string literal assigned to `snippet_exN` (or
+    # similar snippet_ prefix). The triple-quoted body holds the snippet.
+    if not re.search(r'\bsnippet_\w+\s*=\s*"""', source):
+        return False
+    # Marker 3: the cell body itself announces an exercise header in its
+    # own comment block (the detector's `EXERCISE_HEADER_RE` matches both
+    # markdown AND code cell comments). This distinguishes from
+    # `Lean-15b` cells which use `# Verification interactive` headers
+    # (those are NOT exercises — they're worked-example verifications and
+    # already correctly attributed by `closest_preceding_header_is_example`).
+    if not re.search(
+        r'(?:^|\n)\s*#\s*Exercice\b', source, re.IGNORECASE | re.MULTILINE
+    ):
+        return False
+    # Marker 4: a `resultat_exN` (or `resultat_*`) capture variable that the
+    # student inspects via `print(...)`. Required to distinguish from a bare
+    # `run_lean(...)` invocation without a pedagogical wrapper.
+    if not re.search(r'\bresultat_\w+\s*=\s*run_lean\s*\(', source):
+        return False
+    # Anti-solution guard: if the snippet body contains substantive Lean
+    # proof tactics (`theorem ... := by <tactics>` with non-`#check` /
+    # non-`#eval` statements), this is NOT a verification harness — it's a
+    # worked solution. The harness should remain false-positive-resistant
+    # even if a future notebook author writes a real proof in the snippet.
+    snippet_match = re.search(
+        r'snippet_\w+\s*=\s*"""(.*?)"""', source, re.DOTALL
+    )
+    if snippet_match:
+        snippet_body = snippet_match.group(1)
+        # Real proof tactics lines start with `theorem` / `lemma` / `example`
+        # WITHOUT being followed by `#check` / `#eval` / `--` comments.
+        has_proof_statement = bool(re.search(
+            r'^\s*(?:theorem|lemma|example)\b(?![^:]*#check|#[^:]*#eval)',
+            snippet_body, re.MULTILINE,
+        ))
+        if has_proof_statement:
+            return False
+    return True
+
+
 def scan_notebook(path: str) -> list[dict]:
     """Scan a single notebook for solution leaks."""
     findings = []
@@ -757,6 +840,19 @@ def scan_notebook(path: str) -> list[dict]:
             # guidance headers, no substantive call/return body. Arrow-33
             # pattern. The student follows the indicesteps.
             if exercise_with_exercice_indice_skeleton(next_code_source):
+                continue
+            # Lean exercise wrapping a `snippet_exN = """..."""` literal
+            # passed to `run_lean(snippet_exN, timeout_s=...)` with a
+            # `print(resultat_exN)` trailer and `# Lecture : ...` commentary.
+            # Lean-15-Grothendieck-Tribute cells 25/29 pattern (c.8104g
+            # sub-grain of EPIC #8053). The snippet is a verification
+            # harness of `#check` / `#eval` statements, NOT a worked proof.
+            # The student runs the snippet, observes Lean output, and
+            # answers the conceptual question in the markdown header above.
+            # Recall-safe: a real Lean proof (theorem/lemma/example with
+            # substantive tactics) does NOT match — the anti-solution
+            # guard checks for proof statements inside the snippet body.
+            if exercise_with_run_lean_snippet(next_code_source):
                 continue
             solution_markers = bool(SOLUTION_MARKER_RE.search(next_code_source))
             if solution_markers or len(next_code_source.strip().split('\n')) > 8:

--- a/scripts/notebook_tools/test_detect_solution_leaks_skeleton_instructions.py
+++ b/scripts/notebook_tools/test_detect_solution_leaks_skeleton_instructions.py
@@ -27,6 +27,7 @@ from detect_solution_leaks import (  # noqa: E02
     exercise_with_a_completer_minizinc,
     exercise_with_attente_implementation,
     exercise_with_exercice_indice_skeleton,
+    exercise_with_run_lean_snippet,
     intervening_section_breaks_attribution,
     _numbered_subsection_header_between,
     NUMBERED_SUBSECTION_HEADER_RE,
@@ -431,6 +432,149 @@ class TestNumberedSubsectionHeaderBreaks(unittest.TestCase):
         ]
         # No intervening cell between markdown header and code — no break.
         self.assertFalse(intervening_section_breaks_attribution(cells, 0, 1))
+
+
+class TestExerciseWithRunLeanSnippet(unittest.TestCase):
+    """Lean exercise wrapping a ``snippet_exN = \"\"\"...\"\"\"`` literal in a
+    ``run_lean(...)`` invocation with a ``print(resultat_exN)`` trailer —
+    Lean-15-Grothendieck-Tribute cells 25/29 pattern (c.8104g sub-grain of
+    EPIC #8053).
+
+    Recall-safety contract (L812/L815 doctrine): a REAL Lean proof
+    (``theorem ... := by sorry`` / ``example : ... := by ...`` with
+    substantive tactics, NOT ``#check`` / ``#eval`` verification statements)
+    MUST NOT match this helper — the anti-solution guard checks the snippet
+    body for proof statements and returns False when present.
+    """
+
+    def test_lean15_cell25_limites_adjonction(self):
+        """Lean-15 cell 25: Exercice 1 (limites et adjonction) with
+        #check imports + run_lean wrapper + Lecture commentary."""
+        src = '''\
+# Exercice 1 : limites et adjonction
+snippet_ex1 = """
+import Mathlib.CategoryTheory.Limits.Shapes.Products
+import Mathlib.CategoryTheory.Adjunction.Basic
+
+#check @CategoryTheory.Limits.HasLimits
+#check @CategoryTheory.Adjunction
+#check @CategoryTheory.Adjunction.adjunctionOfEquivLeft
+"""
+
+resultat_ex1 = run_lean(snippet_ex1, timeout_s=900)
+print(resultat_ex1)
+print("Lecture : HasLimits et Adjunction sont-ils accessibles depuis Mathlib ?")
+'''
+        self.assertTrue(exercise_with_run_lean_snippet(src))
+
+    def test_lean15_cell29_yoneda(self):
+        """Lean-15 cell 29: Exercice 4 (lemme de Yoneda) with #check
+        CategoryTheory.yoneda + run_lean wrapper + Lecture commentary."""
+        src = '''\
+# Exercice 4 : le lemme de Yoneda
+snippet_ex4 = """
+import Mathlib.CategoryTheory.Yoneda
+
+#check CategoryTheory.yoneda
+"""
+
+resultat_ex4 = run_lean(snippet_ex4, timeout_s=900)
+print(resultat_ex4)
+print("Lecture : Yoneda est-il importe depuis Mathlib ?")
+'''
+        self.assertTrue(exercise_with_run_lean_snippet(src))
+
+    def test_no_run_lean_call_does_not_match(self):
+        """A cell without ``run_lean(...)`` invocation is NOT a Lean
+        run_lean-snippet exercise, regardless of header markers."""
+        src = '''\
+# Exercice 1 : limites et adjonction
+import Mathlib.CategoryTheory.Limits.Shapes.Products
+print("HasLimits OK")
+'''
+        self.assertFalse(exercise_with_run_lean_snippet(src))
+
+    def test_run_lean_without_snippet_string_does_not_match(self):
+        """A cell with ``run_lean(...)`` but no ``snippet_exN = \"\"\"...\"\"\"``
+        wrapper is NOT a Lean run_lean-snippet exercise."""
+        src = '''\
+# Exercice 1 : limite directe
+resultat = run_lean("import Mathlib\\n#check 1 + 1", timeout_s=60)
+print(resultat)
+'''
+        self.assertFalse(exercise_with_run_lean_snippet(src))
+
+    def test_run_lean_without_exercise_header_does_not_match(self):
+        """A cell with run_lean + snippet but NO ``# Exercice N`` header is
+        NOT a Lean run_lean-snippet exercise. This guards against
+        ``Lean-15b`` cells which use ``# Verification interactive``
+        headers — those are worked-example verifications, not exercises,
+        and are correctly attributed by other helpers
+        (``closest_preceding_header_is_example``)."""
+        src = '''\
+# Verification interactive : Yoneda est-il importable ?
+snippet_v = """
+import Mathlib.CategoryTheory.Yoneda
+#check CategoryTheory.yoneda
+"""
+
+resultat_v = run_lean(snippet_v, timeout_s=60)
+print(resultat_v)
+'''
+        self.assertFalse(exercise_with_run_lean_snippet(src))
+
+    def test_run_lean_without_resultat_capture_does_not_match(self):
+        """A cell with run_lean + snippet + # Exercice header but no
+        ``resultat_*`` capture variable is NOT a Lean run_lean-snippet
+        exercise — the ``resultat_* = run_lean(...)`` pattern is the
+        pedagogical wrapper signature."""
+        src = '''\
+# Exercice 1 : Yoneda
+snippet_ex1 = """import Mathlib"""
+
+run_lean(snippet_ex1, timeout_s=60)
+'''
+        self.assertFalse(exercise_with_run_lean_snippet(src))
+
+    def test_real_lean_proof_in_snippet_does_not_match(self):
+        """Recall-safety: a cell whose snippet body contains a REAL Lean
+        proof (``theorem ... := by ...`` with substantive tactics, not
+        ``#check`` / ``#eval``) is NOT a verification harness — it's a
+        worked solution that the detector must continue to flag.
+
+        This test enforces L815 doctrine: structural indistinguishability
+        trade-off resolved by content inspection of the snippet body."""
+        src = '''\
+# Exercice 1 : preuve de has_limits_of_products
+snippet_ex1 = """
+import Mathlib.CategoryTheory.Limits.HasLimits
+
+theorem has_limits_of_products : HasLimits (CategoryTheory.Limits.Shapes.Products.{v} u) :=
+  inferInstance
+"""
+
+resultat_ex1 = run_lean(snippet_ex1, timeout_s=900)
+print(resultat_ex1)
+'''
+        self.assertFalse(exercise_with_run_lean_snippet(src))
+
+    def test_lean15b_verification_interactive_does_not_match(self):
+        """Lean-15b cells use ``# Verification interactive`` headers, not
+        ``# Exercice N`` — the verification harness pattern must NOT
+        classify them as exercises. The cell looks structurally similar
+        (snippet + run_lean + print) but the header marks it as a
+        worked-example verification, not an exercise."""
+        src = '''\
+# Verification interactive : Categories est-il accessible ?
+snippet_v1 = """
+import Mathlib.CategoryTheory.Category.Basic
+#check Category
+"""
+
+resultat_v1 = run_lean(snippet_v1, timeout_s=60)
+print(resultat_v1)
+'''
+        self.assertFalse(exercise_with_run_lean_snippet(src))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
fix(detect-solution-leaks,#8053): close Lean-15 cells 25/29 FP via run_lean snippet helper (recall-safe)

Grain: DEEP/notebook-tools — lane myia-po-2026:CoursIA-2 — prev: MED/notebook-tools (c.8104f)

## Problem

Detector `scripts/notebook_tools/detect_solution_leaks.py` still trips HIGH
on 2 cells in `Lean-15-Grothendieck-Tribute.ipynb` (cells 25 + 29) — a
structurally distinct FP class: a Lean exercise cell wraps a `snippet_exN` =
`"""..."""` string literal in a `run_lean(snippet_exN, timeout_s=N)` call
with a `print(resultat_exN)` trailer and `# Lecture : ...` pedagogical
commentary. The detector saw the snippet as "real Lean code under an
exercise header" and flagged it as a solution leak.

The c.8104 / c.8104b / c.8104c / c.8104d sub-grains closed the prior FP
classes (demo-under-exercise, nested-git-worktree, skeleton-instructions,
numbered-subsection-break) but they were all Python/structural — none
recognized the Lean-specific `run_lean` wrapper pattern.

## Pattern (c.8104g / lean-run_lean-snippet)

A Lean exercise cell in `Lean-15-Grothendieck-Tribute.ipynb` (and
similarly-formatted future Lean notebooks) follows this structural recipe:

```python
# Exercice N : <topic>
snippet_exN = """
import Mathlib.<...>

#check <type-class-instance / constant>
#eval  <expression>
"""
resultat_exN = run_lean(snippet_exN, timeout_s=900)
print(resultat_exN)
print("Lecture : <pedagogical question>")
```

The snippet body is a **verification harness** of `#check` / `#eval`
statements (type-class reachability + value evaluation), NOT a worked
theorem proof. The student runs the snippet, observes the Lean output,
and answers the conceptual question stated in the markdown header above.

Per `exercise-example-labeling.md` §"Classification PAR CONTENU": this is a
LEGITIMATE EXERCISE. The snippet is not a leak — it's a verification
harness the student is meant to run.

## Fix (1 helper + 1 wire-in + 8 tests)

Added `exercise_with_run_lean_snippet(source)` to the FP-class
suppression chain after `exercise_with_exercice_indice_skeleton`
(`scripts/notebook_tools/detect_solution_leaks.py` lines 615-697).

The helper has 4 markers + 1 anti-solution guard:

| Marker | Regex | Why |
|--------|-------|-----|
| 1 | `\brun_lean\s*\(` | The cell uses `run_lean` (Lean wrapper) |
| 2 | `\bsnippet_\w+\s*=\s*"""` | The snippet is a multi-line string literal |
| 3 | `^\s*#\s*Exercice\b` (code comment) | The cell self-declares as an exercise (vs Lean-15b's `# Verification interactive`) |
| 4 | `\bresultat_\w+\s*=\s*run_lean\s*\(` | Pedagogical wrapper signature (`resultat` capture variable) |
| **anti-solution** | snippet body contains `theorem`/`lemma`/`example` without `#check`/`#eval` | Real proof → must NOT match |

The anti-solution guard prevents the FP from spreading if a future notebook
author writes a real proof in the snippet body. The detector stays
recall-safe.

## Evidence (before / after)

```
$ python scripts/notebook_tools/detect_solution_leaks.py --scan MyIA.AI.Notebooks

# Before (c.8104f baseline, includes c.8104f DecPyMC-5 PR #8402 which is OPEN/not-yet-merged)
Results: 11 HIGH (leaks), 30 MEDIUM (duplicates), 0 errors
[Lean-15 cells 25 + 29 in the HIGH list]

# After this PR
Results: 9 HIGH (leaks), 30 MEDIUM (duplicates), 0 errors
```

Net delta: **11 → 9 HIGH** (–2, –18%). The remaining 9 HIGH are all
preserved by L815 doctrine:

- **Oncology-Planning cell 23** — legitimate worked-example solution
- **KMeans-PCA cell 14** — legitimate worked-example solution
- **DecPyMC-5 cell 70** — closed by PR #8402 (c.8104f, OPEN), will not be HIGH after merge
- **QC-Py-12 cell 50** — legitimate worked-example solution
- **QC-Py-13 cell 36** — legitimate worked-example solution
- **App-20-SudokuBenchmark cell 19** — legitimate worked-example solution
- **App-9-EdgeDetection cell 36** — legitimate worked-example solution
- **Lean-17 cell#14** — honest trade-off (structurally indistinguishable from `### Indice` exercise scaffolding per L815); see c.8104d PR #8390
- **SC-23 cell 25** — owned by po-2025 (different lane), out of scope

**Predicted state after both PR #8402 + this PR merge: 8 HIGH** (the 9
remaining minus DecPyMC-5 cell 70, minus Lean-15 cells 25/29).

## Recall-safety (L815 doctrine)

The recall-safety contract: a REAL Lean proof in a cell must NOT be
suppressed by this helper. The anti-solution guard enforces this:

```python
snippet_match = re.search(r'snippet_\w+\s*=\s*"""(.*?)"""', source, re.DOTALL)
if snippet_match:
    snippet_body = snippet_match.group(1)
    has_proof_statement = bool(re.search(
        r'^\s*(?:theorem|lemma|example)\b(?![^:]*#check|#[^:]*#eval)',
        snippet_body, re.MULTILINE,
    ))
    if has_proof_statement:
        return False
```

The `(?![^:]*#check|#[^:]*#eval)` negative lookahead distinguishes
verification statements (`theorem foo := by #check bar`) from genuine
proof declarations (`theorem foo := by exact bar.intro`). This is a
content-aware distinction — the class cannot be closed structurally
without it (per L815 "structural indistinguishability trade-off").

## Tests (8 new tests in `test_detect_solution_leaks_skeleton_instructions.py`)

Added `TestExerciseWithRunLeanSnippet` class with 8 tests:

1. `test_lean15_cell25_limites_adjonction` — Lean-15 cell 25 (Limits/Adjunction)
2. `test_lean15_cell29_yoneda` — Lean-15 cell 29 (Yoneda)
3. `test_no_run_lean_call_does_not_match` — negative: no `run_lean(` call
4. `test_run_lean_without_snippet_string_does_not_match` — negative: no `snippet_exN = """..."""` wrapper
5. `test_run_lean_without_exercise_header_does_not_match` — negative: `# Verification interactive` (Lean-15b pattern, NOT an exercise)
6. `test_run_lean_without_resultat_capture_does_not_match` — negative: no `resultat_*` capture
7. `test_real_lean_proof_in_snippet_does_not_match` — recall-safety: substantive proof in snippet body
8. `test_lean15b_verification_interactive_does_not_match` — Lean-15b cross-lane generalization check

```
$ python scripts/notebook_tools/test_detect_solution_leaks_skeleton_instructions.py
...
Ran 34 tests in 0.002s
OK

$ python scripts/notebook_tools/test_detect_solution_leaks_nested_worktree.py
Ran 4 tests in 0.010s
OK
```

Total: 38 tests pass (34 + 4), no regressions.

## Scope

- Grain: DEEP/notebook-tools — lane myia-po-2026:CoursIA-2 — prev: MED/notebook-tools (c.8104f)
- Sub-grain of EPIC #8053 (leak-CI reconciliation). Atomic: 1 helper file
  modified + 1 test file extended, 240 insertions / 0 deletions.
- 2 FP-class cells closed (Lean-15 cells 25 + 29), 1 new helper added.
- No other detector behavior changed; the existing FP-class guards
  (6 helpers from c.8104/c.8104b/c.8104c/c.8104d + `intervening_section_breaks_attribution`
  + `closest_preceding_header_is_example`) remain intact.

## Validation

- Detector still functions correctly on the main tree (9 HIGH remain,
  7 TPs + 1 honest trade-off + 1 cross-lane).
- `--check` mode still exits 1 on HIGH (preserved — exit code 1 on the
  9 real findings).
- No regressions in any other detector path: nested-worktree skip intact,
  6 prior FP-class helpers intact, `intervening_section_breaks_attribution`
  intact.
- 38/38 tests pass (34 + 4 nested-worktree).

## Cross-references

- c.8104 PR #8161 — demo-under-exercise FP class (L812)
- c.8104b PR #8363 — nested-git-worktree-rescan FP class (L814)
- c.8104c PR #8377 — 4 skeleton-instructions FP classes
- c.8104d PR #8390 — numbered-subsection-break FP class (L815)
- c.8104e PR #8399 — docs-triage sub-grain (different genre, docs)
- c.8104f PR #8402 — DecPyMC-5 de-leak (OPEN, will close 1 more HIGH on merge)
- L815 doctrine — structural indistinguishability trade-off (recall-safety > classification)
- L812 — demo-under-exercise pattern (precedent for sub-grain naming)

## Compliance

- **Variation protocol**: G-VAR-1 (DEEP principal: new helper, content-aware anti-solution guard); G-VAR-3 (same genre `notebook-tools` as c.8104f but genuinely distinct substance — helper + recall-safety guard vs. notebook de-leak)
- **G.4 atomicité**: 1 PR = 1 sujet (run_lean FP class), 1 helper file + 1 test file, 240 insertions
- **L677-L4 ★★**: PR body in scratchpad, NOT in worktree
- **L898 ★★★ pre-push**: 0 OPEN PR for `run_lean` FP class (verified via `gh pr list --search "run_lean OR Lean-15 OR c8104g"`)
- **L721 ★**: stale-tracker check pre-`[DONE]`
- **L740 ★**: cron 7-day verify pre-`[DONE]`
- **No hand-edited outputs**: all changes are detector source + tests
- **A rule**: no direct push on main, branch `fix/c8104g-lean-runsnippet-fp`

Refs #8053
