### PR TITLE
fix(twin-register,#8057): ecriture chirurgicale du registre + provenance horodatee

### DIFF
--- a/.github/workflows/twin-parity.yml
+++ b/.github/workflows/twin-parity.yml
@@ -28,7 +28,7 @@ name: Twin Parity Check
 # Pattern: the worker who edits a twin must either re-audit and rebaseline the
 # SHAs in the registry -- `python scripts/notebook_tools/check_twin_parity.py
 # --update --pair "<entry name>" --by "<machine:workspace>"` (the selector is
-# mandatory, cf #8508; the write is surgical, cf #8568) -- OR split the edit so
+# mandatory, cf #8508; the write is surgical, cf #8570) -- OR split the edit so
 # the twin moves in lockstep on the same PR. The workflow tells them which side
 # has drifted.
 #
@@ -101,12 +101,12 @@ jobs:
             echo "  Re-audite la paire firsthand, puis lance exactement :"
             echo ""
             python -c "import json; d=json.load(open('twin_parity_report.json')); ns=[p['name'] for p in d.get('pairs',[]) if p.get('verdict')=='DRIFT_INTRODUCED'] or ['<nom exact de l entree>']; [print('    python scripts/notebook_tools/check_twin_parity.py --update --pair \"%s\" --by \"<machine:workspace>\"' % n) for n in ns]"
-            echo "  L'ecriture est chirurgicale (#8568) : seules les lignes"
+            echo "  L'ecriture est chirurgicale (#8570) : seules les lignes"
             echo "  last_audit de cette paire changent. Ajoute une ligne en tete"
             echo "  de known_differences expliquant l'edition, puis commit."
             echo "--------------------------------------------------------------"
             echo ""
-            echo "::error title=Twin parity DRIFT INTRODUCED by this PR::La PR a introduit $INTRO paire(s) en DRIFT/MISSING qui etaient OK au base-ref origin/main. La commande de rebaseline exacte (avec le nom de la paire) est imprimee juste au-dessus dans ce log. Le selecteur --pair est obligatoire (#8508, lecons L963/L974) ; l'ecriture est chirurgicale et preserve les commentaires du registre (#8568). Alternative : splitter la PR pour que chaque cote evolue separement. Drift pre-existant ($PRE paire(s)) releve d'une PR dediee cf #8264. Voir twin_parity_report.json dans les artifacts."
+            echo "::error title=Twin parity DRIFT INTRODUCED by this PR::La PR a introduit $INTRO paire(s) en DRIFT/MISSING qui etaient OK au base-ref origin/main. La commande de rebaseline exacte (avec le nom de la paire) est imprimee juste au-dessus dans ce log. Le selecteur --pair est obligatoire (#8508, lecons L963/L974) ; l'ecriture est chirurgicale et preserve les commentaires du registre (#8570). Alternative : splitter la PR pour que chaque cote evolue separement. Drift pre-existant ($PRE paire(s)) releve d'une PR dediee cf #8264. Voir twin_parity_report.json dans les artifacts."
             exit 1
           else
             echo "::error title=Twin parity tool error::Erreur d'execution du check (exit $EXIT). Voir les logs ci-dessus."

--- a/.github/workflows/twin-parity.yml
+++ b/.github/workflows/twin-parity.yml
@@ -25,10 +25,12 @@ name: Twin Parity Check
 # #8372). This keeps the gate green for legitimate single-side edits while
 # still surfacing fleet-wide stale SHAs through the report.
 #
-# Pattern: the worker who edits a twin must either re-audit (and rebaseline
-# the SHAs in the registry, `python scripts/notebook_tools/check_twin_parity.py --update`)
-# OR split the edit so the twin moves in lockstep on the same PR. The
-# workflow tells them which side has drifted.
+# Pattern: the worker who edits a twin must either re-audit and rebaseline the
+# SHAs in the registry -- `python scripts/notebook_tools/check_twin_parity.py
+# --update --pair "<entry name>" --by "<machine:workspace>"` (the selector is
+# mandatory, cf #8508; the write is surgical, cf #8568) -- OR split the edit so
+# the twin moves in lockstep on the same PR. The workflow tells them which side
+# has drifted.
 #
 # Paths watched:
 #   - scripts/notebook_tools/twin_pairs.yaml (registry)
@@ -89,7 +91,22 @@ jobs:
             PRE=$(python -c "import json; d=json.load(open('twin_parity_report.json')); print(d.get('drift_pre_existing',0))")
             echo "drift_introduced=$INTRO" >> "$GITHUB_OUTPUT"
             echo "drift_pre_existing=$PRE" >> "$GITHUB_OUTPUT"
-            echo "::error title=Twin parity DRIFT INTRODUCED by this PR::La PR a introduit $INTRO paire(s) en DRIFT/MISSING qui etaient OK au base-ref origin/main. Action : re-auditer la paire firsthand PUIS rebaseline UNIQUEMENT cette entree dans le registre (methode manuelle, JAMAIS --update sans selecteur -- cf issue #8508 et lecons L963/L974) : 1) Calculer le SHA du notebook modifie : \`git rev-parse HEAD:<chemin-du-notebook>\` ; 2) Editer \`scripts/notebook_tools/twin_pairs.yaml\` a la main, mettre a jour \`python_sha\`/\`csharp_sha\` + \`date\` + \`by\` pour CETTE entree seulement ; 3) OU splitter la PR pour que chaque cote evolue separement avec rebaseline isole. Drift pre-existant ($PRE paire(s)) releve d'une PR dediee cf #8264. Voir twin_parity_report.json dans les artifacts."
+            echo ""
+            echo "--------------------------------------------------------------"
+            echo "  Twin parity : $INTRO paire(s) mise(s) en DRIFT par cette PR."
+            echo "  Le registre stocke le git blob SHA de chaque jumeau : TOUTE"
+            echo "  edition le deplace, y compris markdown-only. Tu rebaselines"
+            echo "  pour ATTESTER la parite, pas pour la reparer."
+            echo ""
+            echo "  Re-audite la paire firsthand, puis lance exactement :"
+            echo ""
+            python -c "import json; d=json.load(open('twin_parity_report.json')); ns=[p['name'] for p in d.get('pairs',[]) if p.get('verdict')=='DRIFT_INTRODUCED'] or ['<nom exact de l entree>']; [print('    python scripts/notebook_tools/check_twin_parity.py --update --pair \"%s\" --by \"<machine:workspace>\"' % n) for n in ns]"
+            echo "  L'ecriture est chirurgicale (#8568) : seules les lignes"
+            echo "  last_audit de cette paire changent. Ajoute une ligne en tete"
+            echo "  de known_differences expliquant l'edition, puis commit."
+            echo "--------------------------------------------------------------"
+            echo ""
+            echo "::error title=Twin parity DRIFT INTRODUCED by this PR::La PR a introduit $INTRO paire(s) en DRIFT/MISSING qui etaient OK au base-ref origin/main. La commande de rebaseline exacte (avec le nom de la paire) est imprimee juste au-dessus dans ce log. Le selecteur --pair est obligatoire (#8508, lecons L963/L974) ; l'ecriture est chirurgicale et preserve les commentaires du registre (#8568). Alternative : splitter la PR pour que chaque cote evolue separement. Drift pre-existant ($PRE paire(s)) releve d'une PR dediee cf #8264. Voir twin_parity_report.json dans les artifacts."
             exit 1
           else
             echo "::error title=Twin parity tool error::Erreur d'execution du check (exit $EXIT). Voir les logs ci-dessus."

--- a/scripts/notebook_tools/check_twin_parity.py
+++ b/scripts/notebook_tools/check_twin_parity.py
@@ -222,7 +222,7 @@ def update_pair(
     un rebaseline qui conserverait le `by`/`date` de l'audit precedent ferait
     affirmer a l'entree « auditee par <l'auditeur d'avant> le <la date d'avant> »
     alors que les SHAs sont ceux d'aujourd'hui -- la tracabilite mentirait, ce
-    que le registre existe precisement pour empecher (cf #8568).
+    que le registre existe precisement pour empecher (cf #8570).
 
     Retourne (last_audit_dict mis a jour, sha_utilise_pour_python ou None si missing).
     """
@@ -257,7 +257,7 @@ def surgical_rebaseline(raw: str, updates: dict[str, dict]) -> tuple[str, int]:
     """Reecrit UNIQUEMENT les lignes `last_audit` des paires ciblees.
 
     Pourquoi ne pas re-serialiser via `yaml.safe_dump` (comportement d'avant
-    #8568) : un dump complet detruit **tout** le fichier autour des donnees.
+    #8570) : un dump complet detruit **tout** le fichier autour des donnees.
     Mesure firsthand sur le registre a 116 paires -- un rebaseline d'UNE paire
     produisait `1108 insertions(+), 658 deletions(-)` et supprimait les **67
     lignes de commentaire**, dont l'en-tete de 15 lignes qui documente le
@@ -525,7 +525,7 @@ def main(argv=None) -> int:
             updates[pp["name"]] = audit
         # Rebaseline CHIRURGICAL : seules les lignes `last_audit` des paires
         # ciblees changent. Un `yaml.safe_dump` complet (comportement d'avant
-        # #8568) reformatait les ~1475 lignes et supprimait les 67 commentaires
+        # #8570) reformatait les ~1475 lignes et supprimait les 67 commentaires
         # du registre, dont l'en-tete qui documente le schema.
         raw = reg_path.read_text(encoding="utf-8")
         new_raw, updated = surgical_rebaseline(raw, updates)

--- a/scripts/notebook_tools/check_twin_parity.py
+++ b/scripts/notebook_tools/check_twin_parity.py
@@ -29,7 +29,17 @@ Pour chaque paire du registre, on :
   5. **OK** sinon (les deux cotes sont au SHA audite, parite tenue).
 
 Le bouclage d'audit : apres avoir re-audite une paire firsthand, on rebaseline
-avec `--update` qui reecrit les SHAs courants comme nouvelle reference.
+avec `--update --pair "<nom>" --by "<lane>"`, qui reecrit les SHAs courants
+comme nouvelle reference.
+
+`--update` EXIGE un selecteur (`--pair`, `--family`, ou l'opt-in
+`--yes-all-pairs`) : sans lui, il reecrirait le `last_audit` des 116 paires et
+masquerait des DRIFTs legitimes (#8508, lecons L963/L974). `--by` horodate
+l'audit a ton nom -- la date est toujours remise a aujourd'hui.
+
+L'ecriture est CHIRURGICALE : seules les lignes `last_audit` des paires ciblees
+changent (cf `surgical_rebaseline`). Le diff d'un rebaseline vaut donc les
+lignes reellement modifiees, commentaires et formatage du registre intacts.
 
 Cet outil lit seulement par defaut (git ls-tree). Le mode `--update` ecrit le
 registre (curated YAML, pas un notebook -> pas de souci de re-exec C.2).
@@ -42,8 +52,11 @@ Usage
     python check_twin_parity.py --check
     # restreindre a une famille
     python check_twin_parity.py --family SMT/Z3-API
-    # rebaseline apres audit firsthand (ecrit les SHAs courants)
-    python check_twin_parity.py --update
+    # rebaseline apres audit firsthand (ecrit les SHAs courants).
+    # --pair + --by obligatoires en pratique : le selecteur evite de rebaseliner
+    # les 116 paires, --by evite d'heriter de l'auteur de l'audit precedent.
+    python check_twin_parity.py --update --pair "Probas-4 Bayesian-Networks" \
+        --by "myia-po-2024:CoursIA-2"
     # sortie machine
     python check_twin_parity.py --json
     # mode per-pair : ne FAIL que sur le drift INTRODUIT par la PR en cours
@@ -71,7 +84,9 @@ Voir aussi
 from __future__ import annotations
 
 import argparse
+import datetime as _dt
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -82,6 +97,9 @@ except ImportError:  # pragma: no cover
     yaml = None
 
 DEFAULT_REGISTRY = Path(__file__).resolve().parent / "twin_pairs.yaml"
+
+# Sentinelle : distingue « cle absente de l'update » de « valeur None ».
+_MISSING = object()
 
 
 def _git_blob_sha(repo_root: Path, rel_path: str, git_ref: str = "HEAD") -> str | None:
@@ -195,8 +213,16 @@ def check_pair(repo_root: Path, pair: dict, git_ref: str = "HEAD") -> dict:
     }
 
 
-def update_pair(repo_root: Path, pair: dict) -> tuple[dict, str | None]:
+def update_pair(
+    repo_root: Path, pair: dict, by: str | None = None, date: str | None = None
+) -> tuple[dict, str | None]:
     """Rebaseline une paire : enregistre les SHAs courants comme nouvelle ref.
+
+    `by` / `date` horodatent l'audit. Ils sont OBLIGATOIREMENT rafraichis :
+    un rebaseline qui conserverait le `by`/`date` de l'audit precedent ferait
+    affirmer a l'entree « auditee par <l'auditeur d'avant> le <la date d'avant> »
+    alors que les SHAs sont ceux d'aujourd'hui -- la tracabilite mentirait, ce
+    que le registre existe precisement pour empecher (cf #8568).
 
     Retourne (last_audit_dict mis a jour, sha_utilise_pour_python ou None si missing).
     """
@@ -204,15 +230,84 @@ def update_pair(repo_root: Path, pair: dict) -> tuple[dict, str | None]:
     cs = pair["csharp"]
     cur_py = _git_blob_sha(repo_root, py)
     cur_cs = _git_blob_sha(repo_root, cs)
-    today = pair.get("last_audit", {}).get("date")  # conserve si deja la
-    by = pair.get("last_audit", {}).get("by", "manual")
     audit = {
-        "date": today,
-        "by": by,
+        "date": date or _dt.date.today().isoformat(),
+        "by": by or pair.get("last_audit", {}).get("by", "manual"),
         "python_sha": cur_py,
         "csharp_sha": cur_cs,
     }
     return audit, cur_py
+
+
+# Cles scalaires du bloc `last_audit` reecrites par le rebaseline chirurgical.
+_AUDIT_KEYS = ("date", "by", "python_sha", "csharp_sha")
+
+
+def _fmt_audit_value(key: str, value) -> str:
+    """Rend une valeur de `last_audit` dans le style du registre.
+
+    `date` est quotee (comme les 116 entrees existantes), le reste est nu.
+    """
+    if value is None:
+        return "null"
+    return f'"{value}"' if key == "date" else str(value)
+
+
+def surgical_rebaseline(raw: str, updates: dict[str, dict]) -> tuple[str, int]:
+    """Reecrit UNIQUEMENT les lignes `last_audit` des paires ciblees.
+
+    Pourquoi ne pas re-serialiser via `yaml.safe_dump` (comportement d'avant
+    #8568) : un dump complet detruit **tout** le fichier autour des donnees.
+    Mesure firsthand sur le registre a 116 paires -- un rebaseline d'UNE paire
+    produisait `1108 insertions(+), 658 deletions(-)` et supprimait les **67
+    lignes de commentaire**, dont l'en-tete de 15 lignes qui documente le
+    schema et le vocabulaire `parity_level`. Le vrai changement (4 lignes)
+    devenait irreviewable, et la documentation du registre disparaissait sans
+    que personne ne l'ait demande.
+
+    L'edition ligne-a-ligne ci-dessous preserve commentaires, ordre, quoting et
+    espacement : le diff d'un rebaseline vaut exactement les lignes changees.
+
+    Args:
+        raw: contenu texte du registre YAML.
+        updates: {nom_de_paire: {"date":.., "by":.., "python_sha":.., "csharp_sha":..}}
+
+    Returns:
+        (nouveau_texte, nombre_de_paires_effectivement_touchees)
+    """
+    out: list[str] = []
+    current: str | None = None
+    in_audit = False
+    touched: set[str] = set()
+
+    for line in raw.splitlines(keepends=True):
+        m_entry = re.match(r"^-\s+name:\s*(.+?)\s*$", line)
+        if m_entry:
+            current = m_entry.group(1).strip().strip("\"'")
+            in_audit = False
+        elif re.match(r"^\s{2}last_audit:\s*$", line):
+            in_audit = current in updates
+        elif re.match(r"^\s{2}\S", line):
+            # toute autre cle de premier niveau de l'entree ferme le bloc
+            in_audit = False
+
+        if in_audit:
+            m_kv = re.match(r"^(\s+)(\w+):\s*(.*)$", line)
+            if m_kv and m_kv.group(2) in _AUDIT_KEYS:
+                key = m_kv.group(2)
+                new = updates[current].get(key, _MISSING)
+                # On ne reecrit que si la VALEUR change : sinon un rebaseline
+                # sur une paire deja a jour normaliserait le quoting (le
+                # registre melange 'x' et "x") et polluerait le diff de lignes
+                # sans changement reel.
+                old = m_kv.group(3).strip().strip("\"'")
+                if new is not _MISSING and str(new) != old:
+                    line = f"{m_kv.group(1)}{key}: {_fmt_audit_value(key, new)}\n"
+                    touched.add(current)
+
+        out.append(line)
+
+    return "".join(out), len(touched)
 
 
 def _classify_per_pair(base_status: str, head_status: str) -> str:
@@ -262,6 +357,11 @@ def main(argv=None) -> int:
     p.add_argument("--yes-all-pairs", action="store_true",
                    help="Opt-in explicite pour rebaseline TOUTES les paires du registre "
                         "avec --update. Sans ce flag (ou --family/--pair), --update refuse.")
+    p.add_argument("--by", default=None,
+                   help="Auteur de l'audit inscrit dans last_audit.by (ex. "
+                        "'myia-po-2024:CoursIA-2'). Avec --update, la date est "
+                        "TOUJOURS mise a aujourd'hui : sans --by, l'entree garderait "
+                        "l'auteur de l'audit precedent alors que les SHAs sont neufs.")
     args = p.parse_args(argv)
 
     # Cross-validation : --per-pair <-> --base
@@ -415,19 +515,26 @@ def main(argv=None) -> int:
         else:
             # --yes-all-pairs (filet anti-corruption silencieuse, cf #8508)
             target = all_pairs
-        updated = 0
+        updates: dict[str, dict] = {}
+        skipped: list[str] = []
         for pp in target:
-            audit, cur_py = update_pair(repo_root, pp)
-            if cur_py is not None:
-                pp["last_audit"] = audit
-                updated += 1
-        # re-ecrit le registre ENTIER (conserve l'ordre + les autres paires)
-        if yaml is None:
-            raise SystemExit("Erreur : PyYAML requis pour --update.")
-        reg_path.write_text(
-            yaml.safe_dump(all_pairs, sort_keys=False, allow_unicode=True, width=100),
-            encoding="utf-8",
-        )
+            audit, cur_py = update_pair(repo_root, pp, by=args.by)
+            if cur_py is None:
+                skipped.append(pp.get("name", "?"))
+                continue
+            updates[pp["name"]] = audit
+        # Rebaseline CHIRURGICAL : seules les lignes `last_audit` des paires
+        # ciblees changent. Un `yaml.safe_dump` complet (comportement d'avant
+        # #8568) reformatait les ~1475 lignes et supprimait les 67 commentaires
+        # du registre, dont l'en-tete qui documente le schema.
+        raw = reg_path.read_text(encoding="utf-8")
+        new_raw, updated = surgical_rebaseline(raw, updates)
+        reg_path.write_text(new_raw, encoding="utf-8")
+        if skipped:
+            print(
+                f"Ignorees (notebook absent de git) : {', '.join(skipped)}",
+                file=sys.stderr,
+            )
         msg = f"Registre rebaseline : {updated} paire(s) mise(s) a jour -> {reg_path}"
         print(msg)
         return 0

--- a/scripts/notebook_tools/tests/test_check_twin_parity_surgical.py
+++ b/scripts/notebook_tools/tests/test_check_twin_parity_surgical.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Rebaseline chirurgical du registre de jumeaux (#8568).
+
+Avant : `--update` (meme avec un selecteur) re-serialisait le registre entier
+via `yaml.safe_dump`. Mesure firsthand sur les 116 paires -- rebaseliner UNE
+paire produisait `1108 insertions(+), 658 deletions(-)` et supprimait les **67
+lignes de commentaire** du fichier, dont l'en-tete de 15 lignes qui documente
+le schema et le vocabulaire `parity_level`. Consequences :
+
+  * le vrai changement (4 lignes) devenait irreviewable -- motif poison-catalogue
+    applique au registre ;
+  * la documentation du registre disparaissait silencieusement ;
+  * `update_pair()` conservait par-dessus le marche `date`/`by` de l'audit
+    PRECEDENT, donc l'entree affirmait « auditee par X le <date d'avant> » avec
+    des SHAs d'aujourd'hui -- la tracabilite mentait.
+
+C'est pourquoi la remediation CI prescrivait l'edition manuelle. Depuis #8568
+l'ecriture est chirurgicale et la provenance est horodatee : la commande courte
+redevient la bonne.
+
+Ces tests couvrent :
+    1. les commentaires du registre survivent a un `--update --pair`
+    2. le diff se limite au bloc `last_audit` de la paire ciblee
+    3. un rebaseline sans changement de valeur est un no-op byte-identique
+    4. `--by` inscrit l'auteur et la date est remise a aujourd'hui
+    5. les autres paires restent byte-identiques
+
+Run:
+    pytest scripts/notebook_tools/tests/test_check_twin_parity_surgical.py
+"""
+from __future__ import annotations
+
+import datetime as dt
+import importlib.util
+import shutil
+from pathlib import Path
+
+import pytest
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent
+SCRIPT = SCRIPT_DIR / "check_twin_parity.py"
+REGISTRY = SCRIPT_DIR / "twin_pairs.yaml"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("check_twin_parity", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+ctp = _load_module()
+
+
+@pytest.fixture
+def registry_backup():
+    """Sauvegarde + restauration du registre autour de chaque test."""
+    if not REGISTRY.exists():
+        pytest.skip(f"registre introuvable : {REGISTRY}")
+    backup = REGISTRY.with_suffix(".yaml.bak.c8568")
+    shutil.copy2(REGISTRY, backup)
+    try:
+        yield REGISTRY
+    finally:
+        shutil.copy2(backup, REGISTRY)
+        backup.unlink(missing_ok=True)
+
+
+def _first_pair_name(raw: str) -> str:
+    for line in raw.splitlines():
+        if line.startswith("- name:"):
+            return line.split(":", 1)[1].strip().strip("\"'")
+    pytest.skip("registre sans entree exploitable")
+
+
+def test_comments_survive_surgical_rebaseline(registry_backup):
+    """Le bug fondateur : `safe_dump` supprimait les 67 commentaires."""
+    raw = REGISTRY.read_text(encoding="utf-8")
+    name = _first_pair_name(raw)
+    before = sum(1 for line in raw.splitlines() if line.lstrip().startswith("#"))
+    assert before > 0, "le registre doit porter son en-tete documentaire"
+
+    new_raw, _ = ctp.surgical_rebaseline(raw, {name: {"by": "test-lane"}})
+    after = sum(1 for line in new_raw.splitlines() if line.lstrip().startswith("#"))
+    assert after == before, "un rebaseline ne doit supprimer aucun commentaire"
+
+
+def test_diff_limited_to_target_block(registry_backup):
+    """Seules les lignes changees de la paire ciblee bougent."""
+    raw = REGISTRY.read_text(encoding="utf-8")
+    name = _first_pair_name(raw)
+
+    new_raw, touched = ctp.surgical_rebaseline(
+        raw, {name: {"by": "sentinelle-c8568", "date": "1999-01-01"}}
+    )
+    assert touched == 1
+
+    before, after = raw.splitlines(), new_raw.splitlines()
+    assert len(before) == len(after), "aucune ligne ajoutee ni supprimee"
+    changed = [i for i, (b, a) in enumerate(zip(before, after)) if b != a]
+    assert len(changed) == 2, f"attendu 2 lignes (date + by), obtenu {len(changed)}"
+    assert all("sentinelle-c8568" in after[i] or "1999-01-01" in after[i]
+               for i in changed)
+
+
+def test_noop_is_byte_identical(registry_backup):
+    """Rebaseliner vers les valeurs deja en place ne produit aucun churn.
+
+    Sans cette garantie, un rebaseline sur une paire a jour normaliserait le
+    quoting (le registre melange 'x' et "x") et polluerait le diff.
+    """
+    raw = REGISTRY.read_text(encoding="utf-8")
+    name = _first_pair_name(raw)
+    import yaml
+
+    entry = next(p for p in yaml.safe_load(raw) if p["name"] == name)
+    audit = entry["last_audit"]
+
+    new_raw, touched = ctp.surgical_rebaseline(
+        raw,
+        {name: {"date": str(audit["date"]), "by": audit["by"],
+                "python_sha": audit["python_sha"], "csharp_sha": audit["csharp_sha"]}},
+    )
+    assert touched == 0
+    assert new_raw == raw, "un no-op doit etre byte-identique"
+
+
+def test_update_pair_stamps_fresh_provenance():
+    """`by` et `date` sont rafraichis : la tracabilite ne doit pas mentir."""
+    pair = {
+        "python": "does/not/exist-a.ipynb",
+        "csharp": "does/not/exist-b.ipynb",
+        "last_audit": {"date": "2020-01-01", "by": "auditeur-precedent"},
+    }
+    audit, _ = ctp.update_pair(Path("."), pair, by="myia-ai-01:CoursIA")
+    assert audit["by"] == "myia-ai-01:CoursIA", "--by doit primer sur l'ancien auteur"
+    assert audit["date"] == dt.date.today().isoformat(), (
+        "la date doit etre celle du rebaseline, pas celle de l'audit precedent"
+    )
+
+
+def test_other_pairs_untouched(registry_backup):
+    """Rebaseliner une paire ne doit rien changer aux 115 autres."""
+    import yaml
+
+    raw = REGISTRY.read_text(encoding="utf-8")
+    name = _first_pair_name(raw)
+    new_raw, _ = ctp.surgical_rebaseline(raw, {name: {"by": "sentinelle-c8568"}})
+
+    before = {p["name"]: p["last_audit"] for p in yaml.safe_load(raw)}
+    after = {p["name"]: p["last_audit"] for p in yaml.safe_load(new_raw)}
+    assert set(before) == set(after), "aucune paire ajoutee ni perdue"
+    for other in before:
+        if other != name:
+            assert before[other] == after[other], f"paire {other} modifiee a tort"

--- a/scripts/notebook_tools/tests/test_check_twin_parity_surgical.py
+++ b/scripts/notebook_tools/tests/test_check_twin_parity_surgical.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Rebaseline chirurgical du registre de jumeaux (#8568).
+"""Rebaseline chirurgical du registre de jumeaux (#8570).
 
 Avant : `--update` (meme avec un selecteur) re-serialisait le registre entier
 via `yaml.safe_dump`. Mesure firsthand sur les 116 paires -- rebaseliner UNE
@@ -14,7 +14,7 @@ le schema et le vocabulaire `parity_level`. Consequences :
     PRECEDENT, donc l'entree affirmait « auditee par X le <date d'avant> » avec
     des SHAs d'aujourd'hui -- la tracabilite mentait.
 
-C'est pourquoi la remediation CI prescrivait l'edition manuelle. Depuis #8568
+C'est pourquoi la remediation CI prescrivait l'edition manuelle. Depuis #8570
 l'ecriture est chirurgicale et la provenance est horodatee : la commande courte
 redevient la bonne.
 
@@ -57,7 +57,7 @@ def registry_backup():
     """Sauvegarde + restauration du registre autour de chaque test."""
     if not REGISTRY.exists():
         pytest.skip(f"registre introuvable : {REGISTRY}")
-    backup = REGISTRY.with_suffix(".yaml.bak.c8568")
+    backup = REGISTRY.with_suffix(".yaml.bak.c8570")
     shutil.copy2(REGISTRY, backup)
     try:
         yield REGISTRY
@@ -91,7 +91,7 @@ def test_diff_limited_to_target_block(registry_backup):
     name = _first_pair_name(raw)
 
     new_raw, touched = ctp.surgical_rebaseline(
-        raw, {name: {"by": "sentinelle-c8568", "date": "1999-01-01"}}
+        raw, {name: {"by": "sentinelle-c8570", "date": "1999-01-01"}}
     )
     assert touched == 1
 
@@ -99,7 +99,7 @@ def test_diff_limited_to_target_block(registry_backup):
     assert len(before) == len(after), "aucune ligne ajoutee ni supprimee"
     changed = [i for i, (b, a) in enumerate(zip(before, after)) if b != a]
     assert len(changed) == 2, f"attendu 2 lignes (date + by), obtenu {len(changed)}"
-    assert all("sentinelle-c8568" in after[i] or "1999-01-01" in after[i]
+    assert all("sentinelle-c8570" in after[i] or "1999-01-01" in after[i]
                for i in changed)
 
 
@@ -145,7 +145,7 @@ def test_other_pairs_untouched(registry_backup):
 
     raw = REGISTRY.read_text(encoding="utf-8")
     name = _first_pair_name(raw)
-    new_raw, _ = ctp.surgical_rebaseline(raw, {name: {"by": "sentinelle-c8568"}})
+    new_raw, _ = ctp.surgical_rebaseline(raw, {name: {"by": "sentinelle-c8570"}})
 
     before = {p["name"]: p["last_audit"] for p in yaml.safe_load(raw)}
     after = {p["name"]: p["last_audit"] for p in yaml.safe_load(new_raw)}

--- a/scripts/notebook_tools/twin_pairs.yaml
+++ b/scripts/notebook_tools/twin_pairs.yaml
@@ -6,8 +6,13 @@
 #
 # Le check `check_twin_parity.py` compare le SHA courant (git ls-tree HEAD) au
 # SHA audite : DRIFT = un cote a evolue sans re-audit -> parite a reverifier.
-# Apres une audit firsthand, rebaseline avec :
-#   python scripts/notebook_tools/check_twin_parity.py --update [--family ...]
+# Apres une audit firsthand, rebaseline UNE paire avec :
+#   python scripts/notebook_tools/check_twin_parity.py --update \
+#       --pair "<nom exact de l'entree>" --by "<machine:workspace>"
+# `--update` refuse de tourner sans selecteur (--pair / --family / --yes-all-pairs) :
+# sans lui il rebaselinerait les 116 paires d'un coup et masquerait des DRIFTs
+# legitimes (#8508). L'ecriture est chirurgicale : seules les lignes `last_audit`
+# de la paire ciblee changent, ce fichier garde ses commentaires (#8568).
 #
 # parity_level :
 #   surface     = meme plan/sections, implimentations independantes

--- a/scripts/notebook_tools/twin_pairs.yaml
+++ b/scripts/notebook_tools/twin_pairs.yaml
@@ -12,7 +12,7 @@
 # `--update` refuse de tourner sans selecteur (--pair / --family / --yes-all-pairs) :
 # sans lui il rebaselinerait les 116 paires d'un coup et masquerait des DRIFTs
 # legitimes (#8508). L'ecriture est chirurgicale : seules les lignes `last_audit`
-# de la paire ciblee changent, ce fichier garde ses commentaires (#8568).
+# de la paire ciblee changent, ce fichier garde ses commentaires (#8570).
 #
 # parity_level :
 #   surface     = meme plan/sections, implimentations independantes


### PR DESCRIPTION
Grain: MED/tooling-infra — lane myia-ai-01:CoursIA — prev: MED/tooling-infra (#8504)

> **Note G-VAR-3.** Deuxième `MED/tooling-infra` consécutif sur ma lane, déclaré tel quel plutôt que renommé pour esquiver le gate. Substance genuinement distincte : #8504 traitait le *conflit de merge* du registre (driver `union` + garde d'intégrité) ; celle-ci traite le *chemin d'écriture* de l'outil (sérialisation destructive, provenance falsifiée, doc qui pointe une commande en erreur). Défaut différent, trouvé par mesure et non par scan — le litmus LIGHT (« j'en génère une douzaine en scannant l'instance suivante ») ne passe pas.

## Pourquoi cette PR

Quatre PRs ouvertes — #8548, #8549, #8556, #8557 — échouent le gate twin-parity pour exactement la même raison. Quatre workers différents, même mur. Ce n'est pas quatre erreurs : c'est une **affordance manquante**.

Le gate est correct et doit rester bloquant : le registre stocke le git blob SHA de chaque jumeau, donc toute édition — y compris markdown-only — le déplace, et le worker doit **attester** la parité en rebaselinant. Le problème est qu'aucun chemin praticable ne menait à cette attestation :

- la doc prescrivait `--update` **nu**, que l'outil **refuse** depuis #8508 (garde `check_twin_parity.py:275-279`) ;
- le worker qui butait improvisait, et le seul chemin court restant était **destructeur**.

## Les quatre défauts, mesurés firsthand

**1. Destruction des commentaires — le plus grave.** `--update` re-sérialisait le registre entier via `yaml.safe_dump`. Les **67 lignes de commentaire** disparaissaient, dont l'en-tête de 15 lignes qui documente le schéma et le vocabulaire `parity_level`. Perte de connaissance silencieuse et irréversible.

```
$ grep -c '^#' twin_pairs.yaml   # avant : 67
$ python check_twin_parity.py --update --pair "…"
$ grep -c '^#' twin_pairs.yaml   # après : 0
```

**2. Churn massif.** Rebaseliner **une** paire déjà OK produisait :

```
scripts/notebook_tools/twin_pairs.yaml | 1766 ++++++++++--------------
1 file changed, 1108 insertions(+), 658 deletions(-)
```

Le vrai changement — 4 lignes — devenait irreviewable. C'est le motif poison-catalogue, appliqué au registre : un artefact regénéré en bloc noie la substance et empêche le review.

**3. Provenance falsifiée.** `update_pair()` conservait le `date`/`by` de l'audit **précédent** tout en écrivant les SHAs du jour. L'entrée affirmait « auditée par X le \<date d'avant\> » avec des empreintes neuves. Le registre est censé porter une métadonnée *auditable, pas déclarative* (#8057) — en l'état il mentait.

**4. Doc trompeuse, en quatre endroits.** Tous prescrivaient le `--update` nu : en-tête du registre l.10, docstring l.32 et l.46, en-tête du workflow l.29. Le worker qui suit la doc se prend une erreur — voilà les quatre PRs sans rebaseline.

## Ce que change cette PR

**Écriture chirurgicale.** `surgical_rebaseline()` réécrit le fichier ligne à ligne : seules les lignes `last_audit` de la paire ciblée changent, et **uniquement si la valeur change réellement** — sans cette dernière condition, un rebaseline no-op normaliserait le quoting (le registre mélange `'x'` et `"x"`) et repolluerait le diff.

| | avant | après |
|---|---|---|
| rebaseline d'une paire | 1766 lignes | **4 lignes** |
| commentaires | 67 → **0** | 67 → **67** |
| no-op | churn de quoting | **byte-identique** |

**Provenance horodatée.** `--by <machine:workspace>` inscrit l'auteur ; la date est **toujours** remise à aujourd'hui. Une sentinelle `_MISSING` distingue « clé absente de l'update » de « valeur `None` ».

**Doc alignée** aux quatre emplacements, sur la forme complète.

**Remédiation CI qui nomme la paire.** Le workflow imprimait une recette manuelle générique — précisément parce que la commande courte était destructrice. Il imprime maintenant la commande prête à coller, en lisant le nom réel dans le rapport JSON :

```
    python scripts/notebook_tools/check_twin_parity.py --update --pair "Probas-4 Bayesian-Networks" --by "<machine:workspace>"
```

## Vérifications

- **31 tests passent** : les 5 nouveaux (`test_check_twin_parity_surgical.py` — commentaires préservés, diff limité au bloc ciblé, no-op byte-identique, provenance horodatée, autres paires intactes), les 4 de la garde #8508 (**le sélecteur reste obligatoire** — cette PR ne relâche rien), les 13 du check et les 9 d'intégrité du registre.
- **CLI complet** ré-exécuté sur une vraie paire (`Z3-Python-01 Introduction`) : 2 lignes touchées (`date`, `by`), commentaires 72 → 72, registre restauré ensuite.
- **Workflow YAML** reparse (5 steps), remédiation rendue correctement.

Le registre versionné n'est pas modifié par cette PR au-delà du correctif de son en-tête documentaire (7 insertions / 2 suppressions) : aucun SHA rebaseliné ici, donc aucun DRIFT masqué.

## Suite

Les quatre PRs bloquées peuvent désormais rebaseliner en une commande. Steers déjà envoyés (commentaire PR + DM HIGH), avec l'ordre de merge — #8556 avant #8549, rebase avant rebaseline pour #8548 et #8557.

See #8057, #8508

🤖 Generated with [Claude Code](https://claude.com/claude-code)
