### PR TITLE
feat(twin-register,#8057): register GameTheory-10 ForwardInduction-SPE pair

### DIFF
--- a/scripts/notebook_tools/twin_pairs.yaml
+++ b/scripts/notebook_tools/twin_pairs.yaml
@@ -1237,3 +1237,21 @@
     - "Python : unified-planning HTN. C# : from-scratch BCL .NET (Predicat grounde, Etat, decomposition de methodes)."
     - "po-2025 a enrichi firsthand (c.678, PR #8173) le cote Python (instance discriminante m_deliver_direct vs m_deliver_via_intermediate)."
     - "Re-baseline 2026-07-25 (po-2024, consolidation #8264) : SHA Python avance depuis l'audit 2026-07-23 via #8173 (enrichissement method-selection demonstration (backtracking) cote Python) ; drift verifie paraphite-preservant (ne touche pas l'axe de parite semantic)."
+
+# === Tranche 6 GameTheory/.NET-Parity completeness (c.734, po-2026) — famille supplementaire #8057 ===
+
+- name: "GameTheory-10 ForwardInduction-SPE"
+  family: GameTheory/.NET-Parity
+  python: MyIA.AI.Notebooks/GameTheory/GameTheory-10-ForwardInduction-SPE.ipynb
+  csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-10-ForwardInduction-SPE-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-25"
+    by: po-2026
+    python_sha: 4e6012c9ddacf33ff951f6068155bf38fa5a4ff6
+    csharp_sha: 76c53cf7c98bf8e089035bf7304e8e45b5e6488d
+  known_differences:
+    - "Socle pedagogique commun : raffinements d'equilibre sur formes extensives — Sous-jeux et SPE (backward induction), menaces/promesses credibles, induction avant (Forward Induction), perfection en mains tremblantes (trembling-hand perfection), application Burn Money, comparaison des raffinements. 8 sections en miroir, exercices alignes (Ex 4 jeu d'entree avec signal de prix, Ex 5 identification des SPE communs)."
+    - "Algorithmes partages : les deux twins implementent backward induction (SPE), trembling-hand perfection (perturbation epsilon) et l'analyse Burn Money — parite au niveau algorithmique, pas seulement narratif."
+    - "Idiomes framework : Python = numpy + matplotlib (viz : Ellipse pour les nœuds d'arbre de jeu, 9 appels plt, courbes de comparaison des raffinements) + dataclasses + typing. C# = pur System.* (System / System.Collections.Generic / System.Linq), 0 NuGet tiers, presentation tabulaire/asci sans viz graphique."
+    - "Asymetrie pedagogique : Python exploite matplotlib pour la visualisation des arbres extensifs et des frontieres de raffinements ; le C# travaille en BCL pure sans viz (tableaux + asci). Meme socle theorique (Selten SPE/trembling-hand + Kohlberg-Mertens forward induction + Burn Money), leviers de demonstration differents (viz riche cote Python, code from-scratch minimaliste cote C#)."


### PR DESCRIPTION
## Summary

Completeness gap in the twin-parity register (#8057): **16 GameTheory Python/C# pairs exist on disk, only GT-2..GT-6 are registered** on `origin/main`. po-2023 mapped this gap (c.910) and is filling it sequentially (GT-7 #8476, GT-8 #8477, both open). This PR registers **GT-10 ForwardInduction-SPE** — picked from the middle of the gap (GT-9..GT-17) to deconflict from po-2023's sequential path.

## Firsthand G.1 audit (worktree at origin/main `601bae9c6`)

**Blob SHAs** (`git ls-tree origin/main`):
- python `4e6012c9ddacf33ff951f6068155bf38fa5a4ff6`
- csharp `76c53cf7c98bf8e089035bf7304e8e45b5e6488d`

**Parity level: `semantic`** — both twins share:
- **Same 8-section structure**: (1) Sous-jeux & SPE, (2) Menaces/promesses crédibles, (3) Induction avant (Forward Induction), (4) Perfection en mains tremblantes, (5) Burn Money, (6) Comparaison des raffinements, (7) Exercices, (8) Résumé.
- **Same core algorithms** (verified by source grep, not just narrative): backward induction (SPE), trembling-hand perfection (epsilon perturbation), Burn Money analysis — parity is at the algorithmic level.
- **Aligned exercises**: Ex 4 (jeu d'entrée avec signal de prix) and Ex 5 (identification des SPE) appear in both.

**Idiomatic asymmetry** (the legitimate `known_differences`):
- **Python**: `numpy` + `matplotlib` (Ellipse patches for extensive-form game-tree node viz, 9 `plt.` calls, comparison curves) + `dataclasses` + `typing`.
- **C#**: pure `System.*` (`System` / `System.Collections.Generic` / `System.Linq`), **0 NuGet** (confirmed: 0 `#r "nuget"` refs, 3 `using`), tabular/asci presentation without graphical viz.

Same theory socle (Selten SPE/trembling-hand, Kohlberg-Mertens forward induction, Burn Money), different demonstration levers (rich viz Python vs from-scratch minimalist C#).

## Verification

- `check_twin_parity.py --family GameTheory/.NET-Parity --base origin/main --per-pair`:
  `[OK] GameTheory-10 ForwardInduction-SPE (GameTheory/.NET-Parity, semantic) base=MISSING head=OK`
  (`base=MISSING` = new registration, `head=OK` = registered blob SHAs match current files).
- YAML parses (`yaml.safe_load` → 80 entries, +1 from 79).
- `git diff --stat`: `+18 / -0`, **single file** (`twin_pairs.yaml`).
- Both notebooks byte-identical (`git diff origin/main` = 0 lines each).
- Catalogue byte-identical (not touched).
- CRLF = 0 (`grep -c $'\r'` = 0 on working file; `git diff --check` empty).

## Placement note

Appended at **EOF** (new "Tranche 6" header) rather than mid-file after GT-6, to be conflict-safe against po-2023's mid-file GT-7/GT-8 inserts (#8476/#8477). `check_twin_parity` is name-keyed, so registry order is not load-bearing.

See #8057

Co-Authored-By: Claude <noreply@anthropic.com>
