### PR TITLE
fix(socialchoice,#8428): remove CJK residue in Arrow non-dictator axiom (04-SAT-Z3)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/SocialChoice/04-Computational-Aggregation-SAT-Z3.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/SocialChoice/04-Computational-Aggregation-SAT-Z3.ipynb
@@ -309,7 +309,7 @@
     "2. **Pareto** : si tous preferent $x$ a $y$, la societe aussi\n",
     "3. **IIA** (Indépendance des Alternatives Irrelevantes) : le classement social\n",
     "   entre $x$ et $y$ depend uniquement des préférences individuelles sur $\\{x, y\\}$\n",
-    "4. **Non-dictature** : aucun individu ne决定 seul le classement social\n",
+    "4. **Non-dictature** : aucun individu ne décide seul le classement social\n",
     "\n",
     "...doit etre dictatoriale. C'est une **impossibilite**.\n",
     "\n",


### PR DESCRIPTION
## Summary

`#8428` fleet-wide CJK cleanup. `MyIA.AI.Notebooks/GameTheory/SocialChoice/04-Computational-Aggregation-SAT-Z3.ipynb` **cell[8]** (markdown, section "2. Encodage SAT du Theoreme d'Arrow") had:

```
4. **Non-dictature** : aucun individu ne决定 seul le classement social
```

The Chinese `决定` ("decide") is LLM-translation residue mid-French prose (Arrow non-dictator axiom). Replaced with the correct French **`décide`**.

## G.1 firsthand verification (read-only origin/main)

- The CJK glyph was present **ONLY in the Python twin** cell[8]. The C# twin (`04-...-Csharp.ipynb`) is clean — **no drift to propagate**.
- Target unique: `ne决定 seul` occurs 1x, `ne décide seul` 0x (not already fixed).
- 0 other CJK glyphs in the notebook post-fix.

## Scope

- **Markdown-only** edit (C.2 exception: no code change, no re-exec needed).
- Byte-surgical raw `str.replace` + write `newline=""` (LF preserved). **NOT NotebookEdit** (which churns `source` list→string, float types, trailing newline — cf #8352/twin-parity).

## Verification

- JSON valid.
- `git diff origin/main` = 1 insertion / 1 deletion, single markdown cell.
- CRLF = 0 (LF preserved).
- All 21 code cells byte-identical (no re-exec, markdown-only).
- 0 remaining CJK glyphs (`[　-鿿＀-￯]`).
- Collision-guard: 0 open/merged CJK PR touching SocialChoice.

Part of the fleet-wide CJK cleanup discovered po-2026 c.720 (#8428). Family slice: SocialChoice (2 glyphs).

See #8428

Co-Authored-By: Claude <noreply@anthropic.com>
