### PR TITLE
fix(genai,#8411): restore free_alternative telltale nulled by cost-mig #8420 (01-1, 01-2)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-1-OpenAI-TTS-Intro.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-1-OpenAI-TTS-Intro.ipynb
@@ -2327,7 +2327,7 @@
    },
    "start_time": "2026-06-23T22:41:41.170863",
    "version": "2.6.0"
-  }, "cost": {"api_usd_est": 0.02, "api_provider": "openai", "cpu_min": 0, "gpu_min": 0, "gpu_required": false, "vram_gb": 0, "vram_tier": "NONE", "network": true, "external_account": "openai", "free_alternative": null, "reduced_pedagogical": null, "reproducibility": "HIGH", "last_validated": "2026-07-24T00:00Z", "validator": "manual", "notes": "OpenAI TTS API (modeles tts-1 $0.015/1K chars et tts-1-hd $0.030/1K chars, 6 voix). Le notebook\ncompare les voix et les modeles. Cout estime depuis les tarifs officiels et le decompte d'appels\n(lecture G.1 firsthand), execution GPU non relancee (API cloud). Alternative locale : 01-5 Kokoro."}},
+  }, "cost": {"api_usd_est": 0.02, "api_provider": "openai", "cpu_min": 0, "gpu_min": 0, "gpu_required": false, "vram_gb": 0, "vram_tier": "NONE", "network": true, "external_account": "openai", "free_alternative": "01-5-Kokoro-TTS-Local", "reduced_pedagogical": null, "reproducibility": "HIGH", "last_validated": "2026-07-24T00:00Z", "validator": "manual", "notes": "OpenAI TTS API (modeles tts-1 $0.015/1K chars et tts-1-hd $0.030/1K chars, 6 voix). Le notebook\ncompare les voix et les modeles. Cout estime depuis les tarifs officiels et le decompte d'appels\n(lecture G.1 firsthand), execution GPU non relancee (API cloud). Alternative locale : 01-5 Kokoro."}},
  "nbformat": 4,
  "nbformat_minor": 5
 }

--- a/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-2-OpenAI-Whisper-STT.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-2-OpenAI-Whisper-STT.ipynb
@@ -2119,7 +2119,7 @@
    },
    "start_time": "2026-06-24T16:38:29.311949",
    "version": "2.6.0"
-  }, "cost": {"api_usd_est": 0.02, "api_provider": "openai", "cpu_min": 0, "gpu_min": 0, "gpu_required": false, "vram_gb": 0, "vram_tier": "NONE", "network": true, "external_account": "openai", "free_alternative": null, "reduced_pedagogical": null, "reproducibility": "HIGH", "last_validated": "2026-07-24T00:00Z", "validator": "manual", "notes": "OpenAI Whisper API (whisper-1, gpt-4o-transcribe). Genere l'audio de test via TTS puis transcrit\ndans plusieurs formats (json, srt, vtt) et compare les modeles. Cout estime depuis les tarifs et le\ndecompte d'appels (lecture G.1 firsthand), execution non relancee (API cloud). Alternative locale : 01-4."}},
+  }, "cost": {"api_usd_est": 0.02, "api_provider": "openai", "cpu_min": 0, "gpu_min": 0, "gpu_required": false, "vram_gb": 0, "vram_tier": "NONE", "network": true, "external_account": "openai", "free_alternative": "01-4-Whisper-Local", "reduced_pedagogical": null, "reproducibility": "HIGH", "last_validated": "2026-07-24T00:00Z", "validator": "manual", "notes": "OpenAI Whisper API (whisper-1, gpt-4o-transcribe). Genere l'audio de test via TTS puis transcrit\ndans plusieurs formats (json, srt, vtt) et compare les modeles. Cout estime depuis les tarifs et le\ndecompte d'appels (lecture G.1 firsthand), execution non relancee (API cloud). Alternative locale : 01-4."}},
  "nbformat": 4,
  "nbformat_minor": 5
 }


### PR DESCRIPTION
## Follow-up to merged #8420 — restore `free_alternative` telltale

`#8420` (Audio 01-Foundation cost-mig step-3) merged at 01:48Z **despite** po-2024's pre-merge CHANGES_REQUESTED forensic review (@01:23Z) flagging a real telltale. This PR addresses that finding on the now-merged main.

### Defect (verified firsthand, G.1)

The cost-migration **nulled** `free_alternative` on 2/5 NB despite cell#0 (#8312, canonical per #8413 dup-resolution) carrying valid string references pointing at **existing notebooks**:

| NB | cell#0 canonical (pre-migration) | main (post-#8420) | this PR |
|----|----------------------------------|-------------------|---------|
| `01-1-OpenAI-TTS-Intro` | `'01-5-Kokoro-TTS-Local'` | `null` ← nulled | `'01-5-Kokoro-TTS-Local'` restored |
| `01-2-OpenAI-Whisper-STT` | `'01-4-Whisper-Local'` | `null` ← nulled | `'01-4-Whisper-Local'` restored |
| 01-3 / 01-4 / 01-5 | `null` (already) | `null` (correct) | untouched |

**Targets verified on disk**: `01-5-Kokoro-TTS-Local.ipynb` (TTS local gratuit, 82M, MIT) and `01-4-Whisper-Local.ipynb` (STT local gratuit) both exist — these are exactly the legitimate cross-references the field is meant to hold. The `notes` prose already mentions them (`Alternative locale : 01-5 Kokoro` / `01-4`), confirming they were meant to be preserved.

### Why this is the telltale (not intentional)

The PR body justified the nulling as *"(was legacy str)"*. But per #8413's canonical decision (KEEP cell#0), **cell#0 is authoritative** — and the same field-source (cell#0) is trusted verbatim for every OTHER field (vram_tier NONE, api_usd_est 0.02, reproducibility HIGH, validator manual). Nulling `free_alternative` is **inconsistent with the PR's own canonical choice** = the c.887-890 systematic `free_alternative`-nulling telltale class (info-loss of a real cross-reference), not a schema resolution.

### Surgical byte-edit

Compact JSON format (from #8420) preserved byte-for-byte — only the 2 `free_alternative` values changed, **+2/−2, no format churn, no metadata-block reformatting**. `reduced_pedagogical` stays `null` on all 5 (correct — cell#0 was null). Verified: only `free_alternative` key changed in the full cost-dict diff.

### Credits

**po-2024** — the forensic review on #8420 caught this telltale pre-merge. This PR implements the fix po-2024 recommended (restore cell#0 string values).

`See #8411` (partial — Audio cost-mig epic; this fixes the telltale regression only, not the whole epic).

Co-Authored-By: Claude <noreply@anthropic.com>