### PR TITLE
fix(ci,#8056): le carve-out QC Cloud suit le runtime, pas le repertoire (debloque #8596)

### DIFF
--- a/scripts/notebook_tools/tests/test_validate_pr_notebooks.py
+++ b/scripts/notebook_tools/tests/test_validate_pr_notebooks.py
@@ -204,6 +204,45 @@ class TestValidateNotebookH3:
         assert result["passed"] is False
         assert any("execution_count is null" in e for e in result["errors"])
 
+    def test_skip_exec_for_quantbook_content_outside_qc_paths(self, tmp_path):
+        """A notebook that instantiates QuantBook() can only run on QC Cloud,
+        wherever it lives. The carve-out follows the RUNTIME REQUIREMENT, not
+        the directory: anchoring on the path alone left 16 QuantBook notebooks
+        outside it (ESGF-2026/lean-workspace, QuantConnect/research,
+        kit-transitoire), 8 with null execution_count — a landmine firing on
+        whoever next touched one of those files. See #8056."""
+        # Neither under QC_CLOUD_PATHS nor flagged qc_reference.
+        odd_path = tmp_path / "ESGF-2026" / "lean-workspace" / "research.ipynb"
+        nb = _write_nb(odd_path, [
+            _code("from QuantConnect.Research import *\nqb = QuantBook()",
+                  exec_count=None),
+        ])
+        result = validate_notebook(nb)
+        assert result["passed"] is True
+
+    def test_skip_exec_for_self_quantbook_attribute(self, tmp_path):
+        """`self.QuantBook` is the other spelling of the same requirement
+        (kept in sync with check_cost_metadata.detect_quantbook_usage)."""
+        odd_path = tmp_path / "elsewhere" / "research.ipynb"
+        nb = _write_nb(odd_path, [
+            _code("qb = self.QuantBook", exec_count=None),
+        ])
+        assert validate_notebook(nb)["passed"] is True
+
+    def test_no_skip_when_quantbook_only_mentioned_in_markdown(self, tmp_path):
+        """Narrowness guard: prose ABOUT QuantBook is not a runtime
+        requirement. Only a code cell instantiating it opts out of H.3 —
+        otherwise any tutorial mentioning QC would silently gain the right to
+        ship empty outputs."""
+        odd_path = tmp_path / "elsewhere" / "tutorial.ipynb"
+        nb = _write_nb(odd_path, [
+            _md("On instancie ensuite `QuantBook()` sur QC Cloud."),
+            _code("print('local, executable here')", exec_count=None),
+        ])
+        result = validate_notebook(nb)
+        assert result["passed"] is False
+        assert any("execution_count is null" in e for e in result["errors"])
+
 
 # ---------------------------------------------------------------------------
 # validate_notebook — C.1 checks (forbidden patterns)

--- a/scripts/notebook_tools/validate_pr_notebooks.py
+++ b/scripts/notebook_tools/validate_pr_notebooks.py
@@ -17,6 +17,7 @@ Exit codes:
 
 import argparse
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -56,7 +57,20 @@ ALLOW_NULL_EXEC_COUNT_KERNELS = {"lean4", "lean4-wsl", "lean"}
 
 # Paths that require QC Cloud (python3 kernel but need QuantBook runtime).
 # H.3 is advisory-only for these — they can only be executed via QC Cloud.
+# NOTE: this list is a FAST PATH, not the definition. The definition is
+# "the notebook instantiates QuantBook" — see QUANTBOOK_PATTERN below.
 QC_CLOUD_PATHS = ("QuantConnect/Python", "QuantConnect/projects")
+
+# The actual reason a null execution_count is tolerated is not WHERE a notebook
+# lives, it is WHAT IT NEEDS: `QuantBook()` only exists inside the QC Cloud
+# research runtime, which is on no worker machine. Anchoring on the path alone
+# left 16 QuantBook notebooks outside the carve-out (ESGF-2026/lean-workspace,
+# QuantConnect/research, partner-course kit-transitoire), 8 of them with null
+# execution_count — a latent CI landmine that fires on whoever next touches one
+# of those files, for a reason that is not their PR's fault. Same predicate as
+# check_cost_metadata.detect_quantbook_usage (Litmus 5/7) so the cost gate and
+# the execution gate agree on what "is a QC notebook" means. See #8056.
+QUANTBOOK_PATTERN = re.compile(r"QuantBook\(\)|self\.QuantBook")
 
 # Research-exploration archive snapshots (path suffix). An `*_archive.ipynb` is
 # a frozen log of exploratory iteration; its error outputs (KeyError/NameError
@@ -138,14 +152,28 @@ def _output_text(output: dict) -> str:
 
 def _is_qc_cloud(rel_path: str, data: dict) -> bool:
     """Whether a notebook can ONLY be executed via QC Cloud (so a null
-    execution_count is tolerated everywhere — CI AND local). True if the path
-    is under a QC Cloud directory OR the notebook is explicitly flagged as a
-    QC reference template (metadata.qc_reference=True, content-aware unification
-    with regression_scan.py:261 / #3776)."""
+    execution_count is tolerated everywhere — CI AND local). True if:
+      - the path is under a QC Cloud directory (fast path), OR
+      - the notebook is explicitly flagged as a QC reference template
+        (metadata.qc_reference=True, content-aware unification with
+        regression_scan.py:261 / #3776), OR
+      - a code cell instantiates `QuantBook()` (content-aware — the runtime
+        requirement itself, wherever the notebook happens to live).
+    """
     normalized = rel_path.replace("\\", "/")
     if any(p in normalized for p in QC_CLOUD_PATHS):
         return True
-    return data.get("metadata", {}).get("qc_reference") is True
+    if data.get("metadata", {}).get("qc_reference") is True:
+        return True
+    for cell in data.get("cells", []):
+        if cell.get("cell_type") != "code":
+            continue
+        source = cell.get("source", "")
+        if isinstance(source, list):
+            source = "".join(source)
+        if QUANTBOOK_PATTERN.search(source):
+            return True
+    return False
 
 
 def validate_notebook(nb_path: Path) -> dict:


### PR DESCRIPTION
`Grain: MED/ci-gate — lane myia-ai-01:CoursIA — prev: MED/metadata-gate (#8597)`

## Le defaut : le motif est le runtime, le test etait le repertoire

`validate_pr_notebooks` tolere un `execution_count: null` **la ou le relecteur ne peut pas executer non plus**. La raison ecrite dans le code est explicite :

> `QC Cloud needs the QuantBook runtime (nowhere on a worker machine).`

Mais le predicat, lui, etait une liste de chemins :

```python
QC_CLOUD_PATHS = ("QuantConnect/Python", "QuantConnect/projects")
```

Scan du depot — sur **93** notebooks qui instancient `QuantBook()`, **77** tombent dans le carve-out et **16 sont hors**, dont **8 avec `execution_count: null`** :

| # | Emplacement |
|---|---|
| 7 | `QuantConnect/ESGF-2026/lean-workspace/*-Researcher/` |
| 1 | `QuantConnect/research/research_m12_har_rv_j_minute.ipynb` |

Ces 8 sont une **mine dormante** : elles ne cassent rien tant que personne n'y touche, et font echouer le gate de la premiere PR qui les effleure — **pour un motif qui n'est pas le sien**.

C'est exactement ce qui vient d'arriver a **#8596** (population `metadata.cost` de 71 quantbooks, metadata pure, 0 cellule touchee, `git diff` verifie : 0 ligne `source`/`outputs`/`execution_count`). Elle a annote `research_m12_har_rv_j_minute.ipynb`, ce qui l'a fait entrer dans l'ensemble « notebooks changes » du validateur, qui a alors signale 8 violations H.3 **preexistantes sur `main`** (8/8 cellules code a `execution_count: null` depuis `a7589ecd3`). Verdict CI : `Static validation (H.1/H.3/C.1)  fail`.

## Le fix

`_is_qc_cloud` gagne un troisieme cas, apres le chemin (fast path) et le flag `metadata.qc_reference` : une cellule **de code** qui matche `QuantBook\(\)|self\.QuantBook`.

C'est le meme predicat que `check_cost_metadata.detect_quantbook_usage` (Litmus 5/7) — le gate de **cout** et le gate d'**execution** s'accordent desormais sur ce qu'est « un notebook QC », au lieu de repondre a la question par deux mecanismes qui divergent.

## Mesure — avant/apres sur les 1020 notebooks du depot

Ancien module charge depuis `main`, nouveau depuis l'arbre, `validate_notebook` appelee sur chaque notebook par les deux :

```
notebooks scannes : 1020
verdict change    :    8      <- exactement les 8 identifiees ci-dessus
False -> True     :    8
True  -> False    :    0      <- aucun notebook ne se met a echouer
```

Et sur la PR bloquee : **#8596 passe de `fail` (8 erreurs) a `71/71 passed`** (validateur patche, meme arbre, meme base).

## Etroitesse — ce que le carve-out ne fait PAS

Il reste opt-in **par le contenu executable**, pas par le sujet. Un tutoriel qui *parle* de QuantBook en markdown ne gagne aucun droit a livrer des sorties vides : seule une cellule de code qui l'instancie declenche l'exemption. Test dedie `test_no_skip_when_quantbook_only_mentioned_in_markdown`.

C'est le meme garde-fou que celui pose en #5214 pour .NET : « CI ne peut pas re-executer » n'est **pas** « les sorties peuvent etre vides ». Ici on elargit le premier ensemble a sa vraie definition sans toucher au second.

## Tests

4 ajoutes, aucun supprime, aucun relache :

- `test_skip_exec_for_quantbook_content_outside_qc_paths` — le cas nominal (chemin hors allowlist, pas de flag).
- `test_skip_exec_for_self_quantbook_attribute` — l'autre orthographe, alignee sur `detect_quantbook_usage`.
- `test_no_skip_when_quantbook_only_mentioned_in_markdown` — la garde d'etroitesse.
- La garde negative preexistante (`test_no_skip_exec_without_qc_reference_metadata`, notebook sans QuantBook) est **inchangee et passe toujours** — c'est elle qui prouve que le carve-out ne s'est pas mis a tout avaler.

```
scripts/notebook_tools/tests/test_validate_pr_notebooks.py
scripts/notebook_tools/tests/test_validate_pr_mutation.py
102 passed in 2.45s
```

## Ce que cette PR ne pretend pas regler

Les 8 notebooks restent **non executes**. Leur dette est reelle et separee : elle demande une passe QC Cloud (Playwright pour un quantbook, cf. modalites QC), pas un assouplissement de gate. Ce que la PR corrige, c'est que cette dette ne soit plus **facturee au hasard** a la prochaine PR qui passe a cote. Le commit `a7589ecd3` annoncait « real outputs » sur un notebook a 0 sortie — ce constat merite son propre grain, il n'est pas dilue ici.

## Gates

- **Scope** : un sujet — la definition du carve-out QC Cloud. 2 fichiers (le predicat + ses tests), aucun notebook touche.
- **Catalogue** : byte-identique a `main`.
- **C.2 / H.3** : N/A (aucun `.ipynb` dans le diff).

See #8056, #8596, #5214.
