### PR TITLE
feat(guard,#8428): detect_cjk_residue.py — CJK LLM-translation residue regression-guard

### DIFF
--- a/scripts/notebook_tools/README.md
+++ b/scripts/notebook_tools/README.md
@@ -15,7 +15,7 @@ complement. L'inventaire ci-dessous remplace la lecture en aveugle de
 
 | Categorie | Scripts | Role |
 |-----------|---------|------|
-| **Detecteurs anti-regression** | `detect_blank_figures.py`, `detect_fabricated_outputs.py`, `detect_svg_decimal_commas.py`, `detect_svg_empty_display.py`, `detect_ascii_workaround.py`, `detect_accent_stripping.py`, `detect_link_target_regression.py`, `detect_solution_leaks.py` | Flags deterministes par regle C.1 / H.1 / SOTA / #2876 (axe-1 texte + **axe-3 link-targets** triade) / #3801 / #4970 / **#6927** (SVG inline rollout) / **#6891 axe-2 fabrication textuelle** (sibling detector) |
+| **Detecteurs anti-regression** | `detect_blank_figures.py`, `detect_fabricated_outputs.py`, `detect_svg_decimal_commas.py`, `detect_svg_empty_display.py`, `detect_ascii_workaround.py`, `detect_accent_stripping.py`, `detect_link_target_regression.py`, `detect_solution_leaks.py`, `detect_cjk_residue.py` | Flags deterministes par regle C.1 / H.1 / SOTA / #2876 (axe-1 texte + **axe-3 link-targets** triade) / #3801 / #4970 / **#6927** (SVG inline rollout) / **#6891 axe-2 fabrication textuelle** (sibling detector) / **#8428** (CJK LLM-translation residue, regression-guard post-fleet-sweep) |
 | **Validateurs CI** | `validate_pr_notebooks.py`, `check_c2_compliance.py`, `check_notebook_navlinks.py`, `check_plotly_static_risk.py` | Gates pre-merge, `--check` exit-code CI-ready |
 | **Scanners structurels** | `scan_cell_ordering.py`, `scan_md_hierarchy.py`, `scan_figure_visual_signature.py` | Audit hierarchie markdown + ordre cellules pedagogiques + **signature visuelle des figures PNG (consolidation L777-L1/L778-L1/L2/L779-L1/L2/L780-L1/L2/L3/L781-L1/L2/L3 du rollout MANIFEST c.754-c.781, EPIC #5780)** |
 | **Execution kernels** | `dotnet_executor.py`, `exec_dotnet_persist.py`, `exec_single_cell.py`, `batch_reexecute.py`, `wsl_papermill.py` | .NET Interactive + Python Papermill via WSL |
@@ -231,6 +231,27 @@ verifie que les cellules de titre "Exercice" portent un stub
 solution complete. Complementaire a
 [.claude/rules/exercise-example-labeling.md](../../.claude/rules/exercise-example-labeling.md) :
 labeling PAR CONTENU, pas par titre.
+
+### `detect_cjk_residue.py` (#8428)
+
+Regression-guard du defect fleet-wide **#8428** : residus de glyphes CJK
+(mots chinois inseres mid-prose FR/EN pendant la generation/enrichissement LLM —
+`风险管理`, `胜利=1`, `分布式约束优化`, `dataset支撑`). Apres le sweep manuel
+(8 PRs 2026-07-25), ce detecteur veille a ce que le reservoir ne se re-remplisse
+pas silencieusement. Scanne markdown ET code, allowlist documentee pour le CJK
+legitime (demo TTS japonaise multilingue) + le residu gated connu
+(QC-Py-Cloud-03, fix = re-exec QC-Cloud). Conservative : signale tout glyphe CJK
+non explicitement allowliste.
+
+```bash
+python scripts/notebook_tools/detect_cjk_residue.py                    # toute la flotte
+python scripts/notebook_tools/detect_cjk_residue.py NB.ipynb --check   # exit 1 si residu (CI-ready)
+python scripts/notebook_tools/detect_cjk_residue.py --family Probas    # une famille
+```
+
+Baseline c.884 : 937 notebooks, **0 residu inattendu**, 2 allowed (fleet clean
+post-sweep). Le guard n'empeche que la recidive ; la correction d'un nouveau
+residu reste byte-surgical par notebook (cf #8428 fix pattern).
 
 ---
 

--- a/scripts/notebook_tools/detect_cjk_residue.py
+++ b/scripts/notebook_tools/detect_cjk_residue.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Detecte les residus de glyphes CJK (corruption LLM-translation) dans les notebooks.
+
+Pourquoi cet outil existe
+-------------------------
+Le defect fleet-wide #8428 : des mots chinois inseres mid-prose francaise/anglaise
+pendant la generation/enrichissement des notebooks par un LLM (ex `风险管理` risk
+management, `胜利=1` victoire, `分布式约束优化` distributed constraint optimization,
+`dataset支撑`, `arbre de分支`). 8 PRs sur 2026-07-25 (#8430/#8433/#8434/#8437/#8455/
+#8461/#8465/#8523) ont elimine ces residus a la main, un notebook a la fois. Chaque
+defaut est decouvert tardivement, ad-hoc, par le worker qui tombe dessus.
+
+Ce tool formalise la moitie DETECTION : il liste toute cellule (markdown OU code) qui
+contient un glyphe CJK inattendu, pour empecher la classe de defect de RECIDIVER
+(regression-guard). C'est la fermeture naturelle de #8428 : apres le sweep manuel,
+le guard veille que le reservoir ne se re-remplit pas silencieusement.
+
+Il DETECTE, il ne CORRIGE PAS. La correction (remplacer la phrase CJK par le terme
+francais/anglais correct en contexte) est un travail de substance par notebook
+(byte-surgical raw-text replacement, cf #8428 fix pattern). Cet outil guide la
+vigilance en listant les candidats au commit/CI.
+
+Discriminateur (G.1, lecons des faux positifs)
+----------------------------------------------
+Un genuine CJK residue = un glyphe des plages CJK (`　-鿿` unified ideographs
++ symbols, `＀-￯` halfwidth/fullwidth forms) dans un notebook pedagogique
+FR/EN, SANS justification multilingue. Le_detecteur est CONSERVATEUR : il signale
+tout glyphe CJK non explicitement allowlisté.
+
+Filtres faux-positifs (EXCLUS — CJK legitime)
+---------------------------------------------
+- Notebooks multilingues legiTIME : la demo TTS japonaise
+  `GenAI/Audio/02-Advanced/02-8-Expressive-TTS.ipynb` contient volontairement du
+  japonais (`こんにちは！多言語音声合成のデモンストレーションです。`) pour demontrer
+  la synthese multilingue. Allowliste avec raison documentee.
+- Residu gated connu : `QuantConnect/Python/QC-Py-Cloud-03-Risk-Parity.ipynb` porte
+  un residu CJK dans un code-comment dont la correction exige une re-exec via QC
+  Cloud (QuantBook, gated). Allowliste de façon temporaire, documentée comme
+  « known gated residual — fix needs QC-Cloud re-exec », pour ne pas bloquer le CI
+  sur un defect deja connu et tracé. Retirer de l'allowlist des que re-executed.
+
+ALLOWED = dictionnaire {substring de chemin: raison}. Un notebook dont le chemin
+contient une cle de ALLOWED est skip entierement (toutes ses cellules CJK sont
+legitimes/connues). La liste est volontairement courte et documentee : ajouter une
+entree exige de justifier la legitimite du CJK (vraie demo multilingue) ou de
+tracer un gated residual.
+
+Usage
+-----
+    python detect_cjk_residue.py NB.ipynb                 # un notebook
+    python detect_cjk_residue.py --family Probas          # une famille
+    python detect_cjk_residue.py                           # toute la flotte
+    python detect_cjk_residue.py NB.ipynb --json          # sortie machine
+    python detect_cjk_residue.py --check                  # exit 1 si hits (CI-ready)
+
+Exit codes
+----------
+    0 -- aucun residu inattendu detecte (ou mode non --check)
+    1 -- un ou plusieurs residus detectes (--check seulement)
+    2 -- erreur (notebook illisible, famille introuvable)
+
+Voir aussi
+----------
+- `detect_ascii_workaround.py` (#3801) -- pattern de detecteur read-only + filtres FP
+- `detect_accent_stripping.py` (#6806) -- baseline honnete + convention detect_*
+- #8428 -- le defect fleet-wide que ce guard cloture (anti-recidive)
+
+See #8428.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# --- Plages CJK (alignees sur la def #8428) ---
+# 　-〿 : CJK symbols and punctuation
+# ぀-ゟ : Hiragana  (JP TTS demo legitime -> allowlist)
+# ゠-ヿ : Katakana
+# 一-鿿 : CJK unified ideographs (le reservoir principal des residus chinois)
+# ＀-￯ : Halfwidth and Fullwidth forms
+CJK_RE = re.compile(r"[　-〿぀-ゟ゠-ヿ一-鿿＀-￯]")
+
+# --- Allowlist CJK legitime / residu gated connu ---
+# Un notebook dont le chemin (relatif au root) contient une cle est skip.
+# Chaque entree DOIT documenter la raison (demo multilingue legiTIME OU gated residual).
+ALLOWED: dict[str, str] = {
+    "GenAI/Audio/02-Advanced/02-8-Expressive-TTS.ipynb":
+        "demo TTS multilingue legiTIME (japonais volontaire pour la synthese)",
+    "QuantConnect/Python/QC-Py-Cloud-03-Risk-Parity.ipynb":
+        "known gated residual (code-comment) -- fix needs QC-Cloud re-exec; retirer apres re-exec",
+}
+
+
+def _cell_source(cell: dict) -> str:
+    src = cell.get("source", "")
+    if isinstance(src, list):
+        return "".join(src)
+    return src or ""
+
+
+def detect_cell(src: str) -> dict | None:
+    """Return a finding dict if `src` (any cell type) carries unexpected CJK glyphs, else None.
+
+    Returns the count + the distinct glyphs + the first context window, so a human
+    can judge whether it is genuine residue or a new legitimate multilingual case
+    (which should then be added to ALLOWED with a reason).
+    """
+    glyphs = CJK_RE.findall(src)
+    if not glyphs:
+        return None
+    first = CJK_RE.search(src)
+    start = first.start() if first else 0
+    context = src[max(0, start - 30): start + 30].replace("\n", " ")
+    return {
+        "count": len(glyphs),
+        "glyphs": sorted(set(glyphs)),
+        "context": context,
+    }
+
+
+def _is_allowed(rel_path: str) -> str | None:
+    """Return the allow reason if the notebook path matches an ALLOWED entry, else None."""
+    for needle, reason in ALLOWED.items():
+        if needle in rel_path:
+            return reason
+    return None
+
+
+def scan_notebook(path: Path, root: Path) -> dict:
+    """Return a result dict for one notebook: path, allowed, hits[], error."""
+    try:
+        rel = str(path.relative_to(root)).replace("\\", "/")
+    except ValueError:
+        rel = str(path).replace("\\", "/")
+    allowed_reason = _is_allowed(rel)
+    if allowed_reason:
+        return {"path": rel, "allowed": allowed_reason, "hits": [], "error": None}
+    try:
+        with open(path, encoding="utf-8") as f:
+            nb = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        return {"path": rel, "allowed": None, "hits": [], "error": str(exc)}
+    hits = []
+    for ci, cell in enumerate(nb.get("cells", [])):
+        src = _cell_source(cell)
+        finding = detect_cell(src)
+        if finding:
+            hits.append({"cell_index": ci, "cell_type": cell.get("cell_type", "?"), **finding})
+    return {"path": rel, "allowed": None, "hits": hits, "error": None}
+
+
+# Dossiers a ignorer (alignes sur detect_ascii_workaround.py:SKIP_DIRS).
+SKIP_DIRS = {
+    ".lake", ".git", "__pycache__", "_archives", "archive", "_archive",
+    ".ipynb_checkpoints", ".pytest_cache", "worktrees",
+    "foundry-lib",  # lib vendored tierce
+}
+_OUTPUT_SUFFIX = "_output.ipynb"
+
+
+def _should_skip(rel: Path) -> bool:
+    if any(part in SKIP_DIRS for part in rel.parts):
+        return True
+    return rel.name.endswith(_OUTPUT_SUFFIX)
+
+
+def _iter_notebooks(root: Path, family: str | None):
+    base = root / "MyIA.AI.Notebooks"
+    if family:
+        base = base / family
+    if not base.exists():
+        return
+    for nb in sorted(base.rglob("*.ipynb")):
+        try:
+            rel = nb.relative_to(base)
+        except ValueError:
+            continue
+        if _should_skip(rel):
+            continue
+        yield nb
+
+
+def _human_report(results: list[dict]) -> str:
+    scanned = [r for r in results if r["allowed"] is None and r["error"] is None]
+    allowed = [r for r in results if r["allowed"]]
+    errors = [r for r in results if r["error"]]
+    total_hits = sum(len(r["hits"]) for r in scanned)
+    affected = [r for r in scanned if r["hits"]]
+    lines = [
+        f"Notebooks scanned : {len(scanned)}",
+        f"Cells with CJK residue : {total_hits}",
+        f"Affected notebooks : {len(affected)}",
+        f"Allowed (skipped) : {len(allowed)}",
+        "",
+    ]
+    if errors:
+        lines.append(f"Read errors : {len(errors)}")
+        for r in errors:
+            lines.append(f"  - {r['path']}: {r['error']}")
+        lines.append("")
+    if not affected:
+        lines.append("No unexpected CJK residue detected (fleet clean vs #8428).")
+        if allowed:
+            lines.append("")
+            lines.append("Allowed notebooks (CJK legitime / gated residual documente) :")
+            for r in allowed:
+                lines.append(f"  - {r['path']}  -- {r['allowed']}")
+        return "\n".join(lines)
+    for r in affected:
+        short = r["path"].split("MyIA.AI.Notebooks")[-1].lstrip("\\/")
+        lines.append(f"## {short}")
+        for h in r["hits"]:
+            glyphs = "".join(h["glyphs"])
+            ctx = f"  | ...{h['context']}..." if h["context"] else ""
+            lines.append(
+                f"  - cell [{h['cell_index']}] ({h['cell_type']}): "
+                f"{h['count']} glyph(s) [{glyphs}]{ctx}"
+            )
+        lines.append("")
+    lines.append(
+        "NOTE: conservative detector. Verify each hit firsthand -- if a notebook "
+        "carries LEGITIMATE multilingual CJK (demo TTS, language course), add it to "
+        "ALLOWED in detect_cjk_residue.py with a documented reason rather than "
+        "stripping the glyphs."
+    )
+    return "\n".join(lines)
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__.split("\n\n")[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("notebook", nargs="?", help="Notebook to scan (default: all pedagogical)")
+    parser.add_argument("--family", help="Top-level family under MyIA.AI.Notebooks/ (e.g. Probas, ML)")
+    parser.add_argument("--root", default=".", help="Repo root (default: cwd)")
+    parser.add_argument("--json", action="store_true", help="Machine-readable JSON output")
+    parser.add_argument("--check", action="store_true", help="Exit 1 if any unexpected CJK hit (CI-ready)")
+    args = parser.parse_args(argv)
+
+    root = Path(args.root).resolve()
+    if args.notebook:
+        paths = [Path(args.notebook)]
+        if not paths[0].is_absolute():
+            paths[0] = root / paths[0]
+        if not paths[0].exists():
+            print(f"error: notebook not found: {paths[0]}", file=sys.stderr)
+            return 2
+    else:
+        paths = list(_iter_notebooks(root, args.family))
+        if args.family and not paths:
+            print(f"error: family not found: {args.family}", file=sys.stderr)
+            return 2
+
+    results = [scan_notebook(p, root) for p in paths]
+    total_hits = sum(len(r["hits"]) for r in results if r["allowed"] is None)
+
+    if args.json:
+        payload = {
+            "notebooks_scanned": sum(1 for r in results if r["allowed"] is None),
+            "total_hits": total_hits,
+            "results": results,
+        }
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+    else:
+        print(_human_report(results))
+
+    if args.check and total_hits > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/notebook_tools/tests/test_detect_cjk_residue.py
+++ b/scripts/notebook_tools/tests/test_detect_cjk_residue.py
@@ -1,0 +1,177 @@
+"""Tests for scripts/notebook_tools/detect_cjk_residue.py — CJK residue regression guard.
+
+Why this test file exists
+---------------------------------
+`detect_cjk_residue.py` is the regression-guard that closes defect fleet-wide #8428
+(LLM-translation residue: Chinese words inserted mid French/English prose during
+notebook generation/enrichment). After the manual sweep (8 PRs on 2026-07-25:
+#8430/#8433/#8434/#8437/#8455/#8461/#8465/#8523 eliminated every residual), this
+detector watches that the reservoir does not silently refill.
+
+The detection half is formally tested here. Four clusters, mirroring the
+detector's documented contract (docstring):
+
+  1. TestDetectCell      -- CJK glyph detection in markdown + code sources
+  2. TestAllowlist        -- legitimate multilingual demo + known gated residual skipped
+  3. TestScanNotebook     -- end-to-end nb read + allowed short-circuit + hit report
+  4. TestMainExitCodes    -- --check exit contract (0 clean / 1 residue / 2 error)
+
+Test data design: positives use the exact residue phrases from #8428
+(`风险管理`, `胜利=1`, `分布式约束优化`, `dataset支撑`); negatives exercise the
+documented allowlist (Audio TTS JP demo) and clean French/English prose.
+
+The baseline validated c.884 on 937 pedagogical notebooks is **0 unexpected hits**
+(fleet clean post-sweep). These tests pin the contract so a future regression
+(CJK residue re-introduced by an enrichment pass) is caught before commit.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+# Make the sibling detector importable regardless of invocation cwd.
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE.parent))
+
+import detect_cjk_residue as mod  # noqa: E402
+
+
+# ---------- helpers ----------
+def _nb(cells):
+    """Build a minimal nbformat 4 notebook from a list of (cell_type, source_str)."""
+    return {
+        "cells": [
+            {"cell_type": ct, "source": [src] if isinstance(src, str) else src,
+             "metadata": {}, "outputs": [] if ct == "code" else None}
+            for ct, src in cells
+        ],
+        "metadata": {},
+        "nbformat": 4, "nbformat_minor": 5,
+    }
+
+
+def _write_nb(tmp_path: Path, name: str, cells) -> Path:
+    p = tmp_path / name
+    p.write_text(json.dumps(_nb(cells)), encoding="utf-8")
+    return p
+
+
+# ---------- 1. TestDetectCell ----------
+class TestDetectCell:
+    def test_markdown_chinese_phrase_detected(self):
+        finding = mod.detect_cell("La 风险管理 est un concept cle (risk management).")
+        assert finding is not None
+        assert finding["count"] >= 4  # 风险管理 = 4 glyphs
+        assert "风" in finding["glyphs"]
+
+    def test_code_comment_victory_residue(self):
+        # App-12 #8523 canonical residue: 胜利=1
+        finding = mod.detect_cell("int utility() { return 胜利=1; } //胜利")
+        assert finding is not None
+        assert "胜" in finding["glyphs"]
+        # return 胜利=1 (2) + //胜利 comment (2) = 4 glyph occurrences; 2 distinct.
+        assert finding["count"] == 4
+        # sorted by codepoint: 利 (U+5229) < 胜 (U+80DC)
+        assert finding["glyphs"] == ["利", "胜"]
+
+    def test_fullwidth_form_detected(self):
+        finding = mod.detect_cell("largeur：50")  # fullwidth colon ＀-￯ range
+        assert finding is not None
+
+    def test_clean_french_prose_no_hit(self):
+        assert mod.detect_cell("L'optimisation de contraintes distribuées.") is None
+
+    def test_clean_english_prose_no_hit(self):
+        assert mod.detect_cell("Distributed constraint optimization.") is None
+
+    def test_context_window_returned(self):
+        finding = mod.detect_cell("prefix texte 分布式约束优化 suffix")
+        assert finding is not None
+        assert "prefix" in finding["context"]
+        assert "suffix" in finding["context"]
+
+    def test_empty_source_no_hit(self):
+        assert mod.detect_cell("") is None
+        assert mod.detect_cell("   \n  ") is None
+
+
+# ---------- 2. TestAllowlist ----------
+class TestAllowlist:
+    def test_audio_tts_demo_allowed(self):
+        reason = mod._is_allowed("MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-8-Expressive-TTS.ipynb")
+        assert reason is not None
+        assert "TTS" in reason or "multilingue" in reason
+
+    def test_qc_cloud_gated_residual_allowed(self):
+        reason = mod._is_allowed("MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-03-Risk-Parity.ipynb")
+        assert reason is not None
+        assert "gated" in reason.lower()
+
+    def test_random_notebook_not_allowed(self):
+        assert mod._is_allowed("MyIA.AI.Notebooks/ML/Some-Notebook.ipynb") is None
+
+
+# ---------- 3. TestScanNotebook ----------
+class TestScanNotebook:
+    def test_scan_finds_cjk_in_markdown_cell(self, tmp_path):
+        p = _write_nb(tmp_path, "NB.ipynb", [
+            ("markdown", "# Titre\n\nProse avec 分布式约束优化 residu."),
+            ("code", "x = 1"),
+        ])
+        r = mod.scan_notebook(p, tmp_path)
+        assert r["allowed"] is None
+        assert len(r["hits"]) == 1
+        assert r["hits"][0]["cell_index"] == 0
+        assert r["hits"][0]["cell_type"] == "markdown"
+
+    def test_scan_finds_cjk_in_code_cell(self, tmp_path):
+        p = _write_nb(tmp_path, "NB.ipynb", [
+            ("markdown", "# Clean"),
+            ("code", "def f(): return 胜利  # dataset支撑"),
+        ])
+        r = mod.scan_notebook(p, tmp_path)
+        assert len(r["hits"]) == 1
+        assert r["hits"][0]["cell_type"] == "code"
+
+    def test_scan_allowed_notebook_skipped_zero_hits(self, tmp_path):
+        # Notebook whose path matches the Audio TTS allowlist entry carries CJK
+        # but is skipped (legitimate multilingual demo).
+        tts_dir = tmp_path / "GenAI" / "Audio" / "02-Advanced"
+        tts_dir.mkdir(parents=True)
+        p = tts_dir / "02-8-Expressive-TTS.ipynb"
+        p.write_text(json.dumps(_nb([("code", "print('こんにちは！多言語音声合成')")])), encoding="utf-8")
+        r = mod.scan_notebook(p, tmp_path)
+        assert r["allowed"] is not None
+        assert r["hits"] == []
+
+    def test_scan_clean_notebook_zero_hits(self, tmp_path):
+        p = _write_nb(tmp_path, "NB.ipynb", [("markdown", "# Propre"), ("code", "x = 1")])
+        r = mod.scan_notebook(p, tmp_path)
+        assert r["hits"] == []
+        assert r["allowed"] is None
+
+
+# ---------- 4. TestMainExitCodes ----------
+class TestMainExitCodes:
+    def test_check_clean_notebook_exits_0(self, tmp_path, capsys):
+        p = _write_nb(tmp_path, "Clean.ipynb", [("markdown", "# Sans CJK")])
+        rc = mod.main(["--root", str(tmp_path), str(p), "--check"])
+        assert rc == 0
+
+    def test_check_residue_notebook_exits_1(self, tmp_path, capsys):
+        p = _write_nb(tmp_path, "Dirty.ipynb", [("markdown", "# Avec 风险管理 residu")])
+        rc = mod.main(["--root", str(tmp_path), str(p), "--check"])
+        assert rc == 1
+
+    def test_missing_notebook_exits_2(self, tmp_path):
+        rc = mod.main(["--root", str(tmp_path), str(tmp_path / "nope.ipynb")])
+        assert rc == 2
+
+    def test_json_output_structure(self, tmp_path, capsys):
+        p = _write_nb(tmp_path, "Dirty.ipynb", [("code", "x = 胜利")])
+        rc = mod.main(["--root", str(tmp_path), str(p), "--json"])
+        out = json.loads(capsys.readouterr().out)
+        assert out["total_hits"] == 1
+        assert out["notebooks_scanned"] == 1
+        assert rc == 0  # --json without --check does not fail


### PR DESCRIPTION
Grain: MED/test — lane myia-po-2025:CoursIA — prev: MED/notebook-dotnet (#8530 Infer-7 MBML attribution)

See #8428.

## Summary

Adds `detect_cjk_residue.py` — the **regression-guard** that closes defect fleet-wide **#8428** (LLM-translation residue: Chinese words inserted mid French/English prose during notebook generation/enrichment). After the manual sweep (8 PRs on 2026-07-25: #8430/#8433/#8434/#8437/#8455/#8461/#8465/#8523 eliminated every residual), this detector watches that the reservoir does not silently refill. **Firsthand baseline: 937 notebooks scanned, 0 unexpected CJK residue, 2 allowlisted** (fleet clean post-sweep).

This is the natural closure of #8428 — a defect class that recurred 8× in one day is worth a deterministic guard, not just ad-hoc fixes.

## G.9 closeable finding (firsthand-verified)

The #8428 inventory is **fully stale**: my firsthand scan of `MyIA.AI.Notebooks/**` finds **0 CJK glyphs remaining** (excluding the legitimate JP TTS demo + the 1 gated QC-Cloud code-comment). All 8 inventory families were fixed by the 8 PRs above. **#8428 is CLOSEABLE** by ai-01 (workers don't close others' issues). This PR delivers the regression-guard so the close is durable (the defect cannot silently return).

## What changed (3 files, additive)

1. **`scripts/notebook_tools/detect_cjk_residue.py`** (new, ~270 lines) — follows the `detect_ascii_workaround.py` convention (module docstring with discriminator + FP filters + usage + exit codes; `detect_cell` → `scan_notebook` → `_iter_notebooks` → `_human_report` → `main`). Scans **markdown AND code** cells for CJK glyphs `[　-鿿＀-￯]` (the #8428 range). CLI: `notebook` | `--family` | `--root` | `--json` | `--check` (exit 1 on residue). Allowlist with documented reasons:
   - `GenAI/Audio/02-Advanced/02-8-Expressive-TTS.ipynb` — legitimate multilingual JP demo (`こんにちは！多言語音声合成…`)
   - `QuantConnect/Python/QC-Py-Cloud-03-Risk-Parity.ipynb` — known gated residual (code-comment; fix needs QC-Cloud re-exec; remove from allowlist once re-executed)
2. **`scripts/notebook_tools/tests/test_detect_cjk_residue.py`** (new, 18 tests) — 4 clusters mirroring the detector contract: `TestDetectCell` (positives use exact #8428 phrases `风险管理`/`胜利=1`/`分布式约束优化`/`dataset支撑` + clean FR/EN negatives), `TestAllowlist`, `TestScanNotebook`, `TestMainExitCodes` (0 clean / 1 residue / 2 error). **18/18 pass.**
3. **`scripts/notebook_tools/README.md`** — adds the detector to the "Detecteurs anti-regression" row + a dedicated `### detect_cjk_residue.py (#8428)` section with baseline + usage.

## Validation

- **Detector on full fleet**: `detect_cjk_residue.py` → 937 scanned, **0 residue**, 2 allowed; `--check` exit 0 (clean).
- **Tests**: `pytest test_detect_cjk_residue.py` → **18 passed**.
- **Regression**: full `scripts/notebook_tools/tests/` suite → **3357 passed, 0 failed** (no existing detector broken).
- **Read-only**: the tool touches no notebooks; purely additive (new file + test + README row).

## Design notes (honest)

- **Conservative**: reports any CJK glyph not explicitly allowlisted (precision over recall — every hit is genuine residue until proven otherwise). A new legitimate multilingual notebook should be added to `ALLOWED` with a reason, not stripped.
- **Markdown + code**: #8428 residue appeared in BOTH (markdown phrases `风险管理`/`分布式约束优化` AND code comments `胜利=1`/`dataset支撑`), so both cell types are scanned.
- **CI-wiring deferred**: this PR delivers the tool + test + baseline. Wiring into `.pre-commit-config.yaml` / CI is a separate one-line follow-up (kept out of scope to keep this PR atomic + avoid a CI break if the tool had a bug — the test suite + fleet baseline prove it correct first).

## Scope note

Genre pivot from `notebook-dotnet` (prev #8530) to `test`/`guard` (variation-protocol G-VAR-3 satisfied). CPU, no-vision, no collision. The pool of non-gated MED/DEEP substance was genuinely thin this cycle (firsthand-verified: #8054 closeable, #7422 actively curated, #8428-Python drained, exercise-convention satisfied) — this regression-guard is the highest-value remaining grain: durable closure of a recurring defect class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
