### PR TITLE
fix(sl-12,#8052): align Resume bullet to committed difflogic output

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-12-DifferentiableLogicGateNetworks.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-12-DifferentiableLogicGateNetworks.ipynb
@@ -952,7 +952,7 @@
     "\n",
     "- **Lib SOTA** : [Felix-Petersen/difflogic](https://github.com/Felix-Petersen/difflogic) (MIT, NeurIPS 2022, arXiv 2210.08277).\n",
     "- **API cle** : `LogicLayer(in, out)`, `GroupSum(k, tau)`, `CompiledLogicNet(model)`.\n",
-    "- **MNIST 20x20** : accuracy ~80-88% avec k=2000, l=3 (3 couches intermediaires) en CPU 2K iters.\n",
+    "- **MNIST 20x20** : accuracy ~0.81 (8098/10000 ; fourchette attendue 80-88%) avec GroupSum k=10 et 3 couches intermediaires (LogicLayer dim 2000). Execution commitee : DEVICE=cuda, implementation python (nvcc absent), 600 iters (1 epoque -- le dataloader s'épuise avant la cible N_ITERS=2000)\n",
     "- **Universalite booleenne** : 16 portes logiques, dont NAND seul est Turing-complet.\n",
     "- **Inference ultra-rapide** : 1M images/s sur 1 core CPU via `CompiledLogicNet` (RECOVERABLE-MACHINE, gcc requis).\n",
     "\n",


### PR DESCRIPTION
## Summary

SL-12 (DifferentiableLogicGateNetworks) `## Resume` bullet claimed `accuracy ~80-88% avec k=2000, l=3 (3 couches intermediaires) en CPU 2K iters`. Firsthand audit (claims↔outputs #8052) found **three inversions** vs the committed output + code config:

| Claim (md[24]) | Committed truth (code[5]/[9]/[10] output) |
|---|---|
| `k=2000` | `GroupSum(k=10, tau=30)` — 2000 is the `LogicLayer` hidden dim, not GroupSum k |
| `en CPU` | `DEVICE : cuda`, `Implementation : python` (CUDA Toolkit match False / nvcc absent) |
| `2K iters` | training terminated at `iter 600/2000` then `Entrainement termine en 18.2s` — the `train_loader` (batch_size=100 × 60000) exhausts after 1 epoch, before the `N_ITERS=2000` break fires |

**Accurate parts preserved**: accuracy range (test `0.810 / 8098/10000` ∈ expected `~80-88%` from code[10]) and `l=3` (3 `LogicLayer` intermediate layers, dim 2000).

## Validation

- Markdown-only (1 line, +1/−1 in `## Resume` cell[24]).
- **C.2 exception**: committed training outputs are non-deterministic (re-exec produces different timings/losses) → outputs are the source of truth; prose aligned to them, no re-exec.
- **Code-cell sha1 signature unchanged** vs origin/main (all code outputs byte-identical).
- secrets-hygiene règle 6 honored — no committed output hand-edited.
- JSON valid, LF-only (CRLF=0), no catalogue churn, H.3 PASS.

## Scope

Single-line markdown fix. `cell[2]` Plan (`2000 itérations (CPU-safe)`) left untouched — it accurately describes the configured target (`N_ITERS=2000`) and the portability design; the inversion is in the Resume's factual summary of the achieved result. The `#8440` SL-9 design-gated decision (Option A/B/C) is **out of scope** (flagged to ai-01, not po-2024-fixable).

See #8052.

Co-Authored-By: Claude-Code <noreply@anthropic.com>