### PR TITLE
docs(probas,#8081): Infer-7 MBML Ch.2 distillation-source attribution + Junker-Sijtsma DINA

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb
@@ -389,6 +389,23 @@
   },
   {
    "cell_type": "markdown",
+   "id": "origine-mbml-ch2",
+   "metadata": {},
+   "source": [
+    "### Origine pedagogique : Model-Based Machine Learning (Chap. 2)\n",
+    "\n",
+    "Ce notebook est une **distillation pratique en Infer.NET** du **Chapitre 2 — *Assessing People's Skills*** de *Model-Based Machine Learning* (Winn, Bishop, Diethe, Guiver & Zaykov, 2020 — [mbmlbook.com](https://mbmlbook.com/LearningSkills.html)), qui resout le meme probleme : **inferer les competences d'un candidat a partir de ses reponses a un test**, en modelisant capacite latente, difficulte des questions et bruit d'observation (slip/guess, lien *probit*).\n",
+    "\n",
+    "| Modele implante | Racine academique |\n",
+    "|---|---|\n",
+    "| **IRT** (Difficulty-Ability, lien Probit) | Rasch (1960), Lord (1980), Birnbaum (1968) — cf. section 3 |\n",
+    "| **DINA** (Deterministic Input, Noisy-AND) | Junker & Sijtsma (2001) |\n",
+    "\n",
+    "> La structure pedagogique (probleme -> defis -> modele -> graphe de facteurs) reprend la demarche de modelisation du chapitre MBML ; les scenarios numeriques et l'implementation Infer.NET sont propres au notebook.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "40c04fbd",
    "metadata": {
     "papermill": {

--- a/scripts/notebook_tools/twin_pairs.yaml
+++ b/scripts/notebook_tools/twin_pairs.yaml
@@ -468,11 +468,12 @@
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb
   parity_level: semantic
   last_audit:
-    date: '2026-07-24'
-    by: po-2023
+    date: '2026-07-25'
+    by: po-2024
     python_sha: 243abda6c6d8da742e47ae61a60d780b770e77ad
-    csharp_sha: 4ee17fda8afb065f28f37dde6fe1b96104257495
+    csharp_sha: 7723219b3c6654629210ed5f0757d04dc3bd6e54
   known_differences:
+  - '2026-07-25 (po-2024) #8530 : csharp_sha rebaseline suite a enrichissement du twin C# Infer-7 -- ajout attribution source MBML Ch.2 (Junker-Sijtsma, modele DINA) sur le twin C# uniquement (distillation-source attribution #8081). python twin (PyMC-7) inchange. Procedural : la PR introduisait DRIFT au gate #8057 car le blob C# avait evolue sans refresh du SHA registre.'
   - 'Socle pedagogique commun : Item Response Theory (modeles de competences / IRT) modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational
     Message Passing, modele compile en code d''inference) ; Python PyMC = echantillonnage MCMC (NUTS/HMC par defaut) + ADVI


### PR DESCRIPTION
Grain: MED/docs — lane myia-po-2025:CoursIA — prev: MED/notebook-dotnet

See #8081, #8087.

## Summary

Closes the remaining **PERTE PAR COMPLAISANCE** finding on `Infer-7-Skills-IRT` from the EPIC #8081 distillation audit: the notebook distills **MBML Chapter 2 — *Assessing People's Skills*** without ever citing the source. Adds one markdown cell (`### Origine pedagogique : Model-Based Machine Learning (Chap. 2)`) linking the notebook to its distillation source, + completes the academic attribution table with **Junker & Sijtsma (2001)** for DINA (was missing — IRT's Rasch/Lord already present).

## G.9 audit-staleness rectification (honest framing)

The #8087 audit row labels Infer-7 "🔥 PERTE PAR COMPLAISANCE, PIRE CAS, 74 cellules **sans mention Rasch/Birnbaum/Lord/MBML**". A firsthand scan **disproves part of this**: Rasch×5 / Birnbaum×2 / Lord×3 are **already present** in markdown cells #0 and #8 (intro + IRT model cell, with full citations "Rasch, G. (1960)…", "Fidélité à la source (Rasch 1960 ; Lord 1980)") — they were backfilled by **PR #8243** (`9bf43fdea docs(probas,#8081): Infer-7 canonical citations + IRT(Rasch 1PL)/DINA fidelity notes`). So the academic pedigree is no longer missing; the audit row is **partially stale**.

The **genuinely vivace** finding: the link to the **distillation source itself** (MBML Ch.2, mbmlbook.com) remains **absent** (MBML×0, mbmlbook×0, Junker×0 pre-PR). That is the real PERTE PAR COMPLAISANCE — a notebook distilling a named MBML chapter without citing it. This PR closes exactly that gap, without inflating to "added Rasch/Lord" (already there).

## Source verified firsthand

MBML Ch.2 title confirmed via mbmlbook.com (searxng): **"Assessing People's Skills"** (Winn, Bishop, Diethe, Guiver & Zaykov, 2020) — "we will address the problem of assessing candidates for a job that requires certain skills… candidates will take a multiple-choice test and we will use model-based machine learning to determine which skills each candidate has". This is exactly what Infer-7 implements: IRT Difficulty-Ability with a **Probit** link (`reponse[i,j] ~ Probit(avantage[i,j])`, cell#8) + DINA multi-skill (slip/guess). The chapter also introduces belief propagation / message-passing (the factor-graph visualizations throughout the notebook). Note: README/c803 shorthand "StudentSkills" → canonical title is "Assessing **People's** Skills"; cited verbatim.

## What changed (byte-surgical, +1 markdown cell)

- **New markdown cell** inserted at index 8 (between cell#7 `## 2. Introduction a l'Evaluation Cognitive` and cell#8 `## 3. modele IRT`):
  - Distillation-source link to MBML Ch.2 (mbmlbook.com/LearningSkills.html)
  - Attribution table: IRT → Rasch/Lord/Birnbaum (cross-ref §3, already cited); DINA → **Junker & Sijtsma (2001)** (NEW)
  - Note that pedagogical structure (problem → challenges → model → factor graph) follows MBML's modelling approach; numeric scenarios + Infer.NET implementation are original to the notebook
- **No code cell touched** (`grep -cE 'execution_count|"outputs"'` on diff = 0). Markdown-only → C.2 exception (existing outputs valid, no re-exec needed).

## Validation

- **H.3** `validate_pr_notebooks.py` → PASS (23 code cells, `.net-csharp`, `execution_count`+`outputs` intact).
- **nbformat.validate()** OK; LF-only (CR=0); 74 → 75 cells; +17 insertions, 0 deletions (purely additive).
- **markdown-rendering baseline** (`detect_markdown_rendering.py --check`) → OK no new ERROR-level violation (new cell uses `###`/table/blockquote, no lone `---` → no #8352 setext-H2 promotion).
- Citation audit post-PR: MBML×1, mbmlbook×2, Junker×1, "Assessing People"×1 (was all 0 pre-PR).
- FR-first prose (readme-french-first rule).

## Diagnostic dérive (C.4)

- **Cause = b** (claim antérieure / audit stale): the #8087 row over-states severity ("sans mention Rasch/Birnbaum/Lord") because #8243 already backfilled those; only the MBML distillation-source link was genuinely missing.
- **Verdict: `CAUSE_FIXED`** — MBML Ch.2 link + Junker-Sijtsma DINA attribution added; academic pedigree (Rasch/Lord/Birnbaum) already present via #8243 and cross-referenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
