### PR TITLE
feat(tooling,#8056): populate_cost_metadata.py + populate 71 QC quantbooks (Litmus 7 cleared)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/research/research_classification.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/research/research_classification.ipynb
@@ -1160,6 +1160,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 1190,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/Python/research/research_lstm.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/research/research_lstm.ipynb
@@ -993,6 +993,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 1190,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/examples/Crypto-MultiCanal/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/examples/Crypto-MultiCanal/research.ipynb
@@ -3563,7 +3563,21 @@
     ]
    }
   },
-  "qc_reference": true
+  "qc_reference": true,
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 1680,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 5

--- a/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/examples/Crypto-MultiCanal/research_archive.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/examples/Crypto-MultiCanal/research_archive.ipynb
@@ -5533,6 +5533,20 @@
     "version_major": 2,
     "version_minor": 0
    }
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 2310,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/kit-transitoire/01-ML-RandomForest/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/kit-transitoire/01-ML-RandomForest/research.ipynb
@@ -876,6 +876,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 770,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/kit-transitoire/02-ML-XGBoost/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/kit-transitoire/02-ML-XGBoost/research.ipynb
@@ -776,6 +776,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 700,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/kit-transitoire/03-Framework-Composite/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/kit-transitoire/03-Framework-Composite/research.ipynb
@@ -693,6 +693,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 630,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/BTC-ML/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/BTC-ML/research.ipynb
@@ -914,6 +914,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 630,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/CSharp-BTC-EMA-Cross/research_robustness.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/CSharp-BTC-EMA-Cross/research_robustness.ipynb
@@ -1011,6 +1011,20 @@
    "parameters": {},
    "start_time": "2026-06-01T00:01:03.344887+00:00",
    "version": "2.7.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 420,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/CSharp-BTC-MACD-ADX/Research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/CSharp-BTC-MACD-ADX/Research.ipynb
@@ -1581,6 +1581,20 @@
      }
     ]
    }
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 1330,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Crypto-MultiCanal/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Crypto-MultiCanal/research.ipynb
@@ -1044,6 +1044,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 770,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ETF-Pairs/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ETF-Pairs/quantbook.ipynb
@@ -925,6 +925,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 700,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ETF-Pairs/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ETF-Pairs/research.ipynb
@@ -69,6 +69,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 400,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/FamaFrench/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/FamaFrench/quantbook.ipynb
@@ -750,6 +750,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 700,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ForexCarry/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ForexCarry/quantbook.ipynb
@@ -720,6 +720,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 700,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_EMATrend/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_EMATrend/quantbook.ipynb
@@ -785,6 +785,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 630,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_EMATrend/quantbook_composite_research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_EMATrend/quantbook_composite_research.ipynb
@@ -884,6 +884,20 @@
    "parameters": {},
    "start_time": "2026-06-01T00:08:18.923742+00:00",
    "version": "2.7.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 630,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_FamaFrenchAllWeather/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_FamaFrenchAllWeather/quantbook.ipynb
@@ -820,6 +820,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 630,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_MomentumRegime/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_MomentumRegime/quantbook.ipynb
@@ -751,6 +751,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 560,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_TrendWeather/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_TrendWeather/quantbook.ipynb
@@ -881,6 +881,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 840,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/FuturesTrend/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/FuturesTrend/quantbook.ipynb
@@ -516,6 +516,20 @@
   "language_info": {
    "name": "python",
    "version": "3.10.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 560,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/HAR-RV-Kelly/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/HAR-RV-Kelly/research.ipynb
@@ -705,6 +705,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 490,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/InverseVolatility-Rank/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/InverseVolatility-Rank/research.ipynb
@@ -407,6 +407,20 @@
   "language_info": {
    "name": "python",
    "version": "3.11.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 490,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-Classification/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-Classification/quantbook.ipynb
@@ -830,6 +830,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 840,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-DeepLearning/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-DeepLearning/quantbook.ipynb
@@ -854,6 +854,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 840,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-EnhancedPairs/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-EnhancedPairs/quantbook.ipynb
@@ -1147,6 +1147,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 840,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-Ensemble/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-Ensemble/quantbook.ipynb
@@ -1043,6 +1043,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 840,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-FeatureEngineering/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-FeatureEngineering/quantbook.ipynb
@@ -1278,6 +1278,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 840,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-HeadShoulders-CNN/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-HeadShoulders-CNN/research.ipynb
@@ -1570,6 +1570,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 420,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-RandomForest/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-RandomForest/quantbook.ipynb
@@ -6595,6 +6595,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 700,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-Regression/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-Regression/quantbook.ipynb
@@ -1014,6 +1014,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 840,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-SVM/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-SVM/quantbook.ipynb
@@ -2926,6 +2926,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 700,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-TextClassification/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-TextClassification/quantbook.ipynb
@@ -881,6 +881,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 980,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-XGBoost/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-XGBoost/quantbook.ipynb
@@ -864,6 +864,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 770,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/MeanReversion/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/MeanReversion/quantbook.ipynb
@@ -635,6 +635,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 560,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/MomentumStrategy/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/MomentumStrategy/quantbook.ipynb
@@ -495,6 +495,20 @@
   "language_info": {
    "name": "python",
    "version": "3.10.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 560,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Multi-Layer-EMA/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Multi-Layer-EMA/quantbook.ipynb
@@ -886,6 +886,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 770,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Multi-Layer-EMA/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Multi-Layer-EMA/research.ipynb
@@ -234,6 +234,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 420,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Option-Wheel/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Option-Wheel/quantbook.ipynb
@@ -870,6 +870,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 700,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Option-Wheel/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Option-Wheel/research.ipynb
@@ -428,6 +428,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 400,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Options-VGT/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Options-VGT/quantbook.ipynb
@@ -778,6 +778,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 630,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/OptionsIncome/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/OptionsIncome/quantbook.ipynb
@@ -812,6 +812,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 700,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/PairsTrading/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/PairsTrading/quantbook.ipynb
@@ -607,6 +607,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 490,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-IBKR-Coinbase-Hybrid/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-IBKR-Coinbase-Hybrid/quantbook.ipynb
@@ -657,6 +657,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 490,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-IBKR-Coinbase-Hybrid/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-IBKR-Coinbase-Hybrid/research.ipynb
@@ -242,6 +242,20 @@
   "language_info": {
    "name": "python",
    "version": "3.11.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 490,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/RL-Portfolio/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/RL-Portfolio/quantbook.ipynb
@@ -856,6 +856,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 700,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/RL-Portfolio/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/RL-Portfolio/research.ipynb
@@ -1700,6 +1700,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 1050,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/RegimeSwitching/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/RegimeSwitching/quantbook.ipynb
@@ -903,6 +903,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 770,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Research-Executor/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Research-Executor/research.ipynb
@@ -62,6 +62,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 400,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Research-Executor/research_asset_class_momentum.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Research-Executor/research_asset_class_momentum.ipynb
@@ -348,6 +348,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 400,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Research-Executor/research_commodity_term_structure.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Research-Executor/research_commodity_term_structure.ipynb
@@ -240,6 +240,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 400,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Research-Executor/research_defensive_etf_rotation.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Research-Executor/research_defensive_etf_rotation.ipynb
@@ -174,6 +174,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 400,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Research-Executor/research_long_short_harvest.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Research-Executor/research_long_short_harvest.ipynb
@@ -197,6 +197,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 400,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Research-Executor/research_macro_factor_rotation.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Research-Executor/research_macro_factor_rotation.ipynb
@@ -177,6 +177,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 400,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Research-Executor/research_piotroski_fscore.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Research-Executor/research_piotroski_fscore.ipynb
@@ -377,6 +377,20 @@
    "parameters": {},
    "start_time": "2026-06-01T00:32:46.549088+00:00",
    "version": "2.7.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 400,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Research-Executor/research_puppies_of_dow.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Research-Executor/research_puppies_of_dow.ipynb
@@ -272,6 +272,20 @@
    "parameters": {},
    "start_time": "2026-06-01T00:32:38.020939+00:00",
    "version": "2.7.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 400,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Research-Executor/research_volatility_regime_ml.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Research-Executor/research_volatility_regime_ml.ipynb
@@ -472,6 +472,20 @@
    "parameters": {},
    "start_time": "2026-06-01T00:32:29.444726+00:00",
    "version": "2.7.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 420,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/RiskParity/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/RiskParity/quantbook.ipynb
@@ -526,6 +526,20 @@
   "language_info": {
    "name": "python",
    "version": "3.10.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 560,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Sector-ML-Classification/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Sector-ML-Classification/research.ipynb
@@ -959,6 +959,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 910,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/SectorMomentum/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/SectorMomentum/quantbook.ipynb
@@ -449,6 +449,20 @@
   "language_info": {
    "name": "python",
    "version": "3.10.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 490,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Stoploss-Volatility-ML/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Stoploss-Volatility-ML/research.ipynb
@@ -409,6 +409,20 @@
   "language_info": {
    "name": "python",
    "version": "3.11.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 560,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Trend-Following/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Trend-Following/quantbook.ipynb
@@ -708,6 +708,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 630,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/TrendStocks-Alpha/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/TrendStocks-Alpha/quantbook.ipynb
@@ -672,6 +672,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 630,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/TurnOfMonth/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/TurnOfMonth/quantbook.ipynb
@@ -526,6 +526,20 @@
    "nbformat_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.6.8"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 630,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/VIX-TermStructure/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/VIX-TermStructure/quantbook.ipynb
@@ -467,6 +467,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 700,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Vol-Ensemble-Conservative/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Vol-Ensemble-Conservative/research.ipynb
@@ -878,6 +878,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 630,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Vol-GARCH-Target/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Vol-GARCH-Target/research.ipynb
@@ -669,6 +669,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 490,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/research/research_btc_ml.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/research/research_btc_ml.ipynb
@@ -1158,6 +1158,20 @@
    "parameters": {},
    "start_time": "2026-05-16T02:11:42.495687+00:00",
    "version": "2.7.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 700,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/research/research_m11ef_ensemble.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/research/research_m11ef_ensemble.ipynb
@@ -328,6 +328,20 @@
   "language_info": {
    "name": "python",
    "version": "3.10.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 420,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/research/research_m12_har_rv_j.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/research/research_m12_har_rv_j.ipynb
@@ -536,6 +536,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 560,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/QuantConnect/research/research_m12_har_rv_j_minute.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/research/research_m12_har_rv_j_minute.ipynb
@@ -325,6 +325,20 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.14"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "qcc_tokens_est": 560,
+   "cpu_min": 0,
+   "gpu_required": false,
+   "network": true,
+   "external_account": "quantconnect-organization",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "last_validated": "2026-07-26",
+   "validator": "qc_cloud"
   }
  },
  "nbformat": 4,

--- a/scripts/audit/populate_cost_metadata.py
+++ b/scripts/audit/populate_cost_metadata.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""
+populate_cost_metadata.py — Peuple `nb.metadata['cost']` pour les notebooks sans matrice de coût.
+
+Issue #8056 — matrice coût/ressource par notebook. Issue #8587 (MERGED) a ajouté le
+champ `qcc_tokens_est` au schema + validator (Litmus 7) + tests. Ce qui reste :
+~69 notebooks QuantConnect (QuantBook) SANS aucune `metadata.cost` — donc présentés
+comme « gratuits » (Litmus 7 flag). Les 10 PR de migration précédentes (#8418..#8585)
+étaient des hand-edits par notebook ; ce script déterministe clôt le gap en une passe.
+
+But : pour chaque notebook QuantConnect utilisant `QuantBook()` et dépourvu de
+`metadata['cost']`, insérer le bloc de coût canonique (profile `quantbook`) dérivé :
+  - `qcc_tokens_est` via l'heuristic documentée `max(400, n_code_cells × 70)`
+    (cf docs/notebook-metadata/cost-matrix.md §"Coût QCC / QuantConnect", #8056)
+  - les champs obligatoires (schema cost-matrix.md) aux valeurs de consensus des
+    13 quantbooks déjà migrés (#8585) ou aux défauts du schema
+  - `null` pour les champs notebook-specific (`reduced_pedagogical`,
+    `free_alternative`) qui exigent un jugement humain — jamais fabriqués
+
+Idempotent : JAMAIS écrase un bloc `cost` existant (un notebook déjà peuplé est
+skippé). Litmus anti-LIGHT : ce script APPLIQUE une transformation documentée et
+déterministe ; le verdict final (la metadata est-elle *juste* ?) = revue humaine.
+Cf `check_cost_metadata.py` (le vérificateur), `docs/notebook-metadata/cost-matrix.md`.
+
+Usage :
+  # Audit (dry-run) — liste ce qui serait peuplé, n'écrit rien
+  python scripts/audit/populate_cost_metadata.py <notebook-ou-dossier>.ipynb --profile quantbook
+
+  # Appliquer
+  python scripts/audit/populate_cost_metadata.py <notebook-ou-dossier> --profile quantbook \\
+      --by myia-po-2024:CoursIA-2 --apply
+"""
+
+import argparse
+import datetime as _dt
+import json
+import re
+import sys
+from pathlib import Path
+
+
+QUANTBOOK_RE = re.compile(r"QuantBook\(\)|self\.QuantBook")
+
+# Champ obligatoires + defaults pour le profile `quantbook`.
+# Valeurs : consensus des 13 quantbooks migrés (#8585) > défaut schema (cost-matrix.md
+# §mandatory) > null honest pour les champs notebook-specific.
+# NOTE doc-vs-practice : le template doc (cost-matrix.md §"QC / QuantConnect") montre
+# `api_provider: qc_cloud` / `external_account: qc`, mais la PRATIQUE migrée (13/13)
+# utilise `api_provider: none` / `external_account: quantconnect-organization`. On suit
+# la pratique migrée (consistance intra-famille QC) ; l'écart est documenté ici, pas caché.
+
+
+def _count_code_cells(nb: dict) -> int:
+    """Nombre de cellules code non-vides (source non-whitespace)."""
+    n = 0
+    for cell in nb.get("cells", []):
+        if cell.get("cell_type") != "code":
+            continue
+        src = "".join(cell.get("source", []))
+        if src.strip():
+            n += 1
+    return n
+
+
+def _uses_quantbook(nb: dict) -> bool:
+    for cell in nb.get("cells", []):
+        if cell.get("cell_type") != "code":
+            continue
+        if QUANTBOOK_RE.search("".join(cell.get("source", []))):
+            return True
+    return False
+
+
+def qcc_tokens_estimate(n_code_cells: int) -> int:
+    """Heuristic QCC documentée (cost-matrix.md §"Coût QCC / QuantConnect", #8056) :
+    ~70 QCC par cellule code, plancher 400. Estimation (suffixe `_est`), pas mesure."""
+    return max(400, n_code_cells * 70)
+
+
+def build_quantbook_cost(nb: dict, by: str, today: str) -> dict:
+    """Construit le bloc `metadata['cost']` canonique pour un quantbook.
+
+    Champs dérivés : `qcc_tokens_est` (heuristic), `last_validated` (date de création
+    de la metadata — pas date d'exécution QC Cloud ; `validator: qc_cloud` nomme la
+    MÉTHODE canonique de validation, pas une exécution récente).
+    Champs notebook-specific (`reduced_pedagogical`, `free_alternative`) : null
+    (jugement humain ; QuantBook = QC uniquement → pas d'alternative locale).
+    """
+    n_code = _count_code_cells(nb)
+    return {
+        "api_usd_est": 0.0,  # QCC = quota non-USD (schema default 0)
+        "api_provider": "none",  # 13/13 migrés ; schema default "none"
+        "qcc_tokens_est": qcc_tokens_estimate(n_code),  # heuristic max(400, n×70)
+        "cpu_min": 0,  # QC s'exécute sur le cloud (QCC) ; CPU local = 0 (schema default)
+        "gpu_required": False,  # quantbook de recherche, pas de GPU local
+        "network": True,  # API QuantConnect obligatoire (HTTPS) (13/13 migrés)
+        "external_account": "quantconnect-organization",  # 12/13 migrés (QC user + token)
+        "free_alternative": None,  # QuantBook = QC uniquement, pas d'alternative locale
+        "reduced_pedagogical": None,  # notebook-specific (jugement humain) ; null = honnête
+        "reproducibility": "MED",  # single-run backtest stochastique (doc template)
+        "last_validated": today,  # date d'établissement de la metadata (script)
+        "validator": "qc_cloud",  # Litmus 5 : qc_cloud pour QuantBook (13/13)
+    }
+
+
+def populate_notebook(path: Path, by: str, today: str, apply: bool) -> str:
+    """Peuple metadata.cost si QuantBook + absent. Retourne un code statut.
+
+    Returns: 'populated' | 'skipped-has-cost' | 'skipped-no-quantbook' | 'error'.
+    """
+    try:
+        nb = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as e:
+        return f"error: {e}"
+
+    if not _uses_quantbook(nb):
+        return "skipped-no-quantbook"
+
+    meta = nb.setdefault("metadata", {})
+    if "cost" in meta:  # idempotent : ne JAMAIS écraser un bloc existant
+        return "skipped-has-cost"
+
+    cost = build_quantbook_cost(nb, by=by, today=today)
+    if not apply:
+        return "populated"  # dry-run : on rapporte, on n'écrit pas
+
+    meta["cost"] = cost
+    # Round-trip json indent=1 (convention repo) ; LF-only ; pas de churn inutile.
+    path.write_text(
+        json.dumps(nb, indent=1, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    return "populated"
+
+
+def iter_notebooks(target: Path):
+    """Énumère les .ipynb sous target (fichier unique ou dossier récursif),
+    en excluant _output.ipynb, .ipynb_checkpoints/, /backtests/."""
+    if target.is_file():
+        yield target
+        return
+    for p in sorted(target.rglob("*.ipynb")):
+        s = str(p).replace("\\", "/")
+        if "_output" in p.name:
+            continue
+        if ".ipynb_checkpoints" in s:
+            continue
+        if "/backtests/" in s:
+            continue
+        yield p
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    ap.add_argument("target", type=Path, help="Notebook .ipynb ou dossier à peupler")
+    ap.add_argument("--profile", choices=["quantbook"], default="quantbook",
+                    help="Profile de coût (seul 'quantbook' est implémenté)")
+    ap.add_argument("--by", default="anonymous",
+                    help="machine:workspace (provenance, pour le rapport)")
+    ap.add_argument("--apply", action="store_true",
+                    help="Écrire les modifications (défaut : dry-run)")
+    ap.add_argument("--today", default=None,
+                    help="Date ISO pour last_validated (défaut : aujourd'hui)")
+    args = ap.parse_args(argv)
+
+    if not args.target.exists():
+        print(f"ERROR: {args.target} n'existe pas", file=sys.stderr)
+        return 2
+
+    today = args.today or _dt.date.today().isoformat()
+    counts = {"populated": 0, "skipped-has-cost": 0, "skipped-no-quantbook": 0}
+    errors = []
+
+    for nb_path in iter_notebooks(args.target):
+        status = populate_notebook(nb_path, by=args.by, today=today, apply=args.apply)
+        if status.startswith("error"):
+            errors.append((nb_path, status))
+        elif status in counts:
+            counts[status] += 1
+            if status == "populated":
+                print(f"  {'WRITE' if args.apply else 'DRY-RUN'}  {nb_path}")
+        else:
+            errors.append((nb_path, f"unexpected: {status}"))
+
+    mode = "APPLY" if args.apply else "DRY-RUN"
+    print(f"\n[{mode}] profile={args.profile} by={args.by} today={today}")
+    print(f"  populated (QuantBook sans cost) : {counts['populated']}")
+    print(f"  skipped-has-cost (déjà peuplé)   : {counts['skipped-has-cost']}")
+    print(f"  skipped-no-quantbook             : {counts['skipped-no-quantbook']}")
+    if errors:
+        print(f"  errors                           : {len(errors)}", file=sys.stderr)
+        for p, e in errors:
+            print(f"    {p}: {e}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/audit/tests/test_populate_cost_metadata.py
+++ b/scripts/audit/tests/test_populate_cost_metadata.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Tests pour populate_cost_metadata.py — Issue #8056, profile quantbook."""
+
+import json
+import sys
+from pathlib import Path
+
+# Importer le module voisin (scripts/audit est sur sys.path via conftest ou ajout manuel).
+HERE = Path(__file__).resolve().parent
+AUDIT_DIR = HERE.parent
+sys.path.insert(0, str(AUDIT_DIR))
+
+import populate_cost_metadata as pcm  # noqa: E402
+
+
+def _make_quantbook(n_code_cells: int = 10) -> dict:
+    """Un notebook QuantBook minimal avec n cellules code."""
+    nb = {
+        "cells": [
+            {"cell_type": "markdown", "metadata": {}, "source": ["# Demo\n"]},
+            {"cell_type": "code", "execution_count": None, "metadata": {},
+             "outputs": [], "source": ["qb = QuantBook()\n"]},
+        ],
+        "metadata": {"kernelspec": {"name": "python3"}},
+        "nbformat": 4, "nbformat_minor": 5,
+    }
+    for _ in range(n_code_cells - 1):
+        nb["cells"].append({"cell_type": "code", "execution_count": None,
+                            "metadata": {}, "outputs": [], "source": ["x = 1\n"]})
+    return nb
+
+
+def _make_non_qc() -> dict:
+    return {"cells": [{"cell_type": "code", "execution_count": None,
+                       "metadata": {}, "outputs": [], "source": ["print('hi')\n"]}],
+            "metadata": {}, "nbformat": 4, "nbformat_minor": 5}
+
+
+# === Heuristic QCC ===
+
+def test_qcc_heuristic_floor():
+    """Peu de cellules → plancher 400 (cf #8056, cost-matrix.md)."""
+    assert pcm.qcc_tokens_estimate(0) == 400
+    assert pcm.qcc_tokens_estimate(1) == 400
+    assert pcm.qcc_tokens_estimate(5) == 400  # 5×70=350 < 400
+
+
+def test_qcc_heuristic_linear():
+    """Au-delà du plancher, ~70 QCC/cellule."""
+    assert pcm.qcc_tokens_estimate(10) == 700
+    assert pcm.qcc_tokens_estimate(14) == 980   # acceptance #8056 : « 14 cellules ≈ 800-1200 »
+    assert pcm.qcc_tokens_estimate(28) == 1960  # QC-Py-04 observé
+
+
+# === Detection ===
+
+def test_uses_quantbook_detect():
+    assert pcm._uses_quantbook(_make_quantbook())
+    assert not pcm._uses_quantbook(_make_non_qc())
+
+
+def test_count_code_cells_ignores_empty():
+    nb = _make_quantbook(3)
+    nb["cells"].append({"cell_type": "code", "execution_count": None,
+                        "metadata": {}, "outputs": [], "source": ["   \n"]})  # whitespace only
+    assert pcm._count_code_cells(nb) == 3  # cellule vide non comptée
+
+
+# === build_quantbook_cost : champs obligatoires + valeurs canoniques ===
+
+def test_build_cost_has_all_mandatory_fields():
+    cost = pcm.build_quantbook_cost(_make_quantbook(10), by="m:w", today="2026-07-26")
+    mandatory = {"api_usd_est", "api_provider", "cpu_min", "gpu_required",
+                 "network", "external_account", "reproducibility",
+                 "last_validated", "validator"}
+    assert mandatory <= set(cost), f"champs obligatoires manquants: {mandatory - set(cost)}"
+
+
+def test_build_cost_clears_litmus5_and_7():
+    """validator=qc_cloud (Litmus 5) + qcc_tokens_est nonzero (Litmus 7)."""
+    cost = pcm.build_quantbook_cost(_make_quantbook(10), by="m:w", today="2026-07-26")
+    assert cost["validator"] == "qc_cloud"
+    assert cost["qcc_tokens_est"] > 0
+
+
+def test_build_cost_honest_nulls_for_notebook_specific():
+    """reduced_pedagogical + free_alternative = null (jugement humain, jamais fabriqué)."""
+    cost = pcm.build_quantbook_cost(_make_quantbook(10), by="m:w", today="2026-07-26")
+    assert cost["reduced_pedagogical"] is None
+    assert cost["free_alternative"] is None
+
+
+def test_build_cost_matches_migrated_consensus():
+    """Consensus des 13 quantbooks migrés (#8585) : api_provider=none, network=true,
+    external_account=quantconnect-organization."""
+    cost = pcm.build_quantbook_cost(_make_quantbook(10), by="m:w", today="2026-07-26")
+    assert cost["api_provider"] == "none"
+    assert cost["network"] is True
+    assert cost["external_account"] == "quantconnect-organization"
+
+
+# === Idempotence (HARD) ===
+
+def test_populate_idempotent_never_overwrites(tmp_path):
+    """Un notebook déjà peuplé est skippé — JAMAIS écraser un bloc existant."""
+    nb = _make_quantbook(10)
+    nb["metadata"]["cost"] = {"api_usd_est": 0.42, "validator": "manual"}  # bloc existant
+    p = tmp_path / "nb.ipynb"
+    p.write_text(json.dumps(nb, indent=1), encoding="utf-8")
+
+    status = pcm.populate_notebook(p, by="m:w", today="2026-07-26", apply=True)
+    assert status == "skipped-has-cost"
+    # Le bloc existant est intact
+    after = json.loads(p.read_text(encoding="utf-8"))
+    assert after["metadata"]["cost"]["api_usd_est"] == 0.42
+    assert after["metadata"]["cost"]["validator"] == "manual"
+
+
+def test_populate_skips_non_qc(tmp_path):
+    nb = _make_non_qc()
+    p = tmp_path / "nb.ipynb"
+    p.write_text(json.dumps(nb, indent=1), encoding="utf-8")
+    assert pcm.populate_notebook(p, by="m:w", today="2026-07-26", apply=True) == "skipped-no-quantbook"
+
+
+def test_populate_applies_and_writes(tmp_path):
+    nb = _make_quantbook(10)
+    p = tmp_path / "nb.ipynb"
+    p.write_text(json.dumps(nb, indent=1), encoding="utf-8")
+    status = pcm.populate_notebook(p, by="m:w", today="2026-07-26", apply=True)
+    assert status == "populated"
+    after = json.loads(p.read_text(encoding="utf-8"))
+    assert after["metadata"]["cost"]["qcc_tokens_est"] == 700
+    assert after["metadata"]["cost"]["validator"] == "qc_cloud"
+
+
+def test_populate_dry_run_writes_nothing(tmp_path):
+    nb = _make_quantbook(10)
+    p = tmp_path / "nb.ipynb"
+    original = json.dumps(nb, indent=1)
+    p.write_text(original, encoding="utf-8")
+    status = pcm.populate_notebook(p, by="m:w", today="2026-07-26", apply=False)
+    assert status == "populated"  # rapporte qu'il peuplerait
+    assert p.read_text(encoding="utf-8") == original  # mais n'écrit rien
+
+
+def test_populate_preserves_notebook_structure(tmp_path):
+    """La transformation ne touche QUE metadata.cost — cells/kernel/nbformat intacts."""
+    nb = _make_quantbook(10)
+    nb["metadata"]["kernelspec"] = {"name": "python3", "display_name": "Python 3"}
+    nb["metadata"]["custom_field"] = "preserve-me"
+    p = tmp_path / "nb.ipynb"
+    p.write_text(json.dumps(nb, indent=1), encoding="utf-8")
+    pcm.populate_notebook(p, by="m:w", today="2026-07-26", apply=True)
+    after = json.loads(p.read_text(encoding="utf-8"))
+    assert after["metadata"]["kernelspec"]["display_name"] == "Python 3"
+    assert after["metadata"]["custom_field"] == "preserve-me"
+    assert after["nbformat"] == 4
+    assert len(after["cells"]) == len(nb["cells"])  # aucune cellule touchée


### PR DESCRIPTION
Grain: MED/tooling-infra — lane myia-po-2024:CoursIA-2 — prev: DEEP/notebook-dotnet (c.887 #8594 OPEN)

## Summary

Closes the remaining QuantConnect cost-metadata gap in ONE deterministic pass: a new
population tool `scripts/audit/populate_cost_metadata.py` (idempotent, heuristic-driven)
+ run it on the 71 QuantBook-using notebooks that had **no** `metadata.cost` at all.

This replaces ~6 hand-edit tranches with a single scripted + mechanically-verified PR
(G-VAR / G.4 lifted per ai-01 c.11 for scripted deterministic transforms).

### Phantom catch (G.1 firsthand)

ai-01's c.11 dispatch ("extend the QCC schema + populate QC family") was **stale**:
PR #8587 (MERGED) already added the `qcc_tokens_est` field to the schema + validator
(Litmus 7) + tests. The genuine remaining gap: **71 QuantBook-using notebooks with no
`metadata.cost` block** (84 use QuantBook − 13 already populated), presented as "free"
because `qcc_tokens_est` was absent — exactly the Litmus-7 flag. No population script
existed (the 10 migration PRs #8418..#8585 were per-notebook hand-edits).

### What this PR adds

1. **`scripts/audit/populate_cost_metadata.py`** — deterministic, idempotent population
   tool. For each notebook using `QuantBook()` (same regex as the validator) and
   lacking `metadata.cost`, inserts the canonical quantbook cost block. CLI:
   `--profile quantbook --by <machine:workspace> [--apply]` (dry-run default).
   - `qcc_tokens_est` via the documented heuristic `max(400, n_code_cells × 70)`
     (cost-matrix.md §"Coût QCC / QuantConnect", #8056 acceptance).
   - **Idempotent (HARD)**: never overwrites an existing `cost` block (unit-tested).
   - **Honest nulls**: `reduced_pedagogical` + `free_alternative` = null (notebook-
     specific human judgment — never fabricated). `free_alternative: null` is correct
     for QuantBook (QC-only, no local alternative).
   - json round-trip (indent=1, LF) — metadata-only, 0 cell churn (unit-tested).

2. **`scripts/audit/tests/test_populate_cost_metadata.py`** — 13 tests: heuristic
   (floor 400, linear 70/cell), detection, all-mandatory-fields, Litmus-5/7 clearing,
   honest-nulls, migrated-consensus values, **idempotence (never overwrites)**,
   dry-run-writes-nothing, structure-preservation. **13/13 pass.**

3. **71 notebooks populated** (cost block added to `metadata`). Diff is surgical:
   +1004/-10. The −10 is mechanical (10 notebooks whose last metadata key needed a
   trailing comma when `cost` was inserted after it — e.g. `"qc_reference": true` →
   `"qc_reference": true,`). Cells byte-identical to origin/main (verified).

### Field-value choices (grounded, documented in script docstring)

- **Consensus from the 13 migrated (#8585)**: `api_provider: "none"` (13/13),
  `external_account: "quantconnect-organization"` (12/13), `network: true`,
  `validator: "qc_cloud"` (Litmus 5).
- **Schema defaults** for the rest: `api_usd_est: 0.0`, `cpu_min: 0`, `gpu_required: false`.
- **`reproducibility: "MED"`** (doc template; single-run backtest stochastic).
- **Doc-vs-practice discrepancy (flagged, not silently diverged)**: the cost-matrix.md
  template shows `api_provider: qc_cloud` / `external_account: qc`, but migrated practice
  uses `none` / `quantconnect-organization`. The script follows **practice** (intra-family
  QC consistency) and documents the discrepancy in its docstring. A separate docs PR can
  reconcile the template if desired.

## Validation

- **Litmus 7 cleared fleet-wide**: ran `check_cost_metadata.py` across all 205 QC
  notebooks → `qc_notebook_no_qcc_estimate` findings = **0** (was 71). The 12 remaining
  findings are pre-existing UNRELATED GPU findings (`gpu_used_but_not_declared` ×11,
  `gpu_no_visual_validator` ×1), not introduced here.
- Existing validator tests: **18/18 pass** (no regression to check_cost_metadata).
- New script tests: **13/13 pass**.
- C.2 N/A: metadata-only, 0 code cells touched, no re-exec needed.
- C.1 N/A: no notebook code (pure metadata).

See #8056 (cost matrix), #8587 (qcc_tokens_est schema field).

**Note**: `last_validated` = metadata-establishment date (script run), not a QC Cloud
execution date. `validator: qc_cloud` names the canonical validation *method*. A future
QC-Cloud re-exec pass can refine `qcc_tokens_est` from real `read_backtest` QCC consumed
(the `_est` suffix attests these are estimates).
