### PR TITLE
fix(lean-12,#8052): align Sensitivity line-counts to sensitivity_lean repo (MainTheorem 131→135, total 487→491, cell#0 521→491)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-12-Sensitivity-Theorem.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-12-Sensitivity-Theorem.ipynb
@@ -30,7 +30,7 @@
     "1. L'intuition combinatoire (hypercube, fonctions booleennes, sensibilite)\n",
     "2. La conjecture (1992-2019) et pourquoi elle a resiste\n",
     "3. L'idee de la preuve de Huang (signing matrix + Cauchy interlacing)\n",
-    "4. Le port Lean 4 du theoreme (521 lignes, 0 sorry)\n",
+    "4. Le port Lean 4 du theoreme (491 lignes, 0 sorry)\n",
     "5. Verification `lake build`\n",
     "6. Pont avec Lean-11 TorchLean et les reseaux de neurones binarises\n",
     "7. Pour aller plus loin\n",
@@ -824,7 +824,7 @@
     "    |-- Hypercube.lean             (124 lignes)  -- Q n, adjacent\n",
     "    |-- VectorSpace.lean           (132 lignes)  -- V n, e, epsilon, duality\n",
     "    |-- Operator.lean              (100 lignes)  -- f, g, f_squared\n",
-    "    |-- MainTheorem.lean           (131 lignes)  -- huang_degree_theorem\n",
+    "    |-- MainTheorem.lean           (135 lignes)  -- huang_degree_theorem\n",
     "```\n",
     "\n",
     "**Graphe de dépendance** :\n",
@@ -832,7 +832,7 @@
     "Hypercube.lean --> VectorSpace.lean --> Operator.lean --> MainTheorem.lean\n",
     "```\n",
     "\n",
-    "**Total** : 4 fichiers, 487 lignes de code Lean, **0 sorry**."
+    "**Total** : 4 fichiers, 491 lignes de code Lean, **0 sorry**."
    ]
   },
   {
@@ -983,7 +983,7 @@
     "tags": []
    },
    "source": [
-    "### MainTheorem.lean (131 lignes)\n",
+    "### MainTheorem.lean (135 lignes)\n",
     "\n",
     "Le résultat principal du port :\n",
     "\n",
@@ -1245,9 +1245,9 @@
     "|----------|-----------------|---------------|\n",
     "| `lake build` exit code | 0 | Compilation sans erreur |\n",
     "| Nombre de `sorry` | 0 | Aucun axiome implicite, preuves completes |\n",
-    "| Lignes de code | 487 | Projet compact et lisible |\n",
+    "| Lignes de code | 491 | Projet compact et lisible |\n",
     "\n",
-    "Le port `sensitivity_lean/` contient 487 lignes de Lean 4 avec 0 `sorry` (verifie G.1 firsthand via `wc -l` + `grep -c sorry`). La commande `lake build` doit etre executee manuellement pour confirmer la compilation complete (le `tail -10` pipe peut masquer des erreurs upstream ; un re-exec avec `set -o pipefail` est recommande).\n",
+    "Le port `sensitivity_lean/` contient 491 lignes de Lean 4 avec 0 `sorry` (verifie G.1 firsthand via `wc -l` + `grep -c sorry`). La commande `lake build` doit etre executee manuellement pour confirmer la compilation complete (le `tail -10` pipe peut masquer des erreurs upstream ; un re-exec avec `set -o pipefail` est recommande).\n",
     "\n",
     "> **Note** : la première compilation peut prendre plusieurs minutes car Mathlib doit etre compile. Les exécutions subsequentes utilisent le cache Lake et sont quasi-instantannees."
    ]


### PR DESCRIPTION
## Summary

`Lean-12-Sensitivity-Theorem.ipynb` claims line-counts for the `sensitivity_lean/` port that contradict the actual `.lean` files on `origin/main`. Markdown-only realignment to the code truth (#8364 case A: code grew, prose lagged).

## Ground truth (verified firsthand, `git show origin/main:... | wc -l`)

| File | Claimed | Actual | Status |
|------|---------|--------|--------|
| `Hypercube.lean` | 124 | 124 | OK |
| `VectorSpace.lean` | 132 | 132 | OK |
| `Operator.lean` | 100 | 100 | OK |
| `MainTheorem.lean` | **131** | **135** | DRIFT (+4) |
| **4-module total** | **487** | **491** | DRIFT |

`MainTheorem.lean` grew 131→135 via the rc2→rc1 Mathlib convergence (#4931, 2026-07-02). The describing notebook's prose was never re-read after that.

## Why cell[0] "521" is also wrong

`521` never matched any real count. Verified at the pre-convergence commit `006de1043` (2026-05-15): 4-module total was **487**, +root `Sensitivity.lean` (16 then, 19 now) = 503/510. No combination yields 521 — it is simply a stale headline figure, inconsistent with the notebook's own detailed breakdown (cell[16] "4 fichiers, 487 lignes"). Corrected to 491 to match the verified 4-module total.

## Changes (6 byte-surgical markdown edits, cells 0/16/20/25)

- cell[0] headline `(521 lignes, 0 sorry)` → `(491 lignes, 0 sorry)`
- cell[16] tree `MainTheorem.lean (131 lignes)` → `(135 lignes)`
- cell[16] total `4 fichiers, 487 lignes` → `491`
- cell[20] header `MainTheorem.lean (131 lignes)` → `(135 lignes)`
- cell[25] table `| Lignes de code | 487 |` → `491`
- cell[25] prose `contient 487 lignes` → `491`

## Verification

- **C.2**: markdown-only edit → outputs precedent valid, no re-exec. Code/outputs byte-identical (diff = 6 ins / 6 del, no JSON churn).
- **Anti-regression**: `sorry` count on `MainTheorem.lean` = 0 (no proof weakened).
- **G.1**: counts re-verified firsthand against `origin/main`, not from memory.
- **#8364 case A**: code = truth; markdown realigned to legitimate rc1-convergence growth (not consecrating a broken run).

## Non-duplication (collision guard)

- #8417 (merged) touched this notebook but **only** the `set -o pipefail` lake-build command + cell[25] pipefail wording — its own diff still shows `contient 487 lignes`.
- #7942 (merged) fixed `MainTheorem 131→135` in the **lake README** Modules table only, not the notebook.
- No prior PR touched the notebook's line-count claims (521/487/131 all still present pre-PR).

## Reference note

Earlier Lean-prose-drift PRs (#8417, #8443, #8529, #8538) cited `See #8053`, but #8053 is a **closed CI exercise-solution-detection** issue — unrelated. This PR cites `See #8052` (the OPEN claims↔outputs EPIC), which is the correct umbrella for "markdown claim contradicts repo/code truth". Flagging for ai-01 in case the prior PRs' references should be corrected.

See #8052
