### PR TITLE
fix(genai-audio,#8056): migrate 04-Applications cost frontmatter -> metadata.cost (13 NBs)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-1-Educational-Audio-Content.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-1-Educational-Audio-Content.ipynb
@@ -42,34 +42,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: \"Contenu Audio Educatif (LLM + Kokoro + OpenAI TTS)\"\n",
-    "cost:\n",
-    "  api_usd_est: 0.35            # ~10 generations tts-1 x $0.030/1k + ~10 LLM gpt-4o-mini segmentation\n",
-    "  api_provider: openai          # OpenAI direct (gpt-4o-mini, tts-1); Kokoro = local Docker\n",
-    "  cpu_min: 4\n",
-    "  gpu_min: 0\n",
-    "  gpu_required: false\n",
-    "  vram_gb: 4                    # VRAM pour Kokoro-82M local si fallback active\n",
-    "  vram_tier: MID\n",
-    "  network: true                 # HTTPS api.openai.com + Docker Kokoro\n",
-    "  external_account: mixed       # OPENAI_API_KEY + service Kokoro Docker local\n",
-    "  free_alternative: GenAI/Audio/01-Foundation/01-3-Basic-Audio-Operations.ipynb\n",
-    "  reduced_pedagogical: GenAI/Audio/01-Foundation/01-3-Basic-Audio-Operations.ipynb\n",
-    "  reproducibility: MED          # LLM stochastic, Kokoro deterministe\n",
-    "  last_validated: 2026-07-23T09:30Z\n",
-    "  validator: papermill\n",
-    "notes: |\n",
-    "  Pipeline LLM pedagogique : segmentation thematique (gpt-4o-mini) + TTS multi-modele\n",
-    "  (tts-1 OpenAI ou Kokoro Docker local) + ffmpeg post-process.\n",
-    "  Cout reel depend du nombre de segments et duree audio generee.\n",
-    "  ---\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "cell-params",
@@ -2673,6 +2645,23 @@
    },
    "start_time": "2026-06-23T22:39:53.264929",
    "version": "2.7.0"
+  },
+  "cost": {
+   "api_usd_est": 0.35,
+   "api_provider": "openai",
+   "cpu_min": 4,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 4,
+   "vram_tier": "MID",
+   "network": true,
+   "external_account": "mixed",
+   "free_alternative": "GenAI/Audio/01-Foundation/01-3-Basic-Audio-Operations.ipynb",
+   "reduced_pedagogical": "GenAI/Audio/01-Foundation/01-3-Basic-Audio-Operations.ipynb",
+   "reproducibility": "MED",
+   "last_validated": "2026-07-23T09:30Z",
+   "validator": "papermill",
+   "notes": "Pipeline LLM pedagogique : segmentation thematique (gpt-4o-mini) + TTS multi-modele\n(tts-1 OpenAI ou Kokoro Docker local) + ffmpeg post-process.\nCout reel depend du nombre de segments et duree audio generee.\n---\n"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-10-Annotation-Prosodique.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-10-Annotation-Prosodique.ipynb
@@ -52,35 +52,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: \"Annotation Prosodique pour TTS Agentique (FishAudio tags expressifs)\"\n",
-    "cost:\n",
-    "  api_usd_est: 0.10            # ~200 annotations generees localement (pas d'API)\n",
-    "  api_provider: openai          # OpenAI indirect via gpt-4o-mini possible pour annotation automatique\n",
-    "  cpu_min: 4\n",
-    "  gpu_min: 0\n",
-    "  gpu_required: false\n",
-    "  vram_gb: 4                    # VRAM pour FishAudio S2-Pro (generation) si fallback offline\n",
-    "  vram_tier: MID\n",
-    "  network: true                 # Docker FishAudio S2-Pro + OpenAI optionnel\n",
-    "  external_account: openai      # OPENAI_API_KEY optionnel pour annotation automatique\n",
-    "  free_alternative: GenAI/Audio/01-Foundation/01-3-Basic-Audio-Operations.ipynb\n",
-    "  reduced_pedagogical: GenAI/Audio/04-Applications/04-8-Lecture-Analytique.ipynb\n",
-    "  reproducibility: HIGH         # Annotation manuelle/regles deterministes\n",
-    "  last_validated: 2026-07-23T09:30Z\n",
-    "  validator: papermill\n",
-    "notes: |\n",
-    "  Annotation prosodique manuelle/semi-automatique : taxonomie FishAudio S2-Pro\n",
-    "  (emotion/pause/speed/whisper) inseree dans le texte avant generation TTS.\n",
-    "  Tags expressifs = +$0.05/run lors generation FishAudio S2-Pro GPU.\n",
-    "  Format JSON/CSV exportable pour P4 Generation TTS (04-11).\n",
-    "  ---\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "2171f375",
@@ -1283,6 +1254,23 @@
    "parameters": {},
    "start_time": "2026-05-17T23:11:14.928420",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.1,
+   "api_provider": "openai",
+   "cpu_min": 4,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 4,
+   "vram_tier": "MID",
+   "network": true,
+   "external_account": "openai",
+   "free_alternative": "GenAI/Audio/01-Foundation/01-3-Basic-Audio-Operations.ipynb",
+   "reduced_pedagogical": "GenAI/Audio/04-Applications/04-8-Lecture-Analytique.ipynb",
+   "reproducibility": "HIGH",
+   "last_validated": "2026-07-23T09:30Z",
+   "validator": "papermill",
+   "notes": "Annotation prosodique manuelle/semi-automatique : taxonomie FishAudio S2-Pro\n(emotion/pause/speed/whisper) inseree dans le texte avant generation TTS.\nTags expressifs = +$0.05/run lors generation FishAudio S2-Pro GPU.\nFormat JSON/CSV exportable pour P4 Generation TTS (04-11).\n---\n"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-11-Generation-TTS.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-11-Generation-TTS.ipynb
@@ -29,36 +29,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: \"Generation TTS pour Audiobook (Kokoro + FishAudio S2-Pro multi-voix)\"\n",
-    "cost:\n",
-    "  api_usd_est: 0.50            # ~25 generations tts-1/FishAudio S2-Pro (audiobook chapter)\n",
-    "  api_provider: openai          # OpenAI indirect + Docker Kokoro + FishAudio S2-Pro GPU\n",
-    "  cpu_min: 4\n",
-    "  gpu_min: 1\n",
-    "  gpu_required: true             # FishAudio S2-Pro GPU quasi obligatoire pour latence raisonnable\n",
-    "  vram_gb: 12                   # VRAM pour FishAudio S2-Pro (~3B) + Kokoro-82M cote a cote\n",
-    "  vram_tier: HIGH\n",
-    "  network: true                 # HTTPS api.openai.com (gpt-4o-mini) + Docker Kokoro/FishAudio\n",
-    "  external_account: openai      # OPENAI_API_KEY dans .env\n",
-    "  free_alternative: GenAI/Audio/02-Advanced/02-8-Expressive-TTS.ipynb\n",
-    "  reduced_pedagogical: GenAI/Audio/02-Advanced/02-5-Multi-Model-TTS-Gateway.ipynb\n",
-    "  reproducibility: MED          # Audio TTS stochastic, simulation LLM stochastique\n",
-    "  last_validated: 2026-07-23T09:30Z\n",
-    "  validator: papermill\n",
-    "notes: |\n",
-    "  Generation TTS pour audiobook : Kokoro Docker local (port 8191) + FishAudio S2-Pro\n",
-    "  GPU (port 8197). Multi-voix (narrateur male/femelle/voix-personnage).\n",
-    "  Tags prosodiques (04-10) injectes avant generation. Cout reel depend duree audio\n",
-    "  + tags expressifs + voice cloning references.\n",
-    "  Mode podcast multi-voix = +$0.15/run pour voix multiples.\n",
-    "  ---\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "c84ee935",
@@ -2430,6 +2400,23 @@
    "parameters": {},
    "start_time": "2026-05-17T23:27:26.879837",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.5,
+   "api_provider": "openai",
+   "cpu_min": 4,
+   "gpu_min": 1,
+   "gpu_required": true,
+   "vram_gb": 12,
+   "vram_tier": "HIGH",
+   "network": true,
+   "external_account": "openai",
+   "free_alternative": "GenAI/Audio/02-Advanced/02-8-Expressive-TTS.ipynb",
+   "reduced_pedagogical": "GenAI/Audio/02-Advanced/02-5-Multi-Model-TTS-Gateway.ipynb",
+   "reproducibility": "MED",
+   "last_validated": "2026-07-23T09:30Z",
+   "validator": "papermill",
+   "notes": "Generation TTS pour audiobook : Kokoro Docker local (port 8191) + FishAudio S2-Pro\nGPU (port 8197). Multi-voix (narrateur male/femelle/voix-personnage).\nTags prosodiques (04-10) injectes avant generation. Cout reel depend duree audio\n+ tags expressifs + voice cloning references.\nMode podcast multi-voix = +$0.15/run pour voix multiples.\n---\n"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-12-Compilation-Audio.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-12-Compilation-Audio.ipynb
@@ -30,36 +30,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: \"Compilation Audio pour Audiobook (FFmpeg concat + post-process)\"\n",
-    "cost:\n",
-    "  api_usd_est: 0.00            # FFmpeg local, aucun cout API\n",
-    "  api_provider: none            # FFmpeg local uniquement\n",
-    "  cpu_min: 2\n",
-    "  gpu_min: 0\n",
-    "  gpu_required: false\n",
-    "  vram_gb: 0\n",
-    "  vram_tier: LITE\n",
-    "  network: false                # FFmpeg local, aucun acces reseau\n",
-    "  external_account: none        # Aucune cle requise\n",
-    "  free_alternative: N/A         # Deja 100% gratuit local\n",
-    "  reduced_pedagogical: GenAI/Audio/01-Foundation/01-3-Basic-Audio-Operations.ipynb\n",
-    "  reproducibility: HIGH         # FFmpeg deterministe (concat demuxer, crossfade, silence gaps)\n",
-    "  last_validated: 2026-07-23T09:30Z\n",
-    "  validator: papermill\n",
-    "notes: |\n",
-    "  Compilation audio post-TTS : FFmpeg concat demuxer pour joindre segments P4 (14 MP3)\n",
-    "  avec transitions (silence 500ms, fade in/out 200ms) -> masterisation audiobook MP3.\n",
-    "  Chargement metadata JSON de P4 -> filtrage success segments -> tri seg_index ->\n",
-    "  concatenation deterministe.\n",
-    "  Cout = 0 ; peut tourner offline complet.\n",
-    "  ---\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "c3bee5ce",
@@ -786,6 +756,23 @@
    "parameters": {},
    "start_time": "2026-05-17T23:37:13.418355",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "LITE",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": "N/A",
+   "reduced_pedagogical": "GenAI/Audio/01-Foundation/01-3-Basic-Audio-Operations.ipynb",
+   "reproducibility": "HIGH",
+   "last_validated": "2026-07-23T09:30Z",
+   "validator": "papermill",
+   "notes": "Compilation audio post-TTS : FFmpeg concat demuxer pour joindre segments P4 (14 MP3)\navec transitions (silence 500ms, fade in/out 200ms) -> masterisation audiobook MP3.\nChargement metadata JSON de P4 -> filtrage success segments -> tri seg_index ->\nconcatenation deterministe.\nCout = 0 ; peut tourner offline complet.\n---\n"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-13-Audiobook-FishAudio-S2Pro.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-13-Audiobook-FishAudio-S2Pro.ipynb
@@ -7,35 +7,6 @@
    "metadata": {}
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: \"Audiobook Agentique avec FishAudio S2-Pro (clonage vocal + Whisper STT)\"\n",
-    "cost:\n",
-    "  api_usd_est: 0.60            # ~30 generations FishAudio S2-Pro + ~5 LLM gpt-4o-mini + ~2 Whisper STT\n",
-    "  api_provider: openai          # OpenAI direct (gpt-4o-mini, whisper-1) + FishAudio S2-Pro Docker GPU\n",
-    "  cpu_min: 4\n",
-    "  gpu_min: 1\n",
-    "  gpu_required: true             # FishAudio S2-Pro GPU quasi obligatoire (clonage vocal)\n",
-    "  vram_gb: 6                    # VRAM annoncee cellule[0] = ~6 GB FishAudio S2-Pro\n",
-    "  vram_tier: MID\n",
-    "  network: true                 # HTTPS api.openai.com + Docker FishAudio S2-Pro (port 8197)\n",
-    "  external_account: openai      # OPENAI_API_KEY dans .env\n",
-    "  free_alternative: GenAI/Audio/02-Advanced/02-8-Expressive-TTS.ipynb\n",
-    "  reduced_pedagogical: GenAI/Audio/02-Advanced/02-1-Chatterbox-TTS.ipynb\n",
-    "  reproducibility: MED          # FishAudio S2-Pro stochastic, LLM stochastic\n",
-    "  last_validated: 2026-07-23T09:30Z\n",
-    "  validator: papermill\n",
-    "notes: |\n",
-    "  Pipeline complet audiobook v4 (8 phases) : segmentation (gpt-4o-mini) -> voice casting\n",
-    "  reference -> generation FishAudio S2-Pro (clonage vocal) -> validation WER Whisper STT.\n",
-    "  VRAM ~6 GB annoncee cellule[0] (\"VRAM estimee : ~6 GB FishAudio S2-Pro sur GPU\").\n",
-    "  Cout reel depend duree chapters + nombre personnages + iterations WER validation.\n",
-    "  ---\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "id": "893e7da1",
    "source": "# Parametres Papermill - JAMAIS modifier ce commentaire\n\n# Configuration notebook\nnotebook_mode = \"interactive\"\nskip_widgets = False\ndebug_level = \"INFO\"\n\n# Parametres pipeline v4\nllm_model = \"gpt-4o-mini\"\ndemo_segment_start = 0\ndemo_segment_end = 5  # Extraits courts pour la demonstration\nfishaudio_url = \"http://localhost:8197\"\nwhisper_url = \"http://localhost:8190/v1/audio/transcriptions\"\nwer_threshold = 0.15  # 15% WER max acceptable\n\n# Configuration FishAudio\nfishaudio_reference_ids = {\n    \"narrateur\": \"v4_narrator_male_neutral\",\n    \"elisabeth_rousset\": \"v4_boule_warm_distressed\",\n    \"comte\": \"v4_comte_onctuous\",\n}\n\n# Configuration sauvegarde\ngenerate_audio = True\nsave_audio_files = True",
@@ -447,6 +418,23 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.8.0"
+  },
+  "cost": {
+   "api_usd_est": 0.6,
+   "api_provider": "openai",
+   "cpu_min": 4,
+   "gpu_min": 1,
+   "gpu_required": true,
+   "vram_gb": 6,
+   "vram_tier": "MID",
+   "network": true,
+   "external_account": "openai",
+   "free_alternative": "GenAI/Audio/02-Advanced/02-8-Expressive-TTS.ipynb",
+   "reduced_pedagogical": "GenAI/Audio/02-Advanced/02-1-Chatterbox-TTS.ipynb",
+   "reproducibility": "MED",
+   "last_validated": "2026-07-23T09:30Z",
+   "validator": "papermill",
+   "notes": "Pipeline complet audiobook v4 (8 phases) : segmentation (gpt-4o-mini) -> voice casting\nreference -> generation FishAudio S2-Pro (clonage vocal) -> validation WER Whisper STT.\nVRAM ~6 GB annoncee cellule[0] (\"VRAM estimee : ~6 GB FishAudio S2-Pro sur GPU\").\nCout reel depend duree chapters + nombre personnages + iterations WER validation.\n---\n"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-2-Transcription-Pipeline.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-2-Transcription-Pipeline.ipynb
@@ -42,34 +42,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: \"Pipeline de Transcription et Sous-titrage (Whisper-1 + LLM + TTS)\"\n",
-    "cost:\n",
-    "  api_usd_est: 0.25            # ~20 min whisper-1 x $0.006/min + ~10 LLM gpt-4o-mini $0.15/Mtok\n",
-    "  api_provider: mixed           # OpenAI whisper-1 + gpt-4o-mini + tts-1 + HuggingFace (Whisper local fallback)\n",
-    "  cpu_min: 4\n",
-    "  gpu_min: 0\n",
-    "  gpu_required: false\n",
-    "  vram_gb: 0                    # Pas de GPU requis (API cloud) ; Whisper local = 10 GB fallback\n",
-    "  vram_tier: LITE\n",
-    "  network: true                 # HTTPS api.openai.com obligatoire\n",
-    "  external_account: openai      # OPENAI_API_KEY dans .env\n",
-    "  free_alternative: GenAI/Audio/01-Foundation/01-4-Whisper-Local.ipynb\n",
-    "  reduced_pedagogical: GenAI/Audio/01-Foundation/01-2-OpenAI-Whisper-STT.ipynb\n",
-    "  reproducibility: MED          # Whisper temperature, LLM stochastic\n",
-    "  last_validated: 2026-07-23T09:30Z\n",
-    "  validator: papermill\n",
-    "notes: |\n",
-    "  Pipeline transcription multi-etapes : extraction audio (ffmpeg) -> STT whisper-1 ->\n",
-    "  segmentation temporelle (gpt-4o-mini) -> generation sous-titres SRT/VTT -> resynthese TTS.\n",
-    "  Modes multilingues (99 langues) + diarisation. Mode BATCH_MODE = True Papermill-compatible.\n",
-    "  ---\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "cell-params",
@@ -2476,6 +2448,23 @@
    },
    "start_time": "2026-07-09T09:44:04.134199",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.25,
+   "api_provider": "mixed",
+   "cpu_min": 4,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "LITE",
+   "network": true,
+   "external_account": "openai",
+   "free_alternative": "GenAI/Audio/01-Foundation/01-4-Whisper-Local.ipynb",
+   "reduced_pedagogical": "GenAI/Audio/01-Foundation/01-2-OpenAI-Whisper-STT.ipynb",
+   "reproducibility": "MED",
+   "last_validated": "2026-07-23T09:30Z",
+   "validator": "papermill",
+   "notes": "Pipeline transcription multi-etapes : extraction audio (ffmpeg) -> STT whisper-1 ->\nsegmentation temporelle (gpt-4o-mini) -> generation sous-titres SRT/VTT -> resynthese TTS.\nModes multilingues (99 langues) + diarisation. Mode BATCH_MODE = True Papermill-compatible.\n---\n"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-3-Music-Composition-Workflow.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-3-Music-Composition-Workflow.ipynb
@@ -41,35 +41,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: \"Workflow de Composition Musicale (LLM + MusicGen + Demucs)\"\n",
-    "cost:\n",
-    "  api_usd_est: 0.00            # 100% local HuggingFace transformers\n",
-    "  api_provider: none            # HF local : MusicGen-medium 1.5B + Demucs htdemucs_ft\n",
-    "  cpu_min: 8\n",
-    "  gpu_min: 1\n",
-    "  gpu_required: false            # GPU recommande (MusicGen + Demucs cote a cote) mais CPU possible pour inference lente\n",
-    "  vram_gb: 12                   # VRAM pour MusicGen-medium (1.5B) + Demucs (4-stems) concourants\n",
-    "  vram_tier: MID\n",
-    "  network: true                 # HuggingFace download initial uniquement\n",
-    "  external_account: huggingface # HF_TOKEN si modeles gates\n",
-    "  free_alternative: N/A         # Deja 100% gratuit local\n",
-    "  reduced_pedagogical: GenAI/Audio/02-Advanced/02-3-MusicGen-Generation.ipynb\n",
-    "  reproducibility: MED          # MusicGen sampling stochastic, pas de seed natif deterministe\n",
-    "  last_validated: 2026-07-23T09:30Z\n",
-    "  validator: papermill\n",
-    "notes: |\n",
-    "  Workflow composition musicale : prompt texte LLM -> generation MusicGen-Medium (30s)\n",
-    "  -> separation stems Demucs htdemucs_ft (vocals/drums/bass/other) -> remix/mix custom.\n",
-    "  100% local HuggingFace transformers, pas d'API payante.\n",
-    "  Cout electricite GPU seulement (~30 min sur RTX 3090).\n",
-    "  ---\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "cell-params",
@@ -2091,6 +2062,23 @@
    },
    "start_time": "2026-05-26T18:04:11.328258",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 8,
+   "gpu_min": 1,
+   "gpu_required": false,
+   "vram_gb": 12,
+   "vram_tier": "MID",
+   "network": true,
+   "external_account": "huggingface",
+   "free_alternative": "N/A",
+   "reduced_pedagogical": "GenAI/Audio/02-Advanced/02-3-MusicGen-Generation.ipynb",
+   "reproducibility": "MED",
+   "last_validated": "2026-07-23T09:30Z",
+   "validator": "papermill",
+   "notes": "Workflow composition musicale : prompt texte LLM -> generation MusicGen-Medium (30s)\n-> separation stems Demucs htdemucs_ft (vocals/drums/bass/other) -> remix/mix custom.\n100% local HuggingFace transformers, pas d'API payante.\nCout electricite GPU seulement (~30 min sur RTX 3090).\n---\n"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-4-Audio-Video-Sync.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-4-Audio-Video-Sync.ipynb
@@ -44,34 +44,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: \"Synchronisation Audio-Video (TTS + BGM + Foley multi-modeles)\"\n",
-    "cost:\n",
-    "  api_usd_est: 0.45            # ~15 generations tts-1 x $0.030/1k + BGM local + foley local\n",
-    "  api_provider: mixed           # OpenAI tts-1 + HF MusicGen + Demucs + XTTS + Chatterbox + Kokoro\n",
-    "  cpu_min: 8\n",
-    "  gpu_min: 1\n",
-    "  gpu_required: false            # GPU recommande pour MusicGen/Demucs concourants\n",
-    "  vram_gb: 16                   # VRAM pour XTTS (1.7B) + Chatterbox (350M) + MusicGen (1.5B)\n",
-    "  vram_tier: HIGH\n",
-    "  network: true                 # HTTPS api.openai.com + HuggingFace download\n",
-    "  external_account: mixed       # OPENAI_API_KEY + HF_TOKEN (Kokoro/Chatterbox)\n",
-    "  free_alternative: GenAI/Audio/03-Orchestration/03-1-Multi-Model-Audio-Comparison.ipynb\n",
-    "  reduced_pedagogical: GenAI/Audio/02-Advanced/02-3-MusicGen-Generation.ipynb\n",
-    "  reproducibility: MED          # Multi-modeles, sampling stochastique\n",
-    "  last_validated: 2026-07-23T09:30Z\n",
-    "  validator: papermill\n",
-    "notes: |\n",
-    "  Pipeline passerelle audio/video : generation TTS voix-off (multi-modeles) + BGM\n",
-    "  MusicGen-Medium + foley Demucs + synchro timeline ffmpeg. Orchestrateur multi-services.\n",
-    "  Cout reel depend du nombre de generations et duree video.\n",
-    "  ---\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "cell-params",
@@ -2582,6 +2554,23 @@
    },
    "start_time": "2026-06-24T00:38:35.926851",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.45,
+   "api_provider": "mixed",
+   "cpu_min": 8,
+   "gpu_min": 1,
+   "gpu_required": false,
+   "vram_gb": 16,
+   "vram_tier": "HIGH",
+   "network": true,
+   "external_account": "mixed",
+   "free_alternative": "GenAI/Audio/03-Orchestration/03-1-Multi-Model-Audio-Comparison.ipynb",
+   "reduced_pedagogical": "GenAI/Audio/02-Advanced/02-3-MusicGen-Generation.ipynb",
+   "reproducibility": "MED",
+   "last_validated": "2026-07-23T09:30Z",
+   "validator": "papermill",
+   "notes": "Pipeline passerelle audio/video : generation TTS voix-off (multi-modeles) + BGM\nMusicGen-Medium + foley Demucs + synchro timeline ffmpeg. Orchestrateur multi-services.\nCout reel depend du nombre de generations et duree video.\n---\n"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-5-LiveCoding-LLM-Music.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-5-LiveCoding-LLM-Music.ipynb
@@ -41,34 +41,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: \"Live Coding Musical pilote par LLM (gpt-4o-mini + MusicGen)\"\n",
-    "cost:\n",
-    "  api_usd_est: 0.30            # ~50 prompts gpt-4o-mini $0.15/Mtok + ~30 generations MusicGen local\n",
-    "  api_provider: mixed           # OpenAI gpt-4o-mini + HF MusicGen-Medium (local)\n",
-    "  cpu_min: 4\n",
-    "  gpu_min: 1\n",
-    "  gpu_required: true             # GPU quasi obligatoire pour MusicGen-Medium fluid live\n",
-    "  vram_gb: 8                    # VRAM pour MusicGen-Medium 1.5B\n",
-    "  vram_tier: MID\n",
-    "  network: true                 # HTTPS api.openai.com\n",
-    "  external_account: openai      # OPENAI_API_KEY dans .env\n",
-    "  free_alternative: GenAI/Audio/02-Advanced/02-3-MusicGen-Generation.ipynb\n",
-    "  reduced_pedagogical: GenAI/Audio/01-Foundation/01-3-Basic-Audio-Operations.ipynb\n",
-    "  reproducibility: LOW          # Live coding = stochasticite inhérente, pas de seed déterministe\n",
-    "  last_validated: 2026-07-23T09:30Z\n",
-    "  validator: papermill\n",
-    "notes: |\n",
-    "  Live coding musical : prompt LLM gpt-4o-mini -> generation MusicGen-Medium ~15s en boucle\n",
-    "  rapide. Mode interactif (notebook_mode=\"interactive\"), boucle feedback temps reel.\n",
-    "  Cout = (LLM tokens) + (cout GPU MusicGen). Mode BATCH_MODE = \"true\" pour tests automatises.\n",
-    "  ---\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "2d2adb6d",
@@ -2567,6 +2539,23 @@
    },
    "start_time": "2026-06-24T00:39:42.739428",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.3,
+   "api_provider": "mixed",
+   "cpu_min": 4,
+   "gpu_min": 1,
+   "gpu_required": true,
+   "vram_gb": 8,
+   "vram_tier": "MID",
+   "network": true,
+   "external_account": "openai",
+   "free_alternative": "GenAI/Audio/02-Advanced/02-3-MusicGen-Generation.ipynb",
+   "reduced_pedagogical": "GenAI/Audio/01-Foundation/01-3-Basic-Audio-Operations.ipynb",
+   "reproducibility": "LOW",
+   "last_validated": "2026-07-23T09:30Z",
+   "validator": "papermill",
+   "notes": "Live coding musical : prompt LLM gpt-4o-mini -> generation MusicGen-Medium ~15s en boucle\nrapide. Mode interactif (notebook_mode=\"interactive\"), boucle feedback temps reel.\nCout = (LLM tokens) + (cout GPU MusicGen). Mode BATCH_MODE = \"true\" pour tests automatises.\n---\n"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-6-Audiobook-Pipeline.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-6-Audiobook-Pipeline.ipynb
@@ -40,35 +40,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: \"Pipeline Audiobook Agentique (LLM + TTS multi-modeles + XTTS)\"\n",
-    "cost:\n",
-    "  api_usd_est: 0.40            # ~20 segmentation LLM gpt-4o-mini + ~20 generations tts-1\n",
-    "  api_provider: mixed           # OpenAI gpt-4o-mini + tts-1 + HF XTTS-v2 voice cloning + Kokoro\n",
-    "  cpu_min: 4\n",
-    "  gpu_min: 1\n",
-    "  gpu_required: false            # XTTS necessite GPU pour voice cloning rapide\n",
-    "  vram_gb: 16                   # VRAM pour XTTS-v2 1.7B (6s voice clone sample)\n",
-    "  vram_tier: HIGH\n",
-    "  network: true                 # HTTPS api.openai.com + HuggingFace download\n",
-    "  external_account: openai      # OPENAI_API_KEY dans .env\n",
-    "  free_alternative: GenAI/Audio/03-Orchestration/03-2-Audio-Pipeline-Orchestration.ipynb\n",
-    "  reduced_pedagogical: GenAI/Audio/01-Foundation/01-1-OpenAI-TTS-Intro.ipynb\n",
-    "  reproducibility: MED          # Pipeline stochastic (LLM temperature)\n",
-    "  last_validated: 2026-07-23T09:30Z\n",
-    "  validator: papermill\n",
-    "notes: |\n",
-    "  Pipeline audiobook complet : extraction texte (Project Gutenberg) -> segmentation\n",
-    "  semantique (gpt-4o-mini) -> attribution voix (XTTS voice cloning 6s sample)\n",
-    "  -> generation TTS multi-modele -> concatenation ffmpeg.\n",
-    "  Modes podcast multi-voix supportes. Cout depend nombre de chapitres et duree audio.\n",
-    "  ---\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "b251a606",
@@ -1867,6 +1838,23 @@
    "parameters": {},
    "start_time": "2026-06-24T02:36:51.825919",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.4,
+   "api_provider": "mixed",
+   "cpu_min": 4,
+   "gpu_min": 1,
+   "gpu_required": false,
+   "vram_gb": 16,
+   "vram_tier": "HIGH",
+   "network": true,
+   "external_account": "openai",
+   "free_alternative": "GenAI/Audio/03-Orchestration/03-2-Audio-Pipeline-Orchestration.ipynb",
+   "reduced_pedagogical": "GenAI/Audio/01-Foundation/01-1-OpenAI-TTS-Intro.ipynb",
+   "reproducibility": "MED",
+   "last_validated": "2026-07-23T09:30Z",
+   "validator": "papermill",
+   "notes": "Pipeline audiobook complet : extraction texte (Project Gutenberg) -> segmentation\nsemantique (gpt-4o-mini) -> attribution voix (XTTS voice cloning 6s sample)\n-> generation TTS multi-modele -> concatenation ffmpeg.\nModes podcast multi-voix supportes. Cout depend nombre de chapitres et duree audio.\n---\n"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-7-TTS-Voice-Benchmark.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-7-TTS-Voice-Benchmark.ipynb
@@ -64,35 +64,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: \"Benchmark TTS Audiobook (OpenAI tts-1 vs XTTS vs Kokoro)\"\n",
-    "cost:\n",
-    "  api_usd_est: 0.35            # ~12 generations tts-1 Boule de Suif + ~12 XTTS local + Kokoro local\n",
-    "  api_provider: mixed           # OpenAI tts-1 + HF XTTS-v2 + Kokoro local Docker\n",
-    "  cpu_min: 4\n",
-    "  gpu_min: 1\n",
-    "  gpu_required: false            # GPU recommande pour XTTS rapide, mais CPU OK pour Kokoro\n",
-    "  vram_gb: 16                   # VRAM pour XTTS-v2 1.7B\n",
-    "  vram_tier: HIGH\n",
-    "  network: true                 # HTTPS api.openai.com + Docker Kokoro\n",
-    "  external_account: openai      # OPENAI_API_KEY dans .env\n",
-    "  free_alternative: GenAI/Audio/01-Foundation/01-5-Kokoro-TTS-Local.ipynb\n",
-    "  reduced_pedagogical: GenAI/Audio/01-Foundation/01-1-OpenAI-TTS-Intro.ipynb\n",
-    "  reproducibility: MED          # Benchmarks TTS stochastiques, pas de seed natif\n",
-    "  last_validated: 2026-07-23T09:30Z\n",
-    "  validator: papermill\n",
-    "notes: |\n",
-    "  Benchmark comparatif 3 voix TTS sur Boule de Suif (Maupassant) : OpenAI tts-1 voix\n",
-    "  alloy/echo/shimmer + XTTS-v2 voice cloning + Kokoro-82M Docker local.\n",
-    "  Metriques : WER (Whisper), latence, cout/1k chars, similarite audio.\n",
-    "  3 runs par modele pour moyenner.\n",
-    "  ---\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "d3122567",
@@ -1761,6 +1732,23 @@
    "parameters": {},
    "start_time": "2026-05-28T19:47:51.070780",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.35,
+   "api_provider": "mixed",
+   "cpu_min": 4,
+   "gpu_min": 1,
+   "gpu_required": false,
+   "vram_gb": 16,
+   "vram_tier": "HIGH",
+   "network": true,
+   "external_account": "openai",
+   "free_alternative": "GenAI/Audio/01-Foundation/01-5-Kokoro-TTS-Local.ipynb",
+   "reduced_pedagogical": "GenAI/Audio/01-Foundation/01-1-OpenAI-TTS-Intro.ipynb",
+   "reproducibility": "MED",
+   "last_validated": "2026-07-23T09:30Z",
+   "validator": "papermill",
+   "notes": "Benchmark comparatif 3 voix TTS sur Boule de Suif (Maupassant) : OpenAI tts-1 voix\nalloy/echo/shimmer + XTTS-v2 voice cloning + Kokoro-82M Docker local.\nMetriques : WER (Whisper), latence, cout/1k chars, similarite audio.\n3 runs par modele pour moyenner.\n---\n"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-8-Lecture-Analytique.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-8-Lecture-Analytique.ipynb
@@ -39,35 +39,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: \"Lecture Analytique pour Audiobook (Project Gutenberg + segmentation)\"\n",
-    "cost:\n",
-    "  api_usd_est: 0.00            # 100% local ; Project Gutenberg API publique gratuite\n",
-    "  api_provider: none            # Aucune API ; juste urllib + JSON (Project Gutenberg) + Kokoro lecture offline\n",
-    "  cpu_min: 2\n",
-    "  gpu_min: 0\n",
-    "  gpu_required: false\n",
-    "  vram_gb: 0\n",
-    "  vram_tier: LITE\n",
-    "  network: true                 # HTTPS gutenberg.org pour telechargement texte\n",
-    "  external_account: none        # Aucune cle requise\n",
-    "  free_alternative: N/A         # Deja 100% gratuit\n",
-    "  reduced_pedagogical: GenAI/Audio/01-Foundation/01-3-Basic-Audio-Operations.ipynb\n",
-    "  reproducibility: HIGH         # Project Gutenberg deterministe, segmentation deterministe (regex)\n",
-    "  last_validated: 2026-07-23T09:30Z\n",
-    "  validator: papermill\n",
-    "notes: |\n",
-    "  Pipeline lecture analytique d'un roman (Boule de Suif, Maupassant) : telechargement\n",
-    "  Project Gutenberg -> segmentation semantique (narration/dialogue/descriptions) ->\n",
-    "  extraction personnages -> generation JSON pour P2 voice casting (04-9) et P3 prosodie.\n",
-    "  Cout = 0 ; peut tourner offline apres telechargement initial.\n",
-    "  ---\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "b57b69ea",
@@ -1186,6 +1157,23 @@
    "parameters": {},
    "start_time": "2026-05-26T18:05:10.539383",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "LITE",
+   "network": true,
+   "external_account": "none",
+   "free_alternative": "N/A",
+   "reduced_pedagogical": "GenAI/Audio/01-Foundation/01-3-Basic-Audio-Operations.ipynb",
+   "reproducibility": "HIGH",
+   "last_validated": "2026-07-23T09:30Z",
+   "validator": "papermill",
+   "notes": "Pipeline lecture analytique d'un roman (Boule de Suif, Maupassant) : telechargement\nProject Gutenberg -> segmentation semantique (narration/dialogue/descriptions) ->\nextraction personnages -> generation JSON pour P2 voice casting (04-9) et P3 prosodie.\nCout = 0 ; peut tourner offline apres telechargement initial.\n---\n"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-9-Voice-Casting.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-9-Voice-Casting.ipynb
@@ -57,35 +57,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: \"Voice Casting : Attribution voix TTS par personnage (LLM + multi-TTS)\"\n",
-    "cost:\n",
-    "  api_usd_est: 0.25            # ~10 LLM gpt-4o-mini voice assignment + ~6 generations tts-1\n",
-    "  api_provider: mixed           # OpenAI gpt-4o-mini + tts-1 + HF Demucs + Kokoro + FishAudio\n",
-    "  cpu_min: 4\n",
-    "  gpu_min: 1\n",
-    "  gpu_required: false            # Demucs segmentation requiert GPU pour fluidite\n",
-    "  vram_gb: 6                    # VRAM pour Demucs htdemucs_ft + Kokoro-82M cote a cote\n",
-    "  vram_tier: MID\n",
-    "  network: true                 # HTTPS api.openai.com + Docker Kokoro/FishAudio\n",
-    "  external_account: openai      # OPENAI_API_KEY dans .env\n",
-    "  free_alternative: GenAI/Audio/04-Applications/04-8-Lecture-Analytique.ipynb\n",
-    "  reduced_pedagogical: GenAI/Audio/01-Foundation/01-5-Kokoro-TTS-Local.ipynb\n",
-    "  reproducibility: MED          # Voice assignment LLM stochastic, audio TTS stochastic\n",
-    "  last_validated: 2026-07-23T09:30Z\n",
-    "  validator: papermill\n",
-    "notes: |\n",
-    "  Voice casting : prend les personnages detectes par P1 (04-8) -> attribue voix TTS via\n",
-    "  LLM (gpt-4o-mini) -> segment via Demucs htdemucs_ft si voix de reference donnee\n",
-    "  -> genere previews audio OpenAI tts-1 / Kokoro / FishAudio pour selection humaine.\n",
-    "  Cout reel depend nombre de personnages (8-15 typiquement).\n",
-    "  ---\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "aad7f0a3",
@@ -1461,6 +1432,23 @@
    "parameters": {},
    "start_time": "2026-05-17T21:09:00.526844",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.25,
+   "api_provider": "mixed",
+   "cpu_min": 4,
+   "gpu_min": 1,
+   "gpu_required": false,
+   "vram_gb": 6,
+   "vram_tier": "MID",
+   "network": true,
+   "external_account": "openai",
+   "free_alternative": "GenAI/Audio/04-Applications/04-8-Lecture-Analytique.ipynb",
+   "reduced_pedagogical": "GenAI/Audio/01-Foundation/01-5-Kokoro-TTS-Local.ipynb",
+   "reproducibility": "MED",
+   "last_validated": "2026-07-23T09:30Z",
+   "validator": "papermill",
+   "notes": "Voice casting : prend les personnages detectes par P1 (04-8) -> attribue voix TTS via\nLLM (gpt-4o-mini) -> segment via Demucs htdemucs_ft si voix de reference donnee\n-> genere previews audio OpenAI tts-1 / Kokoro / FishAudio pour selection humaine.\nCout reel depend nombre de personnages (8-15 typiquement).\n---\n"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary

Guard **#8352** (HARD CI) flags any notebook whose early markdown cell carries a `---\n...\n---` YAML block, because `markdown-it` promotes it to a **setext-H2 supersize** rendering defect. Many GenAI/Audio notebooks carry a legacy **cost frontmatter** there. This PR migrates the **13** notebooks in `GenAI/Audio/04-Applications/` to the canonical `nb.metadata['cost']` storage (schema #8376).

**Storage-format migration only — no re-execution, no GPU needed.** The cost data is preserved verbatim; only its storage location changes (visible `---`-YAML cell -> invisible notebook metadata).

## Changes (13 notebooks, `GenAI/Audio/04-Applications/`)

`04-1, 04-2, 04-3, 04-4, 04-5, 04-6, 04-7, 04-8, 04-9, 04-10, 04-11, 04-12, 04-13`

Per notebook:
- Parsed the cell[1] (or cell[2] for 04-7/04-9/04-10) `---`-YAML frontmatter.
- Moved `cost:` block + top-level `notes:` into `nb.metadata['cost']` (notes merged into `cost.notes`).
- Dropped `title:` (the H1 in cell[0] already serves as title).
- YAML `null` -> JSON `null`; types preserved (floats/ints/bools/strings via PyYAML).
- **Removed** the now-empty frontmatter cell. **0 code cells modified.**

## Validation (all post-fix, firsthand)

| Check | Result |
|-------|--------|
| `check_cost_metadata.py` | `cost_source: 'metadata'` (canonical) |
| `detect_markdown_rendering` | 0 violations in the 13 changed NBs (folder clean on origin/main) |
| `validate_pr_notebooks.py` (H.3) | 13/13 PASS |
| Line endings | LF-only (CRLF=0) |
| Diff scope | surgical: cell-count -1 per NB; only frontmatter-cell removal + metadata.cost add; no `execution_count` churn |

SOTA verdict: N/A (metadata migration, not a solver/model output). Guard #8352 = RECOVERABLE-LOCAL, resolved.

## Scope

`See #8056` (partial epic — fleet backlog remains in other families: GenAI/Image, GenAI/Audio/03-Orchestration, SemanticKernel, Vibe-Coding, QC quantbooks, CaseStudies, etc.). Base `origin/main ac04561a` (fresh worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>