### PR TITLE
fix(iit-ict15b): compute multilinear degree via Mobius transform (#8498)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15b-SensitivityCanonicity.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15b-SensitivityCanonicity.ipynb
@@ -1180,7 +1180,7 @@
    "source": [
     "### Exemple guide 3 -- Lean comme oracle\n",
     "\n",
-    "Le theoreme de Huang est formalise dans `sensitivity_lean/Spectral/SensitivityDegree.lean` avec **0 sorry**. Sans ouvrir le Lean, reproduis la **borne** `s >= sqrt(deg)` sur une fonction booleenne simple : la fonction **OR** sur 4 variables (`deg = 1`, `s = 4`) et la fonction **parite** sur 4 variables (`deg = 4`, `s = 4`). Verifie que les deux respectent la borne.\n",
+    "Le theoreme de Huang est formalise dans `sensitivity_lean/Spectral/SensitivityDegree.lean` avec **0 sorry**. Sans ouvrir le Lean, reproduis la **borne** `s >= sqrt(deg)` sur une fonction booleenne simple : la fonction **OR** sur 4 variables (`deg = 4`, `s = 4`) et la fonction **parite** sur 4 variables (`deg = 1`, `s = 4`). Le `deg` (degre multilineaire, calcule par transformee de Mobius sur l'ANF) et le `s` sont **calcules par le code**, non codes en dur. Verifie que les deux respectent la borne -- et observe le contraste : la parite est **lineaire** (deg = 1) pourtant de sensibilite maximale s = n, tandis que OR porte le degre maximal deg = n. Un troisieme exemple (OR de deux paires) atteint la borne exacte s = sqrt(deg).\n",
     "\n",
     "> **Note pedagogique** : la cellule code suivante execute la solution complete. Cf **Exercice 3** plus bas pour la variante sur la fonction MAJ (majorite sur 4 variables)."
    ]
@@ -1210,8 +1210,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "OR(n=4)     : s = 4, sqrt(deg=1) = 1.00, borne respectee : True\n",
-      "Parite(n=4) : s = 4, sqrt(deg=4) = 2.00, borne respectee : True\n"
+      "OR(n=4) : s = 4, deg = 4, sqrt(deg) = 2.00, borne respectee : True\n",
+      "Parite(n=4) : s = 4, deg = 1, sqrt(deg) = 1.00, borne respectee : True\n",
+      "OR-paires(x1x2|x3x4) : s = 2, deg = 4, sqrt(deg) = 2.00, borne respectee : True\n"
      ]
     }
    ],
@@ -1231,17 +1232,43 @@
     "    return s_max\n",
     "\n",
     "\n",
+    "def multilinear_degree(truth_table):\n",
+    "    \"\"\"Degre du polynome multilineaire de f = max{|S| : a_S != 0}, ou les a_S sont les\n",
+    "    coefficients de la forme normale algebrique (ANF) de f. L'ANF s'obtient par la\n",
+    "    transformee de Mobius sur GF(2) : a[S] = XOR_{T sous-ensemble de S} f(T). C'est le\n",
+    "    degre de Fourier-Walsh utilise dans la borne de Huang s >= sqrt(deg).\n",
+    "    \"\"\"\n",
+    "    n = len(truth_table).bit_length() - 1\n",
+    "    assert len(truth_table) == 2 ** n\n",
+    "    anf = list(truth_table)\n",
+    "    for i in range(n):\n",
+    "        for mask in range(2 ** n):\n",
+    "            if mask & (1 << i):\n",
+    "                anf[mask] ^= anf[mask ^ (1 << i)]\n",
+    "    return max((bin(m).count('1') for m in range(2 ** n) if anf[m]), default=0)\n",
+    "\n",
+    "\n",
     "or_tt = [int(bin(x).count('1') >= 1) for x in range(2 ** 4)]\n",
     "parite_tt = [int(bin(x).count('1') % 2 == 1) for x in range(2 ** 4)]\n",
+    "# OR de deux paires (x1 & x2) | (x3 & x4) : cas ou la borne de Huang est SERREE (s = sqrt(deg)).\n",
+    "orpairs_tt = []\n",
+    "for x in range(2 ** 4):\n",
+    "    bits = [(x >> i) & 1 for i in range(4)]\n",
+    "    orpairs_tt.append(1 if (bits[0] and bits[1]) or (bits[2] and bits[3]) else 0)\n",
     "\n",
-    "s_or = boolean_sensitivity(or_tt)\n",
-    "s_parite = boolean_sensitivity(parite_tt)\n",
+    "for name, tt in [('OR(n=4)', or_tt), ('Parite(n=4)', parite_tt), ('OR-paires(x1x2|x3x4)', orpairs_tt)]:\n",
+    "    s = boolean_sensitivity(tt)\n",
+    "    deg = multilinear_degree(tt)\n",
+    "    seuil = deg ** 0.5\n",
+    "    print(name + ' : s = ' + str(s) + ', deg = ' + str(deg) + ', sqrt(deg) = ' + format(seuil, '.2f') + ', borne respectee : ' + str(s >= seuil))\n",
     "\n",
-    "print('OR(n=4)     : s = ' + str(s_or) + ', sqrt(deg=1) = ' + format(1 ** 0.5, '.2f') + ', borne respectee : ' + str(s_or >= 1 ** 0.5))\n",
-    "print('Parite(n=4) : s = ' + str(s_parite) + ', sqrt(deg=4) = ' + format(4 ** 0.5, '.2f') + ', borne respectee : ' + str(s_parite >= 4 ** 0.5))\n",
-    "\n",
-    "# Verdict honnete : borne TIENT sur les 2 cas triviaux (et le Lean la tient sur tous les cas).\n",
-    "# Huang 2019 montre qu'elle tient pour TOUTE fonction booleenne ; ICT-15b transpose au zoo ICT,\n",
+    "# Verdict honnete : la borne de Huang s >= sqrt(deg) tient sur les 3 cas.\n",
+    "#  - Parite est LINEAIRE (deg = 1, ANF = x1+x2+x3+x4) mais atteint la sensibilite maximale s = n :\n",
+    "#    la sensibilite n'est donc pas portee par le degre.\n",
+    "#  - OR a deg = n (le monome produit x1x2x3x4 figure dans son ANF) et s = n egalement.\n",
+    "#  - OR-paires atteint la BORNE EXACTE s = 2 = sqrt(deg = 4) : cas temoin ou Huang ne peut etre ameliore.\n",
+    "# Les valeurs de deg sont CALCULEES par multilinear_degree (transformee de Mobius), non codees en dur.\n",
+    "# Huang 2019 prouve s >= sqrt(deg) pour TOUTE fonction booleenne ; ICT-15b transpose au zoo ICT,\n",
     "# ou on n'a PAS l'equivalent de la structure de l'hypercube.\n"
    ]
   },
@@ -1397,14 +1424,14 @@
    "source": [
     "### Exercice 3 -- Fonction MAJ sur 4 variables (borne de Huang manuelle)\n",
     "\n",
-    "L'**Exemple guide 3** reproduit la borne `s >= sqrt(deg)` sur OR (deg=1) et parite (deg=4) sur 4 variables. Le defi : implemente la **fonction MAJ (majorite)** sur 4 variables en utilisant le squelette `boolean_sensitivity` deja defini dans l'Exemple guide 3, puis verifie manuellement que `s(MAJ_4) = 2` et `sqrt(deg(MAJ_4)) = sqrt(3) ~ 1.732`.\n",
+    "L'**Exemple guide 3** reproduit la borne `s >= sqrt(deg)` sur OR (`deg = 4`) et parite (`deg = 1`) sur 4 variables. Le defi : implemente la **fonction MAJ (majorite faible)** sur 4 variables en reutilisant `boolean_sensitivity` ET `multilinear_degree` deja definis dans l'Exemple guide 3, puis verifie la borne `s(MAJ_4) >= sqrt(deg(MAJ_4))`.\n",
     "\n",
-    "**Objectif pedagogique** : la majorite 4 est le cas **non-trivial** (entre OR trivial et parite extreme) : sa sensibilite est 2 (2 voisins basculent pour les entrees critiques) et son degre est 3 (un cube de Reed-Muller), donc la borne `s >= sqrt(deg)` tient avec un ratio ~ 1.15.\n",
+    "**Objectif pedagogique** : la majorite 4 est le cas **non-trivial** (entre OR trivial et parite extreme). Sur 4 variables, `MAJ_4(x) = 1` si `>= 2` des bits sont a 1 ; son degre multilineaire (ANF sur GF(2), calcule par `multilinear_degree`) est **4** et sa sensibilite est **3** (3 voisins basculent aux entrees critiques de poids 2), donc la borne `s >= sqrt(deg)` tient avec un ratio `3 / sqrt(4) = 1.5`.\n",
     "\n",
     "**Indices** :\n",
     "- La table de verite de MAJ_4 : `MAJ_4(x) = 1` si `>=2` des bits sont a 1 parmi les 4\n",
     "- La longueur de la table est `2^4 = 16`\n",
-    "- `deg(MAJ_4) = 3` (son polynome de Fourier a un coefficient non-trivial d'ordre 3) -- **pas besoin de le calculer**, juste citer\n"
+    "- **Calcule** `deg(MAJ_4)` avec `multilinear_degree(maj_tt)` (comme pour OR et parite) -- ne le code pas en dur\n"
    ]
   },
   {
@@ -1437,16 +1464,15 @@
     }
    ],
    "source": [
-    "# TODO etudiant : implementer la table de verite MAJ_4 et utiliser boolean_sensitivity\n",
-    "# pour verifier s(MAJ_4) = 2 et la borne de Huang sqrt(deg=3) ~ 1.732.\n",
+    "# TODO etudiant : implementer la table de verite MAJ_4 (longueur 16), puis verifier\n",
+    "# la borne de Huang s >= sqrt(deg) en reutilisant boolean_sensitivity ET multilinear_degree\n",
+    "# (definis dans l'Exemple guide 3 ci-dessus -- ne PAS les redéfinir).\n",
     "\n",
-    "# Skeleton : reutilise la fonction boolean_sensitivity de l'Exemple guide 3 (cellule au-dessus).\n",
-    "# Ne PAS la redéfinir ici.\n",
-    "\n",
-    "# maj_tt = [...]  # TODO etudiant : table de verite de MAJ_4 (longueur 16)\n",
+    "# maj_tt = [...]  # TODO etudiant : MAJ_4(x) = 1 si >= 2 des 4 bits sont a 1\n",
     "# s_maj = boolean_sensitivity(maj_tt)\n",
-    "# print('MAJ_4 : s =', s_maj, ', sqrt(deg=3) =', format(3 ** 0.5, '.3f'),\n",
-    "#       ', borne respectee :', s_maj >= 3 ** 0.5)\n",
+    "# deg_maj = multilinear_degree(maj_tt)\n",
+    "# print('MAJ_4 : s =', s_maj, ', deg =', deg_maj, ', sqrt(deg) =', format(deg_maj ** 0.5, '.3f'),\n",
+    "#       ', borne respectee :', s_maj >= deg_maj ** 0.5)\n",
     "\n",
     "print('Exercice 3 a completer : MAJ_4 sur 4 variables, verification manuelle de la borne de Huang')\n"
    ]


### PR DESCRIPTION
## Summary

Fixes `ICT-15b-SensitivityCanonicity.ipynb` cell[28] where the multilinear degree `deg(f)` was **hardcoded as swapped-wrong literals** (`sqrt(deg=1)` for OR_4, `sqrt(deg=4)` for Parite_4) instead of being computed. Both values are wrong AND swapped.

### Root cause (G.1 firsthand verification)

The real ANF degree `max{|S| : a_S != 0}` over GF(2), computed via the **Mobius transform** on the truth table:

| Function | notebook said `deg` | real `deg` (computed) | `s` |
|----------|--------------------:|----------------------:|----:|
| OR_4     | 1 (wrong)           | **4** (x1x2x3x4 monomial) | 4 |
| Parite_4 | 4 (wrong)           | **1** (parity is LINEAR)  | 4 |

Parite_4 is **linear** (ANF = x1+x2+x3+x4) yet maximally sensitive (s=n) -- so sensitivity is not carried by degree. OR_4 carries the maximal degree (deg=n).

## Changes

- **cell[28]**: add `multilinear_degree(truth_table)` (Mobius transform over GF(2)) and COMPUTE `deg` for OR_4 and Parite_4. Add a third witness -- **OR-of-pairs** `(x1x2)|(x3x4)`: `s=2, deg=4, sqrt(deg)=2.000`, which attains the EXACT Huang bound `s = sqrt(deg)` -- the discriminant case where the bound cannot be tightened.
- **md[27]**: align prose to computed values (OR `deg=4`, Parite `deg=1`), flag the linear-vs-max-degree contrast.
- **cell[33]+cell[34]** (Exercice 3, coherence fix): the MAJ_4 exercise carried the same errors -- prose claimed `s(MAJ_4)=2` and `deg(MAJ_4)=3` (real: `s=3, deg=4`, ratio `3/sqrt(4)=1.5`), and the stub hardcoded `sqrt(deg=3)`. Stub now tells the student to COMPUTE deg via `multilinear_degree` (consistent with the Exemple guide 3 lesson). Stub stays a stub (print unchanged, just re-executed).

## Validation

- `scripts/notebook_tools/validate_pr_notebooks.py origin/main <nb>` -> **1/1 PASS (17 cells)**.
- cell[28] output is real-executed (code run in a clean Python interpreter, deterministic pure math):
  ```
  OR(n=4) : s = 4, deg = 4, sqrt(deg) = 2.00, borne respectee : True
  Parite(n=4) : s = 4, deg = 1, sqrt(deg) = 1.00, borne respectee : True
  OR-paires(x1x2|x3x4) : s = 2, deg = 4, sqrt(deg) = 2.00, borne respectee : True
  ```
- cell[34] print re-executed (identical output). No hardcoded degree literals remain.

## #8364 note (root-cause, not realignment)

The markdown was aligned to the committed output, which is valid here because the prior "values" were **hardcoded literals, never computed** (case A: markdown-prior drift). The fix computes both `s` and `deg` -- no value is coded in dur anymore.

Closes #8498. See #8052 (claims<->outputs fidelity). See #8364 (output is truth).
