### PR TITLE
feat(gradebook,#8606): forcer le gate fuzzy-match sous seuil (journal pseudonymise + sortie non-zero)

### DIFF
--- a/GradeBookApp/PRIVACY.md
+++ b/GradeBookApp/PRIVACY.md
@@ -81,22 +81,38 @@ utilise une **correspondance floue** (`rapidfuzz`). Deux seuils sont en vigueur 
 **Règles de gouvernance (politique, à respecter par l'enseignant) :**
 
 1. **Au-dessus du seuil** : correspondance acceptée automatiquement.
-2. **Sous le seuil mais au-dessus d'une marge d'ambiguïté** (ex. 80–90 %) :
-   **validation humaine obligatoire**. Le moteur émet un avertissement (`AVERTISSEMENT` dans
-   les logs) mais **ne bloque pas** l'exécution : l'enseignant doit inspecter les
-   correspondances ambiguës avant de considérer le rapport comme final.
-3. **Journalisation** : les correspondances ambiguës (sous le seuil) doivent être
-   consignées (manuellement, hors données nominatives — ex. « correspondance ambiguë pour le
-   groupe G3 ») pour audit.
+2. **Dans la bande d'ambiguïté** — score dans `[seuil - AMBIGUITY_MARGIN, seuil[`,
+   soit 80–90 % aux valeurs par défaut : **validation humaine obligatoire**. Le
+   rapprochement n'est **pas** crédité, il est consigné, et le run est déclaré
+   **non final** tant que l'enseignant n'a pas arbitré.
+3. **Journalisation** : les rapprochements de cette bande sont écrits automatiquement
+   dans un journal structuré JSON (`ambiguites_rapprochement.json` par défaut),
+   **sans donnée nominative** — condensé SHA-256 tronqué des deux libellés comparés,
+   score, seuil et marge applicables (cf §5).
 4. **Procédure en cas de confusion entre deux étudiants** : ni l'un ni l'autre n'est
    crédité automatiquement ; l'enseignant tranche, et l'incident est tracé.
 
-> **État d'implémentation (honnête).** Les seuils existent et sont applicables
-> (`gradebook.py` : `SIMILARITY_THRESHOLD`, `group_match_threshold`, `fuzzy_match_group`).
-> En revanche, la **validation humaine sous seuil n'est pas encore forcée par le code**
-> (le moteur affiche un avertissement, puis continue). Cette notice formalise donc la
-> politique attendue ; l'enforcement strict (blocage + journal structuré) est un axe
-> d'amélioration suivi séparément.
+> **État d'implémentation.** L'enforcement est en place (issue #8606).
+>
+> | Mécanisme | Emplacement |
+> |---|---|
+> | Bande d'ambiguïté nommée et configurable | `gradebook.py` : `AMBIGUITY_MARGIN` (défaut `10`) |
+> | Journal structuré pseudonymisé | `gradebook.py` : `AmbiguityJournal`, actif par défaut |
+> | Gate de sortie | `run_grading.py` : code de retour `2` (`EXIT_AMBIGUITIES_PENDING`) tant que des ambiguïtés subsistent ; `--allow-ambiguous` requis pour produire le rapport malgré tout |
+> | Couverture de test | `test_fuzzy_match_group.py` (dont la confusion entre deux patronymes proches, règle 4) |
+>
+> **Décision de conception.** Le gate ne change **aucune décision de rapprochement** :
+> un score sous le seuil reste un refus. Ce qui change est que le run en porte la trace
+> et ne peut plus produire un rapport présenté comme final sans arbitrage — un
+> avertissement dans les logs pouvait n'être jamais lu.
+>
+> **Défaut corrigé au passage.** Le cas d'inclusion simple (`fuzzy_match_group`, Cas 4)
+> court-circuitait le seuil : un libellé inclus dans un autre était accepté même à
+> `threshold=100`. Sur des patronymes proches (`… - dupont` inclus dans `… - dupontt`),
+> l'un des deux étudiants était donc crédité automatiquement, en violation de la règle 4
+> ci-dessus. L'inclusion exige désormais que le reliquat commence sur une frontière de
+> token (séparateur), ce qui préserve le cas visé (« projet alpha » ⊂ « projet alpha -
+> groupe 3 ») et ferme la confusion de noms.
 
 ## 7. Conservation et suppression en fin de semestre
 

--- a/GradeBookApp/gradebook.py
+++ b/GradeBookApp/gradebook.py
@@ -1,5 +1,7 @@
 import pandas as pd
 import numpy as np
+import hashlib
+import json
 import os
 import glob
 import re
@@ -15,6 +17,100 @@ professor_email = "jsboige@gmail.com"
 PROFESSOR_FULL_NAME = "Jean-Sylvain Boige"
 SIMILARITY_THRESHOLD = 80 # Seuil pour le fuzzy matching
 TEACHER_WEIGHT = 1.0 # Poids de la note du professeur. 1.0 = 50% du total.
+
+# Largeur de la bande d'ambiguïté sous le seuil de rapprochement (PRIVACY.md §6).
+# Un score dans [threshold - AMBIGUITY_MARGIN, threshold[ n'est ni accepté ni
+# rejeté : le rapprochement n'est pas crédité automatiquement (règle 4 de §6),
+# et le run est marqué non-final tant que l'enseignant n'a pas arbitré.
+AMBIGUITY_MARGIN = 10
+
+# --- Journalisation des rapprochements ambigus ---
+
+
+def _pseudonymize(value):
+    """Identifiant stable et non réversible pour le journal d'ambiguïtés.
+
+    PRIVACY.md §5 interdit la PII nominative hors du périmètre de traitement :
+    le journal d'audit ne porte donc que ce condensé, jamais le libellé source.
+    Stable d'un run à l'autre (pas de sel aléatoire) pour que l'enseignant
+    puisse rapprocher deux exécutions successives.
+    """
+    normalized = re.sub(r'\s+', ' ', str(value).lower().strip())
+    return hashlib.sha256(normalized.encode('utf-8')).hexdigest()[:12]
+
+
+class AmbiguityJournal:
+    """Consigne les rapprochements tombant dans la bande d'ambiguïté.
+
+    Sert le gate de PRIVACY.md §6 : le moteur ne se contente plus d'un
+    avertissement dans les logs (que l'enseignant peut ne jamais lire), il
+    retient chaque cas litigieux pour que le run puisse être déclaré non-final.
+
+    N'enregistre **aucune donnée nominative** : seulement les condensés des deux
+    libellés comparés, le score obtenu et le seuil applicable.
+    """
+
+    def __init__(self, margin=AMBIGUITY_MARGIN):
+        self.margin = margin
+        self.entries = []
+
+    def record(self, eval_group_name, student_project_string, score, threshold):
+        """Enregistre un rapprochement litigieux. Retourne True s'il a été retenu."""
+        if not (threshold - self.margin <= score < threshold):
+            return False
+        self.entries.append({
+            "groupe_evalue": _pseudonymize(eval_group_name),
+            "projet_etudiant": _pseudonymize(student_project_string),
+            "score": round(float(score), 2),
+            "seuil": threshold,
+            "marge": self.margin,
+            "decision": "non_credite_arbitrage_requis",
+        })
+        return True
+
+    @property
+    def has_ambiguities(self):
+        return bool(self.entries)
+
+    def __len__(self):
+        return len(self.entries)
+
+    def clear(self):
+        self.entries = []
+
+    def write(self, path):
+        """Écrit le journal au format JSON. Retourne le chemin, ou None si vide."""
+        if not self.entries:
+            return None
+        os.makedirs(os.path.dirname(os.path.abspath(path)) or '.', exist_ok=True)
+        payload = {
+            "marge_ambiguite": self.margin,
+            "nb_rapprochements_ambigus": len(self.entries),
+            "note": ("Identifiants pseudonymisés (SHA-256 tronqué) — aucune donnée "
+                     "nominative, cf PRIVACY.md §5. Chaque entrée exige un arbitrage "
+                     "humain avant que le rapport soit considéré comme final (§6)."),
+            "rapprochements": self.entries,
+        }
+        with open(path, 'w', encoding='utf-8') as handle:
+            json.dump(payload, handle, ensure_ascii=False, indent=2)
+        return path
+
+
+# Journal actif par défaut : le gate doit fonctionner sans que chaque appelant
+# ait à le câbler — un journal optionnel que personne ne branche reproduirait
+# exactement l'avertissement-que-nul-ne-lit que ce mécanisme remplace.
+_DEFAULT_AMBIGUITY_JOURNAL = AmbiguityJournal()
+
+
+def get_ambiguity_journal():
+    """Journal d'ambiguïtés utilisé par défaut par ``fuzzy_match_group``."""
+    return _DEFAULT_AMBIGUITY_JOURNAL
+
+
+def reset_ambiguity_journal():
+    """Vide le journal par défaut (à appeler en début de run, et dans les tests)."""
+    _DEFAULT_AMBIGUITY_JOURNAL.clear()
+    return _DEFAULT_AMBIGUITY_JOURNAL
 
 # --- Structures de données ---
 
@@ -326,7 +422,7 @@ def _leading_group_code(normalized):
     return match.group(1) if match else None
 
 
-def fuzzy_match_group(eval_group_name, student_project_string, threshold=90):
+def fuzzy_match_group(eval_group_name, student_project_string, threshold=90, journal=None):
     """
     Correspondance entre nom de groupe évalué et nom de projet inscrit.
     Privilégie la correspondance exacte ou quasi-exacte (>= threshold % similarité).
@@ -334,6 +430,13 @@ def fuzzy_match_group(eval_group_name, student_project_string, threshold=90):
     Le seuil ``threshold`` (défaut 90, comportement historique) rend effectif le
     paramètre ``group_match_threshold`` configurable par épreuve (commit 3a612f85c).
     Les appelants 2-args conservent le défaut 90 (comportement inchangé).
+
+    ``journal`` (défaut : le journal de module) reçoit les scores tombant dans la
+    bande d'ambiguïté ``[threshold - AMBIGUITY_MARGIN, threshold[``. **La décision
+    de rapprochement est inchangée** — un score sous le seuil reste un refus, donc
+    aucun étudiant n'est crédité automatiquement (PRIVACY.md §6 règle 4). Ce qui
+    change est que le run porte désormais la trace du litige et peut être déclaré
+    non-final. Passer ``journal=False`` désactive tout enregistrement.
     """
     if not isinstance(eval_group_name, str) or not isinstance(student_project_string, str):
         return False
@@ -367,6 +470,12 @@ def fuzzy_match_group(eval_group_name, student_project_string, threshold=90):
     if similarity >= threshold:
         return True
 
+    # Sous le seuil : refus (comportement inchangé), mais si le score tombe dans
+    # la bande d'ambiguïté, le litige est consigné pour arbitrage humain.
+    if journal is not False:
+        active_journal = journal if journal is not None else _DEFAULT_AMBIGUITY_JOURNAL
+        active_journal.record(eval_group_name, student_project_string, similarity, threshold)
+
     # Cas 3: Pour les anciens formats (groupe X, project X)
     group_pattern = r'^groupe?\s*(\d+)$'
     eval_group_match = re.match(group_pattern, eval_norm)
@@ -375,13 +484,33 @@ def fuzzy_match_group(eval_group_name, student_project_string, threshold=90):
     if eval_group_match and student_group_match:
         return eval_group_match.group(1) == student_group_match.group(1)
 
-    # Cas 4: Inclusion simple pour les noms courts non numérotés
+    # Cas 4: Inclusion simple pour les noms courts non numérotés.
+    # L'inclusion doit s'arrêter sur une frontière de token : « projet alpha »
+    # inclus dans « projet alpha - groupe 3 » est le cas visé (le reste est un
+    # segment distinct), tandis que « ... dupont » inclus dans « ... dupontt »
+    # est une confusion de patronymes. Sans ce garde-fou, Cas 4 court-circuitait
+    # le seuil et créditait automatiquement l'un des deux étudiants même à
+    # threshold=100 (PRIVACY.md §6 règle 4).
     if not (eval_norm and eval_norm[0].isdigit()):
         if len(eval_norm) > 5 and len(student_norm) > 5:
-            if eval_norm in student_norm or student_norm in eval_norm:
+            if _inclusion_on_token_boundary(eval_norm, student_norm):
                 return True
 
     return False
+
+
+def _inclusion_on_token_boundary(a, b):
+    """Vrai si l'un des libellés inclut l'autre, le reliquat commençant sur un
+    séparateur (frontière de token) et non collé au dernier mot."""
+    shorter, longer = (a, b) if len(a) <= len(b) else (b, a)
+    if shorter not in longer:
+        return False
+    prefix, _, suffix = longer.partition(shorter)
+    # Le reliquat de part et d'autre doit être vide ou débuter/finir sur un
+    # caractère non alphanumérique (espace, tiret, parenthèse...).
+    head_ok = (not prefix) or (not prefix[-1].isalnum())
+    tail_ok = (not suffix) or (not suffix[0].isalnum())
+    return head_ok and tail_ok
 
 
 def is_feedback_empty(evaluation):

--- a/GradeBookApp/run_grading.py
+++ b/GradeBookApp/run_grading.py
@@ -1,7 +1,19 @@
+import argparse
 import os
 import glob
+import sys
 import pandas as pd
-from gradebook import process_grades, load_student_records, generate_qualitative_summary
+from gradebook import (
+    process_grades,
+    load_student_records,
+    generate_qualitative_summary,
+    get_ambiguity_journal,
+    reset_ambiguity_journal,
+)
+
+# Code de sortie signalant un rapport non-final : des rapprochements ambigus
+# attendent l'arbitrage de l'enseignant (PRIVACY.md §6).
+EXIT_AMBIGUITIES_PENDING = 2
 
 # --- Paramètres ---
 # Le chemin racine où se trouvent les données des différentes classes.
@@ -112,16 +124,54 @@ def verify_and_print_excel_head(filepath):
     print("ERREUR: Le fichier de rapport n'a pas été trouvé à l'emplacement attendu après plusieurs tentatives.")
 
 
-def main():
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Orchestration de la notation GradeBookApp.")
+    parser.add_argument(
+        "--allow-ambiguous", action="store_true",
+        help=("Produire le rapport malgré des rapprochements dans la bande "
+              "d'ambiguïté. À n'utiliser qu'après avoir arbitré le journal."))
+    parser.add_argument(
+        "--ambiguity-log", default=os.path.join(OUTPUT_DIR, "ambiguites_rapprochement.json"),
+        help="Chemin du journal structuré des rapprochements ambigus (JSON, sans PII).")
+    return parser.parse_args(argv)
+
+
+def report_ambiguity_gate(journal, log_path, allow_ambiguous):
+    """Applique le gate §6. Retourne le code de sortie du run."""
+    if not journal.has_ambiguities:
+        print("\nGate rapprochement : aucun cas dans la bande d'ambiguïté.")
+        return 0
+
+    written = journal.write(log_path)
+    print(f"\nGate rapprochement : {len(journal)} rapprochement(s) dans la bande "
+          f"d'ambiguïté (marge {journal.margin} points sous le seuil).")
+    print(f"Journal (pseudonymisé, sans donnée nominative) : {written}")
+    print("Aucun de ces rapprochements n'a été crédité automatiquement.")
+
+    if allow_ambiguous:
+        print("--allow-ambiguous : rapport produit malgré tout, sous la "
+              "responsabilité de l'enseignant.")
+        return 0
+
+    print("RAPPORT NON FINAL : arbitrez le journal, puis relancez avec "
+          "--allow-ambiguous pour valider.")
+    return EXIT_AMBIGUITIES_PENDING
+
+
+def main(argv=None):
     """
     Point d'entrée du script d'orchestration.
     """
+    args = parse_args(argv)
+    reset_ambiguity_journal()
+
     print(f"Recherche des fichiers dans : {DATA_ROOT}")
     files_to_process = find_files(DATA_ROOT)
 
     if not files_to_process:
         print("Aucune classe à traiter. Vérifiez les noms de vos fichiers.")
-        return
+        return 0
 
     print(f"Classes à traiter : {', '.join(files_to_process.keys())}")
 
@@ -134,7 +184,7 @@ def main():
             all_students.extend(load_student_records(paths["registration"]))
         except Exception as e:
             print(f"ERREUR CRITIQUE lors du chargement de {paths['registration']}: {e}")
-            return
+            return 1
     print(f"Total de {len(all_students)} étudiants chargés pour la validation.")
 
     for class_name, paths in files_to_process.items():
@@ -159,5 +209,8 @@ def main():
 
     print("\n--- Tous les traitements sont terminés. ---")
 
+    return report_ambiguity_gate(
+        get_ambiguity_journal(), args.ambiguity_log, args.allow_ambiguous)
+
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/GradeBookApp/test_fuzzy_match_group.py
+++ b/GradeBookApp/test_fuzzy_match_group.py
@@ -61,3 +61,134 @@ def test_cas0_distinct_group_codes_never_match():
     assert fuzzy_match_group("a1 - projet", "a2 - projet", threshold=10) is False
     # Same code matches regardless of a strict threshold.
     assert fuzzy_match_group("a1 - projet", "a1 - projet", threshold=100) is True
+
+
+# --- Gate d'ambiguité (issue #8606, PRIVACY.md §6) -------------------------
+
+
+@pytest.fixture
+def journal():
+    """Journal isolé, pour ne pas dépendre du journal de module partagé."""
+    from gradebook import AmbiguityJournal
+
+    return AmbiguityJournal()
+
+
+def _borderline_pair():
+    """Paire dont le ratio tombe strictement entre 50 et 100 (atteint le Cas 2)."""
+    from rapidfuzz import fuzz
+
+    a, b = "projet machine learning", "projet machine learnig"
+    ratio = fuzz.ratio(a, b)
+    assert 50 < ratio < 100, f"fixture ratio {ratio} hors bande attendue"
+    return a, b, ratio
+
+
+def test_score_in_band_is_recorded_but_still_refused(journal):
+    """Bande d'ambiguité : consignée pour arbitrage, et **non créditée** (§6 règle 4)."""
+    a, b, ratio = _borderline_pair()
+    # Seuil juste au-dessus du ratio -> refus, et score dans [seuil - marge, seuil[.
+    threshold = int(ratio) + 1
+    assert fuzzy_match_group(a, b, threshold, journal=journal) is False
+    assert len(journal) == 1, "le litige doit être consigné"
+    entry = journal.entries[0]
+    assert entry["decision"] == "non_credite_arbitrage_requis"
+    assert entry["seuil"] == threshold
+
+
+def test_score_below_band_is_not_recorded(journal):
+    """Sous la bande : refus franc, rien à arbitrer — le journal reste vide."""
+    # Deux libellés très dissemblables : ratio loin sous (seuil - marge).
+    assert fuzzy_match_group("alpha", "zzzzzzzzzzzz", 90, journal=journal) is False
+    assert len(journal) == 0
+
+
+def test_accepted_match_is_not_recorded(journal):
+    """Au-dessus du seuil : accepté, donc hors bande d'ambiguité."""
+    assert fuzzy_match_group("projet alpha", "projet alpha", 90, journal=journal) is True
+    assert len(journal) == 0
+
+
+def test_journal_holds_no_nominative_data(journal):
+    """PRIVACY.md §5 : le journal ne porte que des condensés, jamais les libellés."""
+    a, b, ratio = _borderline_pair()
+    fuzzy_match_group(a, b, int(ratio) + 1, journal=journal)
+    serialized = str(journal.entries)
+    assert a not in serialized and b not in serialized
+    assert "machine" not in serialized and "learning" not in serialized
+    # Condensé stable et tronqué (non réversible par simple lecture).
+    assert len(journal.entries[0]["groupe_evalue"]) == 12
+
+
+def test_two_close_students_neither_credited(journal):
+    """§6 règle 4 : confusion entre deux étudiants -> aucun crédité automatiquement."""
+    evaluation = "projet vision par ordinateur - dupont"
+    student_a = "projet vision par ordinateur - dupond"   # noms quasi identiques
+    student_b = "projet vision par ordinateur - dupontt"
+
+    matched = [s for s in (student_a, student_b)
+               if fuzzy_match_group(evaluation, s, threshold=100, journal=journal)]
+
+    assert matched == [], "aucun des deux étudiants ne doit être crédité automatiquement"
+    assert journal.has_ambiguities, "la confusion doit être tracée pour arbitrage"
+
+
+def test_cas4_inclusion_still_matches_on_token_boundary():
+    """Cas 4 conserve son intention : un libellé étendu par un segment distinct
+    reste le même projet (« projet alpha » ⊂ « projet alpha - groupe 3 »)."""
+    assert fuzzy_match_group(
+        "projet alpha", "projet alpha - groupe 3", threshold=100, journal=False) is True
+
+
+def test_cas4_glued_inclusion_no_longer_bypasses_threshold():
+    """Régression : « ... dupont » ⊂ « ... dupontt » n'est pas une inclusion de
+    projet mais une confusion de patronymes. Cas 4 court-circuitait le seuil et
+    créditait automatiquement l'un des deux (PRIVACY.md §6 règle 4)."""
+    assert fuzzy_match_group(
+        "projet vision - dupont", "projet vision - dupontt",
+        threshold=100, journal=False) is False
+
+
+def test_journal_false_disables_recording():
+    """``journal=False`` coupe tout enregistrement (appels utilitaires, sondes)."""
+    from gradebook import get_ambiguity_journal, reset_ambiguity_journal
+
+    reset_ambiguity_journal()
+    a, b, ratio = _borderline_pair()
+    assert fuzzy_match_group(a, b, int(ratio) + 1, journal=False) is False
+    assert len(get_ambiguity_journal()) == 0
+    reset_ambiguity_journal()
+
+
+def test_default_journal_used_when_unspecified():
+    """Sans ``journal``, le journal de module reçoit le litige : le gate est actif
+    par défaut, sans câblage par l'appelant."""
+    from gradebook import get_ambiguity_journal, reset_ambiguity_journal
+
+    reset_ambiguity_journal()
+    a, b, ratio = _borderline_pair()
+    fuzzy_match_group(a, b, int(ratio) + 1)
+    assert len(get_ambiguity_journal()) == 1
+    reset_ambiguity_journal()
+    assert len(get_ambiguity_journal()) == 0
+
+
+def test_write_produces_json_without_nominative_data(tmp_path, journal):
+    """Le journal écrit est un JSON exploitable, sans PII."""
+    import json
+
+    a, b, ratio = _borderline_pair()
+    fuzzy_match_group(a, b, int(ratio) + 1, journal=journal)
+    target = tmp_path / "ambiguites.json"
+    assert journal.write(str(target)) == str(target)
+
+    payload = json.loads(target.read_text(encoding="utf-8"))
+    assert payload["nb_rapprochements_ambigus"] == 1
+    assert a not in target.read_text(encoding="utf-8")
+
+
+def test_write_returns_none_when_no_ambiguity(tmp_path, journal):
+    """Rien à arbitrer -> aucun fichier créé (pas de journal vide qui traîne)."""
+    target = tmp_path / "ambiguites.json"
+    assert journal.write(str(target)) is None
+    assert not target.exists()

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,6 +9,7 @@ testpaths =
     scripts/tests
     scripts/audit/tests
     MyIA.AI.Notebooks/QuantConnect/scripts/tests
+    GradeBookApp
 pythonpath =
     MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts
 addopts = -v --tb=short --import-mode importlib


### PR DESCRIPTION
`Grain: MED/refactor — lane myia-ai-01:CoursIA — prev: DEEP/docs`

## Ce que faisait le code, et pourquoi ce n'etait pas suffisant

`PRIVACY.md` §6 declarait l'ecart lui-meme, sans le maquiller :

> « Les seuils existent et sont applicables […]. En revanche, la **validation humaine sous seuil n'est pas encore forcee par le code** (le moteur affiche un avertissement, puis continue). »

C'est la bonne facon de documenter une dette. Mais l'ecart etait reel : sur des donnees etudiantes nominatives, un rapprochement ambigu traversait un run en silence et finissait dans un `.xlsx` de notes si l'enseignant ne relisait pas les logs. Un avertissement qu'on peut ne jamais lire n'est pas un gate.

## Ce qui change

| Mecanisme | Emplacement |
|---|---|
| Bande d'ambiguite nommee, configurable | `gradebook.py` : `AMBIGUITY_MARGIN` (defaut `10`) → `[seuil - marge, seuil[` |
| Journal structure, **sans PII nominative** | `gradebook.py` : `AmbiguityJournal` — condense SHA-256 tronque des deux libelles, score, seuil, marge (§5) |
| Gate de sortie | `run_grading.py` : RC `2` (`EXIT_AMBIGUITIES_PENDING`) tant que des ambiguites subsistent ; `--allow-ambiguous` pour passer outre |
| Test regle 4 | `test_fuzzy_match_group.py` : confusion entre deux patronymes proches |

**La decision de rapprochement est inchangee.** Un score sous le seuil reste un refus — aucun etudiant n'est credite automatiquement, conformement a §6 regle 4. Ce qui change est que le run porte la trace du litige et ne peut plus etre presente comme final sans arbitrage. J'ai prefere ca a un changement de semantique de matching, qui aurait modifie des notes reelles sous couvert d'ameliorer un garde-fou.

Le journal est **actif par defaut** (journal de module, `journal=False` pour couper). Un journal optionnel que personne ne cable reproduirait exactement l'avertissement-que-nul-ne-lit qu'il remplace.

## Le defaut que le test a revele

Le test de la regle 4 a **echoue au premier passage**, et pas pour la raison attendue :

```
E   AssertionError: aucun des deux etudiants ne doit etre credite automatiquement
E   assert ['projet vision par ordinateur - dupontt'] == []
```

Cause : le **Cas 4** de `fuzzy_match_group` (inclusion simple) court-circuitait entierement le seuil.

```python
if eval_norm in student_norm or student_norm in eval_norm:
    return True
```

`« projet vision … - dupont »` **est** une sous-chaine de `« … - dupontt »`. Deux etudiants aux patronymes voisins etaient donc rapproches et l'un credite automatiquement — **meme a `threshold=100`**, c'est-a-dire au reglage le plus strict que l'enseignant puisse choisir. C'est precisement le scenario que §6 regle 4 interdit, et il etait atteignable sans aucun reglage fautif.

Correctif : l'inclusion exige desormais que le reliquat commence (ou finisse) sur une **frontiere de token**, pas colle au dernier mot. Le cas visé par Cas 4 est preserve — « projet alpha » ⊂ « projet alpha - groupe 3 », le reliquat commence par un separateur — et la confusion de noms est fermee. Deux tests pinnent les deux directions.

Je n'avais pas prevu ce defaut : il est sorti de l'ecriture du test que l'acceptance demandait. C'est l'argument pour ecrire le test de la regle avant de se declarer conforme a la regle.

## `pytest.ini`

`GradeBookApp` etait **absent de `testpaths`** : `test_fuzzy_match_group.py` existait mais n'etait collecte par aucune suite. Un test qui ne tourne pas ne garde rien — ajoute a la liste. Les gardes `pytest.importorskip` du fichier font qu'il skippe proprement la ou les deps du moteur de notation sont absentes.

## Validation

**15/15**, env conda `mcp-jupyter` (seul env local portant `pandas` + `rapidfuzz` + `unidecode` + `openpyxl` — `coursia-ml-training` n'a ni `rapidfuzz` ni `unidecode`) :

```
collected 15 items
test_fuzzy_match_group.py ...............                                [100%]
============================= 15 passed in 1.06s ==============================
```

Gate verifie de bout en bout, pas seulement le matcher :

```
RC sans --allow-ambiguous : 2      <- rapport non final
RC avec --allow-ambiguous : 0
RC sans ambiguite         : 0      <- aucun fichier journal cree
```

Journal ecrit, verifie sans donnee nominative :

```json
{ "marge_ambiguite": 10, "nb_rapprochements_ambigus": 1,
  "rapprochements": [ { "groupe_evalue": "cbcbf0549942",
                        "projet_etudiant": "75873f2675ff",
                        "score": 97.78, "seuil": 100, "marge": 10,
                        "decision": "non_credite_arbitrage_requis" } ] }
```

## Acceptance

- [x] Bande d'ambiguite nommee et configurable, coherente avec §6.
- [x] Journal structure, **zero PII nominative** (verifie par test : les libelles source n'apparaissent pas dans les entrees).
- [x] Le rapport n'est plus produit silencieusement quand des ambiguites subsistent.
- [x] Test couvrant la confusion entre deux etudiants proches — c'est lui qui a trouve le bug Cas 4.
- [x] `PRIVACY.md` §6 mis a jour : la reserve « pas encore force par le code » est remplacee par le tableau d'implementation, et le defaut Cas 4 y est documente.

## Notes

- **Aucune donnee reelle** n'a ete touchee : le moteur est public, les donnees etudiantes vivent sur GDrive par cohorte. Les fixtures sont synthetiques.
- Catalogue **byte-identique a `main`** (aucun fichier `COURSE_CATALOG*` au diff).
- Trouve en chemin, hors scope : `d:/CoursIA/lib64` (symlink de residu venv, gitignore) fait echouer la collection pytest depuis la racine sous Windows — `OSError: [WinError 1920]`. Contourne ici par `--ignore`. A traiter separement si d'autres machines le rencontrent.

Closes #8606 · See #4208
