### PR TITLE
fix(twin-register,#8057): rebaseline Probas-3 csharp_sha after #8423

### DIFF
--- a/scripts/notebook_tools/twin_pairs.yaml
+++ b/scripts/notebook_tools/twin_pairs.yaml
@@ -387,7 +387,7 @@
     date: '2026-07-24'
     by: po-2023
     python_sha: 9f0c7a44ffd98bfc97b6ef091ae28fe7d6802541
-    csharp_sha: 0d407e2eeed7769b879c2a67a9ab3cb27f067f84
+    csharp_sha: 620b7fd3b52de649ffb063e27b568cd7520bd6fa
   known_differences:
   - 'Socle pedagogique commun : graphes de facteurs et variables aleatoires modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational


### PR DESCRIPTION
Grain: LIGHT/ledger — lane myia-ai-01:CoursIA — prev: MED/refactor

Coordinator register-hygiene follow-up to #8423 (merged). Restores the twin registry to **0 drift** after #8423's cosmetic glyph fix advanced Infer-3's SHA (csharp side of Probas-3).

- **1-line change**: `csharp_sha 0d407e2e -> 620b7fd3`. Comments/documentation fully preserved (surgical sed, NOT `--update` which strips the header + family annotations via YAML round-trip).
- Parity conclusion unchanged: a French-glyph prose fix does not alter Python↔C# semantic parity; the 2026-07-24 audit still holds, only the SHA pointer advances.
- `check_twin_parity.py --check` = **76 OK / 0 DRIFT / 0 MISSING**.

See #8057