### PR TITLE
fix(cjk-detector,#8428): remove FALSE allowlist that hid 简化 defect + allowlist 9_Production_Patterns

### DIFF
--- a/scripts/notebook_tools/detect_cjk_residue.py
+++ b/scripts/notebook_tools/detect_cjk_residue.py
@@ -33,11 +33,18 @@ Filtres faux-positifs (EXCLUS — CJK legitime)
   `GenAI/Audio/02-Advanced/02-8-Expressive-TTS.ipynb` contient volontairement du
   japonais (`こんにちは！多言語音声合成のデモンストレーションです。`) pour demontrer
   la synthese multilingue. Allowliste avec raison documentee.
-- Residu gated connu : `QuantConnect/Python/QC-Py-Cloud-03-Risk-Parity.ipynb` porte
-  un residu CJK dans un code-comment dont la correction exige une re-exec via QC
-  Cloud (QuantBook, gated). Allowliste de façon temporaire, documentée comme
-  « known gated residual — fix needs QC-Cloud re-exec », pour ne pas bloquer le CI
-  sur un defect deja connu et tracé. Retirer de l'allowlist des que re-executed.
+- Notebooks multilingues legiTIME (suite) : `GenAI/Texte/9_Production_Patterns.ipynb`
+  cell[20] demontre une salutation multilingue (`你好，世界！` = « Hello World » mandarin,
+  aux cotes de l'italien). Allowliste avec raison documentee.
+- Residu gated connu : a titre exceptionnel, un notebook dont le residu CJK exige une
+  re-exec gated (ex QuantBook via QC Cloud) peut etre allowliste de façon temporaire,
+  documente comme « known gated residual — fix needs <env> re-exec », pour ne pas bloquer
+  le CI sur un defect connu et tracé. Retirer de l'allowlist des que re-executed.
+  ATTENTION G.1 : verifier que le special-exec est REELLEMENT requis (kernel type, usage
+  QuantBook) — le filename/famille ne suffit pas. « Allowlisted/needs-special-exec » n'est
+  pas un bouton defer : un residu en commentaire ou un notebook Python local n'a pas besoin
+  de QC Cloud. (Incident c.889 : QC-Py-Cloud-03 etait faussement allowliste « needs
+  QC-Cloud » alors qu'il est Python local — defect fixe par re-exec locale en #8553.)
 
 ALLOWED = dictionnaire {substring de chemin: raison}. Un notebook dont le chemin
 contient une cle de ALLOWED est skip entierement (toutes ses cellules CJK sont
@@ -89,8 +96,8 @@ CJK_RE = re.compile(r"[　-〿぀-ゟ゠-ヿ一-鿿＀-￯]")
 ALLOWED: dict[str, str] = {
     "GenAI/Audio/02-Advanced/02-8-Expressive-TTS.ipynb":
         "demo TTS multilingue legiTIME (japonais volontaire pour la synthese)",
-    "QuantConnect/Python/QC-Py-Cloud-03-Risk-Parity.ipynb":
-        "known gated residual (code-comment) -- fix needs QC-Cloud re-exec; retirer apres re-exec",
+    "GenAI/Texte/9_Production_Patterns.ipynb":
+        "demo multilingue legiTIME (cell[20]: 你好，世界！ = 'Hello World' mandarin, aux cotes de Ciao mondo! italien)",
 }
 
 

--- a/scripts/notebook_tools/tests/test_detect_cjk_residue.py
+++ b/scripts/notebook_tools/tests/test_detect_cjk_residue.py
@@ -103,10 +103,17 @@ class TestAllowlist:
         assert reason is not None
         assert "TTS" in reason or "multilingue" in reason
 
-    def test_qc_cloud_gated_residual_allowed(self):
-        reason = mod._is_allowed("MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-03-Risk-Parity.ipynb")
+    def test_texte_multilingual_allowed(self):
+        reason = mod._is_allowed("MyIA.AI.Notebooks/GenAI/Texte/9_Production_Patterns.ipynb")
         assert reason is not None
-        assert "gated" in reason.lower()
+        assert "multilingue" in reason.lower() or "mandarin" in reason.lower()
+
+    def test_qcpy03_no_longer_allowed(self):
+        # QC-Py-Cloud-03 was FALSELY allowlisted as "needs QC-Cloud re-exec" (it is local
+        # Python, no QuantBook). The 简化 residue was fixed by local re-exec in #8553, so the
+        # gated-residual allowlist entry is removed — the notebook must NOT be skipped now.
+        reason = mod._is_allowed("MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-03-Risk-Parity.ipynb")
+        assert reason is None
 
     def test_random_notebook_not_allowed(self):
         assert mod._is_allowed("MyIA.AI.Notebooks/ML/Some-Notebook.ipynb") is None


### PR DESCRIPTION
## Summary

**Root cause of the c.889 "fleet-clean" miss** (the G.1 failure ai-01 caught): the detector's `ALLOWED` dict contained `QC-Py-Cloud-03-Risk-Parity.ipynb` with reason *"known gated residual -- fix needs QC-Cloud re-exec"*. That classification was **false on two counts**:

1. The notebook is **local Python** (`python3` kernel, no `QuantBook()` usage) — no QC-Cloud needed.
2. The `简化` residue is in a code **comment** (output byte-identical after fix).

The false allowlist entry was **suppressing the real defect** — the detector reported "clean" while a residue was live on `origin/main`. ai-01's raw-grep recount (bypassing the allowlist) caught it; the residue is fixed in **#8553**. This PR fixes the detector so it can't hide the defect again.

## Changes

| Change | Why |
|--------|-----|
| **REMOVE** `QC-Py-Cloud-03` from `ALLOWED` | Defect fixed by local re-exec in #8553; the "gated residual" premise was false. Detector now truthfully reports the residue until #8553 merges, then fleet-clean. |
| **ADD** `GenAI/Texte/9_Production_Patterns.ipynb` to `ALLOWED` | Legit multilingual: cell[20] `你好，世界！` = "Hello World" mandarin, alongside Italian `Ciao, mondo!`. Was a false positive. |
| Docstring update | Replace stale QC-Py-Cloud-03 gated-residual example with the 9_Production_Patterns legit example; keep general gated-residual policy, now with a **G.1 warning** (verify special-exec is actually required via kernel type / QuantBook usage — never infer from filename; "allowlisted" is not a defer-button). Captures the c.889 lesson. |

## Verification

- ✅ **Unit tests 19/19** (was 18). Replaced `test_qc_cloud_gated_residual_allowed` with `test_texte_multilingual_allowed` + added `test_qcpy03_no_longer_allowed` (documents the removal).
- ✅ **Fleet scan** (this branch, #8553 NOT yet merged): 938 scanned, **2 allowed** (TTS + 9_Production_Patterns), **1 real residue flagged** (QC-Py-Cloud-03 `简化`) — honest. Once #8553 merges → 0 residue.
- ✅ Collision guard: no PR touches the detector.

## Ordering

**Merge with/after #8553** (which fixes the residue this PR exposes). If merged alone, the detector correctly flags QC-Py-Cloud-03 until #8553 lands — honest behavior, not a regression.

Together with #8553, this **closes the #8428 epic** (real defect fixed + legit multilingual properly excluded + the false allowlist that hid the defect removed).

See #8428
