### PR TITLE
feat(twin-register,#8057): register GameTheory-11 BayesianGames pair

### DIFF
--- a/scripts/notebook_tools/twin_pairs.yaml
+++ b/scripts/notebook_tools/twin_pairs.yaml
@@ -813,6 +813,20 @@
     - "Socle pedagogique commun : les raffinements d'equilibre au-dela du SPE (Selten 1965) -- sous-jeux et equilibre parfait, menaces et promesses credibles, induction avant (forward induction), perfection en mains tremblantes (trembling-hand perfection, Selten 1975), application canonique du jeu du « Burn Money » (signal costly), comparaison des raffinements. Distinct du GT-9 (induction arriere + paradoxes) : le GT-10 porte sur les RAFFINEMENTS de la notion d'equilibre (forward induction, trembling-hand), pas sur l'algorithme de resolution."
     - "Idiomes framework : Python = `matplotlib` (patches `Ellipse` pour rendre les ensembles d'information / infosets sur l'arbre de jeu) + `itertools` + `@dataclass`. C# = **BCL .NET pur 0 NuGet** (modele d'arbre + sous-jeux + raffinements from-scratch, sortie console)."
     - "Couverture tres parallele (twins proches) : les deux cotes suivent les 8 memes sections (SPE, menaces/promesses credibles, forward induction, trembling-hand, Burn Money, comparaison des raffinements, exercices, resume) -- un des twins les plus structurellement alignes de la serie. Le Python (37 cellules : 15 code + 22 markdown) ajoute la viz graphique matplotlib des infosets (Ellipse) ; le C# (34 cellules : 13 code + 21 markdown) reste en console. Meme theorie (Selten 1965/1975), idiomes de visualisation differents."
+- name: "GameTheory-11 BayesianGames"
+  family: GameTheory/.NET-Parity
+  python: MyIA.AI.Notebooks/GameTheory/GameTheory-11-BayesianGames.ipynb
+  csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-11-BayesianGames-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-25"
+    by: po-2023
+    python_sha: bb2bfd9b2b51b7119a9b8c86ea4d63d6845a3d73
+    csharp_sha: 2072a62551b3f6bf76d586ca3b0305fb8e33f450
+  known_differences:
+    - "Socle pedagogique commun : jeux bayesiens (information incomplete / types et croyances), equilibre bayesien de Nash (BNE), applications canoniques : Bataille des Sexes avec incertitude, Cournot avec couts incertains, encheres a valeurs privees (first-price/second-price), introduction aux jeux de signalisation (signaling). Distinct des GT precedents (jeux a information complete) : le GT-11 introduit la « typologie des joueurs » et le calcul d'equilibre sous croyances."
+    - "Idiomes framework : Python = `scipy` (`integrate` pour les integrales d'esperance sur les types continus, `optimize.fsolve`/`minimize` pour resoudre les conditions du BNE) + `itertools` + `@dataclass`. C# = **BCL .NET pur 0 NuGet tiers** (le `#r \"Microsoft.DotNet.Interactive\"` est le kernel lui-meme, pas une dependance ; resolution analytique from-scratch via System.Math)."
+    - "Asymetrie de couverture et de puissance de calcul : le Python (48 cellules : 15 code + 33 markdown, 7 sections) exploite scipy pour les equilibres numeriques (Bataille des Sexes + Cournot + encheres resolus a la machine) ; le C# (26 cellules : 13 code + 13 markdown, meme canevas + References academiques) reste sur la resolution analytique manuelle (System.Math), couverture +compacte. Meme theorie (Harsanyi 1967-68 BNE), leviers numeriques differents (scipy vs from-scratch analytique)."
 
 # === Tranche 5 SemanticWeb/dotNetRDF-rdflib (c.809, po-2024, 2026-07-23) — famille supplementaire #8057 ===
 


### PR DESCRIPTION
## Context

Registers **GameTheory-11 BayesianGames**. Stacked on #8482 (GT-10) ← #8480 ← #8477 ← #8476; linear 5-stack, rebases cleanly once lower PRs merge.

## Entry (firsthand audit, both notebooks on origin/main)

| field | value |
|-------|-------|
| name | GameTheory-11 BayesianGames |
| family | GameTheory/.NET-Parity |
| parity_level | semantic |
| Python (48 cells, 7 sections) | `scipy` (`integrate`, `optimize.fsolve`/`minimize`) + `itertools` + `@dataclass` |
| C# (26 cells, 7 sections + References) | **0 third-party NuGet** (the `#r "Microsoft.DotNet.Interactive"` is the kernel, not a dep); analytical from-scratch via System.Math |
| theory (both) | Bayesian games (incomplete info, types + beliefs), BNE (Harsanyi 1967-68), Battle of the Sexes w/ uncertainty, Cournot w/ uncertain costs, private-value auctions, signaling intro |
| distinction | GT-11 introduces player typology + equilibrium under beliefs (vs complete-info GT-2..10) |

## Verification

| Check | Result |
|-------|--------|
| Blob SHAs vs `origin/main` | python `bb2bfd9b2b51b7119a9b8c86ea4d63d6845a3d73`, csharp `2072a62551b3f6bf76d586ca3b0305fb8e33f450` — verified `git ls-tree` |
| YAML parse | OK |
| `check_twin_parity.py --family GameTheory/.NET-Parity` | **`[OK] GameTheory-11 BayesianGames`** — 10 pairs OK=10 DRIFT=0 MISSING=0 |
| diff vs #8482 base | `+14/-0`, `twin_pairs.yaml` only |
| catalogue | byte-identical to main |

## Vein progress

GT-2..11 registered (10 of 16). **Remaining: GT-12..GT-17 (6 pairs)**. Reco: once #8476 lands, a single tranche-PR for GT-12..17 would be cleaner than a 6-deep stack.

See #8057 (twin-parity metadata, parent #4208).