### PR TITLE
feat(cost-metadata,#8376): qcc_tokens_est field for QC Cloud compute tokens

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-04-Research-Workflow.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-04-Research-Workflow.ipynb
@@ -1798,6 +1798,7 @@
   "cost": {
    "api_usd_est": 0,
    "api_provider": "none",
+   "qcc_tokens_est": 1960,
    "cpu_min": 15,
    "gpu_required": false,
    "network": true,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/AdaptiveAssetAllocation/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/AdaptiveAssetAllocation/quantbook.ipynb
@@ -739,6 +739,7 @@
   "cost": {
    "api_usd_est": 0.0,
    "api_provider": "none",
+   "qcc_tokens_est": 700,
    "cpu_min": 30,
    "gpu_required": false,
    "network": true,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/AllWeather/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/AllWeather/quantbook.ipynb
@@ -496,6 +496,7 @@
   "cost": {
    "api_usd_est": 0.0,
    "api_provider": "none",
+   "qcc_tokens_est": 560,
    "cpu_min": 20,
    "gpu_required": false,
    "network": true,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Alpha-Correlation-Analysis/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Alpha-Correlation-Analysis/quantbook.ipynb
@@ -1810,6 +1810,7 @@
   "cost": {
    "api_usd_est": 0.0,
    "api_provider": "none",
+   "qcc_tokens_est": 1260,
    "cpu_min": 15,
    "gpu_required": false,
    "network": true,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/BTC-ML/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/BTC-ML/quantbook.ipynb
@@ -563,6 +563,7 @@
   "cost": {
    "api_usd_est": 0.0,
    "api_provider": "none",
+   "qcc_tokens_est": 770,
    "cpu_min": 60,
    "gpu_required": false,
    "network": true,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Crypto-MultiCanal/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Crypto-MultiCanal/quantbook.ipynb
@@ -822,6 +822,7 @@
   "cost": {
    "api_usd_est": 0.0,
    "api_provider": "none",
+   "qcc_tokens_est": 700,
    "cpu_min": 45,
    "gpu_required": false,
    "network": true,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/DL-LSTM/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/DL-LSTM/quantbook.ipynb
@@ -829,6 +829,7 @@
   "cost": {
    "api_usd_est": 0.0,
    "api_provider": "none",
+   "qcc_tokens_est": 840,
    "cpu_min": 60,
    "gpu_required": true,
    "vram_gb": 8,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/DualMomentum/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/DualMomentum/quantbook.ipynb
@@ -651,6 +651,7 @@
   "cost": {
    "api_usd_est": 0.0,
    "api_provider": "none",
+   "qcc_tokens_est": 630,
    "cpu_min": 20,
    "gpu_required": false,
    "network": true,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/DualMomentumNoTLT/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/DualMomentumNoTLT/quantbook.ipynb
@@ -782,6 +782,7 @@
   "cost": {
    "api_usd_est": 0.0,
    "api_provider": "none",
+   "qcc_tokens_est": 700,
    "cpu_min": 20,
    "gpu_required": false,
    "network": true,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/EMA-Cross-Alpha/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/EMA-Cross-Alpha/quantbook.ipynb
@@ -479,6 +479,7 @@
   "cost": {
    "api_usd_est": 0.0,
    "api_provider": "none",
+   "qcc_tokens_est": 630,
    "cpu_min": 20,
    "gpu_required": false,
    "network": true,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/EMA-Cross-Crypto/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/EMA-Cross-Crypto/quantbook.ipynb
@@ -889,6 +889,7 @@
   "cost": {
    "api_usd_est": 0.0,
    "api_provider": "none",
+   "qcc_tokens_est": 770,
    "cpu_min": 20,
    "gpu_required": false,
    "network": true,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/EMA-Cross-Index/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/EMA-Cross-Index/quantbook.ipynb
@@ -801,6 +801,7 @@
   "cost": {
    "api_usd_est": 0.0,
    "api_provider": "none",
+   "qcc_tokens_est": 700,
    "cpu_min": 20,
    "gpu_required": false,
    "network": true,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/EMA-Cross-Stocks/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/EMA-Cross-Stocks/quantbook.ipynb
@@ -747,6 +747,7 @@
   "cost": {
    "api_usd_est": 0.0,
    "api_provider": "none",
+   "qcc_tokens_est": 700,
    "cpu_min": 20,
    "gpu_required": false,
    "network": true,

--- a/docs/notebook-metadata/cost-matrix.md
+++ b/docs/notebook-metadata/cost-matrix.md
@@ -29,6 +29,7 @@ bloc `---\n...\n---` est promue par markdown-it en **setext-H2 supersize**
 {
   "api_usd_est": 0.40,            // Coût API estimé par exécution end-to-end (USD). 0 si gratuit.
   "api_provider": "openai",       // openai | anthropic | mistral | hf | replicate | google | local | none
+  "qcc_tokens_est": 0,            // QuantConnect Cloud compute tokens (QCC) estimés par exécution end-to-end. 0 si non-QC. Cf §"Coût QCC / QuantConnect".
   "cpu_min": 1,                   // Estimation CPU-only minutes (range ou best-case)
   "gpu_min": 0,                   // Estimation GPU minutes (range ou best-case)
   "gpu_required": false,          // true si impossible sans GPU
@@ -75,6 +76,7 @@ source de vérité, le badge est un confort de lecture.
 |-------|-------------|----------------|
 | `cost.api_usd_est` | ✓ | `0` |
 | `cost.api_provider` | ✓ | `"none"` |
+| `cost.qcc_tokens_est` | optionnel | `0` (0 = non-QC ; à peupler pour tout quantbook QC Cloud) |
 | `cost.cpu_min` | ✓ | `0` |
 | `cost.gpu_min` | optionnel | (omission = pas d'estimation GPU) |
 | `cost.gpu_required` | ✓ | `false` |
@@ -250,6 +252,7 @@ cost:
 cost:
   api_usd_est: 0.0             # QC Cloud = pas de coût API par backtest (free tier)
   api_provider: qc_cloud
+  qcc_tokens_est: 840          # ~70 QCC/cellule code (cf §"Coût QCC / QuantConnect")
   cpu_min: 0
   gpu_min: 0
   gpu_required: false
@@ -262,6 +265,23 @@ cost:
   last_validated: 2026-07-23T01:30Z
   validator: qc_cloud          # MCP qc-mcp-lite create_backtest + read_backtest
 ```
+
+#### Coût QCC / QuantConnect — pourquoi un champ dédié
+
+QuantConnect Cloud facture l'exécution des quantbooks en **QCC tokens** (QuantConnect
+Compute), une monnaie de quota propre au cloud QC — **non convertible en USD** et
+**non gratuite** au-delà du free tier. Le champ `api_usd_est: 0.0` est donc
+techniquement correct (pas de coût API *en USD*) mais **trompeur** sans
+`qcc_tokens_est` : il présente le quantbook comme « gratuit » alors qu'il consomme
+du quota QCC. `qcc_tokens_est` ferme ce gap en exposant le coût réel en quota QC.
+
+**Estimation** (acceptance [#8056](https://github.com/jsboige/CoursIA/issues/8056) :
+« sessions QuantConnect ≈ 800-1200 QCC tokens pour un notebook de 14 cellules ») :
+heuristic dérivable **~70 QCC par cellule code**, plancher `max(400, n_code_cells × 70)`.
+C'est une **estimation** (le suffixe `_est` l'atteste), pas une mesure — ré-estimer
+après une exécution QC Cloud réelle (`read_backtest` retourne le QCC consommé). Le
+litmus correspondant dans `check_cost_metadata.py` signale tout quantbook
+(`QuantBook()` détecté) dont `qcc_tokens_est` est absent ou `0`.
 
 ### GenAI/Image GPU lourd (référence HIGH tier)
 

--- a/scripts/audit/check_cost_metadata.py
+++ b/scripts/audit/check_cost_metadata.py
@@ -231,6 +231,19 @@ def check_notebook(notebook_path: Path, repo_root: Path) -> dict:
             'severity': 'MINOR',
         })
 
+    # Litmus 7 : QuantBook détecté sans estimation QCC (cf #8376/#8056)
+    # QCC (QuantConnect Cloud compute tokens) = quota non-USD consommé par tout
+    # quantbook exécuté via QC Cloud. api_usd_est: 0.0 est techniquement correct
+    # (pas de USD) mais trompeur : le notebook n'est PAS gratuit. Le champ dédié
+    # cost.qcc_tokens_est (~70 QCC/cellule, plancher max(400, n_cells x 70))
+    # rend la dépense visible. Absent/0 sur un QuantBook = lacune de coût.
+    if uses_qc and not cost_meta.get('qcc_tokens_est'):
+        findings.append({
+            'pattern': 'qc_notebook_no_qcc_estimate',
+            'detail': 'Notebook QuantConnect (QuantBook) mais cost.qcc_tokens_est absent ou 0 (cf #8376/#8056)',
+            'severity': 'MAJOR',
+        })
+
     return {
         'notebook': str(notebook_path),
         'cost_meta_found': bool(cost_meta),


### PR DESCRIPTION
Grain: MED/schema-infra — lane myia-po-2024:CoursIA — prev: DEEP/tooling-infra (#8586 twin-registry)

## What

`cost-metadata` lane — issue #8376 (schema gap) + #8056 (QCC token estimate).

QuantConnect quantbooks consume **QCC tokens** (QuantConnect Cloud compute
quota — non-USD, non-free). `cost.api_usd_est: 0.0` is *technically* correct
(no USD spent) but **misleading**: the notebook presents as "free" while
consuming real compute quota. #8056 estimates **~800-1200 QCC for a 14-cell
quantbook**. This adds a dedicated field to make the QC Cloud compute cost
visible, instead of hiding it behind `api_usd_est: 0.0`.

## Changes (3 parts, one subject)

1. **Schema doc** `docs/notebook-metadata/cost-matrix.md` (+20):
   - `qcc_tokens_est` added to the canonical JSON block (after `api_provider`).
   - New row in the required/default table (`optionnel`, default `0`).
   - `qcc_tokens_est: 840` in the QC example.
   - New subsection **"Coût QCC / QuantConnect — pourquoi un champ dédié"**
     documenting the non-USD quota nature, the `~70 QCC/cell` heuristic,
     the `max(400, n_code_cells × 70)` floor, and the parser litmus that flags
     a QuantBook with no estimate.

2. **Parser litmus** `scripts/audit/check_cost_metadata.py` (+13):
   - **Litmus 7** `qc_notebook_no_qcc_estimate` (MAJOR): fires when
     `detect_quantbook_usage` is true AND `qcc_tokens_est` is absent/0.
     Modeled on the existing Litmus 5 pattern (`qc_notebook_no_validator`),
     reuses the already-computed `uses_qc` flag.

3. **Populate 13 QuantBook notebooks** (+13 lines total, 1 per file):
   the 12 `projects/*/quantbook.ipynb` migrated by #8585 + `QC-Py-04-Research-Workflow.ipynb`.

| Notebook | cells | qcc_tokens_est |
|----------|------:|---------------:|
| AdaptiveAssetAllocation | 10 | 700 |
| AllWeather | 8 | 560 |
| Alpha-Correlation-Analysis | 18 | 1260 |
| BTC-ML | 11 | 770 |
| Crypto-MultiCanal | 10 | 700 |
| DL-LSTM | 12 | 840 |
| DualMomentum | 9 | 630 |
| DualMomentumNoTLT | 10 | 700 |
| EMA-Cross-Alpha | 9 | 630 |
| EMA-Cross-Crypto | 11 | 770 |
| EMA-Cross-Index | 10 | 700 |
| EMA-Cross-Stocks | 10 | 700 |
| QC-Py-04-Research-Workflow | 28 | 1960 |

## Validation (firsthand, this PR)

```
$ python scripts/audit/check_cost_metadata.py \
    MyIA.AI.Notebooks/QuantConnect/projects/AdaptiveAssetAllocation/quantbook.ipynb --repo-root .
# BEFORE population:
findings:
  - pattern: qc_notebook_no_qcc_estimate   (MAJOR)
# AFTER population: findings: (empty)

$ # Fleet sweep (all QC notebooks with cost meta): 0 litmus-7 hits remaining.
$ # Litmus 1-6 regression check: unchanged (QC-Py-02 non-QC stays silent).

$ git diff --stat
# 13 quantbooks | 1 + each  (surgical, 0 churn on untouched cells)
# docs/notebook-metadata/cost-matrix.md        | 20 +
# scripts/audit/check_cost_metadata.py         | 13 +
# 15 files changed, 46 insertions(+), 0 deletions(-)
```

**Byte-stability** (lessons `nbformat-write-churns-untouched-cells-use-raw-json` +
`notebook-json-ensure-ascii-preserve`): values inserted via **raw-text surgical
edit** (anchor: `api_provider:"none"` + following `cpu_min` line, unique per file),
NOT `json.dumps`/`nbformat.write`. `+1 line / file`, `0 deletions`, no CRLF leak,
non-ASCII preserved. Each notebook re-loads as valid JSON post-edit.

## Why a dedicated field (not api_usd_est > 0)

QCC tokens are a **non-USD quota** (cloud compute minutes, not a dollar spend).
Setting `api_usd_est: 0.5` would be a fabrication (no USD is spent) and would
trip Litmus 2 (`api_used_but_cost_zero` is the opposite problem). A dedicated
`qcc_tokens_est` keeps the cost model honest: `api_usd_est` = external paid
APIs in USD; `qcc_tokens_est` = QC Cloud compute quota. Both can be 0
legitimately (local execution, free QC tier).

## Scope

15 files: schema doc + parser litmus + 13 quantbook notebooks. **0 notebooks
re-executed** (metadata-only edit; `#8585` already executed+committed these
quantbooks with outputs — outputs untouched here). No catalogue churn
(byte-identical to main). No CI workflow invokes `check_cost_metadata`
(standalone audit tool, not CI-gated), so the litmus addition is non-breaking.

See #8376, #8056 (schema + cost-attribution epics, partial contribution —
does not close them).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
