### PR TITLE
fix(sl-2,#8052): align EBL wall-clock numbers to committed output

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-2-KnowledgeBasedLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-2-KnowledgeBasedLearning.ipynb
@@ -2262,7 +2262,7 @@
     "| Metrique | Sans EBL | Avec EBL | Verdict |\n",
     "|----------|---------:|---------:|---------|\n",
     "| **Étapes** (déterministe) | 101 | 67 | EBL gagne : **1.51x**, -34% |\n",
-    "| **Temps wall-clock** (mediane) | ~520 us | ~860 us | EBL **perd** : ~0.6x |\n",
+    "| **Temps wall-clock** (mediane) | ~148 us | ~336 us | EBL **perd** : ~0.44x |\n",
     "\n",
     "(Les chiffres wall-clock précis fluctuent avec la charge CPU ; le **classement**, lui, est stable : l'EBL est ici plus lente en temps alors qu'elle gagne en étapes.)\n",
     "\n",


### PR DESCRIPTION
## Summary

SL-2 (KnowledgeBasedLearning) `### Interpretation` speedup table (cell[36]) had **wrong wall-clock numbers** vs the committed code[35] output (claims↔outputs #8052):

| md[36] row | md claim | code[35] committed output |
|---|---|---|
| **Étapes** (deterministic) | 101 → 67, **1.51x**, −34% | 101 → 67, 1.51x, 34 steps (34%) ✓ **matches** |
| **Temps wall-clock** (median) | ~520 us / ~860 us / **~0.6x** | **147.8 us / 336.3 us / 0.44x** ✗ |

The steps metric was correct, but the wall-clock absolute µs values and ratio were wrong. code[35]'s own Q1 answer even confirms `en TEMPS wall-clock, l'EBL est ici plus LENT (0.44x)` — so the markdown contradicted the cell it was interpreting. Markdown was likely written from a run on a different machine/load.

**Pedagogical conclusion unchanged & valid**: EBL *loses* on wall-clock here (slower, not faster) despite winning on steps — the Minton (1990) *utility problem* (search cost among learned rules dominates the step gain on this toy-example of 3 rules). Only the precise numbers are aligned.

## Validation

- Markdown-only (1 table cell, +1/−1 in md[36]).
- **C.2 exception**: wall-clock timing is non-deterministic (fluctuates with CPU load) → committed output is the source of truth; prose aligned to it, no re-exec.
- **Code-cell sha1 signature unchanged** vs origin/main (all code outputs byte-identical).
- The existing `~` qualifier + note *"Les chiffres wall-clock précis fluctuent avec la charge CPU"* already hedge for non-determinism — the committed snapshot is the honest anchor.
- secrets-hygiene règle 6 honored — no committed output hand-edited.
- JSON valid, LF-only (CRLF=0), no catalogue churn, H.3 PASS.

## Scope

Single-line markdown fix to the speedup table. Steps row left untouched (was correct). Other cells (md[33] usage counts `1*(0+z)` 8x / `1*v` 2x / `0+w` 1x) spot-checked faithful vs their outputs.

See #8052.

Co-Authored-By: Claude-Code <noreply@anthropic.com>