### PR TITLE
feat(twin-register,#8057): register GameTheory-7 ExtensiveForm pair (re-apply, supersedes #8458)

### DIFF
--- a/scripts/notebook_tools/twin_pairs.yaml
+++ b/scripts/notebook_tools/twin_pairs.yaml
@@ -757,6 +757,20 @@
     - "Socle pedagogique commun : Dilemme du Prisonnier Itere (IPD), tournoi d'Axelrod, strategies classiques (TitForTat, Pavlov, Generous TitForTat), dynamique evolutive (processus de Moran), emergence de la cooperation."
     - "Idiomes framework : Python = `numpy` + `matplotlib` + `matplotlib.animation` (viz dynamique du tournoi round-robin + courbes de Moran). C# = pur `System.*` (Collections.Generic, Linq) + moteur IPD from-scratch (T=5/R=3/P=1/S=0 convention Axelrod) ; 0 NuGet tiers."
     - "Asymetrie pedagogique : Python utilise matplotlib.animation pour la viz dynamique (gif-like) du tournoi + process de Moran ; le C# travaille en pur System.* sans viz dynamique (asci-art + tableaux). Meme socle theorique (Axelrod + Moran), leviers de demonstration differents (viz riche cote Python, code from-scratch minimaliste cote C#)."
+- name: "GameTheory-7 ExtensiveForm"
+  family: GameTheory/.NET-Parity
+  python: MyIA.AI.Notebooks/GameTheory/GameTheory-7-ExtensiveForm.ipynb
+  csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-7-ExtensiveForm-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-25"
+    by: po-2023
+    python_sha: da5dc9d2c05d6688d03a1097215d4cb7b69228a6
+    csharp_sha: 818b2295149aad115c286816c9ad242f964b400c
+  known_differences:
+    - "Socle pedagogique commun : jeux sous forme extensive (arbre de jeu sequentiel avec noeuds de decision/terminal/chance + infosets), backward induction (induction en arriere) pour calculer les SPE (Subgame Perfect Equilibria), exemple canonique du jeu d'entree sur le marche (entrant vs incumbente)."
+    - "Idiomes framework : Python = `@dataclass` + `networkx` (graphe arborescent + rendu matplotlib des arbres de jeu) + implementation manuelle de `backward_induction` + `ConvertToNormal` (reduction extensive-vers-normal). C# = **BCL .NET pur 0 NuGet** (modele `GameNode` decision/terminal/chance + `ExtensiveFormGame` from-scratch) + **rendu ASCII de l'arbre** (pas de viz graphique, fidele a la contrainte 0-NuGet de la serie)."
+    - "Asymetrie de couverture pedagogique : le Python detaille 35 cellules (15 code + 20 markdown, 9 sections + 3 exercices sur l'entree multi-joueurs, Chain-Store paradox, SPE verification, conversion extensive-vers-normale, integration Lean). Le C# couvre 24 cellules (10 code + 14 markdown, 5 couches : modele, exemple entree, SPE par backward induction, Card Game to normal form, exercices) -- coverage plus compacte, fidele au format twin de la serie. Meme theorie (Kuhn 1953, Selten 1965 SPE), leviers pedagogiques differents."
 
 # === Tranche 5 SemanticWeb/dotNetRDF-rdflib (c.809, po-2024, 2026-07-23) — famille supplementaire #8057 ===
 


### PR DESCRIPTION
## Context

Re-registers the **GameTheory-7 ExtensiveForm** Python<->C# parity pair in `scripts/notebook_tools/twin_pairs.yaml`. **Supersedes #8458** (which became CONFLICTING/DIRTY).

## Why a new PR instead of rebasing #8458

After #8458 branched, two sibling twin-register PRs landed on main — **#8448 (GT-3 Topology2x2)** and **#8456 (GT-6 EvolutionTrust)** — both editing the same `twin_pairs.yaml` region. This shifted the lines #8458 edited, producing an additive content conflict. Per worker git-safety (never `--force`/`--force-with-lease` without explicit user validation) and [catalog-pr-hygiene.md](.claude/rules/catalog-pr-hygiene.md) HARD 2 (rebase frais avant push), the clean path is a fresh branch from current `origin/main` re-applying the same entry. #8458 is closed in favor of this PR.

## Entry

| field | value |
|-------|-------|
| name | GameTheory-7 ExtensiveForm |
| family | GameTheory/.NET-Parity |
| parity_level | semantic |
| Python | `networkx` (game tree) + `matplotlib` tree render + manual `backward_induction` + `ConvertToNormal` |
| C# | **BCL .NET pur 0-NuGet** — `GameNode` (decision/terminal/chance) + `ExtensiveFormGame` from-scratch + ASCII tree render |
| asymmetry | Python 35-cell rich viz (extensive-form entry, Chain-Store paradox, multi-player, Lean integration) vs C# 24-cell compact from-scratch (5 layers, Card-Game-to-normal-form). Same theory (Kuhn 1953, Selten 1965 SPE). |

## Verification (evidence-cited)

| Check | Result |
|-------|--------|
| GT-7 absent from main before | grep `GameTheory-7 ExtensiveForm` = 0 (NOT obsolete, still needed) |
| Blob SHAs vs `origin/main` | python `da5dc9d2c05d6688d03a1097215d4cb7b69228a6`, csharp `818b2295149aad115c286816c9ad242f964b400c` — verified firsthand via `git ls-tree origin/main` (notebooks unchanged since c.906 audit) |
| YAML parse | OK (80 top entries) |
| `check_twin_parity.py --family GameTheory/.NET-Parity` | **`[OK] GameTheory-7 ExtensiveForm`** — 6 pairs, OK=6 DRIFT=0 MISSING=0 |
| diff --stat | `+14/-0`, `twin_pairs.yaml` only |
| catalogue | byte-identical to main (`COURSE_CATALOG.generated.{json,md}` untouched) |

See #8057 (twin-parity metadata, parent #4208).