### PR TITLE
fix(qc,#7575): audit quantbooks sur le contenu, plus sur le chemin (46 -> 93, 16 revelees)

### DIFF
--- a/scripts/quantconnect/audit_quantbooks_unexec.py
+++ b/scripts/quantconnect/audit_quantbooks_unexec.py
@@ -21,9 +21,21 @@ ne CORRIGE PAS -- la correction = re-executer dans le vrai environnement
 puis committer la vraie sortie. Stop&Repair, JAMAIS maquiller (regle
 secrets-hygiene 6 + sota-not-workaround Prong-A).
 
+Fenetre d'analyse : le CONTENU, pas le chemin
+---------------------------------------------
+Est un quantbook **tout notebook dont au moins une cellule code instancie
+``QuantBook()``** -- c'est ce dont il a besoin (le runtime research QC Cloud)
+qui le definit, pas ou il vit ni comment il s'appelle. La fenetre d'origine
+etait ``projects/*/quantbook.ipynb``, soit un chemin ET un basename : deux
+proxys de la vraie raison. ``--scope projects`` conserve cette ancienne
+fenetre pour comparaison ; ``--scope repo`` (defaut) est un sur-ensemble
+strict qui scanne les quantbooks canoniques d'abord (ils gardent leur
+cross-reference ``config.json``) puis balaye l'arbre par contenu, sans jamais
+rescanner ni reclassifier une entree deja vue.
+
 Ce qui est classifie (DETERMINISTE)
 -----------------------------------
-Pour chaque ``quantbook.ipynb`` du dossier ``MyIA.AI.Notebooks/QuantConnect/projects/*/`` :
+Pour chaque quantbook ainsi identifie :
 
   - **HEALTHY**              -- 0 cellule code sans ``execution_count`` ni sortie.
   - **STOP_REPAIR_STRIPPED** -- >=1 cellule code unexec ET >=1 cellule markdown
@@ -59,8 +71,9 @@ appel reseau) pour rester CPU-only et CI-friendly.
 
 Usage
 -----
-    python audit_quantbooks_unexec.py                        # tous les projets
-    python audit_quantbooks_unexec.py --project DualMomentum  # un seul
+    python audit_quantbooks_unexec.py                        # tout le depot (par contenu)
+    python audit_quantbooks_unexec.py --scope projects       # ancienne fenetre (chemin)
+    python audit_quantbooks_unexec.py --project DualMomentum  # un seul projet canonique
     python audit_quantbooks_unexec.py --json                 # sortie machine
     python audit_quantbooks_unexec.py --check                # exit 1 si PREEXISTING_UNEXEC
     python audit_quantbooks_unexec.py --md report.md         # rapport markdown
@@ -99,6 +112,20 @@ _STRIP_MARKER = re.compile(r"(sortie\s+stripp[e\xe9]e|FABRICATED|blank[\s\-]?PNG
 # gaming du detecteur (les deux bug-classes ont deux marqueurs distincts).
 _UNEXEC_MARKER = re.compile(r"QC-UNEXEC-TRIAGED", re.IGNORECASE)
 
+# Ce qui fait d'un notebook un "quantbook" est ce dont il a BESOIN, pas ou il
+# vit ni comment il s'appelle : ``QuantBook()`` n'existe que dans le runtime
+# research de QC Cloud. La fenetre d'origine etait ``projects/*/quantbook.ipynb``
+# -- un chemin ET un basename -- alors que la pathologie decrite par #7575
+# (cellules code jamais executees faute de ce runtime) est une propriete du
+# CONTENU. Neuf notebooks la portaient hors fenetre (ESGF-2026/lean-workspace,
+# QuantConnect/research, partner-course), donc absents de tout rapport : le
+# ``HEALTHY (28)`` se lisait comme un etat de sante global alors qu'il ne
+# couvrait qu'un repertoire. Meme predicat que ``validate_pr_notebooks``
+# (QUANTBOOK_PATTERN, carve-out H.3) et ``check_cost_metadata`` afin que les
+# trois outils repondent la meme chose a "qu'est-ce qu'un notebook QC".
+# Voir #7575, #8598.
+_QUANTBOOK_PATTERN = re.compile(r"QuantBook\(\)|self\.QuantBook")
+
 
 def _is_code(cell: dict) -> bool:
     return cell.get("cell_type") == "code"
@@ -135,6 +162,23 @@ def _has_unexec_marker(nb: dict) -> bool:
         if isinstance(src, list):
             src = "".join(src)
         if _UNEXEC_MARKER.search(src or ""):
+            return True
+    return False
+
+
+def _uses_quantbook(nb: dict) -> bool:
+    """Au moins une cellule CODE instancie ``QuantBook()`` / ``self.QuantBook``.
+
+    Cellules code seulement : un tutoriel qui *parle* de QuantBook en markdown
+    n'a pas besoin du runtime QC Cloud et n'entre donc pas dans la fenetre.
+    """
+    for c in nb.get("cells", []):
+        if not _is_code(c):
+            continue
+        src = c.get("source", "")
+        if isinstance(src, list):
+            src = "".join(src)
+        if _QUANTBOOK_PATTERN.search(src or ""):
             return True
     return False
 
@@ -230,6 +274,48 @@ def scan_projects(quant_root: Path) -> list[dict]:
     results = []
     for nb in sorted(quant_root.glob("*/quantbook.ipynb")):
         results.append(scan_notebook(nb))
+    return results
+
+
+def scan_repo(notebooks_root: Path, quant_root: Path) -> list[dict]:
+    """Scan tout notebook qui INSTANCIE ``QuantBook()``, ou qu'il vive.
+
+    Sur-ensemble strict de :func:`scan_projects` : les quantbooks canoniques de
+    ``quant_root`` sont scannes d'abord (ils conservent leur cross-reference
+    ``config.json``), puis le reste de l'arbre est balaye par contenu. Un
+    notebook deja vu n'est pas rescanne, donc aucune entree existante n'est
+    reclassifiee par l'elargissement.
+
+    ``notebooks_root`` absent n'est pas une erreur ici : le scan canonique est
+    rendu seul (rien a elargir). Un chemin errone passe explicitement en
+    ``--notebooks-root`` est rejete par :func:`main` (exit 2).
+    """
+    results = []
+    seen: set[Path] = set()
+    if quant_root.exists():
+        for nb in sorted(quant_root.glob("*/quantbook.ipynb")):
+            results.append(scan_notebook(nb))
+            seen.add(nb.resolve())
+
+    if not notebooks_root.exists():
+        return results
+
+    for nb in sorted(notebooks_root.rglob("*.ipynb")):
+        resolved = nb.resolve()
+        if resolved in seen:
+            continue
+        if ".ipynb_checkpoints" in nb.parts:
+            continue
+        try:
+            with open(nb, encoding="utf-8") as f:
+                doc = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            continue  # illisible : hors perimetre de cet audit (pas un quantbook prouve)
+        if not _uses_quantbook(doc):
+            continue
+        results.append(scan_notebook(nb))
+        seen.add(resolved)
+
     return results
 
 
@@ -346,6 +432,12 @@ def main(argv=None) -> int:
     parser.add_argument("--quant-root",
                         default="MyIA.AI.Notebooks/QuantConnect/projects",
                         help="Path to QC projects dir (relative to --root)")
+    parser.add_argument("--notebooks-root", default=None,
+                        help="Racine des notebooks pour --scope repo "
+                             "(relative a --root, defaut: MyIA.AI.Notebooks)")
+    parser.add_argument("--scope", choices=("repo", "projects"), default="repo",
+                        help="repo (defaut) : tout notebook instanciant QuantBook(), ou qu'il vive. "
+                             "projects : ancienne fenetre quant-root/*/quantbook.ipynb seulement.")
     parser.add_argument("--project", help="Single project name (under --quant-root)")
     parser.add_argument("--json", action="store_true", help="Machine-readable JSON output")
     parser.add_argument("--md", help="Write markdown report to this path")
@@ -365,8 +457,17 @@ def main(argv=None) -> int:
             print(f"error: project quantbook not found: {nb}", file=sys.stderr)
             return 2
         results = [scan_notebook(nb)]
-    else:
+    elif args.scope == "projects":
         results = scan_projects(quant_root)
+    else:
+        notebooks_root = (root / (args.notebooks_root or "MyIA.AI.Notebooks")).resolve()
+        # Un chemin FOURNI qui n'existe pas est une faute de frappe -> exit 2.
+        # Le defaut absent (arbre synthetique, checkout partiel) degrade
+        # simplement le sweep : on rend les quantbooks canoniques seuls.
+        if args.notebooks_root and not notebooks_root.exists():
+            print(f"error: notebooks root not found: {notebooks_root}", file=sys.stderr)
+            return 2
+        results = scan_repo(notebooks_root, quant_root)
 
     if args.json:
         print(json_report(results))

--- a/scripts/quantconnect/quantbooks_execution_status.md
+++ b/scripts/quantconnect/quantbooks_execution_status.md
@@ -76,6 +76,45 @@ re-exécution différée sur QC Cloud, RECOVERABLE-MACHINE).
 
 ---
 
+## Élargissement de la fenêtre : le contenu, pas le chemin (2026-07-26)
+
+La fenêtre d'analyse était `projects/*/quantbook.ipynb` — **un chemin ET un
+basename**, soit deux proxys de la vraie raison. Ce qui fait d'un notebook un
+quantbook est ce dont il a **besoin** : `QuantBook()` n'existe que dans le
+runtime research de QC Cloud, et c'est ce runtime manquant qui produit la
+pathologie #7575 (cellules code jamais exécutées). L'outil interroge donc
+désormais le **contenu** (`--scope repo`, défaut), même prédicat que
+`validate_pr_notebooks.py` et `check_cost_metadata.py` — les trois outils
+répondent la même chose à « qu'est-ce qu'un notebook QC ». `--scope projects`
+conserve l'ancienne fenêtre pour comparaison.
+
+| Mesure (2026-07-26) | `--scope projects` | `--scope repo` (défaut) |
+|---|---|---|
+| Notebooks dans la fenêtre | 46 | **93** |
+| `HEALTHY` | 28 | 59 |
+| `STOP_REPAIR_STRIPPED` | 9 | 9 |
+| `STOP_REPAIR_UNEXEC` | 9 | 9 |
+| `PREEXISTING_UNEXEC` | 0 | **16** |
+| `--check` exit | 0 | 1 |
+
+**Aucune des entrées existantes n'est reclassifiée** : les quantbooks
+canoniques sont scannés d'abord et gardent leur cross-référence `config.json`.
+Les 47 notebooks nouvellement dans la fenêtre s'ajoutent, ils ne déplacent rien.
+
+Le point saillant : **7 des 16 vivent dans `QuantConnect/projects/`**, le
+répertoire même que l'outil prétendait couvrir — ils n'étaient manqués que sur
+le basename (`Research.ipynb`, `research_robustness_output.ipynb`,
+`research_long_short_harvest.ipynb`, …). Les 9 autres : 7 dans
+`ESGF-2026/lean-workspace/*-Researcher/`, 1 dans `partner-course-quant-trading/`,
+1 dans `QuantConnect/research/`.
+
+**Ces 16 ne sont pas triés ici** — cette section les rend visibles, elle ne
+prononce aucun verdict de re-exécution. Le triage (RECOVERABLE-MACHINE via QC
+Cloud vs INTRINSIC vs archivage) reste suivi par **#7575**. L'outil n'est câblé
+dans aucun workflow CI : l'élargissement ne peut donc pas rendre la CI rouge.
+
+---
+
 ## Snapshot historique DEPRECATED (2026-05-04 → 2026-07-20)
 
 > **Historique préservé tel quel pour mémoire uniquement**, **PAS comme source

--- a/scripts/quantconnect/tests/test_audit_quantbooks_unexec.py
+++ b/scripts/quantconnect/tests/test_audit_quantbooks_unexec.py
@@ -336,3 +336,131 @@ class TestIntegration6891:
         assert by_name["Stripped"]["config"]["status"] == "ALIVE"
         assert by_name["DeadCloud"]["config"]["status"] == "DEAD"
         assert by_name["Preexisting"]["config"]["status"] == "DEAD"
+
+
+# -- _uses_quantbook (fenetre par CONTENU, #7575 / #8598) --
+
+class TestUsesQuantbook:
+    def test_code_cell_instantiating_quantbook(self):
+        nb = _nb([_cell("code", "qb = QuantBook()")])
+        assert aqm._uses_quantbook(nb) is True
+
+    def test_self_quantbook_attribute(self):
+        nb = _nb([_cell("code", "history = self.QuantBook.History(spy, 10)")])
+        assert aqm._uses_quantbook(nb) is True
+
+    def test_source_as_list_of_lines(self):
+        nb = _nb([_cell("code", ["import x\n", "qb = QuantBook()\n"])])
+        assert aqm._uses_quantbook(nb) is True
+
+    def test_markdown_mention_only_is_not_a_quantbook(self):
+        # Un tutoriel qui PARLE de QuantBook n'a pas besoin du runtime QC Cloud.
+        nb = _nb([_cell("markdown", "On utilise `QuantBook()` pour la recherche.")])
+        assert aqm._uses_quantbook(nb) is False
+
+    def test_no_mention_at_all(self):
+        nb = _nb([_cell("code", "import pandas as pd")])
+        assert aqm._uses_quantbook(nb) is False
+
+
+# -- scan_repo : sur-ensemble strict de scan_projects --
+
+def _write_nb(path: Path, cells, kernel="python3") -> Path:
+    """Write an arbitrary notebook at ``path`` (parents created)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(_nb(cells, kernel=kernel), ensure_ascii=False),
+                    encoding="utf-8")
+    return path
+
+
+class TestScanRepo:
+    """La fenetre est le CONTENU (``QuantBook()``), pas le chemin ni le basename."""
+
+    @staticmethod
+    def _tree(tmp_path):
+        nb_root = tmp_path / "MyIA.AI.Notebooks"
+        quant_root = nb_root / "QuantConnect" / "projects"
+        # Canonique : dans la fenetre d'origine, avec config.json.
+        _write_project(quant_root, "Canonical", [
+            _cell("code", "qb = QuantBook()", execution_count=1,
+                  outputs=[{"output_type": "stream", "name": "stdout", "text": "ok"}]),
+        ], config={"cloud-id": 12345})
+        # Hors fenetre d'origine (ni le dossier, ni le basename) mais VRAI quantbook.
+        _write_nb(nb_root / "QuantConnect" / "research" / "research.ipynb", [
+            _cell("code", "qb = QuantBook()", execution_count=None, outputs=[]),
+        ])
+        # Meme dossier canonique, autre basename -- la seconde moitie du proxy.
+        _write_nb(quant_root / "Canonical" / "research.ipynb", [
+            _cell("code", "qb = QuantBook()", execution_count=None, outputs=[]),
+        ])
+        # Bruit : ne doit PAS entrer dans la fenetre.
+        _write_nb(nb_root / "Search" / "tutorial.ipynb",
+                  [_cell("markdown", "`QuantBook()` sert a la recherche.")])
+        _write_nb(nb_root / "ML" / "plain.ipynb",
+                  [_cell("code", "import pandas", execution_count=None, outputs=[])])
+        _write_nb(nb_root / "Foo" / ".ipynb_checkpoints" / "x.ipynb",
+                  [_cell("code", "qb = QuantBook()", execution_count=None, outputs=[])])
+        (nb_root / "Bad").mkdir(parents=True, exist_ok=True)
+        (nb_root / "Bad" / "broken.ipynb").write_text("{not json", encoding="utf-8")
+        return nb_root, quant_root
+
+    def _paths(self, results, nb_root):
+        return {Path(r["path"]).relative_to(nb_root).as_posix() for r in results}
+
+    def test_catches_quantbooks_outside_the_path_window(self, tmp_path):
+        nb_root, quant_root = self._tree(tmp_path)
+        got = self._paths(aqm.scan_repo(nb_root, quant_root), nb_root)
+        assert "QuantConnect/research/research.ipynb" in got
+        assert "QuantConnect/projects/Canonical/research.ipynb" in got
+
+    def test_ignores_non_quantbooks_checkpoints_and_unreadable(self, tmp_path):
+        nb_root, quant_root = self._tree(tmp_path)
+        got = self._paths(aqm.scan_repo(nb_root, quant_root), nb_root)
+        assert "Search/tutorial.ipynb" not in got   # markdown-only mention
+        assert "ML/plain.ipynb" not in got          # aucune mention
+        assert "Foo/.ipynb_checkpoints/x.ipynb" not in got
+        assert "Bad/broken.ipynb" not in got        # JSON invalide : pas de crash
+
+    def test_is_a_strict_superset_that_reclassifies_nothing(self, tmp_path):
+        nb_root, quant_root = self._tree(tmp_path)
+        old = {r["path"]: r for r in aqm.scan_projects(quant_root)}
+        new = {r["path"]: r for r in aqm.scan_repo(nb_root, quant_root)}
+        assert set(old) <= set(new)
+        for path, before in old.items():
+            assert new[path]["classification"] == before["classification"]
+
+    def test_canonical_entries_keep_their_config_cross_reference(self, tmp_path):
+        nb_root, quant_root = self._tree(tmp_path)
+        new = {Path(r["path"]).as_posix(): r for r in aqm.scan_repo(nb_root, quant_root)}
+        canonical = next(v for k, v in new.items() if k.endswith("Canonical/quantbook.ipynb"))
+        assert canonical["config"]["status"] == "ALIVE"
+
+    def test_no_duplicate_entries(self, tmp_path):
+        nb_root, quant_root = self._tree(tmp_path)
+        results = aqm.scan_repo(nb_root, quant_root)
+        paths = [r["path"] for r in results]
+        assert len(paths) == len(set(paths))
+
+    def test_missing_notebooks_root_yields_canonical_only(self, tmp_path):
+        """Rien a elargir n'est pas une erreur -- main() garde l'exit 2 explicite."""
+        _, quant_root = self._tree(tmp_path)
+        results = aqm.scan_repo(tmp_path / "nope", quant_root)
+        assert [r["path"] for r in results] == [r["path"] for r in aqm.scan_projects(quant_root)]
+
+
+class TestMainScope:
+    def test_default_scope_is_wider_than_projects(self, tmp_path, capsys):
+        nb_root, quant_root = TestScanRepo._tree(tmp_path)
+        rc = aqm.main(["--root", str(tmp_path), "--json"])
+        assert rc == 0
+        wide = json.loads(capsys.readouterr().out)["scanned"]
+        rc = aqm.main(["--root", str(tmp_path), "--scope", "projects", "--json"])
+        assert rc == 0
+        narrow = json.loads(capsys.readouterr().out)["scanned"]
+        assert wide > narrow
+
+    def test_explicit_missing_notebooks_root_exits_2(self, tmp_path):
+        self_tree = TestScanRepo._tree(tmp_path)
+        assert self_tree  # fixture built
+        rc = aqm.main(["--root", str(tmp_path), "--notebooks-root", "nope"])
+        assert rc == 2


### PR DESCRIPTION
Grain: MED/qc — lane myia-ai-01:CoursIA — prev: MED/tooling-infra

## Le défaut : la fenêtre s'ancrait sur un proxy de sa raison

`audit_quantbooks_unexec.py` nomme lui-même la pathologie qu'il traque — *« cellules code jamais exécutées faute du runtime research QC Cloud »* — puis la cherche dans `quant_root.glob("*/quantbook.ipynb")` : **un chemin ET un basename**. Deux proxys, zéro lien avec la raison. Ce qui fait d'un notebook un quantbook est ce dont il a **besoin** : `QuantBook()` n'existe que dans ce runtime.

C'est la même classe de défaut que le carve-out H.3 corrigé par #8598 — un test qui interroge l'emplacement plutôt que la propriété qu'il prétend mesurer.

## Ce que la fenêtre étroite cachait

| Mesure (2026-07-26) | `--scope projects` (ancienne) | `--scope repo` (défaut) |
|---|---|---|
| Notebooks dans la fenêtre | 46 | **93** |
| `HEALTHY` | 28 | 59 |
| `STOP_REPAIR_STRIPPED` | 9 | 9 |
| `STOP_REPAIR_UNEXEC` | 9 | 9 |
| `PREEXISTING_UNEXEC` | 0 | **16** |
| `--check` exit | 0 | **1** |

**Le point saillant : 7 des 16 vivent dans `QuantConnect/projects/`** — le répertoire même que l'outil prétendait couvrir. Ils n'étaient manqués que sur le basename : `Research.ipynb` (majuscule), `research_robustness_output.ipynb`, `research_long_short_harvest.ipynb`, `research_macro_factor_rotation.ipynb`, `research_defensive_etf_rotation.ipynb`, et les `research.ipynb` de `ML-HeadShoulders-CNN` / `Multi-Layer-EMA`. Les 9 autres : 7 dans `ESGF-2026/lean-workspace/*-Researcher/`, 1 dans `partner-course-quant-trading/`, 1 dans `QuantConnect/research/`.

Conséquence de lecture : le `HEALTHY (28)` publié se lisait comme un état de santé global alors qu'il ne couvrait qu'un répertoire, et qu'un tiers du vrai périmètre est en défaut.

## Correction de ce que j'avais annoncé sur #7575

J'avais publié comme critère de sortie : *« le tableau passe de 9 à 18 sans reclassifier aucune des 9 existantes, et `--check` exit 1 sur les nouvelles »*.

Deux critères sur trois sont tenus exactement (**0 reclassification**, **`--check` exit 1**). **Le compte, non** : la mesure réelle est **16** `PREEXISTING_UNEXEC` sur **47** notebooks nouvellement dans la fenêtre, pas 9 de plus. Mon estimation excluait `QuantConnect/projects/` en bloc pour éviter un double comptage — c'est précisément ce qui m'avait fait rater les 7 blind spots situés *à l'intérieur* du répertoire couvert. Je publie le chiffre mesuré, pas celui que j'avais promis.

## Non-régression

- **Aucune entrée existante n'est reclassifiée.** Les quantbooks canoniques sont scannés **en premier** (ils gardent leur cross-référence `config.json`), puis l'arbre est balayé par contenu avec un `seen` set : un notebook déjà vu n'est jamais rescanné. Vérifié par diff des classifications ancienne fenêtre → nouvelle : `NONE`.
- **`--scope projects`** conserve l'ancienne fenêtre à l'identique pour comparaison.
- **Aucun câblage CI** : `grep -rn audit_quantbooks_unexec --include=*.yml --include=*.yaml` ne retourne aucun workflow (seulement des références en documentation). L'élargissement **ne peut pas** rendre la CI rouge.
- **Les 16 ne sont pas triées ici.** Cette PR les rend visibles ; elle ne prononce aucun verdict de re-exécution. Le triage (RECOVERABLE-MACHINE via QC Cloud / INTRINSIC / archivage) reste suivi par #7575.

## Tests

`47 passed` — **les 34 existants sont inchangés** (le contrat de l'outil n'a pas été assoupli pour faire passer le changement) + 13 nouveaux :

- `_uses_quantbook` : `QuantBook()`, `self.QuantBook`, `source` en liste de lignes → dans la fenêtre ; **mention markdown seule → hors fenêtre** (un tutoriel qui *parle* de QuantBook n'a pas besoin du runtime).
- `scan_repo` : attrape hors répertoire **et** hors basename ; ignore `.ipynb_checkpoints` et le JSON invalide sans crasher ; sur-ensemble strict ; **reclassifie zéro entrée** ; pas de doublon ; `config.json` préservé sur les canoniques.
- `main` : `--scope repo` strictement plus large que `--scope projects` ; `--notebooks-root` **explicite** introuvable → exit 2 (faute de frappe), défaut absent → dégrade au scan canonique.

```
$ python -m pytest scripts/quantconnect/tests/test_audit_quantbooks_unexec.py -q
47 passed in 0.65s
```

## Reproduire

```bash
python scripts/quantconnect/audit_quantbooks_unexec.py --json            # 93
python scripts/quantconnect/audit_quantbooks_unexec.py --json --scope projects  # 46
python scripts/quantconnect/audit_quantbooks_unexec.py --check ; echo $?  # 1
```

See #7575, #8598.
