### PR TITLE
fix(app-12,#8428): replace CJK glyph 胜利 residue with French (victoire) in utility() docstring

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb
@@ -2410,7 +2410,7 @@
     "        return len(state.moves) == 0\n",
     "    \n",
     "    def utility(self, state, player):\n",
-    "        \"\"\"Utilite de l'etat pour le joueur (胜利=1, defeat=-1, draw=0).\"\"\"\n",
+    "        \"\"\"Utilite de l'etat pour le joueur (victoire=1, defeat=-1, draw=0).\"\"\"\n",
     "        pass  # TODO etudiant\n",
     "\n",
     "# === Fonctions utilitaires pour les jeux AIMA ===\n",


### PR DESCRIPTION
## Summary

**CJK glyph cleanup (fleet #8428).** `App-12-ConnectFour.ipynb` (Python twin) cell[41] `utility()` stub docstring had a stray Chinese glyph `胜利` ("victory") — LLM-translation residue mixing French (`Utilite de l'etat pour le joueur`) + Chinese (`胜利`) + English (`defeat`/`draw`). Replaced with `victoire` (French, matching the docstring's French context).

`See #8428` (fleet-wide CJK cleanup epic — partial contribution; ML-2 done by po-2024 #8517, other families' slices remain).

## Firsthand G.1 audit (worktree at origin/main `8e2fcfa6b`)

**The glyph** (`git show origin/main:...App-12-ConnectFour.ipynb`):
- cell[41] = **code** cell, `def utility(self, state, player)` — an **exercise stub** (`pass  # TODO etudiant`, rule C.1 compliant).
- `source[33]`: `'        """Utilite de l\'etat pour le joueur (胜利=1, defeat=-1, draw=0)."""\n'`
- The docstring documents expected return values for the student: victory=1, defeat=-1, draw=0. The `胜利` was residue; `victoire` is the correct French.

**Scope scan** (App-12 Python, sources + outputs): `胜利` = **1 occurrence** (only this docstring). Post-fix CJK in sources = **0**, in outputs = **0**. The CSharp twin (`App-12-ConnectFour-CSharp.ipynb`) has **0 CJK** — clean, not touched.

**False-positive avoided**: the broader CJK scan also flagged `02-8-Expressive-TTS` (`多言語音声合成`, `こんにちは`) — that is **legitimate Japanese demo content** (a multilingual TTS sample string `{"lang": "Japonais", "text": "こんにちは！多言語音声合成のデモンストレーションです。"}`), NOT residue. Left untouched (it's the notebook's subject matter).

## Fix (byte-surgical)

`胜利` → `victoire` (raw byte-level `str.replace`, single occurrence, UTF-8 no-BOM, LF preserved — JAMAIS NotebookEdit per lesson c.720).

**Resulting docstring**: `"""Utilite de l'etat pour le joueur (victoire=1, defeat=-1, draw=0)."""`

**Scope discipline**: minimal CJK-only fix. The surrounding `defeat`/`draw` (English) are left as-is — they are not CJK (out of #8428 scope) and game-theory terms commonly appear in FR code. A fuller FR i18n (`défaite`/`nul`) would be scope creep beyond the CJK-fleet mandate.

## Why no re-exec (C.2 docstring-only exception)

- The change is to a **docstring** (non-executable text inside `"""..."""`). Python docstrings do not execute and cannot affect a cell's outputs.
- cell[41] retains `execution_count=16` + its outputs (both untouched) → the committed outputs remain **valid and coherent** with the source (identical executable logic; only a comment word changed).
- H.3 pre-commit gate: **0 violations** (22 code cells, none with `execution_count=None and no outputs`).
- This is the code-cell analog of the markdown-only C.2 exception (po-2024 ML-2 #8517 precedent): non-executable text changed, outputs provably unaffected.

## Verification

- `胜利` occurrences: **1 → 0**.
- CJK residual (sources + outputs): **0 / 0**.
- cell[41]: `execution_count=16` retained, outputs retained, `胜利` gone.
- JSON valid; 59 cells intact.
- CRLF = 0; no BOM.
- `git diff --stat`: `+1 / −1`, **single file, single line**.
- `git diff --check`: clean.
- Catalogue byte-identical to main (0 churn).

## Compliance

- **C.1**: the cell remains a compliant stub (`pass # TODO etudiant`) — not filled, not solved.
- **C.2 docstring-only exception**: outputs unaffected, no re-exec required.
- **R6 (variety)**: c.740 = security (Lean-10 token), c.741 = text-cleanup CJK (Search/Applications) — distinct genre AND family from prior cycles.
- **Nettoyage cap**: 1 CJK item/lane/jour (R6) — honored (single notebook, single glyph).

See #8428 (CJK fleet), #8052.

Co-Authored-By: Claude <noreply@anthropic.com>
