### PR TITLE
fix(genai,#8411): resolve duplicate frontmatter on Audio 01-Foundation (5 NB) [steps 1-2]

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-1-OpenAI-TTS-Intro.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-1-OpenAI-TTS-Intro.ipynb
@@ -66,36 +66,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: \"OpenAI TTS - Synthese Vocale par API (tts-1)\"\n",
-    "cost:\n",
-    "  api_usd_est: 0.18            # ~6 generations tts-1 x $0.030/1k chars, demo ~6k chars\n",
-    "  api_provider: openai          # OpenAI direct (OpenRouter ne supporte pas /v1/audio/speech)\n",
-    "  cpu_min: 2\n",
-    "  gpu_min: 0\n",
-    "  gpu_required: false\n",
-    "  vram_gb: 0\n",
-    "  vram_tier: LITE\n",
-    "  network: true                 # HTTPS api.openai.com obligatoire\n",
-    "  external_account: openai      # OPENAI_API_KEY dans .env\n",
-    "  free_alternative: GenAI/Audio/01-Foundation/01-5-Kokoro-TTS-Local.ipynb\n",
-    "  reduced_pedagogical: GenAI/Audio/01-Foundation/01-3-Basic-Audio-Operations.ipynb\n",
-    "  reproducibility: MED          # Pas de seed deterministe cote OpenAI\n",
-    "  last_validated: 2026-07-23T09:30Z\n",
-    "  validator: papermill\n",
-    "notes: |\n",
-    "  OpenAI Text-to-Speech via tts-1 (rapide) / tts-1-hd (qualite superieure).\n",
-    "  Voix : alloy, echo, fable, onyx, nova, shimmer + 6 voix HD supplementaires.\n",
-    "  Formats audio : mp3, opus, aac, flac, wav, pcm.\n",
-    "  Cout reel depend de voice/model + nombre de caracteres generes (~6 demo).\n",
-    "  Pedagogie : introduction TTS cloud, comparaison kokoro local (01-5).\n",
-    "---\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "cell-params",

--- a/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-2-OpenAI-Whisper-STT.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-2-OpenAI-Whisper-STT.ipynb
@@ -64,36 +64,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: \"OpenAI Whisper STT - Transcription par API (whisper-1)\"\n",
-    "cost:\n",
-    "  api_usd_est: 0.18            # ~6 transcriptions whisper-1 x $0.006/min, demo ~30 min total\n",
-    "  api_provider: openai          # OpenAI direct\n",
-    "  cpu_min: 2\n",
-    "  gpu_min: 0\n",
-    "  gpu_required: false\n",
-    "  vram_gb: 0\n",
-    "  vram_tier: LITE\n",
-    "  network: true                 # HTTPS api.openai.com obligatoire\n",
-    "  external_account: openai      # OPENAI_API_KEY dans .env\n",
-    "  free_alternative: GenAI/Audio/01-Foundation/01-4-Whisper-Local.ipynb\n",
-    "  reduced_pedagogical: GenAI/Audio/01-Foundation/01-3-Basic-Audio-Operations.ipynb\n",
-    "  reproducibility: MED          # Pas de seed deterministe, mais output textuel reproductible\n",
-    "  last_validated: 2026-07-23T09:30Z\n",
-    "  validator: papermill\n",
-    "notes: |\n",
-    "  OpenAI Speech-to-Text via whisper-1 (multilingue 99 langues).\n",
-    "  Modes : transcription (texte brut) + translation (vers anglais).\n",
-    "  Formats audio : mp3, mp4, mpeg, mpga, m4a, wav, webm.\n",
-    "  Cout reel depend de la duree audio (facturation a la minute).\n",
-    "  Pedagogie : STT cloud vs Whisper local (01-4) vs Kokoro (01-5).\n",
-    "---\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "cell-params",

--- a/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-3-Basic-Audio-Operations.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-3-Basic-Audio-Operations.ipynb
@@ -65,35 +65,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: \"Operations de Base sur l'Audio (PyAudio/numpy/scipy)\"\n",
-    "cost:\n",
-    "  api_usd_est: 0.00            # Aucune API - operations locales PyAudio/numpy/scipy\n",
-    "  api_provider: none            # 100% local, pas d'API externe\n",
-    "  cpu_min: 2\n",
-    "  gpu_min: 0\n",
-    "  gpu_required: false\n",
-    "  vram_gb: 0\n",
-    "  vram_tier: LITE\n",
-    "  network: false                # 100% local, pas de HTTPS externe\n",
-    "  external_account: none\n",
-    "  free_alternative: N/A         # deja le notebook de base gratuit\n",
-    "  reduced_pedagogical: N/A      # pas de version reduite, c'est la version gratuite de reference\n",
-    "  reproducibility: HIGH         # numpy/scipy deterministes\n",
-    "  last_validated: 2026-07-23T09:30Z\n",
-    "  validator: papermill\n",
-    "notes: |\n",
-    "  Operations audio basiques : lecture WAV/MP3, resampling, FFT, mel-spectrogramme, normalisation, format conversion.\n",
-    "  Bibliotheques : numpy, scipy.signal, librosa (local), soundfile.\n",
-    "  Aucune sortie GenAI ici - c'est le notebook prerequis gratuit avant d'invoquer GenAI audio.\n",
-    "  Adapté pour machine CPU-only, VRAM=0, GPU=0. Aucune dépendance externe payante.\n",
-    "---\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "cell-params",

--- a/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-4-Whisper-Local.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-4-Whisper-Local.ipynb
@@ -67,36 +67,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: \"Whisper Local (openai/whisper-large-v3-turbo via transformers)\"\n",
-    "cost:\n",
-    "  api_usd_est: 0.00            # Pas d'API payante, mais GPU + download HF lourd\n",
-    "  api_provider: none            # local transformers + HuggingFace download\n",
-    "  cpu_min: 4\n",
-    "  gpu_min: 1\n",
-    "  gpu_required: true            # large-v3-turbo = GPU lourd (10 GB VRAM FP16)\n",
-    "  vram_gb: 10\n",
-    "  vram_tier: MID                # 10 GB FP16, 6 GB INT8 quantization possible\n",
-    "  network: true                 # HF download (~3 GB) + HF_TOKEN si gated\n",
-    "  external_account: huggingface # HF_TOKEN dans .env si modele gated (large-v3 = OK sans token)\n",
-    "  free_alternative: N/A         # c'est la version locale gratuite (alternative a OpenAI Whisper STT 01-2)\n",
-    "  reduced_pedagogical: GenAI/Audio/01-Foundation/01-3-Basic-Audio-Operations.ipynb\n",
-    "  reproducibility: HIGH         # transformers seedable, mode deterministe possible\n",
-    "  last_validated: 2026-07-23T09:30Z\n",
-    "  validator: sk_visual          # Audio actif, validation auditive/via sk-agent recommandée\n",
-    "notes: |\n",
-    "  Whisper Large-v3-Turbo via transformers (openai/whisper-large-v3-turbo).\n",
-    "  Modele : 809M parametres, FP16 ~1.6 GB disque, ~10 GB VRAM en inference.\n",
-    "  Alternative a OpenAI Whisper STT API (gratuit apres download initial, pas de facturation par minute).\n",
-    "  Quantization INT8 possible (bitsandbytes) → VRAM ~6 GB.\n",
-    "  Pedagogie : STT cloud vs STT local, controle total (pas d'upload audio), confidentialite.\n",
-    "---\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "cell-params",

--- a/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-5-Kokoro-TTS-Local.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-5-Kokoro-TTS-Local.ipynb
@@ -65,36 +65,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: \"Kokoro TTS Local (hexgrad/Kokoro-82M via transformers)\"\n",
-    "cost:\n",
-    "  api_usd_est: 0.00            # Pas d'API payante, mais GPU + download HF\n",
-    "  api_provider: none            # local transformers + HuggingFace download\n",
-    "  cpu_min: 4\n",
-    "  gpu_min: 1\n",
-    "  gpu_required: true            # Kokoro-82M = modele leger mais beneficie du GPU\n",
-    "  vram_gb: 4\n",
-    "  vram_tier: MID                # 82M parametres = tres leger (FP16 ~200 MB VRAM)\n",
-    "  network: true                 # HF download (~300 MB)\n",
-    "  external_account: huggingface # HF_TOKEN dans .env (modele public mais recommende)\n",
-    "  free_alternative: N/A         # c'est la version locale gratuite (alternative a OpenAI TTS 01-1)\n",
-    "  reduced_pedagogical: GenAI/Audio/01-Foundation/01-3-Basic-Audio-Operations.ipynb\n",
-    "  reproducibility: HIGH         # transformers seedable, Kokoro deterministic\n",
-    "  last_validated: 2026-07-23T09:30Z\n",
-    "  validator: sk_visual          # Audio actif, validation auditive/via sk-agent recommandée\n",
-    "notes: |\n",
-    "  Kokoro-82M = modele TTS open-source compact de haute qualite (hexgrad/Kokoro-82M).\n",
-    "  Alternative gratuite et locale a OpenAI TTS (01-1).\n",
-    "  Voix : multiple voix pre-train (Americain/Britannique + female/male).\n",
-    "  Pedagogie : TTS cloud vs TTS local, confidentialite, controle total.\n",
-    "  Performance : ~10x real-time sur GPU mid-range, ~3x real-time sur CPU moderne.\n",
-    "---\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "cell-params",


### PR DESCRIPTION
## Summary

Resolves the **duplicate frontmatter** ambiguity on the 5 `GenAI/Audio/01-Foundation` notebooks — **issue #8411 steps 1-2** (determine canonical cell + delete stale duplicate). This **unblocks** step 3 (the cost-migration to `metadata.cost`, separate PR).

## Problem (discovered by po-2026 c.717)

Each of the 5 Audio/01-Foundation notebooks had **TWO consecutive `---`-YAML frontmatter cells** with **DIFFERENT cost values** (e.g. 01-1: cell#0 `api_usd_est: 0.02`/`vram_tier: NONE` vs cell#1 `0.18`/`LITE`). This made the verbatim cost-migration ambiguous (which block is canonical?).

## Git-blame grounding (decision rationale)

- **#8208** (`5ca38242d`, c.822, FIRST/older) inserted the ORIGINAL frontmatter at **cell#1** on 14 Audio notebooks (Foundation + Advanced).
- **#8312** (`64c2d8710`, c.831, SECOND/newer) PREPENDED a second frontmatter at **cell#0** on the 5 Audio/01-Foundation notebooks only (23 lines each, pure prepend, no deletion), creating the dup.

## Canonical decision — KEEP cell#0 (#8312), SUPPRESS cell#1 (#8208) — uniform 5/5

| Criterion | cell#0 (#8312) KEPT | cell#1 (#8208) DELETED |
|-----------|---------------------|------------------------|
| Récence | c.831 (latest intent) | c.822 (older) |
| Title convention | `NN-N <french>` (matches `.ipynb` filename) | verbose quoted `"... (model)"` |
| Documentation | 1900-2200 chars (api_provider, notes, free_alt, reproducibility, validator) | 1000-1400 chars |
| Values precision | api 0.02 from official OpenAI tariffs + call decomposition; vram NONE (cloud API) | api 0.18 rough; vram LITE |

This matches issue #8411's own analysis: *"cell#0 follows the canonical file-numbering convention with concrete cost values"*.

## Scope

**DUP RESOLUTION, not a migration.** No telltale nulling/normalization (cf verbatim-forensic discipline c.887/c.888/c.889/c.890). cell#0 (#8312) values preserved **verbatim**. Step 3 (migrate canonical block → `metadata.cost`) is a separate PR under #8056.

## Validation

- **Structural**: `notebook_tools.py validate --quick` → 5/5 OK, 0 warnings.
- **Byte-surgical**: `json.dumps(indent=1)` round-trip byte-identity verified pre-edit; LF preserved (bytes write, no CRLF churn).
- **Diff**: 149 deletions, 0 insertions (pure cell suppression, no reflow).
- **Catalogue**: byte-identical to main (no churn).

See #8411 (partial: steps 1-2 resolved; step 3 migration unblocked). See #8056, See #8352.

Co-Authored-By: Claude-Code <noreply@anthropic.com>