### PR TITLE
docs(lean,#6724): sync conway_lean README.en sorry map 2->8 (FR parity)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/README.en.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/README.en.md
@@ -5,7 +5,7 @@ Lean 4 formalization of Conway's mathematical games and algorithms.
 ## Status
 
 - **Toolchain**: v4.31.0-rc1
-- **Sorry count**: 2 (all in `HashlifeCorrectness.lean` — P4 double-nine wave-glue residual `p4_succ_membership` (private helper `window_cone_in_domain` is the proven local bridge) [1] + P5 large-n jump `p5_large_n_jump` [1], Epic #2162). Several P4 sub-lemmas and additive ingredients are proven sorry-free (see § "Game of Life" below). `p5_inductive_step` (P5.3 glue) was closed by c.310 PR #5998 via vacuous-arm split (design gate #3846): on non-empty grids, the `¬ hsmall` branch is jointly unsatisfiable with `BoxAssezGrand`, hence vacuous by construction. The P4.4 `p4_half_steps_compose` placeholder was deleted: its pure-evolve composition is already closed (`evolve_add` + `evolve_half_step`), its wave-glue content carried by the `p4_succ_membership` residual. **Audit N1 (PR #5853, ai-01 2026-07-09)**: the initial frame sub-claim (`BoxAssezGrand` ∩ `n ≥ jumpSize`) is **VACUOUS on non-empty grids** (`p5_large_n_hyps_unsat`: padding 2 of `gridFrame` ∧ `lvl ≥ 3` ⇒ `n ≤ 2 ∧ js ≥ 8`). **Design gate ai-01 (#3846, 2026-07-10)**: redesign `gridFrame` for `n`-dependent padding, port the `(off, mc)` state through the `evolveHashlifeFastAux` loop without intermediate re-framing, restate the "margin ≥ remaining n, preserved by jump" invariant. The proof debt (#3846) remains the BG-prover target and the coordinated architectural redesign scope.
+- **Sorry count**: **8** (all in `HashlifeCorrectness.lean`, Epic #2162 — **P4: 5** + **P5 large-n: 3**; canonical code-level count via `strip_comments` from `scripts/lean/check_i18n_siblings.py`, raw `grep` over-counts ~68 via docstring prose). Growth 2→8 since audit N1 (#5853) = **forward progress**: structural decomposition of the P4 inductive step (membership iff split into quadrant sub-cases, the **nw quadrant PROVEN** via `p4_nw_membership_arm` L2926) + statement of 2 new top-level N-correctness theorems (`hashlife_correctN` L3678, `p5_large_n_jumpN` L3706, `BoxAssezGrandN`, gated P4) — **not a regression**. See § "Honest state of the HashlifeCorrectness lock" for the per-declaration breakdown. Several P4 sub-lemmas and additive ingredients are proven sorry-free (see § "Game of Life" below). `p5_inductive_step` (P5.3 glue) was closed by c.310 PR #5998 via vacuous-arm split (design gate #3846): on non-empty grids, the `¬ hsmall` branch is jointly unsatisfiable with `BoxAssezGrand`, hence vacuous by construction. The P4.4 `p4_half_steps_compose` placeholder was deleted: its pure-evolve composition is already closed (`evolve_add` + `evolve_half_step`), its wave-glue content carried by the `p4_succ_membership` residual. **Audit N1 (PR #5853, ai-01 2026-07-09)**: the initial frame sub-claim (`BoxAssezGrand` ∩ `n ≥ jumpSize`) is **VACUOUS on non-empty grids** (`p5_large_n_hyps_unsat`: padding 2 of `gridFrame` ∧ `lvl ≥ 3` ⇒ `n ≤ 2 ∧ js ≥ 8`). **Design gate ai-01 (#3846, 2026-07-10)**: redesign `gridFrame` for `n`-dependent padding, port the `(off, mc)` state through the `evolveHashlifeFastAux` loop without intermediate re-framing, restate the "margin ≥ remaining n, preserved by jump" invariant. The proof debt (#3846) remains the BG-prover target and the coordinated architectural redesign scope.
 - **Build**: `lake build Conway` -- SUCCESS (3352 jobs)
 - **Dependencies**: Mathlib4
 - **i18n coverage (EPIC #4980)**: **25 conway_lean modules** shipped as FR-canonical + `_en` sibling on `main` (all but `HashlifeCorrectness.lean`, the P4/P5 prover target which remains EN-only) — Phase 1: **10/10**; Phase 2: **13/14** (`ConeGeometry` included); Phase 3: **2/2**. Rollout complete (c.290-#6439 + cycles c.421-c.423 merged).
@@ -44,7 +44,7 @@ Lean 4 formalization of Conway's mathematical games and algorithms.
 | `Conway/Life/HashlifeMemo.lean` | `HashlifeMemo_en.lean` | 0 | Memoized Hashlife for community pillar witnesses (OTCA 35K, UnitCell 4096, Gemini 33M) |
 | `Conway/Life/HashlifeMarginDemo.lean` | `HashlifeMarginDemo_en.lean` | 0 | Runnable P5 redesign demo (#3846) — n-aware framing margin around `MacroCell`/`HashlifeCorrectness` |
 | `Conway/Life/Pillars.lean` | `Pillars_en.lean` (c.417) | 0 | Community-witness theorem scaffolding (4 pillars) |
-| `Conway/Life/HashlifeCorrectness.lean` | — | 2 | Bounded correctness `hashlife_correct`; P4/P5 prover targets (Epic #1453, #2162) |
+| `Conway/Life/HashlifeCorrectness.lean` | — | 8 | Bounded correctness `hashlife_correct`; P4/P5 prover targets (Epic #1453, #2162). 8 = P4 (5: `p4_nw_supercell_agree` L2910 + `p4_succ_membership` L3193/3195/3197/3202) + P5 large-n (3: `p5_large_n_jump` L3531 + `hashlife_correctN` L3680 + `p5_large_n_jumpN` L3709) |
 
 ### Phase 3 — Free Will Theorem (Epic #1651, COMPLETE)
 
@@ -85,28 +85,8 @@ Lean 4 formalization of Conway's mathematical games and algorithms.
 - **Memoized Hashlife**: Community pillar witnesses (OTCA 35K gen, UnitCell 4096 gen, Gemini 33M gen)
 - **HashlifeCorrectness**: bounded correctness `hashlife_correct`, decomposed P1-P5
   - **P1-P3 proven** (base case `k=0` via `2^16 native_decide`, PR #2810)
-  - **P4 inductive step** (1 residual sorry on `window_cone_in_domain`): decomposed by #2975
-    scaffolding into sub-lemmas. Several are now **proven sorry-free** with real statements
-    — `p4_double_nine_shape` (structural existence of the nine quadrants of a double-nine
-    cell), `p4_wave1_ih` and `p4_wave2_ih` (propagation of `centralCorrect` via the induction
-    hypothesis over the two waves), `p4_ext_bridge`, plus the additive ingredients closed in
-    cycles 145-160 (`evolve_add`, `evolve_half_step`, `centralCorrect_mem_shift`,
-    `evolve_cone_agree`). The P4.4 `p4_half_steps_compose` placeholder (`: True`) was
-    **deleted** (N2-bis): its pure-evolve half-step composition is exactly the closed
-    `evolve_add` + `evolve_half_step`, and its wave-assembly content is carried by the
-    **1 residual sorry** on `window_cone_in_domain` (private helper declared at L2629) — the
-    real offset-matching G3 assembly: characterize super-cell `q_*` membership in the four
-    quadrant offsets via `centralCorrect_mem` (G2) + the bridging `evolve_half_step`/
-    `step_light_cone` (G3). Research-level double-nine light-cone composition, whnf-hard —
-    reserved for a dedicated multi-cycle effort. The sub-lemmas' real statements live in
-    their docstrings — restate + prove, do not eliminate as `True`.
-  - **P5 large-n** (1 residual sorry): `p5_small_n_fallback` **PROVEN** (PR #2984);
-    `evolve_dead_of_cone_dead` (P5.2 contrapositive, #4574) **proven sorry-free**;
-    `p5_inductive_step` (P5.3 glue) **PROVEN** by c.310 PR #5998 via vacuous-arm split
-    (non-empty branch closed by `p5_large_n_hyps_unsat`, empty branch by direct unfold).
-    Remaining: `p5_large_n_jump` (P5.2, `evolveHashlifeFast n g = evolve n g`, body `sorry`,
-    blocked on P4). Base `n=0` proven (`hashlife_correct_base_zero` #2898,
-    `evolveHashlifeFastAux_zero_n` #2901).
+  - **P4 inductive step** (5 sorry: `p4_nw_supercell_agree` L2910 [1, NET-FLAT isolation of the monolithic nw call-site, ai-01 #6875] + `p4_succ_membership` L3193/3195/3197/3202 [4, ne/sw/se quadrants + mpr direction — the **nw quadrant is PROVEN** via `p4_nw_membership_arm` L2926 on `p4_nw_shift_lemma`]): the #2975 scaffolding decomposes the inductive step into sub-lemmas. **Proven sorry-free** — `p4_double_nine_shape` (structural existence of the nine quadrants of a double-nine cell), `p4_wave1_ih` and `p4_wave2_ih` (propagation of `centralCorrect` via the induction hypothesis over the two waves), `p4_ext_bridge`, plus the additive ingredients closed in cycles 145-160: `evolve_add` (S1), `evolve_half_step` (half-step `2^k`, #4555 — pure-evolve composition closed), `centralCorrect_mem_shift` (G2 offset-generalized gate, #4812) and `evolve_cone_agree` (radius-doubling locality composition gate, #4892). The P4.4 placeholder `p4_half_steps_compose` (`: True`) was **deleted** (N2-bis): its pure-evolve composition is exactly `evolve_add` + `evolve_half_step` (closed), its wave-glue content now split into quadrant sub-cases on `p4_succ_membership` (noncomputable def L3103, sorries L3193/3195/3197/3202) + the nw call-site isolated as `p4_nw_supercell_agree` (L2893, sorry L2910) — the G3 offset-matching assembly core: characterize super-cell `q_*` membership in the four quadrant offsets via `centralCorrect_mem` (G2) + the bridging `evolve_half_step`/`step_light_cone` (G3). Research-level double-nine light-cone composition, whnf-hard — a multi-cycle BG-prover target.
+  - **P5 large-n** (3 residual sorry, all gated P4): `p5_small_n_fallback` **PROVEN** (PR #2984); `evolve_dead_of_cone_dead` (P5.2 contrapositive, #4574) **proven sorry-free**; `p5_inductive_step` (P5.3 glue) **PROVEN** by c.310 PR #5998 via vacuous-arm split (non-empty branch closed by `p5_large_n_hyps_unsat`, empty branch by direct unfold). Remaining are 3 top-level `sorry` theorems, all gated P4: `p5_large_n_jump` (P5.2, `evolveHashlifeFast n g = evolve n g`, L3528 sorry L3531), and the 2 newly stated `BoxAssezGrandN` N-steps theorems `hashlife_correctN` (L3678 sorry L3680) + `p5_large_n_jumpN` (L3706 sorry L3709). Base case `n=0` proven (`hashlife_correct_base_zero` #2898, `evolveHashlifeFastAux_zero_n` #2901).
 
 ### Kochen-Specker + Free Will Theorem (Phase 3, PROVED)
 
@@ -136,7 +116,34 @@ This workspace formalizes in Lean 4 three facets of John Conway's work, from cla
 
 ### Honest state of the HashlifeCorrectness lock
 
-The central theorem `hashlife_correct` (bounded by the padding hypothesis `BoxAssezGrand`) is **not yet proven in full generality**: **2 `sorry`** remain in `HashlifeCorrectness.lean`. The foundation is solid — base case `k=0` proven (`2^16 native_decide`), base case `n=0` proven, P1/P2/P3 (padding, light-cone, locality) proven, `p5_small_n_fallback` proven, `p5_inductive_step` (P5.3 glue) proven by c.310 PR #5998 via vacuous-arm split, the P4 sub-lemmas (`p4_double_nine_shape`, `p4_wave1_ih`, `p4_wave2_ih`, `p4_ext_bridge`) proven sorry-free, plus the additive ingredients closed in cycles 145-160 (`evolve_add`, `evolve_half_step`, `centralCorrect_mem_shift`, `evolve_cone_agree`) and the P5.2 contrapositive (`evolve_dead_of_cone_dead`) — but the P4 inductive step (offset-matching G3 assembly, 1 residual sorry on `window_cone_in_domain` — private helper declared at L2629, the `p4_half_steps_compose` placeholder has been deleted, its pure-evolve composition already closed via `evolve_add`+`evolve_half_step`) and P5 large-n (`p5_large_n_jump`, blocked on P4) are **research-level**. These are the BG-prover (`agent_tests/prover/`) targets, not bounded grains: the multi-wave light-cone composition resists current tactical automation. The P4 scaffolds state each sub-goal precisely in their docstrings.
+The central theorem `hashlife_correct` (bounded by the padding hypothesis `BoxAssezGrand`) is **not yet proven in full generality**: **8 `sorry`** remain (code-level, canonical count via `strip_comments` — raw `grep` over-counts via docstring prose) in `HashlifeCorrectness.lean`, all concentrated on the research-level P4/P5 lock. The foundation is solid — base case `k=0` proven (`2^16 native_decide`), base case `n=0` proven, P1/P2/P3 (padding, light-cone, locality) proven, `p5_small_n_fallback` proven, `p5_inductive_step` (P5.3 glue) proven by c.310 PR #5998 via vacuous-arm split, the P4 sub-lemmas (`p4_double_nine_shape`, `p4_wave1_ih`, `p4_wave2_ih`, `p4_ext_bridge`) proven sorry-free, as well as the additive ingredients closed in cycles 145-160 (`evolve_add`, `evolve_half_step`, `centralCorrect_mem_shift`, `evolve_cone_agree`) and the P5.2 contrapositive (`evolve_dead_of_cone_dead`) — but the P4 inductive step (offset-matching G3 assembly) and P5 large-n are **research-level**. **Per-declaration breakdown of the 8 sorry** (post P4.4 decomposition #7012 + statement of N-correctness theorems):
+
+- **P4 — `p4_nw_supercell_agree`** (private theorem L2893, sorry L2910, 1): NET-FLAT isolation of the monolithic nw call-site (ai-01 tree-lock #6875; anti-regression §D N/A — nominally replaces a pre-existing sorry, does not add debt).
+- **P4 — `p4_succ_membership`** (noncomputable def L3103, 4 sorry L3193/3195/3197/3202): the membership iff of the inductive step, **decomposed into quadrant sub-cases**. The **nw quadrant is PROVEN** via `p4_nw_membership_arm` (L2926, sorry-free wiring on `p4_nw_shift_lemma`); remaining are the ne/sw/se quadrants (L3193/3195/3197) + the mpr direction (L3202). The `p4_half_steps_compose` placeholder was deleted (pure-evolve composition already closed via `evolve_add`+`evolve_half_step`).
+- **P5 large-n** (3 sorry, all gated P4): `p5_large_n_jump` (L3528 sorry L3531, P5.2) + `hashlife_correctN` (L3678 sorry L3680) + `p5_large_n_jumpN` (L3706 sorry L3709) — the latter 2 are newly stated top-level N-steps theorems `BoxAssezGrandN`.
+
+**Infrastructure in place**: the 4 shift-lemmas `p4_nw/ne/sw/se_shift_lemma` (L2846/2999/3025/3051, #7012) are sorry-free. **Concrete next step**: write the ne/sw/se membership arms by analogy to `p4_nw_membership_arm` (L2926), which closes 3 of the 4 sorry of `p4_succ_membership`. These are the BG-prover (`agent_tests/prover/`) targets; the multi-wave light-cone composition resists current tactical automation. The P4 scaffolds state each sub-goal precisely in their docstrings.
+
+*The `hashlife_correct` correction pyramid: the proven foundation (base cases, P1-P3,
+`p5_small_n_fallback`) carries the theorem; at the top, the research-level P4 lock
+(double-nine, **unrestricted statement FALSE** — `p4_unrestricted_counterexample`,
+audit N1 PR #5853) blocks P5 large-n:*
+
+```mermaid
+flowchart TD
+    BASE["Base cases  <b>proven</b><br/>k=0 (2¹⁶ native_decide) · n=0"]
+    P1["P1 — Padding<br/>box_assez_grand · natCeilLog2  <b>✓</b>"]
+    P2["P2 — Light-cone<br/>step_light_cone  <b>✓</b>"]
+    P3["P3 — Locality<br/>aliveNext_local · step_local  <b>✓</b>"]
+    P5S["P5 small-n<br/>p5_small_n_fallback  <b>✓</b> (#2984)"]
+    P4["P4 — Double-nine inductive step  <b>⚠ research-level</b><br/>5 sorry · p4_nw_supercell_agree [1, L2910] + p4_succ_membership [4, L3193/3195/3197/3202]<br/><i>nw quadrant PROVEN via p4_nw_membership_arm L2926; shift-lemmas nw/ne/sw/se sorry-free (#7012); sub-lemmas + additive ingredients proven (shape, wave1, wave2, ext_bridge, evolve_cone_agree, centralCorrect_mem_shift, evolve_half_step); p4_half_steps_compose deleted (subsumed by evolve_add/evolve_half_step); the G3 whnf-hard core remains (ne/sw/se arms to write); <b>audit N1 PR #5853 VACUOUS — design gate #3846 in progress</b></i>"]
+    P5["P5 — Large-n jump  <b>⚠ blocked on P4</b><br/>3 sorry · p5_large_n_jump L3531 + hashlife_correctN L3680 + p5_large_n_jumpN L3709 (BoxAssezGrandN)<br/><i>p5_small_n_fallback + evolve_dead_of_cone_dead + p5_inductive_step (c.310 #5998) proven</i>"]
+    GOAL["hashlife_correct  <b>not proven in full generality</b>"]
+
+    BASE --> P1 --> P2 --> P3 --> GOAL
+    P5S -.-> GOAL
+    P4 -.->|"BG-prover lock"| P5 -.-> GOAL
+```
 
 ### Methodological lessons
 


### PR DESCRIPTION
## Summary

FR↔EN sibling-parity fix for `conway_lean/README.en.md`. The EN twin reported **2 sorry** while the FR canonical (`README.md`, refreshed by ai-01 in #8414) correctly reports **8**. This PR realigns the EN README to the audited FR state across **4 stale count positions**.

This is **i18n sibling-parity bookkeeping (Epic #4980)**, distinct from a #8052 claims doc-honesty audit and from a Lean proof change: the 8 `sorry` in `HashlifeCorrectness.lean` are unchanged (research-level P4/P5 prover targets, BG-prover harness #1453/#6724).

## Defect (firsthand G.1)

`HashlifeCorrectness.lean` on `origin/main` carries **8 code-level `sorry`** (canonical count via `strip_comments` of `scripts/lean/check_i18n_siblings.py`; raw `grep` over-counts ~64 via docstring prose):

| Location | Theorem | Gate |
|---|---|---|
| L2910 | `p4_nw_supercell_agree` | P4 nw call-site (NET-FLAT isolation) |
| L3193/3195/3197/3202 | `p4_succ_membership` | P4 ne/sw/se quadrants + mpr |
| L3531 | `p5_large_n_jump` | P5 large-n (gated P4) |
| L3680 | `hashlife_correctN` | P5 N-steps BoxAssezGrandN (gated P4) |
| L3709 | `p5_large_n_jumpN` | P5 N-steps BoxAssezGrandN (gated P4) |

The EN README still said **2** (stale since before #8414, which refreshed only the FR twin).

## Fix — 4 positions realigned to FR

1. **Header `Sorry count` bullet** (EN L8): `2` → `**8**` (P4=5 + P5=3, forward-progress framing — P4.4 decomposition + 2 new N-correctness theorems, not a regression).
2. **Modules table row** (EN L47): `| — | 2 |` → `| — | 8 |` + P4/P5 line-ref breakdown.
3. **`Game of Life` P4/P5 list** (EN L88-109): `"1 residual sorry on window_cone_in_domain (L2629)"` → the full 5+3 sorry decomposition.
4. **`Honest state of the HashlifeCorrectness lock`** (EN L139+): single 2-sorry paragraph → per-declaration breakdown + mermaid correction pyramid (translated verbatim from FR L157-187).

## Validation

- **Zero stale residue** post-fix: exhaustive grep finds no `Sorry count: 2`, `2 \`sorry\``, `1 residual sorry`, `window_cone_in_domain`, `L2629`, or `| — | 2 |`.
- **All 8 line-refs preserved** (L2910/L3193/3195/3197/3202/L3531/L3680/L3709) + supporting (L2926 nw-arm, L2846 shift-lemma, L3678/L3706 statement decls).
- **Mermaid fences balanced** (1 pair, opens=2).
- **CRLF = 0**, LF preserved.
- **Diff**: 1 file, `+32/−25`, only `README.en.md` touched (catalogue byte-identical, `.lean` sources untouched).

## Scope discipline

- No Lean proof change (sorry count unchanged on disk — verified via `strip_comments`).
- No claim doc-honesty audit (the EN text was *under*-reporting a real count toward a research-level lock, not fabricating success).
- Pre-existing markdown-lint style warnings (MD060 compact-table-pipe, MD032) on module coverage tables left untouched per scope discipline — they exist on the FR twin too and are unrelated to this parity fix.

See #6724. See #4980 (Lean i18n). See #1453 (prover harness).