### PR TITLE
fix(search,#8428): remove CJK residue from Search-9-LP-Csharp

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming-Csharp.ipynb
@@ -517,7 +517,7 @@
    "source": [
     "## 5. Programmation Linéaire en Nombres Entiers (PLNE)\n",
     "\n",
-    "Quand les variables doivent être **entières** (on ne peut produire 2,3 unités) ou **binaires** (décision oui/non), on bascule en PLNE. Le solveur **CBC** (COIN-OR Branch-and-Cut) explore un arbre de分支 en résolvant des relaxations continues — c'est NP-difficile mais CBC le gère efficacement pour les tailles pédagogiques.\n",
+    "Quand les variables doivent être **entières** (on ne peut produire 2,3 unités) ou **binaires** (décision oui/non), on bascule en PLNE. Le solveur **CBC** (COIN-OR Branch-and-Cut) explore un arbre de branchement en résolvant des relaxations continues — c'est NP-difficile mais CBC le gère efficacement pour les tailles pédagogiques.\n",
     "\n",
     "### Problème du sac à dos\n",
     "\n",


### PR DESCRIPTION
## Summary

Removes the last CJK LLM-translation residue in the **Search** family: `Search-9-LinearProgramming-Csharp.ipynb` cell[13].

| Cell | Before | After |
|------|--------|-------|
| cell[13] (markdown) | `arbre de分支` | `arbre de branchement` |

`分支` = Chinese for "branch/branching"; the correct French PLNE term for the CBC branch-and-cut tree (the sentence describes CBC exploring a branching tree via continuous relaxations).

## Context (#8428)

Fleet-wide CJK glyph corruption (#8428). The Search family had 2 instances: CSP-9-Distributed (already fixed via #8430) and this one (Search-9-LP). This PR closes the Search family.

**G.1 note:** the #8428 issue-body inventory had gone stale — its Lean rows were already fixed by #8433 (my c.8428). I fleet-rescanned `origin/main` firsthand rather than trusting the inventory, which is how I confirmed Search-9 as the sole remaining Search-family instance.

## Validation

- **Markdown-only** (C.2 exception — no re-exec).
- Code-cell source churn = **0** (sha-verified; 8 code cells unchanged).
- H.3 validator PASS (`validate_pr_notebooks.py`, 8 cells, `.net-csharp`).
- Byte-surgical json round-trip; CJK count in source = 0 post-fix; byte-idempotent; LF (this notebook uses no-trailing-newline format, preserved).
- diff +1/−1.

See #8428

🤖 Generated with [Claude Code](https://claude.com/claude-code)