### PR TITLE
fix(ml,#8428): replace CJK residue in ML-2-Data&Features-Python intro

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-2-Data&Features-Python.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-2-Data&Features-Python.ipynb
@@ -43,7 +43,7 @@
     "\n",
     "En machine learning, **la qualité des données détermine la qualité du modèle**. Cette leçon couvre le **feature engineering** : l'art de transformer des données brutes (texte, catégories, valeurs manquantes) en une matrice numérique `X` qu'un modèle peut consommer.\n",
     "\n",
-    "Le dataset支撑 : **taxi-fare** (tarifs de taxi de NYC). Objectif : prédire `fare_amount` à partir de `vendor_id`, `rate_code`, `passenger_count`, `trip_time_in_secs`, `trip_distance`, `payment_type`.\n",
+    "Le dataset utilisé : **taxi-fare** (tarifs de taxi de NYC). Objectif : prédire `fare_amount` à partir de `vendor_id`, `rate_code`, `passenger_count`, `trip_time_in_secs`, `trip_distance`, `payment_type`.\n",
     "\n",
     "## Chargement des données avec pandas\n",
     "\n",


### PR DESCRIPTION
## Context

`MyIA.AI.Notebooks/ML/ML.Net/ML-2-Data&Features-Python.ipynb` cell[0] (intro) — #8428 fleet-wide CJK glyph corruption sweep.

## Defect

The intro cell had Chinese `支撑` (zhicheng = "support/underpin"), an LLM-translation residue:

> `Le dataset支撑 : **taxi-fare** (tarifs de taxi de NYC)...`

Replaced with the natural French **"Le dataset utilisé"** (the replacement also restores the missing space before `:`).

## Scope (firsthand, G.1)

- The CJK glyph is present **only in the Python twin** cell[0]. The C# twin `ML-2-Data&Features.ipynb` is clean — no drift to propagate (same single-twin pattern as SocialChoice #8461).
- Single occurrence (`支撑` count=1, verified unique).

## Validation (H.3)
- nbformat valid (19 cells, v4.5)
- 0 C.1 violations
- Diff **+1/−1** — one source line only (byte-surgical text replacement; LF preserved, CRLF=0)
- **0 CJK residue remaining** in the notebook (verified post-fix)
- Catalog byte-identical to main
- Markdown-only → C.2 exception

## Scope
One notebook, one family (ML/ML.Net). Atomic. See #8428.

🤖 Generated with [Claude Code](https://claude.com/claude-code)