### PR TITLE
fix(genai-vibecoding,#8056): migrate cost frontmatter -> metadata.cost on Claude-Code 01-05 (guard #8352)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/01-Claude-CLI-Bases.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/01-Claude-CLI-Bases.ipynb
@@ -14,30 +14,6 @@
     "tags": []
    },
    "source": [
-    "---\n",
-    "title: VC-CC-1 Claude CLI Les Bases (haiku/sonnet via OpenRouter)\n",
-    "cost:\n",
-    "  api_usd_est: 0.03           # ~8-11 appels run_claude (haiku+sonnet), prompts courts\n",
-    "  api_provider: anthropic        # Wire Anthropic route via OpenRouter (prereq 'OpenRouter configure')\n",
-    "  cpu_min: 2\n",
-    "  gpu_min: 0\n",
-    "  gpu_required: false\n",
-    "  vram_gb: 0\n",
-    "  vram_tier: LITE\n",
-    "  network: true\n",
-    "  external_account: openrouter    # Cle OpenRouter requise (ou SIMULATION_MODE=True)\n",
-    "  free_alternative: \"MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claudish/notebooks/01-claude-code-via-claudish.ipynb\"\n",
-    "  reduced_pedagogical: \"SIMULATION_MODE=True (mock, sans cle)\"\n",
-    "  reproducibility: LOW\n",
-    "  last_validated: 2026-07-24\n",
-    "  validator: manual\n",
-    "notes: |\n",
-    "  Claude CLI bases : ~8-11 appels API (haiku/sonnet via OpenRouter, wire Anthropic),\n",
-    "  prompts courts. SIMULATION_MODE=True (valeur par defaut commitee False) permet une\n",
-    "  execution sans cle (reponses mockees). Cout reel ~0.03 USD si SIMULATION_MODE=False.\n",
-    "  Estime depuis le decompte des appels run_claude (G.1 firsthand), non relance ce cycle.\n",
-    "---\n",
-    "\n",
     "# Claude CLI - Les Bases\n",
     "\n",
     "**Navigation** : [Index](../../README.md) | [Suivant >>](02-Claude-CLI-Sessions.ipynb)\n",
@@ -68,7 +44,8 @@
     "- Créer des scripts de productivite personnalises\n",
     "- Tester rapidement des prompts sans quitter le terminal\n",
     "\n",
-    "> **Note :** Ce notebook utilise des wrappers Python pour executer les commandes CLI. Vous pouvez aussi executer ces mêmes commandes directement dans un terminal.\n"
+    "> **Note :** Ce notebook utilise des wrappers Python pour executer les commandes CLI. Vous pouvez aussi executer ces mêmes commandes directement dans un terminal.\n",
+    ""
    ]
   },
   {
@@ -1221,6 +1198,23 @@
    "parameters": {},
    "start_time": "2026-05-02T17:50:51.389283+00:00",
    "version": "2.7.0"
+  },
+  "cost": {
+   "api_usd_est": 0.03,
+   "api_provider": "anthropic",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "LITE",
+   "network": true,
+   "external_account": "openrouter",
+   "free_alternative": "MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claudish/notebooks/01-claude-code-via-claudish.ipynb",
+   "reduced_pedagogical": "SIMULATION_MODE=True (mock, sans cle)",
+   "reproducibility": "LOW",
+   "last_validated": "2026-07-24",
+   "validator": "manual",
+   "notes": "Claude CLI bases : ~8-11 appels API (haiku/sonnet via OpenRouter, wire Anthropic),\nprompts courts. SIMULATION_MODE=True (valeur par defaut commitee False) permet une\nexecution sans cle (reponses mockees). Cout reel ~0.03 USD si SIMULATION_MODE=False.\nEstime depuis le decompte des appels run_claude (G.1 firsthand), non relance ce cycle."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/02-Claude-CLI-Sessions.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/02-Claude-CLI-Sessions.ipynb
@@ -14,29 +14,6 @@
     "tags": []
    },
    "source": [
-    "---\n",
-    "title: VC-CC-2 Claude CLI Sessions multi-tours (OpenRouter)\n",
-    "cost:\n",
-    "  api_usd_est: 0.04           # ~8 appels run_claude_continue, contexte de session croissant\n",
-    "  api_provider: anthropic        # Wire Anthropic route via OpenRouter\n",
-    "  cpu_min: 2\n",
-    "  gpu_min: 0\n",
-    "  gpu_required: false\n",
-    "  vram_gb: 0\n",
-    "  vram_tier: LITE\n",
-    "  network: true\n",
-    "  external_account: openrouter    # Cle OpenRouter requise\n",
-    "  free_alternative: \"MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claudish/notebooks/01-claude-code-via-claudish.ipynb\"\n",
-    "  reduced_pedagogical: \"SIMULATION_MODE=True (mock, sans cle)\"\n",
-    "  reproducibility: LOW\n",
-    "  last_validated: 2026-07-24\n",
-    "  validator: manual\n",
-    "notes: |\n",
-    "  Sessions multi-tours (flag -c) : le contexte accumule fait grossir le prompt a chaque\n",
-    "  tour -> cout legerement superieur au NB-01. Exercice c26 estime le cout (price_per_1k\n",
-    "  =0.003). SIMULATION_MODE=True = gratuit. Estime G.1 firsthand, non relance ce cycle.\n",
-    "---\n",
-    "\n",
     "# Claude CLI - Gestion des Sessions\n",
     "\n",
     "**Navigation** : [Index](../../README.md) | [<< Précédent](01-Claude-CLI-Bases.ipynb) | [Suivant >>](03-Claude-CLI-References.ipynb)\n",
@@ -59,7 +36,8 @@
     "\n",
     "> **Cas d'usage typiques** : Debug iteratif, exploration de solutions, prototypage conversationnel\n",
     "\n",
-    "---\n"
+    "---\n",
+    ""
    ]
   },
   {
@@ -1254,6 +1232,23 @@
    "parameters": {},
    "start_time": "2026-05-02T17:53:00.956775+00:00",
    "version": "2.7.0"
+  },
+  "cost": {
+   "api_usd_est": 0.04,
+   "api_provider": "anthropic",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "LITE",
+   "network": true,
+   "external_account": "openrouter",
+   "free_alternative": "MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claudish/notebooks/01-claude-code-via-claudish.ipynb",
+   "reduced_pedagogical": "SIMULATION_MODE=True (mock, sans cle)",
+   "reproducibility": "LOW",
+   "last_validated": "2026-07-24",
+   "validator": "manual",
+   "notes": "Sessions multi-tours (flag -c) : le contexte accumule fait grossir le prompt a chaque\ntour -> cout legerement superieur au NB-01. Exercice c26 estime le cout (price_per_1k\n=0.003). SIMULATION_MODE=True = gratuit. Estime G.1 firsthand, non relance ce cycle."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/03-Claude-CLI-References.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/03-Claude-CLI-References.ipynb
@@ -14,29 +14,6 @@
     "tags": []
    },
    "source": [
-    "---\n",
-    "title: VC-CC-3 Claude CLI References et Contexte (OpenRouter)\n",
-    "cost:\n",
-    "  api_usd_est: 0.05           # ~6 appels, prompts larges (contenu de fichiers complet envoye)\n",
-    "  api_provider: anthropic        # Wire Anthropic route via OpenRouter\n",
-    "  cpu_min: 2\n",
-    "  gpu_min: 0\n",
-    "  gpu_required: false\n",
-    "  vram_gb: 0\n",
-    "  vram_tier: LITE\n",
-    "  network: true\n",
-    "  external_account: openrouter    # Cle OpenRouter requise\n",
-    "  free_alternative: \"MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claudish/notebooks/01-claude-code-via-claudish.ipynb\"\n",
-    "  reduced_pedagogical: \"SIMULATION_MODE=True (mock, sans cle)\"\n",
-    "  reproducibility: LOW\n",
-    "  last_validated: 2026-07-24\n",
-    "  validator: manual\n",
-    "notes: |\n",
-    "  References @file : le contenu complet des fichiers du sample_project est envoye dans\n",
-    "  le prompt -> contexte plus large que NB-01/02. ~6 appels. SIMULATION_MODE=True =\n",
-    "  gratuit. Estime G.1 firsthand, non relance ce cycle.\n",
-    "---\n",
-    "\n",
     "# Claude CLI - References et Contexte\n",
     "\n",
     "**Navigation** : [Index](../../README.md) | [<< Précédent](02-Claude-CLI-Sessions.ipynb) | [Suivant >>](04-Claude-CLI-Agents.ipynb)\n",
@@ -66,7 +43,8 @@
     "3. **References dynamiques** : Le fichier est relu a chaque appel (toujours a jour)\n",
     "4. **Economie de tokens** : Les plages de lignes limitent le contexte au strict necessaire\n",
     "\n",
-    "> **Note importante :** En mode interactif (`claude` sans `-p`), les @-mentions sont auto-completees avec Tab. En mode CLI avec `-p`, vous devez specifier le chemin complet depuis le repertoire courant.\n"
+    "> **Note importante :** En mode interactif (`claude` sans `-p`), les @-mentions sont auto-completees avec Tab. En mode CLI avec `-p`, vous devez specifier le chemin complet depuis le repertoire courant.\n",
+    ""
    ]
   },
   {
@@ -1517,6 +1495,23 @@
    "parameters": {},
    "start_time": "2026-05-02T17:54:51.984577+00:00",
    "version": "2.7.0"
+  },
+  "cost": {
+   "api_usd_est": 0.05,
+   "api_provider": "anthropic",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "LITE",
+   "network": true,
+   "external_account": "openrouter",
+   "free_alternative": "MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claudish/notebooks/01-claude-code-via-claudish.ipynb",
+   "reduced_pedagogical": "SIMULATION_MODE=True (mock, sans cle)",
+   "reproducibility": "LOW",
+   "last_validated": "2026-07-24",
+   "validator": "manual",
+   "notes": "References @file : le contenu complet des fichiers du sample_project est envoye dans\nle prompt -> contexte plus large que NB-01/02. ~6 appels. SIMULATION_MODE=True =\ngratuit. Estime G.1 firsthand, non relance ce cycle."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/04-Claude-CLI-Agents.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/04-Claude-CLI-Agents.ipynb
@@ -14,29 +14,6 @@
     "tags": []
    },
    "source": [
-    "---\n",
-    "title: VC-CC-4 Claude CLI Agents et Subagents (OpenRouter)\n",
-    "cost:\n",
-    "  api_usd_est: 0.07           # ~8 appels + agents paralleles ThreadPoolExecutor (c23/c27)\n",
-    "  api_provider: anthropic        # Wire Anthropic route via OpenRouter\n",
-    "  cpu_min: 3\n",
-    "  gpu_min: 0\n",
-    "  gpu_required: false\n",
-    "  vram_gb: 0\n",
-    "  vram_tier: LITE\n",
-    "  network: true\n",
-    "  external_account: openrouter    # Cle OpenRouter requise\n",
-    "  free_alternative: \"MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claudish/notebooks/01-claude-code-via-claudish.ipynb\"\n",
-    "  reduced_pedagogical: \"SIMULATION_MODE=True (mock, sans cle)\"\n",
-    "  reproducibility: LOW\n",
-    "  last_validated: 2026-07-24\n",
-    "  validator: manual\n",
-    "notes: |\n",
-    "  Agents Explore/Plan + agents personnalises + execution parallele (ThreadPoolExecutor\n",
-    "  c23, commente 'ATTENTION: consomme des tokens'). Plus d'appels concurrents -> cout le\n",
-    "  plus eleve de la serie Claude-Code. SIMULATION_MODE=True = gratuit. G.1 firsthand.\n",
-    "---\n",
-    "\n",
     "# Claude CLI - Agents et Subagents\n",
     "\n",
     "**Navigation** : [Index](../../README.md) | [<< Précédent](03-Claude-CLI-References.ipynb) | [Suivant >>](05-Claude-CLI-Automatisation.ipynb)\n",
@@ -65,7 +42,8 @@
     "- **Securite** : Les agents en lecture seule ne peuvent pas modifier votre code accidentellement\n",
     "- **Parallelisation** : Jusqu'a 10 agents peuvent travailler simultanement sur des sous-tâches\n",
     "\n",
-    "> **Cas d'usage typique** : Vous demandez \"Refactorise ce projet\". Claude lance automatiquement des agents Explore pour comprendre la structure, puis un agent Plan pour définir les étapes, avant d'effectuer les modifications.\n"
+    "> **Cas d'usage typique** : Vous demandez \"Refactorise ce projet\". Claude lance automatiquement des agents Explore pour comprendre la structure, puis un agent Plan pour définir les étapes, avant d'effectuer les modifications.\n",
+    ""
    ]
   },
   {
@@ -1580,6 +1558,23 @@
    "parameters": {},
    "start_time": "2026-05-02T17:56:50.990673+00:00",
    "version": "2.7.0"
+  },
+  "cost": {
+   "api_usd_est": 0.07,
+   "api_provider": "anthropic",
+   "cpu_min": 3,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "LITE",
+   "network": true,
+   "external_account": "openrouter",
+   "free_alternative": "MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claudish/notebooks/01-claude-code-via-claudish.ipynb",
+   "reduced_pedagogical": "SIMULATION_MODE=True (mock, sans cle)",
+   "reproducibility": "LOW",
+   "last_validated": "2026-07-24",
+   "validator": "manual",
+   "notes": "Agents Explore/Plan + agents personnalises + execution parallele (ThreadPoolExecutor\nc23, commente 'ATTENTION: consomme des tokens'). Plus d'appels concurrents -> cout le\nplus eleve de la serie Claude-Code. SIMULATION_MODE=True = gratuit. G.1 firsthand."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/05-Claude-CLI-Automatisation.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/05-Claude-CLI-Automatisation.ipynb
@@ -14,29 +14,6 @@
     "tags": []
    },
    "source": [
-    "---\n",
-    "title: VC-CC-5 Claude CLI Automatisation Avancee (OpenRouter)\n",
-    "cost:\n",
-    "  api_usd_est: 0.06           # pipelines create_pipeline + CodeReviewer, plusieurs appels chaines\n",
-    "  api_provider: anthropic        # Wire Anthropic route via OpenRouter\n",
-    "  cpu_min: 3\n",
-    "  gpu_min: 0\n",
-    "  gpu_required: false\n",
-    "  vram_gb: 0\n",
-    "  vram_tier: LITE\n",
-    "  network: true\n",
-    "  external_account: openrouter    # Cle OpenRouter requise\n",
-    "  free_alternative: \"MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claudish/notebooks/01-claude-code-via-claudish.ipynb\"\n",
-    "  reduced_pedagogical: \"SIMULATION_MODE=True (mock, sans cle)\"\n",
-    "  reproducibility: LOW\n",
-    "  last_validated: 2026-07-24\n",
-    "  validator: manual\n",
-    "notes: |\n",
-    "  Automatisation : pipelines de prompts chaines (create_pipeline), CodeReviewer (revue\n",
-    "  multi-criteres), generation de commit/hook. Plusieurs appels run_claude par pipeline.\n",
-    "  SIMULATION_MODE=True = gratuit. Estime G.1 firsthand, non relance ce cycle.\n",
-    "---\n",
-    "\n",
     "# Claude CLI - Automatisation Avancee\n",
     "\n",
     "**Navigation** : [Index](../../README.md) | [<< Précédent](04-Claude-CLI-Agents.ipynb)\n",
@@ -78,7 +55,8 @@
     "        |\n",
     "        v\n",
     "    Action (commit, notification, rapport)\n",
-    "```\n"
+    "```\n",
+    ""
    ]
   },
   {
@@ -1568,6 +1546,23 @@
    "parameters": {},
    "start_time": "2026-05-02T18:01:23.261322+00:00",
    "version": "2.7.0"
+  },
+  "cost": {
+   "api_usd_est": 0.06,
+   "api_provider": "anthropic",
+   "cpu_min": 3,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "LITE",
+   "network": true,
+   "external_account": "openrouter",
+   "free_alternative": "MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claudish/notebooks/01-claude-code-via-claudish.ipynb",
+   "reduced_pedagogical": "SIMULATION_MODE=True (mock, sans cle)",
+   "reproducibility": "LOW",
+   "last_validated": "2026-07-24",
+   "validator": "manual",
+   "notes": "Automatisation : pipelines de prompts chaines (create_pipeline), CodeReviewer (revue\nmulti-criteres), generation de commit/hook. Plusieurs appels run_claude par pipeline.\nSIMULATION_MODE=True = gratuit. Estime G.1 firsthand, non relance ce cycle."
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: LIGHT/cost-migration — lane myia-po-2026:CoursIA — prev c.716: FORENSIC REVIEW #8409

## Scope

Sub-tranche of EPIC #8056 (cost/ressource matrix). Migrate the 5 **GenAI/Vibe-Coding/Claude-Code** notebooks (01-Bases → 05-Automatisation) from legacy `---`-YAML frontmatter (cell#0) to canonical `nb.metadata['cost']` JSON (schema #8376). Clears 5 of 128 repo-wide guard-#8352 landmines (setext-H2 rendering violations).

**1 subject, 5 notebooks, +95/-121 strict, 0 code cells modified (C.2 N/A).**

## Approach (canonical FT-01 #8389 pattern, verbatim-forensic)

Adapted the proven FineTuning #8389 transformation (commit `1203fa99f`):
- `title` dropped (redundant with the H1 following the frontmatter in cell#0).
- top-level `notes:` merged into `cost.notes` (per #8376 design-gate).
- values preserved VERBATIM — used a `VerbatimLoader` (yaml.SafeLoader with the timestamp resolver stripped) so `last_validated: 2026-07-24` stays the string `"2026-07-24"` (not a re-formatted date object).
- byte-stability gate: `cells[1:]` asserted byte-identical before/after.

## ★ Verification (my c.713/c.714 verbatim-forensic discipline — the lesson that caught the systematic-migration bug)

I found (c.713, #8397) that the shared cost-migration script had 3 latent telltales: `free_alternative` nulled, `vram_tier` normalized NONE→LITE, `reduced_pedagogical` nulled. Applied the exhaustive ORIG-vs-NEW all-fields diff (the technique that caught it) to my OWN migration:

| check | result |
|-------|--------|
| Exhaustive ORIG(origin/main)↔NEW(HEAD) all-fields diff | **75/75 fields match VERBATIM, 0 violations** |
| `free_alternative` | preserved as Claudish path string (NOT nulled) ✓ all 5 |
| `reduced_pedagogical` | preserved as `SIMULATION_MODE=True (mock, sans cle)` (NOT nulled) ✓ all 5 |
| `vram_tier` | `LITE` preserved (no normalization) ✓ all 5 |
| `detect_markdown_rendering.py` (#8352 guard) | 0 findings on the 5 (landmines cleared) ✓ |
| `validate_pr_notebooks.py` (H.3) | 5/5 PASS, 60 code cells ✓ |
| LF-only (CRLF=0) | matches `.gitattributes eol=lf` + FT-01 canonical ✓ |
| byte-stable cells[1:] | diff scope = frontmatter removal + metadata.cost add only ✓ |

## Notes

- **Structural variant skipped (G.1):** GenAI/Audio/01-Foundation (5 NB) has DUPLICATE frontmatter (cell#0 + cell#1 with DIFFERENT cost values) — ambiguous (which is canonical?), needs a decision not a mechanical move. Left for a separate scoped PR. This PR targets only CLEAN single-FM notebooks (canonical cell#0 + H1 structure).
- All 5 notebooks are API-based (Claude CLI via OpenRouter, SIMULATION_MODE default); `last_validated`/`validator` preserved verbatim (format migration, not re-execution).

See #8056 (partial: Vibe-Coding/Claude-Code tranche). Prior tranches: FineTuning #8389 (po-2023), GenAI/Texte (po-2024), PostTraining #8403 (po-2024), QC-Py #8386 (po-2025), DecInfer #8394 (po-2026).