### PR TITLE
fix(sudoku,#8485): restore polyglot kernelName on the 5 cells that break #!import

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-0-Environment-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-0-Environment-Csharp.ipynb
@@ -773,7 +773,13 @@
      "start_time": "2026-05-02T18:17:16.664706+00:00",
      "status": "completed"
     },
-    "tags": []
+    "tags": [],
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    }
    },
    "outputs": [
     {

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Csharp.ipynb
@@ -599,7 +599,14 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    }
+   },
    "outputs": [
     {
      "output_type": "stream",
@@ -881,7 +888,14 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    }
+   },
    "outputs": [
     {
      "output_type": "stream",
@@ -935,7 +949,13 @@
      "start_time": "2026-05-02T18:17:42.738745+00:00",
      "status": "completed"
     },
-    "tags": []
+    "tags": [],
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    }
    },
    "outputs": [
     {
@@ -1027,7 +1047,14 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    }
+   },
    "outputs": [
     {
      "output_type": "stream",


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-ai-01:CoursIA — prev: MED/harness-rules (#8481)

See #8485 (le blocage de re-exec de Sudoku-15 dont ceci est la cause racine). Pas de `Closes` : #8485 demande la ré-exécution du notebook, que cette PR **rend possible** sans la livrer.

## Ce que je cherchais, et ce que j'ai trouvé à la place

#8525 est bloquée depuis le 25/07 : impossible de ré-exécuter `Sudoku-15-Infer-Csharp.ipynb`, sa cellule `#!import` échoue. J'avais conclu au cycle 14, auprès de po-2025, que c'était une affaire de **version de kernel** (« downgrade en 1.0.617701 et `#!import` passe »). **Cette conclusion était fausse** : je l'avais éprouvée sur un notebook-jouet important un helper, pas sur le vrai notebook. Sur ai-01, en 617701, `Sudoku-15` échoue exactement comme chez po-2025.

La trace complète (run `allow_errors=True`) nomme la vraie cause :

```
System.ArgumentNullException: Value cannot be null. (Parameter 'key')
  at System.Collections.Generic.Dictionary`2.FindValue(TKey key)
  at System.Collections.Generic.Dictionary`2.TryGetValue(TKey key, TValue& value)
  at Microsoft.DotNet.Interactive.KernelExtensions.LoadAndRunInteractiveDocument(...)
  at Microsoft.DotNet.Interactive.KernelExtensions.<UseImportMagicCommand>b__0(...)
```

`#!import` ne se contente pas de lire le notebook cible : il **rejoue chaque cellule en la dispatchant au sous-kernel désigné par son nom de langage**. Une cellule code sans `polyglot_notebook.kernelName` ni `dotnet_interactive.language` présente une clé `null` au dictionnaire des kernels — et `Dictionary.TryGetValue(null)` lève. La version du kernel n'y est pour rien : c'est l'artefact qui est mal formé.

Le symptôme collait déjà : l'import imprimait `SudokuGrid defini. / ISudokuSolver defini. / SudokuHelper defini.` — les cellules 1, 3, 6, 9 — puis mourait. La cellule 12 est la suivante.

## Périmètre : exhaustif, pas échantillonné

Le dépôt compte **211** notebooks .NET portant au moins une cellule code sans métadonnée de langage. Je n'en corrige **pas** 211 : sur un notebook exécuté directement, le kernelspec du document sert de défaut et le défaut reste latent. Il ne devient fatal que lorsque le notebook est **importé**.

Or le dépôt entier ne contient que **deux** cibles de `#!import` — et les deux étaient cassées :

| cible | cellules sans métadonnée | importée par |
|---|---|---|
| `Sudoku-0-Environment-Csharp.ipynb` | 1 (cellule 12, « EXERCICE : Validation d'une grille ») | **12 notebooks** (Sudoku-1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 15) |
| `Sudoku-1-Backtracking-Csharp.ipynb` | 4 (cellules 9, 13, 15, 17) | Sudoku-1 étant lui-même cible |

C'est le jeu **complet** des occurrences vivantes du défaut, pas une tranche. Les 5 cellules concernées sont toutes des cellules « EXERCICE » ou « Exemple guidé » — insérées par de l'outillage d'enrichissement qui écrivait le JSON sans la métadonnée polyglot. `Sudoku-0` porte la sienne depuis `9a01bdeb6` (16/03) : le défaut est latent depuis quatre mois.

## Preuve de causalité (avant / après, même kernel, même méthode)

**Avant** (contenu `origin/main`, kernel `.net-csharp`, `NotebookClient`) :
```
cell #!import Sudoku-0-Environment-Csharp.ipynb -> CellExecutionError
  stdout: SudokuGrid defini. / ISudokuSolver defini. / SudokuHelper defini.
  ArgumentNullException (Parameter 'key')
```

**Après** (cette branche, sonde `#!import` dédiée) :
```
Sudoku-0 : cell[0] ec=1 err=0
  SudokuGrid defini. / ISudokuSolver defini. / SudokuHelper defini. / Exercice a completer

Sudoku-1 : cell[0] ec=1 err=0     (importe transitivement Sudoku-0)
  ... BacktrackingDotNetSolver: 122 search calls
  ... BacktrackingDotNetSolver: 490304 search calls
  ... BacktrackingDotNetSolver: 12625368 search calls
  ... TODO: Implementez BacktrackingMRVSolve
```

L'import traverse désormais l'intégralité des deux notebooks, benchmark de backtracking réel compris.

## Discipline de diff

Métadonnée **seule**. Vérification cellule par cellule contre `origin/main`, en ignorant les deux clés ajoutées :

```
Sudoku-0-Environment-Csharp.ipynb   cells=14 | deltas hors metadata-langage : AUCUN | nb.metadata identique : True
Sudoku-1-Backtracking-Csharp.ipynb  cells=19 | deltas hors metadata-langage : AUCUN | nb.metadata identique : True
```

Aucune source, aucun output, aucun `execution_count`, aucune autre métadonnée ne bouge. **Pas de ré-exécution committée** — donc pas de churn papermill, et la règle C.2 est satisfaite par exception (changement non-source). Les `execution_count` incohérents de `Sudoku-1` (1, 2, 3, **1**, 4, **1**, 5, **1**) sont **préexistants**, du même outillage ; les corriger exigerait une ré-exécution, qui est un autre sujet.

## Ce que ça débloque

Les 12 notebooks Sudoku C# peuvent à nouveau être importés et donc ré-exécutés. #8525 / #8485 en particulier : le blocage n'était ni une version de kernel, ni un environnement — c'était une clé nulle dans un dictionnaire, réparable en sept lignes.

**Verdict SOTA : RECOVERABLE-LOCAL** — conclusion inchangée par rapport au cycle 14, mécanisme entièrement différent. Je maintiens la correction publiquement sur #8525.
