### PR TITLE
fix(smartcontracts,#8428): remove CJK residue in SC-26-Final-Project (任何人)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-26-Final-Project.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-26-Final-Project.ipynb
@@ -263,7 +263,7 @@
     "**Fonctions a implementer** :\n",
     "- `registerVoter(address voter)` : Admin uniquement, phase Registration\n",
     "- `submitBallot(bytes calldata encryptedBallot, bytes calldata proof)` : Phase Voting\n",
-    "- `tally()` :任何人 peut declencher, phase Tallying\n",
+    "- `tally()` : **n'importe qui** peut declencher, phase Tallying\n",
     "- `verifyProof(bytes calldata proof)` : Verifie la ZKP avant d'accepter le bulletin\n",
     "\n",
     "**Propriete de securite** : Un electeur ne peut voter qu'une seule fois (verifier `encryptedBallots[voter] == bytes(0)`).\n",


### PR DESCRIPTION
## SmartContracts slice of fleet-wide CJK sweep (#8428)

`#8428` (po-2026 c.720): LLM-translation residue left Chinese words mid-French prose. This PR fixes the **SmartContracts family** (1 notebook, 3 glyphs).

### Fix (context-accurate)

| Notebook (cell) | Before | After | Meaning |
|-----------------|--------|-------|---------|
| `SC-26-Final-Project` (c6, markdown) | `tally() :任何人 peut declencher` | `tally() : **n'importe qui** peut declencher` | 任何人 = *anyone* |

In the `VotingSystem` contract (SC-26 capstone), `tally()` is callable by **anyone** during the `Tallying` phase — a real access-control property, so the translation is semantically correct, not a placeholder.

### Family audit (substance-first)

Before fixing, I G.1-audited the **entire SmartContracts family** (SC-0 → SC-26, 20 notebooks on `origin/main`) for content defects:
- **CJK**: only SC-26 has CJK (3 glyphs). SC-0..SC-25 all clean.
- **Code errors**: SC-26 has 0 error cells, 0 null `execution_count`.
- No other content-honesty defects found in this cell.

### Method

- Byte-surgical raw-text replacement (not NotebookEdit, not json.dumps).
- Markdown-only cell → C.2 exception (no re-execution). 0 code cells touched, 0 outputs modified (Stop & Repair respected).
- LF-only verified (0 CRLF).

### Validations

- `notebook_tools.py validate --quick` : **1/1 OK, 0 errors, 0 warnings**
- `git diff --stat` : **+1/−1 strict**, only source text changed
- CJK count **3 → 0** (verified)
- 0 `raise NotImplementedError` / `assert False` / `1/0` (C.1)
- Catalogue byte-identique (catalog-pr-hygiene R1)
- 0 secret-pattern matches

### Coordinated #8428 sweep

Parallel sessions: Lean family (#8433, mine c.898), Sudoku-13 (#8434), CSP-9 (#8430). This PR adds SmartContracts. Remaining families: GenAI/Environment, GenAI/Applications, ML/ML.Net, Search/Part1, SocialChoice, SymbolicLearning SL-4, QC/research (+ QC-Py-Cloud-03 code-comment needs re-exec).

`See #8428` (partial: SmartContracts family).

Co-Authored-By: Claude <noreply@anthropic.com>