### PR TITLE
fix(genai-sk,#8052,#8364): SK-7 vision — replace failed URL fetch with base64 + re-exec

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/07-SemanticKernel-MultiModal.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/07-SemanticKernel-MultiModal.ipynb
@@ -572,7 +572,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "id": "9c24fd3d",
    "metadata": {
     "execution": {
@@ -595,13 +595,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Image a analyser: https://upload.wikimedia.org/wikipedia/commons/thu...\n"
+      "Image a analyser: https://cataas.com/cat?type=square...\n"
      ]
     },
     {
      "data": {
       "text/html": [
-       "<img src=\"https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Cat03.jpg/1200px-Cat03.jpg\" width=\"300\"/>"
+       "<img src=\"https://cataas.com/cat?type=square\" width=\"300\"/>"
       ],
       "text/plain": [
        "<IPython.core.display.Image object>"
@@ -614,17 +614,37 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Erreur: (\"<class 'semantic_kernel.connectors.ai.open_ai.services.open_ai_chat_completion.OpenAIChatCompletion'> service failed to complete the prompt\", BadRequestError(\"Error code: 400 - {'error': {'message': 'Error while downloading https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Cat03.jpg/1200px-Cat03.jpg.', 'type': 'invalid_request_error', 'param': None, 'code': 'invalid_image_url'}}\"))\n"
+      "Image encodee en base64 : 111710 octets\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Description de l'image:\n",
+      "----------------------------------------\n",
+      "L'image montre un chat assis confortablement à l'intérieur d'une botte en feutre. La botte est posée sur un tapis à motifs, près d'autres chaussures, dont une autre botte en feutre renversée, une paire de chaussures en cuir marron, et une bouteille verte avec un bouchon rose. Le mur en arrière-plan est en bois clair, ce qui donne à la scène un aspect chaleureux et rustique. Le chat a l'air détendu et semble profiter de son perchoir insolite.\n"
      ]
     }
    ],
    "source": [
     "# Analyse d'une image\n",
-    "# Utilisons une image publique pour l'exemple\n",
-    "image_url = \"https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Cat03.jpg/1200px-Cat03.jpg\"\n",
+    "# Source fiable : cataas.com. Les URLs Wikimedia renvoient 403 aux recuperations\n",
+    "# programmees, ce qui declenche un 400 invalid_image_url cote OpenAI (fetch bloque).\n",
+    "image_url = \"https://cataas.com/cat?type=square\"\n",
     "\n",
     "print(f\"Image a analyser: {image_url[:50]}...\")\n",
     "display(Image(url=image_url, width=300))\n",
+    "\n",
+    "# Telecharger l'image et l'encoder en base64 : OpenAI n'a alors pas a re-telecharger\n",
+    "# l'URL lui-meme (certains hebergeurs bloquent son fetcher -> erreur 400 invalid_image_url).\n",
+    "import urllib.request, base64\n",
+    "_req = urllib.request.Request(image_url, headers={\"User-Agent\": \"CoursIA-SK07/1.0\"})\n",
+    "with urllib.request.urlopen(_req, timeout=30) as _resp:\n",
+    "    _img_bytes = _resp.read()\n",
+    "data_uri = \"data:image/jpeg;base64,\" + base64.b64encode(_img_bytes).decode()\n",
+    "print(f\"Image encodee en base64 : {len(_img_bytes)} octets\")\n",
     "\n",
     "# Creer l'historique avec image\n",
     "from semantic_kernel.connectors.ai.open_ai import OpenAIChatPromptExecutionSettings\n",
@@ -632,7 +652,7 @@
     "history = ChatHistory()\n",
     "history.add_user_message([\n",
     "    TextContent(text=\"Decris cette image en detail. Que vois-tu?\"),\n",
-    "    ImageContent(uri=image_url)\n",
+    "    ImageContent(uri=data_uri)\n",
     "])\n",
     "\n",
     "try:\n",
@@ -641,13 +661,13 @@
     "        chat_history=history,\n",
     "        settings=settings\n",
     "    )\n",
-    "    \n",
+    "\n",
     "    print(\"\\nDescription de l'image:\")\n",
     "    print(\"-\" * 40)\n",
     "    print(str(response[0]))\n",
-    "    \n",
+    "\n",
     "except Exception as e:\n",
-    "    print(f\"Erreur: {e}\")"
+    "    print(f\"Erreur: {e}\")\n"
    ]
   },
   {
@@ -666,7 +686,7 @@
    "source": [
     "### Interpretation : Analyse d'image avec GPT-4 Vision\n",
     "\n",
-    "**Sortie obtenue** : Description detaillee de l'image par GPT-4o.\n",
+    "**Sortie obtenue** : GPT-4o produit une description riche et detaillee de l'image (ici, un chat installe dans une botte en feutre, avec le decor environnant).\n",
     "\n",
     "| Aspect | Valeur | Signification |\n",
     "|--------|--------|---------------|\n",
@@ -679,7 +699,7 @@
     "1. **Vision multi-modale** : GPT-4o et GPT-4o-mini supportent nativement les images dans le chat\n",
     "2. **Structure du message** : On combine `TextContent` et `ImageContent` dans un même message utilisateur\n",
     "3. **Paramètre settings** : Requis par les versions recentes de semantic-kernel, peut etre personalise (temperature, max_tokens, etc.)\n",
-    "4. **URL vs base64** : On peut passer soit une URL publique, soit une image encodee en base64\n",
+    "4. **URL vs base64** : `ImageContent` accepte une URL publique (`uri=`) OU une image encodee en base64 (`data:image/...;base64,...`). Ici on telecharge l'image et on la passe en **base64** : certains hebergeurs (ex. Wikimedia) bloquent les recuperations programmees, ce qui fait echouer le fetch cote OpenAI (`400 invalid_image_url`) ; le base64 court-circuite ce probleme en incluant l'image directement dans la requete\n",
     "\n",
     "**Note technique** : Le modèle \"vision\" n'est pas un modèle separe - c'est GPT-4o/GPT-4o-mini avec capacite multimodale integree. Il n'y a pas de service `OpenAIVision` distinct, on utilise `OpenAIChatCompletion` avec `ImageContent`."
    ]


### PR DESCRIPTION
## Summary

`07-SemanticKernel-MultiModal.ipynb` code[13] (GPT-4 Vision analysis) committed a **FAILED run**: OpenAI returned `400 invalid_image_url` ("Error while downloading the Wikimedia Cat03.jpg URL"). But md[14] claimed **"Sortie obtenue: Description détaillée de l'image par GPT-4o"** — fabricating success over a failed output.

This is a **#8364 defect** (not simple stale markdown). Root cause investigated firsthand before any change; the real tool re-invoked with a robust fix.

## #8364 Root-cause investigation

- Tested the Wikimedia URL myself: `requests.get(Cat03.jpg)` → **403 Forbidden**. Wikimedia blocks programmatic fetches (anti-scraping), so OpenAI's image-fetcher cannot retrieve it either → surfaces as `400 invalid_image_url`.
- This is **NOT drift** of a correct value and **NOT a markdown-prior mismatch**: the committed output is a genuine **FAILED run** (infra/env), and the markdown hid the failure.
- Per #8364 + [sota-not-workaround](../../blob/main/.claude/rules/sota-not-workaround.md) + rule F: the fix is **NOT** to mechanically align markdown to the failure, **nor** to hand-inject an output (secrets-hygiene règle 6). The fix is to **repair the cause and RE-EXECUTE**.

## Fix (RECOVERABLE-LOCAL)

| Change | What |
|---|---|
| **code[13]** | Switch to a reliable image source (`cataas.com/cat`, 200 OK) and pass the image as a **base64 data_uri** to `ImageContent` (inline — OpenAI no longer fetches any URL, eliminating the 400). Uses stdlib `urllib` (no new dependency). |
| **Re-exec** | Executed code[13] via `jupyter nbconvert` (truncated copy: cells 1,6,12,13 — **skips the DALL-E call cell 9** to avoid needless cost; C.3 scope respected). Captured a real GPT-4o description. |
| **md[14]** | Headline now accurate (real description produced). Point 4 "URL vs base64" documents the root cause + why base64 is robust. |

**Real re-executed GPT-4o output** (committed):
> *L'image montre un chat assis confortablement à l'intérieur d'une botte en feutre. La botte est posée sur un tapis à motifs, près d'autres chaussures... Le chat a l'air détendu et semble profiter de son perchoir insolite.*

## Validation

- code[13] output: **400/BadRequestError GONE**; real GPT-4o description present.
- **0 C.1 violations** (`raise NotImplementedError|assert False|1/0`).
- **cell[9] (DALL-E) outputs UNCHANGED** (4 outputs) — C.3 scope respected.
- exec_count on cell[13] = 4 (targeted partial re-exec in a fresh kernel; other cells retain original full-run exec_counts — a known cosmetic artifact of scoped re-exec, not a fabrication).
- **H.3 PASS**. JSON round-trip byte-identical format. No secrets in output.
- Diff: 1 file, +32/−12, scoped to cells 13 (code+output) + 14 (markdown).

## Scope

- **#8364-compliant**: root cause investigated (Wikimedia 403) before any change; real tool (GPT-4o) re-invoked with a robust image source; honest output committed.
- Anti-patterns avoided: mechanical md-alignment-to-failure, hand-edited output.
- Atomique: one notebook, one cell's failure mode (vision URL-fetch).
- Collision-guard clean (no other open PR touches SK-07).

See #8052 (partial). #8364 honored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)