### PR TITLE
fix(sl-10-csharp,#8052): align parité PAC claim with C# output (N=1 fails, N=10 ok)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-10-ActiveAutomataLearning-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-10-ActiveAutomataLearning-Csharp.ipynb
@@ -1241,10 +1241,11 @@
    "source": [
     "### Interpretation : tout depend de la densite des desaccords\n",
     "\n",
-    "Sur les **parites**, un seul mot aleatoire par appel suffit déjà : une hypothese\n",
-    "fausse y est en desaccord avec la cible sur environ un mot sur quatre, le premier\n",
-    "tirage venu fait office de contre-exemple. La garantie *semble* intacte --- mais\n",
-    "c'est une propriete du langage, pas de l'algorithme.\n",
+    "Sur les **parites**, les desaccords sont suffisamment denses pour que peu\n",
+    "d'essais suffisent : des N=10, l'EQ trouve les 4 etats exacts. A N=1, un seul mot\n",
+    "peut manquer le contre-exemple (l'approximation retourne un DFA a 2 etats non\n",
+    "exact) --- la garantie *semble* intacte, mais c'est une propriete du langage,\n",
+    "pas de l'algorithme.\n",
     "\n",
     "Sur le **langage-aiguille**, un mot aleatoire de longueur $\\le 20$ ne contient le\n",
     "facteur qu'avec une probabilite de quelques pourcents. A $N = 1$ ou $10$ essais,\n",
@@ -1260,7 +1261,8 @@
     "(le LLM) etait discipline par un oracle exact ; ici, un apprenant exact est\n",
     "fragilise par un oracle faillible. Dans un pipeline neuro-symbolique, *identifier\n",
     "qui joue le rôle de l'oracle et ce qu'il garantit vraiment* est la première\n",
-    "question d'architecture.\n"
+    "question d'architecture.\n",
+    ""
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-dotnet (c.868 #8436)

## What

Fixes a markdown-vs-output contradiction in `SL-10-ActiveAutomataLearning-Csharp.ipynb` cell[18] (interpretation of the PAC-learning / L* demonstration): the markdown claimed **"un seul mot aléatoire par appel suffit"** for the **parités** language, but the committed C# output (cell[17]) shows **N=1 → NON** (DFA à 2 états, non exact).

**Firsthand evidence (cell[17] C# output):**
```
Langage parites (desaccords DENSES) :
 N essais | etats | DFA exact ?
        1 |     2 | NON      <-- N=1 FAILS (2-state non-exact DFA)
       10 |     4 | OUI
      100 |     4 | OUI
     1000 |     4 | OUI
```

**Root cause:** the cell[18] C# markdown was copied verbatim from the **Python twin** (`SL-10-ActiveAutomataLearning.ipynb`), where the claim IS true — Python cell[17] shows `N=1 | 4 | OUI` for parités. The C# L* implementation returns a non-exact 2-state DFA at N=1 (different RNG / approx behavior), so the same prose is false on the C# side. The markdown was never re-synced to the C# run.

## Fix (markdown-only, C.2 exception — outputs are the truth)

Rephrased the parites sentence to match the C# output: "les désaccords sont suffisamment denses pour que peu d'essais suffisent : dès N=10, l'EQ trouve les 4 états exacts. À N=1, un seul mot peut manquer le contre-exemple (l'approximation retourne un DFA à 2 états non exact)". The qualitative pedagogical point survives intact (parites = dense disagreements → few samples suffice, vs langage-aiguille = rare disagreements → N=100 needed), and the langage-aiguille paragraph + the SL-9 analogy closing are unchanged (both correct for C#).

- **No re-exec** (markdown-only edit; C.2 exception — committed outputs remain valid, untouched).
- **Measured, not speculative (C855-L):** the new phrasing cites exactly what cell[17] C# output reports (N=1 → 2 états NON ; N=10 → 4 états OUI). The unsourced "un mot sur quatre" probability claim was removed (not supported by any C# output).

## Validation (firsthand)

- `git diff`: source changed in EXACTLY cell[18]; outputs changed in ZERO cells (markdown-only confirmed).
- 0 CRLF (`.gitattributes *.ipynb text eol=lf`).
- **NOT a registered twin** (`grep SL-10 scripts/notebook_tools/twin_pairs.yaml` → empty) → no SHA rebaseline needed (C868-L checklist clear). The Python twin is also unregistered; this PR touches only the C# side.
- G.1/G.9: this defect was surfaced by a sonnet read-only recon of the SymbolicLearning family; I verified it firsthand (cell[17] C# output) before fixing, and rejected the recon's SL-3 "29 triplets" finding as a **FALSE POSITIVE** (measured firsthand: 29 IS the correct determination count on C(10,3)=120 triplets — separate, not addressed here). SL-9 (6 defects, LLM-non-reproducibility, design-gated) opened as issue #8440.

`See #8052` (audit-claims canal). `See #3801` (axis-2 SOTA — the L*/EQ learner is the notebook's SOTA-relevant engine; honest reporting of its PAC guarantees matters).

## Adjacency

- Distinct from #6021 (Conclusion header prefix drop, MERGED) and #3734 (ILP citations) — those touched other SL cells; this fixes a parity-claim markdown-vs-output drift specific to the C# twin.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
