### PR TITLE
feat(search-6,#3801): §7.2 richer-game Prong-B — when pruning becomes necessary (not accessory)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-6-AdversarialSearch.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-6-AdversarialSearch.ipynb
@@ -1240,7 +1240,8 @@
       "Reproductible : re-execution -> comptes identiques (deterministe, pas de timing).\n"
      ]
     }
-   ],   "source": [
+   ],
+   "source": [
     "# --- Comptage DETERMINISTE des noeuds : minimax vs alpha-beta vs +transposition ---\n",
     "# Versions instrumentees (compteur d'appels recursifs) -- n'instrumentent PAS les\n",
     "# cellules pedagogiques 9/13/19 (celles-ci restent propres pour l'enseignement).\n",
@@ -1325,6 +1326,213 @@
     "2. **Elle isole le mécanisme.** Le temps mélange le coût d'un nœud (création d'état, hachage) et leur nombre ; le compte de nœuds mesure *purement* l'effet de l'élagage alpha-beta (coupe des branches β ≤ α) et de la transposition (fusion des états équivalents par hash). C'est donc la grandeur qui exprime **la capacité algorithmique** des deux optimisations, indépendamment de l'implémentation.\n",
     "\n",
     "> **Lien CS** : la borne théorique de l'élagage alpha-beta avec *ordonnancement parfait* des coups est $b^{d/2}$ nœuds (vs $b^d$ pour minimax), soit un facteur $\\sqrt{b^d}$ — l'élagage « divise la profondeur effective par 2 ». Le ratio empirique ~30× observé ici est cohérent avec cette borne sur le Tic-Tac-Toe ($b \\approx 7$ en moyenne, $d = 9$). La transposition ajoute un gain *orthogonal* (fusion des permutations de coups menant au même état), d'où le facteur ~6× supplémentaire.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec72-prongb-header",
+   "metadata": {},
+   "source": [
+    "### 7.2 Quand l'élagage devient *nécessaire* : un jeu dont l'arbre minimax explose\n",
+    "\n",
+    "Le §7.1 a mesuré la réduction de l'élagage sur le Tic-Tac-Toe — mais celui-ci reste un jeu **trivialement petit** : son arbre complet (549 946 nœuds) se parcourt en millisecondes, et le minimax exhaustif le résout sans effort. L'élagage y est *accessoire* — on pourrait s'en passer.\n",
+    "\n",
+    "Pour voir **quand l'élagage alpha-beta devient indispensable**, il faut un jeu dont l'arbre minimax **explose** avec la profondeur. Prenons un *(m, n, k)-jeu* plus large : une grille $5 \\times 5$ où il faut aligner 4 pions (facteur de branchement $\\approx 20$, profondeur jusqu'à 25). On y relance les trois mêmes compteurs (minimax, alpha-beta, +transposition), cette fois à **profondeur limitée** — l'arbre complet étant inexplorable — et on regarde comment le nombre de nœuds **croît** d'un niveau à l'autre."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "sec72-prongb-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T23:05:26.674821Z",
+     "iopub.status.busy": "2026-07-25T23:05:26.674509Z",
+     "iopub.status.idle": "2026-07-25T23:05:32.331324Z",
+     "shell.execute_reply": "2026-07-25T23:05:32.330367Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Croissance des nœuds visités — jeu (5x5, aligner 4) selon la profondeur :\n",
+      " prof |        minimax |   alpha-beta |  +transposition |   gain AB |  gain +TT\n",
+      "--------------------------------------------------------------------------------------\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    3 |         14,426 |          672 |             672 | x   21.5 | x   21.5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    4 |        318,026 |        1,774 |           1,498 | x  179.3 | x  212.3\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    5 | ~6,693,626 (mesuré) |       14,376 |           8,051 | x  465.6 | x  831.4\n",
+      "\n",
+      "-> Le minimax est multiplié par ~22 à chaque niveau (14k -> 318k -> 6,7M) ;\n",
+      "   l'alpha-beta+transposition ne l'est que par ~3-4 (672 -> 1,5k -> 8k).\n",
+      "   L'écart EXPLOSE : c'est ici que l'élagage passe d'utile à INDISPENSABLE.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- §7.2 (m,n,k)-jeu : grille 5x5, aligner 4 pions (arbre minimax EXPLOSIF) ---\n",
+    "# Les compteurs du §7.1 étaient à profondeur illimitée (conçus pour le Tic-Tac-Toe\n",
+    "# complet). Ici l'arbre est inexplorable : versions à PROFONDEUR LIMITÉE (coupure à\n",
+    "# `prof`, heuristique neutre = utilité — le point est le COMPTE de nœuds, pas la valeur).\n",
+    "\n",
+    "class JeuMNK(JeuSommeNulle):\n",
+    "    \"\"\"(m,n,k)-jeu : grille m x n, aligner k pions. État = tuple hashable.\"\"\"\n",
+    "\n",
+    "    def __init__(self, m=5, n=5, k=4):\n",
+    "        self.m, self.n, self.k = m, n, k\n",
+    "    def etat_initial(self):\n",
+    "        return tuple([0] * (self.m * self.n))\n",
+    "    def actions(self, etat):\n",
+    "        return [i for i, v in enumerate(etat) if v == 0]\n",
+    "    def resultat(self, etat, action):\n",
+    "        joueur = 1 if etat.count(1) <= etat.count(2) else 2   # MAX (X) commence\n",
+    "        return etat[:action] + (joueur,) + etat[action+1:]\n",
+    "    def joueur(self, etat):\n",
+    "        return 'MAX' if etat.count(1) <= etat.count(2) else 'MIN'\n",
+    "    def _aligne(self, etat, pion):\n",
+    "        m, n, k = self.m, self.n, self.k\n",
+    "        for r in range(m):\n",
+    "            for c in range(n):\n",
+    "                if etat[r * n + c] != pion:\n",
+    "                    continue\n",
+    "                for dr, dc in ((0, 1), (1, 0), (1, 1), (1, -1)):\n",
+    "                    rr, cc, longueur = r, c, 0\n",
+    "                    while 0 <= rr < m and 0 <= cc < n and etat[rr * n + cc] == pion:\n",
+    "                        longueur, rr, cc = longueur + 1, rr + dr, cc + dc\n",
+    "                    if longueur >= k:\n",
+    "                        return True\n",
+    "        return False\n",
+    "    def est_terminal(self, etat):\n",
+    "        return self._aligne(etat, 1) or self._aligne(etat, 2) or 0 not in etat\n",
+    "    def utilite(self, etat, joueur='MAX'):\n",
+    "        gagne_max, gagne_min = self._aligne(etat, 1), self._aligne(etat, 2)\n",
+    "        if joueur == 'MAX':\n",
+    "            return 1 if gagne_max else (-1 if gagne_min else 0)\n",
+    "        return 1 if gagne_min else (-1 if gagne_max else 0)\n",
+    "    def afficher(self, etat):\n",
+    "        sym = {0: '.', 1: 'X', 2: 'O'}\n",
+    "        return '\\n'.join(' '.join(sym[etat[r * self.n + c]] for c in range(self.n))\n",
+    "                         for r in range(self.m))\n",
+    "\n",
+    "_cpt_prof = {\"minimax\": 0, \"alpha_beta\": 0, \"transposition\": 0}\n",
+    "\n",
+    "def minimax_prof(jeu, etat, prof, joueur_max='MAX'):\n",
+    "    _cpt_prof[\"minimax\"] += 1\n",
+    "    if jeu.est_terminal(etat) or prof == 0:\n",
+    "        return jeu.utilite(etat, joueur_max)\n",
+    "    actions = jeu.actions(etat)\n",
+    "    if jeu.joueur(etat) == joueur_max:\n",
+    "        return max(minimax_prof(jeu, jeu.resultat(etat, a), prof - 1, joueur_max) for a in actions)\n",
+    "    return min(minimax_prof(jeu, jeu.resultat(etat, a), prof - 1, joueur_max) for a in actions)\n",
+    "\n",
+    "def alpha_beta_prof(jeu, etat, prof, alpha, beta, joueur_max='MAX'):\n",
+    "    _cpt_prof[\"alpha_beta\"] += 1\n",
+    "    if jeu.est_terminal(etat) or prof == 0:\n",
+    "        return jeu.utilite(etat, joueur_max)\n",
+    "    actions = jeu.actions(etat)\n",
+    "    if jeu.joueur(etat) == joueur_max:\n",
+    "        v = float('-inf')\n",
+    "        for a in actions:\n",
+    "            v = max(v, alpha_beta_prof(jeu, jeu.resultat(etat, a), prof - 1, alpha, beta, joueur_max))\n",
+    "            alpha = max(alpha, v)\n",
+    "            if beta <= alpha:\n",
+    "                break\n",
+    "        return v\n",
+    "    v = float('+inf')\n",
+    "    for a in actions:\n",
+    "        v = min(v, alpha_beta_prof(jeu, jeu.resultat(etat, a), prof - 1, alpha, beta, joueur_max))\n",
+    "        beta = min(beta, v)\n",
+    "        if beta <= alpha:\n",
+    "            break\n",
+    "    return v\n",
+    "\n",
+    "def alpha_beta_transpo_prof(jeu, etat, prof, alpha, beta, table, joueur_max='MAX'):\n",
+    "    _cpt_prof[\"transposition\"] += 1\n",
+    "    if etat in table and table[etat][1] >= prof:\n",
+    "        return table[etat][0]\n",
+    "    if jeu.est_terminal(etat) or prof == 0:\n",
+    "        v = jeu.utilite(etat, joueur_max); table[etat] = (v, prof); return v\n",
+    "    actions = jeu.actions(etat)\n",
+    "    if jeu.joueur(etat) == joueur_max:\n",
+    "        v = float('-inf')\n",
+    "        for a in actions:\n",
+    "            v = max(v, alpha_beta_transpo_prof(jeu, jeu.resultat(etat, a), prof - 1, alpha, beta, table, joueur_max))\n",
+    "            alpha = max(alpha, v)\n",
+    "            if beta <= alpha:\n",
+    "                break\n",
+    "    else:\n",
+    "        v = float('+inf')\n",
+    "        for a in actions:\n",
+    "            v = min(v, alpha_beta_transpo_prof(jeu, jeu.resultat(etat, a), prof - 1, alpha, beta, table, joueur_max))\n",
+    "            beta = min(beta, v)\n",
+    "            if beta <= alpha:\n",
+    "                break\n",
+    "    table[etat] = (v, prof)\n",
+    "    return v\n",
+    "\n",
+    "import time\n",
+    "jeu_large = JeuMNK(5, 5, 4)\n",
+    "print(\"Croissance des nœuds visités — jeu (5x5, aligner 4) selon la profondeur :\")\n",
+    "print(f\"{'prof':>5} | {'minimax':>14} | {'alpha-beta':>12} | {'+transposition':>15} | {'gain AB':>9} | {'gain +TT':>9}\")\n",
+    "print(\"-\" * 86)\n",
+    "for prof in [3, 4]:\n",
+    "    for cle in _cpt_prof:\n",
+    "        _cpt_prof[cle] = 0\n",
+    "    minimax_prof(jeu_large, jeu_large.etat_initial(), prof)\n",
+    "    n_mm = _cpt_prof[\"minimax\"]\n",
+    "    alpha_beta_prof(jeu_large, jeu_large.etat_initial(), prof, float('-inf'), float('+inf'))\n",
+    "    n_ab = _cpt_prof[\"alpha_beta\"]\n",
+    "    alpha_beta_transpo_prof(jeu_large, jeu_large.etat_initial(), prof, float('-inf'), float('+inf'), {})\n",
+    "    n_tt = _cpt_prof[\"transposition\"]\n",
+    "    print(f\"{prof:>5} | {n_mm:>14,d} | {n_ab:>12,d} | {n_tt:>15,d} | x{n_mm / n_ab:>7.1f} | x{n_mm / n_tt:>7.1f}\")\n",
+    "\n",
+    "# Profondeur 5 : le minimax explose (~6,7 millions, plusieurs minutes) — on ne lance QUE l'élagage.\n",
+    "for cle in _cpt_prof:\n",
+    "    _cpt_prof[cle] = 0\n",
+    "alpha_beta_prof(jeu_large, jeu_large.etat_initial(), 5, float('-inf'), float('+inf'))\n",
+    "n_ab5 = _cpt_prof[\"alpha_beta\"]\n",
+    "alpha_beta_transpo_prof(jeu_large, jeu_large.etat_initial(), 5, float('-inf'), float('+inf'), {})\n",
+    "n_tt5 = _cpt_prof[\"transposition\"]\n",
+    "N_MM5_MESURE = 6_693_626   # minimax exhaustif prof=5 mesuré hors-ligne (~minutes, non relancé en direct)\n",
+    "print(f\"{'5':>5} | {'~' + format(N_MM5_MESURE, ',d') + ' (mesuré)':>14} | {n_ab5:>12,d} | {n_tt5:>15,d} | x{N_MM5_MESURE / n_ab5:>7.1f} | x{N_MM5_MESURE / n_tt5:>7.1f}\")\n",
+    "print()\n",
+    "print(\"-> Le minimax est multiplié par ~22 à chaque niveau (14k -> 318k -> 6,7M) ;\")\n",
+    "print(\"   l'alpha-beta+transposition ne l'est que par ~3-4 (672 -> 1,5k -> 8k).\")\n",
+    "print(\"   L'écart EXPLOSE : c'est ici que l'élagage passe d'utile à INDISPENSABLE.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec72-prongb-interp",
+   "metadata": {},
+   "source": [
+    "**Lecture — la bascule de l'utile à l'indispensable.** Sur le Tic-Tac-Toe (§7.1), l'arbre complet (549 946 nœuds) se parcourt en millisecondes : l'élagage y est *appréciable* mais non *nécessaire* — le minimax exhaustif suffit. Sur le jeu $5 \\times 5$ (aligner 4), la situation bascule :\n",
+    "\n",
+    "- **Le minimax explose.** Le nombre de nœuds est multiplié par ~22 à chaque niveau de profondeur supplémentaire (14 426 -> 318 026 -> ~6,7 millions à profondeur 5). Au-delà, il devient **inexplorable en pratique** (profondeur 6 ~ 140 millions). C'est le régime où un minimax naïf *ne termine pas*.\n",
+    "- **L'élagage garde une croissance maîtrisée.** Alpha-beta (+transposition) ne multiplie ses nœuds que par ~3-4 par niveau (672 -> 1 498 -> 8 051). Le **gain relatif explose** avec la profondeur : x21 (prof 3) -> x212 (prof 4) -> x831 (prof 5). Plus le jeu est profond, plus l'élagage *détermine* la faisabilité de la recherche.\n",
+    "\n",
+    "C'est la vraie leçon de capacité : sur un jeu trivial, l'élagage est un confort ; sur un jeu dont l'arbre est vaste, il est la **condition même** de la recherche. Les ordinateurs battent les humains aux dames ou (presque) au Go, non pas avec du minimax exhaustif — qui y est inenvisageable — mais avec alpha-beta, des tables de transposition, et (pour le Go) MCTS (cf. Search-7).\n",
+    "\n",
+    "> **Lien CS.** La borne $b^{d/2}$ de l'alpha-beta avec ordonnancement parfait (vs $b^d$ pour le minimax, cf. §7.1) signifie que l'élagage « divise la profondeur effective par deux » : chaque niveau de plus coûte $\\sqrt{b}$ fois plus de nœuds à l'alpha-beta, contre $b$ fois plus au minimax. Sur le $5 \\times 5$ ($b \\approx 20$), cela donne $\\sqrt{20} \\approx 4.5$ vs $20$ — soit le rapport de croissance ~3-4 (mesuré) contre ~22 (mesuré), et le gain cumulé x831 à profondeur 5. Exactement le passage de « trop grand pour minimax » à « tractable avec élagage »."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-search-prongb — lane myia-po-2024:CoursIA-2 — prev: MED/docs (c.880 #8575). Rotation genre honnête : search-engine-prongb (≠ code-ML c.878 / twin-parity c.879 / docs c.880). Complement au #8333 de hier (§7.1 TTT-only), substance distincte (problem-richness vs measurement-methodology).

## What (Prong-B problem-richness, #3801 msg3)

`Search-6-AdversarialSearch.ipynb` §7.1 (PR #8333, 2026-07-24) a mesuré la réduction de l'élagage alpha-beta sur Tic-Tac-Toe de façon **déterministe** (comptage de nœuds : minimax 549 946 → alpha-beta 18 297 → +transposition 3 010). **Mais le Tic-Tac-Toe est un jeu *trivialement* petit et résolu** : son arbre complet (549 946 nœuds) se parcourt en millisecondes, donc l'élagage y est *accessoire* (le minimax exhaustif le résout seul). Le cas discriminant que demande le mandat #3801 — un jeu dont l'arbre minimax **explose** au-delà de la faisabilité, rendant l'élagage *nécessaire* — n'était PAS couvert par #8333.

**§7.2 ajoute ce cas** : un (m,n,k)-jeu plus large (grille 5×5, aligner 4 pions, facteur de branchement ~20). Re-mesuré les 3 mêmes compteurs (minimax / alpha-beta / +transposition) à **profondeur limitée**, cette fois en observant la **croissance** du nombre de nœuds d'un niveau à l'autre.

## Grounded result (measured firsthand, C858-L — deterministic, re-productible)

| prof | minimax | alpha-beta | +transposition | gain AB | gain +TT |
|------|---------|------------|----------------|---------|----------|
| 3 | 14 426 | 672 | 672 | ×21.5 | ×21.5 |
| 4 | 318 026 | 1 774 | 1 498 | ×179.3 | ×212.3 |
| 5 | ~6 693 626 *(mesuré)* | 14 376 | 8 051 | ×465.6 | **×831.4** |

- **Le minimax explose** : multiplié par ~22 à chaque niveau (14k → 318k → ~6,7M). Au-delà de la profondeur 5, il devient **inexplorable en pratique** (profondeur 6 ≈ 140 millions).
- **L'élagage garde une croissance maîtrisée** : alpha-beta+transposition ne multiplie ses nœuds que par ~3-4 par niveau (672 → 1 498 → 8 051).
- **Le gain relatif explose avec la profondeur** : ×21 → ×212 → ×831. C'est la bascule où l'élagage passe d'utile à **indispensable**.

**Lien CS** : cohérent avec la borne $b^{d/2}$ de l'alpha-beta à ordonnancement parfait (vs $b^d$ pour minimax) — l'élagage « divise la profondeur effective par 2 », soit un coût par niveau de $\sqrt{b}$ (~4,5 pour $b\approx20$) contre $b$ (20) pour le minimax. Les ratios de croissance mesurés (~3-4 vs ~22) et le gain cumulé ×831 reproduisent exactement ce passage de « trop grand pour minimax » à « tractable avec élagage ».

## Design choices (honnêtes)

- **Profondeur 5 minimax non exécutée en direct** : ~6,7M nœuds prennent plusieurs minutes (violerait « temps de traitement raisonnable » du mandat). Reportée comme valeur **mesurée hors-ligne** (`N_MM5_MESURE = 6_693_626`, clairement étiquetée « (mesuré) » dans la sortie). Seuls alpha-beta/+transposition tournent à profondeur 5 (instantané). Cellule ~6s au total.
- **Heuristique neutre à la coupure** : le point de §7.2 est le **compte de nœuds** (la capacité de l'algorithme), pas la qualité du coup. Les valeurs retournées à `prof=0` sont l'utilité (0 si non-terminal) — explicité dans le commentaire.
- **Self-contained** : `JeuMNK(JeuSommeNulle)` réutilise l'ABC du notebook (cell 4) ; n'utilise PAS `evaluation_heuristique` (TicTacToe-spécifique, cell 16). Compteurs à profondeur limitée indépendants de ceux de §7.1 (qui sont full-depth).

## Verification

- **Re-exec end-to-end** (nbconvert, kernel python3) : **0 erreurs, 0 cellule null-exec**. §7.2 ec=10, 4 outputs (table déterministe re-productible à l'identique).
- **Byte-surgical** (C876-L/C839) : cellules existantes **byte-identiques à main** — seules +3 cellules ajoutées. Le `-1` unique du diff est une normalisation whitespace d'une ligne pré-existante non-standard (`], "source":`), aucun changement de contenu.
- **C.1** : 0 `raise NotImplementedError`/`assert False`/`1/0`. **CRLF=LF** (.gitattributes `eol=lf`). Aucun leak de chemin machine dans metadata/outputs.
- **Search-6 n'est PAS une paire twin enregistrée** → édition Python-only, pas de drift twin, pas de rebaseline requise.
- **L898** : 0 PR in-flight sur Search-6 (git log : dernier touché par #8333 merged hier ; pas de Prong-B richer-game antérieur).

## Scope

+209/-1, 1 fichier (`Search-6-AdversarialSearch.ipynb`). Pas un composite. Pas de catalogue touché. Complément de #8333 (§7.1 → §7.2, même axe Prong-B #3801, substance distincte).

See #3801 (Prong-B problem-richness), #8052.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
