### PR TITLE
docs(sudoku,#8081): add canonical Z3 citation + fix provenance (fidelity audit)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb
@@ -30,7 +30,7 @@
     "\n",
     "---\n",
     "\n",
-    "Ce notebook implemente un solveur de Sudoku utilisant **Microsoft Z3**, un solveur **SMT** (Satisfiability Modulo Théories).\n",
+    "Ce notebook implemente un solveur de Sudoku utilisant **Z3** (prouveur SMT issu de Microsoft Research, desormais open-source sous licence MIT), un solveur **SMT** (Satisfiable Modulo Theories).\n",
     "\n",
     "Cette approche est equivalente au notebook C# `Sudoku-12-Z3-Csharp.ipynb`.\n",
     "\n",
@@ -98,7 +98,17 @@
     "tags": []
    },
    "source": [
-    "## 1. Solveur Z3 SMT**Microsoft Z3** est un solveur **SMT** (Satisfiability Modulo Théories) - il combine la puissance des solveurs SAT avec des théories mathématiques (arithmétique, tableaux, bitvectors, etc.)."
+    "## 1. Solveur Z3 SMT\n",
+    "\n",
+    "**Z3** est un solveur **SMT** (*Satisfiability Modulo Theories*) developpe a l'origine par **Microsoft Research** (Leonardo de Moura et Nikolaj Bjorner), desormais publie en **open-source sous licence MIT** dans le depot [`Z3Prover/z3`](https://github.com/Z3Prover/z3). Il combine la puissance des solveurs SAT avec des theories mathematiques (arithmetique, tableaux, bitvectors, etc.)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Source et licence.** Z3 est un prouveur de theoremes issu de Microsoft Research, desormais libre (licence **MIT**) sur [`github.com/Z3Prover/z3`](https://github.com/Z3Prover/z3). Reference canonique : Leonardo de Moura et Nikolaj Bjorner, *Z3: An Efficient SMT Solver*, in *Tools and Algorithms for the Construction and Analysis of Systems (TACAS)*, 2008. Ce notebook distille cette source au travers du prisme pedagogique du Sudoku : il ne reproduit ni l'article ni la documentation officielle, mais demontre l'API Python `z3-solver` (`Int`, `BitVec`, `Solver`, `Optimize`) sur un exemple concret.\n",
+    ""
    ]
   },
   {


### PR DESCRIPTION
## Context

`#8081` fidelity-to-literature audit on **Sudoku-12-Z3-Python.ipynb**.

## Defect (firsthand, G.1-verified on `origin/main`)

The notebook exercised Z3's SMT API (`Int`, `BitVec`, `Solver`, `Optimize`) but attributed the solver only as "**Microsoft Z3**" in two cells (`cell[0]` intro + `cell[2]` section header) — **zero** canonical citation: no authors, no paper, no current open-source home. This is exactly the `#8081` question ("did we lose substance by complacency?"), a fidelity gap distinct from `#8052` (claims-vs-internal-outputs).

## Fix (markdown-only, citation add — C.2 exception, no re-exec)

- **cell[0]**: "`**Microsoft Z3**`" → "`**Z3** (prouveur SMT issu de Microsoft Research, desormais open-source sous licence MIT)".
- **cell[2]**: intro now states Z3 was developed at Microsoft Research by **Leonardo de Moura** and **Nikolaj Bjorner**, now MIT-licensed open-source at `Z3Prover/z3`.
- **cell[3] (new markdown)**: a "Source et licence" blockquote giving the canonical reference — **de Moura & Bjorner, *Z3: An Efficient SMT Solver*, TACAS 2008** — + project home `github.com/Z3Prover/z3` + explicit framing that this notebook **distills** the source pedagogically (does not reproduce the paper or official docs).

## Verification (evidence-cited)

| Check | Result |
|-------|--------|
| Stale "**Microsoft Z3**" claim | **0** remaining (was 2) |
| Citation markers | de Moura ×2, TACAS ×1, Z3Prover ×4, MIT ×3, github link ×3 |
| Code cells (11) | byte-identical — sha1 set unchanged, `execution_counts` + outputs preserved (Z3 Int 340.86ms, BitVec table 271/68/462/71/222/61/389/117/237/105, Optimize reward 178, diagonal solver) |
| Cell count | 29 → 30 (1 markdown-cell insert) |
| Byte-idempotent | `json.dumps(indent=1)` + trailing-newline round-trip = True |
| H.3 (unexecuted-notebook check) | **PASS** — 0 violations |
| CRLF | 0 |
| Files changed | `MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb` only — catalogue + `.lean` untouched |
| diff --stat | `+12/-2, 1 file` |

Markdown-only citation add → **C.2 exception** (no kernel re-exec needed; the edits touch prose, not code outputs). The code outputs are real Z3 invocations, preserved verbatim.

## Pattern

Matches the canonical-citation PRs already merged under `#8081`: Search-15 (#8293), GT-7 (#8295), Infer-7/9/10/18, GenAI-Texte NB-13/17. Z3 canonical reference = de Moura & Bjørner, *Z3: An Efficient SMT Solver*, TACAS 2008; project now MIT open-source at `github.com/Z3Prover/z3`.

See #8081 (partial delivery, one notebook of the audit).