### PR TITLE
docs(probas,#8081): Infer-3 MBML Ch.1 fidelity note + recalibration disclosure

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb
@@ -396,6 +396,8 @@
     "\n",
     "### Contexte (MBML Book, Chapter 1)\n",
     "\n",
+    "> **Fidélité à la source** : Scénario adapté du *Model-Based Machine Learning* (Winn & Bishop), chapitre 1 « A Murder Mystery » ([dotnet/mbmlbook](https://github.com/dotnet/mbmlbook)). La structure itérative (prior → arme → cheveu) et la mécanique bayésienne suivent le livre ; les **probabilités conditionnelles sont recalibrées** par rapport à l’exemple canonique (dans le livre, c’est Grey qui préfère le revolver) afin d’illustrer la compensation exacte des indices (section 6, « retour au prior »).\n",
+    "\n",
     "Un meurtre a ete commis dans un manoir victorien. Deux suspects :\n",
     "\n",
     "| Suspect | Description | Prior de culpabilite |\n",

--- a/scripts/notebook_tools/twin_pairs.yaml
+++ b/scripts/notebook_tools/twin_pairs.yaml
@@ -404,10 +404,10 @@
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb
   parity_level: semantic
   last_audit:
-    date: '2026-07-24'
-    by: po-2023
+    date: '2026-07-25'
+    by: po-2024
     python_sha: 9f0c7a44ffd98bfc97b6ef091ae28fe7d6802541
-    csharp_sha: 620b7fd3b52de649ffb063e27b568cd7520bd6fa
+    csharp_sha: f5158092a1488ec4a9a397bffe0f1ae02835f7c0
   known_differences:
   - 'Socle pedagogique commun : graphes de facteurs et variables aleatoires modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational


### PR DESCRIPTION
Grain: MED/notebook-doc-honesty — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-python-audit-claims (c.872 GT-13)

## Problem

`Infer-3-Factor-Graphs.ipynb` cell[7] opens the "Murder Mystery" scenario with:

> ### Contexte (MBML Book, Chapter 1)

…without disclosing that the **conditional probabilities are recalibrated** vs the canonical MBML example. A reader (or auditor) taking the header at face value expects a faithful MBML Ch.1 port and finds the weapon preference inverted (here Auburn prefers the revolver; in the book it's Grey) — which looks like a bug if the recalibration isn't documented.

The #8088 audit (2026-07-23) reached this verdict but only committed a report file; #8168 then removed that report per `audit-cross-source-distillation` HARD 1 ("un audit produit un verdict, pas un fichier … un finding actionnable devient une issue / le notebook la corrige ensuite en PR"). **The actionable notebook correction was never applied** — no open issue tracked it. This PR is that correction.

## Fix (markdown-only, cell[7])

Insert a fidelity note between the "### Contexte" header and the scenario:

> **Fidélité à la source** : Scénario adapté du *Model-Based Machine Learning* (Winn & Bishop), chapitre 1 « A Murder Mystery » ([dotnet/mbmlbook](https://github.com/dotnet/mbmlbook)). La structure itérative (prior → arme → cheveu) et la mécanique bayésienne suivent le livre ; les **probabilités conditionnelles sont recalibrées** par rapport à l'exemple canonique (dans le livre, c'est Grey qui préfère le revolver) afin d'illustrer la compensation exacte des indices (section 6, « retour au prior »).

Documents three things: (a) source attribution (dotnet/mbmlbook), (b) the iterative prior→arme→cheveu structure inherited from the book, (c) the recalibration disclosure + its pedagogical justification (cell[16] "retour au prior" — the LR product ≈ 1.0 compensation lesson, which requires the inverted preferences).

## Source verified firsthand (G.1, L825)

Read `github.com/dotnet/mbmlbook` `src/1. A Murder Mystery/` firsthand (C# WPF app):
- `Program.cs`: `priors = { Grey = 0.3, Auburn = 0.7 }`; `conditionalsWeapon = { RevolverGivenGrey = 0.9, RevolverGivenAuburn = 0.2, … }`; `conditionalsHair = { HairGivenGrey = 0.5, HairGivenAuburn = 0.05 }`.
- `PriorKnowledgeModel.cs` / `ObservedWeaponModel.cs` / `ObservedHairModel.cs`: the iterative class-inheritance model-building (prior → weapon → hair) that Infer-3 mirrors.

**Confirmed**: MBML has **Grey** preferring the revolver (0.9); Infer-3 cell[12] inverts to **Auburn** (Bernoulli 0.9 If / 0.2 IfNot). Hair: MBML 0.5/0.05 → Infer-3 cell[15] 0.8/0.1. **Recalibration is real, coherent, and intentional** (the inversion is what makes cell[16]'s exact-compensation lesson work). Not a bug — a documentation gap. Verdict: **FIDÈLE + DIVERGENCE POSITIVE** (recalibration enriches rather than regresses), with the PERTE DOCUMENTÉE (missing disclosure) now fixed by this note.

## Scope: C# Infer-3 only (no twin asymmetry)

The Probas-3 pair (`parity_level: semantic`, twin of `PyMC-3-Factor-Graphs.ipynb`) was verified firsthand:
- **Infer-3 (C#)**: 2 suspects (Major Auburn 0.7 / Miss Grey 0.3), Victorian manor, hair+weapon evidence — **the actual MBML Ch.1 scenario**.
- **PyMC-3 (Python twin)**: 3 Cluedo suspects (Scarlet 0.6 / Mustard 0.3 / Peacock 0.1), M. Boddy — **a different scenario, not the MBML port**.

The twins pair on **concept** (factor graphs, discrete inference, explaining away), not scenario. The MBML recalibration note is specific to Infer-3's Auburn/Grey scenario and does **not** apply to PyMC-3's Cluedo scenario. (Separate observation, out of scope here: PyMC-3 cell[0] *claims* "MBML Ch.1" but uses a Cluedo scenario — a potential finding for the PyMC owner to assess firsthand.)

## Verification (firsthand)

- `git diff --stat` = +2/-0 in Infer-3 (2 new markdown source-list elements), +3/-3 in twin_pairs.yaml (SHA + date/by). Surgical.
- Byte-surgical raw-JSON replace (not NotebookEdit — L772/L768: NotebookEdit rewrites whole notebook risking output drift): `occurrences of OLD: 1` (exact unique match), JSON round-trips valid, 53 cells unchanged.
- cell[7] = markdown, 0 outputs (C.2 exception — no re-exec needed, no output touched).
- CRLF = 0 (`*.ipynb text eol=lf` respected).
- **Twin-parity rebaseline (C868-L)**: `csharp_sha` 620b7fd3b → f5158092a in the same commit. Verified post-edit: recorded csharp_sha == working-tree SHA (`git hash-object`) == f5158092a → CI `--per-pair --base origin/main` will see drift_introduced=0. python_sha unchanged (PyMC-3 not touched). YAML parses (92 pairs).
- L898 pre-push: no OPEN PR touches Infer-3 (#8528 is Infer-4, a different notebook; #8088 Infer-3 audit was MERGED and only added a report file, since removed).

## Context

Found by completing the #8088 audit's actionable follow-up (the audit verdict existed, the notebook fix did not). `audit-cross-source-distillation.md`: the audit's job is the verdict; the notebook's job is the correction — this PR is the latter. Not `Closes` (the #8081 epic remains open across many notebooks).

See #8081 (audit epic). See #8088 (the audit that identified this), #8168 (report hygiene).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
