### PR TITLE
fix(planners-3-csharp,#8475): CoutChemin exclude depart cell -> cross-twin cost parity (56->55, 17->16)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-3-State-Space-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-3-State-Space-Csharp.ipynb
@@ -650,21 +650,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFS               10    56     91       oui (5 cases)\r\n"
+      "BFS               10    55     91       oui (5 cases)\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Greedy            10    56     11       oui (5 cases)\r\n"
+      "Greedy            10    55     11       oui (5 cases)\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "A*                16    17     42       non\r\n"
+      "A*                16    16     42       non\r\n"
      ]
     },
     {
@@ -678,7 +678,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFS/Greedy : 10 pas (court) mais cout 56 (traverse le marais).\r\n"
+      "BFS/Greedy : 10 pas (court) mais cout 55 (traverse le marais).\r\n"
      ]
     },
     {
@@ -714,7 +714,7 @@
     "var (astarW, astarWcost, astarWnodes) = AStar(start, goal, succPondere, Manhattan);\n",
     "\n",
     "int CoutChemin(List<GridState> path, HashSet<GridState> mz, int cMarais) =>\n",
-    "    path.Sum(s => CoutCase(s, mz, cMarais));\n",
+    "    path.Skip(1).Sum(s => CoutCase(s, mz, cMarais));  // exclut le depart (case deja occupee, non entree)\n",
     "int PasDansMarais(List<GridState> path) => path.Count(s => marais.Contains(s));\n",
     "\n",
     "// Tableau numerique (le twin Python le fait visuellement ; ici c'est la table Pas/Cout/Nœuds).\n",

--- a/scripts/notebook_tools/twin_pairs.yaml
+++ b/scripts/notebook_tools/twin_pairs.yaml
@@ -1144,13 +1144,15 @@
   csharp: MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-3-State-Space-Csharp.ipynb
   parity_level: semantic
   last_audit:
-    date: "2026-07-23"
-    by: po-2023
+    date: "2026-07-25"
+    by: po-2024
     python_sha: 8d03359d12709b134f644e187d04249b6e1fcadf
-    csharp_sha: 435f49ca3c491cf320ddd9b9471fecc94f759f41
+    csharp_sha: cf417c956caa557bee5abcaa2ac19fab3ddfe917
+    note: "cost-parity reconciled (#8475): C# CoutChemin now excludes the depart cell terrain cost (path.Skip(1)), matching the Python twin's canonical convention (path cost = sum of edge weights / entered cells). Committed outputs aligned: BFS/Greedy 56->55, A* table 17->16 (now matches the A* g-cost summary, which was already 16). See #8475."
   known_differences:
     - "Concept : recherche dans l'espace d'etats (BFS/DFS/A* sur le graphe des etats reachables)."
     - "Python : unified-planning engines. C# : from-scratch BFS/DFS/A* BCL .NET (meme algorithme, implementation idiomatic)."
+    - "Node counts differ legitimately (Python A* 75 vs C# 42): implementation-level difference in exploration order, NOT a parity defect. Costs are now identical cross-twin (BFS/Greedy 55, A* 16)."
 - name: "Planners-4 Fast-Downward"
   family: SymbolicAI/Planners
   python: MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-4-Fast-Downward.ipynb


### PR DESCRIPTION
## Summary

`Planners-3-State-Space-Csharp` diverged by **+1 on every reported cost** (BFS/Greedy **56** vs Python 55, A* table **17** vs Python 16) on the identical 11×11-marais problem. `parity_level: semantic` → costs on the same problem are mathematical facts and must match across twins. **Closes #8475.**

## Root cause (firsthand — precise, not the issue's guess)

The issue hypothesized an off-by-one in "whether the départ cell's terrain cost is included." That is the right intuition, localized precisely to C#'s **`CoutChemin(path)` helper**, not the search algorithms:

| Twin | How table cost is computed | Includes départ? |
|------|---------------------------|-----------------|
| **Python** | search loop accumulated g-cost (starts at 0, adds `cout_case` per entered successor) | **No** (canonical) |
| **C# (old)** | `CoutChemin = path.Sum(s => CoutCase(s,...))` — sums terrain of EVERY path cell | **Yes** (the bug) |

C#'s own `AStar` returns `gScore[goal]` with `g(start)=0` (canonical, excludes départ), so the A* **summary** line was already 16 while the **table** said 17 — the internal contradiction #8436 had tried to paper over (in the wrong direction: it harmonized toward the inflated 17/56).

**Independent math** (`verify_math.py`, straight path (0,5)→(10,5)): 11 cells (10 pas), 5 marais cells ×10 + 5 non-marais ×1 = **55** excluding start (canonical), **56** including start (the off-by-one). A* optimal cost **16** (contourne) unaffected.

## Fix

```csharp
// before
int CoutChemin(...) => path.Sum(s => CoutCase(s, mz, cMarais));
// after
int CoutChemin(...) => path.Skip(1).Sum(s => CoutCase(s, mz, cMarais));  // exclut le depart
```

Aligns C# with **both** the Python twin (55/55/16) **and** C#'s own A* g-cost (table A*=16 = summary A*=16 → internally consistent).

## Committed outputs (re-executed, .NET Interactive 1.0.712001 / .NET 10.0.110, rule F)

```
=== Terrain pondere : BFS / Greedy / A* ===
BFS               10    55     91       oui (5 cases)
Greedy            10    55     11       oui (5 cases)
A*                16    16     42       non
```

Node counts (Python A* 75 vs C# 42) remain a **legitimate implementation difference** (exploration order), NOT a parity defect.

## Validation (H.3)

- nbformat JSON valid; **0** C.1 violations; exec_counts 1-11 all non-null
- **Only notebook cell[14]** (code-cell 6) changed source AND outputs (sha1-verified) — C.2 compliant (modified cell re-executed)
- Re-exec churn minimized: transplanted ONLY cell[14]'s re-executed outputs into the canonical notebook (other cells untouched); stripped probeAddresses banner (`strip_probe_banner.py`, rule #6); LF + `ensure_ascii=False` to match origin/main. **Final diff +5/−5**: 1 source line + 4 cost values.
- `check_twin_parity --per-pair --base origin/main`: **[OK] Planners-3, 9/9 OK, 0 DRIFT**
- Catalogue byte-identical.

## Register (`scripts/notebook_tools/twin_pairs.yaml`)

Rebaselined `last_audit.csharp_sha` `435f49ca` → `cf417c95` (git blob oid, `git hash-object`), dated/attributed po-2024, added reconciliation note + `known_differences` entry documenting that node-count divergence is legitimate while costs are now identical cross-twin.

## Supersedes #8436

#8436 (OPEN) harmonized toward the inflated 17/56 direction — wrong call. This fixes the root cause; #8436 should be closed when this merges.

Closes #8475 · See #8052 · See #8057

🤖 Generated with [Claude Code](https://claude.com/claude-code)