### PR TITLE
feat(tools,#8615): audit C.3 par cellule (--base/--head)

### DIFF
--- a/scripts/notebook_tools/audit_c1_c3.py
+++ b/scripts/notebook_tools/audit_c1_c3.py
@@ -5,12 +5,19 @@ Scans all .ipynb files under MyIA.AI.Notebooks/ and reports:
   C.1 violations: raise NotImplementedError, assert False, 1/0
   C.3 violations: output-only changes (outputs changed without source change)
 
+C.3 comes in two granularities. The default (working tree, whole notebook)
+flags a file whose diff touches no source at all. `--base/--head` compares two
+refs cell by cell and flags the case that actually reaches a merge gate: a PR
+edits one cell, re-runs the whole notebook, and commits fresh outputs for the
+cells it never touched.
+
 Usage:
     python audit_c1_c3.py                       # Full scan
     python audit_c1_c3.py --family GenAI        # Single family
     python audit_c1_c3.py --check c1            # C.1 only
     python audit_c1_c3.py --json                # JSON output
     python audit_c1_c3.py --summary             # Summary per family only
+    python audit_c1_c3.py --base main --head HEAD   # Per-cell C.3 on a branch
 
 Exit codes:
     0 — No violations
@@ -18,6 +25,7 @@ Exit codes:
 """
 
 import argparse
+import hashlib
 import json
 import re
 import subprocess
@@ -151,6 +159,129 @@ def check_c3(nb_path: Path) -> list[dict]:
     return []
 
 
+def _cells_at_ref(rel: str, ref: str) -> list[tuple[int, dict]] | None:
+    """Load a notebook's code cells at a given git ref, with their notebook index.
+
+    The index is the position in `nb["cells"]`, not the code-cell ordinal, so a
+    reported cell can be found by opening the notebook. Markdown cells carry no
+    outputs and are skipped.
+
+    Returns None when the notebook does not exist at that ref (added by the
+    diff under audit), which is not a C.3 violation.
+    """
+    try:
+        blob = subprocess.run(
+            ["git", "show", f"{ref}:{rel}"],
+            capture_output=True, cwd=str(REPO_ROOT), timeout=20,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+    if blob.returncode != 0 or not blob.stdout:
+        return None
+    try:
+        nb = json.loads(blob.stdout.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    return [(i, c) for i, c in enumerate(nb.get("cells", []))
+            if c.get("cell_type") == "code"]
+
+
+def _outputs_signature(cell: dict) -> tuple[int, int, str]:
+    """(output count, error-output count, concatenated text) for one cell.
+
+    Error outputs are counted separately because gaining one is the signature
+    of a re-execution that ran against a broken or absent service.
+    """
+    outs = cell.get("outputs", [])
+    n_err = 0
+    text_parts = []
+    for out in outs:
+        kind = out.get("output_type")
+        if kind == "error":
+            n_err += 1
+            text_parts.append(f"{out.get('ename', '')}: {out.get('evalue', '')}")
+        elif kind == "stream":
+            text_parts.append("".join(out.get("text", [])))
+        elif "data" in out:
+            text_parts.append(str(out["data"].get("text/plain", "")))
+    return len(outs), n_err, "".join(text_parts)
+
+
+def check_c3_scope(rel: str, base_ref: str, head_ref: str) -> list[dict]:
+    """Per-cell C.3: flag cells re-executed although their source is unchanged.
+
+    `check_c3` is whole-notebook: a single modified cell suppresses every flag
+    for the rest of the file. That is the case a PR hits in practice — it edits
+    one cell, re-runs the notebook, and commits fresh outputs for cells it never
+    touched. Under C.3 those outputs should not be staged.
+
+    Cells are matched by source hash (occurrence-aware, so two cells sharing the
+    same source stay distinct). A cell whose source is byte-identical across the
+    two refs but whose outputs differ is reported.
+
+    Both labels are C.3 violations; they describe what happened, not how bad it
+    is. OUTPUTS-LOST means the re-execution dropped outputs or gained error
+    outputs. OUTPUTS-REPLACED means the content differs without shrinking — do
+    not read it as benign: a run that fails loudly can *grow* the output count
+    with logged failures, which is how the worst cells of PR #8615 presented
+    (14->31 and 16->37 outputs, every added line an exception trace emitted
+    through `logging` rather than as an `error` output).
+    """
+    base_cells = _cells_at_ref(rel, base_ref)
+    head_cells = _cells_at_ref(rel, head_ref)
+    if base_cells is None or head_cells is None:
+        return []
+
+    base_by_hash: dict[str, list[dict]] = defaultdict(list)
+    for _, cell in base_cells:
+        digest = hashlib.md5("".join(cell.get("source", [])).encode("utf-8")).hexdigest()
+        base_by_hash[digest].append(cell)
+
+    seen: dict[str, int] = defaultdict(int)
+    violations = []
+    for idx, cell in head_cells:
+        source = "".join(cell.get("source", []))
+        digest = hashlib.md5(source.encode("utf-8")).hexdigest()
+        occurrence = seen[digest]
+        seen[digest] += 1
+        candidates = base_by_hash.get(digest, [])
+        if occurrence >= len(candidates):
+            continue  # source is new or modified in this diff — C.3 does not apply
+        before = candidates[occurrence]
+
+        n_before, err_before, text_before = _outputs_signature(before)
+        n_after, err_after, text_after = _outputs_signature(cell)
+        if (n_before, text_before) == (n_after, text_after):
+            continue
+
+        lost = n_after < n_before or err_after > err_before
+        violations.append({
+            "cell_index": idx,
+            "severity": "OUTPUTS-LOST" if lost else "OUTPUTS-REPLACED",
+            "outputs_before": n_before,
+            "outputs_after": n_after,
+            "errors_before": err_before,
+            "errors_after": err_after,
+            "source_head": source.strip().split("\n")[0][:70],
+            "reason": "outputs re-executed although source is unchanged vs base",
+        })
+    return violations
+
+
+def changed_notebooks(base_ref: str, head_ref: str) -> list[str]:
+    """Notebook paths modified between two refs, repo-relative, posix separators."""
+    try:
+        diff = subprocess.run(
+            ["git", "diff", "--name-only", f"{base_ref}...{head_ref}"],
+            capture_output=True, text=True, cwd=str(REPO_ROOT), timeout=30,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return []
+    if diff.returncode != 0:
+        return []
+    return [p for p in diff.stdout.split("\n") if p.strip().endswith(".ipynb")]
+
+
 def get_family(nb_path: Path) -> str:
     """Extract family name from path relative to NOTEBOOKS_DIR."""
     try:
@@ -160,6 +291,42 @@ def get_family(nb_path: Path) -> str:
         return "unknown"
 
 
+def run_scope_audit(base_ref: str, head_ref: str, as_json: bool = False) -> int:
+    """Per-cell C.3 audit over every notebook changed between two refs."""
+    notebooks = changed_notebooks(base_ref, head_ref)
+    if not notebooks:
+        print(f"No notebook changed between {base_ref} and {head_ref}.")
+        return 0
+
+    results = []
+    for rel in notebooks:
+        violations = check_c3_scope(rel, base_ref, head_ref)
+        if violations:
+            results.append({"path": rel, "violations": violations})
+
+    if as_json:
+        print(json.dumps({"base": base_ref, "head": head_ref,
+                          "notebooks_changed": len(notebooks),
+                          "violations": results}, indent=2, ensure_ascii=False))
+        return 1 if results else 0
+
+    print(f"C.3 scope audit ({base_ref}...{head_ref}): "
+          f"{len(notebooks) - len(results)}/{len(notebooks)} notebooks clean")
+    for entry in results:
+        lost = [v for v in entry["violations"] if v["severity"] == "OUTPUTS-LOST"]
+        print(f"\n  {entry['path']}")
+        print(f"    {len(entry['violations'])} cell(s) re-executed with unchanged source"
+              f" — {len(lost)} lost outputs")
+        for v in entry["violations"]:
+            print(f"    [{v['severity']:<16}] cell {v['cell_index']:<3} "
+                  f"outputs {v['outputs_before']}->{v['outputs_after']} "
+                  f"errors {v['errors_before']}->{v['errors_after']}  {v['source_head']}")
+    if results:
+        print("\nUnder C.3 these outputs should not be staged: the PR does not modify "
+              "these cells' source, so they did not have to be re-executed.")
+    return 1 if results else 0
+
+
 def main():
     parser = argparse.ArgumentParser(description="Repo-wide C.1 + C.3 audit")
     parser.add_argument("--family", type=str, default=None, help="Audit single family")
@@ -167,7 +334,14 @@ def main():
                         help="Checks: c1, c3 (default: c1,c3)")
     parser.add_argument("--json", action="store_true", help="JSON output")
     parser.add_argument("--summary", action="store_true", help="Summary per family only")
+    parser.add_argument("--base", type=str, default=None,
+                        help="Base ref for per-cell C.3 scope audit (e.g. origin/main)")
+    parser.add_argument("--head", type=str, default="HEAD",
+                        help="Head ref for per-cell C.3 scope audit (default: HEAD)")
     args = parser.parse_args()
+
+    if args.base:
+        return run_scope_audit(args.base, args.head, as_json=args.json)
 
     checks = set(args.check.split(","))
     notebooks = find_notebooks(args.family)

--- a/scripts/notebook_tools/tests/test_audit_c3_scope.py
+++ b/scripts/notebook_tools/tests/test_audit_c3_scope.py
@@ -1,0 +1,221 @@
+"""Tests for the per-cell C.3 scope audit (`audit_c1_c3.check_c3_scope`).
+
+The audited property: a PR that edits one cell, re-runs the whole notebook and
+commits fresh outputs for cells it never touched is staging outputs that C.3
+says should not be staged. The whole-notebook `check_c3` cannot see this — one
+modified cell suppresses every flag for the rest of the file.
+
+Git is stubbed via `_cells_at_ref` so the tests stay hermetic (no repo fixture,
+no network, no temporary clones).
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import audit_c1_c3  # noqa: E402
+
+
+def code(source, outputs=None, execution_count=1):
+    return {
+        "cell_type": "code",
+        "source": source if isinstance(source, list) else [source],
+        "outputs": outputs or [],
+        "execution_count": execution_count,
+    }
+
+
+def stream(text):
+    return {"output_type": "stream", "name": "stdout", "text": [text]}
+
+
+def error(ename="RuntimeError", evalue="boom"):
+    return {"output_type": "error", "ename": ename, "evalue": evalue, "traceback": []}
+
+
+@pytest.fixture
+def stub_refs(monkeypatch):
+    """Install a fake `_cells_at_ref` returning per-ref `(nb_index, cell)` lists.
+
+    Cells are numbered as if a markdown cell sat before each code cell, which is
+    the usual notebook shape and keeps the tests honest about the reported index
+    being the notebook position rather than the code-cell ordinal.
+    """
+
+    def numbered(cells):
+        return [(2 * i + 1, c) for i, c in enumerate(cells)]
+
+    def install(base_cells, head_cells):
+        def fake(rel, ref):
+            if ref == "BASE":
+                return numbered(base_cells)
+            if ref == "HEAD":
+                return numbered(head_cells)
+            return None
+        monkeypatch.setattr(audit_c1_c3, "_cells_at_ref", fake)
+
+    return install
+
+
+def scope(rel="nb.ipynb"):
+    return audit_c1_c3.check_c3_scope(rel, "BASE", "HEAD")
+
+
+def test_untouched_cell_with_identical_outputs_is_clean(stub_refs):
+    cell = code("print(1)", [stream("1\n")])
+    stub_refs([cell], [cell])
+    assert scope() == []
+
+
+def test_untouched_cell_re_executed_with_fewer_outputs_is_flagged(stub_refs):
+    stub_refs(
+        [code("print(1)", [stream("a"), stream("b"), stream("c")])],
+        [code("print(1)", [stream("a")])],
+    )
+    (v,) = scope()
+    assert v["severity"] == "OUTPUTS-LOST"
+    assert (v["outputs_before"], v["outputs_after"]) == (3, 1)
+
+
+def test_untouched_cell_gaining_error_output_is_flagged_as_lost(stub_refs):
+    stub_refs(
+        [code("call()", [stream("ok")])],
+        [code("call()", [stream("ok"), error()])],
+    )
+    (v,) = scope()
+    assert v["severity"] == "OUTPUTS-LOST"
+    assert (v["errors_before"], v["errors_after"]) == (0, 1)
+
+
+def test_untouched_cell_whose_outputs_grow_is_still_flagged(stub_refs):
+    """The #8615 shape: a failing re-run grows the output count with logged errors."""
+    stub_refs(
+        [code("bench()", [stream("25/25 OK")])],
+        [code("bench()", [stream("[ERROR] exception"), stream("[ERROR] exception")])],
+    )
+    (v,) = scope()
+    assert v["severity"] == "OUTPUTS-REPLACED"
+    assert v["outputs_after"] > v["outputs_before"]
+
+
+def test_modified_source_is_not_a_c3_violation(stub_refs):
+    """C.3 governs untouched cells only — an edited cell must be re-executed."""
+    stub_refs(
+        [code("print(1)", [stream("1")])],
+        [code("print(2)", [stream("2")])],
+    )
+    assert scope() == []
+
+
+def test_edited_cell_does_not_mask_its_untouched_neighbours(stub_refs):
+    """The gap that motivated this audit: `check_c3` goes silent here.
+
+    One edited cell is enough to make the whole-notebook check pass, so the
+    untouched neighbour's destroyed outputs sail through unflagged.
+    """
+    stub_refs(
+        [code("print(1)", [stream("1")]),
+         code("heavy()", [stream("row 1"), stream("row 2"), stream("row 3")])],
+        [code("print(99)", [stream("99")]),
+         code("heavy()", [stream("")])],
+    )
+    (v,) = scope()
+    assert v["cell_index"] == 3  # notebook position of the 2nd code cell
+    assert v["severity"] == "OUTPUTS-LOST"
+
+
+def test_duplicate_sources_are_matched_by_occurrence(stub_refs):
+    """Two cells sharing a source must not collapse onto the same base cell."""
+    stub_refs(
+        [code("ping()", [stream("first")]), code("ping()", [stream("second")])],
+        [code("ping()", [stream("first")]), code("ping()", [stream("CHANGED")])],
+    )
+    (v,) = scope()
+    assert v["cell_index"] == 3
+
+
+def test_execution_count_renumbering_alone_is_not_flagged(stub_refs):
+    """Re-running a notebook renumbers cells; that alone destroys nothing."""
+    stub_refs(
+        [code("print(1)", [stream("1")], execution_count=3)],
+        [code("print(1)", [stream("1")], execution_count=11)],
+    )
+    assert scope() == []
+
+
+def test_appended_new_cell_is_ignored(stub_refs):
+    stub_refs(
+        [code("print(1)", [stream("1")])],
+        [code("print(1)", [stream("1")]), code("brand_new()", [stream("out")])],
+    )
+    assert scope() == []
+
+
+def test_notebook_absent_from_base_is_not_a_violation(monkeypatch):
+    """A notebook added by the diff has no base to compare against."""
+    monkeypatch.setattr(audit_c1_c3, "_cells_at_ref",
+                        lambda rel, ref: None if ref == "BASE" else [(0, code("x"))])
+    assert scope() == []
+
+
+def test_markdown_cells_are_out_of_scope(stub_refs):
+    """`_cells_at_ref` yields code cells only; markdown never reaches the matcher."""
+    stub_refs([code("run()", [stream("a")])], [code("run()", [stream("a")])])
+    assert scope() == []
+
+
+def test_reported_index_is_the_notebook_position_not_the_code_ordinal(stub_refs):
+    """A reader opens the notebook and counts cells — the index must match that.
+
+    With markdown cells interleaved, the 3rd code cell sits at notebook index 5.
+    Reporting `2` would send the reader to the wrong cell.
+    """
+    unchanged = code("keep()", [stream("ok")])
+    stub_refs(
+        [unchanged, unchanged, code("victim()", [stream("a"), stream("b")])],
+        [unchanged, unchanged, code("victim()", [stream("a")])],
+    )
+    (v,) = scope()
+    assert v["cell_index"] == 5
+
+
+def test_cells_at_ref_numbers_by_notebook_position(tmp_path, monkeypatch):
+    """Guards the contract at the git boundary, not just through the stub."""
+    nb = {"cells": [
+        {"cell_type": "markdown", "source": ["# Titre"]},
+        {"cell_type": "code", "source": ["a()"], "outputs": [], "execution_count": 1},
+        {"cell_type": "markdown", "source": ["texte"]},
+        {"cell_type": "code", "source": ["b()"], "outputs": [], "execution_count": 2},
+    ]}
+
+    class Blob:
+        returncode = 0
+        stdout = json.dumps(nb).encode("utf-8")
+
+    monkeypatch.setattr(audit_c1_c3.subprocess, "run", lambda *a, **k: Blob())
+    cells = audit_c1_c3._cells_at_ref("nb.ipynb", "SOMEREF")
+    assert [i for i, _ in cells] == [1, 3]
+
+
+def test_outputs_signature_counts_errors_and_concatenates_text():
+    cell = code("x", [stream("hello "), error("ValueError", "bad"), stream("world")])
+    n_out, n_err, text = audit_c1_c3._outputs_signature(cell)
+    assert (n_out, n_err) == (3, 1)
+    assert "hello " in text and "world" in text and "ValueError" in text
+
+
+def test_execute_result_data_is_part_of_the_signature(stub_refs):
+    """A changed `text/plain` result must be detected even at equal output count."""
+    def result(value):
+        return {"output_type": "execute_result", "data": {"text/plain": value},
+                "metadata": {}, "execution_count": 1}
+
+    stub_refs([code("df.shape", [result("(100, 5)")])],
+              [code("df.shape", [result("(0, 5)")])])
+    (v,) = scope()
+    assert v["severity"] == "OUTPUTS-REPLACED"
+    assert v["outputs_before"] == v["outputs_after"] == 1


### PR DESCRIPTION
Grain: MED/tooling — lane myia-ai-01:CoursIA — prev: MED/docs

## Le trou

`check_c3` est **notebook-entier**. Il ne lève un drapeau que si le diff ne touche **aucune** source :

```python
if output_changes > 0 and source_changes == 0:
    return [{"reason": "output-only changes in working tree (no source change)"}]
```

Une seule cellule modifiée suffit donc à éteindre le contrôle sur tout le reste du fichier. Or c'est exactement la forme que prend une PR en pratique : on édite une cellule, on ré-exécute le notebook entier, et on committe des sorties fraîches pour des cellules qu'on n'a jamais touchées. C.3 vise ce cas — *« les ré-exécutions de notebooks dont aucune cellule source n'a changé ne doivent pas être stagées »* — et le contrôle passe à côté.

Je l'ai constaté en révisant **#8615** au gate de merge, à la main, en hachant les cellules une par une. C'est le genre de vérification qui ne doit pas dépendre de la patience du relecteur.

## Ce que ça ajoute

Une seconde granularité, pas un remplacement. `--base <ref> --head <ref>` compare **cellule par cellule** entre deux refs :

```
python scripts/notebook_tools/audit_c1_c3.py --base main --head HEAD
```

- Appariement par **md5 de la source, sensible aux occurrences** — deux cellules au source identique restent distinctes et ne se rabattent pas l'une sur l'autre.
- Une cellule dont la source est byte-identique mais dont les sorties diffèrent est signalée.
- Les **index sont des positions dans le notebook**, pas des ordinaux de cellule de code : « cellule 24 » se retrouve en ouvrant le fichier. C'est le détail qui fait qu'un rapport est utilisable ou non.
- Source neuve ou modifiée → hors C.3, jamais signalée. Notebook absent de la base (ajouté par le diff) → pas une violation.

## Deux étiquettes, deux violations

`OUTPUTS-LOST` (sorties perdues, ou sorties d'erreur gagnées) et `OUTPUTS-REPLACED` (contenu différent sans rétrécir). Elles décrivent **ce qui s'est passé, pas la gravité**.

`REPLACED` n'est pas le cas bénin : une exécution qui échoue bruyamment **fait grossir** le compte de sorties avec ses échecs journalisés. C'est précisément la forme des pires cellules de #8615 — j'avais d'abord écrit une heuristique « le compte a baissé », et elle classait 51/54 comme anodines.

## Validation sur le cas réel

```
$ python scripts/notebook_tools/audit_c1_c3.py \
    --base origin/main --head origin/feature/c911-genai-text-8369-realserving

C.3 scope audit: 0/1 notebooks clean
  MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb
    9 cell(s) re-executed with unchanged source — 7 lost outputs
    [OUTPUTS-LOST    ] cell 12  outputs 12->3   import json
    [OUTPUTS-LOST    ] cell 18  outputs 35->16  import re
    [OUTPUTS-LOST    ] cell 24  outputs 59->13  def combine_message(msg):
    [OUTPUTS-LOST    ] cell 44  outputs 20->9   import sys
    [OUTPUTS-REPLACED] cell 51  outputs 14->31  import aiohttp
    [OUTPUTS-REPLACED] cell 54  outputs 16->37  import aiohttp
```

L'outil **reproduit indépendamment** le relevé fait à la main sur #8615 — mêmes cellules, mêmes comptes — et en sort une que la passe manuelle avait manquée (cellule 8). Sur 51 et 54, chaque ligne ajoutée est une trace d'exception émise via `logging` plutôt qu'en sortie `error` : un critère « le compte a baissé » les aurait laissées passer.

## Tests

15 tests, hermétiques (`_cells_at_ref` stubbé — pas de fixture de dépôt, pas de clone temporaire). Ils couvrent les faux positifs qui rendraient l'outil inutilisable autant que les vrais positifs :

- renumérotation d'`execution_count` seule → pas signalée
- source modifiée → hors C.3
- cellule ajoutée, notebook absent de la base → pas une violation
- sources dupliquées appariées par occurrence
- `text/plain` d'un `execute_result` modifié à compte de sorties égal → détecté
- index rapporté = position notebook, vérifié à la frontière git et à travers le stub

Un test a échoué à la première passe : j'avais écrit 1 sortie → 1 sortie en attendant `OUTPUTS-LOST`. C'est le test qui avait tort, l'outil avait raison.

`3385 passed` sur l'ensemble de `scripts/notebook_tools/tests/` — `check_c3` est inchangé, aucune régression.

## Portée

Additif : nouveau mode derrière `--base`, comportement par défaut identique. Pas de câblage CI dans cette PR — l'outil est d'abord un instrument de gate de merge. Aucun fichier de catalogue touché.

See #8615
