### PR TITLE
fix(genai-image,#8056): migrate 02-Advanced cost frontmatter -> metadata.cost (guard #8352)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-1-Qwen-Image-Edit-2509.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-1-Qwen-Image-Edit-2509.ipynb
@@ -30,35 +30,6 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: Qwen-Image-Edit 2509 - Inpainting et edition avancee\n",
-    "cost:\n",
-    "  api_usd_est: 0.0             # Self-hosted ComfyUI po-2023, pas de cout API direct\n",
-    "  api_provider: local\n",
-    "  cpu_min: 0\n",
-    "  gpu_min: 25                  # 2509 parameters full ~25 min sur RTX 3090\n",
-    "  gpu_required: true\n",
-    "  vram_gb: 24                  # FP16 = 24 GB, int4 Nunchaku ~10 GB (reduction)\n",
-    "  vram_tier: HIGH\n",
-    "  network: true\n",
-    "  external_account: hf\n",
-    "  free_alternative: GenAI/Image/01-Foundation/01-5-Qwen-Image-Edit.ipynb\n",
-    "  reduced_pedagogical: GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb\n",
-    "  reproducibility: HIGH\n",
-    "  last_validated: 2026-07-23T01:30Z\n",
-    "  validator: sk_visual\n",
-    "notes: |\n",
-    "  **VRAM 24 GB FP16 bloque sur RTX 3090 (24 GB en pratique = 21-23 GB utilisables)**.\n",
-    "  Solutions pour faire tenir le modele : quantization Nunchaku INT4 (~10 GB) ou enable_model_cpu_offload().\n",
-    "  CFGNorm strength=1.0 + cfg=1.0 + scheduler=beta = optimum Phase 29.\n",
-    "  Patterns d'inpainting : create_rectangular_mask() / create_circular_mask() avec feather.\n",
-    "---\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "cell-0",
    "metadata": {
     "papermill": {
@@ -2460,6 +2431,23 @@
    },
    "start_time": "2026-06-21T00:38:08.256732",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "local",
+   "cpu_min": 0,
+   "gpu_min": 25,
+   "gpu_required": true,
+   "vram_gb": 24,
+   "vram_tier": "HIGH",
+   "network": true,
+   "external_account": "hf",
+   "free_alternative": "GenAI/Image/01-Foundation/01-5-Qwen-Image-Edit.ipynb",
+   "reduced_pedagogical": "GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb",
+   "reproducibility": "HIGH",
+   "last_validated": "2026-07-23T01:30Z",
+   "validator": "sk_visual",
+   "notes": "**VRAM 24 GB FP16 bloque sur RTX 3090 (24 GB en pratique = 21-23 GB utilisables)**.\nSolutions pour faire tenir le modele : quantization Nunchaku INT4 (~10 GB) ou enable_model_cpu_offload().\nCFGNorm strength=1.0 + cfg=1.0 + scheduler=beta = optimum Phase 29.\nPatterns d'inpainting : create_rectangular_mask() / create_circular_mask() avec feather."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-2-FLUX-1-Advanced-Generation.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-2-FLUX-1-Advanced-Generation.ipynb
@@ -30,34 +30,6 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: FLUX.1 Advanced Generation - MMDiT 12B flow matching\n",
-    "cost:\n",
-    "  api_usd_est: 0.0             # Self-hosted, pas de cout API direct (variante schnell = Apache 2.0)\n",
-    "  api_provider: local\n",
-    "  cpu_min: 0\n",
-    "  gpu_min: 15                  # 4 steps flow matching ~15 min sur RTX 3090 pour batch demo\n",
-    "  gpu_required: true\n",
-    "  vram_gb: 24                  # FLUX.1 12B parametres + double encodeur T5-XXL + CLIP-L\n",
-    "  vram_tier: HIGH\n",
-    "  network: true                 # Telechargement checkpoint depuis HuggingFace\n",
-    "  external_account: hf          # HF_TOKEN pour download FLUX.1-schnell\n",
-    "  free_alternative: GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb\n",
-    "  reduced_pedagogical: GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb\n",
-    "  reproducibility: HIGH         # guidance_scale=0.0 obligatoire pour schnell + num_inference_steps=4\n",
-    "  last_validated: 2026-07-23T01:30Z\n",
-    "  validator: sk_visual\n",
-    "notes: |\n",
-    "  Variante schnell = Apache 2.0 (dev = LoRA-compat non-commercial, pro = API payante).\n",
-    "  enable_model_cpu_offload() permet de tenir 12B dans 24 GB VRAM.\n",
-    "  Generation de texte lisible dans images = avantage decisif vs SD 3.5 / SD XL Turbo.\n",
-    "---\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "cell-0",
    "metadata": {
     "papermill": {
@@ -11515,6 +11487,23 @@
     "version_major": 2,
     "version_minor": 0
    }
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "local",
+   "cpu_min": 0,
+   "gpu_min": 15,
+   "gpu_required": true,
+   "vram_gb": 24,
+   "vram_tier": "HIGH",
+   "network": true,
+   "external_account": "hf",
+   "free_alternative": "GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb",
+   "reduced_pedagogical": "GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb",
+   "reproducibility": "HIGH",
+   "last_validated": "2026-07-23T01:30Z",
+   "validator": "sk_visual",
+   "notes": "Variante schnell = Apache 2.0 (dev = LoRA-compat non-commercial, pro = API payante).\nenable_model_cpu_offload() permet de tenir 12B dans 24 GB VRAM.\nGeneration de texte lisible dans images = avantage decisif vs SD 3.5 / SD XL Turbo."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-3-Stable-Diffusion-3-5.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-3-Stable-Diffusion-3-5.ipynb
@@ -30,35 +30,6 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: Stable Diffusion 3.5 - MMDiT triple encodeur + Flow Matching\n",
-    "cost:\n",
-    "  api_usd_est: 0.0             # Self-hosted via diffusers (gated repo, HF_TOKEN obligatoire)\n",
-    "  api_provider: local\n",
-    "  cpu_min: 0\n",
-    "  gpu_min: 12                  # Medium 8 min, Large 12 min, Large Turbo 4 min sur RTX 3090\n",
-    "  gpu_required: true\n",
-    "  vram_gb: 16                  # Medium 2.5B = 8 GB | Large 8B FP16 = 16 GB | Large Turbo 8B fp8 = 8 GB\n",
-    "  vram_tier: MID               # Recommandation dynamique selon VRAM detectee\n",
-    "  network: true\n",
-    "  external_account: hf          # HF_TOKEN + acceptation licensee stability-ai/stable-diffusion-3.5-large\n",
-    "  free_alternative: GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb\n",
-    "  reduced_pedagogical: GenAI/Image/01-Foundation/01-3-Basic-Image-Operations.ipynb\n",
-    "  reproducibility: HIGH         # num_inference_steps=28, guidance_scale=4.5 (Large standard)\n",
-    "  last_validated: 2026-07-23T01:30Z\n",
-    "  validator: sk_visual\n",
-    "notes: |\n",
-    "  **GatedRepoError attendu** si HF_TOKEN non autorise pour stability-ai/stable-diffusion-3.5-large.\n",
-    "  Pattern try/except retourne client load_failed=True (mode demo sans crash).\n",
-    "  Architecture MMDiT (Esser 2024) : attention jointe texte+image avec triple encodeur (CLIP-L + CLIP-G + T5-XXL).\n",
-    "  Large Turbo : num_inference_steps=4 + guidance_scale=0.0 (rectified flow).\n",
-    "---\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "cell-0",
    "metadata": {
     "papermill": {
@@ -1212,6 +1183,23 @@
    },
    "start_time": "2026-05-14T08:15:03.471358",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "local",
+   "cpu_min": 0,
+   "gpu_min": 12,
+   "gpu_required": true,
+   "vram_gb": 16,
+   "vram_tier": "MID",
+   "network": true,
+   "external_account": "hf",
+   "free_alternative": "GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb",
+   "reduced_pedagogical": "GenAI/Image/01-Foundation/01-3-Basic-Image-Operations.ipynb",
+   "reproducibility": "HIGH",
+   "last_validated": "2026-07-23T01:30Z",
+   "validator": "sk_visual",
+   "notes": "**GatedRepoError attendu** si HF_TOKEN non autorise pour stability-ai/stable-diffusion-3.5-large.\nPattern try/except retourne client load_failed=True (mode demo sans crash).\nArchitecture MMDiT (Esser 2024) : attention jointe texte+image avec triple encodeur (CLIP-L + CLIP-G + T5-XXL).\nLarge Turbo : num_inference_steps=4 + guidance_scale=0.0 (rectified flow)."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-4-Z-Image-Lumina2.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-4-Z-Image-Lumina2.ipynb
@@ -54,35 +54,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: Z-Image Lumina2 - Flow-based Large Diffusion Transformer\n",
-    "cost:\n",
-    "  api_usd_est: 0.0             # Self-hosted ComfyUI + Diffusers wrapper, pas de cout API\n",
-    "  api_provider: local\n",
-    "  cpu_min: 0\n",
-    "  gpu_min: 8                   # Lumina-Next-SFT-diffusers ~10 GB checkpoint, ~8 min sur RTX 3090\n",
-    "  gpu_required: true\n",
-    "  vram_gb: 12                  # VAE SDXL 4 canaux + scheduler interne + checkpoint 10 GB\n",
-    "  vram_tier: MID\n",
-    "  network: true\n",
-    "  external_account: hf          # HF_TOKEN pour download Alpha-VLLM/Lumina-Next-SFT-diffusers\n",
-    "  free_alternative: GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb\n",
-    "  reduced_pedagogical: GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb\n",
-    "  reproducibility: HIGH         # Flag-DiT -> Next-DiT (Gao/Zhuo 2024), scaling_watershed=0.3\n",
-    "  last_validated: 2026-07-23T01:30Z\n",
-    "  validator: sk_visual\n",
-    "notes: |\n",
-    "  Voie GGUF z_image_turbo + Gemma CLIP **abandonnee** (regle F : incompatibilite dimensionnelle\n",
-    "  RecurrentGemma 2560 vs Gemma-2 2304, defaut architecture = retour au chemin supporte).\n",
-    "  Node ComfyUI LuminaDiffusersNode telecharge le checkpoint automatiquement au premier lancement.\n",
-    "  Parametres specifiques : proportional_attn=True + clean_caption=True + scaling_watershed=0.3.\n",
-    "---\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "1f6097c8",
@@ -714,6 +685,23 @@
    "parameters": {},
    "start_time": "2026-05-12T10:00:40.350409",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "local",
+   "cpu_min": 0,
+   "gpu_min": 8,
+   "gpu_required": true,
+   "vram_gb": 12,
+   "vram_tier": "MID",
+   "network": true,
+   "external_account": "hf",
+   "free_alternative": "GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb",
+   "reduced_pedagogical": "GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb",
+   "reproducibility": "HIGH",
+   "last_validated": "2026-07-23T01:30Z",
+   "validator": "sk_visual",
+   "notes": "Voie GGUF z_image_turbo + Gemma CLIP **abandonnee** (regle F : incompatibilite dimensionnelle\nRecurrentGemma 2560 vs Gemma-2 2304, defaut architecture = retour au chemin supporte).\nNode ComfyUI LuminaDiffusersNode telecharge le checkpoint automatiquement au premier lancement.\nParametres specifiques : proportional_attn=True + clean_caption=True + scaling_watershed=0.3."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-5-Bonsai-Image-Ternary.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-5-Bonsai-Image-Ternary.ipynb
@@ -37,36 +37,6 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: \"Bonsai-Image Ternary 1.58-bit (FLUX.2 Klein 4B gemlite)\"\n",
-    "cost:\n",
-    "  api_usd_est: 0.00            # Bonsai local via ComfyUI + HF, pas d'API payante\n",
-    "  api_provider: none            # local ComfyUI + HuggingFace download\n",
-    "  cpu_min: 4\n",
-    "  gpu_min: 1\n",
-    "  gpu_required: true            # Quantization ternaire 1.58-bit + FLUX.2 Klein 4B = GPU lourd\n",
-    "  vram_gb: 12\n",
-    "  vram_tier: MID                # ~12 GB avec quantization ternaire 1.58-bit (vs ~16 GB FP16)\n",
-    "  network: true                 # HF download (prism-ml/bonsai-image-ternary-4B-gemlite-2bit)\n",
-    "  external_account: huggingface # HF_TOKEN dans .env pour download du modèle\n",
-    "  free_alternative: GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb\n",
-    "  reduced_pedagogical: GenAI/Image/01-Foundation/01-3-Basic-Image-Operations.ipynb\n",
-    "  reproducibility: MED          # ComfyUI stochastic seed control, modele quantize ternaire\n",
-    "  last_validated: 2026-07-23T08:45Z\n",
-    "  validator: sk_visual          # GPU actif, validation visuelle obligatoire\n",
-    "notes: |\n",
-    "  Bonsai-Image (`prism-ml/bonsai-image-ternary-4B-gemlite-2bit`) = FLUX.2 Klein 4B avec quantization ternaire 1.58-bit (gemlite).\n",
-    "  VRAM ~12 GB (vs ~16 GB FP16). Inference via ComfyUI + custom node Bonsai.\n",
-    "  Issue de reference : #1613.\n",
-    "  Statut : BETA (scaffold + theorie + generation API ComfyUI fonctionnelle, exercices a completer).\n",
-    "  HF_TOKEN obligatoire pour download du modele.\n",
-    "---\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "theorie-md",
    "metadata": {
     "papermill": {
@@ -991,6 +961,23 @@
    "parameters": {},
    "start_time": "2026-06-07T13:30:26.022151",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 4,
+   "gpu_min": 1,
+   "gpu_required": true,
+   "vram_gb": 12,
+   "vram_tier": "MID",
+   "network": true,
+   "external_account": "huggingface",
+   "free_alternative": "GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb",
+   "reduced_pedagogical": "GenAI/Image/01-Foundation/01-3-Basic-Image-Operations.ipynb",
+   "reproducibility": "MED",
+   "last_validated": "2026-07-23T08:45Z",
+   "validator": "sk_visual",
+   "notes": "Bonsai-Image (`prism-ml/bonsai-image-ternary-4B-gemlite-2bit`) = FLUX.2 Klein 4B avec quantization ternaire 1.58-bit (gemlite).\nVRAM ~12 GB (vs ~16 GB FP16). Inference via ComfyUI + custom node Bonsai.\nIssue de reference : #1613.\nStatut : BETA (scaffold + theorie + generation API ComfyUI fonctionnelle, exercices a completer).\nHF_TOKEN obligatoire pour download du modele."
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary

Migrate the **5 GenAI/Image/02-Advanced** notebooks from cell#1 `---`-YAML cost frontmatter to `nb.metadata['cost']` (#8376 canonical schema). **Storage-format migration, NOT re-estimation**: the cell#1 pure-FM block is deleted, values moved verbatim to metadata.cost. Cell#0 (canonical Parameters/Navigation) untouched.

| Notebook | vram_tier | free_alternative -> |
|----------|-----------|---------------------|
| 02-1-Qwen-Image-Edit-2509 | HIGH | 01-5-Qwen-Image-Edit |
| 02-2-FLUX-1-Advanced-Generation | HIGH | 01-4-Forge-SD-XL-Turbo |
| 02-3-Stable-Diffusion-3-5 | MID | 01-4-Forge-SD-XL-Turbo |
| 02-4-Z-Image-Lumina2 | MID | 01-4-Forge-SD-XL-Turbo |
| 02-5-Bonsai-Image-Ternary | MID | 01-4-Forge-SD-XL-Turbo |

## Why

Guard #8352 (`detect_markdown_rendering.py --check`) HARD-blocks any notebook whose cell#1 markdown starts with a `---\n...\n---` YAML block (markdown-it promotes it to a setext-H2 supersize rendering defect). Continuation of my merged #8418 (01-Foundation 5). On origin/main `caf5b93f2`, **15 Image landmines** remained (02-Advanced 5 / 03-Orchestration 3 / 04-Applications 4 / examples 3); this PR clears the 02-Advanced 5.

## Migration rules (canonical #8376)
- `title:` dropped (redundant with H1/navigation).
- top-level `notes:` merged INTO `cost.notes`.
- YAML `null` → JSON `null` (none present).
- `last_validated`/`validator` preserved verbatim (GPU-gated notebooks, format migration not re-exec).
- **0 code cells modified** (C.2 N/A).

## Forensic validation (all 5, ORIG-vs-NEW all-fields)
- **Telltale preservation** (c.713/c.714 bug-class): `free_alternative`, `reduced_pedagogical`, `vram_tier` ALL match ORIG verbatim with per-NB variation. **No nulling.** 15 cost keys each + notes merged.
- **0 code-cell churn**: source/`execution_count`/outputs byte-identical to origin/main (sha1 sig match, 59 code cells total).
- `detect_markdown_rendering.py --check 02-Advanced`: **OK** (no violations).
- `check_cost_metadata.py`: `cost_source='metadata'` **5/5**.
- `validate_pr_notebooks.py` (H.3): **5/5 PASS**.
- LF-only (CRLF=0).
- diff scope: +85/−145, 5 NB only (no catalogue churn, no collateral).

See #8056 (partial epic; 10 Image landmines remain: 03-Orchestration 3 / 04-Applications 4 / examples 3).

Co-Authored-By: Claude-Code <noreply@anthropic.com>