### PR TITLE
fix(cost-metadata): litmus 2 api_used local-provider FP guard (6 -> 1)

### DIFF
--- a/scripts/audit/check_cost_metadata.py
+++ b/scripts/audit/check_cost_metadata.py
@@ -176,11 +176,22 @@ def check_notebook(notebook_path: Path, repo_root: Path) -> dict:
             'severity': 'MAJOR',
         })
 
-    # Litmus 2 : api_usd_est: 0 mais API usage
+    # Litmus 2 : api_usd_est: 0 mais API usage.
+    # FP guard: quand cost.api_provider declare une inference locale/gratuite
+    # (local, hf, huggingface, ollama), la presence du keyword 'openai'/
+    # 'replicate' reflete un client OpenAI-compatible pointant vers un serveur
+    # local (vLLM, Ollama, endpoint HF Inference) — pas un appel API payant en
+    # USD. cost.api_usd_est: 0.0 est alors correct, le flag CRITICAL = faux
+    # positif (5 FP fleet-wide avant ce fix : notebooks 'Local'/HF avec
+    # provider=local/hf). On ne flag QUE si le provider est un payant cloud ou
+    # absent/none (cas ambigu a investiguer, cf litmus 3 pour le compte).
+    FREE_API_PROVIDERS = ('local', 'hf', 'huggingface', 'ollama')
+    api_provider_val = str(cost_meta.get('api_provider', '')).lower()
     api_used = set()
     for _, src in code_cells_source:
         api_used.update(detect_api_usage(src))
-    if api_used and cost_meta.get('api_usd_est', 0.0) == 0.0:
+    if api_used and cost_meta.get('api_usd_est', 0.0) == 0.0 \
+            and api_provider_val not in FREE_API_PROVIDERS:
         for provider in api_used:
             findings.append({
                 'pattern': 'api_used_but_cost_zero',


### PR DESCRIPTION
Grain: MED/parser-infra — lane myia-po-2024:CoursIA — prev: MED/parser-infra (#8588)

## ⚠️ G-VAR-3 flag (read first)

This is the **4th consecutive infra/parser grain** from po-2024 (#8586 tooling → #8587 schema → #8588 parser-litmus4 → here parser-litmus2). G-VAR-3 self-detection triggers (same genre, scan-generated). **ai-01 may HOLD on monoculture grounds.** I took it only because: (a) 6 CRITICAL-severity FPs is real harm, (b) the bounded-CPU non-infra pool is genuinely drained (enumerated exhaustively — see "Pool scan" below), (c) never-idle floor. **I urgently request ai-01 provision a non-infra GenAI/Docs DEEP/MED grain for po-2024 next cycle**, or merge the 3 pending parser PRs to unblock the chain.

## What

`check_cost_metadata.py` **Litmus 2** (`api_used_but_cost_zero`, CRITICAL) produced **5 false positives** fleet-wide. The litmus flagged any notebook where `detect_api_usage()` found an `openai`/`replicate` keyword AND `cost.api_usd_est == 0.0`. But when `cost.api_provider` declares a **local/free** inference provider, the keyword reflects an OpenAI-compatible **client** pointed at a local server (vLLM, Ollama, HF Inference endpoint) — not a paid cloud API. `api_usd_est: 0.0` is then correct.

## The 5 FPs (firsthand-verified `cost.api_provider`)

| Notebook | provider | account | Reality |
|----------|----------|---------|---------|
| 01-3-Basic-Audio-Operations | `local` | none | local inference, free |
| 01-4-Whisper-Local | `local` | none | local Whisper, free |
| 01-5-Kokoro-TTS-Local | `local` | none | local TTS, free |
| 02-2-FLUX-1-Advanced-Generation | `local` | hf | local/HF generation, free |
| 11_Quantization | `hf` | hf | `OPENAI_BASE_URL`+localhost → local vLLM endpoint, free |

## Fix

Suppress the flag when `api_provider` is an explicit local/free provider (`local`, `hf`, `huggingface`, `ollama`). Leave `'none'`/missing flagged — that case is ambiguous, and Litmus 3 independently catches missing accounts. One **genuine** finding is RETAINED: `03-2-Video-Workflow-Orchestration` (`provider='none'` + `acct='huggingface'` = real provider/account inconsistency, correctly surfaced).

## Validation (firsthand)

```
$ # batch audit, 196 cost-meta notebooks
$ api_used_but_cost_zero: 6 -> 1   (5 CRITICAL FPs eliminated, 1 genuine kept)
$ # the 5 local/hf notebooks now silent (0 hits)
$ # 03-2-Video-Workflow-Orchestration (provider=none) STILL flagged (genuine)
$ # other litmus (1,3,4,5,6) unchanged
```

## Scope

- **1 file**, `scripts/audit/check_cost_metadata.py`, +13/−2 (comment-heavy).
- **Non-overlapping** with #8587 (Litmus 7 ~line 234) and #8588 (Litmus 4 ~line 204): this is Litmus 2 ~line 179. Three distinct litmus regions → auto-merge sequentially.
- The orthogonal data question (should `03-2` normalize provider to `hf`?) is NOT decided here — surfaced for the GenAI owner.

## Pool scan (why this grain, transparency)

Exhaustive enumeration of `gh issue list --state open` this cycle: all bounded CPU-doable non-gated grains are delivered or addressed. #8485/#8550 collided (active jsboige PRs #8525/#8556); #8369/#8474/#8274 GenAI addressed by merged stopgaps (#8378/#8540) or user-gated (model swap); #7575/#6891 QC-Cloud gated; #7422 docs triage drained (12+ PRs, acceptance complete); ICT issues (#7733 etc.) = ai-01 deep-research epic #4588 (theoretical judgment, not mechanical); #6949 user-assigned; Lean = po-2026 partition. GPU findings (12) verified firsthand to have `is_available()` guards (GPU-optional, defensible `gpu_required:False`). The litmus-2 FP was the one remaining clean CPU fix.

See #8056 (cost-matrix epic), #8376 (schema).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
