### PR TITLE
docs(gametheory,#3979): reconcile game_theory_lean README — Lattice sorry-free + whole-file line-count audit

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/README.md
@@ -119,9 +119,9 @@ préservé ici — anti-régression 4 étapes respectée).
 | Sous-module | Lignes (FR / EN) | Sorries (FR / EN) | Contenu |
 |-------------|------------------|------------------|---------|
 | [`StableMarriage.Definitions`](StableMarriage/Definitions.lean) | 125 / 132 | 0 / 0 | `PrefProfile`, `Matching`, `IsStable`, ordre `ManLE` |
-| [`StableMarriage.GSState`](StableMarriage/GSState.lean) | 173 / 180 | 0 / 0 | État de l'algorithme Gale-Shapley, file d'hommes libres, propositions |
-| [`StableMarriage.Lemmas`](StableMarriage/Lemmas.lean) | 898 / 902 | 0 / 0 | Lemmes intermédiaires (44 lemmes, 0 sorry) |
-| [`StableMarriage.Lattice`](StableMarriage/Lattice.lean) | 885 / 881 | 3 / 3 | Treillis des mariages (join/meet), optimalité homme/femme ; **3 énoncés contrefactuels documentés**, ni eux ni leur traduction anglaise ne sont prouvables |
+| [`StableMarriage.GSState`](StableMarriage/GSState.lean) | 168 / 177 | 0 / 0 | État de l'algorithme Gale-Shapley, file d'hommes libres, propositions |
+| [`StableMarriage.Lemmas`](StableMarriage/Lemmas.lean) | 898 / 907 | 0 / 0 | Lemmes intermédiaires (44 lemmes, 0 sorry) |
+| [`StableMarriage.Lattice`](StableMarriage/Lattice.lean) | 885 / 881 | 0 / 0 | Treillis des mariages (join/meet), optimalité homme/femme ; les énoncés contrefactuels `man_optimality_key_step` et `doctor_optimal_eq_top` ont été **retirés et réfutés** (`NoCrossCounterexample.*_is_false`, carré latin 3×3), Lattice est sorry-free |
 | [`StableMarriage.GaleShapley`](StableMarriage/GaleShapley.lean) | 181 / 171 | 0 / 0 | Terminaison, stabilité, optimalité homme, existence d'un stable |
 
 **Théorèmes clés** (`namespace StableMarriage`) :
@@ -148,7 +148,7 @@ Trois sous-modules FR + leurs siblings EN, absorbés depuis l'ancien
 | Sous-module | Lignes (FR / EN) | Sorries (FR / EN) | Contenu |
 |-------------|------------------|------------------|---------|
 | [`CooperativeGames.Basic`](CooperativeGames/Basic.lean) | 607 / 606 | 0 / 0 | `Coalition = Finset N`, `TUGame`, unanimity/majority games, `BondedWeights`, **théorème de Bondareva-Shapley** (forward) |
-| [`CooperativeGames.ConeKernel`](CooperativeGames/ConeKernel.lean) | 753 / 547 | 0 / 0 | `BondarevaCone.augCone`, séparateur, **Bondareva-Shapley bidirectionnel** (forward + backward), `marginalVector_mem_core`, `convex_core_nonempty` |
+| [`CooperativeGames.ConeKernel`](CooperativeGames/ConeKernel.lean) | 753 / 757 | 0 / 0 | `BondarevaCone.augCone`, séparateur, **Bondareva-Shapley bidirectionnel** (forward + backward), `marginalVector_mem_core`, `convex_core_nonempty` |
 | [`CooperativeGames.Shapley`](CooperativeGames/Shapley.lean) | 2 024 / 2 034 | 0 / 0 | `Solution`, **les quatre axiomes de Shapley** (efficience, symétrie, joueur nul, additivité), unicité, `mobius_decomposition`, `shapley_smulGame`, `shapley_addGames` |
 
 **Théorèmes clés** (`namespaces Solution`, `ShapleyValue`, `Mobius`,
@@ -222,9 +222,10 @@ lake build
 lake build StableMarriage
 lake build CooperativeGames
 
-# Vérifier l'état sorry actuel (manifest attendu = 6 : 3+3 dans Lattice)
-grep -c '\bsorry\b' StableMarriage/Lattice.lean        # 3
-grep -c '\bsorry\b' StableMarriage/Lattice_en.lean     # 3
+# Vérifier l'état sorry actuel (Lattice est sorry-free : 0 sorry de tactique)
+# NB : `grep -c '\bsorry\b'` brut renvoie 3 par fichier car le mot apparaît
+# dans des commentaires de prose (historique des tentatives de preuve) ;
+# le compte canonique (strip_comments de scripts/lean/check_i18n_siblings.py) = 0.
 
 # Cache Mathlib (premier build, ~40s ; incrémental ensuite ~13s)
 lake exe cache get


### PR DESCRIPTION
## Summary

Whole-file audit (rule E) of `game_theory_lean/README.md` table rows against the actual `.lean` files on `origin/main` (canonical sorry count via `strip_comments` of `scripts/lean/check_i18n_siblings.py`; line counts via `wc -l`).

## Primary defect — internal contradiction (doc-honesty)

The `StableMarriage/Lattice` table row claimed **« 3 / 3 sorries, 3 énoncés contrefactuels documentés, non prouvables »**, but the README's own **Statut section (L27)** and **cold-build note (L239-240)** say Lattice is sorry-free (« `Lattice` est désormais sorry-free » / « le fichier ne contient aucun sorry »). A reader hitting the table first is misled.

**Verified firsthand (canonical counter, not raw grep):**
- The 3 raw `grep '\bsorry\b'` matches (L143, L154, L784 of `Lattice.lean`) are all **prose mentions inside block comments** (proof-attempt history), canonical count (after `strip_comments`) = **0**.
- The counterfactuals `man_optimality_key_step` and `doctor_optimal_eq_top` were **retired and refuted**: `theorem man_optimality_key_step_is_false` (L804) and `theorem doctor_optimal_eq_top_is_false` (L817) in `namespace NoCrossCounterexample` (latin-square 3×3 refutation). So they are not « unprouvable stubs » — they are disproven and removed.
- Table row corrected to **0 / 0** + honest description citing the refutation.
- Build verification section (L225-227) rewritten: was instructing `grep -c` expecting « manifest=6, # 3 » — now honestly documents the raw-grep over-count pitfall and points to the canonical counter.

## Secondary — line-count drifts reconciled to `wc -l`

| Module | Was (FR/EN) | Now (FR/EN) | `wc -l` actual |
|--------|-------------|-------------|----------------|
| `StableMarriage.GSState` | 173 / 180 | 168 / 177 | 168 / 177 ✓ |
| `StableMarriage.Lemmas` EN | 902 | 907 | 907 ✓ |
| `CooperativeGames.ConeKernel` EN | 547 | 757 | 757 ✓ (was severely stale) |

**All 8 table rows now EXACTLY match `wc -l`:** Definitions 125/132, GSState 168/177, Lemmas 898/907, Lattice 885/881, GaleShapley 181/171, Basic 607/606, ConeKernel 753/757, Shapley 2024/2034.

## Method note (line-count convention)

`wc -l` counts newline characters. `Shapley_en.lean` does not end with a trailing newline (true line count 2035, `wc -l` 2034); the README uses the `wc -l` convention, so Shapley EN stays 2034 (reverted a first-pass 2035 that used `nlines()` overcount). All other files end with a newline (both methods agree).

## Compliance

- **catalog-pr-hygiene**: catalogue byte-identical to main (0 `CATALOG-STATUS` markers touched), rebase fresh off `origin/main` (HEAD `482adaec2`), atomic (1 file, 1 subject).
- **LF-only** (0 CRLF), all `.lean` links verified to exist on disk.
- **See #3979** (partial — `game_theory_lean` README of the Knot/Grothendieck/Lean-math feuilles family; not closing — other READMEs in the family remain).

`See #3979` · `See #6724` (Lean README sorry-map honesty, sibling of conway #8414)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
