### PR TITLE
docs(harness): add session-resume check as Phase 1 step 1 of /continue

### DIFF
--- a/.claude/commands/continue.md
+++ b/.claude/commands/continue.md
@@ -6,9 +6,10 @@ Reprendre le travail sur cette lane : lire les directives coordinateur, choisir 
 
 ### Phase 1 : Contexte (30s)
 
-1. Lire `MEMORY.md` (auto-memory) pour l'etat des sessions precedentes
-2. `git checkout main && git pull --ff-only` — repartir d'un main courant (les branches feature se rebasent frais, cf [catalog-pr-hygiene](../rules/catalog-pr-hygiene.md))
-3. `git status` — si l'arbre partage est sale (WIP d'une autre session), travailler en **worktree isole** : `git worktree add ../CoursIA-<sujet> -b feature/<sujet> origin/main`. Ne jamais stasher/toucher le WIP d'autrui.
+1. Etablir si la session précédente a été interrompue pour une raison fortuite (crash de l'environnement, saturation du crédit de tokens etc.), et quelles étapes restent à finaliser avant d'entreprendre une nouvelle session propre.
+2. Lire `MEMORY.md` (auto-memory) pour l'etat des sessions precedentes
+3. `git checkout main && git pull --ff-only` — repartir d'un main courant (les branches feature se rebasent frais, cf [catalog-pr-hygiene](../rules/catalog-pr-hygiene.md))
+4. `git status` — si l'arbre partage est sale (WIP d'une autre session), travailler en **worktree isole** : `git worktree add ../CoursIA-<sujet> -b feature/<sujet> origin/main`. Ne jamais stasher/toucher le WIP d'autrui.
 
 ### Phase 1.5 : Tour RooSync (obligatoire, AVANT de travailler)
 


### PR DESCRIPTION
## Summary

Add a session-resume check as the new **Phase 1, step 1** of the `/continue` worker command. Before starting a fresh cycle, the worker now first establishes whether the *previous* session was interrupted for a fortuitous reason (environment crash, token-credit saturation, etc.) and which steps remain to finalize — so a half-finished delivery (branch pushed but PR not opened, commit made but not pushed, dashboard report pending) is picked up rather than silently dropped.

Change authored by the user directly on the harness file; this PR commits it through the normal branch/PR flow.

## Change

`.claude/commands/continue.md`, Phase 1 (`+4 / -3`, single file):

- **New step 1**: establish if the prior session was cut short (crash, token saturation) and what remains to finalize before a clean new session.
- Existing steps renumbered 1→2 (read `MEMORY.md`), 2→3 (`git checkout main && git pull --ff-only`), 3→4 (`git status` / worktree isolation).

No other content touched; downstream phases (1.5 RooSync, 2 task pick, 3 deliver, 4 wrap-up) unchanged.

## Validation

- Diff = exactly the user's working-tree edit (resulting blob `a149bc33a`); base blob `66f25b133` byte-identical on `origin/main`.
- LF-only, CR=0.
- Isolated worktree from `origin/main` (shared tree dirty with unrelated WIP), single-file diff, no catalog / no notebook touched.

Harness doc-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
