### PR TITLE
fix(ict-15b,#8052): align OR sensitivity claim to committed output (s=1 -> s=4)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15b-SensitivityCanonicity.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15b-SensitivityCanonicity.ipynb
@@ -1180,7 +1180,7 @@
    "source": [
     "### Exemple guide 3 -- Lean comme oracle\n",
     "\n",
-    "Le theoreme de Huang est formalise dans `sensitivity_lean/Spectral/SensitivityDegree.lean` avec **0 sorry**. Sans ouvrir le Lean, reproduis la **borne** `s >= sqrt(deg)` sur une fonction booleenne simple : la fonction **OR** sur 4 variables (`deg = 1`, `s = 1`) et la fonction **parite** sur 4 variables (`deg = 4`, `s = 4`). Verifie que les deux respectent la borne.\n",
+    "Le theoreme de Huang est formalise dans `sensitivity_lean/Spectral/SensitivityDegree.lean` avec **0 sorry**. Sans ouvrir le Lean, reproduis la **borne** `s >= sqrt(deg)` sur une fonction booleenne simple : la fonction **OR** sur 4 variables (`deg = 1`, `s = 4`) et la fonction **parite** sur 4 variables (`deg = 4`, `s = 4`). Verifie que les deux respectent la borne.\n",
     "\n",
     "> **Note pedagogique** : la cellule code suivante execute la solution complete. Cf **Exercice 3** plus bas pour la variante sur la fonction MAJ (majorite sur 4 variables)."
    ]


### PR DESCRIPTION
## Summary

`#8052` claims↔outputs audit (IIT/PyPhi frontier). `ICT-15b-SensitivityCanonicity.ipynb` **md[27]** claimed the OR function on 4 variables has `deg = 1, s = 1`, but the **committed code[28] output** prints:

```
OR(n=4) : s = 4, sqrt(deg=1) = 1.00, borne respectee : True
Parite(n=4) : s = 4, sqrt(deg=4) = 2.00, borne respectee : True
```

### G.1 verification (firsthand)

`boolean_sensitivity(truth_table)` computes `s_max = max over all inputs of sensitive-bit count`. For `OR_4` at the all-zero input `(0,0,0,0)`, every one of the 4 bits is sensitive (flipping any bit `0→1` changes `OR` from `0→1`), so `s_max = 4`. The committed output `s = 4` is mathematically correct. The markdown `s = 1` is a genuine defect — likely conflated with `deg = 1`.

The Huang sensitivity bound `s ≥ √deg` is **still satisfied** with the corrected value (`4 ≥ 1`), so the "Verifie que les deux respectent la borne" narrative holds — only the cited value was wrong. The parity case already matched (`s = 4` in both md and output).

## Scope

- **Markdown-only** edit (C.2 exception: committed output is truth, no code re-exec needed).
- 1 line changed (`s = 1` → `s = 4`), all 17 code cells byte-identical (exec_count + outputs preserved).

## Verification

- JSON valid.
- `git diff origin/main` = 1 insertion / 1 deletion, single markdown cell.
- OR truth-output (`OR(n=4) : s = 4`) unchanged.
- Pre-existing: 1 code cell (setup) has no outputs on `origin/main` — **not introduced** by this PR (markdown-only), out of scope.

## Defect class

Same family as #8297 (ICT-2 categorical), #8449 (SK-1 fabricated quote), #8450 (SL-2 wall-clock): markdown interpretation claim misaligned with committed output.

See #8052

Co-Authored-By: Claude <noreply@anthropic.com>