### PR TITLE
fix(genai-image,#8056): migrate 01-Foundation cost frontmatter -> metadata.cost (guard #8352)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-1-OpenAI-DALL-E-3.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-1-OpenAI-DALL-E-3.ipynb
@@ -46,34 +46,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: OpenAI DALL-E 3 - Generation d'Images\n",
-    "cost:\n",
-    "  api_usd_est: 0.40            # 4 images demo x $0.040/image (gpt-image-1 medium 1024x1024)\n",
-    "  api_provider: openai          # DALL-E 3 = OpenAI direct (OpenRouter ne supporte pas /v1/images/generations)\n",
-    "  cpu_min: 2\n",
-    "  gpu_min: 0\n",
-    "  gpu_required: false\n",
-    "  vram_gb: 0\n",
-    "  vram_tier: LITE\n",
-    "  network: true                 # HTTPS api.openai.com obligatoire\n",
-    "  external_account: openai      # OPENAI_API_KEY dans .env\n",
-    "  free_alternative: GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb\n",
-    "  reduced_pedagogical: GenAI/Image/01-Foundation/01-3-Basic-Image-Operations.ipynb\n",
-    "  reproducibility: MED          # Pas de seed deterministe cote OpenAI\n",
-    "  last_validated: 2026-07-23T01:30Z\n",
-    "  validator: papermill\n",
-    "notes: |\n",
-    "  DALL-E 3 reecrit automatiquement le prompt utilisateur (prompt revision via GPT-4).\n",
-    "  Cout reel depend du mode quality (low/medium/high/auto) et de la taille (1024x1024, 1536x1024, 1024x1536).\n",
-    "  En juillet 2026 le modele sous-jacent est gpt-image-1 (dall-e-3 deprecate).\n",
-    "---\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "02190507",
@@ -1491,6 +1463,23 @@
    },
    "start_time": "2026-06-25T00:50:45.585350",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.4,
+   "api_provider": "openai",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "LITE",
+   "network": true,
+   "external_account": "openai",
+   "free_alternative": "GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb",
+   "reduced_pedagogical": "GenAI/Image/01-Foundation/01-3-Basic-Image-Operations.ipynb",
+   "reproducibility": "MED",
+   "last_validated": "2026-07-23T01:30Z",
+   "validator": "papermill",
+   "notes": "DALL-E 3 reecrit automatiquement le prompt utilisateur (prompt revision via GPT-4).\nCout reel depend du mode quality (low/medium/high/auto) et de la taille (1024x1024, 1536x1024, 1024x1536).\nEn juillet 2026 le modele sous-jacent est gpt-image-1 (dall-e-3 deprecate)."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-2-GPT-5-Image-Generation.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-2-GPT-5-Image-Generation.ipynb
@@ -47,34 +47,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: GPT-5 Multimodal - Analyse et Generation d'Images\n",
-    "cost:\n",
-    "  api_usd_est: 0.50            # Mix 3 modes (quick 206 chars + detailed 2606 + educational 2908) ~7-25s\n",
-    "  api_provider: openrouter     # Routage multimodal via OpenRouter (26 modeles GPT-5 detectes)\n",
-    "  cpu_min: 2\n",
-    "  gpu_min: 0\n",
-    "  gpu_required: false\n",
-    "  vram_gb: 0\n",
-    "  vram_tier: LITE\n",
-    "  network: true                 # HTTPS OpenRouter obligatoire\n",
-    "  external_account: openrouter  # OPENROUTER_API_KEY dans .env\n",
-    "  free_alternative: GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb\n",
-    "  reduced_pedagogical: GenAI/Image/01-Foundation/01-3-Basic-Image-Operations.ipynb\n",
-    "  reproducibility: MED          # Mode routing dependant du snapshot OpenRouter\n",
-    "  last_validated: 2026-07-23T01:30Z\n",
-    "  validator: papermill\n",
-    "notes: |\n",
-    "  Cout variable selon mode (quick 7.76s / detailed 19.14s / educational 25.73s).\n",
-    "  Alt text WCAG genere automatiquement (~114 chars, sous seuil 125 chars).\n",
-    "  5 cas d'usage educatif (Histoire, Sciences, Geographie, Art, Medecine).\n",
-    "---\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "21befb91",
@@ -1927,6 +1899,23 @@
    },
    "start_time": "2026-06-24T04:44:48.787417",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.5,
+   "api_provider": "openrouter",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "LITE",
+   "network": true,
+   "external_account": "openrouter",
+   "free_alternative": "GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb",
+   "reduced_pedagogical": "GenAI/Image/01-Foundation/01-3-Basic-Image-Operations.ipynb",
+   "reproducibility": "MED",
+   "last_validated": "2026-07-23T01:30Z",
+   "validator": "papermill",
+   "notes": "Cout variable selon mode (quick 7.76s / detailed 19.14s / educational 25.73s).\nAlt text WCAG genere automatiquement (~114 chars, sous seuil 125 chars).\n5 cas d'usage educatif (Histoire, Sciences, Geographie, Art, Medecine)."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-3-Basic-Image-Operations.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-3-Basic-Image-Operations.ipynb
@@ -42,34 +42,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: \"Operations de Base sur les Images (PIL/NumPy/Matplotlib)\"\n",
-    "cost:\n",
-    "  api_usd_est: 0.00            # Aucune API - operations locales Pillow/NumPy uniquement\n",
-    "  api_provider: none            # 100% local, pas d'API externe\n",
-    "  cpu_min: 2\n",
-    "  gpu_min: 0\n",
-    "  gpu_required: false\n",
-    "  vram_gb: 0\n",
-    "  vram_tier: LITE\n",
-    "  network: false                # 100% local, pas de HTTPS externe\n",
-    "  external_account: none\n",
-    "  free_alternative: N/A         # deja le notebook de base gratuit\n",
-    "  reduced_pedagogical: N/A      # pas de version reduite, c'est la version gratuite de reference\n",
-    "  reproducibility: HIGH         # Pillow/NumPy deterministes\n",
-    "  last_validated: 2026-07-23T08:45Z\n",
-    "  validator: papermill\n",
-    "notes: |\n",
-    "  Operations PIL/NumPy/Matplotlib localement (resize, crop, rotate, filtres, extraction palette).\n",
-    "  Aucune sortie GenAI ici - c'est le notebook prerequis gratuit avant d'invoquer GenAI.\n",
-    "  Adapté pour machine CPU-only, VRAM=0, GPU=0. Aucune dépendance externe payante.\n",
-    "---\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "8c00b415",
@@ -3079,6 +3051,23 @@
     "version_major": 2,
     "version_minor": 0
    }
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "LITE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "N/A",
+   "reduced_pedagogical": "N/A",
+   "reproducibility": "HIGH",
+   "last_validated": "2026-07-23T08:45Z",
+   "validator": "papermill",
+   "notes": "Operations PIL/NumPy/Matplotlib localement (resize, crop, rotate, filtres, extraction palette).\nAucune sortie GenAI ici - c'est le notebook prerequis gratuit avant d'invoquer GenAI.\nAdapté pour machine CPU-only, VRAM=0, GPU=0. Aucune dépendance externe payante."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb
@@ -30,34 +30,6 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: Forge SD XL Turbo - Generation locale rapide\n",
-    "cost:\n",
-    "  api_usd_est: 0.0             # Self-hosted via Forge WebUI (Automatic1111 fork), pas d'API $\n",
-    "  api_provider: local\n",
-    "  cpu_min: 0\n",
-    "  gpu_min: 3                   # ~18s/image, 4-10 images demo = ~3 min sur RTX 3090\n",
-    "  gpu_required: true           # Inference UNet CUDA obligatoire\n",
-    "  vram_gb: 8                   # SD-XL-Turbo 4-step distillation = 8 GB FP16\n",
-    "  vram_tier: LITE\n",
-    "  network: true                 # Telechargement checkpoint + auth Basic Auth\n",
-    "  external_account: none        # Pas de cle externe (auth Basic locale via Service Portal)\n",
-    "  free_alternative: null        # Pas d'alternative locale equivalente en rapidite\n",
-    "  reduced_pedagogical: GenAI/Image/01-Foundation/01-3-Basic-Image-Operations.ipynb\n",
-    "  reproducibility: HIGH         # torch.manual_seed(42) + DPM++ 2M deterministe\n",
-    "  last_validated: 2026-07-23T01:30Z\n",
-    "  validator: sk_visual          # sk-agent vision check sur figures rendues\n",
-    "notes: |\n",
-    "  Distillation adversariale Sauer 2023 : 50+ steps classiques -> 4 steps.\n",
-    "  Endpoint /sdapi/v1/txt2img via Forge WebUI (127.0.0.1:7860 ou myia.io public).\n",
-    "  Compatible RTX 3060+ (8 GB VRAM min).\n",
-    "---\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "8f3c9b2a",
    "metadata": {
     "papermill": {
@@ -1876,6 +1848,23 @@
    },
    "start_time": "2026-05-12T10:00:27.562622",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "local",
+   "cpu_min": 0,
+   "gpu_min": 3,
+   "gpu_required": true,
+   "vram_gb": 8,
+   "vram_tier": "LITE",
+   "network": true,
+   "external_account": "none",
+   "free_alternative": null,
+   "reduced_pedagogical": "GenAI/Image/01-Foundation/01-3-Basic-Image-Operations.ipynb",
+   "reproducibility": "HIGH",
+   "last_validated": "2026-07-23T01:30Z",
+   "validator": "sk_visual",
+   "notes": "Distillation adversariale Sauer 2023 : 50+ steps classiques -> 4 steps.\nEndpoint /sdapi/v1/txt2img via Forge WebUI (127.0.0.1:7860 ou myia.io public).\nCompatible RTX 3060+ (8 GB VRAM min)."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-5-Qwen-Image-Edit.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-5-Qwen-Image-Edit.ipynb
@@ -30,34 +30,6 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: Qwen-Image-Edit - Edition d'image conditionnee par langage\n",
-    "cost:\n",
-    "  api_usd_est: 0.0             # Self-hosted ComfyUI po-2023, pas de cout API direct\n",
-    "  api_provider: local\n",
-    "  cpu_min: 0\n",
-    "  gpu_min: 12                  # Inference ~5-12 min sur RTX 3090 (Phase 29 multi-node)\n",
-    "  gpu_required: true           # UNET fp8_e4m3fn + VLM qwen_2.5_vl_7b_fp8_scaled = impossible CPU\n",
-    "  vram_gb: 16                  # Phase 29 = 16 GB FP16 (VAE 16 canaux + UNET + VLM)\n",
-    "  vram_tier: MID\n",
-    "  network: true                 # Telechargement modeles Qwen via HF au premier run\n",
-    "  external_account: hf          # HF_TOKEN pour download checkpoint Qwen\n",
-    "  free_alternative: null\n",
-    "  reduced_pedagogical: GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb\n",
-    "  reproducibility: HIGH         # torch.manual_seed(42) + workflow JSON identique\n",
-    "  last_validated: 2026-07-23T01:30Z\n",
-    "  validator: sk_visual\n",
-    "notes: |\n",
-    "  Architecture Phase 29 (sept 2025) : 3 loaders separes (VAE + CLIP + UNET).\n",
-    "  Pipeline ComfyUI : ModelSamplingAuraFlow (shift=3.0) -> CFGNorm (strength=1.0) -> TextEncodeQwenImageEdit -> KSampler.\n",
-    "  Service cible comfyui-qwen (21.7/25.8 GB VRAM libre au moment du pilote).\n",
-    "---\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "79be9a9e",
    "metadata": {
     "papermill": {
@@ -2571,6 +2543,23 @@
    },
    "start_time": "2026-06-26T12:49:41.854739",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "local",
+   "cpu_min": 0,
+   "gpu_min": 12,
+   "gpu_required": true,
+   "vram_gb": 16,
+   "vram_tier": "MID",
+   "network": true,
+   "external_account": "hf",
+   "free_alternative": null,
+   "reduced_pedagogical": "GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb",
+   "reproducibility": "HIGH",
+   "last_validated": "2026-07-23T01:30Z",
+   "validator": "sk_visual",
+   "notes": "Architecture Phase 29 (sept 2025) : 3 loaders separes (VAE + CLIP + UNET).\nPipeline ComfyUI : ModelSamplingAuraFlow (shift=3.0) -> CFGNorm (strength=1.0) -> TextEncodeQwenImageEdit -> KSampler.\nService cible comfyui-qwen (21.7/25.8 GB VRAM libre au moment du pilote)."
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary

Delete the cell[1] `---`-YAML cost frontmatter block on the 5 GenAI/Image 01-Foundation notebooks and move it into `nb.metadata['cost']` (JSON), the canonical storage location (#8376 / #8323 reference schema). Clears guard #8352 `frontmatter_supersize` violations.

## Structure finding (firsthand, G.1)

These 5 notebooks carry cost frontmatter in its **OWN cell (cell[1])**, pure-FM (0 chars after closing `---`); cell[0] is the canonical H1/nav/intro. The frontmatter at cell#1 is flagged by guard #8352 as `frontmatter_supersize` (markdown-it promotes it to a setext-H2 supersize defect). Deleting the pure-FM cell[1] and setting metadata.cost clears the guard.

**Authoritative guard run** (`detect_markdown_rendering.py --check GenAI/Image/`): 20 notebooks flagged `cell#1 [frontmatter_supersize]` — the dashboard's "GenAI/Image 8" was STALE (now 20). All 20 are single-FM (0 duplicate-FM, unlike GenAI/Audio which po-2023 is resolving in #8411/#8413). This PR clears the 01-Foundation 5; the other 15 (02-Advanced/03-Orchestration/04-Applications/examples) remain for follow-up tranches.

## Migration: storage-format verbatim (values NOT re-estimated)

Manual YAML parse (`migrate_cost.parse_frontmatter` — NO `yaml.safe_load`, so `last_validated: 2026-07-23T01:30Z` stays a STRING, no timestamp coercion). The 14 cost fields moved as-is; redundant `title:` dropped (cell#0 H1 is the title); top-level `notes:` merged INTO `cost.notes` (#8376 design gate).

### 3-telltale verbatim preservation (the systematic-bug class from c.713/c.714)

The 3 cost-migration telltales (`free_alternative` nulling, `vram_tier` NONE->LITE, `reduced_pedagogical` nulling) are preserved VERBATIM with their per-NB variation intact (proven via exhaustive ORIG-vs-NEW all-fields diff):

| NB | free_alternative | reduced_pedagogical | vram_tier |
|----|------------------|---------------------|-----------|
| 01-1 DALL-E-3 | path(01-4) | path(01-3) | LITE |
| 01-2 GPT-5-Image | path(01-4) | path(01-3) | LITE |
| 01-3 Basic-Ops | 'N/A' | 'N/A' | LITE |
| 01-4 Forge-SDXL | null | path(01-3) | LITE |
| 01-5 Qwen-Edit | null | path(01-4) | **MID** |

The per-NB variation (path vs null vs 'N/A'; LITE vs MID) is exactly what a nulling/normalizing migration script would corrupt — preserved here.

## Scope

0 code cells modified. Byte-stability verified exhaustively: ORIG (`git show HEAD:path`) vs NEW diff proves all 25-31 kept cells per NB are byte-identical in source/execution_count/outputs/cell_type (0 real diffs across all 5). C.2 re-exec N/A (no code cell source touched — same exemption as #8403 PostTraining). Cell-id state preserved (orig 2 no-id cells, new 1 — the deleted FM cell was one of them; pre-existing, not a regression).

## Validation (canonical, all post-migration)

- `detect_markdown_rendering.py --check GenAI/Image/01-Foundation/`: **"OK: no new ERROR-level violations"**, EXIT 0
- `check_cost_metadata.py` (per-file): `cost_source='metadata'` (5/5), findings empty
- **H.3**: 0 code cells with `execution_count=None` (all 5 notebooks fully executed, 12-15 code cells each)
- **LF-only** (CRLF=0 across all 5)
- guard #8352 landmines cleared: 5

See #8056 (cost/ressource matrix per notebook). Sub-tranche of GenAI/Image (15 remain).

Co-authored-by: Claude-Code <noreply@anthropic.com>