### PR TITLE
feat(twin-register,#8057): register Search-4-LocalSearch pair

### DIFF
--- a/scripts/notebook_tools/twin_pairs.yaml
+++ b/scripts/notebook_tools/twin_pairs.yaml
@@ -1237,3 +1237,21 @@
     - "Python : unified-planning HTN. C# : from-scratch BCL .NET (Predicat grounde, Etat, decomposition de methodes)."
     - "po-2025 a enrichi firsthand (c.678, PR #8173) le cote Python (instance discriminante m_deliver_direct vs m_deliver_via_intermediate)."
     - "Re-baseline 2026-07-25 (po-2024, consolidation #8264) : SHA Python avance depuis l'audit 2026-07-23 via #8173 (enrichissement method-selection demonstration (backtracking) cote Python) ; drift verifie paraphite-preservant (ne touche pas l'axe de parite semantic)."
+
+# === Tranche 7 Search/Part1-Foundations completeness (c.735, po-2026) — famille supplementaire #8057 ===
+
+- name: "Search-4 LocalSearch"
+  family: Search/Part1-Foundations
+  python: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-4-LocalSearch.ipynb
+  csharp: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-4-LocalSearch-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-25"
+    by: po-2026
+    python_sha: 46c0f7def3b5d5a0590fc4be85cb0a889fa9c125
+    csharp_sha: 55536c0fbc1e28b660208f9d7e21c40d6fd563fe
+  known_differences:
+    - "Socle pedagogique commun : metaheuristiques de recherche locale — Hill Climbing (variations steepest/first-improvement + diagnosis plateau/ridge), Simulated Annealing (schema de refroidissement, critere de Metropolis), Tabu Search (liste tabou, memoire a court terme). Comparaison empirique sur N-Reines. Les deux twins implementent les 3 algorithmes from-scratch (parite algorithmique, pas seulement narratif)."
+    - "Citations canoniques presentes des deux cotes (audit #8081 po-2023 c.909) : Kirkpatrick/Gelatt/Vecchi 1983 (Simulated Annealing, Science), Glover 1986/1989 (Tabu Search), Russell & Norvig AIMA (cadre local search)."
+    - "Idiomes framework : Python = stdlib + numpy/matplotlib (viz des paysages de fitness, courbes de convergence par temperature, 11 imports, 62 cellules avec demos riches N-Reines). C# = pur System.* (System / System.Collections.Generic / System.Linq), 0 NuGet, 2 using, 28 cellules (implementation minimale from-scratch, presentation tabulaire)."
+    - "Asymetrie pedagogique : Python exploite matplotlib pour la visualisation des paysages de fitness et courbes de refroidissement + section comparative N-Reines approfondie ; le C# travaille en BCL pure sans viz (tableaux + asci), implementation plus compacte. Meme socle theorique (3 metaheuristiques classiques + citations), leviers de demonstration differents."


### PR DESCRIPTION
## Summary

Completeness scan revealed **85 unregistered C# twins across families** (not just GameTheory — po-2023 mapped only the GT gap). po-2023/po-2024 are tunneling GT/Audio, so **Search/Part1-Foundations is an unclaimed vein**: Search-1/2/3 are registered, Search-4..15 are NOT. This PR registers **Search-4-LocalSearch**.

## Firsthand G.1 audit (worktree at origin/main `601bae9c6`)

**Blob SHAs** (`git ls-tree origin/main`):
- python `46c0f7def3b5d5a0590fc4be85cb0a889fa9c125`
- csharp `55536c0fbc1e28b660208f9d7e21c40d6fd563fe`

**Parity level: `semantic`** — both twins implement the **same 3 metaheuristics from-scratch** (algorithmic parity, not just narrative):
- Hill Climbing (steepest/first-improvement + plateau/ridge diagnosis)
- Simulated Annealing (cooling schedule, Metropolis criterion)
- Tabu Search (tabu list, short-term memory)
- N-Reines empirical comparison

**Canonical citations present both sides** (verified by po-2023 #8081 fidelity audit c.909): Kirkpatrick/Gelatt/Vecchi 1983 (*Science*), Glover 1986/1989, Russell & Norvig *AIMA*.

**Idiomatic asymmetry** (legitimate `known_differences`):
- **Python**: stdlib + numpy/matplotlib — fitness-landscape viz, convergence curves by temperature; 62 cells with rich N-Reines demos.
- **C#**: pure `System.*` (`System` / `System.Collections.Generic` / `System.Linq`), **0 NuGet**, 2 `using`; 28 cells, compact from-scratch tabular presentation.

Same theory socle (3 classic metaheuristics + citations), different demonstration levers.

## Verification

- `check_twin_parity.py --family Search/Part1-Foundations --base origin/main --per-pair`:
  `[OK] Search-4 LocalSearch (Search/Part1-Foundations, semantic) base=MISSING head=OK`
- YAML parses (`yaml.safe_load` → 80 entries, +1).
- `git diff --stat`: `+18 / −0`, **single file**.
- Both notebooks + catalogue byte-identical.
- CRLF = 0; `git diff --check` empty.
- Append at EOF (conflict-safe vs parallel workers).

See #8057

Co-Authored-By: Claude <noreply@anthropic.com>
