### PR TITLE
fix(sk-9,#8052): correct C# namespace in markdown (MyIA.AI.Notebooks -> MyNotebookLib)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/09-SemanticKernel-Building-CLR.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/09-SemanticKernel-Building-CLR.ipynb
@@ -215,7 +215,7 @@
     "Nous allons :  \n",
     "1. **Modifier** le chemin Python (`sys.path`) pour inclure le dossier où se trouve la DLL .NET.  \n",
     "2. **Charger** la DLL (`clr.AddReference`)  \n",
-    "3. **Importer** les namespaces/classes C# (ex. `MyIA.AI.Notebooks`).\n",
+    "3. **Importer** les namespaces/classes C# du namespace `MyNotebookLib` (l'assembly se nomme `MyIA.AI.Notebooks.dll`, mais les types exposés vivent dans `MyNotebookLib`).\n",
     "\n",
     "Note : Adaptez `dll_path` si nécessaire."
    ]
@@ -337,12 +337,17 @@
     "tags": []
    },
    "source": [
-    "## Bloc 3 : Import des classes C# du namespace `MyIA.AI.Notebooks`\n",
+    "## Bloc 3 : Import des classes C# depuis l'assembly `MyIA.AI.Notebooks`\n",
     "\n",
-    "On suppose que les classes suivantes sont exposées :\n",
-    "- **`AutoInvokeSKAgentsNotebookUpdater`**  \n",
-    "- **`DisplayLogger`** (et son provider)  \n",
-    "- etc.\n",
+    "L'assembly se nomme `MyIA.AI.Notebooks.dll`, mais les classes C# qu'elle expose vivent dans le **namespace `MyNotebookLib`** (à vérifier dans la sortie de la cellule suivante via `GetExportedTypes()`) :\n",
+    "\n",
+    "- **`MyNotebookLib.AutoInvokeSKAgentsNotebookUpdater`** — l'updater d'agents Semantic Kernel\n",
+    "- **`MyNotebookLib.AutoGenNotebookUpdater`** — updater AutoGen\n",
+    "- **`MyNotebookLib.DisplayLogger`** et **`DisplayLoggerProvider`** — logger intégré au notebook\n",
+    "- **`MyNotebookLib.NotebookExecutor`**, **`NotebookPlannerUpdater`**, **`NotebookUpdaterBase`**\n",
+    "- **`MyNotebookLib.GuessingGame`** — exemple de classe .NET callable depuis Python\n",
+    "\n",
+    "> **Attention** : le nom de l'assembly (`MyIA.AI.Notebooks`) diffère du namespace C# (`MyNotebookLib`). L'import Python doit cibler `MyNotebookLib`, pas `MyIA.AI.Notebooks`.\n",
     "\n",
     "Ensuite, on pourra instancier et exécuter du code C# directement depuis Python."
    ]


### PR DESCRIPTION
## Defect (case-A claims↔outputs)

`cell[7]` and `cell[10]` markdown told students the C# namespace is `MyIA.AI.Notebooks`. That is the **assembly name**, not the namespace.

`cell[11]` output (`GetExportedTypes()`, deterministic) proves the types live in **`MyNotebookLib`**:
```
✅ Assembly trouvé: MyIA.AI.Notebooks        <- assembly name
  -> MyNotebookLib.AutoInvokeSKAgentsNotebookUpdater
  -> MyNotebookLib.DisplayLogger
  -> MyNotebookLib.GuessingGame
  ...
```
Confirmed firsthand in the `.cs` sources — `AutoInvokeSKAgentsNotebookUpdater.cs`, `DisplayLogger.cs`, `GuessingGame.cs` all declare `namespace MyNotebookLib`.

## Why it matters (root-cause cascade)

The wrong namespace in markdown is the root cause of `cell[16]`'s failure: its commented import `# from MyIA.AI.Notebooks import DisplayLogger` targets the non-existent namespace, and `cell[16]` outputs `❌ classe non disponible`. Correcting the markdown stops students repeating the import mistake. `cell[10]` now also lists the actual exported types from `cell[11]`.

## Changes (11 ins / 6 del, markdown-only)

- **cell[7]** point 3: namespace example `MyIA.AI.Notebooks` → `MyNotebookLib` (+ clarify assembly name vs namespace).
- **cell[10]**: heading + body corrected to `MyNotebookLib`; lists the real exported types; warning note that assembly name ≠ namespace.

All code cells and their outputs are byte-identical to `origin/main` (**C.2 markdown exception — no re-exec needed**). H.3 + C.1 clean.

## Scope honesty (#8364)

The deeper defects require re-executing the pythonnet CLR cells (`cell[8]` machine-path leak, `cell[12]` `ReflectionTypeLoadException`, `cell[16]` "classe non disponible"), which needs the compiled `MyIA.AI.Notebooks.dll`. Building it on a worker lane is **RECOVERABLE-MACHINE**: `dotnet build MyIA.AI.Notebooks.csproj` fails with 223 errors — the mega-project globs all repo `.cs` incl. `OwlAdapter` needing dotNetRDF (`RDFResource`/`OWLOntology`), deps not restored. The committed DLL outputs came from an env not reproducible here. **Not consecrated**: `cell[8]`/`[12]`/`[16]` outputs left as-is, flagged for a DLL-build-capable machine.

See #8052 (claims↔outputs EPIC). Markdown-only, so no `Closes` — the deeper CLR re-exec remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)