### PR TITLE
fix(genai-image,#8056): migrate Image cost frontmatter -> metadata.cost (9 NBs)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/03-1-Multi-Model-Comparison.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/03-1-Multi-Model-Comparison.ipynb
@@ -30,35 +30,6 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: Comparaison Multi-Modeles - Forge SDXL Lightning-4step vs ComfyUI Z-Image\n",
-    "cost:\n",
-    "  api_usd_est: 0.0             # Self-hosted via Forge + ComfyUI, pas de cout API direct\n",
-    "  api_provider: local\n",
-    "  cpu_min: 0\n",
-    "  gpu_min: 8                   # SDXL-Lightning-4step sur RTX 3060+ (~10s/image)\n",
-    "  gpu_required: true\n",
-    "  vram_gb: 16                  # Z-Image (Qwen fp8) Phase 29 = 16 GB FP16\n",
-    "  vram_tier: MID\n",
-    "  network: true                 # Televersement checkpoints + auth Bearer ComfyUI\n",
-    "  external_account: hf          # HF_TOKEN pour Qwen Image Edit fp8 checkpoint\n",
-    "  free_alternative: null        # Pas d'alternative equivalente open weights 1024x1024\n",
-    "  reduced_pedagogical: GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb\n",
-    "  reproducibility: HIGH         # seed=42 fige + sampler=Euler (capital, #5867)\n",
-    "  last_validated: 2026-07-23T01:30Z\n",
-    "  validator: sk_visual          # sk-agent vision check sur figures rendues\n",
-    "notes: |\n",
-    "  Architecture dual-stack : Forge sdapi (port 17861 live, #5867) + ComfyUI (8188).\n",
-    "  Endpoint Forge : /sdapi/v1/txt2img avec steps=4, cfg_scale=1.5, sampler_name=\"Euler\" (capital, lowercase=404).\n",
-    "  Workflow ComfyUI : Qwen Image Edit fp8 (meme famille Lumina-2, Phase 29) — le workflow GGUF z_image_turbo d'origine produisait des images vides (nodes ModelSamplingAuraFlow + CFGNorm absents).\n",
-    "  Cold-start Qwen fp8 = 12-min poll window (#5867). Comparison cote a cote 512x512 (Forge) vs 1024x1024 (ComfyUI).\n",
-    "---\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "7ea9c7e0",
    "metadata": {
     "papermill": {
@@ -710,6 +681,23 @@
    },
    "start_time": "2026-05-14T08:14:51.733130",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "local",
+   "cpu_min": 0,
+   "gpu_min": 8,
+   "gpu_required": true,
+   "vram_gb": 16,
+   "vram_tier": "MID",
+   "network": true,
+   "external_account": "hf",
+   "free_alternative": null,
+   "reduced_pedagogical": "GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb",
+   "reproducibility": "HIGH",
+   "last_validated": "2026-07-23T01:30Z",
+   "validator": "sk_visual",
+   "notes": "Architecture dual-stack : Forge sdapi (port 17861 live, #5867) + ComfyUI (8188).\nEndpoint Forge : /sdapi/v1/txt2img avec steps=4, cfg_scale=1.5, sampler_name=\"Euler\" (capital, lowercase=404).\nWorkflow ComfyUI : Qwen Image Edit fp8 (meme famille Lumina-2, Phase 29) — le workflow GGUF z_image_turbo d'origine produisait des images vides (nodes ModelSamplingAuraFlow + CFGNorm absents).\nCold-start Qwen fp8 = 12-min poll window (#5867). Comparison cote a cote 512x512 (Forge) vs 1024x1024 (ComfyUI).\n"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/03-2-Workflow-Orchestration.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/03-2-Workflow-Orchestration.ipynb
@@ -30,36 +30,6 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: Workflow Orchestration - Chainage Multi-Modeles (sequential/parallel/conditional)\n",
-    "cost:\n",
-    "  api_usd_est: 0.0             # Self-hosted via ComfyUI po-2023, pas de cout API direct\n",
-    "  api_provider: local\n",
-    "  cpu_min: 4                   # WorkflowOrchestrator + ThreadPoolExecutor(4 workers)\n",
-    "  gpu_min: 16                  # Qwen fp8 Phase 29 ~6 min/image cold-start (#5867)\n",
-    "  gpu_required: true           # _GPU_SEMAPHORE=1 serialise les generations paralleles\n",
-    "  vram_gb: 16                  # VAE 16 canaux + UNET + VLM qwen_2.5_vl_7b_fp8_scaled\n",
-    "  vram_tier: MID\n",
-    "  network: true\n",
-    "  external_account: hf          # HF_TOKEN pour Qwen checkpoints + Bearer ComfyUI\n",
-    "  free_alternative: null\n",
-    "  reduced_pedagogical: GenAI/Image/01-Foundation/01-5-Qwen-Image-Edit.ipynb\n",
-    "  reproducibility: HIGH         # torch.manual_seed(42) + workflow JSON identique\n",
-    "  last_validated: 2026-07-23T01:30Z\n",
-    "  validator: sk_visual\n",
-    "notes: |\n",
-    "  Pattern d'orchestration : WorkflowOrchestrator(run_sequential + run_parallel + ConditionalPipeline + MultiVariationPipeline).\n",
-    "  Generation reelle via ComfyUI Qwen Image (workflow Phase 29, port 8188) ; repli placeholder colore si service indisponible (orchestration reste demonstrable).\n",
-    "  Semaphore GPU 1 generation Qwen a la fois (FP8 lourd sur 1 GPU) — serialise run_parallel sans changer le contrat.\n",
-    "  Caching MD5 sur (step_name, inputs) + _GENERATED_CACHE prompt->image.\n",
-    "  Workflow text-to-image Phase 29 : VAELoader + CLIPLoader qwen_2.5_vl_7b_fp8_scaled + UNETLoader qwen_image_edit_2509_fp8_e4m3fn + ModelSamplingAuraFlow(shift=3.0) + CFGNorm(strength=1.0) + TextEncodeQwenImageEdit + KSampler(steps=12, cfg=1.0, scheduler=beta).\n",
-    "---\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "cell-0",
    "metadata": {
     "papermill": {
@@ -1989,6 +1959,23 @@
    },
    "start_time": "2026-07-10T18:48:13.376547",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "local",
+   "cpu_min": 4,
+   "gpu_min": 16,
+   "gpu_required": true,
+   "vram_gb": 16,
+   "vram_tier": "MID",
+   "network": true,
+   "external_account": "hf",
+   "free_alternative": null,
+   "reduced_pedagogical": "GenAI/Image/01-Foundation/01-5-Qwen-Image-Edit.ipynb",
+   "reproducibility": "HIGH",
+   "last_validated": "2026-07-23T01:30Z",
+   "validator": "sk_visual",
+   "notes": "Pattern d'orchestration : WorkflowOrchestrator(run_sequential + run_parallel + ConditionalPipeline + MultiVariationPipeline).\nGeneration reelle via ComfyUI Qwen Image (workflow Phase 29, port 8188) ; repli placeholder colore si service indisponible (orchestration reste demonstrable).\nSemaphore GPU 1 generation Qwen a la fois (FP8 lourd sur 1 GPU) — serialise run_parallel sans changer le contrat.\nCaching MD5 sur (step_name, inputs) + _GENERATED_CACHE prompt->image.\nWorkflow text-to-image Phase 29 : VAELoader + CLIPLoader qwen_2.5_vl_7b_fp8_scaled + UNETLoader qwen_image_edit_2509_fp8_e4m3fn + ModelSamplingAuraFlow(shift=3.0) + CFGNorm(strength=1.0) + TextEncodeQwenImageEdit + KSampler(steps=12, cfg=1.0, scheduler=beta).\n"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/03-3-Performance-Optimization.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/03-3-Performance-Optimization.ipynb
@@ -30,36 +30,6 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: Performance Optimization - Profilage GPU/Memoire, Quantization, Batch Sizing\n",
-    "cost:\n",
-    "  api_usd_est: 0.0             # Self-hosted optimization toolkit, pas de cout API\n",
-    "  api_provider: local\n",
-    "  cpu_min: 4\n",
-    "  gpu_min: 24                  # RTX 3090 detecte (24 GB VRAM, HIGH tier recommande)\n",
-    "  gpu_required: true           # Profilage torch.cuda.memory_allocated() + sync\n",
-    "  vram_gb: 24                  # Profil High VRAM (16GB+) — RTX 3090/3080/4090\n",
-    "  vram_tier: HIGH\n",
-    "  network: false                # Toolkit local pur (xformers/flash/sdpa/torch.compile)\n",
-    "  external_account: none        # Pas de cle externe (verification env local uniquement)\n",
-    "  free_alternative: null        # Pas d'equivalent — toolkit optimisation specifique\n",
-    "  reduced_pedagogical: GenAI/Image/03-Orchestration/03-2-Workflow-Orchestration.ipynb\n",
-    "  reproducibility: HIGH         # torch.cuda + dataclass metrics deterministes\n",
-    "  last_validated: 2026-07-23T01:30Z\n",
-    "  validator: papermill          # Executable localement (kernel torch CUDA)\n",
-    "notes: |\n",
-    "  Profils d'optimisation predefinis : low_vram (4-6GB, INT8, sequential_cpu_offload) / medium_vram (8-12GB, FP16, model_cpu_offload) / high_vram (16GB+, BF16, flash_attention_2) / production (max-autotune).\n",
-    "  Recommandation RTX 3090 24GB : high_vram (BF16 + flash_attention_2 + reduce-overhead + batch=4).\n",
-    "  Techniques : FP16/BF16 (50% VRAM), INT8 (75%), Flash Attention 2 (40% speedup), torch.compile (10-20%), VAE tiling (50%+ grandes images).\n",
-    "  GPUProfiler.contextmanager(profile(name, num_images)) encapsule torch.cuda.synchronize() + memory peak/allocated tracking.\n",
-    "  BenchmarkSuite.run_synthetic_benchmark = simulate_model_inference(size_mb, compute_ms) avec iterations=3, warmup=1.\n",
-    "---\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "d4fc8cfa",
    "metadata": {
     "papermill": {
@@ -2981,6 +2951,23 @@
    },
    "start_time": "2026-05-12T10:01:04.241416",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "local",
+   "cpu_min": 4,
+   "gpu_min": 24,
+   "gpu_required": true,
+   "vram_gb": 24,
+   "vram_tier": "HIGH",
+   "network": false,
+   "external_account": "none",
+   "free_alternative": null,
+   "reduced_pedagogical": "GenAI/Image/03-Orchestration/03-2-Workflow-Orchestration.ipynb",
+   "reproducibility": "HIGH",
+   "last_validated": "2026-07-23T01:30Z",
+   "validator": "papermill",
+   "notes": "Profils d'optimisation predefinis : low_vram (4-6GB, INT8, sequential_cpu_offload) / medium_vram (8-12GB, FP16, model_cpu_offload) / high_vram (16GB+, BF16, flash_attention_2) / production (max-autotune).\nRecommandation RTX 3090 24GB : high_vram (BF16 + flash_attention_2 + reduce-overhead + batch=4).\nTechniques : FP16/BF16 (50% VRAM), INT8 (75%), Flash Attention 2 (40% speedup), torch.compile (10-20%), VAE tiling (50%+ grandes images).\nGPUProfiler.contextmanager(profile(name, num_images)) encapsule torch.cuda.synchronize() + memory peak/allocated tracking.\nBenchmarkSuite.run_synthetic_benchmark = simulate_model_inference(size_mb, compute_ms) avec iterations=3, warmup=1.\n"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/Image/04-Applications/04-1-Educational-Content-Generation.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/04-Applications/04-1-Educational-Content-Generation.ipynb
@@ -44,36 +44,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: Educational Content Generation - gpt-image-1 + GPT-5 + WCAG alt text\n",
-    "cost:\n",
-    "  api_usd_est: 0.30            # gpt-image-1 1024x1024 high ~$0.167 + GPT-5 alt text ~$0.005 + ~$0.10 buffer\n",
-    "  api_provider: openai          # gpt-image-1 API directe (OpenRouter ne supporte pas /images)\n",
-    "  cpu_min: 2\n",
-    "  gpu_min: 0\n",
-    "  gpu_required: false\n",
-    "  vram_gb: 0\n",
-    "  vram_tier: LITE\n",
-    "  network: true                 # HTTPS api.openai.com + openrouter.ai obligatoires\n",
-    "  external_account: openai      # OPENAI_API_KEY dans .env + OPENROUTER_API_KEY (alt text)\n",
-    "  free_alternative: GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb\n",
-    "  reduced_pedagogical: GenAI/Image/04-Applications/04-2-Creative-Workflows.ipynb\n",
-    "  reproducibility: MED          # Mode routing OpenRouter dependant du snapshot\n",
-    "  last_validated: 2026-07-23T01:30Z\n",
-    "  validator: papermill\n",
-    "notes: |\n",
-    "  Templates preconfigures 5 matieres (biology/physics/chemistry/mathematics/history) avec style_prompts + colors hex + keywords.\n",
-    "  Pipeline : generate_educational_prompt(subject, topic, level) -> gpt-image-1 (size=1024x1024 quality=high) -> generate_alt_text via OpenRouter Claude 3.5 (max_tokens=100).\n",
-    "  TeacherWorkflow.create_complete_lesson_package genere plan de cours + N diagrammes + alt text WCAG (~125 chars max recommande).\n",
-    "  Demonstration batch reproductible : execute generate_educational_prompt(photosynthesis) + generate_educational_image() + alt text.\n",
-    "  Cout reel depend de quality (low/medium/high/auto) et taille (1024x1024, 1024x1536, 1536x1024).\n",
-    "---\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "cf2c0a34",
@@ -2725,6 +2695,23 @@
     "version_major": 2,
     "version_minor": 0
    }
+  },
+  "cost": {
+   "api_usd_est": 0.3,
+   "api_provider": "openai",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "LITE",
+   "network": true,
+   "external_account": "openai",
+   "free_alternative": "GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb",
+   "reduced_pedagogical": "GenAI/Image/04-Applications/04-2-Creative-Workflows.ipynb",
+   "reproducibility": "MED",
+   "last_validated": "2026-07-23T01:30Z",
+   "validator": "papermill",
+   "notes": "Templates preconfigures 5 matieres (biology/physics/chemistry/mathematics/history) avec style_prompts + colors hex + keywords.\nPipeline : generate_educational_prompt(subject, topic, level) -> gpt-image-1 (size=1024x1024 quality=high) -> generate_alt_text via OpenRouter Claude 3.5 (max_tokens=100).\nTeacherWorkflow.create_complete_lesson_package genere plan de cours + N diagrammes + alt text WCAG (~125 chars max recommande).\nDemonstration batch reproductible : execute generate_educational_prompt(photosynthesis) + generate_educational_image() + alt text.\nCout reel depend de quality (low/medium/high/auto) et taille (1024x1024, 1024x1536, 1536x1024).\n"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/Image/04-Applications/04-2-Creative-Workflows.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/04-Applications/04-2-Creative-Workflows.ipynb
@@ -44,36 +44,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: Creative Workflows - concept_to_image / style_variations / storyboard / brand_identity\n",
-    "cost:\n",
-    "  api_usd_est: 0.65            # 5 variations gpt-image-1 medium 1024x1024 ~$0.21 (demo $0.04 medium)\n",
-    "  api_provider: openai          # gpt-image-1 direct (variations x N styles)\n",
-    "  cpu_min: 2\n",
-    "  gpu_min: 0\n",
-    "  gpu_required: false\n",
-    "  vram_gb: 0\n",
-    "  vram_tier: LITE\n",
-    "  network: true\n",
-    "  external_account: openai      # OPENAI_API_KEY + OPENROUTER_API_KEY (Claude 3.5 Sonnet)\n",
-    "  free_alternative: GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb\n",
-    "  reduced_pedagogical: GenAI/Image/04-Applications/04-1-Educational-Content-Generation.ipynb\n",
-    "  reproducibility: MED\n",
-    "  last_validated: 2026-07-23T01:30Z\n",
-    "  validator: papermill\n",
-    "notes: |\n",
-    "  4 workflows specialises : concept_to_image (3 etapes : base + sketch + refinement) / style_variations (N styles) / storyboard (scene representative) / brand_identity (logo simplifie).\n",
-    "  CreativeWorkflowEngine : style_templates (modern/vintage/minimalist/artistic/professional) avec description + colors + keywords.\n",
-    "  Cout eleve en mode variations : 5 styles x gpt-image-1 medium = ~$0.21. Demo rapide quality=low pour minimiser cout (image reelle gpt-image-1).\n",
-    "  Gallery HTML avec CSS inline (gradients, grid layout, border-radius) generee via display(HTML()).\n",
-    "  Prompt engineering contextuel : meme concept produit des prompts differents par stage (concept_analysis / sketch_generation / refinement / final_render).\n",
-    "---\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "28b971b1",
@@ -3838,6 +3808,23 @@
     "version_major": 2,
     "version_minor": 0
    }
+  },
+  "cost": {
+   "api_usd_est": 0.65,
+   "api_provider": "openai",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "LITE",
+   "network": true,
+   "external_account": "openai",
+   "free_alternative": "GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb",
+   "reduced_pedagogical": "GenAI/Image/04-Applications/04-1-Educational-Content-Generation.ipynb",
+   "reproducibility": "MED",
+   "last_validated": "2026-07-23T01:30Z",
+   "validator": "papermill",
+   "notes": "4 workflows specialises : concept_to_image (3 etapes : base + sketch + refinement) / style_variations (N styles) / storyboard (scene representative) / brand_identity (logo simplifie).\nCreativeWorkflowEngine : style_templates (modern/vintage/minimalist/artistic/professional) avec description + colors + keywords.\nCout eleve en mode variations : 5 styles x gpt-image-1 medium = ~$0.21. Demo rapide quality=low pour minimiser cout (image reelle gpt-image-1).\nGallery HTML avec CSS inline (gradients, grid layout, border-radius) generee via display(HTML()).\nPrompt engineering contextuel : meme concept produit des prompts differents par stage (concept_analysis / sketch_generation / refinement / final_render).\n"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/Image/04-Applications/04-3-Production-Integration.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/04-Applications/04-3-Production-Integration.ipynb
@@ -46,38 +46,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: Production Integration - Batch Processing, Cost Tracking, Quality Assurance, Monitoring\n",
-    "cost:\n",
-    "  api_usd_est: 5.0             # Budget notebook $50 USD configurable (CostTracker) - demo\n",
-    "  api_provider: openai          # gpt-image-1 batch + OpenRouter Claude 3.5 quality check\n",
-    "  cpu_min: 4                   # ProductionEngine + sqlite3 + asyncio + aiohttp\n",
-    "  gpu_min: 0\n",
-    "  gpu_required: false\n",
-    "  vram_gb: 0\n",
-    "  vram_tier: LITE\n",
-    "  network: true                 # HTTPS OpenAI + OpenRouter + webhooks\n",
-    "  external_account: openai      # OPENAI_API_KEY (batch + cost tracking) + OPENROUTER_API_KEY\n",
-    "  free_alternative: null        # Pas d'equivalent production-grade open weights local\n",
-    "  reduced_pedagogical: GenAI/Image/04-Applications/04-2-Creative-Workflows.ipynb\n",
-    "  reproducibility: MED          # Mode routing OpenRouter + rate limits OpenAI variables\n",
-    "  last_validated: 2026-07-23T01:30Z\n",
-    "  validator: papermill\n",
-    "notes: |\n",
-    "  Budget notebook : cost_budget_limit=$50 (configurable via cost_widget.FloatText), cost_alert_threshold=80% (logger.warning).\n",
-    "  Cout reel : gpt-image-1 high ~$0.167/image, medium ~$0.042/image (cost_per_image_high/medium dans api_configs).\n",
-    "  ProductionEngine : job_queue.Queue + active_jobs/completed_jobs + submit_batch_job + CostTracker + QualityAssurance + MonitoringDashboard.\n",
-    "  SQLite logging : tables production_jobs (job_id/job_type/status/cost) + generated_images (image_id/url/quality_score) + cost_tracking (cumulative_cost).\n",
-    "  QualityAssurance.evaluate_image_quality = simulation random.uniform(0.6, 0.95) sur consistency/clarity/relevance ; en production, utiliser modele specialise.\n",
-    "  Dashboard HTML live : total_jobs / success_rate / total_images / total_cost / average_quality / uptime_hours / cost_per_image.\n",
-    "  Circuit breaker : cost_tracker.can_afford(estimated_cost) bloque job si budget > remaining.\n",
-    "---\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "4f9f3e0f",
@@ -4211,6 +4179,23 @@
     "version_major": 2,
     "version_minor": 0
    }
+  },
+  "cost": {
+   "api_usd_est": 5.0,
+   "api_provider": "openai",
+   "cpu_min": 4,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "LITE",
+   "network": true,
+   "external_account": "openai",
+   "free_alternative": null,
+   "reduced_pedagogical": "GenAI/Image/04-Applications/04-2-Creative-Workflows.ipynb",
+   "reproducibility": "MED",
+   "last_validated": "2026-07-23T01:30Z",
+   "validator": "papermill",
+   "notes": "Budget notebook : cost_budget_limit=$50 (configurable via cost_widget.FloatText), cost_alert_threshold=80% (logger.warning).\nCout reel : gpt-image-1 high ~$0.167/image, medium ~$0.042/image (cost_per_image_high/medium dans api_configs).\nProductionEngine : job_queue.Queue + active_jobs/completed_jobs + submit_batch_job + CostTracker + QualityAssurance + MonitoringDashboard.\nSQLite logging : tables production_jobs (job_id/job_type/status/cost) + generated_images (image_id/url/quality_score) + cost_tracking (cumulative_cost).\nQualityAssurance.evaluate_image_quality = simulation random.uniform(0.6, 0.95) sur consistency/clarity/relevance ; en production, utiliser modele specialise.\nDashboard HTML live : total_jobs / success_rate / total_images / total_cost / average_quality / uptime_hours / cost_per_image.\nCircuit breaker : cost_tracker.can_afford(estimated_cost) bloque job si budget > remaining.\n"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/Image/04-Applications/04-4-Cross-Stitch-Pattern-Maker-Legacy.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/04-Applications/04-4-Cross-Stitch-Pattern-Maker-Legacy.ipynb
@@ -40,36 +40,6 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: \"Cross-Stitch Pattern Maker (Legacy Stable Diffusion + palette DMC)\"\n",
-    "cost:\n",
-    "  api_usd_est: 0.20            # ~5 images Stable Diffusion medium 512x512 x $0.04/image\n",
-    "  api_provider: stability        # Stable Diffusion API externe (api.stability.ai)\n",
-    "  cpu_min: 2\n",
-    "  gpu_min: 0\n",
-    "  gpu_required: false\n",
-    "  vram_gb: 0\n",
-    "  vram_tier: LITE\n",
-    "  network: true                 # HTTPS api.stability.ai + DMC palette JSON local\n",
-    "  external_account: stability   # STABILITY_API_KEY dans .env\n",
-    "  free_alternative: GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb\n",
-    "  reduced_pedagogical: GenAI/Image/01-Foundation/01-3-Basic-Image-Operations.ipynb\n",
-    "  reproducibility: LOW          # Stable Diffusion API stochastic, palette DMC deterministe\n",
-    "  last_validated: 2026-07-23T08:45Z\n",
-    "  validator: papermill\n",
-    "notes: |\n",
-    "  Notebook LEGACY : transformation image vers patron de point de croix.\n",
-    "  Pipeline : upload image → Stable Diffusion API (pixel art) → reduction palette DMC → grille.\n",
-    "  Palette DMC : fichier JSON local (pas d'API).\n",
-    "  Cout reel depend du nombre d'iterations Stable Diffusion (~5-10 par demo).\n",
-    "  Alternative gratuite : Forge SD XL Turbo local (pas de cle API).\n",
-    "---\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "f8t8qfwlmdl",
    "metadata": {
     "papermill": {
@@ -1185,7 +1155,24 @@
   },
   "tags": [
    "NEEDS_INFRA"
-  ]
+  ],
+  "cost": {
+   "api_usd_est": 0.2,
+   "api_provider": "stability",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "LITE",
+   "network": true,
+   "external_account": "stability",
+   "free_alternative": "GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb",
+   "reduced_pedagogical": "GenAI/Image/01-Foundation/01-3-Basic-Image-Operations.ipynb",
+   "reproducibility": "LOW",
+   "last_validated": "2026-07-23T08:45Z",
+   "validator": "papermill",
+   "notes": "Notebook LEGACY : transformation image vers patron de point de croix.\nPipeline : upload image → Stable Diffusion API (pixel art) → reduction palette DMC → grille.\nPalette DMC : fichier JSON local (pas d'API).\nCout reel depend du nombre d'iterations Stable Diffusion (~5-10 par demo).\nAlternative gratuite : Forge SD XL Turbo local (pas de cle API).\n"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 5

--- a/MyIA.AI.Notebooks/GenAI/Image/04-Applications/04-4-Cross-Stitch-Pattern-Maker-Legacy.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/04-Applications/04-4-Cross-Stitch-Pattern-Maker-Legacy.ipynb
@@ -40,6 +40,36 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "title: \"Cross-Stitch Pattern Maker (Legacy Stable Diffusion + palette DMC)\"\n",
+    "cost:\n",
+    "  api_usd_est: 0.20            # ~5 images Stable Diffusion medium 512x512 x $0.04/image\n",
+    "  api_provider: stability        # Stable Diffusion API externe (api.stability.ai)\n",
+    "  cpu_min: 2\n",
+    "  gpu_min: 0\n",
+    "  gpu_required: false\n",
+    "  vram_gb: 0\n",
+    "  vram_tier: LITE\n",
+    "  network: true                 # HTTPS api.stability.ai + DMC palette JSON local\n",
+    "  external_account: stability   # STABILITY_API_KEY dans .env\n",
+    "  free_alternative: GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb\n",
+    "  reduced_pedagogical: GenAI/Image/01-Foundation/01-3-Basic-Image-Operations.ipynb\n",
+    "  reproducibility: LOW          # Stable Diffusion API stochastic, palette DMC deterministe\n",
+    "  last_validated: 2026-07-23T08:45Z\n",
+    "  validator: papermill\n",
+    "notes: |\n",
+    "  Notebook LEGACY : transformation image vers patron de point de croix.\n",
+    "  Pipeline : upload image → Stable Diffusion API (pixel art) → reduction palette DMC → grille.\n",
+    "  Palette DMC : fichier JSON local (pas d'API).\n",
+    "  Cout reel depend du nombre d'iterations Stable Diffusion (~5-10 par demo).\n",
+    "  Alternative gratuite : Forge SD XL Turbo local (pas de cle API).\n",
+    "---\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "f8t8qfwlmdl",
    "metadata": {
     "papermill": {
@@ -1155,24 +1185,7 @@
   },
   "tags": [
    "NEEDS_INFRA"
-  ],
-  "cost": {
-   "api_usd_est": 0.2,
-   "api_provider": "stability",
-   "cpu_min": 2,
-   "gpu_min": 0,
-   "gpu_required": false,
-   "vram_gb": 0,
-   "vram_tier": "LITE",
-   "network": true,
-   "external_account": "stability",
-   "free_alternative": "GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb",
-   "reduced_pedagogical": "GenAI/Image/01-Foundation/01-3-Basic-Image-Operations.ipynb",
-   "reproducibility": "LOW",
-   "last_validated": "2026-07-23T08:45Z",
-   "validator": "papermill",
-   "notes": "Notebook LEGACY : transformation image vers patron de point de croix.\nPipeline : upload image → Stable Diffusion API (pixel art) → reduction palette DMC → grille.\nPalette DMC : fichier JSON local (pas d'API).\nCout reel depend du nombre d'iterations Stable Diffusion (~5-10 par demo).\nAlternative gratuite : Forge SD XL Turbo local (pas de cle API).\n"
-  }
+  ]
  },
  "nbformat": 4,
  "nbformat_minor": 5

--- a/MyIA.AI.Notebooks/GenAI/Image/examples/history-geography.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/examples/history-geography.ipynb
@@ -38,35 +38,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: \"Histoire-Geographie avec GenAI (gpt-image-1 OpenAI)\"\n",
-    "cost:\n",
-    "  api_usd_est: 0.40            # ~4 images demo x $0.10/image (gpt-image-1 medium 1024x1024)\n",
-    "  api_provider: openai          # OpenAI direct (OpenRouter ne supporte pas /v1/images/generations)\n",
-    "  cpu_min: 2\n",
-    "  gpu_min: 0\n",
-    "  gpu_required: false\n",
-    "  vram_gb: 0\n",
-    "  vram_tier: LITE\n",
-    "  network: true                 # HTTPS api.openai.com obligatoire\n",
-    "  external_account: openai      # OPENAI_API_KEY dans .env\n",
-    "  free_alternative: GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb\n",
-    "  reduced_pedagogical: GenAI/Image/01-Foundation/01-3-Basic-Image-Operations.ipynb\n",
-    "  reproducibility: MED          # Pas de seed deterministe cote OpenAI\n",
-    "  last_validated: 2026-07-23T08:45Z\n",
-    "  validator: papermill\n",
-    "notes: |\n",
-    "  Exemples sectoriels Histoire-Geographie : cartes historiques, reconstructions, timelines.\n",
-    "  gpt-image-1 (modele sous-jacent a DALL-E 3 en juillet 2026).\n",
-    "  Cout reel depend de quality (low/medium/high/auto) et taille (1024x1024, 1536x1024, 1024x1536).\n",
-    "  Pedagogie : adapter le contenu visuel au niveau educatif (collège, lycée, supérieur).\n",
-    "---\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "8624c6e8",
@@ -1605,6 +1576,23 @@
    },
    "start_time": "2026-06-24T04:50:14.321800",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.4,
+   "api_provider": "openai",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "LITE",
+   "network": true,
+   "external_account": "openai",
+   "free_alternative": "GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb",
+   "reduced_pedagogical": "GenAI/Image/01-Foundation/01-3-Basic-Image-Operations.ipynb",
+   "reproducibility": "MED",
+   "last_validated": "2026-07-23T08:45Z",
+   "validator": "papermill",
+   "notes": "Exemples sectoriels Histoire-Geographie : cartes historiques, reconstructions, timelines.\ngpt-image-1 (modele sous-jacent a DALL-E 3 en juillet 2026).\nCout reel depend de quality (low/medium/high/auto) et taille (1024x1024, 1536x1024, 1024x1536).\nPedagogie : adapter le contenu visuel au niveau educatif (collège, lycée, supérieur).\n"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/Image/examples/literature-visual.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/examples/literature-visual.ipynb
@@ -38,35 +38,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: \"Litterature Visuelle avec GenAI (gpt-image-1 OpenAI)\"\n",
-    "cost:\n",
-    "  api_usd_est: 0.40            # ~4 images demo x $0.10/image (gpt-image-1 medium 1024x1024)\n",
-    "  api_provider: openai          # OpenAI direct (OpenRouter ne supporte pas /v1/images/generations)\n",
-    "  cpu_min: 2\n",
-    "  gpu_min: 0\n",
-    "  gpu_required: false\n",
-    "  vram_gb: 0\n",
-    "  vram_tier: LITE\n",
-    "  network: true                 # HTTPS api.openai.com obligatoire\n",
-    "  external_account: openai      # OPENAI_API_KEY dans .env\n",
-    "  free_alternative: GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb\n",
-    "  reduced_pedagogical: GenAI/Image/01-Foundation/01-3-Basic-Image-Operations.ipynb\n",
-    "  reproducibility: MED          # Pas de seed deterministe cote OpenAI\n",
-    "  last_validated: 2026-07-23T08:45Z\n",
-    "  validator: papermill\n",
-    "notes: |\n",
-    "  Exemples sectoriels Litterature : illustrations classiques, character designs, storyboards, visualisations de metaphores.\n",
-    "  gpt-image-1 (modele sous-jacent a DALL-E 3 en juillet 2026).\n",
-    "  Cout reel depend de quality (low/medium/high/auto) et taille (1024x1024, 1536x1024, 1024x1536).\n",
-    "  Pedagogie : enrichir l'analyse litteraire par l'image (illustration, symbolisme, narration visuelle).\n",
-    "---\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "d0ea4fb5",
@@ -1738,6 +1709,23 @@
    },
    "start_time": "2026-06-24T04:54:12.738879",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.4,
+   "api_provider": "openai",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "LITE",
+   "network": true,
+   "external_account": "openai",
+   "free_alternative": "GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb",
+   "reduced_pedagogical": "GenAI/Image/01-Foundation/01-3-Basic-Image-Operations.ipynb",
+   "reproducibility": "MED",
+   "last_validated": "2026-07-23T08:45Z",
+   "validator": "papermill",
+   "notes": "Exemples sectoriels Litterature : illustrations classiques, character designs, storyboards, visualisations de metaphores.\ngpt-image-1 (modele sous-jacent a DALL-E 3 en juillet 2026).\nCout reel depend de quality (low/medium/high/auto) et taille (1024x1024, 1536x1024, 1024x1536).\nPedagogie : enrichir l'analyse litteraire par l'image (illustration, symbolisme, narration visuelle).\n"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/Image/examples/science-diagrams.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/examples/science-diagrams.ipynb
@@ -40,35 +40,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "title: \"Diagrammes Scientifiques avec GenAI (gpt-image-1 + GPT-4o Vision OpenAI)\"\n",
-    "cost:\n",
-    "  api_usd_est: 0.60            # ~4 images gpt-image-1 x $0.10 + 2 appels GPT-4o Vision x $0.10\n",
-    "  api_provider: openai          # OpenAI direct (gpt-image-1 + GPT-4o Vision)\n",
-    "  cpu_min: 2\n",
-    "  gpu_min: 0\n",
-    "  gpu_required: false\n",
-    "  vram_gb: 0\n",
-    "  vram_tier: LITE\n",
-    "  network: true                 # HTTPS api.openai.com obligatoire\n",
-    "  external_account: openai      # OPENAI_API_KEY dans .env\n",
-    "  free_alternative: GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb\n",
-    "  reduced_pedagogical: GenAI/Image/01-Foundation/01-3-Basic-Image-Operations.ipynb\n",
-    "  reproducibility: MED          # Pas de seed deterministe cote OpenAI\n",
-    "  last_validated: 2026-07-23T08:45Z\n",
-    "  validator: papermill\n",
-    "notes: |\n",
-    "  Exemples sectoriels Sciences : diagrammes biologiques, illustrations physique/chimie, schemas mathematiques.\n",
-    "  Pipeline : GPT-4o Vision (analyse references) + gpt-image-1 (generation diagramme).\n",
-    "  Cout superieur aux autres exemples sectoriels (GPT-4o Vision ajoute ~$0.10/appel).\n",
-    "  Pedagogie : optimisation pour clarte (labels, legendes, annotations).\n",
-    "---\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "26f6505b",
@@ -2115,6 +2086,23 @@
    },
    "start_time": "2026-06-24T04:57:41.088397",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.6,
+   "api_provider": "openai",
+   "cpu_min": 2,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "LITE",
+   "network": true,
+   "external_account": "openai",
+   "free_alternative": "GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb",
+   "reduced_pedagogical": "GenAI/Image/01-Foundation/01-3-Basic-Image-Operations.ipynb",
+   "reproducibility": "MED",
+   "last_validated": "2026-07-23T08:45Z",
+   "validator": "papermill",
+   "notes": "Exemples sectoriels Sciences : diagrammes biologiques, illustrations physique/chimie, schemas mathematiques.\nPipeline : GPT-4o Vision (analyse references) + gpt-image-1 (generation diagramme).\nCout superieur aux autres exemples sectoriels (GPT-4o Vision ajoute ~$0.10/appel).\nPedagogie : optimisation pour clarte (labels, legendes, annotations).\n"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary

Guard **#8352/#8056** storage-format migration: **9 GenAI/Image** notebooks legacy `---`-YAML cost frontmatter -> `nb.metadata['cost']` (schema #8376). Resolves the markdown-it setext-H2 supersize rendering defect (HARD CI block).

Sibling of **#8579** (GenAI/Audio/04, same canonical recipe). Different family (R6 variety).

## Scope (9 NBs)

- `03-Orchestration/` x3: 03-1-Multi-Model-Comparison, 03-2-Workflow-Orchestration, 03-3-Performance-Optimization
- `04-Applications/` x3: 04-1-Educational-Content-Generation, 04-2-Creative-Workflows, 04-3-Production-Integration
- `examples/` x3: history-geography, literature-visual, science-diagrams

## Excluded: 04-4-Cross-Stitch-Pattern-Maker-Legacy

Originally in scope (10 NBs), **excluded** in commit 2 (``5ee837431``). 04-4 carries **2 PRE-EXISTING degenerate figures** (tiny_payload PNG 166B + 148B) on origin/main — confirmed firsthand (identical byte payloads, -1 cell shift from frontmatter removal). NOT introduced by this migration. The "No degenerate figure in changed notebooks" gate scans ALL changed notebooks, so touching 04-4 triggers it regardless of my storage-format-only change. The defect is **RECOVERABLE-MACHINE** (GenAI/Image SD-Legacy re-exec needs ComfyUI/SD GPU stack, po-2023 lane) — out of scope for a cost-frontmatter migration, not fixable on a CPU lane (Stop&Repair: never scrub). 04-4's cost-migration will land together with its figure-fix in the GenAI GPU re-exec PR. Surfaced as a finding for the GenAI/Image lane.

## Canonical rules (cf #8579)

- `title:` dropped — visible H1 serves as title (**each NB verified firsthand to have an H1**)
- top-level `notes:` merged INTO `cost.notes`
- YAML `null` -> JSON `null`; types preserved (PyYAML `safe_load_all`)
- **0 code cells modified** (C.2 N/A — storage-format only, no re-exec)
- `json.dumps(ensure_ascii=False, indent=1)+"\n"` via `write_bytes` (LF, byte-stable, no nbformat churn)

## Validation (canonical chain)

- `check_cost_metadata.py` -> `cost_source:'metadata'` (9/9)
- `detect_markdown_rendering.py --check` -> **0 violations** in changed NBs
- `detect_blank_figures.py --check` -> **0 degenerate figures** in the 9 (04-4 excluded)
- `validate_pr_notebooks.py` H.3 -> **All notebooks passed**
- LF-only (origin/main LF, migrated LF; `core.autocrlf=input`, `.gitattributes *.ipynb text eol=lf`)
- Forensic: cell-count delta **-1 each**, **0 execution_count churn** (storage-format confirmed)
- Surgical diff: **+153/-268 across 9 files**
- No twin-registry entanglement (`grep twin_pairs.yaml` = 0)

See #8056 (partial epic — 128 landmines fleet-wide, this tranche removes 9).

Co-Authored-By: Claude-Code <noreply@anthropic.com>