### PR TITLE
fix(audio,#8052): 02-3 MusicGen interp[19] RTF 0.5-2x (GPU) -> observed 0.21-0.24x

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-3-MusicGen-Generation.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-3-MusicGen-Generation.ipynb
@@ -960,7 +960,7 @@
     "\n",
     "| Aspect | Valeur typique | Signification |\n",
     "|--------|---------------|---------------|\n",
-    "| Ratio temps reel | 0.5-2x (GPU) | La generation musicale est plus lente que le TTS |\n",
+    "| Ratio temps reel | 0.21-0.24x (observe, GPU) | La generation musicale est plus lente que le TTS |\n",
     "| Qualite audio | 32kHz mono | Qualite correcte pour la musique generee |\n",
     "| Coherence | Bonne | La musique suit généralement bien la description |\n",
     "\n",


### PR DESCRIPTION
## Summary

`02-3-MusicGen-Generation.ipynb` INTERP[19] (text-to-music interpretation table) claimed **"Ratio temps reel | 0.5-2x (GPU)"** but the committed `code[16]` output shows the three 10s generations took **47.12 / 46.01 / 42.11 s** = RTF **0.21 / 0.22 / 0.24x** (MusicGen convention `audio_duration / gen_time`). `code[38]` session stats confirm the run was on **GPU (cuda, VRAM 4.16 GB)** — so the "GPU" qualifier was correct, but the figure itself was a stale prior never re-read against the committed output.

**#8364 root-cause verdict: case (A)** — markdown-prior-vs-committed-output drift. The prose was written from assumed ranges, not from re-reading the actual output. Not a degraded run (the run is real and on GPU); the markdown simply predated / ignored the committed numbers.

## Change (1 cell, +1/-1)

| Cell | Before | After |
|------|--------|-------|
| INTERP[19] | `\| Ratio temps reel \| 0.5-2x (GPU) \| La generation musicale est plus lente que le TTS \|` | `\| Ratio temps reel \| 0.21-0.24x (observe, GPU) \| La generation musicale est plus lente que le TTS \|` |

"La generation musicale est plus lente que le TTS" is preserved (still true at 0.21-0.24x RTF).

## Evidence (committed outputs)

- `code[16]`: `Duree : 10.0s | Temps de generation : 47.12s / Ratio temps reel : 0.21x` (jazz), `0.22x` (ambient), `0.24x` (rock)
- `code[38]`: `Device : cuda`, `VRAM utilisee : 4.16 GB`, `Modele : facebook/musicgen-medium`

## Validation (H.3)

- nbformat JSON valid; **0** C.1 violations (`raise NotImplementedError`/`assert False`/`1/0`)
- **Markdown-only edit (C.2 exception)**: 13 code cells byte-identical (sha1), all code **outputs byte-identical** (sha1) — no re-execution needed
- Byte-surgical raw text-replace (file is 2.67 MB base64-heavy; `json.dumps` round-trip would churn untouched cells). LF-only encoding preserved.
- Catalogue byte-identical to main (not touched).

## Audit scope (FAITHFUL, untouched)

- **INTERP[18]**: correctly cites "0.21-0.24x (ce run)"
- **INTERP[25]** (temperature sweep): point "La temperature n'affecte pas significativement le temps" verified by ~constant 41.89/44.38/43.41/45.47 s; RMS sweep exact
- **INTERP[31]** (melody conditioning): qualitative, FAITHFUL
- **INTERP[39]** (architecture / model-variant documentation): reference info, FAITHFUL

## Out of scope (tracked, not scrubbed)

Machine-path leak in `code[38]` **output** (`D:\Dev\CoursIA\.claude\worktrees\audio-embed-023\...`) is a committed cell **output** (secrets-hygiene rule 6, Stop & Repair) → routed to the po-2023 audio re-exec lane, not hand-scrubbed in this markdown PR.

See #8052 (partial contribution to the epic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)