### PR TITLE
fix(tts): 02-8 cell[9] env-config interpretation aligned with output (#8052)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-8-Expressive-TTS.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-8-Expressive-TTS.ipynb
@@ -393,11 +393,11 @@
    "source": [
     "### Interprétation : Chargement des variables d'environnement\n",
     "\n",
-    "**Sortie obtenue** : Avertissement - fichier .env non trouvé dans le chemin de recherche.\n",
+    "**Sortie obtenue** : `.env` chargé depuis `.env` (trouvé) ; mode API cloud désactivé par le paramètre Papermill `use_fish_api=False`.\n",
     "\n",
     "| Variable | Statut | Impact |\n",
     "|----------|--------|--------|\n",
-    "| FISH_AUDIO_API_KEY | Non définie | API cloud indisponible |\n",
+    "| `use_fish_api` | `False` (paramètre Papermill) | API cloud désactivée ; clé non contrôlée (branche `elif` court-circuitée) |\n",
     "| Mode de secours | Local uniquement | Nécessite GPU + packages |\n",
     "\n",
     "**Points clés** :\n",


### PR DESCRIPTION
## Context

`GenAI/Audio/02-Advanced/02-8-Expressive-TTS.ipynb` cell[9] (env-config interpretation) — #8052 claims↔outputs fidelity audit.

## Defect

cell[9] contradicted the committed output of cell[8]:

| Claim (markdown) | Reality (output) |
|---|---|
| `.env non trouvé dans le chemin de recherche` | `.env charge depuis: .env` (FOUND) |
| `FISH_AUDIO_API_KEY` `Non définie` → API cloud indisponible | key check printed **nothing** |

## #8364 root-cause analysis

Verdict: **case (A) — markdown prior written for a different run/env, never re-read.** NOT output drift.

`use_fish_api = False` is a **Papermill parameter** (defined in cell[2], reasserted in cell[8]). With it `False`, the cloud-API path is disabled by parameter and the key check (`elif use_fish_api:`) is **short-circuited** — so the run prints neither "Cle API Fish Audio disponible" nor "WARNING: FISH_AUDIO_API_KEY non definie". The `.env` *was* found and loaded.

The markdown described the not-found branch + attributed API unavailability to a missing key. The actual reason the API is off is the parameter, and the key status is **unverifiable from this output** (the check never ran).

## Fix (cell[9])
- `.env non trouvé` → `.env chargé depuis .env (trouvé) ; mode API cloud désactivé par le paramètre Papermill use_fish_api=False`
- `FISH_AUDIO_API_KEY | Non définie` → `use_fish_api | False (paramètre Papermill) | API cloud désactivée ; clé non contrôlée (branche elif court-circuitée)`

## Validation (H.3)
- nbformat valid (53 cells, v4.5)
- 0 C.1 violations
- Diff +2/-2, **markdown only** — no code-cell source changed
- Catalog byte-identical to main
- Markdown-only edit → C.2 exception (no re-exec; prior outputs remain valid)

## Scope
One notebook, one family (GenAI/Audio), one cell. Atomic. See #8052.

🤖 Generated with [Claude Code](https://claude.com/claude-code)