### PR TITLE
fix(planners-3-csharp,#8052): harmonize A* cost metric in Prong-B summary (cout 16->17)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-3-State-Space-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-3-State-Space-Csharp.ipynb
@@ -610,10 +610,10 @@
    "id": "e658a8a5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T07:38:57.806733Z",
-     "iopub.status.busy": "2026-07-06T07:38:57.806563Z",
-     "iopub.status.idle": "2026-07-06T07:38:57.968943Z",
-     "shell.execute_reply": "2026-07-06T07:38:57.968798Z"
+     "iopub.execute_input": "2026-07-25T03:02:56.395044Z",
+     "iopub.status.busy": "2026-07-25T03:02:56.394769Z",
+     "iopub.status.idle": "2026-07-25T03:02:56.576536Z",
+     "shell.execute_reply": "2026-07-25T03:02:56.576251Z"
     },
     "papermill": {
      "duration": 0.165913,
@@ -626,71 +626,71 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "=== Terrain pondere : BFS / Greedy / A* ===\r\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "Algo              Pas   Cout   Noeuds   Traverse marais ?\r\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "--------------------------------------------------\r\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "BFS               10    56     91       oui (5 cases)\r\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "Greedy            10    56     11       oui (5 cases)\r\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "A*                16    17     42       non\r\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "\r\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "BFS/Greedy : 10 pas (court) mais cout 56 (traverse le marais).\r\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "A*         : 16 pas (plus long) mais cout 16 (contourne le marais).\r\n"
+      "A*         : 16 pas (plus long) mais cout 17 (contourne le marais).\r\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "Seul A* minimise le COUT reel. C'est la ou A* discrimine (terrain uniforme -> A*=BFS).  \r\n"
      ]
@@ -738,7 +738,7 @@
     "\n",
     "Console.WriteLine();\n",
     "Console.WriteLine($\"BFS/Greedy : {bfsW.Count - 1} pas (court) mais cout {CoutChemin(bfsW, marais, coutMaraisLourd)} (traverse le marais).\");\n",
-    "Console.WriteLine($\"A*         : {astarW.Count - 1} pas (plus long) mais cout {astarWcost} (contourne le marais).\");\n",
+    "Console.WriteLine($\"A*         : {astarW.Count - 1} pas (plus long) mais cout {CoutChemin(astarW, marais, coutMaraisLourd)} (contourne le marais).\");\n",
     "Console.WriteLine(\"Seul A* minimise le COUT reel. C'est la ou A* discrimine (terrain uniforme -> A*=BFS).  \");\n"
    ]
   },
@@ -1033,7 +1033,7 @@
     "- **Greedy Best-First** : guide par h seul, rapide mais non optimal.\n",
     "- **A*** : `f = g + h`, optimal en COUT si h admissible (Manhattan).\n",
     "\n",
-    "**Le point cle (#3801 Prong B)** : sur terrain uniforme, BFS = A* (cas degenere). Sur **terrain pondere**, seul A* minimise le cout reel (16 pas / cout 16 en contournant le marais, vs BFS 10 pas / cout 55 en traversant). C'est la ou la capacite d'A* est visible dans la sortie — pas un exemple trivial.\n",
+    "**Le point cle (#3801 Prong B)** : sur terrain uniforme, BFS = A* (cas degenere). Sur **terrain pondere**, seul A* minimise le cout reel (16 pas / cout 17 en contournant le marais, vs BFS 10 pas / cout 56 en traversant). C'est la ou la capacite d'A* est visible dans la sortie — pas un exemple trivial.\n",
     "\n",
     "> Retour au [twin Python](Planners-3-State-Space.ipynb) — qui demontre la même chose visuellement (heatmap + chemins superposes)."
    ]

--- a/scripts/notebook_tools/twin_pairs.yaml
+++ b/scripts/notebook_tools/twin_pairs.yaml
@@ -1096,13 +1096,14 @@
   csharp: MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-3-State-Space-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-23"
-    by: po-2023
+    date: "2026-07-25"
+    by: po-2024
     python_sha: 8d03359d12709b134f644e187d04249b6e1fcadf
-    csharp_sha: 435f49ca3c491cf320ddd9b9471fecc94f759f41
+    csharp_sha: c80529e7f253a8e73c1fb3779cf55fc25ac4820b
   known_differences:
     - "Concept : recherche dans l'espace d'etats (BFS/DFS/A* sur le graphe des etats reachables)."
     - "Python : unified-planning engines. C# : from-scratch BFS/DFS/A* BCL .NET (meme algorithme, implementation idiomatic)."
+    - "Re-baseline 2026-07-25 (po-2024, PR #8436) : SHA C# avance depuis l'audit 2026-07-23 via #8436 (fix d'une inconsistance de metrique de cout dans la cellule Prong-B du twin C# : la ligne de resume A* utilisait astarWcost=16 au lieu de CoutChemin=17, contredisant sa propre table) ; drift verifie paraphite-preservant (Python twin non touche, parite semantique intacte, le fix corrige une incoherence interne au twin C#)."
 - name: "Planners-4 Fast-Downward"
   family: SymbolicAI/Planners
   python: MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-4-Fast-Downward.ipynb


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2024:CoursIA-2 — prev: MED/refactor (c.867 #8415)

## What

Fixes an internal cost-metric inconsistency in `Planners-3-State-Space-Csharp.ipynb` (Prong-B weighted-terrain BFS-vs-A* demonstration) where the **A* summary line reported a different cost metric than its own table row**.

**The bug (firsthand)** — cell[14] `PRONG B : terrain pondere`:

The numeric TABLE uses `CoutChemin(path, marais, coutMaraisLourd)` consistently for ALL three algorithms (BFS=56, Greedy=56, A*=**17**). But the prose SUMMARY lines that follow mixed metrics:

```csharp
// BFS summary — uses CoutChemin (=56), consistent with table
Console.WriteLine($"BFS/Greedy : ... cout {CoutChemin(bfsW, marais, coutMaraisLourd)} ...");   // -> 56

// A* summary — used astarWcost (the A* g-value = 16), NOT CoutChemin
Console.WriteLine($"A*         : ... cout {astarWcost} ...");                                   // -> 16  (WRONG metric)
```

So a reader saw the table `A* 16 17 42 non` (cout 17) immediately contradicted by the summary `A* ... cout 16`. The two "cout" columns meant different things: `CoutChemin` counts every cell incl. start; `astarWcost` (g-value) counts step-entry costs only. The conclusion (cell[21]) then propagated stale values: `"cout 55 en traversant"` (BFS — matches NEITHER the 56 table NOR any metric) and `"cout 16 en contournant"` (A* — the buggy g-value, not the 17 table value).

## Fix (root cause, not md-scrub)

1. **cell[14] source** — make the A* summary use `CoutChemin(astarW, ...)` (=17) so "cout" means the same thing everywhere (table, BFS summary, A* summary). The pedagogical point is unchanged and now honest: A* (cout 17) ≪ BFS (cout 56) on weighted terrain.
2. **cell[14] RE-EXEC** via dotnet-interactive — the output now reads `A* ... cout 17` (was 16), matching the table row.
3. **cell[21] conclusion** — corrected the propagated stale values: `cout 16 -> 17` (A*), `cout 55 -> 56` (BFS) to match the (now-consistent) cell[14] outputs.

## Why this is Stop&Repair, not an output scrub

The defect was NOT a markdown claim disconnected from code — the cell[14] OUTPUT ITSELF was internally inconsistent (its own summary line used a different metric than its own table). A pure md-fix of cell[21] would have left cell[14]'s self-contradictory summary line in place. Root-cause = harmonize the metric in cell[14] SOURCE, then re-exec.

## Validation (firsthand)

- Re-executed via the canonical `scripts/notebook_tools/exec_dotnet_persist.py` (jupyter_client cell-by-cell) — NOT raw `nbconvert`, which injects a `dotnet-interactive-this-cell-$CACHE_BUSTER$` HTML bootstrap `display_data` chrome that no committed sibling carries. `exec_dotnet_persist` produces clean outputs matching origin + all Planners C# siblings (0 HTML chrome).
- `strip_probe_banner.py --apply`: 0 probeAddresses (clean).
- C.1: 0 `raise NotImplementedError` / `assert False` / `1/0`.
- C.2: 0 error outputs, 0 code cells with `execution_count: null` (11/11 code cells executed, exec_count preserved 7/7 on cell[14]).
- 0 CRLF (`.gitattributes *.ipynb text eol=lf`).
- Surgical diff: source changed in EXACTLY cell[14] (code) + cell[21] (md); output changed in EXACTLY cell[14] out[8] (the A* summary line). All 10 other code cells byte-identical to origin (their papermill timestamps preserved — only cell[14] was re-executed, C.3).

```
cell[14] output (after fix):
=== Terrain pondere : BFS / Greedy / A* ===
Algo              Pas   Cout   Noeuds   Traverse marais ?
--------------------------------------------------
BFS               10    56     91       oui (5 cases)
Greedy            10    56     11       oui (5 cases)
A*                16    17     42       non
BFS/Greedy : 10 pas (court) mais cout 56 (traverse le marais).
A*         : 16 pas (plus long) mais cout 17 (contourne le marais).   <- was 16, now matches table=17
```

`See #3801` (Prong-B problem-richness — the A*-discriminates-on-weighted-terrain demo is the canonical non-degenerate case; this fix makes its reported numbers internally consistent). `See #8052` (audit-claims canal).

## Adjacency

- Distinct from prior #3760 (align A*-vs-BFS interpretation) and #3771 (weighted-terrain example) — those MERGED PRs created the demo; this fixes a metric-consistency defect in its committed output.

## Twin-parity SHA rebaseline (commit 2)

Planners-3-State-Space-Csharp.ipynb is a **registered twin** (registered in the merged #8415). Changing its content shifts its blob SHA, so the twin-parity `--per-pair` CI gate flagged `drift_introduced=1` (register-SHA 435f49ca != new tree-SHA c80529e7). Per the C867-L convention, a PR that changes a registered twin MUST rebaseline its SHA in the same PR. This commit updates `scripts/notebook_tools/twin_pairs.yaml`:
- `csharp_sha`: 435f49ca -> c80529e7
- `last_audit`: 2026-07-23/po-2023 -> 2026-07-25/po-2024
- new `known_differences` bullet documenting the drift (parity-preserving: Python twin untouched, semantic parity intact, fix corrects an internal metric inconsistency in the C# twin).

Local verification (same flag as CI):
```
mode: per_pair  total: 76  ok: 76  drift_introduced: 0  drift_resolved: 0  drift_pre_existing: 0
```

Co-Authored-By: Claude-Code <noreply@anthropic.com>
