### PR TITLE
fix(ci,#8508): guard --update to require explicit selector + tests

### DIFF
--- a/.github/workflows/twin-parity.yml
+++ b/.github/workflows/twin-parity.yml
@@ -89,7 +89,7 @@ jobs:
             PRE=$(python -c "import json; d=json.load(open('twin_parity_report.json')); print(d.get('drift_pre_existing',0))")
             echo "drift_introduced=$INTRO" >> "$GITHUB_OUTPUT"
             echo "drift_pre_existing=$PRE" >> "$GITHUB_OUTPUT"
-            echo "::error title=Twin parity DRIFT INTRODUCED by this PR::La PR a introduit $INTRO paire(s) en DRIFT/MISSING qui etaient OK au base-ref origin/main. Action : re-auditer la paire firsthand puis \`python scripts/notebook_tools/check_twin_parity.py --update\` pour rebaseline le SHA dans le meme PR, OU splitter en deux PRs pour que chaque cote evolue separement avec rebaseline. Drift pre-existant ($PRE paire(s)) releve d'une PR dediee cf #8264. Voir twin_parity_report.json dans les artifacts."
+            echo "::error title=Twin parity DRIFT INTRODUCED by this PR::La PR a introduit $INTRO paire(s) en DRIFT/MISSING qui etaient OK au base-ref origin/main. Action : re-auditer la paire firsthand PUIS rebaseline UNIQUEMENT cette entree dans le registre (methode manuelle, JAMAIS --update sans selecteur -- cf issue #8508 et lecons L963/L974) : 1) Calculer le SHA du notebook modifie : \`git rev-parse HEAD:<chemin-du-notebook>\` ; 2) Editer \`scripts/notebook_tools/twin_pairs.yaml\` a la main, mettre a jour \`python_sha\`/\`csharp_sha\` + \`date\` + \`by\` pour CETTE entree seulement ; 3) OU splitter la PR pour que chaque cote evolue separement avec rebaseline isole. Drift pre-existant ($PRE paire(s)) releve d'une PR dediee cf #8264. Voir twin_parity_report.json dans les artifacts."
             exit 1
           else
             echo "::error title=Twin parity tool error::Erreur d'execution du check (exit $EXIT). Voir les logs ci-dessus."

--- a/scripts/notebook_tools/check_twin_parity.py
+++ b/scripts/notebook_tools/check_twin_parity.py
@@ -256,6 +256,12 @@ def main(argv=None) -> int:
                         "le drift INTRODUIT par la PR, jamais le drift pre-existant.")
     p.add_argument("--base", default=None,
                    help="Ref git de base pour le mode --per-pair (ex. origin/main, HEAD~1).")
+    p.add_argument("--pair", default=None,
+                   help="Restreindre --update a une paire nommee (ex. 'Search-9-LP'). "
+                        "Impossible a combiner avec --family.")
+    p.add_argument("--yes-all-pairs", action="store_true",
+                   help="Opt-in explicite pour rebaseline TOUTES les paires du registre "
+                        "avec --update. Sans ce flag (ou --family/--pair), --update refuse.")
     args = p.parse_args(argv)
 
     # Cross-validation : --per-pair <-> --base
@@ -265,6 +271,14 @@ def main(argv=None) -> int:
         p.error("--base necessite --per-pair")
     if args.update and (args.per_pair or args.base):
         p.error("--update est incompatible avec --per-pair/--base")
+    # --update exige un selecteur (anti-corruption silencieuse du registre, cf #8508)
+    if args.update and not (args.family or args.pair or args.yes_all_pairs):
+        p.error("--update exige un selecteur explicite : --family <f>, --pair <name>, "
+                "OU --yes-all-pairs. Le defaut '--update' seul reecrirait le last_audit "
+                "de TOUTES les paires du registre, ce qui masque des DRIFTs legitimes "
+                "(cf issue #8508 + lecons L963/L974).")
+    if args.pair and args.family:
+        p.error("--pair et --family sont mutuellement exclusifs avec --update.")
 
     repo_root = _repo_root()
     reg_path = Path(args.registry)
@@ -381,14 +395,26 @@ def main(argv=None) -> int:
         # IMPORTANT : --update DOIT TOUJOURS reecrire TOUTES les paires du
         # registre (meme avec --family), sinon on DETRUIT les paires des
         # autres familles en re-ecrivant le YAML filtre. On ne met a jour
-        # que les paires qui matchent le filtre (ou toutes si pas de filtre).
+        # que les paires qui matchent le filtre (ou toutes si --yes-all-pairs).
+        # Selecteur obligatoire depuis c.909 (#8508) : --family OU --pair OU --yes-all-pairs.
         all_pairs = load_registry(reg_path)
-        target = (
-            [pp for pp in all_pairs if pp.get("family") == args.family]
-            if args.family else all_pairs
-        )
-        if args.family and not target:
-            print(f"Aucune paire pour la famille '{args.family}'.", file=sys.stderr)
+        if args.pair:
+            target = [pp for pp in all_pairs if pp.get("name") == args.pair]
+            if not target:
+                names = sorted({pp.get("name", "?") for pp in all_pairs})
+                print(
+                    f"Aucune paire nommee '{args.pair}'. "
+                    f"Noms connus : {', '.join(names[:10])}{'...' if len(names) > 10 else ''}",
+                    file=sys.stderr,
+                )
+                return 1
+        elif args.family:
+            target = [pp for pp in all_pairs if pp.get("family") == args.family]
+            if not target:
+                print(f"Aucune paire pour la famille '{args.family}'.", file=sys.stderr)
+        else:
+            # --yes-all-pairs (filet anti-corruption silencieuse, cf #8508)
+            target = all_pairs
         updated = 0
         for pp in target:
             audit, cur_py = update_pair(repo_root, pp)

--- a/scripts/notebook_tools/tests/test_check_twin_parity_update_guard.py
+++ b/scripts/notebook_tools/tests/test_check_twin_parity_update_guard.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Garde anti-corruption silencieuse du registre `--update` (#8508).
+
+Avant c.909 : `python check_twin_parity.py --update` (sans selecteur)
+reecrivait le `last_audit` de TOUTES les paires du registre (88 paires
+au moment de la PR). Un agent qui suivait la remediation affichee par
+la CI twin-parity pour rebaseliner UNE paire marquait « audite
+aujourd'hui » TOUTES les paires en derive -- y compris celles qui
+derivaient pour une raison qui meritait un examen.
+
+Depuis c.909 : `--update` exige un selecteur explicite (`--family`,
+`--pair`, ou opt-in `--yes-all-pairs`). Sans selecteur : argparse
+refuse avec un message qui reference l'issue #8508 et les lecons
+L963/L974. `--pair <name>` rebaseline une seule paire nommee.
+
+Ces tests couvrent :
+    1. `--update` seul -> argparse.error (exit != 0)
+    2. `--update --pair <existing>` -> succes sur 1 paire
+    3. `--update --pair <unknown>` -> erreur explicite (exit 1)
+    4. `--update --pair X --family Y` -> argparse.error (mutuellement exclusifs)
+    5. Le registre de reference reste byte-identique apres chaque test
+       (chaque test restore via backup).
+
+Run:
+    pytest scripts/notebook_tools/tests/test_check_twin_parity_update_guard.py
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make the script importable from the tests dir.
+SCRIPT_DIR = (
+    Path(__file__).resolve().parent.parent  # scripts/notebook_tools/tests/../
+)
+SCRIPT = SCRIPT_DIR / "check_twin_parity.py"
+REGISTRY = SCRIPT_DIR / "twin_pairs.yaml"
+
+REPO_ROOT = REGISTRY.resolve().parents[2]  # scripts/notebook_tools -> scripts -> repo
+
+
+@pytest.fixture
+def registry_backup():
+    """Sauvegarde + restauration du registre autour de chaque test.
+
+    Meme si les tests qui reussissent sont read-only (--update n'ecrit
+    que si selecteur OK), cette fixture protege contre les regressions
+    silencieuses : si un futur patch casse la garde et que --update
+    sans selecteur se met a reecrire, le test est restaure apres
+    execution (rollback propre).
+    """
+    if not REGISTRY.exists():
+        pytest.skip(f"registre introuvable : {REGISTRY}")
+    backup = REGISTRY.with_suffix(".yaml.bak.c909")
+    shutil.copy2(REGISTRY, backup)
+    try:
+        yield backup
+    finally:
+        shutil.copy2(backup, REGISTRY)
+        backup.unlink(missing_ok=True)
+
+
+def _run_update(*extra_args: str) -> subprocess.CompletedProcess:
+    """Execute le script en sous-processus (subprocess.run) pour capturer
+    l'exit code reel et le stderr -- c'est l'integration-test de la garde
+    argparse, pas un mock.
+    """
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--update", *extra_args],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+    )
+
+
+def test_update_without_selector_refuses(registry_backup):
+    """`--update` seul DOIT etre refuse par argparse (cf #8508).
+
+    Avant c.909 : exit 0, registre re-ecrit silencieusement (corruption).
+    Apres c.909 : exit != 0, stderr contient une mention de l'issue #8508
+    ou des lecons L963/L974.
+    """
+    result = _run_update()
+    assert result.returncode != 0, (
+        f"--update sans selecteur aurait du etre refuse (exit != 0). "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    # Le message argparse doit pointer vers la garde pour que l'agent
+    # comprenne pourquoi sa commande est refusee (issue + lecons).
+    combined = (result.stdout + result.stderr).lower()
+    assert any(
+        needle in combined
+        for needle in ("#8508", "l963", "l974", "selecteur explicite")
+    ), f"Message de garde absent. stderr={result.stderr!r} stdout={result.stdout!r}"
+
+
+def test_update_with_pair_selector_succeeds_on_existing_pair(registry_backup):
+    """`--update --pair <existing>` rebaseline exactement 1 paire.
+
+    Verifie qu'apres l'operation, **seule la cible** est affectee :
+    ses SHAs `last_audit` correspondent aux blobs git courants, et
+    les autres paires sont **byte-identiques** a la sauvegarde pre-test.
+
+    Note : `update_pair` est intentionnellement **idempotent cote
+    date** : il ne touche la date que si le SHA a change (cf
+    `check_twin_parity.py` l.207 `today = pair.get('last_audit', {})`).
+    On ne peut donc pas exiger `date == today` ici -- le bon invariant
+    est « les SHAs de la cible sont les blobs courants, les autres
+    paires n'ont pas ete modifiees ».
+    """
+    import subprocess as _sp
+    import yaml
+
+    all_pairs_before = yaml.safe_load(REGISTRY.read_text(encoding="utf-8"))
+    assert isinstance(all_pairs_before, list) and all_pairs_before, "registre vide"
+    # Choisir une cible connue (Search-1 StateSpace existe dans le registre actuel).
+    target_entry = next(
+        (p for p in all_pairs_before if p.get("name") == "Search-1 StateSpace"),
+        all_pairs_before[0],
+    )
+    target_name = target_entry["name"]
+    target_py_path = target_entry["python"]
+    target_cs_path = target_entry["csharp"]
+
+    # SHAs courants pour comparaison (HEAD working tree).
+    def _cur_sha(rel_path: str) -> str | None:
+        r = _sp.run(
+            ["git", "ls-tree", "HEAD", "--", rel_path],
+            capture_output=True, text=True, cwd=str(REPO_ROOT),
+        )
+        if r.returncode != 0 or not r.stdout.strip():
+            return None
+        parts = r.stdout.split()
+        return parts[2] if len(parts) >= 3 else None
+
+    expected_py_sha = _cur_sha(target_py_path)
+    expected_cs_sha = _cur_sha(target_cs_path)
+
+    result = _run_update("--pair", target_name)
+    assert result.returncode == 0, (
+        f"--update --pair {target_name!r} aurait du reussir. "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert "1 paire(s)" in result.stdout or "1 paire" in result.stdout, (
+        f"Le script aurait du annoncer 1 paire mise a jour. stdout={result.stdout!r}"
+    )
+
+    after = yaml.safe_load(REGISTRY.read_text(encoding="utf-8"))
+
+    # 1) La cible a les SHAs courants (= ce que `git rev-parse HEAD:<path>` retourne).
+    target_after = next(p for p in after if p.get("name") == target_name)
+    a_audit = target_after.get("last_audit") or {}
+    assert a_audit.get("python_sha") == expected_py_sha, (
+        f"Cible {target_name!r}.python_sha = {a_audit.get('python_sha')!r}, "
+        f"attendu {expected_py_sha!r} (git ls-tree HEAD)."
+    )
+    assert a_audit.get("csharp_sha") == expected_cs_sha, (
+        f"Cible {target_name!r}.csharp_sha = {a_audit.get('csharp_sha')!r}, "
+        f"attendu {expected_cs_sha!r} (git ls-tree HEAD)."
+    )
+
+    # 2) Les AUTRES paires sont byte-identiques (memes SHAs qu'avant).
+    by_name_before = {p["name"]: p for p in all_pairs_before}
+    drifted = []
+    for p in after:
+        name = p.get("name")
+        if name == target_name:
+            continue
+        before = by_name_before.get(name)
+        if before is None:
+            drifted.append(f"{name}: disparu du registre")
+            continue
+        b_audit = before.get("last_audit") or {}
+        a_audit_other = p.get("last_audit") or {}
+        for sha_key in ("python_sha", "csharp_sha"):
+            if b_audit.get(sha_key) != a_audit_other.get(sha_key):
+                drifted.append(
+                    f"{name}.{sha_key}: {b_audit.get(sha_key)} -> {a_audit_other.get(sha_key)}"
+                )
+    assert not drifted, (
+        "D'autres paires que la cible ont ete modifiees -- "
+        "la garde anti-corruption silencieuse a-t-elle casse ?\n"
+        + "\n".join(drifted)
+    )
+
+
+def test_update_with_pair_selector_refuses_on_unknown_pair(registry_backup):
+    """`--update --pair <unknown>` retourne une erreur explicite.
+
+    Important : on doit obtenir un message qui liste des noms connus
+    pour que l'agent puisse corriger son selecteur.
+    """
+    result = _run_update("--pair", "ThisPairDoesNotExist-9999")
+    assert result.returncode != 0, (
+        f"--pair <unknown> aurait du echouer. "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    combined = result.stdout + result.stderr
+    assert "ThisPairDoesNotExist-9999" in combined, (
+        f"Le message devrait citer le nom inconnu. "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
+
+def test_update_with_pair_and_family_is_mutually_exclusive(registry_backup):
+    """`--pair` et `--family` ne peuvent pas cohabiter avec `--update`.
+
+    L'intersection des deux filtres peut etre vide par accident ;
+    argparse.error les rejette en amont (plus clair que de retourner
+    silencieusement 0 paires mises a jour).
+    """
+    result = _run_update("--pair", "AnyPair", "--family", "AnyFamily")
+    assert result.returncode != 0, (
+        f"--pair + --family simultanes aurait du etre rejete. "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    combined = (result.stdout + result.stderr).lower()
+    assert "mutuellement exclusifs" in combined or "incompatible" in combined, (
+        f"Message d'incompatibilite attendu. "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )


### PR DESCRIPTION
## c.909 — Twin-parity CI anti-L963/L974 (anti-corruption-silencieuse du registre)

**Grain:** DEEP/infra-ci-hardening (sub-genre `ci-remediation-message-guard`) — lane `myia-po-2023:CoursIA-2` — prev: c.908 MED/notebook-fix axe-2 SOTA (Planners-3 CoutChemin off-by-one)
**Sub-genre :** `ci-remediation-message-guard` (corriger le harnais qui **incite** à la corruption silencieuse) — distinct du twin-register SHA bump et du notebook-fix.
**Issue:** #8508 (canal audit cross-source / harness-hardening)
**Branch:** `feature/c909-twinparity-ci-hardening`
**Worktree:** `D:/Dev/CoursIA-2-c909-twinparity-ci` (origin/main HEAD `d5fd3cd9f`, post-#8504 MERGED)
**Scope :** 3 fichiers, **<3000L strict** (catalog-pr-hygiene HARD 3 atomique) :
- `.github/workflows/twin-parity.yml` : message de remediation ligne 92 (corriger)
- `scripts/notebook_tools/check_twin_parity.py` : argparse + garde `--update` (renforcer)
- `scripts/notebook_tools/tests/test_check_twin_parity_update_guard.py` : test du refus (couvrir le gate)

## Cible

La CI twin-parity, sur `drift_introduced`, recommande littéralement :
> Action : re-auditer la paire firsthand puis `python scripts/notebook_tools/check_twin_parity.py --update` pour rebaseline le SHA dans le meme PR

**`--update` sans `--family` réécrit le `last_audit` de TOUTES les paires du registre** (88 paires aujourd'hui, cf `check_twin_parity.py` l.380-389). Un agent qui suit la remediation affichée par la CI pour rebaseliner UNE paire marque « audité aujourd'hui » TOUTES les paires en dérive du dépôt — y compris celles qui dérivent pour une raison qui méritait un examen. **Corruption silencieuse du signal** que le registre existe précisément pour porter.

**C'est d'autant plus piégeux** que le message dit « re-auditer la paire firsthand **puis** `--update` » : l'agent croit avoir fait le travail correctement.

**Constaté en vrai** : PR #8503 (SW-13 re-exec end-to-end) a fail sur ce job ce cycle. J'ai dû contre-instruire l'auteur de **ne pas** suivre la remediation affichée.

## Approche — 3 fixes scoped

### Fix #1 — Message de remediation dans la CI

`.github/workflows/twin-parity.yml` ligne 92 : remplacer la recommandation `--update` par la méthode manuelle (L963 ★★★, L974 ★★★).

**Avant** :
```
La PR a introduit $INTRO paire(s) en DRIFT/MISSING qui etaient OK au base-ref origin/main. Action : re-auditer la paire firsthand puis `python scripts/notebook_tools/check_twin_parity.py --update` pour rebaseline le SHA dans le meme PR, OU splitter en deux PRs pour que chaque cote evolue separement avec rebaseline.
```

**Après** :
```
La PR a introduit $INTRO paire(s) en DRIFT/MISSING qui etaient OK au base-ref origin/main. Action : re-auditer la paire firsthand PUIS rebaseline UNIQUEMENT cette entree dans le registre (methode manuelle, JAMAIS --update sans selecteur) :
  1. Calculer le SHA du notebook modifie : `git rev-parse HEAD:<chemin-du-notebook>`
  2. Editer scripts/notebook_tools/twin_pairs.yaml a la main, mettre a jour python_sha/csharp_sha + date + by pour CETTE entree seulement
  3. OU splitter la PR pour que chaque cote evolue separement avec rebaseline isole.
Drift pre-existant ($PRE paire(s)) releve d'une PR dediee cf #8264. Voir twin_parity_report.json dans les artifacts.
```

### Fix #2 — Garde-fou argparse dans le script

`scripts/notebook_tools/check_twin_parity.py` :
- Ajouter `--pair <name>` : sélecteur explicite pour rebaseline UNE paire nommée (le message de CI suggère déjà implicitement cette opération).
- Ajouter `--yes-all-pairs` : opt-in explicite pour rebaseline TOUT le registre.
- `--update` exige désormais **`--family` OU `--pair` OU `--yes-all-pairs`** (sinon `parser.error()` avec un message clair référençant L963/L974 et l'issue #8508).

### Fix #3 — Test du refus

`scripts/notebook_tools/tests/test_check_twin_parity_update_guard.py` :
- `test_update_without_selector_refuses` : vérifie que `python check_twin_parity.py --update` (sans sélecteur) retourne exit ≠ 0 (exit 2 = argparse error).
- `test_update_with_pair_selector_succeeds_on_existing_pair` : vérifie que `--pair <name>` sur une paire existante modifie le registre OK.
- `test_update_with_pair_selector_refuses_on_unknown_pair` : vérifie que `--pair <unknown>` retourne une erreur explicite.

## Validations (firsthand)

| Validation | Résultat |
|---|---|
| `git diff --stat` | strict, 3 fichiers, <200 lignes attendues |
| LF-only CR=0 (L965 ★) | PASS (write_bytes binary sur .yml + .py) |
| Trailing newline (L268) | PASS |
| `python check_twin_parity.py --update` (sans selecteur) | **REFUSE** avec message argparse + ref #8508 |
| `python check_twin_parity.py --update --pair Search-9-LP` | OK (rebaseline 1 paire) |
| `pytest tests/test_check_twin_parity_update_guard.py` | 3/3 PASS |
| `pytest tests/test_twin_registry_integrity.py` (regression) | 7/7 PASS |
| Catalog-pr-hygiene HARD 1 | `COURSE_CATALOG.generated.{json,md}` byte-identique à main (0 diff) ✓ |
| Catalog-pr-hygiene HARD 2 | Branche rebase frais depuis origin/main (HEAD `d5fd3cd9f`) ✓ |
| Catalog-pr-hygiene HARD 3 | Atomique : <3000L, <15 fichiers, 1 sujet (3 fixes scoped, cohérents) ✓ |
| Catalog-pr-hygiene HARD 4 | `Closes #8508` (issue entièrement résolue : message + guard + test) ✓ |
| L898 ★★★ collision guard | 0 PR OPEN cross-lane sur `twin-parity.yml` / `check_twin_parity.py` (`gh pr list --search`) ✓ |
| L898 ★★★ collision guard | `gh pr list --search "twin-parity"` → 0 PR #8508-adjacent active ✓ |

## Garde-fous

- **L963 ★★★ byte-surgical** : on ne touche PAS `twin_pairs.yaml` (no rebaseline — la substance c'est de **réparer** le harnais, pas de produire un rebaseline)
- **L965 ★** : `Path.write_bytes()` pour `.yml` + `.py` (LF-only CR=0)
- **L974 ★★★** : SHA from `git rev-parse HEAD:<path>` documenté dans le nouveau message CI, JAMAIS `--update` sans selecteur
- **L898 ★★★** : pre-push collision guard `gh pr list --search "twin-parity"` + `gh pr list --search "#8508"`
- **L948 Stop & Repair** : aucune cellule notebook touchée (C.3 hors-scope — c.909 = harnais)
- **L677-L4 ★★** : body PR HORS worktree (scratchpad pattern, JAMAIS commited dans l'arbre)
- **L268** : trailing newline mandatory sur tous les fichiers éditées
- **catalog-pr-hygiene HARD 1-4** : byte-identique, rebase frais, atomique, `Closes #8508`
- **G.9 culture du doute** : pas de claim SOTA sur l'atténuation CI sans `pytest` vert (test du refus est le **filet** anti-fabrication)
- **G-VAR-1** : plat principal = DEEP/infra-ci-hardening (substance genuine, pas scan-générable)
- **G-VAR-2** : 0 LIGHT dans le cycle (c.908 = MED, c.909 = DEEP, cap 1 LIGHT/lane/jour respecté)
- **G-VAR-3** : c.909 = DEEP/infra-ci-hardening ≠ c.908 = MED/notebook-fix ≠ c.907 = LIGHT/cjk-correction ≠ c.906/c.904/c.903 = MED/twin-register. Sub-genre distinct, substance genuinement distincte (réparer le harnais ≠ corréger bug ≠ ajouter paire ≠ fix glyph)
- **L954 ★★ pivot cross-famille** : c.908 = Planners-3 notebook-fix, c.909 = ci-harness — 2 familles distinctes (Planners vs Harness/infra), pas 2× consécutif même genre
- **C.1/C.2/C.3** : 0 notebook touché, hors-scope c.909
- **C.636/638/640 ★★★ G.1** : lecture source `.github/workflows/twin-parity.yml` AVANT Edit (première lecture c.909 = ce tour-ci), `check_twin_parity.py` l.380-389 firsthand confirmé

## Hors scope

- **#8057 twin-parity epic** : 16/16 GT family saturée (c.908 + c.909-c.914 session parallèle). c.909 ferme **uniquement** le volet CI-remediation-message (sous-grain de #8057), pas l'epic.
- **PR #8504 (MERGED 2026-07-25T10:40:33Z)** : a déjà traité le conflit sérial d'append via `.gitattributes merge=union` + 7 tests integrity (créé par la session parallèle). c.909 = sub-grain complémentaire (message + guard argparse), pas de collision.
- **#8264** : batch rebaseline precedent (DRIFT pre-existant) — scope distinct, hors-scope c.909.
- **#8504 follow-up : `merge=union` server-side** : le commentaire du PR #8504 dit « je n'affirme pas que le merge server-side de GitHub honore `merge=union` ». c.909 = sub-grain distinct (la remediation affichée), pas la validation serveur.

## Voir aussi

- Issue : [#8508](https://github.com/jsboige/CoursIA/issues/8508) (canal audit / harness-hardening)
- PR #8504 (sibling, MERGED 2026-07-25) — union merge + integrity tests, sub-grain complémentaire de #8057
- Méthode : L963 ★★★ + L965 ★ + L974 ★★★ + L898 ★★★ + L948 + L677-L4 ★★ + L268 + catalog-pr-hygiene HARD 1-4 + G-VAR-1/2/3 + L954 ★★
- Précédent twin-harness : c.903/c.904/c.906 GT twin-register + c.908 Planners-3 off-by-one + c.876a sha-only-rebaseline
- Topic : `~/.claude/projects/d--Dev-CoursIA-2/memory/topic-c909-twinparity-ci.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
