### PR TITLE
docs(genai-image,#8474): disclose DALL-E 3 -> gpt-image-1 fallback (doc-honesty #8052)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-1-OpenAI-DALL-E-3.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-1-OpenAI-DALL-E-3.ipynb
@@ -382,6 +382,37 @@
   },
   {
    "cell_type": "markdown",
+   "id": "dalle3-gpt-image1-disclosure",
+   "metadata": {},
+   "source": [
+    "### Sur le modèle réellement utilisé : DALL-E 3 -> gpt-image-1\n",
+    "\n",
+    "> **Note d'honnêteté documentaire (EPIC #8052).** La cellule précédente vérifie la\n",
+    "> disponibilité de DALL-E 3 auprès de l'API OpenAI. Le résultat commité montre\n",
+    "> `Connexion API OpenAI reussie - 0 modeles DALL-E disponibles`, puis une\n",
+    "> **repli (fallback) automatique** vers `gpt-image-1` — le modèle de génération\n",
+    "> d'images actuel d'OpenAI. Les sorties commitées dans ce notebook (durée de\n",
+    "> génération, image encodée en data-URI) ont donc été produites par **gpt-image-1**,\n",
+    "> et non par DALL-E 3.\n",
+    "\n",
+    "Pourquoi garde-t-on le cadrage « DALL-E 3 » dans le titre et les commentaires ?\n",
+    "\n",
+    "- **Ancrage pédagogique** : DALL-E 3 est le nom historiquement enseigné pour cette\n",
+    "  famille de modèles de génération d'images ; le conserver comme fil conducteur\n",
+    "  facilite la lecture.\n",
+    "- **L'API est identique** : l'endpoint `/v1/images/generations` et les paramètres\n",
+    "  (`size`, `quality`, `style`) sont communs, seul le nom du modèle change.\n",
+    "- **Transparence** : la présente note explicite le repli afin que la prose ne\n",
+    "**contredise pas** silencieusement les sorties commitées (principe doc-honesty de\n",
+    "  l'Epic #8052).\n",
+    "\n",
+    "Si DALL-E 3 redevient disponible (ou pour basculer sur un autre modèle), il suffit\n",
+    "d'ajuster la sélection du modèle dans la cellule de configuration puis de ré-exécuter ;\n",
+    "la structure du notebook reste valable.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "dwxu8jge49o",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
Grain: MED/docs — lane myia-po-2025:CoursIA — prev: MED/test (#8536 CJK guard)

See #8474, #8052.

## Summary

Closes the **doc-honesty defect** on `01-1-OpenAI-DALL-E-3.ipynb` (EPIC #8052): the notebook's markdown framed the demo as **DALL-E 3** throughout, but the **committed code-cell outputs were produced by `gpt-image-1`** (DALL-E 3 was unavailable at commit time) — and the markdown **never disclosed this**. Adds one markdown cell (`### Sur le modèle réellement utilisé : DALL-E 3 -> gpt-image-1`) right after the API-check code cell whose output reveals the fallback, so the prose no longer silently contradicts the committed outputs.

## G.9 reappraisal — my own prior "GATED" verdict was too conservative

Last cycle (c.883, dashboard line 509) I classified #8474 as **"GATED, décision user"**, grouping it with sibling #8274 (gpt-5-mini video, RECOVERABLE-USER-HAND). A fresh firsthand re-read shows that conflation was **incorrect**:

- **#8274 (video)**: the notebook **ERRORS OUT** (gpt-5-mini 404) — it genuinely needs a **model decision** (which VL model to use) → RECOVERABLE-USER-HAND. Correctly gated.
- **#8474 (image)**: the notebook **WORKS** — it already generates successfully via `gpt-image-1` (committed image exists, `✅ Image générée avec succès!`, 18.99s). The model "decision" was **already made at commit time** (fall back to gpt-image-1). The ONLY remaining defect is that the **markdown doesn't disclose** this → a doc-honesty gap, not a model decision.

So the minimal honest fix is **disclosure** (worker-doable, markdown-only), NOT a model switch. This PR does exactly that. If the user later decides to re-run with a different model, that's a separate action — this disclosure remains accurate (or is adjusted then). **Non-destructive.**

## Firsthand evidence (read-only origin/main, fresh worktree 5b22325bf)

The API-check code cell (cell#6) committed output:
```
Connexion API OpenAI reussie - 0 modeles DALL-E disponibles
Modele selectionne: gpt-image-1
Resolution: 1024x1024
```
The generation code cell (cell#14) committed output:
```
✅ Image générée avec succès!  ⏱️ 18.99s  🔗 Source: image b64 (data-URI, gpt-image-1)
```
Yet markdown said "DALL-E 3" throughout with **0 mentions of `gpt-image-1`** (title, objectives, technologies, cell#5 "verifie que le modèle DALL-E 3 est accessible", cell#7 "fonction d'appel a l'API DALL-E 3", function `generate_dalle3_image`).

## What changed (byte-surgical, +1 markdown cell)

- **New markdown cell** inserted at index 7 (between the API-check code cell#6 whose output reveals the fallback, and the "### Fonction de generation" cell). Discloses:
  - the API check found 0 DALL-E models → automatic fallback to gpt-image-1;
  - committed outputs are gpt-image-1, not DALL-E 3;
  - why the "DALL-E 3" framing is retained (pedagogical anchor + identical API/endpoint/params);
  - how to switch if DALL-E 3 returns.
- **No code cell touched** (`grep -cE 'execution_count|"outputs"'` on diff = 0). **No relabel** of title/function (non-destructive). Markdown-only → C.2 exception (existing outputs valid, no re-exec needed).

## Validation

- **H.3** `validate_pr_notebooks.py` → PASS (12 code cells, `execution_count`+`outputs` intact).
- **nbformat.validate()** OK; LF-only (CR=0); 25 → 26 cells; +31 insertions, 0 deletions (purely additive).
- **markdown-rendering baseline** (`detect_markdown_rendering.py --check`) → OK no new ERROR-level violation (uses `###`/`>`/`-`, no lone `---` → no #8352 setext promotion).
- FR-first prose (readme-french-first rule).

## Scope note

Genre pivot from `test` (#8536 CJK guard) to `docs` (variation-protocol G-VAR-3 satisfied). CPU, no-vision (text disclosure, not image-render verification), no collision (no open PR on #8474). This is the #8052 doc-honesty axis (markdown ↔ committed-output consistency), NOT the model-decision axis — deliberately scoped to the minimal honest correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
