### PR TITLE
chore(qc,#8572): remove dead .gitignore rule projects/*/config.json (silent trap)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/.gitignore
+++ b/MyIA.AI.Notebooks/QuantConnect/.gitignore
@@ -131,7 +131,6 @@ $RECYCLE.BIN/
 # ===============================
 # Docker Research Stubs
 # ===============================
-projects/*/config.json
 
 # ===============================
 # Temporary Files


### PR DESCRIPTION
## Summary

Closes #8572 — removes the dead `.gitignore` rule `projects/*/config.json` from `MyIA.AI.Notebooks/QuantConnect/.gitignore`. One line, exactly as scoped by the issue.

## The defect (verified firsthand)

The rule (added `4e37871d2`, 2026-05-12) was **dead on arrival** — 23 `config.json` are tracked under `projects/`, three added *after* the rule (`HAR-RV-Kelly`, `Vol-Ensemble-Conservative`, `Vol-GARCH-Target`, all 2026-05-27). It was mis-filed under a `# Docker Research Stubs` header that has nothing to do with QC project config, which is why it survived 2 months unquestioned.

An ignore rule that practice systematically contradicts is worse than absent — it **silently traps**: a plain `git add` on a new project's `config.json` was a no-op (no error, the file just absent at review). Every agent had to rediscover the trap and choose between `--force` (then justify) or shipping an incomplete project. This just bit #8571.

## G.1 secrets check (paranoid, done myself — not trusting the issue body)

`config.json` is project **metadata**, not credentials. Paranoid sweep of all 23 tracked `config.json` for `token|secret|api-access|password|credential|key` → **0 matches**. Field inventory:

```
19  organization-id    15  algorithm-language
19  cloud-id           14  parameters
17  local-id           11  cash
15  name                7  id
15  description         4  language
```

All benign public/structural metadata. The actual QC credentials (`api-access-token`) live in `.env` / `secrets/` / `.secrets/`, already gitignored — not in `config.json`. Removing the rule is **safe**: it does not enable committing secrets.

## Verification — all 4 acceptance criteria firsthand

1. ✅ **Rule line gone** — `grep -n "projects/*/config.json" .gitignore` returns nothing.
2. ✅ **Fresh `config.json` stages without `--force`** — created `projects/__c8572_test__/config.json`, ran `git add` (no `--force`): `A projects/__c8572_test__/config.json` (was a silent no-op before the fix). Test artifact removed afterward.
3. ✅ **`git status` clean** — only `M .gitignore`; no newly-tracked side effects (the 23 configs are already tracked, none newly appear).
4. ✅ **Exactly 1 line touched** — diff:

```diff
 # ===============================
 # Docker Research Stubs
 # ===============================
-projects/*/config.json

 # ===============================
 # Temporary Files
```

## Scope honesty

This is a **LIGHT** grain — the issue itself frames it as *« plafonné à 1/lane/jour, à prendre en complément d'un plat principal DEEP/MED, pas comme livrable unique de cycle »*. I'm delivering it as the concrete cycle grain because the DEEP/MED pool is verified-drained this window (doc-honesty ~0% yield fleet-wide, twin-register saturated, i18n drained + documented by #7309, Lean sorries all Mathlib-gated/archived, C.2 clean in my partition, SOTA Prong-B notebooks already well-designed). Reported honestly on the dashboard rather than forcing a weak DEEP/MED PR.

See #8572
See #6891 (QC config.json broader context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
