### PR TITLE
fix(cost-metadata,#8056): free_alternative — un service payant n'est pas une alternative gratuite

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Video/01-Foundation/01-3-Qwen-VL-Video-Analysis.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/01-Foundation/01-3-Qwen-VL-Video-Analysis.ipynb
@@ -2347,7 +2347,7 @@
    "vram_tier": "GPU_HIGH",
    "network": true,
    "external_account": "huggingface",
-   "free_alternative": "openai",
+   "free_alternative": "self",
    "reduced_pedagogical": "ollama",
    "reproducibility": "MED",
    "last_validated": "2026-07-23T14:00Z",

--- a/docs/notebook-metadata/cost-matrix.md
+++ b/docs/notebook-metadata/cost-matrix.md
@@ -37,7 +37,7 @@ bloc `---\n...\n---` est promue par markdown-it en **setext-H2 supersize**
   "vram_tier": "LITE",            // Catégorie VRAM (cf table §"Tiers VRAM")
   "network": true,                // Accès réseau requis (téléchargement modèle, appel API)
   "external_account": "openai",   // Compte externe obligatoire (openai, anthropic, hf, qc, ...) | "none"
-  "free_alternative": null,       // Notebook du dépôt qui couvre le même sujet sans coût | null
+  "free_alternative": null,       // Chemin repo-relatif vers un notebook équivalent sans coût, sentinel canonique, ou null. Cf §"Sentinels de `free_alternative`".
   "reduced_pedagogical": null,    // Version pédagogique réduite (sous-ensemble ou mock) | null
   "reproducibility": "HIGH",      // HIGH=déterministe, MED=seed-dépendant, LOW=stochastique
   "last_validated": "2026-07-24", // Date dernière exécution validée (ISO8601, papermill/QC Cloud/MCP)
@@ -117,6 +117,24 @@ Le catalogue anti-drift expose `cost` via l'inférence du frontmatter. Schéma c
 ```
 
 Le champ `cost.free_alternative` permet le routage machine : si `po-2025` n'a pas le GPU ou l'API key, le catalogue pointe vers le notebook équivalent exécutable localement.
+
+### Sentinels de `free_alternative`
+
+Le champ admet **deux natures** : un chemin repo-relatif, ou un **sentinel sémantique**. Le critère qui décide qu'un sentinel est canonique : **il porte une information que `null` détruit** (design-gate tranché sur #8056).
+
+| Valeur | Statut | Sens |
+|---|---|---|
+| `<chemin repo-relatif>` | forme nominale | Un notebook du dépôt couvre le même sujet sans coût. Résolu en dual-base (racine du dépôt **ou** `MyIA.AI.Notebooks/`). |
+| `self` | **canonique** | Ce notebook **est** l'alternative gratuite. Opposé de `null` — ne jamais normaliser vers `null`, ce serait lire 55 réponses positives comme 55 absences de réponse. |
+| `ollama` | **canonique** | Un moteur local gratuit couvre le sujet. Aucun chemin du dépôt ne l'exprime. |
+| `n/a` | toléré | Synonyme de `null`. Traité à l'identique par le checker ; pas de migration (coût non nul, gain nul). |
+| `null` | forme nominale | Aucune alternative gratuite connue. |
+| **service payant** (`openai`, `anthropic`, `replicate`, …) | **erreur** | C'est précisément le service dont on cherche à s'affranchir. Flaggé `free_alternative_is_paid_service` (MAJOR). |
+| autre valeur non-chemin | **erreur** | Ne résout vers rien que le lecteur puisse suivre. Flaggé `free_alternative_unresolvable` (MINOR). |
+
+Un **basename nu** (`10_LocalLlama.ipynb`) est un chemin imprécis, pas un sentinel : le lecteur ne peut pas le suivre et la dual-base ne le résout pas. Le checker ne le résout **pas** par `glob` sur l'arbre — ça ferait taire le finding sans corriger la référence, et deviendrait ambigu au premier basename partagé. **On répare la donnée, pas le détecteur.**
+
+Implémentation : `scripts/audit/check_cost_metadata.py`, litmus 4.
 
 ## Peuplement pilote (cycle c.794)
 
@@ -374,6 +392,8 @@ Le script `extract_claims_vs_outputs.py` (livré par [PR #8068 / cycle c.793](ht
 | `metadata.cost.api_usd_est: 0.0` mais cellule appelle `openai.ChatCompletion.create()` | CRITICAL |
 | `metadata.cost.external_account: none` mais cellule demande `HF_TOKEN` | MAJOR |
 | `metadata.cost.free_alternative` pointe vers un notebook inexistant | MAJOR |
+| `metadata.cost.free_alternative` nomme un **service payant** (`openai`, `anthropic`, …) | MAJOR |
+| `metadata.cost.free_alternative` : valeur ni sentinel canonique ni chemin | MINOR |
 | Notebook QC sans `qc_cloud` validator | MAJOR |
 | Notebook GPU sans `sk_visual` validator (cf #5780 sweep) | MINOR |
 

--- a/scripts/audit/check_cost_metadata.py
+++ b/scripts/audit/check_cost_metadata.py
@@ -213,23 +213,47 @@ def check_notebook(notebook_path: Path, repo_root: Path) -> dict:
             })
 
     # Litmus 4 : free_alternative pointe vers un notebook inexistant.
-    # Le champ admet deux natures : un path relatif (vers un notebook/.md
-    # alternative gratuit) OU un sentinel semantique ('self' = ce notebook est
-    # deja l'alternative gratuite ; 'ollama'/'openai' = moteur gratuit ; 'N/A'
-    # = non-applicable ; 'none'/'null'). On ne verifie l'existence QUE des
-    # valeurs path-shaped : un sentinel n'est pas un fichier, le flagger =
-    # faux positif. Avant ce fix, le litmus produisait 101 FP fleet-wide
-    # (55x 'self', 18x '10_LocalLlama.ipynb' base fausse, 13x 'ollama',
-    # 5x 'N/A', 1x 'openai'...). Les sentinels explicites sont court-circuites
-    # en premier ; les valeurs path-shaped sont cherchees en dual-base (repo
-    # root OU MyIA.AI.Notebooks/, convention majoritaire).
-    SENTINELS = ('self', 'none', 'null', 'n/a', '')
+    # Le champ admet deux natures (design-gate tranche sur #8056) : un path
+    # relatif vers un notebook/.md alternative gratuit, OU un sentinel
+    # semantique. Un sentinel est canonique quand il porte une information que
+    # `null` detruit : 'self' = ce notebook EST l'alternative gratuite (oppose
+    # de `null` = « aucune alternative connue ») ; 'ollama' = un moteur local
+    # gratuit couvre le sujet, ce qu'aucun chemin du depot n'exprime ; 'n/a' =
+    # non-applicable, synonyme tolere de `null`.
+    #
+    # On ne verifie l'existence QUE des valeurs path-shaped : un sentinel n'est
+    # pas un fichier, le flagger = faux positif. Avant #8588 le litmus produisait
+    # 101 FP fleet-wide (55x 'self', 18x '10_LocalLlama.ipynb' base fausse,
+    # 13x 'ollama', 5x 'N/A'...). Les valeurs path-shaped sont cherchees en
+    # dual-base (repo root OU MyIA.AI.Notebooks/, convention majoritaire).
+    #
+    # 'openai' n'est PAS un sentinel : c'est precisement le service payant dont
+    # on cherche a s'affranchir. Le nommer comme alternative gratuite est une
+    # erreur de saisie -- desormais flaggee (voir plus bas), au lieu d'etre
+    # silencieusement toleree parce qu'elle ne ressemble pas a un chemin.
+    SENTINELS = ('self', 'ollama', 'none', 'null', 'n/a', '')
+    # Services payants : ne peuvent pas etre l'alternative *gratuite*.
+    PAID_SERVICES = (
+        'openai', 'anthropic', 'azure', 'replicate', 'runway',
+        'midjourney', 'gpt', 'claude', 'gemini',
+    )
     free_alt = cost_meta.get('free_alternative')
     if free_alt and str(free_alt).lower() not in SENTINELS:
         free_alt_str = str(free_alt)
         looks_like_path = ('/' in free_alt_str) or ('\\' in free_alt_str) \
             or free_alt_str.lower().endswith(('.ipynb', '.md'))
-        if looks_like_path:
+        if free_alt_str.lower() in PAID_SERVICES:
+            findings.append({
+                'pattern': 'free_alternative_is_paid_service',
+                'detail': (
+                    f"cost.free_alternative vaut '{free_alt}' : c'est un service "
+                    f"payant, il ne peut pas etre l'alternative gratuite. "
+                    f"Attendu : 'self' si ce notebook est deja gratuit, un "
+                    f"chemin repo-relatif, un moteur local ('ollama'), ou null."
+                ),
+                'severity': 'MAJOR',
+            })
+        elif looks_like_path:
             candidates = [
                 repo_root / free_alt,
                 repo_root / 'MyIA.AI.Notebooks' / free_alt,
@@ -240,6 +264,18 @@ def check_notebook(notebook_path: Path, repo_root: Path) -> dict:
                     'detail': f'cost.free_alternative pointe vers {free_alt} mais fichier absent',
                     'severity': 'MAJOR',
                 })
+        else:
+            # Ni sentinel canonique, ni chemin, ni service payant connu : la
+            # valeur ne resout vers rien que le lecteur puisse suivre.
+            findings.append({
+                'pattern': 'free_alternative_unresolvable',
+                'detail': (
+                    f"cost.free_alternative vaut '{free_alt}' : ni sentinel "
+                    f"canonique ({', '.join(s for s in SENTINELS if s)}), ni "
+                    f"chemin repo-relatif. Le lecteur ne peut pas le suivre."
+                ),
+                'severity': 'MINOR',
+            })
 
     # Litmus 5 : QC notebook sans qc_cloud validator
     uses_qc = any(detect_quantbook_usage(src) for _, src in code_cells_source)


### PR DESCRIPTION
`Grain: MED/metadata-gate — lane myia-ai-01:CoursIA — prev: MED/test (#8593)`

## Le defaut

Le design-gate `#8056` a tranche (c.14) que les sentinels de `cost.free_alternative` sont **canoniques** — le critere etant qu'*un sentinel est canonique quand il porte une information que `null` detruit*. `self` (55x) dit « ce notebook **est** l'alternative gratuite » ; `null` dit « je n'en connais aucune » : ce sont des **opposes**, pas deux ecritures de la meme absence.

**Le code ne l'exprimait pas.** `SENTINELS` valait `('self', 'none', 'null', 'n/a', '')`. `ollama` (13x) n'y figurait pas : il passait **par accident**, parce qu'il ne « ressemble pas a un chemin » et retombait donc hors du test d'existence. Et le commentaire du litmus 4 annoncait `openai` comme sentinel legitime — alors que c'est precisement le service **payant** dont on cherche a s'affranchir.

Deux classes de valeur passaient silencieusement :

| Valeur | Pourquoi invisible | Reel |
|---|---|---|
| `"openai"` (1x, `GenAI/Video/01-3-Qwen-VL`) | pas dans `SENTINELS`, mais pas path-shaped → aucune branche ne la voyait | Le service payant nomme comme alternative gratuite — sur un notebook **Qwen-VL local**, qui EST l'alternative a OpenAI. Exactement a l'envers. |
| `"01-5-Kokoro-TTS-Local"`, `"01-4-Whisper-Local"` | basenames **sans extension** : ni sentinel, ni `.ipynb` → hors des deux branches | References qu'aucun lecteur ne peut suivre. Les 18 `10_LocalLlama.ipynb`, eux, ont l'extension et etaient deja MAJOR. |

## Ce que fait la PR

- `SENTINELS` porte le jeu **decide** : `self`, `ollama`, `none`, `null`, `n/a`.
- Nouveau **`free_alternative_is_paid_service`** (MAJOR) — `openai`, `anthropic`, `azure`, `replicate`, `runway`, `midjourney`, `gpt`, `claude`, `gemini`.
- Nouveau **`free_alternative_unresolvable`** (MINOR) — ni sentinel canonique, ni chemin : la valeur ne resout vers rien de suivable.
- Le commentaire du litmus dit desormais ce que le code fait.
- **Correction de la donnee** : `01-3-Qwen-VL-Video-Analysis.ipynb` passe de `"openai"` a `"self"`.
- **Doc** : `cost-matrix.md` gagne une section « Sentinels de `free_alternative` » (elle n'en admettait **aucun** depuis `#8588`) + 2 lignes dans la grille de litmus.

## Mesure — fleet-wide, avant → apres

196 notebooks a metadonnee cout, meme arbre, ancien module charge depuis `main` :

```
free_alternative_missing         20 -> 20    (inchange)
free_alternative_unresolvable     0 ->  2    <- 2 references invisibles revelees
free_alternative_is_paid_service  0 ->  0    <- l'unique occurrence corrigee ici
total findings                  257 -> 259
```

## Controle negatif

Meme notebook, valeur forcee, les deux modules cote a cote :

```
'openai'  AVANT=(rien)   APRES=free_alternative_is_paid_service
'self'    AVANT=(rien)   APRES=(rien)
'ollama'  AVANT=(rien)   APRES=(rien)
'n/a'     AVANT=(rien)   APRES=(rien)
```

Le nouveau litmus **fire** sur le cas vise et **n'introduit aucun FP** sur les trois sentinels canoniques.

## Ce que la PR refuse de faire

Le detecteur n'est **pas** relache sur la donnee fausse. Les 18 basenames `10_LocalLlama.ipynb` restent MAJOR, et le checker ne les resout toujours pas par `glob` sur l'arbre : ca ferait taire 20 findings **sans corriger une seule reference**, et deviendrait ambigu au premier basename partage. On repare la donnee, pas le detecteur — meme famille de raisonnement que le poison-catalogue.

## Gates

- **C.2 / H.3** : le seul notebook touche l'est en **metadonnee pure** (`metadata.cost.free_alternative`, 1 ligne). Aucune cellule `source`, aucun `execution_count`, aucun `outputs` modifie — verifie : 14/14 cellules code gardent leur `execution_count` et leurs sorties. Pas de re-execution requise (C.3 : ne pas re-executer ce qu'on n'a pas modifie).
- **Catalogue** : byte-identique a `main` (aucun fichier catalogue dans le diff).
- **Scope** : un sujet — la semantique de `cost.free_alternative` (code + donnee + doc). 3 fichiers, +70/-14.

See #8056 (contribution partielle : volet `free_alternative` ; l'epic reste ouverte), #8588.
