### PR TITLE
fix(audit,#8618): strip commented lines + triple-quoted strings before API/token regex

### DIFF
--- a/scripts/audit/check_cost_metadata.py
+++ b/scripts/audit/check_cost_metadata.py
@@ -50,9 +50,13 @@ GPU_PATTERNS = [
 ]
 
 # API payantes (litmus 2 : api_usd_est = 0 mais cellule appelle API)
+# Note FP-c.912 : `anthropic.` matchait la ponctuation de fin de phrase
+# ("OpenAI/Anthropic.") et `claude`/`gemini` nus prenaient des panos SOTA
+# en prose. On resserre `anthropic.` en `anthropic.\w` (préserve
+# `anthropic.Anthropic(...)`, élimine le faux positif typographique).
 API_PATTERNS = {
     'openai': r'openai\.ChatCompletion|openai\.Image|openai\.Audio|from openai',
-    'anthropic': r'anthropic\.|from anthropic|claude',
+    'anthropic': r'anthropic\.\w|from anthropic|claude',
     'mistral': r'mistralai|from mistral',
     'google': r'google\.generativeai|gemini',
     'replicate': r'replicate\.',
@@ -67,6 +71,48 @@ TOKEN_PATTERNS = {
     'qc': r'os\.getenv\(["\']QC_USER|os\.getenv\(["\']QC_API_TOKEN',
     'comfyui': r'os\.getenv\(["\']COMFYUI',
 }
+
+
+def strip_commented_lines(code_source: str) -> str:
+    r"""Filtre les lignes commentées (Python) et les triple-quoted strings
+    avant que les regex `API_PATTERNS`/`TOKEN_PATTERNS` ne soient appliquées.
+
+    Avant c.912 (#8618), les regex étaient appliquées sur la source brute des
+    cellules code, sans distinguer une ligne de code d'une ligne de commentaire
+    ou de prose de cellule markdown. Conséquence :
+    `anthropic.` matchait la ponctuation de fin de phrase ("OpenAI/Anthropic.")
+    en commentaire d'avertissement, et `claude`/`gemini` nus prenaient des
+    panoramas SOTA en prose (print multi-ligne avec triple-quoted).
+
+    Le filtre fait 2 passes :
+    1. Retrait des triple-quoted strings (les plus fréquents en docstring).
+       Un panorama SOTA type "Gemini 2.0, GPT-5, Claude 3.5" à l'intérieur d'un
+       print multi-ligne matche gemini/claude sans être un appel d'API.
+    2. Filtrage des lignes dont le strip() commence par le caractère Python
+       de commentaire.
+
+    Trade-off (volontairement borné) : on ne retire PAS les littéraux
+    simple/double-quoted parce qu'un appel d'API authentique passe souvent par
+    argument string (os.getenv(TOKEN), model_id=anthropic/...). Conséquence :
+    une config-dict littérale qui mentionne anthropic/claude-... peut subsister
+    comme signal — c'est un cas rare et le coût (1 finding résiduel) reste
+    inférieur au coût de destruction d'un appel API authentique.
+
+    Le filtre triple-quoted est appliqué sur le bloc entier (et pas ligne par
+    ligne) parce qu'un triple-quoted peut s'étendre sur N lignes.
+    """
+    # 1. Retrait des triple-quoted strings (les plus fréquents en docstring).
+    no_triple = _TRIPLE_QUOTED_RE.sub('', code_source)
+    # 2. Filtrage des lignes commentées.
+    out_lines = []
+    for line in no_triple.splitlines():
+        if line.lstrip().startswith('#'):
+            continue
+        out_lines.append(line)
+    return '\n'.join(out_lines)
+
+
+_TRIPLE_QUOTED_RE = re.compile(r'"""[\s\S]*?"""|\'\'\'[\s\S]*?\'\'\'')
 
 
 def parse_cost_frontmatter(cell_source: str) -> dict:
@@ -96,19 +142,32 @@ def detect_gpu_usage(code_source: str) -> bool:
 
 
 def detect_api_usage(code_source: str) -> list:
-    """Litmus 2 : cellule code appelle API payante."""
+    """Litmus 2 : cellule code appelle API payante.
+
+    Filtre les lignes commentées (`#`) avant regex (cf c.912, issue #8618)
+    pour éviter qu'une ligne de prose `"OpenAI/Anthropic."` matche
+    `anthropic.` (ponctuation) ou que `claude`/`gemini` nus prennent
+    un panorama SOTA en prose.
+    """
+    filtered = strip_commented_lines(code_source)
     found = []
     for provider, pattern in API_PATTERNS.items():
-        if re.search(pattern, code_source, re.IGNORECASE):
+        if re.search(pattern, filtered, re.IGNORECASE):
             found.append(provider)
     return found
 
 
 def detect_token_usage(code_source: str) -> list:
-    """Litmus 3 : cellule code lit token externe."""
+    """Litmus 3 : cellule code lit token externe.
+
+    Filtre les lignes commentées (`#`) avant regex (cf c.912, issue #8618).
+    Les tokens sont peu probables en commentaire mais l'uniformité du
+    filtre (litmus 2 + litmus 3) simplifie la discipline d'audit.
+    """
+    filtered = strip_commented_lines(code_source)
     found = []
     for provider, pattern in TOKEN_PATTERNS.items():
-        if re.search(pattern, code_source):
+        if re.search(pattern, filtered):
             found.append(provider)
     return found
 


### PR DESCRIPTION
## Fix #8618 — `check_cost_metadata.py` litmus 2/3 FP sur prose de cellule

**Issue:** [#8618](https://github.com/jsboige/CoursIA/issues/8618) — `scripts/audit/check_cost_metadata.py` détecte l'usage d'API/token par regex sur la source brute des cellules code, sans distinguer code, commentaire, et prose.

### Symptômes (verbatim issue)

1. `anthropic\.` matche la ponctuation de fin de phrase. Sur `Lean-10-LeanDojo.ipynb` cellule [63] : `"En pratique, remplacez call_llm() par un appel OpenAI/Anthropic."` — match=`'Anthropic.'`. Le notebook n'émet aucune requête payante mais le finding remonte en CRITICAL.

2. `gemini` matche un panorama SOTA en prose. `Lean-7b-Examples.ipynb` remonte `api_used: ['anthropic', 'google']` alors qu'il n'utilise aucun service Google (la cellule contient une docstring multi-ligne mentionnant `Gemini 2.0, GPT-5, Claude 3.5` à titre informatif).

### Correctif (3 modifications, 64+/5-)

| # | Modification | Effet |
|---|---|---|
| 1 | Resserrer `anthropic\.` en `anthropic\.\w` dans `API_PATTERNS['anthropic']` | Élimine le FP `Anthropic.` (ponctuation), préserve `anthropic.Anthropic(...)` et `anthropic.prove(...)` |
| 2 | Nouvelle fonction `strip_commented_lines()` qui retire (a) les triple-quoted strings sur le bloc entier, (b) les lignes dont le `lstrip()` commence par `#` | Élimine les docstrings/print multi-ligne mentionnant `Gemini`/`Claude`/`GPT-5` en prose, ainsi que les commentaires d'avertissement |
| 3 | `detect_api_usage()` (litmus 2) et `detect_token_usage()` (litmus 3) appliquent le filtre avant regex | Uniformise la discipline d'audit |

### Trade-off assumé (documenté dans la docstring de `strip_commented_lines`)

On ne retire PAS les littéraux simple/double-quoted parce qu'un appel API authentique passe souvent par argument string (`os.getenv("TOKEN")`, `model_id="anthropic/..."`). Conséquence : une config-dict littérale qui mentionne `anthropic/claude-...` peut subsister comme signal — coût (1 finding résiduel) < coût de destruction d'un appel API authentique (faux négatif grave).

### Diff de verdicts BEFORE → AFTER (fleet-wide, 943 notebooks)

Fleet audit script : `scratchpad-c912/audit_fleet.py` (exclut `_archives/`, `.ipynb_checkpoints/`).

**Notebooks où le finding disparaît (FP avéré, vérifié ligne-par-ligne) :**

| Notebook | BEFORE api_used | AFTER_FINAL api_used | Cause racine |
|---|---|---|---|
| `Lean/Lean-10-LeanDojo.ipynb` | `['anthropic']` | `[]` | `anthropic.` (ponctuation en cellule markdown) — exemple fondateur de l'issue |
| `Lean/Lean-7b-Examples.ipynb` | `['anthropic', 'google']` | `['anthropic']` | `google` était `Gemini 2.0` dans une docstring multi-ligne (print SOTA panorama) |
| `Search/Part2-CSP/CSP-6-Hybridization.ipynb` | `['anthropic']` | `[]` | `claude` en prose de commentaire |

**Notebooks qui restent flagged après le fix (vrais positifs — vérifié) :**

- `GenAI/Audio/*` (12 notebooks) — vrai usage `openai.*` (TTS, Whisper, Audiobook)
- `GenAI/Vibe-Coding/Claudish/notebooks/01-claude-code-via-claudish.ipynb` — vrai `ANTHROPIC_AUTH_TOKEN` lu en cellule [4] L51 ; prompte Claude via `claude-code` ; **finding justifié, pas FP**
- `GenAI/SemanticKernel/07-SemanticKernel-MultiModal.ipynb`, `Créateur de mail personnalisé.ipynb` — vrai `openai.ChatCompletion.create(...)` dans le code
- `ML/DataScienceWithAgents/Track2-GoogleADK/Day4-Foundations/Lab8-ADK-Introduction.ipynb` — vrai `google.adk.agents` (différent du pattern `google.generativeai`)
- `SymbolicAI/Lean/Lean-8-Agentic-Proving.ipynb` — vrai `openai` via `litellm`
- `SymbolicAI/Lean/Lean-16b-Conway-Game-of-Life-Lean.ipynb` — vrai `google.generativeai` (pano SOTA)

### Statistiques agrégées

| Métrique | BEFORE | AFTER_FINAL | Δ |
|---|---|---|---|
| Notebooks avec `api_used` non-vide | 71 | 69 | −2 (CSP-6, Lean-10) |
| Notebooks avec finding `api_used_but_cost_zero` CRITICAL | 25 | 22 | −3 (Lean-10, CSP-6, Lean-7b) |

Les 12 autres notebooks qui semblaient disparaître dans un audit intermédiaire (`AFTER.json`) ont été ré-vérifiés — ils ont un vrai usage API dans le code (Claudish token, OpenAI TTS, Google ADK, etc.) et **doivent rester flaggés**. Le trade-off du triple-quoted filter est correct : on retire UNIQUEMENT les docstrings/print multi-ligne, pas les vrais appels.

### Acceptance criteria (cochée)

- [x] Filtre lignes commentées appliqué avant détection (litmus 2 et litmus 3)
- [x] `anthropic\.` resserré en `anthropic\.\w`; Lean-10-LeanDojo repasse `findings: []` sans modification de sa métadonnée
- [x] Lean-7b-Examples ne remonte plus `google` (reste `anthropic` car usage réel)
- [x] Diff des verdicts avant/après posté dans la PR (table ci-dessus + JSON `scratchpad-c912/fleet_audit_BEFORE.json` / `scratchpad-c912/fleet_audit_AFTER_FINAL.json`)

### Vérification token detection préservée (litmus 3)

`Lean-9-SK-Multi-Agents.ipynb` cell[19] lit `os.getenv("ANTHROPIC_API_KEY")`. Résultat post-fix :

```
api_used: ['anthropic', 'openai']
tokens_required: ['anthropic', 'openai']
findings:
  - token_required_but_no_account (anthropic) MAJOR
  - token_required_but_no_account (openai) MAJOR
  - api_used_but_cost_zero (anthropic) CRITICAL
  - api_used_but_cost_zero (openai) CRITICAL
```

→ Le filtre triple-quoted n'a **pas** détruit la détection du token (l'argument string `os.getenv("ANTHROPIC_API_KEY")` est sur une ligne de code, pas dans une docstring).

### Granularité

- 1 fichier modifié : `scripts/audit/check_cost_metadata.py`
- 64 insertions / 5 deletions
- Atomique, sujet unique (FP-fix litmus 2/3)

`See #8056` (EPIC reste ouverte ; ce PR est une contribution au sous-grain litmus-2/3)