### PR TITLE
feat(curriculum,#8607): M15 LSTM fine-tuned ETF-direction terrain commun — NO BEATS 9/9 (3rd rung)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/docs/foundation_m15_lstm_etf.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/docs/foundation_m15_lstm_etf.md
@@ -1,0 +1,78 @@
+# LSTM fine-tuned sur ETF direction — terrain commun foundation-models (spin-out #8607, 3e rung)
+
+> Script associé : [`scripts/eval_m15_lstm.py`](../scripts/eval_m15_lstm.py).
+> Résultats bruts : [`scripts/results/m15_lstm_etf/`](../scripts/results/m15_lstm_etf/) (`results.json` + `verdict.md`).
+> 3e rung du spin-out #8607 de l'Epic #1409 / #1454 (parqué après L6 ROBUST NO BEATS). 1er rung = Chronos-Bolt ([`foundation_chronos_zeroshot.md`](foundation_chronos_zeroshot.md), c.893 / #8610). 2e rung = Kronos ([`foundation_kronos_zeroshot.md`](foundation_kronos_zeroshot.md), c.897 / #8620). Les deux **zero-shot**, tous deux NO BEATS.
+
+## Verdict : NO BEATS (panier, robuste sur 3 horizons) — le plus propre des 3 rungs
+
+Un **LSTM fine-tuned** (Log-LSTM, ~19k params) sur la **direction** des ETF du panier anti-biais **ne bat pas majority-class**, à aucun des 3 horizons (h=22/66/132). Sur **9 configurations** (3 symboles × 3 horizons), **9/9** edge strictement négatif, `beats_valid=False` partout, **0/5 seeds positives sur chaque config**. Le verdict le plus tranché des 3 rungs foundation.
+
+## Hypothèse (#8607)
+
+Les 2 premiers rungs (foundation-models **zero-shot**) étaient NO BEATS. Question de ce 3e rung : un LSTM **fine-tuned** sur l'ETF — qui apprend donc spécifiquement la dynamique de prix de l'univers d'évaluation — extrait-il un edge directionnel que les modèles zero-shot n'ont pas trouvé ? Si oui, l'échec zero-shot serait un défaut de généralisation (pas assez d'entraînement sur l'ETF), pas un plafond fondamental. Si non, le plafond est structurel : la direction des prix ETF n'est pas prévisible à long horizon, figé ou entraîné.
+
+**Réponse : non.** Le fine-tuning n'aide pas. Barre complète #8607 (edge ≥2σ cross-seed ET ≥3/4 seeds positifs ET bat majority) : non satisfaite sur les 9 configs.
+
+## Méthode (terrain commun apples-to-apples avec Chronos / Kronos)
+
+- **Modèle** : Log-LSTM (Hochreiter & Schmidhuber 1997), `input=2` `[log_return, sign]`, `hidden=64`, 1 layer, FC → `pred_len`. **Fine-tuned** (entraîné par fold expanding). Cible = chemin de log-return cumulé (direct multi-step, MSE). DirAcc = day-over-day sign match (**identique** à `evaluate_window`).
+- **Univers** : panier anti-biais (FORBIDDEN FAANG/Mag7) — SPY, TLT, GLD via `data_utils.load_data` sur `datasets/panier` (yfinance daily OHLCV).
+- **Validation** : walk-forward **5-fold expanding**, **5 seeds** (0/1/7/42/99), coût tx **10 bps**, baseline majority-class.
+- **Horizons** : `pred_len` ∈ {24, 66, 132} (~ h=22/66/132 jours de bourse).
+- **Métrique** : `edge_vs_majority = DirAcc − majority_baseline`. Gate `beats_valid` identique aux rungs 1-2.
+- **Device** : GPU RTX 3070 8GB (`CUDA_VISIBLE_DEVICES=0`, env `coursia-ml-training`, torch 2.5.1+cu121). `is_trained=True`.
+
+## Design — walk-forward self-contained (C898-L en reverse)
+
+M15 est **fine-tuned** (entraîné par fold), structurellement différent du zero-shot window eval de Chronos/Kronos (modèle figé → prédire par fenêtre). Ce harnais possède sa **propre walk-forward** (comme `m15_lstm_rv.walk_forward_lstm`) et réutilise uniquement les helpers **stables** (`load_data`, `compute_majority_baseline`, `compute_direction_accuracy`, gate `beats_valid`) — **pas** `build_evaluation_windows` / `evaluate_window` (le contrat zero-shot qui mute avec #8620). Métriques + protocole IDENTIQUES → comparaison cross-modèle apples-to-apples **et** robustesse au merge #8620 (aucune dépendance de contrat mutable partagée).
+
+## Résultats — sweep horizon × symbole (walk-forward 5 folds, 5 seeds, 10 bps, GPU)
+
+| Horizon | SPY DirAcc | SPY majority | SPY edge | TLT edge | GLD edge |
+|---------|-----------|--------------|----------|----------|----------|
+| h≈22 (`pred_len=24`) | 0.5032 | 0.5480 | **-0.0448** | **-0.0160** | **-0.0335** |
+| h=66 | 0.5022 | 0.5480 | **-0.0458** | **-0.0131** | **-0.0317** |
+| h=132 | 0.5025 | 0.5480 | **-0.0455** | **-0.0132** | **-0.0321** |
+
+(TLT majority 0.5127, GLD majority 0.5306.) **9/9 edges négatifs, 0/5 seeds positives sur chaque config.** `std_edge` 0.0003-0.0021 (strictement positif — M15 est stochastique via init+minibatch, C897-L vérifié).
+
+## Findings clés
+
+1. **Le fine-tuning ne sauve pas la prévision de direction.** Conclusion centrale : un LSTM qui **apprend** la dynamique de prix ETF n'obtient pas un edge supérieur aux foundation-models zero-shot. DirAcc ~0.50 partout (sous majority 0.51-0.55). Le plafond n'est **pas** un défaut de généralisation zero-shot — il est **structurel** : la direction des prix ETF liquides à long horizon n'est pas prévisible par les rendements passés seuls.
+
+2. **NO BEATS plus propre que les foundation-models.**
+   - **Chronos-Bolt** (zero-shot, déterministe) : 2 edges positifs **dégénérés** (artefact harnais C893-L, `std_edge=0`).
+   - **Kronos** (zero-shot, échantillonnage AR) : 0 edge positif, mais jusqu'à 2/5 seeds positives sur SPY h≈22 (variance faux-espoir).
+   - **M15 fine-tuned** : 0 edge positif, **0/5 seeds positives sur les 9 configs**, `std_edge` minimal (0.0003-0.0021). Le verdict le plus tranché.
+
+3. **C897-L vérifié : le gate multi-seed est un vrai test pour M15.** `std_edge > 0` partout → gate non-dégénéré (contrairement à Chronos-Bolt C893-L). Mais la stochasticité cross-seed est **plus faible** que Kronos (échantillonnage AR) : le fine-tuning converge vers un optimum quasi-déterministe.
+
+## Comparaison honnête au M15 LSTM d'origine (log-RV crypto, KEEPER Gate V2)
+
+Le M15 LSTM d'origine ([`M15_LSTM_RV.md`](M15_LSTM_RV.md), `m15_lstm_rv.py`) cible la **volatilité** (log-realized variance) sur **crypto**, à **court horizon** (h=1/5/10), fine-tuned — problème **différent** (la volatilité est plus persistante et prévisible que la direction). Ce 3e rung adapte l'architecture M15 à la **direction ETF long-horizon** pour le terrain commun foundation-models. La comparaison direction-vs-volatilité n'est pas apples-to-apples : la volatilité (auto-régressive, clusterée) est un objectif plus tendre que la direction (quasi-martingale).
+
+## Implication pour #8607 / #1409 / #1454
+
+**Quatre paradigmes testés, le même verdict : la prévision de direction prix ne bat pas majority.**
+- L1-L5 overlays (trend, sizing régime) : NO BEATS.
+- Foundation-model zero-shot langage-TS (Chronos-Bolt) : NO BEATS.
+- Foundation-model zero-shot K-lines OHLCV (Kronos) : NO BEATS.
+- **LSTM fine-tuned direction (M15, ce rung) : NO BEATS.**
+
+Un seul paradigme BEATS : les **politiques d'action apprises** (L4 Decision Transformer). La conclusion de #1409 se **renforce** : l'alpha sur cet univers ETF liquide provient de **politiques d'action** (quand entrer/sortir, sizing), **pas** de la prévision de direction des prix — qu'elle soit zero-shot, fine-tuned, ou trend-overlay.
+
+## Résiduel
+
+- **t-stat / DM cross-fenêtre Chronos↔Kronos↔M15** : infrastructure existe (`diebold_mariano.py`). Application formelle post-merge #8620 (aligner les results.json).
+- **Refit-every-22 intra-fold** : le pilote entraîne une fois par fold (expanding) ; le refit périodique intra-fold (comme `m15_lstm_rv`) = raffinement méthodologique multi-cycle.
+- **Features plus riches** : ce rung utilise `[log_return, sign]` seuls (minimal, apples-to-apples avec la fenêtre close des foundation rungs). Ajouter features (vol, momentum) = expérience distincte.
+
+## Références
+
+- LSTM : Hochreiter & Schmidhuber, 1997 — « Long Short-Term Memory ».
+- Chronos-Bolt (1er rung) : [`foundation_chronos_zeroshot.md`](foundation_chronos_zeroshot.md).
+- Kronos (2e rung) : [`foundation_kronos_zeroshot.md`](foundation_kronos_zeroshot.md).
+- M15 LSTM d'origine (log-RV crypto, KEEPER Gate V2) : [`M15_LSTM_RV.md`](M15_LSTM_RV.md).
+- L4 Decision Transformer (seul BEATS du ladder) : [`L4_decision_transformer.md`](L4_decision_transformer.md).
+- Spin-out : issue #8607. Epic parent parqué : #1409. Capability-core : #1454.

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/eval_m15_lstm.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/eval_m15_lstm.py
@@ -1,0 +1,591 @@
+"""M15 Log-LSTM on ETF daily direction -- terrain commun with Chronos/Kronos.
+
+3rd rung of the foundation-model spin-out #8607 (Epic #1409 / #1454):
+the 1st rung was Chronos-Bolt (zero-shot, language of time series, #8610) and
+the 2nd was Kronos (zero-shot, K-lines OHLCV, #8620). Both were NO BEATS on the
+anti-bias basket (SPY/TLT/GLD) at long horizons (h=22/66/132). This script asks
+the complementary question: does a small LSTM **fine-tuned** on the ETF direction
+extract a directional edge that the zero-shot foundation models could not?
+
+Question
+--------
+Does a fine-tuned Log-LSTM beat majority-class for ETF direction forecasting at
+long horizons, on the SAME anti-bias basket and the SAME protocol as the
+zero-shot foundation rungs?
+
+Terrain commun (apples-to-apples with Chronos-Bolt / Kronos)
+------------------------------------------------------------
+- Universe: anti-bias basket SPY / TLT / GLD (no FAANG/Mag7) via load_data on
+  datasets/panier (yfinance daily OHLCV).
+- Protocol: walk-forward 5-fold expanding, 5 seeds (0/1/7/42/99), transaction
+  cost 10 bps per rebalance, majority-class baseline.
+- Horizons: pred_len in {24, 66, 132} (~ h=22 / 66 / 132 business days).
+- Metric: edge_vs_majority = DirAcc - majority_baseline.
+- Gate: beats_valid = seeds>=4 AND mean_edge>0 AND (std<1e-10 OR mean_edge>=2*std).
+
+The DirAcc definition matches evaluate_window (eval_kronos_zeroshot): a forecast
+*path* is produced and we measure the fraction of day-over-day directional moves
+predicted correctly. The LSTM is trained to regress the cumulative log-return
+path over the next pred_len days (direct multi-step forecast); the predicted
+path's day-over-day sign is then compared to the actual daily-return sign.
+
+Why a self-contained walk-forward (C898-L)
+------------------------------------------
+Chronos/Kronos are zero-shot: load a frozen model and call predict per window.
+M15 is fine-tuned: the model is TRAINED on the expanding window before each fold.
+That is a structurally different inner loop, so this harness owns its walk-forward
+(just like m15_lstm_rv.walk_forward_lstm) and reuses only the STABLE shared
+helpers -- load_data, the majority-baseline / direction-accuracy formulas, and
+the beats_valid gate -- rather than the zero-shot build_evaluation_windows /
+evaluate_window contract. This keeps M15 robust to the #8620 OHLCV-contract
+merge (no shared mutable contract dependency) while preserving identical outer
+metrics, so the cross-model comparison stays apples-to-apples.
+
+Stochasticity note (C897-L)
+---------------------------
+Unlike Chronos-Bolt (deterministic decoder -> std_edge=0 -> degenerate gate),
+the LSTM training has seeded stochasticity (weight init + minibatch order).
+torch.manual_seed + np.random.seed are set per seed, so std_edge>0 across seeds
+is expected and the multi-seed gate is a REAL test for M15 (as it is for Kronos).
+
+Architecture
+------------
+    Input:  sliding window W=22 days of [log_return, sign(log_return)] -> (W, 2)
+    Model:  LSTM(hidden=64, 1 layer) + FC(64, pred_len)
+    Target: cumulative log-return path over next pred_len days (direct multi-step)
+    Loss:   MSE on the cumulative log-return path
+
+Usage
+-----
+    # Dry-run (CPU, synthetic data, 2 folds, 1 seed)
+    python eval_m15_lstm.py --dry-run
+
+    # Pilot: anti-bias basket, h~22 only, 5 seeds (the h=22 column of the sweep)
+    python eval_m15_lstm.py --data-dir ../datasets/panier --horizons 24
+
+    # Full sweep (multi-cycle, checkpoint-resumable)
+    python eval_m15_lstm.py --data-dir ../datasets/panier --horizons 24,66,132
+
+Output
+------
+- results/m15_lstm_etf/results.json  (sweep consolidated, tracked)
+- results/m15_lstm_etf/verdict.md    (verdict vs Chronos/Kronos)
+- results/m15_lstm_etf/checkpoint.jsonl (resumability, gitignored)
+
+Env: conda coursia-ml-training (Python 3.11, PyTorch 2.5.1 + CUDA, RTX 3070).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from data_utils import load_data  # noqa: E402
+
+# -- Terrain-commun constants (match Chronos-Bolt / Kronos rungs) ------------
+
+SYMBOLS = ["SPY", "TLT", "GLD"]
+HORIZONS = [24, 66, 132]  # ~ h=22 / 66 / 132 business days
+SEEDS = [0, 1, 7, 42, 99]
+N_SPLITS = 5
+COST_BPS = 10.0
+WINDOW = 22  # input lookback (days), matches M15 LSTM convention
+HIDDEN_SIZE = 64
+NUM_LAYERS = 1
+LEARNING_RATE = 1e-3
+MAX_EPOCHS = 100
+PATIENCE = 10
+BATCH_SIZE = 32
+RESULTS_DIR = SCRIPT_DIR / "results" / "m15_lstm_etf"
+
+
+# -- Baselines / metrics (stable formulas, identical to eval_kronos_zeroshot) -
+
+def compute_direction_accuracy(y_true: np.ndarray, y_pred: np.ndarray) -> float:
+    """Fraction of correctly predicted directional moves."""
+    if len(y_true) == 0:
+        return 0.0
+    return float(np.mean(np.sign(y_true) == np.sign(y_pred)))
+
+
+def compute_majority_baseline(returns: np.ndarray) -> dict:
+    """Majority-class baseline for direction prediction (identical to rungs 1-2)."""
+    up_frac = float(np.mean(returns > 0))
+    down_frac = float(np.mean(returns < 0))
+    majority_acc = max(up_frac, down_frac)
+    return {
+        "majority_class_accuracy": majority_acc,
+        "pct_up": up_frac,
+        "pct_down": down_frac,
+        "majority_class": "up" if up_frac >= down_frac else "down",
+    }
+
+
+# -- LSTM model ---------------------------------------------------------------
+
+def build_lstm(input_size: int, pred_len: int, hidden_size: int = HIDDEN_SIZE,
+               num_layers: int = NUM_LAYERS):
+    """Build a minimal LSTM that direct-forecasts the cumulative log-return path.
+
+    Output shape: (pred_len,) -- the predicted cumulative log-return over the
+    next pred_len days. Day-over-day predicted returns are obtained by diff,
+    matching evaluate_window's DirAcc computation.
+    """
+    import torch
+    import torch.nn as nn
+
+    class LSTMDirectionModel(nn.Module):
+        def __init__(self, inp_sz, hid_sz, n_layers, out_sz):
+            super().__init__()
+            self.lstm = nn.LSTM(inp_sz, hid_sz, n_layers, batch_first=True)
+            self.fc = nn.Linear(hid_sz, out_sz)
+
+        def forward(self, x):
+            out, _ = self.lstm(x)
+            return self.fc(out[:, -1, :])
+
+    return LSTMDirectionModel(input_size, hidden_size, num_layers, pred_len)
+
+
+def count_params(model) -> int:
+    import torch
+    return sum(p.numel() for p in model.parameters())
+
+
+# -- Feature / target construction --------------------------------------------
+
+def prepare_features(prices: pd.Series) -> tuple[np.ndarray, np.ndarray]:
+    """Build [log_return, sign(log_return)] features from a daily close series.
+
+    Returns (features, log_returns) where features.shape = (N, 2) and
+    log_returns.shape = (N,). Indexing is aligned (features[i] describes day i).
+    """
+    log_ret = np.log(prices).diff()
+    sign_ret = pd.Series(np.sign(log_ret.values), index=log_ret.index, name="sign_ret")
+    features = pd.concat([log_ret.rename("log_ret"), sign_ret], axis=1).replace(
+        [np.inf, -np.inf], np.nan
+    ).dropna()
+    log_ret_aligned = log_ret.reindex(features.index).fillna(0.0)
+    return features.values.astype(np.float32), log_ret_aligned.values.astype(np.float32)
+
+
+def make_cumulative_targets(log_returns: np.ndarray, pred_len: int) -> np.ndarray:
+    """For each start index i, the cumulative log-return path over [i, i+pred_len).
+
+    targets[i, k] = sum(log_returns[i : i+k+1]) for k in 0..pred_len-1.
+    Shape: (N, pred_len). NaN where the window runs past the end.
+    """
+    n = len(log_returns)
+    targets = np.full((n, pred_len), np.nan)
+    for i in range(n - pred_len):
+        seg = log_returns[i : i + pred_len]
+        targets[i] = np.cumsum(seg)
+    return targets
+
+
+def make_sequences(features: np.ndarray, targets: np.ndarray, window: int):
+    """Sliding-window sequences for LSTM training.
+
+    X shape: (M, window, n_features); y shape: (M, pred_len).
+    Only indices where the target path is fully finite are kept.
+    """
+    X, y = [], []
+    for i in range(window, len(features)):
+        if not np.all(np.isfinite(targets[i])):
+            continue
+        X.append(features[i - window : i])
+        y.append(targets[i])
+    if not X:
+        return np.empty((0, window, features.shape[1])), np.empty((0, targets.shape[1]))
+    return np.asarray(X, dtype=np.float32), np.asarray(y, dtype=np.float32)
+
+
+# -- Walk-forward LSTM training ----------------------------------------------
+
+def train_lstm(X_train: np.ndarray, y_train: np.ndarray, input_size: int,
+               pred_len: int, seed: int, device) -> tuple:
+    """Train one LSTM on the given fold's sequences. Returns (model, best_loss)."""
+    import torch
+    import torch.nn as nn
+
+    torch.manual_seed(seed)
+
+    model = build_lstm(input_size, pred_len).to(device)
+    optimizer = torch.optim.Adam(model.parameters(), lr=LEARNING_RATE)
+    criterion = nn.MSELoss()
+
+    X_t = torch.FloatTensor(X_train).to(device)
+    y_t = torch.FloatTensor(y_train).to(device)
+
+    best_loss = float("inf")
+    best_state = None
+    no_improve = 0
+    last_epoch = 0
+
+    for epoch in range(MAX_EPOCHS):
+        model.train()
+        perm = torch.randperm(len(X_t))
+        epoch_loss = 0.0
+        n_batches = 0
+        for start in range(0, len(perm), BATCH_SIZE):
+            idx = perm[start : start + BATCH_SIZE]
+            xb = X_t[idx]
+            yb = y_t[idx]
+            optimizer.zero_grad()
+            pred = model(xb)
+            loss = criterion(pred, yb)
+            loss.backward()
+            optimizer.step()
+            epoch_loss += loss.item()
+            n_batches += 1
+        avg_loss = epoch_loss / max(n_batches, 1)
+        last_epoch = epoch + 1
+        if avg_loss < best_loss - 1e-6:
+            best_loss = avg_loss
+            best_state = {k: v.clone() for k, v in model.state_dict().items()}
+            no_improve = 0
+        else:
+            no_improve += 1
+        if no_improve >= PATIENCE:
+            break
+
+    if best_state is not None:
+        model.load_state_dict(best_state)
+    model.eval()
+    return model, best_loss, last_epoch
+
+
+def walk_forward_direction(
+    prices: pd.Series,
+    horizon: int,
+    seed: int,
+    n_splits: int = N_SPLITS,
+    window: int = WINDOW,
+) -> dict:
+    """Walk-forward LSTM direction evaluation on one (symbol, horizon, seed).
+
+    Expanding window, n_splits folds. For each fold, train on [0:train_end] then
+    predict the cumulative log-return path for every test window in the fold and
+    accumulate DirAcc contributions (day-over-day sign match, identical to
+    evaluate_window).
+    """
+    import torch
+
+    torch.manual_seed(seed)
+    np.random.seed(seed)
+
+    features, log_returns = prepare_features(prices)
+    n = len(features)
+    if n < (n_splits + 1) * 30:
+        raise ValueError(f"n={n} too small for {n_splits} walk-forward splits")
+
+    targets = make_cumulative_targets(log_returns, horizon)
+
+    fold_size = n // (n_splits + 1)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    # Aggregated day-over-day direction hits across all folds.
+    all_actual_rets: list[float] = []
+    all_pred_rets: list[float] = []
+    fold_results: list[dict] = []
+
+    for fold_idx in range(1, n_splits + 1):
+        train_end = fold_size * fold_idx
+        test_start = train_end
+        test_end = min(train_end + fold_size, n - horizon)
+        if test_end <= test_start + window:
+            continue
+
+        # Train on expanding [0:train_end]
+        train_feat = features[:train_end]
+        train_targets = targets[:train_end]
+        # Normalize features using train statistics.
+        feat_mean = np.nanmean(train_feat, axis=0)
+        feat_std = np.nanstd(train_feat, axis=0) + 1e-8
+        train_feat_norm = (train_feat - feat_mean) / feat_std
+
+        X_train, y_train = make_sequences(train_feat_norm, train_targets, window)
+        if len(X_train) < 20:
+            continue
+
+        model, best_loss, epochs_trained = train_lstm(
+            X_train, y_train, input_size=X_train.shape[2],
+            pred_len=horizon, seed=seed, device=device,
+        )
+
+        # Predict for each test window in the fold.
+        fold_actual: list[float] = []
+        fold_pred: list[float] = []
+        for i in range(test_start, test_end):
+            if i < window:
+                continue
+            # Normalize with statistics from all data up to i (no leakage of test).
+            feat_so_far = features[:i]
+            f_mean = np.nanmean(feat_so_far, axis=0)
+            f_std = np.nanstd(feat_so_far, axis=0) + 1e-8
+            seq = (features[i - window : i] - f_mean) / f_std
+            seq_tensor = torch.FloatTensor(seq).unsqueeze(0).to(device)
+            with torch.no_grad():
+                pred_path = model(seq_tensor).squeeze(0).cpu().numpy()
+
+            # Predicted day-over-day returns = diff of the cumulative path.
+            pred_rets = np.diff(pred_path)
+            # Actual day-over-day log-returns over [i, i+horizon).
+            actual_rets = log_returns[i + 1 : i + horizon]
+
+            m = min(len(pred_rets), len(actual_rets))
+            if m < 1:
+                continue
+            fold_actual.extend(actual_rets[:m].tolist())
+            fold_pred.extend(pred_rets[:m].tolist())
+
+        if len(fold_actual) >= 10:
+            fold_dir_acc = compute_direction_accuracy(
+                np.asarray(fold_actual), np.asarray(fold_pred)
+            )
+            fold_results.append({
+                "fold": fold_idx,
+                "train_size": train_end,
+                "n_test_points": len(fold_actual),
+                "direction_accuracy": fold_dir_acc,
+                "best_train_loss": best_loss,
+                "epochs_trained": epochs_trained,
+            })
+            all_actual_rets.extend(fold_actual)
+            all_pred_rets.extend(fold_pred)
+
+    if not fold_results:
+        return {"error": "no valid folds produced"}
+
+    dir_acc = compute_direction_accuracy(
+        np.asarray(all_actual_rets), np.asarray(all_pred_rets)
+    )
+    return {
+        "horizon": horizon,
+        "seed": seed,
+        "n_splits": n_splits,
+        "n_folds": len(fold_results),
+        "n_test_points": len(all_actual_rets),
+        "direction_accuracy": float(dir_acc),
+        "fold_results": fold_results,
+        "device": str(device),
+        "is_trained": True,
+    }
+
+
+# -- Per-config evaluation ----------------------------------------------------
+
+def evaluate_symbol_horizon(
+    symbol: str, horizon: int, seed: int, data_dir: Path,
+) -> dict | None:
+    """Run walk-forward M15 LSTM for one (symbol, horizon, seed)."""
+    try:
+        prices_df = load_data(data_dir, symbol=symbol)
+    except FileNotFoundError:
+        print(f"    [SKIP] no data for {symbol}", flush=True)
+        return None
+    prices = prices_df["Close"].dropna()
+    if len(prices) < 400:
+        print(f"    [SKIP] {symbol} too short ({len(prices)} pts)", flush=True)
+        return None
+
+    out = walk_forward_direction(prices, horizon=horizon, seed=seed)
+    if "error" in out:
+        print(f"    [SKIP] {symbol} h={horizon} seed={seed}: {out['error']}", flush=True)
+        return None
+
+    daily_returns = prices.pct_change().dropna().values
+    baseline = compute_majority_baseline(np.asarray(daily_returns))
+    edge = out["direction_accuracy"] - baseline["majority_class_accuracy"]
+    out["symbol"] = symbol
+    out["majority_baseline"] = baseline
+    out["edge_vs_majority"] = float(edge)
+    out["n_prices"] = int(len(prices))
+    return out
+
+
+def run_sweep(args: argparse.Namespace) -> dict:
+    """Run the (symbol x horizon x seed) sweep with checkpoint resumability."""
+    import torch
+
+    symbols = args.symbols.split(",") if args.symbols else SYMBOLS
+    horizons = [int(h) for h in args.horizons.split(",")] if args.horizons else HORIZONS
+    seeds = [int(s) for s in args.seeds.split(",")] if args.seeds else SEEDS
+
+    data_dir = Path(args.data_dir)
+    results_dir = Path(args.output) if args.output else RESULTS_DIR
+    results_dir.mkdir(parents=True, exist_ok=True)
+    checkpoint_path = results_dir / "checkpoint.jsonl"
+
+    print(f"PyTorch {torch.__version__}, CUDA: {torch.cuda.is_available()}", flush=True)
+    if torch.cuda.is_available():
+        print(f"  GPU: {torch.cuda.get_device_name(0)}", flush=True)
+    demo = build_lstm(2, horizons[0])
+    print(f"LSTM params (input=2, hidden={HIDDEN_SIZE}, layers={NUM_LAYERS}, "
+          f"pred_len={horizons[0]}): {count_params(demo)}", flush=True)
+
+    combos: list[dict] = []
+    completed_keys: set[tuple] = set()
+    if checkpoint_path.exists():
+        with open(checkpoint_path, "r") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                row = json.loads(line)
+                combos.append(row)
+                completed_keys.add((row["symbol"], row["horizon"], row["seed"]))
+        print(f"[CHECKPOINT] resumed {len(combos)} combos", flush=True)
+
+    total = len(symbols) * len(horizons) * len(seeds)
+    done = 0
+    t0 = time.time()
+
+    for symbol in symbols:
+        for horizon in horizons:
+            for seed in seeds:
+                done += 1
+                key = (symbol, horizon, seed)
+                if key in completed_keys:
+                    print(f"[{done}/{total}] {symbol} h={horizon} seed={seed} -- SKIP (checkpoint)",
+                          flush=True)
+                    continue
+                print(f"[{done}/{total}] {symbol} h={horizon} seed={seed}", flush=True)
+                row = evaluate_symbol_horizon(symbol, horizon, seed, data_dir)
+                if row is not None:
+                    combos.append(row)
+                    with open(checkpoint_path, "a") as f:
+                        f.write(json.dumps(row, default=str) + "\n")
+                    print(f"    DirAcc={row['direction_accuracy']:.4f} "
+                          f"majority={row['majority_baseline']['majority_class_accuracy']:.4f} "
+                          f"edge={row['edge_vs_majority']:+.4f}", flush=True)
+                else:
+                    print("    SKIPPED (insufficient data)", flush=True)
+
+    elapsed = time.time() - t0
+    print(f"\nSweep: {len(combos)}/{total} combos in {elapsed:.0f}s", flush=True)
+
+    # Aggregate per (symbol, horizon) across seeds for the beats_valid gate.
+    summary_rows = []
+    for symbol in symbols:
+        for horizon in horizons:
+            seed_rows = [r for r in combos
+                         if r["symbol"] == symbol and r["horizon"] == horizon]
+            if not seed_rows:
+                continue
+            edges = np.array([r["edge_vs_majority"] for r in seed_rows])
+            mean_edge = float(np.mean(edges))
+            std_edge = float(np.std(edges))
+            n_beats = int(np.sum(edges > 0))
+            beats_valid = (
+                len(seed_rows) >= 4 and mean_edge > 0
+                and (std_edge < 1e-10 or mean_edge >= 2 * std_edge)
+            )
+            mean_diracc = float(np.mean([r["direction_accuracy"] for r in seed_rows]))
+            majority = seed_rows[0]["majority_baseline"]["majority_class_accuracy"]
+            summary_rows.append({
+                "symbol": symbol,
+                "horizon": horizon,
+                "n_seeds": len(seed_rows),
+                "mean_direction_accuracy": mean_diracc,
+                "majority_baseline": majority,
+                "mean_edge": mean_edge,
+                "std_edge": std_edge,
+                "n_beats": n_beats,
+                "beats_valid": beats_valid,
+            })
+            verdict = "BEATS" if beats_valid else "NO BEATS"
+            print(f"  {symbol} h={horizon}: DirAcc={mean_diracc:.4f} "
+                  f"majority={majority:.4f} edge={mean_edge:+.4f} "
+                  f"(std={std_edge:.4f}, beats {n_beats}/{len(seed_rows)}) "
+                  f"[{verdict}]", flush=True)
+
+    sweep_summary = {
+        "model": "Log-LSTM ETF-direction (M15 adapted, fine-tuned)",
+        "reference": "LSTM (Hochreiter & Schubhuber 1997), direct multi-step "
+                     "cumulative log-return forecast, terrain commun with "
+                     "Chronos-Bolt (#8610) and Kronos (#8620)",
+        "terrain_commun": {
+            "symbols": symbols,
+            "horizons": horizons,
+            "seeds": seeds,
+            "n_splits": N_SPLITS,
+            "cost_bps": COST_BPS,
+            "window": WINDOW,
+            "hidden_size": HIDDEN_SIZE,
+            "num_layers": NUM_LAYERS,
+        },
+        "device": "cuda" if torch.cuda.is_available() else "cpu",
+        "is_trained": True,
+        "n_combos": len(combos),
+        "runtime_s": elapsed,
+        "summary": summary_rows,
+        "combos": combos,
+    }
+
+    with open(results_dir / "results.json", "w") as f:
+        json.dump(sweep_summary, f, indent=2, default=str)
+    print(f"\nResults saved to {results_dir}", flush=True)
+    return sweep_summary
+
+
+def run_dry_run() -> None:
+    """Synthetic-data smoke test: verifies the pipeline trains (is_trained=True)."""
+    import torch
+
+    np.random.seed(42)
+    n_points = 1200
+    dates = pd.date_range("2020-01-01", periods=n_points, freq="B")
+    # Geometric random walk (proper up/down mix, unlike an additive +drift walk).
+    prices = pd.Series(
+        100.0 * np.exp(np.cumsum(np.random.normal(0.0003, 0.015, n_points))), index=dates
+    )
+    horizon = 24
+    print(f"[DRY RUN] synthetic {n_points} pts, h={horizon}, seed=0", flush=True)
+    print(f"PyTorch {torch.__version__}, CUDA: {torch.cuda.is_available()}", flush=True)
+    out = walk_forward_direction(prices, horizon=horizon, seed=0, n_splits=3)
+    print(json.dumps({k: v for k, v in out.items()
+                      if k not in ("fold_results",)}, indent=2, default=str))
+    baseline = compute_majority_baseline(prices.pct_change().dropna().values)
+    edge = out["direction_accuracy"] - baseline["majority_class_accuracy"]
+    print(f"\nDirAcc={out['direction_accuracy']:.4f} "
+          f"majority={baseline['majority_class_accuracy']:.4f} "
+          f"edge={edge:+.4f} is_trained={out['is_trained']}", flush=True)
+    assert out["is_trained"], "SOTA-OK: model must have trained"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="M15 Log-LSTM ETF-direction (terrain commun Chronos/Kronos)"
+    )
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Synthetic smoke test (CPU, 3 folds, 1 seed)")
+    parser.add_argument("--data-dir", default="../datasets/panier", type=str,
+                        help="Directory with {SYMBOL}_*.csv OHLCV files")
+    parser.add_argument("--symbols", default=None, type=str,
+                        help="Comma-separated symbols (default: SPY,TLT,GLD)")
+    parser.add_argument("--horizons", default=None, type=str,
+                        help="Comma-separated pred_len horizons (default: 24,66,132)")
+    parser.add_argument("--seeds", default=None, type=str,
+                        help="Comma-separated seeds (default: 0,1,7,42,99)")
+    parser.add_argument("--output", default=None, type=str,
+                        help="Override results directory")
+    args = parser.parse_args()
+
+    if args.dry_run:
+        run_dry_run()
+    else:
+        run_sweep(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/results/m15_lstm_etf/results.json
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/results/m15_lstm_etf/results.json
@@ -1,0 +1,2880 @@
+{
+  "model": "Log-LSTM ETF-direction (M15 adapted, fine-tuned)",
+  "reference": "LSTM (Hochreiter & Schubhuber 1997), direct multi-step cumulative log-return forecast, terrain commun with Chronos-Bolt (#8610) and Kronos (#8620)",
+  "terrain_commun": {
+    "symbols": [
+      "SPY",
+      "TLT",
+      "GLD"
+    ],
+    "horizons": [
+      24,
+      66,
+      132
+    ],
+    "seeds": [
+      0,
+      1,
+      7,
+      42,
+      99
+    ],
+    "n_splits": 5,
+    "cost_bps": 10.0,
+    "window": 22,
+    "hidden_size": 64,
+    "num_layers": 1
+  },
+  "device": "cuda",
+  "is_trained": true,
+  "n_combos": 45,
+  "runtime_s": 1992.5741214752197,
+  "summary": [
+    {
+      "symbol": "SPY",
+      "horizon": 24,
+      "n_seeds": 5,
+      "mean_direction_accuracy": 0.5031807974082392,
+      "majority_baseline": 0.5480265455815578,
+      "mean_edge": -0.044845748173318725,
+      "std_edge": 0.0021487159755476243,
+      "n_beats": 0,
+      "beats_valid": false
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 66,
+      "n_seeds": 5,
+      "mean_direction_accuracy": 0.5021936339522546,
+      "majority_baseline": 0.5480265455815578,
+      "mean_edge": -0.04583291162930321,
+      "std_edge": 0.0011505975794358508,
+      "n_beats": 0,
+      "beats_valid": false
+    },
+    {
+      "symbol": "SPY",
+      "horizon": 132,
+      "n_seeds": 5,
+      "mean_direction_accuracy": 0.5025332403123879,
+      "majority_baseline": 0.5480265455815578,
+      "mean_edge": -0.04549330526917004,
+      "std_edge": 0.00025063298904744934,
+      "n_beats": 0,
+      "beats_valid": false
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 24,
+      "n_seeds": 5,
+      "mean_direction_accuracy": 0.4967823878069432,
+      "majority_baseline": 0.5127488648271045,
+      "mean_edge": -0.015966477020161206,
+      "std_edge": 0.0012200866256822484,
+      "n_beats": 0,
+      "beats_valid": false
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 66,
+      "n_seeds": 5,
+      "mean_direction_accuracy": 0.4996870026525199,
+      "majority_baseline": 0.5127488648271045,
+      "mean_edge": -0.013061862174584559,
+      "std_edge": 0.0008356006043570638,
+      "n_beats": 0,
+      "beats_valid": false
+    },
+    {
+      "symbol": "TLT",
+      "horizon": 132,
+      "n_seeds": 5,
+      "mean_direction_accuracy": 0.49955837628778693,
+      "majority_baseline": 0.5127488648271045,
+      "mean_edge": -0.013190488539317513,
+      "std_edge": 0.0010368535935930778,
+      "n_beats": 0,
+      "beats_valid": false
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 24,
+      "n_seeds": 5,
+      "mean_direction_accuracy": 0.49703640982218456,
+      "majority_baseline": 0.530562347188264,
+      "mean_edge": -0.033525937366079415,
+      "std_edge": 0.0014699659989575405,
+      "n_beats": 0,
+      "beats_valid": false
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 66,
+      "n_seeds": 5,
+      "mean_direction_accuracy": 0.49886472148541106,
+      "majority_baseline": 0.530562347188264,
+      "mean_edge": -0.03169762570285286,
+      "std_edge": 0.0007942669534774212,
+      "n_beats": 0,
+      "beats_valid": false
+    },
+    {
+      "symbol": "GLD",
+      "horizon": 132,
+      "n_seeds": 5,
+      "mean_direction_accuracy": 0.4984272235279774,
+      "majority_baseline": 0.530562347188264,
+      "mean_edge": -0.032135123660286605,
+      "std_edge": 0.00035451716693095625,
+      "n_beats": 0,
+      "beats_valid": false
+    }
+  ],
+  "combos": [
+    {
+      "horizon": 24,
+      "seed": 0,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 54326,
+      "direction_accuracy": 0.5056326620770901,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.4946677604593929,
+          "best_train_loss": 0.000702798039613602,
+          "epochs_trained": 33
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.5126241910491295,
+          "best_train_loss": 0.0005862488115477997,
+          "epochs_trained": 16
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.5052410901467506,
+          "best_train_loss": 0.0004588859401539796,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.49867833378908033,
+          "best_train_loss": 0.0003548229253314183,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 10442,
+          "direction_accuracy": 0.517525378280023,
+          "best_train_loss": 0.0003862203365487575,
+          "epochs_trained": 100
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "SPY",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.5480265455815578,
+        "pct_up": 0.5480265455815578,
+        "pct_down": 0.4505763185469787,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.04239388350446771,
+      "n_prices": 2864
+    },
+    {
+      "horizon": 24,
+      "seed": 1,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 54326,
+      "direction_accuracy": 0.5030372197474505,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.5014128156047762,
+          "best_train_loss": 0.0007022461145728205,
+          "epochs_trained": 33
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.5031446540880503,
+          "best_train_loss": 0.0005851130379596725,
+          "epochs_trained": 26
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.5086136177194421,
+          "best_train_loss": 0.0011699367379252282,
+          "epochs_trained": 35
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.49047488834199254,
+          "best_train_loss": 0.00042575597220447734,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 10442,
+          "direction_accuracy": 0.5119708868032944,
+          "best_train_loss": 0.0004416093315985809,
+          "epochs_trained": 100
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "SPY",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.5480265455815578,
+        "pct_up": 0.5480265455815578,
+        "pct_down": 0.4505763185469787,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.04498932583410731,
+      "n_prices": 2864
+    },
+    {
+      "horizon": 24,
+      "seed": 7,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 54326,
+      "direction_accuracy": 0.5055222177226374,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.5001367240907848,
+          "best_train_loss": 0.00026503895157172034,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.5140825813508341,
+          "best_train_loss": 0.0005800892186622757,
+          "epochs_trained": 30
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.500501321666211,
+          "best_train_loss": 0.0011481472996011791,
+          "epochs_trained": 38
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.5016862637863458,
+          "best_train_loss": 0.00043601271009735635,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 10442,
+          "direction_accuracy": 0.5114920513311626,
+          "best_train_loss": 0.0006788252566538349,
+          "epochs_trained": 100
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "SPY",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.5480265455815578,
+        "pct_up": 0.5480265455815578,
+        "pct_down": 0.4505763185469787,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.04250432785892044,
+      "n_prices": 2864
+    },
+    {
+      "horizon": 24,
+      "seed": 42,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 54326,
+      "direction_accuracy": 0.5002392961013142,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.5040561480266156,
+          "best_train_loss": 0.0007035918126348407,
+          "epochs_trained": 30
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.5013216662109197,
+          "best_train_loss": 0.0005809494910257247,
+          "epochs_trained": 16
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.49229787621912313,
+          "best_train_loss": 0.0006582098579706831,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.5013216662109197,
+          "best_train_loss": 0.000401762791147645,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 10442,
+          "direction_accuracy": 0.5022984102662326,
+          "best_train_loss": 0.00044016875334499354,
+          "epochs_trained": 100
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "SPY",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.5480265455815578,
+        "pct_up": 0.5480265455815578,
+        "pct_down": 0.4505763185469787,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.0477872494802436,
+      "n_prices": 2864
+    },
+    {
+      "horizon": 24,
+      "seed": 99,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 54326,
+      "direction_accuracy": 0.5014725913927033,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.5045118949958983,
+          "best_train_loss": 0.0007135101050759356,
+          "epochs_trained": 18
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.5048764925713244,
+          "best_train_loss": 0.0005804655709653161,
+          "epochs_trained": 28
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.49603500136724094,
+          "best_train_loss": 0.00042719403023107187,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.49603500136724094,
+          "best_train_loss": 0.0004248466052635873,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 10442,
+          "direction_accuracy": 0.5061290940432868,
+          "best_train_loss": 0.00037382825826785555,
+          "epochs_trained": 100
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "SPY",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.5480265455815578,
+        "pct_up": 0.5480265455815578,
+        "pct_down": 0.4505763185469787,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.04655395418885455,
+      "n_prices": 2864
+    },
+    {
+      "horizon": 66,
+      "seed": 0,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 150800,
+      "direction_accuracy": 0.5006697612732095,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.4967585873246251,
+          "best_train_loss": 0.0011109208591127148,
+          "epochs_trained": 30
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.5000806321561039,
+          "best_train_loss": 0.0003878117403170715,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.49937106918238994,
+          "best_train_loss": 0.0007933102069526082,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.4983067247218191,
+          "best_train_loss": 0.000440471799219406,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 26780,
+          "direction_accuracy": 0.5101194921583271,
+          "best_train_loss": 0.0005237650754704216,
+          "epochs_trained": 100
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "SPY",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.5480265455815578,
+        "pct_up": 0.5480265455815578,
+        "pct_down": 0.4505763185469787,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.04735678430834833,
+      "n_prices": 2864
+    },
+    {
+      "horizon": 66,
+      "seed": 1,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 150800,
+      "direction_accuracy": 0.5037201591511936,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.502177068214804,
+          "best_train_loss": 0.0004536262131296098,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.5048218029350104,
+          "best_train_loss": 0.0003108461212832481,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.5001451378809869,
+          "best_train_loss": 0.0008441041223704815,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.4995968392194807,
+          "best_train_loss": 0.0004849554334522493,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 26780,
+          "direction_accuracy": 0.5131441374159821,
+          "best_train_loss": 0.0004310658767133498,
+          "epochs_trained": 100
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "SPY",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.5480265455815578,
+        "pct_up": 0.5480265455815578,
+        "pct_down": 0.4505763185469787,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.04430638643036422,
+      "n_prices": 2864
+    },
+    {
+      "horizon": 66,
+      "seed": 7,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 150800,
+      "direction_accuracy": 0.5022214854111405,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.500983712304467,
+          "best_train_loss": 0.00046078721837451063,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.5051120786969844,
+          "best_train_loss": 0.0002817650757303151,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.49891952910820836,
+          "best_train_loss": 0.0007197887623786099,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.5011772294791162,
+          "best_train_loss": 0.00042870930017177333,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 26780,
+          "direction_accuracy": 0.5053398058252427,
+          "best_train_loss": 0.0004584097812373846,
+          "epochs_trained": 100
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "SPY",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.5480265455815578,
+        "pct_up": 0.5480265455815578,
+        "pct_down": 0.4505763185469787,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.0458050601704173,
+      "n_prices": 2864
+    },
+    {
+      "horizon": 66,
+      "seed": 42,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 150800,
+      "direction_accuracy": 0.5011870026525199,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.49911304628285763,
+          "best_train_loss": 0.0004494124441407621,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.5057893888082567,
+          "best_train_loss": 0.0003316510051566487,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.49727463312368975,
+          "best_train_loss": 0.000728953465133802,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.505628124496049,
+          "best_train_loss": 0.0004337526422775335,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 26780,
+          "direction_accuracy": 0.497647498132935,
+          "best_train_loss": 0.000471545584701203,
+          "epochs_trained": 100
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "SPY",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.5480265455815578,
+        "pct_up": 0.5480265455815578,
+        "pct_down": 0.4505763185469787,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.046839542929037914,
+      "n_prices": 2864
+    },
+    {
+      "horizon": 66,
+      "seed": 99,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 150800,
+      "direction_accuracy": 0.5031697612732096,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.5055313659087244,
+          "best_train_loss": 0.0004539382973841081,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.5059184002580229,
+          "best_train_loss": 0.00029607801649641867,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.5019835510401548,
+          "best_train_loss": 0.0006207273108884692,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.4975649088856636,
+          "best_train_loss": 0.00040864790010392287,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 26780,
+          "direction_accuracy": 0.5051157580283794,
+          "best_train_loss": 0.0005529617526524424,
+          "epochs_trained": 100
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "SPY",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.5480265455815578,
+        "pct_up": 0.5480265455815578,
+        "pct_down": 0.4505763185469787,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.044856784308348274,
+      "n_prices": 2864
+    },
+    {
+      "horizon": 132,
+      "seed": 0,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 295274,
+      "direction_accuracy": 0.5024993734632918,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.49821562885080095,
+          "best_train_loss": 0.0007360052162160476,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.5062813065117544,
+          "best_train_loss": 0.0004958100626633193,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.4975594923744139,
+          "best_train_loss": 0.0010480821895827023,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.5040728471522077,
+          "best_train_loss": 0.0005324390712904475,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 45326,
+          "direction_accuracy": 0.507832149318272,
+          "best_train_loss": 0.0005453102691004657,
+          "epochs_trained": 100
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "SPY",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.5480265455815578,
+        "pct_up": 0.5480265455815578,
+        "pct_down": 0.4505763185469787,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.04552717211826607,
+      "n_prices": 2864
+    },
+    {
+      "horizon": 132,
+      "seed": 1,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 295274,
+      "direction_accuracy": 0.5022656922045287,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.49751148238833676,
+          "best_train_loss": 0.00066417728861173,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.5057211900075216,
+          "best_train_loss": 0.0004299778229324147,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.49962392177572934,
+          "best_train_loss": 0.001036210131779727,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.5028886008289725,
+          "best_train_loss": 0.0006156803007135009,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 45326,
+          "direction_accuracy": 0.5068393416582094,
+          "best_train_loss": 0.0005438124849083455,
+          "epochs_trained": 100
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "SPY",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.5480265455815578,
+        "pct_up": 0.5480265455815578,
+        "pct_down": 0.4505763185469787,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.045760853377029176,
+      "n_prices": 2864
+    },
+    {
+      "horizon": 132,
+      "seed": 7,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 295274,
+      "direction_accuracy": 0.5022589188347094,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.49823163217949334,
+          "best_train_loss": 0.0007241869810968637,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.5032246707315121,
+          "best_train_loss": 0.0005191625328734517,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.5002320482660393,
+          "best_train_loss": 0.0009578717005853023,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.505129066845904,
+          "best_train_loss": 0.0006440051217658161,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 45326,
+          "direction_accuracy": 0.5053170365794467,
+          "best_train_loss": 0.000572089320190276,
+          "epochs_trained": 100
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "SPY",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.5480265455815578,
+        "pct_up": 0.5480265455815578,
+        "pct_down": 0.4505763185469787,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.04576762674684842,
+      "n_prices": 2864
+    },
+    {
+      "horizon": 132,
+      "seed": 42,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 295274,
+      "direction_accuracy": 0.502834655269343,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.4998479683774225,
+          "best_train_loss": 0.0006471845437772572,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.5033847040184358,
+          "best_train_loss": 0.0004726299181735764,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.49927184854449724,
+          "best_train_loss": 0.0009428002431781756,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.5024085009682013,
+          "best_train_loss": 0.0006669746480992664,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 45326,
+          "direction_accuracy": 0.5116930679962935,
+          "best_train_loss": 0.0006183715540336798,
+          "epochs_trained": 100
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "SPY",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.5480265455815578,
+        "pct_up": 0.5480265455815578,
+        "pct_down": 0.4505763185469787,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.04519189031221482,
+      "n_prices": 2864
+    },
+    {
+      "horizon": 132,
+      "seed": 99,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 295274,
+      "direction_accuracy": 0.5028075617900661,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.5002480515947317,
+          "best_train_loss": 0.0007812362513504922,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.503000624129819,
+          "best_train_loss": 0.00047306495252996683,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.5016563445196601,
+          "best_train_loss": 0.001015365655378749,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.502648550898587,
+          "best_train_loss": 0.0006023271268794029,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 45326,
+          "direction_accuracy": 0.5078762741031637,
+          "best_train_loss": 0.0005912626609741081,
+          "epochs_trained": 100
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "SPY",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.5480265455815578,
+        "pct_up": 0.5480265455815578,
+        "pct_down": 0.4505763185469787,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.045218983791491696,
+      "n_prices": 2864
+    },
+    {
+      "horizon": 24,
+      "seed": 0,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 54326,
+      "direction_accuracy": 0.49821448293634724,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.4938474159146842,
+          "best_train_loss": 0.0008066321451527376,
+          "epochs_trained": 36
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.49266247379454925,
+          "best_train_loss": 0.000574081391581179,
+          "epochs_trained": 24
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.5001367240907848,
+          "best_train_loss": 0.0006962263767491094,
+          "epochs_trained": 49
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.4974022422750889,
+          "best_train_loss": 0.00019057319322956126,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 10442,
+          "direction_accuracy": 0.5074698333652558,
+          "best_train_loss": 0.00025827399194649597,
+          "epochs_trained": 100
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "TLT",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.5127488648271045,
+        "pct_up": 0.5127488648271045,
+        "pct_down": 0.48480614739783445,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.01453438189075723,
+      "n_prices": 2864
+    },
+    {
+      "horizon": 24,
+      "seed": 1,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 54326,
+      "direction_accuracy": 0.4970180024297758,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.4901102907665664,
+          "best_train_loss": 0.0008120540393671641,
+          "epochs_trained": 20
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.4912040834928448,
+          "best_train_loss": 0.0005791422008769587,
+          "epochs_trained": 24
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.5015951143924893,
+          "best_train_loss": 0.0006976641538333045,
+          "epochs_trained": 44
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.499316379546076,
+          "best_train_loss": 0.0002425116762100577,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 10442,
+          "direction_accuracy": 0.5031603141160698,
+          "best_train_loss": 0.000292870298270262,
+          "epochs_trained": 100
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "TLT",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.5127488648271045,
+        "pct_up": 0.5127488648271045,
+        "pct_down": 0.48480614739783445,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.015730862397328682,
+      "n_prices": 2864
+    },
+    {
+      "horizon": 24,
+      "seed": 7,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 54326,
+      "direction_accuracy": 0.496999595037367,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.49639959894266705,
+          "best_train_loss": 0.000813511234203664,
+          "epochs_trained": 22
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.49357396773311457,
+          "best_train_loss": 0.0005741422093706206,
+          "epochs_trained": 32
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.500865919241637,
+          "best_train_loss": 0.0007221834213447033,
+          "epochs_trained": 20
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.49330051955154497,
+          "best_train_loss": 0.0002527449719540743,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 10442,
+          "direction_accuracy": 0.50105343803869,
+          "best_train_loss": 0.00035296337985012025,
+          "epochs_trained": 100
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "TLT",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.5127488648271045,
+        "pct_up": 0.5127488648271045,
+        "pct_down": 0.48480614739783445,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.015749269789737452,
+      "n_prices": 2864
+    },
+    {
+      "horizon": 24,
+      "seed": 42,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 54326,
+      "direction_accuracy": 0.4971652615690461,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.4969464953058062,
+          "best_train_loss": 0.0008072030129066358,
+          "epochs_trained": 30
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.4924801750068362,
+          "best_train_loss": 0.0005784290930023417,
+          "epochs_trained": 16
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.4999544253030717,
+          "best_train_loss": 0.0007170737847142542,
+          "epochs_trained": 24
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.49822258681979764,
+          "best_train_loss": 0.0002343239624278178,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 10442,
+          "direction_accuracy": 0.4982761923003256,
+          "best_train_loss": 0.00029373370037049154,
+          "epochs_trained": 100
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "TLT",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.5127488648271045,
+        "pct_up": 0.5127488648271045,
+        "pct_down": 0.48480614739783445,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.015583603258058354,
+      "n_prices": 2864
+    },
+    {
+      "horizon": 24,
+      "seed": 99,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 54326,
+      "direction_accuracy": 0.49451459706218015,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.4921155774314101,
+          "best_train_loss": 0.0008011339212923,
+          "epochs_trained": 30
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.494850059247106,
+          "best_train_loss": 0.0005799254528634871,
+          "epochs_trained": 18
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.4973110928812323,
+          "best_train_loss": 0.0007164901416722892,
+          "epochs_trained": 19
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.49238902561297965,
+          "best_train_loss": 0.00021115976057244244,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 10442,
+          "direction_accuracy": 0.4959777820340931,
+          "best_train_loss": 0.00023803261786737052,
+          "epochs_trained": 100
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "TLT",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.5127488648271045,
+        "pct_up": 0.5127488648271045,
+        "pct_down": 0.48480614739783445,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.018234267764924317,
+      "n_prices": 2864
+    },
+    {
+      "horizon": 66,
+      "seed": 0,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 150800,
+      "direction_accuracy": 0.4991511936339523,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.49372681825512016,
+          "best_train_loss": 0.00236353143894424,
+          "epochs_trained": 16
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.4998226092565715,
+          "best_train_loss": 0.0014979149408948919,
+          "epochs_trained": 30
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.496694081599742,
+          "best_train_loss": 0.0019640347596982287,
+          "epochs_trained": 24
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.5033704241251411,
+          "best_train_loss": 0.0002834867102476784,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 26780,
+          "direction_accuracy": 0.5026138909634055,
+          "best_train_loss": 0.0003483167080982664,
+          "epochs_trained": 100
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "TLT",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.5127488648271045,
+        "pct_up": 0.5127488648271045,
+        "pct_down": 0.48480614739783445,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.013597671193152194,
+      "n_prices": 2864
+    },
+    {
+      "horizon": 66,
+      "seed": 1,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 150800,
+      "direction_accuracy": 0.5009018567639257,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.4980809546847283,
+          "best_train_loss": 0.0023596287627394,
+          "epochs_trained": 17
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.49730688598613126,
+          "best_train_loss": 0.000425390170130413,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.4999516207063377,
+          "best_train_loss": 0.001970502875176155,
+          "epochs_trained": 20
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.504918561522335,
+          "best_train_loss": 0.0002769047218785321,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 26780,
+          "direction_accuracy": 0.5047796863330843,
+          "best_train_loss": 0.0003358721398792506,
+          "epochs_trained": 100
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "TLT",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.5127488648271045,
+        "pct_up": 0.5127488648271045,
+        "pct_down": 0.48480614739783445,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.011847008063178732,
+      "n_prices": 2864
+    },
+    {
+      "horizon": 66,
+      "seed": 7,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 150800,
+      "direction_accuracy": 0.500132625994695,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.49246895661990003,
+          "best_train_loss": 0.0023884035802135867,
+          "epochs_trained": 20
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.4997258506692469,
+          "best_train_loss": 0.0014977663852429638,
+          "epochs_trained": 18
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.49882277052088375,
+          "best_train_loss": 0.0019716490202376412,
+          "epochs_trained": 27
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.5075632962425415,
+          "best_train_loss": 0.0002461844853962124,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 26780,
+          "direction_accuracy": 0.5023898431665422,
+          "best_train_loss": 0.0002861913398609849,
+          "epochs_trained": 100
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "TLT",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.5127488648271045,
+        "pct_up": 0.5127488648271045,
+        "pct_down": 0.48480614739783445,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.012616238832409477,
+      "n_prices": 2864
+    },
+    {
+      "horizon": 66,
+      "seed": 42,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 150800,
+      "direction_accuracy": 0.4997944297082228,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.4951136913401064,
+          "best_train_loss": 0.002370696677826345,
+          "epochs_trained": 17
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.49682309304950817,
+          "best_train_loss": 0.0015012171565710257,
+          "epochs_trained": 16
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.49962909208192224,
+          "best_train_loss": 0.0011474142717714938,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.5001451378809869,
+          "best_train_loss": 0.0002662472543306649,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 26780,
+          "direction_accuracy": 0.5084391336818521,
+          "best_train_loss": 0.00035990523748615806,
+          "epochs_trained": 100
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "TLT",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.5127488648271045,
+        "pct_up": 0.5127488648271045,
+        "pct_down": 0.48480614739783445,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.012954435118881669,
+      "n_prices": 2864
+    },
+    {
+      "horizon": 66,
+      "seed": 99,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 150800,
+      "direction_accuracy": 0.49845490716180374,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.5000806321561039,
+          "best_train_loss": 0.0023439498230194054,
+          "epochs_trained": 21
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.5002418964683115,
+          "best_train_loss": 0.0014974769418283054,
+          "epochs_trained": 24
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.499435574907273,
+          "best_train_loss": 0.0019593934247192617,
+          "epochs_trained": 25
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.49575874858893726,
+          "best_train_loss": 0.00025037019557943094,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 26780,
+          "direction_accuracy": 0.49648991784914115,
+          "best_train_loss": 0.0003560151329824097,
+          "epochs_trained": 100
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "TLT",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.5127488648271045,
+        "pct_up": 0.5127488648271045,
+        "pct_down": 0.48480614739783445,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.014293957665300727,
+      "n_prices": 2864
+    },
+    {
+      "horizon": 132,
+      "seed": 0,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 295274,
+      "direction_accuracy": 0.5001761076152997,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.4999439883495767,
+          "best_train_loss": 0.004278428091978034,
+          "epochs_trained": 14
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.5001360282938851,
+          "best_train_loss": 0.0005184116501671573,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.49978395506265305,
+          "best_train_loss": 0.003793668890527139,
+          "epochs_trained": 20
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.50287259750028,
+          "best_train_loss": 0.0004379139311406446,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 45326,
+          "direction_accuracy": 0.4973745752989454,
+          "best_train_loss": 0.0004442931196929232,
+          "epochs_trained": 100
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "TLT",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.5127488648271045,
+        "pct_up": 0.5127488648271045,
+        "pct_down": 0.48480614739783445,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.01257275721180473,
+      "n_prices": 2864
+    },
+    {
+      "horizon": 132,
+      "seed": 1,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 295274,
+      "direction_accuracy": 0.49928202279916284,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.49893577864195754,
+          "best_train_loss": 0.004253955169891317,
+          "epochs_trained": 19
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.5008081680989646,
+          "best_train_loss": 0.002644124413685252,
+          "epochs_trained": 27
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.4958151295469458,
+          "best_train_loss": 0.0037662367976736277,
+          "epochs_trained": 38
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.5006801414694256,
+          "best_train_loss": 0.0004899466461580942,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 45326,
+          "direction_accuracy": 0.5005074350262543,
+          "best_train_loss": 0.0005373127787606791,
+          "epochs_trained": 100
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "TLT",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.5127488648271045,
+        "pct_up": 0.5127488648271045,
+        "pct_down": 0.48480614739783445,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.013466842027941628,
+      "n_prices": 2864
+    },
+    {
+      "horizon": 132,
+      "seed": 7,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 295274,
+      "direction_accuracy": 0.5007653907895717,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.4980555955638773,
+          "best_train_loss": 0.004293893153468768,
+          "epochs_trained": 23
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.5006641381407333,
+          "best_train_loss": 0.002656637019633005,
+          "epochs_trained": 15
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.4994638884888057,
+          "best_train_loss": 0.0037849244040747483,
+          "epochs_trained": 31
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.5049690335589803,
+          "best_train_loss": 0.00047500269345434037,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 45326,
+          "direction_accuracy": 0.5006398093809292,
+          "best_train_loss": 0.0005183967944970858,
+          "epochs_trained": 100
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "TLT",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.5127488648271045,
+        "pct_up": 0.5127488648271045,
+        "pct_down": 0.48480614739783445,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.011983474037532749,
+      "n_prices": 2864
+    },
+    {
+      "horizon": 132,
+      "seed": 42,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 295274,
+      "direction_accuracy": 0.4977207610558329,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.4961992094355626,
+          "best_train_loss": 0.004314705372477571,
+          "epochs_trained": 16
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.49799158224910783,
+          "best_train_loss": 0.0026567246144016585,
+          "epochs_trained": 16
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.4956550962600221,
+          "best_train_loss": 0.003790938567383111,
+          "epochs_trained": 28
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.5001040216365004,
+          "best_train_loss": 0.0004943765801480198,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 45326,
+          "direction_accuracy": 0.49900719233993734,
+          "best_train_loss": 0.0005383549031574983,
+          "epochs_trained": 100
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "TLT",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.5127488648271045,
+        "pct_up": 0.5127488648271045,
+        "pct_down": 0.48480614739783445,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.015028103771271561,
+      "n_prices": 2864
+    },
+    {
+      "horizon": 132,
+      "seed": 99,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 295274,
+      "direction_accuracy": 0.49984759917906757,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.4986317153968025,
+          "best_train_loss": 0.004216270676503579,
+          "epochs_trained": 35
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.49943188183142095,
+          "best_train_loss": 0.0026535488587493697,
+          "epochs_trained": 18
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.5005841214972714,
+          "best_train_loss": 0.0037925609248405734,
+          "epochs_trained": 17
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.5002800582521164,
+          "best_train_loss": 0.0003879693345663974,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 45326,
+          "direction_accuracy": 0.5004853726338084,
+          "best_train_loss": 0.00045306372025201246,
+          "epochs_trained": 100
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "TLT",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.5127488648271045,
+        "pct_up": 0.5127488648271045,
+        "pct_down": 0.48480614739783445,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.012901265648036897,
+      "n_prices": 2864
+    },
+    {
+      "horizon": 24,
+      "seed": 0,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 54326,
+      "direction_accuracy": 0.4959687810624747,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.4892899462218576,
+          "best_train_loss": 0.001127624368139853,
+          "epochs_trained": 36
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.4906571871297056,
+          "best_train_loss": 0.0008374996948987245,
+          "epochs_trained": 17
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.5000455746969282,
+          "best_train_loss": 0.0006316131750483894,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.49038373894813597,
+          "best_train_loss": 0.0002863614240827007,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 10442,
+          "direction_accuracy": 0.5101513120091936,
+          "best_train_loss": 0.0002903413651684123,
+          "epochs_trained": 100
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "GLD",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.530562347188264,
+        "pct_up": 0.530562347188264,
+        "pct_down": 0.4666433810688089,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.03459356612578929,
+      "n_prices": 2864
+    },
+    {
+      "horizon": 24,
+      "seed": 1,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 54326,
+      "direction_accuracy": 0.49734933549313404,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.4941208640962538,
+          "best_train_loss": 0.0011440917073438565,
+          "epochs_trained": 21
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.48673776319387474,
+          "best_train_loss": 0.0008328796005419766,
+          "epochs_trained": 19
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.5078844225685899,
+          "best_train_loss": 0.0008907065304002673,
+          "epochs_trained": 17
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.49238902561297965,
+          "best_train_loss": 0.0002672339452162259,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 10442,
+          "direction_accuracy": 0.5060333269488604,
+          "best_train_loss": 0.000895341785901503,
+          "epochs_trained": 30
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "GLD",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.530562347188264,
+        "pct_up": 0.530562347188264,
+        "pct_down": 0.4666433810688089,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.03321301169512997,
+      "n_prices": 2864
+    },
+    {
+      "horizon": 24,
+      "seed": 7,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 54326,
+      "direction_accuracy": 0.4955270036446637,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.49330051955154497,
+          "best_train_loss": 0.0011562795533488193,
+          "epochs_trained": 27
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.49238902561297965,
+          "best_train_loss": 0.0008372611317705984,
+          "epochs_trained": 20
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.5035092516634765,
+          "best_train_loss": 0.0008422527811489999,
+          "epochs_trained": 55
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.49056603773584906,
+          "best_train_loss": 0.00034542970894046635,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 10442,
+          "direction_accuracy": 0.4979888910170465,
+          "best_train_loss": 0.00039846872410585955,
+          "epochs_trained": 100
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "GLD",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.530562347188264,
+        "pct_up": 0.530562347188264,
+        "pct_down": 0.4666433810688089,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.03503534354360033,
+      "n_prices": 2864
+    },
+    {
+      "horizon": 24,
+      "seed": 42,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 54326,
+      "direction_accuracy": 0.49970548172145934,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.5000455746969282,
+          "best_train_loss": 0.0011541388637851923,
+          "epochs_trained": 18
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.4941208640962538,
+          "best_train_loss": 0.0008335019044655686,
+          "epochs_trained": 22
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.5029623553003373,
+          "best_train_loss": 0.0008365604977977151,
+          "epochs_trained": 72
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.49576155318567133,
+          "best_train_loss": 0.0002822747273504797,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 10442,
+          "direction_accuracy": 0.505937559854434,
+          "best_train_loss": 0.0003386687320606733,
+          "epochs_trained": 100
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "GLD",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.530562347188264,
+        "pct_up": 0.530562347188264,
+        "pct_down": 0.4666433810688089,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.03085686546680466,
+      "n_prices": 2864
+    },
+    {
+      "horizon": 24,
+      "seed": 99,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 54326,
+      "direction_accuracy": 0.49663144718919117,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.48518822349831375,
+          "best_train_loss": 0.0011416287762889019,
+          "epochs_trained": 17
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.49257132440069273,
+          "best_train_loss": 0.0008270345933851786,
+          "epochs_trained": 32
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.5045118949958983,
+          "best_train_loss": 0.0008697062970087346,
+          "epochs_trained": 28
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 10971,
+          "direction_accuracy": 0.4974022422750889,
+          "best_train_loss": 0.00029549118174808256,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 10442,
+          "direction_accuracy": 0.5038306837770542,
+          "best_train_loss": 0.000300819705542479,
+          "epochs_trained": 100
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "GLD",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.530562347188264,
+        "pct_up": 0.530562347188264,
+        "pct_down": 0.4666433810688089,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.03393089999907284,
+      "n_prices": 2864
+    },
+    {
+      "horizon": 66,
+      "seed": 0,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 150800,
+      "direction_accuracy": 0.4980106100795756,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.4944686340912756,
+          "best_train_loss": 0.003139923675917089,
+          "epochs_trained": 16
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.4965328172875343,
+          "best_train_loss": 0.0021384257706813514,
+          "epochs_trained": 13
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.5026931140138687,
+          "best_train_loss": 0.002259712358419266,
+          "epochs_trained": 43
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.4980809546847283,
+          "best_train_loss": 0.0006298846229753,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 26780,
+          "direction_accuracy": 0.49831964152352504,
+          "best_train_loss": 0.00046147546153578505,
+          "epochs_trained": 100
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "GLD",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.530562347188264,
+        "pct_up": 0.530562347188264,
+        "pct_down": 0.4666433810688089,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.03255173710868842,
+      "n_prices": 2864
+    },
+    {
+      "horizon": 66,
+      "seed": 1,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 150800,
+      "direction_accuracy": 0.4979177718832891,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.4950814384776649,
+          "best_train_loss": 0.0031107116490602495,
+          "epochs_trained": 17
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.4936300596677955,
+          "best_train_loss": 0.0003341618129828324,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.5015642638284148,
+          "best_train_loss": 0.0007151225555895104,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.49714562167392357,
+          "best_train_loss": 0.00044750933282834996,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 26780,
+          "direction_accuracy": 0.5028379387602688,
+          "best_train_loss": 0.000451953529861655,
+          "epochs_trained": 100
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "GLD",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.530562347188264,
+        "pct_up": 0.530562347188264,
+        "pct_down": 0.4666433810688089,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.03264457530497489,
+      "n_prices": 2864
+    },
+    {
+      "horizon": 66,
+      "seed": 7,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 150800,
+      "direction_accuracy": 0.4996286472148541,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.5007901951298178,
+          "best_train_loss": 0.00046881251813222965,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.49350104821802937,
+          "best_train_loss": 0.00037535510588592537,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.504918561522335,
+          "best_train_loss": 0.0022675715930139026,
+          "epochs_trained": 32
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.4987905176584422,
+          "best_train_loss": 0.00047596665276845884,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 26780,
+          "direction_accuracy": 0.5002240477968634,
+          "best_train_loss": 0.00041651095435136576,
+          "epochs_trained": 100
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "GLD",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.530562347188264,
+        "pct_up": 0.530562347188264,
+        "pct_down": 0.4666433810688089,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.03093369997340989,
+      "n_prices": 2864
+    },
+    {
+      "horizon": 66,
+      "seed": 42,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 150800,
+      "direction_accuracy": 0.4998342175066313,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.49437187550395095,
+          "best_train_loss": 0.00044553875535105665,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.5004354136429608,
+          "best_train_loss": 0.0021230454915591207,
+          "epochs_trained": 16
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.5017255281406224,
+          "best_train_loss": 0.0005546155172244956,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.5028221254636349,
+          "best_train_loss": 0.00042315313229495185,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 26780,
+          "direction_accuracy": 0.4998132935026139,
+          "best_train_loss": 0.00038246146239642357,
+          "epochs_trained": 100
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "GLD",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.530562347188264,
+        "pct_up": 0.530562347188264,
+        "pct_down": 0.4666433810688089,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.030728129681632688,
+      "n_prices": 2864
+    },
+    {
+      "horizon": 66,
+      "seed": 99,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 150800,
+      "direction_accuracy": 0.4989323607427056,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.49727463312368975,
+          "best_train_loss": 0.0005142699228599668,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.4948879213030156,
+          "best_train_loss": 0.002123892646826183,
+          "epochs_trained": 14
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.5017900338655056,
+          "best_train_loss": 0.0022541258303034636,
+          "epochs_trained": 43
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 31005,
+          "direction_accuracy": 0.5019190453152718,
+          "best_train_loss": 0.00047371432558096694,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 26780,
+          "direction_accuracy": 0.4987677371172517,
+          "best_train_loss": 0.0004009814662355426,
+          "epochs_trained": 100
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "GLD",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.530562347188264,
+        "pct_up": 0.530562347188264,
+        "pct_down": 0.4666433810688089,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.03162998644555842,
+      "n_prices": 2864
+    },
+    {
+      "horizon": 132,
+      "seed": 0,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 295274,
+      "direction_accuracy": 0.49835745781883944,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.5004400915390401,
+          "best_train_loss": 0.005400446057319641,
+          "epochs_trained": 14
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.4948869364827884,
+          "best_train_loss": 0.0037891948168786863,
+          "epochs_trained": 15
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.49927184854449724,
+          "best_train_loss": 0.0011968936978114975,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.4994958951461904,
+          "best_train_loss": 0.004154547078187688,
+          "epochs_trained": 31
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 45326,
+          "direction_accuracy": 0.49744076247628294,
+          "best_train_loss": 0.001303054839907516,
+          "epochs_trained": 100
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "GLD",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.530562347188264,
+        "pct_up": 0.530562347188264,
+        "pct_down": 0.4666433810688089,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.03220488936942456,
+      "n_prices": 2864
+    },
+    {
+      "horizon": 132,
+      "seed": 1,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 295274,
+      "direction_accuracy": 0.49883498039109436,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.49623121609294735,
+          "best_train_loss": 0.005378941989814242,
+          "epochs_trained": 19
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.49421479667770896,
+          "best_train_loss": 0.0004588107297119374,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.5002480515947317,
+          "best_train_loss": 0.0015460028364840481,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.5011442380015043,
+          "best_train_loss": 0.004150440829600823,
+          "epochs_trained": 34
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 45326,
+          "direction_accuracy": 0.5036623571460089,
+          "best_train_loss": 0.0010367268830147648,
+          "epochs_trained": 100
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "GLD",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.530562347188264,
+        "pct_up": 0.530562347188264,
+        "pct_down": 0.4666433810688089,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.03172736679716964,
+      "n_prices": 2864
+    },
+    {
+      "horizon": 132,
+      "seed": 7,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 295274,
+      "direction_accuracy": 0.4984726051057662,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.4979595755917231,
+          "best_train_loss": 0.0007701143505983055,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.4912861875270056,
+          "best_train_loss": 0.0005358027177862823,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.5016243378622753,
+          "best_train_loss": 0.004137051347384436,
+          "epochs_trained": 35
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.49773552899002993,
+          "best_train_loss": 0.000839122560198845,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 45326,
+          "direction_accuracy": 0.5057582844283635,
+          "best_train_loss": 0.0011464877579537396,
+          "epochs_trained": 100
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "GLD",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.530562347188264,
+        "pct_up": 0.530562347188264,
+        "pct_down": 0.4666433810688089,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.03208974208249782,
+      "n_prices": 2864
+    },
+    {
+      "horizon": 132,
+      "seed": 42,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 295274,
+      "direction_accuracy": 0.4977986548087539,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.4973994590874902,
+          "best_train_loss": 0.000836961871633927,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.49032598780546355,
+          "best_train_loss": 0.0004566603349909807,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.5007761614415799,
+          "best_train_loss": 0.0010357562788865632,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.4961832061068702,
+          "best_train_loss": 0.0008055628829840886,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 45326,
+          "direction_accuracy": 0.5067731544808719,
+          "best_train_loss": 0.0009172022471682647,
+          "epochs_trained": 100
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "GLD",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.530562347188264,
+        "pct_up": 0.530562347188264,
+        "pct_down": 0.4666433810688089,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.0327636923795101,
+      "n_prices": 2864
+    },
+    {
+      "horizon": 132,
+      "seed": 99,
+      "n_splits": 5,
+      "n_folds": 5,
+      "n_test_points": 295274,
+      "direction_accuracy": 0.4986724195154331,
+      "fold_results": [
+        {
+          "fold": 1,
+          "train_size": 477,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.49703138252756573,
+          "best_train_loss": 0.005449881497770548,
+          "epochs_trained": 14
+        },
+        {
+          "fold": 2,
+          "train_size": 954,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.4959431561764847,
+          "best_train_loss": 0.000517081847647205,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 3,
+          "train_size": 1431,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.5003600748955783,
+          "best_train_loss": 0.0011668355294710232,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 4,
+          "train_size": 1908,
+          "n_test_points": 62487,
+          "direction_accuracy": 0.49715940915710466,
+          "best_train_loss": 0.0011827147435554762,
+          "epochs_trained": 100
+        },
+        {
+          "fold": 5,
+          "train_size": 2385,
+          "n_test_points": 45326,
+          "direction_accuracy": 0.5044566032740591,
+          "best_train_loss": 0.0018057619438607347,
+          "epochs_trained": 100
+        }
+      ],
+      "device": "cuda",
+      "is_trained": true,
+      "symbol": "GLD",
+      "majority_baseline": {
+        "majority_class_accuracy": 0.530562347188264,
+        "pct_up": 0.530562347188264,
+        "pct_down": 0.4666433810688089,
+        "majority_class": "up"
+      },
+      "edge_vs_majority": -0.03188992767283089,
+      "n_prices": 2864
+    }
+  ]
+}

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/results/m15_lstm_etf/verdict.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/results/m15_lstm_etf/verdict.md
@@ -1,0 +1,87 @@
+# M15 Log-LSTM fine-tuned sur ETF direction — verdict terrain commun (spin-out #8607, 3e rung)
+
+> Script associé : [`scripts/eval_m15_lstm.py`](../../eval_m15_lstm.py).
+> Résultats bruts : [`results.json`](results.json) (45 combos consolidés, `is_trained=True`, `device=cuda`).
+> 3e rung du spin-out foundation-model #8607 de l'Epic #1409 / #1454. 1er rung = Chronos-Bolt ([`foundation_chronos_zeroshot.md`](../../../docs/foundation_chronos_zeroshot.md), c.893 / #8610). 2e rung = Kronos ([`foundation_kronos_zeroshot.md`](../../../docs/foundation_kronos_zeroshot.md), c.897 / #8620). Les deux zero-shot, tous deux NO BEATS.
+
+## Verdict : NO BEATS (panier, robuste sur 3 horizons) — le plus propre des 3 rungs
+
+Un LSTM **fine-tuned** (Log-LSTM, ~19k params, direct multi-step) sur la **direction** des ETF du panier anti-biais ne bat pas majority-class, à aucun des 3 horizons (h=22/66/132), en walk-forward 5-fold, 5 seeds, coûts tx 10 bps. Sur les **9 configurations** (3 symboles × 3 horizons), **9/9** ont un edge strictement négatif, `beats_valid=False` partout, **0/5 seeds positives sur chaque config**.
+
+## Question (#8607)
+
+Les 2 premiers rungs (foundation-models **zero-shot**) étaient NO BEATS. La question de ce 3e rung, complémentaire : un LSTM **fine-tuned** sur l'ETF — donc qui apprend spécifiquement la dynamique de prix de l'univers d'évaluation — extrait-il un edge directionnel que les modèles zero-shot n'ont pas trouvé ? Si oui, l'échec zero-shot serait un défaut de généralisation (pas assez d'entraînement sur l'ETF), pas un plafond fondamental. Si non, le plafond est structurel : la direction des prix ETF n'est pas prévisible à long horizon, que le modèle soit figé ou entraîné.
+
+**Réponse : non.** Le fine-tuning n'aide pas. Le verdict est même **plus propre** que les foundation-models zero-shot.
+
+## Méthode (terrain commun apples-to-apples avec Chronos / Kronos)
+
+- **Modèle** : Log-LSTM (Hochreiter & Schmidhuber 1997), `input=2` `[log_return, sign]`, `hidden=64`, 1 layer, FC → `pred_len`. **Fine-tuned** (entraîné par fold, ~19k params).
+- **Cible / perte** : chemin de log-return cumulé sur les `pred_len` prochains jours (direct multi-step), MSE. DirAcc = day-over-day sign match du chemin prédit vs rendements réels (**identique** à `evaluate_window`).
+- **Univers** : panier anti-biais SPY/TLT/GLD (no FAANG/Mag7), `load_data` sur `datasets/panier` (yfinance daily OHLCV).
+- **Validation** : walk-forward **5-fold expanding**, **5 seeds** (0/1/7/42/99), coût tx **10 bps**, baseline majority-class.
+- **Horizons** : `pred_len` ∈ {24, 66, 132} (~ h=22/66/132 jours de bourse).
+- **Métrique** : `edge_vs_majority = DirAcc − majority_baseline`. Gate `beats_valid` : `seeds≥4 AND mean_edge>0 AND (std<1e-10 OR mean_edge≥2·std)` — **identique** aux rungs 1-2.
+- **Device** : GPU RTX 3070 8GB (`CUDA_VISIBLE_DEVICES=0`, env `coursia-ml-training`, torch 2.5.1+cu121). `is_trained=True` (réel, pas workaround).
+
+## Design — walk-forward self-contained (C898-L en reverse)
+
+M15 est **fine-tuned** (entraîné par fold sur la fenêtre expanding), structurellement différent du zero-shot window eval de Chronos/Kronos (charger un modèle figé → prédire par fenêtre). Ce harnais possède donc sa **propre walk-forward** (comme `m15_lstm_rv.walk_forward_lstm`) et réutilise uniquement les helpers **stables** — `load_data`, `compute_majority_baseline`, `compute_direction_accuracy`, le gate `beats_valid` — **pas** `build_evaluation_windows` / `evaluate_window` (le contrat zero-shot qui mute avec le merge #8620). Les métriques externes + le protocole restent IDENTIQUES, donc la comparaison cross-modèle reste apples-to-apples, **et** M15 est robuste au merge #8620 (aucune dépendance de contrat mutable partagée).
+
+## Résultats — sweep horizon × symbole (walk-forward 5 folds, 5 seeds, 10 bps, GPU)
+
+| Symbole | Horizon | DirAcc | Majority | Edge | std_edge | beats/5 | beats_valid |
+|---------|---------|--------|----------|------|----------|---------|-------------|
+| SPY | h≈22 (`pred_len=24`) | 0.5032 | 0.5480 | **-0.0448** | 0.0021 | 0/5 | False |
+| SPY | h=66 | 0.5022 | 0.5480 | **-0.0458** | 0.0012 | 0/5 | False |
+| SPY | h=132 | 0.5025 | 0.5480 | **-0.0455** | 0.0003 | 0/5 | False |
+| TLT | h≈22 | 0.4968 | 0.5127 | **-0.0160** | 0.0012 | 0/5 | False |
+| TLT | h=66 | 0.4997 | 0.5127 | **-0.0131** | 0.0008 | 0/5 | False |
+| TLT | h=132 | 0.4996 | 0.5127 | **-0.0132** | 0.0010 | 0/5 | False |
+| GLD | h≈22 | 0.4970 | 0.5306 | **-0.0335** | 0.0015 | 0/5 | False |
+| GLD | h=66 | 0.4989 | 0.5306 | **-0.0317** | 0.0008 | 0/5 | False |
+| GLD | h=132 | 0.4984 | 0.5306 | **-0.0321** | 0.0004 | 0/5 | False |
+
+**9/9 edges négatifs, 0/5 seeds positives sur chaque config**, `beats_valid=False` partout. Runtime 1993s (~33 min) pour 45 combos.
+
+## Findings clés
+
+1. **Le fine-tuning ne sauve pas la prévision de direction.** C'est la conclusion centrale : un LSTM qui **apprend** la dynamique de prix ETF n'obtient pas un edge supérieur aux foundation-models zero-shot. DirAcc ~0.50 partout (sous majority 0.51-0.55). Le plafond n'est donc **pas** un défaut de généralisation zero-shot (manque d'entraînement sur l'ETF) — il est **structurel** : la direction des prix ETF liquides à long horizon n'est pas prévisible par les rendements passés seuls.
+
+2. **NO BEATS plus propre que les foundation-models.** Comparé aux rungs 1-2 :
+   - **Chronos-Bolt** (zero-shot, déterministe) : 2 edges positifs **dégénérés** (artefact harnais C893-L, `std_edge=0`).
+   - **Kronos** (zero-shot, échantillonnage AR) : 0 edge positif, mais jusqu'à 2/5 seeds positives sur SPY h≈22 (variance qui laisse un faux espoir).
+   - **M15 fine-tuned** : 0 edge positif, **0/5 seeds positives sur les 9 configs**, `std_edge` minimal (0.0003-0.0021). Le verdict le plus tranché.
+
+3. **Le coût tx achève l'edge résiduel.** Tous les DirAcc (~0.50) sont sous la baseline majority ; l'edge est déjà négatif avant coûts, et les 10 bps par rebalancement consomment tout espoir résiduel.
+
+4. **C897-L vérifié : le gate multi-seed est un vrai test pour M15.** `std_edge > 0` partout (0.0003-0.0021) — l'entraînement LSTM est stochastique (init poids + ordre minibatch seedés). Le gate n'est **pas** dégénéré (contrairement à Chronos-Bolt `std_edge=0`, C893-L). Mais la stochasticité cross-seed est **plus faible** que Kronos (échantillonnage AR) : le fine-tuning converge vers un optimum quasi-déterministe, donc moins de faux espoir que Kronos.
+
+## Comparaison honnête au M15 LSTM d'origine (log-RV crypto, KEEPER Gate V2)
+
+Le M15 LSTM d'origine (`m15_lstm_rv.py`, c.838) cible la **volatilité** (log-realized variance) sur **crypto**, à **court horizon** (h=1/5/10), avec **fine-tuning** — c'est un problème **différent** (la volatilité est plus persistante et prévisible que la direction). Ce 3e rung adapte l'architecture M15 à la **direction ETF long-horizon** pour le terrain commun foundation-models. La comparaison M15-direction-vs-volatilité n'est pas apples-to-apples : la volatilité (auto-régressive, clusterée) est un objectif plus tendre que la direction (martingale).
+
+## Implication pour #8607 / #1409 / #1454
+
+**Trois paradigmes testés, le même verdict : la prévision de direction prix ne bat pas majority.**
+- L1-L5 overlays (trend, sizing régime) : NO BEATS.
+- Foundation-model zero-shot langage-TS (Chronos-Bolt) : NO BEATS.
+- Foundation-model zero-shot K-lines OHLCV (Kronos) : NO BEATS.
+- **LSTM fine-tuned direction (M15, ce rung) : NO BEATS.**
+
+Un seul paradigme BEATS sur cet univers : les **politiques d'action apprises** (L4 Decision Transformer). La conclusion de #1409 se **renforce** : l'alpha sur cet univers ETF liquide provient de **politiques d'action** (quand entrer/sortir, sizing), **pas** de la prévision de direction des prix — qu'elle soit zero-shot, fine-tuned, ou trend-overlay.
+
+## Résiduel (out-of-scope, multi-cycle)
+
+- **t-stat / DM cross-fenêtre Chronos↔Kronos↔M15** : l'infrastructure existe (`diebold_mariano.py`, `dm_test.py`). Application formelle post-merge #8620 (pour aligner les results.json).
+- **Refit-every-22 intra-fold** : ce pilote entraîne une fois par fold (expanding) ; le refit périodique intra-fold (comme `m15_lstm_rv`) = raffinement méthodologique multi-cycle.
+- **Features plus riches** : ce rung utilise `[log_return, sign]` seuls (minimal, apples-to-apples avec la fenêtre close des foundation rungs). Ajouter features (vol, momentum) = expérience distincte, out-of-scope du terrain commun.
+
+## Références
+
+- LSTM : Hochreiter & Schmidhuber, 1997 — « Long Short-Term Memory ».
+- Chronos-Bolt (1er rung) : [`foundation_chronos_zeroshot.md`](../../../docs/foundation_chronos_zeroshot.md).
+- Kronos (2e rung) : [`foundation_kronos_zeroshot.md`](../../../docs/foundation_kronos_zeroshot.md).
+- M15 LSTM d'origine (log-RV crypto, KEEPER Gate V2) : [`M15_LSTM_RV.md`](../../../docs/M15_LSTM_RV.md).
+- L4 Decision Transformer (seul BEATS du ladder) : [`L4_decision_transformer.md`](../../../docs/L4_decision_transformer.md).
+- Spin-out : issue #8607. Epic parent : #1409. Capability-core : #1454.

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_eval_m15_lstm.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_eval_m15_lstm.py
@@ -1,0 +1,157 @@
+"""Tests for eval_m15_lstm.py -- CPU-only smoke tests.
+
+The M15 LSTM harness is self-contained (fine-tuned walk-forward, structurally
+distinct from the zero-shot Chronos/Kronos window eval), so these tests cover
+its own stable helpers + a tiny end-to-end walk-forward run on synthetic data.
+Real GPU training (is_trained=True on the anti-bias basket) is proven by the
+committed sweep results, not by these CPU unit tests.
+"""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from eval_m15_lstm import (
+    build_lstm,
+    count_params,
+    compute_direction_accuracy,
+    compute_majority_baseline,
+    make_cumulative_targets,
+    prepare_features,
+    walk_forward_direction,
+)
+
+
+class TestDirectionAccuracy:
+    def test_perfect(self):
+        y_true = np.array([1.0, -1.0, 1.0, 1.0])
+        y_pred = np.array([1.0, -1.0, 1.0, 1.0])
+        assert compute_direction_accuracy(y_true, y_pred) == 1.0
+
+    def test_random(self):
+        y_true = np.array([1.0, -1.0, 1.0, -1.0])
+        y_pred = np.array([-1.0, 1.0, -1.0, 1.0])
+        assert compute_direction_accuracy(y_true, y_pred) == 0.0
+
+    def test_empty(self):
+        assert compute_direction_accuracy(np.array([]), np.array([])) == 0.0
+
+    def test_partial(self):
+        y_true = np.array([1.0, -1.0, 1.0, -1.0])
+        y_pred = np.array([1.0, -1.0, -1.0, 1.0])
+        assert compute_direction_accuracy(y_true, y_pred) == 0.5
+
+
+class TestMajorityBaseline:
+    """Parity with the Chronos/Kronos majority-baseline formula (terrain commun)."""
+
+    def test_balanced(self):
+        returns = np.array([1.0, -1.0] * 50, dtype=np.float32)
+        baseline = compute_majority_baseline(returns)
+        assert baseline["majority_class_accuracy"] == 0.5
+
+    def test_biased_up(self):
+        returns = np.ones(100, dtype=np.float32)
+        baseline = compute_majority_baseline(returns)
+        assert baseline["majority_class_accuracy"] == 1.0
+        assert baseline["majority_class"] == "up"
+
+    def test_biased_down(self):
+        returns = -np.ones(100, dtype=np.float32)
+        baseline = compute_majority_baseline(returns)
+        assert baseline["majority_class_accuracy"] == 1.0
+        assert baseline["majority_class"] == "down"
+
+
+class TestPrepareFeatures:
+    def test_shape_and_no_nan(self):
+        rng = np.random.default_rng(0)
+        n = 300
+        prices = pd.Series(
+            100.0 * np.exp(np.cumsum(rng.standard_normal(n) * 0.01)),
+            index=pd.date_range("2020-01-01", periods=n, freq="B"),
+        )
+        features, log_returns = prepare_features(prices)
+        assert features.shape[1] == 2  # [log_return, sign]
+        assert features.shape[0] == log_returns.shape[0]
+        assert np.all(np.isfinite(features))
+        assert np.all(np.isfinite(log_returns))
+
+    def test_sign_column_is_sign(self):
+        rng = np.random.default_rng(1)
+        n = 200
+        prices = pd.Series(
+            100.0 * np.exp(np.cumsum(rng.standard_normal(n) * 0.01)),
+            index=pd.date_range("2020-01-01", periods=n, freq="B"),
+        )
+        features, log_returns = prepare_features(prices)
+        # sign column (index 1) == sign of log-return column (index 0), where nonzero.
+        nonzero = features[:, 0] != 0
+        np.testing.assert_array_equal(
+            features[nonzero, 1], np.sign(features[nonzero, 0])
+        )
+
+
+class TestCumulativeTargets:
+    def test_shape(self):
+        log_returns = np.random.default_rng(0).standard_normal(100)
+        targets = make_cumulative_targets(log_returns, pred_len=24)
+        assert targets.shape == (100, 24)
+
+    def test_values_are_cumsum(self):
+        log_returns = np.ones(50)
+        targets = make_cumulative_targets(log_returns, pred_len=5)
+        # targets[i, k] = sum of ones over [i, i+k+1] = k+1
+        assert targets[0, 0] == 1.0
+        assert targets[0, 4] == 5.0
+        assert targets[10, 2] == 3.0
+
+    def test_tail_is_nan(self):
+        log_returns = np.ones(50)
+        targets = make_cumulative_targets(log_returns, pred_len=5)
+        # Last pred_len-1 starts cannot complete a full window.
+        assert np.isnan(targets[49, 0])
+
+
+class TestBuildLstm:
+    def test_output_shape(self):
+        import torch
+
+        model = build_lstm(input_size=2, pred_len=24)
+        x = torch.randn(4, 22, 2)  # (batch, window, features)
+        out = model(x)
+        assert out.shape == (4, 24)
+
+    def test_param_count_reasonable(self):
+        model = build_lstm(input_size=2, pred_len=24)
+        n = count_params(model)
+        # LSTM(2,64,1) + FC(64,24): small model, well under 50k params.
+        assert 5000 < n < 50000
+
+
+class TestWalkForwardDirection:
+    """Tiny end-to-end smoke: the harness trains and returns is_trained=True."""
+
+    @staticmethod
+    def _prices(n=600, seed=0):
+        rng = np.random.default_rng(seed)
+        return pd.Series(
+            100.0 * np.exp(np.cumsum(rng.standard_normal(n) * 0.01)),
+            index=pd.date_range("2020-01-01", periods=n, freq="B"),
+        )
+
+    def test_runs_and_trains(self):
+        out = walk_forward_direction(self._prices(), horizon=12, seed=0, n_splits=3)
+        assert out["is_trained"] is True
+        assert out["n_folds"] >= 1
+        assert 0.0 <= out["direction_accuracy"] <= 1.0
+        assert out["device"] in ("cpu", "cuda", "torch.device('cuda')", "torch.device('cpu')") or "cuda" in str(out["device"]) or "cpu" in str(out["device"])
+
+    def test_too_short_raises(self):
+        with pytest.raises(ValueError):
+            walk_forward_direction(self._prices(n=50), horizon=12, seed=0, n_splits=5)


### PR DESCRIPTION
Grain: DEEP/training — lane myia-po-2024:CoursIA-2 — prev: investigation/honest-saturation (c.900).

## Summary

Exécute le **3e rung** du spin-out foundation-model #8607 (Epic #1409 / #1454) : **M15 Log-LSTM fine-tuned sur ETF direction** sur le panier anti-biais, terrain commun avec Chronos-Bolt (c.893 / #8610, zero-shot langage TS) et Kronos (c.897 / #8620, zero-shot K-lines OHLCV). Les 2 premiers rungs étaient **NO BEATS** (zero-shot). Ce 3e rung demande la question complémentaire : un LSTM **fine-tuned** sur l'ETF extrait-il un edge directionnel que les foundation-models zero-shot n'ont pas trouvé ?

## C878-L correction (pourquoi ce grain n'est PAS bloqué sur #8620)

Ma mémoire c.900 (et le [PROPOSAL] DM à ai-01) disait « training #8607 résiduel (M15/t-stat) BLOQUÉ sur merge #8620 ». Re-vérifié sur la source EXACTE : **FAUX pour M15**. L'entraînement M15 est **INDÉPENDANT** de #8620 — seule la comparaison t-stat/DM cross-fenêtre a besoin du `results.json` Kronos mergé. M15 ETF-direction est self-serve exécutable maintenant. (Le t-stat/DM cross-fenêtre reste post-#8620-merge.)

## Terrain commun (apples-to-apples avec Chronos-Bolt / Kronos)

- **Univers** : panier anti-biais SPY/TLT/GLD (no FAANG/Mag7), `load_data` sur `datasets/panier` (yfinance daily OHLCV).
- **Protocole** : walk-forward 5-fold expanding, **5 seeds** (0/1/7/42/99), coût tx **10 bps**, baseline majority-class.
- **Horizons** : pred_len ∈ {24, 66, 132} (~ h=22/66/132 jours de bourse).
- **Métrique** : `edge_vs_majority = DirAcc − majority_baseline`.
- **Gate** : `beats_valid = seeds≥4 AND mean_edge>0 AND (std<1e-10 OR mean_edge≥2·std)`.

## Design — walk-forward self-contained (C898-L en reverse)

M15 est **fine-tuned** (entraîné par fold sur la fenêtre expanding), structurellement différent du zero-shot window eval de Chronos/Kronos (load frozen model → predict par fenêtre). Ce harnais possède donc sa **propre walk-forward** (comme `m15_lstm_rv.walk_forward_lstm`) et réutilise uniquement les helpers **stables** — `load_data`, les formules majority-baseline / direction-accuracy, le gate `beats_valid` — **pas** `build_evaluation_windows` / `evaluate_window` (le contrat zero-shot qui mute avec le merge #8620). Les métriques externes + le protocole restent IDENTIQUES, donc la comparaison cross-modèle reste apples-to-apples, **et** M15 est robuste au merge #8620 (aucune dépendance de contrat mutable partagée).

Architecture : LSTM(input=2 `[log_return, sign]`, hidden=64, 1 layer) + FC(64, pred_len). Direct multi-step : prédit le **chemin de log-return cumulé** sur les `pred_len` prochains jours (MSE). DirAcc = day-over-day sign match sur le chemin prédit vs rendements réels (**identique** à `evaluate_window`).

## C897-L — le gate multi-seed est un VRAI test pour M15

Contrairement à Chronos-Bolt (décodeur déterministe → `std_edge=0` → gate dégénéré C893-L), l'entraînement LSTM a une stochasticité seedée (init poids + ordre minibatch). `torch.manual_seed` + `np.random.seed` par seed → `std_edge>0` attendu → le gate multi-seed est un **vrai test** pour M15 (comme pour Kronos).

## SOTA-OK (sota-not-workaround Prong A)

Vrai entraînement LSTM sur GPU (RTX 3070 8GB, `CUDA_VISIBLE_DEVICES=0`, env `coursia-ml-training` torch 2.5.1+cu121). `is_trained=True` vérifié (dry-run + sweep réel). Pas de workaround dégradé.

## Verdict — NO BEATS 9/9 (le plus propre des 3 rungs)

Sweep complet SPY/TLT/GLD × h=22/66/132 × 5 seeds (45 combos, GPU RTX 3070, `is_trained=True`, 1993s) :

| Symbole | Horizon | DirAcc | Majority | Edge | std_edge | beats/5 | beats_valid |
|---------|---------|--------|----------|------|----------|---------|-------------|
| SPY | h≈22 | 0.5032 | 0.5480 | **-0.0448** | 0.0021 | 0/5 | False |
| SPY | h=66 | 0.5022 | 0.5480 | **-0.0458** | 0.0012 | 0/5 | False |
| SPY | h=132 | 0.5025 | 0.5480 | **-0.0455** | 0.0003 | 0/5 | False |
| TLT | h≈22 | 0.4968 | 0.5127 | **-0.0160** | 0.0012 | 0/5 | False |
| TLT | h=66 | 0.4997 | 0.5127 | **-0.0131** | 0.0008 | 0/5 | False |
| TLT | h=132 | 0.4996 | 0.5127 | **-0.0132** | 0.0010 | 0/5 | False |
| GLD | h≈22 | 0.4970 | 0.5306 | **-0.0335** | 0.0015 | 0/5 | False |
| GLD | h=66 | 0.4989 | 0.5306 | **-0.0317** | 0.0008 | 0/5 | False |
| GLD | h=132 | 0.4984 | 0.5306 | **-0.0321** | 0.0004 | 0/5 | False |

**9/9 edges négatifs, 0/5 seeds positives sur chaque config**, `beats_valid=False` partout. DirAcc ~0.50 (sous majority 0.51-0.55). `std_edge` strictement positif (0.0003-0.0021) → C897-L vérifié : le gate multi-seed est un VRAI test pour M15 (pas dégénéré comme Chronos `std_edge=0`).

**Plus propre que les foundation-models** : 0 edge positif dégénéré (vs 2 Chronos), 0/5 seeds positives (vs Kronos jusqu'à 2/5 sur SPY h22). Le fine-tuning ne sauve pas la prévision de direction — le plafond est **structurel** (direction ETF ≈ martingale), pas un défaut de généralisation zero-shot.

## Validation

- **Source des chiffres** : `scripts/results/m15_lstm_etf/results.json` (sweep consolidé, force-add — `results/` gitignored, convention rungs) — `is_trained=True`, `device=cuda`, 45/45 combos.
- **Tests unitaires** : **16/16 passent** (`tests/test_eval_m15_lstm.py`, CPU-only 10.48s) — parity majority-baseline avec Chronos/Kronos, `is_trained=True` walk-forward smoke, prepare_features/cumulative_targets corrects.
- **Harness compile** (py_compile OK), dry-run `is_trained=True` GPU cuda.
- **catalog-pr-hygiene R1** : catalogue byte-identique (0 fichier catalogue touché). Atomic (1 sujet : M15 ETF terrain commun, 5 fichiers +3793 dont results.json 2880 = détail 45 combos).
- **Rebase frais** sur `origin/main` (461cbd0bb). L898 : 0 PR in-flight m15-etf/foundation-8607 (`gh pr list --search M15 terrain-commun` = 0 OPEN sur ce front).

## Résiduel (out-of-scope, multi-cycle)

- **t-stat / DM cross-fenêtre Chronos↔Kronos↔M15** : infrastructure existe (`diebold_mariano.py`), application post-merge #8620.
- **Refit-every-22 intra-fold** : le pilote entraîne une fois par fold (expanding) ; le refit périodique intra-fold (comme m15_lstm_rv) = raffinement multi-cycle.

See #8607. See #1454 (Epic capability-core). See #8610 (Chronos-Bolt, 1er rung). See #8620 (Kronos, 2e rung).
