### PR TITLE
docs(#7422): normalize ARCHIVED header to L1 on curriculum-renumbering-phase1 (2 files)

### DIFF
--- a/docs/archive/curriculum-renumbering-phase1/texte.md
+++ b/docs/archive/curriculum-renumbering-phase1/texte.md
@@ -1,6 +1,6 @@
-# GenAI/Texte — analyse renumérotation (EPIC #5081, phase-1)
-
 > **ARCHIVED 2026-07-19** — Verdict **NO-RENUMBER** figé. EPIC #5081 phase-1 close. Document conservé pour référence historique (daté, immutable). Voir triage table c.674 [PR #7426](https://github.com/jsboige/CoursIA/pull/7426) + archive INDEX [`docs/archive/INDEX.md`](../INDEX.md). Superseded by EPIC #5081 closure ; navlink defect (cf §4) tracké séparément. *Archivé par : po-2023 (lane CoursIA-2, c.676) — `Closes` partiel dispatch triage c.674 UPDATE/ARCHIVE catégorie.*
+
+# GenAI/Texte — analyse renumérotation (EPIC #5081, phase-1)
 
 **Série** : `MyIA.AI.Notebooks/GenAI/Texte/` (20 notebooks Python, série **plate** — pas d'arborescence par étage, numérotation linéaire `1..20`).
 **Phase** : 1 (docs-only, analyse DAG — pas de modification de notebook).

--- a/docs/archive/curriculum-renumbering-phase1/video.md
+++ b/docs/archive/curriculum-renumbering-phase1/video.md
@@ -1,6 +1,6 @@
-# GenAI/Video — analyse renumérotation (EPIC #5081, phase-1)
-
 > **ARCHIVED 2026-07-19** — Verdict **NO-RENUMBER** + 1 défaut de spine « skip » corrigé (`02-5-LTX2-Audiovisual` ré-inséré). EPIC #5081 phase-1 close. Document conservé pour référence historique (daté, immutable). Voir triage table c.674 [PR #7426](https://github.com/jsboige/CoursIA/pull/7426) + archive INDEX [`docs/archive/INDEX.md`](../INDEX.md). Superseded by EPIC #5081 closure. *Archivé par : po-2023 (lane CoursIA-2, c.676) — `Closes` partiel dispatch triage c.674 UPDATE/ARCHIVE catégorie.*
+
+# GenAI/Video — analyse renumérotation (EPIC #5081, phase-1)
 
 **Série** : `MyIA.AI.Notebooks/GenAI/Video/` — arborescence hiérarchique à 4 étages (`01-Foundation` → `04-Applications`), 17 notebooks.
 **Phase** : 1 (docs-only pour l'analyse ; 1 correctif navlink markdown appliqué — pas de ré-exécution, cf C.2).


### PR DESCRIPTION
## Summary

**#7422** docs-hygiene slice — normalize the ARCHIVED-header position on 2 files in `docs/archive/curriculum-renumbering-phase1/` to match the canonical repo-wide convention.

## Context (triage c.895)

Triaged the 6-file subdir `docs/archive/curriculum-renumbering-phase1/` (EPIC #5081 phase-1 renumbering analyses, all verdict NO-RENUMBER, archived 2026-07-19/20). **6/6 = KEEP-AS-ARCHIVE canonique** (header daté + verdict figé + INDEX ref). Triage table posted: https://github.com/jsboige/CoursIA/issues/7422#issuecomment-5076030380

One inconsistency found: **4/6** (infer/planners/pymc/search, dispatchs c.695/c.748) have the `> **ARCHIVED**` blockquote at **L1** (before `# Title`), but **2/6** (texte/video, the oldest c.676 dispatchs) have it at **L3** (after `# Title`).

## Convention verified

**L1 is canonical repo-wide** — confirmed across:
- `docs/archive/` root (5/5 files: 01-cartographie, 02-etude-adk, 03-plan, GROTHENDIECK, H7_P2_DOCKER)
- `docs/_archives/audit/` (1/1)
- The 4 sibling files in the same subdir

Precedent: #7422 has merged header-materialization PRs before (#7922 ml-trading-state, #7933 genai-stack-audit, #7560 stable-marriage breadcrumb).

## Fix

Normalize `texte.md` + `video.md`: blockquote `> **ARCHIVED**` moves to L1, `# Title` follows.

## Anti-regression respected

Archived content is explicitly marked *"Document conservé pour référence historique (daté, immutable)"*. This PR moves the **blockquote position only** — the archived verdict text, date, PR refs, and provenance are **byte-preserved** (nothing stripped/modified). Anti-regression §D targets production code (Lean proofs, called functions), not archived-doc header cosmetics.

## Validation

- Diff = **+4/−4** (pure position swap, content-identical).
- Post-edit: **6/6 files uniformly ARCHIVED at L1**.
- 0 CRLF (LF preserved), catalogue byte-identical (0 churn).
- 0 inbound refs to individual files (resolve via subdir INDEX).

See #7422 (slice curriculum-renumbering-phase1).

Co-Authored-By: Claude-Code <noreply@anthropic.com>