### PR TITLE
fix(ml-dswa,#8056): migrate cost frontmatter -> metadata.cost on 02-ML-Cours (9 NB)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.1-Workflow-ML.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.1-Workflow-ML.ipynb
@@ -40,35 +40,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: \"Workflow d'apprentissage supervisé (NumPy + scikit-learn)\"\n",
-    "cost:\n",
-    "  api_usd_est: 0.00            # 100% local (numpy/scikit-learn/matplotlib)\n",
-    "  api_provider: none           # Local CPU/GPU only, aucun appel API distant\n",
-    "  cpu_min: 2\n",
-    "  gpu_min: 0\n",
-    "  gpu_required: false\n",
-    "  vram_gb: 0\n",
-    "  vram_tier: LITE\n",
-    "  network: false               # Pas de telechargement initial\n",
-    "  external_account: none       # Aucun token/compte externe requis\n",
-    "  free_alternative: self      # Numpy + scikit-learn stdlib only\n",
-    "  reduced_pedagogical: self\n",
-    "  reproducibility: HIGH         # sklearn synthetic make_classification deterministe\n",
-    "  last_validated: 2026-07-23T13:00Z\n",
-    "  validator: papermill\n",
-    "notes: |\n",
-    "  Workflow ML complet (split train/test -> fit -> predict -> evaluate)\n",
-    "  sur donnees synthetiques sklearn (make_classification + make_regression).\n",
-    "  Demo numpy + scikit-learn (DecisionTreeClassifier, LinearRegression).\n",
-    "  Aucun GPU requis. Mode interactif recommande pour explorer le pipeline.\n",
-    "---\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "10000001",
@@ -876,6 +847,23 @@
    "parameters": {},
    "start_time": "2026-06-25T07:01:13.837899+00:00",
    "version": "2.7.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "LITE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": "self",
+   "reproducibility": "HIGH",
+   "last_validated": "2026-07-23T13:00Z",
+   "validator": "papermill",
+   "notes": "Workflow ML complet (split train/test -> fit -> predict -> evaluate)\nsur donnees synthetiques sklearn (make_classification + make_regression).\nDemo numpy + scikit-learn (DecisionTreeClassifier, LinearRegression).\nAucun GPU requis. Mode interactif recommande pour explorer le pipeline."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.2-Descente-de-gradient.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.2-Descente-de-gradient.ipynb
@@ -43,34 +43,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: \"Descente de gradient : comment un modele apprend (NumPy from-scratch)\"\n",
-    "cost:\n",
-    "  api_usd_est: 0.00            # 100% local (numpy + matplotlib from-scratch GD)\n",
-    "  api_provider: none           # Local CPU only, aucune API externe\n",
-    "  cpu_min: 2\n",
-    "  gpu_min: 0\n",
-    "  gpu_required: false\n",
-    "  vram_gb: 0\n",
-    "  vram_tier: LITE\n",
-    "  network: false\n",
-    "  external_account: none\n",
-    "  free_alternative: self\n",
-    "  reduced_pedagogical: self\n",
-    "  reproducibility: HIGH         # np.random.seed(42), gradient descent deterministe\n",
-    "  last_validated: 2026-07-23T13:00Z\n",
-    "  validator: papermill\n",
-    "notes: |\n",
-    "  Implementation from-scratch de la descente de gradient (batch + stochastic)\n",
-    "  sur fonctions tests synthetiques puis sur MSE lineaire. Visualisation des\n",
-    "  isocontours + trajectories de convergence.\n",
-    "---\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "0e925241",
@@ -962,6 +934,23 @@
    "parameters": {},
    "start_time": "2026-06-25T08:48:14.991808+00:00",
    "version": "2.7.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "LITE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": "self",
+   "reproducibility": "HIGH",
+   "last_validated": "2026-07-23T13:00Z",
+   "validator": "papermill",
+   "notes": "Implementation from-scratch de la descente de gradient (batch + stochastic)\nsur fonctions tests synthetiques puis sur MSE lineaire. Visualisation des\nisocontours + trajectories de convergence."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.3-Regression-lineaire-logistique.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.3-Regression-lineaire-logistique.ipynb
@@ -42,34 +42,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: \"Regression lineaire et regression logistique (scikit-learn OLS / Logit)\"\n",
-    "cost:\n",
-    "  api_usd_est: 0.00            # 100% local (scikit-learn + matplotlib + numpy)\n",
-    "  api_provider: none           # Local CPU only\n",
-    "  cpu_min: 2\n",
-    "  gpu_min: 0\n",
-    "  gpu_required: false\n",
-    "  vram_gb: 0\n",
-    "  vram_tier: LITE\n",
-    "  network: false\n",
-    "  external_account: none\n",
-    "  free_alternative: self\n",
-    "  reduced_pedagogical: self\n",
-    "  reproducibility: HIGH         # sklearn synthetic deterministe avec seed\n",
-    "  last_validated: 2026-07-23T13:00Z\n",
-    "  validator: papermill\n",
-    "notes: |\n",
-    "  OLS lineaire (formulation close + scikit-learn LinearRegression) + regression\n",
-    "  logistique (sigmoide + scikit-learn LogisticRegression). Metriques R^2 / accuracy\n",
-    "  / confusion matrix sur donnees synthetiques make_regression / make_classification.\n",
-    "---\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "a1000002",
@@ -938,6 +910,23 @@
    "parameters": {},
    "start_time": "2026-06-25T09:47:41.835885+00:00",
    "version": "2.7.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "LITE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": "self",
+   "reproducibility": "HIGH",
+   "last_validated": "2026-07-23T13:00Z",
+   "validator": "papermill",
+   "notes": "OLS lineaire (formulation close + scikit-learn LinearRegression) + regression\nlogistique (sigmoide + scikit-learn LogisticRegression). Metriques R^2 / accuracy\n/ confusion matrix sur donnees synthetiques make_regression / make_classification."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.4-Arbres-Forets-Ensembles.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.4-Arbres-Forets-Ensembles.ipynb
@@ -42,34 +42,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: \"Arbres de decision, forets aleatoires et ensembles (scikit-learn)\"\n",
-    "cost:\n",
-    "  api_usd_est: 0.00            # 100% local (scikit-learn RandomForest, GradientBoosting)\n",
-    "  api_provider: none           # Local CPU only\n",
-    "  cpu_min: 4\n",
-    "  gpu_min: 0\n",
-    "  gpu_required: false\n",
-    "  vram_gb: 0\n",
-    "  vram_tier: LITE\n",
-    "  network: false\n",
-    "  external_account: none\n",
-    "  free_alternative: self\n",
-    "  reduced_pedagogical: self\n",
-    "  reproducibility: HIGH         # sklearn seed + n_estimators fixe\n",
-    "  last_validated: 2026-07-23T13:00Z\n",
-    "  validator: papermill\n",
-    "notes: |\n",
-    "  Decision tree + Random Forest + Gradient Boosting Classifier. Comparaison des\n",
-    "  frontieres de decision sur donnees synthetiques 2D. Feature importance plot.\n",
-    "  Cout CPU : RandomForest avec 100 arbres consomme ~5-15 secondes CPU par fit.\n",
-    "---\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "2a4c0002",
@@ -928,6 +900,23 @@
    "parameters": {},
    "start_time": "2026-06-25T10:46:05.530085+00:00",
    "version": "2.7.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 4,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "LITE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": "self",
+   "reproducibility": "HIGH",
+   "last_validated": "2026-07-23T13:00Z",
+   "validator": "papermill",
+   "notes": "Decision tree + Random Forest + Gradient Boosting Classifier. Comparaison des\nfrontieres de decision sur donnees synthetiques 2D. Feature importance plot.\nCout CPU : RandomForest avec 100 arbres consomme ~5-15 secondes CPU par fit."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.5-Biais-Variance-CV-ROC.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.5-Biais-Variance-CV-ROC.ipynb
@@ -42,34 +42,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: \"Biais-variance, validation croisee et courbe ROC (scikit-learn)\"\n",
-    "cost:\n",
-    "  api_usd_est: 0.00            # 100% local (scikit-learn cross_val_score + roc_curve)\n",
-    "  api_provider: none           # Local CPU only\n",
-    "  cpu_min: 2\n",
-    "  gpu_min: 0\n",
-    "  gpu_required: false\n",
-    "  vram_gb: 0\n",
-    "  vram_tier: LITE\n",
-    "  network: false\n",
-    "  external_account: none\n",
-    "  free_alternative: self\n",
-    "  reduced_pedagogical: self\n",
-    "  reproducibility: HIGH         # KFold avec random_state + sklearn deterministe\n",
-    "  last_validated: 2026-07-23T13:00Z\n",
-    "  validator: papermill\n",
-    "notes: |\n",
-    "  Diagnostique biais vs variance avec validation croisee KFold sur plusieurs\n",
-    "  complexites de modele (polynomial features). Trace AUC-ROC et precision-recall\n",
-    "  pour classification binaire.\n",
-    "---\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "a50c0002",
@@ -1111,6 +1083,23 @@
    "parameters": {},
    "start_time": "2026-06-25T11:44:20.063792+00:00",
    "version": "2.7.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "LITE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": "self",
+   "reproducibility": "HIGH",
+   "last_validated": "2026-07-23T13:00Z",
+   "validator": "papermill",
+   "notes": "Diagnostique biais vs variance avec validation croisee KFold sur plusieurs\ncomplexites de modele (polynomial features). Trace AUC-ROC et precision-recall\npour classification binaire."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.6-Clustering-KMeans-PCA.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.6-Clustering-KMeans-PCA.ipynb
@@ -42,33 +42,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: \"Clustering K-Means et reduction de dimensionnalite PCA (scikit-learn)\"\n",
-    "cost:\n",
-    "  api_usd_est: 0.00            # 100% local (scikit-learn KMeans + PCA + numpy)\n",
-    "  api_provider: none           # Local CPU only\n",
-    "  cpu_min: 2\n",
-    "  gpu_min: 0\n",
-    "  gpu_required: false\n",
-    "  vram_gb: 0\n",
-    "  vram_tier: LITE\n",
-    "  network: false\n",
-    "  external_account: none\n",
-    "  free_alternative: self\n",
-    "  reduced_pedagogical: self\n",
-    "  reproducibility: HIGH         # KMeans random_state + PCA deterministe\n",
-    "  last_validated: 2026-07-23T13:00Z\n",
-    "  validator: papermill\n",
-    "notes: |\n",
-    "  K-Means clustering sur donnees synthetiques make_blobs (3-5 clusters).\n",
-    "  PCA pour reduction 2D/3D et visualisation. Metrique silhouette + inertie.\n",
-    "---\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "26060002",
@@ -916,6 +889,23 @@
    "parameters": {},
    "start_time": "2026-06-25T12:47:03.339275+00:00",
    "version": "2.7.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "LITE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": "self",
+   "reproducibility": "HIGH",
+   "last_validated": "2026-07-23T13:00Z",
+   "validator": "papermill",
+   "notes": "K-Means clustering sur donnees synthetiques make_blobs (3-5 clusters).\nPCA pour reduction 2D/3D et visualisation. Metrique silhouette + inertie."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.7-Modeles-Non-Parametriques.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.7-Modeles-Non-Parametriques.ipynb
@@ -53,34 +53,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: \"Modeles non-parametriques : KNN, estimation de densite, fenetre de Parzen\"\n",
-    "cost:\n",
-    "  api_usd_est: 0.00            # 100% local (scikit-learn KNeighborsClassifier, KNN from-scratch)\n",
-    "  api_provider: none           # Local CPU only\n",
-    "  cpu_min: 2\n",
-    "  gpu_min: 0\n",
-    "  gpu_required: false\n",
-    "  vram_gb: 0\n",
-    "  vram_tier: LITE\n",
-    "  network: false\n",
-    "  external_account: none\n",
-    "  free_alternative: self\n",
-    "  reduced_pedagogical: self\n",
-    "  reproducibility: HIGH         # sklearn KNN deterministe + make_classification seed\n",
-    "  last_validated: 2026-07-23T13:00Z\n",
-    "  validator: papermill\n",
-    "notes: |\n",
-    "  K-Nearest Neighbors (KNN) from-scratch + scikit-learn. Comparaison des\n",
-    "  frontieres de decision avec different k. Estimation de densite par fenetre\n",
-    "  de Parzen sur donnees 1D et 2D.\n",
-    "---\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "nb270002",
@@ -1028,6 +1000,23 @@
    "parameters": {},
    "start_time": "2026-06-26T08:10:33.068795+00:00",
    "version": "2.7.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "LITE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": "self",
+   "reproducibility": "HIGH",
+   "last_validated": "2026-07-23T13:00Z",
+   "validator": "papermill",
+   "notes": "K-Nearest Neighbors (KNN) from-scratch + scikit-learn. Comparaison des\nfrontieres de decision avec different k. Estimation de densite par fenetre\nde Parzen sur donnees 1D et 2D."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.8-Theorie-PAC.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.8-Theorie-PAC.ipynb
@@ -39,34 +39,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: \"Theorie PAC (Probably Approximately Correct) : bornes de generalisation\"\n",
-    "cost:\n",
-    "  api_usd_est: 0.00            # 100% local (numpy + matplotlib + sympy theoreme)\n",
-    "  api_provider: none           # Local CPU only\n",
-    "  cpu_min: 2\n",
-    "  gpu_min: 0\n",
-    "  gpu_required: false\n",
-    "  vram_gb: 0\n",
-    "  vram_tier: LITE\n",
-    "  network: false\n",
-    "  external_account: none\n",
-    "  free_alternative: self\n",
-    "  reduced_pedagogical: self\n",
-    "  reproducibility: HIGH         # MC sampling avec seed pour PAC empirique vs theorique\n",
-    "  last_validated: 2026-07-23T13:00Z\n",
-    "  validator: papermill\n",
-    "notes: |\n",
-    "  Theorie PAC : borne de generalisation e <= sqrt(log|H|/m) + epsilon.\n",
-    "  Validation empirique par Monte-Carlo sur hypotheses finies. Comparaison\n",
-    "  avec VC-dimension et Rademacher complexity.\n",
-    "---\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "cell-01",
@@ -988,6 +960,23 @@
    "parameters": {},
    "start_time": "2026-06-26T09:05:05.413156+00:00",
    "version": "2.7.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "LITE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": "self",
+   "reproducibility": "HIGH",
+   "last_validated": "2026-07-23T13:00Z",
+   "validator": "papermill",
+   "notes": "Theorie PAC : borne de generalisation e <= sqrt(log|H|/m) + epsilon.\nValidation empirique par Monte-Carlo sur hypotheses finies. Comparaison\navec VC-dimension et Rademacher complexity."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.9-Grokking-Generalisation.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.9-Grokking-Generalisation.ipynb
@@ -32,37 +32,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: \"Grokking et generalisation tardive : transformer toy-model arithmetique\"\n",
-    "cost:\n",
-    "  api_usd_est: 0.00            # 100% local (PyTorch CPU + numpy + matplotlib)\n",
-    "  api_provider: none           # Local CPU/GPU only (PyTorch)\n",
-    "  cpu_min: 4\n",
-    "  gpu_min: 0\n",
-    "  gpu_required: false            # GPU recommande mais CPU possible (entrainement 5-15 min)\n",
-    "  vram_gb: 2                    # VRAM modeste pour transformer 2 couches + dataset toy\n",
-    "  vram_tier: LITE\n",
-    "  network: false\n",
-    "  external_account: none\n",
-    "  free_alternative: self      # Reduction dim embedding (32 -> 8) accelere sur CPU\n",
-    "  reduced_pedagogical: self\n",
-    "  reproducibility: MED          # Grokking stochastic (seed fixe mais emergence tardive)\n",
-    "  last_validated: 2026-07-23T13:00Z\n",
-    "  validator: papermill\n",
-    "notes: |\n",
-    "  Reproduction du phenomene de grokking (Power et al. 2022) sur tache\n",
-    "  arithmetique modulaire (mod 97). Transformer 2 couches entraine au-dela du\n",
-    "  point de memorisation ; on observe la transition subite vers la generalisation\n",
-    "  apres 10x-100x plus d'epoques.\n",
-    "  Mode recommande : GPU pour entrainer 50k-100k steps en <10 min.\n",
-    "  Mode reduit : CPU + embed dim 8 + 5k steps pour demo rapide (~3 min).\n",
-    "---\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "94c489fa",
@@ -792,6 +761,23 @@
    "parameters": {},
    "start_time": "2026-07-18T20:50:27.193904+00:00",
    "version": "2.7.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 4,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 2,
+   "vram_tier": "LITE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": "self",
+   "reproducibility": "MED",
+   "last_validated": "2026-07-23T13:00Z",
+   "validator": "papermill",
+   "notes": "Reproduction du phenomene de grokking (Power et al. 2022) sur tache\narithmetique modulaire (mod 97). Transformer 2 couches entraine au-dela du\npoint de memorisation ; on observe la transition subite vers la generalisation\napres 10x-100x plus d'epoques.\nMode recommande : GPU pour entrainer 50k-100k steps en <10 min.\nMode reduit : CPU + embed dim 8 + 5k steps pour demo rapide (~3 min)."
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary

EPIC **#8056** — migrate the 9 `DataScienceWithAgents/02-ML-Cours` notebooks (2.1-2.9) from top-level YAML frontmatter to canonical `nb.metadata['cost']` JSON. Advances ML cost-matrix coverage.

## Verbatim-forensic discipline (c.887-c.890)

Applied the verbatim-forensic discipline learned from my own #8397/#8400 — where a systematic migration-script bug nulled/normalized 3 telltale fields. **Independent ORIG-vs-NEW all-fields forensic: 135/135 fields match, 0 violations.**

| Telltale (the bug on #8397/#8400) | Value preserved |
|-----------------------------------|-----------------|
| `free_alternative` nulled (self→None) | `'self'` (string, **preserved**) ✅ |
| `reduced_pedagogical` nulled (self→None) | `'self'` (string, **preserved**) ✅ |
| `vram_tier` NONE→LITE normalization | `'LITE'` (preserved verbatim) ✅ |
| `api_provider`/`external_account` none→null | `'none'` (string, **preserved**) ✅ |

## Structure & convention

- cell[0] = prose title, cell[1] = **standalone frontmatter cell** (pure `---YAML---`, no prose after).
- Convention (verified against merged ML-1 #8400 = 0 remaining FM cells): standalone FM cell → **DELETE** after extracting cost → `metadata.cost`. Cell count −1 per NB.
- `title` dropped (canonical convention — #8397/#8400 exemplars have `metadata.title` absent AND `cost.title` absent).
- `notes` merged into `cost.notes` (#8376 design-gate).

## Validation (firsthand)

- `notebook_tools.py validate --quick`: **9/9 OK**, 0 warnings.
- guard **#8352** (`detect_markdown_rendering --check`): **OK, no new violations** (9 `frontmatter_supersize` landmines cleared).
- Round-trip byte-identity `json.dumps(indent=1)` verified pre-edit; **LF preserved (0 CRLF)**.
- Diff = **+153/−255** (pure FM-cell deletion + `metadata.cost` addition, no reflow).
- Catalogue **byte-identical** to main (0 churn, catalog-pr-hygiene R1).
- Independent forensic script (`c894_forensic`-style ORIG-vs-NEW): 135 fields, 0 mismatches, 0 telltales.

See #8056 (partial: ML 02-ML-Cours tranche). See #8352.

Co-Authored-By: Claude-Code <noreply@anthropic.com>