### PR TITLE
fix(gametheory,#8052): GT-13 CFR cell[30] exploitability inequality (0.000112=0.011%, not <0.01%)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-13-ImperfectInfo-CFR.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-13-ImperfectInfo-CFR.ipynb
@@ -2482,7 +2482,7 @@
     "\n",
     "**Points cles** :\n",
     "- L'exploitabilite decroit exponentiellement avec les itérations\n",
-    "- A 10000 itérations, on est a moins de 0.01% de l'equilibre parfait\n",
+    "- A 10000 itérations, on est a environ 0.01% de l'equilibre parfait (exploitabilite 0.000112, soit ~0.011%)\n",
     "- Les stratégies affichees (ex: `0: {0: 0.80, 1: 0.20}`) montrent la probabilite de chaque action (0=pass, 1=bet)\n",
     "\n",
     "> **Note technique** : L'indexation des cartes dans OpenSpiel (0, 1, 2) correspond a Jack, Queen, King. La stratégie pour l'info-set \"0\" (Jack en position initiale) montre bien un mix entre pass et bet, coherent avec l'equilibre théorique."


### PR DESCRIPTION
Grain: MED/notebook-python-audit-claims — lane myia-po-2024:CoursIA-2 — prev: DEEP/notebook-python (c.871 RL seed-repro)

## Problem

`GameTheory-13-ImperfectInfo-CFR.ipynb` cell[30] (markdown, "Points cles") claimed:

> A 10000 itérations, on est a **moins de 0.01%** de l'equilibre parfait

This is **false against the notebook's own committed output**. cell[28] (exec_count=10) prints the OpenSpiel CFR convergence table:

```
Iterations   Exploitabilite
1000         0.000970
2000         0.000529
5000         0.000181
10000        0.000112
```

At 10000 iters, exploitability = **0.000112 = 0.0112%**, which is **strictly greater than 0.01%**. The claim uses a strict inequality ("moins de" / "less than") that the data violates. A reader trusting "moins de 0.01%" would over-state CFR's convergence by ~12%.

## Fix

Markdown-only, single line (C.2 exception — no code cell touched, no re-exec, outputs byte-identical):

```
- A 10000 itérations, on est a moins de 0.01% de l'equilibre parfait
+ A 10000 itérations, on est a environ 0.01% de l'equilibre parfait (exploitabilite 0.000112, soit ~0.011%)
```

Drops the false strict inequality, marks the value explicitly as `~0.011%` (the honest figure, 0.000112), and cites the exact exploitability number so the prose is self-verifying against the table. Consistent with the table's own rounding (`10000 → 0.0001` in the SUMMARY table is correct rounding of 0.000112; the bug was only the prose inequality).

## Scope verified firsthand (G.1)

Re-measured every adjacent claim in the same cell before shipping (C869-L: recon doesn't measure derivable claims → reverify each):

- **cell[28] table `10000 → 0.000112`**: real committed output (firsthand, exec=10). The value my fix cites.
- **cell[29] "~13x superieure"**: CORRECT, no fix. cell[13] (exec=5) from-scratch CFR prints `Exploitabilite: 0.001486` at 10000 iters → `0.001486 / 0.000112 ≈ 13.3×`. The ratio claim holds.
- **cell[28] SUMMARY table `10000 → 0.0001`**: CORRECT (rounding of 0.000112), not touched.
- **No second defect** in the convergence interpretation.

## Verification (firsthand)

- `git diff --stat` = +1/-1, single markdown line (cell[30]), diff scope confirmed surgical.
- cell[28] exploitability output byte-identical (exec_count=10 preserved, table unchanged).
- Byte-surgical raw-bytes replace (not NotebookEdit — L772/L768: NotebookEdit rewrites whole notebook risking output drift); JSON round-trips valid, 44 cells unchanged.
- CRLF = 0 (`*.ipynb text eol=lf` respected).
- C.1 clean (markdown-only, no `raise NotImplementedError`/`assert False` introduced).
- NOT a registered twin on main (grep `twin_pairs.yaml` → empty; #8487 is the OPEN registration PR, config-only, doesn't touch this .ipynb) → no twin-parity rebaseline (C868-L N/A).
- Catalogue byte-identical to main (R1 — no catalogue file touched).

## Context

Found via a GameTheory Python audit-claims scan (c.872, sonnet sub-agent scan + firsthand verify per C855-L/C869-L). The scan also flagged a GT-4c "(Bas,Bas) equilibre" item — verified firsthand as a **FALSE POSITIVE** (cell[29] is a `## Exercice 1` stub, the markdown is theoretically correct game theory → not fixed, C869-L applied).

See #8052 (claims↔outputs audit epic). Not `Closes` — doc-honesty label fix, the audit epic remains open.

Co-Authored-By: Claude <noreply@anthropic.com>
