### PR TITLE
fix(qc-py,#8428): remove CJK residue 简化 in QC-Py-Cloud-03 cell14 comment

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-03-Risk-Parity.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-03-Risk-Parity.ipynb
@@ -766,7 +766,7 @@
     "inv_vols = 1.0 / (vols / 100)\n",
     "ivw_weights = inv_vols / inv_vols.sum()\n",
     "\n",
-    "# --- Methode 2 : ERC (iteratif,简化 Newton-Raphson) ---\n",
+    "# --- Methode 2 : ERC (iteratif, descente de gradient) ---\n",
     "def compute_erc_weights(cov, max_iter=100, tol=1e-8):\n",
     "    \"\"\"Trouve les poids ERC par minimisation iterative.\"\"\"\n",
     "    n = cov.shape[0]\n",


### PR DESCRIPTION
## Summary

Fixes the real CJK residue in **#8428** (spotted by ai-01's recount: 3 notebooks flagged, 54/56 glyphs legit Japanese TTS, **one** real defect).

**Notebook**: `MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-03-Risk-Parity.ipynb`, **cell[14]**.

### The defect (verified firsthand on `origin/main`)

```python
# --- Methode 2 : ERC (iteratif,简化 Newton-Raphson) ---
```

The Chinese `简化` ("simplified") had corrupted a French comment — the single real CJK residue in the notebook (literal UTF-8, only occurrence).

### Fix — and a method-name correction in the same line

Replacing only the CJK would leave `Newton-Raphson`, but reading `compute_erc_weights` shows it is **normalized gradient descent**:

```python
w_new = w - 0.1 * grad / np.sum(np.abs(grad))   # fixed step, no Jacobian/Hessian
```

Not Newton-Raphson. Leaving the false method name would preserve a known inaccuracy — so the comment now reads `descente de gradient`, accurate + CJK-free. This is **#8364** applied to the same line (comment ↔ code consistency). Flagging both together is cleaner than splitting one comment line across two PRs.

### Re-execution (C.2 / H.3)

cell[14] is self-contained (own `import numpy as np` / `from scipy.stats import norm` + `np.random.seed(42)`). Standalone re-exec produces output **byte-identical** to the committed output (`match: True`) — confirms comment-only change, no behavioral effect. Output cell untouched.

### Verification

- ✅ `git show origin/main:<nb>` → `简化` confirmed live (decisive collision-guard test)
- ✅ Post-fix: **0 CJK residue** anywhere in the notebook (full literal scan)
- ✅ `ensure_ascii=False` preserved (literal accented chars like `correlées` intact — no churn)
- ✅ Output byte-identical after re-exec
- ✅ Not in `twin_pairs.yaml` (no twin-gate risk, per ai-01's warning — checked)
- ✅ Diff minimal: 1 ins / 1 del (comment line only)

### Note on #8428 scope

This PR fixes the one **real** CJK defect. The detector exclusion of the 2 legitimate Japanese-TTS notebooks (false positives, ai-01's "ferme l'epic" second half) is a separate deliverable — different file (`scripts/notebook_tools/`), will follow if window allows.

See #8428 (partial — residue fixed, detector-FP exclusion to follow).
