### PR TITLE
chore(qc,#8572): remove dead .gitignore rule projects/*/config.json (silent trap)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/.gitignore
+++ b/MyIA.AI.Notebooks/QuantConnect/.gitignore
@@ -129,11 +129,6 @@ $RECYCLE.BIN/
 .directory
 
 # ===============================
-# Docker Research Stubs
-# ===============================
-projects/*/config.json
-
-# ===============================
 # Temporary Files
 # ===============================
 *.tmp


### PR DESCRIPTION
Grain: LIGHT/chore — lane myia-po-2024:CoursIA-2 — prev: MED/docs (c.880 #8575 CURRICULUM+docstring). Plancher this cycle already MED-satisfied (#8548 twin-gate CI-pass + #8575). G-VAR-2: 0 LIGHT consumed today → 1 LIGHT allowed.

## Problem (firsthand-verified)

`MyIA.AI.Notebooks/QuantConnect/.gitignore` carried a dead rule under a mislabeled header:

```gitignore
# ===============================
# Docker Research Stubs          <- mislabeled (nothing to do with QC project configs)
# ===============================
projects/*/config.json
```

**Dead**: `git ls-tree -r origin/main -- .../projects/ | grep config.json` = **23 tracked** config.json (AllWeather, BlackLitterman-Momentum, Crypto-LSTM-Prediction, DualMomentum, ...). 3 were added AFTER the rule (4e37871d2, 2026-05-12): HAR-RV-Kelly, Vol-Ensemble-Conservative, Vol-GARCH-Target (all 2026-05-27) — force-added past the ignore.

**Silent trap**: `git add projects/NewProject/config.json` = no-op (no error, no message, file absent from review). Just cost #8571 a worker (had to `git add -f` + justify the force in PR body). Each new QC project re-hits it.

## Fix

Removed the entire 5-line section (the mislabeled "Docker Research Stubs" header + the dead rule). The 23 tracked config.json remain tracked — `git check-ignore .../DualMomentum/config.json` returns empty (not ignored) before AND after.

## Verification (firsthand)

- `git diff --stat`: 1 file, -5 lines (the dead section only).
- `grep -nE "Docker Research Stubs|projects/\*/config.json"` → empty (removed clean, no orphan header).
- `git check-ignore .../DualMomentum/config.json` → empty (the 23 config.json still correctly tracked, not newly ignored).

## Scope

5-line deletion in 1 .gitignore file. Not a notebook (no C.1/C.2/H.3). No catalogue touched.

Closes #8572.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
