### PR TITLE
fix(sc-03,#8052): correct median-voter preference order cell[27] (0↔8 swap)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/SocialChoice/03-Voting-Methods.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/SocialChoice/03-Voting-Methods.ipynb
@@ -1398,7 +1398,7 @@
     "\n",
     "| Méthode | Résultat | Conclusion |\n",
     "|---------|----------|------------|\n",
-    "| Electeur median (pic=5) | Alternative 4 | Préférence : 4 > 6 > 2 > 0 > 8 > 10 |\n",
+    "| Electeur median (pic=5) | Alternative 4 | Préférence : 4 > 6 > 2 > 8 > 0 > 10 |\n",
     "| Gagnant de Condorcet | Alternative 4 | Bat tous les autres en duels pairwise |\n",
     "\n",
     "**Pourquoi ça marche** :\n",


### PR DESCRIPTION
## Summary

**Notebook**: `MyIA.AI.Notebooks/GameTheory/SocialChoice/03-Voting-Methods.ipynb`, **cell[27]** (markdown interpretation of the median-voter theorem).

### The defect (case-A: markdown wrong, output is truth)

cell[27] stated the median voter's (pic=5) preference as `4 > 6 > 2 > 0 > 8 > 10`, but cell[26]'s committed output is:

```
Electeur 4 (pic=5): [4, 6, 2, 8, 0, 10]
```

The markdown **swaps 0 and 8**. The correct ordering (single-peaked, distance from peak 5): 8 is |8−5|=3 from peak, 0 is |0−5|=5, so 8 is preferred to 0 → `... 2 > 8 > 0 > 10`.

### Verification (firsthand, deterministic)

cell[26] is **deterministic** — `single_peaked_preference` sorts by distance from peak, no tie-break. Re-executed in **2 fresh processes**: both reproduce `[4, 6, 2, 8, 0, 10]`, matching the committed output exactly. So the committed output is the truth (#8364 case-A: markdown prior contradicts legitimate output → fix markdown). 1-line markdown edit; cell[26] output unchanged.

### Scope note — deeper finding (out of scope, flagged)

A full scan of this notebook found **cells [12]/[15]/[23] have STALE committed outputs** (current code produces different results — the code changed since the outputs were committed) AND **cell[23] (Arrow IIA Monte-Carlo) is non-deterministic across processes** despite `random.seed(42)`: PYTHONHASHSEED affects the string tie-breaking order in the voting rules, so the IIA violation count varies (observed 20/3/0, 61/3/11 across processes). Those need a dedicated **re-exec + determinism fix** (sort tie-breaks in `plurality_rule`/`borda_rule`/`copeland_rule`), NOT a markdown patch — per #8364, realigning markdown to stale/non-deterministic outputs would consecrate a broken run. Flagged separately on #8052. This PR fixes only the clean, deterministic case-A defect (cell[27]).

### Diff

1 insertion, 1 deletion (markdown preference order only). No code change, no output change, no re-exec (C.2 markdown-only exception).

See #8052
