### PR TITLE
fix(ml-2,#8428): replace CJK glyph 撑支 residue with French ("dataset utilisé")

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-2-Data&Features-Python.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-2-Data&Features-Python.ipynb
@@ -43,7 +43,7 @@
     "\n",
     "En machine learning, **la qualité des données détermine la qualité du modèle**. Cette leçon couvre le **feature engineering** : l'art de transformer des données brutes (texte, catégories, valeurs manquantes) en une matrice numérique `X` qu'un modèle peut consommer.\n",
     "\n",
-    "Le dataset支撑 : **taxi-fare** (tarifs de taxi de NYC). Objectif : prédire `fare_amount` à partir de `vendor_id`, `rate_code`, `passenger_count`, `trip_time_in_secs`, `trip_distance`, `payment_type`.\n",
+    "Le dataset utilisé : **taxi-fare** (tarifs de taxi de NYC). Objectif : prédire `fare_amount` à partir de `vendor_id`, `rate_code`, `passenger_count`, `trip_time_in_secs`, `trip_distance`, `payment_type`.\n",
     "\n",
     "## Chargement des données avec pandas\n",
     "\n",


### PR DESCRIPTION
## Summary

ML family slice of the #8428 CJK-glyph fleet cleanup. `ML-2-Data&Features-Python.ipynb` cell[0] (markdown intro) contained an LLM-translation residue: the Chinese `支撑` ("support/backing") inserted mid-French prose.

**Before**: `Le dataset支撑 : **taxi-fare** (tarifs de taxi de NYC). Objectif : prédire fare_amount...`
**After**: `Le dataset utilisé : **taxi-fare** (tarifs de taxi de NYC). Objectif : prédire fare_amount...`

`utilisé` is the natural French rendering ("the dataset used in this lesson is taxi-fare"), faithful to the pedagogical intent (the colon introduces the dataset name).

## Fix

- **Byte-surgical raw-text replace** (single substring, no JSON round-trip churn — per #8428 fix pattern, NOT NotebookEdit which churns `source` list→string). `+1/−1`.
- **Markdown-only cell** → C.2 exception (no re-exec). 0 code cells touched, 0 outputs touched.

## Validation

- `validate_pr_notebooks.py origin/main <nb>` → **1/1 PASS (9 code cells)**.
- Full CJK scan on ML-2 (`[\u3000-\u9fff\uff00-\uffef]`): **0 residual glyphs** in source AND outputs.

## Scope

ML family slice (atomic, per #8428's per-family PR convention). ML-2 is the only ML-family notebook in the #8428 inventory. Other families (GenAI/Env, Lean, Search, SmartContracts, SocialChoice, Sudoku, SymbolicLearning) remain open for separate slices. QC/Python family done in #8426.

See #8428 (fleet-wide CJK cleanup). See #8052.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
