### PR TITLE
feat(twin-register,#8057): register GameTheory-8 CombinatorialGames pair

### DIFF
--- a/scripts/notebook_tools/twin_pairs.yaml
+++ b/scripts/notebook_tools/twin_pairs.yaml
@@ -757,6 +757,20 @@
     - "Socle pedagogique commun : Dilemme du Prisonnier Itere (IPD), tournoi d'Axelrod, strategies classiques (TitForTat, Pavlov, Generous TitForTat), dynamique evolutive (processus de Moran), emergence de la cooperation."
     - "Idiomes framework : Python = `numpy` + `matplotlib` + `matplotlib.animation` (viz dynamique du tournoi round-robin + courbes de Moran). C# = pur `System.*` (Collections.Generic, Linq) + moteur IPD from-scratch (T=5/R=3/P=1/S=0 convention Axelrod) ; 0 NuGet tiers."
     - "Asymetrie pedagogique : Python utilise matplotlib.animation pour la viz dynamique (gif-like) du tournoi + process de Moran ; le C# travaille en pur System.* sans viz dynamique (asci-art + tableaux). Meme socle theorique (Axelrod + Moran), leviers de demonstration differents (viz riche cote Python, code from-scratch minimaliste cote C#)."
+- name: "GameTheory-7 ExtensiveForm"
+  family: GameTheory/.NET-Parity
+  python: MyIA.AI.Notebooks/GameTheory/GameTheory-7-ExtensiveForm.ipynb
+  csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-7-ExtensiveForm-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-25"
+    by: po-2023
+    python_sha: da5dc9d2c05d6688d03a1097215d4cb7b69228a6
+    csharp_sha: 818b2295149aad115c286816c9ad242f964b400c
+  known_differences:
+    - "Socle pedagogique commun : jeux sous forme extensive (arbre de jeu sequentiel avec noeuds de decision/terminal/chance + infosets), backward induction (induction en arriere) pour calculer les SPE (Subgame Perfect Equilibria), exemple canonique du jeu d'entree sur le marche (entrant vs incumbente)."
+    - "Idiomes framework : Python = `@dataclass` + `networkx` (graphe arborescent + rendu matplotlib des arbres de jeu) + implementation manuelle de `backward_induction` + `ConvertToNormal` (reduction extensive-vers-normal). C# = **BCL .NET pur 0 NuGet** (modele `GameNode` decision/terminal/chance + `ExtensiveFormGame` from-scratch) + **rendu ASCII de l'arbre** (pas de viz graphique, fidele a la contrainte 0-NuGet de la serie)."
+    - "Asymetrie de couverture pedagogique : le Python detaille 35 cellules (15 code + 20 markdown, 9 sections + 3 exercices sur l'entree multi-joueurs, Chain-Store paradox, SPE verification, conversion extensive-vers-normale, integration Lean). Le C# couvre 24 cellules (10 code + 14 markdown, 5 couches : modele, exemple entree, SPE par backward induction, Card Game to normal form, exercices) -- coverage plus compacte, fidele au format twin de la serie. Meme theorie (Kuhn 1953, Selten 1965 SPE), leviers pedagogiques differents."
 
 # === Tranche 5 SemanticWeb/dotNetRDF-rdflib (c.809, po-2024, 2026-07-23) — famille supplementaire #8057 ===
 

--- a/scripts/notebook_tools/twin_pairs.yaml
+++ b/scripts/notebook_tools/twin_pairs.yaml
@@ -785,6 +785,20 @@
     - "Socle pedagogique commun : theorie des jeux combinatoires impartiaux (positions P/N, jeu de Nim, nim-sum / theoreme de Bouton 1901, fonction mex (minimum excludant), valeurs de Grundy, theoreme de Sprague-Grundy, jeux de soustraction). Mathematique pure sans solveur tiers (les deux cotes implementent mex + Grundy + nim-sum from-scratch)."
     - "Idiomes framework : Python = `numpy` + `matplotlib` (rendu visuel des sequences de valeurs de Grundy / partition P-N sur les tas de Nim). C# = **BCL .NET pur 0 NuGet** (noms: `GameNode`/`GrundyValue`/`Mex`/`NimSum` from-scratch, XOR bit-a-bit sur `int` pour le nim-sum) -- aucun package tiers, fidele a la contrainte 0-NuGet de la serie."
     - "Asymetrie de couverture pedagogique : le Python (26 cellules : 11 code + 15 markdown, 7 sections P/N + Nim + mex + Grundy + Sprague-Grundy + soustraction + exercices) ajoute la visualisation matplotlib des sequences de Grundy ; le C# (24 cellules : 11 code + 13 markdown, meme canevas P/N + Bouton + mex + Grundy + Sprague-Grundy + soustraction) reste en sortie console/ASCII sans viz graphique. Meme theorie (Bouton 1901, Sprague-Grundy), leviers de demonstration differents (viz numerique cote Python, code from-scratch minimaliste cote C#)."
+- name: "GameTheory-9 BackwardInduction"
+  family: GameTheory/.NET-Parity
+  python: MyIA.AI.Notebooks/GameTheory/GameTheory-9-BackwardInduction.ipynb
+  csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-9-BackwardInduction-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-25"
+    by: po-2023
+    python_sha: 3e4b8db7fa1be8db9c169c8ae60ddf41e37b166f
+    csharp_sha: 0d8a290aead6260078144abe41c5987fc5c2893a
+  known_differences:
+    - "Socle pedagogique commun : l'algorithme d'induction en arriere (backward induction) pour resoudre les jeux sequentiels et calculer les equilibres de sous-jeu parfait (SPE, Selten 1965), applique aux paradoxes canoniques : jeu du mille-pattes (Centipede Game), guerre d'usure (War of Attrition), paradoxe de la chaine de magasins (Chain-Store paradox, Selten 1978). Distinct du GT-7 ExtensiveForm (qui pose la formalisme extensive-form + reduction extensive-vers-normale) : le GT-9 centre l'algorithme d'induction arriere et les paradoxes qu'il fait surgir."
+    - "Idiomes framework : Python = `networkx` (arbre de jeu) + `numpy` + `matplotlib` (rendu graphique des arbres et des trajectoires d'induction) + `@dataclass` + implementation manuelle de l'induction arriere. C# = **BCL .NET pur 0 NuGet** (modele d'arbre de jeu from-scratch + section dediee « Visualisation ASCII de l'arbre de jeu » en sortie console)."
+    - "Asymetrie de couverture pedagogique : le C# (26 cellules, 10 sections) couvre davantage de paradoxes explicitement (entree sur marche, Centipede, War of Attrition, Chain-Store + efficacite/rationalite limitee + viz ASCII) ; le Python (35 cellules, 7 sections + 4 exercices) detal l'algorithme, les limites de l'induction arriere et un resume. Meme theorie (Selten 1965 SPE, Selten 1978 Chain-Store), structuration pedagogique differente (Python focalise algorithme+limites, C# focalise catalogage des paradoxes + viz ASCII)."
 
 # === Tranche 5 SemanticWeb/dotNetRDF-rdflib (c.809, po-2024, 2026-07-23) — famille supplementaire #8057 ===
 

--- a/scripts/notebook_tools/twin_pairs.yaml
+++ b/scripts/notebook_tools/twin_pairs.yaml
@@ -771,6 +771,20 @@
     - "Socle pedagogique commun : jeux sous forme extensive (arbre de jeu sequentiel avec noeuds de decision/terminal/chance + infosets), backward induction (induction en arriere) pour calculer les SPE (Subgame Perfect Equilibria), exemple canonique du jeu d'entree sur le marche (entrant vs incumbente)."
     - "Idiomes framework : Python = `@dataclass` + `networkx` (graphe arborescent + rendu matplotlib des arbres de jeu) + implementation manuelle de `backward_induction` + `ConvertToNormal` (reduction extensive-vers-normal). C# = **BCL .NET pur 0 NuGet** (modele `GameNode` decision/terminal/chance + `ExtensiveFormGame` from-scratch) + **rendu ASCII de l'arbre** (pas de viz graphique, fidele a la contrainte 0-NuGet de la serie)."
     - "Asymetrie de couverture pedagogique : le Python detaille 35 cellules (15 code + 20 markdown, 9 sections + 3 exercices sur l'entree multi-joueurs, Chain-Store paradox, SPE verification, conversion extensive-vers-normale, integration Lean). Le C# couvre 24 cellules (10 code + 14 markdown, 5 couches : modele, exemple entree, SPE par backward induction, Card Game to normal form, exercices) -- coverage plus compacte, fidele au format twin de la serie. Meme theorie (Kuhn 1953, Selten 1965 SPE), leviers pedagogiques differents."
+- name: "GameTheory-8 CombinatorialGames"
+  family: GameTheory/.NET-Parity
+  python: MyIA.AI.Notebooks/GameTheory/GameTheory-8-CombinatorialGames.ipynb
+  csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-8-CombinatorialGames-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-25"
+    by: po-2023
+    python_sha: a05c2bac3f2e12aa36afddb33e8e4b15653628de
+    csharp_sha: 5ae7bab857a02e49e8f6f483e11787c5222fa010
+  known_differences:
+    - "Socle pedagogique commun : theorie des jeux combinatoires impartiaux (positions P/N, jeu de Nim, nim-sum / theoreme de Bouton 1901, fonction mex (minimum excludant), valeurs de Grundy, theoreme de Sprague-Grundy, jeux de soustraction). Mathematique pure sans solveur tiers (les deux cotes implementent mex + Grundy + nim-sum from-scratch)."
+    - "Idiomes framework : Python = `numpy` + `matplotlib` (rendu visuel des sequences de valeurs de Grundy / partition P-N sur les tas de Nim). C# = **BCL .NET pur 0 NuGet** (noms: `GameNode`/`GrundyValue`/`Mex`/`NimSum` from-scratch, XOR bit-a-bit sur `int` pour le nim-sum) -- aucun package tiers, fidele a la contrainte 0-NuGet de la serie."
+    - "Asymetrie de couverture pedagogique : le Python (26 cellules : 11 code + 15 markdown, 7 sections P/N + Nim + mex + Grundy + Sprague-Grundy + soustraction + exercices) ajoute la visualisation matplotlib des sequences de Grundy ; le C# (24 cellules : 11 code + 13 markdown, meme canevas P/N + Bouton + mex + Grundy + Sprague-Grundy + soustraction) reste en sortie console/ASCII sans viz graphique. Meme theorie (Bouton 1901, Sprague-Grundy), leviers de demonstration differents (viz numerique cote Python, code from-scratch minimaliste cote C#)."
 
 # === Tranche 5 SemanticWeb/dotNetRDF-rdflib (c.809, po-2024, 2026-07-23) — famille supplementaire #8057 ===
 


### PR DESCRIPTION
## Context

Registers the **GameTheory-8 CombinatorialGames** Python<->C# parity pair in `scripts/notebook_tools/twin_pairs.yaml`. **Stacked on #8476** (GT-7) — rebases cleanly onto main once #8476 merges (GT-8 entry inserted after GT-7, no overlap).

## Entry (firsthand audit of both notebooks on origin/main)

| field | value |
|-------|-------|
| name | GameTheory-8 CombinatorialGames |
| family | GameTheory/.NET-Parity |
| parity_level | semantic |
| Python (26 cells) | `numpy` + `matplotlib` — viz of Grundy value sequences + P/N partition over Nim heaps |
| C# (24 cells) | **BCL .NET pur 0-NuGet** — `GrundyValue`/`Mex`/`NimSum` from-scratch, XOR bit-à-bit |
| theory (both) | impartial combinatorial games: P/N positions, Nim, nim-sum (Bouton 1901), mex, Grundy values, Sprague-Grundy theorem, subtraction games |
| asymmetry | Python adds matplotlib numerical viz; C# stays console/ASCII, 0-NuGet minimal from-scratch |

## Verification (evidence-cited)

| Check | Result |
|-------|--------|
| Blob SHAs vs `origin/main` | python `a05c2bac3f2e12aa36afddb33e8e4b15653628de`, csharp `5ae7bab857a02e49e8f6f483e11787c5222fa010` — verified via `git ls-tree` |
| YAML parse | OK |
| `check_twin_parity.py --family GameTheory/.NET-Parity` | **`[OK] GameTheory-8 CombinatorialGames`** — 7 pairs, OK=7 DRIFT=0 MISSING=0 |
| diff vs #8476 base | `+14/-0`, `twin_pairs.yaml` only |
| catalogue | byte-identical to main |

## Vein note (for future tranches)

Completeness scan: 16 GT pairs exist on disk (GT-2..17); only 5 were registered on main before this cycle. With GT-7 (#8476) + GT-8 (here) = 7 registered. **Remaining gap: GT-9..GT-17 (9 pairs)** — candidate future twin-register tranches, each needs a real per-pair audit (read both notebooks, parity_level, known_differences, blob SHAs).

See #8057 (twin-parity metadata, parent #4208).