### PR TITLE
fix(twin-registry,#8542): harden integrity tests for merge-union interlacing (Option B)

### DIFF
--- a/scripts/notebook_tools/tests/test_twin_registry_integrity.py
+++ b/scripts/notebook_tools/tests/test_twin_registry_integrity.py
@@ -25,7 +25,19 @@ yaml = pytest.importorskip("yaml")
 
 REGISTRY = Path(__file__).resolve().parents[1] / "twin_pairs.yaml"
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+# Cle minimale qu'une entree doit posseder (sous-ensemble). Un merge union mal
+# tombe peut aussi INJECTER des cles etrangeres (interlacement ligne a ligne) :
+# ALLOWED_KEYS (ensemble exact) couvre ce second mode (cf test ci-dessous, #8542).
 REQUIRED_KEYS = {"name", "family", "python", "csharp", "parity_level", "last_audit"}
+ALLOWED_KEYS = {
+    "name", "family", "python", "csharp", "parity_level",
+    "last_audit", "known_differences",
+}
+# Plancher d'entrees (2026-07-25, 98 paires sur origin/main). Un merge union qui
+# detruit/absorbe silencieusement une entree (interlacement) fait chuter le
+# compte sous ce plancher -> echec CI bruyant. A LEVER au fur et a mesure que le
+# registre grossit (jamais baisser sans investiguer une perte silencieuse, #8542).
+MIN_ENTRIES = 98
 
 
 def _entries() -> list:
@@ -119,3 +131,40 @@ def test_registered_notebooks_exist_on_disk():
         if p and not (repo_root / p).exists()
     ]
     assert not missing, f"notebooks introuvables : {missing}"
+
+
+def test_entries_have_exact_key_set():
+    """Mode de defaillance n3 du merge union (#8542, Constat 2) : l'interlacement
+    ligne a ligne peut INJECTER des cles etrangeres dans une entree (les champs
+    d'une paire appendee se retrouvent meles au bloc d'une autre). Le YAML peut
+    encore parser, les cles requises peuvent encore etre presentes, aucune cle
+    n'est dupliquee -- mais la structure est corrompue. Cet assert verifie que
+    chaque entree possede EXACTEMENT l'ensemble de cles canonique (ni plus, ni
+    moins), ce qu'aucun des tests precedents ne couvrait.
+    """
+    bad = []
+    for entry in _entries():
+        keys = set(entry.keys())
+        extra = keys - ALLOWED_KEYS
+        missing = REQUIRED_KEYS - keys
+        if extra or missing:
+            name = entry.get("name", "?")
+            if extra:
+                bad.append(f"{name} -> cles inattendues: {sorted(extra)}")
+            if missing:
+                bad.append(f"{name} -> cles manquantes: {sorted(missing)}")
+    assert not bad, "entrees au schema corrompu (interlacement merge union ?) : " + "; ".join(bad)
+
+
+def test_entry_count_floor():
+    """Mode de defaillance n4 du merge union (#8542, Constat 2) : l'interlacement
+    peut FUSIONNER ou ABSORBER silencieusement une entree entiere dans le bloc
+    d'une autre, faisant chuter le compte total sans declencher d'erreur de parse
+    ni de cle dupliquee. Le plancher MIN_ENTRIES (leve periodiquement a mesure que
+    le registre grossit) transforme cette perte silencieuse en echec CI bruyant.
+    """
+    n = len(_entries())
+    assert n >= MIN_ENTRIES, (
+        f"le registre a perdu des entrees : {n} < {MIN_ENTRIES} "
+        f"(interlacement merge union ou suppression accidentee ? cf #8542)"
+    )


### PR DESCRIPTION
Grain: MED/tooling (twin-registry integrity hardening — Option B of #8542)

## Summary

**Harden `test_twin_registry_integrity.py` to catch the silent-corruption failure mode of the `merge=union` driver on `twin_pairs.yaml` (#8542, Constat 2).** The `union` driver concatenates line-by-line with no notion of YAML entry boundaries, so an unlucky 3-way merge can **interlace** one pair's fields into another's block — producing YAML that still parses, still has the required keys, and has no duplicate key, yet is structurally corrupt. The existing 7 tests did not cover this; this PR adds 2 that turn it into a loud CI failure (ai-01's stated Option B: "étendre `test_twin_registry_integrity.py` à un `yaml.safe_load` + comptage d'entrées").

`See #8542` (partial — Option B delivered; the A/C decision and driver-strategy question remain for ai-01 to close out).

## Firsthand verification (worktree at origin/main `2caf88d86`, 0 behind)

- **Baseline**: existing 7 tests PASS.
- **Registry shape**: 98 entries, and **every entry shares the exact same 7-key set** `{name, family, python, csharp, parity_level, last_audit, known_differences}` (uniform → a robust exact-key-set guard is possible, no per-entry variance to accommodate).
- **CI wiring confirmed**: these tests ALREADY run in CI via `scripts-tests.yml`, triggered on `scripts/**` path changes (which includes both the test file and `twin_pairs.yaml`). So the extended tests will fail CI on real corruption — ai-01's "échec CI bruyant" goal is met without touching any workflow.

## What I added

```python
ALLOWED_KEYS = {  # exact canonical key set (every entry has exactly these)
    "name", "family", "python", "csharp", "parity_level",
    "last_audit", "known_differences",
}
MIN_ENTRIES = 98  # floor (2026-07-25); raise as the registry grows, never lower
```

1. **`test_entries_have_exact_key_set`** — every entry has EXACTLY the 7 allowed keys (catches interlacing that **injects stray keys** into an entry). This is the failure mode `test_required_keys_present` (subset check) and `test_no_duplicate_keys_anywhere` cannot catch: extra foreign keys from line-interlacing, with no duplicate and all required keys still present.
2. **`test_entry_count_floor`** — `len(_entries()) >= 98` (catches interlacing that **absorbs/destroys** an entire entry, dropping the count). Floor-style: robust to legitimate growth (my open #8539 tranche brings it to 117, still `>= 98`), fails only on silent loss.

## Regression proof (the guards actually fire)

Both new tests verified to FAIL on simulated corruption, then the registry restored byte-identical:

```
# stray key injected (interlacing) → key-set test FAILS:
AssertionError: entrees au schema corrompu (interlacement merge union ?) :
  Z3-Python-01 Introduction -> cles inattendues: ['stray_injected_key']

# one entry destroyed (absorption) → count-floor test FAILS:
AssertionError: le registre a perdu des entrees : 97 < 98
  (interlacement merge union ou suppression accidentee ? cf #8542)
```

Full suite on the clean registry: **9 passed** (7 existing + 2 new).

## Verification

- `git diff --stat`: `+49 / -0`, **single file** (`test_twin_registry_integrity.py` only). Registry `twin_pairs.yaml` byte-identical to origin/main (the regression simulations were restored from backup; `git status` confirms only the test file changed).
- Both new tests regression-verified to FAIL on the exact failure modes they target (stray-key injection, entry destruction).
- Purely additive (2 new test functions + 2 constants + comments); 0 change to existing tests, 0 change to the registry, 0 change to CI workflows.
- Python source (not a notebook) → C.2/H.3 N/A.

## Scope note (why `See #8542`, not `Closes`)

#8542 presents 3 options. This PR delivers **Option B** (the unconditional one — "B dans tous les cas"). Options A (assume driver is local-only, rely on tranches — a policy stance, no code) and C (split to `twin_pairs.d/<name>.yaml` — larger, touches loader + CI) remain open decisions for ai-01. The Constat-1 finding (GitHub's merge server doesn't apply `.gitattributes` drivers — a platform limitation) is informational and needs no code action. So this PR is a partial resolution: the concrete, always-wanted hardening is done; the strategy decision stays with the coordinator.

## Compliance

- **catalog-pr-hygiene**: catalogue untouched; `See #8542` (partial); branch fresh from `origin/main` (0 behind).
- **One subject per PR**: single test file, single concern (interlacing hardening), atomique.
- **R6 (variety)**: tooling/CI-hardening grain (distinct from c.740 Lean-security, c.745 twin-register tranche, c.747 Lean structural-drift). Hors Lean per ai-01 c.8 directive (Hashlife taken by CoursIA-2 #6724).
- **#8542 provenance**: ai-01's finding, filed OPEN with options + stated B preference; picked from the pool (not reserved, 0 collision).

See #8542. — po-2026

Co-Authored-By: Claude <noreply@anthropic.com>
