### PR TITLE
fix(rl-6e,#8052): drop false 'Sharpe annualisé' label (code is mean/std, no √N)

### DIFF
--- a/MyIA.AI.Notebooks/RL/rl_6e_grpo_from_scratch.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_6e_grpo_from_scratch.ipynb
@@ -126,7 +126,7 @@
     "- **Etat** : fenêtre des `LOOKBACK` derniers rendements standardises, applatie `(LOOKBACK x N_ASSETS,)`.\n",
     "- **Action** : poids du portefeuille $\\in \\Delta_{N}$ (simplexe : positifs, somme a 1) -- valide pour toute politique.\n",
     "- **Recompense (pas $t$)** : rendement du portefeuille $w^T r_t$ moins les frais de transaction.\n",
-    "- **Retour d'episode** : ratio de Sharpe annualise du portefeuille (moyenne / ecart-type des rendements de pas).\n",
+    "- **Retour d'episode** : ratio de Sharpe du portefeuille sur l'episode, non annualise (moyenne / ecart-type des rendements de pas).\n",
     "\n",
     "C'est le même squelette que le notebook de recherche QC (`PortfolioEnv`), mais sur données synthetiques.\n"
    ]


### PR DESCRIPTION
Grain: MED/audit-claims — lane myia-po-2024:CoursIA-2 — prev: DEEP/notebook-python (c.870 SL-12)

## Problem

`rl_6e_grpo_from_scratch.ipynb` cell[3] markdown labeled the episode reward as a **"Sharpe annualisé"**, but the code that computes it (`episode_sharpe`, cell[10]) is a plain `mean/std` with **no annualization factor** (√N):

```python
def episode_sharpe(rewards):
    arr = np.asarray(rewards, dtype=float)
    mu, sd = arr.mean(), arr.std() + 1e-8
    return float(mu / sd)        # no sqrt(periods_per_year) — NOT annualized
```

The cell[3] parenthetical "(moyenne / écart-type des rendements de pas)" already correctly described the **non-annualized** formula, making the word "annualisé" an internal contradiction. The committed output (`GRPO Sharpe=+0.023`, `equal-weight=-0.095`) are per-episode mean/std ratios, not annualized Sharpes.

An annualized Sharpe requires scaling by √(periods_per_year); none is applied. The word "annualisé" materially misleads a reader into comparing these per-episode ratios against annualized benchmarks (e.g. the standard √252-scaled equity Sharpe) — they are not comparable.

## Fix

Markdown-only, 1 line (C.2 exception — no code cell touched, no re-exec, outputs byte-identical):

```
- ratio de Sharpe annualise du portefeuille (moyenne / ecart-type des rendements de pas)
+ ratio de Sharpe du portefeuille sur l'episode, non annualise (moyenne / ecart-type des rendements de pas)
```

Drops the false "annualisé" and marks the metric explicitly as non-annualized, consistent with the code and the existing parenthetical. The numerical results (INCONCLUSIVE GRPO vs equal-weight) are honestly reported and unchanged — only the label is corrected.

## Verification (firsthand, G.1)

- `episode_sharpe` source read in full (cell[10]): `mu/sd` with `+1e-8` smoothing, no `np.sqrt` / annualization factor anywhere in the function or its callers.
- grep `annualis` across the notebook: only cell[3] had it (now fixed); no output cell prints "annualisé".
- Diff scope: `git diff origin/main --stat` = +1/-1, cell[3] markdown only.
- C.1 clean (no `raise NotImplementedError`/`assert False`/`1/0`), 11/11 code cells `execution_count != null`, outputs untouched.
- CRLF = 0, `validate_pr_notebooks.py` 1/1 PASS.

## Context

Found via an RL-family audit pass (c.871, sub-agent scan + firsthand verify per C855-L). The audit also re-surfaced the documented c.866 residual (rl_6 + rl_6c CartPole-v1 `195→475`) — addressed in a separate companion PR to keep this one atomic (G.4: one subject per PR).

See #8052 (claims↔outputs). Not `Closes` — doc-honesty label fix, the audit epic remains open.

Co-Authored-By: Claude <noreply@anthropic.com>
