### PR TITLE
feat(twin-register,#8057): register GameTheory-9 BackwardInduction pair

### DIFF
--- a/scripts/notebook_tools/twin_pairs.yaml
+++ b/scripts/notebook_tools/twin_pairs.yaml
@@ -785,6 +785,20 @@
     - "Socle pedagogique commun : theorie des jeux combinatoires impartiaux (positions P/N, jeu de Nim, nim-sum / theoreme de Bouton 1901, fonction mex (minimum excludant), valeurs de Grundy, theoreme de Sprague-Grundy, jeux de soustraction). Mathematique pure sans solveur tiers (les deux cotes implementent mex + Grundy + nim-sum from-scratch)."
     - "Idiomes framework : Python = `numpy` + `matplotlib` (rendu visuel des sequences de valeurs de Grundy / partition P-N sur les tas de Nim). C# = **BCL .NET pur 0 NuGet** (noms: `GameNode`/`GrundyValue`/`Mex`/`NimSum` from-scratch, XOR bit-a-bit sur `int` pour le nim-sum) -- aucun package tiers, fidele a la contrainte 0-NuGet de la serie."
     - "Asymetrie de couverture pedagogique : le Python (26 cellules : 11 code + 15 markdown, 7 sections P/N + Nim + mex + Grundy + Sprague-Grundy + soustraction + exercices) ajoute la visualisation matplotlib des sequences de Grundy ; le C# (24 cellules : 11 code + 13 markdown, meme canevas P/N + Bouton + mex + Grundy + Sprague-Grundy + soustraction) reste en sortie console/ASCII sans viz graphique. Meme theorie (Bouton 1901, Sprague-Grundy), leviers de demonstration differents (viz numerique cote Python, code from-scratch minimaliste cote C#)."
+- name: "GameTheory-9 BackwardInduction"
+  family: GameTheory/.NET-Parity
+  python: MyIA.AI.Notebooks/GameTheory/GameTheory-9-BackwardInduction.ipynb
+  csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-9-BackwardInduction-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-25"
+    by: po-2023
+    python_sha: 3e4b8db7fa1be8db9c169c8ae60ddf41e37b166f
+    csharp_sha: 0d8a290aead6260078144abe41c5987fc5c2893a
+  known_differences:
+    - "Socle pedagogique commun : l'algorithme d'induction en arriere (backward induction) pour resoudre les jeux sequentiels et calculer les equilibres de sous-jeu parfait (SPE, Selten 1965), applique aux paradoxes canoniques : jeu du mille-pattes (Centipede Game), guerre d'usure (War of Attrition), paradoxe de la chaine de magasins (Chain-Store paradox, Selten 1978). Distinct du GT-7 ExtensiveForm (qui pose la formalisme extensive-form + reduction extensive-vers-normale) : le GT-9 centre l'algorithme d'induction arriere et les paradoxes qu'il fait surgir."
+    - "Idiomes framework : Python = `networkx` (arbre de jeu) + `numpy` + `matplotlib` (rendu graphique des arbres et des trajectoires d'induction) + `@dataclass` + implementation manuelle de l'induction arriere. C# = **BCL .NET pur 0 NuGet** (modele d'arbre de jeu from-scratch + section dediee « Visualisation ASCII de l'arbre de jeu » en sortie console)."
+    - "Asymetrie de couverture pedagogique : le C# (26 cellules, 10 sections) couvre davantage de paradoxes explicitement (entree sur marche, Centipede, War of Attrition, Chain-Store + efficacite/rationalite limitee + viz ASCII) ; le Python (35 cellules, 7 sections + 4 exercices) detal l'algorithme, les limites de l'induction arriere et un resume. Meme theorie (Selten 1965 SPE, Selten 1978 Chain-Store), structuration pedagogique differente (Python focalise algorithme+limites, C# focalise catalogage des paradoxes + viz ASCII)."
 
 # === Tranche 5 SemanticWeb/dotNetRDF-rdflib (c.809, po-2024, 2026-07-23) — famille supplementaire #8057 ===
 


### PR DESCRIPTION
## Context

Registers the **GameTheory-9 BackwardInduction** Python<->C# parity pair. **Stacked on #8477** (GT-8), which is itself stacked on #8476 (GT-7) — linear stack, rebases cleanly onto main once the lower PRs merge.

## Entry (firsthand audit of both notebooks on origin/main)

| field | value |
|-------|-------|
| name | GameTheory-9 BackwardInduction |
| family | GameTheory/.NET-Parity |
| parity_level | semantic |
| Python (35 cells, 7 sections + 4 exercises) | `networkx` (game tree) + `numpy` + `matplotlib` tree viz + `@dataclass` + manual backward induction |
| C# (26 cells, 10 sections) | **BCL .NET pur 0-NuGet** — game-tree from-scratch + dedicated "Visualisation ASCII de l'arbre de jeu" section |
| theory (both) | backward-induction algorithm → SPE (Selten 1965); applied to Centipede (Mille-pattes), War of Attrition, Chain-Store paradox (Selten 1978) |
| distinction from GT-7 | GT-7 = extensive-form *formalism* + extensive→normal reduction; GT-9 = backward-induction *algorithm* + the paradoxes it surfaces |

## Verification (evidence-cited)

| Check | Result |
|-------|--------|
| Blob SHAs vs `origin/main` | python `3e4b8db7fa1be8db9c169c8ae60ddf41e37b166f`, csharp `0d8a290aead6260078144abe41c5987fc5c2893a` — verified via `git ls-tree` |
| YAML parse | OK |
| `check_twin_parity.py --family GameTheory/.NET-Parity` | **`[OK] GameTheory-9 BackwardInduction`** — 8 pairs, OK=8 DRIFT=0 MISSING=0 |
| diff vs #8477 base | `+14/-0`, `twin_pairs.yaml` only |
| catalogue | byte-identical to main |

## Vein progress

GT-2..8 now registered (8 of 16 pairs on disk). **Remaining gap: GT-10..GT-17 (8 pairs)** for future tranches.

See #8057 (twin-parity metadata, parent #4208).