### PR TITLE
docs(ml-pipeline,#8546): deposit HMM-alpha DM finding in CURRICULUM.md + fix gpu_training.py docstring defect

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/CURRICULUM.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/CURRICULUM.md
@@ -19,6 +19,8 @@ Anti-bias multi-asset training pipeline for quantitative trading research.
 > - **The only surviving edges are vol-forecasting + a learned action policy**: the 4 V2 KEEPERS above (M12 HAR-RV-J → QC production `HAR-RV-J-Kelly` #83; M15 LSTM h=32 4-seed hardened; S3 HMM; S4 v2 Ridge) + **L4 Decision Transformer** (24/26, the sole direction BEAT via learned buy/hold/sell — multi-seed extension BG ai-01).
 > - **Production candidate = S3+S4 v2 monthly rebalance + vol-targeting 10 % risk overlay** (Sharpe ~1.12), NOT direction-ML.
 >
+> **Note (2026-07-25, PR #8546) — HMM-alpha (S3 family) qualification:** the `hmm_alpha` research verdict had been rendered on a heuristic `edge >= 2σ` criterion, unlike its siblings (M3/M4/M11e/M12/M15) which use the canonical Diebold-Mariano test. A rigorous DM re-validation (9 configs × 5 seeds [0,1,7,42,99] × 5 walk-forward folds × 2 cost scenarios, re-using `m11c_sharpe_test.ledoit_wolf_sharpe_diff_se` for comparability) found **2 BEATS / 7 INCONCLUSIVE** — and the 2 BEATS are narrow: SOL 4-state t=8.17 robust but against a low bar (SOL B&H Sharpe=-0.08, flat → edge is regime-specific); ETH 3-state t=2.60 fragile (collapses to p=0.35 at 50bps transaction-cost stress, per-fold Sharpe -0.30, fold-0 outlier). **The FINAL VERDICT above holds** — this hardens its base (the heuristic had overstated confidence) but does not resurrect direction-ML. Read this before touching the HMM track.
+>
 > The "IN PROGRESS" statuses on Stages 1/3/3a below are retained as historical record but are **DONE — NEGATIVE**; their "Next" bullets describe documented dead ends, not open work.
 
 **Principle**: No single-asset, single-regime training. All stages use diversified data

--- a/MyIA.AI.Notebooks/QuantConnect/shared/gpu_training.py
+++ b/MyIA.AI.Notebooks/QuantConnect/shared/gpu_training.py
@@ -74,7 +74,7 @@ def thermal_check(max_temp: int = 80, cool_sleep: int = 15, verbose: bool = True
     Parameters
     ----------
     max_temp : int
-        Seuil en Celsius au-dela duquel on pause (defaut: 87).
+        Seuil en Celsius au-dela duquel on pause (defaut: 80).
     cool_sleep : int
         Duree de pause en secondes si seuil depasse (defaut: 15).
     verbose : bool


### PR DESCRIPTION
Grain: MED/docs — lane myia-po-2024:CoursIA-2 — prev: MED/twin-parity (c.879 #8548 twin-gate). Coord: ai-01 [DECIDE] msg-20260725T210423 (owes 2 corrections on merged #8546).

## What (per ai-01 DECIDE)

Two owed corrections on #8546 (HMM-alpha DM research, merged c.875):

**1. CURRICULUM.md deposit** — the methodological finding goes where the verdict it qualifies is already written (per ai-01: "un finding qui qualifie un verdict se dépose là où ce verdict est déjà écrit"). Added a note under the FINAL VERDICT (2026-06-23) in `ML-Training-Pipeline/CURRICULUM.md`:
- The `hmm_alpha` (S3 family) verdict had been rendered on a heuristic `edge >= 2σ`, unlike siblings (M3/M4/M11e/M12/M15) which use the canonical Diebold-Mariano test.
- #8546 re-validated via rigorous DM (9 configs × 5 seeds [0,1,7,42,99] × 5 walk-forward folds × 2 cost scenarios, re-using `m11c_sharpe_test.ledoit_wolf_sharpe_diff_se`): **2 BEATS / 7 INCONCLUSIVE**, both BEATS narrow with caveats (SOL4 robust but low bar B&H=-0.08; ETH3 fragile, collapses @50bps).
- **FINAL VERDICT holds** — hardens its base, does not resurrect direction-ML.

Why CURRICULUM.md (not a new doc/memory/dashboard): tier-2 perenne doc that the whole fleet reads before touching the pipeline; the verdict it qualifies lives there (harness-hygiene: update-don't-create; a new `docs/qc/*.md` would fragment the reader).

**2. gpu_training.py docstring fix** — `thermal_check` docstring (L77) claimed `defaut: 87` while the signature is `max_temp: int = 80`. The 3 signatures (thermal_check L70, batch_thermal_check L102, TrainingCheckpoint L366) all carry 80; batch_thermal_check (L121) + TrainingCheckpoint (L379) docstrings already said 80. Only thermal_check L77 was the outlier. Now consistent at 80.

## Self-correction (G.1)

This PR also corrects the **FALSE residual** I posted in #8546: *"gpu_training.py thermal watchdog is absent from the repo (silent no-op stub)"*. Verified firsthand G.1 on `origin/main`: the module is **518 lines**, fully implements `get_gpu_temp` (L50), `thermal_check` (L70), `batch_thermal_check` (L99), plus `test_gpu_training.py`. The watchdog is real and complete — my "absent" claim was an unverified assertion (likely a stale-tree / wrong-path search in the c.875 worktree: I expected it in `ML-Training-Pipeline/`, it lives in `shared/`). ai-01 caught it (DM msg-...210423 §2).

**Lesson (C880-L):** before claiming a mechanism is absent, `find` + `grep` on `origin/main` (after `git fetch`). "Not found" ≠ "does not exist" — 30 seconds separates them. Same root cause as my stale-twin-register grep this cycle (C879-L) and the Qdrant pickaxe (ai-01 noted): un-fetched local tree. **`git fetch` before any audit.**

## Verification

- `python -c "import ast; ast.parse(...)"` → syntax OK (docstring-only change, no code change).
- grep: no remaining `defaut: 87`; all 3 docstrings now say 80, matching all 3 signatures.
- Diff scope: +3/-1, 2 files. CRLF n/a (.py + .md, no ipynb). No outputs (not a notebook).

## Scope

Complement MED/docs (ai-01: "à prendre en complément d'un plat principal DEEP/MED"). Delivery of the owed DECIDE correction + a main pool grain is being picked up separately this cycle.

See #8546, #1621.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
