### PR TITLE
docs(kernels): section .NET Interactive — version reelle 1.0.617701 + Papermill execute bien .NET

### DIFF
--- a/docs/reference/kernels-runtime.md
+++ b/docs/reference/kernels-runtime.md
@@ -11,14 +11,34 @@ Notebooks dans `SymbolicAI/SemanticWeb/`, `SymbolicAI/SmartContract/`, `Search/`
 | Prerequis | Version | Verification |
 |-----------|---------|-------------|
 | .NET SDK | 8.0 + 9.0 (10.0 optionnel) | `dotnet --list-sdks` |
-| dotnet-interactive | >= 1.0.700 (PIN 1.0.552801 sur ai-01) | `dotnet interactive --version` |
+| dotnet-interactive | **1.0.617701** (verifie sur ai-01, cf ci-dessous) | `dotnet interactive --version` |
 | Jupyter kernels `.net-csharp`, `.net-fsharp`, `.net-powershell` | auto-installes | `jupyter kernelspec list` |
 
-Installation : `dotnet tool install --global Microsoft.dotnet-interactive` puis `dotnet interactive jupyter install`.
+Installation : `dotnet tool install --global Microsoft.dotnet-interactive --version 1.0.617701` puis `dotnet interactive jupyter install`. **Preciser la version** : une installation sans `--version` prend le dernier build publie, aujourd'hui 1.0.712001, qui casse `#!import` (cf tableau ci-dessous).
 
-**Execution** : toujours cell-by-cell via MCP Jupyter (Papermill ne supporte pas .NET Interactive). Le kernel `.net-csharp` preserve l'etat entre cellules.
+**Execution** : `python scripts/notebook_tools/notebook_tools.py execute <notebook>` — qui pilote Papermill avec `--kernel .net-csharp`. Le kernel preserve l'etat entre cellules, `#!import` compris.
 
-**Versions a EVITER** : 1.0.522904 (Roslyn bug), 1.0.712001 (`#!import` bug). PIN sur 1.0.552801 si possible.
+Ce document affirmait « Papermill ne supporte pas .NET Interactive » et renvoyait vers l'execution cell-by-cell par MCP Jupyter. **C'est faux**, et la consequence etait couteuse : le chemin MCP hang (#835), donc des notebooks .NET etaient committes sans re-execution (violation C.2/H.3, cf l'anti-pattern PR #1591 cite en CLAUDE.md regle F). Verifie firsthand sur ai-01 le 2026-07-25 (dni 1.0.617701) — Papermill execute bien un notebook `.net-csharp` de bout en bout, `execution_count` et sorties reelles a l'appui, y compris a travers un `#!import`.
+
+La **seule** limite reelle est l'**injection de parametres** : Papermill n'a pas de traducteur C#, donc une cellule taguee `parameters` avec `-p` produit `Translator for 'C#' language does not support parameter introspection.` — l'avertissement est emis, l'injection est ignoree, **et le notebook s'execute quand meme**. Les notebooks .NET du depot ne prennent pas de parametres Papermill ; `BATCH_MODE` passe par variable d'environnement, pas par `-p`, et reste donc disponible.
+
+Deux limites voisines, **distinctes** de celle-ci, restent vraies : le restore `#r "nuget:"` est bloque cluster-wide en Papermill headless (cf [dotnet-plotly-zero-restore.md](dotnet-plotly-zero-restore.md)), et la **CI** ne peut pas re-executer ces notebooks faute de kernel installe sur le runner — d'ou l'exigence d'execution **locale** avant commit ([pr-review-discipline.md](../../.claude/rules/pr-review-discipline.md) §D).
+
+### Version : 1.0.617701, pas « >= 1.0.700 »
+
+| Version | Etat | Preuve |
+|---------|------|--------|
+| 1.0.522904 | a eviter | bug Roslyn |
+| 1.0.552801 | ancien pin — **ne plus viser** : hote net8.0-only, bloque les notebooks qui referencent des DLL `net9.0` | [`Search/Part4-Metaheuristics/README.md`](../../MyIA.AI.Notebooks/Search/Part4-Metaheuristics/README.md) (MGS-6 a MGS-9, `MetaGeneticSharp.Extensions`) |
+| **1.0.617701** | **cible** — cellule C# et `#!import` OK | verifie firsthand sur ai-01 le 2026-07-25 : `notebook_tools.py execute` sur un notebook `.net-csharp` (SUCCESS 4,4 s, `execution_count: 1`) et sur une paire `#!import helper.ipynb` + appel de la methode importee (SUCCESS 3,8 s, cellule 2 imprime le resultat) |
+| 1.0.712001 | a eviter | `#!import` casse (`ArgumentNullException`) — bloque la re-execution de `Sudoku-15-Infer-Csharp` (#8485, #8525) et le pivot d'env #8369 |
+
+Une contrainte `>= 1.0.700` figurait ici : elle est **fausse et nuisible** — elle exclut le pin qu'elle citait dans la meme ligne (552801 < 700) et n'admet, aujourd'hui, que la version cassee. Un `#!import` en echec est un **defaut d'environnement reparable en une commande** (regle F), jamais un blocage utilisateur :
+
+```bash
+dotnet tool update --global Microsoft.dotnet-interactive --version 1.0.617701
+dotnet interactive jupyter install
+```
 
 ## Python 3.10+ (notebooks Python)
 
@@ -99,7 +119,7 @@ Incident 2026-05-06 : training MoE tenté directement sur Python 3.14 système :
 #### .NET
 
 - SDKs : 8.0.x, 9.0.x, 10.0.x
-- dotnet-interactive : **1.0.552801** (PINNED)
+- dotnet-interactive : **1.0.617701** (installe, verifie 2026-07-25 — cf [tableau des versions](#version--10617701-pas--100700))
 - Kernels : `.net-csharp`, `.net-fsharp`, `.net-powershell`
 
 #### Jupyter kernels (10 registered)


### PR DESCRIPTION
Grain: MED/docs — lane myia-ai-01:CoursIA — prev: LIGHT/guard

## Ce que corrige cette PR

Deux affirmations de [`docs/reference/kernels-runtime.md`](https://github.com/jsboige/CoursIA/blob/main/docs/reference/kernels-runtime.md) etaient fausses. Ce ne sont pas des coquilles : chacune **fabriquait un contournement** que la flotte a effectivement pris.

### 1. La contrainte de version s'excluait elle-meme

```
| dotnet-interactive | >= 1.0.700 (PIN 1.0.552801 sur ai-01) |
**Versions a EVITER** : 1.0.522904 (Roslyn bug), 1.0.712001 (`#!import` bug). PIN sur 1.0.552801 si possible.
```

`>= 1.0.700` exclut le pin cite dans la meme ligne (552801 < 700), et n'admet aujourd'hui que **1.0.712001** — c'est-a-dire exactement la version listee deux lignes plus bas comme cassant `#!import`. Un agent qui suit ce document installe le kernel casse. La version reellement installee sur ai-01, **1.0.617701**, n'y figurait nulle part.

**Consequence directe** : le « bug `#!import` de dotnet-interactive — attente d'un sign-off de version » figure comme **bloqueur utilisateur** sur les lanes po-2024 **et** po-2026. Ce n'en est pas un. C'est un defaut d'environnement reparable en une commande, donc regle F :

```bash
dotnet tool update --global Microsoft.dotnet-interactive --version 1.0.617701
dotnet interactive jupyter install
```

Cette entree sort des listes de bloqueurs utilisateur des deux lanes (elle diluait les vrais, cf [user-blocker-signaling](https://github.com/jsboige/CoursIA/blob/main/.claude/rules/user-blocker-signaling.md)).

`1.0.552801` cesse aussi d'etre une cible : hote **net8.0-only**, il bloquait deja MGS-6 a MGS-9 — corroboration dans l'arbre, [`Search/Part4-Metaheuristics/README.md:103`](https://github.com/jsboige/CoursIA/blob/main/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/README.md#L103).

### 2. « Papermill ne supporte pas .NET Interactive » — faux

Le document renvoyait vers l'execution cell-by-cell par MCP Jupyter. Or ce chemin **hang** (#835). Le resultat previsible, et observe : des notebooks .NET committes **sans re-execution** — violation C.2/H.3, exactement l'anti-pattern PR #1591 cite en CLAUDE.md regle F.

Papermill execute un notebook `.net-csharp` de bout en bout, `execution_count` et sorties reelles a l'appui, `#!import` compris.

La **seule** limite reelle est l'injection de parametres : pas de traducteur C#, donc `-p` sur une cellule taguee `parameters` emet un avertissement et est ignoree — **et le notebook s'execute quand meme**. Les notebooks .NET du depot ne prennent pas de `-p` ; `BATCH_MODE` passe par variable d'environnement.

Deux limites voisines, **distinctes**, restent documentees telles quelles pour ne pas corriger en sens inverse : le restore `#r "nuget:"` bloque en headless ([dotnet-plotly-zero-restore.md](https://github.com/jsboige/CoursIA/blob/main/docs/reference/dotnet-plotly-zero-restore.md)) et l'absence de kernel .NET en CI ([pr-review-discipline §D](https://github.com/jsboige/CoursIA/blob/main/.claude/rules/pr-review-discipline.md)).

## Preuves firsthand (ai-01, dni `1.0.617701`)

| Test | Resultat |
|------|----------|
| `notebook_tools.py execute` sur un notebook `.net-csharp` | SUCCESS 4,4 s — `execution_count: 1`, sortie `dni-ok 42` |
| Paire `#!import helper.ipynb` + appel de la methode importee | SUCCESS 3,8 s — cellule 2 imprime `import-ok 42` |
| `papermill -p x 7` sur une cellule taguee `parameters` | `Translator for 'C#' language does not support parameter introspection.` puis **3/3 cellules executees** |
| `dotnet interactive --version` | `1.0.617701+fb2fd8022ab96c55fbaf34d5e1c8c61cb01690fc` |

Sorties relues dans le notebook de sortie (`execution_count` + `outputs` non vides), pas seulement le code retour.

## Verification de non-regression

`git grep` sur la formulation erronee : elle n'existait que dans ce fichier. Les autres occurrences de « Papermill » + « .NET » disent autre chose et restent exactes (absence de kernel en CI ; restore NuGet). `git grep 552801 -- '*.md'` : ne subsistent qu'un document d'archive (historique, laisse tel quel) et le README Metaheuristics qui **corrobore** le retrait du pin.

## Portee

Un seul fichier, un seul sujet : rendre vraie la section .NET Interactive de `kernels-runtime.md`. Le catalogue n'est pas touche.

See #8485, #8525, #8369
