### PR TITLE
fix(audit,#7575): empty cells are not unexecuted cells + correct a false docstring contract

### DIFF
--- a/scripts/quantconnect/audit_quantbooks_unexec.py
+++ b/scripts/quantconnect/audit_quantbooks_unexec.py
@@ -51,10 +51,16 @@ Pour chaque quantbook ainsi identifie :
                                 unexec). Nouvelle occurrence non encore triee --
                                 celle que ``--check`` flagge en CI.
 
-Le verdict est **conservatif** : si une cellule est unexec, on l'attrape.
-Pas de faux positif sur les cellules volontairement non executees (defs,
-helpers) parce qu'on regarde aussi le markdown contextuel -- un notebook
-avec un seul ``def`` unexec et pas d'autre cellule = HEALTHY.
+Le verdict est **conservatif** : toute cellule code **non vide** sans
+``execution_count`` ni sortie est attrapee, quel qu'en soit le contenu. Une
+cellule qui ne contient qu'un ``def`` ou un helper est donc signalee comme
+les autres -- c'est voulu (regle C.2 : un notebook se commite execute de bout
+en bout), et le markdown contextuel ne l'en exempte pas : ``_has_strip_marker``
+et ``_has_unexec_marker`` **routent** entre les classes STOP_REPAIR_*, ils ne
+produisent jamais HEALTHY.
+
+Seul faux positif ecarte : les **cellules vides**, qui satisfont le predicat
+par construction sans rien avoir a executer.
 
 Cross-reference avec ``config.json``
 ------------------------------------
@@ -131,9 +137,27 @@ def _is_code(cell: dict) -> bool:
     return cell.get("cell_type") == "code"
 
 
+def _source_text(cell: dict) -> str:
+    """Source d'une cellule en texte, que nbformat la stocke en str ou en list."""
+    src = cell.get("source", "")
+    if isinstance(src, list):
+        src = "".join(src)
+    return src
+
+
 def _is_unexecuted_code(cell: dict) -> bool:
-    """Cellule code sans execution_count ET sans outputs = JAMAIS executee."""
+    """Cellule code NON VIDE sans execution_count ET sans outputs = JAMAIS executee.
+
+    La clause "non vide" n'est pas cosmetique : une cellule code vide satisfait
+    ``ec is None and outputs == []`` par construction -- il n'y a rien a executer,
+    donc rien a signaler. Sans ce garde-fou, ``--check`` echoue en CI sur un
+    notebook dont les seules cellules "unexec" sont vides, et la seule
+    remediation possible serait de les supprimer : un faux positif qui pousse a
+    modifier un notebook sain (mesure sur le depot : 1 notebook, 2 cellules).
+    """
     if not _is_code(cell):
+        return False
+    if not _source_text(cell).strip():
         return False
     ec = cell.get("execution_count")
     outs = cell.get("outputs") or []

--- a/scripts/quantconnect/tests/test_audit_quantbooks_unexec.py
+++ b/scripts/quantconnect/tests/test_audit_quantbooks_unexec.py
@@ -65,7 +65,7 @@ def _write_project(root: Path, name: str, cells, config: dict | None = None,
 
 class TestIsUnexecutedCode:
     def test_code_cell_without_exec_count(self):
-        c = _cell("code", execution_count=None, outputs=[])
+        c = _cell("code", "qb = QuantBook()", execution_count=None, outputs=[])
         assert aqm._is_unexecuted_code(c) is True
 
     def test_code_cell_with_exec_count(self):
@@ -82,8 +82,21 @@ class TestIsUnexecutedCode:
 
     def test_outputs_none_treated_as_empty(self):
         # Cell where outputs key is missing entirely
-        c = {"cell_type": "code", "execution_count": None}
+        c = {"cell_type": "code", "source": "qb = QuantBook()", "execution_count": None}
         assert aqm._is_unexecuted_code(c) is True
+
+    def test_empty_code_cell_is_not_unexecuted(self):
+        # Une cellule vide satisfait ``ec is None and outputs == []`` par
+        # construction : il n'y a rien a executer, donc rien a signaler.
+        # Sans ce garde-fou, --check echoue en CI sur un notebook sain et la
+        # seule remediation serait de supprimer les cellules vides.
+        assert aqm._is_unexecuted_code(_cell("code", "")) is False
+
+    def test_whitespace_only_code_cell_is_not_unexecuted(self):
+        assert aqm._is_unexecuted_code(_cell("code", "  \n\t\n")) is False
+
+    def test_empty_source_as_list_is_not_unexecuted(self):
+        assert aqm._is_unexecuted_code(_cell("code", ["", "\n"])) is False
 
 
 # -- _has_strip_marker --
@@ -200,6 +213,25 @@ class TestScanNotebook:
         assert r["unexecuted_indexes"] == [1, 2]
         assert r["strip_marker"] is False
 
+    def test_def_only_cell_is_still_caught(self, tmp_path):
+        """Le verdict est conservatif : un ``def`` unexec est signale comme le reste.
+
+        La docstring du module a longtemps promis l'inverse ("un notebook avec
+        un seul ``def`` unexec et pas d'autre cellule = HEALTHY", "pas de faux
+        positif ... parce qu'on regarde aussi le markdown contextuel"). Aucune
+        de ces deux clauses n'a jamais ete implementee : le markdown contextuel
+        ne fait que ROUTER entre les classes STOP_REPAIR_*, il ne produit
+        jamais HEALTHY. Ce test epingle le contrat reel.
+        """
+        proj = _write_project(tmp_path, "DefOnly", [
+            _cell("markdown", "## Fonctions utilitaires"),
+            _cell("code", "def helper(x):\n    return x * 2",
+                  execution_count=None, outputs=[]),
+        ])
+        r = aqm.scan_notebook(proj / "quantbook.ipynb")
+        assert r["classification"] == "PREEXISTING_UNEXEC"
+        assert r["code_unexecuted"] == 1
+
     def test_error_unreadable(self, tmp_path):
         proj = tmp_path / "BadProj"
         proj.mkdir()
@@ -260,8 +292,8 @@ class TestMain:
         assert out["results"][0]["classification"] == "HEALTHY"
 
     def test_project_filter(self, tmp_path, capsys):
-        _write_project(tmp_path, "Good", [_cell("code", execution_count=1)])
-        _write_project(tmp_path, "Bad", [_cell("code", execution_count=None)])
+        _write_project(tmp_path, "Good", [_cell("code", "x = 1", execution_count=1)])
+        _write_project(tmp_path, "Bad", [_cell("code", "x = 1", execution_count=None)])
         rc = aqm.main(["--root", str(tmp_path), "--quant-root", ".",
                        "--project", "Bad", "--json"])
         assert rc == 0
@@ -279,9 +311,23 @@ class TestMain:
         assert rc == 2
 
     def test_check_exits_1_when_preexisting(self, tmp_path):
-        _write_project(tmp_path, "Bad", [_cell("code", execution_count=None)])
+        _write_project(tmp_path, "Bad", [_cell("code", "x = 1", execution_count=None)])
         rc = aqm.main(["--root", str(tmp_path), "--quant-root", ".", "--check"])
         assert rc == 1
+
+    def test_check_ignores_empty_cells(self, tmp_path):
+        """Un notebook dont les seules cellules 'unexec' sont vides est sain.
+
+        Le gate CI ne doit pas exiger une remediation dont la seule forme
+        possible serait de supprimer des cellules vides.
+        """
+        _write_project(tmp_path, "EmptyOnly", [
+            _cell("code", "x = 1", execution_count=1,
+                  outputs=[{"output_type": "stream", "name": "stdout", "text": "ok"}]),
+            _cell("code", "", execution_count=None, outputs=[]),
+        ])
+        rc = aqm.main(["--root", str(tmp_path), "--quant-root", ".", "--check"])
+        assert rc == 0
 
     def test_check_exits_0_when_clean(self, tmp_path):
         _write_project(tmp_path, "Good", [_cell("code", execution_count=1)])


### PR DESCRIPTION
Grain: MED/qc-tooling — lane myia-ai-01:CoursIA — prev: MED/notebook-metadata

## Résumé

Deux défauts de `audit_quantbooks_unexec.py`, l'instrument qui garde en CI l'honnêteté d'exécution des quantbooks. Les deux ont été vérifiés firsthand — mesurés, pas déduits d'une lecture — avant d'écrire une ligne de correctif.

## 1. Faux positif sur les cellules vides

`_is_unexecuted_code` retournait `True` pour une cellule code vide. Une cellule vide satisfait `ec is None and outputs == []` **par construction** : il n'y a rien à exécuter, donc rien à signaler.

Ce n'est pas cosmétique parce que `--check` est l'interface de **gate** de l'outil : il sort 1 sur `PREEXISTING_UNEXEC`. Un notebook dont les seules cellules « unexec » sont vides échoue au gate, et la seule remédiation possible serait de **supprimer des cellules d'un notebook sain** — un faux positif qui pousse à modifier ce qu'il devrait protéger.

*Précision, parce que je l'ai vérifiée après avoir écrit la phrase ci-dessus et qu'elle était fausse dans sa première version :* aucun workflow n'invoque `audit_quantbooks_unexec.py --check` aujourd'hui (`rg "audit_quantbooks" .github/workflows/` ne renvoie rien). C'est la convention `--check` que ce dépôt câble partout ailleurs — `banner-guard`, `svg-empty-display-gate`, `svg-offscreen-flat-gate`, `notebook-navlink-check` — donc le défaut se paie au moment où quelqu'un câble celui-ci, pas en CI aujourd'hui. Le corriger avant plutôt qu'après reste préférable, mais l'urgence est moindre que ce que la formulation initiale laissait croire.

Mesure sur le dépôt entier (93 quantbooks) : **1 notebook, 2 cellules**.

| | avant | après |
|---|---|---|
| `CSharp-BTC-MACD-ADX/Research.ipynb` | 3 unexec — `[11, 34, 44]` | 1 unexec — `[11]` |

Les cellules 34 et 44 ont `len(source) == 0`. La 11 est du vrai code (1732 caractères) et reste signalée à juste titre. Le notebook garde sa classification `PREEXISTING_UNEXEC`.

## 2. Une docstring qui promettait un comportement jamais implémenté

Le module affirmait, aux lignes 54-57 :

> Le verdict est **conservatif** : si une cellule est unexec, on l'attrape.
> Pas de faux positif sur les cellules volontairement non executees (defs, helpers) parce qu'on regarde aussi le markdown contextuel -- un notebook avec un seul `def` unexec et pas d'autre cellule = HEALTHY.

Les deux phrases se contredisent, et c'est la seconde qui est fausse. Vérifié en construisant exactement le notebook décrit :

```
un seul `def` unexec, pas d'autre cellule   -> promis HEALTHY, réel PREEXISTING_UNEXEC
  + une cellule markdown contextuelle        -> réel PREEXISTING_UNEXEC
```

Aucune des deux clauses n'existe dans le code. `_has_strip_marker` et `_has_unexec_marker` **routent** entre les classes `STOP_REPAIR_*` ; ils ne produisent jamais `HEALTHY`. Le classifieur (lignes 231-253) ne regarde jamais le *contenu* d'une cellule unexec.

Le contrat réellement implémenté est le bon — un notebook se commite exécuté de bout en bout (règle C.2), un `def` non exécuté est bien un signal. C'est donc la **prose** qui est alignée sur le code, pas l'inverse.

Que ce défaut vive dans l'outil chargé de détecter les notebooks dont la prose contredit l'artefact n'est pas un détail ironique : c'est la même classe que #8364/#8052, appliquée à l'instrument.

## Effet fleet-wide : aucun verdict ne bascule

```
93 scannés — HEALTHY 59 · STOP_REPAIR_STRIPPED 9 · STOP_REPAIR_UNEXEC 9 · PREEXISTING_UNEXEC 16
```

Distribution **identique** avant et après. Le correctif retire du bruit de comptage sur une seule entrée, il ne blanchit aucun notebook.

## Tests — et une divulgation

**7 tests ajoutés** : cellule vide / whitespace-only / source-liste-vide, `--check` ignore les cellules vides, et un test qui épingle le contrat réel du cas `def` pour que la docstring ne puisse plus dériver sans le faire échouer.

**4 tests existants modifiés, et je le signale explicitement** parce que « modifier les tests pour qu'ils passent » est précisément le geste qui doit se justifier. Ces 4 fixtures utilisaient `_cell("code")` — dont la source est vide par défaut — comme **proxy de commodité** d'une cellule non exécutée :

```python
_write_project(tmp_path, "Bad", [_cell("code", execution_count=None)])   # avant
_write_project(tmp_path, "Bad", [_cell("code", "x = 1", execution_count=None)])  # après
```

Elles testent le plomberie de classification (`--check` sort 1, `--project` filtre), pas la sémantique du vide. Leurs **assertions sont inchangées** ; seule la fixture reçoit une vraie source, ce qui leur fait tester ce qu'elles avaient l'intention de tester. Le seul test qui portait vraiment sur la sémantique — `test_code_cell_without_exec_count` — garde son assertion `True` et reçoit une source réelle, et le cas vide fait désormais l'objet de ses propres tests.

`87 passed`.

## Vérifications

- Catalogue **byte-identique** — la PR ne touche que 2 fichiers Python.
- 2 fichiers / 1 domaine (G.4 OK).
- Aucune sortie de cellule éditée à la main : la PR ne touche aucun notebook.

## Portée

`See #7575` — l'issue reste ouverte : les 16 `PREEXISTING_UNEXEC` demandent une re-exécution en environnement réel, ce que ce correctif ne fait pas. Un recensement à jour de ces 16 est posté en commentaire de l'issue, dont le body est matériellement périmé.
