### PR TITLE
fix(sk-6,#8052): re-exec stale cell[1] kernel-init output (claims<->outputs)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/06-SemanticKernel-ProcessFramework.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/06-SemanticKernel-ProcessFramework.ipynb
@@ -79,7 +79,7 @@
      "output_type": "stream",
      "name": "stdout",
      "text": [
-      "Process Framework - Kernel non initialise (OPENAI_API_KEY absente)\n"
+      "Process Framework - Kernel initialise (cle API detectee)\n"
      ]
     }
    ],


### PR DESCRIPTION
## Summary

**Notebook**: `MyIA.AI.Notebooks/GenAI/SemanticKernel/06-SemanticKernel-ProcessFramework.ipynb` (SK-6, Process Framework)

Fixes a claims↔outputs defect in **cell[1]** (kernel config). The committed OUTPUT contradicted both the markdown interpretation (cell[2]) and the notebook's own execution (cells 7-19).

### The defect (verified firsthand on `origin/main`)

| Cell | Content | State |
|------|---------|-------|
| **cell[1] output** (committed) | `"Process Framework - Kernel non initialise (OPENAI_API_KEY absente)"` | stale no-key run |
| **cell[2] markdown** | `"Kernel SK configuré avec service OpenAI"` / Service=OpenAIChatCompletion / ID="default" | (correct interpretation) |
| **cells 7-19 outputs** | `generate_content_step` → `kernel.get_service("default")` → `"[Step 1] Brouillon genere: 1039 caracteres"` | with-key run (succeeded) |

**Contradiction**: cell[1] says kernel=None (no key), but cell[7]'s `generate_content_step` calls `kernel.get_service(service_id="default")` which would **crash** if kernel=None. cell[11]'s output proves it succeeded (1039 chars generated). So cells 7-19 ran WITH the key; cell[1]'s output is a **stale artifact** from a no-key commit.

### Root cause (#8364 framing)

Per **#8364**: output=truth, markdown=prior interpretation. Here the **OUTPUT was the stale party** — cell[1] was committed with a no-key run (`OPENAI_API_KEY` absent at that moment) while the rest of the notebook executed with the key. The markdown (cell[2]) was actually *correct*. The fix is to **re-exec cell[1] with the correct env** (Stop & Repair, secrets-hygiene règle 6), **not** a markdown realignment and **not** a hand-edit of the output.

### Fix — deterministic single-cell re-exec (zero API cost)

Re-produced cell[1] source verbatim and executed with:
- `OPENAI_API_KEY` from `.secrets/master.env`
- `OPENAI_CHAT_MODEL_ID=gpt-4o` (per cell[0] frontmatter — the env var `OpenAISettings.chat_model_id` reads; the constructor `OpenAIChatCompletion(service_id="default")` is correct, no code change needed)

`kernel.add_service(...)` is **registration only** — no LLM call, zero API cost. Output is now `"Process Framework - Kernel initialise (cle API detectee)"`, consistent with cell[2] + cells 7-19.

### Verification

- ✅ `git show origin/main:<nb>` → `DEFECT LIVE: True` (cell[1] "non initialise" on main before this PR)
- ✅ Re-exec produced exactly `"Kernel initialise (cle API detectee)"` (kernel type `<class 'semantic_kernel.kernel.Kernel'>`, not None)
- ✅ Diff minimal: **1 insertion, 1 deletion** (output line only). cell[1] source else-branch intact. execution_count=1 unchanged.
- ✅ cell[2] markdown now consistent with cell[1] output.
- ✅ C.3: cells 7-19 source unchanged → outputs untouched.
- ✅ No metadata churn (execution-ts / papermill / ensure_ascii preserved per transplant pattern).

### Scope

Single-cell output coherence fix. No source code change. Not a markdown edit. No LLM cost.

See #8052 (claims↔outputs EPIC — partial contribution, EPIC stays open).
