### PR TITLE
feat(cost,#8056): metadata.cost sur les 6 notebooks Lean LLM-API (SymbolicAI)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-1-Setup.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-1-Setup.ipynb
@@ -2257,6 +2257,23 @@
    "parameters": {},
    "start_time": "2026-06-07T15:39:00.204571",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 12,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": true,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "last_validated": "2026-07-27",
+   "validator": "manual",
+   "notes": "Installation de la chaine Lean (elan/lake, cache Mathlib) et des paquets Python de la serie\n(python-dotenv, openai, anthropic, matplotlib, semantic-kernel). Les paquets LLM sont INSTALLES\nmais jamais appeles ici : zero requete API, cout strictement nul. Reseau requis pour le\ntelechargement du toolchain et du cache Mathlib. Profil derive firsthand (lecture des 7 cellules\ncode + sorties committees), pas de re-execution."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-10-LeanDojo.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-10-LeanDojo.ipynb
@@ -4239,6 +4239,23 @@
    "parameters": {},
    "start_time": "2026-06-11T13:02:16.095820+00:00",
    "version": "2.7.0"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "none",
+   "cpu_min": 10,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": true,
+   "external_account": "none",
+   "free_alternative": "self",
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "last_validated": "2026-07-27",
+   "validator": "manual",
+   "notes": "L'assistance LLM est MOCKEE par conception : `call_llm()` est un dict de tactiques et l'appel\nreel est commente (« En pratique, remplacez call_llm() par un appel OpenAI/Anthropic »). Le\nnotebook demontre donc la boucle LeanDojo de bout en bout SANS payer : cout nul, aucune cle.\nC'est a ce titre l'alternative gratuite pointee par Lean-7, Lean-7b, Lean-8 et Lean-9. Reseau\nrequis pour recuperer les traces LeanDojo. Derive firsthand, sans re-execution."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-7-LLM-Integration.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-7-LLM-Integration.ipynb
@@ -2304,6 +2304,23 @@
    "parameters": {},
    "start_time": "2026-06-04T06:56:04.303844",
    "version": "2.6.0"
+  },
+  "cost": {
+   "api_usd_est": 0.05,
+   "api_provider": "openai",
+   "cpu_min": 5,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": true,
+   "external_account": "openai",
+   "free_alternative": "MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-10-LeanDojo.ipynb",
+   "reduced_pedagogical": null,
+   "reproducibility": "LOW",
+   "last_validated": "2026-07-27",
+   "validator": "manual",
+   "notes": "LLMClient(provider='openai') instancie en [26] et [34] ; la boucle de preuve `generator.prove`\nde [34] enchaine plusieurs completions avec retry (max_retries=3). Modele par defaut gpt-5.2\n(PROVIDERS_CONFIG, lean_runner.py:908), max_tokens 1000. LLMClient LEVE une exception si\nOPENAI_API_KEY est absente : la cle est un prerequis dur, pas une option. Estimation derivee du\ndecompte de sites d'appel et du plafond de tokens (lecture G.1 firsthand), sans re-execution.\nAlternative gratuite : Lean-10 demontre la meme boucle avec un LLM mocke."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-7b-Examples.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-7b-Examples.ipynb
@@ -2547,6 +2547,23 @@
    "parameters": {},
    "start_time": "2026-06-04T02:53:25.273004",
    "version": "2.7.0"
+  },
+  "cost": {
+   "api_usd_est": 0.25,
+   "api_provider": "openai+anthropic",
+   "cpu_min": 8,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": true,
+   "external_account": "openai+anthropic",
+   "free_alternative": "MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-10-LeanDojo.ipynb",
+   "reduced_pedagogical": null,
+   "reproducibility": "LOW",
+   "last_validated": "2026-07-27",
+   "validator": "manual",
+   "notes": "Le plus couteux de la serie. Trois boucles de preuve ([12] simple, [20] Mathlib avec davantage\nd'iterations) puis une comparaison DEUX providers en [26] : LLMClient openai ET anthropic, chacun\npasse par `prove` sur le meme theoreme (57 KB de sortie committee). Les DEUX cles sont requises,\naucun chemin degrade a une seule cle sur cette cellule. Modeles par defaut gpt-5.2 et\nclaude-sonnet-4-5. Estimation derivee des sites d'appel firsthand, sans re-execution."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-8-Agentic-Proving.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-8-Agentic-Proving.ipynb
@@ -2594,6 +2594,23 @@
    "parameters": {},
    "start_time": "2026-06-08T18:13:57.091867",
    "version": "2.7.0"
+  },
+  "cost": {
+   "api_usd_est": 0.01,
+   "api_provider": "openai",
+   "cpu_min": 3,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": true,
+   "external_account": "openai",
+   "free_alternative": "MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-10-LeanDojo.ipynb",
+   "reduced_pedagogical": null,
+   "reproducibility": "LOW",
+   "last_validated": "2026-07-27",
+   "validator": "manual",
+   "notes": "Trois sites d'appel sur gpt-4o-mini : le moins couteux des notebooks LLM de la serie. Boucle\nagentique de proposition/correction de tactiques. Estimation derivee du decompte d'appels et du\ntarif gpt-4o-mini (lecture firsthand), sans re-execution. Alternative gratuite : Lean-10 (mock)."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-9-SK-Multi-Agents.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-9-SK-Multi-Agents.ipynb
@@ -5823,6 +5823,23 @@
    "parameters": {},
    "start_time": "2026-06-11T03:24:19.299422",
    "version": "2.7.0"
+  },
+  "cost": {
+   "api_usd_est": 0.15,
+   "api_provider": "openai+anthropic",
+   "cpu_min": 6,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "vram_gb": 0,
+   "vram_tier": "NONE",
+   "network": true,
+   "external_account": "openai+anthropic",
+   "free_alternative": "MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-10-LeanDojo.ipynb",
+   "reduced_pedagogical": null,
+   "reproducibility": "LOW",
+   "last_validated": "2026-07-27",
+   "validator": "manual",
+   "notes": "Orchestration Semantic Kernel multi-agents : cinq sites d'invocation, modeles cites gpt-5.2,\ngpt-5, gpt-4.5, gpt-4o et claude-sonnet-4-5 (56 KB de sortie committee). Le cout reel depend du\nmodele reellement configure via les variables OPENAI_CHAT_MODEL_ID / ANTHROPIC_CHAT_MODEL_ID ;\nl'estimation retient un tour multi-agents complet sur les defauts. Derive firsthand, sans\nre-execution. Alternative gratuite : Lean-10 (mock)."
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: MED/notebook-metadata — lane myia-ai-01:CoursIA — prev: MED/harness

See #8056 (contribution partielle : 3ᵉ puce d'acceptance « notebooks LLM-API », famille SymbolicAI/Lean).

## Ce que fait la PR

Renseigne `metadata.cost` (schéma canonique JSON, `docs/notebook-metadata/cost-matrix.md`) sur les **6 notebooks Lean qui touchent une API LLM** — la seule famille de l'acceptance #8056 encore sans propriétaire. `+17/−0` par fichier, **102 insertions, 0 suppression** : aucune cellule source, aucun output, aucun `execution_count` touché. Le catalogue est byte-identique à `main`.

`populate_cost_metadata.py` ne porte que le profil quantbook — ces six valeurs sont donc **établies à la main, notebook par notebook**, pas dérivées d'un scan.

| Notebook | `api_usd_est` | `api_provider` | `external_account` | `free_alternative` | `repro` | `cpu_min` |
|---|---|---|---|---|---|---|
| Lean-1-Setup | 0.0 | none | none | `self` | HIGH | 12 |
| Lean-7-LLM-Integration | 0.05 | openai | openai | Lean-10 | LOW | 5 |
| Lean-7b-Examples | 0.25 | openai+anthropic | openai+anthropic | Lean-10 | LOW | 8 |
| Lean-8-Agentic-Proving | 0.01 | openai | openai | Lean-10 | LOW | 3 |
| Lean-9-SK-Multi-Agents | 0.15 | openai+anthropic | openai+anthropic | Lean-10 | LOW | 6 |
| Lean-10-LeanDojo | 0.0 | none | none | `self` | HIGH | 10 |

Tous : `gpu_required: false`, `vram_tier: "NONE"`, `network: true`, `last_validated: "2026-07-27"`, `validator: "manual"`.

## Les trois jugements que le scan n'aurait pas faits

1. **Lean-1-Setup — installeur à coût nul.** Il est dans la famille « LLM » par voisinage, pas par usage : il installe elan/Mathlib et n'appelle rien. `0.0` / `none`, et `reproducibility: HIGH` parce que rien n'y dépend d'un modèle.
2. **Lean-10-LeanDojo — mocké par conception, donc `free_alternative: self`.** `call_llm()` est un dict de tactiques ; l'appel réel est **commenté** (`# tactic = call_llm(prompt)`). Le notebook démontre la boucle LeanDojo de bout en bout **sans payer**. C'est à ce titre qu'il est l'alternative gratuite pointée par Lean-7, 7b, 8 et 9 — le sentinel `self` est ici la réponse positive « ce notebook EST l'alternative gratuite », pas une absence de réponse.
3. **Coûts différenciés par volume d'appels, pas par uniformité.** Lean-8 (`0.01`) fait une poignée d'itérations agentiques ; Lean-7b (`0.25`) exécute une **comparaison croisée OpenAI↔Anthropic sur plusieurs théorèmes** (cell[26]), donc deux providers × N itérations. `api_provider: openai+anthropic` reflète le `LLMClient(provider=...)` réellement instancié, pas une mention en prose.

Sources firsthand : `lean_runner.py:908` (`class LLMClient` — `ValueError` si la clé manque, défauts `gpt-5.2` / `claude-sonnet-4-5`, `max_retries=3`), et les cellules d'appel de chaque notebook. Aucune valeur n'a demandé de ré-exécution : ce sont des ordres de grandeur d'usage documentés, `validator: "manual"` le dit.

## Vérification `scripts/audit/check_cost_metadata.py`

**5/6 propres** (`findings:` vide). Le sixième est un **FAUX POSITIF du checker**, vérifié firsthand et documenté ici plutôt que corrigé en gonflant la métadonnée :

```
########## Lean-10-LeanDojo
api_used: ['anthropic']
findings:
  - pattern: api_used_but_cost_zero
    severity: CRITICAL
    detail: 'Cellule code appelle anthropic mais cost.api_usd_est: 0.0'
```

Le déclencheur exact, isolé :

```
[63] match='Anthropic.'  <- En pratique, remplacez call_llm() par un appel OpenAI/Anthropic.
```

Le motif `API_PATTERNS['anthropic'] = r'anthropic\.|from anthropic|claude'` a matché `Anthropic.` où le point est la **ponctuation de fin de phrase**, dans une ligne de prose — pas un accès d'attribut. Recherche des appels vivants (`import openai|anthropic`, `.chat.completions`, `messages.create`, `LLMClient(`) hors lignes commentées : **0 résultat**. Le notebook n'émet aucune requête payante ; `0.0` est la valeur juste.

Porter `api_usd_est` à une valeur non nulle pour faire taire le checker ferait mentir la métadonnée sur un notebook qui ne coûte rien — l'inverse exact de ce que #8056 cherche à produire. Classification `audit-reassessment` : **FALSE POSITIVE**, aucun fix.

Corroboration du caractère textuel de la détection : Lean-7b remonte `api_used: ['anthropic', 'google']` alors qu'il n'utilise **aucun** service Google — `google` vient de `Gemini 2.0` cité en prose dans un panorama SOTA (cell[31]). Le finding n'y déclenche pas seulement parce que son `api_usd_est` est > 0.

Le correctif du motif (exiger un caractère de mot après le point) touche les verdicts des 267 notebooks du dépôt : hors scope d'une PR de métadonnées, suivi en issue séparée.

## Gates

| Gate | État |
|---|---|
| C.2 outputs | aucune cellule touchée — `+17/−0`, métadonnée notebook uniquement |
| C.3 scope | 6 notebooks, tous effectivement modifiés |
| Catalogue | byte-identique à `main` |
| G.4 composite | 6 fichiers, 1 domaine, 1 sujet |
| JSON | 6/6 relus et valides, round-trip `indent=1, ensure_ascii=False` |
