### PR TITLE
fix(lean-16b,#8052): align Life-modules counts to conway_lean (26→31 defs, ~525→~583 lignes)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-16b-Conway-Game-of-Life-Lean.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-16b-Conway-Game-of-Life-Lean.ipynb
@@ -1972,7 +1972,7 @@
    "source": [
     "### Interpretation : statut Phase 1 + Phase 2\n",
     "\n",
-    "Les 3 modules Life sont compacts (~525 lignes, 17 theoremes, 26 definitions) mais couvrent **toutes les briques fondamentales** du Game of Life :\n",
+    "Les 3 modules Life sont compacts (~583 lignes, 17 theoremes, 31 definitions) mais couvrent **toutes les briques fondamentales** du Game of Life :\n",
     "\n",
     "| Module | Theoremes | Patterns |\n",
     "|--------|-----------|----------|\n",


### PR DESCRIPTION
Grain: MED/forensic (claims↔outputs structural drift — conway_lean Life modules grew, prose lagged)

## Summary

**Fix `Lean-16b-Conway-Game-of-Life-Lean` cell[36] structural counts to match the actual `conway_lean` Conway/Life modules on origin/main** (claims↔outputs doc-honesty, #8364 case-A: code=vérité, prose lagged growth). The 3 Life modules grew (more `def` declarations + lines) since the notebook was written; the prose headline drifted.

`See #8052` (partial — claims↔outputs EPIC). Same genre as #8538 (grothendieck_lean 23→32 modules) and #8544 (Lean-12 line-count drift), both delivered this window by po-2024.

## Firsthand verification (origin/main `172e2aaa6`)

The notebook's cell[36] headline claimed the 3 Life modules are "~525 lignes, 17 theoremes, 26 definitions". Verified against `Conway/Life.lean` + `Conway/Life/Spaceships.lean` + `Conway/Life/Oscillators.lean` (read via `git show origin/main:<path>`):

| Module | lignes (wc -l) | `theorem` | `def` |
|--------|---------------|-----------|-------|
| `Conway/Life.lean` | 233 | 8 | 21 |
| `Conway/Life/Spaceships.lean` | 139 | 3 | 3 |
| `Conway/Life/Oscillators.lean` | 211 | 7 | 7 |
| **TOTAL** | **583** | **18** | **31** |

- **Lignes: ~525 → ~583** (drift +58, +11%). 583 = 233+139+211.
- **Définitions: 26 → 31** (drift +5, +19%). 31 `def` declarations total (helpers like `lexLt`/`mooreNeighbors`/`step`/`isSpaceship` + pattern defs `block`/`beehive`/`blinker_h`/`glider`/`lwss`/`pulsar`/`pentadecathlon`/...).

## What I did NOT touch (verified CORRECT, anti-régression)

The **theorem count stays "17"** — deliberately. Although the modules declare 18 `theorem`s total, one is the helper `mem_sortDedup` (a sort/dedup lemma, not a Game-of-Life pattern). The 17 **pattern theorems** = 7 (Life: block/beehive/blinker×2/toad/beacon/glider) + 3 (Spaceships: LWSS/MWSS/HWSS) + 7 (Oscillators: loaf/boat/tub/pond/ship/pulsar/pentadecathlon) = 17, matching cell[34]/[36]/[49] and the per-module table. So the theorem claim is accurate; changing it would be wrong.

`sorry` = 0 on all 3 Life modules (verified), consistent with cell[36]'s "**sorry = 0** sur les 3 modules" — untouched, correct.

## Edit

Single-line byte-surgical markdown edit (raw `str.replace`, LF preserved, no NotebookEdit/json.dump churn — memory c.720):

```
- Les 3 modules Life sont compacts (~525 lignes, 17 theoremes, 26 definitions) ...
+ Les 3 modules Life sont compacts (~583 lignes, 17 theoremes, 31 definitions) ...
```

## Verification

- `git diff --stat`: `+1 / -1`, single line, single file (`Lean-16b-Conway-Game-of-Life-Lean.ipynb`).
- JSON valid post-edit (`json.loads`); 0 CRLF introduced (file is LF-only, 2868 bare LF — preserved).
- Markdown-only cell (`cell[36]`, `execution_count: null`, no outputs) → C.2-exempt, H.3 N/A (no re-exec needed for a markdown prose correction).
- sorry=0 on the 3 Life modules confirmed (no anti-régression — only prose corrected, 0 Lean source touched).
- Theorem count deliberately unchanged (17 pattern theorems verified correct).

## Compliance

- **catalog-pr-hygiene**: catalogue untouched; `See #8052` (partial EPIC); branch fresh from `origin/main` (0 behind).
- **#8364 case-A**: code=vérité, prose lagged the rc1/Phase-2 growth of conway_lean Life modules. Cause = the modules grew +5 defs / +58 lines; the fix re-aligns prose to the current code, no fabrication.
- **R6 (variety)**: doc-honesty structural-drift genre (distinct from c.740 Lean-security fix, c.743 Lean-EP-investigation). SemanticWeb Python audit (12 NB, all CLEAN) + GameTheory audit (3 NB, CLEAN) done this window in fresh families — this Lean drift is the remaining reliable yield after twin-register drained (c.745) and Lean DEEP #2159 assessed not cron-tractable (c.746).
- **One subject per PR**: single notebook, single line, single file, atomique.

See #8052. — po-2026

Co-Authored-By: Claude <noreply@anthropic.com>
