### PR TITLE
chore(twin-parity,#8264): rebaseline 6 ML.NET/Python pairs post cost-mig #8400

### DIFF
--- a/scripts/notebook_tools/twin_pairs.yaml
+++ b/scripts/notebook_tools/twin_pairs.yaml
@@ -240,8 +240,8 @@
   last_audit:
     date: '2026-07-24'
     by: po-2023
-    python_sha: 51ef5d8190ad8cb014064e4369465188c915f45a
-    csharp_sha: 82dc028b28199cb8ed4edaa3a04578625f32db1e
+    python_sha: a0df0cd6648ba72245c1ba944b60654eaa39a72c
+    csharp_sha: d9c923863e86281a93761fd0d090a2cbb96f314e
   known_differences:
     - "Socle pedagogique commun : regression lineaire (R2, MAE) + regression logistique (accuracy, ROC-AUC). Dataset : prediction de prix / classification binaire."
     - "Idiomes framework : C# = `Microsoft.ML` (API imperative MLContext -> PredictionEngine, schema via classes [ColumnName]). Python = `sklearn.linear_model` (LinearRegression, LogisticRegression) fonctionnel (estimator.fit/predict), metrics `r2_score, mean_absolute_error, accuracy_score, roc_auc_score`."
@@ -255,8 +255,8 @@
   last_audit:
     date: '2026-07-24'
     by: po-2023
-    python_sha: 5163a0a6d5d5cf86806b42d639e85f3e25e09e54
-    csharp_sha: 74613155c83f9337ca2288afd1bc14f366f77f91
+    python_sha: 7fcff428e20f614d6dd2567a7af4107d106f46d4
+    csharp_sha: a379bbc58b935a4b6fa0afda1c6337f091035845
   known_differences:
     - "Socle pedagogique commun : featurization (encodage categoriel one-hot, normalisation, imputation) sur donnees tabulaires."
     - "Idiomes framework : C# = `mlContext.Transforms.Categorical.OneHotEncoding` (OutputKind.Binary) sur IDataView (LoadFromEnumerable). Python = `sklearn.preprocessing` (OneHotEncoder, StandardScaler, SimpleImputer) composes via `ColumnTransformer` + `Pipeline`."
@@ -270,8 +270,8 @@
   last_audit:
     date: '2026-07-24'
     by: po-2023
-    python_sha: 9212548070b1d114580643198353bc718d61db8e
-    csharp_sha: f644ea88d58e430780b712ac2c5d8e1d0f32bc3d
+    python_sha: 5b38d83083746e16aa6e0543d9a34dcc7fb4ce3f
+    csharp_sha: e04023c41908e290abec4245a65262d37b5b95b1
   known_differences:
     - "Socle pedagogique commun : comparaison de trainers de regression (lineaire vs boosting) + evaluation RMSE train/test."
     - "Zoos de modeles distincts : C# = `Regression.Trainers.Sdca` (Stochastic Dual Coord Ascent) + `LightGbm` (binding ML.NET LightGBM natif). Python = `LinearRegression` + `GradientBoostingRegressor, RandomForestRegressor, DecisionTreeRegressor, SVR` (ensemble sklearn)."
@@ -285,8 +285,8 @@
   last_audit:
     date: '2026-07-24'
     by: po-2023
-    python_sha: 322cee469a6aceb3ef3be781176b5123c7fca1f2
-    csharp_sha: 7a5a439488e6e28a877d8dc7e38bed21166e1b2b
+    python_sha: e93e9e81f6746f1facc000693ffa115b4e280dba
+    csharp_sha: 24c497936bd864ce6f68913ad95a68b34bba098c
   known_differences:
     - "ASYSMETRIE MAJEURE DE PROFONDEUR : C# = 40 cellules de code (tour exhaustif d'evaluation : FastTree, OneHotEncoding, ReplaceMissingValues, Concatenate Features + `mlContext.Auto().Regression` AutoML complet) ; Python = 10 cellules (pendant tronque : LinearRegression + RandomForestRegressor + cross_validate/GridSearchCV)."
     - "Le pendant Python couvre le CONCEPT (evaluer + GridSearchCV + metrics r2/MAE/MSE) mais n'egale pas l'exhaustivite du C# (AutoML ML.NET absent cote Python, feature engineering detaille reduit)."
@@ -300,8 +300,8 @@
   last_audit:
     date: '2026-07-24'
     by: po-2023
-    python_sha: 6585308b30c5e0d151e2a96af46ac331dae35cc2
-    csharp_sha: 6250dc22c3ec7ce9d154211ae5189ddee5919e2c
+    python_sha: 39ba5f983b84bee6d7b958056fdb82cea5e74936
+    csharp_sha: 3d83e0809ec03521f8b07391e99523e0fdfecf6f
   known_differences:
     - "FAMILLES ALGORITHMIQUES DIFFERENTES (pas un simple idiome swap) : C# = `Microsoft.ML.Transforms.TimeSeries` -> `ForecastBySsa` (Singular Spectrum Analysis, decomposition spectrale ML.NET-native). Python = `statsmodels` -> `STL` (seasonal-trend LOESS decomposition) + `SARIMAX` (seasonal ARIMA classique)."
     - "Aucune lib Python n'expose SSA de facon pedagogique equivalente ; le pendant Python choisit donc l'approche statistique classique (STL+SARIMAX) pour couvrir le meme besoin (forecast saisonnier) avec un OUTIL different."
@@ -315,8 +315,8 @@
   last_audit:
     date: "2026-07-23"
     by: po-2024
-    python_sha: 9b3d68f32e78e16b9c757545e3da6baa06a187ac
-    csharp_sha: 9c5c186b5cc5f731299e5d3526b61a6920bd79fb
+    python_sha: 367fa531d64984ae94bfde4fd5c0937d41ccc9c4
+    csharp_sha: 74a61b1d6bae7e24f27fb54a49fe83612fc6efcc
   known_differences:
     - "Socle pedagogique commun : filtrage collaboratif par factorisation de matrices (recommandation user-item, K facteurs latents)."
     - "Idiomes framework : C# = `mlContext.Recommendation().Trainers.MatrixFactorization` (trainer dedie + MapValueToKey pour UserId/MovieId). Python = `sklearn.decomposition.NMF` (Non-negative Matrix Factorization generique, init='nndsvda', solver='mu') avec erreur de reconstruction explicite."


### PR DESCRIPTION
## Summary

`check_twin_parity.py --check` on `origin/main` (`482adaec2`) reported **OK=33 DRIFT=6** — all 6 drifts in the ML.NET/Python family. This PR rebaselines the 6 drifted pairs to clear the twin-parity gate.

| Pair | parity_level | drift source |
|------|--------------|--------------|
| ML-1 Introduction | semantic | cost-mig #8400 |
| ML-2 Data&Features | semantic | cost-mig #8400 |
| ML-3 Entrainement&AutoML | semantic | cost-mig #8400 |
| ML-4 Evaluation | surface | cost-mig #8400 |
| ML-5 TimeSeries | surface | cost-mig #8400 |
| ML-7 Recommendation | semantic | cost-mig #8400 |

## Root cause

My PR **#8400** (`bdcc9bc9e`, cost-mig ML.Net 14 NB) modified the ML-1..ML-7 + Python variant blobs **without rebaselining the twin-registry** — exactly the `twin-parity-rebaseline-on-merge-mandatory` pattern. The root-cause fix (#8396 per-pair CI mode) is already merged; this PR is the focal cleanup of the 6 ML residuals.

## G.1 firsthand verification (each drift)

Diff `baseline_sha -> HEAD` for each of the 6 pairs confirms the drift is **cost-mig metadata ONLY**, not pedagogical content divergence:

- **ML-1/2/3/4/5**: the 3 cost-mig telltales only (`vram_tier` LITE→NONE, `free_alternative` null→self, `reduced_pedagogical` null→self), 19 diff lines each
- **ML-7**: 66 lines — structural cost-migration (YAML frontmatter markdown cell → `metadata.cost` JSON block), same 3 telltales + the cell restructuring
- **All 6 are SYMMETRICAL py↔cs** (identical change on both twins) → semantic parity **preserved**, pure surface (blob-hash) drift. Safe rebaseline.

## Technique

Surgical edit: 12 `str.replace` of unique 40-char blob SHAs (6 pairs × py+cs) on `scripts/notebook_tools/twin_pairs.yaml`. `git diff --stat` = 12 insertions / 12 deletions, **0 churn** on `known_differences` / `date` / `by` / `parity_level`. The documented ML-4 asymmetry (C# 40-cell exhaustive vs Python 10-cell truncated depth) is preserved untouched.

## Validation

`check_twin_parity.py --check` post-rebaseline → **OK=39 DRIFT=0 MISSING=0** ✓

See #8264 (twin-registry fleet drift). See #8057 (twin parity audit gate). No `Closes` — focal cleanup, the root-cause gate fix is #8396 (merged).

Co-Authored-By: Claude-Code <noreply@anthropic.com>