### PR TITLE
fix(qc,#8428): resolve last CJK residual (简化->simplifié) + retire detector allowlist entry

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-03-Risk-Parity.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-03-Risk-Parity.ipynb
@@ -766,7 +766,7 @@
     "inv_vols = 1.0 / (vols / 100)\n",
     "ivw_weights = inv_vols / inv_vols.sum()\n",
     "\n",
-    "# --- Methode 2 : ERC (iteratif,简化 Newton-Raphson) ---\n",
+    "# --- Methode 2 : ERC (iteratif,simplifié Newton-Raphson) ---\n",
     "def compute_erc_weights(cov, max_iter=100, tol=1e-8):\n",
     "    \"\"\"Trouve les poids ERC par minimisation iterative.\"\"\"\n",
     "    n = cov.shape[0]\n",

--- a/scripts/notebook_tools/detect_cjk_residue.py
+++ b/scripts/notebook_tools/detect_cjk_residue.py
@@ -33,11 +33,12 @@ Filtres faux-positifs (EXCLUS — CJK legitime)
   `GenAI/Audio/02-Advanced/02-8-Expressive-TTS.ipynb` contient volontairement du
   japonais (`こんにちは！多言語音声合成のデモンストレーションです。`) pour demontrer
   la synthese multilingue. Allowliste avec raison documentee.
-- Residu gated connu : `QuantConnect/Python/QC-Py-Cloud-03-Risk-Parity.ipynb` porte
-  un residu CJK dans un code-comment dont la correction exige une re-exec via QC
-  Cloud (QuantBook, gated). Allowliste de façon temporaire, documentée comme
-  « known gated residual — fix needs QC-Cloud re-exec », pour ne pas bloquer le CI
-  sur un defect deja connu et tracé. Retirer de l'allowlist des que re-executed.
+- (Anciennement) residu gated connu sur `QC-Py-Cloud-03-Risk-Parity.ipynb` : residu
+  CJK dans un code-comment, allowliste temporairement le temps de la correction.
+  **RESOLU 2026-07-25** (简化 -> simplifié, re-exec numpy/scipy deterministe — la
+  cellule n'etait pas QC-Cloud-gated : elle est pure numpy/scipy) ; entree ALLOWED
+  retirée, le notebook scanne clean desormais. Mécanisme conservé pour un futur
+  residu gated le cas échéant.
 
 ALLOWED = dictionnaire {substring de chemin: raison}. Un notebook dont le chemin
 contient une cle de ALLOWED est skip entierement (toutes ses cellules CJK sont
@@ -89,8 +90,6 @@ CJK_RE = re.compile(r"[　-〿぀-ゟ゠-ヿ一-鿿＀-￯]")
 ALLOWED: dict[str, str] = {
     "GenAI/Audio/02-Advanced/02-8-Expressive-TTS.ipynb":
         "demo TTS multilingue legiTIME (japonais volontaire pour la synthese)",
-    "QuantConnect/Python/QC-Py-Cloud-03-Risk-Parity.ipynb":
-        "known gated residual (code-comment) -- fix needs QC-Cloud re-exec; retirer apres re-exec",
 }
 
 

--- a/scripts/notebook_tools/tests/test_detect_cjk_residue.py
+++ b/scripts/notebook_tools/tests/test_detect_cjk_residue.py
@@ -12,7 +12,7 @@ The detection half is formally tested here. Four clusters, mirroring the
 detector's documented contract (docstring):
 
   1. TestDetectCell      -- CJK glyph detection in markdown + code sources
-  2. TestAllowlist        -- legitimate multilingual demo + known gated residual skipped
+  2. TestAllowlist        -- legitimate multilingual demo allowed; resolved residual no longer allowlisted
   3. TestScanNotebook     -- end-to-end nb read + allowed short-circuit + hit report
   4. TestMainExitCodes    -- --check exit contract (0 clean / 1 residue / 2 error)
 
@@ -103,10 +103,15 @@ class TestAllowlist:
         assert reason is not None
         assert "TTS" in reason or "multilingue" in reason
 
-    def test_qc_cloud_gated_residual_allowed(self):
+    def test_qc_cloud_residual_resolved_not_allowed(self):
+        # The Risk-Parity CJK code-comment residual (简化 in cell14) was fixed
+        # 2026-07-25 (-> simplifié). The cell turned out to be pure numpy/scipy
+        # (deterministic, seed=42), NOT QC-Cloud-gated as previously assumed, so a
+        # local re-exec proved the committed output byte-identical. The obsolete
+        # allowlist entry was retired; the notebook must now scan clean + NOT be
+        # allowlisted. Guards against re-adding a suppression for a resolved defect.
         reason = mod._is_allowed("MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-03-Risk-Parity.ipynb")
-        assert reason is not None
-        assert "gated" in reason.lower()
+        assert reason is None
 
     def test_random_notebook_not_allowed(self):
         assert mod._is_allowed("MyIA.AI.Notebooks/ML/Some-Notebook.ipynb") is None


### PR DESCRIPTION
## Summary

Resolves the **last** fleet-wide CJK LLM-translation residue (#8428), picked up from ai-01's c.9 recomputation of the tracker.

ai-01 re-scanned the 938 pedagogical notebooks and found the tracker had been stale: **54 of 56 CJK glyphs are legitimate** (50 are Japanese in `02-8-Expressive-TTS.ipynb` — the *subject* of that TTS demo). The **only real residual was one line** in `QC-Py-Cloud-03-Risk-Parity.ipynb` cell14:

```python
# --- Methode 2 : ERC (iteratif,简化 Newton-Raphson) ---
```

`简化` = "simplifié" (Chinese). The detector had allowlisted it as *"known gated residual — fix needs QC-Cloud re-exec"*.

## The gating assumption was wrong — this cell is locally re-executable

cell14 is **pure numpy/scipy** (`import numpy as np`, `from scipy.stats import norm`, `np.random.seed(42)`). It is **not** a QuantBook cell — the notebook's QuantBook API lives in *other* cells. So the "needs QC-Cloud re-exec" assumption was false for this cell.

## Changes

**1. Notebook** (`QC-Py-Cloud-03-Risk-Parity.ipynb` cell14): `简化` → `simplifié` in the code comment. Byte-surgical raw `str.replace` on the UTF-8 literal (1 occurrence), LF preserved, UTF-8 no-BOM, 0 `NotebookEdit` churn. **Outputs/execution_count untouched** (justified below).

**2. Detector** (`detect_cjk_residue.py`): remove the obsolete Risk-Parity entry from `ALLOWED` (the suppression is obsolete once the residual is fixed; leaving it = stale doc claiming a residual that no longer exists). Docstring bullet rewritten to mark the case **RESOLU 2026-07-25** + correct the false QC-Cloud-gated assumption; the gated-residual *mechanism* is preserved for a future case.

**3. Test** (`test_detect_cjk_residue.py`): `test_qc_cloud_gated_residual_allowed` → `test_qc_cloud_residual_resolved_not_allowed` (now asserts the notebook is **NOT** allowlisted, guarding against re-adding a suppression for a resolved defect). Cluster docstring updated.

## Verification (all firsthand, worktree at `origin/main` `bd1a338f4`)

**Determinism proof (the key honesty check — no QC Cloud needed):**
- Ran cell14 standalone (numpy/scipy, seed=42) → output **byte-identical to the committed output** (proves committed output is real + deterministic).
- Re-ran cell14 **after** the comment fix → output **unchanged** (comment-only edit changes 0 output bytes by construction).
- Therefore the existing committed output (`ec=6`, 1 stream output) remains valid; **no notebook re-exec needed, no QC Cloud dependency**.

**Detector + tests:**
- `detect_cjk_residue.py QC-Py-Cloud-03-Risk-Parity.ipynb` → 0 hits, NOT allowed.
- Fleet-wide `--check` → **exit 0**, 0 residue, 1 allowed (TTS demo only).
- `pytest test_detect_cjk_residue.py` → **18 passed**.

**H.3 / scope:**
- cell14 `ec=6` (not null), outputs=1; 0 H.3 violations across the notebook.
- `git diff --stat`: 3 files, +16/−12. Notebook diff = exactly 1 line.

## Closes #8428

This was the last real residual (ai-01 c.9). Fleet is now 0 unexpected CJK; the detector remains as the anti-recurrence guard.

— po-2026
