### PR TITLE
fix(sc-04,#8052): Arrow SAT encoder non-dictatorship over-constraint -> false UNSAT for 2 alternatives

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/SocialChoice/04-Computational-Aggregation-SAT-Z3.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/SocialChoice/04-Computational-Aggregation-SAT-Z3.ipynb
@@ -354,7 +354,7 @@
       "Encodage Arrow (3 alt, 2 voters)\n",
       "  Profils : 36\n",
       "  Variables : 216\n",
-      "  Clauses : 2226\n"
+      "  Clauses : 2216\n"
      ]
     }
    ],
@@ -457,37 +457,28 @@
     "                        clauses.append([v1_xy, -v2_xy])   # R2(x,y) => R1(x,y)\n",
     "        return clauses\n",
     "    def encode_non_dictatorship(self):\n",
-    "        \"\"\"Pour chaque electeur i, il existe un profil ou i n'est pas respecte.\"\"\"\n",
+    "        \"\"\"Non-dictature (Arrow) : pour chaque electeur i, il existe au moins\n",
+    "        un couple (profil, paire) ou le classement social contredit i.\n",
+    "\n",
+    "        Un electeur i est un dictateur (au sens d'Arrow) s'il determine le\n",
+    "        classement social dans TOUS les profils. On nie cela par UNE seule\n",
+    "        clause disjonctive par electeur : il existe au moins un profil pi et une\n",
+    "        paire (x, y) ou i prefere x a y mais la societe ne suit pas.\n",
+    "\n",
+    "        Une clause par electeur (et non par paire) : sinon on exige que i soit\n",
+    "        contredit sur chaque paire, ce qui sur-contraint l'encodage et declare\n",
+    "        faussement UNSAT le cas |A| = 2 -- alors qu'une SWF non dictatoriale\n",
+    "        (regle majoritaire) y satisfait Pareto + IIA + non-dictature.\"\"\"\n",
     "        clauses = []\n",
     "        for voter in range(self.n_voters):\n",
-    "            # Pour chaque paire (x,y), il existe un profil ou le classement social\n",
-    "            # contredit les preferences du dictateur potentiel\n",
-    "            for x, y in permutations(self.alternatives, 2):\n",
-    "                # Trouver un profil ou le voter prefere x a y\n",
-    "                # et forcer le social a ne PAS preferer x a y\n",
-    "                for pi_idx, profile in enumerate(self.profiles):\n",
+    "            witness = []\n",
+    "            for pi_idx, profile in enumerate(self.profiles):\n",
+    "                for x, y in permutations(self.alternatives, 2):\n",
     "                    if profile[voter].index(x) < profile[voter].index(y):\n",
-    "                        v_xy = self.get_var(pi_idx, x, y)\n",
-    "                        # Au moins un cas ou le \"dictateur\" n'est pas suivi\n",
-    "                        # On ajoute la clause qui sera selectionnee globalement\n",
-    "                        pass  # On utilise une autre approche\n",
-    "\n",
-    "        # Approche correcte : variable auxiliaire par dictateur\n",
-    "        # Pour chaque voter i, ajouter des clauses qui excluent\n",
-    "        # que i soit un dictateur\n",
-    "        for voter in range(self.n_voters):\n",
-    "            for x, y in permutations(self.alternatives, 2):\n",
-    "                # Collecter les profils ou voter prefere x a y\n",
-    "                witness_profiles = []\n",
-    "                for pi_idx, profile in enumerate(self.profiles):\n",
-    "                    if profile[voter].index(x) < profile[voter].index(y):\n",
-    "                        v_xy = self.get_var(pi_idx, x, y)\n",
-    "                        witness_profiles.append(-v_xy)  # social ne prefere PAS x a y\n",
-    "\n",
-    "                # Au moins un profil ou le dictateur n'est pas suivi\n",
-    "                if witness_profiles:\n",
-    "                    clauses.append(witness_profiles)\n",
-    "\n",
+    "                        # i prefere x a y sur ce profil ; temoin = social ne prefere PAS x a y\n",
+    "                        witness.append(-self.get_var(pi_idx, x, y))\n",
+    "            if witness:\n",
+    "                clauses.append(witness)  # au moins une contradiction pour cet electeur\n",
     "        return clauses\n",
     "    def encode_all(self):\n",
     "        \"\"\"Retourne toutes les clauses CNF pour le theoreme d'Arrow.\"\"\"\n",
@@ -536,7 +527,7 @@
    "source": [
     "### Interpretation de la structure de l'encodeur\n",
     "\n",
-    "La classe `ArrowSATEncoder` genere un problème SAT avec 216 variables et 2226 clauses pour 3 alternatives et 2 electeurs. Chaque variable represente une decision sociale (x > y) pour un profil spécifique.\n",
+    "La classe `ArrowSATEncoder` genere un problème SAT avec 216 variables et 2216 clauses pour 3 alternatives et 2 electeurs. Chaque variable represente une decision sociale (x > y) pour un profil spécifique.\n",
     "\n",
     "**Decomposition des clauses** :\n",
     "- **Totalite et asymetrie** : assurent que le classement social est une relation d'ordre stricte (antisymetrique et totale)\n",
@@ -626,11 +617,11 @@
       "Configuration : 3 alternatives, 2 electeurs\n",
       "\n",
       "  Glucose3     : UNSAT (Arrow verifie)\n",
-      "    216 variables, 2226 clauses, 36 profils\n",
+      "    216 variables, 2216 clauses, 36 profils\n",
       "  MiniSat22    : UNSAT (Arrow verifie)\n",
-      "    216 variables, 2226 clauses, 36 profils\n",
+      "    216 variables, 2216 clauses, 36 profils\n",
       "  CaDiCaL103   : UNSAT (Arrow verifie)\n",
-      "    216 variables, 2226 clauses, 36 profils\n",
+      "    216 variables, 2216 clauses, 36 profils\n",
       "\n",
       "Resultat : UNSAT pour tous les solveurs\n",
       "=> Aucune SWF ne peut satisfaire Pareto + IIA + non-dictature\n",
@@ -778,16 +769,10 @@
       "============================================================\n",
       " Alt Voters    Profils  Variables    Clauses Temps (ms)\n",
       "------------------------------------------------------------\n",
-      "   2      2          4          8         14        0.1\n",
-      "   2      3          8         16         24        0.2\n",
-      "   3      2         36        216      2,226        7.5\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "   3      3        216      1,296     36,468      323.1\n",
+      "   2      2          4          8         12        0.0\n",
+      "   2      3          8         16         21        0.1\n",
+      "   3      2         36        216      2,216        2.5\n",
+      "   3      3        216      1,296     36,453       85.9\n",
       "\n",
       "Estimation pour 4 alternatives :\n",
       "  4 alt, 2 voters : ~576 profils, ~6,912 variables (trop grand pour l'encodage complet)\n",
@@ -885,20 +870,11 @@
      "text": [
       "CAS 2 ALTERNATIVES : ANALYSE DE L'ENCODAGE\n",
       "==================================================\n",
-      "Resultat : UNSAT\n",
-      "Variables : 8, Clauses : 14\n",
+      "Resultat : SAT (fonction non-dictatoriale existe!)\n",
+      "Variables : 8, Clauses : 12\n",
       "\n",
       "Analyse :\n",
-      "  L'encodage SAT trouve UNSAT meme avec 2 alternatives.\n",
-      "  Ceci s'explique par l'interaction entre Pareto et non-dictature :\n",
-      "  - Pareto force le classement social quand tous sont d'accord\n",
-      "  - Avec 2 alt, le domaine est si petit que non-dictature ne peut\n",
-      "    etre satisfaite en meme temps que les autres contraintes\n",
-      "  - L'encodage couvre TOUS les profils, pas seulement la majorite\n",
-      "\n",
-      "  Note : le theoreme d'Arrow classique suppose |A| >= 3.\n",
-      "  Le resultat UNSAT ici montre que meme la version a 2 alternatives\n",
-      "  de l'encodage est trop contrainte (Pareto + non-dictature seuls).\n"
+      "  Une fonction non-dictatoriale existe : la regle majoritaire.\n"
      ]
     }
    ],
@@ -944,11 +920,11 @@
    "source": [
     "### Interpretation du cas 2 alternatives\n",
     "\n",
-    "Le résultat UNSAT pour 2 alternatives peut sembler surprenant car le theoreme d'Arrow classique suppose $|A| \\geq 3$. Cependant, l'explication reside dans la formulation de la contrainte de non-dictature.\n",
+    "Le resultat est maintenant **SAT** pour 2 alternatives : une fonction de bien-etre social non dictatoriale existe, et la regle majoritaire en est un exemple (elle satisfait Pareto, IIA et non-dictature des que |A| < 3).\n",
     "\n",
-    "Dans notre encodage, la non-dictature impose que pour chaque electeur, il existe au moins un profil ou son choix n'est pas respecte. Avec seulement 2 alternatives, l'espace des profils est si restreint (seulement 4 profils possibles pour 2 electeurs) que cette contrainte entre en conflit avec Pareto et les autres axiomes de base (totalite, asymetrie, transitivite).\n",
+    "C'est precisement ce qui illustre la frontiere du theoreme d'Arrow : celui-ci suppose $|A| \\geq 3$, et la conclusion d'impossibilite ne tient plus en dessous. Pour 2 alternatives, l'espace des profils est suffisamment restreint pour qu'aucun electeur ne puisse etre dictateur au sens d'Arrow -- IIA impose que le classement social d'une paire ne depende que des preferences individuelles sur cette paire, et comme il n'existe qu'une seule paire, tout reglage coherent (par exemple la majorite, ou un tie-break constant sur les profils mixtes) Pareto + non-dictature est realisable.\n",
     "\n",
-    "La règle majoritaire, qui satisfait les conditions d'Arrow pour 2 alternatives, ne peut pas etre representee dans cet encodage car la contrainte de non-dictature y est formulee de maniere plus forte que dans le theoreme original."
+    "L'encodeur SAT et l'encodeur SMT (Z3, partie 2) donnent desormais le meme verdict SAT, ce qui confirme la coherence de l'encodage. (Note : le theoreme d'Arrow reste valide des que |A| \\geq 3 -- voir la section precedente.)"
    ]
   },
   {
@@ -969,17 +945,13 @@
     "\n",
     "| Alternatives | Electeurs | Résultat | Explication |\n",
     "|---|---|---|---|\n",
-    "| 2 | 2+ | UNSAT | Encodage trop contraint (Pareto + non-dictature déjà incompatibles) |\n",
-    "| 3 | 2+ | UNSAT | Arrow verifie : impossibilite |\n",
-    "| 4+ | 2+ | UNSAT | Arrow verifie (explosion combinatoire) |\n",
+    "| 2 | 2+ | SAT | Une SWF non dictatoriale existe (règle majoritaire) |\n",
+    "| 3 | 2+ | UNSAT | Arrow vérifié : impossibilité |\n",
+    "| 4+ | 2+ | UNSAT | Arrow vérifié (explosion combinatoire) |\n",
     "\n",
-    "**Point subtil** : le theoreme d'Arrow classique suppose $|A| \\geq 3$.\n",
-    "Avec 2 alternatives, la règle majoritaire satisfait les conditions originales d'Arrow,\n",
-    "mais notre encodage SAT est plus restrictif car il impose simultanement\n",
-    "Pareto + IIA + non-dictature sur **tous** les profils, ce qui est déjà impossible\n",
-    "avec 2 alternatives dans ce cadre formel.\n",
+    "**Point subtil** : le theoreme d'Arrow classique suppose $|A| \\geq 3$, et la conclusion d'impossibilite ne tient plus en dessous. Pour 2 alternatives, l'encodeur SAT detecte correctement qu'une fonction de bien-etre social non dictatorielle existe (la regle majoritaire satisfait Pareto + IIA + non-dictature) : c'est la **frontiere exacte** du theoreme. L'impossibilite n'apparait qu'a partir de 3 alternatives, ou l'encodeur confirme UNSAT -- ce que verifient egalement les trois solveurs et l'encodeur SMT (Z3, partie 2).\n",
     "\n",
-    "La complexite croit très vite : avec 4 alternatives et 3 electeurs,\n",
+    "La complexite croit tres vite : avec 4 alternatives et 3 electeurs,\n",
     "l'encodage implique $(4!)^3 = 13\\,824$ profils et des milliers de clauses."
    ]
   },
@@ -1166,7 +1138,7 @@
    "source": [
     "### Interpretation\n",
     "\n",
-    "L'encodage du theoreme de Sen produit moins de clauses (558) que celui d'Arrow (2226) car il remplace IIA et non-dictature par une seule contrainte de liberte minimale.\n",
+    "L'encodage du theoreme de Sen produit moins de clauses (558) que celui d'Arrow (2216) car il remplace IIA et non-dictature par une seule contrainte de liberte minimale.\n",
     "\n",
     "Le résultat UNSAT confirme le theoreme de Sen : on ne peut pas avoir simultanement la liberte individuelle minimale, l'efficacite collective (Pareto) et la coherence du classement social (transitivite). C'est un paradoxe fondamental : donner des droits individaux même minimaux mene a l'incoherence collective.\n",
     "\n",
@@ -1247,12 +1219,12 @@
       "============================================================\n",
       "\n",
       "3 alternatives, 2 electeurs\n",
-      "  36 profils, 216 variables, 2226 clauses\n",
+      "  36 profils, 216 variables, 2216 clauses\n",
       "  Solveur      Resultat             Temps (ms)\n",
       "  ------------------------------------------\n",
-      "  Glucose3     UNSAT (Arrow)               2.3\n",
-      "  MiniSat22    UNSAT (Arrow)               3.4\n",
-      "  CaDiCaL103   UNSAT (Arrow)               3.6\n"
+      "  Glucose3     UNSAT (Arrow)               0.7\n",
+      "  MiniSat22    UNSAT (Arrow)               0.7\n",
+      "  CaDiCaL103   UNSAT (Arrow)               1.3\n"
      ]
     },
     {
@@ -1261,12 +1233,12 @@
      "text": [
       "\n",
       "3 alternatives, 3 electeurs\n",
-      "  216 profils, 1296 variables, 36468 clauses\n",
+      "  216 profils, 1296 variables, 36453 clauses\n",
       "  Solveur      Resultat             Temps (ms)\n",
       "  ------------------------------------------\n",
-      "  Glucose3     UNSAT (Arrow)              22.5\n",
-      "  MiniSat22    UNSAT (Arrow)              23.0\n",
-      "  CaDiCaL103   UNSAT (Arrow)              24.9\n"
+      "  Glucose3     UNSAT (Arrow)               9.3\n",
+      "  MiniSat22    UNSAT (Arrow)               8.9\n",
+      "  CaDiCaL103   UNSAT (Arrow)              12.3\n"
      ]
     }
    ],
@@ -2258,9 +2230,7 @@
    "source": [
     "#### Interpretation\n",
     "\n",
-    "Avec 2 alternatives, le résultat depend de la precision de l'encodage. Le theoreme d'Arrow\n",
-    "classique ne s'applique qu'a partir de 3 alternatives. L'encodage SMT, comme l'encodage SAT,\n",
-    "peut etre plus restrictif car il impose des contraintes sur tous les profils possibles."
+    "Avec 2 alternatives, le resultat est **SAT** : une SWF non dictatoriale existe (la regle majoritaire satisfait Pareto + IIA + non-dictature). L'encodeur SMT confirme ici le meme verdict que l'encodeur SAT (partie 1) : pour |A| < 3, le theoreme d'Arrow ne s'applique pas et aucune impossibilite n'emerge. L'impossibilite reapparait des que |A| \\geq 3 (voir sections precedentes)."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python (SC-04 SAT/Z3 — fresh family vs recent Probas/GenAI cycles). Fixes a real code-correctness bug in the Arrow SAT encoder, found by direct inspection (not a scan), verified by re-exec + standalone math check.

## The bug

`ArrowSATEncoder.encode_non_dictatorship` (cell[9]) encoded Arrow's non-dictatorship axiom **too strongly**: it emitted one witness clause **per (voter, pair)**, requiring each voter to be overruled on **every** pair (x,y). Arrow's actual definition only requires: for each voter i, there **exists** some (profile, pair) where i is overruled — i.e. **one disjunctive witness clause per voter**.

## The consequence (claim-vs-ground-truth contradiction)

The over-constraint made the SAT encoder declare **UNSAT for 2 alternatives** (cell[19] committed output: `Resultat : UNSAT, Variables : 8, Clauses : 14`), while:
- The notebook's own **Z3 encoder** (cell[50]) correctly returned **SAT** for 2 alternatives;
- Arrow's theorem mathematically requires $|A| \geq 3$ — for 2 alternatives a non-dictatorial SWF **exists** (majority rule, or any constant tie-break on mixed profiles, satisfies Pareto + IIA + non-dictature; IIA forces social(AB)=social(BA) since the individual (A,B) rankings are the same multiset, so both voters get overruled in one profile → both non-dictators).

So two encoders of the **same theorem** gave **opposite** verdicts on the 2-alternative case. The notebook's interpretation cells ([20], [21]) **consecrated the bug** — explaining the UNSAT away as "l'encodage est trop contraint" / "non-dictature formulée de manière plus forte" instead of fixing the cause (sota-not-workaround: explaining-away a bug = complaisance).

## The fix

`encode_non_dictatorship` now builds **one witness clause per voter** (disjunction over all (profile, pair) where the voter prefers x>y; witness literal = society does NOT prefer x>y):

```python
for voter in range(self.n_voters):
    witness = []
    for pi_idx, profile in enumerate(self.profiles):
        for x, y in permutations(self.alternatives, 2):
            if profile[voter].index(x) < profile[voter].index(y):
                witness.append(-self.get_var(pi_idx, x, y))
    if witness:
        clauses.append(witness)  # at least one over-rule for this voter
```

## Anti-regression verified (standalone, EXEC_PROVED)

Standalone test (pysat Glucose3) before touching the notebook:

| config | BUGGY | FIXED | math |
|--------|-------|-------|------|
| 2 alt, 2 voters | UNSAT (8 var, 14 clauses) ❌ | **SAT** (8 var, 12 clauses) ✅ | SAT (SWF exists) |
| 3 alt, 2 voters | UNSAT (216 var, 2226 clauses) ✅ | **UNSAT** (216 var, 2216 clauses) ✅ | UNSAT (Arrow) |

The main theorem (UNSAT for $|A| \geq 3$) is **preserved** — only the erroneous 2-alternative verdict is corrected. (Confirmed `bot-inspection-underdetermines-logic-execute-to-break-tie`: inspection alone couldn't separate bug-from-feature here; running the encoder vs the Z3 twin vs the math broke the tie.)

## Changes (1 notebook, +49/-79)

- **cell[9]**: fixed `encode_non_dictatorship` (removed the buggy per-pair loop + its dead-code `pass` block; new docstring documents the one-clause-per-voter rationale).
- **cells [10], [24]**: clause count 2226 → 2216 (propagated).
- **cell[19]**: output UNSAT → **SAT** (re-executed; the `if sat_2alt:` branch already handled SAT correctly).
- **cells [13], [17], [27]**: regenerated outputs (clause counts 2226 → 2216 across configs).
- **cells [20], [21]**: consecrating prose rewritten — no longer explains-away the bug; now correctly states 2 alternatives → SAT (Arrow's $|A|\geq 3$ frontier), consistent with the Z3 encoder.
- **cell[51]**: hand-wave ("le résultat dépend de la précision de l'encodage") → both encoders now agree SAT.

## Validation (H.3)

- **C.2 EXEC_PROVED**: full re-exec via `nbconvert --execute` (python3, deterministic: pysat Glucose3 + Z3 + matplotlib); outputs grafted surgically for the 5 SAT-encoder-dependent code cells.
- **Scope discipline (C.3)**: the 4 Z3 cells (47/50/53/56) are **untouched by this fix** (different encoder) — their original outputs preserved (only Windows-vs-WSL timing noise would have changed, unrelated to the fix).
- nbformat VALID; **21/21** code cells ec≠null + outputs; **0** errors; C.1 = 0; LF-only (0 CRLF); trailing newline; ec strict 1..21; leak scan NONE.
- Catalogue byte-identical to main.

See #8052 (semantic sampling — claims↔outputs: the SAT encoder's output contradicted the mathematical ground truth + its own Z3 twin). Not `Closes` — #8052 is an epic; this is one concrete defect found by inspection.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
