### PR TITLE
fix(planners-3,#8052): CoutChemin path.Sum -> path.Skip(1).Sum (axe-2 off-by-one)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-3-State-Space-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-3-State-Space-Csharp.ipynb
@@ -650,21 +650,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFS               10    56     91       oui (5 cases)\r\n"
+      "BFS               10    55     91       oui (5 cases)\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Greedy            10    56     11       oui (5 cases)\r\n"
+      "Greedy            10    55     11       oui (5 cases)\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "A*                16    17     42       non\r\n"
+      "A*                16    16     42       non\r\n"
      ]
     },
     {
@@ -678,7 +678,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFS/Greedy : 10 pas (court) mais cout 56 (traverse le marais).\r\n"
+      "BFS/Greedy : 10 pas (court) mais cout 55 (traverse le marais).\r\n"
      ]
     },
     {
@@ -713,8 +713,13 @@
     "var (greedyW, _, greedyWnodes) = GreedyBestFirst(start, goal, succPondere, Manhattan);\n",
     "var (astarW, astarWcost, astarWnodes) = AStar(start, goal, succPondere, Manhattan);\n",
     "\n",
+    "// c.908 fix : Skip(1) exclut la case depart — CoutChemin doit sommer les couts D'ENTREE (cout(n->n')),\n",
+    "// pas les couts des cases du chemin. Sans Skip(1), CoutChemin = path.Sum(CoutCase) inclut CoutCase(depart)=1,\n",
+    "// soit +1 sur le cout reel. Convention : cout = somme des couts d'entree, depart exclu (= meme convention\n",
+    "// que Python `bfs`/`a_star` qui accumulent g a partir de 0 a l'etat initial, et que `astarWcost` interne).\n",
+    "// Resultat apres fix : BFS=55, A*=16 = Python twin (parite stricte, cf #8052 + #8475).\n",
     "int CoutChemin(List<GridState> path, HashSet<GridState> mz, int cMarais) =>\n",
-    "    path.Sum(s => CoutCase(s, mz, cMarais));\n",
+    "    path.Skip(1).Sum(s => CoutCase(s, mz, cMarais));\n",
     "int PasDansMarais(List<GridState> path) => path.Count(s => marais.Contains(s));\n",
     "\n",
     "// Tableau numerique (le twin Python le fait visuellement ; ici c'est la table Pas/Cout/Nœuds).\n",

--- a/scripts/notebook_tools/twin_pairs.yaml
+++ b/scripts/notebook_tools/twin_pairs.yaml
@@ -1144,13 +1144,14 @@
   csharp: MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-3-State-Space-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-23"
+    date: "2026-07-25"
     by: po-2023
     python_sha: 8d03359d12709b134f644e187d04249b6e1fcadf
-    csharp_sha: 435f49ca3c491cf320ddd9b9471fecc94f759f41
+    csharp_sha: a9306fbf5a3c02555bf3f63b03a35db099da423f
   known_differences:
     - "Concept : recherche dans l'espace d'etats (BFS/DFS/A* sur le graphe des etats reachables)."
-    - "Python : unified-planning engines. C# : from-scratch BFS/DFS/A* BCL .NET (meme algorithme, implementation idiomatic)."
+    - "Python : BFS/DFS/Greedy/A* via networkx + matplotlib heatmap terrain. C# : from-scratch BFS/DFS/Greedy/A* BCL .NET 9 + PriorityQueue (meme algorithme, implementation idiomatic)."
+    - "Prong-B terrain pondere (#3801) : parite stricte apres c.908 (BFS cout 55, A* cout 16 = Python twin). L'off-by-one CoutChemin(path.Sum) -> path.Skip(1).Sum a ete corrige en c.908 (avant : BFS=56, A*=17 = +1 par chemin, causait la fausse note 'parite semantique intacte' de #8436 qui alignait le twin C# sur l'erreur au lieu du ground truth)."
 - name: "Planners-4 Fast-Downward"
   family: SymbolicAI/Planners
   python: MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-4-Fast-Downward.ipynb


### PR DESCRIPTION
## c.908 — Planners-3 C# off-by-one (axe-2 SOTA pondere) — cout strict twin parity Python

**Grain:** MED/notebook-fix + sub-genre sha-only-rebaseline (L974 ★★★) — lane `myia-po-2023:CoursIA-2` — prev: c.907 LIGHT/cjk-correction (CJK tranche 5 #8428)
**Sub-genre:** `notebook-fix` (correctness axe-2 SOTA pondere) + twin-register sha-only-rebaseline (L974 ★★★) — c.906 GT-7 twin-register + c.904 GT-6 + c.903 GT-3 sont les precedents twin-register, c.908 = notebook-fix + SHA bump combiné
**Issue:** #8052 (axe-2 SOTA, epic Planners marathon) — canal audit cross-source
**Branch:** `feature/c908-planners3-offbyone`
**Commits:** `1a8f8a5ec` (notebook fix) + `5d1a1b130` (twin_pairs.yaml SHA bump + known_differences enrichi)
**Supersedes:** PR #8436 (jsboige/po-2024, OPEN, ai-01 HOLD) — wrong-direction (alignait C# sur l'erreur au lieu du ground truth Python)

## Cible

Planners-3 State-Space C# twin (axe-2 SOTA pondere, `PriorityQueue` .NET 9 from-scratch) avait un **off-by-one dans `CoutChemin`** : `path.Sum(s => CoutCase(s, ...))` inclut la case départ (cout=1) dans le total, soit +1 sur le coût réel. Convention canonique (Python `bfs`/`a_star` qui accumulent g à partir de 0 à l'état initial, et `astarWcost` interne C# déjà correct) = **coût = somme des coûts D'ENTRÉE (cout(n→n')), départ exclu**.

| Côté | Notebooks | Bug location | Pré-fix | Post-fix |
|---|---|---|---|---|
| **Python twin** | `Planners-3-State-Space.ipynb` | `bfs_cost_w`/`astar_cost_w` accumulent g entry-costs | 55 / 16 ✓ | 55 / 16 ✓ |
| **C# twin** | `Planners-3-State-Space-Csharp.ipynb` | `CoutChemin(path)` cell[14] ligne 22 | 56 / 17 ✗ | **55 / 16** ✓ (post-fix) |

## Approche — `path.Sum` → `path.Skip(1).Sum`

**Byte-surgical Python script** (L963 ★★★ méthode, JAMAIS `--update` sur `twin_pairs.yaml`) :

1. **Cell[14] source** (id=`e658a8a5`) — Edit raw JSON, list-of-lines preserved (chaque ligne finit par `\n` sauf la dernière, L982) :
   - Ligne 22 : `    path.Sum(s => CoutCase(s, mz, cMarais));\n` → `    path.Skip(1).Sum(s => CoutCase(s, mz, cMarais));\n`
   - +5 lignes de commentaire explicatif avant la def (convention, mathématiques du bug, convention Python twin, lien `#8052 + #8475`)
2. **Cell[14] outputs** — re-exécution via `exec_dotnet_persist.py` (canonical script, persistance outputs). Vérification C.2 :
   - BFS 56 → **55** ✓
   - Greedy 56 → **55** ✓
   - A* 17 → **16** ✓
   - Summary "cout 56" → "cout 55" ✓
3. **Cell[14] outputs key-order restored** — script a généré `output_type` AVANT `name` (alors que HEAD a `name` AVANT `output_type`) ; patch python a re-keyed pour matcher convention HEAD (zéro churn sur les autres cellules, C.3 strict scope)
4. **`twin_pairs.yaml`** rebaseline (L974 ★★★ sha-only-rebaseline, byte-surgical Edit sur la string ancrée ligne 1141-1153) :
   - `csharp_sha: 435f49ca3c491cf320ddd9b9471fecc94f759f41` → `a9306fbf5a3c02555bf3f63b03a35db099da423f` (from `git ls-tree HEAD`)
   - `date: "2026-07-23"` → `"2026-07-25"`
   - `known_differences` enrichi : parité stricte documentée + référence explicite à l'off-by-one c.908 + raison du `parité sémantique intacte` faux de #8436
5. **Conclusion cell[21]** : déjà correcte en HEAD (utilisait `astarWcost` qui était correct, pas `CoutChemin`) — aucune modif markdown nécessaire.

## Validations (firsthand)

| Validation | Résultat |
|---|---|
| **Cell[14] outputs re-exécution** | BFS cout=**55**, Greedy cout=**55**, A* cout=**16** = Python twin ✓ |
| **Conclusion cell[21] prose** | "16 pas / cout 16 en contournant le marais, vs BFS 10 pas / cout 55 en traversant" ✓ |
| **git diff --stat** | **+14/-8 strict, 2 fichiers** (notebook +10/-5 ; twin_pairs.yaml +4/-3) |
| **LF-only CR=0 (L965 ★)** | PASS notebook (0 CRLF), PASS twin_pairs.yaml (0 CRLF) |
| **Trailing newline (L268)** | PASS (les deux fichiers finissent par `\n`) |
| **yaml.safe_load round-trip** | PASS (79 entries parsed) |
| **`check_twin_parity.py --check`** | **79 OK / 0 DRIFT / 0 MISSING** (Planners-3 State-Space = OK) |
| **C.3 strict scope** | Seule cell[14] diffère ; autres cellules : key order preserved (zero churn adjacent) |
| **catalog-pr-hygiene HARD 1** | `COURSE_CATALOG.generated.{json,md}` byte-identique à origin/main (0 diff) ✓ |
| **catalog-pr-hygiene HARD 2** | Branche rebase frais depuis `origin/main` (HEAD `601bae9c6`) ✓ |
| **catalog-pr-hygiene HARD 3** | Atomique : +14/-8 strict, 2 fichiers, 1 sujet (off-by-one + SHA rebaseline cohérent) ✓ |
| **L898 ★★★ collision guard** | 0 PR OPEN cross-lane sur Planners-3-Csharp autre que #8436 (en HOLD, superseded par cette PR) |
| **L977 ★★ extension** | 0 PR OPEN sur "off-by-one Planners" / "Skip(1) CoutChemin" |

## Pattern rollout c.908 — twin-register + notebook-fix combiné

| Cycle | Sub-genre | Notebook | Action |
|---|---|---|---|
| c.903 | twin-register | GT-3 Topology2x2 | SHA bump (78→79) |
| c.904 | twin-register | GT-6 EvolutionTrust | SHA bump (78→79) |
| c.906 | twin-register | GT-7 ExtensiveForm | SHA bump (78→79) |
| **c.908** | **notebook-fix + SHA bump** | **Planners-3 State-Space C#** | **+SHA bump, parité stricte BFS=55/A*=16** |

c.908 = **MED notebook-fix axe-2 SOTA** (le moteur du notebook était cassé — CoutChemin ne respectait pas la convention twin). Cumul twin-register désormais cohérent : tous les Planners pairs Python↔C# sont en parité stricte numérique.

## Supersedes #8436 — wrong-direction (alignait C# sur l'erreur)

PR #8436 (jsboige/po-2024, OPEN, ai-01 HOLD) :
- Titre : "harmonize A* cost metric in Prong-B summary (cout 16->17)"
- Action : modifiait `astarWcost` (= cout 16 dans summary) → 17 pour matcher le CoutChemin buggé (17)
- Direction : **FAUSSE** — l'erreur est dans `CoutChemin` (incohérent avec `astarWcost`), pas dans le résumé. jsboige lui-même l'a confessé dans le commentaire ai-01 HOLD : "tu as raison, j'ai aligné sur l'erreur au lieu du ground truth".

c.908 corrige **la cause** (`CoutChemin` → `Skip(1)`), ce qui aligne automatiquement le résumé sur la valeur ground-truth 16 (sans toucher au résumé lui-même, car `astarWcost` était déjà 16 en interne).

**Action ai-01 souhaitée** : close #8436 sans merge (wrong-direction, superseded par c.908) + merge c.908 + clôture de l'axe off-by-one `Planners-3-Csharp#8052`.

## Garde-fous

- **L963 ★★★ byte-surgical** : JAMAIS `check_twin_parity.py --update` ; Edit regex ancrée twin_pairs.yaml ; notebook cell[14] via Python raw JSON (NotebookEdit avait un bug de sérialisation char-by-char sur Windows, contourné)
- **L965 ★** : LF-only CR=0 (raw.write_bytes(json.dumps(...).encode('utf-8') + b'\n'))
- **L974 ★★★ sha-only-rebaseline** : SHA from `git ls-tree HEAD`, pas d'estimation
- **L898 ★★★** : collision guard pre-push (0 PR OPEN cross-lane sur Planners-3 C# autre que #8436 superseded)
- **L977 ★★** : extension `gh pr list --search "Planners-3-State-Space-Csharp"`
- **L948 Stop & Repair** : aucune cellule non-touchée n'a vu ses outputs modifiés (C.3 strict scope — restore key-order post-exec)
- **L677-L4 ★★** : body PR HORS worktree (scratchpad pattern)
- **L982** : nbformat `source` = list-of-lines, chaque ligne finit par `\n` SAUF dernière — préservé
- **L268** : trailing newline mandatory (notebook + twin_pairs.yaml, vérifié binaire)
- **catalog-pr-hygiene HARD 1** : catalogue byte-identique à main (0 diff hors twin_pairs.yaml)
- **catalog-pr-hygiene HARD 2** : rebase frais depuis origin/main (HEAD `601bae9c6` — post-c.907 merge pre-#8465)
- **catalog-pr-hygiene HARD 3** : atomique (1 sujet = 1 notebook off-by-one + son SHA rebaseline cohérent)
- **catalog-pr-hygiene HARD 4** : `See #8052` (axe-2 SOTA, contribution partielle à l'epic) + `Refs #8057` (twin-register contribution)
- **C.2 notebooks AVEC outputs** : cell[14] `outputs` reflètent les nouvelles valeurs 55/55/16 (re-exécuté via `exec_dotnet_persist.py` canonical)
- **C.3 strict scope** : seule cell[14] diffère ; key-order préservé sur les autres cellules (Python post-processing)
- **G.9 culture du doute** : PR #8436 wrong-direction détectée (G.9 = "puis-je avoir tort ?") avant push, supersession honnête documentée
- **G-VAR-1** : plat principal = MED notebook-fix axe-2 SOTA (substance genuine, pas scan-générable)
- **G-VAR-2** : 0 LIGHT dans le cycle (c.907 = LIGHT, c.908 = MED, cap 1 LIGHT/lane/jour respecté)
- **G-VAR-3** : c.908 = MED/notebook-fix ≠ c.907 = LIGHT/cjk-correction ≠ c.906/c.904/c.903 = MED/twin-register. Sub-genre distinct, substance genuinement distincte (off-by-one correction ≠ SHA bump ≠ CJK glyph fix)
- **L954 ★★ pivot cross-famille** : c.907 = CJK Search-9, c.908 = Planners-3 SOTA — 2 familles distinctes (Search vs SymbolicAI/Planners), pas 2× consécutif même genre

## Hors scope

- **#8436 (jsboige/po-2024)** : OPEN en HOLD par ai-01. Si ai-01 clôture #8436 sans merge (wrong-direction, superseded par c.908) c'est la séquence canonique. Si ai-01 merge #8436 d'abord, jsboige doit immédiatement exécuter le twin-note unblock (documenter +1 divergence, ref #8475) — mais c.908 rend cette branche caduque puisque c.908 fixe la cause en amont.
- **Planners-1 Introduction C#** (sibling du même marathon, pas de bug CoutChemin) : hors scope, pas de régression connexe.
- **Planners-4 à Planners-9** : siblings du marathon, aucun ne porte `CoutChemin` (vérifié par grep), hors scope c.908.
- **#3801 Prong-A SOTA** : Planners-3 n'invoque pas de service externe (from-scratch BCL .NET) — verdict SOTA-OK par construction.
- **#3801 Prong-B** : c.908 AMÉLIORE la discrimination (cout réel aligné, A* montre vraiment son avantage 16 vs BFS 55) — vérifié mathématiquement.

## Voir aussi

- Issue : [#8052](https://github.com/jsboige/CoursIA/issues/8052) (axe-2 SOTA, Planners marathon)
- PR supersedé : [#8436](https://github.com/jsboige/CoursIA/pull/8436) (wrong-direction, ai-01 HOLD)
- `scripts/notebook_tools/twin_pairs.yaml` ligne 1141-1155 (Planners-3 entry, sha `a9306fbf5a3c02555bf3f63b03a35db099da423f`)
- Méthode : L963 ★★★ + L965 ★ + L974 ★★★ + L898 ★★★ + L977 ★★ + L948 + L982 + L268
- Précédent twin-register : c.906 GT-7 PR #8458 + c.904 GT-6 PR #8456 + c.903 GT-3 PR #8448
- Topic : `~/.claude/projects/d--Dev-CoursIA-2/memory/topic-c908-planners3-offbyone.md` (à écrire post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
