### PR TITLE
fix(genai-texte,#8052): NB-8 Reasoning — align fabricated timing claims to committed output

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/8_Reasoning_Models.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/8_Reasoning_Models.ipynb
@@ -564,8 +564,8 @@
     "Dans cet exemple, les deux modèles ont donné la bonne réponse (74 pommes), mais observez :\n",
     "\n",
     "**Temps de réponse** :\n",
-    "- gpt-5-mini (chat mode) : ~0.78s (réponse immédiate)\n",
-    "- gpt-5-mini (reasoning mode) : ~4.67s (temps de réflexion inclus)\n",
+    "- gpt-5-mini (chat mode) : ~5.60s\n",
+    "- gpt-5-mini (reasoning mode) : ~3.58s (sur cette exécution, plus rapide que le mode chat)\n",
     "\n",
     "**Précision** :\n",
     "- Sur ce problème simple, les deux modes réussissent\n",
@@ -576,7 +576,7 @@
     "- Calculs nécessitant de garder plusieurs valeurs en mémoire\n",
     "- Raisonnement nécessitant de tester plusieurs hypothèses\n",
     "\n",
-    "**Trade-off** : Le mode raisonnement prend ~6x plus de temps mais offre une meilleure garantie de précision sur les problèmes complexes. À vous de choisir selon vos besoins !\n",
+    "**Trade-off** : Le mode raisonnement peut ajouter un temps de réflexion (et donc de la latence) en échange d'une meilleure garantie de précision sur les problèmes complexes. L'écart de latence varie selon la charge du service — ici il était négligeable. À vous de choisir selon vos besoins !\n",
     "\n",
     "> **Note technique** : Ici, nous utilisons le même modèle (gpt-5-mini) dans deux modes différents. Le mode chat est le mode par défaut (rapide), tandis que le mode reasoning active le paramètre `reasoning_effort` pour une analyse plus approfondie."
    ]


### PR DESCRIPTION
## Summary

`8_Reasoning_Models.ipynb` cell[10] cited fabricated response timings AND an inverted narrative contradicting the committed output of the comparison cell[9]. Aligned the markdown to the actual committed numbers.

| Claim (md[10]) | Before (fabricated) | After (actual code[9] output) |
|----------------|---------------------|-------------------------------|
| chat timing | `~0.78s (réponse immédiate)` | `~5.60s` |
| reasoning timing | `~4.67s (temps de réflexion inclus)` | `~3.58s (sur cette exécution, plus rapide que le mode chat)` |
| trade-off | `prend ~6x plus de temps` | `peut ajouter un temps de réflexion... l'écart varie selon la charge — ici négligeable` |

## The defect (#8052 timing inversion — same pattern as NB-2 #8218)

code[9] committed output:
```
openai/gpt-5-mini (5.60s): Réponse: 74
openai/gpt-5-mini avec reasoning_effort (3.58s): Réponse: 74
```

md[10] claimed the **opposite** direction — chat `0.78s` (instant) vs reasoning `4.67s` (~6× slower). The committed output shows reasoning was actually **faster** (3.58s < 5.60s) on this run, and both timings were wrong. This is the timing-inversion pattern first pierced on NB-2 (#8218): interpretation markdown written as a prior expectation, never re-read against the committed non-deterministic LLM output.

## Fix

Markdown-only — cite the actual committed timings and replace the `~6x plus de temps` fabrication with an honest statement that reasoning CAN add latency (valid pedagogical point) but the gap is non-deterministic and was negligible on this run. **No re-exec** (C.2 exception: LLM latencies are non-deterministic; align prose to the committed source-of-truth output). Per secrets-hygiene règle 6 (Stop & Repair): did **not** hand-edit any committed output, only the markdown prose.

## Verification (firsthand, G.1)
- The 74-pomme answer + both timings (`5.60s` chat / `3.58s` reasoning) verified verbatim in code[9] output.
- **NB-6 (PDF_Web_Search)** and **NB-7 (Code_Interpreter)** audited faithful this cycle (no defect — all interpretation cells verified against outputs); the NB-7 "mode local" naming is honestly noted by the code cells and the markdown is conceptual Code-Interpreter teaching, so no fix.

## Validation
- `git diff`: **+3/−3** (3 lines, 1 cell, same array-element count).
- code-cell sha1 sigs **unchanged** vs origin/main (14 cells).
- JSON valid; **CRLF=0** (LF-only); no CJK introduced.
- `validate_pr_notebooks.py` (H.3): **PASS** (14 code cells).
- No catalogue churn.

Part of the GenAI/Texte claims↔outputs audit frontier (#8052): NB-2 #8218, NB-3 #8241, NB-4 #8248, NB-5 #8435 (mine), NB-15 (po-2023). This pierces NB-8. See #8052.

Co-Authored-By: Claude-Code <noreply@anthropic.com>