### PR TITLE
fix(audio): 03-2 pipeline interp cells aligned with committed per-step output (#8052)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/03-Orchestration/03-2-Audio-Pipeline-Orchestration.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/03-Orchestration/03-2-Audio-Pipeline-Orchestration.ipynb
@@ -953,12 +953,12 @@
     "| STT (local) | 0.5-2s | GPU / taille audio |\n",
     "| STT (API) | 1-3s | Reseau |\n",
     "| LLM | 1-3s | Generation de tokens |\n",
-    "| TTS | 1-2s | Reseau / synthese |\n",
-    "| **Total** | **3-8s** | **LLM souvent le plus lent** |\n",
+    "| TTS | ~5s (observe 5.02s) | Reseau / synthese — goulot principal ce run |\n",
+    "| **Total** | **~8s (observe 8.33s)** | **TTS le plus lent (5.02s vs LLM 1.72s vs STT 1.59s)** |\n",
     "\n",
     "**Points cles** :\n",
     "1. La latence totale du pipeline est la somme des latences individuelles\n",
-    "2. Le LLM est souvent le goulot d'etranglement (generation autoregressive)\n",
+    "2. Sur ce run, le TTS est le goulot d'etranglement (5.02s vs 1.72s pour le LLM) ; la synthese vocale via API depend fortement de la latence reseau\n",
     "3. Le retry exponentiel protege contre les erreurs transitoires\n",
     "4. Pour du temps reel, privilegier des modèles plus petits (gpt-4o-mini)"
    ]
@@ -1921,12 +1921,12 @@
     "\n",
     "| Pipeline | Étape la plus lente | Optimisation possible |\n",
     "|----------|--------------------|-----------------------|\n",
-    "| STT->LLM->TTS | LLM (generation) | Utiliser gpt-4o-mini, reduire max_tokens |\n",
+    "| STT->LLM->TTS | TTS (synthese, 5.02s observees) | Reduire la longueur du texte a synthetiser, voix plus rapides |\n",
     "| Traduction | Comparable STT/LLM/TTS | Paralleliser STT et TTS si possible |\n",
     "| Podcast | TTS (N segments) | Paralleliser les appels TTS |\n",
     "\n",
     "**Points cles** :\n",
-    "1. Le profilage revele que le LLM est souvent le goulot d'etranglement\n",
+    "1. Le profilage revele que le TTS est le goulot d'etranglement (5.02s sur stt_llm_tts, 12.96s sur le podcast)\n",
     "2. La generation du podcast est dominee par les appels TTS séquentiels\n",
     "3. L'assemblage est negligeable par rapport aux appels API"
    ]


### PR DESCRIPTION
## Context

`GenAI/Audio/03-Orchestration/03-2-Audio-Pipeline-Orchestration.ipynb` — #8052 claims↔outputs fidelity audit (R6 sub-series pivot to 03-Orchestration).

## Defect

Two interpretation cells claimed **"the LLM is the bottleneck"**, directly contradicting the committed per-step output of `code[15]` (STT→LLM→TTS pipeline):

| Step | Claimed (markdown) | Observed (output) |
|---|---|---|
| STT | 1-3s | **1.59s** |
| LLM | 1-3s | **1.72s** |
| TTS | **1-2s** | **5.02s** |
| Total | 3-8s | **8.33s** |
| Bottleneck | "LLM le plus lent" | **TTS** (5.02s ≈ 3× LLM) |

The per-step durations are printed in the committed text output (`Etape N : ... Duree : X.XXs`), so the claim is directly verifiable — no figure / vision-QA needed.

## #8364 root-cause

Verdict: **case (A) — generic "LLM is always the bottleneck" priors, never re-read against the committed per-step output.** The output is a real, stable API run; the markdown applied a common-but-wrong-for-this-run assumption (autoregressive LLM generation is assumed slowest, but here TTS network latency dominated).

## Fix

**cell[17]** (STT→LLM→TTS interp): TTS `1-2s`→`~5s (observe 5.02s)`; Total `3-8s`/`LLM le plus lent`→`~8s (observe 8.33s)`/`TTS le plus lent (5.02s vs LLM 1.72s vs STT 1.59s)`; point 2 reframed to "Sur ce run, le TTS est le goulot".

**cell[33]** (profilage interp): `STT->LLM->TTS | LLM`→`TTS (synthese, 5.02s observees)`; "Le LLM est souvent le goulot"→"Le TTS est le goulot (5.02s sur stt_llm_tts, 12.96s sur le podcast)".

## Untouched (FAITHFUL, prevents re-mining)
- **INTERP[21]** (translation): total `3-8s` matches observed 6.16s; no per-step bottleneck claim; quality observations consistent with successful run.
- **INTERP[27]** (podcast): `6 segments`, `alloy/onyx voices`, script `2-5s` (obs 4.25s), TTS `5-15s` (obs 12.96s) all match.
- **INTERP[33]** translation row `Comparable STT/LLM/TTS` left as-is (obs 2.09/1.20/2.86s are genuinely comparable, unlike the STT→LLM→TTS pipeline).

## Validation (H.3)
- nbformat valid (47 cells, v4.5)
- 0 C.1 violations
- Diff +5/−5, **markdown only** — code-cell source sha1 unchanged
- Catalog byte-identical to main
- Markdown-only → C.2 exception (no re-exec; prior outputs remain valid)

## Scope
One notebook, one family (GenAI/Audio), one audit dimension (#8052). Atomic. See #8052.

🤖 Generated with [Claude Code](https://claude.com/claude-code)