### PR TITLE
fix(ict-15b,#8498): compute multilinear_degree instead of hardcoded deg=1

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15b-SensitivityCanonicity.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15b-SensitivityCanonicity.ipynb
@@ -1180,14 +1180,14 @@
    "source": [
     "### Exemple guide 3 -- Lean comme oracle\n",
     "\n",
-    "Le theoreme de Huang est formalise dans `sensitivity_lean/Spectral/SensitivityDegree.lean` avec **0 sorry**. Sans ouvrir le Lean, reproduis la **borne** `s >= sqrt(deg)` sur une fonction booleenne simple : la fonction **OR** sur 4 variables (`deg = 1`, `s = 4`) et la fonction **parite** sur 4 variables (`deg = 4`, `s = 4`). Verifie que les deux respectent la borne.\n",
+    "Le theoreme de Huang est formalise dans `sensitivity_lean/Spectral/SensitivityDegree.lean` avec **0 sorry**. Sans ouvrir le Lean, reproduis la **borne** `s >= sqrt(deg)` sur deux fonctions booleennes sur 4 variables : la fonction **OR** (`deg = 4`, `s = 4`) et la fonction **parite** (`deg = 4`, `s = 4`). Le degre `deg` est celui du polynome multilineaire **reel** (transformee de Mobius additive sur le reseau des parties), calcule dans la cellule suivante -- a distinguer du degre algebrique sur GF(2) (Mobius via XOR) qui donnerait `deg = 1` pour la parite. Les deux fonctions ayant `deg = 4`, on a `sqrt(deg) = 2` et la borne est largement satisfaite (`s = 4 >= 2`). Verifie que les deux respectent la borne.\n",
     "\n",
-    "> **Note pedagogique** : la cellule code suivante execute la solution complete. Cf **Exercice 3** plus bas pour la variante sur la fonction MAJ (majorite sur 4 variables)."
+    "> **Note pedagogique** : la cellule code suivante execute la solution complete. Cf **Exercice 3** plus bas pour la variante sur la fonction MAJ (majorite sur 4 variables).\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "fa19e24a",
    "metadata": {
     "execution": {
@@ -1210,8 +1210,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "OR(n=4)     : s = 4, sqrt(deg=1) = 1.00, borne respectee : True\n",
-      "Parite(n=4) : s = 4, sqrt(deg=4) = 2.00, borne respectee : True\n"
+      "OR(n=4)     : s = 4, deg = 4, sqrt(deg) = 2.00, borne respectee : True\n",
+      "Parite(n=4) : s = 4, deg = 4, sqrt(deg) = 2.00, borne respectee : True\n"
      ]
     }
    ],
@@ -1231,14 +1231,30 @@
     "    return s_max\n",
     "\n",
     "\n",
+    "def multilinear_degree(truth_table):\n",
+    "    # Degré du polynôme multilinéaire RÉEL représentant f (le \"deg\" de la borne de Huang s >= sqrt(deg)).\n",
+    "    # c_S = sum_{T subset S} (-1)^{|S|-|T|} f(T)  (transformée de Möbius additive sur le réseau des parties).\n",
+    "    # À DISTINGUER du degré algébrique sur GF(2) (Möbius via XOR), qui donnerait deg(Parité_4) = 1 au lieu de 4.\n",
+    "    n = len(truth_table).bit_length() - 1\n",
+    "    assert len(truth_table) == 2 ** n\n",
+    "    coeffs = list(map(int, truth_table))\n",
+    "    for i in range(n):\n",
+    "        for S in range(2 ** n):\n",
+    "            if (S >> i) & 1:\n",
+    "                coeffs[S] -= coeffs[S ^ (1 << i)]\n",
+    "    return max((bin(S).count('1') for S in range(2 ** n) if coeffs[S] != 0), default=0)\n",
+    "\n",
+    "\n",
     "or_tt = [int(bin(x).count('1') >= 1) for x in range(2 ** 4)]\n",
     "parite_tt = [int(bin(x).count('1') % 2 == 1) for x in range(2 ** 4)]\n",
     "\n",
     "s_or = boolean_sensitivity(or_tt)\n",
     "s_parite = boolean_sensitivity(parite_tt)\n",
+    "deg_or = multilinear_degree(or_tt)\n",
+    "deg_parite = multilinear_degree(parite_tt)\n",
     "\n",
-    "print('OR(n=4)     : s = ' + str(s_or) + ', sqrt(deg=1) = ' + format(1 ** 0.5, '.2f') + ', borne respectee : ' + str(s_or >= 1 ** 0.5))\n",
-    "print('Parite(n=4) : s = ' + str(s_parite) + ', sqrt(deg=4) = ' + format(4 ** 0.5, '.2f') + ', borne respectee : ' + str(s_parite >= 4 ** 0.5))\n",
+    "print('OR(n=4)     : s = ' + str(s_or) + ', deg = ' + str(deg_or) + ', sqrt(deg) = ' + format(deg_or ** 0.5, '.2f') + ', borne respectee : ' + str(s_or >= deg_or ** 0.5))\n",
+    "print('Parite(n=4) : s = ' + str(s_parite) + ', deg = ' + str(deg_parite) + ', sqrt(deg) = ' + format(deg_parite ** 0.5, '.2f') + ', borne respectee : ' + str(s_parite >= deg_parite ** 0.5))\n",
     "\n",
     "# Verdict honnete : borne TIENT sur les 2 cas triviaux (et le Lean la tient sur tous les cas).\n",
     "# Huang 2019 montre qu'elle tient pour TOUTE fonction booleenne ; ICT-15b transpose au zoo ICT,\n",


### PR DESCRIPTION
## Summary

Fixes `ICT-15b-SensitivityCanonicity.ipynb` **cell[28]** which hardcoded `deg` as a literal (`sqrt(deg=1)` for OR, `sqrt(deg=4)` for Parité) in the f-string, never computed.

**The bug**: `deg(OR4) = 4`, not 1. `OR4(x) = 1 − (1−x1)(1−x2)(1−x3)(1−x4)` develops the monomial `x1x2x3x4` → degree 4. The notebook taught a false `deg=1`, and the committed output `OR(n=4): s=4, sqrt(deg=1)=1.00` was wrong.

## Fix

Added `multilinear_degree(truth_table)` — the **real** multilinear polynomial degree (Huang's `deg`):

```
c_S = Σ_{T⊆S} (−1)^{|S|−|T|} f(T)   (additive Möbius transform on the subset lattice)
deg = max{|S| : c_S ≠ 0}
```

**Critical subtlety caught in verification**: the GF(2) algebraic degree (Möbius via XOR) gives `deg(Parity4)=1`, but Huang's bound uses the **real** multilinear degree = 4. My first implementation used XOR (mod-2) and gave the wrong `deg(Parity4)=1` — caught by testing against known values before commit. The additive version is correct.

| Function | deg (real, computed) | s | sqrt(deg) |
|----------|---------------------|---|-----------|
| OR4 | **4** (was hardcoded 1) | 4 | 2.00 |
| Parity4 | 4 | 4 | 2.00 |

## Re-execution (C.2 / Stop & Repair)

Cell[28] is pure-python self-contained (defines its own `boolean_sensitivity` + truth tables, no PyPhi/imports). Re-executed the **real** code → captured true stdout, committed that (no hand-editing of output). `execution_count` 14→15.

**New committed output** (H.1 forensic: re-exec of committed source == committed output ✓):
```
OR(n=4)     : s = 4, deg = 4, sqrt(deg) = 2.00, borne respectee : True
Parite(n=4) : s = 4, deg = 4, sqrt(deg) = 2.00, borne respectee : True
```

## md[27] aligned

Updated the markdown: OR `deg=1` → `deg=4`; added a note distinguishing the **real multilinear degree** (additive Möbius) from the **GF(2) algebraic degree** (XOR Möbius) — exactly the confusion that produced the bug.

## Scope

Surgical: only cells 27 (md) + 28 (code) changed — verified cell-by-cell, no untouched cell drifted. Byte-stable write (`json.dumps(indent=1)`, no trailing newline — matches HEAD format). Single file, +23/−7.

## Known Prong-B residual (flagged in #8498, NOT acceptance criteria)

After the fix, OR4 and Parity4 both have `(deg=4, s=4)` → the OR-vs-Parité contrast the original markdown intended ("deg=1 vs deg=4") collapses. The bound `s ≥ √deg` is now trivially `4 ≥ 2` for both. A richer discriminating example (a function where `s` is close to `√deg`, e.g. a tribes/addressing function) would restore the pedagogical punch — but that's a separate Prong-B enhancement (design decision), out of scope for this correctness fix.

Closes #8498

Co-Authored-By: Claude-Code <noreply@anthropic.com>
