### PR TITLE
fix(twin-register,#8057): union merge du registre + garde d'integrite (3e recurrence du conflit serie)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -21,3 +21,14 @@ lake-manifest.json text eol=lf
 # Git LFS tracking for model files referenced by notebooks
 *.pt filter=lfs diff=lfs merge=lfs -text
 *.pkl filter=lfs diff=lfs merge=lfs -text
+
+# Le registre twin-parity (#8057) est une liste append-only : chaque lane ajoute
+# des entrees disjointes en fin de fichier. Sans union merge, N PRs de
+# registration ouvertes = une seule mergeable, les autres DIRTY -- conflit serie
+# systematique (3e recurrence : #8415 consolidation, #8476 re-apply on fresh
+# main, #8499 recovery tranche). `union` concatene les deux cotes du hunk au
+# lieu de poser des marqueurs, ce qui est exactement le resultat voulu pour des
+# appends disjoints. Filet de securite contre le seul mode de defaillance
+# (rebaselines concurrents de la meme entree -> cle dupliquee) :
+# scripts/notebook_tools/tests/test_twin_registry_integrity.py
+scripts/notebook_tools/twin_pairs.yaml merge=union

--- a/scripts/notebook_tools/tests/test_twin_registry_integrity.py
+++ b/scripts/notebook_tools/tests/test_twin_registry_integrity.py
@@ -1,0 +1,121 @@
+"""Integrite structurelle du registre twin_pairs.yaml (#8057).
+
+Ces tests sont le filet de securite du merge `union` declare sur le registre
+dans `.gitattributes`. Le registre est une liste append-only : les lanes y
+ajoutent des entrees disjointes en fin de fichier, ce qui produisait un conflit
+serie systematique (une seule PR mergeable a la fois -- 3e recurrence : #8415
+consolidation, #8476 re-apply, #8499 recovery tranche).
+
+`merge=union` concatene les deux cotes d'un hunk en conflit au lieu de poser des
+marqueurs. Pour des appends disjoints c'est exactement le resultat voulu. Le
+seul mode de defaillance est le rebaselinage concurrent de la *meme* entree :
+l'union produirait alors deux lignes `python_sha:` dans un meme bloc, et
+`yaml.safe_load` retient silencieusement la derniere. Ces tests transforment
+cette corruption silencieuse en echec CI bruyant.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+REGISTRY = Path(__file__).resolve().parents[1] / "twin_pairs.yaml"
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+REQUIRED_KEYS = {"name", "family", "python", "csharp", "parity_level", "last_audit"}
+
+
+def _entries() -> list:
+    data = yaml.safe_load(REGISTRY.read_text(encoding="utf-8"))
+    assert isinstance(data, list), "le registre doit etre une liste de paires"
+    return data
+
+
+class _DupKeyLoader(yaml.SafeLoader):
+    """SafeLoader qui refuse les cles dupliquees au lieu de garder la derniere.
+
+    C'est la signature exacte d'un merge union mal tombe (deux rebaselines
+    concurrents de la meme entree). PyYAML l'accepte silencieusement par defaut.
+    """
+
+
+def _no_duplicate_keys(loader, node, deep=False):
+    mapping = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        if key in mapping:
+            raise yaml.constructor.ConstructorError(
+                None, None, f"cle dupliquee dans le registre : {key!r}", key_node.start_mark
+            )
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+_DupKeyLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _no_duplicate_keys
+)
+
+
+def test_registry_parses_as_list():
+    assert len(_entries()) > 0
+
+
+def test_no_duplicate_keys_anywhere():
+    """Mode de defaillance n1 du merge union : `python_sha` deux fois dans une entree."""
+    yaml.load(REGISTRY.read_text(encoding="utf-8"), Loader=_DupKeyLoader)
+
+
+def test_no_duplicate_pair_names():
+    """Mode de defaillance n2 : la meme paire enregistree par deux lanes."""
+    names = [e.get("name") for e in _entries()]
+    dupes = sorted({n for n in names if names.count(n) > 1})
+    assert not dupes, f"noms de paires dupliques : {dupes}"
+
+
+def test_no_duplicate_notebook_paths():
+    """Un notebook ne doit apparaitre que dans une seule paire."""
+    seen: dict[str, str] = {}
+    collisions = []
+    for entry in _entries():
+        for side in ("python", "csharp"):
+            path = entry.get(side)
+            if path in seen:
+                collisions.append(f"{path} : {seen[path]} et {entry.get('name')}")
+            else:
+                seen[path] = entry.get("name", "?")
+    assert not collisions, "notebooks enregistres deux fois : " + "; ".join(collisions)
+
+
+def test_required_keys_present():
+    missing = [
+        f"{e.get('name', '?')} -> {sorted(REQUIRED_KEYS - set(e))}"
+        for e in _entries()
+        if not REQUIRED_KEYS.issubset(e)
+    ]
+    assert not missing, f"entrees incompletes : {missing}"
+
+
+def test_audit_shas_are_git_blob_shas():
+    """Les shas sont des blob SHA git (40 hex), pas des hashes de contenu."""
+    bad = []
+    for entry in _entries():
+        audit = entry.get("last_audit") or {}
+        for key in ("python_sha", "csharp_sha"):
+            sha = audit.get(key)
+            if not isinstance(sha, str) or not SHA_RE.match(sha):
+                bad.append(f"{entry.get('name', '?')}.{key} = {sha!r}")
+    assert not bad, f"shas invalides : {bad}"
+
+
+def test_registered_notebooks_exist_on_disk():
+    repo_root = REGISTRY.resolve().parents[2]
+    missing = [
+        f"{e.get('name', '?')} -> {p}"
+        for e in _entries()
+        for p in (e.get("python"), e.get("csharp"))
+        if p and not (repo_root / p).exists()
+    ]
+    assert not missing, f"notebooks introuvables : {missing}"


### PR DESCRIPTION
Grain: MED/tooling-infra — lane myia-ai-01:CoursIA — prev: LIGHT/merge-pass

## Probleme

`scripts/notebook_tools/twin_pairs.yaml` est une **liste append-only** : chaque lane ajoute ses entrees en fin de fichier. Sans strategie de merge dediee, **N PRs de registration ouvertes = une seule mergeable**, les autres passent `DIRTY` des que la premiere atterrit.

**3e recurrence du meme conflit serie**, visible dans l'historique du fichier :

| Commit | Symptome |
|---|---|
| `f864996dd` (#8415) | « consolidate **5 tranche PRs** into 1 » |
| `c892616c4` (#8476) | « **re-apply on fresh main** » |
| `09bfbf579` (#8499) | « **recovery** tranche » |

Ce cycle encore : 4 PRs twin-register ouvertes (#8500 #8487 #8492 #8493), toutes en append au meme endroit (`@@ -1270,3`). #8500 mergee -> #8487 immediatement `DIRTY`, resolution manuelle coordinateur requise. Le cout se paie **a chaque cycle**, sur chaque lane.

## Fix

**1. `.gitattributes` : `merge=union` sur le registre.** Pour un hunk en conflit, git concatene les deux cotes au lieu de poser des marqueurs — exactement le resultat voulu pour des appends disjoints.

**Verifie empiriquement, pas suppose** : j'ai rejoue le conflit reel de #8487 (cote `main` : `Search-4` + `App-1` ; cote branche : `GameTheory-13`) avec l'attribut en place.

```
$ git merge origin/main
Merge made by the 'ort' strategy.
 scripts/notebook_tools/twin_pairs.yaml | 86 ++++++++++++++++++++++++++
```

Aucun conflit, et le resultat est **byte-identique** a la resolution manuelle que je venais de faire (`git diff` vide) : 88 paires, 0 doublon, YAML valide, les 3 entrees presentes.

**2. `test_twin_registry_integrity.py` : le filet de securite.** L'union a **un** mode de defaillance : deux rebaselines concurrents de la *meme* entree produiraient deux lignes `python_sha:` dans un meme bloc, et `yaml.safe_load` retient silencieusement la derniere — sha faux, sans bruit. Les 7 tests transforment cette corruption silencieuse en echec CI :

- `test_no_duplicate_keys_anywhere` — loader qui **refuse** les cles dupliquees (PyYAML les accepte par defaut)
- `test_no_duplicate_pair_names` / `test_no_duplicate_notebook_paths` — meme paire enregistree par deux lanes
- `test_audit_shas_are_git_blob_shas` — 40-hex, pas un hash de contenu (lecons L963/L974)
- `test_required_keys_present`, `test_registered_notebooks_exist_on_disk`, `test_registry_parses_as_list`

**Mutation-testes** — un garde qui ne se declenche jamais ne vaut rien :

```
CAUGHT               dup-key (union merge du meme rebaseline)
CAUGHT               dup-name (meme paire par 2 lanes)
CAUGHT               sha invalide (hash de contenu, pas blob git)
```

7/7 passent sur le registre courant (88 paires), registre restaure byte-identique apres mutation.

## Portee et limite honnete

L'attribut est lu depuis le working tree, donc le gain est **certain** la ou la douleur se paie reellement : rebase worker et resolution coordinateur en local. Je **n'affirme pas** que le merge server-side de GitHub honore `merge=union` — je ne l'ai pas verifie, et le statut `DIRTY` peut continuer a s'afficher sur l'UI. Dans ce cas la resolution locale devient triviale (`git merge origin/main` sans conflit) au lieu d'une edition manuelle de marqueurs.

Aucun changement au registre lui-meme ni a `check_twin_parity.py`.

See #8057.
