### PR TITLE
chore(qc,#8572): remove dead .gitignore rule 'projects/*/config.json'

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/.gitignore
+++ b/MyIA.AI.Notebooks/QuantConnect/.gitignore
@@ -131,7 +131,6 @@ $RECYCLE.BIN/
 # ===============================
 # Docker Research Stubs
 # ===============================
-projects/*/config.json
 
 # ===============================
 # Temporary Files


### PR DESCRIPTION
## What

Remove the dead rule `projects/*/config.json` from `MyIA.AI.Notebooks/QuantConnect/.gitignore` (issue #8572, direct follow-up to the wrinkle flagged in PR #8571).

One line deleted, nothing else.

## Why

The rule was **dead since birth** and **mis-filed**:

- **Dead** — proven by practice: 23 `config.json` are tracked under `projects/`, including 3 added *after* the rule (`HAR-RV-Kelly`, `Vol-Ensemble-Conservative`, `Vol-GARCH-Target`, all in `83882fecf`). An ignore rule that practice systematically contradicts is worse than absent: it **silently traps** — a plain `git add` on a new project's `config.json` is a no-op with no error, so the file simply isn't there at review. That is exactly what happened on #8571 (worker had to `git add -f` and wrote a callout justifying the workaround).
- **Mis-filed** — the rule sits under a `# Docker Research Stubs` section header that has nothing to do with QC project config files.

`config.json` is project metadata (algorithm-language, description, organization-id) — version-natured, like the 23 already tracked. No secret, no build artifact; `organization-id` is a public constant already present in 23 files.

## Acceptance criteria (issue #8572 — all verified firsthand)

- [x] `projects/*/config.json` no longer in `MyIA.AI.Notebooks/QuantConnect/.gitignore` (diff = exactly 1 deleted line)
- [x] A plain `git add` on a fresh `projects/*/config.json` now stages it without `--force` (dry-run printed `add '...config.json'` → **PASS**)
- [x] `git status` clean after removal: no newly-tracked side effect (the 23 configs stay tracked, nothing else appears)
- [x] No other `.gitignore` line touched

## Note on provenance

The rule was introduced in `4e37871d2` (2026-05-12, `feat(qc+lean): ML Batch 2+3`), **not** `fa6d4e9cc` (2026-07-24) as a quick `git blame ^` prefix can misread. The `^` prefix means "unchanged since this commit", and `fa6d4e9cc` recreated the entire `.gitignore` (176 insertions, new-file mode), which is why blame points there. The rule's real origin is `4e37871d2`.

Closes #8572
