### PR TITLE
feat(twin-register,#8057): register ML-6-ONNX C#<->Python parity pair (gap ML-5->ML-7 closed)

### DIFF
--- a/scripts/notebook_tools/twin_pairs.yaml
+++ b/scripts/notebook_tools/twin_pairs.yaml
@@ -313,6 +313,22 @@
     - "Aucune lib Python n'expose SSA de facon pedagogique equivalente ; le pendant Python choisit donc l'approche statistique classique (STL+SARIMAX) pour couvrir le meme besoin (forecast saisonnier) avec un OUTIL different."
     - "parity_level = surface : meme probleme (prevision de series temporelles avec saisonnalite) mais algorithmes distincts (SSA spectral vs STL/SARIMAX statistique). Les resultats numeriques ne sont pas directement comparables ; c'est une parite de OBJECTIF pedagogique, pas de methode."
 
+- name: "ML-6 ONNX Integration"
+  family: ML.NET/Python
+  python: MyIA.AI.Notebooks/ML/ML.Net/ML-6-ONNX-Python.ipynb
+  csharp: MyIA.AI.Notebooks/ML/ML.Net/ML-6-ONNX.ipynb
+  parity_level: semantic
+  last_audit:
+    date: '2026-07-25'
+    by: po-2023
+    python_sha: 1694d32c7760664f121c62bd2eb4bc5f7b45e00c
+    csharp_sha: 718a3f70dc68c1c3eb39cdefef10e2a85d19b4f7
+  known_differences:
+    - "Socle pedagogique commun : integration de modeles ONNX (chargement, inference, inspection du graph, exercices). C# = ML.NET OnnxTransformer + OnnxRuntime ; Python = skl2onnx (export sklearn->ONNX) + onnxruntime (inference) + onnx (inspection structurelle). Cree comme twin de parite explicite en #5607 (EPIC #4956 .NET<->Python)."
+    - "Asymetrie export-vs-load (pont Python->.NET) : le C# charge un modele ONNX pre-exporte (iris_model.onnx genere par scripts/ml/generate_iris_onnx.py, RandomForest sklearn) car l'export ML.NET->ONNX est experimental (documente en commentaire, c13/c15) ; le Python effectue l'export sklearn->ONNX lui-meme via skl2onnx (opset 15, zipmap=False). Le twin Python est le cote 'producteur' du pont ONNX, le C# le cote 'consommateur'."
+    - "Idiomes framework : C# = `mlContext.Transforms.ApplyOnnxModel` + classes d'entree/sortie typoes (IrisOnnxInput) ; Python = `ort.InferenceSession(onnx_path)` + `onnx.load` (validation structurelle du graph) + `convert_sklearn` (export)."
+    - "Contenu pedagogique complementaire : C# couvre 6 exercices stub (TODO : classes entree/sortie immobilier, variation FastTree, comparaison formats natif-vs-ONNX, inspection metadonnees, prediction par lot, integration Iris) + section conceptuelle BERT ONNX ; Python couvre 3 exercices (export LogisticRegression, impact n_estimators sur speedup, export Pipeline StandardScaler+classifieur) + benchmark sklearn.predict vs onnxruntime. Meme concept (ONNX interchange), angles d'approche differents."
+
 - name: "ML-7 Recommendation"
   family: ML.NET/Python
   python: MyIA.AI.Notebooks/ML/ML.Net/ML-7-Recommendation-Python.ipynb


### PR DESCRIPTION
## Register the ML-6-ONNX twin pair — closes a registration gap (ML-5 → ML-7 was skipping ML-6)

**Grain:** MED/twin-register-metadata — lane `myia-po-2023:CoursIA` — R6 genre pivot (≠ cost-mig c.901/#8438 + c.902/#8445)
**Issue:** [#8057](https://github.com/jsboige/CoursIA/issues/8057) (twin parity metadata epic)
**Branch:** `feature/ml6-onnx-twin-register-8057`
**Scope:** 1 file, +16/-0 strict (pure addition to `scripts/notebook_tools/twin_pairs.yaml`)

### The gap

`ML-6-ONNX-Python.ipynb` was created in [#5607](https://github.com/jsboige/CoursIA/pull/5607) (EPIC [#4956](https://github.com/jsboige/CoursIA/issues/4956) .NET↔Python parity) as an **explicit parity twin** of `ML-6-ONNX.ipynb` (title: *"ML-6 Python (skl2onnx + onnxruntime) parity twin"*), but was **never registered** in `twin_pairs.yaml`. The ML.NET sequence jumped `ML-5 → ML-7`, leaving ML-6 unregistered. This PR closes the gap → ML-1..ML-9 complete.

### Semantic parity audit (firsthand, both notebooks read cell-by-cell)

| Aspect | C# (`ML-6-ONNX.ipynb`, 12 code cells) | Python (`ML-6-ONNX-Python.ipynb`, 10 code cells) |
|--------|---------------------------------------|--------------------------------------------------|
| Concept | ONNX integration (load + infer + inspect) | ONNX integration (export + infer + inspect) |
| Framework | ML.NET `OnnxTransformer` + `OnnxRuntime` | `skl2onnx` + `onnxruntime` + `onnx` |
| Idiom | `ApplyOnnxModel` + typed `IrisOnnxInput` class | `ort.InferenceSession` + `onnx.load` + `convert_sklearn` |
| Model source | loads pre-exported `iris_model.onnx` (sklearn RF via `generate_iris_onnx.py`) | exports sklearn RF → ONNX itself (opset 15, zipmap=False) |
| Exercises | 6 stubs (TODO: classes, FastTree, format compare, metadata inspect, batch predict, Iris) + BERT conceptual | 3 stubs (LogReg export, n_estimators speedup, Pipeline export) + benchmark |

**parity_level = semantic** — same ONNX-interchange concept, different framework entry points.

### Key documented asymmetry (the Python→.NET bridge)

C# loads a pre-exported ONNX (ML.NET→ONNX export is experimental, commented c13/c15); Python performs the sklearn→ONNX export itself. The Python twin is the **"producer"** side of the ONNX bridge, C# the **"consumer"** side — complementary halves of the #4956 bridge, not an idiomatic mirror.

### Validations (firsthand)

| Check | Result |
|-------|--------|
| `yaml.safe_load` | OK (77 pairs total, +1) |
| `check_twin_parity.py --check --per-pair --base origin/main` | `drift_introduced=0, drift_pre_existing=0` |
| ML-6 entry recognized | name/SHAs/parity_level correct |
| Collision guard (`gh pr list --search "ML-6-ONNX twin"`) | 0 (no prior registration PR) |
| Diff scope | 1 file, +16/-0 (pure addition) |

See #8057
See #4956

Co-Authored-By: Claude-Code <noreply@anthropic.com>