### PR TITLE
fix(ict-15b,#8498): correct MAJ_4 exercise false deg=3 s=2 (follow-up to #8511)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15b-SensitivityCanonicity.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15b-SensitivityCanonicity.ipynb
@@ -1397,19 +1397,19 @@
    "source": [
     "### Exercice 3 -- Fonction MAJ sur 4 variables (borne de Huang manuelle)\n",
     "\n",
-    "L'**Exemple guide 3** reproduit la borne `s >= sqrt(deg)` sur OR (deg=1) et parite (deg=4) sur 4 variables. Le defi : implemente la **fonction MAJ (majorite)** sur 4 variables en utilisant le squelette `boolean_sensitivity` deja defini dans l'Exemple guide 3, puis verifie manuellement que `s(MAJ_4) = 2` et `sqrt(deg(MAJ_4)) = sqrt(3) ~ 1.732`.\n",
+    "L'**Exemple guide 3** reproduit la borne `s >= sqrt(deg)` sur OR (`deg = 4`) et parite (`deg = 4`) sur 4 variables. Le defi : implemente la **fonction MAJ (majorite)** sur 4 variables en utilisant `boolean_sensitivity` **et** `multilinear_degree` deja definis dans l'Exemple guide 3, puis verifie que `s(MAJ_4) = 3` et que la borne `s >= sqrt(deg)` est respectee (avec `deg(MAJ_4) = 4`, soit `sqrt(deg) = 2`).\n",
     "\n",
-    "**Objectif pedagogique** : la majorite 4 est le cas **non-trivial** (entre OR trivial et parite extreme) : sa sensibilite est 2 (2 voisins basculent pour les entrees critiques) et son degre est 3 (un cube de Reed-Muller), donc la borne `s >= sqrt(deg)` tient avec un ratio ~ 1.15.\n",
+    "**Objectif pedagogique** : comme OR et parite, MAJ_4 satisfait confortablement la borne de Huang (`s = 3 >= sqrt(deg) = 2`). La majorite 4 a une sensibilite de 3 (pour une entree comme `1000`, bascule de 3 des 4 voisins) et un degre multilineaire reel de 4 (le monome `x1x2x3x4` apparait avec un coefficient non-nul). Les fonctions booleennes symetriques usuelles (OR, ET, MAJ, parite) satisfont toutes largement la borne ; les exemples *tendaus* ou `s` est proche de `sqrt(deg)` sont plus specialises (fonction *tribes*).\n",
     "\n",
     "**Indices** :\n",
     "- La table de verite de MAJ_4 : `MAJ_4(x) = 1` si `>=2` des bits sont a 1 parmi les 4\n",
     "- La longueur de la table est `2^4 = 16`\n",
-    "- `deg(MAJ_4) = 3` (son polynome de Fourier a un coefficient non-trivial d'ordre 3) -- **pas besoin de le calculer**, juste citer\n"
+    "- `deg(MAJ_4) = 4` : calcule-le avec `multilinear_degree(maj_tt)` (transformee de Mobius additive, definie dans l'Exemple guide 3) -- ne le cite pas en dur.\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "id": "65281d13",
    "metadata": {
     "execution": {
@@ -1437,16 +1437,17 @@
     }
    ],
    "source": [
-    "# TODO etudiant : implementer la table de verite MAJ_4 et utiliser boolean_sensitivity\n",
-    "# pour verifier s(MAJ_4) = 2 et la borne de Huang sqrt(deg=3) ~ 1.732.\n",
+    "# TODO etudiant : implementer la table de verite MAJ_4, calculer s ET deg, puis verifier la borne.\n",
+    "# pour verifier s(MAJ_4) = 3 et la borne de Huang s >= sqrt(deg) (deg=4, sqrt=2.0).\n",
     "\n",
-    "# Skeleton : reutilise la fonction boolean_sensitivity de l'Exemple guide 3 (cellule au-dessus).\n",
-    "# Ne PAS la redéfinir ici.\n",
+    "# Skeleton : reutilise boolean_sensitivity ET multilinear_degree de l'Exemple guide 3 (cellule au-dessus).\n",
+    "# Ne PAS les redéfinir ici.\n",
     "\n",
     "# maj_tt = [...]  # TODO etudiant : table de verite de MAJ_4 (longueur 16)\n",
     "# s_maj = boolean_sensitivity(maj_tt)\n",
-    "# print('MAJ_4 : s =', s_maj, ', sqrt(deg=3) =', format(3 ** 0.5, '.3f'),\n",
-    "#       ', borne respectee :', s_maj >= 3 ** 0.5)\n",
+    "# deg_maj = multilinear_degree(maj_tt)   # degre multilineaire reel (Mobius additive)\n",
+    "# print('MAJ_4 : s =', s_maj, ', deg =', deg_maj, ', sqrt(deg) =', format(deg_maj ** 0.5, '.3f'),\n",
+    "#       ', borne respectee :', s_maj >= deg_maj ** 0.5)\n",
     "\n",
     "print('Exercice 3 a completer : MAJ_4 sur 4 variables, verification manuelle de la borne de Huang')\n"
    ]


### PR DESCRIPTION
## Summary

Follow-up to **#8511** (which fixes `deg` for the OR/Parité *example* in cell[28], closing #8498). This PR extends the same correction to **Exercice 3 (cell[33]/[34])**, whose markdown + exercise-stub still taught wrong `deg(MAJ_4)` and `s(MAJ_4)` values and referenced the old `OR (deg=1)`.

Handoff from po-2024 (c.878), who caught that the exercise cell still carried the defect after #8511's surgical scope (cells 27/28 only).

## The defect (G.1 firsthand-verified)

Notebook `cell[33]` taught:
- `s(MAJ_4) = 2` — **wrong**
- `deg(MAJ_4) = 3` ("un cube de Reed-Muller") — **wrong**
- `sqrt(deg(MAJ_4)) = sqrt(3) ~ 1.732`
- referenced `OR (deg=1)` (stale vs #8511's `OR deg=4`)

**Real values** (additive Möbius `multilinear_degree`, verified two ways — code + analytic `c_{1234} = 1−4+6−0+0 = 3 ≠ 0`):

| Function | s (boolean_sensitivity) | deg (real multilinear) | sqrt(deg) |
|----------|------------------------|------------------------|-----------|
| MAJ_4 weak (≥2 of 4) | **3** | **4** | 2.0 |

(`s=3`: for input `1000`, flipping 3 of the 4 bits changes the majority. `deg=4`: the monomial `x₁x₂x₃x₄` appears with nonzero coefficient.)

## Fix

**cell[33] md** — corrected `s=2→3`, `deg=3→4`, `sqrt(3)~1.732 → sqrt(4)=2`; rewrote the "non-trivial ratio ~1.15" claim honestly: like OR and Parité, MAJ_4 satisfies the bound comfortably (`3 ≥ 2`); tight Huang examples need specialized functions (tribes). Fixed `OR(deg=1) → OR(deg=4)`.

**cell[34] exercise stub** — removed the false hardcoded hint `sqrt(deg=3)` from the *commented* skeleton; now points the student to **compute** `deg` via `multilinear_degree(maj_tt)` (the function #8511 adds to cell[28]) instead of citing a wrong literal. **The exercise is NOT solved** — active code remains the `print()` stub, all calls stay commented (exercise-example-labeling preserved, C.1 clean).

## Validation

- **Surgical**: only cells 33 (md) + 34 (code) changed; the other 33 cells untouched (cell-by-cell verified)
- **Exercise stub preserved**: cell[34] active (non-comment) code = `print(...)` only — no solution filled in
- **H.1 forensic**: re-exec of cell[34] committed source == committed output ✓ (print stub, output identical, `execution_count` 17→18)
- **C.1**: 0 real violations (the only `NotImplementedError` match in the notebook is inside a comment)
- Byte-stable write (`json.dumps(indent=1)`, no trailing newline — matches HEAD format); single file, +11/−10

## Scope relationship

- #8511 closes #8498 (the issue was scoped to cell[28] OR/Parité). This follow-up completes the deg correction across the exercise so the notebook is internally consistent (corrected example + corrected exercise).
- Regions 33/34 ≠ 27/28 → rebases cleanly when #8511 merges (no YAML/region conflict).
- **Prong-B residual** (flagged in #8511, out of scope here too): OR/Parité/MAJ all trivially satisfy `s ≥ √deg` (`4≥2`, `3≥2`) — a discriminating example where `s ≈ √deg` (e.g. tribes) would be a separate pedagogical enhancement.

See #8498 · See #8511

Co-Authored-By: Claude-Code <noreply@anthropic.com>
