### PR TITLE
feat(qc,#6891): metadata-only config.json for 5 QC projects (step 1)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/FuturesTrend/config.json
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/FuturesTrend/config.json
@@ -1,0 +1,6 @@
+{
+    "algorithm-language": "Python",
+    "parameters": {},
+    "description": "Multi-asset ETF trend-following: concentrated positions on the strongest SMA50-filtered trends across a diversified ETF universe.",
+    "organization-id": "d600793ee4caecb03441a09fc2d00f7f"
+}

--- a/MyIA.AI.Notebooks/QuantConnect/projects/MomentumStrategy/config.json
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/MomentumStrategy/config.json
@@ -1,0 +1,6 @@
+{
+    "algorithm-language": "Python",
+    "parameters": {},
+    "description": "Sector ETF momentum rotation with skip-month volatility-adjusted momentum, dual regime filter, and stop-loss.",
+    "organization-id": "d600793ee4caecb03441a09fc2d00f7f"
+}

--- a/MyIA.AI.Notebooks/QuantConnect/projects/RiskParity/config.json
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/RiskParity/config.json
@@ -1,0 +1,6 @@
+{
+    "algorithm-language": "Python",
+    "parameters": {},
+    "description": "Inverse-volatility risk parity with trend filter, rank-based allocation, and a BND safe-haven fallback when fewer than 2 assets are trending.",
+    "organization-id": "d600793ee4caecb03441a09fc2d00f7f"
+}

--- a/MyIA.AI.Notebooks/QuantConnect/projects/SectorMomentum/config.json
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/SectorMomentum/config.json
@@ -1,0 +1,6 @@
+{
+    "algorithm-language": "Python",
+    "parameters": {},
+    "description": "Dual momentum over SPY/TLT/GLD using a multi-lookback composite (1/3/6/12m) with daily SMA200 exit protection.",
+    "organization-id": "d600793ee4caecb03441a09fc2d00f7f"
+}

--- a/MyIA.AI.Notebooks/QuantConnect/projects/TurnOfMonth/config.json
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/TurnOfMonth/config.json
@@ -1,0 +1,6 @@
+{
+    "algorithm-language": "Python",
+    "parameters": {},
+    "description": "Turn-of-month calendar effect: long SPY+QQQ over the last 4 + first 4 trading days with 1.5x leverage and an SMA200 regime filter.",
+    "organization-id": "d600793ee4caecb03441a09fc2d00f7f"
+}


### PR DESCRIPTION
## What

Add metadata-only `config.json` for the 5 QuantConnect projects that had a `main.py` but no `config.json`:

| Project | description (real, from main.py docstring) |
|---------|--------------------------------------------|
| FuturesTrend | Multi-asset ETF trend-following: concentrated positions on the strongest SMA50-filtered trends across a diversified ETF universe. |
| MomentumStrategy | Sector ETF momentum rotation with skip-month volatility-adjusted momentum, dual regime filter, and stop-loss. |
| RiskParity | Inverse-volatility risk parity with trend filter, rank-based allocation, and a BND safe-haven fallback when fewer than 2 assets are trending. |
| SectorMomentum | Dual momentum over SPY/TLT/GLD using a multi-lookback composite (1/3/6/12m) with daily SMA200 exit protection. |
| TurnOfMonth | Turn-of-month calendar effect: long SPY+QQQ over the last 4 + first 4 trading days with 1.5x leverage and an SMA200 regime filter. |

## Form (decided by ai-01, option A — DM msg-20260725T202758-cdbuyh)

```json
{
    "algorithm-language": "Python",
    "parameters": {},
    "description": "<real one-sentence strategy summary>",
    "organization-id": "d600793ee4caecb03441a09fc2d00f7f"
}
```

`local-id`, `id`, `cloud-id`: **absent** (not `null`, not `0`, not a placeholder). This is the `projects/` canonical form (cf `EMA-Cross-Stocks`) minus the cloud fields these 5 projects have not yet earned. `lean-cli` will populate `local-id` at the first `init` and `cloud-id` at the first `push`. This is **not an invented schema variant** — 6 configs already in `projects/` ship without `local-id` (e.g. `EMA-Cross-Alpha`).

## ⚠️ Note for reviewers — `.gitignore` interaction

These 5 files match `MyIA.AI.Notebooks/QuantConnect/.gitignore` line 134 (`projects/*/config.json`). That rule was added **yesterday** in `fa6d4e9cc` (a commit titled "DecInfer cost frontmatter migration" — the ignore section is mislabeled "Docker Research Stubs", suggesting cargo-cult). The 22 sibling `config.json` already tracked in `projects/` are grandfathered (committed before the rule existed), so `git add` alone was a no-op; these were **force-added** to match the established precedent.

ai-01's dispatch deciding this task is dated **after** the `.gitignore` rule and explicitly requested delivery ("livre les 5"). If the ignore rule was intended to block new `config.json` commits going forward, that is a separate cleanup decision and should be addressed at the rule level (not by leaving these 5 projects without a config). Flagging here for full visibility. `organization-id` is the same constant already present in the 22 tracked configs — no new secret is introduced.

## Why

Step 1 of #6891: bring these 5 projects to config-parity with the rest of `projects/` so they are recognizable to `lean-cli` / QC tooling and can subsequently be compiled/backtested on QC Cloud (step 2).

## Validation

- All 5 parse as JSON and carry exactly the 4 decided keys (`algorithm-language`, `parameters`, `description`, `organization-id`); none carry `local-id`/`id`/`cloud-id` (verified programmatically).
- 4-space indent + trailing LF + UTF-8 no-BOM, matching `EMA-Cross-Stocks/config.json` byte style.
- No code cells touched (config-only); C.2 re-exec N/A.

See #6891 (partial — step 1 only; step 2 = QC Cloud compile/backtest).
