### PR TITLE
fix(genai-texte,#8052): NB-5 RAG — replace fabricated response quote with committed output

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/5_RAG_Modern.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/5_RAG_Modern.ipynb
@@ -2997,7 +2997,7 @@
     "\n",
     "**Analyse de la réponse** :\n",
     "\n",
-    "> \"The outcome of the debate... is not explicitly detailed in the provided text.\"\n",
+    "> « The text gives no formal winner. No official outcome was declared; however, public reaction in the account favored Lincoln — he was greeted with loud, protracted cheers from roughly two‑thirds of the audience. »\n",
     "\n",
     "**Points forts** :\n",
     "\n",


### PR DESCRIPTION
## Summary

`5_RAG_Modern.ipynb` cell[60] ("Analyse du reranking et gestion des limites") presented the model's response as a fabricated blockquote that is **absent from all committed outputs**. Replaced with the actual committed response from the reranking demo (code[57]).

| Cell | Before (fabricated) | After (actual code[57] output) |
|------|---------------------|-------------------------------|
| md[60] | `> "The outcome of the debate... is not explicitly detailed in the provided text."` | `> « The text gives no formal winner. No official outcome was declared; however, public reaction in the account favored Lincoln — he was greeted with loud, protracted cheers from roughly two-thirds of the audience. »` |

## The defect (#8052 class-2 narrative mismatch)

The cited quote is in **no** committed output (verified: 0 of 19 code cells contain `not explicitly detailed` / `outcome of the debate`). md[60] describes the reranking demo `code[57]` (`rag_with_reranking`, k=5, min_score=0.3):
- **k=5 / 5-after-filter / 0-filtered numbers ARE faithful** to code[57] (`Chunks récupérés: 5, après filtrage (score >= 0.3): 5`).
- **But the response quote was fabricated** — the model did not say "not explicitly detailed"; it gave the documented audience-reaction favoring Lincoln.

This also distorts the "Points forts" analysis: point #2 ("Contexte fourni: au lieu de dire 'je ne sais pas', il résume les échanges") is actually *more* accurate against the real output (which summarized audience reaction) than against the fabricated near-empty quote.

## Fix

Markdown-only — replace the blockquote with the actual committed response (verbatim). **No re-exec** (C.2 exception: aligning prose to the committed non-deterministic LLM output; outputs unchanged). Per secrets-hygiene règle 6 (Stop & Repair): did **not** hand-edit any committed output, only the markdown prose.

## Verification (firsthand, G.1)

- Searched **all 19 code-cell outputs**: fabricated-quote fragments absent from every cell; actual response present verbatim in code[57].
- Cross-checked the **other** interpretation cells (all faithful):
  - md[23] chunk counts `222/214/327` = code[18] exactly.
  - md[31] embeddings `51/51`, dim `3072` = code[30] exactly.
  - md[42] similarity scores `0.628/0.579/0.572` = code[41] exactly.
  - md[46] tokens `prompt 1634 / completion 822` (= 2456) = code[45].
- md[46] cost "~\$0.0074" **left as-is** (unverifiable without exact gpt-5-mini pricing — out of scope for this atomic fix).

## Validation
- `git diff`: **+1/−1** (1 line, 1 cell).
- code-cell sha1 sigs **unchanged** vs origin/main (19 cells).
- JSON valid; **CRLF=0** (LF-only); no CJK introduced.
- `validate_pr_notebooks.py` (H.3): **PASS** (19 code cells).
- No catalogue churn.

Part of the GenAI/Texte claims↔outputs audit frontier (#8052): NB-2 #8218, NB-3 #8241, NB-4 #8248 (mine), NB-15 (po-2023); this pierces NB-5. See #8052, #8369.

Co-Authored-By: Claude-Code <noreply@anthropic.com>