### PR TITLE
feat(twin-register,#8057): register CSP-6-Hybridization pair (Search/Part2-CSP)

### DIFF
--- a/scripts/notebook_tools/twin_pairs.yaml
+++ b/scripts/notebook_tools/twin_pairs.yaml
@@ -186,6 +186,22 @@
     - "Cas etudies : job-shop scheduling (3 machines x 3 jobs, makespan minimal), equipement maintenance planning."
     - "Note infrastructure : ce notebook (.NET) est explicite sur la pre-configuration IKVM (AppContext['IKVM.Home'] + tzdb OK) - voir cellule d'initialisation 'IKVM 8.15.0 pret (home=ikvm-home-8.15.0-win-x64, tzdb=True) - Choco-solver charge'."
 
+- name: "CSP-6 Hybridization"
+  family: Search/Part2-CSP
+  python: MyIA.AI.Notebooks/Search/Part2-CSP/CSP-6-Hybridization.ipynb
+  csharp: MyIA.AI.Notebooks/Search/Part2-CSP/CSP-6-Hybridization-Csharp.ipynb
+  parity_level: semantic
+  last_audit:
+    date: "2026-07-25"
+    by: po-2024
+    python_sha: 756bd37298dc5456c4bf0ef14d133ca55dfd6d1b
+    csharp_sha: 41227c7457f831f81e09a6cd0da594743faba025
+  known_differences:
+    - "Socle pedagogique commun : approches hybrides modernes en CP -- Lazy Clause Generation (LCG), architecture CP-SAT (CP + SAT + CDCL), hybridation CP + ML (prediction de faisabilite), integration LLM + CSP."
+    - "Cas etudies : N-Reines (LCG via CP-SAT), Job-Shop Scheduling (exploration des parametres CP-SAT : DEFAULT / FIXED_SEARCH / PORTFOLIO), generation d'instances CSP aleatoires + prediction de faisabilite par features (n_vars, n_constraints, density)."
+    - "Cote Python : ortools.sat.python.cp_model + matplotlib + numpy (17 cellules code, predicteur lineaire from-scratch avec descente de gradient). Cote C# : Google.OrTools.Sat natif (NuGet Google.OrTools, 0 bridge IKVM, design option b #4956 ; 15 cellules code, predicteur ponderation manuelle + gradient simplifie)."
+    - "Note API : l'API C# de Google.OrTools 9.15 expose solver.WallTime() mais PAS solver.NumBranches() / NumConflicts() (contrairement a l'API Python). Le cote C# reporte donc le wall-time la ou le cote Python reporte branches/conflits -- difference d'idiome API, pas de defaut de parite (les deux mesurent le cout de resolution, chacun via les compteurs disponibles dans son langage)."
+
 - name: "Search-1 StateSpace"
   family: Search/Part1-Foundations
   python: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-1-StateSpace.ipynb


### PR DESCRIPTION
## Summary

Registers the `CSP-6-Hybridization` Python/C# twin pair in the twin-parity registry (`Search/Part2-CSP` family). Registry now 93 pairs (was 92).

## Parity audit (firsthand, G.1)

Both notebooks cover the **same hybrid-CP concepts** (`parity_level: semantic`):

| Concept | Python | C# |
|---------|--------|-----|
| Lazy Clause Generation | N-Queens via `cp_model` | N-Queens via `Google.OrTools.Sat` |
| CP-SAT parameter exploration | Job-Shop (DEFAULT/FIXED_SEARCH/PORTFOLIO, `random_seed=42`, `num_search_workers=1`) | Job-Shop (3 strategies, same reproducibility discipline) |
| Random CSP instance + feasibility | `cp_model` generate + solve | `Google.OrTools.Sat` generate + solve |
| Feature extraction + predictor | `[n_vars, n_constraints, density]` → linear predictor (gradient descent, from-scratch) | same features → weighted predictor (manual + simplified gradient) |

**Idioms**: Python `ortools.sat.python.cp_model` + matplotlib + numpy (17 code cells) ↔ C# `Google.OrTools.Sat` native (NuGet `Google.OrTools`, 0 IKVM bridge, design option b #4956; 15 code cells).

**Known API idiom difference (NOT a parity defect)**: the C# Google.OrTools 9.15 API exposes `solver.WallTime()` but NOT `solver.NumBranches()`/`NumConflicts()` (which the Python API has). The C# side reports wall-time where Python reports branches/conflicts — both measure solving cost via the counters available in their language. Documented in `known_differences`.

## Insertion strategy

Mid-file insert after CSP-4 (stable `Search/Part2-CSP` region), NOT at EOF — avoids the concurrent-merge EOF cascade (lesson c.913). Single PR, no stack.

## Verification

- `check_twin_parity.py --family Search/Part2-CSP`: **5 pairs OK=5 DRIFT=0 MISSING=0** (CSP-6 [OK]; SHAs match: python `756bd372...`, csharp `41227c74...`).
- Full registry `check_twin_parity.py`: **93 pairs OK=93 DRIFT=0 MISSING=0** (no collateral drift on other families).
- YAML valid, CRLF=0, byte-stable insert (+16 lines).

## Scope

Partial contribution to #8057 (twin-parity metadata). Search/Part2-CSP family has more unregistered pairs: CSP-5 in progress (po-2025 #8492), CSP-7/8/9 remain. SHAs are git blob oids (`git rev-parse origin/main:<path>`).

See #8057.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
