### PR TITLE
fix(security,#8519): scrub GitHub token prefix/suffix leak from Lean-10-LeanDojo cell[15] markdown

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-10-LeanDojo.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-10-LeanDojo.ipynb
@@ -825,7 +825,7 @@
     "**Résultat** : Token charge depuis le fichier `.env` local.\n",
     "\n",
     "```\n",
-    "Token: ghp_IMfYN5...NCsd\n",
+    "Token: ghp_••••••••••••••••••••\n",
     "Source: <répertoire_Lean>/.env (GITHUB_TOKEN)\n",
     "```\n",
     "\n",
@@ -840,7 +840,7 @@
     "\n",
     "Avec token : **5000 requêtes/heure**.\n",
     "\n",
-    "> **Securite** : Le token est masque dans l'affichage (`ghp_IMfYN5...NCsd`). Assurez-vous que `.env` est dans `.gitignore`."
+    "> **Securite** : Le token est masque dans l'affichage (`ghp_••••••••••••••••••••`). Assurez-vous que `.env` est dans `.gitignore`."
    ]
   },
   {


### PR DESCRIPTION
## Summary

**Security fix — SECRETS-HYGIENE.** `Lean-10-LeanDojo.ipynb` markdown cell[15] committed 2 literal occurrences of a GitHub token's real prefix+suffix (`ghp_IMfYN5...NCsd`) as a pedagogical "token loaded from .env" example. The middle was masked (`...`) but the **real prefix `ghp_IMfYN5` (10 chars) + suffix `NCsd` (4 chars)** were exposed in repo since commit `2cc673719` (2026-01-26, ~6 months). This PR scrubs both occurrences from the markdown source.

`Closes #8519`

## Firsthand G.1 audit (worktree at origin/main `8e2fcfa6b`)

**The leak cell** (`git show origin/main:...Lean-10-LeanDojo.ipynb`):
- cell[15] = **markdown** cell (`id=jrr13l15hnh`), **not** code.
- `source[5]` (inside fenced code block): `'Token: ghp_IMfYN5...NCsd\n'`
- `source[20]` (inline prose): `"Le token est masque dans l'affichage (\`ghp_IMfYN5...NCsd\`). Assurez-vous que \`.env\` est dans \`.gitignore\`."`
- Exactly **2 occurrences** of `ghp_IMfYN5...NCsd`, both in cell[15] source.

**THOROUGH secrets scan (all 75 cells, sources + outputs)** for `ghp_[A-Za-z0-9]{8,}`, `github_pat_…`, `sk-…`, `gho_/ghu_/ghs_`, `Bearer …`, `AIza…`:
- `ghp_` = **2 (only cell[15] source)**; in outputs = **0**.
- `NCsd` = 2 (source) / 0 (output); `IMfYN5` = 2 (source) / 0 (output).
- All other secret patterns = **0**. → Leak is confined to cell[15] markdown source.

**Critical: this is a markdown-SOURCE leak, NOT a committed code-cell OUTPUT.** Stop & Repair (secrets-hygiene rule 6) governs code-cell **outputs** — it does not forbid editing markdown prose source. Editing markdown source here is legitimate (no re-exec applicable; markdown has no execution).

## Fix (byte-surgical, L820)

Replacement: `ghp_IMfYN5...NCsd` → `ghp_` + 20× `•` (bullet-masked).

Rationale for the placeholder:
- **Real fragments removed**: `IMfYN5` and `NCsd` are gone (verified 0/0 post-edit).
- **`ghp_` format cue preserved** (2 occurrences remain): the `ghp_` prefix is the *public* format marker for classic GitHub PATs (like `sk-` for OpenAI) — keeping it lets the learner recognize "this is a classic PAT", which is the pedagogical point. It is not secret.
- **"Masked" appearance preserved**: bullets unambiguously read as a masked token, consistent with `source[20]`'s prose "Le token est masque dans l'affichage".
- **No scanner false-positive**: gitleaks matches `ghp_` + 36 base62 chars; bullets aren't base62.

**Method**: raw byte-level `str.replace` on UTF-8-decoded content, write back UTF-8 no-BOM, LF preserved. **Never NotebookEdit** (it churns `source` list↔string, `0.0`→`0`, strips trailing newline — lesson c.720).

## Verification

- `ghp_IMfYN5...NCsd` occurrences: **2 → 0**.
- new placeholder occurrences: **2** (both spots).
- `IMfYN5` / `NCsd`: **0 / 0** (real fragments gone).
- `ghp_` count: **2** (format cue preserved, not secret).
- JSON valid post-edit; 75 cells intact; cell[15] still `markdown`.
- CRLF = 0 (before and after); no BOM.
- `git diff --stat`: `+2 / −2`, **single file, single cell**.
- `git diff --check`: clean (no whitespace errors).

## Scope decision — secrets only (per issue author's recommendation)

The issue documents 2 things: (1) the **CRITICAL secret leak** [primary], (2) a minor count footnote (cell[30] "~27000 theoremes" vs cell[31]/[32] "27360"). The issue author **explicitly defers** the count: *"NOT fixed (deferred — keep this PR scope = secrets only, to minimize blast radius)"*. This PR honors that scoping.

On the count footnote specifically: it is **approximation-vs-exact, not a true inconsistency** — `~27000` is the rounded form of the exact `27360` already committed in cell[31] (code + outputs) and cell[32] (markdown). cell[31] is **code WITH outputs** that I cannot re-exec locally (LeanDojo requires cloning `lean4-example` + a live GitHub token + minutes of tracing); per doc-honesty I leave the established `27360` value untouched rather than risk aligning prose to a possibly-stale number. The `~27000` approximation in cell[30] markdown is harmless. If ai-01 wants strict unification, it's a trivial markdown follow-up — but it should be gated on a LeanDojo re-exec to confirm `27360` is still the real count.

`Closes #8519` is justified: the issue's **entire critical+security payload** (the token leak — the whole point of the issue) is fully resolved; the deferred count is non-security and explicitly carved out by the author.

## USER action required post-merge — token rotation (RECOVERABLE-USER-HAND)

Per secrets-hygiene rule 5: a committed secret is not removed from history by editing the working tree (the token stays in git history at `2cc673719`). **The user must rotate provider-side**:
1. **Revoke** `ghp_IMfYN5…NCsd` at GitHub → Settings → Developer settings → Personal access tokens (classic).
2. **Regenerate** a token if LeanDojo usage is still needed; store in `.env` (gitignored).
3. **Audit** GitHub audit-log for abuse — the prefix+suffix was public ~6 months.

Note: only prefix+suffix (not the full token) were ever committed — the middle was already masked — so direct exploit risk is bounded, but rotation is still the correct hygiene given 6 months of partial exposure.

## Compliance

- **C.2 exception**: markdown-only edit, no code cell touched → no re-exec applicable.
- **Stop & Repair honored**: 0 code-cell outputs hand-edited.
- **L820 byte-surgical**: raw `str.replace`, LF preserved, UTF-8 no-BOM.
- **catalog-pr-hygiene R4**: `Closes #8519` — critical payload fully resolved.
- **secrets-hygiene rule 2/5**: no inline literals remain; rotation signaled.

See #8519, #8052. Cross-ref: incident 2026-05-14 (`b34e3a05`, `os.getenv("KEY","<literal>")`).

Co-Authored-By: Claude <noreply@anthropic.com>
