### PR TITLE
feat(kronos,#8607): real-API harness + zero-shot panier sweep (NO BEATS)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/docs/foundation_kronos_zeroshot.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/docs/foundation_kronos_zeroshot.md
@@ -1,0 +1,69 @@
+# Foundation-model zero-shot — Kronos sur le panier anti-biais (spin-out #8607, 2e rung)
+
+> Script associé : [`scripts/eval_kronos_zeroshot.py`](../scripts/eval_kronos_zeroshot.py) (réécrit sur l'API réelle ce cycle).
+> Résultats bruts : [`scripts/results/kronos_zeroshot/`](../scripts/results/kronos_zeroshot/) (`results.json` + `verdict.md`).
+> 2e rung foundation-model du spin-out #8607 de l'Epic #1409 (parqué après L6 ROBUST NO BEATS). Le 1er rung était Chronos-Bolt ([`docs/foundation_chronos_zeroshot.md`](foundation_chronos_zeroshot.md), c.893 / #8610).
+
+## Verdict : NO BEATS (panier, robuste sur 3 horizons)
+
+Un **foundation-model zero-shot** pré-entraîné sur **K-lines OHLCV** (Kronos-base, AAAI 2026, ~102M params, 12B K-lines multi-actifs, *aucun* entraînement sur l'univers) **ne bat pas majority-class** sur le panier anti-biais en prévision de **direction**, à aucun des 3 horizons demandés par #8607 (h=22/66/132). Sur **9 configurations** (3 symboles × 3 horizons), **9/9** ont un edge strictement négatif, `beats_valid=False` partout, DirAcc sous la baseline majority sur les 9.
+
+## Hypothèse (#8607)
+
+Le 1er rung foundation-model (Chronos-Bolt, c.893) était NO BEATS — mais son harnais a révélé un **artefact méthodologique** (C893-L) : Chronos-Bolt est déterministe, donc `std_edge=0` toutes seeds identiques, et le gate `beats_valid` collapsait en « edge>0=BEATS ». La question de ce 2e rung : un foundation-model **stochastique** (Kronos, échantillonnage autorégressif) donne-t-il un résultat différent — la variance cross-seed étant alors *réelle* et le gate *opérant* ? Biais de fouille après 6 réfutations (L1-L6) → **barre complète** : edge ≥2σ cross-seed, ≥3/4 seeds positifs, bat majority, coûts tx.
+
+## Méthode
+
+- **Modèle** : **Kronos-base** (`NeoQuasar/Kronos-base`, ~102M params, AAAI 2026, transformer pré-entraîné sur 12B K-lines OHLCV) en mode **zero-shot** (figé, *aucun* fine-tuning). Distribué en repo source (pas de wheel PyPI) ; importé via `from model import Kronos, KronosTokenizer, KronosPredictor`.
+- **Inférence** : `prediction_length` ∈ {24, 66, 132} (≈ h=22, 66, 132 jours de bourse), contexte `seq_len=96`, échantillonnage autorégressif (`T=1.0, top_p=0.9, sample_count=1`). Device GPU (RTX 3070 8GB, `CUDA_VISIBLE_DEVICES=0`, env `coursia-ml-training`, torch 2.5.1+cu121).
+- **Univers** : panier anti-biais (FORBIDDEN FAANG/Mag7) — SPY, TLT, GLD via `data_utils.load_data` (yfinance daily OHLCV, data-source-to-convert AUTORISÉ).
+- **Validation** : walk-forward **5 fenêtres**, **5 seeds** (0/1/7/42/99) — le seed contrôle l'échantillonnage AR (`torch.manual_seed`+`np.random.seed` avant chaque `predict`), donc la variance cross-seed est **significative** (contrairement à Chronos). Coût tx **10 bps** par rebalancement, baseline majority-class.
+- **Métrique** : `edge_vs_majority = DirAcc − majority_baseline`. Gate `beats_valid` : `seeds≥4 AND mean_edge>0 AND (std<1e-10 OR mean_edge≥2·std)`.
+
+## Le harness était spéculatif — réécrit sur l'API réelle
+
+`eval_kronos_zeroshot.py` appelait `from kronos import KronosPipeline` (API inexistante). Réécrit sur l'API réelle groundée firsthand (`model/__init__.py` + `examples/prediction_example.py`) : `KronosPredictor` + OHLCV DataFrame + `x_timestamp`/`y_timestamp`. **SOTA-OK** (`is_mock=False`). Voir [`verdict.md`](../scripts/results/kronos_zeroshot/verdict.md).
+
+## Résultats — sweep horizon × symbole (walk-forward 5 fenêtres, 5 seeds, 10 bps)
+
+| Horizon | SPY DirAcc | SPY majority | SPY edge | TLT edge | GLD edge |
+|---------|-----------|--------------|----------|----------|----------|
+| h≈22 (`pred_len=24`) | 0.5113 | 0.5461 | **-0.0348** | **-0.0174** | **-0.0428** |
+| h=66 | 0.5058 | 0.5461 | **-0.0403** | **-0.0201** | **-0.0219** |
+| h=132 | 0.5014 | 0.5461 | **-0.0448** | **-0.0245** | **-0.0249** |
+
+(TLT majority 0.5130, GLD majority 0.5315.) **9/9 edges négatifs.** `std_edge` 0.0086-0.0502 (strictement positif — Kronos est stochastique).
+
+## Findings clés
+
+1. **Kronos est stochastique → C893-L ne s'applique pas.** Contrairement à Chronos-Bolt (déterministe, `std_edge=0`), Kronos échantillonne autorégressivement → `std_edge > 0` partout (0.0086 à 0.0502). Le gate multi-seed est donc un **vrai test** pour Kronos, pas un artefact dégénéré. Les 2 « BEATS » dégénérés de Chronos (TLT h22, SPY h66) n'ont pas d'équivalent Kronos.
+
+2. **Négatif uniforme (9/9), plus propre que Chronos.** Chronos avait 2 edges positifs dégénérés (artefact harnais). Kronos : 9/9 négatifs, 0 config avec ≥3/5 seeds positifs (max 2/5 sur SPY h22), DirAcc sous majority partout. La variance cross-seed, loin de révéler un signal caché, confirme le **bruit** : aucun edge positif consistant.
+
+3. **Aucune configuration ne bat majority-class de façon robuste.** Barre pleine #8607 (≥2σ cross-seed ET ≥3/4 seeds positifs ET bat majority) : non satisfaite sur les 9 configs. NO BEATS.
+
+4. **Le coût tx achève l'edge résiduel.** Tous les edges (< 0, et même les DirAcc autour de 0.50) sont consommés par les 10 bps par rebalancement. La prévision de direction zero-shot n'a pas la précision pour couvrir le turnover sur cet univers liquide (ETF).
+
+## Implication pour #8607 / #1409
+
+Un **2e** paradigme foundation-model zero-shot (K-lines OHLCV, cette fois) **ne bat pas majority-class** sur le panier — rejoignant Chronos-Bolt (langage des TS). **Deux foundation-models, deux échecs.** Cela **renforce** la conclusion centrale de l'Epic #1409 : l'alpha sur cet univers provient de **politiques d'action apprises** (L4 Decision Transformer), **pas** d'overlays *trend*, de *sizing* régime-conditionnel, **ni de prévision foundation-model zero-shot** — qu'elle vienne du « langage des séries temporelles » (Chronos) ou de K-lines OHLCV multi-actifs (Kronos).
+
+Quatre paradigmes testés désormais (L1-L6 + 2 foundation rungs), un seul BEATS (action-based).
+
+## Comparaison honnête au M15 LSTM (KEEPER Gate V2)
+
+Comme pour Chronos, la comparaison *foundation-zero-shot* vs *M15-fine-tuned* n'est **pas apples-to-apples** : univers disjoints (ETF vs crypto), cibles disjointes (direction vs log-RV), horizons disjoints (h=22-132 vs h=1-10), entraînement disjoint (zero-shot vs fine-tuned). Le verdict « Kronos bat-il le LSTM spécialisé ? » exige un terrain commun — out-of-scope ce cycle.
+
+## Résiduel
+
+- **M15 sur terrain commun** (ETF-direction-long-horizon) : fine-tuner M15 sur le même univers+cible+horizon — out-of-scope, multi-cycle.
+- **t-stat cross-fenêtre propre** : le gate actuel utilise std cross-seed (significatif pour Kronos), mais un t-stat cross-fenêtre formaliserait la significativité OOS — non codé ce cycle.
+- **Kronos-large** (499M) : non open-source, inaccessible.
+
+## Références
+
+- Kronos : Liu et al., AAAI 2026 — « Kronos : A learned K-line codec tokenizer for financial time-series forecasting » (shiyu-coder/Kronos, NeoQuasar HF mirrors).
+- Chronos-Bolt (1er rung) : [`docs/foundation_chronos_zeroshot.md`](foundation_chronos_zeroshot.md).
+- M15 LSTM (KEEPER Gate V2) : [`docs/M15_LSTM_RV.md`](M15_LSTM_RV.md).
+- L4 Decision Transformer (seul BEATS du ladder) : [`docs/L4_decision_transformer.md`](L4_decision_transformer.md).
+- Spin-out : issue #8607. Epic parent parqué : #1409.

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/eval_chronos_bolt.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/eval_chronos_bolt.py
@@ -48,7 +48,23 @@ from eval_kronos_zeroshot import (
     compute_majority_baseline,
     compute_transaction_cost,
     evaluate_window,
+    load_ohlcv,
 )
+
+
+def _prices_to_ohlcv(prices: pd.Series) -> pd.DataFrame:
+    """Wrap a close-price Series into a minimal OHLCV DataFrame.
+
+    The shared window builder operates on OHLCV frames (Kronos is multivariate).
+    Chronos is univariate but conforms to the same contract so both rungs build
+    identically-constructed windows (single source of truth for the comparison).
+    """
+    close = prices.rename("close").to_frame()
+    close["open"] = close["close"]
+    close["high"] = close["close"]
+    close["low"] = close["close"]
+    close["volume"] = 0.0
+    return close[["open", "high", "low", "close", "volume"]]
 
 CHRONOS_MODEL_IDS = {
     "small": "amazon/chronos-bolt-small",
@@ -86,16 +102,20 @@ class ChronosBoltWrapper:
         self.model_id = model_id
 
     def predict(
-        self, context: np.ndarray, pred_len: int = 24
+        self,
+        context_ohlcv,
+        x_timestamp=None,
+        y_timestamp=None,
+        pred_len: int = 24,
+        seed=None,
     ) -> np.ndarray:
         """Generate zero-shot forecast via Chronos-Bolt.
 
-        Parameters
-        ----------
-        context : np.ndarray, shape (seq_len,)
-            Historical time series values.
-        pred_len : int
-            Number of future steps to predict.
+        Chronos is univariate: it consumes the ``close`` column of the OHLCV
+        frame (the shared window contract). ``x_timestamp``/``y_timestamp``/
+        ``seed`` are accepted to match the Kronos wrapper signature (shared
+        ``evaluate_window``) but ignored -- Chronos-Bolt is deterministic and
+        timestamp-agnostic. A raw close array is also accepted (unit tests).
 
         Returns
         -------
@@ -103,6 +123,11 @@ class ChronosBoltWrapper:
             Median forecast values.
         """
         import torch
+
+        if hasattr(context_ohlcv, "iloc"):
+            context = np.asarray(context_ohlcv["close"], dtype=float)
+        else:
+            context = np.asarray(context_ohlcv, dtype=float)
 
         tensor = torch.tensor(context, dtype=torch.float32).unsqueeze(0)
         samples = self.pipeline.predict(tensor, prediction_length=pred_len)
@@ -120,8 +145,17 @@ class NaiveChronosWrapper:
         self.model_id = model_id
 
     def predict(
-        self, context: np.ndarray, pred_len: int = 24
+        self,
+        context_ohlcv,
+        x_timestamp=None,
+        y_timestamp=None,
+        pred_len: int = 24,
+        seed=None,
     ) -> np.ndarray:
+        if hasattr(context_ohlcv, "iloc"):
+            context = np.asarray(context_ohlcv["close"], dtype=float)
+        else:
+            context = np.asarray(context_ohlcv, dtype=float)
         last_val = context[-1] if context.ndim == 1 else context[-1, 0]
         return np.full(pred_len, last_val)
 
@@ -147,16 +181,20 @@ def run_evaluation(args: argparse.Namespace) -> dict:
         symbol = "SYNTHETIC"
     else:
         data_path = Path(args.data_dir)
-        prices_df = load_data(data_path, symbol=args.symbol)
-        prices = prices_df["Close"]
+        ohlcv_df = load_ohlcv(data_path, symbol=args.symbol)
+        prices = ohlcv_df["close"]
         symbol = args.symbol
 
     print(f"Data: {symbol}, {len(prices)} points")
     baseline = compute_majority_baseline(np.asarray(prices.pct_change().dropna().values))
     print(f"  Majority baseline: {baseline['majority_class_accuracy']:.4f}")
 
+    # Shared OHLCV window builder (single source of truth with the Kronos rung).
+    # build_evaluation_windows needs an OHLCV frame; in dry-run we wrap the
+    # synthetic close Series into one.
+    ohlcv_windows_df = ohlcv_df if not args.dry_run else _prices_to_ohlcv(prices)
     windows = build_evaluation_windows(
-        prices, seq_len=args.seq_len, pred_len=args.pred_len, n_windows=args.n_windows
+        ohlcv_windows_df, seq_len=args.seq_len, pred_len=args.pred_len, n_windows=args.n_windows
     )
     print(f"  Evaluation windows: {len(windows)}")
 
@@ -249,13 +287,17 @@ def run_walk_forward(args: argparse.Namespace) -> dict:
         if split_point + args.seq_len >= eval_end:
             continue
 
-        ctx = prices.iloc[split_point - args.seq_len : split_point].values
+        ctx_series = prices.iloc[split_point - args.seq_len : split_point]
         actual = prices.iloc[split_point : eval_end].values
         actual_rets = returns[split_point : eval_end - 1]
 
+        # Conform to the shared OHLCV window contract (single source of truth
+        # with the Kronos rung); Chronos extracts its close column internally.
         window = {
-            "context": ctx,
-            "actual_prices": actual,
+            "context_ohlcv": _prices_to_ohlcv(ctx_series),
+            "x_timestamp": pd.Series(ctx_series.index),
+            "y_timestamp": pd.Series(prices.index[split_point:eval_end]),
+            "actual_close": actual,
             "actual_returns": actual_rets,
             "start_date": str(prices.index[split_point - args.seq_len]),
             "end_date": str(prices.index[min(eval_end - 1, n - 1)]),
@@ -334,16 +376,17 @@ def run_multi_seed(args: argparse.Namespace) -> dict:
             prices = pd.Series(
                 np.cumsum(np.random.randn(n_points) * 0.01 + 100), index=dates
             )
+            ohlcv_df = _prices_to_ohlcv(prices)
         else:
             data_path = Path(args.data_dir)
-            prices_df = load_data(data_path, symbol=symbol)
-            prices = prices_df["Close"]
+            ohlcv_df = load_ohlcv(data_path, symbol=symbol)
+            prices = ohlcv_df["close"]
 
         baseline = compute_majority_baseline(
             np.asarray(prices.pct_change().dropna().values)
         )
         windows = build_evaluation_windows(
-            prices, seq_len=args.seq_len, pred_len=args.pred_len, n_windows=args.n_windows
+            ohlcv_df, seq_len=args.seq_len, pred_len=args.pred_len, n_windows=args.n_windows
         )
 
         window_metrics = []

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/eval_kronos_zeroshot.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/eval_kronos_zeroshot.py
@@ -1,40 +1,63 @@
 """
 Stage 5: Kronos zero-shot evaluation for financial time-series forecasting.
 
-Evaluates Kronos foundation model (shiyu-coder/Kronos, AAAI 2026, MIT) in
-zero-shot mode on financial data. Kronos is pre-trained on 12B K-lines (OHLCV)
-across multiple asset classes, enabling direct forecasting without task-specific
-fine-tuning.
+Evaluates the Kronos foundation model (shiyu-coder/Kronos, AAAI 2026, MIT) in
+zero-shot mode on the anti-bias basket. Kronos is pre-trained on 12B K-lines
+(OHLCV) across multiple asset classes, enabling direct forecasting without
+task-specific fine-tuning. This is the **second foundation-model rung** of the
+#8607 spin-out (the first being Chronos-Bolt, c.893, See #8610).
 
-Four model sizes: Small (~4M), Base (~50M), Large (~200M), XL (~499M params).
-Checkpoints available on HuggingFace.
+Unlike Chronos-Bolt (deterministic decoder, std_edge=0 across seeds per C893-L),
+Kronos forecasts are produced by **autoregressive sampling** (temperature T,
+top-p, sample_count). The forward pass is therefore **stochastic**, so the
+multi-seed gate is *meaningful* here: cross-seed variance measures forecast
+dispersion rather than collapsing to zero. This is the structural difference
+that makes Kronos a genuinely distinct rung from Chronos.
+
+Open-source sizes (HuggingFace, ``NeoQuasar/Kronos-*``): mini (~4.1M), small
+(~24.7M), base (~102.3M). Kronos-large (~499M) is NOT open-source and is
+excluded. We default to ``base`` (largest open checkpoint) for a fair comparison
+with Chronos-Bolt-base (~200M, the closest available size).
+
+NOTE on the API: Kronos is distributed as a source repo (no PyPI wheel). The
+harness clones ``github.com/shiyu-coder/Kronos`` to a local cache (or reuses
+``--kronos-repo``) and imports ``from model import Kronos, KronosTokenizer,
+KronosPredictor``. Inference takes an OHLCV pandas DataFrame plus
+``x_timestamp`` / ``y_timestamp`` and ``pred_len``, returning a forecast
+DataFrame (we extract the ``close`` column for direction/Sharpe metrics).
 
 Anti-pattern safeguards (cf. feedback_ml_trading_pitfalls.md):
 - Walk-forward evaluation (no shuffle, temporal split honored)
 - Majority-class baseline computed and reported (must beat to claim edge)
-- Transaction costs deducted from Sharpe computation
+- Transaction costs deducted from the strategy returns
 - Edge-over-majority reported explicitly
 
 Usage:
-    # Dry-run (CPU, synthetic data, 2 windows)
+    # Dry-run (CPU, synthetic data, NaiveKronosWrapper)
     python eval_kronos_zeroshot.py --dry-run
 
-    # Evaluate on SPY with walk-forward
-    python eval_kronos_zeroshot.py --data-dir ../datasets/yfinance \\
-        --symbol SPY --walk-forward --n-splits 5
+    # Multi-seed on SPY at h~22
+    python eval_kronos_zeroshot.py --symbol SPY --pred-len 24 \\
+        --seeds 0,1,7,42,99 --device cuda
 
-    # Evaluate on BTC anti-bias data
-    python eval_kronos_zeroshot.py --data-dir ../datasets/crypto \\
-        --symbol BTC_USD --seq-len 96 --pred-len 24
+    # Full panier sweep (SPY/TLT/GLD x h=22/66/132 x 5 seeds)
+    python eval_kronos_zeroshot.py --mode sweep \\
+        --symbols SPY,TLT,GLD --pred-lens 24,66,132 \\
+        --seeds 0,1,7,42,99 --device cuda \\
+        --output-dir results/kronos_zeroshot
 
 Output:
-    results.json with metrics per window, regime breakdown, majority-class comparison
+    results.json with per-config (symbol x horizon) edge, std_edge, beats_valid,
+    majority baseline and transaction costs, plus a top-level ``sweep`` list
+    mirroring the Chronos results.json layout for direct comparison.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import os
+import subprocess
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -48,12 +71,19 @@ from baselines import sharpe_from_returns
 from data_utils import load_data
 
 
+KRONOS_REPO_URL = "https://github.com/shiyu-coder/Kronos.git"
+KRONOS_REPO_DEFAULT = Path(
+    os.environ.get("KRONOS_REPO", "C:/dev/_kronos_src")
+)
+
+# Real HuggingFace checkpoints (NeoQuasar mirrors). Kronos-large is not
+# open-source and is intentionally absent.
 KRONOS_MODEL_IDS = {
-    "small": "shiyu-coder/Kronos-Small",
-    "base": "shiyu-coder/Kronos-Base",
-    "large": "shiyu-coder/Kronos-Large",
-    "xl": "shiyu-coder/Kronos-XL",
+    "mini": "NeoQuasar/Kronos-mini",
+    "small": "NeoQuasar/Kronos-small",
+    "base": "NeoQuasar/Kronos-base",
 }
+KRONOS_TOKENIZER_ID = "NeoQuasar/Kronos-Tokenizer-base"
 
 
 def compute_direction_accuracy(y_true: np.ndarray, y_pred: np.ndarray) -> float:
@@ -76,7 +106,6 @@ def compute_majority_baseline(returns: np.ndarray) -> dict:
     }
 
 
-
 def compute_transaction_cost(
     predictions: np.ndarray, cost_bps: float = 10.0
 ) -> float:
@@ -87,61 +116,115 @@ def compute_transaction_cost(
     return trades * cost_bps / 10000.0
 
 
-def load_kronos_model(
-    model_size: str = "small", device: str = "auto"
-) -> "KronosWrapper":
-    """Load Kronos model from HuggingFace.
+def ensure_kronos_repo(repo_path: Path) -> Path:
+    """Clone the Kronos source repo if not already present.
 
-    Gracefully handles missing `kronos` package by returning a mock
-    wrapper that generates naive forecasts (for dry-run / CI testing).
+    Kronos has no PyPI wheel; its ``model`` package must be on sys.path. We
+    shallow-clone the official repo to a local cache (idempotent). Override
+    the location with --kronos-repo or the KRONOS_REPO env var.
     """
-    model_id = KRONOS_MODEL_IDS.get(model_size, KRONOS_MODEL_IDS["small"])
-    try:
-        from kronos import KronosPipeline
+    repo_path = Path(repo_path)
+    if (repo_path / "model" / "__init__.py").exists():
+        return repo_path
+    repo_path.parent.mkdir(parents=True, exist_ok=True)
+    print(f"[ensure_kronos_repo] cloning {KRONOS_REPO_URL} -> {repo_path}")
+    subprocess.run(
+        ["git", "clone", "--depth", "1", KRONOS_REPO_URL, str(repo_path)],
+        check=True,
+    )
+    return repo_path
 
-        pipeline = KronosPipeline.from_pretrained(model_id, device_map=device)
-        return KronosWrapper(pipeline, model_id=model_id)
-    except ImportError:
+
+def load_kronos_model(
+    model_size: str = "base",
+    device: str = "auto",
+    kronos_repo: Path | None = None,
+):
+    """Load the real Kronos predictor from the source repo.
+
+    Returns a ``KronosWrapper`` when the repo + deps are available. Falls back
+    to ``NaiveKronosWrapper`` only when the package/deps are missing (dry-run /
+    CI). The ``is_mock`` flag makes a mock result unambiguous, so a committed
+    real result MUST carry ``is_mock=False`` (sota-not-workaround Prong A: the
+    naive fallback is never a substitute for a committed SOTA result).
+    """
+    model_id = KRONOS_MODEL_IDS.get(model_size, KRONOS_MODEL_IDS["base"])
+    try:
+        repo = ensure_kronos_repo(kronos_repo or KRONOS_REPO_DEFAULT)
+        repo_str = str(repo.resolve())
+        if repo_str not in sys.path:
+            sys.path.insert(0, repo_str)
+        from model import Kronos, KronosPredictor, KronosTokenizer
+
+        tokenizer = KronosTokenizer.from_pretrained(KRONOS_TOKENIZER_ID)
+        model = Kronos.from_pretrained(model_id)
+        if device and device != "auto":
+            try:
+                model = model.to(device)
+            except Exception:
+                pass  # device placement is best-effort; predictor handles it
+        predictor = KronosPredictor(model, tokenizer, max_context=512)
+        return KronosWrapper(predictor, model_id=model_id)
+    except Exception as exc:
         print(
-            "[WARN] kronos package not installed. Using naive forecast wrapper. "
-            "Install with: pip install kronos-forecasting"
+            f"[WARN] real Kronos unavailable ({type(exc).__name__}: {exc}); "
+            "falling back to NaiveKronosWrapper (mock). Install the Kronos "
+            "source repo + torch/einops/safetensors for real evaluation."
         )
         return NaiveKronosWrapper(model_id=model_id)
 
 
 class KronosWrapper:
-    """Wrapper for Kronos foundation model inference."""
+    """Wrapper around the real KronosPredictor (OHLCV DataFrame I/O)."""
 
-    def __init__(self, pipeline, model_id: str = ""):
-        self.pipeline = pipeline
+    def __init__(self, predictor, model_id: str = ""):
+        self.predictor = predictor
         self.model_id = model_id
 
     def predict(
-        self, context: np.ndarray, pred_len: int = 24
+        self,
+        context_ohlcv: pd.DataFrame,
+        x_timestamp,
+        y_timestamp,
+        pred_len: int = 24,
+        seed: int | None = None,
     ) -> np.ndarray:
-        """Generate zero-shot forecast.
+        """Generate a zero-shot close-price forecast.
 
         Parameters
         ----------
-        context : np.ndarray, shape (seq_len,) or (seq_len, n_vars)
-            Historical time series values.
-        pred_len : int
-            Number of future steps to predict.
+        context_ohlcv : DataFrame with lowercase open/high/low/close[/volume]
+            columns, length == lookback (<=512).
+        x_timestamp, y_timestamp : DatetimeIndex / Series aligned to the
+            context and the forecast horizon (required by KronosPredictor).
+        pred_len : forecast horizon length.
+        seed : if set, seeds torch + numpy before the sampling forward pass
+            (Kronos samples autoregressively, so the seed materially changes
+            the forecast -- unlike deterministic Chronos-Bolt).
 
         Returns
         -------
-        np.ndarray, shape (pred_len,)
-            Median forecast values.
+        np.ndarray, shape (pred_len,) -- forecast close prices.
         """
         import torch
 
-        if context.ndim == 1:
-            tensor = torch.tensor(context, dtype=torch.float32).unsqueeze(0)
-        else:
-            tensor = torch.tensor(context, dtype=torch.float32).T
+        if seed is not None:
+            torch.manual_seed(seed)
+            np.random.seed(seed)
 
-        samples = self.pipeline.predict(tensor, prediction_length=pred_len)
-        return samples.median(dim=1).values.squeeze().numpy()
+        pred_df = self.predictor.predict(
+            df=context_ohlcv,
+            x_timestamp=x_timestamp,
+            y_timestamp=y_timestamp,
+            pred_len=pred_len,
+            T=1.0,
+            top_p=0.9,
+            sample_count=1,
+            verbose=False,
+        )
+        # pred_df is a DataFrame with a 'close' column (forecast OHLCV)
+        close = np.asarray(pred_df["close"].values, dtype=float)
+        return close[:pred_len]
 
     @property
     def is_mock(self) -> bool:
@@ -149,22 +232,21 @@ class KronosWrapper:
 
 
 class NaiveKronosWrapper:
-    """Naive forecast wrapper when Kronos is not installed.
-
-    Uses last-value persistence as baseline. Useful for dry-run / CI.
-    """
+    """Last-value persistence baseline. Dry-run / CI only (mock)."""
 
     def __init__(self, model_id: str = ""):
         self.model_id = model_id
 
     def predict(
-        self, context: np.ndarray, pred_len: int = 24
+        self,
+        context_ohlcv: pd.DataFrame,
+        x_timestamp=None,
+        y_timestamp=None,
+        pred_len: int = 24,
+        seed: int | None = None,
     ) -> np.ndarray:
-        if context.ndim == 1:
-            last_val = context[-1]
-        else:
-            last_val = context[-1, 0]
-        return np.full(pred_len, last_val)
+        last_close = float(context_ohlcv["close"].iloc[-1])
+        return np.full(pred_len, last_close, dtype=float)
 
     @property
     def is_mock(self) -> bool:
@@ -172,26 +254,26 @@ class NaiveKronosWrapper:
 
 
 def build_evaluation_windows(
-    prices: pd.Series,
+    ohlcv_df: pd.DataFrame,
     seq_len: int = 96,
     pred_len: int = 24,
     n_windows: int = 5,
 ) -> list[dict]:
-    """Build walk-forward evaluation windows from price series.
+    """Build walk-forward evaluation windows from the OHLCV frame.
 
-    Each window contains:
-    - context: past seq_len prices
-    - actual: next pred_len prices
-    - actual_returns: next pred_len returns
+    Each window carries the Kronos inputs (OHLCV context + x_timestamp +
+    y_timestamp) and the ground truth (actual close prices / returns) used to
+    score direction accuracy and Sharpe.
     """
-    returns = prices.pct_change().dropna()
-    windows = []
+    close = ohlcv_df["close"]
+    returns = close.pct_change().dropna()
 
     total_len = seq_len + pred_len
     if len(returns) < total_len + n_windows:
         n_windows = max(1, (len(returns) - total_len) // pred_len)
 
-    start_idx = len(returns) - total_len
+    windows = []
+    start_idx = len(close) - total_len
     for i in range(n_windows):
         ctx_start = start_idx - i * pred_len
         if ctx_start < 0:
@@ -199,17 +281,26 @@ def build_evaluation_windows(
         ctx_end = ctx_start + seq_len
         actual_end = ctx_end + pred_len
 
-        ctx_prices = prices.iloc[ctx_start:ctx_end].values
-        actual_prices = prices.iloc[ctx_end:actual_end].values
-        actual_rets = returns.iloc[ctx_end:actual_end].values
+        ctx_ohlcv = ohlcv_df.iloc[ctx_start:ctx_end]
+        actual_close = close.iloc[ctx_end:actual_end].values
+        actual_rets = returns.iloc[
+            ctx_end - 1 : actual_end - 1
+        ].values  # align returns with forecast returns
+
+        # Kronos calc_time_stamps expects a Series (uses .dt accessor), not a
+        # DatetimeIndex, so wrap the index slices.
+        x_ts = pd.Series(ohlcv_df.index[ctx_start:ctx_end])
+        y_ts = pd.Series(ohlcv_df.index[ctx_end:actual_end])
 
         windows.append(
             {
-                "context": ctx_prices,
-                "actual_prices": actual_prices,
+                "context_ohlcv": ctx_ohlcv,
+                "x_timestamp": x_ts,
+                "y_timestamp": y_ts,
+                "actual_close": actual_close,
                 "actual_returns": actual_rets,
-                "start_date": str(prices.index[ctx_start]),
-                "end_date": str(prices.index[min(actual_end - 1, len(prices) - 1)]),
+                "start_date": str(ohlcv_df.index[ctx_start]),
+                "end_date": str(ohlcv_df.index[min(actual_end - 1, len(close) - 1)]),
             }
         )
 
@@ -217,31 +308,36 @@ def build_evaluation_windows(
 
 
 def evaluate_window(
-    model: KronosWrapper | NaiveKronosWrapper,
+    model,
     window: dict,
     pred_len: int = 24,
     cost_bps: float = 10.0,
+    seed: int | None = None,
 ) -> dict:
-    """Evaluate model on a single window."""
-    context = window["context"]
-    actual_prices = window["actual_prices"]
+    """Evaluate model on a single window (direction + Sharpe after costs)."""
+    context_ohlcv = window["context_ohlcv"]
+    actual_close = window["actual_close"]
     actual_returns = window["actual_returns"]
 
-    forecast = model.predict(context, pred_len=pred_len)
+    forecast = model.predict(
+        context_ohlcv,
+        x_timestamp=window["x_timestamp"],
+        y_timestamp=window["y_timestamp"],
+        pred_len=pred_len,
+        seed=seed,
+    )
 
     forecast_returns = np.diff(forecast) / forecast[:-1]
-    actual_pred_returns = actual_returns[: len(forecast_returns)]
-
-    min_len = min(len(forecast_returns), len(actual_pred_returns))
+    min_len = min(len(forecast_returns), len(actual_returns))
     forecast_returns = forecast_returns[:min_len]
-    actual_pred_returns = actual_pred_returns[:min_len]
+    actual_pred_returns = actual_returns[:min_len]
 
     dir_acc = compute_direction_accuracy(actual_pred_returns, forecast_returns)
-    mse = float(np.mean((actual_prices[:pred_len] - forecast[:pred_len]) ** 2))
+    mse = float(np.mean((actual_close[: len(forecast)] - forecast) ** 2))
 
     strategy_returns = np.sign(forecast_returns) * actual_pred_returns
     tcost = compute_transaction_cost(forecast_returns, cost_bps=cost_bps)
-    net_returns = strategy_returns - tcost / len(strategy_returns)
+    net_returns = strategy_returns - tcost / max(len(strategy_returns), 1)
     sharpe = sharpe_from_returns(net_returns)
 
     return {
@@ -252,87 +348,135 @@ def evaluate_window(
         "n_trades": int(np.sum(np.diff(np.sign(forecast_returns)) != 0)),
         "transaction_cost_bps": tcost * 10000,
         "forecast_mean": float(np.mean(forecast)),
-        "actual_mean": float(np.mean(actual_prices)),
+        "actual_mean": float(np.mean(actual_close)),
     }
 
 
-def run_evaluation(args: argparse.Namespace) -> dict:
-    """Run full zero-shot evaluation."""
-    print(f"Loading Kronos model ({args.model_size})...")
-    device = "cpu" if args.dry_run else "auto"
-    model = load_kronos_model(args.model_size, device=device)
-    print(f"  Model: {model.model_id} (mock={model.is_mock})")
+def load_ohlcv(data_dir: Path, symbol: str) -> pd.DataFrame:
+    """Load OHLCV and lowercase columns for Kronos (open/high/low/close/volume)."""
+    df = load_data(data_dir, symbol=symbol)
+    rename = {c: c.lower() for c in df.columns}
+    df = df.rename(columns=rename)
+    # Kronos requires open/high/low/close; volume optional (zero-filled inside)
+    needed = ["open", "high", "low", "close"]
+    missing = [c for c in needed if c not in df.columns]
+    if missing:
+        raise ValueError(f"{symbol}: missing OHLCV columns {missing}")
+    if "volume" not in df.columns:
+        df["volume"] = 0.0
+    return df[["open", "high", "low", "close", "volume"]]
 
-    if args.dry_run:
-        np.random.seed(42)
-        n_points = args.seq_len + args.pred_len + args.n_windows * args.pred_len
-        dates = pd.date_range("2020-01-01", periods=n_points, freq="B")
-        prices = pd.Series(
-            np.cumsum(np.random.randn(n_points) * 0.01 + 100), index=dates
-        )
-        symbol = "SYNTHETIC"
-    else:
-        data_path = Path(args.data_dir)
-        prices_df = load_data(data_path, symbol=args.symbol)
-        prices = prices_df["Close"]
-        symbol = args.symbol
 
-    print(f"Data: {symbol}, {len(prices)} points")
-    baseline = compute_majority_baseline(prices.pct_change().dropna().values)
-    print(f"  Majority baseline: {baseline['majority_class_accuracy']:.4f}")
+def run_multi_seed(args: argparse.Namespace, ohlcv_df=None, symbol=None) -> dict:
+    """Multi-seed walk-forward validation (>=4 seeds).
+
+    Kronos forward passes are stochastic (autoregressive sampling), so the
+    cross-seed std is a genuine dispersion measure here -- NOT degenerate like
+    Chronos-Bolt (C893-L). The BEATS gate (edge>0, mean_edge>=2*std, >=4 seeds)
+    is therefore a real test rather than a collapsed artefact.
+    """
+    seeds = [int(s) for s in args.seeds.split(",")]
+    symbol = symbol or args.symbol
+    if ohlcv_df is None:
+        ohlcv_df = load_ohlcv(Path(args.data_dir), symbol=symbol)
+
+    close = ohlcv_df["close"]
+    baseline = compute_majority_baseline(close.pct_change().dropna().values)
 
     windows = build_evaluation_windows(
-        prices, seq_len=args.seq_len, pred_len=args.pred_len, n_windows=args.n_windows
+        ohlcv_df, seq_len=args.seq_len, pred_len=args.pred_len, n_windows=args.n_windows
     )
-    print(f"  Evaluation windows: {len(windows)}")
 
-    results_per_window = []
-    for i, window in enumerate(windows):
-        metrics = evaluate_window(
-            model, window, pred_len=args.pred_len, cost_bps=args.cost_bps
-        )
-        metrics["window"] = i
-        metrics["start"] = window["start_date"]
-        metrics["end"] = window["end_date"]
-        results_per_window.append(metrics)
+    seed_results = []
+    for seed in seeds:
+        window_metrics = []
+        for window in windows:
+            m = evaluate_window(
+                args._model, window, pred_len=args.pred_len,
+                cost_bps=args.cost_bps, seed=seed,
+            )
+            window_metrics.append(m)
+        avg_dir_acc = float(np.mean([m["direction_accuracy"] for m in window_metrics]))
+        edge = avg_dir_acc - baseline["majority_class_accuracy"]
+        seed_results.append({
+            "seed": seed,
+            "avg_direction_accuracy": avg_dir_acc,
+            "majority_baseline": baseline["majority_class_accuracy"],
+            "edge_vs_majority": float(edge),
+            "avg_sharpe": float(np.mean([m["sharpe"] for m in window_metrics])),
+        })
+        verdict = "BEATS" if edge > 0 else "FAILS"
         print(
-            f"  Window {i}: DirAcc={metrics['direction_accuracy']:.4f}, "
-            f"MSE={metrics['mse']:.6f}, Sharpe={metrics['sharpe']:.3f}"
+            f"  [{symbol} h={args.pred_len}] seed {seed}: "
+            f"DirAcc={avg_dir_acc:.4f} Edge={edge:+.4f} [{verdict}]"
         )
 
-    avg_dir_acc = np.mean([r["direction_accuracy"] for r in results_per_window])
-    avg_sharpe = np.mean([r["sharpe"] for r in results_per_window])
-    edge_vs_majority = avg_dir_acc - baseline["majority_class_accuracy"]
+    edges = np.array([r["edge_vs_majority"] for r in seed_results])
+    mean_edge = float(np.mean(edges))
+    std_edge = float(np.std(edges))
+    n_beats = int(np.sum(edges > 0))
+    beats_valid = len(seeds) >= 4 and mean_edge > 0 and (
+        std_edge < 1e-10 or mean_edge >= 2 * std_edge
+    )
 
-    summary = {
-        "model": model.model_id,
-        "is_mock": model.is_mock,
+    return {
+        "model": args._model.model_id,
+        "is_mock": args._model.is_mock,
         "symbol": symbol,
-        "seq_len": args.seq_len,
         "pred_len": args.pred_len,
-        "n_windows": len(windows),
-        "avg_direction_accuracy": float(avg_dir_acc),
-        "avg_sharpe": float(avg_sharpe),
+        "evaluation_type": "multi_seed",
+        "seeds": seeds,
+        "n_beats": n_beats,
+        "n_seeds": len(seeds),
+        "mean_edge": mean_edge,
+        "std_edge": std_edge,
+        "beats_valid": beats_valid,
         "majority_baseline": baseline,
-        "edge_vs_majority": float(edge_vs_majority),
-        "windows": results_per_window,
+        "seed_results": seed_results,
         "timestamp": datetime.now().isoformat(),
     }
 
-    print(f"\n=== Results ===")
-    print(f"  Avg DirAcc: {avg_dir_acc:.4f}")
-    print(f"  Majority:   {baseline['majority_class_accuracy']:.4f}")
-    print(f"  Edge:       {edge_vs_majority:+.4f}")
-    print(f"  Avg Sharpe: {avg_sharpe:.3f}")
 
-    if args.output_dir:
-        out_path = Path(args.output_dir)
-        out_path.mkdir(parents=True, exist_ok=True)
-        out_file = out_path / f"kronos_zeroshot_{symbol}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
-        with open(out_file, "w") as f:
-            json.dump(summary, f, indent=2)
-        print(f"  Saved to: {out_file}")
+def run_sweep(args: argparse.Namespace) -> dict:
+    """Sweep symbols x horizons x seeds, consolidating into one results.json.
 
+    Layout mirrors eval_chronos_bolt results.json (top-level metadata + a
+    ``sweep`` list of per-config dicts) so the two foundation-model rungs can
+    be compared directly in the verdict doc.
+    """
+    symbols = [s.strip() for s in args.symbols.split(",")]
+    pred_lens = [int(p) for p in args.pred_lens.split(",")]
+
+    sweep = []
+    for symbol in symbols:
+        try:
+            ohlcv_df = load_ohlcv(Path(args.data_dir), symbol=symbol)
+        except Exception as exc:
+            print(f"[WARN] {symbol}: data load failed ({exc}), skipping")
+            continue
+        print(f"\n=== {symbol} ({len(ohlcv_df)} bars) ===")
+        for pred_len in pred_lens:
+            args.pred_len = pred_len
+            res = run_multi_seed(args, ohlcv_df=ohlcv_df, symbol=symbol)
+            sweep.append(res)
+            print(
+                f"  -> {symbol} h={pred_len}: mean_edge={res['mean_edge']:+.4f} "
+                f"std={res['std_edge']:.4f} beats_valid={res['beats_valid']}"
+            )
+
+    summary = {
+        "model": args._model.model_id,
+        "is_mock": args._model.is_mock,
+        "mode": "sweep",
+        "seeds": [int(s) for s in args.seeds.split(",")],
+        "n_seeds": len([int(s) for s in args.seeds.split(",")]),
+        "cost_bps": args.cost_bps,
+        "walk_forward_windows": args.n_windows,
+        "seq_len": args.seq_len,
+        "device": args.device,
+        "sweep": sweep,
+        "timestamp": datetime.now().isoformat(),
+    }
     return summary
 
 
@@ -340,20 +484,63 @@ def main():
     parser = argparse.ArgumentParser(
         description="Kronos zero-shot evaluation on financial time series"
     )
-    parser.add_argument("--dry-run", action="store_true", help="CPU-only with synthetic data")
+    parser.add_argument("--mode", default="multiseed",
+                        choices=["dry-run", "multiseed", "sweep"])
     parser.add_argument("--data-dir", default="../datasets/yfinance", type=str)
     parser.add_argument("--symbol", default="SPY", type=str)
-    parser.add_argument("--model-size", default="small", type=str,
+    parser.add_argument("--symbols", default="SPY,TLT,GLD", type=str,
+                        help="Comma-separated symbols for --mode sweep")
+    parser.add_argument("--model-size", default="base", type=str,
                         choices=list(KRONOS_MODEL_IDS.keys()))
+    parser.add_argument("--kronos-repo", default=str(KRONOS_REPO_DEFAULT), type=str)
     parser.add_argument("--seq-len", default=96, type=int)
     parser.add_argument("--pred-len", default=24, type=int)
+    parser.add_argument("--pred-lens", default="24,66,132", type=str,
+                        help="Comma-separated horizons for --mode sweep")
     parser.add_argument("--n-windows", default=5, type=int)
-    parser.add_argument("--cost-bps", default=10.0, type=float,
-                        help="Transaction cost in basis points per trade")
+    parser.add_argument("--seeds", default="0,1,7,42,99", type=str)
+    parser.add_argument("--cost-bps", default=10.0, type=float)
+    parser.add_argument("--device", default="auto", type=str)
     parser.add_argument("--output-dir", default=None, type=str)
     args = parser.parse_args()
 
-    run_evaluation(args)
+    if args.mode == "dry-run":
+        args._model = NaiveKronosWrapper(model_id="naive:last-value")
+        # synthetic close series for the dry-run smoke
+        n_points = args.seq_len + args.pred_len + args.n_windows * args.pred_len + 10
+        dates = pd.date_range("2020-01-01", periods=n_points, freq="B")
+        rng = np.random.default_rng(42)
+        ohlcv_df = pd.DataFrame(
+            {
+                "open": np.cumsum(rng.standard_normal(n_points) * 0.1 + 100),
+                "high": 0.0, "low": 0.0,
+                "close": np.cumsum(rng.standard_normal(n_points) * 0.1 + 100),
+                "volume": 0.0,
+            }, index=dates,
+        )
+        ohlcv_df["high"] = ohlcv_df[["open", "close"]].max(axis=1) + 0.5
+        ohlcv_df["low"] = ohlcv_df[["open", "close"]].min(axis=1) - 0.5
+        args.symbol = "SYNTHETIC"
+        res = run_multi_seed(args, ohlcv_df=ohlcv_df, symbol="SYNTHETIC")
+    else:
+        print(f"Loading Kronos ({args.model_size}) from {args.kronos_repo}...")
+        args._model = load_kronos_model(
+            args.model_size, device=args.device,
+            kronos_repo=Path(args.kronos_repo),
+        )
+        print(f"  Model: {args._model.model_id} (mock={args._model.is_mock})")
+        res = run_sweep(args) if args.mode == "sweep" else run_multi_seed(args)
+
+    if args.output_dir:
+        out_path = Path(args.output_dir)
+        out_path.mkdir(parents=True, exist_ok=True)
+        tag = "sweep" if args.mode == "sweep" else f"{args.symbol}_{args.pred_len}"
+        out_file = out_path / f"kronos_zeroshot_{tag}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
+        with open(out_file, "w", encoding="utf-8") as f:
+            json.dump(res, f, indent=2)
+        print(f"  Saved to: {out_file}")
+
+    print("\n=== Done ===")
 
 
 if __name__ == "__main__":

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/results/kronos_zeroshot/results.json
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/results/kronos_zeroshot/results.json
@@ -1,0 +1,587 @@
+{
+  "model": "NeoQuasar/Kronos-base",
+  "is_mock": false,
+  "mode": "sweep",
+  "seeds": [
+    0,
+    1,
+    7,
+    42,
+    99
+  ],
+  "n_seeds": 5,
+  "cost_bps": 10.0,
+  "walk_forward_windows": 5,
+  "seq_len": 96,
+  "device": "cuda",
+  "sweep": [
+    {
+      "model": "NeoQuasar/Kronos-base",
+      "is_mock": false,
+      "symbol": "SPY",
+      "pred_len": 24,
+      "evaluation_type": "multi_seed",
+      "seeds": [
+        0,
+        1,
+        7,
+        42,
+        99
+      ],
+      "n_beats": 2,
+      "n_seeds": 5,
+      "mean_edge": -0.034837259174708535,
+      "std_edge": 0.05022444896763011,
+      "beats_valid": false,
+      "majority_baseline": {
+        "majority_class_accuracy": 0.5461416070007955,
+        "pct_up": 0.5461416070007955,
+        "pct_down": 0.4514717581543357,
+        "majority_class": "up"
+      },
+      "seed_results": [
+        {
+          "seed": 0,
+          "avg_direction_accuracy": 0.41739130434782606,
+          "majority_baseline": 0.5461416070007955,
+          "edge_vs_majority": -0.12875030265296944,
+          "avg_sharpe": -2.368928481303422
+        },
+        {
+          "seed": 1,
+          "avg_direction_accuracy": 0.5478260869565218,
+          "majority_baseline": 0.5461416070007955,
+          "edge_vs_majority": 0.0016844799557262924,
+          "avg_sharpe": -0.8038877571894295
+        },
+        {
+          "seed": 7,
+          "avg_direction_accuracy": 0.5304347826086957,
+          "majority_baseline": 0.5461416070007955,
+          "edge_vs_majority": -0.015706824392099805,
+          "avg_sharpe": 0.10858185001154777
+        },
+        {
+          "seed": 42,
+          "avg_direction_accuracy": 0.5565217391304348,
+          "majority_baseline": 0.5461416070007955,
+          "edge_vs_majority": 0.010380132129639286,
+          "avg_sharpe": 1.2629753890131188
+        },
+        {
+          "seed": 99,
+          "avg_direction_accuracy": 0.5043478260869565,
+          "majority_baseline": 0.5461416070007955,
+          "edge_vs_majority": -0.04179378091383901,
+          "avg_sharpe": 0.06646676040351665
+        }
+      ],
+      "timestamp": "2026-07-27T09:34:53.642631"
+    },
+    {
+      "model": "NeoQuasar/Kronos-base",
+      "is_mock": false,
+      "symbol": "SPY",
+      "pred_len": 66,
+      "evaluation_type": "multi_seed",
+      "seeds": [
+        0,
+        1,
+        7,
+        42,
+        99
+      ],
+      "n_beats": 0,
+      "n_seeds": 5,
+      "mean_edge": -0.040295453154641656,
+      "std_edge": 0.0228273686042971,
+      "beats_valid": false,
+      "majority_baseline": {
+        "majority_class_accuracy": 0.5461416070007955,
+        "pct_up": 0.5461416070007955,
+        "pct_down": 0.4514717581543357,
+        "majority_class": "up"
+      },
+      "seed_results": [
+        {
+          "seed": 0,
+          "avg_direction_accuracy": 0.5292307692307692,
+          "majority_baseline": 0.5461416070007955,
+          "edge_vs_majority": -0.016910837770026332,
+          "avg_sharpe": -1.1161276268977154
+        },
+        {
+          "seed": 1,
+          "avg_direction_accuracy": 0.49846153846153846,
+          "majority_baseline": 0.5461416070007955,
+          "edge_vs_majority": -0.04768006853925705,
+          "avg_sharpe": 0.23256434631552395
+        },
+        {
+          "seed": 7,
+          "avg_direction_accuracy": 0.46769230769230774,
+          "majority_baseline": 0.5461416070007955,
+          "edge_vs_majority": -0.07844929930848776,
+          "avg_sharpe": -2.3903875263995196
+        },
+        {
+          "seed": 42,
+          "avg_direction_accuracy": 0.5292307692307693,
+          "majority_baseline": 0.5461416070007955,
+          "edge_vs_majority": -0.01691083777002622,
+          "avg_sharpe": -0.6654743915730259
+        },
+        {
+          "seed": 99,
+          "avg_direction_accuracy": 0.5046153846153846,
+          "majority_baseline": 0.5461416070007955,
+          "edge_vs_majority": -0.04152622238541093,
+          "avg_sharpe": 0.12117908444066576
+        }
+      ],
+      "timestamp": "2026-07-27T09:35:32.712480"
+    },
+    {
+      "model": "NeoQuasar/Kronos-base",
+      "is_mock": false,
+      "symbol": "SPY",
+      "pred_len": 132,
+      "evaluation_type": "multi_seed",
+      "seeds": [
+        0,
+        1,
+        7,
+        42,
+        99
+      ],
+      "n_beats": 0,
+      "n_seeds": 5,
+      "mean_edge": -0.04476756119926879,
+      "std_edge": 0.022963780979496976,
+      "beats_valid": false,
+      "majority_baseline": {
+        "majority_class_accuracy": 0.5461416070007955,
+        "pct_up": 0.5461416070007955,
+        "pct_down": 0.4514717581543357,
+        "majority_class": "up"
+      },
+      "seed_results": [
+        {
+          "seed": 0,
+          "avg_direction_accuracy": 0.47022900763358777,
+          "majority_baseline": 0.5461416070007955,
+          "edge_vs_majority": -0.07591259936720773,
+          "avg_sharpe": -1.0758157556938013
+        },
+        {
+          "seed": 1,
+          "avg_direction_accuracy": 0.4793893129770993,
+          "majority_baseline": 0.5461416070007955,
+          "edge_vs_majority": -0.0667522940236962,
+          "avg_sharpe": -0.8518506202197165
+        },
+        {
+          "seed": 7,
+          "avg_direction_accuracy": 0.5099236641221374,
+          "majority_baseline": 0.5461416070007955,
+          "edge_vs_majority": -0.036217942878658094,
+          "avg_sharpe": -0.7938286182664352
+        },
+        {
+          "seed": 42,
+          "avg_direction_accuracy": 0.516030534351145,
+          "majority_baseline": 0.5461416070007955,
+          "edge_vs_majority": -0.030111072649650517,
+          "avg_sharpe": -0.5605592141318709
+        },
+        {
+          "seed": 99,
+          "avg_direction_accuracy": 0.5312977099236641,
+          "majority_baseline": 0.5461416070007955,
+          "edge_vs_majority": -0.014843897077131407,
+          "avg_sharpe": 0.6902616217965253
+        }
+      ],
+      "timestamp": "2026-07-27T09:36:57.098414"
+    },
+    {
+      "model": "NeoQuasar/Kronos-base",
+      "is_mock": false,
+      "symbol": "TLT",
+      "pred_len": 24,
+      "evaluation_type": "multi_seed",
+      "seeds": [
+        0,
+        1,
+        7,
+        42,
+        99
+      ],
+      "n_beats": 1,
+      "n_seeds": 5,
+      "mean_edge": -0.0173724281130057,
+      "std_edge": 0.028576829087226068,
+      "beats_valid": false,
+      "majority_baseline": {
+        "majority_class_accuracy": 0.5130246020260492,
+        "pct_up": 0.5130246020260492,
+        "pct_down": 0.48263386396526775,
+        "majority_class": "up"
+      },
+      "seed_results": [
+        {
+          "seed": 0,
+          "avg_direction_accuracy": 0.5043478260869565,
+          "majority_baseline": 0.5130246020260492,
+          "edge_vs_majority": -0.008676775939092662,
+          "avg_sharpe": -2.575821053052681
+        },
+        {
+          "seed": 1,
+          "avg_direction_accuracy": 0.4956521739130434,
+          "majority_baseline": 0.5130246020260492,
+          "edge_vs_majority": -0.017372428113005767,
+          "avg_sharpe": -0.7113435688823391
+        },
+        {
+          "seed": 7,
+          "avg_direction_accuracy": 0.4434782608695652,
+          "majority_baseline": 0.5130246020260492,
+          "edge_vs_majority": -0.06954634115648395,
+          "avg_sharpe": -1.0566598248720394
+        },
+        {
+          "seed": 42,
+          "avg_direction_accuracy": 0.5304347826086957,
+          "majority_baseline": 0.5130246020260492,
+          "edge_vs_majority": 0.01741018058264654,
+          "avg_sharpe": -1.5861228864269443
+        },
+        {
+          "seed": 99,
+          "avg_direction_accuracy": 0.5043478260869565,
+          "majority_baseline": 0.5130246020260492,
+          "edge_vs_majority": -0.008676775939092662,
+          "avg_sharpe": -2.5019387451203485
+        }
+      ],
+      "timestamp": "2026-07-27T09:37:13.045318"
+    },
+    {
+      "model": "NeoQuasar/Kronos-base",
+      "is_mock": false,
+      "symbol": "TLT",
+      "pred_len": 66,
+      "evaluation_type": "multi_seed",
+      "seeds": [
+        0,
+        1,
+        7,
+        42,
+        99
+      ],
+      "n_beats": 0,
+      "n_seeds": 5,
+      "mean_edge": -0.020101525102972195,
+      "std_edge": 0.008571315862882558,
+      "beats_valid": false,
+      "majority_baseline": {
+        "majority_class_accuracy": 0.5130246020260492,
+        "pct_up": 0.5130246020260492,
+        "pct_down": 0.48263386396526775,
+        "majority_class": "up"
+      },
+      "seed_results": [
+        {
+          "seed": 0,
+          "avg_direction_accuracy": 0.4861538461538462,
+          "majority_baseline": 0.5130246020260492,
+          "edge_vs_majority": -0.026870755872202945,
+          "avg_sharpe": -2.0459115603253113
+        },
+        {
+          "seed": 1,
+          "avg_direction_accuracy": 0.49230769230769234,
+          "majority_baseline": 0.5130246020260492,
+          "edge_vs_majority": -0.020716909718356824,
+          "avg_sharpe": -1.3660069835590318
+        },
+        {
+          "seed": 7,
+          "avg_direction_accuracy": 0.4953846153846154,
+          "majority_baseline": 0.5130246020260492,
+          "edge_vs_majority": -0.017639986641433736,
+          "avg_sharpe": -1.6701299877081144
+        },
+        {
+          "seed": 42,
+          "avg_direction_accuracy": 0.48307692307692307,
+          "majority_baseline": 0.5130246020260492,
+          "edge_vs_majority": -0.02994767894912609,
+          "avg_sharpe": -1.9710415551693088
+        },
+        {
+          "seed": 99,
+          "avg_direction_accuracy": 0.5076923076923078,
+          "majority_baseline": 0.5130246020260492,
+          "edge_vs_majority": -0.005332294333741383,
+          "avg_sharpe": -0.9140365352710621
+        }
+      ],
+      "timestamp": "2026-07-27T09:37:57.853100"
+    },
+    {
+      "model": "NeoQuasar/Kronos-base",
+      "is_mock": false,
+      "symbol": "TLT",
+      "pred_len": 132,
+      "evaluation_type": "multi_seed",
+      "seeds": [
+        0,
+        1,
+        7,
+        42,
+        99
+      ],
+      "n_beats": 0,
+      "n_seeds": 5,
+      "mean_edge": -0.02447498370543848,
+      "std_edge": 0.01039962526163448,
+      "beats_valid": false,
+      "majority_baseline": {
+        "majority_class_accuracy": 0.5130246020260492,
+        "pct_up": 0.5130246020260492,
+        "pct_down": 0.48263386396526775,
+        "majority_class": "up"
+      },
+      "seed_results": [
+        {
+          "seed": 0,
+          "avg_direction_accuracy": 0.48244274809160304,
+          "majority_baseline": 0.5130246020260492,
+          "edge_vs_majority": -0.030581853934446124,
+          "avg_sharpe": -1.042764905411779
+        },
+        {
+          "seed": 1,
+          "avg_direction_accuracy": 0.4854961832061068,
+          "majority_baseline": 0.5130246020260492,
+          "edge_vs_majority": -0.027528418819942335,
+          "avg_sharpe": -0.9027332780408519
+        },
+        {
+          "seed": 7,
+          "avg_direction_accuracy": 0.5068702290076337,
+          "majority_baseline": 0.5130246020260492,
+          "edge_vs_majority": -0.006154373018415482,
+          "avg_sharpe": -0.28861125896883294
+        },
+        {
+          "seed": 42,
+          "avg_direction_accuracy": 0.49160305343511446,
+          "majority_baseline": 0.5130246020260492,
+          "edge_vs_majority": -0.021421548590934703,
+          "avg_sharpe": -1.7371165376179518
+        },
+        {
+          "seed": 99,
+          "avg_direction_accuracy": 0.4763358778625954,
+          "majority_baseline": 0.5130246020260492,
+          "edge_vs_majority": -0.036688724163453756,
+          "avg_sharpe": -1.1075534121487673
+        }
+      ],
+      "timestamp": "2026-07-27T09:39:30.729612"
+    },
+    {
+      "model": "NeoQuasar/Kronos-base",
+      "is_mock": false,
+      "symbol": "GLD",
+      "pred_len": 24,
+      "evaluation_type": "multi_seed",
+      "seeds": [
+        0,
+        1,
+        7,
+        42,
+        99
+      ],
+      "n_beats": 0,
+      "n_seeds": 5,
+      "mean_edge": -0.04278046938903921,
+      "std_edge": 0.026603580070918863,
+      "beats_valid": false,
+      "majority_baseline": {
+        "majority_class_accuracy": 0.5314761215629522,
+        "pct_up": 0.5314761215629522,
+        "pct_down": 0.46562952243125905,
+        "majority_class": "up"
+      },
+      "seed_results": [
+        {
+          "seed": 0,
+          "avg_direction_accuracy": 0.4521739130434782,
+          "majority_baseline": 0.5314761215629522,
+          "edge_vs_majority": -0.079302208519474,
+          "avg_sharpe": 0.5093885819683635
+        },
+        {
+          "seed": 1,
+          "avg_direction_accuracy": 0.4608695652173913,
+          "majority_baseline": 0.5314761215629522,
+          "edge_vs_majority": -0.0706065563455609,
+          "avg_sharpe": -0.9494699160345432
+        },
+        {
+          "seed": 7,
+          "avg_direction_accuracy": 0.5130434782608695,
+          "majority_baseline": 0.5314761215629522,
+          "edge_vs_majority": -0.01843264330208272,
+          "avg_sharpe": -0.2473042660075259
+        },
+        {
+          "seed": 42,
+          "avg_direction_accuracy": 0.5130434782608695,
+          "majority_baseline": 0.5314761215629522,
+          "edge_vs_majority": -0.01843264330208272,
+          "avg_sharpe": -0.21670407823437596
+        },
+        {
+          "seed": 99,
+          "avg_direction_accuracy": 0.5043478260869565,
+          "majority_baseline": 0.5314761215629522,
+          "edge_vs_majority": -0.027128295475995712,
+          "avg_sharpe": 0.9589633426726298
+        }
+      ],
+      "timestamp": "2026-07-27T09:39:47.200219"
+    },
+    {
+      "model": "NeoQuasar/Kronos-base",
+      "is_mock": false,
+      "symbol": "GLD",
+      "pred_len": 66,
+      "evaluation_type": "multi_seed",
+      "seeds": [
+        0,
+        1,
+        7,
+        42,
+        99
+      ],
+      "n_beats": 1,
+      "n_seeds": 5,
+      "mean_edge": -0.021937660024490647,
+      "std_edge": 0.029742882396540493,
+      "beats_valid": false,
+      "majority_baseline": {
+        "majority_class_accuracy": 0.5314761215629522,
+        "pct_up": 0.5314761215629522,
+        "pct_down": 0.46562952243125905,
+        "majority_class": "up"
+      },
+      "seed_results": [
+        {
+          "seed": 0,
+          "avg_direction_accuracy": 0.49230769230769234,
+          "majority_baseline": 0.5314761215629522,
+          "edge_vs_majority": -0.03916842925525987,
+          "avg_sharpe": -0.877562172020423
+        },
+        {
+          "seed": 1,
+          "avg_direction_accuracy": 0.5661538461538462,
+          "majority_baseline": 0.5314761215629522,
+          "edge_vs_majority": 0.03467772459089402,
+          "avg_sharpe": 0.7297288199400256
+        },
+        {
+          "seed": 7,
+          "avg_direction_accuracy": 0.5046153846153846,
+          "majority_baseline": 0.5314761215629522,
+          "edge_vs_majority": -0.02686073694756763,
+          "avg_sharpe": -0.4873301476544386
+        },
+        {
+          "seed": 42,
+          "avg_direction_accuracy": 0.4800000000000001,
+          "majority_baseline": 0.5314761215629522,
+          "edge_vs_majority": -0.051476121562952115,
+          "avg_sharpe": -1.487850789267517
+        },
+        {
+          "seed": 99,
+          "avg_direction_accuracy": 0.5046153846153846,
+          "majority_baseline": 0.5314761215629522,
+          "edge_vs_majority": -0.02686073694756763,
+          "avg_sharpe": -1.3981434951226765
+        }
+      ],
+      "timestamp": "2026-07-27T09:40:33.045945"
+    },
+    {
+      "model": "NeoQuasar/Kronos-base",
+      "is_mock": false,
+      "symbol": "GLD",
+      "pred_len": 132,
+      "evaluation_type": "multi_seed",
+      "seeds": [
+        0,
+        1,
+        7,
+        42,
+        99
+      ],
+      "n_beats": 0,
+      "n_seeds": 5,
+      "mean_edge": -0.024911236066768993,
+      "std_edge": 0.01608206910810832,
+      "beats_valid": false,
+      "majority_baseline": {
+        "majority_class_accuracy": 0.5314761215629522,
+        "pct_up": 0.5314761215629522,
+        "pct_down": 0.46562952243125905,
+        "majority_class": "up"
+      },
+      "seed_results": [
+        {
+          "seed": 0,
+          "avg_direction_accuracy": 0.5083969465648854,
+          "majority_baseline": 0.5314761215629522,
+          "edge_vs_majority": -0.023079174998066776,
+          "avg_sharpe": -0.6094571648472942
+        },
+        {
+          "seed": 1,
+          "avg_direction_accuracy": 0.5022900763358779,
+          "majority_baseline": 0.5314761215629522,
+          "edge_vs_majority": -0.029186045227074353,
+          "avg_sharpe": 0.342711975984361
+        },
+        {
+          "seed": 7,
+          "avg_direction_accuracy": 0.5145038167938931,
+          "majority_baseline": 0.5314761215629522,
+          "edge_vs_majority": -0.016972304769059088,
+          "avg_sharpe": 0.033600438584591344
+        },
+        {
+          "seed": 42,
+          "avg_direction_accuracy": 0.4793893129770993,
+          "majority_baseline": 0.5314761215629522,
+          "edge_vs_majority": -0.052086808585852906,
+          "avg_sharpe": -1.303273538685928
+        },
+        {
+          "seed": 99,
+          "avg_direction_accuracy": 0.5282442748091604,
+          "majority_baseline": 0.5314761215629522,
+          "edge_vs_majority": -0.003231846753791845,
+          "avg_sharpe": 0.46575698059956616
+        }
+      ],
+      "timestamp": "2026-07-27T09:42:03.019488"
+    }
+  ],
+  "timestamp": "2026-07-27T09:42:03.019488"
+}

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/results/kronos_zeroshot/verdict.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/results/kronos_zeroshot/verdict.md
@@ -1,0 +1,70 @@
+# Verdict — Kronos zero-shot, panier anti-biais (foundation-model spin-out #8607, 2e rung)
+
+> Script : [`scripts/eval_kronos_zeroshot.py`](../../eval_kronos_zeroshot.py) (modèle `NeoQuasar/Kronos-base`, ~102M params, AAAI 2026, pré-entraîné sur 12B K-lines OHLCV, zero-shot).
+> 2e rung foundation-model du spin-out #8607 de l'Epic #1409 (parqué après L6 NO BEATS). Le 1er rung était Chronos-Bolt (c.893, See #8610).
+
+## Verdict : NO BEATS (panier, robuste sur 3 horizons)
+
+Sur 3 symboles anti-biais × 3 horizons = **9 configurations**, walk-forward 5 fenêtres, 5 seeds (0/1/7/42/99), coût tx 10 bps : **aucune** configuration ne bat majority-class. **9/9 mean_edge strictement négatifs**, `beats_valid=False` partout. DirAcc (0.4885-0.5113) **sous** la baseline majority (0.5130-0.5461) sur les 9 configs.
+
+| Symbole | Horizon | DirAcc | Majority | Edge | std_edge | `beats_valid` |
+|---------|---------|--------|----------|------|----------|---------------|
+| SPY | h≈22 (`pred_len=24`) | 0.5113 | 0.5461 | **-0.0348** | 0.0502 | False |
+| SPY | h=66 | 0.5058 | 0.5461 | **-0.0403** | 0.0228 | False |
+| SPY | h=132 | 0.5014 | 0.5461 | **-0.0448** | 0.0230 | False |
+| TLT | h≈22 | 0.4957 | 0.5130 | **-0.0174** | 0.0286 | False |
+| TLT | h=66 | 0.4929 | 0.5130 | **-0.0201** | 0.0086 | False |
+| TLT | h=132 | 0.4885 | 0.5130 | **-0.0245** | 0.0104 | False |
+| GLD | h≈22 | 0.4887 | 0.5315 | **-0.0428** | 0.0266 | False |
+| GLD | h=66 | 0.5095 | 0.5315 | **-0.0219** | 0.0297 | False |
+| GLD | h=132 | 0.5066 | 0.5315 | **-0.0249** | 0.0161 | False |
+
+`std_edge` est **strictement positif** sur les 9 configs (0.0086 à 0.0502) — voir § ci-dessous (C893-L distinction).
+
+## Le harness était BROKEN/spéculatif — réécrit sur l'API réelle
+
+`eval_kronos_zeroshot.py` n'avait **jamais été exécuté** : il appelait `from kronos import KronosPipeline` + `KronosPipeline.from_pretrained(model_id, device_map=)` — une API **qui n'existe pas**. Kronos n'a pas de wheel PyPI (`kronos-forecasting` absent de PyPI) ; c'est un repo source (`github.com/shiyu-coder/Kronos`). API réelle (groundée firsthand via `model/__init__.py` + `examples/prediction_example.py`) :
+
+- Import : `from model import Kronos, KronosTokenizer, KronosPredictor` (package `model/` du repo, sur `sys.path` — le harness clone le repo si absent).
+- Chargement : `KronosTokenizer.from_pretrained("NeoQuasar/Kronos-Tokenizer-base")` + `Kronos.from_pretrained("NeoQuasar/Kronos-base")` + `KronosPredictor(model, tokenizer, max_context=512)`.
+- Inférence : `predictor.predict(df=OHLCV, x_timestamp, y_timestamp, pred_len, T, top_p, sample_count)` → DataFrame de forecast (colonne `close` extraite).
+- IDs réels `NeoQuasar/Kronos-{mini,small,base}` (Kronos-large ~499M **non open-source** → absent). Défaut `base` (102M, comparable à Chronos-Bolt-base ~200M).
+
+Réécriture complète du wrapper + window-builder (OHLCV + timestamps) + evaluate + ajout `run_multi_seed`/`run_sweep`. **SOTA-OK** : `is_mock=False`, vrai forward pass GPU.
+
+## Distinction critique vs Chronos — C893-L ne s'applique PAS (vérifié firsthand)
+
+**C893-L (Chronos-Bolt, c.893)** : le décodeur Chronos-Bolt est **déterministe** → `std_edge=0.0000` toutes seeds identiques → le gate `beats_valid = seeds≥4 AND edge>0 AND (std<1e-10 OR edge≥2·std)` **collapse** en « n'importe quel edge>0=BEATS » via la branche `std<1e-10`.
+
+**Kronos est l'inverse** : les forecasts sont produits par **échantillonnage autorégressif** (`T=1.0, top_p=0.9, sample_count=1`) → la forward pass est **stochastique** → les 5 seeds produisent des forecasts **différents** → `std_edge > 0` (mesuré : 0.0086 à 0.0502 sur les 9 configs). Le seed (`torch.manual_seed` + `np.random.seed` avant chaque `predict`) contrôle explicitement cet échantillonnage.
+
+**Conséquence** : pour Kronos, le gate multi-seed est un **vrai test** de robustesse, pas un artefact dégénéré. Les 2 `beats_valid=True` « dégénérés » de Chronos (TLT h22, SPY h66) n'ont pas d'équivalent ici — Kronos produit un négatif **uniforme** (9/9), plus propre, précisément parce que la variance cross-seed ne s'effondre pas.
+
+## Barre pleine #8607 non atteinte
+
+#8607 exige, après 6 réfutations (L1-L6), une barre complète : edge ≥2σ cross-seed **ET** ≥3/4 seeds positifs **ET** bat majority-class. Kronos : 9/9 mean_edge négatifs, 0/9 avec ≥3/5 seeds positifs (max 2/5 sur SPY h22), DirAcc sous majority partout. **Aucun critère satisfait.** NO BEATS robuste.
+
+## Comparaison Chronos-Bolt (1er rung) vs Kronos (ce rung)
+
+| Axe | Chronos-Bolt-base (~200M) | Kronos-base (~102M) |
+|-----|---------------------------|---------------------|
+| Pré-entraînement | ~100B séries temporelles (langage des TS) | 12B K-lines OHLCV multi-actifs |
+| Décodage | **Déterministe** (Bolt) | **Stochastique** (échantillonnage AR) |
+| `std_edge` cross-seed | **0.0000** partout (dégénéré, C893-L) | **0.0086-0.0502** (variance réelle) |
+| Configs exécutées | 7 (GLD h22 only) | **9 (grille 3×3 complète)** |
+| Edges positifs | 2 (dégénérés, artefact harnais) | **0** (négatif uniforme) |
+| Verdict panier | NO BEATS | **NO BEATS** (plus propre) |
+
+Les **deux** foundation-models zero-shot (langage des TS **et** K-lines OHLCV) échouent à battre majority-class sur le panier anti-biais en direction, aux horizons longs, après coûts. Renforce #1409 : l'alpha sur cet univers provient de **politiques d'action apprises** (L4 Decision Transformer), pas de prévision foundation-model.
+
+## Données
+
+- SPY 2515 bars (2015-2024), TLT/GLD 2765 bars (2015-2025), yfinance daily OHLCV (data-source-to-convert AUTORISÉ). `data_utils.load_data` depuis `datasets/yfinance/` (gitignored).
+- Zero-shot : aucun entraînement sur le panier (modèle HF `NeoQuasar/Kronos-base` figé, cache 391 MB + tokenizer). Device GPU (RTX 3070 8GB, `CUDA_VISIBLE_DEVICES=0`, env `coursia-ml-training` torch 2.5.1+cu121).
+- OOS : walk-forward 5 fenêtres, 5 seeds (0/1/7/42/99), coût tx 10 bps.
+
+## Résiduel (out-of-scope, multi-cycle)
+
+- **M15 sur terrain commun** (ETF-direction-long-horizon) : fine-tuner M15 pour comparaison directe Chronos vs Kronos vs M15 — multi-cycle.
+- **t-stat cross-fenêtre propre** : le gate actuel utilise std cross-seed (significatif pour Kronos, contrairement à Chronos), mais un t-stat cross-fenêtre formaliserait la significativité OOS — amélioration méthodologique non codée ce cycle.
+- **Kronos-large** (499M) : non open-source, inaccessible.

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_kronos_zeroshot.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_kronos_zeroshot.py
@@ -92,42 +92,64 @@ class TestTransactionCost:
 
 
 class TestEvaluationWindows:
+    @staticmethod
+    def _ohlcv(n=500, seed=0):
+        rng = np.random.default_rng(seed)
+        dates = pd.date_range("2020-01-01", periods=n, freq="B")
+        close = np.cumsum(rng.standard_normal(n) * 0.01 + 100)
+        return pd.DataFrame(
+            {
+                "open": close, "high": close + 0.5, "low": close - 0.5,
+                "close": close, "volume": 0.0,
+            },
+            index=dates,
+        )
+
     def test_window_count(self):
-        dates = pd.date_range("2020-01-01", periods=500, freq="B")
-        prices = pd.Series(np.cumsum(np.random.randn(500) * 0.01 + 100), index=dates)
-        windows = build_evaluation_windows(prices, seq_len=96, pred_len=24, n_windows=5)
-        assert len(windows) > 0
-        assert len(windows) <= 5
+        ohlcv = self._ohlcv()
+        windows = build_evaluation_windows(ohlcv, seq_len=96, pred_len=24, n_windows=5)
+        assert 0 < len(windows) <= 5
 
     def test_window_shapes(self):
-        dates = pd.date_range("2020-01-01", periods=500, freq="B")
-        prices = pd.Series(np.cumsum(np.random.randn(500) * 0.01 + 100), index=dates)
-        windows = build_evaluation_windows(prices, seq_len=96, pred_len=24, n_windows=3)
+        ohlcv = self._ohlcv()
+        windows = build_evaluation_windows(ohlcv, seq_len=96, pred_len=24, n_windows=3)
         for w in windows:
-            assert w["context"].shape == (96,)
-            assert w["actual_prices"].shape == (24,)
-            assert w["actual_returns"].shape == (24,)
+            assert w["context_ohlcv"].shape == (96, 5)  # OHLCV
+            assert w["actual_close"].shape == (24,)
+            assert w["x_timestamp"].shape == (96,)
 
     def test_temporal_ordering(self):
-        dates = pd.date_range("2020-01-01", periods=500, freq="B")
-        prices = pd.Series(np.arange(500, dtype=float), index=dates)
-        windows = build_evaluation_windows(prices, seq_len=10, pred_len=5, n_windows=3)
+        ohlcv = self._ohlcv()
+        windows = build_evaluation_windows(ohlcv, seq_len=10, pred_len=5, n_windows=3)
         for i in range(1, len(windows)):
             assert windows[i]["start_date"] >= windows[i - 1]["start_date"]
 
 
 class TestNaiveKronosWrapper:
+    @staticmethod
+    def _context(n=96):
+        dates = pd.date_range("2020-01-01", periods=n, freq="B")
+        close = np.arange(n, dtype=float) + 100
+        return pd.DataFrame(
+            {"open": close, "high": close, "low": close, "close": close, "volume": 0.0},
+            index=dates,
+        )
+
     def test_predict_shape(self):
         wrapper = NaiveKronosWrapper()
-        context = np.random.randn(96)
-        forecast = wrapper.predict(context, pred_len=24)
+        ctx = self._context()
+        x_ts = pd.Series(ctx.index)
+        y_ts = pd.Series(pd.date_range("2020-05-01", periods=24, freq="B"))
+        forecast = wrapper.predict(ctx, x_timestamp=x_ts, y_timestamp=y_ts, pred_len=24)
         assert forecast.shape == (24,)
 
     def test_predict_persistence(self):
         wrapper = NaiveKronosWrapper()
-        context = np.arange(96, dtype=float)
-        forecast = wrapper.predict(context, pred_len=10)
-        assert np.all(forecast == context[-1])
+        ctx = self._context()
+        x_ts = pd.Series(ctx.index)
+        y_ts = pd.Series(pd.date_range("2020-05-01", periods=10, freq="B"))
+        forecast = wrapper.predict(ctx, x_timestamp=x_ts, y_timestamp=y_ts, pred_len=10)
+        assert np.all(forecast == ctx["close"].iloc[-1])
 
     def test_is_mock(self):
         wrapper = NaiveKronosWrapper()
@@ -147,8 +169,17 @@ class TestNaiveChronosWrapper:
 
 
 class TestModelLoading:
-    def test_kronos_loads_mock_without_package(self):
-        model = load_kronos_model("small", device="cpu")
+    def test_kronos_loads_mock_without_package(self, monkeypatch):
+        # Force the repo-clone step to fail so load_kronos_model exercises its
+        # mock fallback (deterministic, no network). Real-load (is_mock=False)
+        # is proven by the committed sweep results, not by this CPU unit test.
+        import eval_kronos_zeroshot as ekz
+
+        def _boom(_path):
+            raise OSError("simulated: kronos repo unavailable (CI)")
+
+        monkeypatch.setattr(ekz, "ensure_kronos_repo", _boom)
+        model = ekz.load_kronos_model("small", device="cpu")
         assert model.is_mock is True
 
     def test_chronos_loads_mock_without_package(self):
@@ -158,10 +189,12 @@ class TestModelLoading:
     def test_kronos_model_ids(self):
         from eval_kronos_zeroshot import KRONOS_MODEL_IDS
 
+        # Kronos-large (~499M) is NOT open-source -> intentionally absent.
+        assert "mini" in KRONOS_MODEL_IDS
         assert "small" in KRONOS_MODEL_IDS
         assert "base" in KRONOS_MODEL_IDS
-        assert "large" in KRONOS_MODEL_IDS
-        assert "xl" in KRONOS_MODEL_IDS
+        assert "large" not in KRONOS_MODEL_IDS
+        assert "xl" not in KRONOS_MODEL_IDS
 
     def test_chronos_model_ids(self):
         from eval_chronos_bolt import CHRONOS_MODEL_IDS
@@ -174,10 +207,19 @@ class TestModelLoading:
 class TestEvaluateWindow:
     def test_evaluate_with_mock(self):
         model = NaiveKronosWrapper()
+        dates = pd.date_range("2020-01-01", periods=120, freq="B")
+        rng = np.random.default_rng(0)
+        close = np.cumsum(rng.standard_normal(120) * 0.5 + 100)
+        ctx = pd.DataFrame(
+            {"open": close, "high": close, "low": close, "close": close, "volume": 0.0},
+            index=dates,
+        ).iloc[:96]
         window = {
-            "context": np.random.randn(96),
-            "actual_prices": np.random.randn(24) + 100,
-            "actual_returns": np.random.randn(24) * 0.01,
+            "context_ohlcv": ctx,
+            "x_timestamp": pd.Series(ctx.index),
+            "y_timestamp": pd.Series(dates[96:120]),
+            "actual_close": close[96:120],
+            "actual_returns": np.diff(close[96:120]),
         }
         result = evaluate_window(model, window, pred_len=24)
         assert "direction_accuracy" in result


### PR DESCRIPTION
Grain: DEEP/training-foundation — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-doc-honesty (c.896 #8616 fix pushed, attente merge).

## Summary

Exécute le **2e rung foundation-model** de l'Epic #1409 (spin-out #8607) : **Kronos** (AAAI 2026, pré-entraîné sur 12B K-lines OHLCV) en zero-shot sur le panier anti-biais, walk-forward 5 fenêtres, 5 seeds (0/1/7/42/99), coût tx 10 bps, h=22/66/132. Le rung Chronos-Bolt (c.893, See #8610) était le 1er.

**Le harness `eval_kronos_zeroshot.py` était BROKEN/speculatif** (jamais exécuté — écrit contre une API supposée `from kronos import KronosPipeline` qui n'existe pas). Cette PR le **réécrit sur l'API réelle** (groundée firsthand via le repo github.com/shiyu-coder/Kronos) + **exécute le sweep complet** + documente le verdict.

## Fix harness — API réelle (grounded firsthand)

Le repo Kronos n'a **pas de wheel PyPI** (`kronos-forecasting` absent de PyPI). API réelle (confirmée en lisant `model/__init__.py` + `examples/prediction_example.py`) :
- Import : `from model import Kronos, KronosTokenizer, KronosPredictor` (package `model/` du repo, sur sys.path — le harness clone `github.com/shiyu-coder/Kronos` si absent).
- Chargement : `KronosTokenizer.from_pretrained("NeoQuasar/Kronos-Tokenizer-base")` + `Kronos.from_pretrained("NeoQuasar/Kronos-base")` + `KronosPredictor(model, tokenizer, max_context=512)`.
- Inférence : `predictor.predict(df=OHLCV_df, x_timestamp, y_timestamp, pred_len, T, top_p, sample_count)` → DataFrame de forecast (on extrait `close`).
- L'ancien harness utilisait `KronosPipeline.from_pretrained(model_id, device_map=)` + tenseur numpy univarié + `samples.median()` — **tous faux**. Réécriture complète du wrapper + window-builder (OHLCV) + evaluate + ajout `run_multi_seed`/`run_sweep`.
- Model IDs réels `NeoQuasar/Kronos-{mini,small,base}` (Kronos-large ~499M **non open-source** → absent, intentionnel). Défaut `base` (102M, le plus gros checkpoint ouvert, comparable à Chronos-Bolt-base ~200M).

## SOTA-OK (sota-not-workaround Prong A)

Le vrai Kronos est **invoqué** (pas de fallback naïf pour le résultat committé) : `is_mock=False` vérifié. Inférence GPU réelle (RTX 3070 8GB, CUDA_VISIBLE_DEVICES=0, env `coursia-ml-training` torch 2.5.1+cu121). Dépendances satisfaites sans mutation d'env (einops/safetensors/huggingface_hub déjà présents). Smoke test SPY h=22 firsthand : DirAcc variable, edges réels, std>0 (voir §C893-L distinction).

## Distinction critique vs Chronos — C893-L ne s'applique PAS

C893-L (c.893) : Chronos-Bolt est **déterministe** (décodeur non-échantillonné) → `std_edge=0.0000` toutes seeds identiques → gate `beats_valid` collapse en « edge>0=BEATS ». **Kronos est l'inverse** : forecasts produits par **échantillonnage autorégressif** (`T=1.0, top_p=0.9, sample_count=1`) → forward pass **stochastique** → seeds produisent des forecasts **différents** → `std_edge > 0` (vérifié SPY h=22 : 5 seeds, edges -0.1288/+0.0017/-0.0157/+0.0104/-0.0418, std mesurable). **Le gate multi-seed est donc un vrai test pour Kronos**, pas un artefact dégénéré. Le seed est appliqué (`torch.manual_seed` + `np.random.seed`) avant chaque forward pass.

## Verdict — NO BEATS (panier, robuste sur 3 horizons)

Sweep complet SPY/TLT/GLD × h=22/66/132 × 5 seeds (results.json, `is_mock=False`, device cuda) :

| Symbole | Horizon | DirAcc | Majority | Edge | std_edge | beats_valid |
|---------|---------|--------|----------|------|----------|-------------|
| SPY | h≈22 | 0.5113 | 0.5461 | **-0.0348** | 0.0502 | False |
| SPY | h=66 | 0.5058 | 0.5461 | **-0.0403** | 0.0228 | False |
| SPY | h=132 | 0.5014 | 0.5461 | **-0.0448** | 0.0230 | False |
| TLT | h≈22 | 0.4957 | 0.5130 | **-0.0174** | 0.0286 | False |
| TLT | h=66 | 0.4929 | 0.5130 | **-0.0201** | 0.0086 | False |
| TLT | h=132 | 0.4885 | 0.5130 | **-0.0245** | 0.0104 | False |
| GLD | h≈22 | 0.4887 | 0.5315 | **-0.0428** | 0.0266 | False |
| GLD | h=66 | 0.5095 | 0.5315 | **-0.0219** | 0.0297 | False |
| GLD | h=132 | 0.5066 | 0.5315 | **-0.0249** | 0.0161 | False |

**9/9 mean_edge négatifs**, `beats_valid=False` partout, DirAcc sous majority sur les 9. `std_edge` strictement positif (0.0086-0.0502) → **Kronos est stochastique** (C893-L distinction vérifiée). Négatif **plus propre** que Chronos (0 edge positif dégénéré, vs 2 chez Chronos). Barre pleine #8607 non atteinte (0/9 avec ≥3/5 seeds positifs).

## Validation

- **Source des chiffres** : `scripts/results/kronos_zeroshot/results.json` (sweep consolidé, tracked) — `is_mock=False`, device cuda, 5 seeds, walk-forward 5 fenêtres, coût 10 bps.
- **Tests unitaires** : 24/25 passent (le 25e = `test_chronos_loads_mock_without_package`, **préexistant environnemental** : `chronos-forecasting` installé localement → charge réel is_mock=False ; passe en CI sans le package. Pas une régression Kronos — je n'ai pas touché `load_chronos_model`).
- **Harness compile** (py_compile OK), 24 tests Kronos API nouvelle (OHLCV windows, KronosWrapper/NaiveKronosWrapper signatures, model IDs, mock-fallback monkeypatched) passent.
- **catalog-pr-hygiene R1** : catalogue byte-identique (0 fichier catalogue touché). Atomic (1 sujet : Kronos harness réel + sweep). `See #8607` (NOT Closes — Epic reste ouvert, M15 terrain commun + t-stat cross-fenêtre = multi-cycle).
- **Rebase frais** sur `origin/main` (c83f31b75). L898 : 0 PR in-flight kronos/foundation-8607.

## Résiduel (out-of-scope, multi-cycle)

- **M15 sur terrain commun** (ETF-direction-long-horizon) : fine-tuner M15 pour comparaison directe Chronos vs Kronos vs M15 — multi-cycle.
- **t-stat cross-fenêtre propre** : le gate actuel utilise std cross-seed (significatif pour Kronos, contrairement à Chronos), mais un t-stat cross-fenêtre formaliserait la significativité OOS — amélioration méthodologique non codée ce cycle.
- **Kronos-large** (499M) : non open-source, inaccessible.

See #8607. See #1409 (Epic parqué). See #8610 (Chronos-Bolt, 1er rung).
