### PR TITLE
fix(cost-metadata,#8056): resolve free_alternative broken basenames in 20 GenAI notebooks

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/12_Test_Time_Scaling.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/12_Test_Time_Scaling.ipynb
@@ -1739,7 +1739,7 @@
    "vram_tier": "LITE",
    "network": true,
    "external_account": "openrouter",
-   "free_alternative": "10_LocalLlama.ipynb",
+   "free_alternative": "MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb",
    "reduced_pedagogical": null,
    "reproducibility": "MED",
    "last_validated": "2026-07-23",

--- a/MyIA.AI.Notebooks/GenAI/Texte/13_Agentic_Orchestration.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/13_Agentic_Orchestration.ipynb
@@ -1235,7 +1235,7 @@
    "vram_tier": "LITE",
    "network": true,
    "external_account": "openrouter",
-   "free_alternative": "10_LocalLlama.ipynb",
+   "free_alternative": "MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb",
    "reduced_pedagogical": null,
    "reproducibility": "MED",
    "last_validated": "2026-07-23",

--- a/MyIA.AI.Notebooks/GenAI/Texte/14_Persistent_Memory.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/14_Persistent_Memory.ipynb
@@ -1109,7 +1109,7 @@
    "vram_tier": "LITE",
    "network": true,
    "external_account": "openrouter",
-   "free_alternative": "10_LocalLlama.ipynb",
+   "free_alternative": "MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb",
    "reduced_pedagogical": null,
    "reproducibility": "MED",
    "last_validated": "2026-07-23",

--- a/MyIA.AI.Notebooks/GenAI/Texte/15_Tree_of_Thoughts_Search.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/15_Tree_of_Thoughts_Search.ipynb
@@ -959,7 +959,7 @@
    "vram_tier": "LITE",
    "network": true,
    "external_account": "openrouter",
-   "free_alternative": "10_LocalLlama.ipynb",
+   "free_alternative": "MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb",
    "reduced_pedagogical": null,
    "reproducibility": "MED",
    "last_validated": "2026-07-23",

--- a/MyIA.AI.Notebooks/GenAI/Texte/16_Scaling_Test_Time_Compute.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/16_Scaling_Test_Time_Compute.ipynb
@@ -964,7 +964,7 @@
    "vram_tier": "LITE",
    "network": true,
    "external_account": "openrouter",
-   "free_alternative": "10_LocalLlama.ipynb",
+   "free_alternative": "MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb",
    "reduced_pedagogical": null,
    "reproducibility": "MED",
    "last_validated": "2026-07-23",

--- a/MyIA.AI.Notebooks/GenAI/Texte/17_Native_Reasoning_vs_Scaling.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/17_Native_Reasoning_vs_Scaling.ipynb
@@ -977,7 +977,7 @@
    "vram_tier": "LITE",
    "network": true,
    "external_account": "openrouter",
-   "free_alternative": "10_LocalLlama.ipynb",
+   "free_alternative": "MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb",
    "reduced_pedagogical": null,
    "reproducibility": "MED",
    "last_validated": "2026-07-23",

--- a/MyIA.AI.Notebooks/GenAI/Texte/18_Semantic_Kernel_Plugins.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/18_Semantic_Kernel_Plugins.ipynb
@@ -905,7 +905,7 @@
    "vram_tier": "LITE",
    "network": true,
    "external_account": "openrouter",
-   "free_alternative": "10_LocalLlama.ipynb",
+   "free_alternative": "MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb",
    "reduced_pedagogical": null,
    "reproducibility": "MED",
    "last_validated": "2026-07-23",

--- a/MyIA.AI.Notebooks/GenAI/Texte/19_OWUI_Orchestration.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/19_OWUI_Orchestration.ipynb
@@ -994,7 +994,7 @@
    "vram_tier": "LITE",
    "network": true,
    "external_account": "owui",
-   "free_alternative": "10_LocalLlama.ipynb",
+   "free_alternative": "MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb",
    "reduced_pedagogical": null,
    "reproducibility": "MED",
    "last_validated": "2026-07-23",

--- a/MyIA.AI.Notebooks/GenAI/Texte/1_OpenAI_Intro.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/1_OpenAI_Intro.ipynb
@@ -1629,7 +1629,7 @@
    "vram_tier": "LITE",
    "network": true,
    "external_account": "openai",
-   "free_alternative": "10_LocalLlama.ipynb",
+   "free_alternative": "MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb",
    "reduced_pedagogical": null,
    "reproducibility": "MED",
    "last_validated": "2026-07-23",

--- a/MyIA.AI.Notebooks/GenAI/Texte/20_OWUI_Native_API.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/20_OWUI_Native_API.ipynb
@@ -669,7 +669,7 @@
    "vram_tier": "LITE",
    "network": true,
    "external_account": "owui",
-   "free_alternative": "10_LocalLlama.ipynb",
+   "free_alternative": "MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb",
    "reduced_pedagogical": null,
    "reproducibility": "MED",
    "last_validated": "2026-07-23",

--- a/MyIA.AI.Notebooks/GenAI/Texte/2_PromptEngineering.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/2_PromptEngineering.ipynb
@@ -2916,7 +2916,7 @@
    "vram_tier": "LITE",
    "network": true,
    "external_account": "openai",
-   "free_alternative": "10_LocalLlama.ipynb",
+   "free_alternative": "MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb",
    "reduced_pedagogical": null,
    "reproducibility": "MED",
    "last_validated": "2026-07-23",

--- a/MyIA.AI.Notebooks/GenAI/Texte/3_Structured_Outputs.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/3_Structured_Outputs.ipynb
@@ -1988,7 +1988,7 @@
    "vram_tier": "LITE",
    "network": true,
    "external_account": "openai",
-   "free_alternative": "10_LocalLlama.ipynb",
+   "free_alternative": "MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb",
    "reduced_pedagogical": null,
    "reproducibility": "MED",
    "last_validated": "2026-07-23",

--- a/MyIA.AI.Notebooks/GenAI/Texte/4_Function_Calling.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/4_Function_Calling.ipynb
@@ -2697,7 +2697,7 @@
    "vram_tier": "LITE",
    "network": true,
    "external_account": "openai",
-   "free_alternative": "10_LocalLlama.ipynb",
+   "free_alternative": "MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb",
    "reduced_pedagogical": null,
    "reproducibility": "MED",
    "last_validated": "2026-07-23",

--- a/MyIA.AI.Notebooks/GenAI/Texte/5_RAG_Modern.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/5_RAG_Modern.ipynb
@@ -3237,7 +3237,7 @@
    "vram_tier": "LITE",
    "network": true,
    "external_account": "openai",
-   "free_alternative": "10_LocalLlama.ipynb",
+   "free_alternative": "MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb",
    "reduced_pedagogical": null,
    "reproducibility": "MED",
    "last_validated": "2026-07-23",

--- a/MyIA.AI.Notebooks/GenAI/Texte/6_PDF_Web_Search.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/6_PDF_Web_Search.ipynb
@@ -1686,7 +1686,7 @@
    "vram_tier": "LITE",
    "network": true,
    "external_account": "openai",
-   "free_alternative": "10_LocalLlama.ipynb",
+   "free_alternative": "MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb",
    "reduced_pedagogical": null,
    "reproducibility": "MED",
    "last_validated": "2026-07-23",

--- a/MyIA.AI.Notebooks/GenAI/Texte/7_Code_Interpreter.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/7_Code_Interpreter.ipynb
@@ -2152,7 +2152,7 @@
    "vram_tier": "LITE",
    "network": true,
    "external_account": "openai",
-   "free_alternative": "10_LocalLlama.ipynb",
+   "free_alternative": "MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb",
    "reduced_pedagogical": null,
    "reproducibility": "MED",
    "last_validated": "2026-07-23",

--- a/MyIA.AI.Notebooks/GenAI/Texte/8_Reasoning_Models.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/8_Reasoning_Models.ipynb
@@ -2297,7 +2297,7 @@
    "vram_tier": "LITE",
    "network": true,
    "external_account": "openai",
-   "free_alternative": "10_LocalLlama.ipynb",
+   "free_alternative": "MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb",
    "reduced_pedagogical": null,
    "reproducibility": "MED",
    "last_validated": "2026-07-23",

--- a/MyIA.AI.Notebooks/GenAI/Texte/9_Production_Patterns.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/9_Production_Patterns.ipynb
@@ -2665,7 +2665,7 @@
    "vram_tier": "LITE",
    "network": true,
    "external_account": "openai",
-   "free_alternative": "10_LocalLlama.ipynb",
+   "free_alternative": "MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb",
    "reduced_pedagogical": null,
    "reproducibility": "MED",
    "last_validated": "2026-07-23",

--- a/MyIA.AI.Notebooks/GenAI/Video/04-Applications/04-3-Sora-API-Cloud-Video.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/04-Applications/04-3-Sora-API-Cloud-Video.ipynb
@@ -1888,7 +1888,7 @@
    "vram_tier": "NONE",
    "network": true,
    "external_account": "openai",
-   "free_alternative": "04-4-Production-Video-Pipeline.ipynb",
+   "free_alternative": "MyIA.AI.Notebooks/GenAI/Video/04-Applications/04-4-Production-Video-Pipeline.ipynb",
    "reduced_pedagogical": null,
    "reproducibility": "MED",
    "last_validated": "2026-07-24",

--- a/MyIA.AI.Notebooks/GenAI/Video/04-Applications/04-4-Production-Video-Pipeline.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/04-Applications/04-4-Production-Video-Pipeline.ipynb
@@ -1845,7 +1845,7 @@
    "vram_tier": "HIGH",
    "network": true,
    "external_account": "openai",
-   "free_alternative": "04-2-Creative-Video-Workflows.ipynb",
+   "free_alternative": "MyIA.AI.Notebooks/GenAI/Video/04-Applications/04-2-Creative-Video-Workflows.ipynb",
    "reduced_pedagogical": null,
    "reproducibility": "MED",
    "last_validated": "2026-07-24",


### PR DESCRIPTION
Grain: LIGHT/cost-metadata (rotation vs c.923 MED/notebook). Fixes 20 `cost.free_alternative` paths flagged MAJOR by litmus-4 (`free_alternative_missing`), found by fleet-wide cost-metadata audit (po-2024 c.903) routed to po-2023 (GenAI family owner), verified firsthand.

## The defect

20 GenAI notebooks had `cost.free_alternative` set to a **bare basename** that the litmus-4 dual-base check (repo-root OU `MyIA.AI.Notebooks/`) cannot resolve — the targets live one or two levels deeper, so the parser reported `free_alternative pointe vers X mais fichier absent` (MAJOR). The targets all exist; only the path was ambiguous.

| family | count | bare basename | real location |
|--------|-------|---------------|---------------|
| GenAI/Texte | 18 | `10_LocalLlama.ipynb` | `MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb` |
| GenAI/Video/04-Applications | 1 | `04-4-Production-Video-Pipeline.ipynb` (from `04-3-Sora-API-Cloud-Video`) | `…/GenAI/Video/04-Applications/04-4-Production-Video-Pipeline.ipynb` |
| GenAI/Video/04-Applications | 1 | `04-2-Creative-Video-Workflows.ipynb` (from `04-4-Production-Video-Pipeline`) | `…/GenAI/Video/04-Applications/04-2-Creative-Video-Workflows.ipynb` |

## The fix

Bare basename → **full repo-relative path** (canonical convention per `docs/notebook-metadata/cost-matrix.md` line 113 example, which uses `"MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-3-Basic-Image-Operations.ipynb"`).

**Sémantique inchangée** — the free-alternative target stays the same notebook (LocalLlama for the API-paid Texte notebooks = the local-LLM demo; Video pipeline notebooks point to each other). This is a **data-quality path fix**, not a design decision — whoever populated the metadata chose the targets; I only made the path resolvable.

## Validation (H.3)

- **Litmus-4 re-run on GenAI after fix = 0 residual finding** (was 20 MAJOR).
- **20/20 nbformat VALID**; **0 CRLF**; byte-stable per-notebook (`json.dumps(indent=1, ensure_ascii=False)` round-trip asserted PRE/POST).
- **Catalogue byte-identical** to main (only `metadata.cost.free_alternative` touched — 1 field/notebook, no cell source changed).
- **leak-scan NONE** (no token/path/IP in the 20 added lines).
- 20 files, +20/−20 (1 line/notebook, surgical).

## Scope discipline

- Single subject: `free_alternative` broken paths in GenAI. Homogeneous, mechanical, deterministic (same fix × 20) — the G.4 threshold is lifted for scripted/deterministic transformations per the cost-migration decision (cf #8056), and this is smaller still (metadata-only, no schema change, no re-exec).
- Did **not** touch the 17 GenAI notebooks that are not in canonical `json.dumps(indent=1)` form (the script conservatively skipped non-byte-stable PRE files to avoid churn) — those are out of scope (separate normalization concern).
- Did **not** re-judge the semantic target (LocalLlama as the free alternative for each Texte notebook is the populator's decision; my role is the path fix).

See #8056 (cost-matrix epic), #8376 (schema). Not `Closes` — partial data-quality contribution to the epic.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
